### PR TITLE
fix: remove hardcoded repo check from Daytona bootstrap

### DIFF
--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2194,6 +2194,20 @@ gh auth status`
 			if ghStatusResult.ExitCode != 0 {
 				return fmt.Errorf("verify gh auth failed (exit %d): %s", ghStatusResult.ExitCode, ghStatusResult.Stdout)
 			}
+			if len(githubRepos) > 0 {
+				verifyReposScript := "export HOME=/home/daytona; . /etc/profile.d/elasticclaw-github.sh; set -x; "
+				for _, repo := range githubRepos {
+					verifyReposScript += fmt.Sprintf("gh repo view %s >/dev/null || exit 1; ", repo.Repo)
+				}
+				log.Printf("[daytona] verify configured github repos (no retries)...")
+				verifyReposResult, verifyReposErr := p.ExecWithTimeout(ctx, instanceID, []string{"bash", "-c", verifyReposScript}, 30*time.Second)
+				if verifyReposErr != nil {
+					return fmt.Errorf("verify configured github repos: %w", verifyReposErr)
+				}
+				if verifyReposResult.ExitCode != 0 {
+					return fmt.Errorf("verify configured github repos failed (exit %d): %s", verifyReposResult.ExitCode, verifyReposResult.Stdout)
+				}
+			}
 			log.Printf("[daytona] verify gh auth done")
 
 			cloneScript := "export HOME=/home/daytona; . /etc/profile.d/elasticclaw-github.sh; cd ~/.openclaw/workspace; git config --global --get credential.helper >/dev/null || exit 1; [ -n \"$GH_TOKEN\" ] || exit 1; "

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2185,8 +2185,7 @@ export GH_TOKEN="$TOKEN"`
 			ghStatusScript := `export HOME=/home/daytona
 set -x
 . /etc/profile.d/elasticclaw-github.sh
-gh auth status
-gh repo view can-io/canio >/dev/null`
+gh auth status`
 			log.Printf("[daytona] verify gh auth (no retries)...")
 			ghStatusResult, ghStatusErr := p.ExecWithTimeout(ctx, instanceID, []string{"bash", "-c", ghStatusScript}, 20*time.Second)
 			if ghStatusErr != nil {


### PR DESCRIPTION
## Summary
- remove the hardcoded repository check from Daytona GitHub bootstrap
- verify `gh auth status` succeeds after GitHub CLI auth is configured
- when the template config includes GitHub repos, verify access against those configured repos instead

## Why
The bootstrap path should not assume any unrelated repository exists or is accessible. Verification needs to be based on the actual repos configured for the claw being provisioned.

## Behavior
- no configured repos: verify generic GitHub auth only
- configured repos: run `gh repo view <repo>` for each configured repo and fail provisioning if any check fails

## Testing
- `go test ./pkg/hub/... ./cmd/...`
