### PR TITLE
Fix Clawpatch high finding fnd_sig-feat-library-1c7d619b91-720d_5689f35514

### DIFF
--- a/pkg/provider/local/local.go
+++ b/pkg/provider/local/local.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/elasticclaw/elasticclaw/pkg/config"
@@ -36,7 +37,7 @@ func (p *Provider) instanceDir(instanceID string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(paths.StateDir, "local-instances", instanceID), nil
+	return confinedPath(filepath.Join(paths.StateDir, "local-instances"), instanceID, "instance ID")
 }
 
 // Create provisions a new local instance
@@ -59,7 +60,10 @@ func (p *Provider) Create(ctx context.Context, req types.CreateRequest) (*types.
 
 	// Write template files
 	for path, content := range req.TemplateFiles {
-		fullPath := filepath.Join(workspaceDir, path)
+		fullPath, err := confinedPath(workspaceDir, path, "template path")
+		if err != nil {
+			return nil, err
+		}
 		dir := filepath.Dir(fullPath)
 		if err := os.MkdirAll(dir, 0755); err != nil {
 			return nil, fmt.Errorf("failed to create directory for %s: %w", path, err)
@@ -230,4 +234,27 @@ func parseEnvFile(content string) []string {
 		}
 	}
 	return env
+}
+
+func confinedPath(base, path, label string) (string, error) {
+	clean := filepath.Clean(path)
+	if path == "" || clean == "." || filepath.IsAbs(path) {
+		return "", fmt.Errorf("invalid %s %q", label, path)
+	}
+	for _, part := range strings.Split(clean, string(os.PathSeparator)) {
+		if part == ".." {
+			return "", fmt.Errorf("invalid %s %q", label, path)
+		}
+	}
+
+	fullPath := filepath.Join(base, clean)
+	rel, err := filepath.Rel(base, fullPath)
+	if err != nil {
+		return "", fmt.Errorf("invalid %s %q: %w", label, path, err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("invalid %s %q", label, path)
+	}
+
+	return fullPath, nil
 }

--- a/pkg/provider/local/local_test.go
+++ b/pkg/provider/local/local_test.go
@@ -1,0 +1,72 @@
+package local
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func TestInstanceIDTraversalRejected(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	stateOutside := filepath.Join(home, ".elasticclaw", "state", "outside")
+	if err := os.MkdirAll(stateOutside, 0755); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+
+	p := New()
+	if err := p.Destroy(context.Background(), "../outside", false); err == nil {
+		t.Fatal("Destroy should reject traversal instance ID")
+	}
+	if _, err := os.Stat(stateOutside); err != nil {
+		t.Fatalf("Destroy removed or changed escaped path: %v", err)
+	}
+
+	if _, err := p.Exec(context.Background(), "../outside", []string{"true"}); err == nil {
+		t.Fatal("Exec should reject traversal instance ID")
+	}
+
+	absID := filepath.Join(home, "absolute")
+	if _, err := p.Status(context.Background(), absID); err == nil {
+		t.Fatal("Status should reject absolute instance ID")
+	}
+}
+
+func TestCreateRejectsEscapingTemplatePaths(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	p := New()
+	_, err := p.Create(context.Background(), types.CreateRequest{
+		Name: "safe",
+		TemplateFiles: map[string][]byte{
+			"../outside.txt": []byte("escaped"),
+		},
+	})
+	if err == nil {
+		t.Fatal("Create should reject traversal template path")
+	}
+
+	escapedPath := filepath.Join(home, ".elasticclaw", "state", "local-instances", "safe", "outside.txt")
+	if _, err := os.Stat(escapedPath); !os.IsNotExist(err) {
+		t.Fatalf("Create wrote escaped template path, stat err: %v", err)
+	}
+
+	absPath := filepath.Join(home, "absolute.txt")
+	_, err = p.Create(context.Background(), types.CreateRequest{
+		Name: "safe-absolute",
+		TemplateFiles: map[string][]byte{
+			absPath: []byte("escaped"),
+		},
+	})
+	if err == nil {
+		t.Fatal("Create should reject absolute template path")
+	}
+	if _, err := os.Stat(absPath); !os.IsNotExist(err) {
+		t.Fatalf("Create wrote absolute template path, stat err: %v", err)
+	}
+}


### PR DESCRIPTION
## Clawpatch finding

- Finding: `fnd_sig-feat-library-1c7d619b91-720d_5689f35514`
- Severity: `high`
- Confidence: `high`
- Category: `security`
- Title: Local instance and template paths can escape the provider state directory

## Validation

- `clawpatch revalidate --finding fnd_sig-feat-library-1c7d619b91-720d_5689f35514`
- `make test`

## Notes

This PR was created by `make clawpatch-pr` for one agreed open finding.
