### PR TITLE
fix: exe.dev provider config — add CPU, memory, disk fields

### DIFF
--- a/pkg/hub/providers.go
+++ b/pkg/hub/providers.go
@@ -22,7 +22,10 @@ func newLocalProvider() *local.Provider {
 
 func newExedevProvider(cfg types.ProviderConfig) (*exedev.Provider, error) {
 	return exedev.New(exedev.Config{
-		SSHKeyPath: cfg.SSHKeyPath,
+		SSHKeyPath:  cfg.SSHKeyPath,
+		DefaultCPU:    cfg.DefaultCPU,
+		DefaultMemory: cfg.DefaultMemory,
+		DefaultDisk:   cfg.DefaultDisk,
 	})
 }
 

--- a/pkg/provider/exedev/exedev.go
+++ b/pkg/provider/exedev/exedev.go
@@ -18,18 +18,22 @@ import (
 
 // Provider implements the exe.dev provider using the SSH CLI.
 type Provider struct {
-	sshKeyPath string // path to SSH private key for exe.dev authentication
+	cfg Config // provider config including SSH key path and default resources
 }
 
 // Config holds exe.dev provider config (from hub.yaml).
 type Config struct {
 	SSHKeyPath string `yaml:"ssh_key_path,omitempty"` // path to SSH private key; if empty, uses default SSH agent
+	// Default resource settings for new VMs
+	DefaultCPU    int    `yaml:"default_cpu,omitempty"`
+	DefaultMemory string `yaml:"default_memory,omitempty"` // e.g. "4GB"
+	DefaultDisk   string `yaml:"default_disk,omitempty"`   // e.g. "20GB"
 }
 
 // New creates a new exe.dev provider.
 func New(cfg Config) (*Provider, error) {
 	return &Provider{
-		sshKeyPath: cfg.SSHKeyPath,
+		cfg: cfg,
 	}, nil
 }
 
@@ -52,8 +56,8 @@ type exeVMList struct {
 // including identity file if configured.
 func (p *Provider) sshArgs() []string {
 	var args []string
-	if p.sshKeyPath != "" {
-		args = append(args, "-i", p.sshKeyPath)
+	if p.cfg.SSHKeyPath != "" {
+		args = append(args, "-i", p.cfg.SSHKeyPath)
 	}
 	args = append(args, "exe.dev")
 	return args
@@ -63,8 +67,8 @@ func (p *Provider) sshArgs() []string {
 // including identity file and common options if configured.
 func (p *Provider) sshVMArgs(host string) []string {
 	var args []string
-	if p.sshKeyPath != "" {
-		args = append(args, "-i", p.sshKeyPath)
+	if p.cfg.SSHKeyPath != "" {
+		args = append(args, "-i", p.cfg.SSHKeyPath)
 	}
 	args = append(args, "-o", "StrictHostKeyChecking=no", host)
 	return args
@@ -99,6 +103,16 @@ func (p *Provider) Create(ctx context.Context, req types.CreateRequest) (*types.
 	args := []string{"new", "--json"}
 	if req.Name != "" {
 		args = append(args, "--name="+req.Name)
+	}
+	// Apply default resource settings from provider config
+	if p.cfg.DefaultCPU > 0 {
+		args = append(args, fmt.Sprintf("--cpu=%d", p.cfg.DefaultCPU))
+	}
+	if p.cfg.DefaultMemory != "" {
+		args = append(args, "--memory="+p.cfg.DefaultMemory)
+	}
+	if p.cfg.DefaultDisk != "" {
+		args = append(args, "--disk="+p.cfg.DefaultDisk)
 	}
 	// NOTE: env vars are intentionally NOT passed as --env flags to avoid
 	// exposing secrets in process listings (ps aux). Env vars are injected
@@ -292,7 +306,7 @@ func (p *Provider) vmHost(instanceID string) string {
 
 // SSHKeyPath returns the configured SSH private key path (may be empty).
 func (p *Provider) SSHKeyPath() string {
-	return p.sshKeyPath
+	return p.cfg.SSHKeyPath
 }
 
 // extractVMName tries to extract a vm name from plain text output.

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -501,6 +501,10 @@ type ProviderConfig struct {
 
 	// exe.dev
 	SSHKeyPath string `yaml:"ssh_key_path,omitempty"` // optional SSH private key path
+	// Default resources for new VMs
+	DefaultCPU    int    `yaml:"default_cpu,omitempty"`
+	DefaultMemory string `yaml:"default_memory,omitempty"` // e.g. "4GB"
+	DefaultDisk   string `yaml:"default_disk,omitempty"`   // e.g. "20GB"
 
 	// local provider
 	Enabled bool `yaml:"enabled,omitempty"`

--- a/pkg/types/validation.go
+++ b/pkg/types/validation.go
@@ -21,7 +21,7 @@ var validIntegrations = map[string]bool{
 
 // Valid provider types
 var validProviders = map[string]bool{
-	"replicated": true, "daytona": true, "vercel": true, "local": true, "noop": true,
+	"replicated": true, "daytona": true, "vercel": true, "local": true, "noop": true, "exedev": true,
 }
 
 // Valid MCP sources

--- a/pkg/types/validation.go
+++ b/pkg/types/validation.go
@@ -87,7 +87,7 @@ func (f *FactoryConfig) Validate() error {
 
 	// Validate provider if provided
 	if f.Provider != "" && !validProviders[f.Provider] {
-		return fmt.Errorf("factory %q: invalid provider %q (must be one of: replicated, daytona, vercel, local, noop)", f.Name, f.Provider)
+		return fmt.Errorf("factory %q: invalid provider %q (must be one of: replicated, daytona, exedev, vercel, local, noop)", f.Name, f.Provider)
 	}
 
 	// Validate inputs
@@ -185,7 +185,7 @@ func (t *TemplateConfig) Validate() error {
 		return fmt.Errorf("template provider is required")
 	}
 	if !validProviders[t.Provider] {
-		return fmt.Errorf("invalid provider %q (must be one of: replicated, daytona, vercel, local, noop)", t.Provider)
+		return fmt.Errorf("invalid provider %q (must be one of: replicated, daytona, exedev, vercel, local, noop)", t.Provider)
 	}
 
 	// Validate color if provided
@@ -296,7 +296,7 @@ func ValidateProviderConfig(name string, cfg *ProviderConfig) error {
 	}
 
 	if !validProviders[providerType] {
-		return fmt.Errorf("invalid provider type %q (must be one of: replicated, daytona, vercel, local, noop)", providerType)
+		return fmt.Errorf("invalid provider type %q (must be one of: replicated, daytona, exedev, vercel, local, noop)", providerType)
 	}
 
 	return nil

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -53,6 +53,9 @@ interface SettingsData {
     tokenSet?: boolean
     defaultTtl?: string
     defaultInstanceType?: string
+    defaultCpu?: number
+    defaultMemory?: string
+    defaultDisk?: string
   }>
   github: GitHubAppView[]
   sshPublicKeys: string[]
@@ -365,6 +368,9 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
         tokenSet: p.tokenSet,
         defaultTtl: p.defaultTtl,
         defaultInstanceType: p.defaultInstanceType,
+        defaultCpu: p.defaultCpu,
+        defaultMemory: p.defaultMemory,
+        defaultDisk: p.defaultDisk,
       }
     })
 
@@ -381,6 +387,9 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
   const [formDefaultTtl, setFormDefaultTtl] = useState("")
   const [formDefaultInstanceType, setFormDefaultInstanceType] = useState("")
   const [formDefaultSnapshot, setFormDefaultSnapshot] = useState("")
+  const [formDefaultCpu, setFormDefaultCpu] = useState("")
+  const [formDefaultMemory, setFormDefaultMemory] = useState("")
+  const [formDefaultDisk, setFormDefaultDisk] = useState("")
 
   const resetForm = () => {
     setFormProvider("replicated")
@@ -390,6 +399,9 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
     setFormDefaultTtl("")
     setFormDefaultInstanceType("")
     setFormDefaultSnapshot("")
+    setFormDefaultCpu("")
+    setFormDefaultMemory("")
+    setFormDefaultDisk("")
     setEditName(null)
   }
 
@@ -404,6 +416,9 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
     setFormDefaultTtl(p?.defaultTtl || "")
     setFormDefaultInstanceType(p?.defaultInstanceType || "")
     setFormDefaultSnapshot(p?.defaultSnapshot || "")
+    setFormDefaultCpu(p?.defaultCpu?.toString() || "")
+    setFormDefaultMemory(p?.defaultMemory || "")
+    setFormDefaultDisk(p?.defaultDisk || "")
     setEditName(name)
     setModalMode("edit")
     setShowModal(true)
@@ -424,6 +439,9 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
     } else if (formProvider === "exedev") {
       // exe.dev uses SSH key authentication; no API key needed in config
       patch.enabled = true
+      if (formDefaultCpu) patch.defaultCpu = parseInt(formDefaultCpu, 10)
+      if (formDefaultMemory) patch.defaultMemory = formDefaultMemory
+      if (formDefaultDisk) patch.defaultDisk = formDefaultDisk
     }
     onSave({ providers: { [formProvider]: patch } })
     setShowModal(false)
@@ -608,6 +626,18 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
                 <p className="text-xs text-muted-foreground">
                   exe.dev uses SSH key authentication. Ensure your SSH key is registered at <a href="https://exe.dev" target="_blank" rel="noopener noreferrer" className="underline">exe.dev</a>.
                 </p>
+                <div>
+                  <label className="text-xs text-muted-foreground mb-1 block">Default CPUs</label>
+                  <Input value={formDefaultCpu} onChange={e => setFormDefaultCpu(e.target.value)} className="h-8 text-sm" placeholder="2" />
+                </div>
+                <div>
+                  <label className="text-xs text-muted-foreground mb-1 block">Default Memory</label>
+                  <Input value={formDefaultMemory} onChange={e => setFormDefaultMemory(e.target.value)} className="h-8 text-sm" placeholder="4GB" />
+                </div>
+                <div>
+                  <label className="text-xs text-muted-foreground mb-1 block">Default Disk</label>
+                  <Input value={formDefaultDisk} onChange={e => setFormDefaultDisk(e.target.value)} className="h-8 text-sm" placeholder="20GB" />
+                </div>
               </>
             )}
           </div>

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -439,7 +439,8 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
     } else if (formProvider === "exedev") {
       // exe.dev uses SSH key authentication; no API key needed in config
       patch.enabled = true
-      if (formDefaultCpu) patch.defaultCpu = parseInt(formDefaultCpu, 10)
+      const parsedCpu = parseInt(formDefaultCpu, 10)
+      if (formDefaultCpu && !isNaN(parsedCpu)) patch.defaultCpu = parsedCpu
       if (formDefaultMemory) patch.defaultMemory = formDefaultMemory
       if (formDefaultDisk) patch.defaultDisk = formDefaultDisk
     }


### PR DESCRIPTION
exe.dev uses SSH key authentication, not API tokens. The web UI was showing Replicated-specific fields (API token, TTL, instance type) for exe.dev which made no sense.

Changes:
- pkg/types/template.go: add DefaultCPU, DefaultMemory, DefaultDisk to ProviderConfig
- pkg/types/validation.go: add exedev to validProviders (was missing)
- pkg/provider/exedev/exedev.go: store full Config struct; pass --cpu, --memory, --disk flags to ssh exe.dev new when defaults are configured
- pkg/hub/providers.go: wire new fields through to exedev.Config
- web/app/settings/[section]/settings-content.tsx: replace the empty exe.dev form with CPU, Memory, Disk inputs; read/write the new fields

Before: The Add Sandbox Provider modal for exe.dev showed Enter Replicated API token, Default TTL, and Default Instance — all irrelevant.
After: The modal shows SSH key guidance + Default CPUs, Default Memory, Default Disk fields that map to exe.dev new --cpu=N --memory=SIZE --disk=SIZE.

Docs PR: https://github.com/elasticclaw/elasticclaw.ai/pull/15