### PR TITLE
chore: bump openclaw to 2026.5.20

### DIFF
--- a/cmd/bootopt/main.go
+++ b/cmd/bootopt/main.go
@@ -362,7 +362,7 @@ func getKnownBottlenecks() []string {
 	return []string{
 		"apt-get update takes 5-10s",
 		"Node.js install via apt requires GPG key + source list setup",
-		"npm install -g openclaw@2026.5.12 downloads ~50MB",
+		"npm install -g openclaw@2026.5.20 downloads ~50MB",
 		"openclaw onboard runs interactive setup even with --non-interactive",
 		"gateway started twice (first for device.json, then restarted with config)",
 		"device.json wait polls every 1s for up to 120s",

--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -1130,10 +1130,10 @@ echo "Node: $(node --version)"
 	return runShell(script)
 }
 
-// installOpenClaw installs openclaw@2026.5.12 via npm.
+// installOpenClaw installs openclaw@2026.5.20 via npm.
 func installOpenClaw() error {
-	log.Printf("[bootstrap] installing openclaw@2026.5.12...")
-	if err := runShell("sudo npm install -g openclaw@2026.5.12 --ignore-scripts"); err != nil {
+	log.Printf("[bootstrap] installing openclaw@2026.5.20...")
+	if err := runShell("sudo npm install -g openclaw@2026.5.20 --ignore-scripts"); err != nil {
 		return fmt.Errorf("npm install openclaw: %w", err)
 	}
 	out, _ := exec.Command("openclaw", "--version").Output()

--- a/pkg/bootopt/hypothesis.go
+++ b/pkg/bootopt/hypothesis.go
@@ -63,7 +63,7 @@ ElasticClaw provisions ephemeral VMs that run AI agents. The bootstrap sequence 
 4. claw-bridge --bootstrap runs:
    a. Install Node.js 24 + git via apt
    b. Install Nix in background (if enabled)
-   c. npm install -g openclaw@2026.5.12
+   c. npm install -g openclaw@2026.5.20
    d. openclaw onboard (first-run config)
    e. Start gateway, stop it (first-run writes device.json)
    f. Patch openclaw.json with model config, auth, disable bonjour

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2262,7 +2262,7 @@ echo uninstalled`); err != nil {
 		log.Printf("[daytona] warning: uninstall failed (ok if not installed): %v", err)
 	}
 
-	const daytonaOpenClawVersion = "2026.5.12"
+	const daytonaOpenClawVersion = "2026.5.20"
 	if err := exec("install openclaw", 3*time.Minute,
 		fmt.Sprintf(`export NVM_DIR=/usr/local/share/nvm; export PATH=$NVM_DIR/current/bin:$PATH; \
 PREFIX="$(/usr/local/share/nvm/current/bin/npm config get prefix)"; \


### PR DESCRIPTION
Bump the pinned openclaw npm package version from 2026.5.12 to 2026.5.20 in all installation sites:

- `cmd/claw-bridge/main.go` (claw-bridge bootstrap)
- `pkg/hub/server.go` (Daytona onboarding path)
- Comments in bootopt paths (for documentation/consistency)

This ensures newly created claws get the updated openclaw with the latest fixes (including better gateway handling and model list improvements).