### PR TITLE
docs: elasticclaw template — full factory context for agent handoff

### DIFF
--- a/.elasticclaw/templates/elasticclaw/AGENTS.md
+++ b/.elasticclaw/templates/elasticclaw/AGENTS.md
@@ -4,20 +4,25 @@
 
 The repo is already cloned at `~/.openclaw/workspace/elasticclaw/`. Check with `ls ~/.openclaw/workspace/`.
 
-Read SOUL.md, USER.md, and TOOLS.md before doing anything.
+Read SOUL.md, USER.md, MEMORY.md, and TOOLS.md before doing anything.
+
+**Context file:** If a `CONTEXT.md` exists in your workspace, read it — it was injected by a factory with the Linear issue you're working on.
 
 ## Every Session
 
 1. Read SOUL.md — who you are
 2. Read USER.md — who you're helping
-3. Read memory/YYYY-MM-DD.md (today + yesterday) for recent context
-4. `git -C ~/.openclaw/workspace/elasticclaw status` to see where things stand
-5. `git -C ~/.openclaw/workspace/elasticclaw pull` to get latest
+3. Read MEMORY.md — project context, architecture, open work, known gotchas
+4. Read memory/YYYY-MM-DD.md (today + yesterday)
+5. Read CONTEXT.md if it exists (Linear issue context)
+6. `git -C ~/.openclaw/workspace/elasticclaw status` to see where things stand
+7. `git -C ~/.openclaw/workspace/elasticclaw pull` to get latest
 
 ## Memory
 
 - **Daily notes:** `memory/YYYY-MM-DD.md` — log what you did, decisions made, blockers
 - **Long-term:** `MEMORY.md` — distilled context that survives across sessions
+- **Update MEMORY.md** when you learn something new about the codebase
 
 Write to memory files. Don't rely on "mental notes" — this VM can be killed any time.
 
@@ -25,15 +30,16 @@ Write to memory files. Don't rely on "mental notes" — this VM can be killed an
 
 ### Starting a task
 
-1. Check current branch: `git -C ~/ws branch` (alias `~/ws` = workspace elasticclaw dir)
-2. Pull latest: `git pull origin main`
+1. Check current branch: `git -C ~/.openclaw/workspace/elasticclaw branch`
+2. Pull latest: `git -C ~/.openclaw/workspace/elasticclaw pull origin main`
 3. Create a feature branch for non-trivial changes: `git checkout -b feat/my-thing`
+4. Alias: `alias ws="cd ~/.openclaw/workspace/elasticclaw"`
 
 ### Go code
 
 ```bash
-cd ~/ws  # or ~/.openclaw/workspace/elasticclaw
-make build           # fast build, Go only
+ws   # cd to repo
+make build           # fast build, Go only (no web embed)
 go build ./...       # verify compiles
 go vet ./...         # check for issues
 go test ./...        # run tests
@@ -43,50 +49,69 @@ gofmt -w <file>      # format
 ### Web UI (Next.js in `web/`)
 
 ```bash
-cd ~/ws/web
+cd ~/.openclaw/workspace/elasticclaw/web
 npm install
 NEXT_PUBLIC_HUB_URL=http://localhost:8080 npm run dev  # dev server :3000
 
 # Full static build (embeds in binary):
-cd ~/ws && make build-release
+cd ~/.openclaw/workspace/elasticclaw && make build-release
 ```
 
 ### Committing
 
 ```bash
-cd ~/ws
+cd ~/.openclaw/workspace/elasticclaw
 git add -A
 git commit -m "feat: <description>"
 git push origin <branch>
-gh pr create  # open a PR
+gh pr create --base main
 ```
 
-### CI
+## CI
 
 CI runs on Depot. Workflows in `.depot/workflows/`:
-- `release.yaml` — builds Go binaries on tag push
+- `release.yaml` — builds Go binaries on tag push, updates Homebrew formula
 - `test.yaml` — unit tests + shellcheck + container tests on PR
+
+**Important:** Depot does NOT support `release` event trigger — only `push`/`pull_request`/`tag`.
 
 ## Key Files
 
 ```
 cmd/                    CLI commands
