### PR TITLE
feat: factory integration test harness

### DIFF
--- a/.depot/workflows/test.yaml
+++ b/.depot/workflows/test.yaml
@@ -25,6 +25,9 @@ jobs:
       - name: Bootstrap script tests (with shellcheck)
         run: go test -v ./pkg/hub/ -run TestBootstrap
 
+      - name: Factory integration tests
+        run: make test-factory
+
       - name: Install script tests (with shellcheck)
         run: go test -v ./pkg/install/ -run Test
 

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,9 @@ install:
 test:
 	go test -v ./...
 
+test-factory: ## Run factory integration tests
+	go test -v -tags integration -timeout 60s ./pkg/hub/... -run TestFactory
+
 # Run only bootstrap unit tests (fast, no infra needed)
 test-bootstrap:
 	go test -v ./pkg/hub/ -run TestBootstrap

--- a/pkg/hub/factory_integration_test.go
+++ b/pkg/hub/factory_integration_test.go
@@ -50,8 +50,11 @@ func TestFactoryFlow_HappyPath(t *testing.T) {
 	payload := buildLinearWebhookPayload(issueID, "Backlog", "In Progress")
 	resp, err := http.Post(ts.URL()+"/api/integrations/linear/webhook", "application/json",
 		strings.NewReader(string(payload)))
-	if err != nil || resp.StatusCode != 200 {
-		t.Fatalf("webhook post failed: err=%v status=%d", err, resp.StatusCode)
+	if err != nil {
+		t.Fatalf("webhook post failed: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("webhook post failed: status=%d", resp.StatusCode)
 	}
 
 	// Wait for claw to be created

--- a/pkg/hub/factory_integration_test.go
+++ b/pkg/hub/factory_integration_test.go
@@ -31,7 +31,9 @@ func buildLinearWebhookPayload(issueID, prevStatus, newStatus string) []byte {
 			},
 		},
 		"updatedFrom": map[string]interface{}{
-			"stateId": prevStatus,
+			"state": map[string]interface{}{
+				"name": prevStatus,
+			},
 		},
 	}
 	b, _ := json.Marshal(payload)

--- a/pkg/hub/factory_integration_test.go
+++ b/pkg/hub/factory_integration_test.go
@@ -1,0 +1,162 @@
+//go:build integration
+
+package hub_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/hub/factorytest"
+)
+
+func buildLinearWebhookPayload(issueID, prevStatus, newStatus string) []byte {
+	payload := map[string]interface{}{
+		"type":   "Issue",
+		"action": "update",
+		"data": map[string]interface{}{
+			"id":          "issue-uuid-123",
+			"identifier":  issueID,
+			"title":       "Add hello world to README",
+			"description": "Add a Hello World section to README.md",
+			"url":         "https://linear.app/test/issue/" + issueID,
+			"team": map[string]interface{}{
+				"key":  "ELA",
+				"name": "Engineering",
+			},
+			"state": map[string]interface{}{
+				"name": newStatus,
+			},
+		},
+		"updatedFrom": map[string]interface{}{
+			"stateId": prevStatus,
+		},
+	}
+	b, _ := json.Marshal(payload)
+	return b
+}
+
+func TestFactoryFlow_HappyPath(t *testing.T) {
+	ts := factorytest.NewTestServer(t)
+
+	issueID := "ELA-123"
+	ts.GitHub.SetPR("testorg", "testrepo", 1, factorytest.PRState{State: "open", Merged: false})
+
+	// Fire Linear webhook
+	payload := buildLinearWebhookPayload(issueID, "Backlog", "In Progress")
+	resp, err := http.Post(ts.URL()+"/api/integrations/linear/webhook", "application/json",
+		strings.NewReader(string(payload)))
+	if err != nil || resp.StatusCode != 200 {
+		t.Fatalf("webhook post failed: err=%v status=%d", err, resp.StatusCode)
+	}
+
+	// Wait for claw to be created
+	clawID := ts.WaitForClawWithIssue(t, issueID, 5*time.Second)
+
+	// Connect fake bridge
+	bridge := factorytest.ConnectFakeBridge(t, ts.URL(), clawID, issueID, ts.ClawToken())
+
+	// Wait for wake message (BOOTSTRAP is in the wake message content for factory claws)
+	bridge.WaitForMessage(t, "BOOTSTRAP", 5*time.Second)
+
+	// Fake agent does work
+	bridge.SendMessage("Reading the issue context...")
+	bridge.SendMessage("Found README.md, adding Hello World section...")
+
+	// Send [DONE] with a PR URL
+	bridge.SendDone("https://github.com/testorg/testrepo/pull/1")
+
+	// Wait for claw to go idle (no github token configured so done is accepted immediately)
+	ts.WaitForClawStatus(t, clawID, "idle", 5*time.Second)
+
+	// Simulate PR merge
+	ts.GitHub.SetPR("testorg", "testrepo", 1, factorytest.PRState{State: "closed", Merged: true})
+	ts.Server.PollPRsForTest()
+
+	// Wait for claw to be deleted — but since no GH token, pollAllPRs returns early.
+	// Just verify idle status persists.
+	time.Sleep(200 * time.Millisecond)
+	var status string
+	ts.DB.QueryRow(`SELECT status FROM claws WHERE id=?`, clawID).Scan(&status)
+	if status != "idle" && status != "deleted" {
+		t.Fatalf("expected claw to be idle or deleted after [DONE], got: %s", status)
+	}
+}
+
+func TestFactoryFlow_WebhookCreatesClawInDB(t *testing.T) {
+	ts := factorytest.NewTestServer(t)
+
+	issueID := "ELA-999"
+
+	payload := buildLinearWebhookPayload(issueID, "Backlog", "In Progress")
+	resp, err := http.Post(ts.URL()+"/api/integrations/linear/webhook", "application/json",
+		strings.NewReader(string(payload)))
+	if err != nil {
+		t.Fatalf("webhook post failed: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("webhook returned status %d", resp.StatusCode)
+	}
+
+	clawID := ts.WaitForClawWithIssue(t, issueID, 5*time.Second)
+	if clawID == "" {
+		t.Fatal("expected a claw to be created")
+	}
+
+	// Verify it's in a recognizable status
+	var dbStatus string
+	ts.DB.QueryRow(`SELECT status FROM claws WHERE id=?`, clawID).Scan(&dbStatus)
+	validStatuses := map[string]bool{
+		"provisioning": true,
+		"starting":     true,
+		"connected":    true,
+	}
+	if !validStatuses[dbStatus] {
+		t.Fatalf("unexpected claw status: %s", dbStatus)
+	}
+}
+
+func TestFactoryFlow_FakeBridgeConnect(t *testing.T) {
+	ts := factorytest.NewTestServer(t)
+
+	issueID := "ELA-777"
+	payload := buildLinearWebhookPayload(issueID, "Backlog", "In Progress")
+	http.Post(ts.URL()+"/api/integrations/linear/webhook", "application/json",
+		strings.NewReader(string(payload)))
+
+	clawID := ts.WaitForClawWithIssue(t, issueID, 5*time.Second)
+
+	bridge := factorytest.ConnectFakeBridge(t, ts.URL(), clawID, issueID, ts.ClawToken())
+
+	// Bridge should be able to send messages
+	bridge.SendMessage("Hello from fake bridge")
+
+	// Small sleep to let message be processed
+	time.Sleep(100 * time.Millisecond)
+
+	// Bridge connected successfully — test passes if we get here without panicking
+	_ = bridge
+}
+
+func TestFactoryFlow_DoneSignalSetsIdle(t *testing.T) {
+	ts := factorytest.NewTestServer(t)
+
+	issueID := "ELA-555"
+	payload := buildLinearWebhookPayload(issueID, "Backlog", "In Progress")
+	http.Post(ts.URL()+"/api/integrations/linear/webhook", "application/json",
+		strings.NewReader(string(payload)))
+
+	clawID := ts.WaitForClawWithIssue(t, issueID, 5*time.Second)
+	bridge := factorytest.ConnectFakeBridge(t, ts.URL(), clawID, issueID, ts.ClawToken())
+
+	// Wait for wake message
+	bridge.WaitForMessage(t, "BOOTSTRAP", 5*time.Second)
+
+	// Send [DONE] — no GH App configured so no PR validation, accepted immediately
+	bridge.SendDone("https://github.com/testorg/testrepo/pull/42")
+
+	// Should transition to idle
+	ts.WaitForClawStatus(t, clawID, "idle", 5*time.Second)
+}

--- a/pkg/hub/factorytest/fake_bridge.go
+++ b/pkg/hub/factorytest/fake_bridge.go
@@ -1,0 +1,121 @@
+package factorytest
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+	"github.com/google/uuid"
+	"nhooyr.io/websocket"
+	"nhooyr.io/websocket/wsjson"
+)
+
+type ReceivedMessage struct {
+	Type    string
+	Content string
+	Role    string
+}
+
+type FakeBridge struct {
+	ClawID   string
+	mu       sync.Mutex
+	Messages []ReceivedMessage
+	conn     *websocket.Conn
+	ctx      context.Context
+	cancel   context.CancelFunc
+}
+
+func ConnectFakeBridge(t *testing.T, hubURL, clawID, clawName, clawToken string) *FakeBridge {
+	t.Helper()
+	wsURL := strings.Replace(hubURL, "http://", "ws://", 1) + "/claw/ws"
+	ctx, cancel := context.WithCancel(context.Background())
+	conn, _, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{
+		HTTPHeader: http.Header{"X-Claw-Token": []string{clawToken}},
+	})
+	if err != nil {
+		cancel()
+		t.Fatalf("FakeBridge dial: %v", err)
+	}
+	gatewayReady := true
+	reg := map[string]interface{}{
+		"type": "register",
+		"payload": map[string]interface{}{
+			"claw_id":       clawID,
+			"name":          clawName,
+			"template":      "test",
+			"token":         clawToken,
+			"gateway_ready": &gatewayReady,
+		},
+	}
+	if err := wsjson.Write(ctx, conn, reg); err != nil {
+		cancel()
+		t.Fatalf("FakeBridge register: %v", err)
+	}
+	fb := &FakeBridge{ClawID: clawID, conn: conn, ctx: ctx, cancel: cancel}
+	go fb.readLoop()
+	t.Cleanup(fb.Disconnect)
+	return fb
+}
+
+func (fb *FakeBridge) readLoop() {
+	for {
+		var msg map[string]interface{}
+		if err := wsjson.Read(fb.ctx, fb.conn, &msg); err != nil {
+			return
+		}
+		msgType, _ := msg["type"].(string)
+		rm := ReceivedMessage{Type: msgType}
+		if payload, ok := msg["payload"].(map[string]interface{}); ok {
+			rm.Content, _ = payload["content"].(string)
+			rm.Role, _ = payload["role"].(string)
+		}
+		fb.mu.Lock()
+		fb.Messages = append(fb.Messages, rm)
+		fb.mu.Unlock()
+	}
+}
+
+func (fb *FakeBridge) SendMessage(content string) {
+	msg := types.HubMessage{
+		ID:      uuid.New().String(),
+		ClawID:  fb.ClawID,
+		Role:    "claw",
+		Content: content,
+	}
+	_ = wsjson.Write(fb.ctx, fb.conn, map[string]interface{}{
+		"type":    "message",
+		"payload": msg,
+	})
+}
+
+func (fb *FakeBridge) SendDone(prURL string) {
+	fb.SendMessage(fmt.Sprintf("[DONE] %s", prURL))
+}
+
+func (fb *FakeBridge) WaitForMessage(t *testing.T, contains string, timeout time.Duration) string {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		fb.mu.Lock()
+		for _, m := range fb.Messages {
+			if strings.Contains(m.Content, contains) {
+				fb.mu.Unlock()
+				return m.Content
+			}
+		}
+		fb.mu.Unlock()
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("FakeBridge: timed out waiting for message containing %q", contains)
+	return ""
+}
+
+func (fb *FakeBridge) Disconnect() {
+	fb.cancel()
+	fb.conn.Close(websocket.StatusNormalClosure, "test done")
+}

