### PR TITLE
fix: skip Linear template rendering for GitHub Issues in pipeline

### DIFF
--- a/pkg/hub/github_issues.go
+++ b/pkg/hub/github_issues.go
@@ -464,14 +464,21 @@ func (s *Server) createClawForGitHubIssue(factory *types.FactoryConfig, payload 
 	}
 
 	// Enforce 1:1 — check if a claw already exists for this issue.
-	var existingID string
+	// If the claw is offline, error, or stopped, delete and recreate it since
+	// the underlying sandbox is gone. Only skip if it's actively starting,
+	// running, or connected.
+	var existingID, existingStatus string
 	_ = s.db.QueryRow(
-		`SELECT id FROM claws WHERE github_issue_id = ? AND status NOT IN ('error','deleted') LIMIT 1`,
+		`SELECT id, status FROM claws WHERE github_issue_id = ? AND status NOT IN ('deleted') LIMIT 1`,
 		issueID,
-	).Scan(&existingID)
+	).Scan(&existingID, &existingStatus)
 	if existingID != "" {
-		log.Printf("[factory:%s] claw %s already exists for issue %s — treating as idempotent success", factory.Name, existingID[:8], issueID)
-		return nil
+		if existingStatus == "starting" || existingStatus == "connected" || existingStatus == "running" {
+			log.Printf("[factory:%s] claw %s already exists for issue %s (status=%s) — treating as idempotent success", factory.Name, existingID[:8], issueID, existingStatus)
+			return nil
+		}
+		log.Printf("[factory:%s] claw %s exists for issue %s but status=%s, deleting and recreating", factory.Name, existingID[:8], issueID, existingStatus)
+		_, _ = s.db.Exec(`UPDATE claws SET status='deleted' WHERE id=?`, existingID)
 	}
 
 	// Load template

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -320,17 +320,21 @@ func (s *Server) createClawForIssue(factory *types.FactoryConfig, payload linear
 	}
 
 	// Enforce 1:1 — check if a claw already exists for this issue.
-	// If another concurrent request (or Linear redelivery) already created one,
-	// return the existing claw ID instead of failing. This makes the operation
-	// idempotent — duplicate webhooks are harmless.
-	var existingID string
+	// If the claw is offline, error, or stopped, delete and recreate it since
+	// the underlying sandbox is gone. Only skip if it's actively starting,
+	// running, or connected.
+	var existingID, existingStatus string
 	_ = s.db.QueryRow(
-		`SELECT id FROM claws WHERE linear_issue_id = ? AND status NOT IN ('error','deleted') LIMIT 1`,
+		`SELECT id, status FROM claws WHERE linear_issue_id = ? AND status NOT IN ('deleted') LIMIT 1`,
 		issueID,
-	).Scan(&existingID)
+	).Scan(&existingID, &existingStatus)
 	if existingID != "" {
-		log.Printf("[factory:%s] claw %s already exists for issue %s — treating as idempotent success", factory.Name, existingID[:8], issueID)
-		return nil
+		if existingStatus == "starting" || existingStatus == "connected" || existingStatus == "running" {
+			log.Printf("[factory:%s] claw %s already exists for issue %s (status=%s) — treating as idempotent success", factory.Name, existingID[:8], issueID, existingStatus)
+			return nil
+		}
+		log.Printf("[factory:%s] claw %s exists for issue %s but status=%s, deleting and recreating", factory.Name, existingID[:8], issueID, existingStatus)
+		_, _ = s.db.Exec(`UPDATE claws SET status='deleted' WHERE id=?`, existingID)
 	}
 
 	// Resolve template files

--- a/pkg/hub/pipeline/pipeline.go
+++ b/pkg/hub/pipeline/pipeline.go
@@ -89,6 +89,10 @@ type OnEnter struct {
 	MergePR bool `yaml:"merge_pr,omitempty"`
 	// CloseIssue closes the associated GitHub issue when entering this stage.
 	CloseIssue bool `yaml:"close_issue,omitempty"`
+	// AddLabels adds the specified labels to the associated GitHub issue.
+	AddLabels []string `yaml:"add_labels,omitempty"`
+	// RemoveLabels removes the specified labels from the associated GitHub issue.
+	RemoveLabels []string `yaml:"remove_labels,omitempty"`
 }
 
 // Parse decodes YAML bytes into a Pipeline. Returns an error if the YAML is invalid.

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -67,6 +67,39 @@ func (s *Server) fetchGitHubIssueDetails(token, repo string, issueNumber int, ba
 	}, nil
 }
 