-cmd/claw-bridge/        claw-bridge binary (WS proxy on each VM)
-pkg/hub/server.go       Hub server — REST, WS, lifecycle, bootstrap
-pkg/hub/bootstrap.go    Pure function: GenerateReplicatedBootstrapScript()
-pkg/hub/github.go       GitHub App token generation
-pkg/install/scripts.go  Install script generation (pure functions, tested)
-pkg/types/              Shared types
-pkg/config/             Config loading
-pkg/provider/           Provider implementations
-web/                    Next.js web UI (static export)
+  install.go            elasticclaw install (provisions hub on remote server)
+  hub_upgrade.go        elasticclaw hub upgrade (upgrades remote hub via SSH)
+  upgrade.go            elasticclaw upgrade (upgrades local CLI)
+pkg/hub/
+  server.go             Hub server — REST, WS, claw lifecycle, provider polling
+  linear.go             Linear webhook handler, factory engine
+  bootstrap.go          GenerateReplicatedBootstrapScript() — pure function
+  settings.go           GET/PATCH /api/settings
+  templates.go          Hub template storage
+  db.go                 InitDB — SQLite schema + migrations
+pkg/install/scripts.go  Install script generation (pure, tested)
+pkg/types/template.go   FactoryConfig, HubConfig, etc.
+pkg/config/hub.go       Hub config loading
+pkg/provider/replicated/ Replicated CMX provider
+web/                    Next.js web UI
+  app/settings/page.tsx Settings page (Runtimes, LLM, GitHub, Integrations, Factories)
+  app/factories/[name]/ Factory activity page
+  hooks/use-hub.ts      WS + polling, message/claw state
 internal/webui/         Embed package for web UI binary
-.elasticclaw/templates/ Template definitions (you are in one right now)
+.elasticclaw/templates/ Template definitions
 ```
 
 ## Safety
 
 - `go build ./...` must pass before any Go commit
 - `go test ./...` must pass
-- Never put API keys, tokens, or secrets in the repo (it's public, Apache 2.0)
+- Never put API keys, tokens, or secrets in the repo (public, Apache 2.0)
 - PR for non-trivial changes, direct push for obvious fixes
+
+## When You're Done with a Linear Issue
+
+Send exactly this message:
+```
+[DONE]
+```
+This signals the factory engine to move the Linear issue to the done status and terminate this claw.

--- a/.elasticclaw/templates/elasticclaw/MEMORY.md
+++ b/.elasticclaw/templates/elasticclaw/MEMORY.md
@@ -9,73 +9,176 @@ Repo: github.com/elasticclaw/elasticclaw
 
 - **Hub** (`pkg/hub/server.go`) — Go HTTP/WS server, SQLite backing, manages claw lifecycle
 - **claw-bridge** (`cmd/claw-bridge/`) — runs on each VM, persistent WS → hub, proxies gateway
-- **CLI** (`cmd/`) — login, list, create, chat, kill, template, hub, install, profile
+- **CLI** (`cmd/`) — login, list, create, chat, kill, template, hub, install, profile, upgrade
 - **Web UI** (`web/`) — Next.js static export, embedded in Go binary via `//go:embed all:out`
 - **Providers** — `pkg/provider/replicated`, `daytona`, `vercel`, `local`
 - **Relay** (`relay` repo) — optional TURN-style WS proxy for NAT traversal
 
-### Single binary architecture (feat/embedded-web, merged to main)
-- `make build` = Go only, no web (fast dev iteration)
+### Single binary architecture
+- `make build` = Go only, no web (fast dev)
 - `make build-release` = npm build → copy to `internal/webui/out/` → go build with `-tags embedweb`
 - `//go:embed all:out` required (not `//go:embed out`) to include `_next/` directory
-- `http.FileServer` causes 301 redirects — use `fs.ReadFile` directly for static serving
+- `http.FileServer` causes 301 redirects — use `fs.ReadFile` directly
 - No Next.js middleware, no cookies — auth via sessionStorage `ec_hub_token`
 
 ### Auth model
 - Login: `POST /api/auth/login` with `{password}` → returns `{hubToken}`
 - Browser stores `ec_hub_token` in sessionStorage
 - All hub calls: `Authorization: Bearer <hubToken>`
-- Hub validates against `hubCfg.Token` (same token for API and web UI)
+- Hub validates against `hubCfg.Token`
 - `ui_password:` in hub.yaml sets the login password
 
 ### Key decisions
-
-- Single-tenant OSS only (no SaaS, no master token)
+- Single-tenant OSS only (no SaaS)
 - SQLite backing
 - bridge_image in hub.yaml: set → use as-is OCI ref; unset + tagged → GitHub releases; unset + dev → fail
 - Relay is explicit opt-in via `relay_url` / `relay_secret`
