### PR TITLE
Retry transient LLM upstream errors

### DIFF
--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -26,6 +26,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -1427,23 +1428,39 @@ func (gs *gatewaySession) SendMessage(ctx context.Context, message string, onChu
 	gs.sendMu.Lock()
 	defer gs.sendMu.Unlock()
 
-	reply, err := gs.sendMessageOnce(ctx, message, onChunk, onActivity)
-	if err == nil || !isRecoverableSessionSendError(err) {
-		return reply, err
-	}
-	if ctxErr := ctx.Err(); ctxErr != nil {
-		return "", ctxErr
-	}
+	delays := []time.Duration{2 * time.Second, 5 * time.Second}
+	for attempt := 0; ; attempt++ {
+		reply, err := gs.sendMessageOnce(ctx, message, onChunk, onActivity)
+		if err == nil {
+			return reply, err
+		}
+		if isRetryableLLMSendRequestError(err) && attempt < len(delays) {
+			delay := delays[attempt]
+			log.Printf("[gateway] transient LLM error on attempt %d/%d: %v — retrying in %s", attempt+1, len(delays)+1, err, delay)
+			select {
+			case <-time.After(delay):
+			case <-ctx.Done():
+				return "", ctx.Err()
+			}
+			continue
+		}
+		if !isRecoverableSessionSendError(err) {
+			return reply, err
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return "", ctxErr
+		}
 
-	recoveryCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	resetErr := gs.createFreshSession(recoveryCtx, err.Error())
-	cancel()
-	if resetErr != nil {
-		return "", fmt.Errorf("%w; session recovery failed: %v", err, resetErr)
-	}
+		recoveryCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		resetErr := gs.createFreshSession(recoveryCtx, err.Error())
+		cancel()
+		if resetErr != nil {
+			return "", fmt.Errorf("%w; session recovery failed: %v", err, resetErr)
+		}
 
-	log.Printf("[session] retrying message in fresh session after recoverable error")
-	return gs.sendMessageOnce(ctx, message, onChunk, onActivity)
+		log.Printf("[session] retrying message in fresh session after recoverable error")
+		return gs.sendMessageOnce(ctx, message, onChunk, onActivity)
+	}
 }
 
 func (gs *gatewaySession) sendMessageOnce(ctx context.Context, message string, onChunk func(string), onActivity func(agentActivity)) (string, error) {
@@ -1467,7 +1484,7 @@ func (gs *gatewaySession) sendMessageOnce(ctx context.Context, message string, o
 		"message": message,
 	})
 	if err != nil {
-		return "", fmt.Errorf("sessions.send: %w", err)
+		return "", &sessionSendRequestError{err: err}
 	}
 	log.Printf("[gateway] message sent, streaming response...")
 	inf.mu.Lock()
@@ -1498,6 +1515,39 @@ func (gs *gatewaySession) sendMessageOnce(ctx context.Context, message string, o
 			return "", ctx.Err()
 		}
 	}
