### PR TITLE
feat: add GitHub App permission check to settings page

### DIFF
--- a/pkg/hub/github.go
+++ b/pkg/hub/github.go
@@ -23,6 +23,17 @@ type githubInstallation struct {
 	} `json:"account"`
 }
 
+// githubAppPermission is a permission entry in the GitHub App manifest.
+type githubAppPermission struct {
+	Name    string `json:"name"`
+	Granted string `json:"granted"` // "read", "write", or ""
+}
+
+// githubAppMeta is the response from GET /app (authenticated as the App).
+type githubAppMeta struct {
+	Permissions map[string]string `json:"permissions"`
+}
+
 // githubTokenResponse is the GitHub API response for an installation access token.
 type githubTokenResponse struct {
 	Token     string    `json:"token"`
@@ -222,4 +233,37 @@ func (p *GitHubTokenProvider) InstallationToken(ctx context.Context, installatio
 		return "", time.Time{}, fmt.Errorf("decode github response: %w", err)
 	}
 	return result.Token, result.ExpiresAt, nil
+}
+
+// CheckAppPermissions queries the GitHub App's configured permissions via
+// GET /app (authenticated as the App). It returns a map of permission name ->
+// granted level ("read", "write", or "").
+func (p *GitHubTokenProvider) CheckAppPermissions(ctx context.Context) (map[string]string, error) {
+	appJWT, err := p.appJWT()
+	if err != nil {
+		return nil, fmt.Errorf("sign app jwt: %w", err)
+	}
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.github.com/app", nil)
+	req.Header.Set("Authorization", "Bearer "+appJWT)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("github get app: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		var errBody map[string]interface{}
+		json.NewDecoder(resp.Body).Decode(&errBody)
+		return nil, fmt.Errorf("github get app %d: %v", resp.StatusCode, errBody["message"])
+	}
+
+	var meta githubAppMeta
+	if err := json.NewDecoder(resp.Body).Decode(&meta); err != nil {
+		return nil, fmt.Errorf("decode app meta: %w", err)
+	}
+	return meta.Permissions, nil
 }

--- a/pkg/hub/github.go
+++ b/pkg/hub/github.go
@@ -23,12 +23,6 @@ type githubInstallation struct {
 	} `json:"account"`
 }
 
-// githubAppPermission is a permission entry in the GitHub App manifest.
-type githubAppPermission struct {
-	Name    string `json:"name"`
-	Granted string `json:"granted"` // "read", "write", or ""
-}
-
 // githubAppMeta is the response from GET /app (authenticated as the App).
 type githubAppMeta struct {
 	Permissions map[string]string `json:"permissions"`
@@ -244,7 +238,10 @@ func (p *GitHubTokenProvider) CheckAppPermissions(ctx context.Context) (map[stri
 		return nil, fmt.Errorf("sign app jwt: %w", err)
 	}
 
-	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.github.com/app", nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.github.com/app", nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
 	req.Header.Set("Authorization", "Bearer "+appJWT)
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -171,6 +171,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/hub-config", s.withWebAdminAuth(s.handleHubConfig))
 	mux.HandleFunc("/api/settings", s.withWebAdminAuth(s.handleSettings))
 	mux.HandleFunc("/api/settings/status", s.withWebAdminAuth(s.handleSettingsStatus))
+	mux.HandleFunc("/api/settings/github/test", s.withWebAdminAuth(s.handleGitHubAppTest))
 
 	// Template store
 	mux.HandleFunc("/api/templates", s.withWebAuth(s.handleTemplates))

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -1,7 +1,9 @@
 package hub
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/elasticclaw/elasticclaw/pkg/config"
@@ -112,10 +114,21 @@ type ProviderView struct {
 	DefaultInstanceType string `json:"defaultInstanceType,omitempty"`
 }
 
+// GitHubAppPermission is a single permission check result for a GitHub App.
+type GitHubAppPermission struct {
+	Name    string `json:"name"`
+	Granted string `json:"granted"` // "read", "write", or ""
+	Needed  string `json:"needed"`  // "read" or "write"
+	OK      bool   `json:"ok"`
+}
+
 type GitHubAppView struct {
-	AppID  int64  `json:"appId"`
-	URL    string `json:"url,omitempty"`
-	KeySet bool   `json:"keySet"`
+	AppID       int64                 `json:"appId"`
+	URL         string                `json:"url,omitempty"`
+	KeySet      bool                  `json:"keySet"`
+	Permissions []GitHubAppPermission `json:"permissions,omitempty"`
+	PermCheckOK *bool                 `json:"permCheckOk,omitempty"` // nil = not checked yet
+	PermCheckError string           `json:"permCheckError,omitempty"`
 }
 
 // SettingsPatch is the request body for PATCH /api/settings.
@@ -293,11 +306,7 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 
 	// GitHub Apps
 	for _, app := range s.hubCfg.GitHubApps {
-		view.GitHub = append(view.GitHub, GitHubAppView{
-			AppID:  app.AppID,
-			URL:    app.URL,
-			KeySet: app.PrivateKeyPEM != "",
-		})
+		view.GitHub = append(view.GitHub, s.buildGitHubAppView(app))
 	}
 
 	// Integrations
@@ -394,6 +403,60 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 	}
 
 	jsonOK(w, view)
+}
+
+// buildGitHubAppView builds a GitHubAppView for the settings page, including
+// a live permission check if the private key is set.
+func (s *Server) buildGitHubAppView(app *types.GitHubAppConfig) GitHubAppView {
+	view := GitHubAppView{
+		AppID:  app.AppID,
+		URL:    app.URL,
+		KeySet: app.PrivateKeyPEM != "",
+	}
+	if !view.KeySet {
+		return view
+	}
+
+	provider, err := NewGitHubTokenProvider(app)
+	if err != nil {
+		view.PermCheckError = fmt.Sprintf("invalid key: %v", err)
+		return view
+	}
+
+	perms, err := provider.CheckAppPermissions(context.Background())
+	if err != nil {
+		view.PermCheckError = err.Error()
+		return view
+	}
+
+	// Permissions ElasticClaw needs from the GitHub App
+	required := []struct {
+		name   string
+		needed string
+	}{
+		{"contents", "write"},
+		{"pull_requests", "write"},
+		{"metadata", "read"},
+		{"checks", "read"},
+		{"statuses", "read"},
+	}
+
+	allOK := true
+	for _, req := range required {
+		granted := perms[req.name]
+		ok := granted == req.needed || (req.needed == "read" && (granted == "read" || granted == "write"))
+		if !ok {
+			allOK = false
+		}
+		view.Permissions = append(view.Permissions, GitHubAppPermission{
+			Name:    req.name,
+			Granted: granted,
+			Needed:  req.needed,
+			OK:      ok,
+		})
+	}
+	view.PermCheckOK = &allOK
+	return view
 }
 
 func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -459,6 +459,35 @@ func (s *Server) buildGitHubAppView(app *types.GitHubAppConfig) GitHubAppView {
 	return view
 }
 
