### PR TITLE
fix: terminate daytona workspaces when killing claws

### DIFF
--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -974,9 +974,9 @@ func (s *Server) handleClawDetail(w http.ResponseWriter, r *http.Request) {
 			delete(s.claws, clawID)
 		}
 		s.mu.Unlock()
-		// Terminate the provider VM asynchronously
-		if provider == "replicated" && providerID != "" {
-			go s.terminateReplicatedVM(providerID)
+		// Terminate the provider instance asynchronously
+		if providerID != "" {
+			go s.terminateVM(provider, providerID)
 		}
 		w.WriteHeader(http.StatusNoContent)
 		return


### PR DESCRIPTION
## Summary
- make UI/API claw deletion terminate provider instances for all supported providers
- fix Daytona claws being recreated after kill because the workspace/bridge kept running

## Why
The hub delete path removed the claw row and disconnected the WebSocket, but only actually terminated provider instances for The 'replicated' CLI allows Replicated customers (vendors) to manage their Commercial Software Distribution Lifecycle (CSDL) using the Replicated API.


Usage:
  replicated [command]

Available Commands:
  api               Make ad-hoc API calls to the Replicated API
  app               Manage applications
  channel           List channels
  cluster           Manage test Kubernetes clusters.
  completion        Generate completion script
  config            Manage .replicated configuration
  customer          Manage customers
  default           Manage default values used by other commands
  installer         Manage Kubernetes installers
  instance          Manage instances
  login             Log in to Replicated
  logout            Logout from Replicated
  network           Manage test networks for VMs and Clusters
  profile           Manage authentication profiles
  registry          Manage registries
  release           Manage app releases
  version           Print the current version and exit
  vm                Manage test virtual machines.

Flags:
      --app string       The app slug or app id to use in all calls
      --debug            Enable debug output
  -h, --help             help for replicated
      --profile string   The authentication profile to use for this command
      --token string     The API token to use to access your app in the Vendor API

Use "replicated [command] --help" for more information about a command.. Daytona workspaces stayed alive, so the bridge reconnected and re-registered the claw, making it appear to come back from the dead.

## Testing
- ok  	github.com/elasticclaw/elasticclaw/pkg/hub	(cached)
?   	github.com/elasticclaw/elasticclaw/pkg/hub/factorytest	[no test files]
ok  	github.com/elasticclaw/elasticclaw/pkg/hub/pipeline	(cached)
?   	github.com/elasticclaw/elasticclaw/cmd	[no test files]
?   	github.com/elasticclaw/elasticclaw/cmd/bootopt	[no test files]
?   	github.com/elasticclaw/elasticclaw/cmd/claw-bridge	[no test files]
