### PR TITLE
feat: add secret_refs to templates with backward compat for deprecated secrets list

### DIFF
--- a/pkg/hub/doctor.go
+++ b/pkg/hub/doctor.go
@@ -670,6 +670,44 @@ func (s *Server) checkTemplates(cfg *types.HubConfig, diskCfg *types.HubConfig) 
 						Label:  "Manage Templates",
 					},
 				})
+			} else {
+				// Check for deprecated secrets: list format
+				if data, err := os.ReadFile(configPath); err == nil {
+					tmplCfg, parseErr := config.ParseTemplateConfig(data)
+					if parseErr == nil && tmplCfg != nil {
+						if len(tmplCfg.Secrets) > 0 {
+							checks = append(checks, DoctorCheck{
+								Category:    "templates",
+								Severity:    "warning",
+								Title:       fmt.Sprintf("Template %q uses deprecated secrets: list", name),
+								Description: fmt.Sprintf("Template %q uses the deprecated 'secrets:' list format. Migrate to 'secret_refs:' map.\n\nExample:\n  secret_refs:\n    LINEAR_API_KEY: linear_api_key\n\nSee: https://elasticclaw.ai/docs/templates/secrets", name),
+								OK:          false,
+								FixAction: &FixAction{
+									Type:   "navigate",
+									Target: "/settings/templates",
+									Label:  "Manage Templates",
+								},
+							})
+						}
+						// Check for missing secret_refs references
+						for envName, secretRef := range tmplCfg.SecretRefs {
+							if !secretNames[secretRef] {
+								checks = append(checks, DoctorCheck{
+									Category:    "templates",
+									Severity:    "warning",
+									Title:       fmt.Sprintf("Template %q secret_refs references missing secret", name),
+									Description: fmt.Sprintf("Template %q secret_refs maps %q to secret %q which is not in the secrets map.", name, envName, secretRef),
+									OK:          false,
+									FixAction: &FixAction{
+										Type:   "navigate",
+										Target: "/settings/secrets",
+										Label:  "Create Secret",
+									},
+								})
+							}
+						}
+					}
+				}
 			}
 		}
 		if len(externalNames) == 0 {

--- a/pkg/hub/doctor.go
+++ b/pkg/hub/doctor.go
@@ -539,7 +539,25 @@ func (s *Server) checkFactories(cfg *types.HubConfig, diskCfg *types.HubConfig) 
 			})
 		}
 
-		// Check 4: overlapping triggers
+		// Check 4: factory secret_refs point to existing secrets
+		for envName, secretRef := range f.SecretRefs {
+			if !secretNames[secretRef] {
+				checks = append(checks, DoctorCheck{
+					Category: "factories",
+					Severity: "warning",
+					Title:    fmt.Sprintf("Factory %q secret_refs references missing secret", f.Name),
+					Description: fmt.Sprintf("Factory %q secret_refs maps %q to secret %q which is not in the secrets map.", f.Name, envName, secretRef),
+					OK: false,
+					FixAction: &FixAction{
+						Type:   "navigate",
+						Target: "/settings/secrets",
+						Label:  "Create Secret",
+					},
+				})
+			}
+		}
+
+		// Check 5: overlapping triggers
 		var key triggerKey
 		switch f.Integration {
 		case "linear", "shortcut", "github-issues":

--- a/pkg/hub/doctor.go
+++ b/pkg/hub/doctor.go
@@ -680,7 +680,7 @@ func (s *Server) checkTemplates(cfg *types.HubConfig, diskCfg *types.HubConfig) 
 								Category:    "templates",
 								Severity:    "warning",
 								Title:       fmt.Sprintf("Template %q uses deprecated secrets: list", name),
-								Description: fmt.Sprintf("Template %q uses the deprecated 'secrets:' list format. Migrate to 'secret_refs:' map.\n\nExample:\n  secret_refs:\n    LINEAR_API_KEY: linear_api_key\n\nDocs: https://elasticclaw.ai/docs/templates/secrets", name),
+								Description: fmt.Sprintf("Template %q uses the deprecated 'secrets:' list format. Migrate to 'secret_refs:' map.\n\nExample:\n  secret_refs:\n    LINEAR_API_KEY: linear_api_key\n\nDocs: https://www.elasticclaw.ai/docs/troubleshooting", name),
 								OK:          false,
 							})
 						}

