### PR TITLE
Filter and isolate E2E runs

### DIFF
--- a/.depot/workflows/e2e.yml
+++ b/.depot/workflows/e2e.yml
@@ -27,6 +27,7 @@ jobs:
     env:
       ELASTICCLAW_E2E_BIN: ${{ github.workspace }}/bin/elasticclaw
       ELASTICCLAW_E2E_BRIDGE_BINARY: ${{ github.workspace }}/bin/claw-bridge-linux-amd64
+      ELASTICCLAW_E2E_DAYTONA_SANDBOX_ID_FILE: ${{ github.workspace }}/e2e-daytona-sandbox-ids
       ELASTICCLAW_E2E_HUB_ADDR: 127.0.0.1:8080
       ELASTICCLAW_E2E_GITHUB_TOKEN: ${{ secrets.ELASTICCLAW_E2E_GITHUB_TOKEN }}
       ELASTICCLAW_E2E_GITHUB_REPO: ${{ vars.ELASTICCLAW_E2E_GITHUB_REPO || 'elasticclaw/e2e-fixtures' }}
@@ -104,6 +105,10 @@ jobs:
       - name: Run Daytona GitHub Issues E2E
         run: go test -tags e2e -v ./test/e2e -run TestDaytonaGitHubIssuesWorkflowE2E -count=1 -timeout 30m
 
+      - name: Cleanup Daytona sandbox
+        if: always()
+        run: go test -tags e2e -v ./test/e2e -run TestCleanupRecordedDaytonaSandboxes -count=1 -timeout 6m
+
       - name: Stop ngrok
         if: always()
         run: |
@@ -125,3 +130,4 @@ jobs:
             ngrok.yml
             ngrok-domain.json
             ngrok-domain-id
+            e2e-daytona-sandbox-ids

--- a/.depot/workflows/e2e.yml
+++ b/.depot/workflows/e2e.yml
@@ -2,6 +2,21 @@ name: E2E
 
 on:
   pull_request:
+    paths:
+      - '.depot/workflows/e2e.yml'
+      - 'Makefile'
+      - 'cmd/claw-bridge/**'
+      - 'pkg/hub/bootstrap.go'
+      - 'pkg/hub/github.go'
+      - 'pkg/hub/github_issues.go'
+      - 'pkg/hub/pipeline_runner.go'
+      - 'pkg/hub/server.go'
+      - 'pkg/hub/workspace*.go'
+      - 'pkg/provider/daytona/**'
+      - 'pkg/types/**'
+      - 'test/e2e/**'
+      - 'go.mod'
+      - 'go.sum'
   workflow_dispatch:
 
 jobs:
@@ -51,9 +66,7 @@ jobs:
       - name: Start ngrok
         run: |
           NGROK_HOST="ec-${GITHUB_SHA:0:12}-${GITHUB_RUN_ATTEMPT}-$(date +%s).ngrok-free.app"
-          echo "Stopping existing ngrok agents so this job owns the tunnel"
-          pkill -x ngrok >/dev/null 2>&1 || true
-          sleep 1
+          NGROK_API_ADDR="127.0.0.1:4049"
           echo "Creating temporary ngrok reserved domain https://$NGROK_HOST"
           ngrok api reserved-domains create \
             --api-key "$NGROK_API_KEY" \
@@ -68,11 +81,11 @@ jobs:
           fi
           sleep 5
           echo "Starting ngrok tunnel https://$NGROK_HOST for localhost:8080"
-          printf 'version: "3"\n' > ngrok.yml
+          printf 'version: "3"\nagent:\n  web_addr: "%s"\n' "$NGROK_API_ADDR" > ngrok.yml
           ngrok http 8080 --url "https://$NGROK_HOST" --authtoken "$NGROK_AUTHTOKEN" --config ngrok.yml --log stdout > ngrok.log 2>&1 &
           echo "$!" > ngrok.pid
           for i in $(seq 1 30); do
-            url="$(curl -fsS http://127.0.0.1:4040/api/tunnels | python3 -c 'import json,sys; data=json.load(sys.stdin); print(next((t["public_url"] for t in data.get("tunnels", []) if t.get("proto") == "https"), ""))' 2>/dev/null || true)"
+            url="$(curl -fsS "http://$NGROK_API_ADDR/api/tunnels" | python3 -c 'import json,sys; data=json.load(sys.stdin); print(next((t["public_url"] for t in data.get("tunnels", []) if t.get("proto") == "https"), ""))' 2>/dev/null || true)"
             if [ -n "$url" ]; then
               case "$url" in
                 *://elasticclaw.ngrok.app*)

