### PR TITLE
feat: better claw title for manual factory triggers

### DIFF
--- a/pkg/hub/factory_creator.go
+++ b/pkg/hub/factory_creator.go
@@ -73,6 +73,19 @@ func (s *Server) createClawFromFactory(factory *types.FactoryConfig, issueID str
 	if clawName == factory.Name && issueID != "" {
 		clawName = issueID
 	}
+	// For manual triggers without a name_pattern, generate a descriptive name
+	// using the first input value (e.g., "my-factory: fix login bug")
+	if clawName == factory.Name && inputs != nil && len(inputs) > 0 {
+		// Use the first input's value as the descriptive part
+		var firstVal string
+		for _, v := range inputs {
+			firstVal = v
+			break
+		}
+		if firstVal != "" {
+			clawName = factory.Name + ": " + firstVal
+		}
+	}
 
 	// Find tenant
 	var tenantID string

--- a/pkg/hub/factory_creator.go
+++ b/pkg/hub/factory_creator.go
@@ -75,14 +75,12 @@ func (s *Server) createClawFromFactory(factory *types.FactoryConfig, issueID str
 	}
 	// For manual triggers without a name_pattern, generate a descriptive name
 	// using the first input value (e.g., "my-factory: fix login bug")
-	if clawName == factory.Name && inputs != nil && len(inputs) > 0 {
-		// Use the first input's value as the descriptive part
-		var firstVal string
-		for _, v := range inputs {
-			firstVal = v
-			break
-		}
-		if firstVal != "" {
+	if clawName == factory.Name && inputs != nil && len(factory.Inputs) > 0 {
+		// Use the first defined input's value as the descriptive part.
+		// factory.Inputs is an ordered slice, so this is deterministic even
+		// when inputs contains multiple keys (Go map iteration order is random).
+		firstKey := factory.Inputs[0].Name
+		if firstVal := inputs[firstKey]; firstVal != "" {
 			clawName = factory.Name + ": " + firstVal
 		}
 	}


### PR DESCRIPTION
When a factory is triggered manually without a name_pattern, the claw name now includes the first input value instead of just the factory name.

Before: factory name = "feature-factory"
After:  factory name = "feature-factory: fix login bug" (using first input)

This makes manually triggered claws more descriptive and easier to distinguish in the dashboard, matching the usefulness of webhook- triggered claws that use issue IDs.

Fixes #168