### PR TITLE
Ignore missing GitHub labels on removal

### DIFF
--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -171,6 +171,9 @@ func githubAPIDeleteLabel(baseURL, repo string, issueNumber int, label, token st
 	}
 	defer resp.Body.Close()
 	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode == http.StatusNotFound && strings.Contains(string(respBody), "Label does not exist") {
+		return nil
+	}
 	if resp.StatusCode >= 300 {
 		return fmt.Errorf("github API DELETE %s: %d %s", path, resp.StatusCode, string(respBody))
 	}

--- a/pkg/hub/pipeline_runner_test.go
+++ b/pkg/hub/pipeline_runner_test.go
@@ -47,12 +47,17 @@ func TestTransitionPipelineStageSkipsDuplicateCurrentStage(t *testing.T) {
 
 func TestGitHubAPIDeleteLabelIgnoresMissingLabel(t *testing.T) {
 	var sawDelete bool
+	var handlerErr string
 	github := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodDelete {
-			t.Fatalf("method = %s, want DELETE", r.Method)
+			handlerErr = "method = " + r.Method + ", want DELETE"
+			http.Error(w, handlerErr, http.StatusInternalServerError)
+			return
 		}
 		if r.URL.Path != "/repos/elasticclaw/elasticclaw/issues/305/labels/agent-ready" {
-			t.Fatalf("path = %s", r.URL.Path)
+			handlerErr = "path = " + r.URL.Path
+			http.Error(w, handlerErr, http.StatusInternalServerError)
+			return
 		}
 		sawDelete = true
 		w.WriteHeader(http.StatusNotFound)
@@ -62,6 +67,9 @@ func TestGitHubAPIDeleteLabelIgnoresMissingLabel(t *testing.T) {
 
 	if err := githubAPIDeleteLabel(github.URL, "elasticclaw/elasticclaw", 305, "agent-ready", "test-token"); err != nil {
 		t.Fatalf("githubAPIDeleteLabel returned error for missing label: %v", err)
+	}
+	if handlerErr != "" {
+		t.Fatal(handlerErr)
 	}
 	if !sawDelete {
 		t.Fatal("test server did not receive DELETE")

--- a/pkg/hub/pipeline_runner_test.go
+++ b/pkg/hub/pipeline_runner_test.go
@@ -1,6 +1,8 @@
 package hub
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"sync"
 	"testing"
 
@@ -40,6 +42,29 @@ func TestTransitionPipelineStageSkipsDuplicateCurrentStage(t *testing.T) {
 	}
 	if got := s.getPipelineStage(clawID); got != "pr_opened" {
 		t.Fatalf("pipeline stage = %q, want pr_opened", got)
+	}
+}
+
+func TestGitHubAPIDeleteLabelIgnoresMissingLabel(t *testing.T) {
+	var sawDelete bool
+	github := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Fatalf("method = %s, want DELETE", r.Method)
+		}
+		if r.URL.Path != "/repos/elasticclaw/elasticclaw/issues/305/labels/agent-ready" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		sawDelete = true
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"Label does not exist","status":"404"}`))
+	}))
+	t.Cleanup(github.Close)
+
+	if err := githubAPIDeleteLabel(github.URL, "elasticclaw/elasticclaw", 305, "agent-ready", "test-token"); err != nil {
+		t.Fatalf("githubAPIDeleteLabel returned error for missing label: %v", err)
+	}
+	if !sawDelete {
+		t.Fatal("test server did not receive DELETE")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Treat GitHub's missing-label 404 response as a successful no-op when removing issue labels
- Add a regression test for deleting an absent label

## Tests
- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./pkg/hub -run 'TestGitHubAPIDeleteLabelIgnoresMissingLabel|TestTransitionPipelineStage'
- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./pkg/hub