### PR TITLE
feat: GitHub Issues factory actions (CloseIssue, comment injection)

### DIFF
--- a/cmd/factory.go
+++ b/cmd/factory.go
@@ -67,7 +67,56 @@ func runFactoryCreate(name, integration, workspace, triggerStatus, doneStatus, t
 		workspace = name
 	}
 
-	factoryYAML := fmt.Sprintf(`name: %s
+	var factoryYAML, pipelineYAML string
+
+	if integration == "github" {
+		// GitHub issue factory — uses repos and trigger instead of workspace/trigger_status
+		factoryYAML = fmt.Sprintf(`name: %s
+integration: github-issues
+workspace: %s
+trigger_status: "claw-ready"   # label name or issue state ("open")
+# labels: [bug]                # ALL labels must be present (AND)
+# assigned_to: "@username"      # or !@username, any, none
+# allowed_labelers:             # restrict who can trigger by labeling
+#   - marc-campbell
+#   - root-bot
+webhook_secret_ref: %s_webhook_secret
+
+template: %s
+`, name, workspace, name, tmpl)
+
+		pipelineYAML = fmt.Sprintf(`# Pipeline for %s (GitHub Issues)
+stages:
+  - id: working
+    label: "Working"
+    entry: true
+    on_enter:
+      inject: |
+        Read the GitHub issue in CONTEXT.md and start working.
+        Create a branch, implement the fix, and open a PR.
+        Narrate your progress. Send [DONE] when the PR is ready.
+
+  - id: pr_opened
+    label: "PR Opened"
+    triggers:
+      - message_contains: "[DONE]"
+    on_enter:
+      inject: |
+        PR created. Watch for CI results and review comments.
+
+  - id: done
+    label: "Done"
+    triggers:
+      - message_contains: "[DONE]"
+    on_enter:
+      close_issue: true
+      inject: |
+        Issue resolved. Closing the GitHub issue.
+    terminal: true
+`, name)
+	} else {
+		// Linear/Shortcut factory
+		factoryYAML = fmt.Sprintf(`name: %s
 integration: %s
 workspace: %s
 trigger_status: %q
@@ -78,7 +127,7 @@ webhook_secret_ref: %s_webhook_secret
 template: %s
 `, name, integration, workspace, triggerStatus, name, tmpl)
 
-	pipelineYAML := fmt.Sprintf(`# Pipeline for %s
+		pipelineYAML = fmt.Sprintf(`# Pipeline for %s
 # Stages define the lifecycle of a factory claw.
 # The hub is the state machine — it injects instructions into the claw at each stage.
 
@@ -114,6 +163,7 @@ stages:
       inject: |
         PR was closed without merging. Decide: reopen, new PR, or ask the user.
 `, name, doneStatus)
+	}
 
 	dir := filepath.Join(".elasticclaw", "factories", name)
 	if err := os.MkdirAll(dir, 0755); err != nil {

--- a/pkg/hub/github_issues.go
+++ b/pkg/hub/github_issues.go
@@ -172,11 +172,16 @@ func verifyGitHubHMAC(body []byte, sig, secret string) bool {
 }
 
 func (s *Server) processGitHubIssuesEvent(payload githubIssuesWebhookPayload) {
+	issueID := fmt.Sprintf("%s/%d", payload.Repository.FullName, payload.Issue.Number)
+	log.Printf("[github-issues-webhook] processing event: action=%q issue=%s title=%q sender=%q",
+		payload.Action, issueID, payload.Issue.Title, payload.Sender.Login)
+
 	if s.hubCfg.Factories == nil {
+		log.Printf("[github-issues-webhook] no factories configured — nothing to do")
 		return
 	}
+	log.Printf("[github-issues-webhook] checking %d factories", len(s.hubCfg.Factories))
 
-	issueID := fmt.Sprintf("gh-%s/%d", payload.Repository.FullName, payload.Issue.Number)
 	currentStatus := payload.Issue.State
 	previousStatus := ""
 
@@ -198,6 +203,14 @@ func (s *Server) processGitHubIssuesEvent(payload githubIssuesWebhookPayload) {
 	for _, l := range payload.Issue.Labels {
 		issueLabels[strings.ToLower(l.Name)] = true
 	}
+	log.Printf("[github-issues-webhook] issue %s labels=%v assignee=%q currentStatus=%q previousStatus=%q",
+		issueID, func() []string {
+			out := make([]string, 0, len(issueLabels))
+			for k := range issueLabels {
+				out = append(out, k)
+			}
+			return out
+		}(), assignee, currentStatus, previousStatus)
 
 	// Handle label/unlabel actions: the label that was added/removed is in payload.Label
 	// For "labeled", build the pre-event label set so previousMatched works correctly
@@ -214,6 +227,14 @@ func (s *Server) processGitHubIssuesEvent(payload githubIssuesWebhookPayload) {
 		if previousStatus == "" {
 			previousStatus = currentStatus
 		}
+		log.Printf("[github-issues-webhook] label '%s' added by %q — previousLabels=%v",
+			payload.Label.Name, payload.Sender.Login, func() []string {
+				out := make([]string, 0, len(previousLabels))
+				for k := range previousLabels {
+					out = append(out, k)
+				}
+				return out
+			}())
 	}
 	if payload.Action == "unlabeled" && payload.Label != nil {
 		delete(issueLabels, strings.ToLower(payload.Label.Name))
@@ -224,61 +245,114 @@ func (s *Server) processGitHubIssuesEvent(payload githubIssuesWebhookPayload) {
 
 	matched := false
 	for _, factory := range s.hubCfg.Factories {
+		log.Printf("[github-issues-webhook] checking factory %q: integration=%q enabled=%v trigger_status=%q labels=%v assigned_to=%q allowed_labelers=%v",
+			factory.Name, factory.Integration,
+			func() bool {
+				if factory.Enabled == nil {
+					return true
+				}
+				return *factory.Enabled
+			}(),
+			factory.TriggerStatus, factory.Labels, factory.AssignedTo, factory.AllowedLabelers)
+
 		if factory.Integration != "github-issues" {
+			log.Printf("[github-issues-webhook] factory %q: SKIP — integration=%q, want github-issues", factory.Name, factory.Integration)
 			continue
 		}
 		if factory.Enabled != nil && !*factory.Enabled {
+			log.Printf("[github-issues-webhook] factory %q: SKIP — disabled", factory.Name)
 			continue
 		}
 
-		// Workspace filter: if factory specifies a workspace, match against integration workspace
-		// (for GitHub Issues, workspace is a human label on the integration config, not the repo)
-		if factory.Workspace != "" {
+		// Workspace filter: for Linear/Shortcut, workspace selects the integration token.
+		// For GitHub Issues, workspace is just a human label — no token resolution needed.
+		if factory.Workspace != "" && factory.Integration != "github-issues" {
 			ghToken := s.resolveGitHubIssuesTokenForFactory(factory)
 			if ghToken == "" {
+				log.Printf("[github-issues-webhook] factory %q: SKIP — workspace=%q but no token resolved", factory.Name, factory.Workspace)
 				continue
 			}
-			// Workspace is just a label — we don't filter by repo here.
-			// If we wanted repo-level filtering, we'd add a Repos field to FactoryConfig.
+			log.Printf("[github-issues-webhook] factory %q: workspace=%q, token resolved", factory.Name, factory.Workspace)
 		}
 
 		// Labels filter: all configured labels must be present on the issue (AND)
 		if len(factory.Labels) > 0 {
 			allMatch := true
+			missing := []string{}
 			for _, required := range factory.Labels {
 				if !issueLabels[strings.ToLower(required)] {
 					allMatch = false
-					break
+					missing = append(missing, required)
 				}
 			}
 			if !allMatch {
+				log.Printf("[github-issues-webhook] factory %q: SKIP — missing required labels: %v (have: %v)", factory.Name, missing, func() []string {
+					out := make([]string, 0, len(issueLabels))
+					for k := range issueLabels {
+						out = append(out, k)
+					}
+					return out
+				}())
 				continue
 			}
+			log.Printf("[github-issues-webhook] factory %q: labels match (all %v present)", factory.Name, factory.Labels)
+		}
+
+		// AllowedLabelers filter: restrict who can trigger by labeling
+		if len(factory.AllowedLabelers) > 0 && (payload.Action == "labeled" || payload.Action == "unlabeled") {
+			labelerAllowed := false
+			for _, allowed := range factory.AllowedLabelers {
+				if strings.EqualFold(allowed, payload.Sender.Login) {
+					labelerAllowed = true
+					break
+				}
+			}
+			if !labelerAllowed {
+				log.Printf("[github-issues-webhook] factory %q: SKIP — labeler %q not in allowed_labelers %v",
+					factory.Name, payload.Sender.Login, factory.AllowedLabelers)
+				continue
+			}
+			log.Printf("[github-issues-webhook] factory %q: labeler %q allowed", factory.Name, payload.Sender.Login)
 		}
 
 		// AssignedTo filter
 		if factory.AssignedTo != "" {
 			wanted := strings.ToLower(strings.TrimSpace(factory.AssignedTo))
+			assigneeMatch := false
+			skipReason := ""
 			switch {
 			case wanted == "any":
-				if assignee == "" {
-					continue
+				if assignee != "" {
+					assigneeMatch = true
+				} else {
+					skipReason = "assignee=any but issue unassigned"
 				}
 			case wanted == "none":
-				if assignee != "" {
-					continue
+				if assignee == "" {
+					assigneeMatch = true
+				} else {
+					skipReason = fmt.Sprintf("assignee=none but issue assigned to %q", assignee)
 				}
 			case strings.HasPrefix(wanted, "!"):
 				excluded := strings.TrimPrefix(strings.TrimPrefix(wanted, "!"), "@")
-				if strings.EqualFold(assignee, excluded) {
-					continue
+				if !strings.EqualFold(assignee, excluded) {
+					assigneeMatch = true
+				} else {
+					skipReason = fmt.Sprintf("assignee %q is excluded (%q)", assignee, wanted)
 				}
 			default:
 				target := strings.TrimPrefix(wanted, "@")
-				if !strings.EqualFold(assignee, target) {
-					continue
+				if strings.EqualFold(assignee, target) {
+					assigneeMatch = true
+				} else {
+					skipReason = fmt.Sprintf("assignee=%q, want %q", assignee, target)
 				}
 			}
+			if !assigneeMatch {
+				log.Printf("[github-issues-webhook] factory %q: SKIP — %s", factory.Name, skipReason)
+				continue
+			}
+			log.Printf("[github-issues-webhook] factory %q: assignee match (%q)", factory.Name, factory.AssignedTo)
 		}
 
 		// Issue entering trigger status → create claw.
@@ -286,8 +360,21 @@ func (s *Server) processGitHubIssuesEvent(payload githubIssuesWebhookPayload) {
 		triggerMatched := false
 		if strings.EqualFold(currentStatus, factory.TriggerStatus) {
 			triggerMatched = true
+			log.Printf("[github-issues-webhook] factory %q: trigger matched by current status %q == trigger_status %q",
+				factory.Name, currentStatus, factory.TriggerStatus)
 		} else if issueLabels[strings.ToLower(factory.TriggerStatus)] {
 			triggerMatched = true
+			log.Printf("[github-issues-webhook] factory %q: trigger matched by label %q present",
+				factory.Name, factory.TriggerStatus)
+		} else {
+			log.Printf("[github-issues-webhook] factory %q: trigger NOT matched — currentStatus=%q, labels=%v, trigger_status=%q",
+				factory.Name, currentStatus, func() []string {
+					out := make([]string, 0, len(issueLabels))
+					for k := range issueLabels {
+						out = append(out, k)
+					}
+					return out
+				}(), factory.TriggerStatus)
 		}
 
 		// Only create when transitioning into the trigger condition
@@ -295,6 +382,8 @@ func (s *Server) processGitHubIssuesEvent(payload githubIssuesWebhookPayload) {
 		if previousStatus != "" {
 			if strings.EqualFold(previousStatus, factory.TriggerStatus) {
 				previousMatched = true
+				log.Printf("[github-issues-webhook] factory %q: previous status %q matched trigger (transition detection)",
+					factory.Name, previousStatus)
 			}
 		}
 		// For label-based triggers, also check if the trigger label was already
@@ -302,20 +391,29 @@ func (s *Server) processGitHubIssuesEvent(payload githubIssuesWebhookPayload) {
 		if !previousMatched && (payload.Action == "labeled" || payload.Action == "unlabeled") {
 			if previousLabels[strings.ToLower(factory.TriggerStatus)] {
 				previousMatched = true
+				log.Printf("[github-issues-webhook] factory %q: trigger label %q was already present before this event",
+					factory.Name, factory.TriggerStatus)
 			}
 		}
 
 		if triggerMatched && !previousMatched {
 			matched = true
-			log.Printf("[factory:%s] issue %s entered trigger '%s' — creating claw", factory.Name, issueID, factory.TriggerStatus)
+			log.Printf("[github-issues-webhook] factory %q: ✓ CREATING CLAW — issue %s entered trigger '%s' (was not in trigger before)",
+				factory.Name, issueID, factory.TriggerStatus)
 			clawID := ""
 			if err := s.createClawForGitHubIssue(factory, payload); err != nil {
-				log.Printf("[factory:%s] failed to create claw for %s: %v", factory.Name, issueID, err)
+				log.Printf("[github-issues-webhook] factory %q: ✗ FAILED to create claw for %s: %v", factory.Name, issueID, err)
 				s.logFactoryEvent(factory.Name, issueID, issueTitle, previousStatus, currentStatus, "error", "", err.Error())
 			} else {
 				_ = s.db.QueryRow(`SELECT id FROM claws WHERE github_issue_id=? ORDER BY created_at DESC LIMIT 1`, issueID).Scan(&clawID)
+				log.Printf("[github-issues-webhook] factory %q: ✓ CREATED claw %s for issue %s", factory.Name, clawID[:8], issueID)
 				s.logFactoryEvent(factory.Name, issueID, issueTitle, previousStatus, currentStatus, "claw_created", clawID, "")
 			}
+		} else if triggerMatched && previousMatched {
+			log.Printf("[github-issues-webhook] factory %q: SKIP — issue %s already in trigger '%s', no transition",
+				factory.Name, issueID, factory.TriggerStatus)
+		} else {
+			log.Printf("[github-issues-webhook] factory %q: SKIP — trigger not matched for issue %s", factory.Name, issueID)
 		}
 
 		// Issue leaving trigger status → terminate claw.
@@ -327,7 +425,8 @@ func (s *Server) processGitHubIssuesEvent(payload githubIssuesWebhookPayload) {
 			).Scan(&activeClaw)
 			if activeClaw != "" {
 				matched = true
-				log.Printf("[factory:%s] issue %s left trigger '%s' — terminating claw", factory.Name, issueID, factory.TriggerStatus)
+				log.Printf("[github-issues-webhook] factory %q: issue %s left trigger '%s' — terminating claw %s",
+					factory.Name, issueID, factory.TriggerStatus, activeClaw[:8])
 				s.terminateClawForGitHubIssue(issueID)
 				s.logFactoryEvent(factory.Name, issueID, issueTitle, previousStatus, currentStatus, "claw_terminated", activeClaw, "terminated: issue left trigger status")
 			}
@@ -335,8 +434,11 @@ func (s *Server) processGitHubIssuesEvent(payload githubIssuesWebhookPayload) {
 	}
 
 	if !matched {
+		log.Printf("[github-issues-webhook] no factory matched for issue %s — checking why:", issueID)
 		for _, factory := range s.hubCfg.Factories {
 			if factory.Integration == "github-issues" && (factory.Enabled == nil || *factory.Enabled) {
+				log.Printf("[github-issues-webhook] factory %q: not_actionable — status '%s'→'%s' did not match trigger '%s' (labels=%v)",
+					factory.Name, previousStatus, currentStatus, factory.TriggerStatus, factory.Labels)
 				s.logFactoryEvent(factory.Name, issueID, issueTitle, previousStatus, currentStatus, "not_actionable",
 					"", fmt.Sprintf("status '%s'→'%s' did not match trigger '%s'", previousStatus, currentStatus, factory.TriggerStatus))
 			}
@@ -345,7 +447,7 @@ func (s *Server) processGitHubIssuesEvent(payload githubIssuesWebhookPayload) {
 }
 
 func (s *Server) createClawForGitHubIssue(factory *types.FactoryConfig, payload githubIssuesWebhookPayload) error {
-	issueID := fmt.Sprintf("gh-%s/%d", payload.Repository.FullName, payload.Issue.Number)
+	issueID := fmt.Sprintf("%s/%d", payload.Repository.FullName, payload.Issue.Number)
 
 	// Verify we can read the issue before spending money on a sandbox
 	ghToken := s.resolveGitHubIssuesTokenForFactory(factory)
@@ -702,6 +804,119 @@ func githubAPIPostWithBase(baseURL, path, token, method string, body interface{}
 		return nil, fmt.Errorf("github API parse error: %w", err)
 	}
 	return result, nil
+}
+
+// findClawForGitHubIssue finds an active claw tracking the given GitHub issue URL.
+func (s *Server) findClawForGitHubIssue(issueURL string) string {
+	var clawID string
+	_ = s.db.QueryRow(
+		`SELECT id FROM claws WHERE github_issue_id = ? AND status NOT IN ('error','deleted') LIMIT 1`,
+		issueURL,
+	).Scan(&clawID)
+	return clawID
+}
+
+// closeGitHubIssueForClaw finds the tracked GitHub issue for a claw and closes it.
+func (s *Server) closeGitHubIssueForClaw(clawID string) {
+	var issueURL string
+	err := s.db.QueryRow(
+		`SELECT github_issue_id FROM claws WHERE id=?`,
+		clawID,
+	).Scan(&issueURL)
+	if err != nil || issueURL == "" {
+		log.Printf("[pipeline] close_issue: no tracked GitHub issue for claw %s", clawID[:8])
+		return
+	}
+
+	// Parse owner/repo#number from the issue URL
+	// URL format: https://github.com/owner/repo/issues/123
+	parts := strings.Split(issueURL, "/")
+	if len(parts) < 2 {
+		log.Printf("[pipeline] close_issue: invalid issue URL %q", issueURL)
+		return
+	}
+	// Extract owner/repo from URL
+	var owner, repo string
+	for i, p := range parts {
+		if p == "github.com" && i+2 < len(parts) {
+			owner = parts[i+1]
+			repo = parts[i+2]
+			break
+		}
+	}
+	if owner == "" || repo == "" {
+		log.Printf("[pipeline] close_issue: could not parse owner/repo from %q", issueURL)
+		return
+	}
+	repoFullName := owner + "/" + repo
+
+	// Extract issue number from URL
+	var issueNumber int
+	fmt.Sscanf(parts[len(parts)-1], "%d", &issueNumber)
+	if issueNumber == 0 {
+		log.Printf("[pipeline] close_issue: could not parse issue number from %q", issueURL)
+		return
+	}
+
+	// Find token for this repo
+	token := s.resolveGitHubIssuesTokenForRepo(repoFullName)
+	if token == "" {
+		log.Printf("[pipeline] close_issue: no GitHub token for repo %s", repoFullName)
+		s.injectHubMessageByID(clawID, fmt.Sprintf("[hub] close_issue: no GitHub token available for %s — cannot close issue.", repoFullName))
+		return
+	}
+
+	baseURL := s.ghBaseURL()
+
+	body, _ := json.Marshal(map[string]string{
+		"state":        "closed",
+		"state_reason": "completed",
+	})
+	_, err = githubAPIPostWithBase(baseURL, fmt.Sprintf("repos/%s/issues/%d", repoFullName, issueNumber), token, "PATCH", body)
+	if err != nil {
+		log.Printf("[pipeline] close_issue: failed to close issue %s#%d: %v", repoFullName, issueNumber, err)
+		s.injectHubMessageByID(clawID, fmt.Sprintf("[hub] close_issue: failed to close issue #%d: %v", issueNumber, err))
+		return
+	}
+
+	log.Printf("[pipeline] close_issue: closed issue %s#%d", repoFullName, issueNumber)
+	s.injectHubMessageByID(clawID, fmt.Sprintf("[hub] Closed GitHub issue #%d in %s.", issueNumber, repoFullName))
+}
+
+// resolveGitHubIssuesTokenForRepo resolves a GitHub token for a specific repo by checking
+// all GitHub Issues integrations and factories.
+func (s *Server) resolveGitHubIssuesTokenForRepo(repoFullName string) string {
+	s.mu.RLock()
+	integrations := s.hubCfg.Integrations
+	factories := s.hubCfg.Factories
+	secrets := s.hubCfg.Secrets
+	s.mu.RUnlock()
+
+	if integrations != nil {
+		for _, gi := range integrations.GitHubIssues {
+			if gi.Token != "" {
+				return gi.Token
+			}
+		}
+	}
+
+	if factories != nil {
+		for _, factory := range factories {
+			if factory.Integration != "github-issues" {
+				continue
+			}
+			if factory.WebhookSecret != "" {
+				return factory.WebhookSecret
+			}
+			if factory.WebhookSecretRef != "" && secrets != nil {
+				if secret := secrets[factory.WebhookSecretRef]; secret != "" {
+					return secret
+				}
+			}
+		}
+	}
+
+	return ""
 }
 
 // moveGitHubIssue updates a GitHub issue's state or labels.

--- a/pkg/hub/github_webhook.go
+++ b/pkg/hub/github_webhook.go
@@ -91,13 +91,17 @@ func (s *Server) handleGitHubWebhook(w http.ResponseWriter, r *http.Request) {
 			log.Printf("[github-webhook] failed to parse issue_comment payload: %v", err)
 			break
 		}
-		// Only care about comments on pull requests
-		if payload.Issue.PullRequest.URL == "" {
-			break
+		if payload.Issue.PullRequest.URL != "" {
+			// Comment on a pull request
+			log.Printf("[github-webhook] issue_comment action=%q repo=%q pr=#%d author=%q",
+				payload.Action, payload.Repository.FullName, payload.Issue.Number, payload.Comment.User.Login)
+			go s.processGitHubIssueCommentEvent(payload)
+		} else {
+			// Comment on a plain issue (not PR)
+			log.Printf("[github-webhook] issue_comment action=%q repo=%q issue=#%d author=%q",
+				payload.Action, payload.Repository.FullName, payload.Issue.Number, payload.Comment.User.Login)
+			go s.processGitHubIssueComment(payload)
 		}
-		log.Printf("[github-webhook] issue_comment action=%q repo=%q pr=#%d author=%q",
-			payload.Action, payload.Repository.FullName, payload.Issue.Number, payload.Comment.User.Login)
-		go s.processGitHubIssueCommentEvent(payload)
 	case "ping":
 		log.Printf("[github-webhook] ping received — webhook configured correctly")
 	default:
@@ -240,7 +244,8 @@ func (s *Server) processGitHubPREvent(payload githubPRPayload) {
 type githubIssueCommentPayload struct {
 	Action string `json:"action"` // "created", "edited", "deleted"
 	Issue  struct {
-		Number      int `json:"number"`
+		Number      int    `json:"number"`
+		HTMLURL     string `json:"html_url"` // web URL for the issue
 		PullRequest struct {
 			URL     string `json:"url"`      // non-empty only for PR comments
 			HTMLURL string `json:"html_url"` // web URL for the PR
@@ -261,6 +266,32 @@ type githubIssueCommentPayload struct {
 		Login string `json:"login"`
 		Type  string `json:"type"`
 	} `json:"sender"`
+}
+
+// processGitHubIssueComment handles issue_comment events on plain issues (not PRs).
+// If a claw exists for the issue, it injects the comment.
+func (s *Server) processGitHubIssueComment(payload githubIssueCommentPayload) {
+	if payload.Action != "created" {
+		return
+	}
+	// Skip bot comments to avoid loops
+	if strings.EqualFold(payload.Comment.User.Type, "bot") {
+		return
+	}
+
+	issueURL := payload.Issue.HTMLURL
+	commentMsg := fmt.Sprintf("**@%s** commented on issue #%d:\n> %s\n[View](%s)",
+		payload.Comment.User.Login, payload.Issue.Number,
+		strings.TrimSpace(payload.Comment.Body), payload.Comment.HTMLURL)
+
+	existingClawID := s.findClawForGitHubIssue(issueURL)
+	if existingClawID != "" {
+		log.Printf("[github-webhook] issue_comment on issue #%d — injecting into existing claw %s", payload.Issue.Number, existingClawID[:8])
+		s.injectHubMessageByID(existingClawID, commentMsg)
+		return
+	}
+
+	log.Printf("[github-webhook] issue_comment on issue #%d — no claw found for %s", payload.Issue.Number, issueURL)
 }
 
 // processGitHubIssueCommentEvent handles issue_comment events on PRs.

--- a/pkg/hub/pipeline/pipeline.go
+++ b/pkg/hub/pipeline/pipeline.go
@@ -87,6 +87,8 @@ type OnEnter struct {
 	MoveIssue string `yaml:"move_issue"`
 	// MergePR triggers the GitHub merge API for the tracked PR (stub — not yet implemented).
 	MergePR bool `yaml:"merge_pr,omitempty"`
+	// CloseIssue closes the associated GitHub issue when entering this stage.
+	CloseIssue bool `yaml:"close_issue,omitempty"`
 }
 
 // Parse decodes YAML bytes into a Pipeline. Returns an error if the YAML is invalid.

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -89,6 +89,10 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, factory *types.
 		go s.mergePRForClaw(clawID)
 	}
 
+	if stage.OnEnter.CloseIssue {
+		go s.closeGitHubIssueForClaw(clawID)
+	}
+
 	if stage.OnEnter.MoveIssue == "" || factory == nil || issueID == "" {
 		return
 	}
@@ -159,9 +163,14 @@ func (s *Server) initializePipelineEntryIfNeeded(clawID string) bool {
 // findFactoryForClaw looks up the factory that created a claw by its claw ID.
 // It uses the factory:<name> tag stored on the claw to identify the factory.
 func (s *Server) findFactoryForClaw(clawID string) (*types.FactoryConfig, string) {
-	var issueID, tagsJSON string
-	if err := s.db.QueryRow(`SELECT COALESCE(linear_issue_id,''), COALESCE(tags,'[]') FROM claws WHERE id=?`, clawID).Scan(&issueID, &tagsJSON); err != nil {
+	var issueID, githubIssueID, tagsJSON string
+	if err := s.db.QueryRow(`SELECT COALESCE(linear_issue_id,''), COALESCE(github_issue_id,''), COALESCE(tags,'[]') FROM claws WHERE id=?`, clawID).Scan(&issueID, &githubIssueID, &tagsJSON); err != nil {
 		return nil, ""
+	}
+
+	// Prefer github_issue_id for GitHub issue-based claws
+	if githubIssueID != "" {
+		issueID = githubIssueID
 	}
 
 	if issueID != "" {

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -401,6 +401,10 @@ type FactoryConfig struct {
 	Labels []string `yaml:"labels,omitempty"`
 	// AssignedTo filter: "@user", "!@user" (exclude), "any", "none"
 	AssignedTo string `yaml:"assigned_to,omitempty"`
+	// AllowedLabelers restricts who can trigger claw creation by labeling an issue.
+	// Only users in this list (GitHub logins, case-insensitive) can trigger.
+	// If empty, any user with label permissions can trigger.
+	AllowedLabelers []string `yaml:"allowed_labelers,omitempty"`
 	// WebhookSecretRef is a named key in HubConfig.Secrets (use instead of inline WebhookSecret for repo-defined factories)
 	WebhookSecretRef string `yaml:"webhook_secret_ref,omitempty"`
 	// PipelineYAML is the raw pipeline.yaml content stored alongside this factory


### PR DESCRIPTION
Implements missing features from the botched PR #109, now based on latest main:

- **CloseIssue pipeline action**: Closes tracked GitHub issues when entering a terminal stage
- **Issue comment injection**: Injects issue comments into existing issue-tracking claws (not just PRs)
- **Factory CLI scaffolding**: 
  
  
- **findFactoryForClaw**: Now prefers github_issue_id over linear_issue_id for GitHub issue-based claws

All features are additive — existing Linear/Shortcut/GitHub PR factory behavior is unchanged.