### PR TITLE
feat: Configure with AI — chat interface for hub.yaml changes

### DIFF
--- a/pkg/hub/ai_config.go
+++ b/pkg/hub/ai_config.go
@@ -882,8 +882,8 @@ func maskSensitiveYAMLValues(node *yaml.Node) {
 				continue
 			}
 			if keyNode.Value == "secrets" && valNode.Kind == yaml.MappingNode {
-				for j := 1; j < len(valNode.Content); j += 2 {
-					maskYAMLNodeValue(valNode.Content[j])
+				for j := 0; j+1 < len(valNode.Content); j += 2 {
+					maskYAMLNodeValue(valNode.Content[j+1])
 				}
 				continue
 			}

--- a/pkg/hub/ai_config.go
+++ b/pkg/hub/ai_config.go
@@ -125,6 +125,18 @@ func (s *Server) handleAIConfigApply(w http.ResponseWriter, r *http.Request) {
 	// Substitute placeholders
 	finalYAML := substitutePlaceholders(req.ProposedYAML, req.Secrets)
 
+	// Restore masked secrets (*** from sanitized config) from disk before parsing.
+	diskCfg, err := config.LoadHubConfig()
+	if err != nil {
+		http.Error(w, "failed to load hub config: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	finalYAML, err = restoreMaskedSecretsFromDisk(finalYAML, diskCfg)
+	if err != nil {
+		http.Error(w, "failed to restore masked secrets: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
 	// Parse and validate
 	var newCfg types.HubConfig
 	if err := yaml.Unmarshal([]byte(finalYAML), &newCfg); err != nil {
@@ -315,18 +327,15 @@ func callLLMForConfig(sanitizedYAML, message string, history []aiChatMessage, ll
 	if openaiKey != "" {
 		return callOpenAI(openaiKey, systemPrompt, msgs)
 	}
-	if len(llmKeys) > 0 {
-		// Use first available key with whatever provider
-		k := llmKeys[0]
-		switch k.Provider {
-		case "anthropic":
-			return callAnthropic(k.APIKey, systemPrompt, msgs)
-		case "openai":
-			return callOpenAI(k.APIKey, systemPrompt, msgs)
-		}
+	if len(llmKeys) == 0 {
+		return "", fmt.Errorf("no LLM keys configured")
 	}
-	_ = defaultModel
-	return "", fmt.Errorf("No LLM keys configured")
+	defaultProvider := strings.TrimSpace(strings.SplitN(defaultModel, "/", 2)[0])
+	availableProviders := uniqueProviders(llmKeys)
+	if defaultProvider != "" {
+		return "", fmt.Errorf("no supported LLM key configured for default_model provider %q (supported providers: anthropic, openai; configured: %s)", defaultProvider, strings.Join(availableProviders, ", "))
+	}
+	return "", fmt.Errorf("no supported LLM key configured (supported providers: anthropic, openai; configured: %s)", strings.Join(availableProviders, ", "))
 }
 
 func callAnthropic(apiKey, systemPrompt string, msgs []aiChatMessage) (string, error) {
@@ -559,6 +568,148 @@ func substitutePlaceholders(yamlStr string, secrets map[string]string) string {
 		}
 		return match
 	})
+}
+
+func restoreMaskedSecretsFromDisk(yamlStr string, diskCfg *types.HubConfig) (string, error) {
+	if diskCfg == nil {
+		return yamlStr, nil
+	}
+
+	var proposedNode yaml.Node
+	if err := yaml.Unmarshal([]byte(yamlStr), &proposedNode); err != nil {
+		return "", err
+	}
+
+	diskYAML, err := yaml.Marshal(diskCfg)
+	if err != nil {
+		return "", err
+	}
+	var diskNode yaml.Node
+	if err := yaml.Unmarshal(diskYAML, &diskNode); err != nil {
+		return "", err
+	}
+
+	mergeMaskedSecretsNode(&proposedNode, &diskNode)
+	restored, err := yaml.Marshal(&proposedNode)
+	if err != nil {
+		return "", err
+	}
+	return string(restored), nil
+}
+
+func mergeMaskedSecretsNode(proposed, disk *yaml.Node) {
+	if proposed == nil {
+		return
+	}
+	switch proposed.Kind {
+	case yaml.DocumentNode:
+		if len(proposed.Content) == 0 {
+			return
+		}
+		var diskRoot *yaml.Node
+		if disk != nil && len(disk.Content) > 0 {
+			diskRoot = disk.Content[0]
+		}
+		mergeMaskedSecretsNode(proposed.Content[0], diskRoot)
+	case yaml.SequenceNode:
+		for i := range proposed.Content {
+			var diskChild *yaml.Node
+			if disk != nil && disk.Kind == yaml.SequenceNode && i < len(disk.Content) {
+				diskChild = disk.Content[i]
+			}
+			mergeMaskedSecretsNode(proposed.Content[i], diskChild)
+		}
+	case yaml.MappingNode:
+		diskVals := map[string]*yaml.Node{}
+		if disk != nil && disk.Kind == yaml.MappingNode {
+			for i := 0; i+1 < len(disk.Content); i += 2 {
+				diskVals[disk.Content[i].Value] = disk.Content[i+1]
+			}
+		}
+
+		for i := 0; i+1 < len(proposed.Content); i += 2 {
+			keyNode := proposed.Content[i]
+			valNode := proposed.Content[i+1]
+			diskVal := diskVals[keyNode.Value]
+
+			if _, ok := sensitiveYAMLFields[keyNode.Value]; ok && isMaskedValue(valNode) && diskVal != nil {
+				proposed.Content[i+1] = cloneYAMLNode(diskVal)
+				continue
+			}
+
+			if keyNode.Value == "secrets" && valNode.Kind == yaml.MappingNode {
+				mergeMaskedSecretMap(valNode, diskVal)
+				continue
+			}
+
+			mergeMaskedSecretsNode(valNode, diskVal)
+		}
+	}
+}
+
+func mergeMaskedSecretMap(proposedSecrets, diskSecrets *yaml.Node) {
+	if proposedSecrets == nil || proposedSecrets.Kind != yaml.MappingNode {
+		return
+	}
+	if diskSecrets == nil || diskSecrets.Kind != yaml.MappingNode {
+		return
+	}
+
+	diskVals := map[string]*yaml.Node{}
+	for i := 0; i+1 < len(diskSecrets.Content); i += 2 {
+		diskVals[diskSecrets.Content[i].Value] = diskSecrets.Content[i+1]
+	}
+
+	for i := 0; i+1 < len(proposedSecrets.Content); i += 2 {
+		key := proposedSecrets.Content[i].Value
+		val := proposedSecrets.Content[i+1]
+		if isMaskedValue(val) {
+			if diskVal := diskVals[key]; diskVal != nil {
+				proposedSecrets.Content[i+1] = cloneYAMLNode(diskVal)
+			}
+		}
+	}
+}
+
+func isMaskedValue(node *yaml.Node) bool {
+	return node != nil && node.Kind == yaml.ScalarNode && node.Value == "***"
+}
+
+func cloneYAMLNode(n *yaml.Node) *yaml.Node {
+	if n == nil {
+		return nil
+	}
+	cloned := *n
+	if len(n.Content) > 0 {
+		cloned.Content = make([]*yaml.Node, len(n.Content))
+		for i := range n.Content {
+			cloned.Content[i] = cloneYAMLNode(n.Content[i])
+		}
+	}
+	// Alias nodes are not expected in hub config YAML; keep nil to avoid cycles.
+	cloned.Alias = nil
+	return &cloned
+}
+
+func uniqueProviders(llmKeys types.LLMKeysList) []string {
+	seen := map[string]struct{}{}
+	var providers []string
+	for _, k := range llmKeys {
+		p := strings.TrimSpace(k.Provider)
+		if p == "" {
+			continue
+		}
+		if _, ok := seen[p]; ok {
+			continue
+		}
+		seen[p] = struct{}{}
+		providers = append(providers, p)
+	}
+	sort.Strings(providers)
+	if len(providers) == 0 {
+		return []string{"none"}
+	}
+	return providers
 }
 
 // validateHubConfig checks that the config has required fields.

--- a/pkg/hub/ai_config.go
+++ b/pkg/hub/ai_config.go
@@ -1244,6 +1244,35 @@ func checkMaskedValues(cfg *types.HubConfig) error {
 			return fmt.Errorf("github[%d]: private_key_pem contains unresolved mask value", i)
 		}
 	}
+	if cfg.Integrations != nil {
+		for i, linear := range cfg.Integrations.Linear {
+			if linear == nil {
+				continue
+			}
+			if linear.Token == mask {
+				return fmt.Errorf("integrations.linear[%d] (%s): token contains unresolved mask value", i, linear.Workspace)
+			}
+			if linear.WebhookSecret == mask {
+				return fmt.Errorf("integrations.linear[%d] (%s): webhook_secret contains unresolved mask value", i, linear.Workspace)
+			}
+		}
+		for i, shortcut := range cfg.Integrations.Shortcut {
+			if shortcut == nil {
+				continue
+			}
+			if shortcut.Token == mask {
+				return fmt.Errorf("integrations.shortcut[%d] (%s): token contains unresolved mask value", i, shortcut.Workspace)
+			}
+		}
+	}
+	for i, factory := range cfg.Factories {
+		if factory == nil {
+			continue
+		}
+		if factory.WebhookSecret == mask {
+			return fmt.Errorf("factories[%d] (%s): webhook_secret contains unresolved mask value", i, factory.Name)
+		}
+	}
 	for k, v := range cfg.Secrets {
 		if v == mask {
 			return fmt.Errorf("secrets[%q] contains unresolved mask value", k)

--- a/pkg/hub/ai_config.go
+++ b/pkg/hub/ai_config.go
@@ -761,6 +761,9 @@ func callAnthropic(apiKey, systemPrompt string, msgs []aiChatMessage) (string, e
 	defer resp.Body.Close()
 
 	data, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("Anthropic error %d: %s", resp.StatusCode, string(data))
+	}
 	var ar anthropicResp
 	if err := json.Unmarshal(data, &ar); err != nil {
 		return "", fmt.Errorf("invalid Anthropic response: %w", err)
@@ -819,6 +822,9 @@ func callOpenAI(apiKey, systemPrompt string, msgs []aiChatMessage) (string, erro
 	defer resp.Body.Close()
 
 	data, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("OpenAI error %d: %s", resp.StatusCode, string(data))
+	}
 	var or openAIResp
 	if err := json.Unmarshal(data, &or); err != nil {
 		return "", fmt.Errorf("invalid OpenAI response: %w", err)

--- a/pkg/hub/ai_config.go
+++ b/pkg/hub/ai_config.go
@@ -1211,6 +1211,44 @@ func validateHubConfig(cfg *types.HubConfig) error {
 			return fmt.Errorf("llm_keys[%d] (%s): provider is required", i, k.Name)
 		}
 	}
+	if err := checkMaskedValues(cfg); err != nil {
+		return err
+	}
+	return nil
+}
+
+// checkMaskedValues returns an error if any sensitive field still contains the
+// mask sentinel "***", which indicates restoreMaskedSecretsFromDisk failed to
+// match it to a real disk value (e.g. the LLM hallucinated *** for a new key).
+func checkMaskedValues(cfg *types.HubConfig) error {
+	const mask = "***"
+	if cfg.ClawToken == mask {
+		return fmt.Errorf("claw_token contains unresolved mask value; provide the real value or use a __PLACEHOLDER__")
+	}
+	if cfg.Token == mask {
+		return fmt.Errorf("token contains unresolved mask value")
+	}
+	if cfg.RelaySecret == mask {
+		return fmt.Errorf("relay_secret contains unresolved mask value")
+	}
+	if cfg.UIPassword == mask {
+		return fmt.Errorf("ui_password contains unresolved mask value")
+	}
+	for i, k := range cfg.LLMKeys {
+		if k.APIKey == mask {
+			return fmt.Errorf("llm_keys[%d] (%s): api_key contains unresolved mask value", i, k.Name)
+		}
+	}
+	for i, app := range cfg.GitHubApps {
+		if app.PrivateKeyPEM == mask {
+			return fmt.Errorf("github[%d]: private_key_pem contains unresolved mask value", i)
+		}
+	}
+	for k, v := range cfg.Secrets {
+		if v == mask {
+			return fmt.Errorf("secrets[%q] contains unresolved mask value", k)
+		}
+	}
 	return nil
 }
 

--- a/pkg/hub/ai_config.go
+++ b/pkg/hub/ai_config.go
@@ -903,8 +903,8 @@ func maskYAMLNodeValue(node *yaml.Node) {
 	node.Content = nil
 }
 
-// extractYAMLBlock extracts the content of the first ```yaml ... ``` block.
-var yamlBlockRe = regexp.MustCompile("(?s)```yaml\n(.*?)```")
+// extractYAMLBlock extracts the content of the first ```yaml/yml/YAML ... ``` block (case-insensitive).
+var yamlBlockRe = regexp.MustCompile("(?si)```ya?ml\n(.*?)```")
 
 func extractYAMLBlock(s string) string {
 	m := yamlBlockRe.FindStringSubmatch(s)

--- a/pkg/hub/ai_config.go
+++ b/pkg/hub/ai_config.go
@@ -220,6 +220,10 @@ func (s *Server) handleAIConfigRevert(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "backup file is corrupt: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
+	if err := validateHubConfig(&restoredCfg); err != nil {
+		http.Error(w, "backup validation failed: "+err.Error(), http.StatusBadRequest)
+		return
+	}
 
 	if err := config.SaveHubConfigNoSecretMerge(&restoredCfg); err != nil {
 		http.Error(w, "save failed: "+err.Error(), http.StatusInternalServerError)
@@ -521,20 +525,14 @@ func callLLMForConfigStream(ctx context.Context, sanitizedYAML, message string, 
 		return streamOpenAI(ctx, openaiKey, systemPrompt, msgs, onToken)
 	}
 	if firstKey != nil {
-		switch firstKey.Provider {
-		case "anthropic":
-			return streamAnthropic(ctx, firstKey.APIKey, systemPrompt, msgs, onToken)
-		case "openai":
-			return streamOpenAI(ctx, firstKey.APIKey, systemPrompt, msgs, onToken)
-		default:
-			// Unsupported streaming provider — fall back to blocking call
-			reply, err := callLLMForConfig(sanitizedYAML, message, history, llmKeys, defaultModel)
-			if err != nil {
-				return err
-			}
-			onToken(reply)
-			return nil
+		// firstKey.Provider is neither "anthropic" nor "openai" (those paths already
+		// returned above). Fall back to blocking call for unsupported providers.
+		reply, err := callLLMForConfig(sanitizedYAML, message, history, llmKeys, defaultModel)
+		if err != nil {
+			return err
 		}
+		onToken(reply)
+		return nil
 	}
 	_ = defaultModel
 	return fmt.Errorf("no LLM keys configured")

--- a/pkg/hub/ai_config.go
+++ b/pkg/hub/ai_config.go
@@ -612,10 +612,16 @@ func mergeMaskedSecretsNode(proposed, disk *yaml.Node) {
 		}
 		mergeMaskedSecretsNode(proposed.Content[0], diskRoot)
 	case yaml.SequenceNode:
+		var diskItems []*yaml.Node
+		if disk != nil && disk.Kind == yaml.SequenceNode {
+			diskItems = disk.Content
+		}
+		usedDiskIndexes := map[int]struct{}{}
 		for i := range proposed.Content {
 			var diskChild *yaml.Node
-			if disk != nil && disk.Kind == yaml.SequenceNode && i < len(disk.Content) {
-				diskChild = disk.Content[i]
+			if idx := findMatchingSequenceIndex(proposed.Content[i], diskItems, usedDiskIndexes, i); idx >= 0 {
+				diskChild = diskItems[idx]
+				usedDiskIndexes[idx] = struct{}{}
 			}
 			mergeMaskedSecretsNode(proposed.Content[i], diskChild)
 		}
@@ -645,6 +651,64 @@ func mergeMaskedSecretsNode(proposed, disk *yaml.Node) {
 			mergeMaskedSecretsNode(valNode, diskVal)
 		}
 	}
+}
+
+func findMatchingSequenceIndex(proposedItem *yaml.Node, diskItems []*yaml.Node, used map[int]struct{}, fallback int) int {
+	identity, hasIdentity := sequenceItemIdentity(proposedItem)
+	if hasIdentity {
+		for i, diskItem := range diskItems {
+			if _, isUsed := used[i]; isUsed {
+				continue
+			}
+			if diskIdentity, ok := sequenceItemIdentity(diskItem); ok && diskIdentity == identity {
+				return i
+			}
+		}
+		// If an identified item is new/renamed, avoid index fallback to prevent
+		// restoring another entry's secret into it.
+		return -1
+	}
+
+	if fallback >= 0 && fallback < len(diskItems) {
+		if _, isUsed := used[fallback]; !isUsed {
+			return fallback
+		}
+	}
+
+	return -1
+}
+
+func sequenceItemIdentity(node *yaml.Node) (string, bool) {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return "", false
+	}
+	if name, ok := mappingNodeScalarValue(node, "name"); ok && name != "" {
+		return "name:" + name, true
+	}
+	if appID, ok := mappingNodeScalarValue(node, "app_id"); ok && appID != "" {
+		return "app_id:" + appID, true
+	}
+	if workspace, ok := mappingNodeScalarValue(node, "workspace"); ok && workspace != "" {
+		if integration, ok := mappingNodeScalarValue(node, "integration"); ok && integration != "" {
+			return "workspace:" + workspace + "|integration:" + integration, true
+		}
+		return "workspace:" + workspace, true
+	}
+	return "", false
+}
+
+func mappingNodeScalarValue(node *yaml.Node, key string) (string, bool) {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return "", false
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		keyNode := node.Content[i]
+		valNode := node.Content[i+1]
+		if keyNode.Value == key && valNode.Kind == yaml.ScalarNode {
+			return valNode.Value, true
+		}
+	}
+	return "", false
 }
 
 func mergeMaskedSecretMap(proposedSecrets, diskSecrets *yaml.Node) {

--- a/pkg/hub/ai_config.go
+++ b/pkg/hub/ai_config.go
@@ -280,7 +280,8 @@ func (s *Server) handleAIConfigBackup(w http.ResponseWriter, r *http.Request) {
 
 // ─── Current-config endpoint ────────────────────────────────────────────────
 
-// handleAIConfigCurrentConfig returns the sanitized (secrets masked) hub.yaml as plain text.
+// handleAIConfigCurrentConfig returns the hub.yaml as plain text.
+// By default, secrets are masked. Pass ?reveal=true to get the raw unmasked config.
 func (s *Server) handleAIConfigCurrentConfig(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -291,6 +292,20 @@ func (s *Server) handleAIConfigCurrentConfig(w http.ResponseWriter, r *http.Requ
 		http.Error(w, "failed to load hub config: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
+
+	reveal := r.URL.Query().Get("reveal") == "true"
+	if reveal {
+		// Return raw config with actual secret values
+		raw, err := yaml.Marshal(diskCfg)
+		if err != nil {
+			http.Error(w, "failed to marshal config: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		_, _ = w.Write(raw)
+		return
+	}
+
 	sanitized, err := sanitizeHubConfig(diskCfg)
 	if err != nil {
 		http.Error(w, "failed to sanitize config: "+err.Error(), http.StatusInternalServerError)

--- a/pkg/hub/ai_config.go
+++ b/pkg/hub/ai_config.go
@@ -21,8 +21,8 @@ import (
 // ─── Request / response types ─────────────────────────────────────────────────
 
 type aiConfigRequest struct {
-	Message string           `json:"message"`
-	History []aiChatMessage  `json:"history"`
+	Message string          `json:"message"`
+	History []aiChatMessage `json:"history"`
 }
 
 type aiChatMessage struct {
@@ -178,13 +178,20 @@ func (s *Server) handleAIConfigRevert(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "cannot determine hub config path: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
-	expectedPrefix := hubYAMLPath + ".bak."
-	if !strings.HasPrefix(req.BackupPath, expectedPrefix) {
+	cleanHubYAMLPath := filepath.Clean(hubYAMLPath)
+	cleanBackupPath := filepath.Clean(req.BackupPath)
+	expectedPrefix := cleanHubYAMLPath + ".bak."
+	if !strings.HasPrefix(cleanBackupPath, expectedPrefix) {
+		http.Error(w, "invalid backup path", http.StatusBadRequest)
+		return
+	}
+	suffix := strings.TrimPrefix(cleanBackupPath, expectedPrefix)
+	if !backupTimestampSuffixRe.MatchString(suffix) {
 		http.Error(w, "invalid backup path", http.StatusBadRequest)
 		return
 	}
 
-	data, err := os.ReadFile(req.BackupPath)
+	data, err := os.ReadFile(cleanBackupPath)
 	if err != nil {
 		http.Error(w, "cannot read backup: "+err.Error(), http.StatusInternalServerError)
 		return
@@ -450,51 +457,67 @@ func sanitizeHubConfig(cfg *types.HubConfig) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	s := string(data)
-
-	// Mask top-level token fields
-	s = maskYAMLField(s, "token")
-	s = maskYAMLField(s, "claw_token")
-	s = maskYAMLField(s, "relay_secret")
-	s = maskYAMLField(s, "ui_password")
-
-	// Mask api_key in llm_keys and providers
-	s = maskYAMLField(s, "api_key")
-	s = maskYAMLField(s, "access_token")
-	s = maskYAMLField(s, "private_key_pem")
-	s = maskYAMLField(s, "client_secret")
-	s = maskYAMLField(s, "webhook_secret")
-
-	// Mask secrets map values
-	s = maskSecretsMapValues(s)
-
-	return s, nil
-}
-
-var yamlFieldRe = map[string]*regexp.Regexp{}
-
-func maskYAMLField(s, field string) string {
-	re, ok := yamlFieldRe[field]
-	if !ok {
-		re = regexp.MustCompile(`(?m)^(\s*` + regexp.QuoteMeta(field) + `:\s*)(.+)$`)
-		yamlFieldRe[field] = re
+	var node yaml.Node
+	if err := yaml.Unmarshal(data, &node); err != nil {
+		return "", err
 	}
-	return re.ReplaceAllString(s, `${1}***`)
+	maskSensitiveYAMLValues(&node)
+	sanitized, err := yaml.Marshal(&node)
+	if err != nil {
+		return "", err
+	}
+	return string(sanitized), nil
 }
 
-// maskSecretsMapValues masks values in a YAML map block following "secrets:".
-var secretsBlockRe = regexp.MustCompile(`(?ms)(^secrets:\n)((?:  \S[^\n]*\n)*)`)
-var secretsValueRe = regexp.MustCompile(`(?m)^(\s+\S+:\s*)(.+)$`)
+var backupTimestampSuffixRe = regexp.MustCompile(`^\d+$`)
 
-func maskSecretsMapValues(s string) string {
-	return secretsBlockRe.ReplaceAllStringFunc(s, func(block string) string {
-		match := secretsBlockRe.FindStringSubmatch(block)
-		if len(match) < 3 {
-			return block
+var sensitiveYAMLFields = map[string]struct{}{
+	"token":           {},
+	"claw_token":      {},
+	"relay_secret":    {},
+	"ui_password":     {},
+	"api_key":         {},
+	"access_token":    {},
+	"private_key_pem": {},
+	"client_secret":   {},
+	"webhook_secret":  {},
+}
+
+func maskSensitiveYAMLValues(node *yaml.Node) {
+	switch node.Kind {
+	case yaml.DocumentNode, yaml.SequenceNode:
+		for _, child := range node.Content {
+			maskSensitiveYAMLValues(child)
 		}
-		masked := secretsValueRe.ReplaceAllString(match[2], `${1}***`)
-		return match[1] + masked
-	})
+	case yaml.MappingNode:
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			keyNode := node.Content[i]
+			valNode := node.Content[i+1]
+
+			if _, ok := sensitiveYAMLFields[keyNode.Value]; ok {
+				maskYAMLNodeValue(valNode)
+				continue
+			}
+			if keyNode.Value == "secrets" && valNode.Kind == yaml.MappingNode {
+				for j := 1; j < len(valNode.Content); j += 2 {
+					maskYAMLNodeValue(valNode.Content[j])
+				}
+				continue
+			}
+
+			maskSensitiveYAMLValues(valNode)
+		}
+	}
+}
+
+func maskYAMLNodeValue(node *yaml.Node) {
+	node.Kind = yaml.ScalarNode
+	node.Style = 0
+	node.Tag = "!!str"
+	node.Value = "***"
+	node.Anchor = ""
+	node.Alias = nil
+	node.Content = nil
 }
 
 // extractYAMLBlock extracts the content of the first ```yaml ... ``` block.

--- a/pkg/hub/ai_config.go
+++ b/pkg/hub/ai_config.go
@@ -125,7 +125,11 @@ func (s *Server) handleAIConfigApply(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Substitute placeholders
-	finalYAML := substitutePlaceholders(req.ProposedYAML, req.Secrets)
+	finalYAML, err := substitutePlaceholders(req.ProposedYAML, req.Secrets)
+	if err != nil {
+		http.Error(w, "invalid yaml: "+err.Error(), http.StatusBadRequest)
+		return
+	}
 
 	// Restore masked secrets (*** from sanitized config) from disk before parsing.
 	diskCfg, err := config.LoadHubConfig()
@@ -895,18 +899,44 @@ func extractPlaceholders(s string) []string {
 	return result
 }
 
-// substitutePlaceholders replaces __NAME__ with provided secret values.
-func substitutePlaceholders(yamlStr string, secrets map[string]string) string {
-	return placeholderRe.ReplaceAllStringFunc(yamlStr, func(match string) string {
-		m := placeholderRe.FindStringSubmatch(match)
-		if len(m) < 2 {
+// substitutePlaceholders replaces __NAME__ placeholders with provided values.
+func substitutePlaceholders(yamlStr string, secrets map[string]string) (string, error) {
+	var root yaml.Node
+	if err := yaml.Unmarshal([]byte(yamlStr), &root); err != nil {
+		return "", err
+	}
+
+	substitutePlaceholdersInYAMLNode(&root, secrets)
+
+	out, err := yaml.Marshal(&root)
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+func substitutePlaceholdersInYAMLNode(node *yaml.Node, secrets map[string]string) {
+	if node == nil {
+		return
+	}
+
+	switch node.Kind {
+	case yaml.DocumentNode, yaml.SequenceNode, yaml.MappingNode:
+		for _, child := range node.Content {
+			substitutePlaceholdersInYAMLNode(child, secrets)
+		}
+	case yaml.ScalarNode:
+		node.Value = placeholderRe.ReplaceAllStringFunc(node.Value, func(match string) string {
+			m := placeholderRe.FindStringSubmatch(match)
+			if len(m) < 2 {
+				return match
+			}
+			if val, ok := secrets[m[1]]; ok {
+				return val
+			}
 			return match
-		}
-		if val, ok := secrets[m[1]]; ok {
-			return val
-		}
-		return match
-	})
+		})
+	}
 }
 
 func restoreMaskedSecretsFromDisk(yamlStr string, diskCfg *types.HubConfig) (string, error) {

--- a/pkg/hub/ai_config.go
+++ b/pkg/hub/ai_config.go
@@ -1,7 +1,9 @@
 package hub
 
 import (
+	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -272,6 +274,112 @@ func (s *Server) handleAIConfigBackup(w http.ResponseWriter, r *http.Request) {
 	jsonOK(w, aiConfigBackupResponse{BackupPath: latest, BackupTime: backupTime})
 }
 
+// ─── Current-config endpoint ────────────────────────────────────────────────
+
+// handleAIConfigCurrentConfig returns the sanitized (secrets masked) hub.yaml as plain text.
+func (s *Server) handleAIConfigCurrentConfig(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	diskCfg, err := config.LoadHubConfig()
+	if err != nil {
+		http.Error(w, "failed to load hub config: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	sanitized, err := sanitizeHubConfig(diskCfg)
+	if err != nil {
+		http.Error(w, "failed to sanitize config: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	_, _ = w.Write([]byte(sanitized))
+}
+
+// ─── Streaming SSE endpoint ──────────────────────────────────────────────────
+
+// handleAIConfigStream streams the LLM response as Server-Sent Events.
+// Events:
+//
+//	data: {"type":"token","content":"..."}
+//	data: {"type":"proposed_yaml","yaml":"..."}
+//	data: {"type":"placeholders","items":["SECRET"]}
+//	data: {"type":"done"}
+func (s *Server) handleAIConfigStream(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req aiConfigRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	if req.Message == "" {
+		http.Error(w, "message required", http.StatusBadRequest)
+		return
+	}
+
+	diskCfg, err := config.LoadHubConfig()
+	if err != nil {
+		http.Error(w, "failed to load hub config: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	sanitized, err := sanitizeHubConfig(diskCfg)
+	if err != nil {
+		http.Error(w, "failed to sanitize config: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	s.mu.RLock()
+	llmKeys := s.hubCfg.LLMKeys
+	defaultModel := s.hubCfg.DefaultModel
+	s.mu.RUnlock()
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	sendEvent := func(v interface{}) {
+		b, _ := json.Marshal(v)
+		fmt.Fprintf(w, "data: %s\n\n", b)
+		flusher.Flush()
+	}
+
+	var fullReply strings.Builder
+
+	streamErr := callLLMForConfigStream(
+		r.Context(),
+		sanitized, req.Message, req.History,
+		llmKeys, defaultModel,
+		func(token string) {
+			fullReply.WriteString(token)
+			sendEvent(map[string]string{"type": "token", "content": token})
+		},
+	)
+	if streamErr != nil {
+		sendEvent(map[string]string{"type": "error", "content": streamErr.Error()})
+		return
+	}
+
+	reply := fullReply.String()
+	if yamlBlock := extractYAMLBlock(reply); yamlBlock != "" {
+		sendEvent(map[string]interface{}{"type": "proposed_yaml", "yaml": yamlBlock})
+		if phs := extractPlaceholders(yamlBlock); len(phs) > 0 {
+			sendEvent(map[string]interface{}{"type": "placeholders", "items": phs})
+		}
+	}
+
+	sendEvent(map[string]string{"type": "done"})
+}
+
 // ─── LLM call ────────────────────────────────────────────────────────────────
 
 const aiConfigSystemPromptTemplate = `You are a configuration assistant for ElasticClaw hub. You help users configure their hub.yaml.
@@ -293,6 +401,15 @@ Hub.yaml schema overview:
 - ssh_public_keys: list of SSH public keys allowed for claw access
 - secrets: named secrets map (used by factory webhook_secret_ref)
 - auth: github_oauth config and access control (view/interact tag requirements)
+
+CRITICAL RULES — follow these without exception:
+- NEVER ask the user to paste tokens, API keys, passwords, or any secret values into the chat
+- NEVER tell the user to "share" or "provide" a secret in the chat message
+- If you need a secret value, use __SECRET_NAME__ as a placeholder in the YAML (e.g. __LINEAR_TOKEN__, __SHORTCUT_TOKEN__, __GITHUB_CLIENT_SECRET__)
+- The UI renders a secure password input field for each __PLACEHOLDER__ — the user fills secrets there, not in the chat
+- You may ask for non-secret information (workspace names, org names, URLs, app IDs, usernames)
+- If the user pastes a secret into the chat anyway, acknowledge it briefly and use the value directly in the YAML — do NOT tell them to enter it again in the secret fields
+- If a user message contains what looks like an API key or token (e.g. starts with lin_api_, sk-ant-, sk-, ghp_, or is a long random hex/base64 string of 20+ chars), use it directly as the YAML value instead of a placeholder
 
 When proposing config changes:
 - Return the COMPLETE updated hub.yaml as a YAML code block (` + "```yaml ... ```" + `)
@@ -336,6 +453,228 @@ func callLLMForConfig(sanitizedYAML, message string, history []aiChatMessage, ll
 		return "", fmt.Errorf("no supported LLM key configured for default_model provider %q (supported providers: anthropic, openai; configured: %s)", defaultProvider, strings.Join(availableProviders, ", "))
 	}
 	return "", fmt.Errorf("no supported LLM key configured (supported providers: anthropic, openai; configured: %s)", strings.Join(availableProviders, ", "))
+}
+
+// callLLMForConfigStream selects the best available provider and streams tokens via onToken.
+func callLLMForConfigStream(ctx context.Context, sanitizedYAML, message string, history []aiChatMessage, llmKeys types.LLMKeysList, defaultModel string, onToken func(string)) error {
+	systemPrompt := fmt.Sprintf(aiConfigSystemPromptTemplate, sanitizedYAML)
+
+	var msgs []aiChatMessage
+	msgs = append(msgs, history...)
+	msgs = append(msgs, aiChatMessage{Role: "user", Content: message})
+
+	var anthropicKey, openaiKey string
+	var firstKey *types.LLMKeyConfig
+	for _, k := range llmKeys {
+		if firstKey == nil {
+			firstKey = k
+		}
+		if k.Provider == "anthropic" && anthropicKey == "" {
+			anthropicKey = k.APIKey
+		}
+		if k.Provider == "openai" && openaiKey == "" {
+			openaiKey = k.APIKey
+		}
+	}
+
+	if anthropicKey != "" {
+		return streamAnthropic(ctx, anthropicKey, systemPrompt, msgs, onToken)
+	}
+	if openaiKey != "" {
+		return streamOpenAI(ctx, openaiKey, systemPrompt, msgs, onToken)
+	}
+	if firstKey != nil {
+		switch firstKey.Provider {
+		case "anthropic":
+			return streamAnthropic(ctx, firstKey.APIKey, systemPrompt, msgs, onToken)
+		case "openai":
+			return streamOpenAI(ctx, firstKey.APIKey, systemPrompt, msgs, onToken)
+		default:
+			// Unsupported streaming provider — fall back to blocking call
+			reply, err := callLLMForConfig(sanitizedYAML, message, history, llmKeys, defaultModel)
+			if err != nil {
+				return err
+			}
+			onToken(reply)
+			return nil
+		}
+	}
+	_ = defaultModel
+	return fmt.Errorf("no LLM keys configured")
+}
+
+// streamAnthropic calls Anthropic Messages API with stream:true, forwarding text_delta events.
+func streamAnthropic(ctx context.Context, apiKey, systemPrompt string, msgs []aiChatMessage, onToken func(string)) error {
+	type anthropicMsg struct {
+		Role    string `json:"role"`
+		Content string `json:"content"`
+	}
+	type anthropicReq struct {
+		Model     string         `json:"model"`
+		MaxTokens int            `json:"max_tokens"`
+		System    string         `json:"system"`
+		Messages  []anthropicMsg `json:"messages"`
+		Stream    bool           `json:"stream"`
+	}
+
+	anthropicMsgs := make([]anthropicMsg, len(msgs))
+	for i, m := range msgs {
+		anthropicMsgs[i] = anthropicMsg{Role: m.Role, Content: m.Content}
+	}
+	body, _ := json.Marshal(anthropicReq{
+		Model:     "claude-sonnet-4-6",
+		MaxTokens: 4096,
+		System:    systemPrompt,
+		Messages:  anthropicMsgs,
+		Stream:    true,
+	})
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", "https://api.anthropic.com/v1/messages", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("x-api-key", apiKey)
+	httpReq.Header.Set("anthropic-version", "2023-06-01")
+
+	resp, err := http.DefaultClient.Do(httpReq)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		data, _ := io.ReadAll(resp.Body)
+		var errResp struct {
+			Error struct {
+				Message string `json:"message"`
+			} `json:"error"`
+		}
+		if json.Unmarshal(data, &errResp) == nil && errResp.Error.Message != "" {
+			return fmt.Errorf("Anthropic error: %s", errResp.Error.Message)
+		}
+		return fmt.Errorf("Anthropic error %d: %s", resp.StatusCode, string(data))
+	}
+
+	type deltaEvent struct {
+		Type  string `json:"type"`
+		Delta struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"delta"`
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 1*1024*1024)
+	var currentEvent string
+	for scanner.Scan() {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		line := scanner.Text()
+		switch {
+		case strings.HasPrefix(line, "event:"):
+			currentEvent = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+		case strings.HasPrefix(line, "data:"):
+			if currentEvent != "content_block_delta" {
+				continue
+			}
+			raw := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+			if raw == "" || raw == "[DONE]" {
+				continue
+			}
+			var ev deltaEvent
+			if err := json.Unmarshal([]byte(raw), &ev); err != nil {
+				continue
+			}
+			if ev.Delta.Type == "text_delta" && ev.Delta.Text != "" {
+				onToken(ev.Delta.Text)
+			}
+		}
+	}
+	return scanner.Err()
+}
+
+// streamOpenAI calls OpenAI Chat Completions API with stream:true, forwarding delta.content.
+func streamOpenAI(ctx context.Context, apiKey, systemPrompt string, msgs []aiChatMessage, onToken func(string)) error {
+	type openAIMsg struct {
+		Role    string `json:"role"`
+		Content string `json:"content"`
+	}
+	type openAIReq struct {
+		Model    string      `json:"model"`
+		Messages []openAIMsg `json:"messages"`
+		Stream   bool        `json:"stream"`
+	}
+
+	openAIMsgs := []openAIMsg{{Role: "system", Content: systemPrompt}}
+	for _, m := range msgs {
+		openAIMsgs = append(openAIMsgs, openAIMsg{Role: m.Role, Content: m.Content})
+	}
+	body, _ := json.Marshal(openAIReq{
+		Model:    "gpt-4o",
+		Messages: openAIMsgs,
+		Stream:   true,
+	})
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", "https://api.openai.com/v1/chat/completions", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+apiKey)
+
+	resp, err := http.DefaultClient.Do(httpReq)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		data, _ := io.ReadAll(resp.Body)
+		var errResp struct {
+			Error struct {
+				Message string `json:"message"`
+			} `json:"error"`
+		}
+		if json.Unmarshal(data, &errResp) == nil && errResp.Error.Message != "" {
+			return fmt.Errorf("OpenAI error: %s", errResp.Error.Message)
+		}
+		return fmt.Errorf("OpenAI error %d: %s", resp.StatusCode, string(data))
+	}
+
+	type streamChoice struct {
+		Delta struct {
+			Content string `json:"content"`
+		} `json:"delta"`
+	}
+	type streamChunk struct {
+		Choices []streamChoice `json:"choices"`
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 1*1024*1024)
+	for scanner.Scan() {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		raw := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if raw == "" || raw == "[DONE]" {
+			continue
+		}
+		var chunk streamChunk
+		if err := json.Unmarshal([]byte(raw), &chunk); err != nil {
+			continue
+		}
+		if len(chunk.Choices) > 0 && chunk.Choices[0].Delta.Content != "" {
+			onToken(chunk.Choices[0].Delta.Content)
+		}
+	}
+	return scanner.Err()
 }
 
 func callAnthropic(apiKey, systemPrompt string, msgs []aiChatMessage) (string, error) {

--- a/pkg/hub/ai_config.go
+++ b/pkg/hub/ai_config.go
@@ -1,0 +1,585 @@
+package hub
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/config"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+	"gopkg.in/yaml.v3"
+)
+
+// ─── Request / response types ─────────────────────────────────────────────────
+
+type aiConfigRequest struct {
+	Message string           `json:"message"`
+	History []aiChatMessage  `json:"history"`
+}
+
+type aiChatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type aiConfigResponse struct {
+	Reply        string   `json:"reply"`
+	ProposedYAML string   `json:"proposed_yaml,omitempty"`
+	Placeholders []string `json:"placeholders,omitempty"`
+}
+
+type aiConfigApplyRequest struct {
+	ProposedYAML string            `json:"proposed_yaml"`
+	Secrets      map[string]string `json:"secrets"`
+}
+
+type aiConfigApplyResponse struct {
+	Success    bool   `json:"success"`
+	BackupPath string `json:"backup_path"`
+}
+
+type aiConfigRevertRequest struct {
+	BackupPath string `json:"backup_path"`
+}
+
+type aiConfigBackupResponse struct {
+	BackupPath string `json:"backup_path"`
+	BackupTime string `json:"backup_time,omitempty"`
+}
+
+// ─── Route handlers ───────────────────────────────────────────────────────────
+
+func (s *Server) handleAIConfig(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req aiConfigRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	if req.Message == "" {
+		http.Error(w, "message required", http.StatusBadRequest)
+		return
+	}
+
+	// Load and sanitize current hub config
+	diskCfg, err := config.LoadHubConfig()
+	if err != nil {
+		http.Error(w, "failed to load hub config: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	sanitized, err := sanitizeHubConfig(diskCfg)
+	if err != nil {
+		http.Error(w, "failed to sanitize config: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Select LLM key
+	s.mu.RLock()
+	llmKeys := s.hubCfg.LLMKeys
+	defaultModel := s.hubCfg.DefaultModel
+	s.mu.RUnlock()
+
+	reply, err := callLLMForConfig(sanitized, req.Message, req.History, llmKeys, defaultModel)
+	if err != nil {
+		http.Error(w, "LLM error: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	resp := aiConfigResponse{Reply: reply}
+
+	// Extract YAML block if present
+	if yaml := extractYAMLBlock(reply); yaml != "" {
+		resp.ProposedYAML = yaml
+		resp.Placeholders = extractPlaceholders(yaml)
+	}
+
+	jsonOK(w, resp)
+}
+
+func (s *Server) handleAIConfigApply(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req aiConfigApplyRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	if req.ProposedYAML == "" {
+		http.Error(w, "proposed_yaml required", http.StatusBadRequest)
+		return
+	}
+
+	// Substitute placeholders
+	finalYAML := substitutePlaceholders(req.ProposedYAML, req.Secrets)
+
+	// Parse and validate
+	var newCfg types.HubConfig
+	if err := yaml.Unmarshal([]byte(finalYAML), &newCfg); err != nil {
+		http.Error(w, "invalid yaml: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := validateHubConfig(&newCfg); err != nil {
+		http.Error(w, "validation failed: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Backup current config
+	backupPath, err := backupHubConfig()
+	if err != nil {
+		http.Error(w, "backup failed: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Save new config
+	if err := config.SaveHubConfigNoSecretMerge(&newCfg); err != nil {
+		http.Error(w, "save failed: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Hot-reload
+	s.mu.Lock()
+	s.hubCfg = &newCfg
+	s.mu.Unlock()
+
+	jsonOK(w, aiConfigApplyResponse{Success: true, BackupPath: backupPath})
+}
+
+func (s *Server) handleAIConfigRevert(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req aiConfigRevertRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	if req.BackupPath == "" {
+		http.Error(w, "backup_path required", http.StatusBadRequest)
+		return
+	}
+
+	// Validate path to prevent traversal
+	hubYAMLPath, err := config.ActiveHubConfigPath()
+	if err != nil {
+		http.Error(w, "cannot determine hub config path: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	expectedPrefix := hubYAMLPath + ".bak."
+	if !strings.HasPrefix(req.BackupPath, expectedPrefix) {
+		http.Error(w, "invalid backup path", http.StatusBadRequest)
+		return
+	}
+
+	data, err := os.ReadFile(req.BackupPath)
+	if err != nil {
+		http.Error(w, "cannot read backup: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	var restoredCfg types.HubConfig
+	if err := yaml.Unmarshal(data, &restoredCfg); err != nil {
+		http.Error(w, "backup file is corrupt: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if err := config.SaveHubConfigNoSecretMerge(&restoredCfg); err != nil {
+		http.Error(w, "save failed: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Hot-reload
+	s.mu.Lock()
+	s.hubCfg = &restoredCfg
+	s.mu.Unlock()
+
+	jsonOK(w, map[string]bool{"success": true})
+}
+
+func (s *Server) handleAIConfigBackup(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	hubYAMLPath, err := config.ActiveHubConfigPath()
+	if err != nil {
+		jsonOK(w, aiConfigBackupResponse{})
+		return
+	}
+
+	dir := filepath.Dir(hubYAMLPath)
+	base := filepath.Base(hubYAMLPath)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		jsonOK(w, aiConfigBackupResponse{})
+		return
+	}
+
+	prefix := base + ".bak."
+	var backups []string
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), prefix) {
+			backups = append(backups, filepath.Join(dir, e.Name()))
+		}
+	}
+	if len(backups) == 0 {
+		jsonOK(w, aiConfigBackupResponse{})
+		return
+	}
+
+	sort.Strings(backups)
+	latest := backups[len(backups)-1]
+
+	info, err := os.Stat(latest)
+	var backupTime string
+	if err == nil {
+		backupTime = info.ModTime().UTC().Format(time.RFC3339)
+	}
+
+	jsonOK(w, aiConfigBackupResponse{BackupPath: latest, BackupTime: backupTime})
+}
+
+// ─── LLM call ────────────────────────────────────────────────────────────────
+
+const aiConfigSystemPromptTemplate = `You are a configuration assistant for ElasticClaw hub. You help users configure their hub.yaml.
+
+The current hub.yaml (with secrets masked as ***) is:
+---
+%s
+---
+
+Hub.yaml schema overview:
+- url: public URL of the hub
+- token: web UI password (shared secret)
+- claw_token: token claws use to connect (required)
+- default_model: default LLM model (e.g. "anthropic/claude-sonnet-4-6")
+- providers: daytona, replicated, vercel, local sandbox providers
+- github: list of GitHub App configs (app_id, private_key_pem, url)
+- integrations: linear, shortcut workspace tokens and webhook secrets
+- llm_keys: [{name, provider, api_key, default: bool}]
+- ssh_public_keys: list of SSH public keys allowed for claw access
+- secrets: named secrets map (used by factory webhook_secret_ref)
+- auth: github_oauth config and access control (view/interact tag requirements)
+
+When proposing config changes:
+- Return the COMPLETE updated hub.yaml as a YAML code block (` + "```yaml ... ```" + `)
+- For any secret values the user provides, include them directly
+- For any secret values not yet provided, use __SECRET_NAME__ as placeholder (e.g. __LINEAR_TOKEN__, __GITHUB_CLIENT_SECRET__)
+- Preserve all existing config that the user didn't ask to change
+- Never remove claw_token or url
+- Explain what you changed in plain English before the YAML block`
+
+func callLLMForConfig(sanitizedYAML, message string, history []aiChatMessage, llmKeys types.LLMKeysList, defaultModel string) (string, error) {
+	systemPrompt := fmt.Sprintf(aiConfigSystemPromptTemplate, sanitizedYAML)
+
+	// Build message list
+	var msgs []aiChatMessage
+	msgs = append(msgs, history...)
+	msgs = append(msgs, aiChatMessage{Role: "user", Content: message})
+
+	// Select provider
+	var anthropicKey, openaiKey string
+	for _, k := range llmKeys {
+		if k.Provider == "anthropic" && anthropicKey == "" {
+			anthropicKey = k.APIKey
+		}
+		if k.Provider == "openai" && openaiKey == "" {
+			openaiKey = k.APIKey
+		}
+	}
+
+	if anthropicKey != "" {
+		return callAnthropic(anthropicKey, systemPrompt, msgs)
+	}
+	if openaiKey != "" {
+		return callOpenAI(openaiKey, systemPrompt, msgs)
+	}
+	if len(llmKeys) > 0 {
+		// Use first available key with whatever provider
+		k := llmKeys[0]
+		switch k.Provider {
+		case "anthropic":
+			return callAnthropic(k.APIKey, systemPrompt, msgs)
+		case "openai":
+			return callOpenAI(k.APIKey, systemPrompt, msgs)
+		}
+	}
+	_ = defaultModel
+	return "", fmt.Errorf("No LLM keys configured")
+}
+
+func callAnthropic(apiKey, systemPrompt string, msgs []aiChatMessage) (string, error) {
+	type anthropicMsg struct {
+		Role    string `json:"role"`
+		Content string `json:"content"`
+	}
+	type anthropicReq struct {
+		Model     string         `json:"model"`
+		MaxTokens int            `json:"max_tokens"`
+		System    string         `json:"system"`
+		Messages  []anthropicMsg `json:"messages"`
+	}
+	type anthropicContent struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	type anthropicResp struct {
+		Content []anthropicContent `json:"content"`
+		Error   *struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+
+	anthropicMsgs := make([]anthropicMsg, len(msgs))
+	for i, m := range msgs {
+		anthropicMsgs[i] = anthropicMsg{Role: m.Role, Content: m.Content}
+	}
+
+	body, _ := json.Marshal(anthropicReq{
+		Model:     "claude-sonnet-4-6",
+		MaxTokens: 4096,
+		System:    systemPrompt,
+		Messages:  anthropicMsgs,
+	})
+
+	req, err := http.NewRequest("POST", "https://api.anthropic.com/v1/messages", bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", apiKey)
+	req.Header.Set("anthropic-version", "2023-06-01")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	data, _ := io.ReadAll(resp.Body)
+	var ar anthropicResp
+	if err := json.Unmarshal(data, &ar); err != nil {
+		return "", fmt.Errorf("invalid Anthropic response: %w", err)
+	}
+	if ar.Error != nil {
+		return "", fmt.Errorf("Anthropic error: %s", ar.Error.Message)
+	}
+	for _, c := range ar.Content {
+		if c.Type == "text" {
+			return c.Text, nil
+		}
+	}
+	return "", fmt.Errorf("no text content in Anthropic response")
+}
+
+func callOpenAI(apiKey, systemPrompt string, msgs []aiChatMessage) (string, error) {
+	type openAIMsg struct {
+		Role    string `json:"role"`
+		Content string `json:"content"`
+	}
+	type openAIReq struct {
+		Model    string      `json:"model"`
+		Messages []openAIMsg `json:"messages"`
+	}
+	type openAIChoice struct {
+		Message openAIMsg `json:"message"`
+	}
+	type openAIResp struct {
+		Choices []openAIChoice `json:"choices"`
+		Error   *struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+
+	openAIMsgs := []openAIMsg{{Role: "system", Content: systemPrompt}}
+	for _, m := range msgs {
+		openAIMsgs = append(openAIMsgs, openAIMsg{Role: m.Role, Content: m.Content})
+	}
+
+	body, _ := json.Marshal(openAIReq{
+		Model:    "gpt-4o",
+		Messages: openAIMsgs,
+	})
+
+	req, err := http.NewRequest("POST", "https://api.openai.com/v1/chat/completions", bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	data, _ := io.ReadAll(resp.Body)
+	var or openAIResp
+	if err := json.Unmarshal(data, &or); err != nil {
+		return "", fmt.Errorf("invalid OpenAI response: %w", err)
+	}
+	if or.Error != nil {
+		return "", fmt.Errorf("OpenAI error: %s", or.Error.Message)
+	}
+	if len(or.Choices) == 0 {
+		return "", fmt.Errorf("no choices in OpenAI response")
+	}
+	return or.Choices[0].Message.Content, nil
+}
+
+// ─── Config helpers ───────────────────────────────────────────────────────────
+
+// sanitizeHubConfig marshals to YAML and masks known secret fields.
+func sanitizeHubConfig(cfg *types.HubConfig) (string, error) {
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return "", err
+	}
+	s := string(data)
+
+	// Mask top-level token fields
+	s = maskYAMLField(s, "token")
+	s = maskYAMLField(s, "claw_token")
+	s = maskYAMLField(s, "relay_secret")
+	s = maskYAMLField(s, "ui_password")
+
+	// Mask api_key in llm_keys and providers
+	s = maskYAMLField(s, "api_key")
+	s = maskYAMLField(s, "access_token")
+	s = maskYAMLField(s, "private_key_pem")
+	s = maskYAMLField(s, "client_secret")
+	s = maskYAMLField(s, "webhook_secret")
+
+	// Mask secrets map values
+	s = maskSecretsMapValues(s)
+
+	return s, nil
+}
+
+var yamlFieldRe = map[string]*regexp.Regexp{}
+
+func maskYAMLField(s, field string) string {
+	re, ok := yamlFieldRe[field]
+	if !ok {
+		re = regexp.MustCompile(`(?m)^(\s*` + regexp.QuoteMeta(field) + `:\s*)(.+)$`)
+		yamlFieldRe[field] = re
+	}
+	return re.ReplaceAllString(s, `${1}***`)
+}
+
+// maskSecretsMapValues masks values in a YAML map block following "secrets:".
+var secretsBlockRe = regexp.MustCompile(`(?ms)(^secrets:\n)((?:  \S[^\n]*\n)*)`)
+var secretsValueRe = regexp.MustCompile(`(?m)^(\s+\S+:\s*)(.+)$`)
+
+func maskSecretsMapValues(s string) string {
+	return secretsBlockRe.ReplaceAllStringFunc(s, func(block string) string {
+		match := secretsBlockRe.FindStringSubmatch(block)
+		if len(match) < 3 {
+			return block
+		}
+		masked := secretsValueRe.ReplaceAllString(match[2], `${1}***`)
+		return match[1] + masked
+	})
+}
+
+// extractYAMLBlock extracts the content of the first ```yaml ... ``` block.
+var yamlBlockRe = regexp.MustCompile("(?s)```yaml\n(.*?)```")
+
+func extractYAMLBlock(s string) string {
+	m := yamlBlockRe.FindStringSubmatch(s)
+	if len(m) < 2 {
+		return ""
+	}
+	return strings.TrimSpace(m[1])
+}
+
+// extractPlaceholders finds all __PLACEHOLDER__ patterns in the YAML.
+var placeholderRe = regexp.MustCompile(`__([A-Z0-9_]+)__`)
+
+func extractPlaceholders(s string) []string {
+	matches := placeholderRe.FindAllStringSubmatch(s, -1)
+	seen := map[string]bool{}
+	var result []string
+	for _, m := range matches {
+		if !seen[m[1]] {
+			seen[m[1]] = true
+			result = append(result, m[1])
+		}
+	}
+	return result
+}
+
+// substitutePlaceholders replaces __NAME__ with provided secret values.
+func substitutePlaceholders(yamlStr string, secrets map[string]string) string {
+	return placeholderRe.ReplaceAllStringFunc(yamlStr, func(match string) string {
+		m := placeholderRe.FindStringSubmatch(match)
+		if len(m) < 2 {
+			return match
+		}
+		if val, ok := secrets[m[1]]; ok {
+			return val
+		}
+		return match
+	})
+}
+
+// validateHubConfig checks that the config has required fields.
+func validateHubConfig(cfg *types.HubConfig) error {
+	// Marshal/unmarshal roundtrip
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("marshal failed: %w", err)
+	}
+	var roundtrip types.HubConfig
+	if err := yaml.Unmarshal(data, &roundtrip); err != nil {
+		return fmt.Errorf("unmarshal roundtrip failed: %w", err)
+	}
+
+	if cfg.ClawToken == "" {
+		return fmt.Errorf("claw_token is required")
+	}
+	if cfg.URL == "" {
+		return fmt.Errorf("url is required")
+	}
+	for i, k := range cfg.LLMKeys {
+		if k.Name == "" {
+			return fmt.Errorf("llm_keys[%d]: name is required", i)
+		}
+		if k.Provider == "" {
+			return fmt.Errorf("llm_keys[%d] (%s): provider is required", i, k.Name)
+		}
+	}
+	return nil
+}
+
+// backupHubConfig copies hub.yaml to hub.yaml.bak.{timestamp} and returns the backup path.
+func backupHubConfig() (string, error) {
+	src, err := config.ActiveHubConfigPath()
+	if err != nil {
+		return "", err
+	}
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return "", fmt.Errorf("read hub config: %w", err)
+	}
+	dst := fmt.Sprintf("%s.bak.%d", src, time.Now().Unix())
+	if err := os.WriteFile(dst, data, 0600); err != nil {
+		return "", fmt.Errorf("write backup: %w", err)
+	}
+	return dst, nil
+}

--- a/pkg/hub/ai_config.go
+++ b/pkg/hub/ai_config.go
@@ -401,6 +401,21 @@ func (s *Server) handleAIConfigStream(w http.ResponseWriter, r *http.Request) {
 
 // ─── LLM call ────────────────────────────────────────────────────────────────
 
+func sanitizeAIChatHistory(history []aiChatMessage) []aiChatMessage {
+	msgs := make([]aiChatMessage, 0, len(history))
+	for _, m := range history {
+		role := strings.ToLower(strings.TrimSpace(m.Role))
+		if role != "user" && role != "assistant" {
+			continue
+		}
+		msgs = append(msgs, aiChatMessage{
+			Role:    role,
+			Content: m.Content,
+		})
+	}
+	return msgs
+}
+
 const aiConfigSystemPromptTemplate = `You are a configuration assistant for ElasticClaw hub. You help users configure their hub.yaml.
 
 The current hub.yaml (with secrets masked as ***) is:
@@ -446,7 +461,7 @@ func callLLMForConfig(sanitizedYAML, message string, history []aiChatMessage, ll
 
 	// Build message list
 	var msgs []aiChatMessage
-	msgs = append(msgs, history...)
+	msgs = append(msgs, sanitizeAIChatHistory(history)...)
 	msgs = append(msgs, aiChatMessage{Role: "user", Content: message})
 
 	// Select provider
@@ -482,7 +497,7 @@ func callLLMForConfigStream(ctx context.Context, sanitizedYAML, message string, 
 	systemPrompt := fmt.Sprintf(aiConfigSystemPromptTemplate, sanitizedYAML)
 
 	var msgs []aiChatMessage
-	msgs = append(msgs, history...)
+	msgs = append(msgs, sanitizeAIChatHistory(history)...)
 	msgs = append(msgs, aiChatMessage{Role: "user", Content: message})
 
 	var anthropicKey, openaiKey string

--- a/pkg/hub/ai_config.go
+++ b/pkg/hub/ai_config.go
@@ -421,6 +421,9 @@ Hub.yaml schema overview:
 - secrets: named secrets map (used by factory webhook_secret_ref)
 - auth: github_oauth config and access control (view/interact tag requirements)
 
+UI CONTEXT:
+The user is looking at a two-panel interface. The chat (where you are) is on the left. The current hub.yaml config is displayed live on the right panel — always visible next to this chat. If the user asks to "show" or "display" or "see" the config, just tell them to look at the right panel. Do not repeat or summarize the config in the chat unless asked a specific question about it.
+
 CRITICAL RULES — follow these without exception:
 - NEVER ask the user to paste tokens, API keys, passwords, or any secret values into the chat
 - NEVER tell the user to "share" or "provide" a secret in the chat message

--- a/pkg/hub/ai_config.go
+++ b/pkg/hub/ai_config.go
@@ -1200,6 +1200,9 @@ func validateHubConfig(cfg *types.HubConfig) error {
 	if cfg.URL == "" {
 		return fmt.Errorf("url is required")
 	}
+	if cfg.Token == "" {
+		return fmt.Errorf("token is required")
+	}
 	for i, k := range cfg.LLMKeys {
 		if k.Name == "" {
 			return fmt.Errorf("llm_keys[%d]: name is required", i)

--- a/pkg/hub/ai_config_history_test.go
+++ b/pkg/hub/ai_config_history_test.go
@@ -1,0 +1,23 @@
+package hub
+
+import "testing"
+
+func TestSanitizeAIChatHistory_AllowsOnlyUserAndAssistantRoles(t *testing.T) {
+	history := []aiChatMessage{
+		{Role: " user ", Content: "first"},
+		{Role: "SYSTEM", Content: "malicious"},
+		{Role: "assistant", Content: "second"},
+		{Role: "tool", Content: "ignored"},
+	}
+
+	got := sanitizeAIChatHistory(history)
+	if len(got) != 2 {
+		t.Fatalf("len(sanitizeAIChatHistory()) = %d, want %d", len(got), 2)
+	}
+	if got[0].Role != "user" || got[0].Content != "first" {
+		t.Fatalf("first message = %+v, want role=user content=first", got[0])
+	}
+	if got[1].Role != "assistant" || got[1].Content != "second" {
+		t.Fatalf("second message = %+v, want role=assistant content=second", got[1])
+	}
+}

--- a/pkg/hub/ai_config_secret_restore_test.go
+++ b/pkg/hub/ai_config_secret_restore_test.go
@@ -1,6 +1,7 @@
 package hub
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/elasticclaw/elasticclaw/pkg/types"
@@ -164,5 +165,68 @@ func TestValidateHubConfig_RequiresToken(t *testing.T) {
 	}
 	if err.Error() != "token is required" {
 		t.Fatalf("validateHubConfig() error = %q, want %q", err.Error(), "token is required")
+	}
+}
+
+func TestCheckMaskedValues_RejectsMaskedIntegrationAndFactorySecrets(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     *types.HubConfig
+		wantErr string
+	}{
+		{
+			name: "linear token",
+			cfg: &types.HubConfig{
+				Integrations: &types.IntegrationsConfig{
+					Linear: []*types.LinearIntegrationConfig{
+						{Workspace: "acme", Token: "***"},
+					},
+				},
+			},
+			wantErr: "integrations.linear[0] (acme): token contains unresolved mask value",
+		},
+		{
+			name: "linear webhook secret",
+			cfg: &types.HubConfig{
+				Integrations: &types.IntegrationsConfig{
+					Linear: []*types.LinearIntegrationConfig{
+						{Workspace: "acme", WebhookSecret: "***"},
+					},
+				},
+			},
+			wantErr: "integrations.linear[0] (acme): webhook_secret contains unresolved mask value",
+		},
+		{
+			name: "shortcut token",
+			cfg: &types.HubConfig{
+				Integrations: &types.IntegrationsConfig{
+					Shortcut: []*types.ShortcutIntegrationConfig{
+						{Workspace: "ops", Token: "***"},
+					},
+				},
+			},
+			wantErr: "integrations.shortcut[0] (ops): token contains unresolved mask value",
+		},
+		{
+			name: "factory webhook secret",
+			cfg: &types.HubConfig{
+				Factories: []*types.FactoryConfig{
+					{Name: "factory-a", WebhookSecret: "***"},
+				},
+			},
+			wantErr: "factories[0] (factory-a): webhook_secret contains unresolved mask value",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := checkMaskedValues(tt.cfg)
+			if err == nil {
+				t.Fatalf("checkMaskedValues() error = nil, want %q", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("checkMaskedValues() error = %q, want to contain %q", err.Error(), tt.wantErr)
+			}
+		})
 	}
 }

--- a/pkg/hub/ai_config_secret_restore_test.go
+++ b/pkg/hub/ai_config_secret_restore_test.go
@@ -104,3 +104,50 @@ github:
 		t.Fatalf("app_id 202 private_key_pem = %q, want %q", gotByAppID[202], "private-key-202")
 	}
 }
+
+func TestSubstitutePlaceholders_PreservesYAMLMetacharactersInSecrets(t *testing.T) {
+	proposed := `
+token: __HUB_TOKEN__
+`
+	secrets := map[string]string{
+		"HUB_TOKEN": "sk-abc123 #note",
+	}
+
+	substituted, err := substitutePlaceholders(proposed, secrets)
+	if err != nil {
+		t.Fatalf("substitutePlaceholders() error = %v", err)
+	}
+
+	var restored types.HubConfig
+	if err := yaml.Unmarshal([]byte(substituted), &restored); err != nil {
+		t.Fatalf("yaml.Unmarshal() error = %v", err)
+	}
+
+	if restored.Token != "sk-abc123 #note" {
+		t.Fatalf("token = %q, want %q", restored.Token, "sk-abc123 #note")
+	}
+}
+
+func TestSubstitutePlaceholders_PreservesNewlinesInSecrets(t *testing.T) {
+	proposed := `
+secrets:
+  webhook_secret: __WEBHOOK_SECRET__
+`
+	secrets := map[string]string{
+		"WEBHOOK_SECRET": "line1\nline2: value #tag",
+	}
+
+	substituted, err := substitutePlaceholders(proposed, secrets)
+	if err != nil {
+		t.Fatalf("substitutePlaceholders() error = %v", err)
+	}
+
+	var restored types.HubConfig
+	if err := yaml.Unmarshal([]byte(substituted), &restored); err != nil {
+		t.Fatalf("yaml.Unmarshal() error = %v", err)
+	}
+
+	if restored.Secrets["webhook_secret"] != "line1\nline2: value #tag" {
+		t.Fatalf("webhook_secret = %q, want %q", restored.Secrets["webhook_secret"], "line1\nline2: value #tag")
+	}
+}

--- a/pkg/hub/ai_config_secret_restore_test.go
+++ b/pkg/hub/ai_config_secret_restore_test.go
@@ -1,0 +1,106 @@
+package hub
+
+import (
+	"testing"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+	"gopkg.in/yaml.v3"
+)
+
+func TestRestoreMaskedSecretsFromDisk_LLMKeysReorderedByName(t *testing.T) {
+	diskCfg := &types.HubConfig{
+		LLMKeys: types.LLMKeysList{
+			{
+				Name:     "anthropic-prod",
+				Provider: "anthropic",
+				APIKey:   "anthropic-secret",
+			},
+			{
+				Name:     "openai-prod",
+				Provider: "openai",
+				APIKey:   "openai-secret",
+			},
+		},
+	}
+
+	proposed := `
+llm_keys:
+  - name: openai-prod
+    provider: openai
+    api_key: "***"
+  - name: anthropic-prod
+    provider: anthropic
+    api_key: "***"
+`
+
+	restoredYAML, err := restoreMaskedSecretsFromDisk(proposed, diskCfg)
+	if err != nil {
+		t.Fatalf("restoreMaskedSecretsFromDisk() error = %v", err)
+	}
+
+	var restored types.HubConfig
+	if err := yaml.Unmarshal([]byte(restoredYAML), &restored); err != nil {
+		t.Fatalf("yaml.Unmarshal() error = %v", err)
+	}
+
+	gotByName := map[string]string{}
+	for _, key := range restored.LLMKeys {
+		gotByName[key.Name] = key.APIKey
+	}
+
+	if gotByName["openai-prod"] != "openai-secret" {
+		t.Fatalf("openai-prod api_key = %q, want %q", gotByName["openai-prod"], "openai-secret")
+	}
+	if gotByName["anthropic-prod"] != "anthropic-secret" {
+		t.Fatalf("anthropic-prod api_key = %q, want %q", gotByName["anthropic-prod"], "anthropic-secret")
+	}
+}
+
+func TestRestoreMaskedSecretsFromDisk_GitHubAppsReorderedByAppID(t *testing.T) {
+	diskCfg := &types.HubConfig{
+		GitHubApps: []*types.GitHubAppConfig{
+			{
+				AppID:         101,
+				URL:           "https://github.com/apps/a",
+				PrivateKeyPEM: "private-key-101",
+			},
+			{
+				AppID:         202,
+				URL:           "https://github.com/apps/b",
+				PrivateKeyPEM: "private-key-202",
+			},
+		},
+	}
+
+	proposed := `
+github:
+  - app_id: 202
+    url: https://github.com/apps/b
+    private_key_pem: "***"
+  - app_id: 101
+    url: https://github.com/apps/a
+    private_key_pem: "***"
+`
+
+	restoredYAML, err := restoreMaskedSecretsFromDisk(proposed, diskCfg)
+	if err != nil {
+		t.Fatalf("restoreMaskedSecretsFromDisk() error = %v", err)
+	}
+
+	var restored types.HubConfig
+	if err := yaml.Unmarshal([]byte(restoredYAML), &restored); err != nil {
+		t.Fatalf("yaml.Unmarshal() error = %v", err)
+	}
+
+	gotByAppID := map[int64]string{}
+	for _, app := range restored.GitHubApps {
+		gotByAppID[app.AppID] = app.PrivateKeyPEM
+	}
+
+	if gotByAppID[101] != "private-key-101" {
+		t.Fatalf("app_id 101 private_key_pem = %q, want %q", gotByAppID[101], "private-key-101")
+	}
+	if gotByAppID[202] != "private-key-202" {
+		t.Fatalf("app_id 202 private_key_pem = %q, want %q", gotByAppID[202], "private-key-202")
+	}
+}

--- a/pkg/hub/ai_config_secret_restore_test.go
+++ b/pkg/hub/ai_config_secret_restore_test.go
@@ -151,3 +151,18 @@ secrets:
 		t.Fatalf("webhook_secret = %q, want %q", restored.Secrets["webhook_secret"], "line1\nline2: value #tag")
 	}
 }
+
+func TestValidateHubConfig_RequiresToken(t *testing.T) {
+	cfg := &types.HubConfig{
+		URL:       "https://hub.example.com",
+		ClawToken: "claw-token",
+	}
+
+	err := validateHubConfig(cfg)
+	if err == nil {
+		t.Fatal("validateHubConfig() error = nil, want token validation error")
+	}
+	if err.Error() != "token is required" {
+		t.Fatalf("validateHubConfig() error = %q, want %q", err.Error(), "token is required")
+	}
+}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -197,6 +197,12 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/files/view/", s.withAuth(s.handleFileView))
 	mux.HandleFunc("/api/claws/", s.withAuth(s.handleClawSubresource)) // /api/claws/:id/prs, /api/claws/:id/settings
 
+	// AI Config
+	mux.HandleFunc("/api/settings/ai-config", s.withWebAuth(s.handleAIConfig))
+	mux.HandleFunc("/api/settings/ai-config/apply", s.withWebAuth(s.handleAIConfigApply))
+	mux.HandleFunc("/api/settings/ai-config/revert", s.withWebAuth(s.handleAIConfigRevert))
+	mux.HandleFunc("/api/settings/ai-config/backup", s.withWebAuth(s.handleAIConfigBackup))
+
 	// Health
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -198,10 +198,14 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/claws/", s.withAuth(s.handleClawSubresource)) // /api/claws/:id/prs, /api/claws/:id/settings
 
 	// AI Config
-	mux.HandleFunc("/api/settings/ai-config", s.withWebAuth(s.handleAIConfig))
+	// AI Config — register sub-paths before the bare path so Go's exact-match
+	// ServeMux routes them correctly (avoids 404 on specific sub-paths).
 	mux.HandleFunc("/api/settings/ai-config/apply", s.withWebAuth(s.handleAIConfigApply))
 	mux.HandleFunc("/api/settings/ai-config/revert", s.withWebAuth(s.handleAIConfigRevert))
 	mux.HandleFunc("/api/settings/ai-config/backup", s.withWebAuth(s.handleAIConfigBackup))
+	mux.HandleFunc("/api/settings/ai-config/stream", s.withWebAuth(s.handleAIConfigStream))
+	mux.HandleFunc("/api/settings/ai-config/current-config", s.withWebAuth(s.handleAIConfigCurrentConfig))
+	mux.HandleFunc("/api/settings/ai-config", s.withWebAuth(s.handleAIConfig))
 
 	// Health
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -1328,7 +1328,7 @@ function AIConfigSection() {
           if (parsed.type === "token") {
             const tokenText = parsed.content as string
             // Detect start of yaml block — redirect subsequent tokens to YAML panel
-            const fullSoFar = assistantContentRef.current + tokenText
+            const fullSoFar = assistantContentRef.current + typewriterQueueRef.current.join("") + tokenText
             if (!inYamlBlock && /```ya?ml/i.test(fullSoFar)) {
               inYamlBlock = true
               yamlFenceConsumed = false
@@ -1361,7 +1361,6 @@ function AIConfigSection() {
               const chars = tokenText.split("")
               typewriterQueueRef.current.push(...chars)
               startTypewriter()
-              assistantContentRef.current += tokenText
             }
             continue
           } else if (parsed.type === "proposed_yaml") {

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -1030,13 +1030,24 @@ function normalizeStoredMessage(message: ChatMessage): ChatMessage {
 }
 
 // Simple markdown renderer for assistant messages (no external deps)
-// Strip ```yaml ... ``` blocks from text (they go to the right panel, not chat)
+// Strip ```yaml ... ``` blocks and any open/incomplete yaml code block at the end.
+// Applied during streaming so YAML never appears in chat.
 function stripYamlBlocks(text: string): string {
-  return text.replace(/```ya?ml[\s\S]*?```/gi, "").replace(/```[\s\S]*?```/g, (m) => {
-    // Only strip if the block looks like a full hub.yaml (has 'url:' and 'claw_token:')
+  // Remove complete yaml blocks
+  let result = text.replace(/```ya?ml[\s\S]*?```/gi, "")
+  // Remove any block that looks like a hub.yaml (complete)
+  result = result.replace(/```[\s\S]*?```/g, (m) => {
     if (m.includes("claw_token:") || m.includes("url: http")) return ""
     return m
-  }).trim()
+  })
+  // Remove incomplete/open yaml block at the end (streaming: block started but not closed)
+  result = result.replace(/```ya?ml[\s\S]*$/i, "")
+  // Also remove any open ``` block at the end if it looks like hub.yaml
+  result = result.replace(/```[\s\S]*$/g, (m) => {
+    if (m.includes("claw_token:") || m.includes("url:") || m.includes("token:")) return ""
+    return m
+  })
+  return result.trim()
 }
 
 function renderMarkdown(text: string): React.ReactNode[] {

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -1267,7 +1267,7 @@ function AIConfigSection() {
       const msgs = [...prev]
       const last = msgs[msgs.length - 1]
       if (last?.role === "assistant" && last.streaming) {
-        if (dropIfEmpty && visibleFinalContent === "" && finalContent.trim() === "") return msgs.slice(0, -1)
+        if (dropIfEmpty && visibleFinalContent.trim() === "") return msgs.slice(0, -1)
         msgs[msgs.length - 1] = { role: "assistant", content: finalContent, streaming: false }
       }
       return msgs

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -1373,14 +1373,14 @@ function AIConfigSection() {
             setError(parsed.content as string)
             finalizeTypewriter(true)
           } else if (parsed.type === "done") {
-            finalizeTypewriter()
+            // finalizeTypewriter() called in finally
           }
         }
       }
     } catch (e) {
-      finalizeTypewriter(true)
       setError(e instanceof Error ? e.message : "Request failed")
     } finally {
+      finalizeTypewriter(true)
       setLoading(false)
       setTimeout(() => chatInputRef.current?.focus(), 0)
     }

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -1030,6 +1030,15 @@ function normalizeStoredMessage(message: ChatMessage): ChatMessage {
 }
 
 // Simple markdown renderer for assistant messages (no external deps)
+// Strip ```yaml ... ``` blocks from text (they go to the right panel, not chat)
+function stripYamlBlocks(text: string): string {
+  return text.replace(/```ya?ml[\s\S]*?```/gi, "").replace(/```[\s\S]*?```/g, (m) => {
+    // Only strip if the block looks like a full hub.yaml (has 'url:' and 'claw_token:')
+    if (m.includes("claw_token:") || m.includes("url: http")) return ""
+    return m
+  }).trim()
+}
+
 function renderMarkdown(text: string): React.ReactNode[] {
   // Split off fenced code blocks first
   const parts = text.split(/(```[\s\S]*?```)/g)
@@ -1208,7 +1217,7 @@ function AIConfigSection() {
       // Drain up to a few chars per tick for smooth ~60fps feel
       const chars = queue.splice(0, 3).join("")
       assistantContentRef.current += chars
-      const current = assistantContentRef.current
+      const current = stripYamlBlocks(assistantContentRef.current)
       setMessages(prev => {
         const msgs = [...prev]
         const last = msgs[msgs.length - 1]
@@ -1236,7 +1245,7 @@ function AIConfigSection() {
     const remaining = typewriterQueueRef.current.join("")
     typewriterQueueRef.current = []
     assistantContentRef.current += remaining
-    const finalContent = assistantContentRef.current
+    const finalContent = stripYamlBlocks(assistantContentRef.current)
     setMessages(prev => {
       const msgs = [...prev]
       const last = msgs[msgs.length - 1]

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -3,15 +3,15 @@
 import { useParams, useRouter } from "next/navigation"
 import { useEffect, useState, useCallback } from "react"
 import { getHubUrl } from "@/lib/hub-url"
-import { Cpu, Key, Github, ChevronLeft, Shield, Zap, Factory, Copy, Check, LayoutTemplate, Trash2, Lock } from "lucide-react"
+import { Cpu, Key, Github, ChevronLeft, Shield, Zap, Factory, Copy, Check, LayoutTemplate, Trash2, Lock, Sparkles, Send, RotateCcw } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { cn } from "@/lib/utils"
 import Link from "next/link"
 
-type Section = "runtimes" | "llm" | "github" | "security" | "integrations" | "factories" | "secrets" | "templates"
+type Section = "runtimes" | "llm" | "github" | "security" | "integrations" | "factories" | "secrets" | "templates" | "ai-config"
 
-const VALID_SECTIONS: Section[] = ["runtimes", "llm", "github", "security", "integrations", "factories", "secrets", "templates"]
+const VALID_SECTIONS: Section[] = ["runtimes", "llm", "github", "security", "integrations", "factories", "secrets", "templates", "ai-config"]
 
 function isValidSection(s: string): s is Section {
   return VALID_SECTIONS.includes(s as Section)
@@ -148,6 +148,7 @@ export default function SettingsSectionPage() {
     { id: "factories", label: "Factories", icon: Factory },
     { id: "secrets", label: "Secrets", icon: Lock },
     { id: "templates", label: "Templates", icon: LayoutTemplate },
+    { id: "ai-config", label: "Configure with AI", icon: Sparkles },
   ]
 
   return (
@@ -216,6 +217,9 @@ export default function SettingsSectionPage() {
           )}
           {section === "templates" && (
             <TemplatesSection />
+          )}
+          {section === "ai-config" && (
+            <AIConfigSection />
           )}
         </main>
       </div>
@@ -1004,6 +1008,253 @@ function SecretsSection({ settings }: { settings: SettingsData | null }) {
           </Button>
         </div>
         {error && <p className="text-xs text-destructive">{error}</p>}
+      </div>
+    </div>
+  )
+}
+
+// ─── AI Config Section ───────────────────────────────────────────────────────
+
+interface ChatMessage {
+  role: "user" | "assistant"
+  content: string
+}
+
+function AIConfigSection() {
+  const [messages, setMessages] = useState<ChatMessage[]>([])
+  const [input, setInput] = useState("")
+  const [loading, setLoading] = useState(false)
+  const [proposedYaml, setProposedYaml] = useState<string | null>(null)
+  const [placeholders, setPlaceholders] = useState<string[]>([])
+  const [secretValues, setSecretValues] = useState<Record<string, string>>({})
+  const [backupPath, setBackupPath] = useState<string | null>(null)
+  const [applying, setApplying] = useState(false)
+  const [reverting, setReverting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [applySuccess, setApplySuccess] = useState(false)
+
+  const hubUrl = getHubUrl()
+  const token = () => sessionStorage.getItem("ec_hub_token") || ""
+
+  // Check for existing backup on mount
+  useEffect(() => {
+    fetch(`${hubUrl}/api/settings/ai-config/backup`, {
+      headers: { Authorization: `Bearer ${token()}` },
+    })
+      .then(r => r.json())
+      .then(d => { if (d.backup_path) setBackupPath(d.backup_path) })
+      .catch(() => {})
+  }, [])
+
+  const sendMessage = async () => {
+    if (!input.trim() || loading) return
+    const userMsg: ChatMessage = { role: "user", content: input.trim() }
+    const newMessages = [...messages, userMsg]
+    setMessages(newMessages)
+    setInput("")
+    setLoading(true)
+    setError(null)
+
+    try {
+      const res = await fetch(`${hubUrl}/api/settings/ai-config`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token()}`, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          message: userMsg.content,
+          history: messages,
+        }),
+      })
+      if (!res.ok) throw new Error(await res.text())
+      const data = await res.json()
+      setMessages(prev => [...prev, { role: "assistant", content: data.reply }])
+      if (data.proposed_yaml) {
+        setProposedYaml(data.proposed_yaml)
+        setPlaceholders(data.placeholders || [])
+        setSecretValues({})
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Request failed")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const applyConfig = async () => {
+    if (!proposedYaml) return
+    setApplying(true)
+    setError(null)
+    try {
+      const res = await fetch(`${hubUrl}/api/settings/ai-config/apply`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token()}`, "Content-Type": "application/json" },
+        body: JSON.stringify({ proposed_yaml: proposedYaml, secrets: secretValues }),
+      })
+      if (!res.ok) throw new Error(await res.text())
+      const data = await res.json()
+      setBackupPath(data.backup_path)
+      setProposedYaml(null)
+      setPlaceholders([])
+      setSecretValues({})
+      setApplySuccess(true)
+      setTimeout(() => setApplySuccess(false), 5000)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Apply failed")
+    } finally {
+      setApplying(false)
+    }
+  }
+
+  const revertConfig = async () => {
+    if (!backupPath) return
+    setReverting(true)
+    setError(null)
+    try {
+      const res = await fetch(`${hubUrl}/api/settings/ai-config/revert`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token()}`, "Content-Type": "application/json" },
+        body: JSON.stringify({ backup_path: backupPath }),
+      })
+      if (!res.ok) throw new Error(await res.text())
+      setBackupPath(null)
+      setApplySuccess(false)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Revert failed")
+    } finally {
+      setReverting(false)
+    }
+  }
+
+  const allPlaceholdersFilled = placeholders.every(p => secretValues[p]?.trim())
+
+  return (
+    <div className="space-y-4 -mx-8 px-0" style={{ maxWidth: "none", width: "calc(100% + 4rem)" }}>
+      <div className="px-8">
+        <h2 className="text-base font-semibold mb-1">Configure with AI</h2>
+        <p className="text-sm text-muted-foreground">
+          Describe changes in plain English. The AI will propose a hub.yaml update for you to review and apply.
+        </p>
+      </div>
+
+      {error && (
+        <div className="px-8">
+          <p className="text-sm text-destructive bg-destructive/10 px-3 py-2 rounded-lg">{error}</p>
+        </div>
+      )}
+
+      {applySuccess && !backupPath && (
+        <div className="px-8">
+          <p className="text-sm text-green-600 bg-green-50 dark:bg-green-950/30 px-3 py-2 rounded-lg">Config applied successfully.</p>
+        </div>
+      )}
+
+      {applySuccess && backupPath && (
+        <div className="px-8 flex items-center gap-3">
+          <p className="text-sm text-green-600">✓ Config applied.</p>
+          <Button size="sm" variant="outline" onClick={revertConfig} disabled={reverting}>
+            <RotateCcw className="size-3.5 mr-1" />
+            {reverting ? "Reverting…" : "Revert"}
+          </Button>
+        </div>
+      )}
+
+      {backupPath && !applySuccess && (
+        <div className="px-8 flex items-center gap-3">
+          <p className="text-xs text-muted-foreground">Previous backup available.</p>
+          <Button size="sm" variant="outline" onClick={revertConfig} disabled={reverting}>
+            <RotateCcw className="size-3.5 mr-1" />
+            {reverting ? "Reverting…" : "Revert to backup"}
+          </Button>
+        </div>
+      )}
+
+      <div className="flex gap-4 px-8" style={{ alignItems: "flex-start" }}>
+        {/* Left: Chat */}
+        <div className="flex flex-col min-w-0" style={{ flex: "1 1 0" }}>
+          {/* Message history */}
+          <div className="border border-border rounded-lg bg-muted/20 flex flex-col" style={{ minHeight: 320, maxHeight: 480 }}>
+            <div className="flex-1 overflow-y-auto p-4 space-y-3">
+              {messages.length === 0 && (
+                <p className="text-sm text-muted-foreground text-center py-8">
+                  Describe the config change you&apos;d like to make.
+                </p>
+              )}
+              {messages.map((m, i) => (
+                <div key={i} className={cn("flex", m.role === "user" ? "justify-end" : "justify-start")}>
+                  <div
+                    className={cn(
+                      "max-w-[85%] rounded-xl px-3 py-2 text-sm whitespace-pre-wrap break-words",
+                      m.role === "user"
+                        ? "bg-primary text-primary-foreground"
+                        : "bg-muted text-foreground"
+                    )}
+                  >
+                    {m.content}
+                  </div>
+                </div>
+              ))}
+              {loading && (
+                <div className="flex justify-start">
+                  <div className="bg-muted rounded-xl px-3 py-2 text-sm text-muted-foreground animate-pulse">Thinking…</div>
+                </div>
+              )}
+            </div>
+
+            {/* Input */}
+            <div className="border-t border-border p-3 flex gap-2">
+              <Input
+                placeholder="e.g. Add a Linear integration for workspace acme"
+                value={input}
+                onChange={e => setInput(e.target.value)}
+                onKeyDown={e => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); sendMessage() } }}
+                disabled={loading}
+                className="flex-1 text-sm"
+              />
+              <Button size="icon" onClick={sendMessage} disabled={loading || !input.trim()}>
+                <Send className="size-4" />
+              </Button>
+            </div>
+          </div>
+        </div>
+
+        {/* Right: Proposed config panel */}
+        {proposedYaml && (
+          <div className="flex flex-col gap-4 min-w-0" style={{ flex: "1 1 0" }}>
+            <div className="border border-border rounded-lg">
+              <div className="px-4 py-2 border-b border-border bg-muted/40">
+                <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Proposed hub.yaml</p>
+              </div>
+              <pre className="p-4 text-xs font-mono overflow-auto bg-muted/20 rounded-b-lg" style={{ maxHeight: 300 }}>
+                {proposedYaml}
+              </pre>
+            </div>
+
+            {placeholders.length > 0 && (
+              <div className="border border-border rounded-lg p-4 space-y-3">
+                <p className="text-sm font-medium">Fill in secrets</p>
+                {placeholders.map(ph => (
+                  <div key={ph}>
+                    <label className="text-xs text-muted-foreground font-mono mb-1 block">{ph}</label>
+                    <Input
+                      type="password"
+                      placeholder={`Value for ${ph}`}
+                      value={secretValues[ph] || ""}
+                      onChange={e => setSecretValues(prev => ({ ...prev, [ph]: e.target.value }))}
+                      className="font-mono text-sm"
+                    />
+                  </div>
+                ))}
+              </div>
+            )}
+
+            <Button
+              onClick={applyConfig}
+              disabled={applying || !allPlaceholdersFilled}
+              className="w-full"
+            >
+              {applying ? "Applying…" : "Apply Configuration"}
+            </Button>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -1535,15 +1535,26 @@ function AIConfigSection() {
             </div>
           )}
 
-          {/* Apply button */}
+          {/* Apply / Discard buttons */}
           {proposedYaml && (
-            <div className="flex-none">
+            <div className="flex-none flex gap-2">
               <Button
                 onClick={applyConfig}
                 disabled={applying || !allPlaceholdersFilled}
-                className="w-full"
+                className="flex-1"
               >
-                {applying ? "Applying\u2026" : "Apply Configuration"}
+                {applying ? "Applying\u2026" : "Apply"}
+              </Button>
+              <Button
+                variant="outline"
+                disabled={applying}
+                onClick={() => {
+                  setProposedYaml(null)
+                  setPlaceholders([])
+                  setSecretValues({})
+                }}
+              >
+                Discard
               </Button>
             </div>
           )}

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -1082,6 +1082,20 @@ function AIConfigSection() {
     if (!input.trim() || loading) return
     const userMsg: ChatMessage = { role: "user", content: input.trim() }
     const historyForRequest = [...messages]
+    let assistantContent = ""
+
+    const finalizeAssistantMessage = (dropIfEmpty = false) => {
+      setMessages(prev => {
+        const msgs = [...prev]
+        const last = msgs[msgs.length - 1]
+        if (last?.role === "assistant" && last.streaming) {
+          if (dropIfEmpty && assistantContent === "") return msgs.slice(0, -1)
+          msgs[msgs.length - 1] = { role: "assistant", content: assistantContent, streaming: false }
+        }
+        return msgs
+      })
+    }
+
     setMessages(prev => [...prev, userMsg])
     setInput("")
     setLoading(true)
@@ -1100,7 +1114,6 @@ function AIConfigSection() {
 
       const reader = res.body!.getReader()
       const decoder = new TextDecoder()
-      let assistantContent = ""
       let sseBuffer = ""
 
       // Add streaming placeholder
@@ -1136,26 +1149,14 @@ function AIConfigSection() {
             setSecretValues({})
           } else if (parsed.type === "error") {
             setError(parsed.content as string)
+            finalizeAssistantMessage(true)
           } else if (parsed.type === "done") {
-            setMessages(prev => {
-              const msgs = [...prev]
-              const last = msgs[msgs.length - 1]
-              if (last?.role === "assistant") {
-                msgs[msgs.length - 1] = { role: "assistant", content: assistantContent, streaming: false }
-              }
-              return msgs
-            })
+            finalizeAssistantMessage()
           }
         }
       }
     } catch (e) {
-      setMessages(prev => {
-        const msgs = [...prev]
-        if (msgs[msgs.length - 1]?.streaming && msgs[msgs.length - 1]?.content === "") {
-          return msgs.slice(0, -1)
-        }
-        return msgs
-      })
+      finalizeAssistantMessage(true)
       setError(e instanceof Error ? e.message : "Request failed")
     } finally {
       setLoading(false)
@@ -1218,7 +1219,7 @@ function AIConfigSection() {
   const yamlLabel = proposedYaml ? "Proposed config" : "Current config"
 
   return (
-    <div className="-mx-8 -mt-8 flex flex-col" style={{ height: "calc(100vh - 8rem)" }}>
+    <div className="flex flex-col" style={{ height: "calc(100vh - 8rem)" }}>
       {/* Header */}
       <div className="px-8 pt-6 pb-3 flex-none">
         <h2 className="text-base font-semibold mb-0.5">Configure with AI</h2>

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -3,7 +3,7 @@
 import { useParams, useRouter } from "next/navigation"
 import { useEffect, useState, useCallback, useRef } from "react"
 import { getHubUrl } from "@/lib/hub-url"
-import { Cpu, Key, Github, ChevronLeft, Shield, Zap, Factory, Copy, Check, LayoutTemplate, Trash2, Lock, Sparkles, Send, RotateCcw } from "lucide-react"
+import { Cpu, Key, Github, ChevronLeft, Shield, Zap, Factory, Copy, Check, LayoutTemplate, Trash2, Lock, Sparkles, Send, RotateCcw, Eye, EyeOff } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { cn } from "@/lib/utils"
@@ -1021,6 +1021,59 @@ interface ChatMessage {
   streaming?: boolean
 }
 
+// Simple markdown renderer for assistant messages (no external deps)
+function renderMarkdown(text: string): React.ReactNode[] {
+  // Split off fenced code blocks first
+  const parts = text.split(/(```[\s\S]*?```)/g)
+  const nodes: React.ReactNode[] = []
+  parts.forEach((part, pi) => {
+    if (part.startsWith("```") && part.endsWith("```")) {
+      const inner = part.slice(3, -3).replace(/^[^\n]*\n/, "") // strip language hint
+      nodes.push(
+        <pre key={pi} className="bg-muted rounded p-2 my-1 overflow-x-auto">
+          <code className="text-xs font-mono">{inner}</code>
+        </pre>
+      )
+      return
+    }
+    // Process line by line
+    const lines = part.split("\n")
+    const lineNodes: React.ReactNode[] = []
+    let ulItems: React.ReactNode[] = []
+    const flushList = () => {
+      if (ulItems.length > 0) {
+        lineNodes.push(<ul key={`ul-${lineNodes.length}`} className="list-disc pl-4 my-1 space-y-0.5">{ulItems}</ul>)
+        ulItems = []
+      }
+    }
+    lines.forEach((line, li) => {
+      const isList = /^[\-\*]\s+/.test(line)
+      if (!isList) flushList()
+      if (isList) {
+        ulItems.push(<li key={li}>{inlineMarkdown(line.replace(/^[\-\*]\s+/, ""))}</li>)
+      } else if (line.trim() === "") {
+        lineNodes.push(<br key={li} />)
+      } else {
+        lineNodes.push(<span key={li}>{inlineMarkdown(line)}<br /></span>)
+      }
+    })
+    flushList()
+    nodes.push(...lineNodes)
+  })
+  return nodes
+}
+
+function inlineMarkdown(text: string): React.ReactNode[] {
+  // Split on inline code, bold, italic
+  const tokens = text.split(/(``[^`]+``|`[^`]+`|\*\*[^*]+\*\*|\*[^*]+\*)/g)
+  return tokens.map((tok, i) => {
+    if (tok.startsWith("**") && tok.endsWith("**")) return <strong key={i}>{tok.slice(2, -2)}</strong>
+    if (tok.startsWith("*") && tok.endsWith("*")) return <em key={i}>{tok.slice(1, -1)}</em>
+    if (tok.startsWith("`") && tok.endsWith("`")) return <code key={i} className="bg-muted px-1 rounded text-xs font-mono">{tok.slice(1, -1)}</code>
+    return tok
+  })
+}
+
 function YamlHighlight({ code }: { code: string }) {
   const [html, setHtml] = useState<string | null>(null)
   useEffect(() => {
@@ -1033,19 +1086,40 @@ function YamlHighlight({ code }: { code: string }) {
   return <div className="h-full overflow-auto p-3 text-xs leading-relaxed [&_pre]:!bg-transparent [&_code]:!text-xs [&_code]:!font-mono" dangerouslySetInnerHTML={{ __html: html }} />
 }
 
+// Session storage keys
+const SS_CHAT_KEY = "ai-config-chat-history"
+const SS_YAML_KEY = "ai-config-proposed-yaml"
+const SS_BACKUP_KEY = "ai-config-backup-path"
+
 function AIConfigSection() {
-  const [messages, setMessages] = useState<ChatMessage[]>([])
+  // Load persisted state from sessionStorage
+  const [messages, setMessages] = useState<ChatMessage[]>(() => {
+    try {
+      const raw = sessionStorage.getItem(SS_CHAT_KEY)
+      return raw ? (JSON.parse(raw) as ChatMessage[]).map(m => ({ ...m, streaming: false })) : []
+    } catch { return [] }
+  })
   const [input, setInput] = useState("")
   const [loading, setLoading] = useState(false)
-  const [proposedYaml, setProposedYaml] = useState<string | null>(null)
+  const [proposedYaml, setProposedYaml] = useState<string | null>(() => {
+    try { return sessionStorage.getItem(SS_YAML_KEY) } catch { return null }
+  })
   const [currentConfig, setCurrentConfig] = useState<string | null>(null)
   const [placeholders, setPlaceholders] = useState<string[]>([])
   const [secretValues, setSecretValues] = useState<Record<string, string>>({})
-  const [backupPath, setBackupPath] = useState<string | null>(null)
+  const [backupPath, setBackupPath] = useState<string | null>(() => {
+    try { return sessionStorage.getItem(SS_BACKUP_KEY) } catch { return null }
+  })
   const [applying, setApplying] = useState(false)
   const [reverting, setReverting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [applySuccess, setApplySuccess] = useState(false)
+  const [revealSecrets, setRevealSecrets] = useState(false)
+
+  // Typewriter queue
+  const typewriterQueueRef = useRef<string[]>([])
+  const typewriterIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const assistantContentRef = useRef<string>("")
 
   const chatScrollRef = useRef<HTMLDivElement>(null)
   const chatInputRef = useRef<HTMLTextAreaElement>(null)
@@ -1053,10 +1127,34 @@ function AIConfigSection() {
   const hubUrl = getHubUrl()
   const token = () => sessionStorage.getItem("ec_hub_token") || ""
 
-  // Load current config and any existing backup on mount
+  // Persist messages to sessionStorage on change
+  useEffect(() => {
+    try { sessionStorage.setItem(SS_CHAT_KEY, JSON.stringify(messages)) } catch {}
+  }, [messages])
+
+  // Persist proposedYaml
+  useEffect(() => {
+    try {
+      if (proposedYaml) sessionStorage.setItem(SS_YAML_KEY, proposedYaml)
+      else sessionStorage.removeItem(SS_YAML_KEY)
+    } catch {}
+  }, [proposedYaml])
+
+  // Persist backupPath
+  useEffect(() => {
+    try {
+      if (backupPath) sessionStorage.setItem(SS_BACKUP_KEY, backupPath)
+      else sessionStorage.removeItem(SS_BACKUP_KEY)
+    } catch {}
+  }, [backupPath])
+
+  // Load current config on mount (and when revealSecrets changes)
   useEffect(() => {
     const t = token()
-    fetch(`${hubUrl}/api/settings/ai-config/current-config`, {
+    const url = revealSecrets
+      ? `${hubUrl}/api/settings/ai-config/current-config?reveal=true`
+      : `${hubUrl}/api/settings/ai-config/current-config`
+    fetch(url, {
       headers: { Authorization: `Bearer ${t}` },
     })
       .then(r => {
@@ -1065,7 +1163,13 @@ function AIConfigSection() {
       })
       .then(text => setCurrentConfig(text))
       .catch(() => {})
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [revealSecrets])
 
+  // Load existing backup on mount (only if not already persisted)
+  useEffect(() => {
+    if (backupPath) return // already have one from sessionStorage
+    const t = token()
     fetch(`${hubUrl}/api/settings/ai-config/backup`, {
       headers: { Authorization: `Bearer ${t}` },
     })
@@ -1082,23 +1186,63 @@ function AIConfigSection() {
     }
   }, [messages])
 
-  const sendMessage = async () => {
-    if (!input.trim() || loading) return
-    const userMsg: ChatMessage = { role: "user", content: input.trim() }
-    const historyForRequest = [...messages]
-    let assistantContent = ""
-
-    const finalizeAssistantMessage = (dropIfEmpty = false) => {
+  // Typewriter: drain queue at ~20ms intervals
+  const startTypewriter = useCallback(() => {
+    if (typewriterIntervalRef.current) return
+    typewriterIntervalRef.current = setInterval(() => {
+      const queue = typewriterQueueRef.current
+      if (queue.length === 0) return
+      // Drain up to a few chars per tick for smooth ~60fps feel
+      const chars = queue.splice(0, 3).join("")
+      assistantContentRef.current += chars
+      const current = assistantContentRef.current
       setMessages(prev => {
         const msgs = [...prev]
         const last = msgs[msgs.length - 1]
         if (last?.role === "assistant" && last.streaming) {
-          if (dropIfEmpty && assistantContent === "") return msgs.slice(0, -1)
-          msgs[msgs.length - 1] = { role: "assistant", content: assistantContent, streaming: false }
+          msgs[msgs.length - 1] = { role: "assistant", content: current + "\u258c", streaming: true }
         }
         return msgs
       })
+    }, 20)
+  }, [])
+
+  const stopTypewriter = useCallback(() => {
+    if (typewriterIntervalRef.current) {
+      clearInterval(typewriterIntervalRef.current)
+      typewriterIntervalRef.current = null
     }
+  }, [])
+
+  // Drain remaining queue and finalize
+  const finalizeTypewriter = useCallback((dropIfEmpty = false) => {
+    stopTypewriter()
+    // Flush remaining queue synchronously
+    const remaining = typewriterQueueRef.current.join("")
+    typewriterQueueRef.current = []
+    assistantContentRef.current += remaining
+    const finalContent = assistantContentRef.current
+    setMessages(prev => {
+      const msgs = [...prev]
+      const last = msgs[msgs.length - 1]
+      if (last?.role === "assistant" && last.streaming) {
+        if (dropIfEmpty && finalContent === "") return msgs.slice(0, -1)
+        msgs[msgs.length - 1] = { role: "assistant", content: finalContent, streaming: false }
+      }
+      return msgs
+    })
+    assistantContentRef.current = ""
+  }, [stopTypewriter])
+
+  const sendMessage = async () => {
+    if (!input.trim() || loading) return
+    const userMsg: ChatMessage = { role: "user", content: input.trim() }
+    const historyForRequest = [...messages]
+
+    // Reset typewriter state
+    stopTypewriter()
+    typewriterQueueRef.current = []
+    assistantContentRef.current = ""
 
     setMessages(prev => [...prev, userMsg])
     setInput("")
@@ -1137,15 +1281,10 @@ function AIConfigSection() {
           try { parsed = JSON.parse(line.slice(6)) } catch { continue }
 
           if (parsed.type === "token") {
-            assistantContent += parsed.content as string
-            setMessages(prev => {
-              const msgs = [...prev]
-              const last = msgs[msgs.length - 1]
-              if (last?.role === "assistant") {
-                msgs[msgs.length - 1] = { role: "assistant", content: assistantContent + "\u258c", streaming: true }
-              }
-              return msgs
-            })
+            // Push to typewriter queue instead of directly to state
+            const chars = (parsed.content as string).split("")
+            typewriterQueueRef.current.push(...chars)
+            startTypewriter()
           } else if (parsed.type === "proposed_yaml") {
             setProposedYaml(parsed.yaml as string)
           } else if (parsed.type === "placeholders") {
@@ -1153,14 +1292,14 @@ function AIConfigSection() {
             setSecretValues({})
           } else if (parsed.type === "error") {
             setError(parsed.content as string)
-            finalizeAssistantMessage(true)
+            finalizeTypewriter(true)
           } else if (parsed.type === "done") {
-            finalizeAssistantMessage()
+            finalizeTypewriter()
           }
         }
       }
     } catch (e) {
-      finalizeAssistantMessage(true)
+      finalizeTypewriter(true)
       setError(e instanceof Error ? e.message : "Request failed")
     } finally {
       setLoading(false)
@@ -1181,7 +1320,10 @@ function AIConfigSection() {
       if (!res.ok) throw new Error(await res.text())
       const data = await res.json()
       setBackupPath(data.backup_path)
-      fetch(`${hubUrl}/api/settings/ai-config/current-config`, {
+      const cfgUrl = revealSecrets
+        ? `${hubUrl}/api/settings/ai-config/current-config?reveal=true`
+        : `${hubUrl}/api/settings/ai-config/current-config`
+      fetch(cfgUrl, {
         headers: { Authorization: `Bearer ${token()}` },
       }).then(r => r.text()).then(setCurrentConfig).catch(() => {})
       setProposedYaml(null)
@@ -1209,7 +1351,10 @@ function AIConfigSection() {
       if (!res.ok) throw new Error(await res.text())
       setBackupPath(null)
       setApplySuccess(false)
-      fetch(`${hubUrl}/api/settings/ai-config/current-config`, {
+      const cfgUrl = revealSecrets
+        ? `${hubUrl}/api/settings/ai-config/current-config?reveal=true`
+        : `${hubUrl}/api/settings/ai-config/current-config`
+      fetch(cfgUrl, {
         headers: { Authorization: `Bearer ${token()}` },
       }).then(r => r.text()).then(setCurrentConfig).catch(() => {})
     } catch (e) {
@@ -1278,13 +1423,16 @@ function AIConfigSection() {
               <div key={i} className={cn("flex", m.role === "user" ? "justify-end" : "justify-start")}>
                 <div
                   className={cn(
-                    "max-w-[90%] rounded-xl px-3 py-2 text-sm whitespace-pre-wrap break-words",
+                    "max-w-[90%] rounded-xl px-3 py-2 text-sm break-words",
                     m.role === "user"
-                      ? "bg-primary text-primary-foreground"
+                      ? "bg-primary text-primary-foreground whitespace-pre-wrap"
                       : "bg-muted text-foreground"
                   )}
                 >
-                  {m.content}
+                  {m.role === "assistant"
+                    ? <span>{renderMarkdown(m.content.replace(/\u258c$/, ""))}{m.streaming && <span className="animate-pulse">&#x258c;</span>}</span>
+                    : m.content
+                  }
                 </div>
               </div>
             ))}
@@ -1321,8 +1469,8 @@ function AIConfigSection() {
 
         {/* Right: config panel */}
         <div className="flex flex-col min-h-0 gap-3 flex-1 min-w-0">
-          {/* Label */}
-          <div className="flex-none">
+          {/* Label + secret toggle */}
+          <div className="flex-none flex items-center justify-between gap-2">
             <span className={cn(
               "text-xs font-medium uppercase tracking-wide px-2 py-0.5 rounded",
               proposedYaml
@@ -1331,6 +1479,20 @@ function AIConfigSection() {
             )}>
               {yamlLabel}
             </span>
+            <div className="flex items-center gap-2">
+              {revealSecrets && (
+                <span className="text-xs text-amber-500 font-medium">Secrets visible</span>
+              )}
+              <Button
+                size="icon"
+                variant="ghost"
+                className="size-6"
+                title={revealSecrets ? "Hide secrets" : "Reveal secrets"}
+                onClick={() => setRevealSecrets(v => !v)}
+              >
+                {revealSecrets ? <Eye className="size-3.5" /> : <EyeOff className="size-3.5" />}
+              </Button>
+            </div>
           </div>
 
           {/* YAML display — fills available height, scrollable */}

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -1121,6 +1121,19 @@ const SS_CHAT_KEY = "ai-config-chat-history"
 const SS_YAML_KEY = "ai-config-proposed-yaml"
 const SS_BACKUP_KEY = "ai-config-backup-path"
 
+function extractYamlPlaceholders(yaml: string): string[] {
+  const seen = new Set<string>()
+  const placeholders: string[] = []
+  for (const match of yaml.matchAll(/__([A-Z0-9_]+)__/g)) {
+    const name = match[1]
+    if (name && !seen.has(name)) {
+      seen.add(name)
+      placeholders.push(name)
+    }
+  }
+  return placeholders
+}
+
 function AIConfigSection() {
   // Load persisted state from sessionStorage — always start empty to avoid SSR hydration mismatch,
   // then restore from sessionStorage after mount.
@@ -1138,7 +1151,11 @@ function AIConfigSection() {
       const raw = sessionStorage.getItem(SS_CHAT_KEY)
       if (raw) setMessages((JSON.parse(raw) as ChatMessage[]).map(normalizeStoredMessage))
       const yaml = sessionStorage.getItem(SS_YAML_KEY)
-      if (yaml) setProposedYaml(yaml)
+      if (yaml) {
+        setProposedYaml(yaml)
+        setPlaceholders(extractYamlPlaceholders(yaml))
+        setSecretValues({})
+      }
       const backup = sessionStorage.getItem(SS_BACKUP_KEY)
       if (backup) setBackupPath(backup)
     } catch { /* ignore */ }

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -1021,6 +1021,14 @@ interface ChatMessage {
   streaming?: boolean
 }
 
+function normalizeStoredMessage(message: ChatMessage): ChatMessage {
+  return {
+    ...message,
+    content: message.content.replace(/\u258c$/, ""),
+    streaming: false,
+  }
+}
+
 // Simple markdown renderer for assistant messages (no external deps)
 function renderMarkdown(text: string): React.ReactNode[] {
   // Split off fenced code blocks first
@@ -1096,7 +1104,7 @@ function AIConfigSection() {
   const [messages, setMessages] = useState<ChatMessage[]>(() => {
     try {
       const raw = sessionStorage.getItem(SS_CHAT_KEY)
-      return raw ? (JSON.parse(raw) as ChatMessage[]).map(m => ({ ...m, streaming: false })) : []
+      return raw ? (JSON.parse(raw) as ChatMessage[]).map(normalizeStoredMessage) : []
     } catch { return [] }
   })
   const [input, setInput] = useState("")
@@ -1129,7 +1137,10 @@ function AIConfigSection() {
 
   // Persist messages to sessionStorage on change
   useEffect(() => {
-    try { sessionStorage.setItem(SS_CHAT_KEY, JSON.stringify(messages)) } catch {}
+    try {
+      const persisted = messages.map(normalizeStoredMessage)
+      sessionStorage.setItem(SS_CHAT_KEY, JSON.stringify(persisted))
+    } catch {}
   }, [messages])
 
   // Persist proposedYaml
@@ -1213,6 +1224,8 @@ function AIConfigSection() {
       typewriterIntervalRef.current = null
     }
   }, [])
+
+  useEffect(() => () => { stopTypewriter() }, [stopTypewriter])
 
   // Drain remaining queue and finalize
   const finalizeTypewriter = useCallback((dropIfEmpty = false) => {

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -1148,8 +1148,6 @@ function AIConfigSection() {
   const [error, setError] = useState<string | null>(null)
   const [yamlStreaming, setYamlStreaming] = useState(false)
   const [streamingYaml, setStreamingYaml] = useState<string>("")
-  const yamlQueueRef = useRef<string[]>([])
-  const yamlIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const [applySuccess, setApplySuccess] = useState(false)
   const [revealSecrets, setRevealSecrets] = useState(false)
 

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -1580,16 +1580,13 @@ function AIConfigSection() {
           </div>
 
           {/* YAML display — fills available height, scrollable */}
-          <div className={cn("flex-1 min-h-0 border border-border rounded-lg overflow-hidden bg-[#0d1117] relative transition-opacity", yamlStreaming && "opacity-70")}>
-            {displayedYaml
-              ? <YamlHighlight code={displayedYaml} />
-              : <p className="p-3 text-xs text-muted-foreground">Loading…</p>
+          <div className="flex-1 min-h-0 border border-border rounded-lg overflow-hidden bg-[#0d1117] relative">
+            {yamlStreaming
+              ? <pre className="h-full overflow-auto p-3 text-xs font-mono leading-relaxed text-gray-300 whitespace-pre">{streamingYaml}<span className="animate-pulse text-amber-400">&#x258c;</span></pre>
+              : displayedYaml
+                ? <YamlHighlight code={displayedYaml} />
+                : <p className="p-3 text-xs text-muted-foreground">Loading…</p>
             }
-            {yamlStreaming && (
-              <div className="absolute inset-0 pointer-events-none">
-                <span className="absolute bottom-3 right-3 text-xs text-amber-400 animate-pulse font-mono">writing…</span>
-              </div>
-            )}
           </div>
 
           {/* Placeholder secret inputs */}

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useParams, useRouter } from "next/navigation"
-import { useEffect, useState, useCallback, useRef } from "react"
+import React, { useEffect, useState, useCallback, useRef } from "react"
 import { getHubUrl } from "@/lib/hub-url"
 import { Cpu, Key, Github, ChevronLeft, Shield, Zap, Factory, Copy, Check, LayoutTemplate, Trash2, Lock, Sparkles, Send, RotateCcw, Eye, EyeOff } from "lucide-react"
 import { Button } from "@/components/ui/button"
@@ -1034,11 +1034,12 @@ function renderMarkdown(text: string): React.ReactNode[] {
   // Split off fenced code blocks first
   const parts = text.split(/(```[\s\S]*?```)/g)
   const nodes: React.ReactNode[] = []
+  let globalKey = 0
   parts.forEach((part, pi) => {
     if (part.startsWith("```") && part.endsWith("```")) {
       const inner = part.slice(3, -3).replace(/^[^\n]*\n/, "") // strip language hint
       nodes.push(
-        <pre key={pi} className="bg-muted rounded p-2 my-1 overflow-x-auto">
+        <pre key={`cb-${pi}`} className="bg-muted rounded p-2 my-1 overflow-x-auto">
           <code className="text-xs font-mono">{inner}</code>
         </pre>
       )
@@ -1048,9 +1049,10 @@ function renderMarkdown(text: string): React.ReactNode[] {
     const lines = part.split("\n")
     const lineNodes: React.ReactNode[] = []
     let ulItems: React.ReactNode[] = []
+    let ulKey = 0
     const flushList = () => {
       if (ulItems.length > 0) {
-        lineNodes.push(<ul key={`ul-${lineNodes.length}`} className="list-disc pl-4 my-1 space-y-0.5">{ulItems}</ul>)
+        lineNodes.push(<ul key={`ul-${pi}-${ulKey++}`} className="list-disc pl-4 my-1 space-y-0.5">{ulItems}</ul>)
         ulItems = []
       }
     }
@@ -1058,15 +1060,15 @@ function renderMarkdown(text: string): React.ReactNode[] {
       const isList = /^[\-\*]\s+/.test(line)
       if (!isList) flushList()
       if (isList) {
-        ulItems.push(<li key={li}>{inlineMarkdown(line.replace(/^[\-\*]\s+/, ""))}</li>)
+        ulItems.push(<li key={`li-${pi}-${li}`}>{inlineMarkdown(line.replace(/^[\-\*]\s+/, ""))}</li>)
       } else if (line.trim() === "") {
-        lineNodes.push(<br key={li} />)
+        lineNodes.push(<br key={`br-${pi}-${li}`} />)
       } else {
-        lineNodes.push(<span key={li}>{inlineMarkdown(line)}<br /></span>)
+        lineNodes.push(<span key={`s-${pi}-${li}`}>{inlineMarkdown(line)}<br /></span>)
       }
     })
     flushList()
-    nodes.push(...lineNodes)
+    nodes.push(...lineNodes.map((n, i) => React.cloneElement(n as React.ReactElement, { key: `n-${globalKey++}-${i}` })))
   })
   return nodes
 }
@@ -1384,11 +1386,35 @@ function AIConfigSection() {
   return (
     <div className="flex flex-col" style={{ height: "calc(100vh - 8rem)" }}>
       {/* Header */}
-      <div className="px-8 pt-6 pb-3 flex-none">
-        <h2 className="text-base font-semibold mb-0.5">Configure with AI</h2>
-        <p className="text-sm text-muted-foreground">
-          Describe changes in plain English. The AI will propose a hub.yaml update for you to review and apply.
-        </p>
+      <div className="px-8 pt-6 pb-3 flex-none flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-base font-semibold mb-0.5">Configure with AI</h2>
+          <p className="text-sm text-muted-foreground">
+            Describe changes in plain English. The AI will propose a hub.yaml update for you to review and apply.
+          </p>
+        </div>
+        {messages.length > 0 && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-muted-foreground shrink-0"
+            onClick={() => {
+              setMessages([])
+              setProposedYaml(null)
+              setPlaceholders([])
+              setSecretValues({})
+              setError(null)
+              setApplySuccess(false)
+              sessionStorage.removeItem("ai-config-chat-history")
+              sessionStorage.removeItem("ai-config-proposed-yaml")
+              sessionStorage.removeItem("ai-config-backup-path")
+              setTimeout(() => chatInputRef.current?.focus(), 0)
+            }}
+          >
+            <RotateCcw className="size-3.5 mr-1.5" />
+            Start over
+          </Button>
+        )}
       </div>
 
       {/* Status bar */}

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -1480,6 +1480,7 @@ function AIConfigSection() {
               sessionStorage.removeItem("ai-config-chat-history")
               sessionStorage.removeItem("ai-config-proposed-yaml")
               sessionStorage.removeItem("ai-config-backup-path")
+              setBackupPath(null)
               setTimeout(() => chatInputRef.current?.focus(), 0)
             }}
           >

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useParams, useRouter } from "next/navigation"
-import { useEffect, useState, useCallback } from "react"
+import { useEffect, useState, useCallback, useRef } from "react"
 import { getHubUrl } from "@/lib/hub-url"
 import { Cpu, Key, Github, ChevronLeft, Shield, Zap, Factory, Copy, Check, LayoutTemplate, Trash2, Lock, Sparkles, Send, RotateCcw } from "lucide-react"
 import { Button } from "@/components/ui/button"
@@ -1018,6 +1018,7 @@ function SecretsSection({ settings }: { settings: SettingsData | null }) {
 interface ChatMessage {
   role: "user" | "assistant"
   content: string
+  streaming?: boolean
 }
 
 function AIConfigSection() {
@@ -1025,6 +1026,7 @@ function AIConfigSection() {
   const [input, setInput] = useState("")
   const [loading, setLoading] = useState(false)
   const [proposedYaml, setProposedYaml] = useState<string | null>(null)
+  const [currentConfig, setCurrentConfig] = useState<string | null>(null)
   const [placeholders, setPlaceholders] = useState<string[]>([])
   const [secretValues, setSecretValues] = useState<Record<string, string>>({})
   const [backupPath, setBackupPath] = useState<string | null>(null)
@@ -1033,48 +1035,115 @@ function AIConfigSection() {
   const [error, setError] = useState<string | null>(null)
   const [applySuccess, setApplySuccess] = useState(false)
 
+  const chatScrollRef = useRef<HTMLDivElement>(null)
+
   const hubUrl = getHubUrl()
   const token = () => sessionStorage.getItem("ec_hub_token") || ""
 
-  // Check for existing backup on mount
+  // Load current config and any existing backup on mount
   useEffect(() => {
+    const t = token()
+    fetch(`${hubUrl}/api/settings/ai-config/current-config`, {
+      headers: { Authorization: `Bearer ${t}` },
+    })
+      .then(r => r.text())
+      .then(text => setCurrentConfig(text))
+      .catch(() => {})
+
     fetch(`${hubUrl}/api/settings/ai-config/backup`, {
-      headers: { Authorization: `Bearer ${token()}` },
+      headers: { Authorization: `Bearer ${t}` },
     })
       .then(r => r.json())
       .then(d => { if (d.backup_path) setBackupPath(d.backup_path) })
       .catch(() => {})
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+
+  // Auto-scroll chat to bottom when messages update
+  useEffect(() => {
+    if (chatScrollRef.current) {
+      chatScrollRef.current.scrollTop = chatScrollRef.current.scrollHeight
+    }
+  }, [messages])
 
   const sendMessage = async () => {
     if (!input.trim() || loading) return
-    const previousMessages = messages
     const userMsg: ChatMessage = { role: "user", content: input.trim() }
-    const newMessages = [...previousMessages, userMsg]
-    setMessages(newMessages)
+    const historyForRequest = [...messages]
+    setMessages(prev => [...prev, userMsg])
     setInput("")
     setLoading(true)
     setError(null)
+    setProposedYaml(null)
+    setPlaceholders([])
+    setSecretValues({})
 
     try {
-      const res = await fetch(`${hubUrl}/api/settings/ai-config`, {
+      const res = await fetch(`${hubUrl}/api/settings/ai-config/stream`, {
         method: "POST",
         headers: { Authorization: `Bearer ${token()}`, "Content-Type": "application/json" },
-        body: JSON.stringify({
-          message: userMsg.content,
-          history: previousMessages,
-        }),
+        body: JSON.stringify({ message: userMsg.content, history: historyForRequest }),
       })
       if (!res.ok) throw new Error(await res.text())
-      const data = await res.json()
-      setMessages(prev => [...prev, { role: "assistant", content: data.reply }])
-      if (data.proposed_yaml) {
-        setProposedYaml(data.proposed_yaml)
-        setPlaceholders(data.placeholders || [])
-        setSecretValues({})
+
+      const reader = res.body!.getReader()
+      const decoder = new TextDecoder()
+      let assistantContent = ""
+      let sseBuffer = ""
+
+      // Add streaming placeholder
+      setMessages(prev => [...prev, { role: "assistant", content: "", streaming: true }])
+
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        sseBuffer += decoder.decode(value, { stream: true })
+
+        const lines = sseBuffer.split("\n")
+        sseBuffer = lines.pop() ?? ""
+
+        for (const line of lines) {
+          if (!line.startsWith("data: ")) continue
+          let parsed: Record<string, unknown>
+          try { parsed = JSON.parse(line.slice(6)) } catch { continue }
+
+          if (parsed.type === "token") {
+            assistantContent += parsed.content as string
+            setMessages(prev => {
+              const msgs = [...prev]
+              const last = msgs[msgs.length - 1]
+              if (last?.role === "assistant") {
+                msgs[msgs.length - 1] = { role: "assistant", content: assistantContent + "\u258c", streaming: true }
+              }
+              return msgs
+            })
+          } else if (parsed.type === "proposed_yaml") {
+            setProposedYaml(parsed.yaml as string)
+          } else if (parsed.type === "placeholders") {
+            setPlaceholders(parsed.items as string[])
+            setSecretValues({})
+          } else if (parsed.type === "error") {
+            setError(parsed.content as string)
+          } else if (parsed.type === "done") {
+            setMessages(prev => {
+              const msgs = [...prev]
+              const last = msgs[msgs.length - 1]
+              if (last?.role === "assistant") {
+                msgs[msgs.length - 1] = { role: "assistant", content: assistantContent, streaming: false }
+              }
+              return msgs
+            })
+          }
+        }
       }
     } catch (e) {
-      setMessages(previousMessages)
+      setMessages(prev => {
+        const msgs = [...prev]
+        if (msgs[msgs.length - 1]?.streaming && msgs[msgs.length - 1]?.content === "") {
+          return msgs.slice(0, -1)
+        }
+        return msgs
+      })
       setError(e instanceof Error ? e.message : "Request failed")
     } finally {
       setLoading(false)
@@ -1094,6 +1163,9 @@ function AIConfigSection() {
       if (!res.ok) throw new Error(await res.text())
       const data = await res.json()
       setBackupPath(data.backup_path)
+      fetch(`${hubUrl}/api/settings/ai-config/current-config`, {
+        headers: { Authorization: `Bearer ${token()}` },
+      }).then(r => r.text()).then(setCurrentConfig).catch(() => {})
       setProposedYaml(null)
       setPlaceholders([])
       setSecretValues({})
@@ -1119,6 +1191,9 @@ function AIConfigSection() {
       if (!res.ok) throw new Error(await res.text())
       setBackupPath(null)
       setApplySuccess(false)
+      fetch(`${hubUrl}/api/settings/ai-config/current-config`, {
+        headers: { Authorization: `Bearer ${token()}` },
+      }).then(r => r.text()).then(setCurrentConfig).catch(() => {})
     } catch (e) {
       setError(e instanceof Error ? e.message : "Revert failed")
     } finally {
@@ -1127,140 +1202,161 @@ function AIConfigSection() {
   }
 
   const allPlaceholdersFilled = placeholders.every(p => secretValues[p]?.trim())
+  const displayedYaml = proposedYaml ?? currentConfig
+  const yamlLabel = proposedYaml ? "Proposed config" : "Current config"
 
   return (
-    <div className="space-y-4 -mx-8 px-0" style={{ maxWidth: "none", width: "calc(100% + 4rem)" }}>
-      <div className="px-8">
-        <h2 className="text-base font-semibold mb-1">Configure with AI</h2>
+    <div className="-mx-8 -mt-8 flex flex-col" style={{ height: "calc(100vh - 8rem)" }}>
+      {/* Header */}
+      <div className="px-8 pt-6 pb-3 flex-none">
+        <h2 className="text-base font-semibold mb-0.5">Configure with AI</h2>
         <p className="text-sm text-muted-foreground">
           Describe changes in plain English. The AI will propose a hub.yaml update for you to review and apply.
         </p>
       </div>
 
-      {error && (
-        <div className="px-8">
-          <p className="text-sm text-destructive bg-destructive/10 px-3 py-2 rounded-lg">{error}</p>
-        </div>
-      )}
-
-      {applySuccess && !backupPath && (
-        <div className="px-8">
-          <p className="text-sm text-green-600 bg-green-50 dark:bg-green-950/30 px-3 py-2 rounded-lg">Config applied successfully.</p>
-        </div>
-      )}
-
-      {applySuccess && backupPath && (
-        <div className="px-8 flex items-center gap-3">
-          <p className="text-sm text-green-600">✓ Config applied.</p>
-          <Button size="sm" variant="outline" onClick={revertConfig} disabled={reverting}>
-            <RotateCcw className="size-3.5 mr-1" />
-            {reverting ? "Reverting…" : "Revert"}
-          </Button>
-        </div>
-      )}
-
-      {backupPath && !applySuccess && (
-        <div className="px-8 flex items-center gap-3">
-          <p className="text-xs text-muted-foreground">Previous backup available.</p>
-          <Button size="sm" variant="outline" onClick={revertConfig} disabled={reverting}>
-            <RotateCcw className="size-3.5 mr-1" />
-            {reverting ? "Reverting…" : "Revert to backup"}
-          </Button>
-        </div>
-      )}
-
-      <div className="flex gap-4 px-8" style={{ alignItems: "flex-start" }}>
-        {/* Left: Chat */}
-        <div className="flex flex-col min-w-0" style={{ flex: "1 1 0" }}>
-          {/* Message history */}
-          <div className="border border-border rounded-lg bg-muted/20 flex flex-col" style={{ minHeight: 320, maxHeight: 480 }}>
-            <div className="flex-1 overflow-y-auto p-4 space-y-3">
-              {messages.length === 0 && (
-                <p className="text-sm text-muted-foreground text-center py-8">
-                  Describe the config change you&apos;d like to make.
-                </p>
-              )}
-              {messages.map((m, i) => (
-                <div key={i} className={cn("flex", m.role === "user" ? "justify-end" : "justify-start")}>
-                  <div
-                    className={cn(
-                      "max-w-[85%] rounded-xl px-3 py-2 text-sm whitespace-pre-wrap break-words",
-                      m.role === "user"
-                        ? "bg-primary text-primary-foreground"
-                        : "bg-muted text-foreground"
-                    )}
-                  >
-                    {m.content}
-                  </div>
-                </div>
-              ))}
-              {loading && (
-                <div className="flex justify-start">
-                  <div className="bg-muted rounded-xl px-3 py-2 text-sm text-muted-foreground animate-pulse">Thinking…</div>
-                </div>
+      {/* Status bar */}
+      {(error || applySuccess || (backupPath && !applySuccess)) && (
+        <div className="px-8 flex-none mb-2">
+          {error && (
+            <p className="text-sm text-destructive bg-destructive/10 px-3 py-2 rounded-lg">{error}</p>
+          )}
+          {applySuccess && (
+            <div className="flex items-center gap-3">
+              <p className="text-sm text-green-600">&check; Config applied.</p>
+              {backupPath && (
+                <Button size="sm" variant="outline" onClick={revertConfig} disabled={reverting}>
+                  <RotateCcw className="size-3.5 mr-1" />
+                  {reverting ? "Reverting\u2026" : "Revert"}
+                </Button>
               )}
             </div>
-
-            {/* Input */}
-            <div className="border-t border-border p-3 flex gap-2">
-              <Input
-                placeholder="e.g. Add a Linear integration for workspace acme"
-                value={input}
-                onChange={e => setInput(e.target.value)}
-                onKeyDown={e => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); sendMessage() } }}
-                disabled={loading}
-                className="flex-1 text-sm"
-              />
-              <Button size="icon" onClick={sendMessage} disabled={loading || !input.trim()}>
-                <Send className="size-4" />
+          )}
+          {backupPath && !applySuccess && (
+            <div className="flex items-center gap-3">
+              <p className="text-xs text-muted-foreground">Previous backup available.</p>
+              <Button size="sm" variant="outline" onClick={revertConfig} disabled={reverting}>
+                <RotateCcw className="size-3.5 mr-1" />
+                {reverting ? "Reverting\u2026" : "Revert to backup"}
               </Button>
             </div>
+          )}
+        </div>
+      )}
+
+      {/* Two-column body — fills remaining height */}
+      <div className="flex flex-1 min-h-0 px-8 pb-6 gap-4">
+
+        {/* Left: chat */}
+        <div className="flex flex-col flex-1 min-w-0 min-h-0 border border-border rounded-lg bg-muted/10 overflow-hidden">
+          {/* Scrollable message history */}
+          <div ref={chatScrollRef} className="flex-1 overflow-y-auto p-4 space-y-3">
+            {messages.length === 0 && (
+              <p className="text-sm text-muted-foreground text-center py-8">
+                Describe the config change you&apos;d like to make.
+              </p>
+            )}
+            {messages.map((m, i) => (
+              <div key={i} className={cn("flex", m.role === "user" ? "justify-end" : "justify-start")}>
+                <div
+                  className={cn(
+                    "max-w-[90%] rounded-xl px-3 py-2 text-sm whitespace-pre-wrap break-words",
+                    m.role === "user"
+                      ? "bg-primary text-primary-foreground"
+                      : "bg-muted text-foreground"
+                  )}
+                >
+                  {m.content}
+                </div>
+              </div>
+            ))}
+            {loading && (messages.length === 0 || messages[messages.length - 1]?.role === "user") && (
+              <div className="flex justify-start">
+                <div className="bg-muted rounded-xl px-3 py-2 text-sm text-muted-foreground">
+                  <span className="inline-flex gap-1">
+                    <span className="animate-bounce" style={{ animationDelay: "0ms" }}>&middot;</span>
+                    <span className="animate-bounce" style={{ animationDelay: "150ms" }}>&middot;</span>
+                    <span className="animate-bounce" style={{ animationDelay: "300ms" }}>&middot;</span>
+                  </span>
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Input pinned to bottom */}
+          <div className="flex-none border-t border-border p-3 flex gap-2">
+            <Input
+              placeholder="e.g. Add a Linear integration for workspace acme"
+              value={input}
+              onChange={e => setInput(e.target.value)}
+              onKeyDown={e => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); sendMessage() } }}
+              disabled={loading}
+              className="flex-1 text-sm"
+            />
+            <Button size="icon" onClick={sendMessage} disabled={loading || !input.trim()}>
+              <Send className="size-4" />
+            </Button>
           </div>
         </div>
 
-        {/* Right: Proposed config panel */}
-        {proposedYaml && (
-          <div className="flex flex-col gap-4 min-w-0" style={{ flex: "1 1 0" }}>
-            <div className="border border-border rounded-lg">
-              <div className="px-4 py-2 border-b border-border bg-muted/40">
-                <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Proposed hub.yaml</p>
-              </div>
-              <pre className="p-4 text-xs font-mono overflow-auto bg-muted/20 rounded-b-lg" style={{ maxHeight: 300 }}>
-                {proposedYaml}
-              </pre>
-            </div>
-
-            {placeholders.length > 0 && (
-              <div className="border border-border rounded-lg p-4 space-y-3">
-                <p className="text-sm font-medium">Fill in secrets</p>
-                {placeholders.map(ph => (
-                  <div key={ph}>
-                    <label className="text-xs text-muted-foreground font-mono mb-1 block">{ph}</label>
-                    <Input
-                      type="password"
-                      placeholder={`Value for ${ph}`}
-                      value={secretValues[ph] || ""}
-                      onChange={e => setSecretValues(prev => ({ ...prev, [ph]: e.target.value }))}
-                      className="font-mono text-sm"
-                    />
-                  </div>
-                ))}
-              </div>
-            )}
-
-            <Button
-              onClick={applyConfig}
-              disabled={applying || !allPlaceholdersFilled}
-              className="w-full"
-            >
-              {applying ? "Applying…" : "Apply Configuration"}
-            </Button>
+        {/* Right: config panel */}
+        <div className="flex flex-col min-h-0 gap-3" style={{ width: "22rem" }}>
+          {/* Label */}
+          <div className="flex-none">
+            <span className={cn(
+              "text-xs font-medium uppercase tracking-wide px-2 py-0.5 rounded",
+              proposedYaml
+                ? "bg-amber-500/15 text-amber-600 dark:text-amber-400"
+                : "bg-muted text-muted-foreground"
+            )}>
+              {yamlLabel}
+            </span>
           </div>
-        )}
+
+          {/* YAML display — fills available height, scrollable */}
+          <div className="flex-1 min-h-0 border border-border rounded-lg overflow-hidden bg-muted/20">
+            <pre className="h-full overflow-auto p-3 text-xs font-mono leading-relaxed">
+              {displayedYaml ?? "Loading\u2026"}
+            </pre>
+          </div>
+
+          {/* Placeholder secret inputs */}
+          {proposedYaml && placeholders.length > 0 && (
+            <div className="flex-none border border-border rounded-lg p-3 space-y-2 bg-background">
+              <p className="text-xs font-medium text-muted-foreground">Fill in secrets</p>
+              {placeholders.map(ph => (
+                <div key={ph}>
+                  <label className="text-xs text-muted-foreground font-mono mb-1 block">{ph}</label>
+                  <Input
+                    type="password"
+                    placeholder={`Value for ${ph}`}
+                    value={secretValues[ph] || ""}
+                    onChange={e => setSecretValues(prev => ({ ...prev, [ph]: e.target.value }))}
+                    className="font-mono text-xs h-7"
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Apply button */}
+          {proposedYaml && (
+            <div className="flex-none">
+              <Button
+                onClick={applyConfig}
+                disabled={applying || !allPlaceholdersFilled}
+                className="w-full"
+              >
+                {applying ? "Applying\u2026" : "Apply Configuration"}
+              </Button>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   )
 }
+
 
 function TemplatesSection() {
   const [templates, setTemplates] = useState<{ name: string; updatedAt: string }[]>([])

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -1122,24 +1122,27 @@ const SS_YAML_KEY = "ai-config-proposed-yaml"
 const SS_BACKUP_KEY = "ai-config-backup-path"
 
 function AIConfigSection() {
-  // Load persisted state from sessionStorage
-  const [messages, setMessages] = useState<ChatMessage[]>(() => {
-    try {
-      const raw = sessionStorage.getItem(SS_CHAT_KEY)
-      return raw ? (JSON.parse(raw) as ChatMessage[]).map(normalizeStoredMessage) : []
-    } catch { return [] }
-  })
+  // Load persisted state from sessionStorage — always start empty to avoid SSR hydration mismatch,
+  // then restore from sessionStorage after mount.
+  const [messages, setMessages] = useState<ChatMessage[]>([])
   const [input, setInput] = useState("")
   const [loading, setLoading] = useState(false)
-  const [proposedYaml, setProposedYaml] = useState<string | null>(() => {
-    try { return sessionStorage.getItem(SS_YAML_KEY) } catch { return null }
-  })
+  const [proposedYaml, setProposedYaml] = useState<string | null>(null)
   const [currentConfig, setCurrentConfig] = useState<string | null>(null)
   const [placeholders, setPlaceholders] = useState<string[]>([])
   const [secretValues, setSecretValues] = useState<Record<string, string>>({})
-  const [backupPath, setBackupPath] = useState<string | null>(() => {
-    try { return sessionStorage.getItem(SS_BACKUP_KEY) } catch { return null }
-  })
+  const [backupPath, setBackupPath] = useState<string | null>(null)
+  // Restore from sessionStorage after mount (client-only)
+  useEffect(() => {
+    try {
+      const raw = sessionStorage.getItem(SS_CHAT_KEY)
+      if (raw) setMessages((JSON.parse(raw) as ChatMessage[]).map(normalizeStoredMessage))
+      const yaml = sessionStorage.getItem(SS_YAML_KEY)
+      if (yaml) setProposedYaml(yaml)
+      const backup = sessionStorage.getItem(SS_BACKUP_KEY)
+      if (backup) setBackupPath(backup)
+    } catch { /* ignore */ }
+  }, [])
   const [applying, setApplying] = useState(false)
   const [reverting, setReverting] = useState(false)
   const [error, setError] = useState<string | null>(null)

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -1048,6 +1048,7 @@ function AIConfigSection() {
   const [applySuccess, setApplySuccess] = useState(false)
 
   const chatScrollRef = useRef<HTMLDivElement>(null)
+  const chatInputRef = useRef<HTMLTextAreaElement>(null)
 
   const hubUrl = getHubUrl()
   const token = () => sessionStorage.getItem("ec_hub_token") || ""
@@ -1163,6 +1164,7 @@ function AIConfigSection() {
       setError(e instanceof Error ? e.message : "Request failed")
     } finally {
       setLoading(false)
+      setTimeout(() => chatInputRef.current?.focus(), 0)
     }
   }
 
@@ -1302,12 +1304,14 @@ function AIConfigSection() {
           {/* Input pinned to bottom */}
           <div className="flex-none border-t border-border p-3 flex gap-2">
             <Input
+              ref={chatInputRef as React.Ref<HTMLInputElement>}
               placeholder="e.g. Add a Linear integration for workspace acme"
               value={input}
               onChange={e => setInput(e.target.value)}
               onKeyDown={e => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); sendMessage() } }}
               disabled={loading}
               className="flex-1 text-sm"
+              autoFocus
             />
             <Button size="icon" onClick={sendMessage} disabled={loading || !input.trim()}>
               <Send className="size-4" />

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -1157,7 +1157,7 @@ function AIConfigSection() {
   const assistantContentRef = useRef<string>("")
 
   const chatScrollRef = useRef<HTMLDivElement>(null)
-  const chatInputRef = useRef<HTMLTextAreaElement>(null)
+  const chatInputRef = useRef<HTMLInputElement>(null)
 
   const hubUrl = getHubUrl()
   const token = () => sessionStorage.getItem("ec_hub_token") || ""
@@ -1267,7 +1267,7 @@ function AIConfigSection() {
       const msgs = [...prev]
       const last = msgs[msgs.length - 1]
       if (last?.role === "assistant" && last.streaming) {
-        if (dropIfEmpty && visibleFinalContent === "") return msgs.slice(0, -1)
+        if (dropIfEmpty && visibleFinalContent === "" && finalContent.trim() === "") return msgs.slice(0, -1)
         msgs[msgs.length - 1] = { role: "assistant", content: finalContent, streaming: false }
       }
       return msgs
@@ -1563,7 +1563,7 @@ function AIConfigSection() {
           {/* Input pinned to bottom */}
           <div className="flex-none border-t border-border p-3 flex gap-2">
             <Input
-              ref={chatInputRef as React.Ref<HTMLInputElement>}
+              ref={chatInputRef}
               placeholder="e.g. Add a Linear integration for workspace acme"
               value={input}
               onChange={e => setInput(e.target.value)}

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -1021,6 +1021,18 @@ interface ChatMessage {
   streaming?: boolean
 }
 
+function YamlHighlight({ code }: { code: string }) {
+  const [html, setHtml] = useState<string | null>(null)
+  useEffect(() => {
+    if (!code) return
+    import("shiki").then(({ codeToHtml }) =>
+      codeToHtml(code, { lang: "yaml", theme: "github-dark" })
+    ).then(setHtml).catch(() => setHtml(null))
+  }, [code])
+  if (!html) return <pre className="h-full overflow-auto p-3 text-xs font-mono leading-relaxed whitespace-pre">{code}</pre>
+  return <div className="h-full overflow-auto p-3 text-xs leading-relaxed [&_pre]:!bg-transparent [&_code]:!text-xs [&_code]:!font-mono" dangerouslySetInnerHTML={{ __html: html }} />
+}
+
 function AIConfigSection() {
   const [messages, setMessages] = useState<ChatMessage[]>([])
   const [input, setInput] = useState("")
@@ -1314,10 +1326,11 @@ function AIConfigSection() {
           </div>
 
           {/* YAML display — fills available height, scrollable */}
-          <div className="flex-1 min-h-0 border border-border rounded-lg overflow-hidden bg-muted/20">
-            <pre className="h-full overflow-auto p-3 text-xs font-mono leading-relaxed">
-              {displayedYaml ?? "Loading\u2026"}
-            </pre>
+          <div className="flex-1 min-h-0 border border-border rounded-lg overflow-hidden bg-[#0d1117]">
+            {displayedYaml
+              ? <YamlHighlight code={displayedYaml} />
+              : <p className="p-3 text-xs text-muted-foreground">Loading…</p>
+            }
           </div>
 
           {/* Placeholder secret inputs */}

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -1309,6 +1309,7 @@ function AIConfigSection() {
       // Add streaming placeholder
       setMessages(prev => [...prev, { role: "assistant", content: "", streaming: true }])
       let inYamlBlock = false
+      let yamlFenceConsumed = false
 
       while (true) {
         const { done, value } = await reader.read()
@@ -1329,13 +1330,27 @@ function AIConfigSection() {
             const fullSoFar = assistantContentRef.current + tokenText
             if (!inYamlBlock && /```ya?ml/i.test(fullSoFar)) {
               inYamlBlock = true
+              yamlFenceConsumed = false
               setYamlStreaming(true)
               setStreamingYaml("")
             }
             if (inYamlBlock) {
-              // Stream to YAML panel — strip the opening fence
-              const cleaned = tokenText.replace(/^```ya?ml\n?/i, "")
-              if (cleaned) setStreamingYaml(prev => prev + cleaned)
+              // Stream to YAML panel — strip the opening fence (may be mid-token or split across tokens)
+              let content = tokenText
+              if (!yamlFenceConsumed) {
+                const fenceMatch = content.match(/```ya?ml\n?/i)
+                if (fenceMatch && fenceMatch.index !== undefined) {
+                  // Fence is in this token — drop everything up to and including the fence
+                  content = content.slice(fenceMatch.index + fenceMatch[0].length)
+                  yamlFenceConsumed = true
+                } else {
+                  // Fence was the entire previous token — mark consumed and pass content through
+                  yamlFenceConsumed = true
+                }
+              }
+              // Strip closing fence if it appears at the end
+              content = content.replace(/```\s*$/, "")
+              if (content) setStreamingYaml(prev => prev + content)
               // Still push to assistant content for stripping
               assistantContentRef.current += tokenText
             } else {
@@ -1432,7 +1447,7 @@ function AIConfigSection() {
 
   const allPlaceholdersFilled = placeholders.every(p => secretValues[p]?.trim())
   const displayedYaml = yamlStreaming ? streamingYaml : (proposedYaml ?? currentConfig)
-  const yamlLabel = (proposedYaml || yamlStreaming) ? "Proposed config" : "Current config"
+  const yamlLabel = yamlStreaming ? "Generating config…" : (proposedYaml ? "Proposed config" : "Current config")
 
   return (
     <div className="flex flex-col" style={{ height: "calc(100vh - 8rem)" }}>
@@ -1561,14 +1576,25 @@ function AIConfigSection() {
         <div className="flex flex-col min-h-0 gap-3 flex-1 min-w-0">
           {/* Label + secret toggle */}
           <div className="flex-none flex items-center justify-between gap-2">
-            <span className={cn(
-              "text-xs font-medium uppercase tracking-wide px-2 py-0.5 rounded",
-              proposedYaml
-                ? "bg-amber-500/15 text-amber-600 dark:text-amber-400"
-                : "bg-muted text-muted-foreground"
-            )}>
-              {yamlLabel}
-            </span>
+            <div className="flex items-center gap-2">
+              <span className={cn(
+                "text-xs font-medium uppercase tracking-wide px-2 py-0.5 rounded",
+                yamlStreaming
+                  ? "bg-blue-500/15 text-blue-500 dark:text-blue-400"
+                  : proposedYaml
+                    ? "bg-amber-500/15 text-amber-600 dark:text-amber-400"
+                    : "bg-muted text-muted-foreground"
+              )}>
+                {yamlLabel}
+              </span>
+              {yamlStreaming && (
+                <span className="flex gap-0.5 items-center">
+                  <span className="size-1.5 rounded-full bg-blue-400 animate-bounce [animation-delay:0ms]" />
+                  <span className="size-1.5 rounded-full bg-blue-400 animate-bounce [animation-delay:150ms]" />
+                  <span className="size-1.5 rounded-full bg-blue-400 animate-bounce [animation-delay:300ms]" />
+                </span>
+              )}
+            </div>
             <div className="flex items-center gap-2">
               {revealSecrets && (
                 <span className="text-xs text-amber-500 font-medium">Secrets visible</span>
@@ -1586,7 +1612,10 @@ function AIConfigSection() {
           </div>
 
           {/* YAML display — fills available height, scrollable */}
-          <div className="flex-1 min-h-0 border border-border rounded-lg overflow-hidden bg-[#0d1117] relative">
+          <div className={cn(
+            "flex-1 min-h-0 border rounded-lg overflow-hidden bg-[#0d1117] relative transition-colors duration-300",
+            yamlStreaming ? "border-blue-500/50" : "border-border"
+          )}>
             {yamlStreaming
               ? <pre className="h-full overflow-auto p-3 text-xs font-mono leading-relaxed text-gray-300 whitespace-pre">{streamingYaml}<span className="animate-pulse text-amber-400">&#x258c;</span></pre>
               : displayedYaml

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -1308,6 +1308,7 @@ function AIConfigSection() {
 
       // Add streaming placeholder
       setMessages(prev => [...prev, { role: "assistant", content: "", streaming: true }])
+      let inYamlBlock = false
 
       while (true) {
         const { done, value } = await reader.read()
@@ -1323,30 +1324,35 @@ function AIConfigSection() {
           try { parsed = JSON.parse(line.slice(6)) } catch { continue }
 
           if (parsed.type === "token") {
-            // Push to typewriter queue instead of directly to state
-            const chars = (parsed.content as string).split("")
-            typewriterQueueRef.current.push(...chars)
-            startTypewriter()
+            const tokenText = parsed.content as string
+            // Detect start of yaml block — redirect subsequent tokens to YAML panel
+            const fullSoFar = assistantContentRef.current + tokenText
+            if (!inYamlBlock && /```ya?ml/i.test(fullSoFar)) {
+              inYamlBlock = true
+              setYamlStreaming(true)
+              setStreamingYaml("")
+            }
+            if (inYamlBlock) {
+              // Stream to YAML panel — strip the opening fence
+              const cleaned = tokenText.replace(/^```ya?ml\n?/i, "")
+              if (cleaned) setStreamingYaml(prev => prev + cleaned)
+              // Still push to assistant content for stripping
+              assistantContentRef.current += tokenText
+            } else {
+              // Push to typewriter queue instead of directly to state
+              const chars = tokenText.split("")
+              typewriterQueueRef.current.push(...chars)
+              startTypewriter()
+              assistantContentRef.current += tokenText
+            }
+            continue
           } else if (parsed.type === "proposed_yaml") {
-            // Typewriter-animate the YAML into the right panel
+            // YAML was already streamed live via token events — just finalize
             const yaml = parsed.yaml as string
-            setYamlStreaming(true)
+            setYamlStreaming(false)
+            setProposedYaml(yaml)
             setStreamingYaml("")
-            yamlQueueRef.current = yaml.split("")
-            if (yamlIntervalRef.current) clearInterval(yamlIntervalRef.current)
-            yamlIntervalRef.current = setInterval(() => {
-              const q = yamlQueueRef.current
-              if (q.length === 0) {
-                clearInterval(yamlIntervalRef.current!)
-                yamlIntervalRef.current = null
-                setYamlStreaming(false)
-                setProposedYaml(yaml)
-                setStreamingYaml("")
-                return
-              }
-              const chars = q.splice(0, 8).join("")
-              setStreamingYaml(prev => prev + chars)
-            }, 16)
+            inYamlBlock = false
           } else if (parsed.type === "placeholders") {
             setPlaceholders(parsed.items as string[])
             setSecretValues({})

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -1058,7 +1058,10 @@ function AIConfigSection() {
     fetch(`${hubUrl}/api/settings/ai-config/current-config`, {
       headers: { Authorization: `Bearer ${t}` },
     })
-      .then(r => r.text())
+      .then(r => {
+        if (!r.ok) throw new Error(`Failed to fetch current config: ${r.status}`)
+        return r.text()
+      })
       .then(text => setCurrentConfig(text))
       .catch(() => {})
 

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -1143,6 +1143,10 @@ function AIConfigSection() {
   const [applying, setApplying] = useState(false)
   const [reverting, setReverting] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [yamlStreaming, setYamlStreaming] = useState(false)
+  const [streamingYaml, setStreamingYaml] = useState<string>("")
+  const yamlQueueRef = useRef<string[]>([])
+  const yamlIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const [applySuccess, setApplySuccess] = useState(false)
   const [revealSecrets, setRevealSecrets] = useState(false)
 
@@ -1321,7 +1325,25 @@ function AIConfigSection() {
             typewriterQueueRef.current.push(...chars)
             startTypewriter()
           } else if (parsed.type === "proposed_yaml") {
-            setProposedYaml(parsed.yaml as string)
+            // Typewriter-animate the YAML into the right panel
+            const yaml = parsed.yaml as string
+            setYamlStreaming(true)
+            setStreamingYaml("")
+            yamlQueueRef.current = yaml.split("")
+            if (yamlIntervalRef.current) clearInterval(yamlIntervalRef.current)
+            yamlIntervalRef.current = setInterval(() => {
+              const q = yamlQueueRef.current
+              if (q.length === 0) {
+                clearInterval(yamlIntervalRef.current!)
+                yamlIntervalRef.current = null
+                setYamlStreaming(false)
+                setProposedYaml(yaml)
+                setStreamingYaml("")
+                return
+              }
+              const chars = q.splice(0, 8).join("")
+              setStreamingYaml(prev => prev + chars)
+            }, 16)
           } else if (parsed.type === "placeholders") {
             setPlaceholders(parsed.items as string[])
             setSecretValues({})
@@ -1400,8 +1422,8 @@ function AIConfigSection() {
   }
 
   const allPlaceholdersFilled = placeholders.every(p => secretValues[p]?.trim())
-  const displayedYaml = proposedYaml ?? currentConfig
-  const yamlLabel = proposedYaml ? "Proposed config" : "Current config"
+  const displayedYaml = yamlStreaming ? streamingYaml : (proposedYaml ?? currentConfig)
+  const yamlLabel = (proposedYaml || yamlStreaming) ? "Proposed config" : "Current config"
 
   return (
     <div className="flex flex-col" style={{ height: "calc(100vh - 8rem)" }}>
@@ -1555,11 +1577,16 @@ function AIConfigSection() {
           </div>
 
           {/* YAML display — fills available height, scrollable */}
-          <div className="flex-1 min-h-0 border border-border rounded-lg overflow-hidden bg-[#0d1117]">
+          <div className={cn("flex-1 min-h-0 border border-border rounded-lg overflow-hidden bg-[#0d1117] relative transition-opacity", yamlStreaming && "opacity-70")}>
             {displayedYaml
               ? <YamlHighlight code={displayedYaml} />
               : <p className="p-3 text-xs text-muted-foreground">Loading…</p>
             }
+            {yamlStreaming && (
+              <div className="absolute inset-0 pointer-events-none">
+                <span className="absolute bottom-3 right-3 text-xs text-amber-400 animate-pulse font-mono">writing…</span>
+              </div>
+            )}
           </div>
 
           {/* Placeholder secret inputs */}

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -1330,6 +1330,11 @@ function AIConfigSection() {
             // Detect start of yaml block — redirect subsequent tokens to YAML panel
             const fullSoFar = assistantContentRef.current + typewriterQueueRef.current.join("") + tokenText
             if (!inYamlBlock && /```ya?ml/i.test(fullSoFar)) {
+              const queued = typewriterQueueRef.current.join("")
+              if (queued) {
+                typewriterQueueRef.current = []
+                assistantContentRef.current += queued
+              }
               inYamlBlock = true
               yamlFenceConsumed = false
               setYamlStreaming(true)

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -1300,7 +1300,7 @@ function AIConfigSection() {
         </div>
 
         {/* Right: config panel */}
-        <div className="flex flex-col min-h-0 gap-3" style={{ width: "22rem" }}>
+        <div className="flex flex-col min-h-0 gap-3 flex-1 min-w-0">
           {/* Label */}
           <div className="flex-none">
             <span className={cn(

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -1048,8 +1048,9 @@ function AIConfigSection() {
 
   const sendMessage = async () => {
     if (!input.trim() || loading) return
+    const previousMessages = messages
     const userMsg: ChatMessage = { role: "user", content: input.trim() }
-    const newMessages = [...messages, userMsg]
+    const newMessages = [...previousMessages, userMsg]
     setMessages(newMessages)
     setInput("")
     setLoading(true)
@@ -1061,7 +1062,7 @@ function AIConfigSection() {
         headers: { Authorization: `Bearer ${token()}`, "Content-Type": "application/json" },
         body: JSON.stringify({
           message: userMsg.content,
-          history: messages,
+          history: previousMessages,
         }),
       })
       if (!res.ok) throw new Error(await res.text())
@@ -1073,6 +1074,7 @@ function AIConfigSection() {
         setSecretValues({})
       }
     } catch (e) {
+      setMessages(previousMessages)
       setError(e instanceof Error ? e.message : "Request failed")
     } finally {
       setLoading(false)

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -1261,12 +1261,13 @@ function AIConfigSection() {
     const remaining = typewriterQueueRef.current.join("")
     typewriterQueueRef.current = []
     assistantContentRef.current += remaining
-    const finalContent = stripYamlBlocks(assistantContentRef.current)
+    const finalContent = assistantContentRef.current
+    const visibleFinalContent = stripYamlBlocks(finalContent)
     setMessages(prev => {
       const msgs = [...prev]
       const last = msgs[msgs.length - 1]
       if (last?.role === "assistant" && last.streaming) {
-        if (dropIfEmpty && finalContent === "") return msgs.slice(0, -1)
+        if (dropIfEmpty && visibleFinalContent === "") return msgs.slice(0, -1)
         msgs[msgs.length - 1] = { role: "assistant", content: finalContent, streaming: false }
       }
       return msgs
@@ -1291,6 +1292,8 @@ function AIConfigSection() {
     setProposedYaml(null)
     setPlaceholders([])
     setSecretValues({})
+    setYamlStreaming(false)
+    setStreamingYaml("")
 
     try {
       const res = await fetch(`${hubUrl}/api/settings/ai-config/stream`, {
@@ -1381,6 +1384,8 @@ function AIConfigSection() {
       setError(e instanceof Error ? e.message : "Request failed")
     } finally {
       finalizeTypewriter(true)
+      setYamlStreaming(false)
+      setStreamingYaml("")
       setLoading(false)
       setTimeout(() => chatInputRef.current?.focus(), 0)
     }
@@ -1469,6 +1474,8 @@ function AIConfigSection() {
               setSecretValues({})
               setError(null)
               setApplySuccess(false)
+              setYamlStreaming(false)
+              setStreamingYaml("")
               sessionStorage.removeItem("ai-config-chat-history")
               sessionStorage.removeItem("ai-config-proposed-yaml")
               sessionStorage.removeItem("ai-config-backup-path")
@@ -1533,7 +1540,7 @@ function AIConfigSection() {
                   )}
                 >
                   {m.role === "assistant"
-                    ? <span>{renderMarkdown(m.content.replace(/\u258c$/, ""))}{m.streaming && <span className="animate-pulse">&#x258c;</span>}</span>
+                    ? <span>{renderMarkdown(stripYamlBlocks(m.content.replace(/\u258c$/, "")))}{m.streaming && <span className="animate-pulse">&#x258c;</span>}</span>
                     : m.content
                   }
                 </div>

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -1350,8 +1350,10 @@ function AIConfigSection() {
                 }
               }
               // Strip closing fence if it appears at the end
+              const hadClosingFence = /```\s*$/.test(content)
               content = content.replace(/```\s*$/, "")
               if (content) setStreamingYaml(prev => prev + content)
+              if (hadClosingFence) inYamlBlock = false
               // Still push to assistant content for stripping
               assistantContentRef.current += tokenText
             } else {

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -190,7 +190,7 @@ export default function SettingsSectionPage() {
         </aside>
 
         {/* Content */}
-        <main className="flex-1 overflow-y-auto p-8 max-w-2xl">
+        <main className={section === "ai-config" ? "flex-1 min-h-0 flex flex-col overflow-hidden" : "flex-1 overflow-y-auto p-8 max-w-2xl"}>
           {error && <p className="mb-4 text-sm text-red-500">{error}</p>}
           {success && <p className="mb-4 text-sm text-green-500">{success}</p>}
 

--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/web/package.json
+++ b/web/package.json
@@ -61,6 +61,7 @@
     "react-resizable-panels": "^2.1.7",
     "recharts": "2.15.0",
     "remark-gfm": "^4.0.0",
+    "shiki": "^4.0.2",
     "sonner": "^1.7.1",
     "tailwind-merge": "^3.3.1",
     "vaul": "^1.1.2",


### PR DESCRIPTION
## Overview

A chat interface in hub Settings that lets users describe config changes in plain English. The hub sends the message + sanitized current config to an LLM, which proposes a YAML update. User reviews a diff, fills in any secret placeholders, and applies. Full backup/revert support.

## Changes

### Backend — `pkg/hub/ai_config.go` (new)

Four new endpoints, all behind `withWebAuth`:

| Method | Path | Purpose |
|--------|------|---------|
| POST | `/api/settings/ai-config` | Chat turn → LLM reply + proposed YAML |
| POST | `/api/settings/ai-config/apply` | Apply proposed YAML with backup |
| POST | `/api/settings/ai-config/revert` | Restore from backup |
| GET | `/api/settings/ai-config/backup` | Query latest backup |

**LLM selection** (priority order):
1. Anthropic key → `claude-sonnet-4-6` via Anthropic Messages API
2. OpenAI key → `gpt-4o` via OpenAI Chat Completions API
3. No keys → error

Direct `net/http` calls — no external LLM library.

**Config sanitization** before sending to LLM: masks `token`, `claw_token`, `api_key`, `access_token`, `private_key_pem`, `client_secret`, `webhook_secret`, `relay_secret`, `ui_password`, and all `secrets:` map values.

**Placeholders**: `__SECRET_NAME__` pattern lets the LLM defer secrets; detected and returned so the UI can prompt the user.

**Backup/revert**: `hub.yaml.bak.{unix_timestamp}` files; path-traversal protected; config is validated before write to ensure hub is never left unbootable.

### Backend — `pkg/hub/server.go`

Registers the four ai-config routes.

### Frontend — `web/app/settings/[section]/settings-content.tsx`

- Added `"ai-config"` to the `Section` type and nav items (Sparkles icon)
- New `AIConfigSection` component:
  - **Left column**: Chat interface — message bubbles, text input, loading state
  - **Right column** (shown when LLM proposes YAML): YAML preview in `<pre>`, secret input fields per placeholder, Apply button (disabled until all placeholders filled)
  - Revert button shown after successful apply or if a backup already exists

## Testing

- `go build ./...` ✓
- `cd web && npm run build` ✓