### PR TITLE
feat: PR watcher — auto fix CI and bugbot on detected PRs

### DIFF
--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -102,10 +102,11 @@ func migrate(db *sql.DB) error {
 		claw_id     TEXT NOT NULL REFERENCES claws(id),
 		repo        TEXT NOT NULL,  -- e.g. "owner/repo"
 		pr_number   INTEGER NOT NULL,
-		pr_url      TEXT NOT NULL UNIQUE,
+		pr_url      TEXT NOT NULL,
 		last_ci_sha TEXT NOT NULL DEFAULT '',   -- last SHA we checked CI on
 		last_comment_id INTEGER NOT NULL DEFAULT 0, -- last bugbot comment ID seen
-		created_at  DATETIME NOT NULL
+		created_at  DATETIME NOT NULL,
+		UNIQUE(claw_id, pr_url)
 	);
 
 	CREATE TABLE IF NOT EXISTS factory_events (

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -36,6 +36,8 @@ func migrate(db *sql.DB) error {
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN tags TEXT NOT NULL DEFAULT '[]'`)
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN color TEXT NOT NULL DEFAULT ''`)
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN linear_issue_id TEXT NOT NULL DEFAULT ''`)
+	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN auto_fix_ci INTEGER NOT NULL DEFAULT 1`)
+	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN auto_fix_bugbot INTEGER NOT NULL DEFAULT 1`)
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN llm_key TEXT NOT NULL DEFAULT ''`)
 
 	_, err := db.Exec(`
@@ -69,6 +71,8 @@ func migrate(db *sql.DB) error {
 		tags             TEXT NOT NULL DEFAULT '[]',
 		color            TEXT NOT NULL DEFAULT '',
 		linear_issue_id  TEXT NOT NULL DEFAULT '',
+		auto_fix_ci      INTEGER NOT NULL DEFAULT 1,
+		auto_fix_bugbot  INTEGER NOT NULL DEFAULT 1,
 		llm_key          TEXT NOT NULL DEFAULT ''
 	);
 
@@ -91,6 +95,17 @@ func migrate(db *sql.DB) error {
 		files      TEXT NOT NULL DEFAULT '{}',  -- JSON map of filename -> content
 		created_at DATETIME NOT NULL,
 		updated_at DATETIME NOT NULL
+	);
+
+	CREATE TABLE IF NOT EXISTS claw_prs (
+		id          TEXT PRIMARY KEY,
+		claw_id     TEXT NOT NULL REFERENCES claws(id),
+		repo        TEXT NOT NULL,  -- e.g. "owner/repo"
+		pr_number   INTEGER NOT NULL,
+		pr_url      TEXT NOT NULL UNIQUE,
+		last_ci_sha TEXT NOT NULL DEFAULT '',   -- last SHA we checked CI on
+		last_comment_id INTEGER NOT NULL DEFAULT 0, -- last bugbot comment ID seen
+		created_at  DATETIME NOT NULL
 	);
 
 	CREATE TABLE IF NOT EXISTS factory_events (

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -54,10 +54,11 @@ func (s *Server) storePRMention(clawID, repo string, prNumber int, prURL string)
 	if existing != "" {
 		return
 	}
-	
-	// Get the current max comment ID to avoid flooding with historical comments
+
+	// Get the current max comment ID and head SHA to avoid flooding with historical data
 	token := s.resolveGitHubToken()
 	var maxCommentID int64
+	var headSHA string
 	if token != "" {
 		commentsData, err := githubAPIList(fmt.Sprintf("repos/%s/issues/%d/comments", repo, prNumber), token)
 		if err == nil {
@@ -70,11 +71,18 @@ func (s *Server) storePRMention(clawID, repo string, prNumber int, prURL string)
 				}
 			}
 		}
+
+		prData, err := githubAPI(fmt.Sprintf("repos/%s/pulls/%d", repo, prNumber), token)
+		if err == nil {
+			if headObj, ok := prData["head"].(map[string]interface{}); ok {
+				headSHA, _ = headObj["sha"].(string)
+			}
+		}
 	}
-	
+
 	_, _ = s.db.Exec(
-		`INSERT INTO claw_prs(id,claw_id,repo,pr_number,pr_url,last_comment_id,created_at) VALUES(?,?,?,?,?,?,?)`,
-		uuid.New().String(), clawID, repo, prNumber, prURL, maxCommentID, now(),
+		`INSERT INTO claw_prs(id,claw_id,repo,pr_number,pr_url,last_comment_id,last_ci_sha,created_at) VALUES(?,?,?,?,?,?,?,?)`,
+		uuid.New().String(), clawID, repo, prNumber, prURL, maxCommentID, headSHA, now(),
 	)
 	log.Printf("[pr-watcher] detected PR %s#%d for claw %s", repo, prNumber, clawID[:8])
 }

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -14,13 +14,22 @@ import (
 
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 	"github.com/google/uuid"
+	"nhooyr.io/websocket/wsjson"
 )
 
 var prURLRegex = regexp.MustCompile(`https://github\.com/([a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+)/pull/(\d+)`)
 
 // extractPRs finds GitHub PR URLs in a message body.
-func extractPRs(content string) []struct{ repo string; number int; url string } {
-	var results []struct{ repo string; number int; url string }
+func extractPRs(content string) []struct {
+	repo   string
+	number int
+	url    string
+} {
+	var results []struct {
+		repo   string
+		number int
+		url    string
+	}
 	seen := map[string]bool{}
 	for _, m := range prURLRegex.FindAllStringSubmatch(content, -1) {
 		url := m[0]
@@ -29,7 +38,11 @@ func extractPRs(content string) []struct{ repo string; number int; url string } 
 		}
 		seen[url] = true
 		num, _ := strconv.Atoi(m[2])
-		results = append(results, struct{ repo string; number int; url string }{m[1], num, url})
+		results = append(results, struct {
+			repo   string
+			number int
+			url    string
+		}{m[1], num, url})
 	}
 	return results
 }
@@ -67,12 +80,12 @@ func (s *Server) startPRWatcher() {
 }
 
 type clawPR struct {
-	id           string
-	clawID       string
-	repo         string
-	prNumber     int
-	prURL        string
-	lastCISHA    string
+	id            string
+	clawID        string
+	repo          string
+	prNumber      int
+	prURL         string
+	lastCISHA     string
 	lastCommentID int64
 }
 
@@ -90,8 +103,8 @@ func (s *Server) pollAllPRs() {
 	defer rows.Close()
 
 	type row struct {
-		pr           clawPR
-		autoFixCI    bool
+		pr            clawPR
+		autoFixCI     bool
 		autoFixBugbot bool
 	}
 	var prs []row
@@ -152,8 +165,12 @@ func (s *Server) checkCIFailures(pr clawPR, token string) {
 	if err != nil {
 		return
 	}
-	headSHA, _ := prData["head"].(map[string]interface{})["sha"].(string)
-	if headSHA == "" || headSHA == pr.lastCISHA {
+	headObj, ok := prData["head"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	headSHA, ok := headObj["sha"].(string)
+	if !ok || headSHA == "" || headSHA == pr.lastCISHA {
 		return // no new commits
 	}
 
@@ -165,18 +182,27 @@ func (s *Server) checkCIFailures(pr clawPR, token string) {
 
 	checkRuns, _ := checksData["check_runs"].([]interface{})
 	var failures []string
+	allCompleted := true
 	for _, cr := range checkRuns {
 		run, _ := cr.(map[string]interface{})
+		status, _ := run["status"].(string)
 		conclusion, _ := run["conclusion"].(string)
 		name, _ := run["name"].(string)
+
+		if status != "completed" || conclusion == "" {
+			allCompleted = false
+		}
+
 		if conclusion == "failure" || conclusion == "timed_out" {
 			detailsURL, _ := run["details_url"].(string)
 			failures = append(failures, fmt.Sprintf("**%s** — [view logs](%s)", name, detailsURL))
 		}
 	}
 
-	// Update last CI SHA
-	_, _ = s.db.Exec(`UPDATE claw_prs SET last_ci_sha=? WHERE id=?`, headSHA, pr.id)
+	// Only update SHA if all checks have completed or if we found failures
+	if len(failures) > 0 || allCompleted {
+		_, _ = s.db.Exec(`UPDATE claw_prs SET last_ci_sha=? WHERE id=?`, headSHA, pr.id)
+	}
 
 	if len(failures) == 0 {
 		return
@@ -242,18 +268,26 @@ func (s *Server) checkBugbotComments(pr clawPR, token string) {
 // and forwards it over the WS connection (if connected) so the agent sees it.
 // Skips injection if the claw is currently streaming a response.
 func (s *Server) injectUserMessage(clawID, content string) {
+	s.injectUserMessageWithRetry(clawID, content, 0)
+}
+
+func (s *Server) injectUserMessageWithRetry(clawID, content string, retryCount int) {
 	// Don't interrupt a response in progress
 	s.mu.RLock()
 	cc, connected := s.claws[clawID]
 	streaming := connected && cc.streamingBuf.Len() > 0
 	s.mu.RUnlock()
 	if streaming {
-		log.Printf("[pr-watcher] claw %s is streaming, delaying injection", clawID[:8])
-		// Retry once after 30s
-		go func() {
-			time.Sleep(30 * time.Second)
-			s.injectUserMessage(clawID, content)
-		}()
+		if retryCount < 1 {
+			log.Printf("[pr-watcher] claw %s is streaming, delaying injection", clawID[:8])
+			// Retry once after 30s
+			go func() {
+				time.Sleep(30 * time.Second)
+				s.injectUserMessageWithRetry(clawID, content, retryCount+1)
+			}()
+		} else {
+			log.Printf("[pr-watcher] claw %s still streaming after retry, dropping message", clawID[:8])
+		}
 		return
 	}
 
@@ -278,12 +312,10 @@ func (s *Server) injectUserMessage(clawID, content string) {
 	cc, ok := s.claws[clawID]
 	s.mu.RUnlock()
 	if ok {
-		msg := map[string]interface{}{
-			"type":    "message",
-			"payload": map[string]string{"role": "user", "content": content},
-		}
-		data, _ := json.Marshal(msg)
-		_ = cc.conn.Write(cc.conn.CloseRead(nil), 1, data)
+		_ = wsjson.Write(context.Background(), cc.conn, types.WSMessage{
+			Type:    "message",
+			Payload: map[string]string{"role": "user", "content": content},
+		})
 	}
 
 	// Broadcast to dashboard
@@ -365,6 +397,15 @@ func (s *Server) handleClawPRs(w http.ResponseWriter, r *http.Request, clawID st
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
+	tenantID := tenantFromCtx(r)
+
+	// Verify claw belongs to tenant
+	var exists int
+	if err := s.db.QueryRow(`SELECT 1 FROM claws WHERE id=? AND tenant_id=?`, clawID, tenantID).Scan(&exists); err != nil {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+
 	rows, err := s.db.Query(
 		`SELECT id, repo, pr_number, pr_url, created_at FROM claw_prs WHERE claw_id=? ORDER BY created_at ASC`,
 		clawID,
@@ -397,9 +438,11 @@ func (s *Server) handleClawPRs(w http.ResponseWriter, r *http.Request, clawID st
 
 // handleClawSettings reads/writes per-claw settings (auto_fix_ci, auto_fix_bugbot).
 func (s *Server) handleClawSettings(w http.ResponseWriter, r *http.Request, clawID string) {
+	tenantID := tenantFromCtx(r)
+
 	if r.Method == http.MethodGet {
 		var autoCI, autoBugbot int
-		if err := s.db.QueryRow(`SELECT auto_fix_ci, auto_fix_bugbot FROM claws WHERE id=?`, clawID).
+		if err := s.db.QueryRow(`SELECT auto_fix_ci, auto_fix_bugbot FROM claws WHERE id=? AND tenant_id=?`, clawID, tenantID).
 			Scan(&autoCI, &autoBugbot); err != nil {
 			http.Error(w, "claw not found", http.StatusNotFound)
 			return
@@ -421,14 +464,14 @@ func (s *Server) handleClawSettings(w http.ResponseWriter, r *http.Request, claw
 			if *body.AutoFixCI {
 				v = 1
 			}
-			_, _ = s.db.Exec(`UPDATE claws SET auto_fix_ci=? WHERE id=?`, v, clawID)
+			_, _ = s.db.Exec(`UPDATE claws SET auto_fix_ci=? WHERE id=? AND tenant_id=?`, v, clawID, tenantID)
 		}
 		if body.AutoFixBugbot != nil {
 			v := 0
 			if *body.AutoFixBugbot {
 				v = 1
 			}
-			_, _ = s.db.Exec(`UPDATE claws SET auto_fix_bugbot=? WHERE id=?`, v, clawID)
+			_, _ = s.db.Exec(`UPDATE claws SET auto_fix_bugbot=? WHERE id=? AND tenant_id=?`, v, clawID, tenantID)
 		}
 		jsonOK(w, map[string]bool{"ok": true})
 		return

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -1,0 +1,437 @@
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+	"github.com/google/uuid"
+)
+
+var prURLRegex = regexp.MustCompile(`https://github\.com/([a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+)/pull/(\d+)`)
+
+// extractPRs finds GitHub PR URLs in a message body.
+func extractPRs(content string) []struct{ repo string; number int; url string } {
+	var results []struct{ repo string; number int; url string }
+	seen := map[string]bool{}
+	for _, m := range prURLRegex.FindAllStringSubmatch(content, -1) {
+		url := m[0]
+		if seen[url] {
+			continue
+		}
+		seen[url] = true
+		num, _ := strconv.Atoi(m[2])
+		results = append(results, struct{ repo string; number int; url string }{m[1], num, url})
+	}
+	return results
+}
+
+// storePRMention persists a detected PR reference for a claw (idempotent by URL).
+func (s *Server) storePRMention(clawID, repo string, prNumber int, prURL string) {
+	var existing string
+	_ = s.db.QueryRow(`SELECT id FROM claw_prs WHERE pr_url=?`, prURL).Scan(&existing)
+	if existing != "" {
+		return
+	}
+	_, _ = s.db.Exec(
+		`INSERT INTO claw_prs(id,claw_id,repo,pr_number,pr_url,created_at) VALUES(?,?,?,?,?,?)`,
+		uuid.New().String(), clawID, repo, prNumber, prURL, now(),
+	)
+	log.Printf("[pr-watcher] detected PR %s#%d for claw %s", repo, prNumber, clawID[:8])
+}
+
+// scanMessageForPRs extracts and stores any PR URLs found in a message.
+func (s *Server) scanMessageForPRs(clawID, content string) {
+	for _, pr := range extractPRs(content) {
+		s.storePRMention(clawID, pr.repo, pr.number, pr.url)
+	}
+}
+
+// startPRWatcher launches the background poller.
+func (s *Server) startPRWatcher() {
+	go func() {
+		ticker := time.NewTicker(2 * time.Minute)
+		defer ticker.Stop()
+		for range ticker.C {
+			s.pollAllPRs()
+		}
+	}()
+}
+
+type clawPR struct {
+	id           string
+	clawID       string
+	repo         string
+	prNumber     int
+	prURL        string
+	lastCISHA    string
+	lastCommentID int64
+}
+
+func (s *Server) pollAllPRs() {
+	rows, err := s.db.Query(`
+		SELECT cp.id, cp.claw_id, cp.repo, cp.pr_number, cp.pr_url, cp.last_ci_sha, cp.last_comment_id,
+		       cl.auto_fix_ci, cl.auto_fix_bugbot
+		FROM claw_prs cp
+		JOIN claws cl ON cl.id = cp.claw_id
+		WHERE cl.status NOT IN ('deleted','error','offline')
+	`)
+	if err != nil {
+		return
+	}
+	defer rows.Close()
+
+	type row struct {
+		pr           clawPR
+		autoFixCI    bool
+		autoFixBugbot bool
+	}
+	var prs []row
+	for rows.Next() {
+		var r row
+		var ciInt, bugbotInt int
+		if err := rows.Scan(&r.pr.id, &r.pr.clawID, &r.pr.repo, &r.pr.prNumber, &r.pr.prURL,
+			&r.pr.lastCISHA, &r.pr.lastCommentID, &ciInt, &bugbotInt); err != nil {
+			continue
+		}
+		r.autoFixCI = ciInt == 1
+		r.autoFixBugbot = bugbotInt == 1
+		prs = append(prs, r)
+	}
+	rows.Close()
+
+	token := s.resolveGitHubToken()
+	if token == "" {
+		return
+	}
+
+	for _, r := range prs {
+		if r.autoFixCI {
+			s.checkCIFailures(r.pr, token)
+		}
+		if r.autoFixBugbot {
+			s.checkBugbotComments(r.pr, token)
+		}
+	}
+}
+
+// resolveGitHubToken returns a GitHub App installation token for PR polling.
+func (s *Server) resolveGitHubToken() string {
+	s.mu.RLock()
+	cfg := s.hubCfg
+	s.mu.RUnlock()
+	if len(cfg.GitHubApps) == 0 {
+		return ""
+	}
+	for _, appCfg := range cfg.GitHubApps {
+		provider, err := NewGitHubTokenProvider(appCfg)
+		if err != nil {
+			continue
+		}
+		token, _, err := provider.InstallationToken(context.Background(), 0, nil)
+		if err != nil {
+			continue
+		}
+		return token
+	}
+	return ""
+}
+
+// checkCIFailures polls PR check runs and injects a message on new failures.
+func (s *Server) checkCIFailures(pr clawPR, token string) {
+	// Get PR head SHA
+	prData, err := githubAPI(fmt.Sprintf("repos/%s/pulls/%d", pr.repo, pr.prNumber), token)
+	if err != nil {
+		return
+	}
+	headSHA, _ := prData["head"].(map[string]interface{})["sha"].(string)
+	if headSHA == "" || headSHA == pr.lastCISHA {
+		return // no new commits
+	}
+
+	// Get check runs for head SHA
+	checksData, err := githubAPI(fmt.Sprintf("repos/%s/commits/%s/check-runs", pr.repo, headSHA), token)
+	if err != nil {
+		return
+	}
+
+	checkRuns, _ := checksData["check_runs"].([]interface{})
+	var failures []string
+	for _, cr := range checkRuns {
+		run, _ := cr.(map[string]interface{})
+		conclusion, _ := run["conclusion"].(string)
+		name, _ := run["name"].(string)
+		if conclusion == "failure" || conclusion == "timed_out" {
+			detailsURL, _ := run["details_url"].(string)
+			failures = append(failures, fmt.Sprintf("**%s** — [view logs](%s)", name, detailsURL))
+		}
+	}
+
+	// Update last CI SHA
+	_, _ = s.db.Exec(`UPDATE claw_prs SET last_ci_sha=? WHERE id=?`, headSHA, pr.id)
+
+	if len(failures) == 0 {
+		return
+	}
+
+	msg := fmt.Sprintf("CI failed on PR #%d ([%s](%s)):\n\n%s\n\nPlease fix these failures on the same branch.",
+		pr.prNumber, pr.repo, pr.prURL, strings.Join(failures, "\n"))
+
+	s.injectUserMessage(pr.clawID, msg)
+}
+
+// checkBugbotComments polls PR review comments for new bugbot entries.
+func (s *Server) checkBugbotComments(pr clawPR, token string) {
+	commentsData, err := githubAPIList(fmt.Sprintf("repos/%s/issues/%d/comments", pr.repo, pr.prNumber), token)
+	if err != nil {
+		return
+	}
+
+	var newComments []string
+	var maxID int64 = pr.lastCommentID
+
+	for _, c := range commentsData {
+		comment, _ := c.(map[string]interface{})
+		idF, _ := comment["id"].(float64)
+		id := int64(idF)
+		if id <= pr.lastCommentID {
+			continue
+		}
+		if id > maxID {
+			maxID = id
+		}
+		user, _ := comment["user"].(map[string]interface{})
+		login, _ := user["login"].(string)
+		body, _ := comment["body"].(string)
+		htmlURL, _ := comment["html_url"].(string)
+
+		// Match cursor bugbot (login starts with "cursor" or body has "cursor bot" signature)
+		isBugbot := strings.Contains(strings.ToLower(login), "cursor") ||
+			strings.Contains(strings.ToLower(body), "cursor bot") ||
+			strings.Contains(strings.ToLower(body), "bugbot")
+
+		if isBugbot {
+			newComments = append(newComments, fmt.Sprintf("> %s\n\n[View comment](%s)",
+				strings.TrimSpace(body), htmlURL))
+		}
+	}
+
+	if maxID > pr.lastCommentID {
+		_, _ = s.db.Exec(`UPDATE claw_prs SET last_comment_id=? WHERE id=?`, maxID, pr.id)
+	}
+
+	if len(newComments) == 0 {
+		return
+	}
+
+	msg := fmt.Sprintf("New bugbot comment on PR #%d ([%s](%s)):\n\n%s\n\nPlease address this in the same branch.",
+		pr.prNumber, pr.repo, pr.prURL, strings.Join(newComments, "\n\n---\n\n"))
+
+	s.injectUserMessage(pr.clawID, msg)
+}
+
+// injectUserMessage inserts a user-role message into the claw's conversation
+// and forwards it over the WS connection (if connected) so the agent sees it.
+// Skips injection if the claw is currently streaming a response.
+func (s *Server) injectUserMessage(clawID, content string) {
+	// Don't interrupt a response in progress
+	s.mu.RLock()
+	cc, connected := s.claws[clawID]
+	streaming := connected && cc.streamingBuf.Len() > 0
+	s.mu.RUnlock()
+	if streaming {
+		log.Printf("[pr-watcher] claw %s is streaming, delaying injection", clawID[:8])
+		// Retry once after 30s
+		go func() {
+			time.Sleep(30 * time.Second)
+			s.injectUserMessage(clawID, content)
+		}()
+		return
+	}
+
+	// Resolve tenant
+	var tenantID string
+	if err := s.db.QueryRow(`SELECT tenant_id FROM claws WHERE id=?`, clawID).Scan(&tenantID); err != nil {
+		return
+	}
+
+	msgID := uuid.New().String()
+	_, err := s.db.Exec(
+		`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at) VALUES(?,?,?,?,?,?)`,
+		msgID, clawID, tenantID, "user", content, now(),
+	)
+	if err != nil {
+		log.Printf("[pr-watcher] failed to insert message: %v", err)
+		return
+	}
+
+	// Forward to agent over WS
+	s.mu.RLock()
+	cc, ok := s.claws[clawID]
+	s.mu.RUnlock()
+	if ok {
+		msg := map[string]interface{}{
+			"type":    "message",
+			"payload": map[string]string{"role": "user", "content": content},
+		}
+		data, _ := json.Marshal(msg)
+		_ = cc.conn.Write(cc.conn.CloseRead(nil), 1, data)
+	}
+
+	// Broadcast to dashboard
+	s.broadcastToUsers(tenantID, types.WSMessage{
+		Type: "message",
+		Payload: map[string]interface{}{
+			"id":         msgID,
+			"claw_id":    clawID,
+			"tenant_id":  tenantID,
+			"role":       "user",
+			"content":    content,
+			"created_at": now(),
+		},
+	})
+	log.Printf("[pr-watcher] injected message into claw %s", clawID[:8])
+}
+
+// githubAPI makes a GET request to the GitHub API and returns parsed JSON.
+func githubAPI(path, token string) (map[string]interface{}, error) {
+	req, _ := http.NewRequest("GET", "https://api.github.com/"+path, nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	var result map[string]interface{}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("github API parse error: %w", err)
+	}
+	return result, nil
+}
+
+// githubAPIList makes a GET request expecting a JSON array.
+func githubAPIList(path, token string) ([]interface{}, error) {
+	req, _ := http.NewRequest("GET", "https://api.github.com/"+path+"?per_page=100&sort=created&direction=desc", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	var result []interface{}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("github API list parse error: %w", err)
+	}
+	return result, nil
+}
+
+// handleClawSubresource routes /api/claws/:id/prs and /api/claws/:id/settings
+func (s *Server) handleClawSubresource(w http.ResponseWriter, r *http.Request) {
+	parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/api/claws/"), "/")
+	if len(parts) < 2 {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+	clawID := parts[0]
+	sub := parts[1]
+
+	switch sub {
+	case "prs":
+		s.handleClawPRs(w, r, clawID)
+	case "settings":
+		s.handleClawSettings(w, r, clawID)
+	default:
+		http.Error(w, "not found", http.StatusNotFound)
+	}
+}
+
+// handleClawPRs returns the list of PRs detected for a claw.
+func (s *Server) handleClawPRs(w http.ResponseWriter, r *http.Request, clawID string) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	rows, err := s.db.Query(
+		`SELECT id, repo, pr_number, pr_url, created_at FROM claw_prs WHERE claw_id=? ORDER BY created_at ASC`,
+		clawID,
+	)
+	if err != nil {
+		http.Error(w, "db error", http.StatusInternalServerError)
+		return
+	}
+	defer rows.Close()
+	type PR struct {
+		ID        string `json:"id"`
+		Repo      string `json:"repo"`
+		PRNumber  int    `json:"prNumber"`
+		URL       string `json:"url"`
+		CreatedAt string `json:"createdAt"`
+	}
+	var prs []PR
+	for rows.Next() {
+		var p PR
+		if err := rows.Scan(&p.ID, &p.Repo, &p.PRNumber, &p.URL, &p.CreatedAt); err != nil {
+			continue
+		}
+		prs = append(prs, p)
+	}
+	if prs == nil {
+		prs = []PR{}
+	}
+	jsonOK(w, prs)
+}
+
+// handleClawSettings reads/writes per-claw settings (auto_fix_ci, auto_fix_bugbot).
+func (s *Server) handleClawSettings(w http.ResponseWriter, r *http.Request, clawID string) {
+	if r.Method == http.MethodGet {
+		var autoCI, autoBugbot int
+		if err := s.db.QueryRow(`SELECT auto_fix_ci, auto_fix_bugbot FROM claws WHERE id=?`, clawID).
+			Scan(&autoCI, &autoBugbot); err != nil {
+			http.Error(w, "claw not found", http.StatusNotFound)
+			return
+		}
+		jsonOK(w, map[string]bool{"autoFixCI": autoCI == 1, "autoFixBugbot": autoBugbot == 1})
+		return
+	}
+	if r.Method == http.MethodPatch {
+		var body struct {
+			AutoFixCI     *bool `json:"autoFixCI"`
+			AutoFixBugbot *bool `json:"autoFixBugbot"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
+		if body.AutoFixCI != nil {
+			v := 0
+			if *body.AutoFixCI {
+				v = 1
+			}
+			_, _ = s.db.Exec(`UPDATE claws SET auto_fix_ci=? WHERE id=?`, v, clawID)
+		}
+		if body.AutoFixBugbot != nil {
+			v := 0
+			if *body.AutoFixBugbot {
+				v = 1
+			}
+			_, _ = s.db.Exec(`UPDATE claws SET auto_fix_bugbot=? WHERE id=?`, v, clawID)
+		}
+		jsonOK(w, map[string]bool{"ok": true})
+		return
+	}
+	http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+}

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -50,13 +50,31 @@ func extractPRs(content string) []struct {
 // storePRMention persists a detected PR reference for a claw (idempotent by URL).
 func (s *Server) storePRMention(clawID, repo string, prNumber int, prURL string) {
 	var existing string
-	_ = s.db.QueryRow(`SELECT id FROM claw_prs WHERE pr_url=?`, prURL).Scan(&existing)
+	_ = s.db.QueryRow(`SELECT id FROM claw_prs WHERE claw_id=? AND pr_url=?`, clawID, prURL).Scan(&existing)
 	if existing != "" {
 		return
 	}
+	
+	// Get the current max comment ID to avoid flooding with historical comments
+	token := s.resolveGitHubToken()
+	var maxCommentID int64
+	if token != "" {
+		commentsData, err := githubAPIList(fmt.Sprintf("repos/%s/issues/%d/comments", repo, prNumber), token)
+		if err == nil {
+			for _, c := range commentsData {
+				comment, _ := c.(map[string]interface{})
+				idF, _ := comment["id"].(float64)
+				id := int64(idF)
+				if id > maxCommentID {
+					maxCommentID = id
+				}
+			}
+		}
+	}
+	
 	_, _ = s.db.Exec(
-		`INSERT INTO claw_prs(id,claw_id,repo,pr_number,pr_url,created_at) VALUES(?,?,?,?,?,?)`,
-		uuid.New().String(), clawID, repo, prNumber, prURL, now(),
+		`INSERT INTO claw_prs(id,claw_id,repo,pr_number,pr_url,last_comment_id,created_at) VALUES(?,?,?,?,?,?,?)`,
+		uuid.New().String(), clawID, repo, prNumber, prURL, maxCommentID, now(),
 	)
 	log.Printf("[pr-watcher] detected PR %s#%d for claw %s", repo, prNumber, clawID[:8])
 }

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -96,6 +96,7 @@ func NewServer(addr, dbPath, identityDir string, hubCfg *types.HubConfig) (*Serv
 
 	// Start background poller to keep provider VM status fresh
 	go srv.pollProviderStatus()
+	srv.startPRWatcher()
 
 	return srv, nil
 }
@@ -138,6 +139,7 @@ func (s *Server) Run(opts ...RunOptions) error {
 	mux.HandleFunc("/api/terminal/", s.handleTerminal)
 	mux.HandleFunc("/api/github/token/", s.handleGitHubToken) // credential helper endpoint (claw-token auth)
 	mux.HandleFunc("/api/messages/", s.withAuth(s.handleMessages))
+	mux.HandleFunc("/api/claws/", s.withAuth(s.handleClawSubresource)) // /api/claws/:id/prs, /api/claws/:id/settings
 
 	// Health
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
@@ -1024,6 +1026,8 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				if strings.Contains(hm.Content, "[DONE]") {
 					go s.handleClawDoneSignal(clawID)
 				}
+				// Detect and store any PR URLs mentioned by the agent
+				go s.scanMessageForPRs(clawID, hm.Content)
 			} else if msg.Type == "http_proxy_req" {
 				// Proxy an HTTP request from the bridge to the hub's internal API.
 				// This allows tools in the sandbox to reach hub APIs without a public URL.

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -685,6 +685,7 @@ func (s *Server) handleClawDetail(w http.ResponseWriter, r *http.Request) {
 
 		// Delete messages first (FK constraint)
 		_, _ = s.db.Exec(`DELETE FROM messages WHERE claw_id = ?`, clawID)
+		_, _ = s.db.Exec(`DELETE FROM claw_prs WHERE claw_id = ?`, clawID)
 		_, err := s.db.Exec(`DELETE FROM claws WHERE id = ? AND tenant_id = ?`, clawID, tenantID)
 		if err != nil {
 			log.Printf("kill: db delete error for claw %s: %v", clawID, err)

--- a/web/components/conversation-view.tsx
+++ b/web/components/conversation-view.tsx
@@ -177,6 +177,76 @@ function ClawCardBack({ claw }: { claw: Claw }) {
 
   return (
     <div className="flex-1 overflow-y-auto scrollbar-hide p-4 space-y-4">
+      <div>
+        <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
+          Purpose
+        </h3>
+        <p className="text-sm text-foreground leading-relaxed">
+          {claw.description || "No description provided for this claw."}
+        </p>
+      </div>
+
+      <div>
+        <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
+          Template
+        </h3>
+        <p className="text-sm font-mono text-foreground">
+          {claw.template}
+        </p>
+      </div>
+
+      <div>
+        <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
+          Status
+        </h3>
+        <div className="flex items-center gap-2">
+          <StatusDot status={claw.status} isStreaming={claw.isStreaming} />
+          <span className="text-sm text-foreground capitalize">{claw.status}</span>
+          {claw.isStreaming && (
+            <span className="text-xs text-green-500">(streaming)</span>
+          )}
+        </div>
+      </div>
+
+      <div>
+        <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
+          Context Usage
+        </h3>
+        <div className="flex items-center gap-2">
+          <div className="flex-1">
+            <ContextProgressBar usage={claw.contextUsage} size="sm" />
+          </div>
+          <span className="text-sm font-mono text-foreground">{claw.contextUsage}%</span>
+        </div>
+      </div>
+
+      <div>
+        <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
+          Uptime
+        </h3>
+        <p className="text-sm font-mono text-foreground">
+          {formatUptime(claw.uptime)}
+        </p>
+      </div>
+
+      {claw.tags.length > 0 && (
+        <div>
+          <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
+            Tags
+          </h3>
+          <div className="flex flex-wrap gap-1.5">
+            {claw.tags.map((tag) => (
+              <span
+                key={tag}
+                className="inline-flex items-center px-2 py-1 text-xs font-medium bg-secondary text-muted-foreground rounded"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
       {prs.length > 0 && (
         <div>
           <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">Pull Requests</h3>

--- a/web/components/conversation-view.tsx
+++ b/web/components/conversation-view.tsx
@@ -12,7 +12,7 @@ import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sh
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog"
 import { cn } from "@/lib/utils"
 import type { Claw, Message, ClawStatus } from "@/lib/types"
-import { getTerminalWsUrl } from "@/lib/api"
+import { getTerminalWsUrl, fetchClawPRs, fetchClawAutoSettings, patchClawAutoSettings, type ClawPR } from "@/lib/api"
 import dynamic from "next/dynamic"
 
 const XTerminal = dynamic(
@@ -156,6 +156,59 @@ function KillConfirmDialog({ clawName, open, onConfirm, onCancel }: {
         </DialogFooter>
       </DialogContent>
     </Dialog>
+  )
+}
+
+function ClawCardBack({ claw }: { claw: Claw }) {
+  const [prs, setPrs] = useState<ClawPR[]>([])
+  const [autoFixCI, setAutoFixCI] = useState(true)
+  const [autoFixBugbot, setAutoFixBugbot] = useState(true)
+
+  useEffect(() => {
+    fetchClawPRs(claw.id).then(setPrs).catch(() => {})
+    fetchClawAutoSettings(claw.id).then(s => { setAutoFixCI(s.autoFixCI); setAutoFixBugbot(s.autoFixBugbot) }).catch(() => {})
+  }, [claw.id])
+
+  const toggle = async (key: "autoFixCI" | "autoFixBugbot", value: boolean) => {
+    if (key === "autoFixCI") setAutoFixCI(value)
+    else setAutoFixBugbot(value)
+    await patchClawAutoSettings(claw.id, { [key]: value }).catch(() => {})
+  }
+
+  return (
+    <div className="flex-1 overflow-y-auto scrollbar-hide p-4 space-y-4">
+      {prs.length > 0 && (
+        <div>
+          <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">Pull Requests</h3>
+          <div className="space-y-1.5">
+            {prs.map(pr => (
+              <a key={pr.id} href={pr.url} target="_blank" rel="noopener noreferrer"
+                className="flex items-center gap-2 text-xs text-blue-400 hover:underline">
+                <span className="font-mono text-muted-foreground">#{pr.prNumber}</span>
+                <span className="truncate">{pr.repo}</span>
+              </a>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div>
+        <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">Auto Actions</h3>
+        <div className="space-y-2">
+          <label className="flex items-center justify-between gap-2 cursor-pointer">
+            <span className="text-xs text-foreground">Fix CI failures automatically</span>
+            <input type="checkbox" checked={autoFixCI} onChange={e => toggle("autoFixCI", e.target.checked)}
+              className="size-3.5 accent-primary" />
+          </label>
+          <label className="flex items-center justify-between gap-2 cursor-pointer">
+            <span className="text-xs text-foreground">Resolve bugbot comments automatically</span>
+            <input type="checkbox" checked={autoFixBugbot} onChange={e => toggle("autoFixBugbot", e.target.checked)}
+              className="size-3.5 accent-primary" />
+          </label>
+        </div>
+        <p className="text-[10px] text-muted-foreground mt-2">When on, the hub injects a message when CI fails or bugbot comments appear on a PR.</p>
+      </div>
+    </div>
   )
 }
 
@@ -455,79 +508,7 @@ function ClawBoardCard({
           </div>
 
           {/* Bot info content */}
-          <div className="flex-1 overflow-y-auto scrollbar-hide p-4">
-            <div className="space-y-4">
-              <div>
-                <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
-                  Purpose
-                </h3>
-                <p className="text-sm text-foreground leading-relaxed">
-                  {claw.description || "No description provided for this claw."}
-                </p>
-              </div>
-
-              <div>
-                <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
-                  Template
-                </h3>
-                <p className="text-sm font-mono text-foreground">
-                  {claw.template}
-                </p>
-              </div>
-
-              <div>
-                <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
-                  Status
-                </h3>
-                <div className="flex items-center gap-2">
-                  <StatusDot status={claw.status} isStreaming={claw.isStreaming} />
-                  <span className="text-sm text-foreground capitalize">{claw.status}</span>
-                  {claw.isStreaming && (
-                    <span className="text-xs text-green-500">(streaming)</span>
-                  )}
-                </div>
-              </div>
-
-              <div>
-                <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
-                  Context Usage
-                </h3>
-                <div className="flex items-center gap-2">
-                  <div className="flex-1">
-                    <ContextProgressBar usage={claw.contextUsage} size="sm" />
-                  </div>
-                  <span className="text-sm font-mono text-foreground">{claw.contextUsage}%</span>
-                </div>
-              </div>
-
-              <div>
-                <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
-                  Uptime
-                </h3>
-                <p className="text-sm font-mono text-foreground">
-                  {formatUptime(claw.uptime)}
-                </p>
-              </div>
-
-              {Object.keys(claw.tags).length > 0 && (
-                <div>
-                  <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
-                    Tags
-                  </h3>
-                  <div className="flex flex-wrap gap-1.5">
-                    {claw.tags.map((tag) => (
-                      <span
-                        key={tag}
-                        className="inline-flex items-center px-2 py-1 text-xs font-medium bg-secondary text-muted-foreground rounded"
-                      >
-                        {tag}
-                      </span>
-                    ))}
-                  </div>
-                </div>
-              )}
-            </div>
-          </div>
+          <ClawCardBack claw={claw} />
 
           {/* Footer */}
           <div className="p-3 border-t border-border space-y-2">

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -162,3 +162,26 @@ export async function patchClaw(clawId: string, patch: { name?: string; tags?: s
     body: JSON.stringify(patch),
   })
 }
+
+export interface ClawPR {
+  id: string
+  repo: string
+  prNumber: number
+  url: string
+  createdAt: string
+}
+
+export async function fetchClawPRs(clawId: string): Promise<ClawPR[]> {
+  return apiFetch<ClawPR[]>(`/api/claws/${clawId}/prs`)
+}
+
+export async function fetchClawAutoSettings(clawId: string): Promise<{ autoFixCI: boolean; autoFixBugbot: boolean }> {
+  return apiFetch(`/api/claws/${clawId}/settings`)
+}
+
+export async function patchClawAutoSettings(clawId: string, patch: { autoFixCI?: boolean; autoFixBugbot?: boolean }): Promise<void> {
+  await apiFetch(`/api/claws/${clawId}/settings`, {
+    method: "PATCH",
+    body: JSON.stringify(patch),
+  })
+}


### PR DESCRIPTION
When a claw mentions a GitHub PR URL in a message, the hub now tracks it and (optionally) auto-injects messages when things need attention.

**What it does:**
- Scans every agent message for `github.com/owner/repo/pull/N` URLs
- Polls those PRs every 2 minutes while the claw is active
- Injects a user message (claw sees it and responds) when:
  - A new CI check run fails on the latest commit
  - A new bugbot/cursor comment appears on the PR
- Skips injection if the claw is currently streaming (retries after 30s)

**Per-claw toggles (both on by default):**
- Fix CI failures automatically
- Resolve bugbot comments automatically

**Card back changes:**
- Shows list of detected PRs with links
- Shows toggle checkboxes for both auto-action behaviors

**APIs:**
- `GET/PATCH /api/claws/:id/settings` — read/write toggle state
- `GET /api/claws/:id/prs` — list detected PRs