### PR TITLE
fix: improve gateway health monitoring and recovery

### DIFF
--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -1554,7 +1554,7 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 }
 
 func checkGateway(addr string) bool {
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://%s/healthz", addr), nil)
 	resp, err := http.DefaultClient.Do(req)

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1345,17 +1345,18 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 							} else if cc.gatewayUnhealthyCount%4 == 0 {
 								log.Printf("[heartbeat] %s (%s): gateway unhealthy for %d consecutive checks", rp.Name, clawID[:8], cc.gatewayUnhealthyCount)
 							}
-							if cc.gatewayUnhealthyCount == 4 {
+							if cc.gatewayUnhealthyCount == 4 && !cc.streamingStartedAt.IsZero() {
 								go s.injectHubMessageByID(clawID, "[hub] The gateway has been unresponsive for about a minute. If you're stuck in a long operation, consider sending [DONE] and starting fresh.")
 							}
-						} else {
-							if cc.gatewayUnhealthyCount > 0 {
-								log.Printf("[heartbeat] %s (%s): gateway recovered after %d unhealthy checks", rp.Name, clawID[:8], cc.gatewayUnhealthyCount)
-								cc.gatewayUnhealthyCount = 0
-							}
-							if hb.ContextUsage != prevUsage && (hb.ContextUsage >= 80 || prevUsage >= 80) {
-								log.Printf("[heartbeat] %s (%s): context_usage=%d%%", rp.Name, clawID[:8], hb.ContextUsage)
-							}
+						}
+						// Log context usage on every heartbeat when it crosses the 80% threshold,
+						// regardless of gateway health — don't silence diagnostics during outages.
+						if hb.ContextUsage != prevUsage && (hb.ContextUsage >= 80 || prevUsage >= 80) {
+							log.Printf("[heartbeat] %s (%s): context_usage=%d%%", rp.Name, clawID[:8], hb.ContextUsage)
+						}
+						if hb.GatewayHealthy && cc.gatewayUnhealthyCount > 0 {
+							log.Printf("[heartbeat] %s (%s): gateway recovered after %d unhealthy checks", rp.Name, clawID[:8], cc.gatewayUnhealthyCount)
+							cc.gatewayUnhealthyCount = 0
 						}
 					}
 					// Inject context warning once per streaming turn when usage is >=95%

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -65,6 +65,7 @@ type clawConn struct {
 	streamingStartedAt    time.Time       // when the current streaming turn started (zero if not streaming)
 	streamingTimeoutSent  bool            // true once the 12-min timeout message has been injected this turn
 	contextWarningSent    bool            // true once the context-nearly-full warning has been injected this turn
+	gatewayNudgeSent      bool            // true once the gateway-unhealthy nudge has been injected this turn
 }
 
 // initialStatus returns the claw status string to use on bridge registration.
@@ -1345,7 +1346,8 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 							} else if cc.gatewayUnhealthyCount%4 == 0 {
 								log.Printf("[heartbeat] %s (%s): gateway unhealthy for %d consecutive checks", rp.Name, clawID[:8], cc.gatewayUnhealthyCount)
 							}
-							if cc.gatewayUnhealthyCount == 4 && !cc.streamingStartedAt.IsZero() {
+							if cc.gatewayUnhealthyCount >= 4 && !cc.streamingStartedAt.IsZero() && !cc.gatewayNudgeSent {
+								cc.gatewayNudgeSent = true
 								go s.injectHubMessageByID(clawID, "[hub] The gateway has been unresponsive for about a minute. If you're stuck in a long operation, consider sending [DONE] and starting fresh.")
 							}
 						}
@@ -1414,6 +1416,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 							cc.streamingStartedAt = time.Now()
 							cc.streamingTimeoutSent = false
 							cc.contextWarningSent = false
+							cc.gatewayNudgeSent = false
 						}
 						cc.streamingBuf.WriteString(chunk.Content)
 						msgID := cc.streamingMsgID
@@ -1449,6 +1452,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 					cc.streamingStartedAt = time.Time{}
 					cc.streamingTimeoutSent = false
 					cc.contextWarningSent = false
