### PR TITLE
Upsert pushed workflows

### DIFF
--- a/pkg/hub/external_storage.go
+++ b/pkg/hub/external_storage.go
@@ -480,9 +480,6 @@ func saveExternalWorkflows(workspaceName string, workflows []*types.WorkflowConf
 	if err := os.MkdirAll(workflowDir, 0750); err != nil {
 		return fmt.Errorf("mkdir %s: %w", workflowDir, err)
 	}
-	if err := removeExternalWorkflowFiles(workflowDir); err != nil {
-		return err
-	}
 	for _, workflow := range workflows {
 		if workflow == nil {
 			continue
@@ -500,22 +497,6 @@ func saveExternalWorkflows(workspaceName string, workflows []*types.WorkflowConf
 		}
 		if err := os.WriteFile(filepath.Join(workflowDir, workflow.Name+".yaml"), data, 0640); err != nil {
 			return fmt.Errorf("write workflow %q: %w", workflow.Name, err)
-		}
-	}
-	return nil
-}
-
-func removeExternalWorkflowFiles(workflowDir string) error {
-	entries, err := os.ReadDir(workflowDir)
-	if err != nil {
-		return fmt.Errorf("read workflows dir: %w", err)
-	}
-	for _, entry := range entries {
-		if entry.IsDir() || strings.HasPrefix(entry.Name(), ".") || !strings.HasSuffix(entry.Name(), ".yaml") {
-			continue
-		}
-		if err := os.Remove(filepath.Join(workflowDir, entry.Name())); err != nil {
-			return fmt.Errorf("remove stale workflow %s: %w", entry.Name(), err)
 		}
 	}
 	return nil

--- a/pkg/hub/external_storage.go
+++ b/pkg/hub/external_storage.go
@@ -487,6 +487,10 @@ func saveExternalWorkflows(workspaceName string, workflows []*types.WorkflowConf
 		if err := validateName(workflow.Name); err != nil {
 			return fmt.Errorf("workflow %q: %w", workflow.Name, err)
 		}
+		targetPath := filepath.Join(workflowDir, strings.ToLower(workflow.Name)+".yaml")
+		if err := removeCaseVariantWorkflowFiles(workflowDir, workflow.Name, targetPath); err != nil {
+			return err
+		}
 		data := []byte(workflow.RawConfig)
 		if len(strings.TrimSpace(string(data))) == 0 {
 			var err error
@@ -495,8 +499,28 @@ func saveExternalWorkflows(workspaceName string, workflows []*types.WorkflowConf
 				return fmt.Errorf("marshal workflow %q: %w", workflow.Name, err)
 			}
 		}
-		if err := os.WriteFile(filepath.Join(workflowDir, workflow.Name+".yaml"), data, 0640); err != nil {
+		if err := os.WriteFile(targetPath, data, 0640); err != nil {
 			return fmt.Errorf("write workflow %q: %w", workflow.Name, err)
+		}
+	}
+	return nil
+}
+
+func removeCaseVariantWorkflowFiles(workflowDir, workflowName, targetPath string) error {
+	entries, err := os.ReadDir(workflowDir)
+	if err != nil {
+		return fmt.Errorf("read workflows dir: %w", err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || strings.HasPrefix(entry.Name(), ".") || !strings.HasSuffix(entry.Name(), ".yaml") {
+			continue
+		}
+		path := filepath.Join(workflowDir, entry.Name())
+		name := strings.TrimSuffix(entry.Name(), ".yaml")
+		if strings.EqualFold(name, workflowName) && path != targetPath {
+			if err := os.Remove(path); err != nil {
+				return fmt.Errorf("remove stale workflow %s: %w", entry.Name(), err)
+			}
 		}
 	}
 	return nil

--- a/pkg/hub/workspace_api_test.go
+++ b/pkg/hub/workspace_api_test.go
@@ -91,8 +91,16 @@ func TestWorkflowPushPersistsWorkspaceWorkflows(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer test-token")
 	rr = httptest.NewRecorder()
 	s.Handler().ServeHTTP(rr, req)
-	if rr.Code != http.StatusNotFound {
-		t.Fatalf("stale workflow status = %d, want 404, body = %s", rr.Code, rr.Body.String())
+	if rr.Code != http.StatusOK {
+		t.Fatalf("existing workflow status = %d, want 200, body = %s", rr.Code, rr.Body.String())
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/workspaces/engineering/workflows/second", nil)
+	req.Header.Set("Authorization", "Bearer test-token")
+	rr = httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("second workflow detail status = %d, body = %s", rr.Code, rr.Body.String())
 	}
 }
 

--- a/pkg/hub/workspace_api_test.go
+++ b/pkg/hub/workspace_api_test.go
@@ -102,6 +102,31 @@ func TestWorkflowPushPersistsWorkspaceWorkflows(t *testing.T) {
 	if rr.Code != http.StatusOK {
 		t.Fatalf("second workflow detail status = %d, body = %s", rr.Code, rr.Body.String())
 	}
+
+	body = `{"workflows":[{"name":"Bugfix","integration":"github","enable_manual_trigger":true}]}`
+	req = httptest.NewRequest(http.MethodPost, "/api/workspaces/engineering/workflows", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	rr = httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("case-variant workflow push status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/workspaces/engineering/workflows", nil)
+	req.Header.Set("Authorization", "Bearer test-token")
+	rr = httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("workflow list status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	var workflows []WorkflowView
+	if err := json.Unmarshal(rr.Body.Bytes(), &workflows); err != nil {
+		t.Fatalf("decode workflows: %v", err)
+	}
+	if len(workflows) != 2 {
+		t.Fatalf("workflow count = %d, want 2: %#v", len(workflows), workflows)
+	}
 }
 
 func TestWorkspaceWorkflowTriggerUsesWorkflowRules(t *testing.T) {


### PR DESCRIPTION
## Summary
- change workflow push persistence to upsert submitted workflows by name instead of deleting existing workflow files
- update workspace workflow push coverage so a second push preserves the first workflow

## Tests
- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./pkg/hub