### PR TITLE
fix: use enable_manual_trigger consistently across backend and frontend

### DIFF
--- a/pkg/hub/factory_api.go
+++ b/pkg/hub/factory_api.go
@@ -46,7 +46,7 @@ type FactoryPushView struct {
 	HasWebhookSecret    bool                `json:"has_webhook_secret"`
 	WebhookSecretRef    string              `json:"webhook_secret_ref,omitempty"`
 	PipelineYAML        string              `json:"pipeline_yaml,omitempty"`
-	EnableManualTrigger bool                `json:"enableManualTrigger,omitempty"`
+	EnableManualTrigger bool                `json:"enable_manual_trigger,omitempty"`
 	Inputs              []types.FactoryInput `json:"inputs,omitempty"`
 }
 

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -133,7 +133,7 @@ type FactoryView struct {
 	AssignedTo          string   `json:"assigned_to,omitempty"`
 	Enabled             bool     `json:"enabled"`
 	ConcurrencyGroup    string   `json:"concurrencyGroup,omitempty"`
-	EnableManualTrigger bool     `json:"enableManualTrigger,omitempty"`
+	EnableManualTrigger bool     `json:"enable_manual_trigger,omitempty"`
 }
 
 type ProviderView struct {
@@ -286,7 +286,7 @@ type FactoryPatch struct {
 	AssignedTo          string              `json:"assigned_to,omitempty"`
 	Enabled             *bool               `json:"enabled,omitempty"`
 	ConcurrencyGroup    string              `json:"concurrencyGroup,omitempty"`
-	EnableManualTrigger bool                `json:"enableManualTrigger,omitempty"`
+	EnableManualTrigger bool                `json:"enable_manual_trigger,omitempty"`
 	Inputs              []types.FactoryInput `json:"inputs,omitempty"`
 	Repos               []string            `json:"repos,omitempty"`
 	Trigger             *types.GitHubTrigger `json:"trigger,omitempty"`

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -447,7 +447,7 @@ type FactoryConfig struct {
 	// If empty, the factory uses the "global" group.
 	ConcurrencyGroup string `yaml:"concurrency_group,omitempty" json:"concurrencyGroup,omitempty"`
 	// EnableManualTrigger allows this factory to be triggered manually from the dashboard.
-	EnableManualTrigger bool `yaml:"enable_manual_trigger,omitempty" json:"enableManualTrigger,omitempty"`
+	EnableManualTrigger bool `yaml:"enable_manual_trigger,omitempty" json:"enable_manual_trigger,omitempty"`
 	// GitHub factory fields (integration: github)
 	Repos   []string       `yaml:"repos,omitempty"`   // e.g. ["can-io/canio", "can-io/*"]
 	Trigger *GitHubTrigger `yaml:"trigger,omitempty"`

--- a/web/components/sidebar.tsx
+++ b/web/components/sidebar.tsx
@@ -128,7 +128,7 @@ export function Sidebar({
         .then((data) => {
           if (cancelled) return
           const manual = data.filter(
-            (f) => (f.enabled !== false) && f.enableManualTrigger
+            (f) => (f.enabled !== false) && f.enable_manual_trigger
           )
           console.log("[sidebar] loaded factories:", data.length, "manual:", manual.length)
           setManualFactories(manual)

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -265,7 +265,7 @@ export interface Factory {
   has_webhook_secret: boolean
   webhook_secret_ref?: string
   pipeline_yaml?: string
-  enableManualTrigger?: boolean
+  enable_manual_trigger?: boolean
   inputs?: FactoryInput[]
 }
 


### PR DESCRIPTION
The factory push action sends YAML field names (snake_case) directly as JSON keys. The backend had a mix of enableManualTrigger (camelCase) and enable_manual_trigger (snake_case) tags, causing the field to be ignored during factory push.

Standardize on enable_manual_trigger everywhere to match what the publish-factory action sends.