### PR TITLE
feat(settings): Doctor diagnostics page

### DIFF
--- a/pkg/hub/doctor.go
+++ b/pkg/hub/doctor.go
@@ -1,0 +1,785 @@
+package hub
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/config"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+// DoctorCheck is a single diagnostic check result.
+type DoctorCheck struct {
+	Category    string     `json:"category"`              // "auth", "models", "sandboxes", "factories", "integrations", "mcp", "templates"
+	Severity    string     `json:"severity"`              // "critical", "warning", "info"
+	Title       string     `json:"title"`
+	Description string     `json:"description"`
+	OK          bool       `json:"ok"`
+	Error       string     `json:"error,omitempty"`
+	FixAction   *FixAction `json:"fixAction,omitempty"` // nil if no auto-fix available
+}
+
+// FixAction describes an actionable fix the user can take.
+type FixAction struct {
+	Type   string            `json:"type"`   // "navigate", "set_field", "toggle"
+	Target string            `json:"target"` // settings section path or object identifier
+	Params map[string]string `json:"params,omitempty"`
+	Label  string            `json:"label"` // button text
+}
+
+// DoctorResponse is the full diagnostic report.
+type DoctorResponse struct {
+	Checks  []DoctorCheck `json:"checks"`
+	Summary struct {
+		Total    int `json:"total"`
+		Critical int `json:"critical"`
+		Warning  int `json:"warning"`
+		Info     int `json:"info"`
+		Passed   int `json:"passed"`
+	} `json:"summary"`
+	CachedAt *time.Time `json:"cachedAt,omitempty"`
+}
+
+// doctorCache holds the last computed report and its timestamp.
+type doctorCache struct {
+	report DoctorResponse
+	at     time.Time
+}
+
+var lastDoctorReport *doctorCache
+
+// handleDoctor handles GET /api/doctor.
+func (s *Server) handleDoctor(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Check cache unless ?refresh=true
+	refresh := r.URL.Query().Get("refresh") == "true"
+	if !refresh && lastDoctorReport != nil && time.Since(lastDoctorReport.at) < 5*time.Minute {
+		resp := lastDoctorReport.report
+		resp.CachedAt = &lastDoctorReport.at
+		jsonOK(w, resp)
+		return
+	}
+
+	report := s.runDoctorChecks(r.Context())
+	lastDoctorReport = &doctorCache{report: report, at: time.Now()}
+	jsonOK(w, report)
+}
+
+// runDoctorChecks runs all diagnostic checks and returns the report.
+func (s *Server) runDoctorChecks(ctx context.Context) DoctorResponse {
+	var checks []DoctorCheck
+
+	s.mu.RLock()
+	hubCfg := s.hubCfg
+	s.mu.RUnlock()
+
+	// Load disk config for secrets, integrations, etc.
+	diskCfg, _ := config.LoadHubConfig()
+	if diskCfg == nil {
+		diskCfg = hubCfg
+	}
+
+	// --- Models / LLM Keys ---
+	checks = append(checks, s.checkLLMKeys(hubCfg)...)
+	checks = append(checks, s.checkDefaultModel(hubCfg)...)
+
+	// --- Sandboxes / Providers ---
+	checks = append(checks, s.checkProviders(hubCfg)...)
+
+	// --- Factories ---
+	checks = append(checks, s.checkFactories(hubCfg, diskCfg)...)
+
+	// --- Templates ---
+	checks = append(checks, s.checkTemplates(hubCfg, diskCfg)...)
+
+	// --- Integrations ---
+	checks = append(checks, s.checkIntegrations(hubCfg, diskCfg)...)
+
+	// --- GitHub Apps ---
+	checks = append(checks, s.checkGitHubApps(hubCfg)...)
+
+	// --- MCP Servers ---
+	checks = append(checks, s.checkMCPServers(hubCfg, diskCfg)...)
+
+	// --- Auth ---
+	checks = append(checks, s.checkAuth(hubCfg)...)
+
+	// --- Hub Settings ---
+	checks = append(checks, s.checkHubSettings(hubCfg)...)
+
+	// Compute summary
+	var report DoctorResponse
+	report.Checks = checks
+	for _, c := range checks {
+		report.Summary.Total++
+		if c.OK {
+			report.Summary.Passed++
+			continue
+		}
+		switch c.Severity {
+		case "critical":
+			report.Summary.Critical++
+		case "warning":
+			report.Summary.Warning++
+		case "info":
+			report.Summary.Info++
+		}
+	}
+	return report
+}
+
+// ==================== LLM KEY CHECKS ====================
+
+func (s *Server) checkLLMKeys(cfg *types.HubConfig) []DoctorCheck {
+	var checks []DoctorCheck
+
+	if len(cfg.LLMKeys) == 0 {
+		checks = append(checks, DoctorCheck{
+			Category:    "models",
+			Severity:    "critical",
+			Title:       "No LLM keys configured",
+			Description: "At least one LLM key is required for claws to function.",
+			OK:          false,
+			FixAction: &FixAction{
+				Type:   "navigate",
+				Target: "/settings/models",
+				Label:  "Add LLM Key",
+			},
+		})
+		return checks
+	}
+
+	// Check each key for valid provider
+	validProviders := map[string]bool{
+		"anthropic": true, "openai": true, "fireworks": true,
+		"moonshot": true, "google": true, "mistral": true,
+	}
+
+	for _, key := range cfg.LLMKeys {
+		if !validProviders[key.Provider] {
+			checks = append(checks, DoctorCheck{
+				Category:    "models",
+				Severity:    "warning",
+				Title:       fmt.Sprintf("Unknown LLM provider: %q", key.Provider),
+				Description: fmt.Sprintf("LLM key %q uses provider %q which is not recognized.", key.Name, key.Provider),
+				OK:          false,
+				FixAction: &FixAction{
+					Type:   "navigate",
+					Target: "/settings/models",
+					Label:  "Edit LLM Key",
+				},
+			})
+		}
+		if key.APIKey == "" {
+			checks = append(checks, DoctorCheck{
+				Category:    "models",
+				Severity:    "critical",
+				Title:       fmt.Sprintf("LLM key %q has no API key", key.Name),
+				Description: fmt.Sprintf("LLM key %q is configured but the API key is empty.", key.Name),
+				OK:          false,
+				FixAction: &FixAction{
+					Type:   "navigate",
+					Target: "/settings/models",
+					Label:  "Set API Key",
+				},
+			})
+		}
+	}
+
+	// Check for a default key
+	hasDefault := false
+	for _, key := range cfg.LLMKeys {
+		if key.Default {
+			hasDefault = true
+			break
+		}
+	}
+	if !hasDefault && len(cfg.LLMKeys) > 0 {
+		checks = append(checks, DoctorCheck{
+			Category:    "models",
+			Severity:    "info",
+			Title:       "No default LLM key set",
+			Description: "No LLM key is marked as default. The first key will be used, but explicit default is recommended.",
+			OK:          false,
+			FixAction: &FixAction{
+				Type:   "navigate",
+				Target: "/settings/models",
+				Label:  "Set Default",
+			},
+		})
+	}
+
+	return checks
+}
+
+func (s *Server) checkDefaultModel(cfg *types.HubConfig) []DoctorCheck {
+	var checks []DoctorCheck
+
+	if cfg.DefaultModel != "" && !strings.Contains(cfg.DefaultModel, "/") {
+		checks = append(checks, DoctorCheck{
+			Category:    "models",
+			Severity:    "warning",
+			Title:       "Default model format is invalid",
+			Description: fmt.Sprintf("Default model %q should be in format provider/model (e.g., anthropic/claude-sonnet-4-6).", cfg.DefaultModel),
+			OK:          false,
+			FixAction: &FixAction{
+				Type:   "set_field",
+				Target: "default_model",
+				Params: map[string]string{"hint": "provider/model"},
+				Label:  "Fix Format",
+			},
+		})
+	}
+
+	return checks
+}
+
+// ==================== PROVIDER CHECKS ====================
+
+func (s *Server) checkProviders(cfg *types.HubConfig) []DoctorCheck {
+	var checks []DoctorCheck
+
+	if len(cfg.Providers) == 0 {
+		checks = append(checks, DoctorCheck{
+			Category:    "sandboxes",
+			Severity:    "critical",
+			Title:       "No sandbox providers configured",
+			Description: "At least one sandbox provider (daytona, vercel, replicated, local) must be configured.",
+			OK:          false,
+			FixAction: &FixAction{
+				Type:   "navigate",
+				Target: "/settings/runtimes",
+				Label:  "Add Provider",
+			},
+		})
+		return checks
+	}
+
+	for name, p := range cfg.Providers {
+		switch name {
+		case "daytona":
+			if p.APIKey == "" {
+				checks = append(checks, DoctorCheck{
+					Category:    "sandboxes",
+					Severity:    "critical",
+					Title:       "Daytona provider missing API key",
+					Description: "The Daytona sandbox provider is configured but the API key is empty.",
+					OK:          false,
+					FixAction: &FixAction{
+						Type:   "navigate",
+						Target: "/settings/runtimes",
+						Label:  "Configure Daytona",
+					},
+				})
+			}
+		case "replicated":
+			if p.Token == "" {
+				checks = append(checks, DoctorCheck{
+					Category:    "sandboxes",
+					Severity:    "critical",
+					Title:       "Replicated provider missing token",
+					Description: "The Replicated sandbox provider is configured but the token is empty.",
+					OK:          false,
+					FixAction: &FixAction{
+						Type:   "navigate",
+						Target: "/settings/runtimes",
+						Label:  "Configure Replicated",
+					},
+				})
+			}
+		case "vercel":
+			if p.AccessToken == "" {
+				checks = append(checks, DoctorCheck{
+					Category:    "sandboxes",
+					Severity:    "critical",
+					Title:       "Vercel provider missing access token",
+					Description: "The Vercel sandbox provider is configured but the access token is empty.",
+					OK:          false,
+					FixAction: &FixAction{
+						Type:   "navigate",
+						Target: "/settings/runtimes",
+						Label:  "Configure Vercel",
+					},
+				})
+			}
+		case "local":
+			// Local provider doesn't need credentials
+			continue
+		}
+	}
+
+	return checks
+}
+
+// ==================== FACTORY CHECKS ====================
+
+func (s *Server) checkFactories(cfg *types.HubConfig, diskCfg *types.HubConfig) []DoctorCheck {
+	var checks []DoctorCheck
+
+	if len(cfg.Factories) == 0 {
+		return checks // No factories is fine
+	}
+
+	// Build set of template names from hub DB
+	templateNames := make(map[string]bool)
+	rows, err := s.db.Query(`SELECT name FROM hub_templates`)
+	if err == nil && rows != nil {
+		for rows.Next() {
+			var name string
+			if err := rows.Scan(&name); err == nil {
+				templateNames[name] = true
+			}
+		}
+		rows.Close()
+	}
+	// Also check local templates via config resolution
+	// (templates are directories, not a list in hub.yaml)
+
+	// Build set of secret names
+	secretNames := make(map[string]bool)
+	for name := range diskCfg.Secrets {
+		secretNames[name] = true
+	}
+
+	// Track factory names for duplicates
+	factoryNames := make(map[string]int)
+
+	// Track triggers for overlap detection
+	type triggerKey struct {
+		integration string
+		workspace   string
+		trigger     string
+	}
+	triggers := make(map[triggerKey][]string)
+
+	for _, f := range cfg.Factories {
+		if f == nil {
+			continue
+		}
+
+		// Skip disabled factories
+		if !isFactoryEnabled(f) {
+			continue
+		}
+
+		// Check 1: duplicate name
+		factoryNames[f.Name]++
+
+		// Check 2: template exists
+		if f.Template != "" && !templateNames[f.Template] {
+			checks = append(checks, DoctorCheck{
+				Category:    "factories",
+				Severity:    "critical",
+				Title:       fmt.Sprintf("Factory %q references missing template", f.Name),
+				Description: fmt.Sprintf("Factory %q references template %q which is not found in pushed templates or local templates.", f.Name, f.Template),
+				OK:          false,
+				FixAction: &FixAction{
+					Type:   "navigate",
+					Target: "/settings/templates",
+					Label:  "Push Template",
+				},
+			})
+		}
+
+		// Check 3: webhook secret
+		if f.WebhookSecret == "" && f.WebhookSecretRef == "" {
+			checks = append(checks, DoctorCheck{
+				Category:    "factories",
+				Severity:    "warning",
+				Title:       fmt.Sprintf("Factory %q has no webhook secret", f.Name),
+				Description: fmt.Sprintf("Factory %q has neither an inline webhook_secret nor a webhook_secret_ref. Webhooks from the integration will not be validated.", f.Name),
+				OK:          false,
+				FixAction: &FixAction{
+					Type:   "navigate",
+					Target: "/settings/secrets",
+					Label:  "Add Secret",
+				},
+			})
+		} else if f.WebhookSecretRef != "" && !secretNames[f.WebhookSecretRef] {
+			checks = append(checks, DoctorCheck{
+				Category:    "factories",
+				Severity:    "warning",
+				Title:       fmt.Sprintf("Factory %q references missing secret", f.Name),
+				Description: fmt.Sprintf("Factory %q references webhook_secret_ref %q which is not in the secrets map.", f.Name, f.WebhookSecretRef),
+				OK:          false,
+				FixAction: &FixAction{
+					Type:   "navigate",
+					Target: "/settings/secrets",
+					Label:  "Create Secret",
+				},
+			})
+		}
+
+		// Check 4: overlapping triggers
+		var key triggerKey
+		switch f.Integration {
+		case "linear", "shortcut", "github-issues":
+			key = triggerKey{integration: f.Integration, workspace: f.Workspace, trigger: f.TriggerStatus}
+		case "github":
+			if f.Trigger != nil {
+				key = triggerKey{integration: f.Integration, workspace: strings.Join(f.Repos, ","), trigger: f.Trigger.On + "/" + f.Trigger.Action}
+			}
+		}
+		if key.integration != "" {
+			triggers[key] = append(triggers[key], f.Name)
+		}
+	}
+
+	// Report duplicate names
+	for name, count := range factoryNames {
+		if count > 1 {
+			checks = append(checks, DoctorCheck{
+				Category:    "factories",
+				Severity:    "warning",
+				Title:       fmt.Sprintf("Duplicate factory name: %q", name),
+				Description: fmt.Sprintf("There are %d factories named %q. Only the last one will be used.", count, name),
+				OK:          false,
+				FixAction: &FixAction{
+					Type:   "navigate",
+					Target: "/settings/factories",
+					Label:  "Rename Factory",
+				},
+			})
+		}
+	}
+
+	// Report overlapping triggers
+	for key, names := range triggers {
+		if len(names) > 1 {
+			checks = append(checks, DoctorCheck{
+				Category:    "factories",
+				Severity:    "warning",
+				Title:       fmt.Sprintf("Overlapping factory triggers: %s", strings.Join(names, ", ")),
+				Description: fmt.Sprintf("Factories %s all trigger on the same event (integration=%s, workspace=%s, trigger=%s). This will create duplicate claws.", strings.Join(names, ", "), key.integration, key.workspace, key.trigger),
+				OK:          false,
+				FixAction: &FixAction{
+					Type:   "navigate",
+					Target: "/settings/factories",
+					Label:  "Fix Triggers",
+				},
+			})
+		}
+	}
+
+	return checks
+}
+
+// ==================== TEMPLATE CHECKS ====================
+
+func (s *Server) checkTemplates(cfg *types.HubConfig, diskCfg *types.HubConfig) []DoctorCheck {
+	var checks []DoctorCheck
+
+	// Build set of secret names
+	secretNames := make(map[string]bool)
+	for name := range diskCfg.Secrets {
+		secretNames[name] = true
+	}
+
+	// Template secrets are checked at the factory level (factory references template)
+	// Individual template configs are loaded at runtime, not stored in hub.yaml
+	// TODO: Load template configs from hub_templates DB or filesystem and check their secrets
+
+	return checks
+}
+
+// ==================== INTEGRATION CHECKS ====================
+
+func (s *Server) checkIntegrations(cfg *types.HubConfig, diskCfg *types.HubConfig) []DoctorCheck {
+	var checks []DoctorCheck
+
+	if cfg.Integrations == nil {
+		return checks
+	}
+
+	// Build set of factory workspaces for cross-reference
+	factoryWorkspaces := make(map[string]map[string]bool) // integration -> workspace -> exists
+	for _, f := range cfg.Factories {
+		if f == nil || !isFactoryEnabled(f) {
+			continue
+		}
+		if factoryWorkspaces[f.Integration] == nil {
+			factoryWorkspaces[f.Integration] = make(map[string]bool)
+		}
+		factoryWorkspaces[f.Integration][f.Workspace] = true
+	}
+
+	// Check Linear
+	for _, li := range cfg.Integrations.Linear {
+		if li.Token == "" {
+			checks = append(checks, DoctorCheck{
+				Category:    "integrations",
+				Severity:    "critical",
+				Title:       fmt.Sprintf("Linear workspace %q missing token", li.Workspace),
+				Description: fmt.Sprintf("Linear integration workspace %q has no API token configured.", li.Workspace),
+				OK:          false,
+				FixAction: &FixAction{
+					Type:   "navigate",
+					Target: "/settings/issue-trackers",
+					Label:  "Add Token",
+				},
+			})
+		}
+		if li.WebhookSecret == "" {
+			checks = append(checks, DoctorCheck{
+				Category:    "integrations",
+				Severity:    "warning",
+				Title:       fmt.Sprintf("Linear workspace %q missing webhook secret", li.Workspace),
+				Description: fmt.Sprintf("Linear integration workspace %q has no webhook secret. Webhooks will not be validated.", li.Workspace),
+				OK:          false,
+				FixAction: &FixAction{
+					Type:   "navigate",
+					Target: "/settings/issue-trackers",
+					Label:  "Add Secret",
+				},
+			})
+		}
+		// Check if any factory uses this workspace
+		if !factoryWorkspaces["linear"][li.Workspace] {
+			checks = append(checks, DoctorCheck{
+				Category:    "integrations",
+				Severity:    "info",
+				Title:       fmt.Sprintf("Linear workspace %q has no factory using it", li.Workspace),
+				Description: fmt.Sprintf("Linear workspace %q is configured but no factory references it.", li.Workspace),
+				OK:          false,
+			})
+		}
+	}
+
+	// Check Shortcut
+	for _, si := range cfg.Integrations.Shortcut {
+		if si.Token == "" {
+			checks = append(checks, DoctorCheck{
+				Category:    "integrations",
+				Severity:    "critical",
+				Title:       fmt.Sprintf("Shortcut workspace %q missing token", si.Workspace),
+				Description: fmt.Sprintf("Shortcut integration workspace %q has no API token configured.", si.Workspace),
+				OK:          false,
+				FixAction: &FixAction{
+					Type:   "navigate",
+					Target: "/settings/issue-trackers",
+					Label:  "Add Token",
+				},
+			})
+		}
+		if !factoryWorkspaces["shortcut"][si.Workspace] {
+			checks = append(checks, DoctorCheck{
+				Category:    "integrations",
+				Severity:    "info",
+				Title:       fmt.Sprintf("Shortcut workspace %q has no factory using it", si.Workspace),
+				Description: fmt.Sprintf("Shortcut workspace %q is configured but no factory references it.", si.Workspace),
+				OK:          false,
+			})
+		}
+	}
+
+	// Check GitHub Issues
+	for _, gi := range cfg.Integrations.GitHubIssues {
+		if gi.Token == "" {
+			checks = append(checks, DoctorCheck{
+				Category:    "integrations",
+				Severity:    "critical",
+				Title:       fmt.Sprintf("GitHub Issues workspace %q missing token", gi.Workspace),
+				Description: fmt.Sprintf("GitHub Issues integration workspace %q has no personal access token configured.", gi.Workspace),
+				OK:          false,
+				FixAction: &FixAction{
+					Type:   "navigate",
+					Target: "/settings/issue-trackers",
+					Label:  "Add Token",
+				},
+			})
+		}
+		if gi.WebhookSecret == "" {
+			checks = append(checks, DoctorCheck{
+				Category:    "integrations",
+				Severity:    "warning",
+				Title:       fmt.Sprintf("GitHub Issues workspace %q missing webhook secret", gi.Workspace),
+				Description: fmt.Sprintf("GitHub Issues workspace %q has no webhook secret. Webhooks will not be validated.", gi.Workspace),
+				OK:          false,
+				FixAction: &FixAction{
+					Type:   "navigate",
+					Target: "/settings/issue-trackers",
+					Label:  "Add Secret",
+				},
+			})
+		}
+		if !factoryWorkspaces["github-issues"][gi.Workspace] {
+			checks = append(checks, DoctorCheck{
+				Category:    "integrations",
+				Severity:    "info",
+				Title:       fmt.Sprintf("GitHub Issues workspace %q has no factory using it", gi.Workspace),
+				Description: fmt.Sprintf("GitHub Issues workspace %q is configured but no factory references it.", gi.Workspace),
+				OK:          false,
+			})
+		}
+	}
+
+	return checks
+}
+
+// ==================== GITHUB APP CHECKS ====================
+
+func (s *Server) checkGitHubApps(cfg *types.HubConfig) []DoctorCheck {
+	var checks []DoctorCheck
+
+	for _, app := range cfg.GitHubApps {
+		if app.PrivateKeyPEM == "" {
+			checks = append(checks, DoctorCheck{
+				Category:    "github",
+				Severity:    "critical",
+				Title:       fmt.Sprintf("GitHub App %d missing private key", app.AppID),
+				Description: fmt.Sprintf("GitHub App %d has no private key configured. Installation tokens cannot be minted.", app.AppID),
+				OK:          false,
+				FixAction: &FixAction{
+					Type:   "navigate",
+					Target: "/settings/github",
+					Label:  "Add Private Key",
+				},
+			})
+		}
+		if app.AppID == 0 {
+			checks = append(checks, DoctorCheck{
+				Category:    "github",
+				Severity:    "critical",
+				Title:       "GitHub App missing App ID",
+				Description: "A GitHub App is configured but has no App ID.",
+				OK:          false,
+				FixAction: &FixAction{
+					Type:   "navigate",
+					Target: "/settings/github",
+					Label:  "Configure App",
+				},
+			})
+		}
+	}
+
+	return checks
+}
+
+// ==================== MCP SERVER CHECKS ====================
+
+func (s *Server) checkMCPServers(cfg *types.HubConfig, diskCfg *types.HubConfig) []DoctorCheck {
+	var checks []DoctorCheck
+
+	// Build set of secret names
+	secretNames := make(map[string]bool)
+	for name := range diskCfg.Secrets {
+		secretNames[name] = true
+	}
+
+	for _, mcp := range cfg.MCPServers {
+		if mcp == nil {
+			continue
+		}
+
+		// Check secrets referenced
+		for envVar, secretRef := range mcp.Secrets {
+			if !secretNames[secretRef] {
+				checks = append(checks, DoctorCheck{
+					Category:    "mcp",
+					Severity:    "warning",
+					Title:       fmt.Sprintf("MCP server %q references missing secret", mcp.Name),
+					Description: fmt.Sprintf("MCP server %q references secret %q (env var %s) which is not in the secrets map.", mcp.Name, secretRef, envVar),
+					OK:          false,
+					FixAction: &FixAction{
+						Type:   "navigate",
+						Target: "/settings/secrets",
+						Label:  "Create Secret",
+					},
+				})
+			}
+		}
+	}
+
+	return checks
+}
+
+// ==================== AUTH CHECKS ====================
+
+func (s *Server) checkAuth(cfg *types.HubConfig) []DoctorCheck {
+	var checks []DoctorCheck
+
+	// Check for lockout risk
+	hasPassword := cfg.UIPassword != "" || (cfg.Auth != nil && !cfg.Auth.DisablePasswordAuth)
+	hasOAuth := cfg.Auth != nil && cfg.Auth.GitHubOAuth != nil && cfg.Auth.GitHubOAuth.ClientID != ""
+
+	if !hasPassword && !hasOAuth {
+		checks = append(checks, DoctorCheck{
+			Category:    "auth",
+			Severity:    "critical",
+			Title:       "Authentication lockout risk",
+			Description: "Both password auth and GitHub OAuth are disabled/unconfigured. You will be locked out of the web UI.",
+			OK:          false,
+			FixAction: &FixAction{
+				Type:   "navigate",
+				Target: "/settings/authentication",
+				Label:  "Configure Auth",
+			},
+		})
+	}
+
+	if cfg.Auth != nil && cfg.Auth.GitHubOAuth != nil {
+		if cfg.Auth.GitHubOAuth.ClientID != "" && cfg.Auth.GitHubOAuth.ClientSecret == "" {
+			checks = append(checks, DoctorCheck{
+				Category:    "auth",
+				Severity:    "warning",
+				Title:       "GitHub OAuth missing client secret",
+				Description: "GitHub OAuth Client ID is set but the client secret is empty.",
+				OK:          false,
+				FixAction: &FixAction{
+					Type:   "navigate",
+					Target: "/settings/authentication",
+					Label:  "Add Secret",
+				},
+			})
+		}
+		if cfg.Auth.GitHubOAuth.ClientID != "" &&
+			len(cfg.Auth.GitHubOAuth.AllowedUsers) == 0 &&
+			len(cfg.Auth.GitHubOAuth.AllowedOrgs) == 0 &&
+			len(cfg.Auth.GitHubOAuth.AllowedTeams) == 0 {
+			checks = append(checks, DoctorCheck{
+				Category:    "auth",
+				Severity:    "warning",
+				Title:       "GitHub OAuth has no access restrictions",
+				Description: "GitHub OAuth is configured but no allowed users, orgs, or teams are set. Any GitHub user can sign in.",
+				OK:          false,
+				FixAction: &FixAction{
+					Type:   "navigate",
+					Target: "/settings/authentication",
+					Label:  "Set Access Control",
+				},
+			})
+		}
+	}
+
+	return checks
+}
+
+// ==================== HUB SETTINGS CHECKS ====================
+
+func (s *Server) checkHubSettings(cfg *types.HubConfig) []DoctorCheck {
+	var checks []DoctorCheck
+
+	if cfg.MaxConcurrentClaws == 1 && len(cfg.Factories) > 1 {
+		checks = append(checks, DoctorCheck{
+			Category:    "hub",
+			Severity:    "info",
+			Title:       "Low concurrency limit with multiple factories",
+			Description: fmt.Sprintf("Max concurrent claws is 1 but %d factories are configured. Most factory-created claws will queue as pending.", len(cfg.Factories)),
+			OK:          false,
+			FixAction: &FixAction{
+				Type:   "navigate",
+				Target: "/settings/runtimes",
+				Label:  "Increase Limit",
+			},
+		})
+	}
+
+	return checks
+}

