### PR TITLE
fix: bootstrap syntax error — replace PROFEOF heredoc with printf

### DIFF
--- a/pkg/hub/bootstrap.go
+++ b/pkg/hub/bootstrap.go
@@ -82,40 +82,7 @@ if [ ! -f "$HOME/.openclaw/openclaw.json" ]; then
     --anthropic-api-key "$ANTHROPIC_API_KEY" \
     --gateway-bind loopback --gateway-port 18789 \
     --skip-daemon 2>/dev/null || true
-  python3 << 'PYEOF'
-import json, os
-path = os.path.expanduser('~/.openclaw/openclaw.json')
-try:
-    with open(path) as f:
-        config = json.load(f)
-except:
-    config = {}
-model = os.environ.get('OPENCLAW_DEFAULT_MODEL', 'anthropic/claude-sonnet-4-6')
-apiKey = os.environ.get('ANTHROPIC_API_KEY', 'placeholder')
-config.setdefault('agents', {}).setdefault('defaults', {})['model'] = model
-config['models'] = {
-    'providers': {
-        'anthropic': {
-            'apiKey': apiKey,
-            'baseUrl': 'https://api.anthropic.com',
-            'api': 'anthropic-messages',
-            'models': [
-                {'id': 'claude-sonnet-4-6', 'name': 'Claude Sonnet 4.6', 'api': 'anthropic-messages'},
-                {'id': 'claude-opus-4-5', 'name': 'Claude Opus 4.5', 'api': 'anthropic-messages'},
-                {'id': 'claude-sonnet-4-5', 'name': 'Claude Sonnet 4.5', 'api': 'anthropic-messages'}
-            ]
-        }
-    }
-}
-config.setdefault('gateway', {})['bind'] = 'loopback'
-config['gateway']['port'] = 18789
-gw_password = os.environ.get('ELASTICCLAW_GATEWAY_PASSWORD', '')
-if gw_password:
-    config['gateway']['auth'] = {'mode': 'password', 'password': gw_password}
-with open(path, 'w') as f:
-    json.dump(config, f, indent=2)
-print('OpenClaw config patched')
-PYEOF
+  printf 'import json, os\npath = os.path.expanduser('"'"'~/.openclaw/openclaw.json'"'"')\ntry:\n    with open(path) as f:\n        config = json.load(f)\nexcept:\n    config = {}\nmodel = os.environ.get('"'"'OPENCLAW_DEFAULT_MODEL'"'"', '"'"'anthropic/claude-sonnet-4-6'"'"')\napiKey = os.environ.get('"'"'ANTHROPIC_API_KEY'"'"', '"'"'placeholder'"'"')\nconfig.setdefault('"'"'agents'"'"', {}).setdefault('"'"'defaults'"'"', {})['"'"'model'"'"'] = model\nconfig['"'"'models'"'"'] = {\n    '"'"'providers'"'"': {\n        '"'"'anthropic'"'"': {\n            '"'"'apiKey'"'"': apiKey,\n            '"'"'baseUrl'"'"': '"'"'https://api.anthropic.com'"'"',\n            '"'"'api'"'"': '"'"'anthropic-messages'"'"',\n            '"'"'models'"'"': [\n                {'"'"'id'"'"': '"'"'claude-sonnet-4-6'"'"', '"'"'name'"'"': '"'"'Claude Sonnet 4.6'"'"', '"'"'api'"'"': '"'"'anthropic-messages'"'"'},\n                {'"'"'id'"'"': '"'"'claude-opus-4-5'"'"', '"'"'name'"'"': '"'"'Claude Opus 4.5'"'"', '"'"'api'"'"': '"'"'anthropic-messages'"'"'},\n                {'"'"'id'"'"': '"'"'claude-sonnet-4-5'"'"', '"'"'name'"'"': '"'"'Claude Sonnet 4.5'"'"', '"'"'api'"'"': '"'"'anthropic-messages'"'"'}\n            ]\n        }\n    }\n}\nconfig.setdefault('"'"'gateway'"'"', {})['"'"'bind'"'"'] = '"'"'loopback'"'"'\nconfig['"'"'gateway'"'"']['"'"'port'"'"'] = 18789\ngw_password = os.environ.get('"'"'ELASTICCLAW_GATEWAY_PASSWORD'"'"', '"'"''"'"')\nif gw_password:\n    config['"'"'gateway'"'"']['"'"'auth'"'"'] = {'"'"'mode'"'"': '"'"'password'"'"', '"'"'password'"'"': gw_password}\nwith open(path, '"'"'w'"'"') as f:\n    json.dump(config, f, indent=2)\nprint('"'"'OpenClaw config patched'"'"')\n' | python3
 fi
 
 # ── Start OpenClaw gateway ────────────────────────────────────────────────────

