### PR TITLE
fix: align INSERT statements with claws table schema

### DIFF
--- a/pkg/hub/github_issues.go
+++ b/pkg/hub/github_issues.go
@@ -717,10 +717,10 @@ func (s *Server) createClawForGitHubIssue(factory *types.FactoryConfig, payload 
 	}
 
 	_, err = s.db.Exec(`
-		INSERT INTO claws(id, tenant_id, name, template, provider, default_model, template_files, github_repos, linear_workspace, nix, docker, tags, color, llm_key, auto_fix_ci, auto_fix_bugbot, github_issue_id, status, created_at, factory_name, concurrency_group)
-		VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		INSERT INTO claws(id, tenant_id, name, template, provider, default_model, template_files, github_repos, linear_workspace, nix, docker, tags, color, llm_key, auto_fix_ci, auto_fix_bugbot, linear_issue_id, github_issue_id, shortcut_story_id, status, created_at, factory_name, concurrency_group)
+		VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
 		clawID, tenantID, clawName, factory.Template, provider, defaultModel, string(filesJSON),
-		string(githubReposJSON), linearWorkspace, nixEnabled, dockerEnabled, string(tagsJSON), clawColor, llmKey, autoFixCI, autoFixBugbot, issueID, initialStatus, now, factory.Name, groupName,
+		string(githubReposJSON), linearWorkspace, nixEnabled, dockerEnabled, string(tagsJSON), clawColor, llmKey, autoFixCI, autoFixBugbot, "", issueID, "", initialStatus, now, factory.Name, groupName,
 	)
 
 	// Release promoteMu immediately after INSERT so we don't hold it across

--- a/pkg/hub/github_webhook.go
+++ b/pkg/hub/github_webhook.go
@@ -656,11 +656,13 @@ func (s *Server) createClawForGitHubPR(factory *types.FactoryConfig, pr githubPR
 	filesJSON, _ := json.Marshal(templateFiles)
 	createdAt := now()
 
+	groupName, _ := s.resolveGroupLimit(factory)
+
 	_, err = s.db.Exec(`
-		INSERT INTO claws(id, tenant_id, name, template, provider, default_model, template_files, github_repos, linear_workspace, nix, docker, tags, color, llm_key, auto_fix_ci, auto_fix_bugbot, linear_issue_id, status, created_at)
-		VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,'provisioning',?)`,
+		INSERT INTO claws(id, tenant_id, name, template, provider, default_model, template_files, github_repos, linear_workspace, nix, docker, tags, color, llm_key, auto_fix_ci, auto_fix_bugbot, linear_issue_id, github_issue_id, shortcut_story_id, status, created_at, factory_name, concurrency_group)
+		VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,'provisioning',?,?,?)`,
 		clawID, tenantID, clawName, factory.Template, provider, defaultModel, string(filesJSON),
-		string(githubReposJSON), linearWorkspace, nixEnabled, dockerEnabled, string(tagsJSON), clawColor, llmKey, autoFixCI, autoFixBugbot, "", createdAt,
+		string(githubReposJSON), linearWorkspace, nixEnabled, dockerEnabled, string(tagsJSON), clawColor, llmKey, autoFixCI, autoFixBugbot, "", "", "", createdAt, factory.Name, groupName,
 	)
 	if err != nil {
 		return fmt.Errorf("db insert: %w", err)


### PR DESCRIPTION
The claws table schema has 25 columns. Two INSERT statements were out of sync:

1. github_issues.go: 21 columns + 22 values (missing linear_issue_id, shortcut_story_id; one extra value). Fixed to 25 columns + 25 values.

2. github_webhook.go: 17 columns + hardcoded 'provisioning' status (missing github_issue_id, shortcut_story_id, factory_name, concurrency_group). Also missing resolveGroupLimit() call. Fixed to 25 columns + 25 values.

Both now match the canonical INSERT in factory_creator.go.