### PR TITLE
feat: Factories section in settings

### DIFF
--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -89,6 +89,19 @@ func migrate(db *sql.DB) error {
 		created_at DATETIME NOT NULL,
 		updated_at DATETIME NOT NULL
 	);
+
+	CREATE TABLE IF NOT EXISTS factory_events (
+		id           TEXT PRIMARY KEY,
+		factory_name TEXT NOT NULL,
+		issue_id     TEXT NOT NULL,
+		issue_title  TEXT NOT NULL DEFAULT '',
+		prev_status  TEXT NOT NULL DEFAULT '',
+		new_status   TEXT NOT NULL DEFAULT '',
+		action       TEXT NOT NULL,  -- 'claw_created', 'claw_terminated', 'not_actionable'
+		claw_id      TEXT NOT NULL DEFAULT '',
+		detail       TEXT NOT NULL DEFAULT '',
+		created_at   DATETIME NOT NULL
+	);
 	`)
 	return err
 }

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -9,7 +9,7 @@ import (
 )
 
 func openDB(path string) (*sql.DB, error) {
-	db, err := sql.Open("sqlite", path+"?_pragma=journal_mode(WAL)&_pragma=foreign_keys(on)")
+	db, err := sql.Open("sqlite", path+"?_time_format=sqlite&_pragma=journal_mode(WAL)&_pragma=foreign_keys(on)")
 	if err != nil {
 		return nil, fmt.Errorf("open db: %w", err)
 	}

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -66,7 +66,8 @@ func migrate(db *sql.DB) error {
 		linear_workspace TEXT NOT NULL DEFAULT '',
 		nix              INTEGER NOT NULL DEFAULT 0,
 		tags             TEXT NOT NULL DEFAULT '[]',
-		color            TEXT NOT NULL DEFAULT ''
+		color            TEXT NOT NULL DEFAULT '',
+		linear_issue_id  TEXT NOT NULL DEFAULT ''
 	);
 
 

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -137,12 +137,21 @@ func (s *Server) processLinearEvent(payload linearWebhookPayload) {
 			}
 		}
 
-		// Issue leaving trigger status → terminate claw
-		if factory.TerminateOnLeave && strings.EqualFold(previousStatus, factory.TriggerStatus) && !strings.EqualFold(currentStatus, factory.TriggerStatus) {
-			matched = true
-			log.Printf("[factory:%s] issue %s left '%s' — terminating claw", factory.Name, issueID, factory.TriggerStatus)
-			s.terminateClawForIssue(issueID)
-			s.logFactoryEvent(factory.Name, issueID, payload.Data.Title, previousStatus, currentStatus, "claw_terminated", "", "")
+		// Issue leaving trigger status → terminate claw.
+		// Check DB for active claw rather than relying solely on previousStatus
+		// (Linear sometimes sends empty previousStatus).
+		if factory.TerminateOnLeave && !strings.EqualFold(currentStatus, factory.TriggerStatus) {
+			var activeClaw string
+			_ = s.db.QueryRow(
+				`SELECT id FROM claws WHERE linear_issue_id = ? AND status NOT IN ('error','deleted') LIMIT 1`,
+				issueID,
+			).Scan(&activeClaw)
+			if activeClaw != "" {
+				matched = true
+				log.Printf("[factory:%s] issue %s moved to '%s' (not trigger) — terminating claw", factory.Name, issueID, currentStatus)
+				s.terminateClawForIssue(issueID)
+				s.logFactoryEvent(factory.Name, issueID, payload.Data.Title, previousStatus, currentStatus, "claw_terminated", activeClaw, "terminated: issue left trigger status")
+			}
 		}
 	}
 

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -209,15 +209,27 @@ func (s *Server) createClawForIssue(factory *types.FactoryConfig, payload linear
 		env["LINEAR_API_KEY"] = linearToken
 	}
 
+	// Build tags — always include factory tag; merge with factory-configured tags
+	tags := []string{"factory:" + factory.Name}
+	for _, t := range factory.Tags {
+		if t != "factory:"+factory.Name {
+			tags = append(tags, t)
+		}
+	}
+	tagsJSON, _ := json.Marshal(tags)
+
+	// Color
+	clawColor := factory.Color
+
 	// Insert claw record
 	clawID := uuid.New().String()
 	filesJSON, _ := json.Marshal(templateFiles)
 	now := now()
 
 	_, err = s.db.Exec(`
