### PR TITLE
fix: factory wake message fires when gateway_ready=true on connect

### DIFF
--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -563,7 +563,12 @@ func (s *Server) validateDonePRs(clawID string, prURLs []string, ghToken string)
 
 	var problems []string
 	for _, pr := range extractPRs(strings.Join(prURLs, " ")) {
-		data, err := githubAPIWithBase(base, fmt.Sprintf("repos/%s/pulls/%d", pr.repo, pr.number), ghToken)
+		// Use a repo-scoped token so private repos are accessible
+		tokenForPR := s.resolveGitHubTokenForRepo(pr.repo)
+		if tokenForPR == "" {
+			tokenForPR = ghToken // fallback to unscoped
+		}
+		data, err := githubAPIWithBase(base, fmt.Sprintf("repos/%s/pulls/%d", pr.repo, pr.number), tokenForPR)
 		if err != nil {
 			problems = append(problems, fmt.Sprintf("- could not fetch %s: %v", pr.url, err))
 			continue

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -162,16 +162,15 @@ func (s *Server) pollAllPRs() {
 	}
 }
 
-// resolveGitHubTokenForRepo returns a GitHub App installation token scoped to the given repo.
-// Use this for private repos — an unscoped token won't have read access.
-func (s *Server) resolveGitHubTokenForRepo(repo string) string {
+// resolveGitHubTokenWithRepos is a shared helper that resolves a GitHub App installation token
+// with optional repo-scoped access.
+func (s *Server) resolveGitHubTokenWithRepos(repoAccess []RepoAccess) string {
 	s.mu.RLock()
 	cfg := s.hubCfg
 	s.mu.RUnlock()
 	if len(cfg.GitHubApps) == 0 {
 		return ""
 	}
-	repoAccess := []RepoAccess{{Repo: repo, Permissions: "read"}}
 	for _, appCfg := range cfg.GitHubApps {
 		provider, err := NewGitHubTokenProvider(appCfg)
 		if err != nil {
@@ -186,26 +185,15 @@ func (s *Server) resolveGitHubTokenForRepo(repo string) string {
 	return ""
 }
 
+// resolveGitHubTokenForRepo returns a GitHub App installation token scoped to the given repo.
+// Use this for private repos — an unscoped token won't have read access.
+func (s *Server) resolveGitHubTokenForRepo(repo string) string {
+	return s.resolveGitHubTokenWithRepos([]RepoAccess{{Repo: repo, Permissions: "read"}})
+}
+
 // resolveGitHubToken returns a GitHub App installation token for PR polling.
 func (s *Server) resolveGitHubToken() string {
-	s.mu.RLock()
-	cfg := s.hubCfg
-	s.mu.RUnlock()
-	if len(cfg.GitHubApps) == 0 {
-		return ""
-	}
-	for _, appCfg := range cfg.GitHubApps {
-		provider, err := NewGitHubTokenProvider(appCfg)
-		if err != nil {
-			continue
-		}
-		token, _, err := provider.InstallationToken(context.Background(), 0, nil)
-		if err != nil {
-			continue
-		}
-		return token
-	}
-	return ""
+	return s.resolveGitHubTokenWithRepos(nil)
 }
 
 // checkCIFailures polls PR check runs and injects a message on new failures.

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -162,6 +162,30 @@ func (s *Server) pollAllPRs() {
 	}
 }
 
+// resolveGitHubTokenForRepo returns a GitHub App installation token scoped to the given repo.
+// Use this for private repos — an unscoped token won't have read access.
+func (s *Server) resolveGitHubTokenForRepo(repo string) string {
+	s.mu.RLock()
+	cfg := s.hubCfg
+	s.mu.RUnlock()
+	if len(cfg.GitHubApps) == 0 {
+		return ""
+	}
+	repoAccess := []RepoAccess{{Repo: repo, Permissions: "read"}}
+	for _, appCfg := range cfg.GitHubApps {
+		provider, err := NewGitHubTokenProvider(appCfg)
+		if err != nil {
+			continue
+		}
+		token, _, err := provider.InstallationToken(context.Background(), 0, repoAccess)
+		if err != nil {
+			continue
+		}
+		return token
+	}
+	return ""
+}
+
 // resolveGitHubToken returns a GitHub App installation token for PR polling.
 func (s *Server) resolveGitHubToken() string {
 	s.mu.RLock()

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -894,6 +894,12 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 	// Broadcast initial status to user sessions
 	s.broadcastToUsers(tenantID, types.WSMessage{Type: "claw_status", Payload: map[string]string{"claw_id": clawID, "status": initialStatus(rp.GatewayReady)}})
 
+	// If gateway is already ready on connect (common for factory claws where bootstrap
+	// completes before bridge registers), fire the wake message immediately.
+	if cc.gatewayReady {
+		go s.sendWakeMessage(cc, clawID)
+	}
+
 	// Read loop — claw sends messages back to users
 	defer func() {
 		s.mu.Lock()
@@ -947,17 +953,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 								Payload: map[string]string{"claw_id": clawID, "status": "connected"},
 							})
 							log.Printf("[bridge] ✓ ready: %s (%s)", rp.Name, clawID[:8])
-							// Send a silent wake message to trigger an intro response.
-							// Not stored in DB — invisible to user, just wakes the agent.
-							go func(c *clawConn) {
-								wakeMsg := types.HubMessage{
-									ID:      uuid.New().String(),
-									ClawID:  clawID,
-									Role:    "system",
-									Content: "Introduce yourself briefly and let the user know you're ready to help.",
-								}
-								_ = wsjson.Write(context.Background(), c.conn, types.WSMessage{Type: "message", Payload: wakeMsg})
-							}(cc)
+							go s.sendWakeMessage(cc, clawID)
 						} else if !hb.GatewayHealthy && prevHealthy {
 							// Gateway went unhealthy
 							log.Printf("[heartbeat] %s (%s): gateway unhealthy", rp.Name, clawID[:8])
@@ -1847,6 +1843,25 @@ func (s *Server) bridgeDownloadURL() string {
 
 // bootstrapReplicated SSHes into a newly-running Replicated VM, pulls the
 // claw-bridge binary from GitHub Releases, and starts it with hub connection env vars.
+// sendWakeMessage sends a silent system message to wake the agent.
+// For factory claws (those with a linear_issue_id), it sends a task-specific prompt.
+// Not stored in DB — invisible to the user but triggers the agent to respond.
+func (s *Server) sendWakeMessage(cc *clawConn, clawID string) {
+	wakeContent := "Introduce yourself briefly and let the user know you're ready to help."
+	var issueID string
+	_ = s.db.QueryRow(`SELECT COALESCE(linear_issue_id,'') FROM claws WHERE id=?`, clawID).Scan(&issueID)
+	if issueID != "" {
+		wakeContent = "Read your BOOTSTRAP.md file to understand the task. Then explore the codebase, plan your approach, and begin working on it. Reply with a brief summary of what you found and your plan."
+	}
+	wakeMsg := types.HubMessage{
+		ID:      uuid.New().String(),
+		ClawID:  clawID,
+		Role:    "system",
+		Content: wakeContent,
+	}
+	_ = wsjson.Write(context.Background(), cc.conn, types.WSMessage{Type: "message", Payload: wakeMsg})
+}
+
 func (s *Server) bootstrapReplicated(clawID, clawName, vmID string, cfg types.ProviderConfig) {
 	// Bail immediately if claw was deleted while VM was spinning up
 	var checkStatus string

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1851,7 +1851,7 @@ func (s *Server) sendWakeMessage(cc *clawConn, clawID string) {
 	var issueID string
 	_ = s.db.QueryRow(`SELECT COALESCE(linear_issue_id,'') FROM claws WHERE id=?`, clawID).Scan(&issueID)
 	if issueID != "" {
-		wakeContent = "Read your BOOTSTRAP.md file to understand the task. Then explore the codebase, plan your approach, and begin working on it. Reply with a brief summary of what you found and your plan."
+		wakeContent = "Read your BOOTSTRAP.md now. Then immediately start working on the task — do not ask for permission or confirmation. Explore the codebase, implement the change, and report back with what you did."
 	}
 	wakeMsg := types.HubMessage{
 		ID:      uuid.New().String(),


### PR DESCRIPTION
Factory bootstrap completes **before** bridge registers with the hub (13s gap in logs). Bridge connected with `gateway_ready=true` so the false→true heartbeat transition never fired and the wake message was lost.\n\nFix: also fire `sendWakeMessage` immediately on connect when `gateway_ready=true`.\n\nExtracted shared `sendWakeMessage()` method used by both paths.