### PR TITLE
fix: homebrew formula URL has stale v prefix for CalVer tags

### DIFF
--- a/.depot/workflows/release-notes.yml
+++ b/.depot/workflows/release-notes.yml
@@ -42,7 +42,7 @@ jobs:
           TAG="${GITHUB_REF_NAME}"
 
           # Build the prompt JSON safely with Python (handles quotes, newlines, backslashes)
-          python3 -c '
+          cat > /tmp/build_prompt.py << 'PYEOF'
           import json, sys
 
           tag = sys.argv[1]
@@ -61,7 +61,8 @@ jobs:
 
           with open("/tmp/prompt.json", "w") as f:
             json.dump(prompt, f)
-          ' "$TAG"
+          PYEOF
+          python3 /tmp/build_prompt.py "$TAG"
 
           RESPONSE=$(curl -s -X POST "https://api.groq.com/openai/v1/chat/completions" \
             -H "Authorization: Bearer $GROQ_API_KEY" \

--- a/.depot/workflows/release.yaml
+++ b/.depot/workflows/release.yaml
@@ -104,6 +104,7 @@ jobs:
 
           awk -v arm_sha="${SHA_ARM64}" -v amd_sha="${SHA_AMD64}" -v ver="${VERSION_NO_V}" '
             /version ".*"/ { sub(/version ".*"/, "version \"" ver "\"") }
+            /url ".*"/ { sub(/v#{version}/, "#{version}") }
             /on_arm/ { in_arm=1 }
             /on_intel/ { in_arm=0; in_amd=1 }
             /end/ { in_arm=0; in_amd=0 }


### PR DESCRIPTION
Since the switch from SemVer to CalVer, GitHub release tags no longer have a `v` prefix (e.g. `2026.5.13` instead of `v2026.5.13`). The homebrew formula still had `v#{version}` in its download URL, so `brew install` was hitting 404s.

The update-homebrew job now patches the `url` line too, removing the `v` prefix to match CalVer tagging.