### PR TITLE
feat: auto-generate SSH key for exe.dev provider

### DIFF
--- a/pkg/hub/identity.go
+++ b/pkg/hub/identity.go
@@ -63,6 +63,54 @@ func LoadOrCreateIdentity(dir string) (*HubIdentity, error) {
 	return loadIdentity(privPath, pubPath)
 }
 
+// GenerateExedevKey creates or loads an SSH keypair specifically for exe.dev.
+// Returns the public key (authorized_keys format) and the private key path.
+func GenerateExedevKey(dir string) (pubKey string, privPath string, err error) {
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return "", "", fmt.Errorf("create identity dir: %w", err)
+	}
+
+	privPath = filepath.Join(dir, "exedev-key")
+	pubPath := filepath.Join(dir, "exedev-key.pub")
+
+	// If both exist, just return the public key
+	if _, err := os.Stat(privPath); err == nil {
+		pubBytes, err := os.ReadFile(pubPath)
+		if err != nil {
+			return "", "", fmt.Errorf("read exedev public key: %w", err)
+		}
+		return string(pubBytes), privPath, nil
+	}
+
+	// Generate new ed25519 keypair
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return "", "", fmt.Errorf("generate exedev keypair: %w", err)
+	}
+
+	// Marshal private key as PEM
+	privPEM, err := ssh.MarshalPrivateKey(priv, "elasticclaw exe.dev key")
+	if err != nil {
+		return "", "", fmt.Errorf("marshal exedev private key: %w", err)
+	}
+	privBytes := pem.EncodeToMemory(privPEM)
+	if err := os.WriteFile(privPath, privBytes, 0600); err != nil {
+		return "", "", fmt.Errorf("write exedev private key: %w", err)
+	}
+
+	// Marshal public key in authorized_keys format
+	sshPub, err := ssh.NewPublicKey(pub)
+	if err != nil {
+		return "", "", fmt.Errorf("marshal exedev public key: %w", err)
+	}
+	pubLine := strings.TrimSuffix(string(ssh.MarshalAuthorizedKey(sshPub)), "\n") + " elasticclaw@exedev\n"
+	if err := os.WriteFile(pubPath, []byte(pubLine), 0644); err != nil {
+		return "", "", fmt.Errorf("write exedev public key: %w", err)
+	}
+
+	return pubLine, privPath, nil
+}
+
 func loadIdentity(privPath, pubPath string) (*HubIdentity, error) {
 	privBytes, err := os.ReadFile(privPath)
 	if err != nil {

--- a/pkg/hub/identity.go
+++ b/pkg/hub/identity.go
@@ -74,12 +74,27 @@ func GenerateExedevKey(dir string) (pubKey string, privPath string, err error) {
 	pubPath := filepath.Join(dir, "exedev-key.pub")
 
 	// If both exist, just return the public key
+	privExists := false
 	if _, err := os.Stat(privPath); err == nil {
+		privExists = true
+	}
+	pubExists := false
+	if _, err := os.Stat(pubPath); err == nil {
+		pubExists = true
+	}
+	if privExists && pubExists {
 		pubBytes, err := os.ReadFile(pubPath)
 		if err != nil {
 			return "", "", fmt.Errorf("read exedev public key: %w", err)
 		}
 		return string(pubBytes), privPath, nil
+	}
+	// If only one exists, clean up the orphaned file before regenerating
+	if privExists {
+		os.Remove(privPath)
+	}
+	if pubExists {
+		os.Remove(pubPath)
 	}
 
 	// Generate new ed25519 keypair

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
+	"os"
+	"path/filepath"
 	"sort"
 
 	"github.com/elasticclaw/elasticclaw/pkg/config"
@@ -149,6 +152,12 @@ type ProviderView struct {
 	TokenSet            bool   `json:"tokenSet,omitempty"`
 	DefaultTTL          string `json:"defaultTtl,omitempty"`
 	DefaultInstanceType string `json:"defaultInstanceType,omitempty"`
+	// exe.dev
+	SSHKeySet       bool   `json:"sshKeySet,omitempty"`
+	SSHPublicKey    string `json:"sshPublicKey,omitempty"`
+	DefaultCPU      int    `json:"defaultCpu,omitempty"`
+	DefaultMemory   string `json:"defaultMemory,omitempty"`
+	DefaultDisk     string `json:"defaultDisk,omitempty"`
 }
 
 // GitHubAppPermission is a single permission check result for a GitHub App.
@@ -305,6 +314,10 @@ type ProviderPatch struct {
 	Token               string `json:"token,omitempty"`
 	DefaultTTL          string `json:"defaultTtl,omitempty"`
 	DefaultInstanceType string `json:"defaultInstanceType,omitempty"`
+	// exe.dev
+	DefaultCPU    int    `json:"defaultCpu,omitempty"`
+	DefaultMemory string `json:"defaultMemory,omitempty"`
+	DefaultDisk   string `json:"defaultDisk,omitempty"`
 	// Delete removes this provider when true.
 	Delete bool `json:"delete,omitempty"`
 }
@@ -377,6 +390,17 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 			pv.TokenSet = p.Token != ""
 			pv.DefaultTTL = p.DefaultTTL
 			pv.DefaultInstanceType = p.DefaultInstanceType
+		case "exedev":
+			pv.SSHKeySet = p.SSHKeyPath != ""
+			pv.DefaultCPU = p.DefaultCPU
+			pv.DefaultMemory = p.DefaultMemory
+			pv.DefaultDisk = p.DefaultDisk
+			// Generate and return public key if key exists
+			if p.SSHKeyPath != "" {
+				if pubBytes, err := os.ReadFile(p.SSHKeyPath + ".pub"); err == nil {
+					pv.SSHPublicKey = string(pubBytes)
+				}
+			}
 		}
 		view.Providers[name] = pv
 	}
@@ -767,6 +791,25 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 				}
 				if pp.DefaultInstanceType != "" {
 					existing.DefaultInstanceType = pp.DefaultInstanceType
+				}
+			case "exedev":
+				// Auto-generate SSH key if not already present
+				if existing.SSHKeyPath == "" {
+					_, privPath, err := GenerateExedevKey(filepath.Join(hubConfigDir(), "keys"))
+					if err != nil {
+						log.Printf("failed to generate exedev key: %v", err)
+					} else {
+						existing.SSHKeyPath = privPath
+					}
+				}
+				if pp.DefaultCPU > 0 {
+					existing.DefaultCPU = pp.DefaultCPU
+				}
+				if pp.DefaultMemory != "" {
+					existing.DefaultMemory = pp.DefaultMemory
+				}
+				if pp.DefaultDisk != "" {
+					existing.DefaultDisk = pp.DefaultDisk
 				}
 			}
 			updatedCfg.Providers[name] = existing

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -463,17 +463,6 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 			Limit: s.hubCfg.MaxConcurrentClaws,
 		})
 	}
