### PR TITLE
feat: agent stopped notifications with issue tracker comments

### DIFF
--- a/pkg/hub/factory_creator.go
+++ b/pkg/hub/factory_creator.go
@@ -346,7 +346,7 @@ func (s *Server) createClawFromFactory(factory *types.FactoryConfig, issueID str
 		}
 		if provErr != nil {
 			log.Printf("[factory] provision failed for %s: %v", clawID, provErr)
-			_, _ = s.db.Exec(`UPDATE claws SET status='error' WHERE id=? AND status != 'deleted'`, clawID)
+			s.stopAgentWithReason(clawID, fmt.Sprintf("Factory provision failed: %v", provErr))
 		}
 	}()
 

--- a/pkg/hub/factory_creator.go
+++ b/pkg/hub/factory_creator.go
@@ -346,7 +346,7 @@ func (s *Server) createClawFromFactory(factory *types.FactoryConfig, issueID str
 		}
 		if provErr != nil {
 			log.Printf("[factory] provision failed for %s: %v", clawID, provErr)
-			s.stopAgentWithReason(clawID, fmt.Sprintf("Factory provision failed: %v", provErr))
+			s.stopAgentWithReason(clawID, fmt.Sprintf("Factory provision failed: %v", provErr), false)
 		}
 	}()
 

--- a/pkg/hub/github_issues.go
+++ b/pkg/hub/github_issues.go
@@ -727,11 +727,7 @@ func (s *Server) createClawForGitHubIssue(factory *types.FactoryConfig, payload 
 
 		if provErr != nil {
 			log.Printf("[factory] claw %s provision failed: %v", clawID[:8], provErr)
-			_, _ = s.db.Exec(`UPDATE claws SET status='error' WHERE id=?`, clawID)
-			s.broadcastToUsers(tenantID, types.WSMessage{
-				Type:    "claw_status",
-				Payload: map[string]string{"claw_id": clawID, "status": "error"},
-			})
+			s.stopAgentWithReason(clawID, fmt.Sprintf("Factory provision failed: %v", provErr))
 			return
 		}
 
@@ -815,6 +811,31 @@ func buildGitHubIssuesContext(payload githubIssuesWebhookPayload) string {
 	b.WriteString("3. Implement the feature/fix described above\n")
 	b.WriteString("4. When complete, send exactly: `[DONE] https://github.com/org/repo/pull/N` (with your PR URL)\n")
 	return b.String()
+}
+
+// commentGitHubIssue adds a comment to a GitHub issue.
+func commentGitHubIssue(token, repo string, issueNumber int, body string) error {
+	base := "https://api.github.com"
+	commentBody := map[string]interface{}{"body": body}
+	b, _ := json.Marshal(commentBody)
+	req, _ := http.NewRequest("POST",
+		fmt.Sprintf("%s/repos/%s/issues/%d/comments", base, repo, issueNumber),
+		bytes.NewReader(b))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("github API error %d: %s", resp.StatusCode, string(respBody))
+	}
+	return nil
 }
 
 // githubAPIPostWithBase makes a POST/PATCH/PUT request to the GitHub API.

--- a/pkg/hub/github_issues.go
+++ b/pkg/hub/github_issues.go
@@ -727,7 +727,7 @@ func (s *Server) createClawForGitHubIssue(factory *types.FactoryConfig, payload 
 
 		if provErr != nil {
 			log.Printf("[factory] claw %s provision failed: %v", clawID[:8], provErr)
-			s.stopAgentWithReason(clawID, fmt.Sprintf("Factory provision failed: %v", provErr))
+			s.stopAgentWithReason(clawID, fmt.Sprintf("Factory provision failed: %v", provErr), false)
 			return
 		}
 

--- a/pkg/hub/github_webhook.go
+++ b/pkg/hub/github_webhook.go
@@ -695,7 +695,7 @@ func (s *Server) createClawForGitHubPR(factory *types.FactoryConfig, pr githubPR
 		}
 		if provErr != nil {
 			log.Printf("[factory] provision failed for %s: %v", clawID, provErr)
-			s.stopAgentWithReason(clawID, fmt.Sprintf("Factory provision failed: %v", provErr))
+			s.stopAgentWithReason(clawID, fmt.Sprintf("Factory provision failed: %v", provErr), false)
 		}
 	}()
 

--- a/pkg/hub/github_webhook.go
+++ b/pkg/hub/github_webhook.go
@@ -695,7 +695,7 @@ func (s *Server) createClawForGitHubPR(factory *types.FactoryConfig, pr githubPR
 		}
 		if provErr != nil {
 			log.Printf("[factory] provision failed for %s: %v", clawID, provErr)
-			_, _ = s.db.Exec(`UPDATE claws SET status='error' WHERE id=? AND status != 'deleted'`, clawID)
+			s.stopAgentWithReason(clawID, fmt.Sprintf("Factory provision failed: %v", provErr))
 		}
 	}()
 

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -624,7 +624,7 @@ func (s *Server) provisionPendingClaw(clawID string) {
 	).Scan(&tenantID, &name, &template, &provider, &defaultModel, &templateFilesJSON, &githubReposJSON, &linearWorkspace, &nixEnabled, &dockerEnabled, &tagsJSON, &color, &llmKey, &autoFixCI, &autoFixBugbot, &issueID)
 	if err != nil {
 		log.Printf("[factory] failed to fetch pending claw %s: %v", clawID[:8], err)
-		s.stopAgentWithReason(clawID, fmt.Sprintf("Factory provision failed: failed to fetch pending claw: %v", err))
+		s.stopAgentWithReason(clawID, fmt.Sprintf("Factory provision failed: failed to fetch pending claw: %v", err), false)
 		return
 	}
 
