### PR TITLE
fix: skip intro wake message on reconnect if claw already has messages

### DIFF
--- a/pkg/hub/bootstrap.go
+++ b/pkg/hub/bootstrap.go
@@ -272,7 +272,7 @@ chmod 600 "$HOME/.claw-bridge.env"
 export ELASTICCLAW_BOOTSTRAP=1
 export ELASTICCLAW_BOOTSTRAP_NOTIFY_FILE="$HOME/.claw-bridge.bootstrap.ready"
 rm -f "$ELASTICCLAW_BOOTSTRAP_NOTIFY_FILE"
-nohup /usr/local/bin/claw-bridge >> "$HOME/.claw-bridge.log" 2>&1 </dev/null &
+nohup /usr/local/bin/claw-bridge >> "$HOME/claw-bridge.log" 2>&1 </dev/null &
 BRIDGE_PID=$!
 for _ in {1..1800}; do
   if [ -f "$ELASTICCLAW_BOOTSTRAP_NOTIFY_FILE" ]; then

--- a/pkg/hub/bootstrap_test.go
+++ b/pkg/hub/bootstrap_test.go
@@ -35,7 +35,7 @@ func TestBootstrapScript_ContainsBootstrapMode(t *testing.T) {
 	// Node/OpenClaw/gateway steps live inside claw-bridge Go code.
 	script := GenerateReplicatedBootstrapScript(baseParams())
 	assertContains(t, script, "ELASTICCLAW_BOOTSTRAP=1", "bootstrap env var set")
-	assertContains(t, script, "/usr/local/bin/claw-bridge >> \"$HOME/.claw-bridge.log\" 2>&1 </dev/null &", "bridge backgrounded in bootstrap mode")
+	assertContains(t, script, "/usr/local/bin/claw-bridge >> \"$HOME/claw-bridge.log\" 2>&1 </dev/null &", "bridge backgrounded in bootstrap mode")
 	assertContains(t, script, "ELASTICCLAW_BOOTSTRAP_NOTIFY_FILE", "bootstrap completion notify file set")
 	assertNotContains(t, script, "exec /usr/local/bin/claw-bridge", "bridge must not block SSH session")
 	// Node/OpenClaw installs are NOT in the bash script anymore
@@ -105,7 +105,7 @@ func TestBootstrapScript_BridgeStartsBeforeCredentialHelper(t *testing.T) {
 	p.GitHubRepos = []types.GitHubRepoAccess{{Repo: "owner/repo", Permissions: "write"}}
 	script := GenerateReplicatedBootstrapScript(p)
 
-	assertContains(t, script, "/usr/local/bin/claw-bridge >> \"$HOME/.claw-bridge.log\" 2>&1 </dev/null &", "bridge started")
+	assertContains(t, script, "/usr/local/bin/claw-bridge >> \"$HOME/claw-bridge.log\" 2>&1 </dev/null &", "bridge started")
 	// Credential helper is NOT in the generated script — it runs as a separate SSH step
 	assertNotContains(t, script, "elasticclaw-git-credentials", "cred helper not in bootstrap script")
 }

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1236,7 +1236,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 	// If no pipeline entry inject was sent, fire the default wake message.
 	// But don't re-wake claws that already have a pipeline stage (hub restart reconnect).
 	if cc.gatewayReady && currentStatus == "connected" && !usedPipelineEntryInject {
-		if s.getPipelineStage(clawID) == "" {
+		if s.getPipelineStage(clawID) == "" && !s.clawHasMessages(clawID) {
 			go s.sendWakeMessage(cc, clawID)
 		}
 	}
@@ -2376,6 +2376,14 @@ func (s *Server) bridgeDownloadURL() string {
 // sendWakeMessage sends a silent system message to wake the agent.
 // For factory claws, it sends a task-specific prompt.
 // Not stored in DB — invisible to the user but triggers the agent to respond.
+// clawHasMessages returns true if the claw already has message history.
+// Used to suppress the intro wake message on reconnect.
+func (s *Server) clawHasMessages(clawID string) bool {
+	var count int
+	_ = s.db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id = ?`, clawID).Scan(&count)
+	return count > 0
+}
+
 func (s *Server) sendWakeMessage(cc *clawConn, clawID string) {
 	wakeContent := "Introduce yourself briefly and let the user know you're ready to help."
 	if factory, _ := s.findFactoryForClaw(clawID); factory != nil {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2376,14 +2376,6 @@ func (s *Server) bridgeDownloadURL() string {
 // sendWakeMessage sends a silent system message to wake the agent.
 // For factory claws, it sends a task-specific prompt.
 // Not stored in DB — invisible to the user but triggers the agent to respond.
-// clawHasMessages returns true if the claw already has message history.
-// Used to suppress the intro wake message on reconnect.
-func (s *Server) clawHasMessages(clawID string) bool {
-	var count int
-	_ = s.db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id = ?`, clawID).Scan(&count)
-	return count > 0
-}
-
 func (s *Server) sendWakeMessage(cc *clawConn, clawID string) {
 	wakeContent := "Introduce yourself briefly and let the user know you're ready to help."
 	if factory, _ := s.findFactoryForClaw(clawID); factory != nil {
@@ -2401,6 +2393,14 @@ func (s *Server) sendWakeMessage(cc *clawConn, clawID string) {
 		Content: wakeContent,
 	}
 	_ = wsjson.Write(context.Background(), cc.conn, types.WSMessage{Type: "message", Payload: wakeMsg})
+}
+
+// clawHasMessages returns true if the claw already has message history.
+// Used to suppress the intro wake message on reconnect.
+func (s *Server) clawHasMessages(clawID string) bool {
+	var count int
+	_ = s.db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id = ?`, clawID).Scan(&count)
+	return count > 0
 }
 
 func (s *Server) bootstrapReplicated(clawID, clawName, vmID string, cfg types.ProviderConfig) {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1358,7 +1358,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 						}
 					}
 					if shouldWake {
-						if !s.initializePipelineEntryIfNeeded(clawID) && s.getPipelineStage(clawID) == "" {
+						if !s.initializePipelineEntryIfNeeded(clawID) && s.getPipelineStage(clawID) == "" && !s.clawHasMessages(clawID) {
 							go s.sendWakeMessage(wakeConn, clawID)
 						}
 					}


### PR DESCRIPTION
When the bridge reconnects (e.g. gateway restart, heartbeat failure), the hub was firing the intro wake message again — causing a duplicate greeting and a new OpenClaw session, losing all context.\n\nFix: check message history before firing the wake. If the claw already has messages it's a reconnect, not first boot — skip the intro.