-	s.mu.RUnlock()
-
-	// Read SSH public keys outside the lock (file I/O)
-	for name, pv := range view.Providers {
-		if pv._sshKeyPath != "" {
-			if pubBytes, err := os.ReadFile(pv._sshKeyPath + ".pub"); err == nil {
-				pv.SSHPublicKey = string(pubBytes)
-				view.Providers[name] = pv
-			}
-		}
-	}
 
 	// Factories — load only from external storage (single source of truth)
 	view.Factories = []FactoryView{}
@@ -522,45 +511,42 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 			ExternalTrigger:     f.ExternalTrigger,
 		})
 	}
-	// Auth config
+	// Auth config — copy under lock before RUnlock
+	var authView *AuthView
 	if s.hubCfg.Auth != nil {
-		view.Auth = &AuthView{
+		authView = &AuthView{
 			DisablePasswordAuth: s.hubCfg.Auth.DisablePasswordAuth,
 		}
 		if s.hubCfg.Auth.GitHubOAuth != nil {
 			gh := s.hubCfg.Auth.GitHubOAuth
-			view.Auth.GitHubOAuth = &GitHubOAuthView{
+			authView.GitHubOAuth = &GitHubOAuthView{
 				ClientID:        gh.ClientID,
 				ClientSecretSet: gh.ClientSecret != "",
-				AllowedUsers:    gh.AllowedUsers,
-				AllowedOrgs:     gh.AllowedOrgs,
-				AllowedTeams:    gh.AllowedTeams,
-			}
-			if view.Auth.GitHubOAuth.AllowedUsers == nil {
-				view.Auth.GitHubOAuth.AllowedUsers = []string{}
-			}
-			if view.Auth.GitHubOAuth.AllowedOrgs == nil {
-				view.Auth.GitHubOAuth.AllowedOrgs = []string{}
-			}
-			if view.Auth.GitHubOAuth.AllowedTeams == nil {
-				view.Auth.GitHubOAuth.AllowedTeams = []string{}
+				AllowedUsers:    append([]string(nil), gh.AllowedUsers...),
+				AllowedOrgs:     append([]string(nil), gh.AllowedOrgs...),
+				AllowedTeams:    append([]string(nil), gh.AllowedTeams...),
 			}
 		}
 		if s.hubCfg.Auth.Access != nil {
 			acc := s.hubCfg.Auth.Access
-			view.Auth.Access = &AccessView{
-				Admins:               acc.Admins,
-				ViewRequiresTags:     acc.ViewRequiresTags,
-				InteractRequiresTags: acc.InteractRequiresTags,
+			authView.Access = &AccessView{
+				Admins:               append([]string(nil), acc.Admins...),
+				ViewRequiresTags:     append([]string(nil), acc.ViewRequiresTags...),
+				InteractRequiresTags: append([]string(nil), acc.InteractRequiresTags...),
 			}
-			if view.Auth.Access.Admins == nil {
-				view.Auth.Access.Admins = []string{}
-			}
-			if view.Auth.Access.ViewRequiresTags == nil {
-				view.Auth.Access.ViewRequiresTags = []string{}
-			}
-			if view.Auth.Access.InteractRequiresTags == nil {
-				view.Auth.Access.InteractRequiresTags = []string{}
+		}
+	}
+
+	s.mu.RUnlock()
+
+	view.Auth = authView
+
+	// Read SSH public keys outside the lock (file I/O)
+	for name, pv := range view.Providers {
+		if pv._sshKeyPath != "" {
+			if pubBytes, err := os.ReadFile(pv._sshKeyPath + ".pub"); err == nil {
+				pv.SSHPublicKey = string(pubBytes)
+				view.Providers[name] = pv
 			}
 		}
 	}

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -158,6 +158,7 @@ type ProviderView struct {
 	DefaultCPU      int    `json:"defaultCpu,omitempty"`
 	DefaultMemory   string `json:"defaultMemory,omitempty"`
 	DefaultDisk     string `json:"defaultDisk,omitempty"`
+	_sshKeyPath     string `json:"-"` // internal: path for file I/O outside lock
 }
 
 // GitHubAppPermission is a single permission check result for a GitHub App.
@@ -395,11 +396,9 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 			pv.DefaultCPU = p.DefaultCPU
 			pv.DefaultMemory = p.DefaultMemory
 			pv.DefaultDisk = p.DefaultDisk
-			// Generate and return public key if key exists
+			// Record SSHKeyPath for file I/O outside the lock
 			if p.SSHKeyPath != "" {
-				if pubBytes, err := os.ReadFile(p.SSHKeyPath + ".pub"); err == nil {
-					pv.SSHPublicKey = string(pubBytes)
-				}
+				pv._sshKeyPath = p.SSHKeyPath
 			}
 		}
 		view.Providers[name] = pv
@@ -463,6 +462,17 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 			Name:  "global",
 			Limit: s.hubCfg.MaxConcurrentClaws,
 		})
+	}
+	s.mu.RUnlock()
+
+	// Read SSH public keys outside the lock (file I/O)
+	for name, pv := range view.Providers {
+		if pv._sshKeyPath != "" {
+			if pubBytes, err := os.ReadFile(pv._sshKeyPath + ".pub"); err == nil {
+				pv.SSHPublicKey = string(pubBytes)
+				view.Providers[name] = pv
+			}
+		}
 	}
 
 	// Factories — load only from external storage (single source of truth)
