### PR TITLE
Add troubleshoot settings static route

### DIFF
--- a/web/app/settings/[section]/page.tsx
+++ b/web/app/settings/[section]/page.tsx
@@ -1,6 +1,5 @@
 import SettingsSectionPage from "./settings-content"
-
-const VALID_SECTIONS = ["runtimes", "models", "github", "authentication", "issue-trackers", "factories", "secrets", "mcp-servers", "templates", "ai-config", "webhooks", "doctor", "analytics", "troubleshoot"]
+import { VALID_SECTIONS } from "./sections"
 
 export function generateStaticParams() {
   return VALID_SECTIONS.map((section) => ({ section }))

--- a/web/app/settings/[section]/page.tsx
+++ b/web/app/settings/[section]/page.tsx
@@ -1,6 +1,6 @@
 import SettingsSectionPage from "./settings-content"
 
-const VALID_SECTIONS = ["runtimes", "models", "github", "authentication", "issue-trackers", "factories", "secrets", "mcp-servers", "templates", "ai-config", "webhooks", "doctor", "analytics"]
+const VALID_SECTIONS = ["runtimes", "models", "github", "authentication", "issue-trackers", "factories", "secrets", "mcp-servers", "templates", "ai-config", "webhooks", "doctor", "analytics", "troubleshoot"]
 
 export function generateStaticParams() {
   return VALID_SECTIONS.map((section) => ({ section }))

--- a/web/app/settings/[section]/sections.ts
+++ b/web/app/settings/[section]/sections.ts
@@ -1,0 +1,18 @@
+export const VALID_SECTIONS = [
+  "runtimes",
+  "models",
+  "github",
+  "authentication",
+  "issue-trackers",
+  "factories",
+  "secrets",
+  "templates",
+  "ai-config",
+  "mcp-servers",
+  "webhooks",
+  "doctor",
+  "analytics",
+  "troubleshoot",
+] as const
+
+export type Section = (typeof VALID_SECTIONS)[number]

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -9,10 +9,7 @@ import { Input } from "@/components/ui/input"
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog"
 import { cn } from "@/lib/utils"
 import Link from "next/link"
-
-type Section = "runtimes" | "models" | "github" | "authentication" | "issue-trackers" | "factories" | "secrets" | "templates" | "ai-config" | "mcp-servers" | "webhooks" | "doctor" | "analytics" | "troubleshoot"
-
-const VALID_SECTIONS: Section[] = ["runtimes", "models", "github", "authentication", "issue-trackers", "factories", "secrets", "templates", "ai-config", "mcp-servers", "webhooks", "doctor", "analytics", "troubleshoot"]
+import { VALID_SECTIONS, type Section } from "./sections"
 
 function isValidSection(s: string): s is Section {
   return VALID_SECTIONS.includes(s as Section)


### PR DESCRIPTION
## Summary
- include the troubleshoot settings section in generateStaticParams
- ensure /settings/troubleshoot is emitted by the static export

## Verification
- npm run build
- verified web/out/settings/troubleshoot/index.html exists