### PR TITLE
feat: add GitHub Issues as third issue tracker

### DIFF
--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -37,6 +37,7 @@ func migrate(db *sql.DB) error {
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN tags TEXT NOT NULL DEFAULT '[]'`)
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN color TEXT NOT NULL DEFAULT ''`)
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN linear_issue_id TEXT NOT NULL DEFAULT ''`)
+	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN github_issue_id TEXT NOT NULL DEFAULT ''`)
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN auto_fix_ci INTEGER NOT NULL DEFAULT 1`)
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN auto_fix_bugbot INTEGER NOT NULL DEFAULT 1`)
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN llm_key TEXT NOT NULL DEFAULT ''`)
@@ -78,6 +79,7 @@ func migrate(db *sql.DB) error {
 		tags             TEXT NOT NULL DEFAULT '[]',
 		color            TEXT NOT NULL DEFAULT '',
 		linear_issue_id  TEXT NOT NULL DEFAULT '',
+		github_issue_id  TEXT NOT NULL DEFAULT '',
 		auto_fix_ci      INTEGER NOT NULL DEFAULT 1,
 		auto_fix_bugbot  INTEGER NOT NULL DEFAULT 1,
 		llm_key          TEXT NOT NULL DEFAULT '',

--- a/pkg/hub/github_issues.go
+++ b/pkg/hub/github_issues.go
@@ -1,0 +1,691 @@
+package hub
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/elasticclaw/elasticclaw/pkg/config"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+	"github.com/google/uuid"
+)
+
+// githubIssuesWebhookPayload holds the relevant fields from a GitHub issues webhook event.
+type githubIssuesWebhookPayload struct {
+	Action string `json:"action"` // "opened", "edited", "closed", "reopened", "labeled", "unlabeled", "assigned", "unassigned"
+	Issue  struct {
+		ID        int64  `json:"id"`
+		Number    int    `json:"number"`
+		Title     string `json:"title"`
+		Body      string `json:"body"`
+		HTMLURL   string `json:"html_url"`
+		State     string `json:"state"` // "open", "closed"
+		StateReason string `json:"state_reason,omitempty"` // "completed", "not_planned", "reopened"
+		Labels    []struct {
+			Name string `json:"name"`
+		} `json:"labels"`
+		Assignee *struct {
+			Login string `json:"login"`
+		} `json:"assignee"`
+		User struct {
+			Login string `json:"login"`
+		} `json:"user"`
+	} `json:"issue"`
+	Repository struct {
+		FullName string `json:"full_name"`
+	} `json:"repository"`
+	Sender struct {
+		Login string `json:"login"`
+		Type  string `json:"type"` // "Bot", "User", "Organization"
+	} `json:"sender"`
+	Label *struct {
+		Name string `json:"name"`
+	} `json:"label,omitempty"`
+	Changes *struct {
+		Title *struct {
+			From string `json:"from"`
+		} `json:"title,omitempty"`
+		Body *struct {
+			From string `json:"from"`
+		} `json:"body,omitempty"`
+	} `json:"changes,omitempty"`
+	// GitHub sends X-GitHub-Delivery header as unique delivery ID
+}
+
+func (s *Server) handleGitHubIssuesWebhook(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	if err != nil {
+		http.Error(w, "read error", http.StatusBadRequest)
+		return
+	}
+
+	// Validate signature using X-Hub-Signature-256 header
+	sig := r.Header.Get("X-Hub-Signature-256")
+	if !s.validateGitHubIssuesSignature(body, sig) {
+		http.Error(w, "invalid signature", http.StatusUnauthorized)
+		return
+	}
+
+	var payload githubIssuesWebhookPayload
+	if err := json.Unmarshal(body, &payload); err != nil {
+		http.Error(w, "invalid payload", http.StatusBadRequest)
+		return
+	}
+
+	// Only handle issues events (not pull_request, etc.)
+	// The webhook should be configured to only send issues events, but guard anyway
+	if payload.Issue.Number == 0 {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	// Dedup: ignore duplicate webhook deliveries using GitHub's delivery ID
+	deliveryID := r.Header.Get("X-GitHub-Delivery")
+	if deliveryID != "" && s.isDuplicateWebhook("gh-issues:"+deliveryID) {
+		log.Printf("[github-issues-webhook] dedup: skipping duplicate delivery %s for issue #%d in %s", deliveryID, payload.Issue.Number, payload.Repository.FullName)
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	go s.processGitHubIssuesEvent(payload)
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *Server) validateGitHubIssuesSignature(body []byte, sig string) bool {
+	s.mu.RLock()
+	integrations := s.hubCfg.Integrations
+	factories := s.hubCfg.Factories
+	secrets := s.hubCfg.Secrets
+	s.mu.RUnlock()
+
+	hasAnySecret := false
+
+	// Check integration-level secrets
+	if integrations != nil {
+		for _, gi := range integrations.GitHubIssues {
+			if gi.WebhookSecret == "" {
+				continue
+			}
+			hasAnySecret = true
+			if verifyGitHubHMAC(body, sig, gi.WebhookSecret) {
+				return true
+			}
+		}
+	}
+
+	// Check factory-level secrets
+	if factories != nil {
+		for _, factory := range factories {
+			if factory.Integration != "github-issues" {
+				continue
+			}
+			secret := factory.WebhookSecret
+			if secret == "" && factory.WebhookSecretRef != "" && secrets != nil {
+				secret = secrets[factory.WebhookSecretRef]
+			}
+			if secret == "" {
+				continue
+			}
+			hasAnySecret = true
+			if verifyGitHubHMAC(body, sig, secret) {
+				return true
+			}
+		}
+	}
+
+	// If any secrets are configured but none matched, reject
+	if hasAnySecret {
+		return false
+	}
+	return true // no secrets configured
+}
+
+func verifyGitHubHMAC(body []byte, sig, secret string) bool {
+	if sig == "" || secret == "" {
+		return false
+	}
+	// Strip "sha256=" prefix if present
+	sig = strings.TrimPrefix(sig, "sha256=")
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	expected := hex.EncodeToString(mac.Sum(nil))
+	return hmac.Equal([]byte(sig), []byte(expected))
+}
+
+func (s *Server) processGitHubIssuesEvent(payload githubIssuesWebhookPayload) {
+	if s.hubCfg.Factories == nil {
+		return
+	}
+
+	issueID := fmt.Sprintf("gh-%s/%d", payload.Repository.FullName, payload.Issue.Number)
+	currentStatus := payload.Issue.State
+	previousStatus := ""
+
+	// For state changes, track the transition
+	if payload.Action == "closed" {
+		previousStatus = "open"
+	} else if payload.Action == "reopened" {
+		previousStatus = "closed"
+	}
+
+	issueTitle := payload.Issue.Title
+	assignee := ""
+	if payload.Issue.Assignee != nil {
+		assignee = payload.Issue.Assignee.Login
+	}
+
+	// Build label set
+	issueLabels := map[string]bool{}
+	for _, l := range payload.Issue.Labels {
+		issueLabels[strings.ToLower(l.Name)] = true
+	}
+
+	// Handle label/unlabel actions: the label that was added/removed is in payload.Label
+	if payload.Action == "labeled" && payload.Label != nil {
+		issueLabels[strings.ToLower(payload.Label.Name)] = true
+		// Treat labeling as a status change for factory matching
+		if previousStatus == "" {
+			previousStatus = currentStatus
+		}
+	}
+	if payload.Action == "unlabeled" && payload.Label != nil {
+		delete(issueLabels, strings.ToLower(payload.Label.Name))
+		if previousStatus == "" {
+			previousStatus = currentStatus
+		}
+	}
+
+	matched := false
+	for _, factory := range s.hubCfg.Factories {
+		if factory.Integration != "github-issues" {
+			continue
+		}
+		if factory.Enabled != nil && !*factory.Enabled {
+			continue
+		}
+
+		// Workspace filter: if factory specifies a workspace, match against integration workspace
+		// (for GitHub Issues, workspace is a human label on the integration config, not the repo)
+		if factory.Workspace != "" {
+			ghToken := s.resolveGitHubIssuesTokenForFactory(factory)
+			if ghToken == "" {
+				continue
+			}
+			// Workspace is just a label — we don't filter by repo here.
+			// If we wanted repo-level filtering, we'd add a Repos field to FactoryConfig.
+		}
+
+		// Labels filter: all configured labels must be present on the issue (AND)
+		if len(factory.Labels) > 0 {
+			allMatch := true
+			for _, required := range factory.Labels {
+				if !issueLabels[strings.ToLower(required)] {
+					allMatch = false
+					break
+				}
+			}
+			if !allMatch {
+				continue
+			}
+		}
+
+		// AssignedTo filter
+		if factory.AssignedTo != "" {
+			wanted := strings.ToLower(strings.TrimSpace(factory.AssignedTo))
+			switch {
+			case wanted == "any":
+				if assignee == "" {
+					continue
+				}
+			case wanted == "none":
+				if assignee != "" {
+					continue
+				}
+			case strings.HasPrefix(wanted, "!"):
+				excluded := strings.TrimPrefix(strings.TrimPrefix(wanted, "!"), "@")
+				if strings.EqualFold(assignee, excluded) {
+					continue
+				}
+			default:
+				target := strings.TrimPrefix(wanted, "@")
+				if !strings.EqualFold(assignee, target) {
+					continue
+				}
+			}
+		}
+
+		// Issue entering trigger status → create claw.
+		// For GitHub Issues, trigger_status maps to state ("open") or a label.
+		triggerMatched := false
+		if strings.EqualFold(currentStatus, factory.TriggerStatus) {
+			triggerMatched = true
+		} else if issueLabels[strings.ToLower(factory.TriggerStatus)] {
+			triggerMatched = true
+		}
+
+		// Only create when transitioning into the trigger condition
+		previousMatched := false
+		if previousStatus != "" {
+			if strings.EqualFold(previousStatus, factory.TriggerStatus) {
+				previousMatched = true
+			}
+		}
+
+		if triggerMatched && !previousMatched {
+			matched = true
+			log.Printf("[factory:%s] issue %s entered trigger '%s' — creating claw", factory.Name, issueID, factory.TriggerStatus)
+			clawID := ""
+			if err := s.createClawForGitHubIssue(factory, payload); err != nil {
+				log.Printf("[factory:%s] failed to create claw for %s: %v", factory.Name, issueID, err)
+				s.logFactoryEvent(factory.Name, issueID, issueTitle, previousStatus, currentStatus, "error", "", err.Error())
+			} else {
+				_ = s.db.QueryRow(`SELECT id FROM claws WHERE github_issue_id=? ORDER BY created_at DESC LIMIT 1`, issueID).Scan(&clawID)
+				s.logFactoryEvent(factory.Name, issueID, issueTitle, previousStatus, currentStatus, "claw_created", clawID, "")
+			}
+		}
+
+		// Issue leaving trigger status → terminate claw.
+		if factory.TerminateOnLeave && !triggerMatched {
+			var activeClaw string
+			_ = s.db.QueryRow(
+				`SELECT id FROM claws WHERE github_issue_id = ? AND status NOT IN ('error','deleted') LIMIT 1`,
+				issueID,
+			).Scan(&activeClaw)
+			if activeClaw != "" {
+				matched = true
+				log.Printf("[factory:%s] issue %s left trigger '%s' — terminating claw", factory.Name, issueID, factory.TriggerStatus)
+				s.terminateClawForGitHubIssue(issueID)
+				s.logFactoryEvent(factory.Name, issueID, issueTitle, previousStatus, currentStatus, "claw_terminated", activeClaw, "terminated: issue left trigger status")
+			}
+		}
+	}
+
+	if !matched {
+		for _, factory := range s.hubCfg.Factories {
+			if factory.Integration == "github-issues" && (factory.Enabled == nil || *factory.Enabled) {
+				s.logFactoryEvent(factory.Name, issueID, issueTitle, previousStatus, currentStatus, "not_actionable",
+					"", fmt.Sprintf("status '%s'→'%s' did not match trigger '%s'", previousStatus, currentStatus, factory.TriggerStatus))
+			}
+		}
+	}
+}
+
+func (s *Server) createClawForGitHubIssue(factory *types.FactoryConfig, payload githubIssuesWebhookPayload) error {
+	issueID := fmt.Sprintf("gh-%s/%d", payload.Repository.FullName, payload.Issue.Number)
+
+	// Verify we can read the issue before spending money on a sandbox
+	ghToken := s.resolveGitHubIssuesTokenForFactory(factory)
+	if ghToken != "" {
+		// Quick pre-flight: can we fetch the issue?
+		base := s.githubBaseURL
+		if base == "" {
+			base = "https://api.github.com"
+		}
+		_, err := githubAPIWithBase(base, fmt.Sprintf("repos/%s/issues/%d", payload.Repository.FullName, payload.Issue.Number), ghToken)
+		if err != nil {
+			return fmt.Errorf("cannot read issue: %w", err)
+		}
+	}
+
+	// Load template
+	templateFiles, err := s.resolveTemplateFiles(factory.Template)
+	if err != nil {
+		return err
+	}
+	var tmplCfg *types.TemplateConfig
+	if cfgContent, ok := templateFiles["elasticclaw-config.yaml"]; ok {
+		var parseErr error
+		tmplCfg, parseErr = config.ParseTemplateConfig([]byte(cfgContent))
+		if parseErr != nil {
+			log.Printf("[factory:%s] warning: elasticclaw-config.yaml parse error: %v", factory.Name, parseErr)
+			tmplCfg = nil
+		}
+	}
+
+	// Build context file
+	ctxFile := buildGitHubIssuesContext(payload)
+	templateFiles["CONTEXT.md"] = ctxFile
+
+	// Build claw name
+	clawName := issueID
+	if factory.NamePattern != "" {
+		clawName = strings.ReplaceAll(factory.NamePattern, "{issue_id}", issueID)
+		clawName = strings.ReplaceAll(clawName, "{issue_number}", fmt.Sprintf("%d", payload.Issue.Number))
+		clawName = strings.ReplaceAll(clawName, "{repo}", payload.Repository.FullName)
+	}
+
+	// Find tenant
+	var tenantID string
+	if err := s.db.QueryRow(`SELECT id FROM tenants LIMIT 1`).Scan(&tenantID); err != nil {
+		return fmt.Errorf("no tenant: %w", err)
+	}
+
+	// Find provider
+	provider := factory.Provider
+	if provider == "" {
+		if tmplCfg != nil && tmplCfg.Provider != "" {
+			provider = tmplCfg.Provider
+		}
+	}
+	if provider == "" {
+		provider = s.defaultProvider()
+	}
+	if provider == "" {
+		return fmt.Errorf("no provider configured")
+	}
+
+	// Build env vars
+	env := map[string]string{
+		"ELASTICCLAW_HUB_URL":    s.clawHubURL(),
+		"ELASTICCLAW_CLAW_TOKEN": s.hubCfg.ClawToken,
+	}
+	if ghToken != "" {
+		env["GITHUB_ISSUES_API_KEY"] = ghToken
+		env["GITHUB_TOKEN"] = ghToken // also set generic GITHUB_TOKEN for GitHub API access
+	}
+
+	// Resolve and inject template-requested secrets
+	resolvedSecrets := make(map[string]string)
+	if tmplCfg != nil && len(tmplCfg.Secrets) > 0 {
+		for _, ref := range tmplCfg.Secrets {
+			secretVal, envName, ok := s.resolveSecretRef(ref, factory)
+			if ok {
+				env[envName] = secretVal
+				resolvedSecrets[envName] = secretVal
+				log.Printf("[factory:%s] injected secret %s as %s into claw env", factory.Name, ref.Type, envName)
+			} else {
+				log.Printf("[factory:%s] warning: requested secret (type=%s name=%s workspace=%s) not found", factory.Name, ref.Type, ref.Name, ref.Workspace)
+			}
+		}
+	}
+
+	// Resolve template config fields
+	var (
+		instanceType    string
+		defaultModel    string
+		llmKey          string
+		nixEnabled      int
+		dockerEnabled   int
+		githubRepos     []types.GitHubRepoAccess
+		linearWorkspace string
+		autoFixCI       int = 1
+		autoFixBugbot   int = 1
+	)
+	if tmplCfg != nil {
+		instanceType = tmplCfg.InstanceType
+		defaultModel = tmplCfg.DefaultModel
+		llmKey = tmplCfg.LLMKey
+		if tmplCfg.Nix {
+			nixEnabled = 1
+		}
+		if tmplCfg.Docker {
+			dockerEnabled = 1
+		}
+		if tmplCfg.GitHub != nil {
+			githubRepos = tmplCfg.GitHub.Repos
+		}
+		if tmplCfg.Linear != nil {
+			linearWorkspace = tmplCfg.Linear.Workspace
+		}
+		if tmplCfg.AutoWatchCI != nil && !*tmplCfg.AutoWatchCI {
+			autoFixCI = 0
+		}
+		if tmplCfg.AutoWatchBugbot != nil && !*tmplCfg.AutoWatchBugbot {
+			autoFixBugbot = 0
+		}
+	}
+
+	// Build SECRETS.md
+	var secretList []string
+	if ghToken != "" {
+		secretList = append(secretList, "- `GITHUB_ISSUES_API_KEY` — GitHub Issues API token")
+		secretList = append(secretList, "- `GITHUB_TOKEN` — GitHub API token")
+	}
+	for envName := range resolvedSecrets {
+		var refType string
+		for _, ref := range tmplCfg.Secrets {
+			if ref.EnvVarName() == envName {
+				refType = ref.Type
+				break
+			}
+		}
+		if refType == "" {
+			refType = "custom"
+		}
+		secretList = append(secretList, fmt.Sprintf("- `%s` — %s secret", envName, refType))
+	}
+	if len(secretList) > 0 {
+		templateFiles["SECRETS.md"] = "# Available Secrets\n\n" + strings.Join(secretList, "\n") + "\n\n> Do not write these values to files. They are injected as environment variables.\n"
+	}
+
+	// Build tags
+	tags := mergeTags(factory.Template, factory.Tags, nil)
+	hasfactory := false
+	for _, t := range tags {
+		if t == "factory:"+factory.Name {
+			hasfactory = true
+			break
+		}
+	}
+	if !hasfactory {
+		tags = append(tags, "factory:"+factory.Name)
+	}
+	tagsJSON, _ := json.Marshal(tags)
+
+	// Color
+	clawColor := factory.Color
+	if clawColor == "" && tmplCfg != nil {
+		clawColor = tmplCfg.Color
+	}
+
+	githubReposJSON, _ := json.Marshal(githubRepos)
+
+	// Insert claw record
+	clawID := uuid.New().String()
+	filesJSON, _ := json.Marshal(templateFiles)
+	now := now()
+
+	_, err = s.db.Exec(`
+		INSERT INTO claws(id, tenant_id, name, template, provider, default_model, template_files, github_repos, linear_workspace, nix, docker, tags, color, llm_key, auto_fix_ci, auto_fix_bugbot, github_issue_id, status, created_at)
+		VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,'provisioning',?)`,
+		clawID, tenantID, clawName, factory.Template, provider, defaultModel, string(filesJSON),
+		string(githubReposJSON), linearWorkspace, nixEnabled, dockerEnabled, string(tagsJSON), clawColor, llmKey, autoFixCI, autoFixBugbot, issueID, now,
+	)
+	if err != nil {
+		return fmt.Errorf("db insert: %w", err)
+	}
+
+	// Provision asynchronously
+	provCfg, _ := s.hubCfg.Providers[provider]
+	go func() {
+		var currentStatus string
+		_ = s.db.QueryRow(`SELECT status FROM claws WHERE id=?`, clawID).Scan(&currentStatus)
+		if currentStatus == "deleted" {
+			log.Printf("[factory] claw %s already deleted before provisioning, aborting", clawID[:8])
+			return
+		}
+		ctx := context.Background()
+		req := types.CreateClawRequest{
+			Name:         clawName,
+			TemplateName: factory.Template,
+			Provider:     provider,
+			Files:        templateFiles,
+			Env:          env,
+			InstanceType: instanceType,
+			ProviderName: "ec-" + clawID[:8],
+		}
+		fileBytes := make(map[string][]byte, len(templateFiles))
+		for k, v := range templateFiles {
+			fileBytes[k] = []byte(v)
+		}
+
+		var provErr error
+		switch provider {
+		case "replicated":
+			provErr = s.provisionReplicated(ctx, clawID, req, provCfg, env)
+		case "daytona":
+			provErr = s.provisionDaytona(ctx, clawID, req, provCfg, fileBytes, env)
+		case "vercel":
+			provErr = s.provisionVercel(ctx, clawID, req, provCfg, fileBytes, env)
+		case "noop":
+			// Noop provider is not implemented; skip
+		default:
+			provErr = fmt.Errorf("unknown provider %s", provider)
+		}
+
+		if provErr != nil {
+			log.Printf("[factory] claw %s provision failed: %v", clawID[:8], provErr)
+			_, _ = s.db.Exec(`UPDATE claws SET status='error' WHERE id=?`, clawID)
+			s.broadcastToUsers(tenantID, types.WSMessage{
+				Type:    "claw_status",
+				Payload: map[string]string{"claw_id": clawID, "status": "error"},
+			})
+			return
+		}
+
+		_, _ = s.db.Exec(`UPDATE claws SET status='online' WHERE id=?`, clawID)
+		s.broadcastToUsers(tenantID, types.WSMessage{
+			Type:    "claw_status",
+			Payload: map[string]string{"claw_id": clawID, "status": "online"},
+		})
+		log.Printf("[factory] claw %s provisioned successfully", clawID[:8])
+	}()
+
+	return nil
+}
+
+func (s *Server) terminateClawForGitHubIssue(issueID string) {
+	var clawID, tenantID string
+	if err := s.db.QueryRow(`SELECT id, tenant_id FROM claws WHERE github_issue_id = ? AND status NOT IN ('error','deleted') LIMIT 1`, issueID).Scan(&clawID, &tenantID); err != nil {
+		return
+	}
+	log.Printf("[factory] terminating claw %s for GitHub issue %s", clawID[:8], issueID)
+	s.mu.Lock()
+	if cc, ok := s.claws[clawID]; ok {
+		cc.conn.Close(1000, "factory: issue left trigger status")
+		delete(s.claws, clawID)
+	}
+	s.mu.Unlock()
+	_, _ = s.db.Exec(`UPDATE claws SET status='deleted' WHERE id=?`, clawID)
+	s.broadcastToUsers(tenantID, types.WSMessage{
+		Type:    "claw_status",
+		Payload: map[string]string{"claw_id": clawID, "status": "deleted"},
+	})
+}
+
+func (s *Server) resolveGitHubIssuesTokenForFactory(factory *types.FactoryConfig) string {
+	if s.hubCfg.Integrations == nil {
+		return ""
+	}
+	for _, gi := range s.hubCfg.Integrations.GitHubIssues {
+		if factory.Workspace == "" || strings.EqualFold(gi.Workspace, factory.Workspace) {
+			return gi.Token
+		}
+	}
+	return ""
+}
+
+func buildGitHubIssuesContext(payload githubIssuesWebhookPayload) string {
+	i := payload.Issue
+	var b strings.Builder
+	b.WriteString("# Issue Context\n\n")
+	b.WriteString("This claw was automatically created by a factory to work on a GitHub issue. Read this, understand the task, then get to work.\n\n")
+	b.WriteString(fmt.Sprintf("## Issue: #%d\n\n", i.Number))
+	b.WriteString(fmt.Sprintf("**Title:** %s\n\n", i.Title))
+	b.WriteString(fmt.Sprintf("**Repository:** %s\n\n", payload.Repository.FullName))
+	if i.HTMLURL != "" {
+		b.WriteString(fmt.Sprintf("**URL:** %s\n\n", i.HTMLURL))
+	}
+	if i.User.Login != "" {
+		b.WriteString(fmt.Sprintf("**Author:** @%s\n\n", i.User.Login))
+	}
+	if len(i.Labels) > 0 {
+		b.WriteString("**Labels:** ")
+		for i, l := range i.Labels {
+			if i > 0 {
+				b.WriteString(", ")
+			}
+			b.WriteString(l.Name)
+		}
+		b.WriteString("\n\n")
+	}
+	if i.Body != "" {
+		b.WriteString("## Description\n\n")
+		b.WriteString(i.Body)
+		b.WriteString("\n")
+	}
+	b.WriteString("\n---\n\n")
+	b.WriteString("## Instructions\n\n")
+	b.WriteString("1. Read this file fully\n")
+	b.WriteString("2. Explore the codebase\n")
+	b.WriteString("3. Implement the feature/fix described above\n")
+	b.WriteString("4. When complete, send exactly: `[DONE] https://github.com/org/repo/pull/N` (with your PR URL)\n")
+	return b.String()
+}
+
+// githubAPIPostWithBase makes a POST/PATCH/PUT request to the GitHub API.
+func githubAPIPostWithBase(baseURL, path, token, method string, body interface{}) (map[string]interface{}, error) {
+	var bodyReader io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return nil, err
+		}
+		bodyReader = bytes.NewReader(b)
+	}
+	req, err := http.NewRequest(method, baseURL+"/"+path, bodyReader)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("github API %s %s: %d %s", method, path, resp.StatusCode, string(respBody))
+	}
+	var result map[string]interface{}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("github API parse error: %w", err)
+	}
+	return result, nil
+}
+
+// moveGitHubIssue updates a GitHub issue's state or labels.
+func moveGitHubIssue(token, repo string, issueNumber int, targetState string) error {
+	base := "https://api.github.com"
+	// targetState can be "open", "closed", or a label name
+	if strings.EqualFold(targetState, "open") || strings.EqualFold(targetState, "closed") {
+		state := strings.ToLower(targetState)
+		body := map[string]string{"state": state}
+		if state == "closed" {
+			body["state_reason"] = "completed"
+		}
+		_, err := githubAPIPostWithBase(base, fmt.Sprintf("repos/%s/issues/%d", repo, issueNumber), token, "PATCH", body)
+		return err
+	}
+	// Otherwise treat as label addition
+	_, err := githubAPIPostWithBase(base, fmt.Sprintf("repos/%s/issues/%d/labels", repo, issueNumber), token, "POST", map[string][]string{"labels": {targetState}})
+	return err
+}

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -683,6 +683,20 @@ func (s *Server) resolveSecretRef(ref types.SecretRef, factory *types.FactoryCon
 			}
 		}
 		return "", envName, false
