### PR TITLE
fix: claw reliability — universal Daytona keepalive, status channel w…

### DIFF
--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -1433,6 +1433,9 @@ func main() {
 	}
 	log.Printf("[bridge] gateway session ready: %s", gwSession.sessionKey)
 
+	// Start status channel goroutine (lightweight second WS to hub)
+	go runStatusChannel(ctx, wsURL, clawID, clawName, templateName, token)
+
 	for {
 		if err := runHubLoop(ctx, wsURL, clawID, clawName, templateName, token, gwClient, gwSession, proxy, queue); err != nil {
 			if ctx.Err() != nil {
@@ -1449,6 +1452,89 @@ func main() {
 				return
 			case <-time.After(5 * time.Second):
 			}
+		}
+	}
+}
+
+// runStatusChannel maintains a lightweight second WebSocket to the hub for
+// watchdog / health pings. It replies to status_ping with status_pong.
+func runStatusChannel(ctx context.Context, wsURL, clawID, clawName, templateName, token string) {
+	backoff := time.Second
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		conn, _, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{
+			HTTPHeader: http.Header{
+				"User-Agent":                 {"claw-bridge/1.0"},
+				"ngrok-skip-browser-warning": {"true"},
+			},
+		})
+		if err != nil {
+			log.Printf("[status] dial failed: %v — retry in %v", err, backoff)
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(backoff):
+				if backoff < 30*time.Second {
+					backoff *= 2
+				}
+				continue
+			}
+		}
+		backoff = time.Second
+		conn.SetReadLimit(1 << 20) // 1MB
+
+		reg := hubMsg{
+			Type: "register",
+			Payload: mustJSON(map[string]interface{}{
+				"claw_id":  clawID,
+				"name":     clawName,
+				"template": templateName,
+				"token":    token,
+				"channel":  "status",
+			}),
+		}
+		if err := wsjson.Write(ctx, conn, reg); err != nil {
+			conn.CloseNow()
+			log.Printf("[status] register failed: %v — retry", err)
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(5 * time.Second):
+				continue
+			}
+		}
+
+		var ack hubMsg
+		if err := wsjson.Read(ctx, conn, &ack); err != nil || ack.Type != "registered" {
+			conn.CloseNow()
+			log.Printf("[status] register ack failed: %v — retry", err)
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(5 * time.Second):
+				continue
+			}
+		}
+		log.Printf("[status] connected")
+
+		// Read loop — reply to pings
+		for {
+			var msg hubMsg
+			if err := wsjson.Read(ctx, conn, &msg); err != nil {
+				log.Printf("[status] read error: %v — reconnecting", err)
+				break
+			}
+			if msg.Type == "status_ping" {
+				_ = wsjson.Write(ctx, conn, hubMsg{Type: "status_pong"})
+			}
+		}
+		conn.CloseNow()
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(5 * time.Second):
 		}
 	}
 }

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2892,8 +2892,12 @@ func (s *Server) checkClawStatus() {
 			cc.mu.Unlock()
 		}
 
