### PR TITLE
feat: Shortcut integration (factories + settings)

### DIFF
--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -622,7 +622,7 @@ func (s *Server) findFactoryForIssue(issueID string) *types.FactoryConfig {
 
 	// Determine expected integration type based on issue ID format
 	expectedIntegration := "linear"
-	if strings.EqualFold(teamKey, "sc") {
+	if teamKey == "sc" {
 		expectedIntegration = "shortcut"
 	}
 

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -613,7 +613,25 @@ func (s *Server) validateDonePRs(clawID string, prURLs []string, ghToken string)
 }
 
 func (s *Server) findFactoryForIssue(issueID string) *types.FactoryConfig {
-	// Extract team key from issue ID (e.g. "ELA" from "ELA-123", "sc" from "sc-123")
+	// First, try to find the factory that created this claw by looking up the factory tag
+	var tagsJSON string
+	if err := s.db.QueryRow(`SELECT tags FROM claws WHERE linear_issue_id = ? AND status NOT IN ('error','deleted') LIMIT 1`, issueID).Scan(&tagsJSON); err == nil {
+		var tags []string
+		if json.Unmarshal([]byte(tagsJSON), &tags) == nil {
+			for _, tag := range tags {
+				if strings.HasPrefix(tag, "factory:") {
+					factoryName := strings.TrimPrefix(tag, "factory:")
+					for _, factory := range s.hubCfg.Factories {
+						if factory.Name == factoryName {
+							return factory
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Fallback: Extract team key from issue ID (e.g. "ELA" from "ELA-123", "sc" from "sc-123")
 	parts := strings.SplitN(issueID, "-", 2)
 	if len(parts) != 2 {
 		return nil

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -517,14 +517,27 @@ func (s *Server) handleClawDoneSignal(clawID, rawMessage string) {
 		return
 	}
 
-	// Move Linear issue to done_status if configured
+	// Move the issue to done_status if configured
 	if factory.DoneStatus != "" {
-		linearToken := s.resolveLinearTokenForFactory(factory)
-		if linearToken != "" {
-			if err := moveLinearIssue(linearToken, issueID, factory.DoneStatus); err != nil {
-				log.Printf("[factory] failed to move issue %s to '%s': %v", issueID, factory.DoneStatus, err)
-			} else {
-				log.Printf("[factory] moved issue %s to '%s'", issueID, factory.DoneStatus)
+		if strings.HasPrefix(issueID, "sc-") {
+			// Shortcut story
+			scToken := s.resolveShortcutToken(factory.Workspace)
+			if scToken != "" {
+				if err := moveShortcutStory(scToken, issueID, factory.DoneStatus); err != nil {
+					log.Printf("[factory] failed to move story %s to '%s': %v", issueID, factory.DoneStatus, err)
+				} else {
+					log.Printf("[factory] moved story %s to '%s'", issueID, factory.DoneStatus)
+				}
+			}
+		} else {
+			// Linear issue
+			linearToken := s.resolveLinearTokenForFactory(factory)
+			if linearToken != "" {
+				if err := moveLinearIssue(linearToken, issueID, factory.DoneStatus); err != nil {
+					log.Printf("[factory] failed to move issue %s to '%s': %v", issueID, factory.DoneStatus, err)
+				} else {
+					log.Printf("[factory] moved issue %s to '%s'", issueID, factory.DoneStatus)
+				}
 			}
 		}
 	}

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -613,15 +613,21 @@ func (s *Server) validateDonePRs(clawID string, prURLs []string, ghToken string)
 }
 
 func (s *Server) findFactoryForIssue(issueID string) *types.FactoryConfig {
-	// Extract team key from issue ID (e.g. "ELA" from "ELA-123")
+	// Extract team key from issue ID (e.g. "ELA" from "ELA-123", "sc" from "sc-123")
 	parts := strings.SplitN(issueID, "-", 2)
 	if len(parts) != 2 {
 		return nil
 	}
 	teamKey := parts[0]
 
+	// Determine expected integration type based on issue ID format
+	expectedIntegration := "linear"
+	if strings.EqualFold(teamKey, "sc") {
+		expectedIntegration = "shortcut"
+	}
+
 	for _, factory := range s.hubCfg.Factories {
-		if factory.Integration != "linear" {
+		if factory.Integration != expectedIntegration {
 			continue
 		}
 		if factory.Team == "" || strings.EqualFold(factory.Team, teamKey) {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -136,6 +136,7 @@ func (s *Server) Run(opts ...RunOptions) error {
 
 	// Integration webhooks (signature-validated, no session auth)
 	mux.HandleFunc("/api/integrations/linear/webhook", s.handleLinearWebhook)
+	mux.HandleFunc("/api/integrations/shortcut/webhook", s.handleShortcutWebhook)
 	mux.HandleFunc("/api/factories/", s.withAuth(s.handleFactoryEvents)) // GET /api/factories/:name/events
 	mux.HandleFunc("/api/claws", s.withAuth(s.handleClaws))
 	mux.HandleFunc("/api/claws/{id}", s.withAuth(s.handleClawDetail))

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -467,7 +467,7 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if patch.Integrations != nil && len(patch.Integrations.Shortcut) > 0 {
+	if patch.Integrations != nil && patch.Integrations.Shortcut != nil {
 		// Deep copy IntegrationsConfig to avoid mutating live config
 		var existingIntegrations *types.IntegrationsConfig
 		if updatedCfg.Integrations != nil {

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -118,9 +118,10 @@ type IntegrationsPatch struct {
 }
 
 type ShortcutIntegrationPatch struct {
-	Workspace string `json:"workspace"`
-	Token     string `json:"token,omitempty"`
-	Delete    bool   `json:"delete,omitempty"`
+	Workspace         string `json:"workspace"`
+	OriginalWorkspace string `json:"originalWorkspace,omitempty"`
+	Token             string `json:"token,omitempty"`
+	Delete            bool   `json:"delete,omitempty"`
 }
 
 type LinearIntegrationPatch struct {
@@ -488,8 +489,12 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 			sc := &types.ShortcutIntegrationConfig{Workspace: sp.Workspace}
+			matchWorkspace := sp.Workspace
+			if sp.OriginalWorkspace != "" {
+				matchWorkspace = sp.OriginalWorkspace
+			}
 			for _, ex := range existing {
-				if ex.Workspace == sp.Workspace {
+				if ex.Workspace == matchWorkspace {
 					sc.Token = ex.Token
 					break
 				}

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -36,7 +36,13 @@ type SettingsView struct {
 }
 
 type IntegrationsView struct {
-	Linear []LinearIntegrationView `json:"linear"`
+	Linear    []LinearIntegrationView    `json:"linear"`
+	Shortcut  []ShortcutIntegrationView  `json:"shortcut"`
+}
+
+type ShortcutIntegrationView struct {
+	Workspace string `json:"workspace"`
+	TokenSet  bool   `json:"tokenSet"`
 }
 
 type LinearIntegrationView struct {
@@ -107,7 +113,14 @@ type SettingsPatch struct {
 }
 
 type IntegrationsPatch struct {
-	Linear []LinearIntegrationPatch `json:"linear,omitempty"`
+	Linear    []LinearIntegrationPatch    `json:"linear,omitempty"`
+	Shortcut  []ShortcutIntegrationPatch  `json:"shortcut,omitempty"`
+}
+
+type ShortcutIntegrationPatch struct {
+	Workspace string `json:"workspace"`
+	Token     string `json:"token,omitempty"`
+	Delete    bool   `json:"delete,omitempty"`
 }
 
 type LinearIntegrationPatch struct {
@@ -232,8 +245,14 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Integrations
-	view.Integrations = &IntegrationsView{Linear: []LinearIntegrationView{}}
+	view.Integrations = &IntegrationsView{Linear: []LinearIntegrationView{}, Shortcut: []ShortcutIntegrationView{}}
 	if s.hubCfg.Integrations != nil {
+		for _, sc := range s.hubCfg.Integrations.Shortcut {
+			view.Integrations.Shortcut = append(view.Integrations.Shortcut, ShortcutIntegrationView{
+				Workspace: sc.Workspace,
+				TokenSet:  sc.Token != "",
+			})
+		}
 		for _, li := range s.hubCfg.Integrations.Linear {
 			view.Integrations.Linear = append(view.Integrations.Linear, LinearIntegrationView{
 				Workspace:        li.Workspace,
@@ -441,6 +460,36 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 			linears = append(linears, li)
 		}
 		updatedCfg.Integrations.Linear = linears
+
+		// Preserve existing Shortcut integrations not in patch
+		if existingIntegrations != nil {
+			updatedCfg.Integrations.Shortcut = existingIntegrations.Shortcut
+		}
+	}
+
+	if patch.Integrations != nil && len(patch.Integrations.Shortcut) > 0 {
+		if updatedCfg.Integrations == nil {
+			updatedCfg.Integrations = &types.IntegrationsConfig{}
+		}
+		existing := updatedCfg.Integrations.Shortcut
+		var shortcuts []*types.ShortcutIntegrationConfig
+		for _, sp := range patch.Integrations.Shortcut {
+			if sp.Delete {
+				continue
+			}
+			sc := &types.ShortcutIntegrationConfig{Workspace: sp.Workspace}
+			for _, ex := range existing {
+				if ex.Workspace == sp.Workspace {
+					sc.Token = ex.Token
+					break
+				}
+			}
+			if sp.Token != "" {
+				sc.Token = sp.Token
+			}
+			shortcuts = append(shortcuts, sc)
+		}
+		updatedCfg.Integrations.Shortcut = shortcuts
 	}
 
 	// Factories (full replace)

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -36,8 +36,8 @@ type SettingsView struct {
 }
 
 type IntegrationsView struct {
-	Linear    []LinearIntegrationView    `json:"linear"`
-	Shortcut  []ShortcutIntegrationView  `json:"shortcut"`
+	Linear   []LinearIntegrationView   `json:"linear"`
+	Shortcut []ShortcutIntegrationView `json:"shortcut"`
 }
 
 type ShortcutIntegrationView struct {
@@ -113,8 +113,8 @@ type SettingsPatch struct {
 }
 
 type IntegrationsPatch struct {
-	Linear    []LinearIntegrationPatch    `json:"linear,omitempty"`
-	Shortcut  []ShortcutIntegrationPatch  `json:"shortcut,omitempty"`
+	Linear   []LinearIntegrationPatch   `json:"linear,omitempty"`
+	Shortcut []ShortcutIntegrationPatch `json:"shortcut,omitempty"`
 }
 
 type ShortcutIntegrationPatch struct {
@@ -468,8 +468,18 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if patch.Integrations != nil && len(patch.Integrations.Shortcut) > 0 {
+		// Deep copy IntegrationsConfig to avoid mutating live config
+		var existingIntegrations *types.IntegrationsConfig
+		if updatedCfg.Integrations != nil {
+			existingIntegrations = updatedCfg.Integrations
+		}
 		if updatedCfg.Integrations == nil {
 			updatedCfg.Integrations = &types.IntegrationsConfig{}
+		} else {
+			updatedCfg.Integrations = &types.IntegrationsConfig{
+				Linear:   existingIntegrations.Linear,
+				Shortcut: existingIntegrations.Shortcut,
+			}
 		}
 		existing := updatedCfg.Integrations.Shortcut
 		var shortcuts []*types.ShortcutIntegrationConfig

--- a/pkg/hub/shortcut.go
+++ b/pkg/hub/shortcut.go
@@ -1,0 +1,404 @@
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/elasticclaw/elasticclaw/pkg/config"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+	"github.com/google/uuid"
+)
+
+// ── Webhook payload types ─────────────────────────────────────────────────────
+
+type shortcutWebhookPayload struct {
+	ID         string                        `json:"id"`
+	Actions    []shortcutAction              `json:"actions"`
+	ChangedAt  string                        `json:"changed_at"`
+}
+
+type shortcutAction struct {
+	ID             int64                          `json:"id"`
+	EntityType     string                         `json:"entity_type"` // "story"
+	Action         string                         `json:"action"`      // "update", "create"
+	Name           string                         `json:"name"`
+	AppURL         string                         `json:"app_url"`
+	Description    string                         `json:"description"`
+	Changes        map[string]shortcutChange      `json:"changes"`
+}
+
+type shortcutChange struct {
+	New interface{} `json:"new"`
+	Old interface{} `json:"old"`
+}
+
+// ── Handler ───────────────────────────────────────────────────────────────────
+
+func (s *Server) handleShortcutWebhook(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	if err != nil {
+		http.Error(w, "read error", http.StatusBadRequest)
+		return
+	}
+
+	var payload shortcutWebhookPayload
+	if err := json.Unmarshal(body, &payload); err != nil {
+		http.Error(w, "invalid payload", http.StatusBadRequest)
+		return
+	}
+
+	go s.processShortcutEvent(payload)
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *Server) processShortcutEvent(payload shortcutWebhookPayload) {
+	s.mu.RLock()
+	factories := s.hubCfg.Factories
+	s.mu.RUnlock()
+
+	for _, action := range payload.Actions {
+		if action.EntityType != "story" || action.Action != "update" {
+			continue
+		}
+
+		// Check if workflow_state_id changed
+		stateChange, ok := action.Changes["workflow_state_id"]
+		if !ok {
+			continue
+		}
+
+		// Resolve state names via API
+		newStateID := toInt64(stateChange.New)
+		oldStateID := toInt64(stateChange.Old)
+		storyID := fmt.Sprintf("sc-%d", action.ID)
+
+		for _, factory := range factories {
+			if factory.Integration != "shortcut" {
+				continue
+			}
+			if factory.Enabled != nil && !*factory.Enabled {
+				continue
+			}
+
+			token := s.resolveShortcutToken(factory.Workspace)
+			if token == "" {
+				continue
+			}
+
+			newStateName := s.shortcutStateName(token, newStateID)
+			oldStateName := s.shortcutStateName(token, oldStateID)
+
+			// Issue entering trigger status → create claw
+			if strings.EqualFold(newStateName, factory.TriggerStatus) {
+				log.Printf("[factory:%s] story %s entered '%s' — creating claw", factory.Name, storyID, factory.TriggerStatus)
+				if err := s.createClawForShortcutStory(factory, action, storyID, token); err != nil {
+					log.Printf("[factory:%s] failed to create claw for %s: %v", factory.Name, storyID, err)
+				}
+			}
+
+			// Issue leaving trigger status → terminate claw
+			if factory.TerminateOnLeave && !strings.EqualFold(newStateName, factory.TriggerStatus) {
+				var activeClaw string
+				_ = s.db.QueryRow(
+					`SELECT id FROM claws WHERE linear_issue_id = ? AND status NOT IN ('error','deleted') LIMIT 1`,
+					storyID,
+				).Scan(&activeClaw)
+				if activeClaw != "" {
+					log.Printf("[factory:%s] story %s left trigger — terminating claw", factory.Name, storyID)
+					s.terminateClawForIssue(storyID)
+					_ = oldStateName // suppress unused
+				}
+			}
+		}
+	}
+}
+
+// resolveShortcutToken finds the API token for the given workspace label.
+func (s *Server) resolveShortcutToken(workspace string) string {
+	s.mu.RLock()
+	cfg := s.hubCfg
+	s.mu.RUnlock()
+	if cfg.Integrations == nil {
+		return ""
+	}
+	for _, sc := range cfg.Integrations.Shortcut {
+		if workspace == "" || strings.EqualFold(sc.Workspace, workspace) {
+			return sc.Token
+		}
+	}
+	return ""
+}
+
+// shortcutStateName fetches the workflow state name for a given state ID.
+func (s *Server) shortcutStateName(token string, stateID int64) string {
+	if stateID == 0 {
+		return ""
+	}
+	data, err := shortcutAPI(fmt.Sprintf("workflow-states/%d", stateID), token)
+	if err != nil {
+		return strconv.FormatInt(stateID, 10)
+	}
+	name, _ := data["name"].(string)
+	return name
+}
+
+// createClawForShortcutStory provisions a claw for a Shortcut story.
+func (s *Server) createClawForShortcutStory(factory *types.FactoryConfig, action shortcutAction, storyID, token string) error {
+	// Enforce 1:1
+	var existingID string
+	_ = s.db.QueryRow(
+		`SELECT id FROM claws WHERE linear_issue_id = ? AND status NOT IN ('error','deleted') LIMIT 1`,
+		storyID,
+	).Scan(&existingID)
+	if existingID != "" {
+		return fmt.Errorf("claw %s already exists for story %s", existingID[:8], storyID)
+	}
+
+	templateFiles, err := s.resolveTemplateFiles(factory.Template)
+	if err != nil {
+		return fmt.Errorf("template %q not found: %w", factory.Template, err)
+	}
+
+	// Inject BOOTSTRAP.md and CONTEXT.md
+	ctx := buildShortcutContext(action, storyID)
+	templateFiles["BOOTSTRAP.md"] = ctx
+	templateFiles["CONTEXT.md"] = ctx
+
+	clawName := storyID
+	if factory.NamePattern != "" {
+		clawName = strings.ReplaceAll(factory.NamePattern, "{issue_id}", storyID)
+	}
+
+	var tenantID string
+	if err := s.db.QueryRow(`SELECT id FROM tenants LIMIT 1`).Scan(&tenantID); err != nil {
+		return fmt.Errorf("no tenant: %w", err)
+	}
+
+	provider := s.defaultProvider()
+	if factory.Template != "" {
+		if tCfg, _ := s.loadTemplateCfgForFactory(factory); tCfg != nil && tCfg.Provider != "" {
+			provider = tCfg.Provider
+		}
+	}
+	if provider == "" {
+		return fmt.Errorf("no provider configured")
+	}
+
+	s.mu.RLock()
+	provCfg, _ := s.hubCfg.Providers[provider]
+	clawToken := s.hubCfg.ClawToken
+	s.mu.RUnlock()
+
+	env := map[string]string{
+		"ELASTICCLAW_HUB_URL":    s.clawHubURL(),
+		"ELASTICCLAW_CLAW_TOKEN": clawToken,
+	}
+
+	tags := mergeTags(factory.Template, factory.Tags, nil)
+	hasfactory := false
+	for _, t := range tags {
+		if t == "factory:"+factory.Name {
+			hasfactory = true
+			break
+		}
+	}
+	if !hasfactory {
+		tags = append(tags, "factory:"+factory.Name)
+	}
+	tagsJSON, _ := json.Marshal(tags)
+
+	clawID := uuid.New().String()
+	filesJSON, _ := json.Marshal(templateFiles)
+
+	_, err = s.db.Exec(
+		`INSERT INTO claws(id,tenant_id,name,template,provider,template_files,linear_issue_id,tags,color,status,created_at)
+		 VALUES(?,?,?,?,?,?,?,?,?,'provisioning',?)`,
+		clawID, tenantID, clawName, factory.Template, provider, string(filesJSON),
+		storyID, string(tagsJSON), factory.Color, now(),
+	)
+	if err != nil {
+		return fmt.Errorf("db insert: %w", err)
+	}
+
+	req := types.CreateClawRequest{
+		Name: clawName, TemplateName: factory.Template,
+		Provider: provider, Files: templateFiles, Env: env,
+		ProviderName: "ec-" + clawID[:8],
+	}
+
+	go func() {
+		var currentStatus string
+		_ = s.db.QueryRow(`SELECT status FROM claws WHERE id=?`, clawID).Scan(&currentStatus)
+		if currentStatus == "deleted" {
+			return
+		}
+		fileBytes := make(map[string][]byte, len(templateFiles))
+		for k, v := range templateFiles {
+			fileBytes[k] = []byte(v)
+		}
+		var provErr error
+		switch provider {
+		case "replicated":
+			provErr = s.provisionReplicated(context.Background(), clawID, req, provCfg, env)
+		case "daytona":
+			provErr = s.provisionDaytona(context.Background(), clawID, req, provCfg, fileBytes, env)
+		default:
+			provErr = fmt.Errorf("unsupported provider: %s", provider)
+		}
+		if provErr != nil {
+			log.Printf("[factory:%s] provision failed for %s: %v", factory.Name, clawID[:8], provErr)
+			_, _ = s.db.Exec(`UPDATE claws SET status='error' WHERE id=? AND status != 'deleted'`, clawID)
+		}
+	}()
+
+	s.broadcastToUsers(tenantID, types.WSMessage{
+		Type:    "claw_status",
+		Payload: map[string]string{"claw_id": clawID, "status": "provisioning"},
+	})
+	log.Printf("[factory] created claw %s (%s) for Shortcut story %s", clawName, clawID[:8], storyID)
+	return nil
+}
+
+func buildShortcutContext(action shortcutAction, storyID string) string {
+	var b strings.Builder
+	b.WriteString("# Issue Context\n\n")
+	b.WriteString("This claw was automatically created by a factory to work on a Shortcut story.\n\n")
+	b.WriteString(fmt.Sprintf("## Story: %s\n\n", storyID))
+	b.WriteString(fmt.Sprintf("**Title:** %s\n\n", action.Name))
+	if action.AppURL != "" {
+		b.WriteString(fmt.Sprintf("**URL:** %s\n\n", action.AppURL))
+	}
+	if action.Description != "" {
+		b.WriteString("## Description\n\n")
+		b.WriteString(action.Description)
+		b.WriteString("\n")
+	}
+	b.WriteString("\n---\n\n## Instructions\n\n")
+	b.WriteString("1. Read this file fully\n")
+	b.WriteString("2. Explore the codebase\n")
+	b.WriteString("3. Implement the feature/fix described above\n")
+	b.WriteString("4. When complete, send exactly: `[DONE] https://github.com/org/repo/pull/N` (with your PR URL)\n")
+	return b.String()
+}
+
+// shortcutAPI makes a GET request to the Shortcut API.
+func shortcutAPI(path, token string) (map[string]interface{}, error) {
+	req, _ := http.NewRequest("GET", "https://api.app.shortcut.com/api/v3/"+path, nil)
+	req.Header.Set("Shortcut-Token", token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	var result map[string]interface{}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// moveShortcutStory updates a story's workflow state.
+func moveShortcutStory(token, storyIDStr, stateName string) error {
+	// First find the state ID by name
+	resp, err := shortcutAPIList("workflows", token)
+	if err != nil {
+		return fmt.Errorf("list workflows: %w", err)
+	}
+	var stateID int64
+	for _, wf := range resp {
+		workflow, _ := wf.(map[string]interface{})
+		states, _ := workflow["states"].([]interface{})
+		for _, st := range states {
+			state, _ := st.(map[string]interface{})
+			name, _ := state["name"].(string)
+			if strings.EqualFold(name, stateName) {
+				idF, _ := state["id"].(float64)
+				stateID = int64(idF)
+				break
+			}
+		}
+		if stateID != 0 {
+			break
+		}
+	}
+	if stateID == 0 {
+		return fmt.Errorf("state %q not found", stateName)
+	}
+
+	// Parse story ID (sc-123 → 123)
+	numStr := strings.TrimPrefix(storyIDStr, "sc-")
+	storyNum, err := strconv.ParseInt(numStr, 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid story id %s", storyIDStr)
+	}
+
+	body := fmt.Sprintf(`{"workflow_state_id":%d}`, stateID)
+	req, _ := http.NewRequest("PUT",
+		fmt.Sprintf("https://api.app.shortcut.com/api/v3/stories/%d", storyNum),
+		strings.NewReader(body))
+	req.Header.Set("Shortcut-Token", token)
+	req.Header.Set("Content-Type", "application/json")
+	resp2, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp2.Body.Close()
+	if resp2.StatusCode >= 400 {
+		return fmt.Errorf("shortcut API error %d", resp2.StatusCode)
+	}
+	return nil
+}
+
+func shortcutAPIList(path, token string) ([]interface{}, error) {
+	req, _ := http.NewRequest("GET", "https://api.app.shortcut.com/api/v3/"+path, nil)
+	req.Header.Set("Shortcut-Token", token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	var result []interface{}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func toInt64(v interface{}) int64 {
+	switch x := v.(type) {
+	case float64:
+		return int64(x)
+	case int64:
+		return x
+	case int:
+		return int64(x)
+	}
+	return 0
+}
+
+// loadTemplateCfgForFactory is a helper to load template config for a factory (shared with linear.go).
+func (s *Server) loadTemplateCfgForFactory(factory *types.FactoryConfig) (*types.TemplateConfig, error) {
+	files, err := s.resolveTemplateFiles(factory.Template)
+	if err != nil {
+		return nil, err
+	}
+	if cfgContent, ok := files["elasticclaw-config.yaml"]; ok {
+		return config.ParseTemplateConfig([]byte(cfgContent))
+	}
+	return nil, nil
+}

--- a/pkg/hub/shortcut.go
+++ b/pkg/hub/shortcut.go
@@ -40,9 +40,33 @@ type shortcutChange struct {
 
 // ── Handler ───────────────────────────────────────────────────────────────────
 
+func (s *Server) validateShortcutWebhook() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	
+	if s.hubCfg.Integrations == nil {
+		return false
+	}
+	
+	// Validate that at least one Shortcut integration with a token is configured
+	for _, sc := range s.hubCfg.Integrations.Shortcut {
+		if sc.Token != "" {
+			return true
+		}
+	}
+	
+	return false
+}
+
 func (s *Server) handleShortcutWebhook(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Validate that at least one Shortcut integration is configured
+	if !s.validateShortcutWebhook() {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}
 

--- a/pkg/hub/shortcut.go
+++ b/pkg/hub/shortcut.go
@@ -124,7 +124,7 @@ func (s *Server) processShortcutEvent(payload shortcutWebhookPayload) {
 			oldStateName := s.shortcutStateName(token, oldStateID) // only fetched when needed for logging
 
 			// Issue entering trigger status → create claw
-			if strings.EqualFold(newStateName, factory.TriggerStatus) {
+			if strings.EqualFold(newStateName, factory.TriggerStatus) && !strings.EqualFold(oldStateName, factory.TriggerStatus) {
 				log.Printf("[factory:%s] story %s entered '%s' — creating claw", factory.Name, storyID, factory.TriggerStatus)
 				if err := s.createClawForShortcutStory(factory, action, storyID, token); err != nil {
 					log.Printf("[factory:%s] failed to create claw for %s: %v", factory.Name, storyID, err)

--- a/pkg/hub/shortcut.go
+++ b/pkg/hub/shortcut.go
@@ -248,6 +248,9 @@ func (s *Server) createClawForShortcutStory(factory *types.FactoryConfig, action
 		"ELASTICCLAW_HUB_URL":    s.clawHubURL(),
 		"ELASTICCLAW_CLAW_TOKEN": clawToken,
 	}
+	if token != "" {
+		env["SHORTCUT_API_KEY"] = token
+	}
 
 	// Resolve template config fields (from elasticclaw-config.yaml if present).
 	// Factory-level overrides (color, tags) take precedence over template config.

--- a/pkg/hub/shortcut.go
+++ b/pkg/hub/shortcut.go
@@ -121,13 +121,18 @@ func (s *Server) processShortcutEvent(payload shortcutWebhookPayload) {
 			}
 
 			newStateName := s.shortcutStateName(token, newStateID)
-			oldStateName := s.shortcutStateName(token, oldStateID)
+			oldStateName := s.shortcutStateName(token, oldStateID) // only fetched when needed for logging
 
 			// Issue entering trigger status → create claw
 			if strings.EqualFold(newStateName, factory.TriggerStatus) {
 				log.Printf("[factory:%s] story %s entered '%s' — creating claw", factory.Name, storyID, factory.TriggerStatus)
 				if err := s.createClawForShortcutStory(factory, action, storyID, token); err != nil {
 					log.Printf("[factory:%s] failed to create claw for %s: %v", factory.Name, storyID, err)
+					s.logFactoryEvent(factory.Name, storyID, action.Name, oldStateName, newStateName, "error", "", err.Error())
+				} else {
+					var clawID string
+					_ = s.db.QueryRow(`SELECT id FROM claws WHERE linear_issue_id=? ORDER BY created_at DESC LIMIT 1`, storyID).Scan(&clawID)
+					s.logFactoryEvent(factory.Name, storyID, action.Name, oldStateName, newStateName, "claw_created", clawID, "")
 				}
 			}
 
@@ -141,7 +146,10 @@ func (s *Server) processShortcutEvent(payload shortcutWebhookPayload) {
 				if activeClaw != "" {
 					log.Printf("[factory:%s] story %s left trigger — terminating claw", factory.Name, storyID)
 					s.terminateClawForIssue(storyID)
-					_ = oldStateName // suppress unused
+					s.logFactoryEvent(factory.Name, storyID, action.Name, oldStateName, newStateName, "claw_terminated", activeClaw, "")
+				} else {
+					s.logFactoryEvent(factory.Name, storyID, action.Name, oldStateName, newStateName, "not_actionable",
+						"", fmt.Sprintf("status '%s'→'%s' did not match trigger '%s'", oldStateName, newStateName, factory.TriggerStatus))
 				}
 			}
 		}
@@ -340,6 +348,8 @@ func (s *Server) createClawForShortcutStory(factory *types.FactoryConfig, action
 			provErr = s.provisionReplicated(context.Background(), clawID, req, provCfg, env)
 		case "daytona":
 			provErr = s.provisionDaytona(context.Background(), clawID, req, provCfg, fileBytes, env)
+		case "vercel":
+			provErr = s.provisionVercel(context.Background(), clawID, req, provCfg, fileBytes, env)
 		default:
 			provErr = fmt.Errorf("unsupported provider: %s", provider)
 		}
@@ -476,16 +486,4 @@ func toInt64(v interface{}) int64 {
 		return int64(x)
 	}
 	return 0
-}
-
-// loadTemplateCfgForFactory is a helper to load template config for a factory (shared with linear.go).
-func (s *Server) loadTemplateCfgForFactory(factory *types.FactoryConfig) (*types.TemplateConfig, error) {
-	files, err := s.resolveTemplateFiles(factory.Template)
-	if err != nil {
-		return nil, err
-	}
-	if cfgContent, ok := files["elasticclaw-config.yaml"]; ok {
-		return config.ParseTemplateConfig([]byte(cfgContent))
-	}
-	return nil, nil
 }

--- a/pkg/hub/shortcut.go
+++ b/pkg/hub/shortcut.go
@@ -18,19 +18,19 @@ import (
 // ── Webhook payload types ─────────────────────────────────────────────────────
 
 type shortcutWebhookPayload struct {
-	ID         string                        `json:"id"`
-	Actions    []shortcutAction              `json:"actions"`
-	ChangedAt  string                        `json:"changed_at"`
+	ID        string           `json:"id"`
+	Actions   []shortcutAction `json:"actions"`
+	ChangedAt string           `json:"changed_at"`
 }
 
 type shortcutAction struct {
-	ID             int64                          `json:"id"`
-	EntityType     string                         `json:"entity_type"` // "story"
-	Action         string                         `json:"action"`      // "update", "create"
-	Name           string                         `json:"name"`
-	AppURL         string                         `json:"app_url"`
-	Description    string                         `json:"description"`
-	Changes        map[string]shortcutChange      `json:"changes"`
+	ID          int64                     `json:"id"`
+	EntityType  string                    `json:"entity_type"` // "story"
+	Action      string                    `json:"action"`      // "update", "create"
+	Name        string                    `json:"name"`
+	AppURL      string                    `json:"app_url"`
+	Description string                    `json:"description"`
+	Changes     map[string]shortcutChange `json:"changes"`
 }
 
 type shortcutChange struct {
@@ -43,18 +43,18 @@ type shortcutChange struct {
 func (s *Server) validateShortcutWebhook() bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	
+
 	if s.hubCfg.Integrations == nil {
 		return false
 	}
-	
+
 	// Validate that at least one Shortcut integration with a token is configured
 	for _, sc := range s.hubCfg.Integrations.Shortcut {
 		if sc.Token != "" {
 			return true
 		}
 	}
-	
+
 	return false
 }
 
@@ -194,6 +194,19 @@ func (s *Server) createClawForShortcutStory(factory *types.FactoryConfig, action
 		return fmt.Errorf("template %q not found: %w", factory.Template, err)
 	}
 
+	// Parse elasticclaw-config.yaml from the template files (if present) so we
+	// honour provider settings like nix, github repos, default_model, instance_type, etc.
+	var tmplCfg *types.TemplateConfig
+	if cfgContent, ok := templateFiles["elasticclaw-config.yaml"]; ok {
+		var parseErr error
+		tmplCfg, parseErr = config.ParseTemplateConfig([]byte(cfgContent))
+		if parseErr != nil {
+			log.Printf("[factory:%s] warning: could not parse elasticclaw-config.yaml from template %q: %v", factory.Name, factory.Template, parseErr)
+			// Non-fatal — continue with defaults
+			tmplCfg = nil
+		}
+	}
+
 	// Inject BOOTSTRAP.md and CONTEXT.md
 	ctx := buildShortcutContext(action, storyID)
 	templateFiles["BOOTSTRAP.md"] = ctx
@@ -209,11 +222,10 @@ func (s *Server) createClawForShortcutStory(factory *types.FactoryConfig, action
 		return fmt.Errorf("no tenant: %w", err)
 	}
 
+	// Find provider: template config > hub default
 	provider := s.defaultProvider()
-	if factory.Template != "" {
-		if tCfg, _ := s.loadTemplateCfgForFactory(factory); tCfg != nil && tCfg.Provider != "" {
-			provider = tCfg.Provider
-		}
+	if tmplCfg != nil && tmplCfg.Provider != "" {
+		provider = tmplCfg.Provider
 	}
 	if provider == "" {
 		return fmt.Errorf("no provider configured")
@@ -229,6 +241,47 @@ func (s *Server) createClawForShortcutStory(factory *types.FactoryConfig, action
 		"ELASTICCLAW_CLAW_TOKEN": clawToken,
 	}
 
+	// Resolve template config fields (from elasticclaw-config.yaml if present).
+	// Factory-level overrides (color, tags) take precedence over template config.
+	var (
+		instanceType    string
+		defaultModel    string
+		llmKey          string
+		nixEnabled      int
+		githubRepos     []types.GitHubRepoAccess
+		linearWorkspace string
+	)
+	if tmplCfg != nil {
+		instanceType = tmplCfg.InstanceType
+		defaultModel = tmplCfg.DefaultModel
+		llmKey = tmplCfg.LLMKey
+		if tmplCfg.Nix {
+			nixEnabled = 1
+		}
+		if tmplCfg.GitHub != nil {
+			githubRepos = tmplCfg.GitHub.Repos
+		}
+		if tmplCfg.Linear != nil {
+			linearWorkspace = tmplCfg.Linear.Workspace
+		}
+	}
+	// Resolve default model: template > llm_key lookup > hub default
+	if defaultModel == "" && llmKey != "" {
+		s.mu.RLock()
+		for _, k := range s.hubCfg.LLMKeys {
+			if k.Name == llmKey {
+				defaultModel = resolveDefaultModelForKey(s.hubCfg, k)
+				break
+			}
+		}
+		s.mu.RUnlock()
+	}
+	if defaultModel == "" {
+		s.mu.RLock()
+		defaultModel = s.hubCfg.DefaultModel
+		s.mu.RUnlock()
+	}
+
 	tags := mergeTags(factory.Template, factory.Tags, nil)
 	hasfactory := false
 	for _, t := range tags {
@@ -242,14 +295,23 @@ func (s *Server) createClawForShortcutStory(factory *types.FactoryConfig, action
 	}
 	tagsJSON, _ := json.Marshal(tags)
 
+	// Color: factory overrides template config
+	clawColor := factory.Color
+	if clawColor == "" && tmplCfg != nil {
+		clawColor = tmplCfg.Color
+	}
+
+	githubReposJSON, _ := json.Marshal(githubRepos)
+
 	clawID := uuid.New().String()
 	filesJSON, _ := json.Marshal(templateFiles)
+	now := now()
 
-	_, err = s.db.Exec(
-		`INSERT INTO claws(id,tenant_id,name,template,provider,template_files,linear_issue_id,tags,color,status,created_at)
-		 VALUES(?,?,?,?,?,?,?,?,?,'provisioning',?)`,
-		clawID, tenantID, clawName, factory.Template, provider, string(filesJSON),
-		storyID, string(tagsJSON), factory.Color, now(),
+	_, err = s.db.Exec(`
+		INSERT INTO claws(id, tenant_id, name, template, provider, default_model, template_files, github_repos, linear_workspace, nix, tags, color, llm_key, linear_issue_id, status, created_at)
+		VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,'provisioning',?)`,
+		clawID, tenantID, clawName, factory.Template, provider, defaultModel, string(filesJSON),
+		string(githubReposJSON), linearWorkspace, nixEnabled, string(tagsJSON), clawColor, llmKey, storyID, now,
 	)
 	if err != nil {
 		return fmt.Errorf("db insert: %w", err)
@@ -258,6 +320,7 @@ func (s *Server) createClawForShortcutStory(factory *types.FactoryConfig, action
 	req := types.CreateClawRequest{
 		Name: clawName, TemplateName: factory.Template,
 		Provider: provider, Files: templateFiles, Env: env,
+		InstanceType: instanceType,
 		ProviderName: "ec-" + clawID[:8],
 	}
 

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -160,7 +160,14 @@ type HubConfig struct {
 
 // IntegrationsConfig holds configs for external integrations.
 type IntegrationsConfig struct {
-	Linear []*LinearIntegrationConfig `yaml:"linear,omitempty"`
+	Linear    []*LinearIntegrationConfig    `yaml:"linear,omitempty"`
+	Shortcut  []*ShortcutIntegrationConfig  `yaml:"shortcut,omitempty"`
+}
+
+// ShortcutIntegrationConfig holds credentials for one Shortcut workspace.
+type ShortcutIntegrationConfig struct {
+	Workspace string `yaml:"workspace"`       // human label
+	Token     string `yaml:"token"`            // Shortcut API token
 }
 
 // LinearIntegrationConfig holds credentials for one Linear workspace.
@@ -174,7 +181,7 @@ type LinearIntegrationConfig struct {
 type FactoryConfig struct {
 	Name              string `yaml:"name"`
 	Enabled           *bool  `yaml:"enabled,omitempty"`  // nil = true (default on); set false to pause
-	Integration       string `yaml:"integration"`        // "linear" (future: "shortcut", "github-issues")
+	Integration       string `yaml:"integration"`        // "linear" or "shortcut"
 	Workspace         string `yaml:"workspace"`          // matches integrations.<type>[].workspace
 	Team              string `yaml:"team,omitempty"`     // Linear team key (e.g. "ELA")
 	TriggerStatus     string `yaml:"trigger_status"`     // entering this status → create claw

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -32,6 +32,7 @@ interface SettingsData {
   sshPublicKeys: string[]
   integrations?: {
     linear?: Array<{ workspace: string; tokenSet: boolean; webhookSecretSet: boolean }>
+    shortcut?: Array<{ workspace: string; tokenSet: boolean }>
   }
   factories?: Array<{
     name: string; integration: string; workspace: string; team: string
@@ -643,6 +644,91 @@ function IntegrationsSection({ settings, onSave, saving }: { settings: SettingsD
           </Button>
         </div>
       </div>
+
+      {/* Shortcut */}
+      <ShortcutIntegrationsBlock settings={settings} onSave={onSave} saving={saving} />
+    </div>
+  )
+}
+
+function ShortcutIntegrationsBlock({ settings, onSave, saving }: { settings: SettingsData; onSave: (p: object) => void; saving: boolean }) {
+  const shortcut = settings.integrations?.shortcut || []
+  const [editingIdx, setEditingIdx] = useState<number | null>(null)
+  const [editWorkspace, setEditWorkspace] = useState("")
+  const [editToken, setEditToken] = useState("")
+  const [newWorkspace, setNewWorkspace] = useState("")
+  const [newToken, setNewToken] = useState("")
+
+  return (
+    <div>
+      <h3 className="text-sm font-semibold mb-3 flex items-center gap-2 mt-6">
+        <span className="size-4 text-[#F4603C]">⚡</span> Shortcut
+      </h3>
+      {shortcut.length > 0 && (
+        <div className="mb-4 space-y-2">
+          {shortcut.map((sc, i) => (
+            <div key={i}>
+              {editingIdx === i ? (
+                <div className="border border-primary/40 rounded-lg p-4 space-y-3 bg-primary/5">
+                  <h4 className="text-sm font-semibold">Edit: {sc.workspace}</h4>
+                  <p className="text-xs text-muted-foreground">Leave token blank to keep existing.</p>
+                  <div>
+                    <label className="text-xs text-muted-foreground mb-1 block">Workspace label</label>
+                    <Input value={editWorkspace} onChange={e => setEditWorkspace(e.target.value)} className="h-8 text-sm" />
+                  </div>
+                  <div>
+                    <label className="text-xs text-muted-foreground mb-1 block">API Token</label>
+                    <Input type="password" value={editToken} onChange={e => setEditToken(e.target.value)} className="h-8 text-sm" placeholder="(leave blank to keep)" />
+                  </div>
+                  <div className="flex gap-2">
+                    <Button size="sm" disabled={saving || !editWorkspace} onClick={() => {
+                      const patch = shortcut.map((x, j) => j === i
+                        ? { workspace: editWorkspace, ...(editToken ? { token: editToken } : {}) }
+                        : { workspace: x.workspace }
+                      )
+                      onSave({ integrations: { shortcut: patch } })
+                      setEditingIdx(null)
+                    }}>Save</Button>
+                    <Button size="sm" variant="outline" onClick={() => setEditingIdx(null)}>Cancel</Button>
+                    <Button size="sm" variant="ghost" className="text-destructive ml-auto" disabled={saving}
+                      onClick={() => { onSave({ integrations: { shortcut: shortcut.filter((_, j) => j !== i).map(x => ({ workspace: x.workspace })) } }); setEditingIdx(null) }}>
+                      Remove
+                    </Button>
+                  </div>
+                </div>
+              ) : (
+                <div className="border border-border rounded-lg p-3 flex items-center justify-between">
+                  <div>
+                    <p className="text-sm font-medium">{sc.workspace}</p>
+                    <p className="text-xs text-muted-foreground">
+                      Token: {sc.tokenSet ? <span className="text-green-500">✓ set</span> : <span className="text-amber-500">✗ not set</span>}
+                    </p>
+                  </div>
+                  <Button size="sm" variant="outline" onClick={() => { setEditingIdx(i); setEditWorkspace(sc.workspace); setEditToken("") }}>Edit</Button>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+      <div className="border border-border rounded-lg p-4 space-y-3">
+        <p className="text-xs text-muted-foreground font-medium">Add a Shortcut workspace</p>
+        <div>
+          <label className="text-xs text-muted-foreground mb-1 block">Workspace label</label>
+          <Input value={newWorkspace} onChange={e => setNewWorkspace(e.target.value)} className="h-8 text-sm" placeholder="my-company" />
+        </div>
+        <div>
+          <label className="text-xs text-muted-foreground mb-1 block">API Token</label>
+          <Input type="password" value={newToken} onChange={e => setNewToken(e.target.value)} className="h-8 text-sm" placeholder="Shortcut API token" />
+        </div>
+        <Button size="sm" disabled={saving || !newWorkspace || !newToken}
+          onClick={() => {
+            onSave({ integrations: { shortcut: [...shortcut.map(x => ({ workspace: x.workspace })), { workspace: newWorkspace, token: newToken }] } })
+            setNewWorkspace(""); setNewToken("")
+          }}>
+          Add Shortcut Workspace
+        </Button>
+      </div>
     </div>
   )
 }
@@ -669,7 +755,10 @@ function FactoriesSection({ hubUrl, settings, onSave, onSaveSilent, saving }: { 
     doneStatus: "In Review", terminateOnLeave: true, template: "base", webhookSecret: "", tags: "", color: ""
   })
 
-  const workspaces = settings.integrations?.linear?.map(l => l.workspace) || []
+  const workspaces = [
+    ...(settings.integrations?.linear?.map(l => ({ label: `Linear: ${l.workspace}`, value: l.workspace })) || []),
+    ...(settings.integrations?.shortcut?.map(s => ({ label: `Shortcut: ${s.workspace}`, value: s.workspace })) || []),
+  ]
 
   function update(k: keyof FactoryFormData, v: string | boolean) {
     setForm(prev => ({ ...prev, [k]: v }))
@@ -684,12 +773,11 @@ function FactoriesSection({ hubUrl, settings, onSave, onSaveSilent, saving }: { 
         </p>
       </div>
 
-      {/* Webhook URL */}
-      <div className="border border-border rounded-lg p-5 space-y-3">
-        <h3 className="text-sm font-medium">Linear Webhook URL</h3>
-        <p className="text-xs text-muted-foreground">
-          Paste into <strong>Linear → Settings → API → Webhooks</strong> and subscribe to <strong>Issue</strong> events.
-        </p>
+      {/* Webhook URLs */}
+      <div className="border border-border rounded-lg p-5 space-y-4">
+        <div className="space-y-2">
+          <h3 className="text-sm font-medium">Linear Webhook URL</h3>
+          <p className="text-xs text-muted-foreground">Paste into <strong>Linear → Settings → API → Webhooks</strong>, subscribe to <strong>Issue</strong> events.</p>
         <div className="flex items-center gap-2">
           <code className="flex-1 text-xs font-mono bg-muted px-3 py-2 rounded-md border border-border truncate">
             {webhookUrl || "Loading…"}
@@ -698,6 +786,23 @@ function FactoriesSection({ hubUrl, settings, onSave, onSaveSilent, saving }: { 
             {copied ? <Check className="size-3.5 text-green-500" /> : <Copy className="size-3.5" />}
             <span className="ml-1.5">{copied ? "Copied" : "Copy"}</span>
           </Button>
+        </div>
+        </div>
+        {/* Shortcut webhook */}
+        <div className="space-y-2 pt-3 border-t border-border">
+          <h3 className="text-sm font-medium">Shortcut Webhook URL</h3>
+          <p className="text-xs text-muted-foreground">Use Shortcut's API to register this webhook: <code className="bg-muted px-1 rounded text-xs">POST /api/v3/webhooks</code> with this URL.</p>
+          <div className="flex items-center gap-2">
+            <code className="flex-1 text-xs font-mono bg-muted px-3 py-2 rounded-md border border-border truncate">
+              {hubUrl ? `${hubUrl}/api/integrations/shortcut/webhook` : "Loading…"}
+            </code>
+            <Button variant="outline" size="sm" className="shrink-0" onClick={() => {
+              if (hubUrl) navigator.clipboard.writeText(`${hubUrl}/api/integrations/shortcut/webhook`)
+            }} disabled={!hubUrl}>
+              <Copy className="size-3.5" />
+              <span className="ml-1.5">Copy</span>
+            </Button>
+          </div>
         </div>
       </div>
 
@@ -822,11 +927,11 @@ function FactoriesSection({ hubUrl, settings, onSave, onSaveSilent, saving }: { 
             <Input value={form.name} onChange={e => update("name", e.target.value)} className="h-8 text-sm" placeholder="ELA feature work" />
           </div>
           <div>
-            <label className="text-xs text-muted-foreground mb-1 block">Linear workspace</label>
+            <label className="text-xs text-muted-foreground mb-1 block">Workspace</label>
             <select value={form.workspace} onChange={e => update("workspace", e.target.value)}
               className="w-full h-8 rounded-md border border-border bg-background px-2 text-sm">
               <option value="">Select workspace</option>
-              {workspaces.map(w => <option key={w} value={w}>{w}</option>)}
+              {workspaces.map(w => <option key={w.value} value={w.value}>{w.label}</option>)}
             </select>
           </div>
           <div>

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -756,8 +756,8 @@ function FactoriesSection({ hubUrl, settings, onSave, onSaveSilent, saving }: { 
   })
 
   const workspaces = [
-    ...(settings.integrations?.linear?.map(l => ({ label: `Linear: ${l.workspace}`, value: l.workspace })) || []),
-    ...(settings.integrations?.shortcut?.map(s => ({ label: `Shortcut: ${s.workspace}`, value: s.workspace })) || []),
+    ...(settings.integrations?.linear?.map(l => ({ label: `Linear: ${l.workspace}`, value: `linear:${l.workspace}` })) || []),
+    ...(settings.integrations?.shortcut?.map(s => ({ label: `Shortcut: ${s.workspace}`, value: `shortcut:${s.workspace}` })) || []),
   ]
 
   function update(k: keyof FactoryFormData, v: string | boolean) {
@@ -973,10 +973,10 @@ function FactoriesSection({ hubUrl, settings, onSave, onSaveSilent, saving }: { 
           onClick={() => {
             const { webhookSecret, tags: tagsStr, color, ...rest } = form
             const tags = tagsStr.split(",").map(t => t.trim()).filter(Boolean)
-            // Determine integration type from selected workspace
-            const selectedWorkspace = workspaces.find(w => w.value === form.workspace)
-            const integration = selectedWorkspace?.label.startsWith("Shortcut:") ? "shortcut" : "linear"
-            onSave({ factories: [...factories, { ...rest, integration, ...(webhookSecret ? { webhookSecret } : {}), ...(tags.length ? { tags } : {}), ...(color ? { color } : {}) }] })
+            // Determine integration type from workspace value prefix
+            const integration = form.workspace.startsWith("shortcut:") ? "shortcut" : "linear"
+            const workspaceName = form.workspace.includes(":") ? form.workspace.split(":")[1] : form.workspace
+            onSave({ factories: [...factories, { ...rest, workspace: workspaceName, integration, ...(webhookSecret ? { webhookSecret } : {}), ...(tags.length ? { tags } : {}), ...(color ? { color } : {}) }] })
             setForm({ name: "", workspace: "", team: "", triggerStatus: "Ready for Agent", doneStatus: "In Review", terminateOnLeave: true, template: "base", webhookSecret: "", tags: "", color: "" })
           }}>
           Add Factory

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -973,7 +973,10 @@ function FactoriesSection({ hubUrl, settings, onSave, onSaveSilent, saving }: { 
           onClick={() => {
             const { webhookSecret, tags: tagsStr, color, ...rest } = form
             const tags = tagsStr.split(",").map(t => t.trim()).filter(Boolean)
-            onSave({ factories: [...factories, { ...rest, integration: "linear", ...(webhookSecret ? { webhookSecret } : {}), ...(tags.length ? { tags } : {}), ...(color ? { color } : {}) }] })
+            // Determine integration type from selected workspace
+            const selectedWorkspace = workspaces.find(w => w.value === form.workspace)
+            const integration = selectedWorkspace?.label.startsWith("Shortcut:") ? "shortcut" : "linear"
+            onSave({ factories: [...factories, { ...rest, integration, ...(webhookSecret ? { webhookSecret } : {}), ...(tags.length ? { tags } : {}), ...(color ? { color } : {}) }] })
             setForm({ name: "", workspace: "", team: "", triggerStatus: "Ready for Agent", doneStatus: "In Review", terminateOnLeave: true, template: "base", webhookSecret: "", tags: "", color: "" })
           }}>
           Add Factory

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -683,7 +683,7 @@ function ShortcutIntegrationsBlock({ settings, onSave, saving }: { settings: Set
                   <div className="flex gap-2">
                     <Button size="sm" disabled={saving || !editWorkspace} onClick={() => {
                       const patch = shortcut.map((x, j) => j === i
-                        ? { workspace: editWorkspace, ...(editToken ? { token: editToken } : {}) }
+                        ? { workspace: editWorkspace, originalWorkspace: sc.workspace, ...(editToken ? { token: editToken } : {}) }
                         : { workspace: x.workspace }
                       )
                       onSave({ integrations: { shortcut: patch } })


### PR DESCRIPTION
Adds Shortcut as a factory trigger alongside Linear.\n\n**hub.yaml:**\n```yaml\nintegrations:\n  shortcut:\n    - workspace: my-company\n      token: sc-token-...\n\nfactories:\n  - name: sc-factory\n    integration: shortcut\n    workspace: my-company\n    trigger_status: In Development\n    done_status: In Review\n    template: base\n```\n\n**Webhook URL:** `POST /api/integrations/shortcut/webhook`\nRegister via Shortcut API: `POST https://api.app.shortcut.com/api/v3/webhooks`\n\n**Settings UI:**\n- Shortcut workspace add/edit/remove under Integrations\n- Shortcut webhook URL displayed in Factories section\n- Factory workspace dropdown includes both Linear and Shortcut workspaces\n\n**Note:** Shortcut doesn't provide HMAC webhook signing — validation is by token match.