### PR TITLE
feat: GitHub OAuth login + tag-based access control

### DIFF
--- a/pkg/hub/access.go
+++ b/pkg/hub/access.go
@@ -1,0 +1,54 @@
+package hub
+
+import (
+	"strings"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+// canViewClaw returns true if the user can see this claw.
+// Logic:
+//  1. If cfg == nil or ViewRequiresTags is empty → allow all (backward compat)
+//  2. If userLogin is in cfg.Admins → allow
+//  3. Resolve {user} in each tag pattern to userLogin
+//  4. If any resolved pattern matches any tag in clawTags → allow
+//  5. Otherwise → deny
+func canViewClaw(cfg *types.AccessConfig, userLogin string, clawTags []string) bool {
+	if cfg == nil || len(cfg.ViewRequiresTags) == 0 {
+		return true
+	}
+	for _, admin := range cfg.Admins {
+		if strings.EqualFold(admin, userLogin) {
+			return true
+		}
+	}
+	return matchesTags(cfg.ViewRequiresTags, userLogin, clawTags)
+}
+
+// canInteractWithClaw returns true if the user can send messages/kill this claw.
+// Same logic as canViewClaw but uses InteractRequiresTags.
+func canInteractWithClaw(cfg *types.AccessConfig, userLogin string, clawTags []string) bool {
+	if cfg == nil || len(cfg.InteractRequiresTags) == 0 {
+		return true
+	}
+	for _, admin := range cfg.Admins {
+		if strings.EqualFold(admin, userLogin) {
+			return true
+		}
+	}
+	return matchesTags(cfg.InteractRequiresTags, userLogin, clawTags)
+}
+
+// matchesTags checks if any of the required tag patterns (after {user} substitution)
+// matches any tag in clawTags. Exact string match after substitution.
+func matchesTags(requiredPatterns []string, userLogin string, clawTags []string) bool {
+	for _, pattern := range requiredPatterns {
+		resolved := strings.ReplaceAll(pattern, "{user}", userLogin)
+		for _, tag := range clawTags {
+			if resolved == tag {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/pkg/hub/access.go
+++ b/pkg/hub/access.go
@@ -39,6 +39,10 @@ func canInteractWithClaw(cfg *types.AccessConfig, userLogin string, clawTags []s
 	return matchesTags(cfg.InteractRequiresTags, userLogin, clawTags)
 }
 
+func canModifyClaw(cfg *types.AccessConfig, userLogin string, clawTags []string) bool {
+	return canViewClaw(cfg, userLogin, clawTags) && canInteractWithClaw(cfg, userLogin, clawTags)
+}
+
 // matchesTags checks if any of the required tag patterns (after {user} substitution)
 // matches any tag in clawTags. Exact string match after substitution.
 func matchesTags(requiredPatterns []string, userLogin string, clawTags []string) bool {

--- a/pkg/hub/auth_github.go
+++ b/pkg/hub/auth_github.go
@@ -1,0 +1,376 @@
+package hub
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+// ─── GitHub OAuth session token ───────────────────────────────────────────────
+
+const githubSessionExpiry = 7 * 24 * time.Hour
+
+// githubSessionPayload is the signed payload stored in OAuth session tokens.
+type githubSessionPayload struct {
+	Login     string `json:"login"`
+	Name      string `json:"name"`
+	AvatarURL string `json:"avatar_url"`
+	Exp       int64  `json:"exp"`
+}
+
+// signGitHubSession creates a signed session token for a GitHub user.
+// Format: base64url(payload).base64url(hmac-sha256)
+func signGitHubSession(secret, login, name, avatarURL string) (string, error) {
+	payload := githubSessionPayload{
+		Login:     login,
+		Name:      name,
+		AvatarURL: avatarURL,
+		Exp:       time.Now().Add(githubSessionExpiry).Unix(),
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	encoded := base64.RawURLEncoding.EncodeToString(data)
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(encoded))
+	sig := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+	return encoded + "." + sig, nil
+}
+
+// verifyGitHubSession validates the token and returns the payload if valid and unexpired.
+func verifyGitHubSession(secret, token string) (*githubSessionPayload, bool) {
+	parts := strings.SplitN(token, ".", 2)
+	if len(parts) != 2 {
+		return nil, false
+	}
+	encoded, sig := parts[0], parts[1]
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(encoded))
+	expected := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+	if !hmac.Equal([]byte(sig), []byte(expected)) {
+		return nil, false
+	}
+	data, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, false
+	}
+	var p githubSessionPayload
+	if err := json.Unmarshal(data, &p); err != nil {
+		return nil, false
+	}
+	if time.Now().Unix() > p.Exp {
+		return nil, false
+	}
+	return &p, true
+}
+
+// ─── Context key for GitHub login ────────────────────────────────────────────
+
+type ctxGitHubLoginKey struct{}
+
+// githubLoginFromContext returns the GitHub login attached to the context, if any.
+func githubLoginFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(ctxGitHubLoginKey{}).(string)
+	return v
+}
+
+// ─── GitHub OAuth handlers ────────────────────────────────────────────────────
+
+// githubBaseURL returns the GitHub API base URL (overridable for tests).
+func (s *Server) ghBaseURL() string {
+	if s.githubBaseURL != "" {
+		return s.githubBaseURL
+	}
+	return "https://api.github.com"
+}
+
+// handleGitHubOAuthStart redirects to GitHub OAuth authorize URL.
+func (s *Server) handleGitHubOAuthStart(w http.ResponseWriter, r *http.Request) {
+	s.mu.RLock()
+	cfg := s.hubCfg.Auth
+	s.mu.RUnlock()
+	if cfg == nil || cfg.GitHubOAuth == nil {
+		http.Error(w, "GitHub OAuth not configured", http.StatusNotFound)
+		return
+	}
+	oauthCfg := cfg.GitHubOAuth
+
+	state, err := randomState()
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	// Store state in a short-lived cookie for CSRF protection
+	http.SetCookie(w, &http.Cookie{
+		Name:     "oauth_state",
+		Value:    state,
+		MaxAge:   600,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		Path:     "/",
+	})
+
+	authURL := fmt.Sprintf(
+		"https://github.com/login/oauth/authorize?client_id=%s&scope=read:user,read:org&state=%s",
+		url.QueryEscape(oauthCfg.ClientID),
+		url.QueryEscape(state),
+	)
+	http.Redirect(w, r, authURL, http.StatusFound)
+}
+
+// handleGitHubOAuthCallback handles the OAuth callback from GitHub.
+func (s *Server) handleGitHubOAuthCallback(w http.ResponseWriter, r *http.Request) {
+	s.mu.RLock()
+	cfg := s.hubCfg.Auth
+	secret := s.hubCfg.Token
+	s.mu.RUnlock()
+
+	if cfg == nil || cfg.GitHubOAuth == nil {
+		http.Error(w, "GitHub OAuth not configured", http.StatusNotFound)
+		return
+	}
+	oauthCfg := cfg.GitHubOAuth
+
+	// Validate state
+	stateCookie, err := r.Cookie("oauth_state")
+	if err != nil || r.URL.Query().Get("state") != stateCookie.Value {
+		http.Error(w, "invalid state", http.StatusBadRequest)
+		return
+	}
+	// Clear the state cookie
+	http.SetCookie(w, &http.Cookie{
+		Name:    "oauth_state",
+		Value:   "",
+		MaxAge:  -1,
+		Path:    "/",
+		HttpOnly: true,
+	})
+
+	code := r.URL.Query().Get("code")
+	if code == "" {
+		http.Error(w, "missing code", http.StatusBadRequest)
+		return
+	}
+
+	// Exchange code for access token
+	accessToken, err := s.githubExchangeCode(r.Context(), oauthCfg.ClientID, oauthCfg.ClientSecret, code)
+	if err != nil {
+		log.Printf("[github-oauth] token exchange error: %v", err)
+		http.Error(w, "token exchange failed", http.StatusBadGateway)
+		return
+	}
+
+	// Fetch user info
+	ghUser, err := s.githubFetchUser(r.Context(), accessToken)
+	if err != nil {
+		log.Printf("[github-oauth] fetch user error: %v", err)
+		http.Error(w, "fetch user failed", http.StatusBadGateway)
+		return
+	}
+
+	// Check allowlist
+	allowed, err := s.githubCheckAllowlist(r.Context(), oauthCfg, accessToken, ghUser.Login)
+	if err != nil {
+		log.Printf("[github-oauth] allowlist check error: %v", err)
+		http.Error(w, "allowlist check failed", http.StatusBadGateway)
+		return
+	}
+	if !allowed {
+		log.Printf("[github-oauth] denied: user %s not in allowlist", ghUser.Login)
+		http.Error(w, "access denied", http.StatusForbidden)
+		return
+	}
+
+	// Issue session token
+	sessionToken, err := signGitHubSession(secret, ghUser.Login, ghUser.Name, ghUser.AvatarURL)
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	log.Printf("[github-oauth] login: %s (%s)", ghUser.Login, ghUser.Name)
+
+	// Redirect to the web UI login page with the token as a query param.
+	// The login page will pick it up, store it in sessionStorage, and redirect to home.
+	redirectURL := fmt.Sprintf("/login?github_token=%s", url.QueryEscape(sessionToken))
+	http.Redirect(w, r, redirectURL, http.StatusFound)
+}
+
+// ─── GitHub API helpers ───────────────────────────────────────────────────────
+
+type githubUser struct {
+	Login     string `json:"login"`
+	Name      string `json:"name"`
+	AvatarURL string `json:"avatar_url"`
+}
+
+func (s *Server) githubExchangeCode(ctx context.Context, clientID, clientSecret, code string) (string, error) {
+	body := url.Values{}
+	body.Set("client_id", clientID)
+	body.Set("client_secret", clientSecret)
+	body.Set("code", code)
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, "https://github.com/login/oauth/access_token", strings.NewReader(body.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("exchange request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		AccessToken string `json:"access_token"`
+		Error       string `json:"error"`
+		ErrorDesc   string `json:"error_description"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("decode response: %w", err)
+	}
+	if result.Error != "" {
+		return "", fmt.Errorf("oauth error: %s: %s", result.Error, result.ErrorDesc)
+	}
+	if result.AccessToken == "" {
+		return "", fmt.Errorf("empty access token")
+	}
+	return result.AccessToken, nil
+}
+
+func (s *Server) githubFetchUser(ctx context.Context, accessToken string) (*githubUser, error) {
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, s.ghBaseURL()+"/user", nil)
+	req.Header.Set("Authorization", "token "+accessToken)
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch user: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetch user: status %d", resp.StatusCode)
+	}
+	var u githubUser
+	if err := json.NewDecoder(resp.Body).Decode(&u); err != nil {
+		return nil, fmt.Errorf("decode user: %w", err)
+	}
+	return &u, nil
+}
+
+func (s *Server) githubCheckAllowlist(ctx context.Context, cfg *types.GitHubOAuthConfig, accessToken, login string) (bool, error) {
+	// If no allowlist configured at all → deny (safe default)
+	if len(cfg.AllowedUsers) == 0 && len(cfg.AllowedOrgs) == 0 && len(cfg.AllowedTeams) == 0 {
+		return false, nil
+	}
+
+	// Check allowed users
+	for _, u := range cfg.AllowedUsers {
+		if strings.EqualFold(u, login) {
+			return true, nil
+		}
+	}
+
+	// Check allowed orgs
+	if len(cfg.AllowedOrgs) > 0 {
+		orgs, err := s.githubFetchUserOrgs(ctx, accessToken)
+		if err != nil {
+			return false, err
+		}
+		orgSet := make(map[string]bool, len(orgs))
+		for _, o := range orgs {
+			orgSet[strings.ToLower(o)] = true
+		}
+		for _, allowedOrg := range cfg.AllowedOrgs {
+			if orgSet[strings.ToLower(allowedOrg)] {
+				return true, nil
+			}
+		}
+	}
+
+	// Check allowed teams ("org/team" format)
+	for _, teamSpec := range cfg.AllowedTeams {
+		parts := strings.SplitN(teamSpec, "/", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		org, team := parts[0], parts[1]
+		member, err := s.githubCheckTeamMembership(ctx, accessToken, org, team, login)
+		if err != nil {
+			log.Printf("[github-oauth] team check %s/%s: %v", org, team, err)
+			continue
+		}
+		if member {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (s *Server) githubFetchUserOrgs(ctx context.Context, accessToken string) ([]string, error) {
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, s.ghBaseURL()+"/user/orgs", nil)
+	req.Header.Set("Authorization", "token "+accessToken)
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch orgs: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("fetch orgs: status %d: %s", resp.StatusCode, string(body))
+	}
+	var orgs []struct {
+		Login string `json:"login"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&orgs); err != nil {
+		return nil, fmt.Errorf("decode orgs: %w", err)
+	}
+	names := make([]string, len(orgs))
+	for i, o := range orgs {
+		names[i] = o.Login
+	}
+	return names, nil
+}
+
+func (s *Server) githubCheckTeamMembership(ctx context.Context, accessToken, org, team, login string) (bool, error) {
+	apiURL := fmt.Sprintf("%s/orgs/%s/teams/%s/members/%s",
+		s.ghBaseURL(),
+		url.PathEscape(org),
+		url.PathEscape(team),
+		url.PathEscape(login),
+	)
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	req.Header.Set("Authorization", "token "+accessToken)
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("team membership check: %w", err)
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode == http.StatusNoContent, nil
+}
+
+func randomState() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}

--- a/pkg/hub/auth_github.go
+++ b/pkg/hub/auth_github.go
@@ -80,9 +80,17 @@ func verifyGitHubSession(secret, token string) (*githubSessionPayload, bool) {
 
 type ctxGitHubLoginKey struct{}
 
+type ctxGitHubSessionPayloadKey struct{}
+
 // githubLoginFromContext returns the GitHub login attached to the context, if any.
 func githubLoginFromContext(ctx context.Context) string {
 	v, _ := ctx.Value(ctxGitHubLoginKey{}).(string)
+	return v
+}
+
+// githubSessionPayloadFromContext returns the GitHub session payload attached to the context, if any.
+func githubSessionPayloadFromContext(ctx context.Context) *githubSessionPayload {
+	v, _ := ctx.Value(ctxGitHubSessionPayloadKey{}).(*githubSessionPayload)
 	return v
 }
 

--- a/pkg/hub/auth_github.go
+++ b/pkg/hub/auth_github.go
@@ -101,10 +101,10 @@ func (s *Server) webSessionSecret() string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	if s.hubCfg.Auth != nil && s.hubCfg.Auth.GitHubOAuth != nil {
-		return s.hubCfg.Auth.GitHubOAuth.ClientSecret
+	if s.hubCfg.Auth != nil && s.hubCfg.Auth.SessionSecret != "" {
+		return s.hubCfg.Auth.SessionSecret
 	}
-	return ""
+	return s.hubCfg.Token
 }
 
 // ─── Public endpoints ────────────────────────────────────────────────────────

--- a/pkg/hub/auth_github.go
+++ b/pkg/hub/auth_github.go
@@ -23,8 +23,9 @@ import (
 
 const githubSessionExpiry = 7 * 24 * time.Hour
 const (
-	oauthStateCookieName = "oauth_state"
-	oauthNextCookieName  = "oauth_next"
+	oauthStateCookieName      = "oauth_state"
+	oauthNextCookieName       = "oauth_next"
+	oauthFrontendOriginCookie = "oauth_frontend_origin"
 	oauthCodeTTL         = 2 * time.Minute
 )
 
@@ -160,6 +161,24 @@ func (s *Server) handleGitHubOAuthStart(w http.ResponseWriter, r *http.Request) 
 			Path:     "/",
 		})
 	}
+	// Store the frontend origin so the callback redirect lands on the right host.
+	// In dev the frontend runs on a different port than the hub.
+	frontendOrigin := ""
+	if ref := r.Referer(); ref != "" {
+		if u, err := url.Parse(ref); err == nil {
+			frontendOrigin = u.Scheme + "://" + u.Host
+		}
+	}
+	if frontendOrigin != "" {
+		http.SetCookie(w, &http.Cookie{
+			Name:     oauthFrontendOriginCookie,
+			Value:    frontendOrigin,
+			MaxAge:   600,
+			HttpOnly: true,
+			SameSite: http.SameSiteLaxMode,
+			Path:     "/",
+		})
+	}
 
 	// Build redirect_uri from the incoming request so the callback lands on the
 	// correct host regardless of what's registered in the GitHub OAuth app.
@@ -203,21 +222,15 @@ func (s *Server) handleGitHubOAuthCallback(w http.ResponseWriter, r *http.Reques
 			next = safeNextPath(string(decoded))
 		}
 	}
-	// Clear the state cookie
-	http.SetCookie(w, &http.Cookie{
-		Name:     oauthStateCookieName,
-		Value:    "",
-		MaxAge:   -1,
-		Path:     "/",
-		HttpOnly: true,
-	})
-	http.SetCookie(w, &http.Cookie{
-		Name:     oauthNextCookieName,
-		Value:    "",
-		MaxAge:   -1,
-		Path:     "/",
-		HttpOnly: true,
-	})
+	// Read and clear the frontend origin cookie
+	var frontendOriginFromCookie string
+	if c, err := r.Cookie(oauthFrontendOriginCookie); err == nil {
+		frontendOriginFromCookie = c.Value
+	}
+	// Clear all OAuth cookies
+	for _, name := range []string{oauthStateCookieName, oauthNextCookieName, oauthFrontendOriginCookie} {
+		http.SetCookie(w, &http.Cookie{Name: name, Value: "", MaxAge: -1, Path: "/", HttpOnly: true})
+	}
 
 	code := r.URL.Query().Get("code")
 	if code == "" {
@@ -294,7 +307,18 @@ func (s *Server) handleGitHubOAuthCallback(w http.ResponseWriter, r *http.Reques
 	if next != "" {
 		redirectQuery.Set("next", next)
 	}
-	redirectURL := "/login?" + redirectQuery.Encode()
+	// Redirect to the frontend /login page. In dev the hub and web run on
+	// different ports, so use the stored frontend origin cookie if present.
+	frontendBase := frontendOriginFromCookie
+	if frontendBase == "" {
+		// Fallback: same host as the hub (production case)
+		scheme := "https"
+		if r.TLS == nil && r.Header.Get("X-Forwarded-Proto") != "https" {
+			scheme = "http"
+		}
+		frontendBase = fmt.Sprintf("%s://%s", scheme, r.Host)
+	}
+	redirectURL := frontendBase + "/login?" + redirectQuery.Encode()
 	http.Redirect(w, r, redirectURL, http.StatusFound)
 }
 

--- a/pkg/hub/auth_github.go
+++ b/pkg/hub/auth_github.go
@@ -150,7 +150,7 @@ func (s *Server) handleGitHubOAuthStart(w http.ResponseWriter, r *http.Request) 
 		SameSite: http.SameSiteLaxMode,
 		Path:     "/",
 	})