--- a/pkg/hub/doctor.go
+++ b/pkg/hub/doctor.go
@@ -680,13 +680,8 @@ func (s *Server) checkTemplates(cfg *types.HubConfig, diskCfg *types.HubConfig) 
 								Category:    "templates",
 								Severity:    "warning",
 								Title:       fmt.Sprintf("Template %q uses deprecated secrets: list", name),
-								Description: fmt.Sprintf("Template %q uses the deprecated 'secrets:' list format. Migrate to 'secret_refs:' map.\n\nExample:\n  secret_refs:\n    LINEAR_API_KEY: linear_api_key\n\nSee: https://elasticclaw.ai/docs/templates/secrets", name),
+								Description: fmt.Sprintf("Template %q uses the deprecated 'secrets:' list format. Migrate to 'secret_refs:' map.\n\nExample:\n  secret_refs:\n    LINEAR_API_KEY: linear_api_key\n\nDocs: https://elasticclaw.ai/docs/templates/secrets", name),
 								OK:          false,
-								FixAction: &FixAction{
-									Type:   "navigate",
-									Target: "/settings/templates",
-									Label:  "Manage Templates",
-								},
 							})
 						}
 						// Check for missing secret_refs references

--- a/pkg/hub/factory_api.go
+++ b/pkg/hub/factory_api.go
@@ -47,6 +47,7 @@ type FactoryPushView struct {
 	WebhookSecretRef    string              `json:"webhook_secret_ref,omitempty"`
 	PipelineYAML        string              `json:"pipeline_yaml,omitempty"`
 	EnableManualTrigger bool                `json:"enable_manual_trigger,omitempty"`
+	SecretRefs          map[string]string    `json:"secret_refs,omitempty"`
 	Inputs              []types.FactoryInput `json:"inputs,omitempty"`
 }
 
@@ -65,6 +66,7 @@ func factoryToPushView(f *types.FactoryConfig) FactoryPushView {
 		WebhookSecretRef:    f.WebhookSecretRef,
 		PipelineYAML:        f.PipelineYAML,
 		EnableManualTrigger: f.EnableManualTrigger,
+		SecretRefs:          f.SecretRefs,
 		Inputs:              f.Inputs,
 	}
 }

--- a/pkg/hub/factory_creator.go
+++ b/pkg/hub/factory_creator.go
@@ -109,9 +109,10 @@ func (s *Server) createClawFromFactory(factory *types.FactoryConfig, issueID str
 		}
 	}
 
