### PR TITLE
fix(config): include elasticclaw-config.yaml in template file loading

### DIFF
--- a/pkg/config/hub.go
+++ b/pkg/config/hub.go
@@ -251,6 +251,7 @@ func ReadTemplateFiles(templateDir string) (map[string]string, error) {
 	known := []string{
 		"AGENTS.md", "SOUL.md", "TOOLS.md", "IDENTITY.md",
 		"USER.md", "MEMORY.md", "BOOTSTRAP.md", "HEARTBEAT.md",
+		"elasticclaw-config.yaml",
 	}
 	files := make(map[string]string)
 	for _, name := range known {


### PR DESCRIPTION
## Problem
Claws created from templates with `github.repos` configured were cloning 0 repos. Hub logs showed `cloning 0 repo(s)` despite the template defining repos.

## Root Cause
`ReadTemplateFiles` in `pkg/config/hub.go` loads a hardcoded list of known template files. `elasticclaw-config.yaml` was not in this list, so template configs (github repos, instance type, provider, secrets, etc.) were never parsed when creating claws from external templates.

## Fix
Add `elasticclaw-config.yaml` to the known files list in `ReadTemplateFiles`.

## Verification
- [ ] Create a claw from a template with `github.repos" configured
- [ ] Confirm hub logs show `cloning N repo(s)` where N matches the template