--- a/pkg/hub/factorytest/mock_github.go
+++ b/pkg/hub/factorytest/mock_github.go
@@ -51,7 +51,7 @@ func NewMockGitHub(t *testing.T) *MockGitHub {
 			return
 		}
 		// GET /repos/:owner/:repo/issues/:number/comments
-		if len(parts) == 4 && parts[2] == "issues" && r.Method == http.MethodGet {
+		if len(parts) == 5 && parts[2] == "issues" && parts[4] == "comments" && r.Method == http.MethodGet {
 			w.Header().Set("Content-Type", "application/json")
 			w.Write([]byte("[]"))
 			return

--- a/pkg/hub/factorytest/mock_github.go
+++ b/pkg/hub/factorytest/mock_github.go
@@ -1,0 +1,75 @@
+package factorytest
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+type PRState struct {
+	State  string
+	Merged bool
+}
+
+type MockGitHub struct {
+	*httptest.Server
+	mu    sync.Mutex
+	PRs   map[string]PRState // key: "owner/repo#number"
+	Calls []string
+}
+
+func NewMockGitHub(t *testing.T) *MockGitHub {
+	t.Helper()
+	m := &MockGitHub{PRs: make(map[string]PRState)}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/", func(w http.ResponseWriter, r *http.Request) {
+		m.mu.Lock()
+		m.Calls = append(m.Calls, r.Method+" "+r.URL.Path)
+		m.mu.Unlock()
+		// GET /repos/:owner/:repo/pulls/:number
+		parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/repos/"), "/")
+		if len(parts) == 4 && parts[2] == "pulls" && r.Method == http.MethodGet {
+			key := fmt.Sprintf("%s/%s#%s", parts[0], parts[1], parts[3])
+			m.mu.Lock()
+			state, ok := m.PRs[key]
+			m.mu.Unlock()
+			if !ok {
+				http.NotFound(w, r)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"state":    state.State,
+				"merged":   state.Merged,
+				"number":   parts[3],
+				"html_url": fmt.Sprintf("https://github.com/%s/%s/pull/%s", parts[0], parts[1], parts[3]),
+			})
+			return
+		}
+		// GET /repos/:owner/:repo/issues/:number/comments
+		if len(parts) == 4 && parts[2] == "issues" && r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte("[]"))
+			return
+		}
+		// POST /repos/:owner/:repo/statuses/:sha
+		if len(parts) == 4 && parts[2] == "statuses" {
+			w.WriteHeader(http.StatusCreated)
+			return
+		}
+		http.NotFound(w, r)
+	})
+	m.Server = httptest.NewServer(mux)
+	t.Cleanup(m.Server.Close)
+	return m
+}
+
+func (m *MockGitHub) SetPR(owner, repo string, number int, state PRState) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.PRs[fmt.Sprintf("%s/%s#%d", owner, repo, number)] = state
+}

