### PR TITLE
feat(hub): store templates and factories as external files alongside …

### DIFF
--- a/pkg/hub/doctor.go
+++ b/pkg/hub/doctor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -624,7 +625,7 @@ func (s *Server) checkTemplates(cfg *types.HubConfig, diskCfg *types.HubConfig) 
 		})
 	} else {
 		for _, name := range externalNames {
-			files, err := loadExternalTemplate(name)
+			_, err := loadExternalTemplate(name)
 			if err != nil {
 				checks = append(checks, DoctorCheck{
 					Category:    "templates",
@@ -635,8 +636,9 @@ func (s *Server) checkTemplates(cfg *types.HubConfig, diskCfg *types.HubConfig) 
 				})
 				continue
 			}
-			// Check for elasticclaw-config.yaml
-			if _, ok := files["elasticclaw-config.yaml"]; !ok {
+			// Check for elasticclaw-config.yaml directly (not via ReadTemplateFiles allow-list)
+			configPath := filepath.Join(templatesDir(), name, "elasticclaw-config.yaml")
+			if _, err := os.Stat(configPath); os.IsNotExist(err) {
 				checks = append(checks, DoctorCheck{
 					Category:    "templates",
 					Severity:    "warning",

--- a/pkg/hub/doctor.go
+++ b/pkg/hub/doctor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -407,21 +408,33 @@ func (s *Server) checkFactories(cfg *types.HubConfig, diskCfg *types.HubConfig) 
 		return checks
 	}
 
-	// Build set of template names from hub DB
+	// Build set of template names from external storage + legacy DB
 	templateNames := make(map[string]bool)
 	templateNamesValid := true
+
+	// External templates first
+	externalNames, err := listExternalTemplates()
+	if err == nil {
+		for _, name := range externalNames {
+			templateNames[name] = true
+		}
+	}
+
+	// Legacy DB templates (for migration period)
 	rows, err := s.db.Query(`SELECT name FROM hub_templates`)
 	if err != nil {
-		// Query itself failed — templateNames is empty, so we must skip
-		// template-existence checks to avoid false critical alerts.
-		templateNamesValid = false
-		checks = append(checks, DoctorCheck{
-			Category:    "factories",
-			Severity:    "warning",
-			Title:       "Could not verify templates from database",
-			Description: fmt.Sprintf("Template list query failed: %v. Factory template references cannot be validated.", err),
-			OK:          false,
-		})
+		// Query itself failed — templateNames may be empty from external too,
+		// so we must skip template-existence checks to avoid false critical alerts.
+		if len(templateNames) == 0 {
+			templateNamesValid = false
+			checks = append(checks, DoctorCheck{
+				Category:    "factories",
+				Severity:    "warning",
+				Title:       "Could not verify templates",
+				Description: fmt.Sprintf("Template list query failed: %v. Factory template references cannot be validated.", err),
+				OK:          false,
+			})
+		}
 	} else if rows != nil {
 		defer rows.Close()
 		for rows.Next() {
@@ -434,14 +447,16 @@ func (s *Server) checkFactories(cfg *types.HubConfig, diskCfg *types.HubConfig) 
 			// DB iteration failed — templateNames may be incomplete.
 			// Emit a warning and skip the template-existence factory check
 			// to avoid false "missing template" critical alerts.
-			templateNamesValid = false
-			checks = append(checks, DoctorCheck{
-				Category:    "factories",
-				Severity:    "warning",
-				Title:       "Could not verify templates from database",
-				Description: fmt.Sprintf("Template list query failed during iteration: %v. Factory template references cannot be validated.", err),
-				OK:          false,
-			})
+			if len(templateNames) == 0 {
+				templateNamesValid = false
+				checks = append(checks, DoctorCheck{
+					Category:    "factories",
+					Severity:    "warning",
+					Title:       "Could not verify templates",
+					Description: fmt.Sprintf("Template list query failed during iteration: %v. Factory template references cannot be validated.", err),
+					OK:          false,
+				})
+			}
 		}
 	}
 	// Also check local templates via config resolution
@@ -597,17 +612,63 @@ func (s *Server) checkTemplates(cfg *types.HubConfig, diskCfg *types.HubConfig) 
 		secretNames[name] = true
 	}
 
-	// Template secrets are checked at the factory level (factory references template)
-	// Individual template configs are loaded at runtime, not stored in hub.yaml
-	// TODO: Load template configs from hub_templates DB or filesystem and check their secrets
-
-	checks = append(checks, DoctorCheck{
-		Category:    "templates",
-		Severity:    "info",
-		Title:       "Template checks pending",
-		Description: "Template configuration validation is not yet implemented.",
-		OK:          true,
-	})
+	// Check external templates for common issues
+	externalNames, err := listExternalTemplates()
+	if err != nil && !os.IsNotExist(err) {
+		checks = append(checks, DoctorCheck{
+			Category:    "templates",
+			Severity:    "warning",
+			Title:       "Could not list external templates",
+			Description: fmt.Sprintf("Error reading templates directory: %v", err),
+			OK:          false,
+		})
+	} else {
+		for _, name := range externalNames {
+			files, err := loadExternalTemplate(name)
+			if err != nil {
+				checks = append(checks, DoctorCheck{
+					Category:    "templates",
+					Severity:    "warning",
+					Title:       fmt.Sprintf("Template %q unreadable", name),
+					Description: fmt.Sprintf("Could not read template %q: %v", name, err),
+					OK:          false,
+				})
+				continue
+			}
+			// Check for elasticclaw-config.yaml
+			if _, ok := files["elasticclaw-config.yaml"]; !ok {
+				checks = append(checks, DoctorCheck{
+					Category:    "templates",
+					Severity:    "warning",
+					Title:       fmt.Sprintf("Template %q missing elasticclaw-config.yaml", name),
+					Description: fmt.Sprintf("Template %q does not contain an elasticclaw-config.yaml file. This may cause issues when creating claws.", name),
+					OK:          false,
+					FixAction: &FixAction{
+						Type:   "navigate",
+						Target: "/settings/templates",
+						Label:  "Manage Templates",
+					},
+				})
+			}
+		}
+		if len(externalNames) == 0 {
+			checks = append(checks, DoctorCheck{
+				Category:    "templates",
+				Severity:    "info",
+				Title:       "No external templates",
+				Description: "No templates found in external storage. Use 'elasticclaw template push' to add templates.",
+				OK:          true,
+			})
+		} else {
+			checks = append(checks, DoctorCheck{
+				Category:    "templates",
+				Severity:    "info",
+				Title:       fmt.Sprintf("%d template(s) in external storage", len(externalNames)),
+				Description: "Templates are stored as external files alongside hub.yaml.",
+				OK:          true,
+			})
+		}
+	}
 
 	return checks
 }

--- a/pkg/hub/external_storage.go
+++ b/pkg/hub/external_storage.go
@@ -224,11 +224,14 @@ func saveExternalFactory(f *types.FactoryConfig) error {
 		return fmt.Errorf("write factory.yaml: %w", err)
 	}
 
-	// Write pipeline.yaml if present
+	// Write or remove pipeline.yaml based on whether PipelineYAML is set
+	pipelinePath := filepath.Join(dir, "pipeline.yaml")
 	if f.PipelineYAML != "" {
-		if err := os.WriteFile(filepath.Join(dir, "pipeline.yaml"), []byte(f.PipelineYAML), 0640); err != nil {
+		if err := os.WriteFile(pipelinePath, []byte(f.PipelineYAML), 0640); err != nil {
 			return fmt.Errorf("write pipeline.yaml: %w", err)
 		}
+	} else {
+		_ = os.Remove(pipelinePath)
 	}
 
 	return nil

--- a/pkg/hub/external_storage.go
+++ b/pkg/hub/external_storage.go
@@ -88,11 +88,18 @@ func validateName(name string) error {
 }
 
 // saveExternalTemplate writes a template to the external templates directory.
+// Any files present on disk but absent from the new files map are removed
+// so that deletions are persisted across pushes.
 func saveExternalTemplate(name string, files map[string]string) error {
 	if err := validateName(name); err != nil {
 		return err
 	}
 	dir := filepath.Join(templatesDir(), name)
+	// Remove and recreate the directory so stale files from previous pushes
+	// are not re-read by ReadTemplateFiles (which walks the memory/ subtree).
+	if err := os.RemoveAll(dir); err != nil {
+		return fmt.Errorf("remove old template dir %s: %w", dir, err)
+	}
 	if err := os.MkdirAll(dir, 0750); err != nil {
 		return fmt.Errorf("mkdir %s: %w", dir, err)
 	}

--- a/pkg/hub/external_storage.go
+++ b/pkg/hub/external_storage.go
@@ -1,6 +1,7 @@
 package hub
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -69,14 +70,31 @@ func loadExternalTemplate(name string) (map[string]string, error) {
 	return config.ReadTemplateFiles(dir)
 }
 
+// validateName rejects names that could cause path traversal.
+func validateName(name string) error {
+	if name == "" {
+		return fmt.Errorf("name is empty")
+	}
+	if strings.Contains(name, "..") {
+		return fmt.Errorf("name contains path traversal")
+	}
+	if strings.ContainsAny(name, `/\`) {
+		return fmt.Errorf("name contains path separator")
+	}
+	return nil
+}
+
 // saveExternalTemplate writes a template to the external templates directory.
 func saveExternalTemplate(name string, files map[string]string) error {
+	if err := validateName(name); err != nil {
+		return err
+	}
 	dir := filepath.Join(templatesDir(), name)
 	if err := os.MkdirAll(dir, 0750); err != nil {
 		return fmt.Errorf("mkdir %s: %w", dir, err)
 	}
 	for fname, content := range files {
-		if strings.Contains(fname, "..") || strings.Contains(fname, "/") {
+		if strings.Contains(fname, "..") || strings.ContainsAny(fname, `/\`) {
 			continue // skip paths with directory traversal
 		}
 		path := filepath.Join(dir, fname)
@@ -89,6 +107,9 @@ func saveExternalTemplate(name string, files map[string]string) error {
 
 // deleteExternalTemplate removes a template from the external directory.
 func deleteExternalTemplate(name string) error {
+	if err := validateName(name); err != nil {
+		return err
+	}
 	dir := filepath.Join(templatesDir(), name)
 	return os.RemoveAll(dir)
 }
@@ -170,6 +191,9 @@ func saveExternalFactory(f *types.FactoryConfig) error {
 	if f == nil || f.Name == "" {
 		return fmt.Errorf("factory name required")
 	}
+	if err := validateName(f.Name); err != nil {
+		return err
+	}
 
 	dir := filepath.Join(factoriesDir(), f.Name)
 	if err := os.MkdirAll(dir, 0750); err != nil {
@@ -199,6 +223,9 @@ func saveExternalFactory(f *types.FactoryConfig) error {
 
 // deleteExternalFactory removes a factory directory.
 func deleteExternalFactory(name string) error {
+	if err := validateName(name); err != nil {
+		return err
+	}
 	dir := filepath.Join(factoriesDir(), name)
 	return os.RemoveAll(dir)
 }
@@ -236,7 +263,7 @@ func (s *Server) MigrateLegacyTemplates() error {
 			continue
 		}
 		var files map[string]string
-		if err := yaml.Unmarshal([]byte(filesJSON), &files); err != nil {
+		if err := json.Unmarshal([]byte(filesJSON), &files); err != nil {
 			continue
 		}
 		if err := saveExternalTemplate(name, files); err != nil {

--- a/pkg/hub/external_storage.go
+++ b/pkg/hub/external_storage.go
@@ -1,0 +1,266 @@
+package hub
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/elasticclaw/elasticclaw/pkg/config"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+	"gopkg.in/yaml.v3"
+)
+
+// hubDataDir returns the hub's data directory (where hub.yaml lives).
+// It mirrors the logic in cmd/hub.go: /var/lib/elasticclaw for system installs,
+// ~/.elasticclaw otherwise.
+func hubDataDir() string {
+	if _, err := os.Stat("/etc/elasticclaw/hub.yaml"); err == nil {
+		return "/var/lib/elasticclaw"
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".elasticclaw")
+}
+
+// hubConfigDir returns the directory containing hub.yaml.
+func hubConfigDir() string {
+	if env := os.Getenv("ELASTICCLAW_HUB_CONFIG"); env != "" {
+		return filepath.Dir(env)
+	}
+	if _, err := os.Stat("/etc/elasticclaw/hub.yaml"); err == nil {
+		return "/etc/elasticclaw"
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".elasticclaw")
+}
+
+// factoriesDir returns the path to the external factories directory.
+func factoriesDir() string {
+	return filepath.Join(hubConfigDir(), "factories")
+}
+
+// templatesDir returns the path to the external templates directory.
+func templatesDir() string {
+	return filepath.Join(hubConfigDir(), "templates")
+}
+
+// EnsureExternalDirs creates the factories/ and templates/ directories
+// alongside hub.yaml if they don't exist.
+func EnsureExternalDirs() error {
+	for _, dir := range []string{factoriesDir(), templatesDir()} {
+		if err := os.MkdirAll(dir, 0750); err != nil {
+			return fmt.Errorf("mkdir %s: %w", dir, err)
+		}
+	}
+	return nil
+}
+
+// ── Templates ────────────────────────────────────────────────────────────────
+
+// loadExternalTemplate reads a template from the external templates directory.
+func loadExternalTemplate(name string) (map[string]string, error) {
+	dir := filepath.Join(templatesDir(), name)
+	return config.ReadTemplateFiles(dir)
+}
+
+// saveExternalTemplate writes a template to the external templates directory.
+func saveExternalTemplate(name string, files map[string]string) error {
+	dir := filepath.Join(templatesDir(), name)
+	if err := os.MkdirAll(dir, 0750); err != nil {
+		return fmt.Errorf("mkdir %s: %w", dir, err)
+	}
+	for fname, content := range files {
+		if strings.Contains(fname, "..") || strings.Contains(fname, "/") {
+			continue // skip paths with directory traversal
+		}
+		path := filepath.Join(dir, fname)
+		if err := os.WriteFile(path, []byte(content), 0640); err != nil {
+			return fmt.Errorf("write %s: %w", path, err)
+		}
+	}
+	return nil
+}
+
+// deleteExternalTemplate removes a template from the external directory.
+func deleteExternalTemplate(name string) error {
+	dir := filepath.Join(templatesDir(), name)
+	return os.RemoveAll(dir)
+}
+
+// listExternalTemplates returns all template names from the external directory.
+func listExternalTemplates() ([]string, error) {
+	entries, err := os.ReadDir(templatesDir())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() && !strings.HasPrefix(e.Name(), ".") {
+			names = append(names, e.Name())
+		}
+	}
+	return names, nil
+}
+
+// ── Factories ────────────────────────────────────────────────────────────────
+
+// loadExternalFactories scans the factories directory and returns all
+// FactoryConfigs with PipelineYAML loaded from disk.
+func loadExternalFactories() ([]*types.FactoryConfig, error) {
+	dir := factoriesDir()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read factories dir: %w", err)
+	}
+
+	var factories []*types.FactoryConfig
+	for _, e := range entries {
+		if !e.IsDir() || strings.HasPrefix(e.Name(), ".") {
+			continue
+		}
+		f, err := loadExternalFactory(e.Name())
+		if err != nil {
+			// Log but don't fail — one bad factory shouldn't break the rest
+			fmt.Fprintf(os.Stderr, "[hub] skip factory %q: %v\n", e.Name(), err)
+			continue
+		}
+		factories = append(factories, f)
+	}
+	return factories, nil
+}
+
+// loadExternalFactory reads a single factory from disk.
+func loadExternalFactory(name string) (*types.FactoryConfig, error) {
+	dir := filepath.Join(factoriesDir(), name)
+
+	factoryPath := filepath.Join(dir, "factory.yaml")
+	data, err := os.ReadFile(factoryPath)
+	if err != nil {
+		return nil, fmt.Errorf("read factory.yaml: %w", err)
+	}
+
+	var f types.FactoryConfig
+	if err := yaml.Unmarshal(data, &f); err != nil {
+		return nil, fmt.Errorf("parse factory.yaml: %w", err)
+	}
+
+	// Load pipeline.yaml alongside if present
+	pipelinePath := filepath.Join(dir, "pipeline.yaml")
+	if pdata, err := os.ReadFile(pipelinePath); err == nil {
+		f.PipelineYAML = string(pdata)
+	}
+
+	return &f, nil
+}
+
+// saveExternalFactory writes a factory to the external directory.
+func saveExternalFactory(f *types.FactoryConfig) error {
+	if f == nil || f.Name == "" {
+		return fmt.Errorf("factory name required")
+	}
+
+	dir := filepath.Join(factoriesDir(), f.Name)
+	if err := os.MkdirAll(dir, 0750); err != nil {
+		return fmt.Errorf("mkdir %s: %w", dir, err)
+	}
+
+	// Write factory.yaml (without PipelineYAML — that goes in pipeline.yaml)
+	factoryCopy := *f
+	factoryCopy.PipelineYAML = ""
+	fdata, err := yaml.Marshal(&factoryCopy)
+	if err != nil {
+		return fmt.Errorf("marshal factory.yaml: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "factory.yaml"), fdata, 0640); err != nil {
+		return fmt.Errorf("write factory.yaml: %w", err)
+	}
+
+	// Write pipeline.yaml if present
+	if f.PipelineYAML != "" {
+		if err := os.WriteFile(filepath.Join(dir, "pipeline.yaml"), []byte(f.PipelineYAML), 0640); err != nil {
+			return fmt.Errorf("write pipeline.yaml: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// deleteExternalFactory removes a factory directory.
+func deleteExternalFactory(name string) error {
+	dir := filepath.Join(factoriesDir(), name)
+	return os.RemoveAll(dir)
+}
+
+// ── Migration ────────────────────────────────────────────────────────────────
+
+// migrationMarkerPath returns the path to the migration marker file.
+func migrationMarkerPath() string {
+	return filepath.Join(hubDataDir(), ".migrated_v2")
+}
+
+// hasMigratedV2 checks if the v2 migration has already run.
+func hasMigratedV2() bool {
+	_, err := os.Stat(migrationMarkerPath())
+	return err == nil
+}
+
+// markMigratedV2 writes the migration marker.
+func markMigratedV2() error {
+	return os.WriteFile(migrationMarkerPath(), []byte(""), 0644)
+}
+
+// MigrateLegacyTemplates migrates templates from the SQLite hub_templates table
+// to the external templates/ directory.
+func (s *Server) MigrateLegacyTemplates() error {
+	rows, err := s.db.Query(`SELECT name, files FROM hub_templates`)
+	if err != nil {
+		return fmt.Errorf("query hub_templates: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var name, filesJSON string
+		if err := rows.Scan(&name, &filesJSON); err != nil {
+			continue
+		}
+		var files map[string]string
+		if err := yaml.Unmarshal([]byte(filesJSON), &files); err != nil {
+			continue
+		}
+		if err := saveExternalTemplate(name, files); err != nil {
+			fmt.Fprintf(os.Stderr, "[hub] migrate template %q: %v\n", name, err)
+			continue
+		}
+		fmt.Printf("[hub] migrated template %q to external storage\n", name)
+	}
+	return rows.Err()
+}
+
+// MigrateLegacyFactories migrates factories from hub.yaml to the external
+// factories/ directory. Returns the list of migrated factory names.
+func MigrateLegacyFactories(cfg *types.HubConfig) ([]string, error) {
+	var migrated []string
+	for _, f := range cfg.Factories {
+		if f == nil {
+			continue
+		}
+		if err := saveExternalFactory(f); err != nil {
+			fmt.Fprintf(os.Stderr, "[hub] migrate factory %q: %v\n", f.Name, err)
+			continue
+		}
+		migrated = append(migrated, f.Name)
+	}
+	return migrated, nil
+}

--- a/pkg/hub/external_storage.go
+++ b/pkg/hub/external_storage.go
@@ -66,6 +66,9 @@ func EnsureExternalDirs() error {
 
 // loadExternalTemplate reads a template from the external templates directory.
 func loadExternalTemplate(name string) (map[string]string, error) {
+	if err := validateName(name); err != nil {
+		return nil, err
+	}
 	dir := filepath.Join(templatesDir(), name)
 	return config.ReadTemplateFiles(dir)
 }
@@ -164,6 +167,9 @@ func loadExternalFactories() ([]*types.FactoryConfig, error) {
 
 // loadExternalFactory reads a single factory from disk.
 func loadExternalFactory(name string) (*types.FactoryConfig, error) {
+	if err := validateName(name); err != nil {
+		return nil, err
+	}
 	dir := filepath.Join(factoriesDir(), name)
 
 	factoryPath := filepath.Join(dir, "factory.yaml")

--- a/pkg/hub/factory_api.go
+++ b/pkg/hub/factory_api.go
@@ -2,6 +2,7 @@ package hub
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -68,12 +69,34 @@ func factoryToPushView(f *types.FactoryConfig) FactoryPushView {
 func (s *Server) handleFactoriesList(w http.ResponseWriter, r *http.Request) {
 	nameFilter := strings.TrimSpace(r.URL.Query().Get("name"))
 
+	// Load from external storage first
+	factories, err := loadExternalFactories()
+	if err != nil {
+		http.Error(w, "fs error: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Merge with in-memory factories (external takes precedence)
 	s.mu.RLock()
-	factories := s.hubCfg.Factories
+	memFactories := s.hubCfg.Factories
 	s.mu.RUnlock()
 
-	views := make([]FactoryPushView, 0, len(factories))
+	merged := make(map[string]*types.FactoryConfig, len(factories)+len(memFactories))
+	for _, f := range memFactories {
+		if f == nil {
+			continue
+		}
+		merged[f.Name] = f
+	}
 	for _, f := range factories {
+		if f == nil {
+			continue
+		}
+		merged[f.Name] = f
+	}
+
+	views := make([]FactoryPushView, 0, len(merged))
+	for _, f := range merged {
 		if nameFilter != "" && !strings.EqualFold(f.Name, nameFilter) {
 			continue
 		}
@@ -98,10 +121,20 @@ func (s *Server) handleFactoriesPush(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Write each factory to external storage
+	for _, f := range req.Factories {
+		if f == nil || f.Name == "" {
+			http.Error(w, "factory name required", http.StatusBadRequest)
+			return
+		}
+		if err := saveExternalFactory(f); err != nil {
+			http.Error(w, fmt.Sprintf("save factory %q: %v", f.Name, err), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	// Also update in-memory config for backward compat during migration
 	s.mu.Lock()
-	// Upsert by name — preserve existing webhook secrets for repo-pushed factories.
-	// Keep factory ordering stable: preserve existing order and append newly-added
-	// factories in request order.
 	existing := make(map[string]*types.FactoryConfig)
 	for _, f := range s.hubCfg.Factories {
 		existing[f.Name] = f
@@ -142,6 +175,7 @@ func (s *Server) handleFactoriesPush(w http.ResponseWriter, r *http.Request) {
 	s.hubCfg = &cfgCopy
 	s.mu.Unlock()
 
+	// Save to hub.yaml for backward compat during migration
 	if err := config.SaveHubConfig(&cfgCopy); err != nil {
 		http.Error(w, "failed to save config: "+err.Error(), http.StatusInternalServerError)
 		return
@@ -158,6 +192,12 @@ func (s *Server) handleFactoriesPush(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleFactoryDelete(w http.ResponseWriter, _ *http.Request, name string) {
+	// Delete from external storage first
+	if err := deleteExternalFactory(name); err != nil {
+		http.Error(w, "delete error: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
 	s.mu.Lock()
 	factories := make([]*types.FactoryConfig, 0, len(s.hubCfg.Factories))
 	found := false
@@ -170,7 +210,8 @@ func (s *Server) handleFactoryDelete(w http.ResponseWriter, _ *http.Request, nam
 	}
 	if !found {
 		s.mu.Unlock()
-		http.Error(w, "factory not found", http.StatusNotFound)
+		// If not in memory but deleted from disk, still report success
+		jsonOK(w, map[string]string{"deleted": name})
 		return
 	}
 	cfgCopy := *s.hubCfg

--- a/pkg/hub/factory_api.go
+++ b/pkg/hub/factory_api.go
@@ -121,6 +121,21 @@ func (s *Server) handleFactoriesPush(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Preserve inline webhook secrets before writing to external storage
+	s.mu.RLock()
+	existing := make(map[string]*types.FactoryConfig)
+	for _, f := range s.hubCfg.Factories {
+		existing[f.Name] = f
+	}
+	s.mu.RUnlock()
+	for _, incoming := range req.Factories {
+		if prev, ok := existing[incoming.Name]; ok {
+			if incoming.WebhookSecret == "" && incoming.WebhookSecretRef == "" && prev.WebhookSecret != "" {
+				incoming.WebhookSecret = prev.WebhookSecret
+			}
+		}
+	}
+
 	// Write each factory to external storage
 	for _, f := range req.Factories {
 		if f == nil || f.Name == "" {
@@ -135,7 +150,7 @@ func (s *Server) handleFactoriesPush(w http.ResponseWriter, r *http.Request) {
 
 	// Also update in-memory config for backward compat during migration
 	s.mu.Lock()
-	existing := make(map[string]*types.FactoryConfig)
+	existing = make(map[string]*types.FactoryConfig)
 	for _, f := range s.hubCfg.Factories {
 		existing[f.Name] = f
 	}
@@ -143,12 +158,6 @@ func (s *Server) handleFactoriesPush(w http.ResponseWriter, r *http.Request) {
 	incomingOrder := make([]string, 0, len(req.Factories))
 	seenIncoming := make(map[string]bool, len(req.Factories))
 	for _, incoming := range req.Factories {
-		if prev, ok := existing[incoming.Name]; ok {
-			// Preserve inline webhook secret if not provided in push
-			if incoming.WebhookSecret == "" && incoming.WebhookSecretRef == "" && prev.WebhookSecret != "" {
-				incoming.WebhookSecret = prev.WebhookSecret
-			}
-		}
 		existing[incoming.Name] = incoming
 		incomingByName[incoming.Name] = incoming
 		if !seenIncoming[incoming.Name] {

--- a/pkg/hub/factory_api.go
+++ b/pkg/hub/factory_api.go
@@ -121,7 +121,9 @@ func (s *Server) handleFactoriesPush(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Preserve inline webhook secrets before writing to external storage
+	// Preserve inline webhook secrets before writing to external storage.
+	// Check in-memory config first, then fall back to external storage
+	// so that factories with secrets only on disk are also protected.
 	s.mu.RLock()
 	existing := make(map[string]*types.FactoryConfig)
 	for _, f := range s.hubCfg.Factories {
@@ -129,7 +131,15 @@ func (s *Server) handleFactoriesPush(w http.ResponseWriter, r *http.Request) {
 	}
 	s.mu.RUnlock()
 	for _, incoming := range req.Factories {
-		if prev, ok := existing[incoming.Name]; ok {
+		prev, ok := existing[incoming.Name]
+		if !ok {
+			// Factory not in memory — try external storage
+			if disk, err := loadExternalFactory(incoming.Name); err == nil {
+				prev = disk
+				ok = true
+			}
+		}
+		if ok {
 			if incoming.WebhookSecret == "" && incoming.WebhookSecretRef == "" && prev.WebhookSecret != "" {
 				incoming.WebhookSecret = prev.WebhookSecret
 			}

--- a/pkg/hub/factory_api.go
+++ b/pkg/hub/factory_api.go
@@ -127,6 +127,9 @@ func (s *Server) handleFactoriesPush(w http.ResponseWriter, r *http.Request) {
 	s.mu.RLock()
 	existing := make(map[string]*types.FactoryConfig)
 	for _, f := range s.hubCfg.Factories {
+		if f == nil {
+			continue
+		}
 		existing[f.Name] = f
 	}
 	s.mu.RUnlock()
@@ -170,6 +173,9 @@ func (s *Server) handleFactoriesPush(w http.ResponseWriter, r *http.Request) {
 	s.mu.Lock()
 	existing = make(map[string]*types.FactoryConfig)
 	for _, f := range s.hubCfg.Factories {
+		if f == nil {
+			continue
+		}
 		existing[f.Name] = f
 	}
 	incomingByName := make(map[string]*types.FactoryConfig, len(req.Factories))

--- a/pkg/hub/factory_api.go
+++ b/pkg/hub/factory_api.go
@@ -146,16 +146,21 @@ func (s *Server) handleFactoriesPush(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Write each factory to external storage
+	// Write each factory to external storage — attempt all writes before
+	// returning so that a failure mid-batch doesn't leave a partial update.
+	var saveErrs []string
 	for _, f := range req.Factories {
 		if f == nil || f.Name == "" {
-			http.Error(w, "factory name required", http.StatusBadRequest)
-			return
+			saveErrs = append(saveErrs, "factory name required")
+			continue
 		}
 		if err := saveExternalFactory(f); err != nil {
-			http.Error(w, fmt.Sprintf("save factory %q: %v", f.Name, err), http.StatusInternalServerError)
-			return
+			saveErrs = append(saveErrs, fmt.Sprintf("save factory %q: %v", f.Name, err))
 		}
+	}
+	if len(saveErrs) > 0 {
+		http.Error(w, strings.Join(saveErrs, "; "), http.StatusInternalServerError)
+		return
 	}
 
 	// Also update in-memory config for backward compat during migration

--- a/pkg/hub/factory_api.go
+++ b/pkg/hub/factory_api.go
@@ -235,6 +235,9 @@ func (s *Server) handleFactoryDelete(w http.ResponseWriter, _ *http.Request, nam
 	factories := make([]*types.FactoryConfig, 0, len(s.hubCfg.Factories))
 	found := false
 	for _, f := range s.hubCfg.Factories {
+		if f == nil {
+			continue
+		}
 		if strings.EqualFold(f.Name, name) {
 			found = true
 			continue

--- a/pkg/hub/factory_api.go
+++ b/pkg/hub/factory_api.go
@@ -131,6 +131,9 @@ func (s *Server) handleFactoriesPush(w http.ResponseWriter, r *http.Request) {
 	}
 	s.mu.RUnlock()
 	for _, incoming := range req.Factories {
+		if incoming == nil || incoming.Name == "" {
+			continue
+		}
 		prev, ok := existing[incoming.Name]
 		if !ok {
 			// Factory not in memory — try external storage

--- a/pkg/hub/templates.go
+++ b/pkg/hub/templates.go
@@ -60,7 +60,8 @@ func (s *Server) listTemplates(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Also include legacy DB templates (for migration period)
+	// Collect legacy DB templates and their updated_at timestamps in one pass
+	dbUpdatedAt := make(map[string]string)
 	rows, err := s.db.Query(`SELECT name, updated_at FROM hub_templates ORDER BY name ASC`)
 	if err == nil {
 		defer rows.Close()
@@ -69,6 +70,7 @@ func (s *Server) listTemplates(w http.ResponseWriter, r *http.Request) {
 			if err := rows.Scan(&name, &updatedAt); err != nil {
 				continue
 			}
+			dbUpdatedAt[name] = updatedAt
 			// Deduplicate: external takes precedence
 			found := false
 			for _, n := range names {
@@ -79,19 +81,6 @@ func (s *Server) listTemplates(w http.ResponseWriter, r *http.Request) {
 			}
 			if !found {
 				names = append(names, name)
-			}
-		}
-	}
-
-	// Collect real updated_at timestamps from legacy DB rows
-	dbUpdatedAt := make(map[string]string)
-	rows2, err2 := s.db.Query(`SELECT name, updated_at FROM hub_templates ORDER BY name ASC`)
-	if err2 == nil {
-		defer rows2.Close()
-		for rows2.Next() {
-			var n, ts string
-			if err := rows2.Scan(&n, &ts); err == nil {
-				dbUpdatedAt[n] = ts
 			}
 		}
 	}

--- a/pkg/hub/templates.go
+++ b/pkg/hub/templates.go
@@ -40,10 +40,12 @@ func (s *Server) handleTemplateDetail(w http.ResponseWriter, r *http.Request) {
 			"files": files,
 		})
 	case http.MethodDelete:
-		if _, err := s.db.Exec(`DELETE FROM hub_templates WHERE name = ?`, name); err != nil {
-			http.Error(w, "db error", http.StatusInternalServerError)
+		if err := deleteExternalTemplate(name); err != nil {
+			http.Error(w, "delete error: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
+		// Also clean up legacy DB row if present
+		_, _ = s.db.Exec(`DELETE FROM hub_templates WHERE name = ?`, name)
 		w.WriteHeader(http.StatusNoContent)
 	default:
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -51,24 +53,43 @@ func (s *Server) handleTemplateDetail(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) listTemplates(w http.ResponseWriter, r *http.Request) {
-	rows, err := s.db.Query(`SELECT name, updated_at FROM hub_templates ORDER BY name ASC`)
+	// List from external storage first
+	names, err := listExternalTemplates()
 	if err != nil {
-		http.Error(w, "db error", http.StatusInternalServerError)
+		http.Error(w, "fs error: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
-	defer rows.Close()
+
+	// Also include legacy DB templates (for migration period)
+	rows, err := s.db.Query(`SELECT name, updated_at FROM hub_templates ORDER BY name ASC`)
+	if err == nil {
+		defer rows.Close()
+		for rows.Next() {
+			var name, updatedAt string
+			if err := rows.Scan(&name, &updatedAt); err != nil {
+				continue
+			}
+			// Deduplicate: external takes precedence
+			found := false
+			for _, n := range names {
+				if n == name {
+					found = true
+					break
+				}
+			}
+			if !found {
+				names = append(names, name)
+			}
+		}
+	}
 
 	type entry struct {
 		Name      string `json:"name"`
 		UpdatedAt string `json:"updatedAt"`
 	}
-	var out []entry
-	for rows.Next() {
-		var e entry
-		if err := rows.Scan(&e.Name, &e.UpdatedAt); err != nil {
-			continue
-		}
-		out = append(out, e)
+	out := make([]entry, len(names))
+	for i, name := range names {
+		out[i] = entry{Name: name, UpdatedAt: time.Now().UTC().Format(time.RFC3339)}
 	}
 	if out == nil {
 		out = []entry{}
@@ -91,41 +112,54 @@ func (s *Server) pushTemplate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Write to external storage
+	if err := saveExternalTemplate(body.Name, body.Files); err != nil {
+		http.Error(w, "save error: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Also write to legacy DB for backward compat during migration
 	filesJSON, _ := json.Marshal(body.Files)
 	now := time.Now().UTC()
-
-	_, err := s.db.Exec(`
+	_, _ = s.db.Exec(`
 		INSERT INTO hub_templates(name, files, created_at, updated_at)
 		VALUES(?, ?, ?, ?)
 		ON CONFLICT(name) DO UPDATE SET files=excluded.files, updated_at=excluded.updated_at`,
 		body.Name, string(filesJSON), now, now,
 	)
-	if err != nil {
-		http.Error(w, "db error: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
+
 	jsonOK(w, map[string]string{"name": body.Name})
 }
 
-// loadHubTemplate fetches a template's files from the hub DB.
-// Used by the factory engine when creating claws.
+// loadHubTemplate fetches a template's files.
+// Tries external storage first, then legacy DB.
 func (s *Server) loadHubTemplate(name string) (map[string]string, error) {
+	// External storage first
+	files, err := loadExternalTemplate(name)
+	if err == nil {
+		return files, nil
+	}
+	// Legacy DB fallback
 	var filesJSON string
-	err := s.db.QueryRow(`SELECT files FROM hub_templates WHERE name = ?`, name).Scan(&filesJSON)
+	err = s.db.QueryRow(`SELECT files FROM hub_templates WHERE name = ?`, name).Scan(&filesJSON)
 	if err != nil {
 		return nil, err
 	}
-	var files map[string]string
 	if err := json.Unmarshal([]byte(filesJSON), &files); err != nil {
 		return nil, err
 	}
 	return files, nil
 }
 
-// resolveTemplateFiles tries hub DB first, then local filesystem via config.ResolveTemplate.
+// resolveTemplateFiles tries external storage first, then legacy DB, then local filesystem.
 func (s *Server) resolveTemplateFiles(name string) (map[string]string, error) {
-	// Hub DB first (pushed via `elasticclaw template push`)
-	files, err := s.loadHubTemplate(name)
+	// External storage first
+	files, err := loadExternalTemplate(name)
+	if err == nil {
+		return files, nil
+	}
+	// Legacy DB second
+	files, err = s.loadHubTemplate(name)
 	if err == nil {
 		return files, nil
 	}

--- a/pkg/hub/templates.go
+++ b/pkg/hub/templates.go
@@ -83,13 +83,31 @@ func (s *Server) listTemplates(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Collect real updated_at timestamps from legacy DB rows
+	dbUpdatedAt := make(map[string]string)
+	rows2, err2 := s.db.Query(`SELECT name, updated_at FROM hub_templates ORDER BY name ASC`)
+	if err2 == nil {
+		defer rows2.Close()
+		for rows2.Next() {
+			var n, ts string
+			if err := rows2.Scan(&n, &ts); err == nil {
+				dbUpdatedAt[n] = ts
+			}
+		}
+	}
+
 	type entry struct {
 		Name      string `json:"name"`
 		UpdatedAt string `json:"updatedAt"`
 	}
+	now := time.Now().UTC().Format(time.RFC3339)
 	out := make([]entry, len(names))
 	for i, name := range names {
-		out[i] = entry{Name: name, UpdatedAt: time.Now().UTC().Format(time.RFC3339)}
+		ts := now
+		if v, ok := dbUpdatedAt[name]; ok && v != "" {
+			ts = v
+		}
+		out[i] = entry{Name: name, UpdatedAt: ts}
 	}
 	if out == nil {
 		out = []entry{}


### PR DESCRIPTION
…hub.yaml

Implements #145:
- Templates live in <hub_dir>/templates/* (one directory per template)
- Factories live in <hub_dir>/factories/<name>/factory.yaml (+ pipeline.yaml)
- External storage takes precedence; legacy DB/hub.yaml still read for migration
- Added migration helpers (MigrateLegacyTemplates, MigrateLegacyFactories)
- Doctor checks updated to inspect external templates for missing config files