### PR TITLE
ci(release-notes): exclude internal commits from changelog generation

### DIFF
--- a/.depot/workflows/release-notes.yml
+++ b/.depot/workflows/release-notes.yml
@@ -37,8 +37,6 @@ jobs:
           #   .depot/           — CI/workflows
           #   hack/             — internal scripts
           #   scripts/          — internal scripts
-          # Use --full-history so merges that touch both internal and product
-          # files are still considered (we then filter by touched paths).
           git log --pretty=format:'%h %s (%an)' \
             "$PREV..${GITHUB_REF_NAME}" \
             -- . \
@@ -47,6 +45,11 @@ jobs:
             ':(exclude)hack' \
             ':(exclude)scripts' \
             > /tmp/changelog.txt
+          # Guard: if every commit touched excluded paths, the changelog is empty.
+          # Write a placeholder so the Groq step doesn't hallucinate or fail on empty input.
+          if [ ! -s /tmp/changelog.txt ]; then
+            echo "No user-facing changes in this release." > /tmp/changelog.txt
+          fi
 
       - name: Generate release notes with Groq
         id: groq

--- a/.depot/workflows/release-notes.yml
+++ b/.depot/workflows/release-notes.yml
@@ -32,7 +32,21 @@ jobs:
         id: changelog
         run: |
           PREV="${{ steps.prev.outputs.tag }}"
-          git log --pretty=format:'%h %s (%an)' "$PREV..${GITHUB_REF_NAME}" > /tmp/changelog.txt
+          # Exclude commits that only touch internal paths:
+          #   .elasticclaw/      — our own factory configs
+          #   .depot/           — CI/workflows
+          #   hack/             — internal scripts
+          #   scripts/          — internal scripts
+          # Use --full-history so merges that touch both internal and product
+          # files are still considered (we then filter by touched paths).
+          git log --pretty=format:'%h %s (%an)' \
+            "$PREV..${GITHUB_REF_NAME}" \
+            -- . \
+            ':(exclude).elasticclaw' \
+            ':(exclude).depot' \
+            ':(exclude)hack' \
+            ':(exclude)scripts' \
+            > /tmp/changelog.txt
 
       - name: Generate release notes with Groq
         id: groq


### PR DESCRIPTION
Filter out commits that only touch internal paths from the release notes changelog:
- .elasticclaw/   - our own factory configs
- .depot/         - CI/workflows
- hack/           - internal scripts
- scripts/        - internal scripts

This prevents 'added a new factory' and similar internal-only commits from appearing in user-facing release notes.