### PR TITLE
feat: factory-as-code — labels/assignedTo filters, CLI, hub CRUD API

### DIFF
--- a/cmd/factory.go
+++ b/cmd/factory.go
@@ -83,7 +83,7 @@ func runFactoryCreate() error {
 	if labelsRaw != "" {
 		parts := strings.Split(labelsRaw, ",")
 		var lb strings.Builder
-		lb.WriteString("    labels: [")
+		lb.WriteString("labels: [")
 		for i, p := range parts {
 			if i > 0 {
 				lb.WriteString(", ")
@@ -93,14 +93,14 @@ func runFactoryCreate() error {
 		lb.WriteString("]")
 		labelsYAML = lb.String() + "\n"
 	} else {
-		labelsYAML = "    # labels: [bug, claw-ready]\n"
+		labelsYAML = "# labels: [bug, claw-ready]\n"
 	}
 
 	var assignedToYAML string
 	if assignedTo != "" {
-		assignedToYAML = fmt.Sprintf("    assigned_to: %q\n", assignedTo)
+		assignedToYAML = fmt.Sprintf("assigned_to: %q\n", assignedTo)
 	} else {
-		assignedToYAML = "    # assigned_to: \"@username\"  # or !@username, any, none\n"
+		assignedToYAML = "# assigned_to: \"@username\"  # or !@username, any, none\n"
 	}
 
 	var descriptionYAML string
@@ -109,13 +109,10 @@ func runFactoryCreate() error {
 	}
 
 	factoryYAML := fmt.Sprintf(`name: %s
-%strigger:
-  integration: %s
-  workspace: %s
-  on:
-    status: %q
-%s%s  secrets:
-    webhook_secret: %s_webhook_secret
+%sintegration: %s
+workspace: %s
+trigger_status: %q
+%s%swebhook_secret: %s_webhook_secret
 
 template: %s
 `, name, descriptionYAML, integration, workspace, triggerStatus,

--- a/cmd/factory.go
+++ b/cmd/factory.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -349,7 +350,7 @@ func runFactoryShow(name string) error {
 		return err
 	}
 
-	req, _ := http.NewRequest(http.MethodGet, hubURL+"/api/factories?name="+name, nil)
+	req, _ := http.NewRequest(http.MethodGet, hubURL+"/api/factories?name="+url.QueryEscape(name), nil)
 	req.Header.Set("Authorization", "Bearer "+clawToken)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -388,7 +389,7 @@ func runFactoryRm(name string) error {
 		return err
 	}
 
-	req, _ := http.NewRequest(http.MethodDelete, hubURL+"/api/factories?name="+name, nil)
+	req, _ := http.NewRequest(http.MethodDelete, hubURL+"/api/factories?name="+url.QueryEscape(name), nil)
 	req.Header.Set("Authorization", "Bearer "+clawToken)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/cmd/factory.go
+++ b/cmd/factory.go
@@ -363,9 +363,12 @@ func runFactoryShow(name string) error {
 	}
 
 	// Pretty print as YAML
-	var v interface{}
+	var v []interface{}
 	_ = json.Unmarshal(body, &v)
-	out, _ := yaml.Marshal(v)
+	if len(v) == 0 {
+		return fmt.Errorf("factory %q not found", name)
+	}
+	out, _ := yaml.Marshal(v[0])
 	fmt.Print(string(out))
 	return nil
 }

--- a/cmd/factory.go
+++ b/cmd/factory.go
@@ -1,0 +1,440 @@
+package cmd
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/elasticclaw/elasticclaw/pkg/config"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+func FactoryCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "factory",
+		Short: "Manage elasticclaw factories",
+	}
+	cmd.AddCommand(factoryCreateCmd())
+	cmd.AddCommand(factoryPushCmd())
+	cmd.AddCommand(factoryListCmd())
+	cmd.AddCommand(factoryShowCmd())
+	cmd.AddCommand(factoryRmCmd())
+	return cmd
+}
+
+// ── factory create ────────────────────────────────────────────────────────────
+
+func factoryCreateCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "create",
+		Short: "Bootstrap a new factory directory with interactive prompts",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runFactoryCreate()
+		},
+	}
+}
+
+func prompt(scanner *bufio.Scanner, question, defaultVal string) string {
+	if defaultVal != "" {
+		fmt.Printf("%s [%s]: ", question, defaultVal)
+	} else {
+		fmt.Printf("%s: ", question)
+	}
+	scanner.Scan()
+	val := strings.TrimSpace(scanner.Text())
+	if val == "" {
+		return defaultVal
+	}
+	return val
+}
+
+func runFactoryCreate() error {
+	scanner := bufio.NewScanner(os.Stdin)
+
+	name := prompt(scanner, "Factory name (slug, used as directory name)", "")
+	if name == "" {
+		return fmt.Errorf("factory name is required")
+	}
+	name = strings.ToLower(strings.ReplaceAll(name, " ", "-"))
+
+	description := prompt(scanner, "Description (optional)", "")
+	integration := prompt(scanner, "Integration (linear / shortcut)", "linear")
+	workspace := prompt(scanner, "Workspace name", "")
+	if workspace == "" {
+		return fmt.Errorf("workspace is required")
+	}
+	triggerStatus := prompt(scanner, "Trigger status", "In Progress")
+	labelsRaw := prompt(scanner, "Labels to match, comma-separated (optional)", "")
+	assignedTo := prompt(scanner, "Assigned to filter (optional: @user, !@user, any, none)", "")
+	tmpl := prompt(scanner, "Template", "elasticclaw")
+	doneStatus := prompt(scanner, "Done status (issue status when claw sends [DONE])", "In Review")
+
+	// Parse labels
+	var labelsYAML string
+	if labelsRaw != "" {
+		parts := strings.Split(labelsRaw, ",")
+		var lb strings.Builder
+		lb.WriteString("    labels: [")
+		for i, p := range parts {
+			if i > 0 {
+				lb.WriteString(", ")
+			}
+			lb.WriteString(strings.TrimSpace(p))
+		}
+		lb.WriteString("]")
+		labelsYAML = lb.String() + "\n"
+	} else {
+		labelsYAML = "    # labels: [bug, claw-ready]\n"
+	}
+
+	var assignedToYAML string
+	if assignedTo != "" {
+		assignedToYAML = fmt.Sprintf("    assigned_to: %q\n", assignedTo)
+	} else {
+		assignedToYAML = "    # assigned_to: \"@username\"  # or !@username, any, none\n"
+	}
+
+	var descriptionYAML string
+	if description != "" {
+		descriptionYAML = fmt.Sprintf("description: %q\n\n", description)
+	}
+
+	factoryYAML := fmt.Sprintf(`name: %s
+%strigger:
+  integration: %s
+  workspace: %s
+  on:
+    status: %q
+%s%s  secrets:
+    webhook_secret: %s_webhook_secret
+
+template: %s
+`, name, descriptionYAML, integration, workspace, triggerStatus,
+		labelsYAML, assignedToYAML, name, tmpl)
+
+	pipelineYAML := fmt.Sprintf(`# Pipeline for %s
+# Stages define the lifecycle of a factory claw.
+# The hub is the state machine — it injects instructions into the claw at each stage.
+
+stages:
+  - id: working
+    label: "Working"
+    entry: true
+    on_enter:
+      inject: |
+        Read your BOOTSTRAP.md and start working on the issue.
+        Narrate your progress as you go. Keep me updated.
+
+  - id: pr_opened
+    label: "PR Opened"
+    triggers:
+      - message_contains: "[DONE]"
+    on_enter:
+      move_issue: %q
+      inject: |
+        PR created. Watch for CI results and review comments.
+
+  - id: merged
+    label: "Merged"
+    triggers:
+      - pr_merged:
+    terminal: true
+
+  - id: closed_no_merge
+    label: "Closed Without Merge"
+    triggers:
+      - pr_closed:
+    on_enter:
+      inject: |
+        PR was closed without merging. Decide: reopen, new PR, or ask the user.
+`, name, doneStatus)
+
+	dir := filepath.Join(".elasticclaw", "factories", name)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "factory.yaml"), []byte(factoryYAML), 0644); err != nil {
+		return fmt.Errorf("failed to write factory.yaml: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "pipeline.yaml"), []byte(pipelineYAML), 0644); err != nil {
+		return fmt.Errorf("failed to write pipeline.yaml: %w", err)
+	}
+
+	fmt.Printf("\nCreated %s/\n", dir)
+	fmt.Printf("  factory.yaml\n")
+	fmt.Printf("  pipeline.yaml\n\n")
+	fmt.Printf("Next steps:\n")
+	fmt.Printf("  1. Edit %s/factory.yaml to review settings\n", dir)
+	fmt.Printf("  2. Add your webhook secret to the hub: elasticclaw hub settings\n")
+	fmt.Printf("  3. Push to hub: elasticclaw factory push\n")
+	return nil
+}
+
+// ── factory push ──────────────────────────────────────────────────────────────
+
+func factoryPushCmd() *cobra.Command {
+	var name string
+	cmd := &cobra.Command{
+		Use:   "push [name]",
+		Short: "Push factory definitions to the hub",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				name = args[0]
+			}
+			return runFactoryPush(name)
+		},
+	}
+	return cmd
+}
+
+func runFactoryPush(filterName string) error {
+	hubURL, clawToken, err := resolveHubConn()
+	if err != nil {
+		return err
+	}
+
+	// Find all factory.yaml files
+	pattern := filepath.Join(".elasticclaw", "factories", "*", "factory.yaml")
+	matches, err := filepath.Glob(pattern)
+	if err != nil || len(matches) == 0 {
+		return fmt.Errorf("no factories found under .elasticclaw/factories/")
+	}
+
+	var factories []*types.FactoryConfig
+	for _, match := range matches {
+		data, err := os.ReadFile(match)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", match, err)
+		}
+		var f types.FactoryConfig
+		if err := yaml.Unmarshal(data, &f); err != nil {
+			return fmt.Errorf("parse %s: %w", match, err)
+		}
+		if filterName != "" && !strings.EqualFold(f.Name, filterName) {
+			continue
+		}
+
+		// Read pipeline.yaml alongside if present
+		pipelinePath := filepath.Join(filepath.Dir(match), "pipeline.yaml")
+		if pdata, err := os.ReadFile(pipelinePath); err == nil {
+			f.PipelineYAML = string(pdata)
+		}
+
+		factories = append(factories, &f)
+	}
+
+	if len(factories) == 0 {
+		return fmt.Errorf("no factories matched")
+	}
+
+	body, _ := json.Marshal(map[string]interface{}{"factories": factories})
+	req, _ := http.NewRequest(http.MethodPost, hubURL+"/api/factories", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+clawToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("push failed: %w", err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("hub returned %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+
+	var result struct {
+		Pushed    int `json:"pushed"`
+		Factories []struct {
+			Name string `json:"name"`
+		} `json:"factories"`
+	}
+	_ = json.Unmarshal(respBody, &result)
+
+	fmt.Printf("Pushed %d factory/factories to hub:\n", result.Pushed)
+	for _, f := range result.Factories {
+		fmt.Printf("  ✓ %s\n", f.Name)
+	}
+	return nil
+}
+
+// ── factory list ──────────────────────────────────────────────────────────────
+
+func factoryListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List factories on the hub",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runFactoryList()
+		},
+	}
+}
+
+type factoryView struct {
+	Name          string   `json:"name"`
+	Integration   string   `json:"integration"`
+	Workspace     string   `json:"workspace"`
+	TriggerStatus string   `json:"trigger_status"`
+	DoneStatus    string   `json:"done_status"`
+	Template      string   `json:"template"`
+	Labels        []string `json:"labels"`
+	AssignedTo    string   `json:"assigned_to"`
+	Enabled       *bool    `json:"enabled"`
+}
+
+func runFactoryList() error {
+	hubURL, clawToken, err := resolveHubConn()
+	if err != nil {
+		return err
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, hubURL+"/api/factories", nil)
+	req.Header.Set("Authorization", "Bearer "+clawToken)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("list failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("hub returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var factories []factoryView
+	if err := json.NewDecoder(resp.Body).Decode(&factories); err != nil {
+		return fmt.Errorf("decode: %w", err)
+	}
+
+	if len(factories) == 0 {
+		fmt.Println("No factories configured.")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "NAME\tINTEGRATION\tWORKSPACE\tTRIGGER\tTEMPLATE\tENABLED")
+	for _, f := range factories {
+		enabled := "true"
+		if f.Enabled != nil && !*f.Enabled {
+			enabled = "false"
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			f.Name, f.Integration, f.Workspace, f.TriggerStatus, f.Template, enabled)
+	}
+	w.Flush()
+	return nil
+}
+
+// ── factory show ──────────────────────────────────────────────────────────────
+
+func factoryShowCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show <name>",
+		Short: "Show a factory's current hub configuration",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runFactoryShow(args[0])
+		},
+	}
+}
+
+func runFactoryShow(name string) error {
+	hubURL, clawToken, err := resolveHubConn()
+	if err != nil {
+		return err
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, hubURL+"/api/factories?name="+name, nil)
+	req.Header.Set("Authorization", "Bearer "+clawToken)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("hub returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	// Pretty print as YAML
+	var v interface{}
+	_ = json.Unmarshal(body, &v)
+	out, _ := yaml.Marshal(v)
+	fmt.Print(string(out))
+	return nil
+}
+
+// ── factory rm ────────────────────────────────────────────────────────────────
+
+func factoryRmCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "rm <name>",
+		Short: "Remove a factory from the hub",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runFactoryRm(args[0])
+		},
+	}
+}
+
+func runFactoryRm(name string) error {
+	hubURL, clawToken, err := resolveHubConn()
+	if err != nil {
+		return err
+	}
+
+	req, _ := http.NewRequest(http.MethodDelete, hubURL+"/api/factories?name="+name, nil)
+	req.Header.Set("Authorization", "Bearer "+clawToken)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("hub returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	fmt.Printf("Removed factory %q from hub.\n", name)
+	return nil
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+func resolveHubConn() (hubURL, clawToken string, err error) {
+	// Try env first
+	hubURL = os.Getenv("ELASTICCLAW_HUB_URL")
+	clawToken = os.Getenv("ELASTICCLAW_CLAW_TOKEN")
+
+	if hubURL == "" || clawToken == "" {
+		cfg, cfgErr := config.LoadHubConfig()
+		if cfgErr == nil && cfg != nil {
+			if hubURL == "" {
+				hubURL = cfg.URL
+			}
+			if clawToken == "" {
+				clawToken = cfg.ClawToken
+			}
+		}
+	}
+
+	if hubURL == "" {
+		return "", "", fmt.Errorf("hub URL not set — use ELASTICCLAW_HUB_URL or configure with `elasticclaw hub init`")
+	}
+	if clawToken == "" {
+		return "", "", fmt.Errorf("claw token not set — use ELASTICCLAW_CLAW_TOKEN or configure with `elasticclaw hub init`")
+	}
+	return hubURL, clawToken, nil
+}
+
+func init() {
+	rootCmd.AddCommand(FactoryCmd())
+}

--- a/cmd/factory.go
+++ b/cmd/factory.go
@@ -112,7 +112,7 @@ func runFactoryCreate() error {
 %sintegration: %s
 workspace: %s
 trigger_status: %q
-%s%swebhook_secret: %s_webhook_secret
+%s%swebhook_secret_ref: %s_webhook_secret
 
 template: %s
 `, name, descriptionYAML, integration, workspace, triggerStatus,

--- a/pkg/hub/factory_api.go
+++ b/pkg/hub/factory_api.go
@@ -65,13 +65,18 @@ func factoryToPushView(f *types.FactoryConfig) FactoryPushView {
 	}
 }
 
-func (s *Server) handleFactoriesList(w http.ResponseWriter, _ *http.Request) {
+func (s *Server) handleFactoriesList(w http.ResponseWriter, r *http.Request) {
+	nameFilter := strings.TrimSpace(r.URL.Query().Get("name"))
+
 	s.mu.RLock()
 	factories := s.hubCfg.Factories
 	s.mu.RUnlock()
 
 	views := make([]FactoryPushView, 0, len(factories))
 	for _, f := range factories {
+		if nameFilter != "" && !strings.EqualFold(f.Name, nameFilter) {
+			continue
+		}
 		views = append(views, factoryToPushView(f))
 	}
 	jsonOK(w, views)
@@ -126,7 +131,7 @@ func (s *Server) handleFactoriesPush(w http.ResponseWriter, r *http.Request) {
 		views = append(views, factoryToPushView(f))
 	}
 	jsonOK(w, map[string]interface{}{
-		"pushed": len(req.Factories),
+		"pushed":    len(req.Factories),
 		"factories": views,
 	})
 }

--- a/pkg/hub/factory_api.go
+++ b/pkg/hub/factory_api.go
@@ -112,7 +112,7 @@ func (s *Server) handleFactoriesPush(w http.ResponseWriter, r *http.Request) {
 	for _, incoming := range req.Factories {
 		if prev, ok := existing[incoming.Name]; ok {
 			// Preserve inline webhook secret if not provided in push
-			if incoming.WebhookSecret == "" && prev.WebhookSecret != "" {
+			if incoming.WebhookSecret == "" && incoming.WebhookSecretRef == "" && prev.WebhookSecret != "" {
 				incoming.WebhookSecret = prev.WebhookSecret
 			}
 		}

--- a/pkg/hub/factory_api.go
+++ b/pkg/hub/factory_api.go
@@ -99,11 +99,16 @@ func (s *Server) handleFactoriesPush(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.mu.Lock()
-	// Upsert by name — preserve existing webhook secrets for repo-pushed factories
+	// Upsert by name — preserve existing webhook secrets for repo-pushed factories.
+	// Keep factory ordering stable: preserve existing order and append newly-added
+	// factories in request order.
 	existing := make(map[string]*types.FactoryConfig)
 	for _, f := range s.hubCfg.Factories {
 		existing[f.Name] = f
 	}
+	incomingByName := make(map[string]*types.FactoryConfig, len(req.Factories))
+	incomingOrder := make([]string, 0, len(req.Factories))
+	seenIncoming := make(map[string]bool, len(req.Factories))
 	for _, incoming := range req.Factories {
 		if prev, ok := existing[incoming.Name]; ok {
 			// Preserve inline webhook secret if not provided in push
@@ -112,10 +117,25 @@ func (s *Server) handleFactoriesPush(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		existing[incoming.Name] = incoming
+		incomingByName[incoming.Name] = incoming
+		if !seenIncoming[incoming.Name] {
+			seenIncoming[incoming.Name] = true
+			incomingOrder = append(incomingOrder, incoming.Name)
+		}
 	}
 	updated := make([]*types.FactoryConfig, 0, len(existing))
-	for _, f := range existing {
+	for _, f := range s.hubCfg.Factories {
+		if incoming, ok := incomingByName[f.Name]; ok {
+			updated = append(updated, incoming)
+			delete(incomingByName, f.Name)
+			continue
+		}
 		updated = append(updated, f)
+	}
+	for _, name := range incomingOrder {
+		if incoming, ok := incomingByName[name]; ok {
+			updated = append(updated, incoming)
+		}
 	}
 	s.hubCfg.Factories = updated
 	cfgCopy := *s.hubCfg

--- a/pkg/hub/factory_api.go
+++ b/pkg/hub/factory_api.go
@@ -59,7 +59,7 @@ func factoryToPushView(f *types.FactoryConfig) FactoryPushView {
 		Labels:           f.Labels,
 		AssignedTo:       f.AssignedTo,
 		Enabled:          f.Enabled,
-		HasWebhookSecret: f.WebhookSecret != "",
+		HasWebhookSecret: f.WebhookSecret != "" || f.WebhookSecretRef != "",
 		WebhookSecretRef: f.WebhookSecretRef,
 		PipelineYAML:     f.PipelineYAML,
 	}
@@ -137,14 +137,17 @@ func (s *Server) handleFactoriesPush(w http.ResponseWriter, r *http.Request) {
 			updated = append(updated, incoming)
 		}
 	}
-	s.hubCfg.Factories = updated
 	cfgCopy := *s.hubCfg
+	cfgCopy.Factories = updated
 	s.mu.Unlock()
 
 	if err := config.SaveHubConfig(&cfgCopy); err != nil {
 		http.Error(w, "failed to save config: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
+	s.mu.Lock()
+	s.hubCfg.Factories = updated
+	s.mu.Unlock()
 
 	views := make([]FactoryPushView, 0, len(req.Factories))
 	for _, f := range req.Factories {
@@ -167,8 +170,8 @@ func (s *Server) handleFactoryDelete(w http.ResponseWriter, _ *http.Request, nam
 		}
 		factories = append(factories, f)
 	}
-	s.hubCfg.Factories = factories
 	cfgCopy := *s.hubCfg
+	cfgCopy.Factories = factories
 	s.mu.Unlock()
 
 	if !found {
@@ -180,6 +183,9 @@ func (s *Server) handleFactoryDelete(w http.ResponseWriter, _ *http.Request, nam
 		http.Error(w, "failed to save config: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
+	s.mu.Lock()
+	s.hubCfg.Factories = factories
+	s.mu.Unlock()
 
 	jsonOK(w, map[string]string{"deleted": name})
 }

--- a/pkg/hub/factory_api.go
+++ b/pkg/hub/factory_api.go
@@ -1,0 +1,160 @@
+package hub
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/elasticclaw/elasticclaw/pkg/config"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+// handleFactoriesCRUD handles:
+//
+//	GET  /api/factories        → list all factories (secrets masked)
+//	POST /api/factories        → upsert batch from factory push
+//	DELETE /api/factories?name=<name> → remove a factory
+func (s *Server) handleFactoriesCRUD(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		s.handleFactoriesList(w, r)
+	case http.MethodPost:
+		s.handleFactoriesPush(w, r)
+	case http.MethodDelete:
+		name := r.URL.Query().Get("name")
+		if name == "" {
+			http.Error(w, "name required", http.StatusBadRequest)
+			return
+		}
+		s.handleFactoryDelete(w, r, name)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+// FactoryPushView is the JSON-safe view of a factory returned by push/list API (secrets masked).
+type FactoryPushView struct {
+	Name             string   `json:"name"`
+	Integration      string   `json:"integration"`
+	Workspace        string   `json:"workspace"`
+	TriggerStatus    string   `json:"trigger_status"`
+	DoneStatus       string   `json:"done_status,omitempty"`
+	Template         string   `json:"template"`
+	Labels           []string `json:"labels,omitempty"`
+	AssignedTo       string   `json:"assigned_to,omitempty"`
+	Enabled          *bool    `json:"enabled,omitempty"`
+	HasWebhookSecret bool     `json:"has_webhook_secret"`
+	WebhookSecretRef string   `json:"webhook_secret_ref,omitempty"`
+	PipelineYAML     string   `json:"pipeline_yaml,omitempty"`
+}
+
+func factoryToPushView(f *types.FactoryConfig) FactoryPushView {
+	return FactoryPushView{
+		Name:             f.Name,
+		Integration:      f.Integration,
+		Workspace:        f.Workspace,
+		TriggerStatus:    f.TriggerStatus,
+		DoneStatus:       f.DoneStatus,
+		Template:         f.Template,
+		Labels:           f.Labels,
+		AssignedTo:       f.AssignedTo,
+		Enabled:          f.Enabled,
+		HasWebhookSecret: f.WebhookSecret != "",
+		WebhookSecretRef: f.WebhookSecretRef,
+		PipelineYAML:     f.PipelineYAML,
+	}
+}
+
+func (s *Server) handleFactoriesList(w http.ResponseWriter, _ *http.Request) {
+	s.mu.RLock()
+	factories := s.hubCfg.Factories
+	s.mu.RUnlock()
+
+	views := make([]FactoryPushView, 0, len(factories))
+	for _, f := range factories {
+		views = append(views, factoryToPushView(f))
+	}
+	jsonOK(w, views)
+}
+
+// FactoryPushRequest is the payload for POST /api/factories.
+type FactoryPushRequest struct {
+	Factories []*types.FactoryConfig `json:"factories"`
+}
+
+func (s *Server) handleFactoriesPush(w http.ResponseWriter, r *http.Request) {
+	var req FactoryPushRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if len(req.Factories) == 0 {
+		http.Error(w, "no factories provided", http.StatusBadRequest)
+		return
+	}
+
+	s.mu.Lock()
+	// Upsert by name — preserve existing webhook secrets for repo-pushed factories
+	existing := make(map[string]*types.FactoryConfig)
+	for _, f := range s.hubCfg.Factories {
+		existing[f.Name] = f
+	}
+	for _, incoming := range req.Factories {
+		if prev, ok := existing[incoming.Name]; ok {
+			// Preserve inline webhook secret if not provided in push
+			if incoming.WebhookSecret == "" && prev.WebhookSecret != "" {
+				incoming.WebhookSecret = prev.WebhookSecret
+			}
+		}
+		existing[incoming.Name] = incoming
+	}
+	updated := make([]*types.FactoryConfig, 0, len(existing))
+	for _, f := range existing {
+		updated = append(updated, f)
+	}
+	s.hubCfg.Factories = updated
+	cfgCopy := *s.hubCfg
+	s.mu.Unlock()
+
+	if err := config.SaveHubConfig(&cfgCopy); err != nil {
+		http.Error(w, "failed to save config: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	views := make([]FactoryPushView, 0, len(req.Factories))
+	for _, f := range req.Factories {
+		views = append(views, factoryToPushView(f))
+	}
+	jsonOK(w, map[string]interface{}{
+		"pushed": len(req.Factories),
+		"factories": views,
+	})
+}
+
+func (s *Server) handleFactoryDelete(w http.ResponseWriter, _ *http.Request, name string) {
+	s.mu.Lock()
+	factories := make([]*types.FactoryConfig, 0, len(s.hubCfg.Factories))
+	found := false
+	for _, f := range s.hubCfg.Factories {
+		if strings.EqualFold(f.Name, name) {
+			found = true
+			continue
+		}
+		factories = append(factories, f)
+	}
+	s.hubCfg.Factories = factories
+	cfgCopy := *s.hubCfg
+	s.mu.Unlock()
+
+	if !found {
+		http.Error(w, "factory not found", http.StatusNotFound)
+		return
+	}
+
+	if err := config.SaveHubConfig(&cfgCopy); err != nil {
+		http.Error(w, "failed to save config: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	jsonOK(w, map[string]string{"deleted": name})
+}

--- a/pkg/hub/factory_api.go
+++ b/pkg/hub/factory_api.go
@@ -139,15 +139,13 @@ func (s *Server) handleFactoriesPush(w http.ResponseWriter, r *http.Request) {
 	}
 	cfgCopy := *s.hubCfg
 	cfgCopy.Factories = updated
+	s.hubCfg = &cfgCopy
 	s.mu.Unlock()
 
 	if err := config.SaveHubConfig(&cfgCopy); err != nil {
 		http.Error(w, "failed to save config: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
-	s.mu.Lock()
-	s.hubCfg.Factories = updated
-	s.mu.Unlock()
 
 	views := make([]FactoryPushView, 0, len(req.Factories))
 	for _, f := range req.Factories {
@@ -170,22 +168,20 @@ func (s *Server) handleFactoryDelete(w http.ResponseWriter, _ *http.Request, nam
 		}
 		factories = append(factories, f)
 	}
-	cfgCopy := *s.hubCfg
-	cfgCopy.Factories = factories
-	s.mu.Unlock()
-
 	if !found {
+		s.mu.Unlock()
 		http.Error(w, "factory not found", http.StatusNotFound)
 		return
 	}
+	cfgCopy := *s.hubCfg
+	cfgCopy.Factories = factories
+	s.hubCfg = &cfgCopy
+	s.mu.Unlock()
 
 	if err := config.SaveHubConfig(&cfgCopy); err != nil {
 		http.Error(w, "failed to save config: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
-	s.mu.Lock()
-	s.hubCfg.Factories = factories
-	s.mu.Unlock()
 
 	jsonOK(w, map[string]string{"deleted": name})
 }

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -34,6 +34,12 @@ type linearWebhookPayload struct {
 			Key  string `json:"key"`
 			Name string `json:"name"`
 		} `json:"team"`
+		Labels []struct {
+			Name string `json:"name"`
+		} `json:"labels,omitempty"`
+		Assignee *struct {
+			Name string `json:"name"`
+		} `json:"assignee,omitempty"`
 	} `json:"data"`
 	UpdatedFrom *struct {
 		State *struct {
@@ -99,11 +105,19 @@ func (s *Server) validateLinearSignature(body []byte, sig string) bool {
 	// Check factory-level secrets
 	if s.hubCfg.Factories != nil {
 		for _, factory := range s.hubCfg.Factories {
-			if factory.Integration != "linear" || factory.WebhookSecret == "" {
+			if factory.Integration != "linear" {
+				continue
+			}
+			// Resolve secret: inline value or named ref
+			secret := factory.WebhookSecret
+			if secret == "" && factory.WebhookSecretRef != "" && s.hubCfg.Secrets != nil {
+				secret = s.hubCfg.Secrets[factory.WebhookSecretRef]
+			}
+			if secret == "" {
 				continue
 			}
 			hasAnySecret = true
-			mac := hmac.New(sha256.New, []byte(factory.WebhookSecret))
+			mac := hmac.New(sha256.New, []byte(secret))
 			mac.Write(body)
 			expected := hex.EncodeToString(mac.Sum(nil))
 			if hmac.Equal([]byte(sig), []byte(expected)) {
@@ -143,6 +157,52 @@ func (s *Server) processLinearEvent(payload linearWebhookPayload) {
 		}
 		if factory.Team != "" && !strings.EqualFold(factory.Team, teamKey) {
 			continue
+		}
+
+		// Labels filter: all configured labels must be present on the issue (AND)
+		if len(factory.Labels) > 0 {
+			issueLabels := map[string]bool{}
+			for _, l := range payload.Data.Labels {
+				issueLabels[strings.ToLower(l.Name)] = true
+			}
+			allMatch := true
+			for _, required := range factory.Labels {
+				if !issueLabels[strings.ToLower(required)] {
+					allMatch = false
+					break
+				}
+			}
+			if !allMatch {
+				continue
+			}
+		}
+
+		// AssignedTo filter
+		if factory.AssignedTo != "" {
+			assignee := ""
+			if payload.Data.Assignee != nil {
+				assignee = payload.Data.Assignee.Name
+			}
+			switch {
+			case factory.AssignedTo == "any":
+				if assignee == "" {
+					continue
+				}
+			case factory.AssignedTo == "none":
+				if assignee != "" {
+					continue
+				}
+			case strings.HasPrefix(factory.AssignedTo, "!"):
+				excluded := strings.TrimPrefix(strings.TrimPrefix(factory.AssignedTo, "!"), "@")
+				if strings.EqualFold(assignee, excluded) {
+					continue
+				}
+			default:
+				wanted := strings.TrimPrefix(factory.AssignedTo, "@")
+				if !strings.EqualFold(assignee, wanted) {
+					continue
+				}
+			}
 		}
 
 		// Issue entering trigger status → create claw.

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -84,11 +84,17 @@ func (s *Server) handleLinearWebhook(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) validateLinearSignature(body []byte, sig string) bool {
+	s.mu.RLock()
+	integrations := s.hubCfg.Integrations
+	factories := s.hubCfg.Factories
+	secrets := s.hubCfg.Secrets
+	s.mu.RUnlock()
+
 	hasAnySecret := false
 
 	// Check integration-level secrets
-	if s.hubCfg.Integrations != nil {
-		for _, li := range s.hubCfg.Integrations.Linear {
+	if integrations != nil {
+		for _, li := range integrations.Linear {
 			if li.WebhookSecret == "" {
 				continue
 			}
@@ -103,15 +109,15 @@ func (s *Server) validateLinearSignature(body []byte, sig string) bool {
 	}
 
 	// Check factory-level secrets
-	if s.hubCfg.Factories != nil {
-		for _, factory := range s.hubCfg.Factories {
+	if factories != nil {
+		for _, factory := range factories {
 			if factory.Integration != "linear" {
 				continue
 			}
 			// Resolve secret: inline value or named ref
 			secret := factory.WebhookSecret
-			if secret == "" && factory.WebhookSecretRef != "" && s.hubCfg.Secrets != nil {
-				secret = s.hubCfg.Secrets[factory.WebhookSecretRef]
+			if secret == "" && factory.WebhookSecretRef != "" && secrets != nil {
+				secret = secrets[factory.WebhookSecretRef]
 			}
 			if secret == "" {
 				continue

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -183,23 +183,24 @@ func (s *Server) processLinearEvent(payload linearWebhookPayload) {
 			if payload.Data.Assignee != nil {
 				assignee = payload.Data.Assignee.Name
 			}
+			wanted := strings.ToLower(strings.TrimSpace(factory.AssignedTo))
 			switch {
-			case factory.AssignedTo == "any":
+			case wanted == "any":
 				if assignee == "" {
 					continue
 				}
-			case factory.AssignedTo == "none":
+			case wanted == "none":
 				if assignee != "" {
 					continue
 				}
-			case strings.HasPrefix(factory.AssignedTo, "!"):
-				excluded := strings.TrimPrefix(strings.TrimPrefix(factory.AssignedTo, "!"), "@")
+			case strings.HasPrefix(wanted, "!"):
+				excluded := strings.TrimPrefix(strings.TrimPrefix(wanted, "!"), "@")
 				if strings.EqualFold(assignee, excluded) {
 					continue
 				}
 			default:
-				wanted := strings.TrimPrefix(factory.AssignedTo, "@")
-				if !strings.EqualFold(assignee, wanted) {
+				target := strings.TrimPrefix(wanted, "@")
+				if !strings.EqualFold(assignee, target) {
 					continue
 				}
 			}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -138,6 +138,7 @@ func (s *Server) Run(opts ...RunOptions) error {
 	mux.HandleFunc("/api/integrations/linear/webhook", s.handleLinearWebhook)
 	mux.HandleFunc("/api/integrations/shortcut/webhook", s.handleShortcutWebhook)
 	mux.HandleFunc("/api/factories/", s.withAuth(s.handleFactoryEvents)) // GET /api/factories/:name/events
+	mux.HandleFunc("/api/factories", s.withAuth(s.handleFactoriesCRUD)) // factory CRUD (GET list, POST push)
 	mux.HandleFunc("/api/claws", s.withAuth(s.handleClaws))
 	mux.HandleFunc("/api/claws/{id}", s.withAuth(s.handleClawDetail))
 	mux.HandleFunc("/api/terminal/", s.handleTerminal)

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -68,8 +68,12 @@ type FactoryView struct {
 	Template         string   `json:"template"`
 	NamePattern      string   `json:"namePattern"`
 	WebhookSecretSet bool     `json:"webhookSecretSet"`
+	WebhookSecretRef string   `json:"webhookSecretRef,omitempty"`
+	PipelineYAML     string   `json:"pipelineYAML,omitempty"`
 	Tags             []string `json:"tags"`
 	Color            string   `json:"color"`
+	Labels           []string `json:"labels,omitempty"`
+	AssignedTo       string   `json:"assigned_to,omitempty"`
 	Enabled          bool     `json:"enabled"`
 }
 
@@ -145,8 +149,12 @@ type FactoryPatch struct {
 	Template         string   `json:"template"`
 	NamePattern      string   `json:"namePattern,omitempty"`
 	WebhookSecret    string   `json:"webhookSecret,omitempty"`
+	WebhookSecretRef string   `json:"webhookSecretRef,omitempty"`
+	PipelineYAML     string   `json:"pipelineYAML,omitempty"`
 	Tags             []string `json:"tags,omitempty"`
 	Color            string   `json:"color,omitempty"`
+	Labels           []string `json:"labels,omitempty"`
+	AssignedTo       string   `json:"assigned_to,omitempty"`
 	Enabled          *bool    `json:"enabled,omitempty"`
 }
 
@@ -279,9 +287,13 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 			TerminateOnLeave: f.TerminateOnLeave,
 			Template:         f.Template,
 			NamePattern:      f.NamePattern,
-			WebhookSecretSet: f.WebhookSecret != "",
+			WebhookSecretSet: f.WebhookSecret != "" || f.WebhookSecretRef != "",
+			WebhookSecretRef: f.WebhookSecretRef,
+			PipelineYAML:     f.PipelineYAML,
 			Tags:             f.Tags,
 			Color:            f.Color,
+			Labels:           f.Labels,
+			AssignedTo:       f.AssignedTo,
 			Enabled:          isFactoryEnabled(f),
 		})
 	}
@@ -539,7 +551,9 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 				TriggerStatus: fp.TriggerStatus, DoneStatus: fp.DoneStatus,
 				TerminateOnLeave: fp.TerminateOnLeave, Template: fp.Template,
 				NamePattern: fp.NamePattern, WebhookSecret: webhookSecret,
-				Tags: fp.Tags, Color: fp.Color, Enabled: fp.Enabled,
+				WebhookSecretRef: fp.WebhookSecretRef, PipelineYAML: fp.PipelineYAML,
+				Tags: fp.Tags, Color: fp.Color, Labels: fp.Labels,
+				AssignedTo: fp.AssignedTo, Enabled: fp.Enabled,
 			})
 		}
 		updatedCfg.Factories = factories

--- a/pkg/hub/shortcut.go
+++ b/pkg/hub/shortcut.go
@@ -36,6 +36,13 @@ type shortcutAction struct {
 	Changes     map[string]shortcutChange `json:"changes"`
 }
 
+type shortcutStoryFilterData struct {
+	labels    map[string]bool
+	assignees map[string]bool
+	hasOwner  bool
+	loadErr   error
+}
+
 type shortcutChange struct {
 	New interface{} `json:"new"`
 	Old interface{} `json:"old"`
@@ -139,6 +146,8 @@ func (s *Server) processShortcutEvent(payload shortcutWebhookPayload) {
 			continue
 		}
 
+		storyFiltersByToken := map[string]*shortcutStoryFilterData{}
+
 		// Check if workflow_state_id changed
 		stateChange, ok := action.Changes["workflow_state_id"]
 		if !ok {
@@ -161,6 +170,67 @@ func (s *Server) processShortcutEvent(payload shortcutWebhookPayload) {
 			token := s.resolveShortcutToken(factory.Workspace)
 			if token == "" {
 				continue
+			}
+
+			if len(factory.Labels) > 0 || factory.AssignedTo != "" {
+				filterData, ok := storyFiltersByToken[token]
+				if !ok {
+					filterData = s.loadShortcutStoryFilterData(token, action.ID)
+					storyFiltersByToken[token] = filterData
+				}
+				if filterData.loadErr != nil {
+					log.Printf("[factory:%s] skipping story %s: failed to load Shortcut story filters: %v", factory.Name, storyID, filterData.loadErr)
+					continue
+				}
+
+				// Labels filter: all configured labels must be present on the story (AND)
+				if len(factory.Labels) > 0 {
+					allMatch := true
+					for _, required := range factory.Labels {
+						required = strings.ToLower(strings.TrimSpace(required))
+						if required == "" {
+							continue
+						}
+						if !filterData.labels[required] {
+							allMatch = false
+							break
+						}
+					}
+					if !allMatch {
+						continue
+					}
+				}
+
+				// AssignedTo filter
+				if factory.AssignedTo != "" {
+					wanted := strings.ToLower(strings.TrimSpace(factory.AssignedTo))
+					switch {
+					case wanted == "any":
+						if !filterData.hasOwner {
+							continue
+						}
+					case wanted == "none":
+						if filterData.hasOwner {
+							continue
+						}
+					case strings.HasPrefix(wanted, "!"):
+						excluded := strings.TrimPrefix(strings.TrimPrefix(wanted, "!"), "@")
+						if excluded == "" {
+							continue
+						}
+						if filterData.assignees[excluded] {
+							continue
+						}
+					default:
+						target := strings.TrimPrefix(wanted, "@")
+						if target == "" {
+							continue
+						}
+						if !filterData.assignees[target] {
+							continue
+						}
+					}
+				}
 			}
 
 			newStateName := s.shortcutStateName(token, newStateID)
@@ -195,6 +265,87 @@ func (s *Server) processShortcutEvent(payload shortcutWebhookPayload) {
 						"", fmt.Sprintf("status '%s'→'%s' did not match trigger '%s'", oldStateName, newStateName, factory.TriggerStatus))
 				}
 			}
+		}
+	}
+}
+
+func (s *Server) loadShortcutStoryFilterData(token string, storyID int64) *shortcutStoryFilterData {
+	data := &shortcutStoryFilterData{
+		labels:    map[string]bool{},
+		assignees: map[string]bool{},
+	}
+	story, err := shortcutAPI(fmt.Sprintf("stories/%d", storyID), token)
+	if err != nil {
+		data.loadErr = err
+		return data
+	}
+
+	if rawLabels, ok := story["labels"].([]interface{}); ok {
+		for _, item := range rawLabels {
+			m, ok := item.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			labelName, _ := m["name"].(string)
+			labelName = strings.ToLower(strings.TrimSpace(labelName))
+			if labelName != "" {
+				data.labels[labelName] = true
+			}
+		}
+	}
+
+	var ownerIDs []string
+	if rawOwners, ok := story["owner_ids"].([]interface{}); ok {
+		for _, raw := range rawOwners {
+			ownerID, ok := raw.(string)
+			if !ok {
+				continue
+			}
+			ownerID = strings.TrimSpace(ownerID)
+			if ownerID == "" {
+				continue
+			}
+			ownerIDs = append(ownerIDs, ownerID)
+			data.assignees[strings.ToLower(ownerID)] = true
+		}
+	}
+	data.hasOwner = len(ownerIDs) > 0
+
+	for _, ownerID := range ownerIDs {
+		member, err := shortcutAPI("members/"+ownerID, token)
+		if err != nil {
+			continue
+		}
+		collectShortcutAssigneeIdentifiers(data.assignees, member)
+	}
+
+	return data
+}
+
+func collectShortcutAssigneeIdentifiers(set map[string]bool, member map[string]interface{}) {
+	add := func(value string) {
+		value = strings.ToLower(strings.TrimSpace(value))
+		if value == "" {
+			return
+		}
+		set[value] = true
+		if strings.HasPrefix(value, "@") {
+			set[strings.TrimPrefix(value, "@")] = true
+		}
+	}
+
+	if mentionName, ok := member["mention_name"].(string); ok {
+		add(mentionName)
+	}
+	if name, ok := member["name"].(string); ok {
+		add(name)
+	}
+	if profile, ok := member["profile"].(map[string]interface{}); ok {
+		if mentionName, ok := profile["mention_name"].(string); ok {
+			add(mentionName)
+		}
+		if name, ok := profile["name"].(string); ok {
+			add(name)
 		}
 	}
 }

--- a/pkg/hub/shortcut.go
+++ b/pkg/hub/shortcut.go
@@ -49,14 +49,22 @@ func (s *Server) validateShortcutSignature(body []byte, sig string) bool {
 	sig = strings.TrimPrefix(sig, "sha256=")
 	s.mu.RLock()
 	factories := s.hubCfg.Factories
+	secrets := s.hubCfg.Secrets
 	s.mu.RUnlock()
 	hasSecrets := false
 	for _, f := range factories {
-		if f.Integration != "shortcut" || f.WebhookSecret == "" {
+		if f.Integration != "shortcut" {
+			continue
+		}
+		secret := f.WebhookSecret
+		if secret == "" && f.WebhookSecretRef != "" && secrets != nil {
+			secret = secrets[f.WebhookSecretRef]
+		}
+		if secret == "" {
 			continue
 		}
 		hasSecrets = true
-		mac := hmac.New(sha256.New, []byte(f.WebhookSecret))
+		mac := hmac.New(sha256.New, []byte(secret))
 		mac.Write(body)
 		expected := hex.EncodeToString(mac.Sum(nil))
 		if hmac.Equal([]byte(sig), []byte(expected)) {

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -210,6 +210,8 @@ type HubConfig struct {
 
 	// Factories defines automation rules that spin up claws based on integration events.
 	Factories []*FactoryConfig `yaml:"factories,omitempty"`
+	// Secrets is a named map of secret values referenced by factories via webhook_secret_ref.
+	Secrets map[string]string `yaml:"secrets,omitempty"`
 }
 
 // IntegrationsConfig holds configs for external integrations.
@@ -246,6 +248,14 @@ type FactoryConfig struct {
 	WebhookSecret     string   `yaml:"webhook_secret,omitempty"` // HMAC-SHA256 secret for validating webhooks
 	Tags              []string `yaml:"tags,omitempty"`          // tags applied to created claws
 	Color             string   `yaml:"color,omitempty"`         // color applied to created claws
+	// Labels: all must be present on the issue to trigger (AND)
+	Labels []string `yaml:"labels,omitempty"`
+	// AssignedTo filter: "@user", "!@user" (exclude), "any", "none"
+	AssignedTo string `yaml:"assigned_to,omitempty"`
+	// WebhookSecretRef is a named key in HubConfig.Secrets (use instead of inline WebhookSecret for repo-defined factories)
+	WebhookSecretRef string `yaml:"webhook_secret_ref,omitempty"`
+	// PipelineYAML is the raw pipeline.yaml content stored alongside this factory
+	PipelineYAML string `yaml:"pipeline_yaml,omitempty"`
 }
 
 type ProviderConfig struct {

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -38,7 +38,7 @@ interface SettingsData {
   factories?: Array<{
     name: string; integration: string; workspace: string; team: string
     triggerStatus: string; doneStatus: string; terminateOnLeave: boolean; template: string
-    webhookSecretSet?: boolean; tags?: string[]; color?: string; enabled?: boolean
+    webhookSecretSet?: boolean; tags?: string[]; color?: string; enabled?: boolean; labels?: string[]; assigned_to?: string
   }>
 }
 
@@ -767,59 +767,14 @@ function ShortcutIntegrationsBlock({ settings, onSave, saving }: { settings: Set
   )
 }
 
-interface FactoryFormData {
-  name: string; workspace: string; team: string
-  triggerStatus: string; doneStatus: string; terminateOnLeave: boolean; template: string
-  webhookSecret: string; tags: string; color: string; originalName?: string
-}
-
 function FactoriesSection({ hubUrl, settings, onSave, onSaveSilent, saving }: { hubUrl: string; settings: SettingsData; onSave: (p: object) => Promise<boolean>; onSaveSilent: (p: object) => void; saving: boolean }) {
   const [savedFactory, setSavedFactory] = useState<string | null>(null)
-  const [generatedSecret, setGeneratedSecret] = useState<string>(() => {
-    // Generate a random hex secret for Shortcut webhook signing
-    const bytes = new Uint8Array(32)
-    crypto.getRandomValues(bytes)
-    return Array.from(bytes).map(b => b.toString(16).padStart(2, "0")).join("")
-  })
-  const [secretCopied, setSecretCopied] = useState(false)
-  const copySecret = () => {
-    navigator.clipboard.writeText(generatedSecret).then(() => { setSecretCopied(true); setTimeout(() => setSecretCopied(false), 2000) })
-  }
   const factories = settings.factories || []
-  const [availableTemplates, setAvailableTemplates] = useState<string[]>([])
-  useEffect(() => {
-    const hubUrl = getHubUrl()
-    const token = sessionStorage.getItem("ec_hub_token") || ""
-    fetch(`${hubUrl}/api/templates`, { headers: { Authorization: `Bearer ${token}` } })
-      .then(r => r.json())
-      .then((d: Array<{ name: string }>) => setAvailableTemplates(d.map(t => t.name)))
-      .catch(() => {})
-  }, [])
   const [copied, setCopied] = useState(false)
   const webhookUrl = hubUrl ? `${hubUrl}/api/integrations/linear/webhook` : ""
   const handleCopy = () => {
     if (!webhookUrl) return
     navigator.clipboard.writeText(webhookUrl).then(() => { setCopied(true); setTimeout(() => setCopied(false), 2000) })
-  }
-  const [editingFactory, setEditingFactory] = useState<number | null>(null)
-  const [editForm, setEditForm] = useState<FactoryFormData>({ name: "", workspace: "", team: "", triggerStatus: "", doneStatus: "", terminateOnLeave: true, template: "", webhookSecret: "", tags: "", color: "", originalName: "" })
-  const [form, setForm] = useState<FactoryFormData>({
-    name: "", workspace: "", team: "", triggerStatus: "Ready for Agent",
-    doneStatus: "In Review", terminateOnLeave: true, template: "base", webhookSecret: "", tags: "", color: ""
-  })
-
-  const formIntegration = form.workspace.startsWith("shortcut:") ? "shortcut" : "linear"
-  const workspaces = [
-    ...(settings.integrations?.linear?.map(l => ({ label: `Linear: ${l.workspace}`, value: `linear:${l.workspace}` })) || []),
-    ...(settings.integrations?.shortcut?.map(s => ({ label: `Shortcut: ${s.workspace}`, value: `shortcut:${s.workspace}` })) || []),
-  ]
-
-  function update(k: keyof FactoryFormData, v: string | boolean) {
-    if (k === "workspace" && typeof v === "string" && v.startsWith("shortcut:")) {
-      setForm(prev => ({ ...prev, workspace: v, team: "", webhookSecret: "" }))
-      return
-    }
-    setForm(prev => ({ ...prev, [k]: v }))
   }
 
   return (
@@ -864,230 +819,65 @@ function FactoriesSection({ hubUrl, settings, onSave, onSaveSilent, saving }: { 
         </div>
       </div>
 
+      {/* Factories-as-code callout */}
+      <div className="rounded-lg border border-border bg-muted/30 p-4 text-sm">
+        <p className="font-medium mb-1">Factories are managed as code</p>
+        <p className="text-muted-foreground text-xs">
+          Define factories in <code className="bg-muted px-1 rounded">.elasticclaw/factories/</code> and push to this hub with{" "}
+          <code className="bg-muted px-1 rounded">elasticclaw factory push</code>.
+          Use <code className="bg-muted px-1 rounded">elasticclaw factory create</code> to scaffold a new factory.
+        </p>
+      </div>
+
       {factories.length > 0 && (
-        <div className="space-y-2 mb-6">
+        <div className="space-y-2">
           {factories.map((f, i) => (
-            <div key={i}>
-              {editingFactory === i ? (
-                <div className="border border-primary/40 rounded-lg p-4 space-y-3 bg-primary/5">
-                  <h4 className="text-sm font-semibold">Edit: {f.name}</h4>
-                  <div className="grid grid-cols-2 gap-3">
-                    <div>
-                      <label className="text-xs text-muted-foreground mb-1 block">Name</label>
-                      <Input value={editForm.name} onChange={e => setEditForm(p => ({...p, name: e.target.value}))} className="h-8 text-sm" />
-                    </div>
-                    {f.integration !== "shortcut" && (
-                    <div>
-                      <label className="text-xs text-muted-foreground mb-1 block">Team key <span className="text-muted-foreground/60">(optional)</span></label>
-                      <Input value={editForm.team} onChange={e => setEditForm(p => ({...p, team: e.target.value}))} className="h-8 text-sm" placeholder="ELA" />
-                    </div>
-                    )}
-                    <div>
-                      <label className="text-xs text-muted-foreground mb-1 block">Trigger status</label>
-                      <Input value={editForm.triggerStatus} onChange={e => setEditForm(p => ({...p, triggerStatus: e.target.value}))} className="h-8 text-sm" />
-                    </div>
-                    <div>
-                      <label className="text-xs text-muted-foreground mb-1 block">Done status</label>
-                      <Input value={editForm.doneStatus} onChange={e => setEditForm(p => ({...p, doneStatus: e.target.value}))} className="h-8 text-sm" />
-                    </div>
-                    <div>
-                      <label className="text-xs text-muted-foreground mb-1 block">Template</label>
-                      {availableTemplates.length > 0 ? (
-                        <select value={editForm.template} onChange={e => setEditForm(p => ({...p, template: e.target.value}))}
-                          className="w-full h-8 rounded-md border border-border bg-background px-2 text-sm">
-                          <option value="">Select template</option>
-                          {availableTemplates.map(t => <option key={t} value={t}>{t}</option>)}
-                        </select>
-                      ) : (
-                        <Input value={editForm.template} onChange={e => setEditForm(p => ({...p, template: e.target.value}))} className="h-8 text-sm" />
-                      )}
-                    </div>
-                    {f.integration === "shortcut" ? (
-                    <div>
-                      <label className="text-xs text-muted-foreground mb-1 block">Webhook Secret</label>
-                      <p className="text-xs text-muted-foreground mb-1">{f.webhookSecretSet ? "Set — enter a new value to rotate it." : "Not set — enter a value to set it."}</p>
-                      <Input type="password" value={editForm.webhookSecret} onChange={e => setEditForm(p => ({...p, webhookSecret: e.target.value}))} className="h-8 text-sm" placeholder="(generate a new secret or leave blank to keep)" />
-                    </div>
-                    ) : (
-                    <div>
-                      <label className="text-xs text-muted-foreground mb-1 block">Webhook Signing Secret</label>
-                      <Input type="password" value={editForm.webhookSecret} onChange={e => setEditForm(p => ({...p, webhookSecret: e.target.value}))} className="h-8 text-sm" placeholder="whsec_... (leave blank to keep)" />
-                    </div>
-                    )}
-                    <div>
-                      <label className="text-xs text-muted-foreground mb-1 block">Tags <span className="text-muted-foreground/60">(comma-separated)</span></label>
-                      <Input value={editForm.tags} onChange={e => setEditForm(p => ({...p, tags: e.target.value}))} className="h-8 text-sm" placeholder={f.integration === "shortcut" ? "shortcut, feature" : "linear, feature"} />
-                    </div>
-                    <div>
-                      <label className="text-xs text-muted-foreground mb-1 block">Color</label>
-                      <Input value={editForm.color} onChange={e => setEditForm(p => ({...p, color: e.target.value}))} className="h-8 text-sm" placeholder="teal, coral, amber…" />
-                    </div>
-                  </div>
-                  <label className="flex items-center gap-2 text-sm cursor-pointer">
-                    <input type="checkbox" checked={editForm.terminateOnLeave} onChange={e => setEditForm(p => ({...p, terminateOnLeave: e.target.checked}))} />
-                    Terminate claw when issue leaves trigger status
-                  </label>
-                  <div className="flex gap-2">
-                    <Button size="sm" disabled={saving} onClick={() => {
-                      const { webhookSecret, tags: tagsStr, color, originalName, ...rest } = editForm
-                      const tags = tagsStr.split(",").map(t => t.trim()).filter(Boolean)
-                      const updated = factories.map((x, j) => j === i ? { ...x, ...rest, ...(originalName ? { originalName } : {}), ...(webhookSecret ? { webhookSecret } : {}), tags, color } : x)
-                      onSave({ factories: updated })
-                      setEditingFactory(null)
-                    }}>Save</Button>
-                    <Button size="sm" variant="outline" onClick={() => setEditingFactory(null)}>Cancel</Button>
-                    <Button size="sm" variant="ghost" className="text-destructive hover:text-destructive ml-auto" disabled={saving}
-                      onClick={() => { onSave({ factories: factories.filter((_, j) => j !== i) }); setEditingFactory(null) }}>
-                      Remove
-                    </Button>
-                  </div>
+            <div key={i} className={cn("border rounded-lg p-4 flex items-center justify-between", (f.enabled ?? true) ? "border-border" : "border-border/50 opacity-60")}>
+              <div>
+                <div className="flex items-center gap-2">
+                  <p className="text-sm font-medium">{f.name}</p>
+                  {!(f.enabled ?? true) && <span className="text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded">paused</span>}
                 </div>
-              ) : (
-                <div className={cn("border rounded-lg p-4 flex items-center justify-between", (f.enabled ?? true) ? "border-border" : "border-border/50 opacity-60")}>
-                  <div>
-                    <div className="flex items-center gap-2">
-                      <p className="text-sm font-medium">{f.name}</p>
-                      {!(f.enabled ?? true) && <span className="text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded">paused</span>}
-                    </div>
-                    <p className="text-xs text-muted-foreground">
-                      {f.integration} · {f.team || f.workspace} · "{f.triggerStatus}" → {f.template}
-                      {" · webhook: "}{f.webhookSecretSet ? <span className="text-green-500">✓</span> : <span className="text-amber-500">not set</span>}
-                    </p>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    {/* Toggle switch — uses silent save to avoid global 'Saved' banner */}
-                    {savedFactory === f.name && (
-                      <span className="text-xs text-green-500">✓</span>
-                    )}
-                    <button
-                      onClick={async () => {
-                        const enabled = !(f.enabled ?? true)
-                        const updated = factories.map((x, j) => j === i ? { ...x, enabled } : x)
-                        setSavedFactory(f.name)
-                        setTimeout(() => setSavedFactory(null), 1500)
-                        onSaveSilent({ factories: updated })
-                      }}
-                      className={cn(
-                        "relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full transition-colors duration-200",
-                        (f.enabled ?? true)
-                          ? "bg-green-600 border-2 border-transparent"
-                          : "bg-transparent border-2 border-muted-foreground/40"
-                      )}
-                      title={(f.enabled ?? true) ? "Pause factory" : "Enable factory"}
-                    >
-                      <span className={cn(
-                        "pointer-events-none inline-block size-4 rounded-full shadow-sm transform transition-transform duration-200",
-                        (f.enabled ?? true)
-                          ? "bg-white translate-x-4"
-                          : "bg-muted-foreground/50 translate-x-0"
-                      )} />
-                    </button>
-                    <Button size="sm" variant="outline" onClick={() => window.open(`/factories?name=${encodeURIComponent(f.name)}`, '_self')}>Activity</Button>
-                    <Button size="sm" variant="outline" onClick={() => {
-                      setEditingFactory(i)
-                      setEditForm({ name: f.name, workspace: f.workspace, team: f.team || "", triggerStatus: f.triggerStatus, doneStatus: f.doneStatus || "", terminateOnLeave: f.terminateOnLeave, template: f.template, webhookSecret: "", tags: (f.tags || []).join(", "), color: f.color || "", originalName: f.name })
-                    }}>Edit</Button>
-                  </div>
-                </div>
-              )}
+                <p className="text-xs text-muted-foreground">
+                  {f.integration} · {f.workspace} · &ldquo;{f.triggerStatus}&rdquo; → {f.template}
+                  {f.labels && f.labels.length > 0 && ` · labels: ${f.labels.join(", ")}`}
+                  {f.assigned_to && ` · assigned: ${f.assigned_to}`}
+                  {" · webhook: "}{f.webhookSecretSet ? <span className="text-green-500">✓</span> : <span className="text-amber-500">not set</span>}
+                </p>
+              </div>
+              <div className="flex items-center gap-2">
+                {savedFactory === f.name && (
+                  <span className="text-xs text-green-500">✓</span>
+                )}
+                <button
+                  onClick={async () => {
+                    const enabled = !(f.enabled ?? true)
+                    const updated = factories.map((x, j) => j === i ? { ...x, enabled } : x)
+                    setSavedFactory(f.name)
+                    setTimeout(() => setSavedFactory(null), 1500)
+                    onSaveSilent({ factories: updated })
+                  }}
+                  className={cn(
+                    "relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full transition-colors duration-200",
+                    (f.enabled ?? true)
+                      ? "bg-green-600 border-2 border-transparent"
+                      : "bg-transparent border-2 border-muted-foreground/40"
+                  )}
+                  title={(f.enabled ?? true) ? "Pause factory" : "Enable factory"}
+                >
+                  <span className={cn(
+                    "pointer-events-none inline-block size-4 rounded-full shadow-sm transform transition-transform duration-200",
+                    (f.enabled ?? true)
+                      ? "bg-white translate-x-4"
+                      : "bg-muted-foreground/50 translate-x-0"
+                  )} />
+                </button>
+                <Button size="sm" variant="outline" onClick={() => window.open(`/factories?name=${encodeURIComponent(f.name)}`, '_self')}>Activity</Button>
+              </div>
             </div>
           ))}
         </div>
       )}
-
-      <div className="border border-border rounded-lg p-5 space-y-4">
-        <h3 className="text-sm font-semibold">New Factory</h3>
-        <div className="grid grid-cols-2 gap-3">
-          <div>
-            <label className="text-xs text-muted-foreground mb-1 block">Factory name</label>
-            <Input value={form.name} onChange={e => update("name", e.target.value)} className="h-8 text-sm" placeholder="ELA feature work" />
-          </div>
-          <div>
-            <label className="text-xs text-muted-foreground mb-1 block">Workspace</label>
-            <select value={form.workspace} onChange={e => update("workspace", e.target.value)}
-              className="w-full h-8 rounded-md border border-border bg-background px-2 text-sm">
-              <option value="">Select workspace</option>
-              {workspaces.map(w => <option key={w.value} value={w.value}>{w.label}</option>)}
-            </select>
-          </div>
-          {formIntegration === "linear" && (
-          <div>
-            <label className="text-xs text-muted-foreground mb-1 block">Team key <span className="text-muted-foreground/60">(optional)</span></label>
-            <Input value={form.team} onChange={e => update("team", e.target.value)} className="h-8 text-sm" placeholder="ELA" />
-          </div>
-          )}
-          <div>
-            <label className="text-xs text-muted-foreground mb-1 block">Template</label>
-            {availableTemplates.length > 0 ? (
-              <select value={form.template} onChange={e => update("template", e.target.value)}
-                className="w-full h-8 rounded-md border border-border bg-background px-2 text-sm">
-                <option value="">Select template</option>
-                {availableTemplates.map(t => <option key={t} value={t}>{t}</option>)}
-              </select>
-            ) : (
-              <Input value={form.template} onChange={e => update("template", e.target.value)} className="h-8 text-sm" placeholder="base (push templates first)" />
-            )}
-          </div>
-          <div>
-            <label className="text-xs text-muted-foreground mb-1 block">Trigger status</label>
-            <Input value={form.triggerStatus} onChange={e => update("triggerStatus", e.target.value)} className="h-8 text-sm" />
-          </div>
-          <div>
-            <label className="text-xs text-muted-foreground mb-1 block">Done status</label>
-            <Input value={form.doneStatus} onChange={e => update("doneStatus", e.target.value)} className="h-8 text-sm" />
-          </div>
-        </div>
-        <label className="flex items-center gap-2 text-sm cursor-pointer">
-          <input type="checkbox" checked={form.terminateOnLeave} onChange={e => update("terminateOnLeave", e.target.checked)} />
-          Terminate claw when issue leaves trigger status
-        </label>
-        {formIntegration === "linear" ? (
-          <div>
-            <label className="text-xs text-muted-foreground mb-1 block">Webhook Signing Secret</label>
-            <Input type="password" value={form.webhookSecret} onChange={e => update("webhookSecret", e.target.value)} className="h-8 text-sm" placeholder="whsec_... from Linear webhook settings" />
-          </div>
-        ) : (
-          <div>
-            <label className="text-xs text-muted-foreground mb-1.5 block">Webhook Signing Secret</label>
-            <p className="text-xs text-muted-foreground mb-2">Copy this secret and include it as <code className="bg-muted px-1 rounded">secret</code> when registering your Shortcut webhook.</p>
-            <div className="flex items-center gap-2">
-              <code className="flex-1 text-xs font-mono bg-muted px-3 py-2 rounded-md border border-border truncate select-all">{generatedSecret}</code>
-              <Button variant="outline" size="sm" className="shrink-0" onClick={copySecret}>
-                {secretCopied ? <Check className="size-3.5 text-green-500" /> : <Copy className="size-3.5" />}
-                <span className="ml-1.5">{secretCopied ? "Copied" : "Copy"}</span>
-              </Button>
-            </div>
-          </div>
-        )}
-        <div className="grid grid-cols-2 gap-3">
-          <div>
-            <label className="text-xs text-muted-foreground mb-1 block">Tags <span className="text-muted-foreground/60">(comma-separated)</span></label>
-            <Input value={form.tags} onChange={e => update("tags", e.target.value)} className="h-8 text-sm" placeholder={formIntegration === "shortcut" ? "shortcut, feature" : "linear, feature"} />
-          </div>
-          <div>
-            <label className="text-xs text-muted-foreground mb-1 block">Color</label>
-            <Input value={form.color} onChange={e => update("color", e.target.value)} className="h-8 text-sm" placeholder="teal, coral, amber…" />
-          </div>
-        </div>
-        <Button size="sm" disabled={saving || !form.name || !form.workspace || !form.template || !form.triggerStatus}
-          onClick={async () => {
-            const { webhookSecret, tags: tagsStr, color, ...rest } = form
-            const tags = tagsStr.split(",").map(t => t.trim()).filter(Boolean)
-            // Determine integration type from workspace value prefix
-            const integration = form.workspace.startsWith("shortcut:") ? "shortcut" : "linear"
-            const workspaceName = form.workspace.includes(":") ? form.workspace.split(":")[1] : form.workspace
-            // For Shortcut, use the generated secret (user copies it to their webhook registration)
-            const effectiveSecret = integration === "shortcut" ? generatedSecret : webhookSecret
-            const saved = await onSave({ factories: [...factories, { ...rest, workspace: workspaceName, integration, ...(effectiveSecret ? { webhookSecret: effectiveSecret } : {}), ...(tags.length ? { tags } : {}), ...(color ? { color } : {}) }] })
-            if (!saved) return
-            // Regenerate secret for next Shortcut factory
-            const newBytes = new Uint8Array(32); crypto.getRandomValues(newBytes)
-            setGeneratedSecret(Array.from(newBytes).map(b => b.toString(16).padStart(2, "0")).join(""))
-            setForm({ name: "", workspace: "", team: "", triggerStatus: "Ready for Agent", doneStatus: "In Review", terminateOnLeave: true, template: "base", webhookSecret: "", tags: "", color: "" })
-          }}>
-          Add Factory
-        </Button>
-      </div>
     </div>
   )
 }


### PR DESCRIPTION
Implements the factory-as-code spec from https://gist.github.com/marccampbell/a7dabef9c707ab7b086945c74c87f0e0

## What's in this PR

**New trigger filters:**
- `labels: [bug, claw-ready]` — all labels must be present (AND)
- `assigned_to: "@user"` / `"!@user"` / `"any"` / `"none"`
- `webhook_secret_ref: my_secret_name` — reference a named secret from hub.yaml `secrets:` map instead of inline value

**Hub API:**
- `POST /api/factories` — upsert batch from `factory push`
- `GET /api/factories` — list all factories (secrets masked)
- `DELETE /api/factories?name=<name>` — remove a factory

**CLI:**
- `elasticclaw factory create` — interactive wizard that generates `.elasticclaw/factories/<name>/factory.yaml` + `pipeline.yaml`
- `elasticclaw factory push [name]` — push factories from repo to hub
- `elasticclaw factory list` — list what's on the hub
- `elasticclaw factory show <name>` — show factory config
- `elasticclaw factory rm <name>` — remove from hub

**Factory push** reads both `factory.yaml` and `pipeline.yaml` from each factory directory and stores the pipeline YAML on the hub for future pipeline execution support.