### PR TITLE
Fix Clawpatch medium finding fnd_sig-feat-cli-command-3f0482b723-_9afed42cfe

### DIFF
--- a/cmd/factory.go
+++ b/cmd/factory.go
@@ -499,7 +499,7 @@ func runFactoryTrigger(name string, inputs []string) error {
 		return fmt.Errorf("decode response: %w", err)
 	}
 
-	fmt.Printf("Triggered factory %q → claw %s (%s)\n", name, result.ClawID[:8], result.Status)
+	fmt.Printf("Triggered factory %q → claw %s (%s)\n", name, shortID(result.ClawID), result.Status)
 	return nil
 }
 

--- a/cmd/id.go
+++ b/cmd/id.go
@@ -1,0 +1,8 @@
+package cmd
+
+func shortID(id string) string {
+	if len(id) <= 8 {
+		return id
+	}
+	return id[:8]
+}

--- a/cmd/id_test.go
+++ b/cmd/id_test.go
@@ -1,0 +1,117 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func TestShortID(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+		want string
+	}{
+		{name: "empty", id: "", want: ""},
+		{name: "short", id: "abc", want: "abc"},
+		{name: "exact", id: "abcdefgh", want: "abcdefgh"},
+		{name: "long", id: "abcdefghi", want: "abcdefgh"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shortID(tt.id); got != tt.want {
+				t.Fatalf("shortID(%q) = %q, want %q", tt.id, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunListHubHandlesShortClawID(t *testing.T) {
+	oldJSONOut := jsonOut
+	oldListTag := listTag
+	jsonOut = false
+	listTag = ""
+	defer func() {
+		jsonOut = oldJSONOut
+		listTag = oldListTag
+	}()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/claws" {
+			http.NotFound(w, r)
+			return
+		}
+		claws := []types.Claw{{
+			ID:       "abc",
+			Name:     "short",
+			Template: "elasticclaw",
+			Status:   types.StatusRunning,
+		}}
+		if err := json.NewEncoder(w).Encode(claws); err != nil {
+			t.Fatalf("encode claws: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	out, err := captureStdout(func() error {
+		return runListHub(&types.HubProfile{URL: server.URL, Token: "test-token"})
+	})
+	if err != nil {
+		t.Fatalf("runListHub returned error: %v", err)
+	}
+	if !strings.Contains(out, "abc") {
+		t.Fatalf("output missing short ID: %q", out)
+	}
+}
+
+func TestRunFactoryTriggerHandlesShortClawID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/factories/demo/trigger" {
+			http.NotFound(w, r)
+			return
+		}
+		fmt.Fprint(w, `{"claw_id":"abc","status":"running"}`)
+	}))
+	defer server.Close()
+
+	t.Setenv("ELASTICCLAW_HUB_URL", server.URL)
+	t.Setenv("ELASTICCLAW_CLAW_TOKEN", "test-token")
+
+	out, err := captureStdout(func() error {
+		return runFactoryTrigger("demo", nil)
+	})
+	if err != nil {
+		t.Fatalf("runFactoryTrigger returned error: %v", err)
+	}
+	if !strings.Contains(out, "claw abc") {
+		t.Fatalf("output missing short claw ID: %q", out)
+	}
+}
+
+func captureStdout(fn func() error) (string, error) {
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		return "", err
+	}
+	os.Stdout = w
+
+	fnErr := fn()
+	w.Close()
+	os.Stdout = old
+
+	out, readErr := io.ReadAll(r)
+	r.Close()
+	if readErr != nil {
+		return "", readErr
+	}
+	return string(out), fnErr
+}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -125,7 +125,7 @@ func runListHub(h *types.HubProfile) error {
 			tags = "-"
 		}
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
-			c.ID[:8], c.Name, c.Template, c.Status, formatAge(c.CreatedAt), tags)
+			shortID(c.ID), c.Name, c.Template, c.Status, formatAge(c.CreatedAt), tags)
 	}
 	w.Flush()
 	return nil


### PR DESCRIPTION
## Clawpatch finding

- Finding: `fnd_sig-feat-cli-command-3f0482b723-_9afed42cfe`
- Severity: `medium`
- Confidence: `high`
- Category: `bug`
- Title: CLI panics when hub returns a short claw ID

## Validation

- `clawpatch revalidate --finding fnd_sig-feat-cli-command-3f0482b723-_9afed42cfe`
- `make test`

## Notes

This PR was created by `make clawpatch-pr` for one agreed open finding.
