### PR TITLE
feat: doctor page hides passed checks by default

### DIFF
--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -3389,7 +3389,7 @@ function DoctorSection() {
               Cached {new Date(report.cachedAt).toLocaleTimeString()}
             </span>
           )}
-          {report && (
+          {report && passedChecks.length > 0 && (
             <Button
               size="sm"
               variant={showPassed ? "default" : "outline"}

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -3327,6 +3327,7 @@ function DoctorSection() {
   const [report, setReport] = useState<any>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [showPassed, setShowPassed] = useState(false)
 
   const load = useCallback(async (refresh = false) => {
     setLoading(true)
@@ -3346,6 +3347,11 @@ function DoctorSection() {
   }, [])
 
   useEffect(() => { load() }, [load])
+
+  const failedChecks = report?.checks?.filter((c: any) => !c.ok) || []
+  const passedChecks = report?.checks?.filter((c: any) => c.ok) || []
+  const visibleChecks = showPassed ? report?.checks || [] : failedChecks
+  const allPassing = failedChecks.length === 0 && report?.checks?.length > 0
 
   const severityIcon = (s: string) => {
     switch (s) {
@@ -3383,6 +3389,16 @@ function DoctorSection() {
               Cached {new Date(report.cachedAt).toLocaleTimeString()}
             </span>
           )}
+          {report && (
+            <Button
+              size="sm"
+              variant={showPassed ? "default" : "outline"}
+              onClick={() => setShowPassed(!showPassed)}
+            >
+              <CheckCircle2 className="size-3.5 mr-1.5" />
+              {showPassed ? "Hide passed" : `Show passed (${passedChecks.length})`}
+            </Button>
+          )}
           <Button size="sm" variant="outline" onClick={() => load(true)} disabled={loading}>
             <RotateCcw className={cn("size-3.5 mr-1.5", loading && "animate-spin")} />
             {loading ? "Checking…" : "Refresh"}
@@ -3417,11 +3433,21 @@ function DoctorSection() {
             </div>
           </div>
 
-          {report.checks.length === 0 ? (
-            <p className="text-sm text-muted-foreground">All checks passed — no issues found.</p>
+          {visibleChecks.length === 0 ? (
+            allPassing ? (
+              <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/5 p-6 text-center">
+                <CheckCircle2 className="size-8 text-emerald-500 mx-auto mb-2" />
+                <p className="text-sm font-medium text-emerald-500">All checks passing</p>
+                <p className="text-xs text-muted-foreground mt-1">
+                  {report.summary.passed} check{report.summary.passed !== 1 ? "s" : ""} passed with no issues
+                </p>
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground">No checks to display.</p>
+            )
           ) : (
             <div className="space-y-3">
-              {report.checks.map((check: any, i: number) => (
+              {visibleChecks.map((check: any, i: number) => (
                 <div
                   key={i}
                   className={cn(


### PR DESCRIPTION
## Summary

The Doctor page was cluttered with passing checks. Now it focuses on issues.

## Changes

- **Passed checks hidden by default** — only shows warnings/errors
- **Toggle button** — "Show passed (N)" / "Hide passed" to reveal them
- **Happy state** — when all checks pass, shows a green "All checks passing" card with count instead of an empty list
- Summary stats still show total/passed counts at the top