### PR TITLE
fix(settings): include analytics section in static export params

### DIFF
--- a/web/app/settings/[section]/page.tsx
+++ b/web/app/settings/[section]/page.tsx
@@ -1,6 +1,6 @@
 import SettingsSectionPage from "./settings-content"
 
-const VALID_SECTIONS = ["runtimes", "models", "github", "authentication", "issue-trackers", "factories", "secrets", "mcp-servers", "templates", "ai-config", "webhooks", "doctor"]
+const VALID_SECTIONS = ["runtimes", "models", "github", "authentication", "issue-trackers", "factories", "secrets", "mcp-servers", "templates", "ai-config", "webhooks", "doctor", "analytics"]
 
 export function generateStaticParams() {
   return VALID_SECTIONS.map((section) => ({ section }))


### PR DESCRIPTION
The analytics settings page was added to `settings-content.tsx` but was not included in the `generateStaticParams` list in `page.tsx`. This caused the analytics route to fail when building with `output: 'static'` since Next.js only pre-renders the paths returned by `generateStaticParams`.