### PR TITLE
fix(bootstrap): also scrub stale 'routers' entries when injecting pro…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,11 +33,11 @@ build-release: build-web
 
 build-bridge:
 	mkdir -p bin
-	CGO_ENABLED=0 go build -o bin/claw-bridge ./cmd/claw-bridge/
+	CGO_ENABLED=0 go build -ldflags "-X main.Version=$(VERSION) -X main.Commit=$(COMMIT) -X main.BuildDate=$(BUILD_DATE)" -o bin/claw-bridge ./cmd/claw-bridge/
 
 build-bridge-linux:
 	mkdir -p bin
-	GONOSUMDB=* CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/claw-bridge-linux-amd64 ./cmd/claw-bridge/
+	GONOSUMDB=* CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-X main.Version=$(VERSION) -X main.Commit=$(COMMIT) -X main.BuildDate=$(BUILD_DATE)" -o bin/claw-bridge-linux-amd64 ./cmd/claw-bridge/
 
 
 install:

--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -43,6 +43,12 @@ import (
 	"nhooyr.io/websocket/wsjson"
 )
 
+var (
+	Version   = "dev"
+	Commit    = "none"
+	BuildDate = "unknown"
+)
+
 // ─── hub wire types ─────────────────────────────────────────────────────────
 
 type hubMsg struct {
@@ -420,7 +426,7 @@ func (gc *gatewayClient) connectToGateway(ctx context.Context) (*websocket.Conn,
 		"maxProtocol": 4,
 		"client": map[string]interface{}{
 			"id":         clientID,
-			"version":    "1.0.0",
+			"version":    Version,
 			"platform":   "linux",
 			"mode":       clientMode,
 			"instanceId": instanceID,
@@ -1565,7 +1571,21 @@ func (p *httpProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func printVersion() {
+	fmt.Printf("claw-bridge %s (commit: %s, built: %s)\n", Version, Commit, BuildDate)
+}
+
 func main() {
+	// Handle version requests very early, before any env var requirements.
+	// Supports: claw-bridge version, claw-bridge --version, claw-bridge -v
+	if len(os.Args) > 1 {
+		arg := os.Args[1]
+		if arg == "version" || arg == "--version" || arg == "-v" {
+			printVersion()
+			os.Exit(0)
+		}
+	}
+
 	// Subcommand dispatch: linear CLI embedded in the bridge binary.
 	if len(os.Args) > 1 && os.Args[1] == "linear" {
 		os.Exit(runLinearCLI(os.Args[2:]))

--- a/pkg/hub/bootstrap.go
+++ b/pkg/hub/bootstrap.go
@@ -194,15 +194,36 @@ func buildOpenClawProviderConfig(keys []*types.LLMKeyConfig, selectedKeyName str
 	}
 
 	providersDict := strings.Join(providerLines, ",\n        ")
+
+	// Collect just the provider names so we can also clean up any stale
+	// router/recommendation entries that openclaw onboard may have seeded.
+	providerNames := []string{}
+	for _, line := range providerLines {
+		// lines look like: 'fireworks': { ... }
+		if idx := strings.Index(line, "':"); idx > 1 {
+			name := strings.Trim(line[:idx], " \t'\"")
+			if name != "" {
+				providerNames = append(providerNames, name)
+			}
+		}
+	}
+
 	modelsPatch := ""
 	anthropicPatch := ""
 	if providersDict != "" {
+		providerNamesPy := `["` + strings.Join(providerNames, `", "`) + `"]`
 		modelsPatch = fmt.Sprintf(`models = config.setdefault('models', {})
 providers = models.setdefault('providers', {})
 providers.update({
         %s
 })
-`, providersDict)
+# Also remove any pre-seeded routers/recommendations for providers we control.
+# openclaw onboard can inject things like "routers/kimi-k2p5-turbo" for fireworks
+# based on its own built-in knowledge.
+routers = models.setdefault('routers', {})
+for p in %s:
+    routers.pop(p, None)
+`, providersDict, providerNamesPy)
 	}
 	if anthropicEnvVar != "" {
 		anthropicPatch = fmt.Sprintf(`anthropic_key = os.environ.get('%s', '')

--- a/pkg/hub/bootstrap.go
+++ b/pkg/hub/bootstrap.go
@@ -1,6 +1,7 @@
 package hub
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -79,6 +80,7 @@ func buildOpenClawProviderConfig(keys []*types.LLMKeyConfig, selectedKeyName str
 	// otherwise the first occurrence.
 	seen := map[string]bool{}
 	var providerLines []string
+	var providerNames []string
 	anthropicEnvVar := ""
 	if activeKey.Provider == "anthropic" {
 		anthropicEnvVar = activeKey.EnvVarName()
@@ -92,6 +94,11 @@ func buildOpenClawProviderConfig(keys []*types.LLMKeyConfig, selectedKeyName str
 	}
 
 	// Helper: build a single provider dict as a python literal.
+	pythonStringLiteral := func(value string) string {
+		encoded, _ := json.Marshal(value)
+		return string(encoded)
+	}
+
 	buildEntry := func(k *types.LLMKeyConfig) string {
 		envVar := k.EnvVarName()
 		switch k.Provider {
@@ -163,21 +170,27 @@ func buildOpenClawProviderConfig(keys []*types.LLMKeyConfig, selectedKeyName str
             ]
         }`, envVar)
 		default:
-			return fmt.Sprintf(`'%s': {
-            'apiKey': os.environ.get('%s', ''),
+			return fmt.Sprintf(`%s: {
+            'apiKey': os.environ.get(%s, ''),
             'api': 'openai-completions'
-        }`, k.Provider, envVar)
+        }`, pythonStringLiteral(k.Provider), pythonStringLiteral(envVar))
 		}
+	}
+
+	appendProvider := func(k *types.LLMKeyConfig) {
+		entry := buildEntry(k)
+		if entry == "" {
+			return
+		}
+		seen[k.Provider] = true
+		providerLines = append(providerLines, entry)
+		providerNames = append(providerNames, k.Provider)
 	}
 
 	// Prioritize the active key's provider first. Anthropic is intentionally
 	// omitted so OpenClaw's bundled Anthropic provider owns model metadata.
 	if activeKey.Provider != "anthropic" {
-		entry := buildEntry(activeKey)
-		if entry != "" {
-			seen[activeKey.Provider] = true
-			providerLines = append(providerLines, entry)
-		}
+		appendProvider(activeKey)
 	}
 
 	// Then remaining keys
@@ -185,33 +198,16 @@ func buildOpenClawProviderConfig(keys []*types.LLMKeyConfig, selectedKeyName str
 		if k.Provider == "anthropic" || seen[k.Provider] {
 			continue
 		}
-		entry := buildEntry(k)
-		if entry == "" {
-			continue
-		}
-		seen[k.Provider] = true
-		providerLines = append(providerLines, entry)
+		appendProvider(k)
 	}
 
 	providersDict := strings.Join(providerLines, ",\n        ")
 
-	// Collect just the provider names so we can also clean up any stale
-	// router/recommendation entries that openclaw onboard may have seeded.
-	providerNames := []string{}
-	for _, line := range providerLines {
-		// lines look like: 'fireworks': { ... }
-		if idx := strings.Index(line, "':"); idx > 1 {
-			name := strings.Trim(line[:idx], " \t'\"")
-			if name != "" {
-				providerNames = append(providerNames, name)
-			}
-		}
-	}
-
 	modelsPatch := ""
 	anthropicPatch := ""
 	if providersDict != "" {
-		providerNamesPy := `["` + strings.Join(providerNames, `", "`) + `"]`
+		providerNamesJSON, _ := json.Marshal(providerNames)
+		providerNamesPy := string(providerNamesJSON)
 		modelsPatch = fmt.Sprintf(`models = config.setdefault('models', {})
 providers = models.setdefault('providers', {})
 providers.update({

--- a/pkg/hub/bootstrap_test.go
+++ b/pkg/hub/bootstrap_test.go
@@ -356,6 +356,79 @@ func TestBuildOpenClawProviderConfig_MergesCustomProviders(t *testing.T) {
 	assertContains(t, snippet, "profiles['anthropic:default']", "still configures Anthropic auth")
 }
 
+func TestBuildOpenClawProviderConfig_EscapesUnknownProviderNames(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not in PATH")
+	}
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not in PATH")
+	}
+
+	providerName := `custom"\provider`
+	keys := []*types.LLMKeyConfig{
+		{Name: "custom-main", Provider: providerName, Default: true},
+	}
+
+	snippet := buildOpenClawProviderConfig(keys, "custom-main")
+
+	assertContains(t, snippet, `"custom\"\\provider": {`, "escaped provider dict key")
+	assertContains(t, snippet, `for p in ["custom\"\\provider"]:`, "escaped router cleanup list")
+
+	home := t.TempDir()
+	configDir := filepath.Join(home, ".openclaw")
+	if err := os.MkdirAll(configDir, 0700); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	configPath := filepath.Join(configDir, "openclaw.json")
+	initialConfig := map[string]interface{}{
+		"models": map[string]interface{}{
+			"routers": map[string]interface{}{
+				providerName: map[string]interface{}{"stale": true},
+			},
+		},
+	}
+	data, _ := json.Marshal(initialConfig)
+	if err := os.WriteFile(configPath, data, 0600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cmd := exec.Command("bash", "-c", snippet)
+	cmd.Env = append(os.Environ(),
+		"HOME="+home,
+		keys[0].EnvVarName()+"=sk-custom-test",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("run config snippet: %v\n%s", err, string(out))
+	}
+
+	var patched map[string]interface{}
+	configData, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read patched config: %v", err)
+	}
+	if err := json.Unmarshal(configData, &patched); err != nil {
+		t.Fatalf("parse patched config: %v", err)
+	}
+	models, ok := patched["models"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("models missing or wrong type: %#v", patched["models"])
+	}
+	providers, ok := models["providers"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("models.providers missing or wrong type: %#v", models["providers"])
+	}
+	if _, ok := providers[providerName]; !ok {
+		t.Fatalf("escaped provider missing from config: %#v", providers)
+	}
+	routers, ok := models["routers"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("models.routers missing or wrong type: %#v", models["routers"])
+	}
+	if _, ok := routers[providerName]; ok {
+		t.Fatalf("stale router entry was not removed: %#v", routers)
+	}
+}
+
 func TestBuildOpenClawProviderConfig_WritesAnthropicAuthProfileWithoutBreakingProviderCatalog(t *testing.T) {
 	if _, err := exec.LookPath("bash"); err != nil {
 		t.Skip("bash not in PATH")


### PR DESCRIPTION
…vider config

openclaw onboard can auto-register things like
'routers/kimi-k2p5-turbo' for the fireworks provider based on its built-in recommendations.

Our previous patch only did providers.update({...}), which replaced the models list but left any pre-seeded routers dict in place.

We now also do routers.pop(p, None) for every provider we configure. This ensures that once we ship a cleaned model list, newly created claws (and re-configured ones) no longer see the old k2p5-turbo router even if the openclaw version inside the image still knows about it.