### PR TITLE
feat: add hub role for system-injected messages

### DIFF
--- a/cmd/factory.go
+++ b/cmd/factory.go
@@ -375,13 +375,13 @@ func resolveHubConn() (hubURL, clawToken string, err error) {
 	clawToken = os.Getenv("ELASTICCLAW_CLAW_TOKEN")
 
 	if hubURL == "" || clawToken == "" {
-		cfg, cfgErr := config.LoadHubConfig()
-		if cfgErr == nil && cfg != nil {
+		h, _, resolveErr := config.ResolveHub(profile)
+		if resolveErr == nil && h != nil {
 			if hubURL == "" {
-				hubURL = cfg.URL
+				hubURL = h.URL
 			}
 			if clawToken == "" {
-				clawToken = cfg.ClawToken
+				clawToken = h.Token
 			}
 		}
 	}

--- a/cmd/hub_upgrade.go
+++ b/cmd/hub_upgrade.go
@@ -28,8 +28,8 @@ func init() {
 
 func runHubUpgrade(cmd *cobra.Command, args []string) error {
 	if hubUpgradeServer == "" {
-		// Try to infer from active profile's hub URL
-		hubUpgradeServer = inferSSHFromProfile()
+		// Try to infer from --profile (or active profile)
+		hubUpgradeServer = inferSSHFromProfile(profile)
 	}
 	if hubUpgradeServer == "" {
 		return fmt.Errorf("--server required, e.g. --server ssh://root@elasticclaw.example.com")
@@ -102,9 +102,10 @@ fi
 	return nil
 }
 
-// inferSSHFromProfile tries to guess the SSH target from the active profile's hub URL.
-func inferSSHFromProfile() string {
-	hubProfile, _, err := config.ResolveHub("")
+// inferSSHFromProfile tries to guess the SSH target from the given profile's hub URL.
+// Pass "" to use the active profile.
+func inferSSHFromProfile(profileName string) string {
+	hubProfile, _, err := config.ResolveHub(profileName)
 	if err != nil || hubProfile == nil || hubProfile.URL == "" {
 		return ""
 	}

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -31,7 +31,7 @@ func parsePipelineForFactory(factory *types.FactoryConfig) *pipeline.Pipeline {
 // move is skipped silently.
 func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, factory *types.FactoryConfig, issueID string) {
 	if stage.OnEnter.Inject != "" {
-		s.injectUserMessage(clawID, strings.TrimRight(stage.OnEnter.Inject, "\n"))
+		s.injectHubMessageByID(clawID, strings.TrimRight(stage.OnEnter.Inject, "\n"))
 	}
 
 	if stage.OnEnter.MoveIssue == "" || factory == nil || issueID == "" {

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -329,7 +329,7 @@ func (s *Server) checkPRComments(pr clawPR, commentsData []interface{}, skipBugb
 	}
 
 	log.Printf("[pr-watcher] forwarding %d new comment(s) to claw %s", len(newComments), pr.clawID[:8])
-	s.injectUserMessage(pr.clawID, strings.Join(newComments, "\n\n"))
+	s.injectHubMessageByID(pr.clawID, strings.Join(newComments, "\n\n"))
 }
 
 // checkBugbotComments polls PR review comments for new bugbot entries.
@@ -388,10 +388,20 @@ func (s *Server) updatePRCommentWatermark(pr clawPR, commentsData []interface{})
 // and forwards it over the WS connection (if connected) so the agent sees it.
 // Skips injection if the claw is currently streaming a response.
 func (s *Server) injectUserMessage(clawID, content string) {
-	s.injectUserMessageWithRetry(clawID, content, 0)
+	s.injectMessageWithRetry(clawID, content, "user", 0)
+}
+
+// injectHubMessageByID inserts a hub-role message into the claw's conversation.
+// Hub messages are system-injected and rendered distinctly in the UI.
+func (s *Server) injectHubMessageByID(clawID, content string) {
+	s.injectMessageWithRetry(clawID, content, "hub", 0)
 }
 
 func (s *Server) injectUserMessageWithRetry(clawID, content string, retryCount int) {
+	s.injectMessageWithRetry(clawID, content, "user", retryCount)
+}
+
+func (s *Server) injectMessageWithRetry(clawID, content, role string, retryCount int) {
 	// Don't interrupt a response in progress
 	s.mu.RLock()
 	cc, connected := s.claws[clawID]
@@ -403,7 +413,7 @@ func (s *Server) injectUserMessageWithRetry(clawID, content string, retryCount i
 			// Retry once after 30s
 			go func() {
 				time.Sleep(30 * time.Second)
-				s.injectUserMessageWithRetry(clawID, content, retryCount+1)
+				s.injectMessageWithRetry(clawID, content, role, retryCount+1)
 			}()
 		} else {
 			log.Printf("[pr-watcher] claw %s still streaming after retry, dropping message", clawID[:8])
@@ -420,7 +430,7 @@ func (s *Server) injectUserMessageWithRetry(clawID, content string, retryCount i
 	msgID := uuid.New().String()
 	_, err := s.db.Exec(
 		`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at) VALUES(?,?,?,?,?,?)`,
-		msgID, clawID, tenantID, "user", content, now(),
+		msgID, clawID, tenantID, role, content, now(),
 	)
 	if err != nil {
 		log.Printf("[pr-watcher] failed to insert message: %v", err)
@@ -434,7 +444,7 @@ func (s *Server) injectUserMessageWithRetry(clawID, content string, retryCount i
 	if ok {
 		_ = wsjson.Write(context.Background(), cc.conn, types.WSMessage{
 			Type:    "message",
-			Payload: map[string]string{"role": "user", "content": content},
+			Payload: map[string]string{"role": role, "content": content},
 		})
 	}
 
@@ -445,7 +455,7 @@ func (s *Server) injectUserMessageWithRetry(clawID, content string, retryCount i
 			"id":         msgID,
 			"claw_id":    clawID,
 			"tenant_id":  tenantID,
-			"role":       "user",
+			"role":       role,
 			"content":    content,
 			"created_at": now(),
 		},
@@ -652,7 +662,7 @@ func (s *Server) checkPRMerged(pr clawPR, token string) bool {
 			}
 		}
 		if !pipelineHandled {
-			s.injectUserMessage(clawID, fmt.Sprintf("PR %s was closed without being merged. Decide what to do: reopen it, open a new PR, or let the user know.", pr.prURL))
+			s.injectHubMessageByID(clawID, fmt.Sprintf("PR %s was closed without being merged. Decide what to do: reopen it, open a new PR, or let the user know.", pr.prURL))
 		}
 		return false
 	}

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -397,10 +397,6 @@ func (s *Server) injectHubMessageByID(clawID, content string) {
 	s.injectMessageWithRetry(clawID, content, "hub", 0)
 }
 
-func (s *Server) injectUserMessageWithRetry(clawID, content string, retryCount int) {
-	s.injectMessageWithRetry(clawID, content, "user", retryCount)
-}
-
 func (s *Server) injectMessageWithRetry(clawID, content, role string, retryCount int) {
 	// Don't interrupt a response in progress
 	s.mu.RLock()

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -48,13 +48,15 @@ type Server struct {
 }
 
 type clawConn struct {
-	id             string
-	tenantID       string
-	conn           *websocket.Conn
-	contextUsage   int             // 0-100, updated from heartbeats
-	gatewayReady   bool            // true once bridge reports gateway session established
-	streamingBuf   strings.Builder // accumulates chunks for current in-flight response
-	streamingMsgID string          // pre-assigned message ID for the current stream
+	id                   string
+	tenantID             string
+	conn                 *websocket.Conn
+	contextUsage         int             // 0-100, updated from heartbeats
+	gatewayReady         bool            // true once bridge reports gateway session established
+	streamingBuf         strings.Builder // accumulates chunks for current in-flight response
+	streamingMsgID       string          // pre-assigned message ID for the current stream
+	streamingStartedAt   time.Time       // when the current streaming turn started (zero if not streaming)
+	streamingTimeoutSent bool            // true once the 12-min timeout message has been injected this turn
 }
 
 // initialStatus returns the claw status string to use on bridge registration.
@@ -1028,6 +1030,23 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 							go s.sendWakeMessage(wakeConn, clawID)
 						}
 					}
+					// Check for streaming turn timeout (12 minutes)
+					s.mu.Lock()
+					if cc, ok := s.claws[clawID]; ok &&
+						!cc.streamingStartedAt.IsZero() &&
+						!cc.streamingTimeoutSent &&
+						time.Since(cc.streamingStartedAt) > 12*time.Minute {
+						cc.streamingTimeoutSent = true
+						s.mu.Unlock()
+						s.mu.RLock()
+						timeoutCC := s.claws[clawID]
+						s.mu.RUnlock()
+						if timeoutCC != nil {
+							go s.injectHubMessage(ctx, timeoutCC, "[hub] Your current response has been running for over 12 minutes. Please wrap up and send your response.")
+						}
+					} else {
+						s.mu.Unlock()
+					}
 				}
 			} else if msg.Type == "chunk" {
 				// Streaming chunk — forward to users immediately AND buffer server-side
@@ -1045,6 +1064,8 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 					if cc, ok := s.claws[clawID]; ok {
 						if cc.streamingMsgID == "" {
 							cc.streamingMsgID = uuid.New().String()
+							cc.streamingStartedAt = time.Now()
+							cc.streamingTimeoutSent = false
 						}
 						cc.streamingBuf.WriteString(chunk.Content)
 						msgID := cc.streamingMsgID
@@ -1073,6 +1094,8 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 					hm.ID = cc.streamingMsgID
 					cc.streamingMsgID = ""
 					cc.streamingBuf.Reset()
+					cc.streamingStartedAt = time.Time{}
+					cc.streamingTimeoutSent = false
 				} else {
 					hm.ID = uuid.New().String()
 				}
@@ -1093,6 +1116,15 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				}
 				// Detect and store any PR URLs mentioned by the agent
 				go s.scanMessageForPRs(clawID, hm.Content)
+				// Detect tool error loops and inject a corrective message
+				if detectToolLoop(hm.Content) {
+					s.mu.RLock()
+					loopCC := s.claws[clawID]
+					s.mu.RUnlock()
+					if loopCC != nil {
+						go s.injectHubMessage(ctx, loopCC, "[hub] You've hit the same tool error 3+ times in a row. Stop retrying. Take a completely different approach or ask for help.")
+					}
+				}
 			} else if msg.Type == "http_proxy_req" {
 				// Proxy an HTTP request from the bridge to the hub's internal API.
 				// This allows tools in the sandbox to reach hub APIs without a public URL.
@@ -2132,6 +2164,37 @@ func mergeTags(templateName string, configTags []string, cliTags []string) []str
 		add(t)
 	}
 	return result
+}
+
+// detectToolLoop returns true if the same class of tool error appears 3+ times
+// in the content of a completed assistant turn.
+func detectToolLoop(content string) bool {
+	patterns := []string{"edit failed:", "write failed:", "read failed:"}
+	for _, p := range patterns {
+		if strings.Count(strings.ToLower(content), p) >= 3 {
+			return true
+		}
+	}
+	return false
+}
+
+// injectHubMessage sends a user-role message to the claw over its WebSocket
+// connection and persists it to the DB so it appears in the message history.
+func (s *Server) injectHubMessage(ctx context.Context, cc *clawConn, text string) {
+	msg := types.HubMessage{
+		ID:        uuid.New().String(),
+		ClawID:    cc.id,
+		TenantID:  cc.tenantID,
+		Role:      "user",
+		Content:   text,
+		CreatedAt: now(),
+	}
+	_, _ = s.db.Exec(
+		`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at) VALUES(?,?,?,?,?,?)`,
+		msg.ID, msg.ClawID, msg.TenantID, msg.Role, msg.Content, msg.CreatedAt,
+	)
+	_ = wsjson.Write(ctx, cc.conn, types.WSMessage{Type: "message", Payload: msg})
+	s.broadcastToUsers(cc.tenantID, types.WSMessage{Type: "message", Payload: msg})
 }
 
 func randomHex(n int) string {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1038,12 +1038,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 						time.Since(cc.streamingStartedAt) > 12*time.Minute {
 						cc.streamingTimeoutSent = true
 						s.mu.Unlock()
-						s.mu.RLock()
-						timeoutCC := s.claws[clawID]
-						s.mu.RUnlock()
-						if timeoutCC != nil {
-							go s.injectHubMessage(ctx, timeoutCC, "[hub] Your current response has been running for over 12 minutes. Please wrap up and send your response.")
-						}
+						go s.injectHubMessage(ctx, cc, "[hub] Your current response has been running for over 12 minutes. Please wrap up and send your response.")
 					} else {
 						s.mu.Unlock()
 					}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2178,14 +2178,15 @@ func detectToolLoop(content string) bool {
 	return false
 }
 
-// injectHubMessage sends a user-role message to the claw over its WebSocket
+// injectHubMessage sends a hub-role message to the claw over its WebSocket
 // connection and persists it to the DB so it appears in the message history.
+// Hub messages are visually distinct from user messages in the UI.
 func (s *Server) injectHubMessage(ctx context.Context, cc *clawConn, text string) {
 	msg := types.HubMessage{
 		ID:        uuid.New().String(),
 		ClawID:    cc.id,
 		TenantID:  cc.tenantID,
-		Role:      "user",
+		Role:      "hub",
 		Content:   text,
 		CreatedAt: now(),
 	}

--- a/web/components/conversation-view.tsx
+++ b/web/components/conversation-view.tsx
@@ -818,6 +818,7 @@ function ClawChatView({
   onDeselectClaw: () => void
 }) {
   const [input, setInput] = useState("")
+  const [cmdToast, setCmdToast] = useState<string | null>(null)
   const [terminalOpen, setTerminalOpen] = useState(false)
   const [confirmKill, setConfirmKill] = useState(false)
   const bottomRef = useRef<HTMLDivElement>(null)
@@ -865,17 +866,26 @@ function ClawChatView({
     return () => timers.forEach(clearTimeout)
   }, [messages])
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    if (input.trim()) {
-      onSendMessage(input)
-      setInput("")
-      pinnedToBottom.current = true
-      if (panelTextareaRef.current) {
-        panelTextareaRef.current.style.height = "auto"
-        panelTextareaRef.current.style.overflowY = "hidden"
-      }
+    const text = input.trim()
+    if (!text) return
+    setInput("")
+    pinnedToBottom.current = true
+    if (panelTextareaRef.current) {
+      panelTextareaRef.current.style.height = "auto"
+      panelTextareaRef.current.style.overflowY = "hidden"
     }
+    if (text.startsWith("/cancel")) {
+      setCmdToast("Hard cancel not yet implemented")
+      setTimeout(() => setCmdToast(null), 3000)
+      return
+    }
+    if (text.startsWith("/stop")) {
+      onSendMessage("Stop what you are doing immediately and wait for my next instruction.")
+      return
+    }
+    onSendMessage(text)
   }
 
   return (
@@ -943,6 +953,11 @@ function ClawChatView({
       </div>
 
       <div className="p-4 border-t border-border">
+        {cmdToast && (
+          <div className="mb-2 max-w-3xl mx-auto text-xs text-amber-400 bg-amber-500/10 border border-amber-500/20 rounded-md px-3 py-2">
+            {cmdToast}
+          </div>
+        )}
         <form onSubmit={handleSubmit} className="flex gap-2 items-end max-w-3xl mx-auto">
           <textarea
             value={input}
@@ -966,7 +981,7 @@ function ClawChatView({
               }
             }}
             ref={panelTextareaRef}
-            placeholder="Send a message to this claw..."
+            placeholder="Message claw or /stop"
             rows={1}
             className="flex-1 resize-none overflow-hidden rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 min-h-[40px]"
           />

--- a/web/components/conversation-view.tsx
+++ b/web/components/conversation-view.tsx
@@ -886,6 +886,9 @@ function ClawChatView({
     return () => timers.forEach(clearTimeout)
   }, [messages])
 
+  const isSlashCommand = (value: string, command: string) =>
+    value === command || value.startsWith(`${command} `)
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     const text = input.trim()
@@ -896,12 +899,12 @@ function ClawChatView({
       panelTextareaRef.current.style.height = "auto"
       panelTextareaRef.current.style.overflowY = "hidden"
     }
-    if (text.startsWith("/cancel")) {
+    if (isSlashCommand(text, "/cancel")) {
       setCmdToast("Hard cancel not yet implemented")
       setTimeout(() => setCmdToast(null), 3000)
       return
     }
-    if (text.startsWith("/stop")) {
+    if (isSlashCommand(text, "/stop")) {
       onSendMessage("Stop what you are doing immediately and wait for my next instruction.")
       return
     }

--- a/web/components/conversation-view.tsx
+++ b/web/components/conversation-view.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState, useRef, useEffect, useCallback, memo } from "react"
-import { Send, Terminal, TerminalSquare, ChevronLeft, ChevronRight, ChevronDown, Loader2, LayoutGrid, Info, MessageSquare, RotateCcw, Trash2, AlertCircle, Wrench, GripVertical } from "lucide-react"
+import { Send, Terminal, TerminalSquare, ChevronLeft, ChevronRight, ChevronDown, Loader2, LayoutGrid, Info, MessageSquare, RotateCcw, Trash2, AlertCircle, Wrench, GripVertical, Settings2 } from "lucide-react"
 import {
   DndContext,
   closestCenter,
@@ -493,6 +493,14 @@ function ClawBoardCard({
                     </div>
                   )
                 }
+                if (message.role === "hub") {
+                  return (
+                    <div key={message.id} className="flex items-center gap-1.5 py-0.5">
+                      <Settings2 className="size-2.5 shrink-0 text-muted-foreground/40" />
+                      <span className="text-[10px] italic text-muted-foreground/60 leading-tight">{message.content}</span>
+                    </div>
+                  )
+                }
                 return (
                   <div
                     key={message.id}
@@ -766,6 +774,18 @@ const MessageBubble = memo(function MessageBubble({
   }
 
   const isUser = message.role === "user"
+  const isHub = message.role === "hub"
+
+  if (isHub) {
+    return (
+      <div className="flex items-center gap-2 py-1">
+        <div className="flex items-center gap-1.5 text-muted-foreground/60 text-xs italic bg-muted/40 border border-border/40 rounded px-3 py-1.5 max-w-[85%]">
+          <Settings2 className="size-3 shrink-0 text-muted-foreground/50" />
+          <span className="text-muted-foreground/80">{message.content}</span>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div className={cn("flex w-full", isUser ? "justify-end" : "justify-start")}>

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -25,7 +25,7 @@ export interface Claw {
 
 export interface Message {
   id: string
-  role: "user" | "claw" | "system"
+  role: "user" | "claw" | "system" | "hub"
   content: string
   timestamp: Date
   // API fields
@@ -54,7 +54,7 @@ export interface ApiMessage {
   id: string
   claw_id: string
   tenant_id: string
-  role: "user" | "claw"
+  role: "user" | "claw" | "hub"
   content: string
   created_at: string
 }


### PR DESCRIPTION
## Summary

Adds a distinct `role="hub"` for messages that the hub injects into claw conversations, so they render differently from genuine user messages in the UI.

## Changes

### Backend (Go)
- **`pkg/hub/server.go`**: `injectHubMessage` now stores `role="hub"` instead of `"user"`. WS broadcast carries the correct role.
- **`pkg/hub/pr_watcher.go`**: Refactored `injectUserMessageWithRetry` into `injectMessageWithRetry(clawID, content, role, retryCount)`. Added `injectHubMessageByID` wrapper. Updated callers:
  - PR closed without merge notification → `injectHubMessageByID`
  - PR comment forwarding (`checkPRComments`) → `injectHubMessageByID`
  - CI failure notification remains `injectUserMessage` (kept as-is per spec — hub-injected but treated as user for now; can update separately)
- **`pkg/hub/pipeline_runner.go`**: `runOnEnter` on_enter inject → `injectHubMessageByID`

### Frontend (TypeScript/React)
- **`web/lib/types.ts`**: Added `"hub"` to `Message.role` union type
- **`web/components/conversation-view.tsx`**:
  - `MessageBubble`: hub messages render as muted italic text with `Settings2` icon — no avatar, no timestamp, clearly system-generated
  - Card board view: hub messages render as small italic text with gear icon

### Unchanged
- `POST /api/messages` (user-initiated web UI messages) remains `role="user"`
- Old DB messages with `role="user"` that were hub-injected display as before

## Builds
- `go build ./...` ✅
- `npm run build` ✅