### PR TITLE
Prevent duplicate workflow issue claws

### DIFF
--- a/pkg/hub/github_issues.go
+++ b/pkg/hub/github_issues.go
@@ -437,6 +437,7 @@ func (s *Server) createClawForGitHubIssueWorkflow(workspace *types.WorkspaceConf
 		return err
 	}
 	if err := s.completeFactoryTrigger(triggerOwner, "github-issues", triggerKey, clawID); err != nil {
+		_, _ = s.db.Exec(`UPDATE claws SET status='deleted' WHERE id=?`, clawID)
 		return fmt.Errorf("complete workflow trigger: %w", err)
 	}
 	claimOpen = false

--- a/pkg/hub/github_issues.go
+++ b/pkg/hub/github_issues.go
@@ -395,6 +395,28 @@ func (s *Server) createClawForGitHubIssueWorkflow(workspace *types.WorkspaceConf
 		return nil
 	}
 
+	triggerKey := factoryTriggerKey("github-issues", issueID)
+	triggerOwner := fmt.Sprintf("workflow:%s/%s", workspace.Name, workflow.Name)
+	claimed, err := s.claimFactoryTrigger(triggerOwner, "github-issues", triggerKey, reason, map[string]string{
+		"issue_id":  issueID,
+		"source":    reason,
+		"workspace": workspace.Name,
+		"workflow":  workflow.Name,
+	})
+	if err != nil {
+		return fmt.Errorf("claim workflow trigger: %w", err)
+	}
+	if !claimed {
+		log.Printf("[workflow:%s/%s] GitHub issue %s already has an active trigger claim", workspace.Name, workflow.Name, issueID)
+		return nil
+	}
+	claimOpen := true
+	defer func() {
+		if claimOpen {
+			s.failFactoryTrigger(triggerOwner, "github-issues", triggerKey)
+		}
+	}()
+
 	templateFiles := cloneStringMap(workspace.Files)
 	templateFiles["CONTEXT.md"] = buildGitHubIssuesContext(payload)
 
@@ -405,13 +427,20 @@ func (s *Server) createClawForGitHubIssueWorkflow(workspace *types.WorkspaceConf
 		clawName = strings.ReplaceAll(clawName, "{repo}", payload.Repository.FullName)
 	}
 
-	_, _, err := s.createClawFromWorkflowWithOptions(workspace, workflow, workflowCreateOptions{
+	clawID, _, err := s.createClawFromWorkflowWithOptions(workspace, workflow, workflowCreateOptions{
 		workspaceFiles: templateFiles,
 		clawName:       clawName,
 		githubIssueID:  issueID,
 		reason:         reason,
 	})
-	return err
+	if err != nil {
+		return err
+	}
+	if err := s.completeFactoryTrigger(triggerOwner, "github-issues", triggerKey, clawID); err != nil {
+		return fmt.Errorf("complete workflow trigger: %w", err)
+	}
+	claimOpen = false
+	return nil
 }
 
 func (s *Server) createClawForGitHubIssue(factory *types.FactoryConfig, payload githubIssuesWebhookPayload, reason string) error {

--- a/pkg/hub/github_issues_webhook_test.go
+++ b/pkg/hub/github_issues_webhook_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -127,6 +128,65 @@ func TestGitHubIssuesWorkspaceWebhookOnlyDispatchesThatWorkspace(t *testing.T) {
 	}
 	if total != 1 || workspaceA != 1 || workspaceB != 0 {
 		t.Fatalf("counts total=%d workspace-a=%d workspace-b=%d, want 1/1/0", total, workspaceA, workspaceB)
+	}
+}
+
+func TestGitHubIssuesWorkspaceWebhookIsIdempotentForSameIssue(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
+	ghi := factorytest.NewMockGitHubIssues(t)
+	ghi.WebhookSecret = "secret"
+	li := factorytest.NewMockLinear(t)
+
+	cfg := &types.HubConfig{
+		ClawToken: "test-claw-token",
+		Providers: map[string]types.ProviderConfig{
+			"noop": {Type: "noop"},
+		},
+	}
+	s, db := hub.NewTestServerWithConfig(t, cfg, ghi.URL, li.URL, "")
+	saveGitHubIssueWorkflowFixture(t, "workspace-a", "secret")
+
+	httpSrv := httptest.NewServer(s.Handler())
+	t.Cleanup(httpSrv.Close)
+
+	ghi.SetIssue("testorg/testrepo", 42, factorytest.IssueState{Title: "Test Issue", Body: "Test body", State: "open"})
+	payload, _ := ghi.BuildWebhookPayload("testorg/testrepo", 42, "closed", "open")
+
+	var wg sync.WaitGroup
+	for _, deliveryID := range []string{"delivery-a", "delivery-b"} {
+		wg.Add(1)
+		go func(deliveryID string) {
+			defer wg.Done()
+			req, err := http.NewRequest(http.MethodPost, httpSrv.URL+"/api/workspaces/workspace-a/webhooks/github-issues", strings.NewReader(string(payload)))
+			if err != nil {
+				t.Errorf("request: %v", err)
+				return
+			}
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("X-Hub-Signature-256", hmacSHA256(payload, "secret"))
+			req.Header.Set("X-GitHub-Delivery", deliveryID)
+
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Errorf("post: %v", err)
+				return
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("status = %d, want 200", resp.StatusCode)
+			}
+		}(deliveryID)
+	}
+	wg.Wait()
+
+	time.Sleep(100 * time.Millisecond)
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM claws WHERE github_issue_id='testorg/testrepo/42'`).Scan(&count); err != nil {
+		t.Fatalf("count claws: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("created %d claws for the same GitHub issue, want 1", count)
 	}
 }
 

--- a/pkg/hub/github_issues_webhook_test.go
+++ b/pkg/hub/github_issues_webhook_test.go
@@ -180,10 +180,16 @@ func TestGitHubIssuesWorkspaceWebhookIsIdempotentForSameIssue(t *testing.T) {
 	}
 	wg.Wait()
 
-	time.Sleep(100 * time.Millisecond)
 	var count int
-	if err := db.QueryRow(`SELECT COUNT(*) FROM claws WHERE github_issue_id='testorg/testrepo/42'`).Scan(&count); err != nil {
-		t.Fatalf("count claws: %v", err)
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if err := db.QueryRow(`SELECT COUNT(*) FROM claws WHERE github_issue_id='testorg/testrepo/42'`).Scan(&count); err != nil {
+			t.Fatalf("count claws: %v", err)
+		}
+		if count > 0 || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 	if count != 1 {
 		t.Fatalf("created %d claws for the same GitHub issue, want 1", count)


### PR DESCRIPTION
## Summary
- claim GitHub Issues workflow triggers before creating a claw
- make repeated webhook deliveries for the same workspace/workflow/issue idempotent before provisioning starts
- add regression coverage for concurrent GitHub Issues webhook deliveries creating only one claw

## Why
A duplicate webhook could pass the existing active-claw SELECT before the first claw row had its github_issue_id set, allowing multiple Daytona sandboxes for the same issue.

## Tests
- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./pkg/hub -run 'TestGitHubIssuesWorkspaceWebhook'
- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./pkg/hub