### PR TITLE
fix: delete sandbox provider when remove is clicked in settings

### DIFF
--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -297,6 +297,8 @@ type ProviderPatch struct {
 	Token               string `json:"token,omitempty"`
 	DefaultTTL          string `json:"defaultTtl,omitempty"`
 	DefaultInstanceType string `json:"defaultInstanceType,omitempty"`
+	// Delete removes this provider when true.
+	Delete bool `json:"delete,omitempty"`
 }
 
 type GitHubAppPatch struct {
@@ -730,6 +732,10 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 			updatedCfg.Providers = newProviders
 		}
 		for name, pp := range patch.Providers {
+			if pp.Delete {
+				delete(updatedCfg.Providers, name)
+				continue
+			}
 			existing := updatedCfg.Providers[name]
 			switch name {
 			case "daytona":

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -420,7 +420,7 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
   }
 
   function doRemove(name: string) {
-    onSave({ providers: { [name]: null } })
+    onSave({ providers: { [name]: { delete: true } } })
     setShowModal(false)
     resetForm()
   }


### PR DESCRIPTION
The settings page sent `{ providers: { [name]: null } }` when removing a sandbox provider, but the backend never handled deletion — it only upserted fields. The provider stayed in the config and kept showing in the UI.

Changes:
- Backend: add `Delete bool` to `ProviderPatch` and handle it in `patchSettings` by removing from the map
- Frontend: send `{ providers: { [name]: { delete: true } } }` instead of `null`

Fixes: removing daytona/replicated providers from settings now actually deletes them.