-		INSERT INTO claws(id, tenant_id, name, template, provider, template_files, linear_issue_id, status, created_at)
-		VALUES(?,?,?,?,?,?,?,'provisioning',?)`,
-		clawID, tenantID, clawName, factory.Template, provider, string(filesJSON), issueID, now,
+		INSERT INTO claws(id, tenant_id, name, template, provider, template_files, linear_issue_id, tags, color, status, created_at)
+		VALUES(?,?,?,?,?,?,?,?,?,'provisioning',?)`,
+		clawID, tenantID, clawName, factory.Template, provider, string(filesJSON), issueID, string(tagsJSON), clawColor, now,
 	)
 	if err != nil {
 		return fmt.Errorf("db insert: %w", err)

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -77,25 +77,43 @@ func (s *Server) handleLinearWebhook(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) validateLinearSignature(body []byte, sig string) bool {
-	if s.hubCfg.Integrations == nil {
-		return true // no integrations configured, accept all
+	hasAnySecret := false
+
+	// Check integration-level secrets
+	if s.hubCfg.Integrations != nil {
+		for _, li := range s.hubCfg.Integrations.Linear {
+			if li.WebhookSecret == "" {
+				continue
+			}
+			hasAnySecret = true
+			mac := hmac.New(sha256.New, []byte(li.WebhookSecret))
+			mac.Write(body)
+			expected := hex.EncodeToString(mac.Sum(nil))
+			if hmac.Equal([]byte(sig), []byte(expected)) {
+				return true
+			}
+		}
 	}
-	for _, li := range s.hubCfg.Integrations.Linear {
-		if li.WebhookSecret == "" {
-			continue
-		}
-		mac := hmac.New(sha256.New, []byte(li.WebhookSecret))
-		mac.Write(body)
-		expected := hex.EncodeToString(mac.Sum(nil))
-		if hmac.Equal([]byte(sig), []byte(expected)) {
-			return true
+
+	// Check factory-level secrets
+	if s.hubCfg.Factories != nil {
+		for _, factory := range s.hubCfg.Factories {
+			if factory.Integration != "linear" || factory.WebhookSecret == "" {
+				continue
+			}
+			hasAnySecret = true
+			mac := hmac.New(sha256.New, []byte(factory.WebhookSecret))
+			mac.Write(body)
+			expected := hex.EncodeToString(mac.Sum(nil))
+			if hmac.Equal([]byte(sig), []byte(expected)) {
+				return true
+			}
 		}
 	}
-	// If secrets are configured but none matched, reject
-	for _, li := range s.hubCfg.Integrations.Linear {
-		if li.WebhookSecret != "" {
-			return false
-		}
+
+	// If any secrets are configured but none matched, reject
+	if hasAnySecret {
+		return false
 	}
 	return true // no secrets configured
 }
@@ -138,13 +156,13 @@ func (s *Server) processLinearEvent(payload linearWebhookPayload) {
 		}
 
 		// Issue leaving trigger status → terminate claw.
-		// Check DB for active claw rather than relying solely on previousStatus
-		// (Linear sometimes sends empty previousStatus).
+		// Check DB for active claw created by this factory by matching factory tag.
 		if factory.TerminateOnLeave && !strings.EqualFold(currentStatus, factory.TriggerStatus) {
 			var activeClaw string
 			_ = s.db.QueryRow(
-				`SELECT id FROM claws WHERE linear_issue_id = ? AND status NOT IN ('error','deleted') LIMIT 1`,
+				`SELECT id FROM claws WHERE linear_issue_id = ? AND status NOT IN ('error','deleted') AND tags LIKE ? LIMIT 1`,
 				issueID,
+				"%factory:"+factory.Name+"%",
 			).Scan(&activeClaw)
 			if activeClaw != "" {
 				matched = true
@@ -158,7 +176,7 @@ func (s *Server) processLinearEvent(payload linearWebhookPayload) {
 	if !matched {
 		// Webhook received but no factory matched — log as not_actionable
 		for _, factory := range s.hubCfg.Factories {
-			if factory.Integration == "linear" {
+			if factory.Integration == "linear" && (factory.Team == "" || strings.EqualFold(factory.Team, teamKey)) {
 				s.logFactoryEvent(factory.Name, issueID, payload.Data.Title, previousStatus, currentStatus, "not_actionable",
 					"", fmt.Sprintf("status '%s'→'%s' did not match trigger '%s'", previousStatus, currentStatus, factory.TriggerStatus))
 			}

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -141,7 +141,7 @@ func (s *Server) processLinearEvent(payload linearWebhookPayload) {
 		}
 
 		// Issue entering trigger status → create claw
-		if strings.EqualFold(currentStatus, factory.TriggerStatus) && !strings.EqualFold(previousStatus, factory.TriggerStatus) {
+		if previousStatus != "" && strings.EqualFold(currentStatus, factory.TriggerStatus) && !strings.EqualFold(previousStatus, factory.TriggerStatus) {
 			matched = true
 			log.Printf("[factory:%s] issue %s entered '%s' — creating claw", factory.Name, issueID, factory.TriggerStatus)
 			clawID := ""

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -265,6 +265,14 @@ func (s *Server) createClawForIssue(factory *types.FactoryConfig, payload linear
 	// Provision asynchronously
 	provCfg, _ := s.hubCfg.Providers[provider]
 	go func() {
+		// Guard: if the claw was deleted before provisioning started (e.g. issue
+		// immediately moved back out of trigger status), abort silently.
+		var currentStatus string
+		_ = s.db.QueryRow(`SELECT status FROM claws WHERE id=?`, clawID).Scan(&currentStatus)
+		if currentStatus == "deleted" {
+			log.Printf("[factory] claw %s already deleted before provisioning, aborting", clawID[:8])
+			return
+		}
 		ctx := context.Background()
 		req := types.CreateClawRequest{
 			Name:         clawName,
@@ -277,7 +285,8 @@ func (s *Server) createClawForIssue(factory *types.FactoryConfig, payload linear
 		case "replicated":
 			if err := s.provisionReplicated(ctx, clawID, req, provCfg, env); err != nil {
 				log.Printf("[factory] provision failed for %s: %v", clawID, err)
-				_, _ = s.db.Exec(`UPDATE claws SET status='error' WHERE id=?`, clawID)
+				// Only mark error if not already deleted
+				_, _ = s.db.Exec(`UPDATE claws SET status='error' WHERE id=? AND status != 'deleted'`, clawID)
 			}
 		}
 	}()

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -159,10 +159,11 @@ func (s *Server) processLinearEvent(payload linearWebhookPayload) {
 		// Check DB for active claw created by this factory by matching factory tag.
 		if factory.TerminateOnLeave && !strings.EqualFold(currentStatus, factory.TriggerStatus) {
 			var activeClaw string
+			escapedName := escapeLikeWildcards(factory.Name)
 			_ = s.db.QueryRow(
-				`SELECT id FROM claws WHERE linear_issue_id = ? AND status NOT IN ('error','deleted') AND tags LIKE ? LIMIT 1`,
+				`SELECT id FROM claws WHERE linear_issue_id = ? AND status NOT IN ('error','deleted') AND tags LIKE ? ESCAPE '\' LIMIT 1`,
 				issueID,
-				"%factory:"+factory.Name+"%",
+				"%factory:"+escapedName+"%",
 			).Scan(&activeClaw)
 			if activeClaw != "" {
 				matched = true
@@ -342,6 +343,13 @@ func (s *Server) resolveLinearTokenForFactory(factory *types.FactoryConfig) stri
 		}
 	}
 	return ""
+}
+
+func escapeLikeWildcards(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `%`, `\%`)
+	s = strings.ReplaceAll(s, `_`, `\_`)
+	return s
 }
 
 func buildLinearContext(payload linearWebhookPayload) string {

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -113,6 +113,7 @@ func (s *Server) processLinearEvent(payload linearWebhookPayload) {
 	teamKey := payload.Data.Team.Key
 	issueID := payload.Data.Identifier // e.g. "ELA-123"
 
+	matched := false
 	for _, factory := range s.hubCfg.Factories {
 		if factory.Integration != "linear" {
 			continue
@@ -123,16 +124,35 @@ func (s *Server) processLinearEvent(payload linearWebhookPayload) {
 
 		// Issue entering trigger status → create claw
 		if strings.EqualFold(currentStatus, factory.TriggerStatus) && !strings.EqualFold(previousStatus, factory.TriggerStatus) {
+			matched = true
 			log.Printf("[factory:%s] issue %s entered '%s' — creating claw", factory.Name, issueID, factory.TriggerStatus)
+			clawID := ""
 			if err := s.createClawForIssue(factory, payload); err != nil {
 				log.Printf("[factory:%s] failed to create claw for %s: %v", factory.Name, issueID, err)
+				s.logFactoryEvent(factory.Name, issueID, payload.Data.Title, previousStatus, currentStatus, "error", "", err.Error())
+			} else {
+				// Look up the newly created claw ID
+				_ = s.db.QueryRow(`SELECT id FROM claws WHERE linear_issue_id=? ORDER BY created_at DESC LIMIT 1`, issueID).Scan(&clawID)
+				s.logFactoryEvent(factory.Name, issueID, payload.Data.Title, previousStatus, currentStatus, "claw_created", clawID, "")
 			}
 		}
 
 		// Issue leaving trigger status → terminate claw
 		if factory.TerminateOnLeave && strings.EqualFold(previousStatus, factory.TriggerStatus) && !strings.EqualFold(currentStatus, factory.TriggerStatus) {
+			matched = true
 			log.Printf("[factory:%s] issue %s left '%s' — terminating claw", factory.Name, issueID, factory.TriggerStatus)
 			s.terminateClawForIssue(issueID)
+			s.logFactoryEvent(factory.Name, issueID, payload.Data.Title, previousStatus, currentStatus, "claw_terminated", "", "")
+		}
+	}
+
+	if !matched {
+		// Webhook received but no factory matched — log as not_actionable
+		for _, factory := range s.hubCfg.Factories {
+			if factory.Integration == "linear" {
+				s.logFactoryEvent(factory.Name, issueID, payload.Data.Title, previousStatus, currentStatus, "not_actionable",
+					"", fmt.Sprintf("status '%s'→'%s' did not match trigger '%s'", previousStatus, currentStatus, factory.TriggerStatus))
+			}
 		}
 	}
 }
@@ -419,4 +439,67 @@ func moveLinearIssue(token, issueIdentifier, targetStateName string) error {
 	}
 	resp2.Body.Close()
 	return nil
+}
+
+// logFactoryEvent records a factory webhook event and prunes entries older than 4 hours.
+func (s *Server) logFactoryEvent(factoryName, issueID, issueTitle, prevStatus, newStatus, action, clawID, detail string) {
+	id := uuid.New().String()
+	_, _ = s.db.Exec(
+		`INSERT INTO factory_events(id,factory_name,issue_id,issue_title,prev_status,new_status,action,claw_id,detail,created_at) VALUES(?,?,?,?,?,?,?,?,?,?)`,
+		id, factoryName, issueID, issueTitle, prevStatus, newStatus, action, clawID, detail, now(),
+	)
+	// Prune events older than 4 hours
+	_, _ = s.db.Exec(`DELETE FROM factory_events WHERE created_at < datetime('now', '-4 hours')`)
+}
+
+// handleFactoryEvents serves GET /api/factories/:name/events
+func (s *Server) handleFactoryEvents(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	// Path: /api/factories/:name/events
+	parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/api/factories/"), "/")
+	if len(parts) < 2 || parts[1] != "events" {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+	factoryName := parts[0]
+
+	rows, err := s.db.Query(
+		`SELECT id, factory_name, issue_id, issue_title, prev_status, new_status, action, claw_id, detail, created_at
+		 FROM factory_events WHERE factory_name = ? ORDER BY created_at DESC LIMIT 200`,
+		factoryName,
+	)
+	if err != nil {
+		http.Error(w, "db error", http.StatusInternalServerError)
+		return
+	}
+	defer rows.Close()
+
+	type FactoryEvent struct {
+		ID          string `json:"id"`
+		FactoryName string `json:"factoryName"`
+		IssueID     string `json:"issueId"`
+		IssueTitle  string `json:"issueTitle"`
+		PrevStatus  string `json:"prevStatus"`
+		NewStatus   string `json:"newStatus"`
+		Action      string `json:"action"`
+		ClawID      string `json:"clawId"`
+		Detail      string `json:"detail"`
+		CreatedAt   string `json:"createdAt"`
+	}
+
+	var events []FactoryEvent
+	for rows.Next() {
+		var e FactoryEvent
+		if err := rows.Scan(&e.ID, &e.FactoryName, &e.IssueID, &e.IssueTitle, &e.PrevStatus, &e.NewStatus, &e.Action, &e.ClawID, &e.Detail, &e.CreatedAt); err != nil {
+			continue
+		}
+		events = append(events, e)
+	}
+	if events == nil {
+		events = []FactoryEvent{}
+	}
+	jsonOK(w, events)
 }

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -274,11 +274,11 @@ func (s *Server) createClawForIssue(factory *types.FactoryConfig, payload linear
 }
 
 func (s *Server) terminateClawForIssue(issueID string) {
-	var clawID string
+	var clawID, tenantID string
 	if err := s.db.QueryRow(
-		`SELECT id FROM claws WHERE linear_issue_id = ? AND status NOT IN ('error','deleted') LIMIT 1`,
+		`SELECT id, tenant_id FROM claws WHERE linear_issue_id = ? AND status NOT IN ('error','deleted') LIMIT 1`,
 		issueID,
-	).Scan(&clawID); err != nil {
+	).Scan(&clawID, &tenantID); err != nil {
 		return
 	}
 	log.Printf("[factory] terminating claw %s for issue %s", clawID[:8], issueID)
@@ -289,6 +289,11 @@ func (s *Server) terminateClawForIssue(issueID string) {
 	}
 	s.mu.Unlock()
 	_, _ = s.db.Exec(`UPDATE claws SET status='deleted' WHERE id=?`, clawID)
+	// Notify dashboards so the card disappears immediately
+	s.broadcastToUsers(tenantID, types.WSMessage{
+		Type:    "claw_status",
+		Payload: map[string]string{"claw_id": clawID, "status": "deleted"},
+	})
 }
 
 func (s *Server) defaultProvider() string {

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -159,11 +159,9 @@ func (s *Server) processLinearEvent(payload linearWebhookPayload) {
 		// Check DB for active claw created by this factory by matching factory tag.
 		if factory.TerminateOnLeave && !strings.EqualFold(currentStatus, factory.TriggerStatus) {
 			var activeClaw string
-			escapedName := escapeLikeWildcards(factory.Name)
 			_ = s.db.QueryRow(
-				`SELECT id FROM claws WHERE linear_issue_id = ? AND status NOT IN ('error','deleted') AND tags LIKE ? ESCAPE '\' LIMIT 1`,
+				`SELECT id FROM claws WHERE linear_issue_id = ? AND status NOT IN ('error','deleted') LIMIT 1`,
 				issueID,
-				"%factory:"+escapedName+"%",
 			).Scan(&activeClaw)
 			if activeClaw != "" {
 				matched = true

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -265,6 +265,11 @@ func (s *Server) createClawForIssue(factory *types.FactoryConfig, payload linear
 	}()
 
 	log.Printf("[factory] created claw %s (%s) for Linear issue %s", clawName, clawID[:8], issueID)
+	// Notify connected dashboards immediately so the card appears without waiting for next poll
+	s.broadcastToUsers(tenantID, types.WSMessage{
+		Type:    "claw_status",
+		Payload: map[string]string{"claw_id": clawID, "status": "provisioning"},
+	})
 	return nil
 }
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -132,6 +132,7 @@ func (s *Server) Run(opts ...RunOptions) error {
 
 	// Integration webhooks (signature-validated, no session auth)
 	mux.HandleFunc("/api/integrations/linear/webhook", s.handleLinearWebhook)
+	mux.HandleFunc("/api/factories/", s.withAuth(s.handleFactoryEvents)) // GET /api/factories/:name/events
 	mux.HandleFunc("/api/claws", s.withAuth(s.handleClaws))
 	mux.HandleFunc("/api/claws/{id}", s.withAuth(s.handleClawDetail))
 	mux.HandleFunc("/api/terminal/", s.handleTerminal)

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1653,10 +1653,18 @@ func (s *Server) provisionReplicated(ctx context.Context, clawID string, req typ
 	if err != nil {
 		return fmt.Errorf("replicated provision: %w", err)
 	}
-	// Store vm_id in the claw record for later operations (destroy, SSH, etc.)
+	// Store vm_id in the claw record — skip if already deleted (factory terminated mid-provision)
 	_, _ = s.db.Exec(
-		`UPDATE claws SET status='starting', provider='replicated', provider_id=? WHERE id=?`, vmID, clawID,
+		`UPDATE claws SET status='starting', provider='replicated', provider_id=? WHERE id=? AND status != 'deleted'`, vmID, clawID,
 	)
+	// If deleted, clean up the VM and bail
+	var currentStatus string
+	_ = s.db.QueryRow(`SELECT status FROM claws WHERE id=?`, clawID).Scan(&currentStatus)
+	if currentStatus == "deleted" {
+		log.Printf("[provision] claw %s deleted mid-provision, destroying VM %s", clawID[:8], vmID)
+		_ = p.DeleteVM(ctx, vmID)
+		return fmt.Errorf("claw deleted mid-provision")
+	}
 
 	instanceType := req.InstanceType
 	if instanceType == "" {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -441,7 +441,7 @@ func (s *Server) handleClaws(w http.ResponseWriter, r *http.Request) {
 	}
 
 	rows, err := s.db.Query(
-		`SELECT id, name, template, status, last_seen, created_at, ssh_host, ssh_port, ssh_user, COALESCE(tags,'[]'), COALESCE(color,'') FROM claws WHERE tenant_id = ? ORDER BY created_at DESC`,
+		`SELECT id, name, template, status, last_seen, created_at, ssh_host, ssh_port, ssh_user, COALESCE(tags,'[]'), COALESCE(color,'') FROM claws WHERE tenant_id = ? AND status != 'deleted' ORDER BY created_at DESC`,
 		tenantID,
 	)
 	if err != nil {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1717,7 +1717,7 @@ func (s *Server) syncReplicatedVMs() {
 		FROM claws
 		WHERE provider = 'replicated'
 		  AND provider_id != ''
-		  AND status NOT IN ('failed', 'error', 'offline')
+		  AND status NOT IN ('failed', 'error', 'offline', 'deleted')
 	`)
 	if err != nil {
 		log.Printf("pollProviderStatus: query error: %v", err)
@@ -1820,6 +1820,18 @@ func (s *Server) bridgeDownloadURL() string {
 // bootstrapReplicated SSHes into a newly-running Replicated VM, pulls the
 // claw-bridge binary from GitHub Releases, and starts it with hub connection env vars.
 func (s *Server) bootstrapReplicated(clawID, clawName, vmID string, cfg types.ProviderConfig) {
+	// Bail immediately if claw was deleted while VM was spinning up
+	var checkStatus string
+	_ = s.db.QueryRow(`SELECT status FROM claws WHERE id=?`, clawID).Scan(&checkStatus)
+	if checkStatus == "deleted" {
+		log.Printf("[bootstrap] claw %s deleted before bootstrap, destroying VM %s", clawID[:8], vmID)
+		p, _ := newReplicatedProvider(cfg)
+		if p != nil {
+			_ = p.DeleteVM(context.Background(), vmID)
+		}
+		return
+	}
+
 	var filesJSON string
 	_ = s.db.QueryRow(`SELECT COALESCE(template_files,'{}') FROM claws WHERE id=?`, clawID).Scan(&filesJSON)
 	var files map[string]string

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -96,6 +96,7 @@ type LinearIntegrationPatch struct {
 
 type FactoryPatch struct {
 	Name             string   `json:"name"`
+	OriginalName     string   `json:"originalName,omitempty"`
 	Integration      string   `json:"integration"`
 	Workspace        string   `json:"workspace"`
 	Team             string   `json:"team,omitempty"`
@@ -390,8 +391,13 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 			webhookSecret := fp.WebhookSecret
 			if webhookSecret == "" {
 				// Find existing factory by name and keep its secret
+				// Use originalName if provided (for renames), otherwise use name
+				matchName := fp.Name
+				if fp.OriginalName != "" {
+					matchName = fp.OriginalName
+				}
 				for _, existing := range s.hubCfg.Factories {
-					if existing.Name == fp.Name {
+					if existing.Name == matchName {
 						webhookSecret = existing.WebhookSecret
 						break
 					}

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -88,9 +88,10 @@ type IntegrationsPatch struct {
 }
 
 type LinearIntegrationPatch struct {
-	Workspace     string `json:"workspace"`
-	Token         string `json:"token,omitempty"`
-	WebhookSecret string `json:"webhookSecret,omitempty"`
+	Workspace         string `json:"workspace"`
+	OriginalWorkspace string `json:"originalWorkspace,omitempty"`
+	Token             string `json:"token,omitempty"`
+	WebhookSecret     string `json:"webhookSecret,omitempty"`
 }
 
 type FactoryPatch struct {
@@ -356,9 +357,14 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 		for _, lp := range patch.Integrations.Linear {
 			li := &types.LinearIntegrationConfig{Workspace: lp.Workspace}
 			// Find existing to preserve secrets not being updated
+			// Use originalWorkspace if provided (for renames), otherwise use workspace
+			matchWorkspace := lp.Workspace
+			if lp.OriginalWorkspace != "" {
+				matchWorkspace = lp.OriginalWorkspace
+			}
 			if existingIntegrations != nil {
 				for _, existing := range existingIntegrations.Linear {
-					if existing.Workspace == lp.Workspace {
+					if existing.Workspace == matchWorkspace {
 						li.Token = existing.Token
 						li.WebhookSecret = existing.WebhookSecret
 						break

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -47,6 +47,7 @@ type FactoryView struct {
 	TerminateOnLeave bool   `json:"terminateOnLeave"`
 	Template         string `json:"template"`
 	NamePattern      string `json:"namePattern"`
+	WebhookSecretSet bool   `json:"webhookSecretSet"`
 }
 
 type ProviderView struct {
@@ -100,6 +101,7 @@ type FactoryPatch struct {
 	TerminateOnLeave bool   `json:"terminateOnLeave"`
 	Template         string `json:"template"`
 	NamePattern      string `json:"namePattern,omitempty"`
+	WebhookSecret    string `json:"webhookSecret,omitempty"`
 }
 
 type ProviderPatch struct {
@@ -219,6 +221,7 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 			TerminateOnLeave: f.TerminateOnLeave,
 			Template:         f.Template,
 			NamePattern:      f.NamePattern,
+			WebhookSecretSet: f.WebhookSecret != "",
 		})
 	}
 	s.mu.RUnlock()
@@ -371,12 +374,23 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 	if patch.Factories != nil {
 		var factories []*types.FactoryConfig
 		for _, fp := range patch.Factories {
+			// Preserve existing webhook secret if not being replaced
+			webhookSecret := fp.WebhookSecret
+			if webhookSecret == "" {
+				// Find existing factory by name and keep its secret
+				for _, existing := range s.hubCfg.Factories {
+					if existing.Name == fp.Name {
+						webhookSecret = existing.WebhookSecret
+						break
+					}
+				}
+			}
 			factories = append(factories, &types.FactoryConfig{
 				Name: fp.Name, Integration: fp.Integration,
 				Workspace: fp.Workspace, Team: fp.Team,
 				TriggerStatus: fp.TriggerStatus, DoneStatus: fp.DoneStatus,
 				TerminateOnLeave: fp.TerminateOnLeave, Template: fp.Template,
-				NamePattern: fp.NamePattern,
+				NamePattern: fp.NamePattern, WebhookSecret: webhookSecret,
 			})
 		}
 		updatedCfg.Factories = factories

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -38,16 +38,18 @@ type LinearIntegrationView struct {
 }
 
 type FactoryView struct {
-	Name             string `json:"name"`
-	Integration      string `json:"integration"`
-	Workspace        string `json:"workspace"`
-	Team             string `json:"team"`
-	TriggerStatus    string `json:"triggerStatus"`
-	DoneStatus       string `json:"doneStatus"`
-	TerminateOnLeave bool   `json:"terminateOnLeave"`
-	Template         string `json:"template"`
-	NamePattern      string `json:"namePattern"`
-	WebhookSecretSet bool   `json:"webhookSecretSet"`
+	Name             string   `json:"name"`
+	Integration      string   `json:"integration"`
+	Workspace        string   `json:"workspace"`
+	Team             string   `json:"team"`
+	TriggerStatus    string   `json:"triggerStatus"`
+	DoneStatus       string   `json:"doneStatus"`
+	TerminateOnLeave bool     `json:"terminateOnLeave"`
+	Template         string   `json:"template"`
+	NamePattern      string   `json:"namePattern"`
+	WebhookSecretSet bool     `json:"webhookSecretSet"`
+	Tags             []string `json:"tags"`
+	Color            string   `json:"color"`
 }
 
 type ProviderView struct {
@@ -92,16 +94,18 @@ type LinearIntegrationPatch struct {
 }
 
 type FactoryPatch struct {
-	Name             string `json:"name"`
-	Integration      string `json:"integration"`
-	Workspace        string `json:"workspace"`
-	Team             string `json:"team,omitempty"`
-	TriggerStatus    string `json:"triggerStatus"`
-	DoneStatus       string `json:"doneStatus,omitempty"`
-	TerminateOnLeave bool   `json:"terminateOnLeave"`
-	Template         string `json:"template"`
-	NamePattern      string `json:"namePattern,omitempty"`
-	WebhookSecret    string `json:"webhookSecret,omitempty"`
+	Name             string   `json:"name"`
+	Integration      string   `json:"integration"`
+	Workspace        string   `json:"workspace"`
+	Team             string   `json:"team,omitempty"`
+	TriggerStatus    string   `json:"triggerStatus"`
+	DoneStatus       string   `json:"doneStatus,omitempty"`
+	TerminateOnLeave bool     `json:"terminateOnLeave"`
+	Template         string   `json:"template"`
+	NamePattern      string   `json:"namePattern,omitempty"`
+	WebhookSecret    string   `json:"webhookSecret,omitempty"`
+	Tags             []string `json:"tags,omitempty"`
+	Color            string   `json:"color,omitempty"`
 }
 
 type ProviderPatch struct {
@@ -222,6 +226,8 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 			Template:         f.Template,
 			NamePattern:      f.NamePattern,
 			WebhookSecretSet: f.WebhookSecret != "",
+			Tags:             f.Tags,
+			Color:            f.Color,
 		})
 	}
 	s.mu.RUnlock()
@@ -391,6 +397,7 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 				TriggerStatus: fp.TriggerStatus, DoneStatus: fp.DoneStatus,
 				TerminateOnLeave: fp.TerminateOnLeave, Template: fp.Template,
 				NamePattern: fp.NamePattern, WebhookSecret: webhookSecret,
+				Tags: fp.Tags, Color: fp.Color,
 			})
 		}
 		updatedCfg.Factories = factories

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -145,8 +145,10 @@ type FactoryConfig struct {
 	DoneStatus        string `yaml:"done_status,omitempty"`  // claw moves issue here when done
 	TerminateOnLeave  bool   `yaml:"terminate_on_leave,omitempty"` // leaving trigger_status → kill claw
 	Template          string `yaml:"template"`           // template name (must be pushed to hub)
-	NamePattern       string `yaml:"name_pattern,omitempty"` // claw name pattern, e.g. "{issue_id}"
-	WebhookSecret     string `yaml:"webhook_secret,omitempty"` // HMAC-SHA256 secret for validating webhooks
+	NamePattern       string   `yaml:"name_pattern,omitempty"` // claw name pattern, e.g. "{issue_id}"
+	WebhookSecret     string   `yaml:"webhook_secret,omitempty"` // HMAC-SHA256 secret for validating webhooks
+	Tags              []string `yaml:"tags,omitempty"`          // tags applied to created claws
+	Color             string   `yaml:"color,omitempty"`         // color applied to created claws
 }
 
 type ProviderConfig struct {

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -146,6 +146,7 @@ type FactoryConfig struct {
 	TerminateOnLeave  bool   `yaml:"terminate_on_leave,omitempty"` // leaving trigger_status → kill claw
 	Template          string `yaml:"template"`           // template name (must be pushed to hub)
 	NamePattern       string `yaml:"name_pattern,omitempty"` // claw name pattern, e.g. "{issue_id}"
+	WebhookSecret     string `yaml:"webhook_secret,omitempty"` // HMAC-SHA256 secret for validating webhooks
 }
 
 type ProviderConfig struct {

--- a/web/app/factories/[name]/page.tsx
+++ b/web/app/factories/[name]/page.tsx
@@ -1,0 +1,150 @@
+"use client"
+
+import { useState, useEffect, useCallback } from "react"
+import { useParams } from "next/navigation"
+import { getHubUrl } from "@/lib/hub-url"
+import { Button } from "@/components/ui/button"
+import { ChevronLeft, RefreshCw, CheckCircle, XCircle, AlertCircle, Zap } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+interface FactoryEvent {
+  id: string
+  factoryName: string
+  issueId: string
+  issueTitle: string
+  prevStatus: string
+  newStatus: string
+  action: string
+  clawId: string
+  detail: string
+  createdAt: string
+}
+
+function ActionBadge({ action }: { action: string }) {
+  if (action === "claw_created") return (
+    <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-green-500/15 text-green-400 font-medium">
+      <CheckCircle className="size-3" /> claw created
+    </span>
+  )
+  if (action === "claw_terminated") return (
+    <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-blue-500/15 text-blue-400 font-medium">
+      <CheckCircle className="size-3" /> claw terminated
+    </span>
+  )
+  if (action === "error") return (
+    <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-red-500/15 text-red-400 font-medium">
+      <XCircle className="size-3" /> error
+    </span>
+  )
+  return (
+    <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-muted text-muted-foreground font-medium">
+      <AlertCircle className="size-3" /> not actionable
+    </span>
+  )
+}
+
+function formatTime(ts: string): string {
+  const d = new Date(ts)
+  return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" }) +
+    " · " + d.toLocaleDateString([], { month: "short", day: "numeric" })
+}
+
+export default function FactoryEventsPage() {
+  const params = useParams<{ name: string }>()
+  const name = decodeURIComponent(params.name)
+  const [events, setEvents] = useState<FactoryEvent[]>([])
+  const [loading, setLoading] = useState(true)
+  const [lastRefresh, setLastRefresh] = useState<Date | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      const hubUrl = getHubUrl()
+      const token = sessionStorage.getItem("ec_hub_token") || ""
+      const res = await fetch(`${hubUrl}/api/factories/${encodeURIComponent(name)}/events`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (res.ok) setEvents(await res.json())
+    } catch {}
+    setLoading(false)
+    setLastRefresh(new Date())
+  }, [name])
+
+  useEffect(() => { load() }, [load])
+
+  // Auto-refresh every 30s
+  useEffect(() => {
+    const t = setInterval(load, 30_000)
+    return () => clearInterval(t)
+  }, [load])
+
+  return (
+    <div className="min-h-screen bg-background">
+      <header className="border-b border-border px-6 py-4 flex items-center gap-4">
+        <Button variant="ghost" size="icon" onClick={() => window.location.href = "/settings"}>
+          <ChevronLeft className="size-4" />
+        </Button>
+        <Zap className="size-4 text-muted-foreground" />
+        <div>
+          <h1 className="text-base font-semibold">{name}</h1>
+          <p className="text-xs text-muted-foreground">Factory activity · last 4 hours</p>
+        </div>
+        <div className="ml-auto flex items-center gap-3">
+          {lastRefresh && (
+            <span className="text-xs text-muted-foreground" suppressHydrationWarning>
+              Updated {lastRefresh.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+            </span>
+          )}
+          <Button variant="outline" size="sm" onClick={load} disabled={loading}>
+            <RefreshCw className={cn("size-3.5 mr-1.5", loading && "animate-spin")} />
+            Refresh
+          </Button>
+        </div>
+      </header>
+
+      <div className="max-w-3xl mx-auto px-6 py-8">
+        {loading && events.length === 0 ? (
+          <p className="text-sm text-muted-foreground text-center py-12 animate-pulse">Loading…</p>
+        ) : events.length === 0 ? (
+          <div className="text-center py-16 space-y-2">
+            <p className="text-sm font-medium text-muted-foreground">No events in the last 4 hours</p>
+            <p className="text-xs text-muted-foreground">Webhooks will appear here as they arrive.</p>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {events.map((e) => (
+              <div key={e.id} className={cn(
+                "border border-border rounded-lg p-4 space-y-2",
+                e.action === "not_actionable" && "opacity-60"
+              )}>
+                <div className="flex items-center justify-between gap-3">
+                  <div className="flex items-center gap-2 min-w-0">
+                    <span className="text-sm font-medium font-mono shrink-0">{e.issueId}</span>
+                    <span className="text-sm text-muted-foreground truncate">{e.issueTitle}</span>
+                  </div>
+                  <ActionBadge action={e.action} />
+                </div>
+                <div className="flex items-center gap-3 text-xs text-muted-foreground">
+                  {e.prevStatus && (
+                    <>
+                      <span className="bg-muted px-1.5 py-0.5 rounded">{e.prevStatus}</span>
+                      <span>→</span>
+                    </>
+                  )}
+                  <span className="bg-muted px-1.5 py-0.5 rounded">{e.newStatus}</span>
+                  <span className="ml-auto" suppressHydrationWarning>{formatTime(e.createdAt)}</span>
+                </div>
+                {e.detail && (
+                  <p className="text-xs text-muted-foreground">{e.detail}</p>
+                )}
+                {e.clawId && (
+                  <p className="text-xs text-muted-foreground font-mono">claw: {e.clawId}</p>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -29,7 +29,7 @@ interface SettingsData {
   factories?: Array<{
     name: string; integration: string; workspace: string; team: string
     triggerStatus: string; doneStatus: string; terminateOnLeave: boolean; template: string
-    webhookSecretSet?: boolean
+    webhookSecretSet?: boolean; tags?: string[]; color?: string
   }>
 }
 
@@ -566,7 +566,7 @@ function IntegrationsSection({ settings, onSave, saving }: { settings: SettingsD
 interface FactoryFormData {
   name: string; workspace: string; team: string
   triggerStatus: string; doneStatus: string; terminateOnLeave: boolean; template: string
-  webhookSecret: string
+  webhookSecret: string; tags: string; color: string
 }
 
 function FactoriesSection({ hubUrl, settings, onSave, saving }: { hubUrl: string; settings: SettingsData; onSave: (p: object) => void; saving: boolean }) {
@@ -578,10 +578,10 @@ function FactoriesSection({ hubUrl, settings, onSave, saving }: { hubUrl: string
     navigator.clipboard.writeText(webhookUrl).then(() => { setCopied(true); setTimeout(() => setCopied(false), 2000) })
   }
   const [editingFactory, setEditingFactory] = useState<number | null>(null)
-  const [editForm, setEditForm] = useState<FactoryFormData>({ name: "", workspace: "", team: "", triggerStatus: "", doneStatus: "", terminateOnLeave: true, template: "", webhookSecret: "" })
+  const [editForm, setEditForm] = useState<FactoryFormData>({ name: "", workspace: "", team: "", triggerStatus: "", doneStatus: "", terminateOnLeave: true, template: "", webhookSecret: "", tags: "", color: "" })
   const [form, setForm] = useState<FactoryFormData>({
     name: "", workspace: "", team: "", triggerStatus: "Ready for Agent",
-    doneStatus: "In Review", terminateOnLeave: true, template: "base", webhookSecret: ""
+    doneStatus: "In Review", terminateOnLeave: true, template: "base", webhookSecret: "", tags: "", color: ""
   })
 
   const workspaces = settings.integrations?.linear?.map(l => l.workspace) || []
@@ -648,11 +648,20 @@ function FactoriesSection({ hubUrl, settings, onSave, saving }: { hubUrl: string
                       <label className="text-xs text-muted-foreground mb-1 block">Webhook Signing Secret</label>
                       <Input type="password" value={editForm.webhookSecret} onChange={e => setEditForm(p => ({...p, webhookSecret: e.target.value}))} className="h-8 text-sm" placeholder="whsec_... (leave blank to keep)" />
                     </div>
+                    <div>
+                      <label className="text-xs text-muted-foreground mb-1 block">Tags <span className="text-muted-foreground/60">(comma-separated)</span></label>
+                      <Input value={editForm.tags} onChange={e => setEditForm(p => ({...p, tags: e.target.value}))} className="h-8 text-sm" placeholder="linear, feature" />
+                    </div>
+                    <div>
+                      <label className="text-xs text-muted-foreground mb-1 block">Color</label>
+                      <Input value={editForm.color} onChange={e => setEditForm(p => ({...p, color: e.target.value}))} className="h-8 text-sm" placeholder="teal, coral, amber…" />
+                    </div>
                   </div>
                   <div className="flex gap-2">
                     <Button size="sm" disabled={saving} onClick={() => {
-                      const { webhookSecret, ...rest } = editForm
-                      const updated = factories.map((x, j) => j === i ? { ...x, ...rest, ...(webhookSecret ? { webhookSecret } : {}) } : x)
+                      const { webhookSecret, tags: tagsStr, color, ...rest } = editForm
+                      const tags = tagsStr.split(",").map(t => t.trim()).filter(Boolean)
+                      const updated = factories.map((x, j) => j === i ? { ...x, ...rest, ...(webhookSecret ? { webhookSecret } : {}), tags, color } : x)
                       onSave({ factories: updated })
                       setEditingFactory(null)
                     }}>Save</Button>
@@ -676,7 +685,7 @@ function FactoriesSection({ hubUrl, settings, onSave, saving }: { hubUrl: string
                     <a href={`/factories/${encodeURIComponent(f.name)}`} className="text-xs text-primary hover:underline whitespace-nowrap">Activity</a>
                     <Button size="sm" variant="outline" onClick={() => {
                       setEditingFactory(i)
-                      setEditForm({ name: f.name, workspace: f.workspace, team: f.team || "", triggerStatus: f.triggerStatus, doneStatus: f.doneStatus || "", terminateOnLeave: f.terminateOnLeave, template: f.template, webhookSecret: "" })
+                      setEditForm({ name: f.name, workspace: f.workspace, team: f.team || "", triggerStatus: f.triggerStatus, doneStatus: f.doneStatus || "", terminateOnLeave: f.terminateOnLeave, template: f.template, webhookSecret: "", tags: (f.tags || []).join(", "), color: f.color || "" })
                     }}>Edit</Button>
                   </div>
                 </div>
@@ -726,11 +735,22 @@ function FactoriesSection({ hubUrl, settings, onSave, saving }: { hubUrl: string
           <label className="text-xs text-muted-foreground mb-1 block">Webhook Signing Secret</label>
           <Input type="password" value={form.webhookSecret} onChange={e => update("webhookSecret", e.target.value)} className="h-8 text-sm" placeholder="whsec_... from Linear webhook settings" />
         </div>
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="text-xs text-muted-foreground mb-1 block">Tags <span className="text-muted-foreground/60">(comma-separated)</span></label>
+            <Input value={form.tags} onChange={e => update("tags", e.target.value)} className="h-8 text-sm" placeholder="linear, feature" />
+          </div>
+          <div>
+            <label className="text-xs text-muted-foreground mb-1 block">Color</label>
+            <Input value={form.color} onChange={e => update("color", e.target.value)} className="h-8 text-sm" placeholder="teal, coral, amber…" />
+          </div>
+        </div>
         <Button size="sm" disabled={saving || !form.name || !form.workspace || !form.template || !form.triggerStatus}
           onClick={() => {
-            const { webhookSecret, ...rest } = form
-            onSave({ factories: [...factories, { ...rest, integration: "linear", ...(webhookSecret ? { webhookSecret } : {}) }] })
-            setForm({ name: "", workspace: "", team: "", triggerStatus: "Ready for Agent", doneStatus: "In Review", terminateOnLeave: true, template: "base", webhookSecret: "" })
+            const { webhookSecret, tags: tagsStr, color, ...rest } = form
+            const tags = tagsStr.split(",").map(t => t.trim()).filter(Boolean)
+            onSave({ factories: [...factories, { ...rest, integration: "linear", ...(webhookSecret ? { webhookSecret } : {}), ...(tags.length ? { tags } : {}), ...(color ? { color } : {}) }] })
+            setForm({ name: "", workspace: "", team: "", triggerStatus: "Ready for Agent", doneStatus: "In Review", terminateOnLeave: true, template: "base", webhookSecret: "", tags: "", color: "" })
           }}>
           Add Factory
         </Button>

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -659,6 +659,10 @@ function FactoriesSection({ hubUrl, settings, onSave, saving }: { hubUrl: string
                       <Input value={editForm.color} onChange={e => setEditForm(p => ({...p, color: e.target.value}))} className="h-8 text-sm" placeholder="teal, coral, amber…" />
                     </div>
                   </div>
+                  <label className="flex items-center gap-2 text-sm cursor-pointer">
+                    <input type="checkbox" checked={editForm.terminateOnLeave} onChange={e => setEditForm(p => ({...p, terminateOnLeave: e.target.checked}))} />
+                    Terminate claw when issue leaves trigger status
+                  </label>
                   <div className="flex gap-2">
                     <Button size="sm" disabled={saving} onClick={() => {
                       const { webhookSecret, tags: tagsStr, color, originalName, ...rest } = editForm

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -465,9 +465,30 @@ function SecuritySection({ onSave, saving }: { onSave: (p: object) => void; savi
 }
 function IntegrationsSection({ settings, onSave, saving }: { settings: SettingsData; onSave: (p: object) => void; saving: boolean }) {
   const linear = settings.integrations?.linear || []
-  const [workspace, setWorkspace] = useState("")
-  const [token, setToken] = useState("")
-  const [secret, setSecret] = useState("")
+  const [editingIdx, setEditingIdx] = useState<number | null>(null)
+  const [editWorkspace, setEditWorkspace] = useState("")
+  const [editToken, setEditToken] = useState("")
+  const [editSecret, setEditSecret] = useState("")
+  const [newWorkspace, setNewWorkspace] = useState("")
+  const [newToken, setNewToken] = useState("")
+  const [newSecret, setNewSecret] = useState("")
+
+  const startEdit = (i: number) => {
+    setEditingIdx(i)
+    setEditWorkspace(linear[i].workspace)
+    setEditToken("")
+    setEditSecret("")
+  }
+
+  const saveEdit = () => {
+    if (editingIdx === null) return
+    const updated = linear.map((li, i) => i === editingIdx
+      ? { workspace: editWorkspace, ...(editToken ? { token: editToken } : {}), ...(editSecret ? { webhookSecret: editSecret } : {}) }
+      : { workspace: li.workspace }
+    )
+    onSave({ integrations: { linear: updated } })
+    setEditingIdx(null)
+  }
 
   return (
     <div className="space-y-6">
@@ -484,39 +505,66 @@ function IntegrationsSection({ settings, onSave, saving }: { settings: SettingsD
         {linear.length > 0 && (
           <div className="mb-4 space-y-2">
             {linear.map((li, i) => (
-              <div key={i} className="border border-border rounded-lg p-3 flex items-center justify-between">
-                <div>
-                  <p className="text-sm font-medium">{li.workspace}</p>
-                  <p className="text-xs text-muted-foreground">
-                    Token: {li.tokenSet ? "✓" : "✗"} · Webhook secret: {li.webhookSecretSet ? "✓" : "✗"}
-                  </p>
-                </div>
-                <Button size="sm" variant="ghost" className="text-destructive hover:text-destructive h-7 px-2" disabled={saving}
-                  onClick={() => onSave({ integrations: { linear: linear.filter((_, j) => j !== i) } })}>
-                  Remove
-                </Button>
+              <div key={i}>
+                {editingIdx === i ? (
+                  <div className="border border-primary/40 rounded-lg p-4 space-y-3 bg-primary/5">
+                    <h4 className="text-sm font-semibold">Edit: {li.workspace}</h4>
+                    <p className="text-xs text-muted-foreground">Leave token/secret blank to keep existing values.</p>
+                    <div>
+                      <label className="text-xs text-muted-foreground mb-1 block">Workspace label</label>
+                      <Input value={editWorkspace} onChange={e => setEditWorkspace(e.target.value)} className="h-8 text-sm" />
+                    </div>
+                    <div>
+                      <label className="text-xs text-muted-foreground mb-1 block">API Token</label>
+                      <Input type="password" value={editToken} onChange={e => setEditToken(e.target.value)} className="h-8 text-sm" placeholder="lin_api_... (leave blank to keep)" />
+                    </div>
+                    <div>
+                      <label className="text-xs text-muted-foreground mb-1 block">Webhook Secret</label>
+                      <Input type="password" value={editSecret} onChange={e => setEditSecret(e.target.value)} className="h-8 text-sm" placeholder="whsec_... (leave blank to keep)" />
+                    </div>
+                    <div className="flex gap-2">
+                      <Button size="sm" disabled={saving || !editWorkspace} onClick={saveEdit}>Save</Button>
+                      <Button size="sm" variant="outline" onClick={() => setEditingIdx(null)}>Cancel</Button>
+                      <Button size="sm" variant="ghost" className="text-destructive hover:text-destructive ml-auto" disabled={saving}
+                        onClick={() => { onSave({ integrations: { linear: linear.filter((_, j) => j !== i) } }); setEditingIdx(null) }}>
+                        Remove
+                      </Button>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="border border-border rounded-lg p-3 flex items-center justify-between">
+                    <div>
+                      <p className="text-sm font-medium">{li.workspace}</p>
+                      <p className="text-xs text-muted-foreground">
+                        Token: {li.tokenSet ? <span className="text-green-500">✓</span> : <span className="text-amber-500">✗</span>}
+                        {" · Webhook secret: "}{li.webhookSecretSet ? <span className="text-green-500">✓</span> : <span className="text-amber-500">✗</span>}
+                      </p>
+                    </div>
+                    <Button size="sm" variant="outline" onClick={() => startEdit(i)}>Edit</Button>
+                  </div>
+                )}
               </div>
             ))}
           </div>
         )}
         <div className="border border-border rounded-lg p-4 space-y-3">
-          <p className="text-xs text-muted-foreground">Add a Linear workspace to enable factory automation.</p>
+          <p className="text-xs text-muted-foreground font-medium">Add a Linear workspace</p>
           <div>
             <label className="text-xs text-muted-foreground mb-1 block">Workspace label</label>
-            <Input value={workspace} onChange={e => setWorkspace(e.target.value)} className="h-8 text-sm" placeholder="my-company" />
+            <Input value={newWorkspace} onChange={e => setNewWorkspace(e.target.value)} className="h-8 text-sm" placeholder="my-company" />
           </div>
           <div>
             <label className="text-xs text-muted-foreground mb-1 block">API Token</label>
-            <Input type="password" value={token} onChange={e => setToken(e.target.value)} className="h-8 text-sm" placeholder="lin_api_..." />
+            <Input type="password" value={newToken} onChange={e => setNewToken(e.target.value)} className="h-8 text-sm" placeholder="lin_api_..." />
           </div>
           <div>
             <label className="text-xs text-muted-foreground mb-1 block">Webhook Secret <span className="text-muted-foreground/60">(optional)</span></label>
-            <Input type="password" value={secret} onChange={e => setSecret(e.target.value)} className="h-8 text-sm" placeholder="Used to validate incoming webhooks" />
+            <Input type="password" value={newSecret} onChange={e => setNewSecret(e.target.value)} className="h-8 text-sm" placeholder="whsec_..." />
           </div>
-          <Button size="sm" disabled={saving || !workspace || !token}
+          <Button size="sm" disabled={saving || !newWorkspace || !newToken}
             onClick={() => {
-              onSave({ integrations: { linear: [...linear, { workspace, token, webhookSecret: secret || undefined }] } })
-              setWorkspace(""); setToken(""); setSecret("")
+              onSave({ integrations: { linear: [...linear, { workspace: newWorkspace, token: newToken, ...(newSecret ? { webhookSecret: newSecret } : {}) }] } })
+              setNewWorkspace(""); setNewToken(""); setNewSecret("")
             }}>
             Add Linear Workspace
           </Button>

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -2,12 +2,29 @@
 
 import { useState, useEffect, useCallback } from "react"
 import { getHubUrl } from "@/lib/hub-url"
-import { Cpu, Key, Github, ChevronLeft, Shield, Zap, Factory } from "lucide-react"
+import { Cpu, Key, Github, ChevronLeft, Shield, Zap, Copy, Check } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { cn } from "@/lib/utils"
 
-type Section = "runtimes" | "llm" | "github" | "security" | "integrations" | "factories"
+type Section = "runtimes" | "llm" | "github" | "security" | "factories"
+
+interface FactoryData {
+  name: string
+  integration: string
+  workspace: string
+  team?: string
+  triggerStatus: string
+  doneStatus?: string
+  terminateOnLeave?: boolean
+  template: string
+  namePattern?: string
+}
+
+interface LinearIntegrationData {
+  workspace: string
+  webhookSecretSet: boolean
+}
 
 interface SettingsData {
   llmKeys: Record<string, boolean>
@@ -23,13 +40,8 @@ interface SettingsData {
   }>
   github: Array<{ appId: number; url?: string; keySet: boolean }>
   sshPublicKeys: string[]
-  integrations?: {
-    linear?: Array<{ workspace: string; tokenSet: boolean; webhookSecretSet: boolean }>
-  }
-  factories?: Array<{
-    name: string; integration: string; workspace: string; team: string
-    triggerStatus: string; doneStatus: string; terminateOnLeave: boolean; template: string
-  }>
+  integrations?: { linear: LinearIntegrationData[] }
+  factories?: FactoryData[]
 }
 
 async function fetchSettings(): Promise<SettingsData> {
@@ -60,6 +72,7 @@ export default function SettingsPage() {
   const [error, setError] = useState("")
   const [success, setSuccess] = useState("")
   const [version, setVersion] = useState("")
+  const [hubPublicUrl, setHubPublicUrl] = useState("")
 
   const load = useCallback(async () => {
     try {
@@ -76,7 +89,7 @@ export default function SettingsPage() {
     const token = sessionStorage.getItem("ec_hub_token") || ""
     fetch(`${hubUrl}/api/hub-config`, { headers: { Authorization: `Bearer ${token}` } })
       .then((r) => r.json())
-      .then((d) => { setVersion(d.version || "unknown") })
+      .then((d) => { setVersion(d.version || "unknown"); setHubPublicUrl(d.hubUrl || "") })
       .catch(() => {})
   }, [])
 
@@ -101,8 +114,7 @@ export default function SettingsPage() {
     { id: "llm", label: "LLM Keys", icon: Key },
     { id: "github", label: "GitHub Apps", icon: Github },
     { id: "security", label: "Security", icon: Shield },
-    { id: "integrations", label: "Integrations", icon: Zap },
-    { id: "factories", label: "Factories", icon: Factory },
+    { id: "factories", label: "Factories", icon: Zap },
   ]
 
   return (
@@ -160,11 +172,8 @@ export default function SettingsPage() {
           {settings && section === "security" && (
             <SecuritySection onSave={save} saving={saving} />
           )}
-          {settings && section === "integrations" && (
-            <IntegrationsSection settings={settings} onSave={save} saving={saving} />
-          )}
           {settings && section === "factories" && (
-            <FactoriesSection settings={settings} onSave={save} saving={saving} />
+            <FactoriesSection hubUrl={hubPublicUrl} settings={settings} onSave={save} saving={saving} />
           )}
         </main>
       </div>
@@ -462,160 +471,221 @@ function SecuritySection({ onSave, saving }: { onSave: (p: object) => void; savi
     </div>
   )
 }
-function IntegrationsSection({ settings, onSave, saving }: { settings: SettingsData; onSave: (p: object) => void; saving: boolean }) {
-  const linear = settings.integrations?.linear || []
-  const [workspace, setWorkspace] = useState("")
-  const [token, setToken] = useState("")
-  const [secret, setSecret] = useState("")
-
-  return (
-    <div className="space-y-6">
-      <div>
-        <h2 className="text-base font-semibold mb-1">Integrations</h2>
-        <p className="text-sm text-muted-foreground mb-6">Connect external services to enable Factories.</p>
-      </div>
-
-      {/* Linear */}
-      <div>
-        <h3 className="text-sm font-semibold mb-3 flex items-center gap-2">
-          <Zap className="size-4" /> Linear
-        </h3>
-        {linear.length > 0 && (
-          <div className="mb-4 space-y-2">
-            {linear.map((li, i) => (
-              <div key={i} className="border border-border rounded-lg p-3 flex items-center justify-between">
-                <div>
-                  <p className="text-sm font-medium">{li.workspace}</p>
-                  <p className="text-xs text-muted-foreground">
-                    Token: {li.tokenSet ? "✓" : "✗"} · Webhook secret: {li.webhookSecretSet ? "✓" : "✗"}
-                  </p>
-                </div>
-                <Button size="sm" variant="ghost" className="text-destructive hover:text-destructive h-7 px-2" disabled={saving}
-                  onClick={() => onSave({ integrations: { linear: linear.filter((_, j) => j !== i) } })}>
-                  Remove
-                </Button>
-              </div>
-            ))}
-          </div>
-        )}
-        <div className="border border-border rounded-lg p-4 space-y-3">
-          <p className="text-xs text-muted-foreground">Add a Linear workspace to enable factory automation.</p>
-          <div>
-            <label className="text-xs text-muted-foreground mb-1 block">Workspace label</label>
-            <Input value={workspace} onChange={e => setWorkspace(e.target.value)} className="h-8 text-sm" placeholder="my-company" />
-          </div>
-          <div>
-            <label className="text-xs text-muted-foreground mb-1 block">API Token</label>
-            <Input type="password" value={token} onChange={e => setToken(e.target.value)} className="h-8 text-sm" placeholder="lin_api_..." />
-          </div>
-          <div>
-            <label className="text-xs text-muted-foreground mb-1 block">Webhook Secret <span className="text-muted-foreground/60">(optional)</span></label>
-            <Input type="password" value={secret} onChange={e => setSecret(e.target.value)} className="h-8 text-sm" placeholder="Used to validate incoming webhooks" />
-          </div>
-          <Button size="sm" disabled={saving || !workspace || !token}
-            onClick={() => {
-              onSave({ integrations: { linear: [...linear, { workspace, token, webhookSecret: secret || undefined }] } })
-              setWorkspace(""); setToken(""); setSecret("")
-            }}>
-            Add Linear Workspace
-          </Button>
-        </div>
-      </div>
-    </div>
-  )
-}
-
-interface FactoryFormData {
-  name: string; workspace: string; team: string
-  triggerStatus: string; doneStatus: string; terminateOnLeave: boolean; template: string
-}
-
-function FactoriesSection({ settings, onSave, saving }: { settings: SettingsData; onSave: (p: object) => void; saving: boolean }) {
+function FactoriesSection({ hubUrl, settings, onSave, saving }: {
+  hubUrl: string
+  settings: SettingsData
+  onSave: (p: object) => void
+  saving: boolean
+}) {
+  const [copied, setCopied] = useState(false)
+  const webhookUrl = hubUrl ? `${hubUrl}/api/integrations/linear/webhook` : ""
   const factories = settings.factories || []
-  const [form, setForm] = useState<FactoryFormData>({
-    name: "", workspace: "", team: "", triggerStatus: "Ready for Agent",
-    doneStatus: "In Review", terminateOnLeave: true, template: "base"
-  })
+  const linearIntegrations = settings.integrations?.linear || []
+  const [editingFactory, setEditingFactory] = useState<FactoryData | null>(null)
+  const [editingLinear, setEditingLinear] = useState<{ workspace: string } | null>(null)
 
-  const workspaces = settings.integrations?.linear?.map(l => l.workspace) || []
+  const handleCopy = () => {
+    if (!webhookUrl) return
+    navigator.clipboard.writeText(webhookUrl).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    })
+  }
 
-  function update(k: keyof FactoryFormData, v: string | boolean) {
-    setForm(prev => ({ ...prev, [k]: v }))
+  const saveFactory = (f: FactoryData) => {
+    const updated = factories.map((x) => x.name === f.name ? f : x)
+    onSave({ factories: updated.map((x) => ({
+      name: x.name, integration: x.integration, workspace: x.workspace,
+      team: x.team || "", triggerStatus: x.triggerStatus,
+      doneStatus: x.doneStatus || "", terminateOnLeave: x.terminateOnLeave ?? false,
+      template: x.template, namePattern: x.namePattern || "",
+    })) })
+    setEditingFactory(null)
+  }
+
+  const saveLinear = (ws: string, token: string, webhookSecret: string) => {
+    const patch = linearIntegrations.map((li) =>
+      li.workspace === ws
+        ? { workspace: ws, ...(token ? { token } : {}), ...(webhookSecret ? { webhookSecret } : {}) }
+        : { workspace: li.workspace }
+    )
+    onSave({ integrations: { linear: patch } })
+    setEditingLinear(null)
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-8">
       <div>
         <h2 className="text-base font-semibold mb-1">Factories</h2>
-        <p className="text-sm text-muted-foreground mb-6">
-          Automation rules that spin up claws when Linear issues enter a status.
+        <p className="text-sm text-muted-foreground mb-1">
+          Automatically spawn and terminate claws based on external events.
         </p>
+        <a href="https://elasticclaw.ai/docs/factories" target="_blank" rel="noopener noreferrer" className="text-xs text-primary hover:underline">Setup guide →</a>
       </div>
 
-      {factories.length > 0 && (
-        <div className="space-y-2 mb-6">
-          {factories.map((f, i) => (
-            <div key={i} className="border border-border rounded-lg p-4">
-              <div className="flex items-center justify-between">
-                <div>
-                  <p className="text-sm font-medium">{f.name}</p>
-                  <p className="text-xs text-muted-foreground">
-                    {f.integration} · {f.team || f.workspace} · "{f.triggerStatus}" → template: {f.template}
-                  </p>
+      {/* Webhook URL */}
+      <div className="border border-border rounded-lg p-5 space-y-3">
+        <h3 className="text-sm font-medium">Linear Webhook URL</h3>
+        <p className="text-xs text-muted-foreground">
+          Paste into <strong>Linear → Settings → API → Webhooks</strong>. Subscribe to <strong>Issue</strong> events.
+        </p>
+        <div className="flex items-center gap-2">
+          <code className="flex-1 text-xs font-mono bg-muted px-3 py-2 rounded-md border border-border truncate">
+            {webhookUrl || "Loading…"}
+          </code>
+          <Button variant="outline" size="sm" className="shrink-0" onClick={handleCopy} disabled={!webhookUrl}>
+            {copied ? <Check className="size-3.5 text-green-500" /> : <Copy className="size-3.5" />}
+            <span className="ml-1.5">{copied ? "Copied" : "Copy"}</span>
+          </Button>
+        </div>
+      </div>
+
+      {/* Linear integrations */}
+      {linearIntegrations.length > 0 && (
+        <div className="border border-border rounded-lg p-5 space-y-2">
+          <h3 className="text-sm font-medium mb-3">Linear Integrations</h3>
+          {linearIntegrations.map((li) => (
+            <div key={li.workspace}>
+              {editingLinear?.workspace === li.workspace ? (
+                <LinearEditPanel
+                  workspace={li.workspace}
+                  onSave={saveLinear}
+                  onCancel={() => setEditingLinear(null)}
+                  saving={saving}
+                />
+              ) : (
+                <div className="flex items-center justify-between py-2 border-b border-border last:border-0">
+                  <div>
+                    <p className="text-sm font-mono">{li.workspace}</p>
+                    <p className="text-xs text-muted-foreground">
+                      Webhook secret: {li.webhookSecretSet
+                        ? <span className="text-green-500">set</span>
+                        : <span className="text-amber-500">not set</span>}
+                    </p>
+                  </div>
+                  <Button variant="outline" size="sm" onClick={() => setEditingLinear({ workspace: li.workspace })}>Edit</Button>
                 </div>
-                <Button size="sm" variant="ghost" className="text-destructive hover:text-destructive h-7 px-2" disabled={saving}
-                  onClick={() => onSave({ factories: factories.filter((_, j) => j !== i) })}>
-                  Remove
-                </Button>
-              </div>
+              )}
             </div>
           ))}
         </div>
       )}
 
-      <div className="border border-border rounded-lg p-5 space-y-4">
-        <h3 className="text-sm font-semibold">New Factory</h3>
-        <div className="grid grid-cols-2 gap-3">
-          <div>
-            <label className="text-xs text-muted-foreground mb-1 block">Factory name</label>
-            <Input value={form.name} onChange={e => update("name", e.target.value)} className="h-8 text-sm" placeholder="ELA feature work" />
-          </div>
-          <div>
-            <label className="text-xs text-muted-foreground mb-1 block">Linear workspace</label>
-            <select value={form.workspace} onChange={e => update("workspace", e.target.value)}
-              className="w-full h-8 rounded-md border border-border bg-background px-2 text-sm">
-              <option value="">Select workspace</option>
-              {workspaces.map(w => <option key={w} value={w}>{w}</option>)}
-            </select>
-          </div>
-          <div>
-            <label className="text-xs text-muted-foreground mb-1 block">Team key</label>
-            <Input value={form.team} onChange={e => update("team", e.target.value)} className="h-8 text-sm" placeholder="ELA" />
-          </div>
-          <div>
-            <label className="text-xs text-muted-foreground mb-1 block">Template (push to hub first)</label>
-            <Input value={form.template} onChange={e => update("template", e.target.value)} className="h-8 text-sm" placeholder="base" />
-          </div>
-          <div>
-            <label className="text-xs text-muted-foreground mb-1 block">Trigger status</label>
-            <Input value={form.triggerStatus} onChange={e => update("triggerStatus", e.target.value)} className="h-8 text-sm" />
-          </div>
-          <div>
-            <label className="text-xs text-muted-foreground mb-1 block">Done status</label>
-            <Input value={form.doneStatus} onChange={e => update("doneStatus", e.target.value)} className="h-8 text-sm" />
-          </div>
+      {/* Factories list */}
+      {factories.length > 0 && (
+        <div className="border border-border rounded-lg p-5 space-y-2">
+          <h3 className="text-sm font-medium mb-3">Configured Factories</h3>
+          {factories.map((f) => (
+            <div key={f.name}>
+              {editingFactory?.name === f.name ? (
+                <FactoryEditPanel factory={editingFactory} onSave={saveFactory} onCancel={() => setEditingFactory(null)} saving={saving} />
+              ) : (
+                <div className="flex items-start justify-between py-2 border-b border-border last:border-0">
+                  <div className="space-y-0.5">
+                    <p className="text-sm font-medium">{f.name}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {f.integration} · {f.workspace}{f.team ? ` / ${f.team}` : ""}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      Trigger: <span className="text-foreground">{f.triggerStatus}</span>
+                      {f.doneStatus && <> → <span className="text-foreground">{f.doneStatus}</span></>}
+                      {" · template: "}<span className="text-foreground font-mono">{f.template}</span>
+                    </p>
+                  </div>
+                  <Button variant="outline" size="sm" onClick={() => setEditingFactory({ ...f })}>Edit</Button>
+                </div>
+              )}
+            </div>
+          ))}
         </div>
-        <label className="flex items-center gap-2 text-sm cursor-pointer">
-          <input type="checkbox" checked={form.terminateOnLeave} onChange={e => update("terminateOnLeave", e.target.checked)} />
-          Terminate claw when issue leaves trigger status
-        </label>
-        <Button size="sm" disabled={saving || !form.name || !form.workspace || !form.template || !form.triggerStatus}
-          onClick={() => {
-            onSave({ factories: [...factories, { ...form, integration: "linear" }] })
-            setForm({ name: "", workspace: "", team: "", triggerStatus: "Ready for Agent", doneStatus: "In Review", terminateOnLeave: true, template: "base" })
-          }}>
-          Add Factory
-        </Button>
+      )}
+
+      {factories.length === 0 && linearIntegrations.length === 0 && (
+        <p className="text-sm text-muted-foreground">
+          No factories configured yet. Add them to{" "}
+          <code className="bg-muted px-1 rounded text-xs">/etc/elasticclaw/hub.yaml</code> and restart the hub.
+        </p>
+      )}
+    </div>
+  )
+}
+
+function FactoryEditPanel({ factory, onSave, onCancel, saving }: {
+  factory: FactoryData
+  onSave: (f: FactoryData) => void
+  onCancel: () => void
+  saving: boolean
+}) {
+  const [f, setF] = useState<FactoryData>({ ...factory })
+  const set = (k: keyof FactoryData, v: string | boolean) => setF((prev) => ({ ...prev, [k]: v }))
+
+  return (
+    <div className="border border-primary/40 rounded-lg p-4 space-y-4 bg-primary/5 my-2">
+      <h4 className="text-sm font-semibold">Edit: {factory.name}</h4>
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <label className="text-xs text-muted-foreground mb-1 block">Name</label>
+          <Input value={f.name} onChange={(e) => set("name", e.target.value)} className="h-8 text-sm" />
+        </div>
+        <div>
+          <label className="text-xs text-muted-foreground mb-1 block">Workspace</label>
+          <Input value={f.workspace} onChange={(e) => set("workspace", e.target.value)} className="h-8 text-sm" />
+        </div>
+        <div>
+          <label className="text-xs text-muted-foreground mb-1 block">Team (optional)</label>
+          <Input value={f.team || ""} onChange={(e) => set("team", e.target.value)} className="h-8 text-sm" placeholder="All teams" />
+        </div>
+        <div>
+          <label className="text-xs text-muted-foreground mb-1 block">Template</label>
+          <Input value={f.template} onChange={(e) => set("template", e.target.value)} className="h-8 text-sm" />
+        </div>
+        <div>
+          <label className="text-xs text-muted-foreground mb-1 block">Trigger status</label>
+          <Input value={f.triggerStatus} onChange={(e) => set("triggerStatus", e.target.value)} className="h-8 text-sm" placeholder="In Progress" />
+        </div>
+        <div>
+          <label className="text-xs text-muted-foreground mb-1 block">Done status</label>
+          <Input value={f.doneStatus || ""} onChange={(e) => set("doneStatus", e.target.value)} className="h-8 text-sm" placeholder="Done" />
+        </div>
+        <div className="col-span-2">
+          <label className="text-xs text-muted-foreground mb-1 block">Name pattern (optional)</label>
+          <Input value={f.namePattern || ""} onChange={(e) => set("namePattern", e.target.value)} className="h-8 text-sm" placeholder="{issue}-{title}" />
+        </div>
+      </div>
+      <div className="flex items-center gap-2">
+        <Button size="sm" disabled={saving} onClick={() => onSave(f)}>Save</Button>
+        <Button size="sm" variant="outline" onClick={onCancel}>Cancel</Button>
+      </div>
+    </div>
+  )
+}
+
+function LinearEditPanel({ workspace, onSave, onCancel, saving }: {
+  workspace: string
+  onSave: (ws: string, token: string, webhookSecret: string) => void
+  onCancel: () => void
+  saving: boolean
+}) {
+  const [token, setToken] = useState("")
+  const [webhookSecret, setWebhookSecret] = useState("")
+
+  return (
+    <div className="border border-primary/40 rounded-lg p-4 space-y-4 bg-primary/5 my-2">
+      <h4 className="text-sm font-semibold">Edit Linear: {workspace}</h4>
+      <p className="text-xs text-muted-foreground">Leave blank to keep existing values.</p>
+      <div className="space-y-3">
+        <div>
+          <label className="text-xs text-muted-foreground mb-1 block">API Token</label>
+          <Input type="password" value={token} onChange={(e) => setToken(e.target.value)} className="h-8 text-sm" placeholder="lin_api_... (leave blank to keep)" />
+        </div>
+        <div>
+          <label className="text-xs text-muted-foreground mb-1 block">Webhook Signing Secret</label>
+          <Input type="password" value={webhookSecret} onChange={(e) => setWebhookSecret(e.target.value)} className="h-8 text-sm" placeholder="whsec_... (leave blank to keep)" />
+        </div>
+      </div>
+      <div className="flex items-center gap-2">
+        <Button size="sm" disabled={saving || (!token && !webhookSecret)} onClick={() => onSave(workspace, token, webhookSecret)}>Save</Button>
+        <Button size="sm" variant="outline" onClick={onCancel}>Cancel</Button>
       </div>
     </div>
   )

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -469,6 +469,7 @@ function IntegrationsSection({ settings, onSave, saving }: { settings: SettingsD
   const [editingIdx, setEditingIdx] = useState<number | null>(null)
   const [editWorkspace, setEditWorkspace] = useState("")
   const [editToken, setEditToken] = useState("")
+  const [originalWorkspace, setOriginalWorkspace] = useState("")
   const [newWorkspace, setNewWorkspace] = useState("")
   const [newToken, setNewToken] = useState("")
 
@@ -476,12 +477,13 @@ function IntegrationsSection({ settings, onSave, saving }: { settings: SettingsD
     setEditingIdx(i)
     setEditWorkspace(linear[i].workspace)
     setEditToken("")
+    setOriginalWorkspace(linear[i].workspace)
   }
 
   const saveEdit = () => {
     if (editingIdx === null) return
     const updated = linear.map((li, i) => i === editingIdx
-      ? { workspace: editWorkspace, ...(editToken ? { token: editToken } : {}) }
+      ? { workspace: editWorkspace, originalWorkspace, ...(editToken ? { token: editToken } : {}) }
       : { workspace: li.workspace }
     )
     onSave({ integrations: { linear: updated } })

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -29,6 +29,7 @@ interface SettingsData {
   factories?: Array<{
     name: string; integration: string; workspace: string; team: string
     triggerStatus: string; doneStatus: string; terminateOnLeave: boolean; template: string
+    webhookSecretSet?: boolean
   }>
 }
 
@@ -468,22 +469,19 @@ function IntegrationsSection({ settings, onSave, saving }: { settings: SettingsD
   const [editingIdx, setEditingIdx] = useState<number | null>(null)
   const [editWorkspace, setEditWorkspace] = useState("")
   const [editToken, setEditToken] = useState("")
-  const [editSecret, setEditSecret] = useState("")
   const [newWorkspace, setNewWorkspace] = useState("")
   const [newToken, setNewToken] = useState("")
-  const [newSecret, setNewSecret] = useState("")
 
   const startEdit = (i: number) => {
     setEditingIdx(i)
     setEditWorkspace(linear[i].workspace)
     setEditToken("")
-    setEditSecret("")
   }
 
   const saveEdit = () => {
     if (editingIdx === null) return
     const updated = linear.map((li, i) => i === editingIdx
-      ? { workspace: editWorkspace, ...(editToken ? { token: editToken } : {}), ...(editSecret ? { webhookSecret: editSecret } : {}) }
+      ? { workspace: editWorkspace, ...(editToken ? { token: editToken } : {}) }
       : { workspace: li.workspace }
     )
     onSave({ integrations: { linear: updated } })
@@ -518,10 +516,6 @@ function IntegrationsSection({ settings, onSave, saving }: { settings: SettingsD
                       <label className="text-xs text-muted-foreground mb-1 block">API Token</label>
                       <Input type="password" value={editToken} onChange={e => setEditToken(e.target.value)} className="h-8 text-sm" placeholder="lin_api_... (leave blank to keep)" />
                     </div>
-                    <div>
-                      <label className="text-xs text-muted-foreground mb-1 block">Webhook Secret</label>
-                      <Input type="password" value={editSecret} onChange={e => setEditSecret(e.target.value)} className="h-8 text-sm" placeholder="whsec_... (leave blank to keep)" />
-                    </div>
                     <div className="flex gap-2">
                       <Button size="sm" disabled={saving || !editWorkspace} onClick={saveEdit}>Save</Button>
                       <Button size="sm" variant="outline" onClick={() => setEditingIdx(null)}>Cancel</Button>
@@ -536,8 +530,7 @@ function IntegrationsSection({ settings, onSave, saving }: { settings: SettingsD
                     <div>
                       <p className="text-sm font-medium">{li.workspace}</p>
                       <p className="text-xs text-muted-foreground">
-                        Token: {li.tokenSet ? <span className="text-green-500">✓</span> : <span className="text-amber-500">✗</span>}
-                        {" · Webhook secret: "}{li.webhookSecretSet ? <span className="text-green-500">✓</span> : <span className="text-amber-500">✗</span>}
+                        Token: {li.tokenSet ? <span className="text-green-500">✓ set</span> : <span className="text-amber-500">✗ not set</span>}
                       </p>
                     </div>
                     <Button size="sm" variant="outline" onClick={() => startEdit(i)}>Edit</Button>
@@ -557,14 +550,10 @@ function IntegrationsSection({ settings, onSave, saving }: { settings: SettingsD
             <label className="text-xs text-muted-foreground mb-1 block">API Token</label>
             <Input type="password" value={newToken} onChange={e => setNewToken(e.target.value)} className="h-8 text-sm" placeholder="lin_api_..." />
           </div>
-          <div>
-            <label className="text-xs text-muted-foreground mb-1 block">Webhook Secret <span className="text-muted-foreground/60">(optional)</span></label>
-            <Input type="password" value={newSecret} onChange={e => setNewSecret(e.target.value)} className="h-8 text-sm" placeholder="whsec_..." />
-          </div>
           <Button size="sm" disabled={saving || !newWorkspace || !newToken}
             onClick={() => {
-              onSave({ integrations: { linear: [...linear, { workspace: newWorkspace, token: newToken, ...(newSecret ? { webhookSecret: newSecret } : {}) }] } })
-              setNewWorkspace(""); setNewToken(""); setNewSecret("")
+              onSave({ integrations: { linear: [...linear, { workspace: newWorkspace, token: newToken }] } })
+              setNewWorkspace(""); setNewToken("")
             }}>
             Add Linear Workspace
           </Button>
@@ -577,6 +566,7 @@ function IntegrationsSection({ settings, onSave, saving }: { settings: SettingsD
 interface FactoryFormData {
   name: string; workspace: string; team: string
   triggerStatus: string; doneStatus: string; terminateOnLeave: boolean; template: string
+  webhookSecret: string
 }
 
 function FactoriesSection({ hubUrl, settings, onSave, saving }: { hubUrl: string; settings: SettingsData; onSave: (p: object) => void; saving: boolean }) {
@@ -587,9 +577,11 @@ function FactoriesSection({ hubUrl, settings, onSave, saving }: { hubUrl: string
     if (!webhookUrl) return
     navigator.clipboard.writeText(webhookUrl).then(() => { setCopied(true); setTimeout(() => setCopied(false), 2000) })
   }
+  const [editingFactory, setEditingFactory] = useState<number | null>(null)
+  const [editForm, setEditForm] = useState<FactoryFormData>({ name: "", workspace: "", team: "", triggerStatus: "", doneStatus: "", terminateOnLeave: true, template: "", webhookSecret: "" })
   const [form, setForm] = useState<FactoryFormData>({
     name: "", workspace: "", team: "", triggerStatus: "Ready for Agent",
-    doneStatus: "In Review", terminateOnLeave: true, template: "base"
+    doneStatus: "In Review", terminateOnLeave: true, template: "base", webhookSecret: ""
   })
 
   const workspaces = settings.integrations?.linear?.map(l => l.workspace) || []
@@ -627,19 +619,65 @@ function FactoriesSection({ hubUrl, settings, onSave, saving }: { hubUrl: string
       {factories.length > 0 && (
         <div className="space-y-2 mb-6">
           {factories.map((f, i) => (
-            <div key={i} className="border border-border rounded-lg p-4">
-              <div className="flex items-center justify-between">
-                <div>
-                  <p className="text-sm font-medium">{f.name}</p>
-                  <p className="text-xs text-muted-foreground">
-                    {f.integration} · {f.team || f.workspace} · "{f.triggerStatus}" → template: {f.template}
-                  </p>
+            <div key={i}>
+              {editingFactory === i ? (
+                <div className="border border-primary/40 rounded-lg p-4 space-y-3 bg-primary/5">
+                  <h4 className="text-sm font-semibold">Edit: {f.name}</h4>
+                  <div className="grid grid-cols-2 gap-3">
+                    <div>
+                      <label className="text-xs text-muted-foreground mb-1 block">Name</label>
+                      <Input value={editForm.name} onChange={e => setEditForm(p => ({...p, name: e.target.value}))} className="h-8 text-sm" />
+                    </div>
+                    <div>
+                      <label className="text-xs text-muted-foreground mb-1 block">Team key</label>
+                      <Input value={editForm.team} onChange={e => setEditForm(p => ({...p, team: e.target.value}))} className="h-8 text-sm" placeholder="ELA" />
+                    </div>
+                    <div>
+                      <label className="text-xs text-muted-foreground mb-1 block">Trigger status</label>
+                      <Input value={editForm.triggerStatus} onChange={e => setEditForm(p => ({...p, triggerStatus: e.target.value}))} className="h-8 text-sm" />
+                    </div>
+                    <div>
+                      <label className="text-xs text-muted-foreground mb-1 block">Done status</label>
+                      <Input value={editForm.doneStatus} onChange={e => setEditForm(p => ({...p, doneStatus: e.target.value}))} className="h-8 text-sm" />
+                    </div>
+                    <div>
+                      <label className="text-xs text-muted-foreground mb-1 block">Template</label>
+                      <Input value={editForm.template} onChange={e => setEditForm(p => ({...p, template: e.target.value}))} className="h-8 text-sm" />
+                    </div>
+                    <div>
+                      <label className="text-xs text-muted-foreground mb-1 block">Webhook Signing Secret</label>
+                      <Input type="password" value={editForm.webhookSecret} onChange={e => setEditForm(p => ({...p, webhookSecret: e.target.value}))} className="h-8 text-sm" placeholder="whsec_... (leave blank to keep)" />
+                    </div>
+                  </div>
+                  <div className="flex gap-2">
+                    <Button size="sm" disabled={saving} onClick={() => {
+                      const { webhookSecret, ...rest } = editForm
+                      const updated = factories.map((x, j) => j === i ? { ...x, ...rest, ...(webhookSecret ? { webhookSecret } : {}) } : x)
+                      onSave({ factories: updated })
+                      setEditingFactory(null)
+                    }}>Save</Button>
+                    <Button size="sm" variant="outline" onClick={() => setEditingFactory(null)}>Cancel</Button>
+                    <Button size="sm" variant="ghost" className="text-destructive hover:text-destructive ml-auto" disabled={saving}
+                      onClick={() => { onSave({ factories: factories.filter((_, j) => j !== i) }); setEditingFactory(null) }}>
+                      Remove
+                    </Button>
+                  </div>
                 </div>
-                <Button size="sm" variant="ghost" className="text-destructive hover:text-destructive h-7 px-2" disabled={saving}
-                  onClick={() => onSave({ factories: factories.filter((_, j) => j !== i) })}>
-                  Remove
-                </Button>
-              </div>
+              ) : (
+                <div className="border border-border rounded-lg p-4 flex items-center justify-between">
+                  <div>
+                    <p className="text-sm font-medium">{f.name}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {f.integration} · {f.team || f.workspace} · "{f.triggerStatus}" → {f.template}
+                      {" · webhook: "}{f.webhookSecretSet ? <span className="text-green-500">✓</span> : <span className="text-amber-500">not set</span>}
+                    </p>
+                  </div>
+                  <Button size="sm" variant="outline" onClick={() => {
+                    setEditingFactory(i)
+                    setEditForm({ name: f.name, workspace: f.workspace, team: f.team || "", triggerStatus: f.triggerStatus, doneStatus: f.doneStatus || "", terminateOnLeave: f.terminateOnLeave, template: f.template, webhookSecret: "" })
+                  }}>Edit</Button>
+                </div>
+              )}
             </div>
           ))}
         </div>
@@ -681,10 +719,15 @@ function FactoriesSection({ hubUrl, settings, onSave, saving }: { hubUrl: string
           <input type="checkbox" checked={form.terminateOnLeave} onChange={e => update("terminateOnLeave", e.target.checked)} />
           Terminate claw when issue leaves trigger status
         </label>
+        <div>
+          <label className="text-xs text-muted-foreground mb-1 block">Webhook Signing Secret</label>
+          <Input type="password" value={form.webhookSecret} onChange={e => update("webhookSecret", e.target.value)} className="h-8 text-sm" placeholder="whsec_... from Linear webhook settings" />
+        </div>
         <Button size="sm" disabled={saving || !form.name || !form.workspace || !form.template || !form.triggerStatus}
           onClick={() => {
-            onSave({ factories: [...factories, { ...form, integration: "linear" }] })
-            setForm({ name: "", workspace: "", team: "", triggerStatus: "Ready for Agent", doneStatus: "In Review", terminateOnLeave: true, template: "base" })
+            const { webhookSecret, ...rest } = form
+            onSave({ factories: [...factories, { ...rest, integration: "linear", ...(webhookSecret ? { webhookSecret } : {}) }] })
+            setForm({ name: "", workspace: "", team: "", triggerStatus: "Ready for Agent", doneStatus: "In Review", terminateOnLeave: true, template: "base", webhookSecret: "" })
           }}>
           Add Factory
         </Button>

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -2,29 +2,12 @@
 
 import { useState, useEffect, useCallback } from "react"
 import { getHubUrl } from "@/lib/hub-url"
-import { Cpu, Key, Github, ChevronLeft, Shield, Zap, Copy, Check } from "lucide-react"
+import { Cpu, Key, Github, ChevronLeft, Shield, Zap, Factory, Copy, Check } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { cn } from "@/lib/utils"
 
-type Section = "runtimes" | "llm" | "github" | "security" | "factories"
-
-interface FactoryData {
-  name: string
-  integration: string
-  workspace: string
-  team?: string
-  triggerStatus: string
-  doneStatus?: string
-  terminateOnLeave?: boolean
-  template: string
-  namePattern?: string
-}
-
-interface LinearIntegrationData {
-  workspace: string
-  webhookSecretSet: boolean
-}
+type Section = "runtimes" | "llm" | "github" | "security" | "integrations" | "factories"
 
 interface SettingsData {
   llmKeys: Record<string, boolean>
@@ -40,8 +23,13 @@ interface SettingsData {
   }>
   github: Array<{ appId: number; url?: string; keySet: boolean }>
   sshPublicKeys: string[]
-  integrations?: { linear: LinearIntegrationData[] }
-  factories?: FactoryData[]
+  integrations?: {
+    linear?: Array<{ workspace: string; tokenSet: boolean; webhookSecretSet: boolean }>
+  }
+  factories?: Array<{
+    name: string; integration: string; workspace: string; team: string
+    triggerStatus: string; doneStatus: string; terminateOnLeave: boolean; template: string
+  }>
 }
 
 async function fetchSettings(): Promise<SettingsData> {
@@ -114,7 +102,8 @@ export default function SettingsPage() {
     { id: "llm", label: "LLM Keys", icon: Key },
     { id: "github", label: "GitHub Apps", icon: Github },
     { id: "security", label: "Security", icon: Shield },
-    { id: "factories", label: "Factories", icon: Zap },
+    { id: "integrations", label: "Integrations", icon: Zap },
+    { id: "factories", label: "Factories", icon: Factory },
   ]
 
   return (
@@ -171,6 +160,9 @@ export default function SettingsPage() {
           )}
           {settings && section === "security" && (
             <SecuritySection onSave={save} saving={saving} />
+          )}
+          {settings && section === "integrations" && (
+            <IntegrationsSection settings={settings} onSave={save} saving={saving} />
           )}
           {settings && section === "factories" && (
             <FactoriesSection hubUrl={hubPublicUrl} settings={settings} onSave={save} saving={saving} />
@@ -471,63 +463,107 @@ function SecuritySection({ onSave, saving }: { onSave: (p: object) => void; savi
     </div>
   )
 }
-function FactoriesSection({ hubUrl, settings, onSave, saving }: {
-  hubUrl: string
-  settings: SettingsData
-  onSave: (p: object) => void
-  saving: boolean
-}) {
+function IntegrationsSection({ settings, onSave, saving }: { settings: SettingsData; onSave: (p: object) => void; saving: boolean }) {
+  const linear = settings.integrations?.linear || []
+  const [workspace, setWorkspace] = useState("")
+  const [token, setToken] = useState("")
+  const [secret, setSecret] = useState("")
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-base font-semibold mb-1">Integrations</h2>
+        <p className="text-sm text-muted-foreground mb-6">Connect external services to enable Factories.</p>
+      </div>
+
+      {/* Linear */}
+      <div>
+        <h3 className="text-sm font-semibold mb-3 flex items-center gap-2">
+          <Zap className="size-4" /> Linear
+        </h3>
+        {linear.length > 0 && (
+          <div className="mb-4 space-y-2">
+            {linear.map((li, i) => (
+              <div key={i} className="border border-border rounded-lg p-3 flex items-center justify-between">
+                <div>
+                  <p className="text-sm font-medium">{li.workspace}</p>
+                  <p className="text-xs text-muted-foreground">
+                    Token: {li.tokenSet ? "✓" : "✗"} · Webhook secret: {li.webhookSecretSet ? "✓" : "✗"}
+                  </p>
+                </div>
+                <Button size="sm" variant="ghost" className="text-destructive hover:text-destructive h-7 px-2" disabled={saving}
+                  onClick={() => onSave({ integrations: { linear: linear.filter((_, j) => j !== i) } })}>
+                  Remove
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+        <div className="border border-border rounded-lg p-4 space-y-3">
+          <p className="text-xs text-muted-foreground">Add a Linear workspace to enable factory automation.</p>
+          <div>
+            <label className="text-xs text-muted-foreground mb-1 block">Workspace label</label>
+            <Input value={workspace} onChange={e => setWorkspace(e.target.value)} className="h-8 text-sm" placeholder="my-company" />
+          </div>
+          <div>
+            <label className="text-xs text-muted-foreground mb-1 block">API Token</label>
+            <Input type="password" value={token} onChange={e => setToken(e.target.value)} className="h-8 text-sm" placeholder="lin_api_..." />
+          </div>
+          <div>
+            <label className="text-xs text-muted-foreground mb-1 block">Webhook Secret <span className="text-muted-foreground/60">(optional)</span></label>
+            <Input type="password" value={secret} onChange={e => setSecret(e.target.value)} className="h-8 text-sm" placeholder="Used to validate incoming webhooks" />
+          </div>
+          <Button size="sm" disabled={saving || !workspace || !token}
+            onClick={() => {
+              onSave({ integrations: { linear: [...linear, { workspace, token, webhookSecret: secret || undefined }] } })
+              setWorkspace(""); setToken(""); setSecret("")
+            }}>
+            Add Linear Workspace
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+interface FactoryFormData {
+  name: string; workspace: string; team: string
+  triggerStatus: string; doneStatus: string; terminateOnLeave: boolean; template: string
+}
+
+function FactoriesSection({ hubUrl, settings, onSave, saving }: { hubUrl: string; settings: SettingsData; onSave: (p: object) => void; saving: boolean }) {
+  const factories = settings.factories || []
   const [copied, setCopied] = useState(false)
   const webhookUrl = hubUrl ? `${hubUrl}/api/integrations/linear/webhook` : ""
-  const factories = settings.factories || []
-  const linearIntegrations = settings.integrations?.linear || []
-  const [editingFactory, setEditingFactory] = useState<FactoryData | null>(null)
-  const [editingLinear, setEditingLinear] = useState<{ workspace: string } | null>(null)
-
   const handleCopy = () => {
     if (!webhookUrl) return
-    navigator.clipboard.writeText(webhookUrl).then(() => {
-      setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
-    })
+    navigator.clipboard.writeText(webhookUrl).then(() => { setCopied(true); setTimeout(() => setCopied(false), 2000) })
   }
+  const [form, setForm] = useState<FactoryFormData>({
+    name: "", workspace: "", team: "", triggerStatus: "Ready for Agent",
+    doneStatus: "In Review", terminateOnLeave: true, template: "base"
+  })
 
-  const saveFactory = (f: FactoryData) => {
-    const updated = factories.map((x) => x.name === f.name ? f : x)
-    onSave({ factories: updated.map((x) => ({
-      name: x.name, integration: x.integration, workspace: x.workspace,
-      team: x.team || "", triggerStatus: x.triggerStatus,
-      doneStatus: x.doneStatus || "", terminateOnLeave: x.terminateOnLeave ?? false,
-      template: x.template, namePattern: x.namePattern || "",
-    })) })
-    setEditingFactory(null)
-  }
+  const workspaces = settings.integrations?.linear?.map(l => l.workspace) || []
 
-  const saveLinear = (ws: string, token: string, webhookSecret: string) => {
-    const patch = linearIntegrations.map((li) =>
-      li.workspace === ws
-        ? { workspace: ws, ...(token ? { token } : {}), ...(webhookSecret ? { webhookSecret } : {}) }
-        : { workspace: li.workspace }
-    )
-    onSave({ integrations: { linear: patch } })
-    setEditingLinear(null)
+  function update(k: keyof FactoryFormData, v: string | boolean) {
+    setForm(prev => ({ ...prev, [k]: v }))
   }
 
   return (
-    <div className="space-y-8">
+    <div className="space-y-6">
       <div>
         <h2 className="text-base font-semibold mb-1">Factories</h2>
-        <p className="text-sm text-muted-foreground mb-1">
-          Automatically spawn and terminate claws based on external events.
+        <p className="text-sm text-muted-foreground mb-6">
+          Automation rules that spin up claws when Linear issues enter a status.
         </p>
-        <a href="https://elasticclaw.ai/docs/factories" target="_blank" rel="noopener noreferrer" className="text-xs text-primary hover:underline">Setup guide →</a>
       </div>
 
       {/* Webhook URL */}
       <div className="border border-border rounded-lg p-5 space-y-3">
         <h3 className="text-sm font-medium">Linear Webhook URL</h3>
         <p className="text-xs text-muted-foreground">
-          Paste into <strong>Linear → Settings → API → Webhooks</strong>. Subscribe to <strong>Issue</strong> events.
+          Paste into <strong>Linear → Settings → API → Webhooks</strong> and subscribe to <strong>Issue</strong> events.
         </p>
         <div className="flex items-center gap-2">
           <code className="flex-1 text-xs font-mono bg-muted px-3 py-2 rounded-md border border-border truncate">
@@ -540,152 +576,70 @@ function FactoriesSection({ hubUrl, settings, onSave, saving }: {
         </div>
       </div>
 
-      {/* Linear integrations */}
-      {linearIntegrations.length > 0 && (
-        <div className="border border-border rounded-lg p-5 space-y-2">
-          <h3 className="text-sm font-medium mb-3">Linear Integrations</h3>
-          {linearIntegrations.map((li) => (
-            <div key={li.workspace}>
-              {editingLinear?.workspace === li.workspace ? (
-                <LinearEditPanel
-                  workspace={li.workspace}
-                  onSave={saveLinear}
-                  onCancel={() => setEditingLinear(null)}
-                  saving={saving}
-                />
-              ) : (
-                <div className="flex items-center justify-between py-2 border-b border-border last:border-0">
-                  <div>
-                    <p className="text-sm font-mono">{li.workspace}</p>
-                    <p className="text-xs text-muted-foreground">
-                      Webhook secret: {li.webhookSecretSet
-                        ? <span className="text-green-500">set</span>
-                        : <span className="text-amber-500">not set</span>}
-                    </p>
-                  </div>
-                  <Button variant="outline" size="sm" onClick={() => setEditingLinear({ workspace: li.workspace })}>Edit</Button>
-                </div>
-              )}
-            </div>
-          ))}
-        </div>
-      )}
-
-      {/* Factories list */}
       {factories.length > 0 && (
-        <div className="border border-border rounded-lg p-5 space-y-2">
-          <h3 className="text-sm font-medium mb-3">Configured Factories</h3>
-          {factories.map((f) => (
-            <div key={f.name}>
-              {editingFactory?.name === f.name ? (
-                <FactoryEditPanel factory={editingFactory} onSave={saveFactory} onCancel={() => setEditingFactory(null)} saving={saving} />
-              ) : (
-                <div className="flex items-start justify-between py-2 border-b border-border last:border-0">
-                  <div className="space-y-0.5">
-                    <p className="text-sm font-medium">{f.name}</p>
-                    <p className="text-xs text-muted-foreground">
-                      {f.integration} · {f.workspace}{f.team ? ` / ${f.team}` : ""}
-                    </p>
-                    <p className="text-xs text-muted-foreground">
-                      Trigger: <span className="text-foreground">{f.triggerStatus}</span>
-                      {f.doneStatus && <> → <span className="text-foreground">{f.doneStatus}</span></>}
-                      {" · template: "}<span className="text-foreground font-mono">{f.template}</span>
-                    </p>
-                  </div>
-                  <Button variant="outline" size="sm" onClick={() => setEditingFactory({ ...f })}>Edit</Button>
+        <div className="space-y-2 mb-6">
+          {factories.map((f, i) => (
+            <div key={i} className="border border-border rounded-lg p-4">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm font-medium">{f.name}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {f.integration} · {f.team || f.workspace} · "{f.triggerStatus}" → template: {f.template}
+                  </p>
                 </div>
-              )}
+                <Button size="sm" variant="ghost" className="text-destructive hover:text-destructive h-7 px-2" disabled={saving}
+                  onClick={() => onSave({ factories: factories.filter((_, j) => j !== i) })}>
+                  Remove
+                </Button>
+              </div>
             </div>
           ))}
         </div>
       )}
 
-      {factories.length === 0 && linearIntegrations.length === 0 && (
-        <p className="text-sm text-muted-foreground">
-          No factories configured yet. Add them to{" "}
-          <code className="bg-muted px-1 rounded text-xs">/etc/elasticclaw/hub.yaml</code> and restart the hub.
-        </p>
-      )}
-    </div>
-  )
-}
-
-function FactoryEditPanel({ factory, onSave, onCancel, saving }: {
-  factory: FactoryData
-  onSave: (f: FactoryData) => void
-  onCancel: () => void
-  saving: boolean
-}) {
-  const [f, setF] = useState<FactoryData>({ ...factory })
-  const set = (k: keyof FactoryData, v: string | boolean) => setF((prev) => ({ ...prev, [k]: v }))
-
-  return (
-    <div className="border border-primary/40 rounded-lg p-4 space-y-4 bg-primary/5 my-2">
-      <h4 className="text-sm font-semibold">Edit: {factory.name}</h4>
-      <div className="grid grid-cols-2 gap-3">
-        <div>
-          <label className="text-xs text-muted-foreground mb-1 block">Name</label>
-          <Input value={f.name} onChange={(e) => set("name", e.target.value)} className="h-8 text-sm" />
+      <div className="border border-border rounded-lg p-5 space-y-4">
+        <h3 className="text-sm font-semibold">New Factory</h3>
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="text-xs text-muted-foreground mb-1 block">Factory name</label>
+            <Input value={form.name} onChange={e => update("name", e.target.value)} className="h-8 text-sm" placeholder="ELA feature work" />
+          </div>
+          <div>
+            <label className="text-xs text-muted-foreground mb-1 block">Linear workspace</label>
+            <select value={form.workspace} onChange={e => update("workspace", e.target.value)}
+              className="w-full h-8 rounded-md border border-border bg-background px-2 text-sm">
+              <option value="">Select workspace</option>
+              {workspaces.map(w => <option key={w} value={w}>{w}</option>)}
+            </select>
+          </div>
+          <div>
+            <label className="text-xs text-muted-foreground mb-1 block">Team key</label>
+            <Input value={form.team} onChange={e => update("team", e.target.value)} className="h-8 text-sm" placeholder="ELA" />
+          </div>
+          <div>
+            <label className="text-xs text-muted-foreground mb-1 block">Template (push to hub first)</label>
+            <Input value={form.template} onChange={e => update("template", e.target.value)} className="h-8 text-sm" placeholder="base" />
+          </div>
+          <div>
+            <label className="text-xs text-muted-foreground mb-1 block">Trigger status</label>
+            <Input value={form.triggerStatus} onChange={e => update("triggerStatus", e.target.value)} className="h-8 text-sm" />
+          </div>
+          <div>
+            <label className="text-xs text-muted-foreground mb-1 block">Done status</label>
+            <Input value={form.doneStatus} onChange={e => update("doneStatus", e.target.value)} className="h-8 text-sm" />
+          </div>
         </div>
-        <div>
-          <label className="text-xs text-muted-foreground mb-1 block">Workspace</label>
-          <Input value={f.workspace} onChange={(e) => set("workspace", e.target.value)} className="h-8 text-sm" />
-        </div>
-        <div>
-          <label className="text-xs text-muted-foreground mb-1 block">Team (optional)</label>
-          <Input value={f.team || ""} onChange={(e) => set("team", e.target.value)} className="h-8 text-sm" placeholder="All teams" />
-        </div>
-        <div>
-          <label className="text-xs text-muted-foreground mb-1 block">Template</label>
-          <Input value={f.template} onChange={(e) => set("template", e.target.value)} className="h-8 text-sm" />
-        </div>
-        <div>
-          <label className="text-xs text-muted-foreground mb-1 block">Trigger status</label>
-          <Input value={f.triggerStatus} onChange={(e) => set("triggerStatus", e.target.value)} className="h-8 text-sm" placeholder="In Progress" />
-        </div>
-        <div>
-          <label className="text-xs text-muted-foreground mb-1 block">Done status</label>
-          <Input value={f.doneStatus || ""} onChange={(e) => set("doneStatus", e.target.value)} className="h-8 text-sm" placeholder="Done" />
-        </div>
-        <div className="col-span-2">
-          <label className="text-xs text-muted-foreground mb-1 block">Name pattern (optional)</label>
-          <Input value={f.namePattern || ""} onChange={(e) => set("namePattern", e.target.value)} className="h-8 text-sm" placeholder="{issue}-{title}" />
-        </div>
-      </div>
-      <div className="flex items-center gap-2">
-        <Button size="sm" disabled={saving} onClick={() => onSave(f)}>Save</Button>
-        <Button size="sm" variant="outline" onClick={onCancel}>Cancel</Button>
-      </div>
-    </div>
-  )
-}
-
-function LinearEditPanel({ workspace, onSave, onCancel, saving }: {
-  workspace: string
-  onSave: (ws: string, token: string, webhookSecret: string) => void
-  onCancel: () => void
-  saving: boolean
-}) {
-  const [token, setToken] = useState("")
-  const [webhookSecret, setWebhookSecret] = useState("")
-
-  return (
-    <div className="border border-primary/40 rounded-lg p-4 space-y-4 bg-primary/5 my-2">
-      <h4 className="text-sm font-semibold">Edit Linear: {workspace}</h4>
-      <p className="text-xs text-muted-foreground">Leave blank to keep existing values.</p>
-      <div className="space-y-3">
-        <div>
-          <label className="text-xs text-muted-foreground mb-1 block">API Token</label>
-          <Input type="password" value={token} onChange={(e) => setToken(e.target.value)} className="h-8 text-sm" placeholder="lin_api_... (leave blank to keep)" />
-        </div>
-        <div>
-          <label className="text-xs text-muted-foreground mb-1 block">Webhook Signing Secret</label>
-          <Input type="password" value={webhookSecret} onChange={(e) => setWebhookSecret(e.target.value)} className="h-8 text-sm" placeholder="whsec_... (leave blank to keep)" />
-        </div>
-      </div>
-      <div className="flex items-center gap-2">
-        <Button size="sm" disabled={saving || (!token && !webhookSecret)} onClick={() => onSave(workspace, token, webhookSecret)}>Save</Button>
-        <Button size="sm" variant="outline" onClick={onCancel}>Cancel</Button>
+        <label className="flex items-center gap-2 text-sm cursor-pointer">
+          <input type="checkbox" checked={form.terminateOnLeave} onChange={e => update("terminateOnLeave", e.target.checked)} />
+          Terminate claw when issue leaves trigger status
+        </label>
+        <Button size="sm" disabled={saving || !form.name || !form.workspace || !form.template || !form.triggerStatus}
+          onClick={() => {
+            onSave({ factories: [...factories, { ...form, integration: "linear" }] })
+            setForm({ name: "", workspace: "", team: "", triggerStatus: "Ready for Agent", doneStatus: "In Review", terminateOnLeave: true, template: "base" })
+          }}>
+          Add Factory
+        </Button>
       </div>
     </div>
   )

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -568,7 +568,7 @@ function IntegrationsSection({ settings, onSave, saving }: { settings: SettingsD
 interface FactoryFormData {
   name: string; workspace: string; team: string
   triggerStatus: string; doneStatus: string; terminateOnLeave: boolean; template: string
-  webhookSecret: string; tags: string; color: string
+  webhookSecret: string; tags: string; color: string; originalName?: string
 }
 
 function FactoriesSection({ hubUrl, settings, onSave, saving }: { hubUrl: string; settings: SettingsData; onSave: (p: object) => void; saving: boolean }) {
@@ -580,7 +580,7 @@ function FactoriesSection({ hubUrl, settings, onSave, saving }: { hubUrl: string
     navigator.clipboard.writeText(webhookUrl).then(() => { setCopied(true); setTimeout(() => setCopied(false), 2000) })
   }
   const [editingFactory, setEditingFactory] = useState<number | null>(null)
-  const [editForm, setEditForm] = useState<FactoryFormData>({ name: "", workspace: "", team: "", triggerStatus: "", doneStatus: "", terminateOnLeave: true, template: "", webhookSecret: "", tags: "", color: "" })
+  const [editForm, setEditForm] = useState<FactoryFormData>({ name: "", workspace: "", team: "", triggerStatus: "", doneStatus: "", terminateOnLeave: true, template: "", webhookSecret: "", tags: "", color: "", originalName: "" })
   const [form, setForm] = useState<FactoryFormData>({
     name: "", workspace: "", team: "", triggerStatus: "Ready for Agent",
     doneStatus: "In Review", terminateOnLeave: true, template: "base", webhookSecret: "", tags: "", color: ""
@@ -661,9 +661,9 @@ function FactoriesSection({ hubUrl, settings, onSave, saving }: { hubUrl: string
                   </div>
                   <div className="flex gap-2">
                     <Button size="sm" disabled={saving} onClick={() => {
-                      const { webhookSecret, tags: tagsStr, color, ...rest } = editForm
+                      const { webhookSecret, tags: tagsStr, color, originalName, ...rest } = editForm
                       const tags = tagsStr.split(",").map(t => t.trim()).filter(Boolean)
-                      const updated = factories.map((x, j) => j === i ? { ...x, ...rest, ...(webhookSecret ? { webhookSecret } : {}), tags, color } : x)
+                      const updated = factories.map((x, j) => j === i ? { ...x, ...rest, ...(originalName ? { originalName } : {}), ...(webhookSecret ? { webhookSecret } : {}), tags, color } : x)
                       onSave({ factories: updated })
                       setEditingFactory(null)
                     }}>Save</Button>
@@ -687,7 +687,7 @@ function FactoriesSection({ hubUrl, settings, onSave, saving }: { hubUrl: string
                     <a href={`/factories/${encodeURIComponent(f.name)}`} className="text-xs text-primary hover:underline whitespace-nowrap">Activity</a>
                     <Button size="sm" variant="outline" onClick={() => {
                       setEditingFactory(i)
-                      setEditForm({ name: f.name, workspace: f.workspace, team: f.team || "", triggerStatus: f.triggerStatus, doneStatus: f.doneStatus || "", terminateOnLeave: f.terminateOnLeave, template: f.template, webhookSecret: "", tags: (f.tags || []).join(", "), color: f.color || "" })
+                      setEditForm({ name: f.name, workspace: f.workspace, team: f.team || "", triggerStatus: f.triggerStatus, doneStatus: f.doneStatus || "", terminateOnLeave: f.terminateOnLeave, template: f.template, webhookSecret: "", tags: (f.tags || []).join(", "), color: f.color || "", originalName: f.name })
                     }}>Edit</Button>
                   </div>
                 </div>

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -672,10 +672,13 @@ function FactoriesSection({ hubUrl, settings, onSave, saving }: { hubUrl: string
                       {" · webhook: "}{f.webhookSecretSet ? <span className="text-green-500">✓</span> : <span className="text-amber-500">not set</span>}
                     </p>
                   </div>
-                  <Button size="sm" variant="outline" onClick={() => {
-                    setEditingFactory(i)
-                    setEditForm({ name: f.name, workspace: f.workspace, team: f.team || "", triggerStatus: f.triggerStatus, doneStatus: f.doneStatus || "", terminateOnLeave: f.terminateOnLeave, template: f.template, webhookSecret: "" })
-                  }}>Edit</Button>
+                  <div className="flex items-center gap-2">
+                    <a href={`/factories/${encodeURIComponent(f.name)}`} className="text-xs text-primary hover:underline whitespace-nowrap">Activity</a>
+                    <Button size="sm" variant="outline" onClick={() => {
+                      setEditingFactory(i)
+                      setEditForm({ name: f.name, workspace: f.workspace, team: f.team || "", triggerStatus: f.triggerStatus, doneStatus: f.doneStatus || "", terminateOnLeave: f.terminateOnLeave, template: f.template, webhookSecret: "" })
+                    }}>Edit</Button>
+                  </div>
                 </div>
               )}
             </div>

--- a/web/hooks/use-hub.ts
+++ b/web/hooks/use-hub.ts
@@ -260,20 +260,25 @@ export function useHub(selectedClawId: string | null): HubState {
           })
         } else if (type === "claw_status") {
           const { claw_id, status } = payload
-          setClaws((prev) =>
-            prev.map((c) =>
-              c.id === claw_id
-                ? { ...c, status: mapApiStatus(status), isStreaming: status !== "connected" ? false : c.isStreaming }
-                : c
+          if (status === "deleted") {
+            // Remove immediately — don't wait for next poll
+            setClaws((prev) => prev.filter((c) => c.id !== claw_id))
+          } else {
+            setClaws((prev) =>
+              prev.map((c) =>
+                c.id === claw_id
+                  ? { ...c, status: mapApiStatus(status), isStreaming: status !== "connected" ? false : c.isStreaming }
+                  : c
+              )
             )
-          )
-          // If a new claw came online that we don't know about, refresh
-          setClaws((prev) => {
-            if (!prev.find((c) => c.id === claw_id)) {
-              refreshClaws()
-            }
-            return prev
-          })
+            // If a new claw came online that we don't know about, refresh
+            setClaws((prev) => {
+              if (!prev.find((c) => c.id === claw_id)) {
+                refreshClaws()
+              }
+              return prev
+            })
+          }
         } else if (type === "claw_error") {
           const { claw_id, error } = payload
           console.warn(`Claw ${claw_id} error:`, error)

--- a/web/hooks/use-hub.ts
+++ b/web/hooks/use-hub.ts
@@ -299,7 +299,7 @@ export function useHub(selectedClawId: string | null): HubState {
     refreshClaws().then(() => {})
 
     // Poll every 30s
-    pollIntervalRef.current = setInterval(refreshClaws, 30_000)
+    pollIntervalRef.current = setInterval(refreshClaws, 10_000)
 
     // Wait for token then connect WS
     resolveToken().then(() => connectWebSocket())


### PR DESCRIPTION
Adds a **Factories** section to the settings page.

- Shows the Linear webhook URL with one-click copy
- URL is sourced from `hub-config` API (correct public domain, not localhost)
- Links to `elasticclaw.ai/docs/factories`
- Note about configuring `hub.yaml`