-- claw-bridge has 32MB WS read limit
 - Credential helper calls hub AFTER bridge starts (hub API reachable via bridge proxy)
 - Config: `/etc/elasticclaw/hub.yaml` (system) or `~/.elasticclaw/hub.yaml` (dev)
 - Data: `/var/lib/elasticclaw/` (system) or `~/.elasticclaw/` (dev)
 
-### Install command
-- `elasticclaw install --server ssh://user@ip --domain hub.example.com`
-- No Docker needed — single binary handles everything
-- Caddy config: single `reverse_proxy localhost:8080` (not split routing)
-- `elasticclaw hub service install` for manual systemd setup on server
-- `elasticclaw hub caddy install --domain hub.example.com` for Caddy
+---
 
-### Bootstrap sequence (Replicated)
-1. Apt: Node 24, git
-2. `npm install -g openclaw@latest`
-3. Configure OpenClaw (model, gateway password, auth)
-4. Start gateway, wait for :18789
-5. Download claw-bridge (OCI or GitHub releases)
-6. Start bridge, wait for connection
-7. Install GitHub credential helper (AFTER bridge)
-8. Clone repos
+## Factories — How They Work
 
-### Hub env vars (web)
-- `NEXT_PUBLIC_HUB_URL` — browser-visible hub URL for dev (not a secret)
-- No server-side env needed in production (same-origin)
+Factories auto-spawn and terminate claws based on external events.
 
-### CI
-- Depot-based (`.depot/workflows/`)
-- `release.yaml` — Go binaries on tag push
-- `release-web.yaml` — Docker image (deprecated, now embedded)
-- `test.yaml` — unit tests + shellcheck + container integration tests on PR
+### Linear factory
 
