### PR TITLE
fix: drop factory name prefix from manual trigger titles

### DIFF
--- a/pkg/hub/factory_creator.go
+++ b/pkg/hub/factory_creator.go
@@ -74,14 +74,14 @@ func (s *Server) createClawFromFactory(factory *types.FactoryConfig, issueID str
 		clawName = issueID
 	}
 	// For manual triggers without a name_pattern, generate a descriptive name
-	// using the first input value (e.g., "my-factory: fix login bug")
+	// using the first input value (e.g., "fix login bug")
 	if clawName == factory.Name && inputs != nil && len(factory.Inputs) > 0 {
 		// Use the first defined input's value as the descriptive part.
 		// factory.Inputs is an ordered slice, so this is deterministic even
 		// when inputs contains multiple keys (Go map iteration order is random).
 		firstKey := factory.Inputs[0].Name
 		if firstVal := inputs[firstKey]; firstVal != "" {
-			clawName = factory.Name + ": " + firstVal
+			clawName = firstVal
 		}
 	}
 


### PR DESCRIPTION
Manual triggered factories were titled 'factoryname: issue number' which is redundant in the dashboard. Just use the issue number / input value directly.