### PR TITLE
fix: message quality improvements in hub

### DIFF
--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1059,9 +1059,9 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 							log.Printf("[heartbeat] %s (%s): context_usage=%d%%", rp.Name, clawID[:8], hb.ContextUsage)
 						}
 					}
-					// Inject context warning when crossing 95% threshold for the first time this turn
+					// Inject context warning once per streaming turn when usage is >=95%
 					var shouldWarnContext bool
-					if cc2, ok2 := s.claws[clawID]; ok2 && hb.ContextUsage >= 95 && prevUsage < 95 && !cc2.contextWarningSent {
+					if cc2, ok2 := s.claws[clawID]; ok2 && hb.ContextUsage >= 95 && !cc2.contextWarningSent {
 						cc2.contextWarningSent = true
 						shouldWarnContext = true
 					}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -967,16 +967,21 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 	// Read loop — claw sends messages back to users
 	defer func() {
 		s.mu.Lock()
+		var partialContent string
+		var partialMsgID string
 		// Flush any partial streaming buffer as an interrupted message
 		if partialCC, ok := s.claws[clawID]; ok && partialCC.streamingBuf.Len() > 0 {
-			partialContent := partialCC.streamingBuf.String() + " [interrupted]"
-			partialMsgID := partialCC.streamingMsgID
+			partialContent = partialCC.streamingBuf.String() + " [interrupted]"
+			partialMsgID = partialCC.streamingMsgID
 			if partialMsgID == "" {
 				partialMsgID = uuid.New().String()
 			}
 			partialCC.streamingBuf.Reset()
 			partialCC.streamingMsgID = ""
-			s.mu.Unlock()
+		}
+		delete(s.claws, clawID)
+		s.mu.Unlock()
+		if partialContent != "" {
 			_, _ = s.db.Exec(
 				`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at) VALUES(?,?,?,?,?,?)
 				 ON CONFLICT(id) DO UPDATE SET content=excluded.content`,
@@ -986,10 +991,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				ID: partialMsgID, ClawID: clawID, TenantID: tenantID, Role: "claw",
 				Content: partialContent, CreatedAt: now(),
 			}})
-			s.mu.Lock()
 		}
-		delete(s.claws, clawID)
-		s.mu.Unlock()
 		var currentStatus string
 		_ = s.db.QueryRow(`SELECT status FROM claws WHERE id=?`, clawID).Scan(&currentStatus)
 		// Don't overwrite terminal/watching states — idle means the claw sent [DONE]

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1061,7 +1061,10 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 					}
 					// Inject context warning once per streaming turn when usage is >=95%
 					var shouldWarnContext bool
