### PR TITLE
fix: add webhooks to settings static export whitelist

### DIFF
--- a/web/app/settings/[section]/page.tsx
+++ b/web/app/settings/[section]/page.tsx
@@ -1,6 +1,6 @@
 import SettingsSectionPage from "./settings-content"
 
-const VALID_SECTIONS = ["runtimes", "models", "github", "authentication", "issue-trackers", "factories", "secrets", "mcp-servers", "templates", "ai-config"]
+const VALID_SECTIONS = ["runtimes", "models", "github", "authentication", "issue-trackers", "factories", "secrets", "mcp-servers", "templates", "ai-config", "webhooks", "doctor"]
 
 export function generateStaticParams() {
   return VALID_SECTIONS.map((section) => ({ section }))


### PR DESCRIPTION
The /settings/webhooks page was missing from the generateStaticParams whitelist, causing it to render the dashboard fallback in static export builds instead of the actual webhooks settings page.