### PR TITLE
feat: embed minimal Linear CLI in claw-bridge

### DIFF
--- a/cmd/claw-bridge/linear.go
+++ b/cmd/claw-bridge/linear.go
@@ -28,7 +28,7 @@ import (
 	"time"
 )
 
-const linearAPIURL = "https://api.linear.app/graphql"
+var linearAPIURL = "https://api.linear.app/graphql"
 
 func runLinearCLI(args []string) int {
 	apiKey := os.Getenv("LINEAR_API_KEY")

--- a/cmd/claw-bridge/linear.go
+++ b/cmd/claw-bridge/linear.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 )
 
 const linearAPIURL = "https://api.linear.app/graphql"
@@ -66,7 +67,9 @@ func runLinearCLI(args []string) int {
 				fmt.Fprintln(os.Stderr, "usage: claw-bridge linear issue search <query>")
 				return 1
 			}
-			return linearIssueSearch(apiKey, args[2])
+			// Join all remaining args so multi-word queries work without quoting.
+			queryStr := strings.Join(args[2:], " ")
+			return linearIssueSearch(apiKey, queryStr)
 		default:
 			fmt.Fprintf(os.Stderr, "unknown issue subcommand: %s\n", args[1])
 			return 1
@@ -78,6 +81,9 @@ func runLinearCLI(args []string) int {
 		return 1
 	}
 }
