### PR TITLE
Queue injected messages behind active agent turns

### DIFF
--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -600,7 +600,7 @@ func (s *Server) injectMessage(clawID, content, role string) {
 	s.mu.RLock()
 	cc, ok := s.claws[clawID]
 	s.mu.RUnlock()
-	delivered := false
+	acceptedForAgent := false
 	if ok {
 		cc.mu.Lock()
 		cc.lastUserMessageAt = time.Now()
@@ -608,7 +608,7 @@ func (s *Server) injectMessage(clawID, content, role string) {
 			cc.messageQueue = append(cc.messageQueue, msg)
 			queueLen := len(cc.messageQueue)
 			cc.mu.Unlock()
-			delivered = true
+			acceptedForAgent = true
 			log.Printf("[pr-watcher] queued injected message for claw %s (queue length: %d)", shortID(clawID), queueLen)
 		} else {
 			conn := cc.conn
@@ -619,19 +619,24 @@ func (s *Server) injectMessage(clawID, content, role string) {
 			cancel()
 			if err != nil {
 				log.Printf("[pr-watcher] failed to send injected message to claw %s: %v, queueing", shortID(clawID), err)
-				cc.mu.Lock()
-				cc.messageQueue = append([]types.HubMessage{msg}, cc.messageQueue...)
-				cc.mu.Unlock()
-				delivered = true
+				s.mu.RLock()
+				currentCC := s.claws[clawID]
+				s.mu.RUnlock()
+				if currentCC != nil {
+					currentCC.mu.Lock()
+					currentCC.messageQueue = append([]types.HubMessage{msg}, currentCC.messageQueue...)
+					queueLen := len(currentCC.messageQueue)
+					currentCC.mu.Unlock()
+					acceptedForAgent = true
+					log.Printf("[pr-watcher] queued injected message for claw %s after send failure (queue length: %d)", shortID(clawID), queueLen)
+				}
 			} else {
-				delivered = true
+				acceptedForAgent = true
+				log.Printf("[pr-watcher] delivered injected message to claw %s", shortID(clawID))
 			}
 		}
-		if delivered {
-			log.Printf("[pr-watcher] delivered injected message to claw %s", shortID(clawID))
-		}
 	}
-	if delivered {
+	if acceptedForAgent {
 		// Signal to UI that agent is working on the injected message
 		s.broadcastToUsers(tenantID, types.WSMessage{
 			Type: "agent_typing",
@@ -645,7 +650,7 @@ func (s *Server) injectMessage(clawID, content, role string) {
 	// If this is a user/hub message injection (not a claw response), move the issue
 	// to WorkingStatus if the claw was idle (watching for PR events).
 	// Only move if the message was delivered or queued for the agent.
-	if delivered && (role == "user" || role == "hub") {
+	if acceptedForAgent && (role == "user" || role == "hub") {
 		var currentStatus string
 		_ = s.db.QueryRow(`SELECT status FROM claws WHERE id=?`, clawID).Scan(&currentStatus)
 		if currentStatus == "idle" {

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -554,66 +554,84 @@ func (s *Server) updateReviewCommentWatermark(pr clawPR, reviewCommentsData []in
 
 // injectUserMessage inserts a user-role message into the claw's conversation
 // and forwards it over the WS connection (if connected) so the agent sees it.
-// Skips injection if the claw is currently streaming a response.
 func (s *Server) injectUserMessage(clawID, content string) {
-	s.injectMessageWithRetry(clawID, content, "user", 0)
+	s.injectMessage(clawID, content, "user")
 }
 
 // injectHubMessageByID inserts a hub-role message into the claw's conversation.
 // Hub messages are system-injected and rendered distinctly in the UI.
 func (s *Server) injectHubMessageByID(clawID, content string) {
-	s.injectMessageWithRetry(clawID, content, "hub", 0)
+	s.injectMessage(clawID, content, "hub")
 }
 
-func (s *Server) injectMessageWithRetry(clawID, content, role string, retryCount int) {
-	// Don't interrupt a response in progress
-	s.mu.RLock()
-	cc, connected := s.claws[clawID]
-	streaming := connected && cc.streamingBuf.Len() > 0
-	s.mu.RUnlock()
-	if streaming {
-		if retryCount < 1 {
-			log.Printf("[pr-watcher] claw %s is streaming, delaying injection", clawID[:8])
-			// Retry once after 30s
-			go func() {
-				time.Sleep(30 * time.Second)
-				s.injectMessageWithRetry(clawID, content, role, retryCount+1)
-			}()
-		} else {
-			log.Printf("[pr-watcher] claw %s still streaming after retry, dropping message", clawID[:8])
-		}
-		return
-	}
-
+func (s *Server) injectMessage(clawID, content, role string) {
 	// Resolve tenant
 	var tenantID string
 	if err := s.db.QueryRow(`SELECT tenant_id FROM claws WHERE id=?`, clawID).Scan(&tenantID); err != nil {
 		return
 	}
 
-	msgID := uuid.New().String()
 	format := ""
 	if role == "hub" {
 		format = "pre"
 	}
+	msg := types.HubMessage{
+		ID:        uuid.New().String(),
+		ClawID:    clawID,
+		TenantID:  tenantID,
+		Role:      role,
+		Content:   content,
+		Format:    format,
+		CreatedAt: now(),
+	}
 	_, err := s.db.Exec(
 		`INSERT INTO messages(id,claw_id,tenant_id,role,content,format,created_at) VALUES(?,?,?,?,?,?,?)`,
-		msgID, clawID, tenantID, role, content, format, now(),
+		msg.ID, msg.ClawID, msg.TenantID, msg.Role, msg.Content, msg.Format, msg.CreatedAt,
 	)
 	if err != nil {
 		log.Printf("[pr-watcher] failed to insert message: %v", err)
 		return
 	}
 
-	// Forward to agent over WS
+	// Broadcast to dashboard immediately, even if delivery to the agent is queued.
+	s.broadcastToUsers(tenantID, types.WSMessage{Type: "message", Payload: msg})
+
+	// Forward to agent over WS, or queue behind the current turn.
 	s.mu.RLock()
 	cc, ok := s.claws[clawID]
 	s.mu.RUnlock()
+	delivered := false
 	if ok {
-		_ = wsjson.Write(context.Background(), cc.conn, types.WSMessage{
-			Type:    "message",
-			Payload: map[string]string{"role": role, "content": content},
-		})
+		cc.mu.Lock()
+		cc.lastUserMessageAt = time.Now()
+		if cc.isBusyLocked() {
+			cc.messageQueue = append(cc.messageQueue, msg)
+			queueLen := len(cc.messageQueue)
+			cc.mu.Unlock()
+			delivered = true
+			log.Printf("[pr-watcher] queued injected message for claw %s (queue length: %d)", shortID(clawID), queueLen)
+		} else {
+			conn := cc.conn
+			cc.mu.Unlock()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			err := wsjson.Write(ctx, conn, types.WSMessage{Type: "message", Payload: msg})
+			cancel()
+			if err != nil {
+				log.Printf("[pr-watcher] failed to send injected message to claw %s: %v, queueing", shortID(clawID), err)
+				cc.mu.Lock()
+				cc.messageQueue = append([]types.HubMessage{msg}, cc.messageQueue...)
+				cc.mu.Unlock()
+				delivered = true
+			} else {
+				delivered = true
+			}
+		}
+		if delivered {
+			log.Printf("[pr-watcher] delivered injected message to claw %s", shortID(clawID))
+		}
+	}
+	if delivered {
 		// Signal to UI that agent is working on the injected message
 		s.broadcastToUsers(tenantID, types.WSMessage{
 			Type: "agent_typing",
@@ -626,8 +644,8 @@ func (s *Server) injectMessageWithRetry(clawID, content, role string, retryCount
 
 	// If this is a user/hub message injection (not a claw response), move the issue
 	// to WorkingStatus if the claw was idle (watching for PR events).
-	// Only move if the message was actually delivered to the agent (ok=true).
-	if ok && (role == "user" || role == "hub") {
+	// Only move if the message was delivered or queued for the agent.
+	if delivered && (role == "user" || role == "hub") {
 		var currentStatus string
 		_ = s.db.QueryRow(`SELECT status FROM claws WHERE id=?`, clawID).Scan(&currentStatus)
 		if currentStatus == "idle" {
@@ -680,20 +698,7 @@ func (s *Server) injectMessageWithRetry(clawID, content, role string, retryCount
 		}
 	}
 
-	// Broadcast to dashboard
-	s.broadcastToUsers(tenantID, types.WSMessage{
-		Type: "message",
-		Payload: map[string]interface{}{
-			"id":         msgID,
-			"claw_id":    clawID,
-			"tenant_id":  tenantID,
-			"role":       role,
-			"content":    content,
-			"format":     format,
-			"created_at": now(),
-		},
-	})
-	log.Printf("[pr-watcher] injected message into claw %s", clawID[:8])
+	log.Printf("[pr-watcher] injected message into claw %s", shortID(clawID))
 }
 
 // githubAPI makes a GET request to the GitHub API and returns parsed JSON.

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -629,6 +629,7 @@ func (s *Server) injectMessage(clawID, content, role string) {
 					currentCC.mu.Unlock()
 					acceptedForAgent = true
 					log.Printf("[pr-watcher] queued injected message for claw %s after send failure (queue length: %d)", shortID(clawID), queueLen)
+					go s.sendNextQueuedMessage(currentCC)
 				}
 			} else {
 				acceptedForAgent = true

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -112,6 +112,18 @@ func gatewayReadyBool(v *bool) bool {
 	return v == nil || *v
 }
 
+func (cc *clawConn) isBusyLocked() bool {
+	return !cc.streamingStartedAt.IsZero() || cc.streamingMsgID != ""
+}
+
+func (cc *clawConn) finishTurnLocked() {
+	cc.streamingMsgID = ""
+	cc.streamingBuf.Reset()
+	cc.streamingStartedAt = time.Time{}
+	cc.streamingTimeoutSent = false
+	cc.contextWarningSent = false
+}
+
 type userConn struct {
 	conn        *websocket.Conn
 	send        func(context.Context, types.WSMessage) error
@@ -1769,6 +1781,15 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				}
 			} else if msg.Type == "agent_activity" {
 				if activity, payload, ok := normalizeAgentActivityPayload(msg.Payload); ok {
+					if isBusyAgentActivity(activity) {
+						cc.mu.Lock()
+						if cc.streamingStartedAt.IsZero() {
+							cc.streamingStartedAt = time.Now()
+							cc.streamingTimeoutSent = false
+							cc.contextWarningSent = false
+						}
+						cc.mu.Unlock()
+					}
 					createdAt := now()
 					activity["claw_id"] = clawID
 					activity["created_at"] = createdAt.Format(time.RFC3339Nano)
@@ -1804,9 +1825,11 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 						cc.mu.Lock()
 						if cc.streamingMsgID == "" {
 							cc.streamingMsgID = uuid.New().String()
-							cc.streamingStartedAt = time.Now()
 							cc.streamingTimeoutSent = false
 							cc.contextWarningSent = false
+						}
+						if cc.streamingStartedAt.IsZero() {
+							cc.streamingStartedAt = time.Now()
 						}
 						cc.streamingBuf.WriteString(chunk.Content)
 						msgID := cc.streamingMsgID
@@ -1837,14 +1860,10 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				cc.mu.Lock()
 				if cc.streamingMsgID != "" {
 					hm.ID = cc.streamingMsgID
-					cc.streamingMsgID = ""
-					cc.streamingBuf.Reset()
-					cc.streamingStartedAt = time.Time{}
-					cc.streamingTimeoutSent = false
-					cc.contextWarningSent = false
 				} else {
 					hm.ID = uuid.New().String()
 				}
+				cc.finishTurnLocked()
 				cc.mu.Unlock()
 				// Drop empty messages — never store or broadcast
 				if strings.TrimSpace(hm.Content) == "" {
@@ -3070,6 +3089,24 @@ func normalizeAgentActivityPayload(payload interface{}) (map[string]interface{},
 		return nil, nil, false
 	}
 	return activity, raw, true
+}
+
+func isBusyAgentActivity(activity map[string]interface{}) bool {
+	kind, _ := activity["kind"].(string)
+	switch strings.ToLower(strings.TrimSpace(kind)) {
+	case "model_started":
+		return true
+	case "tool":
+		phase, _ := activity["phase"].(string)
+		switch strings.ToLower(strings.TrimSpace(phase)) {
+		case "completed", "complete", "done", "failed", "error", "cancelled", "canceled":
+			return false
+		default:
+			return true
+		}
+	default:
+		return false
+	}
 }
 
 func isPhaseActivityText(value string) bool {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -4778,7 +4778,7 @@ func (s *Server) sendNextQueuedMessage(cc *clawConn) {
 	}
 
 	// Check if claw is still busy
-	if !cc.streamingStartedAt.IsZero() || cc.streamingMsgID != "" {
+	if cc.isBusyLocked() {
 		cc.mu.Unlock()
 		return
 	}

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -650,3 +650,98 @@ func TestNormalizeAgentActivityPayloadRejectsNull(t *testing.T) {
 		t.Fatalf("valid payload normalized to activity=%v raw=%q ok=%v", activity, raw, ok)
 	}
 }
+
+func TestBusyAgentActivitySignals(t *testing.T) {
+	tests := []struct {
+		name     string
+		activity map[string]interface{}
+		want     bool
+	}{
+		{
+			name:     "model started",
+			activity: map[string]interface{}{"kind": "model_started"},
+			want:     true,
+		},
+		{
+			name:     "tool running",
+			activity: map[string]interface{}{"kind": "tool", "phase": "running"},
+			want:     true,
+		},
+		{
+			name:     "tool completed",
+			activity: map[string]interface{}{"kind": "tool", "phase": "completed"},
+			want:     false,
+		},
+		{
+			name:     "session error",
+			activity: map[string]interface{}{"kind": "session_error"},
+			want:     false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isBusyAgentActivity(tt.activity); got != tt.want {
+				t.Fatalf("isBusyAgentActivity() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFinishTurnClearsActivityOnlyBusyState(t *testing.T) {
+	cc := &clawConn{
+		id:                   "claw-1",
+		tenantID:             "test-tenant-id",
+		streamingStartedAt:   now(),
+		streamingTimeoutSent: true,
+		contextWarningSent:   true,
+	}
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+	if !cc.isBusyLocked() {
+		t.Fatal("expected activity-only turn to be busy")
+	}
+	cc.finishTurnLocked()
+	if cc.isBusyLocked() {
+		t.Fatal("expected finishTurnLocked to clear busy state")
+	}
+	if cc.streamingTimeoutSent || cc.contextWarningSent {
+		t.Fatal("expected finishTurnLocked to clear turn warnings")
+	}
+}
+
+func TestInjectUserMessageQueuesWhenActivityOnlyTurnIsBusy(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, nil, "", "", "")
+	_, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, tags, created_at, status) VALUES(?,?,?,?,datetime('now'),?)`,
+		"claw-1", "test-tenant-id", "claw 1", `[]`, "connected",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cc := &clawConn{
+		id:                 "claw-1",
+		tenantID:           "test-tenant-id",
+		streamingStartedAt: now(),
+	}
+	s.claws["claw-1"] = cc
+
+	s.injectUserMessage("claw-1", "New greptile review comment on PR #339")
+
+	cc.mu.Lock()
+	if len(cc.messageQueue) != 1 {
+		t.Fatalf("expected 1 queued message, got %d", len(cc.messageQueue))
+	}
+	queued := cc.messageQueue[0]
+	cc.mu.Unlock()
+	if queued.Role != "user" || queued.Content != "New greptile review comment on PR #339" {
+		t.Fatalf("queued message = %#v", queued)
+	}
+
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND content=?`, "claw-1", queued.Content).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("expected persisted injected message, got count %d", count)
+	}
+}


### PR DESCRIPTION
## Summary
- treat model_started and active tool activity as a busy agent turn, even before assistant chunks arrive
- clear busy state when any completed claw message arrives, including silent/no-chunk turns
- persist and display PR watcher injected messages immediately, but queue them behind active turns instead of writing directly to the bridge

## Tests
- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./pkg/hub