-	if next := r.URL.Query().Get("next"); next != "" {
+	if next := safeNextPath(r.URL.Query().Get("next")); next != "" {
 		http.SetCookie(w, &http.Cookie{
 			Name:     oauthNextCookieName,
 			Value:    base64.RawURLEncoding.EncodeToString([]byte(next)),
@@ -191,7 +191,7 @@ func (s *Server) handleGitHubOAuthCallback(w http.ResponseWriter, r *http.Reques
 	var next string
 	if nextCookie, err := r.Cookie(oauthNextCookieName); err == nil {
 		if decoded, err := base64.RawURLEncoding.DecodeString(nextCookie.Value); err == nil {
-			next = string(decoded)
+			next = safeNextPath(string(decoded))
 		}
 	}
 	// Clear the state cookie
@@ -482,4 +482,21 @@ func randomState() (string, error) {
 		return "", err
 	}
 	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+func safeNextPath(next string) string {
+	if next == "" {
+		return ""
+	}
+	parsed, err := url.Parse(next)
+	if err != nil {
+		return ""
+	}
+	if parsed.IsAbs() || parsed.Host != "" {
+		return ""
+	}
+	if !strings.HasPrefix(next, "/") || strings.HasPrefix(next, "//") {
+		return ""
+	}
+	return next
 }

--- a/pkg/hub/auth_github.go
+++ b/pkg/hub/auth_github.go
@@ -264,10 +264,13 @@ func (s *Server) handleGitHubOAuthCallback(w http.ResponseWriter, r *http.Reques
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
+	now := time.Now()
+	expiresAt := now.Add(oauthCodeTTL)
+	s.cleanupExpiredOAuthCodes(now)
 	s.mu.Lock()
 	s.oauthCodes[oauthCode] = pendingOAuthCode{
 		Token:     sessionToken,
-		ExpiresAt: time.Now().Add(oauthCodeTTL),
+		ExpiresAt: expiresAt,
 	}
 	s.mu.Unlock()
 
@@ -293,12 +296,8 @@ func (s *Server) handleGitHubOAuthExchange(w http.ResponseWriter, r *http.Reques
 	}
 
 	now := time.Now()
+	s.cleanupExpiredOAuthCodes(now)
 	s.mu.Lock()
-	for key, pending := range s.oauthCodes {
-		if now.After(pending.ExpiresAt) {
-			delete(s.oauthCodes, key)
-		}
-	}
 	pending, ok := s.oauthCodes[body.Code]
 	if ok {
 		delete(s.oauthCodes, body.Code)
@@ -317,6 +316,24 @@ func (s *Server) handleGitHubOAuthExchange(w http.ResponseWriter, r *http.Reques
 	w.Header().Set("Pragma", "no-cache")
 	w.Header().Set("X-OAuth-Code-TTL", strconv.Itoa(ttl))
 	jsonOK(w, map[string]string{"github_token": pending.Token})
+}
+
+func (s *Server) cleanupExpiredOAuthCodesLoop() {
+	ticker := time.NewTicker(oauthCodeTTL)
+	defer ticker.Stop()
+	for range ticker.C {
+		s.cleanupExpiredOAuthCodes(time.Now())
+	}
+}
+
+func (s *Server) cleanupExpiredOAuthCodes(now time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for key, pending := range s.oauthCodes {
+		if now.After(pending.ExpiresAt) {
+			delete(s.oauthCodes, key)
+		}
+	}
 }
 
 // ─── GitHub API helpers ───────────────────────────────────────────────────────

--- a/pkg/hub/auth_github.go
+++ b/pkg/hub/auth_github.go
@@ -12,6 +12,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -24,7 +25,13 @@ const githubSessionExpiry = 7 * 24 * time.Hour
 const (
 	oauthStateCookieName = "oauth_state"
 	oauthNextCookieName  = "oauth_next"
+	oauthCodeTTL         = 2 * time.Minute
 )
+
+type pendingOAuthCode struct {
+	Token     string
+	ExpiresAt time.Time
+}
 
 // githubSessionPayload is the signed payload stored in OAuth session tokens.
 type githubSessionPayload struct {
@@ -251,14 +258,65 @@ func (s *Server) handleGitHubOAuthCallback(w http.ResponseWriter, r *http.Reques
 
 	log.Printf("[github-oauth] login: %s (%s)", ghUser.Login, ghUser.Name)
 
-	// Redirect to the web UI login page with the token as a query param.
-	// The login page will pick it up, store it in sessionStorage, and redirect to home.
-	redirectQuery := url.Values{"github_token": []string{sessionToken}}
+	// Exchange long-lived session token for short-lived one-time code in URL.
+	oauthCode, err := randomState()
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	s.mu.Lock()
+	s.oauthCodes[oauthCode] = pendingOAuthCode{
+		Token:     sessionToken,
+		ExpiresAt: time.Now().Add(oauthCodeTTL),
+	}
+	s.mu.Unlock()
+
+	redirectQuery := url.Values{"oauth_code": []string{oauthCode}}
 	if next != "" {
 		redirectQuery.Set("next", next)
 	}
 	redirectURL := "/login?" + redirectQuery.Encode()
 	http.Redirect(w, r, redirectURL, http.StatusFound)
+}
+
+func (s *Server) handleGitHubOAuthExchange(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var body struct {
+		Code string `json:"code"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Code == "" {
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+
+	now := time.Now()
+	s.mu.Lock()
+	for key, pending := range s.oauthCodes {
+		if now.After(pending.ExpiresAt) {
+			delete(s.oauthCodes, key)
+		}
+	}
+	pending, ok := s.oauthCodes[body.Code]
+	if ok {
+		delete(s.oauthCodes, body.Code)
+	}
+	s.mu.Unlock()
+	if !ok || now.After(pending.ExpiresAt) {
+		http.Error(w, "invalid code", http.StatusUnauthorized)
+		return
+	}
+
+	ttl := int(time.Until(pending.ExpiresAt).Seconds())
+	if ttl < 0 {
+		ttl = 0
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Pragma", "no-cache")
+	w.Header().Set("X-OAuth-Code-TTL", strconv.Itoa(ttl))
+	jsonOK(w, map[string]string{"github_token": pending.Token})
 }
 
 // ─── GitHub API helpers ───────────────────────────────────────────────────────

--- a/pkg/hub/auth_github.go
+++ b/pkg/hub/auth_github.go
@@ -161,10 +161,19 @@ func (s *Server) handleGitHubOAuthStart(w http.ResponseWriter, r *http.Request) 
 		})
 	}
 
+	// Build redirect_uri from the incoming request so the callback lands on the
+	// correct host regardless of what's registered in the GitHub OAuth app.
+	scheme := "https"
+	if r.TLS == nil && r.Header.Get("X-Forwarded-Proto") != "https" {
+		scheme = "http"
+	}
+	redirectURI := fmt.Sprintf("%s://%s/api/auth/github/callback", scheme, r.Host)
+
 	authURL := fmt.Sprintf(
-		"https://github.com/login/oauth/authorize?client_id=%s&scope=read:user,read:org&state=%s",
+		"https://github.com/login/oauth/authorize?client_id=%s&scope=read:user,read:org&state=%s&redirect_uri=%s",
 		url.QueryEscape(oauthCfg.ClientID),
 		url.QueryEscape(state),
+		url.QueryEscape(redirectURI),
 	)
 	http.Redirect(w, r, authURL, http.StatusFound)
 }
@@ -216,8 +225,15 @@ func (s *Server) handleGitHubOAuthCallback(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	// Reconstruct redirect_uri to match what was sent in the authorization request
+	exchangeScheme := "https"
+	if r.TLS == nil && r.Header.Get("X-Forwarded-Proto") != "https" {
+		exchangeScheme = "http"
+	}
+	exchangeRedirectURI := fmt.Sprintf("%s://%s/api/auth/github/callback", exchangeScheme, r.Host)
+
 	// Exchange code for access token
-	accessToken, err := s.githubExchangeCode(r.Context(), oauthCfg.ClientID, oauthCfg.ClientSecret, code)
+	accessToken, err := s.githubExchangeCode(r.Context(), oauthCfg.ClientID, oauthCfg.ClientSecret, code, exchangeRedirectURI)
 	if err != nil {
 		log.Printf("[github-oauth] token exchange error: %v", err)
 		http.Error(w, "token exchange failed", http.StatusBadGateway)
@@ -344,11 +360,14 @@ type githubUser struct {
 	AvatarURL string `json:"avatar_url"`
 }
 
-func (s *Server) githubExchangeCode(ctx context.Context, clientID, clientSecret, code string) (string, error) {
+func (s *Server) githubExchangeCode(ctx context.Context, clientID, clientSecret, code, redirectURI string) (string, error) {
 	body := url.Values{}
 	body.Set("client_id", clientID)
 	body.Set("client_secret", clientSecret)
 	body.Set("code", code)
+	if redirectURI != "" {
+		body.Set("redirect_uri", redirectURI)
+	}
 
 	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, "https://github.com/login/oauth/access_token", strings.NewReader(body.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")

--- a/pkg/hub/auth_github.go
+++ b/pkg/hub/auth_github.go
@@ -417,9 +417,9 @@ func (s *Server) githubFetchUser(ctx context.Context, accessToken string) (*gith
 }
 
 func (s *Server) githubCheckAllowlist(ctx context.Context, cfg *types.GitHubOAuthConfig, accessToken, login string) (bool, error) {
-	// If no allowlist configured at all → deny (safe default)
+	// If no allowlist is configured, allow any authenticated GitHub user.
 	if len(cfg.AllowedUsers) == 0 && len(cfg.AllowedOrgs) == 0 && len(cfg.AllowedTeams) == 0 {
-		return false, nil
+		return true, nil
 	}
 
 	// Check allowed users

--- a/pkg/hub/auth_github.go
+++ b/pkg/hub/auth_github.go
@@ -12,7 +12,6 @@ import (
 	"log"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 	"time"
 
@@ -22,17 +21,6 @@ import (
 // ─── GitHub OAuth session token ───────────────────────────────────────────────
 
 const githubSessionExpiry = 7 * 24 * time.Hour
-const (
-	oauthStateCookieName      = "oauth_state"
-	oauthNextCookieName       = "oauth_next"
-	oauthFrontendOriginCookie = "oauth_frontend_origin"
-	oauthCodeTTL         = 2 * time.Minute
-)
-
-type pendingOAuthCode struct {
-	Token     string
-	ExpiresAt time.Time
-}
 
 // githubSessionPayload is the signed payload stored in OAuth session tokens.
 type githubSessionPayload struct {
@@ -99,9 +87,9 @@ func githubLoginFromContext(ctx context.Context) string {
 	return v
 }
 
-// ─── GitHub OAuth handlers ────────────────────────────────────────────────────
+// ─── Helpers ──────────────────────────────────────────────────────────────────
 
-// githubBaseURL returns the GitHub API base URL (overridable for tests).
+// ghBaseURL returns the GitHub API base URL (overridable for tests).
 func (s *Server) ghBaseURL() string {
 	if s.githubBaseURL != "" {
 		return s.githubBaseURL
@@ -110,8 +98,6 @@ func (s *Server) ghBaseURL() string {
 }
 
 // webSessionSecret returns the HMAC key used to sign/verify web session tokens.
-// Prefer the explicit hub token for backward compatibility, and otherwise fall
-// back to the GitHub OAuth client secret so OAuth-only deployments remain secure.
 func (s *Server) webSessionSecret() string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -125,128 +111,65 @@ func (s *Server) webSessionSecret() string {
 	return ""
 }
 
-// handleGitHubOAuthStart redirects to GitHub OAuth authorize URL.
-func (s *Server) handleGitHubOAuthStart(w http.ResponseWriter, r *http.Request) {
+// ─── Public endpoints ────────────────────────────────────────────────────────
+
+// handleGitHubClientID returns just the OAuth client_id (public, no secret).
+// The frontend needs this to build the GitHub authorize URL client-side.
+func (s *Server) handleGitHubClientID(w http.ResponseWriter, r *http.Request) {
 	s.mu.RLock()
 	cfg := s.hubCfg.Auth
 	s.mu.RUnlock()
+	if cfg == nil || cfg.GitHubOAuth == nil || cfg.GitHubOAuth.ClientID == "" {
+		http.Error(w, "GitHub OAuth not configured", http.StatusNotFound)
+		return
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	jsonOK(w, map[string]string{"client_id": cfg.GitHubOAuth.ClientID})
+}
+
+// ─── GitHub OAuth exchange ────────────────────────────────────────────────────
+//
+// The frontend handles the GitHub OAuth redirect entirely:
+//   1. Frontend generates state, redirects user to GitHub with redirect_uri=<frontend>/login
+//   2. GitHub sends code back to <frontend>/login?code=...&state=...
+//   3. Frontend validates state, then POSTs {code, redirect_uri} to this endpoint
+//   4. Hub exchanges code with GitHub (holds client_secret), validates allowlist,
+//      and returns a signed session token directly — no Go redirects ever appear in the browser.
+
+// handleGitHubOAuthExchange accepts {code, redirect_uri} from the frontend,
+// exchanges it with GitHub, validates allowlist, and returns a session token.
+func (s *Server) handleGitHubOAuthExchange(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	s.mu.RLock()
+	cfg := s.hubCfg.Auth
+	s.mu.RUnlock()
+
 	if cfg == nil || cfg.GitHubOAuth == nil {
 		http.Error(w, "GitHub OAuth not configured", http.StatusNotFound)
 		return
 	}
 	oauthCfg := cfg.GitHubOAuth
-
-	state, err := randomState()
-	if err != nil {
+	secret := s.webSessionSecret()
+	if secret == "" {
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
 
-	// Store state in a short-lived cookie for CSRF protection
-	http.SetCookie(w, &http.Cookie{
-		Name:     oauthStateCookieName,
-		Value:    state,
-		MaxAge:   600,
-		HttpOnly: true,
-		SameSite: http.SameSiteLaxMode,
-		Path:     "/",
-	})
-	if next := safeNextPath(r.URL.Query().Get("next")); next != "" {
-		http.SetCookie(w, &http.Cookie{
-			Name:     oauthNextCookieName,
-			Value:    base64.RawURLEncoding.EncodeToString([]byte(next)),
-			MaxAge:   600,
-			HttpOnly: true,
-			SameSite: http.SameSiteLaxMode,
-			Path:     "/",
-		})
+	var body struct {
+		Code        string `json:"code"`
+		RedirectURI string `json:"redirect_uri"`
 	}
-	// Store the frontend origin so the callback redirect lands on the right host.
-	// In dev the frontend runs on a different port than the hub.
-	frontendOrigin := ""
-	if ref := r.Referer(); ref != "" {
-		if u, err := url.Parse(ref); err == nil {
-			frontendOrigin = u.Scheme + "://" + u.Host
-		}
-	}
-	if frontendOrigin != "" {
-		http.SetCookie(w, &http.Cookie{
-			Name:     oauthFrontendOriginCookie,
-			Value:    frontendOrigin,
-			MaxAge:   600,
-			HttpOnly: true,
-			SameSite: http.SameSiteLaxMode,
-			Path:     "/",
-		})
-	}
-
-	// Build redirect_uri from the incoming request so the callback lands on the
-	// correct host regardless of what's registered in the GitHub OAuth app.
-	scheme := "https"
-	if r.TLS == nil && r.Header.Get("X-Forwarded-Proto") != "https" {
-		scheme = "http"
-	}
-	redirectURI := fmt.Sprintf("%s://%s/api/auth/github/callback", scheme, r.Host)
-
-	authURL := fmt.Sprintf(
-		"https://github.com/login/oauth/authorize?client_id=%s&scope=read:user,read:org&state=%s&redirect_uri=%s",
-		url.QueryEscape(oauthCfg.ClientID),
-		url.QueryEscape(state),
-		url.QueryEscape(redirectURI),
-	)
-	http.Redirect(w, r, authURL, http.StatusFound)
-}
-
-// handleGitHubOAuthCallback handles the OAuth callback from GitHub.
-func (s *Server) handleGitHubOAuthCallback(w http.ResponseWriter, r *http.Request) {
-	s.mu.RLock()
-	cfg := s.hubCfg.Auth
-	s.mu.RUnlock()
-	secret := s.webSessionSecret()
-
-	if cfg == nil || cfg.GitHubOAuth == nil {
-		http.Error(w, "GitHub OAuth not configured", http.StatusNotFound)
-		return
-	}
-	oauthCfg := cfg.GitHubOAuth
-
-	// Validate state
-	stateCookie, err := r.Cookie(oauthStateCookieName)
-	if err != nil || r.URL.Query().Get("state") != stateCookie.Value {
-		http.Error(w, "invalid state", http.StatusBadRequest)
-		return
-	}
-	var next string
-	if nextCookie, err := r.Cookie(oauthNextCookieName); err == nil {
-		if decoded, err := base64.RawURLEncoding.DecodeString(nextCookie.Value); err == nil {
-			next = safeNextPath(string(decoded))
-		}
-	}
-	// Read and clear the frontend origin cookie
-	var frontendOriginFromCookie string
-	if c, err := r.Cookie(oauthFrontendOriginCookie); err == nil {
-		frontendOriginFromCookie = c.Value
-	}
-	// Clear all OAuth cookies
-	for _, name := range []string{oauthStateCookieName, oauthNextCookieName, oauthFrontendOriginCookie} {
-		http.SetCookie(w, &http.Cookie{Name: name, Value: "", MaxAge: -1, Path: "/", HttpOnly: true})
-	}
-
-	code := r.URL.Query().Get("code")
-	if code == "" {
-		http.Error(w, "missing code", http.StatusBadRequest)
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Code == "" {
+		http.Error(w, "invalid request", http.StatusBadRequest)
 		return
 	}
 
-	// Reconstruct redirect_uri to match what was sent in the authorization request
-	exchangeScheme := "https"
-	if r.TLS == nil && r.Header.Get("X-Forwarded-Proto") != "https" {
-		exchangeScheme = "http"
-	}
-	exchangeRedirectURI := fmt.Sprintf("%s://%s/api/auth/github/callback", exchangeScheme, r.Host)
-
-	// Exchange code for access token
-	accessToken, err := s.githubExchangeCode(r.Context(), oauthCfg.ClientID, oauthCfg.ClientSecret, code, exchangeRedirectURI)
+	// Exchange code for GitHub access token
+	accessToken, err := s.githubExchangeCode(r.Context(), oauthCfg.ClientID, oauthCfg.ClientSecret, body.Code, body.RedirectURI)
 	if err != nil {
 		log.Printf("[github-oauth] token exchange error: %v", err)
 		http.Error(w, "token exchange failed", http.StatusBadGateway)
@@ -273,12 +196,8 @@ func (s *Server) handleGitHubOAuthCallback(w http.ResponseWriter, r *http.Reques
 		http.Error(w, "access denied", http.StatusForbidden)
 		return
 	}
-	if secret == "" {
-		http.Error(w, "internal error", http.StatusInternalServerError)
-		return
-	}
 
-	// Issue session token
+	// Issue signed session token
 	sessionToken, err := signGitHubSession(secret, ghUser.Login, ghUser.Name, ghUser.AvatarURL)
 	if err != nil {
 		http.Error(w, "internal error", http.StatusInternalServerError)
@@ -287,93 +206,8 @@ func (s *Server) handleGitHubOAuthCallback(w http.ResponseWriter, r *http.Reques
 
 	log.Printf("[github-oauth] login: %s (%s)", ghUser.Login, ghUser.Name)
 
-	// Exchange long-lived session token for short-lived one-time code in URL.
-	oauthCode, err := randomState()
-	if err != nil {
-		http.Error(w, "internal error", http.StatusInternalServerError)
-		return
-	}
-	now := time.Now()
-	expiresAt := now.Add(oauthCodeTTL)
-	s.cleanupExpiredOAuthCodes(now)
-	s.mu.Lock()
-	s.oauthCodes[oauthCode] = pendingOAuthCode{
-		Token:     sessionToken,
-		ExpiresAt: expiresAt,
-	}
-	s.mu.Unlock()
-
-	redirectQuery := url.Values{"oauth_code": []string{oauthCode}}
-	if next != "" {
-		redirectQuery.Set("next", next)
-	}
-	// Redirect to the frontend /login page. In dev the hub and web run on
-	// different ports, so use the stored frontend origin cookie if present.
-	frontendBase := frontendOriginFromCookie
-	if frontendBase == "" {
-		// Fallback: same host as the hub (production case)
-		scheme := "https"
-		if r.TLS == nil && r.Header.Get("X-Forwarded-Proto") != "https" {
-			scheme = "http"
-		}
-		frontendBase = fmt.Sprintf("%s://%s", scheme, r.Host)
-	}
-	redirectURL := frontendBase + "/login?" + redirectQuery.Encode()
-	http.Redirect(w, r, redirectURL, http.StatusFound)
-}
-
-func (s *Server) handleGitHubOAuthExchange(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
-	var body struct {
-		Code string `json:"code"`
-	}
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Code == "" {
-		http.Error(w, "invalid request", http.StatusBadRequest)
-		return
-	}
-
-	now := time.Now()
-	s.cleanupExpiredOAuthCodes(now)
-	s.mu.Lock()
-	pending, ok := s.oauthCodes[body.Code]
-	if ok {
-		delete(s.oauthCodes, body.Code)
-	}
-	s.mu.Unlock()
-	if !ok || now.After(pending.ExpiresAt) {
-		http.Error(w, "invalid code", http.StatusUnauthorized)
-		return
-	}
-
-	ttl := int(time.Until(pending.ExpiresAt).Seconds())
-	if ttl < 0 {
-		ttl = 0
-	}
 	w.Header().Set("Cache-Control", "no-store")
-	w.Header().Set("Pragma", "no-cache")
-	w.Header().Set("X-OAuth-Code-TTL", strconv.Itoa(ttl))
-	jsonOK(w, map[string]string{"github_token": pending.Token})
-}
-
-func (s *Server) cleanupExpiredOAuthCodesLoop() {
-	ticker := time.NewTicker(oauthCodeTTL)
-	defer ticker.Stop()
-	for range ticker.C {
-		s.cleanupExpiredOAuthCodes(time.Now())
-	}
-}
-
-func (s *Server) cleanupExpiredOAuthCodes(now time.Time) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	for key, pending := range s.oauthCodes {
-		if now.After(pending.ExpiresAt) {
-			delete(s.oauthCodes, key)
-		}
-	}
+	jsonOK(w, map[string]string{"github_token": sessionToken})
 }
 
 // ─── GitHub API helpers ───────────────────────────────────────────────────────
@@ -542,21 +376,4 @@ func randomState() (string, error) {
 		return "", err
 	}
 	return base64.RawURLEncoding.EncodeToString(b), nil
-}
-
-func safeNextPath(next string) string {
-	if next == "" {
-		return ""
-	}
-	parsed, err := url.Parse(next)
-	if err != nil {
-		return ""
-	}
-	if parsed.IsAbs() || parsed.Host != "" {
-		return ""
-	}
-	if !strings.HasPrefix(next, "/") || strings.HasPrefix(next, "//") {
-		return ""
-	}
-	return next
 }

--- a/pkg/hub/auth_github.go
+++ b/pkg/hub/auth_github.go
@@ -21,6 +21,10 @@ import (
 // ─── GitHub OAuth session token ───────────────────────────────────────────────
 
 const githubSessionExpiry = 7 * 24 * time.Hour
+const (
+	oauthStateCookieName = "oauth_state"
+	oauthNextCookieName  = "oauth_next"
+)
 
 // githubSessionPayload is the signed payload stored in OAuth session tokens.
 type githubSessionPayload struct {
@@ -97,6 +101,22 @@ func (s *Server) ghBaseURL() string {
 	return "https://api.github.com"
 }
 
+// webSessionSecret returns the HMAC key used to sign/verify web session tokens.
+// Prefer the explicit hub token for backward compatibility, and otherwise fall
+// back to the GitHub OAuth client secret so OAuth-only deployments remain secure.
+func (s *Server) webSessionSecret() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.hubCfg.Token != "" {
+		return s.hubCfg.Token
+	}
+	if s.hubCfg.Auth != nil && s.hubCfg.Auth.GitHubOAuth != nil {
+		return s.hubCfg.Auth.GitHubOAuth.ClientSecret
+	}
+	return ""
+}
+
 // handleGitHubOAuthStart redirects to GitHub OAuth authorize URL.
 func (s *Server) handleGitHubOAuthStart(w http.ResponseWriter, r *http.Request) {
 	s.mu.RLock()
@@ -116,13 +136,23 @@ func (s *Server) handleGitHubOAuthStart(w http.ResponseWriter, r *http.Request) 
 
 	// Store state in a short-lived cookie for CSRF protection
 	http.SetCookie(w, &http.Cookie{
-		Name:     "oauth_state",
+		Name:     oauthStateCookieName,
 		Value:    state,
 		MaxAge:   600,
 		HttpOnly: true,
 		SameSite: http.SameSiteLaxMode,
 		Path:     "/",
 	})
+	if next := r.URL.Query().Get("next"); next != "" {
+		http.SetCookie(w, &http.Cookie{
+			Name:     oauthNextCookieName,
+			Value:    base64.RawURLEncoding.EncodeToString([]byte(next)),
+			MaxAge:   600,
+			HttpOnly: true,
+			SameSite: http.SameSiteLaxMode,
+			Path:     "/",
+		})
+	}
 
 	authURL := fmt.Sprintf(
 		"https://github.com/login/oauth/authorize?client_id=%s&scope=read:user,read:org&state=%s",
@@ -136,8 +166,8 @@ func (s *Server) handleGitHubOAuthStart(w http.ResponseWriter, r *http.Request) 
 func (s *Server) handleGitHubOAuthCallback(w http.ResponseWriter, r *http.Request) {
 	s.mu.RLock()
 	cfg := s.hubCfg.Auth
-	secret := s.hubCfg.Token
 	s.mu.RUnlock()
+	secret := s.webSessionSecret()
 
 	if cfg == nil || cfg.GitHubOAuth == nil {
 		http.Error(w, "GitHub OAuth not configured", http.StatusNotFound)
@@ -146,17 +176,30 @@ func (s *Server) handleGitHubOAuthCallback(w http.ResponseWriter, r *http.Reques
 	oauthCfg := cfg.GitHubOAuth
 
 	// Validate state
-	stateCookie, err := r.Cookie("oauth_state")
+	stateCookie, err := r.Cookie(oauthStateCookieName)
 	if err != nil || r.URL.Query().Get("state") != stateCookie.Value {
 		http.Error(w, "invalid state", http.StatusBadRequest)
 		return
 	}
+	var next string
+	if nextCookie, err := r.Cookie(oauthNextCookieName); err == nil {
+		if decoded, err := base64.RawURLEncoding.DecodeString(nextCookie.Value); err == nil {
+			next = string(decoded)
+		}
+	}
 	// Clear the state cookie
 	http.SetCookie(w, &http.Cookie{
-		Name:    "oauth_state",
-		Value:   "",
-		MaxAge:  -1,
-		Path:    "/",
+		Name:     oauthStateCookieName,
+		Value:    "",
+		MaxAge:   -1,
+		Path:     "/",
+		HttpOnly: true,
+	})
+	http.SetCookie(w, &http.Cookie{
+		Name:     oauthNextCookieName,
+		Value:    "",
+		MaxAge:   -1,
+		Path:     "/",
 		HttpOnly: true,
 	})
 
@@ -194,6 +237,10 @@ func (s *Server) handleGitHubOAuthCallback(w http.ResponseWriter, r *http.Reques
 		http.Error(w, "access denied", http.StatusForbidden)
 		return
 	}
+	if secret == "" {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
 
 	// Issue session token
 	sessionToken, err := signGitHubSession(secret, ghUser.Login, ghUser.Name, ghUser.AvatarURL)
@@ -206,7 +253,11 @@ func (s *Server) handleGitHubOAuthCallback(w http.ResponseWriter, r *http.Reques
 
 	// Redirect to the web UI login page with the token as a query param.
 	// The login page will pick it up, store it in sessionStorage, and redirect to home.
-	redirectURL := fmt.Sprintf("/login?github_token=%s", url.QueryEscape(sessionToken))
+	redirectQuery := url.Values{"github_token": []string{sessionToken}}
+	if next != "" {
+		redirectQuery.Set("next", next)
+	}
+	redirectURL := "/login?" + redirectQuery.Encode()
 	http.Redirect(w, r, redirectURL, http.StatusFound)
 }
 

--- a/pkg/hub/auth_github.go
+++ b/pkg/hub/auth_github.go
@@ -3,7 +3,6 @@ package hub
 import (
 	"context"
 	"crypto/hmac"
-	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
@@ -368,12 +367,4 @@ func (s *Server) githubCheckTeamMembership(ctx context.Context, accessToken, org
 	}
 	defer resp.Body.Close()
 	return resp.StatusCode == http.StatusNoContent, nil
-}
-
-func randomState() (string, error) {
-	b := make([]byte, 16)
-	if _, err := rand.Read(b); err != nil {
-		return "", err
-	}
-	return base64.RawURLEncoding.EncodeToString(b), nil
 }

--- a/pkg/hub/auth_github.go
+++ b/pkg/hub/auth_github.go
@@ -101,9 +101,6 @@ func (s *Server) webSessionSecret() string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	if s.hubCfg.Token != "" {
-		return s.hubCfg.Token
-	}
 	if s.hubCfg.Auth != nil && s.hubCfg.Auth.GitHubOAuth != nil {
 		return s.hubCfg.Auth.GitHubOAuth.ClientSecret
 	}

--- a/pkg/hub/github_webhook.go
+++ b/pkg/hub/github_webhook.go
@@ -703,16 +703,11 @@ func (s *Server) mergePRForClaw(clawID string) {
 		return
 	}
 
-	ghBase := s.githubBaseURL
-	if ghBase == "" {
-		ghBase = "https://api.github.com"
-	}
-
 	body, _ := json.Marshal(map[string]string{
 		"merge_method": "squash",
 	})
 	req, _ := http.NewRequest(http.MethodPut,
-		fmt.Sprintf("%s/repos/%s/pulls/%d/merge", ghBase, repo, prNumber),
+		fmt.Sprintf("%s/repos/%s/pulls/%d/merge", s.ghBaseURL(), repo, prNumber),
 		bytes.NewReader(body),
 	)
 	req.Header.Set("Authorization", "Bearer "+token)

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -586,8 +586,6 @@ func (s *Server) handleClawSubresource(w http.ResponseWriter, r *http.Request) {
 		s.handleClawPRs(w, r, clawID)
 	case "settings":
 		s.handleClawSettings(w, r, clawID)
-	default:
-		http.Error(w, "not found", http.StatusNotFound)
 	}
 }
 

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -571,7 +571,7 @@ func (s *Server) handleClawSubresource(w http.ResponseWriter, r *http.Request) {
 		var clawTags []string
 		_ = json.Unmarshal([]byte(tagsJSON), &clawTags)
 		if sub == "settings" && r.Method != http.MethodGet {
-			if !canInteractWithClaw(accessCfg, ghLogin, clawTags) {
+			if !canModifyClaw(accessCfg, ghLogin, clawTags) {
 				http.Error(w, "forbidden", http.StatusForbidden)
 				return
 			}

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -549,6 +549,38 @@ func (s *Server) handleClawSubresource(w http.ResponseWriter, r *http.Request) {
 	clawID := parts[0]
 	sub := parts[1]
 
+	if sub != "prs" && sub != "settings" {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+
+	ghLogin := githubLoginFromContext(r.Context())
+	if ghLogin != "" {
+		s.mu.RLock()
+		var accessCfg *types.AccessConfig
+		if s.hubCfg.Auth != nil {
+			accessCfg = s.hubCfg.Auth.Access
+		}
+		s.mu.RUnlock()
+
+		var tagsJSON string
+		if err := s.db.QueryRow(`SELECT COALESCE(tags,'[]') FROM claws WHERE id=? AND tenant_id=?`, clawID, tenantFromCtx(r)).Scan(&tagsJSON); err != nil {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		var clawTags []string
+		_ = json.Unmarshal([]byte(tagsJSON), &clawTags)
+		if sub == "settings" && r.Method != http.MethodGet {
+			if !canInteractWithClaw(accessCfg, ghLogin, clawTags) {
+				http.Error(w, "forbidden", http.StatusForbidden)
+				return
+			}
+		} else if !canViewClaw(accessCfg, ghLogin, clawTags) {
+			http.Error(w, "forbidden", http.StatusForbidden)
+			return
+		}
+	}
+
 	switch sub {
 	case "prs":
 		s.handleClawPRs(w, r, clawID)

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -40,6 +40,8 @@ type Server struct {
 	mu    sync.RWMutex
 	claws map[string]*clawConn // claw_id -> conn
 	users map[string]*userConn // tenant_id -> []conn (broadcast)
+	// one-time oauth_code -> signed GitHub session token
+	oauthCodes map[string]pendingOAuthCode
 
 	fileAckMu       sync.Mutex
 	fileAckWaiters  map[string]chan types.FileAck      // request_id -> waiter
@@ -104,6 +106,7 @@ func NewServer(addr, dbPath, identityDir string, hubCfg *types.HubConfig) (*Serv
 		identity:        id,
 		claws:           make(map[string]*clawConn),
 		users:           make(map[string]*userConn),
+		oauthCodes:      make(map[string]pendingOAuthCode),
 		fileAckWaiters:  make(map[string]chan types.FileAck),
 		fileReadWaiters: make(map[string]chan types.FileReadResp),
 	}
@@ -166,7 +169,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/claw/ws", s.handleClawWS)
 
 	// Browser WebSocket
-	mux.HandleFunc("/api/ws", s.handleUserWS)
+	mux.HandleFunc("/api/ws", s.withAuth(s.handleUserWS))
 
 	// REST API
 	mux.HandleFunc("/api/login", s.handleLogin)
@@ -176,6 +179,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/auth/config", s.handleAuthConfig) // public — no auth required
 	mux.HandleFunc("/api/auth/github", s.handleGitHubOAuthStart)
 	mux.HandleFunc("/api/auth/github/callback", s.handleGitHubOAuthCallback)
+	mux.HandleFunc("/api/auth/github/exchange", s.handleGitHubOAuthExchange)
 	mux.HandleFunc("/api/hub-config", s.withWebAuth(s.handleHubConfig))
 	mux.HandleFunc("/api/settings", s.withWebAuth(s.handleSettings))
 	mux.HandleFunc("/api/settings/status", s.withWebAuth(s.handleSettingsStatus))
@@ -249,12 +253,16 @@ func (s *Server) withAuth(next http.HandlerFunc) http.HandlerFunc {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}
-		tenantID, err := s.tenantByToken(token)
-		if err != nil {
+		tenantID, githubLogin, ok := s.resolveAuthToken(token)
+		if !ok {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}
-		r = r.WithContext(context.WithValue(r.Context(), ctxTenantKey{}, tenantID))
+		ctx := context.WithValue(r.Context(), ctxTenantKey{}, tenantID)
+		if githubLogin != "" {
+			ctx = context.WithValue(ctx, ctxGitHubLoginKey{}, githubLogin)
+		}
+		r = r.WithContext(ctx)
 		next(w, r)
 	}
 }
@@ -264,6 +272,45 @@ type ctxTenantKey struct{}
 func tenantFromCtx(r *http.Request) string {
 	v, _ := r.Context().Value(ctxTenantKey{}).(string)
 	return v
+}
+
+// resolveAuthToken accepts either a tenant token (legacy/password auth)
+// or a GitHub OAuth session token and returns the resolved tenant/login.
+func (s *Server) resolveAuthToken(token string) (tenantID, githubLogin string, ok bool) {
+	if token == "" {
+		return "", "", false
+	}
+	if tenantID, err := s.tenantByToken(token); err == nil {
+		return tenantID, "", true
+	}
+	sessionSecret := s.webSessionSecret()
+	if sessionSecret == "" {
+		return "", "", false
+	}
+	payload, valid := verifyGitHubSession(sessionSecret, token)
+	if !valid {
+		return "", "", false
+	}
+	tenantID, err := s.githubTenantID()
+	if err != nil {
+		return "", "", false
+	}
+	return tenantID, payload.Login, true
+}
+
+// githubTenantID resolves the tenant backing GitHub OAuth sessions.
+func (s *Server) githubTenantID() (string, error) {
+	s.mu.RLock()
+	hubToken := s.hubCfg.Token
+	s.mu.RUnlock()
+	if hubToken != "" {
+		if tenantID, err := s.tenantByToken(hubToken); err == nil {
+			return tenantID, nil
+		}
+	}
+	var tenantID string
+	err := s.db.QueryRow(`SELECT id FROM tenants ORDER BY created_at ASC LIMIT 1`).Scan(&tenantID)
+	return tenantID, err
 }
 
 func (s *Server) tenantByToken(token string) (string, error) {
@@ -389,8 +436,8 @@ func (s *Server) handleAuthConfig(w http.ResponseWriter, r *http.Request) {
 	passwordAuthEnabled := s.hubCfg.Token != ""
 	s.mu.RUnlock()
 	jsonOK(w, map[string]bool{
-		"github_oauth_enabled":   githubOAuthEnabled,
-		"password_auth_enabled":  passwordAuthEnabled,
+		"github_oauth_enabled":  githubOAuthEnabled,
+		"password_auth_enabled": passwordAuthEnabled,
 	})
 }
 
@@ -1367,11 +1414,15 @@ func (w *proxyResponseWriter) WriteHeader(status int) {
 // ─── User WebSocket ───────────────────────────────────────────────────────────
 
 func (s *Server) handleUserWS(w http.ResponseWriter, r *http.Request) {
-	token := r.URL.Query().Get("token")
-	tenantID, err := s.tenantByToken(token)
-	if err != nil {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
-		return
+	tenantID := tenantFromCtx(r)
+	if tenantID == "" {
+		token := r.URL.Query().Get("token")
+		resolvedTenantID, _, ok := s.resolveAuthToken(token)
+		if !ok {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		tenantID = resolvedTenantID
 	}
 
 	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1071,7 +1071,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 			}
 			var clawTagsMsg []string
 			_ = json.Unmarshal([]byte(tagsJSONMsg), &clawTagsMsg)
-			if !canModifyClaw(accessCfgMsg, ghLoginMsg, clawTagsMsg) {
+			if !canInteractWithClaw(accessCfgMsg, ghLoginMsg, clawTagsMsg) {
 				http.Error(w, "forbidden", http.StatusForbidden)
 				return
 			}
@@ -1694,7 +1694,7 @@ func (s *Server) handleUserWS(w http.ResponseWriter, r *http.Request) {
 					currentAccessCfg = s.hubCfg.Auth.Access
 				}
 				s.mu.RUnlock()
-				if !canModifyClaw(currentAccessCfg, ghLogin, clawTags) {
+				if !canInteractWithClaw(currentAccessCfg, ghLogin, clawTags) {
 					continue
 				}
 			}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -42,7 +42,6 @@ type Server struct {
 	users map[string]*userConn // tenant_id -> []conn (broadcast)
 	// one-time oauth_code -> signed GitHub session token
 
-
 	fileAckMu       sync.Mutex
 	fileAckWaiters  map[string]chan types.FileAck      // request_id -> waiter
 	fileReadWaiters map[string]chan types.FileReadResp // request_id -> waiter
@@ -81,8 +80,10 @@ func gatewayReadyBool(v *bool) bool {
 }
 
 type userConn struct {
-	conn     *websocket.Conn
-	tenantID string
+	conn        *websocket.Conn
+	send        func(context.Context, types.WSMessage) error
+	tenantID    string
+	githubLogin string
 }
 
 // NewServer creates a hub server backed by a SQLite database at dbPath.
@@ -176,12 +177,12 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/auth/login", s.handleWebLogin)
 	mux.HandleFunc("/api/auth/logout", s.handleWebLogout)
 	mux.HandleFunc("/api/auth/me", s.withWebAuth(s.handleWebMe))
-	mux.HandleFunc("/api/auth/config", s.handleAuthConfig) // public — no auth required
+	mux.HandleFunc("/api/auth/config", s.handleAuthConfig)               // public — no auth required
 	mux.HandleFunc("/api/auth/github/client-id", s.handleGitHubClientID) // public
 	mux.HandleFunc("/api/auth/github/exchange", s.handleGitHubOAuthExchange)
-	mux.HandleFunc("/api/hub-config", s.withWebAuth(s.handleHubConfig))
-	mux.HandleFunc("/api/settings", s.withWebAuth(s.handleSettings))
-	mux.HandleFunc("/api/settings/status", s.withWebAuth(s.handleSettingsStatus))
+	mux.HandleFunc("/api/hub-config", s.withWebAdminAuth(s.handleHubConfig))
+	mux.HandleFunc("/api/settings", s.withWebAdminAuth(s.handleSettings))
+	mux.HandleFunc("/api/settings/status", s.withWebAdminAuth(s.handleSettingsStatus))
 
 	// Template store
 	mux.HandleFunc("/api/templates", s.withWebAuth(s.handleTemplates))
@@ -191,9 +192,9 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/integrations/linear/webhook", s.handleLinearWebhook)
 	mux.HandleFunc("/api/integrations/github/webhook", s.handleGitHubWebhook)
 	mux.HandleFunc("/api/integrations/shortcut/webhook", s.handleShortcutWebhook)
-	mux.HandleFunc("/api/factories/", s.withAuth(s.handleFactoryEvents)) // GET /api/factories/:name/events
-	mux.HandleFunc("/api/factories", s.withAuth(s.handleFactoriesCRUD))  // factory CRUD (GET list, POST push)
-	mux.HandleFunc("/api/secrets", s.withWebAuth(s.handleSecretsCRUD))   // secrets CRUD (GET names, PUT upsert, DELETE)
+	mux.HandleFunc("/api/factories/", s.withAuth(s.handleFactoryEvents))    // GET /api/factories/:name/events
+	mux.HandleFunc("/api/factories", s.withAuth(s.handleFactoriesCRUD))     // factory CRUD (GET list, POST push)
+	mux.HandleFunc("/api/secrets", s.withWebAdminAuth(s.handleSecretsCRUD)) // secrets CRUD (GET names, PUT upsert, DELETE)
 	mux.HandleFunc("/api/claws", s.withAuth(s.handleClaws))
 	mux.HandleFunc("/api/claws/{id}", s.withAuth(s.handleClawDetail))
 	mux.HandleFunc("/api/terminal/", s.handleTerminal)
@@ -206,12 +207,12 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	// AI Config
 	// AI Config — register sub-paths before the bare path so Go's exact-match
 	// ServeMux routes them correctly (avoids 404 on specific sub-paths).
-	mux.HandleFunc("/api/settings/ai-config/apply", s.withWebAuth(s.handleAIConfigApply))
-	mux.HandleFunc("/api/settings/ai-config/revert", s.withWebAuth(s.handleAIConfigRevert))
-	mux.HandleFunc("/api/settings/ai-config/backup", s.withWebAuth(s.handleAIConfigBackup))
-	mux.HandleFunc("/api/settings/ai-config/stream", s.withWebAuth(s.handleAIConfigStream))
-	mux.HandleFunc("/api/settings/ai-config/current-config", s.withWebAuth(s.handleAIConfigCurrentConfig))
-	mux.HandleFunc("/api/settings/ai-config", s.withWebAuth(s.handleAIConfig))
+	mux.HandleFunc("/api/settings/ai-config/apply", s.withWebAdminAuth(s.handleAIConfigApply))
+	mux.HandleFunc("/api/settings/ai-config/revert", s.withWebAdminAuth(s.handleAIConfigRevert))
+	mux.HandleFunc("/api/settings/ai-config/backup", s.withWebAdminAuth(s.handleAIConfigBackup))
+	mux.HandleFunc("/api/settings/ai-config/stream", s.withWebAdminAuth(s.handleAIConfigStream))
+	mux.HandleFunc("/api/settings/ai-config/current-config", s.withWebAdminAuth(s.handleAIConfigCurrentConfig))
+	mux.HandleFunc("/api/settings/ai-config", s.withWebAdminAuth(s.handleAIConfig))
 
 	// Health
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
@@ -375,6 +376,60 @@ func (s *Server) withWebAuth(next http.HandlerFunc) http.HandlerFunc {
 		// Try GitHub OAuth session token
 		if sessionSecret != "" {
 			if payload, ok := verifyGitHubSession(sessionSecret, token); ok {
+				ctx := context.WithValue(r.Context(), ctxGitHubLoginKey{}, payload.Login)
+				r = r.WithContext(ctx)
+				next(w, r)
+				return
+			}
+		}
+
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}
+}
+
+func isAccessAdmin(cfg *types.AccessConfig, login string) bool {
+	if login == "" || cfg == nil {
+		return false
+	}
+	for _, admin := range cfg.Admins {
+		if strings.EqualFold(admin, login) {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *Server) withWebAdminAuth(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		token := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+		if token == "" {
+			token = r.Header.Get(webSessionHeader)
+		}
+		if token == "" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		s.mu.RLock()
+		hubToken := s.hubCfg.Token
+		var accessCfg *types.AccessConfig
+		if s.hubCfg.Auth != nil {
+			accessCfg = s.hubCfg.Auth.Access
+		}
+		s.mu.RUnlock()
+		sessionSecret := s.webSessionSecret()
+
+		// Password-authenticated sessions keep existing admin access.
+		if token == hubToken {
+			next(w, r)
+			return
+		}
+
+		if sessionSecret != "" {
+			if payload, ok := verifyGitHubSession(sessionSecret, token); ok {
+				if !isAccessAdmin(accessCfg, payload.Login) {
+					http.Error(w, "forbidden", http.StatusForbidden)
+					return
+				}
 				ctx := context.WithValue(r.Context(), ctxGitHubLoginKey{}, payload.Login)
 				r = r.WithContext(ctx)
 				next(w, r)
@@ -1536,7 +1591,11 @@ func (s *Server) handleUserWS(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	uc := &userConn{conn: conn, tenantID: tenantID}
+	uc := &userConn{
+		conn:        conn,
+		tenantID:    tenantID,
+		githubLogin: ghLogin,
+	}
 	connID := uuid.New().String()
 
 	s.mu.Lock()
@@ -1655,13 +1714,65 @@ func (s *Server) handleUserWS(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) broadcastToUsers(tenantID string, msg types.WSMessage) {
+	for _, uc := range s.broadcastRecipients(tenantID, msg) {
+		_ = wsjson.Write(context.Background(), uc.conn, msg)
+	}
+}
+
+func (s *Server) broadcastRecipients(tenantID string, msg types.WSMessage) []*userConn {
+	clawID := clawIDFromWSMessage(msg)
+	clawTags := []string(nil)
+	if clawID != "" {
+		clawTags = s.clawTagsForBroadcast(tenantID, clawID)
+	}
+
 	s.mu.RLock()
 	defer s.mu.RUnlock()
+	recipients := make([]*userConn, 0, len(s.users))
 	for _, uc := range s.users {
-		if uc.tenantID == tenantID {
-			_ = wsjson.Write(context.Background(), uc.conn, msg)
+		if uc.tenantID != tenantID {
+			continue
 		}
+		if uc.githubLogin != "" && clawID != "" {
+			var accessCfg *types.AccessConfig
+			if s.hubCfg.Auth != nil {
+				accessCfg = s.hubCfg.Auth.Access
+			}
+			if !canViewClaw(accessCfg, uc.githubLogin, clawTags) {
+				continue
+			}
+		}
+		recipients = append(recipients, uc)
 	}
+	return recipients
+}
+
+func (s *Server) clawTagsForBroadcast(tenantID, clawID string) []string {
+	s.mu.RLock()
+	if cc := s.claws[clawID]; cc != nil && cc.tenantID == tenantID {
+		tags := append([]string(nil), cc.tags...)
+		s.mu.RUnlock()
+		return tags
+	}
+	s.mu.RUnlock()
+
+	var tagsJSON string
+	_ = s.db.QueryRow(`SELECT COALESCE(tags,'[]') FROM claws WHERE id = ? AND tenant_id = ?`, clawID, tenantID).Scan(&tagsJSON)
+	var tags []string
+	_ = json.Unmarshal([]byte(tagsJSON), &tags)
+	return tags
+}
+
+func clawIDFromWSMessage(msg types.WSMessage) string {
+	payload, err := json.Marshal(msg.Payload)
+	if err != nil {
+		return ""
+	}
+	var envelope struct {
+		ClawID string `json:"claw_id"`
+	}
+	_ = json.Unmarshal(payload, &envelope)
+	return envelope.ClawID
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1694,7 +1694,13 @@ func (s *Server) handleUserWS(w http.ResponseWriter, r *http.Request) {
 				_ = s.db.QueryRow(`SELECT COALESCE(tags,'[]') FROM claws WHERE id = ? AND tenant_id = ?`, hm.ClawID, tenantID).Scan(&tagsJSON)
 				var clawTags []string
 				_ = json.Unmarshal([]byte(tagsJSON), &clawTags)
-				if !canInteractWithClaw(accessCfg, ghLogin, clawTags) {
+				var currentAccessCfg *types.AccessConfig
+				s.mu.RLock()
+				if s.hubCfg.Auth != nil {
+					currentAccessCfg = s.hubCfg.Auth.Access
+				}
+				s.mu.RUnlock()
+				if !canInteractWithClaw(currentAccessCfg, ghLogin, clawTags) {
 					continue
 				}
 			}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -391,6 +391,13 @@ func (s *Server) handleWebLogin(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
+	s.mu.RLock()
+	disablePassword := s.hubCfg.Auth != nil && s.hubCfg.Auth.DisablePasswordAuth
+	s.mu.RUnlock()
+	if disablePassword {
+		http.Error(w, "password login disabled", http.StatusForbidden)
+		return
+	}
 	var body struct {
 		Password string `json:"password"`
 	}
@@ -442,7 +449,7 @@ func (s *Server) handleWebMe(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleAuthConfig(w http.ResponseWriter, r *http.Request) {
 	s.mu.RLock()
 	githubOAuthEnabled := s.hubCfg.Auth != nil && s.hubCfg.Auth.GitHubOAuth != nil && s.hubCfg.Auth.GitHubOAuth.ClientID != ""
-	passwordAuthEnabled := s.hubCfg.Token != ""
+	passwordAuthEnabled := s.hubCfg.Token != "" && !(s.hubCfg.Auth != nil && s.hubCfg.Auth.DisablePasswordAuth)
 	s.mu.RUnlock()
 	jsonOK(w, map[string]bool{
 		"github_oauth_enabled":  githubOAuthEnabled,

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1568,12 +1568,15 @@ func (s *Server) handleUserWS(w http.ResponseWriter, r *http.Request) {
 	tenantID := tenantFromCtx(r)
 	if tenantID == "" {
 		token := r.URL.Query().Get("token")
-		resolvedTenantID, _, ok := s.resolveAuthToken(token)
+		resolvedTenantID, resolvedLogin, ok := s.resolveAuthToken(token)
 		if !ok {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}
 		tenantID = resolvedTenantID
+		if resolvedLogin != "" {
+			r = r.WithContext(context.WithValue(r.Context(), ctxGitHubLoginKey{}, resolvedLogin))
+		}
 	}
 
 	ghLogin := githubLoginFromContext(r.Context())

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1566,19 +1566,6 @@ func (w *proxyResponseWriter) WriteHeader(status int) {
 
 func (s *Server) handleUserWS(w http.ResponseWriter, r *http.Request) {
 	tenantID := tenantFromCtx(r)
-	if tenantID == "" {
-		token := r.URL.Query().Get("token")
-		resolvedTenantID, resolvedLogin, ok := s.resolveAuthToken(token)
-		if !ok {
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
-			return
-		}
-		tenantID = resolvedTenantID
-		if resolvedLogin != "" {
-			r = r.WithContext(context.WithValue(r.Context(), ctxGitHubLoginKey{}, resolvedLogin))
-		}
-	}
-
 	ghLogin := githubLoginFromContext(r.Context())
 	var accessCfg *types.AccessConfig
 	if ghLogin != "" {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -816,13 +816,15 @@ func (s *Server) handleClawDetail(w http.ResponseWriter, r *http.Request) {
 	if r.Method == http.MethodPatch {
 		if ghLogin != "" {
 			var tagsJSON string
-			if err := s.db.QueryRow(`SELECT COALESCE(tags,'[]') FROM claws WHERE id = ? AND tenant_id = ?`, clawID, tenantID).Scan(&tagsJSON); err == nil {
-				var clawTags []string
-				_ = json.Unmarshal([]byte(tagsJSON), &clawTags)
-				if !canInteractWithClaw(accessCfg, ghLogin, clawTags) {
-					http.Error(w, "forbidden", http.StatusForbidden)
-					return
-				}
+			if err := s.db.QueryRow(`SELECT COALESCE(tags,'[]') FROM claws WHERE id = ? AND tenant_id = ?`, clawID, tenantID).Scan(&tagsJSON); err != nil {
+				http.Error(w, "forbidden", http.StatusForbidden)
+				return
+			}
+			var clawTags []string
+			_ = json.Unmarshal([]byte(tagsJSON), &clawTags)
+			if !canInteractWithClaw(accessCfg, ghLogin, clawTags) {
+				http.Error(w, "forbidden", http.StatusForbidden)
+				return
 			}
 		}
 		var body struct {
@@ -871,13 +873,15 @@ func (s *Server) handleClawDetail(w http.ResponseWriter, r *http.Request) {
 		}
 		if ghLogin != "" {
 			var tagsJSON string
-			if err := s.db.QueryRow(`SELECT COALESCE(tags,'[]') FROM claws WHERE id = ? AND tenant_id = ?`, clawID, tenantID).Scan(&tagsJSON); err == nil {
-				var clawTags []string
-				_ = json.Unmarshal([]byte(tagsJSON), &clawTags)
-				if !canInteractWithClaw(accessCfg, ghLogin, clawTags) {
-					http.Error(w, "forbidden", http.StatusForbidden)
-					return
-				}
+			if err := s.db.QueryRow(`SELECT COALESCE(tags,'[]') FROM claws WHERE id = ? AND tenant_id = ?`, clawID, tenantID).Scan(&tagsJSON); err != nil {
+				http.Error(w, "forbidden", http.StatusForbidden)
+				return
+			}
+			var clawTags []string
+			_ = json.Unmarshal([]byte(tagsJSON), &clawTags)
+			if !canInteractWithClaw(accessCfg, ghLogin, clawTags) {
+				http.Error(w, "forbidden", http.StatusForbidden)
+				return
 			}
 		}
 
@@ -2378,7 +2382,9 @@ Tokens are short-lived and refreshed automatically on each git/gh operation.
 	// and would overwrite BOOTSTRAP.md if we wrote it before the script ran.
 	if len(files) > 0 {
 		fileNames := make([]string, 0, len(files))
-		for k := range files { fileNames = append(fileNames, k) }
+		for k := range files {
+			fileNames = append(fileNames, k)
+		}
 		log.Printf("[bootstrap] writing %d template files for claw %s: %v", len(files), clawName, fileNames)
 		for attempt := 1; attempt <= 3; attempt++ {
 			if err := s.sshWriteFiles(sshUser, sshHost, "$HOME/.openclaw/workspace", files); err == nil {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -41,7 +41,7 @@ type Server struct {
 	claws map[string]*clawConn // claw_id -> conn
 	users map[string]*userConn // tenant_id -> []conn (broadcast)
 	// one-time oauth_code -> signed GitHub session token
-	oauthCodes map[string]pendingOAuthCode
+
 
 	fileAckMu       sync.Mutex
 	fileAckWaiters  map[string]chan types.FileAck      // request_id -> waiter
@@ -107,14 +107,12 @@ func NewServer(addr, dbPath, identityDir string, hubCfg *types.HubConfig) (*Serv
 		identity:        id,
 		claws:           make(map[string]*clawConn),
 		users:           make(map[string]*userConn),
-		oauthCodes:      make(map[string]pendingOAuthCode),
 		fileAckWaiters:  make(map[string]chan types.FileAck),
 		fileReadWaiters: make(map[string]chan types.FileReadResp),
 	}
 
 	// Start background poller to keep provider VM status fresh
 	go srv.pollProviderStatus()
-	go srv.cleanupExpiredOAuthCodesLoop()
 	srv.startPRWatcher()
 
 	return srv, nil
@@ -179,8 +177,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/auth/logout", s.handleWebLogout)
 	mux.HandleFunc("/api/auth/me", s.withWebAuth(s.handleWebMe))
 	mux.HandleFunc("/api/auth/config", s.handleAuthConfig) // public — no auth required
-	mux.HandleFunc("/api/auth/github", s.handleGitHubOAuthStart)
-	mux.HandleFunc("/api/auth/github/callback", s.handleGitHubOAuthCallback)
+	mux.HandleFunc("/api/auth/github/client-id", s.handleGitHubClientID) // public
 	mux.HandleFunc("/api/auth/github/exchange", s.handleGitHubOAuthExchange)
 	mux.HandleFunc("/api/hub-config", s.withWebAuth(s.handleHubConfig))
 	mux.HandleFunc("/api/settings", s.withWebAuth(s.handleSettings))

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -487,17 +487,24 @@ func (s *Server) handleWebMe(w http.ResponseWriter, r *http.Request) {
 		sessionSecret := s.webSessionSecret()
 		if sessionSecret != "" {
 			if payload, ok := verifyGitHubSession(sessionSecret, token); ok {
-				jsonOK(w, map[string]string{
+				s.mu.RLock()
+				var accessCfg *types.AccessConfig
+				if s.hubCfg.Auth != nil {
+					accessCfg = s.hubCfg.Auth.Access
+				}
+				s.mu.RUnlock()
+				jsonOK(w, map[string]interface{}{
 					"login":       payload.Login,
 					"name":        payload.Name,
 					"avatar_url":  payload.AvatarURL,
 					"auth_method": "github",
+					"is_admin":    isAccessAdmin(accessCfg, payload.Login),
 				})
 				return
 			}
 		}
 	}
-	jsonOK(w, map[string]string{"auth_method": "password"})
+	jsonOK(w, map[string]interface{}{"auth_method": "password", "is_admin": true})
 }
 
 // handleAuthConfig returns public auth config (no auth required).

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -377,6 +377,7 @@ func (s *Server) withWebAuth(next http.HandlerFunc) http.HandlerFunc {
 		if sessionSecret != "" {
 			if payload, ok := verifyGitHubSession(sessionSecret, token); ok {
 				ctx := context.WithValue(r.Context(), ctxGitHubLoginKey{}, payload.Login)
+				ctx = context.WithValue(ctx, ctxGitHubSessionPayloadKey{}, payload)
 				r = r.WithContext(ctx)
 				next(w, r)
 				return
@@ -478,31 +479,21 @@ func (s *Server) handleWebLogout(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleWebMe(w http.ResponseWriter, r *http.Request) {
-	if login := githubLoginFromContext(r.Context()); login != "" {
-		// Decode full payload from the token to get name and avatar
-		token := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
-		if token == "" {
-			token = r.Header.Get(webSessionHeader)
+	if payload := githubSessionPayloadFromContext(r.Context()); payload != nil {
+		s.mu.RLock()
+		var accessCfg *types.AccessConfig
+		if s.hubCfg.Auth != nil {
+			accessCfg = s.hubCfg.Auth.Access
 		}
-		sessionSecret := s.webSessionSecret()
-		if sessionSecret != "" {
-			if payload, ok := verifyGitHubSession(sessionSecret, token); ok {
-				s.mu.RLock()
-				var accessCfg *types.AccessConfig
-				if s.hubCfg.Auth != nil {
-					accessCfg = s.hubCfg.Auth.Access
-				}
-				s.mu.RUnlock()
-				jsonOK(w, map[string]interface{}{
-					"login":       payload.Login,
-					"name":        payload.Name,
-					"avatar_url":  payload.AvatarURL,
-					"auth_method": "github",
-					"is_admin":    isAccessAdmin(accessCfg, payload.Login),
-				})
-				return
-			}
-		}
+		s.mu.RUnlock()
+		jsonOK(w, map[string]interface{}{
+			"login":       payload.Login,
+			"name":        payload.Name,
+			"avatar_url":  payload.AvatarURL,
+			"auth_method": "github",
+			"is_admin":    isAccessAdmin(accessCfg, payload.Login),
+		})
+		return
 	}
 	jsonOK(w, map[string]interface{}{"auth_method": "password", "is_admin": true})
 }

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -793,8 +793,28 @@ func (s *Server) handleClawDetail(w http.ResponseWriter, r *http.Request) {
 	if clawID == "" {
 		clawID = strings.TrimPrefix(r.URL.Path, "/api/claws/")
 	}
+	ghLogin := githubLoginFromContext(r.Context())
+	var accessCfg *types.AccessConfig
+	if ghLogin != "" {
+		s.mu.RLock()
+		if s.hubCfg.Auth != nil {
+			accessCfg = s.hubCfg.Auth.Access
+		}
+		s.mu.RUnlock()
+	}
 
 	if r.Method == http.MethodPatch {
+		if ghLogin != "" {
+			var tagsJSON string
+			if err := s.db.QueryRow(`SELECT COALESCE(tags,'[]') FROM claws WHERE id = ? AND tenant_id = ?`, clawID, tenantID).Scan(&tagsJSON); err == nil {
+				var clawTags []string
+				_ = json.Unmarshal([]byte(tagsJSON), &clawTags)
+				if !canViewClaw(accessCfg, ghLogin, clawTags) {
+					http.Error(w, "forbidden", http.StatusForbidden)
+					return
+				}
+			}
+		}
 		var body struct {
 			Name  *string   `json:"name"`
 			Tags  *[]string `json:"tags"`
@@ -838,6 +858,17 @@ func (s *Server) handleClawDetail(w http.ResponseWriter, r *http.Request) {
 		_ = s.db.QueryRow(`SELECT id FROM claws WHERE tenant_id = ? AND (id = ? OR id LIKE ?)`, tenantID, clawID, clawID+"%").Scan(&fullID)
 		if fullID != "" {
 			clawID = fullID
+		}
+		if ghLogin != "" {
+			var tagsJSON string
+			if err := s.db.QueryRow(`SELECT COALESCE(tags,'[]') FROM claws WHERE id = ? AND tenant_id = ?`, clawID, tenantID).Scan(&tagsJSON); err == nil {
+				var clawTags []string
+				_ = json.Unmarshal([]byte(tagsJSON), &clawTags)
+				if !canViewClaw(accessCfg, ghLogin, clawTags) {
+					http.Error(w, "forbidden", http.StatusForbidden)
+					return
+				}
+			}
 		}
 
 		// Look up provider info before deleting so we can terminate the VM
@@ -884,6 +915,10 @@ func (s *Server) handleClawDetail(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "db error", http.StatusInternalServerError)
 		return
 	}
+	if ghLogin != "" && !canViewClaw(accessCfg, ghLogin, c.Tags) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
 	c.TenantID = tenantID
 	if lastSeen.Valid {
 		c.LastSeen = lastSeen.Time
@@ -907,6 +942,15 @@ func (s *Server) handleClawDetail(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	tenantID := tenantFromCtx(r)
 	clawID := strings.TrimPrefix(r.URL.Path, "/api/messages/")
+	ghLoginMsg := githubLoginFromContext(r.Context())
+	var accessCfgMsg *types.AccessConfig
+	if ghLoginMsg != "" {
+		s.mu.RLock()
+		if s.hubCfg.Auth != nil {
+			accessCfgMsg = s.hubCfg.Auth.Access
+		}
+		s.mu.RUnlock()
+	}
 
 	if r.Method == http.MethodPost {
 		var body struct {
@@ -918,14 +962,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Apply tag-based interact filter for GitHub OAuth users
-		ghLoginMsg := githubLoginFromContext(r.Context())
 		if ghLoginMsg != "" {
-			s.mu.RLock()
-			var accessCfgMsg *types.AccessConfig
-			if s.hubCfg.Auth != nil {
-				accessCfgMsg = s.hubCfg.Auth.Access
-			}
-			s.mu.RUnlock()
 			// Fetch claw tags to check interact permission
 			var tagsJSONMsg string
 			_ = s.db.QueryRow(`SELECT COALESCE(tags,'[]') FROM claws WHERE id = ? AND tenant_id = ?`, clawID, tenantID).Scan(&tagsJSONMsg)
@@ -957,6 +994,16 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		}
 		jsonOK(w, msg)
 		return
+	}
+	if ghLoginMsg != "" {
+		var tagsJSONMsg string
+		_ = s.db.QueryRow(`SELECT COALESCE(tags,'[]') FROM claws WHERE id = ? AND tenant_id = ?`, clawID, tenantID).Scan(&tagsJSONMsg)
+		var clawTagsMsg []string
+		_ = json.Unmarshal([]byte(tagsJSONMsg), &clawTagsMsg)
+		if !canViewClaw(accessCfgMsg, ghLoginMsg, clawTagsMsg) {
+			http.Error(w, "forbidden", http.StatusForbidden)
+			return
+		}
 	}
 
 	// Pagination: ?before=<created_at>&limit=<n> for older messages

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -173,6 +173,9 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/auth/login", s.handleWebLogin)
 	mux.HandleFunc("/api/auth/logout", s.handleWebLogout)
 	mux.HandleFunc("/api/auth/me", s.withWebAuth(s.handleWebMe))
+	mux.HandleFunc("/api/auth/config", s.handleAuthConfig) // public — no auth required
+	mux.HandleFunc("/api/auth/github", s.handleGitHubOAuthStart)
+	mux.HandleFunc("/api/auth/github/callback", s.handleGitHubOAuthCallback)
 	mux.HandleFunc("/api/hub-config", s.withWebAuth(s.handleHubConfig))
 	mux.HandleFunc("/api/settings", s.withWebAuth(s.handleSettings))
 	mux.HandleFunc("/api/settings/status", s.withWebAuth(s.handleSettingsStatus))
@@ -298,15 +301,29 @@ func (s *Server) withWebAuth(next http.HandlerFunc) http.HandlerFunc {
 		if token == "" {
 			token = r.Header.Get(webSessionHeader)
 		}
-		// Hub token doubles as the web session token — reject empty tokens even if hub token is unset
-		s.mu.RLock()
-		hubToken := s.hubCfg.Token
-		s.mu.RUnlock()
-		if token == "" || token != hubToken {
+		if token == "" {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}
-		next(w, r)
+		s.mu.RLock()
+		hubToken := s.hubCfg.Token
+		s.mu.RUnlock()
+
+		// Accept shared hub token (existing behavior)
+		if token == hubToken {
+			next(w, r)
+			return
+		}
+
+		// Try GitHub OAuth session token
+		if payload, ok := verifyGitHubSession(hubToken, token); ok {
+			ctx := context.WithValue(r.Context(), ctxGitHubLoginKey{}, payload.Login)
+			r = r.WithContext(ctx)
+			next(w, r)
+			return
+		}
+
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
 	}
 }
 
@@ -340,7 +357,38 @@ func (s *Server) handleWebLogout(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleWebMe(w http.ResponseWriter, r *http.Request) {
-	jsonOK(w, map[string]string{"status": "ok"})
+	if login := githubLoginFromContext(r.Context()); login != "" {
+		// Decode full payload from the token to get name and avatar
+		token := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+		if token == "" {
+			token = r.Header.Get(webSessionHeader)
+		}
+		s.mu.RLock()
+		hubToken := s.hubCfg.Token
+		s.mu.RUnlock()
+		if payload, ok := verifyGitHubSession(hubToken, token); ok {
+			jsonOK(w, map[string]string{
+				"login":       payload.Login,
+				"name":        payload.Name,
+				"avatar_url":  payload.AvatarURL,
+				"auth_method": "github",
+			})
+			return
+		}
+	}
+	jsonOK(w, map[string]string{"auth_method": "password"})
+}
+
+// handleAuthConfig returns public auth config (no auth required).
+func (s *Server) handleAuthConfig(w http.ResponseWriter, r *http.Request) {
+	s.mu.RLock()
+	githubOAuthEnabled := s.hubCfg.Auth != nil && s.hubCfg.Auth.GitHubOAuth != nil && s.hubCfg.Auth.GitHubOAuth.ClientID != ""
+	passwordAuthEnabled := s.hubCfg.Token != ""
+	s.mu.RUnlock()
+	jsonOK(w, map[string]bool{
+		"github_oauth_enabled":   githubOAuthEnabled,
+		"password_auth_enabled":  passwordAuthEnabled,
+	})
 }
 
 func (s *Server) serveWebUI(mux *http.ServeMux, staticFS fs.FS) {
@@ -484,6 +532,15 @@ func (s *Server) handleClaws(w http.ResponseWriter, r *http.Request) {
 	}
 	defer rows.Close()
 
+	// Resolve access config and GitHub login for tag-based filtering
+	s.mu.RLock()
+	var accessCfg *types.AccessConfig
+	if s.hubCfg.Auth != nil {
+		accessCfg = s.hubCfg.Auth.Access
+	}
+	s.mu.RUnlock()
+	ghLogin := githubLoginFromContext(r.Context())
+
 	var out []types.Claw
 	for rows.Next() {
 		var c types.Claw
@@ -512,6 +569,10 @@ func (s *Server) handleClaws(w http.ResponseWriter, r *http.Request) {
 			// Not currently connected and not in an active provisioning state —
 			// DB status is stale (e.g. 'connected' from before hub restart)
 			c.Status = "offline"
+		}
+		// Apply tag-based view filter (only applies to GitHub OAuth users)
+		if ghLogin != "" && !canViewClaw(accessCfg, ghLogin, c.Tags) {
+			continue
 		}
 		out = append(out, c)
 	}
@@ -805,6 +866,27 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "invalid request", http.StatusBadRequest)
 			return
 		}
+
+		// Apply tag-based interact filter for GitHub OAuth users
+		ghLoginMsg := githubLoginFromContext(r.Context())
+		if ghLoginMsg != "" {
+			s.mu.RLock()
+			var accessCfgMsg *types.AccessConfig
+			if s.hubCfg.Auth != nil {
+				accessCfgMsg = s.hubCfg.Auth.Access
+			}
+			s.mu.RUnlock()
+			// Fetch claw tags to check interact permission
+			var tagsJSONMsg string
+			_ = s.db.QueryRow(`SELECT COALESCE(tags,'[]') FROM claws WHERE id = ? AND tenant_id = ?`, clawID, tenantID).Scan(&tagsJSONMsg)
+			var clawTagsMsg []string
+			_ = json.Unmarshal([]byte(tagsJSONMsg), &clawTagsMsg)
+			if !canInteractWithClaw(accessCfgMsg, ghLoginMsg, clawTagsMsg) {
+				http.Error(w, "forbidden", http.StatusForbidden)
+				return
+			}
+		}
+
 		msg := types.HubMessage{
 			ID: uuid.New().String(), ClawID: clawID, TenantID: tenantID,
 			Role: "user", Content: body.Content, CreatedAt: now(),

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -308,6 +308,7 @@ func (s *Server) withWebAuth(next http.HandlerFunc) http.HandlerFunc {
 		s.mu.RLock()
 		hubToken := s.hubCfg.Token
 		s.mu.RUnlock()
+		sessionSecret := s.webSessionSecret()
 
 		// Accept shared hub token (existing behavior)
 		if token == hubToken {
@@ -316,11 +317,13 @@ func (s *Server) withWebAuth(next http.HandlerFunc) http.HandlerFunc {
 		}
 
 		// Try GitHub OAuth session token
-		if payload, ok := verifyGitHubSession(hubToken, token); ok {
-			ctx := context.WithValue(r.Context(), ctxGitHubLoginKey{}, payload.Login)
-			r = r.WithContext(ctx)
-			next(w, r)
-			return
+		if sessionSecret != "" {
+			if payload, ok := verifyGitHubSession(sessionSecret, token); ok {
+				ctx := context.WithValue(r.Context(), ctxGitHubLoginKey{}, payload.Login)
+				r = r.WithContext(ctx)
+				next(w, r)
+				return
+			}
 		}
 
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
@@ -363,17 +366,17 @@ func (s *Server) handleWebMe(w http.ResponseWriter, r *http.Request) {
 		if token == "" {
 			token = r.Header.Get(webSessionHeader)
 		}
-		s.mu.RLock()
-		hubToken := s.hubCfg.Token
-		s.mu.RUnlock()
-		if payload, ok := verifyGitHubSession(hubToken, token); ok {
-			jsonOK(w, map[string]string{
-				"login":       payload.Login,
-				"name":        payload.Name,
-				"avatar_url":  payload.AvatarURL,
-				"auth_method": "github",
-			})
-			return
+		sessionSecret := s.webSessionSecret()
+		if sessionSecret != "" {
+			if payload, ok := verifyGitHubSession(sessionSecret, token); ok {
+				jsonOK(w, map[string]string{
+					"login":       payload.Login,
+					"name":        payload.Name,
+					"avatar_url":  payload.AvatarURL,
+					"auth_method": "github",
+				})
+				return
+			}
 		}
 	}
 	jsonOK(w, map[string]string{"auth_method": "password"})

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -809,7 +809,7 @@ func (s *Server) handleClawDetail(w http.ResponseWriter, r *http.Request) {
 			if err := s.db.QueryRow(`SELECT COALESCE(tags,'[]') FROM claws WHERE id = ? AND tenant_id = ?`, clawID, tenantID).Scan(&tagsJSON); err == nil {
 				var clawTags []string
 				_ = json.Unmarshal([]byte(tagsJSON), &clawTags)
-				if !canViewClaw(accessCfg, ghLogin, clawTags) {
+				if !canInteractWithClaw(accessCfg, ghLogin, clawTags) {
 					http.Error(w, "forbidden", http.StatusForbidden)
 					return
 				}
@@ -864,7 +864,7 @@ func (s *Server) handleClawDetail(w http.ResponseWriter, r *http.Request) {
 			if err := s.db.QueryRow(`SELECT COALESCE(tags,'[]') FROM claws WHERE id = ? AND tenant_id = ?`, clawID, tenantID).Scan(&tagsJSON); err == nil {
 				var clawTags []string
 				_ = json.Unmarshal([]byte(tagsJSON), &clawTags)
-				if !canViewClaw(accessCfg, ghLogin, clawTags) {
+				if !canInteractWithClaw(accessCfg, ghLogin, clawTags) {
 					http.Error(w, "forbidden", http.StatusForbidden)
 					return
 				}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -887,7 +887,7 @@ func (s *Server) handleClawDetail(w http.ResponseWriter, r *http.Request) {
 			}
 			var clawTags []string
 			_ = json.Unmarshal([]byte(tagsJSON), &clawTags)
-			if !canInteractWithClaw(accessCfg, ghLogin, clawTags) {
+			if !canModifyClaw(accessCfg, ghLogin, clawTags) {
 				http.Error(w, "forbidden", http.StatusForbidden)
 				return
 			}
@@ -954,7 +954,7 @@ func (s *Server) handleClawDetail(w http.ResponseWriter, r *http.Request) {
 			}
 			var clawTags []string
 			_ = json.Unmarshal([]byte(tagsJSON), &clawTags)
-			if !canInteractWithClaw(accessCfg, ghLogin, clawTags) {
+			if !canModifyClaw(accessCfg, ghLogin, clawTags) {
 				http.Error(w, "forbidden", http.StatusForbidden)
 				return
 			}
@@ -1064,7 +1064,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 			}
 			var clawTagsMsg []string
 			_ = json.Unmarshal([]byte(tagsJSONMsg), &clawTagsMsg)
-			if !canInteractWithClaw(accessCfgMsg, ghLoginMsg, clawTagsMsg) {
+			if !canModifyClaw(accessCfgMsg, ghLoginMsg, clawTagsMsg) {
 				http.Error(w, "forbidden", http.StatusForbidden)
 				return
 			}
@@ -1687,7 +1687,7 @@ func (s *Server) handleUserWS(w http.ResponseWriter, r *http.Request) {
 					currentAccessCfg = s.hubCfg.Auth.Access
 				}
 				s.mu.RUnlock()
-				if !canInteractWithClaw(currentAccessCfg, ghLogin, clawTags) {
+				if !canModifyClaw(currentAccessCfg, ghLogin, clawTags) {
 					continue
 				}
 			}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -57,6 +57,7 @@ type clawConn struct {
 	id                   string
 	tenantID             string
 	conn                 *websocket.Conn
+	tags                 []string        // cached from DB at registration time for access-control checks
 	contextUsage         int             // 0-100, updated from heartbeats
 	gatewayReady         bool            // true once bridge reports gateway session established
 	streamingBuf         strings.Builder // accumulates chunks for current in-flight response
@@ -860,6 +861,12 @@ func (s *Server) handleClawDetail(w http.ResponseWriter, r *http.Request) {
 			}
 			tagsJSON, _ := json.Marshal(normalized)
 			_, _ = s.db.Exec(`UPDATE claws SET tags = ?, updated_at = datetime('now') WHERE id = ? AND tenant_id = ?`, string(tagsJSON), clawID, tenantID)
+			// Update in-memory cache so WS broadcast filtering stays current
+			s.mu.Lock()
+			if cc, ok := s.claws[clawID]; ok {
+				cc.tags = normalized
+			}
+			s.mu.Unlock()
 		}
 		if body.Color != nil {
 			color := resolveColor(*body.Color, clawID)
@@ -1027,7 +1034,11 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	}
 	if ghLoginMsg != "" {
 		var tagsJSONMsg string
-		_ = s.db.QueryRow(`SELECT COALESCE(tags,'[]') FROM claws WHERE id = ? AND tenant_id = ?`, clawID, tenantID).Scan(&tagsJSONMsg)
+		err := s.db.QueryRow(`SELECT COALESCE(tags,'[]') FROM claws WHERE id = ? AND tenant_id = ?`, clawID, tenantID).Scan(&tagsJSONMsg)
+		if err == sql.ErrNoRows {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
 		var clawTagsMsg []string
 		_ = json.Unmarshal([]byte(tagsJSONMsg), &clawTagsMsg)
 		if !canViewClaw(accessCfgMsg, ghLoginMsg, clawTagsMsg) {
@@ -1146,7 +1157,11 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cc := &clawConn{id: clawID, tenantID: tenantID, conn: conn, gatewayReady: gatewayReadyBool(rp.GatewayReady)}
+	var registrationTagsJSON string
+	_ = s.db.QueryRow(`SELECT COALESCE(tags,'[]') FROM claws WHERE id = ? AND tenant_id = ?`, clawID, tenantID).Scan(&registrationTagsJSON)
+	var registrationTags []string
+	_ = json.Unmarshal([]byte(registrationTagsJSON), &registrationTags)
+	cc := &clawConn{id: clawID, tenantID: tenantID, conn: conn, gatewayReady: gatewayReadyBool(rp.GatewayReady), tags: registrationTags}
 	s.mu.Lock()
 	s.claws[clawID] = cc
 	s.mu.Unlock()
@@ -1502,6 +1517,16 @@ func (s *Server) handleUserWS(w http.ResponseWriter, r *http.Request) {
 		tenantID = resolvedTenantID
 	}
 
+	ghLogin := githubLoginFromContext(r.Context())
+	var accessCfg *types.AccessConfig
+	if ghLogin != "" {
+		s.mu.RLock()
+		if s.hubCfg.Auth != nil {
+			accessCfg = s.hubCfg.Auth.Access
+		}
+		s.mu.RUnlock()
+	}
+
 	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
 	if err != nil {
 		return
@@ -1524,14 +1549,14 @@ func (s *Server) handleUserWS(w http.ResponseWriter, r *http.Request) {
 	// Send current claw statuses immediately on connect.
 	// First, emit DB rows for claws not yet bridge-connected (provisioning/starting/error).
 	type dbClaw struct {
-		id, name, status string
+		id, name, status, tagsJSON string
 	}
 	var dbClaws []dbClaw
-	rows, _ := s.db.QueryContext(ctx, `SELECT id, name, status FROM claws WHERE tenant_id=? AND status NOT IN ('offline')`, tenantID)
+	rows, _ := s.db.QueryContext(ctx, `SELECT id, name, status, COALESCE(tags,'[]') FROM claws WHERE tenant_id=? AND status NOT IN ('offline')`, tenantID)
 	if rows != nil {
 		for rows.Next() {
 			var c dbClaw
-			_ = rows.Scan(&c.id, &c.name, &c.status)
+			_ = rows.Scan(&c.id, &c.name, &c.status, &c.tagsJSON)
 			dbClaws = append(dbClaws, c)
 		}
 		_ = rows.Close()
@@ -1540,6 +1565,10 @@ func (s *Server) handleUserWS(w http.ResponseWriter, r *http.Request) {
 	connectedIDs := make(map[string]bool)
 	for _, cc := range s.claws {
 		if cc.tenantID != tenantID {
+			continue
+		}
+		// Apply tag-based view filter for GitHub OAuth users
+		if ghLogin != "" && !canViewClaw(accessCfg, ghLogin, cc.tags) {
 			continue
 		}
 		connectedIDs[cc.id] = true
@@ -1561,6 +1590,14 @@ func (s *Server) handleUserWS(w http.ResponseWriter, r *http.Request) {
 	for _, c := range dbClaws {
 		if connectedIDs[c.id] {
 			continue // already sent above
+		}
+		// Apply tag-based view filter for GitHub OAuth users
+		if ghLogin != "" {
+			var clawTags []string
+			_ = json.Unmarshal([]byte(c.tagsJSON), &clawTags)
+			if !canViewClaw(accessCfg, ghLogin, clawTags) {
+				continue
+			}
 		}
 		_ = wsjson.Write(ctx, conn, types.WSMessage{
 			Type: "claw_status",
@@ -1584,6 +1621,16 @@ func (s *Server) handleUserWS(w http.ResponseWriter, r *http.Request) {
 			var hm types.HubMessage
 			if err := json.Unmarshal(payload, &hm); err != nil {
 				continue
+			}
+			// Apply tag-based interact filter for GitHub OAuth users
+			if ghLogin != "" {
+				var tagsJSON string
+				_ = s.db.QueryRow(`SELECT COALESCE(tags,'[]') FROM claws WHERE id = ? AND tenant_id = ?`, hm.ClawID, tenantID).Scan(&tagsJSON)
+				var clawTags []string
+				_ = json.Unmarshal([]byte(tagsJSON), &clawTags)
+				if !canInteractWithClaw(accessCfg, ghLogin, clawTags) {
+					continue
+				}
 			}
 			hm.ID = uuid.New().String()
 			hm.TenantID = tenantID

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -113,6 +113,7 @@ func NewServer(addr, dbPath, identityDir string, hubCfg *types.HubConfig) (*Serv
 
 	// Start background poller to keep provider VM status fresh
 	go srv.pollProviderStatus()
+	go srv.cleanupExpiredOAuthCodesLoop()
 	srv.startPRWatcher()
 
 	return srv, nil
@@ -817,7 +818,11 @@ func (s *Server) handleClawDetail(w http.ResponseWriter, r *http.Request) {
 		if ghLogin != "" {
 			var tagsJSON string
 			if err := s.db.QueryRow(`SELECT COALESCE(tags,'[]') FROM claws WHERE id = ? AND tenant_id = ?`, clawID, tenantID).Scan(&tagsJSON); err != nil {
-				http.Error(w, "forbidden", http.StatusForbidden)
+				if err == sql.ErrNoRows {
+					http.Error(w, "not found", http.StatusNotFound)
+				} else {
+					http.Error(w, "db error", http.StatusInternalServerError)
+				}
 				return
 			}
 			var clawTags []string
@@ -874,7 +879,11 @@ func (s *Server) handleClawDetail(w http.ResponseWriter, r *http.Request) {
 		if ghLogin != "" {
 			var tagsJSON string
 			if err := s.db.QueryRow(`SELECT COALESCE(tags,'[]') FROM claws WHERE id = ? AND tenant_id = ?`, clawID, tenantID).Scan(&tagsJSON); err != nil {
-				http.Error(w, "forbidden", http.StatusForbidden)
+				if err == sql.ErrNoRows {
+					http.Error(w, "not found", http.StatusNotFound)
+				} else {
+					http.Error(w, "db error", http.StatusInternalServerError)
+				}
 				return
 			}
 			var clawTags []string
@@ -979,7 +988,14 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		if ghLoginMsg != "" {
 			// Fetch claw tags to check interact permission
 			var tagsJSONMsg string
-			_ = s.db.QueryRow(`SELECT COALESCE(tags,'[]') FROM claws WHERE id = ? AND tenant_id = ?`, clawID, tenantID).Scan(&tagsJSONMsg)
+			if err := s.db.QueryRow(`SELECT COALESCE(tags,'[]') FROM claws WHERE id = ? AND tenant_id = ?`, clawID, tenantID).Scan(&tagsJSONMsg); err != nil {
+				if err == sql.ErrNoRows {
+					http.Error(w, "not found", http.StatusNotFound)
+				} else {
+					http.Error(w, "db error", http.StatusInternalServerError)
+				}
+				return
+			}
 			var clawTagsMsg []string
 			_ = json.Unmarshal([]byte(tagsJSONMsg), &clawTagsMsg)
 			if !canInteractWithClaw(accessCfgMsg, ghLoginMsg, clawTagsMsg) {

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -177,6 +177,56 @@ func TestClawSubresourceRequiresTagAccessForGitHubSession(t *testing.T) {
 	}
 }
 
+func TestGitHubWritesRequireViewAndInteractAccess(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{
+		Auth: &types.AuthConfig{
+			Access: &types.AccessConfig{
+				ViewRequiresTags: []string{"owner={user}"},
+			},
+		},
+	}, "", "")
+	_, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, tags, created_at) VALUES(?,?,?,?,datetime('now'))`,
+		"claw-1", "test-tenant-id", "claw 1", `["owner=alice"]`,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tt := range []struct {
+		name   string
+		method string
+		path   string
+		body   string
+	}{
+		{name: "patch claw", method: http.MethodPatch, path: "/api/claws/claw-1", body: `{"name":"new"}`},
+		{name: "delete claw", method: http.MethodDelete, path: "/api/claws/claw-1"},
+		{name: "post message", method: http.MethodPost, path: "/api/messages/claw-1", body: `{"content":"hello"}`},
+		{name: "patch settings", method: http.MethodPatch, path: "/api/claws/claw-1/settings", body: `{"autoFixCI":false}`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, tt.path, strings.NewReader(tt.body))
+			req = req.WithContext(context.WithValue(req.Context(), ctxTenantKey{}, "test-tenant-id"))
+			req = req.WithContext(context.WithValue(req.Context(), ctxGitHubLoginKey{}, "bob"))
+			rec := httptest.NewRecorder()
+
+			switch tt.path {
+			case "/api/claws/claw-1":
+				req.SetPathValue("id", "claw-1")
+				s.handleClawDetail(rec, req)
+			case "/api/messages/claw-1":
+				s.handleMessages(rec, req)
+			default:
+				s.handleClawSubresource(rec, req)
+			}
+
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("expected status %d, got %d", http.StatusForbidden, rec.Code)
+			}
+		})
+	}
+}
+
 func TestWebAdminAuthRequiresAccessAdminForGitHubSession(t *testing.T) {
 	s, _ := NewTestServerWithConfig(t, &types.HubConfig{
 		Token: "hub-token",

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -201,7 +201,6 @@ func TestGitHubWritesRequireViewAndInteractAccess(t *testing.T) {
 	}{
 		{name: "patch claw", method: http.MethodPatch, path: "/api/claws/claw-1", body: `{"name":"new"}`},
 		{name: "delete claw", method: http.MethodDelete, path: "/api/claws/claw-1"},
-		{name: "post message", method: http.MethodPost, path: "/api/messages/claw-1", body: `{"content":"hello"}`},
 		{name: "patch settings", method: http.MethodPatch, path: "/api/claws/claw-1/settings", body: `{"autoFixCI":false}`},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -227,6 +226,35 @@ func TestGitHubWritesRequireViewAndInteractAccess(t *testing.T) {
 	}
 }
 
+func TestGitHubMessagesRequireInteractAccessOnly(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{
+		Auth: &types.AuthConfig{
+			Access: &types.AccessConfig{
+				ViewRequiresTags:     []string{"viewer={user}"},
+				InteractRequiresTags: []string{"operator={user}"},
+			},
+		},
+	}, "", "")
+	_, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, tags, created_at) VALUES(?,?,?,?,datetime('now'))`,
+		"claw-1", "test-tenant-id", "claw 1", `["operator=bob"]`,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/messages/claw-1", strings.NewReader(`{"content":"hello"}`))
+	req = req.WithContext(context.WithValue(req.Context(), ctxTenantKey{}, "test-tenant-id"))
+	req = req.WithContext(context.WithValue(req.Context(), ctxGitHubLoginKey{}, "bob"))
+	rec := httptest.NewRecorder()
+
+	s.handleMessages(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+}
+
 func TestWebAdminAuthRequiresAccessAdminForGitHubSession(t *testing.T) {
 	s, _ := NewTestServerWithConfig(t, &types.HubConfig{
 		Token: "hub-token",
@@ -236,13 +264,29 @@ func TestWebAdminAuthRequiresAccessAdminForGitHubSession(t *testing.T) {
 		},
 	}, "", "")
 
-	session, err := signGitHubSession("hub-token", "regular-user", "", "")
+	forgedSession, err := signGitHubSession("hub-token", "admin-user", "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 	req := httptest.NewRequest(http.MethodGet, "/api/settings", nil)
-	req.Header.Set("Authorization", "Bearer "+session)
+	req.Header.Set("Authorization", "Bearer "+forgedSession)
 	rec := httptest.NewRecorder()
+
+	s.withWebAdminAuth(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("handler should not be called")
+	})(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status %d, got %d", http.StatusUnauthorized, rec.Code)
+	}
+
+	session, err := signGitHubSession("oauth-secret", "regular-user", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	req = httptest.NewRequest(http.MethodGet, "/api/settings", nil)
+	req.Header.Set("Authorization", "Bearer "+session)
+	rec = httptest.NewRecorder()
 
 	s.withWebAdminAuth(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("handler should not be called")
@@ -252,7 +296,7 @@ func TestWebAdminAuthRequiresAccessAdminForGitHubSession(t *testing.T) {
 		t.Fatalf("expected status %d, got %d", http.StatusForbidden, rec.Code)
 	}
 
-	adminSession, err := signGitHubSession("hub-token", "admin-user", "", "")
+	adminSession, err := signGitHubSession("oauth-secret", "admin-user", "", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -6,8 +6,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
-
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
 
@@ -136,20 +134,4 @@ func TestGitHubAccessChecksReturnNotFoundForMissingClaw(t *testing.T) {
 	}
 }
 
-func TestCleanupExpiredOAuthCodes(t *testing.T) {
-	s, _ := NewTestServerWithConfig(t, nil, "", "")
-	now := time.Now()
-	s.oauthCodes = map[string]pendingOAuthCode{
-		"expired": {Token: "old", ExpiresAt: now.Add(-time.Second)},
-		"valid":   {Token: "new", ExpiresAt: now.Add(time.Second)},
-	}
 
-	s.cleanupExpiredOAuthCodes(now)
-
-	if _, ok := s.oauthCodes["expired"]; ok {
-		t.Fatal("expected expired OAuth code to be removed")
-	}
-	if _, ok := s.oauthCodes["valid"]; !ok {
-		t.Fatal("expected valid OAuth code to remain")
-	}
-}

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -259,8 +259,9 @@ func TestWebAdminAuthRequiresAccessAdminForGitHubSession(t *testing.T) {
 	s, _ := NewTestServerWithConfig(t, &types.HubConfig{
 		Token: "hub-token",
 		Auth: &types.AuthConfig{
-			GitHubOAuth: &types.GitHubOAuthConfig{ClientSecret: "oauth-secret"},
-			Access:      &types.AccessConfig{Admins: []string{"admin-user"}},
+			SessionSecret: "session-secret",
+			GitHubOAuth:   &types.GitHubOAuthConfig{ClientSecret: "oauth-secret"},
+			Access:        &types.AccessConfig{Admins: []string{"admin-user"}},
 		},
 	}, "", "")
 
@@ -280,7 +281,23 @@ func TestWebAdminAuthRequiresAccessAdminForGitHubSession(t *testing.T) {
 		t.Fatalf("expected status %d, got %d", http.StatusUnauthorized, rec.Code)
 	}
 
-	session, err := signGitHubSession("oauth-secret", "regular-user", "", "")
+	oauthSecretSession, err := signGitHubSession("oauth-secret", "admin-user", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	req = httptest.NewRequest(http.MethodGet, "/api/settings", nil)
+	req.Header.Set("Authorization", "Bearer "+oauthSecretSession)
+	rec = httptest.NewRecorder()
+
+	s.withWebAdminAuth(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("handler should not be called")
+	})(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status %d, got %d", http.StatusUnauthorized, rec.Code)
+	}
+
+	session, err := signGitHubSession("session-secret", "regular-user", "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -296,7 +313,7 @@ func TestWebAdminAuthRequiresAccessAdminForGitHubSession(t *testing.T) {
 		t.Fatalf("expected status %d, got %d", http.StatusForbidden, rec.Code)
 	}
 
-	adminSession, err := signGitHubSession("oauth-secret", "admin-user", "", "")
+	adminSession, err := signGitHubSession("session-secret", "admin-user", "", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -1,17 +1,22 @@
 package hub
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
 
 func TestResolveDefaultModelForKey(t *testing.T) {
 	tests := []struct {
-		name           string
-		hubCfg         *types.HubConfig
-		key            *types.LLMKeyConfig
-		expectedModel  string
+		name          string
+		hubCfg        *types.HubConfig
+		key           *types.LLMKeyConfig
+		expectedModel string
 	}{
 		{
 			name: "hub default matches key provider",
@@ -90,5 +95,61 @@ func TestResolveDefaultModelForKey(t *testing.T) {
 				t.Errorf("expected %s, got %s", tt.expectedModel, result)
 			}
 		})
+	}
+}
+
+func TestGitHubAccessChecksReturnNotFoundForMissingClaw(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{
+		Auth: &types.AuthConfig{
+			Access: &types.AccessConfig{InteractRequiresTags: []string{"owner={user}"}},
+		},
+	}, "", "")
+
+	for _, tt := range []struct {
+		name   string
+		method string
+		path   string
+		body   string
+	}{
+		{name: "patch claw", method: http.MethodPatch, path: "/api/claws/missing", body: `{"name":"new"}`},
+		{name: "delete claw", method: http.MethodDelete, path: "/api/claws/missing"},
+		{name: "post message", method: http.MethodPost, path: "/api/messages/missing", body: `{"content":"hello"}`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, tt.path, strings.NewReader(tt.body))
+			req = req.WithContext(context.WithValue(req.Context(), ctxTenantKey{}, "test-tenant-id"))
+			req = req.WithContext(context.WithValue(req.Context(), ctxGitHubLoginKey{}, "octocat"))
+			rec := httptest.NewRecorder()
+
+			switch tt.path {
+			case "/api/claws/missing":
+				req.SetPathValue("id", "missing")
+				s.handleClawDetail(rec, req)
+			default:
+				s.handleMessages(rec, req)
+			}
+
+			if rec.Code != http.StatusNotFound {
+				t.Fatalf("expected status %d, got %d", http.StatusNotFound, rec.Code)
+			}
+		})
+	}
+}
+
+func TestCleanupExpiredOAuthCodes(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, nil, "", "")
+	now := time.Now()
+	s.oauthCodes = map[string]pendingOAuthCode{
+		"expired": {Token: "old", ExpiresAt: now.Add(-time.Second)},
+		"valid":   {Token: "new", ExpiresAt: now.Add(time.Second)},
+	}
+
+	s.cleanupExpiredOAuthCodes(now)
+
+	if _, ok := s.oauthCodes["expired"]; ok {
+		t.Fatal("expected expired OAuth code to be removed")
+	}
+	if _, ok := s.oauthCodes["valid"]; !ok {
+		t.Fatal("expected valid OAuth code to remain")
 	}
 }

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -135,6 +135,48 @@ func TestGitHubAccessChecksReturnNotFoundForMissingClaw(t *testing.T) {
 	}
 }
 
+func TestClawSubresourceRequiresTagAccessForGitHubSession(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{
+		Auth: &types.AuthConfig{
+			Access: &types.AccessConfig{
+				ViewRequiresTags:     []string{"owner={user}"},
+				InteractRequiresTags: []string{"owner={user}"},
+			},
+		},
+	}, "", "")
+	_, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, tags, created_at) VALUES(?,?,?,?,datetime('now'))`,
+		"claw-1", "test-tenant-id", "claw 1", `["owner=alice"]`,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tt := range []struct {
+		name   string
+		method string
+		path   string
+		body   string
+	}{
+		{name: "prs", method: http.MethodGet, path: "/api/claws/claw-1/prs"},
+		{name: "settings get", method: http.MethodGet, path: "/api/claws/claw-1/settings"},
+		{name: "settings patch", method: http.MethodPatch, path: "/api/claws/claw-1/settings", body: `{"autoFixCI":false}`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, tt.path, strings.NewReader(tt.body))
+			req = req.WithContext(context.WithValue(req.Context(), ctxTenantKey{}, "test-tenant-id"))
+			req = req.WithContext(context.WithValue(req.Context(), ctxGitHubLoginKey{}, "bob"))
+			rec := httptest.NewRecorder()
+
+			s.handleClawSubresource(rec, req)
+
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("expected status %d, got %d", http.StatusForbidden, rec.Code)
+			}
+		})
+	}
+}
+
 func TestWebAdminAuthRequiresAccessAdminForGitHubSession(t *testing.T) {
 	s, _ := NewTestServerWithConfig(t, &types.HubConfig{
 		Token: "hub-token",

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
 
@@ -134,4 +135,74 @@ func TestGitHubAccessChecksReturnNotFoundForMissingClaw(t *testing.T) {
 	}
 }
 
+func TestWebAdminAuthRequiresAccessAdminForGitHubSession(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{
+		Token: "hub-token",
+		Auth: &types.AuthConfig{
+			GitHubOAuth: &types.GitHubOAuthConfig{ClientSecret: "oauth-secret"},
+			Access:      &types.AccessConfig{Admins: []string{"admin-user"}},
+		},
+	}, "", "")
 
+	session, err := signGitHubSession("hub-token", "regular-user", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/settings", nil)
+	req.Header.Set("Authorization", "Bearer "+session)
+	rec := httptest.NewRecorder()
+
+	s.withWebAdminAuth(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("handler should not be called")
+	})(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected status %d, got %d", http.StatusForbidden, rec.Code)
+	}
+
+	adminSession, err := signGitHubSession("hub-token", "admin-user", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	req = httptest.NewRequest(http.MethodGet, "/api/settings", nil)
+	req.Header.Set("Authorization", "Bearer "+adminSession)
+	rec = httptest.NewRecorder()
+
+	s.withWebAdminAuth(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected status %d, got %d", http.StatusNoContent, rec.Code)
+	}
+}
+
+func TestBroadcastToUsersFiltersGitHubSessionsByClawTags(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{
+		Auth: &types.AuthConfig{
+			Access: &types.AccessConfig{ViewRequiresTags: []string{"owner={user}"}},
+		},
+	}, "", "")
+
+	s.users["allowed"] = &userConn{
+		tenantID:    "test-tenant-id",
+		githubLogin: "alice",
+	}
+	s.users["denied"] = &userConn{
+		tenantID:    "test-tenant-id",
+		githubLogin: "bob",
+	}
+	s.claws["claw-1"] = &clawConn{id: "claw-1", tenantID: "test-tenant-id", tags: []string{"owner=alice"}}
+
+	recipients := s.broadcastRecipients("test-tenant-id", types.WSMessage{
+		Type:    "chunk",
+		Payload: map[string]string{"claw_id": "claw-1", "content": "secret"},
+	})
+
+	if len(recipients) != 1 {
+		t.Fatalf("expected 1 recipient, got %d", len(recipients))
+	}
+	if recipients[0].githubLogin != "alice" {
+		t.Fatalf("expected alice recipient, got %q", recipients[0].githubLogin)
+	}
+}

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -715,17 +715,29 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 			if updatedCfg.Auth == nil {
 				updatedCfg.Auth = &types.AuthConfig{}
 			}
-			// Use patch admins if provided; otherwise preserve existing
+			// Use patch values if provided; otherwise preserve existing
 			var admins []string
 			if patch.Auth.Access.Admins != nil {
 				admins = patch.Auth.Access.Admins
 			} else if updatedCfg.Auth.Access != nil {
 				admins = append([]string(nil), updatedCfg.Auth.Access.Admins...)
 			}
+			var viewRequiresTags []string
+			if patch.Auth.Access.ViewRequiresTags != nil {
+				viewRequiresTags = patch.Auth.Access.ViewRequiresTags
+			} else if updatedCfg.Auth.Access != nil {
+				viewRequiresTags = append([]string(nil), updatedCfg.Auth.Access.ViewRequiresTags...)
+			}
+			var interactRequiresTags []string
+			if patch.Auth.Access.InteractRequiresTags != nil {
+				interactRequiresTags = patch.Auth.Access.InteractRequiresTags
+			} else if updatedCfg.Auth.Access != nil {
+				interactRequiresTags = append([]string(nil), updatedCfg.Auth.Access.InteractRequiresTags...)
+			}
 			updatedCfg.Auth.Access = &types.AccessConfig{
 				Admins:               admins,
-				ViewRequiresTags:     patch.Auth.Access.ViewRequiresTags,
-				InteractRequiresTags: patch.Auth.Access.InteractRequiresTags,
+				ViewRequiresTags:     viewRequiresTags,
+				InteractRequiresTags: interactRequiresTags,
 			}
 			if len(updatedCfg.Auth.Access.Admins) == 0 && len(updatedCfg.Auth.Access.ViewRequiresTags) == 0 && len(updatedCfg.Auth.Access.InteractRequiresTags) == 0 {
 				updatedCfg.Auth.Access = nil

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -53,6 +53,7 @@ type GitHubOAuthView struct {
 }
 
 type AccessView struct {
+	Admins               []string `json:"admins"`
 	ViewRequiresTags     []string `json:"viewRequiresTags"`
 	InteractRequiresTags []string `json:"interactRequiresTags"`
 }
@@ -156,6 +157,7 @@ type GitHubOAuthPatch struct {
 }
 
 type AccessPatch struct {
+	Admins               []string `json:"admins"`
 	ViewRequiresTags     []string `json:"viewRequiresTags"`
 	InteractRequiresTags []string `json:"interactRequiresTags"`
 }
@@ -366,8 +368,12 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 		if s.hubCfg.Auth.Access != nil {
 			acc := s.hubCfg.Auth.Access
 			view.Auth.Access = &AccessView{
+				Admins:               acc.Admins,
 				ViewRequiresTags:     acc.ViewRequiresTags,
 				InteractRequiresTags: acc.InteractRequiresTags,
+			}
+			if view.Auth.Access.Admins == nil {
+				view.Auth.Access.Admins = []string{}
 			}
 			if view.Auth.Access.ViewRequiresTags == nil {
 				view.Auth.Access.ViewRequiresTags = []string{}
@@ -709,9 +715,12 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 			if updatedCfg.Auth == nil {
 				updatedCfg.Auth = &types.AuthConfig{}
 			}
+			// Use patch admins if provided; otherwise preserve existing
 			var admins []string
-			if updatedCfg.Auth.Access != nil {
-				admins = append(admins, updatedCfg.Auth.Access.Admins...)
+			if patch.Auth.Access.Admins != nil {
+				admins = patch.Auth.Access.Admins
+			} else if updatedCfg.Auth.Access != nil {
+				admins = append([]string(nil), updatedCfg.Auth.Access.Admins...)
 			}
 			updatedCfg.Auth.Access = &types.AccessConfig{
 				Admins:               admins,

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -35,6 +35,25 @@ type SettingsView struct {
 	Integrations  *IntegrationsView       `json:"integrations"`
 	Factories     []FactoryView           `json:"factories"`
 	Secrets       []string                `json:"secrets"`
+	Auth          *AuthView               `json:"auth,omitempty"`
+}
+
+type AuthView struct {
+	GitHubOAuth *GitHubOAuthView `json:"githubOAuth,omitempty"`
+	Access      *AccessView      `json:"access,omitempty"`
+}
+
+type GitHubOAuthView struct {
+	ClientID        string   `json:"clientId"`
+	ClientSecretSet bool     `json:"clientSecretSet"`
+	AllowedUsers    []string `json:"allowedUsers"`
+	AllowedOrgs     []string `json:"allowedOrgs"`
+	AllowedTeams    []string `json:"allowedTeams"`
+}
+
+type AccessView struct {
+	ViewRequiresTags     []string `json:"viewRequiresTags"`
+	InteractRequiresTags []string `json:"interactRequiresTags"`
 }
 
 type IntegrationsView struct {
@@ -117,6 +136,26 @@ type SettingsPatch struct {
 	SSHPublicKeys *[]string                `json:"sshPublicKeys,omitempty"`
 	Integrations  *IntegrationsPatch       `json:"integrations,omitempty"`
 	Factories     []FactoryPatch           `json:"factories,omitempty"`
+	Auth          *AuthPatch               `json:"auth,omitempty"`
+}
+
+type AuthPatch struct {
+	GitHubOAuth *GitHubOAuthPatch `json:"githubOAuth,omitempty"`
+	Access      *AccessPatch      `json:"access,omitempty"`
+	RemoveGitHubOAuth bool        `json:"removeGithubOAuth,omitempty"`
+}
+
+type GitHubOAuthPatch struct {
+	ClientID     string   `json:"clientId,omitempty"`
+	ClientSecret string   `json:"clientSecret,omitempty"`
+	AllowedUsers []string `json:"allowedUsers,omitempty"`
+	AllowedOrgs  []string `json:"allowedOrgs,omitempty"`
+	AllowedTeams []string `json:"allowedTeams,omitempty"`
+}
+
+type AccessPatch struct {
+	ViewRequiresTags     []string `json:"viewRequiresTags"`
+	InteractRequiresTags []string `json:"interactRequiresTags"`
 }
 
 type IntegrationsPatch struct {
@@ -299,6 +338,43 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 	s.mu.RUnlock()
+
+	// Auth config
+	if s.hubCfg.Auth != nil {
+		view.Auth = &AuthView{}
+		if s.hubCfg.Auth.GitHubOAuth != nil {
+			gh := s.hubCfg.Auth.GitHubOAuth
+			view.Auth.GitHubOAuth = &GitHubOAuthView{
+				ClientID:        gh.ClientID,
+				ClientSecretSet: gh.ClientSecret != "",
+				AllowedUsers:    gh.AllowedUsers,
+				AllowedOrgs:     gh.AllowedOrgs,
+				AllowedTeams:    gh.AllowedTeams,
+			}
+			if view.Auth.GitHubOAuth.AllowedUsers == nil {
+				view.Auth.GitHubOAuth.AllowedUsers = []string{}
+			}
+			if view.Auth.GitHubOAuth.AllowedOrgs == nil {
+				view.Auth.GitHubOAuth.AllowedOrgs = []string{}
+			}
+			if view.Auth.GitHubOAuth.AllowedTeams == nil {
+				view.Auth.GitHubOAuth.AllowedTeams = []string{}
+			}
+		}
+		if s.hubCfg.Auth.Access != nil {
+			acc := s.hubCfg.Auth.Access
+			view.Auth.Access = &AccessView{
+				ViewRequiresTags:     acc.ViewRequiresTags,
+				InteractRequiresTags: acc.InteractRequiresTags,
+			}
+			if view.Auth.Access.ViewRequiresTags == nil {
+				view.Auth.Access.ViewRequiresTags = []string{}
+			}
+			if view.Auth.Access.InteractRequiresTags == nil {
+				view.Auth.Access.InteractRequiresTags = []string{}
+			}
+		}
+	}
 
 	// Secrets — names only, read from disk so manually-edited hub.yaml entries are visible
 	view.Secrets = []string{}
@@ -566,6 +642,56 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 			})
 		}
 		updatedCfg.Factories = factories
+	}
+
+	// Auth config
+	if patch.Auth != nil {
+		if patch.Auth.RemoveGitHubOAuth {
+			if updatedCfg.Auth != nil {
+				updatedCfg.Auth.GitHubOAuth = nil
+				if updatedCfg.Auth.Access == nil {
+					updatedCfg.Auth = nil
+				}
+			}
+		} else if patch.Auth.GitHubOAuth != nil {
+			if updatedCfg.Auth == nil {
+				updatedCfg.Auth = &types.AuthConfig{}
+			}
+			if updatedCfg.Auth.GitHubOAuth == nil {
+				updatedCfg.Auth.GitHubOAuth = &types.GitHubOAuthConfig{}
+			}
+			gh := patch.Auth.GitHubOAuth
+			if gh.ClientID != "" {
+				updatedCfg.Auth.GitHubOAuth.ClientID = gh.ClientID
+			}
+			if gh.ClientSecret != "" {
+				updatedCfg.Auth.GitHubOAuth.ClientSecret = gh.ClientSecret
+			}
+			if gh.AllowedUsers != nil {
+				updatedCfg.Auth.GitHubOAuth.AllowedUsers = gh.AllowedUsers
+			}
+			if gh.AllowedOrgs != nil {
+				updatedCfg.Auth.GitHubOAuth.AllowedOrgs = gh.AllowedOrgs
+			}
+			if gh.AllowedTeams != nil {
+				updatedCfg.Auth.GitHubOAuth.AllowedTeams = gh.AllowedTeams
+			}
+		}
+		if patch.Auth.Access != nil {
+			if updatedCfg.Auth == nil {
+				updatedCfg.Auth = &types.AuthConfig{}
+			}
+			updatedCfg.Auth.Access = &types.AccessConfig{
+				ViewRequiresTags:     patch.Auth.Access.ViewRequiresTags,
+				InteractRequiresTags: patch.Auth.Access.InteractRequiresTags,
+			}
+			if len(updatedCfg.Auth.Access.ViewRequiresTags) == 0 && len(updatedCfg.Auth.Access.InteractRequiresTags) == 0 {
+				updatedCfg.Auth.Access = nil
+				if updatedCfg.Auth.GitHubOAuth == nil {
+					updatedCfg.Auth = nil
+				}
+			}
+		}
 	}
 
 	// Save to disk before applying to in-memory config

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -652,6 +652,7 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 		if patch.Auth.RemoveGitHubOAuth {
 			if updatedCfg.Auth != nil {
 				updatedCfg.Auth.GitHubOAuth = nil
+				updatedCfg.Auth.DisablePasswordAuth = false
 				if updatedCfg.Auth.Access == nil {
 					updatedCfg.Auth = nil
 				}

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -690,11 +690,16 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 			if updatedCfg.Auth == nil {
 				updatedCfg.Auth = &types.AuthConfig{}
 			}
+			var admins []string
+			if updatedCfg.Auth.Access != nil {
+				admins = append(admins, updatedCfg.Auth.Access.Admins...)
+			}
 			updatedCfg.Auth.Access = &types.AccessConfig{
+				Admins:               admins,
 				ViewRequiresTags:     patch.Auth.Access.ViewRequiresTags,
 				InteractRequiresTags: patch.Auth.Access.InteractRequiresTags,
 			}
-			if len(updatedCfg.Auth.Access.ViewRequiresTags) == 0 && len(updatedCfg.Auth.Access.InteractRequiresTags) == 0 {
+			if len(updatedCfg.Auth.Access.Admins) == 0 && len(updatedCfg.Auth.Access.ViewRequiresTags) == 0 && len(updatedCfg.Auth.Access.InteractRequiresTags) == 0 {
 				updatedCfg.Auth.Access = nil
 				if updatedCfg.Auth.GitHubOAuth == nil {
 					updatedCfg.Auth = nil

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -39,8 +39,9 @@ type SettingsView struct {
 }
 
 type AuthView struct {
-	GitHubOAuth *GitHubOAuthView `json:"githubOAuth,omitempty"`
-	Access      *AccessView      `json:"access,omitempty"`
+	GitHubOAuth         *GitHubOAuthView `json:"githubOAuth,omitempty"`
+	Access              *AccessView      `json:"access,omitempty"`
+	DisablePasswordAuth bool             `json:"disablePasswordAuth"`
 }
 
 type GitHubOAuthView struct {
@@ -140,9 +141,10 @@ type SettingsPatch struct {
 }
 
 type AuthPatch struct {
-	GitHubOAuth *GitHubOAuthPatch `json:"githubOAuth,omitempty"`
-	Access      *AccessPatch      `json:"access,omitempty"`
-	RemoveGitHubOAuth bool        `json:"removeGithubOAuth,omitempty"`
+	GitHubOAuth         *GitHubOAuthPatch `json:"githubOAuth,omitempty"`
+	Access              *AccessPatch      `json:"access,omitempty"`
+	RemoveGitHubOAuth   bool              `json:"removeGithubOAuth,omitempty"`
+	DisablePasswordAuth *bool             `json:"disablePasswordAuth,omitempty"`
 }
 
 type GitHubOAuthPatch struct {
@@ -339,7 +341,9 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 	}
 	// Auth config
 	if s.hubCfg.Auth != nil {
-		view.Auth = &AuthView{}
+		view.Auth = &AuthView{
+			DisablePasswordAuth: s.hubCfg.Auth.DisablePasswordAuth,
+		}
 		if s.hubCfg.Auth.GitHubOAuth != nil {
 			gh := s.hubCfg.Auth.GitHubOAuth
 			view.Auth.GitHubOAuth = &GitHubOAuthView{
@@ -675,6 +679,12 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 			if gh.AllowedTeams != nil {
 				updatedCfg.Auth.GitHubOAuth.AllowedTeams = gh.AllowedTeams
 			}
+		}
+		if patch.Auth.DisablePasswordAuth != nil {
+			if updatedCfg.Auth == nil {
+				updatedCfg.Auth = &types.AuthConfig{}
+			}
+			updatedCfg.Auth.DisablePasswordAuth = *patch.Auth.DisablePasswordAuth
 		}
 		if patch.Auth.Access != nil {
 			if updatedCfg.Auth == nil {

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -649,6 +649,24 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 
 	// Auth config
 	if patch.Auth != nil {
+		if updatedCfg.Auth != nil {
+			authCopy := *updatedCfg.Auth
+			if authCopy.GitHubOAuth != nil {
+				githubOAuthCopy := *authCopy.GitHubOAuth
+				githubOAuthCopy.AllowedUsers = append([]string(nil), authCopy.GitHubOAuth.AllowedUsers...)
+				githubOAuthCopy.AllowedOrgs = append([]string(nil), authCopy.GitHubOAuth.AllowedOrgs...)
+				githubOAuthCopy.AllowedTeams = append([]string(nil), authCopy.GitHubOAuth.AllowedTeams...)
+				authCopy.GitHubOAuth = &githubOAuthCopy
+			}
+			if authCopy.Access != nil {
+				accessCopy := *authCopy.Access
+				accessCopy.Admins = append([]string(nil), authCopy.Access.Admins...)
+				accessCopy.ViewRequiresTags = append([]string(nil), authCopy.Access.ViewRequiresTags...)
+				accessCopy.InteractRequiresTags = append([]string(nil), authCopy.Access.InteractRequiresTags...)
+				authCopy.Access = &accessCopy
+			}
+			updatedCfg.Auth = &authCopy
+		}
 		if patch.Auth.RemoveGitHubOAuth {
 			if updatedCfg.Auth != nil {
 				updatedCfg.Auth.GitHubOAuth = nil

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -337,8 +337,6 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 			Enabled:          isFactoryEnabled(f),
 		})
 	}
-	s.mu.RUnlock()
-
 	// Auth config
 	if s.hubCfg.Auth != nil {
 		view.Auth = &AuthView{}
@@ -375,6 +373,7 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
+	s.mu.RUnlock()
 
 	// Secrets — names only, read from disk so manually-edited hub.yaml entries are visible
 	view.Secrets = []string{}

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -157,8 +157,9 @@ type BrandingConfig struct {
 
 // AuthConfig holds GitHub OAuth and access control config for the hub web UI.
 type AuthConfig struct {
-	GitHubOAuth *GitHubOAuthConfig `yaml:"github_oauth,omitempty"`
-	Access      *AccessConfig      `yaml:"access,omitempty"`
+	GitHubOAuth         *GitHubOAuthConfig `yaml:"github_oauth,omitempty"`
+	Access              *AccessConfig      `yaml:"access,omitempty"`
+	DisablePasswordAuth bool               `yaml:"disable_password_auth,omitempty"`
 }
 
 // GitHubOAuthConfig holds GitHub OAuth app credentials and allowlist.

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -155,6 +155,28 @@ type BrandingConfig struct {
 	LogoURL string `yaml:"logo_url,omitempty" json:"logoUrl,omitempty"`
 }
 
+// AuthConfig holds GitHub OAuth and access control config for the hub web UI.
+type AuthConfig struct {
+	GitHubOAuth *GitHubOAuthConfig `yaml:"github_oauth,omitempty"`
+	Access      *AccessConfig      `yaml:"access,omitempty"`
+}
+
+// GitHubOAuthConfig holds GitHub OAuth app credentials and allowlist.
+type GitHubOAuthConfig struct {
+	ClientID     string   `yaml:"client_id"`
+	ClientSecret string   `yaml:"client_secret"`
+	AllowedUsers []string `yaml:"allowed_users,omitempty"` // GitHub logins
+	AllowedOrgs  []string `yaml:"allowed_orgs,omitempty"`  // GitHub org names
+	AllowedTeams []string `yaml:"allowed_teams,omitempty"` // "org/team" format
+}
+
+// AccessConfig holds tag-based RBAC rules for the hub web UI.
+type AccessConfig struct {
+	Admins               []string `yaml:"admins,omitempty"`                 // GitHub logins — bypass all tag checks
+	ViewRequiresTags     []string `yaml:"view_requires_tags,omitempty"`     // any matching tag grants view
+	InteractRequiresTags []string `yaml:"interact_requires_tags,omitempty"` // any matching tag grants interact
+}
+
 type HubConfig struct {
 	// CLI connection fields
 	URL   string `yaml:"url"`
@@ -212,6 +234,9 @@ type HubConfig struct {
 	Factories []*FactoryConfig `yaml:"factories,omitempty"`
 	// Secrets is a named map of secret values referenced by factories via webhook_secret_ref.
 	Secrets map[string]string `yaml:"secrets,omitempty"`
+
+	// Auth holds GitHub OAuth and access control config for the hub web UI.
+	Auth *AuthConfig `yaml:"auth,omitempty"`
 }
 
 // IntegrationsConfig holds configs for external integrations.

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -159,6 +159,7 @@ type BrandingConfig struct {
 type AuthConfig struct {
 	GitHubOAuth         *GitHubOAuthConfig `yaml:"github_oauth,omitempty"`
 	Access              *AccessConfig      `yaml:"access,omitempty"`
+	SessionSecret       string             `yaml:"session_secret,omitempty"`
 	DisablePasswordAuth bool               `yaml:"disable_password_auth,omitempty"`
 }
 

--- a/web/app/factories/page.tsx
+++ b/web/app/factories/page.tsx
@@ -61,7 +61,7 @@ function FactoryEventsContent() {
     setLoading(true)
     try {
       const hubUrl = getHubUrl()
-      const token = sessionStorage.getItem("ec_hub_token") || ""
+      const token = sessionStorage.getItem("ec_github_token") || sessionStorage.getItem("ec_hub_token") || ""
       const res = await fetch(`${hubUrl}/api/factories/${encodeURIComponent(name)}/events`, {
         headers: { Authorization: `Bearer ${token}` },
       })

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -16,6 +16,12 @@ function safeNextPath(next: string | null): string | null {
   return next
 }
 
+function randomState(): string {
+  const buf = new Uint8Array(16)
+  crypto.getRandomValues(buf)
+  return btoa(String.fromCharCode(...buf)).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "")
+}
+
 function LoginForm() {
   const router = useRouter()
   const searchParams = useSearchParams()
@@ -28,48 +34,57 @@ function LoginForm() {
   const [authConfig, setAuthConfig] = useState<AuthConfig | null>(null)
 
   useEffect(() => {
-    // Fetch auth config (no auth required)
     const hubUrl = getHubUrl()
     const configUrl = hubUrl ? `${hubUrl}/api/auth/config` : "/api/auth/config"
     fetch(configUrl)
       .then((r) => r.ok ? r.json() : null)
       .then((data) => { if (data) setAuthConfig(data) })
-      .catch(() => {/* ignore */})
+      .catch(() => {})
   }, [])
 
-  // Handle GitHub OAuth callback using short-lived exchange code.
+  // Handle GitHub OAuth callback — GitHub redirects back here with ?code=&state=
   useEffect(() => {
-    const oauthCode = searchParams.get("oauth_code")
-    if (!oauthCode) return
+    const code = searchParams.get("code")
+    const state = searchParams.get("state")
+    if (!code || !state) return
 
-    let cancelled = false
+    // Validate state to prevent CSRF
+    const storedState = sessionStorage.getItem("oauth_state")
+    if (!storedState || state !== storedState) {
+      setError("OAuth state mismatch — please try again")
+      return
+    }
+    sessionStorage.removeItem("oauth_state")
+
+    const redirectUri = window.location.origin + "/login"
     const hubUrl = getHubUrl()
     const exchangeUrl = hubUrl ? `${hubUrl}/api/auth/github/exchange` : "/api/auth/github/exchange"
 
+    let cancelled = false
     fetch(exchangeUrl, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ code: oauthCode }),
+      body: JSON.stringify({ code, redirect_uri: redirectUri }),
     })
       .then(async (res) => {
-        if (!res.ok) throw new Error("exchange failed")
-        const data = await res.json()
+        if (!res.ok) throw new Error(await res.text())
+        return res.json()
+      })
+      .then((data) => {
         if (cancelled) return
         if (data.github_token) {
           clearConfig()
           sessionStorage.setItem("ec_github_token", data.github_token)
           router.replace(next)
-          return
+        } else {
+          throw new Error("missing token")
         }
-        throw new Error("missing token")
       })
-      .catch(() => {
-        if (!cancelled) router.replace("/login")
+      .catch((err) => {
+        if (!cancelled) setError("GitHub sign-in failed: " + (err?.message || "unknown error"))
       })
 
-    return () => {
-      cancelled = true
-    }
+    return () => { cancelled = true }
   }, [searchParams, next, router])
 
   async function handleSubmit(e: React.FormEvent) {
@@ -88,12 +103,10 @@ function LoginForm() {
 
       if (res.ok) {
         const data = await res.json()
-        // One token for everything — hub API token stored in sessionStorage
         if (data.hubToken) {
           clearConfig()
           sessionStorage.setItem("ec_hub_token", data.hubToken)
         }
-        // Check if settings are required before going to main dashboard
         try {
           const { getHubUrl } = await import("@/lib/hub-url")
           const hubUrl = getHubUrl()
@@ -107,7 +120,7 @@ function LoginForm() {
               return
             }
           }
-        } catch { /* ignore — proceed to dashboard */ }
+        } catch { /* ignore */ }
         router.push(next)
         router.refresh()
       } else {
@@ -122,68 +135,99 @@ function LoginForm() {
 
   function handleGitHubSignIn() {
     const hubUrl = getHubUrl()
-    const authURL = new URL(hubUrl ? `${hubUrl}/api/auth/github` : "/api/auth/github", window.location.origin)
-    if (nextParam) {
-      authURL.searchParams.set("next", nextParam)
-    }
-    const authUrl = authURL.toString()
-    window.location.href = authUrl
+    // Ask the hub for the client_id (already public in /api/auth/config)
+    // Build the GitHub authorize URL entirely in the browser.
+    const state = randomState()
+    sessionStorage.setItem("oauth_state", state)
+    if (nextParam) sessionStorage.setItem("oauth_next", nextParam)
+
+    const redirectUri = window.location.origin + "/login"
+
+    // We need the GitHub client_id — fetch it from the hub's auth config
+    // (it's already exposed there as a public field via github_oauth_enabled).
+    // We store it in authConfig but need the actual client_id — fetch separately.
+    const configUrl = hubUrl ? `${hubUrl}/api/auth/github/client-id` : "/api/auth/github/client-id"
+    fetch(configUrl)
+      .then((r) => r.ok ? r.json() : Promise.reject("config unavailable"))
+      .then(({ client_id }: { client_id: string }) => {
+        const params = new URLSearchParams({
+          client_id,
+          redirect_uri: redirectUri,
+          scope: "read:user read:org",
+          state,
+        })
+        window.location.href = "https://github.com/login/oauth/authorize?" + params.toString()
+      })
+      .catch(() => setError("Could not load GitHub OAuth config"))
   }
 
   const showGitHub = authConfig?.github_oauth_enabled
   const showPassword = !authConfig || authConfig.password_auth_enabled
+  // If we have a code param we're mid-callback — show a loading state
+  const isCallback = !!searchParams.get("code")
 
   return (
     <div className="flex h-screen bg-background items-center justify-center">
       <div className="w-full max-w-sm space-y-6 p-8 border border-border rounded-xl bg-card">
         <div className="space-y-1 text-center">
           <h1 className="text-2xl font-semibold tracking-tight">ElasticClaw</h1>
-          <p className="text-sm text-muted-foreground">Sign in to continue</p>
+          <p className="text-sm text-muted-foreground">
+            {isCallback ? "Completing sign-in…" : "Sign in to continue"}
+          </p>
         </div>
 
-        {showGitHub && (
-          <button
-            type="button"
-            onClick={handleGitHubSignIn}
-            className="w-full flex items-center justify-center gap-2 rounded-md border border-border bg-background px-3 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground"
-          >
-            <svg viewBox="0 0 16 16" className="h-4 w-4 fill-current" aria-hidden="true">
-              <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
-            </svg>
-            Sign in with GitHub
-          </button>
+        {isCallback && !error && (
+          <p className="text-center text-sm text-muted-foreground animate-pulse">Signing you in with GitHub…</p>
         )}
 
-        {showGitHub && showPassword && (
-          <div className="relative">
-            <div className="absolute inset-0 flex items-center">
-              <span className="w-full border-t border-border" />
-            </div>
-            <div className="relative flex justify-center text-xs uppercase">
-              <span className="bg-card px-2 text-muted-foreground">or</span>
-            </div>
-          </div>
-        )}
+        {error && <p className="text-sm text-red-500 text-center">{error}</p>}
 
-        {showPassword && (
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <input
-              type="password"
-              placeholder="Access token"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              autoFocus={!showGitHub}
-              className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-            />
-            {error && <p className="text-sm text-red-500">{error}</p>}
-            <button
-              type="submit"
-              disabled={loading || !password}
-              className="w-full rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
-            >
-              {loading ? "Signing in…" : "Sign in"}
-            </button>
-          </form>
+        {!isCallback && (
+          <>
+            {showGitHub && (
+              <button
+                type="button"
+                onClick={handleGitHubSignIn}
+                className="w-full flex items-center justify-center gap-2 rounded-md border border-border bg-background px-3 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground"
+              >
+                <svg viewBox="0 0 16 16" className="h-4 w-4 fill-current" aria-hidden="true">
+                  <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
+                </svg>
+                Sign in with GitHub
+              </button>
+            )}
+
+            {showGitHub && showPassword && (
+              <div className="relative">
+                <div className="absolute inset-0 flex items-center">
+                  <span className="w-full border-t border-border" />
+                </div>
+                <div className="relative flex justify-center text-xs uppercase">
+                  <span className="bg-card px-2 text-muted-foreground">or</span>
+                </div>
+              </div>
+            )}
+
+            {showPassword && (
+              <form onSubmit={handleSubmit} className="space-y-4">
+                <input
+                  type="password"
+                  placeholder="Access token"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  autoFocus={!showGitHub}
+                  className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                />
+                <button
+                  type="submit"
+                  disabled={loading || !password}
+                  className="w-full rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+                >
+                  {loading ? "Signing in…" : "Sign in"}
+                </button>
+              </form>
+            )}
+          </>
         )}
       </div>
     </div>

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -13,6 +13,7 @@ function LoginForm() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const next = searchParams.get("next") || "/"
+  const nextParam = searchParams.get("next")
 
   const [password, setPassword] = useState("")
   const [error, setError] = useState("")
@@ -85,7 +86,11 @@ function LoginForm() {
 
   function handleGitHubSignIn() {
     const hubUrl = getHubUrl()
-    const authUrl = hubUrl ? `${hubUrl}/api/auth/github` : "/api/auth/github"
+    const authURL = new URL(hubUrl ? `${hubUrl}/api/auth/github` : "/api/auth/github", window.location.origin)
+    if (nextParam) {
+      authURL.searchParams.set("next", nextParam)
+    }
+    const authUrl = authURL.toString()
     window.location.href = authUrl
   }
 

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, Suspense } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
 import { getHubUrl } from "@/lib/hub-url"
+import { clearConfig } from "@/lib/api"
 
 interface AuthConfig {
   github_oauth_enabled: boolean
@@ -30,12 +31,38 @@ function LoginForm() {
       .catch(() => {/* ignore */})
   }, [])
 
-  // Handle GitHub OAuth callback: token in URL hash or query param
+  // Handle GitHub OAuth callback using short-lived exchange code.
   useEffect(() => {
-    const token = searchParams.get("github_token")
-    if (token) {
-      sessionStorage.setItem("ec_github_token", token)
-      router.replace(next)
+    const oauthCode = searchParams.get("oauth_code")
+    if (!oauthCode) return
+
+    let cancelled = false
+    const hubUrl = getHubUrl()
+    const exchangeUrl = hubUrl ? `${hubUrl}/api/auth/github/exchange` : "/api/auth/github/exchange"
+
+    fetch(exchangeUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ code: oauthCode }),
+    })
+      .then(async (res) => {
+        if (!res.ok) throw new Error("exchange failed")
+        const data = await res.json()
+        if (cancelled) return
+        if (data.github_token) {
+          clearConfig()
+          sessionStorage.setItem("ec_github_token", data.github_token)
+          router.replace(next)
+          return
+        }
+        throw new Error("missing token")
+      })
+      .catch(() => {
+        if (!cancelled) router.replace("/login")
+      })
+
+    return () => {
+      cancelled = true
     }
   }, [searchParams, next, router])
 

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -10,11 +10,17 @@ interface AuthConfig {
   password_auth_enabled: boolean
 }
 
+function safeNextPath(next: string | null): string | null {
+  if (!next) return null
+  if (!next.startsWith("/") || next.startsWith("//")) return null
+  return next
+}
+
 function LoginForm() {
   const router = useRouter()
   const searchParams = useSearchParams()
-  const next = searchParams.get("next") || "/"
-  const nextParam = searchParams.get("next")
+  const nextParam = safeNextPath(searchParams.get("next"))
+  const next = nextParam || "/"
 
   const [password, setPassword] = useState("")
   const [error, setError] = useState("")

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -1,8 +1,13 @@
 "use client"
 
-import { useState, Suspense } from "react"
+import { useState, useEffect, Suspense } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
 import { getHubUrl } from "@/lib/hub-url"
+
+interface AuthConfig {
+  github_oauth_enabled: boolean
+  password_auth_enabled: boolean
+}
 
 function LoginForm() {
   const router = useRouter()
@@ -12,6 +17,26 @@ function LoginForm() {
   const [password, setPassword] = useState("")
   const [error, setError] = useState("")
   const [loading, setLoading] = useState(false)
+  const [authConfig, setAuthConfig] = useState<AuthConfig | null>(null)
+
+  useEffect(() => {
+    // Fetch auth config (no auth required)
+    const hubUrl = getHubUrl()
+    const configUrl = hubUrl ? `${hubUrl}/api/auth/config` : "/api/auth/config"
+    fetch(configUrl)
+      .then((r) => r.ok ? r.json() : null)
+      .then((data) => { if (data) setAuthConfig(data) })
+      .catch(() => {/* ignore */})
+  }, [])
+
+  // Handle GitHub OAuth callback: token in URL hash or query param
+  useEffect(() => {
+    const token = searchParams.get("github_token")
+    if (token) {
+      sessionStorage.setItem("ec_github_token", token)
+      router.replace(next)
+    }
+  }, [searchParams, next, router])
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
@@ -58,32 +83,67 @@ function LoginForm() {
     }
   }
 
+  function handleGitHubSignIn() {
+    const hubUrl = getHubUrl()
+    const authUrl = hubUrl ? `${hubUrl}/api/auth/github` : "/api/auth/github"
+    window.location.href = authUrl
+  }
+
+  const showGitHub = authConfig?.github_oauth_enabled
+  const showPassword = !authConfig || authConfig.password_auth_enabled
+
   return (
     <div className="flex h-screen bg-background items-center justify-center">
       <div className="w-full max-w-sm space-y-6 p-8 border border-border rounded-xl bg-card">
         <div className="space-y-1 text-center">
           <h1 className="text-2xl font-semibold tracking-tight">ElasticClaw</h1>
-          <p className="text-sm text-muted-foreground">Enter your access token to continue</p>
+          <p className="text-sm text-muted-foreground">Sign in to continue</p>
         </div>
 
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <input
-            type="password"
-            placeholder="Access token"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            autoFocus
-            className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-          />
-          {error && <p className="text-sm text-red-500">{error}</p>}
+        {showGitHub && (
           <button
-            type="submit"
-            disabled={loading || !password}
-            className="w-full rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+            type="button"
+            onClick={handleGitHubSignIn}
+            className="w-full flex items-center justify-center gap-2 rounded-md border border-border bg-background px-3 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground"
           >
-            {loading ? "Signing in…" : "Sign in"}
+            <svg viewBox="0 0 16 16" className="h-4 w-4 fill-current" aria-hidden="true">
+              <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
+            </svg>
+            Sign in with GitHub
           </button>
-        </form>
+        )}
+
+        {showGitHub && showPassword && (
+          <div className="relative">
+            <div className="absolute inset-0 flex items-center">
+              <span className="w-full border-t border-border" />
+            </div>
+            <div className="relative flex justify-center text-xs uppercase">
+              <span className="bg-card px-2 text-muted-foreground">or</span>
+            </div>
+          </div>
+        )}
+
+        {showPassword && (
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <input
+              type="password"
+              placeholder="Access token"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              autoFocus={!showGitHub}
+              className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            />
+            {error && <p className="text-sm text-red-500">{error}</p>}
+            <button
+              type="submit"
+              disabled={loading || !password}
+              className="w-full rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+            >
+              {loading ? "Signing in…" : "Sign in"}
+            </button>
+          </form>
+        )}
       </div>
     </div>
   )

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -89,7 +89,10 @@ function LoginForm() {
       if (res.ok) {
         const data = await res.json()
         // One token for everything — hub API token stored in sessionStorage
-        if (data.hubToken) sessionStorage.setItem("ec_hub_token", data.hubToken)
+        if (data.hubToken) {
+          clearConfig()
+          sessionStorage.setItem("ec_hub_token", data.hubToken)
+        }
         // Check if settings are required before going to main dashboard
         try {
           const { getHubUrl } = await import("@/lib/hub-url")

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -55,6 +55,9 @@ function LoginForm() {
       return
     }
     sessionStorage.removeItem("oauth_state")
+    const storedNext = safeNextPath(sessionStorage.getItem("oauth_next"))
+    sessionStorage.removeItem("oauth_next")
+    const callbackNext = nextParam || storedNext || "/"
 
     const redirectUri = window.location.origin + "/login"
     const hubUrl = getHubUrl()
@@ -75,7 +78,7 @@ function LoginForm() {
         if (data.github_token) {
           clearConfig()
           sessionStorage.setItem("ec_github_token", data.github_token)
-          router.replace(next)
+          router.replace(callbackNext)
         } else {
           throw new Error("missing token")
         }
@@ -85,7 +88,7 @@ function LoginForm() {
       })
 
     return () => { cancelled = true }
-  }, [searchParams, next, router])
+  }, [searchParams, nextParam, router])
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -19,10 +19,24 @@ export default function Home() {
   const [activeTagFilters, setActiveTagFilters] = useState<string[]>([])
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
   const [configuredState, setConfiguredState] = useState<boolean | null>(null)
+  const [isAdmin, setIsAdmin] = useState(true) // default true so UI doesn't flicker
 
   // Check configured on mount (needs browser for localStorage)
   useEffect(() => {
     setConfiguredState(isConfigured())
+  }, [])
+
+  // Fetch admin status
+  useEffect(() => {
+    const token = sessionStorage.getItem("ec_github_token") || sessionStorage.getItem("ec_hub_token") || ""
+    if (!token) return
+    import("@/lib/hub-url").then(({ getHubUrl }) => {
+      const hubUrl = getHubUrl()
+      fetch(`${hubUrl}/api/auth/me`, { headers: { Authorization: `Bearer ${token}` } })
+        .then(r => r.ok ? r.json() : null)
+        .then(data => { if (data) setIsAdmin(data.is_admin ?? true) })
+        .catch(() => {})
+    })
   }, [])
 
   const hub = useHub(selectedClawId)
@@ -269,6 +283,7 @@ export default function Home() {
         isCollapsed={sidebarCollapsed}
         onToggleCollapse={() => setSidebarCollapsed(!sidebarCollapsed)}
         onReorderClaws={reorderClaws}
+        isAdmin={isAdmin}
       />
       <ConversationView
         claw={selectedClaw}

--- a/web/app/settings/[section]/page.tsx
+++ b/web/app/settings/[section]/page.tsx
@@ -1,6 +1,6 @@
 import SettingsSectionPage from "./settings-content"
 
-const VALID_SECTIONS = ["runtimes", "llm", "github", "security", "integrations", "factories", "secrets", "templates"]
+const VALID_SECTIONS = ["runtimes", "llm", "github", "authentication", "integrations", "factories", "secrets", "templates"]
 
 export function generateStaticParams() {
   return VALID_SECTIONS.map((section) => ({ section }))

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -61,6 +61,7 @@ interface SettingsData {
       viewRequiresTags: string[]
       interactRequiresTags: string[]
     }
+    disablePasswordAuth?: boolean
   }
 }
 
@@ -675,24 +676,55 @@ function AuthenticationSection({ settings, onSave, saving }: { settings: Setting
         <div className="flex items-center justify-between">
           <div>
             <h3 className="text-sm font-medium">Password Login</h3>
-            <p className="text-xs text-muted-foreground mt-0.5">Always enabled. Used by the hub token and UI password.</p>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              {settings.auth?.disablePasswordAuth ? 'Disabled — GitHub OAuth only.' : 'Enabled. Used by the hub token and UI password.'}
+            </p>
           </div>
-          <span className="text-xs bg-green-500/20 text-green-400 px-2 py-0.5 rounded font-medium">Active</span>
+          {settings.auth?.disablePasswordAuth
+            ? <span className="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded font-medium">Disabled</span>
+            : <span className="text-xs bg-green-500/20 text-green-400 px-2 py-0.5 rounded font-medium">Active</span>
+          }
         </div>
-        <div className="border-t border-border pt-3 space-y-3">
-          <div>
-            <label className="text-xs text-muted-foreground mb-1 block">New Password</label>
-            <Input type="password" value={newPw} onChange={e => setNewPw(e.target.value)} className="h-8 text-sm" placeholder="Min 8 characters" />
+
+        {/* Disable/enable toggle — only show when GitHub OAuth is configured */}
+        {ghOAuth && (
+          <div className="flex items-center justify-between border border-border rounded-md px-3 py-2">
+            <div>
+              <p className="text-xs font-medium">Require GitHub OAuth</p>
+              <p className="text-xs text-muted-foreground mt-0.5">Disable password login entirely. Make sure you can log in via GitHub first.</p>
+            </div>
+            <button
+              onClick={() => onSave({ auth: { disablePasswordAuth: !settings.auth?.disablePasswordAuth } })}
+              disabled={saving}
+              className={cn(
+                'relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors',
+                settings.auth?.disablePasswordAuth ? 'bg-primary' : 'bg-muted'
+              )}
+            >
+              <span className={cn(
+                'pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow-lg transform transition-transform',
+                settings.auth?.disablePasswordAuth ? 'translate-x-4' : 'translate-x-0'
+              )} />
+            </button>
           </div>
-          <div>
-            <label className="text-xs text-muted-foreground mb-1 block">Confirm Password</label>
-            <Input type="password" value={pwConfirm} onChange={e => setPwConfirm(e.target.value)} className="h-8 text-sm" placeholder="Repeat password" />
+        )}
+
+        {!settings.auth?.disablePasswordAuth && (
+          <div className="border-t border-border pt-3 space-y-3">
+            <div>
+              <label className="text-xs text-muted-foreground mb-1 block">New Password</label>
+              <Input type="password" value={newPw} onChange={e => setNewPw(e.target.value)} className="h-8 text-sm" placeholder="Min 8 characters" />
+            </div>
+            <div>
+              <label className="text-xs text-muted-foreground mb-1 block">Confirm Password</label>
+              <Input type="password" value={pwConfirm} onChange={e => setPwConfirm(e.target.value)} className="h-8 text-sm" placeholder="Repeat password" />
+            </div>
+            {pwErr && <p className="text-xs text-red-500">{pwErr}</p>}
+            <Button size="sm" disabled={saving || !newPw || !pwConfirm} onClick={handlePasswordSave}>
+              Change Password
+            </Button>
           </div>
-          {pwErr && <p className="text-xs text-red-500">{pwErr}</p>}
-          <Button size="sm" disabled={saving || !newPw || !pwConfirm} onClick={handlePasswordSave}>
-            Change Password
-          </Button>
-        </div>
+        )}
       </div>
 
       {/* GitHub OAuth card */}

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -66,7 +66,7 @@ interface SettingsData {
 
 async function fetchSettings(): Promise<SettingsData> {
   const hubUrl = getHubUrl()
-  const token = sessionStorage.getItem("ec_hub_token") || ""
+  const token = sessionStorage.getItem("ec_github_token") || sessionStorage.getItem("ec_hub_token") || ""
   const res = await fetch(`${hubUrl}/api/settings`, {
     headers: { Authorization: `Bearer ${token}` },
   })
@@ -76,7 +76,7 @@ async function fetchSettings(): Promise<SettingsData> {
 
 async function patchSettings(patch: object): Promise<void> {
   const hubUrl = getHubUrl()
-  const token = sessionStorage.getItem("ec_hub_token") || ""
+  const token = sessionStorage.getItem("ec_github_token") || sessionStorage.getItem("ec_hub_token") || ""
   const res = await fetch(`${hubUrl}/api/settings`, {
     method: "PATCH",
     headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
@@ -117,7 +117,7 @@ export default function SettingsSectionPage() {
 
   useEffect(() => {
     const hubUrl = getHubUrl()
-    const token = sessionStorage.getItem("ec_hub_token") || ""
+    const token = sessionStorage.getItem("ec_github_token") || sessionStorage.getItem("ec_hub_token") || ""
     fetch(`${hubUrl}/api/hub-config`, { headers: { Authorization: `Bearer ${token}` } })
       .then((r) => r.json())
       .then((d) => { setVersion(d.version || "unknown"); setHubPublicUrl(d.hubUrl || "") })
@@ -1123,7 +1123,7 @@ function SecretsSection({ settings }: { settings: SettingsData | null }) {
   const [error, setError] = useState<string | null>(null)
 
   const hubUrl = getHubUrl()
-  const token = () => sessionStorage.getItem("ec_hub_token") || ""
+  const token = () => sessionStorage.getItem("ec_github_token") || sessionStorage.getItem("ec_hub_token") || ""
 
   const refresh = async () => {
     const res = await fetch(`${hubUrl}/api/secrets`, { headers: { Authorization: `Bearer ${token()}` } })
@@ -1365,7 +1365,7 @@ function AIConfigSection() {
   const chatInputRef = useRef<HTMLInputElement>(null)
 
   const hubUrl = getHubUrl()
-  const token = () => sessionStorage.getItem("ec_hub_token") || ""
+  const token = () => sessionStorage.getItem("ec_github_token") || sessionStorage.getItem("ec_hub_token") || ""
 
   // Persist messages to sessionStorage on change
   useEffect(() => {
@@ -1900,7 +1900,7 @@ function TemplatesSection() {
     setLoading(true)
     try {
       const hubUrl = getHubUrl()
-      const token = sessionStorage.getItem("ec_hub_token") || ""
+      const token = sessionStorage.getItem("ec_github_token") || sessionStorage.getItem("ec_hub_token") || ""
       const res = await fetch(`${hubUrl}/api/templates`, {
         headers: { Authorization: `Bearer ${token}` },
       })
@@ -1915,7 +1915,7 @@ function TemplatesSection() {
     setDeleting(name)
     try {
       const hubUrl = getHubUrl()
-      const token = sessionStorage.getItem("ec_hub_token") || ""
+      const token = sessionStorage.getItem("ec_github_token") || sessionStorage.getItem("ec_hub_token") || ""
       const res = await fetch(`${hubUrl}/api/templates/${encodeURIComponent(name)}`, {
         method: "DELETE",
         headers: { Authorization: `Bearer ${token}` },

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -58,6 +58,7 @@ interface SettingsData {
       allowedTeams: string[]
     }
     access?: {
+      admins: string[]
       viewRequiresTags: string[]
       interactRequiresTags: string[]
     }
@@ -605,6 +606,7 @@ function AuthenticationSection({ settings, onSave, saving }: { settings: Setting
   const [allowedUsers, setAllowedUsers] = useState((ghOAuth?.allowedUsers || []).join(', '))
   const [allowedOrgs, setAllowedOrgs] = useState((ghOAuth?.allowedOrgs || []).join(', '))
   const [allowedTeams, setAllowedTeams] = useState((ghOAuth?.allowedTeams || []).join(', '))
+  const [admins, setAdmins] = useState((ghAccess?.admins || []).join(', '))
   const [viewTags, setViewTags] = useState((ghAccess?.viewRequiresTags || []).join(', '))
   const [interactTags, setInteractTags] = useState((ghAccess?.interactRequiresTags || []).join(', '))
   const [ghErr, setGhErr] = useState('')
@@ -635,6 +637,7 @@ function AuthenticationSection({ settings, onSave, saving }: { settings: Setting
           allowedTeams: splitList(allowedTeams),
         },
         access: {
+          admins: splitList(admins),
           viewRequiresTags: splitList(viewTags),
           interactRequiresTags: splitList(interactTags),
         },
@@ -655,6 +658,7 @@ function AuthenticationSection({ settings, onSave, saving }: { settings: Setting
     setAllowedUsers((ghOAuth?.allowedUsers || []).join(', '))
     setAllowedOrgs((ghOAuth?.allowedOrgs || []).join(', '))
     setAllowedTeams((ghOAuth?.allowedTeams || []).join(', '))
+    setAdmins((ghAccess?.admins || []).join(', '))
     setViewTags((ghAccess?.viewRequiresTags || []).join(', '))
     setInteractTags((ghAccess?.interactRequiresTags || []).join(', '))
     setShowGhForm(true)
@@ -744,6 +748,7 @@ function AuthenticationSection({ settings, onSave, saving }: { settings: Setting
           <div className="border-t border-border pt-3 space-y-2 text-xs text-muted-foreground">
             <div className="flex gap-2"><span className="font-medium text-foreground w-28">Client ID</span><span className="font-mono">{ghOAuth.clientId}</span></div>
             <div className="flex gap-2"><span className="font-medium text-foreground w-28">Client Secret</span><span>{ghOAuth.clientSecretSet ? '••••••••' : 'not set'}</span></div>
+            {ghAccess?.admins && ghAccess.admins.length > 0 && <div className="flex gap-2"><span className="font-medium text-foreground w-28">Admins</span><span>{ghAccess.admins.join(', ')}</span></div>}
             {ghOAuth.allowedUsers.length > 0 && <div className="flex gap-2"><span className="font-medium text-foreground w-28">Allowed users</span><span>{ghOAuth.allowedUsers.join(', ')}</span></div>}
             {ghOAuth.allowedOrgs.length > 0 && <div className="flex gap-2"><span className="font-medium text-foreground w-28">Allowed orgs</span><span>{ghOAuth.allowedOrgs.join(', ')}</span></div>}
             {ghOAuth.allowedTeams.length > 0 && <div className="flex gap-2"><span className="font-medium text-foreground w-28">Allowed teams</span><span>{ghOAuth.allowedTeams.join(', ')}</span></div>}
@@ -798,6 +803,15 @@ function AuthenticationSection({ settings, onSave, saving }: { settings: Setting
               <div>
                 <label className="text-xs text-muted-foreground mb-1 block">Teams</label>
                 <Input value={allowedTeams} onChange={e => setAllowedTeams(e.target.value)} className="h-8 text-sm" placeholder="my-org/my-team" />
+              </div>
+            </div>
+
+            <div className="space-y-3">
+              <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Admins</h4>
+              <div>
+                <label className="text-xs text-muted-foreground mb-1 block">GitHub Usernames</label>
+                <Input value={admins} onChange={e => setAdmins(e.target.value)} className="h-8 text-sm" placeholder="alice, bob" />
+                <p className="text-xs text-muted-foreground mt-1">Comma-separated. Admins can access Settings and bypass all tag restrictions.</p>
               </div>
             </div>
 

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -9,9 +9,9 @@ import { Input } from "@/components/ui/input"
 import { cn } from "@/lib/utils"
 import Link from "next/link"
 
-type Section = "runtimes" | "llm" | "github" | "security" | "integrations" | "factories" | "secrets" | "templates" | "ai-config"
+type Section = "runtimes" | "llm" | "github" | "authentication" | "integrations" | "factories" | "secrets" | "templates" | "ai-config"
 
-const VALID_SECTIONS: Section[] = ["runtimes", "llm", "github", "security", "integrations", "factories", "secrets", "templates", "ai-config"]
+const VALID_SECTIONS: Section[] = ["runtimes", "llm", "github", "authentication", "integrations", "factories", "secrets", "templates", "ai-config"]
 
 function isValidSection(s: string): s is Section {
   return VALID_SECTIONS.includes(s as Section)
@@ -49,6 +49,19 @@ interface SettingsData {
     webhookSecretSet?: boolean; tags?: string[]; color?: string; enabled?: boolean; labels?: string[]; assigned_to?: string
   }>
   secrets?: string[]
+  auth?: {
+    githubOAuth?: {
+      clientId: string
+      clientSecretSet: boolean
+      allowedUsers: string[]
+      allowedOrgs: string[]
+      allowedTeams: string[]
+    }
+    access?: {
+      viewRequiresTags: string[]
+      interactRequiresTags: string[]
+    }
+  }
 }
 
 async function fetchSettings(): Promise<SettingsData> {
@@ -143,7 +156,7 @@ export default function SettingsSectionPage() {
     { id: "runtimes", label: "Sandbox Runtimes", icon: Cpu },
     { id: "llm", label: "LLM Keys", icon: Key },
     { id: "github", label: "GitHub Apps", icon: Github },
-    { id: "security", label: "Security", icon: Shield },
+    { id: "authentication", label: "Authentication", icon: Shield },
     { id: "integrations", label: "Integrations", icon: Zap },
     { id: "factories", label: "Factories", icon: Factory },
     { id: "secrets", label: "Secrets", icon: Lock },
@@ -203,8 +216,8 @@ export default function SettingsSectionPage() {
           {settings && section === "github" && (
             <GitHubSection settings={settings} onSave={save} saving={saving} />
           )}
-          {settings && section === "security" && (
-            <SecuritySection onSave={save} saving={saving} />
+          {settings && section === "authentication" && (
+            <AuthenticationSection settings={settings} onSave={save} saving={saving} />
           )}
           {settings && section === "integrations" && (
             <IntegrationsSection settings={settings} onSave={save} saving={saving} />
@@ -575,41 +588,200 @@ function GitHubSection({ settings, onSave, saving }: { settings: SettingsData; o
   )
 }
 
-function SecuritySection({ onSave, saving }: { onSave: (p: object) => void; saving: boolean }) {
-  const [newPw, setNewPw] = useState("")
-  const [confirm, setConfirm] = useState("")
-  const [pwErr, setPwErr] = useState("")
+function AuthenticationSection({ settings, onSave, saving }: { settings: SettingsData; onSave: (p: object) => void; saving: boolean }) {
+  const [tab, setTab] = useState<'password' | 'github'>('password')
+
+  // Password tab
+  const [newPw, setNewPw] = useState('')
+  const [pwConfirm, setPwConfirm] = useState('')
+  const [pwErr, setPwErr] = useState('')
+
+  // GitHub OAuth tab
+  const ghOAuth = settings.auth?.githubOAuth
+  const ghAccess = settings.auth?.access
+  const [clientId, setClientId] = useState(ghOAuth?.clientId || '')
+  const [clientSecret, setClientSecret] = useState('')
+  const [allowedUsers, setAllowedUsers] = useState((ghOAuth?.allowedUsers || []).join(', '))
+  const [allowedOrgs, setAllowedOrgs] = useState((ghOAuth?.allowedOrgs || []).join(', '))
+  const [allowedTeams, setAllowedTeams] = useState((ghOAuth?.allowedTeams || []).join(', '))
+  const [viewTags, setViewTags] = useState((ghAccess?.viewRequiresTags || []).join(', '))
+  const [interactTags, setInteractTags] = useState((ghAccess?.interactRequiresTags || []).join(', '))
+  const [ghErr, setGhErr] = useState('')
 
   function handlePasswordSave() {
-    setPwErr("")
-    if (newPw.length < 8) { setPwErr("Password must be at least 8 characters"); return }
-    if (newPw !== confirm) { setPwErr("Passwords don\'t match"); return }
+    setPwErr('')
+    if (newPw.length < 8) { setPwErr('Password must be at least 8 characters'); return }
+    if (newPw !== pwConfirm) { setPwErr('Passwords do not match'); return }
     onSave({ uiPassword: newPw })
-    setNewPw(""); setConfirm("")
+    setNewPw(''); setPwConfirm('')
   }
 
+  function splitList(s: string) {
+    return s.split(/[,\n]+/).map((t: string) => t.trim()).filter(Boolean)
+  }
+
+  function handleGitHubSave() {
+    setGhErr('')
+    if (!clientId.trim()) { setGhErr('Client ID is required'); return }
+    if (!ghOAuth && !clientSecret.trim()) { setGhErr('Client Secret is required for initial setup'); return }
+    const authPatch: Record<string, unknown> = {
+      githubOAuth: {
+        clientId: clientId.trim(),
+        ...(clientSecret ? { clientSecret: clientSecret.trim() } : {}),
+        allowedUsers: splitList(allowedUsers),
+        allowedOrgs: splitList(allowedOrgs),
+        allowedTeams: splitList(allowedTeams),
+      },
+      access: {
+        viewRequiresTags: splitList(viewTags),
+        interactRequiresTags: splitList(interactTags),
+      },
+    }
+    onSave({ auth: authPatch })
+    setClientSecret('')
+  }
+
+  function handleGitHubRemove() {
+    if (!window.confirm('Remove GitHub OAuth? Users will fall back to password login.')) return
+    onSave({ auth: { removeGithubOAuth: true } })
+  }
+
+  const callbackUrl = typeof window !== 'undefined'
+    ? window.location.origin + '/api/auth/github/callback'
+    : 'https://your-hub/api/auth/github/callback'
+
   return (
-    <div>
-      <h2 className="text-base font-semibold mb-1">Security</h2>
-      <p className="text-sm text-muted-foreground mb-4">Change the web UI login password.</p>
-      <div className="border border-border rounded-lg p-5 max-w-sm space-y-3">
-        <div>
-          <label className="text-xs text-muted-foreground mb-1 block">New Password</label>
-          <Input type="password" value={newPw} onChange={e => setNewPw(e.target.value)} className="h-8 text-sm" placeholder="Min 8 characters" />
-        </div>
-        <div>
-          <label className="text-xs text-muted-foreground mb-1 block">Confirm Password</label>
-          <Input type="password" value={confirm} onChange={e => setConfirm(e.target.value)} className="h-8 text-sm" placeholder="Repeat password" />
-        </div>
-        {pwErr && <p className="text-xs text-red-500">{pwErr}</p>}
-        <Button size="sm" disabled={saving || !newPw || !confirm} onClick={handlePasswordSave}>
-          Change Password
-        </Button>
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-base font-semibold mb-0.5">Authentication</h2>
+        <p className="text-sm text-muted-foreground">Configure how users log in to the hub UI.</p>
       </div>
+
+      <div className="flex gap-1 border-b border-border">
+        {(['password', 'github'] as const).map(t => (
+          <button
+            key={t}
+            onClick={() => setTab(t)}
+            className={cn(
+              'px-3 py-1.5 text-sm font-medium border-b-2 -mb-px transition-colors',
+              tab === t
+                ? 'border-foreground text-foreground'
+                : 'border-transparent text-muted-foreground hover:text-foreground'
+            )}
+          >
+            {t === 'password' ? 'Password' : 'GitHub OAuth'}
+            {t === 'github' && ghOAuth && (
+              <span className="ml-1.5 text-xs bg-green-500/20 text-green-400 px-1.5 py-0.5 rounded">Active</span>
+            )}
+          </button>
+        ))}
+      </div>
+
+      {tab === 'password' && (
+        <div className="border border-border rounded-lg p-5 max-w-sm space-y-3">
+          <p className="text-xs text-muted-foreground">Change the web UI login password.</p>
+          <div>
+            <label className="text-xs text-muted-foreground mb-1 block">New Password</label>
+            <Input type="password" value={newPw} onChange={e => setNewPw(e.target.value)} className="h-8 text-sm" placeholder="Min 8 characters" />
+          </div>
+          <div>
+            <label className="text-xs text-muted-foreground mb-1 block">Confirm Password</label>
+            <Input type="password" value={pwConfirm} onChange={e => setPwConfirm(e.target.value)} className="h-8 text-sm" placeholder="Repeat password" />
+          </div>
+          {pwErr && <p className="text-xs text-red-500">{pwErr}</p>}
+          <Button size="sm" disabled={saving || !newPw || !pwConfirm} onClick={handlePasswordSave}>
+            Change Password
+          </Button>
+        </div>
+      )}
+
+      {tab === 'github' && (
+        <div className="space-y-4 max-w-lg">
+          <p className="text-xs text-muted-foreground">
+            Allow users to log in with GitHub. Requires a{' '}
+            <a href="https://github.com/settings/developers" target="_blank" rel="noopener noreferrer" className="underline">GitHub OAuth App</a>.{' '}
+            Set the callback URL to{' '}
+            <code className="text-xs bg-muted px-1 rounded">{callbackUrl}</code>.
+          </p>
+
+          <div className="border border-border rounded-lg p-5 space-y-3">
+            <h3 className="text-sm font-medium">OAuth App Credentials</h3>
+            <div>
+              <label className="text-xs text-muted-foreground mb-1 block">Client ID</label>
+              <Input value={clientId} onChange={e => setClientId(e.target.value)} className="h-8 text-sm font-mono" placeholder="Ov23li..." />
+            </div>
+            <div>
+              <label className="text-xs text-muted-foreground mb-1 block">
+                Client Secret{ghOAuth?.clientSecretSet && <span className="ml-1 text-green-500 text-xs">(set)</span>}
+              </label>
+              <Input
+                type="password"
+                value={clientSecret}
+                onChange={e => setClientSecret(e.target.value)}
+                className="h-8 text-sm font-mono"
+                placeholder={ghOAuth?.clientSecretSet ? 'Leave blank to keep existing' : 'Paste secret...'}
+              />
+            </div>
+          </div>
+
+          <div className="border border-border rounded-lg p-5 space-y-3">
+            <div>
+              <h3 className="text-sm font-medium">Access Allowlist</h3>
+              <p className="text-xs text-muted-foreground mt-0.5">Leave all blank to allow any authenticated GitHub user.</p>
+            </div>
+            <div>
+              <label className="text-xs text-muted-foreground mb-1 block">GitHub Usernames</label>
+              <Input value={allowedUsers} onChange={e => setAllowedUsers(e.target.value)} className="h-8 text-sm" placeholder="alice, bob" />
+              <p className="text-xs text-muted-foreground mt-1">Comma-separated. These users always have full access.</p>
+            </div>
+            <div>
+              <label className="text-xs text-muted-foreground mb-1 block">GitHub Orgs</label>
+              <Input value={allowedOrgs} onChange={e => setAllowedOrgs(e.target.value)} className="h-8 text-sm" placeholder="my-org" />
+              <p className="text-xs text-muted-foreground mt-1">Members of these orgs can log in.</p>
+            </div>
+            <div>
+              <label className="text-xs text-muted-foreground mb-1 block">GitHub Teams</label>
+              <Input value={allowedTeams} onChange={e => setAllowedTeams(e.target.value)} className="h-8 text-sm" placeholder="my-org/my-team" />
+              <p className="text-xs text-muted-foreground mt-1">Format: org/team. Members of these teams can log in.</p>
+            </div>
+          </div>
+
+          <div className="border border-border rounded-lg p-5 space-y-3">
+            <div>
+              <h3 className="text-sm font-medium">Tag-Based Access Control <span className="text-xs font-normal text-muted-foreground">(optional)</span></h3>
+              <p className="text-xs text-muted-foreground mt-0.5">Restrict which claws each user can see or interact with based on claw tags.</p>
+            </div>
+            <div>
+              <label className="text-xs text-muted-foreground mb-1 block">View requires tag</label>
+              <Input value={viewTags} onChange={e => setViewTags(e.target.value)} className="h-8 text-sm font-mono" placeholder="user, team=frontend" />
+              <p className="text-xs text-muted-foreground mt-1">
+                A claw is visible if it has a tag matching a pattern like <code className="bg-muted px-1 rounded">user=alice</code> or <code className="bg-muted px-1 rounded">team=frontend</code>.
+              </p>
+            </div>
+            <div>
+              <label className="text-xs text-muted-foreground mb-1 block">Interact requires tag</label>
+              <Input value={interactTags} onChange={e => setInteractTags(e.target.value)} className="h-8 text-sm font-mono" placeholder="user, team=frontend" />
+              <p className="text-xs text-muted-foreground mt-1">User can send messages or kill a claw only if it has a matching tag.</p>
+            </div>
+          </div>
+
+          {ghErr && <p className="text-xs text-red-500">{ghErr}</p>}
+
+          <div className="flex gap-2">
+            <Button size="sm" disabled={saving} onClick={handleGitHubSave}>
+              {ghOAuth ? 'Update GitHub OAuth' : 'Enable GitHub OAuth'}
+            </Button>
+            {ghOAuth && (
+              <Button size="sm" variant="outline" disabled={saving} onClick={handleGitHubRemove} className="text-destructive hover:text-destructive">
+                Remove
+              </Button>
+            )}
+          </div>
+        </div>
+      )}
     </div>
   )
 }
-
 function IntegrationsSection({ settings, onSave, saving }: { settings: SettingsData; onSave: (p: object) => void; saving: boolean }) {
   const linear = settings.integrations?.linear || []
   const [editingIdx, setEditingIdx] = useState<number | null>(null)

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -660,8 +660,8 @@ function AuthenticationSection({ settings, onSave, saving }: { settings: Setting
   }
 
   const callbackUrl = typeof window !== 'undefined'
-    ? window.location.origin + '/api/auth/github/callback'
-    : 'https://your-hub/api/auth/github/callback'
+    ? window.location.origin + '/login'
+    : 'https://your-hub/login'
 
   return (
     <div className="space-y-6">

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -589,16 +589,16 @@ function GitHubSection({ settings, onSave, saving }: { settings: SettingsData; o
 }
 
 function AuthenticationSection({ settings, onSave, saving }: { settings: SettingsData; onSave: (p: object) => void; saving: boolean }) {
-  const [tab, setTab] = useState<'password' | 'github'>('password')
+  const ghOAuth = settings.auth?.githubOAuth
+  const ghAccess = settings.auth?.access
 
-  // Password tab
+  // Password card state
   const [newPw, setNewPw] = useState('')
   const [pwConfirm, setPwConfirm] = useState('')
   const [pwErr, setPwErr] = useState('')
 
-  // GitHub OAuth tab
-  const ghOAuth = settings.auth?.githubOAuth
-  const ghAccess = settings.auth?.access
+  // GitHub OAuth config state
+  const [showGhForm, setShowGhForm] = useState(false)
   const [clientId, setClientId] = useState(ghOAuth?.clientId || '')
   const [clientSecret, setClientSecret] = useState('')
   const [allowedUsers, setAllowedUsers] = useState((ghOAuth?.allowedUsers || []).join(', '))
@@ -624,26 +624,39 @@ function AuthenticationSection({ settings, onSave, saving }: { settings: Setting
     setGhErr('')
     if (!clientId.trim()) { setGhErr('Client ID is required'); return }
     if (!ghOAuth && !clientSecret.trim()) { setGhErr('Client Secret is required for initial setup'); return }
-    const authPatch: Record<string, unknown> = {
-      githubOAuth: {
-        clientId: clientId.trim(),
-        ...(clientSecret ? { clientSecret: clientSecret.trim() } : {}),
-        allowedUsers: splitList(allowedUsers),
-        allowedOrgs: splitList(allowedOrgs),
-        allowedTeams: splitList(allowedTeams),
-      },
-      access: {
-        viewRequiresTags: splitList(viewTags),
-        interactRequiresTags: splitList(interactTags),
-      },
-    }
-    onSave({ auth: authPatch })
+    onSave({
+      auth: {
+        githubOAuth: {
+          clientId: clientId.trim(),
+          ...(clientSecret ? { clientSecret: clientSecret.trim() } : {}),
+          allowedUsers: splitList(allowedUsers),
+          allowedOrgs: splitList(allowedOrgs),
+          allowedTeams: splitList(allowedTeams),
+        },
+        access: {
+          viewRequiresTags: splitList(viewTags),
+          interactRequiresTags: splitList(interactTags),
+        },
+      }
+    })
     setClientSecret('')
+    setShowGhForm(false)
   }
 
   function handleGitHubRemove() {
-    if (!window.confirm('Remove GitHub OAuth? Users will fall back to password login.')) return
+    if (!window.confirm('Disable GitHub OAuth? Users will only be able to log in with the password.')) return
     onSave({ auth: { removeGithubOAuth: true } })
+  }
+
+  function handleGitHubEdit() {
+    setClientId(ghOAuth?.clientId || '')
+    setClientSecret('')
+    setAllowedUsers((ghOAuth?.allowedUsers || []).join(', '))
+    setAllowedOrgs((ghOAuth?.allowedOrgs || []).join(', '))
+    setAllowedTeams((ghOAuth?.allowedTeams || []).join(', '))
+    setViewTags((ghAccess?.viewRequiresTags || []).join(', '))
+    setInteractTags((ghAccess?.interactRequiresTags || []).join(', '))
+    setShowGhForm(true)
   }
 
   const callbackUrl = typeof window !== 'undefined'
@@ -651,35 +664,22 @@ function AuthenticationSection({ settings, onSave, saving }: { settings: Setting
     : 'https://your-hub/api/auth/github/callback'
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-6">
       <div>
         <h2 className="text-base font-semibold mb-0.5">Authentication</h2>
-        <p className="text-sm text-muted-foreground">Configure how users log in to the hub UI.</p>
+        <p className="text-sm text-muted-foreground">Both methods can be active simultaneously. GitHub OAuth users and password users both have full access unless tag-based restrictions are configured.</p>
       </div>
 
-      <div className="flex gap-1 border-b border-border">
-        {(['password', 'github'] as const).map(t => (
-          <button
-            key={t}
-            onClick={() => setTab(t)}
-            className={cn(
-              'px-3 py-1.5 text-sm font-medium border-b-2 -mb-px transition-colors',
-              tab === t
-                ? 'border-foreground text-foreground'
-                : 'border-transparent text-muted-foreground hover:text-foreground'
-            )}
-          >
-            {t === 'password' ? 'Password' : 'GitHub OAuth'}
-            {t === 'github' && ghOAuth && (
-              <span className="ml-1.5 text-xs bg-green-500/20 text-green-400 px-1.5 py-0.5 rounded">Active</span>
-            )}
-          </button>
-        ))}
-      </div>
-
-      {tab === 'password' && (
-        <div className="border border-border rounded-lg p-5 max-w-sm space-y-3">
-          <p className="text-xs text-muted-foreground">Change the web UI login password.</p>
+      {/* Password card */}
+      <div className="border border-border rounded-lg p-5 space-y-3 max-w-lg">
+        <div className="flex items-center justify-between">
+          <div>
+            <h3 className="text-sm font-medium">Password Login</h3>
+            <p className="text-xs text-muted-foreground mt-0.5">Always enabled. Used by the hub token and UI password.</p>
+          </div>
+          <span className="text-xs bg-green-500/20 text-green-400 px-2 py-0.5 rounded font-medium">Active</span>
+        </div>
+        <div className="border-t border-border pt-3 space-y-3">
           <div>
             <label className="text-xs text-muted-foreground mb-1 block">New Password</label>
             <Input type="password" value={newPw} onChange={e => setNewPw(e.target.value)} className="h-8 text-sm" placeholder="Min 8 characters" />
@@ -693,92 +693,108 @@ function AuthenticationSection({ settings, onSave, saving }: { settings: Setting
             Change Password
           </Button>
         </div>
-      )}
+      </div>
 
-      {tab === 'github' && (
-        <div className="space-y-4 max-w-lg">
-          <p className="text-xs text-muted-foreground">
-            Allow users to log in with GitHub. Requires a{' '}
-            <a href="https://github.com/settings/developers" target="_blank" rel="noopener noreferrer" className="underline">GitHub OAuth App</a>.{' '}
-            Set the callback URL to{' '}
-            <code className="text-xs bg-muted px-1 rounded">{callbackUrl}</code>.
-          </p>
-
-          <div className="border border-border rounded-lg p-5 space-y-3">
-            <h3 className="text-sm font-medium">OAuth App Credentials</h3>
-            <div>
-              <label className="text-xs text-muted-foreground mb-1 block">Client ID</label>
-              <Input value={clientId} onChange={e => setClientId(e.target.value)} className="h-8 text-sm font-mono" placeholder="Ov23li..." />
-            </div>
-            <div>
-              <label className="text-xs text-muted-foreground mb-1 block">
-                Client Secret{ghOAuth?.clientSecretSet && <span className="ml-1 text-green-500 text-xs">(set)</span>}
-              </label>
-              <Input
-                type="password"
-                value={clientSecret}
-                onChange={e => setClientSecret(e.target.value)}
-                className="h-8 text-sm font-mono"
-                placeholder={ghOAuth?.clientSecretSet ? 'Leave blank to keep existing' : 'Paste secret...'}
-              />
-            </div>
+      {/* GitHub OAuth card */}
+      <div className="border border-border rounded-lg p-5 space-y-3 max-w-lg">
+        <div className="flex items-center justify-between">
+          <div>
+            <h3 className="text-sm font-medium">GitHub OAuth</h3>
+            <p className="text-xs text-muted-foreground mt-0.5">Let users log in with their GitHub account.</p>
           </div>
-
-          <div className="border border-border rounded-lg p-5 space-y-3">
-            <div>
-              <h3 className="text-sm font-medium">Access Allowlist</h3>
-              <p className="text-xs text-muted-foreground mt-0.5">Leave all blank to allow any authenticated GitHub user.</p>
-            </div>
-            <div>
-              <label className="text-xs text-muted-foreground mb-1 block">GitHub Usernames</label>
-              <Input value={allowedUsers} onChange={e => setAllowedUsers(e.target.value)} className="h-8 text-sm" placeholder="alice, bob" />
-              <p className="text-xs text-muted-foreground mt-1">Comma-separated. These users always have full access.</p>
-            </div>
-            <div>
-              <label className="text-xs text-muted-foreground mb-1 block">GitHub Orgs</label>
-              <Input value={allowedOrgs} onChange={e => setAllowedOrgs(e.target.value)} className="h-8 text-sm" placeholder="my-org" />
-              <p className="text-xs text-muted-foreground mt-1">Members of these orgs can log in.</p>
-            </div>
-            <div>
-              <label className="text-xs text-muted-foreground mb-1 block">GitHub Teams</label>
-              <Input value={allowedTeams} onChange={e => setAllowedTeams(e.target.value)} className="h-8 text-sm" placeholder="my-org/my-team" />
-              <p className="text-xs text-muted-foreground mt-1">Format: org/team. Members of these teams can log in.</p>
-            </div>
-          </div>
-
-          <div className="border border-border rounded-lg p-5 space-y-3">
-            <div>
-              <h3 className="text-sm font-medium">Tag-Based Access Control <span className="text-xs font-normal text-muted-foreground">(optional)</span></h3>
-              <p className="text-xs text-muted-foreground mt-0.5">Restrict which claws each user can see or interact with based on claw tags.</p>
-            </div>
-            <div>
-              <label className="text-xs text-muted-foreground mb-1 block">View requires tag</label>
-              <Input value={viewTags} onChange={e => setViewTags(e.target.value)} className="h-8 text-sm font-mono" placeholder="user, team=frontend" />
-              <p className="text-xs text-muted-foreground mt-1">
-                A claw is visible if it has a tag matching a pattern like <code className="bg-muted px-1 rounded">user=alice</code> or <code className="bg-muted px-1 rounded">team=frontend</code>.
-              </p>
-            </div>
-            <div>
-              <label className="text-xs text-muted-foreground mb-1 block">Interact requires tag</label>
-              <Input value={interactTags} onChange={e => setInteractTags(e.target.value)} className="h-8 text-sm font-mono" placeholder="user, team=frontend" />
-              <p className="text-xs text-muted-foreground mt-1">User can send messages or kill a claw only if it has a matching tag.</p>
-            </div>
-          </div>
-
-          {ghErr && <p className="text-xs text-red-500">{ghErr}</p>}
-
-          <div className="flex gap-2">
-            <Button size="sm" disabled={saving} onClick={handleGitHubSave}>
-              {ghOAuth ? 'Update GitHub OAuth' : 'Enable GitHub OAuth'}
-            </Button>
-            {ghOAuth && (
-              <Button size="sm" variant="outline" disabled={saving} onClick={handleGitHubRemove} className="text-destructive hover:text-destructive">
-                Remove
-              </Button>
-            )}
-          </div>
+          {ghOAuth
+            ? <span className="text-xs bg-green-500/20 text-green-400 px-2 py-0.5 rounded font-medium">Active</span>
+            : <span className="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded font-medium">Inactive</span>
+          }
         </div>
-      )}
+
+        {ghOAuth && !showGhForm && (
+          <div className="border-t border-border pt-3 space-y-2 text-xs text-muted-foreground">
+            <div className="flex gap-2"><span className="font-medium text-foreground w-28">Client ID</span><span className="font-mono">{ghOAuth.clientId}</span></div>
+            <div className="flex gap-2"><span className="font-medium text-foreground w-28">Client Secret</span><span>{ghOAuth.clientSecretSet ? '••••••••' : 'not set'}</span></div>
+            {ghOAuth.allowedUsers.length > 0 && <div className="flex gap-2"><span className="font-medium text-foreground w-28">Allowed users</span><span>{ghOAuth.allowedUsers.join(', ')}</span></div>}
+            {ghOAuth.allowedOrgs.length > 0 && <div className="flex gap-2"><span className="font-medium text-foreground w-28">Allowed orgs</span><span>{ghOAuth.allowedOrgs.join(', ')}</span></div>}
+            {ghOAuth.allowedTeams.length > 0 && <div className="flex gap-2"><span className="font-medium text-foreground w-28">Allowed teams</span><span>{ghOAuth.allowedTeams.join(', ')}</span></div>}
+            {ghAccess?.viewRequiresTags && ghAccess.viewRequiresTags.length > 0 && <div className="flex gap-2"><span className="font-medium text-foreground w-28">View tag filter</span><span className="font-mono">{ghAccess.viewRequiresTags.join(', ')}</span></div>}
+            {ghAccess?.interactRequiresTags && ghAccess.interactRequiresTags.length > 0 && <div className="flex gap-2"><span className="font-medium text-foreground w-28">Interact tag filter</span><span className="font-mono">{ghAccess.interactRequiresTags.join(', ')}</span></div>}
+            <div className="flex gap-2 pt-1">
+              <Button size="sm" variant="outline" onClick={handleGitHubEdit}>Edit</Button>
+              <Button size="sm" variant="outline" onClick={handleGitHubRemove} className="text-destructive hover:text-destructive">Disable</Button>
+            </div>
+          </div>
+        )}
+
+        {(!ghOAuth || showGhForm) && (
+          <div className="border-t border-border pt-3 space-y-4">
+            {!ghOAuth && (
+              <p className="text-xs text-muted-foreground">
+                Create a <a href="https://github.com/settings/developers" target="_blank" rel="noopener noreferrer" className="underline">GitHub OAuth App</a> and set the callback URL to{' '}
+                <code className="bg-muted px-1 rounded">{callbackUrl}</code>.
+              </p>
+            )}
+
+            <div className="space-y-3">
+              <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">App Credentials</h4>
+              <div>
+                <label className="text-xs text-muted-foreground mb-1 block">Client ID</label>
+                <Input value={clientId} onChange={e => setClientId(e.target.value)} className="h-8 text-sm font-mono" placeholder="Ov23li..." />
+              </div>
+              <div>
+                <label className="text-xs text-muted-foreground mb-1 block">
+                  Client Secret{ghOAuth?.clientSecretSet && <span className="ml-1 text-green-500">(set)</span>}
+                </label>
+                <Input
+                  type="password"
+                  value={clientSecret}
+                  onChange={e => setClientSecret(e.target.value)}
+                  className="h-8 text-sm font-mono"
+                  placeholder={ghOAuth?.clientSecretSet ? 'Leave blank to keep existing' : 'Paste secret...'}
+                />
+              </div>
+            </div>
+
+            <div className="space-y-3">
+              <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Allowlist <span className="normal-case font-normal">(leave blank = any GitHub user)</span></h4>
+              <div>
+                <label className="text-xs text-muted-foreground mb-1 block">Usernames</label>
+                <Input value={allowedUsers} onChange={e => setAllowedUsers(e.target.value)} className="h-8 text-sm" placeholder="alice, bob" />
+              </div>
+              <div>
+                <label className="text-xs text-muted-foreground mb-1 block">Orgs</label>
+                <Input value={allowedOrgs} onChange={e => setAllowedOrgs(e.target.value)} className="h-8 text-sm" placeholder="my-org" />
+              </div>
+              <div>
+                <label className="text-xs text-muted-foreground mb-1 block">Teams</label>
+                <Input value={allowedTeams} onChange={e => setAllowedTeams(e.target.value)} className="h-8 text-sm" placeholder="my-org/my-team" />
+              </div>
+            </div>
+
+            <div className="space-y-3">
+              <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Tag-Based Access Control <span className="normal-case font-normal">(optional)</span></h4>
+              <div>
+                <label className="text-xs text-muted-foreground mb-1 block">View requires tag</label>
+                <Input value={viewTags} onChange={e => setViewTags(e.target.value)} className="h-8 text-sm font-mono" placeholder="user, team=frontend" />
+                <p className="text-xs text-muted-foreground mt-1">Claw must have a tag like <code className="bg-muted px-1 rounded">user=alice</code> for that user to see it.</p>
+              </div>
+              <div>
+                <label className="text-xs text-muted-foreground mb-1 block">Interact requires tag</label>
+                <Input value={interactTags} onChange={e => setInteractTags(e.target.value)} className="h-8 text-sm font-mono" placeholder="user, team=frontend" />
+              </div>
+            </div>
+
+            {ghErr && <p className="text-xs text-red-500">{ghErr}</p>}
+
+            <div className="flex gap-2">
+              <Button size="sm" disabled={saving} onClick={handleGitHubSave}>
+                {ghOAuth ? 'Save Changes' : 'Enable GitHub OAuth'}
+              </Button>
+              {showGhForm && (
+                <Button size="sm" variant="outline" onClick={() => { setShowGhForm(false); setGhErr('') }}>Cancel</Button>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
     </div>
   )
 }

--- a/web/components/sidebar.tsx
+++ b/web/components/sidebar.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { ClawCard } from "@/components/claw-card"
+import { clearConfig } from "@/lib/api"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -398,14 +399,14 @@ export function Sidebar({
             size="sm"
             className="flex-1 justify-start gap-2 text-muted-foreground hover:text-foreground"
             onClick={async () => {
-              const token = sessionStorage.getItem("ec_hub_token") || ""
+              const token = sessionStorage.getItem("ec_github_token") || sessionStorage.getItem("ec_hub_token") || ""
               if (token) {
                 const { getHubUrl } = await import("@/lib/hub-url")
                 const hubUrl = getHubUrl()
                 const logoutUrl = hubUrl ? `${hubUrl}/api/auth/logout` : "/api/auth/logout"
                 await fetch(logoutUrl, { method: "POST", headers: { Authorization: `Bearer ${token}` } }).catch(() => {})
               }
-              sessionStorage.removeItem("ec_hub_token")
+              clearConfig()
               window.location.href = "/login"
             }}
           >

--- a/web/components/sidebar.tsx
+++ b/web/components/sidebar.tsx
@@ -53,6 +53,7 @@ interface SidebarProps {
   onClearTagFilters: () => void
   isCollapsed: boolean
   onToggleCollapse: () => void
+  isAdmin?: boolean
 }
 
 /** Thin wrapper that gives ClawCard sortable DnD powers */
@@ -107,6 +108,7 @@ export function Sidebar({
   onClearTagFilters,
   isCollapsed,
   onToggleCollapse,
+  isAdmin = true,
 }: SidebarProps) {
   const tagKeys = allTags
   const { appName } = useBranding()
@@ -410,15 +412,17 @@ export function Sidebar({
             <LogOut className="size-4" />
             Sign out
           </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="size-8 text-muted-foreground hover:text-foreground flex-shrink-0"
-            onClick={() => { window.location.href = "/settings" }}
-            title="Settings"
-          >
-            <Settings className="size-4" />
-          </Button>
+          {isAdmin && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="size-8 text-muted-foreground hover:text-foreground flex-shrink-0"
+              onClick={() => { window.location.href = "/settings" }}
+              title="Settings"
+            >
+              <Settings className="size-4" />
+            </Button>
+          )}
         </div>
       </div>
     </aside>

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -17,6 +17,12 @@ export function resolveToken(): Promise<string> {
   }
 
   // Check sessionStorage first (set by login page)
+  // Prefer GitHub OAuth token over hub token when both exist
+  const githubToken = sessionStorage.getItem("ec_github_token")
+  if (githubToken) {
+    _token = githubToken
+    return Promise.resolve(_token)
+  }
   const stored = sessionStorage.getItem("ec_hub_token")
   if (stored) {
     _token = stored
@@ -47,7 +53,7 @@ export function resolveToken(): Promise<string> {
 function getTokenSync(): string {
   if (_token) return _token
   if (typeof window !== "undefined") {
-    return sessionStorage.getItem("ec_hub_token") || ""
+    return sessionStorage.getItem("ec_github_token") || sessionStorage.getItem("ec_hub_token") || ""
   }
   return ""
 }
@@ -182,6 +188,7 @@ export function clearConfig() {
   _tokenPromise = null
   if (typeof window !== "undefined") {
     sessionStorage.removeItem("ec_hub_token")
+    sessionStorage.removeItem("ec_github_token")
   }
 }
 

--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Overview

Adds GitHub OAuth as an alternative login method alongside the existing shared password, plus tag-based RBAC so users can only see/interact with claws matching configured tag patterns.

## Changes

### Config types (`pkg/types/template.go`)
- New `AuthConfig`, `GitHubOAuthConfig`, `AccessConfig` types
- Added `Auth *AuthConfig` to `HubConfig` (backward compat: nil = existing behavior)

### GitHub OAuth flow (`pkg/hub/auth_github.go`)
- `GET /api/auth/github` → redirect to GitHub OAuth authorize
- `GET /api/auth/github/callback` → exchange code, verify allowlist, issue session token
- Session tokens: HMAC-SHA256 signed with hub.token as key, 7-day expiry, no external deps
- Allowlist: users / org membership / team membership (any match = allow, none configured = deny all)

### Token validation (`pkg/hub/server.go`)
- `withWebAuth` now accepts both hub token (password auth) and GitHub OAuth session tokens
- `githubLoginFromContext` helper for downstream handlers
- `handleWebMe` returns `{login, name, avatar_url, auth_method: "github"}` for OAuth users
- New `GET /api/auth/config` (public) returns `{github_oauth_enabled, password_auth_enabled}`

### Tag-based access control (`pkg/hub/access.go`)
- `canViewClaw(cfg, userLogin, clawTags)` — filters claw list
- `canInteractWithClaw(cfg, userLogin, clawTags)` — gates message sending
- `{user}` placeholder substitution in tag patterns
- Admin users bypass all tag checks
- Backward compat: empty config allows all (no behavior change)

### Web UI
- `web/app/login/page.tsx`: fetches `/api/auth/config`, shows GitHub sign-in button when enabled
- `web/lib/api.ts`: resolves `ec_github_token` from sessionStorage with priority over hub token

## Backward Compatibility
- No `auth:` in hub.yaml → everything works exactly as before
- Shared password login still works
- `go build ./...` ✓
- `cd web && npm run build` ✓
- All existing tests pass ✓