### PR TITLE
fix(fireworks): remove stale Kimi K2.5 / kimi-k2p5-turbo router from …

### DIFF
--- a/pkg/hub/bootstrap.go
+++ b/pkg/hub/bootstrap.go
@@ -109,7 +109,6 @@ func buildOpenClawProviderConfig(keys []*types.LLMKeyConfig, selectedKeyName str
                 {'id': 'accounts/fireworks/models/minimax-m2p7',               'name': 'MiniMax M2.7'},
                 {'id': 'accounts/fireworks/models/glm-5p1',                    'name': 'GLM 5.1'},
                 {'id': 'accounts/fireworks/models/qwen3p6-plus',               'name': 'Qwen3.6 Plus'},
-                {'id': 'accounts/fireworks/models/kimi-k2p5',                  'name': 'Kimi K2.5'},
                 {'id': 'accounts/fireworks/models/gpt-oss-120b',               'name': 'OpenAI gpt-oss-120b'},
                 {'id': 'accounts/fireworks/models/gpt-oss-20b',                'name': 'OpenAI gpt-oss-20b'},
                 {'id': 'accounts/fireworks/models/minimax-m2p5',               'name': 'MiniMax M2.5'},

--- a/web/app/settings/[section]/settings-content.tsx
+++ b/web/app/settings/[section]/settings-content.tsx
@@ -755,7 +755,6 @@ const PROVIDER_MODELS: Record<string, { id: string; name: string }[]> = {
     { id: "fireworks/accounts/fireworks/models/minimax-m2p7",               name: "MiniMax M2.7" },
     { id: "fireworks/accounts/fireworks/models/glm-5p1",                    name: "GLM 5.1" },
     { id: "fireworks/accounts/fireworks/models/qwen3p6-plus",               name: "Qwen3.6 Plus" },
-    { id: "fireworks/accounts/fireworks/models/kimi-k2p5",                  name: "Kimi K2.5" },
     { id: "fireworks/accounts/fireworks/models/gpt-oss-120b",               name: "OpenAI gpt-oss-120b" },
     { id: "fireworks/accounts/fireworks/models/gpt-oss-20b",                name: "OpenAI gpt-oss-20b" },
     { id: "fireworks/accounts/fireworks/models/minimax-m2p5",               name: "MiniMax M2.5" },


### PR DESCRIPTION
…model catalogs

The agent was creating an auth profile (or candidate) using the dead "accounts/fireworks/routers/kimi-k2p5-turbo" (or models/kimi-k2p5) variant even when the user had explicitly set default_model to the current kimi-k2p6 on their fireworks LLM key.

This caused 404 "model not found", profile cooldown, and "no available auth profile for fireworks".

- Removed the kimi-k2p5 entry from the Fireworks models list in bootstrap.go (the config injected into every claw / openclaw environment).
- Removed it from the PROVIDER_MODELS in the settings UI so users can no longer select the dead model as default_model for a key.

New claws will no longer be told about the removed Kimi 2.5 turbo router. Existing claws may need restart or the agent's model-fallback cooldown to recover once the bad model is no longer advertised.