### PR TITLE
feat: factory claw UX improvements — intro, progress narration, no delete on PR close

### DIFF
--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -552,8 +552,9 @@ func (s *Server) handleClawDoneSignal(clawID, rawMessage string) {
 	}
 
 	// Keep the claw running — it stays connected to watch for CI failures,
-	// bugbot comments, and PR events. The claw will be terminated when the
-	// PR is merged or closed (polled by checkPRMerged).
+	// bugbot comments, and PR events. The claw is terminated when the PR is
+	// merged; if it is closed without merge, the claw is notified and decides
+	// what to do (polled by checkPRMerged).
 	// Just mark it as 'watching' so the UI shows it differently.
 	res, err := s.db.Exec(`UPDATE claws SET status='idle' WHERE id=? AND status NOT IN ('deleted','error')`, clawID)
 	if err != nil {
@@ -568,7 +569,7 @@ func (s *Server) handleClawDoneSignal(clawID, rawMessage string) {
 		Payload: map[string]string{"claw_id": clawID, "status": "idle"},
 	})
 	// Notify the claw it's in watch mode
-	s.injectUserMessage(clawID, "PR created and Linear issue updated. Staying connected to watch for CI failures and review comments. Will terminate when PR is merged or closed.")
+	s.injectUserMessage(clawID, "PR created and Linear issue updated. Staying connected to watch for CI failures and review comments. Will terminate when PR is merged; if it is closed without merge, I'll notify you and decide next steps.")
 }
 
 // extractDonePRURLs parses PR URLs from a [DONE] message.

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -165,6 +165,13 @@ func (s *Server) pollAllPRs() {
 			terminatedClaws[r.pr.clawID] = true
 			continue // claw is being terminated, skip other checks
 		}
+		if r.clawStatus == "idle" {
+			var prCount int
+			if err := s.db.QueryRow(`SELECT COUNT(1) FROM claw_prs WHERE id=?`, r.pr.id).Scan(&prCount); err == nil && prCount == 0 {
+				// PR was removed while handling close/merge state, so skip follow-up checks.
+				continue
+			}
+		}
 		if r.autoFixCI {
 			s.checkCIFailures(r.pr, token)
 		}

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -542,7 +542,7 @@ func (s *Server) handleClawSettings(w http.ResponseWriter, r *http.Request, claw
 }
 
 // checkPRMerged checks if a tracked PR is merged or closed.
-// If so, terminates the claw and returns true.
+// It terminates the claw only when merged, and returns true only in that case.
 func (s *Server) checkPRMerged(pr clawPR, token string) bool {
 	tokenForPR := s.resolveGitHubTokenForRepo(pr.repo)
 	if tokenForPR == "" {

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -561,6 +561,8 @@ func (s *Server) checkPRMerged(pr clawPR, token string) bool {
 	// If the PR was closed without merging, notify the claw and let it decide — don't terminate.
 	if state == "closed" && !merged {
 		log.Printf("[pr-watcher] PR %s#%d closed without merge — notifying claw %s", pr.repo, pr.prNumber, clawID[:8])
+		// Stop polling this closed PR so we only notify once.
+		_, _ = s.db.Exec(`DELETE FROM claw_prs WHERE id=?`, pr.id)
 		s.injectUserMessage(clawID, fmt.Sprintf("PR %s was closed without being merged. Decide what to do: reopen it, open a new PR, or let the user know.", pr.prURL))
 		return false
 	}

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -552,18 +552,21 @@ func (s *Server) checkPRMerged(pr clawPR, token string) bool {
 		return false // still open
 	}
 
-	// PR is merged or closed — terminate the claw
 	clawID := pr.clawID
 	var tenantID string
 	if err := s.db.QueryRow(`SELECT tenant_id FROM claws WHERE id=?`, clawID).Scan(&tenantID); err != nil {
 		return false
 	}
 
-	action := "merged"
-	if !merged {
-		action = "closed"
+	// If the PR was closed without merging, notify the claw and let it decide — don't terminate.
+	if state == "closed" && !merged {
+		log.Printf("[pr-watcher] PR %s#%d closed without merge — notifying claw %s", pr.repo, pr.prNumber, clawID[:8])
+		s.injectUserMessage(clawID, fmt.Sprintf("PR %s was closed without being merged. Decide what to do: reopen it, open a new PR, or let the user know.", pr.prURL))
+		return false
 	}
-	log.Printf("[pr-watcher] PR %s#%d %s — terminating claw %s", pr.repo, pr.prNumber, action, clawID[:8])
+
+	// PR was merged — terminate the claw.
+	log.Printf("[pr-watcher] PR %s#%d merged — terminating claw %s", pr.repo, pr.prNumber, clawID[:8])
 
 	var providerID, provider string
 	_ = s.db.QueryRow(`SELECT COALESCE(provider_id,''), COALESCE(provider,'') FROM claws WHERE id=?`, clawID).Scan(&providerID, &provider)
@@ -573,7 +576,7 @@ func (s *Server) checkPRMerged(pr clawPR, token string) bool {
 
 	s.mu.Lock()
 	if cc, ok := s.claws[clawID]; ok {
-		cc.conn.Close(1000, fmt.Sprintf("factory: PR %s", action))
+		cc.conn.Close(1000, "factory: PR merged")
 		delete(s.claws, clawID)
 	}
 	s.mu.Unlock()

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1865,7 +1865,12 @@ func (s *Server) sendWakeMessage(cc *clawConn, clawID string) {
 	var issueID string
 	_ = s.db.QueryRow(`SELECT COALESCE(linear_issue_id,'') FROM claws WHERE id=?`, clawID).Scan(&issueID)
 	if issueID != "" {
-		wakeContent = "Read your BOOTSTRAP.md now. Then immediately start working on the task — do not ask for permission or confirmation. Explore the codebase, implement the change, and report back with what you did."
+		wakeContent = `Read your BOOTSTRAP.md now. Then:
+1. Send a short intro message to the user: your name, the issue you're working on, and your plan.
+2. Start working. As you go, narrate your progress — what you're exploring, what you're trying, why.
+3. If you hit something interesting or unexpected, say so.
+4. When you open a PR, summarize what you did and what the PR contains.
+5. Do NOT ask for permission at any point. Just work and keep the user informed.`
 	}
 	wakeMsg := types.HubMessage{
 		ID:      uuid.New().String(),


### PR DESCRIPTION
Three UX fixes for factory claws:

**1. Introduction + progress narration**
Wake message now instructs the claw to:
- Introduce itself (name, issue, plan) before starting
- Narrate progress as it works — what it's exploring, trying, why
- Summarize what it did when opening a PR
- Never ask for permission

**2. No termination when PR is closed without merge**
Previously `checkPRMerged` terminated the claw on any `state=closed`, including PRs closed without merging. Now:
- PR merged → claw terminates (as before)
- PR closed without merge → claw is notified and stays alive to decide what to do

**3. Tests pass**