### PR TITLE
feat: on/off toggle per factory

### DIFF
--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -137,6 +137,10 @@ func (s *Server) processLinearEvent(payload linearWebhookPayload) {
 		if factory.Integration != "linear" {
 			continue
 		}
+		// Skip disabled factories
+		if factory.Enabled != nil && !*factory.Enabled {
+			continue
+		}
 		if factory.Team != "" && !strings.EqualFold(factory.Team, teamKey) {
 			continue
 		}

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -182,7 +182,7 @@ func (s *Server) processLinearEvent(payload linearWebhookPayload) {
 	if !matched {
 		// Webhook received but no factory matched — log as not_actionable
 		for _, factory := range s.hubCfg.Factories {
-			if factory.Integration == "linear" && (factory.Team == "" || strings.EqualFold(factory.Team, teamKey)) {
+			if factory.Integration == "linear" && (factory.Enabled == nil || *factory.Enabled) && (factory.Team == "" || strings.EqualFold(factory.Team, teamKey)) {
 				s.logFactoryEvent(factory.Name, issueID, payload.Data.Title, previousStatus, currentStatus, "not_actionable",
 					"", fmt.Sprintf("status '%s'→'%s' did not match trigger '%s'", previousStatus, currentStatus, factory.TriggerStatus))
 			}
@@ -259,11 +259,11 @@ func (s *Server) createClawForIssue(factory *types.FactoryConfig, payload linear
 	// Resolve template config fields (from elasticclaw-config.yaml if present).
 	// Factory-level overrides (color, tags) take precedence over template config.
 	var (
-		instanceType   string
-		defaultModel   string
-		llmKey         string
-		nixEnabled     int
-		githubRepos    []types.GitHubRepoAccess
+		instanceType    string
+		defaultModel    string
+		llmKey          string
+		nixEnabled      int
+		githubRepos     []types.GitHubRepoAccess
 		linearWorkspace string
 	)
 	if tmplCfg != nil {

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -45,6 +45,11 @@ type LinearIntegrationView struct {
 	WebhookSecretSet bool   `json:"webhookSecretSet"`
 }
 
+// isFactoryEnabled returns true if the factory is enabled (nil = enabled by default).
+func isFactoryEnabled(f *types.FactoryConfig) bool {
+	return f.Enabled == nil || *f.Enabled
+}
+
 type FactoryView struct {
 	Name             string   `json:"name"`
 	Integration      string   `json:"integration"`
@@ -58,6 +63,7 @@ type FactoryView struct {
 	WebhookSecretSet bool     `json:"webhookSecretSet"`
 	Tags             []string `json:"tags"`
 	Color            string   `json:"color"`
+	Enabled          bool     `json:"enabled"`
 }
 
 type ProviderView struct {
@@ -125,6 +131,7 @@ type FactoryPatch struct {
 	WebhookSecret    string   `json:"webhookSecret,omitempty"`
 	Tags             []string `json:"tags,omitempty"`
 	Color            string   `json:"color,omitempty"`
+	Enabled          *bool    `json:"enabled,omitempty"`
 }
 
 type ProviderPatch struct {
@@ -252,6 +259,7 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 			WebhookSecretSet: f.WebhookSecret != "",
 			Tags:             f.Tags,
 			Color:            f.Color,
+			Enabled:          isFactoryEnabled(f),
 		})
 	}
 	s.mu.RUnlock()
@@ -461,7 +469,7 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 				TriggerStatus: fp.TriggerStatus, DoneStatus: fp.DoneStatus,
 				TerminateOnLeave: fp.TerminateOnLeave, Template: fp.Template,
 				NamePattern: fp.NamePattern, WebhookSecret: webhookSecret,
-				Tags: fp.Tags, Color: fp.Color,
+				Tags: fp.Tags, Color: fp.Color, Enabled: fp.Enabled,
 			})
 		}
 		updatedCfg.Factories = factories

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -173,6 +173,7 @@ type LinearIntegrationConfig struct {
 // FactoryConfig defines an automation rule that creates claws based on integration events.
 type FactoryConfig struct {
 	Name              string `yaml:"name"`
+	Enabled           *bool  `yaml:"enabled,omitempty"`  // nil = true (default on); set false to pause
 	Integration       string `yaml:"integration"`        // "linear" (future: "shortcut", "github-issues")
 	Workspace         string `yaml:"workspace"`          // matches integrations.<type>[].workspace
 	Team              string `yaml:"team,omitempty"`     // Linear team key (e.g. "ELA")

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -36,7 +36,7 @@ interface SettingsData {
   factories?: Array<{
     name: string; integration: string; workspace: string; team: string
     triggerStatus: string; doneStatus: string; terminateOnLeave: boolean; template: string
-    webhookSecretSet?: boolean; tags?: string[]; color?: string
+    webhookSecretSet?: boolean; tags?: string[]; color?: string; enabled?: boolean
   }>
 }
 
@@ -747,15 +747,29 @@ function FactoriesSection({ hubUrl, settings, onSave, saving }: { hubUrl: string
                   </div>
                 </div>
               ) : (
-                <div className="border border-border rounded-lg p-4 flex items-center justify-between">
+                <div className={cn("border rounded-lg p-4 flex items-center justify-between", (f.enabled ?? true) ? "border-border" : "border-border/50 opacity-60")}>
                   <div>
-                    <p className="text-sm font-medium">{f.name}</p>
+                    <div className="flex items-center gap-2">
+                      <p className="text-sm font-medium">{f.name}</p>
+                      {!(f.enabled ?? true) && <span className="text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded">paused</span>}
+                    </div>
                     <p className="text-xs text-muted-foreground">
                       {f.integration} · {f.team || f.workspace} · "{f.triggerStatus}" → {f.template}
                       {" · webhook: "}{f.webhookSecretSet ? <span className="text-green-500">✓</span> : <span className="text-amber-500">not set</span>}
                     </p>
                   </div>
                   <div className="flex items-center gap-2">
+                    <label className="flex items-center gap-1.5 cursor-pointer" title={(f.enabled ?? true) ? "Pause factory" : "Enable factory"}>
+                      <span className="text-xs text-muted-foreground">{(f.enabled ?? true) ? "On" : "Off"}</span>
+                      <input type="checkbox" checked={f.enabled ?? true}
+                        onChange={e => {
+                          const enabled = e.target.checked
+                          const updated = factories.map((x, j) => j === i ? { ...x, enabled } : x)
+                          onSave({ factories: updated })
+                        }}
+                        className="size-3.5 accent-primary"
+                      />
+                    </label>
                     <a href={`/factories?name=${encodeURIComponent(f.name)}`} className="text-xs text-primary hover:underline whitespace-nowrap">Activity</a>
                     <Button size="sm" variant="outline" onClick={() => {
                       setEditingFactory(i)

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -105,6 +105,16 @@ export default function SettingsPage() {
     }
   }
 
+  // Silent save: patches without the global 'Saved' banner (used for toggle-style updates)
+  async function saveSilent(patch: object) {
+    try {
+      await patchSettings(patch)
+      await load()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Save failed")
+    }
+  }
+
   const navItems: { id: Section; label: string; icon: React.ElementType }[] = [
     { id: "runtimes", label: "Sandbox Runtimes", icon: Cpu },
     { id: "llm", label: "LLM Keys", icon: Key },
@@ -173,7 +183,7 @@ export default function SettingsPage() {
             <IntegrationsSection settings={settings} onSave={save} saving={saving} />
           )}
           {settings && section === "factories" && (
-            <FactoriesSection hubUrl={hubPublicUrl} settings={settings} onSave={save} saving={saving} />
+            <FactoriesSection hubUrl={hubPublicUrl} settings={settings} onSave={save} onSaveSilent={saveSilent} saving={saving} />
           )}
         </main>
       </div>
@@ -639,7 +649,8 @@ interface FactoryFormData {
   webhookSecret: string; tags: string; color: string; originalName?: string
 }
 
-function FactoriesSection({ hubUrl, settings, onSave, saving }: { hubUrl: string; settings: SettingsData; onSave: (p: object) => void; saving: boolean }) {
+function FactoriesSection({ hubUrl, settings, onSave, onSaveSilent, saving }: { hubUrl: string; settings: SettingsData; onSave: (p: object) => void; onSaveSilent: (p: object) => void; saving: boolean }) {
+  const [savedFactory, setSavedFactory] = useState<string | null>(null)
   const factories = settings.factories || []
   const [copied, setCopied] = useState(false)
   const webhookUrl = hubUrl ? `${hubUrl}/api/integrations/linear/webhook` : ""
@@ -759,22 +770,31 @@ function FactoriesSection({ hubUrl, settings, onSave, saving }: { hubUrl: string
                     </p>
                   </div>
                   <div className="flex items-center gap-2">
-                    {/* Toggle switch */}
+                    {/* Toggle switch — uses silent save to avoid global 'Saved' banner */}
+                    {savedFactory === f.name && (
+                      <span className="text-xs text-green-500">✓</span>
+                    )}
                     <button
-                      onClick={() => {
+                      onClick={async () => {
                         const enabled = !(f.enabled ?? true)
                         const updated = factories.map((x, j) => j === i ? { ...x, enabled } : x)
-                        onSave({ factories: updated })
+                        setSavedFactory(f.name)
+                        setTimeout(() => setSavedFactory(null), 1500)
+                        onSaveSilent({ factories: updated })
                       }}
                       className={cn(
-                        "relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200",
-                        (f.enabled ?? true) ? "bg-primary" : "bg-muted-foreground/30"
+                        "relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full transition-colors duration-200",
+                        (f.enabled ?? true)
+                          ? "bg-primary border-2 border-transparent"
+                          : "bg-transparent border-2 border-muted-foreground/40"
                       )}
                       title={(f.enabled ?? true) ? "Pause factory" : "Enable factory"}
                     >
                       <span className={cn(
-                        "pointer-events-none inline-block size-4 rounded-full bg-white shadow-sm transform transition-transform duration-200",
-                        (f.enabled ?? true) ? "translate-x-4" : "translate-x-0"
+                        "pointer-events-none inline-block size-4 rounded-full shadow-sm transform transition-transform duration-200",
+                        (f.enabled ?? true)
+                          ? "bg-white translate-x-4"
+                          : "bg-muted-foreground/50 translate-x-0"
                       )} />
                     </button>
                     <Button size="sm" variant="outline" onClick={() => window.open(`/factories?name=${encodeURIComponent(f.name)}`, '_self')}>Activity</Button>

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -759,18 +759,25 @@ function FactoriesSection({ hubUrl, settings, onSave, saving }: { hubUrl: string
                     </p>
                   </div>
                   <div className="flex items-center gap-2">
-                    <label className="flex items-center gap-1.5 cursor-pointer" title={(f.enabled ?? true) ? "Pause factory" : "Enable factory"}>
-                      <span className="text-xs text-muted-foreground">{(f.enabled ?? true) ? "On" : "Off"}</span>
-                      <input type="checkbox" checked={f.enabled ?? true}
-                        onChange={e => {
-                          const enabled = e.target.checked
-                          const updated = factories.map((x, j) => j === i ? { ...x, enabled } : x)
-                          onSave({ factories: updated })
-                        }}
-                        className="size-3.5 accent-primary"
-                      />
-                    </label>
-                    <a href={`/factories?name=${encodeURIComponent(f.name)}`} className="text-xs text-primary hover:underline whitespace-nowrap">Activity</a>
+                    {/* Toggle switch */}
+                    <button
+                      onClick={() => {
+                        const enabled = !(f.enabled ?? true)
+                        const updated = factories.map((x, j) => j === i ? { ...x, enabled } : x)
+                        onSave({ factories: updated })
+                      }}
+                      className={cn(
+                        "relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200",
+                        (f.enabled ?? true) ? "bg-primary" : "bg-muted-foreground/30"
+                      )}
+                      title={(f.enabled ?? true) ? "Pause factory" : "Enable factory"}
+                    >
+                      <span className={cn(
+                        "pointer-events-none inline-block size-4 rounded-full bg-white shadow-sm transform transition-transform duration-200",
+                        (f.enabled ?? true) ? "translate-x-4" : "translate-x-0"
+                      )} />
+                    </button>
+                    <Button size="sm" variant="outline" onClick={() => window.open(`/factories?name=${encodeURIComponent(f.name)}`, '_self')}>Activity</Button>
                     <Button size="sm" variant="outline" onClick={() => {
                       setEditingFactory(i)
                       setEditForm({ name: f.name, workspace: f.workspace, team: f.team || "", triggerStatus: f.triggerStatus, doneStatus: f.doneStatus || "", terminateOnLeave: f.terminateOnLeave, template: f.template, webhookSecret: "", tags: (f.tags || []).join(", "), color: f.color || "", originalName: f.name })

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -785,7 +785,7 @@ function FactoriesSection({ hubUrl, settings, onSave, onSaveSilent, saving }: { 
                       className={cn(
                         "relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full transition-colors duration-200",
                         (f.enabled ?? true)
-                          ? "bg-primary border-2 border-transparent"
+                          ? "bg-green-600 border-2 border-transparent"
                           : "bg-transparent border-2 border-muted-foreground/40"
                       )}
                       title={(f.enabled ?? true) ? "Pause factory" : "Enable factory"}


### PR DESCRIPTION
Each factory in Settings → Factories now has an on/off checkbox.\n\n- **On**: normal behavior, webhook events processed\n- **Off**: factory is dimmed with a 'paused' badge; all webhook events for that factory are silently ignored\n\nThe toggle updates `enabled` in hub.yaml via the settings API. Default is on (nil = enabled).