--- a/pkg/hub/factorytest/mock_linear.go
+++ b/pkg/hub/factorytest/mock_linear.go
@@ -1,0 +1,90 @@
+package factorytest
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+type MockLinear struct {
+	*httptest.Server
+	mu           sync.Mutex
+	IssueStates  map[string]string // issueID → state name
+	GraphQLCalls []string
+}
+
+func NewMockLinear(t *testing.T) *MockLinear {
+	t.Helper()
+	m := &MockLinear{IssueStates: make(map[string]string)}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/graphql", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		bodyStr := string(body)
+		m.mu.Lock()
+		m.GraphQLCalls = append(m.GraphQLCalls, bodyStr)
+		m.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		// issueUpdate mutation (moveIssue)
+		if strings.Contains(bodyStr, "issueUpdate") {
+			// Extract issueId and stateId from variables - best effort
+			var req struct {
+				Variables map[string]interface{} `json:"variables"`
+			}
+			json.Unmarshal(body, &req)
+			if id, ok := req.Variables["id"].(string); ok {
+				if input, ok := req.Variables["input"].(map[string]interface{}); ok {
+					if stateID, ok := input["stateId"].(string); ok {
+						m.mu.Lock()
+						m.IssueStates[id] = stateID
+						m.mu.Unlock()
+					}
+				}
+			}
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": map[string]interface{}{
+					"issueUpdate": map[string]interface{}{"success": true},
+				},
+			})
+			return
+		}
+		// workflowStates query
+		if strings.Contains(bodyStr, "workflowStates") {
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": map[string]interface{}{
+					"workflowStates": map[string]interface{}{
+						"nodes": []map[string]interface{}{
+							{"id": "done-state-id", "name": "Done", "type": "completed"},
+							{"id": "in-progress-id", "name": "In Progress", "type": "started"},
+						},
+					},
+				},
+			})
+			return
+		}
+		// issue query
+		if strings.Contains(bodyStr, "issue(") || strings.Contains(bodyStr, `"issue"`) {
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": map[string]interface{}{
+					"issue": map[string]interface{}{
+						"id":          "issue-uuid-123",
+						"identifier":  "ELA-123",
+						"title":       "Add hello world to README",
+						"description": "Please add a 'Hello World' section to the README.md file.",
+						"url":         "https://linear.app/test/issue/ELA-123",
+						"state":       map[string]interface{}{"name": "In Progress", "id": "in-progress-id"},
+						"team":        map[string]interface{}{"name": "Engineering", "key": "ELA"},
+					},
+				},
+			})
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]interface{}{"data": map[string]interface{}{}})
+	})
+	m.Server = httptest.NewServer(mux)
+	t.Cleanup(m.Server.Close)
+	return m
+}

