### PR TITLE
fix: bash syntax error in release-notes workflow

### DIFF
--- a/.depot/workflows/release-notes.yml
+++ b/.depot/workflows/release-notes.yml
@@ -42,7 +42,7 @@ jobs:
           TAG="${GITHUB_REF_NAME}"
 
           # Build the prompt JSON safely with Python (handles quotes, newlines, backslashes)
-          python3 -c '
+          cat > /tmp/build_prompt.py << 'PYEOF'
           import json, sys
 
           tag = sys.argv[1]
@@ -61,7 +61,8 @@ jobs:
 
           with open("/tmp/prompt.json", "w") as f:
             json.dump(prompt, f)
-          ' "$TAG"
+          PYEOF
+          python3 /tmp/build_prompt.py "$TAG"
 
           RESPONSE=$(curl -s -X POST "https://api.groq.com/openai/v1/chat/completions" \
             -H "Authorization: Bearer $GROQ_API_KEY" \


### PR DESCRIPTION
The inline `python3 -c` in the Groq step still had Python parentheses that bash tried to interpret. The #174 heredoc fix only covered the later Python blocks, leaving the prompt builder broken.

Converts the Groq prompt builder to use `cat << 'PYEOF'` heredoc + execute, consistent with the rest of the workflow.