### PR TITLE
Link GitHub issue agent titles

### DIFF
--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -787,7 +787,7 @@ func (s *Server) handleClaws(w http.ResponseWriter, r *http.Request) {
 	}
 
 	rows, err := s.db.Query(
-		`SELECT id, name, template, COALESCE(provider,''), COALESCE(provider_id,''), status, last_seen, created_at, ssh_host, ssh_port, ssh_user, COALESCE(tags,'[]'), COALESCE(color,''), COALESCE(bootstrap_status,''), COALESCE(bootstrap_diagnostic,'') FROM claws WHERE tenant_id = ? AND status != 'deleted' ORDER BY created_at DESC`,
+		`SELECT id, name, template, COALESCE(provider,''), COALESCE(provider_id,''), status, last_seen, created_at, ssh_host, ssh_port, ssh_user, COALESCE(tags,'[]'), COALESCE(color,''), COALESCE(bootstrap_status,''), COALESCE(bootstrap_diagnostic,''), COALESCE(github_issue_id,'') FROM claws WHERE tenant_id = ? AND status != 'deleted' ORDER BY created_at DESC`,
 		tenantID,
 	)
 	if err != nil {
@@ -811,9 +811,10 @@ func (s *Server) handleClaws(w http.ResponseWriter, r *http.Request) {
 		var c types.Claw
 		var lastSeen sql.NullTime
 		var tagsJSON string
-		if err := rows.Scan(&c.ID, &c.Name, &c.Template, &c.Provider, &c.ProviderID, &c.Status, &lastSeen, &c.CreatedAt, &c.SSHHost, &c.SSHPort, &c.SSHUser, &tagsJSON, &c.Color, &c.BootstrapStatus, &c.BootstrapDiagnostic); err != nil {
+		if err := rows.Scan(&c.ID, &c.Name, &c.Template, &c.Provider, &c.ProviderID, &c.Status, &lastSeen, &c.CreatedAt, &c.SSHHost, &c.SSHPort, &c.SSHUser, &tagsJSON, &c.Color, &c.BootstrapStatus, &c.BootstrapDiagnostic, &c.GitHubIssueID); err != nil {
 			continue
 		}
+		c.GitHubIssueURL = githubIssueURL(c.GitHubIssueID)
 		_ = json.Unmarshal([]byte(tagsJSON), &c.Tags)
 		c.TenantID = tenantID
 		if lastSeen.Valid {
@@ -845,6 +846,14 @@ func (s *Server) handleClaws(w http.ResponseWriter, r *http.Request) {
 		out = []types.Claw{}
 	}
 	jsonOK(w, out)
+}
+
+func githubIssueURL(issueID string) string {
+	parts := strings.Split(issueID, "/")
+	if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+		return ""
+	}
+	return fmt.Sprintf("https://github.com/%s/%s/issues/%s", parts[0], parts[1], parts[2])
 }
 
 func (s *Server) handleCreateClaw(w http.ResponseWriter, r *http.Request, tenantID string) {
@@ -1256,9 +1265,9 @@ func (s *Server) handleClawDetail(w http.ResponseWriter, r *http.Request) {
 	var lastSeen sql.NullTime
 	var tagsJSON string
 	err := s.db.QueryRow(
-		`SELECT id, name, template, COALESCE(provider,''), COALESCE(provider_id,''), status, last_seen, created_at, ssh_host, ssh_port, ssh_user, COALESCE(tags,'[]'), COALESCE(color,''), COALESCE(bootstrap_status,''), COALESCE(bootstrap_diagnostic,'') FROM claws WHERE id = ? AND tenant_id = ? AND status != 'deleted'`,
+		`SELECT id, name, template, COALESCE(provider,''), COALESCE(provider_id,''), status, last_seen, created_at, ssh_host, ssh_port, ssh_user, COALESCE(tags,'[]'), COALESCE(color,''), COALESCE(bootstrap_status,''), COALESCE(bootstrap_diagnostic,''), COALESCE(github_issue_id,'') FROM claws WHERE id = ? AND tenant_id = ? AND status != 'deleted'`,
 		clawID, tenantID,
-	).Scan(&c.ID, &c.Name, &c.Template, &c.Provider, &c.ProviderID, &c.Status, &lastSeen, &c.CreatedAt, &c.SSHHost, &c.SSHPort, &c.SSHUser, &tagsJSON, &c.Color, &c.BootstrapStatus, &c.BootstrapDiagnostic)
+	).Scan(&c.ID, &c.Name, &c.Template, &c.Provider, &c.ProviderID, &c.Status, &lastSeen, &c.CreatedAt, &c.SSHHost, &c.SSHPort, &c.SSHUser, &tagsJSON, &c.Color, &c.BootstrapStatus, &c.BootstrapDiagnostic, &c.GitHubIssueID)
 	_ = json.Unmarshal([]byte(tagsJSON), &c.Tags)
 	if err == sql.ErrNoRows {
 		http.Error(w, "not found", http.StatusNotFound)
@@ -1273,6 +1282,7 @@ func (s *Server) handleClawDetail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	c.TenantID = tenantID
+	c.GitHubIssueURL = githubIssueURL(c.GitHubIssueID)
 	if lastSeen.Valid {
 		c.LastSeen = lastSeen.Time
 	}
@@ -2076,14 +2086,14 @@ func (s *Server) handleUserWS(w http.ResponseWriter, r *http.Request) {
 	// Send current claw statuses immediately on connect.
 	// First, emit DB rows for claws not yet bridge-connected (provisioning/starting/error).
 	type dbClaw struct {
-		id, name, status, tagsJSON, bootstrapStatus, bootstrapDiagnostic string
+		id, name, status, tagsJSON, bootstrapStatus, bootstrapDiagnostic, githubIssueID string
 	}
 	var dbClaws []dbClaw
-	rows, _ := s.db.QueryContext(ctx, `SELECT id, name, status, COALESCE(tags,'[]'), COALESCE(bootstrap_status,''), COALESCE(bootstrap_diagnostic,'') FROM claws WHERE tenant_id=? AND status NOT IN ('offline')`, tenantID)
+	rows, _ := s.db.QueryContext(ctx, `SELECT id, name, status, COALESCE(tags,'[]'), COALESCE(bootstrap_status,''), COALESCE(bootstrap_diagnostic,''), COALESCE(github_issue_id,'') FROM claws WHERE tenant_id=? AND status NOT IN ('offline')`, tenantID)
 	if rows != nil {
 		for rows.Next() {
 			var c dbClaw
-			_ = rows.Scan(&c.id, &c.name, &c.status, &c.tagsJSON, &c.bootstrapStatus, &c.bootstrapDiagnostic)
+			_ = rows.Scan(&c.id, &c.name, &c.status, &c.tagsJSON, &c.bootstrapStatus, &c.bootstrapDiagnostic, &c.githubIssueID)
 			dbClaws = append(dbClaws, c)
 		}
 		_ = rows.Close()
@@ -2134,6 +2144,8 @@ func (s *Server) handleUserWS(w http.ResponseWriter, r *http.Request) {
 				"status":               c.status, // provisioning / starting / error
 				"bootstrap_status":     c.bootstrapStatus,
 				"bootstrap_diagnostic": c.bootstrapDiagnostic,
+				"github_issue_id":      c.githubIssueID,
+				"github_issue_url":     githubIssueURL(c.githubIssueID),
 			},
 		})
 	}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -853,6 +853,11 @@ func githubIssueURL(issueID string) string {
 	if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
 		return ""
 	}
+	for _, ch := range parts[2] {
+		if ch < '0' || ch > '9' {
+			return ""
+		}
+	}
 	return fmt.Sprintf("https://github.com/%s/%s/issues/%s", parts[0], parts[1], parts[2])
 }
 

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -413,6 +413,15 @@ func TestClawAPIReturnsGitHubIssueLink(t *testing.T) {
 	}
 }
 
+func TestGitHubIssueURLRequiresNumericIssueNumber(t *testing.T) {
+	if got := githubIssueURL("elasticclaw/elasticclaw/342"); got != "https://github.com/elasticclaw/elasticclaw/issues/342" {
+		t.Fatalf("githubIssueURL(valid) = %q", got)
+	}
+	if got := githubIssueURL("elasticclaw/elasticclaw/not-a-number"); got != "" {
+		t.Fatalf("githubIssueURL(invalid) = %q, want empty", got)
+	}
+}
+
 func TestClawSubresourceRequiresTagAccessForGitHubSession(t *testing.T) {
 	s, db := NewTestServerWithConfig(t, &types.HubConfig{
 		Auth: &types.AuthConfig{

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -365,6 +365,54 @@ func TestDeleteClawSoftDeletesAndHidesFromAPI(t *testing.T) {
 	}
 }
 
+func TestClawAPIReturnsGitHubIssueLink(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, nil, "", "", "")
+	_, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, tags, created_at, status, github_issue_id) VALUES(?,?,?,?,datetime('now'),?,?)`,
+		"claw-1", "test-tenant-id", "elasticclaw/elasticclaw/342", `[]`, "connected", "elasticclaw/elasticclaw/342",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	listReq := httptest.NewRequest(http.MethodGet, "/api/claws", nil)
+	listReq = listReq.WithContext(context.WithValue(listReq.Context(), ctxTenantKey{}, "test-tenant-id"))
+	listRec := httptest.NewRecorder()
+	s.handleClaws(listRec, listReq)
+	if listRec.Code != http.StatusOK {
+		t.Fatalf("expected list status %d, got %d", http.StatusOK, listRec.Code)
+	}
+	var claws []types.Claw
+	if err := json.NewDecoder(listRec.Body).Decode(&claws); err != nil {
+		t.Fatal(err)
+	}
+	if len(claws) != 1 {
+		t.Fatalf("expected 1 claw, got %d", len(claws))
+	}
+	if claws[0].GitHubIssueID != "elasticclaw/elasticclaw/342" {
+		t.Fatalf("github_issue_id = %q", claws[0].GitHubIssueID)
+	}
+	if claws[0].GitHubIssueURL != "https://github.com/elasticclaw/elasticclaw/issues/342" {
+		t.Fatalf("github_issue_url = %q", claws[0].GitHubIssueURL)
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/api/claws/claw-1", nil)
+	getReq = getReq.WithContext(context.WithValue(getReq.Context(), ctxTenantKey{}, "test-tenant-id"))
+	getReq.SetPathValue("id", "claw-1")
+	getRec := httptest.NewRecorder()
+	s.handleClawDetail(getRec, getReq)
+	if getRec.Code != http.StatusOK {
+		t.Fatalf("expected detail status %d, got %d", http.StatusOK, getRec.Code)
+	}
+	var claw types.Claw
+	if err := json.NewDecoder(getRec.Body).Decode(&claw); err != nil {
+		t.Fatal(err)
+	}
+	if claw.GitHubIssueURL != "https://github.com/elasticclaw/elasticclaw/issues/342" {
+		t.Fatalf("detail github_issue_url = %q", claw.GitHubIssueURL)
+	}
+}
+
 func TestClawSubresourceRequiresTagAccessForGitHubSession(t *testing.T) {
 	s, db := NewTestServerWithConfig(t, &types.HubConfig{
 		Auth: &types.AuthConfig{

--- a/pkg/types/hub.go
+++ b/pkg/types/hub.go
@@ -4,23 +4,25 @@ import "time"
 
 // Claw represents an agent instance registered with the hub.
 type Claw struct {
-	ID              string         `json:"id" db:"id"`
-	TenantID        string         `json:"tenant_id" db:"tenant_id"`
-	Name            string         `json:"name" db:"name"`
-	Template        string         `json:"template" db:"template"`
-	Provider        string         `json:"provider,omitempty" db:"provider"`
-	ProviderID      string         `json:"provider_id,omitempty" db:"provider_id"`
-	Status          InstanceStatus `json:"status" db:"status"`
-	LastSeen        time.Time      `json:"last_seen" db:"last_seen"`
-	CreatedAt       time.Time      `json:"created_at" db:"created_at"`
-	ContextUsage    int            `json:"context_usage"`
-	BootstrapStatus    string         `json:"bootstrap_status,omitempty"`
+	ID                  string         `json:"id" db:"id"`
+	TenantID            string         `json:"tenant_id" db:"tenant_id"`
+	Name                string         `json:"name" db:"name"`
+	Template            string         `json:"template" db:"template"`
+	Provider            string         `json:"provider,omitempty" db:"provider"`
+	ProviderID          string         `json:"provider_id,omitempty" db:"provider_id"`
+	Status              InstanceStatus `json:"status" db:"status"`
+	LastSeen            time.Time      `json:"last_seen" db:"last_seen"`
+	CreatedAt           time.Time      `json:"created_at" db:"created_at"`
+	ContextUsage        int            `json:"context_usage"`
+	BootstrapStatus     string         `json:"bootstrap_status,omitempty"`
 	BootstrapDiagnostic string         `json:"bootstrap_diagnostic,omitempty"`
-	Tags            []string       `json:"tags,omitempty"`
-	Color           string         `json:"color,omitempty"`
-	SSHHost         string         `json:"ssh_host,omitempty"`
-	SSHPort         int            `json:"ssh_port,omitempty"`
-	SSHUser         string         `json:"ssh_user,omitempty"`
+	GitHubIssueID       string         `json:"github_issue_id,omitempty"`
+	GitHubIssueURL      string         `json:"github_issue_url,omitempty"`
+	Tags                []string       `json:"tags,omitempty"`
+	Color               string         `json:"color,omitempty"`
+	SSHHost             string         `json:"ssh_host,omitempty"`
+	SSHPort             int            `json:"ssh_port,omitempty"`
+	SSHUser             string         `json:"ssh_user,omitempty"`
 }
 
 // HubMessage is a message exchanged between a claw and a user.

--- a/web/components/claw-card.tsx
+++ b/web/components/claw-card.tsx
@@ -9,6 +9,7 @@ import { TagEditor } from "@/components/tag-editor"
 import { patchClaw } from "@/lib/api"
 import { Loader2, Pin, AlertCircle, Pencil } from "lucide-react"
 import { BootstrapProgress } from "@/components/bootstrap-progress"
+import { ClawTitle } from "@/components/claw-title"
 
 interface ClawCardProps {
   claw: Claw
@@ -148,7 +149,7 @@ export function ClawCard({ claw, isSelected, onClick, onTogglePin, onTagsChange,
         <StatusIndicator status={claw.status} isStreaming={claw.isStreaming} />
         <span 
           className={cn(
-            "font-mono text-sm truncate flex-1 group/name flex items-center gap-1",
+            "font-mono text-sm min-w-0 flex-1 group/name flex items-center gap-1",
             hasUnread ? "text-foreground font-medium" : "text-foreground"
           )}
         >
@@ -164,7 +165,12 @@ export function ClawCard({ claw, isSelected, onClick, onTogglePin, onTagsChange,
             />
           ) : (
             <>
-              <span className="truncate">{localName}</span>
+              <ClawTitle
+                name={localName}
+                githubIssueId={claw.githubIssueId}
+                githubIssueUrl={claw.githubIssueUrl}
+                className="flex-1"
+              />
               <button
                 onClick={startRename}
                 className="opacity-0 group-hover/name:opacity-60 hover:!opacity-100 transition-opacity flex-shrink-0"

--- a/web/components/claw-title.tsx
+++ b/web/components/claw-title.tsx
@@ -1,0 +1,52 @@
+"use client"
+
+import { cn } from "@/lib/utils"
+
+export function IssueAwareTitle({ name }: { name: string }) {
+  const lastSlash = name.lastIndexOf("/")
+  if (lastSlash <= 0 || lastSlash === name.length - 1) {
+    return <span className="block min-w-0 truncate">{name}</span>
+  }
+
+  return (
+    <span className="min-w-0 flex items-baseline">
+      <span className="min-w-0 truncate">{name.slice(0, lastSlash + 1)}</span>
+      <span className="shrink-0">{name.slice(lastSlash + 1)}</span>
+    </span>
+  )
+}
+
+export function ClawTitle({
+  name,
+  githubIssueId,
+  githubIssueUrl,
+  className,
+}: {
+  name: string
+  githubIssueId?: string
+  githubIssueUrl?: string
+  className?: string
+}) {
+  if (!githubIssueUrl) {
+    return (
+      <span className={cn("min-w-0", className)}>
+        <IssueAwareTitle name={name} />
+      </span>
+    )
+  }
+
+  return (
+    <a
+      href={githubIssueUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      title={githubIssueId ? `Open ${githubIssueId}` : "Open GitHub issue"}
+      onPointerDown={(e) => e.stopPropagation()}
+      onClick={(e) => e.stopPropagation()}
+      onKeyDown={(e) => e.stopPropagation()}
+      className={cn("min-w-0 rounded-sm hover:underline focus:outline-none focus:ring-1 focus:ring-ring", className)}
+    >
+      <IssueAwareTitle name={name} />
+    </a>
+  )
+}

--- a/web/components/conversation-view.tsx
+++ b/web/components/conversation-view.tsx
@@ -432,12 +432,23 @@ function ClawBoardCard({
               </span>
               <StatusDot status={claw.status} isStreaming={claw.isStreaming} />
               {claw.githubIssueUrl ? (
-                <ClawTitle
-                  name={claw.name}
-                  githubIssueId={claw.githubIssueId}
-                  githubIssueUrl={claw.githubIssueUrl}
-                  className="flex-1 font-mono text-sm font-medium text-foreground"
-                />
+                <>
+                  <ClawTitle
+                    name={claw.name}
+                    githubIssueId={claw.githubIssueId}
+                    githubIssueUrl={claw.githubIssueUrl}
+                    className="flex-1 font-mono text-sm font-medium text-foreground"
+                  />
+                  {!isPending && (
+                    <button
+                      onClick={onClick}
+                      className="p-1 rounded hover:bg-accent transition-colors"
+                      title="Open conversation"
+                    >
+                      <MessageSquare className="size-3.5 text-muted-foreground" />
+                    </button>
+                  )}
+                </>
               ) : (
                 <button
                   onClick={isPending ? undefined : onClick}

--- a/web/components/conversation-view.tsx
+++ b/web/components/conversation-view.tsx
@@ -36,6 +36,7 @@ import { AttachmentChip } from "@/components/attachment-chip"
 import dynamic from "next/dynamic"
 import { useBranding } from "@/hooks/use-branding"
 import { BootstrapProgress } from "@/components/bootstrap-progress"
+import { ClawTitle } from "@/components/claw-title"
 import { isTerminalAssistantMessage } from "@/lib/messages"
 
 const XTerminal = dynamic(
@@ -430,15 +431,24 @@ function ClawBoardCard({
                 <GripVertical className="size-3.5" />
               </span>
               <StatusDot status={claw.status} isStreaming={claw.isStreaming} />
-              <button
-                onClick={isPending ? undefined : onClick}
-                className={cn(
-                  "font-mono text-sm font-medium text-foreground truncate flex-1 text-left",
-                  !isPending && "hover:underline"
-                )}
-              >
-                {claw.name}
-              </button>
+              {claw.githubIssueUrl ? (
+                <ClawTitle
+                  name={claw.name}
+                  githubIssueId={claw.githubIssueId}
+                  githubIssueUrl={claw.githubIssueUrl}
+                  className="flex-1 font-mono text-sm font-medium text-foreground"
+                />
+              ) : (
+                <button
+                  onClick={isPending ? undefined : onClick}
+                  className={cn(
+                    "min-w-0 font-mono text-sm font-medium text-foreground flex-1 text-left",
+                    !isPending && "hover:underline"
+                  )}
+                >
+                  <ClawTitle name={claw.name} className="block" />
+                </button>
+              )}
               {hasUnread && (
                 <span className="px-1.5 py-0.5 text-[10px] font-medium bg-blue-500 text-white rounded-full">
                   {claw.unreadCount > 99 ? "99+" : claw.unreadCount}
@@ -700,9 +710,12 @@ function ClawBoardCard({
           <div className="p-3 border-b border-border">
             <div className="flex items-center gap-2">
               <StatusDot status={claw.status} isStreaming={claw.isStreaming} />
-              <span className="font-mono text-sm font-medium text-foreground truncate flex-1">
-                {claw.name}
-              </span>
+              <ClawTitle
+                name={claw.name}
+                githubIssueId={claw.githubIssueId}
+                githubIssueUrl={claw.githubIssueUrl}
+                className="flex-1 font-mono text-sm font-medium text-foreground"
+              />
               {claw.ssh_host && (
                 <button
                   onClick={(e) => { e.stopPropagation(); setShowTerminal((v) => !v) }}
@@ -1389,11 +1402,16 @@ function ClawChatView({
           <ContextProgressBar usage={claw.contextUsage} size="lg" />
         </div>
         <div className="flex items-center justify-between px-6 py-3">
-          <div className="flex items-center gap-4">
+          <div className="flex min-w-0 items-center gap-4">
             <Button variant="ghost" size="icon" onClick={onDeselectClaw} title="Back to dashboard" className="size-8">
               <LayoutGrid className="size-4" />
             </Button>
-            <h2 className="font-mono text-xl font-semibold text-foreground">{claw.name}</h2>
+            <ClawTitle
+              name={claw.name}
+              githubIssueId={claw.githubIssueId}
+              githubIssueUrl={claw.githubIssueUrl}
+              className="flex-1 font-mono text-xl font-semibold text-foreground"
+            />
             <StatusBadge status={claw.status} />
             <span className="text-sm text-muted-foreground font-mono">{formatUptime(claw.uptime)}</span>
           </div>

--- a/web/hooks/use-hub.ts
+++ b/web/hooks/use-hub.ts
@@ -478,6 +478,8 @@ export function useHub(selectedClawId: string | null): HubState {
                       isStreaming: status !== "connected" ? false : c.isStreaming,
                       reason: status === "error" ? payload.reason : undefined,
                       bootstrap_status: status === "connected" || status === "error" ? undefined : payload.bootstrap_status ?? c.bootstrap_status,
+                      githubIssueId: payload.github_issue_id ?? c.githubIssueId,
+                      githubIssueUrl: payload.github_issue_url ?? c.githubIssueUrl,
                     }
                   : c
               )

--- a/web/lib/mappers.ts
+++ b/web/lib/mappers.ts
@@ -109,6 +109,8 @@ export function mapApiClaw(
     description: overrides.description,
     reason: overrides.reason,
     bootstrap_status: overrides.bootstrap_status ?? apiClaw.bootstrap_status,
+    githubIssueId: overrides.githubIssueId ?? apiClaw.github_issue_id,
+    githubIssueUrl: overrides.githubIssueUrl ?? apiClaw.github_issue_url,
     ssh_host: apiClaw.ssh_host,
     ssh_port: apiClaw.ssh_port,
     ssh_user: apiClaw.ssh_user,

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -15,6 +15,8 @@ export interface Claw {
   description?: string
   reason?: string // stop reason when status is error
   bootstrap_status?: string
+  githubIssueId?: string
+  githubIssueUrl?: string
   // SSH / terminal access
   ssh_host?: string
   ssh_port?: number
@@ -66,6 +68,8 @@ export interface ApiClaw {
   ssh_port?: number
   ssh_user?: string
   bootstrap_status?: string
+  github_issue_id?: string
+  github_issue_url?: string
 }
 
 export interface ApiMessage {


### PR DESCRIPTION
## Summary
- expose stored GitHub issue IDs and computed issue URLs on claw API responses and initial WebSocket status payloads
- render issue-backed agent titles as GitHub links
- preserve the trailing issue number when slash-delimited titles truncate in sidebar, dashboard cards, and the selected-agent header

## Verification
- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./...
- ./node_modules/.bin/next build --webpack