### PR TITLE
fix: use openclaw onboard --auth-choice for provider auth instead of json patch

### DIFF
--- a/pkg/hub/bootstrap.go
+++ b/pkg/hub/bootstrap.go
@@ -40,6 +40,24 @@ type BootstrapParams struct {
 	OnboardFlags   string // --auth-choice ... flags for openclaw onboard
 }
 
+// resolveActiveKey selects the active key by selected name, then default, then first.
+func resolveActiveKey(keys []*types.LLMKeyConfig, selectedKeyName string) *types.LLMKeyConfig {
+	for _, k := range keys {
+		if k.Name == selectedKeyName {
+			return k
+		}
+	}
+	for _, k := range keys {
+		if k.Default {
+			return k
+		}
+	}
+	if len(keys) > 0 {
+		return keys[0]
+	}
+	return nil
+}
+
 // buildOpenClawProviderConfig returns a python snippet that writes the correct
 // models.providers config to ~/.openclaw/openclaw.json based on configured LLM keys.
 // selectedKeyName is used to pick the active key (falls back to default, then first).
@@ -50,24 +68,7 @@ func buildOpenClawProviderConfig(keys []*types.LLMKeyConfig, selectedKeyName str
 	}
 
 	// Determine active key
-	var activeKey *types.LLMKeyConfig
-	for _, k := range keys {
-		if k.Name == selectedKeyName {
-			activeKey = k
-			break
-		}
-	}
-	if activeKey == nil {
-		for _, k := range keys {
-			if k.Default {
-				activeKey = k
-				break
-			}
-		}
-	}
-	if activeKey == nil {
-		activeKey = keys[0]
-	}
+	activeKey := resolveActiveKey(keys, selectedKeyName)
 	_ = activeKey // used implicitly via the provider list
 
 	// Build per-provider config entries.
@@ -322,24 +323,7 @@ fi
 // buildOnboardFlags returns the --auth-choice flags for openclaw onboard
 // based on the active LLM key (selected > default > first).
 func buildOnboardFlags(keys []*types.LLMKeyConfig, selectedKeyName string) string {
-	var active *types.LLMKeyConfig
-	for _, k := range keys {
-		if k.Name == selectedKeyName {
-			active = k
-			break
-		}
-	}
-	if active == nil {
-		for _, k := range keys {
-			if k.Default {
-				active = k
-				break
-			}
-		}
-	}
-	if active == nil && len(keys) > 0 {
-		active = keys[0]
-	}
+	active := resolveActiveKey(keys, selectedKeyName)
 	if active == nil {
 		return `--auth-choice anthropic-api-key --anthropic-api-key "${ANTHROPIC_API_KEY:-placeholder}"`
 	}

--- a/pkg/hub/bootstrap.go
+++ b/pkg/hub/bootstrap.go
@@ -104,34 +104,6 @@ func buildOpenClawProviderConfig(keys []*types.LLMKeyConfig, selectedKeyName str
                 {'id': 'accounts/fireworks/models/deepseek-v3',                'name': 'DeepSeek V3'}
             ]
         }`, envVar)
-		case "openai":
-			return fmt.Sprintf(`'openai': {
-            'apiKey': os.environ.get('%s', ''),
-            'baseUrl': 'https://api.openai.com/v1',
-            'api': 'openai-completions',
-            'models': [
-                {'id': 'gpt-4o',      'name': 'GPT-4o'},
-                {'id': 'gpt-4o-mini', 'name': 'GPT-4o Mini'}
-            ]
-        }`, envVar)
-		case "groq":
-			return fmt.Sprintf(`'groq': {
-            'apiKey': os.environ.get('%s', ''),
-            'baseUrl': 'https://api.groq.com/openai/v1',
-            'api': 'openai-completions',
-            'models': [
-                {'id': 'llama-3.3-70b-versatile', 'name': 'Llama 3.3 70B'}
-            ]
-        }`, envVar)
-		case "deepseek":
-			return fmt.Sprintf(`'deepseek': {
-            'apiKey': os.environ.get('%s', ''),
-            'baseUrl': 'https://api.deepseek.com/v1',
-            'api': 'openai-completions',
-            'models': [
-                {'id': 'deepseek-chat', 'name': 'DeepSeek Chat'}
-            ]
-        }`, envVar)
 		default:
 			return fmt.Sprintf(`'%s': {
             'apiKey': os.environ.get('%s', ''),
@@ -333,12 +305,6 @@ func buildOnboardFlags(keys []*types.LLMKeyConfig, selectedKeyName string) strin
 		return fmt.Sprintf(`--auth-choice anthropic-api-key --anthropic-api-key "${%s:-placeholder}"`, envVar)
 	case "fireworks":
 		return fmt.Sprintf(`--auth-choice fireworks-api-key --fireworks-api-key "${%s}"`, envVar)
-	case "openai":
-		return fmt.Sprintf(`--auth-choice openai-api-key --openai-api-key "${%s}"`, envVar)
-	case "groq":
-		return fmt.Sprintf(`--auth-choice groq-api-key --groq-api-key "${%s}"`, envVar)
-	case "deepseek":
-		return fmt.Sprintf(`--auth-choice deepseek-api-key --deepseek-api-key "${%s}"`, envVar)
 	default:
 		return `--auth-choice anthropic-api-key --anthropic-api-key "${ANTHROPIC_API_KEY:-placeholder}"`
 	}

