### PR TITLE
fix: check HTTP status before parsing GitHub API response

### DIFF
--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -952,6 +952,9 @@ func githubAPIListWithBase(baseURL, path, token string) ([]interface{}, error) {
 	}
 	defer resp.Body.Close()
 	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("github API returned status %d: %s", resp.StatusCode, string(body))
+	}
 	var result []interface{}
 	if err := json.Unmarshal(body, &result); err != nil {
 		return nil, fmt.Errorf("github API list parse error: %w", err)

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -951,7 +951,10 @@ func githubAPIListWithBase(baseURL, path, token string) ([]interface{}, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	body, _ := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("github API response read error: %w", err)
+	}
 	if resp.StatusCode >= 400 {
 		return nil, fmt.Errorf("github API returned status %d: %s", resp.StatusCode, string(body))
 	}


### PR DESCRIPTION
Fixes confusing parse error when GitHub API returns an error object.

**Before:**  blindly unmarshaled the response body into . When GitHub returned an error (401/403/404/etc — an object, not an array),  failed with:


**After:** Checks  before parsing and returns the actual status + body, so logs show the real error instead of a confusing parse failure.

**Example log after fix:**
