### PR TITLE
fix: avoid Daytona bootstrap wake race

### DIFF
--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -43,6 +43,7 @@ func migrate(db *sql.DB) error {
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN bootstrap_ok INTEGER NOT NULL DEFAULT 0`)
 	_, _ = db.Exec(`ALTER TABLE claw_prs ADD COLUMN last_comment_at TEXT NOT NULL DEFAULT ''`)
 	_, _ = db.Exec(`ALTER TABLE claw_prs ADD COLUMN pr_conditions_fired INTEGER NOT NULL DEFAULT 0`)
+	_, _ = db.Exec(`ALTER TABLE messages ADD COLUMN format TEXT NOT NULL DEFAULT ''`)
 
 	_, err := db.Exec(`
 	CREATE TABLE IF NOT EXISTS tenants (
@@ -90,6 +91,7 @@ func migrate(db *sql.DB) error {
 		tenant_id  TEXT NOT NULL,
 		role       TEXT NOT NULL,
 		content    TEXT NOT NULL,
+		format     TEXT NOT NULL DEFAULT '',
 		created_at DATETIME NOT NULL
 	);
 

--- a/pkg/hub/factory_integration_test.go
+++ b/pkg/hub/factory_integration_test.go
@@ -63,8 +63,8 @@ func TestFactoryFlow_HappyPath(t *testing.T) {
 	// Connect fake bridge
 	bridge := factorytest.ConnectFakeBridge(t, ts.URL(), clawID, issueID, ts.ClawToken())
 
-	// Wait for wake message (BOOTSTRAP is in the wake message content for factory claws)
-	bridge.WaitForMessage(t, "BOOTSTRAP", 5*time.Second)
+	// Wait for wake message (pipeline injects the entry stage message)
+	bridge.WaitForMessage(t, "CONTEXT.md", 5*time.Second)
 
 	// Fake agent does work
 	bridge.SendMessage("Reading the issue context...")
@@ -156,8 +156,8 @@ func TestFactoryFlow_DoneSignalSetsIdle(t *testing.T) {
 	clawID := ts.WaitForClawWithIssue(t, issueID, 5*time.Second)
 	bridge := factorytest.ConnectFakeBridge(t, ts.URL(), clawID, issueID, ts.ClawToken())
 
-	// Wait for wake message
-	bridge.WaitForMessage(t, "BOOTSTRAP", 5*time.Second)
+	// Wait for wake message (pipeline injects the entry stage message)
+	bridge.WaitForMessage(t, "CONTEXT.md", 5*time.Second)
 
 	// Send [DONE] — no GH App configured so no PR validation, accepted immediately
 	bridge.SendDone("https://github.com/testorg/testrepo/pull/42")

--- a/pkg/hub/factorytest/server.go
+++ b/pkg/hub/factorytest/server.go
@@ -71,6 +71,14 @@ func NewTestServer(t *testing.T) *TestServer {
 				DoneStatus:    "done-state-id",
 				Template:      "elasticclaw",
 				Provider:      "noop",
+				PipelineYAML: `stages:
+  - id: working
+    label: "Working"
+    entry: true
+    on_enter:
+      inject: |
+        Read your CONTEXT.md and start working on the issue.
+`,
 			},
 		},
 		Integrations: &types.IntegrationsConfig{

--- a/pkg/hub/github_webhook.go
+++ b/pkg/hub/github_webhook.go
@@ -511,6 +511,18 @@ func (s *Server) createClawForGitHubPR(factory *types.FactoryConfig, pr githubPR
 		"ELASTICCLAW_CLAW_TOKEN": s.hubCfg.ClawToken,
 	}
 
+	// Inject template-requested secrets from hub.yaml secrets:
+	if tmplCfg != nil && len(tmplCfg.Secrets) > 0 {
+		for _, secretName := range tmplCfg.Secrets {
+			if val, ok := s.hubCfg.Secrets[secretName]; ok {
+				env[secretName] = val
+				log.Printf("[factory:%s] injected secret %s into claw env", factory.Name, secretName)
+			} else {
+				log.Printf("[factory:%s] warning: requested secret %s not found in hub secrets", factory.Name, secretName)
+			}
+		}
+	}
+
 	// Resolve template config fields
 	var (
 		instanceType    string

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -974,8 +974,10 @@ func (s *Server) fetchLinearIssueDetails(token, issueIdentifier string) (*linear
 	keyPrefix := "<empty>"
 	if len(token) > 12 {
 		keyPrefix = token[:12] + "..."
-	} else if token != "" {
+	} else if len(token) >= 4 {
 		keyPrefix = token[:4] + "..."
+	} else if token != "" {
+		keyPrefix = token + "..."
 	}
 	log.Printf("[linear] fetchLinearIssueDetails: issue=%s base=%s keyPrefix=%s", issueIdentifier, base, keyPrefix)
 

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -913,3 +913,50 @@ func (s *Server) handleFactoryEvents(w http.ResponseWriter, r *http.Request) {
 	}
 	jsonOK(w, events)
 }
+
+// linearIssueDetails holds the fields we fetch for pipeline template rendering.
+type linearIssueDetails struct {
+	Identifier  string `json:"identifier"`
+	Title       string `json:"title"`
+	URL         string `json:"url"`
+	Description string `json:"description"`
+}
+
+// fetchLinearIssueDetails looks up an issue by its Linear identifier (e.g. "CAN-61")
+// and returns the fields needed for pipeline template rendering.
+func (s *Server) fetchLinearIssueDetails(token, issueIdentifier string) (*linearIssueDetails, error) {
+	base := s.linearBaseURL
+	if base == "" {
+		base = "https://api.linear.app"
+	}
+
+	queryBody := map[string]interface{}{
+		"query": "query($id: String!) { issue(id: $id) { identifier title url description } }",
+		"variables": map[string]string{
+			"id": issueIdentifier,
+		},
+	}
+	queryJSON, _ := json.Marshal(queryBody)
+	req, _ := http.NewRequest("POST", base+"/graphql", strings.NewReader(string(queryJSON)))
+	req.Header.Set("Authorization", token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		Data struct {
+			Issue linearIssueDetails `json:"issue"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+	if result.Data.Issue.Identifier == "" {
+		return nil, fmt.Errorf("issue %s not found", issueIdentifier)
+	}
+	return &result.Data.Issue, nil
+}

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -291,10 +291,11 @@ func (s *Server) createClawForIssue(factory *types.FactoryConfig, payload linear
 		}
 	}
 
-	// Inject issue context as BOOTSTRAP.md (picked up by standard AGENTS.md first-run flow)
-	// and as CONTEXT.md for persistent reference after bootstrap is deleted.
+	// Inject issue context as CONTEXT.md for persistent reference.
+	// BOOTSTRAP.md is intentionally omitted — the pipeline inject message tells
+	// the agent to fetch issue details via Linear tools instead of reading a file
+	// that races with first-run cleanup.
 	issueContext := buildLinearContext(payload)
-	templateFiles["BOOTSTRAP.md"] = issueContext
 	templateFiles["CONTEXT.md"] = issueContext
 
 	// Determine claw name

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -381,6 +381,23 @@ func (s *Server) createClawForIssue(factory *types.FactoryConfig, payload linear
 			autoFixBugbot = 0
 		}
 	}
+	// Build SECRETS.md so the agent knows which env vars are available.
+	// Values are NOT written — they stay in env only.
+	var secretList []string
+	if linearToken != "" {
+		secretList = append(secretList, "- `LINEAR_API_KEY` — Linear API token")
+	}
+	if tmplCfg != nil && len(tmplCfg.Secrets) > 0 {
+		for _, name := range tmplCfg.Secrets {
+			if _, ok := s.hubCfg.Secrets[name]; ok {
+				secretList = append(secretList, fmt.Sprintf("- `%s` — injected from hub secrets", name))
+			}
+		}
+	}
+	if len(secretList) > 0 {
+		templateFiles["SECRETS.md"] = "## Available Secrets\n\nThe following API keys are available as environment variables:\n\n" + strings.Join(secretList, "\n") + "\n\nUse these with your tools as needed. Values are in the environment, not in files.\n"
+	}
+
 	// Resolve default model: template > llm_key lookup > hub default
 	if defaultModel == "" && llmKey != "" {
 		s.mu.RLock()

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/elasticclaw/elasticclaw/pkg/config"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
@@ -261,6 +262,18 @@ func (s *Server) processLinearEvent(payload linearWebhookPayload) {
 func (s *Server) createClawForIssue(factory *types.FactoryConfig, payload linearWebhookPayload) error {
 	issueID := payload.Data.Identifier
 
+	// Verify we can read the issue before spending money on a sandbox.
+	// Non-negotiable: if the issue is unreadable, we can't do any work.
+	linearToken := s.resolveLinearTokenForFactory(factory)
+	if linearToken != "" {
+		if _, err := s.fetchLinearIssueDetails(linearToken, issueID); err != nil {
+			return fmt.Errorf("cannot read issue %s from Linear (check token/workspace access): %w", issueID, err)
+		}
+		log.Printf("[factory:%s] verified issue %s is readable", factory.Name, issueID)
+	} else {
+		log.Printf("[factory:%s] warning: no Linear token, skipping pre-flight issue read for %s", factory.Name, issueID)
+	}
+
 	// Enforce 1:1 — check if a claw already exists for this issue
 	var existingID string
 	_ = s.db.QueryRow(
@@ -324,9 +337,7 @@ func (s *Server) createClawForIssue(factory *types.FactoryConfig, payload linear
 		return fmt.Errorf("no provider configured")
 	}
 
-	// Find Linear token for this workspace
-	linearToken := s.resolveLinearTokenForFactory(factory)
-
+	// linearToken was already resolved in the pre-flight check above.
 	// Build env vars
 	env := map[string]string{
 		"ELASTICCLAW_HUB_URL":    s.clawHubURL(),
@@ -959,6 +970,15 @@ func (s *Server) fetchLinearIssueDetails(token, issueIdentifier string) (*linear
 		base = "https://api.linear.app"
 	}
 
+	// Log key prefix for debugging (never log full key)
+	keyPrefix := "<empty>"
+	if len(token) > 12 {
+		keyPrefix = token[:12] + "..."
+	} else if token != "" {
+		keyPrefix = token[:4] + "..."
+	}
+	log.Printf("[linear] fetchLinearIssueDetails: issue=%s base=%s keyPrefix=%s", issueIdentifier, base, keyPrefix)
+
 	queryBody := map[string]interface{}{
 		"query": "query($id: String!) { issue(id: $id) { identifier title url description } }",
 		"variables": map[string]string{
@@ -970,22 +990,30 @@ func (s *Server) fetchLinearIssueDetails(token, issueIdentifier string) (*linear
 	req.Header.Set("Authorization", token)
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
 	if err != nil {
+		log.Printf("[linear] fetchLinearIssueDetails HTTP error for %s: %v", issueIdentifier, err)
 		return nil, err
 	}
 	defer resp.Body.Close()
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	log.Printf("[linear] fetchLinearIssueDetails response for %s: status=%d len=%d", issueIdentifier, resp.StatusCode, len(bodyBytes))
 
 	var result struct {
 		Data struct {
 			Issue linearIssueDetails `json:"issue"`
 		} `json:"data"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	if err := json.Unmarshal(bodyBytes, &result); err != nil {
+		log.Printf("[linear] fetchLinearIssueDetails JSON decode error for %s: %v", issueIdentifier, err)
 		return nil, err
 	}
 	if result.Data.Issue.Identifier == "" {
+		log.Printf("[linear] fetchLinearIssueDetails: empty issue returned for %s", issueIdentifier)
 		return nil, fmt.Errorf("issue %s not found", issueIdentifier)
 	}
+	log.Printf("[linear] fetchLinearIssueDetails success for %s: id=%s title=%s", issueIdentifier, result.Data.Issue.Identifier, result.Data.Issue.Title)
 	return &result.Data.Issue, nil
 }

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -336,6 +336,18 @@ func (s *Server) createClawForIssue(factory *types.FactoryConfig, payload linear
 		env["LINEAR_API_KEY"] = linearToken
 	}
 
+	// Inject template-requested secrets from hub.yaml secrets:
+	if tmplCfg != nil && len(tmplCfg.Secrets) > 0 {
+		for _, secretName := range tmplCfg.Secrets {
+			if val, ok := s.hubCfg.Secrets[secretName]; ok {
+				env[secretName] = val
+				log.Printf("[factory:%s] injected secret %s into claw env", factory.Name, secretName)
+			} else {
+				log.Printf("[factory:%s] warning: requested secret %s not found in hub secrets", factory.Name, secretName)
+			}
+		}
+	}
+
 	// Resolve template config fields (from elasticclaw-config.yaml if present).
 	// Factory-level overrides (color, tags) take precedence over template config.
 	var (

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -34,32 +34,41 @@ func parsePipelineForFactory(factory *types.FactoryConfig) *pipeline.Pipeline {
 // move is skipped silently.
 func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, factory *types.FactoryConfig, issueID string) {
 	if stage.OnEnter.Inject != "" {
-		injectMsg := strings.TrimRight(stage.OnEnter.Inject, "\n")
+		injectMsg := stage.OnEnter.Inject
 
 		// Render {{issue.identifier}}, {{issue.title}}, {{issue.url}} if this is a Linear claw
 		if issueID != "" && !strings.HasPrefix(issueID, "sc-") {
 			log.Printf("[pipeline] attempting to render template for claw %s issue %s", clawID[:8], issueID)
 			linearToken := s.resolveLinearTokenForFactory(factory)
 			if linearToken != "" {
-				if details, err := s.fetchLinearIssueDetails(linearToken, issueID); err == nil && details != nil {
-					log.Printf("[pipeline] fetched issue %s: identifier=%s title=%s", issueID, details.Identifier, details.Title)
-					tmpl, err := template.New("inject").Parse(injectMsg)
-					if err == nil {
-						var buf bytes.Buffer
-						data := map[string]interface{}{
-							"issue": details,
-						}
-						if err := tmpl.Execute(&buf, data); err == nil {
-							injectMsg = buf.String()
-							log.Printf("[pipeline] template rendered successfully for claw %s", clawID[:8])
-						} else {
-							log.Printf("[pipeline] template render failed for claw %s: %v", clawID[:8], err)
-						}
-					} else {
-						log.Printf("[pipeline] template parse failed for claw %s: %v", clawID[:8], err)
-					}
+				details, err := s.fetchLinearIssueDetails(linearToken, issueID)
+				if err != nil {
+					log.Printf("[pipeline] fetchLinearIssueDetails FAILED for %s: %v", issueID, err)
+				} else if details == nil {
+					log.Printf("[pipeline] fetchLinearIssueDetails returned nil details for %s", issueID)
 				} else {
-					log.Printf("[pipeline] could not fetch issue %s for template: %v", issueID, err)
+					log.Printf("[pipeline] fetched issue %s: identifier=%s title=%s", issueID, details.Identifier, details.Title)
+					log.Printf("[pipeline] RAW TEMPLATE for claw %s:\n%s", clawID[:8], injectMsg)
+					tmpl, err := template.New("inject").Parse(injectMsg)
+					if err != nil {
+						log.Printf("[pipeline] template PARSE FAILED for claw %s: %v", clawID[:8], err)
+						log.Printf("[pipeline] FALLING BACK to raw template for claw %s", clawID[:8])
+					} else {
+						var buf bytes.Buffer
+						data := struct {
+							Issue *linearIssueDetails
+						}{
+							Issue: details,
+						}
+						log.Printf("[pipeline] template DATA for claw %s: Issue.Identifier=%q Issue.Title=%q Issue.URL=%q", clawID[:8], data.Issue.Identifier, data.Issue.Title, data.Issue.URL)
+						if err := tmpl.Execute(&buf, data); err != nil {
+							log.Printf("[pipeline] template EXECUTE FAILED for claw %s: %v", clawID[:8], err)
+							log.Printf("[pipeline] FALLING BACK to raw template for claw %s", clawID[:8])
+						} else {
+							injectMsg = buf.String()
+							log.Printf("[pipeline] template RENDERED for claw %s:\n%s", clawID[:8], injectMsg)
+						}
+					}
 				}
 			} else {
 				log.Printf("[pipeline] no linear token for factory %q, skipping template render", factory.Name)

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -1,9 +1,11 @@
 package hub
 
 import (
+	"bytes"
 	"encoding/json"
 	"log"
 	"strings"
+	"text/template"
 
 	"github.com/elasticclaw/elasticclaw/pkg/hub/pipeline"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
@@ -32,7 +34,32 @@ func parsePipelineForFactory(factory *types.FactoryConfig) *pipeline.Pipeline {
 // move is skipped silently.
 func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, factory *types.FactoryConfig, issueID string) {
 	if stage.OnEnter.Inject != "" {
-		s.injectHubMessageByID(clawID, strings.TrimRight(stage.OnEnter.Inject, "\n"))
+		injectMsg := strings.TrimRight(stage.OnEnter.Inject, "\n")
+
+		// Render {{issue.identifier}}, {{issue.title}}, {{issue.url}} if this is a Linear claw
+		if issueID != "" && !strings.HasPrefix(issueID, "sc-") {
+			linearToken := s.resolveLinearTokenForFactory(factory)
+			if linearToken != "" {
+				if details, err := s.fetchLinearIssueDetails(linearToken, issueID); err == nil && details != nil {
+					tmpl, err := template.New("inject").Parse(injectMsg)
+					if err == nil {
+						var buf bytes.Buffer
+						data := map[string]interface{}{
+							"issue": details,
+						}
+						if err := tmpl.Execute(&buf, data); err == nil {
+							injectMsg = buf.String()
+						} else {
+							log.Printf("[pipeline] template render failed for claw %s: %v", clawID[:8], err)
+						}
+					}
+				} else {
+					log.Printf("[pipeline] could not fetch issue %s for template: %v", issueID, err)
+				}
+			}
+		}
+
+		s.injectHubMessageByID(clawID, injectMsg)
 	}
 
 	if stage.OnEnter.MergePR {

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -38,9 +38,11 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, factory *types.
 
 		// Render {{issue.identifier}}, {{issue.title}}, {{issue.url}} if this is a Linear claw
 		if issueID != "" && !strings.HasPrefix(issueID, "sc-") {
+			log.Printf("[pipeline] attempting to render template for claw %s issue %s", clawID[:8], issueID)
 			linearToken := s.resolveLinearTokenForFactory(factory)
 			if linearToken != "" {
 				if details, err := s.fetchLinearIssueDetails(linearToken, issueID); err == nil && details != nil {
+					log.Printf("[pipeline] fetched issue %s: identifier=%s title=%s", issueID, details.Identifier, details.Title)
 					tmpl, err := template.New("inject").Parse(injectMsg)
 					if err == nil {
 						var buf bytes.Buffer
@@ -49,14 +51,21 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, factory *types.
 						}
 						if err := tmpl.Execute(&buf, data); err == nil {
 							injectMsg = buf.String()
+							log.Printf("[pipeline] template rendered successfully for claw %s", clawID[:8])
 						} else {
 							log.Printf("[pipeline] template render failed for claw %s: %v", clawID[:8], err)
 						}
+					} else {
+						log.Printf("[pipeline] template parse failed for claw %s: %v", clawID[:8], err)
 					}
 				} else {
 					log.Printf("[pipeline] could not fetch issue %s for template: %v", issueID, err)
 				}
+			} else {
+				log.Printf("[pipeline] no linear token for factory %q, skipping template render", factory.Name)
 			}
+		} else {
+			log.Printf("[pipeline] skipping template render for claw %s: issueID=%q", clawID[:8], issueID)
 		}
 
 		s.injectHubMessageByID(clawID, injectMsg)

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -478,9 +478,13 @@ func (s *Server) injectMessageWithRetry(clawID, content, role string, retryCount
 	}
 
 	msgID := uuid.New().String()
+	format := ""
+	if role == "hub" {
+		format = "pre"
+	}
 	_, err := s.db.Exec(
-		`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at) VALUES(?,?,?,?,?,?)`,
-		msgID, clawID, tenantID, role, content, now(),
+		`INSERT INTO messages(id,claw_id,tenant_id,role,content,format,created_at) VALUES(?,?,?,?,?,?,?)`,
+		msgID, clawID, tenantID, role, content, format, now(),
 	)
 	if err != nil {
 		log.Printf("[pr-watcher] failed to insert message: %v", err)
@@ -507,6 +511,7 @@ func (s *Server) injectMessageWithRetry(clawID, content, role string, retryCount
 			"tenant_id":  tenantID,
 			"role":       role,
 			"content":    content,
+			"format":     format,
 			"created_at": now(),
 		},
 	})

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1902,9 +1902,6 @@ func (s *Server) bootstrapDaytona(ctx context.Context, clawID, clawName, instanc
 				lastErr = fmt.Errorf("%s failed (exit %d): %s", label, result.ExitCode, result.Stdout)
 				continue
 			}
-			if strings.Contains(label, "write ") && result.Stdout != "" {
-				log.Printf("[daytona] %s output: %s", label, result.Stdout)
-			}
 			log.Printf("[daytona] %s done", label)
 			return nil
 		}
@@ -3522,11 +3519,12 @@ func (s *Server) injectHubMessage(ctx context.Context, cc *clawConn, text string
 		TenantID:  cc.tenantID,
 		Role:      "hub",
 		Content:   text,
+		Format:    "pre",
 		CreatedAt: now(),
 	}
 	_, _ = s.db.Exec(
-		`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at) VALUES(?,?,?,?,?,?)`,
-		msg.ID, msg.ClawID, msg.TenantID, msg.Role, msg.Content, msg.CreatedAt,
+		`INSERT INTO messages(id,claw_id,tenant_id,role,content,format,created_at) VALUES(?,?,?,?,?,?,?)`,
+		msg.ID, msg.ClawID, msg.TenantID, msg.Role, msg.Content, msg.Format, msg.CreatedAt,
 	)
 	_ = wsjson.Write(ctx, cc.conn, types.WSMessage{Type: "message", Payload: msg})
 	s.broadcastToUsers(cc.tenantID, types.WSMessage{Type: "message", Payload: msg})

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1198,8 +1198,15 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 		clawID = uuid.New().String()
 	}
 
+	var bootstrapOK int
+	var provider string
+	_ = s.db.QueryRow(`SELECT COALESCE(bootstrap_ok,0), COALESCE(provider,'') FROM claws WHERE id = ? AND tenant_id = ?`, clawID, tenantID).Scan(&bootstrapOK, &provider)
+
 	// Upsert claw and keep terminal/watching states sticky across reconnects.
 	desiredStatus := initialStatus(rp.GatewayReady)
+	if provider == "daytona" && bootstrapOK != 1 {
+		desiredStatus = "starting"
+	}
 	currentStatus := desiredStatus
 	_ = s.db.QueryRow(
 		`INSERT INTO claws(id,tenant_id,name,template,status,last_seen,created_at) VALUES(?,?,?,?,?,?,?)
@@ -1215,9 +1222,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var registrationTagsJSON string
-	var bootstrapOK int
-	var provider string
-	_ = s.db.QueryRow(`SELECT COALESCE(tags,'[]'), COALESCE(bootstrap_ok,0), COALESCE(provider,'') FROM claws WHERE id = ? AND tenant_id = ?`, clawID, tenantID).Scan(&registrationTagsJSON, &bootstrapOK, &provider)
+	_ = s.db.QueryRow(`SELECT COALESCE(tags,'[]') FROM claws WHERE id = ? AND tenant_id = ?`, clawID, tenantID).Scan(&registrationTagsJSON)
 	allowWake := bootstrapOK == 1 || provider != "daytona"
 	var registrationTags []string
 	_ = json.Unmarshal([]byte(registrationTagsJSON), &registrationTags)
@@ -1993,8 +1998,8 @@ exit 1`
 		return err
 	}
 
-	// Step 3: Download and start claw-bridge
-	// Download synchronously first, then background the process.
+	// Step 3: Download claw-bridge now, but do not start it until the workspace,
+	// template files, and bootstrap gating are fully ready.
 	bridgeURL := s.bridgeDownloadURL()
 	if bridgeURL == "" {
 		return fmt.Errorf("claw-bridge URL not configured: set bridge_image in hub.yaml (e.g. bridge_image: ttl.sh/your/claw-bridge:tag) or build a tagged release")
@@ -2016,23 +2021,12 @@ cp "$BIN" /tmp/claw-bridge && chmod +x /tmp/claw-bridge && echo downloaded`, bri
 		return err
 	}
 
-	// Start the bridge — it reads the gateway token from openclaw.json automatically.
-	// Use setsid to detach from exec session so it survives after exec returns.
 	s.mu.RLock()
 	clawToken := s.hubCfg.ClawToken
 	s.mu.RUnlock()
 
-	startCmd := fmt.Sprintf(
-		`export HOME=/home/daytona; \
-ELASTICCLAW_HUB_URL=%q ELASTICCLAW_CLAW_ID=%q ELASTICCLAW_CLAW_TOKEN=%q ELASTICCLAW_CLAW_NAME=%q \
-setsid nohup /tmp/claw-bridge >> /tmp/claw-bridge.log 2>&1 </dev/null &
-echo started`,
-		s.clawHubURL(), clawID, clawToken, clawName)
-	if err := exec("start claw-bridge", 30*time.Second, startCmd); err != nil {
-		return err
-	}
-
-	// Write template files (SOUL.md, AGENTS.md, etc.) to the workspace
+	// Write template files (SOUL.md, AGENTS.md, etc.) to the workspace before
+	// the bridge starts so BOOTSTRAP.md and friends are present for the first turn.
 	var filesJSON string
 	_ = s.db.QueryRow(`SELECT COALESCE(template_files,'{}') FROM claws WHERE id=?`, clawID).Scan(&filesJSON)
 	var templateFiles map[string]string
@@ -2062,14 +2056,16 @@ ELASTICCLAW_EOF`,
 		_ = s.db.QueryRow(`SELECT COALESCE(github_repos,'[]') FROM claws WHERE id=?`, clawID).Scan(&reposJSON)
 		_ = json.Unmarshal([]byte(reposJSON), &githubRepos)
 
-		// Use local HTTP proxy (bridge listens on 18790, proxies to hub)
-		tokenURL := fmt.Sprintf("http://localhost:18790/api/github/token/%s?claw_token=%s", clawID, clawToken)
+		// Use the hub directly during bootstrap. The bridge is intentionally not
+		// started yet so startup cannot race ahead of template file writes and
+		// bootstrap_ok gating.
+		tokenURL := fmt.Sprintf("%s/api/github/token/%s?claw_token=%s", s.clawHubURL(), clawID, clawToken)
 
 		// Step 5a: write the credential helper binary
 		credHelperScript := fmt.Sprintf(`export HOME=/home/daytona
 sudo tee /usr/local/bin/elasticclaw-git-credentials > /dev/null << 'CREDEOF'
 #!/bin/bash
-# Retry up to 10 times — proxy may not be ready immediately after bridge connects
+# Retry up to 10 times — hub token endpoint may not be ready immediately
 for i in $(seq 1 10); do
   response=$(curl -sf --max-time 35 %q)
   if [ $? -eq 0 ] && [ -n "$response" ]; then break; fi
@@ -2085,19 +2081,6 @@ CREDEOF
 sudo chmod +x /usr/local/bin/elasticclaw-git-credentials
 git config --global credential.helper /usr/local/bin/elasticclaw-git-credentials
 echo 'credential helper installed'`, tokenURL)
-		// Wait for the bridge to connect and register with hub (needed for HTTP proxy)
-		log.Printf("[daytona] waiting for bridge to connect...")
-		for i := 0; i < 30; i++ {
-			s.mu.RLock()
-			_, connected := s.claws[clawID]
-			s.mu.RUnlock()
-			if connected {
-				log.Printf("[daytona] bridge connected after %ds", i*3)
-				break
-			}
-			time.Sleep(3 * time.Second)
-		}
-
 		if err := exec("install git credential helper", 20*time.Second, credHelperScript); err != nil {
 			return fmt.Errorf("install git credential helper: %w", err)
 		} else {
@@ -2240,6 +2223,20 @@ gh auth status`
 	}
 
 	_, _ = s.db.Exec(`UPDATE claws SET bootstrap_ok=1 WHERE id=?`, clawID)
+	log.Printf("[daytona] bootstrap gated ready for claw %s", clawID)
+
+	// Start the bridge last so the first registration happens only after the
+	// workspace, template files, GitHub setup, and bootstrap_ok gate are ready.
+	startCmd := fmt.Sprintf(
+		`export HOME=/home/daytona; \
+ELASTICCLAW_HUB_URL=%q ELASTICCLAW_CLAW_ID=%q ELASTICCLAW_CLAW_TOKEN=%q ELASTICCLAW_CLAW_NAME=%q \
+setsid nohup /tmp/claw-bridge >> /tmp/claw-bridge.log 2>&1 </dev/null &
+echo started`,
+		s.clawHubURL(), clawID, clawToken, clawName)
+	if err := exec("start claw-bridge", 30*time.Second, startCmd); err != nil {
+		return err
+	}
+
 	log.Printf("[daytona] bootstrap complete for claw %s", clawID)
 	return nil
 }

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2038,16 +2038,12 @@ cp "$BIN" /tmp/claw-bridge && chmod +x /tmp/claw-bridge && echo downloaded`, bri
 			name := name
 			content := content
 			writeCmd := fmt.Sprintf(
-				`export HOME=/home/daytona; echo "[DEBUG] HOME=$HOME pwd=$(pwd) writing %s"; mkdir -p ~/.openclaw/workspace && cat > ~/.openclaw/workspace/%s << 'ELASTICCLAW_EOF'
+				`export HOME=/home/daytona; mkdir -p ~/.openclaw/workspace && cat > ~/.openclaw/workspace/%s << 'ELASTICCLAW_EOF'
 %s
-ELASTICCLAW_EOF
-ls -la ~/.openclaw/workspace/%s 2>/dev/null || echo "[DEBUG] MISSING in ~/.openclaw/workspace/%s"
-ls -la ~/%s 2>/dev/null || echo "[DEBUG] MISSING in ~/%s"`,
-				name, name, content, name, name, name, name)
+ELASTICCLAW_EOF`,
+				name, content)
 			if err := exec("write "+name, 15*time.Second, writeCmd); err != nil {
 				log.Printf("[daytona] warning: failed to write %s: %v", name, err)
-			} else {
-				log.Printf("[daytona] wrote %s", name)
 			}
 		}
 		log.Printf("[daytona] template files written for claw %s", clawID)
@@ -2623,7 +2619,7 @@ func (s *Server) bridgeDownloadURL() string {
 const (
 	wakeMessageMarker  = "__WAKE_MESSAGE__"
 	defaultWakeContent = "Introduce yourself briefly and let the user know you're ready to help."
-	factoryWakeContent = `Read your BOOTSTRAP.md now. Then:
+	factoryWakeContent = `You've been assigned an issue. Use your tools to read the full details, then:
 1. Send a short intro message to the user: your name, the issue you're working on, and your plan.
 2. Start working. As you go, narrate your progress — what you're exploring, what you're trying, why.
 3. If you hit something interesting or unexpected, say so.

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1902,6 +1902,9 @@ func (s *Server) bootstrapDaytona(ctx context.Context, clawID, clawName, instanc
 				lastErr = fmt.Errorf("%s failed (exit %d): %s", label, result.ExitCode, result.Stdout)
 				continue
 			}
+			if strings.Contains(label, "write ") && result.Stdout != "" {
+				log.Printf("[daytona] %s output: %s", label, result.Stdout)
+			}
 			log.Printf("[daytona] %s done", label)
 			return nil
 		}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2035,12 +2035,16 @@ cp "$BIN" /tmp/claw-bridge && chmod +x /tmp/claw-bridge && echo downloaded`, bri
 			name := name
 			content := content
 			writeCmd := fmt.Sprintf(
-				`export HOME=/home/daytona; mkdir -p ~/.openclaw/workspace && cat > ~/.openclaw/workspace/%s << 'ELASTICCLAW_EOF'
+				`export HOME=/home/daytona; echo "[DEBUG] HOME=$HOME pwd=$(pwd) writing %s"; mkdir -p ~/.openclaw/workspace && cat > ~/.openclaw/workspace/%s << 'ELASTICCLAW_EOF'
 %s
-ELASTICCLAW_EOF`,
-				name, content)
+ELASTICCLAW_EOF
+ls -la ~/.openclaw/workspace/%s 2>/dev/null || echo "[DEBUG] MISSING in ~/.openclaw/workspace/%s"
+ls -la ~/%s 2>/dev/null || echo "[DEBUG] MISSING in ~/%s"`,
+				name, name, content, name, name, name, name)
 			if err := exec("write "+name, 15*time.Second, writeCmd); err != nil {
 				log.Printf("[daytona] warning: failed to write %s: %v", name, err)
+			} else {
+				log.Printf("[daytona] wrote %s", name)
 			}
 		}
 		log.Printf("[daytona] template files written for claw %s", clawID)

--- a/pkg/hub/shortcut.go
+++ b/pkg/hub/shortcut.go
@@ -446,6 +446,18 @@ func (s *Server) createClawForShortcutStory(factory *types.FactoryConfig, action
 		env["SHORTCUT_API_KEY"] = token
 	}
 
+	// Inject template-requested secrets from hub.yaml secrets:
+	if tmplCfg != nil && len(tmplCfg.Secrets) > 0 {
+		for _, secretName := range tmplCfg.Secrets {
+			if val, ok := s.hubCfg.Secrets[secretName]; ok {
+				env[secretName] = val
+				log.Printf("[factory:%s] injected secret %s into claw env", factory.Name, secretName)
+			} else {
+				log.Printf("[factory:%s] warning: requested secret %s not found in hub secrets", factory.Name, secretName)
+			}
+		}
+	}
+
 	// Resolve template config fields (from elasticclaw-config.yaml if present).
 	// Factory-level overrides (color, tags) take precedence over template config.
 	var (

--- a/pkg/hub/shortcut.go
+++ b/pkg/hub/shortcut.go
@@ -381,6 +381,13 @@ func (s *Server) shortcutStateName(token string, stateID int64) string {
 
 // createClawForShortcutStory provisions a claw for a Shortcut story.
 func (s *Server) createClawForShortcutStory(factory *types.FactoryConfig, action shortcutAction, storyID, token string) error {
+	// Verify we can read the story before spending money on a sandbox.
+	// Non-negotiable: if the story is unreadable, we can't do any work.
+	if _, err := shortcutAPI(fmt.Sprintf("stories/%s", storyID), token); err != nil {
+		return fmt.Errorf("cannot read story %s from Shortcut (check token/workspace access): %w", storyID, err)
+	}
+	log.Printf("[factory:%s] verified story %s is readable", factory.Name, storyID)
+
 	// Enforce 1:1
 	var existingID string
 	_ = s.db.QueryRow(

--- a/pkg/types/hub.go
+++ b/pkg/types/hub.go
@@ -26,6 +26,7 @@ type HubMessage struct {
 	TenantID       string    `json:"tenant_id" db:"tenant_id"`
 	Role           string    `json:"role" db:"role"` // "user" | "claw"
 	Content        string    `json:"content" db:"content"`
+	Format         string    `json:"format,omitempty" db:"format"` // "pre" = preserve whitespace
 	CreatedAt      time.Time `json:"created_at" db:"created_at"`
 }
 

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -104,6 +104,10 @@ type TemplateConfig struct {
 	//         cyan, sky, blue, indigo, violet, purple, pink, rose
 	// If unset, a color is auto-assigned from the claw name.
 	Color string `yaml:"color,omitempty"`
+	// Secrets is a list of named secrets from hub.yaml secrets: to inject
+	// as environment variables into the claw. The secret name becomes the
+	// env var name (uppercased if needed).
+	Secrets []string `yaml:"secrets,omitempty"`
 }
 
 type TemplateResources struct {

--- a/web/components/conversation-view.tsx
+++ b/web/components/conversation-view.tsx
@@ -527,9 +527,12 @@ function ClawBoardCard({
                 }
                 if (message.role === "hub") {
                   return (
-                    <div key={message.id} className="flex items-center gap-1.5 py-0.5">
-                      <Settings2 className="size-2.5 shrink-0 text-muted-foreground/40" />
-                      <span className="text-[10px] italic text-muted-foreground/60 leading-tight">{message.content}</span>
+                    <div key={message.id} className="flex items-start gap-1.5 py-0.5">
+                      <Settings2 className="size-2.5 shrink-0 text-muted-foreground/40 mt-0.5" />
+                      <span className={cn(
+                        "text-[10px] italic text-muted-foreground/60 leading-tight",
+                        message.format === "pre" && "whitespace-pre-wrap"
+                      )}>{message.content}</span>
                     </div>
                   )
                 }
@@ -873,9 +876,12 @@ const MessageBubble = memo(function MessageBubble({
 
   if (isHub) {
     return (
-      <div className="flex items-center gap-2 py-1">
-        <div className="flex items-center gap-1.5 text-muted-foreground/60 text-xs italic bg-muted/40 border border-border/40 rounded px-3 py-1.5 max-w-[85%]">
-          <Settings2 className="size-3 shrink-0 text-muted-foreground/50" />
+      <div className="flex items-start gap-2 py-1">
+        <div className={cn(
+          "flex items-start gap-1.5 text-muted-foreground/60 text-xs italic bg-muted/40 border border-border/40 rounded px-3 py-1.5 max-w-[85%]",
+          message.format === "pre" && "whitespace-pre-wrap"
+        )}>
+          <Settings2 className="size-3 shrink-0 text-muted-foreground/50 mt-0.5" />
           <span className="text-muted-foreground/80">{message.content}</span>
         </div>
       </div>

--- a/web/lib/mappers.ts
+++ b/web/lib/mappers.ts
@@ -120,6 +120,7 @@ export function mapApiMessage(apiMsg: ApiMessage): Message {
     id: apiMsg.id,
     role: apiMsg.role,
     content: apiMsg.content,
+    format: apiMsg.format,
     timestamp: new Date(apiMsg.created_at),
     claw_id: apiMsg.claw_id,
     tenant_id: apiMsg.tenant_id,

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -27,6 +27,7 @@ export interface Message {
   id: string
   role: "user" | "claw" | "system" | "hub"
   content: string
+  format?: string // "pre" = preserve whitespace
   timestamp: Date
   // API fields
   claw_id?: string
@@ -56,6 +57,7 @@ export interface ApiMessage {
   tenant_id: string
   role: "user" | "claw" | "hub"
   content: string
+  format?: string
   created_at: string
 }
 

--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary
- write Daytona template files before starting the bridge
- complete Daytona GitHub/bootstrap gating before starting the bridge
- force Daytona claws to register as `starting` until `bootstrap_ok=1`

## Why
Daytona could start `claw-bridge` too early, before `BOOTSTRAP.md` and other workspace files were written and before `bootstrap_ok` was set. That allowed a claw to register as `connected` while wake was still suppressed, which could leave the factory idle with no initial prompt injected.

## Testing
- `go test ./pkg/hub/... ./cmd/...`