+// handleGitHubAppTest tests a GitHub App's permissions without saving it.
+func (s *Server) handleGitHubAppTest(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req struct {
+		AppID         int64  `json:"appId"`
+		URL           string `json:"url,omitempty"`
+		PrivateKeyPEM string `json:"privateKeyPem"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	if req.AppID == 0 || req.PrivateKeyPEM == "" {
+		http.Error(w, "appId and privateKeyPem required", http.StatusBadRequest)
+		return
+	}
+
+	app := &types.GitHubAppConfig{
+		AppID:         req.AppID,
+		URL:           req.URL,
+		PrivateKeyPEM: req.PrivateKeyPEM,
+	}
+	view := s.buildGitHubAppView(app)
+	jsonOK(w, view)
+}
+
 func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 	var patch SettingsPatch
 	if err := json.NewDecoder(r.Body).Decode(&patch); err != nil {

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -414,6 +414,7 @@ func (s *Server) buildGitHubAppView(app *types.GitHubAppConfig) GitHubAppView {
 		KeySet: app.PrivateKeyPEM != "",
 	}
 	if !view.KeySet {
+		view.PermCheckError = "Private key is required to test permissions"
 		return view
 	}
 

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -304,9 +304,11 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 		view.SSHPublicKeys = []string{}
 	}
 
-	// GitHub Apps
-	for _, app := range s.hubCfg.GitHubApps {
-		view.GitHub = append(view.GitHub, s.buildGitHubAppView(app))
+	// GitHub Apps — copy configs under lock, check permissions after releasing lock
+	ghAppCfgs := make([]*types.GitHubAppConfig, len(s.hubCfg.GitHubApps))
+	for i, app := range s.hubCfg.GitHubApps {
+		copy := *app
+		ghAppCfgs[i] = &copy
 	}
 
 	// Integrations
@@ -394,6 +396,11 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 	}
 	s.mu.RUnlock()
 
+	// Check GitHub App permissions outside the lock (network call)
+	for _, app := range ghAppCfgs {
+		view.GitHub = append(view.GitHub, s.buildGitHubAppView(r.Context(), app))
+	}
+
 	// Secrets — names only, read from disk so manually-edited hub.yaml entries are visible
 	view.Secrets = []string{}
 	if diskCfg, err := config.LoadHubConfig(); err == nil && diskCfg != nil {
@@ -407,7 +414,7 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 
 // buildGitHubAppView builds a GitHubAppView for the settings page, including
 // a live permission check if the private key is set.
-func (s *Server) buildGitHubAppView(app *types.GitHubAppConfig) GitHubAppView {
+func (s *Server) buildGitHubAppView(ctx context.Context, app *types.GitHubAppConfig) GitHubAppView {
 	view := GitHubAppView{
 		AppID:  app.AppID,
 		URL:    app.URL,
@@ -424,7 +431,7 @@ func (s *Server) buildGitHubAppView(app *types.GitHubAppConfig) GitHubAppView {
 		return view
 	}
 
-	perms, err := provider.CheckAppPermissions(context.Background())
+	perms, err := provider.CheckAppPermissions(ctx)
 	if err != nil {
 		view.PermCheckError = err.Error()
 		return view
@@ -485,7 +492,7 @@ func (s *Server) handleGitHubAppTest(w http.ResponseWriter, r *http.Request) {
 		URL:           req.URL,
 		PrivateKeyPEM: req.PrivateKeyPEM,
 	}
-	view := s.buildGitHubAppView(app)
+	view := s.buildGitHubAppView(r.Context(), app)
 	jsonOK(w, view)
 }
 

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -748,6 +748,18 @@ function GitHubSection({ settings, onSave, saving }: { settings: SettingsData; o
                 </div>
               )}
 
+              {/* Test result — success banner when all OK */}
+              {testResult && testResult.permCheckOk === true && (
+                <div className="rounded-lg bg-green-500/10 border border-green-500/20 px-3 py-2.5 flex items-center gap-2">
+                  <CheckCircle2 className="size-4 text-green-400" />
+                  <div>
+                    <p className="text-xs font-medium text-green-400">All {totalCount} required permissions granted</p>
+                    <p className="text-xs text-green-400/70">This GitHub App is ready to use.</p>
+                  </div>
+                </div>
+              )}
+
+              {/* Test result — permission details (shown for both OK and not-OK) */}
               {testResult && testResult.permissions && testResult.permissions.length > 0 && (
                 <div className="space-y-3">
                   {testResult.permCheckOk === false && (
@@ -770,13 +782,6 @@ function GitHubSection({ settings, onSave, saving }: { settings: SettingsData; o
                           </Button>
                         </a>
                       )}
-                    </div>
-                  )}
-
-                  {testResult.permCheckOk === true && (
-                    <div className="rounded-lg bg-green-500/10 border border-green-500/20 px-3 py-2.5 flex items-center gap-2">
-                      <CheckCircle2 className="size-4 text-green-400" />
-                      <p className="text-xs font-medium text-green-400">All {totalCount} required permissions granted</p>
                     </div>
                   )}
 

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -748,77 +748,90 @@ function GitHubSection({ settings, onSave, saving }: { settings: SettingsData; o
                 </div>
               )}
 
-              {/* Test result — success banner when all OK */}
-              {testResult && testResult.permCheckOk === true && (
-                <div className="rounded-lg bg-green-500/10 border border-green-500/20 px-3 py-2.5 flex items-center gap-2">
-                  <CheckCircle2 className="size-4 text-green-400" />
-                  <div>
-                    <p className="text-xs font-medium text-green-400">All {totalCount} required permissions granted</p>
-                    <p className="text-xs text-green-400/70">This GitHub App is ready to use.</p>
-                  </div>
-                </div>
-              )}
-
-              {/* Test result — permission details (shown for both OK and not-OK) */}
-              {testResult && testResult.permissions && testResult.permissions.length > 0 && (
+              {/* Test result — show SOMETHING for every result state */}
+              {testResult && (
                 <div className="space-y-3">
-                  {testResult.permCheckOk === false && (
-                    <div className="rounded-lg bg-yellow-500/10 border border-yellow-500/20 px-3 py-2.5 flex items-center justify-between">
-                      <div className="flex items-center gap-2">
-                        <Shield className="size-4 text-yellow-400" />
-                        <div>
-                          <p className="text-xs font-medium text-yellow-400">
-                            {needsAttention} permission{needsAttention !== 1 ? "s" : ""} need attention
-                          </p>
-                          <p className="text-xs text-yellow-400/70">
-                            {configuredCount} of {totalCount} required permissions granted
-                          </p>
-                        </div>
+                  {/* permCheckOk is true — all good */}
+                  {testResult.permCheckOk === true && (
+                    <div className="rounded-lg bg-green-500/10 border border-green-500/20 px-3 py-2.5 flex items-center gap-2">
+                      <CheckCircle2 className="size-4 text-green-400" />
+                      <div>
+                        <p className="text-xs font-medium text-green-400">All {totalCount} required permissions granted</p>
+                        <p className="text-xs text-green-400/70">This GitHub App is ready to use.</p>
                       </div>
-                      {url && (
-                        <a href={url} target="_blank" rel="noopener noreferrer">
-                          <Button size="sm" variant="outline" className="h-7 text-xs gap-1">
-                            <ExternalLink className="size-3" /> Fix in GitHub
-                          </Button>
-                        </a>
-                      )}
                     </div>
                   )}
 
-                  <div className="space-y-1">
-                    {testResult.permissions.filter(p => !p.ok).length > 0 && (
-                      <>
-                        <p className="text-[10px] uppercase tracking-wider text-muted-foreground/60 font-medium">Needs Attention</p>
-                        {testResult.permissions.filter(p => !p.ok).map(p => (
-                          <div key={p.name} className="flex items-center justify-between rounded-lg bg-yellow-500/10 border border-yellow-500/20 px-3 py-2">
-                            <div className="flex items-center gap-2">
-                              <AlertTriangle className="size-3.5 text-yellow-400" />
-                              <span className="text-sm font-mono text-yellow-400">{p.name}</span>
-                            </div>
-                            <div className="flex items-center gap-1.5 text-xs">
-                              <span className="px-1.5 py-0.5 rounded bg-yellow-500/20 text-yellow-400">{p.granted || "not set"}</span>
-                              <span className="text-muted-foreground">→</span>
-                              <span className="px-1.5 py-0.5 rounded border border-yellow-500/30 text-yellow-400">needs {p.needed}</span>
+                  {/* permCheckOk is false or missing — show the problem */}
+                  {(testResult.permCheckOk === false || testResult.permCheckOk == null) && (
+                    <>
+                      {testResult.permCheckError ? (
+                        <div className="rounded-lg bg-yellow-500/10 border border-yellow-500/20 px-3 py-2.5 flex items-start gap-2">
+                          <AlertTriangle className="size-4 text-yellow-400 shrink-0 mt-0.5" />
+                          <p className="text-xs text-yellow-400">{testResult.permCheckError}</p>
+                        </div>
+                      ) : (
+                        <div className="rounded-lg bg-yellow-500/10 border border-yellow-500/20 px-3 py-2.5 flex items-center justify-between">
+                          <div className="flex items-center gap-2">
+                            <Shield className="size-4 text-yellow-400" />
+                            <div>
+                              <p className="text-xs font-medium text-yellow-400">
+                                {needsAttention} permission{needsAttention !== 1 ? "s" : ""} need attention
+                              </p>
+                              <p className="text-xs text-yellow-400/70">
+                                {configuredCount} of {totalCount} required permissions granted
+                              </p>
                             </div>
                           </div>
-                        ))}
-                      </>
-                    )}
-                    {testResult.permissions.filter(p => p.ok).length > 0 && (
-                      <>
-                        <p className="text-[10px] uppercase tracking-wider text-muted-foreground/60 font-medium mt-2">Configured</p>
-                        {testResult.permissions.filter(p => p.ok).map(p => (
-                          <div key={p.name} className="flex items-center justify-between rounded-lg bg-green-500/10 border border-green-500/20 px-3 py-2">
-                            <div className="flex items-center gap-2">
-                              <CheckCircle2 className="size-3.5 text-green-400" />
-                              <span className="text-sm font-mono text-green-400">{p.name}</span>
+                          {url && (
+                            <a href={url} target="_blank" rel="noopener noreferrer">
+                              <Button size="sm" variant="outline" className="h-7 text-xs gap-1">
+                                <ExternalLink className="size-3" /> Fix in GitHub
+                              </Button>
+                            </a>
+                          )}
+                        </div>
+                      )}
+                    </>
+                  )}
+
+                  {/* Permission list — shown whenever we have permissions */}
+                  {testResult.permissions && testResult.permissions.length > 0 && (
+                    <div className="space-y-1">
+                      {testResult.permissions.filter(p => !p.ok).length > 0 && (
+                        <>
+                          <p className="text-[10px] uppercase tracking-wider text-muted-foreground/60 font-medium">Needs Attention</p>
+                          {testResult.permissions.filter(p => !p.ok).map(p => (
+                            <div key={p.name} className="flex items-center justify-between rounded-lg bg-yellow-500/10 border border-yellow-500/20 px-3 py-2">
+                              <div className="flex items-center gap-2">
+                                <AlertTriangle className="size-3.5 text-yellow-400" />
+                                <span className="text-sm font-mono text-yellow-400">{p.name}</span>
+                              </div>
+                              <div className="flex items-center gap-1.5 text-xs">
+                                <span className="px-1.5 py-0.5 rounded bg-yellow-500/20 text-yellow-400">{p.granted || "not set"}</span>
+                                <span className="text-muted-foreground">→</span>
+                                <span className="px-1.5 py-0.5 rounded border border-yellow-500/30 text-yellow-400">needs {p.needed}</span>
+                              </div>
                             </div>
-                            <span className="text-xs px-1.5 py-0.5 rounded bg-green-500/20 text-green-400">{p.granted}</span>
-                          </div>
-                        ))}
-                      </>
-                    )}
-                  </div>
+                          ))}
+                        </>
+                      )}
+                      {testResult.permissions.filter(p => p.ok).length > 0 && (
+                        <>
+                          <p className="text-[10px] uppercase tracking-wider text-muted-foreground/60 font-medium mt-2">Configured</p>
+                          {testResult.permissions.filter(p => p.ok).map(p => (
+                            <div key={p.name} className="flex items-center justify-between rounded-lg bg-green-500/10 border border-green-500/20 px-3 py-2">
+                              <div className="flex items-center gap-2">
+                                <CheckCircle2 className="size-3.5 text-green-400" />
+                                <span className="text-sm font-mono text-green-400">{p.name}</span>
+                              </div>
+                              <span className="text-xs px-1.5 py-0.5 rounded bg-green-500/20 text-green-400">{p.granted}</span>
+                            </div>
+                          ))}
+                        </>
+                      )}
+                    </div>
+                  )}
                 </div>
               )}
             </div>

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -25,6 +25,22 @@ interface LLMKeyView {
   defaultModel?: string
 }
 
+interface GitHubAppPermission {
+  name: string
+  granted: string
+  needed: string
+  ok: boolean
+}
+
+interface GitHubAppView {
+  appId: number
+  url?: string
+  keySet: boolean
+  permissions?: GitHubAppPermission[]
+  permCheckOk?: boolean
+  permCheckError?: string
+}
+
 interface SettingsData {
   llmKeys: LLMKeyView[]
   providers: Record<string, {
@@ -37,7 +53,7 @@ interface SettingsData {
     defaultTtl?: string
     defaultInstanceType?: string
   }>
-  github: Array<{ appId: number; url?: string; keySet: boolean }>
+  github: GitHubAppView[]
   sshPublicKeys: string[]
   integrations?: {
     linear?: Array<{ workspace: string; tokenSet: boolean; webhookSecretSet: boolean }>
@@ -548,6 +564,34 @@ function GitHubSection({ settings, onSave, saving }: { settings: SettingsData; o
                   </Button>
                 </div>
               </div>
+
+              {/* Permission check results */}
+              {app.permCheckError && (
+                <div className="mt-2 text-xs text-red-500 bg-red-500/10 rounded px-2 py-1.5">
+                  ⚠ {app.permCheckError}
+                </div>
+              )}
+              {app.permissions && app.permissions.length > 0 && (
+                <div className="mt-2">
+                  <p className="text-xs font-medium text-muted-foreground mb-1.5">Required permissions</p>
+                  <div className="grid grid-cols-2 gap-1.5">
+                    {app.permissions.map(p => (
+                      <div key={p.name} className={cn(
+                        "flex items-center justify-between text-xs rounded px-2 py-1",
+                        p.ok ? "bg-green-500/10 text-green-400" : "bg-red-500/10 text-red-400"
+                      )}>
+                        <span className="font-mono">{p.name}</span>
+                        <span>{p.granted || "—"} <span className="text-muted-foreground/60">/ need {p.needed}</span></span>
+                      </div>
+                    ))}
+                  </div>
+                  {app.permCheckOk === false && (
+                    <p className="text-xs text-red-500 mt-1.5">
+                      Missing permissions. Update the GitHub App settings and re-install on your org.
+                    </p>
+                  )}
+                </div>
+              )}
             </div>
           ))}
         </div>

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -592,9 +592,18 @@ function GitHubSection({ settings, onSave, saving }: { settings: SettingsData; o
   return (
     <div>
       <h2 className="text-base font-semibold mb-1">GitHub Apps</h2>
-      <p className="text-sm text-muted-foreground mb-6">
-        GitHub App credentials for claws to access repositories. <span className="text-muted-foreground/60">(Optional)</span>
-      </p>
+      <div className="text-sm text-muted-foreground mb-6 space-y-1.5">
+        <p>
+          Register a GitHub App so your ElasticClaw templates can access repositories.
+          When a claw is created, it gets a scoped token that can read and write code,
+          open pull requests, and check CI status — but only on repos the App is installed on.
+        </p>
+        <p>
+          The App needs <strong>contents:write</strong>, <strong>pull_requests:write</strong>,
+          and read access to <strong>metadata</strong>, <strong>checks</strong>, and <strong>statuses</strong>.
+          Install it on your org or specific repos, then add the App ID and private key here.
+        </p>
+      </div>
 
       {settings.github?.length > 0 && (
         <div className="mb-6 space-y-2">

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -565,7 +565,19 @@ function GitHubSection({ settings, onSave, saving }: { settings: SettingsData; o
     }
   }
 
-  function doSave() {
+  const [showConfirmModal, setShowConfirmModal] = useState(false)
+
+  function doSave(force = false) {
+    // Not tested yet — recommend testing
+    if (!force && testResult === null) {
+      setShowConfirmModal(true)
+      return
+    }
+    // Tested and failed — warn but allow
+    if (!force && testResult && testResult.permCheckOk !== true) {
+      setShowConfirmModal(true)
+      return
+    }
     const parsedAppId = parseInt(appId, 10)
     const newApp: { appId: number; privateKeyPem: string; url?: string } = { appId: parsedAppId, privateKeyPem: pem }
     if (url) newApp.url = url
@@ -838,7 +850,45 @@ function GitHubSection({ settings, onSave, saving }: { settings: SettingsData; o
 
             <div className="flex items-center justify-end gap-2 px-5 py-4 border-t border-border">
               <Button size="sm" variant="outline" onClick={closeModal}>Cancel</Button>
-              <Button size="sm" disabled={saving || !appId || !pem || isNaN(Number(appId))} onClick={doSave}>
+              <Button size="sm" disabled={saving || !appId || !pem || isNaN(Number(appId))} onClick={() => doSave(false)}>
+                Save
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Confirm save modal — not tested or test failed */}
+      {showConfirmModal && (
+        <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50 p-4">
+          <div className="bg-background border border-border rounded-xl shadow-lg w-full max-w-md p-5 space-y-4">
+            {testResult === null ? (
+              <>
+                <div className="flex items-center gap-2">
+                  <AlertTriangle className="size-5 text-yellow-400" />
+                  <h3 className="font-medium">Test Recommended</h3>
+                </div>
+                <p className="text-sm text-muted-foreground">
+                  You haven't tested this GitHub App yet. We recommend clicking <strong>Test Permissions</strong> first to verify it works.
+                </p>
+              </>
+            ) : (
+              <>
+                <div className="flex items-center gap-2">
+                  <AlertTriangle className="size-5 text-yellow-400" />
+                  <h3 className="font-medium">Permissions Missing</h3>
+                </div>
+                <p className="text-sm text-muted-foreground">
+                  This GitHub App is missing required permissions. It <strong>will not work</strong> for claws until fixed.
+                </p>
+                {testResult.permCheckError && (
+                  <p className="text-xs text-yellow-400 bg-yellow-500/10 rounded px-2 py-1.5">{testResult.permCheckError}</p>
+                )}
+              </>
+            )}
+            <div className="flex items-center justify-end gap-2 pt-2">
+              <Button size="sm" variant="outline" onClick={() => setShowConfirmModal(false)}>Go Back</Button>
+              <Button size="sm" variant="secondary" onClick={() => { setShowConfirmModal(false); doSave(true) }}>
                 Save Anyway
               </Button>
             </div>

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -3,7 +3,7 @@
 import { useParams, useRouter } from "next/navigation"
 import React, { useEffect, useState, useCallback, useRef } from "react"
 import { getHubUrl } from "@/lib/hub-url"
-import { Cpu, Key, Github, ChevronLeft, Shield, Zap, Factory, Copy, Check, LayoutTemplate, Trash2, Lock, Sparkles, Send, RotateCcw, Eye, EyeOff } from "lucide-react"
+import { Cpu, Key, Github, ChevronLeft, Shield, Zap, Factory, Copy, Check, LayoutTemplate, Trash2, Lock, Sparkles, Send, RotateCcw, Eye, EyeOff, ExternalLink, AlertTriangle, X, CheckCircle2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { cn } from "@/lib/utils"
@@ -527,9 +527,55 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
 }
 
 function GitHubSection({ settings, onSave, saving }: { settings: SettingsData; onSave: (p: object) => void; saving: boolean }) {
+  const [showModal, setShowModal] = useState(false)
   const [appId, setAppId] = useState("")
   const [url, setUrl] = useState("")
   const [pem, setPem] = useState("")
+  const [testResult, setTestResult] = useState<GitHubAppView | null>(null)
+  const [testing, setTesting] = useState(false)
+  const [testError, setTestError] = useState("")
+
+  const resetModal = () => {
+    setAppId(""); setUrl(""); setPem("")
+    setTestResult(null); setTestError(""); setTesting(false)
+  }
+
+  const openModal = () => { resetModal(); setShowModal(true) }
+  const closeModal = () => { setShowModal(false); resetModal() }
+
+  async function runTest() {
+    setTesting(true); setTestError(""); setTestResult(null)
+    try {
+      const hubUrl = getHubUrl()
+      const token = sessionStorage.getItem("ec_github_token") || sessionStorage.getItem("ec_hub_token") || ""
+      const res = await fetch(`${hubUrl}/api/settings/github/test`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+        body: JSON.stringify({ appId: parseInt(appId, 10), url, privateKeyPem: pem }),
+      })
+      if (!res.ok) {
+        const txt = await res.text()
+        throw new Error(txt || `HTTP ${res.status}`)
+      }
+      setTestResult(await res.json())
+    } catch (e) {
+      setTestError(e instanceof Error ? e.message : "Test failed")
+    } finally {
+      setTesting(false)
+    }
+  }
+
+  function doSave() {
+    const parsedAppId = parseInt(appId, 10)
+    const newApp: { appId: number; privateKeyPem: string; url?: string } = { appId: parsedAppId, privateKeyPem: pem }
+    if (url) newApp.url = url
+    onSave({ github: [...(settings.github || []), newApp] })
+    closeModal()
+  }
+
+  const needsAttention = testResult?.permissions?.filter(p => !p.ok).length ?? 0
+  const configuredCount = testResult?.permissions?.filter(p => p.ok).length ?? 0
+  const totalCount = testResult?.permissions?.length ?? 0
 
   return (
     <div>
@@ -545,7 +591,11 @@ function GitHubSection({ settings, onSave, saving }: { settings: SettingsData; o
               <div className="flex items-center justify-between mb-2">
                 <div>
                   <p className="text-sm font-medium">App ID: {app.appId}</p>
-                  {app.url && <p className="text-xs text-muted-foreground">{app.url}</p>}
+                  {app.url && (
+                    <a href={app.url} target="_blank" rel="noopener noreferrer" className="text-xs text-muted-foreground hover:text-primary flex items-center gap-1">
+                      {app.url} <ExternalLink className="size-3" />
+                    </a>
+                  )}
                 </div>
                 <div className="flex items-center gap-2">
                   <span className={cn("text-xs px-2 py-1 rounded", app.keySet ? "bg-green-500/20 text-green-400" : "bg-yellow-500/20 text-yellow-400")}>
@@ -560,36 +610,87 @@ function GitHubSection({ settings, onSave, saving }: { settings: SettingsData; o
                       })
                       onSave({ github: filtered })
                     }}>
-                    Remove
+                    <Trash2 className="size-3.5" />
                   </Button>
                 </div>
               </div>
 
               {/* Permission check results */}
               {app.permCheckError && (
-                <div className="mt-2 text-xs text-red-500 bg-red-500/10 rounded px-2 py-1.5">
-                  ⚠ {app.permCheckError}
+                <div className="mt-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20 px-3 py-2.5 flex items-start gap-2">
+                  <AlertTriangle className="size-4 text-yellow-400 shrink-0 mt-0.5" />
+                  <div>
+                    <p className="text-xs font-medium text-yellow-400">Permission check failed</p>
+                    <p className="text-xs text-yellow-400/80">{app.permCheckError}</p>
+                  </div>
                 </div>
               )}
               {app.permissions && app.permissions.length > 0 && (
-                <div className="mt-2">
-                  <p className="text-xs font-medium text-muted-foreground mb-1.5">Required permissions</p>
-                  <div className="grid grid-cols-2 gap-1.5">
-                    {app.permissions.map(p => (
-                      <div key={p.name} className={cn(
-                        "flex items-center justify-between text-xs rounded px-2 py-1",
-                        p.ok ? "bg-green-500/10 text-green-400" : "bg-red-500/10 text-red-400"
-                      )}>
-                        <span className="font-mono">{p.name}</span>
-                        <span>{p.granted || "—"} <span className="text-muted-foreground/60">/ need {p.needed}</span></span>
-                      </div>
-                    ))}
-                  </div>
+                <div className="mt-3">
                   {app.permCheckOk === false && (
-                    <p className="text-xs text-red-500 mt-1.5">
-                      Missing permissions. Update the GitHub App settings and re-install on your org.
-                    </p>
+                    <div className="rounded-lg bg-yellow-500/10 border border-yellow-500/20 px-3 py-2.5 mb-2 flex items-center justify-between">
+                      <div className="flex items-center gap-2">
+                        <Shield className="size-4 text-yellow-400" />
+                        <div>
+                          <p className="text-xs font-medium text-yellow-400">
+                            {app.permissions.filter(p => !p.ok).length} permission{app.permissions.filter(p => !p.ok).length !== 1 ? "s" : ""} need attention
+                          </p>
+                          <p className="text-xs text-yellow-400/70">
+                            {app.permissions.filter(p => p.ok).length} of {app.permissions.length} required permissions granted
+                          </p>
+                        </div>
+                      </div>
+                      {app.url && (
+                        <a href={app.url} target="_blank" rel="noopener noreferrer">
+                          <Button size="sm" variant="outline" className="h-7 text-xs gap-1">
+                            <ExternalLink className="size-3" /> Fix in GitHub
+                          </Button>
+                        </a>
+                      )}
+                    </div>
                   )}
+
+                  <details className="group" open={app.permCheckOk === false}>
+                    <summary className="flex items-center gap-2 text-xs font-medium text-muted-foreground cursor-pointer list-none">
+                      <Shield className="size-3.5" />
+                      Required Permissions
+                      <ChevronLeft className="size-3 transition-transform group-open:-rotate-90" />
+                    </summary>
+
+                    {app.permissions.filter(p => !p.ok).length > 0 && (
+                      <div className="mt-2 space-y-1">
+                        <p className="text-[10px] uppercase tracking-wider text-muted-foreground/60 font-medium">Needs Attention</p>
+                        {app.permissions.filter(p => !p.ok).map(p => (
+                          <div key={p.name} className="flex items-center justify-between rounded-lg bg-yellow-500/10 border border-yellow-500/20 px-3 py-2">
+                            <div className="flex items-center gap-2">
+                              <AlertTriangle className="size-3.5 text-yellow-400" />
+                              <span className="text-sm font-mono text-yellow-400">{p.name}</span>
+                            </div>
+                            <div className="flex items-center gap-1.5 text-xs">
+                              <span className="px-1.5 py-0.5 rounded bg-yellow-500/20 text-yellow-400">{p.granted || "not set"}</span>
+                              <span className="text-muted-foreground">→</span>
+                              <span className="px-1.5 py-0.5 rounded border border-yellow-500/30 text-yellow-400">needs {p.needed}</span>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+
+                    {app.permissions.filter(p => p.ok).length > 0 && (
+                      <div className="mt-2 space-y-1">
+                        <p className="text-[10px] uppercase tracking-wider text-muted-foreground/60 font-medium">Configured</p>
+                        {app.permissions.filter(p => p.ok).map(p => (
+                          <div key={p.name} className="flex items-center justify-between rounded-lg bg-green-500/10 border border-green-500/20 px-3 py-2">
+                            <div className="flex items-center gap-2">
+                              <CheckCircle2 className="size-3.5 text-green-400" />
+                              <span className="text-sm font-mono text-green-400">{p.name}</span>
+                            </div>
+                            <span className="text-xs px-1.5 py-0.5 rounded bg-green-500/20 text-green-400">{p.granted}</span>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </details>
                 </div>
               )}
             </div>
@@ -597,39 +698,135 @@ function GitHubSection({ settings, onSave, saving }: { settings: SettingsData; o
         </div>
       )}
 
-      <div className="border border-border rounded-lg p-5">
-        <h3 className="font-medium text-sm mb-4">Add GitHub App</h3>
-        <div className="space-y-3">
-          <div className="grid grid-cols-2 gap-3">
-            <div>
-              <label className="text-xs text-muted-foreground mb-1 block">App ID</label>
-              <Input type="number" value={appId} onChange={e => setAppId(e.target.value)} className="h-8 text-sm" placeholder="123456" />
+      <Button onClick={openModal} className="gap-2">
+        <Github className="size-4" /> Add GitHub App
+      </Button>
+
+      {/* Modal */}
+      {showModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+          <div className="bg-background border border-border rounded-xl shadow-lg w-full max-w-lg max-h-[90vh] overflow-y-auto">
+            <div className="flex items-center justify-between px-5 py-4 border-b border-border">
+              <h3 className="font-medium">Add GitHub App</h3>
+              <Button size="sm" variant="ghost" onClick={closeModal} className="h-8 w-8 p-0">
+                <X className="size-4" />
+              </Button>
             </div>
-            <div>
-              <label className="text-xs text-muted-foreground mb-1 block">App URL (optional)</label>
-              <Input value={url} onChange={e => setUrl(e.target.value)} className="h-8 text-sm" placeholder="https://github.com/apps/..." />
+
+            <div className="p-5 space-y-4">
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className="text-xs text-muted-foreground mb-1 block">App ID</label>
+                  <Input type="number" value={appId} onChange={e => setAppId(e.target.value)} className="h-8 text-sm" placeholder="123456" />
+                </div>
+                <div>
+                  <label className="text-xs text-muted-foreground mb-1 block">App URL (optional)</label>
+                  <Input value={url} onChange={e => setUrl(e.target.value)} className="h-8 text-sm" placeholder="https://github.com/apps/..." />
+                </div>
+              </div>
+              <div>
+                <label className="text-xs text-muted-foreground mb-1 block">Private Key (PEM)</label>
+                <textarea
+                  value={pem}
+                  onChange={e => setPem(e.target.value)}
+                  placeholder="-----BEGIN RSA PRIVATE KEY-----&#10;...&#10;-----END RSA PRIVATE KEY-----"
+                  className="w-full h-32 rounded-md border border-border bg-background px-3 py-2 text-xs font-mono resize-none focus:outline-none focus:ring-2 focus:ring-ring"
+                />
+              </div>
+
+              <div className="flex gap-2">
+                <Button size="sm" variant="outline" disabled={testing || !appId || !pem || isNaN(Number(appId))} onClick={runTest} className="gap-1">
+                  {testing ? <RotateCcw className="size-3 animate-spin" /> : <Check className="size-3" />}
+                  Test Permissions
+                </Button>
+              </div>
+
+              {testError && (
+                <div className="rounded-lg bg-red-500/10 border border-red-500/20 px-3 py-2.5 flex items-start gap-2">
+                  <AlertTriangle className="size-4 text-red-400 shrink-0 mt-0.5" />
+                  <p className="text-xs text-red-400">{testError}</p>
+                </div>
+              )}
+
+              {testResult && testResult.permissions && testResult.permissions.length > 0 && (
+                <div className="space-y-3">
+                  {testResult.permCheckOk === false && (
+                    <div className="rounded-lg bg-yellow-500/10 border border-yellow-500/20 px-3 py-2.5 flex items-center justify-between">
+                      <div className="flex items-center gap-2">
+                        <Shield className="size-4 text-yellow-400" />
+                        <div>
+                          <p className="text-xs font-medium text-yellow-400">
+                            {needsAttention} permission{needsAttention !== 1 ? "s" : ""} need attention
+                          </p>
+                          <p className="text-xs text-yellow-400/70">
+                            {configuredCount} of {totalCount} required permissions granted
+                          </p>
+                        </div>
+                      </div>
+                      {url && (
+                        <a href={url} target="_blank" rel="noopener noreferrer">
+                          <Button size="sm" variant="outline" className="h-7 text-xs gap-1">
+                            <ExternalLink className="size-3" /> Fix in GitHub
+                          </Button>
+                        </a>
+                      )}
+                    </div>
+                  )}
+
+                  {testResult.permCheckOk === true && (
+                    <div className="rounded-lg bg-green-500/10 border border-green-500/20 px-3 py-2.5 flex items-center gap-2">
+                      <CheckCircle2 className="size-4 text-green-400" />
+                      <p className="text-xs font-medium text-green-400">All {totalCount} required permissions granted</p>
+                    </div>
+                  )}
+
+                  <div className="space-y-1">
+                    {testResult.permissions.filter(p => !p.ok).length > 0 && (
+                      <>
+                        <p className="text-[10px] uppercase tracking-wider text-muted-foreground/60 font-medium">Needs Attention</p>
+                        {testResult.permissions.filter(p => !p.ok).map(p => (
+                          <div key={p.name} className="flex items-center justify-between rounded-lg bg-yellow-500/10 border border-yellow-500/20 px-3 py-2">
+                            <div className="flex items-center gap-2">
+                              <AlertTriangle className="size-3.5 text-yellow-400" />
+                              <span className="text-sm font-mono text-yellow-400">{p.name}</span>
+                            </div>
+                            <div className="flex items-center gap-1.5 text-xs">
+                              <span className="px-1.5 py-0.5 rounded bg-yellow-500/20 text-yellow-400">{p.granted || "not set"}</span>
+                              <span className="text-muted-foreground">→</span>
+                              <span className="px-1.5 py-0.5 rounded border border-yellow-500/30 text-yellow-400">needs {p.needed}</span>
+                            </div>
+                          </div>
+                        ))}
+                      </>
+                    )}
+                    {testResult.permissions.filter(p => p.ok).length > 0 && (
+                      <>
+                        <p className="text-[10px] uppercase tracking-wider text-muted-foreground/60 font-medium mt-2">Configured</p>
+                        {testResult.permissions.filter(p => p.ok).map(p => (
+                          <div key={p.name} className="flex items-center justify-between rounded-lg bg-green-500/10 border border-green-500/20 px-3 py-2">
+                            <div className="flex items-center gap-2">
+                              <CheckCircle2 className="size-3.5 text-green-400" />
+                              <span className="text-sm font-mono text-green-400">{p.name}</span>
+                            </div>
+                            <span className="text-xs px-1.5 py-0.5 rounded bg-green-500/20 text-green-400">{p.granted}</span>
+                          </div>
+                        ))}
+                      </>
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+
+            <div className="flex items-center justify-end gap-2 px-5 py-4 border-t border-border">
+              <Button size="sm" variant="outline" onClick={closeModal}>Cancel</Button>
+              <Button size="sm" disabled={saving || !appId || !pem || isNaN(Number(appId))} onClick={doSave}>
+                Save Anyway
+              </Button>
             </div>
           </div>
-          <div>
-            <label className="text-xs text-muted-foreground mb-1 block">Private Key (PEM)</label>
-            <textarea
-              value={pem}
-              onChange={e => setPem(e.target.value)}
-              placeholder="-----BEGIN RSA PRIVATE KEY-----&#10;...&#10;-----END RSA PRIVATE KEY-----"
-              className="w-full h-32 rounded-md border border-border bg-background px-3 py-2 text-xs font-mono resize-none focus:outline-none focus:ring-2 focus:ring-ring"
-            />
-          </div>
-          <Button size="sm" disabled={saving || !appId || !pem || isNaN(Number(appId))} onClick={() => {
-            const parsedAppId = parseInt(appId, 10)
-            const newApp: { appId: number; privateKeyPem: string; url?: string } = { appId: parsedAppId, privateKeyPem: pem }
-            if (url) newApp.url = url
-            onSave({ github: [...(settings.github || []), newApp] })
-            setAppId(""); setUrl(""); setPem("")
-          }}>
-            Add App
-          </Button>
         </div>
-      </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
Adds live permission validation for configured GitHub Apps on the Settings page.

## Backend
- \+ \+CheckAppPermissions()` on GitHubTokenProvider — queries GitHub's GET /app endpoint (authenticated as the App via JWT) to fetch configured permissions.
- Enriches GitHubAppView with a permission check result in getSettings.

## Frontend
- Each GitHub App card now shows a permission grid: contents, pull_requests, metadata, checks, statuses.
- Green badge = granted level meets or exceeds what's needed.
- Red badge = missing or insufficient.
- Error banner if the check fails (bad key, network issue, etc.).

## Required permissions checked
| Permission | Needed |
|------------|--------|
| contents | write |
| pull_requests | write |
| metadata | read |
| checks | read |
| statuses | read |