--- a/Makefile
+++ b/Makefile
@@ -60,17 +60,15 @@ e2e: build-dev build-bridge-linux ## Run the real Daytona + GitHub Issues E2E su
 	@set -e; \
 	HUB_ADDR="$${ELASTICCLAW_E2E_HUB_ADDR:-127.0.0.1:8080}"; \
 	HUB_PORT="$${HUB_ADDR##*:}"; \
+	NGROK_API_ADDR="$${ELASTICCLAW_E2E_NGROK_API_ADDR:-127.0.0.1:4049}"; \
 	NGROK_LOG="$$(mktemp -t elasticclaw-ngrok.XXXXXX.log)"; \
 	NGROK_CONFIG="$$(mktemp -t elasticclaw-ngrok.XXXXXX.yml)"; \
 	NGROK_DOMAIN_JSON="$$(mktemp -t elasticclaw-ngrok-domain.XXXXXX.json)"; \
 	NGROK_PID=""; \
 	NGROK_DOMAIN_ID=""; \
-	printf 'version: "3"\n' > "$$NGROK_CONFIG"; \
+	printf 'version: "3"\nagent:\n  web_addr: "%s"\n' "$$NGROK_API_ADDR" > "$$NGROK_CONFIG"; \
 	cleanup() { code="$$?"; if [ -n "$$NGROK_PID" ]; then kill "$$NGROK_PID" >/dev/null 2>&1 || true; fi; if [ -n "$$NGROK_DOMAIN_ID" ]; then ngrok api reserved-domains delete "$$NGROK_DOMAIN_ID" --api-key "$$NGROK_API_KEY" >/dev/null 2>&1 || true; fi; rm -f "$$NGROK_LOG" "$$NGROK_CONFIG" "$$NGROK_DOMAIN_JSON"; exit "$$code"; }; \
 	trap cleanup EXIT INT TERM; \
-	echo "Stopping existing ngrok agents so make e2e owns the tunnel"; \
-	pkill -x ngrok >/dev/null 2>&1 || true; \
-	sleep 1; \
 	NGROK_HOST="ec-$$(git rev-parse --short HEAD 2>/dev/null || echo dev)-$$(date +%s).ngrok-free.app"; \
 	echo "Creating temporary ngrok reserved domain https://$$NGROK_HOST"; \
 	ngrok api reserved-domains create --api-key "$$NGROK_API_KEY" --domain "$$NGROK_HOST" --description "ElasticClaw E2E temporary tunnel" --metadata "elasticclaw-e2e" > "$$NGROK_DOMAIN_JSON"; \
@@ -82,7 +80,7 @@ e2e: build-dev build-bridge-linux ## Run the real Daytona + GitHub Issues E2E su
 	NGROK_PID="$$!"; \
 	echo "Waiting for ngrok tunnel on localhost:$$HUB_PORT..."; \
 	for i in $$(seq 1 30); do \