-### Known gotchas
-- `tsconfig.tsbuildinfo` causes merge conflicts — always resolve with `--theirs`
-- Linux-only npm deps must be in `optionalDependencies`
-- `isRedirectError` is in `next/dist/client/components/redirect-error`
-- `trailingSlash: true` causes 308 loops in dev — only enable in prod static export
-- `SilenceUsage: true` on cobra root command to avoid wall of help text on errors
-- Replicated VMs use SSH proxy that rejects arbitrary bash commands (not suitable for `install`)
+**Config in hub.yaml:**
+```yaml
+integrations:
+  linear:
+    - workspace: my-company       # label matching factory.workspace
+      api_key: lin_api_...        # Linear API key (moves issues, reads state)
+      # webhook_secret is per-factory now, not here
 
-### Claw features
-- **Tags**: flat strings (e.g. `template:elasticclaw`, `nix`), auto-assigned `template:<name>`
-- **Color**: 16 named accent colors, auto-assigned from name hash
-- **Rename**: inline from UI card
-- **Auto-wake**: hub sends silent intro message when claw first connects
+factories:
+  - name: feature-factory
+    integration: linear
+    workspace: my-company
+    team: ELA                     # Linear team key (optional, all teams if omitted)
+    trigger_status: "Ready for Agent"
+    done_status: "In Review"
+    terminate_on_leave: true      # kill claw if issue leaves trigger_status
+    template: base                # template name (must be pushed to hub)
+    webhook_secret: whsec_...     # HMAC-SHA256 signing secret from Linear webhook
+    tags:                         # applied to created claws (factory:<name> always added)
+      - linear
+      - feature
+    color: teal                   # color for claw card
+    name_pattern: "{issue_id}"    # claw name pattern (optional)
+```
+
+**Webhook URL:** `https://<hub-domain>/api/integrations/linear/webhook`
+
+**Flow:**
+1. Linear sends webhook on issue status change
+2. Hub validates HMAC-SHA256 signature using factory's `webhook_secret`
+3. `processLinearEvent()` checks each factory for matching workspace/team
+4. Issue entering `trigger_status` → `createClawForIssue()`:
+   - Enforces 1:1 (no duplicate claws per issue)
+   - Resolves template files, injects `CONTEXT.md` with issue details
+   - Inserts claw record with `linear_issue_id`, `tags`, `color`
+   - Provisions VM async (Replicated CMX)
+   - Broadcasts `claw_status: provisioning` over WS (dashboard appears immediately)
+5. Issue leaving `trigger_status` → `terminateClawForIssue()`:
+   - Queries DB by `linear_issue_id` (not by previousStatus — Linear omits it sometimes)
+   - Closes WS, marks `status='deleted'`
+   - Broadcasts `claw_status: deleted` over WS (card vanishes immediately)
+   - If VM still provisioning: goroutine checks status='deleted' and calls `DeleteVM()`
+6. Claw sends `[DONE]` message → `handleClawDoneSignal()`:
+   - Moves issue to `done_status` via Linear GraphQL
+   - Terminates claw
+
+**CONTEXT.md injected:**
+```markdown
+# Linear Issue Context
+
+**Title:** Fix login redirect bug
+**ID:** ENG-123
+**Status:** In Progress
+**URL:** https://linear.app/.../ENG-123
+
+## Description
+...
+```
+
+### Race condition fixes (important)
+- Poller (`pollProviderStatus`) excludes `status='deleted'` — won't re-bootstrap deleted claws
+- `bootstrapReplicated` checks status at entry; if deleted, calls `DeleteVM` and returns
+- DB status UPDATEs use `AND status != 'deleted'` guard
+- `terminateClawForIssue` queries DB directly (not previousStatus from webhook payload)
+
+### Factory activity log
+- Table: `factory_events` (auto-pruned >4h)
+- Actions: `claw_created`, `claw_terminated`, `error`, `not_actionable`
+- API: `GET /api/factories/:name/events`
+- UI: Settings → Factories → Activity link per factory
+- `not_actionable` events still logged (for debugging wrong status names, etc.)
+
+### Done signal
+Agent sends `[DONE]` as a chat message → hub detects → moves Linear issue → terminates claw.
+Add to agent template AGENTS.md:
+```markdown
+When your task is complete, send exactly:
+[DONE]
+This closes the Linear issue and terminates this session.
+```
+
+---
+
+## Settings UI
+
+Settings page at `/settings` with these sections:
+- **Sandbox Runtimes** — Replicated CMX token, Daytona URL/key/snapshot
+- **LLM Keys** — Anthropic, OpenAI, etc. (injected as env vars at bootstrap)
+- **GitHub Apps** — SSH public keys, App config
+- **Security** — UI password change
+- **Integrations** — Linear workspaces (label + API token)
+- **Factories** — webhook URL display + copy, factory list with Edit/Activity/Remove, new factory form
+
+Settings API: `GET/PATCH /api/settings` — reads/writes hub.yaml live (restarts in-memory config).
+
+---
+
+## Key Bugs Fixed (don't repeat)
+
+- `{ }` bash group command in bootstrap → use `( )` subshell instead
+- `sshRun()` was using `CombinedOutput(script)` which ran via `/bin/sh` (dash on Ubuntu) — fixed to pipe via stdin to `/bin/bash`
+- Optimistic user messages (`opt-*`) filtered from localStorage — fixed by replacing with real UUID after API returns
+- `loadMessages()` not called on refresh if claw already selected — fixed with mount effect
+- `linear_issue_id` column missing from fresh DB `CREATE TABLE` (was ALTER TABLE only)
+- Poller resurrecting deleted claws — exclude `deleted` from poller query
+- LIKE `%factory:NAME%` matches prefixes — use `linear_issue_id` directly instead
+
+---
+
+## Known Gotchas
+
+- `tsconfig.tsbuildinfo` causes merge conflicts — resolve with `--theirs`
+- CI: Depot only, NOT GitHub Actions. Workflows in `.depot/workflows/`
+- `release.yaml` triggers on tag push only — Depot doesn't support `release` event
+- SilenceUsage: true on cobra root (prevents help wall on errors)
+- `make build` does NOT embed web UI — use `make build-release` for production binary
+- Bootstrap heredocs must NOT be PROFEOF-style when piped via stdin — use `printf`
+- Replicated VM SSH proxy rejects arbitrary bash commands
+
+---
+
+## Open / Planned Work
+
+### Factory improvements needed
+- Webhook signature validation: currently validates against integration-level `webhook_secret`; recently moved to factory-level. Ensure linear.go validates per-factory not per-integration.
+- Factory UI should show "currently active claws" count per factory
+- Support multiple factories per Linear workspace (already works, just needs testing)
+- Daytona provider support for factory-created claws
+- GitHub Issues factory (next integration after Linear)
+- Cron factory (time-based spawning)
+
+### General
+- `elasticclaw hub upgrade` — upgrades remote hub binary via SSH (done, in feat/upgrade-command)
+- `elasticclaw upgrade` — upgrades local CLI binary (done)
+- Template registry at `github.com/elasticclaw/elasticclaw-templates`
+- Relay: test with Caddy directly on VPS (Cloudflare idle timeout blocks WS)
+- Bootstrap test that executes via stdin (catches bash-specific syntax issues)

