### PR TITLE
Recover bridge sessions after context overflow

### DIFF
--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -1417,8 +1417,7 @@ func isRecoverableSessionSendError(err error) bool {
 	}
 	msg := strings.ToLower(err.Error())
 	return strings.Contains(msg, "context overflow") ||
-		strings.Contains(msg, "prompt too large") ||
-		strings.Contains(msg, "context deadline exceeded")
+		strings.Contains(msg, "prompt too large")
 }
 
 // SendMessage sends a user message to the persistent session, streams chunks
@@ -1432,6 +1431,9 @@ func (gs *gatewaySession) SendMessage(ctx context.Context, message string, onChu
 	if err == nil || !isRecoverableSessionSendError(err) {
 		return reply, err
 	}
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return "", ctxErr
+	}
 
 	recoveryCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	resetErr := gs.createFreshSession(recoveryCtx, err.Error())
@@ -1440,14 +1442,8 @@ func (gs *gatewaySession) SendMessage(ctx context.Context, message string, onChu
 		return "", fmt.Errorf("%w; session recovery failed: %v", err, resetErr)
 	}
 
-	retryCtx := ctx
-	retryCancel := func() {}
-	if ctx.Err() != nil {
-		retryCtx, retryCancel = context.WithTimeout(context.Background(), 30*time.Minute)
-	}
-	defer retryCancel()
 	log.Printf("[session] retrying message in fresh session after recoverable error")
-	return gs.sendMessageOnce(retryCtx, message, onChunk, onActivity)
+	return gs.sendMessageOnce(ctx, message, onChunk, onActivity)
 }
 
 func (gs *gatewaySession) sendMessageOnce(ctx context.Context, message string, onChunk func(string), onActivity func(agentActivity)) (string, error) {

--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -1385,6 +1385,42 @@ func (gs *gatewaySession) setReady() {
 	go gs.refreshContextUsage(context.Background())
 }
 
+func (gs *gatewaySession) createFreshSession(ctx context.Context, reason string) error {
+	log.Printf("[session] creating fresh session after %s", reason)
+	resp, err := gs.sendReq(ctx, "sessions.create", map[string]string{"agentId": "main"})
+	if err != nil {
+		return fmt.Errorf("sessions.create: %w", err)
+	}
+	var payload struct {
+		Key string `json:"key"`
+	}
+	_ = json.Unmarshal(resp.Payload, &payload)
+	if payload.Key == "" {
+		return fmt.Errorf("sessions.create returned empty key")
+	}
+	gs.sessionKey = payload.Key
+	saveBridgeSession(payload.Key)
+	if err := gs.subscribe(ctx); err != nil {
+		return err
+	}
+	gs.ctxMu.Lock()
+	gs.contextUsage = 0
+	gs.ctxMu.Unlock()
+	gs.setReady()
+	log.Printf("[session] recovered with fresh session: %s", gs.sessionKey)
+	return nil
+}
+
+func isRecoverableSessionSendError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "context overflow") ||
+		strings.Contains(msg, "prompt too large") ||
+		strings.Contains(msg, "context deadline exceeded")
+}
+
 // SendMessage sends a user message to the persistent session, streams chunks
 // via onChunk, and returns the full response text.
 func (gs *gatewaySession) SendMessage(ctx context.Context, message string, onChunk func(string), onActivity func(agentActivity)) (string, error) {
@@ -1392,6 +1428,29 @@ func (gs *gatewaySession) SendMessage(ctx context.Context, message string, onChu
 	gs.sendMu.Lock()
 	defer gs.sendMu.Unlock()
 
+	reply, err := gs.sendMessageOnce(ctx, message, onChunk, onActivity)
+	if err == nil || !isRecoverableSessionSendError(err) {
+		return reply, err
+	}
+
+	recoveryCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	resetErr := gs.createFreshSession(recoveryCtx, err.Error())
+	cancel()
+	if resetErr != nil {
+		return "", fmt.Errorf("%w; session recovery failed: %v", err, resetErr)
+	}
+
+	retryCtx := ctx
+	retryCancel := func() {}
+	if ctx.Err() != nil {
+		retryCtx, retryCancel = context.WithTimeout(context.Background(), 30*time.Minute)
+	}
+	defer retryCancel()
+	log.Printf("[session] retrying message in fresh session after recoverable error")
+	return gs.sendMessageOnce(retryCtx, message, onChunk, onActivity)
+}
+
+func (gs *gatewaySession) sendMessageOnce(ctx context.Context, message string, onChunk func(string), onActivity func(agentActivity)) (string, error) {
 	inf := &inFlightState{
 		onChunk:    onChunk,
 		onActivity: onActivity,

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -398,7 +398,8 @@ func TestIsRecoverableSessionSendError(t *testing.T) {
 		want bool
 	}{
 		{name: "nil", err: nil, want: false},
-		{name: "context overflow", err: context.DeadlineExceeded, want: true},
+		{name: "caller deadline", err: context.DeadlineExceeded, want: false},
+		{name: "context overflow", err: errString("context overflow detected"), want: true},
 		{name: "prompt too large", err: errString("Context overflow: prompt too large for the model"), want: true},
 		{name: "send failure", err: errString("sessions.send failed: tool crashed"), want: false},
 	}

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -390,3 +390,27 @@ func TestGatewayReadLoopFailsPendingRequestsOnDisconnect(t *testing.T) {
 		t.Fatalf("pending requests = %d, want 0", pendingLen)
 	}
 }
+
+func TestIsRecoverableSessionSendError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "context overflow", err: context.DeadlineExceeded, want: true},
+		{name: "prompt too large", err: errString("Context overflow: prompt too large for the model"), want: true},
+		{name: "send failure", err: errString("sessions.send failed: tool crashed"), want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isRecoverableSessionSendError(tt.err); got != tt.want {
+				t.Fatalf("isRecoverableSessionSendError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+type errString string
+
+func (e errString) Error() string { return string(e) }


### PR DESCRIPTION
## Summary
- create a fresh OpenClaw gateway session after recoverable send failures such as context overflow, prompt-too-large, or model deadline errors
- retry the triggering message once in the fresh session instead of surfacing repeated claw-bridge errors in chat
- reset saved session key/context usage after recovery

## Tests
- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./cmd/claw-bridge
- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./...