--- a/pkg/hub/bootstrap.go
+++ b/pkg/hub/bootstrap.go
@@ -37,6 +37,7 @@ type BootstrapParams struct {
 	LinearEnv      string // pre-built export line
 	RelayEnv       string // pre-built export lines
 	ProviderConfig string // python snippet to configure models.providers
+	OnboardFlags   string // --auth-choice ... flags for openclaw onboard
 }
 
 // buildOpenClawProviderConfig returns a python snippet that writes the correct
@@ -221,7 +222,7 @@ if [ ! -f "$HOME/.openclaw/openclaw.json" ]; then
   openclaw onboard \
     --non-interactive --accept-risk \
     --gateway-bind loopback --gateway-port 18789 \
-    --skip-daemon 2>/dev/null || true
+    --skip-daemon %s 2>/dev/null || true
   %s
 fi
 
@@ -309,10 +310,52 @@ fi
 `,
 		p.DefaultModel, p.GatewayPassword, p.LLMKeyEnv, p.LinearEnv,
 		buildNixInstall(p.Nix),
+		p.OnboardFlags,
 		p.ProviderConfig,
 		p.BridgeURL,
 		p.HubURL, p.ClawID, p.ClawToken, p.ClawName, p.GatewayPassword,
 		p.RelayEnv, p.DefaultModel, p.LLMKeyEnv,
 		credHelper,
 	)
+}
+
+// buildOnboardFlags returns the --auth-choice flags for openclaw onboard
+// based on the active LLM key (selected > default > first).
+func buildOnboardFlags(keys []*types.LLMKeyConfig, selectedKeyName string) string {
+	var active *types.LLMKeyConfig
+	for _, k := range keys {
+		if k.Name == selectedKeyName {
+			active = k
+			break
+		}
+	}
+	if active == nil {
+		for _, k := range keys {
+			if k.Default {
+				active = k
+				break
+			}
+		}
+	}
+	if active == nil && len(keys) > 0 {
+		active = keys[0]
+	}
+	if active == nil {
+		return `--auth-choice anthropic-api-key --anthropic-api-key "${ANTHROPIC_API_KEY:-placeholder}"`
+	}
+	envVar := active.EnvVarName()
+	switch active.Provider {
+	case "anthropic":
+		return fmt.Sprintf(`--auth-choice anthropic-api-key --anthropic-api-key "${%s:-placeholder}"`, envVar)
+	case "fireworks":
+		return fmt.Sprintf(`--auth-choice fireworks-api-key --fireworks-api-key "${%s}"`, envVar)
+	case "openai":
+		return fmt.Sprintf(`--auth-choice openai-api-key --openai-api-key "${%s}"`, envVar)
+	case "groq":
+		return fmt.Sprintf(`--auth-choice groq-api-key --groq-api-key "${%s}"`, envVar)
+	case "deepseek":
+		return fmt.Sprintf(`--auth-choice deepseek-api-key --deepseek-api-key "${%s}"`, envVar)
+	default:
+		return `--auth-choice anthropic-api-key --anthropic-api-key "${ANTHROPIC_API_KEY:-placeholder}"`
+	}
 }

--- a/pkg/hub/bootstrap.go
+++ b/pkg/hub/bootstrap.go
@@ -104,6 +104,34 @@ func buildOpenClawProviderConfig(keys []*types.LLMKeyConfig, selectedKeyName str
                 {'id': 'accounts/fireworks/models/deepseek-v3',                'name': 'DeepSeek V3'}
             ]
         }`, envVar)