--- a/.elasticclaw/templates/elasticclaw/TOOLS.md
+++ b/.elasticclaw/templates/elasticclaw/TOOLS.md
@@ -3,9 +3,9 @@
 ## Repo
 
 The `elasticclaw/elasticclaw` repo is cloned into your workspace.
-Check: `ls ~/.openclaw/workspace/` or `ls ~/`
 
 ```bash
+alias ws="~/.openclaw/workspace/elasticclaw"
 cd ~/.openclaw/workspace/elasticclaw
 ```
 
@@ -16,7 +16,7 @@ Tokens are fetched automatically from the hub — you don't need to set anything
 
 ```bash
 git clone https://github.com/elasticclaw/elasticclaw  # works without auth prompt
-gh pr create                                           # works
+gh pr create --base main                               # works
 gh issue list --repo elasticclaw/elasticclaw           # works
 ```
 
@@ -24,14 +24,14 @@ Token is scoped: **write** on `elasticclaw/elasticclaw`.
 
 ## Go
 
-Go is NOT pre-installed by default. Use nix if available, otherwise install:
+Go is NOT pre-installed by default. Install if needed:
 ```bash
 curl -fsSL https://go.dev/dl/go1.23.4.linux-amd64.tar.gz | sudo tar -C /usr/local -xz
 export PATH=$PATH:/usr/local/go/bin
 echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc
 ```
 
-Or if nix is enabled: it's already there via the flake.
+Or if nix is enabled in the template: it's already there via the flake.
 
 Check: `go version`
 
@@ -42,7 +42,7 @@ Node 24 is pre-installed: `node --version`, `npm --version`
 ```bash
 cd ~/.openclaw/workspace/elasticclaw/web
 npm install
-npm run dev   # dev server on :3000 (requires NEXT_PUBLIC_HUB_URL)
+npm run dev   # dev server on :3000
 ```
 
 ## OpenClaw
@@ -57,71 +57,66 @@ Gateway logs: `~/openclaw-gateway.log`
 claw-bridge is running in the background connecting this VM to the hub.
 Logs: `~/claw-bridge.log`
 
-Don't kill it — you'll lose your connection.
+Don't kill it — you'll lose your connection to the hub.
 
 ## Build Commands
 
 ```bash
-make build          # Go only, fast (dev iteration)
+make build          # Go only, fast (no web UI — dev iteration)
 make build-release  # Full: web UI + Go binary (requires npm)
-make build-dev      # Alias for make build
 make build-web      # npm build → copy to internal/webui/out/
 make test           # Go unit tests
 make test-bootstrap # Bootstrap script tests
 make test-install   # Container integration test for install scripts
 ```
 
-## Architecture: How This VM Got Here
+## Hub Architecture
 
-1. User ran `elasticclaw create --template elasticclaw` from the hub CLI
-2. Hub provisioned a Replicated CMX VM (r1.large)
-3. Hub SSHed in and ran the bootstrap script:
+The hub binary:
+- Serves REST API (`/api/*`) + WS (`/api/ws`)
+- Serves embedded web UI at `/` (static Next.js export)
+- Manages claw lifecycle (provision, bootstrap, poll, kill)
+- Runs factory engine (Linear webhook → spawn/kill claws)
+- Stores everything in SQLite
+
+**Config:** `/etc/elasticclaw/hub.yaml` (system) or `~/.elasticclaw/hub.yaml` (dev)
+**DB:** `/var/lib/elasticclaw/hub.db` (system) or `~/.elasticclaw/hub.db` (dev)
+
+## Factory Engine (this is likely why you're here)
+
+If you have a `CONTEXT.md`, a factory spawned you for a Linear issue.
+
+The factory system is in `pkg/hub/linear.go`:
+- `handleLinearWebhook()` — receives webhook, validates HMAC sig
+- `processLinearEvent()` — matches factory config, dispatches create/terminate
+- `createClawForIssue()` — provisions VM, injects CONTEXT.md
+- `terminateClawForIssue()` — closes WS, marks deleted, destroys VM if mid-provision
+- `handleClawDoneSignal()` — called when claw sends `[DONE]`
+
+**When you're done:** Send `[DONE]` as a message. This moves the Linear issue and kills you.
+
+## Bootstrap Sequence (how you got here)
+
+1. Linear issue moved to trigger status → webhook hit hub
+2. Hub called `createClawForIssue()`:
+   - Resolved template, injected CONTEXT.md
+   - Inserted claw record with `linear_issue_id`, tags, color
+   - Provisioned Replicated CMX VM
+3. VM booted → bootstrap script ran:
    - Installed Node 24, OpenClaw, claw-bridge