+					cc.gatewayNudgeSent = false
 				} else {
 					hm.ID = uuid.New().String()
 				}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -53,17 +53,18 @@ type Server struct {
 }
 
 type clawConn struct {
-	id                   string
-	tenantID             string
-	conn                 *websocket.Conn
-	tags                 []string        // cached from DB at registration time for access-control checks
-	contextUsage         int             // 0-100, updated from heartbeats
-	gatewayReady         bool            // true once bridge reports gateway session established
-	streamingBuf         strings.Builder // accumulates chunks for current in-flight response
-	streamingMsgID       string          // pre-assigned message ID for the current stream
-	streamingStartedAt   time.Time       // when the current streaming turn started (zero if not streaming)
-	streamingTimeoutSent bool            // true once the 12-min timeout message has been injected this turn
-	contextWarningSent   bool            // true once the context-nearly-full warning has been injected this turn
+	id                    string
+	tenantID              string
+	conn                  *websocket.Conn
+	tags                  []string        // cached from DB at registration time for access-control checks
+	contextUsage          int             // 0-100, updated from heartbeats
+	gatewayReady          bool            // true once bridge reports gateway session established
+	gatewayUnhealthyCount int             // consecutive unhealthy heartbeats
+	streamingBuf          strings.Builder // accumulates chunks for current in-flight response
+	streamingMsgID        string          // pre-assigned message ID for the current stream
+	streamingStartedAt    time.Time       // when the current streaming turn started (zero if not streaming)
+	streamingTimeoutSent  bool            // true once the 12-min timeout message has been injected this turn
+	contextWarningSent    bool            // true once the context-nearly-full warning has been injected this turn
 }
 
 // initialStatus returns the claw status string to use on bridge registration.
@@ -1317,7 +1318,6 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 					s.mu.Lock()
 					if cc, ok := s.claws[clawID]; ok {
 						// Log only on status changes, not every heartbeat
-						prevHealthy := cc.gatewayReady
 						prevUsage = cc.contextUsage
 						cc.contextUsage = hb.ContextUsage
 						// Promote from 'starting' to 'connected' once gateway is ready.
@@ -1338,12 +1338,24 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 								shouldWake = true
 								wakeConn = cc
 							}
-						} else if !hb.GatewayHealthy && prevHealthy {
-							// Gateway went unhealthy
-							log.Printf("[heartbeat] %s (%s): gateway unhealthy", rp.Name, clawID[:8])
-						} else if hb.ContextUsage != prevUsage && (hb.ContextUsage >= 80 || prevUsage >= 80) {
-							// Log context usage only when crossing 80% threshold
-							log.Printf("[heartbeat] %s (%s): context_usage=%d%%", rp.Name, clawID[:8], hb.ContextUsage)
+						} else if !hb.GatewayHealthy {
+							cc.gatewayUnhealthyCount++
+							if cc.gatewayUnhealthyCount == 1 {
+								log.Printf("[heartbeat] %s (%s): gateway unhealthy", rp.Name, clawID[:8])
+							} else if cc.gatewayUnhealthyCount%4 == 0 {
+								log.Printf("[heartbeat] %s (%s): gateway unhealthy for %d consecutive checks", rp.Name, clawID[:8], cc.gatewayUnhealthyCount)
+							}
+							if cc.gatewayUnhealthyCount == 4 {
+								go s.injectHubMessageByID(clawID, "[hub] The gateway has been unresponsive for about a minute. If you're stuck in a long operation, consider sending [DONE] and starting fresh.")
+							}
+						} else {
+							if cc.gatewayUnhealthyCount > 0 {
+								log.Printf("[heartbeat] %s (%s): gateway recovered after %d unhealthy checks", rp.Name, clawID[:8], cc.gatewayUnhealthyCount)
+								cc.gatewayUnhealthyCount = 0
+							}
+							if hb.ContextUsage != prevUsage && (hb.ContextUsage >= 80 || prevUsage >= 80) {
+								log.Printf("[heartbeat] %s (%s): context_usage=%d%%", rp.Name, clawID[:8], hb.ContextUsage)
+							}
 						}
 					}
 					// Inject context warning once per streaming turn when usage is >=95%


### PR DESCRIPTION
- Increase checkGateway timeout from 3s to 5s to reduce false positives under gateway load

- Track consecutive unhealthy heartbeats in hub (gatewayUnhealthyCount) to distinguish transient blips from sustained problems

- Log gateway recovery after unhealthy streaks

- Inject a nudge message to the claw after ~1 minute of unhealthiness suggesting it send [DONE] if stuck

- Reduce log spam: only log on first unhealthy, every 4th consecutive unhealthy (roughly 1 minute intervals), and on recovery