### PR TITLE
feat: optional ssh_host in profile for hub upgrade

### DIFF
--- a/cmd/hub_upgrade.go
+++ b/cmd/hub_upgrade.go
@@ -109,9 +109,13 @@ func inferSSHFromProfile(profileName string) string {
 	if err != nil || hubProfile == nil {
 		return ""
 	}
-	// Use explicit ssh_host if set (e.g. Tailscale address)
-	if hubProfile.SSHHost != "" {
-		return fmt.Sprintf("ssh://root@%s", hubProfile.SSHHost)
+	// Use explicit ssh_uri if set (e.g. ssh://marc@canio-factory)
+	if hubProfile.SSHURI != "" {
+		if strings.HasPrefix(hubProfile.SSHURI, "ssh://") {
+			return hubProfile.SSHURI
+		}
+		// bare hostname — wrap as ssh://root@<host>
+		return fmt.Sprintf("ssh://root@%s", hubProfile.SSHURI)
 	}
 	if hubProfile.URL == "" {
 		return ""

--- a/cmd/hub_upgrade.go
+++ b/cmd/hub_upgrade.go
@@ -106,10 +106,17 @@ fi
 // Pass "" to use the active profile.
 func inferSSHFromProfile(profileName string) string {
 	hubProfile, _, err := config.ResolveHub(profileName)
-	if err != nil || hubProfile == nil || hubProfile.URL == "" {
+	if err != nil || hubProfile == nil {
 		return ""
 	}
-	// Strip scheme and port to get hostname
+	// Use explicit ssh_host if set (e.g. Tailscale address)
+	if hubProfile.SSHHost != "" {
+		return fmt.Sprintf("ssh://root@%s", hubProfile.SSHHost)
+	}
+	if hubProfile.URL == "" {
+		return ""
+	}
+	// Derive from URL
 	host := hubProfile.URL
 	host = strings.TrimPrefix(host, "https://")
 	host = strings.TrimPrefix(host, "http://")

--- a/pkg/types/profile.go
+++ b/pkg/types/profile.go
@@ -4,7 +4,7 @@ package types
 type HubProfile struct {
 	URL     string `yaml:"url"`
 	Token   string `yaml:"token"`
-	SSHHost string `yaml:"ssh_host,omitempty"` // optional override for hub upgrade SSH (e.g. Tailscale hostname)
+	SSHURI  string `yaml:"ssh_uri,omitempty"` // optional SSH target for hub upgrade (e.g. ssh://marc@canio-factory)
 }
 
 // Profile represents an execution context (legacy, kept for compat)

--- a/pkg/types/profile.go
+++ b/pkg/types/profile.go
@@ -2,8 +2,9 @@ package types
 
 // HubProfile holds connection details for one ElasticClaw hub.
 type HubProfile struct {
-	URL   string `yaml:"url"`
-	Token string `yaml:"token"`
+	URL     string `yaml:"url"`
+	Token   string `yaml:"token"`
+	SSHHost string `yaml:"ssh_host,omitempty"` // optional override for hub upgrade SSH (e.g. Tailscale hostname)
 }
 
 // Profile represents an execution context (legacy, kept for compat)


### PR DESCRIPTION
Adds an optional `ssh_host` field to hub profiles. When set, `elasticclaw hub upgrade` uses it instead of deriving the SSH target from the hub URL.\n\nUseful when the hub URL is a public domain but SSH should go over Tailscale or another address.\n\nExample:\n```yaml\nprofiles:\n  canio:\n    url: https://factory.canio.dev\n    token: xxx\n    ssh_host: canio-factory  # Tailscale hostname\n```