+	case "github-issues":
+		if s.hubCfg.Integrations == nil {
+			return "", envName, false
+		}
+		ws := ref.Workspace
+		if ws == "" && factory != nil {
+			ws = factory.Workspace
+		}
+		for _, gi := range s.hubCfg.Integrations.GitHubIssues {
+			if ws == "" || strings.EqualFold(gi.Workspace, ws) {
+				return gi.Token, envName, true
+			}
+		}
+		return "", envName, false
 	case "github":
 		// GitHub tokens are minted per-installation; not stored in integrations.
 		// For now, fall through to custom lookup in hub secrets.
@@ -739,9 +753,9 @@ func buildLinearContext(payload linearWebhookPayload) string {
 // If no valid open PRs are found (and a GH App is configured), it injects an
 // error message back so the claw can retry.
 func (s *Server) handleClawDoneSignal(clawID, rawMessage string) {
-	// Get the linear_issue_id and tenant for this claw
+	// Get the issue ID and tenant for this claw (linear or github-issues)
 	var issueID, tenantID string
-	if err := s.db.QueryRow(`SELECT linear_issue_id, tenant_id FROM claws WHERE id = ?`, clawID).Scan(&issueID, &tenantID); err != nil || issueID == "" {
+	if err := s.db.QueryRow(`SELECT COALESCE(NULLIF(linear_issue_id,''),NULLIF(github_issue_id,'')), tenant_id FROM claws WHERE id = ?`, clawID).Scan(&issueID, &tenantID); err != nil || issueID == "" {
 		return // not a factory claw
 	}
 
@@ -795,6 +809,26 @@ func (s *Server) handleClawDoneSignal(clawID, rawMessage string) {
 					log.Printf("[factory] failed to move story %s to '%s': %v", issueID, factory.DoneStatus, err)
 				} else {
 					log.Printf("[factory] moved story %s to '%s'", issueID, factory.DoneStatus)
+				}
+			}
+		} else if strings.HasPrefix(issueID, "gh-") {
+			// GitHub issue
+			ghToken := s.resolveGitHubIssuesTokenForFactory(factory)
+			if ghToken != "" {
+				// Parse gh-owner/repo/number from issueID
+				rest := strings.TrimPrefix(issueID, "gh-")
+				lastSlash := strings.LastIndex(rest, "/")
+				if lastSlash > 0 {
+					repo := rest[:lastSlash]
+					issueNumStr := rest[lastSlash+1:]
+					var issueNum int
+					if _, err := fmt.Sscanf(issueNumStr, "%d", &issueNum); err == nil {
+						if err := moveGitHubIssue(ghToken, repo, issueNum, factory.DoneStatus); err != nil {
+							log.Printf("[factory] failed to move GitHub issue %s to '%s': %v", issueID, factory.DoneStatus, err)
+						} else {
+							log.Printf("[factory] moved GitHub issue %s to '%s'", issueID, factory.DoneStatus)
+						}
+					}
 				}
 			}
 		} else {
@@ -911,6 +945,22 @@ func (s *Server) findFactoryForIssue(issueID string) *types.FactoryConfig {
 			}
 		}
 	}
