### PR TITLE
feat: add min/max constraints for number type factory inputs

### DIFF
--- a/pkg/hub/factory_trigger.go
+++ b/pkg/hub/factory_trigger.go
@@ -103,30 +103,37 @@ func validateFactoryInputs(inputs []types.FactoryInput, values map[string]interf
 			}
 		}
 
-		// Number range validation (min / max)
-		if def.Type == "number" && (def.Min != nil || def.Max != nil) {
-			num, err := strconv.ParseFloat(str, 64)
-			if err != nil {
-				return nil, fmt.Errorf("input %q: expected number, got %q", name, str)
-			}
-			if def.Min != nil && num < float64(*def.Min) {
-				return nil, fmt.Errorf("input %q: %v is below minimum %d", name, num, *def.Min)
-			}
-			if def.Max != nil && num > float64(*def.Max) {
-				return nil, fmt.Errorf("input %q: %v is above maximum %d", name, num, *def.Max)
-			}
-		}
-
 		result[name] = str
 	}
 
-	// Apply defaults for missing optional inputs
+	// Apply defaults for missing optional inputs, then validate them too
 	for _, in := range inputs {
 		if _, ok := result[in.Name]; ok {
 			continue
 		}
 		if in.Default != "" {
 			result[in.Name] = in.Default
+		}
+	}
+
+	// Number range validation (min / max) — applied to both user values and defaults
+	for _, in := range inputs {
+		if in.Type != "number" || (in.Min == nil && in.Max == nil) {
+			continue
+		}
+		str, ok := result[in.Name]
+		if !ok || str == "" {
+			continue
+		}
+		num, err := strconv.ParseFloat(str, 64)
+		if err != nil {
+			return nil, fmt.Errorf("input %q: expected number, got %q", in.Name, str)
+		}
+		if in.Min != nil && num < *in.Min {
+			return nil, fmt.Errorf("input %q: %v is below minimum %v", in.Name, num, *in.Min)
+		}
+		if in.Max != nil && num > *in.Max {
+			return nil, fmt.Errorf("input %q: %v is above maximum %v", in.Name, num, *in.Max)
 		}
 	}
 

--- a/pkg/hub/factory_trigger.go
+++ b/pkg/hub/factory_trigger.go
@@ -103,6 +103,20 @@ func validateFactoryInputs(inputs []types.FactoryInput, values map[string]interf
 			}
 		}
 
+		// Number range validation (min / max)
+		if def.Type == "number" && (def.Min != nil || def.Max != nil) {
+			num, err := strconv.ParseFloat(str, 64)
+			if err != nil {
+				return nil, fmt.Errorf("input %q: expected number, got %q", name, str)
+			}
+			if def.Min != nil && num < float64(*def.Min) {
+				return nil, fmt.Errorf("input %q: %v is below minimum %d", name, num, *def.Min)
+			}
+			if def.Max != nil && num > float64(*def.Max) {
+				return nil, fmt.Errorf("input %q: %v is above maximum %d", name, num, *def.Max)
+			}
+		}
+
 		result[name] = str
 	}
 
@@ -148,6 +162,7 @@ func coerceInput(typ string, raw interface{}) (string, error) {
 		default:
 			return "", fmt.Errorf("expected number, got %T", raw)
 		}
+		// unreachable — all branches above return
 	case "bool":
 		switch v := raw.(type) {
 		case bool:

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -402,6 +402,8 @@ type FactoryInput struct {
 	Description string   `yaml:"description,omitempty" json:"description,omitempty"`
 	Options     []string `yaml:"options,omitempty" json:"options,omitempty"`       // for enum type
 	Validation  string   `yaml:"validation,omitempty" json:"validation,omitempty"` // regex pattern
+	Min         *int     `yaml:"min,omitempty" json:"min,omitempty"`             // inclusive minimum for number type
+	Max         *int     `yaml:"max,omitempty" json:"max,omitempty"`             // inclusive maximum for number type
 }
 
 // ConcurrencyGroup limits the number of simultaneously running claws per group.

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -402,8 +402,8 @@ type FactoryInput struct {
 	Description string   `yaml:"description,omitempty" json:"description,omitempty"`
 	Options     []string `yaml:"options,omitempty" json:"options,omitempty"`       // for enum type
 	Validation  string   `yaml:"validation,omitempty" json:"validation,omitempty"` // regex pattern
-	Min         *int     `yaml:"min,omitempty" json:"min,omitempty"`             // inclusive minimum for number type
-	Max         *int     `yaml:"max,omitempty" json:"max,omitempty"`             // inclusive maximum for number type
+	Min         *float64 `yaml:"min,omitempty" json:"min,omitempty"`             // inclusive minimum for number type
+	Max         *float64 `yaml:"max,omitempty" json:"max,omitempty"`             // inclusive maximum for number type
 }
 
 // ConcurrencyGroup limits the number of simultaneously running claws per group.

--- a/web/components/manual-trigger-modal.tsx
+++ b/web/components/manual-trigger-modal.tsx
@@ -67,6 +67,12 @@ export function ManualTriggerModal({ open, onOpenChange, factory, onClawCreated 
             if (val !== undefined && val !== "") {
               const num = parseFloat(val)
               if (isNaN(num)) throw new Error(`Invalid number for "${input.name}"`)
+              if (input.min !== undefined && num < input.min) {
+                throw new Error(`${input.name} must be at least ${input.min}`)
+              }
+              if (input.max !== undefined && num > input.max) {
+                throw new Error(`${input.name} must be at most ${input.max}`)
+              }
               inputs[input.name] = num
             }
           } else {

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -238,6 +238,8 @@ export interface FactoryInput {
   description?: string
   options?: string[]
   validation?: string
+  min?: number
+  max?: number
 }
 
 // Factory matches FactoryPushView from GET /api/factories.


### PR DESCRIPTION
Adds optional `min` and `max` fields to factory input definitions for number types. Both client-side (modal validation) and server-side (trigger API) enforcement included.

Example usage in factory.yaml:
```yaml
inputs:
  - name: pr_number
    type: number
    required: true
    min: 1
    description: PR number to review
```