### PR TITLE
Poll missed workflow triggers

### DIFF
--- a/pkg/hub/factorytest/mock_github_issues.go
+++ b/pkg/hub/factorytest/mock_github_issues.go
@@ -33,16 +33,19 @@ type IssueState struct {
 // move_issue parity tests in a future phase).
 type MockGitHubIssues struct {
 	*httptest.Server
-	mu      sync.Mutex
-	Issues  map[string]IssueState // key: "owner/repo#number"
-	Calls   []string
+	mu            sync.Mutex
+	Issues        map[string]IssueState // key: "owner/repo#number"
+	IssueEvents   map[string][]map[string]interface{}
+	Calls         []string
+	AuthHeaders   []string
 	WebhookSecret string
 }
 
 func NewMockGitHubIssues(t *testing.T) *MockGitHubIssues {
 	t.Helper()
 	m := &MockGitHubIssues{
-		Issues: make(map[string]IssueState),
+		Issues:      make(map[string]IssueState),
+		IssueEvents: make(map[string][]map[string]interface{}),
 	}
 	mux := http.NewServeMux()
 
@@ -63,12 +66,24 @@ func NewMockGitHubIssues(t *testing.T) *MockGitHubIssues {
 
 		m.mu.Lock()
 		m.Calls = append(m.Calls, r.Method+" "+r.URL.Path+"?"+r.URL.RawQuery)
+		m.AuthHeaders = append(m.AuthHeaders, r.Header.Get("Authorization"))
 		m.mu.Unlock()
 
 		// issues endpoint
 		if strings.HasPrefix(rest, "issues") {
-			// Single issue fetch: /repos/{owner}/{repo}/issues/{number}
 			parts2 := strings.Split(rest, "/")
+			if len(parts2) == 3 && parts2[0] == "issues" && parts2[2] == "events" {
+				var num int
+				fmt.Sscanf(parts2[1], "%d", &num)
+				key := fmt.Sprintf("%s/%s#%d", owner, repo, num)
+				m.mu.Lock()
+				events := append([]map[string]interface{}(nil), m.IssueEvents[key]...)
+				m.mu.Unlock()
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(events)
+				return
+			}
+			// Single issue fetch: /repos/{owner}/{repo}/issues/{number}
 			if len(parts2) == 2 && parts2[0] == "issues" {
 				var num int
 				fmt.Sscanf(parts2[1], "%d", &num)
@@ -123,6 +138,12 @@ func (m *MockGitHubIssues) SetIssue(repo string, number int, state IssueState) {
 	m.Issues[fmt.Sprintf("%s#%d", repo, number)] = state
 }
 
+func (m *MockGitHubIssues) SetIssueEvents(repo string, number int, events []map[string]interface{}) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.IssueEvents[fmt.Sprintf("%s#%d", repo, number)] = append([]map[string]interface{}(nil), events...)
+}
+
 func (m *MockGitHubIssues) SetIssueState(repo string, number int, state string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -168,6 +189,18 @@ func (m *MockGitHubIssues) SawAPICall() bool {
 	return len(m.Calls) > 0
 }
 
+func (m *MockGitHubIssues) AuthHeaderCount(header string) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	count := 0
+	for _, got := range m.AuthHeaders {
+		if got == header {
+			count++
+		}
+	}
+	return count
+}
+
 // BuildWebhookPayload returns a JSON webhook payload and the X-Hub-Signature-256
 // for the given issue state transition.
 //
@@ -196,16 +229,16 @@ func (m *MockGitHubIssues) BuildWebhookPayload(repo string, number int, prevStat
 	payload := map[string]interface{}{
 		"action": action,
 		"issue": map[string]interface{}{
-			"id":         number,
-			"number":     number,
-			"title":      issue.Title,
-			"body":       issue.Body,
-			"html_url":   fmt.Sprintf("https://github.com/%s/issues/%d", repo, number),
-			"state":      newState,
+			"id":           number,
+			"number":       number,
+			"title":        issue.Title,
+			"body":         issue.Body,
+			"html_url":     fmt.Sprintf("https://github.com/%s/issues/%d", repo, number),
+			"state":        newState,
 			"state_reason": "",
-			"labels":     labelsToNameMaps(issue.Labels),
-			"assignee":   nil,
-			"user":       map[string]interface{}{"login": "testuser", "type": "User"},
+			"labels":       labelsToNameMaps(issue.Labels),
+			"assignee":     nil,
+			"user":         map[string]interface{}{"login": "testuser", "type": "User"},
 		},
 		"repository": map[string]interface{}{
 			"full_name": repo,

--- a/pkg/hub/github_issues.go
+++ b/pkg/hub/github_issues.go
@@ -872,6 +872,13 @@ func (s *Server) resolveGitHubIssuesTokenForFactory(factory *types.FactoryConfig
 	return ""
 }
 
+func (s *Server) resolveGitHubIssuesTokenForWorkflow(workspaceName string, workflow *types.WorkflowConfig) string {
+	if tracker, ok := findWorkspaceIssueTracker(workspaceName, "github-issues", workflow.Workspace); ok {
+		return tracker.Token
+	}
+	return ""
+}
+
 func buildGitHubIssuesContext(payload githubIssuesWebhookPayload) string {
 	i := payload.Issue
 	var b strings.Builder

--- a/pkg/hub/github_issues_webhook_test.go
+++ b/pkg/hub/github_issues_webhook_test.go
@@ -230,6 +230,79 @@ func TestGitHubIssuesWorkflowPollCreatesOnceForMissedWebhook(t *testing.T) {
 	}
 }
 
+func TestGitHubIssuesWorkflowPollUsesActualLabeler(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
+	ghi := factorytest.NewMockGitHubIssues(t)
+	li := factorytest.NewMockLinear(t)
+
+	cfg := &types.HubConfig{
+		ClawToken: "test-claw-token",
+		Providers: map[string]types.ProviderConfig{
+			"noop": {Type: "noop"},
+		},
+	}
+	s, db := hub.NewTestServerWithConfig(t, cfg, ghi.URL, li.URL, "")
+	saveGitHubIssueLabeledWorkflowFixtureWithLabelers(t, "workspace-a", []string{"alice"})
+
+	ghi.SetIssue("testorg/testrepo", 42, factorytest.IssueState{
+		Title:  "Test Issue",
+		Body:   "Test body",
+		State:  "open",
+		Labels: []string{"agent-ready"},
+	})
+	ghi.SetIssueEvents("testorg/testrepo", 42, []map[string]interface{}{{
+		"id":         1,
+		"event":      "labeled",
+		"created_at": time.Now().UTC().Format(time.RFC3339),
+		"actor":      map[string]interface{}{"login": "alice"},
+		"label":      map[string]interface{}{"name": "agent-ready"},
+	}})
+
+	s.PollIntegrationsForTest()
+
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM claws WHERE github_issue_id='testorg/testrepo/42'`).Scan(&count); err != nil {
+		t.Fatalf("count claws: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("poll created %d claws for labeler-restricted GitHub issue, want 1", count)
+	}
+}
+
+func TestGitHubIssuesWorkflowPollQueriesEachWorkspaceToken(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
+	ghi := factorytest.NewMockGitHubIssues(t)
+	li := factorytest.NewMockLinear(t)
+
+	cfg := &types.HubConfig{
+		ClawToken: "test-claw-token",
+		Providers: map[string]types.ProviderConfig{
+			"noop": {Type: "noop"},
+		},
+	}
+	s, _ := hub.NewTestServerWithConfig(t, cfg, ghi.URL, li.URL, "")
+	saveGitHubIssueLabeledWorkflowFixtureWithLabelersAndToken(t, "workspace-a", []string{"*"}, "token-a")
+	saveGitHubIssueLabeledWorkflowFixtureWithLabelersAndToken(t, "workspace-b", []string{"*"}, "token-b")
+
+	ghi.SetIssue("testorg/testrepo", 42, factorytest.IssueState{
+		Title:  "Test Issue",
+		Body:   "Test body",
+		State:  "open",
+		Labels: []string{"agent-ready"},
+	})
+
+	s.PollIntegrationsForTest()
+
+	if got := ghi.AuthHeaderCount("Bearer token-a"); got != 1 {
+		t.Fatalf("poll used token-a %d times, want 1", got)
+	}
+	if got := ghi.AuthHeaderCount("Bearer token-b"); got != 1 {
+		t.Fatalf("poll used token-b %d times, want 1", got)
+	}
+}
+
 func saveGitHubIssueWorkflowFixture(t *testing.T, workspace, secret string) {
 	t.Helper()
 	hub.SaveWorkspaceForTest(t,
@@ -265,6 +338,16 @@ func saveGitHubIssueWorkflowFixture(t *testing.T, workspace, secret string) {
 
 func saveGitHubIssueLabeledWorkflowFixture(t *testing.T, workspace string) {
 	t.Helper()
+	saveGitHubIssueLabeledWorkflowFixtureWithLabelers(t, workspace, []string{"*"})
+}
+
+func saveGitHubIssueLabeledWorkflowFixtureWithLabelers(t *testing.T, workspace string, labelers []string) {
+	t.Helper()
+	saveGitHubIssueLabeledWorkflowFixtureWithLabelersAndToken(t, workspace, labelers, "test-github-issues-token")
+}
+
+func saveGitHubIssueLabeledWorkflowFixtureWithLabelersAndToken(t *testing.T, workspace string, labelers []string, token string) {
+	t.Helper()
 	hub.SaveWorkspaceForTest(t,
 		&types.WorkspaceConfig{
 			SchemaVersion: "v1",
@@ -283,7 +366,7 @@ func saveGitHubIssueLabeledWorkflowFixture(t *testing.T, workspace string) {
 					Repositories: []string{"testorg/testrepo"},
 					States:       []string{"open"},
 					Labels:       []string{"agent-ready"},
-					Labelers:     []string{"*"},
+					Labelers:     labelers,
 				},
 			},
 			Stages: []types.WorkflowStage{{
@@ -296,7 +379,7 @@ func saveGitHubIssueLabeledWorkflowFixture(t *testing.T, workspace string) {
 			}},
 		}},
 	)
-	hub.SaveWorkspaceIssueTrackerForTest(t, workspace, "github-issues", "default", "test-github-issues-token", "")
+	hub.SaveWorkspaceIssueTrackerForTest(t, workspace, "github-issues", "default", token, "")
 }
 
 func hmacSHA256(body []byte, secret string) string {

--- a/pkg/hub/github_issues_webhook_test.go
+++ b/pkg/hub/github_issues_webhook_test.go
@@ -196,6 +196,40 @@ func TestGitHubIssuesWorkspaceWebhookIsIdempotentForSameIssue(t *testing.T) {
 	}
 }
 
+func TestGitHubIssuesWorkflowPollCreatesOnceForMissedWebhook(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
+	ghi := factorytest.NewMockGitHubIssues(t)
+	li := factorytest.NewMockLinear(t)
+
+	cfg := &types.HubConfig{
+		ClawToken: "test-claw-token",
+		Providers: map[string]types.ProviderConfig{
+			"noop": {Type: "noop"},
+		},
+	}
+	s, db := hub.NewTestServerWithConfig(t, cfg, ghi.URL, li.URL, "")
+	saveGitHubIssueLabeledWorkflowFixture(t, "workspace-a")
+
+	ghi.SetIssue("testorg/testrepo", 42, factorytest.IssueState{
+		Title:  "Test Issue",
+		Body:   "Test body",
+		State:  "open",
+		Labels: []string{"agent-ready"},
+	})
+
+	s.PollIntegrationsForTest()
+	s.PollIntegrationsForTest()
+
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM claws WHERE github_issue_id='testorg/testrepo/42'`).Scan(&count); err != nil {
+		t.Fatalf("count claws: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("poll created %d claws for the same GitHub issue, want 1", count)
+	}
+}
+
 func saveGitHubIssueWorkflowFixture(t *testing.T, workspace, secret string) {
 	t.Helper()
 	hub.SaveWorkspaceForTest(t,
@@ -227,6 +261,42 @@ func saveGitHubIssueWorkflowFixture(t *testing.T, workspace, secret string) {
 		}},
 	)
 	hub.SaveWorkspaceIssueTrackerForTest(t, workspace, "github-issues", "default", "test-github-issues-token", secret)
+}
+
+func saveGitHubIssueLabeledWorkflowFixture(t *testing.T, workspace string) {
+	t.Helper()
+	hub.SaveWorkspaceForTest(t,
+		&types.WorkspaceConfig{
+			SchemaVersion: "v1",
+			Name:          workspace,
+			Files: map[string]string{
+				"elasticclaw-config.yaml": "schema_version: v1\nname: " + workspace + "\nprovider: noop\n",
+				"CONTEXT.md":              "Test context\n",
+			},
+		},
+		[]*types.WorkflowConfig{{
+			SchemaVersion: "v1",
+			Name:          "test-workflow",
+			Trigger: &types.WorkflowTrigger{
+				GitHubIssues: &types.GitHubIssuesWorkflowTrigger{
+					Event:        "issue_labeled",
+					Repositories: []string{"testorg/testrepo"},
+					States:       []string{"open"},
+					Labels:       []string{"agent-ready"},
+					Labelers:     []string{"*"},
+				},
+			},
+			Stages: []types.WorkflowStage{{
+				ID:    "working",
+				Label: "Working",
+				Entry: true,
+				OnEnter: map[string]interface{}{
+					"inject": "Read your CONTEXT.md and start working on the issue.\n",
+				},
+			}},
+		}},
+	)
+	hub.SaveWorkspaceIssueTrackerForTest(t, workspace, "github-issues", "default", "test-github-issues-token", "")
 }
 
 func hmacSHA256(body []byte, secret string) string {

--- a/pkg/hub/integration_poller.go
+++ b/pkg/hub/integration_poller.go
@@ -36,11 +36,19 @@ func (s *Server) pollTick() {
 	since := now.Add(-2 * time.Minute).Format(time.RFC3339)
 
 	factories := s.resolveFactories()
+	linearWorkflowWorkspaces, err := loadExternalWorkflowsByIntegration("linear")
+	if err != nil {
+		log.Printf("[poll] tick: failed to load linear workflows: %v", err)
+	}
+	shortcutWorkflowWorkspaces, err := loadExternalWorkflowsByIntegration("shortcut")
+	if err != nil {
+		log.Printf("[poll] tick: failed to load shortcut workflows: %v", err)
+	}
 	githubIssueWorkflowWorkspaces, err := loadExternalWorkflowsByIntegration("github-issues")
 	if err != nil {
 		log.Printf("[poll] tick: failed to load github-issues workflows: %v", err)
 	}
-	if len(factories) == 0 && len(githubIssueWorkflowWorkspaces) == 0 {
+	if len(factories) == 0 && len(linearWorkflowWorkspaces) == 0 && len(shortcutWorkflowWorkspaces) == 0 && len(githubIssueWorkflowWorkspaces) == 0 {
 		log.Printf("[poll] tick: no factories or workflows configured")
 		return
 	}
@@ -53,10 +61,16 @@ func (s *Server) pollTick() {
 	if integrations != nil && len(integrations.Linear) > 0 {
 		s.pollLinear(factories, integrations.Linear, since)
 	}
+	if len(linearWorkflowWorkspaces) > 0 {
+		s.pollLinearWorkflows(linearWorkflowWorkspaces, since)
+	}
 
 	// === SHORTCUT ===
 	if integrations != nil && len(integrations.Shortcut) > 0 {
 		s.pollShortcut(factories, integrations.Shortcut, since)
+	}
+	if len(shortcutWorkflowWorkspaces) > 0 {
+		s.pollShortcutWorkflows(shortcutWorkflowWorkspaces, since)
 	}
 
 	// === GITHUB ISSUES ===
@@ -117,6 +131,44 @@ func (s *Server) pollLinear(factories []*types.FactoryConfig, linearCfgs []*type
 
 		for _, issue := range issues {
 			s.processLinearPollItem(issue, wsFactories, ws)
+		}
+	}
+}
+
+type linearWorkflowPollTarget struct {
+	workspace *types.WorkspaceConfig
+	workflow  *types.WorkflowConfig
+}
+
+func (s *Server) pollLinearWorkflows(workspaces []*types.WorkspaceConfig, since string) {
+	tokenTargets := map[string][]linearWorkflowPollTarget{}
+	for _, workspace := range workspaces {
+		if workspace == nil {
+			continue
+		}
+		for _, workflow := range workspace.Workflows {
+			if workflow == nil || workflow.Integration != "linear" {
+				continue
+			}
+			if workflow.Enabled != nil && !*workflow.Enabled {
+				continue
+			}
+			token := s.resolveLinearTokenForWorkflow(workspace.Name, workflow)
+			if token == "" {
+				log.Printf("[poll-linear] workflow %s/%s: no Linear token configured — skipping", workspace.Name, workflow.Name)
+				continue
+			}
+			tokenTargets[token] = append(tokenTargets[token], linearWorkflowPollTarget{workspace: workspace, workflow: workflow})
+		}
+	}
+	for token, targets := range tokenTargets {
+		issues, err := s.queryLinearIssues(token, since)
+		if err != nil {
+			log.Printf("[poll-linear] workflow query failed: %v", err)
+			continue
+		}
+		for _, issue := range issues {
+			s.processLinearWorkflowPollItem(issue, targets)
 		}
 	}
 }
@@ -296,6 +348,52 @@ func (s *Server) processLinearPollItem(issue linearPollIssue, factories []*types
 	}
 }
 
+func (s *Server) processLinearWorkflowPollItem(issue linearPollIssue, targets []linearWorkflowPollTarget) {
+	entityID := issue.Identifier
+	currentStatus := issue.State.Name
+	currentLabels := make(map[string]bool)
+	for _, l := range issue.Labels {
+		currentLabels[strings.ToLower(l.Name)] = true
+	}
+	currentAssignee := ""
+	if issue.Assignee != nil {
+		currentAssignee = issue.Assignee.Name
+	}
+	payload := s.buildLinearPollPayload(issue)
+
+	for _, target := range targets {
+		workspace := target.workspace
+		workflow := target.workflow
+		if workspace == nil || workflow == nil {
+			continue
+		}
+		if workflow.Team != "" && !strings.EqualFold(workflow.Team, issue.Team.Key) {
+			continue
+		}
+		if workflow.TriggerStatus == "" || !strings.EqualFold(currentStatus, workflow.TriggerStatus) {
+			continue
+		}
+		if workflow.AssignedTo != "" && !assignedToMatches(workflow.AssignedTo, currentAssignee) {
+			continue
+		}
+		labelsMatched := true
+		for _, required := range workflow.Labels {
+			if !currentLabels[strings.ToLower(required)] {
+				labelsMatched = false
+				break
+			}
+		}
+		if !labelsMatched {
+			continue
+		}
+
+		log.Printf("[workflow:%s/%s] Linear issue %s matched workflow trigger via poll — creating claw", workspace.Name, workflow.Name, entityID)
+		if err := s.createClawForLinearWorkflow(workspace, workflow, payload, "poll"); err != nil {
+			log.Printf("[workflow:%s/%s] failed to create claw for %s via poll: %v", workspace.Name, workflow.Name, entityID, err)
+		}
+	}
+}
+
 func (s *Server) buildLinearPollPayload(issue linearPollIssue) linearWebhookPayload {
 	var payload linearWebhookPayload
 	payload.Action = "update"
@@ -385,6 +483,12 @@ type shortcutPollStory struct {
 	OwnerIDs []string `json:"owner_ids"`
 }
 
+type shortcutWorkflowPollTarget struct {
+	workspace *types.WorkspaceConfig
+	workflow  *types.WorkflowConfig
+	token     string
+}
+
 func (s *Server) queryShortcutStories(token, since string) ([]shortcutPollStory, error) {
 	body := map[string]interface{}{
 		"updated_at_start": since,
@@ -410,6 +514,44 @@ func (s *Server) queryShortcutStories(token, since string) ([]shortcutPollStory,
 		return nil, fmt.Errorf("parse shortcut response: %w", err)
 	}
 	return stories, nil
+}
+
+func (s *Server) pollShortcutWorkflows(workspaces []*types.WorkspaceConfig, since string) {
+	tokenTargets := map[string][]shortcutWorkflowPollTarget{}
+	for _, workspace := range workspaces {
+		if workspace == nil {
+			continue
+		}
+		for _, workflow := range workspace.Workflows {
+			if workflow == nil || workflow.Integration != "shortcut" {
+				continue
+			}
+			if workflow.Enabled != nil && !*workflow.Enabled {
+				continue
+			}
+			token := s.resolveShortcutTokenForWorkflow(workspace.Name, workflow)
+			if token == "" {
+				log.Printf("[poll-shortcut] workflow %s/%s: no Shortcut token configured — skipping", workspace.Name, workflow.Name)
+				continue
+			}
+			tokenTargets[token] = append(tokenTargets[token], shortcutWorkflowPollTarget{workspace: workspace, workflow: workflow, token: token})
+		}
+	}
+	for token, targets := range tokenTargets {
+		stories, err := s.queryShortcutStories(token, since)
+		if err != nil {
+			log.Printf("[poll-shortcut] workflow query failed: %v", err)
+			continue
+		}
+		stateNameMap := buildShortcutStateMap(s.resolveShortcutBaseURL(), token)
+		if len(stateNameMap) == 0 {
+			log.Printf("[poll-shortcut] failed to load workflow states for workflow polling — skipping %d stories", len(stories))
+			continue
+		}
+		for _, story := range stories {
+			s.processShortcutWorkflowPollItem(story, targets, token, stateNameMap)
+		}
+	}
 }
 
 func (s *Server) processShortcutPollItem(story shortcutPollStory, factories []*types.FactoryConfig, workspace, token string, stateNameMap map[int64]string) {
@@ -482,6 +624,71 @@ func (s *Server) processShortcutPollItem(story shortcutPollStory, factories []*t
 		} else {
 			log.Printf("[poll-shortcut] created claw for %s via factory %s", storyID, factory.Name)
 			s.logFactoryEvent(factory.Name, storyID, story.Name, "", currentStateName, "claw_created", "", "poll")
+		}
+	}
+}
+
+func (s *Server) processShortcutWorkflowPollItem(story shortcutPollStory, targets []shortcutWorkflowPollTarget, token string, stateNameMap map[int64]string) {
+	storyID := fmt.Sprintf("sc-%d", story.ID)
+	currentStateName := stateNameMap[story.WorkflowStateID]
+	if currentStateName == "" {
+		currentStateName = strconv.FormatInt(story.WorkflowStateID, 10)
+	}
+	currentLabels := make(map[string]bool)
+	for _, l := range story.Labels {
+		currentLabels[strings.ToLower(l.Name)] = true
+	}
+	currentAssignee := ""
+	needsAssignee := false
+	for _, target := range targets {
+		if target.workflow != nil && target.workflow.AssignedTo != "" {
+			needsAssignee = true
+			break
+		}
+	}
+	if needsAssignee && len(story.OwnerIDs) > 0 {
+		data, err := shortcutAPI(s.resolveShortcutBaseURL(), fmt.Sprintf("members/%s", story.OwnerIDs[0]), token)
+		if err == nil {
+			if name, ok := data["mention_name"].(string); ok && name != "" {
+				currentAssignee = name
+			} else if name, ok := data["name"].(string); ok && name != "" {
+				currentAssignee = name
+			}
+		}
+	}
+	action := shortcutAction{
+		ID:          story.ID,
+		EntityType:  "story",
+		Action:      "update",
+		Name:        story.Name,
+		AppURL:      story.AppURL,
+		Description: story.Description,
+	}
+	for _, target := range targets {
+		workspace := target.workspace
+		workflow := target.workflow
+		if workspace == nil || workflow == nil {
+			continue
+		}
+		if workflow.TriggerStatus == "" || !strings.EqualFold(currentStateName, workflow.TriggerStatus) {
+			continue
+		}
+		if workflow.AssignedTo != "" && !assignedToMatches(workflow.AssignedTo, currentAssignee) {
+			continue
+		}
+		labelsMatched := true
+		for _, required := range workflow.Labels {
+			if !currentLabels[strings.ToLower(required)] {
+				labelsMatched = false
+				break
+			}
+		}
+		if !labelsMatched {
+			continue
+		}
+		log.Printf("[workflow:%s/%s] Shortcut story %s matched workflow trigger via poll — creating claw", workspace.Name, workflow.Name, storyID)
+		if err := s.createClawForShortcutWorkflow(workspace, workflow, action, storyID, "poll"); err != nil {
+			log.Printf("[workflow:%s/%s] failed to create claw for %s via poll: %v", workspace.Name, workflow.Name, storyID, err)
 		}
 	}
 }

--- a/pkg/hub/integration_poller.go
+++ b/pkg/hub/integration_poller.go
@@ -759,7 +759,11 @@ type githubIssueWorkflowPollTarget struct {
 }
 
 func (s *Server) pollGitHubIssueWorkflows(workspaces []*types.WorkspaceConfig, since string) {
-	repoTargets := map[string][]githubIssueWorkflowPollTarget{}
+	type repoTokenKey struct {
+		repo  string
+		token string
+	}
+	repoTargets := map[repoTokenKey][]githubIssueWorkflowPollTarget{}
 	for _, workspace := range workspaces {
 		if workspace == nil {
 			continue
@@ -784,7 +788,8 @@ func (s *Server) pollGitHubIssueWorkflows(workspaces []*types.WorkspaceConfig, s
 					log.Printf("[poll-github-issues] workflow %s/%s: repository %q is an org wildcard; polling requires exact owner/repo entries", workspace.Name, workflow.Name, repo)
 					continue
 				}
-				repoTargets[repo] = append(repoTargets[repo], githubIssueWorkflowPollTarget{
+				key := repoTokenKey{repo: repo, token: token}
+				repoTargets[key] = append(repoTargets[key], githubIssueWorkflowPollTarget{
 					workspace: workspace,
 					workflow:  workflow,
 					token:     token,
@@ -797,24 +802,17 @@ func (s *Server) pollGitHubIssueWorkflows(workspaces []*types.WorkspaceConfig, s
 	if base == "" {
 		base = "https://api.github.com"
 	}
-	for repo, targets := range repoTargets {
-		token := ""
-		for _, target := range targets {
-			if target.token != "" {
-				token = target.token
-				break
-			}
-		}
-		if token == "" {
+	for key, targets := range repoTargets {
+		if key.token == "" {
 			continue
 		}
-		issues, err := s.queryGitHubIssues(repo, token, since, base)
+		issues, err := s.queryGitHubIssues(key.repo, key.token, since, base)
 		if err != nil {
-			log.Printf("[poll-github-issues] workflow query failed for repo %q: %v", repo, err)
+			log.Printf("[poll-github-issues] workflow query failed for repo %q: %v", key.repo, err)
 			continue
 		}
 		for _, issue := range issues {
-			s.processGitHubIssueWorkflowPollItem(issue, targets, repo)
+			s.processGitHubIssueWorkflowPollItem(issue, targets, key.repo, key.token, base)
 		}
 	}
 }
@@ -1007,13 +1005,21 @@ func (s *Server) processGitHubIssuesPollItem(issue githubIssuesPollItem, factori
 	}
 }
 
-func (s *Server) processGitHubIssueWorkflowPollItem(issue githubIssuesPollItem, targets []githubIssueWorkflowPollTarget, repo string) {
+func (s *Server) processGitHubIssueWorkflowPollItem(issue githubIssuesPollItem, targets []githubIssueWorkflowPollTarget, repo, token, base string) {
 	issueID := fmt.Sprintf("%s/%d", repo, issue.Number)
 	currentStatus := issue.State
 	issueLabels := githubIssuesPollLabels(issue)
 	assignee := ""
 	if issue.Assignee != nil {
 		assignee = issue.Assignee.Login
+	}
+	var events []githubIssueEvent
+	if githubIssueWorkflowPollNeedsLabelerEvents(targets) {
+		var err error
+		events, err = s.queryGitHubIssueEvents(repo, token, base, issue.Number)
+		if err != nil {
+			log.Printf("[poll-github-issues] failed to fetch events for %s: %v", issueID, err)
+		}
 	}
 
 	for _, target := range targets {
@@ -1022,11 +1028,10 @@ func (s *Server) processGitHubIssueWorkflowPollItem(issue githubIssuesPollItem, 
 		if workspace == nil || workflow == nil {
 			continue
 		}
-		payload, ok := buildGitHubIssuesWorkflowPollPayload(issue, repo, workflow, currentStatus, issueLabels, assignee)
+		payload, ok := buildGitHubIssuesWorkflowPollPayload(issue, repo, workflow, currentStatus, issueLabels, assignee, events)
 		if !ok {
 			continue
 		}
-		log.Printf("[workflow:%s/%s] GitHub issue %s matched workflow trigger via poll — creating claw", workspace.Name, workflow.Name, issueID)
 		if err := s.createClawForGitHubIssueWorkflow(workspace, workflow, payload, "poll"); err != nil {
 			log.Printf("[workflow:%s/%s] failed to create claw for %s via poll: %v", workspace.Name, workflow.Name, issueID, err)
 		}
@@ -1041,7 +1046,7 @@ func githubIssuesPollLabels(issue githubIssuesPollItem) map[string]bool {
 	return labels
 }
 
-func buildGitHubIssuesWorkflowPollPayload(issue githubIssuesPollItem, repo string, workflow *types.WorkflowConfig, currentStatus string, issueLabels map[string]bool, assignee string) (githubIssuesWebhookPayload, bool) {
+func buildGitHubIssuesWorkflowPollPayload(issue githubIssuesPollItem, repo string, workflow *types.WorkflowConfig, currentStatus string, issueLabels map[string]bool, assignee string, events []githubIssueEvent) (githubIssuesWebhookPayload, bool) {
 	payload := buildGitHubIssuesPollPayloadForAction(issue, repo, githubIssuesWorkflowPollAction(workflow))
 	if payload.Action == "" {
 		return payload, false
@@ -1054,9 +1059,16 @@ func buildGitHubIssuesWorkflowPollPayload(issue githubIssuesPollItem, repo strin
 		if !ok {
 			return payload, false
 		}
+		labeler, ok := githubIssuesWorkflowPollLabeler(workflow, labelName, events)
+		if !ok {
+			return payload, false
+		}
 		payload.Label = &struct {
 			Name string `json:"name"`
 		}{Name: labelName}
+		if labeler != "" {
+			payload.Sender.Login = labeler
+		}
 	}
 	if workflow.Trigger != nil {
 		if !githubIssuesWorkflowTriggerMatches(workflow.Trigger, payload, currentStatus, issueLabels) {
@@ -1126,6 +1138,62 @@ func githubIssuesWorkflowPollLabel(workflow *types.WorkflowConfig, issueLabels m
 	}
 	for label := range issueLabels {
 		return label, true
+	}
+	return "", false
+}
+
+func githubIssueWorkflowPollNeedsLabelerEvents(targets []githubIssueWorkflowPollTarget) bool {
+	for _, target := range targets {
+		for _, labeler := range githubIssuesWorkflowPollLabelers(target.workflow) {
+			labeler = strings.TrimSpace(labeler)
+			if labeler != "" && labeler != "*" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func githubIssuesWorkflowPollLabelers(workflow *types.WorkflowConfig) []string {
+	if workflow == nil {
+		return nil
+	}
+	if workflow.Trigger != nil {
+		if workflow.Trigger.GitHubIssues != nil {
+			return workflow.Trigger.GitHubIssues.Labelers
+		}
+		if workflow.Trigger.Type == "github_issues" {
+			return workflow.Trigger.Labelers
+		}
+	}
+	return workflow.AllowedLabelers
+}
+
+func githubIssuesWorkflowPollLabeler(workflow *types.WorkflowConfig, labelName string, events []githubIssueEvent) (string, bool) {
+	labelers := githubIssuesWorkflowPollLabelers(workflow)
+	needsSpecificLabeler := false
+	for _, labeler := range labelers {
+		labeler = strings.TrimSpace(labeler)
+		if labeler != "" && labeler != "*" {
+			needsSpecificLabeler = true
+			break
+		}
+	}
+	if !needsSpecificLabeler {
+		return "", true
+	}
+	for _, event := range events {
+		if event.Event != "labeled" || event.Label == nil {
+			continue
+		}
+		if !strings.EqualFold(event.Label.Name, labelName) {
+			continue
+		}
+		for _, labeler := range labelers {
+			if strings.EqualFold(strings.TrimSpace(labeler), event.Actor.Login) {
+				return event.Actor.Login, true
+			}
+		}
 	}
 	return "", false
 }

--- a/pkg/hub/integration_poller.go
+++ b/pkg/hub/integration_poller.go
@@ -16,8 +16,9 @@ import (
 
 // startIntegrationPoller launches the background polling goroutine that queries
 // each configured integration's API every 30 seconds to detect missed webhook
-// events. It evaluates factory filters against current state and creates claws
-// when the matching factory has not already claimed that external trigger.
+// events. It evaluates factory/workflow filters against current state and
+// creates agents when the matching trigger has not already claimed that
+// external item.
 func (s *Server) startIntegrationPoller() {
 	go func() {
 		ticker := time.NewTicker(30 * time.Second)
@@ -28,15 +29,19 @@ func (s *Server) startIntegrationPoller() {
 	}()
 }
 
-// pollTick queries all four integration platforms for recently updated items
-// and processes any trigger transitions that webhooks may have missed.
+// pollTick queries integration platforms for recently updated items and
+// processes any trigger transitions that webhooks may have missed.
 func (s *Server) pollTick() {
 	now := time.Now().UTC()
 	since := now.Add(-2 * time.Minute).Format(time.RFC3339)
 
 	factories := s.resolveFactories()
-	if len(factories) == 0 {
-		log.Printf("[poll] tick: no factories configured")
+	githubIssueWorkflowWorkspaces, err := loadExternalWorkflowsByIntegration("github-issues")
+	if err != nil {
+		log.Printf("[poll] tick: failed to load github-issues workflows: %v", err)
+	}
+	if len(factories) == 0 && len(githubIssueWorkflowWorkspaces) == 0 {
+		log.Printf("[poll] tick: no factories or workflows configured")
 		return
 	}
 
@@ -58,10 +63,15 @@ func (s *Server) pollTick() {
 	if integrations != nil && len(integrations.GitHubIssues) > 0 {
 		s.pollGitHubIssues(factories, integrations.GitHubIssues, since)
 	}
+	if len(githubIssueWorkflowWorkspaces) > 0 {
+		s.pollGitHubIssueWorkflows(githubIssueWorkflowWorkspaces, since)
+	}
 
 	// === GITHUB PRs ===
 	// Use factories with integration=="github" to discover repos
-	s.pollGitHubPRs(factories, since)
+	if len(factories) > 0 {
+		s.pollGitHubPRs(factories, since)
+	}
 }
 
 // ── LINEAR POLLER ───────────────────────────────────────────────────────────
@@ -535,6 +545,73 @@ func (s *Server) pollGitHubIssues(factories []*types.FactoryConfig, ghIssueCfgs 
 	}
 }
 
+type githubIssueWorkflowPollTarget struct {
+	workspace *types.WorkspaceConfig
+	workflow  *types.WorkflowConfig
+	token     string
+}
+
+func (s *Server) pollGitHubIssueWorkflows(workspaces []*types.WorkspaceConfig, since string) {
+	repoTargets := map[string][]githubIssueWorkflowPollTarget{}
+	for _, workspace := range workspaces {
+		if workspace == nil {
+			continue
+		}
+		for _, workflow := range workspace.Workflows {
+			if workflow == nil || workflow.Integration != "github-issues" {
+				continue
+			}
+			if workflow.Enabled != nil && !*workflow.Enabled {
+				continue
+			}
+			token := s.resolveGitHubIssuesTokenForWorkflow(workspace.Name, workflow)
+			if token == "" {
+				log.Printf("[poll-github-issues] workflow %s/%s: no GitHub Issues token configured — skipping", workspace.Name, workflow.Name)
+				continue
+			}
+			for _, repo := range githubIssuesWorkflowTriggerRepos(workflow) {
+				if repo == "" {
+					continue
+				}
+				if strings.HasSuffix(repo, "/*") {
+					log.Printf("[poll-github-issues] workflow %s/%s: repository %q is an org wildcard; polling requires exact owner/repo entries", workspace.Name, workflow.Name, repo)
+					continue
+				}
+				repoTargets[repo] = append(repoTargets[repo], githubIssueWorkflowPollTarget{
+					workspace: workspace,
+					workflow:  workflow,
+					token:     token,
+				})
+			}
+		}
+	}
+
+	base := s.githubBaseURL
+	if base == "" {
+		base = "https://api.github.com"
+	}
+	for repo, targets := range repoTargets {
+		token := ""
+		for _, target := range targets {
+			if target.token != "" {
+				token = target.token
+				break
+			}
+		}
+		if token == "" {
+			continue
+		}
+		issues, err := s.queryGitHubIssues(repo, token, since, base)
+		if err != nil {
+			log.Printf("[poll-github-issues] workflow query failed for repo %q: %v", repo, err)
+			continue
+		}
+		for _, issue := range issues {
+			s.processGitHubIssueWorkflowPollItem(issue, targets, repo)
+		}
+	}
+}
+
 func githubIssuesPollingRepos(factory *types.FactoryConfig) []string {
 	if len(factory.TriggerRepos) > 0 {
 		return factory.TriggerRepos
@@ -723,9 +800,136 @@ func (s *Server) processGitHubIssuesPollItem(issue githubIssuesPollItem, factori
 	}
 }
 
+func (s *Server) processGitHubIssueWorkflowPollItem(issue githubIssuesPollItem, targets []githubIssueWorkflowPollTarget, repo string) {
+	issueID := fmt.Sprintf("%s/%d", repo, issue.Number)
+	currentStatus := issue.State
+	issueLabels := githubIssuesPollLabels(issue)
+	assignee := ""
+	if issue.Assignee != nil {
+		assignee = issue.Assignee.Login
+	}
+
+	for _, target := range targets {
+		workspace := target.workspace
+		workflow := target.workflow
+		if workspace == nil || workflow == nil {
+			continue
+		}
+		payload, ok := buildGitHubIssuesWorkflowPollPayload(issue, repo, workflow, currentStatus, issueLabels, assignee)
+		if !ok {
+			continue
+		}
+		log.Printf("[workflow:%s/%s] GitHub issue %s matched workflow trigger via poll — creating claw", workspace.Name, workflow.Name, issueID)
+		if err := s.createClawForGitHubIssueWorkflow(workspace, workflow, payload, "poll"); err != nil {
+			log.Printf("[workflow:%s/%s] failed to create claw for %s via poll: %v", workspace.Name, workflow.Name, issueID, err)
+		}
+	}
+}
+
+func githubIssuesPollLabels(issue githubIssuesPollItem) map[string]bool {
+	labels := map[string]bool{}
+	for _, label := range issue.Labels {
+		labels[strings.ToLower(label.Name)] = true
+	}
+	return labels
+}
+
+func buildGitHubIssuesWorkflowPollPayload(issue githubIssuesPollItem, repo string, workflow *types.WorkflowConfig, currentStatus string, issueLabels map[string]bool, assignee string) (githubIssuesWebhookPayload, bool) {
+	payload := buildGitHubIssuesPollPayloadForAction(issue, repo, githubIssuesWorkflowPollAction(workflow))
+	if payload.Action == "" {
+		return payload, false
+	}
+	if workflow.AssignedTo != "" && !assignedToMatches(workflow.AssignedTo, assignee) {
+		return payload, false
+	}
+	if payload.Action == "labeled" {
+		labelName, ok := githubIssuesWorkflowPollLabel(workflow, issueLabels)
+		if !ok {
+			return payload, false
+		}
+		payload.Label = &struct {
+			Name string `json:"name"`
+		}{Name: labelName}
+	}
+	if workflow.Trigger != nil {
+		if !githubIssuesWorkflowTriggerMatches(workflow.Trigger, payload, currentStatus, issueLabels) {
+			return payload, false
+		}
+		return payload, true
+	}
+	if len(workflow.Labels) > 0 {
+		for _, required := range workflow.Labels {
+			if !issueLabels[strings.ToLower(required)] {
+				return payload, false
+			}
+		}
+	}
+	triggerStatus := workflow.TriggerStatus
+	if triggerStatus == "" {
+		triggerStatus = "open"
+	}
+	if !strings.EqualFold(currentStatus, triggerStatus) && !issueLabels[strings.ToLower(triggerStatus)] {
+		return payload, false
+	}
+	return payload, true
+}
+
+func githubIssuesWorkflowPollAction(workflow *types.WorkflowConfig) string {
+	event := ""
+	if workflow != nil && workflow.Trigger != nil {
+		if workflow.Trigger.GitHubIssues != nil {
+			event = workflow.Trigger.GitHubIssues.Event
+		} else if workflow.Trigger.Type == "github_issues" {
+			event = workflow.Trigger.Event
+		}
+	}
+	switch event {
+	case "issue_labeled":
+		return "labeled"
+	case "issue_opened":
+		return "opened"
+	case "issue_reopened":
+		return "reopened"
+	case "issue_edited":
+		return "edited"
+	case "issue_assigned":
+		return "assigned"
+	case "issue_unassigned":
+		return "unassigned"
+	case "":
+		return "opened"
+	default:
+		return ""
+	}
+}
+
+func githubIssuesWorkflowPollLabel(workflow *types.WorkflowConfig, issueLabels map[string]bool) (string, bool) {
+	if workflow != nil && workflow.Trigger != nil {
+		var labels []string
+		if workflow.Trigger.GitHubIssues != nil {
+			labels = workflow.Trigger.GitHubIssues.Labels
+		} else if workflow.Trigger.Type == "github_issues" {
+			labels = workflow.Trigger.Labels
+		}
+		for _, label := range labels {
+			if issueLabels[strings.ToLower(label)] {
+				return label, true
+			}
+		}
+	}
+	for label := range issueLabels {
+		return label, true
+	}
+	return "", false
+}
+
 func (s *Server) buildGitHubIssuesPollPayload(issue githubIssuesPollItem, repo string) githubIssuesWebhookPayload {
+	return buildGitHubIssuesPollPayloadForAction(issue, repo, "opened")
+}
+
+func buildGitHubIssuesPollPayloadForAction(issue githubIssuesPollItem, repo, action string) githubIssuesWebhookPayload {
 	var payload githubIssuesWebhookPayload
-	payload.Action = "opened" // synthetic action for polling
+	payload.Action = action
 	payload.Issue.Number = issue.Number
 	payload.Issue.Title = issue.Title
 	payload.Issue.Body = issue.Body
@@ -744,6 +948,7 @@ func (s *Server) buildGitHubIssuesPollPayload(issue githubIssuesPollItem, repo s
 		}{Login: issue.Assignee.Login}
 	}
 	payload.Repository.FullName = repo
+	payload.Sender.Login = issue.User.Login
 	return payload
 }
 

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -429,6 +429,28 @@ func (s *Server) createClawForLinearWorkflow(workspace *types.WorkspaceConfig, w
 		return nil
 	}
 
+	triggerKey := factoryTriggerKey("linear", issueID)
+	triggerOwner := fmt.Sprintf("workflow:%s/%s", workspace.Name, workflow.Name)
+	claimed, err := s.claimFactoryTrigger(triggerOwner, "linear", triggerKey, reason, map[string]string{
+		"issue_id":  issueID,
+		"source":    reason,
+		"workspace": workspace.Name,
+		"workflow":  workflow.Name,
+	})
+	if err != nil {
+		return fmt.Errorf("claim workflow trigger: %w", err)
+	}
+	if !claimed {
+		log.Printf("[workflow:%s/%s] Linear issue %s already has an active trigger claim", workspace.Name, workflow.Name, issueID)
+		return nil
+	}
+	claimOpen := true
+	defer func() {
+		if claimOpen {
+			s.failFactoryTrigger(triggerOwner, "linear", triggerKey)
+		}
+	}()
+
 	templateFiles := cloneStringMap(workspace.Files)
 	templateFiles["CONTEXT.md"] = buildLinearContext(payload)
 
@@ -447,6 +469,11 @@ func (s *Server) createClawForLinearWorkflow(workspace *types.WorkspaceConfig, w
 	if err != nil {
 		return err
 	}
+	if err := s.completeFactoryTrigger(triggerOwner, "linear", triggerKey, clawID); err != nil {
+		_, _ = s.db.Exec(`UPDATE claws SET status='deleted' WHERE id=?`, clawID)
+		return fmt.Errorf("complete workflow trigger: %w", err)
+	}
+	claimOpen = false
 	if !isPending && workflow.WorkingStatus != "" {
 		if token := s.resolveLinearTokenForWorkflow(workspace.Name, workflow); token != "" {
 			if err := s.moveLinearIssueOnServer(token, issueID, workflow.WorkingStatus); err != nil {
@@ -627,6 +654,13 @@ func (s *Server) resolveLinearTokenForFactory(factory *types.FactoryConfig) stri
 
 func (s *Server) resolveLinearTokenForWorkflow(workspaceName string, workflow *types.WorkflowConfig) string {
 	if tracker, ok := findWorkspaceIssueTracker(workspaceName, "linear", workflow.Workspace); ok {
+		return tracker.Token
+	}
+	return ""
+}
+
+func (s *Server) resolveShortcutTokenForWorkflow(workspaceName string, workflow *types.WorkflowConfig) string {
+	if tracker, ok := findWorkspaceIssueTracker(workspaceName, "shortcut", workflow.Workspace); ok {
 		return tracker.Token
 	}
 	return ""

--- a/pkg/hub/shortcut.go
+++ b/pkg/hub/shortcut.go
@@ -715,6 +715,61 @@ func (s *Server) createClawForShortcutStory(factory *types.FactoryConfig, action
 	return nil
 }
 
+func (s *Server) createClawForShortcutWorkflow(workspace *types.WorkspaceConfig, workflow *types.WorkflowConfig, action shortcutAction, storyID, reason string) error {
+	var existing string
+	_ = s.db.QueryRow(`SELECT id FROM claws WHERE shortcut_story_id=? AND status NOT IN ('error','deleted') LIMIT 1`, storyID).Scan(&existing)
+	if existing != "" {
+		log.Printf("[workflow:%s/%s] Shortcut story %s already has active claw %s", workspace.Name, workflow.Name, storyID, existing[:8])
+		return nil
+	}
+
+	triggerKey := factoryTriggerKey("shortcut", storyID)
+	triggerOwner := fmt.Sprintf("workflow:%s/%s", workspace.Name, workflow.Name)
+	claimed, err := s.claimFactoryTrigger(triggerOwner, "shortcut", triggerKey, reason, map[string]string{
+		"story_id":  storyID,
+		"source":    reason,
+		"workspace": workspace.Name,
+		"workflow":  workflow.Name,
+	})
+	if err != nil {
+		return fmt.Errorf("claim workflow trigger: %w", err)
+	}
+	if !claimed {
+		log.Printf("[workflow:%s/%s] Shortcut story %s already has an active trigger claim", workspace.Name, workflow.Name, storyID)
+		return nil
+	}
+	claimOpen := true
+	defer func() {
+		if claimOpen {
+			s.failFactoryTrigger(triggerOwner, "shortcut", triggerKey)
+		}
+	}()
+
+	templateFiles := cloneStringMap(workspace.Files)
+	templateFiles["CONTEXT.md"] = buildShortcutContext(action, storyID)
+
+	clawName := storyID
+	if workflow.NamePattern != "" {
+		clawName = strings.ReplaceAll(workflow.NamePattern, "{issue_id}", storyID)
+	}
+
+	clawID, _, err := s.createClawFromWorkflowWithOptions(workspace, workflow, workflowCreateOptions{
+		workspaceFiles:  templateFiles,
+		clawName:        clawName,
+		shortcutStoryID: storyID,
+		reason:          reason,
+	})
+	if err != nil {
+		return err
+	}
+	if err := s.completeFactoryTrigger(triggerOwner, "shortcut", triggerKey, clawID); err != nil {
+		_, _ = s.db.Exec(`UPDATE claws SET status='deleted' WHERE id=?`, clawID)
+		return fmt.Errorf("complete workflow trigger: %w", err)
+	}
+	claimOpen = false
+	return nil
+}
+
 func buildShortcutContext(action shortcutAction, storyID string) string {
 	var b strings.Builder
 	b.WriteString("# Issue Context\n\n")

--- a/pkg/hub/workflow_creator.go
+++ b/pkg/hub/workflow_creator.go
@@ -15,12 +15,13 @@ import (
 )
 
 type workflowCreateOptions struct {
-	inputs         map[string]string
-	workspaceFiles map[string]string
-	clawName       string
-	githubIssueID  string
-	linearIssueID  string
-	reason         string
+	inputs          map[string]string
+	workspaceFiles  map[string]string
+	clawName        string
+	githubIssueID   string
+	linearIssueID   string
+	shortcutStoryID string
+	reason          string
 }
 
 func (s *Server) createClawFromWorkflow(workspace *types.WorkspaceConfig, workflow *types.WorkflowConfig, inputs map[string]string, reason string) (string, bool, error) {
@@ -218,6 +219,9 @@ func (s *Server) createClawFromWorkflowWithOptions(workspace *types.WorkspaceCon
 	}
 	if opts.linearIssueID != "" {
 		_, _ = s.db.Exec(`UPDATE claws SET linear_issue_id=? WHERE id=?`, opts.linearIssueID, clawID)
+	}
+	if opts.shortcutStoryID != "" {
+		_, _ = s.db.Exec(`UPDATE claws SET shortcut_story_id=? WHERE id=?`, opts.shortcutStoryID, clawID)
 	}
 
 	log.Printf("[workflow] created claw %s (%s) for workflow %s/%s (status=%s, reason=%s)", clawName, clawID[:8], workspace.Name, workflow.Name, initialStatus, opts.reason)

--- a/pkg/hub/workflow_poller_test.go
+++ b/pkg/hub/workflow_poller_test.go
@@ -1,0 +1,116 @@
+package hub_test
+
+import (
+	"testing"
+
+	"github.com/elasticclaw/elasticclaw/pkg/hub"
+	"github.com/elasticclaw/elasticclaw/pkg/hub/factorytest"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func TestLinearWorkflowPollCreatesOnceForMissedWebhook(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
+	linear := factorytest.NewMockLinear(t)
+
+	cfg := &types.HubConfig{
+		ClawToken: "test-claw-token",
+		Providers: map[string]types.ProviderConfig{
+			"noop": {Type: "noop"},
+		},
+	}
+	s, db := hub.NewTestServerWithConfig(t, cfg, "", linear.URL, "")
+	saveWorkflowPollWorkspaceFixture(t, "workspace-a", []*types.WorkflowConfig{{
+		SchemaVersion: "v1",
+		Name:          "linear-workflow",
+		Trigger: &types.WorkflowTrigger{
+			Linear: &types.LinearWorkflowTrigger{
+				Event:  "status_changed",
+				Team:   "ELA",
+				States: []string{"In Progress"},
+			},
+		},
+		Stages: workflowPollTestStages(),
+	}})
+	hub.SaveWorkspaceIssueTrackerForTest(t, "workspace-a", "linear", "default", "test-linear-token", "")
+	linear.SetIssueStateName("ELA-123", "In Progress")
+
+	s.PollIntegrationsForTest()
+	s.PollIntegrationsForTest()
+
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM claws WHERE linear_issue_id='ELA-123'`).Scan(&count); err != nil {
+		t.Fatalf("count claws: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("poll created %d claws for the same Linear issue, want 1", count)
+	}
+}
+
+func TestShortcutWorkflowPollCreatesOnceForMissedWebhook(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
+	shortcut := factorytest.NewMockShortcut(t)
+
+	cfg := &types.HubConfig{
+		ClawToken: "test-claw-token",
+		Providers: map[string]types.ProviderConfig{
+			"noop": {Type: "noop"},
+		},
+	}
+	s, db := hub.NewTestServerWithConfig(t, cfg, "", "", shortcut.URL)
+	saveWorkflowPollWorkspaceFixture(t, "workspace-a", []*types.WorkflowConfig{{
+		SchemaVersion: "v1",
+		Name:          "shortcut-workflow",
+		Trigger: &types.WorkflowTrigger{
+			Shortcut: &types.ShortcutWorkflowTrigger{
+				Event:  "status_changed",
+				States: []string{"In Progress"},
+			},
+		},
+		Stages: workflowPollTestStages(),
+	}})
+	hub.SaveWorkspaceIssueTrackerForTest(t, "workspace-a", "shortcut", "default", "test-shortcut-token", "")
+	shortcut.SetStory(123, factorytest.StoryState{
+		Name:            "Test Story",
+		Description:     "Test description",
+		WorkflowStateID: shortcut.StateIDForName("In Progress"),
+	})
+
+	s.PollIntegrationsForTest()
+	s.PollIntegrationsForTest()
+
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM claws WHERE shortcut_story_id='sc-123'`).Scan(&count); err != nil {
+		t.Fatalf("count claws: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("poll created %d claws for the same Shortcut story, want 1", count)
+	}
+}
+
+func saveWorkflowPollWorkspaceFixture(t *testing.T, workspace string, workflows []*types.WorkflowConfig) {
+	t.Helper()
+	hub.SaveWorkspaceForTest(t,
+		&types.WorkspaceConfig{
+			SchemaVersion: "v1",
+			Name:          workspace,
+			Files: map[string]string{
+				"elasticclaw-config.yaml": "schema_version: v1\nname: " + workspace + "\nprovider: noop\n",
+				"CONTEXT.md":              "Test context\n",
+			},
+		},
+		workflows,
+	)
+}
+
+func workflowPollTestStages() []types.WorkflowStage {
+	return []types.WorkflowStage{{
+		ID:    "working",
+		Label: "Working",
+		Entry: true,
+		OnEnter: map[string]interface{}{
+			"inject": "Read your CONTEXT.md and start working on the issue.\n",
+		},
+	}}
+}


### PR DESCRIPTION
## Summary
- port polling to workflow-backed triggers for GitHub Issues, Linear, and Shortcut
- use workspace-managed issue tracker tokens for workflow polling instead of old hub.yaml integration config
- add a Shortcut workflow creation path and persist shortcut_story_id for workflow-created agents
- add trigger claims to Linear and Shortcut workflow creation so poll/webhook races do not create duplicate agents
- update the no-config poll log to account for workflows, not just factories

## Duplicate-agent guard
Polling routes through the same workflow creation and trigger-claim model used by webhooks. GitHub Issues, Linear, and Shortcut each have regression coverage that runs two poll ticks for the same external item and asserts only one agent is created.

## Verification
- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./pkg/hub -run 'TestLinearWorkflowPollCreatesOnceForMissedWebhook|TestShortcutWorkflowPollCreatesOnceForMissedWebhook|TestGitHubIssuesWorkflowPollCreatesOnceForMissedWebhook'
- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./pkg/hub