### PR TITLE
feat: named LLM keys — multiple providers, default, per-template override

### DIFF
--- a/cmd/hub.go
+++ b/cmd/hub.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/elasticclaw/elasticclaw/pkg/config"
 	"github.com/elasticclaw/elasticclaw/pkg/hub"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
 	"github.com/spf13/cobra"
 )
 
@@ -71,13 +72,22 @@ func runHub(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to load hub config: %w", err)
 	}
 
-	// Apply LLM keys from env
+	// Apply LLM keys from env — backward compat: if ANTHROPIC_API_KEY set and no anthropic key configured, add it
 	if apiKey := os.Getenv("ANTHROPIC_API_KEY"); apiKey != "" {
-		if hubCfg.LLMKeys == nil {
-			hubCfg.LLMKeys = map[string]string{}
+		hasAnthropicKey := false
+		for _, k := range hubCfg.LLMKeys {
+			if k.Provider == "anthropic" {
+				hasAnthropicKey = true
+				break
+			}
 		}
-		if hubCfg.LLMKeys["anthropic"] == "" {
-			hubCfg.LLMKeys["anthropic"] = apiKey
+		if !hasAnthropicKey {
+			hubCfg.LLMKeys = append(hubCfg.LLMKeys, &types.LLMKeyConfig{
+				Name:     "anthropic",
+				Provider: "anthropic",
+				APIKey:   apiKey,
+				Default:  len(hubCfg.LLMKeys) == 0,
+			})
 		}
 	}
 

--- a/pkg/config/hub.go
+++ b/pkg/config/hub.go
@@ -33,13 +33,25 @@ func LoadHubConfig() (*types.HubConfig, error) {
 		if err != nil {
 			// Check if this is a type error on llm_keys (old format vs new format)
 			if typeErr, ok := err.(*yaml.TypeError); ok {
-				// If the error mentions llm_keys, try migrating old format
 				errMsg := typeErr.Error()
+				// Only attempt migration if the error ONLY mentions llm_keys and no other fields
 				if bytes.Contains([]byte(errMsg), []byte("llm_keys")) {
-					// Try to migrate and re-parse
-					if migrateErr := migrateOldLLMKeys(cfg, data); migrateErr == nil {
-						// Successfully migrated, cfg is now populated
-						return cfg, nil
+					// Parse the type error to check if it only contains llm_keys errors
+					// yaml.TypeError.Errors contains a slice of error strings
+					hasOtherErrors := false
+					for _, errLine := range typeErr.Errors {
+						if !bytes.Contains([]byte(errLine), []byte("llm_keys")) {
+							hasOtherErrors = true
+							break
+						}
+					}
+					// Only migrate if all errors are llm_keys related
+					if !hasOtherErrors {
+						// Try to migrate and re-parse
+						if migrateErr := migrateOldLLMKeys(cfg, data); migrateErr == nil {
+							// Successfully migrated, cfg is now populated
+							return cfg, nil
+						}
 					}
 				}
 			}
@@ -253,7 +265,7 @@ func migrateOldLLMKeys(cfg *types.HubConfig, raw []byte) error {
 	if err := yaml.Unmarshal(raw, &legacy); err != nil || len(legacy.LLMKeys) == 0 {
 		return err
 	}
-	
+
 	// Sort providers to ensure deterministic default selection
 	var providers []string
 	for provider := range legacy.LLMKeys {
@@ -264,7 +276,7 @@ func migrateOldLLMKeys(cfg *types.HubConfig, raw []byte) error {
 	if len(providers) == 0 {
 		return nil
 	}
-	
+
 	// Use lexicographic ordering for deterministic behavior
 	for i := 0; i < len(providers); i++ {
 		for j := i + 1; j < len(providers); j++ {
@@ -273,7 +285,7 @@ func migrateOldLLMKeys(cfg *types.HubConfig, raw []byte) error {
 			}
 		}
 	}
-	
+
 	// First provider in sorted order becomes default
 	for i, provider := range providers {
 		cfg.LLMKeys = append(cfg.LLMKeys, &types.LLMKeyConfig{

--- a/pkg/config/hub.go
+++ b/pkg/config/hub.go
@@ -32,6 +32,8 @@ func LoadHubConfig() (*types.HubConfig, error) {
 		if err := yaml.Unmarshal(data, cfg); err != nil {
 			return nil, fmt.Errorf("failed to parse hub config %s: %w", path, err)
 		}
+		// Backwards compat: old flat map format {provider: key} stored in LLMKeysLegacy
+		migrateOldLLMKeys(cfg, data)
 		return cfg, nil
 	}
 	return &types.HubConfig{}, nil
@@ -221,4 +223,34 @@ func ReadTemplateFiles(templateDir string) (map[string]string, error) {
 		}
 	}
 	return files, nil
+}
+
+// migrateOldLLMKeys converts old flat map {provider: key} yaml format to the new named slice.
+// Old format: llm_keys:\n  anthropic: sk-...
+// New format: llm_keys:\n  - name: anthropic\n    provider: anthropic\n    api_key: sk-...
+func migrateOldLLMKeys(cfg *types.HubConfig, raw []byte) {
+	// If we already have new-format keys, nothing to do
+	if len(cfg.LLMKeys) > 0 {
+		return
+	}
+	// Try to parse as the old flat map
+	var legacy struct {
+		LLMKeys map[string]string `yaml:"llm_keys"`
+	}
+	if err := yaml.Unmarshal(raw, &legacy); err != nil || len(legacy.LLMKeys) == 0 {
+		return
+	}
+	first := true
+	for provider, key := range legacy.LLMKeys {
+		if key == "" {
+			continue
+		}
+		cfg.LLMKeys = append(cfg.LLMKeys, &types.LLMKeyConfig{
+			Name:     provider,
+			Provider: provider,
+			APIKey:   key,
+			Default:  first,
+		})
+		first = false
+	}
 }

--- a/pkg/config/hub.go
+++ b/pkg/config/hub.go
@@ -45,7 +45,7 @@ func LoadHubConfig() (*types.HubConfig, error) {
 			}
 			return nil, fmt.Errorf("failed to parse hub config %s: %w", path, err)
 		}
-		// Backwards compat: old flat map format {provider: key} stored in LLMKeysLegacy
+		// Backwards compat: migrate old flat map format {provider: key} to new llm_keys slice
 		migrateOldLLMKeys(cfg, data)
 		return cfg, nil
 	}

--- a/pkg/config/hub.go
+++ b/pkg/config/hub.go
@@ -29,7 +29,20 @@ func LoadHubConfig() (*types.HubConfig, error) {
 			return nil, fmt.Errorf("failed to read hub config %s: %w", path, err)
 		}
 		cfg := &types.HubConfig{}
-		if err := yaml.Unmarshal(data, cfg); err != nil {
+		err = yaml.Unmarshal(data, cfg)
+		if err != nil {
+			// Check if this is a type error on llm_keys (old format vs new format)
+			if typeErr, ok := err.(*yaml.TypeError); ok {
+				// If the error mentions llm_keys, try migrating old format
+				errMsg := typeErr.Error()
+				if bytes.Contains([]byte(errMsg), []byte("llm_keys")) {
+					// Try to migrate and re-parse
+					if migrateErr := migrateOldLLMKeys(cfg, data); migrateErr == nil {
+						// Successfully migrated, cfg is now populated
+						return cfg, nil
+					}
+				}
+			}
 			return nil, fmt.Errorf("failed to parse hub config %s: %w", path, err)
 		}
 		// Backwards compat: old flat map format {provider: key} stored in LLMKeysLegacy
@@ -228,29 +241,47 @@ func ReadTemplateFiles(templateDir string) (map[string]string, error) {
 // migrateOldLLMKeys converts old flat map {provider: key} yaml format to the new named slice.
 // Old format: llm_keys:\n  anthropic: sk-...
 // New format: llm_keys:\n  - name: anthropic\n    provider: anthropic\n    api_key: sk-...
-func migrateOldLLMKeys(cfg *types.HubConfig, raw []byte) {
+func migrateOldLLMKeys(cfg *types.HubConfig, raw []byte) error {
 	// If we already have new-format keys, nothing to do
 	if len(cfg.LLMKeys) > 0 {
-		return
+		return nil
 	}
 	// Try to parse as the old flat map
 	var legacy struct {
 		LLMKeys map[string]string `yaml:"llm_keys"`
 	}
 	if err := yaml.Unmarshal(raw, &legacy); err != nil || len(legacy.LLMKeys) == 0 {
-		return
+		return err
 	}
-	first := true
-	for provider, key := range legacy.LLMKeys {
-		if key == "" {
-			continue
+	
+	// Sort providers to ensure deterministic default selection
+	var providers []string
+	for provider := range legacy.LLMKeys {
+		if legacy.LLMKeys[provider] != "" {
+			providers = append(providers, provider)
 		}
+	}
+	if len(providers) == 0 {
+		return nil
+	}
+	
+	// Use lexicographic ordering for deterministic behavior
+	for i := 0; i < len(providers); i++ {
+		for j := i + 1; j < len(providers); j++ {
+			if providers[i] > providers[j] {
+				providers[i], providers[j] = providers[j], providers[i]
+			}
+		}
+	}
+	
+	// First provider in sorted order becomes default
+	for i, provider := range providers {
 		cfg.LLMKeys = append(cfg.LLMKeys, &types.LLMKeyConfig{
 			Name:     provider,
 			Provider: provider,
-			APIKey:   key,
-			Default:  first,
+			APIKey:   legacy.LLMKeys[provider],
+			Default:  i == 0,
 		})
-		first = false
 	}
+	return nil
 }

--- a/pkg/config/hub_test.go
+++ b/pkg/config/hub_test.go
@@ -1,0 +1,104 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func TestMigrateOldLLMKeys_DeterministicDefault(t *testing.T) {
+	// Old format YAML with multiple keys
+	oldYAML := []byte(`
+llm_keys:
+  fireworks: sk-fw-123
+  anthropic: sk-ant-456
+  openai: sk-openai-789
+`)
+
+	cfg := &types.HubConfig{}
+	err := migrateOldLLMKeys(cfg, oldYAML)
+	if err != nil {
+		t.Fatalf("migration failed: %v", err)
+	}
+
+	if len(cfg.LLMKeys) != 3 {
+		t.Fatalf("expected 3 keys, got %d", len(cfg.LLMKeys))
+	}
+
+	// First key in alphabetical order (anthropic) should be default
+	if cfg.LLMKeys[0].Name != "anthropic" {
+		t.Errorf("expected first key to be 'anthropic', got '%s'", cfg.LLMKeys[0].Name)
+	}
+	if !cfg.LLMKeys[0].Default {
+		t.Error("first key should be marked as default")
+	}
+
+	// Other keys should not be default
+	for i := 1; i < len(cfg.LLMKeys); i++ {
+		if cfg.LLMKeys[i].Default {
+			t.Errorf("key %d (%s) should not be default", i, cfg.LLMKeys[i].Name)
+		}
+	}
+
+	// Verify deterministic ordering (alphabetical)
+	expected := []string{"anthropic", "fireworks", "openai"}
+	for i, k := range cfg.LLMKeys {
+		if k.Name != expected[i] {
+			t.Errorf("key %d: expected %s, got %s", i, expected[i], k.Name)
+		}
+		if k.Provider != expected[i] {
+			t.Errorf("key %d: expected provider %s, got %s", i, expected[i], k.Provider)
+		}
+	}
+}
+
+func TestMigrateOldLLMKeys_SkipsIfNewFormatPresent(t *testing.T) {
+	oldYAML := []byte(`
+llm_keys:
+  anthropic: sk-ant-456
+`)
+
+	cfg := &types.HubConfig{
+		LLMKeys: []*types.LLMKeyConfig{
+			{Name: "existing", Provider: "openai", APIKey: "sk-existing", Default: true},
+		},
+	}
+
+	err := migrateOldLLMKeys(cfg, oldYAML)
+	if err != nil {
+		t.Fatalf("migration failed: %v", err)
+	}
+
+	// Should not have changed
+	if len(cfg.LLMKeys) != 1 {
+		t.Errorf("expected 1 key (unchanged), got %d", len(cfg.LLMKeys))
+	}
+	if cfg.LLMKeys[0].Name != "existing" {
+		t.Errorf("existing key should be unchanged")
+	}
+}
+
+func TestMigrateOldLLMKeys_HandlesEmptyKeys(t *testing.T) {
+	oldYAML := []byte(`
+llm_keys:
+  anthropic: sk-ant-456
+  fireworks: ""
+  openai: sk-openai-789
+`)
+
+	cfg := &types.HubConfig{}
+	err := migrateOldLLMKeys(cfg, oldYAML)
+	if err != nil {
+		t.Fatalf("migration failed: %v", err)
+	}
+
+	// Should only have 2 keys (empty fireworks skipped)
+	if len(cfg.LLMKeys) != 2 {
+		t.Fatalf("expected 2 keys, got %d", len(cfg.LLMKeys))
+	}
+
+	// Keys should be anthropic and openai in alphabetical order
+	if cfg.LLMKeys[0].Name != "anthropic" || cfg.LLMKeys[1].Name != "openai" {
+		t.Errorf("expected anthropic and openai, got %s and %s", cfg.LLMKeys[0].Name, cfg.LLMKeys[1].Name)
+	}
+}

--- a/pkg/hub/client.go
+++ b/pkg/hub/client.go
@@ -113,6 +113,7 @@ func (c *Client) CreateClaw(ctx context.Context, name, templateName string, tmpl
 		Image:        tmplCfg.Image,
 		TTL:          tmplCfg.TTL,
 		DefaultModel: tmplCfg.DefaultModel,
+		LLMKey:       tmplCfg.LLMKey,
 		Files:        files,
 		Env:          env,
 		GitHub:       tmplCfg.GitHub,

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -36,6 +36,7 @@ func migrate(db *sql.DB) error {
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN tags TEXT NOT NULL DEFAULT '[]'`)
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN color TEXT NOT NULL DEFAULT ''`)
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN linear_issue_id TEXT NOT NULL DEFAULT ''`)
+	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN llm_key TEXT NOT NULL DEFAULT ''`)
 
 	_, err := db.Exec(`
 	CREATE TABLE IF NOT EXISTS tenants (
@@ -67,7 +68,8 @@ func migrate(db *sql.DB) error {
 		nix              INTEGER NOT NULL DEFAULT 0,
 		tags             TEXT NOT NULL DEFAULT '[]',
 		color            TEXT NOT NULL DEFAULT '',
-		linear_issue_id  TEXT NOT NULL DEFAULT ''
+		linear_issue_id  TEXT NOT NULL DEFAULT '',
+		llm_key          TEXT NOT NULL DEFAULT ''
 	);
 
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -556,9 +556,9 @@ func (s *Server) handleCreateClaw(w http.ResponseWriter, r *http.Request, tenant
 	color := resolveColor(req.Color, req.Name)
 
 	_, err := s.db.Exec(
-		`INSERT INTO claws(id, tenant_id, name, template, provider, default_model, template_files, github_repos, linear_workspace, nix, tags, color, status, created_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,'provisioning',?)`,
+		`INSERT INTO claws(id, tenant_id, name, template, provider, default_model, template_files, github_repos, linear_workspace, nix, tags, color, llm_key, status, created_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,'provisioning',?)`,
 		clawID, tenantID, req.Name, req.TemplateName, req.Provider, req.DefaultModel, string(filesJSON),
-		githubReposJSON, linearWorkspace, nixEnabled, string(tagsJSON), color, now(),
+		githubReposJSON, linearWorkspace, nixEnabled, string(tagsJSON), color, req.LLMKey, now(),
 	)
 	if err != nil {
 		http.Error(w, "db error", http.StatusInternalServerError)
@@ -1880,6 +1880,9 @@ func (s *Server) bootstrapReplicated(clawID, clawName, vmID string, cfg types.Pr
 		log.Printf("[bootstrap] warning: could not read nix flag for claw %s: %v", clawID[:8], err)
 	}
 	log.Printf("[bootstrap] claw %s nix=%d", clawID[:8], nixEnabled)
+	// Read llm_key selection
+	var llmKeyName string
+	_ = s.db.QueryRow(`SELECT COALESCE(llm_key,'') FROM claws WHERE id=?`, clawID).Scan(&llmKeyName)
 
 	bridgeURL := s.bridgeDownloadURL()
 	if bridgeURL == "" {
@@ -1914,8 +1917,8 @@ func (s *Server) bootstrapReplicated(clawID, clawName, vmID string, cfg types.Pr
 	gatewayPassword := randomHex(16)
 
 	s.mu.RLock()
-	// Inject all configured LLM keys — OpenClaw picks the right one based on the default_model provider.
-	llmKeyEnv := buildLLMKeyEnv(s.hubCfg.LLMKeys)
+	// Inject all configured LLM keys, prioritizing the selected key if specified
+	llmKeyEnv := buildLLMKeyEnv(s.hubCfg.LLMKeys, llmKeyName)
 	relayEnv := buildRelayEnv(s.hubCfg, s.identity.PublicKey)
 	clawToken := s.hubCfg.ClawToken
 	hubCfg := s.hubCfg
@@ -2141,14 +2144,28 @@ func buildLinearEnv(token string) string {
 }
 
 // buildLLMKeyEnv converts llm_keys slice to shell env var export lines.
+// If selectedKeyName is non-empty, the selected key is prioritized over default keys.
 // All keys are exported so each claw has access to whichever provider it needs.
-func buildLLMKeyEnv(keys []*types.LLMKeyConfig) string {
+func buildLLMKeyEnv(keys []*types.LLMKeyConfig, selectedKeyName string) string {
 	if len(keys) == 0 {
 		return ""
 	}
 	var b strings.Builder
 	seen := map[string]bool{}
-	// First pass: export default keys
+
+	// First pass: export the selected key if specified
+	if selectedKeyName != "" {
+		for _, k := range keys {
+			if k.Name == selectedKeyName {
+				envVar := k.EnvVarName()
+				seen[envVar] = true
+				fmt.Fprintf(&b, "export %s=%q\n", envVar, k.APIKey)
+				break
+			}
+		}
+	}
+
+	// Second pass: export default keys for providers not yet seen
 	for _, k := range keys {
 		if !k.Default {
 			continue
@@ -2160,7 +2177,7 @@ func buildLLMKeyEnv(keys []*types.LLMKeyConfig) string {
 		seen[envVar] = true
 		fmt.Fprintf(&b, "export %s=%q\n", envVar, k.APIKey)
 	}
-	// Second pass: export non-default keys for providers not yet seen
+	// Third pass: export non-default keys for providers not yet seen
 	for _, k := range keys {
 		envVar := k.EnvVarName()
 		if seen[envVar] {
@@ -2178,12 +2195,12 @@ func resolveDefaultModelForKey(hubCfg *types.HubConfig, key *types.LLMKeyConfig)
 	if key == nil {
 		return hubCfg.DefaultModel
 	}
-	
+
 	// Check if hub's DefaultModel matches this key's provider
 	if hubCfg.DefaultModel != "" && strings.HasPrefix(hubCfg.DefaultModel, key.Provider+"/") {
 		return hubCfg.DefaultModel
 	}
-	
+
 	// Construct a provider-specific default model
 	switch key.Provider {
 	case "anthropic":

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -537,9 +537,8 @@ func (s *Server) handleCreateClaw(w http.ResponseWriter, r *http.Request, tenant
 		s.mu.RLock()
 		for _, k := range s.hubCfg.LLMKeys {
 			if k.Name == req.LLMKey {
-				// Use hub DefaultModel but ensure the right provider is selected
-				// by looking for a match; fall back to hub default
-				defaultModel = s.hubCfg.DefaultModel
+				// Use the key's provider to derive a model
+				defaultModel = resolveDefaultModelForKey(s.hubCfg, k)
 				break
 			}
 		}
@@ -2160,18 +2159,34 @@ func buildLLMKeyEnv(keys []*types.LLMKeyConfig) string {
 	return b.String()
 }
 
-// resolveDefaultModel returns the effective model: template key's model > hub default.
-func resolveDefaultModelForKey(hubCfg *types.HubConfig, llmKey string) string {
-	if llmKey == "" {
+// resolveDefaultModelForKey returns the effective model for a given LLM key.
+// If the hub's default model matches the key's provider, use it; otherwise construct a provider-specific default.
+func resolveDefaultModelForKey(hubCfg *types.HubConfig, key *types.LLMKeyConfig) string {
+	if key == nil {
 		return hubCfg.DefaultModel
 	}
-	for _, k := range hubCfg.LLMKeys {
-		if k.Name == llmKey {
-			// If no explicit default_model set, use this provider's default
-			return hubCfg.DefaultModel
-		}
+	
+	// Check if hub's DefaultModel matches this key's provider
+	if hubCfg.DefaultModel != "" && strings.HasPrefix(hubCfg.DefaultModel, key.Provider+"/") {
+		return hubCfg.DefaultModel
 	}
-	return hubCfg.DefaultModel
+	
+	// Construct a provider-specific default model
+	switch key.Provider {
+	case "anthropic":
+		return "anthropic/claude-sonnet-4-6"
+	case "openai":
+		return "openai/gpt-4o"
+	case "fireworks":
+		return "fireworks/llama-v3p3-70b-instruct"
+	case "groq":
+		return "groq/llama-3.3-70b-versatile"
+	case "deepseek":
+		return "deepseek/deepseek-chat"
+	default:
+		// Fall back to hub default even if provider doesn't match
+		return hubCfg.DefaultModel
+	}
 }
 
 // buildGitHubCloneScript returns shell lines that clone repos into the current directory.

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2148,10 +2148,23 @@ func buildLLMKeyEnv(keys []*types.LLMKeyConfig) string {
 	}
 	var b strings.Builder
 	seen := map[string]bool{}
+	// First pass: export default keys
+	for _, k := range keys {
+		if !k.Default {
+			continue
+		}
+		envVar := k.EnvVarName()
+		if seen[envVar] {
+			continue
+		}
+		seen[envVar] = true
+		fmt.Fprintf(&b, "export %s=%q\n", envVar, k.APIKey)
+	}
+	// Second pass: export non-default keys for providers not yet seen
 	for _, k := range keys {
 		envVar := k.EnvVarName()
 		if seen[envVar] {
-			continue // first key for a given provider wins
+			continue
 		}
 		seen[envVar] = true
 		fmt.Fprintf(&b, "export %s=%q\n", envVar, k.APIKey)
@@ -2183,6 +2196,8 @@ func resolveDefaultModelForKey(hubCfg *types.HubConfig, key *types.LLMKeyConfig)
 		return "groq/llama-3.3-70b-versatile"
 	case "deepseek":
 		return "deepseek/deepseek-chat"
+	case "moonshot":
+		return "moonshot/moonshot-v1-8k"
 	default:
 		// Fall back to hub default even if provider doesn't match
 		return hubCfg.DefaultModel

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -531,6 +531,27 @@ func (s *Server) handleCreateClaw(w http.ResponseWriter, r *http.Request, tenant
 	}
 	log.Printf("[create] claw %s: req.Nix=%v nixEnabled=%d", req.Name, req.Nix, nixEnabled)
 
+	// Resolve default model: explicit > llm_key lookup > hub default
+	defaultModel := req.DefaultModel
+	if defaultModel == "" && req.LLMKey != "" {
+		s.mu.RLock()
+		for _, k := range s.hubCfg.LLMKeys {
+			if k.Name == req.LLMKey {
+				// Use hub DefaultModel but ensure the right provider is selected
+				// by looking for a match; fall back to hub default
+				defaultModel = s.hubCfg.DefaultModel
+				break
+			}
+		}
+		s.mu.RUnlock()
+	}
+	if defaultModel == "" {
+		s.mu.RLock()
+		defaultModel = s.hubCfg.DefaultModel
+		s.mu.RUnlock()
+	}
+	req.DefaultModel = defaultModel
+
 	tags := mergeTags(req.TemplateName, req.Tags, nil) // CLI tags already merged client-side
 	tagsJSON, _ := json.Marshal(tags)
 	color := resolveColor(req.Color, req.Name)
@@ -1324,9 +1345,9 @@ echo $! > /tmp/openclaw-install.pid && echo 'install started'`); err != nil {
 		defaultModel = "anthropic/claude-sonnet-4-6"
 	}
 	if anthropicKey == "" {
-		for k, v := range s.hubCfg.LLMKeys {
-			if k == "anthropic" {
-				anthropicKey = v
+		for _, k := range s.hubCfg.LLMKeys {
+			if k.Provider == "anthropic" && k.APIKey != "" {
+				anthropicKey = k.APIKey
 				break
 			}
 		}
@@ -1894,6 +1915,7 @@ func (s *Server) bootstrapReplicated(clawID, clawName, vmID string, cfg types.Pr
 	gatewayPassword := randomHex(16)
 
 	s.mu.RLock()
+	// Inject all configured LLM keys — OpenClaw picks the right one based on the default_model provider.
 	llmKeyEnv := buildLLMKeyEnv(s.hubCfg.LLMKeys)
 	relayEnv := buildRelayEnv(s.hubCfg, s.identity.PublicKey)
 	clawToken := s.hubCfg.ClawToken
@@ -2119,18 +2141,37 @@ func buildLinearEnv(token string) string {
 	return fmt.Sprintf("export LINEAR_API_KEY=%q", token)
 }
 
-// buildLLMKeyEnv converts the llm_keys map to shell env var lines for the bootstrap script.
-// e.g. {"anthropic": "sk-ant-..."} -> "  ANTHROPIC_API_KEY=\"sk-ant-...\" \\\n"
-func buildLLMKeyEnv(keys map[string]string) string {
+// buildLLMKeyEnv converts llm_keys slice to shell env var export lines.
+// All keys are exported so each claw has access to whichever provider it needs.
+func buildLLMKeyEnv(keys []*types.LLMKeyConfig) string {
 	if len(keys) == 0 {
 		return ""
 	}
 	var b strings.Builder
-	for provider, key := range keys {
-		envVar := strings.ToUpper(provider) + "_API_KEY"
-		fmt.Fprintf(&b, "export %s=%q\n", envVar, key)
+	seen := map[string]bool{}
+	for _, k := range keys {
+		envVar := k.EnvVarName()
+		if seen[envVar] {
+			continue // first key for a given provider wins
+		}
+		seen[envVar] = true
+		fmt.Fprintf(&b, "export %s=%q\n", envVar, k.APIKey)
 	}
 	return b.String()
+}
+
+// resolveDefaultModel returns the effective model: template key's model > hub default.
+func resolveDefaultModelForKey(hubCfg *types.HubConfig, llmKey string) string {
+	if llmKey == "" {
+		return hubCfg.DefaultModel
+	}
+	for _, k := range hubCfg.LLMKeys {
+		if k.Name == llmKey {
+			// If no explicit default_model set, use this provider's default
+			return hubCfg.DefaultModel
+		}
+	}
+	return hubCfg.DefaultModel
 }
 
 // buildGitHubCloneScript returns shell lines that clone repos into the current directory.

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -1,0 +1,94 @@
+package hub
+
+import (
+	"testing"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func TestResolveDefaultModelForKey(t *testing.T) {
+	tests := []struct {
+		name           string
+		hubCfg         *types.HubConfig
+		key            *types.LLMKeyConfig
+		expectedModel  string
+	}{
+		{
+			name: "hub default matches key provider",
+			hubCfg: &types.HubConfig{
+				DefaultModel: "anthropic/claude-opus-4-5",
+			},
+			key: &types.LLMKeyConfig{
+				Provider: "anthropic",
+			},
+			expectedModel: "anthropic/claude-opus-4-5",
+		},
+		{
+			name: "hub default doesn't match - use provider default",
+			hubCfg: &types.HubConfig{
+				DefaultModel: "anthropic/claude-sonnet-4-6",
+			},
+			key: &types.LLMKeyConfig{
+				Provider: "openai",
+			},
+			expectedModel: "openai/gpt-4o",
+		},
+		{
+			name: "no hub default - use provider default",
+			hubCfg: &types.HubConfig{
+				DefaultModel: "",
+			},
+			key: &types.LLMKeyConfig{
+				Provider: "fireworks",
+			},
+			expectedModel: "fireworks/llama-v3p3-70b-instruct",
+		},
+		{
+			name: "unknown provider - fall back to hub default",
+			hubCfg: &types.HubConfig{
+				DefaultModel: "anthropic/claude-sonnet-4-6",
+			},
+			key: &types.LLMKeyConfig{
+				Provider: "unknown-provider",
+			},
+			expectedModel: "anthropic/claude-sonnet-4-6",
+		},
+		{
+			name: "nil key - return hub default",
+			hubCfg: &types.HubConfig{
+				DefaultModel: "anthropic/claude-sonnet-4-6",
+			},
+			key:           nil,
+			expectedModel: "anthropic/claude-sonnet-4-6",
+		},
+		{
+			name: "groq provider",
+			hubCfg: &types.HubConfig{
+				DefaultModel: "anthropic/claude-sonnet-4-6",
+			},
+			key: &types.LLMKeyConfig{
+				Provider: "groq",
+			},
+			expectedModel: "groq/llama-3.3-70b-versatile",
+		},
+		{
+			name: "deepseek provider",
+			hubCfg: &types.HubConfig{
+				DefaultModel: "",
+			},
+			key: &types.LLMKeyConfig{
+				Provider: "deepseek",
+			},
+			expectedModel: "deepseek/deepseek-chat",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := resolveDefaultModelForKey(tt.hubCfg, tt.key)
+			if result != tt.expectedModel {
+				t.Errorf("expected %s, got %s", tt.expectedModel, result)
+			}
+		})
+	}
+}

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -16,10 +16,18 @@ type SettingsStatus struct {
 	HasGitHub   bool `json:"hasGitHub"`
 }
 
+// LLMKeyView is the masked view of a named LLM key.
+type LLMKeyView struct {
+	Name     string `json:"name"`
+	Provider string `json:"provider"`
+	KeySet   bool   `json:"keySet"`
+	Default  bool   `json:"default"`
+}
+
 // SettingsView is the redacted view of hub config for the settings page.
 // Secrets are masked — never returned in full.
 type SettingsView struct {
-	LLMKeys       map[string]bool         `json:"llmKeys"`
+	LLMKeys       []LLMKeyView            `json:"llmKeys"`
 	Providers     map[string]ProviderView `json:"providers"`
 	GitHub        []GitHubAppView         `json:"github"`
 	SSHPublicKeys []string                `json:"sshPublicKeys"`
@@ -73,8 +81,17 @@ type GitHubAppView struct {
 
 // SettingsPatch is the request body for PATCH /api/settings.
 // Only non-nil fields are updated.
+// LLMKeyPatch adds/updates a named LLM key. Set APIKey to "" to remove.
+type LLMKeyPatch struct {
+	Name     string `json:"name"`
+	Provider string `json:"provider,omitempty"`
+	APIKey   string `json:"apiKey,omitempty"`
+	Default  *bool  `json:"default,omitempty"`
+	Delete   bool   `json:"delete,omitempty"`
+}
+
 type SettingsPatch struct {
-	LLMKeys       map[string]string        `json:"llmKeys,omitempty"`
+	LLMKeys       []LLMKeyPatch            `json:"llmKeys,omitempty"`
 	Providers     map[string]ProviderPatch `json:"providers,omitempty"`
 	GitHub        []GitHubAppPatch         `json:"github,omitempty"`
 	UIPassword    string                   `json:"uiPassword,omitempty"`
@@ -160,15 +177,20 @@ func (s *Server) handleSettings(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 	view := SettingsView{
-		LLMKeys:   make(map[string]bool),
 		Providers: make(map[string]ProviderView),
 		GitHub:    []GitHubAppView{},
 	}
 
 	s.mu.RLock()
-	// LLM keys — boolean flag only
-	for provider, key := range s.hubCfg.LLMKeys {
-		view.LLMKeys[provider] = key != ""
+	// LLM keys — mask actual key values
+	view.LLMKeys = []LLMKeyView{}
+	for _, k := range s.hubCfg.LLMKeys {
+		view.LLMKeys = append(view.LLMKeys, LLMKeyView{
+			Name:     k.Name,
+			Provider: k.Provider,
+			KeySet:   k.APIKey != "",
+			Default:  k.Default,
+		})
 	}
 
 	// Providers
@@ -250,25 +272,55 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 	// Shallow copy of config struct; maps and slices are deep-copied only when modified below
 	updatedCfg := *s.hubCfg
 
-	// LLM keys
-	if patch.LLMKeys != nil {
-		if updatedCfg.LLMKeys == nil {
-			updatedCfg.LLMKeys = make(map[string]string)
-		} else {
-			// Deep copy the map
-			newKeys := make(map[string]string, len(updatedCfg.LLMKeys))
-			for k, v := range updatedCfg.LLMKeys {
-				newKeys[k] = v
-			}
-			updatedCfg.LLMKeys = newKeys
+	// LLM keys — upsert/delete by name
+	if len(patch.LLMKeys) > 0 {
+		// Deep copy existing keys
+		existing := make([]*types.LLMKeyConfig, len(updatedCfg.LLMKeys))
+		for i, k := range updatedCfg.LLMKeys {
+			copy := *k
+			existing[i] = &copy
 		}
-		for k, v := range patch.LLMKeys {
-			if v == "" {
-				delete(updatedCfg.LLMKeys, k)
-			} else {
-				updatedCfg.LLMKeys[k] = v
+		for _, kp := range patch.LLMKeys {
+			if kp.Delete {
+				// Remove by name
+				filtered := existing[:0]
+				for _, k := range existing {
+					if k.Name != kp.Name {
+						filtered = append(filtered, k)
+					}
+				}
+				existing = filtered
+				continue
+			}
+			// Find existing by name
+			var found *types.LLMKeyConfig
+			for _, k := range existing {
+				if k.Name == kp.Name {
+					found = k
+					break
+				}
+			}
+			if found == nil {
+				found = &types.LLMKeyConfig{Name: kp.Name}
+				existing = append(existing, found)
+			}
+			if kp.Provider != "" {
+				found.Provider = kp.Provider
+			}
+			if kp.APIKey != "" {
+				found.APIKey = kp.APIKey
+			}
+			if kp.Default != nil {
+				// Clear other defaults
+				if *kp.Default {
+					for _, k := range existing {
+						k.Default = false
+					}
+				}
+				found.Default = *kp.Default
 			}
 		}
+		updatedCfg.LLMKeys = existing
 	}
 
 	// Providers

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -1,5 +1,36 @@
 package types
 
+import "strings"
+
+// LLMKeyConfig represents a named LLM API key entry in hub.yaml.
+type LLMKeyConfig struct {
+	Name     string `yaml:"name"     json:"name"`     // unique label, e.g. "anthropic-prod"
+	Provider string `yaml:"provider" json:"provider"` // e.g. "anthropic", "fireworks", "moonshot"
+	APIKey   string `yaml:"api_key"  json:"-"`        // the actual key (never exposed in API)
+	Default  bool   `yaml:"default"  json:"default"`  // use when no llm_key specified
+}
+
+// EnvVarName returns the environment variable name for this provider's API key.
+func (k *LLMKeyConfig) EnvVarName() string {
+	switch k.Provider {
+	case "anthropic":
+		return "ANTHROPIC_API_KEY"
+	case "fireworks":
+		return "FIREWORKS_API_KEY"
+	case "moonshot":
+		return "MOONSHOT_API_KEY"
+	case "openai":
+		return "OPENAI_API_KEY"
+	case "groq":
+		return "GROQ_API_KEY"
+	case "deepseek":
+		return "DEEPSEEK_API_KEY"
+	default:
+		// Generic: PROVIDER_API_KEY uppercased
+		return strings.ToUpper(k.Provider) + "_API_KEY"
+	}
+}
+
 // TemplateConfig is the elasticclaw-config.yaml inside a template directory.
 type TemplateConfig struct {
 	Provider     string            `yaml:"provider"`
@@ -10,6 +41,9 @@ type TemplateConfig struct {
 	// DefaultModel overrides the hub-level default model for this template.
 	// Format: provider/model, e.g. anthropic/claude-opus-4-5
 	DefaultModel string                `yaml:"default_model,omitempty"`
+	// LLMKey specifies which named LLM key (from hub.yaml llm_keys) to use.
+	// Omit to use the hub default key.
+	LLMKey string                     `yaml:"llm_key,omitempty"`
 	// Snapshot is the Daytona snapshot name (e.g. "daytona-medium", "daytona-large").
 	// Overrides hub providers.daytona.default_snapshot.
 	Snapshot string                    `yaml:"snapshot,omitempty"`
@@ -89,8 +123,11 @@ type HubConfig struct {
 	// DefaultModel is the model used by all claws unless overridden in the template.
 	// Format: provider/model, e.g. anthropic/claude-sonnet-4-6
 	DefaultModel string            `yaml:"default_model,omitempty"`
-	// LLMKeys is a flat map of provider name to API key, e.g. {"anthropic": "sk-ant-..."}
-	LLMKeys map[string]string      `yaml:"llm_keys,omitempty"`
+	// LLMKeys is a list of named LLM API keys. One can be marked default:true.
+	// Legacy flat map {"anthropic": "sk-..."} is still accepted for backwards compat.
+	LLMKeys    []*LLMKeyConfig   `yaml:"llm_keys,omitempty"`
+	// LLMKeysLegacy is the old flat map format — populated by custom unmarshal.
+	LLMKeysLegacy map[string]string `yaml:"-"`
 	// Linear is a list of Linear workspace configs for injecting API tokens into claws.
 	Linear []*LinearConfig `yaml:"linear,omitempty"`
 
@@ -190,6 +227,9 @@ type CreateClawRequest struct {
 	TTL          string            `json:"ttl,omitempty"`
 	// DefaultModel overrides hub default model for this claw (from template config).
 	DefaultModel string                `json:"default_model,omitempty"`
+	// LLMKey is the name of the LLM key from hub.yaml to use for this claw.
+	// When set and DefaultModel is empty, the hub resolves the model from the key.
+	LLMKey string                     `json:"llm_key,omitempty"`
 	Snapshot     string                `json:"snapshot,omitempty"`
 	Files        map[string]string     `json:"files"`
 	Env          map[string]string     `json:"env,omitempty"`

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -126,8 +126,6 @@ type HubConfig struct {
 	// LLMKeys is a list of named LLM API keys. One can be marked default:true.
 	// Legacy flat map {"anthropic": "sk-..."} is still accepted for backwards compat.
 	LLMKeys    []*LLMKeyConfig   `yaml:"llm_keys,omitempty"`
-	// LLMKeysLegacy is the old flat map format — populated by custom unmarshal.
-	LLMKeysLegacy map[string]string `yaml:"-"`
 	// Linear is a list of Linear workspace configs for injecting API tokens into claws.
 	Linear []*LinearConfig `yaml:"linear,omitempty"`
 

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -327,6 +327,7 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
   const llmKeys = settings.llmKeys || []
   const [newName, setNewName] = useState("")
   const [newProvider, setNewProvider] = useState("anthropic")
+  const [newCustomProvider, setNewCustomProvider] = useState("")
   const [newKey, setNewKey] = useState("")
   const [newDefault, setNewDefault] = useState(false)
 
@@ -388,6 +389,13 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
             </select>
           </div>
         </div>
+        {newProvider === "other" && (
+          <div>
+            <label className="text-xs text-muted-foreground mb-1 block">Custom Provider Name</label>
+            <Input value={newCustomProvider} onChange={e => setNewCustomProvider(e.target.value)}
+              className="h-8 text-sm" placeholder="mistral" />
+          </div>
+        )}
         <div>
           <label className="text-xs text-muted-foreground mb-1 block">API Key</label>
           <Input type="password" value={newKey} onChange={e => setNewKey(e.target.value)}
@@ -397,10 +405,11 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
           <input type="checkbox" checked={newDefault} onChange={e => setNewDefault(e.target.checked)} />
           Set as default key
         </label>
-        <Button size="sm" disabled={saving || !newName || !newKey}
+        <Button size="sm" disabled={saving || !newName || !newKey || (newProvider === "other" && !newCustomProvider)}
           onClick={() => {
-            onSave({ llmKeys: [{ name: newName, provider: newProvider, apiKey: newKey, default: newDefault }] })
-            setNewName(""); setNewKey(""); setNewDefault(false)
+            const actualProvider = newProvider === "other" ? newCustomProvider : newProvider
+            onSave({ llmKeys: [{ name: newName, provider: actualProvider, apiKey: newKey, default: newDefault }] })
+            setNewName(""); setNewKey(""); setNewDefault(false); setNewCustomProvider("")
           }}>
           Add Key
         </Button>

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -9,8 +9,15 @@ import { cn } from "@/lib/utils"
 
 type Section = "runtimes" | "llm" | "github" | "security" | "integrations" | "factories"
 
+interface LLMKeyView {
+  name: string
+  provider: string
+  keySet: boolean
+  default: boolean
+}
+
 interface SettingsData {
-  llmKeys: Record<string, boolean>
+  llmKeys: LLMKeyView[]
   providers: Record<string, {
     type: string
     enabled: boolean
@@ -306,45 +313,97 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
   )
 }
 
+const PROVIDER_OPTIONS = [
+  { value: "anthropic",  label: "Anthropic",  placeholder: "sk-ant-..." },
+  { value: "fireworks",  label: "Fireworks",   placeholder: "fw-..." },
+  { value: "moonshot",   label: "Moonshot (Kimi)", placeholder: "sk-..." },
+  { value: "openai",     label: "OpenAI",      placeholder: "sk-..." },
+  { value: "groq",       label: "Groq",        placeholder: "gsk_..." },
+  { value: "deepseek",   label: "DeepSeek",    placeholder: "sk-..." },
+  { value: "other",      label: "Other",       placeholder: "" },
+]
+
 function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSave: (p: object) => void; saving: boolean }) {
-  const providers = [
-    { id: "anthropic", label: "Anthropic", placeholder: "sk-ant-..." },
-  ]
-  const [keys, setKeys] = useState<Record<string, string>>({})
+  const llmKeys = settings.llmKeys || []
+  const [newName, setNewName] = useState("")
+  const [newProvider, setNewProvider] = useState("anthropic")
+  const [newKey, setNewKey] = useState("")
+  const [newDefault, setNewDefault] = useState(false)
+
+  const providerLabel = (p: string) => PROVIDER_OPTIONS.find(o => o.value === p)?.label ?? p
+  const providerPlaceholder = (p: string) => PROVIDER_OPTIONS.find(o => o.value === p)?.placeholder ?? ""
 
   return (
     <div>
       <h2 className="text-base font-semibold mb-1">LLM Keys</h2>
-      <p className="text-sm text-muted-foreground mb-6">API keys injected into claws at bootstrap time.</p>
-      <div className="space-y-4">
-        {providers.map(({ id, label, placeholder }) => (
-          <div key={id} className="border border-border rounded-lg p-4">
-            <div className="flex items-center justify-between mb-3">
-              <h3 className="font-medium text-sm">{label}</h3>
-              {settings.llmKeys?.[id] && <span className="text-xs bg-green-500/20 text-green-400 px-2 py-1 rounded">Set</span>}
-            </div>
-            <div className="flex gap-2">
-              <Input
-                type="password"
-                placeholder={settings.llmKeys?.[id] ? "••••••••••• (set)" : placeholder}
-                value={keys[id] || ""}
-                onChange={e => setKeys(prev => ({ ...prev, [id]: e.target.value }))}
-                className="h-8 text-sm flex-1"
-              />
-              <Button size="sm" disabled={saving || !keys[id]} onClick={() => {
-                onSave({ llmKeys: { [id]: keys[id] } })
-                setKeys(prev => ({ ...prev, [id]: "" }))
-              }}>
-                Save
-              </Button>
-              {settings.llmKeys?.[id] && (
-                <Button size="sm" variant="outline" disabled={saving} onClick={() => onSave({ llmKeys: { [id]: "" } })}>
+      <p className="text-sm text-muted-foreground mb-6">
+        Named API keys injected into claws at bootstrap. The default key's model is used unless overridden by the template.
+      </p>
+
+      {/* Existing keys */}
+      {llmKeys.length > 0 && (
+        <div className="space-y-2 mb-6">
+          {llmKeys.map((k) => (
+            <div key={k.name} className="border border-border rounded-lg p-3 flex items-center justify-between gap-3">
+              <div className="min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium">{k.name}</span>
+                  <span className="text-xs text-muted-foreground">{providerLabel(k.provider)}</span>
+                  {k.default && <span className="text-xs bg-primary/20 text-primary px-1.5 py-0.5 rounded">default</span>}
+                  {k.keySet
+                    ? <span className="text-xs text-green-500">✓ set</span>
+                    : <span className="text-xs text-amber-500">✗ not set</span>}
+                </div>
+              </div>
+              <div className="flex gap-2 shrink-0">
+                {!k.default && (
+                  <Button size="sm" variant="outline" disabled={saving}
+                    onClick={() => onSave({ llmKeys: [{ name: k.name, default: true }] })}>
+                    Set default
+                  </Button>
+                )}
+                <Button size="sm" variant="ghost" className="text-destructive" disabled={saving}
+                  onClick={() => onSave({ llmKeys: [{ name: k.name, delete: true }] })}>
                   Remove
                 </Button>
-              )}
+              </div>
             </div>
+          ))}
+        </div>
+      )}
+
+      {/* Add new key */}
+      <div className="border border-border rounded-lg p-4 space-y-3">
+        <p className="text-xs font-medium text-muted-foreground">Add key</p>
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="text-xs text-muted-foreground mb-1 block">Name</label>
+            <Input value={newName} onChange={e => setNewName(e.target.value)} className="h-8 text-sm" placeholder="anthropic-prod" />
           </div>
-        ))}
+          <div>
+            <label className="text-xs text-muted-foreground mb-1 block">Provider</label>
+            <select value={newProvider} onChange={e => setNewProvider(e.target.value)}
+              className="w-full h-8 rounded-md border border-border bg-background px-2 text-sm">
+              {PROVIDER_OPTIONS.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+            </select>
+          </div>
+        </div>
+        <div>
+          <label className="text-xs text-muted-foreground mb-1 block">API Key</label>
+          <Input type="password" value={newKey} onChange={e => setNewKey(e.target.value)}
+            className="h-8 text-sm" placeholder={providerPlaceholder(newProvider)} />
+        </div>
+        <label className="flex items-center gap-2 text-sm cursor-pointer">
+          <input type="checkbox" checked={newDefault} onChange={e => setNewDefault(e.target.checked)} />
+          Set as default key
+        </label>
+        <Button size="sm" disabled={saving || !newName || !newKey}
+          onClick={() => {
+            onSave({ llmKeys: [{ name: newName, provider: newProvider, apiKey: newKey, default: newDefault }] })
+            setNewName(""); setNewKey(""); setNewDefault(false)
+          }}>
+          Add Key
+        </Button>
       </div>
     </div>
   )


### PR DESCRIPTION
## hub.yaml (new format)
```yaml
llm_keys:
  - name: anthropic-prod
    provider: anthropic
    api_key: sk-ant-...
    default: true
  - name: fireworks-kimi
    provider: fireworks
    api_key: fw-...
```

## elasticclaw-config.yaml (optional override)
```yaml
llm_key: fireworks-kimi   # use this key; omit = hub default
```

## What changed
- **Multiple keys** per provider or across providers, each with a name
- **Default key** — one marked `default: true`, used when template doesn't specify
- **Per-template override** — `llm_key: name` in elasticclaw-config.yaml
- **All keys injected** as env vars at bootstrap (`ANTHROPIC_API_KEY`, `FIREWORKS_API_KEY`, etc.) — OpenClaw picks the right one based on `default_model` provider prefix
- **Backwards compat** — old flat `{anthropic: sk-...}` format auto-migrated on load
- **Supported providers**: anthropic, fireworks, moonshot, openai, groq, deepseek, + generic fallback
- **Settings UI**: list with provider label, default badge, add/remove/set-default