+
+// linearClient is a shared HTTP client with a reasonable timeout.
+var linearClient = &http.Client{Timeout: 15 * time.Second}
 
 // linearQuery performs a GraphQL query/mutation against Linear's API.
 func linearQuery(apiKey, query string, variables map[string]interface{}) (map[string]interface{}, error) {
@@ -94,7 +100,7 @@ func linearQuery(apiKey, query string, variables map[string]interface{}) (map[st
 	req.Header.Set("Authorization", apiKey)
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := linearClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -167,10 +173,10 @@ func linearIssueUpdate(apiKey, identifier string, flags []string) int {
 		}
 	}
 
-	// Resolve issue ID from identifier
+	// Resolve issue ID and team ID from identifier
 	query := `query($identifier: String!) {
 		issues(filter: { identifier: { eq: $identifier } }) {
-			nodes { id }
+			nodes { id team { id name } }
 		}
 	}`
 	result, err := linearQuery(apiKey, query, map[string]interface{}{"identifier": identifier})
@@ -193,15 +199,33 @@ func linearIssueUpdate(apiKey, identifier string, flags []string) int {
 		return 1
 	}
 
+	// Extract team ID for state scoping
+	var teamID string
+	if teamData, ok := issue0["team"].(map[string]interface{}); ok {
+		teamID, _ = teamData["id"].(string)
+	}
+
 	// Update state if requested
 	if stateName != "" {
-		// Find state ID by name
-		statesQuery := `query($name: String!) {
-			workflowStates(filter: { name: { eq: $name } }) {
-				nodes { id name }
-			}
-		}`
-		statesResult, err := linearQuery(apiKey, statesQuery, map[string]interface{}{"name": stateName})
+		// Find state ID by name, scoped to the issue's team
+		var statesQuery string
+		var statesVars map[string]interface{}
+		if teamID != "" {
+			statesQuery = `query($name: String!, $teamId: String!) {
+				workflowStates(filter: { name: { eq: $name }, team: { id: { eq: $teamId } } }) {
+					nodes { id name team { name } }
+				}
+			}`
+			statesVars = map[string]interface{}{"name": stateName, "teamId": teamID}
+		} else {
+			statesQuery = `query($name: String!) {
+				workflowStates(filter: { name: { eq: $name } }) {
+					nodes { id name team { name } }
+				}
+			}`
+			statesVars = map[string]interface{}{"name": stateName}
+		}
+		statesResult, err := linearQuery(apiKey, statesQuery, statesVars)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error finding state '%s': %v\n", stateName, err)
 			return 1
@@ -209,7 +233,11 @@ func linearIssueUpdate(apiKey, identifier string, flags []string) int {
 		states := dig(statesResult, "data", "workflowStates", "nodes")
 		statesList, _ := states.([]interface{})
 		if len(statesList) == 0 {
-			fmt.Fprintf(os.Stderr, "state '%s' not found\n", stateName)
+			if teamID != "" {
+				fmt.Fprintf(os.Stderr, "state '%s' not found for this issue's team\n", stateName)
+			} else {
+				fmt.Fprintf(os.Stderr, "state '%s' not found\n", stateName)
+			}
 			return 1
 		}
 		state0, _ := statesList[0].(map[string]interface{})

--- a/cmd/claw-bridge/linear.go
+++ b/cmd/claw-bridge/linear.go
@@ -173,6 +173,11 @@ func linearIssueUpdate(apiKey, identifier string, flags []string) int {
 		}
 	}
 
+	if stateName == "" && comment == "" {
+		fmt.Fprintln(os.Stderr, "nothing to do: specify --state=<name> and/or --comment=<text>")
+		return 1
+	}
+
 	// Resolve issue ID and team ID from identifier
 	query := `query($identifier: String!) {
 		issues(filter: { identifier: { eq: $identifier } }) {

--- a/cmd/claw-bridge/linear.go
+++ b/cmd/claw-bridge/linear.go
@@ -1,0 +1,344 @@
+// linear.go — minimal Linear GraphQL CLI embedded in claw-bridge
+//
+// Reads LINEAR_API_KEY from env. Provides a small set of commands the claw
+// can invoke via exec (the bridge binary is already present in the sandbox).
+//
+// Usage: claw-bridge linear <command> [args...]
+//
+// Commands:
+//   issue get <identifier>           — fetch issue details (e.g. CAN-61)
+//   issue update <identifier> --state=<name> --comment=<text>
+//   issue search <query>             — search issues
+//   teams                            — list teams
+//
+// This is intentionally minimal. The hub already injects full issue context
+// into CONTEXT.md; these commands let the claw update status, add comments,
+// or search for related issues without needing a separate Go binary.
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+)
+
+const linearAPIURL = "https://api.linear.app/graphql"
+
+func runLinearCLI(args []string) int {
+	apiKey := os.Getenv("LINEAR_API_KEY")
+	if apiKey == "" {
+		fmt.Fprintln(os.Stderr, "LINEAR_API_KEY not set")
+		return 1
+	}
+
+	if len(args) < 1 {
+		fmt.Fprintln(os.Stderr, "usage: claw-bridge linear <command> [args...]")
+		fmt.Fprintln(os.Stderr, "commands: issue get, issue update, issue search, teams")
+		return 1
+	}
+
+	switch args[0] {
+	case "issue":
+		if len(args) < 2 {
+			fmt.Fprintln(os.Stderr, "usage: claw-bridge linear issue <get|update|search> ...")
+			return 1
+		}
+		switch args[1] {
+		case "get":
+			if len(args) < 3 {
+				fmt.Fprintln(os.Stderr, "usage: claw-bridge linear issue get <identifier>")
+				return 1
+			}
+			return linearIssueGet(apiKey, args[2])
+		case "update":
+			if len(args) < 3 {
+				fmt.Fprintln(os.Stderr, "usage: claw-bridge linear issue update <identifier> [--state=<name>] [--comment=<text>]")
+				return 1
+			}
+			return linearIssueUpdate(apiKey, args[2], args[3:])
+		case "search":
+			if len(args) < 3 {
+				fmt.Fprintln(os.Stderr, "usage: claw-bridge linear issue search <query>")
+				return 1
+			}
+			return linearIssueSearch(apiKey, args[2])
+		default:
+			fmt.Fprintf(os.Stderr, "unknown issue subcommand: %s\n", args[1])
+			return 1
+		}
+	case "teams":
+		return linearTeams(apiKey)
+	default:
+		fmt.Fprintf(os.Stderr, "unknown command: %s\n", args[0])
+		return 1
+	}
+}
+
+// linearQuery performs a GraphQL query/mutation against Linear's API.
+func linearQuery(apiKey, query string, variables map[string]interface{}) (map[string]interface{}, error) {
+	body := map[string]interface{}{"query": query}
+	if variables != nil {
+		body["variables"] = variables
+	}
+	b, _ := json.Marshal(body)
+
+	req, err := http.NewRequest("POST", linearAPIURL, bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, fmt.Errorf("parse response: %w (body: %s)", err, string(data))
+	}
+
+	if errs, ok := result["errors"].([]interface{}); ok && len(errs) > 0 {
+		return nil, fmt.Errorf("graphql error: %v", errs[0])
+	}
+
+	return result, nil
+}
+
+// linearIssueGet fetches an issue by identifier (e.g. "CAN-61").
+func linearIssueGet(apiKey, identifier string) int {
+	query := `
+		query($identifier: String!) {
+			issues(filter: { identifier: { eq: $identifier } }) {
+				nodes {
+					id
+					identifier
+					title
+					description
+					state { name }
+					priority
+					url
+					team { name key }
+					assignee { name }
+					createdAt
+					updatedAt
+				}
+			}
+		}
+	`
+	result, err := linearQuery(apiKey, query, map[string]interface{}{"identifier": identifier})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+
+	data := dig(result, "data", "issues", "nodes")
+	issues, ok := data.([]interface{})
+	if !ok || len(issues) == 0 {
+		fmt.Fprintf(os.Stderr, "issue %s not found\n", identifier)
+		return 1
+	}
+
+	b, _ := json.MarshalIndent(issues[0], "", "  ")
+	fmt.Println(string(b))
+	return 0
+}
+
+// linearIssueUpdate updates an issue state and/or adds a comment.
+func linearIssueUpdate(apiKey, identifier string, flags []string) int {
+	var stateName, comment string
+	for _, f := range flags {
+		if strings.HasPrefix(f, "--state=") {
+			stateName = strings.TrimPrefix(f, "--state=")
+		} else if strings.HasPrefix(f, "--comment=") {
+			comment = strings.TrimPrefix(f, "--comment=")
+		}
+	}
+
+	// Resolve issue ID from identifier
+	query := `query($identifier: String!) {
+		issues(filter: { identifier: { eq: $identifier } }) {
+			nodes { id }
+		}
+	}`
+	result, err := linearQuery(apiKey, query, map[string]interface{}{"identifier": identifier})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error resolving issue: %v\n", err)
+		return 1
+	}
+
+	data := dig(result, "data", "issues", "nodes")
+	issues, ok := data.([]interface{})
+	if !ok || len(issues) == 0 {
+		fmt.Fprintf(os.Stderr, "issue %s not found\n", identifier)
+		return 1
+	}
+	issue0, _ := issues[0].(map[string]interface{})
+	issueID := issue0["id"]
+	id, _ := issueID.(string)
+	if id == "" {
+		fmt.Fprintf(os.Stderr, "issue %s has no id\n", identifier)
+		return 1
+	}
+
+	// Update state if requested
+	if stateName != "" {
+		// Find state ID by name
+		statesQuery := `query($name: String!) {
+			workflowStates(filter: { name: { eq: $name } }) {
+				nodes { id name }
+			}
+		}`
+		statesResult, err := linearQuery(apiKey, statesQuery, map[string]interface{}{"name": stateName})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error finding state '%s': %v\n", stateName, err)
+			return 1
+		}
+		states := dig(statesResult, "data", "workflowStates", "nodes")
+		statesList, _ := states.([]interface{})
+		if len(statesList) == 0 {
+			fmt.Fprintf(os.Stderr, "state '%s' not found\n", stateName)
+			return 1
+		}
+		state0, _ := statesList[0].(map[string]interface{})
+		stateID := state0["id"]
+		sid, _ := stateID.(string)
+
+		mut := `mutation($id: String!, $stateId: String!) {
+			issueUpdate(id: $id, input: { stateId: $stateId }) {
+				success
+				issue { id identifier state { name } }
+			}
+		}`
+		_, err = linearQuery(apiKey, mut, map[string]interface{}{"id": id, "stateId": sid})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error updating state: %v\n", err)
+			return 1
+		}
+		fmt.Printf("Updated %s state → %s\n", identifier, stateName)
+	}
+
+	// Add comment if requested
+	if comment != "" {
+		mut := `mutation($issueId: String!, $body: String!) {
+			commentCreate(input: { issueId: $issueId, body: $body }) {
+				success
+				comment { id body }
+			}
+		}`
+		_, err = linearQuery(apiKey, mut, map[string]interface{}{"issueId": id, "body": comment})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error adding comment: %v\n", err)
+			return 1
+		}
+		fmt.Printf("Added comment to %s\n", identifier)
+	}
+
+	return 0
+}
+
+// linearIssueSearch searches for issues by query string.
+func linearIssueSearch(apiKey, queryStr string) int {
+	query := `
+		query($query: String!) {
+			issueSearch(query: $query) {
+				nodes {
+					id
+					identifier
+					title
+					state { name }
+					team { name key }
+					assignee { name }
+					url
+				}
+			}
+		}
+	`
+	result, err := linearQuery(apiKey, query, map[string]interface{}{"query": queryStr})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+
+	data := dig(result, "data", "issueSearch", "nodes")
+	issues, ok := data.([]interface{})
+	if !ok {
+		fmt.Fprintln(os.Stderr, "no results")
+		return 0
+	}
+
+	for _, i := range issues {
+		issue, _ := i.(map[string]interface{})
+		id, _ := issue["identifier"].(string)
+		title, _ := issue["title"].(string)
+		state := ""
+		if s, ok := issue["state"].(map[string]interface{}); ok {
+			state, _ = s["name"].(string)
+		}
+		fmt.Printf("%s [%s] %s\n", id, state, title)
+	}
+	return 0
+}
+
+// linearTeams lists all teams.
+func linearTeams(apiKey string) int {
+	query := `
+		query {
+			teams {
+				nodes {
+					id
+					name
+					key
+				}
+			}
+		}
+	`
+	result, err := linearQuery(apiKey, query, nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+
+	data := dig(result, "data", "teams", "nodes")
+	teams, ok := data.([]interface{})
+	if !ok {
+		fmt.Fprintln(os.Stderr, "no teams")
+		return 0
+	}
+
+	for _, t := range teams {
+		team, _ := t.(map[string]interface{})
+		key, _ := team["key"].(string)
+		name, _ := team["name"].(string)
+		fmt.Printf("%s — %s\n", key, name)
+	}
+	return 0
+}
+
+// dig walks a nested map[string]interface{} path. Returns nil if any step fails.
+func dig(m map[string]interface{}, keys ...string) interface{} {
+	var v interface{} = m
+	for _, k := range keys {
+		next, ok := v.(map[string]interface{})
+		if !ok {
+			return nil
+		}
+		v, ok = next[k]
+		if !ok {
+			return nil
+		}
+	}
+	return v
+}

--- a/cmd/claw-bridge/linear.go
+++ b/cmd/claw-bridge/linear.go
@@ -250,10 +250,16 @@ func linearIssueUpdate(apiKey, identifier string, flags []string) int {
 				issue { id identifier state { name } }
 			}
 		}`
-		_, err = linearQuery(apiKey, mut, map[string]interface{}{"id": id, "stateId": sid})
+		updateResult, err := linearQuery(apiKey, mut, map[string]interface{}{"id": id, "stateId": sid})
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error updating state: %v\n", err)
 			return 1
+		}
+		if payload, _ := dig(updateResult, "data", "issueUpdate").(map[string]interface{}); payload != nil {
+			if ok, _ := payload["success"].(bool); !ok {
+				fmt.Fprintf(os.Stderr, "issueUpdate returned success=false for %s\n", identifier)
+				return 1
+			}
 		}
 		fmt.Printf("Updated %s state → %s\n", identifier, stateName)
 	}
@@ -266,10 +272,16 @@ func linearIssueUpdate(apiKey, identifier string, flags []string) int {
 				comment { id body }
 			}
 		}`
-		_, err = linearQuery(apiKey, mut, map[string]interface{}{"issueId": id, "body": comment})
+		commentResult, err := linearQuery(apiKey, mut, map[string]interface{}{"issueId": id, "body": comment})
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error adding comment: %v\n", err)
 			return 1
+		}
+		if payload, _ := dig(commentResult, "data", "commentCreate").(map[string]interface{}); payload != nil {
+			if ok, _ := payload["success"].(bool); !ok {
+				fmt.Fprintf(os.Stderr, "commentCreate returned success=false for %s\n", identifier)
+				return 1
+			}
 		}
 		fmt.Printf("Added comment to %s\n", identifier)
 	}

--- a/cmd/claw-bridge/linear_test.go
+++ b/cmd/claw-bridge/linear_test.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestLinearCLI_NoAPIKey verifies the CLI exits with error when LINEAR_API_KEY is missing.
+func TestLinearCLI_NoAPIKey(t *testing.T) {
+	os.Unsetenv("LINEAR_API_KEY")
+	if got := runLinearCLI([]string{"teams"}); got != 1 {
+		t.Fatalf("expected exit 1 without LINEAR_API_KEY, got %d", got)
+	}
+}
+
+// TestLinearCLI_Teams verifies the teams command makes a GraphQL request and prints results.
+func TestLinearCLI_Teams(t *testing.T) {
+	// Mock Linear API server
+	var requestBody map[string]interface{}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "test-key" {
+			t.Errorf("missing or wrong Authorization header")
+		}
+		b, _ := io.ReadAll(r.Body)
+		json.Unmarshal(b, &requestBody)
+
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `{"data":{"teams":{"nodes":[{"id":"t1","name":"Engineering","key":"ENG"},{"id":"t2","name":"Design","key":"DSN"}]}}}`)
+	}))
+	defer ts.Close()
+
+	// Override the API URL for this test
+	oldURL := linearAPIURL
+	defer func() { linearAPIURL = oldURL }()
+	linearAPIURL = ts.URL + "/graphql"
+
+	os.Setenv("LINEAR_API_KEY", "test-key")
+	defer os.Unsetenv("LINEAR_API_KEY")
+
+	// Capture stdout
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	got := runLinearCLI([]string{"teams"})
+
+	w.Close()
+	os.Stdout = oldStdout
+	out, _ := io.ReadAll(r)
+
+	if got != 0 {
+		t.Fatalf("expected exit 0, got %d", got)
+	}
+
+	output := string(out)
+	if !strings.Contains(output, "ENG — Engineering") {
+		t.Errorf("expected 'ENG — Engineering' in output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "DSN — Design") {
+		t.Errorf("expected 'DSN — Design' in output, got:\n%s", output)
+	}
+
+	query, _ := requestBody["query"].(string)
+	if !strings.Contains(query, "teams") {
+		t.Errorf("expected teams query, got: %s", query)
+	}
+}
+
+// TestLinearCLI_IssueGet verifies issue get fetches by identifier.
+func TestLinearCLI_IssueGet(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		var body map[string]interface{}
+		json.Unmarshal(b, &body)
+
+		vars, _ := body["variables"].(map[string]interface{})
+		id, _ := vars["identifier"].(string)
+		if id != "CAN-61" {
+			t.Errorf("expected identifier CAN-61, got %s", id)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `{"data":{"issues":{"nodes":[{"id":"issue-uuid","identifier":"CAN-61","title":"Fix auth","state":{"name":"In Progress"},"team":{"name":"Engineering","key":"ENG"}}]}}}`)
+	}))
+	defer ts.Close()
+
+	oldURL := linearAPIURL
+	defer func() { linearAPIURL = oldURL }()
+	linearAPIURL = ts.URL + "/graphql"
+
+	os.Setenv("LINEAR_API_KEY", "test-key")
+	defer os.Unsetenv("LINEAR_API_KEY")
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	got := runLinearCLI([]string{"issue", "get", "CAN-61"})
+
+	w.Close()
+	os.Stdout = oldStdout
+	out, _ := io.ReadAll(r)
+
+	if got != 0 {
+		t.Fatalf("expected exit 0, got %d", got)
+	}
+
+	output := string(out)
+	if !strings.Contains(output, "Fix auth") {
+		t.Errorf("expected 'Fix auth' in output, got:\n%s", output)
+	}
+}
+
+// TestLinearCLI_IssueUpdate_MutationSuccessFalse verifies the CLI reports failure when Linear returns success=false.
+func TestLinearCLI_IssueUpdate_MutationSuccessFalse(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		var body map[string]interface{}
+		json.Unmarshal(b, &body)
+
+		query, _ := body["query"].(string)
+		w.Header().Set("Content-Type", "application/json")
+
+		if strings.Contains(query, "issues(filter") {
+			// Issue lookup response
+			fmt.Fprintln(w, `{"data":{"issues":{"nodes":[{"id":"issue-uuid","team":{"id":"team-uuid","name":"Eng"}}]}}}`)
+		} else if strings.Contains(query, "workflowStates") {
+			fmt.Fprintln(w, `{"data":{"workflowStates":{"nodes":[{"id":"state-uuid","name":"Done","team":{"name":"Eng"}}]}}}`)
+		} else if strings.Contains(query, "issueUpdate") {
+			// Return success: false (application-level failure)
+			fmt.Fprintln(w, `{"data":{"issueUpdate":{"success":false,"issue":null}}}`)
+		} else {
+			fmt.Fprintln(w, `{"data":{}}`)
+		}
+	}))
+	defer ts.Close()
+
+	oldURL := linearAPIURL
+	defer func() { linearAPIURL = oldURL }()
+	linearAPIURL = ts.URL + "/graphql"
+
+	os.Setenv("LINEAR_API_KEY", "test-key")
+	defer os.Unsetenv("LINEAR_API_KEY")
+
+	got := runLinearCLI([]string{"issue", "update", "CAN-61", "--state=Done"})
+	if got != 1 {
+		t.Fatalf("expected exit 1 when mutation returns success=false, got %d", got)
+	}
+}
+
+// TestLinearCLI_IssueSearch_MultiWord verifies multi-word queries are joined.
+func TestLinearCLI_IssueSearch_MultiWord(t *testing.T) {
+	var capturedQuery string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		var body map[string]interface{}
+		json.Unmarshal(b, &body)
+
+		vars, _ := body["variables"].(map[string]interface{})
+		capturedQuery, _ = vars["query"].(string)
+
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `{"data":{"issueSearch":{"nodes":[]}}}`)
+	}))
+	defer ts.Close()
+
+	oldURL := linearAPIURL
+	defer func() { linearAPIURL = oldURL }()
+	linearAPIURL = ts.URL + "/graphql"
+
+	os.Setenv("LINEAR_API_KEY", "test-key")
+	defer os.Unsetenv("LINEAR_API_KEY")
+
+	got := runLinearCLI([]string{"issue", "search", "fix", "the", "login", "bug"})
+	if got != 0 {
+		t.Fatalf("expected exit 0, got %d", got)
+	}
+
+	if capturedQuery != "fix the login bug" {
+		t.Errorf("expected query 'fix the login bug', got %q", capturedQuery)
+	}
+}

--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -1270,6 +1270,11 @@ func (p *httpProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
+	// Subcommand dispatch: linear CLI embedded in the bridge binary.
+	if len(os.Args) > 1 && os.Args[1] == "linear" {
+		os.Exit(runLinearCLI(os.Args[2:]))
+	}
+
 	// Bootstrap mode: run all VM setup steps before entering the bridge loop.
 	// Activated by --bootstrap flag or ELASTICCLAW_BOOTSTRAP=1 env var.
 	bootstrapMode := os.Getenv("ELASTICCLAW_BOOTSTRAP") == "1"

--- a/pkg/hub/factorytest/mock_linear.go
+++ b/pkg/hub/factorytest/mock_linear.go
@@ -65,18 +65,22 @@ func NewMockLinear(t *testing.T) *MockLinear {
 			})
 			return
 		}
-		// issue query
-		if strings.Contains(bodyStr, "issue(") || strings.Contains(bodyStr, `"issue"`) {
+		// issue query — support both legacy issue(id:) and new issues(filter:) queries
+		if strings.Contains(bodyStr, "issue(") || strings.Contains(bodyStr, `"issue"`) || strings.Contains(bodyStr, "issues(filter") {
 			json.NewEncoder(w).Encode(map[string]interface{}{
 				"data": map[string]interface{}{
-					"issue": map[string]interface{}{
-						"id":          "issue-uuid-123",
-						"identifier":  "ELA-123",
-						"title":       "Add hello world to README",
-						"description": "Please add a 'Hello World' section to the README.md file.",
-						"url":         "https://linear.app/test/issue/ELA-123",
-						"state":       map[string]interface{}{"name": "In Progress", "id": "in-progress-id"},
-						"team":        map[string]interface{}{"name": "Engineering", "key": "ELA"},
+					"issues": map[string]interface{}{
+						"nodes": []map[string]interface{}{
+							{
+								"id":          "issue-uuid-123",
+								"identifier":  "ELA-123",
+								"title":       "Add hello world to README",
+								"description": "Please add a 'Hello World' section to the README.md file.",
+								"url":         "https://linear.app/test/issue/ELA-123",
+								"state":       map[string]interface{}{"name": "In Progress", "id": "in-progress-id"},
+								"team":        map[string]interface{}{"name": "Engineering", "key": "ELA"},
+							},
+						},
 					},
 				},
 			})

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -974,8 +974,10 @@ func (s *Server) fetchLinearIssueDetails(token, issueIdentifier string) (*linear
 	keyPrefix := "<empty>"
 	if len(token) > 12 {
 		keyPrefix = token[:12] + "..."
-	} else if token != "" {
+	} else if len(token) >= 4 {
 		keyPrefix = token[:4] + "..."
+	} else if token != "" {
+		keyPrefix = token + "..."
 	}
 	log.Printf("[linear] fetchLinearIssueDetails: issue=%s base=%s keyPrefix=%s", issueIdentifier, base, keyPrefix)
 

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -990,7 +990,10 @@ func (s *Server) fetchLinearIssueDetails(token, issueIdentifier string) (*linear
 		},
 	}
 	queryJSON, _ := json.Marshal(queryBody)
-	req, _ := http.NewRequest("POST", base+"/graphql", strings.NewReader(string(queryJSON)))
+	req, err := http.NewRequest("POST", base+"/graphql", strings.NewReader(string(queryJSON)))
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
 	req.Header.Set("Authorization", token)
 	req.Header.Set("Content-Type", "application/json")
 

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -981,10 +981,12 @@ func (s *Server) fetchLinearIssueDetails(token, issueIdentifier string) (*linear
 	}
 	log.Printf("[linear] fetchLinearIssueDetails: issue=%s base=%s keyPrefix=%s", issueIdentifier, base, keyPrefix)
 
+	// Linear's issue(id:) expects a UUID, not a display identifier like "CAN-61".
+	// Use the issues(filter:) query with identifier.eq instead.
 	queryBody := map[string]interface{}{
-		"query": "query($id: String!) { issue(id: $id) { identifier title url description } }",
+		"query": "query($identifier: String!) { issues(filter: { identifier: { eq: $identifier } }) { nodes { identifier title url description } } }",
 		"variables": map[string]string{
-			"id": issueIdentifier,
+			"identifier": issueIdentifier,
 		},
 	}
 	queryJSON, _ := json.Marshal(queryBody)
@@ -1005,17 +1007,20 @@ func (s *Server) fetchLinearIssueDetails(token, issueIdentifier string) (*linear
 
 	var result struct {
 		Data struct {
-			Issue linearIssueDetails `json:"issue"`
+			Issues struct {
+				Nodes []linearIssueDetails `json:"nodes"`
+			} `json:"issues"`
 		} `json:"data"`
 	}
 	if err := json.Unmarshal(bodyBytes, &result); err != nil {
 		log.Printf("[linear] fetchLinearIssueDetails JSON decode error for %s: %v", issueIdentifier, err)
 		return nil, err
 	}
-	if result.Data.Issue.Identifier == "" {
-		log.Printf("[linear] fetchLinearIssueDetails: empty issue returned for %s", issueIdentifier)
+	if len(result.Data.Issues.Nodes) == 0 {
+		log.Printf("[linear] fetchLinearIssueDetails: no issue found for %s", issueIdentifier)
 		return nil, fmt.Errorf("issue %s not found", issueIdentifier)
 	}
-	log.Printf("[linear] fetchLinearIssueDetails success for %s: id=%s title=%s", issueIdentifier, result.Data.Issue.Identifier, result.Data.Issue.Title)
-	return &result.Data.Issue, nil
+	issue := result.Data.Issues.Nodes[0]
+	log.Printf("[linear] fetchLinearIssueDetails success for %s: id=%s title=%s", issueIdentifier, issue.Identifier, issue.Title)
+	return &issue, nil
 }

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -36,7 +36,7 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, factory *types.
 	if stage.OnEnter.Inject != "" {
 		injectMsg := stage.OnEnter.Inject
 
-		// Render {{issue.identifier}}, {{issue.title}}, {{issue.url}} if this is a Linear claw
+		// Render {{.Issue.Identifier}}, {{.Issue.Title}}, {{.Issue.URL}} if this is a Linear claw
 		if issueID != "" && !strings.HasPrefix(issueID, "sc-") {
 			log.Printf("[pipeline] attempting to render template for claw %s issue %s", clawID[:8], issueID)
 			linearToken := s.resolveLinearTokenForFactory(factory)


### PR DESCRIPTION
Add a 'linear' subcommand to claw-bridge so claws can interact with Linear's GraphQL API without needing a separate Go binary in the sandbox.

## Problem
- Daytona sandboxes don't have Go installed
- Claws need to update Linear issue status, add comments, search for related issues
- No existing tool in the claw's toolkit consumes LINEAR_API_KEY

## Solution
Embed a minimal Linear CLI directly into claw-bridge (already present in every sandbox).

## Commands


## How it works
- Reads LINEAR_API_KEY from env (injected by hub during factory creation)
- Makes direct GraphQL queries to api.linear.app/graphql
- Outputs JSON (for get) or plain text (for search, teams)
- ~240 lines, zero external dependencies beyond stdlib

## Why this approach
- claw-bridge is already downloaded into every sandbox
- No additional binary to install/maintain
- No MCP server complexity
- Minimal enough to not bloat the bridge, complete enough for common claw workflows

## Next steps (not in this PR)
- Update factory wake message / AGENTS.md to tell claws about this tool
- Consider adding more commands (create issue, add labels, etc.) as needed