### PR TITLE
Fix Clawpatch high finding fnd_sig-feat-cli-command-0b9f15889a-_30b2a14535

### DIFF
--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -597,6 +597,24 @@ func (gs *gatewaySession) sendReq(ctx context.Context, method string, params int
 	}
 }
 
+func (gs *gatewaySession) failPendingRequests(err error) {
+	gs.pendMu.Lock()
+	pending := gs.pending
+	gs.pending = make(map[string]chan gwFrame)
+	gs.pendMu.Unlock()
+
+	for id, ch := range pending {
+		ch <- gwFrame{
+			Type: "res",
+			ID:   id,
+			Error: &gwError{
+				Code:    "gateway_disconnected",
+				Message: err.Error(),
+			},
+		}
+	}
+}
+
 // initSession resolves the persistent session key (loading from disk and
 // verifying, or creating a new one) and subscribes to it.
 func (gs *gatewaySession) initSession(ctx context.Context) error {
@@ -663,6 +681,8 @@ func (gs *gatewaySession) readLoop(ctx context.Context) {
 				return // shutting down
 			}
 			log.Printf("[gateway] read error: %v — reconnecting in 3s", err)
+
+			gs.failPendingRequests(fmt.Errorf("gateway disconnected"))
 
 			// Fail any in-flight message
 			gs.infMu.RLock()

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -1,9 +1,17 @@
 package main
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
+
+	"nhooyr.io/websocket"
+	"nhooyr.io/websocket/wsjson"
 )
 
 func writeGatewayClientConfig(t *testing.T, home, config string) {
@@ -88,5 +96,72 @@ func TestLoadGatewayClientEnvVarFallbackWhenNoConfigPassword(t *testing.T) {
 	}
 	if client.password != "env-password" {
 		t.Fatalf("password = %q, want env-password (env var fallback when config has no password)", client.password)
+	}
+}
+
+func TestGatewayReadLoopFailsPendingRequestsOnDisconnect(t *testing.T) {
+	serverRead := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Errorf("accept websocket: %v", err)
+			return
+		}
+		defer conn.CloseNow()
+
+		var req gwFrame
+		if err := wsjson.Read(r.Context(), conn, &req); err != nil {
+			t.Errorf("read request: %v", err)
+			return
+		}
+		close(serverRead)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer conn.CloseNow()
+
+	gs := &gatewaySession{
+		conn:    conn,
+		pending: make(map[string]chan gwFrame),
+	}
+	go gs.readLoop(ctx)
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := gs.sendReq(ctx, "sessions.get", map[string]string{"key": "session-1"})
+		errCh <- err
+	}()
+
+	select {
+	case <-serverRead:
+	case <-time.After(time.Second):
+		t.Fatal("server did not receive request")
+	}
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("sendReq returned nil error")
+		}
+		if !strings.Contains(err.Error(), "gateway disconnected") {
+			t.Fatalf("sendReq error = %v, want gateway disconnected", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("sendReq did not return after gateway disconnect")
+	}
+
+	gs.pendMu.Lock()
+	pendingLen := len(gs.pending)
+	gs.pendMu.Unlock()
+	if pendingLen != 0 {
+		t.Fatalf("pending requests = %d, want 0", pendingLen)
 	}
 }


### PR DESCRIPTION
## Clawpatch finding

- Finding: `fnd_sig-feat-cli-command-0b9f15889a-_30b2a14535`
- Severity: `high`
- Confidence: `high`
- Category: `concurrency`
- Title: Gateway reconnect does not fail pending requests

## Validation

- `clawpatch revalidate --finding fnd_sig-feat-cli-command-0b9f15889a-_30b2a14535`
- `make test`

## Notes

This PR was created by `make clawpatch-pr` for one agreed open finding.