@@ -554,7 +564,6 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
-	s.mu.RUnlock()
 
 	// Check GitHub App permissions outside the lock (network call)
 	for _, app := range ghAppCfgs {

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -56,6 +56,8 @@ interface SettingsData {
     defaultCpu?: number
     defaultMemory?: string
     defaultDisk?: string
+    sshKeySet?: boolean
+    sshPublicKey?: string
   }>
   github: GitHubAppView[]
   sshPublicKeys: string[]
@@ -637,9 +639,36 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
 
             {formProvider === "exedev" && (
               <>
-                <p className="text-xs text-muted-foreground">
-                  exe.dev uses SSH key authentication. Ensure your SSH key is registered at <a href="https://exe.dev" target="_blank" rel="noopener noreferrer" className="underline">exe.dev</a>.
-                </p>
+                <div className="bg-muted/50 rounded-lg p-3 space-y-2">
+                  <p className="text-xs font-medium">SSH Key Setup</p>
+                  <p className="text-xs text-muted-foreground">
+                    A key pair has been generated for exe.dev. Add this public key to your{" "}
+                    <a href="https://exe.dev" target="_blank" rel="noopener noreferrer" className="underline">exe.dev account</a>.
+                  </p>
+                  {modalMode === "edit" && providers.exedev?.sshPublicKey ? (
+                    <div className="flex items-center gap-2">
+                      <code className="text-xs font-mono bg-background px-2 py-1 rounded flex-1 truncate">
+                        {providers.exedev.sshPublicKey}
+                      </code>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        className="h-7 px-2"
+                        onClick={() => {
+                          navigator.clipboard.writeText(providers.exedev.sshPublicKey || "")
+                          setSuccess("Public key copied")
+                          setTimeout(() => setSuccess(""), 2000)
+                        }}
+                      >
+                        <Copy className="size-3" />
+                      </Button>
+                    </div>
+                  ) : (
+                    <p className="text-xs text-muted-foreground italic">
+                      Public key will be shown after saving.
+                    </p>
+                  )}
+                </div>
                 <div>
                   <label className="text-xs text-muted-foreground mb-1 block">Default CPUs</label>
                   <Input value={formDefaultCpu} onChange={e => setFormDefaultCpu(e.target.value)} className="h-8 text-sm" placeholder="2" />

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -380,6 +380,7 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
   const [showModal, setShowModal] = useState(false)
   const [modalMode, setModalMode] = useState<"add" | "edit">("add")
   const [editName, setEditName] = useState<string | null>(null)
+  const [copiedKey, setCopiedKey] = useState(false)
 
   // Form state
   const [formProvider, setFormProvider] = useState("replicated")
@@ -656,10 +657,11 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
                         className="h-7 px-2"
                         onClick={() => {
                           navigator.clipboard.writeText(providers.exedev.sshPublicKey || "")
-                          alert("Public key copied to clipboard")
+                          setCopiedKey(true)
+                          setTimeout(() => setCopiedKey(false), 2000)
                         }}
                       >
-                        <Copy className="size-3" />
+                        {copiedKey ? <Check className="size-3 text-green-500" /> : <Copy className="size-3" />}
                       </Button>
                     </div>
                   ) : (

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -656,8 +656,7 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
                         className="h-7 px-2"
                         onClick={() => {
                           navigator.clipboard.writeText(providers.exedev.sshPublicKey || "")
-                          setSuccess("Public key copied")
-                          setTimeout(() => setSuccess(""), 2000)
+                          alert("Public key copied to clipboard")
                         }}
                       >
                         <Copy className="size-3" />

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -643,8 +643,9 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
                 <div className="bg-muted/50 rounded-lg p-3 space-y-2">
                   <p className="text-xs font-medium">SSH Key Setup</p>
                   <p className="text-xs text-muted-foreground">
-                    A key pair has been generated for exe.dev. Add this public key to your{" "}
-                    <a href="https://exe.dev" target="_blank" rel="noopener noreferrer" className="underline">exe.dev account</a>.
+                    {modalMode === "edit"
+                      ? <>A key pair has been generated for exe.dev. Add this public key to your{" "}<a href="https://exe.dev" target="_blank" rel="noopener noreferrer" className="underline">exe.dev account</a>.</>
+                      : <>An SSH key pair will be generated automatically when you save. You can copy the public key from the edit view and add it to your{" "}<a href="https://exe.dev" target="_blank" rel="noopener noreferrer" className="underline">exe.dev account</a>.</>}
                   </p>
                   {modalMode === "edit" && providers.exedev?.sshPublicKey ? (
                     <div className="flex items-center gap-2">

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -414,8 +414,8 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
       setFormProvider(firstAvailable.value)
       if (firstAvailable.value === "exedev") {
         setFormDefaultCpu("2")
-        setFormDefaultMemory("4GB")
-        setFormDefaultDisk("10GB")
+        setFormDefaultMemory("4")
+        setFormDefaultDisk("10")
       }
     }
     setModalMode("add")
@@ -432,8 +432,8 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
     setFormDefaultInstanceType(p?.defaultInstanceType || "")
     setFormDefaultSnapshot(p?.defaultSnapshot || "")
     setFormDefaultCpu(p?.defaultCpu?.toString() || "")
-    setFormDefaultMemory(p?.defaultMemory || "")
-    setFormDefaultDisk(p?.defaultDisk || "")
+    setFormDefaultMemory(p?.defaultMemory ? p.defaultMemory.replace(/GB$/, "") : "")
+    setFormDefaultDisk(p?.defaultDisk ? p.defaultDisk.replace(/GB$/, "") : "")
     setEditName(name)
     setModalMode("edit")
     setShowModal(true)
@@ -456,8 +456,8 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
       patch.enabled = true
       const parsedCpu = parseInt(formDefaultCpu, 10)
       if (formDefaultCpu && !isNaN(parsedCpu)) patch.defaultCpu = parsedCpu
-      if (formDefaultMemory) patch.defaultMemory = formDefaultMemory
-      if (formDefaultDisk) patch.defaultDisk = formDefaultDisk
+      if (formDefaultMemory) patch.defaultMemory = formDefaultMemory + "GB"
+      if (formDefaultDisk) patch.defaultDisk = formDefaultDisk + "GB"
     }
     onSave({ providers: { [formProvider]: patch } })
     setShowModal(false)
@@ -671,15 +671,39 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
                 </div>
                 <div>
                   <label className="text-xs text-muted-foreground mb-1 block">Default CPUs</label>
-                  <Input value={formDefaultCpu} onChange={e => setFormDefaultCpu(e.target.value)} className="h-8 text-sm" placeholder="2" />
+                  <Input
+                    type="number"
+                    min={1}
+                    max={32}
+                    value={formDefaultCpu}
+                    onChange={e => setFormDefaultCpu(e.target.value)}
+                    className="h-8 text-sm"
+                    placeholder="2"
+                  />
                 </div>
                 <div>
-                  <label className="text-xs text-muted-foreground mb-1 block">Default Memory</label>
-                  <Input value={formDefaultMemory} onChange={e => setFormDefaultMemory(e.target.value)} className="h-8 text-sm" placeholder="4GB" />
+                  <label className="text-xs text-muted-foreground mb-1 block">Default Memory (GB)</label>
+                  <Input
+                    type="number"
+                    min={1}
+                    max={128}
+                    value={formDefaultMemory}
+                    onChange={e => setFormDefaultMemory(e.target.value)}
+                    className="h-8 text-sm"
+                    placeholder="4"
+                  />
                 </div>
                 <div>
-                  <label className="text-xs text-muted-foreground mb-1 block">Default Disk</label>
-                  <Input value={formDefaultDisk} onChange={e => setFormDefaultDisk(e.target.value)} className="h-8 text-sm" placeholder="20GB" />
+                  <label className="text-xs text-muted-foreground mb-1 block">Default Disk (GB)</label>
+                  <Input
+                    type="number"
+                    min={10}
+                    max={500}
+                    value={formDefaultDisk}
+                    onChange={e => setFormDefaultDisk(e.target.value)}
+                    className="h-8 text-sm"
+                    placeholder="10"
+                  />
                 </div>
               </>
             )}


### PR DESCRIPTION
When configuring exe.dev, automatically generate an ed25519 SSH keypair stored at ~/.elasticclaw/keys/exedev-key. The public key is returned in the settings API and displayed in the UI with a copy button, so users can add it to their exe.dev account.

Changes:
- pkg/hub/identity.go: add GenerateExedevKey()
- pkg/hub/settings.go: include exe.dev fields in ProviderView/ProviderPatch, auto-generate key on patch if missing, return public key in GET
- web/app/settings/[section]/settings-content.tsx: show SSH key setup box with copy-to-clipboard, add sshKeySet/sshPublicKey to SettingsData type