### PR TITLE
fix: validate sudo and elevate remote install steps

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -113,19 +113,24 @@ func runInstall(cmd *cobra.Command, args []string) error {
 	defer client.Close()
 	fmt.Println("OK")
 
+	useSudo, err := detectRemotePrivilegeMode(client)
+	if err != nil {
+		return err
+	}
+
 	steps := []struct {
 		name   string
 		script string
 	}{
-		{"Installing hub binary", install.ScriptInstallBinary(version)},
+		{"Installing hub binary", install.ScriptInstallBinary(version, useSudo)},
 		{"Writing hub config", install.ScriptWriteConfig(params)},
-		{"Installing systemd service", install.ScriptInstallSystemd()},
+		{"Installing systemd service", install.ScriptInstallSystemd(useSudo)},
 	}
 	skipCaddy, _ := cmd.Flags().GetBool("skip-caddy")
 	if !skipCaddy {
 		steps = append(steps,
-			struct{ name, script string }{"Installing Caddy", install.ScriptInstallCaddy()},
-			struct{ name, script string }{"Configuring Caddy", install.ScriptWriteCaddyfile(installDomain)},
+			struct{ name, script string }{"Installing Caddy", install.ScriptInstallCaddy(useSudo)},
+			struct{ name, script string }{"Configuring Caddy", install.ScriptWriteCaddyfile(installDomain, useSudo)},
 		)
 	}
 
@@ -243,6 +248,22 @@ func dialSSH(user, addr, keyPath string) (*gossh.Client, error) {
 		Timeout:         15 * time.Second,
 	}
 	return gossh.Dial("tcp", addr, cfg)
+}
+
+func detectRemotePrivilegeMode(client *gossh.Client) (bool, error) {
+	out, err := sshRunClient(client, "id -u")
+	if err != nil {
+		return false, fmt.Errorf("failed to detect remote uid: %w", err)
+	}
+	if strings.TrimSpace(out) == "0" {
+		return false, nil
+	}
+
+	if _, err := sshRunClient(client, "sudo -n true"); err != nil {
+		return false, fmt.Errorf("remote user is not root and passwordless sudo is unavailable")
+	}
+
+	return true, nil
 }
 
 func sshRunClient(client *gossh.Client, script string) (string, error) {

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -251,11 +251,19 @@ func dialSSH(user, addr, keyPath string) (*gossh.Client, error) {
 }
 
 func detectRemotePrivilegeMode(client *gossh.Client) (bool, error) {
-	out, err := sshRunClient(client, "id -u")
+	out, err := sshRunClient(client, "sh -c 'printf __EC_UID__ ; id -u ; printf __EC_DONE__'")
 	if err != nil {
 		return false, fmt.Errorf("failed to detect remote uid: %w", err)
 	}
-	if strings.TrimSpace(out) == "0" {
+
+	start := strings.Index(out, "__EC_UID__")
+	end := strings.Index(out, "__EC_DONE__")
+	if start == -1 || end == -1 || end <= start+len("__EC_UID__") {
+		return false, fmt.Errorf("failed to parse remote uid probe output")
+	}
+
+	uid := strings.TrimSpace(out[start+len("__EC_UID__") : end])
+	if uid == "0" {
 		return false, nil
 	}
 

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -123,7 +123,7 @@ func runInstall(cmd *cobra.Command, args []string) error {
 		script string
 	}{
 		{"Installing hub binary", install.ScriptInstallBinary(version, useSudo)},
-		{"Writing hub config", install.ScriptWriteConfig(params)},
+		{"Writing hub config", install.ScriptWriteConfig(params, useSudo)},
 		{"Installing systemd service", install.ScriptInstallSystemd(useSudo)},
 	}
 	skipCaddy, _ := cmd.Flags().GetBool("skip-caddy")

--- a/pkg/install/container_test.go
+++ b/pkg/install/container_test.go
@@ -146,7 +146,7 @@ cat > /etc/systemd/system/elasticclaw.service << 'SVCEOF'
 	// ── Verify hub binary URL is correct ─────────────────────────────────────
 	// We don't actually download the binary in the container test (slow + network)
 	// but verify the install script would use the right URL
-	script := install.ScriptInstallBinary(params.Version)
+	script := install.ScriptInstallBinary(params.Version, false)
 	if !strings.Contains(script, "v0.0.3") {
 		t.Error("install script missing version in URL")
 	}

--- a/pkg/install/container_test.go
+++ b/pkg/install/container_test.go
@@ -121,7 +121,7 @@ sed -i 's/#PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_c
 	}
 
 	// ── Write hub config ──────────────────────────────────────────────────────
-	run("write config", install.ScriptWriteConfig(params))
+	run("write config", install.ScriptWriteConfig(params, false))
 	assertFile("/root/.elasticclaw/hub.yaml", "test-hub-token-abc")
 	assertFile("/root/.elasticclaw/hub.yaml", "test-claw-token-def")
 	assertFile("/root/.elasticclaw/hub.yaml", "hub.test.example.com")

--- a/pkg/install/scripts.go
+++ b/pkg/install/scripts.go
@@ -86,7 +86,8 @@ func ScriptWriteConfig(p Params, useSudo bool) string {
 	if useSudo {
 		configDir = "/root/.elasticclaw"
 	}
-	return fmt.Sprintf(`cat > /tmp/hub.yaml << 'HUBEOF'
+	return fmt.Sprintf(`umask 077
+cat > /tmp/hub.yaml << 'HUBEOF'
 %sHUBEOF
 %s mkdir -p %q
 %s mv /tmp/hub.yaml %q/hub.yaml`, HubConfig(p), sudo, configDir, sudo, configDir)

--- a/pkg/install/scripts.go
+++ b/pkg/install/scripts.go
@@ -62,13 +62,21 @@ func Caddyfile(domain string) string {
 `, domain)
 }
 
+func sudoPrefix(useSudo bool) string {
+	if useSudo {
+		return "sudo "
+	}
+	return ""
+}
+
 // ScriptInstallBinary returns the shell script to download and install the hub binary.
-func ScriptInstallBinary(version string) string {
+func ScriptInstallBinary(version string, useSudo bool) string {
 	url := HubBinaryURL(version)
+	sudo := sudoPrefix(useSudo)
 	return fmt.Sprintf(`set -ex
 curl -fsSL %q -o /tmp/elasticclaw-bin
 chmod +x /tmp/elasticclaw-bin
-sudo mv /tmp/elasticclaw-bin /usr/local/bin/elasticclaw`, url)
+%s mv /tmp/elasticclaw-bin /usr/local/bin/elasticclaw`, url, sudo)
 }
 
 // ScriptWriteConfig returns the shell script to write the hub config.
@@ -79,19 +87,30 @@ cat > "$HOME/.elasticclaw/hub.yaml" << 'HUBEOF'
 }
 
 // ScriptInstallSystemd returns the shell script to install and start the systemd service.
-func ScriptInstallSystemd() string {
+func ScriptInstallSystemd(useSudo bool) string {
+	sudo := sudoPrefix(useSudo)
 	return fmt.Sprintf(`cat > /tmp/elasticclaw.service << 'SVCEOF'
 %sSVCEOF
-sudo mv /tmp/elasticclaw.service /etc/systemd/system/elasticclaw.service
-sudo systemctl daemon-reload
-sudo systemctl enable elasticclaw
-sudo systemctl restart elasticclaw`, SystemdUnit())
+%s mv /tmp/elasticclaw.service /etc/systemd/system/elasticclaw.service
+%s systemctl daemon-reload
+%s systemctl enable elasticclaw
+%s systemctl restart elasticclaw`, SystemdUnit(), sudo, sudo, sudo, sudo)
 }
 
 // ScriptInstallCaddy returns the shell script to install Caddy if not present.
-func ScriptInstallCaddy() string {
-	return `which caddy >/dev/null 2>&1 || (
+func ScriptInstallCaddy(useSudo bool) string {
+	sudo := sudoPrefix(useSudo)
+	return fmt.Sprintf(`which caddy >/dev/null 2>&1 || (
   set -eu
+
+  SUDO=%q
+  sh_c() {
+    if [ -n "$SUDO" ]; then
+      sudo sh -c "$1"
+    else
+      sh -c "$1"
+    fi
+  }
 
   OS_ID=""
   OS_LIKE=""
@@ -101,19 +120,19 @@ func ScriptInstallCaddy() string {
   fi
 
   if command -v apt-get >/dev/null 2>&1; then
-    install -d /usr/share/keyrings /etc/apt/sources.list.d
-    apt-get install -y debian-keyring debian-archive-keyring apt-transport-https curl gpg 2>/dev/null || true
-    curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
-    curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | tee /etc/apt/sources.list.d/caddy-stable.list >/dev/null
-    apt-get update -qq
-    apt-get install -y caddy
+    sh_c 'install -d /usr/share/keyrings /etc/apt/sources.list.d'
+    sh_c 'apt-get install -y debian-keyring debian-archive-keyring apt-transport-https curl gpg 2>/dev/null || true'
+    curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sh_c 'gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg'
+    curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | sh_c 'tee /etc/apt/sources.list.d/caddy-stable.list >/dev/null'
+    sh_c 'apt-get update -qq'
+    sh_c 'apt-get install -y caddy'
   elif command -v dnf >/dev/null 2>&1 || command -v yum >/dev/null 2>&1; then
     PKG_MGR=dnf
     if ! command -v dnf >/dev/null 2>&1; then
       PKG_MGR=yum
     fi
 
-    $PKG_MGR install -y curl tar
+    sh_c "$PKG_MGR install -y curl tar"
 
     ARCH=$(uname -m)
     case "$ARCH" in
@@ -130,10 +149,10 @@ func ScriptInstallCaddy() string {
 
     curl -fsSL 'https://github.com/caddyserver/caddy/releases/download/'"$CADDY_VERSION"'/caddy_'"${CADDY_VERSION#v}"'_linux_'"$CADDY_ARCH"'.tar.gz' -o /tmp/caddy.tar.gz
     tar -xzf /tmp/caddy.tar.gz -C /tmp caddy
-    install -m 0755 /tmp/caddy /usr/local/bin/caddy
-    install -d /etc/caddy
+    sh_c 'install -m 0755 /tmp/caddy /usr/local/bin/caddy'
+    sh_c 'install -d /etc/caddy'
 
-    cat > /etc/systemd/system/caddy.service <<'CADDYSVC'
+    cat > /tmp/caddy.service <<'CADDYSVC'
 [Unit]
 Description=Caddy
 Documentation=https://caddyserver.com/docs/
@@ -155,19 +174,21 @@ AmbientCapabilities=CAP_NET_BIND_SERVICE
 WantedBy=multi-user.target
 CADDYSVC
 
-    systemctl daemon-reload
-    systemctl enable caddy
+    sh_c 'mv /tmp/caddy.service /etc/systemd/system/caddy.service'
+    sh_c 'systemctl daemon-reload'
+    sh_c 'systemctl enable caddy'
   else
     echo "unsupported Linux distribution for automatic Caddy install (ID=${OS_ID:-unknown}, ID_LIKE=${OS_LIKE:-unknown})" >&2
     exit 1
   fi
-)`
+)`, sudo)
 }
 
 // ScriptWriteCaddyfile returns the shell script to write the Caddyfile and reload Caddy.
-func ScriptWriteCaddyfile(domain string) string {
+func ScriptWriteCaddyfile(domain string, useSudo bool) string {
+	sudo := sudoPrefix(useSudo)
 	return fmt.Sprintf(`cat > /tmp/Caddyfile << 'CADDYEOF'
 %sCADDYEOF
-sudo mv /tmp/Caddyfile /etc/caddy/Caddyfile
-sudo systemctl reload caddy || sudo systemctl restart caddy`, Caddyfile(domain))
+%s mv /tmp/Caddyfile /etc/caddy/Caddyfile
+%s systemctl reload caddy || %s systemctl restart caddy`, Caddyfile(domain), sudo, sudo, sudo)
 }

--- a/pkg/install/scripts.go
+++ b/pkg/install/scripts.go
@@ -82,12 +82,14 @@ chmod +x /tmp/elasticclaw-bin
 // ScriptWriteConfig returns the shell script to write the hub config.
 func ScriptWriteConfig(p Params, useSudo bool) string {
 	configDir := "$HOME/.elasticclaw"
+	sudo := sudoPrefix(useSudo)
 	if useSudo {
 		configDir = "/root/.elasticclaw"
 	}
-	return fmt.Sprintf(`mkdir -p %q
-cat > %q/hub.yaml << 'HUBEOF'
-%sHUBEOF`, configDir, configDir, HubConfig(p))
+	return fmt.Sprintf(`cat > /tmp/hub.yaml << 'HUBEOF'
+%sHUBEOF
+%s mkdir -p %q
+%s mv /tmp/hub.yaml %q/hub.yaml`, HubConfig(p), sudo, configDir, sudo, configDir)
 }
 
 // ScriptInstallSystemd returns the shell script to install and start the systemd service.

--- a/pkg/install/scripts.go
+++ b/pkg/install/scripts.go
@@ -80,10 +80,14 @@ chmod +x /tmp/elasticclaw-bin
 }
 
 // ScriptWriteConfig returns the shell script to write the hub config.
-func ScriptWriteConfig(p Params) string {
-	return fmt.Sprintf(`mkdir -p "$HOME/.elasticclaw"
-cat > "$HOME/.elasticclaw/hub.yaml" << 'HUBEOF'
-%sHUBEOF`, HubConfig(p))
+func ScriptWriteConfig(p Params, useSudo bool) string {
+	configDir := "$HOME/.elasticclaw"
+	if useSudo {
+		configDir = "/root/.elasticclaw"
+	}
+	return fmt.Sprintf(`mkdir -p %q
+cat > %q/hub.yaml << 'HUBEOF'
+%sHUBEOF`, configDir, configDir, HubConfig(p))
 }
 
 // ScriptInstallSystemd returns the shell script to install and start the systemd service.

--- a/pkg/install/scripts_test.go
+++ b/pkg/install/scripts_test.go
@@ -83,6 +83,7 @@ func TestScriptInstallBinary(t *testing.T) {
 
 func TestScriptWriteConfig(t *testing.T) {
 	s := install.ScriptWriteConfig(testParams, false)
+	assertContains(t, s, "umask 077", "restrict temp config permissions")
 	assertContains(t, s, "/tmp/hub.yaml", "temp config path")
 	assertContains(t, s, "mkdir -p", "create dir")
 	assertContains(t, s, ".elasticclaw", "config dir")

--- a/pkg/install/scripts_test.go
+++ b/pkg/install/scripts_test.go
@@ -82,12 +82,17 @@ func TestScriptInstallBinary(t *testing.T) {
 }
 
 func TestScriptWriteConfig(t *testing.T) {
-	s := install.ScriptWriteConfig(testParams)
+	s := install.ScriptWriteConfig(testParams, false)
 	assertContains(t, s, "mkdir -p", "create dir")
 	assertContains(t, s, ".elasticclaw", "config dir")
 	assertContains(t, s, "hub.yaml", "config path")
 	assertContains(t, s, "test-hub-token", "token embedded")
 	assertContains(t, s, "HUBEOF", "heredoc markers")
+}
+
+func TestScriptWriteConfig_UsesRootHomeWithSudo(t *testing.T) {
+	s := install.ScriptWriteConfig(testParams, true)
+	assertContains(t, s, "/root/.elasticclaw", "root config dir for sudo installs")
 }
 
 func TestScriptInstallSystemd(t *testing.T) {
@@ -138,7 +143,7 @@ func TestScripts_Shellcheck(t *testing.T) {
 
 	scripts := map[string]string{
 		"install_binary":   install.ScriptInstallBinary("v0.0.3", true),
-		"write_config":     install.ScriptWriteConfig(testParams),
+		"write_config":     install.ScriptWriteConfig(testParams, true),
 		"install_systemd":  install.ScriptInstallSystemd(true),
 		"install_caddy":    install.ScriptInstallCaddy(true),
 		"write_caddyfile":  install.ScriptWriteCaddyfile("hub.example.com", true),

--- a/pkg/install/scripts_test.go
+++ b/pkg/install/scripts_test.go
@@ -83,6 +83,7 @@ func TestScriptInstallBinary(t *testing.T) {
 
 func TestScriptWriteConfig(t *testing.T) {
 	s := install.ScriptWriteConfig(testParams, false)
+	assertContains(t, s, "/tmp/hub.yaml", "temp config path")
 	assertContains(t, s, "mkdir -p", "create dir")
 	assertContains(t, s, ".elasticclaw", "config dir")
 	assertContains(t, s, "hub.yaml", "config path")
@@ -93,6 +94,9 @@ func TestScriptWriteConfig(t *testing.T) {
 func TestScriptWriteConfig_UsesRootHomeWithSudo(t *testing.T) {
 	s := install.ScriptWriteConfig(testParams, true)
 	assertContains(t, s, "/root/.elasticclaw", "root config dir for sudo installs")
+	assertContains(t, s, "sudo ", "sudo prefix for root config writes")
+	assertContains(t, s, "mkdir -p \"/root/.elasticclaw\"", "mkdir root config dir")
+	assertContains(t, s, "mv /tmp/hub.yaml \"/root/.elasticclaw\"/hub.yaml", "move temp config into root config dir")
 }
 
 func TestScriptInstallSystemd(t *testing.T) {

--- a/pkg/install/scripts_test.go
+++ b/pkg/install/scripts_test.go
@@ -73,7 +73,7 @@ func TestCaddyfile(t *testing.T) {
 // ── Script generation ─────────────────────────────────────────────────────────
 
 func TestScriptInstallBinary(t *testing.T) {
-	s := install.ScriptInstallBinary("v0.0.3")
+	s := install.ScriptInstallBinary("v0.0.3", true)
 	assertContains(t, s, "set -e", "fail fast")
 	assertContains(t, s, "curl -fsSL", "curl download")
 	assertContains(t, s, "v0.0.3", "version in URL")
@@ -91,7 +91,7 @@ func TestScriptWriteConfig(t *testing.T) {
 }
 
 func TestScriptInstallSystemd(t *testing.T) {
-	s := install.ScriptInstallSystemd()
+	s := install.ScriptInstallSystemd(true)
 	assertContains(t, s, "/etc/systemd/system/elasticclaw.service", "service path")
 	assertContains(t, s, "systemctl daemon-reload", "daemon reload")
 	assertContains(t, s, "systemctl enable elasticclaw", "enable service")
@@ -99,14 +99,23 @@ func TestScriptInstallSystemd(t *testing.T) {
 }
 
 func TestScriptWriteCaddyfile(t *testing.T) {
-	s := install.ScriptWriteCaddyfile("hub.example.com")
+	s := install.ScriptWriteCaddyfile("hub.example.com", true)
 	assertContains(t, s, "/etc/caddy/Caddyfile", "caddyfile path")
 	assertContains(t, s, "hub.example.com", "domain in config")
 	assertContains(t, s, "systemctl reload caddy", "caddy reload")
 }
 
+func TestScriptHelpers_SudoPrefix(t *testing.T) {
+	if s := install.ScriptInstallBinary("v0.0.3", false); strings.Contains(s, "sudo") {
+		t.Error("did not expect sudo for root install path")
+	}
+	if s := install.ScriptInstallBinary("v0.0.3", true); !strings.Contains(s, "sudo ") {
+		t.Error("expected sudo for non-root install path")
+	}
+}
+
 func TestScriptInstallCaddy_SupportsAptAndRpmDistros(t *testing.T) {
-	s := install.ScriptInstallCaddy()
+	s := install.ScriptInstallCaddy(true)
 	assertContains(t, s, "command -v apt-get", "apt detection")
 	assertContains(t, s, "command -v dnf", "dnf detection")
 	assertContains(t, s, "command -v yum", "yum detection")
@@ -115,6 +124,7 @@ func TestScriptInstallCaddy_SupportsAptAndRpmDistros(t *testing.T) {
 	assertContains(t, s, "https://github.com/caddyserver/caddy/releases/download/", "versioned caddy asset download")
 	assertContains(t, s, "caddy_'\"${CADDY_VERSION#v}\"'_linux_", "versioned caddy asset filename")
 	assertContains(t, s, "install -m 0755 /tmp/caddy /usr/local/bin/caddy", "static caddy binary install")
+	assertContains(t, s, "SUDO=\"sudo \"", "sudo mode wiring")
 	assertContains(t, s, "systemctl enable caddy", "caddy service enable")
 	assertContains(t, s, "unsupported Linux distribution", "unsupported distro message")
 }
@@ -127,11 +137,11 @@ func TestScripts_Shellcheck(t *testing.T) {
 	}
 
 	scripts := map[string]string{
-		"install_binary":   install.ScriptInstallBinary("v0.0.3"),
+		"install_binary":   install.ScriptInstallBinary("v0.0.3", true),
 		"write_config":     install.ScriptWriteConfig(testParams),
-		"install_systemd":  install.ScriptInstallSystemd(),
-		"install_caddy":    install.ScriptInstallCaddy(),
-		"write_caddyfile":  install.ScriptWriteCaddyfile("hub.example.com"),
+		"install_systemd":  install.ScriptInstallSystemd(true),
+		"install_caddy":    install.ScriptInstallCaddy(true),
+		"write_caddyfile":  install.ScriptWriteCaddyfile("hub.example.com", true),
 	}
 
 	for name, script := range scripts {


### PR DESCRIPTION
## Summary
- detect whether the remote SSH user is root
- require passwordless sudo up front when the user is not root
- run privileged install steps with sudo when needed instead of assuming root

## Why
 connected successfully as  on Amazon Linux, but later failed during package installation because the remote scripts assumed root privileges. This change fails early if sudo is unavailable and otherwise uses sudo consistently for privileged operations.

## Testing
- ok  	github.com/elasticclaw/elasticclaw/pkg/install	(cached)
?   	github.com/elasticclaw/elasticclaw/cmd	[no test files]
?   	github.com/elasticclaw/elasticclaw/cmd/bootopt	[no test files]
?   	github.com/elasticclaw/elasticclaw/cmd/claw-bridge	[no test files]
