### PR TITLE
fix: factory activity page — static route + CI web build check

### DIFF
--- a/.depot/workflows/test.yaml
+++ b/.depot/workflows/test.yaml
@@ -48,3 +48,24 @@ jobs:
 
       - name: Build claw-bridge (linux)
         run: make build-bridge-linux
+
+  web:
+    name: Web UI build
+    runs-on: depot-ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: web
+
+      - name: Build (static export)
+        run: npm run build
+        working-directory: web

--- a/.depot/workflows/test.yaml
+++ b/.depot/workflows/test.yaml
@@ -59,11 +59,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
-          cache: npm
-          cache-dependency-path: web/package-lock.json
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
         working-directory: web
 
       - name: Build (static export)

--- a/web/app/factories/page.tsx
+++ b/web/app/factories/page.tsx
@@ -57,6 +57,7 @@ function FactoryEventsContent() {
   const [lastRefresh, setLastRefresh] = useState<Date | null>(null)
 
   const load = useCallback(async () => {
+    if (!name) return
     setLoading(true)
     try {
       const hubUrl = getHubUrl()
@@ -74,9 +75,28 @@ function FactoryEventsContent() {
 
   // Auto-refresh every 30s
   useEffect(() => {
+    if (!name) return
     const t = setInterval(load, 30_000)
     return () => clearInterval(t)
-  }, [load])
+  }, [load, name])
+
+  if (!name) {
+    return (
+      <div className="min-h-screen bg-background">
+        <header className="border-b border-border px-6 py-4 flex items-center gap-4">
+          <Button variant="ghost" size="icon" onClick={() => window.location.href = "/settings"}>
+            <ChevronLeft className="size-4" />
+          </Button>
+        </header>
+        <div className="max-w-3xl mx-auto px-6 py-8">
+          <div className="text-center py-16 space-y-2">
+            <p className="text-sm font-medium text-muted-foreground">Missing factory name</p>
+            <p className="text-xs text-muted-foreground">Please provide a factory name in the URL query parameter.</p>
+          </div>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div className="min-h-screen bg-background">

--- a/web/app/factories/page.tsx
+++ b/web/app/factories/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
-import { useState, useEffect, useCallback } from "react"
-import { useParams } from "next/navigation"
+import { useState, useEffect, useCallback, Suspense } from "react"
+import { useSearchParams } from "next/navigation"
 import { getHubUrl } from "@/lib/hub-url"
 import { Button } from "@/components/ui/button"
 import { ChevronLeft, RefreshCw, CheckCircle, XCircle, AlertCircle, Zap } from "lucide-react"
@@ -49,9 +49,9 @@ function formatTime(ts: string): string {
     " · " + d.toLocaleDateString([], { month: "short", day: "numeric" })
 }
 
-export default function FactoryEventsPage() {
-  const params = useParams<{ name: string }>()
-  const name = decodeURIComponent(params.name)
+function FactoryEventsContent() {
+  const searchParams = useSearchParams()
+  const name = searchParams.get("name") ?? ""
   const [events, setEvents] = useState<FactoryEvent[]>([])
   const [loading, setLoading] = useState(true)
   const [lastRefresh, setLastRefresh] = useState<Date | null>(null)
@@ -146,5 +146,14 @@ export default function FactoryEventsPage() {
         )}
       </div>
     </div>
+  )
+}
+
+
+export default function FactoryEventsPage() {
+  return (
+    <Suspense fallback={<div className="min-h-screen bg-background flex items-center justify-center"><p className="text-sm text-muted-foreground animate-pulse">Loading…</p></div>}>
+      <FactoryEventsContent />
+    </Suspense>
   )
 }

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -688,7 +688,7 @@ function FactoriesSection({ hubUrl, settings, onSave, saving }: { hubUrl: string
                     </p>
                   </div>
                   <div className="flex items-center gap-2">
-                    <a href={`/factories/${encodeURIComponent(f.name)}`} className="text-xs text-primary hover:underline whitespace-nowrap">Activity</a>
+                    <a href={`/factories?name=${encodeURIComponent(f.name)}`} className="text-xs text-primary hover:underline whitespace-nowrap">Activity</a>
                     <Button size="sm" variant="outline" onClick={() => {
                       setEditingFactory(i)
                       setEditForm({ name: f.name, workspace: f.workspace, team: f.team || "", triggerStatus: f.triggerStatus, doneStatus: f.doneStatus || "", terminateOnLeave: f.terminateOnLeave, template: f.template, webhookSecret: "", tags: (f.tags || []).join(", "), color: f.color || "", originalName: f.name })


### PR DESCRIPTION
**Problem:** `/factories/[name]` is a dynamic route. Next.js static export (`output: 'export'`) requires `generateStaticParams()` for dynamic routes, but factory names aren't known at build time.

**Fix:** Move to `/factories?name=<name>` — a static page that reads the factory name from query params client-side. Uses `useSearchParams` wrapped in `<Suspense>` (required for static export).

**Bonus:** Adds a `web` CI job to `test.yaml` that runs `npm run build` on every PR, so this class of error is caught before release.