### PR TITLE
fix: persist llm_keys to hub.yaml and dynamic openclaw provider config at bootstrap

### DIFF
--- a/pkg/config/hub.go
+++ b/pkg/config/hub.go
@@ -28,10 +28,8 @@ func LoadHubConfig() (*types.HubConfig, error) {
 			}
 			return nil, fmt.Errorf("failed to read hub config %s: %w", path, err)
 		}
-		// Parse hub config with auto-migration of legacy llm_keys flat map format.
-		// Strategy: parse without llm_keys first, then handle llm_keys separately.
-		cfg, err := parseHubConfig(data)
-		if err != nil {
+		cfg := &types.HubConfig{}
+		if err := yaml.Unmarshal(data, cfg); err != nil {
 			return nil, fmt.Errorf("failed to parse hub config %s: %w", path, err)
 		}
 		return cfg, nil
@@ -57,13 +55,6 @@ func ActiveHubConfigPath() (string, error) {
 	return filepath.Join(home, ".elasticclaw", "hub.yaml"), nil
 }
 
-// hubConfigForSave is a serialization wrapper that includes LLMKeys (which is
-// tagged yaml:"-" in HubConfig to avoid double-parsing conflicts).
-type hubConfigForSave struct {
-	*types.HubConfig `yaml:",inline"`
-	LLMKeys          []*types.LLMKeyConfig `yaml:"llm_keys,omitempty"`
-}
-
 func SaveHubConfig(cfg *types.HubConfig) error {
 	path, err := ActiveHubConfigPath()
 	if err != nil {
@@ -72,7 +63,7 @@ func SaveHubConfig(cfg *types.HubConfig) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return err
 	}
-	data, err := yaml.Marshal(hubConfigForSave{HubConfig: cfg, LLMKeys: cfg.LLMKeys})
+	data, err := yaml.Marshal(cfg)
 	if err != nil {
 		return err
 	}
@@ -256,97 +247,4 @@ func ReadTemplateFiles(templateDir string) (map[string]string, error) {
 	return files, nil
 }
 
-// migrateOldLLMKeys converts old flat map {provider: key} yaml format to the new named slice.
-// Old format: llm_keys:\n  anthropic: sk-...
-// New format: llm_keys:\n  - name: anthropic\n    provider: anthropic\n    api_key: sk-...
-// parseHubConfig parses hub.yaml handling both old flat-map llm_keys and new named-slice format.
-func parseHubConfig(data []byte) (*types.HubConfig, error) {
-	// Use a temporary type with llm_keys as a raw yaml.Node to handle both formats.
-	type hubConfigRaw struct {
-		types.HubConfig `yaml:",inline"`
-		LLMKeysRaw      yaml.Node `yaml:"llm_keys"`
-	}
 
-	// Zero out the LLMKeys field in HubConfig so inline doesn't conflict
-	var raw hubConfigRaw
-	if err := yaml.Unmarshal(data, &raw); err != nil {
-		return nil, err
-	}
-	cfg := &raw.HubConfig
-	cfg.LLMKeys = nil // will be populated below
-
-	// Try to decode llm_keys as new slice format first
-	if raw.LLMKeysRaw.Kind != 0 {
-		var newFormat []*types.LLMKeyConfig
-		if err := raw.LLMKeysRaw.Decode(&newFormat); err == nil {
-			cfg.LLMKeys = newFormat
-		} else {
-			// Fall back to old flat map format
-			var oldFormat map[string]string
-			if err2 := raw.LLMKeysRaw.Decode(&oldFormat); err2 == nil {
-				var providers []string
-				for p, k := range oldFormat {
-					if k != "" {
-						providers = append(providers, p)
-					}
-				}
-				for i, p := range providers {
-					cfg.LLMKeys = append(cfg.LLMKeys, &types.LLMKeyConfig{
-						Name:     p,
-						Provider: p,
-						APIKey:   oldFormat[p],
-						Default:  i == 0,
-					})
-				}
-			} else {
-				return nil, fmt.Errorf("llm_keys: expected list of {name,provider,api_key} or flat map {provider: key}: %w", err2)
-			}
-		}
-	}
-	return cfg, nil
-}
-
-func migrateOldLLMKeys(cfg *types.HubConfig, raw []byte) error {
-	// If we already have new-format keys, nothing to do
-	if len(cfg.LLMKeys) > 0 {
-		return nil
-	}
-	// Try to parse as the old flat map
-	var legacy struct {
-		LLMKeys map[string]string `yaml:"llm_keys"`
-	}
-	if err := yaml.Unmarshal(raw, &legacy); err != nil || len(legacy.LLMKeys) == 0 {
-		return err
-	}
-
-	// Sort providers to ensure deterministic default selection
-	var providers []string
-	for provider := range legacy.LLMKeys {
-		if legacy.LLMKeys[provider] != "" {
-			providers = append(providers, provider)
-		}
-	}
-	if len(providers) == 0 {
-		return nil
-	}
-
-	// Use lexicographic ordering for deterministic behavior
-	for i := 0; i < len(providers); i++ {
-		for j := i + 1; j < len(providers); j++ {
-			if providers[i] > providers[j] {
-				providers[i], providers[j] = providers[j], providers[i]
-			}
-		}
-	}
-
-	// First provider in sorted order becomes default
-	for i, provider := range providers {
-		cfg.LLMKeys = append(cfg.LLMKeys, &types.LLMKeyConfig{
-			Name:     provider,
-			Provider: provider,
-			APIKey:   legacy.LLMKeys[provider],
-			Default:  i == 0,
-		})
-	}
-	return nil
-}

--- a/pkg/config/hub.go
+++ b/pkg/config/hub.go
@@ -57,6 +57,13 @@ func ActiveHubConfigPath() (string, error) {
 	return filepath.Join(home, ".elasticclaw", "hub.yaml"), nil
 }
 
+// hubConfigForSave is a serialization wrapper that includes LLMKeys (which is
+// tagged yaml:"-" in HubConfig to avoid double-parsing conflicts).
+type hubConfigForSave struct {
+	*types.HubConfig `yaml:",inline"`
+	LLMKeys          []*types.LLMKeyConfig `yaml:"llm_keys,omitempty"`
+}
+
 func SaveHubConfig(cfg *types.HubConfig) error {
 	path, err := ActiveHubConfigPath()
 	if err != nil {
@@ -65,7 +72,7 @@ func SaveHubConfig(cfg *types.HubConfig) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return err
 	}
-	data, err := yaml.Marshal(cfg)
+	data, err := yaml.Marshal(hubConfigForSave{HubConfig: cfg, LLMKeys: cfg.LLMKeys})
 	if err != nil {
 		return err
 	}

--- a/pkg/config/hub_test.go
+++ b/pkg/config/hub_test.go
@@ -4,45 +4,50 @@ import (
 	"testing"
 
 	"github.com/elasticclaw/elasticclaw/pkg/types"
+	"gopkg.in/yaml.v3"
 )
 
-func TestMigrateOldLLMKeys_DeterministicDefault(t *testing.T) {
+// parseLLMKeys is a helper that unmarshals a hub.yaml snippet and returns the LLMKeys.
+func parseLLMKeys(t *testing.T, yamlStr string) types.LLMKeysList {
+	t.Helper()
+	cfg := &types.HubConfig{}
+	if err := yaml.Unmarshal([]byte(yamlStr), cfg); err != nil {
+		t.Fatalf("yaml.Unmarshal failed: %v", err)
+	}
+	return cfg.LLMKeys
+}
+
+func TestLLMKeysList_OldFormat_DeterministicDefault(t *testing.T) {
 	// Old format YAML with multiple keys
-	oldYAML := []byte(`
+	keys := parseLLMKeys(t, `
 llm_keys:
   fireworks: sk-fw-123
   anthropic: sk-ant-456
   openai: sk-openai-789
 `)
 
-	cfg := &types.HubConfig{}
-	err := migrateOldLLMKeys(cfg, oldYAML)
-	if err != nil {
-		t.Fatalf("migration failed: %v", err)
-	}
-
-	if len(cfg.LLMKeys) != 3 {
-		t.Fatalf("expected 3 keys, got %d", len(cfg.LLMKeys))
+	if len(keys) != 3 {
+		t.Fatalf("expected 3 keys, got %d", len(keys))
 	}
 
 	// First key in alphabetical order (anthropic) should be default
-	if cfg.LLMKeys[0].Name != "anthropic" {
-		t.Errorf("expected first key to be 'anthropic', got '%s'", cfg.LLMKeys[0].Name)
+	if keys[0].Name != "anthropic" {
+		t.Errorf("expected first key to be 'anthropic', got '%s'", keys[0].Name)
 	}
-	if !cfg.LLMKeys[0].Default {
+	if !keys[0].Default {
 		t.Error("first key should be marked as default")
 	}
 
 	// Other keys should not be default
-	for i := 1; i < len(cfg.LLMKeys); i++ {
-		if cfg.LLMKeys[i].Default {
-			t.Errorf("key %d (%s) should not be default", i, cfg.LLMKeys[i].Name)
+	for i := 1; i < len(keys); i++ {
+		if keys[i].Default {
+			t.Errorf("key %d (%s) should not be default", i, keys[i].Name)
 		}
 	}
 
 	// Verify deterministic ordering (alphabetical)
 	expected := []string{"anthropic", "fireworks", "openai"}
-	for i, k := range cfg.LLMKeys {
+	for i, k := range keys {
 		if k.Name != expected[i] {
 			t.Errorf("key %d: expected %s, got %s", i, expected[i], k.Name)
 		}
@@ -52,53 +57,54 @@ llm_keys:
 	}
 }
 
-func TestMigrateOldLLMKeys_SkipsIfNewFormatPresent(t *testing.T) {
-	oldYAML := []byte(`
+func TestLLMKeysList_NewFormat(t *testing.T) {
+	keys := parseLLMKeys(t, `
 llm_keys:
-  anthropic: sk-ant-456
+  - name: anthropic-prod
+    provider: anthropic
+    api_key: sk-ant-456
+    default: true
+  - name: fireworks-prod
+    provider: fireworks
+    api_key: sk-fw-123
 `)
 
-	cfg := &types.HubConfig{
-		LLMKeys: []*types.LLMKeyConfig{
-			{Name: "existing", Provider: "openai", APIKey: "sk-existing", Default: true},
-		},
+	if len(keys) != 2 {
+		t.Fatalf("expected 2 keys, got %d", len(keys))
 	}
-
-	err := migrateOldLLMKeys(cfg, oldYAML)
-	if err != nil {
-		t.Fatalf("migration failed: %v", err)
+	if keys[0].Name != "anthropic-prod" {
+		t.Errorf("expected first key to be 'anthropic-prod', got '%s'", keys[0].Name)
 	}
-
-	// Should not have changed
-	if len(cfg.LLMKeys) != 1 {
-		t.Errorf("expected 1 key (unchanged), got %d", len(cfg.LLMKeys))
+	if !keys[0].Default {
+		t.Error("first key should be default")
 	}
-	if cfg.LLMKeys[0].Name != "existing" {
-		t.Errorf("existing key should be unchanged")
+	if keys[1].Name != "fireworks-prod" {
+		t.Errorf("expected second key to be 'fireworks-prod', got '%s'", keys[1].Name)
 	}
 }
 
-func TestMigrateOldLLMKeys_HandlesEmptyKeys(t *testing.T) {
-	oldYAML := []byte(`
+func TestLLMKeysList_OldFormat_HandlesEmptyKeys(t *testing.T) {
+	keys := parseLLMKeys(t, `
 llm_keys:
   anthropic: sk-ant-456
   fireworks: ""
   openai: sk-openai-789
 `)
 
-	cfg := &types.HubConfig{}
-	err := migrateOldLLMKeys(cfg, oldYAML)
-	if err != nil {
-		t.Fatalf("migration failed: %v", err)
-	}
-
 	// Should only have 2 keys (empty fireworks skipped)
-	if len(cfg.LLMKeys) != 2 {
-		t.Fatalf("expected 2 keys, got %d", len(cfg.LLMKeys))
+	if len(keys) != 2 {
+		t.Fatalf("expected 2 keys, got %d", len(keys))
 	}
 
 	// Keys should be anthropic and openai in alphabetical order
-	if cfg.LLMKeys[0].Name != "anthropic" || cfg.LLMKeys[1].Name != "openai" {
-		t.Errorf("expected anthropic and openai, got %s and %s", cfg.LLMKeys[0].Name, cfg.LLMKeys[1].Name)
+	if keys[0].Name != "anthropic" || keys[1].Name != "openai" {
+		t.Errorf("expected anthropic and openai, got %s and %s", keys[0].Name, keys[1].Name)
+	}
+}
+
+func TestLLMKeysList_Empty(t *testing.T) {
+	keys := parseLLMKeys(t, `url: https://example.com`)
+	if len(keys) != 0 {
+		t.Errorf("expected 0 keys when llm_keys absent, got %d", len(keys))
 	}
 }

--- a/pkg/hub/bootstrap.go
+++ b/pkg/hub/bootstrap.go
@@ -2,6 +2,7 @@ package hub
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
@@ -32,9 +33,151 @@ type BootstrapParams struct {
 	GitHubRepos []types.GitHubRepoAccess
 
 	// Env injection
-	LLMKeyEnv   string // pre-built export lines
-	LinearEnv   string // pre-built export line
-	RelayEnv    string // pre-built export lines
+	LLMKeyEnv      string // pre-built export lines
+	LinearEnv      string // pre-built export line
+	RelayEnv       string // pre-built export lines
+	ProviderConfig string // python snippet to configure models.providers
+}
+
+// buildOpenClawProviderConfig returns a python snippet that writes the correct
+// models.providers config to ~/.openclaw/openclaw.json based on configured LLM keys.
+// selectedKeyName is used to pick the active key (falls back to default, then first).
+func buildOpenClawProviderConfig(keys []*types.LLMKeyConfig, selectedKeyName string) string {
+	if len(keys) == 0 {
+		// No keys configured — produce empty snippet
+		return ""
+	}
+
+	// Determine active key
+	var activeKey *types.LLMKeyConfig
+	for _, k := range keys {
+		if k.Name == selectedKeyName {
+			activeKey = k
+			break
+		}
+	}
+	if activeKey == nil {
+		for _, k := range keys {
+			if k.Default {
+				activeKey = k
+				break
+			}
+		}
+	}
+	if activeKey == nil {
+		activeKey = keys[0]
+	}
+	_ = activeKey // used implicitly via the provider list
+
+	// Build per-provider config entries.
+	// We emit an entry for every unique provider across all configured keys.
+	// If a provider appears multiple times we use the active key's entry if it matches,
+	// otherwise the first occurrence.
+	seen := map[string]bool{}
+	var providerLines []string
+
+	// Helper: build a single provider dict as a python literal.
+	buildEntry := func(k *types.LLMKeyConfig) string {
+		envVar := k.EnvVarName()
+		switch k.Provider {
+		case "anthropic":
+			return fmt.Sprintf(`'anthropic': {
+            'apiKey': os.environ.get('%s', ''),
+            'baseUrl': 'https://api.anthropic.com',
+            'api': 'anthropic-messages',
+            'models': [
+                {'id': 'claude-sonnet-4-6', 'name': 'Claude Sonnet 4.6', 'api': 'anthropic-messages'},
+                {'id': 'claude-opus-4-5',   'name': 'Claude Opus 4.5',   'api': 'anthropic-messages'},
+                {'id': 'claude-sonnet-4-5', 'name': 'Claude Sonnet 4.5', 'api': 'anthropic-messages'}
+            ]
+        }`, envVar)
+		case "fireworks":
+			return fmt.Sprintf(`'fireworks': {
+            'apiKey': os.environ.get('%s', ''),
+            'baseUrl': 'https://api.fireworks.ai/inference/v1',
+            'api': 'openai-chat-completions',
+            'models': [
+                {'id': 'accounts/fireworks/models/kimi-k2p6',                  'name': 'Kimi K2'},
+                {'id': 'accounts/fireworks/models/llama-v3p3-70b-instruct',    'name': 'Llama 3.3 70B'},
+                {'id': 'accounts/fireworks/models/deepseek-v3',                'name': 'DeepSeek V3'}
+            ]
+        }`, envVar)
+		case "openai":
+			return fmt.Sprintf(`'openai': {
+            'apiKey': os.environ.get('%s', ''),
+            'baseUrl': 'https://api.openai.com/v1',
+            'api': 'openai-chat-completions',
+            'models': [
+                {'id': 'gpt-4o',      'name': 'GPT-4o'},
+                {'id': 'gpt-4o-mini', 'name': 'GPT-4o Mini'}
+            ]
+        }`, envVar)
+		case "groq":
+			return fmt.Sprintf(`'groq': {
+            'apiKey': os.environ.get('%s', ''),
+            'baseUrl': 'https://api.groq.com/openai/v1',
+            'api': 'openai-chat-completions',
+            'models': [
+                {'id': 'llama-3.3-70b-versatile', 'name': 'Llama 3.3 70B'}
+            ]
+        }`, envVar)
+		case "deepseek":
+			return fmt.Sprintf(`'deepseek': {
+            'apiKey': os.environ.get('%s', ''),
+            'baseUrl': 'https://api.deepseek.com/v1',
+            'api': 'openai-chat-completions',
+            'models': [
+                {'id': 'deepseek-chat', 'name': 'DeepSeek Chat'}
+            ]
+        }`, envVar)
+		default:
+			return fmt.Sprintf(`'%s': {
+            'apiKey': os.environ.get('%s', ''),
+            'api': 'openai-chat-completions'
+        }`, k.Provider, envVar)
+		}
+	}
+
+	// Prioritize the active key's provider first
+	entry := buildEntry(activeKey)
+	seen[activeKey.Provider] = true
+	providerLines = append(providerLines, entry)
+
+	// Then remaining keys
+	for _, k := range keys {
+		if seen[k.Provider] {
+			continue
+		}
+		seen[k.Provider] = true
+		providerLines = append(providerLines, buildEntry(k))
+	}
+
+	providersDict := strings.Join(providerLines, ",\n        ")
+
+	return fmt.Sprintf(`python3 << 'PYEOF'
+import json, os
+path = os.path.expanduser('~/.openclaw/openclaw.json')
+try:
+    with open(path) as f:
+        config = json.load(f)
+except:
+    config = {}
+model = os.environ.get('OPENCLAW_DEFAULT_MODEL', 'anthropic/claude-sonnet-4-6')
+config.setdefault('agents', {}).setdefault('defaults', {})['model'] = model
+config['models'] = {
+    'providers': {
+        %s
+    }
+}
+config.setdefault('gateway', {})['bind'] = 'loopback'
+config['gateway']['port'] = 18789
+gw_password = os.environ.get('ELASTICCLAW_GATEWAY_PASSWORD', '')
+if gw_password:
+    config['gateway']['auth'] = {'mode': 'password', 'password': gw_password}
+with open(path, 'w') as f:
+    json.dump(config, f, indent=2)
+print('OpenClaw config patched')
+PYEOF`, providersDict)
 }
 
 // GenerateReplicatedBootstrapScript returns the bash script that bootstraps
@@ -75,14 +218,11 @@ echo "OpenClaw: $(openclaw --version)"
 mkdir -p "$HOME/.openclaw/workspace"
 if [ ! -f "$HOME/.openclaw/openclaw.json" ]; then
   echo "Configuring OpenClaw..."
-  export ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-placeholder}"
   openclaw onboard \
     --non-interactive --accept-risk \
-    --auth-choice anthropic-api-key \
-    --anthropic-api-key "$ANTHROPIC_API_KEY" \
     --gateway-bind loopback --gateway-port 18789 \
     --skip-daemon 2>/dev/null || true
-  printf 'import json, os\npath = os.path.expanduser('"'"'~/.openclaw/openclaw.json'"'"')\ntry:\n    with open(path) as f:\n        config = json.load(f)\nexcept:\n    config = {}\nmodel = os.environ.get('"'"'OPENCLAW_DEFAULT_MODEL'"'"', '"'"'anthropic/claude-sonnet-4-6'"'"')\napiKey = os.environ.get('"'"'ANTHROPIC_API_KEY'"'"', '"'"'placeholder'"'"')\nconfig.setdefault('"'"'agents'"'"', {}).setdefault('"'"'defaults'"'"', {})['"'"'model'"'"'] = model\nconfig['"'"'models'"'"'] = {\n    '"'"'providers'"'"': {\n        '"'"'anthropic'"'"': {\n            '"'"'apiKey'"'"': apiKey,\n            '"'"'baseUrl'"'"': '"'"'https://api.anthropic.com'"'"',\n            '"'"'api'"'"': '"'"'anthropic-messages'"'"',\n            '"'"'models'"'"': [\n                {'"'"'id'"'"': '"'"'claude-sonnet-4-6'"'"', '"'"'name'"'"': '"'"'Claude Sonnet 4.6'"'"', '"'"'api'"'"': '"'"'anthropic-messages'"'"'},\n                {'"'"'id'"'"': '"'"'claude-opus-4-5'"'"', '"'"'name'"'"': '"'"'Claude Opus 4.5'"'"', '"'"'api'"'"': '"'"'anthropic-messages'"'"'},\n                {'"'"'id'"'"': '"'"'claude-sonnet-4-5'"'"', '"'"'name'"'"': '"'"'Claude Sonnet 4.5'"'"', '"'"'api'"'"': '"'"'anthropic-messages'"'"'}\n            ]\n        }\n    }\n}\nconfig.setdefault('"'"'gateway'"'"', {})['"'"'bind'"'"'] = '"'"'loopback'"'"'\nconfig['"'"'gateway'"'"']['"'"'port'"'"'] = 18789\ngw_password = os.environ.get('"'"'ELASTICCLAW_GATEWAY_PASSWORD'"'"', '"'"''"'"')\nif gw_password:\n    config['"'"'gateway'"'"']['"'"'auth'"'"'] = {'"'"'mode'"'"': '"'"'password'"'"', '"'"'password'"'"': gw_password}\nwith open(path, '"'"'w'"'"') as f:\n    json.dump(config, f, indent=2)\nprint('"'"'OpenClaw config patched'"'"')\n' | python3
+  %s
 fi
 
 # ── Start OpenClaw gateway ────────────────────────────────────────────────────
@@ -169,6 +309,7 @@ fi
 `,
 		p.DefaultModel, p.GatewayPassword, p.LLMKeyEnv, p.LinearEnv,
 		buildNixInstall(p.Nix),
+		p.ProviderConfig,
 		p.BridgeURL,
 		p.HubURL, p.ClawID, p.ClawToken, p.ClawName, p.GatewayPassword,
 		p.RelayEnv, p.DefaultModel, p.LLMKeyEnv,

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1994,6 +1994,7 @@ func (s *Server) bootstrapReplicated(clawID, clawName, vmID string, cfg types.Pr
 		LLMKeyEnv:       llmKeyEnv,
 		LinearEnv:       buildLinearEnv(linearToken),
 		RelayEnv:        relayEnv,
+		ProviderConfig:  buildOpenClawProviderConfig(s.hubCfg.LLMKeys, llmKeyName),
 	})
 	// Inject GitHub tools context into TOOLS.md if GitHub is configured
 	s.mu.RLock()

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1994,7 +1994,7 @@ func (s *Server) bootstrapReplicated(clawID, clawName, vmID string, cfg types.Pr
 		LLMKeyEnv:       llmKeyEnv,
 		LinearEnv:       buildLinearEnv(linearToken),
 		RelayEnv:        relayEnv,
-		ProviderConfig:  buildOpenClawProviderConfig(s.hubCfg.LLMKeys, llmKeyName),
+		ProviderConfig:  buildOpenClawProviderConfig(hubCfg.LLMKeys, llmKeyName),
 	})
 	// Inject GitHub tools context into TOOLS.md if GitHub is configured
 	s.mu.RLock()

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -1,6 +1,12 @@
 package types
 
-import "strings"
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
 
 // LLMKeyConfig represents a named LLM API key entry in hub.yaml.
 type LLMKeyConfig struct {
@@ -8,6 +14,43 @@ type LLMKeyConfig struct {
 	Provider string `yaml:"provider" json:"provider"` // e.g. "anthropic", "fireworks", "moonshot"
 	APIKey   string `yaml:"api_key"  json:"-"`        // the actual key (never exposed in API)
 	Default  bool   `yaml:"default"  json:"default"`  // use when no llm_key specified
+}
+
+// LLMKeysList is a custom YAML type that handles both the legacy flat-map format
+// and the current named-slice format for llm_keys in hub.yaml.
+type LLMKeysList []*LLMKeyConfig
+
+func (l *LLMKeysList) UnmarshalYAML(value *yaml.Node) error {
+	// Try new slice format first
+	var slice []*LLMKeyConfig
+	if err := value.Decode(&slice); err == nil {
+		*l = slice
+		return nil
+	}
+	// Fall back to old flat map format: {provider: apiKey}
+	var flat map[string]string
+	if err := value.Decode(&flat); err != nil {
+		return fmt.Errorf("llm_keys: expected list of {name,provider,api_key} or flat map {provider: key}: %w", err)
+	}
+	// Sort providers for deterministic ordering
+	providers := make([]string, 0, len(flat))
+	for p, k := range flat {
+		if k != "" {
+			providers = append(providers, p)
+		}
+	}
+	sort.Strings(providers)
+	result := make([]*LLMKeyConfig, len(providers))
+	for i, p := range providers {
+		result[i] = &LLMKeyConfig{
+			Name:     p,
+			Provider: p,
+			APIKey:   flat[p],
+			Default:  i == 0,
+		}
+	}
+	*l = result
+	return nil
 }
 
 // EnvVarName returns the environment variable name for this provider's API key.
@@ -140,7 +183,7 @@ type HubConfig struct {
 	DefaultModel string            `yaml:"default_model,omitempty"`
 	// LLMKeys is a list of named LLM API keys. One can be marked default:true.
 	// Legacy flat map {"anthropic": "sk-..."} is still accepted for backwards compat.
-	LLMKeys    []*LLMKeyConfig   `yaml:"-"` // populated by parseHubConfig in pkg/config
+	LLMKeys    LLMKeysList   `yaml:"llm_keys,omitempty"`
 	// Linear is a list of Linear workspace configs for injecting API tokens into claws.
 	Linear []*LinearConfig `yaml:"linear,omitempty"`
 


### PR DESCRIPTION
## Fixes two LLM key bugs

### Bug 1: SaveHubConfig not persisting llm_keys
`HubConfig.LLMKeys` is tagged `yaml:"-"` so `yaml.Marshal` silently dropped it. Added a `hubConfigForSave` wrapper struct that embeds `HubConfig` inline and adds `LLMKeys` with the correct yaml tag — keys now survive hub restarts.

### Bug 2: Bootstrap hardcodes anthropic provider config
Bootstrap script always wrote an anthropic-only `models.providers` block to the openclaw config regardless of what LLM keys were configured. Added `buildOpenClawProviderConfig()` that dynamically generates the correct provider entries (anthropic, fireworks, openai, groq, deepseek) using env vars for keys. Also dropped the hardcoded `--auth-choice anthropic-api-key` flags from the onboard call.