### PR TITLE
fix: update generateStaticParams for renamed settings sections

### DIFF
--- a/web/app/settings/[section]/page.tsx
+++ b/web/app/settings/[section]/page.tsx
@@ -1,6 +1,6 @@
 import SettingsSectionPage from "./settings-content"
 
-const VALID_SECTIONS = ["runtimes", "llm", "github", "authentication", "integrations", "factories", "secrets", "templates"]
+const VALID_SECTIONS = ["runtimes", "models", "github", "authentication", "issue-trackers", "factories", "secrets", "templates", "ai-config"]
 
 export function generateStaticParams() {
   return VALID_SECTIONS.map((section) => ({ section }))


### PR DESCRIPTION
- Add 'models' (renamed from 'llm')
- Add 'issue-trackers' (renamed from 'integrations')
- Add 'ai-config' (was missing entirely)
- Remove 'llm' and 'integrations' (old names)

These sections were 404ing in production because Next.js static export only pre-renders paths returned by generateStaticParams.