-		// Context usage warning (>90%)
-		if contextUsage > 90 && !contextWarningSent {
+		// Context usage warning (>90%) — skip if a streaming turn is in progress
+		// so the heartbeat's more-urgent 95% in-streaming warning isn't suppressed.
+		cc.mu.RLock()
+		streaming := !cc.streamingStartedAt.IsZero()
+		cc.mu.RUnlock()
+		if contextUsage > 90 && !contextWarningSent && !streaming {
 			msg := fmt.Sprintf("⚠️ Claw %s is at %d%% context usage. It should wrap up soon or restart.", name, contextUsage)
 			log.Printf("[watchdog] %s", msg)
 			s.broadcastToUsers(tenantID, types.WSMessage{

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -62,6 +62,8 @@ type Server struct {
 }
 
 type clawConn struct {
+	mu sync.RWMutex // protects mutable fields below
+
 	id                    string
 	tenantID              string
 	conn                  *websocket.Conn
@@ -1232,7 +1234,9 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		cc := s.claws[clawID]
 		s.mu.RUnlock()
 		if cc != nil {
-			cc.lastUserMessageAt = time.Now()
+			cc.mu.Lock()
+		cc.lastUserMessageAt = time.Now()
+		cc.mu.Unlock()
 			_ = wsjson.Write(r.Context(), cc.conn, types.WSMessage{Type: "message", Payload: msg})
 			// Immediately signal to UI that agent is working, before first chunk arrives
 			s.broadcastToUsers(tenantID, types.WSMessage{
@@ -1358,27 +1362,38 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 		clawID = uuid.New().String()
 	}
 
+	// Check if this is a status channel registration BEFORE any DB upsert.
+	// Status channels must not mutate claw DB state (rp.GatewayReady is nil,
+	// so initialStatus would incorrectly overwrite 'starting'/'bootstrap_needed').
+	isStatusChannel := rp.Channel == "status"
+
 	var bootstrapOK int
 	var provider string
+	var currentStatus string
 	_ = s.db.QueryRow(`SELECT COALESCE(bootstrap_ok,0), COALESCE(provider,'') FROM claws WHERE id = ? AND tenant_id = ?`, clawID, tenantID).Scan(&bootstrapOK, &provider)
 
-	// Upsert claw and keep terminal/watching states sticky across reconnects.
-	desiredStatus := initialStatus(rp.GatewayReady)
-	if provider == "daytona" && bootstrapOK != 1 {
-		desiredStatus = "starting"
-	}
-	currentStatus := desiredStatus
-	_ = s.db.QueryRow(
-		`INSERT INTO claws(id,tenant_id,name,template,status,last_seen,created_at) VALUES(?,?,?,?,?,?,?)
-		 ON CONFLICT(id) DO UPDATE SET name=excluded.name, template=excluded.template,
-		 status=CASE WHEN claws.status IN ('idle','deleted') THEN claws.status ELSE excluded.status END,
-		 last_seen=excluded.last_seen
-		 RETURNING status`,
-		clawID, tenantID, rp.Name, rp.Template, desiredStatus, now(), now(),
-	).Scan(&currentStatus)
-	if currentStatus == "deleted" {
-		conn.Close(websocket.StatusPolicyViolation, "claw deleted")
-		return
+	if !isStatusChannel {
+		// Upsert claw and keep terminal/watching states sticky across reconnects.
+		desiredStatus := initialStatus(rp.GatewayReady)
+		if provider == "daytona" && bootstrapOK != 1 {
+			desiredStatus = "starting"
+		}
+		currentStatus = desiredStatus
+		_ = s.db.QueryRow(
+			`INSERT INTO claws(id,tenant_id,name,template,status,last_seen,created_at) VALUES(?,?,?,?,?,?,?)
+			 ON CONFLICT(id) DO UPDATE SET name=excluded.name, template=excluded.template,
+			 status=CASE WHEN claws.status IN ('idle','deleted') THEN claws.status ELSE excluded.status END,
+			 last_seen=excluded.last_seen
+			 RETURNING status`,
+			clawID, tenantID, rp.Name, rp.Template, desiredStatus, now(), now(),
+		).Scan(&currentStatus)
+		if currentStatus == "deleted" {
+			conn.Close(websocket.StatusPolicyViolation, "claw deleted")
+			return
+		}
+	} else {
+		// For status channel, just read current status from DB
+		_ = s.db.QueryRow(`SELECT status FROM claws WHERE id = ? AND tenant_id = ?`, clawID, tenantID).Scan(&currentStatus)
 	}
 
 	var registrationTagsJSON string
@@ -1386,14 +1401,14 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 	allowWake := bootstrapOK == 1 || provider != "daytona"
 	var registrationTags []string
 	_ = json.Unmarshal([]byte(registrationTagsJSON), &registrationTags)
-	// Check if this is a status channel registration
-	isStatusChannel := rp.Channel == "status"
 
 	if isStatusChannel {
 		// Status channel connects to existing claw
 		s.mu.Lock()
 		if existing, ok := s.claws[clawID]; ok {
+			existing.mu.Lock()
 			existing.statusConn = conn
+			existing.mu.Unlock()
 			s.mu.Unlock()
 			log.Printf("[bridge] ✓ status channel connected: %s (%s)", rp.Name, clawID[:8])
 			_ = wsjson.Write(ctx, conn, types.WSMessage{Type: "registered", Payload: map[string]string{"claw_id": clawID, "channel": "status"}})
@@ -1403,7 +1418,9 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				if err := wsjson.Read(ctx, conn, &msg); err != nil {
 					s.mu.Lock()
 					if existing2, ok2 := s.claws[clawID]; ok2 {
+						existing2.mu.Lock()
 						existing2.statusConn = nil
+						existing2.mu.Unlock()
 					}
 					s.mu.Unlock()
 					return
@@ -1411,7 +1428,9 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				if msg.Type == "status_pong" {
 					s.mu.Lock()
 					if existing2, ok2 := s.claws[clawID]; ok2 {
+						existing2.mu.Lock()
 						existing2.lastStatusAt = time.Now()
+						existing2.mu.Unlock()
 					}
 					s.mu.Unlock()
 				}
@@ -1425,8 +1444,10 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 	cc := &clawConn{id: clawID, tenantID: tenantID, conn: conn, gatewayReady: gatewayReadyBool(rp.GatewayReady), tags: registrationTags, lastUserMessageAt: time.Now(), lastStatusAt: time.Now()}
 	s.mu.Lock()
 	if old, ok := s.claws[clawID]; ok && old.statusConn != nil {
+		old.mu.RLock()
 		cc.statusConn = old.statusConn
 		cc.lastStatusAt = old.lastStatusAt
+		old.mu.RUnlock()
 	}
 	s.claws[clawID] = cc
 	s.mu.Unlock()
@@ -1527,9 +1548,11 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				if err := json.Unmarshal(payload, &hb); err == nil {
 					var wakeConn *clawConn
 					var shouldWake bool
+					var shouldWarnContext bool
 					var prevUsage int
 					s.mu.Lock()
 					if cc, ok := s.claws[clawID]; ok {
+						cc.mu.Lock()
 						// Log only on status changes, not every heartbeat
 						prevUsage = cc.contextUsage
 						cc.contextUsage = hb.ContextUsage
@@ -1571,15 +1594,14 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 							log.Printf("[heartbeat] %s (%s): gateway recovered after %d unhealthy checks", rp.Name, clawID[:8], cc.gatewayUnhealthyCount)
 							cc.gatewayUnhealthyCount = 0
 						}
-					}
-					// Inject context warning once per streaming turn when usage is >=95%
-					var shouldWarnContext bool
-					if cc2, ok2 := s.claws[clawID]; ok2 &&
-						!cc2.streamingStartedAt.IsZero() &&
-						hb.ContextUsage >= 95 &&
-						!cc2.contextWarningSent {
-						cc2.contextWarningSent = true
-						shouldWarnContext = true
+						// Inject context warning once per streaming turn when usage is >=95%
+						if !cc.streamingStartedAt.IsZero() &&
+							hb.ContextUsage >= 95 &&
+							!cc.contextWarningSent {
+							cc.contextWarningSent = true
+							shouldWarnContext = true
+						}
+						cc.mu.Unlock()
 					}
 					s.mu.Unlock()
 					if shouldWarnContext {
@@ -2795,104 +2817,97 @@ func (s *Server) statusWatchdog() {
 // checkClawStatus queries active claws, sends status requests via the status channel,
 // and detects claws that have gone silent (no status response, no user message recently).
 func (s *Server) checkClawStatus() {
-	s.mu.RLock()
 	now := time.Now()
-	type clawSnapshot struct {
-		id                    string
-		tenantID              string
-		name                  string
-		statusConn            *websocket.Conn
-		gatewayReady          bool
-		lastUserMessageAt     time.Time
-		lastStatusAt          time.Time
-		lastStatusBroadcastAt time.Time
-		contextUsage          int
-		contextWarningSent    bool
-	}
-	var checks []clawSnapshot
-	for id, cc := range s.claws {
-		checks = append(checks, clawSnapshot{
-			id:                    id,
-			tenantID:              cc.tenantID,
-			name:                  "",
-			statusConn:            cc.statusConn,
-			gatewayReady:          cc.gatewayReady,
-			lastUserMessageAt:     cc.lastUserMessageAt,
-			lastStatusAt:          cc.lastStatusAt,
-			lastStatusBroadcastAt: cc.lastStatusBroadcastAt,
-			contextUsage:          cc.contextUsage,
-			contextWarningSent:    cc.contextWarningSent,
-		})
+
+	s.mu.RLock()
+	var clawIDs []string
+	for id := range s.claws {
+		clawIDs = append(clawIDs, id)
 	}
 	s.mu.RUnlock()
 
-	// Resolve names from DB
-	for i := range checks {
-		var name string
-		_ = s.db.QueryRow(`SELECT name FROM claws WHERE id=?`, checks[i].id).Scan(&name)
-		checks[i].name = name
-	}
-
-	for _, c := range checks {
-		// If user sent a message in the last 2 minutes, skip status broadcast
-		if now.Sub(c.lastUserMessageAt) < 2*time.Minute {
+	for _, id := range clawIDs {
+		s.mu.RLock()
+		cc, ok := s.claws[id]
+		s.mu.RUnlock()
+		if !ok {
 			continue
 		}
 
-		// If we have a status channel, ping it
-		if c.statusConn != nil {
-			_ = wsjson.Write(context.Background(), c.statusConn, types.WSMessage{
-				Type: "status_ping",
-				Payload: mustJSONRaw(map[string]interface{}{
-					"claw_id": c.id,
-					"ts":      now.Unix(),
-				}),
-			})
+		cc.mu.RLock()
+		lastUserMessageAt := cc.lastUserMessageAt
+		lastStatusAt := cc.lastStatusAt
+		lastStatusBroadcastAt := cc.lastStatusBroadcastAt
+		statusConn := cc.statusConn
+		gatewayReady := cc.gatewayReady
+		contextUsage := cc.contextUsage
+		contextWarningSent := cc.contextWarningSent
+		tenantID := cc.tenantID
+		cc.mu.RUnlock()
+
+		// If user sent a message in the last 2 minutes, skip status broadcast
+		if now.Sub(lastUserMessageAt) < 2*time.Minute {
+			continue
 		}
+
+		// If we have a status channel, ping it (hold lock during write)
+		if statusConn != nil {
+			cc.mu.RLock()
+			sc := cc.statusConn
+			cc.mu.RUnlock()
+			if sc != nil {
+				_ = wsjson.Write(context.Background(), sc, types.WSMessage{
+					Type: "status_ping",
+					Payload: mustJSONRaw(map[string]interface{}{
+						"claw_id": id,
+						"ts":      now.Unix(),
+					}),
+				})
+			}
+		}
+
+		var name string
+		_ = s.db.QueryRow(`SELECT name FROM claws WHERE id=?`, id).Scan(&name)
 
 		// Detect silent death: no status response AND no user message for >5 min
 		// while the claw is supposedly connected and gateway was ready
-		if c.gatewayReady &&
-			now.Sub(c.lastStatusAt) > 5*time.Minute &&
-			now.Sub(c.lastUserMessageAt) > 5*time.Minute &&
-			now.Sub(c.lastStatusBroadcastAt) > 5*time.Minute {
-			msg := fmt.Sprintf("🚨 Claw %s appears unresponsive (no status in 5m). It may have crashed.", c.name)
+		if gatewayReady &&
+			now.Sub(lastStatusAt) > 5*time.Minute &&
+			now.Sub(lastUserMessageAt) > 5*time.Minute &&
+			now.Sub(lastStatusBroadcastAt) > 5*time.Minute {
+			msg := fmt.Sprintf("🚨 Claw %s appears unresponsive (no status in 5m). It may have crashed.", name)
 			log.Printf("[watchdog] %s", msg)
 			// Inject as system message so user sees it in the chat stream
-			s.broadcastToUsers(c.tenantID, types.WSMessage{
+			s.broadcastToUsers(tenantID, types.WSMessage{
 				Type: "message",
 				Payload: map[string]interface{}{
 					"role":    "system",
 					"content": msg,
-					"claw_id": c.id,
+					"claw_id": id,
 				},
 			})
-			// Update lastStatusBroadcastAt under lock so we don't spam
-			s.mu.Lock()
-			if cc, ok := s.claws[c.id]; ok {
-				cc.lastStatusBroadcastAt = now
-			}
-			s.mu.Unlock()
+			// Update lastStatusBroadcastAt under per-claw lock so we don't spam
+			cc.mu.Lock()
+			cc.lastStatusBroadcastAt = now
+			cc.mu.Unlock()
 		}
 
 		// Context usage warning (>90%)
-		if c.contextUsage > 90 && !c.contextWarningSent {
-			msg := fmt.Sprintf("⚠️ Claw %s is at %d%% context usage. It should wrap up soon or restart.", c.name, c.contextUsage)
+		if contextUsage > 90 && !contextWarningSent {
+			msg := fmt.Sprintf("⚠️ Claw %s is at %d%% context usage. It should wrap up soon or restart.", name, contextUsage)
 			log.Printf("[watchdog] %s", msg)
-			s.broadcastToUsers(c.tenantID, types.WSMessage{
+			s.broadcastToUsers(tenantID, types.WSMessage{
 				Type: "message",
 				Payload: map[string]interface{}{
 					"role":    "system",
 					"content": msg,
-					"claw_id": c.id,
+					"claw_id": id,
 				},
 			})
-			// Update contextWarningSent under lock
-			s.mu.Lock()
-			if cc, ok := s.claws[c.id]; ok {
-				cc.contextWarningSent = true
-			}
-			s.mu.Unlock()
+			// Update contextWarningSent under per-claw lock
+			cc.mu.Lock()
+			cc.contextWarningSent = true
+			cc.mu.Unlock()
 		}
 	}
 }

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1424,6 +1424,10 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 
 	cc := &clawConn{id: clawID, tenantID: tenantID, conn: conn, gatewayReady: gatewayReadyBool(rp.GatewayReady), tags: registrationTags, lastUserMessageAt: time.Now(), lastStatusAt: time.Now()}
 	s.mu.Lock()
+	if old, ok := s.claws[clawID]; ok && old.statusConn != nil {
+		cc.statusConn = old.statusConn
+		cc.lastStatusAt = old.lastStatusAt
+	}
 	s.claws[clawID] = cc
 	s.mu.Unlock()
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -74,6 +74,12 @@ type clawConn struct {
 	streamingStartedAt    time.Time       // when the current streaming turn started (zero if not streaming)
 	streamingTimeoutSent  bool            // true once the 12-min timeout message has been injected this turn
 	contextWarningSent    bool            // true once the context-nearly-full warning has been injected this turn
+
+	// Status channel for watchdog / progress reporting (second session on bridge)
+	statusConn             *websocket.Conn // separate WS for lightweight status queries
+	lastStatusAt           time.Time       // when we last got a status response
+	lastUserMessageAt      time.Time       // when the user last sent a message (for idle detection)
+	lastStatusBroadcastAt  time.Time       // when we last broadcast status to user
 }
 
 // initialStatus returns the claw status string to use on bridge registration.
@@ -126,6 +132,7 @@ func NewServer(addr, dbPath, identityDir string, hubCfg *types.HubConfig) (*Serv
 	// Start background poller to keep provider VM status fresh
 	go srv.pollProviderStatus()
 	go srv.keepAliveDaytonaSandboxes()
+	go srv.statusWatchdog()
 	srv.startPRWatcher()
 	srv.startIntegrationPoller()
 
@@ -1225,6 +1232,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		cc := s.claws[clawID]
 		s.mu.RUnlock()
 		if cc != nil {
+			cc.lastUserMessageAt = time.Now()
 			_ = wsjson.Write(r.Context(), cc.conn, types.WSMessage{Type: "message", Payload: msg})
 			// Immediately signal to UI that agent is working, before first chunk arrives
 			s.broadcastToUsers(tenantID, types.WSMessage{
@@ -1378,7 +1386,43 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 	allowWake := bootstrapOK == 1 || provider != "daytona"
 	var registrationTags []string
 	_ = json.Unmarshal([]byte(registrationTagsJSON), &registrationTags)
-	cc := &clawConn{id: clawID, tenantID: tenantID, conn: conn, gatewayReady: gatewayReadyBool(rp.GatewayReady), tags: registrationTags}
+	// Check if this is a status channel registration
+	isStatusChannel := rp.Channel == "status"
+
+	if isStatusChannel {
+		// Status channel connects to existing claw
+		s.mu.Lock()
+		if existing, ok := s.claws[clawID]; ok {
+			existing.statusConn = conn
+			s.mu.Unlock()
+			log.Printf("[bridge] ✓ status channel connected: %s (%s)", rp.Name, clawID[:8])
+			_ = wsjson.Write(ctx, conn, types.WSMessage{Type: "registered", Payload: map[string]string{"claw_id": clawID, "channel": "status"}})
+			// Simple read loop for status channel — just keepalive
+			for {
+				var msg types.WSMessage
+				if err := wsjson.Read(ctx, conn, &msg); err != nil {
+					s.mu.Lock()
+					if existing2, ok2 := s.claws[clawID]; ok2 {
+						existing2.statusConn = nil
+					}
+					s.mu.Unlock()
+					return
+				}
+				if msg.Type == "status_pong" {
+					s.mu.Lock()
+					if existing2, ok2 := s.claws[clawID]; ok2 {
+						existing2.lastStatusAt = time.Now()
+					}
+					s.mu.Unlock()
+				}
+			}
+		}
+		s.mu.Unlock()
+		conn.Close(websocket.StatusPolicyViolation, "main channel not connected")
+		return
+	}
+
+	cc := &clawConn{id: clawID, tenantID: tenantID, conn: conn, gatewayReady: gatewayReadyBool(rp.GatewayReady), tags: registrationTags, lastUserMessageAt: time.Now(), lastStatusAt: time.Now()}
 	s.mu.Lock()
 	s.claws[clawID] = cc
 	s.mu.Unlock()
@@ -2685,12 +2729,11 @@ func (s *Server) keepAliveDaytonaSandboxes() {
 
 func (s *Server) petDaytonaSandboxes() {
 	rows, err := s.db.Query(`
-		SELECT DISTINCT c.id, c.name, c.provider_id
-		FROM claws c
-		JOIN claw_prs cp ON cp.claw_id = c.id
-		WHERE c.provider = 'daytona'
-		  AND c.provider_id != ''
-		  AND c.status NOT IN ('idle','deleted','error','offline')
+		SELECT id, name, provider_id
+		FROM claws
+		WHERE provider = 'daytona'
+		  AND provider_id != ''
+		  AND status NOT IN ('idle','deleted','error','offline')
 	`)
 	if err != nil {
 		log.Printf("keepAliveDaytonaSandboxes: query error: %v", err)
@@ -2732,6 +2775,121 @@ func (s *Server) petDaytonaSandboxes() {
 			continue
 		}
 		log.Printf("[daytona] keepalive ok for %s (%s)", c.name, c.id[:8])
+	}
+}
+
+// statusWatchdog runs every 2 minutes to check claw health and request status
+// updates from the status channel. It also detects silent deaths and alerts the user.
+func (s *Server) statusWatchdog() {
+	ticker := time.NewTicker(2 * time.Minute)
+	defer ticker.Stop()
+	for range ticker.C {
+		s.checkClawStatus()
+	}
+}
+
+// checkClawStatus queries active claws, sends status requests via the status channel,
+// and detects claws that have gone silent (no status response, no user message recently).
+func (s *Server) checkClawStatus() {
+	s.mu.RLock()
+	now := time.Now()
+	type clawSnapshot struct {
+		id                    string
+		tenantID              string
+		name                  string
+		statusConn            *websocket.Conn
+		gatewayReady          bool
+		lastUserMessageAt     time.Time
+		lastStatusAt          time.Time
+		lastStatusBroadcastAt time.Time
+		contextUsage          int
+		contextWarningSent    bool
+	}
+	var checks []clawSnapshot
+	for id, cc := range s.claws {
+		checks = append(checks, clawSnapshot{
+			id:                    id,
+			tenantID:              cc.tenantID,
+			name:                  "",
+			statusConn:            cc.statusConn,
+			gatewayReady:          cc.gatewayReady,
+			lastUserMessageAt:     cc.lastUserMessageAt,
+			lastStatusAt:          cc.lastStatusAt,
+			lastStatusBroadcastAt: cc.lastStatusBroadcastAt,
+			contextUsage:          cc.contextUsage,
+			contextWarningSent:    cc.contextWarningSent,
+		})
+	}
+	s.mu.RUnlock()
+
+	// Resolve names from DB
+	for i := range checks {
+		var name string
+		_ = s.db.QueryRow(`SELECT name FROM claws WHERE id=?`, checks[i].id).Scan(&name)
+		checks[i].name = name
+	}
+
+	for _, c := range checks {
+		// If user sent a message in the last 2 minutes, skip status broadcast
+		if now.Sub(c.lastUserMessageAt) < 2*time.Minute {
+			continue
+		}
+
+		// If we have a status channel, ping it
+		if c.statusConn != nil {
+			_ = wsjson.Write(context.Background(), c.statusConn, types.WSMessage{
+				Type: "status_ping",
+				Payload: mustJSONRaw(map[string]interface{}{
+					"claw_id": c.id,
+					"ts":      now.Unix(),
+				}),
+			})
+		}
+
+		// Detect silent death: no status response AND no user message for >5 min
+		// while the claw is supposedly connected and gateway was ready
+		if c.gatewayReady &&
+			now.Sub(c.lastStatusAt) > 5*time.Minute &&
+			now.Sub(c.lastUserMessageAt) > 5*time.Minute &&
+			now.Sub(c.lastStatusBroadcastAt) > 5*time.Minute {
+			msg := fmt.Sprintf("🚨 Claw %s appears unresponsive (no status in 5m). It may have crashed.", c.name)
+			log.Printf("[watchdog] %s", msg)
+			// Inject as system message so user sees it in the chat stream
+			s.broadcastToUsers(c.tenantID, types.WSMessage{
+				Type: "message",
+				Payload: map[string]interface{}{
+					"role":    "system",
+					"content": msg,
+					"claw_id": c.id,
+				},
+			})
+			// Update lastStatusBroadcastAt under lock so we don't spam
+			s.mu.Lock()
+			if cc, ok := s.claws[c.id]; ok {
+				cc.lastStatusBroadcastAt = now
+			}
+			s.mu.Unlock()
+		}
+
+		// Context usage warning (>90%)
+		if c.contextUsage > 90 && !c.contextWarningSent {
+			msg := fmt.Sprintf("⚠️ Claw %s is at %d%% context usage. It should wrap up soon or restart.", c.name, c.contextUsage)
+			log.Printf("[watchdog] %s", msg)
+			s.broadcastToUsers(c.tenantID, types.WSMessage{
+				Type: "message",
+				Payload: map[string]interface{}{
+					"role":    "system",
+					"content": msg,
+					"claw_id": c.id,
+				},
+			})
+			// Update contextWarningSent under lock
+			s.mu.Lock()
+			if cc, ok := s.claws[c.id]; ok {
+				cc.contextWarningSent = true
+			}
+			s.mu.Unlock()
+		}
 	}
 }
 

--- a/pkg/types/hub.go
+++ b/pkg/types/hub.go
@@ -66,5 +66,6 @@ type RegisterPayload struct {
 	Template      string `json:"template"`
 	Token         string `json:"token"` // hub claw token for auth
 	GatewayReady  *bool  `json:"gateway_ready,omitempty"` // true once openclaw gateway session is established; nil means unknown (old bridge, assume ready)
+	Channel       string `json:"channel,omitempty"`       // "status" for status channel, empty for main
 }
 


### PR DESCRIPTION
…atchdog, proactive alerts

- Keep ALL active Daytona claws alive (not just PR-watching ones)
- Add status channel: bridge opens second WS for lightweight health pings
- Hub watchdog checks every 2 min: pings status channel, detects silent death
- Alerts injected into chat stream only when idle (no user msg in 2 min)
- Context usage warnings broadcast to user when >90%