### PR TITLE
fix: factory create fires even when Linear omits previousStatus

### DIFF
--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -141,9 +141,9 @@ func (s *Server) processLinearEvent(payload linearWebhookPayload) {
 		}
 
 		// Issue entering trigger status → create claw.
-		// Don't rely on previousStatus — Linear sometimes omits it.
-		// The 1:1 DB guard in createClawForIssue handles duplicate prevention.
-		if strings.EqualFold(currentStatus, factory.TriggerStatus) {
+		// Only create when transitioning into the trigger status (not already in it).
+		// When previousStatus is empty (Linear omits it), EqualFold returns false, so the guard passes.
+		if strings.EqualFold(currentStatus, factory.TriggerStatus) && !strings.EqualFold(previousStatus, factory.TriggerStatus) {
 			matched = true
 			log.Printf("[factory:%s] issue %s entered '%s' — creating claw", factory.Name, issueID, factory.TriggerStatus)
 			clawID := ""

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -140,8 +140,10 @@ func (s *Server) processLinearEvent(payload linearWebhookPayload) {
 			continue
 		}
 
-		// Issue entering trigger status → create claw
-		if previousStatus != "" && strings.EqualFold(currentStatus, factory.TriggerStatus) && !strings.EqualFold(previousStatus, factory.TriggerStatus) {
+		// Issue entering trigger status → create claw.
+		// Don't rely on previousStatus — Linear sometimes omits it.
+		// The 1:1 DB guard in createClawForIssue handles duplicate prevention.
+		if strings.EqualFold(currentStatus, factory.TriggerStatus) {
 			matched = true
 			log.Printf("[factory:%s] issue %s entered '%s' — creating claw", factory.Name, issueID, factory.TriggerStatus)
 			clawID := ""


### PR DESCRIPTION
Linear doesn't always send `previousStatus` in webhook payloads. The create path was guarded with `previousStatus != ""` so it logged 'not actionable' and never spawned a claw.\n\nFix: remove the guard. The 1:1 DB check in `createClawForIssue` already prevents duplicate claws per issue.