### PR TITLE
fix(bridge): WebSocket ping keepalive for status channel

### DIFF
--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -1519,6 +1519,26 @@ func runStatusChannel(ctx context.Context, wsURL, clawID, clawName, templateName
 		}
 		log.Printf("[status] connected")
 
+		// Start a background goroutine to send WebSocket ping frames every 30s.
+		// This keeps the connection alive at the TCP/WebSocket layer, preventing
+		// proxies and the nhooyr/websocket library from dropping the idle connection.
+		pingCtx, pingCancel := context.WithCancel(ctx)
+		go func() {
+			ticker := time.NewTicker(30 * time.Second)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-pingCtx.Done():
+					return
+				case <-ticker.C:
+					if err := conn.Ping(pingCtx); err != nil {
+						log.Printf("[status] ping failed: %v", err)
+						return
+					}
+				}
+			}
+		}()
+
 		// Read loop — reply to pings
 		for {
 			var msg hubMsg
@@ -1530,6 +1550,7 @@ func runStatusChannel(ctx context.Context, wsURL, clawID, clawName, templateName
 				_ = wsjson.Write(ctx, conn, hubMsg{Type: "status_pong"})
 			}
 		}
+		pingCancel()   // stop the ping goroutine before closing the connection
 		conn.CloseNow()
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
## Problem

The bridge status channel WebSocket reconnects every 60-90 seconds:



The main hub loop stays alive (15s heartbeat ticker), but the status channel only sees traffic every 2 minutes from the hub watchdog. Something in the middle (nhooyr/websocket idle handling, proxies, OS TCP timeouts) drops the idle connection.

## Fix

Add a background goroutine in  that sends  every 30 seconds. This is standard WebSocket keepalive — same mechanism the main connection implicitly gets from constant heartbeat traffic.

## Testing

-  passes
- The ping goroutine exits cleanly when the read loop breaks (via  from )

## Changes

- : add 30s ping ticker in status channel read loop