--- a/pkg/hub/bootstrap_test.go
+++ b/pkg/hub/bootstrap_test.go
@@ -262,6 +262,80 @@ func TestBootstrapScript_Shellcheck(t *testing.T) {
 	}
 }
 
+// ── Stdin-pipe parse test ──────────────────────────────────────────────
+
+// TestBootstrapScript_StdinExec executes the bootstrap script via stdin to bash with all
+// network/system commands stubbed out. This is the same code path as sshRun() which uses
+// sess.Stdin = strings.NewReader(script) piped to /bin/bash.
+// Catches heredoc-in-stdin parse bugs that shellcheck misses (shellcheck reads from a file,
+// bash -n also misses this since it doesn't actually consume heredoc bodies from stdin).
+func TestBootstrapScript_StdinExec(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not in PATH")
+	}
+
+	cases := []struct {
+		name   string
+		params BootstrapParams
+	}{
+		{"base", baseParams()},
+		{"with_github", func() BootstrapParams {
+			p := baseParams()
+			p.HubCfg = &types.HubConfig{
+				GitHubApps: []*types.GitHubAppConfig{{AppID: 123}},
+				ClawToken:  "tok",
+			}
+			p.GitHubRepos = []types.GitHubRepoAccess{{Repo: "org/repo", Permissions: "write"}}
+			return p
+		}()},
+		{"nix_enabled", func() BootstrapParams { p := baseParams(); p.Nix = true; return p }()},
+		// Regression: GitHub App configured but no repos — was producing empty { } group command
+		{"github_app_no_repos", func() BootstrapParams {
+			p := baseParams()
+			p.HubCfg = &types.HubConfig{
+				GitHubApps: []*types.GitHubAppConfig{{AppID: 123}},
+				ClawToken:  "tok",
+			}
+			p.GitHubRepos = nil // no repos
+			return p
+		}()},
+	}
+
+	// We need to verify heredoc-in-stdin parsing works.
+	// Strategy: prepend function stubs for every command and use a fake PATH
+	// so the script runs to completion without actually doing anything.
+	stubScript := `
+set +e
+# Stub everything
+for cmd in curl apt-get npm sudo systemctl git gh oras python3 gpg tee chmod mv nohup; do
+  eval "${cmd}() { return 0; }"
+done
+curl() { echo stub_curl_output; return 0; }
+openclaw() {
+  if [ "$1" = "--version" ]; then echo "OpenClaw 2026.1.0"; fi
+  return 0
+}
+`
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			script := GenerateReplicatedBootstrapScript(tc.params)
+			// Replace set -euo pipefail with set -uo pipefail so stubs can fail gracefully
+			script = strings.Replace(script, "set -euo pipefail", "set -uo pipefail", 1)
+			full := stubScript + script
+			// Execute via stdin — same as sshRun()
+			cmd := exec.Command("bash")
+			cmd.Stdin = strings.NewReader(full)
+			out, err := cmd.CombinedOutput()
+			// We allow non-zero exit (stubs may fail mid-script)
+			// What we're checking is no *parse* error from the heredoc-in-stdin pattern
+			if err != nil && strings.Contains(string(out), "syntax error") {
+				t.Errorf("bash syntax error (stdin exec) for %s:\n%s", tc.name, string(out))
+			}
+		})
+	}
+}
+
 // ── Container integration test ────────────────────────────────────────────────
 
 func TestBootstrapScript_ContainerRun(t *testing.T) {

--- a/pkg/hub/bootstrap_test.go
+++ b/pkg/hub/bootstrap_test.go
@@ -252,6 +252,7 @@ func TestBootstrapScript_Shellcheck(t *testing.T) {
 			cmd := exec.Command("shellcheck", "-s", "bash",
 				"-e", "SC1091", // don't check sourced files
 				"-e", "SC2086", // we're ok with unquoted vars in some places
+				"-e", "SC2016", // $() in single quotes is intentional (expands on remote host)
 				f.Name(),
 			)
 			out, err := cmd.CombinedOutput()

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1,6 +1,7 @@
 package hub
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"database/sql"
@@ -2195,11 +2196,16 @@ func (s *Server) sshRun(user, host, script string) error {
 	}
 	defer sess.Close()
 
-	out, err := sess.CombinedOutput(script)
-	if err != nil {
-		return fmt.Errorf("ssh script failed: %w\noutput: %s", err, string(out))
+	// Pipe the script to bash via stdin — avoids the server's default shell (/bin/sh,
+	// often dash on Ubuntu) which may not support bash-specific syntax.
+	var buf bytes.Buffer
+	sess.Stdout = &buf
+	sess.Stderr = &buf
+	sess.Stdin = strings.NewReader(script)
+	if err := sess.Run("/bin/bash"); err != nil {
+		return fmt.Errorf("ssh script failed: %w\noutput: %s", err, buf.String())
 	}
-	log.Printf("bootstrap output:\n%s", string(out))
+	log.Printf("bootstrap output:\n%s", buf.String())
 	return nil
 }
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2123,19 +2123,7 @@ func buildGitHubCredentialHelper(cfg *types.HubConfig, hubURL, clawID string, re
 	clawToken := cfg.ClawToken
 	tokenURL := fmt.Sprintf("%s/api/github/token/%s?claw_token=%s", hubURL, clawID, clawToken)
 	return fmt.Sprintf(`# Install GitHub credential helper
-sudo tee /usr/local/bin/elasticclaw-git-credentials > /dev/null << 'CREDEOF'
-#!/bin/bash
-# Git credential helper — fetches a fresh GitHub App installation token from the hub.
-response=$(curl -sf %q)
-if [ $? -ne 0 ] || [ -z "$response" ]; then
-  exit 1
-fi
-token=$(echo "$response" | python3 -c "import sys,json; print(json.load(sys.stdin)['token'])")
-echo "protocol=https"
-echo "host=github.com"
-echo "username=x-access-token"
-echo "password=$token"
-CREDEOF
+printf '#!/bin/bash\n# Git credential helper — fetches a fresh GitHub App installation token from the hub.\nresponse=$(curl -sf %q)\nif [ $? -ne 0 ] || [ -z "$response" ]; then\n  exit 1\nfi\ntoken=$(echo "$response" | python3 -c "import sys,json; print(json.load(sys.stdin)['"'"'token'"'"'])")\necho "protocol=https"\necho "host=github.com"\necho "username=x-access-token"\necho "password=$token"\n' | sudo tee /usr/local/bin/elasticclaw-git-credentials > /dev/null
 sudo chmod +x /usr/local/bin/elasticclaw-git-credentials
 
 # Install git + gh CLI

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2123,7 +2123,7 @@ func buildGitHubCredentialHelper(cfg *types.HubConfig, hubURL, clawID string, re
 	clawToken := cfg.ClawToken
 	tokenURL := fmt.Sprintf("%s/api/github/token/%s?claw_token=%s", hubURL, clawID, clawToken)
 	return fmt.Sprintf(`# Install GitHub credential helper
-printf '#!/bin/bash\n# Git credential helper — fetches a fresh GitHub App installation token from the hub.\nresponse=$(curl -sf %q)\nif [ $? -ne 0 ] || [ -z "$response" ]; then\n  exit 1\nfi\ntoken=$(echo "$response" | python3 -c "import sys,json; print(json.load(sys.stdin)['"'"'token'"'"'])")\necho "protocol=https"\necho "host=github.com"\necho "username=x-access-token"\necho "password=$token"\n' | sudo tee /usr/local/bin/elasticclaw-git-credentials > /dev/null
+printf '%%s' '#!/bin/bash\n# Git credential helper — fetches a fresh GitHub App installation token from the hub.\nresponse=$(curl -sf %q)\nif [ $? -ne 0 ] || [ -z "$response" ]; then\n  exit 1\nfi\ntoken=$(echo "$response" | python3 -c "import sys,json; print(json.load(sys.stdin)['"'"'token'"'"'])")\necho "protocol=https"\necho "host=github.com"\necho "username=x-access-token"\necho "password=$token"\n' | sudo tee /usr/local/bin/elasticclaw-git-credentials > /dev/null
 sudo chmod +x /usr/local/bin/elasticclaw-git-credentials
 
 # Install git + gh CLI

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2170,6 +2170,18 @@ cd "$HOME/.openclaw/workspace" || true
 { %s } || echo "Warning: repo clone failed — agent can retry after bridge connects"`, tokenURL, buildGitHubCloneScript(repos))
 }
 
+// syncedWriter wraps a bytes.Buffer with a mutex to make it safe for concurrent writes.
+type syncedWriter struct {
+	buf *bytes.Buffer
+	mu  *sync.Mutex
+}
+
+func (w *syncedWriter) Write(p []byte) (n int, err error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.Write(p)
+}
+
 // sshRun connects to host via the hub's SSH identity and runs a script.
 func (s *Server) sshRun(user, host, script string) error {
 	pubKeyType := s.identity.PrivateKey.PublicKey().Type()
@@ -2199,13 +2211,21 @@ func (s *Server) sshRun(user, host, script string) error {
 	// Pipe the script to bash via stdin — avoids the server's default shell (/bin/sh,
 	// often dash on Ubuntu) which may not support bash-specific syntax.
 	var buf bytes.Buffer
-	sess.Stdout = &buf
-	sess.Stderr = &buf
+	var mu sync.Mutex
+	syncWriter := &syncedWriter{buf: &buf, mu: &mu}
+	sess.Stdout = syncWriter
+	sess.Stderr = syncWriter
 	sess.Stdin = strings.NewReader(script)
 	if err := sess.Run("/bin/bash"); err != nil {
-		return fmt.Errorf("ssh script failed: %w\noutput: %s", err, buf.String())
+		mu.Lock()
+		output := buf.String()
+		mu.Unlock()
+		return fmt.Errorf("ssh script failed: %w\noutput: %s", err, output)
 	}
-	log.Printf("bootstrap output:\n%s", buf.String())
+	mu.Lock()
+	output := buf.String()
+	mu.Unlock()
+	log.Printf("bootstrap output:\n%s", output)
 	return nil
 }
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -18,10 +18,10 @@ import (
 
 	"github.com/elasticclaw/elasticclaw/internal/webui"
 
-	"github.com/elasticclaw/elasticclaw/pkg/types"
 	daytona "github.com/elasticclaw/elasticclaw/pkg/provider/daytona"
 	replicatedpkg "github.com/elasticclaw/elasticclaw/pkg/provider/replicated"
 	vercelProvider "github.com/elasticclaw/elasticclaw/pkg/provider/vercel"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
 	"github.com/google/uuid"
 	gossh "golang.org/x/crypto/ssh"
 	"nhooyr.io/websocket"
@@ -45,8 +45,8 @@ type clawConn struct {
 	id             string
 	tenantID       string
 	conn           *websocket.Conn
-	contextUsage   int  // 0-100, updated from heartbeats
-	gatewayReady   bool // true once bridge reports gateway session established
+	contextUsage   int             // 0-100, updated from heartbeats
+	gatewayReady   bool            // true once bridge reports gateway session established
 	streamingBuf   strings.Builder // accumulates chunks for current in-flight response
 	streamingMsgID string          // pre-assigned message ID for the current stream
 }
@@ -89,8 +89,8 @@ func NewServer(addr, dbPath, identityDir string, hubCfg *types.HubConfig) (*Serv
 		addr:     addr,
 		hubCfg:   hubCfg,
 		identity: id,
-		claws: make(map[string]*clawConn),
-		users: make(map[string]*userConn),
+		claws:    make(map[string]*clawConn),
+		users:    make(map[string]*userConn),
 	}
 
 	// Start background poller to keep provider VM status fresh
@@ -312,14 +312,14 @@ func (s *Server) serveWebUI(mux *http.ServeMux, staticFS fs.FS) {
 	// Register MIME types that may not be set on the host OS
 	// (important for embedded static files served from Go)
 	for ext, mimeType := range map[string]string{
-		".js":   "application/javascript",
-		".mjs":  "application/javascript",
-		".css":  "text/css",
-		".html": "text/html",
-		".json": "application/json",
-		".svg":  "image/svg+xml",
-		".png":  "image/png",
-		".ico":  "image/x-icon",
+		".js":    "application/javascript",
+		".mjs":   "application/javascript",
+		".css":   "text/css",
+		".html":  "text/html",
+		".json":  "application/json",
+		".svg":   "image/svg+xml",
+		".png":   "image/png",
+		".ico":   "image/x-icon",
 		".woff2": "font/woff2",
 		".woff":  "font/woff",
 	} {
@@ -540,8 +540,8 @@ func (s *Server) handleCreateClaw(w http.ResponseWriter, r *http.Request, tenant
 	clawToken := s.hubCfg.ClawToken
 	s.mu.RUnlock()
 	env := map[string]string{
-		"ELASTICCLAW_HUB_URL":   s.clawHubURL(),
-		"ELASTICCLAW_CLAW_ID":   clawID,
+		"ELASTICCLAW_HUB_URL":    s.clawHubURL(),
+		"ELASTICCLAW_CLAW_ID":    clawID,
 		"ELASTICCLAW_CLAW_TOKEN": clawToken,
 	}
 	for k, v := range req.Env {
@@ -907,17 +907,17 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 								Payload: map[string]string{"claw_id": clawID, "status": "connected"},
 							})
 							log.Printf("[bridge] ✓ ready: %s (%s)", rp.Name, clawID[:8])
-						// Send a silent wake message to trigger an intro response.
-						// Not stored in DB — invisible to user, just wakes the agent.
-						go func(c *clawConn) {
-							wakeMsg := types.HubMessage{
-								ID:      uuid.New().String(),
-								ClawID:  clawID,
-								Role:    "system",
-								Content: "Introduce yourself briefly and let the user know you're ready to help.",
-							}
-							_ = wsjson.Write(context.Background(), c.conn, types.WSMessage{Type: "message", Payload: wakeMsg})
-						}(cc)
+							// Send a silent wake message to trigger an intro response.
+							// Not stored in DB — invisible to user, just wakes the agent.
+							go func(c *clawConn) {
+								wakeMsg := types.HubMessage{
+									ID:      uuid.New().String(),
+									ClawID:  clawID,
+									Role:    "system",
+									Content: "Introduce yourself briefly and let the user know you're ready to help.",
+								}
+								_ = wsjson.Write(context.Background(), c.conn, types.WSMessage{Type: "message", Payload: wakeMsg})
+							}(cc)
 						} else if !hb.GatewayHealthy && prevHealthy {
 							// Gateway went unhealthy
 							log.Printf("[heartbeat] %s (%s): gateway unhealthy", rp.Name, clawID[:8])
@@ -936,7 +936,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				}
 				if err := json.Unmarshal(payload, &chunk); err == nil && chunk.Content != "" {
 					s.broadcastToUsers(tenantID, types.WSMessage{
-						Type: "chunk",
+						Type:    "chunk",
 						Payload: map[string]string{"claw_id": clawID, "content": chunk.Content},
 					})
 					// Buffer chunk and upsert partial message to DB so refreshes don't lose it
@@ -1347,8 +1347,8 @@ PYEOF`, defaultModel, anthropicKey)
 		// Let openclaw self-heal any remaining config schema issues
 		_ = exec("openclaw doctor fix", 20*time.Second,
 			"export HOME=/home/daytona NVM_DIR=/usr/local/share/nvm; "+
-			"export PATH=$NVM_DIR/current/bin:$PATH; "+
-			"openclaw doctor --fix 2>&1 || true")
+				"export PATH=$NVM_DIR/current/bin:$PATH; "+
+				"openclaw doctor --fix 2>&1 || true")
 	}
 
 	// Step 2c: Configure gateway bind/port and start it.
@@ -1486,7 +1486,7 @@ if command -v gh &>/dev/null; then
   GH_TOKEN=$(/usr/local/bin/elasticclaw-git-credentials 2>/dev/null | grep ^password | cut -d= -f2)
   if [ -n "$GH_TOKEN" ]; then
     echo "$GH_TOKEN" | gh auth login --with-token 2>/dev/null && echo 'gh CLI authenticated' || echo 'gh auth failed'
-    printf 'export GH_TOKEN=$(/usr/local/bin/elasticclaw-git-credentials 2>/dev/null | grep ^password | cut -d= -f2)\\n' | sudo tee /etc/profile.d/elasticclaw-github.sh > /dev/null
+    printf 'export GH_TOKEN=$(/usr/local/bin/elasticclaw-git-credentials 2>/dev/null | grep ^password | cut -d= -f2)\n' | sudo tee /etc/profile.d/elasticclaw-github.sh > /dev/null
     sudo chmod +x /etc/profile.d/elasticclaw-github.sh
   fi
 else
@@ -1942,7 +1942,6 @@ Tokens are short-lived and refreshed automatically on each git/gh operation.
 	log.Printf("Bootstrap complete for claw %s (%s)", clawName, clawID[:8])
 }
 