+		case "openai":
+			return fmt.Sprintf(`'openai': {
+            'apiKey': os.environ.get('%s', ''),
+            'baseUrl': 'https://api.openai.com/v1',
+            'api': 'openai-completions',
+            'models': [
+                {'id': 'gpt-4o',      'name': 'GPT-4o'},
+                {'id': 'gpt-4o-mini', 'name': 'GPT-4o Mini'}
+            ]
+        }`, envVar)
+		case "groq":
+			return fmt.Sprintf(`'groq': {
+            'apiKey': os.environ.get('%s', ''),
+            'baseUrl': 'https://api.groq.com/openai/v1',
+            'api': 'openai-completions',
+            'models': [
+                {'id': 'llama-3.3-70b-versatile', 'name': 'Llama 3.3 70B'}
+            ]
+        }`, envVar)
+		case "deepseek":
+			return fmt.Sprintf(`'deepseek': {
+            'apiKey': os.environ.get('%s', ''),
+            'baseUrl': 'https://api.deepseek.com/v1',
+            'api': 'openai-completions',
+            'models': [
+                {'id': 'deepseek-chat', 'name': 'DeepSeek Chat'}
+            ]
+        }`, envVar)
 		default:
 			return fmt.Sprintf(`'%s': {
             'apiKey': os.environ.get('%s', ''),
@@ -305,6 +333,12 @@ func buildOnboardFlags(keys []*types.LLMKeyConfig, selectedKeyName string) strin
 		return fmt.Sprintf(`--auth-choice anthropic-api-key --anthropic-api-key "${%s:-placeholder}"`, envVar)
 	case "fireworks":
 		return fmt.Sprintf(`--auth-choice fireworks-api-key --fireworks-api-key "${%s}"`, envVar)
+	case "openai":
+		return fmt.Sprintf(`--auth-choice openai-api-key --openai-api-key "${%s}"`, envVar)
+	case "groq":
+		return fmt.Sprintf(`--auth-choice groq-api-key --groq-api-key "${%s}"`, envVar)
+	case "deepseek":
+		return fmt.Sprintf(`--auth-choice deepseek-api-key --deepseek-api-key "${%s}"`, envVar)
 	default:
 		return `--auth-choice anthropic-api-key --anthropic-api-key "${ANTHROPIC_API_KEY:-placeholder}"`
 	}

--- a/pkg/hub/bootstrap_test.go
+++ b/pkg/hub/bootstrap_test.go
@@ -201,6 +201,72 @@ func TestBootstrapScript_ShebangPresent(t *testing.T) {
 	}
 }
 
+func TestBuildOnboardFlags_OpenAICompatibleProviders(t *testing.T) {
+	cases := []struct {
+		name       string
+		provider   string
+		envVar     string
+		authChoice string
+		flagName   string
+	}{
+		{
+			name:       "openai",
+			provider:   "openai",
+			envVar:     "OPENAI_API_KEY",
+			authChoice: "openai-api-key",
+			flagName:   "--openai-api-key",
+		},
+		{
+			name:       "groq",
+			provider:   "groq",
+			envVar:     "GROQ_API_KEY",
+			authChoice: "groq-api-key",
+			flagName:   "--groq-api-key",
+		},
+		{
+			name:       "deepseek",
+			provider:   "deepseek",
+			envVar:     "DEEPSEEK_API_KEY",
+			authChoice: "deepseek-api-key",
+			flagName:   "--deepseek-api-key",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			keys := []*types.LLMKeyConfig{
+				{Name: tc.name + "-key", Provider: tc.provider, Default: true},
+			}
+			flags := buildOnboardFlags(keys, "")
+			assertContains(t, flags, "--auth-choice "+tc.authChoice, "provider auth choice")
+			assertContains(t, flags, tc.flagName+` "${`+tc.envVar+`}"`, "provider api key flag")
+			assertNotContains(t, flags, "anthropic-api-key", "should not fallback to anthropic")
+		})
+	}
+}
+
+func TestBuildOpenClawProviderConfig_OpenAICompatibleProviders(t *testing.T) {
+	keys := []*types.LLMKeyConfig{
+		{Name: "openai-main", Provider: "openai", Default: true},
+		{Name: "groq-main", Provider: "groq"},
+		{Name: "deepseek-main", Provider: "deepseek"},
+	}
+
+	snippet := buildOpenClawProviderConfig(keys, "openai-main")
+
+	assertContains(t, snippet, `'openai': {`, "openai provider entry")
+	assertContains(t, snippet, "'baseUrl': 'https://api.openai.com/v1'", "openai baseUrl")
+	assertContains(t, snippet, "{'id': 'gpt-4o',      'name': 'GPT-4o'}", "openai models")
+
+	assertContains(t, snippet, `'groq': {`, "groq provider entry")
+	assertContains(t, snippet, "'baseUrl': 'https://api.groq.com/openai/v1'", "groq baseUrl")
+	assertContains(t, snippet, "{'id': 'llama-3.3-70b-versatile', 'name': 'Llama 3.3 70B'}", "groq models")
+
+	assertContains(t, snippet, `'deepseek': {`, "deepseek provider entry")
+	assertContains(t, snippet, "'baseUrl': 'https://api.deepseek.com/v1'", "deepseek baseUrl")
+	assertContains(t, snippet, "{'id': 'deepseek-chat', 'name': 'DeepSeek Chat'}", "deepseek models")
+}
+
 // ── Shellcheck test ───────────────────────────────────────────────────────────
 
 func TestBootstrapScript_Shellcheck(t *testing.T) {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1368,11 +1368,13 @@ echo $! > /tmp/openclaw-install.pid && echo 'install started'`); err != nil {
 	var llmKeyNameDaytona string
 	_ = s.db.QueryRow(`SELECT COALESCE(llm_key,'') FROM claws WHERE id=?`, clawID).Scan(&llmKeyNameDaytona)
 	s.mu.RLock()
+	llmKeyEnvDaytona := buildLLMKeyEnv(s.hubCfg.LLMKeys, llmKeyNameDaytona)
 	onboardFlags := buildOnboardFlags(s.hubCfg.LLMKeys, llmKeyNameDaytona)
 	providerConfigScript := buildOpenClawProviderConfig(s.hubCfg.LLMKeys, llmKeyNameDaytona)
 	s.mu.RUnlock()
 	onboardCmd := fmt.Sprintf(
-		"export NVM_DIR=/usr/local/share/nvm; export PATH=$NVM_DIR/current/bin:$PATH; openclaw onboard --non-interactive --accept-risk --skip-daemon %s 2>&1 || true",
+		"%sexport NVM_DIR=/usr/local/share/nvm; export PATH=$NVM_DIR/current/bin:$PATH; openclaw onboard --non-interactive --accept-risk --skip-daemon %s 2>&1 || true",
+		llmKeyEnvDaytona,
 		onboardFlags,
 	)
 	if err := exec("onboard openclaw", 2*time.Minute, onboardCmd); err != nil {
@@ -1381,7 +1383,7 @@ echo $! > /tmp/openclaw-install.pid && echo 'install started'`); err != nil {
 
 	// Step 2b: Patch OpenClaw config with dynamic provider model list
 	if providerConfigScript != "" {
-		configPatch := "export HOME=/home/daytona; " + providerConfigScript
+		configPatch := "export HOME=/home/daytona; " + llmKeyEnvDaytona + providerConfigScript
 		if err := exec("configure openclaw model", 30*time.Second, configPatch); err != nil {
 			log.Printf("[daytona] warning: failed to configure model: %v", err)
 		}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2249,16 +2249,8 @@ func resolveDefaultModelForKey(hubCfg *types.HubConfig, key *types.LLMKeyConfig)
 	switch key.Provider {
 	case "anthropic":
 		return "anthropic/claude-sonnet-4-6"
-	case "openai":
-		return "openai/gpt-4o"
 	case "fireworks":
 		return "fireworks/accounts/fireworks/models/llama-v3p3-70b-instruct"
-	case "groq":
-		return "groq/llama-3.3-70b-versatile"
-	case "deepseek":
-		return "deepseek/deepseek-chat"
-	case "moonshot":
-		return "moonshot/moonshot-v1-8k"
 	default:
 		// Fall back to hub default even if provider doesn't match
 		return hubCfg.DefaultModel

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -544,22 +544,31 @@ func (s *Server) handleCreateClaw(w http.ResponseWriter, r *http.Request, tenant
 	}
 	log.Printf("[create] claw %s: req.Nix=%v nixEnabled=%d", req.Name, req.Nix, nixEnabled)
 
-	// Resolve default model: explicit > llm_key lookup > hub default
+	// Resolve default model: explicit > llm_key lookup > default key > hub default
 	defaultModel := req.DefaultModel
-	if defaultModel == "" && req.LLMKey != "" {
+	if defaultModel == "" {
 		s.mu.RLock()
+		var activeKey *types.LLMKeyConfig
 		for _, k := range s.hubCfg.LLMKeys {
 			if k.Name == req.LLMKey {
-				// Use the key's provider to derive a model
-				defaultModel = resolveDefaultModelForKey(s.hubCfg, k)
+				activeKey = k
 				break
 			}
 		}
-		s.mu.RUnlock()
-	}
-	if defaultModel == "" {
-		s.mu.RLock()
-		defaultModel = s.hubCfg.DefaultModel
+		// If no explicit key selected, fall back to the default key
+		if activeKey == nil {
+			for _, k := range s.hubCfg.LLMKeys {
+				if k.Default {
+					activeKey = k
+					break
+				}
+			}
+		}
+		if activeKey != nil {
+			defaultModel = resolveDefaultModelForKey(s.hubCfg, activeKey)
+		} else {
+			defaultModel = s.hubCfg.DefaultModel
+		}
 		s.mu.RUnlock()
 	}
 	req.DefaultModel = defaultModel

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1364,67 +1364,33 @@ echo $! > /tmp/openclaw-install.pid && echo 'install started'`); err != nil {
 		return err
 	}
 
-	// Step 2: Onboard (configure OpenClaw)
-	if err := exec("onboard openclaw", 2*time.Minute,
-		"export NVM_DIR=/usr/local/share/nvm; export PATH=$NVM_DIR/current/bin:$PATH; openclaw onboard --non-interactive --accept-risk --skip-daemon 2>&1 || true"); err != nil {
+	// Step 2: Onboard (configure OpenClaw) with the correct auth provider
+	var llmKeyNameDaytona string
+	_ = s.db.QueryRow(`SELECT COALESCE(llm_key,'') FROM claws WHERE id=?`, clawID).Scan(&llmKeyNameDaytona)
+	s.mu.RLock()
+	onboardFlags := buildOnboardFlags(s.hubCfg.LLMKeys, llmKeyNameDaytona)
+	providerConfigScript := buildOpenClawProviderConfig(s.hubCfg.LLMKeys, llmKeyNameDaytona)
+	s.mu.RUnlock()
+	onboardCmd := fmt.Sprintf(
+		"export NVM_DIR=/usr/local/share/nvm; export PATH=$NVM_DIR/current/bin:$PATH; openclaw onboard --non-interactive --accept-risk --skip-daemon %s 2>&1 || true",
+		onboardFlags,
+	)
+	if err := exec("onboard openclaw", 2*time.Minute, onboardCmd); err != nil {
 		return err
 	}
 
-	// Step 2b: Patch OpenClaw config with model + LLM API keys
-	anthropicKey := env["ANTHROPIC_API_KEY"]
-	defaultModel := env["OPENCLAW_DEFAULT_MODEL"]
-	s.mu.RLock()
-	if defaultModel == "" {
-		defaultModel = s.hubCfg.DefaultModel
-	}
-	if defaultModel == "" {
-		defaultModel = "anthropic/claude-sonnet-4-6"
-	}
-	if anthropicKey == "" {
-		for _, k := range s.hubCfg.LLMKeys {
-			if k.Provider == "anthropic" && k.APIKey != "" {
-				anthropicKey = k.APIKey
-				break
-			}
-		}
-	}
-	s.mu.RUnlock()
-	if anthropicKey != "" {
-		configPatch := fmt.Sprintf(`
-export HOME=/home/daytona; python3 - <<'PYEOF'
-import json, os
-path = os.path.expanduser('~/.openclaw/openclaw.json')
-try:
-  with open(path) as f: cfg = json.load(f)
-except: cfg = {}
-cfg.setdefault('agents', {}).setdefault('defaults', {})['model'] = %q
-cfg['models'] = {
-  'providers': {
-    'anthropic': {
-      'apiKey': %q,
-      'baseUrl': 'https://api.anthropic.com',
-      'api': 'anthropic-messages',
-      'models': [
-        {'id': 'claude-sonnet-4-6', 'name': 'Claude Sonnet 4.6', 'api': 'anthropic-messages'},
-        {'id': 'claude-opus-4-5', 'name': 'Claude Opus 4.5', 'api': 'anthropic-messages'}
-      ]
-    }
-  }
-}
-cfg.setdefault('gateway', {})['bind'] = 'loopback'
-cfg['gateway']['port'] = 18789
-with open(path, 'w') as f: json.dump(cfg, f, indent=2)
-print('model config updated')
-PYEOF`, defaultModel, anthropicKey)
+	// Step 2b: Patch OpenClaw config with dynamic provider model list
+	if providerConfigScript != "" {
+		configPatch := "export HOME=/home/daytona; " + providerConfigScript
 		if err := exec("configure openclaw model", 30*time.Second, configPatch); err != nil {
 			log.Printf("[daytona] warning: failed to configure model: %v", err)
 		}
-		// Let openclaw self-heal any remaining config schema issues
-		_ = exec("openclaw doctor fix", 20*time.Second,
-			"export HOME=/home/daytona NVM_DIR=/usr/local/share/nvm; "+
-				"export PATH=$NVM_DIR/current/bin:$PATH; "+
-				"openclaw doctor --fix 2>&1 || true")
 	}
+	// Let openclaw self-heal any remaining config schema issues
+	_ = exec("openclaw doctor fix", 20*time.Second,
+		"export HOME=/home/daytona NVM_DIR=/usr/local/share/nvm; "+
+			"export PATH=$NVM_DIR/current/bin:$PATH; "+
+			"openclaw doctor --fix 2>&1 || true")
 
 	// Step 2c: Configure gateway bind/port and start it.
 	// Use token auth (what onboard sets up) — don't override auth mode.
@@ -1995,6 +1961,7 @@ func (s *Server) bootstrapReplicated(clawID, clawName, vmID string, cfg types.Pr
 		LinearEnv:       buildLinearEnv(linearToken),
 		RelayEnv:        relayEnv,
 		ProviderConfig:  buildOpenClawProviderConfig(hubCfg.LLMKeys, llmKeyName),
+		OnboardFlags:    buildOnboardFlags(hubCfg.LLMKeys, llmKeyName),
 	})
 	// Inject GitHub tools context into TOOLS.md if GitHub is configured
 	s.mu.RLock()

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -987,7 +987,9 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 							cc.gatewayReady = true
 							res, execErr := s.db.Exec(`UPDATE claws SET status='connected' WHERE id=? AND status='starting'`, clawID)
 							var rowsUpdated int64
-							if execErr == nil { rowsUpdated, _ = res.RowsAffected() }
+							if execErr == nil {
+								rowsUpdated, _ = res.RowsAffected()
+							}
 							if rowsUpdated > 0 {
 								s.broadcastToUsers(tenantID, types.WSMessage{
 									Type:    "claw_status",
@@ -1377,6 +1379,8 @@ echo $! > /tmp/openclaw-install.pid && echo 'install started'`); err != nil {
 	var llmKeyNameDaytona string
 	_ = s.db.QueryRow(`SELECT COALESCE(llm_key,'') FROM claws WHERE id=?`, clawID).Scan(&llmKeyNameDaytona)
 	s.mu.RLock()
+	activeKeyDaytona := resolveActiveKey(s.hubCfg.LLMKeys, llmKeyNameDaytona)
+	defaultModelDaytona := resolveDefaultModelForKey(s.hubCfg, activeKeyDaytona)
 	llmKeyEnvDaytona := buildLLMKeyEnv(s.hubCfg.LLMKeys, llmKeyNameDaytona)
 	onboardFlags := buildOnboardFlags(s.hubCfg.LLMKeys, llmKeyNameDaytona)
 	providerConfigScript := buildOpenClawProviderConfig(s.hubCfg.LLMKeys, llmKeyNameDaytona)
@@ -1392,7 +1396,7 @@ echo $! > /tmp/openclaw-install.pid && echo 'install started'`); err != nil {
 
 	// Step 2b: Patch OpenClaw config with dynamic provider model list
 	if providerConfigScript != "" {
-		configPatch := "export HOME=/home/daytona; " + llmKeyEnvDaytona + providerConfigScript
+		configPatch := fmt.Sprintf("export HOME=/home/daytona; export OPENCLAW_DEFAULT_MODEL=%q; ", defaultModelDaytona) + llmKeyEnvDaytona + providerConfigScript
 		if err := exec("configure openclaw model", 30*time.Second, configPatch); err != nil {
 			log.Printf("[daytona] warning: failed to configure model: %v", err)
 		}
@@ -2249,8 +2253,16 @@ func resolveDefaultModelForKey(hubCfg *types.HubConfig, key *types.LLMKeyConfig)
 	switch key.Provider {
 	case "anthropic":
 		return "anthropic/claude-sonnet-4-6"
+	case "openai":
+		return "openai/gpt-4o"
 	case "fireworks":
 		return "fireworks/accounts/fireworks/models/llama-v3p3-70b-instruct"
+	case "groq":
+		return "groq/llama-3.3-70b-versatile"
+	case "deepseek":
+		return "deepseek/deepseek-chat"
+	case "moonshot":
+		return "moonshot/moonshot-v1-8k"
 	default:
 		// Fall back to hub default even if provider doesn't match
 		return hubCfg.DefaultModel

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2231,8 +2231,12 @@ func resolveDefaultModelForKey(hubCfg *types.HubConfig, key *types.LLMKeyConfig)
 		return hubCfg.DefaultModel
 	}
 
-	// Use per-key default model if set
+	// Use per-key default model if set; normalize to include provider prefix
 	if key.DefaultModel != "" {
+		prefix := key.Provider + "/"
+		if !strings.HasPrefix(key.DefaultModel, prefix) {
+			return prefix + key.DefaultModel
+		}
 		return key.DefaultModel
 	}
 
@@ -2248,7 +2252,7 @@ func resolveDefaultModelForKey(hubCfg *types.HubConfig, key *types.LLMKeyConfig)
 	case "openai":
 		return "openai/gpt-4o"
 	case "fireworks":
-		return "fireworks/llama-v3p3-70b-instruct"
+		return "fireworks/accounts/fireworks/models/llama-v3p3-70b-instruct"
 	case "groq":
 		return "groq/llama-3.3-70b-versatile"
 	case "deepseek":

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -41,7 +41,7 @@ func TestResolveDefaultModelForKey(t *testing.T) {
 			key: &types.LLMKeyConfig{
 				Provider: "fireworks",
 			},
-			expectedModel: "fireworks/llama-v3p3-70b-instruct",
+			expectedModel: "fireworks/accounts/fireworks/models/llama-v3p3-70b-instruct",
 		},
 		{
 			name: "unknown provider - fall back to hub default",

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -61,14 +61,6 @@ func (k *LLMKeyConfig) EnvVarName() string {
 		return "ANTHROPIC_API_KEY"
 	case "fireworks":
 		return "FIREWORKS_API_KEY"
-	case "moonshot":
-		return "MOONSHOT_API_KEY"
-	case "openai":
-		return "OPENAI_API_KEY"
-	case "groq":
-		return "GROQ_API_KEY"
-	case "deepseek":
-		return "DEEPSEEK_API_KEY"
 	default:
 		// Generic: PROVIDER_API_KEY uppercased
 		return strings.ToUpper(k.Provider) + "_API_KEY"

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -333,13 +333,22 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
 
 const PROVIDER_OPTIONS = [
   { value: "anthropic",  label: "Anthropic",  placeholder: "sk-ant-..." },
-  { value: "fireworks",  label: "Fireworks",   placeholder: "fw-..." },
-  { value: "moonshot",   label: "Moonshot (Kimi)", placeholder: "sk-..." },
-  { value: "openai",     label: "OpenAI",      placeholder: "sk-..." },
-  { value: "groq",       label: "Groq",        placeholder: "gsk_..." },
-  { value: "deepseek",   label: "DeepSeek",    placeholder: "sk-..." },
-  { value: "other",      label: "Other",       placeholder: "" },
+  { value: "fireworks",  label: "Fireworks",  placeholder: "fw_..." },
+  { value: "other",      label: "Other",      placeholder: "" },
 ]
+
+const PROVIDER_MODELS: Record<string, { id: string; name: string }[]> = {
+  anthropic: [
+    { id: "anthropic/claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
+    { id: "anthropic/claude-opus-4-5",   name: "Claude Opus 4.5" },
+    { id: "anthropic/claude-sonnet-4-5", name: "Claude Sonnet 4.5" },
+  ],
+  fireworks: [
+    { id: "fireworks/accounts/fireworks/models/kimi-k2p6",                  name: "Kimi K2" },
+    { id: "fireworks/accounts/fireworks/models/llama-v3p3-70b-instruct",    name: "Llama 3.3 70B" },
+    { id: "fireworks/accounts/fireworks/models/deepseek-v3",                name: "DeepSeek V3" },
+  ],
+}
 
 function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSave: (p: object) => void; saving: boolean }) {
   const llmKeys = settings.llmKeys || []
@@ -405,7 +414,7 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
           </div>
           <div>
             <label className="text-xs text-muted-foreground mb-1 block">Provider</label>
-            <select value={newProvider} onChange={e => setNewProvider(e.target.value)}
+            <select value={newProvider} onChange={e => { setNewProvider(e.target.value); setNewDefaultModel("") }}
               className="w-full h-8 rounded-md border border-border bg-background px-2 text-sm">
               {PROVIDER_OPTIONS.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
             </select>
@@ -425,8 +434,21 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
         </div>
         <div>
           <label className="text-xs text-muted-foreground mb-1 block">Default model <span className="text-muted-foreground/60">(optional)</span></label>
-          <Input value={newDefaultModel} onChange={e => setNewDefaultModel(e.target.value)}
-            className="h-8 text-sm" placeholder="e.g. fireworks/accounts/fireworks/models/kimi-k2p6" />
+          {PROVIDER_MODELS[newProvider] ? (
+            <select
+              value={newDefaultModel}
+              onChange={e => setNewDefaultModel(e.target.value)}
+              className="h-8 text-sm w-full rounded-md border border-input bg-background px-2 py-1"
+            >
+              <option value="">— use provider default —</option>
+              {PROVIDER_MODELS[newProvider].map(m => (
+                <option key={m.id} value={m.id}>{m.name}</option>
+              ))}
+            </select>
+          ) : (
+            <Input value={newDefaultModel} onChange={e => setNewDefaultModel(e.target.value)}
+              className="h-8 text-sm" placeholder="e.g. myprovider/model-name" />
+          )}
         </div>
         <label className="flex items-center gap-2 text-sm cursor-pointer">
           <input type="checkbox" checked={newDefault} onChange={e => setNewDefault(e.target.checked)} />


### PR DESCRIPTION
## Problem

Bootstrap was calling `openclaw onboard` without `--auth-choice`, then manually patching `openclaw.json` via python. But openclaw also stores auth in `auth-profiles.json`, which the python patch never touched. Result: fireworks (or any non-anthropic provider) would fail at runtime with "No API key found for provider anthropic".

## Fix

Added `buildOnboardFlags()` that generates the correct `--auth-choice <provider>-api-key --<provider>-api-key "$KEY"` flags based on the active LLM key. Both the Replicated and Daytona bootstrap paths now use it.

Supported: `anthropic`, `fireworks`, `openai`, `groq`, `deepseek`. Unknown providers fall back to anthropic placeholder.