-   - Configured OpenClaw with model + gateway password
+   - Configured OpenClaw (model, gateway password)
    - Started gateway (port 18789) + bridge (WS to hub)
-   - Installed git credential helper (fetches GitHub App tokens)
-   - Cloned this repo into workspace
-4. Bridge registered with hub → status became "online"
-5. Hub sent intro message → you replied
-
-## Single Binary Architecture (important!)
-
-The web UI is **embedded in the Go binary** via `//go:embed all:out`.
-
-Key files:
-- `internal/webui/embed.go` — embed directive (build tag: `embedweb`)
-- `internal/webui/embed_stub.go` — stub when not embedded
-- `internal/webui/out/` — built Next.js static export (gitignored, populated by `make build-web`)
-
-`make build` does NOT embed web (uses stub). `make build-release` embeds it.
-
-## Hub Config Paths
-
-- System: `/etc/elasticclaw/hub.yaml` + `/var/lib/elasticclaw/`
-- Dev: `~/.elasticclaw/hub.yaml` + `~/.elasticclaw/`
-
-## Install Command
-
-```bash
-elasticclaw install \
-  --server ssh://root@ip \
-  --domain hub.example.com \
-  --anthropic-key sk-ant-... \
-  [--version v0.0.9] \
-  [--skip-caddy]
-```
-
-Or manual on the server:
-```bash
-sudo elasticclaw hub service install
-sudo elasticclaw hub caddy install --domain hub.example.com
-```
+   - Installed git credential helper
+   - Cloned `elasticclaw/elasticclaw` repo to workspace
+4. Bridge connected → hub sent intro message → you're here
 
 ## Debugging Tips
 
-- Bridge not connecting? Check `~/claw-bridge.log`
-- Gateway not responding? Check `~/openclaw-gateway.log`
+- Bridge not connecting? `cat ~/claw-bridge.log`
+- Gateway not responding? `cat ~/openclaw-gateway.log`
 - GitHub auth not working? Credential helper calls hub at `$ELASTICCLAW_HUB_URL/api/github/token/$ELASTICCLAW_CLAW_ID`
-- Web UI 404? Did you `make build-release`? Check `internal/webui/out/` has `index.html`
-- White page? Missing `_next/` in embedded files — ensure `//go:embed all:out` (not `//go:embed out`)
-- 301 redirect loop? Don't use `http.FileServer` for embedded files, use `fs.ReadFile`
+- Web UI 404? `make build-release` + check `internal/webui/out/` has `index.html`
+- White page? Missing `_next/` — ensure `//go:embed all:out` (not `//go:embed out`)
+- 301 redirect loop? Don't use `http.FileServer` — use `fs.ReadFile` directly
+- Bootstrap syntax error? Script runs via `/bin/bash` stdin — avoid `PROFEOF`-style heredocs, use `printf`
+- Claw resurrection after delete? Check `pollProviderStatus` excludes `deleted` and `bootstrapReplicated` has deleted guard


### PR DESCRIPTION
Updates `.elasticclaw/templates/elasticclaw/` with everything a new claw needs to hit the ground running on factory-driven work.

**MEMORY.md:**
- Full Linear factory architecture (webhook flow, hub.yaml config, CONTEXT.md injection, done signal)
- Race condition fixes (don't repeat them)
- Factory activity log details
- All known bugs we fixed today
- Open/planned factory work

**AGENTS.md:**
- Read CONTEXT.md on startup (factory injects Linear issue details)
- `[DONE]` signal with exact syntax
- Updated key files list (linear.go, factory activity page, settings)

**TOOLS.md:**
- Factory engine section with full file map
- Bootstrap sequence explanation
- `[DONE]` reminder
- New debugging tips (claw resurrection, bootstrap syntax errors)