### PR TITLE
fix: destroy VM on [DONE] — bridge was reconnecting after task complete

### DIFF
--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -474,9 +474,9 @@ func buildLinearContext(payload linearWebhookPayload) string {
 // If no valid open PRs are found (and a GH App is configured), it injects an
 // error message back so the claw can retry.
 func (s *Server) handleClawDoneSignal(clawID, rawMessage string) {
-	// Get the linear_issue_id for this claw
-	var issueID string
-	if err := s.db.QueryRow(`SELECT linear_issue_id FROM claws WHERE id = ?`, clawID).Scan(&issueID); err != nil || issueID == "" {
+	// Get the linear_issue_id and tenant for this claw
+	var issueID, tenantID string
+	if err := s.db.QueryRow(`SELECT linear_issue_id, tenant_id FROM claws WHERE id = ?`, clawID).Scan(&issueID, &tenantID); err != nil || issueID == "" {
 		return // not a factory claw
 	}
 
@@ -523,14 +523,27 @@ func (s *Server) handleClawDoneSignal(clawID, rawMessage string) {
 		}
 	}
 
-	// Mark claw as completed
-	_, _ = s.db.Exec(`UPDATE claws SET status='completed' WHERE id=?`, clawID)
+	// Mark as deleted and destroy the VM so the bridge can't reconnect
+	var providerID string
+	_ = s.db.QueryRow(`SELECT COALESCE(provider_id,'') FROM claws WHERE id=?`, clawID).Scan(&providerID)
+	_, _ = s.db.Exec(`UPDATE claws SET status='deleted' WHERE id=?`, clawID)
 	s.mu.Lock()
 	if cc, ok := s.claws[clawID]; ok {
 		cc.conn.Close(1000, "factory: claw signaled done")
 		delete(s.claws, clawID)
 	}
 	s.mu.Unlock()
+	// Broadcast deletion so dashboard card disappears
+	if tenantID != "" {
+		s.broadcastToUsers(tenantID, types.WSMessage{
+			Type:    "claw_status",
+			Payload: map[string]string{"claw_id": clawID, "status": "deleted"},
+		})
+	}
+	// Destroy the VM so the bridge process terminates and can't reconnect
+	if providerID != "" {
+		go s.terminateReplicatedVM(providerID)
+	}
 }
 
 // extractDonePRURLs parses PR URLs from a [DONE] message.

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -523,27 +523,17 @@ func (s *Server) handleClawDoneSignal(clawID, rawMessage string) {
 		}
 	}
 
