### PR TITLE
feat: /settings page with Sandbox Runtimes, LLM Keys, GitHub Apps

### DIFF
--- a/.depot/workflows/release.yaml
+++ b/.depot/workflows/release.yaml
@@ -20,6 +20,14 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Build web UI
+        run: make build-web
+          cache: true
+
       - name: Determine prerelease
         id: semver
         run: |
@@ -42,11 +50,11 @@ jobs:
           mkdir -p dist
 
           # elasticclaw CLI
-          GOOS=linux   GOARCH=amd64 go build -ldflags "$LDFLAGS" -o dist/elasticclaw-linux-amd64   .
-          GOOS=linux   GOARCH=arm64 go build -ldflags "$LDFLAGS" -o dist/elasticclaw-linux-arm64   .
-          GOOS=darwin  GOARCH=amd64 go build -ldflags "$LDFLAGS" -o dist/elasticclaw-darwin-amd64  .
-          GOOS=darwin  GOARCH=arm64 go build -ldflags "$LDFLAGS" -o dist/elasticclaw-darwin-arm64  .
-          GOOS=windows GOARCH=amd64 go build -ldflags "$LDFLAGS" -o dist/elasticclaw-windows-amd64.exe .
+          GOOS=linux   GOARCH=amd64 go build -tags embedweb -ldflags "$LDFLAGS" -o dist/elasticclaw-linux-amd64   .
+          GOOS=linux   GOARCH=arm64 go build -tags embedweb -ldflags "$LDFLAGS" -o dist/elasticclaw-linux-arm64   .
+          GOOS=darwin  GOARCH=amd64 go build -tags embedweb -ldflags "$LDFLAGS" -o dist/elasticclaw-darwin-amd64  .
+          GOOS=darwin  GOARCH=arm64 go build -tags embedweb -ldflags "$LDFLAGS" -o dist/elasticclaw-darwin-arm64  .
+          GOOS=windows GOARCH=amd64 go build -tags embedweb -ldflags "$LDFLAGS" -o dist/elasticclaw-windows-amd64.exe .
 
           # claw-bridge (VM-side agent; only needs linux/amd64)
           GOOS=linux GOARCH=amd64 go build -ldflags "$LDFLAGS" -o dist/claw-bridge-linux-amd64 ./cmd/claw-bridge/

--- a/.depot/workflows/release.yaml
+++ b/.depot/workflows/release.yaml
@@ -23,10 +23,11 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: 'web/package.json'
 
       - name: Build web UI
         run: make build-web
