### PR TITLE
Fix workspace settings static routing

### DIFF
--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -647,6 +647,13 @@ func (s *Server) serveWebUI(mux *http.ServeMux, staticFS fs.FS) {
 				return
 			}
 		}
+		if workspacePath, ok := settingsWorkspaceStaticPath(p); ok {
+			if f, err := staticFS.Open(workspacePath); err == nil {
+				f.Close()
+				serveFile(w, r, workspacePath)
+				return
+			}
+		}
 		// Unknown path — serve root index.html (SPA fallback)
 		serveFile(w, r, "index.html")
 	})
@@ -655,6 +662,49 @@ func (s *Server) serveWebUI(mux *http.ServeMux, staticFS fs.FS) {
 	// and on the API endpoints (withAuth middleware).
 	// Static HTML/JS/CSS files don't contain secrets so no server-side gate needed.
 	mux.Handle("/", fileServer)
+}
+
+func settingsWorkspaceStaticPath(requestPath string) (string, bool) {
+	p := strings.Trim(strings.TrimPrefix(requestPath, "/"), "/")
+	if p == "" {
+		return "", false
+	}
+	parts := strings.Split(p, "/")
+	if len(parts) < 2 || len(parts) > 3 || parts[0] != "settings" {
+		return "", false
+	}
+	if parts[1] == "" || settingsStaticSection(parts[1]) || strings.HasPrefix(parts[1], "_") {
+		return "", false
+	}
+	if len(parts) == 2 {
+		return "settings/_workspace/index.html", true
+	}
+	if !settingsStaticSection(parts[2]) {
+		return "", false
+	}
+	return "settings/_workspace/" + parts[2] + "/index.html", true
+}
+
+func settingsStaticSection(section string) bool {
+	switch section {
+	case "runtimes",
+		"models",
+		"github",
+		"authentication",
+		"issue-trackers",
+		"workspaces",
+		"workflows",
+		"workspace-analytics",
+		"secrets",
+		"ai-config",
+		"mcp-servers",
+		"analytics",
+		"doctor",
+		"troubleshoot":
+		return true
+	default:
+		return false
+	}
 }
 
 func (s *Server) handleHubConfig(w http.ResponseWriter, r *http.Request) {

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -53,6 +53,9 @@ func TestServeWebUIMapsWorkspaceSettingsRoutesToStaticPlaceholder(t *testing.T) 
 		{path: "/settings/elasticclaw/issue-trackers", want: "workspace-issue-trackers"},
 		{path: "/settings/elasticclaw/workspace-analytics", want: "workspace-analytics"},
 		{path: "/settings/workflows", want: "legacy-workflows"},
+		{path: "/settings/elasticclaw/nonexistent", want: "root"},
+		{path: "/settings/elasticclaw/runtimes", want: "root"},
+		{path: "/settings/elasticclaw/issue-trackers/extra", want: "root"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"testing/fstest"
 
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
@@ -29,6 +30,43 @@ func TestSanitizeBootstrapOutputTruncatesLongOutput(t *testing.T) {
 	got := sanitizeBootstrapOutput(strings.Repeat("x", 1400))
 	if len(got) != 1200 {
 		t.Fatalf("expected output to be truncated to 1200 bytes, got %d", len(got))
+	}
+}
+
+func TestServeWebUIMapsWorkspaceSettingsRoutesToStaticPlaceholder(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{}, "", "", "")
+	mux := http.NewServeMux()
+	s.serveWebUI(mux, fstest.MapFS{
+		"index.html":                                         &fstest.MapFile{Data: []byte("root")},
+		"settings/index.html":                                &fstest.MapFile{Data: []byte("settings-root")},
+		"settings/workflows/index.html":                      &fstest.MapFile{Data: []byte("legacy-workflows")},
+		"settings/_workspace/index.html":                     &fstest.MapFile{Data: []byte("workspace-overview")},
+		"settings/_workspace/issue-trackers/index.html":      &fstest.MapFile{Data: []byte("workspace-issue-trackers")},
+		"settings/_workspace/workspace-analytics/index.html": &fstest.MapFile{Data: []byte("workspace-analytics")},
+	})
+
+	tests := []struct {
+		path string
+		want string
+	}{
+		{path: "/settings/elasticclaw", want: "workspace-overview"},
+		{path: "/settings/elasticclaw/issue-trackers", want: "workspace-issue-trackers"},
+		{path: "/settings/elasticclaw/workspace-analytics", want: "workspace-analytics"},
+		{path: "/settings/workflows", want: "legacy-workflows"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			mux.ServeHTTP(rr, req)
+			if rr.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200", rr.Code)
+			}
+			if got := rr.Body.String(); got != tt.want {
+				t.Fatalf("body = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -8,8 +8,19 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
-  // No rewrites needed — in dev, the browser calls the hub directly via NEXT_PUBLIC_HUB_URL
-  // In production, the hub serves the static files so everything is same-origin
+  ...(isDev
+    ? {
+        async rewrites() {
+          const hubUrl = process.env.NEXT_PUBLIC_HUB_URL || process.env.HUB_URL || "http://localhost:8080"
+          return [
+            {
+              source: "/api/:path*",
+              destination: `${hubUrl}/api/:path*`,
+            },
+          ]
+        },
+      }
+    : {}),
 }
 
 export default nextConfig


### PR DESCRIPTION
## Summary
- proxy /api requests to the hub during Next dev when no explicit hub URL is set
- map release/static workspace settings URLs to the exported _workspace placeholder pages
- add coverage for workspace settings static route fallback

## Tests
- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./pkg/hub -run 'TestServeWebUIMapsWorkspaceSettingsRoutesToStaticPlaceholder|TestSanitizeBootstrapOutput'
- npm run build