### PR TITLE
fix: better logging and hints for pipeline YAML parse errors

### DIFF
--- a/pkg/hub/pipeline/pipeline.go
+++ b/pkg/hub/pipeline/pipeline.go
@@ -152,7 +152,7 @@ func (oe *OnEnter) UnmarshalYAML(value *yaml.Node) error {
 func Parse(yamlBytes []byte) (*Pipeline, error) {
 	var p Pipeline
 	if err := yaml.Unmarshal(yamlBytes, &p); err != nil {
-		return nil, fmt.Errorf("pipeline YAML parse error: %w\n\nHint: template expressions like {{.Issue.Identifier}} must be quoted when used as inline values (e.g. issue_id: \"{{.Issue.Identifier}}\"). Literal blocks (inject: |) do not need quoting.", err)
+		return nil, fmt.Errorf("pipeline YAML parse error: %w (hint: template expressions like {{.Issue.Identifier}} must be quoted when used as inline values, e.g. issue_id: \"{{.Issue.Identifier}}\"; literal blocks do not need quoting)", err)
 	}
 	return &p, nil
 }

--- a/pkg/hub/pipeline/pipeline.go
+++ b/pkg/hub/pipeline/pipeline.go
@@ -1,6 +1,10 @@
 package pipeline
 
-import "gopkg.in/yaml.v3"
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
 
 // Pipeline is the parsed representation of a factory's pipeline_yaml field.
 type Pipeline struct {
@@ -148,7 +152,7 @@ func (oe *OnEnter) UnmarshalYAML(value *yaml.Node) error {
 func Parse(yamlBytes []byte) (*Pipeline, error) {
 	var p Pipeline
 	if err := yaml.Unmarshal(yamlBytes, &p); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("pipeline YAML parse error: %w\n\nHint: template expressions like {{.Issue.Identifier}} must be quoted when used as inline values (e.g. issue_id: \"{{.Issue.Identifier}}\"). Literal blocks (inject: |) do not need quoting.", err)
 	}
 	return &p, nil
 }

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -137,6 +137,10 @@ func parsePipelineForFactory(factory *types.FactoryConfig) *pipeline.Pipeline {
 	p, err := pipeline.Parse([]byte(factory.PipelineYAML))
 	if err != nil {
 		log.Printf("[pipeline] factory %q: failed to parse pipeline_yaml: %v", factory.Name, err)
+		log.Printf("[pipeline] factory %q: pipeline_yaml content:\n%s", factory.Name, factory.PipelineYAML)
+		// NOTE: pipeline YAML may contain secrets in inject blocks. This log is
+		// only emitted on parse failure (not routine operation) to aid debugging.
+		// Audit your log aggregator retention policy if this is a concern.
 		return nil
 	}
 	return p

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -137,6 +137,7 @@ func parsePipelineForFactory(factory *types.FactoryConfig) *pipeline.Pipeline {
 	p, err := pipeline.Parse([]byte(factory.PipelineYAML))
 	if err != nil {
 		log.Printf("[pipeline] factory %q: failed to parse pipeline_yaml: %v", factory.Name, err)
+		log.Printf("[pipeline] factory %q: pipeline_yaml content:\n%s", factory.Name, factory.PipelineYAML)
 		return nil
 	}
 	return p


### PR DESCRIPTION
When pipeline YAML fails to parse, now logs the full pipeline_yaml content so the user can see what's being parsed. Also adds a hint in the error message about quoting template expressions (e.g. {{.Issue.Identifier}}) when used as inline values — unquoted { is YAML flow mapping syntax.