### PR TITLE
fix: user messages lost on refresh

### DIFF
--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -398,8 +398,9 @@ func (s *Server) handleHubConfig(w http.ResponseWriter, r *http.Request) {
 		hubURL = "http://localhost:8080"
 	}
 	jsonOK(w, map[string]interface{}{
-		"token":  token,
-		"hubUrl": hubURL,
+		"token":   token,
+		"hubUrl":  hubURL,
+		"version": Version,
 	})
 }
 

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useMemo, useEffect, useCallback } from "react"
+import { useState, useMemo, useEffect, useCallback, useRef } from "react"
 import { Sidebar } from "@/components/sidebar"
 import { ConversationView } from "@/components/conversation-view"
 import { SpawnModal } from "@/components/spawn-modal"
@@ -126,12 +126,17 @@ export default function Home() {
     )
   }, [pinnedClaws, activeTagFilters])
 
-  // On mount, if a claw was already selected (restored from localStorage),
-  // eagerly load its messages from the API — handleSelectClaw won't fire on refresh.
+    // Eagerly load messages for all claws once the claw list is first available.
+  // Covers: initial load, refresh, navigating back from /settings.
+  // Board cards are passive — they never trigger loadMessages themselves.
+  const boardLoadedRef = useRef(false)
   useEffect(() => {
-    if (selectedClawId) hub.loadMessages(selectedClawId)
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []) // run once on mount
+    if (boardLoadedRef.current || claws.length === 0) return
+    boardLoadedRef.current = true
+    for (const c of claws) {
+      hub.loadMessages(c.id)
+    }
+  }, [claws]) // re-runs when claws first populate
 
   // Mark messages as read when selecting a claw + lazy load history
   const handleSelectClaw = useCallback(

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -126,6 +126,13 @@ export default function Home() {
     )
   }, [pinnedClaws, activeTagFilters])
 
