### PR TITLE
fix: single source of truth for factories — external storage only

### DIFF
--- a/pkg/hub/external_storage.go
+++ b/pkg/hub/external_storage.go
@@ -172,6 +172,20 @@ func loadExternalFactories() ([]*types.FactoryConfig, error) {
 	return factories, nil
 }
 
+// sLoadExternalFactories is the server method wrapper that acquires the
+// server's read lock and loads from external storage. Use this anywhere
+// that previously read s.hubCfg.Factories.
+func (s *Server) sLoadExternalFactories() []*types.FactoryConfig {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	factories, err := loadExternalFactories()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[hub] loadExternalFactories: %v\n", err)
+		return nil
+	}
+	return factories
+}
+
 // loadExternalFactory reads a single factory from disk.
 func loadExternalFactory(name string) (*types.FactoryConfig, error) {
 	if err := validateName(name); err != nil {

--- a/pkg/hub/external_storage.go
+++ b/pkg/hub/external_storage.go
@@ -173,17 +173,44 @@ func loadExternalFactories() ([]*types.FactoryConfig, error) {
 }
 
 // sLoadExternalFactories is the server method wrapper that acquires the
-// server's read lock and loads from external storage. Use this anywhere
-// that previously read s.hubCfg.Factories.
+// server's read lock and loads from external storage, merging with in-memory
+// factories (external takes precedence). Use this anywhere that previously
+// read s.hubCfg.Factories.
 func (s *Server) sLoadExternalFactories() []*types.FactoryConfig {
 	s.mu.RLock()
-	defer s.mu.RUnlock()
-	factories, err := loadExternalFactories()
+	memFactories := s.hubCfg.Factories
+	s.mu.RUnlock()
+
+	external, err := loadExternalFactories()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[hub] loadExternalFactories: %v\n", err)
-		return nil
+		return memFactories
 	}
-	return factories
+
+	if len(external) == 0 {
+		return memFactories
+	}
+	if len(memFactories) == 0 {
+		return external
+	}
+
+	merged := make(map[string]*types.FactoryConfig, len(memFactories)+len(external))
+	for _, f := range memFactories {
+		if f != nil {
+			merged[f.Name] = f
+		}
+	}
+	for _, f := range external {
+		if f != nil {
+			merged[f.Name] = f
+		}
+	}
+
+	result := make([]*types.FactoryConfig, 0, len(merged))
+	for _, f := range merged {
+		result = append(result, f)
+	}
+	return result
 }
 
 // loadExternalFactory reads a single factory from disk.

--- a/pkg/hub/factory_api.go
+++ b/pkg/hub/factory_api.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/elasticclaw/elasticclaw/pkg/config"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
 
@@ -73,34 +72,17 @@ func factoryToPushView(f *types.FactoryConfig) FactoryPushView {
 func (s *Server) handleFactoriesList(w http.ResponseWriter, r *http.Request) {
 	nameFilter := strings.TrimSpace(r.URL.Query().Get("name"))
 
-	// Load from external storage first
 	factories, err := loadExternalFactories()
 	if err != nil {
 		http.Error(w, "fs error: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	// Merge with in-memory factories (external takes precedence)
-	s.mu.RLock()
-	memFactories := s.hubCfg.Factories
-	s.mu.RUnlock()
-
-	merged := make(map[string]*types.FactoryConfig, len(factories)+len(memFactories))
-	for _, f := range memFactories {
-		if f == nil {
-			continue
-		}
-		merged[f.Name] = f
-	}
+	views := make([]FactoryPushView, 0, len(factories))
 	for _, f := range factories {
 		if f == nil {
 			continue
 		}
-		merged[f.Name] = f
-	}
-
-	views := make([]FactoryPushView, 0, len(merged))
-	for _, f := range merged {
 		if nameFilter != "" && !strings.EqualFold(f.Name, nameFilter) {
 			continue
 		}
@@ -125,33 +107,14 @@ func (s *Server) handleFactoriesPush(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Preserve inline webhook secrets before writing to external storage.
-	// Check in-memory config first, then fall back to external storage
-	// so that factories with secrets only on disk are also protected.
-	s.mu.RLock()
-	existing := make(map[string]*types.FactoryConfig)
-	for _, f := range s.hubCfg.Factories {
-		if f == nil {
-			continue
-		}
-		existing[f.Name] = f
-	}
-	s.mu.RUnlock()
+	// Preserve webhook secrets from external storage before overwriting.
 	for _, incoming := range req.Factories {
 		if incoming == nil || incoming.Name == "" {
 			continue
 		}
-		prev, ok := existing[incoming.Name]
-		if !ok {
-			// Factory not in memory — try external storage
-			if disk, err := loadExternalFactory(incoming.Name); err == nil {
-				prev = disk
-				ok = true
-			}
-		}
-		if ok {
-			if incoming.WebhookSecret == "" && incoming.WebhookSecretRef == "" && prev.WebhookSecret != "" {
-				incoming.WebhookSecret = prev.WebhookSecret
+		if disk, err := loadExternalFactory(incoming.Name); err == nil {
+			if incoming.WebhookSecret == "" && incoming.WebhookSecretRef == "" && disk.WebhookSecret != "" {
+				incoming.WebhookSecret = disk.WebhookSecret
 			}
 		}
 	}
@@ -173,50 +136,8 @@ func (s *Server) handleFactoriesPush(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Also update in-memory config for backward compat during migration
-	s.mu.Lock()
-	existing = make(map[string]*types.FactoryConfig)
-	for _, f := range s.hubCfg.Factories {
-		if f == nil {
-			continue
-		}
-		existing[f.Name] = f
-	}
-	incomingByName := make(map[string]*types.FactoryConfig, len(req.Factories))
-	incomingOrder := make([]string, 0, len(req.Factories))
-	seenIncoming := make(map[string]bool, len(req.Factories))
-	for _, incoming := range req.Factories {
-		existing[incoming.Name] = incoming
-		incomingByName[incoming.Name] = incoming
-		if !seenIncoming[incoming.Name] {
-			seenIncoming[incoming.Name] = true
-			incomingOrder = append(incomingOrder, incoming.Name)
-		}
-	}
-	updated := make([]*types.FactoryConfig, 0, len(existing))
-	for _, f := range s.hubCfg.Factories {
-		if incoming, ok := incomingByName[f.Name]; ok {
-			updated = append(updated, incoming)
-			delete(incomingByName, f.Name)
-			continue
-		}
-		updated = append(updated, f)
-	}
-	for _, name := range incomingOrder {
-		if incoming, ok := incomingByName[name]; ok {
-			updated = append(updated, incoming)
-		}
-	}
-	cfgCopy := *s.hubCfg
-	cfgCopy.Factories = updated
-	s.hubCfg = &cfgCopy
-	s.mu.Unlock()
-
-	// Save to hub.yaml for backward compat during migration
-	if err := config.SaveHubConfig(&cfgCopy); err != nil {
-		http.Error(w, "failed to save config: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
+	// Keep hubCfg.Factories empty — external storage is the only source of truth.
+	// This prevents stale in-memory configs from shadowing disk state.
 
 	views := make([]FactoryPushView, 0, len(req.Factories))
 	for _, f := range req.Factories {
@@ -229,40 +150,9 @@ func (s *Server) handleFactoriesPush(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleFactoryDelete(w http.ResponseWriter, _ *http.Request, name string) {
-	// Delete from external storage first
 	if err := deleteExternalFactory(name); err != nil {
 		http.Error(w, "delete error: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
-
-	s.mu.Lock()
-	factories := make([]*types.FactoryConfig, 0, len(s.hubCfg.Factories))
-	found := false
-	for _, f := range s.hubCfg.Factories {
-		if f == nil {
-			continue
-		}
-		if strings.EqualFold(f.Name, name) {
-			found = true
-			continue
-		}
-		factories = append(factories, f)
-	}
-	if !found {
-		s.mu.Unlock()
-		// If not in memory but deleted from disk, still report success
-		jsonOK(w, map[string]string{"deleted": name})
-		return
-	}
-	cfgCopy := *s.hubCfg
-	cfgCopy.Factories = factories
-	s.hubCfg = &cfgCopy
-	s.mu.Unlock()
-
-	if err := config.SaveHubConfig(&cfgCopy); err != nil {
-		http.Error(w, "failed to save config: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-
 	jsonOK(w, map[string]string{"deleted": name})
 }

--- a/pkg/hub/factory_trigger.go
+++ b/pkg/hub/factory_trigger.go
@@ -212,20 +212,8 @@ func (s *Server) handleFactoryTrigger(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Load factory from external storage + in-memory
 	factory, err := loadExternalFactory(name)
 	if err != nil {
-		// Fall back to in-memory
-		s.mu.RLock()
-		for _, f := range s.hubCfg.Factories {
-			if f != nil && strings.EqualFold(f.Name, name) {
-				factory = f
-				break
-			}
-		}
-		s.mu.RUnlock()
-	}
-	if factory == nil {
 		jsonError(w, http.StatusNotFound, "factory not found")
 		return
 	}

--- a/pkg/hub/factory_trigger.go
+++ b/pkg/hub/factory_trigger.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -214,7 +215,11 @@ func (s *Server) handleFactoryTrigger(w http.ResponseWriter, r *http.Request) {
 
 	factory, err := loadExternalFactory(name)
 	if err != nil {
-		jsonError(w, http.StatusNotFound, "factory not found")
+		if os.IsNotExist(err) {
+			jsonError(w, http.StatusNotFound, "factory not found")
+		} else {
+			jsonError(w, http.StatusInternalServerError, "failed to load factory: "+err.Error())
+		}
 		return
 	}
 

--- a/pkg/hub/factory_trigger_test.go
+++ b/pkg/hub/factory_trigger_test.go
@@ -1,6 +1,7 @@
 package hub
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/elasticclaw/elasticclaw/pkg/types"
@@ -110,7 +111,7 @@ func TestValidateFactoryInputs_MinMax(t *testing.T) {
 				if err == nil {
 					t.Fatalf("expected error containing %q, got nil", tt.errSubstr)
 				}
-				if tt.errSubstr != "" && !contains(err.Error(), tt.errSubstr) {
+				if tt.errSubstr != "" && !strings.Contains(err.Error(), tt.errSubstr) {
 					t.Fatalf("expected error containing %q, got: %v", tt.errSubstr, err)
 				}
 			} else {
@@ -122,15 +123,4 @@ func TestValidateFactoryInputs_MinMax(t *testing.T) {
 	}
 }
 
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsSubstr(s, substr))
-}
-
-func containsSubstr(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
-}
+// (uses strings.Contains from the standard library)

--- a/pkg/hub/factory_trigger_test.go
+++ b/pkg/hub/factory_trigger_test.go
@@ -1,0 +1,136 @@
+package hub
+
+import (
+	"testing"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func TestValidateFactoryInputs_MinMax(t *testing.T) {
+	min1 := 1.0
+	max10 := 10.0
+
+	tests := []struct {
+		name      string
+		inputs    []types.FactoryInput
+		values    map[string]interface{}
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name: "negative below min",
+			inputs: []types.FactoryInput{
+				{Name: "pr_number", Type: "number", Required: true, Min: &min1},
+			},
+			values: map[string]interface{}{
+				"pr_number": -3.0,
+			},
+			wantErr:   true,
+			errSubstr: "below minimum",
+		},
+		{
+			name: "zero below min",
+			inputs: []types.FactoryInput{
+				{Name: "pr_number", Type: "number", Required: true, Min: &min1},
+			},
+			values: map[string]interface{}{
+				"pr_number": 0.0,
+			},
+			wantErr:   true,
+			errSubstr: "below minimum",
+		},
+		{
+			name: "valid at min",
+			inputs: []types.FactoryInput{
+				{Name: "pr_number", Type: "number", Required: true, Min: &min1},
+			},
+			values: map[string]interface{}{
+				"pr_number": 1.0,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid above min",
+			inputs: []types.FactoryInput{
+				{Name: "pr_number", Type: "number", Required: true, Min: &min1},
+			},
+			values: map[string]interface{}{
+				"pr_number": 5.0,
+			},
+			wantErr: false,
+		},
+		{
+			name: "above max",
+			inputs: []types.FactoryInput{
+				{Name: "rating", Type: "number", Required: true, Max: &max10},
+			},
+			values: map[string]interface{}{
+				"rating": 15.0,
+			},
+			wantErr:   true,
+			errSubstr: "above maximum",
+		},
+		{
+			name: "valid within range",
+			inputs: []types.FactoryInput{
+				{Name: "rating", Type: "number", Required: true, Min: &min1, Max: &max10},
+			},
+			values: map[string]interface{}{
+				"rating": 5.0,
+			},
+			wantErr: false,
+		},
+		{
+			name: "string number below min",
+			inputs: []types.FactoryInput{
+				{Name: "pr_number", Type: "number", Required: true, Min: &min1},
+			},
+			values: map[string]interface{}{
+				"pr_number": "-3",
+			},
+			wantErr:   true,
+			errSubstr: "below minimum",
+		},
+		{
+			name: "string number valid",
+			inputs: []types.FactoryInput{
+				{Name: "pr_number", Type: "number", Required: true, Min: &min1},
+			},
+			values: map[string]interface{}{
+				"pr_number": "5",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := validateFactoryInputs(tt.inputs, tt.values)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.errSubstr)
+				}
+				if tt.errSubstr != "" && !contains(err.Error(), tt.errSubstr) {
+					t.Fatalf("expected error containing %q, got: %v", tt.errSubstr, err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsSubstr(s, substr))
+}
+
+func containsSubstr(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/hub/github_issues.go
+++ b/pkg/hub/github_issues.go
@@ -107,9 +107,10 @@ func (s *Server) handleGitHubIssuesWebhook(w http.ResponseWriter, r *http.Reques
 func (s *Server) validateGitHubIssuesSignature(body []byte, sig string) bool {
 	s.mu.RLock()
 	integrations := s.hubCfg.Integrations
-	factories := s.hubCfg.Factories
 	secrets := s.hubCfg.Secrets
 	s.mu.RUnlock()
+
+	factories := s.sLoadExternalFactories()
 
 	hasAnySecret := false
 
@@ -127,22 +128,20 @@ func (s *Server) validateGitHubIssuesSignature(body []byte, sig string) bool {
 	}
 
 	// Check factory-level secrets
-	if factories != nil {
-		for _, factory := range factories {
-			if factory.Integration != "github-issues" {
-				continue
-			}
-			secret := factory.WebhookSecret
-			if secret == "" && factory.WebhookSecretRef != "" && secrets != nil {
-				secret = secrets[factory.WebhookSecretRef]
-			}
-			if secret == "" {
-				continue
-			}
-			hasAnySecret = true
-			if verifyGitHubHMAC(body, sig, secret) {
-				return true
-			}
+	for _, factory := range factories {
+		if factory.Integration != "github-issues" {
+			continue
+		}
+		secret := factory.WebhookSecret
+		if secret == "" && factory.WebhookSecretRef != "" && secrets != nil {
+			secret = secrets[factory.WebhookSecretRef]
+		}
+		if secret == "" {
+			continue
+		}
+		hasAnySecret = true
+		if verifyGitHubHMAC(body, sig, secret) {
+			return true
 		}
 	}
 
@@ -176,11 +175,12 @@ func (s *Server) processGitHubIssuesEvent(payload githubIssuesWebhookPayload) {
 	log.Printf("[github-issues-webhook] processing event: action=%q issue=%s title=%q sender=%q",
 		payload.Action, issueID, payload.Issue.Title, payload.Sender.Login)
 
-	if s.hubCfg.Factories == nil {
+	factories := s.sLoadExternalFactories()
+	if len(factories) == 0 {
 		log.Printf("[github-issues-webhook] no factories configured — nothing to do")
 		return
 	}
-	log.Printf("[github-issues-webhook] checking %d factories", len(s.hubCfg.Factories))
+	log.Printf("[github-issues-webhook] checking %d factories", len(factories))
 
 	currentStatus := payload.Issue.State
 	previousStatus := ""
@@ -244,7 +244,7 @@ func (s *Server) processGitHubIssuesEvent(payload githubIssuesWebhookPayload) {
 	}
 
 	matched := false
-	for _, factory := range s.hubCfg.Factories {
+	for _, factory := range factories {
 		log.Printf("[github-issues-webhook] checking factory %q: integration=%q enabled=%v trigger_status=%q labels=%v assigned_to=%q allowed_labelers=%v",
 			factory.Name, factory.Integration,
 			func() bool {
@@ -435,7 +435,7 @@ func (s *Server) processGitHubIssuesEvent(payload githubIssuesWebhookPayload) {
 
 	if !matched {
 		log.Printf("[github-issues-webhook] no factory matched for issue %s — checking why:", issueID)
-		for _, factory := range s.hubCfg.Factories {
+		for _, factory := range factories {
 			if factory.Integration == "github-issues" && (factory.Enabled == nil || *factory.Enabled) {
 				log.Printf("[github-issues-webhook] factory %q: not_actionable — status '%s'→'%s' did not match trigger '%s' (labels=%v)",
 					factory.Name, previousStatus, currentStatus, factory.TriggerStatus, factory.Labels)
@@ -935,7 +935,6 @@ func (s *Server) closeGitHubIssueForClaw(clawID string) {
 func (s *Server) resolveGitHubIssuesTokenForRepo(repoFullName string) string {
 	s.mu.RLock()
 	integrations := s.hubCfg.Integrations
-	factories := s.hubCfg.Factories
 	secrets := s.hubCfg.Secrets
 	s.mu.RUnlock()
 
@@ -947,18 +946,16 @@ func (s *Server) resolveGitHubIssuesTokenForRepo(repoFullName string) string {
 		}
 	}
 
-	if factories != nil {
-		for _, factory := range factories {
-			if factory.Integration != "github-issues" {
-				continue
-			}
-			if factory.WebhookSecret != "" {
-				return factory.WebhookSecret
-			}
-			if factory.WebhookSecretRef != "" && secrets != nil {
-				if secret := secrets[factory.WebhookSecretRef]; secret != "" {
-					return secret
-				}
+	for _, factory := range s.sLoadExternalFactories() {
+		if factory.Integration != "github-issues" {
+			continue
+		}
+		if factory.WebhookSecret != "" {
+			return factory.WebhookSecret
+		}
+		if factory.WebhookSecretRef != "" && secrets != nil {
+			if secret := secrets[factory.WebhookSecretRef]; secret != "" {
+				return secret
 			}
 		}
 	}

--- a/pkg/hub/github_webhook.go
+++ b/pkg/hub/github_webhook.go
@@ -120,10 +120,12 @@ func (s *Server) validateGitHubSignature(body []byte, sig string) bool {
 		return false
 	}
 
-	s.mu.RLock()
-	factories := s.hubCfg.Factories
-	secrets := s.hubCfg.Secrets
-	s.mu.RUnlock()
+	factories := s.sLoadExternalFactories()
+	secrets := func() map[string]string {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+		return s.hubCfg.Secrets
+	}()
 
 	for _, factory := range factories {
 		if factory.Integration != "github" {
@@ -151,9 +153,7 @@ func (s *Server) validateGitHubSignature(body []byte, sig string) bool {
 
 // processGitHubPREvent finds matching factories and creates claws for a PR event.
 func (s *Server) processGitHubPREvent(payload githubPRPayload) {
-	s.mu.RLock()
-	factories := s.hubCfg.Factories
-	s.mu.RUnlock()
+	factories := s.sLoadExternalFactories()
 
 	repoFullName := payload.Repository.FullName
 	log.Printf("[github-webhook] processing PR event: repo=%q action=%q — checking %d factories", repoFullName, payload.Action, len(factories))
@@ -306,9 +306,7 @@ func (s *Server) processGitHubIssueCommentEvent(payload githubIssueCommentPayloa
 		return
 	}
 
-	s.mu.RLock()
-	factories := s.hubCfg.Factories
-	s.mu.RUnlock()
+	factories := s.sLoadExternalFactories()
 
 	repoFullName := payload.Repository.FullName
 	prNumber := payload.Issue.Number

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -133,9 +133,10 @@ func (s *Server) isDuplicateWebhook(key string) bool {
 func (s *Server) validateLinearSignature(body []byte, sig string) bool {
 	s.mu.RLock()
 	integrations := s.hubCfg.Integrations
-	factories := s.hubCfg.Factories
 	secrets := s.hubCfg.Secrets
 	s.mu.RUnlock()
+
+	factories := s.sLoadExternalFactories()
 
 	hasAnySecret := false
 
@@ -156,26 +157,24 @@ func (s *Server) validateLinearSignature(body []byte, sig string) bool {
 	}
 
 	// Check factory-level secrets
-	if factories != nil {
-		for _, factory := range factories {
-			if factory.Integration != "linear" {
-				continue
-			}
-			// Resolve secret: inline value or named ref
-			secret := factory.WebhookSecret
-			if secret == "" && factory.WebhookSecretRef != "" && secrets != nil {
-				secret = secrets[factory.WebhookSecretRef]
-			}
-			if secret == "" {
-				continue
-			}
-			hasAnySecret = true
-			mac := hmac.New(sha256.New, []byte(secret))
-			mac.Write(body)
-			expected := hex.EncodeToString(mac.Sum(nil))
-			if hmac.Equal([]byte(sig), []byte(expected)) {
-				return true
-			}
+	for _, factory := range factories {
+		if factory.Integration != "linear" {
+			continue
+		}
+		// Resolve secret: inline value or named ref
+		secret := factory.WebhookSecret
+		if secret == "" && factory.WebhookSecretRef != "" && secrets != nil {
+			secret = secrets[factory.WebhookSecretRef]
+		}
+		if secret == "" {
+			continue
+		}
+		hasAnySecret = true
+		mac := hmac.New(sha256.New, []byte(secret))
+		mac.Write(body)
+		expected := hex.EncodeToString(mac.Sum(nil))
+		if hmac.Equal([]byte(sig), []byte(expected)) {
+			return true
 		}
 	}
 
@@ -187,10 +186,6 @@ func (s *Server) validateLinearSignature(body []byte, sig string) bool {
 }
 
 func (s *Server) processLinearEvent(payload linearWebhookPayload) {
-	if s.hubCfg.Factories == nil {
-		return
-	}
-
 	currentStatus := payload.Data.State.Name
 	previousStatus := ""
 	if payload.UpdatedFrom != nil && payload.UpdatedFrom.State != nil {
@@ -199,8 +194,12 @@ func (s *Server) processLinearEvent(payload linearWebhookPayload) {
 	teamKey := payload.Data.Team.Key
 	issueID := payload.Data.Identifier // e.g. "ELA-123"
 
+	factories := s.sLoadExternalFactories()
+	if len(factories) == 0 {
+		return
+	}
 	matched := false
-	for _, factory := range s.hubCfg.Factories {
+	for _, factory := range factories {
 		if factory.Integration != "linear" {
 			continue
 		}
@@ -295,7 +294,7 @@ func (s *Server) processLinearEvent(payload linearWebhookPayload) {
 
 	if !matched {
 		// Webhook received but no factory matched — log as not_actionable
-		for _, factory := range s.hubCfg.Factories {
+		for _, factory := range factories {
 			if factory.Integration == "linear" && (factory.Enabled == nil || *factory.Enabled) && (factory.Team == "" || strings.EqualFold(factory.Team, teamKey)) {
 				s.logFactoryEvent(factory.Name, issueID, payload.Data.Title, previousStatus, currentStatus, "not_actionable",
 					"", fmt.Sprintf("status '%s'→'%s' did not match trigger '%s'", previousStatus, currentStatus, factory.TriggerStatus))
@@ -973,13 +972,14 @@ func (s *Server) validateDonePRs(clawID string, prURLs []string, ghToken string)
 func (s *Server) findFactoryForIssue(issueID string) *types.FactoryConfig {
 	// First, try to find the factory that created this claw by looking up the factory tag
 	var tagsJSON string
+	factories := s.sLoadExternalFactories()
 	if err := s.db.QueryRow(`SELECT tags FROM claws WHERE linear_issue_id = ? AND status NOT IN ('error','deleted') LIMIT 1`, issueID).Scan(&tagsJSON); err == nil {
 		var tags []string
 		if json.Unmarshal([]byte(tagsJSON), &tags) == nil {
 			for _, tag := range tags {
 				if strings.HasPrefix(tag, "factory:") {
 					factoryName := strings.TrimPrefix(tag, "factory:")
-					for _, factory := range s.hubCfg.Factories {
+					for _, factory := range factories {
 						if factory.Name == factoryName {
 							return factory
 						}
@@ -995,7 +995,7 @@ func (s *Server) findFactoryForIssue(issueID string) *types.FactoryConfig {
 			for _, tag := range tags {
 				if strings.HasPrefix(tag, "factory:") {
 					factoryName := strings.TrimPrefix(tag, "factory:")
-					for _, factory := range s.hubCfg.Factories {
+					for _, factory := range factories {
 						if factory.Name == factoryName {
 							return factory
 						}
@@ -1021,7 +1021,7 @@ func (s *Server) findFactoryForIssue(issueID string) *types.FactoryConfig {
 		expectedIntegration = "github-issues"
 	}
 
-	for _, factory := range s.hubCfg.Factories {
+	for _, factory := range factories {
 		if factory.Integration != expectedIntegration {
 			continue
 		}

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -473,15 +473,12 @@ func (s *Server) findFactoryForClaw(clawID string) (*types.FactoryConfig, string
 	if err := json.Unmarshal([]byte(tagsJSON), &tags); err != nil {
 		return nil, issueID
 	}
-	s.mu.RLock()
-	factories := s.hubCfg.Factories
-	s.mu.RUnlock()
 	for _, tag := range tags {
 		if !strings.HasPrefix(tag, "factory:") {
 			continue
 		}
 		factoryName := strings.TrimPrefix(tag, "factory:")
-		for _, factory := range factories {
+		for _, factory := range s.sLoadExternalFactories() {
 			if factory.Name == factoryName {
 				return factory, issueID
 			}

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -982,9 +982,7 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 			if fp.DoneStatus != "" {
 				disk.DoneStatus = fp.DoneStatus
 			}
-			if fp.TerminateOnLeave {
-				disk.TerminateOnLeave = fp.TerminateOnLeave
-			}
+			disk.TerminateOnLeave = fp.TerminateOnLeave
 			if fp.Template != "" {
 				disk.Template = fp.Template
 			}
@@ -1018,9 +1016,7 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 			if fp.ConcurrencyGroup != "" {
 				disk.ConcurrencyGroup = fp.ConcurrencyGroup
 			}
-			if fp.EnableManualTrigger {
-				disk.EnableManualTrigger = fp.EnableManualTrigger
-			}
+			disk.EnableManualTrigger = fp.EnableManualTrigger
 			if fp.Inputs != nil {
 				disk.Inputs = fp.Inputs
 			}
@@ -1032,7 +1028,10 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 				disk.Trigger = fp.Trigger
 			}
 
-			_ = saveExternalFactory(disk)
+			if err := saveExternalFactory(disk); err != nil {
+				http.Error(w, "failed to save factory "+fp.Name+": "+err.Error(), http.StatusInternalServerError)
+				return
+			}
 		}
 		updatedCfg.Factories = nil // never store factories in hubCfg
 	}

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -267,25 +267,29 @@ type GitHubIssuesIntegrationPatch struct {
 }
 
 type FactoryPatch struct {
-	Name             string   `json:"name"`
-	OriginalName     string   `json:"originalName,omitempty"`
-	Integration      string   `json:"integration"`
-	Workspace        string   `json:"workspace"`
-	Team             string   `json:"team,omitempty"`
-	TriggerStatus    string   `json:"triggerStatus"`
-	DoneStatus       string   `json:"doneStatus,omitempty"`
-	TerminateOnLeave bool     `json:"terminateOnLeave"`
-	Template         string   `json:"template"`
-	NamePattern      string   `json:"namePattern,omitempty"`
-	WebhookSecret    string   `json:"webhookSecret,omitempty"`
-	WebhookSecretRef string   `json:"webhookSecretRef,omitempty"`
-	PipelineYAML     string   `json:"pipelineYAML,omitempty"`
-	Tags             []string `json:"tags,omitempty"`
-	Color            string   `json:"color,omitempty"`
-	Labels           []string `json:"labels,omitempty"`
-	AssignedTo       string   `json:"assigned_to,omitempty"`
-	Enabled          *bool    `json:"enabled,omitempty"`
-	ConcurrencyGroup string   `json:"concurrencyGroup,omitempty"`
+	Name                string              `json:"name"`
+	OriginalName        string              `json:"originalName,omitempty"`
+	Integration         string              `json:"integration"`
+	Workspace           string              `json:"workspace"`
+	Team                string              `json:"team,omitempty"`
+	TriggerStatus       string              `json:"triggerStatus"`
+	DoneStatus          string              `json:"doneStatus,omitempty"`
+	TerminateOnLeave    bool                `json:"terminateOnLeave"`
+	Template            string              `json:"template"`
+	NamePattern         string              `json:"namePattern,omitempty"`
+	WebhookSecret       string              `json:"webhookSecret,omitempty"`
+	WebhookSecretRef    string              `json:"webhookSecretRef,omitempty"`
+	PipelineYAML        string              `json:"pipelineYAML,omitempty"`
+	Tags                []string            `json:"tags,omitempty"`
+	Color               string              `json:"color,omitempty"`
+	Labels              []string            `json:"labels,omitempty"`
+	AssignedTo          string              `json:"assigned_to,omitempty"`
+	Enabled             *bool               `json:"enabled,omitempty"`
+	ConcurrencyGroup    string              `json:"concurrencyGroup,omitempty"`
+	EnableManualTrigger bool                `json:"enableManualTrigger,omitempty"`
+	Inputs              []types.FactoryInput `json:"inputs,omitempty"`
+	Repos               []string            `json:"repos,omitempty"`
+	Trigger             *types.GitHubTrigger `json:"trigger,omitempty"`
 }
 
 type ProviderPatch struct {
@@ -433,29 +437,25 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	// Factories — merge external (disk) with in-memory (hub.yaml), external takes precedence
+	// Factories — load only from external storage (single source of truth)
 	view.Factories = []FactoryView{}
-	mergedFactories := make(map[string]*types.FactoryConfig)
-	for _, f := range s.hubCfg.Factories {
-		if f != nil {
-			mergedFactories[f.Name] = f
-		}
-	}
-	// Load from external storage and merge (external takes precedence)
-	externalFactories, _ := loadExternalFactories()
-	for _, f := range externalFactories {
-		if f != nil {
-			mergedFactories[f.Name] = f
-		}
-	}
+	factories, _ := loadExternalFactories()
 	// Sort by name for stable ordering
-	factoryNames := make([]string, 0, len(mergedFactories))
-	for name := range mergedFactories {
-		factoryNames = append(factoryNames, name)
+	factoryNames := make([]string, 0, len(factories))
+	for _, f := range factories {
+		if f != nil {
+			factoryNames = append(factoryNames, f.Name)
+		}
 	}
 	sort.Strings(factoryNames)
+	factoryMap := make(map[string]*types.FactoryConfig, len(factories))
+	for _, f := range factories {
+		if f != nil {
+			factoryMap[f.Name] = f
+		}
+	}
 	for _, name := range factoryNames {
-		f := mergedFactories[name]
+		f := factoryMap[name]
 		view.Factories = append(view.Factories, FactoryView{
 			Name:                f.Name,
 			Integration:         f.Integration,
@@ -944,99 +944,97 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 		updatedCfg.ConcurrencyGroups = groups
 	}
 
-	// Factories (full replace)
+	// Factories (full replace) — write directly to external storage, never hubCfg.Factories
 	if patch.Factories != nil {
-		var factories []*types.FactoryConfig
 		for _, fp := range patch.Factories {
 			// Preserve existing webhook secret if not being replaced
 			webhookSecret := fp.WebhookSecret
 			if webhookSecret == "" {
-				// Find existing factory by name and keep its secret
-				// Use originalName if provided (for renames), otherwise use name
 				matchName := fp.Name
 				if fp.OriginalName != "" {
 					matchName = fp.OriginalName
 				}
-				for _, existing := range s.hubCfg.Factories {
-					if existing.Name == matchName {
-						webhookSecret = existing.WebhookSecret
-						break
-					}
-				}
-				// Also check external storage for secrets
-				if webhookSecret == "" {
-					if disk, err := loadExternalFactory(matchName); err == nil && disk.WebhookSecret != "" {
-						webhookSecret = disk.WebhookSecret
-					}
+				if disk, err := loadExternalFactory(matchName); err == nil && disk.WebhookSecret != "" {
+					webhookSecret = disk.WebhookSecret
 				}
 			}
-			factory := &types.FactoryConfig{
-				Name: fp.Name, Integration: fp.Integration,
-				Workspace: fp.Workspace, Team: fp.Team,
-				TriggerStatus: fp.TriggerStatus, DoneStatus: fp.DoneStatus,
-				TerminateOnLeave: fp.TerminateOnLeave, Template: fp.Template,
-				NamePattern: fp.NamePattern, WebhookSecret: webhookSecret,
-				WebhookSecretRef: fp.WebhookSecretRef, PipelineYAML: fp.PipelineYAML,
-				Tags: fp.Tags, Color: fp.Color, Labels: fp.Labels,
-				AssignedTo: fp.AssignedTo, Enabled: fp.Enabled,
-				ConcurrencyGroup: fp.ConcurrencyGroup,
-			}
-			factories = append(factories, factory)
 
-			// If this factory exists in external storage, update it there too
-			// so that toggles like Enabled are persisted to disk.
-			// Load the existing disk factory and overlay only the patch fields
-			// to avoid wiping integration-specific fields (Repos, Trigger, etc.).
-			if disk, err := loadExternalFactory(fp.Name); err == nil {
-				if fp.Workspace != "" {
-					disk.Workspace = fp.Workspace
-				}
-				if fp.Team != "" {
-					disk.Team = fp.Team
-				}
-				if fp.TriggerStatus != "" {
-					disk.TriggerStatus = fp.TriggerStatus
-				}
-				if fp.DoneStatus != "" {
-					disk.DoneStatus = fp.DoneStatus
-				}
-				if fp.Template != "" {
-					disk.Template = fp.Template
-				}
-				if fp.NamePattern != "" {
-					disk.NamePattern = fp.NamePattern
-				}
-				if webhookSecret != "" {
-					disk.WebhookSecret = webhookSecret
-				}
-				if fp.WebhookSecretRef != "" {
-					disk.WebhookSecretRef = fp.WebhookSecretRef
-				}
-				if fp.PipelineYAML != "" {
-					disk.PipelineYAML = fp.PipelineYAML
-				}
-				if fp.Tags != nil {
-					disk.Tags = fp.Tags
-				}
-				if fp.Color != "" {
-					disk.Color = fp.Color
-				}
-				if fp.Labels != nil {
-					disk.Labels = fp.Labels
-				}
-				if fp.AssignedTo != "" {
-					disk.AssignedTo = fp.AssignedTo
-				}
-				if fp.Enabled != nil {
-					disk.Enabled = fp.Enabled
-				}
-				if fp.ConcurrencyGroup != "" {
-					disk.ConcurrencyGroup = fp.ConcurrencyGroup
-				}
-				_ = saveExternalFactory(disk)
+			// Start from disk if it exists, otherwise build fresh
+			var disk *types.FactoryConfig
+			if d, err := loadExternalFactory(fp.Name); err == nil {
+				disk = d
+			} else {
+				disk = &types.FactoryConfig{Name: fp.Name}
 			}
+
+			if fp.Integration != "" {
+				disk.Integration = fp.Integration
+			}
+			if fp.Workspace != "" {
+				disk.Workspace = fp.Workspace
+			}
+			if fp.Team != "" {
+				disk.Team = fp.Team
+			}
+			if fp.TriggerStatus != "" {
+				disk.TriggerStatus = fp.TriggerStatus
+			}
+			if fp.DoneStatus != "" {
+				disk.DoneStatus = fp.DoneStatus
+			}
+			if fp.TerminateOnLeave {
+				disk.TerminateOnLeave = fp.TerminateOnLeave
+			}
+			if fp.Template != "" {
+				disk.Template = fp.Template
+			}
+			if fp.NamePattern != "" {
+				disk.NamePattern = fp.NamePattern
+			}
+			if webhookSecret != "" {
+				disk.WebhookSecret = webhookSecret
+			}
+			if fp.WebhookSecretRef != "" {
+				disk.WebhookSecretRef = fp.WebhookSecretRef
+			}
+			if fp.PipelineYAML != "" {
+				disk.PipelineYAML = fp.PipelineYAML
+			}
+			if fp.Tags != nil {
+				disk.Tags = fp.Tags
+			}
+			if fp.Color != "" {
+				disk.Color = fp.Color
+			}
+			if fp.Labels != nil {
+				disk.Labels = fp.Labels
+			}
+			if fp.AssignedTo != "" {
+				disk.AssignedTo = fp.AssignedTo
+			}
+			if fp.Enabled != nil {
+				disk.Enabled = fp.Enabled
+			}
+			if fp.ConcurrencyGroup != "" {
+				disk.ConcurrencyGroup = fp.ConcurrencyGroup
+			}
+			if fp.EnableManualTrigger {
+				disk.EnableManualTrigger = fp.EnableManualTrigger
+			}
+			if fp.Inputs != nil {
+				disk.Inputs = fp.Inputs
+			}
+			// Integration-specific fields
+			if fp.Repos != nil {
+				disk.Repos = fp.Repos
+			}
+			if fp.Trigger != nil {
+				disk.Trigger = fp.Trigger
+			}
+
+			_ = saveExternalFactory(disk)
 		}
-		updatedCfg.Factories = factories
+		updatedCfg.Factories = nil // never store factories in hubCfg
 	}
 
 	// Auth config

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -439,7 +439,11 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 
 	// Factories — load only from external storage (single source of truth)
 	view.Factories = []FactoryView{}
-	factories, _ := loadExternalFactories()
+	factories, err := loadExternalFactories()
+	if err != nil {
+		http.Error(w, "failed to load factories: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
 	// Sort by name for stable ordering
 	factoryNames := make([]string, 0, len(factories))
 	for _, f := range factories {
@@ -1043,7 +1047,10 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 			// If this was a rename, delete the old factory directory so it doesn't
 			// appear as a phantom duplicate in listings.
 			if fp.OriginalName != "" && fp.OriginalName != fp.Name {
-				_ = deleteExternalFactory(fp.OriginalName)
+				if err := deleteExternalFactory(fp.OriginalName); err != nil {
+					http.Error(w, "failed to delete old factory "+fp.OriginalName+": "+err.Error(), http.StatusInternalServerError)
+					return
+				}
 			}
 		}
 		updatedCfg.Factories = nil // never store factories in hubCfg

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -954,15 +954,22 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 				if fp.OriginalName != "" {
 					matchName = fp.OriginalName
 				}
-				if disk, err := loadExternalFactory(matchName); err == nil && disk.WebhookSecret != "" {
-					webhookSecret = disk.WebhookSecret
+				if old, err := loadExternalFactory(matchName); err == nil && old.WebhookSecret != "" {
+					webhookSecret = old.WebhookSecret
 				}
 			}
 
-			// Start from disk if it exists, otherwise build fresh
+			// For renames, start from the original factory on disk so no fields are lost.
+			baseName := fp.Name
+			if fp.OriginalName != "" && fp.OriginalName != fp.Name {
+				baseName = fp.OriginalName
+			}
 			var disk *types.FactoryConfig
-			if d, err := loadExternalFactory(fp.Name); err == nil {
+			if d, err := loadExternalFactory(baseName); err == nil {
 				disk = d
+				if fp.OriginalName != "" && fp.OriginalName != fp.Name {
+					disk.Name = fp.Name // apply the new name
+				}
 			} else {
 				disk = &types.FactoryConfig{Name: fp.Name}
 			}
@@ -1031,6 +1038,12 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 			if err := saveExternalFactory(disk); err != nil {
 				http.Error(w, "failed to save factory "+fp.Name+": "+err.Error(), http.StatusInternalServerError)
 				return
+			}
+
+			// If this was a rename, delete the old factory directory so it doesn't
+			// appear as a phantom duplicate in listings.
+			if fp.OriginalName != "" && fp.OriginalName != fp.Name {
+				_ = deleteExternalFactory(fp.OriginalName)
 			}
 		}
 		updatedCfg.Factories = nil // never store factories in hubCfg

--- a/pkg/hub/shortcut.go
+++ b/pkg/hub/shortcut.go
@@ -55,9 +55,9 @@ func (s *Server) validateShortcutSignature(body []byte, sig string) bool {
 	// Strip sha256= prefix if present
 	sig = strings.TrimPrefix(sig, "sha256=")
 	s.mu.RLock()
-	factories := s.hubCfg.Factories
 	secrets := s.hubCfg.Secrets
 	s.mu.RUnlock()
+	factories := s.sLoadExternalFactories()
 	hasSecrets := false
 	for _, f := range factories {
 		if f.Integration != "shortcut" {
@@ -137,9 +137,7 @@ func (s *Server) handleShortcutWebhook(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) processShortcutEvent(payload shortcutWebhookPayload) {
-	s.mu.RLock()
-	factories := s.hubCfg.Factories
-	s.mu.RUnlock()
+	factories := s.sLoadExternalFactories()
 
 	for _, action := range payload.Actions {
 		if action.EntityType != "story" || action.Action != "update" {


### PR DESCRIPTION
Removes all in-memory fallback paths for factories. External storage is now the only source of truth.

- factory_api.go: list/push/delete operate on external storage only
- factory_trigger.go: trigger loads from external storage only, no fallback to hubCfg.Factories
- settings.go: settings page loads from external storage only; patch writes directly to disk
- Adds unit tests for min/max validation on number inputs
- Adds missing fields to FactoryPatch (EnableManualTrigger, Inputs, Repos, Trigger)