### PR TITLE
fix: require --template on create — was silently using 'base' default

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -54,6 +54,7 @@ func init() {
 	createCmd.Flags().StringVarP(&createName, "name", "n", "", "claw name (required)")
 	createCmd.MarkFlagRequired("name")
 	createCmd.Flags().StringVarP(&createTemplate, "template", "t", "", "template name (required)")
+	createCmd.MarkFlagRequired("template")
 	createCmd.Flags().StringVar(&createSource, "source", "auto", "template source: auto (local, then hub), local, or hub")
 	createCmd.Flags().StringArrayVar(&createEnvs, "env", nil, "extra env vars to inject (KEY=value)")
 	createCmd.Flags().StringVar(&createInstanceType, "instance-type", "", "override instance type (e.g. r1.small for Replicated)")

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -53,7 +53,7 @@ func init() {
 	rootCmd.AddCommand(createCmd)
 	createCmd.Flags().StringVarP(&createName, "name", "n", "", "claw name (required)")
 	createCmd.MarkFlagRequired("name")
-	createCmd.Flags().StringVarP(&createTemplate, "template", "t", "base", "template name (default: base)")
+	createCmd.Flags().StringVarP(&createTemplate, "template", "t", "", "template name (required)")
 	createCmd.Flags().StringVar(&createSource, "source", "auto", "template source: auto (local, then hub), local, or hub")
 	createCmd.Flags().StringArrayVar(&createEnvs, "env", nil, "extra env vars to inject (KEY=value)")
 	createCmd.Flags().StringVar(&createInstanceType, "instance-type", "", "override instance type (e.g. r1.small for Replicated)")
@@ -62,6 +62,9 @@ func init() {
 }
 
 func runCreate(cmd *cobra.Command, args []string) error {
+	if createTemplate == "" {
+		return fmt.Errorf("--template is required (e.g. --template canio)")
+	}
 	// Resolve hub connection from profile
 	h, _, err := config.ResolveHub(profile)
 	if err != nil {


### PR DESCRIPTION
Running `elasticclaw create --name test --profile canio` would silently use the `base` template (replicated provider) instead of erroring, causing confusing 422 errors when the hub doesn't have replicated configured.\n\nFix: remove the default, require `--template` explicitly.