### PR TITLE
Add workflow run action

### DIFF
--- a/.elasticclaw/workflows/github-issue.yaml
+++ b/.elasticclaw/workflows/github-issue.yaml
@@ -30,6 +30,22 @@ stages:
 
         Read the issue and CONTEXT.md and start working on the issue.
         Narrate your progress as you go. Keep me updated.
+        When implementation is complete and before committing, say [READY_TO_COMMIT].
+
+  - id: pre_commit
+    label: Pre-Commit Checks
+    triggers:
+      - message_contains: "[READY_TO_COMMIT]"
+    on_enter:
+      run:
+        command: mkdir -p .elasticclaw/clawpatch && clawpatch ci --format json --output .elasticclaw/clawpatch/report.json
+        continue_on_error: true
+        timeout: 15m
+      inject: |
+        Review the clawpatch report at .elasticclaw/clawpatch/report.json.
+        Fix issues you agree with.
+        Do not commit .elasticclaw/clawpatch files.
+        When fixes are complete, create the final commit and PR, then say [DONE].
 
   - id: pr_opened
     label: PR Opened

--- a/pkg/hub/checkpoints.go
+++ b/pkg/hub/checkpoints.go
@@ -1035,7 +1035,7 @@ func (s *Server) restoreCheckpointToSSH(clawID, user, host string) error {
 	sshCfg := &gossh.ClientConfig{
 		User:            user,
 		Auth:            []gossh.AuthMethod{gossh.PublicKeys(s.identity.PrivateKey)},
-		HostKeyCallback: gossh.InsecureIgnoreHostKey(),
+		HostKeyCallback: s.sshHostKeyCallback(host),
 		Timeout:         30 * time.Second,
 	}
 	client, err := gossh.Dial("tcp", host, sshCfg)

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -80,6 +80,15 @@ func migrate(db *sql.DB) error {
 	_, _ = db.Exec(`CREATE INDEX IF NOT EXISTS idx_claw_checkpoints_claw ON claw_checkpoints(claw_id, created_at)`)
 	_, _ = db.Exec(`CREATE INDEX IF NOT EXISTS idx_claw_checkpoints_status ON claw_checkpoints(status, created_at)`)
 
+	_, _ = db.Exec(`CREATE TABLE IF NOT EXISTS ssh_known_hosts (
+		host          TEXT PRIMARY KEY,
+		key_type      TEXT NOT NULL,
+		key_data      TEXT NOT NULL,
+		fingerprint   TEXT NOT NULL,
+		first_seen_at DATETIME NOT NULL,
+		last_seen_at  DATETIME NOT NULL
+	)`)
+
 	_, _ = db.Exec(`CREATE TABLE IF NOT EXISTS factory_triggers (
 		id             TEXT PRIMARY KEY,
 		factory_name   TEXT NOT NULL,
@@ -249,6 +258,15 @@ func migrate(db *sql.DB) error {
 	);
 	CREATE INDEX IF NOT EXISTS idx_claw_checkpoints_claw ON claw_checkpoints(claw_id, created_at);
 	CREATE INDEX IF NOT EXISTS idx_claw_checkpoints_status ON claw_checkpoints(status, created_at);
+
+	CREATE TABLE IF NOT EXISTS ssh_known_hosts (
+		host          TEXT PRIMARY KEY,
+		key_type      TEXT NOT NULL,
+		key_data      TEXT NOT NULL,
+		fingerprint   TEXT NOT NULL,
+		first_seen_at DATETIME NOT NULL,
+		last_seen_at  DATETIME NOT NULL
+	);
 
 	CREATE TABLE IF NOT EXISTS factory_events (
 		id           TEXT PRIMARY KEY,

--- a/pkg/hub/pipeline/pipeline.go
+++ b/pkg/hub/pipeline/pipeline.go
@@ -91,8 +91,18 @@ type MoveIssueAction struct {
 	IssueID string `yaml:"issue_id,omitempty"`
 }
 
+// RunAction executes a shell command in the agent workspace before the
+// remaining on_enter actions continue.
+type RunAction struct {
+	Command         string `yaml:"command"`
+	ContinueOnError bool   `yaml:"continue_on_error,omitempty"`
+	Timeout         string `yaml:"timeout,omitempty"`
+}
+
 // OnEnter holds the actions to run when entering a stage.
 type OnEnter struct {
+	// Run executes a command in the agent workspace.
+	Run RunAction `yaml:"run,omitempty"`
 	// Inject sends this message to the claw as a user message.
 	Inject string `yaml:"inject"`
 	// MoveIssue moves the associated Linear/Shortcut issue to this status name.
@@ -112,18 +122,20 @@ type OnEnter struct {
 func (oe *OnEnter) UnmarshalYAML(value *yaml.Node) error {
 	// Use a shadow type to avoid infinite recursion.
 	type rawOnEnter struct {
-		Inject       string            `yaml:"inject"`
-		MoveIssueRaw yaml.Node          `yaml:"move_issue"`
-		MergePR      bool              `yaml:"merge_pr,omitempty"`
-		CloseIssue   bool              `yaml:"close_issue,omitempty"`
-		AddLabels    []string          `yaml:"add_labels,omitempty"`
-		RemoveLabels []string          `yaml:"remove_labels,omitempty"`
+		Run          RunAction `yaml:"run,omitempty"`
+		Inject       string    `yaml:"inject"`
+		MoveIssueRaw yaml.Node `yaml:"move_issue"`
+		MergePR      bool      `yaml:"merge_pr,omitempty"`
+		CloseIssue   bool      `yaml:"close_issue,omitempty"`
+		AddLabels    []string  `yaml:"add_labels,omitempty"`
+		RemoveLabels []string  `yaml:"remove_labels,omitempty"`
 	}
 	var raw rawOnEnter
 	if err := value.Decode(&raw); err != nil {
 		return err
 	}
 
+	oe.Run = raw.Run
 	oe.Inject = raw.Inject
 	oe.MergePR = raw.MergePR
 	oe.CloseIssue = raw.CloseIssue

--- a/pkg/hub/pipeline/pipeline_test.go
+++ b/pkg/hub/pipeline/pipeline_test.go
@@ -74,6 +74,34 @@ stages:
 	}
 }
 
+func TestParseRunAction(t *testing.T) {
+	p, err := pipeline.Parse([]byte(`
+stages:
+  - id: pre_commit
+    on_enter:
+      run:
+        command: clawpatch ci --format json --output .elasticclaw/clawpatch/report.json
+        continue_on_error: true
+        timeout: 15m
+`))
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	if len(p.Stages) != 1 {
+		t.Fatalf("expected 1 stage, got %d", len(p.Stages))
+	}
+	run := p.Stages[0].OnEnter.Run
+	if run.Command != "clawpatch ci --format json --output .elasticclaw/clawpatch/report.json" {
+		t.Fatalf("command = %q", run.Command)
+	}
+	if !run.ContinueOnError {
+		t.Fatal("expected continue_on_error")
+	}
+	if run.Timeout != "15m" {
+		t.Fatalf("timeout = %q, want 15m", run.Timeout)
+	}
+}
+
 func TestEntryStage(t *testing.T) {
 	p, _ := pipeline.Parse([]byte(sampleYAML))
 	entry := p.EntryStage()

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -773,14 +773,14 @@ issueResolved:
 // transitionPipelineStage sets the claw's current pipeline stage and runs on_enter.
 // If the stage is terminal, it terminates the claw after running on_enter and
 // ensuring any injected message is delivered (waits if agent is streaming).
-func (s *Server) transitionPipelineStage(clawID string, stage pipeline.Stage, factory *types.FactoryConfig, issueID string) {
-	s.transitionPipelineStageWithContext(clawID, stage, pipelineContext{Factory: factory, IssueID: issueID})
+func (s *Server) transitionPipelineStage(clawID string, stage pipeline.Stage, factory *types.FactoryConfig, issueID string) bool {
+	return s.transitionPipelineStageWithContext(clawID, stage, pipelineContext{Factory: factory, IssueID: issueID})
 }
 
-func (s *Server) transitionPipelineStageWithContext(clawID string, stage pipeline.Stage, ctx pipelineContext) {
+func (s *Server) transitionPipelineStageWithContext(clawID string, stage pipeline.Stage, ctx pipelineContext) bool {
 	if !s.claimPipelineStageTransition(clawID, stage.ID) {
 		log.Printf("[pipeline] claw %s already in stage %q (%s), skipping duplicate transition", clawID[:8], stage.ID, stage.Label)
-		return
+		return false
 	}
 	log.Printf("[pipeline] claw %s → stage %q (%s)", clawID[:8], stage.ID, stage.Label)
 	s.runOnEnter(clawID, stage, ctx)
@@ -825,6 +825,7 @@ func (s *Server) transitionPipelineStageWithContext(clawID string, stage pipelin
 			go s.terminateVM(provider, providerID)
 		}
 	}
+	return true
 }
 
 // initializePipelineEntryIfNeeded transitions a claw into its entry pipeline stage
@@ -850,8 +851,7 @@ func (s *Server) initializePipelineEntryIfNeeded(clawID string) bool {
 		return false
 	}
 
-	s.transitionPipelineStageWithContext(clawID, *entry, ctx)
-	return strings.TrimSpace(entry.OnEnter.Inject) != ""
+	return s.transitionPipelineStageWithContext(clawID, *entry, ctx) && strings.TrimSpace(entry.OnEnter.Inject) != ""
 }
 
 // stopAgentWithReason is the centralized handler for unexpected agent termination.

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -395,7 +395,7 @@ func (s *Server) executePipelineRunAction(clawID string, action pipeline.RunActi
 		if sshHost == "" || sshPort == 0 || sshUser == "" {
 			return nil, fmt.Errorf("replicated agent has no SSH connection details")
 		}
-		return s.executeReplicatedPipelineRun(sshUser, fmt.Sprintf("%s:%d", sshHost, sshPort), workspaceCommand)
+		return s.executeReplicatedPipelineRun(sshUser, fmt.Sprintf("%s:%d", sshHost, sshPort), workspaceCommand, timeout)
 	case "noop":
 		return &pipelineRunResult{ExitCode: 0, Stdout: "noop provider skipped workflow command"}, nil
 	default:
@@ -403,11 +403,12 @@ func (s *Server) executePipelineRunAction(clawID string, action pipeline.RunActi
 	}
 }
 
-func (s *Server) executeReplicatedPipelineRun(user, host, command string) (*pipelineRunResult, error) {
-	if err := s.sshRun(user, host, command); err != nil {
-		return &pipelineRunResult{ExitCode: 1, Stderr: err.Error()}, err
+func (s *Server) executeReplicatedPipelineRun(user, host, command string, timeout time.Duration) (*pipelineRunResult, error) {
+	output, err := s.sshRunWithTimeout(user, host, command, timeout)
+	if err != nil {
+		return &pipelineRunResult{ExitCode: 1, Stderr: err.Error(), Stdout: output}, err
 	}
-	return &pipelineRunResult{ExitCode: 0}, nil
+	return &pipelineRunResult{ExitCode: 0, Stdout: output}, nil
 }
 
 func formatPipelineRunFailure(action pipeline.RunAction, result *pipelineRunResult, err error) string {

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -392,22 +392,12 @@ func (s *Server) executePipelineRunAction(clawID string, action pipeline.RunActi
 		}
 		return &pipelineRunResult{ExitCode: result.ExitCode, Stdout: result.Stdout, Stderr: result.Stderr}, err
 	case "replicated":
-		if sshHost == "" || sshPort == 0 || sshUser == "" {
-			return nil, fmt.Errorf("replicated agent has no SSH connection details")
-		}
-		return s.executeReplicatedPipelineRun(sshUser, fmt.Sprintf("%s:%d", sshHost, sshPort), workspaceCommand)
+		return nil, fmt.Errorf("workflow run actions are not supported for replicated agents until SSH host keys are verified")
 	case "noop":
 		return &pipelineRunResult{ExitCode: 0, Stdout: "noop provider skipped workflow command"}, nil
 	default:
 		return nil, fmt.Errorf("provider %q does not support workflow run actions", providerName)
 	}
-}
-
-func (s *Server) executeReplicatedPipelineRun(user, host, command string) (*pipelineRunResult, error) {
-	if err := s.sshRun(user, host, command); err != nil {
-		return &pipelineRunResult{ExitCode: 1, Stderr: err.Error()}, err
-	}
-	return &pipelineRunResult{ExitCode: 0}, nil
 }
 
 func formatPipelineRunFailure(action pipeline.RunAction, result *pipelineRunResult, err error) string {

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/elasticclaw/elasticclaw/pkg/hub/pipeline"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
-	gossh "golang.org/x/crypto/ssh"
 )
 
 // githubIssueDetails holds the fields we fetch for pipeline template rendering.
@@ -396,7 +395,7 @@ func (s *Server) executePipelineRunAction(clawID string, action pipeline.RunActi
 		if sshHost == "" || sshPort == 0 || sshUser == "" {
 			return nil, fmt.Errorf("replicated agent has no SSH connection details")
 		}
-		return s.executeReplicatedPipelineRun(sshUser, fmt.Sprintf("%s:%d", sshHost, sshPort), workspaceCommand, timeout)
+		return s.executeReplicatedPipelineRun(sshUser, fmt.Sprintf("%s:%d", sshHost, sshPort), workspaceCommand)
 	case "noop":
 		return &pipelineRunResult{ExitCode: 0, Stdout: "noop provider skipped workflow command"}, nil
 	default:
@@ -404,53 +403,11 @@ func (s *Server) executePipelineRunAction(clawID string, action pipeline.RunActi
 	}
 }
 
-func (s *Server) executeReplicatedPipelineRun(user, host, command string, timeout time.Duration) (*pipelineRunResult, error) {
-	sshCfg := &gossh.ClientConfig{
-		User:            user,
-		Auth:            []gossh.AuthMethod{gossh.PublicKeys(s.identity.PrivateKey)},
-		HostKeyCallback: gossh.InsecureIgnoreHostKey(),
-		Timeout:         30 * time.Second,
+func (s *Server) executeReplicatedPipelineRun(user, host, command string) (*pipelineRunResult, error) {
+	if err := s.sshRun(user, host, command); err != nil {
+		return &pipelineRunResult{ExitCode: 1, Stderr: err.Error()}, err
 	}
-	client, err := gossh.Dial("tcp", host, sshCfg)
-	if err != nil {
-		return nil, fmt.Errorf("ssh dial %s: %w", host, err)
-	}
-	defer client.Close()
-	sess, err := client.NewSession()
-	if err != nil {
-		return nil, fmt.Errorf("ssh session: %w", err)
-	}
-	defer sess.Close()
-
-	done := make(chan struct {
-		out []byte
-		err error
-	}, 1)
-	go func() {
-		out, err := sess.CombinedOutput("bash -lc " + checkpointShellQuote(command))
-		done <- struct {
-			out []byte
-			err error
-		}{out: out, err: err}
-	}()
-
-	timer := time.NewTimer(timeout)
-	defer timer.Stop()
-	select {
-	case res := <-done:
-		exitCode := 0
-		if res.err != nil {
-			exitCode = 1
-			if exitErr, ok := res.err.(*gossh.ExitError); ok {
-				exitCode = exitErr.ExitStatus()
-			}
-		}
-		result := &pipelineRunResult{ExitCode: exitCode, Stdout: string(res.out)}
-		return result, res.err
-	case <-timer.C:
-		_ = client.Close()
-		return nil, fmt.Errorf("command timed out after %s", timeout)
-	}
+	return &pipelineRunResult{ExitCode: 0}, nil
 }
 
 func formatPipelineRunFailure(action pipeline.RunAction, result *pipelineRunResult, err error) string {

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -392,12 +392,22 @@ func (s *Server) executePipelineRunAction(clawID string, action pipeline.RunActi
 		}
 		return &pipelineRunResult{ExitCode: result.ExitCode, Stdout: result.Stdout, Stderr: result.Stderr}, err
 	case "replicated":
-		return nil, fmt.Errorf("workflow run actions are not supported for replicated agents until SSH host keys are verified")
+		if sshHost == "" || sshPort == 0 || sshUser == "" {
+			return nil, fmt.Errorf("replicated agent has no SSH connection details")
+		}
+		return s.executeReplicatedPipelineRun(sshUser, fmt.Sprintf("%s:%d", sshHost, sshPort), workspaceCommand)
 	case "noop":
 		return &pipelineRunResult{ExitCode: 0, Stdout: "noop provider skipped workflow command"}, nil
 	default:
 		return nil, fmt.Errorf("provider %q does not support workflow run actions", providerName)
 	}
+}
+
+func (s *Server) executeReplicatedPipelineRun(user, host, command string) (*pipelineRunResult, error) {
+	if err := s.sshRun(user, host, command); err != nil {
+		return &pipelineRunResult{ExitCode: 1, Stderr: err.Error()}, err
+	}
+	return &pipelineRunResult{ExitCode: 0}, nil
 }
 
 func formatPipelineRunFailure(action pipeline.RunAction, result *pipelineRunResult, err error) string {

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -2,6 +2,7 @@ package hub
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/elasticclaw/elasticclaw/pkg/hub/pipeline"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
+	gossh "golang.org/x/crypto/ssh"
 )
 
 // githubIssueDetails holds the fields we fetch for pipeline template rendering.
@@ -324,8 +326,154 @@ func (s *Server) resolveGitHubIssuesTokenForPipeline(ctx pipelineContext) string
 	return ""
 }
 
+const defaultPipelineRunTimeout = 10 * time.Minute
+
+type pipelineRunResult struct {
+	ExitCode int
+	Stdout   string
+	Stderr   string
+}
+
+func (s *Server) executePipelineRunAction(clawID string, action pipeline.RunAction) (*pipelineRunResult, error) {
+	command := strings.TrimSpace(action.Command)
+	if command == "" {
+		return nil, nil
+	}
+	timeout := defaultPipelineRunTimeout
+	if strings.TrimSpace(action.Timeout) != "" {
+		parsed, err := time.ParseDuration(strings.TrimSpace(action.Timeout))
+		if err != nil {
+			return nil, fmt.Errorf("invalid run timeout %q: %w", action.Timeout, err)
+		}
+		timeout = parsed
+	}
+
+	var providerName, providerID, sshHost, sshUser string
+	var sshPort int
+	if err := s.db.QueryRow(`
+		SELECT COALESCE(provider,''), COALESCE(provider_id,''), COALESCE(ssh_host,''), COALESCE(ssh_port,0), COALESCE(ssh_user,'')
+		FROM claws WHERE id=?
+	`, clawID).Scan(&providerName, &providerID, &sshHost, &sshPort, &sshUser); err != nil {
+		return nil, fmt.Errorf("load agent provider: %w", err)
+	}
+	if providerID == "" {
+		return nil, fmt.Errorf("agent has no provider instance yet")
+	}
+
+	workspaceCommand := `cd "$HOME/.openclaw/workspace" && ` + command
+	ctx, cancel := context.WithTimeout(context.Background(), timeout+30*time.Second)
+	defer cancel()
+
+	s.mu.RLock()
+	provCfg, ok := s.hubCfg.Providers[providerName]
+	s.mu.RUnlock()
+	if !ok && providerName != "noop" {
+		return nil, fmt.Errorf("provider %q is not configured", providerName)
+	}
+
+	switch providerName {
+	case "daytona":
+		p, err := newDaytonaProvider(provCfg)
+		if err != nil {
+			return nil, fmt.Errorf("daytona init: %w", err)
+		}
+		result, err := p.ExecWithTimeout(ctx, providerID, []string{workspaceCommand}, timeout)
+		if result == nil {
+			return nil, err
+		}
+		return &pipelineRunResult{ExitCode: result.ExitCode, Stdout: result.Stdout, Stderr: result.Stderr}, err
+	case "exedev":
+		p, err := newExedevProvider(provCfg)
+		if err != nil {
+			return nil, fmt.Errorf("exedev init: %w", err)
+		}
+		result, err := p.Exec(ctx, providerID, []string{"bash", "-lc", workspaceCommand})
+		if result == nil {
+			return nil, err
+		}
+		return &pipelineRunResult{ExitCode: result.ExitCode, Stdout: result.Stdout, Stderr: result.Stderr}, err
+	case "replicated":
+		if sshHost == "" || sshPort == 0 || sshUser == "" {
+			return nil, fmt.Errorf("replicated agent has no SSH connection details")
+		}
+		return s.executeReplicatedPipelineRun(sshUser, fmt.Sprintf("%s:%d", sshHost, sshPort), workspaceCommand, timeout)
+	case "noop":
+		return &pipelineRunResult{ExitCode: 0, Stdout: "noop provider skipped workflow command"}, nil
+	default:
+		return nil, fmt.Errorf("provider %q does not support workflow run actions", providerName)
+	}
+}
+
+func (s *Server) executeReplicatedPipelineRun(user, host, command string, timeout time.Duration) (*pipelineRunResult, error) {
+	sshCfg := &gossh.ClientConfig{
+		User:            user,
+		Auth:            []gossh.AuthMethod{gossh.PublicKeys(s.identity.PrivateKey)},
+		HostKeyCallback: gossh.InsecureIgnoreHostKey(),
+		Timeout:         30 * time.Second,
+	}
+	client, err := gossh.Dial("tcp", host, sshCfg)
+	if err != nil {
+		return nil, fmt.Errorf("ssh dial %s: %w", host, err)
+	}
+	defer client.Close()
+	sess, err := client.NewSession()
+	if err != nil {
+		return nil, fmt.Errorf("ssh session: %w", err)
+	}
+	defer sess.Close()
+
+	done := make(chan struct {
+		out []byte
+		err error
+	}, 1)
+	go func() {
+		out, err := sess.CombinedOutput("bash -lc " + checkpointShellQuote(command))
+		done <- struct {
+			out []byte
+			err error
+		}{out: out, err: err}
+	}()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case res := <-done:
+		exitCode := 0
+		if res.err != nil {
+			exitCode = 1
+			if exitErr, ok := res.err.(*gossh.ExitError); ok {
+				exitCode = exitErr.ExitStatus()
+			}
+		}
+		result := &pipelineRunResult{ExitCode: exitCode, Stdout: string(res.out)}
+		return result, res.err
+	case <-timer.C:
+		_ = client.Close()
+		return nil, fmt.Errorf("command timed out after %s", timeout)
+	}
+}
+
+func formatPipelineRunFailure(action pipeline.RunAction, result *pipelineRunResult, err error) string {
+	command := strings.TrimSpace(action.Command)
+	if command == "" {
+		command = "(empty command)"
+	}
+	details := ""
+	if result != nil {
+		details = strings.TrimSpace(result.Stdout + "\n" + result.Stderr)
+	}
+	if details == "" && err != nil {
+		details = err.Error()
+	}
+	if details == "" {
+		details = "no command output"
+	}
+	return fmt.Sprintf("Workflow command failed: `%s`\n\n%s", command, sanitizeBootstrapOutput(details))
+}
+
 // runOnEnter executes the on_enter actions for a given stage.
 //
+// - stage.OnEnter.Run: executes a command in the agent workspace
 // - stage.OnEnter.Inject: injects a user message into the claw
 // - stage.OnEnter.MoveIssue: moves the Linear/Shortcut issue to the named status
 //
@@ -333,6 +481,24 @@ func (s *Server) resolveGitHubIssuesTokenForPipeline(ctx pipelineContext) string
 // MoveIssue.IssueID (including template references like {{.Inputs.xxx}}).
 func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineContext) {
 	issueID := ctx.IssueID
+	if strings.TrimSpace(stage.OnEnter.Run.Command) != "" {
+		log.Printf("[pipeline] running workflow command for claw %s stage %q: %s", clawID[:8], stage.ID, stage.OnEnter.Run.Command)
+		result, err := s.executePipelineRunAction(clawID, stage.OnEnter.Run)
+		if err != nil || (result != nil && result.ExitCode != 0) {
+			msg := formatPipelineRunFailure(stage.OnEnter.Run, result, err)
+			if stage.OnEnter.Run.ContinueOnError {
+				log.Printf("[pipeline] %s; continuing because continue_on_error=true", msg)
+				s.injectHubMessageByID(clawID, "[hub] Warning: "+msg)
+			} else {
+				log.Printf("[pipeline] %s", msg)
+				s.injectHubMessageByID(clawID, "[hub] Error: "+msg)
+				return
+			}
+		} else {
+			log.Printf("[pipeline] workflow command completed for claw %s stage %q", clawID[:8], stage.ID)
+		}
+	}
+
 	if stage.OnEnter.Inject != "" {
 		injectMsg := stage.OnEnter.Inject
 

--- a/pkg/hub/pipeline_runner_test.go
+++ b/pkg/hub/pipeline_runner_test.go
@@ -27,7 +27,9 @@ func TestTransitionPipelineStageSkipsDuplicateCurrentStage(t *testing.T) {
 			Inject: "PR created. Watch for CI results and review comments.",
 		},
 	}
-	s.transitionPipelineStageWithContext(clawID, stage, pipelineContext{})
+	if s.transitionPipelineStageWithContext(clawID, stage, pipelineContext{}) {
+		t.Fatalf("duplicate stage transition returned true")
+	}
 
 	var messageCount int
 	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=?`, clawID).Scan(&messageCount); err != nil {
@@ -62,14 +64,23 @@ func TestTransitionPipelineStageConcurrentCallsRunOnEnterOnce(t *testing.T) {
 	}
 
 	var wg sync.WaitGroup
+	var mu sync.Mutex
+	transitionCount := 0
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			s.transitionPipelineStageWithContext(clawID, stage, pipelineContext{})
+			if s.transitionPipelineStageWithContext(clawID, stage, pipelineContext{}) {
+				mu.Lock()
+				transitionCount++
+				mu.Unlock()
+			}
 		}()
 	}
 	wg.Wait()
+	if transitionCount != 1 {
+		t.Fatalf("concurrent stage transitions returned true %d times, want 1", transitionCount)
+	}
 
 	var messageCount int
 	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=?`, clawID).Scan(&messageCount); err != nil {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -4161,7 +4161,7 @@ func (s *Server) sshRun(user, host, script string) error {
 	sshCfg := &gossh.ClientConfig{
 		User:            user,
 		Auth:            []gossh.AuthMethod{gossh.PublicKeys(s.identity.PrivateKey)},
-		HostKeyCallback: gossh.InsecureIgnoreHostKey(),
+		HostKeyCallback: s.sshHostKeyCallback(host),
 		Timeout:         30 * time.Second,
 	}
 
@@ -4203,7 +4203,7 @@ func (s *Server) sshWriteFiles(user, host, dir string, files map[string]string) 
 	sshCfg := &gossh.ClientConfig{
 		User:            user,
 		Auth:            []gossh.AuthMethod{gossh.PublicKeys(s.identity.PrivateKey)},
-		HostKeyCallback: gossh.InsecureIgnoreHostKey(),
+		HostKeyCallback: s.sshHostKeyCallback(host),
 		Timeout:         30 * time.Second,
 	}
 	client, err := gossh.Dial("tcp", host, sshCfg)
@@ -4284,7 +4284,7 @@ func (s *Server) handleTerminal(w http.ResponseWriter, r *http.Request) {
 	sshCfg := &gossh.ClientConfig{
 		User:            sshUser,
 		Auth:            []gossh.AuthMethod{gossh.PublicKeys(s.identity.PrivateKey)},
-		HostKeyCallback: gossh.InsecureIgnoreHostKey(),
+		HostKeyCallback: s.sshHostKeyCallback(fmt.Sprintf("%s:%d", sshHost, sshPort)),
 		Timeout:         30 * time.Second,
 	}
 	sshAddr := fmt.Sprintf("%s:%d", sshHost, sshPort)

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -4153,6 +4153,17 @@ func (w *syncedWriter) Write(p []byte) (n int, err error) {
 
 // sshRun connects to host via the hub's SSH identity and runs a script.
 func (s *Server) sshRun(user, host, script string) error {
+	output, err := s.sshRunWithTimeout(user, host, script, 0)
+	if err != nil {
+		return err
+	}
+	log.Printf("bootstrap output:\n%s", output)
+	return nil
+}
+
+// sshRunWithTimeout connects to host via the hub's SSH identity and runs a script.
+// A zero timeout waits for the remote command to finish.
+func (s *Server) sshRunWithTimeout(user, host, script string, timeout time.Duration) (string, error) {
 	pubKeyType := s.identity.PrivateKey.PublicKey().Type()
 	pubKeyFP := gossh.FingerprintSHA256(s.identity.PrivateKey.PublicKey())
 	log.Printf("SSH attempting: user=%s host=%s key-type=%s fingerprint=%s", user, host, pubKeyType, pubKeyFP)
@@ -4167,13 +4178,13 @@ func (s *Server) sshRun(user, host, script string) error {
 
 	client, err := gossh.Dial("tcp", host, sshCfg)
 	if err != nil {
-		return fmt.Errorf("ssh dial %s: %w", host, err)
+		return "", fmt.Errorf("ssh dial %s: %w", host, err)
 	}
 	defer client.Close()
 
 	sess, err := client.NewSession()
 	if err != nil {
-		return fmt.Errorf("ssh session: %w", err)
+		return "", fmt.Errorf("ssh session: %w", err)
 	}
 	defer sess.Close()
 
@@ -4185,17 +4196,40 @@ func (s *Server) sshRun(user, host, script string) error {
 	sess.Stdout = syncWriter
 	sess.Stderr = syncWriter
 	sess.Stdin = strings.NewReader(script)
-	if err := sess.Run("/bin/bash"); err != nil {
+
+	runDone := make(chan error, 1)
+	go func() {
+		runDone <- sess.Run("/bin/bash")
+	}()
+	if timeout > 0 {
+		timer := time.NewTimer(timeout)
+		defer timer.Stop()
+		select {
+		case err := <-runDone:
+			if err != nil {
+				mu.Lock()
+				output := buf.String()
+				mu.Unlock()
+				return output, fmt.Errorf("ssh script failed: %w\noutput: %s", err, output)
+			}
+		case <-timer.C:
+			_ = sess.Close()
+			_ = client.Close()
+			mu.Lock()
+			output := buf.String()
+			mu.Unlock()
+			return output, fmt.Errorf("ssh script timed out after %s\noutput: %s", timeout, output)
+		}
+	} else if err := <-runDone; err != nil {
 		mu.Lock()
 		output := buf.String()
 		mu.Unlock()
-		return fmt.Errorf("ssh script failed: %w\noutput: %s", err, output)
+		return output, fmt.Errorf("ssh script failed: %w\noutput: %s", err, output)
 	}
 	mu.Lock()
 	output := buf.String()
 	mu.Unlock()
-	log.Printf("bootstrap output:\n%s", output)
-	return nil
+	return output, nil
 }
 
 // sshWriteFiles writes a map of filename->content to a remote directory via SSH.

--- a/pkg/hub/ssh_known_hosts.go
+++ b/pkg/hub/ssh_known_hosts.go
@@ -1,10 +1,11 @@
 package hub
 
 import (
-	"database/sql"
 	"encoding/base64"
 	"fmt"
 	"net"
+	"strings"
+	"time"
 
 	gossh "golang.org/x/crypto/ssh"
 )
@@ -16,6 +17,18 @@ func (s *Server) sshHostKeyCallback(host string) gossh.HostKeyCallback {
 }
 
 func (s *Server) verifySSHHostKey(host string, key gossh.PublicKey) error {
+	var err error
+	for attempt := 0; attempt < 20; attempt++ {
+		err = s.verifySSHHostKeyOnce(host, key)
+		if err == nil || !isSQLiteBusy(err) {
+			return err
+		}
+		time.Sleep(time.Duration(attempt+1) * 10 * time.Millisecond)
+	}
+	return err
+}
+
+func (s *Server) verifySSHHostKeyOnce(host string, key gossh.PublicKey) error {
 	if s == nil || s.db == nil {
 		return fmt.Errorf("ssh host key store is not available")
 	}
@@ -23,32 +36,26 @@ func (s *Server) verifySSHHostKey(host string, key gossh.PublicKey) error {
 	keyData := base64.StdEncoding.EncodeToString(key.Marshal())
 	fingerprint := gossh.FingerprintSHA256(key)
 
-	tx, err := s.db.Begin()
-	if err != nil {
-		return fmt.Errorf("ssh host key transaction: %w", err)
+	if _, err := s.db.Exec(`
+		INSERT OR IGNORE INTO ssh_known_hosts(host, key_type, key_data, fingerprint, first_seen_at, last_seen_at)
+		VALUES(?,?,?,?,?,?)
+	`, host, keyType, keyData, fingerprint, now(), now()); err != nil {
+		return fmt.Errorf("store ssh host key for %s: %w", host, err)
 	}
-	defer tx.Rollback()
 
 	var storedType, storedKey, storedFingerprint string
-	err = tx.QueryRow(`SELECT key_type, key_data, fingerprint FROM ssh_known_hosts WHERE host=?`, host).Scan(&storedType, &storedKey, &storedFingerprint)
-	if err == sql.ErrNoRows {
-		_, err = tx.Exec(`
-			INSERT INTO ssh_known_hosts(host, key_type, key_data, fingerprint, first_seen_at, last_seen_at)
-			VALUES(?,?,?,?,?,?)
-		`, host, keyType, keyData, fingerprint, now(), now())
-		if err != nil {
-			return fmt.Errorf("store ssh host key for %s: %w", host, err)
-		}
-		return tx.Commit()
-	}
-	if err != nil {
+	if err := s.db.QueryRow(`SELECT key_type, key_data, fingerprint FROM ssh_known_hosts WHERE host=?`, host).Scan(&storedType, &storedKey, &storedFingerprint); err != nil {
 		return fmt.Errorf("load ssh host key for %s: %w", host, err)
 	}
 	if storedType != keyType || storedKey != keyData {
 		return fmt.Errorf("ssh host key changed for %s: expected %s %s, got %s %s", host, storedType, storedFingerprint, keyType, fingerprint)
 	}
-	if _, err := tx.Exec(`UPDATE ssh_known_hosts SET last_seen_at=? WHERE host=?`, now(), host); err != nil {
+	if _, err := s.db.Exec(`UPDATE ssh_known_hosts SET last_seen_at=? WHERE host=?`, now(), host); err != nil {
 		return fmt.Errorf("update ssh host key for %s: %w", host, err)
 	}
-	return tx.Commit()
+	return nil
+}
+
+func isSQLiteBusy(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "database is locked")
 }

--- a/pkg/hub/ssh_known_hosts.go
+++ b/pkg/hub/ssh_known_hosts.go
@@ -1,0 +1,54 @@
+package hub
+
+import (
+	"database/sql"
+	"encoding/base64"
+	"fmt"
+	"net"
+
+	gossh "golang.org/x/crypto/ssh"
+)
+
+func (s *Server) sshHostKeyCallback(host string) gossh.HostKeyCallback {
+	return func(_ string, _ net.Addr, key gossh.PublicKey) error {
+		return s.verifySSHHostKey(host, key)
+	}
+}
+
+func (s *Server) verifySSHHostKey(host string, key gossh.PublicKey) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("ssh host key store is not available")
+	}
+	keyType := key.Type()
+	keyData := base64.StdEncoding.EncodeToString(key.Marshal())
+	fingerprint := gossh.FingerprintSHA256(key)
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("ssh host key transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	var storedType, storedKey, storedFingerprint string
+	err = tx.QueryRow(`SELECT key_type, key_data, fingerprint FROM ssh_known_hosts WHERE host=?`, host).Scan(&storedType, &storedKey, &storedFingerprint)
+	if err == sql.ErrNoRows {
+		_, err = tx.Exec(`
+			INSERT INTO ssh_known_hosts(host, key_type, key_data, fingerprint, first_seen_at, last_seen_at)
+			VALUES(?,?,?,?,?,?)
+		`, host, keyType, keyData, fingerprint, now(), now())
+		if err != nil {
+			return fmt.Errorf("store ssh host key for %s: %w", host, err)
+		}
+		return tx.Commit()
+	}
+	if err != nil {
+		return fmt.Errorf("load ssh host key for %s: %w", host, err)
+	}
+	if storedType != keyType || storedKey != keyData {
+		return fmt.Errorf("ssh host key changed for %s: expected %s %s, got %s %s", host, storedType, storedFingerprint, keyType, fingerprint)
+	}
+	if _, err := tx.Exec(`UPDATE ssh_known_hosts SET last_seen_at=? WHERE host=?`, now(), host); err != nil {
+		return fmt.Errorf("update ssh host key for %s: %w", host, err)
+	}
+	return tx.Commit()
+}

--- a/pkg/hub/ssh_known_hosts_test.go
+++ b/pkg/hub/ssh_known_hosts_test.go
@@ -3,6 +3,8 @@ package hub
 import (
 	"crypto/ed25519"
 	"crypto/rand"
+	"path/filepath"
+	"sync"
 	"testing"
 
 	gossh "golang.org/x/crypto/ssh"
@@ -28,6 +30,44 @@ func TestVerifySSHHostKeyTrustsFirstKeyAndRejectsChange(t *testing.T) {
 	}
 	if err := s.verifySSHHostKey(host, key2); err == nil {
 		t.Fatal("changed key should be rejected")
+	}
+}
+
+func TestVerifySSHHostKeyConcurrentFirstUse(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "hub.db")
+	db, err := openDB(dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+	s := &Server{db: db}
+
+	key := testSSHPublicKey(t)
+	host := "127.0.0.1:2223"
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 20)
+	for i := 0; i < cap(errs); i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs <- s.verifySSHHostKey(host, key)
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent first-use key should be accepted: %v", err)
+		}
+	}
+
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM ssh_known_hosts WHERE host=?`, host).Scan(&count); err != nil {
+		t.Fatalf("count known hosts: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("known host rows = %d, want 1", count)
 	}
 }
 