-
 // randomHex returns a random hex string of n bytes (2*n hex chars).
 // mergeTags combines tags from all sources in priority order:
 // 1. auto tag (template:<name>)
@@ -2046,7 +2045,6 @@ echo '. /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh 2>/dev/null ||
 echo "Nix: $(nix --version 2>/dev/null || echo 'installed')"`
 }
 
-
 // buildRelayEnv returns shell lines that export relay env vars for the bridge.
 // When relay is not configured, returns an empty comment.
 func buildRelayEnv(cfg *types.HubConfig, publicKey string) string {
@@ -2096,6 +2094,7 @@ func buildLLMKeyEnv(keys map[string]string) string {
 	}
 	return b.String()
 }
+
 // buildGitHubCloneScript returns shell lines that clone repos into the current directory.
 func buildGitHubCloneScript(repos []types.GitHubRepoAccess) string {
 	if len(repos) == 0 {
@@ -2158,7 +2157,7 @@ fi
 # Configure gh to use the credential helper via GH_TOKEN env (set in a wrapper)
 if command -v gh &>/dev/null; then
   # Write GH_TOKEN to /etc/profile.d so it's available in ALL shells
-  printf 'export GH_TOKEN=$(/usr/local/bin/elasticclaw-git-credentials 2>/dev/null | grep ^password | cut -d= -f2)\\n' | sudo tee /etc/profile.d/elasticclaw-github.sh > /dev/null
+  printf 'export GH_TOKEN=$(/usr/local/bin/elasticclaw-git-credentials 2>/dev/null | grep ^password | cut -d= -f2)\n' | sudo tee /etc/profile.d/elasticclaw-github.sh > /dev/null
   sudo chmod +x /etc/profile.d/elasticclaw-github.sh
   echo "GitHub profile.d configured"
 fi
@@ -2365,8 +2364,8 @@ func (s *Server) handleTerminal(w http.ResponseWriter, r *http.Request) {
 		// Check for resize message
 		var resizeMsg struct {
 			Type string `json:"type"`
-			Cols  uint32 `json:"cols"`
-			Rows  uint32 `json:"rows"`
+			Cols uint32 `json:"cols"`
+			Rows uint32 `json:"rows"`
 		}
 		if len(data) > 0 && data[0] == '{' {
 			if json.Unmarshal(data, &resizeMsg) == nil && resizeMsg.Type == "resize" {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1486,9 +1486,7 @@ if command -v gh &>/dev/null; then
   GH_TOKEN=$(/usr/local/bin/elasticclaw-git-credentials 2>/dev/null | grep ^password | cut -d= -f2)
   if [ -n "$GH_TOKEN" ]; then
     echo "$GH_TOKEN" | gh auth login --with-token 2>/dev/null && echo 'gh CLI authenticated' || echo 'gh auth failed'
-    sudo tee /etc/profile.d/elasticclaw-github.sh > /dev/null << 'PROFEOF'
-export GH_TOKEN=$(/usr/local/bin/elasticclaw-git-credentials 2>/dev/null | grep ^password | cut -d= -f2)
-PROFEOF
+    printf 'export GH_TOKEN=$(/usr/local/bin/elasticclaw-git-credentials 2>/dev/null | grep ^password | cut -d= -f2)\\n' | sudo tee /etc/profile.d/elasticclaw-github.sh > /dev/null
     sudo chmod +x /etc/profile.d/elasticclaw-github.sh
   fi
 else
@@ -2160,9 +2158,7 @@ fi
 # Configure gh to use the credential helper via GH_TOKEN env (set in a wrapper)
 if command -v gh &>/dev/null; then
   # Write GH_TOKEN to /etc/profile.d so it's available in ALL shells
-  sudo tee /etc/profile.d/elasticclaw-github.sh > /dev/null << 'PROFEOF'
-export GH_TOKEN=$(/usr/local/bin/elasticclaw-git-credentials 2>/dev/null | grep ^password | cut -d= -f2)
-PROFEOF
+  printf 'export GH_TOKEN=$(/usr/local/bin/elasticclaw-git-credentials 2>/dev/null | grep ^password | cut -d= -f2)\\n' | sudo tee /etc/profile.d/elasticclaw-github.sh > /dev/null
   sudo chmod +x /etc/profile.d/elasticclaw-github.sh
   echo "GitHub profile.d configured"
 fi


### PR DESCRIPTION
Heredocs in scripts piped to bash via stdin cause parse errors in some environments. The PROFEOF heredoc was causing 'syntax error near unexpected token }' at bootstrap line 203.

Replaced with printf to avoid heredoc entirely.