### PR TITLE
chore: pin openclaw to 2026.5.2

### DIFF
--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1961,7 +1961,7 @@ echo uninstalled`); err != nil {
 		log.Printf("[daytona] warning: uninstall failed (ok if not installed): %v", err)
 	}
 
-	const daytonaOpenClawVersion = "2026.4.27"
+	const daytonaOpenClawVersion = "2026.5.2"
 	if err := exec("install openclaw", 3*time.Minute,
 		fmt.Sprintf(`export NVM_DIR=/usr/local/share/nvm; export PATH=$NVM_DIR/current/bin:$PATH; \
 PREFIX="$(/usr/local/share/nvm/current/bin/npm config get prefix)"; \


### PR DESCRIPTION
Updates the Daytona bootstrap to install openclaw 2026.5.2 (was 2026.4.27).