### PR TITLE
feat: white-label branding (app_name + logo_url in hub.yaml)

### DIFF
--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -406,6 +406,11 @@ func (s *Server) handleHubConfig(w http.ResponseWriter, r *http.Request) {
 		hubURL = s.hubCfg.PublicURL
 	}
 	token := s.hubCfg.Token
+	var appName, logoURL string
+	if s.hubCfg.Branding != nil {
+		appName = s.hubCfg.Branding.AppName
+		logoURL = s.hubCfg.Branding.LogoURL
+	}
 	s.mu.RUnlock()
 	if hubURL == "" {
 		hubURL = "http://localhost:8080"
@@ -414,6 +419,8 @@ func (s *Server) handleHubConfig(w http.ResponseWriter, r *http.Request) {
 		"token":   token,
 		"hubUrl":  hubURL,
 		"version": Version,
+		"appName": appName,
+		"logoUrl": logoURL,
 	})
 }
 

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -104,6 +104,15 @@ type GitHubTemplateConfig struct {
 
 // HubConfig is used in two contexts:
 //   - ~/.elasticclaw/hub.yaml: CLI connection + full server config
+// BrandingConfig controls white-label appearance of the web UI.
+type BrandingConfig struct {
+	// AppName replaces "ElasticClaw" in the top-left header and page title.
+	AppName string `yaml:"app_name,omitempty" json:"appName,omitempty"`
+	// LogoURL is a URL to an externally-hosted image used as the empty-state mascot.
+	// Replaces the default lobster mascot PNG.
+	LogoURL string `yaml:"logo_url,omitempty" json:"logoUrl,omitempty"`
+}
+
 type HubConfig struct {
 	// CLI connection fields
 	URL   string `yaml:"url"`
@@ -150,6 +159,9 @@ type HubConfig struct {
 
 	// UIPassword is the password for the web UI. If not set, defaults to "admin".
 	UIPassword string `yaml:"ui_password,omitempty"`
+
+	// Branding allows white-labeling the web UI.
+	Branding *BrandingConfig `yaml:"branding,omitempty"`
 
 	// Integrations holds external service configs (Linear, future: Shortcut, etc.)
 	Integrations *IntegrationsConfig `yaml:"integrations,omitempty"`

--- a/web/components/conversation-view.tsx
+++ b/web/components/conversation-view.tsx
@@ -31,6 +31,7 @@ import { cn } from "@/lib/utils"
 import type { Claw, Message, ClawStatus } from "@/lib/types"
 import { getTerminalWsUrl, fetchClawPRs, fetchClawAutoSettings, patchClawAutoSettings, type ClawPR } from "@/lib/api"
 import dynamic from "next/dynamic"
+import { useBranding } from "@/hooks/use-branding"
 
 const XTerminal = dynamic(
   () => import("@/components/terminal").then((m) => m.XTerminal),
@@ -1022,6 +1023,7 @@ export function ConversationView({
 }: ConversationViewProps) {
   const boardRef = useRef<HTMLDivElement>(null)
   const [activeDragClaw, setActiveDragClaw] = useState<Claw | null>(null)
+  const { logoUrl } = useBranding()
 
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -1114,8 +1116,8 @@ export function ConversationView({
           {sortedClaws.length === 0 && !loading ? (
             <div className="flex flex-col items-center justify-center h-full gap-6 px-8 text-center">
               <img
-                src="/mascot.png"
-                alt="ElasticClaw mascot"
+                src={logoUrl || "/mascot.png"}
+                alt="mascot"
                 className="w-72 h-72 object-contain select-none pointer-events-none opacity-90"
                 draggable={false}
               />

--- a/web/components/sidebar.tsx
+++ b/web/components/sidebar.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { Search, Pin, X, ChevronDown, PanelLeftClose, PanelLeft, Loader2, AlertCircle, LogOut, Settings } from "lucide-react"
+import { useBranding } from "@/hooks/use-branding"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { ScrollArea } from "@/components/ui/scroll-area"
@@ -108,6 +109,7 @@ export function Sidebar({
   onToggleCollapse,
 }: SidebarProps) {
   const tagKeys = allTags
+  const { appName } = useBranding()
   const [activeDragClaw, setActiveDragClaw] = useState<Claw | null>(null)
 
   const sensors = useSensors(
@@ -218,7 +220,7 @@ export function Sidebar({
     <aside className="w-[260px] h-screen flex flex-col border-r border-border bg-card">
       <div className="flex items-center justify-between p-4 border-b border-border">
         <h1 className="text-lg font-semibold tracking-tight text-foreground">
-          ElasticClaw
+          {appName}
         </h1>
         <div className="flex items-center gap-1">
           <Button

--- a/web/hooks/use-branding.ts
+++ b/web/hooks/use-branding.ts
@@ -1,0 +1,36 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { getHubUrl } from "@/lib/hub-url"
+
+interface Branding {
+  appName: string
+  logoUrl: string
+}
+
+const DEFAULT: Branding = { appName: "ElasticClaw", logoUrl: "" }
+
+let cached: Branding | null = null
+
+export function useBranding(): Branding {
+  const [branding, setBranding] = useState<Branding>(cached ?? DEFAULT)
+
+  useEffect(() => {
+    if (cached) return
+    const hubUrl = getHubUrl()
+    const token = typeof window !== "undefined" ? sessionStorage.getItem("ec_hub_token") || "" : ""
+    fetch(`${hubUrl}/api/hub-config`, { headers: { Authorization: `Bearer ${token}` } })
+      .then(r => r.json())
+      .then(d => {
+        const b: Branding = {
+          appName: d.appName || "ElasticClaw",
+          logoUrl: d.logoUrl || "",
+        }
+        cached = b
+        setBranding(b)
+      })
+      .catch(() => {})
+  }, [])
+
+  return branding
+}


### PR DESCRIPTION
White-label the web UI via `hub.yaml`:\n\n```yaml\nbranding:\n  app_name: My Platform\n  logo_url: https://example.com/my-logo.png\n```\n\n- `app_name` replaces "ElasticClaw" in the sidebar header\n- `logo_url` replaces the default mascot on the empty dashboard state\n- Falls back to defaults when not configured