### PR TITLE
fix: prevent double claw creation from rapid webhooks

### DIFF
--- a/pkg/hub/github_issues.go
+++ b/pkg/hub/github_issues.go
@@ -480,21 +480,23 @@ func (s *Server) createClawForGitHubIssue(factory *types.FactoryConfig, payload 
 	}
 
 	// Enforce 1:1 — check if a claw already exists for this issue.
-	// If the claw is offline, error, or stopped, delete and recreate it since
-	// the underlying sandbox is gone. Only skip if it's actively starting,
-	// running, or connected.
+	// Skip if actively starting, running, connected, provisioning, or pending —
+	// the claw is being created and we must not race another webhook or trigger.
+	// Only delete+recreate if offline, error, or stopped (sandbox is gone).
 	var existingID, existingStatus string
 	_ = s.db.QueryRow(
 		`SELECT id, status FROM claws WHERE github_issue_id = ? AND status NOT IN ('deleted') LIMIT 1`,
 		issueID,
 	).Scan(&existingID, &existingStatus)
 	if existingID != "" {
-		if existingStatus == "starting" || existingStatus == "connected" || existingStatus == "running" {
+		switch existingStatus {
+		case "starting", "connected", "running", "provisioning", "pending":
 			log.Printf("[factory:%s] claw %s already exists for issue %s (status=%s) — treating as idempotent success", factory.Name, existingID[:8], issueID, existingStatus)
 			return nil
+		default:
+			log.Printf("[factory:%s] claw %s exists for issue %s but status=%s, deleting and recreating", factory.Name, existingID[:8], issueID, existingStatus)
+			_, _ = s.db.Exec(`UPDATE claws SET status='deleted' WHERE id=?`, existingID)
 		}
-		log.Printf("[factory:%s] claw %s exists for issue %s but status=%s, deleting and recreating", factory.Name, existingID[:8], issueID, existingStatus)
-		_, _ = s.db.Exec(`UPDATE claws SET status='deleted' WHERE id=?`, existingID)
 	}
 
 	// Load template

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -320,21 +320,24 @@ func (s *Server) createClawForIssue(factory *types.FactoryConfig, payload linear
 	}
 
 	// Enforce 1:1 — check if a claw already exists for this issue.
-	// If the claw is offline, error, or stopped, delete and recreate it since
-	// the underlying sandbox is gone. Only skip if it's actively starting,
-	// running, or connected.
+	// Skip if actively starting, running, or connected (idempotent).
+	// Also skip if provisioning or pending — the claw is being created and
+	// we must not race another webhook or trigger.
 	var existingID, existingStatus string
 	_ = s.db.QueryRow(
 		`SELECT id, status FROM claws WHERE linear_issue_id = ? AND status NOT IN ('deleted') LIMIT 1`,
 		issueID,
 	).Scan(&existingID, &existingStatus)
 	if existingID != "" {
-		if existingStatus == "starting" || existingStatus == "connected" || existingStatus == "running" {
+		switch existingStatus {
+		case "starting", "connected", "running", "provisioning", "pending":
 			log.Printf("[factory:%s] claw %s already exists for issue %s (status=%s) — treating as idempotent success", factory.Name, existingID[:8], issueID, existingStatus)
 			return nil
+		default:
+			// offline, error, stopped: sandbox is gone, safe to recreate
+			log.Printf("[factory:%s] claw %s exists for issue %s but status=%s, deleting and recreating", factory.Name, existingID[:8], issueID, existingStatus)
+			_, _ = s.db.Exec(`UPDATE claws SET status='deleted' WHERE id=?`, existingID)
 		}
-		log.Printf("[factory:%s] claw %s exists for issue %s but status=%s, deleting and recreating", factory.Name, existingID[:8], issueID, existingStatus)
-		_, _ = s.db.Exec(`UPDATE claws SET status='deleted' WHERE id=?`, existingID)
 	}
 
 	// Build Linear-specific context and inject into template files

--- a/pkg/hub/shortcut.go
+++ b/pkg/hub/shortcut.go
@@ -414,20 +414,22 @@ func (s *Server) createClawForShortcutStory(factory *types.FactoryConfig, action
 	log.Printf("[factory:%s] verified story %s is readable", factory.Name, storyID)
 
 	// Enforce 1:1 — check if a claw already exists for this story.
-	// If the claw is offline, error, or stopped, delete and recreate it since
-	// the underlying sandbox is gone. Only skip if it's actively starting,
-	// running, or connected.
+	// Skip if actively starting, running, connected, provisioning, or pending —
+	// the claw is being created and we must not race another webhook or trigger.
+	// Only delete+recreate if offline, error, or stopped (sandbox is gone).
 	var existingID, existingStatus string
 	_ = s.db.QueryRow(
 		`SELECT id, status FROM claws WHERE shortcut_story_id = ? AND status NOT IN ('deleted') LIMIT 1`,
 		storyID,
 	).Scan(&existingID, &existingStatus)
 	if existingID != "" {
-		if existingStatus == "starting" || existingStatus == "connected" || existingStatus == "running" {
+		switch existingStatus {
+		case "starting", "connected", "running", "provisioning", "pending":
 			return fmt.Errorf("claw %s already exists for story %s (status=%s)", existingID[:8], storyID, existingStatus)
+		default:
+			log.Printf("[factory:%s] claw %s exists for story %s but status=%s, deleting and recreating", factory.Name, existingID[:8], storyID, existingStatus)
+			_, _ = s.db.Exec(`UPDATE claws SET status='deleted' WHERE id=?`, existingID)
 		}
-		log.Printf("[factory:%s] claw %s exists for story %s but status=%s, deleting and recreating", factory.Name, existingID[:8], storyID, existingStatus)
-		_, _ = s.db.Exec(`UPDATE claws SET status='deleted' WHERE id=?`, existingID)
 	}
 
 	templateFiles, err := s.resolveTemplateFiles(factory.Template)


### PR DESCRIPTION
When a webhook fires twice in rapid succession, the second request was seeing the first claw in 'provisioning' status and deciding to 'delete and recreate' it. But deleting the DB record doesn't stop the VM provisioning, so two workspaces end up running.

Now treats 'provisioning' and 'pending' as active states that should be skipped (idempotent), same as 'starting', 'connected', and 'running'. Only delete+recreate when the claw is 'offline', 'error', or 'stopped' — states where the sandbox is actually gone.

Applied to Linear, GitHub Issues, and Shortcut webhooks.