### PR TITLE
refactor(settings): move MCP servers form into modal

### DIFF
--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -2651,77 +2651,140 @@ function AIConfigSection() {
 
 function MCPServersSection({ settings, onSave, saving }: { settings: SettingsData; onSave: (p: object) => Promise<boolean>; saving: boolean }) {
   const mcps = settings.mcpServers || []
-  const [newMCP, setNewMCP] = useState({
-    name: "",
-    source: "npx" as "npx" | "uvx" | "smithery" | "docker" | "sse",
-    package: "",
-    image: "",
-    url: "",
-    enabled: true,
-    config: {} as Record<string, string>,
-    secrets: {} as Record<string, string>,
-    command: "" as string,
-  })
+  const [showModal, setShowModal] = useState(false)
+  const [modalMode, setModalMode] = useState<"add" | "edit">("add")
+  const [editIdx, setEditIdx] = useState<number | null>(null)
+
+  // Form state
+  const [formName, setFormName] = useState("")
+  const [formSource, setFormSource] = useState<"npx" | "uvx" | "smithery" | "docker" | "sse">("npx")
+  const [formPackage, setFormPackage] = useState("")
+  const [formImage, setFormImage] = useState("")
+  const [formURL, setFormURL] = useState("")
+  const [formEnabled, setFormEnabled] = useState(true)
+  const [formCommand, setFormCommand] = useState("")
+  const [formConfig, setFormConfig] = useState<Record<string, string>>({})
+  const [formSecrets, setFormSecrets] = useState<Record<string, string>>({})
   const [configKey, setConfigKey] = useState("")
   const [configValue, setConfigValue] = useState("")
   const [secretEnvVar, setSecretEnvVar] = useState("")
   const [secretRef, setSecretRef] = useState("")
-  const [localSaving, setLocalSaving] = useState(false)
 
-  const handleAdd = async () => {
-    if (!newMCP.name.trim() || !newMCP.source) return
+  const resetForm = () => {
+    setFormName(""); setFormSource("npx"); setFormPackage(""); setFormImage(""); setFormURL("");
+    setFormEnabled(true); setFormCommand(""); setFormConfig({}); setFormSecrets({});
+    setConfigKey(""); setConfigValue(""); setSecretEnvVar(""); setSecretRef(""); setEditIdx(null)
+  }
+
+  const openAdd = () => { resetForm(); setModalMode("add"); setShowModal(true) }
+  const openEdit = (i: number) => {
+    const m = mcps[i]
+    setFormName(m.name)
+    setFormSource(m.source as typeof formSource)
+    setFormPackage(m.package || "")
+    setFormImage(m.image || "")
+    setFormURL(m.url || "")
+    setFormEnabled(m.enabled)
+    setFormCommand(m.command?.join(" ") || "")
+    setFormConfig(m.config || {})
+    // secrets is array of env var names in the view; we need to reconstruct from... wait,
+    // the view has secrets as string[] (env var names only). We can't edit secret refs
+    // in edit mode without the actual mapping. For now, start empty.
+    setFormSecrets({})
+    setEditIdx(i)
+    setModalMode("edit")
+    setShowModal(true)
+  }
+
+  const needsPackage = formSource === "npx" || formSource === "uvx" || formSource === "smithery"
+  const needsImage = formSource === "docker"
+  const needsURL = formSource === "sse"
+
+  async function doSave() {
     const mcp = {
-      name: newMCP.name.trim(),
-      source: newMCP.source,
-      package: newMCP.package || undefined,
-      image: newMCP.image || undefined,
-      url: newMCP.url || undefined,
-      enabled: newMCP.enabled,
-      config: Object.keys(newMCP.config).length > 0 ? newMCP.config : undefined,
-      secrets: Object.keys(newMCP.secrets).length > 0 ? newMCP.secrets : undefined,
-      command: newMCP.command ? newMCP.command.split(" ").filter(Boolean) : undefined,
+      name: formName.trim(),
+      source: formSource,
+      package: needsPackage ? formPackage.trim() || undefined : undefined,
+      image: needsImage ? formImage.trim() || undefined : undefined,
+      url: needsURL ? formURL.trim() || undefined : undefined,
+      enabled: formEnabled,
+      command: formCommand.trim() ? formCommand.trim().split(/\s+/).filter(Boolean) : undefined,
+      config: Object.keys(formConfig).length > 0 ? formConfig : undefined,
+      secrets: Object.keys(formSecrets).length > 0 ? formSecrets : undefined,
     }
-    const updated = [...mcps.filter(m => m.name !== mcp.name), mcp]
-    setLocalSaving(true)
-    const ok = await onSave({ mcpServers: updated })
-    setLocalSaving(false)
+
+    let ok = false
+    if (modalMode === "add") {
+      const updated = [...mcps.filter(m => m.name !== mcp.name), mcp]
+      ok = await onSave({ mcpServers: updated })
+    } else if (editIdx !== null) {
+      const existing = mcps[editIdx]
+      const patch: Record<string, unknown> = { name: existing.name }
+      if (formName.trim() !== existing.name) patch.newName = formName.trim()
+      if (formSource !== existing.source) patch.source = formSource
+      if (needsPackage && formPackage.trim() !== (existing.package || "")) patch.package = formPackage.trim()
+      if (needsImage && formImage.trim() !== (existing.image || "")) patch.image = formImage.trim()
+      if (needsURL && formURL.trim() !== (existing.url || "")) patch.url = formURL.trim()
+      if (formEnabled !== existing.enabled) patch.enabled = formEnabled
+      if (formCommand.trim() !== (existing.command?.join(" ") || "")) patch.command = formCommand.trim().split(/\s+/).filter(Boolean)
+      if (Object.keys(formConfig).length > 0) patch.config = formConfig
+      if (Object.keys(formSecrets).length > 0) patch.secrets = formSecrets
+      ok = await onSave({ mcpServers: [patch] })
+    }
     if (ok) {
-      setNewMCP({ name: "", source: "npx", package: "", image: "", url: "", enabled: true, config: {}, secrets: {}, command: "" })
+      setShowModal(false)
+      resetForm()
     }
   }
 
-  const handleDelete = async (name: string) => {
-    const updated = mcps.map(m => m.name === name ? { ...m, delete: true } : m)
-    await onSave({ mcpServers: updated })
+  async function doRemove(i: number) {
+    const ok = await onSave({ mcpServers: [{ name: mcps[i].name, delete: true }] })
+    if (ok) {
+      setShowModal(false)
+      resetForm()
+    }
   }
 
-  const handleToggle = async (name: string) => {
-    const updated = mcps.map(m => m.name === name ? { ...m, enabled: !m.enabled } : m)
-    await onSave({ mcpServers: updated })
+  async function doToggle(name: string) {
+    await onSave({ mcpServers: [{ name, enabled: !mcps.find(m => m.name === name)?.enabled }] })
   }
 
-  const needsPackage = newMCP.source === "npx" || newMCP.source === "uvx" || newMCP.source === "smithery"
-  const needsImage = newMCP.source === "docker"
-  const needsURL = newMCP.source === "sse"
+  const enabledCount = mcps.filter(m => m.enabled).length
 
   return (
     <div className="space-y-6">
       <div>
         <h2 className="text-base font-semibold mb-1">MCP Servers</h2>
-        <p className="text-sm text-muted-foreground mb-6">
+        <p className="text-sm text-muted-foreground mb-4">
           Model Context Protocol servers add tools to your claws. Configure them here and reference them in templates.
         </p>
+        <div className="flex items-center gap-2 mb-6">
+          <span className="text-xs bg-muted text-muted-foreground px-2 py-1 rounded font-medium">
+            {mcps.length} server{mcps.length !== 1 ? "s" : ""} configured
+          </span>
+          {enabledCount > 0 && (
+            <span className="text-xs bg-green-500/10 text-green-400 border border-green-500/20 px-2 py-1 rounded font-medium">
+              {enabledCount} enabled
+            </span>
+          )}
+        </div>
       </div>
 
-      <div className="border border-border rounded-lg divide-y divide-border">
-        {mcps.length === 0 ? (
-          <p className="text-sm text-muted-foreground px-4 py-6 text-center">No MCP servers configured.</p>
-        ) : (
-          mcps.map(mcp => (
-            <div key={mcp.name} className="flex items-center justify-between px-4 py-3">
+      {mcps.length === 0 ? (
+        <p className="text-sm text-muted-foreground px-4 py-6 text-center border border-border rounded-lg">
+          No MCP servers configured.
+        </p>
+      ) : (
+        <div className="space-y-2">
+          {mcps.map((mcp, i) => (
+            <div
+              key={mcp.name}
+              onClick={() => openEdit(i)}
+              className="border border-border rounded-lg p-3 flex items-center justify-between cursor-pointer hover:bg-muted/50 transition-colors"
+            >
               <div className="flex items-center gap-3">
                 <button
-                  onClick={() => handleToggle(mcp.name)}
+                  onClick={(e) => { e.stopPropagation(); doToggle(mcp.name) }}
                   className={cn(
                     "relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full transition-colors duration-200",
                     mcp.enabled
@@ -2735,132 +2798,176 @@ function MCPServersSection({ settings, onSave, saving }: { settings: SettingsDat
                   )} />
                 </button>
                 <div>
-                  <code className="text-sm font-mono font-medium">{mcp.name}</code>
+                  <div className="flex items-center gap-2">
+                    <code className="text-sm font-mono font-medium">{mcp.name}</code>
+                    <span className="text-xs text-muted-foreground capitalize">{mcp.source}</span>
+                  </div>
                   <p className="text-xs text-muted-foreground">
-                    {mcp.source}
-                    {mcp.package && ` · ${mcp.package}`}
-                    {mcp.image && ` · ${mcp.image}`}
-                    {mcp.url && ` · ${mcp.url}`}
-                    {mcp.secrets && mcp.secrets.length > 0 && ` · ${mcp.secrets.length} secret(s)`}
+                    {[
+                      mcp.package && `package: ${mcp.package}`,
+                      mcp.image && `image: ${mcp.image}`,
+                      mcp.url && `url: ${mcp.url}`,
+                      mcp.secrets && mcp.secrets.length > 0 && `${mcp.secrets.length} secret(s)`,
+                    ].filter(Boolean).join(" · ")}
                   </p>
                 </div>
               </div>
-              <Button variant="ghost" size="icon" className="text-muted-foreground hover:text-destructive" onClick={() => handleDelete(mcp.name)}>
-                <Trash2 className="size-4" />
+              <span className="text-muted-foreground text-lg">⋯</span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <Button onClick={openAdd} className="gap-2">
+        <span className="text-sm">+</span> Add MCP Server
+      </Button>
+
+      {/* Modal */}
+      {showModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+          <div className="bg-background border border-border rounded-xl shadow-lg w-full max-w-lg max-h-[90vh] overflow-y-auto">
+            <div className="flex items-center justify-between px-5 py-4 border-b border-border">
+              <h3 className="font-medium">{modalMode === "add" ? "Add MCP Server" : `Edit ${formName}`}</h3>
+              <Button size="sm" variant="ghost" onClick={() => { setShowModal(false); resetForm() }} className="h-8 w-8 p-0">
+                <X className="size-4" />
               </Button>
             </div>
-          ))
-        )}
-      </div>
 
-      <div className="border border-border rounded-lg p-5 space-y-4">
-        <h3 className="text-sm font-medium">Add MCP Server</h3>
-        <div className="grid grid-cols-2 gap-3">
-          <div>
-            <label className="text-xs text-muted-foreground mb-1 block">Name</label>
-            <Input placeholder="e.g. github" value={newMCP.name} onChange={e => setNewMCP({ ...newMCP, name: e.target.value })} className="font-mono text-sm h-8" />
-          </div>
-          <div>
-            <label className="text-xs text-muted-foreground mb-1 block">Source</label>
-            <select
-              value={newMCP.source}
-              onChange={e => setNewMCP({ ...newMCP, source: e.target.value as typeof newMCP.source })}
-              className="w-full h-8 text-sm rounded-md border border-input bg-background px-3"
-            >
-              <option value="npx">npx</option>
-              <option value="uvx">uvx</option>
-              <option value="smithery">smithery</option>
-              <option value="docker">docker</option>
-              <option value="sse">sse</option>
-            </select>
-          </div>
-        </div>
-        {needsPackage && (
-          <div>
-            <label className="text-xs text-muted-foreground mb-1 block">Package</label>
-            <Input placeholder="e.g. @modelcontextprotocol/server-github" value={newMCP.package} onChange={e => setNewMCP({ ...newMCP, package: e.target.value })} className="font-mono text-sm h-8" />
-          </div>
-        )}
-        {needsImage && (
-          <div>
-            <label className="text-xs text-muted-foreground mb-1 block">Image</label>
-            <Input placeholder="e.g. mcp/postgres" value={newMCP.image} onChange={e => setNewMCP({ ...newMCP, image: e.target.value })} className="font-mono text-sm h-8" />
-          </div>
-        )}
-        {needsURL && (
-          <div>
-            <label className="text-xs text-muted-foreground mb-1 block">URL</label>
-            <Input placeholder="e.g. https://mcp.example.com/sse" value={newMCP.url} onChange={e => setNewMCP({ ...newMCP, url: e.target.value })} className="font-mono text-sm h-8" />
-          </div>
-        )}
-        <div>
-          <label className="text-xs text-muted-foreground mb-1 block">Command override (optional)</label>
-          <Input placeholder="e.g. npx -y @scope/package --flag" value={newMCP.command} onChange={e => setNewMCP({ ...newMCP, command: e.target.value })} className="font-mono text-sm h-8" />
-        </div>
+            <div className="p-5 space-y-4">
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className="text-xs text-muted-foreground mb-1 block">Name</label>
+                  <Input
+                    placeholder="e.g. github"
+                    value={formName}
+                    onChange={e => setFormName(e.target.value)}
+                    className="font-mono text-sm h-8"
+                    disabled={modalMode === "edit"}
+                  />
+                </div>
+                <div>
+                  <label className="text-xs text-muted-foreground mb-1 block">Source</label>
+                  <select
+                    value={formSource}
+                    onChange={e => setFormSource(e.target.value as typeof formSource)}
+                    className="w-full h-8 text-sm rounded-md border border-input bg-background px-3"
+                  >
+                    <option value="npx">npx</option>
+                    <option value="uvx">uvx</option>
+                    <option value="smithery">smithery</option>
+                    <option value="docker">docker</option>
+                    <option value="sse">sse</option>
+                  </select>
+                </div>
+              </div>
 
-        {/* Config vars */}
-        <div className="space-y-2">
-          <label className="text-xs text-muted-foreground block">Config variables</label>
-          {Object.entries(newMCP.config).map(([k, v]) => (
-            <div key={k} className="flex items-center gap-2">
-              <code className="text-xs font-mono">{k}</code>
-              <span className="text-xs text-muted-foreground">= {v}</span>
-              <Button size="sm" variant="ghost" className="h-6 px-2" onClick={() => {
-                const { [k]: _, ...rest } = newMCP.config
-                setNewMCP({ ...newMCP, config: rest })
-              }}>Remove</Button>
+              {needsPackage && (
+                <div>
+                  <label className="text-xs text-muted-foreground mb-1 block">Package</label>
+                  <Input placeholder="e.g. @modelcontextprotocol/server-github" value={formPackage} onChange={e => setFormPackage(e.target.value)} className="font-mono text-sm h-8" />
+                </div>
+              )}
+              {needsImage && (
+                <div>
+                  <label className="text-xs text-muted-foreground mb-1 block">Image</label>
+                  <Input placeholder="e.g. mcp/postgres" value={formImage} onChange={e => setFormImage(e.target.value)} className="font-mono text-sm h-8" />
+                </div>
+              )}
+              {needsURL && (
+                <div>
+                  <label className="text-xs text-muted-foreground mb-1 block">URL</label>
+                  <Input placeholder="e.g. https://mcp.example.com/sse" value={formURL} onChange={e => setFormURL(e.target.value)} className="font-mono text-sm h-8" />
+                </div>
+              )}
+
+              <div>
+                <label className="text-xs text-muted-foreground mb-1 block">Command override (optional)</label>
+                <Input placeholder="e.g. npx -y @scope/package --flag" value={formCommand} onChange={e => setFormCommand(e.target.value)} className="font-mono text-sm h-8" />
+              </div>
+
+              <label className="flex items-center gap-2 text-sm cursor-pointer">
+                <input type="checkbox" checked={formEnabled} onChange={e => setFormEnabled(e.target.checked)} />
+                Enabled
+              </label>
+
+              {/* Config vars */}
+              <div className="space-y-2">
+                <label className="text-xs text-muted-foreground block">Config variables</label>
+                {Object.entries(formConfig).map(([k, v]) => (
+                  <div key={k} className="flex items-center gap-2">
+                    <code className="text-xs font-mono">{k}</code>
+                    <span className="text-xs text-muted-foreground">= {v}</span>
+                    <Button size="sm" variant="ghost" className="h-6 px-2" onClick={() => {
+                      const { [k]: _, ...rest } = formConfig
+                      setFormConfig(rest)
+                    }}>Remove</Button>
+                  </div>
+                ))}
+                <div className="flex gap-2">
+                  <Input placeholder="Key" value={configKey} onChange={e => setConfigKey(e.target.value)} className="font-mono text-xs h-7 flex-1" />
+                  <Input placeholder="Value" value={configValue} onChange={e => setConfigValue(e.target.value)} className="font-mono text-xs h-7 flex-1" />
+                  <Button size="sm" variant="outline" className="h-7" onClick={() => {
+                    if (!configKey.trim()) return
+                    setFormConfig({ ...formConfig, [configKey.trim()]: configValue })
+                    setConfigKey(""); setConfigValue("")
+                  }}>Add</Button>
+                </div>
+              </div>
+
+              {/* Secret refs */}
+              <div className="space-y-2">
+                <label className="text-xs text-muted-foreground block">Secret references</label>
+                {Object.entries(formSecrets).map(([envVar, ref]) => (
+                  <div key={envVar} className="flex items-center gap-2">
+                    <code className="text-xs font-mono">{envVar}</code>
+                    <span className="text-xs text-muted-foreground">→ secret: {ref}</span>
+                    <Button size="sm" variant="ghost" className="h-6 px-2" onClick={() => {
+                      const { [envVar]: _, ...rest } = formSecrets
+                      setFormSecrets(rest)
+                    }}>Remove</Button>
+                  </div>
+                ))}
+                <div className="flex gap-2">
+                  <Input placeholder="Env var (e.g. GITHUB_TOKEN)" value={secretEnvVar} onChange={e => setSecretEnvVar(e.target.value)} className="font-mono text-xs h-7 flex-1" />
+                  <select
+                    value={secretRef}
+                    onChange={e => setSecretRef(e.target.value)}
+                    className="h-7 text-xs rounded-md border border-input bg-background px-2 flex-1"
+                  >
+                    <option value="">Select secret…</option>
+                    {(settings.secrets || []).map(s => (
+                      <option key={s} value={s}>{s}</option>
+                    ))}
+                  </select>
+                  <Button size="sm" variant="outline" className="h-7" onClick={() => {
+                    if (!secretEnvVar.trim() || !secretRef) return
+                    setFormSecrets({ ...formSecrets, [secretEnvVar.trim()]: secretRef })
+                    setSecretEnvVar(""); setSecretRef("")
+                  }}>Add</Button>
+                </div>
+              </div>
             </div>
-          ))}
-          <div className="flex gap-2">
-            <Input placeholder="Key" value={configKey} onChange={e => setConfigKey(e.target.value)} className="font-mono text-xs h-7 flex-1" />
-            <Input placeholder="Value" value={configValue} onChange={e => setConfigValue(e.target.value)} className="font-mono text-xs h-7 flex-1" />
-            <Button size="sm" variant="outline" className="h-7" onClick={() => {
-              if (!configKey.trim()) return
-              setNewMCP({ ...newMCP, config: { ...newMCP.config, [configKey.trim()]: configValue } })
-              setConfigKey("")
-              setConfigValue("")
-            }}>Add</Button>
-          </div>
-        </div>
 
-        {/* Secret refs */}
-        <div className="space-y-2">
-          <label className="text-xs text-muted-foreground block">Secret references</label>
-          {Object.entries(newMCP.secrets).map(([envVar, ref]) => (
-            <div key={envVar} className="flex items-center gap-2">
-              <code className="text-xs font-mono">{envVar}</code>
-              <span className="text-xs text-muted-foreground">→ secret: {ref}</span>
-              <Button size="sm" variant="ghost" className="h-6 px-2" onClick={() => {
-                const { [envVar]: _, ...rest } = newMCP.secrets
-                setNewMCP({ ...newMCP, secrets: rest })
-              }}>Remove</Button>
+            <div className="flex items-center justify-between px-5 py-4 border-t border-border">
+              {modalMode === "edit" && editIdx !== null && (
+                <Button size="sm" variant="ghost" className="text-destructive hover:text-destructive" onClick={() => doRemove(editIdx)}>
+                  <Trash2 className="size-3.5 mr-1" /> Remove
+                </Button>
+              )}
+              <div className="flex items-center gap-2 ml-auto">
+                <Button size="sm" variant="outline" onClick={() => { setShowModal(false); resetForm() }}>Cancel</Button>
+                <Button
+                  size="sm"
+                  disabled={saving || !formName.trim() || (needsPackage && !formPackage.trim()) || (needsImage && !formImage.trim()) || (needsURL && !formURL.trim())}
+                  onClick={doSave}
+                >
+                  {modalMode === "add" ? "Add MCP Server" : "Save changes"}
+                </Button>
+              </div>
             </div>
-          ))}
-          <div className="flex gap-2">
-            <Input placeholder="Env var (e.g. GITHUB_TOKEN)" value={secretEnvVar} onChange={e => setSecretEnvVar(e.target.value)} className="font-mono text-xs h-7 flex-1" />
-            <select
-              value={secretRef}
-              onChange={e => setSecretRef(e.target.value)}
-              className="h-7 text-xs rounded-md border border-input bg-background px-2 flex-1"
-            >
-              <option value="">Select secret…</option>
-              {(settings.secrets || []).map(s => (
-                <option key={s} value={s}>{s}</option>
-              ))}
-            </select>
-            <Button size="sm" variant="outline" className="h-7" onClick={() => {
-              if (!secretEnvVar.trim() || !secretRef) return
-              setNewMCP({ ...newMCP, secrets: { ...newMCP.secrets, [secretEnvVar.trim()]: secretRef } })
-              setSecretEnvVar("")
-              setSecretRef("")
-            }}>Add</Button>
           </div>
         </div>
-
-        <Button onClick={handleAdd} disabled={saving || localSaving || !newMCP.name.trim() || !newMCP.source}>
-          {saving || localSaving ? "Saving…" : "Add MCP Server"}
-        </Button>
-      </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
Follows the existing design pattern used by Models (LLMSection):
- List all configured MCP servers as clickable cards
- Add button opens a modal with the full form
- Click an existing server to edit in the same modal
- Toggle enabled/disabled inline without opening modal
- Remove button inside edit modal

Previously the add form was inline at the bottom of the page, which
cluttered the UI and didn't allow editing existing servers. Now the
MCP section matches the rest of the settings design language.