### PR TITLE
fix: use openai/gpt-oss-120b for release notes on Groq

### DIFF
--- a/.depot/workflows/release-notes.yml
+++ b/.depot/workflows/release-notes.yml
@@ -50,7 +50,7 @@ jobs:
             commits = f.read()
 
           prompt = {
-            "model": "gpt-oss-120b",
+            "model": "llama-3.3-70b-versatile",
             "messages": [
               {"role": "system", "content": "You are a technical writer who writes engaging, human-friendly release notes for developer tools. You write in a casual but informative tone. Each release gets a creative, slightly playful title (like \"The One With...\" or a movie reference). You categorize changes into: What's New (features), Improvements (enhancements), Fixes (bug fixes). Be descriptive and specific — mention what changed and why it matters. Don't just list commit messages."},
               {"role": "user", "content": "Write release notes for ElasticClaw version " + tag + ". Here are the commits since the last release:\n\n" + commits + "\n\nRespond with ONLY a JSON object in this exact shape (no markdown code block, no extra text):\n{\n  \"title\": \"creative title here\",\n  \"whatsNew\": [\"descriptive bullet\", \"another bullet\"],\n  \"improvements\": [\"descriptive bullet\"],\n  \"fixes\": [\"descriptive bullet\"],\n  \"summary\": \"one-line teaser for the release list page\"\n}"}


### PR DESCRIPTION
The Groq API requires the full model identifier 'openai/gpt-oss-120b' rather than just 'gpt-oss-120b'. The shorter name returns model_not_found.