### PR TITLE
fix: don't prematurely flip Replicated claw status to 'starting' before VM is running

### DIFF
--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2787,9 +2787,10 @@ func (s *Server) provisionReplicated(ctx context.Context, clawID string, req typ
 	if err != nil {
 		return fmt.Errorf("replicated provision: %w", err)
 	}
-	// Store vm_id in the claw record — skip if already deleted (factory terminated mid-provision)
+	// Store vm_id in the claw record — keep status='provisioning' so the poller can detect
+	// the provisioning→running transition and trigger bootstrap. Skip if already deleted.
 	_, _ = s.db.Exec(
-		`UPDATE claws SET status='starting', provider='replicated', provider_id=? WHERE id=? AND status != 'deleted'`, vmID, clawID,
+		`UPDATE claws SET provider='replicated', provider_id=? WHERE id=? AND status NOT IN ('deleted','starting','connected','idle')`, vmID, clawID,
 	)
 	// If deleted, clean up the VM and bail
 	var currentStatus string

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2822,7 +2822,7 @@ func (s *Server) provisionReplicated(ctx context.Context, clawID string, req typ
 	log.Printf("  Instance type: %s", instanceType)
 	log.Printf("  TTL:           %s", ttl)
 	log.Printf("  SSH:           ssh %s", replicatedpkg.VMHostname(vmID))
-	log.Printf("  Status:        starting (waiting for claw to register)")
+	log.Printf("  Status:        provisioning (waiting for VM to start)")
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- `provisionReplicated` was immediately setting `status='starting'` right after `ProvisionClaw` returned — before the VM actually reached the `running` state
- `syncReplicatedVMs` only calls `bootstrapReplicated` when `c.status == 'provisioning'` transitions to `vm.Status == 'running'`; since the claw was already `'starting'`, that condition was never true
- Result: VM starts fine but `claw-bridge` and `openclaw` are never installed — claw sits in `starting` forever

## Fix

Remove the `status='starting'` from the immediate DB update in `provisionReplicated`. Only store the `provider_id`. The poller then correctly detects the `provisioning → running` transition and fires bootstrap.

## Test plan
- [ ] Trigger a factory that uses the Replicated provider
- [ ] Confirm hub logs show `"Claw X: VM running, bootstrapping..."` after VM reaches running state
- [ ] Confirm `claw-bridge` and `openclaw` get installed and claw registers with hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)