### PR TITLE
fix(webui): serve index.html for static export sub-routes

### DIFF
--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -571,7 +571,7 @@ func (s *Server) serveWebUI(mux *http.ServeMux, staticFS fs.FS) {
 		if p == "" {
 			p = "index.html"
 		}
-		// Try exact path first
+		// Try exact path first (file or directory)
 		if f, err := staticFS.Open(p); err == nil {
 			stat, _ := f.Stat()
 			f.Close()
@@ -582,6 +582,15 @@ func (s *Server) serveWebUI(mux *http.ServeMux, staticFS fs.FS) {
 			// It's a dir — try index.html inside
 			serveFile(w, r, strings.TrimRight(p, "/")+"/index.html")
 			return
+		}
+		// embed.FS doesn't support Open() on directories — the dir check above
+		// may have failed. Try index.html at this path before falling back.
+		if !strings.HasSuffix(p, "/index.html") {
+			idxPath := strings.TrimRight(p, "/") + "/index.html"
+			if _, err := staticFS.Open(idxPath); err == nil {
+				serveFile(w, r, idxPath)
+				return
+			}
 		}
 		// Unknown path — serve root index.html (SPA fallback)
 		serveFile(w, r, "index.html")

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -587,7 +587,8 @@ func (s *Server) serveWebUI(mux *http.ServeMux, staticFS fs.FS) {
 		// may have failed. Try index.html at this path before falling back.
 		if !strings.HasSuffix(p, "/index.html") {
 			idxPath := strings.TrimRight(p, "/") + "/index.html"
-			if _, err := staticFS.Open(idxPath); err == nil {
+			if f, err := staticFS.Open(idxPath); err == nil {
+				f.Close()
 				serveFile(w, r, idxPath)
 				return
 			}

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -181,17 +181,32 @@ export default function SettingsSectionPage() {
     }
   }
 
-  const navItems: { id: Section; label: string; icon: React.ElementType }[] = [
-    { id: "runtimes", label: "Sandbox Runtimes", icon: Cpu },
-    { id: "models", label: "Models", icon: Key },
-    { id: "github", label: "GitHub Apps", icon: Github },
-    { id: "authentication", label: "Authentication", icon: Shield },
-    { id: "issue-trackers", label: "Issue Trackers", icon: Zap },
-    { id: "factories", label: "Factories", icon: Factory },
-    { id: "secrets", label: "Secrets", icon: Lock },
-    { id: "mcp-servers", label: "MCP Servers", icon: Zap },
-    { id: "templates", label: "Templates", icon: LayoutTemplate },
-    { id: "ai-config", label: "Configure with AI", icon: Sparkles },
+  const navGroups: { id: Section; label: string; icon: React.ElementType }[][] = [
+    // Infrastructure
+    [
+      { id: "runtimes", label: "Sandboxes", icon: Cpu },
+      { id: "models", label: "Models", icon: Key },
+    ],
+    // Integrations
+    [
+      { id: "github", label: "GitHub Apps", icon: Github },
+      { id: "issue-trackers", label: "Issue Trackers", icon: Zap },
+      { id: "mcp-servers", label: "MCP Servers", icon: Zap },
+    ],
+    // Configuration
+    [
+      { id: "secrets", label: "Secrets", icon: Lock },
+      { id: "templates", label: "Templates", icon: LayoutTemplate },
+      { id: "factories", label: "Factories", icon: Factory },
+    ],
+    // Access
+    [
+      { id: "authentication", label: "Authentication", icon: Shield },
+    ],
+    // AI Assistant
+    [
+      { id: "ai-config", label: "Configure with AI", icon: Sparkles },
+    ],
   ]
 
   return (
@@ -209,21 +224,26 @@ export default function SettingsSectionPage() {
         {/* Left nav */}
         <aside className="w-56 border-r border-border p-4 flex flex-col overflow-y-auto">
           <div className="space-y-1 flex-1">
-          {navItems.map(({ id, label, icon: Icon }) => (
-            <Link
-              key={id}
-              href={`/settings/${id}`}
-              className={cn(
-                "w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm transition-colors text-left",
-                section === id
-                  ? "bg-primary/10 text-primary font-medium"
-                  : "text-muted-foreground hover:bg-secondary hover:text-foreground"
-              )}
-            >
-              <Icon className="size-4 flex-shrink-0" />
-              {label}
-            </Link>
-          ))}
+            {navGroups.map((group, groupIdx) => (
+              <div key={groupIdx}>
+                {groupIdx > 0 && <div className="my-2 border-t border-border/50" />}
+                {group.map(({ id, label, icon: Icon }) => (
+                  <Link
+                    key={id}
+                    href={`/settings/${id}`}
+                    className={cn(
+                      "w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm transition-colors text-left",
+                      section === id
+                        ? "bg-primary/10 text-primary font-medium"
+                        : "text-muted-foreground hover:bg-secondary hover:text-foreground"
+                    )}
+                  >
+                    <Icon className="size-4 flex-shrink-0" />
+                    {label}
+                  </Link>
+                ))}
+              </div>
+            ))}
           </div>
           {version && (
             <p className="text-xs text-muted-foreground/50 px-3 pt-4 font-mono">


### PR DESCRIPTION
With Next.js static export (output: 'export', trailingSlash: true), pages like /settings/models are generated as out/settings/models/index.html.

The previous file server logic tried to Open() the directory path first (e.g. 'settings/models'), but embed.FS does not support opening directories directly — it only exposes files. This caused all sub-routes to fall through to the SPA fallback (root index.html), showing the dashboard instead of the correct page on refresh.

Now we try the index.html path directly when the directory Open() fails, so /settings/models correctly serves out/settings/models/index.html.