--- a/pkg/hub/doctor.go
+++ b/pkg/hub/doctor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/elasticclaw/elasticclaw/pkg/config"
@@ -49,7 +50,10 @@ type doctorCache struct {
 	at     time.Time
 }
 
-var lastDoctorReport *doctorCache
+var (
+	lastDoctorReport *doctorCache
+	doctorMu         sync.RWMutex
+)
 
 // handleDoctor handles GET /api/doctor.
 func (s *Server) handleDoctor(w http.ResponseWriter, r *http.Request) {
@@ -60,15 +64,20 @@ func (s *Server) handleDoctor(w http.ResponseWriter, r *http.Request) {
 
 	// Check cache unless ?refresh=true
 	refresh := r.URL.Query().Get("refresh") == "true"
-	if !refresh && lastDoctorReport != nil && time.Since(lastDoctorReport.at) < 5*time.Minute {
-		resp := lastDoctorReport.report
-		resp.CachedAt = &lastDoctorReport.at
+	doctorMu.RLock()
+	cached := lastDoctorReport
+	doctorMu.RUnlock()
+	if !refresh && cached != nil && time.Since(cached.at) < 5*time.Minute {
+		resp := cached.report
+		resp.CachedAt = &cached.at
 		jsonOK(w, resp)
 		return
 	}
 
 	report := s.runDoctorChecks(r.Context())
+	doctorMu.Lock()
 	lastDoctorReport = &doctorCache{report: report, at: time.Now()}
+	doctorMu.Unlock()
 	jsonOK(w, report)
 }
 
@@ -114,22 +123,22 @@ func (s *Server) runDoctorChecks(ctx context.Context) DoctorResponse {
 	// --- Hub Settings ---
 	checks = append(checks, s.checkHubSettings(hubCfg)...)
 
-	// Compute summary
+	// Compute summary: total = all checks, passed = OK checks
 	var report DoctorResponse
 	report.Checks = checks
 	for _, c := range checks {
 		report.Summary.Total++
 		if c.OK {
 			report.Summary.Passed++
-			continue
-		}
-		switch c.Severity {
-		case "critical":
-			report.Summary.Critical++
-		case "warning":
-			report.Summary.Warning++
-		case "info":
-			report.Summary.Info++
+		} else {
+			switch c.Severity {
+			case "critical":
+				report.Summary.Critical++
+			case "warning":
+				report.Summary.Warning++
+			case "info":
+				report.Summary.Info++
+			}
 		}
 	}
 	return report
@@ -162,8 +171,10 @@ func (s *Server) checkLLMKeys(cfg *types.HubConfig) []DoctorCheck {
 		"moonshot": true, "google": true, "mistral": true,
 	}
 
+	allKeysValid := true
 	for _, key := range cfg.LLMKeys {
 		if !validProviders[key.Provider] {
+			allKeysValid = false
 			checks = append(checks, DoctorCheck{
 				Category:    "models",
 				Severity:    "warning",
@@ -178,6 +189,7 @@ func (s *Server) checkLLMKeys(cfg *types.HubConfig) []DoctorCheck {
 			})
 		}
 		if key.APIKey == "" {
+			allKeysValid = false
 			checks = append(checks, DoctorCheck{
 				Category:    "models",
 				Severity:    "critical",
@@ -214,6 +226,14 @@ func (s *Server) checkLLMKeys(cfg *types.HubConfig) []DoctorCheck {
 				Label:  "Set Default",
 			},
 		})
+	} else if allKeysValid {
+		checks = append(checks, DoctorCheck{
+			Category:    "models",
+			Severity:    "info",
+			Title:       "LLM keys configured",
+			Description: fmt.Sprintf("%d LLM key(s) configured and valid.", len(cfg.LLMKeys)),
+			OK:          true,
+		})
 	}
 
 	return checks
@@ -235,6 +255,14 @@ func (s *Server) checkDefaultModel(cfg *types.HubConfig) []DoctorCheck {
 				Params: map[string]string{"hint": "provider/model"},
 				Label:  "Fix Format",
 			},
+		})
+	} else if cfg.DefaultModel != "" {
+		checks = append(checks, DoctorCheck{
+			Category:    "models",
+			Severity:    "info",
+			Title:       "Default model configured",
+			Description: fmt.Sprintf("Default model is set to %q.", cfg.DefaultModel),
+			OK:          true,
 		})
 	}
 
@@ -262,10 +290,12 @@ func (s *Server) checkProviders(cfg *types.HubConfig) []DoctorCheck {
 		return checks
 	}
 
+	allProvidersValid := true
 	for name, p := range cfg.Providers {
 		switch name {
 		case "daytona":
 			if p.APIKey == "" {
+				allProvidersValid = false
 				checks = append(checks, DoctorCheck{
 					Category:    "sandboxes",
 					Severity:    "critical",
@@ -281,6 +311,7 @@ func (s *Server) checkProviders(cfg *types.HubConfig) []DoctorCheck {
 			}
 		case "replicated":
 			if p.Token == "" {
+				allProvidersValid = false
 				checks = append(checks, DoctorCheck{
 					Category:    "sandboxes",
 					Severity:    "critical",
@@ -296,6 +327,7 @@ func (s *Server) checkProviders(cfg *types.HubConfig) []DoctorCheck {
 			}
 		case "vercel":
 			if p.AccessToken == "" {
+				allProvidersValid = false
 				checks = append(checks, DoctorCheck{
 					Category:    "sandboxes",
 					Severity:    "critical",
@@ -311,8 +343,16 @@ func (s *Server) checkProviders(cfg *types.HubConfig) []DoctorCheck {
 			}
 		case "local":
 			// Local provider doesn't need credentials
-			continue
 		}
+	}
+	if allProvidersValid {
+		checks = append(checks, DoctorCheck{
+			Category:    "sandboxes",
+			Severity:    "info",
+			Title:       "Sandbox providers configured",
+			Description: fmt.Sprintf("%d sandbox provider(s) configured with credentials.", len(cfg.Providers)),
+			OK:          true,
+		})
 	}
 
 	return checks
@@ -324,7 +364,14 @@ func (s *Server) checkFactories(cfg *types.HubConfig, diskCfg *types.HubConfig) 
 	var checks []DoctorCheck
 
 	if len(cfg.Factories) == 0 {
-		return checks // No factories is fine
+		checks = append(checks, DoctorCheck{
+			Category:    "factories",
+			Severity:    "info",
+			Title:       "No factories configured",
+			Description: "No factories are configured. Factory-based claw creation is disabled.",
+			OK:          true,
+		})
+		return checks
 	}
 
 	// Build set of template names from hub DB
@@ -468,6 +515,16 @@ func (s *Server) checkFactories(cfg *types.HubConfig, diskCfg *types.HubConfig) 
 		}
 	}
 
+	if len(checks) == 0 {
+		checks = append(checks, DoctorCheck{
+			Category:    "factories",
+			Severity:    "info",
+			Title:       "Factories configured",
+			Description: fmt.Sprintf("%d factory(ies) configured with no issues detected.", len(cfg.Factories)),
+			OK:          true,
+		})
+	}
+
 	return checks
 }
 
@@ -485,6 +542,14 @@ func (s *Server) checkTemplates(cfg *types.HubConfig, diskCfg *types.HubConfig) 
 	// Template secrets are checked at the factory level (factory references template)
 	// Individual template configs are loaded at runtime, not stored in hub.yaml
 	// TODO: Load template configs from hub_templates DB or filesystem and check their secrets
+
+	checks = append(checks, DoctorCheck{
+		Category:    "templates",
+		Severity:    "info",
+		Title:       "Template checks pending",
+		Description: "Template configuration validation is not yet implemented.",
+		OK:          true,
+	})
 
 	return checks
 }
@@ -524,6 +589,14 @@ func (s *Server) checkIntegrations(cfg *types.HubConfig, diskCfg *types.HubConfi
 					Target: "/settings/issue-trackers",
 					Label:  "Add Token",
 				},
+			})
+		} else {
+			checks = append(checks, DoctorCheck{
+				Category:    "integrations",
+				Severity:    "info",
+				Title:       fmt.Sprintf("Linear workspace %q token configured", li.Workspace),
+				Description: fmt.Sprintf("Linear workspace %q has an API token configured.", li.Workspace),
+				OK:          true,
 			})
 		}
 		if li.WebhookSecret == "" {
@@ -567,6 +640,14 @@ func (s *Server) checkIntegrations(cfg *types.HubConfig, diskCfg *types.HubConfi
 					Label:  "Add Token",
 				},
 			})
+		} else {
+			checks = append(checks, DoctorCheck{
+				Category:    "integrations",
+				Severity:    "info",
+				Title:       fmt.Sprintf("Shortcut workspace %q token configured", si.Workspace),
+				Description: fmt.Sprintf("Shortcut workspace %q has an API token configured.", si.Workspace),
+				OK:          true,
+			})
 		}
 		if !factoryWorkspaces["shortcut"][si.Workspace] {
 			checks = append(checks, DoctorCheck{
@@ -594,6 +675,14 @@ func (s *Server) checkIntegrations(cfg *types.HubConfig, diskCfg *types.HubConfi
 					Label:  "Add Token",
 				},
 			})
+		} else {
+			checks = append(checks, DoctorCheck{
+				Category:    "integrations",
+				Severity:    "info",
+				Title:       fmt.Sprintf("GitHub Issues workspace %q token configured", gi.Workspace),
+				Description: fmt.Sprintf("GitHub Issues workspace %q has a personal access token configured.", gi.Workspace),
+				OK:          true,
+			})
 		}
 		if gi.WebhookSecret == "" {
 			checks = append(checks, DoctorCheck{
@@ -620,6 +709,16 @@ func (s *Server) checkIntegrations(cfg *types.HubConfig, diskCfg *types.HubConfi
 		}
 	}
 
+	if len(checks) == 0 {
+		checks = append(checks, DoctorCheck{
+			Category:    "integrations",
+			Severity:    "info",
+			Title:       "No integrations configured",
+			Description: "No issue tracker integrations are configured.",
+			OK:          true,
+		})
+	}
+
 	return checks
 }
 
@@ -628,8 +727,21 @@ func (s *Server) checkIntegrations(cfg *types.HubConfig, diskCfg *types.HubConfi
 func (s *Server) checkGitHubApps(cfg *types.HubConfig) []DoctorCheck {
 	var checks []DoctorCheck
 
+	if len(cfg.GitHubApps) == 0 {
+		checks = append(checks, DoctorCheck{
+			Category:    "github",
+			Severity:    "info",
+			Title:       "No GitHub Apps configured",
+			Description: "No GitHub Apps are configured. GitHub App-based authentication is disabled.",
+			OK:          true,
+		})
+		return checks
+	}
+
+	allAppsValid := true
 	for _, app := range cfg.GitHubApps {
 		if app.PrivateKeyPEM == "" {
+			allAppsValid = false
 			checks = append(checks, DoctorCheck{
 				Category:    "github",
 				Severity:    "critical",
@@ -644,6 +756,7 @@ func (s *Server) checkGitHubApps(cfg *types.HubConfig) []DoctorCheck {
 			})
 		}
 		if app.AppID == 0 {
+			allAppsValid = false
 			checks = append(checks, DoctorCheck{
 				Category:    "github",
 				Severity:    "critical",
@@ -658,6 +771,15 @@ func (s *Server) checkGitHubApps(cfg *types.HubConfig) []DoctorCheck {
 			})
 		}
 	}
+	if allAppsValid {
+		checks = append(checks, DoctorCheck{
+			Category:    "github",
+			Severity:    "info",
+			Title:       "GitHub Apps configured",
+			Description: fmt.Sprintf("%d GitHub App(s) configured with valid credentials.", len(cfg.GitHubApps)),
+			OK:          true,
+		})
+	}
 
 	return checks
 }
@@ -667,12 +789,24 @@ func (s *Server) checkGitHubApps(cfg *types.HubConfig) []DoctorCheck {
 func (s *Server) checkMCPServers(cfg *types.HubConfig, diskCfg *types.HubConfig) []DoctorCheck {
 	var checks []DoctorCheck
 
+	if len(cfg.MCPServers) == 0 {
+		checks = append(checks, DoctorCheck{
+			Category:    "mcp",
+			Severity:    "info",
+			Title:       "No MCP servers configured",
+			Description: "No MCP servers are configured.",
+			OK:          true,
+		})
+		return checks
+	}
+
 	// Build set of secret names
 	secretNames := make(map[string]bool)
 	for name := range diskCfg.Secrets {
 		secretNames[name] = true
 	}
 
+	allMCPValid := true
 	for _, mcp := range cfg.MCPServers {
 		if mcp == nil {
 			continue
@@ -681,6 +815,7 @@ func (s *Server) checkMCPServers(cfg *types.HubConfig, diskCfg *types.HubConfig)
 		// Check secrets referenced
 		for envVar, secretRef := range mcp.Secrets {
 			if !secretNames[secretRef] {
+				allMCPValid = false
 				checks = append(checks, DoctorCheck{
 					Category:    "mcp",
 					Severity:    "warning",
@@ -695,6 +830,15 @@ func (s *Server) checkMCPServers(cfg *types.HubConfig, diskCfg *types.HubConfig)
 				})
 			}
 		}
+	}
+	if allMCPValid {
+		checks = append(checks, DoctorCheck{
+			Category:    "mcp",
+			Severity:    "info",
+			Title:       "MCP servers configured",
+			Description: fmt.Sprintf("%d MCP server(s) configured with valid secrets.", len(cfg.MCPServers)),
+			OK:          true,
+		})
 	}
 
 	return checks
@@ -722,10 +866,13 @@ func (s *Server) checkAuth(cfg *types.HubConfig) []DoctorCheck {
 				Label:  "Configure Auth",
 			},
 		})
+		return checks
 	}
 
+	authIssues := 0
 	if cfg.Auth != nil && cfg.Auth.GitHubOAuth != nil {
 		if cfg.Auth.GitHubOAuth.ClientID != "" && cfg.Auth.GitHubOAuth.ClientSecret == "" {
+			authIssues++
 			checks = append(checks, DoctorCheck{
 				Category:    "auth",
 				Severity:    "warning",
@@ -743,6 +890,7 @@ func (s *Server) checkAuth(cfg *types.HubConfig) []DoctorCheck {
 			len(cfg.Auth.GitHubOAuth.AllowedUsers) == 0 &&
 			len(cfg.Auth.GitHubOAuth.AllowedOrgs) == 0 &&
 			len(cfg.Auth.GitHubOAuth.AllowedTeams) == 0 {
+			authIssues++
 			checks = append(checks, DoctorCheck{
 				Category:    "auth",
 				Severity:    "warning",
@@ -756,6 +904,16 @@ func (s *Server) checkAuth(cfg *types.HubConfig) []DoctorCheck {
 				},
 			})
 		}
+	}
+
+	if authIssues == 0 {
+		checks = append(checks, DoctorCheck{
+			Category:    "auth",
+			Severity:    "info",
+			Title:       "Authentication configured",
+			Description: "At least one authentication method is configured.",
+			OK:          true,
+		})
 	}
 
 	return checks
@@ -778,6 +936,14 @@ func (s *Server) checkHubSettings(cfg *types.HubConfig) []DoctorCheck {
 				Target: "/settings/runtimes",
 				Label:  "Increase Limit",
 			},
+		})
+	} else {
+		checks = append(checks, DoctorCheck{
+			Category:    "hub",
+			Severity:    "info",
+			Title:       "Hub settings look good",
+			Description: fmt.Sprintf("Max concurrent claws is %d with %d factories configured.", cfg.MaxConcurrentClaws, len(cfg.Factories)),
+			OK:          true,
 		})
 	}
 

--- a/pkg/hub/doctor.go
+++ b/pkg/hub/doctor.go
@@ -290,8 +290,28 @@ func (s *Server) checkProviders(cfg *types.HubConfig) []DoctorCheck {
 		return checks
 	}
 
+	validProviders := map[string]bool{
+		"daytona": true, "vercel": true, "replicated": true, "local": true,
+	}
+
 	allProvidersValid := true
 	for name, p := range cfg.Providers {
+		if !validProviders[name] {
+			allProvidersValid = false
+			checks = append(checks, DoctorCheck{
+				Category:    "sandboxes",
+				Severity:    "warning",
+				Title:       fmt.Sprintf("Unknown sandbox provider: %q", name),
+				Description: fmt.Sprintf("Provider %q is not a recognised sandbox provider (daytona, vercel, replicated, local).", name),
+				OK:          false,
+				FixAction: &FixAction{
+					Type:   "navigate",
+					Target: "/settings/runtimes",
+					Label:  "Fix Provider",
+				},
+			})
+			continue
+		}
 		switch name {
 		case "daytona":
 			if p.APIKey == "" {
@@ -378,13 +398,25 @@ func (s *Server) checkFactories(cfg *types.HubConfig, diskCfg *types.HubConfig) 
 	templateNames := make(map[string]bool)
 	rows, err := s.db.Query(`SELECT name FROM hub_templates`)
 	if err == nil && rows != nil {
+		defer rows.Close()
 		for rows.Next() {
 			var name string
 			if err := rows.Scan(&name); err == nil {
 				templateNames[name] = true
 			}
 		}
-		rows.Close()
+		if err := rows.Err(); err != nil {
+			// DB iteration failed — templateNames may be incomplete.
+			// Emit a warning and skip the template-existence factory check
+			// to avoid false "missing template" critical alerts.
+			checks = append(checks, DoctorCheck{
+				Category:    "factories",
+				Severity:    "warning",
+				Title:       "Could not verify templates from database",
+				Description: fmt.Sprintf("Template list query failed during iteration: %v. Factory template references cannot be validated.", err),
+				OK:          false,
+			})
+		}
 	}
 	// Also check local templates via config resolution
 	// (templates are directories, not a list in hub.yaml)

--- a/pkg/hub/doctor.go
+++ b/pkg/hub/doctor.go
@@ -411,7 +411,18 @@ func (s *Server) checkFactories(cfg *types.HubConfig, diskCfg *types.HubConfig) 
 	templateNames := make(map[string]bool)
 	templateNamesValid := true
 	rows, err := s.db.Query(`SELECT name FROM hub_templates`)
-	if err == nil && rows != nil {
+	if err != nil {
+		// Query itself failed — templateNames is empty, so we must skip
+		// template-existence checks to avoid false critical alerts.
+		templateNamesValid = false
+		checks = append(checks, DoctorCheck{
+			Category:    "factories",
+			Severity:    "warning",
+			Title:       "Could not verify templates from database",
+			Description: fmt.Sprintf("Template list query failed: %v. Factory template references cannot be validated.", err),
+			OK:          false,
+		})
+	} else if rows != nil {
 		defer rows.Close()
 		for rows.Next() {
 			var name string

--- a/pkg/hub/doctor.go
+++ b/pkg/hub/doctor.go
@@ -649,6 +649,7 @@ func (s *Server) checkIntegrations(cfg *types.HubConfig, diskCfg *types.HubConfi
 				OK:          true,
 			})
 		}
+
 		if !factoryWorkspaces["shortcut"][si.Workspace] {
 			checks = append(checks, DoctorCheck{
 				Category:    "integrations",

--- a/pkg/hub/doctor.go
+++ b/pkg/hub/doctor.go
@@ -396,6 +396,7 @@ func (s *Server) checkFactories(cfg *types.HubConfig, diskCfg *types.HubConfig) 
 
 	// Build set of template names from hub DB
 	templateNames := make(map[string]bool)
+	templateNamesValid := true
 	rows, err := s.db.Query(`SELECT name FROM hub_templates`)
 	if err == nil && rows != nil {
 		defer rows.Close()
@@ -409,6 +410,7 @@ func (s *Server) checkFactories(cfg *types.HubConfig, diskCfg *types.HubConfig) 
 			// DB iteration failed — templateNames may be incomplete.
 			// Emit a warning and skip the template-existence factory check
 			// to avoid false "missing template" critical alerts.
+			templateNamesValid = false
 			checks = append(checks, DoctorCheck{
 				Category:    "factories",
 				Severity:    "warning",
@@ -452,7 +454,7 @@ func (s *Server) checkFactories(cfg *types.HubConfig, diskCfg *types.HubConfig) 
 		factoryNames[f.Name]++
 
 		// Check 2: template exists
-		if f.Template != "" && !templateNames[f.Template] {
+		if templateNamesValid && f.Template != "" && !templateNames[f.Template] {
 			checks = append(checks, DoctorCheck{
 				Category:    "factories",
 				Severity:    "critical",

--- a/pkg/hub/doctor.go
+++ b/pkg/hub/doctor.go
@@ -242,7 +242,20 @@ func (s *Server) checkLLMKeys(cfg *types.HubConfig) []DoctorCheck {
 func (s *Server) checkDefaultModel(cfg *types.HubConfig) []DoctorCheck {
 	var checks []DoctorCheck
 
-	if cfg.DefaultModel != "" && !strings.Contains(cfg.DefaultModel, "/") {
+	if cfg.DefaultModel == "" {
+		checks = append(checks, DoctorCheck{
+			Category:    "models",
+			Severity:    "info",
+			Title:       "No default model configured",
+			Description: "No default model is set. The first available LLM key will be used, but an explicit default is recommended.",
+			OK:          false,
+			FixAction: &FixAction{
+				Type:   "navigate",
+				Target: "/settings/models",
+				Label:  "Set Default Model",
+			},
+		})
+	} else if !strings.Contains(cfg.DefaultModel, "/") {
 		checks = append(checks, DoctorCheck{
 			Category:    "models",
 			Severity:    "warning",
@@ -256,7 +269,7 @@ func (s *Server) checkDefaultModel(cfg *types.HubConfig) []DoctorCheck {
 				Label:  "Fix Format",
 			},
 		})
-	} else if cfg.DefaultModel != "" {
+	} else {
 		checks = append(checks, DoctorCheck{
 			Category:    "models",
 			Severity:    "info",

--- a/pkg/hub/doctor.go
+++ b/pkg/hub/doctor.go
@@ -710,7 +710,7 @@ func (s *Server) checkIntegrations(cfg *types.HubConfig, diskCfg *types.HubConfi
 		}
 	}
 
-	if len(checks) == 0 {
+	if len(cfg.Integrations.Linear) == 0 && len(cfg.Integrations.Shortcut) == 0 && len(cfg.Integrations.GitHubIssues) == 0 {
 		checks = append(checks, DoctorCheck{
 			Category:    "integrations",
 			Severity:    "info",

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -215,6 +215,9 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/settings/ai-config/current-config", s.withWebAdminAuth(s.handleAIConfigCurrentConfig))
 	mux.HandleFunc("/api/settings/ai-config", s.withWebAdminAuth(s.handleAIConfig))
 
+	// Doctor
+	mux.HandleFunc("/api/doctor", s.withWebAdminAuth(s.handleDoctor))
+
 	// Health
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -3110,13 +3110,13 @@ function DoctorSection() {
   }
 
   const severityBadge = (s: string) => {
-    const classes = {
+    const classes: Record<string, string> = {
       critical: "bg-red-500/10 text-red-500 border-red-500/20",
       warning: "bg-amber-500/10 text-amber-500 border-amber-500/20",
       info: "bg-blue-400/10 text-blue-400 border-blue-400/20",
     }
     return (
-      <span className={cn("text-[10px] uppercase tracking-wider font-semibold px-2 py-0.5 rounded border", classes[s as keyof typeof classes] || classes.info)}>
+      <span className={cn("text-[10px] uppercase tracking-wider font-semibold px-2 py-0.5 rounded border", classes[s] || classes.info)}>
         {s}
       </span>
     )

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -3211,17 +3211,29 @@ function DoctorSection() {
                       )}
                       {check.fixAction && !check.ok && (
                         <div className="mt-3">
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            className="text-xs"
-                            asChild
-                          >
-                            <Link href={check.fixAction.target}>
+                          {check.fixAction.type === "navigate" ? (
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              className="text-xs"
+                              asChild
+                            >
+                              <Link href={check.fixAction.target}>
+                                {check.fixAction.label}
+                                <ArrowRight className="size-3 ml-1" />
+                              </Link>
+                            </Button>
+                          ) : (
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              className="text-xs"
+                              disabled
+                              title={`Action type "${check.fixAction.type}" not yet supported in UI`}
+                            >
                               {check.fixAction.label}
-                              <ArrowRight className="size-3 ml-1" />
-                            </Link>
-                          </Button>
+                            </Button>
+                          )}
                         </div>
                       )}
                     </div>

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -3,15 +3,15 @@
 import { useParams, useRouter } from "next/navigation"
 import React, { useEffect, useState, useCallback, useRef } from "react"
 import { getHubUrl } from "@/lib/hub-url"
-import { Cpu, Key, Github, ChevronLeft, Shield, Zap, Factory, Copy, Check, LayoutTemplate, Trash2, Lock, Sparkles, Send, RotateCcw, Eye, EyeOff, ExternalLink, AlertTriangle, X, CheckCircle2, Webhook } from "lucide-react"
+import { Cpu, Key, Github, ChevronLeft, Shield, Zap, Factory, Copy, Check, LayoutTemplate, Trash2, Lock, Sparkles, Send, RotateCcw, Eye, EyeOff, ExternalLink, AlertTriangle, X, CheckCircle2, Webhook, Stethoscope } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { cn } from "@/lib/utils"
 import Link from "next/link"
 
-type Section = "runtimes" | "models" | "github" | "authentication" | "issue-trackers" | "factories" | "secrets" | "templates" | "ai-config" | "mcp-servers"
+type Section = "runtimes" | "models" | "github" | "authentication" | "issue-trackers" | "factories" | "secrets" | "templates" | "ai-config" | "mcp-servers" | "doctor"
 
-const VALID_SECTIONS: Section[] = ["runtimes", "models", "github", "authentication", "issue-trackers", "factories", "secrets", "templates", "ai-config", "mcp-servers"]
+const VALID_SECTIONS: Section[] = ["runtimes", "models", "github", "authentication", "issue-trackers", "factories", "secrets", "templates", "ai-config", "mcp-servers", "doctor"]
 
 function isValidSection(s: string): s is Section {
   return VALID_SECTIONS.includes(s as Section)
@@ -209,6 +209,10 @@ export default function SettingsSectionPage() {
     [
       { id: "ai-config", label: "Configure with AI", icon: Sparkles },
     ],
+    // Diagnostics
+    [
+      { id: "doctor", label: "Doctor", icon: Stethoscope },
+    ],
   ]
 
   return (
@@ -288,6 +292,9 @@ export default function SettingsSectionPage() {
           )}
           {section === "ai-config" && (
             <AIConfigSection />
+          )}
+          {section === "doctor" && (
+            <DoctorSection />
           )}
         </main>
       </div>

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -3,7 +3,7 @@
 import { useParams, useRouter } from "next/navigation"
 import React, { useEffect, useState, useCallback, useRef } from "react"
 import { getHubUrl } from "@/lib/hub-url"
-import { Cpu, Key, Github, ChevronLeft, Shield, Zap, Factory, Copy, Check, LayoutTemplate, Trash2, Lock, Sparkles, Send, RotateCcw, Eye, EyeOff, ExternalLink, AlertTriangle, X, CheckCircle2, Webhook, Stethoscope } from "lucide-react"
+import { Cpu, Key, Github, ChevronLeft, Shield, Zap, Factory, Copy, Check, LayoutTemplate, Trash2, Lock, Sparkles, Send, RotateCcw, Eye, EyeOff, ExternalLink, AlertTriangle, X, CheckCircle2, Webhook, Stethoscope, ArrowRight } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { cn } from "@/lib/utils"
@@ -3215,13 +3215,12 @@ function DoctorSection() {
                             size="sm"
                             variant="outline"
                             className="text-xs"
-                            onClick={() => {
-                              if (check.fixAction.type === "navigate") {
-                                window.location.href = check.fixAction.target
-                              }
-                            }}
+                            asChild
                           >
-                            {check.fixAction.label}
+                            <Link href={check.fixAction.target}>
+                              {check.fixAction.label}
+                              <ArrowRight className="size-3 ml-1" />
+                            </Link>
                           </Button>
                         </div>
                       )}

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -3076,3 +3076,163 @@ function TemplatesSection() {
     </div>
   )
 }
+
+function DoctorSection() {
+  const [report, setReport] = useState<any>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = useCallback(async (refresh = false) => {
+    setLoading(true)
+    setError(null)
+    try {
+      const hubUrl = getHubUrl()
+      const token = sessionStorage.getItem("ec_github_token") || sessionStorage.getItem("ec_hub_token") || ""
+      const res = await fetch(`${hubUrl}/api/doctor${refresh ? "?refresh=true" : ""}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (!res.ok) throw new Error(await res.text())
+      setReport(await res.json())
+    } catch (e: any) {
+      setError(e.message || "Failed to load diagnostics")
+    }
+    setLoading(false)
+  }, [])
+
+  useEffect(() => { load() }, [load])
+
+  const severityIcon = (s: string) => {
+    switch (s) {
+      case "critical": return <AlertTriangle className="size-4 text-red-500" />
+      case "warning": return <AlertTriangle className="size-4 text-amber-500" />
+      default: return <CheckCircle2 className="size-4 text-blue-400" />
+    }
+  }
+
+  const severityBadge = (s: string) => {
+    const classes = {
+      critical: "bg-red-500/10 text-red-500 border-red-500/20",
+      warning: "bg-amber-500/10 text-amber-500 border-amber-500/20",
+      info: "bg-blue-400/10 text-blue-400 border-blue-400/20",
+    }
+    return (
+      <span className={cn("text-[10px] uppercase tracking-wider font-semibold px-2 py-0.5 rounded border", classes[s as keyof typeof classes] || classes.info)}>
+        {s}
+      </span>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-base font-semibold mb-1">Doctor</h2>
+          <p className="text-sm text-muted-foreground">
+            Diagnose hub configuration issues and get actionable fixes.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {report?.cachedAt && (
+            <span className="text-xs text-muted-foreground">
+              Cached {new Date(report.cachedAt).toLocaleTimeString()}
+            </span>
+          )}
+          <Button size="sm" variant="outline" onClick={() => load(true)} disabled={loading}>
+            <RotateCcw className={cn("size-3.5 mr-1.5", loading && "animate-spin")} />
+            {loading ? "Checking…" : "Refresh"}
+          </Button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-4 text-sm text-red-500">
+          {error}
+        </div>
+      )}
+
+      {report && (
+        <>
+          <div className="grid grid-cols-4 gap-3">
+            <div className="rounded-lg border border-border p-3 text-center">
+              <p className="text-2xl font-bold">{report.summary.total}</p>
+              <p className="text-xs text-muted-foreground mt-1">Checks</p>
+            </div>
+            <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-3 text-center">
+              <p className="text-2xl font-bold text-red-500">{report.summary.critical}</p>
+              <p className="text-xs text-muted-foreground mt-1">Critical</p>
+            </div>
+            <div className="rounded-lg border border-amber-500/20 bg-amber-500/5 p-3 text-center">
+              <p className="text-2xl font-bold text-amber-500">{report.summary.warning}</p>
+              <p className="text-xs text-muted-foreground mt-1">Warnings</p>
+            </div>
+            <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/5 p-3 text-center">
+              <p className="text-2xl font-bold text-emerald-500">{report.summary.passed}</p>
+              <p className="text-xs text-muted-foreground mt-1">Passed</p>
+            </div>
+          </div>
+
+          {report.checks.length === 0 ? (
+            <p className="text-sm text-muted-foreground">All checks passed — no issues found.</p>
+          ) : (
+            <div className="space-y-3">
+              {report.checks.map((check: any, i: number) => (
+                <div
+                  key={i}
+                  className={cn(
+                    "rounded-lg border p-4",
+                    check.ok
+                      ? "border-emerald-500/20 bg-emerald-500/5"
+                      : check.severity === "critical"
+                        ? "border-red-500/20 bg-red-500/5"
+                        : check.severity === "warning"
+                          ? "border-amber-500/20 bg-amber-500/5"
+                          : "border-border"
+                  )}
+                >
+                  <div className="flex items-start gap-3">
+                    <div className="mt-0.5 shrink-0">
+                      {check.ok ? (
+                        <CheckCircle2 className="size-4 text-emerald-500" />
+                      ) : (
+                        severityIcon(check.severity)
+                      )}
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                          {check.category}
+                        </span>
+                        {!check.ok && severityBadge(check.severity)}
+                      </div>
+                      <p className="text-sm font-medium mt-1">{check.title}</p>
+                      <p className="text-sm text-muted-foreground mt-0.5">{check.description}</p>
+                      {check.error && (
+                        <p className="text-xs text-red-400 mt-1 font-mono">{check.error}</p>
+                      )}
+                      {check.fixAction && !check.ok && (
+                        <div className="mt-3">
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            className="text-xs"
+                            onClick={() => {
+                              if (check.fixAction.type === "navigate") {
+                                window.location.href = check.fixAction.target
+                              }
+                            }}
+                          >
+                            {check.fixAction.label}
+                          </Button>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
Adds a new Settings / Doctor page that runs 20 diagnostic checks against the hub configuration and surfaces actionable fixes.

## What's New

- **Backend**: New /api/doctor endpoint with 5-min caching and `?refresh=true` bypass
- **20 checks** across 9 categories:
  - **Models**: LLM keys present, valid providers, default key set, default model format
  - **Sandboxes**: Provider credentials (Daytona, Vercel, Replicated)
  - **Factories**: Template references, webhook secrets, duplicate names, overlapping triggers
  - **Integrations**: Linear/Shortcut/GitHub Issues tokens and webhook secrets
  - **GitHub Apps**: Private keys and App IDs
  - **MCP Servers**: Secret references
  - **Auth**: Lockout risk, OAuth secrets, access restrictions
  - **Hub**: Concurrency limits vs factory count
- **Guided fixes**: Each check returns a `FixAction` with type (navigate/set_field/toggle), target path, and button label. The frontend renders actionable buttons that jump to the relevant settings section.

## API Response Format

```json
{
  "checks": [
    {
      "category": "models",
      "severity": "critical",
      "title": "No LLM keys configured",
      "description": "At least one LLM key is required...",
      "ok": false,
      "fixAction": {
        "type": "navigate",
        "target": "/settings/models",
        "label": "Add LLM Key"
      }
    }
  ],
  "summary": { "total": 20, "critical": 1, "warning": 0, "info": 0, "passed": 19 }
}
```

