### PR TITLE
fix(poll): require 'repos' for github-issues factories

### DIFF
--- a/pkg/hub/integration_poller.go
+++ b/pkg/hub/integration_poller.go
@@ -506,12 +506,11 @@ func (s *Server) pollGitHubIssues(factories []*types.FactoryConfig, ghIssueCfgs 
 		if f.Enabled != nil && !*f.Enabled {
 			continue
 		}
-		// Use workspace as repo if no explicit repos configured
-		repos := []string{f.Workspace}
-		if len(f.Repos) > 0 {
-			repos = f.Repos
+		if len(f.Repos) == 0 {
+			log.Printf("[poll-github-issues] factory %q: missing required 'repos' field — skipping", f.Name)
+			continue
 		}
-		for _, repo := range repos {
+		for _, repo := range f.Repos {
 			if repo == "" {
 				continue
 			}


### PR DESCRIPTION
Remove the workspace-as-repo fallback. A github-issues factory without 'repos' was silently using workspace (a human label like 'my-org') as the repo path, causing 404s on the GitHub API. Now logs a clear error and skips the factory instead.