+	// Also check github_issue_id column
+	if err := s.db.QueryRow(`SELECT tags FROM claws WHERE github_issue_id = ? AND status NOT IN ('error','deleted') LIMIT 1`, issueID).Scan(&tagsJSON); err == nil {
+		var tags []string
+		if json.Unmarshal([]byte(tagsJSON), &tags) == nil {
+			for _, tag := range tags {
+				if strings.HasPrefix(tag, "factory:") {
+					factoryName := strings.TrimPrefix(tag, "factory:")
+					for _, factory := range s.hubCfg.Factories {
+						if factory.Name == factoryName {
+							return factory
+						}
+					}
+				}
+			}
+		}
+	}
 
 	// Fallback: Extract team key from issue ID (e.g. "ELA" from "ELA-123", "sc" from "sc-123")
 	parts := strings.SplitN(issueID, "-", 2)
@@ -923,6 +973,9 @@ func (s *Server) findFactoryForIssue(issueID string) *types.FactoryConfig {
 	expectedIntegration := "linear"
 	if teamKey == "sc" {
 		expectedIntegration = "shortcut"
+	}
+	if strings.HasPrefix(issueID, "gh-") {
+		expectedIntegration = "github-issues"
 	}
 
 	for _, factory := range s.hubCfg.Factories {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -186,6 +186,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	// Integration webhooks (signature-validated, no session auth)
 	mux.HandleFunc("/api/integrations/linear/webhook", s.handleLinearWebhook)
 	mux.HandleFunc("/api/integrations/github/webhook", s.handleGitHubWebhook)
+	mux.HandleFunc("/api/integrations/github-issues/webhook", s.handleGitHubIssuesWebhook)
 	mux.HandleFunc("/api/integrations/shortcut/webhook", s.handleShortcutWebhook)
 	mux.HandleFunc("/api/factories/", s.withAuth(s.handleFactoryEvents))    // GET /api/factories/:name/events
 	mux.HandleFunc("/api/factories", s.withAuth(s.handleFactoriesCRUD))     // factory CRUD (GET list, POST push)

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -75,8 +75,9 @@ type AccessView struct {
 }
 
 type IntegrationsView struct {
-	Linear   []LinearIntegrationView   `json:"linear"`
-	Shortcut []ShortcutIntegrationView `json:"shortcut"`
+	Linear       []LinearIntegrationView       `json:"linear"`
+	Shortcut     []ShortcutIntegrationView     `json:"shortcut"`
+	GitHubIssues []GitHubIssuesIntegrationView `json:"githubIssues"`
 }
 
 type ShortcutIntegrationView struct {
@@ -85,6 +86,12 @@ type ShortcutIntegrationView struct {
 }
 
 type LinearIntegrationView struct {
+	Workspace        string `json:"workspace"`
+	TokenSet         bool   `json:"tokenSet"`
+	WebhookSecretSet bool   `json:"webhookSecretSet"`
+}
+
+type GitHubIssuesIntegrationView struct {
 	Workspace        string `json:"workspace"`
 	TokenSet         bool   `json:"tokenSet"`
 	WebhookSecretSet bool   `json:"webhookSecretSet"`
@@ -206,8 +213,9 @@ type AccessPatch struct {
 }
 
 type IntegrationsPatch struct {
-	Linear   []LinearIntegrationPatch   `json:"linear,omitempty"`
-	Shortcut []ShortcutIntegrationPatch `json:"shortcut,omitempty"`
+	Linear       []LinearIntegrationPatch       `json:"linear,omitempty"`
+	Shortcut     []ShortcutIntegrationPatch     `json:"shortcut,omitempty"`
+	GitHubIssues []GitHubIssuesIntegrationPatch `json:"githubIssues,omitempty"`
 }
 
 type ShortcutIntegrationPatch struct {
@@ -222,6 +230,14 @@ type LinearIntegrationPatch struct {
 	OriginalWorkspace string `json:"originalWorkspace,omitempty"`
 	Token             string `json:"token,omitempty"`
 	WebhookSecret     string `json:"webhookSecret,omitempty"`
+}
+
+type GitHubIssuesIntegrationPatch struct {
+	Workspace         string `json:"workspace"`
+	OriginalWorkspace string `json:"originalWorkspace,omitempty"`
+	Token             string `json:"token,omitempty"`
+	WebhookSecret     string `json:"webhookSecret,omitempty"`
+	Delete            bool   `json:"delete,omitempty"`
 }
 
 type FactoryPatch struct {
@@ -342,7 +358,7 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Integrations
-	view.Integrations = &IntegrationsView{Linear: []LinearIntegrationView{}, Shortcut: []ShortcutIntegrationView{}}
+	view.Integrations = &IntegrationsView{Linear: []LinearIntegrationView{}, Shortcut: []ShortcutIntegrationView{}, GitHubIssues: []GitHubIssuesIntegrationView{}}
 	if s.hubCfg.Integrations != nil {
 		for _, sc := range s.hubCfg.Integrations.Shortcut {
 			view.Integrations.Shortcut = append(view.Integrations.Shortcut, ShortcutIntegrationView{
@@ -355,6 +371,13 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 				Workspace:        li.Workspace,
 				TokenSet:         li.Token != "",
 				WebhookSecretSet: li.WebhookSecret != "",
+			})
+		}
+		for _, gi := range s.hubCfg.Integrations.GitHubIssues {
+			view.Integrations.GitHubIssues = append(view.Integrations.GitHubIssues, GitHubIssuesIntegrationView{
+				Workspace:        gi.Workspace,
+				TokenSet:         gi.Token != "",
+				WebhookSecretSet: gi.WebhookSecret != "",
 			})
 		}
 	}
@@ -734,9 +757,10 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 		}
 		updatedCfg.Integrations.Linear = linears
 
-		// Preserve existing Shortcut integrations not in patch
+		// Preserve existing Shortcut and GitHub Issues integrations not in patch
 		if existingIntegrations != nil {
 			updatedCfg.Integrations.Shortcut = existingIntegrations.Shortcut
+			updatedCfg.Integrations.GitHubIssues = existingIntegrations.GitHubIssues
 		}
 	}
 
@@ -750,8 +774,9 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 			updatedCfg.Integrations = &types.IntegrationsConfig{}
 		} else {
 			updatedCfg.Integrations = &types.IntegrationsConfig{
-				Linear:   existingIntegrations.Linear,
-				Shortcut: existingIntegrations.Shortcut,
+				Linear:       existingIntegrations.Linear,
+				Shortcut:     existingIntegrations.Shortcut,
+				GitHubIssues: existingIntegrations.GitHubIssues,
 			}
 		}
 		existing := updatedCfg.Integrations.Shortcut
@@ -777,6 +802,49 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 			shortcuts = append(shortcuts, sc)
 		}
 		updatedCfg.Integrations.Shortcut = shortcuts
+	}
+
+	if patch.Integrations != nil && patch.Integrations.GitHubIssues != nil {
+		var existingIntegrations *types.IntegrationsConfig
+		if updatedCfg.Integrations != nil {
+			existingIntegrations = updatedCfg.Integrations
+		}
+		if updatedCfg.Integrations == nil {
+			updatedCfg.Integrations = &types.IntegrationsConfig{}
+		} else {
+			updatedCfg.Integrations = &types.IntegrationsConfig{
+				Linear:       existingIntegrations.Linear,
+				Shortcut:     existingIntegrations.Shortcut,
+				GitHubIssues: existingIntegrations.GitHubIssues,
+			}
+		}
+		existing := updatedCfg.Integrations.GitHubIssues
+		var githubIssues []*types.GitHubIssuesIntegrationConfig
+		for _, gp := range patch.Integrations.GitHubIssues {
+			if gp.Delete {
+				continue
+			}
+			gi := &types.GitHubIssuesIntegrationConfig{Workspace: gp.Workspace}
+			matchWorkspace := gp.Workspace
+			if gp.OriginalWorkspace != "" {
+				matchWorkspace = gp.OriginalWorkspace
+			}
+			for _, ex := range existing {
+				if ex.Workspace == matchWorkspace {
+					gi.Token = ex.Token
+					gi.WebhookSecret = ex.WebhookSecret
+					break
+				}
+			}
+			if gp.Token != "" {
+				gi.Token = gp.Token
+			}
+			if gp.WebhookSecret != "" {
+				gi.WebhookSecret = gp.WebhookSecret
+			}
+			githubIssues = append(githubIssues, gi)
+		}
+		updatedCfg.Integrations.GitHubIssues = githubIssues
 	}
 
 	// Factories (full replace)

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -168,6 +168,8 @@ func (r SecretRef) EnvVarName() string {
 		return "LINEAR_API_KEY"
 	case "shortcut":
 		return "SHORTCUT_API_KEY"
+	case "github-issues":
+		return "GITHUB_ISSUES_API_KEY"
 	case "github":
 		return "GITHUB_TOKEN"
 	case "custom":
@@ -354,8 +356,9 @@ type HubConfig struct {
 
 // IntegrationsConfig holds configs for external integrations.
 type IntegrationsConfig struct {
-	Linear    []*LinearIntegrationConfig    `yaml:"linear,omitempty"`
-	Shortcut  []*ShortcutIntegrationConfig  `yaml:"shortcut,omitempty"`
+	Linear      []*LinearIntegrationConfig      `yaml:"linear,omitempty"`
+	Shortcut    []*ShortcutIntegrationConfig    `yaml:"shortcut,omitempty"`
+	GitHubIssues []*GitHubIssuesIntegrationConfig `yaml:"github_issues,omitempty"`
 }
 
 // ShortcutIntegrationConfig holds credentials for one Shortcut workspace.
@@ -371,11 +374,18 @@ type LinearIntegrationConfig struct {
 	WebhookSecret string `yaml:"webhook_secret,omitempty"` // HMAC secret for validating webhooks
 }
 
+// GitHubIssuesIntegrationConfig holds credentials for one GitHub Issues integration.
+type GitHubIssuesIntegrationConfig struct {
+	Workspace     string `yaml:"workspace"`       // human label (e.g. "my-org")
+	Token         string `yaml:"token"`            // GitHub personal access token
+	WebhookSecret string `yaml:"webhook_secret,omitempty"` // HMAC secret for validating webhooks
+}
+
 // FactoryConfig defines an automation rule that creates claws based on integration events.
 type FactoryConfig struct {
 	Name              string `yaml:"name"`
 	Enabled           *bool  `yaml:"enabled,omitempty"`  // nil = true (default on); set false to pause
-	Integration       string `yaml:"integration"`        // "linear", "shortcut", or "github"
+	Integration       string `yaml:"integration"`        // "linear", "shortcut", "github-issues", or "github"
 	Workspace         string `yaml:"workspace,omitempty"` // matches integrations.<type>[].workspace
 	Team              string `yaml:"team,omitempty"`     // Linear team key (e.g. "ELA")
 	TriggerStatus     string `yaml:"trigger_status,omitempty"` // entering this status → create claw

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -58,6 +58,7 @@ interface SettingsData {
   integrations?: {
     linear?: Array<{ workspace: string; tokenSet: boolean; webhookSecretSet: boolean }>
     shortcut?: Array<{ workspace: string; tokenSet: boolean }>
+    githubIssues?: Array<{ workspace: string; tokenSet: boolean; webhookSecretSet: boolean }>
   }
   factories?: Array<{
     name: string; integration: string; workspace: string; team: string
@@ -1363,7 +1364,7 @@ function AuthenticationSection({ settings, onSave, saving }: { settings: Setting
     </div>
   )
 }
-type TrackerType = "linear" | "shortcut"
+type TrackerType = "linear" | "shortcut" | "github-issues"
 
 interface TrackerItem {
   type: TrackerType
@@ -1374,10 +1375,12 @@ interface TrackerItem {
 function IntegrationsSection({ settings, onSave, saving }: { settings: SettingsData; onSave: (p: object) => void; saving: boolean }) {
   const linear = settings.integrations?.linear || []
   const shortcut = settings.integrations?.shortcut || []
+  const githubIssues = settings.integrations?.githubIssues || []
 
   const allTrackers: TrackerItem[] = [
     ...linear.map((li: { workspace: string; tokenSet?: boolean }) => ({ type: "linear" as TrackerType, workspace: li.workspace, tokenSet: li.tokenSet ?? false })),
     ...shortcut.map((sc: { workspace: string; tokenSet?: boolean }) => ({ type: "shortcut" as TrackerType, workspace: sc.workspace, tokenSet: sc.tokenSet ?? false })),
+    ...githubIssues.map((gi: { workspace: string; tokenSet?: boolean }) => ({ type: "github-issues" as TrackerType, workspace: gi.workspace, tokenSet: gi.tokenSet ?? false })),
   ]
 
   // Unified modal state
@@ -1417,7 +1420,14 @@ function IntegrationsSection({ settings, onSave, saving }: { settings: SettingsD
   }
 
   const openEdit = (tracker: TrackerItem, idx: number) => {
-    const typeIdx = tracker.type === "linear" ? idx : idx - linear.length
+    let typeIdx: number
+    if (tracker.type === "linear") {
+      typeIdx = idx
+    } else if (tracker.type === "shortcut") {
+      typeIdx = idx - linear.length
+    } else {
+      typeIdx = idx - linear.length - shortcut.length
+    }
     setWorkspace(tracker.workspace)
     setToken("")
     setEditIdx(typeIdx)
@@ -1443,7 +1453,7 @@ function IntegrationsSection({ settings, onSave, saving }: { settings: SettingsD
         )
         onSave({ integrations: { linear: updated } })
       }
-    } else {
+    } else if (type === "shortcut") {
       if (modalMode === "add") {
         onSave({ integrations: { shortcut: [...shortcut.map((x: { workspace: string }) => ({ workspace: x.workspace })), { workspace: workspace.trim(), token: token.trim() }] } })
       } else if (editIdx !== null) {
@@ -1453,6 +1463,18 @@ function IntegrationsSection({ settings, onSave, saving }: { settings: SettingsD
           : { workspace: item.workspace }
         )
         onSave({ integrations: { shortcut: updated } })
+      }
+    } else {
+      // github-issues
+      if (modalMode === "add") {
+        onSave({ integrations: { githubIssues: [...githubIssues.map((x: { workspace: string }) => ({ workspace: x.workspace })), { workspace: workspace.trim(), token: token.trim() }] } })
+      } else if (editIdx !== null) {
+        const gi = githubIssues[editIdx]
+        const updated = githubIssues.map((item: { workspace: string }, i: number) => i === editIdx
+          ? { workspace: workspace.trim(), originalWorkspace: gi.workspace, ...(token.trim() ? { token: token.trim() } : {}) }
+          : { workspace: item.workspace }
+        )
+        onSave({ integrations: { githubIssues: updated } })
       }
     }
     setShowModal(false)
@@ -1464,21 +1486,35 @@ function IntegrationsSection({ settings, onSave, saving }: { settings: SettingsD
       onSave({ integrations: { linear: linear.filter((_: unknown, j: number) => j !== editIdx) } })
     } else if (editType === "shortcut" && editIdx !== null) {
       onSave({ integrations: { shortcut: shortcut.filter((_: unknown, j: number) => j !== editIdx).map((x: { workspace: string }) => ({ workspace: x.workspace })) } })
+    } else if (editType === "github-issues" && editIdx !== null) {
+      onSave({ integrations: { githubIssues: githubIssues.filter((_: unknown, j: number) => j !== editIdx).map((x: { workspace: string }) => ({ workspace: x.workspace })) } })
     }
     setShowModal(false)
     resetModal()
   }
 
+  const trackerTypeLabel = (t: TrackerType) => {
+    switch (t) {
+      case "linear": return "Linear"
+      case "shortcut": return "Shortcut"
+      case "github-issues": return "GitHub Issues"
+    }
+  }
+
   const modalTitle = modalMode === "add"
-    ? `Add ${modalType === "linear" ? "Linear" : "Shortcut"} workspace`
-    : `Edit ${editType === "linear" ? "Linear" : "Shortcut"} — ${workspace}`
+    ? `Add ${trackerTypeLabel(modalType)} workspace`
+    : `Edit ${trackerTypeLabel(editType)} — ${workspace}`
 
-  const modalIcon = modalType === "linear" || (modalMode === "edit" && editType === "linear")
+  const modalIcon = (modalMode === "add" ? modalType : editType) === "linear"
     ? <Zap className="size-4" />
-    : <span className="text-[#F4603C]">⚡</span>
+    : (modalMode === "add" ? modalType : editType) === "shortcut"
+    ? <span className="text-[#F4603C]">⚡</span>
+    : <Github className="size-4" />
 
-  const tokenHint = modalType === "linear" || (modalMode === "edit" && editType === "linear")
+  const tokenHint = (modalMode === "add" ? modalType : editType) === "linear"
     ? <>Create a token at <a href="https://linear.app/settings/api" target="_blank" rel="noopener noreferrer" className="underline">linear.app/settings/api</a></>
+    : (modalMode === "add" ? modalType : editType) === "github-issues"
+    ? <>Create a token at <a href="https://github.com/settings/tokens" target="_blank" rel="noopener noreferrer" className="underline">github.com/settings/tokens</a> with <code>repo</code> and <code>issues</code> scopes</>
     : null
 
   return (
@@ -1498,6 +1534,9 @@ function IntegrationsSection({ settings, onSave, saving }: { settings: SettingsD
           {shortcut.length > 0 && (
             <span className="text-xs bg-muted text-muted-foreground px-1.5 py-0.5 rounded">Shortcut: {shortcut.length}</span>
           )}
+          {githubIssues.length > 0 && (
+            <span className="text-xs bg-muted text-muted-foreground px-1.5 py-0.5 rounded">GitHub Issues: {githubIssues.length}</span>
+          )}
         </div>
       </div>
 
@@ -1513,13 +1552,15 @@ function IntegrationsSection({ settings, onSave, saving }: { settings: SettingsD
               <div className="flex items-center gap-3">
                 {tracker.type === "linear" ? (
                   <Zap className="size-4 text-muted-foreground" />
-                ) : (
+                ) : tracker.type === "shortcut" ? (
                   <span className="text-[#F4603C]">⚡</span>
+                ) : (
+                  <Github className="size-4 text-muted-foreground" />
                 )}
                 <div>
                   <p className="text-sm font-medium">{tracker.workspace}</p>
                   <div className="flex items-center gap-1.5 mt-0.5">
-                    <span className="text-xs text-muted-foreground capitalize">{tracker.type}</span>
+                    <span className="text-xs text-muted-foreground capitalize">{tracker.type === "github-issues" ? "github issues" : tracker.type}</span>
                     <span className="text-xs text-muted-foreground">·</span>
                     {tracker.tokenSet ? (
                       <span className="text-xs text-green-400 flex items-center gap-1">
@@ -1569,6 +1610,13 @@ function IntegrationsSection({ settings, onSave, saving }: { settings: SettingsD
               <span className="text-[#F4603C]">⚡</span>
               <span>Shortcut</span>
             </button>
+            <button
+              onClick={() => openAdd("github-issues")}
+              className="w-full flex items-center gap-2 px-3 py-2 text-sm hover:bg-muted transition-colors text-left"
+            >
+              <Github className="size-4" />
+              <span>GitHub Issues</span>
+            </button>
           </div>
         )}
       </div>
@@ -1588,7 +1636,7 @@ function IntegrationsSection({ settings, onSave, saving }: { settings: SettingsD
             </div>
             <div className="p-5 space-y-4">
               <p className="text-sm text-muted-foreground">
-                Connect a {modalType === "linear" || (modalMode === "edit" && editType === "linear") ? "Linear" : "Shortcut"} workspace to sync issues.
+                Connect a {trackerTypeLabel(modalMode === "add" ? modalType : editType)} workspace to sync issues.
               </p>
               <div>
                 <label className="text-xs text-muted-foreground mb-1 block">Workspace label</label>
@@ -1597,7 +1645,7 @@ function IntegrationsSection({ settings, onSave, saving }: { settings: SettingsD
               </div>
               <div>
                 <label className="text-xs text-muted-foreground mb-1 block">API Token</label>
-                <Input type="password" value={token} onChange={e => setToken(e.target.value)} className="h-9 text-sm" placeholder={`${modalType === "linear" || (modalMode === "edit" && editType === "linear") ? "Linear" : "Shortcut"} API token`} />
+                <Input type="password" value={token} onChange={e => setToken(e.target.value)} className="h-9 text-sm" placeholder={`${trackerTypeLabel(modalMode === "add" ? modalType : editType)} API token`} />
                 {tokenHint && <p className="text-xs text-muted-foreground mt-1">{tokenHint}</p>}
               </div>
             </div>
@@ -1639,7 +1687,12 @@ function WebhookUrlsModal({ hubUrl }: { hubUrl: string }) {
       hint: "Use Shortcut's API to register this webhook: POST /api/v3/webhooks with this URL.",
     },
     {
-      name: "GitHub",
+      name: "GitHub Issues",
+      url: hubUrl ? `${hubUrl}/api/integrations/github-issues/webhook` : "",
+      hint: "Use in GitHub repo or org settings. Subscribe to: Issues events.",
+    },
+    {
+      name: "GitHub (PRs)",
       url: hubUrl ? `${hubUrl}/api/integrations/github/webhook` : "",
       hint: "Use in GitHub repo or org settings. Subscribe to: Pull requests and Issue comments.",
     },

--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
Adds GitHub Issues as a completely separate integration from the existing GitHub App/PR webhook.

- New backend webhook handler at `/api/integrations/github-issues/webhook`
- HMAC-SHA256 signature validation via `X-Hub-Signature-256`
- Factory support: trigger on open/closed/labeled, done signal moves issue to closed or adds label
- Personal access token auth (not GitHub App) — separate from PR integration
- Frontend: third option in unified tracker list with dropdown add