### PR TITLE
feat: Linear integration foundation

### DIFF
--- a/cmd/template.go
+++ b/cmd/template.go
@@ -1,11 +1,14 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/elasticclaw/elasticclaw/pkg/config"
+	"github.com/elasticclaw/elasticclaw/pkg/hub"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
@@ -235,17 +238,45 @@ func runTemplateList(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if len(found) == 0 {
+	// Check hub-stored templates
+	var hubTemplates []string
+	if h, _, err := config.ResolveHub(profile); err == nil {
+		client := hub.NewClient(h.URL, h.Token)
+		if hubTmpls, err := client.ListHubTemplates(context.Background()); err == nil {
+			for _, t := range hubTmpls {
+				if name, ok := t["name"]; ok {
+					hubTemplates = append(hubTemplates, name)
+				}
+			}
+		}
+	}
+
+	if len(found) == 0 && len(hubTemplates) == 0 {
 		fmt.Println("No templates found.")
 		fmt.Println()
 		fmt.Println("Create one with:")
 		fmt.Println("  elasticclaw template create <name>")
+		fmt.Println("Push to hub with:")
+		fmt.Println("  elasticclaw template push <name>")
 		return nil
 	}
 
-	fmt.Printf("%-20s  %-12s  %s\n", "NAME", "PROVIDER", "LOCATION")
-	for _, t := range found {
-		fmt.Printf("%-20s  %-12s  %s\n", t.name, t.provider, t.dir)
+	if len(found) > 0 {
+		fmt.Println("Local templates:")
+		fmt.Printf("  %-20s  %-12s  %s\n", "NAME", "PROVIDER", "LOCATION")
+		for _, t := range found {
+			fmt.Printf("  %-20s  %-12s  %s\n", t.name, t.provider, t.dir)
+		}
+	}
+
+	if len(hubTemplates) > 0 {
+		if len(found) > 0 {
+			fmt.Println()
+		}
+		fmt.Println("Hub templates (available for factories):")
+		for _, name := range hubTemplates {
+			fmt.Printf("  %-20s  hub\n", name)
+		}
 	}
 	return nil
 }

--- a/cmd/template_push.go
+++ b/cmd/template_push.go
@@ -1,0 +1,89 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/elasticclaw/elasticclaw/pkg/config"
+	"github.com/elasticclaw/elasticclaw/pkg/hub"
+	"github.com/spf13/cobra"
+)
+
+var templatePushCmd = &cobra.Command{
+	Use:   "push [name-or-path]",
+	Short: "Push a template to the hub",
+	Long: `Push a template to the connected hub so it can be used by factories and remote claw creation.
+
+Push a local template by name:
+  elasticclaw template push elasticclaw-dev
+
+Push a template from a specific directory:
+  elasticclaw template push ./my-template
+
+Push a template from the public registry to the hub:
+  elasticclaw template push base`,
+	Args: cobra.ExactArgs(1),
+	RunE: runTemplatePush,
+}
+
+func init() {
+	templateCmd.AddCommand(templatePushCmd)
+}
+
+func runTemplatePush(cmd *cobra.Command, args []string) error {
+	nameOrPath := args[0]
+
+	// Resolve template directory
+	var templateDir string
+	var templateName string
+
+	// Check if it looks like a path
+	if strings.HasPrefix(nameOrPath, "./") || strings.HasPrefix(nameOrPath, "/") || strings.HasPrefix(nameOrPath, "../") {
+		// Explicit path
+		abs, err := filepath.Abs(nameOrPath)
+		if err != nil {
+			return fmt.Errorf("invalid path: %w", err)
+		}
+		templateDir = abs
+		templateName = filepath.Base(abs)
+	} else {
+		// Name — resolve via normal template resolution (local, then registry)
+		templateName = nameOrPath
+		dir, err := config.ResolveTemplate(nameOrPath)
+		if err != nil {
+			return fmt.Errorf("template %q not found: %w\nUse 'elasticclaw template list' to see available templates", nameOrPath, err)
+		}
+		templateDir = dir
+	}
+
+	// Read template files
+	fsFiles, err := config.ReadTemplateFiles(templateDir)
+	if err != nil {
+		return fmt.Errorf("failed to read template: %w", err)
+	}
+
+	// Also include the config yaml
+	configPath := filepath.Join(templateDir, "elasticclaw-config.yaml")
+	if data, err := os.ReadFile(configPath); err == nil {
+		fsFiles["elasticclaw-config.yaml"] = string(data)
+	}
+
+	if len(fsFiles) == 0 {
+		return fmt.Errorf("template directory is empty")
+	}
+
+	// Push to hub
+	h, _, err := config.ResolveHub(profile)
+	if err != nil {
+		return err
+	}
+	client := hub.NewClient(h.URL, h.Token)
+	if err := client.PushTemplate(templateName, fsFiles); err != nil {
+		return fmt.Errorf("push failed: %w", err)
+	}
+
+	fmt.Printf("✓ Template %q pushed to hub (%d files)\n", templateName, len(fsFiles))
+	return nil
+}

--- a/pkg/hub/client.go
+++ b/pkg/hub/client.go
@@ -232,3 +232,23 @@ func (c *Client) Login(ctx context.Context) (string, error) {
 	}
 	return resp["tenant_id"], nil
 }
