### PR TITLE
fix: build portable linux release binaries

### DIFF
--- a/.depot/workflows/release.yaml
+++ b/.depot/workflows/release.yaml
@@ -51,14 +51,14 @@ jobs:
           mkdir -p dist
 
           # elasticclaw CLI
-          GOOS=linux   GOARCH=amd64 go build -tags embedweb -ldflags "$LDFLAGS" -o dist/elasticclaw-linux-amd64   .
-          GOOS=linux   GOARCH=arm64 go build -tags embedweb -ldflags "$LDFLAGS" -o dist/elasticclaw-linux-arm64   .
+          CGO_ENABLED=0 GOOS=linux   GOARCH=amd64 go build -tags embedweb -ldflags "$LDFLAGS" -o dist/elasticclaw-linux-amd64   .
+          CGO_ENABLED=0 GOOS=linux   GOARCH=arm64 go build -tags embedweb -ldflags "$LDFLAGS" -o dist/elasticclaw-linux-arm64   .
           GOOS=darwin  GOARCH=amd64 go build -tags embedweb -ldflags "$LDFLAGS" -o dist/elasticclaw-darwin-amd64  .
           GOOS=darwin  GOARCH=arm64 go build -tags embedweb -ldflags "$LDFLAGS" -o dist/elasticclaw-darwin-arm64  .
           GOOS=windows GOARCH=amd64 go build -tags embedweb -ldflags "$LDFLAGS" -o dist/elasticclaw-windows-amd64.exe .
 
           # claw-bridge (VM-side agent; only needs linux/amd64)
-          GOOS=linux GOARCH=amd64 go build -ldflags "$LDFLAGS" -o dist/claw-bridge-linux-amd64 ./cmd/claw-bridge/
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "$LDFLAGS" -o dist/claw-bridge-linux-amd64 ./cmd/claw-bridge/
 
           # Checksums
           cd dist && sha256sum * > checksums.txt


### PR DESCRIPTION
## Summary
- build Linux release binaries with 
- do the same for the Linux claw-bridge artifact

## Why
Amazon Linux failed to start the released  binary with:
- 
- 

The release workflow was building Linux binaries on Ubuntu 24.04 with default CGO settings, which can pull in newer glibc requirements. Disabling CGO for the Linux artifacts makes them much more portable across older glibc environments like Amazon Linux.

## Validation
-  in 
- 
- /tmp/elasticclaw-linux-amd64-test: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, BuildID[sha1]=1fd504708c6d2789df1e70088d6a2552eff5a911, with debug_info, not stripped
