### PR TITLE
feat: manual trigger creation stays on dashboard

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -316,7 +316,6 @@ export default function Home() {
         open={!!selectedFactory}
         onOpenChange={(open) => { if (!open) setSelectedFactory(null) }}
         factory={selectedFactory}
-        onClawCreated={() => setSelectedFactory(null)}
       />
     </div>
   )

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -316,7 +316,7 @@ export default function Home() {
         open={!!selectedFactory}
         onOpenChange={(open) => { if (!open) setSelectedFactory(null) }}
         factory={selectedFactory}
-        onClawCreated={handleSelectClaw}
+        onClawCreated={() => setSelectedFactory(null)}
       />
     </div>
   )

--- a/web/components/manual-trigger-modal.tsx
+++ b/web/components/manual-trigger-modal.tsx
@@ -19,10 +19,9 @@ interface ManualTriggerModalProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   factory?: Factory | null
-  onClawCreated?: (clawId: string) => void
 }
 
-export function ManualTriggerModal({ open, onOpenChange, factory, onClawCreated }: ManualTriggerModalProps) {
+export function ManualTriggerModal({ open, onOpenChange, factory }: ManualTriggerModalProps) {
   const [inputValues, setInputValues] = useState<Record<string, string>>({})
   const [triggering, setTriggering] = useState(false)
   const [triggerError, setTriggerError] = useState<string | null>(null)
@@ -80,16 +79,15 @@ export function ManualTriggerModal({ open, onOpenChange, factory, onClawCreated 
           }
         }
       }
-      const res = await triggerFactory(factory.name, inputs)
+      await triggerFactory(factory.name, inputs)
       setTriggering(false)
       onOpenChange(false)
-      onClawCreated?.(res.claw_id)
     } catch (e) {
       setTriggering(false)
       // Keep modal open so user sees the backend validation error
       setTriggerError(e instanceof Error ? e.message : String(e))
     }
-  }, [factory, inputValues, onOpenChange, onClawCreated])
+  }, [factory, inputValues, onOpenChange])
 
   if (!factory) return null
 


### PR DESCRIPTION
After creating a claw via the + button manual trigger modal, stay on the dashboard instead of navigating into the newly created claw.