+  // On mount, if a claw was already selected (restored from localStorage),
+  // eagerly load its messages from the API — handleSelectClaw won't fire on refresh.
+  useEffect(() => {
+    if (selectedClawId) hub.loadMessages(selectedClawId)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []) // run once on mount
+
   // Mark messages as read when selecting a claw + lazy load history
   const handleSelectClaw = useCallback(
     (id: string) => {

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -97,7 +97,7 @@ export default function SettingsPage() {
   ]
 
   return (
-    <div className="min-h-screen bg-background flex flex-col">
+    <div className="h-screen bg-background flex flex-col overflow-hidden">
       {/* Header */}
       <header className="border-b border-border px-6 py-4 flex items-center gap-4">
         <Button variant="ghost" size="icon" onClick={() => window.location.href = "/"}>

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -52,6 +52,7 @@ export default function SettingsPage() {
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState("")
   const [success, setSuccess] = useState("")
+  const [version, setVersion] = useState("")
 
   const load = useCallback(async () => {
     try {
@@ -62,6 +63,15 @@ export default function SettingsPage() {
   }, [])
 
   useEffect(() => { load() }, [load])
+
+  useEffect(() => {
+    const hubUrl = getHubUrl()
+    const token = sessionStorage.getItem("ec_hub_token") || ""
+    fetch(`${hubUrl}/api/hub-config`, { headers: { Authorization: `Bearer ${token}` } })
+      .then((r) => r.json())
+      .then((d) => { if (d.version) setVersion(d.version) })
+      .catch(() => {})
+  }, [])
 
   async function save(patch: object) {
     setSaving(true)
@@ -98,7 +108,8 @@ export default function SettingsPage() {
 
       <div className="flex flex-1">
         {/* Left nav */}
-        <aside className="w-56 border-r border-border p-4 space-y-1">
+        <aside className="w-56 border-r border-border p-4 flex flex-col">
+          <div className="space-y-1 flex-1">
           {navItems.map(({ id, label, icon: Icon }) => (
             <button
               key={id}
@@ -114,6 +125,12 @@ export default function SettingsPage() {
               {label}
             </button>
           ))}
+          </div>
+          {version && (
+            <p className="text-xs text-muted-foreground/50 px-3 pt-4 font-mono">
+              v{version}
+            </p>
+          )}
         </aside>
 
         {/* Content */}

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -69,7 +69,7 @@ export default function SettingsPage() {
     const token = sessionStorage.getItem("ec_hub_token") || ""
     fetch(`${hubUrl}/api/hub-config`, { headers: { Authorization: `Bearer ${token}` } })
       .then((r) => r.json())
-      .then((d) => { if (d.version) setVersion(d.version) })
+      .then((d) => { setVersion(d.version || "unknown") })
       .catch(() => {})
   }, [])
 
@@ -104,6 +104,7 @@ export default function SettingsPage() {
           <ChevronLeft className="size-4" />
         </Button>
         <h1 className="text-lg font-semibold">Settings</h1>
+        {version && <span className="ml-auto text-xs text-muted-foreground font-mono">{version}</span>}
       </header>
 
       <div className="flex flex-1 min-h-0 overflow-hidden">

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -106,9 +106,9 @@ export default function SettingsPage() {
         <h1 className="text-lg font-semibold">Settings</h1>
       </header>
 
-      <div className="flex flex-1">
+      <div className="flex flex-1 min-h-0 overflow-hidden">
         {/* Left nav */}
-        <aside className="w-56 border-r border-border p-4 flex flex-col">
+        <aside className="w-56 border-r border-border p-4 flex flex-col overflow-y-auto">
           <div className="space-y-1 flex-1">
           {navItems.map(({ id, label, icon: Icon }) => (
             <button
@@ -134,7 +134,7 @@ export default function SettingsPage() {
         </aside>
 
         {/* Content */}
-        <main className="flex-1 p-8 max-w-2xl">
+        <main className="flex-1 overflow-y-auto p-8 max-w-2xl">
           {error && <p className="mb-4 text-sm text-red-500">{error}</p>}
           {success && <p className="mb-4 text-sm text-green-500">{success}</p>}
 

--- a/web/components/claw-card.tsx
+++ b/web/components/claw-card.tsx
@@ -217,7 +217,7 @@ export function ClawCard({ claw, isSelected, onClick, onTogglePin, onTagsChange,
             onTagsChange={handleTagsChange}
           />
           {/* Color picker */}
-          <div className="relative flex-shrink-0" data-color-picker>
+          <div className="relative flex-shrink-0 ml-auto" data-color-picker>
             <button
               ref={colorDotRef}
               onClick={() => {

--- a/web/hooks/use-hub.ts
+++ b/web/hooks/use-hub.ts
@@ -42,8 +42,6 @@ export function useHub(selectedClawId: string | null): HubState {
   const [loading, setLoading] = useState(true) // true until first claws fetch completes
   const [hubError, setHubError] = useState<string | null>(null)
 
-  // Track which claws have had messages loaded from API
-  const loadedMessages = useRef<Set<string>>(new Set())
   // Track pinned state from localStorage
   const pinnedRef = useRef<Record<string, boolean>>({})
 
@@ -147,8 +145,6 @@ export function useHub(selectedClawId: string | null): HubState {
   }, [mergeClaws])
 
   const loadMessages = useCallback(async (clawId: string) => {
-    if (loadedMessages.current.has(clawId)) return
-    loadedMessages.current.add(clawId)
     try {
       const apiMsgs = await fetchMessages(clawId)
       const msgs = apiMsgs.map(mapApiMessage)
@@ -358,7 +354,7 @@ export function useHub(selectedClawId: string | null): HubState {
       persistMessages(next)
       return next
     })
-    loadedMessages.current.delete(clawId)
+
   }, [persistMessages])
 
   return {

--- a/web/hooks/use-hub.ts
+++ b/web/hooks/use-hub.ts
@@ -305,7 +305,17 @@ export function useHub(selectedClawId: string | null): HubState {
     pushChunk(clawId, "")
 
     try {
-      await apiSendMessage(clawId, content.trim())
+      const sent = await apiSendMessage(clawId, content.trim())
+      // Replace the optimistic message with the real one from the DB
+      // so it survives cache persistence (opt- IDs are filtered out)
+      const realMsg = mapApiMessage(sent)
+      setMessages((prev) => {
+        const msgs = prev[clawId] || []
+        const replaced = msgs.map((m) => m.id === optimistic.id ? realMsg : m)
+        const next = { ...prev, [clawId]: replaced }
+        persistMessages(next)
+        return next
+      })
       // WS events will handle the response (chunk/message)
     } catch (err) {
       console.error("Failed to send message:", err)

--- a/web/hooks/use-hub.ts
+++ b/web/hooks/use-hub.ts
@@ -36,6 +36,7 @@ export interface HubState {
 export function useHub(selectedClawId: string | null): HubState {
   const [claws, setClaws] = useState<Claw[]>([])
   const [messages, setMessages] = useState<Record<string, Message[]>>({})
+  const messagesRef = useRef<Record<string, Message[]>>({})
   const [connected, setConnected] = useState(false)
   const { displayBuffers: streamingBuffers, pushChunk, finalize: finalizeTypewriter } = useTypewriter()
   const [configured, setConfigured] = useState(false)
@@ -81,6 +82,10 @@ export function useHub(selectedClawId: string | null): HubState {
   useEffect(() => {
     selectedClawIdRef.current = selectedClawId
   }, [selectedClawId])
+
+  useEffect(() => {
+    messagesRef.current = messages
+  }, [messages])
 
   // Load pinned state + message cache from localStorage on mount
   useEffect(() => {
@@ -149,9 +154,11 @@ export function useHub(selectedClawId: string | null): HubState {
       const apiMsgs = await fetchMessages(clawId)
       const msgs = apiMsgs.map(mapApiMessage)
       
-      // Compute new messages and their count outside the state updater
-      let newClawMsgs: Message[] = []
-      
+      // Capture existing IDs before updating so we can diff outside the updater.
+      // React 18 batches state updates — side effects inside updaters are unreliable.
+      const existingIds = new Set((messagesRef.current[clawId] || []).map((m) => m.id))
+      const newClawMsgs = msgs.filter((m) => !existingIds.has(m.id) && m.role !== 'user' && m.role !== 'system')
+
       setMessages((prev) => {
         const existing = prev[clawId] || []
         // Merge API result with cached state:
@@ -166,16 +173,10 @@ export function useHub(selectedClawId: string | null): HubState {
         merged.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime())
         const next = { ...prev, [clawId]: merged }
         persistMessages(next)
-        
-        // Track new non-user/non-system messages for unread count update
-        newClawMsgs = newMsgs.filter((m) => m.role !== 'user' && m.role !== 'system')
-        
         return next
       })
-      
-      // Bump unread count for new non-user/non-system messages when claw is not selected
-      // This is outside the setMessages updater to avoid impure side effects
-      if (newClawMsgs.length > 0) {
+
+      if (newClawMsgs.length > 0 && selectedClawIdRef.current !== clawId) {
         setClaws((prevClaws) =>
           prevClaws.map((c) =>
             c.id === clawId && selectedClawIdRef.current !== clawId

--- a/web/hooks/use-hub.ts
+++ b/web/hooks/use-hub.ts
@@ -148,6 +148,10 @@ export function useHub(selectedClawId: string | null): HubState {
     try {
       const apiMsgs = await fetchMessages(clawId)
       const msgs = apiMsgs.map(mapApiMessage)
+      
+      // Compute new messages and their count outside the state updater
+      let newClawMsgs: Message[] = []
+      
       setMessages((prev) => {
         const existing = prev[clawId] || []
         
@@ -161,23 +165,29 @@ export function useHub(selectedClawId: string | null): HubState {
         // This preserves richer cache data (up to 200 messages) instead of truncating to API limit (100)
         const merged = [...existing, ...newMsgs]
         
+        // Sort merged messages by timestamp to ensure chronological order
+        merged.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime())
+        
         const next = { ...prev, [clawId]: merged }
         persistMessages(next)
         
-        // Bump unread count for new non-user/non-system messages when claw is not selected
-        const newClawMsgs = newMsgs.filter((m) => m.role !== 'user' && m.role !== 'system')
-        if (newClawMsgs.length > 0) {
-          setClaws((prevClaws) =>
-            prevClaws.map((c) =>
-              c.id === clawId && selectedClawIdRef.current !== clawId
-                ? { ...c, unreadCount: c.unreadCount + newClawMsgs.length }
-                : c
-            )
-          )
-        }
+        // Track new non-user/non-system messages for unread count update
+        newClawMsgs = newMsgs.filter((m) => m.role !== 'user' && m.role !== 'system')
         
         return next
       })
+      
+      // Bump unread count for new non-user/non-system messages when claw is not selected
+      // This is outside the setMessages updater to avoid impure side effects
+      if (newClawMsgs.length > 0) {
+        setClaws((prevClaws) =>
+          prevClaws.map((c) =>
+            c.id === clawId && selectedClawIdRef.current !== clawId
+              ? { ...c, unreadCount: c.unreadCount + newClawMsgs.length }
+              : c
+          )
+        )
+      }
     } catch (err) {
       console.warn(`Failed to load messages for ${clawId}:`, err)
     }

--- a/web/hooks/use-hub.ts
+++ b/web/hooks/use-hub.ts
@@ -155,15 +155,19 @@ export function useHub(selectedClawId: string | null): HubState {
       setMessages((prev) => {
         const existing = prev[clawId] || []
         
+        // Filter out optimistic messages before merging to prevent duplicates
+        // Optimistic messages will be replaced by real ones from the API or send()
+        const nonOptimistic = existing.filter((m) => !m.id.startsWith("opt-"))
+        
         // Build a Set of existing message IDs for efficient lookup
-        const existingIds = new Set(existing.map((m) => m.id))
+        const existingIds = new Set(nonOptimistic.map((m) => m.id))
         
         // Find truly new messages (not in existing cache) by comparing IDs
         const newMsgs = msgs.filter((m) => !existingIds.has(m.id))
         
-        // Merge: keep existing messages, append only new ones
+        // Merge: keep non-optimistic messages, append only new ones
         // This preserves richer cache data (up to 200 messages) instead of truncating to API limit (100)
-        const merged = [...existing, ...newMsgs]
+        const merged = [...nonOptimistic, ...newMsgs]
         
         // Sort merged messages by timestamp to ensure chronological order
         merged.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime())

--- a/web/hooks/use-hub.ts
+++ b/web/hooks/use-hub.ts
@@ -150,21 +150,32 @@ export function useHub(selectedClawId: string | null): HubState {
       const msgs = apiMsgs.map(mapApiMessage)
       setMessages((prev) => {
         const existing = prev[clawId] || []
-        const next = { ...prev, [clawId]: msgs }
+        
+        // Build a Set of existing message IDs for efficient lookup
+        const existingIds = new Set(existing.map((m) => m.id))
+        
+        // Find truly new messages (not in existing cache) by comparing IDs
+        const newMsgs = msgs.filter((m) => !existingIds.has(m.id))
+        
+        // Merge: keep existing messages, append only new ones
+        // This preserves richer cache data (up to 200 messages) instead of truncating to API limit (100)
+        const merged = [...existing, ...newMsgs]
+        
+        const next = { ...prev, [clawId]: merged }
         persistMessages(next)
-        // If we got new messages that weren't in state, bump unread for board view
-        if (msgs.length > existing.length) {
-          const newClawMsgs = msgs.slice(existing.length).filter((m) => m.role !== 'user' && m.role !== 'system')
-          if (newClawMsgs.length > 0) {
-            setClaws((prevClaws) =>
-              prevClaws.map((c) =>
-                c.id === clawId && selectedClawIdRef.current !== clawId
-                  ? { ...c, unreadCount: c.unreadCount + newClawMsgs.length }
-                  : c
-              )
+        
+        // Bump unread count for new non-user/non-system messages when claw is not selected
+        const newClawMsgs = newMsgs.filter((m) => m.role !== 'user' && m.role !== 'system')
+        if (newClawMsgs.length > 0) {
+          setClaws((prevClaws) =>
+            prevClaws.map((c) =>
+              c.id === clawId && selectedClawIdRef.current !== clawId
+                ? { ...c, unreadCount: c.unreadCount + newClawMsgs.length }
+                : c
             )
-          }
+          )
         }
+        
         return next
       })
     } catch (err) {

--- a/web/hooks/use-hub.ts
+++ b/web/hooks/use-hub.ts
@@ -153,8 +153,22 @@ export function useHub(selectedClawId: string | null): HubState {
       const apiMsgs = await fetchMessages(clawId)
       const msgs = apiMsgs.map(mapApiMessage)
       setMessages((prev) => {
+        const existing = prev[clawId] || []
         const next = { ...prev, [clawId]: msgs }
         persistMessages(next)
+        // If we got new messages that weren't in state, bump unread for board view
+        if (msgs.length > existing.length) {
+          const newClawMsgs = msgs.slice(existing.length).filter((m) => m.role !== 'user' && m.role !== 'system')
+          if (newClawMsgs.length > 0) {
+            setClaws((prevClaws) =>
+              prevClaws.map((c) =>
+                c.id === clawId && selectedClawIdRef.current !== clawId
+                  ? { ...c, unreadCount: c.unreadCount + newClawMsgs.length }
+                  : c
+              )
+            )
+          }
+        }
         return next
       })
     } catch (err) {

--- a/web/hooks/use-hub.ts
+++ b/web/hooks/use-hub.ts
@@ -154,24 +154,16 @@ export function useHub(selectedClawId: string | null): HubState {
       
       setMessages((prev) => {
         const existing = prev[clawId] || []
-        
-        // Filter out optimistic messages before merging to prevent duplicates
-        // Optimistic messages will be replaced by real ones from the API or send()
-        const nonOptimistic = existing.filter((m) => !m.id.startsWith("opt-"))
-        
-        // Build a Set of existing message IDs for efficient lookup
-        const existingIds = new Set(nonOptimistic.map((m) => m.id))
-        
-        // Find truly new messages (not in existing cache) by comparing IDs
-        const newMsgs = msgs.filter((m) => !existingIds.has(m.id))
-        
-        // Merge: keep non-optimistic messages, append only new ones
-        // This preserves richer cache data (up to 200 messages) instead of truncating to API limit (100)
-        const merged = [...nonOptimistic, ...newMsgs]
-        
-        // Sort merged messages by timestamp to ensure chronological order
+        // Merge API result with cached state:
+        // 1. Keep non-optimistic existing messages not in API result (preserves cache beyond API limit)
+        // 2. Re-append any in-flight opt- messages so send() can still swap them with real UUIDs
+        const existingNonOpt = existing.filter((m) => !m.id.startsWith('opt-'))
+        const apiIds = new Set(msgs.map((m) => m.id))
+        const cachedOnly = existingNonOpt.filter((m) => !apiIds.has(m.id))
+        const inflight = existing.filter((m) => m.id.startsWith('opt-') &&
+          !msgs.some((r) => r.content === m.content && r.role === m.role))
+        const merged = [...msgs, ...cachedOnly, ...inflight]
         merged.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime())
-        
         const next = { ...prev, [clawId]: merged }
         persistMessages(next)
         


### PR DESCRIPTION
## Problem

On page refresh, user messages disappear but assistant messages stay.

## Root Cause

Two bugs combining:

**Bug 1: Optimistic message filtered from cache**
`send()` adds an optimistic user message with `id: 'opt-${Date.now()}'`. `persistMessages()` filters out `opt-` prefixed IDs before saving to localStorage. There's no WS event for user messages, so the optimistic ID is the only representation — it never gets replaced with a real UUID, so it never survives a page reload.

**Fix:** After `apiSendMessage()` returns the real DB message (it already returns `ApiMessage`), replace the optimistic entry in state with the real UUID. It then gets persisted normally.

**Bug 2: loadMessages never called on refresh**
`loadMessages(clawId)` is only triggered by `handleSelectClaw()` (user click). On refresh, `selectedClawId` is restored from localStorage but no click fires, so the API is never consulted and only the stale cache is shown.

**Fix:** Call `loadMessages` once on mount when `selectedClawId` is already set.