### PR TITLE
feat: use branded app name for page title

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import { Geist, Geist_Mono } from 'next/font/google'
+import { BrandingPageTitle } from '@/components/branding-page-title'
 import './globals.css'
 
 const _geist = Geist({ subsets: ["latin"] });
@@ -36,6 +37,7 @@ export default function RootLayout({
   return (
     <html lang="en" className="dark h-full">
       <body className="font-sans antialiased h-full overflow-hidden">
+        <BrandingPageTitle />
         {children}
       </body>
     </html>

--- a/web/components/branding-page-title.tsx
+++ b/web/components/branding-page-title.tsx
@@ -1,0 +1,16 @@
+"use client"
+
+import { useEffect } from "react"
+import { useBranding } from "@/hooks/use-branding"
+
+const DEFAULT_TITLE = "ElasticClaw"
+
+export function BrandingPageTitle() {
+  const { appName } = useBranding()
+
+  useEffect(() => {
+    document.title = appName || DEFAULT_TITLE
+  }, [appName])
+
+  return null
+}


### PR DESCRIPTION
## Summary
- update the web UI page title to use `branding.app_name` when configured
- keep `ElasticClaw` as the default title when no branded app name is set

## Why
If a hub is branded with `branding.app_name`, we should use that consistently in the browser tab as well as the top-left app label.

## Testing
- `go test ./cmd/... ./pkg/...`