-          cache: true
 
       - name: Determine prerelease
         id: semver

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -42,7 +42,6 @@ var (
 	installVersion string
 	installToken        string
 	installUIPassword   string
-	installAnthropicKey string
 )
 
 func init() {
@@ -53,7 +52,6 @@ func init() {
 	installCmd.Flags().StringVar(&installVersion, "version", "", "Hub version to install (default: latest release)")
 	installCmd.Flags().StringVar(&installToken, "token", "", "Hub user token (default: randomly generated)")
 	installCmd.Flags().StringVar(&installUIPassword, "ui-password", "", "Web UI login password (used as ui_password in hub.yaml) (default: randomly generated)")
-	installCmd.Flags().StringVar(&installAnthropicKey, "anthropic-key", "", "Anthropic API key for LLM access (sk-ant-...) — can also be set after install")
 	installCmd.Flags().Bool("skip-caddy", false, "Skip Caddy installation and TLS (useful when domain/DNS not ready)")
 	installCmd.MarkFlagRequired("server")
 	installCmd.MarkFlagRequired("domain")
@@ -83,20 +81,12 @@ func runInstall(cmd *cobra.Command, args []string) error {
 	}
 	clawToken := randomHex32()
 
-	// Prompt for Anthropic key if not provided
-	anthropicKey := installAnthropicKey
-	if anthropicKey == "" && !quiet {
-		fmt.Print("Anthropic API key (sk-ant-..., or press Enter to skip): ")
-		fmt.Scanln(&anthropicKey)
-	}
-
 	params := install.Params{
 		Domain:       installDomain,
 		Version:      version,
 		Token:        token,
 		ClawToken:    clawToken,
 		UIPassword:   uiToken,
-		AnthropicKey: anthropicKey,
 	}
 
 	// ── Preflight: DNS check (skipped with --skip-caddy) ─────────────────────
@@ -157,13 +147,6 @@ func runInstall(cmd *cobra.Command, args []string) error {
 	fmt.Println()
 	fmt.Printf("  Login: elasticclaw login --hub https://%s --token %s\n", installDomain, token)
 	fmt.Printf("  Web UI: https://%s\n", installDomain)
-	if anthropicKey == "" {
-		fmt.Println()
-		fmt.Println("  ⚠️  No Anthropic key set. Add it later to hub.yaml on the server:")
-		fmt.Println("     llm_keys:")
-		fmt.Println("       anthropic: sk-ant-...")
-		fmt.Println("     Then: systemctl restart elasticclaw")
-	}
 	fmt.Println()
 	fmt.Println("  Save these credentials — they won't be shown again.")
 

--- a/pkg/config/hub.go
+++ b/pkg/config/hub.go
@@ -35,19 +35,26 @@ func LoadHubConfig() (*types.HubConfig, error) {
 // SaveHubConfig writes hub config to ~/.elasticclaw/hub.yaml.
 // ActiveHubConfigPath returns the path of the hub.yaml that was loaded.
 // Used to save config changes back to the right file.
-func ActiveHubConfigPath() string {
+// Returns an error if no path can be determined.
+func ActiveHubConfigPath() (string, error) {
 	for _, p := range hubConfigPaths() {
 		if _, err := os.Stat(p); err == nil {
-			return p
+			return p, nil
 		}
 	}
 	// Default: ~/.elasticclaw/hub.yaml
-	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".elasticclaw", "hub.yaml")
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine hub config path: %w", err)
+	}
+	return filepath.Join(home, ".elasticclaw", "hub.yaml"), nil
 }
 
 func SaveHubConfig(cfg *types.HubConfig) error {
-	path := ActiveHubConfigPath()
+	path, err := ActiveHubConfigPath()
+	if err != nil {
+		return err
+	}
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return err
 	}

--- a/pkg/config/hub.go
+++ b/pkg/config/hub.go
@@ -33,16 +33,24 @@ func LoadHubConfig() (*types.HubConfig, error) {
 }
 
 // SaveHubConfig writes hub config to ~/.elasticclaw/hub.yaml.
+// ActiveHubConfigPath returns the path of the hub.yaml that was loaded.
+// Used to save config changes back to the right file.
+func ActiveHubConfigPath() string {
+	for _, p := range hubConfigPaths() {
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	// Default: ~/.elasticclaw/hub.yaml
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".elasticclaw", "hub.yaml")
+}
+
 func SaveHubConfig(cfg *types.HubConfig) error {
-	home, err := os.UserHomeDir()
-	if err != nil {
+	path := ActiveHubConfigPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return err
 	}
-	dir := filepath.Join(home, ".elasticclaw")
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		return err
-	}
-	path := filepath.Join(dir, "hub.yaml")
 	data, err := yaml.Marshal(cfg)
 	if err != nil {
 		return err

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2009,6 +2009,8 @@ func randomHex(n int) string {
 // clawHubURL returns the URL claws should use to connect back.
 // Uses public_url if set, otherwise falls back to url.
 func (s *Server) clawHubURL() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	if s.hubCfg.PublicURL != "" {
 		return s.hubCfg.PublicURL
 	}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -164,10 +164,14 @@ func (s *Server) Run(opts ...RunOptions) error {
 	}
 
 	// Connect to relay if configured
+	s.mu.RLock()
 	relayURL := s.hubCfg.RelayURL
+	relaySecret := s.hubCfg.RelaySecret
+	clawToken := s.hubCfg.ClawToken
+	s.mu.RUnlock()
 	if relayURL != "" {
 		hubID := HubID(s.identity.PublicKey)
-		relayToken := RelayToken(s.hubCfg.RelaySecret, hubID, s.hubCfg.ClawToken)
+		relayToken := RelayToken(relaySecret, hubID, clawToken)
 		log.Printf("[relay] hub ID: %s", hubID[:8]+"...")
 		log.Printf("[relay] connecting to %s", relayURL)
 		go s.connectRelay(context.Background(), relayURL, hubID, relayToken)
@@ -260,7 +264,10 @@ func (s *Server) withWebAuth(next http.HandlerFunc) http.HandlerFunc {
 			token = r.Header.Get(webSessionHeader)
 		}
 		// Hub token doubles as the web session token — reject empty tokens even if hub token is unset
-		if token == "" || token != s.hubCfg.Token {
+		s.mu.RLock()
+		hubToken := s.hubCfg.Token
+		s.mu.RUnlock()
+		if token == "" || token != hubToken {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}
@@ -284,9 +291,12 @@ func (s *Server) handleWebLogin(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid password", http.StatusUnauthorized)
 		return
 	}
+	s.mu.RLock()
+	hubToken := s.hubCfg.Token
+	s.mu.RUnlock()
 	jsonOK(w, map[string]interface{}{
 		"ok":       true,
-		"hubToken": s.hubCfg.Token, // hub API token — browser uses for all hub calls
+		"hubToken": hubToken, // hub API token — browser uses for all hub calls
 	})
 }
 
@@ -376,15 +386,18 @@ func (s *Server) serveWebUI(mux *http.ServeMux, staticFS fs.FS) {
 }
 
 func (s *Server) handleHubConfig(w http.ResponseWriter, r *http.Request) {
+	s.mu.RLock()
 	hubURL := s.hubCfg.URL
 	if s.hubCfg.PublicURL != "" {
 		hubURL = s.hubCfg.PublicURL
 	}
+	token := s.hubCfg.Token
+	s.mu.RUnlock()
 	if hubURL == "" {
 		hubURL = "http://localhost:8080"
 	}
 	jsonOK(w, map[string]interface{}{
-		"token":  s.hubCfg.Token,
+		"token":  token,
 		"hubUrl": hubURL,
 	})
 }
@@ -523,10 +536,13 @@ func (s *Server) handleCreateClaw(w http.ResponseWriter, r *http.Request, tenant
 	}
 
 	// Build env to inject: hub connection info so the claw can register back
+	s.mu.RLock()
+	clawToken := s.hubCfg.ClawToken
+	s.mu.RUnlock()
 	env := map[string]string{
 		"ELASTICCLAW_HUB_URL":   s.clawHubURL(),
 		"ELASTICCLAW_CLAW_ID":   clawID,
-		"ELASTICCLAW_CLAW_TOKEN": s.hubCfg.ClawToken,
+		"ELASTICCLAW_CLAW_TOKEN": clawToken,
 	}
 	for k, v := range req.Env {
 		env[k] = v
@@ -999,7 +1015,10 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 						httpReq.Header.Set(k, v)
 					}
 					// Inject claw_token auth so withAuth middleware passes
-					httpReq.Header.Set("X-Claw-Token", s.hubCfg.ClawToken)
+					s.mu.RLock()
+					clawToken := s.hubCfg.ClawToken
+					s.mu.RUnlock()
+					httpReq.Header.Set("X-Claw-Token", clawToken)
 					// Execute against internal mux
 					w := &proxyResponseWriter{header: make(http.Header)}
 					s.mux.ServeHTTP(w, httpReq)
@@ -1379,8 +1398,12 @@ cp "$BIN" /tmp/claw-bridge && chmod +x /tmp/claw-bridge && echo downloaded`, bri
 	// Start the bridge — it reads the gateway token from openclaw.json automatically.
 	// Use setsid to detach from exec session so it survives after exec returns.
 	hubID := HubID(s.identity.PublicKey)
+	s.mu.RLock()
 	relayURL := s.hubCfg.RelayURL
-	relayToken := RelayToken(s.hubCfg.RelaySecret, hubID, s.hubCfg.ClawToken)
+	relaySecret := s.hubCfg.RelaySecret
+	clawToken := s.hubCfg.ClawToken
+	s.mu.RUnlock()
+	relayToken := RelayToken(relaySecret, hubID, clawToken)
 
 	startCmd := fmt.Sprintf(
 		`export HOME=/home/daytona; \
@@ -1388,7 +1411,7 @@ ELASTICCLAW_HUB_URL=%q ELASTICCLAW_CLAW_ID=%q ELASTICCLAW_CLAW_TOKEN=%q ELASTICC
 ELASTICCLAW_RELAY_URL=%q ELASTICCLAW_HUB_ID=%q ELASTICCLAW_RELAY_TOKEN=%q \
 setsid nohup /tmp/claw-bridge >> /tmp/claw-bridge.log 2>&1 </dev/null &
 echo started`,
-		s.clawHubURL(), clawID, s.hubCfg.ClawToken, clawName,
+		s.clawHubURL(), clawID, clawToken, clawName,
 		relayURL, hubID, relayToken)
 	if err := exec("start claw-bridge", 30*time.Second, startCmd); err != nil {
 		return err
@@ -1417,7 +1440,6 @@ ELASTICCLAW_EOF`,
 	// Step 5: GitHub credential helper (if GitHub Apps configured)
 	s.mu.RLock()
 	hasGitHubApps := len(s.hubCfg.GitHubApps) > 0
-	clawToken := s.hubCfg.ClawToken
 	s.mu.RUnlock()
 	if hasGitHubApps {
 		var githubRepos []types.GitHubRepoAccess
@@ -1565,11 +1587,14 @@ echo "OpenClaw ready"
 	if bridgeURL == "" {
 		return fmt.Errorf("claw-bridge URL not configured: set bridge_image in hub.yaml or build a tagged release")
 	}
+	s.mu.RLock()
+	clawToken := s.hubCfg.ClawToken
+	s.mu.RUnlock()
 	bridgeScript := fmt.Sprintf(`
 curl -fsSL "%s" -o /tmp/claw-bridge && chmod +x /tmp/claw-bridge
 ELASTICCLAW_HUB_URL=%q ELASTICCLAW_CLAW_ID=%q ELASTICCLAW_CLAW_TOKEN=%q nohup /tmp/claw-bridge >> /tmp/claw-bridge.log 2>&1 &
 echo "claw-bridge started"
-`, bridgeURL, s.clawHubURL(), clawID, s.hubCfg.ClawToken)
+`, bridgeURL, s.clawHubURL(), clawID, clawToken)
 	out, code, err = p.Exec(ctx, sandboxID, "bash -c '"+strings.ReplaceAll(bridgeScript, "'", "'\"'\"'")+"'")
 	if err != nil || code != 0 {
 		return fmt.Errorf("claw-bridge install failed (exit %d): %s", code, out)
@@ -2398,7 +2423,10 @@ func (s *Server) handleGitHubToken(w http.ResponseWriter, r *http.Request) {
 		clawToken = strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
 	}
 	// Single-tenant: validate against hub's claw_token directly
-	if clawToken != s.hubCfg.ClawToken {
+	s.mu.RLock()
+	hubClawToken := s.hubCfg.ClawToken
+	s.mu.RUnlock()
+	if clawToken != hubClawToken {
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -174,6 +174,9 @@ func (s *Server) Run(opts ...RunOptions) error {
 	}
 
 	log.Printf("ElasticClaw Hub listening on %s", s.addr)
+	if s.hubCfg.UIPassword == "" {
+		log.Printf("⚠️  Web UI password not set — using default: 'admin'. Set ui_password in hub.yaml to secure the UI.")
+	}
 	return http.ListenAndServe(s.addr, corsMiddleware(mux))
 }
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -245,6 +245,8 @@ func (s *Server) tenantByClawToken(token string) (string, error) {
 const webSessionHeader = "X-Elasticclaw-Session"
 
 func (s *Server) resolveUIPassword() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	if s.hubCfg.UIPassword != "" {
 		return s.hubCfg.UIPassword
 	}
@@ -1277,6 +1279,7 @@ echo $! > /tmp/openclaw-install.pid && echo 'install started'`); err != nil {
 	// Step 2b: Patch OpenClaw config with model + LLM API keys
 	anthropicKey := env["ANTHROPIC_API_KEY"]
 	defaultModel := env["OPENCLAW_DEFAULT_MODEL"]
+	s.mu.RLock()
 	if defaultModel == "" {
 		defaultModel = s.hubCfg.DefaultModel
 	}
@@ -1284,15 +1287,14 @@ echo $! > /tmp/openclaw-install.pid && echo 'install started'`); err != nil {
 		defaultModel = "anthropic/claude-sonnet-4-6"
 	}
 	if anthropicKey == "" {
-		s.mu.RLock()
 		for k, v := range s.hubCfg.LLMKeys {
 			if k == "anthropic" {
 				anthropicKey = v
 				break
 			}
 		}
-		s.mu.RUnlock()
 	}
+	s.mu.RUnlock()
 	if anthropicKey != "" {
 		configPatch := fmt.Sprintf(`
 export HOME=/home/daytona; python3 - <<'PYEOF'
@@ -1833,18 +1835,20 @@ func (s *Server) bootstrapReplicated(clawID, clawName, vmID string, cfg types.Pr
 	s.mu.RLock()
 	llmKeyEnv := buildLLMKeyEnv(s.hubCfg.LLMKeys)
 	relayEnv := buildRelayEnv(s.hubCfg, s.identity.PublicKey)
+	clawToken := s.hubCfg.ClawToken
+	hubCfg := s.hubCfg
 	s.mu.RUnlock()
 
 	script := GenerateReplicatedBootstrapScript(BootstrapParams{
 		ClawID:          clawID,
 		ClawName:        clawName,
-		ClawToken:       s.hubCfg.ClawToken,
+		ClawToken:       clawToken,
 		HubURL:          s.clawHubURL(),
 		DefaultModel:    defaultModel,
 		GatewayPassword: gatewayPassword,
 		BridgeURL:       bridgeURL,
 		Nix:             nixEnabled != 0,
-		HubCfg:          s.hubCfg,
+		HubCfg:          hubCfg,
 		GitHubRepos:     githubRepos,
 		LLMKeyEnv:       llmKeyEnv,
 		LinearEnv:       buildLinearEnv(linearToken),

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -122,6 +122,8 @@ func (s *Server) Run(opts ...RunOptions) error {
 	mux.HandleFunc("/api/auth/logout", s.handleWebLogout)
 	mux.HandleFunc("/api/auth/me", s.withWebAuth(s.handleWebMe))
 	mux.HandleFunc("/api/hub-config", s.withWebAuth(s.handleHubConfig))
+	mux.HandleFunc("/api/settings", s.withWebAuth(s.handleSettings))
+	mux.HandleFunc("/api/settings/status", s.withWebAuth(s.handleSettingsStatus))
 	mux.HandleFunc("/api/claws", s.withAuth(s.handleClaws))
 	mux.HandleFunc("/api/claws/{id}", s.withAuth(s.handleClawDetail))
 	mux.HandleFunc("/api/terminal/", s.handleTerminal)

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -475,7 +475,9 @@ func (s *Server) handleCreateClaw(w http.ResponseWriter, r *http.Request, tenant
 	}
 
 	// Check provider is configured
+	s.mu.RLock()
 	provCfg, ok := s.hubCfg.Providers[req.Provider]
+	s.mu.RUnlock()
 	if !ok {
 		http.Error(w, fmt.Sprintf("provider %q is not configured on this hub", req.Provider), http.StatusUnprocessableEntity)
 		return
@@ -1282,12 +1284,14 @@ echo $! > /tmp/openclaw-install.pid && echo 'install started'`); err != nil {
 		defaultModel = "anthropic/claude-sonnet-4-6"
 	}
 	if anthropicKey == "" {
+		s.mu.RLock()
 		for k, v := range s.hubCfg.LLMKeys {
 			if k == "anthropic" {
 				anthropicKey = v
 				break
 			}
 		}
+		s.mu.RUnlock()
 	}
 	if anthropicKey != "" {
 		configPatch := fmt.Sprintf(`
@@ -1409,14 +1413,18 @@ ELASTICCLAW_EOF`,
 	}
 
 	// Step 5: GitHub credential helper (if GitHub Apps configured)
-	if len(s.hubCfg.GitHubApps) > 0 {
+	s.mu.RLock()
+	hasGitHubApps := len(s.hubCfg.GitHubApps) > 0
+	clawToken := s.hubCfg.ClawToken
+	s.mu.RUnlock()
+	if hasGitHubApps {
 		var githubRepos []types.GitHubRepoAccess
 		var reposJSON string
 		_ = s.db.QueryRow(`SELECT COALESCE(github_repos,'[]') FROM claws WHERE id=?`, clawID).Scan(&reposJSON)
 		_ = json.Unmarshal([]byte(reposJSON), &githubRepos)
 
 		// Use local HTTP proxy (bridge listens on 18790, proxies to hub)
-		tokenURL := fmt.Sprintf("http://localhost:18790/api/github/token/%s?claw_token=%s", clawID, s.hubCfg.ClawToken)
+		tokenURL := fmt.Sprintf("http://localhost:18790/api/github/token/%s?claw_token=%s", clawID, clawToken)
 
 		// Step 5a: write the credential helper binary
 		credHelperScript := fmt.Sprintf(`export HOME=/home/daytona
@@ -1645,7 +1653,9 @@ func (s *Server) pollProviderStatus() {
 }
 
 func (s *Server) syncReplicatedVMs() {
+	s.mu.RLock()
 	replicatedCfg, ok := s.hubCfg.Providers["replicated"]
+	s.mu.RUnlock()
 	if !ok || replicatedCfg.Token == "" {
 		return
 	}
@@ -1820,6 +1830,11 @@ func (s *Server) bootstrapReplicated(clawID, clawName, vmID string, cfg types.Pr
 	// Generate a random gateway password for this VM so claw-bridge can connect with full scopes
 	gatewayPassword := randomHex(16)
 
+	s.mu.RLock()
+	llmKeyEnv := buildLLMKeyEnv(s.hubCfg.LLMKeys)
+	relayEnv := buildRelayEnv(s.hubCfg, s.identity.PublicKey)
+	s.mu.RUnlock()
+
 	script := GenerateReplicatedBootstrapScript(BootstrapParams{
 		ClawID:          clawID,
 		ClawName:        clawName,
@@ -1831,12 +1846,15 @@ func (s *Server) bootstrapReplicated(clawID, clawName, vmID string, cfg types.Pr
 		Nix:             nixEnabled != 0,
 		HubCfg:          s.hubCfg,
 		GitHubRepos:     githubRepos,
-		LLMKeyEnv:       buildLLMKeyEnv(s.hubCfg.LLMKeys),
+		LLMKeyEnv:       llmKeyEnv,
 		LinearEnv:       buildLinearEnv(linearToken),
-		RelayEnv:        buildRelayEnv(s.hubCfg, s.identity.PublicKey),
+		RelayEnv:        relayEnv,
 	})
 	// Inject GitHub tools context into TOOLS.md if GitHub is configured
-	if len(s.hubCfg.GitHubApps) > 0 && len(githubRepos) > 0 {
+	s.mu.RLock()
+	hasGitHubApps2 := len(s.hubCfg.GitHubApps) > 0
+	s.mu.RUnlock()
+	if hasGitHubApps2 && len(githubRepos) > 0 {
 		repoLines := ""
 		for _, r := range githubRepos {
 			repoLines += fmt.Sprintf("- `%s` (%s)\n", r.Repo, r.Permissions)
@@ -2337,7 +2355,9 @@ func (s *Server) handleTerminal(w http.ResponseWriter, r *http.Request) {
 
 // terminateReplicatedVM terminates a Replicated CMX VM by ID.
 func (s *Server) terminateReplicatedVM(vmID string) {
+	s.mu.RLock()
 	cfg, ok := s.hubCfg.Providers["replicated"]
+	s.mu.RUnlock()
 	if !ok {
 		log.Printf("terminateReplicatedVM: no replicated provider configured")
 		return
@@ -2361,7 +2381,10 @@ func (s *Server) terminateReplicatedVM(vmID string) {
 // URL: GET /api/github/token/:clawId
 // Used by the git credential helper on the VM.
 func (s *Server) handleGitHubToken(w http.ResponseWriter, r *http.Request) {
-	if len(s.hubCfg.GitHubApps) == 0 {
+	s.mu.RLock()
+	hasGitHubApps := len(s.hubCfg.GitHubApps) > 0
+	s.mu.RUnlock()
+	if !hasGitHubApps {
 		http.Error(w, "no github apps configured", http.StatusNotImplemented)
 		return
 	}
@@ -2424,7 +2447,10 @@ func (s *Server) handleGitHubToken(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Try each configured GitHub App in order; use the first that finds an installation
-	for i, appCfg := range s.hubCfg.GitHubApps {
+	s.mu.RLock()
+	githubApps := s.hubCfg.GitHubApps
+	s.mu.RUnlock()
+	for i, appCfg := range githubApps {
 		provider, err := NewGitHubTokenProvider(appCfg)
 		if err != nil {
 			log.Printf("github app[%d] (app_id=%d url=%s) config error: %v", i, appCfg.AppID, appCfg.URL, err)

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -46,9 +46,10 @@ type GitHubAppView struct {
 // SettingsPatch is the request body for PATCH /api/settings.
 // Only non-nil fields are updated.
 type SettingsPatch struct {
-	LLMKeys   map[string]string         `json:"llmKeys,omitempty"`
-	Providers map[string]ProviderPatch  `json:"providers,omitempty"`
-	GitHub    []GitHubAppPatch          `json:"github,omitempty"`
+	LLMKeys    map[string]string         `json:"llmKeys,omitempty"`
+	Providers  map[string]ProviderPatch  `json:"providers,omitempty"`
+	GitHub     []GitHubAppPatch          `json:"github,omitempty"`
+	UIPassword string                    `json:"uiPassword,omitempty"`
 }
 
 type ProviderPatch struct {
@@ -218,6 +219,11 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 			apps = append(apps, app)
 		}
 		s.hubCfg.GitHubApps = apps
+	}
+
+	// UI password
+	if patch.UIPassword != "" {
+		s.hubCfg.UIPassword = patch.UIPassword
 	}
 
 	// Save to disk

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -19,9 +19,10 @@ type SettingsStatus struct {
 // SettingsView is the redacted view of hub config for the settings page.
 // Secrets are masked — never returned in full.
 type SettingsView struct {
-	LLMKeys   map[string]string      `json:"llmKeys"`   // provider → masked key ("sk-ant-...***")
-	Providers map[string]ProviderView `json:"providers"` // provider name → config (tokens masked)
-	GitHub    []GitHubAppView        `json:"github"`
+	LLMKeys       map[string]string      `json:"llmKeys"`       // provider → masked key
+	Providers     map[string]ProviderView `json:"providers"`     // provider name → config (tokens masked)
+	GitHub        []GitHubAppView        `json:"github"`
+	SSHPublicKeys []string               `json:"sshPublicKeys"` // extra keys added to all sandbox VMs
 }
 
 type ProviderView struct {
@@ -46,10 +47,11 @@ type GitHubAppView struct {
 // SettingsPatch is the request body for PATCH /api/settings.
 // Only non-nil fields are updated.
 type SettingsPatch struct {
-	LLMKeys    map[string]string         `json:"llmKeys,omitempty"`
-	Providers  map[string]ProviderPatch  `json:"providers,omitempty"`
-	GitHub     []GitHubAppPatch          `json:"github,omitempty"`
-	UIPassword string                    `json:"uiPassword,omitempty"`
+	LLMKeys       map[string]string         `json:"llmKeys,omitempty"`
+	Providers     map[string]ProviderPatch  `json:"providers,omitempty"`
+	GitHub        []GitHubAppPatch          `json:"github,omitempty"`
+	UIPassword    string                    `json:"uiPassword,omitempty"`
+	SSHPublicKeys *[]string                 `json:"sshPublicKeys,omitempty"` // nil = no change, [] = clear all
 }
 
 type ProviderPatch struct {
@@ -128,6 +130,12 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 			pv.DefaultInstanceType = p.DefaultInstanceType
 		}
 		view.Providers[name] = pv
+	}
+
+	// SSH public keys
+	view.SSHPublicKeys = s.hubCfg.SSHPublicKeys
+	if view.SSHPublicKeys == nil {
+		view.SSHPublicKeys = []string{}
 	}
 
 	// GitHub Apps
@@ -224,6 +232,11 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 	// UI password
 	if patch.UIPassword != "" {
 		s.hubCfg.UIPassword = patch.UIPassword
+	}
+
+	// SSH public keys (nil = no change, pointer to slice = replace all)
+	if patch.SSHPublicKeys != nil {
+		s.hubCfg.SSHPublicKeys = *patch.SSHPublicKeys
 	}
 
 	// Save to disk

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -160,7 +160,7 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Create a deep copy of the config to apply changes
+	// Shallow copy of config struct; maps and slices are deep-copied only when modified below
 	updatedCfg := *s.hubCfg
 
 	// LLM keys

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -19,10 +19,10 @@ type SettingsStatus struct {
 // SettingsView is the redacted view of hub config for the settings page.
 // Secrets are masked — never returned in full.
 type SettingsView struct {
-	LLMKeys       map[string]string      `json:"llmKeys"`       // provider → masked key
-	Providers     map[string]ProviderView `json:"providers"`     // provider name → config (tokens masked)
-	GitHub        []GitHubAppView        `json:"github"`
-	SSHPublicKeys []string               `json:"sshPublicKeys"` // extra keys added to all sandbox VMs
+	LLMKeys       map[string]bool         `json:"llmKeys"`   // provider → keySet
+	Providers     map[string]ProviderView `json:"providers"` // provider name → config (tokens masked)
+	GitHub        []GitHubAppView         `json:"github"`
+	SSHPublicKeys []string                `json:"sshPublicKeys"` // extra keys added to all sandbox VMs
 }
 
 type ProviderView struct {
@@ -39,19 +39,19 @@ type ProviderView struct {
 }
 
 type GitHubAppView struct {
-	AppID     int64  `json:"appId"`
-	URL       string `json:"url,omitempty"`
-	KeySet    bool   `json:"keySet"`
+	AppID  int64  `json:"appId"`
+	URL    string `json:"url,omitempty"`
+	KeySet bool   `json:"keySet"`
 }
 
 // SettingsPatch is the request body for PATCH /api/settings.
 // Only non-nil fields are updated.
 type SettingsPatch struct {
-	LLMKeys       map[string]string         `json:"llmKeys,omitempty"`
-	Providers     map[string]ProviderPatch  `json:"providers,omitempty"`
-	GitHub        []GitHubAppPatch          `json:"github,omitempty"`
-	UIPassword    string                    `json:"uiPassword,omitempty"`
-	SSHPublicKeys *[]string                 `json:"sshPublicKeys,omitempty"` // nil = no change, [] = clear all
+	LLMKeys       map[string]string        `json:"llmKeys,omitempty"`
+	Providers     map[string]ProviderPatch `json:"providers,omitempty"`
+	GitHub        []GitHubAppPatch         `json:"github,omitempty"`
+	UIPassword    string                   `json:"uiPassword,omitempty"`
+	SSHPublicKeys *[]string                `json:"sshPublicKeys,omitempty"` // nil = no change, [] = clear all
 }
 
 type ProviderPatch struct {
@@ -75,7 +75,7 @@ func (s *Server) handleSettingsStatus(w http.ResponseWriter, r *http.Request) {
 	s.mu.RLock()
 	hasProvider := false
 	for _, p := range s.hubCfg.Providers {
-		if p.Token != "" || p.APIKey != "" {
+		if p.Token != "" || p.APIKey != "" || p.AccessToken != "" || p.Enabled {
 			hasProvider = true
 			break
 		}
@@ -104,19 +104,15 @@ func (s *Server) handleSettings(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 	view := SettingsView{
-		LLMKeys:   make(map[string]string),
+		LLMKeys:   make(map[string]bool),
 		Providers: make(map[string]ProviderView),
 		GitHub:    []GitHubAppView{},
 	}
 
 	s.mu.RLock()
-	// Mask LLM keys — show prefix only
+	// LLM keys — boolean flag only
 	for provider, key := range s.hubCfg.LLMKeys {
-		if len(key) > 8 {
-			view.LLMKeys[provider] = key[:8] + "***"
-		} else if key != "" {
-			view.LLMKeys[provider] = "***"
-		}
+		view.LLMKeys[provider] = key != ""
 	}
 
 	// Providers

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -72,6 +72,7 @@ type GitHubAppPatch struct {
 }
 
 func (s *Server) handleSettingsStatus(w http.ResponseWriter, r *http.Request) {
+	s.mu.RLock()
 	hasProvider := false
 	for _, p := range s.hubCfg.Providers {
 		if p.Token != "" || p.APIKey != "" {
@@ -81,6 +82,7 @@ func (s *Server) handleSettingsStatus(w http.ResponseWriter, r *http.Request) {
 	}
 	hasLLMKey := len(s.hubCfg.LLMKeys) > 0
 	hasGitHub := len(s.hubCfg.GitHubApps) > 0
+	s.mu.RUnlock()
 
 	jsonOK(w, SettingsStatus{
 		HasProvider: hasProvider,
@@ -107,6 +109,7 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 		GitHub:    []GitHubAppView{},
 	}
 
+	s.mu.RLock()
 	// Mask LLM keys — show prefix only
 	for provider, key := range s.hubCfg.LLMKeys {
 		if len(key) > 8 {
@@ -146,6 +149,7 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 			KeySet: app.PrivateKeyPEM != "",
 		})
 	}
+	s.mu.RUnlock()
 
 	jsonOK(w, view)
 }
@@ -157,28 +161,47 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Update in-memory config
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Create a deep copy of the config to apply changes
+	updatedCfg := *s.hubCfg
+
 	// LLM keys
 	if patch.LLMKeys != nil {
-		if s.hubCfg.LLMKeys == nil {
-			s.hubCfg.LLMKeys = make(map[string]string)
+		if updatedCfg.LLMKeys == nil {
+			updatedCfg.LLMKeys = make(map[string]string)
+		} else {
+			// Deep copy the map
+			newKeys := make(map[string]string, len(updatedCfg.LLMKeys))
+			for k, v := range updatedCfg.LLMKeys {
+				newKeys[k] = v
+			}
+			updatedCfg.LLMKeys = newKeys
 		}
 		for k, v := range patch.LLMKeys {
 			if v == "" {
-				delete(s.hubCfg.LLMKeys, k)
+				delete(updatedCfg.LLMKeys, k)
 			} else {
-				s.hubCfg.LLMKeys[k] = v
+				updatedCfg.LLMKeys[k] = v
 			}
 		}
 	}
 
 	// Providers
 	if patch.Providers != nil {
-		if s.hubCfg.Providers == nil {
-			s.hubCfg.Providers = make(map[string]types.ProviderConfig)
+		if updatedCfg.Providers == nil {
+			updatedCfg.Providers = make(map[string]types.ProviderConfig)
+		} else {
+			// Deep copy the map
+			newProviders := make(map[string]types.ProviderConfig, len(updatedCfg.Providers))
+			for k, v := range updatedCfg.Providers {
+				newProviders[k] = v
+			}
+			updatedCfg.Providers = newProviders
 		}
 		for name, pp := range patch.Providers {
-			existing := s.hubCfg.Providers[name]
+			existing := updatedCfg.Providers[name]
 			switch name {
 			case "daytona":
 				if pp.APIURL != "" {
@@ -201,7 +224,7 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 					existing.DefaultInstanceType = pp.DefaultInstanceType
 				}
 			}
-			s.hubCfg.Providers[name] = existing
+			updatedCfg.Providers[name] = existing
 		}
 	}
 
@@ -226,24 +249,27 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 			}
 			apps = append(apps, app)
 		}
-		s.hubCfg.GitHubApps = apps
+		updatedCfg.GitHubApps = apps
 	}
 
 	// UI password
 	if patch.UIPassword != "" {
-		s.hubCfg.UIPassword = patch.UIPassword
+		updatedCfg.UIPassword = patch.UIPassword
 	}
 
 	// SSH public keys (nil = no change, pointer to slice = replace all)
 	if patch.SSHPublicKeys != nil {
-		s.hubCfg.SSHPublicKeys = *patch.SSHPublicKeys
+		updatedCfg.SSHPublicKeys = *patch.SSHPublicKeys
 	}
 
-	// Save to disk
-	if err := config.SaveHubConfig(s.hubCfg); err != nil {
+	// Save to disk before applying to in-memory config
+	if err := config.SaveHubConfig(&updatedCfg); err != nil {
 		http.Error(w, "failed to save config: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
+
+	// Only update in-memory config after successful disk write
+	s.hubCfg = &updatedCfg
 
 	jsonOK(w, map[string]bool{"ok": true})
 }

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -1,0 +1,230 @@
+package hub
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/elasticclaw/elasticclaw/pkg/config"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+// SettingsStatus is returned by GET /api/settings/status.
+// Used by the web UI to decide whether to redirect to settings on login.
+type SettingsStatus struct {
+	HasProvider bool `json:"hasProvider"`
+	HasLLMKey   bool `json:"hasLLMKey"`
+	HasGitHub   bool `json:"hasGitHub"`
+}
+
+// SettingsView is the redacted view of hub config for the settings page.
+// Secrets are masked — never returned in full.
+type SettingsView struct {
+	LLMKeys   map[string]string      `json:"llmKeys"`   // provider → masked key ("sk-ant-...***")
+	Providers map[string]ProviderView `json:"providers"` // provider name → config (tokens masked)
+	GitHub    []GitHubAppView        `json:"github"`
+}
+
+type ProviderView struct {
+	Type    string `json:"type"`
+	Enabled bool   `json:"enabled"`
+	// Daytona
+	APIURL          string `json:"apiUrl,omitempty"`
+	APIKeySet       bool   `json:"apiKeySet,omitempty"`
+	DefaultSnapshot string `json:"defaultSnapshot,omitempty"`
+	// Replicated
+	TokenSet            bool   `json:"tokenSet,omitempty"`
+	DefaultTTL          string `json:"defaultTtl,omitempty"`
+	DefaultInstanceType string `json:"defaultInstanceType,omitempty"`
+}
+
+type GitHubAppView struct {
+	AppID     int64  `json:"appId"`
+	URL       string `json:"url,omitempty"`
+	KeySet    bool   `json:"keySet"`
+}
+
+// SettingsPatch is the request body for PATCH /api/settings.
+// Only non-nil fields are updated.
+type SettingsPatch struct {
+	LLMKeys   map[string]string         `json:"llmKeys,omitempty"`
+	Providers map[string]ProviderPatch  `json:"providers,omitempty"`
+	GitHub    []GitHubAppPatch          `json:"github,omitempty"`
+}
+
+type ProviderPatch struct {
+	// Daytona
+	APIURL          string `json:"apiUrl,omitempty"`
+	APIKey          string `json:"apiKey,omitempty"`
+	DefaultSnapshot string `json:"defaultSnapshot,omitempty"`
+	// Replicated
+	Token               string `json:"token,omitempty"`
+	DefaultTTL          string `json:"defaultTtl,omitempty"`
+	DefaultInstanceType string `json:"defaultInstanceType,omitempty"`
+}
+
+type GitHubAppPatch struct {
+	AppID         int64  `json:"appId"`
+	URL           string `json:"url,omitempty"`
+	PrivateKeyPEM string `json:"privateKeyPem,omitempty"` // full PEM, stored on server only
+}
+
+func (s *Server) handleSettingsStatus(w http.ResponseWriter, r *http.Request) {
+	hasProvider := false
+	for _, p := range s.hubCfg.Providers {
+		if p.Token != "" || p.APIKey != "" {
+			hasProvider = true
+			break
+		}
+	}
+	hasLLMKey := len(s.hubCfg.LLMKeys) > 0
+	hasGitHub := len(s.hubCfg.GitHubApps) > 0
+
+	jsonOK(w, SettingsStatus{
+		HasProvider: hasProvider,
+		HasLLMKey:   hasLLMKey,
+		HasGitHub:   hasGitHub,
+	})
+}
+
+func (s *Server) handleSettings(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		s.getSettings(w, r)
+	case http.MethodPatch:
+		s.patchSettings(w, r)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
+	view := SettingsView{
+		LLMKeys:   make(map[string]string),
+		Providers: make(map[string]ProviderView),
+		GitHub:    []GitHubAppView{},
+	}
+
+	// Mask LLM keys — show prefix only
+	for provider, key := range s.hubCfg.LLMKeys {
+		if len(key) > 8 {
+			view.LLMKeys[provider] = key[:8] + "***"
+		} else if key != "" {
+			view.LLMKeys[provider] = "***"
+		}
+	}
+
+	// Providers
+	for name, p := range s.hubCfg.Providers {
+		pv := ProviderView{Type: name, Enabled: true}
+		switch name {
+		case "daytona":
+			pv.APIURL = p.APIURL
+			pv.APIKeySet = p.APIKey != ""
+			pv.DefaultSnapshot = p.DefaultSnapshot
+		case "replicated":
+			pv.TokenSet = p.Token != ""
+			pv.DefaultTTL = p.DefaultTTL
+			pv.DefaultInstanceType = p.DefaultInstanceType
+		}
+		view.Providers[name] = pv
+	}
+
+	// GitHub Apps
+	for _, app := range s.hubCfg.GitHubApps {
+		view.GitHub = append(view.GitHub, GitHubAppView{
+			AppID:  app.AppID,
+			URL:    app.URL,
+			KeySet: app.PrivateKeyPEM != "",
+		})
+	}
+
+	jsonOK(w, view)
+}
+
+func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
+	var patch SettingsPatch
+	if err := json.NewDecoder(r.Body).Decode(&patch); err != nil {
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+
+	// Update in-memory config
+	// LLM keys
+	if patch.LLMKeys != nil {
+		if s.hubCfg.LLMKeys == nil {
+			s.hubCfg.LLMKeys = make(map[string]string)
+		}
+		for k, v := range patch.LLMKeys {
+			if v == "" {
+				delete(s.hubCfg.LLMKeys, k)
+			} else {
+				s.hubCfg.LLMKeys[k] = v
+			}
+		}
+	}
+
+	// Providers
+	if patch.Providers != nil {
+		if s.hubCfg.Providers == nil {
+			s.hubCfg.Providers = make(map[string]types.ProviderConfig)
+		}
+		for name, pp := range patch.Providers {
+			existing := s.hubCfg.Providers[name]
+			switch name {
+			case "daytona":
+				if pp.APIURL != "" {
+					existing.APIURL = pp.APIURL
+				}
+				if pp.APIKey != "" {
+					existing.APIKey = pp.APIKey
+				}
+				if pp.DefaultSnapshot != "" {
+					existing.DefaultSnapshot = pp.DefaultSnapshot
+				}
+			case "replicated":
+				if pp.Token != "" {
+					existing.Token = pp.Token
+				}
+				if pp.DefaultTTL != "" {
+					existing.DefaultTTL = pp.DefaultTTL
+				}
+				if pp.DefaultInstanceType != "" {
+					existing.DefaultInstanceType = pp.DefaultInstanceType
+				}
+			}
+			s.hubCfg.Providers[name] = existing
+		}
+	}
+
+	// GitHub Apps
+	if patch.GitHub != nil {
+		var apps []*types.GitHubAppConfig
+		for _, ga := range patch.GitHub {
+			app := &types.GitHubAppConfig{
+				AppID: ga.AppID,
+				URL:   ga.URL,
+			}
+			if ga.PrivateKeyPEM != "" {
+				app.PrivateKeyPEM = ga.PrivateKeyPEM
+			} else {
+				// Preserve existing key if not provided
+				for _, existing := range s.hubCfg.GitHubApps {
+					if existing.AppID == ga.AppID {
+						app.PrivateKeyPEM = existing.PrivateKeyPEM
+						break
+					}
+				}
+			}
+			apps = append(apps, app)
+		}
+		s.hubCfg.GitHubApps = apps
+	}
+
+	// Save to disk
+	if err := config.SaveHubConfig(s.hubCfg); err != nil {
+		http.Error(w, "failed to save config: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	jsonOK(w, map[string]bool{"ok": true})
+}

--- a/pkg/install/scripts.go
+++ b/pkg/install/scripts.go
@@ -12,7 +12,6 @@ type Params struct {
 	Token        string
 	ClawToken    string
 	UIPassword   string
-	AnthropicKey string // optional; adds llm_keys to hub.yaml if set
 }
 
 // HubBinaryURL returns the GitHub releases download URL for the hub binary.
@@ -25,17 +24,13 @@ func HubBinaryURL(version string) string {
 
 // HubConfig returns the hub.yaml config file content.
 func HubConfig(p Params) string {
-	llmKeys := ""
-	if p.AnthropicKey != "" {
-		llmKeys = fmt.Sprintf("\nllm_keys:\n  anthropic: %s", p.AnthropicKey)
-	}
 	return fmt.Sprintf(`url: https://%s
 public_url: https://%s
 token: %s
 claw_token: %s
 ui_password: %s
-address: :8080%s
-`, p.Domain, p.Domain, p.Token, p.ClawToken, p.UIPassword, llmKeys)
+address: :8080
+`, p.Domain, p.Domain, p.Token, p.ClawToken, p.UIPassword)
 }
 
 // SystemdUnit returns the systemd unit file for the hub service.

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -31,6 +31,21 @@ function LoginForm() {
         const data = await res.json()
         // One token for everything — hub API token stored in sessionStorage
         if (data.hubToken) sessionStorage.setItem("ec_hub_token", data.hubToken)
+        // Check if settings are required before going to main dashboard
+        try {
+          const { getHubUrl } = await import("@/lib/hub-url")
+          const hubUrl = getHubUrl()
+          const statusRes = await fetch(`${hubUrl}/api/settings/status`, {
+            headers: { Authorization: `Bearer ${data.hubToken}` },
+          })
+          if (statusRes.ok) {
+            const status = await statusRes.json()
+            if (!status.hasProvider || !status.hasLLMKey) {
+              router.push("/settings")
+              return
+            }
+          }
+        } catch { /* ignore — proceed to dashboard */ }
         router.push(next)
         router.refresh()
       } else {

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -264,7 +264,6 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
 function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSave: (p: object) => void; saving: boolean }) {
   const providers = [
     { id: "anthropic", label: "Anthropic", placeholder: "sk-ant-..." },
-    { id: "openai", label: "OpenAI", placeholder: "sk-..." },
   ]
   const [keys, setKeys] = useState<Record<string, string>>({})
 

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -131,7 +131,7 @@ export default function SettingsPage() {
             <GitHubSection settings={settings} onSave={save} saving={saving} />
           )}
           {settings && section === "security" && (
-            <SecuritySection settings={settings} onSave={save} saving={saving} />
+            <SecuritySection onSave={save} saving={saving} />
           )}
         </main>
       </div>
@@ -140,6 +140,7 @@ export default function SettingsPage() {
 }
 
 function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData; onSave: (p: object) => void; saving: boolean }) {
+  const [newKey, setNewKey] = useState("")
   const rep = settings.providers?.replicated
   const day = settings.providers?.daytona
 
@@ -196,6 +197,29 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
             }}>
               Save Replicated
             </Button>
+            {/* SSH Keys for Replicated VMs */}
+            <div className="border-t border-border mt-4 pt-4">
+              <p className="text-xs font-medium mb-2">Additional SSH Keys</p>
+              <p className="text-xs text-muted-foreground mb-3">Public keys injected into Replicated VMs at bootstrap for direct SSH access.</p>
+              {(settings.sshPublicKeys || []).map((key, i) => (
+                <div key={i} className="flex items-center gap-2 mb-2">
+                  <code className="flex-1 text-xs bg-secondary px-2 py-1 rounded truncate">{key}</code>
+                  <Button size="sm" variant="ghost" className="text-destructive hover:text-destructive px-2 h-7" disabled={saving}
+                    onClick={() => onSave({ sshPublicKeys: (settings.sshPublicKeys || []).filter((_, j) => j !== i) })}>
+                    Remove
+                  </Button>
+                </div>
+              ))}
+              <div className="flex gap-2">
+                <Input value={newKey} onChange={e => setNewKey(e.target.value)}
+                  onKeyDown={e => { if (e.key === "Enter" && newKey.trim()) { onSave({ sshPublicKeys: [...(settings.sshPublicKeys || []), newKey.trim()] }); setNewKey("") }}}
+                  placeholder="ssh-ed25519 AAAA..." className="h-7 text-xs font-mono flex-1" />
+                <Button size="sm" disabled={saving || !newKey.trim()}
+                  onClick={() => { onSave({ sshPublicKeys: [...(settings.sshPublicKeys || []), newKey.trim()] }); setNewKey("") }}>
+                  Add
+                </Button>
+              </div>
+            </div>
           </div>
         </div>
 
@@ -344,84 +368,36 @@ function GitHubSection({ settings, onSave, saving }: { settings: SettingsData; o
   )
 }
 
-function SecuritySection({ settings, onSave, saving }: { settings: SettingsData; onSave: (p: object) => void; saving: boolean }) {
+function SecuritySection({ onSave, saving }: { onSave: (p: object) => void; saving: boolean }) {
   const [newPw, setNewPw] = useState("")
   const [confirm, setConfirm] = useState("")
   const [pwErr, setPwErr] = useState("")
-  const [newKey, setNewKey] = useState("")
 
   function handlePasswordSave() {
     setPwErr("")
     if (newPw.length < 8) { setPwErr("Password must be at least 8 characters"); return }
-    if (newPw !== confirm) { setPwErr("Passwords don't match"); return }
+    if (newPw !== confirm) { setPwErr("Passwords don\'t match"); return }
     onSave({ uiPassword: newPw })
     setNewPw(""); setConfirm("")
   }
 
-  function addKey() {
-    const key = newKey.trim()
-    if (!key) return
-    const keys = [...(settings.sshPublicKeys || []), key]
-    onSave({ sshPublicKeys: keys })
-    setNewKey("")
-  }
-
-  function removeKey(idx: number) {
-    const keys = (settings.sshPublicKeys || []).filter((_, i) => i !== idx)
-    onSave({ sshPublicKeys: keys })
-  }
-
   return (
-    <div className="space-y-8">
-      {/* Password */}
-      <div>
-        <h2 className="text-base font-semibold mb-1">Security</h2>
-        <p className="text-sm text-muted-foreground mb-4">Change the web UI login password.</p>
-        <div className="border border-border rounded-lg p-5 max-w-sm space-y-3">
-          <div>
-            <label className="text-xs text-muted-foreground mb-1 block">New Password</label>
-            <Input type="password" value={newPw} onChange={e => setNewPw(e.target.value)} className="h-8 text-sm" placeholder="Min 8 characters" />
-          </div>
-          <div>
-            <label className="text-xs text-muted-foreground mb-1 block">Confirm Password</label>
-            <Input type="password" value={confirm} onChange={e => setConfirm(e.target.value)} className="h-8 text-sm" placeholder="Repeat password" />
-          </div>
-          {pwErr && <p className="text-xs text-red-500">{pwErr}</p>}
-          <Button size="sm" disabled={saving || !newPw || !confirm} onClick={handlePasswordSave}>
-            Change Password
-          </Button>
+    <div>
+      <h2 className="text-base font-semibold mb-1">Security</h2>
+      <p className="text-sm text-muted-foreground mb-4">Change the web UI login password.</p>
+      <div className="border border-border rounded-lg p-5 max-w-sm space-y-3">
+        <div>
+          <label className="text-xs text-muted-foreground mb-1 block">New Password</label>
+          <Input type="password" value={newPw} onChange={e => setNewPw(e.target.value)} className="h-8 text-sm" placeholder="Min 8 characters" />
         </div>
-      </div>
-
-      {/* SSH Keys */}
-      <div>
-        <h3 className="text-sm font-semibold mb-1">Additional SSH Keys</h3>
-        <p className="text-xs text-muted-foreground mb-4">
-          These public keys are injected into every sandbox VM at bootstrap, giving direct SSH access for debugging.
-        </p>
-        <div className="border border-border rounded-lg p-4 space-y-3 max-w-xl">
-          {(settings.sshPublicKeys || []).length === 0 && (
-            <p className="text-xs text-muted-foreground italic">No additional SSH keys configured.</p>
-          )}
-          {(settings.sshPublicKeys || []).map((key, i) => (
-            <div key={i} className="flex items-center gap-2">
-              <code className="flex-1 text-xs bg-secondary px-2 py-1 rounded truncate">{key}</code>
-              <Button size="sm" variant="ghost" className="text-destructive hover:text-destructive px-2 h-7" disabled={saving} onClick={() => removeKey(i)}>
-                Remove
-              </Button>
-            </div>
-          ))}
-          <div className="flex gap-2 pt-1">
-            <Input
-              value={newKey}
-              onChange={e => setNewKey(e.target.value)}
-              onKeyDown={e => { if (e.key === "Enter") addKey() }}
-              placeholder="ssh-ed25519 AAAA... or ssh-rsa AAAA..."
-              className="h-8 text-xs font-mono flex-1"
-            />
-            <Button size="sm" disabled={saving || !newKey.trim()} onClick={addKey}>Add</Button>
-          </div>
+        <div>
+          <label className="text-xs text-muted-foreground mb-1 block">Confirm Password</label>
+          <Input type="password" value={confirm} onChange={e => setConfirm(e.target.value)} className="h-8 text-sm" placeholder="Repeat password" />
         </div>
+        {pwErr && <p className="text-xs text-red-500">{pwErr}</p>}
+        <Button size="sm" disabled={saving || !newPw || !confirm} onClick={handlePasswordSave}>
+          Change Password
+        </Button>
       </div>
     </div>
   )

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -22,6 +22,7 @@ interface SettingsData {
     defaultInstanceType?: string
   }>
   github: Array<{ appId: number; url?: string; keySet: boolean }>
+  sshPublicKeys: string[]
 }
 
 async function fetchSettings(): Promise<SettingsData> {
@@ -129,8 +130,8 @@ export default function SettingsPage() {
           {settings && section === "github" && (
             <GitHubSection settings={settings} onSave={save} saving={saving} />
           )}
-          {section === "security" && (
-            <SecuritySection onSave={save} saving={saving} />
+          {settings && section === "security" && (
+            <SecuritySection settings={settings} onSave={save} saving={saving} />
           )}
         </main>
       </div>
@@ -343,37 +344,84 @@ function GitHubSection({ settings, onSave, saving }: { settings: SettingsData; o
   )
 }
 
-function SecuritySection({ onSave, saving }: { onSave: (p: object) => void; saving: boolean }) {
-  const [current, setCurrent] = useState("")
+function SecuritySection({ settings, onSave, saving }: { settings: SettingsData; onSave: (p: object) => void; saving: boolean }) {
   const [newPw, setNewPw] = useState("")
   const [confirm, setConfirm] = useState("")
-  const [err, setErr] = useState("")
+  const [pwErr, setPwErr] = useState("")
+  const [newKey, setNewKey] = useState("")
 
-  function handleSave() {
-    setErr("")
-    if (newPw.length < 8) { setErr("Password must be at least 8 characters"); return }
-    if (newPw !== confirm) { setErr("Passwords don't match"); return }
+  function handlePasswordSave() {
+    setPwErr("")
+    if (newPw.length < 8) { setPwErr("Password must be at least 8 characters"); return }
+    if (newPw !== confirm) { setPwErr("Passwords don't match"); return }
     onSave({ uiPassword: newPw })
-    setCurrent(""); setNewPw(""); setConfirm("")
+    setNewPw(""); setConfirm("")
+  }
+
+  function addKey() {
+    const key = newKey.trim()
+    if (!key) return
+    const keys = [...(settings.sshPublicKeys || []), key]
+    onSave({ sshPublicKeys: keys })
+    setNewKey("")
+  }
+
+  function removeKey(idx: number) {
+    const keys = (settings.sshPublicKeys || []).filter((_, i) => i !== idx)
+    onSave({ sshPublicKeys: keys })
   }
 
   return (
-    <div>
-      <h2 className="text-base font-semibold mb-1">Security</h2>
-      <p className="text-sm text-muted-foreground mb-6">Change the web UI login password.</p>
-      <div className="border border-border rounded-lg p-5 max-w-sm space-y-3">
-        <div>
-          <label className="text-xs text-muted-foreground mb-1 block">New Password</label>
-          <Input type="password" value={newPw} onChange={e => setNewPw(e.target.value)} className="h-8 text-sm" placeholder="Min 8 characters" />
+    <div className="space-y-8">
+      {/* Password */}
+      <div>
+        <h2 className="text-base font-semibold mb-1">Security</h2>
+        <p className="text-sm text-muted-foreground mb-4">Change the web UI login password.</p>
+        <div className="border border-border rounded-lg p-5 max-w-sm space-y-3">
+          <div>
+            <label className="text-xs text-muted-foreground mb-1 block">New Password</label>
+            <Input type="password" value={newPw} onChange={e => setNewPw(e.target.value)} className="h-8 text-sm" placeholder="Min 8 characters" />
+          </div>
+          <div>
+            <label className="text-xs text-muted-foreground mb-1 block">Confirm Password</label>
+            <Input type="password" value={confirm} onChange={e => setConfirm(e.target.value)} className="h-8 text-sm" placeholder="Repeat password" />
+          </div>
+          {pwErr && <p className="text-xs text-red-500">{pwErr}</p>}
+          <Button size="sm" disabled={saving || !newPw || !confirm} onClick={handlePasswordSave}>
+            Change Password
+          </Button>
         </div>
-        <div>
-          <label className="text-xs text-muted-foreground mb-1 block">Confirm Password</label>
-          <Input type="password" value={confirm} onChange={e => setConfirm(e.target.value)} className="h-8 text-sm" placeholder="Repeat password" />
+      </div>
+
+      {/* SSH Keys */}
+      <div>
+        <h3 className="text-sm font-semibold mb-1">Additional SSH Keys</h3>
+        <p className="text-xs text-muted-foreground mb-4">
+          These public keys are injected into every sandbox VM at bootstrap, giving direct SSH access for debugging.
+        </p>
+        <div className="border border-border rounded-lg p-4 space-y-3 max-w-xl">
+          {(settings.sshPublicKeys || []).length === 0 && (
+            <p className="text-xs text-muted-foreground italic">No additional SSH keys configured.</p>
+          )}
+          {(settings.sshPublicKeys || []).map((key, i) => (
+            <div key={i} className="flex items-center gap-2">
+              <code className="flex-1 text-xs bg-secondary px-2 py-1 rounded truncate">{key}</code>
+              <Button size="sm" variant="ghost" className="text-destructive hover:text-destructive px-2 h-7" disabled={saving} onClick={() => removeKey(i)}>
+                Remove
+              </Button>
+            </div>
+          ))}
+          <div className="flex gap-2 pt-1">
+            <Input
+              value={newKey}
+              onChange={e => setNewKey(e.target.value)}
+              onKeyDown={e => { if (e.key === "Enter") addKey() }}
+              placeholder="ssh-ed25519 AAAA... or ssh-rsa AAAA..."
+              className="h-8 text-xs font-mono flex-1"
+            />
+            <Button size="sm" disabled={saving || !newKey.trim()} onClick={addKey}>Add</Button>
+          </div>
         </div>
-        {err && <p className="text-xs text-red-500">{err}</p>}
-        <Button size="sm" disabled={saving || !newPw || !confirm} onClick={handleSave}>
-          Change Password
-        </Button>
       </div>
     </div>
   )

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -1,96 +1,339 @@
 "use client"
 
-import { useState, useEffect } from "react"
-import { useRouter } from "next/navigation"
+import { useState, useEffect, useCallback } from "react"
+import { getHubUrl } from "@/lib/hub-url"
+import { Cpu, Key, Github, ChevronLeft } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import { Field, FieldLabel } from "@/components/ui/field"
-import { saveConfig, clearConfig, isConfigured } from "@/lib/api"
-import { ArrowLeft, Save, Trash2 } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+type Section = "runtimes" | "llm" | "github"
+
+interface SettingsData {
+  llmKeys: Record<string, string>
+  providers: Record<string, {
+    type: string
+    enabled: boolean
+    apiUrl?: string
+    apiKeySet?: boolean
+    defaultSnapshot?: string
+    tokenSet?: boolean
+    defaultTtl?: string
+    defaultInstanceType?: string
+  }>
+  github: Array<{ appId: number; url?: string; keySet: boolean }>
+}
+
+async function fetchSettings(): Promise<SettingsData> {
+  const hubUrl = getHubUrl()
+  const token = sessionStorage.getItem("ec_hub_token") || ""
+  const res = await fetch(`${hubUrl}/api/settings`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  if (!res.ok) throw new Error("Failed to load settings")
+  return res.json()
+}
+
+async function patchSettings(patch: object): Promise<void> {
+  const hubUrl = getHubUrl()
+  const token = sessionStorage.getItem("ec_hub_token") || ""
+  const res = await fetch(`${hubUrl}/api/settings`, {
+    method: "PATCH",
+    headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+    body: JSON.stringify(patch),
+  })
+  if (!res.ok) throw new Error(await res.text())
+}
 
 export default function SettingsPage() {
-  const router = useRouter()
-  const [hubUrl, setHubUrl] = useState("")
-  const [hubToken, setHubToken] = useState("")
-  const [saved, setSaved] = useState(false)
+  const [section, setSection] = useState<Section>("runtimes")
+  const [settings, setSettings] = useState<SettingsData | null>(null)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState("")
+  const [success, setSuccess] = useState("")
 
-  useEffect(() => {
-    const url =
-      process.env.NEXT_PUBLIC_HUB_URL ||
-      (typeof window !== "undefined" ? localStorage.getItem("hub_url") || "" : "")
-    const token =
-      process.env.NEXT_PUBLIC_HUB_TOKEN ||
-      (typeof window !== "undefined" ? localStorage.getItem("hub_token") || "" : "")
-    setHubUrl(url)
-    setHubToken(token)
+  const load = useCallback(async () => {
+    try {
+      setSettings(await fetchSettings())
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load")
+    }
   }, [])
 
-  const handleSave = () => {
-    saveConfig(hubUrl.trim(), hubToken.trim())
-    setSaved(true)
-    setTimeout(() => {
-      router.push("/")
-    }, 800)
+  useEffect(() => { load() }, [load])
+
+  async function save(patch: object) {
+    setSaving(true)
+    setError("")
+    setSuccess("")
+    try {
+      await patchSettings(patch)
+      setSuccess("Saved")
+      await load()
+      setTimeout(() => setSuccess(""), 2000)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Save failed")
+    } finally {
+      setSaving(false)
+    }
   }
 
-  const handleClear = () => {
-    clearConfig()
-    setHubUrl("")
-    setHubToken("")
-  }
+  const navItems: { id: Section; label: string; icon: React.ElementType }[] = [
+    { id: "runtimes", label: "Sandbox Runtimes", icon: Cpu },
+    { id: "llm", label: "LLM Keys", icon: Key },
+    { id: "github", label: "GitHub Apps", icon: Github },
+  ]
 
   return (
-    <div className="flex h-screen bg-background items-center justify-center">
-      <div className="w-full max-w-md p-8 space-y-6">
-        <div className="flex items-center gap-3">
-          <Button variant="ghost" size="icon" onClick={() => router.push("/")}>
-            <ArrowLeft className="size-4" />
-          </Button>
-          <h1 className="text-xl font-semibold">Settings</h1>
+    <div className="min-h-screen bg-background flex flex-col">
+      {/* Header */}
+      <header className="border-b border-border px-6 py-4 flex items-center gap-4">
+        <Button variant="ghost" size="icon" onClick={() => window.location.href = "/"}>
+          <ChevronLeft className="size-4" />
+        </Button>
+        <h1 className="text-lg font-semibold">Settings</h1>
+      </header>
+
+      <div className="flex flex-1">
+        {/* Left nav */}
+        <aside className="w-56 border-r border-border p-4 space-y-1">
+          {navItems.map(({ id, label, icon: Icon }) => (
+            <button
+              key={id}
+              onClick={() => setSection(id)}
+              className={cn(
+                "w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm transition-colors text-left",
+                section === id
+                  ? "bg-primary/10 text-primary font-medium"
+                  : "text-muted-foreground hover:bg-secondary hover:text-foreground"
+              )}
+            >
+              <Icon className="size-4 flex-shrink-0" />
+              {label}
+            </button>
+          ))}
+        </aside>
+
+        {/* Content */}
+        <main className="flex-1 p-8 max-w-2xl">
+          {error && <p className="mb-4 text-sm text-red-500">{error}</p>}
+          {success && <p className="mb-4 text-sm text-green-500">{success}</p>}
+
+          {settings && section === "runtimes" && (
+            <RuntimesSection settings={settings} onSave={save} saving={saving} />
+          )}
+          {settings && section === "llm" && (
+            <LLMSection settings={settings} onSave={save} saving={saving} />
+          )}
+          {settings && section === "github" && (
+            <GitHubSection settings={settings} onSave={save} saving={saving} />
+          )}
+        </main>
+      </div>
+    </div>
+  )
+}
+
+function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData; onSave: (p: object) => void; saving: boolean }) {
+  const rep = settings.providers?.replicated
+  const day = settings.providers?.daytona
+
+  const [repToken, setRepToken] = useState("")
+  const [repTTL, setRepTTL] = useState(rep?.defaultTtl || "48h")
+  const [repType, setRepType] = useState(rep?.defaultInstanceType || "r1.large")
+
+  const [dayURL, setDayURL] = useState(day?.apiUrl || "")
+  const [dayKey, setDayKey] = useState("")
+  const [daySnapshot, setDaySnapshot] = useState(day?.defaultSnapshot || "")
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h2 className="text-base font-semibold mb-1">Sandbox Runtimes</h2>
+        <p className="text-sm text-muted-foreground mb-6">Configure VM providers for spawning claws.</p>
+
+        {/* Replicated */}
+        <div className="border border-border rounded-lg p-5 mb-4">
+          <div className="flex items-center justify-between mb-4">
+            <div>
+              <h3 className="font-medium">Replicated CMX</h3>
+              <p className="text-xs text-muted-foreground mt-0.5">Kubernetes-based VM provider</p>
+            </div>
+            {rep?.tokenSet && <span className="text-xs bg-green-500/20 text-green-400 px-2 py-1 rounded">Configured</span>}
+          </div>
+          <div className="space-y-3">
+            <div>
+              <label className="text-xs text-muted-foreground mb-1 block">API Token</label>
+              <Input
+                type="password"
+                placeholder={rep?.tokenSet ? "••••••••••• (set)" : "Enter Replicated API token"}
+                value={repToken}
+                onChange={e => setRepToken(e.target.value)}
+                className="h-8 text-sm"
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="text-xs text-muted-foreground mb-1 block">Default TTL</label>
+                <Input value={repTTL} onChange={e => setRepTTL(e.target.value)} className="h-8 text-sm" placeholder="48h" />
+              </div>
+              <div>
+                <label className="text-xs text-muted-foreground mb-1 block">Default Instance</label>
+                <Input value={repType} onChange={e => setRepType(e.target.value)} className="h-8 text-sm" placeholder="r1.large" />
+              </div>
+            </div>
+            <Button size="sm" disabled={saving || (!repToken && !repTTL && !repType)} onClick={() => {
+              const patch: Record<string, string> = {}
+              if (repTTL) patch.defaultTtl = repTTL
+              if (repType) patch.defaultInstanceType = repType
+              if (repToken) patch.token = repToken
+              onSave({ providers: { replicated: patch } })
+            }}>
+              Save Replicated
+            </Button>
+          </div>
         </div>
 
-        <div className="space-y-4">
-          <Field>
-            <FieldLabel htmlFor="hub-url">Hub URL</FieldLabel>
-            <Input
-              id="hub-url"
-              placeholder="http://your-hub-host:8080"
-              value={hubUrl}
-              onChange={(e) => setHubUrl(e.target.value)}
+        {/* Daytona */}
+        <div className="border border-border rounded-lg p-5">
+          <div className="flex items-center justify-between mb-4">
+            <div>
+              <h3 className="font-medium">Daytona</h3>
+              <p className="text-xs text-muted-foreground mt-0.5">Development environment provider</p>
+            </div>
+            {day?.apiKeySet && <span className="text-xs bg-green-500/20 text-green-400 px-2 py-1 rounded">Configured</span>}
+          </div>
+          <div className="space-y-3">
+            <div>
+              <label className="text-xs text-muted-foreground mb-1 block">API URL</label>
+              <Input value={dayURL} onChange={e => setDayURL(e.target.value)} className="h-8 text-sm" placeholder="https://app.daytona.io" />
+            </div>
+            <div>
+              <label className="text-xs text-muted-foreground mb-1 block">API Key</label>
+              <Input type="password" placeholder={day?.apiKeySet ? "••••••••••• (set)" : "Enter Daytona API key"} value={dayKey} onChange={e => setDayKey(e.target.value)} className="h-8 text-sm" />
+            </div>
+            <div>
+              <label className="text-xs text-muted-foreground mb-1 block">Default Snapshot</label>
+              <Input value={daySnapshot} onChange={e => setDaySnapshot(e.target.value)} className="h-8 text-sm" placeholder="daytona-medium" />
+            </div>
+            <Button size="sm" disabled={saving} onClick={() => {
+              const patch: Record<string, string> = {}
+              if (dayURL) patch.apiUrl = dayURL
+              if (dayKey) patch.apiKey = dayKey
+              if (daySnapshot) patch.defaultSnapshot = daySnapshot
+              onSave({ providers: { daytona: patch } })
+            }}>
+              Save Daytona
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSave: (p: object) => void; saving: boolean }) {
+  const providers = [
+    { id: "anthropic", label: "Anthropic", placeholder: "sk-ant-..." },
+    { id: "openai", label: "OpenAI", placeholder: "sk-..." },
+  ]
+  const [keys, setKeys] = useState<Record<string, string>>({})
+
+  return (
+    <div>
+      <h2 className="text-base font-semibold mb-1">LLM Keys</h2>
+      <p className="text-sm text-muted-foreground mb-6">API keys injected into claws at bootstrap time.</p>
+      <div className="space-y-4">
+        {providers.map(({ id, label, placeholder }) => (
+          <div key={id} className="border border-border rounded-lg p-4">
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="font-medium text-sm">{label}</h3>
+              {settings.llmKeys?.[id] && <span className="text-xs bg-green-500/20 text-green-400 px-2 py-1 rounded">Set</span>}
+            </div>
+            <div className="flex gap-2">
+              <Input
+                type="password"
+                placeholder={settings.llmKeys?.[id] ? `${settings.llmKeys[id]}` : placeholder}
+                value={keys[id] || ""}
+                onChange={e => setKeys(prev => ({ ...prev, [id]: e.target.value }))}
+                className="h-8 text-sm flex-1"
+              />
+              <Button size="sm" disabled={saving || !keys[id]} onClick={() => {
+                onSave({ llmKeys: { [id]: keys[id] } })
+                setKeys(prev => ({ ...prev, [id]: "" }))
+              }}>
+                Save
+              </Button>
+              {settings.llmKeys?.[id] && (
+                <Button size="sm" variant="outline" disabled={saving} onClick={() => onSave({ llmKeys: { [id]: "" } })}>
+                  Remove
+                </Button>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function GitHubSection({ settings, onSave, saving }: { settings: SettingsData; onSave: (p: object) => void; saving: boolean }) {
+  const [appId, setAppId] = useState("")
+  const [url, setUrl] = useState("")
+  const [pem, setPem] = useState("")
+
+  return (
+    <div>
+      <h2 className="text-base font-semibold mb-1">GitHub Apps</h2>
+      <p className="text-sm text-muted-foreground mb-6">
+        GitHub App credentials for claws to access repositories. <span className="text-muted-foreground/60">(Optional)</span>
+      </p>
+
+      {settings.github?.length > 0 && (
+        <div className="mb-6 space-y-2">
+          {settings.github.map(app => (
+            <div key={app.appId} className="border border-border rounded-lg p-4 flex items-center justify-between">
+              <div>
+                <p className="text-sm font-medium">App ID: {app.appId}</p>
+                {app.url && <p className="text-xs text-muted-foreground">{app.url}</p>}
+              </div>
+              <span className={cn("text-xs px-2 py-1 rounded", app.keySet ? "bg-green-500/20 text-green-400" : "bg-yellow-500/20 text-yellow-400")}>
+                {app.keySet ? "Key set" : "No key"}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="border border-border rounded-lg p-5">
+        <h3 className="font-medium text-sm mb-4">Add GitHub App</h3>
+        <div className="space-y-3">
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="text-xs text-muted-foreground mb-1 block">App ID</label>
+              <Input value={appId} onChange={e => setAppId(e.target.value)} className="h-8 text-sm" placeholder="123456" />
+            </div>
+            <div>
+              <label className="text-xs text-muted-foreground mb-1 block">App URL (optional)</label>
+              <Input value={url} onChange={e => setUrl(e.target.value)} className="h-8 text-sm" placeholder="https://github.com/apps/..." />
+            </div>
+          </div>
+          <div>
+            <label className="text-xs text-muted-foreground mb-1 block">Private Key (PEM)</label>
+            <textarea
+              value={pem}
+              onChange={e => setPem(e.target.value)}
+              placeholder="-----BEGIN RSA PRIVATE KEY-----&#10;...&#10;-----END RSA PRIVATE KEY-----"
+              className="w-full h-32 rounded-md border border-border bg-background px-3 py-2 text-xs font-mono resize-none focus:outline-none focus:ring-2 focus:ring-ring"
             />
-          </Field>
-          <Field>
-            <FieldLabel htmlFor="hub-token">Hub Token</FieldLabel>
-            <Input
-              id="hub-token"
-              type="password"
-              placeholder="your-auth-token"
-              value={hubToken}
-              onChange={(e) => setHubToken(e.target.value)}
-            />
-          </Field>
-        </div>
-
-        <div className="flex items-center gap-3">
-          <Button
-            onClick={handleSave}
-            disabled={!hubUrl.trim() || !hubToken.trim()}
-            className="flex-1"
-          >
-            <Save className="size-4 mr-2" />
-            {saved ? "Saved!" : "Save & Connect"}
-          </Button>
-          <Button variant="outline" size="icon" onClick={handleClear}>
-            <Trash2 className="size-4" />
+          </div>
+          <Button size="sm" disabled={saving || !appId || !pem} onClick={() => {
+            onSave({ github: [...(settings.github || []), { appId: parseInt(appId), url, privateKeyPem: pem }] })
+            setAppId(""); setUrl(""); setPem("")
+          }}>
+            Add App
           </Button>
         </div>
-
-        <p className="text-xs text-muted-foreground">
-          These settings are stored in localStorage. You can also set{" "}
-          <code className="bg-muted px-1 rounded text-xs">NEXT_PUBLIC_HUB_URL</code> and{" "}
-          <code className="bg-muted px-1 rounded text-xs">NEXT_PUBLIC_HUB_TOKEN</code>{" "}
-          environment variables instead.
-        </p>
       </div>
     </div>
   )

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -10,7 +10,7 @@ import { cn } from "@/lib/utils"
 type Section = "runtimes" | "llm" | "github" | "security"
 
 interface SettingsData {
-  llmKeys: Record<string, string>
+  llmKeys: Record<string, boolean>
   providers: Record<string, {
     type: string
     enabled: boolean
@@ -291,7 +291,7 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
             <div className="flex gap-2">
               <Input
                 type="password"
-                placeholder={settings.llmKeys?.[id] ? `${settings.llmKeys[id]}` : placeholder}
+                placeholder={settings.llmKeys?.[id] ? "••••••••••• (set)" : placeholder}
                 value={keys[id] || ""}
                 onChange={e => setKeys(prev => ({ ...prev, [id]: e.target.value }))}
                 className="h-8 text-sm flex-1"

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -2,12 +2,12 @@
 
 import { useState, useEffect, useCallback } from "react"
 import { getHubUrl } from "@/lib/hub-url"
-import { Cpu, Key, Github, ChevronLeft } from "lucide-react"
+import { Cpu, Key, Github, ChevronLeft, Shield } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { cn } from "@/lib/utils"
 
-type Section = "runtimes" | "llm" | "github"
+type Section = "runtimes" | "llm" | "github" | "security"
 
 interface SettingsData {
   llmKeys: Record<string, string>
@@ -82,6 +82,7 @@ export default function SettingsPage() {
     { id: "runtimes", label: "Sandbox Runtimes", icon: Cpu },
     { id: "llm", label: "LLM Keys", icon: Key },
     { id: "github", label: "GitHub Apps", icon: Github },
+    { id: "security", label: "Security", icon: Shield },
   ]
 
   return (
@@ -127,6 +128,9 @@ export default function SettingsPage() {
           )}
           {settings && section === "github" && (
             <GitHubSection settings={settings} onSave={save} saving={saving} />
+          )}
+          {section === "security" && (
+            <SecuritySection onSave={save} saving={saving} />
           )}
         </main>
       </div>
@@ -334,6 +338,42 @@ function GitHubSection({ settings, onSave, saving }: { settings: SettingsData; o
             Add App
           </Button>
         </div>
+      </div>
+    </div>
+  )
+}
+
+function SecuritySection({ onSave, saving }: { onSave: (p: object) => void; saving: boolean }) {
+  const [current, setCurrent] = useState("")
+  const [newPw, setNewPw] = useState("")
+  const [confirm, setConfirm] = useState("")
+  const [err, setErr] = useState("")
+
+  function handleSave() {
+    setErr("")
+    if (newPw.length < 8) { setErr("Password must be at least 8 characters"); return }
+    if (newPw !== confirm) { setErr("Passwords don't match"); return }
+    onSave({ uiPassword: newPw })
+    setCurrent(""); setNewPw(""); setConfirm("")
+  }
+
+  return (
+    <div>
+      <h2 className="text-base font-semibold mb-1">Security</h2>
+      <p className="text-sm text-muted-foreground mb-6">Change the web UI login password.</p>
+      <div className="border border-border rounded-lg p-5 max-w-sm space-y-3">
+        <div>
+          <label className="text-xs text-muted-foreground mb-1 block">New Password</label>
+          <Input type="password" value={newPw} onChange={e => setNewPw(e.target.value)} className="h-8 text-sm" placeholder="Min 8 characters" />
+        </div>
+        <div>
+          <label className="text-xs text-muted-foreground mb-1 block">Confirm Password</label>
+          <Input type="password" value={confirm} onChange={e => setConfirm(e.target.value)} className="h-8 text-sm" placeholder="Repeat password" />
+        </div>
+        {err && <p className="text-xs text-red-500">{err}</p>}
+        <Button size="sm" disabled={saving || !newPw || !confirm} onClick={handleSave}>
+          Change Password
+        </Button>
       </div>
     </div>
   )

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -218,7 +218,8 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
                     Remove
                   </Button>
                 </div>
-              ))}
+              )
+              })}
               <div className="flex gap-2">
                 <Input value={newKey} onChange={e => setNewKey(e.target.value)}
                   onKeyDown={e => { if (e.key === "Enter" && newKey.trim()) { onSave({ sshPublicKeys: [...(settings.sshPublicKeys || []), newKey.trim()] }); setNewKey("") }}}

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -341,7 +341,14 @@ function GitHubSection({ settings, onSave, saving }: { settings: SettingsData; o
                     {app.keySet ? "Key set" : "No key"}
                   </span>
                   <Button size="sm" variant="ghost" className="text-destructive hover:text-destructive h-7 px-2" disabled={saving}
-                    onClick={() => onSave({ github: settings.github.filter(a => a.appId !== app.appId) })}>
+                    onClick={() => {
+                      const filtered = settings.github.filter(a => a.appId !== app.appId).map(a => {
+                        const item: { appId: number; url?: string } = { appId: a.appId }
+                        if (a.url) item.url = a.url
+                        return item
+                      })
+                      onSave({ github: filtered })
+                    }}>
                     Remove
                   </Button>
                 </div>
@@ -357,7 +364,7 @@ function GitHubSection({ settings, onSave, saving }: { settings: SettingsData; o
           <div className="grid grid-cols-2 gap-3">
             <div>
               <label className="text-xs text-muted-foreground mb-1 block">App ID</label>
-              <Input value={appId} onChange={e => setAppId(e.target.value)} className="h-8 text-sm" placeholder="123456" />
+              <Input type="number" value={appId} onChange={e => setAppId(e.target.value)} className="h-8 text-sm" placeholder="123456" />
             </div>
             <div>
               <label className="text-xs text-muted-foreground mb-1 block">App URL (optional)</label>
@@ -373,8 +380,11 @@ function GitHubSection({ settings, onSave, saving }: { settings: SettingsData; o
               className="w-full h-32 rounded-md border border-border bg-background px-3 py-2 text-xs font-mono resize-none focus:outline-none focus:ring-2 focus:ring-ring"
             />
           </div>
-          <Button size="sm" disabled={saving || !appId || !pem} onClick={() => {
-            onSave({ github: [...(settings.github || []), { appId: parseInt(appId), url, privateKeyPem: pem }] })
+          <Button size="sm" disabled={saving || !appId || !pem || isNaN(Number(appId))} onClick={() => {
+            const parsedAppId = parseInt(appId, 10)
+            const newApp: { appId: number; privateKeyPem: string; url?: string } = { appId: parsedAppId, privateKeyPem: pem }
+            if (url) newApp.url = url
+            onSave({ github: [...(settings.github || []), newApp] })
             setAppId(""); setUrl(""); setPem("")
           }}>
             Add App

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -320,14 +320,22 @@ function GitHubSection({ settings, onSave, saving }: { settings: SettingsData; o
       {settings.github?.length > 0 && (
         <div className="mb-6 space-y-2">
           {settings.github.map(app => (
-            <div key={app.appId} className="border border-border rounded-lg p-4 flex items-center justify-between">
-              <div>
-                <p className="text-sm font-medium">App ID: {app.appId}</p>
-                {app.url && <p className="text-xs text-muted-foreground">{app.url}</p>}
+            <div key={app.appId} className="border border-border rounded-lg p-4">
+              <div className="flex items-center justify-between mb-2">
+                <div>
+                  <p className="text-sm font-medium">App ID: {app.appId}</p>
+                  {app.url && <p className="text-xs text-muted-foreground">{app.url}</p>}
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className={cn("text-xs px-2 py-1 rounded", app.keySet ? "bg-green-500/20 text-green-400" : "bg-yellow-500/20 text-yellow-400")}>
+                    {app.keySet ? "Key set" : "No key"}
+                  </span>
+                  <Button size="sm" variant="ghost" className="text-destructive hover:text-destructive h-7 px-2" disabled={saving}
+                    onClick={() => onSave({ github: settings.github.filter(a => a.appId !== app.appId) })}>
+                    Remove
+                  </Button>
+                </div>
               </div>
-              <span className={cn("text-xs px-2 py-1 rounded", app.keySet ? "bg-green-500/20 text-green-400" : "bg-yellow-500/20 text-yellow-400")}>
-                {app.keySet ? "Key set" : "No key"}
-              </span>
             </div>
           ))}
         </div>

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -201,9 +201,18 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
             <div className="border-t border-border mt-4 pt-4">
               <p className="text-xs font-medium mb-2">Additional SSH Keys</p>
               <p className="text-xs text-muted-foreground mb-3">Public keys injected into Replicated VMs at bootstrap for direct SSH access.</p>
-              {(settings.sshPublicKeys || []).map((key, i) => (
+              {(settings.sshPublicKeys || []).map((key, i) => {
+                const parts = key.trim().split(/\s+/)
+                const keyType = parts[0] || ""
+                const comment = parts[2] || ""
+                const keyBody = parts[1] || ""
+                const shortKey = keyBody.length > 12 ? keyBody.slice(0, 8) + "..." + keyBody.slice(-4) : keyBody
+                return (
                 <div key={i} className="flex items-center gap-2 mb-2">
-                  <code className="flex-1 text-xs bg-secondary px-2 py-1 rounded truncate">{key}</code>
+                  <div className="flex-1 min-w-0">
+                    <code className="text-xs font-mono">{keyType} {shortKey}</code>
+                    {comment && <span className="ml-2 text-xs text-muted-foreground">{comment}</span>}
+                  </div>
                   <Button size="sm" variant="ghost" className="text-destructive hover:text-destructive px-2 h-7" disabled={saving}
                     onClick={() => onSave({ sshPublicKeys: (settings.sshPublicKeys || []).filter((_, j) => j !== i) })}>
                     Remove

--- a/web/components/sidebar.tsx
+++ b/web/components/sidebar.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Search, Pin, X, ChevronDown, PanelLeftClose, PanelLeft, Loader2, AlertCircle, LogOut } from "lucide-react"
+import { Search, Pin, X, ChevronDown, PanelLeftClose, PanelLeft, Loader2, AlertCircle, LogOut, Settings } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { ScrollArea } from "@/components/ui/scroll-area"
@@ -272,6 +272,15 @@ export function Sidebar({
         >
           <LogOut className="size-4" />
           Sign out
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="w-full justify-start gap-2 text-muted-foreground hover:text-foreground"
+          onClick={() => { window.location.href = "/settings" }}
+        >
+          <Settings className="size-4" />
+          Settings
         </Button>
       </div>
     </aside>

--- a/web/components/sidebar.tsx
+++ b/web/components/sidebar.tsx
@@ -252,36 +252,38 @@ export function Sidebar({
         </div>
       </ScrollArea>
 
-      {/* Logout */}
+      {/* Logout + Settings */}
       <div className="p-2 border-t border-border">
-        <Button
-          variant="ghost"
-          size="sm"
-          className="w-full justify-start gap-2 text-muted-foreground hover:text-foreground"
-          onClick={async () => {
-            const token = sessionStorage.getItem("ec_hub_token") || ""
-            if (token) {
-              const { getHubUrl } = await import("@/lib/hub-url")
-              const hubUrl = getHubUrl()
-              const logoutUrl = hubUrl ? `${hubUrl}/api/auth/logout` : "/api/auth/logout"
-              await fetch(logoutUrl, { method: "POST", headers: { Authorization: `Bearer ${token}` } }).catch(() => {})
-            }
-            sessionStorage.removeItem("ec_hub_token")
-            window.location.href = "/login"
-          }}
-        >
-          <LogOut className="size-4" />
-          Sign out
-        </Button>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="w-full justify-start gap-2 text-muted-foreground hover:text-foreground"
-          onClick={() => { window.location.href = "/settings" }}
-        >
-          <Settings className="size-4" />
-          Settings
-        </Button>
+        <div className="flex items-center gap-1">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="flex-1 justify-start gap-2 text-muted-foreground hover:text-foreground"
+            onClick={async () => {
+              const token = sessionStorage.getItem("ec_hub_token") || ""
+              if (token) {
+                const { getHubUrl } = await import("@/lib/hub-url")
+                const hubUrl = getHubUrl()
+                const logoutUrl = hubUrl ? `${hubUrl}/api/auth/logout` : "/api/auth/logout"
+                await fetch(logoutUrl, { method: "POST", headers: { Authorization: `Bearer ${token}` } }).catch(() => {})
+              }
+              sessionStorage.removeItem("ec_hub_token")
+              window.location.href = "/login"
+            }}
+          >
+            <LogOut className="size-4" />
+            Sign out
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-8 text-muted-foreground hover:text-foreground flex-shrink-0"
+            onClick={() => { window.location.href = "/settings" }}
+            title="Settings"
+          >
+            <Settings className="size-4" />
+          </Button>
+        </div>
       </div>
     </aside>
   )

--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
Hub:
- GET/PATCH /api/settings — read/write hub.yaml config sections
- GET /api/settings/status — {hasProvider, hasLLMKey, hasGitHub} for redirect logic
- config.ActiveHubConfigPath() — saves to the same file that was loaded

Web:
- /settings page with left nav (Runtimes | LLM Keys | GitHub Apps)
- Replicated and Daytona forms with masked existing values
- LLM key management (add/remove per provider)
- GitHub App form with PEM textarea
- After login: if !hasProvider || !hasLLMKey → redirect to /settings
- Sidebar: ⚙️ Settings button above Sign out