-	// Resolve and inject template-requested secrets
+	// Resolve and inject template-requested secrets (deprecated list format)
 	resolvedSecrets := make(map[string]string)
 	if tmplCfg != nil && len(tmplCfg.Secrets) > 0 {
+		log.Printf("[factory:%s] DEPRECATED: template %q uses 'secrets:' list — migrate to 'secret_refs:' map", factory.Name, factory.Template)
 		for _, ref := range tmplCfg.Secrets {
 			val, envName, ok := s.resolveSecretRef(ref, factory)
 			if ok {
@@ -122,7 +123,22 @@ func (s *Server) createClawFromFactory(factory *types.FactoryConfig, issueID str
 		}
 	}
 
+	// Resolve and inject template-level secret_refs (env var → hub secret name)
+	// Template-level refs go first; factory-level refs override them for the same env var.
+	if tmplCfg != nil && len(tmplCfg.SecretRefs) > 0 {
+		for envName, secretRef := range tmplCfg.SecretRefs {
+			if val, ok := s.hubCfg.Secrets[secretRef]; ok {
+				env[envName] = val
+				resolvedSecrets[envName] = val
+				log.Printf("[factory:%s] injected template secret_ref %s as %s into claw env", factory.Name, secretRef, envName)
+			} else {
+				log.Printf("[factory:%s] WARNING: template secret_ref %q not found in hub secrets", factory.Name, secretRef)
+			}
+		}
+	}
+
 	// Resolve and inject factory-level secret_refs (env var → hub secret name)
+	// Factory-level refs win over template-level refs for the same env var.
 	if len(factory.SecretRefs) > 0 {
 		for envName, secretRef := range factory.SecretRefs {
 			if val, ok := s.hubCfg.Secrets[secretRef]; ok {
@@ -178,13 +194,19 @@ func (s *Server) createClawFromFactory(factory *types.FactoryConfig, issueID str
 	}
 	for envName, val := range resolvedSecrets {
 		var refType string
-		// Check template secrets first
+		// Check template secrets (deprecated list format)
 		if tmplCfg != nil {
 			for _, ref := range tmplCfg.Secrets {
 				if ref.EnvVarName() == envName {
 					refType = ref.Type
 					break
 				}
+			}
+		}
+		// Check template secret_refs
+		if refType == "" && tmplCfg != nil {
+			if _, ok := tmplCfg.SecretRefs[envName]; ok {
+				refType = "template secret_ref"
 			}
 		}
 		// Check factory secret_refs

--- a/pkg/hub/factory_creator.go
+++ b/pkg/hub/factory_creator.go
@@ -117,7 +117,20 @@ func (s *Server) createClawFromFactory(factory *types.FactoryConfig, issueID str
 			if ok {
 				env[envName] = val
 				resolvedSecrets[envName] = val
-				log.Printf("[factory:%s] injected secret %s as %s into claw env", factory.Name, ref.Type, envName)
+				log.Printf("[factory:%s] injected template secret %s as %s into claw env", factory.Name, ref.Type, envName)
+			}
+		}
+	}
+
+	// Resolve and inject factory-level secret_refs (env var → hub secret name)
+	if len(factory.SecretRefs) > 0 {
+		for envName, secretRef := range factory.SecretRefs {
+			if val, ok := s.hubCfg.Secrets[secretRef]; ok {
+				env[envName] = val
+				resolvedSecrets[envName] = val
+				log.Printf("[factory:%s] injected factory secret_ref %s as %s into claw env", factory.Name, secretRef, envName)
+			} else {
+				log.Printf("[factory:%s] WARNING: secret_ref %q not found in hub secrets", factory.Name, secretRef)
 			}
 		}
 	}
@@ -165,10 +178,19 @@ func (s *Server) createClawFromFactory(factory *types.FactoryConfig, issueID str
 	}
 	for envName, val := range resolvedSecrets {
 		var refType string
-		for _, ref := range tmplCfg.Secrets {
-			if ref.EnvVarName() == envName {
-				refType = ref.Type
-				break
+		// Check template secrets first
+		if tmplCfg != nil {
+			for _, ref := range tmplCfg.Secrets {
+				if ref.EnvVarName() == envName {
+					refType = ref.Type
+					break
+				}
+			}
+		}
+		// Check factory secret_refs
+		if refType == "" {
+			if _, ok := factory.SecretRefs[envName]; ok {
+				refType = "factory secret_ref"
 			}
 		}
 		if refType == "" {

--- a/pkg/hub/github_issues.go
+++ b/pkg/hub/github_issues.go
@@ -626,10 +626,22 @@ func (s *Server) createClawForGitHubIssue(factory *types.FactoryConfig, payload 
 	}
 	for envName := range resolvedSecrets {
 		var refType string
-		for _, ref := range tmplCfg.Secrets {
-			if ref.EnvVarName() == envName {
-				refType = ref.Type
-				break
+		if tmplCfg != nil {
+			for _, ref := range tmplCfg.Secrets {
+				if ref.EnvVarName() == envName {
+					refType = ref.Type
+					break
+				}
+			}
+			if refType == "" {
+				if _, ok := tmplCfg.SecretRefs[envName]; ok {
+					refType = "template secret_ref"
+				}
+			}
+		}
+		if refType == "" {
+			if _, ok := factory.SecretRefs[envName]; ok {
+				refType = "factory secret_ref"
 			}
 		}
 		if refType == "" {

--- a/pkg/hub/github_issues.go
+++ b/pkg/hub/github_issues.go
@@ -543,14 +543,41 @@ func (s *Server) createClawForGitHubIssue(factory *types.FactoryConfig, payload 
 	// Resolve and inject template-requested secrets
 	resolvedSecrets := make(map[string]string)
 	if tmplCfg != nil && len(tmplCfg.Secrets) > 0 {
+		log.Printf("[factory:%s] DEPRECATED: template %q uses 'secrets:' list — migrate to 'secret_refs:' map", factory.Name, factory.Template)
 		for _, ref := range tmplCfg.Secrets {
 			secretVal, envName, ok := s.resolveSecretRef(ref, factory)
 			if ok {
 				env[envName] = secretVal
 				resolvedSecrets[envName] = secretVal
-				log.Printf("[factory:%s] injected secret %s as %s into claw env", factory.Name, ref.Type, envName)
+				log.Printf("[factory:%s] injected template secret %s as %s into claw env", factory.Name, ref.Type, envName)
 			} else {
 				log.Printf("[factory:%s] warning: requested secret (type=%s name=%s workspace=%s) not found", factory.Name, ref.Type, ref.Name, ref.Workspace)
+			}
+		}
+	}
+
+	// Resolve and inject template-level secret_refs
+	if tmplCfg != nil && len(tmplCfg.SecretRefs) > 0 {
+		for envName, secretRef := range tmplCfg.SecretRefs {
+			if val, ok := s.hubCfg.Secrets[secretRef]; ok {
+				env[envName] = val
+				resolvedSecrets[envName] = val
+				log.Printf("[factory:%s] injected template secret_ref %s as %s into claw env", factory.Name, secretRef, envName)
+			} else {
+				log.Printf("[factory:%s] WARNING: template secret_ref %q not found in hub secrets", factory.Name, secretRef)
+			}
+		}
+	}
+
+	// Resolve and inject factory-level secret_refs (factory overrides template)
+	if len(factory.SecretRefs) > 0 {
+		for envName, secretRef := range factory.SecretRefs {
+			if val, ok := s.hubCfg.Secrets[secretRef]; ok {
+				env[envName] = val
+				resolvedSecrets[envName] = val
+				log.Printf("[factory:%s] injected factory secret_ref %s as %s into claw env", factory.Name, secretRef, envName)
+			} else {
+				log.Printf("[factory:%s] WARNING: secret_ref %q not found in hub secrets", factory.Name, secretRef)
 			}
 		}
 	}

--- a/pkg/hub/github_webhook.go
+++ b/pkg/hub/github_webhook.go
@@ -540,13 +540,38 @@ func (s *Server) createClawForGitHubPR(factory *types.FactoryConfig, pr githubPR
 
 	// Resolve and inject template-requested secrets (typed refs + legacy)
 	if tmplCfg != nil && len(tmplCfg.Secrets) > 0 {
+		log.Printf("[factory:%s] DEPRECATED: template %q uses 'secrets:' list — migrate to 'secret_refs:' map", factory.Name, factory.Template)
 		for _, ref := range tmplCfg.Secrets {
 			val, envName, ok := s.resolveSecretRef(ref, factory)
 			if ok {
 				env[envName] = val
-				log.Printf("[factory:%s] injected secret %s as %s into claw env", factory.Name, ref.Type, envName)
+				log.Printf("[factory:%s] injected template secret %s as %s into claw env", factory.Name, ref.Type, envName)
 			} else {
 				log.Printf("[factory:%s] warning: requested secret (type=%s name=%s workspace=%s) not found", factory.Name, ref.Type, ref.Name, ref.Workspace)
+			}
+		}
+	}
+
+	// Resolve and inject template-level secret_refs
+	if tmplCfg != nil && len(tmplCfg.SecretRefs) > 0 {
+		for envName, secretRef := range tmplCfg.SecretRefs {
+			if val, ok := s.hubCfg.Secrets[secretRef]; ok {
+				env[envName] = val
+				log.Printf("[factory:%s] injected template secret_ref %s as %s into claw env", factory.Name, secretRef, envName)
+			} else {
+				log.Printf("[factory:%s] WARNING: template secret_ref %q not found in hub secrets", factory.Name, secretRef)
+			}
+		}
+	}
+
+	// Resolve and inject factory-level secret_refs (factory overrides template)
+	if len(factory.SecretRefs) > 0 {
+		for envName, secretRef := range factory.SecretRefs {
+			if val, ok := s.hubCfg.Secrets[secretRef]; ok {
+				env[envName] = val
+				log.Printf("[factory:%s] injected factory secret_ref %s as %s into claw env", factory.Name, secretRef, envName)
+			} else {
+				log.Printf("[factory:%s] WARNING: secret_ref %q not found in hub secrets", factory.Name, secretRef)
 			}
 		}
 	}

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -686,13 +686,38 @@ func (s *Server) provisionPendingClaw(clawID string) {
 
 	// Resolve and inject template-requested secrets (same as factory create paths).
 	if tmplCfg != nil && len(tmplCfg.Secrets) > 0 && factory != nil {
+		log.Printf("[factory] DEPRECATED: template %q uses 'secrets:' list — migrate to 'secret_refs:' map", template)
 		for _, ref := range tmplCfg.Secrets {
 			secretVal, envName, ok := s.resolveSecretRef(ref, factory)
 			if ok {
 				env[envName] = secretVal
-				log.Printf("[factory] injected secret %s as %s into pending claw %s env", ref.Type, envName, clawID[:8])
+				log.Printf("[factory] injected template secret %s as %s into pending claw %s env", ref.Type, envName, clawID[:8])
 			} else {
 				log.Printf("[factory] warning: requested secret (type=%s name=%s workspace=%s) not found for pending claw %s", ref.Type, ref.Name, ref.Workspace, clawID[:8])
+			}
+		}
+	}
+
+	// Resolve and inject template-level secret_refs
+	if tmplCfg != nil && len(tmplCfg.SecretRefs) > 0 {
+		for envName, secretRef := range tmplCfg.SecretRefs {
+			if val, ok := s.hubCfg.Secrets[secretRef]; ok {
+				env[envName] = val
+				log.Printf("[factory] injected template secret_ref %s as %s into pending claw %s env", secretRef, envName, clawID[:8])
+			} else {
+				log.Printf("[factory] WARNING: template secret_ref %q not found in hub secrets for pending claw %s", secretRef, clawID[:8])
+			}
+		}
+	}
+
+	// Resolve and inject factory-level secret_refs (factory overrides template)
+	if factory != nil && len(factory.SecretRefs) > 0 {
+		for envName, secretRef := range factory.SecretRefs {
+			if val, ok := s.hubCfg.Secrets[secretRef]; ok {
+				env[envName] = val
+				log.Printf("[factory] injected factory secret_ref %s as %s into pending claw %s env", secretRef, envName, clawID[:8])
+			} else {
+				log.Printf("[factory] WARNING: factory secret_ref %q not found in hub secrets for pending claw %s", secretRef, clawID[:8])
 			}
 		}
 	}

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -134,6 +134,7 @@ type FactoryView struct {
 	Enabled             bool     `json:"enabled"`
 	ConcurrencyGroup    string   `json:"concurrencyGroup,omitempty"`
 	EnableManualTrigger bool     `json:"enable_manual_trigger,omitempty"`
+	SecretRefs          map[string]string `json:"secret_refs,omitempty"`
 }
 
 type ProviderView struct {
@@ -287,6 +288,7 @@ type FactoryPatch struct {
 	Enabled             *bool               `json:"enabled,omitempty"`
 	ConcurrencyGroup    string              `json:"concurrencyGroup,omitempty"`
 	EnableManualTrigger bool                `json:"enable_manual_trigger,omitempty"`
+	SecretRefs          map[string]string   `json:"secret_refs,omitempty"`
 	Inputs              []types.FactoryInput `json:"inputs,omitempty"`
 	Repos               []string            `json:"repos,omitempty"`
 	Trigger             *types.GitHubTrigger `json:"trigger,omitempty"`
@@ -480,6 +482,7 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 			Enabled:             isFactoryEnabled(f),
 			ConcurrencyGroup:    f.ConcurrencyGroup,
 			EnableManualTrigger: f.EnableManualTrigger,
+			SecretRefs:          f.SecretRefs,
 		})
 	}
 	// Auth config
@@ -1028,6 +1031,9 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 				disk.ConcurrencyGroup = fp.ConcurrencyGroup
 			}
 			disk.EnableManualTrigger = fp.EnableManualTrigger
+			if fp.SecretRefs != nil {
+				disk.SecretRefs = fp.SecretRefs
+			}
 			if fp.Inputs != nil {
 				disk.Inputs = fp.Inputs
 			}

--- a/pkg/hub/shortcut.go
+++ b/pkg/hub/shortcut.go
@@ -461,13 +461,38 @@ func (s *Server) createClawForShortcutStory(factory *types.FactoryConfig, action
 
 	// Resolve and inject template-requested secrets (typed refs + legacy)
 	if tmplCfg != nil && len(tmplCfg.Secrets) > 0 {
+		log.Printf("[factory:%s] DEPRECATED: template %q uses 'secrets:' list — migrate to 'secret_refs:' map", factory.Name, factory.Template)
 		for _, ref := range tmplCfg.Secrets {
 			val, envName, ok := s.resolveSecretRef(ref, factory)
 			if ok {
 				env[envName] = val
-				log.Printf("[factory:%s] injected secret %s as %s into claw env", factory.Name, ref.Type, envName)
+				log.Printf("[factory:%s] injected template secret %s as %s into claw env", factory.Name, ref.Type, envName)
 			} else {
 				log.Printf("[factory:%s] warning: requested secret (type=%s name=%s workspace=%s) not found", factory.Name, ref.Type, ref.Name, ref.Workspace)
+			}
+		}
+	}
+
+	// Resolve and inject template-level secret_refs
+	if tmplCfg != nil && len(tmplCfg.SecretRefs) > 0 {
+		for envName, secretRef := range tmplCfg.SecretRefs {
+			if val, ok := s.hubCfg.Secrets[secretRef]; ok {
+				env[envName] = val
+				log.Printf("[factory:%s] injected template secret_ref %s as %s into claw env", factory.Name, secretRef, envName)
+			} else {
+				log.Printf("[factory:%s] WARNING: template secret_ref %q not found in hub secrets", factory.Name, secretRef)
+			}
+		}
+	}
+
+	// Resolve and inject factory-level secret_refs (factory overrides template)
+	if len(factory.SecretRefs) > 0 {
+		for envName, secretRef := range factory.SecretRefs {
+			if val, ok := s.hubCfg.Secrets[secretRef]; ok {
+				env[envName] = val
+				log.Printf("[factory:%s] injected factory secret_ref %s as %s into claw env", factory.Name, secretRef, envName)
+			} else {
+				log.Printf("[factory:%s] WARNING: secret_ref %q not found in hub secrets", factory.Name, secretRef)
 			}
 		}
 	}

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -112,7 +112,12 @@ type TemplateConfig struct {
 	// into the claw. Each entry can be a plain string (legacy: secret name from
 	// hub.yaml secrets, injected with that name) or a typed SecretRef that
 	// resolves the right secret and maps it to the correct env var name.
+	// DEPRECATED: Use secret_refs instead. Kept for backward compatibility.
 	Secrets SecretRefList `yaml:"secrets,omitempty"`
+	// SecretRefs maps env var names to hub secret names to inject into claws
+	// created from this template. Resolved at claw creation time.
+	// Example: {LINEAR_API_KEY: linear_api_key}
+	SecretRefs map[string]string `yaml:"secret_refs,omitempty"`
 	// MCPs is a list of MCP server names from hub.yaml mcp_servers to enable
 	// in this template's claws. Each claw will start these MCP servers as
 	// subprocesses and register their tools with the gateway.

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -448,6 +448,9 @@ type FactoryConfig struct {
 	ConcurrencyGroup string `yaml:"concurrency_group,omitempty" json:"concurrencyGroup,omitempty"`
 	// EnableManualTrigger allows this factory to be triggered manually from the dashboard.
 	EnableManualTrigger bool `yaml:"enable_manual_trigger,omitempty" json:"enable_manual_trigger,omitempty"`
+	// SecretRefs maps env var names to hub secret names to inject into claws
+	// created by this factory. Resolved at claw creation time.
+	SecretRefs map[string]string `yaml:"secret_refs,omitempty" json:"secret_refs,omitempty"`
 	// GitHub factory fields (integration: github)
 	Repos   []string       `yaml:"repos,omitempty"`   // e.g. ["can-io/canio", "can-io/*"]
 	Trigger *GitHubTrigger `yaml:"trigger,omitempty"`

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -3323,6 +3323,28 @@ function TemplatesSection() {
   )
 }
 
+// linkifyText converts URLs in text into clickable <a> elements.
+function linkifyText(text: string): React.ReactNode {
+  const urlRegex = /(https?:\/\/[^\s]+)/g
+  const parts = text.split(urlRegex)
+  return parts.map((part, i) => {
+    if (part.match(urlRegex)) {
+      return (
+        <a
+          key={i}
+          href={part}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary hover:underline"
+        >
+          {part}
+        </a>
+      )
+    }
+    return part
+  })
+}
+
 function DoctorSection() {
   const [report, setReport] = useState<any>(null)
   const [loading, setLoading] = useState(false)
@@ -3451,7 +3473,7 @@ function DoctorSection() {
                         {!check.ok && severityBadge(check.severity)}
                       </div>
                       <p className="text-sm font-medium mt-1">{check.title}</p>
-                      <p className="text-sm text-muted-foreground mt-0.5">{check.description}</p>
+                      <p className="text-sm text-muted-foreground mt-0.5 whitespace-pre-wrap">{linkifyText(check.description)}</p>
                       {check.error && (
                         <p className="text-xs text-red-400 mt-1 font-mono">{check.error}</p>
                       )}

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -266,6 +266,7 @@ export interface Factory {
   webhook_secret_ref?: string
   pipeline_yaml?: string
   enable_manual_trigger?: boolean
+  secret_refs?: Record<string, string>
   inputs?: FactoryInput[]
 }
 


### PR DESCRIPTION
## Summary

Adds \+secret_refs\+ map to TemplateConfig, consistent with the factory-level `secret_refs` format. The legacy `secrets:` list format is still supported but marked deprecated.

## Changes

- **TemplateConfig**: Added `SecretRefs map[string]string` field (env var → hub secret name)
- **Backward compatibility**: The existing `Secrets SecretRefList` (typed list) still works — no breaking changes
- **Deprecation logging**: Logs a warning when a template uses the old `secrets:` list format
- **Doctor checks**:
  - Warns when templates use deprecated `secrets:` list format
  - Validates template `secret_refs` references point to existing hub secrets
- **All injection paths updated**: factory_creator, linear, github_issues, github_webhook, shortcut

## Migration Example

**Old (deprecated):**
```yaml
secrets:
  - type: linear
    workspace: my-team
```

**New:**
```yaml
secret_refs:
  LINEAR_API_KEY: linear_api_key
```

## Why

Factories already use `secret_refs` (env var → hub secret name). Templates should use the same format for consistency. The old `secrets:` list with typed `SecretRef` objects is more complex and less intuitive.