### PR TITLE
fix: enforce min/max constraints on number inputs in manual trigger modal

### DIFF
--- a/web/components/manual-trigger-modal.tsx
+++ b/web/components/manual-trigger-modal.tsx
@@ -85,8 +85,9 @@ export function ManualTriggerModal({ open, onOpenChange, factory, onClawCreated 
       onOpenChange(false)
       onClawCreated?.(res.claw_id)
     } catch (e) {
-      setTriggerError(String(e))
       setTriggering(false)
+      // Keep modal open so user sees the backend validation error
+      setTriggerError(e instanceof Error ? e.message : String(e))
     }
   }, [factory, inputValues, onOpenChange, onClawCreated])
 
@@ -196,6 +197,8 @@ function FactoryInputField({
           value={value || ""}
           onChange={(e) => onChange(e.target.value)}
           placeholder={input.default}
+          min={input.type === "number" ? input.min : undefined}
+          max={input.type === "number" ? input.max : undefined}
         />
       )}
     </div>

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -87,7 +87,15 @@ async function apiFetch<T>(path: string, options?: RequestInit): Promise<T> {
     throw new Error("session expired")
   }
   if (!res.ok) {
-    throw new Error(`API error ${res.status}: ${await res.text()}`)
+    const body = await res.text()
+    let message = body
+    try {
+      const parsed = JSON.parse(body)
+      if (typeof parsed.message === "string") message = parsed.message
+      if (typeof parsed.error === "string") message = parsed.error
+    } catch { /* not JSON */ }
+    if (!message) message = `API error ${res.status}`
+    throw new Error(message)
   }
   if (res.status === 204) return undefined as T
   return res.json()


### PR DESCRIPTION
The manual trigger modal already validated min/max in JavaScript before submit, but the HTML `<input type="number">` itself didn't have `min`/`max` attributes, so browsers let users type or step outside the valid range. This adds native HTML constraint attributes so the browser prevents invalid values at the input level.