+
+// PushTemplate uploads a template to the hub's template store.
+func (c *Client) PushTemplate(name string, files map[string]string) error {
+	body := map[string]interface{}{
+		"name":  name,
+		"files": files,
+	}
+	_, err := c.do(context.Background(), "POST", "/api/templates", body)
+	return err
+}
+
+// ListHubTemplates returns the templates stored on the hub.
+func (c *Client) ListHubTemplates(ctx context.Context) ([]map[string]string, error) {
+	data, err := c.do(ctx, "GET", "/api/templates", nil)
+	if err != nil {
+		return nil, err
+	}
+	var result []map[string]string
+	return result, json.Unmarshal(data, &result)
+}

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -35,6 +35,7 @@ func migrate(db *sql.DB) error {
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN nix INTEGER NOT NULL DEFAULT 0`)
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN tags TEXT NOT NULL DEFAULT '[]'`)
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN color TEXT NOT NULL DEFAULT ''`)
+	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN linear_issue_id TEXT NOT NULL DEFAULT ''`)
 
 	_, err := db.Exec(`
 	CREATE TABLE IF NOT EXISTS tenants (
@@ -81,6 +82,13 @@ func migrate(db *sql.DB) error {
 
 	CREATE INDEX IF NOT EXISTS idx_messages_claw ON messages(claw_id, created_at);
 	CREATE INDEX IF NOT EXISTS idx_claws_tenant  ON claws(tenant_id);
+
+	CREATE TABLE IF NOT EXISTS hub_templates (
+		name       TEXT PRIMARY KEY,
+		files      TEXT NOT NULL DEFAULT '{}',  -- JSON map of filename -> content
+		created_at DATETIME NOT NULL,
+		updated_at DATETIME NOT NULL
+	);
 	`)
 	return err
 }

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -22,7 +22,7 @@ type linearWebhookPayload struct {
 	Type   string `json:"type"`   // "Issue", "IssueLabel", etc.
 	Data   struct {
 		ID          string `json:"id"`
-		Identifier  string `json:"identifier"`  // e.g. "ELA-123"
+		Identifier  string `json:"identifier"` // e.g. "ELA-123"
 		Title       string `json:"title"`
 		Description string `json:"description"`
 		URL         string `json:"url"`
@@ -189,7 +189,7 @@ func (s *Server) createClawForIssue(factory *types.FactoryConfig, payload linear
 
 	// Insert claw record
 	clawID := uuid.New().String()
-	filesJSON, _ := json.Marshal(filesMapToBytes(templateFiles))
+	filesJSON, _ := json.Marshal(templateFiles)
 	now := now()
 
 	_, err = s.db.Exec(`
@@ -288,16 +288,7 @@ func buildLinearContext(payload linearWebhookPayload) string {
 	return b.String()
 }
 
-func filesMapToBytes(files map[string]string) map[string][]byte {
-	result := make(map[string][]byte, len(files))
-	for k, v := range files {
-		result[k] = []byte(v)
-	}
-	return result
-}
-
 // Avoid collision with existing now() function
-
 
 // handleClawDoneSignal is called when a claw sends a message containing [DONE].
 // Finds the matching factory config and moves the Linear issue to done_status.

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -1,0 +1,301 @@
+package hub
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+	"github.com/google/uuid"
+)
+
+// linearWebhookPayload is the relevant subset of a Linear webhook event.
+type linearWebhookPayload struct {
+	Action string `json:"action"` // "create", "update", "remove"
+	Type   string `json:"type"`   // "Issue", "IssueLabel", etc.
+	Data   struct {
+		ID          string `json:"id"`
+		Identifier  string `json:"identifier"`  // e.g. "ELA-123"
+		Title       string `json:"title"`
+		Description string `json:"description"`
+		URL         string `json:"url"`
+		State       struct {
+			Name string `json:"name"`
+		} `json:"state"`
+		Team struct {
+			Key  string `json:"key"`
+			Name string `json:"name"`
+		} `json:"team"`
+		PreviousState *struct {
+			Name string `json:"name"`
+		} `json:"previousState,omitempty"`
+	} `json:"data"`
+}
+
+func (s *Server) handleLinearWebhook(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	if err != nil {
+		http.Error(w, "read error", http.StatusBadRequest)
+		return
+	}
+
+	// Validate signature if any Linear integration has a webhook_secret
+	sig := r.Header.Get("Linear-Signature")
+	if !s.validateLinearSignature(body, sig) {
+		http.Error(w, "invalid signature", http.StatusUnauthorized)
+		return
+	}
+
+	var payload linearWebhookPayload
+	if err := json.Unmarshal(body, &payload); err != nil {
+		http.Error(w, "invalid payload", http.StatusBadRequest)
+		return
+	}
+
+	// Only handle Issue updates
+	if payload.Type != "Issue" || payload.Action != "update" {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	go s.processLinearEvent(payload)
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *Server) validateLinearSignature(body []byte, sig string) bool {
+	if s.hubCfg.Integrations == nil {
+		return true // no integrations configured, accept all
+	}
+	for _, li := range s.hubCfg.Integrations.Linear {
+		if li.WebhookSecret == "" {
+			continue
+		}
+		mac := hmac.New(sha256.New, []byte(li.WebhookSecret))
+		mac.Write(body)
+		expected := hex.EncodeToString(mac.Sum(nil))
+		if hmac.Equal([]byte(sig), []byte(expected)) {
+			return true
+		}
+	}
+	// If secrets are configured but none matched, reject
+	for _, li := range s.hubCfg.Integrations.Linear {
+		if li.WebhookSecret != "" {
+			return false
+		}
+	}
+	return true // no secrets configured
+}
+
+func (s *Server) processLinearEvent(payload linearWebhookPayload) {
+	if s.hubCfg.Factories == nil {
+		return
+	}
+
+	currentStatus := payload.Data.State.Name
+	previousStatus := ""
+	if payload.Data.PreviousState != nil {
+		previousStatus = payload.Data.PreviousState.Name
+	}
+	teamKey := payload.Data.Team.Key
+	issueID := payload.Data.Identifier // e.g. "ELA-123"
+
+	for _, factory := range s.hubCfg.Factories {
+		if factory.Integration != "linear" {
+			continue
+		}
+		if factory.Team != "" && !strings.EqualFold(factory.Team, teamKey) {
+			continue
+		}
+
+		// Issue entering trigger status → create claw
+		if currentStatus == factory.TriggerStatus && previousStatus != factory.TriggerStatus {
+			log.Printf("[factory:%s] issue %s entered '%s' — creating claw", factory.Name, issueID, factory.TriggerStatus)
+			if err := s.createClawForIssue(factory, payload); err != nil {
+				log.Printf("[factory:%s] failed to create claw for %s: %v", factory.Name, issueID, err)
+			}
+		}
+
+		// Issue leaving trigger status → terminate claw
+		if factory.TerminateOnLeave && previousStatus == factory.TriggerStatus && currentStatus != factory.TriggerStatus {
+			log.Printf("[factory:%s] issue %s left '%s' — terminating claw", factory.Name, issueID, factory.TriggerStatus)
+			s.terminateClawForIssue(issueID)
+		}
+	}
+}
+
+func (s *Server) createClawForIssue(factory *types.FactoryConfig, payload linearWebhookPayload) error {
+	issueID := payload.Data.Identifier
+
+	// Enforce 1:1 — check if a claw already exists for this issue
+	var existingID string
+	_ = s.db.QueryRow(
+		`SELECT id FROM claws WHERE linear_issue_id = ? AND status NOT IN ('error','deleted') LIMIT 1`,
+		issueID,
+	).Scan(&existingID)
+	if existingID != "" {
+		return fmt.Errorf("claw %s already exists for issue %s", existingID[:8], issueID)
+	}
+
+	// Resolve template files
+	templateFiles, err := s.resolveTemplateFiles(factory.Template)
+	if err != nil {
+		return fmt.Errorf("template %q not found: %w", factory.Template, err)
+	}
+
+	// Inject CONTEXT.md with issue details
+	templateFiles["CONTEXT.md"] = buildLinearContext(payload)
+
+	// Determine claw name
+	clawName := issueID // e.g. "ELA-123"
+	if factory.NamePattern != "" {
+		clawName = strings.ReplaceAll(factory.NamePattern, "{issue_id}", issueID)
+	}
+
+	// Find tenant
+	var tenantID string
+	if err := s.db.QueryRow(`SELECT id FROM tenants LIMIT 1`).Scan(&tenantID); err != nil {
+		return fmt.Errorf("no tenant: %w", err)
+	}
+
+	// Find provider from factory or hub config default
+	provider := s.defaultProvider()
+	if provider == "" {
+		return fmt.Errorf("no provider configured")
+	}
+
+	// Find Linear token for this workspace
+	linearToken := s.resolveLinearTokenForFactory(factory)
+
+	// Build env vars
+	env := map[string]string{
+		"ELASTICCLAW_HUB_URL":    s.clawHubURL(),
+		"ELASTICCLAW_CLAW_TOKEN": s.hubCfg.ClawToken,
+	}
+	if linearToken != "" {
+		env["LINEAR_API_KEY"] = linearToken
+	}
+
+	// Insert claw record
+	clawID := uuid.New().String()
+	filesJSON, _ := json.Marshal(filesMapToBytes(templateFiles))
+	now := now()
+
+	_, err = s.db.Exec(`
+		INSERT INTO claws(id, tenant_id, name, template, provider, template_files, linear_issue_id, status, created_at)
+		VALUES(?,?,?,?,?,?,?,'provisioning',?)`,
+		clawID, tenantID, clawName, factory.Template, provider, string(filesJSON), issueID, now,
+	)
+	if err != nil {
+		return fmt.Errorf("db insert: %w", err)
+	}
+
+	// Provision asynchronously
+	provCfg, _ := s.hubCfg.Providers[provider]
+	go func() {
+		ctx := context.Background()
+		req := types.CreateClawRequest{
+			Name:         clawName,
+			TemplateName: factory.Template,
+			Provider:     provider,
+			Files:        templateFiles,
+			Env:          env,
+		}
+		_ = req // provisioning called below
+		switch provider {
+		case "replicated":
+			if err := s.provisionReplicated(ctx, clawID, req, provCfg, env); err != nil {
+				log.Printf("[factory] provision failed for %s: %v", clawID, err)
+				_, _ = s.db.Exec(`UPDATE claws SET status='error' WHERE id=?`, clawID)
+			}
+		}
+	}()
+
+	log.Printf("[factory] created claw %s (%s) for Linear issue %s", clawName, clawID[:8], issueID)
+	return nil
+}
+
+func (s *Server) terminateClawForIssue(issueID string) {
+	var clawID string
+	if err := s.db.QueryRow(
+		`SELECT id FROM claws WHERE linear_issue_id = ? AND status NOT IN ('error','deleted') LIMIT 1`,
+		issueID,
+	).Scan(&clawID); err != nil {
+		return
+	}
+	log.Printf("[factory] terminating claw %s for issue %s", clawID[:8], issueID)
+	s.mu.Lock()
+	if cc, ok := s.claws[clawID]; ok {
+		cc.conn.Close(1000, "factory: issue left trigger status")
+		delete(s.claws, clawID)
+	}
+	s.mu.Unlock()
+	_, _ = s.db.Exec(`UPDATE claws SET status='deleted' WHERE id=?`, clawID)
+}
+
+func (s *Server) defaultProvider() string {
+	for name, p := range s.hubCfg.Providers {
+		if p.Token != "" || p.APIKey != "" {
+			return name
+		}
+	}
+	return ""
+}
+
+func (s *Server) resolveLinearTokenForFactory(factory *types.FactoryConfig) string {
+	if s.hubCfg.Integrations == nil {
+		return ""
+	}
+	for _, li := range s.hubCfg.Integrations.Linear {
+		if factory.Workspace == "" || strings.EqualFold(li.Workspace, factory.Workspace) {
+			return li.Token
+		}
+	}
+	return ""
+}
+
+func buildLinearContext(payload linearWebhookPayload) string {
+	d := payload.Data
+	var b strings.Builder
+	b.WriteString("# CONTEXT.md - Issue Context\n\n")
+	b.WriteString("This claw was automatically created by ElasticClaw to work on a Linear issue.\n\n")
+	b.WriteString(fmt.Sprintf("## Issue: %s\n\n", d.Identifier))
+	b.WriteString(fmt.Sprintf("**Title:** %s\n\n", d.Title))
+	if d.URL != "" {
+		b.WriteString(fmt.Sprintf("**URL:** %s\n\n", d.URL))
+	}
+	if d.Team.Name != "" {
+		b.WriteString(fmt.Sprintf("**Team:** %s (%s)\n\n", d.Team.Name, d.Team.Key))
+	}
+	if d.Description != "" {
+		b.WriteString("## Description\n\n")
+		b.WriteString(d.Description)
+		b.WriteString("\n")
+	}
+	b.WriteString("\n---\n\n")
+	b.WriteString("Read this file first. Understand the issue. Then look at the codebase and implement it.\n")
+	b.WriteString("When done: move the Linear issue to the configured done status using the Linear API, then signal done.\n")
+	return b.String()
+}
+
+func filesMapToBytes(files map[string]string) map[string][]byte {
+	result := make(map[string][]byte, len(files))
+	for k, v := range files {
+		result[k] = []byte(v)
+	}
+	return result
+}
+
+// Avoid collision with existing now() function
+

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -33,10 +33,12 @@ type linearWebhookPayload struct {
 			Key  string `json:"key"`
 			Name string `json:"name"`
 		} `json:"team"`
-		PreviousState *struct {
-			Name string `json:"name"`
-		} `json:"previousState,omitempty"`
 	} `json:"data"`
+	UpdatedFrom *struct {
+		State *struct {
+			Name string `json:"name"`
+		} `json:"state,omitempty"`
+	} `json:"updatedFrom,omitempty"`
 }
 
 func (s *Server) handleLinearWebhook(w http.ResponseWriter, r *http.Request) {
@@ -105,8 +107,8 @@ func (s *Server) processLinearEvent(payload linearWebhookPayload) {
 
 	currentStatus := payload.Data.State.Name
 	previousStatus := ""
-	if payload.Data.PreviousState != nil {
-		previousStatus = payload.Data.PreviousState.Name
+	if payload.UpdatedFrom != nil && payload.UpdatedFrom.State != nil {
+		previousStatus = payload.UpdatedFrom.State.Name
 	}
 	teamKey := payload.Data.Team.Key
 	issueID := payload.Data.Identifier // e.g. "ELA-123"
@@ -120,7 +122,7 @@ func (s *Server) processLinearEvent(payload linearWebhookPayload) {
 		}
 
 		// Issue entering trigger status → create claw
-		if currentStatus == factory.TriggerStatus && previousStatus != factory.TriggerStatus {
+		if strings.EqualFold(currentStatus, factory.TriggerStatus) && !strings.EqualFold(previousStatus, factory.TriggerStatus) {
 			log.Printf("[factory:%s] issue %s entered '%s' — creating claw", factory.Name, issueID, factory.TriggerStatus)
 			if err := s.createClawForIssue(factory, payload); err != nil {
 				log.Printf("[factory:%s] failed to create claw for %s: %v", factory.Name, issueID, err)
@@ -128,7 +130,7 @@ func (s *Server) processLinearEvent(payload linearWebhookPayload) {
 		}
 
 		// Issue leaving trigger status → terminate claw
-		if factory.TerminateOnLeave && previousStatus == factory.TriggerStatus && currentStatus != factory.TriggerStatus {
+		if factory.TerminateOnLeave && strings.EqualFold(previousStatus, factory.TriggerStatus) && !strings.EqualFold(currentStatus, factory.TriggerStatus) {
 			log.Printf("[factory:%s] issue %s left '%s' — terminating claw", factory.Name, issueID, factory.TriggerStatus)
 			s.terminateClawForIssue(issueID)
 		}

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -212,7 +212,6 @@ func (s *Server) createClawForIssue(factory *types.FactoryConfig, payload linear
 			Files:        templateFiles,
 			Env:          env,
 		}
-		_ = req // provisioning called below
 		switch provider {
 		case "replicated":
 			if err := s.provisionReplicated(ctx, clawID, req, provCfg, env); err != nil {
@@ -299,3 +298,119 @@ func filesMapToBytes(files map[string]string) map[string][]byte {
 
 // Avoid collision with existing now() function
 
+
+// handleClawDoneSignal is called when a claw sends a message containing [DONE].
+// Finds the matching factory config and moves the Linear issue to done_status.
+func (s *Server) handleClawDoneSignal(clawID string) {
+	// Get the linear_issue_id for this claw
+	var issueID string
+	if err := s.db.QueryRow(`SELECT linear_issue_id FROM claws WHERE id = ?`, clawID).Scan(&issueID); err != nil || issueID == "" {
+		return // not a factory claw
+	}
+
+	log.Printf("[factory] claw %s sent [DONE] for issue %s", clawID[:8], issueID)
+
+	// Find the factory config for this issue
+	factory := s.findFactoryForIssue(issueID)
+	if factory == nil {
+		return
+	}
+
+	// Move Linear issue to done_status if configured
+	if factory.DoneStatus != "" {
+		linearToken := s.resolveLinearTokenForFactory(factory)
+		if linearToken != "" {
+			if err := moveLinearIssue(linearToken, issueID, factory.DoneStatus); err != nil {
+				log.Printf("[factory] failed to move issue %s to '%s': %v", issueID, factory.DoneStatus, err)
+			} else {
+				log.Printf("[factory] moved issue %s to '%s'", issueID, factory.DoneStatus)
+			}
+		}
+	}
+
+	// Mark claw as completed
+	_, _ = s.db.Exec(`UPDATE claws SET status='completed' WHERE id=?`, clawID)
+	s.mu.Lock()
+	if cc, ok := s.claws[clawID]; ok {
+		cc.conn.Close(1000, "factory: claw signaled done")
+		delete(s.claws, clawID)
+	}
+	s.mu.Unlock()
+}
+
+func (s *Server) findFactoryForIssue(issueID string) *types.FactoryConfig {
+	// Extract team key from issue ID (e.g. "ELA" from "ELA-123")
+	parts := strings.SplitN(issueID, "-", 2)
+	if len(parts) != 2 {
+		return nil
+	}
+	teamKey := parts[0]
+
+	for _, factory := range s.hubCfg.Factories {
+		if factory.Integration != "linear" {
+			continue
+		}
+		if factory.Team == "" || strings.EqualFold(factory.Team, teamKey) {
+			return factory
+		}
+	}
+	return nil
+}
+
+// moveLinearIssue updates a Linear issue's state by name using the Linear GraphQL API.
+func moveLinearIssue(token, issueIdentifier, targetStateName string) error {
+	// First find the issue ID from identifier
+	query := fmt.Sprintf(`{"query": "{ issue(id: \"%s\") { id team { states { nodes { id name } } } } }"}`, issueIdentifier)
+	req, _ := http.NewRequest("POST", "https://api.linear.app/graphql", strings.NewReader(query))
+	req.Header.Set("Authorization", token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		Data struct {
+			Issue struct {
+				ID   string `json:"id"`
+				Team struct {
+					States struct {
+						Nodes []struct {
+							ID   string `json:"id"`
+							Name string `json:"name"`
+						} `json:"nodes"`
+					} `json:"states"`
+				} `json:"team"`
+			} `json:"issue"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return err
+	}
+
+	issueID := result.Data.Issue.ID
+	var stateID string
+	for _, s := range result.Data.Issue.Team.States.Nodes {
+		if strings.EqualFold(s.Name, targetStateName) {
+			stateID = s.ID
+			break
+		}
+	}
+	if issueID == "" || stateID == "" {
+		return fmt.Errorf("issue or state not found")
+	}
+
+	// Update the issue state
+	mutation := fmt.Sprintf(`{"query": "mutation { issueUpdate(id: \"%s\", input: { stateId: \"%s\" }) { success } }"}`, issueID, stateID)
+	req2, _ := http.NewRequest("POST", "https://api.linear.app/graphql", strings.NewReader(mutation))
+	req2.Header.Set("Authorization", token)
+	req2.Header.Set("Content-Type", "application/json")
+	resp2, err := http.DefaultClient.Do(req2)
+	if err != nil {
+		return err
+	}
+	resp2.Body.Close()
+	return nil
+}

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -352,9 +352,15 @@ func (s *Server) findFactoryForIssue(issueID string) *types.FactoryConfig {
 
 // moveLinearIssue updates a Linear issue's state by name using the Linear GraphQL API.
 func moveLinearIssue(token, issueIdentifier, targetStateName string) error {
-	// First find the issue ID from identifier
-	query := fmt.Sprintf(`{"query": "{ issue(id: \"%s\") { id team { states { nodes { id name } } } } }"}`, issueIdentifier)
-	req, _ := http.NewRequest("POST", "https://api.linear.app/graphql", strings.NewReader(query))
+	// First find the issue ID from identifier using GraphQL variables
+	queryBody := map[string]interface{}{
+		"query": "query($id: String!) { issue(id: $id) { id team { states { nodes { id name } } } } }",
+		"variables": map[string]string{
+			"id": issueIdentifier,
+		},
+	}
+	queryJSON, _ := json.Marshal(queryBody)
+	req, _ := http.NewRequest("POST", "https://api.linear.app/graphql", strings.NewReader(string(queryJSON)))
 	req.Header.Set("Authorization", token)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -395,9 +401,16 @@ func moveLinearIssue(token, issueIdentifier, targetStateName string) error {
 		return fmt.Errorf("issue or state not found")
 	}
 
-	// Update the issue state
-	mutation := fmt.Sprintf(`{"query": "mutation { issueUpdate(id: \"%s\", input: { stateId: \"%s\" }) { success } }"}`, issueID, stateID)
-	req2, _ := http.NewRequest("POST", "https://api.linear.app/graphql", strings.NewReader(mutation))
+	// Update the issue state using GraphQL variables
+	mutationBody := map[string]interface{}{
+		"query": "mutation($id: String!, $stateId: String!) { issueUpdate(id: $id, input: { stateId: $stateId }) { success } }",
+		"variables": map[string]string{
+			"id":      issueID,
+			"stateId": stateID,
+		},
+	}
+	mutationJSON, _ := json.Marshal(mutationBody)
+	req2, _ := http.NewRequest("POST", "https://api.linear.app/graphql", strings.NewReader(string(mutationJSON)))
 	req2.Header.Set("Authorization", token)
 	req2.Header.Set("Content-Type", "application/json")
 	resp2, err := http.DefaultClient.Do(req2)

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -993,6 +993,10 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 					hm.ID, hm.ClawID, hm.TenantID, hm.Role, hm.Content, hm.CreatedAt,
 				)
 				s.broadcastToUsers(tenantID, types.WSMessage{Type: "message", Payload: hm})
+				// Check for [DONE] signal from a factory-created claw
+				if strings.Contains(hm.Content, "[DONE]") {
+					go s.handleClawDoneSignal(clawID)
+				}
 			} else if msg.Type == "http_proxy_req" {
 				// Proxy an HTTP request from the bridge to the hub's internal API.
 				// This allows tools in the sandbox to reach hub APIs without a public URL.

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -870,8 +870,12 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 		s.mu.Lock()
 		delete(s.claws, clawID)
 		s.mu.Unlock()
-		_, _ = s.db.Exec(`UPDATE claws SET status='offline', last_seen=? WHERE id=?`, now(), clawID)
-		s.broadcastToUsers(tenantID, types.WSMessage{Type: "claw_status", Payload: map[string]string{"claw_id": clawID, "status": "offline"}})
+		var currentStatus string
+		_ = s.db.QueryRow(`SELECT status FROM claws WHERE id=?`, clawID).Scan(&currentStatus)
+		if currentStatus != "completed" && currentStatus != "deleted" {
+			_, _ = s.db.Exec(`UPDATE claws SET status='offline', last_seen=? WHERE id=?`, now(), clawID)
+			s.broadcastToUsers(tenantID, types.WSMessage{Type: "claw_status", Payload: map[string]string{"claw_id": clawID, "status": "offline"}})
+		}
 		log.Printf("[bridge] ✗ disconnected: %s (%s)", rp.Name, clawID[:8])
 	}()
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -124,6 +124,13 @@ func (s *Server) Run(opts ...RunOptions) error {
 	mux.HandleFunc("/api/hub-config", s.withWebAuth(s.handleHubConfig))
 	mux.HandleFunc("/api/settings", s.withWebAuth(s.handleSettings))
 	mux.HandleFunc("/api/settings/status", s.withWebAuth(s.handleSettingsStatus))
+
+	// Template store
+	mux.HandleFunc("/api/templates", s.withWebAuth(s.handleTemplates))
+	mux.HandleFunc("/api/templates/{name}", s.withWebAuth(s.handleTemplateDetail))
+
+	// Integration webhooks (signature-validated, no session auth)
+	mux.HandleFunc("/api/integrations/linear/webhook", s.handleLinearWebhook)
 	mux.HandleFunc("/api/claws", s.withAuth(s.handleClaws))
 	mux.HandleFunc("/api/claws/{id}", s.withAuth(s.handleClawDetail))
 	mux.HandleFunc("/api/terminal/", s.handleTerminal)

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -46,6 +46,7 @@ type FactoryView struct {
 	DoneStatus       string `json:"doneStatus"`
 	TerminateOnLeave bool   `json:"terminateOnLeave"`
 	Template         string `json:"template"`
+	NamePattern      string `json:"namePattern"`
 }
 
 type ProviderView struct {
@@ -98,6 +99,7 @@ type FactoryPatch struct {
 	DoneStatus       string `json:"doneStatus,omitempty"`
 	TerminateOnLeave bool   `json:"terminateOnLeave"`
 	Template         string `json:"template"`
+	NamePattern      string `json:"namePattern,omitempty"`
 }
 
 type ProviderPatch struct {
@@ -216,6 +218,7 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 			DoneStatus:       f.DoneStatus,
 			TerminateOnLeave: f.TerminateOnLeave,
 			Template:         f.Template,
+			NamePattern:      f.NamePattern,
 		})
 	}
 	s.mu.RUnlock()
@@ -333,18 +336,24 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 
 	// Integrations
 	if patch.Integrations != nil && patch.Integrations.Linear != nil {
-		if updatedCfg.Integrations == nil {
-			updatedCfg.Integrations = &types.IntegrationsConfig{}
+		// Deep copy IntegrationsConfig to avoid mutating live config
+		var existingIntegrations *types.IntegrationsConfig
+		if updatedCfg.Integrations != nil {
+			existingIntegrations = updatedCfg.Integrations
 		}
+		updatedCfg.Integrations = &types.IntegrationsConfig{}
+
 		var linears []*types.LinearIntegrationConfig
 		for _, lp := range patch.Integrations.Linear {
 			li := &types.LinearIntegrationConfig{Workspace: lp.Workspace}
 			// Find existing to preserve secrets not being updated
-			for _, existing := range updatedCfg.Integrations.Linear {
-				if existing.Workspace == lp.Workspace {
-					li.Token = existing.Token
-					li.WebhookSecret = existing.WebhookSecret
-					break
+			if existingIntegrations != nil {
+				for _, existing := range existingIntegrations.Linear {
+					if existing.Workspace == lp.Workspace {
+						li.Token = existing.Token
+						li.WebhookSecret = existing.WebhookSecret
+						break
+					}
 				}
 			}
 			if lp.Token != "" {
@@ -367,6 +376,7 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 				Workspace: fp.Workspace, Team: fp.Team,
 				TriggerStatus: fp.TriggerStatus, DoneStatus: fp.DoneStatus,
 				TerminateOnLeave: fp.TerminateOnLeave, Template: fp.Template,
+				NamePattern: fp.NamePattern,
 			})
 		}
 		updatedCfg.Factories = factories

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -19,10 +19,33 @@ type SettingsStatus struct {
 // SettingsView is the redacted view of hub config for the settings page.
 // Secrets are masked — never returned in full.
 type SettingsView struct {
-	LLMKeys       map[string]bool         `json:"llmKeys"`   // provider → keySet
-	Providers     map[string]ProviderView `json:"providers"` // provider name → config (tokens masked)
+	LLMKeys       map[string]bool         `json:"llmKeys"`
+	Providers     map[string]ProviderView `json:"providers"`
 	GitHub        []GitHubAppView         `json:"github"`
-	SSHPublicKeys []string                `json:"sshPublicKeys"` // extra keys added to all sandbox VMs
+	SSHPublicKeys []string                `json:"sshPublicKeys"`
+	Integrations  *IntegrationsView       `json:"integrations"`
+	Factories     []FactoryView           `json:"factories"`
+}
+
+type IntegrationsView struct {
+	Linear []LinearIntegrationView `json:"linear"`
+}
+
+type LinearIntegrationView struct {
+	Workspace        string `json:"workspace"`
+	TokenSet         bool   `json:"tokenSet"`
+	WebhookSecretSet bool   `json:"webhookSecretSet"`
+}
+
+type FactoryView struct {
+	Name             string `json:"name"`
+	Integration      string `json:"integration"`
+	Workspace        string `json:"workspace"`
+	Team             string `json:"team"`
+	TriggerStatus    string `json:"triggerStatus"`
+	DoneStatus       string `json:"doneStatus"`
+	TerminateOnLeave bool   `json:"terminateOnLeave"`
+	Template         string `json:"template"`
 }
 
 type ProviderView struct {
@@ -51,7 +74,30 @@ type SettingsPatch struct {
 	Providers     map[string]ProviderPatch `json:"providers,omitempty"`
 	GitHub        []GitHubAppPatch         `json:"github,omitempty"`
 	UIPassword    string                   `json:"uiPassword,omitempty"`
-	SSHPublicKeys *[]string                `json:"sshPublicKeys,omitempty"` // nil = no change, [] = clear all
+	SSHPublicKeys *[]string                `json:"sshPublicKeys,omitempty"`
+	Integrations  *IntegrationsPatch       `json:"integrations,omitempty"`
+	Factories     []FactoryPatch           `json:"factories,omitempty"`
+}
+
+type IntegrationsPatch struct {
+	Linear []LinearIntegrationPatch `json:"linear,omitempty"`
+}
+
+type LinearIntegrationPatch struct {
+	Workspace     string `json:"workspace"`
+	Token         string `json:"token,omitempty"`
+	WebhookSecret string `json:"webhookSecret,omitempty"`
+}
+
+type FactoryPatch struct {
+	Name             string `json:"name"`
+	Integration      string `json:"integration"`
+	Workspace        string `json:"workspace"`
+	Team             string `json:"team,omitempty"`
+	TriggerStatus    string `json:"triggerStatus"`
+	DoneStatus       string `json:"doneStatus,omitempty"`
+	TerminateOnLeave bool   `json:"terminateOnLeave"`
+	Template         string `json:"template"`
 }
 
 type ProviderPatch struct {
@@ -143,6 +189,33 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 			AppID:  app.AppID,
 			URL:    app.URL,
 			KeySet: app.PrivateKeyPEM != "",
+		})
+	}
+
+	// Integrations
+	view.Integrations = &IntegrationsView{Linear: []LinearIntegrationView{}}
+	if s.hubCfg.Integrations != nil {
+		for _, li := range s.hubCfg.Integrations.Linear {
+			view.Integrations.Linear = append(view.Integrations.Linear, LinearIntegrationView{
+				Workspace:        li.Workspace,
+				TokenSet:         li.Token != "",
+				WebhookSecretSet: li.WebhookSecret != "",
+			})
+		}
+	}
+
+	// Factories
+	view.Factories = []FactoryView{}
+	for _, f := range s.hubCfg.Factories {
+		view.Factories = append(view.Factories, FactoryView{
+			Name:             f.Name,
+			Integration:      f.Integration,
+			Workspace:        f.Workspace,
+			Team:             f.Team,
+			TriggerStatus:    f.TriggerStatus,
+			DoneStatus:       f.DoneStatus,
+			TerminateOnLeave: f.TerminateOnLeave,
+			Template:         f.Template,
 		})
 	}
 	s.mu.RUnlock()
@@ -253,9 +326,50 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 		updatedCfg.UIPassword = patch.UIPassword
 	}
 
-	// SSH public keys (nil = no change, pointer to slice = replace all)
+	// SSH public keys
 	if patch.SSHPublicKeys != nil {
 		updatedCfg.SSHPublicKeys = *patch.SSHPublicKeys
+	}
+
+	// Integrations
+	if patch.Integrations != nil && patch.Integrations.Linear != nil {
+		if updatedCfg.Integrations == nil {
+			updatedCfg.Integrations = &types.IntegrationsConfig{}
+		}
+		var linears []*types.LinearIntegrationConfig
+		for _, lp := range patch.Integrations.Linear {
+			li := &types.LinearIntegrationConfig{Workspace: lp.Workspace}
+			// Find existing to preserve secrets not being updated
+			for _, existing := range updatedCfg.Integrations.Linear {
+				if existing.Workspace == lp.Workspace {
+					li.Token = existing.Token
+					li.WebhookSecret = existing.WebhookSecret
+					break
+				}
+			}
+			if lp.Token != "" {
+				li.Token = lp.Token
+			}
+			if lp.WebhookSecret != "" {
+				li.WebhookSecret = lp.WebhookSecret
+			}
+			linears = append(linears, li)
+		}
+		updatedCfg.Integrations.Linear = linears
+	}
+
+	// Factories (full replace)
+	if patch.Factories != nil {
+		var factories []*types.FactoryConfig
+		for _, fp := range patch.Factories {
+			factories = append(factories, &types.FactoryConfig{
+				Name: fp.Name, Integration: fp.Integration,
+				Workspace: fp.Workspace, Team: fp.Team,
+				TriggerStatus: fp.TriggerStatus, DoneStatus: fp.DoneStatus,
+				TerminateOnLeave: fp.TerminateOnLeave, Template: fp.Template,
+			})
+		}
+		updatedCfg.Factories = factories
 	}
 
 	// Save to disk before applying to in-memory config

--- a/pkg/hub/templates.go
+++ b/pkg/hub/templates.go
@@ -75,7 +75,7 @@ func (s *Server) pushTemplate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Validate name
-	if strings.ContainsAny(body.Name, "/\\..") {
+	if strings.ContainsAny(body.Name, "/\\") || strings.Contains(body.Name, "..") {
 		http.Error(w, "invalid template name", http.StatusBadRequest)
 		return
 	}

--- a/pkg/hub/templates.go
+++ b/pkg/hub/templates.go
@@ -123,14 +123,5 @@ func (s *Server) resolveTemplateFiles(name string) (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	fsFiles, err := config.ReadTemplateFiles(templateDir)
-	if err != nil {
-		return nil, err
-	}
-	// Convert []byte values to string
-	result := make(map[string]string, len(fsFiles))
-	for k, v := range fsFiles {
-		result[k] = string(v)
-	}
-	return result, nil
+	return config.ReadTemplateFiles(templateDir)
 }

--- a/pkg/hub/templates.go
+++ b/pkg/hub/templates.go
@@ -1,0 +1,136 @@
+package hub
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/config"
+)
+
+// handleTemplates handles GET /api/templates and POST /api/templates.
+func (s *Server) handleTemplates(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		s.listTemplates(w, r)
+	case http.MethodPost:
+		s.pushTemplate(w, r)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+// handleTemplateDetail handles DELETE /api/templates/{name}.
+func (s *Server) handleTemplateDetail(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	if name == "" {
+		http.Error(w, "missing template name", http.StatusBadRequest)
+		return
+	}
+	if r.Method != http.MethodDelete {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if _, err := s.db.Exec(`DELETE FROM hub_templates WHERE name = ?`, name); err != nil {
+		http.Error(w, "db error", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) listTemplates(w http.ResponseWriter, r *http.Request) {
+	rows, err := s.db.Query(`SELECT name, updated_at FROM hub_templates ORDER BY name ASC`)
+	if err != nil {
+		http.Error(w, "db error", http.StatusInternalServerError)
+		return
+	}
+	defer rows.Close()
+
+	type entry struct {
+		Name      string `json:"name"`
+		UpdatedAt string `json:"updatedAt"`
+	}
+	var out []entry
+	for rows.Next() {
+		var e entry
+		if err := rows.Scan(&e.Name, &e.UpdatedAt); err != nil {
+			continue
+		}
+		out = append(out, e)
+	}
+	if out == nil {
+		out = []entry{}
+	}
+	jsonOK(w, out)
+}
+
+func (s *Server) pushTemplate(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Name  string            `json:"name"`
+		Files map[string]string `json:"files"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Name == "" {
+		http.Error(w, "invalid request: name and files required", http.StatusBadRequest)
+		return
+	}
+	// Validate name
+	if strings.ContainsAny(body.Name, "/\\..") {
+		http.Error(w, "invalid template name", http.StatusBadRequest)
+		return
+	}
+
+	filesJSON, _ := json.Marshal(body.Files)
+	now := time.Now().UTC()
+
+	_, err := s.db.Exec(`
+		INSERT INTO hub_templates(name, files, created_at, updated_at)
+		VALUES(?, ?, ?, ?)
+		ON CONFLICT(name) DO UPDATE SET files=excluded.files, updated_at=excluded.updated_at`,
+		body.Name, string(filesJSON), now, now,
+	)
+	if err != nil {
+		http.Error(w, "db error: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	jsonOK(w, map[string]string{"name": body.Name})
+}
+
+// loadHubTemplate fetches a template's files from the hub DB.
+// Used by the factory engine when creating claws.
+func (s *Server) loadHubTemplate(name string) (map[string]string, error) {
+	var filesJSON string
+	err := s.db.QueryRow(`SELECT files FROM hub_templates WHERE name = ?`, name).Scan(&filesJSON)
+	if err != nil {
+		return nil, err
+	}
+	var files map[string]string
+	if err := json.Unmarshal([]byte(filesJSON), &files); err != nil {
+		return nil, err
+	}
+	return files, nil
+}
+
+// resolveTemplateFiles tries hub DB first, then local filesystem via config.ResolveTemplate.
+func (s *Server) resolveTemplateFiles(name string) (map[string]string, error) {
+	// Hub DB first (pushed via `elasticclaw template push`)
+	files, err := s.loadHubTemplate(name)
+	if err == nil {
+		return files, nil
+	}
+	// Fall back to filesystem resolution
+	templateDir, err := config.ResolveTemplate(name)
+	if err != nil {
+		return nil, err
+	}
+	fsFiles, err := config.ReadTemplateFiles(templateDir)
+	if err != nil {
+		return nil, err
+	}
+	// Convert []byte values to string
+	result := make(map[string]string, len(fsFiles))
+	for k, v := range fsFiles {
+		result[k] = string(v)
+	}
+	return result, nil
+}

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -114,8 +114,38 @@ type HubConfig struct {
 	GitHubApps []*GitHubAppConfig `yaml:"github,omitempty"`
 
 	// UIPassword is the password for the web UI. If not set, defaults to "admin".
-	// The hub validates this on /api/auth/login and returns a session token.
 	UIPassword string `yaml:"ui_password,omitempty"`
+
+	// Integrations holds external service configs (Linear, future: Shortcut, etc.)
+	Integrations *IntegrationsConfig `yaml:"integrations,omitempty"`
+
+	// Factories defines automation rules that spin up claws based on integration events.
+	Factories []*FactoryConfig `yaml:"factories,omitempty"`
+}
+
+// IntegrationsConfig holds configs for external integrations.
+type IntegrationsConfig struct {
+	Linear []*LinearIntegrationConfig `yaml:"linear,omitempty"`
+}
+
+// LinearIntegrationConfig holds credentials for one Linear workspace.
+type LinearIntegrationConfig struct {
+	Workspace     string `yaml:"workspace"`       // human label
+	Token         string `yaml:"token"`            // Linear API token (lin_api_...)
+	WebhookSecret string `yaml:"webhook_secret,omitempty"` // HMAC secret for validating webhooks
+}
+
+// FactoryConfig defines an automation rule that creates claws based on integration events.
+type FactoryConfig struct {
+	Name              string `yaml:"name"`
+	Integration       string `yaml:"integration"`        // "linear" (future: "shortcut", "github-issues")
+	Workspace         string `yaml:"workspace"`          // matches integrations.<type>[].workspace
+	Team              string `yaml:"team,omitempty"`     // Linear team key (e.g. "ELA")
+	TriggerStatus     string `yaml:"trigger_status"`     // entering this status → create claw
+	DoneStatus        string `yaml:"done_status,omitempty"`  // claw moves issue here when done
+	TerminateOnLeave  bool   `yaml:"terminate_on_leave,omitempty"` // leaving trigger_status → kill claw
+	Template          string `yaml:"template"`           // template name (must be pushed to hub)
+	NamePattern       string `yaml:"name_pattern,omitempty"` // claw name pattern, e.g. "{issue_id}"
 }
 
 type ProviderConfig struct {

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -2,12 +2,12 @@
 
 import { useState, useEffect, useCallback } from "react"
 import { getHubUrl } from "@/lib/hub-url"
-import { Cpu, Key, Github, ChevronLeft, Shield } from "lucide-react"
+import { Cpu, Key, Github, ChevronLeft, Shield, Zap, Factory } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { cn } from "@/lib/utils"
 
-type Section = "runtimes" | "llm" | "github" | "security"
+type Section = "runtimes" | "llm" | "github" | "security" | "integrations" | "factories"
 
 interface SettingsData {
   llmKeys: Record<string, boolean>
@@ -23,6 +23,13 @@ interface SettingsData {
   }>
   github: Array<{ appId: number; url?: string; keySet: boolean }>
   sshPublicKeys: string[]
+  integrations?: {
+    linear?: Array<{ workspace: string; tokenSet: boolean; webhookSecretSet: boolean }>
+  }
+  factories?: Array<{
+    name: string; integration: string; workspace: string; team: string
+    triggerStatus: string; doneStatus: string; terminateOnLeave: boolean; template: string
+  }>
 }
 
 async function fetchSettings(): Promise<SettingsData> {
@@ -84,6 +91,8 @@ export default function SettingsPage() {
     { id: "llm", label: "LLM Keys", icon: Key },
     { id: "github", label: "GitHub Apps", icon: Github },
     { id: "security", label: "Security", icon: Shield },
+    { id: "integrations", label: "Integrations", icon: Zap },
+    { id: "factories", label: "Factories", icon: Factory },
   ]
 
   return (
@@ -132,6 +141,12 @@ export default function SettingsPage() {
           )}
           {settings && section === "security" && (
             <SecuritySection onSave={save} saving={saving} />
+          )}
+          {settings && section === "integrations" && (
+            <IntegrationsSection settings={settings} onSave={save} saving={saving} />
+          )}
+          {settings && section === "factories" && (
+            <FactoriesSection settings={settings} onSave={save} saving={saving} />
           )}
         </main>
       </div>
@@ -424,6 +439,164 @@ function SecuritySection({ onSave, saving }: { onSave: (p: object) => void; savi
         {pwErr && <p className="text-xs text-red-500">{pwErr}</p>}
         <Button size="sm" disabled={saving || !newPw || !confirm} onClick={handlePasswordSave}>
           Change Password
+        </Button>
+      </div>
+    </div>
+  )
+}
+function IntegrationsSection({ settings, onSave, saving }: { settings: SettingsData; onSave: (p: object) => void; saving: boolean }) {
+  const linear = settings.integrations?.linear || []
+  const [workspace, setWorkspace] = useState("")
+  const [token, setToken] = useState("")
+  const [secret, setSecret] = useState("")
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-base font-semibold mb-1">Integrations</h2>
+        <p className="text-sm text-muted-foreground mb-6">Connect external services to enable Factories.</p>
+      </div>
+
+      {/* Linear */}
+      <div>
+        <h3 className="text-sm font-semibold mb-3 flex items-center gap-2">
+          <Zap className="size-4" /> Linear
+        </h3>
+        {linear.length > 0 && (
+          <div className="mb-4 space-y-2">
+            {linear.map((li, i) => (
+              <div key={i} className="border border-border rounded-lg p-3 flex items-center justify-between">
+                <div>
+                  <p className="text-sm font-medium">{li.workspace}</p>
+                  <p className="text-xs text-muted-foreground">
+                    Token: {li.tokenSet ? "✓" : "✗"} · Webhook secret: {li.webhookSecretSet ? "✓" : "✗"}
+                  </p>
+                </div>
+                <Button size="sm" variant="ghost" className="text-destructive hover:text-destructive h-7 px-2" disabled={saving}
+                  onClick={() => onSave({ integrations: { linear: linear.filter((_, j) => j !== i) } })}>
+                  Remove
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+        <div className="border border-border rounded-lg p-4 space-y-3">
+          <p className="text-xs text-muted-foreground">Add a Linear workspace to enable factory automation.</p>
+          <div>
+            <label className="text-xs text-muted-foreground mb-1 block">Workspace label</label>
+            <Input value={workspace} onChange={e => setWorkspace(e.target.value)} className="h-8 text-sm" placeholder="my-company" />
+          </div>
+          <div>
+            <label className="text-xs text-muted-foreground mb-1 block">API Token</label>
+            <Input type="password" value={token} onChange={e => setToken(e.target.value)} className="h-8 text-sm" placeholder="lin_api_..." />
+          </div>
+          <div>
+            <label className="text-xs text-muted-foreground mb-1 block">Webhook Secret <span className="text-muted-foreground/60">(optional)</span></label>
+            <Input type="password" value={secret} onChange={e => setSecret(e.target.value)} className="h-8 text-sm" placeholder="Used to validate incoming webhooks" />
+          </div>
+          <Button size="sm" disabled={saving || !workspace || !token}
+            onClick={() => {
+              onSave({ integrations: { linear: [...linear, { workspace, token, webhookSecret: secret || undefined }] } })
+              setWorkspace(""); setToken(""); setSecret("")
+            }}>
+            Add Linear Workspace
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+interface FactoryFormData {
+  name: string; workspace: string; team: string
+  triggerStatus: string; doneStatus: string; terminateOnLeave: boolean; template: string
+}
+
+function FactoriesSection({ settings, onSave, saving }: { settings: SettingsData; onSave: (p: object) => void; saving: boolean }) {
+  const factories = settings.factories || []
+  const [form, setForm] = useState<FactoryFormData>({
+    name: "", workspace: "", team: "", triggerStatus: "Ready for Agent",
+    doneStatus: "In Review", terminateOnLeave: true, template: "base"
+  })
+
+  const workspaces = settings.integrations?.linear?.map(l => l.workspace) || []
+
+  function update(k: keyof FactoryFormData, v: string | boolean) {
+    setForm(prev => ({ ...prev, [k]: v }))
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-base font-semibold mb-1">Factories</h2>
+        <p className="text-sm text-muted-foreground mb-6">
+          Automation rules that spin up claws when Linear issues enter a status.
+        </p>
+      </div>
+
+      {factories.length > 0 && (
+        <div className="space-y-2 mb-6">
+          {factories.map((f, i) => (
+            <div key={i} className="border border-border rounded-lg p-4">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm font-medium">{f.name}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {f.integration} · {f.team || f.workspace} · "{f.triggerStatus}" → template: {f.template}
+                  </p>
+                </div>
+                <Button size="sm" variant="ghost" className="text-destructive hover:text-destructive h-7 px-2" disabled={saving}
+                  onClick={() => onSave({ factories: factories.filter((_, j) => j !== i) })}>
+                  Remove
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="border border-border rounded-lg p-5 space-y-4">
+        <h3 className="text-sm font-semibold">New Factory</h3>
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="text-xs text-muted-foreground mb-1 block">Factory name</label>
+            <Input value={form.name} onChange={e => update("name", e.target.value)} className="h-8 text-sm" placeholder="ELA feature work" />
+          </div>
+          <div>
+            <label className="text-xs text-muted-foreground mb-1 block">Linear workspace</label>
+            <select value={form.workspace} onChange={e => update("workspace", e.target.value)}
+              className="w-full h-8 rounded-md border border-border bg-background px-2 text-sm">
+              <option value="">Select workspace</option>
+              {workspaces.map(w => <option key={w} value={w}>{w}</option>)}
+            </select>
+          </div>
+          <div>
+            <label className="text-xs text-muted-foreground mb-1 block">Team key</label>
+            <Input value={form.team} onChange={e => update("team", e.target.value)} className="h-8 text-sm" placeholder="ELA" />
+          </div>
+          <div>
+            <label className="text-xs text-muted-foreground mb-1 block">Template (push to hub first)</label>
+            <Input value={form.template} onChange={e => update("template", e.target.value)} className="h-8 text-sm" placeholder="base" />
+          </div>
+          <div>
+            <label className="text-xs text-muted-foreground mb-1 block">Trigger status</label>
+            <Input value={form.triggerStatus} onChange={e => update("triggerStatus", e.target.value)} className="h-8 text-sm" />
+          </div>
+          <div>
+            <label className="text-xs text-muted-foreground mb-1 block">Done status</label>
+            <Input value={form.doneStatus} onChange={e => update("doneStatus", e.target.value)} className="h-8 text-sm" />
+          </div>
+        </div>
+        <label className="flex items-center gap-2 text-sm cursor-pointer">
+          <input type="checkbox" checked={form.terminateOnLeave} onChange={e => update("terminateOnLeave", e.target.checked)} />
+          Terminate claw when issue leaves trigger status
+        </label>
+        <Button size="sm" disabled={saving || !form.name || !form.workspace || !form.template || !form.triggerStatus}
+          onClick={() => {
+            onSave({ factories: [...factories, { ...form, integration: "linear" }] })
+            setForm({ name: "", workspace: "", team: "", triggerStatus: "Ready for Agent", doneStatus: "In Review", terminateOnLeave: true, template: "base" })
+          }}>
+          Add Factory
         </Button>
       </div>
     </div>


### PR DESCRIPTION
Types (pkg/types/template.go):
- IntegrationsConfig: {linear: [{workspace, token, webhook_secret}]}
- FactoryConfig: {name, integration, workspace, team, trigger_status, done_status, terminate_on_leave, template, name_pattern}

Hub (pkg/hub/):
- templates.go: GET/POST /api/templates, DELETE /api/templates/{name}
  - Template store in DB (hub_templates table)
  - resolveTemplateFiles(): hub DB first, then filesystem fallback
- linear.go: POST /api/integrations/linear/webhook
  - HMAC-SHA256 signature validation
  - Issue entering trigger_status → createClawForIssue()
  - Issue leaving trigger_status → terminateClawForIssue()
  - CONTEXT.md injected with issue details at claw creation
  - 1:1 enforcement (no duplicate claws per issue)
  - linear_issue_id column on claws table

CLI (cmd/):
- template push [name-or-path]: push template files to hub
  - Resolves local name, explicit path, or registry template
  - hub.Client.PushTemplate() added