@@ -740,7 +740,7 @@ func (s *Server) provisionPendingClaw(clawID string) {
 	}
 	if provErr != nil {
 		log.Printf("[factory] provision failed for pending claw %s: %v", clawID, provErr)
-		s.stopAgentWithReason(clawID, fmt.Sprintf("Factory provision failed: %v", provErr))
+		s.stopAgentWithReason(clawID, fmt.Sprintf("Factory provision failed: %v", provErr), false)
 		// Slot is now free (error claws don't count toward limit); try to
 		// promote the next pending claw.
 		go s.promotePendingClaws()

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -1139,6 +1139,10 @@ func commentLinearIssueWithBase(baseURL, token, issueIdentifier, body string) er
 		return err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("Linear API error %d: %s", resp.StatusCode, string(body))
+	}
 
 	var result struct {
 		Data struct {
@@ -1176,6 +1180,10 @@ func commentLinearIssueWithBase(baseURL, token, issueIdentifier, body string) er
 		return err
 	}
 	defer resp2.Body.Close()
+	if resp2.StatusCode >= 400 {
+		body, _ := io.ReadAll(resp2.Body)
+		return fmt.Errorf("Linear API error %d: %s", resp2.StatusCode, string(body))
+	}
 
 	var commentResult struct {
 		Data struct {

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -624,7 +624,7 @@ func (s *Server) provisionPendingClaw(clawID string) {
 	).Scan(&tenantID, &name, &template, &provider, &defaultModel, &templateFilesJSON, &githubReposJSON, &linearWorkspace, &nixEnabled, &dockerEnabled, &tagsJSON, &color, &llmKey, &autoFixCI, &autoFixBugbot, &issueID)
 	if err != nil {
 		log.Printf("[factory] failed to fetch pending claw %s: %v", clawID[:8], err)
-		_, _ = s.db.Exec(`UPDATE claws SET status='error' WHERE id=?`, clawID)
+		s.stopAgentWithReason(clawID, fmt.Sprintf("Factory provision failed: failed to fetch pending claw: %v", err))
 		return
 	}
 
@@ -740,7 +740,7 @@ func (s *Server) provisionPendingClaw(clawID string) {
 	}
 	if provErr != nil {
 		log.Printf("[factory] provision failed for pending claw %s: %v", clawID, provErr)
-		_, _ = s.db.Exec(`UPDATE claws SET status='error' WHERE id=? AND status != 'deleted'`, clawID)
+		s.stopAgentWithReason(clawID, fmt.Sprintf("Factory provision failed: %v", provErr))
 		// Slot is now free (error claws don't count toward limit); try to
 		// promote the next pending claw.
 		go s.promotePendingClaws()
@@ -1110,6 +1110,86 @@ func moveLinearIssueWithBase(baseURL, token, issueIdentifier, targetStateName st
 		return err
 	}
 	resp2.Body.Close()
+	return nil
+}
+
+// commentLinearIssue adds a comment to a Linear issue using the commentCreate GraphQL mutation.
+func (s *Server) commentLinearIssue(token, issueIdentifier, body string) error {
+	base := s.linearBaseURL
+	if base == "" {
+		base = "https://api.linear.app"
+	}
+	return commentLinearIssueWithBase(base, token, issueIdentifier, body)
+}
+
+// commentLinearIssueWithBase adds a comment to a Linear issue against a custom base URL.
+func commentLinearIssueWithBase(baseURL, token, issueIdentifier, body string) error {
+	// Resolve issue ID from identifier
+	queryBody := map[string]interface{}{
+		"query": "query($id: String!) { issue(id: $id) { id } }",
+		"variables": map[string]string{"id": issueIdentifier},
+	}
+	queryJSON, _ := json.Marshal(queryBody)
+	req, _ := http.NewRequest("POST", baseURL+"/graphql", strings.NewReader(string(queryJSON)))
+	req.Header.Set("Authorization", token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		Data struct {
+			Issue struct {
+				ID string `json:"id"`
+			} `json:"issue"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return err
+	}
+	issueID := result.Data.Issue.ID
+	if issueID == "" {
+		return fmt.Errorf("issue %s not found", issueIdentifier)
+	}
+
+	// Create comment
+	mut := `mutation($issueId: String!, $body: String!) {
+		commentCreate(input: { issueId: $issueId, body: $body }) {
+			success
+			comment { id }
+		}
+	}`
+	mutBody := map[string]interface{}{
+		"query":     mut,
+		"variables": map[string]string{"issueId": issueID, "body": body},
+	}
+	mutJSON, _ := json.Marshal(mutBody)
+	req2, _ := http.NewRequest("POST", baseURL+"/graphql", strings.NewReader(string(mutJSON)))
+	req2.Header.Set("Authorization", token)
+	req2.Header.Set("Content-Type", "application/json")
+
+	resp2, err := http.DefaultClient.Do(req2)
+	if err != nil {
+		return err
+	}
+	defer resp2.Body.Close()
+
+	var commentResult struct {
+		Data struct {
+			CommentCreate struct {
+				Success bool `json:"success"`
+			} `json:"commentCreate"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp2.Body).Decode(&commentResult); err != nil {
+		return err
+	}
+	if !commentResult.Data.CommentCreate.Success {
+		return fmt.Errorf("commentCreate returned success=false")
+	}
 	return nil
 }
 

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -171,7 +171,7 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, factory *types.
 			}
 			if details == nil {
 				log.Printf("[pipeline] fetchLinearIssueDetails returned nil details for %s", issueID)
-				s.stopAgentWithReason(clawID, fmt.Sprintf("Pipeline template render failed: %v", err))
+				s.stopAgentWithReason(clawID, fmt.Sprintf("Pipeline template render failed: issue %s returned no details", issueID))
 				return
 			}
 			log.Printf("[pipeline] fetched issue %s: identifier=%s title=%s", issueID, details.Identifier, details.Title)
@@ -229,7 +229,7 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, factory *types.
 			}
 			if details == nil {
 				log.Printf("[pipeline] fetchGitHubIssueDetails returned nil for %s, putting claw in error state", issueID)
-				s.stopAgentWithReason(clawID, fmt.Sprintf("Pipeline template render failed: %v", err))
+				s.stopAgentWithReason(clawID, fmt.Sprintf("Pipeline template render failed: issue %s returned no details", issueID))
 				return
 			}
 			log.Printf("[pipeline] fetched GitHub issue %s: #%s title=%s", issueID, details.Identifier, details.Title)

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -160,18 +160,18 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, factory *types.
 			linearToken := s.resolveLinearTokenForFactory(factory)
 			if linearToken == "" {
 				log.Printf("[pipeline] no linear token for factory %q, putting claw in error state", factory.Name)
-				s.stopAgentWithReason(clawID, fmt.Sprintf("Pipeline template render failed: no linear token for factory %s", factory.Name))
+				s.stopAgentWithReason(clawID, fmt.Sprintf("Pipeline template render failed: no linear token for factory %s", factory.Name), false)
 				return
 			}
 			details, err := s.fetchLinearIssueDetails(linearToken, issueID)
 			if err != nil {
 				log.Printf("[pipeline] fetchLinearIssueDetails FAILED for %s: %v", issueID, err)
-				s.stopAgentWithReason(clawID, fmt.Sprintf("Pipeline template render failed: %v", err))
+				s.stopAgentWithReason(clawID, fmt.Sprintf("Pipeline template render failed: %v", err), false)
 				return
 			}
 			if details == nil {
 				log.Printf("[pipeline] fetchLinearIssueDetails returned nil details for %s", issueID)
-				s.stopAgentWithReason(clawID, fmt.Sprintf("Pipeline template render failed: issue %s returned no details", issueID))
+				s.stopAgentWithReason(clawID, fmt.Sprintf("Pipeline template render failed: issue %s returned no details", issueID), false)
 				return
 			}
 			log.Printf("[pipeline] fetched issue %s: identifier=%s title=%s", issueID, details.Identifier, details.Title)
@@ -179,7 +179,7 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, factory *types.
 			tmpl, err := template.New("inject").Parse(injectMsg)
 			if err != nil {
 				log.Printf("[pipeline] template PARSE FAILED for claw %s: %v", clawID[:8], err)
-				s.stopAgentWithReason(clawID, fmt.Sprintf("Pipeline template render failed: %v", err))
+				s.stopAgentWithReason(clawID, fmt.Sprintf("Pipeline template render failed: %v", err), false)
 				return
 			}
 			var buf bytes.Buffer
@@ -191,7 +191,7 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, factory *types.
 			log.Printf("[pipeline] template DATA for claw %s: Issue.Identifier=%q Issue.Title=%q Issue.URL=%q", clawID[:8], data.Issue.Identifier, data.Issue.Title, data.Issue.URL)
 			if err := tmpl.Execute(&buf, data); err != nil {
 				log.Printf("[pipeline] template EXECUTE FAILED for claw %s: %v", clawID[:8], err)
-				s.stopAgentWithReason(clawID, fmt.Sprintf("Pipeline template render failed: %v", err))
+				s.stopAgentWithReason(clawID, fmt.Sprintf("Pipeline template render failed: %v", err), false)
 				return
 			}
 			injectMsg = buf.String()
@@ -201,20 +201,20 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, factory *types.
 			ghToken := s.resolveGitHubIssuesTokenForFactory(factory)
 			if ghToken == "" {
 				log.Printf("[pipeline] no GitHub token for factory %q, putting claw in error state", factory.Name)
-				s.stopAgentWithReason(clawID, fmt.Sprintf("Pipeline template render failed: no GitHub token for factory %s", factory.Name))
+				s.stopAgentWithReason(clawID, fmt.Sprintf("Pipeline template render failed: no GitHub token for factory %s", factory.Name), false)
 				return
 			}
 			parts := strings.Split(issueID, "/")
 			if len(parts) != 3 {
 				log.Printf("[pipeline] invalid GitHub issue ID format %q, putting claw in error state", issueID)
-				s.stopAgentWithReason(clawID, fmt.Sprintf("Pipeline template render failed: invalid GitHub issue ID format %q", issueID))
+				s.stopAgentWithReason(clawID, fmt.Sprintf("Pipeline template render failed: invalid GitHub issue ID format %q", issueID), false)
 				return
 			}
 			repo := parts[0] + "/" + parts[1]
 			var issueNum int
 			if _, err := fmt.Sscanf(parts[2], "%d", &issueNum); err != nil {
 				log.Printf("[pipeline] invalid GitHub issue number in %q: %v, putting claw in error state", issueID, err)
-				s.stopAgentWithReason(clawID, fmt.Sprintf("Pipeline template render failed: %v", err))
+				s.stopAgentWithReason(clawID, fmt.Sprintf("Pipeline template render failed: %v", err), false)
 				return
 			}
 			base := s.githubBaseURL
@@ -224,19 +224,19 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, factory *types.
 			details, err := s.fetchGitHubIssueDetails(ghToken, repo, issueNum, base)
 			if err != nil {
 				log.Printf("[pipeline] fetchGitHubIssueDetails FAILED for %s: %v, putting claw in error state", issueID, err)
-				s.stopAgentWithReason(clawID, fmt.Sprintf("Pipeline template render failed: %v", err))
+				s.stopAgentWithReason(clawID, fmt.Sprintf("Pipeline template render failed: %v", err), false)
 				return
 			}
 			if details == nil {
 				log.Printf("[pipeline] fetchGitHubIssueDetails returned nil for %s, putting claw in error state", issueID)
-				s.stopAgentWithReason(clawID, fmt.Sprintf("Pipeline template render failed: issue %s returned no details", issueID))
+				s.stopAgentWithReason(clawID, fmt.Sprintf("Pipeline template render failed: issue %s returned no details", issueID), false)
 				return
 			}
 			log.Printf("[pipeline] fetched GitHub issue %s: #%s title=%s", issueID, details.Identifier, details.Title)
 			tmpl, err := template.New("inject").Parse(injectMsg)
 			if err != nil {
 				log.Printf("[pipeline] template PARSE FAILED for claw %s: %v, putting claw in error state", clawID[:8], err)
-				s.stopAgentWithReason(clawID, fmt.Sprintf("Pipeline template render failed: %v", err))
+				s.stopAgentWithReason(clawID, fmt.Sprintf("Pipeline template render failed: %v", err), false)
 				return
 			}
 			var buf bytes.Buffer
@@ -247,7 +247,7 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, factory *types.
 			}
 			if err := tmpl.Execute(&buf, data); err != nil {
 				log.Printf("[pipeline] template EXECUTE FAILED for claw %s: %v, putting claw in error state", clawID[:8], err)
-				s.stopAgentWithReason(clawID, fmt.Sprintf("Pipeline template render failed: %v", err))
+				s.stopAgentWithReason(clawID, fmt.Sprintf("Pipeline template render failed: %v", err), false)
 				return
 			}
 			injectMsg = buf.String()
@@ -453,7 +453,9 @@ func (s *Server) initializePipelineEntryIfNeeded(clawID string) bool {
 // stopAgentWithReason is the centralized handler for unexpected agent termination.
 // Every path that means "the agent is dead" routes through here.
 // It: sets status='error', broadcasts to dashboard, writes issue-tracker comment, terminates VM.
-func (s *Server) stopAgentWithReason(clawID, reason string) {
+// skipVMTerminate should be true when the caller already knows the VM is gone (e.g. Replicated
+// poll saw "terminated") to avoid redundant delete attempts that spam the logs with 404 errors.
+func (s *Server) stopAgentWithReason(clawID, reason string, skipVMTerminate bool) {
 	// Resolve factory + issueID
 	factory, issueID := s.findFactoryForClaw(clawID)
 	if factory == nil {
@@ -522,7 +524,7 @@ func (s *Server) stopAgentWithReason(clawID, reason string) {
 	s.mu.Unlock()
 
 	// 5. Terminate VM if still running
-	if providerID != "" {
+	if providerID != "" && !skipVMTerminate {
 		go s.terminateVM(provider, providerID)
 	}
 

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -160,18 +160,18 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, factory *types.
 			linearToken := s.resolveLinearTokenForFactory(factory)
 			if linearToken == "" {
 				log.Printf("[pipeline] no linear token for factory %q, putting claw in error state", factory.Name)
-				_, _ = s.db.Exec(`UPDATE claws SET status='error' WHERE id=? AND status != 'deleted'`, clawID)
+				s.stopAgentWithReason(clawID, fmt.Sprintf("Pipeline template render failed: no linear token for factory %s", factory.Name))
 				return
 			}
 			details, err := s.fetchLinearIssueDetails(linearToken, issueID)
 			if err != nil {
 				log.Printf("[pipeline] fetchLinearIssueDetails FAILED for %s: %v", issueID, err)
-				_, _ = s.db.Exec(`UPDATE claws SET status='error' WHERE id=? AND status != 'deleted'`, clawID)
+				s.stopAgentWithReason(clawID, fmt.Sprintf("Pipeline template render failed: %v", err))
 				return
 			}
 			if details == nil {
 				log.Printf("[pipeline] fetchLinearIssueDetails returned nil details for %s", issueID)
-				_, _ = s.db.Exec(`UPDATE claws SET status='error' WHERE id=? AND status != 'deleted'`, clawID)
+				s.stopAgentWithReason(clawID, fmt.Sprintf("Pipeline template render failed: %v", err))
 				return
 			}
 			log.Printf("[pipeline] fetched issue %s: identifier=%s title=%s", issueID, details.Identifier, details.Title)
@@ -179,7 +179,7 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, factory *types.
 			tmpl, err := template.New("inject").Parse(injectMsg)
 			if err != nil {
 				log.Printf("[pipeline] template PARSE FAILED for claw %s: %v", clawID[:8], err)
-				_, _ = s.db.Exec(`UPDATE claws SET status='error' WHERE id=? AND status != 'deleted'`, clawID)
+				s.stopAgentWithReason(clawID, fmt.Sprintf("Pipeline template render failed: %v", err))
 				return
 			}
 			var buf bytes.Buffer
@@ -191,7 +191,7 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, factory *types.
 			log.Printf("[pipeline] template DATA for claw %s: Issue.Identifier=%q Issue.Title=%q Issue.URL=%q", clawID[:8], data.Issue.Identifier, data.Issue.Title, data.Issue.URL)
 			if err := tmpl.Execute(&buf, data); err != nil {
 				log.Printf("[pipeline] template EXECUTE FAILED for claw %s: %v", clawID[:8], err)
-				_, _ = s.db.Exec(`UPDATE claws SET status='error' WHERE id=? AND status != 'deleted'`, clawID)
+				s.stopAgentWithReason(clawID, fmt.Sprintf("Pipeline template render failed: %v", err))
 				return
 			}
 			injectMsg = buf.String()
@@ -201,20 +201,20 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, factory *types.
 			ghToken := s.resolveGitHubIssuesTokenForFactory(factory)
 			if ghToken == "" {
 				log.Printf("[pipeline] no GitHub token for factory %q, putting claw in error state", factory.Name)
-				_, _ = s.db.Exec(`UPDATE claws SET status='error' WHERE id=? AND status != 'deleted'`, clawID)
+				s.stopAgentWithReason(clawID, fmt.Sprintf("Pipeline template render failed: no GitHub token for factory %s", factory.Name))
 				return
 			}
 			parts := strings.Split(issueID, "/")
 			if len(parts) != 3 {
 				log.Printf("[pipeline] invalid GitHub issue ID format %q, putting claw in error state", issueID)
-				_, _ = s.db.Exec(`UPDATE claws SET status='error' WHERE id=? AND status != 'deleted'`, clawID)
+				s.stopAgentWithReason(clawID, fmt.Sprintf("Pipeline template render failed: invalid GitHub issue ID format %q", issueID))
 				return
 			}
 			repo := parts[0] + "/" + parts[1]
 			var issueNum int
 			if _, err := fmt.Sscanf(parts[2], "%d", &issueNum); err != nil {
 				log.Printf("[pipeline] invalid GitHub issue number in %q: %v, putting claw in error state", issueID, err)
-				_, _ = s.db.Exec(`UPDATE claws SET status='error' WHERE id=? AND status != 'deleted'`, clawID)
+				s.stopAgentWithReason(clawID, fmt.Sprintf("Pipeline template render failed: %v", err))
 				return
 			}
 			base := s.githubBaseURL
@@ -224,19 +224,19 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, factory *types.
 			details, err := s.fetchGitHubIssueDetails(ghToken, repo, issueNum, base)
 			if err != nil {
 				log.Printf("[pipeline] fetchGitHubIssueDetails FAILED for %s: %v, putting claw in error state", issueID, err)
-				_, _ = s.db.Exec(`UPDATE claws SET status='error' WHERE id=? AND status != 'deleted'`, clawID)
+				s.stopAgentWithReason(clawID, fmt.Sprintf("Pipeline template render failed: %v", err))
 				return
 			}
 			if details == nil {
 				log.Printf("[pipeline] fetchGitHubIssueDetails returned nil for %s, putting claw in error state", issueID)
-				_, _ = s.db.Exec(`UPDATE claws SET status='error' WHERE id=? AND status != 'deleted'`, clawID)
+				s.stopAgentWithReason(clawID, fmt.Sprintf("Pipeline template render failed: %v", err))
 				return
 			}
 			log.Printf("[pipeline] fetched GitHub issue %s: #%s title=%s", issueID, details.Identifier, details.Title)
 			tmpl, err := template.New("inject").Parse(injectMsg)
 			if err != nil {
 				log.Printf("[pipeline] template PARSE FAILED for claw %s: %v, putting claw in error state", clawID[:8], err)
-				_, _ = s.db.Exec(`UPDATE claws SET status='error' WHERE id=? AND status != 'deleted'`, clawID)
+				s.stopAgentWithReason(clawID, fmt.Sprintf("Pipeline template render failed: %v", err))
 				return
 			}
 			var buf bytes.Buffer
@@ -247,7 +247,7 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, factory *types.
 			}
 			if err := tmpl.Execute(&buf, data); err != nil {
 				log.Printf("[pipeline] template EXECUTE FAILED for claw %s: %v, putting claw in error state", clawID[:8], err)
-				_, _ = s.db.Exec(`UPDATE claws SET status='error' WHERE id=? AND status != 'deleted'`, clawID)
+				s.stopAgentWithReason(clawID, fmt.Sprintf("Pipeline template render failed: %v", err))
 				return
 			}
 			injectMsg = buf.String()
@@ -448,6 +448,85 @@ func (s *Server) initializePipelineEntryIfNeeded(clawID string) bool {
 
 	s.transitionPipelineStage(clawID, *entry, factory, issueID)
 	return strings.TrimSpace(entry.OnEnter.Inject) != ""
+}
+
+// stopAgentWithReason is the centralized handler for unexpected agent termination.
+// Every path that means "the agent is dead" routes through here.
+// It: sets status='error', broadcasts to dashboard, writes issue-tracker comment, terminates VM.
+func (s *Server) stopAgentWithReason(clawID, reason string) {
+	// Resolve factory + issueID
+	factory, issueID := s.findFactoryForClaw(clawID)
+	if factory == nil {
+		log.Printf("[stopAgent] claw %s: no factory found, skipping issue tracker comment", clawID[:8])
+	}
+
+	// Fetch tenantID + provider info for broadcast + VM cleanup
+	var tenantID, providerID, provider string
+	_ = s.db.QueryRow(`SELECT tenant_id, COALESCE(provider_id,''), COALESCE(provider,'') FROM claws WHERE id=?`, clawID).Scan(&tenantID, &providerID, &provider)
+
+	// 1. Set terminal status
+	_, _ = s.db.Exec(`UPDATE claws SET status='error' WHERE id=? AND status != 'deleted'`, clawID)
+
+	// 2. Broadcast "Agent Stopped" card to dashboard
+	s.broadcastToUsers(tenantID, types.WSMessage{
+		Type: "claw_status",
+		Payload: map[string]string{"claw_id": clawID, "status": "error", "reason": reason},
+	})
+
+	// 3. Write issue-tracker comment based on factory integration
+	if factory != nil && issueID != "" {
+		switch factory.Integration {
+		case "linear":
+			token := s.resolveLinearTokenForFactory(factory)
+			if token != "" {
+				if err := s.commentLinearIssue(token, issueID, fmt.Sprintf("Agent stopped: %s", reason)); err != nil {
+					log.Printf("[stopAgent] failed to comment Linear issue %s: %v", issueID, err)
+				} else {
+					log.Printf("[stopAgent] commented Linear issue %s", issueID)
+				}
+			}
+		case "shortcut":
+			token := s.resolveShortcutToken(factory.Workspace)
+			if token != "" {
+				if err := commentShortcutIssue(token, issueID, fmt.Sprintf("Agent stopped: %s", reason)); err != nil {
+					log.Printf("[stopAgent] failed to comment Shortcut story %s: %v", issueID, err)
+				} else {
+					log.Printf("[stopAgent] commented Shortcut story %s", issueID)
+				}
+			}
+		case "github-issues":
+			parts := strings.Split(issueID, "/")
+			if len(parts) == 3 {
+				token := s.resolveGitHubIssuesTokenForFactory(factory)
+				if token != "" {
+					repo := parts[0] + "/" + parts[1]
+					var issueNum int
+					if _, err := fmt.Sscanf(parts[2], "%d", &issueNum); err == nil {
+						if err := commentGitHubIssue(token, repo, issueNum, fmt.Sprintf("Agent stopped: %s", reason)); err != nil {
+							log.Printf("[stopAgent] failed to comment GitHub issue %s: %v", issueID, err)
+						} else {
+							log.Printf("[stopAgent] commented GitHub issue %s", issueID)
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// 4. Disconnect WebSocket if still connected
+	s.mu.Lock()
+	if cc, ok := s.claws[clawID]; ok {
+		cc.conn.Close(1000, "Agent stopped: "+reason)
+		delete(s.claws, clawID)
+	}
+	s.mu.Unlock()
+
+	// 5. Terminate VM if still running
+	if providerID != "" {
+		go s.terminateVM(provider, providerID)
+	}
+
+	log.Printf("[stopAgent] claw %s stopped: %s", clawID[:8], reason)
 }
 
 // findFactoryForClaw looks up the factory that created a claw by its claw ID.

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -743,7 +743,7 @@ func (s *Server) checkPRMerged(pr clawPR, token string) bool {
 			}
 		}
 		if !pipelineHandled {
-			s.stopAgentWithReason(clawID, fmt.Sprintf("PR %s was closed without being merged", pr.prURL), false)
+			go s.stopAgentWithReason(clawID, fmt.Sprintf("PR %s was closed without being merged", pr.prURL), false)
 		}
 		return false
 	}

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -725,11 +725,10 @@ func (s *Server) checkPRMerged(pr clawPR, token string) bool {
 
 	// If the PR was closed without merging, notify the claw and let it decide — don't terminate.
 	if state == "closed" && !merged {
-		log.Printf("[pr-watcher] PR %s#%d closed without merge — notifying claw %s", pr.repo, pr.prNumber, clawID[:8])
-		// Stop polling this closed PR so we only notify once.
+		log.Printf("[pr-watcher] PR %s#%d closed without merge — stopping claw %s", pr.repo, pr.prNumber, clawID[:8])
 		_, _ = s.db.Exec(`DELETE FROM claw_prs WHERE id=?`, pr.id)
 
-		// Check if the pipeline handles pr_closed
+		// Check if the pipeline handles pr_closed (run on_enter before stopping)
 		factory, issueID := s.findFactoryForClaw(clawID)
 		pipelineHandled := false
 		if factory != nil {
@@ -744,7 +743,7 @@ func (s *Server) checkPRMerged(pr clawPR, token string) bool {
 			}
 		}
 		if !pipelineHandled {
-			s.injectHubMessageByID(clawID, fmt.Sprintf("PR %s was closed without being merged. Decide what to do: reopen it, open a new PR, or let the user know.", pr.prURL))
+			s.stopAgentWithReason(clawID, fmt.Sprintf("PR %s was closed without being merged", pr.prURL))
 		}
 		return false
 	}

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -743,7 +743,7 @@ func (s *Server) checkPRMerged(pr clawPR, token string) bool {
 			}
 		}
 		if !pipelineHandled {
-			s.stopAgentWithReason(clawID, fmt.Sprintf("PR %s was closed without being merged", pr.prURL))
+			s.stopAgentWithReason(clawID, fmt.Sprintf("PR %s was closed without being merged", pr.prURL), false)
 		}
 		return false
 	}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2780,8 +2780,9 @@ func (s *Server) syncReplicatedVMs() {
 			}
 		case "terminated", "error":
 			log.Printf("Replicated VM %s for claw %s (%s) terminated", c.providerID, c.name, c.id)
-			s.stopAgentWithReason(c.id, "Sandbox terminated (TTL expired or external shutdown)")
+			go s.stopAgentWithReason(c.id, "Sandbox terminated (TTL expired or external shutdown)")
 			// Note: stopAgentWithReason handles disconnect, status, broadcast, VM cleanup
+			// Spawned in goroutine so slow issue-tracker APIs don't stall the poll loop.
 			// Skip the rest of the status update logic for this claw
 			continue
 		default:

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -937,11 +937,7 @@ func (s *Server) handleCreateClaw(w http.ResponseWriter, r *http.Request, tenant
 
 		if provErr != nil {
 			log.Printf("provisioning failed for claw %s: %v", clawID, provErr)
-			_, _ = s.db.Exec(`UPDATE claws SET status='error' WHERE id=?`, clawID)
-			s.broadcastToUsers(tenantID, types.WSMessage{
-				Type:    "claw_error",
-				Payload: map[string]string{"claw_id": clawID, "error": provErr.Error()},
-			})
+			s.stopAgentWithReason(clawID, fmt.Sprintf("Provisioning failed: %v", provErr))
 		}
 	}()
 
@@ -2012,7 +2008,7 @@ func (s *Server) provisionDaytona(ctx context.Context, clawID string, req types.
 			log.Printf("[daytona] bootstrap attempt %d/%d failed for claw %s: %v", attempt, maxBootstrapAttempts, clawName, lastErr)
 		}
 		log.Printf("[daytona] bootstrap failed for claw %s: %v", clawName, lastErr)
-		_, _ = s.db.Exec(`UPDATE claws SET status='error', bootstrap_ok=0 WHERE id=?`, clawID)
+		s.stopAgentWithReason(clawID, fmt.Sprintf("Daytona bootstrap failed: %v", lastErr))
 		// Destroy the sandbox — auto-stop is disabled so it would run forever otherwise
 		log.Printf("[daytona] destroying failed sandbox %s for claw %s", instance.ID, clawName)
 		if delErr := p.Destroy(context.Background(), instance.ID, false); delErr != nil {
@@ -2497,11 +2493,7 @@ func (s *Server) provisionVercel(ctx context.Context, clawID string, req types.C
 	go func() {
 		if err := s.bootstrapVercel(context.Background(), clawID, sandboxID, p, files); err != nil {
 			log.Printf("vercel bootstrap failed for claw %s: %v", clawID, err)
-			_, _ = s.db.Exec(`UPDATE claws SET status='error' WHERE id=?`, clawID)
-			s.broadcastToUsers("", types.WSMessage{
-				Type:    "claw_error",
-				Payload: map[string]string{"claw_id": clawID, "error": err.Error()},
-			})
+			s.stopAgentWithReason(clawID, fmt.Sprintf("Vercel bootstrap failed: %v", err))
 		}
 	}()
 
@@ -2793,15 +2785,11 @@ func (s *Server) syncReplicatedVMs() {
 				go s.bootstrapReplicated(c.id, c.name, c.providerID, replicatedCfg)
 			}
 		case "terminated", "error":
-			newStatus = "offline"
 			log.Printf("Replicated VM %s for claw %s (%s) terminated", c.providerID, c.name, c.id)
-			// Disconnect claw WebSocket if still connected
-			s.mu.Lock()
-			if cc, ok := s.claws[c.id]; ok {
-				cc.conn.Close(websocket.StatusGoingAway, "VM terminated")
-				delete(s.claws, c.id)
-			}
-			s.mu.Unlock()
+			s.stopAgentWithReason(c.id, "Sandbox terminated (TTL expired or external shutdown)")
+			// Note: stopAgentWithReason handles disconnect, status, broadcast, VM cleanup
+			// Skip the rest of the status update logic for this claw
+			continue
 		default:
 			// assigned, pending, etc — still coming up
 			newStatus = "provisioning"
@@ -2946,7 +2934,7 @@ func (s *Server) bootstrapReplicated(clawID, clawName, vmID string, cfg types.Pr
 	bridgeURL := s.bridgeDownloadURL()
 	if bridgeURL == "" {
 		log.Printf("[bootstrap] ERROR: bridge_image not set and hub version is 'dev' — set bridge_image in hub.yaml")
-		_, _ = s.db.Exec(`UPDATE claws SET status='error' WHERE id=?`, clawID)
+		s.stopAgentWithReason(clawID, "Bootstrap failed: bridge_image not configured")
 		return
 	}
 
@@ -3046,7 +3034,7 @@ Tokens are short-lived and refreshed automatically on each git/gh operation.
 	}
 	if sshErr != nil {
 		log.Printf("Bootstrap failed for claw %s after 5 attempts: %v", clawID, sshErr)
-		_, _ = s.db.Exec(`UPDATE claws SET status='error' WHERE id=?`, clawID)
+		s.stopAgentWithReason(clawID, fmt.Sprintf("Bootstrap failed after 5 attempts: %v", sshErr))
 		return
 	}
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -937,7 +937,7 @@ func (s *Server) handleCreateClaw(w http.ResponseWriter, r *http.Request, tenant
 
 		if provErr != nil {
 			log.Printf("provisioning failed for claw %s: %v", clawID, provErr)
-			s.stopAgentWithReason(clawID, fmt.Sprintf("Provisioning failed: %v", provErr))
+			s.stopAgentWithReason(clawID, fmt.Sprintf("Provisioning failed: %v", provErr), false)
 		}
 	}()
 
@@ -2008,7 +2008,7 @@ func (s *Server) provisionDaytona(ctx context.Context, clawID string, req types.
 			log.Printf("[daytona] bootstrap attempt %d/%d failed for claw %s: %v", attempt, maxBootstrapAttempts, clawName, lastErr)
 		}
 		log.Printf("[daytona] bootstrap failed for claw %s: %v", clawName, lastErr)
-		s.stopAgentWithReason(clawID, fmt.Sprintf("Daytona bootstrap failed: %v", lastErr))
+		s.stopAgentWithReason(clawID, fmt.Sprintf("Daytona bootstrap failed: %v", lastErr), false)
 		// stopAgentWithReason already terminates the VM; no need to destroy again
 	}()
 	return nil
@@ -2487,7 +2487,7 @@ func (s *Server) provisionVercel(ctx context.Context, clawID string, req types.C
 	go func() {
 		if err := s.bootstrapVercel(context.Background(), clawID, sandboxID, p, files); err != nil {
 			log.Printf("vercel bootstrap failed for claw %s: %v", clawID, err)
-			s.stopAgentWithReason(clawID, fmt.Sprintf("Vercel bootstrap failed: %v", err))
+			s.stopAgentWithReason(clawID, fmt.Sprintf("Vercel bootstrap failed: %v", err), false)
 		}
 	}()
 
@@ -2780,7 +2780,7 @@ func (s *Server) syncReplicatedVMs() {
 			}
 		case "terminated", "error":
 			log.Printf("Replicated VM %s for claw %s (%s) terminated", c.providerID, c.name, c.id)
-			go s.stopAgentWithReason(c.id, "Sandbox terminated (TTL expired or external shutdown)")
+			go s.stopAgentWithReason(c.id, "Sandbox terminated (TTL expired or external shutdown)", true)
 			// Note: stopAgentWithReason handles disconnect, status, broadcast, VM cleanup
 			// Spawned in goroutine so slow issue-tracker APIs don't stall the poll loop.
 			// Skip the rest of the status update logic for this claw
@@ -2929,7 +2929,7 @@ func (s *Server) bootstrapReplicated(clawID, clawName, vmID string, cfg types.Pr
 	bridgeURL := s.bridgeDownloadURL()
 	if bridgeURL == "" {
 		log.Printf("[bootstrap] ERROR: bridge_image not set and hub version is 'dev' — set bridge_image in hub.yaml")
-		s.stopAgentWithReason(clawID, "Bootstrap failed: bridge_image not configured")
+		s.stopAgentWithReason(clawID, "Bootstrap failed: bridge_image not configured", false)
 		return
 	}
 
@@ -3029,7 +3029,7 @@ Tokens are short-lived and refreshed automatically on each git/gh operation.
 	}
 	if sshErr != nil {
 		log.Printf("Bootstrap failed for claw %s after 5 attempts: %v", clawID, sshErr)
-		s.stopAgentWithReason(clawID, fmt.Sprintf("Bootstrap failed after 5 attempts: %v", sshErr))
+		s.stopAgentWithReason(clawID, fmt.Sprintf("Bootstrap failed after 5 attempts: %v", sshErr), false)
 		return
 	}
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2009,13 +2009,7 @@ func (s *Server) provisionDaytona(ctx context.Context, clawID string, req types.
 		}
 		log.Printf("[daytona] bootstrap failed for claw %s: %v", clawName, lastErr)
 		s.stopAgentWithReason(clawID, fmt.Sprintf("Daytona bootstrap failed: %v", lastErr))
-		// Destroy the sandbox — auto-stop is disabled so it would run forever otherwise
-		log.Printf("[daytona] destroying failed sandbox %s for claw %s", instance.ID, clawName)
-		if delErr := p.Destroy(context.Background(), instance.ID, false); delErr != nil {
-			log.Printf("[daytona] warning: failed to destroy sandbox %s: %v", instance.ID, delErr)
-		} else {
-			log.Printf("[daytona] destroyed failed sandbox %s", instance.ID)
-		}
+		// stopAgentWithReason already terminates the VM; no need to destroy again
 	}()
 	return nil
 }

--- a/pkg/hub/shortcut.go
+++ b/pkg/hub/shortcut.go
@@ -618,7 +618,7 @@ func (s *Server) createClawForShortcutStory(factory *types.FactoryConfig, action
 		}
 		if provErr != nil {
 			log.Printf("[factory:%s] provision failed for %s: %v", factory.Name, clawID[:8], provErr)
-			s.stopAgentWithReason(clawID, fmt.Sprintf("Factory provision failed: %v", provErr))
+			s.stopAgentWithReason(clawID, fmt.Sprintf("Factory provision failed: %v", provErr), false)
 		}
 	}()
 

--- a/pkg/hub/shortcut.go
+++ b/pkg/hub/shortcut.go
@@ -1,6 +1,7 @@
 package hub
 
 import (
+	"bytes"
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
@@ -617,7 +618,7 @@ func (s *Server) createClawForShortcutStory(factory *types.FactoryConfig, action
 		}
 		if provErr != nil {
 			log.Printf("[factory:%s] provision failed for %s: %v", factory.Name, clawID[:8], provErr)
-			_, _ = s.db.Exec(`UPDATE claws SET status='error' WHERE id=? AND status != 'deleted'`, clawID)
+			s.stopAgentWithReason(clawID, fmt.Sprintf("Factory provision failed: %v", provErr))
 		}
 	}()
 
@@ -712,6 +713,34 @@ func moveShortcutStory(token, storyIDStr, stateName string) error {
 	defer resp2.Body.Close()
 	if resp2.StatusCode >= 400 {
 		return fmt.Errorf("shortcut API error %d", resp2.StatusCode)
+	}
+	return nil
+}
+
+// commentShortcutIssue adds a comment to a Shortcut story.
+func commentShortcutIssue(token, storyIDStr, body string) error {
+	// Parse story ID (sc-123 → 123)
+	numStr := strings.TrimPrefix(storyIDStr, "sc-")
+	storyNum, err := strconv.ParseInt(numStr, 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid story id %s", storyIDStr)
+	}
+
+	commentBody := map[string]interface{}{"text": body}
+	b, _ := json.Marshal(commentBody)
+	req, _ := http.NewRequest("POST",
+		fmt.Sprintf("https://api.app.shortcut.com/api/v3/stories/%d/comments", storyNum),
+		bytes.NewReader(b))
+	req.Header.Set("Shortcut-Token", token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("shortcut API error %d", resp.StatusCode)
 	}
 	return nil
 }

--- a/web/hooks/use-hub.ts
+++ b/web/hooks/use-hub.ts
@@ -304,7 +304,12 @@ export function useHub(selectedClawId: string | null): HubState {
             setClaws((prev) =>
               prev.map((c) =>
                 c.id === claw_id
-                  ? { ...c, status: mapApiStatus(status), isStreaming: status !== "connected" ? false : c.isStreaming }
+                  ? {
+                      ...c,
+                      status: mapApiStatus(status),
+                      isStreaming: status !== "connected" ? false : c.isStreaming,
+                      reason: status === "error" ? payload.reason : undefined,
+                    }
                   : c
               )
             )
@@ -316,14 +321,6 @@ export function useHub(selectedClawId: string | null): HubState {
               return prev
             })
           }
-        } else if (type === "claw_error") {
-          const { claw_id, error } = payload
-          console.warn(`Claw ${claw_id} error:`, error)
-          setClaws((prev) =>
-            prev.map((c) =>
-              c.id === claw_id ? { ...c, status: "error", isStreaming: false } : c
-            )
-          )
         }
       } catch (err) {
         console.warn("Failed to parse WS message:", err)

--- a/web/lib/mappers.ts
+++ b/web/lib/mappers.ts
@@ -106,6 +106,7 @@ export function mapApiClaw(
     color: overrides.color ?? (apiClaw.color || autoColor(apiClaw.name)),
     contextUsage: overrides.contextUsage ?? apiClaw.context_usage ?? 0,
     description: overrides.description,
+    reason: overrides.reason,
     ssh_host: apiClaw.ssh_host,
     ssh_port: apiClaw.ssh_port,
     ssh_user: apiClaw.ssh_user,

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -13,6 +13,7 @@ export interface Claw {
   color: string // accent color name, e.g. "blue", "emerald"
   contextUsage: number // 0-100 percentage, hardcoded 0 for now
   description?: string
+  reason?: string // stop reason when status is error
   // SSH / terminal access
   ssh_host?: string
   ssh_port?: number


### PR DESCRIPTION
Closes #141

When a factory-created agent dies unexpectedly, the hub now:
- Sets status='error' (universal signal for agent death)
- Broadcasts 'Agent Stopped' card to the dashboard
- Writes a comment to the issue tracker (Linear, Shortcut, or GitHub Issues) explaining why
- Terminates the VM

Centralized via `stopAgentWithReason()` — all fatal paths route through it:
- PR closed without merge
- VM TTL expired / sandbox terminated
- Bootstrap failures (Replicated, Daytona, Vercel)
- Provisioning failures
- Pipeline template render failures

New helpers:
- `commentLinearIssue()` — Linear GraphQL commentCreate
- `commentShortcutIssue()` — Shortcut story comment API
- `commentGitHubIssue()` — GitHub Issues comment API