### PR TITLE
fix: improve hub upgrade ssh key and sudo behavior

### DIFF
--- a/cmd/hub_upgrade.go
+++ b/cmd/hub_upgrade.go
@@ -56,6 +56,11 @@ func runHubUpgrade(cmd *cobra.Command, args []string) error {
 	}
 	defer client.Close()
 
+	useSudo, err := detectRemotePrivilegeMode(client)
+	if err != nil {
+		return err
+	}
+
 	// Check current version on server
 	fmt.Println("Checking remote version...")
 	remoteVerOut, err := sshRunClient(client, "elasticclaw version 2>/dev/null || echo 'unknown'")
@@ -83,19 +88,30 @@ func runHubUpgrade(cmd *cobra.Command, args []string) error {
 		latest,
 	)
 
+	moveCmd := "mv /tmp/elasticclaw-new \"$SELF\""
+	versionCmd := "elasticclaw version 2>/dev/null"
+	restartCheckCmd := "systemctl is-active --quiet elasticclaw 2>/dev/null"
+	restartCmd := "systemctl restart elasticclaw"
+	if useSudo {
+		moveCmd = "sudo mv /tmp/elasticclaw-new \"$SELF\""
+		versionCmd = "sudo elasticclaw version 2>/dev/null"
+		restartCheckCmd = "sudo systemctl is-active --quiet elasticclaw 2>/dev/null"
+		restartCmd = "sudo systemctl restart elasticclaw"
+	}
+
 	script := fmt.Sprintf(`set -euo pipefail
 echo "Downloading %s..."
 curl -fsSL %q -o /tmp/elasticclaw-new
 chmod +x /tmp/elasticclaw-new
 SELF=$(which elasticclaw || echo /usr/local/bin/elasticclaw)
-mv /tmp/elasticclaw-new "$SELF"
-echo "Upgraded to $(elasticclaw version 2>/dev/null)"
-if systemctl is-active --quiet elasticclaw 2>/dev/null; then
+%s
+echo "Upgraded to $(%s)"
+if %s; then
   echo "Restarting hub service..."
-  systemctl restart elasticclaw
+  %s
   echo "Hub service restarted."
 fi
-`, latest, downloadURL)
+`, latest, downloadURL, moveCmd, versionCmd, restartCheckCmd, restartCmd)
 
 	fmt.Printf("Upgrading remote hub to %s...\n", latest)
 	out, err := sshRunClient(client, script)

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -225,6 +225,9 @@ func dialSSH(user, addr, keyPath string) (*gossh.Client, error) {
 	for _, p := range keyPaths {
 		key, err := os.ReadFile(p)
 		if err != nil {
+			if keyPath != "" && os.IsNotExist(err) {
+				return nil, fmt.Errorf("ssh key file not found: %s", p)
+			}
 			continue // key doesn't exist, skip
 		}
 		signer, err := gossh.ParsePrivateKey(key)


### PR DESCRIPTION
## Summary
- fail clearly when a configured `ssh_key` file does not exist
- make `elasticclaw hub upgrade` follow the same remote sudo logic as install

## Why
PR #80 merged before these two follow-up fixes were included.

## Testing
- `go test ./cmd/... ./pkg/config/... ./pkg/types/...`
