### PR TITLE
fix: align INSERT statements with claws table schema

### DIFF
--- a/pkg/hub/github_issues.go
+++ b/pkg/hub/github_issues.go
@@ -718,7 +718,7 @@ func (s *Server) createClawForGitHubIssue(factory *types.FactoryConfig, payload 
 
 	_, err = s.db.Exec(`
 		INSERT INTO claws(id, tenant_id, name, template, provider, default_model, template_files, github_repos, linear_workspace, nix, docker, tags, color, llm_key, auto_fix_ci, auto_fix_bugbot, linear_issue_id, github_issue_id, shortcut_story_id, status, created_at, factory_name, concurrency_group)
-		VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
 		clawID, tenantID, clawName, factory.Template, provider, defaultModel, string(filesJSON),
 		string(githubReposJSON), linearWorkspace, nixEnabled, dockerEnabled, string(tagsJSON), clawColor, llmKey, autoFixCI, autoFixBugbot, "", issueID, "", initialStatus, now, factory.Name, groupName,
 	)

--- a/pkg/hub/github_issues.go
+++ b/pkg/hub/github_issues.go
@@ -717,10 +717,10 @@ func (s *Server) createClawForGitHubIssue(factory *types.FactoryConfig, payload 
 	}
 
 	_, err = s.db.Exec(`
-		INSERT INTO claws(id, tenant_id, name, template, provider, default_model, template_files, github_repos, linear_workspace, nix, docker, tags, color, llm_key, auto_fix_ci, auto_fix_bugbot, github_issue_id, status, created_at, factory_name, concurrency_group)
-		VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		INSERT INTO claws(id, tenant_id, name, template, provider, default_model, template_files, github_repos, linear_workspace, nix, docker, tags, color, llm_key, auto_fix_ci, auto_fix_bugbot, linear_issue_id, github_issue_id, shortcut_story_id, status, created_at, factory_name, concurrency_group)
+		VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
 		clawID, tenantID, clawName, factory.Template, provider, defaultModel, string(filesJSON),
-		string(githubReposJSON), linearWorkspace, nixEnabled, dockerEnabled, string(tagsJSON), clawColor, llmKey, autoFixCI, autoFixBugbot, issueID, initialStatus, now, factory.Name, groupName,
+		string(githubReposJSON), linearWorkspace, nixEnabled, dockerEnabled, string(tagsJSON), clawColor, llmKey, autoFixCI, autoFixBugbot, "", issueID, "", initialStatus, now, factory.Name, groupName,
 	)
 
 	// Release promoteMu immediately after INSERT so we don't hold it across

--- a/pkg/hub/github_webhook.go
+++ b/pkg/hub/github_webhook.go
@@ -656,13 +656,15 @@ func (s *Server) createClawForGitHubPR(factory *types.FactoryConfig, pr githubPR
 	filesJSON, _ := json.Marshal(templateFiles)
 	createdAt := now()
 
+	s.mu.RLock()
 	groupName, _ := s.resolveGroupLimit(factory)
+	s.mu.RUnlock()
 
 	_, err = s.db.Exec(`
 		INSERT INTO claws(id, tenant_id, name, template, provider, default_model, template_files, github_repos, linear_workspace, nix, docker, tags, color, llm_key, auto_fix_ci, auto_fix_bugbot, linear_issue_id, github_issue_id, shortcut_story_id, status, created_at, factory_name, concurrency_group)
-		VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,'provisioning',?,?,?)`,
+		VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
 		clawID, tenantID, clawName, factory.Template, provider, defaultModel, string(filesJSON),
-		string(githubReposJSON), linearWorkspace, nixEnabled, dockerEnabled, string(tagsJSON), clawColor, llmKey, autoFixCI, autoFixBugbot, "", "", "", createdAt, factory.Name, groupName,
+		string(githubReposJSON), linearWorkspace, nixEnabled, dockerEnabled, string(tagsJSON), clawColor, llmKey, autoFixCI, autoFixBugbot, "", "", "", "provisioning", createdAt, factory.Name, groupName,
 	)
 	if err != nil {
 		return fmt.Errorf("db insert: %w", err)

--- a/pkg/hub/github_webhook.go
+++ b/pkg/hub/github_webhook.go
@@ -656,16 +656,38 @@ func (s *Server) createClawForGitHubPR(factory *types.FactoryConfig, pr githubPR
 	filesJSON, _ := json.Marshal(templateFiles)
 	createdAt := now()
 
+	// Check concurrency limit — serialize with promoteMu to prevent TOCTOU
+	// race where concurrent factory webhooks both read active < max and both
+	// insert as provisioning, exceeding the limit.
+	s.promoteMu.Lock()
+
 	s.mu.RLock()
-	groupName, _ := s.resolveGroupLimit(factory)
+	groupName, groupLimit := s.resolveGroupLimit(factory)
 	s.mu.RUnlock()
+
+	activeCount := s.countActiveClawsInGroup(groupName)
+	isPending := false
+	if groupLimit > 0 && activeCount >= groupLimit {
+		isPending = true
+		log.Printf("[factory] concurrency limit reached for group %q (active=%d, limit=%d) — queueing claw for GitHub PR %s#%d as pending", groupName, activeCount, groupLimit, repoFullName, prNumber)
+	}
+
+	initialStatus := "provisioning"
+	if isPending {
+		initialStatus = "pending"
+	}
 
 	_, err = s.db.Exec(`
 		INSERT INTO claws(id, tenant_id, name, template, provider, default_model, template_files, github_repos, linear_workspace, nix, docker, tags, color, llm_key, auto_fix_ci, auto_fix_bugbot, linear_issue_id, github_issue_id, shortcut_story_id, status, created_at, factory_name, concurrency_group)
 		VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
 		clawID, tenantID, clawName, factory.Template, provider, defaultModel, string(filesJSON),
-		string(githubReposJSON), linearWorkspace, nixEnabled, dockerEnabled, string(tagsJSON), clawColor, llmKey, autoFixCI, autoFixBugbot, "", "", "", "provisioning", createdAt, factory.Name, groupName,
+		string(githubReposJSON), linearWorkspace, nixEnabled, dockerEnabled, string(tagsJSON), clawColor, llmKey, autoFixCI, autoFixBugbot, "", "", "", initialStatus, createdAt, factory.Name, groupName,
 	)
+
+	// Release promoteMu immediately after INSERT so we don't hold it across
+	// the potentially slow async provisioning below.
+	s.promoteMu.Unlock()
+
 	if err != nil {
 		return fmt.Errorf("db insert: %w", err)
 	}
@@ -677,6 +699,16 @@ func (s *Server) createClawForGitHubPR(factory *types.FactoryConfig, pr githubPR
 	s.logFactoryEvent(factory.Name,
 		fmt.Sprintf("%s#%d", repoFullName, prNumber),
 		pr.PullRequest.Title, "", pr.Action, "claw_created", clawID, "")
+
+	log.Printf("[factory] created claw %s (%s) for GitHub PR %s#%d (status=%s)", clawName, clawID[:8], repoFullName, prNumber, initialStatus)
+	s.broadcastToUsers(tenantID, types.WSMessage{
+		Type:    "claw_status",
+		Payload: map[string]string{"claw_id": clawID, "status": initialStatus},
+	})
+
+	if isPending {
+		return nil
+	}
 
 	// Provision asynchronously
 	provCfg, _ := s.hubCfg.Providers[provider]
@@ -725,12 +757,6 @@ func (s *Server) createClawForGitHubPR(factory *types.FactoryConfig, pr githubPR
 			s.stopAgentWithReason(clawID, fmt.Sprintf("Factory provision failed: %v", provErr), false)
 		}
 	}()
-
-	log.Printf("[factory] created claw %s (%s) for GitHub PR %s#%d", clawName, clawID[:8], repoFullName, prNumber)
-	s.broadcastToUsers(tenantID, types.WSMessage{
-		Type:    "claw_status",
-		Payload: map[string]string{"claw_id": clawID, "status": "provisioning"},
-	})
 
 	return nil
 }

--- a/pkg/hub/github_webhook.go
+++ b/pkg/hub/github_webhook.go
@@ -656,11 +656,13 @@ func (s *Server) createClawForGitHubPR(factory *types.FactoryConfig, pr githubPR
 	filesJSON, _ := json.Marshal(templateFiles)
 	createdAt := now()
 
+	groupName, _ := s.resolveGroupLimit(factory)
+
 	_, err = s.db.Exec(`
-		INSERT INTO claws(id, tenant_id, name, template, provider, default_model, template_files, github_repos, linear_workspace, nix, docker, tags, color, llm_key, auto_fix_ci, auto_fix_bugbot, linear_issue_id, status, created_at)
-		VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,'provisioning',?)`,
+		INSERT INTO claws(id, tenant_id, name, template, provider, default_model, template_files, github_repos, linear_workspace, nix, docker, tags, color, llm_key, auto_fix_ci, auto_fix_bugbot, linear_issue_id, github_issue_id, shortcut_story_id, status, created_at, factory_name, concurrency_group)
+		VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,'provisioning',?,?,?)`,
 		clawID, tenantID, clawName, factory.Template, provider, defaultModel, string(filesJSON),
-		string(githubReposJSON), linearWorkspace, nixEnabled, dockerEnabled, string(tagsJSON), clawColor, llmKey, autoFixCI, autoFixBugbot, "", createdAt,
+		string(githubReposJSON), linearWorkspace, nixEnabled, dockerEnabled, string(tagsJSON), clawColor, llmKey, autoFixCI, autoFixBugbot, "", "", "", createdAt, factory.Name, groupName,
 	)
 	if err != nil {
 		return fmt.Errorf("db insert: %w", err)


### PR DESCRIPTION
The claws table schema has 25 columns. Two INSERT statements were out of sync:

1. github_issues.go: 21 columns + 22 values (missing linear_issue_id, shortcut_story_id; one extra value). Fixed to 25 columns + 25 values.

2. github_webhook.go: 17 columns + hardcoded 'provisioning' status (missing github_issue_id, shortcut_story_id, factory_name, concurrency_group). Also missing resolveGroupLimit() call. Fixed to 25 columns + 25 values.

Both now match the canonical INSERT in factory_creator.go.