-					if cc2, ok2 := s.claws[clawID]; ok2 && hb.ContextUsage >= 95 && !cc2.contextWarningSent {
+					if cc2, ok2 := s.claws[clawID]; ok2 &&
+						!cc2.streamingStartedAt.IsZero() &&
+						hb.ContextUsage >= 95 &&
+						!cc2.contextWarningSent {
 						cc2.contextWarningSent = true
 						shouldWarnContext = true
 					}
@@ -1133,6 +1136,14 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				if err := json.Unmarshal(payload, &hm); err != nil {
 					continue
 				}
+				hm.ClawID = clawID
+				hm.TenantID = tenantID
+				hm.Role = "claw"
+				hm.CreatedAt = now()
+				// Skip empty messages — never store or broadcast
+				if strings.TrimSpace(hm.Content) == "" {
+					continue
+				}
 				// Use the streaming message ID if we already started buffering
 				s.mu.Lock()
 				if cc, ok := s.claws[clawID]; ok && cc.streamingMsgID != "" {
@@ -1146,14 +1157,6 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 					hm.ID = uuid.New().String()
 				}
 				s.mu.Unlock()
-				hm.ClawID = clawID
-				hm.TenantID = tenantID
-				hm.Role = "claw"
-				hm.CreatedAt = now()
-				// Skip empty messages — never store or broadcast
-				if strings.TrimSpace(hm.Content) == "" {
-					continue
-				}
 				_, _ = s.db.Exec(
 					`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at) VALUES(?,?,?,?,?,?)
 					 ON CONFLICT(id) DO UPDATE SET content=excluded.content`,

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1140,11 +1140,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				hm.TenantID = tenantID
 				hm.Role = "claw"
 				hm.CreatedAt = now()
-				// Skip empty messages — never store or broadcast
-				if strings.TrimSpace(hm.Content) == "" {
-					continue
-				}
-				// Use the streaming message ID if we already started buffering
+				// Always clean up streaming state first, even for empty messages.
 				s.mu.Lock()
 				if cc, ok := s.claws[clawID]; ok && cc.streamingMsgID != "" {
 					hm.ID = cc.streamingMsgID
@@ -1157,6 +1153,10 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 					hm.ID = uuid.New().String()
 				}
 				s.mu.Unlock()
+				// Drop empty messages — never store or broadcast
+				if strings.TrimSpace(hm.Content) == "" {
+					continue
+				}
 				_, _ = s.db.Exec(
 					`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at) VALUES(?,?,?,?,?,?)
 					 ON CONFLICT(id) DO UPDATE SET content=excluded.content`,

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -61,6 +61,7 @@ type clawConn struct {
 	streamingMsgID       string          // pre-assigned message ID for the current stream
 	streamingStartedAt   time.Time       // when the current streaming turn started (zero if not streaming)
 	streamingTimeoutSent bool            // true once the 12-min timeout message has been injected this turn
+	contextWarningSent   bool            // true once the context-nearly-full warning has been injected this turn
 }
 
 // initialStatus returns the claw status string to use on bridge registration.
@@ -966,6 +967,27 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 	// Read loop — claw sends messages back to users
 	defer func() {
 		s.mu.Lock()
+		// Flush any partial streaming buffer as an interrupted message
+		if partialCC, ok := s.claws[clawID]; ok && partialCC.streamingBuf.Len() > 0 {
+			partialContent := partialCC.streamingBuf.String() + " [interrupted]"
+			partialMsgID := partialCC.streamingMsgID
+			if partialMsgID == "" {
+				partialMsgID = uuid.New().String()
+			}
+			partialCC.streamingBuf.Reset()
+			partialCC.streamingMsgID = ""
+			s.mu.Unlock()
+			_, _ = s.db.Exec(
+				`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at) VALUES(?,?,?,?,?,?)
+				 ON CONFLICT(id) DO UPDATE SET content=excluded.content`,
+				partialMsgID, clawID, tenantID, "claw", partialContent, now(),
+			)
+			s.broadcastToUsers(tenantID, types.WSMessage{Type: "message", Payload: types.HubMessage{
+				ID: partialMsgID, ClawID: clawID, TenantID: tenantID, Role: "claw",
+				Content: partialContent, CreatedAt: now(),
+			}})
+			s.mu.Lock()
+		}
 		delete(s.claws, clawID)
 		s.mu.Unlock()
 		var currentStatus string
@@ -1004,11 +1026,12 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				if err := json.Unmarshal(payload, &hb); err == nil {
 					var wakeConn *clawConn
 					var shouldWake bool
+					var prevUsage int
 					s.mu.Lock()
 					if cc, ok := s.claws[clawID]; ok {
 						// Log only on status changes, not every heartbeat
 						prevHealthy := cc.gatewayReady
-						prevUsage := cc.contextUsage
+						prevUsage = cc.contextUsage
 						cc.contextUsage = hb.ContextUsage
 						// Promote from 'starting' to 'connected' once gateway is ready.
 						// nil means field absent (old bridge) — treat as ready.
@@ -1036,7 +1059,21 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 							log.Printf("[heartbeat] %s (%s): context_usage=%d%%", rp.Name, clawID[:8], hb.ContextUsage)
 						}
 					}
+					// Inject context warning when crossing 95% threshold for the first time this turn
+					var shouldWarnContext bool
+					if cc2, ok2 := s.claws[clawID]; ok2 && hb.ContextUsage >= 95 && prevUsage < 95 && !cc2.contextWarningSent {
+						cc2.contextWarningSent = true
+						shouldWarnContext = true
+					}
 					s.mu.Unlock()
+					if shouldWarnContext {
+						s.mu.RLock()
+						warnCC := s.claws[clawID]
+						s.mu.RUnlock()
+						if warnCC != nil {
+							go s.injectHubMessage(ctx, warnCC, "[hub] Context window is nearly full. Summarize your progress briefly and send [DONE] with any PR URL, or ask the user what to do next.")
+						}
+					}
 					if shouldWake {
 						if !s.initializePipelineEntryIfNeeded(clawID) && s.getPipelineStage(clawID) == "" {
 							go s.sendWakeMessage(wakeConn, clawID)
@@ -1073,6 +1110,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 							cc.streamingMsgID = uuid.New().String()
 							cc.streamingStartedAt = time.Now()
 							cc.streamingTimeoutSent = false
+							cc.contextWarningSent = false
 						}
 						cc.streamingBuf.WriteString(chunk.Content)
 						msgID := cc.streamingMsgID
@@ -1111,6 +1149,10 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				hm.TenantID = tenantID
 				hm.Role = "claw"
 				hm.CreatedAt = now()
+				// Skip empty messages — never store or broadcast
+				if strings.TrimSpace(hm.Content) == "" {
+					continue
+				}
 				_, _ = s.db.Exec(
 					`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at) VALUES(?,?,?,?,?,?)
 					 ON CONFLICT(id) DO UPDATE SET content=excluded.content`,

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -982,14 +982,15 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 		delete(s.claws, clawID)
 		s.mu.Unlock()
 		if partialContent != "" {
+			interruptedAt := now()
 			_, _ = s.db.Exec(
 				`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at) VALUES(?,?,?,?,?,?)
 				 ON CONFLICT(id) DO UPDATE SET content=excluded.content`,
-				partialMsgID, clawID, tenantID, "claw", partialContent, now(),
+				partialMsgID, clawID, tenantID, "claw", partialContent, interruptedAt,
 			)
 			s.broadcastToUsers(tenantID, types.WSMessage{Type: "message", Payload: types.HubMessage{
 				ID: partialMsgID, ClawID: clawID, TenantID: tenantID, Role: "claw",
-				Content: partialContent, CreatedAt: now(),
+				Content: partialContent, CreatedAt: interruptedAt,
 			}})
 		}
 		var currentStatus string

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1141,6 +1141,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 					cc.streamingBuf.Reset()
 					cc.streamingStartedAt = time.Time{}
 					cc.streamingTimeoutSent = false
+					cc.contextWarningSent = false
 				} else {
 					hm.ID = uuid.New().String()
 				}


### PR DESCRIPTION
## Summary

Fixes three message quality bugs in the ElasticClaw hub.

### Bug 1: Empty messages never stored or broadcast
Added a guard in the `msg.Type == "message"` handler to skip messages with empty or whitespace-only content. This prevents empty bubbles from appearing in the UI.

### Bug 2: Context deadline → empty bubble (partial flush on disconnect)
When a bridge disconnects mid-stream, the partial content buffered in `streamingBuf` is now saved as a complete message with ` [interrupted]` appended, rather than being silently lost. The empty-message guard from Bug 1 also covers the case where the bridge sends an empty `message` event on disconnect.

### Bug 3: Context window full → claw stops responding
Added detection for when context usage crosses 95%. When this happens for the first time in a turn, the hub injects:
```
[hub] Context window is nearly full. Summarize your progress briefly and send [DONE] with any PR URL, or ask the user what to do next.
```
Tracked with a new `contextWarningSent bool` field on `clawConn`, reset at the start of each new streaming turn.

## Testing
- `go build ./...` ✅
- `go test ./...` ✅