### PR TITLE
fix: redirect to /login on 401 instead of 'cannot reach hub'

### DIFF
--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -69,6 +69,14 @@ async function apiFetch<T>(path: string, options?: RequestInit): Promise<T> {
       ...options?.headers,
     },
   })
+  if (res.status === 401) {
+    // Token expired or invalid — clear it and redirect to login
+    sessionStorage.removeItem("ec_hub_token")
+    if (typeof window !== "undefined" && !window.location.pathname.startsWith("/login")) {
+      window.location.href = "/login"
+    }
+    throw new Error("session expired")
+  }
   if (!res.ok) {
     throw new Error(`API error ${res.status}: ${await res.text()}`)
   }

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -71,7 +71,7 @@ async function apiFetch<T>(path: string, options?: RequestInit): Promise<T> {
   })
   if (res.status === 401) {
     // Token expired or invalid — clear it and redirect to login
-    sessionStorage.removeItem("ec_hub_token")
+    clearConfig()
     if (typeof window !== "undefined" && !window.location.pathname.startsWith("/login")) {
       window.location.href = "/login"
     }

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -74,6 +74,9 @@ async function apiFetch<T>(path: string, options?: RequestInit): Promise<T> {
     clearConfig()
     if (typeof window !== "undefined" && !window.location.pathname.startsWith("/login")) {
       window.location.href = "/login"
+      // Return a never-resolving promise to prevent the error from propagating
+      // and triggering the "Cannot reach hub" error screen before navigation completes
+      return new Promise(() => {})
     }
     throw new Error("session expired")
   }


### PR DESCRIPTION
Any API 401 clears the session token and redirects to `/login`. Previously it threw an error that landed as 'Cannot reach hub' — wrong message, wrong recovery path.

Root cause: after a hub restart with a changed token, the browser's stale `ec_hub_token` got 401s from every API call, which `refreshClaws` caught and set as `hubError`.