### PR TITLE
fix: disable Daytona 15min auto-stop on sandbox creation

### DIFF
--- a/pkg/provider/daytona/daytona.go
+++ b/pkg/provider/daytona/daytona.go
@@ -71,10 +71,13 @@ func (p *Provider) Info() types.ProviderInfo {
 func (p *Provider) Create(ctx context.Context, req types.CreateRequest) (*types.Instance, error) {
 	// Create sandbox params - use SnapshotParams for default snapshot-based creation.
 	// req.FromImage maps to the Daytona snapshot name (e.g. "daytona-medium").
+	// Disable auto-stop (default is 15 min inactivity which kills long-running agent sessions)
+	autoStopDisabled := 0
 	params := daytonatypes.SnapshotParams{
 		SandboxBaseParams: daytonatypes.SandboxBaseParams{
-			Name:    req.Name,
-			EnvVars: req.Env,
+			Name:             req.Name,
+			EnvVars:          req.Env,
+			AutoStopInterval: &autoStopDisabled, // 0 = no auto-stop
 		},
 		Snapshot: req.FromImage, // snapshot name — empty string uses Daytona default
 	}


### PR DESCRIPTION
Daytona defaults to auto-stopping sandboxes after 15 minutes of inactivity. This was killing agent sessions mid-task (the hub sees bridge disconnect after 8+ minutes idle).\n\nFix: set AutoStopInterval=0 on sandbox creation to disable auto-stop entirely.