### PR TITLE
Fix Clawpatch medium finding fnd_sig-feat-cli-command-dd3b636156-_9f762fa40b

### DIFF
--- a/pkg/bootopt/measure_test.go
+++ b/pkg/bootopt/measure_test.go
@@ -95,10 +95,51 @@ esac
 	if result.ClawID != clawID {
 		t.Fatalf("claw ID = %q, want %q", result.ClawID, clawID)
 	}
-	if !strings.Contains(result.Error, "cleanup claw "+clawID) {
-		t.Fatalf("result error %q missing claw cleanup context", result.Error)
+	if result.Error != "" {
+		t.Fatalf("result error = %q, want empty boot error", result.Error)
+	}
+	if !strings.Contains(result.CleanupError, "cleanup claw "+clawID) {
+		t.Fatalf("cleanup error %q missing claw cleanup context", result.CleanupError)
 	}
 	if !strings.Contains(err.Error(), "kill failed for "+clawID) {
 		t.Fatalf("error %q missing kill failure output", err.Error())
+	}
+}
+
+func TestAggregateVMBootResultsIncludesCleanupFailures(t *testing.T) {
+	results := []*VMBootResult{
+		{
+			TotalMs:      100,
+			Phases:       map[string]int64{"vm_create_api": 10, "vm_provisioning": 20, "bootstrap": 70},
+			CleanupError: "cleanup failed",
+		},
+		{
+			TotalMs: 300,
+			Phases:  map[string]int64{"vm_create_api": 30, "vm_provisioning": 60, "bootstrap": 210},
+		},
+		{
+			Error:  "wait online failed",
+			Phases: map[string]int64{"vm_create_api": 5},
+		},
+	}
+
+	mean, median, p95, phaseMeans := AggregateVMBootResults(results)
+	if mean != 200 {
+		t.Fatalf("mean = %d, want 200", mean)
+	}
+	if median != 200 {
+		t.Fatalf("median = %d, want 200", median)
+	}
+	if p95 != 300 {
+		t.Fatalf("p95 = %d, want 300", p95)
+	}
+	if phaseMeans["vm_create_api"] != 20 {
+		t.Fatalf("vm_create_api mean = %d, want 20", phaseMeans["vm_create_api"])
+	}
+	if phaseMeans["vm_provisioning"] != 40 {
+		t.Fatalf("vm_provisioning mean = %d, want 40", phaseMeans["vm_provisioning"])
+	}
+	if phaseMeans["bootstrap"] != 140 {
+		t.Fatalf("bootstrap mean = %d, want 140", phaseMeans["bootstrap"])
 	}
 }

--- a/pkg/bootopt/measure_test.go
+++ b/pkg/bootopt/measure_test.go
@@ -1,6 +1,9 @@
 package bootopt
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -53,5 +56,49 @@ func TestRunTiming_AllErrorsReturnsError(t *testing.T) {
 	}
 	if len(runs) != 2 {
 		t.Fatalf("len(runs) = %d, want 2", len(runs))
+	}
+}
+
+func TestRunVMBootTestReturnsCleanupError(t *testing.T) {
+	const clawID = "550e8400-e29b-41d4-a716-446655440000"
+	bin := filepath.Join(t.TempDir(), "elasticclaw")
+	script := `#!/bin/sh
+case "$1" in
+create)
+	echo "Created claw bootopt (id: 550e8400-e29b-41d4-a716-446655440000)"
+	;;
+list)
+	printf '[{"id":"550e8400-e29b-41d4-a716-446655440000","status":"online"}]\n'
+	;;
+kill)
+	echo "kill failed for $2" >&2
+	exit 17
+	;;
+*)
+	echo "unexpected command: $1" >&2
+	exit 2
+	;;
+esac
+`
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake CLI: %v", err)
+	}
+
+	runner := NewVMTestRunnerWithConfig(bin, "", "base")
+	result, err := runner.RunVMBootTest(t.Context())
+	if err == nil {
+		t.Fatal("expected cleanup error")
+	}
+	if result == nil {
+		t.Fatal("expected result")
+	}
+	if result.ClawID != clawID {
+		t.Fatalf("claw ID = %q, want %q", result.ClawID, clawID)
+	}
+	if !strings.Contains(result.Error, "cleanup claw "+clawID) {
+		t.Fatalf("result error %q missing claw cleanup context", result.Error)
+	}
+	if !strings.Contains(err.Error(), "kill failed for "+clawID) {
+		t.Fatalf("error %q missing kill failure output", err.Error())
 	}
 }

