### PR TITLE
Improve agent activity transparency

### DIFF
--- a/.elasticclaw/workspaces/elasticclaw/AGENTS.md
+++ b/.elasticclaw/workspaces/elasticclaw/AGENTS.md
@@ -40,6 +40,11 @@ go version && node --version && npm --version && oras version
 docker version   # Docker is on the VM; use for container tests
 ```
 
+## Git
+
+You have a git credential helper installed. Use that to interaction with git and gh.
+NEVER force push and rebase unless you are resolving conflicts. When addressing standard feedback, it's preferable to push a new commit.
+
 ## Memory
 
 - **Daily notes:** `memory/YYYY-MM-DD.md` — log what you did, decisions made, blockers

--- a/.elasticclaw/workspaces/elasticclaw/USER.md
+++ b/.elasticclaw/workspaces/elasticclaw/USER.md
@@ -14,3 +14,4 @@
 - If you're blocked, say so clearly with what you tried
 - When sharing run/dev/test guidance, include exact commands and required prerequisites
 - Be explicit about which checks were run (`make test`, `go test ./...`, `make build-release`) and what still needs to be verified
+- NEVER force push when resolving CI or Greptile feedback. It's better to push a new commit.

--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -747,16 +747,29 @@ func sanitizeActivityText(value string) string {
 		{"GH_TOKEN=", "GH_TOKEN=[redacted]"},
 	}
 	for _, r := range replacers {
-		if idx := strings.Index(strings.ToLower(value), strings.ToLower(r.prefix)); idx >= 0 {
-			end := idx + len(r.prefix)
-			for end < len(value) && value[end] != ' ' && value[end] != '&' && value[end] != '"' && value[end] != '\'' {
-				end++
-			}
-			value = value[:idx] + r.value + value[end:]
-		}
+		value = redactActivityPrefix(value, r.prefix, r.value)
 	}
 	if len(value) > 240 {
 		value = value[:237] + "..."
+	}
+	return value
+}
+
+func redactActivityPrefix(value, prefix, replacement string) string {
+	offset := 0
+	lowerPrefix := strings.ToLower(prefix)
+	for offset < len(value) {
+		idx := strings.Index(strings.ToLower(value[offset:]), lowerPrefix)
+		if idx < 0 {
+			break
+		}
+		start := offset + idx
+		end := start + len(prefix)
+		for end < len(value) && value[end] != ' ' && value[end] != '&' && value[end] != '"' && value[end] != '\'' {
+			end++
+		}
+		value = value[:start] + replacement + value[end:]
+		offset = start + len(replacement)
 	}
 	return value
 }

--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -34,6 +34,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"syscall"
@@ -607,11 +608,157 @@ type agentResult struct {
 	err  error
 }
 
+type agentActivity struct {
+	Kind    string `json:"kind"`
+	Stream  string `json:"stream,omitempty"`
+	Phase   string `json:"phase,omitempty"`
+	Tool    string `json:"tool,omitempty"`
+	Detail  string `json:"detail,omitempty"`
+	Command string `json:"command,omitempty"`
+	Path    string `json:"path,omitempty"`
+	URL     string `json:"url,omitempty"`
+	Message string `json:"message,omitempty"`
+	Error   string `json:"error,omitempty"`
+}
+
 // inFlightState tracks a single in-progress agent turn.
 type inFlightState struct {
-	onChunk  func(string)
-	fullText strings.Builder
-	done     chan agentResult
+	onChunk             func(string)
+	onActivity          func(agentActivity)
+	fullText            strings.Builder
+	done                chan agentResult
+	mu                  sync.Mutex
+	activeTool          *agentActivity
+	activeToolStartedAt time.Time
+	lastToolPulseAt     time.Time
+	modelWaitStartedAt  time.Time
+	lastModelPulseAt    time.Time
+}
+
+func (inf *inFlightState) emitActivity(a agentActivity) {
+	if inf.onActivity != nil {
+		inf.onActivity(a)
+	}
+}
+
+func (inf *inFlightState) noteActivity(a agentActivity) {
+	if a.Kind != "tool" {
+		return
+	}
+	phase := strings.ToLower(strings.TrimSpace(a.Phase))
+	inf.mu.Lock()
+	defer inf.mu.Unlock()
+	switch phase {
+	case "running", "start", "started", "in_progress":
+		copy := a
+		if inf.activeTool == nil || inf.activeTool.Tool != copy.Tool || inf.activeTool.Command != copy.Command || inf.activeTool.Path != copy.Path || inf.activeTool.URL != copy.URL {
+			inf.activeToolStartedAt = time.Now()
+			inf.lastToolPulseAt = time.Time{}
+		}
+		inf.activeTool = &copy
+		inf.modelWaitStartedAt = time.Time{}
+		inf.lastModelPulseAt = time.Time{}
+	case "completed", "complete", "done", "failed", "error", "cancelled", "canceled":
+		inf.activeTool = nil
+		inf.activeToolStartedAt = time.Time{}
+		inf.lastToolPulseAt = time.Time{}
+		inf.modelWaitStartedAt = time.Now()
+		inf.lastModelPulseAt = time.Time{}
+	}
+}
+
+func (inf *inFlightState) noteAssistantChunk() {
+	inf.mu.Lock()
+	defer inf.mu.Unlock()
+	inf.modelWaitStartedAt = time.Time{}
+	inf.lastModelPulseAt = time.Time{}
+}
+
+func (inf *inFlightState) toolProgressPulse() (agentActivity, bool) {
+	inf.mu.Lock()
+	defer inf.mu.Unlock()
+	if inf.activeTool == nil || inf.activeToolStartedAt.IsZero() {
+		return agentActivity{}, false
+	}
+	now := time.Now()
+	elapsed := now.Sub(inf.activeToolStartedAt)
+	if elapsed < 90*time.Second {
+		return agentActivity{}, false
+	}
+	if !inf.lastToolPulseAt.IsZero() && now.Sub(inf.lastToolPulseAt) < 60*time.Second {
+		return agentActivity{}, false
+	}
+	inf.lastToolPulseAt = now
+	pulse := *inf.activeTool
+	pulse.Phase = "running"
+	pulse.Message = fmt.Sprintf("running for %s", formatActivityDuration(elapsed))
+	return pulse, true
+}
+
+func (inf *inFlightState) modelProgressPulse() (agentActivity, bool) {
+	inf.mu.Lock()
+	defer inf.mu.Unlock()
+	if inf.activeTool != nil || inf.modelWaitStartedAt.IsZero() {
+		return agentActivity{}, false
+	}
+	now := time.Now()
+	elapsed := now.Sub(inf.modelWaitStartedAt)
+	if elapsed < 90*time.Second {
+		return agentActivity{}, false
+	}
+	if !inf.lastModelPulseAt.IsZero() && now.Sub(inf.lastModelPulseAt) < 60*time.Second {
+		return agentActivity{}, false
+	}
+	inf.lastModelPulseAt = now
+	return agentActivity{
+		Kind:    "model_started",
+		Message: fmt.Sprintf("waiting for %s", formatActivityDuration(elapsed)),
+	}, true
+}
+
+func cleanAgentActivity(a agentActivity) agentActivity {
+	a.Tool = sanitizeActivityText(a.Tool)
+	a.Detail = sanitizeActivityText(a.Detail)
+	a.Command = sanitizeActivityText(a.Command)
+	a.Path = sanitizeActivityText(a.Path)
+	a.URL = sanitizeActivityText(a.URL)
+	a.Message = sanitizeActivityText(a.Message)
+	a.Error = sanitizeActivityText(a.Error)
+	return a
+}
+
+func sanitizeActivityText(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	replacers := []struct {
+		prefix string
+		value  string
+	}{
+		{"Bearer ", "Bearer [redacted]"},
+		{"token=", "token=[redacted]"},
+		{"access_token=", "access_token=[redacted]"},
+		{"api_key=", "api_key=[redacted]"},
+		{"OPENAI_API_KEY=", "OPENAI_API_KEY=[redacted]"},
+		{"ANTHROPIC_API_KEY=", "ANTHROPIC_API_KEY=[redacted]"},
+		{"FIREWORKS_API_KEY=", "FIREWORKS_API_KEY=[redacted]"},
+		{"GITHUB_TOKEN=", "GITHUB_TOKEN=[redacted]"},
+		{"GH_TOKEN=", "GH_TOKEN=[redacted]"},
+	}
+	for _, r := range replacers {
+		if idx := strings.Index(strings.ToLower(value), strings.ToLower(r.prefix)); idx >= 0 {
+			end := idx + len(r.prefix)
+			for end < len(value) && value[end] != ' ' && value[end] != '&' && value[end] != '"' && value[end] != '\'' {
+				end++
+			}
+			value = value[:idx] + r.value + value[end:]
+		}
+	}
+	if len(value) > 240 {
+		value = value[:237] + "..."
+	}
+	return value
 }
 
 // gatewaySession is a long-lived connection to the OpenClaw gateway that
@@ -866,11 +1013,23 @@ func (gs *gatewaySession) readLoop(ctx context.Context) {
 					Phase   string `json:"phase"`
 					Error   string `json:"error"`
 					Message string `json:"message"`
+					Tool    string `json:"tool"`
+					Name    string `json:"name"`
+					Command string `json:"command"`
+					Path    string `json:"path"`
+					URL     string `json:"url"`
+					URI     string `json:"uri"`
+					Meta    string `json:"meta"`
+					Status  string `json:"status"`
 				} `json:"data"`
 			}
 			if err := json.Unmarshal(frame.Payload, &agentPayload); err != nil {
 				continue
 			}
+			var rawAgentPayload struct {
+				Data map[string]interface{} `json:"data"`
+			}
+			_ = json.Unmarshal(frame.Payload, &rawAgentPayload)
 			if agentPayload.SessionKey != gs.sessionKey {
 				continue
 			}
@@ -884,9 +1043,49 @@ func (gs *gatewaySession) readLoop(ctx context.Context) {
 
 			if agentPayload.Stream == "assistant" && agentPayload.Data.Delta != "" {
 				inf.fullText.WriteString(agentPayload.Data.Delta)
+				inf.noteAssistantChunk()
 				if inf.onChunk != nil {
 					inf.onChunk(agentPayload.Data.Delta)
 				}
+			} else if agentPayload.Stream != "assistant" && agentPayload.Stream != "lifecycle" {
+				tool := agentPayload.Data.Tool
+				if tool == "" {
+					tool = agentPayload.Data.Name
+				}
+				kind := "activity"
+				switch {
+				case tool != "":
+					kind = "tool"
+				case strings.Contains(agentPayload.Stream, "tool"):
+					kind = "tool"
+				case strings.Contains(agentPayload.Stream, "diagnostic"):
+					kind = "diagnostic"
+				}
+				command := firstNonEmpty(
+					agentPayload.Data.Command,
+					nestedString(rawAgentPayload.Data, "command", "cmd", "shell_command", "shellCommand", "script", "argv", "input"),
+				)
+				path := firstNonEmpty(agentPayload.Data.Path, nestedString(rawAgentPayload.Data, "path", "file", "filename"))
+				url := firstNonEmpty(agentPayload.Data.URL, agentPayload.Data.URI, nestedString(rawAgentPayload.Data, "url", "uri"))
+				meta := firstNonEmpty(agentPayload.Data.Meta, nestedString(rawAgentPayload.Data, "meta"))
+				command, path, url, detail := resolveToolActivityDetail(tool, command, path, url, meta, rawAgentPayload.Data)
+				activity := cleanAgentActivity(agentActivity{
+					Kind:    kind,
+					Stream:  agentPayload.Stream,
+					Phase:   agentPayload.Data.Phase,
+					Tool:    tool,
+					Detail:  detail,
+					Command: command,
+					Path:    path,
+					URL:     url,
+					Message: firstNonEmpty(agentPayload.Data.Message, agentPayload.Data.Status),
+					Error:   agentPayload.Data.Error,
+				})
+				if kind == "tool" && activity.Command == "" && activity.Path == "" && activity.URL == "" && activity.Detail == "" {
+					logMissingToolActivityDetail(agentPayload.Stream, activity.Phase, activity.Tool, rawAgentPayload.Data)
+				}
+				inf.noteActivity(activity)
+				inf.emitActivity(activity)
 			}
 			if agentPayload.Stream == "lifecycle" {
 				switch agentPayload.Data.Phase {
@@ -902,10 +1101,220 @@ func (gs *gatewaySession) readLoop(ctx context.Context) {
 						msg = "agent lifecycle error"
 					}
 					log.Printf("[gateway] agent turn error: %s", msg)
+					inf.emitActivity(cleanAgentActivity(agentActivity{Kind: "session_error", Stream: "lifecycle", Phase: "error", Error: msg}))
 					inf.done <- agentResult{err: fmt.Errorf("%s", msg)}
 				}
 			}
 		}
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func resolveToolActivityDetail(tool, command, path, url, meta string, data map[string]interface{}) (string, string, string, string) {
+	detail := nestedString(data, "title", "summary", "description", "label", "display", "display_name", "displayName", "text")
+	cleanTool := strings.ToLower(strings.TrimSpace(tool))
+	cleanMeta := strings.TrimSpace(meta)
+	if cleanMeta == "" {
+		return command, path, url, detail
+	}
+	switch cleanTool {
+	case "exec", "bash":
+		if command == "" {
+			command = cleanMeta
+		}
+	case "read", "write", "edit", "attach", "memory_get":
+		if path == "" {
+			path = cleanMeta
+		}
+	case "web_fetch", "browser":
+		if url == "" && looksLikeURL(cleanMeta) {
+			url = cleanMeta
+		} else if detail == "" {
+			detail = cleanMeta
+		}
+	default:
+		if detail == "" {
+			detail = cleanMeta
+		}
+	}
+	return command, path, url, detail
+}
+
+func looksLikeURL(value string) bool {
+	value = strings.ToLower(strings.TrimSpace(value))
+	return strings.HasPrefix(value, "http://") || strings.HasPrefix(value, "https://")
+}
+
+func logMissingToolActivityDetail(stream, phase, tool string, data map[string]interface{}) {
+	log.Printf(
+		"[agent-activity] missing tool detail stream=%s phase=%s tool=%s keys=%s payload=%s",
+		sanitizeActivityText(stream),
+		sanitizeActivityText(phase),
+		sanitizeActivityText(tool),
+		strings.Join(sortedMapKeys(data), ","),
+		summarizeActivityPayload(data),
+	)
+}
+
+func sortedMapKeys(data map[string]interface{}) []string {
+	if len(data) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(data))
+	for key := range data {
+		keys = append(keys, sanitizeActivityText(key))
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func summarizeActivityPayload(data map[string]interface{}) string {
+	if len(data) == 0 {
+		return "{}"
+	}
+	cleaned := sanitizeActivityPayloadValue(data, 0)
+	bytes, err := json.Marshal(cleaned)
+	if err != nil {
+		return "{}"
+	}
+	return sanitizeActivityText(string(bytes))
+}
+
+func sanitizeActivityPayloadValue(value interface{}, depth int) interface{} {
+	if depth > 2 {
+		return "[nested]"
+	}
+	switch typed := value.(type) {
+	case map[string]interface{}:
+		out := make(map[string]interface{}, len(typed))
+		for key, child := range typed {
+			out[key] = sanitizeActivityPayloadValue(child, depth+1)
+		}
+		return out
+	case []interface{}:
+		limit := len(typed)
+		if limit > 4 {
+			limit = 4
+		}
+		out := make([]interface{}, 0, limit)
+		for _, child := range typed[:limit] {
+			out = append(out, sanitizeActivityPayloadValue(child, depth+1))
+		}
+		if len(typed) > limit {
+			out = append(out, fmt.Sprintf("... %d more", len(typed)-limit))
+		}
+		return out
+	case string:
+		return sanitizeActivityText(typed)
+	default:
+		return typed
+	}
+}
+
+func nestedString(data map[string]interface{}, keys ...string) string {
+	if len(data) == 0 {
+		return ""
+	}
+	for _, key := range keys {
+		if value := nestedValueString(data[key], keys...); value != "" {
+			return value
+		}
+	}
+	for _, containerKey := range []string{"raw_params", "params", "input", "arguments", "args", "request", "item", "tool_call", "toolCall", "call", "details", "metadata", "payload"} {
+		if value := nestedContainerString(data[containerKey], keys...); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func nestedContainerString(value interface{}, keys ...string) string {
+	switch typed := value.(type) {
+	case map[string]interface{}:
+		return nestedString(typed, keys...)
+	case []interface{}:
+		for _, item := range typed {
+			if value := nestedContainerString(item, keys...); value != "" {
+				return value
+			}
+		}
+	case string:
+		trimmed := strings.TrimSpace(typed)
+		if strings.HasPrefix(trimmed, "{") {
+			var nested map[string]interface{}
+			if err := json.Unmarshal([]byte(trimmed), &nested); err == nil {
+				return nestedString(nested, keys...)
+			}
+		}
+		if strings.HasPrefix(trimmed, "[") {
+			var nested []interface{}
+			if err := json.Unmarshal([]byte(trimmed), &nested); err == nil {
+				return nestedContainerString(nested, keys...)
+			}
+		}
+	}
+	return ""
+}
+
+func nestedValueString(value interface{}, keys ...string) string {
+	switch typed := value.(type) {
+	case map[string]interface{}:
+		return nestedString(typed, keys...)
+	case []interface{}:
+		var parts []string
+		for _, item := range typed {
+			if value := nestedValueString(item, keys...); value != "" {
+				parts = append(parts, value)
+			}
+		}
+		if len(parts) > 0 {
+			return strings.Join(parts, " ")
+		}
+	case string:
+		trimmed := strings.TrimSpace(typed)
+		if strings.HasPrefix(trimmed, "{") {
+			var nested map[string]interface{}
+			if err := json.Unmarshal([]byte(trimmed), &nested); err == nil {
+				if value := nestedString(nested, keys...); value != "" {
+					return value
+				}
+			}
+		}
+		if strings.HasPrefix(trimmed, "[") {
+			var nested []interface{}
+			if err := json.Unmarshal([]byte(trimmed), &nested); err == nil {
+				if value := nestedValueString(nested, keys...); value != "" {
+					return value
+				}
+			}
+		}
+		return trimmed
+	}
+	return stringFromUnknown(value)
+}
+
+func stringFromUnknown(value interface{}) string {
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	case []interface{}:
+		var parts []string
+		for _, item := range typed {
+			if value := stringFromUnknown(item); value != "" {
+				parts = append(parts, value)
+			}
+		}
+		return strings.TrimSpace(strings.Join(parts, " "))
+	default:
+		return ""
 	}
 }
 
@@ -965,14 +1374,15 @@ func (gs *gatewaySession) setReady() {
 
 // SendMessage sends a user message to the persistent session, streams chunks
 // via onChunk, and returns the full response text.
-func (gs *gatewaySession) SendMessage(ctx context.Context, message string, onChunk func(string)) (string, error) {
+func (gs *gatewaySession) SendMessage(ctx context.Context, message string, onChunk func(string), onActivity func(agentActivity)) (string, error) {
 	// Serialise: only one message in flight at a time
 	gs.sendMu.Lock()
 	defer gs.sendMu.Unlock()
 
 	inf := &inFlightState{
-		onChunk: onChunk,
-		done:    make(chan agentResult, 1),
+		onChunk:    onChunk,
+		onActivity: onActivity,
+		done:       make(chan agentResult, 1),
 	}
 	gs.infMu.Lock()
 	gs.inFlight = inf
@@ -992,19 +1402,42 @@ func (gs *gatewaySession) SendMessage(ctx context.Context, message string, onChu
 		return "", fmt.Errorf("sessions.send: %w", err)
 	}
 	log.Printf("[gateway] message sent, streaming response...")
+	inf.mu.Lock()
+	inf.modelWaitStartedAt = time.Now()
+	inf.lastModelPulseAt = time.Time{}
+	inf.mu.Unlock()
+	inf.emitActivity(agentActivity{Kind: "model_started", Message: "Waiting on model response"})
 
 	// Wait for lifecycle/end from the read loop
-	select {
-	case result := <-inf.done:
-		if result.err != nil {
-			return "", result.err
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case result := <-inf.done:
+			if result.err != nil {
+				return "", result.err
+			}
+			// Refresh context usage after each turn (best-effort)
+			go gs.refreshContextUsage(context.Background())
+			return result.text, nil
+		case <-ticker.C:
+			if pulse, ok := inf.toolProgressPulse(); ok {
+				inf.emitActivity(cleanAgentActivity(pulse))
+			} else if pulse, ok := inf.modelProgressPulse(); ok {
+				inf.emitActivity(cleanAgentActivity(pulse))
+			}
+		case <-ctx.Done():
+			return "", ctx.Err()
 		}
-		// Refresh context usage after each turn (best-effort)
-		go gs.refreshContextUsage(context.Background())
-		return result.text, nil
-	case <-ctx.Done():
-		return "", ctx.Err()
 	}
+}
+
+func formatActivityDuration(d time.Duration) string {
+	d = d.Round(time.Second)
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	return fmt.Sprintf("%dm%02ds", int(d.Minutes()), int(d.Seconds())%60)
 }
 
 // ─── bootstrap mode ─────────────────────────────────────────────────────────
@@ -1986,6 +2419,13 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 	}
 	log.Printf("registered with hub as %s", clawID)
 
+	writeActivity := func(connCtx context.Context, activity agentActivity) {
+		_ = wsjson.Write(connCtx, conn, hubMsg{
+			Type:    "agent_activity",
+			Payload: mustJSON(cleanAgentActivity(activity)),
+		})
+	}
+
 	// Replay any queued messages that arrived while we were disconnected
 	if queued := queue.drain(); len(queued) > 0 {
 		log.Printf("[bridge] replaying %d queued message(s)", len(queued))
@@ -1999,6 +2439,8 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 						Type:    "chunk",
 						Payload: mustJSON(map[string]interface{}{"role": "claw", "content": chunk}),
 					})
+				}, func(activity agentActivity) {
+					writeActivity(connCtx, activity)
 				})
 				if agentErr != nil {
 					reply = fmt.Sprintf("⚠️ error: %v", agentErr)
@@ -2087,6 +2529,8 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 							"content": chunk,
 						}),
 					})
+				}, func(activity agentActivity) {
+					writeActivity(connCtx, activity)
 				})
 				if agentErr != nil {
 					log.Printf("[bridge] ✗ agent error: %v", agentErr)

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -204,6 +204,20 @@ func TestResolveToolActivityDetailUsesOpenClawMeta(t *testing.T) {
 	}
 }
 
+func TestSanitizeActivityTextRedactsRepeatedSecretPrefixes(t *testing.T) {
+	input := `curl "https://api.example.com?access_token=abc&access_token=xyz" -H "Authorization: Bearer tok1" -H "X-Alt: Bearer tok2"`
+	got := sanitizeActivityText(input)
+	if strings.Contains(got, "abc") || strings.Contains(got, "xyz") || strings.Contains(got, "tok1") || strings.Contains(got, "tok2") {
+		t.Fatalf("sanitizeActivityText leaked secret: %q", got)
+	}
+	if strings.Count(got, "access_token=[redacted]") != 2 {
+		t.Fatalf("sanitizeActivityText redacted access_token count = %d, want 2 in %q", strings.Count(got, "access_token=[redacted]"), got)
+	}
+	if strings.Count(got, "Bearer [redacted]") != 2 {
+		t.Fatalf("sanitizeActivityText redacted bearer count = %d, want 2 in %q", strings.Count(got, "Bearer [redacted]"), got)
+	}
+}
+
 func TestPromoteInsufficientGatewayPairingPromotesReadOnlyDevice(t *testing.T) {
 	home := t.TempDir()
 	devicesDir := filepath.Join(home, ".openclaw", "devices")

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -100,6 +100,110 @@ func TestLoadGatewayClientEnvVarFallbackWhenNoConfigPassword(t *testing.T) {
 	}
 }
 
+func TestNestedStringExtractsToolCommandDetails(t *testing.T) {
+	tests := []struct {
+		name string
+		data map[string]interface{}
+		keys []string
+		want string
+	}{
+		{
+			name: "direct command",
+			data: map[string]interface{}{"command": "npm run build"},
+			keys: []string{"command", "cmd", "input"},
+			want: "npm run build",
+		},
+		{
+			name: "nested item arguments",
+			data: map[string]interface{}{
+				"item": map[string]interface{}{
+					"arguments": map[string]interface{}{"cmd": "go test ./pkg/hub"},
+				},
+			},
+			keys: []string{"command", "cmd", "input"},
+			want: "go test ./pkg/hub",
+		},
+		{
+			name: "json encoded args",
+			data: map[string]interface{}{
+				"input": `{"command":"npm run lint"}`,
+			},
+			keys: []string{"command", "cmd", "input"},
+			want: "npm run lint",
+		},
+		{
+			name: "argv array",
+			data: map[string]interface{}{
+				"arguments": map[string]interface{}{
+					"argv": []interface{}{"npm", "run", "test"},
+				},
+			},
+			keys: []string{"command", "cmd", "argv", "input"},
+			want: "npm run test",
+		},
+		{
+			name: "plain input is not path",
+			data: map[string]interface{}{
+				"input": "npm run build",
+			},
+			keys: []string{"path", "file", "filename"},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := nestedString(tt.data, tt.keys...); got != tt.want {
+				t.Fatalf("nestedString() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveToolActivityDetailUsesOpenClawMeta(t *testing.T) {
+	tests := []struct {
+		name        string
+		tool        string
+		meta        string
+		wantCommand string
+		wantPath    string
+		wantURL     string
+		wantDetail  string
+	}{
+		{
+			name:        "exec meta is command",
+			tool:        "exec",
+			meta:        "npm run build",
+			wantCommand: "npm run build",
+		},
+		{
+			name:     "read meta is path",
+			tool:     "read",
+			meta:     "/workspace/web/package.json",
+			wantPath: "/workspace/web/package.json",
+		},
+		{
+			name:    "web fetch url meta is url",
+			tool:    "web_fetch",
+			meta:    "https://example.com/docs",
+			wantURL: "https://example.com/docs",
+		},
+		{
+			name:       "unknown tool meta is detail",
+			tool:       "memory_search",
+			meta:       "query eslint",
+			wantDetail: "query eslint",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			command, path, url, detail := resolveToolActivityDetail(tt.tool, "", "", "", tt.meta, nil)
+			if command != tt.wantCommand || path != tt.wantPath || url != tt.wantURL || detail != tt.wantDetail {
+				t.Fatalf("resolveToolActivityDetail() = (%q, %q, %q, %q), want (%q, %q, %q, %q)", command, path, url, detail, tt.wantCommand, tt.wantPath, tt.wantURL, tt.wantDetail)
+			}
+		})
+	}
+}
+
 func TestPromoteInsufficientGatewayPairingPromotesReadOnlyDevice(t *testing.T) {
 	home := t.TempDir()
 	devicesDir := filepath.Join(home, ".openclaw", "devices")

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1163,7 +1163,7 @@ func (s *Server) handleClawDetail(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		// Look up provider info before deleting so we can terminate the VM
+		// Look up provider info before marking deleted so we can terminate the VM.
 		var provider, providerID string
 		_ = s.db.QueryRow(`SELECT COALESCE(provider,''), COALESCE(provider_id,'') FROM claws WHERE id = ? AND tenant_id = ?`, clawID, tenantID).Scan(&provider, &providerID)
 
@@ -1208,17 +1208,17 @@ func (s *Server) handleClawDetail(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		s.checkpointBeforeTermination(clawID, "manual-kill")
-
-		// Delete messages first (FK constraint)
-		_, _ = s.db.Exec(`DELETE FROM messages WHERE claw_id = ?`, clawID)
-		_, _ = s.db.Exec(`DELETE FROM claw_prs WHERE claw_id = ?`, clawID)
-		_, err := s.db.Exec(`DELETE FROM claws WHERE id = ? AND tenant_id = ?`, clawID, tenantID)
+		_, err := s.db.Exec(`UPDATE claws SET status='deleted', bootstrap_status='' WHERE id = ? AND tenant_id = ?`, clawID, tenantID)
 		if err != nil {
-			log.Printf("kill: db delete error for claw %s: %v", clawID, err)
+			log.Printf("kill: db soft-delete error for claw %s: %v", clawID, err)
 			http.Error(w, fmt.Sprintf("db error: %v", err), http.StatusInternalServerError)
 			return
 		}
+		// Notify dashboards before provider cleanup so the card disappears immediately.
+		s.broadcastToUsers(tenantID, types.WSMessage{
+			Type:    "claw_status",
+			Payload: map[string]string{"claw_id": clawID, "status": "deleted"},
+		})
 		// Disconnect WebSocket if online
 		s.mu.Lock()
 		if cc, ok := s.claws[clawID]; ok {
@@ -1226,10 +1226,14 @@ func (s *Server) handleClawDetail(w http.ResponseWriter, r *http.Request) {
 			delete(s.claws, clawID)
 		}
 		s.mu.Unlock()
-		// Terminate the provider instance asynchronously
-		if providerID != "" {
-			go s.terminateVM(provider, providerID)
-		}
+		go func() {
+			s.checkpointBeforeTermination(clawID, "manual-kill")
+			if providerID != "" {
+				s.terminateVM(provider, providerID)
+			}
+			_, _ = s.db.Exec(`DELETE FROM messages WHERE claw_id = ?`, clawID)
+			_, _ = s.db.Exec(`DELETE FROM claw_prs WHERE claw_id = ?`, clawID)
+		}()
 		// Promote any pending claws now that a slot is free
 		go s.promotePendingClaws()
 		w.WriteHeader(http.StatusNoContent)
@@ -1240,7 +1244,7 @@ func (s *Server) handleClawDetail(w http.ResponseWriter, r *http.Request) {
 	var lastSeen sql.NullTime
 	var tagsJSON string
 	err := s.db.QueryRow(
-		`SELECT id, name, template, COALESCE(provider,''), COALESCE(provider_id,''), status, last_seen, created_at, ssh_host, ssh_port, ssh_user, COALESCE(tags,'[]'), COALESCE(color,''), COALESCE(bootstrap_status,'') FROM claws WHERE id = ? AND tenant_id = ?`,
+		`SELECT id, name, template, COALESCE(provider,''), COALESCE(provider_id,''), status, last_seen, created_at, ssh_host, ssh_port, ssh_user, COALESCE(tags,'[]'), COALESCE(color,''), COALESCE(bootstrap_status,'') FROM claws WHERE id = ? AND tenant_id = ? AND status != 'deleted'`,
 		clawID, tenantID,
 	).Scan(&c.ID, &c.Name, &c.Template, &c.Provider, &c.ProviderID, &c.Status, &lastSeen, &c.CreatedAt, &c.SSHHost, &c.SSHPort, &c.SSHUser, &tagsJSON, &c.Color, &c.BootstrapStatus)
 	_ = json.Unmarshal([]byte(tagsJSON), &c.Tags)
@@ -1389,7 +1393,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	if before != "" {
 		// Fetch older messages — return in ASC order after fetching DESC
 		rows, err = s.db.Query(
-			`SELECT id, claw_id, tenant_id, role, content, created_at FROM messages
+			`SELECT id, claw_id, tenant_id, role, content, COALESCE(format,''), created_at FROM messages
 			 WHERE claw_id = ? AND tenant_id = ? AND created_at < ?
 			 AND NOT (role = 'system' AND content IN (?, ?, ?))
 			 ORDER BY created_at DESC LIMIT ?`,