--- a/pkg/hub/ssh_known_hosts_test.go
+++ b/pkg/hub/ssh_known_hosts_test.go
@@ -1,0 +1,45 @@
+package hub
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"testing"
+
+	gossh "golang.org/x/crypto/ssh"
+)
+
+func TestVerifySSHHostKeyTrustsFirstKeyAndRejectsChange(t *testing.T) {
+	db, err := openDB(":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+	s := &Server{db: db}
+
+	key1 := testSSHPublicKey(t)
+	key2 := testSSHPublicKey(t)
+	host := "127.0.0.1:2222"
+
+	if err := s.verifySSHHostKey(host, key1); err != nil {
+		t.Fatalf("first key should be trusted: %v", err)
+	}
+	if err := s.verifySSHHostKey(host, key1); err != nil {
+		t.Fatalf("same key should be accepted: %v", err)
+	}
+	if err := s.verifySSHHostKey(host, key2); err == nil {
+		t.Fatal("changed key should be rejected")
+	}
+}
+
+func testSSHPublicKey(t *testing.T) gossh.PublicKey {
+	t.Helper()
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	key, err := gossh.NewPublicKey(pub)
+	if err != nil {
+		t.Fatalf("ssh public key: %v", err)
+	}
+	return key
+}

--- a/test/e2e/linear_test.go
+++ b/test/e2e/linear_test.go
@@ -44,6 +44,7 @@ func runLinearWorkflowE2E(t *testing.T, sandboxProvider string) {
 	linear := linearClient{token: env.LinearAPIKey}
 
 	var webhookID string
+	var labelID string
 	var issueID string
 	var issueIdentifier string
 	var agentID string
@@ -70,6 +71,9 @@ func runLinearWorkflowE2E(t *testing.T, sandboxProvider string) {
 		if issueID != "" {
 			_ = linear.archiveIssue(cleanupCtx, issueID)
 		}
+		if labelID != "" {
+			_ = linear.deleteLabel(cleanupCtx, labelID)
+		}
 		if webhookID != "" {
 			_ = linear.deleteWebhook(cleanupCtx, webhookID)
 		}
@@ -78,6 +82,9 @@ func runLinearWorkflowE2E(t *testing.T, sandboxProvider string) {
 
 	team := linear.teamByKey(ctx, t, env.LinearTeamKey)
 	linear.deleteE2EWebhooks(ctx, t)
+	labelName := "elasticclaw-e2e-" + env.RunID
+	linear.deleteLabelsByName(ctx, t, labelName)
+	labelID = linear.createLabel(ctx, t, team.ID, labelName)
 	triggerStateID := team.stateID(t, env.LinearTriggerState)
 	initialStateID := team.initialStateID(t, env.LinearInitialState, env.LinearTriggerState)
 
@@ -93,7 +100,7 @@ func runLinearWorkflowE2E(t *testing.T, sandboxProvider string) {
 	runCLI(ctx, t, root, env, "workflow", "push", "--workspace", workspaceName, filepath.Join(root, ".elasticclaw", "workflows", "linear.yaml"))
 
 	webhookID = linear.createWebhook(ctx, t, env.PublicURL+"/api/workspaces/"+workspaceName+"/webhooks/linear", team.ID, webhookSecret)
-	issue := linear.createIssue(ctx, t, team.ID, initialStateID, "Tell a dad joke. Do not make a PR.", "Tell a dad joke. Do not make a PR.\n\nElasticClaw E2E run: "+env.RunID)
+	issue := linear.createIssue(ctx, t, team.ID, initialStateID, labelID, "Tell a dad joke. Do not make a PR.", "Tell a dad joke. Do not make a PR.\n\nElasticClaw E2E run: "+env.RunID)
 	issueID = issue.ID
 	issueIdentifier = issue.Identifier
 	linear.updateIssueState(ctx, t, issueID, triggerStateID)
@@ -133,6 +140,8 @@ trigger:
     team: %s
     states:
       - %s
+    labels:
+      - %s
 
 concurrency_group: e2e-linear-%s
 
@@ -147,7 +156,7 @@ stages:
 
         Do exactly what this issue asks.
         Do not create a pull request.
-`, workflowName, env.LinearTeamKey, env.LinearTriggerState, env.RunID))
+`, workflowName, env.LinearTeamKey, env.LinearTriggerState, "elasticclaw-e2e-"+env.RunID, env.RunID))
 	return root
 }
 
@@ -308,7 +317,76 @@ func (c linearClient) deleteWebhook(ctx context.Context, id string) error {
 }`, map[string]interface{}{"id": id}, &out)
 }
 
-func (c linearClient) createIssue(ctx context.Context, t *testing.T, teamID, stateID, title, description string) linearIssue {
+func (c linearClient) createLabel(ctx context.Context, t *testing.T, teamID, name string) string {
+	t.Helper()
+	var out struct {
+		Data struct {
+			IssueLabelCreate struct {
+				Success bool `json:"success"`
+				Label   struct {
+					ID string `json:"id"`
+				} `json:"issueLabel"`
+			} `json:"issueLabelCreate"`
+		} `json:"data"`
+	}
+	vars := map[string]interface{}{
+		"input": map[string]interface{}{
+			"teamId": teamID,
+			"name":   name,
+			"color":  "#5E6AD2",
+		},
+	}
+	c.graphql(ctx, t, `mutation($input: IssueLabelCreateInput!) {
+  issueLabelCreate(input: $input) {
+    success
+    issueLabel { id }
+  }
+}`, vars, &out)
+	if !out.Data.IssueLabelCreate.Success || out.Data.IssueLabelCreate.Label.ID == "" {
+		t.Fatalf("Linear issueLabelCreate did not return a label id")
+	}
+	return out.Data.IssueLabelCreate.Label.ID
+}
+
+func (c linearClient) deleteLabelsByName(ctx context.Context, t *testing.T, name string) {
+	t.Helper()
+	var out struct {
+		Data struct {
+			IssueLabels struct {
+				Nodes []struct {
+					ID   string `json:"id"`
+					Name string `json:"name"`
+				} `json:"nodes"`
+			} `json:"issueLabels"`
+		} `json:"data"`
+	}
+	c.graphql(ctx, t, `query {
+  issueLabels {
+    nodes { id name }
+  }
+}`, nil, &out)
+	var deleteErr error
+	for _, label := range out.Data.IssueLabels.Nodes {
+		if label.Name == name {
+			if err := c.deleteLabel(ctx, label.ID); err != nil {
+				t.Logf("delete stale Linear E2E label %s: %v", label.ID, err)
+				deleteErr = err
+			}
+		}
+	}
+	if deleteErr != nil {
+		t.Fatalf("one or more Linear E2E labels named %q could not be deleted", name)
+	}
+}
+
+func (c linearClient) deleteLabel(ctx context.Context, id string) error {
+	var out map[string]interface{}
+	return c.graphqlNoFatal(ctx, `mutation($id: String!) {
+  issueLabelDelete(id: $id) { success }
+}`, map[string]interface{}{"id": id}, &out)
+}
+
+func (c linearClient) createIssue(ctx context.Context, t *testing.T, teamID, stateID, labelID, title, description string) linearIssue {
 	t.Helper()
 	var out struct {
 		Data struct {
@@ -326,6 +404,7 @@ func (c linearClient) createIssue(ctx context.Context, t *testing.T, teamID, sta
 		"input": map[string]interface{}{
 			"teamId":      teamID,
 			"stateId":     stateID,
+			"labelIds":    []string{labelID},
 			"title":       title,
 			"description": description,
 		},


### PR DESCRIPTION
## Summary
- add on_enter.run support for workflow stages
- execute run commands in the agent workspace for Daytona, Replicated, exe.dev, and noop test agents
- add persisted trust-on-first-use SSH host key verification for server SSH paths
- update the GitHub Issues workflow with a pre-commit Clawpatch stage

## Tests
- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./pkg/hub/pipeline ./pkg/hub