-	// Mark as deleted and destroy the VM so the bridge can't reconnect
-	var providerID string
-	_ = s.db.QueryRow(`SELECT COALESCE(provider_id,'') FROM claws WHERE id=?`, clawID).Scan(&providerID)
-	_, _ = s.db.Exec(`UPDATE claws SET status='deleted' WHERE id=?`, clawID)
-	s.mu.Lock()
-	if cc, ok := s.claws[clawID]; ok {
-		cc.conn.Close(1000, "factory: claw signaled done")
-		delete(s.claws, clawID)
-	}
-	s.mu.Unlock()
-	// Broadcast deletion so dashboard card disappears
-	if tenantID != "" {
-		s.broadcastToUsers(tenantID, types.WSMessage{
-			Type:    "claw_status",
-			Payload: map[string]string{"claw_id": clawID, "status": "deleted"},
-		})
-	}
-	// Destroy the VM so the bridge process terminates and can't reconnect
-	if providerID != "" {
-		go s.terminateReplicatedVM(providerID)
-	}
+	// Keep the claw running — it stays connected to watch for CI failures,
+	// bugbot comments, and PR events. The claw will be terminated when the
+	// PR is merged or closed (polled by checkPRMerged).
+	// Just mark it as 'watching' so the UI shows it differently.
+	_, _ = s.db.Exec(`UPDATE claws SET status='idle' WHERE id=?`, clawID)
+	s.broadcastToUsers(tenantID, types.WSMessage{
+		Type:    "claw_status",
+		Payload: map[string]string{"claw_id": clawID, "status": "idle"},
+	})
+	// Notify the claw it's in watch mode
+	s.injectUserMessage(clawID, "PR created and Linear issue updated. Staying connected to watch for CI failures and review comments. Will terminate when PR is merged or closed.")
 }
 
 // extractDonePRURLs parses PR URLs from a [DONE] message.

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -527,7 +527,14 @@ func (s *Server) handleClawDoneSignal(clawID, rawMessage string) {
 	// bugbot comments, and PR events. The claw will be terminated when the
 	// PR is merged or closed (polled by checkPRMerged).
 	// Just mark it as 'watching' so the UI shows it differently.
-	_, _ = s.db.Exec(`UPDATE claws SET status='idle' WHERE id=?`, clawID)
+	res, err := s.db.Exec(`UPDATE claws SET status='idle' WHERE id=? AND status NOT IN ('deleted','error')`, clawID)
+	if err != nil {
+		return
+	}
+	rowsAffected, err := res.RowsAffected()
+	if err != nil || rowsAffected == 0 {
+		return
+	}
 	s.broadcastToUsers(tenantID, types.WSMessage{
 		Type:    "claw_status",
 		Payload: map[string]string{"claw_id": clawID, "status": "idle"},

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -153,6 +153,10 @@ func (s *Server) pollAllPRs() {
 	}
 
 	for _, r := range prs {
+		// Always check if PR is merged/closed — if so, terminate the claw
+		if s.checkPRMerged(r.pr, token) {
+			continue // claw is being terminated, skip other checks
+		}
 		if r.autoFixCI {
 			s.checkCIFailures(r.pr, token)
 		}
@@ -520,4 +524,62 @@ func (s *Server) handleClawSettings(w http.ResponseWriter, r *http.Request, claw
 		return
 	}
 	http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+}
+
+// checkPRMerged checks if a tracked PR is merged or closed.
+// If so, terminates the claw and returns true.
+func (s *Server) checkPRMerged(pr clawPR, token string) bool {
+	tokenForPR := s.resolveGitHubTokenForRepo(pr.repo)
+	if tokenForPR == "" {
+		tokenForPR = token
+	}
+	data, err := githubAPI(fmt.Sprintf("repos/%s/pulls/%d", pr.repo, pr.prNumber), tokenForPR)
+	if err != nil {
+		return false
+	}
+	state, _ := data["state"].(string)
+	merged, _ := data["merged"].(bool)
+
+	if state != "closed" && !merged {
+		return false // still open
+	}
+
+	// PR is merged or closed — terminate the claw
+	var clawID, tenantID string
+	if err := s.db.QueryRow(`SELECT claw_id FROM claw_prs WHERE id=?`, pr.id).Scan(&clawID); err != nil {
+		return true
+	}
+	if err := s.db.QueryRow(`SELECT tenant_id FROM claws WHERE id=?`, clawID).Scan(&tenantID); err != nil {
+		return true
+	}
+
+	action := "merged"
+	if !merged {
+		action = "closed"
+	}
+	log.Printf("[pr-watcher] PR %s#%d %s — terminating claw %s", pr.repo, pr.prNumber, action, clawID[:8])
+
+	var providerID string
+	_ = s.db.QueryRow(`SELECT COALESCE(provider_id,'') FROM claws WHERE id=?`, clawID).Scan(&providerID)
+
+	_, _ = s.db.Exec(`DELETE FROM claw_prs WHERE claw_id=?`, clawID)
+	_, _ = s.db.Exec(`UPDATE claws SET status='deleted' WHERE id=?`, clawID)
+
+	s.mu.Lock()
+	if cc, ok := s.claws[clawID]; ok {
+		cc.conn.Close(1000, fmt.Sprintf("factory: PR %s", action))
+		delete(s.claws, clawID)
+	}
+	s.mu.Unlock()
+
+	s.broadcastToUsers(tenantID, types.WSMessage{
+		Type:    "claw_status",
+		Payload: map[string]string{"claw_id": clawID, "status": "deleted"},
+	})
+
+	if providerID != "" {
+		go s.terminateReplicatedVM(providerID)
+	}
+
+	return true
 }

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -564,8 +564,8 @@ func (s *Server) checkPRMerged(pr clawPR, token string) bool {
 	}
 	log.Printf("[pr-watcher] PR %s#%d %s — terminating claw %s", pr.repo, pr.prNumber, action, clawID[:8])
 
-	var providerID string
-	_ = s.db.QueryRow(`SELECT COALESCE(provider_id,'') FROM claws WHERE id=?`, clawID).Scan(&providerID)
+	var providerID, provider string
+	_ = s.db.QueryRow(`SELECT COALESCE(provider_id,''), COALESCE(provider,'') FROM claws WHERE id=?`, clawID).Scan(&providerID, &provider)
 
 	_, _ = s.db.Exec(`DELETE FROM claw_prs WHERE claw_id=?`, clawID)
 	_, _ = s.db.Exec(`UPDATE claws SET status='deleted' WHERE id=?`, clawID)
@@ -583,7 +583,7 @@ func (s *Server) checkPRMerged(pr clawPR, token string) bool {
 	})
 
 	if providerID != "" {
-		go s.terminateReplicatedVM(providerID)
+		go s.terminateVM(provider, providerID)
 	}
 
 	return true

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -545,10 +545,8 @@ func (s *Server) checkPRMerged(pr clawPR, token string) bool {
 	}
 
 	// PR is merged or closed — terminate the claw
-	var clawID, tenantID string
-	if err := s.db.QueryRow(`SELECT claw_id FROM claw_prs WHERE id=?`, pr.id).Scan(&clawID); err != nil {
-		return true
-	}
+	clawID := pr.clawID
+	var tenantID string
 	if err := s.db.QueryRow(`SELECT tenant_id FROM claws WHERE id=?`, clawID).Scan(&tenantID); err != nil {
 		return true
 	}

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -556,7 +556,7 @@ func (s *Server) checkPRMerged(pr clawPR, token string) bool {
 	clawID := pr.clawID
 	var tenantID string
 	if err := s.db.QueryRow(`SELECT tenant_id FROM claws WHERE id=?`, clawID).Scan(&tenantID); err != nil {
-		return true
+		return false
 	}
 
 	action := "merged"

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -118,7 +118,7 @@ type clawPR struct {
 func (s *Server) pollAllPRs() {
 	rows, err := s.db.Query(`
 		SELECT cp.id, cp.claw_id, cp.repo, cp.pr_number, cp.pr_url, cp.last_ci_sha, cp.last_comment_id,
-		       cl.auto_fix_ci, cl.auto_fix_bugbot
+		       cl.auto_fix_ci, cl.auto_fix_bugbot, cl.status
 		FROM claw_prs cp
 		JOIN claws cl ON cl.id = cp.claw_id
 		WHERE cl.status NOT IN ('deleted','error','offline')
@@ -132,13 +132,14 @@ func (s *Server) pollAllPRs() {
 		pr            clawPR
 		autoFixCI     bool
 		autoFixBugbot bool
+		clawStatus    string
 	}
 	var prs []row
 	for rows.Next() {
 		var r row
 		var ciInt, bugbotInt int
 		if err := rows.Scan(&r.pr.id, &r.pr.clawID, &r.pr.repo, &r.pr.prNumber, &r.pr.prURL,
-			&r.pr.lastCISHA, &r.pr.lastCommentID, &ciInt, &bugbotInt); err != nil {
+			&r.pr.lastCISHA, &r.pr.lastCommentID, &ciInt, &bugbotInt, &r.clawStatus); err != nil {
 			continue
 		}
 		r.autoFixCI = ciInt == 1
@@ -159,8 +160,8 @@ func (s *Server) pollAllPRs() {
 			continue
 		}
 
-		// Always check if PR is merged/closed — if so, terminate the claw
-		if s.checkPRMerged(r.pr, token) {
+		// Only check if PR is merged/closed for idle claws (factory claws that sent [DONE])
+		if r.clawStatus == "idle" && s.checkPRMerged(r.pr, token) {
 			terminatedClaws[r.pr.clawID] = true
 			continue // claw is being terminated, skip other checks
 		}

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -152,9 +152,16 @@ func (s *Server) pollAllPRs() {
 		return
 	}
 
+	terminatedClaws := map[string]bool{}
 	for _, r := range prs {
+		// Skip PRs for claws that were already terminated in this poll
+		if terminatedClaws[r.pr.clawID] {
+			continue
+		}
+
 		// Always check if PR is merged/closed — if so, terminate the claw
 		if s.checkPRMerged(r.pr, token) {
+			terminatedClaws[r.pr.clawID] = true
 			continue // claw is being terminated, skip other checks
 		}
 		if r.autoFixCI {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -907,7 +907,9 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 		s.mu.Unlock()
 		var currentStatus string
 		_ = s.db.QueryRow(`SELECT status FROM claws WHERE id=?`, clawID).Scan(&currentStatus)
-		if currentStatus != "completed" && currentStatus != "deleted" {
+		// Don't overwrite terminal/watching states — idle means the claw sent [DONE]
+		// and is watching for PR merge; deleted means it's being cleaned up.
+		if currentStatus != "completed" && currentStatus != "deleted" && currentStatus != "idle" {
 			_, _ = s.db.Exec(`UPDATE claws SET status='offline', last_seen=? WHERE id=?`, now(), clawID)
 			s.broadcastToUsers(tenantID, types.WSMessage{Type: "claw_status", Payload: map[string]string{"claw_id": clawID, "status": "offline"}})
 		}
@@ -2556,6 +2558,41 @@ func (s *Server) handleTerminal(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+}
+
+// terminateVM terminates a provider VM by type and ID.
+func (s *Server) terminateVM(provider, vmID string) {
+	if vmID == "" {
+		return
+	}
+	switch provider {
+	case "replicated":
+		s.terminateReplicatedVM(vmID)
+	case "daytona":
+		s.terminateDaytonaVM(vmID)
+	default:
+		log.Printf("terminateVM: unsupported provider %q for VM %s", provider, vmID)
+	}
+}
+
+// terminateDaytonaVM destroys a Daytona workspace by ID.
+func (s *Server) terminateDaytonaVM(workspaceID string) {
+	s.mu.RLock()
+	cfg, ok := s.hubCfg.Providers["daytona"]
+	s.mu.RUnlock()
+	if !ok {
+		return
+	}
+	p, err := newDaytonaProvider(cfg)
+	if err != nil {
+		log.Printf("terminateDaytonaVM: provider init error: %v", err)
+		return
+	}
+	if err := p.Destroy(context.Background(), workspaceID, false); err != nil {
+		log.Printf("terminateDaytonaVM: failed to destroy workspace %s: %v", workspaceID, err)
+		return
+	}
+	log.Printf("Daytona workspace %s terminated", workspaceID)
 }
 
 // terminateReplicatedVM terminates a Replicated CMX VM by ID.

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -958,8 +958,10 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 						// nil means field absent (old bridge) — treat as ready.
 						if gatewayReadyBool(hb.GatewayReady) && !cc.gatewayReady {
 							cc.gatewayReady = true
-							res, _ := s.db.Exec(`UPDATE claws SET status='connected' WHERE id=? AND status='starting'`, clawID)
-							if rows, _ := res.RowsAffected(); rows > 0 {
+							res, execErr := s.db.Exec(`UPDATE claws SET status='connected' WHERE id=? AND status='starting'`, clawID)
+							var rowsUpdated int64
+							if execErr == nil { rowsUpdated, _ = res.RowsAffected() }
+							if rowsUpdated > 0 {
 								s.broadcastToUsers(tenantID, types.WSMessage{
 									Type:    "claw_status",
 									Payload: map[string]string{"claw_id": clawID, "status": "connected"},

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -874,14 +874,21 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 		clawID = uuid.New().String()
 	}
 
-	// Upsert claw
-	_, _ = s.db.Exec(
+	// Upsert claw and keep terminal/watching states sticky across reconnects.
+	desiredStatus := initialStatus(rp.GatewayReady)
+	currentStatus := desiredStatus
+	_ = s.db.QueryRow(
 		`INSERT INTO claws(id,tenant_id,name,template,status,last_seen,created_at) VALUES(?,?,?,?,?,?,?)
 		 ON CONFLICT(id) DO UPDATE SET name=excluded.name, template=excluded.template,
-		 status=CASE WHEN claws.status='idle' THEN claws.status ELSE excluded.status END,
-		 last_seen=excluded.last_seen`,
-		clawID, tenantID, rp.Name, rp.Template, initialStatus(rp.GatewayReady), now(), now(),
-	)
+		 status=CASE WHEN claws.status IN ('idle','deleted') THEN claws.status ELSE excluded.status END,
+		 last_seen=excluded.last_seen
+		 RETURNING status`,
+		clawID, tenantID, rp.Name, rp.Template, desiredStatus, now(), now(),
+	).Scan(&currentStatus)
+	if currentStatus == "deleted" {
+		conn.Close(websocket.StatusPolicyViolation, "claw deleted")
+		return
+	}
 
 	cc := &clawConn{id: clawID, tenantID: tenantID, conn: conn, gatewayReady: gatewayReadyBool(rp.GatewayReady)}
 	s.mu.Lock()
@@ -894,11 +901,11 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 	_ = wsjson.Write(ctx, conn, types.WSMessage{Type: "registered", Payload: map[string]string{"claw_id": clawID}})
 
 	// Broadcast initial status to user sessions
-	s.broadcastToUsers(tenantID, types.WSMessage{Type: "claw_status", Payload: map[string]string{"claw_id": clawID, "status": initialStatus(rp.GatewayReady)}})
+	s.broadcastToUsers(tenantID, types.WSMessage{Type: "claw_status", Payload: map[string]string{"claw_id": clawID, "status": currentStatus}})
 
 	// If gateway is already ready on connect (common for factory claws where bootstrap
 	// completes before bridge registers), fire the wake message immediately.
-	if cc.gatewayReady {
+	if cc.gatewayReady && currentStatus == "connected" {
 		go s.sendWakeMessage(cc, clawID)
 	}
 
@@ -951,13 +958,15 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 						// nil means field absent (old bridge) — treat as ready.
 						if gatewayReadyBool(hb.GatewayReady) && !cc.gatewayReady {
 							cc.gatewayReady = true
-							_, _ = s.db.Exec(`UPDATE claws SET status='connected' WHERE id=?`, clawID)
-							s.broadcastToUsers(tenantID, types.WSMessage{
-								Type:    "claw_status",
-								Payload: map[string]string{"claw_id": clawID, "status": "connected"},
-							})
-							log.Printf("[bridge] ✓ ready: %s (%s)", rp.Name, clawID[:8])
-							go s.sendWakeMessage(cc, clawID)
+							res, _ := s.db.Exec(`UPDATE claws SET status='connected' WHERE id=? AND status='starting'`, clawID)
+							if rows, _ := res.RowsAffected(); rows > 0 {
+								s.broadcastToUsers(tenantID, types.WSMessage{
+									Type:    "claw_status",
+									Payload: map[string]string{"claw_id": clawID, "status": "connected"},
+								})
+								log.Printf("[bridge] ✓ ready: %s (%s)", rp.Name, clawID[:8])
+								go s.sendWakeMessage(cc, clawID)
+							}
 						} else if !hb.GatewayHealthy && prevHealthy {
 							// Gateway went unhealthy
 							log.Printf("[heartbeat] %s (%s): gateway unhealthy", rp.Name, clawID[:8])

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -877,7 +877,9 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 	// Upsert claw
 	_, _ = s.db.Exec(
 		`INSERT INTO claws(id,tenant_id,name,template,status,last_seen,created_at) VALUES(?,?,?,?,?,?,?)
-		 ON CONFLICT(id) DO UPDATE SET name=excluded.name, template=excluded.template, status=excluded.status, last_seen=excluded.last_seen`,
+		 ON CONFLICT(id) DO UPDATE SET name=excluded.name, template=excluded.template,
+		 status=CASE WHEN claws.status='idle' THEN claws.status ELSE excluded.status END,
+		 last_seen=excluded.last_seen`,
 		clawID, tenantID, rp.Name, rp.Template, initialStatus(rp.GatewayReady), now(), now(),
 	)
 

--- a/web/lib/mappers.ts
+++ b/web/lib/mappers.ts
@@ -77,6 +77,8 @@ export function mapApiStatus(status: ApiClaw["status"]): ClawStatus {
   switch (status) {
     case "connected":
       return "connected"
+    case "idle":
+      return "idle"
     case "provisioning":
     case "starting":
       return "provisioning"

--- a/web/lib/mappers.ts
+++ b/web/lib/mappers.ts
@@ -60,10 +60,10 @@ export function parseTagsFromName(name: string): Record<string, string> {
 }
 
 /**
- * Compute uptime in seconds from created_at if status is connected.
+ * Compute uptime in seconds from created_at if status is connected or idle.
  */
 export function computeUptime(apiClaw: ApiClaw): number {
-  if (apiClaw.status !== "connected") return 0
+  if (apiClaw.status !== "connected" && apiClaw.status !== "idle") return 0
   try {
     const created = new Date(apiClaw.created_at).getTime()
     const now = Date.now()

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -38,7 +38,7 @@ export interface ApiClaw {
   id: string
   name: string
   template: string
-  status: "connected" | "offline" | "provisioning" | "starting" | "error"
+  status: "connected" | "offline" | "provisioning" | "starting" | "error" | "idle"
   last_seen: string
   created_at: string
   tenant_id: string


### PR DESCRIPTION
After `[DONE]` the hub marked `status='completed'` but didn't destroy the VM. The bridge process on the VM kept reconnecting, triggering another wake message: "No BOOTSTRAP.md — already deleted after the last task."\n\nFix:\n- Mark `status='deleted'` so poller ignores it\n- Destroy the Replicated VM async\n- Broadcast deletion so dashboard card disappears immediately