### PR TITLE
fix: move_issue not working for manual factory triggers

### DIFF
--- a/pkg/hub/factory_creator.go
+++ b/pkg/hub/factory_creator.go
@@ -333,10 +333,19 @@ func (s *Server) createClawFromFactory(factory *types.FactoryConfig, issueID str
 	var linearIssueID, githubIssueID, shortcutStoryID string
 	if factory.Integration == "linear" && issueID != "" {
 		linearIssueID = issueID
-	} else if factory.Integration == "github-issues" && issueID != "" {
+	} else if factory.Integration == "linear" && inputs != nil {
+		// Manual trigger: extract issue ID from inputs if available
+		linearIssueID = inputs["linear_issue_id"]
+	}
+	if factory.Integration == "github-issues" && issueID != "" {
 		githubIssueID = issueID
-	} else if factory.Integration == "shortcut" && issueID != "" {
+	} else if factory.Integration == "github-issues" && inputs != nil {
+		githubIssueID = inputs["github_issue_id"]
+	}
+	if factory.Integration == "shortcut" && issueID != "" {
 		shortcutStoryID = issueID
+	} else if factory.Integration == "shortcut" && inputs != nil {
+		shortcutStoryID = inputs["shortcut_story_id"]
 	}
 
 	_, err = s.db.Exec(`

--- a/pkg/hub/factory_creator.go
+++ b/pkg/hub/factory_creator.go
@@ -333,9 +333,11 @@ func (s *Server) createClawFromFactory(factory *types.FactoryConfig, issueID str
 	var linearIssueID, githubIssueID, shortcutStoryID string
 	if factory.Integration == "linear" && issueID != "" {
 		linearIssueID = issueID
-	} else if factory.Integration == "github-issues" && issueID != "" {
+	}
+	if factory.Integration == "github-issues" && issueID != "" {
 		githubIssueID = issueID
-	} else if factory.Integration == "shortcut" && issueID != "" {
+	}
+	if factory.Integration == "shortcut" && issueID != "" {
 		shortcutStoryID = issueID
 	}
 

--- a/pkg/hub/pipeline/pipeline.go
+++ b/pkg/hub/pipeline/pipeline.go
@@ -79,12 +79,20 @@ func (t *Trigger) UnmarshalYAML(value *yaml.Node) error {
 	return nil
 }
 
+// MoveIssueAction specifies the target status and optional explicit issue ID
+// for the move_issue pipeline action. If IssueID is empty, the issue is looked
+// up from the claw's factory tracking (webhook issue or manual trigger inputs).
+type MoveIssueAction struct {
+	Status  string `yaml:"status"`
+	IssueID string `yaml:"issue_id,omitempty"`
+}
+
 // OnEnter holds the actions to run when entering a stage.
 type OnEnter struct {
 	// Inject sends this message to the claw as a user message.
 	Inject string `yaml:"inject"`
 	// MoveIssue moves the associated Linear/Shortcut issue to this status name.
-	MoveIssue string `yaml:"move_issue"`
+	MoveIssue MoveIssueAction `yaml:"move_issue"`
 	// MergePR triggers the GitHub merge API for the tracked PR (stub — not yet implemented).
 	MergePR bool `yaml:"merge_pr,omitempty"`
 	// CloseIssue closes the associated GitHub issue when entering this stage.
@@ -93,6 +101,47 @@ type OnEnter struct {
 	AddLabels []string `yaml:"add_labels,omitempty"`
 	// RemoveLabels removes the specified labels from the associated GitHub issue.
 	RemoveLabels []string `yaml:"remove_labels,omitempty"`
+}
+
+// UnmarshalYAML implements yaml.Unmarshaler for OnEnter so that move_issue can
+// be specified either as a scalar string (backward compat) or as a mapping.
+func (oe *OnEnter) UnmarshalYAML(value *yaml.Node) error {
+	// Use a shadow type to avoid infinite recursion.
+	type rawOnEnter struct {
+		Inject       string            `yaml:"inject"`
+		MoveIssueRaw yaml.Node          `yaml:"move_issue"`
+		MergePR      bool              `yaml:"merge_pr,omitempty"`
+		CloseIssue   bool              `yaml:"close_issue,omitempty"`
+		AddLabels    []string          `yaml:"add_labels,omitempty"`
+		RemoveLabels []string          `yaml:"remove_labels,omitempty"`
+	}
+	var raw rawOnEnter
+	if err := value.Decode(&raw); err != nil {
+		return err
+	}
+
+	oe.Inject = raw.Inject
+	oe.MergePR = raw.MergePR
+	oe.CloseIssue = raw.CloseIssue
+	oe.AddLabels = raw.AddLabels
+	oe.RemoveLabels = raw.RemoveLabels
+
+	if raw.MoveIssueRaw.Kind == 0 {
+		// move_issue not present
+		return nil
+	}
+
+	if raw.MoveIssueRaw.Kind == yaml.ScalarNode {
+		// Bare string: treat as status, no explicit issue_id
+		oe.MoveIssue = MoveIssueAction{Status: raw.MoveIssueRaw.Value}
+	} else if raw.MoveIssueRaw.Kind == yaml.MappingNode {
+		var mia MoveIssueAction
+		if err := raw.MoveIssueRaw.Decode(&mia); err != nil {
+			return err
+		}
+		oe.MoveIssue = mia
+	}
+	return nil
 }
 
 // Parse decodes YAML bytes into a Pipeline. Returns an error if the YAML is invalid.

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -147,8 +147,9 @@ func parsePipelineForFactory(factory *types.FactoryConfig) *pipeline.Pipeline {
 // - stage.OnEnter.Inject: injects a user message into the claw
 // - stage.OnEnter.MoveIssue: moves the Linear/Shortcut issue to the named status
 //
-// factory and issueID are required for MoveIssue; if either is nil/empty the
-// move is skipped silently.
+// factory is required for MoveIssue; if nil the move is skipped silently.
+// issueID is the default issue from the factory/webhook; it can be overridden
+// by MoveIssue.IssueID (including template references like {{.Inputs.xxx}}).
 func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, factory *types.FactoryConfig, issueID string) {
 	if stage.OnEnter.Inject != "" {
 		injectMsg := stage.OnEnter.Inject
@@ -323,40 +324,62 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, factory *types.
 		}
 	}
 
-	if stage.OnEnter.MoveIssue == "" || factory == nil || issueID == "" {
+	targetStatus := stage.OnEnter.MoveIssue.Status
+	if targetStatus == "" || factory == nil {
 		return
 	}
 
-	targetStatus := stage.OnEnter.MoveIssue
+	// If pipeline specifies an explicit issue_id, resolve it from inputs or use directly
+	resolvedIssueID := issueID
+	if stage.OnEnter.MoveIssue.IssueID != "" {
+		resolvedIssueID = stage.OnEnter.MoveIssue.IssueID
+		// Support template syntax {{.Inputs.xxx}} for manual trigger inputs
+		if strings.Contains(resolvedIssueID, "{{.Inputs.") {
+			inputs := s.loadManualTriggerInputs(clawID)
+			if inputs != nil {
+				tmpl, err := template.New("issue_id").Parse(resolvedIssueID)
+				if err == nil {
+					var buf bytes.Buffer
+					data := struct{ Inputs map[string]string }{Inputs: inputs}
+					if err := tmpl.Execute(&buf, data); err == nil {
+						resolvedIssueID = buf.String()
+					}
+				}
+			}
+		}
+	}
+	if resolvedIssueID == "" {
+		return
+	}
 
-	if strings.HasPrefix(issueID, "sc-") {
+	if strings.HasPrefix(resolvedIssueID, "sc-") {
 		// Shortcut story
 		scToken := s.resolveShortcutToken(factory.Workspace)
 		if scToken == "" {
 			log.Printf("[pipeline] factory %q: no Shortcut token for workspace %q, skipping move_issue", factory.Name, factory.Workspace)
 			return
 		}
-		if err := moveShortcutStory(scToken, issueID, targetStatus); err != nil {
-			log.Printf("[pipeline] failed to move story %s to %q: %v", issueID, targetStatus, err)
+		if err := moveShortcutStory(scToken, resolvedIssueID, targetStatus); err != nil {
+			log.Printf("[pipeline] failed to move story %s to %q: %v", resolvedIssueID, targetStatus, err)
 		} else {
-			log.Printf("[pipeline] moved story %s to %q", issueID, targetStatus)
+			log.Printf("[pipeline] moved story %s to %q", resolvedIssueID, targetStatus)
 		}
-	} else if strings.Contains(issueID, "/") {
+	} else if strings.Contains(resolvedIssueID, "/") {
 		// GitHub issue (owner/repo/number format)
 		ghToken := s.resolveGitHubIssuesTokenForFactory(factory)
 		if ghToken == "" {
 			log.Printf("[pipeline] factory %q: no GitHub token for move_issue, skipping", factory.Name)
 			return
 		}
-		parts := strings.Split(issueID, "/")
+		parts := strings.Split(resolvedIssueID, "/")
 		if len(parts) == 3 {
 			repo := parts[0] + "/" + parts[1]
 			var issueNum int
 			if _, err := fmt.Sscanf(parts[2], "%d", &issueNum); err == nil {
 				if err := moveGitHubIssue(ghToken, repo, issueNum, targetStatus, s.githubBaseURL); err != nil {
-					log.Printf("[pipeline] failed to move GitHub issue %s to %q: %v", issueID, targetStatus, err)
+					log.Printf("[pipeline] failed to move GitHub issue %s to %q: %v", resolvedIssueID, targetStatus, err)
 				} else {
-					log.Printf("[pipeline] moved GitHub issue %s to %q", issueID, targetStatus)
+					log.Printf("[pipeline] moved GitHub issue %s to %q", resolvedIssueID, targetStatus)
 				}
 			}
 		}
@@ -367,10 +390,10 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, factory *types.
 			log.Printf("[pipeline] factory %q: no Linear token for workspace %q, skipping move_issue", factory.Name, factory.Workspace)
 			return
 		}
-		if err := s.moveLinearIssueOnServer(linearToken, issueID, targetStatus); err != nil {
-			log.Printf("[pipeline] failed to move issue %s to %q: %v", issueID, targetStatus, err)
+		if err := s.moveLinearIssueOnServer(linearToken, resolvedIssueID, targetStatus); err != nil {
+			log.Printf("[pipeline] failed to move issue %s to %q: %v", resolvedIssueID, targetStatus, err)
 		} else {
-			log.Printf("[pipeline] moved issue %s to %q", issueID, targetStatus)
+			log.Printf("[pipeline] moved issue %s to %q", resolvedIssueID, targetStatus)
 		}
 	}
 }

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -609,14 +609,16 @@ func (s *Server) stopAgentWithReason(clawID, reason string, skipVMTerminate bool
 // findFactoryForClaw looks up the factory that created a claw by its claw ID.
 // It uses the factory:<name> tag stored on the claw to identify the factory.
 func (s *Server) findFactoryForClaw(clawID string) (*types.FactoryConfig, string) {
-	var issueID, githubIssueID, tagsJSON string
-	if err := s.db.QueryRow(`SELECT COALESCE(linear_issue_id,''), COALESCE(github_issue_id,''), COALESCE(tags,'[]') FROM claws WHERE id=?`, clawID).Scan(&issueID, &githubIssueID, &tagsJSON); err != nil {
+	var issueID, githubIssueID, shortcutStoryID, tagsJSON string
+	if err := s.db.QueryRow(`SELECT COALESCE(linear_issue_id,''), COALESCE(github_issue_id,''), COALESCE(shortcut_story_id,''), COALESCE(tags,'[]') FROM claws WHERE id=?`, clawID).Scan(&issueID, &githubIssueID, &shortcutStoryID, &tagsJSON); err != nil {
 		return nil, ""
 	}
 
-	// Prefer github_issue_id for GitHub issue-based claws
+	// Prefer github_issue_id for GitHub issue-based claws, then shortcut
 	if githubIssueID != "" {
 		issueID = githubIssueID
+	} else if shortcutStoryID != "" {
+		issueID = shortcutStoryID
 	}
 
 	if issueID != "" {


### PR DESCRIPTION
Manual triggers pass an empty issueID to createClawFromFactory, so linear_issue_id was never stored in the DB. Pipeline move_issue was silently skipped because findFactoryForClaw returned an empty issueID.

Now extracts the issue ID from manual trigger inputs (linear_issue_id, github_issue_id, shortcut_story_id) when the webhook issueID is empty.