### PR TITLE
Fix Clawpatch high finding fnd_sig-feat-cli-command-3f0482b723-_d2e1015bd1

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spf13/cobra"
 	gossh "golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
+	"golang.org/x/crypto/ssh/knownhosts"
 )
 
 var installCmd = &cobra.Command{
@@ -37,12 +38,12 @@ Prerequisites:
 }
 
 var (
-	installServer   string
-	installDomain  string
-	installSSHKey  string
-	installVersion string
-	installToken        string
-	installUIPassword   string
+	installServer     string
+	installDomain     string
+	installSSHKey     string
+	installVersion    string
+	installToken      string
+	installUIPassword string
 )
 
 func init() {
@@ -83,11 +84,11 @@ func runInstall(cmd *cobra.Command, args []string) error {
 	clawToken := randomHex32()
 
 	params := install.Params{
-		Domain:       installDomain,
-		Version:      version,
-		Token:        token,
-		ClawToken:    clawToken,
-		UIPassword:   uiToken,
+		Domain:     installDomain,
+		Version:    version,
+		Token:      token,
+		ClawToken:  clawToken,
+		UIPassword: uiToken,
 	}
 
 	// ── Preflight: DNS check (skipped with --skip-caddy) ─────────────────────
@@ -202,9 +203,10 @@ func findGitHubRelease(owner, repo, tag string) error {
 }
 
 // extractTrack returns the non-incrementing prefix of a CalVer/SemVer tag.
-//   "2026.05.11-beta.2" → "2026.05.11-beta"
-//   "2026.05.11.1"      → "2026.05.11"
-//   "2026.05.11"        → "2026.05.11"
+//
+//	"2026.05.11-beta.2" → "2026.05.11-beta"
+//	"2026.05.11.1"      → "2026.05.11"
+//	"2026.05.11"        → "2026.05.11"
 func extractTrack(version string) string {
 	if idx := strings.LastIndex(version, "-"); idx != -1 {
 		suffix := version[idx+1:]
@@ -379,13 +381,31 @@ func dialSSH(user, addr, keyPath string) (*gossh.Client, error) {
 		return nil, fmt.Errorf("no SSH auth methods available — ensure SSH agent is running (eval $(ssh-agent)) or use --ssh-key with an unencrypted key")
 	}
 
+	hostKeyCallback, err := knownHostsCallback()
+	if err != nil {
+		return nil, err
+	}
+
 	cfg := &gossh.ClientConfig{
 		User:            user,
 		Auth:            authMethods,
-		HostKeyCallback: gossh.InsecureIgnoreHostKey(),
+		HostKeyCallback: hostKeyCallback,
 		Timeout:         15 * time.Second,
 	}
 	return gossh.Dial("tcp", addr, cfg)
+}
+
+func knownHostsCallback() (gossh.HostKeyCallback, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("could not locate home directory for SSH known_hosts: %w", err)
+	}
+	path := home + "/.ssh/known_hosts"
+	callback, err := knownhosts.New(path)
+	if err != nil {
+		return nil, fmt.Errorf("could not load SSH known_hosts from %s: %w", path, err)
+	}
+	return callback, nil
 }
 
 func detectRemotePrivilegeMode(client *gossh.Client) (bool, error) {

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -400,12 +401,35 @@ func knownHostsCallback() (gossh.HostKeyCallback, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not locate home directory for SSH known_hosts: %w", err)
 	}
-	path := home + "/.ssh/known_hosts"
+	path := filepath.Join(home, ".ssh", "known_hosts")
 	callback, err := knownhosts.New(path)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return func(hostname string, remote net.Addr, key gossh.PublicKey) error {
+				return fmt.Errorf("SSH known_hosts file not found at %s; add the server host key first with: %s", path, sshKeyscanHint(hostname, path))
+			}, nil
+		}
 		return nil, fmt.Errorf("could not load SSH known_hosts from %s: %w", path, err)
 	}
-	return callback, nil
+	return func(hostname string, remote net.Addr, key gossh.PublicKey) error {
+		if err := callback(hostname, remote, key); err != nil {
+			return fmt.Errorf("SSH host key verification failed for %s: %w; add or update the trusted host key with: %s", hostname, err, sshKeyscanHint(hostname, path))
+		}
+		return nil
+	}, nil
+}
+
+func sshKeyscanHint(hostname, knownHostsPath string) string {
+	host := hostname
+	port := ""
+	if splitHost, splitPort, err := net.SplitHostPort(hostname); err == nil {
+		host = splitHost
+		port = splitPort
+	}
+	if port != "" && port != "22" {
+		return fmt.Sprintf("ssh-keyscan -p %s -H %s >> %s", port, host, knownHostsPath)
+	}
+	return fmt.Sprintf("ssh-keyscan -H %s >> %s", host, knownHostsPath)
 }
 
 func detectRemotePrivilegeMode(client *gossh.Client) (bool, error) {

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	gossh "golang.org/x/crypto/ssh"
+)
+
+func TestKnownHostsCallbackVerifiesServerKey(t *testing.T) {
+	trustedKey, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	trustedPub, err := gossh.NewPublicKey(trustedKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherKey, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherPub, err := gossh.NewPublicKey(otherKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	home := t.TempDir()
+	sshDir := filepath.Join(home, ".ssh")
+	if err := os.Mkdir(sshDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	knownHosts := filepath.Join(sshDir, "known_hosts")
+	line := "example.com " + strings.TrimSpace(string(gossh.MarshalAuthorizedKey(trustedPub))) + "\n"
+	if err := os.WriteFile(knownHosts, []byte(line), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+
+	callback, err := knownHostsCallback()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	addr := &net.TCPAddr{IP: net.ParseIP("203.0.113.10"), Port: 22}
+	if err := callback("example.com:22", addr, trustedPub); err != nil {
+		t.Fatalf("trusted host key rejected: %v", err)
+	}
+	if err := callback("example.com:22", addr, otherPub); err == nil {
+		t.Fatal("mismatched host key accepted")
+	}
+	if err := callback("unknown.example.com:22", addr, trustedPub); err == nil {
+		t.Fatal("unknown host key accepted")
+	}
+}

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -56,5 +56,71 @@ func TestKnownHostsCallbackVerifiesServerKey(t *testing.T) {
 	}
 	if err := callback("unknown.example.com:22", addr, trustedPub); err == nil {
 		t.Fatal("unknown host key accepted")
+	} else if !strings.Contains(err.Error(), "ssh-keyscan -H unknown.example.com") {
+		t.Fatalf("unknown host key error missing ssh-keyscan hint: %v", err)
+	}
+}
+
+func TestKnownHostsCallbackMissingFileRejectsWithHint(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	callback, err := knownHostsCallback()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	key, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pub, err := gossh.NewPublicKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	addr := &net.TCPAddr{IP: net.ParseIP("203.0.113.10"), Port: 2222}
+	err = callback("example.com:2222", addr, pub)
+	if err == nil {
+		t.Fatal("missing known_hosts file accepted host key")
+	}
+	if !strings.Contains(err.Error(), "known_hosts file not found") {
+		t.Fatalf("missing known_hosts error missing context: %v", err)
+	}
+	if !strings.Contains(err.Error(), "ssh-keyscan -p 2222 -H example.com") {
+		t.Fatalf("missing known_hosts error missing port-aware ssh-keyscan hint: %v", err)
+	}
+}
+
+func TestSSHKeyscanHint(t *testing.T) {
+	path := filepath.Join("home", ".ssh", "known_hosts")
+	tests := []struct {
+		name     string
+		hostname string
+		want     string
+	}{
+		{
+			name:     "default port",
+			hostname: "example.com:22",
+			want:     "ssh-keyscan -H example.com >> " + path,
+		},
+		{
+			name:     "custom port",
+			hostname: "example.com:2222",
+			want:     "ssh-keyscan -p 2222 -H example.com >> " + path,
+		},
+		{
+			name:     "host without port",
+			hostname: "example.com",
+			want:     "ssh-keyscan -H example.com >> " + path,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sshKeyscanHint(tt.hostname, path); got != tt.want {
+				t.Fatalf("sshKeyscanHint() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Clawpatch finding

- Finding: `fnd_sig-feat-cli-command-3f0482b723-_d2e1015bd1`
- Severity: `high`
- Confidence: `high`
- Category: `security`
- Title: SSH installer and upgrader disable host key verification

## Validation

- `clawpatch revalidate --finding fnd_sig-feat-cli-command-3f0482b723-_d2e1015bd1`
- `make test`

## Notes

This PR was created by `make clawpatch-pr` for one agreed open finding.