@@ -1397,7 +1401,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		)
 	} else if after != "" {
 		rows, err = s.db.Query(
-			`SELECT id, claw_id, tenant_id, role, content, created_at FROM messages
+			`SELECT id, claw_id, tenant_id, role, content, COALESCE(format,''), created_at FROM messages
 			 WHERE claw_id = ? AND tenant_id = ? AND created_at > ?
 			 AND NOT (role = 'system' AND content IN (?, ?, ?))
 			 ORDER BY created_at ASC LIMIT ?`,
@@ -1406,7 +1410,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	} else {
 		// Default: last N messages
 		rows, err = s.db.Query(
-			`SELECT id, claw_id, tenant_id, role, content, created_at FROM messages
+			`SELECT id, claw_id, tenant_id, role, content, COALESCE(format,''), created_at FROM messages
 			 WHERE claw_id = ? AND tenant_id = ?
 			 AND NOT (role = 'system' AND content IN (?, ?, ?))
 			 ORDER BY created_at DESC LIMIT ?`,
@@ -1421,7 +1425,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	var msgs []types.HubMessage
 	for rows.Next() {
 		var m types.HubMessage
-		if err := rows.Scan(&m.ID, &m.ClawID, &m.TenantID, &m.Role, &m.Content, &m.CreatedAt); err != nil {
+		if err := rows.Scan(&m.ID, &m.ClawID, &m.TenantID, &m.Role, &m.Content, &m.Format, &m.CreatedAt); err != nil {
 			continue
 		}
 		msgs = append(msgs, m)
@@ -1762,6 +1766,26 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 							cc.mu.Unlock()
 						}
 					}
+				}
+			} else if msg.Type == "agent_activity" {
+				payload, _ := json.Marshal(msg.Payload)
+				var activity map[string]interface{}
+				if err := json.Unmarshal(payload, &activity); err == nil {
+					createdAt := now()
+					activity["claw_id"] = clawID
+					activity["created_at"] = createdAt.Format(time.RFC3339Nano)
+					content := activityContent(activity)
+					if content != "" && !isUnhelpfulActivityContent(activity, content) {
+						format := "activity:" + string(payload)
+						_, _ = s.db.Exec(
+							`INSERT INTO messages(id,claw_id,tenant_id,role,content,format,created_at) VALUES(?,?,?,?,?,?,?)`,
+							uuid.New().String(), clawID, tenantID, "activity", content, format, createdAt,
+						)
+					}
+					s.broadcastToUsers(tenantID, types.WSMessage{
+						Type:    "agent_activity",
+						Payload: activity,
+					})
 				}
 			} else if msg.Type == "chunk" {
 				// Streaming chunk — forward to users immediately AND buffer server-side
@@ -2250,6 +2274,7 @@ func (s *Server) provisionDaytona(ctx context.Context, clawID string, req types.
 	if err != nil {
 		return fmt.Errorf("daytona init: %w", err)
 	}
+	s.setBootstrapStatus(clawID, "Creating sandbox")
 	// Resolve snapshot: template snapshot > hub default_snapshot
 	snapshot := req.Snapshot
 	if snapshot == "" {
@@ -2300,9 +2325,10 @@ func (s *Server) provisionDaytona(ctx context.Context, clawID string, req types.
 
 func (s *Server) bootstrapDaytona(ctx context.Context, clawID, clawName, instanceID string, p *daytona.Provider, env map[string]string) error {
 	log.Printf("[daytona] bootstrapping claw %s (instance %s)", clawID, instanceID)
-	s.setBootstrapStatus(clawID, "Preparing ElasticClaw workspace")
+	s.setBootstrapStatus(clawID, "Preparing runtime")
 
 	exec := func(label string, timeout time.Duration, cmd string) error {
+		s.setBootstrapStatus(clawID, daytonaBootstrapStatusForStep(label))
 		const maxAttempts = 3
 		var lastErr error
 		for attempt := 1; attempt <= maxAttempts; attempt++ {
@@ -2413,6 +2439,7 @@ docker --version`); err != nil {
 	}
 
 	// Step 2: Onboard (configure OpenClaw) with the correct auth provider
+	s.setBootstrapStatus(clawID, "Configuring OpenClaw")
 	var llmKeyNameDaytona string
 	_ = s.db.QueryRow(`SELECT COALESCE(llm_key,'') FROM claws WHERE id=?`, clawID).Scan(&llmKeyNameDaytona)
 	activeKeyNameDaytona := ""
@@ -2523,6 +2550,7 @@ exit 1`
 
 	// Step 3: Download claw-bridge now, but do not start it until the workspace,
 	// template files, and bootstrap gating are fully ready.
+	s.setBootstrapStatus(clawID, "Preparing workspace")
 	bridgeURL := s.bridgeDownloadURL()
 	if bridgeURL == "" {
 		return fmt.Errorf("claw-bridge URL not configured: set bridge_image in hub.yaml (e.g. bridge_image: ttl.sh/your/claw-bridge:tag) or build a tagged release")
@@ -2550,6 +2578,7 @@ cp "$BIN" /tmp/claw-bridge.download && chmod +x /tmp/claw-bridge.download && mv 
 
 	// Write template files (SOUL.md, AGENTS.md, etc.) to the workspace before
 	// the bridge starts so BOOTSTRAP.md and friends are present for the first turn.
+	s.setBootstrapStatus(clawID, "Preparing workspace")
 	var filesJSON string
 	_ = s.db.QueryRow(`SELECT COALESCE(template_files,'{}') FROM claws WHERE id=?`, clawID).Scan(&filesJSON)
 	var templateFiles map[string]string
@@ -2586,6 +2615,7 @@ ELASTICCLAW_EOF`,
 	}
 	hasGitHubApps := hasHubGitHubApps || hasWorkspaceGitHubApps
 	if hasGitHubApps {
+		s.setBootstrapStatus(clawID, "Preparing repository access")
 		// Use the hub directly during bootstrap. The bridge is intentionally not
 		// started yet so startup cannot race ahead of template file writes and
 		// bootstrap_ok gating.
@@ -2724,6 +2754,7 @@ gh auth status`
 			log.Printf("[daytona] verify gh auth done")
 
 			log.Printf("[daytona] cloning %d repositories for claw %s", len(repositories), clawID)
+			s.setBootstrapStatus(clawID, "Syncing repositories")
 			for i, repo := range repositories {
 				log.Printf("[daytona] repository[%d]: %s", i, repo.Repo)
 			}
@@ -2774,6 +2805,7 @@ gh auth status`
 
 	_, _ = s.db.Exec(`UPDATE claws SET bootstrap_ok=1 WHERE id=?`, clawID)
 	log.Printf("[daytona] bootstrap gated ready for claw %s", clawID)
+	s.setBootstrapStatus(clawID, "Connecting to hub")
 
 	// Start the bridge last so the first registration happens only after the
 	// workspace, template files, GitHub setup, and bootstrap_ok gate are ready.
@@ -3003,6 +3035,62 @@ func (s *Server) setBootstrapStatus(clawID, status string) {
 			"bootstrap_status": status,
 		},
 	})
+}
+
+func activityContent(activity map[string]interface{}) string {
+	for _, key := range []string{"error", "command", "path", "url", "detail"} {
+		if value, ok := activity[key].(string); ok && strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	if value, ok := activity["message"].(string); ok && strings.TrimSpace(value) != "" && !isPhaseActivityText(value) {
+		return strings.TrimSpace(value)
+	}
+	if value, ok := activity["tool"].(string); ok && strings.TrimSpace(value) != "" {
+		return strings.TrimSpace(value)
+	}
+	for _, key := range []string{"phase", "stream"} {
+		if value, ok := activity[key].(string); ok && strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return "Activity"
+}
+
+func isPhaseActivityText(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "running", "completed", "complete", "done", "failed", "error":
+		return true
+	default:
+		return false
+	}
+}
+
+func isUnhelpfulActivityContent(activity map[string]interface{}, content string) bool {
+	if kind, _ := activity["kind"].(string); kind == "still_working" {
+		return true
+	}
+	return strings.HasPrefix(content, "No streamed output")
+}
+
+func daytonaBootstrapStatusForStep(label string) string {
+	switch label {
+	case "uninstall old openclaw", "install openclaw", "verify openclaw":
+		return "Preparing runtime"
+	case "install nix", "install docker", "preflight required commands", "stage openclaw plugin deps":
+		return "Preparing runtime"
+	case "configure openclaw model", "start openclaw gateway":
+		return "Configuring OpenClaw"
+	case "install git credential helper", "install gh cli", "fetch github bootstrap token json", "parse github bootstrap token", "write github token env":
+		return "Preparing repository access"
+	case "write SOUL.md", "write AGENTS.md", "write BOOTSTRAP.md", "write CONTEXT.md":
+		return "Preparing workspace"
+	default:
+		if strings.HasPrefix(label, "write ") {
+			return "Preparing workspace"
+		}
+		return "Preparing sandbox"
+	}
 }
 
 func formatRetryDelay(d time.Duration) string {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1768,9 +1768,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 					}
 				}
 			} else if msg.Type == "agent_activity" {
-				payload, _ := json.Marshal(msg.Payload)
-				var activity map[string]interface{}
-				if err := json.Unmarshal(payload, &activity); err == nil {
+				if activity, payload, ok := normalizeAgentActivityPayload(msg.Payload); ok {
 					createdAt := now()
 					activity["claw_id"] = clawID
 					activity["created_at"] = createdAt.Format(time.RFC3339Nano)
@@ -2374,21 +2372,26 @@ echo uninstalled`); err != nil {
 
 	const daytonaOpenClawVersion = "2026.5.20"
 	if err := exec("install openclaw", 3*time.Minute,
-		fmt.Sprintf(`export NVM_DIR=/usr/local/share/nvm; export PATH=$NVM_DIR/current/bin:$PATH; \
-PREFIX="$(/usr/local/share/nvm/current/bin/npm config get prefix)"; \
-echo "npm=$NVM_DIR/current/bin/npm prefix=$PREFIX"; \
-sudo env PATH="$NVM_DIR/current/bin:$PATH" npm install -g openclaw@%s --prefix "$PREFIX" --ignore-scripts 2>&1; \
+		fmt.Sprintf(`export NVM_DIR=/usr/local/share/nvm; \
+NPM="$NVM_DIR/current/bin/npm"; \
+PREFIX="$("$NPM" config get prefix)"; \
+export PATH="$PREFIX/bin:$NVM_DIR/current/bin:/usr/local/bin:$PATH"; \
+echo "npm=$NPM prefix=$PREFIX"; \
+sudo env PATH="$PREFIX/bin:$NVM_DIR/current/bin:/usr/local/bin:$PATH" "$NPM" install -g openclaw@%s --prefix "$PREFIX" --ignore-scripts 2>&1; \
 hash -r; \
 echo 'install done'`, daytonaOpenClawVersion)); err != nil {
 		return err
 	}
 
 	if err := exec("verify openclaw", 20*time.Second,
-		fmt.Sprintf(`export NVM_DIR=/usr/local/share/nvm; export PATH=$NVM_DIR/current/bin:$PATH; \
+		fmt.Sprintf(`export NVM_DIR=/usr/local/share/nvm; \
+NPM="$NVM_DIR/current/bin/npm"; \
+PREFIX="$("$NPM" config get prefix)"; \
+export PATH="$PREFIX/bin:$NVM_DIR/current/bin:/usr/local/bin:$PATH"; \
 hash -r; \
 OPENCLAW_PATH="$(command -v openclaw || true)"; \
 OPENCLAW_VERSION="$(openclaw --version 2>&1 || true)"; \
-PACKAGE_VERSION="$(node -e "try{console.log(require('$NVM_DIR/current/lib/node_modules/openclaw/package.json').version)}catch(e){process.exit(0)}" 2>/dev/null || true)"; \
+PACKAGE_VERSION="$(PREFIX="$PREFIX" node -e "try{console.log(require(process.env.PREFIX + '/lib/node_modules/openclaw/package.json').version)}catch(e){process.exit(0)}" 2>/dev/null || true)"; \
 echo "openclaw path=$OPENCLAW_PATH"; \
 echo "openclaw version=$OPENCLAW_VERSION"; \
 echo "openclaw package_version=$PACKAGE_VERSION"; \
@@ -3055,6 +3058,18 @@ func activityContent(activity map[string]interface{}) string {
 		}
 	}
 	return "Activity"
+}
+
+func normalizeAgentActivityPayload(payload interface{}) (map[string]interface{}, []byte, bool) {
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return nil, nil, false
+	}
+	var activity map[string]interface{}
+	if err := json.Unmarshal(raw, &activity); err != nil || activity == nil {
+		return nil, nil, false
+	}
+	return activity, raw, true
 }
 
 func isPhaseActivityText(value string) bool {

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -626,3 +626,12 @@ func TestBroadcastToUsersFiltersGitHubSessionsByClawTags(t *testing.T) {
 		t.Fatalf("expected alice recipient, got %q", recipients[0].githubLogin)
 	}
 }
+
+func TestNormalizeAgentActivityPayloadRejectsNull(t *testing.T) {
+	if activity, raw, ok := normalizeAgentActivityPayload(nil); ok || activity != nil || raw != nil {
+		t.Fatalf("nil payload normalized to activity=%v raw=%q ok=%v", activity, raw, ok)
+	}
+	if activity, raw, ok := normalizeAgentActivityPayload(map[string]interface{}{"kind": "tool", "tool": "exec"}); !ok || activity["tool"] != "exec" || len(raw) == 0 {
+		t.Fatalf("valid payload normalized to activity=%v raw=%q ok=%v", activity, raw, ok)
+	}
+}

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -311,6 +311,60 @@ func TestGitHubAccessChecksReturnNotFoundForMissingClaw(t *testing.T) {
 	}
 }
 
+func TestDeleteClawSoftDeletesAndHidesFromAPI(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, nil, "", "", "")
+	_, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, tags, created_at, status) VALUES(?,?,?,?,datetime('now'),?)`,
+		"claw-1", "test-tenant-id", "claw 1", `[]`, "connected",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/claws/claw-1", nil)
+	req = req.WithContext(context.WithValue(req.Context(), ctxTenantKey{}, "test-tenant-id"))
+	req.SetPathValue("id", "claw-1")
+	rec := httptest.NewRecorder()
+
+	s.handleClawDetail(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected status %d, got %d", http.StatusNoContent, rec.Code)
+	}
+
+	var status string
+	if err := db.QueryRow(`SELECT status FROM claws WHERE id=?`, "claw-1").Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	if status != "deleted" {
+		t.Fatalf("expected claw status deleted, got %q", status)
+	}
+
+	listReq := httptest.NewRequest(http.MethodGet, "/api/claws", nil)
+	listReq = listReq.WithContext(context.WithValue(listReq.Context(), ctxTenantKey{}, "test-tenant-id"))
+	listRec := httptest.NewRecorder()
+	s.handleClaws(listRec, listReq)
+	if listRec.Code != http.StatusOK {
+		t.Fatalf("expected list status %d, got %d", http.StatusOK, listRec.Code)
+	}
+	var claws []types.Claw
+	if err := json.NewDecoder(listRec.Body).Decode(&claws); err != nil {
+		t.Fatal(err)
+	}
+	if len(claws) != 0 {
+		t.Fatalf("expected deleted claw to be hidden from list, got %#v", claws)
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/api/claws/claw-1", nil)
+	getReq = getReq.WithContext(context.WithValue(getReq.Context(), ctxTenantKey{}, "test-tenant-id"))
+	getReq.SetPathValue("id", "claw-1")
+	getRec := httptest.NewRecorder()
+	s.handleClawDetail(getRec, getReq)
+	if getRec.Code != http.StatusNotFound {
+		t.Fatalf("expected detail status %d, got %d", http.StatusNotFound, getRec.Code)
+	}
+}
+
 func TestClawSubresourceRequiresTagAccessForGitHubSession(t *testing.T) {
 	s, db := NewTestServerWithConfig(t, &types.HubConfig{
 		Auth: &types.AuthConfig{

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -63,7 +63,6 @@ export default function Home() {
   // Build merged messages:
   // - no chunks yet → append a "thinking" placeholder
   // - chunks flowing → append the partial typewriter text
-  // - chunks paused (tool call) → append text + a gap marker
   // - done → nothing (final message already in messages)
   const mergedMessages = useMemo((): Record<string, Message[]> => {
     const result: Record<string, Message[]> = { ...messages }
@@ -79,15 +78,6 @@ export default function Home() {
         }]
       } else {
         const msgs: Message[] = [...existing]
-        if (state.isPaused) {
-          // Gap separator for tool call
-          msgs.push({
-            id: `gap-${clawId}`,
-            role: "system" as const,
-            content: "__TOOL_GAP__",
-            timestamp: new Date(),
-          })
-        }
         if (state.text) {
           msgs.push({
             id: `streaming-${clawId}`,

--- a/web/components/bootstrap-progress.tsx
+++ b/web/components/bootstrap-progress.tsx
@@ -1,0 +1,148 @@
+"use client"
+
+import { CheckCircle2, Circle, Loader2 } from "lucide-react"
+import type { Claw } from "@/lib/types"
+import { cn } from "@/lib/utils"
+
+const STEPS = [
+  { key: "sandbox", label: "Sandbox" },
+  { key: "runtime", label: "Runtime" },
+  { key: "openclaw", label: "OpenClaw" },
+  { key: "workspace", label: "Workspace" },
+  { key: "connect", label: "Connect" },
+] as const
+
+type StepKey = typeof STEPS[number]["key"]
+
+function activeStep(status?: string): StepKey {
+  const value = (status || "").toLowerCase()
+  if (value.includes("connecting to hub") || value.includes("starting elasticclaw connector")) return "connect"
+  if (value.includes("repo") || value.includes("workspace") || value.includes("sync")) return "workspace"
+  if (value.includes("configuring openclaw") || value.includes("gateway")) return "openclaw"
+  if (value.includes("runtime") || value.includes("install")) return "runtime"
+  return "sandbox"
+}
+
+function friendlyDetail(status?: string): string {
+  const value = status || "Creating sandbox"
+  switch (activeStep(value)) {
+    case "sandbox":
+      return "Creating sandbox"
+    case "runtime":
+      return "Preparing runtime"
+    case "openclaw":
+      return "Starting OpenClaw"
+    case "workspace":
+      if (value.toLowerCase().includes("sync")) return "Syncing repositories"
+      if (value.toLowerCase().includes("access")) return "Preparing repository access"
+      return "Preparing workspace"
+    case "connect":
+      return "Connecting to hub"
+  }
+}
+
+export function BootstrapProgress({
+  claw,
+  variant = "compact",
+}: {
+  claw: Claw
+  variant?: "sidebar" | "compact" | "full"
+}) {
+  if (claw.status !== "provisioning") return null
+
+  const current = activeStep(claw.bootstrap_status)
+  const currentIndex = STEPS.findIndex((step) => step.key === current)
+  const detail = friendlyDetail(claw.bootstrap_status)
+
+  if (variant === "sidebar") {
+    return (
+      <div className="mt-1.5 w-full min-w-0 overflow-hidden space-y-1">
+        <div className="flex min-w-0 items-center justify-between gap-2 text-[9px]">
+          <span className="min-w-0 truncate font-medium text-blue-400">{detail}</span>
+          <span className="shrink-0 text-muted-foreground/50">{currentIndex + 1}/{STEPS.length}</span>
+        </div>
+        <div className="grid min-w-0 grid-cols-5 gap-0.5">
+          {STEPS.map((step, index) => (
+            <div
+              key={step.key}
+              className={cn(
+                "h-0.5 rounded-full bg-border",
+                index < currentIndex && "bg-blue-500/70",
+                index === currentIndex && "bg-blue-400 animate-pulse"
+              )}
+              title={step.label}
+            />
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  if (variant === "compact") {
+    return (
+      <div className="mt-2 space-y-1.5">
+        <div className="flex items-center justify-between text-[10px]">
+          <span className="font-medium text-blue-400">{detail}</span>
+          <span className="text-muted-foreground/60">{currentIndex + 1}/{STEPS.length}</span>
+        </div>
+        <div className="grid grid-cols-5 gap-1">
+          {STEPS.map((step, index) => (
+            <div
+              key={step.key}
+              className={cn(
+                "h-1 rounded-full bg-border",
+                index < currentIndex && "bg-blue-500/70",
+                index === currentIndex && "bg-blue-400 animate-pulse"
+              )}
+              title={step.label}
+            />
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="border-t border-border/60 px-6 py-3">
+      <div className="mb-2 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Loader2 className="size-3.5 animate-spin text-blue-400" />
+          <span className="text-sm font-medium text-foreground">Setting up agent</span>
+        </div>
+        <span className="text-xs text-muted-foreground">{detail}</span>
+      </div>
+      <div className="grid grid-cols-5 gap-2">
+        {STEPS.map((step, index) => {
+          const isDone = index < currentIndex
+          const isCurrent = index === currentIndex
+          return (
+            <div key={step.key} className="min-w-0">
+              <div
+                className={cn(
+                  "mb-1 h-1 rounded-full bg-border",
+                  isDone && "bg-blue-500/70",
+                  isCurrent && "bg-blue-400 animate-pulse"
+                )}
+              />
+              <div className="flex min-w-0 items-center gap-1.5">
+                {isDone ? (
+                  <CheckCircle2 className="size-3 shrink-0 text-blue-400" />
+                ) : isCurrent ? (
+                  <Loader2 className="size-3 shrink-0 animate-spin text-blue-400" />
+                ) : (
+                  <Circle className="size-3 shrink-0 text-muted-foreground/40" />
+                )}
+                <span className={cn(
+                  "truncate text-[11px]",
+                  isCurrent ? "font-medium text-foreground" : "text-muted-foreground"
+                )}>
+                  {step.label}
+                </span>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/web/components/claw-card.tsx
+++ b/web/components/claw-card.tsx
@@ -8,6 +8,7 @@ import { COLOR_CLASSES, CLAW_COLORS } from "@/lib/mappers"
 import { TagEditor } from "@/components/tag-editor"
 import { patchClaw } from "@/lib/api"
 import { Loader2, Pin, AlertCircle, Pencil } from "lucide-react"
+import { BootstrapProgress } from "@/components/bootstrap-progress"
 
 interface ClawCardProps {
   claw: Claw
@@ -116,6 +117,13 @@ export function ClawCard({ claw, isSelected, onClick, onTogglePin, onTagsChange,
   }
   const hasUnread = claw.unreadCount > 0
   const isPending = claw.status === "provisioning" || claw.status === "error"
+  const railClass = claw.isStreaming
+    ? "border-l-green-500"
+    : claw.status === "provisioning"
+      ? "border-l-blue-400"
+      : claw.status === "error"
+        ? "border-l-red-500"
+        : COLOR_CLASSES[localColor]?.border ?? "border-l-border"
 
   return (
     <div
@@ -129,8 +137,8 @@ export function ClawCard({ claw, isSelected, onClick, onTogglePin, onTagsChange,
         }
       }}
       className={cn(
-        "w-full text-left p-3 rounded-md transition-colors relative group border-l-2",
-        COLOR_CLASSES[localColor]?.border ?? "border-l-border",
+        "w-full min-w-0 text-left p-3 rounded-md transition-colors relative group border-l-2",
+        railClass,
         isPending ? "cursor-pointer opacity-70 hover:bg-accent" : "cursor-pointer hover:bg-accent",
         isSelected && "bg-accent",
         hasUnread && !isSelected && "bg-blue-950/30"
@@ -186,8 +194,11 @@ export function ClawCard({ claw, isSelected, onClick, onTogglePin, onTagsChange,
           </button>
         )}
       </div>
+      <div className="min-w-0 max-w-[170px] overflow-hidden pl-5 pr-1">
+        <BootstrapProgress claw={claw} variant="sidebar" />
+      </div>
       {(localTags.length > 0 || isSelected) && (
-        <div className="mt-1.5 pl-5 flex items-start gap-2" onClick={(e) => e.stopPropagation()}>
+        <div className="mt-1.5 max-w-[170px] overflow-hidden pl-5 pr-1 flex items-start gap-2" onClick={(e) => e.stopPropagation()}>
           <TagEditor
             clawId={claw.id}
             tags={localTags}
@@ -236,9 +247,6 @@ export function ClawCard({ claw, isSelected, onClick, onTogglePin, onTagsChange,
             )}
           </div>
         </div>
-      )}
-      {claw.isStreaming && (
-        <div className="absolute left-0 top-0 bottom-0 w-0.5 bg-green-500 rounded-full" />
       )}
     </div>
   )

--- a/web/components/conversation-view.tsx
+++ b/web/components/conversation-view.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useRef, useEffect, useCallback, memo } from "react"
+import { useState, useRef, useEffect, useCallback, useMemo, memo } from "react"
 import { Send, Terminal, TerminalSquare, ChevronLeft, ChevronRight, ChevronDown, Loader2, LayoutGrid, Info, MessageSquare, RotateCcw, Trash2, AlertCircle, Wrench, GripVertical, Settings2, Paperclip, File as FileIcon, X } from "lucide-react"
 import {
   DndContext,
@@ -35,6 +35,7 @@ import { useAttachments } from "@/hooks/use-attachments"
 import { AttachmentChip } from "@/components/attachment-chip"
 import dynamic from "next/dynamic"
 import { useBranding } from "@/hooks/use-branding"
+import { BootstrapProgress } from "@/components/bootstrap-progress"
 
 const XTerminal = dynamic(
   () => import("@/components/terminal").then((m) => m.XTerminal),
@@ -307,6 +308,10 @@ function ClawBoardCard({
   const isPending = claw.status === "provisioning" || claw.status === "error" || claw.status === "offline"
   const msgScrollRef = useRef<HTMLDivElement>(null)
   const [showCardScrollBtn, setShowCardScrollBtn] = useState(false)
+  const [expandedActivityGroups, setExpandedActivityGroups] = useState<Record<string, boolean>>({})
+  const conversationItems = useMemo(() => compactActivityRuns(messages), [messages])
+  const latestActivity = useMemo(() => latestActivityMessage(messages), [messages])
+  const [activityNow, setActivityNow] = useState(() => Date.now())
 
   const {
     attachments,
@@ -323,6 +328,17 @@ function ClawBoardCard({
   const stillUploading = attachments.some((a) => a.status === "uploading")
   const hasErrored = attachments.some((a) => a.status === "error")
   const canSubmitCard = !isPending && !stillUploading && !hasErrored && (input.trim().length > 0 || attachments.some((a) => a.status === "ready"))
+
+  const toggleActivityGroup = useCallback((id: string) => {
+    setExpandedActivityGroups((prev) => ({ ...prev, [id]: !prev[id] }))
+  }, [])
+
+  useEffect(() => {
+    if (!latestActivity) return
+    setActivityNow(Date.now())
+    const timer = window.setInterval(() => setActivityNow(Date.now()), 1_000)
+    return () => window.clearInterval(timer)
+  }, [latestActivity])
 
   useEffect(() => {
     const el = msgScrollRef.current
@@ -453,6 +469,7 @@ function ClawBoardCard({
                 )}
               </span>
             </div>
+            <BootstrapProgress claw={claw} />
             {claw.tags.length > 0 && (
               <div className="flex flex-wrap gap-1 mt-2">
                 {claw.tags.slice(0, 3).map((tag) => (
@@ -480,7 +497,20 @@ function ClawBoardCard({
                 No messages yet
               </p>
             ) : (
-              messages.map((message) => {
+              conversationItems.map((item) => {
+                if (item.type === "activity-summary") {
+                  return (
+                    <ActivitySummary
+                      key={item.id}
+                      item={item}
+                      expanded={Boolean(expandedActivityGroups[item.id])}
+                      onToggle={() => toggleActivityGroup(item.id)}
+                      variant="card"
+                    />
+                  )
+                }
+                const { message } = item
+                const isLatestVisibleActivity = message.role === "activity" && isLatestActivityMessage(messages, message)
                 if (message.content === "__THINKING__") {
                   return (
                     <div key={message.id} className="flex gap-1 py-2 pl-2">
@@ -510,6 +540,17 @@ function ClawBoardCard({
                         message.format === "pre" && "whitespace-pre-wrap"
                       )}>{message.content}</span>
                     </div>
+                  )
+                }
+                if (message.role === "activity") {
+                  return (
+                    <ActivityRow
+                      key={message.id}
+                      message={message}
+                      variant="card"
+                      label={isLatestVisibleActivity ? "Last activity" : undefined}
+                      now={isLatestVisibleActivity ? activityNow : undefined}
+                    />
                   )
                 }
                 const { body: cardBody, attachments: cardAttachments } = message.role === "user"
@@ -797,6 +838,319 @@ function formatTimestamp(date: Date): string {
   return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
 }
 
+function activityTitle(message: Message): string {
+  const activity = message.activity
+  if (!activity) return "Activity"
+  if (activity.kind === "session_error") return "Session issue"
+  if (activity.error) return "Agent error"
+  if (activity.kind === "model_started") return "Waiting for model"
+  if (activity.kind === "tool") return activity.tool || activity.phase || "Tool"
+  if (activity.kind === "diagnostic") return "Diagnostic"
+  return activity.tool || activity.phase || activity.stream || "Activity"
+}
+
+function activityDetail(message: Message): string {
+  const activity = message.activity
+  if (!activity) return nonPhaseMessage(message.content)
+  if (activity.kind === "model_started" && activity.message?.startsWith("waiting for ")) {
+    return activity.message.replace(/^waiting for\s+/, "")
+  }
+  return activity.error || activity.command || activity.path || activity.url || activity.detail || nonPhaseMessage(activity.message) || nonPhaseMessage(message.content)
+}
+
+function activityDetailKind(message: Message): "command" | "path" | "url" | "text" {
+  const activity = message.activity
+  if (activity?.command) return "command"
+  if (activity?.path) return "path"
+  if (activity?.url) return "url"
+  return "text"
+}
+
+function activityStatusText(message: Message): string {
+  const activity = message.activity
+  if (!activity?.message || isPhaseMessage(activity.message)) return ""
+  const detail = activityDetail(message)
+  return activity.message === detail ? "" : activity.message
+}
+
+function isPhaseMessage(value?: string): boolean {
+  if (!value) return false
+  return ["running", "completed", "complete", "done", "failed", "error"].includes(value.toLowerCase())
+}
+
+function nonPhaseMessage(value?: string): string {
+  return isPhaseMessage(value) ? "" : value || ""
+}
+
+function activityIcon(message: Message, className: string) {
+  const kind = message.activity?.kind
+  if (message.activity?.error || kind === "session_error") return <AlertCircle className={className} />
+  if (kind === "tool") return <Wrench className={className} />
+  if (kind === "model_started") return <Loader2 className={cn(className, "animate-spin")} />
+  return <Info className={className} />
+}
+
+function isHiddenActivity(message: Message): boolean {
+  return message.activity?.kind === "still_working" || message.content.startsWith("No streamed output")
+}
+
+function isStaleModelWait(message: Message, latestActivity: Message | null): boolean {
+  return message.activity?.kind === "model_started" && latestActivity?.id !== message.id
+}
+
+function isTerminalAssistantMessage(message: Message): boolean {
+  return message.role === "claw" && /\[(DONE|READY_TO_COMMIT)\]/.test(message.content)
+}
+
+function hasEarlierTerminalAssistant(messages: Message[], index: number): boolean {
+  for (let i = index - 1; i >= 0; i -= 1) {
+    if (isTerminalAssistantMessage(messages[i])) return true
+  }
+  return false
+}
+
+function activityTone(message: Message): "error" | "warning" | "normal" {
+  if (message.activity?.error && message.activity.kind === "tool") return "error"
+  if (message.activity?.error || message.activity?.kind === "session_error") return "warning"
+  return "normal"
+}
+
+function latestActivityMessage(messages: Message[]): Message | null {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const message = messages[i]
+    if (message.role !== "activity" || isHiddenActivity(message)) continue
+    if (message.activity?.kind === "model_started" && hasEarlierTerminalAssistant(messages, i)) continue
+    return message
+  }
+  return null
+}
+
+function isLatestActivityMessage(messages: Message[], candidate: Message): boolean {
+  return latestActivityMessage(messages)?.id === candidate.id
+}
+
+function formatActivityAge(timestamp: Date, now: number): string {
+  const seconds = Math.max(0, Math.floor((now - timestamp.getTime()) / 1000))
+  if (seconds < 60) return `${seconds}s ago`
+  const minutes = Math.floor(seconds / 60)
+  const remainingSeconds = seconds % 60
+  if (minutes < 60) return remainingSeconds > 0 ? `${minutes}m ${remainingSeconds}s ago` : `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  return `${hours}h ago`
+}
+
+type ConversationItem =
+  | { type: "message"; message: Message }
+  | { type: "activity-summary"; id: string; messages: Message[] }
+
+function compactActivityRuns(messages: Message[]): ConversationItem[] {
+  const items: ConversationItem[] = []
+  let run: Message[] = []
+  const latestActivity = latestActivityMessage(messages)
+
+  const flush = () => {
+    const visible = run.filter((message) => !isHiddenActivity(message) && !isStaleModelWait(message, latestActivity))
+    run = []
+    if (visible.length === 0) return
+    if (visible.length === 1) {
+      items.push({ type: "message", message: visible[0] })
+      return
+    }
+    const collapsed = visible.slice(0, -1)
+    const latest = visible[visible.length - 1]
+    items.push({
+      type: "activity-summary",
+      id: `activity-summary-${collapsed[0].id}-${collapsed[collapsed.length - 1].id}`,
+      messages: collapsed,
+    })
+    items.push({ type: "message", message: latest })
+  }
+
+  for (const message of messages) {
+    if (message.role === "activity") {
+      run.push(message)
+      continue
+    }
+    flush()
+    items.push({ type: "message", message })
+  }
+  flush()
+
+  return items
+}
+
+function activityGroupKey(message: Message): string {
+  const activity = message.activity
+  if (!activity) return message.id
+  return [
+    activity.kind || "",
+    activity.tool || "",
+    activity.detail || "",
+    activity.command || "",
+    activity.path || "",
+    activity.url || "",
+  ].join("\u0000")
+}
+
+function isRunningActivity(message: Message): boolean {
+  return message.activity?.kind === "tool" && (message.activity.phase === "running" || message.activity.message === "running")
+}
+
+function isTerminalActivity(message: Message): boolean {
+  const phase = (message.activity?.phase || message.activity?.message || "").toLowerCase()
+  return message.activity?.kind === "tool" && ["completed", "complete", "done", "failed", "error"].includes(phase)
+}
+
+function coalesceActivityMessages(messages: Message[]): Message[] {
+  const terminalKeys = new Set(messages.filter(isTerminalActivity).map(activityGroupKey))
+  return messages.filter((message) => !(isRunningActivity(message) && terminalKeys.has(activityGroupKey(message))))
+}
+
+function activitySummaryLabel(messages: Message[]): string {
+  const toolCount = messages.filter((message) => message.activity?.kind === "tool").length
+  const noun = toolCount === messages.length ? "tool call" : "activity update"
+  return `${messages.length} earlier ${noun}${messages.length === 1 ? "" : "s"}`
+}
+
+function ActivityRow({
+  message,
+  variant = "full",
+  label,
+  now,
+}: {
+  message: Message
+  variant?: "card" | "full"
+  label?: string
+  now?: number
+}) {
+  if (isHiddenActivity(message)) return null
+  const detail = activityDetail(message)
+  const detailKind = activityDetailKind(message)
+  const statusText = activityStatusText(message)
+  const tone = activityTone(message)
+  const age = now ? `updated ${formatActivityAge(message.timestamp, now)}` : ""
+
+  if (variant === "card") {
+    return (
+      <div className={cn(
+        "rounded border px-1.5 py-1 text-[10px]",
+        tone === "error"
+          ? "border-red-500/20 bg-red-500/5 text-red-400"
+          : tone === "warning"
+            ? "border-amber-500/20 bg-amber-500/5 text-amber-400"
+          : "border-border/50 bg-muted/30 text-muted-foreground"
+      )}>
+        <div className="flex min-w-0 items-center gap-1.5">
+          {activityIcon(message, "size-2.5 shrink-0")}
+          {label && <span className="font-medium shrink-0">{label}</span>}
+          <span className="min-w-0 truncate font-medium">{activityTitle(message)}</span>
+          {statusText && (
+            <span className="min-w-0 truncate text-muted-foreground/50">{statusText}</span>
+          )}
+          {age && <span className="ml-auto shrink-0 text-muted-foreground/60" suppressHydrationWarning>{age}</span>}
+        </div>
+        {detail && (
+          <span
+            className={cn(
+              "mt-0.5 block truncate pl-4 text-muted-foreground/70",
+              detailKind !== "text" && "font-mono"
+            )}
+            title={detail}
+          >
+            {detail}
+          </span>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex items-center gap-2 py-2">
+      <div className="flex-1 h-px bg-border/50" />
+      <div className={cn(
+        "min-w-0 max-w-[82%] rounded border px-2.5 py-1.5 text-xs",
+        tone === "error"
+          ? "border-red-500/20 bg-red-500/5 text-red-400"
+          : tone === "warning"
+            ? "border-amber-500/20 bg-amber-500/5 text-amber-400"
+          : "border-border/60 bg-muted/35 text-muted-foreground"
+      )}>
+        <div className="flex min-w-0 items-center gap-2">
+          {activityIcon(message, "size-3 shrink-0")}
+          <span className="min-w-0 truncate font-medium">{activityTitle(message)}</span>
+          {statusText && (
+            <span className="min-w-0 truncate text-muted-foreground/50">{statusText}</span>
+          )}
+          <span className="ml-auto shrink-0 text-muted-foreground/50" suppressHydrationWarning>
+            {formatTimestamp(message.timestamp)}
+          </span>
+        </div>
+        {detail && (
+          <span
+            className={cn(
+              "mt-1 block truncate pl-5 text-muted-foreground/80",
+              detailKind !== "text" && "font-mono"
+            )}
+            title={detail}
+          >
+            {detail}
+          </span>
+        )}
+      </div>
+      <div className="flex-1 h-px bg-border/50" />
+    </div>
+  )
+}
+
+function ActivitySummary({
+  item,
+  expanded,
+  onToggle,
+  variant = "full",
+}: {
+  item: Extract<ConversationItem, { type: "activity-summary" }>
+  expanded: boolean
+  onToggle: () => void
+  variant?: "card" | "full"
+}) {
+  const visibleMessages = coalesceActivityMessages(item.messages)
+  if (variant === "card") {
+    return (
+      <div className="space-y-1">
+        <button
+          type="button"
+          onClick={onToggle}
+          className="w-full rounded border border-border/50 bg-muted/20 px-1.5 py-1 text-left text-[10px] text-muted-foreground hover:bg-muted/35"
+        >
+          {expanded ? "Hide" : "Show"} {activitySummaryLabel(visibleMessages)}
+        </button>
+        {expanded && visibleMessages.map((message) => (
+          <ActivityRow key={message.id} message={message} variant="card" />
+        ))}
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center gap-2 py-1">
+        <div className="flex-1 h-px bg-border/50" />
+        <button
+          type="button"
+          onClick={onToggle}
+          className="rounded border border-border/60 bg-muted/25 px-2.5 py-1 text-xs text-muted-foreground hover:bg-muted/40 hover:text-foreground"
+        >
+          {expanded ? "Hide" : "Show"} {activitySummaryLabel(visibleMessages)}
+        </button>
+        <div className="flex-1 h-px bg-border/50" />
+      </div>
+      {expanded && visibleMessages.map((message) => (
+        <ActivityRow key={message.id} message={message} />
+      ))}
+    </div>
+  )
+}
+
 const MessageBubble = memo(function MessageBubble({
   message,
   clawId,
@@ -830,6 +1184,10 @@ const MessageBubble = memo(function MessageBubble({
         <div className="flex-1 h-px bg-border" />
       </div>
     )
+  }
+
+  if (message.role === "activity") {
+    return <ActivityRow message={message} />
   }
 
   // Thinking indicator
@@ -960,6 +1318,8 @@ function ClawChatView({
     clawId: claw.id,
     liveMessages,
   })
+  const conversationItems = useMemo(() => compactActivityRuns(messages), [messages])
+  const [expandedActivityGroups, setExpandedActivityGroups] = useState<Record<string, boolean>>({})
   const [showScrollBtn, setShowScrollBtn] = useState(false)
   // Track whether user has scrolled away from the bottom
   const pinnedToBottom = useRef(true)
@@ -1004,6 +1364,10 @@ function ClawChatView({
   const stillUploading = attachments.some((a) => a.status === "uploading")
   const hasErrored = attachments.some((a) => a.status === "error")
   const canSubmit = !stillUploading && !hasErrored && (input.trim().length > 0 || attachments.some((a) => a.status === "ready"))
+
+  const toggleActivityGroup = useCallback((id: string) => {
+    setExpandedActivityGroups((prev) => ({ ...prev, [id]: !prev[id] }))
+  }, [])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -1071,6 +1435,7 @@ function ClawChatView({
             <Button variant="destructive" size="sm" onClick={() => setConfirmKill(true)}>Kill</Button>
           </div>
         </div>
+        <BootstrapProgress claw={claw} variant="full" />
       </header>
 
       <div ref={scrollRef} onScroll={handleScroll} className="flex-1 overflow-y-auto scrollbar-hide p-6 relative">
@@ -1088,8 +1453,17 @@ function ClawChatView({
           {messages.length === 0 ? (
             <p className="text-center text-muted-foreground py-12">No messages yet. Start the conversation below.</p>
           ) : (
-            messages.map((message) => (
-              <MessageBubble key={message.id} message={message} clawId={claw.id} clawName={claw.name} clawColor={claw.color} />
+            conversationItems.map((item) => (
+              item.type === "activity-summary" ? (
+                <ActivitySummary
+                  key={item.id}
+                  item={item}
+                  expanded={Boolean(expandedActivityGroups[item.id])}
+                  onToggle={() => toggleActivityGroup(item.id)}
+                />
+              ) : (
+                <MessageBubble key={item.message.id} message={item.message} clawId={claw.id} clawName={claw.name} clawColor={claw.color} />
+              )
             ))
           )}
           <div ref={bottomRef} className="h-4" />

--- a/web/components/conversation-view.tsx
+++ b/web/components/conversation-view.tsx
@@ -36,6 +36,7 @@ import { AttachmentChip } from "@/components/attachment-chip"
 import dynamic from "next/dynamic"
 import { useBranding } from "@/hooks/use-branding"
 import { BootstrapProgress } from "@/components/bootstrap-progress"
+import { isTerminalAssistantMessage } from "@/lib/messages"
 
 const XTerminal = dynamic(
   () => import("@/components/terminal").then((m) => m.XTerminal),
@@ -896,10 +897,6 @@ function isHiddenActivity(message: Message): boolean {
 
 function isStaleModelWait(message: Message, latestActivity: Message | null): boolean {
   return message.activity?.kind === "model_started" && latestActivity?.id !== message.id
-}
-
-function isTerminalAssistantMessage(message: Message): boolean {
-  return message.role === "claw" && /\[(DONE|READY_TO_COMMIT)\]/.test(message.content)
 }
 
 function hasEarlierTerminalAssistant(messages: Message[], index: number): boolean {

--- a/web/hooks/use-hub.ts
+++ b/web/hooks/use-hub.ts
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState, useEffect, useRef, useCallback } from "react"
-import type { Claw, Message, CreateClawRequest } from "@/lib/types"
+import type { AgentActivity, Claw, Message, CreateClawRequest } from "@/lib/types"
 import {
   fetchClaws,
   fetchMessages,
@@ -36,6 +36,52 @@ export interface HubState {
 
 const ORDER_KEY = "elasticclaw_claw_order"
 
+function describeWsUrl(rawUrl: string): string {
+  try {
+    const url = new URL(rawUrl)
+    if (url.searchParams.has("token")) {
+      url.searchParams.set("token", "[redacted]")
+    }
+    return url.toString()
+  } catch {
+    return rawUrl.replace(/token=[^&]+/, "token=[redacted]")
+  }
+}
+
+function isTransientMessage(message: Message): boolean {
+  return message.id.startsWith("activity-") || message.id.startsWith("live-") || message.id.startsWith("thinking-")
+}
+
+function formatActivityContent(activity: AgentActivity): string {
+  if (activity.error) return activity.error
+  if (activity.command) return activity.command
+  if (activity.path) return activity.path
+  if (activity.url) return activity.url
+  if (activity.detail) return activity.detail
+  if (activity.message) return activity.message
+  if (activity.tool) return activity.tool
+  switch (activity.kind) {
+    case "model_started":
+      return "Waiting on model response"
+    case "tool":
+      return "Tool activity"
+    default:
+      return activity.phase || activity.stream || "Activity"
+  }
+}
+
+function isUnhelpfulActivity(activity: AgentActivity): boolean {
+  return activity.kind === "still_working" || Boolean(activity.message?.startsWith("No streamed output")) || Boolean(activity.error?.startsWith("No streamed output"))
+}
+
+function withoutModelWaitActivities(messages: Message[]): Message[] {
+  return messages.filter((message) => message.activity?.kind !== "model_started")
+}
+
+function isTerminalAssistantMessage(message: Message): boolean {
+  return message.role === "claw" && /\[(DONE|READY_TO_COMMIT)\]/.test(message.content)
+}
+
 function loadSavedOrder(): string[] {
   try {
     const raw = localStorage.getItem(ORDER_KEY)
@@ -57,10 +103,24 @@ export function useHub(selectedClawId: string | null): HubState {
   const [messages, setMessages] = useState<Record<string, Message[]>>({})
   const messagesRef = useRef<Record<string, Message[]>>({})
   const [connected, setConnected] = useState(false)
-  const { displayBuffers: streamingBuffers, pushChunk, finalize: finalizeTypewriter } = useTypewriter()
+  const {
+    displayBuffers: streamingBuffers,
+    pushChunk,
+    finalize: finalizeTypewriter,
+    split: splitTypewriter,
+    clear: clearTypewriter,
+  } = useTypewriter()
   const [configured, setConfigured] = useState(false)
   const [loading, setLoading] = useState(true) // true until first claws fetch completes
   const [hubError, setHubError] = useState<string | null>(null)
+  const segmentedStreamRef = useRef<Record<string, boolean>>({})
+  const clientMessageSeqRef = useRef(0)
+
+  const nextClientMessageId = useCallback((prefix: string, clawId?: string) => {
+    clientMessageSeqRef.current += 1
+    const scope = clawId ? `${clawId}-` : ""
+    return `${prefix}-${scope}${Date.now()}-${clientMessageSeqRef.current}`
+  }, [])
 
   // Track pinned state from localStorage
   const pinnedRef = useRef<Record<string, boolean>>({})
@@ -86,15 +146,20 @@ export function useHub(selectedClawId: string | null): HubState {
     try {
       const toSave: Record<string, unknown[]> = {}
       for (const [clawId, clawMsgs] of Object.entries(msgs)) {
-        // Keep last N messages per claw, skip optimistic/system
+        // Keep last N durable messages per claw. Live stream segments and activity
+        // rows are per-tab transcript state; the API stores canonical messages.
         toSave[clawId] = clawMsgs
-          .filter((m) => !m.id.startsWith("opt-") && m.role !== "system")
+          .filter((m) => !m.id.startsWith("opt-") && m.role !== "system" && !isTransientMessage(m))
           .slice(-MAX_CACHED_PER_CLAW)
       }
       localStorage.setItem(MESSAGES_KEY, JSON.stringify(toSave))
     } catch {}
   }, [])
   const wsRef = useRef<WebSocket | null>(null)
+  const reconnectTimerRef = useRef<number | null>(null)
+  const reconnectAttemptRef = useRef(0)
+  const shouldReconnectRef = useRef(false)
+  const lastWsErrorLogRef = useRef(0)
   const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const selectedClawIdRef = useRef<string | null>(selectedClawId)
 
@@ -201,7 +266,7 @@ export function useHub(selectedClawId: string | null): HubState {
         // Merge API result with cached state:
         // 1. Keep non-optimistic existing messages not in API result (preserves cache beyond API limit)
         // 2. Re-append any in-flight opt- messages so send() can still swap them with real UUIDs
-        const existingNonOpt = existing.filter((m) => !m.id.startsWith('opt-'))
+        const existingNonOpt = existing.filter((m) => !m.id.startsWith('opt-') && !isTransientMessage(m))
         const apiIds = new Set(msgs.map((m) => m.id))
         const cachedOnly = existingNonOpt.filter((m) => !apiIds.has(m.id))
         const inflight = existing.filter((m) => m.id.startsWith('opt-') &&
@@ -228,31 +293,49 @@ export function useHub(selectedClawId: string | null): HubState {
   }, [persistMessages])
 
   const connectWebSocket = useCallback(() => {
+    if (!shouldReconnectRef.current) return
     if (wsRef.current) {
+      wsRef.current.onclose = null
+      wsRef.current.onerror = null
       wsRef.current.close()
     }
     const wsUrl = getHubWsUrl()
+    const safeWsUrl = describeWsUrl(wsUrl)
     let ws: WebSocket
     try {
       ws = new WebSocket(wsUrl)
     } catch (err) {
-      console.error("WS create failed:", err)
+      console.error(`WS create failed for ${safeWsUrl}:`, err)
       return
     }
     wsRef.current = ws
 
     ws.onopen = () => {
+      reconnectAttemptRef.current = 0
       setConnected(true)
     }
 
-    ws.onclose = () => {
+    ws.onclose = (event) => {
+      if (wsRef.current !== ws) return
       setConnected(false)
-      // Reconnect after 3s
-      setTimeout(connectWebSocket, 3000)
+      if (!shouldReconnectRef.current) return
+      const attempt = reconnectAttemptRef.current
+      reconnectAttemptRef.current += 1
+      const delayMs = Math.min(30_000, 1000 * 2 ** Math.min(attempt, 5))
+      if (event.code !== 1000) {
+        console.warn(
+          `WS closed for ${safeWsUrl}: code=${event.code} reason=${event.reason || "none"}; reconnecting in ${Math.round(delayMs / 1000)}s`
+        )
+      }
+      if (reconnectTimerRef.current) window.clearTimeout(reconnectTimerRef.current)
+      reconnectTimerRef.current = window.setTimeout(connectWebSocket, delayMs)
     }
 
-    ws.onerror = (err) => {
-      console.warn("WS error:", err)
+    ws.onerror = () => {
+      const nowMs = Date.now()
+      if (nowMs - lastWsErrorLogRef.current < 10_000) return
+      lastWsErrorLogRef.current = nowMs
+      console.warn(`WS error for ${safeWsUrl}; check the Network tab for /api/ws status and close code`)
     }
 
     ws.onmessage = (event) => {
@@ -266,14 +349,64 @@ export function useHub(selectedClawId: string | null): HubState {
           pushChunk(claw_id, content)
           setClaws((prev) =>
             prev.map((c) =>
-              c.id === claw_id ? { ...c, isStreaming: true } : c
+                c.id === claw_id ? { ...c, isStreaming: true } : c
+            )
+          )
+        } else if (type === "agent_activity") {
+          const clawId = payload.claw_id
+          if (!clawId) return
+          const activity: AgentActivity = {
+            kind: payload.kind || "activity",
+            stream: payload.stream,
+            phase: payload.phase,
+            tool: payload.tool,
+            detail: payload.detail,
+            command: payload.command,
+            path: payload.path,
+            url: payload.url,
+            message: payload.message,
+            error: payload.error,
+          }
+          if (isUnhelpfulActivity(activity)) return
+          const currentMessages = messagesRef.current[clawId] || []
+          const lastDurable = [...currentMessages].reverse().find((message) => !isTransientMessage(message) && message.role !== "activity")
+          if (activity.kind === "model_started" && lastDurable && isTerminalAssistantMessage(lastDurable)) return
+          const segment = splitTypewriter(clawId)
+          const createdAt = payload.created_at ? new Date(payload.created_at) : new Date()
+          segmentedStreamRef.current[clawId] = true
+          setMessages((prev) => {
+            const nextMessages = [...(prev[clawId] || [])]
+            if (segment.trim()) {
+              nextMessages.push({
+                id: nextClientMessageId("live-segment", clawId),
+                role: "claw",
+                content: segment,
+                timestamp: createdAt,
+              })
+            }
+            nextMessages.push({
+              id: nextClientMessageId("activity", clawId),
+              role: "activity",
+              content: formatActivityContent(activity),
+              activity,
+              timestamp: createdAt,
+            })
+            const next = { ...prev, [clawId]: nextMessages }
+            persistMessages(next)
+            return next
+          })
+          setClaws((prev) =>
+            prev.map((c) =>
+              c.id === clawId ? { ...c, isStreaming: true } : c
             )
           )
         } else if (type === "message") {
           // Final message — hold until typewriter drains, then commit
           const msg = mapApiMessage(payload)
           const clawId = payload.claw_id
-          finalizeTypewriter(clawId, () => {
+          if (segmentedStreamRef.current[clawId]) {
+            const tail = clearTypewriter(clawId)
+            delete segmentedStreamRef.current[clawId]
             // Called once typewriter is fully drained — safe to add final message
             setClaws((prev) =>
               prev.map((c) =>
@@ -290,11 +423,46 @@ export function useHub(selectedClawId: string | null): HubState {
               )
             )
             setMessages((prev) => {
-              const next = { ...prev, [clawId]: [...(prev[clawId] || []), msg] }
+              const nextMessages = withoutModelWaitActivities(prev[clawId] || [])
+              const hasLiveSegment = nextMessages.some((m) => m.id.startsWith(`live-segment-${clawId}-`))
+              if (tail.trim()) {
+                nextMessages.push({
+                  id: nextClientMessageId("live-segment", clawId),
+                  role: "claw",
+                  content: tail,
+                  timestamp: msg.timestamp,
+                })
+              } else if (!hasLiveSegment && msg.content.trim()) {
+                nextMessages.push(msg)
+              }
+              const next = { ...prev, [clawId]: nextMessages }
               persistMessages(next)
               return next
             })
-          })
+          } else {
+            finalizeTypewriter(clawId, () => {
+              // Called once typewriter is fully drained — safe to add final message
+              setClaws((prev) =>
+                prev.map((c) =>
+                  c.id === clawId
+                    ? {
+                        ...c,
+                        isStreaming: false,
+                        unreadCount:
+                          selectedClawIdRef.current !== clawId && msg.role === "claw"
+                            ? c.unreadCount + 1
+                            : c.unreadCount,
+                      }
+                    : c
+                )
+              )
+              setMessages((prev) => {
+                const next = { ...prev, [clawId]: [...withoutModelWaitActivities(prev[clawId] || []), msg] }
+                persistMessages(next)
+                return next
+              })
+            })
+          }
         } else if (type === "claw_status") {
           const { claw_id, status } = payload
           if (status === "deleted") {
@@ -327,7 +495,7 @@ export function useHub(selectedClawId: string | null): HubState {
         console.warn("Failed to parse WS message:", err)
       }
     }
-  }, [mergeClaws, refreshClaws])
+  }, [clearTypewriter, finalizeTypewriter, nextClientMessageId, persistMessages, pushChunk, refreshClaws, splitTypewriter])
 
   // Initialize
   useEffect(() => {
@@ -342,11 +510,18 @@ export function useHub(selectedClawId: string | null): HubState {
     pollIntervalRef.current = setInterval(refreshClaws, 10_000)
 
     // Wait for token then connect WS
+    shouldReconnectRef.current = true
     resolveToken().then(() => connectWebSocket())
 
     return () => {
+      shouldReconnectRef.current = false
       if (pollIntervalRef.current) clearInterval(pollIntervalRef.current)
-      if (wsRef.current) wsRef.current.close()
+      if (reconnectTimerRef.current) window.clearTimeout(reconnectTimerRef.current)
+      if (wsRef.current) {
+        wsRef.current.onclose = null
+        wsRef.current.onerror = null
+        wsRef.current.close()
+      }
     }
   }, []) // run once on mount
 
@@ -355,7 +530,7 @@ export function useHub(selectedClawId: string | null): HubState {
 
     // Optimistically add user message
     const optimistic: Message = {
-      id: `opt-${Date.now()}`,
+      id: nextClientMessageId("opt", clawId),
       role: "user",
       content: content.trim(),
       timestamp: new Date(),
@@ -391,7 +566,7 @@ export function useHub(selectedClawId: string | null): HubState {
         prev.map((c) => (c.id === clawId ? { ...c, isStreaming: false } : c))
       )
     }
-  }, [])
+  }, [nextClientMessageId, persistMessages, pushChunk])
 
   const createClaw = useCallback(async (req: { name: string; template: string }) => {
     const apiClaw = await apiCreateClaw({

--- a/web/hooks/use-hub.ts
+++ b/web/hooks/use-hub.ts
@@ -13,6 +13,7 @@ import {
   isConfigured,
 } from "@/lib/api"
 import { mapApiClaw, mapApiMessage, mapApiStatus, computeUptime } from "@/lib/mappers"
+import { isTerminalAssistantMessage } from "@/lib/messages"
 import type { ApiClaw } from "@/lib/types"
 import { useTypewriter, type TypewriterState } from "@/hooks/use-typewriter"
 
@@ -76,10 +77,6 @@ function isUnhelpfulActivity(activity: AgentActivity): boolean {
 
 function withoutModelWaitActivities(messages: Message[]): Message[] {
   return messages.filter((message) => message.activity?.kind !== "model_started")
-}
-
-function isTerminalAssistantMessage(message: Message): boolean {
-  return message.role === "claw" && /\[(DONE|READY_TO_COMMIT)\]/.test(message.content)
 }
 
 function loadSavedOrder(): string[] {
@@ -373,19 +370,21 @@ export function useHub(selectedClawId: string | null): HubState {
           if (activity.kind === "model_started" && lastDurable && isTerminalAssistantMessage(lastDurable)) return
           const segment = splitTypewriter(clawId)
           const createdAt = payload.created_at ? new Date(payload.created_at) : new Date()
+          const segmentId = segment.trim() ? nextClientMessageId("live-segment", clawId) : null
+          const activityId = nextClientMessageId("activity", clawId)
           segmentedStreamRef.current[clawId] = true
           setMessages((prev) => {
             const nextMessages = [...(prev[clawId] || [])]
-            if (segment.trim()) {
+            if (segmentId) {
               nextMessages.push({
-                id: nextClientMessageId("live-segment", clawId),
+                id: segmentId,
                 role: "claw",
                 content: segment,
                 timestamp: createdAt,
               })
             }
             nextMessages.push({
-              id: nextClientMessageId("activity", clawId),
+              id: activityId,
               role: "activity",
               content: formatActivityContent(activity),
               activity,
@@ -407,6 +406,7 @@ export function useHub(selectedClawId: string | null): HubState {
           if (segmentedStreamRef.current[clawId]) {
             const tail = clearTypewriter(clawId)
             delete segmentedStreamRef.current[clawId]
+            const tailId = tail.trim() ? nextClientMessageId("live-segment", clawId) : null
             // Called once typewriter is fully drained — safe to add final message
             setClaws((prev) =>
               prev.map((c) =>
@@ -425,9 +425,9 @@ export function useHub(selectedClawId: string | null): HubState {
             setMessages((prev) => {
               const nextMessages = withoutModelWaitActivities(prev[clawId] || [])
               const hasLiveSegment = nextMessages.some((m) => m.id.startsWith(`live-segment-${clawId}-`))
-              if (tail.trim()) {
+              if (tailId) {
                 nextMessages.push({
-                  id: nextClientMessageId("live-segment", clawId),
+                  id: tailId,
                   role: "claw",
                   content: tail,
                   timestamp: msg.timestamp,

--- a/web/hooks/use-typewriter.ts
+++ b/web/hooks/use-typewriter.ts
@@ -20,7 +20,7 @@ interface TypewriterEntry {
  * smoothly-drained display buffers that feel like a typewriter.
  *
  * Usage:
- *   const { displayBuffers, pushChunk, finalize } = useTypewriter()
+ *   const { displayBuffers, pushChunk, finalize, split, clear } = useTypewriter()
  *
  *   pushChunk(clawId, chunkText)   — call on every WS chunk event
  *   finalize(clawId)               — call when the final message arrives
@@ -139,6 +139,35 @@ export function useTypewriter() {
     }
   }, [])
 
+  /** Snapshot and reset the currently displayed stream at an activity boundary. */
+  const split = useCallback((clawId: string): string => {
+    const entry = entries.current[clawId]
+    if (!entry) return ""
+    const text = entry.shown + entry.queue
+    entry.shown = ""
+    entry.queue = ""
+    entry.hadChunks = false
+    entry.pausedAt = null
+    entry.done = false
+    setDisplayBuffers((prev) => ({ ...prev, [clawId]: { text: "", hadChunks: false, isPaused: false } }))
+    return text
+  }, [])
+
+  /** Snapshot and remove the currently displayed stream. */
+  const clear = useCallback((clawId: string): string => {
+    const entry = entries.current[clawId]
+    if (!entry) return ""
+    const text = entry.shown + entry.queue
+    delete entries.current[clawId]
+    delete onDrainCallbacks.current[clawId]
+    setDisplayBuffers((prev) => {
+      const next = { ...prev }
+      delete next[clawId]
+      return next
+    })
+    return text
+  }, [])
+
   /** Check if a claw is still draining */
   const isTyping = useCallback((clawId: string) => {
     return Boolean(entries.current[clawId])
@@ -150,5 +179,5 @@ export function useTypewriter() {
     }
   }, [])
 
-  return { displayBuffers, pushChunk, finalize, isTyping }
+  return { displayBuffers, pushChunk, finalize, split, clear, isTyping }
 }

--- a/web/hooks/use-windowed-messages.ts
+++ b/web/hooks/use-windowed-messages.ts
@@ -7,6 +7,13 @@ import type { Message } from "@/lib/types"
 
 const PAGE_SIZE = 50    // messages per page
 const MAX_WINDOW = 50   // max messages kept in DOM
+const ROLE_ORDER: Record<Message["role"], number> = {
+  user: 0,
+  hub: 1,
+  claw: 2,
+  activity: 3,
+  system: 4,
+}
 
 interface UseWindowedMessagesOptions {
   clawId: string
@@ -27,13 +34,16 @@ export function useWindowedMessages({ clawId, liveMessages }: UseWindowedMessage
   const [hasOlder, setHasOlder] = useState(false)
   const [loadingOlder, setLoadingOlder] = useState(false)
   const scrollRef = useRef<HTMLDivElement>(null)
-  const initialLoaded = useRef(false)
+  const loadedClawId = useRef<string | null>(null)
   const oldestTimestamp = useRef<string | null>(null)
 
   // Initial load — last PAGE_SIZE messages
   useEffect(() => {
-    if (initialLoaded.current || !clawId) return
-    initialLoaded.current = true
+    if (!clawId || loadedClawId.current === clawId) return
+    loadedClawId.current = clawId
+    oldestTimestamp.current = null
+    setHistoricalMsgs([])
+    setHasOlder(false)
 
     fetchMessages(clawId)
       .then((apiMsgs) => {
@@ -97,7 +107,7 @@ export function useWindowedMessages({ clawId, liveMessages }: UseWindowedMessage
     }
   }, [loadOlder, loadingOlder, hasOlder])
 
-  // Merge historical + live, deduplicate by id, cap window
+  // Merge historical + live, deduplicate, sort by timestamp, cap window
   const messages = (() => {
     const seen = new Set<string>()
     const all: Message[] = []
@@ -105,11 +115,40 @@ export function useWindowedMessages({ clawId, liveMessages }: UseWindowedMessage
       if (!seen.has(m.id)) { seen.add(m.id); all.push(m) }
     }
     for (const m of liveMessages) {
-      if (!seen.has(m.id)) { seen.add(m.id); all.push(m) }
+      if (seen.has(m.id)) continue
+      if (all.some((existing) => isDuplicateLiveActivity(existing, m))) continue
+      seen.add(m.id)
+      all.push(m)
     }
-    // If too many, drop oldest
+    all.sort(compareMessages)
     return all.length > MAX_WINDOW ? all.slice(all.length - MAX_WINDOW) : all
   })()
 
   return { messages, hasOlder, loadingOlder, loadOlder, scrollRef, onScroll }
+}
+
+function compareMessages(a: Message, b: Message): number {
+  const timeDelta = a.timestamp.getTime() - b.timestamp.getTime()
+  if (timeDelta !== 0) return timeDelta
+  return (ROLE_ORDER[a.role] ?? 9) - (ROLE_ORDER[b.role] ?? 9)
+}
+
+function isDuplicateLiveActivity(existing: Message, candidate: Message): boolean {
+  if (existing.role !== "activity" || candidate.role !== "activity") return false
+  const timeDelta = Math.abs(existing.timestamp.getTime() - candidate.timestamp.getTime())
+  if (timeDelta > 2000) return false
+  if (existing.content !== candidate.content) return false
+
+  const existingActivity = existing.activity
+  const candidateActivity = candidate.activity
+  if (!existingActivity || !candidateActivity) return true
+
+  return (
+    existingActivity.kind === candidateActivity.kind &&
+    existingActivity.phase === candidateActivity.phase &&
+    existingActivity.tool === candidateActivity.tool &&
+    existingActivity.command === candidateActivity.command &&
+    existingActivity.path === candidateActivity.path &&
+    existingActivity.url === candidateActivity.url
+  )
 }

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -38,6 +38,9 @@ export function resolveToken(): Promise<string> {
   })
     .then((r) => r.json())
     .then((d) => {
+      if (typeof d.hubUrl === "string" && d.hubUrl.trim()) {
+        setHubUrl(d.hubUrl.trim())
+      }
       _token = d.token || ""
       return _token!
     })

--- a/web/lib/mappers.ts
+++ b/web/lib/mappers.ts
@@ -119,11 +119,18 @@ export function mapApiClaw(
 }
 
 export function mapApiMessage(apiMsg: ApiMessage): Message {
+  let activity
+  if (apiMsg.role === "activity" && apiMsg.format?.startsWith("activity:")) {
+    try {
+      activity = JSON.parse(apiMsg.format.slice("activity:".length))
+    } catch {}
+  }
   return {
     id: apiMsg.id,
     role: apiMsg.role,
     content: apiMsg.content,
-    format: apiMsg.format,
+    format: apiMsg.format?.startsWith("activity:") ? undefined : apiMsg.format,
+    activity,
     timestamp: new Date(apiMsg.created_at),
     claw_id: apiMsg.claw_id,
     tenant_id: apiMsg.tenant_id,

--- a/web/lib/messages.ts
+++ b/web/lib/messages.ts
@@ -1,0 +1,5 @@
+import type { Message } from "@/lib/types"
+
+export function isTerminalAssistantMessage(message: Message): boolean {
+  return message.role === "claw" && /\[(DONE|READY_TO_COMMIT)\]/.test(message.content)
+}

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -27,13 +27,27 @@ export interface Claw {
 
 export interface Message {
   id: string
-  role: "user" | "claw" | "system" | "hub"
+  role: "user" | "claw" | "system" | "hub" | "activity"
   content: string
   format?: string // "pre" = preserve whitespace
   timestamp: Date
+  activity?: AgentActivity
   // API fields
   claw_id?: string
   tenant_id?: string
+}
+
+export interface AgentActivity {
+  kind: string
+  stream?: string
+  phase?: string
+  tool?: string
+  detail?: string
+  command?: string
+  path?: string
+  url?: string
+  message?: string
+  error?: string
 }
 
 // Raw API types
@@ -58,7 +72,7 @@ export interface ApiMessage {
   id: string
   claw_id: string
   tenant_id: string
-  role: "user" | "claw" | "hub"
+  role: "user" | "claw" | "hub" | "activity"
   content: string
   format?: string
   created_at: string

--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -11,7 +11,7 @@ const nextConfig = {
   ...(isDev
     ? {
         async rewrites() {
-          const hubUrl = process.env.NEXT_PUBLIC_HUB_URL || process.env.HUB_URL || "http://localhost:8080"
+          const hubUrl = process.env.NEXT_PUBLIC_HUB_URL || process.env.ELASTICCLAW_HUB_URL || process.env.HUB_URL || "http://localhost:8080"
           return [
             {
               source: "/api/:path*",


### PR DESCRIPTION
## Summary
- show persisted agent activity/tool-call updates with collapsible transcript grouping
- add cleaner Daytona bootstrap progress and immediate soft-delete behavior for killed claws
- surface bridge activity details from OpenClaw tool metadata and log sanitized payloads when details are missing
- harden websocket reconnect handling and suppress stale model-wait activity after terminal replies

## Verification
- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./cmd/claw-bridge ./pkg/hub
- npm run build
- git diff --check