### PR TITLE
fix: create OpenClaw config path during Daytona bootstrap

### DIFF
--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -1178,6 +1178,7 @@ func newHTTPProxy(send func(hubMsg) error) *httpProxy {
 }
 
 func (p *httpProxy) deliver(res httpProxyRes) {
+	log.Printf("[bridge-proxy] deliver req_id=%s status=%d body_len=%d", res.ReqID, res.Status, len(res.Body))
 	p.mu.Lock()
 	ch, ok := p.pending[res.ReqID]
 	if ok {
@@ -1186,6 +1187,8 @@ func (p *httpProxy) deliver(res httpProxyRes) {
 	p.mu.Unlock()
 	if ok {
 		ch <- res
+	} else {
+		log.Printf("[bridge-proxy] deliver dropped req_id=%s (no pending waiter)", res.ReqID)
 	}
 }
 
@@ -1196,6 +1199,7 @@ func (p *httpProxy) ready() bool {
 }
 
 func (p *httpProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	log.Printf("[bridge-proxy] incoming %s %s?%s", r.Method, r.URL.Path, r.URL.RawQuery)
 	// Wait up to 30s for the bridge to connect to the hub
 	for i := 0; i < 30; i++ {
 		if p.ready() {
@@ -1204,6 +1208,7 @@ func (p *httpProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(1 * time.Second)
 	}
 	if !p.ready() {
+		log.Printf("[bridge-proxy] not ready for %s %s", r.Method, r.URL.Path)
 		http.Error(w, "bridge not connected to hub", http.StatusServiceUnavailable)
 		return
 	}
@@ -1236,10 +1241,13 @@ func (p *httpProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	sendFn := p.send
 	p.mu.Unlock()
 	if sendFn == nil {
+		log.Printf("[bridge-proxy] sendFn nil req_id=%s", reqID)
 		http.Error(w, "bridge not connected", http.StatusServiceUnavailable)
 		return
 	}
+	log.Printf("[bridge-proxy] forwarding req_id=%s path=%s", reqID, req.Path)
 	if err := sendFn(hubMsg{Type: "http_proxy_req", Payload: mustJSON(req)}); err != nil {
+		log.Printf("[bridge-proxy] send error req_id=%s err=%v", reqID, err)
 		p.mu.Lock()
 		delete(p.pending, reqID)
 		p.mu.Unlock()
@@ -1249,9 +1257,11 @@ func (p *httpProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	select {
 	case res := <-ch:
+		log.Printf("[bridge-proxy] response req_id=%s status=%d body_len=%d", reqID, res.Status, len(res.Body))
 		w.WriteHeader(res.Status)
 		_, _ = w.Write([]byte(res.Body))
 	case <-time.After(10 * time.Second):
+		log.Printf("[bridge-proxy] timeout req_id=%s path=%s", reqID, req.Path)
 		p.mu.Lock()
 		delete(p.pending, reqID)
 		p.mu.Unlock()

--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -1257,7 +1257,7 @@ func (p *httpProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	select {
 	case res := <-ch:
-		log.Printf("[bridge-proxy] response req_id=%s status=%d body_len=%d body=%q", reqID, res.Status, len(res.Body), res.Body)
+		log.Printf("[bridge-proxy] response req_id=%s status=%d body_len=%d", reqID, res.Status, len(res.Body))
 		w.WriteHeader(res.Status)
 		_, _ = w.Write([]byte(res.Body))
 	case <-time.After(10 * time.Second):

--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -1245,7 +1245,7 @@ func (p *httpProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "bridge not connected", http.StatusServiceUnavailable)
 		return
 	}
-	log.Printf("[bridge-proxy] forwarding req_id=%s path=%s", reqID, req.Path)
+	log.Printf("[bridge-proxy] forwarding req_id=%s method=%s path=%s query=%s headers=%v body_len=%d", reqID, req.Method, req.Path, req.Query, req.Header, len(req.Body))
 	if err := sendFn(hubMsg{Type: "http_proxy_req", Payload: mustJSON(req)}); err != nil {
 		log.Printf("[bridge-proxy] send error req_id=%s err=%v", reqID, err)
 		p.mu.Lock()
@@ -1257,7 +1257,7 @@ func (p *httpProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	select {
 	case res := <-ch:
-		log.Printf("[bridge-proxy] response req_id=%s status=%d body_len=%d", reqID, res.Status, len(res.Body))
+		log.Printf("[bridge-proxy] response req_id=%s status=%d body_len=%d body=%q", reqID, res.Status, len(res.Body), res.Body)
 		w.WriteHeader(res.Status)
 		_, _ = w.Write([]byte(res.Body))
 	case <-time.After(10 * time.Second):

--- a/pkg/hub/bootstrap.go
+++ b/pkg/hub/bootstrap.go
@@ -158,10 +158,13 @@ func buildOpenClawProviderConfig(keys []*types.LLMKeyConfig, selectedKeyName str
 	return fmt.Sprintf(`python3 << 'PYEOF'
 import json, os
 path = os.path.expanduser('~/.openclaw/openclaw.json')
+os.makedirs(os.path.dirname(path), exist_ok=True)
 try:
     with open(path) as f:
         config = json.load(f)
-except:
+except FileNotFoundError:
+    config = {}
+except Exception:
     config = {}
 model = os.environ.get('OPENCLAW_DEFAULT_MODEL', 'anthropic/claude-sonnet-4-6')
 config.setdefault('agents', {}).setdefault('defaults', {})['model'] = model

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -40,6 +40,7 @@ func migrate(db *sql.DB) error {
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN auto_fix_bugbot INTEGER NOT NULL DEFAULT 1`)
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN llm_key TEXT NOT NULL DEFAULT ''`)
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN pipeline_stage TEXT NOT NULL DEFAULT ''`)
+	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN bootstrap_ok INTEGER NOT NULL DEFAULT 0`)
 	_, _ = db.Exec(`ALTER TABLE claw_prs ADD COLUMN last_comment_at TEXT NOT NULL DEFAULT ''`)
 	_, _ = db.Exec(`ALTER TABLE claw_prs ADD COLUMN pr_conditions_fired INTEGER NOT NULL DEFAULT 0`)
 
@@ -77,7 +78,8 @@ func migrate(db *sql.DB) error {
 		auto_fix_ci      INTEGER NOT NULL DEFAULT 1,
 		auto_fix_bugbot  INTEGER NOT NULL DEFAULT 1,
 		llm_key          TEXT NOT NULL DEFAULT '',
-		pipeline_stage   TEXT NOT NULL DEFAULT ''
+		pipeline_stage   TEXT NOT NULL DEFAULT '',
+		bootstrap_ok     INTEGER NOT NULL DEFAULT 0
 	);
 
 

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -143,6 +143,9 @@ func (s *Server) pollAllPRs() {
 		WHERE cl.status NOT IN ('deleted','error','offline')
 	`)
 	if err != nil {
+		if strings.Contains(err.Error(), "database is closed") {
+			return
+		}
 		log.Printf("[pr-watcher] poll query error: %v", err)
 		return
 	}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2167,17 +2167,21 @@ sudo chmod +x /etc/profile.d/elasticclaw-github.sh
 			}
 
 			ghAuthScript := `export HOME=/home/daytona
+set -x
 . /etc/profile.d/elasticclaw-github.sh
-command -v gh >/dev/null 2>&1 || exit 1
-[ -n "$GH_TOKEN" ] || exit 1
-echo "$GH_TOKEN" | gh auth login --with-token >/dev/null 2>&1`
+command -v gh
+[ -n "$GH_TOKEN" ]
+printf 'gh_token_len=%s\n' "${#GH_TOKEN}"
+gh --version
+echo "$GH_TOKEN" | gh auth login --with-token`
 			if err := exec("auth gh cli", 30*time.Second, ghAuthScript); err != nil {
 				return fmt.Errorf("auth gh cli: %w", err)
 			}
 
 			ghStatusScript := `export HOME=/home/daytona
+set -x
 . /etc/profile.d/elasticclaw-github.sh
-gh auth status >/dev/null 2>&1`
+gh auth status`
 			if err := exec("verify gh auth", 20*time.Second, ghStatusScript); err != nil {
 				return fmt.Errorf("verify gh auth: %w", err)
 			}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1904,8 +1904,9 @@ echo uninstalled`); err != nil {
 	}
 
 	if err := exec("install openclaw", 3*time.Minute,
-		`NPM="/usr/local/share/nvm/current/bin/npm"; \
-sudo "$NPM" install -g openclaw@latest --ignore-scripts 2>&1 && echo 'install done'`); err != nil {
+		`export NVM_DIR=/usr/local/share/nvm; export PATH=$NVM_DIR/current/bin:$PATH; \
+PREFIX="$(/usr/local/share/nvm/current/bin/npm config get prefix)"; \
+sudo env PATH="$NVM_DIR/current/bin:$PATH" npm install -g openclaw@latest --prefix "$PREFIX" --ignore-scripts 2>&1 && echo 'install done'`); err != nil {
 		return err
 	}
 
@@ -1926,12 +1927,16 @@ openclaw --version`); err != nil {
 	providerConfigScript := buildOpenClawProviderConfig(s.hubCfg.LLMKeys, llmKeyNameDaytona)
 	s.mu.RUnlock()
 	onboardCmd := fmt.Sprintf(
-		"%sexport NVM_DIR=/usr/local/share/nvm; export PATH=$NVM_DIR/current/bin:$PATH; openclaw onboard --non-interactive --accept-risk --skip-daemon %s 2>&1 || true",
+		"%sexport NVM_DIR=/usr/local/share/nvm; export PATH=$NVM_DIR/current/bin:$PATH; openclaw onboard --non-interactive --accept-risk --skip-daemon %s 2>&1",
 		llmKeyEnvDaytona,
 		onboardFlags,
 	)
 	if err := exec("onboard openclaw", 2*time.Minute, onboardCmd); err != nil {
-		return err
+		result, diagErr := p.ExecWithTimeout(ctx, instanceID, []string{"bash", "-c", `export HOME=/home/daytona; [ -f "$HOME/.openclaw/openclaw.json" ] && echo exists || echo missing`}, 10*time.Second)
+		if diagErr != nil || strings.TrimSpace(result.Stdout) != "exists" {
+			return err
+		}
+		log.Printf("[daytona] onboard returned non-zero, but config file exists; continuing")
 	}
 
 	dumpOpenClawState := func(reason string) {
@@ -1958,13 +1963,6 @@ openclaw --version`); err != nil {
 	}
 
 	dumpOpenClawState("post-onboard")
-
-	// Step 2b: Wait for OpenClaw to materialize its config, then patch it.
-	if err := exec("wait for openclaw config", 30*time.Second,
-		`export HOME=/home/daytona; for i in $(seq 1 30); do [ -f "$HOME/.openclaw/openclaw.json" ] && exit 0; sleep 1; done; echo "openclaw config file not created"; exit 1`); err != nil {
-		dumpOpenClawState("missing-openclaw-config")
-		return err
-	}
 	if providerConfigScript != "" {
 		configPatch := fmt.Sprintf("export HOME=/home/daytona; export OPENCLAW_DEFAULT_MODEL=%q; ", defaultModelDaytona) + llmKeyEnvDaytona + providerConfigScript
 		if err := exec("configure openclaw model", 30*time.Second, configPatch); err != nil {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1931,12 +1931,22 @@ openclaw --version`); err != nil {
 		llmKeyEnvDaytona,
 		onboardFlags,
 	)
-	if err := exec("onboard openclaw", 2*time.Minute, onboardCmd); err != nil {
+	log.Printf("[daytona] onboard openclaw...")
+	onboardResult, onboardErr := p.ExecWithTimeout(ctx, instanceID, []string{"bash", "-c", "export HOME=/home/daytona; " + onboardCmd}, 2*time.Minute)
+	if onboardErr != nil {
 		result, diagErr := p.ExecWithTimeout(ctx, instanceID, []string{"bash", "-c", `export HOME=/home/daytona; [ -f "$HOME/.openclaw/openclaw.json" ] && echo exists || echo missing`}, 10*time.Second)
 		if diagErr != nil || strings.TrimSpace(result.Stdout) != "exists" {
-			return err
+			return fmt.Errorf("onboard openclaw: %w", onboardErr)
+		}
+		log.Printf("[daytona] onboard returned error, but config file exists; continuing")
+	} else if onboardResult.ExitCode != 0 {
+		result, diagErr := p.ExecWithTimeout(ctx, instanceID, []string{"bash", "-c", `export HOME=/home/daytona; [ -f "$HOME/.openclaw/openclaw.json" ] && echo exists || echo missing`}, 10*time.Second)
+		if diagErr != nil || strings.TrimSpace(result.Stdout) != "exists" {
+			return fmt.Errorf("onboard openclaw failed (exit %d): %s", onboardResult.ExitCode, onboardResult.Stdout)
 		}
 		log.Printf("[daytona] onboard returned non-zero, but config file exists; continuing")
+	} else {
+		log.Printf("[daytona] onboard openclaw done")
 	}
 
 	dumpOpenClawState := func(reason string) {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2113,7 +2113,14 @@ command -v gh >/dev/null 2>&1 && gh --version >/dev/null 2>&1`
 			}
 
 			fetchGitHubTokenJSON := fmt.Sprintf(`export HOME=/home/daytona
-curl -sf --max-time 35 %q -o /tmp/elasticclaw-github-token.json
+rm -f /tmp/elasticclaw-github-token.json
+curl -sv --max-time 35 %q -o /tmp/elasticclaw-github-token.json
+status=$?
+echo "curl_exit=$status"
+ls -l /tmp/elasticclaw-github-token.json 2>&1 || true
+echo '--- token json ---'
+cat /tmp/elasticclaw-github-token.json 2>&1 || true
+[ $status -eq 0 ] || exit $status
 [ -s /tmp/elasticclaw-github-token.json ] || exit 1
 `, tokenURL)
 			if err := exec("fetch github bootstrap token json", 45*time.Second, fetchGitHubTokenJSON); err != nil {
@@ -2125,11 +2132,18 @@ python3 - <<'PYEOF' > /tmp/elasticclaw-github-token.txt
 import json
 with open('/tmp/elasticclaw-github-token.json') as f:
     data = json.load(f)
-token = data.get('token', '')
-if not token:
-    raise SystemExit(1)
-print(token)
+print(data.get('token', ''))
 PYEOF
+status=$?
+echo "python_exit=$status"
+ls -l /tmp/elasticclaw-github-token.txt 2>&1 || true
+echo '--- parsed token length ---'
+python3 - <<'PYEOF'
+from pathlib import Path
+p = Path('/tmp/elasticclaw-github-token.txt')
+print(len(p.read_text().strip()) if p.exists() else 0)
+PYEOF
+[ $status -eq 0 ] || exit $status
 [ -s /tmp/elasticclaw-github-token.txt ] || exit 1`
 			if err := exec("parse github bootstrap token", 20*time.Second, parseGitHubToken); err != nil {
 				return fmt.Errorf("parse github bootstrap token: %w", err)

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2102,6 +2102,26 @@ exit 1`, tokenURL)
 		if err := exec("install git credential helper", 20*time.Second, credHelperScript); err != nil {
 			return fmt.Errorf("install git credential helper: %w", err)
 		} else {
+			installGhScript := `export HOME=/home/daytona
+if command -v gh >/dev/null 2>&1; then
+  gh --version >/dev/null 2>&1
+  exit 0
+fi
+if command -v apt-get >/dev/null 2>&1; then
+  sudo apt-get update -qq && sudo apt-get install -y gh
+elif command -v dnf >/dev/null 2>&1; then
+  sudo dnf install -y gh
+elif command -v yum >/dev/null 2>&1; then
+  sudo yum install -y gh
+else
+  echo 'unsupported package manager for gh install'
+  exit 1
+fi
+command -v gh >/dev/null 2>&1 && gh --version >/dev/null 2>&1`
+			if err := exec("install gh cli", 2*time.Minute, installGhScript); err != nil {
+				return fmt.Errorf("install gh cli: %w", err)
+			}
+
 			// Step 5b: fetch one bootstrap token and reuse it for gh + clone
 			bootstrapGitHubAuth := fmt.Sprintf(`export HOME=/home/daytona
 response=$(curl -sf --max-time 35 %q)
@@ -2110,9 +2130,8 @@ token=$(echo "$response" | python3 -c "import sys,json; print(json.load(sys.stdi
 [ -n "$token" ] || exit 1
 printf 'export GH_TOKEN=%s\n' "$token" | sudo tee /etc/profile.d/elasticclaw-github.sh > /dev/null
 sudo chmod +x /etc/profile.d/elasticclaw-github.sh
-if command -v gh &>/dev/null; then
-  echo "$token" | gh auth login --with-token 2>/dev/null && echo 'gh CLI authenticated' || echo 'gh auth failed'
-fi
+command -v gh >/dev/null 2>&1 || exit 1
+echo "$token" | gh auth login --with-token >/dev/null 2>&1 || exit 1
 if [ `+fmt.Sprintf("%d", len(githubRepos))+` -gt 0 ]; then
   cd ~/.openclaw/workspace
   FAILED=0

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2173,8 +2173,12 @@ command -v gh
 [ -n "$GH_TOKEN" ]
 printf 'gh_token_len=%s\n' "${#GH_TOKEN}"
 gh --version
+TOKEN="$(cat /tmp/elasticclaw-github-token.txt)"
+[ -n "$TOKEN" ]
+unset GH_TOKEN
 gh auth logout -h github.com || true
-gh auth login --hostname github.com --with-token < /tmp/elasticclaw-github-token.txt`
+printf '%s\n' "$TOKEN" | gh auth login --hostname github.com --with-token
+export GH_TOKEN="$TOKEN"`
 			log.Printf("[daytona] auth gh cli (no retries)...")
 			ghAuthResult, ghAuthErr := p.ExecWithTimeout(ctx, instanceID, []string{"bash", "-c", ghAuthScript}, 30*time.Second)
 			if ghAuthErr != nil {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1903,10 +1903,14 @@ echo uninstalled`); err != nil {
 		log.Printf("[daytona] warning: uninstall failed (ok if not installed): %v", err)
 	}
 
+	openclawVersion := Version
+	if openclawVersion == "" || openclawVersion == "dev" {
+		openclawVersion = "latest"
+	}
 	if err := exec("install openclaw", 3*time.Minute,
-		`export NVM_DIR=/usr/local/share/nvm; export PATH=$NVM_DIR/current/bin:$PATH; \
+		fmt.Sprintf(`export NVM_DIR=/usr/local/share/nvm; export PATH=$NVM_DIR/current/bin:$PATH; \
 PREFIX="$(/usr/local/share/nvm/current/bin/npm config get prefix)"; \
-sudo env PATH="$NVM_DIR/current/bin:$PATH" npm install -g openclaw@latest --prefix "$PREFIX" --ignore-scripts 2>&1 && echo 'install done'`); err != nil {
+sudo env PATH="$NVM_DIR/current/bin:$PATH" npm install -g openclaw@%s --prefix "$PREFIX" --ignore-scripts 2>&1 && echo 'install done'`, openclawVersion)); err != nil {
 		return err
 	}
 
@@ -1949,30 +1953,6 @@ openclaw --version`); err != nil {
 		log.Printf("[daytona] onboard openclaw done")
 	}
 
-	dumpOpenClawState := func(reason string) {
-		diagCmd := fmt.Sprintf(`export HOME=/home/daytona; \
- echo "=== %s ==="; \
- echo "HOME=$HOME"; \
- echo "pwd=$(pwd)"; \
- echo "--- ~/.openclaw ---"; \
- ls -la "$HOME/.openclaw" 2>&1 || true; \
- echo "--- ~/.openclaw tree ---"; \
- find "$HOME/.openclaw" -maxdepth 3 -mindepth 1 -print 2>&1 || true; \
- echo "--- openclaw.json ---"; \
- cat "$HOME/.openclaw/openclaw.json" 2>&1 || true; \
- echo "--- gateway.log ---"; \
- tail -n 100 "$HOME/.openclaw/gateway.log" 2>&1 || true`, reason)
-		result, err := p.ExecWithTimeout(ctx, instanceID, []string{"bash", "-c", diagCmd}, 30*time.Second)
-		if err != nil {
-			log.Printf("[daytona] warning: failed to collect OpenClaw diagnostics (%s): %v", reason, err)
-			return
-		}
-		if strings.TrimSpace(result.Stdout) != "" {
-			log.Printf("[daytona] diagnostics (%s):\n%s", reason, result.Stdout)
-		}
-	}
-
-	dumpOpenClawState("post-onboard")
 	if providerConfigScript != "" {
 		configPatch := fmt.Sprintf("export HOME=/home/daytona; export OPENCLAW_DEFAULT_MODEL=%q; ", defaultModelDaytona) + llmKeyEnvDaytona + providerConfigScript
 		if err := exec("configure openclaw model", 30*time.Second, configPatch); err != nil {
@@ -1994,8 +1974,13 @@ print('gateway config updated')
 PYEOF
 export NVM_DIR="/usr/local/share/nvm"; [ -s "$NVM_DIR/nvm.sh" ] && source "$NVM_DIR/nvm.sh"
 export NVM_DIR=/usr/local/share/nvm; export PATH=$NVM_DIR/current/bin:$PATH; setsid nohup openclaw gateway run >> ~/.openclaw/gateway.log 2>&1 </dev/null &
-sleep 8
-curl -sf http://localhost:18789/healthz && echo 'gateway ready' || echo 'gateway not ready yet'`
+for i in $(seq 1 20); do
+  curl -sf http://localhost:18789/healthz >/dev/null && echo 'gateway ready' && exit 0
+  sleep 2
+done
+echo 'gateway not ready'
+tail -n 100 ~/.openclaw/gateway.log 2>/dev/null || true
+exit 1`
 	if err := exec("start openclaw gateway", 2*time.Minute, gatewaySetup); err != nil {
 		return err
 	}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2173,18 +2173,32 @@ command -v gh
 [ -n "$GH_TOKEN" ]
 printf 'gh_token_len=%s\n' "${#GH_TOKEN}"
 gh --version
-echo "$GH_TOKEN" | gh auth login --with-token`
-			if err := exec("auth gh cli", 30*time.Second, ghAuthScript); err != nil {
-				return fmt.Errorf("auth gh cli: %w", err)
+gh auth logout -h github.com || true
+echo "$GH_TOKEN" | gh auth login --hostname github.com --with-token`
+			log.Printf("[daytona] auth gh cli (no retries)...")
+			ghAuthResult, ghAuthErr := p.ExecWithTimeout(ctx, instanceID, []string{"bash", "-c", ghAuthScript}, 30*time.Second)
+			if ghAuthErr != nil {
+				return fmt.Errorf("auth gh cli: %w", ghAuthErr)
 			}
+			if ghAuthResult.ExitCode != 0 {
+				return fmt.Errorf("auth gh cli failed (exit %d): %s", ghAuthResult.ExitCode, ghAuthResult.Stdout)
+			}
+			log.Printf("[daytona] auth gh cli done")
 
 			ghStatusScript := `export HOME=/home/daytona
 set -x
 . /etc/profile.d/elasticclaw-github.sh
-gh auth status`
-			if err := exec("verify gh auth", 20*time.Second, ghStatusScript); err != nil {
-				return fmt.Errorf("verify gh auth: %w", err)
+gh auth status
+gh repo view can-io/canio >/dev/null`
+			log.Printf("[daytona] verify gh auth (no retries)...")
+			ghStatusResult, ghStatusErr := p.ExecWithTimeout(ctx, instanceID, []string{"bash", "-c", ghStatusScript}, 20*time.Second)
+			if ghStatusErr != nil {
+				return fmt.Errorf("verify gh auth: %w", ghStatusErr)
 			}
+			if ghStatusResult.ExitCode != 0 {
+				return fmt.Errorf("verify gh auth failed (exit %d): %s", ghStatusResult.ExitCode, ghStatusResult.Stdout)
+			}
+			log.Printf("[daytona] verify gh auth done")
 
 			cloneScript := "export HOME=/home/daytona; . /etc/profile.d/elasticclaw-github.sh; cd ~/.openclaw/workspace; git config --global --get credential.helper >/dev/null || exit 1; [ -n \"$GH_TOKEN\" ] || exit 1; "
 			for _, repo := range githubRepos {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2089,17 +2089,6 @@ echo 'credential helper installed'`, tokenURL)
 			time.Sleep(3 * time.Second)
 		}
 
-		waitTokenProxy := fmt.Sprintf(`export HOME=/home/daytona
-for i in $(seq 1 20); do
-  curl -sf --max-time 10 %q >/dev/null && exit 0
-  sleep 2
-done
-echo 'token proxy not ready'
-exit 1`, tokenURL)
-		if err := exec("wait for github token proxy", 45*time.Second, waitTokenProxy); err != nil {
-			return fmt.Errorf("github token proxy not ready: %w", err)
-		}
-
 		if err := exec("install git credential helper", 20*time.Second, credHelperScript); err != nil {
 			return fmt.Errorf("install git credential helper: %w", err)
 		} else {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1934,11 +1934,15 @@ openclaw --version`); err != nil {
 		return err
 	}
 
-	// Step 2b: Patch OpenClaw config with dynamic provider model list
+	// Step 2b: Wait for OpenClaw to materialize its config, then patch it.
+	if err := exec("wait for openclaw config", 30*time.Second,
+		`export HOME=/home/daytona; for i in $(seq 1 30); do [ -f "$HOME/.openclaw/openclaw.json" ] && exit 0; sleep 1; done; echo "openclaw config file not created"; exit 1`); err != nil {
+		return err
+	}
 	if providerConfigScript != "" {
 		configPatch := fmt.Sprintf("export HOME=/home/daytona; export OPENCLAW_DEFAULT_MODEL=%q; ", defaultModelDaytona) + llmKeyEnvDaytona + providerConfigScript
 		if err := exec("configure openclaw model", 30*time.Second, configPatch); err != nil {
-			log.Printf("[daytona] warning: failed to configure model: %v", err)
+			return err
 		}
 	}
 	// Let openclaw self-heal any remaining config schema issues

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1927,7 +1927,7 @@ openclaw --version`); err != nil {
 	providerConfigScript := buildOpenClawProviderConfig(s.hubCfg.LLMKeys, llmKeyNameDaytona)
 	s.mu.RUnlock()
 	onboardCmd := fmt.Sprintf(
-		"%sexport NVM_DIR=/usr/local/share/nvm; export PATH=$NVM_DIR/current/bin:$PATH; openclaw onboard --non-interactive --accept-risk --skip-daemon %s 2>&1",
+		"%sexport NVM_DIR=/usr/local/share/nvm; export PATH=$NVM_DIR/current/bin:$PATH; openclaw onboard --non-interactive --accept-risk --skip-daemon --skip-health %s 2>&1",
 		llmKeyEnvDaytona,
 		onboardFlags,
 	)

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1979,12 +1979,6 @@ openclaw --version`); err != nil {
 			return err
 		}
 	}
-	// Let openclaw self-heal any remaining config schema issues
-	_ = exec("openclaw doctor fix", 20*time.Second,
-		"export HOME=/home/daytona NVM_DIR=/usr/local/share/nvm; "+
-			"export PATH=$NVM_DIR/current/bin:$PATH; "+
-			"openclaw doctor --fix 2>&1 || true")
-
 	// Step 2c: Configure gateway bind/port and start it.
 	// Use token auth (what onboard sets up) — don't override auth mode.
 	gatewaySetup := `

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2112,16 +2112,37 @@ command -v gh >/dev/null 2>&1 && gh --version >/dev/null 2>&1`
 				return fmt.Errorf("install gh cli: %w", err)
 			}
 
-			bootstrapGitHubToken := fmt.Sprintf(`export HOME=/home/daytona
-response=$(curl -sf --max-time 35 %q)
-[ -n "$response" ] || exit 1
-token=$(echo "$response" | python3 -c "import sys,json; print(json.load(sys.stdin)['token'])")
-[ -n "$token" ] || exit 1
-printf 'export GH_TOKEN=%%s\n' "$token" | sudo tee /etc/profile.d/elasticclaw-github.sh > /dev/null
-sudo chmod +x /etc/profile.d/elasticclaw-github.sh
+			fetchGitHubTokenJSON := fmt.Sprintf(`export HOME=/home/daytona
+curl -sf --max-time 35 %q -o /tmp/elasticclaw-github-token.json
+[ -s /tmp/elasticclaw-github-token.json ] || exit 1
 `, tokenURL)
-			if err := exec("fetch github bootstrap token", 45*time.Second, bootstrapGitHubToken); err != nil {
-				return fmt.Errorf("fetch github bootstrap token: %w", err)
+			if err := exec("fetch github bootstrap token json", 45*time.Second, fetchGitHubTokenJSON); err != nil {
+				return fmt.Errorf("fetch github bootstrap token json: %w", err)
+			}
+
+			parseGitHubToken := `export HOME=/home/daytona
+python3 - <<'PYEOF' > /tmp/elasticclaw-github-token.txt
+import json
+with open('/tmp/elasticclaw-github-token.json') as f:
+    data = json.load(f)
+token = data.get('token', '')
+if not token:
+    raise SystemExit(1)
+print(token)
+PYEOF
+[ -s /tmp/elasticclaw-github-token.txt ] || exit 1`
+			if err := exec("parse github bootstrap token", 20*time.Second, parseGitHubToken); err != nil {
+				return fmt.Errorf("parse github bootstrap token: %w", err)
+			}
+
+			writeGitHubTokenEnv := `export HOME=/home/daytona
+TOKEN=$(cat /tmp/elasticclaw-github-token.txt)
+[ -n "$TOKEN" ] || exit 1
+printf 'export GH_TOKEN=%s\n' "$TOKEN" | sudo tee /etc/profile.d/elasticclaw-github.sh > /dev/null
+sudo chmod +x /etc/profile.d/elasticclaw-github.sh
+[ -s /etc/profile.d/elasticclaw-github.sh ] || exit 1`
+			if err := exec("write github token env", 20*time.Second, writeGitHubTokenEnv); err != nil {
+				return fmt.Errorf("write github token env: %w", err)
 			}
 
 			ghAuthScript := `export HOME=/home/daytona

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2121,12 +2121,10 @@ command -v gh >/dev/null 2>&1 && gh --version >/dev/null 2>&1`
 
 			fetchGitHubTokenJSON := fmt.Sprintf(`export HOME=/home/daytona
 rm -f /tmp/elasticclaw-github-token.json
-curl -sv --max-time 35 %q -o /tmp/elasticclaw-github-token.json
+curl -sf --max-time 35 %q -o /tmp/elasticclaw-github-token.json
 status=$?
 echo "curl_exit=$status"
 ls -l /tmp/elasticclaw-github-token.json 2>&1 || true
-echo '--- token json ---'
-cat /tmp/elasticclaw-github-token.json 2>&1 || true
 [ $status -eq 0 ] || exit $status
 [ -s /tmp/elasticclaw-github-token.json ] || exit 1
 `, tokenURL)
@@ -2144,12 +2142,6 @@ PYEOF
 status=$?
 echo "python_exit=$status"
 ls -l /tmp/elasticclaw-github-token.txt 2>&1 || true
-echo '--- parsed token length ---'
-python3 - <<'PYEOF'
-from pathlib import Path
-p = Path('/tmp/elasticclaw-github-token.txt')
-print(len(p.read_text().strip()) if p.exists() else 0)
-PYEOF
 [ $status -eq 0 ] || exit $status
 [ -s /tmp/elasticclaw-github-token.txt ] || exit 1`
 			if err := exec("parse github bootstrap token", 20*time.Second, parseGitHubToken); err != nil {
@@ -2171,7 +2163,6 @@ set -x
 . /etc/profile.d/elasticclaw-github.sh
 command -v gh
 [ -n "$GH_TOKEN" ]
-printf 'gh_token_len=%s\n' "${#GH_TOKEN}"
 gh --version
 TOKEN="$(cat /tmp/elasticclaw-github-token.txt)"
 [ -n "$TOKEN" ]
@@ -3482,7 +3473,7 @@ func (s *Server) handleGitHubToken(w http.ResponseWriter, r *http.Request) {
 			log.Printf("[github] app[%d] app_id=%d: no match for repos (trying next): %v", i, appCfg.AppID, err)
 			continue
 		}
-		log.Printf("github token issued via app_id=%d (url=%s) for claw %s", appCfg.AppID, appCfg.URL, clawID[:8])
+		log.Printf("github token issued via app_id=%d for claw %s", appCfg.AppID, clawID[:8])
 		jsonOK(w, map[string]interface{}{
 			"token":      token,
 			"expires_at": expiresAt,

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1216,7 +1216,9 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 
 	var registrationTagsJSON string
 	var bootstrapOK int
-	_ = s.db.QueryRow(`SELECT COALESCE(tags,'[]'), COALESCE(bootstrap_ok,0) FROM claws WHERE id = ? AND tenant_id = ?`, clawID, tenantID).Scan(&registrationTagsJSON, &bootstrapOK)
+	var provider string
+	_ = s.db.QueryRow(`SELECT COALESCE(tags,'[]'), COALESCE(bootstrap_ok,0), COALESCE(provider,'') FROM claws WHERE id = ? AND tenant_id = ?`, clawID, tenantID).Scan(&registrationTagsJSON, &bootstrapOK, &provider)
+	allowWake := bootstrapOK == 1 || provider != "daytona"
 	var registrationTags []string
 	_ = json.Unmarshal([]byte(registrationTagsJSON), &registrationTags)
 	cc := &clawConn{id: clawID, tenantID: tenantID, conn: conn, gatewayReady: gatewayReadyBool(rp.GatewayReady), tags: registrationTags}
@@ -1235,12 +1237,12 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 	// Initialize entry pipeline stage only after bridge connects so on_enter inject
 	// can be delivered over WS.
 	usedPipelineEntryInject := false
-	if bootstrapOK == 1 && cc.gatewayReady && currentStatus == "connected" {
+	if allowWake && cc.gatewayReady && currentStatus == "connected" {
 		usedPipelineEntryInject = s.initializePipelineEntryIfNeeded(clawID)
 	}
 	// If no pipeline entry inject was sent, fire the default wake message.
 	// But don't re-wake claws that already have a pipeline stage (hub restart reconnect).
-	if bootstrapOK == 1 && cc.gatewayReady && currentStatus == "connected" && !usedPipelineEntryInject {
+	if allowWake && cc.gatewayReady && currentStatus == "connected" && !usedPipelineEntryInject {
 		if s.getPipelineStage(clawID) == "" && !s.clawHasMessages(clawID) {
 			go s.sendWakeMessage(cc, clawID)
 		}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1934,9 +1934,34 @@ openclaw --version`); err != nil {
 		return err
 	}
 
+	dumpOpenClawState := func(reason string) {
+		result, err := p.ExecWithTimeout(ctx, instanceID, []string{"bash", "-c", `export HOME=/home/daytona; \
++echo "=== ` + reason + ` ==="; \
++echo "HOME=$HOME"; \
++echo "pwd=$(pwd)"; \
++echo "--- ~/.openclaw ---"; \
++ls -la "$HOME/.openclaw" 2>&1 || true; \
++echo "--- ~/.openclaw tree ---"; \
++find "$HOME/.openclaw" -maxdepth 3 -mindepth 1 -print 2>&1 || true; \
++echo "--- openclaw.json ---"; \
++cat "$HOME/.openclaw/openclaw.json" 2>&1 || true; \
++echo "--- gateway.log ---"; \
++tail -n 100 "$HOME/.openclaw/gateway.log" 2>&1 || true`}, 30*time.Second)
+		if err != nil {
+			log.Printf("[daytona] warning: failed to collect OpenClaw diagnostics (%s): %v", reason, err)
+			return
+		}
+		if strings.TrimSpace(result.Stdout) != "" {
+			log.Printf("[daytona] diagnostics (%s):\n%s", reason, result.Stdout)
+		}
+	}
+
+	dumpOpenClawState("post-onboard")
+
 	// Step 2b: Wait for OpenClaw to materialize its config, then patch it.
 	if err := exec("wait for openclaw config", 30*time.Second,
 		`export HOME=/home/daytona; for i in $(seq 1 30); do [ -f "$HOME/.openclaw/openclaw.json" ] && exit 0; sleep 1; done; echo "openclaw config file not created"; exit 1`); err != nil {
+		dumpOpenClawState("missing-openclaw-config")
 		return err
 	}
 	if providerConfigScript != "" {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1903,14 +1903,11 @@ echo uninstalled`); err != nil {
 		log.Printf("[daytona] warning: uninstall failed (ok if not installed): %v", err)
 	}
 
-	openclawVersion := Version
-	if openclawVersion == "" || openclawVersion == "dev" {
-		openclawVersion = "latest"
-	}
+	const daytonaOpenClawVersion = "2026.4.27"
 	if err := exec("install openclaw", 3*time.Minute,
 		fmt.Sprintf(`export NVM_DIR=/usr/local/share/nvm; export PATH=$NVM_DIR/current/bin:$PATH; \
 PREFIX="$(/usr/local/share/nvm/current/bin/npm config get prefix)"; \
-sudo env PATH="$NVM_DIR/current/bin:$PATH" npm install -g openclaw@%s --prefix "$PREFIX" --ignore-scripts 2>&1 && echo 'install done'`, openclawVersion)); err != nil {
+sudo env PATH="$NVM_DIR/current/bin:$PATH" npm install -g openclaw@%s --prefix "$PREFIX" --ignore-scripts 2>&1 && echo 'install done'`, daytonaOpenClawVersion)); err != nil {
 		return err
 	}
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1506,8 +1506,10 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 						Header map[string]string `json:"header"`
 					}
 					if err := json.Unmarshal(rawPayload, &req); err != nil {
+						log.Printf("[hub-proxy] bad req payload: %v", err)
 						return
 					}
+					log.Printf("[hub-proxy] req req_id=%s %s %s?%s", req.ReqID, req.Method, req.Path, req.Query)
 					// Build an internal HTTP request
 					urls := req.Path
 					if req.Query != "" {
@@ -1515,6 +1517,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 					}
 					httpReq, err := http.NewRequest(req.Method, "http://localhost"+urls, strings.NewReader(req.Body))
 					if err != nil {
+						log.Printf("[hub-proxy] build request failed req_id=%s err=%v", req.ReqID, err)
 						s.sendHTTPProxyRes(ctx, conn, req.ReqID, 400, "bad request")
 						return
 					}
@@ -1529,6 +1532,10 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 					// Execute against internal mux
 					w := &proxyResponseWriter{header: make(http.Header)}
 					s.mux.ServeHTTP(w, httpReq)
+					if w.status == 0 {
+						w.status = 200
+					}
+					log.Printf("[hub-proxy] res req_id=%s status=%d body_len=%d", req.ReqID, w.status, len(w.body))
 					s.sendHTTPProxyRes(ctx, conn, req.ReqID, w.status, string(w.body))
 				}(mustJSONRaw(msg.Payload), conn)
 			}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2112,33 +2112,45 @@ command -v gh >/dev/null 2>&1 && gh --version >/dev/null 2>&1`
 				return fmt.Errorf("install gh cli: %w", err)
 			}
 
-			// Step 5b: fetch one bootstrap token and reuse it for gh + clone
-			bootstrapGitHubAuth := fmt.Sprintf(`export HOME=/home/daytona
+			bootstrapGitHubToken := fmt.Sprintf(`export HOME=/home/daytona
 response=$(curl -sf --max-time 35 %q)
 [ -n "$response" ] || exit 1
 token=$(echo "$response" | python3 -c "import sys,json; print(json.load(sys.stdin)['token'])")
 [ -n "$token" ] || exit 1
-printf 'export GH_TOKEN=%s\n' "$token" | sudo tee /etc/profile.d/elasticclaw-github.sh > /dev/null
+printf 'export GH_TOKEN=%%s\n' "$token" | sudo tee /etc/profile.d/elasticclaw-github.sh > /dev/null
 sudo chmod +x /etc/profile.d/elasticclaw-github.sh
-command -v gh >/dev/null 2>&1 || exit 1
-echo "$token" | gh auth login --with-token >/dev/null 2>&1 || exit 1
-if [ `+fmt.Sprintf("%d", len(githubRepos))+` -gt 0 ]; then
-  cd ~/.openclaw/workspace
-  FAILED=0
 `, tokenURL)
+			if err := exec("fetch github bootstrap token", 45*time.Second, bootstrapGitHubToken); err != nil {
+				return fmt.Errorf("fetch github bootstrap token: %w", err)
+			}
+
+			ghAuthScript := `export HOME=/home/daytona
+. /etc/profile.d/elasticclaw-github.sh
+command -v gh >/dev/null 2>&1 || exit 1
+[ -n "$GH_TOKEN" ] || exit 1
+echo "$GH_TOKEN" | gh auth login --with-token >/dev/null 2>&1`
+			if err := exec("auth gh cli", 30*time.Second, ghAuthScript); err != nil {
+				return fmt.Errorf("auth gh cli: %w", err)
+			}
+
+			ghStatusScript := `export HOME=/home/daytona
+. /etc/profile.d/elasticclaw-github.sh
+gh auth status >/dev/null 2>&1`
+			if err := exec("verify gh auth", 20*time.Second, ghStatusScript); err != nil {
+				return fmt.Errorf("verify gh auth: %w", err)
+			}
+
+			cloneScript := "export HOME=/home/daytona; . /etc/profile.d/elasticclaw-github.sh; cd ~/.openclaw/workspace; git config --global --get credential.helper >/dev/null || exit 1; "
 			for _, repo := range githubRepos {
 				repoParts := strings.SplitN(repo.Repo, "/", 2)
 				repoName := repo.Repo
 				if len(repoParts) == 2 {
 					repoName = repoParts[1]
 				}
-				bootstrapGitHubAuth += fmt.Sprintf("if [ ! -d %q ]; then git clone https://x-access-token:$token@github.com/%s %s && echo 'Cloned %s' || FAILED=1; else git -C %s pull --ff-only && echo 'Updated %s' || FAILED=1; fi\n",
-					repoName, repo.Repo, repoName, repo.Repo, repoName, repo.Repo)
+				cloneScript += fmt.Sprintf("if [ ! -d %q ]; then git clone https://github.com/%s %s; else git -C %s pull --ff-only; fi; ", repoName, repo.Repo, repoName, repoName)
 			}
-			bootstrapGitHubAuth += "git config --global --get credential.helper >/dev/null || exit 1\n"
-			bootstrapGitHubAuth += "exit $FAILED\nfi\n"
-			if err := exec("auth gh cli and clone repos", 2*time.Minute, bootstrapGitHubAuth); err != nil {
-				return fmt.Errorf("bootstrap GitHub auth/clone failed: %w", err)
+			if err := exec("clone repos", 2*time.Minute, cloneScript); err != nil {
+				return fmt.Errorf("clone repos: %w", err)
 			}
 			if len(githubRepos) > 0 {
 				verifyCloneScript := "export HOME=/home/daytona; cd ~/.openclaw/workspace; "

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1935,18 +1935,19 @@ openclaw --version`); err != nil {
 	}
 
 	dumpOpenClawState := func(reason string) {
-		result, err := p.ExecWithTimeout(ctx, instanceID, []string{"bash", "-c", `export HOME=/home/daytona; \
-+echo "=== ` + reason + ` ==="; \
-+echo "HOME=$HOME"; \
-+echo "pwd=$(pwd)"; \
-+echo "--- ~/.openclaw ---"; \
-+ls -la "$HOME/.openclaw" 2>&1 || true; \
-+echo "--- ~/.openclaw tree ---"; \
-+find "$HOME/.openclaw" -maxdepth 3 -mindepth 1 -print 2>&1 || true; \
-+echo "--- openclaw.json ---"; \
-+cat "$HOME/.openclaw/openclaw.json" 2>&1 || true; \
-+echo "--- gateway.log ---"; \
-+tail -n 100 "$HOME/.openclaw/gateway.log" 2>&1 || true`}, 30*time.Second)
+		diagCmd := fmt.Sprintf(`export HOME=/home/daytona; \
+ echo "=== %s ==="; \
+ echo "HOME=$HOME"; \
+ echo "pwd=$(pwd)"; \
+ echo "--- ~/.openclaw ---"; \
+ ls -la "$HOME/.openclaw" 2>&1 || true; \
+ echo "--- ~/.openclaw tree ---"; \
+ find "$HOME/.openclaw" -maxdepth 3 -mindepth 1 -print 2>&1 || true; \
+ echo "--- openclaw.json ---"; \
+ cat "$HOME/.openclaw/openclaw.json" 2>&1 || true; \
+ echo "--- gateway.log ---"; \
+ tail -n 100 "$HOME/.openclaw/gateway.log" 2>&1 || true`, reason)
+		result, err := p.ExecWithTimeout(ctx, instanceID, []string{"bash", "-c", diagCmd}, 30*time.Second)
 		if err != nil {
 			log.Printf("[daytona] warning: failed to collect OpenClaw diagnostics (%s): %v", reason, err)
 			return

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2090,30 +2090,33 @@ echo 'credential helper installed'`, tokenURL)
 		if err := exec("install git credential helper", 20*time.Second, credHelperScript); err != nil {
 			log.Printf("[daytona] warning: credential helper install failed: %v", err)
 		} else {
-			// Step 5b: authenticate gh CLI
-			ghAuthScript := `export HOME=/home/daytona
+			// Step 5b: fetch one bootstrap token and reuse it for gh + clone
+			bootstrapGitHubAuth := fmt.Sprintf(`export HOME=/home/daytona
+response=$(curl -sf --max-time 35 %q)
+[ -n "$response" ] || exit 1
+token=$(echo "$response" | python3 -c "import sys,json; print(json.load(sys.stdin)['token'])")
+[ -n "$token" ] || exit 1
+printf 'export GH_TOKEN=%s\n' "$token" | sudo tee /etc/profile.d/elasticclaw-github.sh > /dev/null
+sudo chmod +x /etc/profile.d/elasticclaw-github.sh
 if command -v gh &>/dev/null; then
-  GH_TOKEN=$(/usr/local/bin/elasticclaw-git-credentials 2>/dev/null | grep ^password | cut -d= -f2)
-  if [ -n "$GH_TOKEN" ]; then
-    echo "$GH_TOKEN" | gh auth login --with-token 2>/dev/null && echo 'gh CLI authenticated' || echo 'gh auth failed'
-    printf 'export GH_TOKEN=$(/usr/local/bin/elasticclaw-git-credentials 2>/dev/null | grep ^password | cut -d= -f2)\n' | sudo tee /etc/profile.d/elasticclaw-github.sh > /dev/null
-    sudo chmod +x /etc/profile.d/elasticclaw-github.sh
-  fi
-else
-  echo 'gh not installed'
-fi`
-			if err := exec("auth gh cli", 20*time.Second, ghAuthScript); err != nil {
-				log.Printf("[daytona] warning: gh auth failed: %v", err)
-			}
-
-			// Step 5c: clone repos into workspace
-			if len(githubRepos) > 0 {
-				cloneScript := buildGitHubCloneScript(githubRepos)
-				if cloneScript != "" {
-					if err := exec("clone repos", 2*time.Minute, "export HOME=/home/daytona; cd ~/.openclaw/workspace; "+cloneScript); err != nil {
-						log.Printf("[daytona] warning: repo clone failed: %v", err)
-					}
+  echo "$token" | gh auth login --with-token 2>/dev/null && echo 'gh CLI authenticated' || echo 'gh auth failed'
+fi
+if [ `+fmt.Sprintf("%d", len(githubRepos))+` -gt 0 ]; then
+  cd ~/.openclaw/workspace
+  FAILED=0
+`, tokenURL)
+			for _, repo := range githubRepos {
+				repoParts := strings.SplitN(repo.Repo, "/", 2)
+				repoName := repo.Repo
+				if len(repoParts) == 2 {
+					repoName = repoParts[1]
 				}
+				bootstrapGitHubAuth += fmt.Sprintf("if [ ! -d %q ]; then git clone https://x-access-token:$token@github.com/%s %s && echo 'Cloned %s' || FAILED=1; else git -C %s pull --ff-only && echo 'Updated %s' || FAILED=1; fi\n",
+					repoName, repo.Repo, repoName, repo.Repo, repoName, repo.Repo)
+			}
+			bootstrapGitHubAuth += "exit $FAILED\nfi\n"
+			if err := exec("auth gh cli and clone repos", 2*time.Minute, bootstrapGitHubAuth); err != nil {
+				log.Printf("[daytona] warning: bootstrap GitHub auth/clone failed: %v", err)
 			}
 		}
 	}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -114,6 +114,7 @@ func NewServer(addr, dbPath, identityDir string, hubCfg *types.HubConfig) (*Serv
 
 	// Start background poller to keep provider VM status fresh
 	go srv.pollProviderStatus()
+	go srv.keepAliveDaytonaSandboxes()
 	srv.startPRWatcher()
 
 	return srv, nil
@@ -2295,6 +2296,59 @@ func (s *Server) pollProviderStatus() {
 	defer ticker.Stop()
 	for range ticker.C {
 		s.syncReplicatedVMs()
+	}
+}
+
+func (s *Server) keepAliveDaytonaSandboxes() {
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+	for range ticker.C {
+		s.petDaytonaSandboxes()
+	}
+}
+
+func (s *Server) petDaytonaSandboxes() {
+	rows, err := s.db.Query(`
+		SELECT DISTINCT c.id, c.name, c.provider_id
+		FROM claws c
+		JOIN claw_prs cp ON cp.claw_id = c.id
+		WHERE c.provider = 'daytona'
+		  AND c.provider_id != ''
+		  AND c.status NOT IN ('idle','deleted','error','offline')
+	`)
+	if err != nil {
+		log.Printf("keepAliveDaytonaSandboxes: query error: %v", err)
+		return
+	}
+	defer rows.Close()
+
+	type clawRow struct{ id, name, providerID string }
+	var claws []clawRow
+	for rows.Next() {
+		var c clawRow
+		if err := rows.Scan(&c.id, &c.name, &c.providerID); err == nil {
+			claws = append(claws, c)
+		}
+	}
+	if len(claws) == 0 {
+		return
+	}
+
+	p, err := daytona.New(nil)
+	if err != nil {
+		log.Printf("keepAliveDaytonaSandboxes: provider init error: %v", err)
+		return
+	}
+
+	for _, c := range claws {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		_, err := p.ExecWithTimeout(ctx, c.providerID, []string{"bash", "-lc", "true"}, 20*time.Second)
+		cancel()
+		if err != nil {
+			log.Printf("[daytona] keepalive failed for %s (%s): %v", c.name, c.id[:8], err)
+			continue
+		}
+		log.Printf("[daytona] keepalive ok for %s (%s)", c.name, c.id[:8])
 	}
 }
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2088,6 +2088,17 @@ echo 'credential helper installed'`, tokenURL)
 			time.Sleep(3 * time.Second)
 		}
 
+		waitTokenProxy := fmt.Sprintf(`export HOME=/home/daytona
+for i in $(seq 1 20); do
+  curl -sf --max-time 10 %q >/dev/null && exit 0
+  sleep 2
+done
+echo 'token proxy not ready'
+exit 1`, tokenURL)
+		if err := exec("wait for github token proxy", 45*time.Second, waitTokenProxy); err != nil {
+			log.Printf("[daytona] warning: github token proxy not ready: %v", err)
+		}
+
 		if err := exec("install git credential helper", 20*time.Second, credHelperScript); err != nil {
 			log.Printf("[daytona] warning: credential helper install failed: %v", err)
 		} else {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2182,14 +2182,14 @@ gh auth status >/dev/null 2>&1`
 				return fmt.Errorf("verify gh auth: %w", err)
 			}
 
-			cloneScript := "export HOME=/home/daytona; . /etc/profile.d/elasticclaw-github.sh; cd ~/.openclaw/workspace; git config --global --get credential.helper >/dev/null || exit 1; "
+			cloneScript := "export HOME=/home/daytona; . /etc/profile.d/elasticclaw-github.sh; cd ~/.openclaw/workspace; git config --global --get credential.helper >/dev/null || exit 1; [ -n \"$GH_TOKEN\" ] || exit 1; "
 			for _, repo := range githubRepos {
 				repoParts := strings.SplitN(repo.Repo, "/", 2)
 				repoName := repo.Repo
 				if len(repoParts) == 2 {
 					repoName = repoParts[1]
 				}
-				cloneScript += fmt.Sprintf("if [ ! -d %q ]; then git clone https://github.com/%s %s; else git -C %s pull --ff-only; fi; ", repoName, repo.Repo, repoName, repoName)
+				cloneScript += fmt.Sprintf("if [ ! -d %q ]; then git clone https://x-access-token:$GH_TOKEN@github.com/%s %s; else git -C %s pull --ff-only; fi; ", repoName, repo.Repo, repoName, repoName)
 			}
 			if err := exec("clone repos", 2*time.Minute, cloneScript); err != nil {
 				return fmt.Errorf("clone repos: %w", err)

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2174,7 +2174,7 @@ command -v gh
 printf 'gh_token_len=%s\n' "${#GH_TOKEN}"
 gh --version
 gh auth logout -h github.com || true
-echo "$GH_TOKEN" | gh auth login --hostname github.com --with-token`
+gh auth login --hostname github.com --with-token < /tmp/elasticclaw-github-token.txt`
 			log.Printf("[daytona] auth gh cli (no retries)...")
 			ghAuthResult, ghAuthErr := p.ExecWithTimeout(ctx, instanceID, []string{"bash", "-c", ghAuthScript}, 30*time.Second)
 			if ghAuthErr != nil {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2096,11 +2096,11 @@ done
 echo 'token proxy not ready'
 exit 1`, tokenURL)
 		if err := exec("wait for github token proxy", 45*time.Second, waitTokenProxy); err != nil {
-			log.Printf("[daytona] warning: github token proxy not ready: %v", err)
+			return fmt.Errorf("github token proxy not ready: %w", err)
 		}
 
 		if err := exec("install git credential helper", 20*time.Second, credHelperScript); err != nil {
-			log.Printf("[daytona] warning: credential helper install failed: %v", err)
+			return fmt.Errorf("install git credential helper: %w", err)
 		} else {
 			// Step 5b: fetch one bootstrap token and reuse it for gh + clone
 			bootstrapGitHubAuth := fmt.Sprintf(`export HOME=/home/daytona
@@ -2126,9 +2126,24 @@ if [ `+fmt.Sprintf("%d", len(githubRepos))+` -gt 0 ]; then
 				bootstrapGitHubAuth += fmt.Sprintf("if [ ! -d %q ]; then git clone https://x-access-token:$token@github.com/%s %s && echo 'Cloned %s' || FAILED=1; else git -C %s pull --ff-only && echo 'Updated %s' || FAILED=1; fi\n",
 					repoName, repo.Repo, repoName, repo.Repo, repoName, repo.Repo)
 			}
+			bootstrapGitHubAuth += "git config --global --get credential.helper >/dev/null || exit 1\n"
 			bootstrapGitHubAuth += "exit $FAILED\nfi\n"
 			if err := exec("auth gh cli and clone repos", 2*time.Minute, bootstrapGitHubAuth); err != nil {
-				log.Printf("[daytona] warning: bootstrap GitHub auth/clone failed: %v", err)
+				return fmt.Errorf("bootstrap GitHub auth/clone failed: %w", err)
+			}
+			if len(githubRepos) > 0 {
+				verifyCloneScript := "export HOME=/home/daytona; cd ~/.openclaw/workspace; "
+				for _, repo := range githubRepos {
+					repoParts := strings.SplitN(repo.Repo, "/", 2)
+					repoName := repo.Repo
+					if len(repoParts) == 2 {
+						repoName = repoParts[1]
+					}
+					verifyCloneScript += fmt.Sprintf("[ -d %q/.git ] || exit 1; ", repoName)
+				}
+				if err := exec("verify cloned repos", 20*time.Second, verifyCloneScript); err != nil {
+					return fmt.Errorf("verify cloned repos: %w", err)
+				}
 			}
 		}
 	}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1215,7 +1215,8 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var registrationTagsJSON string
-	_ = s.db.QueryRow(`SELECT COALESCE(tags,'[]') FROM claws WHERE id = ? AND tenant_id = ?`, clawID, tenantID).Scan(&registrationTagsJSON)
+	var bootstrapOK int
+	_ = s.db.QueryRow(`SELECT COALESCE(tags,'[]'), COALESCE(bootstrap_ok,0) FROM claws WHERE id = ? AND tenant_id = ?`, clawID, tenantID).Scan(&registrationTagsJSON, &bootstrapOK)
 	var registrationTags []string
 	_ = json.Unmarshal([]byte(registrationTagsJSON), &registrationTags)
 	cc := &clawConn{id: clawID, tenantID: tenantID, conn: conn, gatewayReady: gatewayReadyBool(rp.GatewayReady), tags: registrationTags}
@@ -1234,12 +1235,12 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 	// Initialize entry pipeline stage only after bridge connects so on_enter inject
 	// can be delivered over WS.
 	usedPipelineEntryInject := false
-	if cc.gatewayReady && currentStatus == "connected" {
+	if bootstrapOK == 1 && cc.gatewayReady && currentStatus == "connected" {
 		usedPipelineEntryInject = s.initializePipelineEntryIfNeeded(clawID)
 	}
 	// If no pipeline entry inject was sent, fire the default wake message.
 	// But don't re-wake claws that already have a pipeline stage (hub restart reconnect).
-	if cc.gatewayReady && currentStatus == "connected" && !usedPipelineEntryInject {
+	if bootstrapOK == 1 && cc.gatewayReady && currentStatus == "connected" && !usedPipelineEntryInject {
 		if s.getPipelineStage(clawID) == "" && !s.clawHasMessages(clawID) {
 			go s.sendWakeMessage(cc, clawID)
 		}
@@ -1321,7 +1322,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 						// nil means field absent (old bridge) — treat as ready.
 						if gatewayReadyBool(hb.GatewayReady) && !cc.gatewayReady {
 							cc.gatewayReady = true
-							res, execErr := s.db.Exec(`UPDATE claws SET status='connected' WHERE id=? AND status='starting'`, clawID)
+							res, execErr := s.db.Exec(`UPDATE claws SET status='connected' WHERE id=? AND status='starting' AND bootstrap_ok=1`, clawID)
 							var rowsUpdated int64
 							if execErr == nil {
 								rowsUpdated, _ = res.RowsAffected()
@@ -1852,7 +1853,7 @@ func (s *Server) provisionDaytona(ctx context.Context, clawID string, req types.
 			log.Printf("[daytona] bootstrap attempt %d/%d failed for claw %s: %v", attempt, maxBootstrapAttempts, clawName, lastErr)
 		}
 		log.Printf("[daytona] bootstrap failed for claw %s: %v", clawName, lastErr)
-		_, _ = s.db.Exec(`UPDATE claws SET status='error' WHERE id=?`, clawID)
+		_, _ = s.db.Exec(`UPDATE claws SET status='error', bootstrap_ok=0 WHERE id=?`, clawID)
 		// Destroy the sandbox — auto-stop is disabled so it would run forever otherwise
 		log.Printf("[daytona] destroying failed sandbox %s for claw %s", instance.ID, clawName)
 		if delErr := p.Destroy(context.Background(), instance.ID, false); delErr != nil {
@@ -2167,6 +2168,7 @@ if [ `+fmt.Sprintf("%d", len(githubRepos))+` -gt 0 ]; then
 		}
 	}
 
+	_, _ = s.db.Exec(`UPDATE claws SET bootstrap_ok=1 WHERE id=?`, clawID)
 	log.Printf("[daytona] bootstrap complete for claw %s", clawID)
 	return nil
 }

--- a/pkg/provider/daytona/daytona.go
+++ b/pkg/provider/daytona/daytona.go
@@ -71,13 +71,10 @@ func (p *Provider) Info() types.ProviderInfo {
 func (p *Provider) Create(ctx context.Context, req types.CreateRequest) (*types.Instance, error) {
 	// Create sandbox params - use SnapshotParams for default snapshot-based creation.
 	// req.FromImage maps to the Daytona snapshot name (e.g. "daytona-medium").
-	// Disable auto-stop (default is 15 min inactivity which kills long-running agent sessions)
-	autoStopDisabled := 0
 	params := daytonatypes.SnapshotParams{
 		SandboxBaseParams: daytonatypes.SandboxBaseParams{
-			Name:             req.Name,
-			EnvVars:          req.Env,
-			AutoStopInterval: &autoStopDisabled, // 0 = no auto-stop
+			Name:    req.Name,
+			EnvVars: req.Env,
 		},
 		Snapshot: req.FromImage, // snapshot name — empty string uses Daytona default
 	}


### PR DESCRIPTION
## Summary
- make the OpenClaw provider-config patch create ~/.openclaw/ if needed
- treat a missing openclaw.json as an empty config instead of crashing

## Why
On Daytona, ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
██░▄▄▄░██░▄▄░██░▄▄▄██░▀██░██░▄▄▀██░████░▄▄▀██░███░██
██░███░██░▀▀░██░▄▄▄██░█░█░██░█████░████░▀▀░██░█░█░██
██░▀▀▀░██░█████░▀▀▀██░██▄░██░▀▀▄██░▀▀░█░██░██▄▀▄▀▄██
▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
                  🦞 OPENCLAW 🦞                    
 
┌  OpenClaw setup
│
◇  Security ──────────────────────────────────────────────────────────────╮
│                                                                         │
│  Security warning — please read.                                        │
│                                                                         │
│  OpenClaw is a hobby project and still in beta. Expect sharp edges.     │
│  By default, OpenClaw is a personal agent: one trusted operator         │
│  boundary.                                                              │
│  This bot can read files and run actions if tools are enabled.          │
│  A bad prompt can trick it into doing unsafe things.                    │
│                                                                         │
│  OpenClaw is not a hostile multi-tenant boundary by default.            │
│  If multiple users can message one tool-enabled agent, they share that  │
│  delegated tool authority.                                              │
│                                                                         │
│  If you’re not comfortable with security hardening and access control,  │
│  don’t run OpenClaw.                                                    │
│  Ask someone experienced to help before enabling tools or exposing it   │
│  to the internet.                                                       │
│                                                                         │
│  Recommended baseline:                                                  │
│  - Pairing/allowlists + mention gating.                                 │
│  - Multi-user/shared inbox: split trust boundaries (separate            │
│    gateway/credentials, ideally separate OS users/hosts).               │
│  - Sandbox + least-privilege tools.                                     │
│  - Shared inboxes: isolate DM sessions (`session.dmScope:               │
│    per-channel-peer`) and keep tool access minimal.                     │
│  - Keep secrets out of the agent’s reachable filesystem.                │
│  - Use the strongest available model for any bot with tools or          │
│    untrusted inboxes.                                                   │
│                                                                         │
│  Run regularly:                                                         │
│  openclaw security audit --deep                                         │
│  openclaw security audit --fix                                          │
│                                                                         │
│  Must read: https://docs.openclaw.ai/gateway/security                   │
│                                                                         │
├─────────────────────────────────────────────────────────────────────────╯
[?25l│
◆  I understand this is personal-by-default and shared/multi-user use requires 
│  lock-down. Continue?
│  ○ Yes / ● No
└ can complete before  exists. The follow-up model configuration patch assumed the file was already there and crashed with FileNotFoundError.

## Testing
- ok  	github.com/elasticclaw/elasticclaw/pkg/hub	(cached)
?   	github.com/elasticclaw/elasticclaw/pkg/hub/factorytest	[no test files]
ok  	github.com/elasticclaw/elasticclaw/pkg/hub/pipeline	(cached)
?   	github.com/elasticclaw/elasticclaw/cmd	[no test files]
?   	github.com/elasticclaw/elasticclaw/cmd/bootopt	[no test files]
?   	github.com/elasticclaw/elasticclaw/cmd/claw-bridge	[no test files]
