### PR TITLE
fix: missing columns in claw_prs CREATE TABLE cause pr-watcher errors

### DIFF
--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -109,6 +109,8 @@ func migrate(db *sql.DB) error {
 		pr_url      TEXT NOT NULL,
 		last_ci_sha TEXT NOT NULL DEFAULT '',   -- last SHA we checked CI on
 		last_comment_id INTEGER NOT NULL DEFAULT 0, -- last bugbot comment ID seen
+		last_comment_at TEXT NOT NULL DEFAULT '', -- timestamp of last seen comment
+		pr_conditions_fired INTEGER NOT NULL DEFAULT 0,
 		created_at  DATETIME NOT NULL,
 		UNIQUE(claw_id, pr_url)
 	);


### PR DESCRIPTION
last_comment_at and pr_conditions_fired were only added via ALTER TABLE migrations but not in the original CREATE TABLE. On fresh installs where claw_prs doesn't exist yet, the ALTER runs before the table is created and fails silently, leaving the columns missing.\n\nFix: add both columns to the CREATE TABLE definition. The ALTER TABLE migrations are kept for existing databases.