-		ELASTICCLAW_E2E_PUBLIC_URL="$$(curl -fsS http://127.0.0.1:4040/api/tunnels 2>/dev/null | python3 -c 'import json,sys; data=json.load(sys.stdin); print(next((t["public_url"] for t in data.get("tunnels", []) if t.get("proto") == "https"), ""))' 2>/dev/null || true)"; \
+		ELASTICCLAW_E2E_PUBLIC_URL="$$(curl -fsS "http://$$NGROK_API_ADDR/api/tunnels" 2>/dev/null | python3 -c 'import json,sys; data=json.load(sys.stdin); print(next((t["public_url"] for t in data.get("tunnels", []) if t.get("proto") == "https"), ""))' 2>/dev/null || true)"; \
 		if [ -n "$$ELASTICCLAW_E2E_PUBLIC_URL" ]; then \
 			case "$$ELASTICCLAW_E2E_PUBLIC_URL" in *://elasticclaw.ngrok.app*) echo "Refusing shared ngrok domain: $$ELASTICCLAW_E2E_PUBLIC_URL"; exit 1;; esac; \
 			echo "ngrok: $$ELASTICCLAW_E2E_PUBLIC_URL"; \

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -775,7 +775,7 @@ func (s *Server) handleClaws(w http.ResponseWriter, r *http.Request) {
 	}
 
 	rows, err := s.db.Query(
-		`SELECT id, name, template, status, last_seen, created_at, ssh_host, ssh_port, ssh_user, COALESCE(tags,'[]'), COALESCE(color,''), COALESCE(bootstrap_status,'') FROM claws WHERE tenant_id = ? AND status != 'deleted' ORDER BY created_at DESC`,
+		`SELECT id, name, template, COALESCE(provider,''), COALESCE(provider_id,''), status, last_seen, created_at, ssh_host, ssh_port, ssh_user, COALESCE(tags,'[]'), COALESCE(color,''), COALESCE(bootstrap_status,'') FROM claws WHERE tenant_id = ? AND status != 'deleted' ORDER BY created_at DESC`,
 		tenantID,
 	)
 	if err != nil {
@@ -799,7 +799,7 @@ func (s *Server) handleClaws(w http.ResponseWriter, r *http.Request) {
 		var c types.Claw
 		var lastSeen sql.NullTime
 		var tagsJSON string
-		if err := rows.Scan(&c.ID, &c.Name, &c.Template, &c.Status, &lastSeen, &c.CreatedAt, &c.SSHHost, &c.SSHPort, &c.SSHUser, &tagsJSON, &c.Color, &c.BootstrapStatus); err != nil {
+		if err := rows.Scan(&c.ID, &c.Name, &c.Template, &c.Provider, &c.ProviderID, &c.Status, &lastSeen, &c.CreatedAt, &c.SSHHost, &c.SSHPort, &c.SSHUser, &tagsJSON, &c.Color, &c.BootstrapStatus); err != nil {
 			continue
 		}
 		_ = json.Unmarshal([]byte(tagsJSON), &c.Tags)
@@ -1240,9 +1240,9 @@ func (s *Server) handleClawDetail(w http.ResponseWriter, r *http.Request) {
 	var lastSeen sql.NullTime
 	var tagsJSON string
 	err := s.db.QueryRow(
-		`SELECT id, name, template, status, last_seen, created_at, ssh_host, ssh_port, ssh_user, COALESCE(tags,'[]'), COALESCE(color,''), COALESCE(bootstrap_status,'') FROM claws WHERE id = ? AND tenant_id = ?`,
+		`SELECT id, name, template, COALESCE(provider,''), COALESCE(provider_id,''), status, last_seen, created_at, ssh_host, ssh_port, ssh_user, COALESCE(tags,'[]'), COALESCE(color,''), COALESCE(bootstrap_status,'') FROM claws WHERE id = ? AND tenant_id = ?`,
 		clawID, tenantID,
-	).Scan(&c.ID, &c.Name, &c.Template, &c.Status, &lastSeen, &c.CreatedAt, &c.SSHHost, &c.SSHPort, &c.SSHUser, &tagsJSON, &c.Color, &c.BootstrapStatus)
+	).Scan(&c.ID, &c.Name, &c.Template, &c.Provider, &c.ProviderID, &c.Status, &lastSeen, &c.CreatedAt, &c.SSHHost, &c.SSHPort, &c.SSHUser, &tagsJSON, &c.Color, &c.BootstrapStatus)
 	_ = json.Unmarshal([]byte(tagsJSON), &c.Tags)
 	if err == sql.ErrNoRows {
 		http.Error(w, "not found", http.StatusNotFound)

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2266,6 +2266,7 @@ func (s *Server) provisionDaytona(ctx context.Context, clawID string, req types.
 		return fmt.Errorf("daytona create: %w", err)
 	}
 	log.Printf("daytona workspace created: %s (claw %s)", instance.ID, clawID)
+	recordE2EDaytonaSandboxID(instance.ID)
 	_, _ = s.db.Exec(`UPDATE claws SET status='starting', provider='daytona', provider_id=? WHERE id=?`, instance.ID, clawID)
 
 	// Bootstrap: install OpenClaw + claw-bridge via exec (retry up to 3x for transient Daytona API timeouts)
@@ -2784,6 +2785,28 @@ gh auth status`
 
 	log.Printf("[daytona] bootstrap complete for claw %s", clawID)
 	return nil
+}
+
+func recordE2EDaytonaSandboxID(sandboxID string) {
+	path := strings.TrimSpace(os.Getenv("ELASTICCLAW_E2E_DAYTONA_SANDBOX_ID_FILE"))
+	if path == "" || strings.TrimSpace(sandboxID) == "" {
+		return
+	}
+	if dir := filepath.Dir(path); dir != "." && dir != "" {
+		if err := os.MkdirAll(dir, 0700); err != nil {
+			log.Printf("[e2e] record Daytona sandbox id: mkdir %s: %v", dir, err)
+			return
+		}
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
+	if err != nil {
+		log.Printf("[e2e] record Daytona sandbox id: open %s: %v", path, err)
+		return
+	}
+	defer f.Close()
+	if _, err := fmt.Fprintln(f, sandboxID); err != nil {
+		log.Printf("[e2e] record Daytona sandbox id: write %s: %v", path, err)
+	}
 }
 
 func (s *Server) startDaytonaBridge(ctx context.Context, instanceID string, p *daytona.Provider, hubURL, clawID, clawToken, clawName string) error {

--- a/pkg/types/hub.go
+++ b/pkg/types/hub.go
@@ -8,6 +8,8 @@ type Claw struct {
 	TenantID        string         `json:"tenant_id" db:"tenant_id"`
 	Name            string         `json:"name" db:"name"`
 	Template        string         `json:"template" db:"template"`
+	Provider        string         `json:"provider,omitempty" db:"provider"`
+	ProviderID      string         `json:"provider_id,omitempty" db:"provider_id"`
 	Status          InstanceStatus `json:"status" db:"status"`
 	LastSeen        time.Time      `json:"last_seen" db:"last_seen"`
 	CreatedAt       time.Time      `json:"created_at" db:"created_at"`

--- a/test/e2e/cleanup_recorded_daytona_test.go
+++ b/test/e2e/cleanup_recorded_daytona_test.go
@@ -1,0 +1,82 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	daytonaProvider "github.com/elasticclaw/elasticclaw/pkg/provider/daytona"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func TestCleanupRecordedDaytonaSandboxes(t *testing.T) {
+	path := strings.TrimSpace(os.Getenv("ELASTICCLAW_E2E_DAYTONA_SANDBOX_ID_FILE"))
+	if path == "" {
+		t.Skip("ELASTICCLAW_E2E_DAYTONA_SANDBOX_ID_FILE is not set")
+	}
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return
+	}
+	if err != nil {
+		t.Fatalf("read recorded Daytona sandbox ids: %v", err)
+	}
+	ids := uniqueNonEmptyLines(string(data))
+	if len(ids) == 0 {
+		return
+	}
+
+	provider, err := daytonaProvider.New(map[string]interface{}{"api_key": os.Getenv("DAYTONA_API_KEY")})
+	if err != nil {
+		t.Fatalf("create Daytona provider for recorded cleanup: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	for _, id := range ids {
+		if err := provider.Destroy(ctx, id, false); err != nil && !isBenignDaytonaDeleteError(err) {
+			t.Fatalf("delete recorded Daytona sandbox %s: %v", id, err)
+		}
+	}
+
+	deadline := time.Now().Add(4 * time.Minute)
+	for {
+		remaining := make([]string, 0, len(ids))
+		for _, id := range ids {
+			status, err := provider.Status(ctx, id)
+			if err != nil {
+				if isBenignDaytonaDeleteError(err) {
+					continue
+				}
+				t.Fatalf("check recorded Daytona sandbox %s deletion: %v", id, err)
+			}
+			if status != types.StatusNotFound {
+				remaining = append(remaining, id)
+			}
+		}
+		if len(remaining) == 0 {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for recorded Daytona sandboxes to terminate: %s", strings.Join(remaining, ", "))
+		}
+		time.Sleep(5 * time.Second)
+	}
+}
+
+func uniqueNonEmptyLines(data string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, line := range strings.Split(data, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || seen[line] {
+			continue
+		}
+		seen[line] = true
+		out = append(out, line)
+	}
+	return out
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -5,7 +5,6 @@ package e2e
 import (
 	"bytes"
 	"context"
-	"database/sql"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -20,7 +19,6 @@ import (
 
 	daytonaProvider "github.com/elasticclaw/elasticclaw/pkg/provider/daytona"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
-	_ "modernc.org/sqlite"
 )
 
 const (
@@ -73,14 +71,23 @@ func TestDaytonaGitHubIssuesWorkflowE2E(t *testing.T) {
 	t.Cleanup(func() {
 		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 4*time.Minute)
 		defer cleanupCancel()
+		var providerID string
 		if agentID != "" {
-			providerID := hub.agentProviderID(cleanupCtx, t, agentID)
+			providerID = hub.agentProviderID(cleanupCtx, t, agentID)
 			_ = hub.deleteAgent(cleanupCtx, agentID)
-			if providerID != "" {
-				destroyDaytonaSandboxByID(cleanupCtx, t, env, providerID)
-			}
 		}
+		if providerID != "" {
+			destroyDaytonaSandboxByID(cleanupCtx, t, env, providerID)
+		}
+	})
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 4*time.Minute)
+		defer cleanupCancel()
 		cleanupDaytonaE2ESandboxes(cleanupCtx, t, env)
+	})
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 4*time.Minute)
+		defer cleanupCancel()
 		if issueNumber != 0 {
 			_ = gh.closeIssue(cleanupCtx, issueNumber)
 		}
@@ -140,7 +147,6 @@ type hubProcess struct {
 	token   string
 	cmd     *exec.Cmd
 	logPath string
-	dbPath  string
 }
 
 func startHub(ctx context.Context, t *testing.T, env e2eEnv) *hubProcess {
@@ -178,7 +184,7 @@ llm_keys:
 	}
 	t.Cleanup(func() { _ = logFile.Close() })
 
-	cmd := exec.CommandContext(ctx, env.Bin, "hub", "--addr", env.HubAddr, "--db", dbPath, "--no-web-ui")
+	cmd := exec.Command(env.Bin, "hub", "--addr", env.HubAddr, "--db", dbPath, "--no-web-ui")
 	cmd.Env = append(os.Environ(),
 		"ELASTICCLAW_HUB_CONFIG="+configPath,
 		"DAYTONA_API_KEY="+env.DaytonaAPIKey,
@@ -193,7 +199,7 @@ llm_keys:
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start hub: %v", err)
 	}
-	hub := &hubProcess{baseURL: baseURL, token: userToken, cmd: cmd, logPath: logPath, dbPath: dbPath}
+	hub := &hubProcess{baseURL: baseURL, token: userToken, cmd: cmd, logPath: logPath}
 	t.Cleanup(func() {
 		_ = cmd.Process.Kill()
 		_ = cmd.Wait()
@@ -356,23 +362,31 @@ func (h *hubProcess) deleteAgent(ctx context.Context, agentID string) error {
 
 func (h *hubProcess) agentProviderID(ctx context.Context, t *testing.T, agentID string) string {
 	t.Helper()
-	db, err := sql.Open("sqlite", h.dbPath+"?_time_format=sqlite&_pragma=journal_mode(WAL)&_pragma=foreign_keys(on)")
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, h.baseURL+"/api/claws/"+agentID, nil)
+	req.Header.Set("Authorization", "Bearer "+h.token)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		t.Fatalf("open E2E hub db for provider cleanup: %v", err)
-	}
-	defer db.Close()
-	var provider, providerID string
-	err = db.QueryRowContext(ctx, `SELECT COALESCE(provider,''), COALESCE(provider_id,'') FROM claws WHERE id = ?`, agentID).Scan(&provider, &providerID)
-	if err == sql.ErrNoRows {
+		t.Logf("read agent provider id: %v", err)
 		return ""
 	}
-	if err != nil {
-		t.Fatalf("read E2E agent provider id: %v", err)
-	}
-	if provider != "daytona" {
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
 		return ""
 	}
-	return providerID
+	if resp.StatusCode >= 300 {
+		data, _ := io.ReadAll(resp.Body)
+		t.Logf("read agent provider id: %s: %s", resp.Status, strings.TrimSpace(string(data)))
+		return ""
+	}
+	var agent types.Claw
+	if err := json.NewDecoder(resp.Body).Decode(&agent); err != nil {
+		t.Logf("decode agent provider id: %v", err)
+		return ""
+	}
+	if agent.Provider != "daytona" {
+		return ""
+	}
+	return agent.ProviderID
 }
 
 func (h *hubProcess) listAgents(ctx context.Context, t *testing.T) []types.Claw {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -5,6 +5,7 @@ package e2e
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -19,6 +20,7 @@ import (
 
 	daytonaProvider "github.com/elasticclaw/elasticclaw/pkg/provider/daytona"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
+	_ "modernc.org/sqlite"
 )
 
 const (
@@ -72,7 +74,11 @@ func TestDaytonaGitHubIssuesWorkflowE2E(t *testing.T) {
 		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 4*time.Minute)
 		defer cleanupCancel()
 		if agentID != "" {
+			providerID := hub.agentProviderID(cleanupCtx, t, agentID)
 			_ = hub.deleteAgent(cleanupCtx, agentID)
+			if providerID != "" {
+				destroyDaytonaSandboxByID(cleanupCtx, t, env, providerID)
+			}
 		}
 		cleanupDaytonaE2ESandboxes(cleanupCtx, t, env)
 		if issueNumber != 0 {
@@ -134,6 +140,7 @@ type hubProcess struct {
 	token   string
 	cmd     *exec.Cmd
 	logPath string
+	dbPath  string
 }
 
 func startHub(ctx context.Context, t *testing.T, env e2eEnv) *hubProcess {
@@ -186,7 +193,7 @@ llm_keys:
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start hub: %v", err)
 	}
-	hub := &hubProcess{baseURL: baseURL, token: userToken, cmd: cmd, logPath: logPath}
+	hub := &hubProcess{baseURL: baseURL, token: userToken, cmd: cmd, logPath: logPath, dbPath: dbPath}
 	t.Cleanup(func() {
 		_ = cmd.Process.Kill()
 		_ = cmd.Wait()
@@ -347,6 +354,27 @@ func (h *hubProcess) deleteAgent(ctx context.Context, agentID string) error {
 	return nil
 }
 
+func (h *hubProcess) agentProviderID(ctx context.Context, t *testing.T, agentID string) string {
+	t.Helper()
+	db, err := sql.Open("sqlite", h.dbPath+"?_time_format=sqlite&_pragma=journal_mode(WAL)&_pragma=foreign_keys(on)")
+	if err != nil {
+		t.Fatalf("open E2E hub db for provider cleanup: %v", err)
+	}
+	defer db.Close()
+	var provider, providerID string
+	err = db.QueryRowContext(ctx, `SELECT COALESCE(provider,''), COALESCE(provider_id,'') FROM claws WHERE id = ?`, agentID).Scan(&provider, &providerID)
+	if err == sql.ErrNoRows {
+		return ""
+	}
+	if err != nil {
+		t.Fatalf("read E2E agent provider id: %v", err)
+	}
+	if provider != "daytona" {
+		return ""
+	}
+	return providerID
+}
+
 func (h *hubProcess) listAgents(ctx context.Context, t *testing.T) []types.Claw {
 	t.Helper()
 	var agents []types.Claw
@@ -489,6 +517,35 @@ func cleanupDaytonaE2ESandboxes(ctx context.Context, t *testing.T, env e2eEnv) {
 		}
 		if time.Now().After(deadline) {
 			t.Fatalf("timed out waiting for Daytona E2E sandboxes with prefix %q to terminate", env.DaytonaPrefix)
+		}
+		time.Sleep(5 * time.Second)
+	}
+}
+
+func destroyDaytonaSandboxByID(ctx context.Context, t *testing.T, env e2eEnv, sandboxID string) {
+	t.Helper()
+	provider, err := daytonaProvider.New(map[string]interface{}{"api_key": env.DaytonaAPIKey})
+	if err != nil {
+		t.Fatalf("create Daytona provider for E2E sandbox cleanup: %v", err)
+	}
+	if err := provider.Destroy(ctx, sandboxID, false); err != nil && !isBenignDaytonaDeleteError(err) {
+		t.Fatalf("delete Daytona E2E sandbox %s: %v", sandboxID, err)
+	}
+
+	deadline := time.Now().Add(3 * time.Minute)
+	for {
+		status, err := provider.Status(ctx, sandboxID)
+		if err != nil {
+			if isBenignDaytonaDeleteError(err) {
+				return
+			}
+			t.Fatalf("check Daytona E2E sandbox %s deletion: %v", sandboxID, err)
+		}
+		if status == types.StatusNotFound {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for Daytona E2E sandbox %s to terminate; status=%s", sandboxID, status)
 		}
 		time.Sleep(5 * time.Second)
 	}


### PR DESCRIPTION
Adds aggressive path filtering for the expensive Daytona/GitHub Issues/OpenClaw E2E workflow so it only runs when relevant code or E2E infrastructure changes.\n\nAlso isolates the E2E ngrok agent on its own local web API address so local tunnels such as elasticclaw.ngrok.app are not killed or inspected, and hardens Daytona cleanup by deleting the exact provider_id recorded in the E2E hub DB before sweeping ec-e2e-* sandboxes.\n\nVerification:\n- go test ./test/e2e ./pkg/provider/daytona ./pkg/hub\n- source ~/elasticclaw-e2e-secrets.sh && make e2e\n- daytona ls | rg 'ec-e2e-' || true