### PR TITLE
ci: switch release trigger to CalVer tag patterns

### DIFF
--- a/.depot/workflows/release.yaml
+++ b/.depot/workflows/release.yaml
@@ -3,8 +3,13 @@ name: Release
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
-      - 'v[0-9]+.[0-9]+.[0-9]+-*'
+      # CalVer: YYYY.MM.DD (first release of the day)
+      - '20[0-9][0-9].[0-9]+.[0-9]+'
+      # CalVer: YYYY.MM.DD.MICRO (same-day hotfix)
+      - '20[0-9][0-9].[0-9]+.[0-9]+.[0-9]+'
+      # CalVer prerelease suffix (e.g. 2026.05.11-rc1)
+      - '20[0-9][0-9].[0-9]+.[0-9]+-*'
+      - '20[0-9][0-9].[0-9]+.[0-9]+.[0-9]+-*'
 
 jobs:
   release:
@@ -33,8 +38,8 @@ jobs:
         id: semver
         run: |
           TAG="${GITHUB_REF_NAME}"
-          # Prerelease if tag contains a hyphen after the version core (e.g. v1.0.0-alpha.1)
-          if echo "$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+-.+'; then
+          # Prerelease if tag contains a hyphen (e.g. 2026.05.11-rc1)
+          if echo "$TAG" | grep -qE '^20[0-9]{2}\.[0-9]+\.[0-9]+(\.[0-9]+)?-.+'; then
             echo "prerelease=true" >> "$GITHUB_OUTPUT"
           else
             echo "prerelease=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Support calendar versioning:
- 2026.05.11       → first release of the day
- 2026.05.11.1     → same-day hotfix (micro component)
- 2026.05.11-rc1   → prerelease (hyphen suffix)

Patterns match 20xx years only to avoid colliding with old SemVer tags.