+// githubAPIAddLabel adds a label to a GitHub issue. Unlike
+// githubAPIPostWithBase, this does not attempt to unmarshal the response body
+// (POST /labels returns a JSON array of label objects, not a JSON object).
+func githubAPIAddLabel(baseURL, repo string, issueNumber int, label, token string) error {
+	if baseURL == "" {
+		baseURL = "https://api.github.com"
+	}
+	path := fmt.Sprintf("repos/%s/issues/%d/labels", repo, issueNumber)
+	body := map[string][]string{"labels": {label}}
+	b, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest("POST", baseURL+"/"+path, bytes.NewReader(b))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("github API POST %s: %d %s", path, resp.StatusCode, string(respBody))
+	}
+	return nil
+}
+
 // githubAPIDeleteLabel removes a label from a GitHub issue. Unlike
 // githubAPIPostWithBase, this does not attempt to unmarshal the response body
 // (DELETE returns an array of remaining labels, not a JSON object).
@@ -248,7 +281,7 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, factory *types.
 							base = "https://api.github.com"
 						}
 						for _, label := range stage.OnEnter.AddLabels {
-							if _, err := githubAPIPostWithBase(base, fmt.Sprintf("repos/%s/issues/%d/labels", repo, issueNum), ghToken, "POST", map[string][]string{"labels": {label}}); err != nil {
+							if err := githubAPIAddLabel(base, repo, issueNum, label, ghToken); err != nil {
 								log.Printf("[pipeline] failed to add label %q to issue %s: %v", label, issueID, err)
 							} else {
 								log.Printf("[pipeline] added label %q to issue %s", label, issueID)

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -3,6 +3,7 @@ package hub
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"log"
 	"strings"
 	"text/template"
@@ -94,6 +95,40 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, factory *types.
 		go s.closeGitHubIssueForClaw(clawID)
 	}
 
+	// Handle add_labels / remove_labels for GitHub Issues
+	if len(stage.OnEnter.AddLabels) > 0 || len(stage.OnEnter.RemoveLabels) > 0 {
+		if strings.Contains(issueID, "/") {
+			ghToken := s.resolveGitHubIssuesTokenForFactory(factory)
+			if ghToken != "" {
+				parts := strings.Split(issueID, "/")
+				if len(parts) == 3 {
+					repo := parts[0] + "/" + parts[1]
+					var issueNum int
+					if _, err := fmt.Sscanf(parts[2], "%d", &issueNum); err == nil {
+						base := s.githubBaseURL
+						if base == "" {
+							base = "https://api.github.com"
+						}
+						for _, label := range stage.OnEnter.AddLabels {
+							if _, err := githubAPIPostWithBase(base, fmt.Sprintf("repos/%s/issues/%d/labels", repo, issueNum), ghToken, "POST", map[string][]string{"labels": {label}}); err != nil {
+								log.Printf("[pipeline] failed to add label %q to issue %s: %v", label, issueID, err)
+							} else {
+								log.Printf("[pipeline] added label %q to issue %s", label, issueID)
+							}
+						}
+						for _, label := range stage.OnEnter.RemoveLabels {
+							if _, err := githubAPIPostWithBase(base, fmt.Sprintf("repos/%s/issues/%d/labels/%s", repo, issueNum, label), ghToken, "DELETE", nil); err != nil {
+								log.Printf("[pipeline] failed to remove label %q from issue %s: %v", label, issueID, err)
+							} else {
+								log.Printf("[pipeline] removed label %q from issue %s", label, issueID)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
 	if stage.OnEnter.MoveIssue == "" || factory == nil || issueID == "" {
 		return
 	}
@@ -111,6 +146,25 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, factory *types.
 			log.Printf("[pipeline] failed to move story %s to %q: %v", issueID, targetStatus, err)
 		} else {
 			log.Printf("[pipeline] moved story %s to %q", issueID, targetStatus)
+		}
+	} else if strings.Contains(issueID, "/") {
+		// GitHub issue (owner/repo/number format)
+		ghToken := s.resolveGitHubIssuesTokenForFactory(factory)
+		if ghToken == "" {
+			log.Printf("[pipeline] factory %q: no GitHub token for move_issue, skipping", factory.Name)
+			return
+		}
+		parts := strings.Split(issueID, "/")
+		if len(parts) == 3 {
+			repo := parts[0] + "/" + parts[1]
+			var issueNum int
+			if _, err := fmt.Sscanf(parts[2], "%d", &issueNum); err == nil {
+				if err := moveGitHubIssue(ghToken, repo, issueNum, targetStatus, s.githubBaseURL); err != nil {
+					log.Printf("[pipeline] failed to move GitHub issue %s to %q: %v", issueID, targetStatus, err)
+				} else {
+					log.Printf("[pipeline] moved GitHub issue %s to %q", issueID, targetStatus)
+				}
+			}
 		}
 	} else {
 		// Linear issue

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -37,7 +37,8 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, factory *types.
 		injectMsg := stage.OnEnter.Inject
 
 		// Render {{.Issue.Identifier}}, {{.Issue.Title}}, {{.Issue.URL}} if this is a Linear claw
-		if issueID != "" && !strings.HasPrefix(issueID, "sc-") {
+		// GitHub Issues IDs are owner/repo/number format (contain "/"), Shortcut IDs start with "sc-"
+		if issueID != "" && !strings.HasPrefix(issueID, "sc-") && !strings.Contains(issueID, "/") {
 			log.Printf("[pipeline] attempting to render template for claw %s issue %s", clawID[:8], issueID)
 			linearToken := s.resolveLinearTokenForFactory(factory)
 			if linearToken == "" {

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -4,13 +4,67 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
+	"net/http"
 	"strings"
 	"text/template"
 
 	"github.com/elasticclaw/elasticclaw/pkg/hub/pipeline"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
+
+// githubIssueDetails holds the fields we fetch for pipeline template rendering.
+type githubIssueDetails struct {
+	Identifier  string `json:"identifier"`
+	Title       string `json:"title"`
+	URL         string `json:"url"`
+	Description string `json:"description"`
+}
+
+// fetchGitHubIssueDetails looks up an issue by owner/repo/number and returns
+// the fields needed for pipeline template rendering.
+func (s *Server) fetchGitHubIssueDetails(token, repo string, issueNumber int, baseURL string) (*githubIssueDetails, error) {
+	if baseURL == "" {
+		baseURL = "https://api.github.com"
+	}
+	url := fmt.Sprintf("%s/repos/%s/issues/%d", baseURL, repo, issueNumber)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("github API GET %s: %d %s", url, resp.StatusCode, string(body))
+	}
+
+	var result struct {
+		Number int    `json:"number"`
+		Title  string `json:"title"`
+		Body   string `json:"body"`
+		URL    string `json:"html_url"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("parse github issue response: %w", err)
+	}
+
+	return &githubIssueDetails{
+		Identifier:  fmt.Sprintf("#%d", result.Number),
+		Title:       result.Title,
+		URL:         result.URL,
+		Description: result.Body,
+	}, nil
+}
 
 // parsePipelineForFactory parses the PipelineYAML from a factory config.
 // Returns nil (and logs a warning) if the YAML is empty or invalid.
@@ -80,6 +134,47 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, factory *types.
 			}
 			injectMsg = buf.String()
 			log.Printf("[pipeline] template RENDERED for claw %s:\n%s", clawID[:8], injectMsg)
+		} else if strings.Contains(issueID, "/") {
+			// GitHub issue — fetch details and render with same {{.Issue.*}} variables
+			ghToken := s.resolveGitHubIssuesTokenForFactory(factory)
+			if ghToken != "" {
+				parts := strings.Split(issueID, "/")
+				if len(parts) == 3 {
+					repo := parts[0] + "/" + parts[1]
+					var issueNum int
+					if _, err := fmt.Sscanf(parts[2], "%d", &issueNum); err == nil {
+						base := s.githubBaseURL
+						if base == "" {
+							base = "https://api.github.com"
+						}
+						details, err := s.fetchGitHubIssueDetails(ghToken, repo, issueNum, base)
+						if err != nil {
+							log.Printf("[pipeline] fetchGitHubIssueDetails FAILED for %s: %v", issueID, err)
+						} else if details == nil {
+							log.Printf("[pipeline] fetchGitHubIssueDetails returned nil for %s", issueID)
+						} else {
+							log.Printf("[pipeline] fetched GitHub issue %s: #%s title=%s", issueID, details.Identifier, details.Title)
+							tmpl, err := template.New("inject").Parse(injectMsg)
+							if err != nil {
+								log.Printf("[pipeline] template PARSE FAILED for claw %s: %v", clawID[:8], err)
+							} else {
+								var buf bytes.Buffer
+								data := struct {
+									Issue *githubIssueDetails
+								}{
+									Issue: details,
+								}
+								if err := tmpl.Execute(&buf, data); err != nil {
+									log.Printf("[pipeline] template EXECUTE FAILED for claw %s: %v", clawID[:8], err)
+								} else {
+									injectMsg = buf.String()
+									log.Printf("[pipeline] template RENDERED for claw %s:\n%s", clawID[:8], injectMsg)
+								}
+							}
+						}
+					}
+				}
+			}
 		} else {
 			log.Printf("[pipeline] skipping template render for claw %s: issueID=%q", clawID[:8], issueID)
 		}

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"strings"
 	"text/template"
 
@@ -64,6 +65,33 @@ func (s *Server) fetchGitHubIssueDetails(token, repo string, issueNumber int, ba
 		URL:         result.URL,
 		Description: result.Body,
 	}, nil
+}
+
+// githubAPIDeleteLabel removes a label from a GitHub issue. Unlike
+// githubAPIPostWithBase, this does not attempt to unmarshal the response body
+// (DELETE returns an array of remaining labels, not a JSON object).
+func githubAPIDeleteLabel(baseURL, repo string, issueNumber int, label, token string) error {
+	if baseURL == "" {
+		baseURL = "https://api.github.com"
+	}
+	path := fmt.Sprintf("repos/%s/issues/%d/labels/%s", repo, issueNumber, url.PathEscape(label))
+	req, err := http.NewRequest("DELETE", baseURL+"/"+path, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("github API DELETE %s: %d %s", path, resp.StatusCode, string(respBody))
+	}
+	return nil
 }
 
 // parsePipelineForFactory parses the PipelineYAML from a factory config.
@@ -137,44 +165,59 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, factory *types.
 		} else if strings.Contains(issueID, "/") {
 			// GitHub issue — fetch details and render with same {{.Issue.*}} variables
 			ghToken := s.resolveGitHubIssuesTokenForFactory(factory)
-			if ghToken != "" {
-				parts := strings.Split(issueID, "/")
-				if len(parts) == 3 {
-					repo := parts[0] + "/" + parts[1]
-					var issueNum int
-					if _, err := fmt.Sscanf(parts[2], "%d", &issueNum); err == nil {
-						base := s.githubBaseURL
-						if base == "" {
-							base = "https://api.github.com"
-						}
-						details, err := s.fetchGitHubIssueDetails(ghToken, repo, issueNum, base)
-						if err != nil {
-							log.Printf("[pipeline] fetchGitHubIssueDetails FAILED for %s: %v", issueID, err)
-						} else if details == nil {
-							log.Printf("[pipeline] fetchGitHubIssueDetails returned nil for %s", issueID)
-						} else {
-							log.Printf("[pipeline] fetched GitHub issue %s: #%s title=%s", issueID, details.Identifier, details.Title)
-							tmpl, err := template.New("inject").Parse(injectMsg)
-							if err != nil {
-								log.Printf("[pipeline] template PARSE FAILED for claw %s: %v", clawID[:8], err)
-							} else {
-								var buf bytes.Buffer
-								data := struct {
-									Issue *githubIssueDetails
-								}{
-									Issue: details,
-								}
-								if err := tmpl.Execute(&buf, data); err != nil {
-									log.Printf("[pipeline] template EXECUTE FAILED for claw %s: %v", clawID[:8], err)
-								} else {
-									injectMsg = buf.String()
-									log.Printf("[pipeline] template RENDERED for claw %s:\n%s", clawID[:8], injectMsg)
-								}
-							}
-						}
-					}
-				}
+			if ghToken == "" {
+				log.Printf("[pipeline] no GitHub token for factory %q, putting claw in error state", factory.Name)
+				_, _ = s.db.Exec(`UPDATE claws SET status='error' WHERE id=? AND status != 'deleted'`, clawID)
+				return
 			}
+			parts := strings.Split(issueID, "/")
+			if len(parts) != 3 {
+				log.Printf("[pipeline] invalid GitHub issue ID format %q, putting claw in error state", issueID)
+				_, _ = s.db.Exec(`UPDATE claws SET status='error' WHERE id=? AND status != 'deleted'`, clawID)
+				return
+			}
+			repo := parts[0] + "/" + parts[1]
+			var issueNum int
+			if _, err := fmt.Sscanf(parts[2], "%d", &issueNum); err != nil {
+				log.Printf("[pipeline] invalid GitHub issue number in %q: %v, putting claw in error state", issueID, err)
+				_, _ = s.db.Exec(`UPDATE claws SET status='error' WHERE id=? AND status != 'deleted'`, clawID)
+				return
+			}
+			base := s.githubBaseURL
+			if base == "" {
+				base = "https://api.github.com"
+			}
+			details, err := s.fetchGitHubIssueDetails(ghToken, repo, issueNum, base)
+			if err != nil {
+				log.Printf("[pipeline] fetchGitHubIssueDetails FAILED for %s: %v, putting claw in error state", issueID, err)
+				_, _ = s.db.Exec(`UPDATE claws SET status='error' WHERE id=? AND status != 'deleted'`, clawID)
+				return
+			}
+			if details == nil {
+				log.Printf("[pipeline] fetchGitHubIssueDetails returned nil for %s, putting claw in error state", issueID)
+				_, _ = s.db.Exec(`UPDATE claws SET status='error' WHERE id=? AND status != 'deleted'`, clawID)
+				return
+			}
+			log.Printf("[pipeline] fetched GitHub issue %s: #%s title=%s", issueID, details.Identifier, details.Title)
+			tmpl, err := template.New("inject").Parse(injectMsg)
+			if err != nil {
+				log.Printf("[pipeline] template PARSE FAILED for claw %s: %v, putting claw in error state", clawID[:8], err)
+				_, _ = s.db.Exec(`UPDATE claws SET status='error' WHERE id=? AND status != 'deleted'`, clawID)
+				return
+			}
+			var buf bytes.Buffer
+			data := struct {
+				Issue *githubIssueDetails
+			}{
+				Issue: details,
+			}
+			if err := tmpl.Execute(&buf, data); err != nil {
+				log.Printf("[pipeline] template EXECUTE FAILED for claw %s: %v, putting claw in error state", clawID[:8], err)
+				_, _ = s.db.Exec(`UPDATE claws SET status='error' WHERE id=? AND status != 'deleted'`, clawID)
+				return
+			}
+			injectMsg = buf.String()
+			log.Printf("[pipeline] template RENDERED for claw %s:\n%s", clawID[:8], injectMsg)
 		} else {
 			log.Printf("[pipeline] skipping template render for claw %s: issueID=%q", clawID[:8], issueID)
 		}
@@ -212,7 +255,7 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, factory *types.
 							}
 						}
 						for _, label := range stage.OnEnter.RemoveLabels {
-							if _, err := githubAPIPostWithBase(base, fmt.Sprintf("repos/%s/issues/%d/labels/%s", repo, issueNum, label), ghToken, "DELETE", nil); err != nil {
+							if err := githubAPIDeleteLabel(base, repo, issueNum, label, ghToken); err != nil {
 								log.Printf("[pipeline] failed to remove label %q from issue %s: %v", label, issueID, err)
 							} else {
 								log.Printf("[pipeline] removed label %q from issue %s", label, issueID)

--- a/pkg/hub/shortcut.go
+++ b/pkg/hub/shortcut.go
@@ -388,14 +388,21 @@ func (s *Server) createClawForShortcutStory(factory *types.FactoryConfig, action
 	}
 	log.Printf("[factory:%s] verified story %s is readable", factory.Name, storyID)
 
-	// Enforce 1:1
-	var existingID string
+	// Enforce 1:1 — check if a claw already exists for this story.
+	// If the claw is offline, error, or stopped, delete and recreate it since
+	// the underlying sandbox is gone. Only skip if it's actively starting,
+	// running, or connected.
+	var existingID, existingStatus string
 	_ = s.db.QueryRow(
-		`SELECT id FROM claws WHERE linear_issue_id = ? AND status NOT IN ('error','deleted') LIMIT 1`,
+		`SELECT id, status FROM claws WHERE linear_issue_id = ? AND status NOT IN ('deleted') LIMIT 1`,
 		storyID,
-	).Scan(&existingID)
+	).Scan(&existingID, &existingStatus)
 	if existingID != "" {
-		return fmt.Errorf("claw %s already exists for story %s", existingID[:8], storyID)
+		if existingStatus == "starting" || existingStatus == "connected" || existingStatus == "running" {
+			return fmt.Errorf("claw %s already exists for story %s (status=%s)", existingID[:8], storyID, existingStatus)
+		}
+		log.Printf("[factory:%s] claw %s exists for story %s but status=%s, deleting and recreating", factory.Name, existingID[:8], storyID, existingStatus)
+		_, _ = s.db.Exec(`UPDATE claws SET status='deleted' WHERE id=?`, existingID)
 	}
 
 	templateFiles, err := s.resolveTemplateFiles(factory.Template)


### PR DESCRIPTION
GitHub Issues IDs are in \owner/repo/number\ format (e.g. \elasticclaw/elasticclaw/113\) and contain a \/\. The pipeline runner was treating all non-Shortcut issues as Linear issues, causing it to require a Linear token and put the claw in an error state when none was configured.

Now the template rendering only runs for Linear issues (no \/\ in ID, not \sc-\ prefix), allowing GitHub Issues factories to use pipelines without Linear integration.

Fixes #113