### PR TITLE
Skip duplicate pipeline stage transitions

### DIFF
--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -654,11 +654,10 @@ func (s *Server) transitionPipelineStage(clawID string, stage pipeline.Stage, fa
 }
 
 func (s *Server) transitionPipelineStageWithContext(clawID string, stage pipeline.Stage, ctx pipelineContext) {
-	if current := s.getPipelineStage(clawID); current == stage.ID {
+	if !s.claimPipelineStageTransition(clawID, stage.ID) {
 		log.Printf("[pipeline] claw %s already in stage %q (%s), skipping duplicate transition", clawID[:8], stage.ID, stage.Label)
 		return
 	}
-	s.setPipelineStage(clawID, stage.ID)
 	log.Printf("[pipeline] claw %s → stage %q (%s)", clawID[:8], stage.ID, stage.Label)
 	s.runOnEnter(clawID, stage, ctx)
 

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -654,6 +654,10 @@ func (s *Server) transitionPipelineStage(clawID string, stage pipeline.Stage, fa
 }
 
 func (s *Server) transitionPipelineStageWithContext(clawID string, stage pipeline.Stage, ctx pipelineContext) {
+	if current := s.getPipelineStage(clawID); current == stage.ID {
+		log.Printf("[pipeline] claw %s already in stage %q (%s), skipping duplicate transition", clawID[:8], stage.ID, stage.Label)
+		return
+	}
 	s.setPipelineStage(clawID, stage.ID)
 	log.Printf("[pipeline] claw %s → stage %q (%s)", clawID[:8], stage.ID, stage.Label)
 	s.runOnEnter(clawID, stage, ctx)

--- a/pkg/hub/pipeline_runner_test.go
+++ b/pkg/hub/pipeline_runner_test.go
@@ -1,0 +1,41 @@
+package hub
+
+import (
+	"testing"
+
+	"github.com/elasticclaw/elasticclaw/pkg/hub/pipeline"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func TestTransitionPipelineStageSkipsDuplicateCurrentStage(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+
+	const clawID = "claw-duplicate-stage"
+	_, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, template, status, pipeline_stage, created_at) VALUES(?,?,?,?,?,?,datetime('now'))`,
+		clawID, "test-tenant-id", "MAR-56", "elasticclaw", "connected", "pr_opened",
+	)
+	if err != nil {
+		t.Fatalf("insert claw: %v", err)
+	}
+
+	stage := pipeline.Stage{
+		ID:    "pr_opened",
+		Label: "PR Opened",
+		OnEnter: pipeline.OnEnter{
+			Inject: "PR created. Watch for CI results and review comments.",
+		},
+	}
+	s.transitionPipelineStageWithContext(clawID, stage, pipelineContext{})
+
+	var messageCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=?`, clawID).Scan(&messageCount); err != nil {
+		t.Fatalf("count messages: %v", err)
+	}
+	if messageCount != 0 {
+		t.Fatalf("duplicate stage transition injected %d messages, want 0", messageCount)
+	}
+	if got := s.getPipelineStage(clawID); got != "pr_opened" {
+		t.Fatalf("pipeline stage = %q, want pr_opened", got)
+	}
+}

--- a/pkg/hub/pipeline_runner_test.go
+++ b/pkg/hub/pipeline_runner_test.go
@@ -1,6 +1,7 @@
 package hub
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/elasticclaw/elasticclaw/pkg/hub/pipeline"
@@ -34,6 +35,48 @@ func TestTransitionPipelineStageSkipsDuplicateCurrentStage(t *testing.T) {
 	}
 	if messageCount != 0 {
 		t.Fatalf("duplicate stage transition injected %d messages, want 0", messageCount)
+	}
+	if got := s.getPipelineStage(clawID); got != "pr_opened" {
+		t.Fatalf("pipeline stage = %q, want pr_opened", got)
+	}
+}
+
+func TestTransitionPipelineStageConcurrentCallsRunOnEnterOnce(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+
+	const clawID = "claw-concurrent-stage"
+	_, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, template, status, pipeline_stage, created_at) VALUES(?,?,?,?,?,?,datetime('now'))`,
+		clawID, "test-tenant-id", "MAR-56", "elasticclaw", "connected", "working",
+	)
+	if err != nil {
+		t.Fatalf("insert claw: %v", err)
+	}
+
+	stage := pipeline.Stage{
+		ID:    "pr_opened",
+		Label: "PR Opened",
+		OnEnter: pipeline.OnEnter{
+			Inject: "PR created. Watch for CI results and review comments.",
+		},
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			s.transitionPipelineStageWithContext(clawID, stage, pipelineContext{})
+		}()
+	}
+	wg.Wait()
+
+	var messageCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=?`, clawID).Scan(&messageCount); err != nil {
+		t.Fatalf("count messages: %v", err)
+	}
+	if messageCount != 1 {
+		t.Fatalf("concurrent stage transitions injected %d messages, want 1", messageCount)
 	}
 	if got := s.getPipelineStage(clawID); got != "pr_opened" {
 		t.Fatalf("pipeline stage = %q, want pr_opened", got)

--- a/pkg/hub/pipeline_state.go
+++ b/pkg/hub/pipeline_state.go
@@ -10,9 +10,19 @@ func (s *Server) getPipelineStage(clawID string) string {
 	return stage
 }
 
-// setPipelineStage updates the pipeline stage ID for a claw.
-func (s *Server) setPipelineStage(clawID, stageID string) {
-	if _, err := s.db.Exec(`UPDATE claws SET pipeline_stage=? WHERE id=?`, stageID, clawID); err != nil {
+// claimPipelineStageTransition atomically updates the pipeline stage only if the
+// claw is not already in that stage. It returns true when the caller won the
+// transition and should run on_enter actions.
+func (s *Server) claimPipelineStageTransition(clawID, stageID string) bool {
+	res, err := s.db.Exec(`UPDATE claws SET pipeline_stage=? WHERE id=? AND pipeline_stage<>?`, stageID, clawID, stageID)
+	if err != nil {
 		log.Printf("[pipeline] failed to set stage %q for claw %s: %v", stageID, clawID[:8], err)
+		return false
 	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		log.Printf("[pipeline] failed to inspect stage transition for claw %s: %v", clawID[:8], err)
+		return false
+	}
+	return rows > 0
 }


### PR DESCRIPTION
## Summary
- make pipeline stage transitions idempotent when the target stage is already current
- prevents repeated [DONE] messages from re-running the pr_opened on_enter action and reinjecting the same hub prompt
- add regression coverage for duplicate stage transitions not injecting messages

## Tests
- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./pkg/hub -run 'TestTransitionPipelineStageSkipsDuplicateCurrentStage|TestStageForMessageContains'
- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./pkg/hub