### PR TITLE
feat: add docker template flag for Docker Engine bootstrap install

### DIFF
--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -12,6 +12,7 @@
 //
 //	ELASTICCLAW_BOOTSTRAP         - set to "1" to run bootstrap before normal bridge loop
 //	ELASTICCLAW_NIX               - set to "true" to install Nix in background
+//	ELASTICCLAW_DOCKER            - set to "true" to install Docker Engine
 //	ELASTICCLAW_GATEWAY_PASSWORD  - OpenClaw gateway password
 //	ELASTICCLAW_ONBOARD_FLAGS     - extra flags for openclaw onboard
 //	OPENCLAW_DEFAULT_MODEL        - default agent model
@@ -856,6 +857,63 @@ curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix 
 	return ch
 }
 
+// dockerInstallBg starts the Docker Engine installer in background and returns
+// a done channel. The channel receives an error (or nil) when the install finishes.
+func dockerInstallBg() <-chan error {
+	ch := make(chan error, 1)
+	go func() {
+		log.Printf("[bootstrap] starting Docker install in background...")
+		script := `
+set -euo pipefail
+# Detect OS family (debian vs ubuntu) for the correct Docker repo
+. /etc/os-release
+if [ "$ID" = "debian" ] && [ -n "$VERSION_CODENAME" ]; then
+  DOCKER_REPO="deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian $VERSION_CODENAME stable"
+  DOCKER_GPG="https://download.docker.com/linux/debian/gpg"
+else
+  DOCKER_REPO="deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $VERSION_CODENAME stable"
+  DOCKER_GPG="https://download.docker.com/linux/ubuntu/gpg"
+fi
+# Add Docker's official GPG key
+sudo apt-get update -qq
+sudo apt-get install -y --fix-broken ca-certificates curl gnupg
+sudo install -m 0755 -d /etc/apt/keyrings
+curl -fsSL "$DOCKER_GPG" | sudo gpg --batch --yes --dearmor -o /etc/apt/keyrings/docker.gpg
+sudo chmod a+r /etc/apt/keyrings/docker.gpg
+# Add the repository to Apt sources
+echo "$DOCKER_REPO" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt-get update -qq
+sudo apt-get install -y --fix-broken docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+echo "Docker: $(docker --version)"
+`
+		err := runShell(script)
+		if err != nil {
+			log.Printf("[bootstrap] Docker install failed: %v", err)
+		} else {
+			log.Printf("[bootstrap] Docker install complete")
+		}
+		ch <- err
+	}()
+	return ch
+}
+
+// finishDocker waits for the background Docker install to complete and adds
+// the current user to the docker group so docker commands work without sudo.
+func finishDocker(dockerDone <-chan error) {
+	if dockerDone == nil {
+		return
+	}
+	log.Printf("[bootstrap] waiting for Docker install...")
+	if err := <-dockerDone; err != nil {
+		log.Printf("[bootstrap] Docker install error: %v", err)
+		return
+	}
+	// Add daytona user to docker group (common username on Replicated VMs)
+	_ = runShell("sudo usermod -aG docker daytona 2>/dev/null || true")
+	_ = runShell("sudo usermod -aG docker root 2>/dev/null || true")
+	log.Printf("[bootstrap] Docker ready")
+}
+
 // installNodeGit installs Node.js 24 and git via apt.
 func installNodeGit() error {
 	log.Printf("[bootstrap] installing Node.js 24 + git...")
@@ -1082,6 +1140,12 @@ func runBootstrap() error {
 		nixDone = nixInstallBg()
 	}
 
+	// Step 2b: Start Docker install in background (if requested)
+	var dockerDone <-chan error
+	if os.Getenv("ELASTICCLAW_DOCKER") == "true" {
+		dockerDone = dockerInstallBg()
+	}
+
 	// Step 3: Install OpenClaw (needs Node)
 	if err := installOpenClaw(); err != nil {
 		return fmt.Errorf("installOpenClaw: %w", err)
@@ -1128,8 +1192,9 @@ func runBootstrap() error {
 		return fmt.Errorf("waitForDeviceJSON: %w", err)
 	}
 
-	// Step 9: After bridge connects, finish Nix in background
+	// Step 9: After bridge connects, finish Nix and Docker in background
 	go finishNix(nixDone)
+	go finishDocker(dockerDone)
 
 	if notifyFile := os.Getenv("ELASTICCLAW_BOOTSTRAP_NOTIFY_FILE"); notifyFile != "" {
 		if err := os.WriteFile(notifyFile, []byte("ok\n"), 0600); err != nil {

--- a/pkg/hub/bootstrap.go
+++ b/pkg/hub/bootstrap.go
@@ -26,7 +26,8 @@ type BootstrapParams struct {
 	BridgeURL string
 
 	// Features
-	Nix bool
+	Nix    bool
+	Docker bool
 
 	// GitHub credential helper
 	HubCfg      *types.HubConfig
@@ -195,6 +196,10 @@ func GenerateReplicatedBootstrapScript(p BootstrapParams) string {
 	if p.Nix {
 		nixFlag = "true"
 	}
+	dockerFlag := "false"
+	if p.Docker {
+		dockerFlag = "true"
+	}
 	// Encode the provider config python snippet as a single env var value so
 	// claw-bridge can receive it without heredoc escaping issues.
 	// We use a simple approach: if it's non-empty, pass it as ELASTICCLAW_PROVIDER_CONFIG.
@@ -224,6 +229,7 @@ export ELASTICCLAW_CLAW_NAME="%s"
 export ELASTICCLAW_GATEWAY_PASSWORD="%s"
 export OPENCLAW_DEFAULT_MODEL="%s"
 export ELASTICCLAW_NIX="%s"
+export ELASTICCLAW_DOCKER="%s"
 %s
 %s
 export ELASTICCLAW_ONBOARD_FLAGS=%s
@@ -292,7 +298,7 @@ echo "ERROR: timed out waiting for claw-bridge bootstrap to complete"
 exit 1
 `,
 		p.HubURL, p.ClawID, p.ClawToken, p.ClawName, p.GatewayPassword,
-		p.DefaultModel, nixFlag,
+		p.DefaultModel, nixFlag, dockerFlag,
 		p.LLMKeyEnv, linearEnvLine, shellQuote(p.OnboardFlags), providerConfigLine,
 		p.BridgeURL,
 	)

--- a/pkg/hub/bootstrap_test.go
+++ b/pkg/hub/bootstrap_test.go
@@ -282,6 +282,7 @@ func TestBootstrapScript_Shellcheck(t *testing.T) {
 	}{
 		{"base", baseParams()},
 		{"nix_enabled", func() BootstrapParams { p := baseParams(); p.Nix = true; return p }()},
+		{"docker_enabled", func() BootstrapParams { p := baseParams(); p.Docker = true; return p }()},
 		{"with_github", func() BootstrapParams {
 			p := baseParams()
 			p.HubCfg = &types.HubConfig{
@@ -353,6 +354,7 @@ func TestBootstrapScript_StdinExec(t *testing.T) {
 			return p
 		}()},
 		{"nix_enabled", func() BootstrapParams { p := baseParams(); p.Nix = true; return p }()},
+		{"docker_enabled", func() BootstrapParams { p := baseParams(); p.Docker = true; return p }()},
 		// Regression: GitHub App configured but no repos — was producing empty { } group command
 		{"github_app_no_repos", func() BootstrapParams {
 			p := baseParams()

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -33,6 +33,7 @@ func migrate(db *sql.DB) error {
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN github_repos TEXT NOT NULL DEFAULT ''`)
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN linear_workspace TEXT NOT NULL DEFAULT ''`)
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN nix INTEGER NOT NULL DEFAULT 0`)
+	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN docker INTEGER NOT NULL DEFAULT 0`)
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN tags TEXT NOT NULL DEFAULT '[]'`)
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN color TEXT NOT NULL DEFAULT ''`)
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN linear_issue_id TEXT NOT NULL DEFAULT ''`)
@@ -73,6 +74,7 @@ func migrate(db *sql.DB) error {
 		github_repos   TEXT NOT NULL DEFAULT '',
 		linear_workspace TEXT NOT NULL DEFAULT '',
 		nix              INTEGER NOT NULL DEFAULT 0,
+		docker           INTEGER NOT NULL DEFAULT 0,
 		tags             TEXT NOT NULL DEFAULT '[]',
 		color            TEXT NOT NULL DEFAULT '',
 		linear_issue_id  TEXT NOT NULL DEFAULT '',

--- a/pkg/hub/github_webhook.go
+++ b/pkg/hub/github_webhook.go
@@ -530,6 +530,7 @@ func (s *Server) createClawForGitHubPR(factory *types.FactoryConfig, pr githubPR
 		defaultModel    string
 		llmKey          string
 		nixEnabled      int
+		dockerEnabled   int
 		githubRepos     []types.GitHubRepoAccess
 		linearWorkspace string
 		autoFixCI       int = 1
@@ -541,6 +542,9 @@ func (s *Server) createClawForGitHubPR(factory *types.FactoryConfig, pr githubPR
 		llmKey = tmplCfg.LLMKey
 		if tmplCfg.Nix {
 			nixEnabled = 1
+		}
+		if tmplCfg.Docker {
+			dockerEnabled = 1
 		}
 		if tmplCfg.GitHub != nil {
 			githubRepos = tmplCfg.GitHub.Repos
@@ -601,10 +605,10 @@ func (s *Server) createClawForGitHubPR(factory *types.FactoryConfig, pr githubPR
 	createdAt := now()
 
 	_, err = s.db.Exec(`
-		INSERT INTO claws(id, tenant_id, name, template, provider, default_model, template_files, github_repos, linear_workspace, nix, tags, color, llm_key, auto_fix_ci, auto_fix_bugbot, linear_issue_id, status, created_at)
-		VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,'provisioning',?)`,
+		INSERT INTO claws(id, tenant_id, name, template, provider, default_model, template_files, github_repos, linear_workspace, nix, docker, tags, color, llm_key, auto_fix_ci, auto_fix_bugbot, linear_issue_id, status, created_at)
+		VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,'provisioning',?)`,
 		clawID, tenantID, clawName, factory.Template, provider, defaultModel, string(filesJSON),
-		string(githubReposJSON), linearWorkspace, nixEnabled, string(tagsJSON), clawColor, llmKey, autoFixCI, autoFixBugbot, "", createdAt,
+		string(githubReposJSON), linearWorkspace, nixEnabled, dockerEnabled, string(tagsJSON), clawColor, llmKey, autoFixCI, autoFixBugbot, "", createdAt,
 	)
 	if err != nil {
 		return fmt.Errorf("db insert: %w", err)

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -369,6 +369,7 @@ func (s *Server) createClawForIssue(factory *types.FactoryConfig, payload linear
 		defaultModel    string
 		llmKey          string
 		nixEnabled      int
+		dockerEnabled   int
 		githubRepos     []types.GitHubRepoAccess
 		linearWorkspace string
 		autoFixCI       int = 1
@@ -380,6 +381,9 @@ func (s *Server) createClawForIssue(factory *types.FactoryConfig, payload linear
 		llmKey = tmplCfg.LLMKey
 		if tmplCfg.Nix {
 			nixEnabled = 1
+		}
+		if tmplCfg.Docker {
+			dockerEnabled = 1
 		}
 		if tmplCfg.GitHub != nil {
 			githubRepos = tmplCfg.GitHub.Repos
@@ -491,10 +495,10 @@ func (s *Server) createClawForIssue(factory *types.FactoryConfig, payload linear
 	now := now()
 
 	_, err = s.db.Exec(`
-		INSERT INTO claws(id, tenant_id, name, template, provider, default_model, template_files, github_repos, linear_workspace, nix, tags, color, llm_key, auto_fix_ci, auto_fix_bugbot, linear_issue_id, status, created_at)
-		VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,'provisioning',?)`,
+		INSERT INTO claws(id, tenant_id, name, template, provider, default_model, template_files, github_repos, linear_workspace, nix, docker, tags, color, llm_key, auto_fix_ci, auto_fix_bugbot, linear_issue_id, status, created_at)
+		VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,'provisioning',?)`,
 		clawID, tenantID, clawName, factory.Template, provider, defaultModel, string(filesJSON),
-		string(githubReposJSON), linearWorkspace, nixEnabled, string(tagsJSON), clawColor, llmKey, autoFixCI, autoFixBugbot, issueID, now,
+		string(githubReposJSON), linearWorkspace, nixEnabled, dockerEnabled, string(tagsJSON), clawColor, llmKey, autoFixCI, autoFixBugbot, issueID, now,
 	)
 	if err != nil {
 		return fmt.Errorf("db insert: %w", err)

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -740,7 +740,11 @@ func (s *Server) handleCreateClaw(w http.ResponseWriter, r *http.Request, tenant
 	if req.Nix {
 		nixEnabled = 1
 	}
-	log.Printf("[create] claw %s: req.Nix=%v nixEnabled=%d", req.Name, req.Nix, nixEnabled)
+	dockerEnabled := 0
+	if req.Docker {
+		dockerEnabled = 1
+	}
+	log.Printf("[create] claw %s: req.Nix=%v nixEnabled=%d docker=%d", req.Name, req.Nix, nixEnabled, dockerEnabled)
 
 	// Resolve default model: explicit > llm_key lookup > default key > hub default
 	defaultModel := req.DefaultModel
@@ -786,9 +790,9 @@ func (s *Server) handleCreateClaw(w http.ResponseWriter, r *http.Request, tenant
 	}
 
 	_, err := s.db.Exec(
-		`INSERT INTO claws(id, tenant_id, name, template, provider, default_model, template_files, github_repos, linear_workspace, nix, tags, color, llm_key, auto_fix_ci, auto_fix_bugbot, status, created_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,'provisioning',?)`,
+		`INSERT INTO claws(id, tenant_id, name, template, provider, default_model, template_files, github_repos, linear_workspace, nix, docker, tags, color, llm_key, auto_fix_ci, auto_fix_bugbot, status, created_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,'provisioning',?)`,
 		clawID, tenantID, req.Name, req.TemplateName, req.Provider, req.DefaultModel, string(filesJSON),
-		githubReposJSON, linearWorkspace, nixEnabled, string(tagsJSON), color, req.LLMKey, autoFixCI, autoFixBugbot, now(),
+		githubReposJSON, linearWorkspace, nixEnabled, dockerEnabled, string(tagsJSON), color, req.LLMKey, autoFixCI, autoFixBugbot, now(),
 	)
 	if err != nil {
 		http.Error(w, "db error", http.StatusInternalServerError)
@@ -1975,6 +1979,48 @@ openclaw --version`); err != nil {
 		return err
 	}
 
+	// Step 1b: Install Nix (Determinate Systems) if requested.
+	var nixEnabled int
+	_ = s.db.QueryRow(`SELECT nix FROM claws WHERE id=?`, clawID).Scan(&nixEnabled)
+	if nixEnabled == 1 {
+		if err := exec("install nix", 3*time.Minute,
+			`export HOME=/home/daytona; \
+curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | \
+  sh -s -- install linux --no-confirm --init none >> /tmp/nix-install.log 2>&1; \
+. /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh 2>/dev/null || true; \
+nix --version`); err != nil {
+			log.Printf("[daytona] warning: nix install failed: %v", err)
+		}
+	}
+
+	// Step 1c: Install Docker Engine if requested.
+	var dockerEnabled int
+	_ = s.db.QueryRow(`SELECT docker FROM claws WHERE id=?`, clawID).Scan(&dockerEnabled)
+	if dockerEnabled == 1 {
+		if err := exec("install docker", 3*time.Minute,
+			`export HOME=/home/daytona; \
+. /etc/os-release; \
+if [ "$ID" = "debian" ] && [ -n "$VERSION_CODENAME" ]; then \
+  DOCKER_REPO="deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian $VERSION_CODENAME stable"; \
+  DOCKER_GPG="https://download.docker.com/linux/debian/gpg"; \
+else \
+  DOCKER_REPO="deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable"; \
+  DOCKER_GPG="https://download.docker.com/linux/ubuntu/gpg"; \
+fi; \
+sudo apt-get update -qq && \
+sudo apt-get install -y --fix-broken ca-certificates curl gnupg && \
+sudo install -m 0755 -d /etc/apt/keyrings && \
+curl -fsSL "$DOCKER_GPG" | sudo gpg --batch --yes --dearmor -o /etc/apt/keyrings/docker.gpg && \
+sudo chmod a+r /etc/apt/keyrings/docker.gpg && \
+echo "$DOCKER_REPO" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null && \
+sudo apt-get update -qq && \
+sudo apt-get install -y --fix-broken docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin && \
+sudo usermod -aG docker daytona 2>/dev/null || true && \
+docker --version`); err != nil {
+			log.Printf("[daytona] warning: docker install failed: %v", err)
+		}
+	}
+
 	// Step 2: Onboard (configure OpenClaw) with the correct auth provider
 	var llmKeyNameDaytona string
 	_ = s.db.QueryRow(`SELECT COALESCE(llm_key,'') FROM claws WHERE id=?`, clawID).Scan(&llmKeyNameDaytona)
@@ -2785,7 +2831,11 @@ func (s *Server) bootstrapReplicated(clawID, clawName, vmID string, cfg types.Pr
 	if err := s.db.QueryRow(`SELECT nix FROM claws WHERE id=?`, clawID).Scan(&nixEnabled); err != nil {
 		log.Printf("[bootstrap] warning: could not read nix flag for claw %s: %v", clawID[:8], err)
 	}
-	log.Printf("[bootstrap] claw %s nix=%d", clawID[:8], nixEnabled)
+	var dockerEnabled int
+	if err := s.db.QueryRow(`SELECT docker FROM claws WHERE id=?`, clawID).Scan(&dockerEnabled); err != nil {
+		log.Printf("[bootstrap] warning: could not read docker flag for claw %s: %v", clawID[:8], err)
+	}
+	log.Printf("[bootstrap] claw %s nix=%d docker=%d", clawID[:8], nixEnabled, dockerEnabled)
 	// Read llm_key selection
 	var llmKeyName string
 	_ = s.db.QueryRow(`SELECT COALESCE(llm_key,'') FROM claws WHERE id=?`, clawID).Scan(&llmKeyName)
@@ -2838,6 +2888,7 @@ func (s *Server) bootstrapReplicated(clawID, clawName, vmID string, cfg types.Pr
 		GatewayPassword: gatewayPassword,
 		BridgeURL:       bridgeURL,
 		Nix:             nixEnabled != 0,
+		Docker:          dockerEnabled != 0,
 		HubCfg:          hubCfg,
 		GitHubRepos:     githubRepos,
 		LLMKeyEnv:       llmKeyEnv,

--- a/pkg/hub/shortcut.go
+++ b/pkg/hub/shortcut.go
@@ -473,6 +473,7 @@ func (s *Server) createClawForShortcutStory(factory *types.FactoryConfig, action
 		defaultModel    string
 		llmKey          string
 		nixEnabled      int
+		dockerEnabled   int
 		githubRepos     []types.GitHubRepoAccess
 		linearWorkspace string
 	)
@@ -482,6 +483,9 @@ func (s *Server) createClawForShortcutStory(factory *types.FactoryConfig, action
 		llmKey = tmplCfg.LLMKey
 		if tmplCfg.Nix {
 			nixEnabled = 1
+		}
+		if tmplCfg.Docker {
+			dockerEnabled = 1
 		}
 		if tmplCfg.GitHub != nil {
 			githubRepos = tmplCfg.GitHub.Repos
@@ -533,10 +537,10 @@ func (s *Server) createClawForShortcutStory(factory *types.FactoryConfig, action
 	now := now()
 
 	_, err = s.db.Exec(`
-		INSERT INTO claws(id, tenant_id, name, template, provider, default_model, template_files, github_repos, linear_workspace, nix, tags, color, llm_key, linear_issue_id, status, created_at)
-		VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,'provisioning',?)`,
+		INSERT INTO claws(id, tenant_id, name, template, provider, default_model, template_files, github_repos, linear_workspace, nix, docker, tags, color, llm_key, linear_issue_id, status, created_at)
+		VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,'provisioning',?)`,
 		clawID, tenantID, clawName, factory.Template, provider, defaultModel, string(filesJSON),
-		string(githubReposJSON), linearWorkspace, nixEnabled, string(tagsJSON), clawColor, llmKey, storyID, now,
+		string(githubReposJSON), linearWorkspace, nixEnabled, dockerEnabled, string(tagsJSON), clawColor, llmKey, storyID, now,
 	)
 	if err != nil {
 		return fmt.Errorf("db insert: %w", err)

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -96,6 +96,10 @@ type TemplateConfig struct {
 	// Nix installs the Determinate Systems variant of Nix during bootstrap.
 	// Adds ~2-3 min to bootstrap time. Opt-in only.
 	Nix bool `yaml:"nix,omitempty"`
+	// Docker installs Docker Engine (via the official Docker apt repo) during
+	// bootstrap. Useful for projects that need docker build/run but can't
+	// include Docker in a Nix flake for portability. Opt-in only.
+	Docker bool `yaml:"docker,omitempty"`
 	// Tags are static labels applied to every claw created from this template.
 	// Merged with the auto template=<name> tag and any --tag CLI flags.
 	Tags []string `yaml:"tags,omitempty"`
@@ -417,6 +421,7 @@ type CreateClawRequest struct {
 	GitHub       *GitHubTemplateConfig `json:"github,omitempty"`
 	Linear       *LinearTemplateConfig `json:"linear,omitempty"`
 	Nix          bool                  `json:"nix,omitempty"`
+	Docker       bool                  `json:"docker,omitempty"`
 	Tags         []string              `json:"tags,omitempty"`
 	Color        string                `json:"color,omitempty"`
 	AutoWatchCI     *bool             `json:"auto_watch_ci,omitempty"`


### PR DESCRIPTION
Adds a new `docker: true` option to elasticclaw-config.yaml templates.

When set, the claw bootstrap installs Docker Engine via the official Docker apt repo (docker-ce, docker-ce-cli, containerd.io, docker-buildx-plugin, docker-compose-plugin) in parallel with the existing Nix/OpenClaw installation.

**Why:** Docker can't be included in a Nix flake for portability reasons, but it's commonly needed for projects that use `docker build` or `docker-compose`.

**Changes:**
- New `TemplateConfig.Docker` and `CreateClawRequest.Docker` fields
- New `claws` table column: `docker` (INTEGER NOT NULL DEFAULT 0)
- Bootstrap script passes `ELASTICCLAW_DOCKER` env var to claw-bridge
- `claw-bridge` installs Docker in background, adds user to docker group
- Mirrors the existing `nix: true` pattern exactly

**Usage in template:**
```yaml
nix: true
docker: true
```