### PR TITLE
fix(upgrade): match client version instead of fetching latest release

### DIFF
--- a/cmd/hub_upgrade.go
+++ b/cmd/hub_upgrade.go
@@ -10,14 +10,23 @@ import (
 
 var hubUpgradeServer string
 var hubUpgradeSSHKey string
+var hubUpgradeVersion string
 
 var hubUpgradeCmd = &cobra.Command{
 	Use:   "upgrade",
-	Short: "Upgrade the hub binary on a remote server",
+	Short: "Upgrade the hub binary on a remote server to the latest release on the current track",
 	Long: `Upgrade the elasticclaw hub on a remote server via SSH.
+
+By default the hub is upgraded to the latest release on the same track as
+the client binary — stable clients get the latest stable, prerelease clients
+(e.g. beta, rc) get the latest on their prerelease track. Cross-track jumps
+are prevented.
+
+Use --version to override and install a specific release.
 
 Examples:
   elasticclaw hub upgrade --server ssh://root@elasticclaw.example.com
+  elasticclaw hub upgrade --server ssh://root@elasticclaw.example.com --version 2026.5.11.2
 `,
 	RunE: runHubUpgrade,
 }
@@ -26,6 +35,7 @@ func init() {
 	hubCmd.AddCommand(hubUpgradeCmd)
 	hubUpgradeCmd.Flags().StringVar(&hubUpgradeServer, "server", "", "SSH target, e.g. ssh://root@host (required)")
 	hubUpgradeCmd.Flags().StringVar(&hubUpgradeSSHKey, "ssh-key", "", "SSH private key path (optional; defaults to profile ssh_key when available)")
+	hubUpgradeCmd.Flags().StringVar(&hubUpgradeVersion, "version", "", "Override the target version (default: client version)")
 }
 
 func runHubUpgrade(cmd *cobra.Command, args []string) error {
@@ -69,15 +79,28 @@ func runHubUpgrade(cmd *cobra.Command, args []string) error {
 	}
 	remoteVer := parseVersionFromOutput(strings.TrimSpace(remoteVerOut))
 
-	// Check latest release
-	latest, err := latestGitHubRelease("elasticclaw", "elasticclaw")
-	if err != nil {
-		return fmt.Errorf("failed to fetch latest version: %w", err)
+	// Determine target version: --version flag overrides track-based lookup.
+	targetVer := hubUpgradeVersion
+	if targetVer == "" {
+		if Version == "dev" {
+			return fmt.Errorf("cannot upgrade hub from a dev build — use --version or download a release from https://github.com/elasticclaw/elasticclaw/releases")
+		}
+		// Find the latest release on the same track as the client.
+		var err error
+		targetVer, err = latestReleaseOnTrack("elasticclaw", "elasticclaw", Version)
+		if err != nil {
+			return fmt.Errorf("no releases found on track %s: %w", extractTrack(Version), err)
+		}
+	} else {
+		// Explicit --version: verify the release exists.
+		if err := findGitHubRelease("elasticclaw", "elasticclaw", targetVer); err != nil {
+			return fmt.Errorf("no matching release for version %s: %w", targetVer, err)
+		}
 	}
 
-	fmt.Printf("Remote: %s  →  Latest: %s\n", remoteVer, latest)
+	fmt.Printf("Remote: %s  →  Target: %s\n", remoteVer, targetVer)
 
-	if remoteVer == latest {
+	if remoteVer == targetVer {
 		fmt.Println("Already up to date.")
 		return nil
 	}
@@ -85,7 +108,7 @@ func runHubUpgrade(cmd *cobra.Command, args []string) error {
 	// Build download URL for linux/amd64 (server is always linux)
 	downloadURL := fmt.Sprintf(
 		"https://github.com/elasticclaw/elasticclaw/releases/download/%s/elasticclaw-linux-amd64",
-		latest,
+		targetVer,
 	)
 
 	moveCmd := "mv /tmp/elasticclaw-new \"$SELF\""
@@ -111,9 +134,9 @@ if %s; then
   %s
   echo "Hub service restarted."
 fi
-`, latest, downloadURL, moveCmd, versionCmd, restartCheckCmd, restartCmd)
+`, targetVer, downloadURL, moveCmd, versionCmd, restartCheckCmd, restartCmd)
 
-	fmt.Printf("Upgrading remote hub to %s...\n", latest)
+	fmt.Printf("Upgrading remote hub to %s...\n", targetVer)
 	out, err := sshRunClient(client, script)
 	if out != "" {
 		fmt.Print(out)
@@ -122,7 +145,7 @@ fi
 		return fmt.Errorf("upgrade failed: %w", err)
 	}
 
-	fmt.Printf("✓ Hub upgraded to %s\n", latest)
+	fmt.Printf("✓ Hub upgraded to %s\n", targetVer)
 	return nil
 }
 

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -181,6 +182,119 @@ func latestGitHubRelease(owner, repo string) (string, error) {
 		return "", fmt.Errorf("no releases found")
 	}
 	return rel.TagName, nil
+}
+
+// findGitHubRelease checks whether a specific release tag exists on GitHub.
+func findGitHubRelease(owner, repo, tag string) error {
+	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/releases/tags/%s", owner, repo, tag)
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("release %s not found", tag)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("GitHub API error: HTTP %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// extractTrack returns the non-incrementing prefix of a CalVer/SemVer tag.
+//   "2026.05.11-beta.2" → "2026.05.11-beta"
+//   "2026.05.11.1"      → "2026.05.11"
+//   "2026.05.11"        → "2026.05.11"
+func extractTrack(version string) string {
+	if idx := strings.LastIndex(version, "-"); idx != -1 {
+		suffix := version[idx+1:]
+		if dotIdx := strings.LastIndex(suffix, "."); dotIdx != -1 {
+			if _, err := strconv.Atoi(suffix[dotIdx+1:]); err == nil {
+				return version[:idx+1+dotIdx]
+			}
+		}
+		return version
+	}
+	parts := strings.Split(version, ".")
+	if len(parts) >= 4 {
+		return strings.Join(parts[:3], ".")
+	}
+	return version
+}
+
+// releaseMatchesTrack reports whether a release tag belongs to the same
+// upgrade track as the given track prefix.
+func releaseMatchesTrack(tag, track string) bool {
+	if strings.Contains(track, "-") {
+		return tag == track || strings.HasPrefix(tag, track+".")
+	}
+	if tag == track {
+		return true
+	}
+	if !strings.HasPrefix(tag, track+".") {
+		return false
+	}
+	suffix := tag[len(track)+1:]
+	// Stable track: suffix must be numeric only (no prerelease indicators)
+	if strings.Contains(suffix, "-") {
+		return false
+	}
+	_, err := strconv.Atoi(suffix)
+	return err == nil
+}
+
+// trackSuffix returns the numeric suffix after the track prefix, or 0 if none.
+func trackSuffix(tag, track string) int {
+	if tag == track {
+		return 0
+	}
+	if !strings.HasPrefix(tag, track) {
+		return 0
+	}
+	rest := tag[len(track):]
+	if strings.HasPrefix(rest, ".") {
+		rest = rest[1:]
+	}
+	n, _ := strconv.Atoi(rest)
+	return n
+}
+
+// latestReleaseOnTrack queries GitHub for the most recent release whose tag
+// belongs to the same track as currentVersion.
+func latestReleaseOnTrack(owner, repo, currentVersion string) (string, error) {
+	track := extractTrack(currentVersion)
+	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/releases?per_page=100", owner, repo)
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("GitHub API error: HTTP %d", resp.StatusCode)
+	}
+	var releases []struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&releases); err != nil {
+		return "", err
+	}
+
+	var best string
+	bestSuffix := -1
+	for _, r := range releases {
+		if !releaseMatchesTrack(r.TagName, track) {
+			continue
+		}
+		suf := trackSuffix(r.TagName, track)
+		if suf > bestSuffix {
+			bestSuffix = suf
+			best = r.TagName
+		}
+	}
+	if best == "" {
+		return "", fmt.Errorf("no releases found on track %s", track)
+	}
+	return best, nil
 }
 
 func parseSSHHost(host string) (user, addr string, err error) {

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -260,37 +260,58 @@ func trackSuffix(tag, track string) int {
 }
 
 // latestReleaseOnTrack queries GitHub for the most recent release whose tag
-// belongs to the same track as currentVersion.
+// belongs to the same track as currentVersion. It paginates through releases
+// until it finds at least one match or exhausts all pages (max 10 pages = 1000
+// releases) to avoid the case where >100 releases on other tracks push the
+// target track off the first page.
 func latestReleaseOnTrack(owner, repo, currentVersion string) (string, error) {
 	track := extractTrack(currentVersion)
-	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/releases?per_page=100", owner, repo)
-	resp, err := http.Get(url)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("GitHub API error: HTTP %d", resp.StatusCode)
-	}
-	var releases []struct {
-		TagName string `json:"tag_name"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&releases); err != nil {
-		return "", err
-	}
-
+	const maxPages = 10
 	var best string
 	bestSuffix := -1
-	for _, r := range releases {
-		if !releaseMatchesTrack(r.TagName, track) {
-			continue
+
+	for page := 1; page <= maxPages; page++ {
+		url := fmt.Sprintf("https://api.github.com/repos/%s/%s/releases?per_page=100&page=%d", owner, repo, page)
+		resp, err := http.Get(url)
+		if err != nil {
+			return "", err
 		}
-		suf := trackSuffix(r.TagName, track)
-		if suf > bestSuffix {
-			bestSuffix = suf
-			best = r.TagName
+		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
+			return "", fmt.Errorf("GitHub API error: HTTP %d", resp.StatusCode)
+		}
+
+		var releases []struct {
+			TagName string `json:"tag_name"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&releases); err != nil {
+			resp.Body.Close()
+			return "", err
+		}
+		resp.Body.Close()
+
+		if len(releases) == 0 {
+			break // no more pages
+		}
+
+		for _, r := range releases {
+			if !releaseMatchesTrack(r.TagName, track) {
+				continue
+			}
+			suf := trackSuffix(r.TagName, track)
+			if suf > bestSuffix {
+				bestSuffix = suf
+				best = r.TagName
+			}
+		}
+
+		// If we found at least one match, we can stop — GitHub returns releases
+		// newest-first, so any later page would only have older releases.
+		if best != "" {
+			break
 		}
 	}
+
 	if best == "" {
 		return "", fmt.Errorf("no releases found on track %s", track)
 	}

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -305,11 +305,11 @@ func latestReleaseOnTrack(owner, repo, currentVersion string) (string, error) {
 			}
 		}
 
-		// If we found at least one match, we can stop — GitHub returns releases
-		// newest-first, so any later page would only have older releases.
-		if best != "" {
-			break
-		}
+		// Continue scanning all pages up to maxPages.
+		// GitHub returns releases newest-first by publication time, but
+		// bestSuffix is a version-number comparison — the two orderings
+		// can diverge (e.g. beta.5 published before beta.3). We stop
+		// only when a page is empty.
 	}
 
 	if best == "" {

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -15,7 +15,12 @@ import (
 
 var upgradeCmd = &cobra.Command{
 	Use:   "upgrade",
-	Short: "Upgrade elasticclaw to the latest release",
+	Short: "Upgrade elasticclaw to the latest release on the current track",
+	Long: `Upgrades the elasticclaw binary to the latest release on the same track.
+
+Stable clients upgrade to the latest stable release; prerelease clients
+(e.g. beta, rc) upgrade to the latest release on the same prerelease track.
+Cross-track jumps (beta → stable) are prevented.`,
 	RunE:  runUpgrade,
 }
 
@@ -26,12 +31,17 @@ func init() {
 func runUpgrade(cmd *cobra.Command, args []string) error {
 	fmt.Println("Checking for updates...")
 
-	latest, err := latestGitHubRelease("elasticclaw", "elasticclaw")
-	if err != nil {
-		return fmt.Errorf("failed to check latest version: %w", err)
+	current := Version
+	if current == "dev" {
+		return fmt.Errorf("cannot upgrade a dev build — download a release from https://github.com/elasticclaw/elasticclaw/releases")
 	}
 
-	current := Version
+	// Find the latest release on the same track (stable→stable, beta→beta, etc.)
+	latest, err := latestReleaseOnTrack("elasticclaw", "elasticclaw", current)
+	if err != nil {
+		return fmt.Errorf("no releases found on track %s: %w", extractTrack(current), err)
+	}
+
 	if current == latest {
 		fmt.Printf("Already up to date (%s)\n", current)
 		return nil


### PR DESCRIPTION
Both  and  previously called
 which always returned the latest stable release.
This caused prerelease clients (e.g. 2026.5.11-beta.2) to accidentally upgrade to stable, jumping tracks.

New behavior:
- Uses the client binary's Version to determine the target release
- Calls GitHub API to verify the release exists before downloading
- Errors if no matching release is found (e.g. dev builds)
- Prevents stable/prerelease track jumps

Also updates command descriptions to reflect the version-matching semantics.