### PR TITLE
fix: disable Bonjour on Replicated VMs — mDNS crash kills gateway

### DIFF
--- a/pkg/hub/bootstrap.go
+++ b/pkg/hub/bootstrap.go
@@ -236,8 +236,9 @@ if not os.path.exists(path):
 try:
     with open(path) as f:
         cfg = json.load(f)
-except Exception:
-    cfg = {}
+except Exception as e:
+    print(f'Failed to parse OpenClaw config; not disabling Bonjour: {e}')
+    raise SystemExit(1)
 cfg.setdefault('plugins', {}).setdefault('entries', {}).setdefault('bonjour', {})['enabled'] = False
 with open(path, 'w') as f:
     json.dump(cfg, f, indent=2)

--- a/pkg/hub/bootstrap.go
+++ b/pkg/hub/bootstrap.go
@@ -226,6 +226,20 @@ if [ ! -f "$HOME/.openclaw/openclaw.json" ]; then
     --skip-daemon %s 2>/dev/null || true
   %s
 fi
+# Disable Bonjour/mDNS — not needed on a server VM and causes crashes
+python3 - <<'PYEOF'
+import json, os
+path = os.path.expanduser('~/.openclaw/openclaw.json')
+try:
+    with open(path) as f:
+        cfg = json.load(f)
+except Exception:
+    cfg = {}
+cfg.setdefault('plugins', {}).setdefault('entries', {}).setdefault('bonjour', {})['enabled'] = False
+with open(path, 'w') as f:
+    json.dump(cfg, f, indent=2)
+print('Bonjour disabled')
+PYEOF
 
 # ── Start OpenClaw gateway ────────────────────────────────────────────────────
 echo "Starting OpenClaw gateway..."

--- a/pkg/hub/bootstrap.go
+++ b/pkg/hub/bootstrap.go
@@ -230,6 +230,9 @@ fi
 python3 - <<'PYEOF'
 import json, os
 path = os.path.expanduser('~/.openclaw/openclaw.json')
+if not os.path.exists(path):
+    print('OpenClaw config not found; skipping Bonjour disable')
+    raise SystemExit(0)
 try:
     with open(path) as f:
         cfg = json.load(f)


### PR DESCRIPTION
On Replicated CMX VMs the Bonjour advertiser crashes with `CIAO ANNOUNCEMENT CANCELLED` because server VMs don't support mDNS multicast. This crashes the OpenClaw process, so claw-bridge can never connect to `localhost:18789` and claws stay stuck in `starting`.

Fix: after `openclaw onboard` creates `openclaw.json`, patch `plugins.entries.bonjour.enabled = false` so the plugin is disabled before the gateway starts.