### PR TITLE
Fix Clawpatch high finding fnd_sig-feat-library-0fc085f96c-7fb7_408ea136c3

### DIFF
--- a/pkg/provider/daytona/daytona.go
+++ b/pkg/provider/daytona/daytona.go
@@ -134,6 +134,10 @@ func getDir(path string) string {
 	return ""
 }
 
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
+}
+
 // Status checks current sandbox state
 func (p *Provider) Status(ctx context.Context, instanceID string) (types.InstanceStatus, error) {
 	sandbox, err := p.client.FindOne(ctx, &instanceID, nil)
@@ -348,7 +352,7 @@ func (p *Provider) StartOpenClaw(ctx context.Context, instanceID string, workdir
 	// Use gateway run (foreground mode) with setsid/nohup so the gateway
 	// stays alive after the exec session ends.  gateway start is for
 	// systemd/launchd service installation and is not appropriate here.
-	cmd := fmt.Sprintf("bash -c 'cd %s && source ~/.openclaw/env 2>/dev/null; setsid nohup openclaw gateway run >> ~/.openclaw/gateway.log 2>&1 </dev/null &'", workdir)
+	cmd := buildStartOpenClawCommand(workdir)
 	response, err := sandbox.Process.ExecuteCommand(ctx, cmd)
 	if err != nil {
 		return fmt.Errorf("failed to start gateway: %w", err)
@@ -358,4 +362,9 @@ func (p *Provider) StartOpenClaw(ctx context.Context, instanceID string, workdir
 	}
 
 	return nil
+}
+
+func buildStartOpenClawCommand(workdir string) string {
+	script := fmt.Sprintf("cd %s && source ~/.openclaw/env 2>/dev/null; setsid nohup openclaw gateway run >> ~/.openclaw/gateway.log 2>&1 </dev/null &", shellQuote(workdir))
+	return fmt.Sprintf("bash -c %s", shellQuote(script))
 }

--- a/pkg/provider/daytona/daytona_test.go
+++ b/pkg/provider/daytona/daytona_test.go
@@ -1,0 +1,22 @@
+package daytona
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildStartOpenClawCommandQuotesWorkdir(t *testing.T) {
+	workdir := `/tmp/a'; touch /tmp/pwned; #'`
+
+	cmd := buildStartOpenClawCommand(workdir)
+
+	if !strings.HasPrefix(cmd, "bash -c '") {
+		t.Fatalf("command should pass a quoted script to bash -c: %s", cmd)
+	}
+	if strings.Contains(cmd, "cd /tmp/a'; touch /tmp/pwned; #'") {
+		t.Fatalf("workdir was interpolated without shell quoting: %s", cmd)
+	}
+	if !strings.Contains(cmd, `cd '"'"'/tmp/a'"'"'"'"'"'"'"'"'; touch /tmp/pwned; #'"'"'"'"'"'"'"'"''"'"'`) {
+		t.Fatalf("workdir was not preserved as one quoted cd target: %s", cmd)
+	}
+}


### PR DESCRIPTION
## Clawpatch finding

- Finding: `fnd_sig-feat-library-0fc085f96c-7fb7_408ea136c3`
- Severity: `high`
- Confidence: `high`
- Category: `security`
- Title: Shell command construction allows workdir command injection

## Validation

- `clawpatch revalidate --finding fnd_sig-feat-library-0fc085f96c-7fb7_408ea136c3`
- `make test`

## Notes

This PR was created by `make clawpatch-pr` for one agreed open finding.