+}
+
+type sessionSendRequestError struct {
+	err error
+}
+
+func (e *sessionSendRequestError) Error() string {
+	return fmt.Sprintf("sessions.send: %v", e.err)
+}
+
+func (e *sessionSendRequestError) Unwrap() error {
+	return e.err
+}
+
+func isRetryableLLMSendRequestError(err error) bool {
+	var sendErr *sessionSendRequestError
+	if !errors.As(err, &sendErr) {
+		return false
+	}
+	return isRetryableLLMSendError(sendErr.err)
+}
+
+func isRetryableLLMSendError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "api_error") ||
+		strings.Contains(msg, "upstream error") ||
+		strings.Contains(msg, "overloaded") ||
+		strings.Contains(msg, "temporarily unavailable") ||
+		strings.Contains(msg, "rate limit") ||
+		strings.Contains(msg, "timeout")
 }
 
 func formatActivityDuration(d time.Duration) string {

--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -1431,6 +1431,9 @@ func (gs *gatewaySession) SendMessage(ctx context.Context, message string, onChu
 	delays := []time.Duration{2 * time.Second, 5 * time.Second}
 	for attempt := 0; ; attempt++ {
 		reply, err := gs.sendMessageOnce(ctx, message, onChunk, onActivity)
+		// Retry only failures from the initial sessions.send request. Once the
+		// request is accepted, chunks may already be visible to the UI, so stream
+		// or lifecycle errors must not replay the turn.
 		if err == nil {
 			return reply, err
 		}
@@ -1547,7 +1550,8 @@ func isRetryableLLMSendError(err error) bool {
 		strings.Contains(msg, "overloaded") ||
 		strings.Contains(msg, "temporarily unavailable") ||
 		strings.Contains(msg, "rate limit") ||
-		strings.Contains(msg, "timeout")
+		strings.Contains(msg, "request timeout") ||
+		strings.Contains(msg, "model timeout")
 }
 
 func formatActivityDuration(d time.Duration) string {

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -412,6 +412,29 @@ func TestIsRecoverableSessionSendError(t *testing.T) {
 	}
 }
 
+func TestIsRetryableLLMSendError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "api upstream", err: errString("api_error: upstream error"), want: true},
+		{name: "overloaded", err: errString("provider overloaded, try again"), want: true},
+		{name: "temporary unavailable", err: errString("model temporarily unavailable"), want: true},
+		{name: "rate limit", err: errString("rate limit exceeded"), want: true},
+		{name: "timeout", err: errString("request timeout waiting for model"), want: true},
+		{name: "permanent tool error", err: errString("tool-policy: exec is not allowed"), want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isRetryableLLMSendError(tt.err); got != tt.want {
+				t.Fatalf("isRetryableLLMSendError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
 type errString string
 
 func (e errString) Error() string { return string(e) }

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -423,7 +423,9 @@ func TestIsRetryableLLMSendError(t *testing.T) {
 		{name: "overloaded", err: errString("provider overloaded, try again"), want: true},
 		{name: "temporary unavailable", err: errString("model temporarily unavailable"), want: true},
 		{name: "rate limit", err: errString("rate limit exceeded"), want: true},
-		{name: "timeout", err: errString("request timeout waiting for model"), want: true},
+		{name: "request timeout", err: errString("request timeout waiting for model"), want: true},
+		{name: "model timeout", err: errString("model timeout waiting for completion"), want: true},
+		{name: "transport timeout", err: errString("sessions.send: i/o timeout"), want: false},
 		{name: "permanent tool error", err: errString("tool-policy: exec is not allowed"), want: false},
 	}
 	for _, tt := range tests {
@@ -443,7 +445,10 @@ func TestIsRetryableLLMSendRequestError(t *testing.T) {
 	}{
 		{name: "nil", err: nil, want: false},
 		{name: "lifecycle upstream", err: errString("api_error: upstream error"), want: false},
+		{name: "lifecycle model timeout", err: errString("model timeout waiting for completion"), want: false},
 		{name: "send request upstream", err: &sessionSendRequestError{err: errString("api_error: upstream error")}, want: true},
+		{name: "send request model timeout", err: &sessionSendRequestError{err: errString("model timeout waiting for completion")}, want: true},
+		{name: "send request transport timeout", err: &sessionSendRequestError{err: errString("i/o timeout")}, want: false},
 		{name: "send request permanent", err: &sessionSendRequestError{err: errString("tool-policy: exec is not allowed")}, want: false},
 	}
 	for _, tt := range tests {

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -435,6 +435,26 @@ func TestIsRetryableLLMSendError(t *testing.T) {
 	}
 }
 
+func TestIsRetryableLLMSendRequestError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "lifecycle upstream", err: errString("api_error: upstream error"), want: false},
+		{name: "send request upstream", err: &sessionSendRequestError{err: errString("api_error: upstream error")}, want: true},
+		{name: "send request permanent", err: &sessionSendRequestError{err: errString("tool-policy: exec is not allowed")}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isRetryableLLMSendRequestError(tt.err); got != tt.want {
+				t.Fatalf("isRetryableLLMSendRequestError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
 type errString string
 
 func (e errString) Error() string { return string(e) }


### PR DESCRIPTION
## Summary
- retry bridge sends when the gateway reports transient LLM/provider failures such as api_error upstream error
- use bounded backoff retries before surfacing the error to chat
- keep permanent failures such as tool-policy errors non-retryable

## Tests
- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./cmd/claw-bridge
- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./...