### PR TITLE
chore(poller): remove noisy '[poll] tick: N factories loaded...' log …

### DIFF
--- a/pkg/hub/integration_poller.go
+++ b/pkg/hub/integration_poller.go
@@ -44,8 +44,6 @@ func (s *Server) pollTick() {
 	integrations := s.hubCfg.Integrations
 	s.mu.RUnlock()
 
-	log.Printf("[poll] tick: %d factories loaded, evaluating integrations", len(factories))
-
 	// === LINEAR ===
 	if integrations != nil && len(integrations.Linear) > 0 {
 		s.pollLinear(factories, integrations.Linear, since)


### PR DESCRIPTION
…line

This log fired every 30s even when nothing was happening and was spamming the server logs. The 'no factories configured' case is left in place for diagnostics.