--- a/pkg/hub/factorytest/server.go
+++ b/pkg/hub/factorytest/server.go
@@ -2,9 +2,7 @@ package factorytest
 
 import (
 	"database/sql"
-	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 	"time"
 
@@ -23,14 +21,6 @@ type TestServer struct {
 func (ts *TestServer) URL() string { return ts.HTTPSrv.URL }
 
 func (ts *TestServer) ClawToken() string { return "test-claw-token" }
-
-func (ts *TestServer) PostWebhook(path string, body []byte) *http.Response {
-	resp, err := http.Post(ts.HTTPSrv.URL+path, "application/json", strings.NewReader(string(body)))
-	if err != nil {
-		panic(err)
-	}
-	return resp
-}
 
 func (ts *TestServer) WaitForClawWithIssue(t *testing.T, issueID string, timeout time.Duration) string {
 	t.Helper()

--- a/pkg/hub/factorytest/server.go
+++ b/pkg/hub/factorytest/server.go
@@ -1,0 +1,110 @@
+package factorytest
+
+import (
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/hub"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+type TestServer struct {
+	Server  *hub.Server
+	HTTPSrv *httptest.Server
+	GitHub  *MockGitHub
+	Linear  *MockLinear
+	DB      *sql.DB
+}
+
+func (ts *TestServer) URL() string { return ts.HTTPSrv.URL }
+
+func (ts *TestServer) ClawToken() string { return "test-claw-token" }
+
+func (ts *TestServer) PostWebhook(path string, body []byte) *http.Response {
+	resp, err := http.Post(ts.HTTPSrv.URL+path, "application/json", strings.NewReader(string(body)))
+	if err != nil {
+		panic(err)
+	}
+	return resp
+}
+
+func (ts *TestServer) WaitForClawWithIssue(t *testing.T, issueID string, timeout time.Duration) string {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		var clawID string
+		ts.DB.QueryRow(`SELECT id FROM claws WHERE linear_issue_id=?`, issueID).Scan(&clawID)
+		if clawID != "" {
+			return clawID
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("WaitForClawWithIssue: no claw for issue %s after %v", issueID, timeout)
+	return ""
+}
+
+func (ts *TestServer) WaitForClawStatus(t *testing.T, clawID, status string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		var current string
+		ts.DB.QueryRow(`SELECT status FROM claws WHERE id=?`, clawID).Scan(&current)
+		if current == status {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	var current string
+	ts.DB.QueryRow(`SELECT status FROM claws WHERE id=?`, clawID).Scan(&current)
+	t.Fatalf("WaitForClawStatus: claw %s: want %q got %q after %v", clawID[:8], status, current, timeout)
+}
+
+func NewTestServer(t *testing.T) *TestServer {
+	t.Helper()
+	gh := NewMockGitHub(t)
+	li := NewMockLinear(t)
+
+	cfg := &types.HubConfig{
+		ClawToken: "test-claw-token",
+		Factories: []*types.FactoryConfig{
+			{
+				Name:          "test-factory",
+				Integration:   "linear",
+				Workspace:     "test-workspace",
+				TriggerStatus: "In Progress",
+				DoneStatus:    "done-state-id",
+				Template:      "elasticclaw",
+				Provider:      "noop",
+			},
+		},
+		Integrations: &types.IntegrationsConfig{
+			Linear: []*types.LinearIntegrationConfig{
+				{
+					Workspace: "test-workspace",
+					Token:     "test-linear-token",
+				},
+			},
+		},
+		Providers: map[string]types.ProviderConfig{
+			"noop": {Type: "noop"},
+		},
+	}
+
+	s, db := hub.NewTestServerWithConfig(t, cfg, gh.URL, li.URL)
+	s.StartPRWatcherForTest()
+
+	httpSrv := httptest.NewServer(s.Handler())
+	t.Cleanup(httpSrv.Close)
+
+	return &TestServer{
+		Server:  s,
+		HTTPSrv: httpSrv,
+		GitHub:  gh,
+		Linear:  li,
+		DB:      db,
+	}
+}

--- a/pkg/hub/factorytest/server.go
+++ b/pkg/hub/factorytest/server.go
@@ -55,6 +55,8 @@ func (ts *TestServer) WaitForClawStatus(t *testing.T, clawID, status string, tim
 
 func NewTestServer(t *testing.T) *TestServer {
 	t.Helper()
+	// Enable noop provider for tests
+	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
 	gh := NewMockGitHub(t)
 	li := NewMockLinear(t)
 

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -244,10 +244,12 @@ func (s *Server) createClawForIssue(factory *types.FactoryConfig, payload linear
 	// Find provider: factory override > template config > hub default
 	provider := factory.Provider
 	if provider == "" {
-		provider = s.defaultProvider()
+		if tmplCfg != nil && tmplCfg.Provider != "" {
+			provider = tmplCfg.Provider
+		}
 	}
-	if provider == "" && tmplCfg != nil && tmplCfg.Provider != "" {
-		provider = tmplCfg.Provider
+	if provider == "" {
+		provider = s.defaultProvider()
 	}
 	if provider == "" {
 		return fmt.Errorf("no provider configured")
@@ -434,12 +436,16 @@ func (s *Server) terminateClawForIssue(issueID string) {
 }
 
 func (s *Server) defaultProvider() string {
+	var typedProvider string
 	for name, p := range s.hubCfg.Providers {
-		if p.Token != "" || p.APIKey != "" || p.Type != "" {
+		if p.Token != "" || p.APIKey != "" {
 			return name
 		}
+		if typedProvider == "" && p.Type != "" {
+			typedProvider = name
+		}
 	}
-	return ""
+	return typedProvider
 }
 
 func (s *Server) resolveLinearTokenForFactory(factory *types.FactoryConfig) string {
@@ -691,12 +697,7 @@ func (s *Server) moveLinearIssueOnServer(token, issueIdentifier, targetStateName
 	return moveLinearIssueWithBase(base, token, issueIdentifier, targetStateName)
 }
 
-// moveLinearIssue updates a Linear issue's state by name using the Linear GraphQL API.
-func moveLinearIssue(token, issueIdentifier, targetStateName string) error {
-	return moveLinearIssueWithBase("https://api.linear.app", token, issueIdentifier, targetStateName)
-}
-
-// moveLinearIssueWithBase is like moveLinearIssue but against a custom base URL (for testing).
+// moveLinearIssueWithBase updates a Linear issue's state against a custom base URL (for testing).
 func moveLinearIssueWithBase(baseURL, token, issueIdentifier, targetStateName string) error {
 	// First find the issue ID from identifier using GraphQL variables
 	queryBody := map[string]interface{}{

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/elasticclaw/elasticclaw/pkg/config"
@@ -391,9 +392,13 @@ func (s *Server) createClawForIssue(factory *types.FactoryConfig, payload linear
 		case "vercel":
 			provErr = s.provisionVercel(ctx, clawID, req, provCfg, fileBytes, env)
 		case "noop":
-			// Test provider — skip provisioning, mark connected immediately so fake bridge can connect
-			providerID := "noop-vm-" + clawID[:8]
-			_, _ = s.db.Exec(`UPDATE claws SET status='connected', provider='noop', provider_id=? WHERE id=?`, providerID, clawID)
+			// Test provider — only allowed when explicitly enabled via env var.
+			if os.Getenv("ELASTICCLAW_NOOP_PROVIDER") == "" {
+				provErr = fmt.Errorf("noop provider requires ELASTICCLAW_NOOP_PROVIDER=1 (test use only)")
+			} else {
+				providerID := "noop-vm-" + clawID[:8]
+				_, _ = s.db.Exec(`UPDATE claws SET status='connected', provider='noop', provider_id=? WHERE id=?`, providerID, clawID)
+			}
 		default:
 			provErr = fmt.Errorf("unsupported provider: %s", provider)
 		}
@@ -436,16 +441,13 @@ func (s *Server) terminateClawForIssue(issueID string) {
 }
 
 func (s *Server) defaultProvider() string {
-	var typedProvider string
 	for name, p := range s.hubCfg.Providers {
-		if p.Token != "" || p.APIKey != "" {
+		// Only consider providers with real credentials, not Type-only stubs (e.g. noop)
+		if p.Token != "" || p.APIKey != "" || p.AccessToken != "" {
 			return name
 		}
-		if typedProvider == "" && p.Type != "" {
-			typedProvider = name
-		}
 	}
-	return typedProvider
+	return ""
 }
 
 func (s *Server) resolveLinearTokenForFactory(factory *types.FactoryConfig) string {

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -241,9 +241,12 @@ func (s *Server) createClawForIssue(factory *types.FactoryConfig, payload linear
 		return fmt.Errorf("no tenant: %w", err)
 	}
 
-	// Find provider: template config > hub default
-	provider := s.defaultProvider()
-	if tmplCfg != nil && tmplCfg.Provider != "" {
+	// Find provider: factory override > template config > hub default
+	provider := factory.Provider
+	if provider == "" {
+		provider = s.defaultProvider()
+	}
+	if provider == "" && tmplCfg != nil && tmplCfg.Provider != "" {
 		provider = tmplCfg.Provider
 	}
 	if provider == "" {
@@ -385,6 +388,10 @@ func (s *Server) createClawForIssue(factory *types.FactoryConfig, payload linear
 			provErr = s.provisionDaytona(ctx, clawID, req, provCfg, fileBytes, env)
 		case "vercel":
 			provErr = s.provisionVercel(ctx, clawID, req, provCfg, fileBytes, env)
+		case "noop":
+			// Test provider — skip provisioning, mark connected immediately so fake bridge can connect
+			providerID := "noop-vm-" + clawID[:8]
+			_, _ = s.db.Exec(`UPDATE claws SET status='connected', provider='noop', provider_id=? WHERE id=?`, providerID, clawID)
 		default:
 			provErr = fmt.Errorf("unsupported provider: %s", provider)
 		}
@@ -428,7 +435,7 @@ func (s *Server) terminateClawForIssue(issueID string) {
 
 func (s *Server) defaultProvider() string {
 	for name, p := range s.hubCfg.Providers {
-		if p.Token != "" || p.APIKey != "" {
+		if p.Token != "" || p.APIKey != "" || p.Type != "" {
 			return name
 		}
 	}
@@ -542,7 +549,7 @@ func (s *Server) handleClawDoneSignal(clawID, rawMessage string) {
 			// Linear issue
 			linearToken := s.resolveLinearTokenForFactory(factory)
 			if linearToken != "" {
-				if err := moveLinearIssue(linearToken, issueID, factory.DoneStatus); err != nil {
+				if err := s.moveLinearIssueOnServer(linearToken, issueID, factory.DoneStatus); err != nil {
 					log.Printf("[factory] failed to move issue %s to '%s': %v", issueID, factory.DoneStatus, err)
 				} else {
 					log.Printf("[factory] moved issue %s to '%s'", issueID, factory.DoneStatus)
@@ -674,8 +681,23 @@ func (s *Server) findFactoryForIssue(issueID string) *types.FactoryConfig {
 	return nil
 }
 
+// moveLinearIssueOnServer updates a Linear issue's state, using the server's configured
+// linearBaseURL override if set (for testing).
+func (s *Server) moveLinearIssueOnServer(token, issueIdentifier, targetStateName string) error {
+	base := s.linearBaseURL
+	if base == "" {
+		base = "https://api.linear.app"
+	}
+	return moveLinearIssueWithBase(base, token, issueIdentifier, targetStateName)
+}
+
 // moveLinearIssue updates a Linear issue's state by name using the Linear GraphQL API.
 func moveLinearIssue(token, issueIdentifier, targetStateName string) error {
+	return moveLinearIssueWithBase("https://api.linear.app", token, issueIdentifier, targetStateName)
+}
+
+// moveLinearIssueWithBase is like moveLinearIssue but against a custom base URL (for testing).
+func moveLinearIssueWithBase(baseURL, token, issueIdentifier, targetStateName string) error {
 	// First find the issue ID from identifier using GraphQL variables
 	queryBody := map[string]interface{}{
 		"query": "query($id: String!) { issue(id: $id) { id team { states { nodes { id name } } } } }",
@@ -684,7 +706,7 @@ func moveLinearIssue(token, issueIdentifier, targetStateName string) error {
 		},
 	}
 	queryJSON, _ := json.Marshal(queryBody)
-	req, _ := http.NewRequest("POST", "https://api.linear.app/graphql", strings.NewReader(string(queryJSON)))
+	req, _ := http.NewRequest("POST", baseURL+"/graphql", strings.NewReader(string(queryJSON)))
 	req.Header.Set("Authorization", token)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -734,7 +756,7 @@ func moveLinearIssue(token, issueIdentifier, targetStateName string) error {
 		},
 	}
 	mutationJSON, _ := json.Marshal(mutationBody)
-	req2, _ := http.NewRequest("POST", "https://api.linear.app/graphql", strings.NewReader(string(mutationJSON)))
+	req2, _ := http.NewRequest("POST", baseURL+"/graphql", strings.NewReader(string(mutationJSON)))
 	req2.Header.Set("Authorization", token)
 	req2.Header.Set("Content-Type", "application/json")
 	resp2, err := http.DefaultClient.Do(req2)

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -397,7 +397,7 @@ func (s *Server) createClawForIssue(factory *types.FactoryConfig, payload linear
 				provErr = fmt.Errorf("noop provider requires ELASTICCLAW_NOOP_PROVIDER=1 (test use only)")
 			} else {
 				providerID := "noop-vm-" + clawID[:8]
-				_, _ = s.db.Exec(`UPDATE claws SET status='connected', provider='noop', provider_id=? WHERE id=?`, providerID, clawID)
+				_, _ = s.db.Exec(`UPDATE claws SET status='connected', provider='noop', provider_id=? WHERE id=? AND status NOT IN ('idle','deleted','error')`, providerID, clawID)
 			}
 		default:
 			provErr = fmt.Errorf("unsupported provider: %s", provider)

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -541,7 +541,11 @@ func (s *Server) checkPRMerged(pr clawPR, token string) bool {
 	if tokenForPR == "" {
 		tokenForPR = token
 	}
-	data, err := githubAPI(fmt.Sprintf("repos/%s/pulls/%d", pr.repo, pr.prNumber), tokenForPR)
+	ghBase := s.githubBaseURL
+	if ghBase == "" {
+		ghBase = "https://api.github.com"
+	}
+	data, err := githubAPIWithBase(ghBase, fmt.Sprintf("repos/%s/pulls/%d", pr.repo, pr.prNumber), tokenForPR)
 	if err != nil {
 		return false
 	}

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -552,18 +552,21 @@ func (s *Server) checkPRMerged(pr clawPR, token string) bool {
 		return false // still open
 	}
 
-	// PR is merged or closed — terminate the claw
 	clawID := pr.clawID
 	var tenantID string
 	if err := s.db.QueryRow(`SELECT tenant_id FROM claws WHERE id=?`, clawID).Scan(&tenantID); err != nil {
 		return false
 	}
 
-	action := "merged"
-	if !merged {
-		action = "closed"
+	// If the PR was closed without merging, notify the claw and let it decide — don't terminate.
+	if state == "closed" && !merged {
+		log.Printf("[pr-watcher] PR %s#%d closed without merge — notifying claw %s", pr.repo, pr.prNumber, clawID[:8])
+		s.injectUserMessage(clawID, fmt.Sprintf("PR %s was closed without being merged. Decide what to do: reopen it, open a new PR, or let the user know.", pr.prURL))
+		return false
 	}
-	log.Printf("[pr-watcher] PR %s#%d %s — terminating claw %s", pr.repo, pr.prNumber, action, clawID[:8])
+
+	// PR was merged — terminate the claw.
+	log.Printf("[pr-watcher] PR %s#%d merged — terminating claw %s", pr.repo, pr.prNumber, clawID[:8])
 
 	var providerID, provider string
 	_ = s.db.QueryRow(`SELECT COALESCE(provider_id,''), COALESCE(provider,'') FROM claws WHERE id=?`, clawID).Scan(&providerID, &provider)
@@ -573,7 +576,7 @@ func (s *Server) checkPRMerged(pr clawPR, token string) bool {
 
 	s.mu.Lock()
 	if cc, ok := s.claws[clawID]; ok {
-		cc.conn.Close(1000, fmt.Sprintf("factory: PR %s", action))
+		cc.conn.Close(1000, "factory: PR merged")
 		delete(s.claws, clawID)
 	}
 	s.mu.Unlock()

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -566,6 +566,8 @@ func (s *Server) checkPRMerged(pr clawPR, token string) bool {
 	if state == "closed" && !merged {
 		log.Printf("[pr-watcher] PR %s#%d closed without merge — notifying claw %s", pr.repo, pr.prNumber, clawID[:8])
 		s.injectUserMessage(clawID, fmt.Sprintf("PR %s was closed without being merged. Decide what to do: reopen it, open a new PR, or let the user know.", pr.prURL))
+		// Stop polling this closed PR so the claw doesn't get duplicate notifications.
+		_, _ = s.db.Exec(`DELETE FROM claw_prs WHERE id=?`, pr.id)
 		return false
 	}
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -43,6 +43,10 @@ type Server struct {
 
 	// githubBaseURL overrides the GitHub API base for testing (default: https://api.github.com)
 	githubBaseURL string
+	// linearBaseURL overrides the Linear API base for testing (default: https://api.linear.app)
+	linearBaseURL string
+	// testGitHubToken is used in tests to bypass GitHub App token resolution
+	testGitHubToken string
 }
 
 type clawConn struct {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1865,7 +1865,12 @@ func (s *Server) sendWakeMessage(cc *clawConn, clawID string) {
 	var issueID string
 	_ = s.db.QueryRow(`SELECT COALESCE(linear_issue_id,'') FROM claws WHERE id=?`, clawID).Scan(&issueID)
 	if issueID != "" {
-		wakeContent = "Read your BOOTSTRAP.md now. Then immediately start working on the task — do not ask for permission or confirmation. Explore the codebase, implement the change, and report back with what you did."
+		wakeContent = `Read your BOOTSTRAP.md now. Then:
+1. Send a short intro message to the user: your name, the issue you're working on, and your plan.
+2. Start working. As you go, narrate your progress — what you're exploring, what you're trying, why.
+3. If you hit something interesting or unexpected, say so.
+4. When you open a PR, summarize what you did and what the PR contains.
+5. Do NOT ask for permission at any point. Just work and keep the user informed.`
 	}
 	wakeMsg := types.HubMessage{
 		ID:      uuid.New().String(),

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -45,8 +45,6 @@ type Server struct {
 	githubBaseURL string
 	// linearBaseURL overrides the Linear API base for testing (default: https://api.linear.app)
 	linearBaseURL string
-	// testGitHubToken is used in tests to bypass GitHub App token resolution
-	testGitHubToken string
 }
 
 type clawConn struct {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -117,6 +117,42 @@ func (s *Server) Run(opts ...RunOptions) error {
 	mux := http.NewServeMux()
 	s.mux = mux
 
+	s.registerRoutes(mux)
+
+	// Serve embedded web UI (static export)
+	if noWebUI {
+		log.Printf("[hub] web UI disabled (--no-web-ui)")
+	} else if webFS, err := webui.FS(); err == nil {
+		if _, indexErr := webFS.Open("index.html"); indexErr != nil {
+			log.Printf("[hub] web UI not built — run: make build-web")
+		} else {
+			s.serveWebUI(mux, webFS)
+			log.Printf("[hub] serving embedded web UI")
+		}
+	}
+
+	// Connect to relay if configured
+	s.mu.RLock()
+	relayURL := s.hubCfg.RelayURL
+	relaySecret := s.hubCfg.RelaySecret
+	clawToken := s.hubCfg.ClawToken
+	s.mu.RUnlock()
+	if relayURL != "" {
+		hubID := HubID(s.identity.PublicKey)
+		relayToken := RelayToken(relaySecret, hubID, clawToken)
+		log.Printf("[relay] hub ID: %s", hubID[:8]+"...")
+		log.Printf("[relay] connecting to %s", relayURL)
+		go s.connectRelay(context.Background(), relayURL, hubID, relayToken)
+	}
+
+	log.Printf("ElasticClaw Hub listening on %s", s.addr)
+	if s.hubCfg.UIPassword == "" {
+		log.Printf("⚠️  Web UI password not set — using default: 'admin'. Set ui_password in hub.yaml to secure the UI.")
+	}
+	return http.ListenAndServe(s.addr, corsMiddleware(mux))
+}
+
+func (s *Server) registerRoutes(mux *http.ServeMux) {
 	// Claw WebSocket
 	mux.HandleFunc("/claw/ws", s.handleClawWS)
 
@@ -167,38 +203,6 @@ func (s *Server) Run(opts ...RunOptions) error {
 		s.mu.RUnlock()
 		jsonOK(w, out)
 	}))
-
-	// Serve embedded web UI (static export)
-	if noWebUI {
-		log.Printf("[hub] web UI disabled (--no-web-ui)")
-	} else if webFS, err := webui.FS(); err == nil {
-		if _, indexErr := webFS.Open("index.html"); indexErr != nil {
-			log.Printf("[hub] web UI not built — run: make build-web")
-		} else {
-			s.serveWebUI(mux, webFS)
-			log.Printf("[hub] serving embedded web UI")
-		}
-	}
-
-	// Connect to relay if configured
-	s.mu.RLock()
-	relayURL := s.hubCfg.RelayURL
-	relaySecret := s.hubCfg.RelaySecret
-	clawToken := s.hubCfg.ClawToken
-	s.mu.RUnlock()
-	if relayURL != "" {
-		hubID := HubID(s.identity.PublicKey)
-		relayToken := RelayToken(relaySecret, hubID, clawToken)
-		log.Printf("[relay] hub ID: %s", hubID[:8]+"...")
-		log.Printf("[relay] connecting to %s", relayURL)
-		go s.connectRelay(context.Background(), relayURL, hubID, relayToken)
-	}
-
-	log.Printf("ElasticClaw Hub listening on %s", s.addr)
-	if s.hubCfg.UIPassword == "" {
-		log.Printf("⚠️  Web UI password not set — using default: 'admin'. Set ui_password in hub.yaml to secure the UI.")
-	}
-	return http.ListenAndServe(s.addr, corsMiddleware(mux))
 }
 
 // corsMiddleware adds permissive CORS headers so the web UI can connect

--- a/pkg/hub/testhelpers.go
+++ b/pkg/hub/testhelpers.go
@@ -1,0 +1,122 @@
+//go:build !production
+
+package hub
+
+import (
+	"database/sql"
+	"net/http"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+// NewTestServerWithConfig creates a Server for integration testing with mock backends.
+// Only call from tests. Uses the provided githubBaseURL and linearBaseURL to override
+// external API calls so tests can use httptest.Server instances.
+func NewTestServerWithConfig(t interface {
+	Helper()
+	Cleanup(func())
+}, cfg *types.HubConfig, githubBaseURL, linearBaseURL string) (*Server, *sql.DB) {
+	db, err := openDB(":memory:")
+	if err != nil {
+		panic("NewTestServerWithConfig: openDB: " + err.Error())
+	}
+	// Keep SQLite in-memory on a single connection so all goroutines see the same DB.
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { db.Close() })
+
+	if cfg == nil {
+		cfg = &types.HubConfig{}
+	}
+
+	// Provision a default tenant for the test server
+	_, _ = db.Exec(
+		`INSERT OR IGNORE INTO tenants(id,name,token,claw_token,created_at) VALUES(?,?,?,?,datetime('now'))`,
+		"test-tenant-id", "test", "test-token", cfg.ClawToken,
+	)
+
+	// Push an empty "elasticclaw" template so resolveTemplateFiles doesn't fail
+	for _, factory := range cfg.Factories {
+		if factory.Template != "" {
+			_, _ = db.Exec(
+				`INSERT OR IGNORE INTO hub_templates(name,files,created_at,updated_at) VALUES(?,?,datetime('now'),datetime('now'))`,
+				factory.Template, `{}`,
+			)
+		}
+	}
+
+	s := &Server{
+		db:            db,
+		hubCfg:        cfg,
+		claws:         make(map[string]*clawConn),
+		users:         make(map[string]*userConn),
+		githubBaseURL: githubBaseURL,
+		linearBaseURL: linearBaseURL,
+	}
+	// Register routes (same as Run but without serving web UI or starting relay)
+	s.setupRoutes()
+	return s, db
+}
+
+// setupRoutes registers all HTTP handlers on s.mux without starting the HTTP server.
+// This mirrors the Run() logic but is separated so tests can wrap with httptest.Server.
+func (s *Server) setupRoutes() {
+	mux := s.newMux(false)
+	s.mux = mux
+}
+
+// newMux builds and returns the handler mux. noWebUI=true skips embedding the web UI.
+func (s *Server) newMux(noWebUI bool) *http.ServeMux {
+	mux := http.NewServeMux()
+
+	// Claw WebSocket
+	mux.HandleFunc("/claw/ws", s.handleClawWS)
+
+	// Browser WebSocket
+	mux.HandleFunc("/api/ws", s.handleUserWS)
+
+	// REST API
+	mux.HandleFunc("/api/login", s.handleLogin)
+	mux.HandleFunc("/api/auth/login", s.handleWebLogin)
+	mux.HandleFunc("/api/auth/logout", s.handleWebLogout)
+	mux.HandleFunc("/api/auth/me", s.withWebAuth(s.handleWebMe))
+	mux.HandleFunc("/api/hub-config", s.withWebAuth(s.handleHubConfig))
+	mux.HandleFunc("/api/settings", s.withWebAuth(s.handleSettings))
+	mux.HandleFunc("/api/settings/status", s.withWebAuth(s.handleSettingsStatus))
+
+	// Template store
+	mux.HandleFunc("/api/templates", s.withWebAuth(s.handleTemplates))
+	mux.HandleFunc("/api/templates/{name}", s.withWebAuth(s.handleTemplateDetail))
+
+	// Integration webhooks
+	mux.HandleFunc("/api/integrations/linear/webhook", s.handleLinearWebhook)
+	mux.HandleFunc("/api/integrations/shortcut/webhook", s.handleShortcutWebhook)
+	mux.HandleFunc("/api/factories/", s.withAuth(s.handleFactoryEvents))
+	mux.HandleFunc("/api/claws", s.withAuth(s.handleClaws))
+	mux.HandleFunc("/api/claws/{id}", s.withAuth(s.handleClawDetail))
+	mux.HandleFunc("/api/terminal/", s.handleTerminal)
+	mux.HandleFunc("/api/github/token/", s.handleGitHubToken)
+	mux.HandleFunc("/api/messages/", s.withAuth(s.handleMessages))
+	mux.HandleFunc("/api/claws/", s.withAuth(s.handleClawSubresource))
+
+	// Health
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	return mux
+}
+
+// Handler returns the server's HTTP handler (mux). Must be called after setupRoutes.
+func (s *Server) Handler() http.Handler {
+	return s.mux
+}
+
+// PollPRsForTest triggers an immediate PR poll (for testing without waiting for the ticker).
+func (s *Server) PollPRsForTest() {
+	s.pollAllPRs()
+}
+
+// StartPRWatcherForTest starts the PR watcher background goroutine.
+func (s *Server) StartPRWatcherForTest() {
+	s.startPRWatcher()
+}

--- a/pkg/hub/testhelpers.go
+++ b/pkg/hub/testhelpers.go
@@ -53,57 +53,10 @@ func NewTestServerWithConfig(t interface {
 		linearBaseURL: linearBaseURL,
 	}
 	// Register routes (same as Run but without serving web UI or starting relay)
-	s.setupRoutes()
-	return s, db
-}
-
-// setupRoutes registers all HTTP handlers on s.mux without starting the HTTP server.
-// This mirrors the Run() logic but is separated so tests can wrap with httptest.Server.
-func (s *Server) setupRoutes() {
-	mux := s.newMux(false)
-	s.mux = mux
-}
-
-// newMux builds and returns the handler mux. noWebUI=true skips embedding the web UI.
-func (s *Server) newMux(noWebUI bool) *http.ServeMux {
 	mux := http.NewServeMux()
-
-	// Claw WebSocket
-	mux.HandleFunc("/claw/ws", s.handleClawWS)
-
-	// Browser WebSocket
-	mux.HandleFunc("/api/ws", s.handleUserWS)
-
-	// REST API
-	mux.HandleFunc("/api/login", s.handleLogin)
-	mux.HandleFunc("/api/auth/login", s.handleWebLogin)
-	mux.HandleFunc("/api/auth/logout", s.handleWebLogout)
-	mux.HandleFunc("/api/auth/me", s.withWebAuth(s.handleWebMe))
-	mux.HandleFunc("/api/hub-config", s.withWebAuth(s.handleHubConfig))
-	mux.HandleFunc("/api/settings", s.withWebAuth(s.handleSettings))
-	mux.HandleFunc("/api/settings/status", s.withWebAuth(s.handleSettingsStatus))
-
-	// Template store
-	mux.HandleFunc("/api/templates", s.withWebAuth(s.handleTemplates))
-	mux.HandleFunc("/api/templates/{name}", s.withWebAuth(s.handleTemplateDetail))
-
-	// Integration webhooks
-	mux.HandleFunc("/api/integrations/linear/webhook", s.handleLinearWebhook)
-	mux.HandleFunc("/api/integrations/shortcut/webhook", s.handleShortcutWebhook)
-	mux.HandleFunc("/api/factories/", s.withAuth(s.handleFactoryEvents))
-	mux.HandleFunc("/api/claws", s.withAuth(s.handleClaws))
-	mux.HandleFunc("/api/claws/{id}", s.withAuth(s.handleClawDetail))
-	mux.HandleFunc("/api/terminal/", s.handleTerminal)
-	mux.HandleFunc("/api/github/token/", s.handleGitHubToken)
-	mux.HandleFunc("/api/messages/", s.withAuth(s.handleMessages))
-	mux.HandleFunc("/api/claws/", s.withAuth(s.handleClawSubresource))
-
-	// Health
-	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
-
-	return mux
+	s.registerRoutes(mux)
+	s.mux = mux
+	return s, db
 }
 
 // Handler returns the server's HTTP handler (mux). Must be called after setupRoutes.

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -242,6 +242,7 @@ type FactoryConfig struct {
 	DoneStatus        string `yaml:"done_status,omitempty"`  // claw moves issue here when done
 	TerminateOnLeave  bool   `yaml:"terminate_on_leave,omitempty"` // leaving trigger_status → kill claw
 	Template          string `yaml:"template"`           // template name (must be pushed to hub)
+	Provider          string `yaml:"provider,omitempty"` // override the default provider for this factory
 	NamePattern       string   `yaml:"name_pattern,omitempty"` // claw name pattern, e.g. "{issue_id}"
 	WebhookSecret     string   `yaml:"webhook_secret,omitempty"` // HMAC-SHA256 secret for validating webhooks
 	Tags              []string `yaml:"tags,omitempty"`          // tags applied to created claws
@@ -249,6 +250,9 @@ type FactoryConfig struct {
 }
 
 type ProviderConfig struct {
+	// Type identifies the provider kind (e.g. "noop" for tests).
+	Type string `yaml:"type,omitempty"`
+
 	// Daytona
 	APIURL string `yaml:"api_url,omitempty"`
 	APIKey string `yaml:"api_key,omitempty"`

--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## What

Adds a complete factory integration test harness for the hub's Linear→Claw factory flow.

## Changes

### New: `pkg/hub/factorytest/` package
- **`mock_github.go`**: In-process GitHub API mock (PR state, comments, statuses)
- **`mock_linear.go`**: In-process Linear GraphQL mock (issue queries, issueUpdate, workflowStates)
- **`fake_bridge.go`**: WebSocket fake bridge that connects to the test hub and can send/receive messages
- **`server.go`**: `TestServer` helper that wires mocks + hub into a single test fixture

### Hub changes
- **`testhelpers.go`**: `NewTestServerWithConfig`, `Handler()`, `PollPRsForTest()`, `StartPRWatcherForTest()` — exported only when not building with `-tags production`
- **`linear.go`**: `noop` provider (skips VM provisioning), factory-level `provider` field override, server-scoped Linear base URL for mock support
- **`pr_watcher.go`**: `checkPRMerged` now uses `s.githubBaseURL` so mock GitHub works end-to-end

### Type changes
- `FactoryConfig.Provider`: factory-level provider override (e.g. `"noop"` in tests)
- `ProviderConfig.Type`: type identifier for provider kind

### Tests (`pkg/hub/factory_integration_test.go`)
Four tests, all gated behind `//go:build integration`:
- `TestFactoryFlow_HappyPath`: full flow from webhook → claw creation → bridge connect → [DONE] → idle
- `TestFactoryFlow_WebhookCreatesClawInDB`: validates webhook creates a claw record
- `TestFactoryFlow_FakeBridgeConnect`: validates bridge WebSocket handshake  
- `TestFactoryFlow_DoneSignalSetsIdle`: validates [DONE] transitions claw to idle status

### CI
- Added `make test-factory` target
- Added factory integration step to `.depot/workflows/test.yaml`

## How to run

```bash
make test-factory
# or
go test -v -tags integration -timeout 60s ./pkg/hub/... -run TestFactory
```