--- a/pkg/bootopt/vmtest.go
+++ b/pkg/bootopt/vmtest.go
@@ -147,7 +147,7 @@ func (vtr *VMTestRunner) RunVMBootTest(ctx context.Context) (*VMBootResult, erro
 
 	// Phase 4: Cleanup — destroy immediately, we only needed timing
 	if err := vtr.cleanupClaw(clawID); err != nil {
-		result.Error = err.Error()
+		result.CleanupError = err.Error()
 		return result, err
 	}
 
@@ -161,6 +161,9 @@ type VMBootResult struct {
 	TotalMs int64            `json:"total_ms"`
 	Phases  map[string]int64 `json:"phases"`
 	Error   string           `json:"error,omitempty"`
+	// CleanupError records post-measurement cleanup failures without invalidating
+	// successful boot timing data.
+	CleanupError string `json:"cleanup_error,omitempty"`
 }
 
 // createClaw provisions a new claw via the elasticclaw CLI.
@@ -285,7 +288,7 @@ func parseClawStatus(jsonOutput, clawID string) (string, error) {
 func AggregateVMBootResults(results []*VMBootResult) (mean, median, p95 int64, phaseMeans map[string]int64) {
 	var valid []*VMBootResult
 	for _, r := range results {
-		if r.Error == "" {
+		if r.Error == "" && r.TotalMs > 0 {
 			valid = append(valid, r)
 		}
 	}

--- a/pkg/bootopt/vmtest.go
+++ b/pkg/bootopt/vmtest.go
@@ -3,6 +3,7 @@ package bootopt
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -122,7 +123,10 @@ func (vtr *VMTestRunner) RunVMBootTest(ctx context.Context) (*VMBootResult, erro
 	_, err = vtr.waitForStatus(ctx, clawID, "provisioning", 2*time.Minute)
 	if err != nil {
 		result.Error = fmt.Sprintf("wait provisioning: %v", err)
-		vtr.cleanupClaw(clawID)
+		if cleanupErr := vtr.cleanupClaw(clawID); cleanupErr != nil {
+			result.Error = fmt.Sprintf("%s; %v", result.Error, cleanupErr)
+			return result, errors.Join(err, cleanupErr)
+		}
 		return result, err
 	}
 	result.Phases["vm_provisioning"] = time.Since(phaseStart).Milliseconds()
@@ -132,14 +136,20 @@ func (vtr *VMTestRunner) RunVMBootTest(ctx context.Context) (*VMBootResult, erro
 	_, err = vtr.waitForStatus(ctx, clawID, "online", vtr.Timeout)
 	if err != nil {
 		result.Error = fmt.Sprintf("wait online: %v", err)
-		vtr.cleanupClaw(clawID)
+		if cleanupErr := vtr.cleanupClaw(clawID); cleanupErr != nil {
+			result.Error = fmt.Sprintf("%s; %v", result.Error, cleanupErr)
+			return result, errors.Join(err, cleanupErr)
+		}
 		return result, err
 	}
 	result.Phases["bootstrap"] = time.Since(phaseStart).Milliseconds()
 	result.TotalMs = time.Since(start).Milliseconds()
 
 	// Phase 4: Cleanup — destroy immediately, we only needed timing
-	vtr.cleanupClaw(clawID)
+	if err := vtr.cleanupClaw(clawID); err != nil {
+		result.Error = err.Error()
+		return result, err
+	}
 
 	return result, nil
 }
@@ -242,10 +252,13 @@ func (vtr *VMTestRunner) destroyClaw(ctx context.Context, clawID string) error {
 	return nil
 }
 
-func (vtr *VMTestRunner) cleanupClaw(clawID string) {
+func (vtr *VMTestRunner) cleanupClaw(clawID string) error {
 	cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	_ = vtr.destroyClaw(cleanupCtx, clawID)
+	if err := vtr.destroyClaw(cleanupCtx, clawID); err != nil {
+		return fmt.Errorf("cleanup claw %s: %w", clawID, err)
+	}
+	return nil
 }
 
 // parseClawStatus extracts a claw's status from JSON list output.


### PR DESCRIPTION
## Clawpatch finding

- Finding: `fnd_sig-feat-cli-command-dd3b636156-_9f762fa40b`
- Severity: `medium`
- Confidence: `high`
- Category: `data-loss`
- Title: VM cleanup failures are ignored, allowing leaked test VMs

## Validation

- `clawpatch revalidate --finding fnd_sig-feat-cli-command-dd3b636156-_9f762fa40b`
- `make test`

## Notes

This PR was created by `make clawpatch-pr` for one agreed open finding.
