### PR TITLE
Isolate concurrent E2E tracker runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,8 @@ e2e-run: build-dev build-bridge-linux
 	NGROK_DOMAIN_JSON="$$(mktemp -t elasticclaw-ngrok-domain.XXXXXX.json)"; \
 	DAYTONA_IDS="$$(mktemp -t elasticclaw-daytona-sandbox-ids.XXXXXX)"; \
 	REPLICATED_IDS="$$(mktemp -t elasticclaw-replicated-vm-ids.XXXXXX)"; \
-	E2E_RUN_ID="$${ELASTICCLAW_E2E_RUN_ID:-$$(python3 -c 'import time,uuid; print(f"{time.time_ns()}-{uuid.uuid4().hex[:8]}")')}"; \
+	E2E_RUN_ID_RAW="$${ELASTICCLAW_E2E_RUN_ID:-$$(python3 -c 'import time,uuid; print(f"{time.time_ns()}-{uuid.uuid4().hex[:8]}")')}"; \
+	E2E_RUN_ID="$$(printf '%s' "$$E2E_RUN_ID_RAW" | python3 -c 'import sys; value=sys.stdin.read().strip().lower(); out="".join(ch if ch.isalnum() and ch.isascii() or ch == "-" else "-" for ch in value).strip("-") or "run"; print((out[:32].strip("-")) or "run")')"; \
 	NGROK_PID=""; \
 	NGROK_DOMAIN_ID=""; \
 	printf 'version: "3"\nagent:\n  web_addr: "%s"\n' "$$NGROK_API_ADDR" > "$$NGROK_CONFIG"; \

--- a/Makefile
+++ b/Makefile
@@ -80,12 +80,13 @@ e2e-run: build-dev build-bridge-linux
 	NGROK_DOMAIN_JSON="$$(mktemp -t elasticclaw-ngrok-domain.XXXXXX.json)"; \
 	DAYTONA_IDS="$$(mktemp -t elasticclaw-daytona-sandbox-ids.XXXXXX)"; \
 	REPLICATED_IDS="$$(mktemp -t elasticclaw-replicated-vm-ids.XXXXXX)"; \
+	E2E_RUN_ID="$${ELASTICCLAW_E2E_RUN_ID:-$$(python3 -c 'import time,uuid; print(f"{time.time_ns()}-{uuid.uuid4().hex[:8]}")')}"; \
 	NGROK_PID=""; \
 	NGROK_DOMAIN_ID=""; \
 	printf 'version: "3"\nagent:\n  web_addr: "%s"\n' "$$NGROK_API_ADDR" > "$$NGROK_CONFIG"; \
 	cleanup() { code="$$?"; ELASTICCLAW_E2E_DAYTONA_SANDBOX_ID_FILE="$$DAYTONA_IDS" ELASTICCLAW_E2E_REPLICATED_VM_ID_FILE="$$REPLICATED_IDS" go test -tags e2e -v ./test/e2e -run 'TestCleanupRecorded(DaytonaSandboxes|ReplicatedVMs)' -count=1 -timeout 6m >/dev/null 2>&1 || true; if [ -n "$$NGROK_PID" ]; then kill "$$NGROK_PID" >/dev/null 2>&1 || true; fi; if [ -n "$$NGROK_DOMAIN_ID" ]; then ngrok api reserved-domains delete "$$NGROK_DOMAIN_ID" --api-key "$$NGROK_API_KEY" >/dev/null 2>&1 || true; fi; rm -f "$$NGROK_LOG" "$$NGROK_CONFIG" "$$NGROK_DOMAIN_JSON" "$$DAYTONA_IDS" "$$REPLICATED_IDS"; exit "$$code"; }; \
 	trap cleanup EXIT INT TERM; \
-	NGROK_HOST="ec-$$(git rev-parse --short HEAD 2>/dev/null || echo dev)-$$(date +%s).ngrok-free.app"; \
+	NGROK_HOST="ec-$$(git rev-parse --short HEAD 2>/dev/null || echo dev)-$$E2E_RUN_ID.ngrok-free.app"; \
 	echo "Creating temporary ngrok reserved domain https://$$NGROK_HOST"; \
 	ngrok api reserved-domains create --api-key "$$NGROK_API_KEY" --domain "$$NGROK_HOST" --description "ElasticClaw E2E temporary tunnel" --metadata "elasticclaw-e2e" > "$$NGROK_DOMAIN_JSON"; \
 	NGROK_DOMAIN_ID="$$(python3 -c 'import json,sys; print(json.load(sys.stdin).get("id", ""))' < "$$NGROK_DOMAIN_JSON")"; \
@@ -106,6 +107,7 @@ e2e-run: build-dev build-bridge-linux
 			ELASTICCLAW_E2E_REPLICATED_VM_ID_FILE="$$REPLICATED_IDS" \
 			ELASTICCLAW_E2E_HUB_ADDR="$$HUB_ADDR" \
 			ELASTICCLAW_E2E_PUBLIC_URL="$$ELASTICCLAW_E2E_PUBLIC_URL" \
+			ELASTICCLAW_E2E_RUN_ID="$$E2E_RUN_ID" \
 			go test -tags e2e -v ./test/e2e -run "$${E2E_TEST:-TestDaytonaGitHubIssuesWorkflowE2E}" -count=1 -timeout 30m; \
 			exit "$$?"; \
 		fi; \

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,20 @@ e2e-run: build-dev build-bridge-linux
 	trap cleanup EXIT INT TERM; \
 	NGROK_HOST="ec-$$(git rev-parse --short HEAD 2>/dev/null || echo dev)-$$E2E_RUN_ID.ngrok-free.app"; \
 	echo "Creating temporary ngrok reserved domain https://$$NGROK_HOST"; \
-	ngrok api reserved-domains create --api-key "$$NGROK_API_KEY" --domain "$$NGROK_HOST" --description "ElasticClaw E2E temporary tunnel" --metadata "elasticclaw-e2e" > "$$NGROK_DOMAIN_JSON"; \
+	for attempt in $$(seq 1 5); do \
+		if ngrok api reserved-domains create --api-key "$$NGROK_API_KEY" --domain "$$NGROK_HOST" --description "ElasticClaw E2E temporary tunnel" --metadata "elasticclaw-e2e" > "$$NGROK_DOMAIN_JSON"; then \
+			break; \
+		fi; \
+		if [ "$$attempt" -eq 5 ]; then \
+			cat "$$NGROK_DOMAIN_JSON" 2>/dev/null || true; \
+			echo "ngrok reserved domain create failed after $$attempt attempts"; \
+			exit 1; \
+		fi; \
+		cat "$$NGROK_DOMAIN_JSON" 2>/dev/null || true; \
+		sleep_seconds=$$((attempt * 5)); \
+		echo "ngrok reserved domain create failed on attempt $$attempt; retrying in $$sleep_seconds seconds"; \
+		sleep "$$sleep_seconds"; \
+	done; \
 	NGROK_DOMAIN_ID="$$(python3 -c 'import json,sys; print(json.load(sys.stdin).get("id", ""))' < "$$NGROK_DOMAIN_JSON")"; \
 	if [ -z "$$NGROK_DOMAIN_ID" ]; then cat "$$NGROK_DOMAIN_JSON"; echo "ngrok reserved domain create did not return an id"; exit 1; fi; \
 	sleep 5; \

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -27,8 +27,8 @@ const (
 	agentToken     = "e2e-agent-token"
 	defaultModel   = "fireworks/accounts/fireworks/models/kimi-k2p6"
 	defaultFixture = "elasticclaw/e2e-fixtures"
-	daytonaPrefix  = "ec-e2e-"
-	cmxPrefix      = "ec-e2e-cmx-"
+	daytonaPrefix  = "ec-e2e"
+	cmxPrefix      = "ec-e2e-cmx"
 	maxRunIDLen    = 32
 )
 
@@ -91,8 +91,7 @@ func runGitHubIssuesWorkflowE2E(t *testing.T, sandboxProvider string) {
 		_ = hub.deleteWorkspace(cleanupCtx, workspaceName)
 	})
 
-	gh.deleteE2EHooks(ctx, t)
-	gh.cleanupE2EIssuesAndLabels(ctx, t)
+	gh.cleanupGitHubE2EResources(ctx, t, workspaceName, env.RunID, labelName)
 	runCLI(ctx, t, root, env, "workspace", "push", workspaceName)
 	runCLI(ctx, t, root, env, "github-app", "create", "e2e",
 		"--workspace", workspaceName,
@@ -170,17 +169,21 @@ func newE2EEnv(t *testing.T, runID, sandboxProvider string) e2eEnv {
 	switch sandboxProvider {
 	case "daytona":
 		env.DaytonaAPIKey = requiredEnv(t, "DAYTONA_API_KEY")
-		env.ProviderPrefix = daytonaPrefix
+		env.ProviderPrefix = e2eProviderPrefix(daytonaPrefix, runID)
 	case "replicated":
 		env.ReplicatedToken = requiredEnv(t, "REPLICATED_API_TOKEN")
 		env.ReplicatedAPIURL = os.Getenv("ELASTICCLAW_E2E_REPLICATED_API_URL")
 		env.ReplicatedType = envOrDefault("ELASTICCLAW_E2E_REPLICATED_INSTANCE_TYPE", "r1.small")
 		env.ReplicatedTTL = envOrDefault("ELASTICCLAW_E2E_REPLICATED_TTL", "1h")
-		env.ProviderPrefix = cmxPrefix
+		env.ProviderPrefix = e2eProviderPrefix(cmxPrefix, runID)
 	default:
 		t.Fatalf("unsupported E2E sandbox provider %q", sandboxProvider)
 	}
 	return env
+}
+
+func e2eProviderPrefix(base, runID string) string {
+	return fmt.Sprintf("%s-%s-", base, runID)
 }
 
 type hubProcess struct {
@@ -730,7 +733,35 @@ func (g githubClient) createHook(ctx context.Context, t *testing.T, url, secret 
 	return out.ID
 }
 
+func (g githubClient) cleanupGitHubE2EResources(ctx context.Context, t *testing.T, workspaceName, runID, labelName string) {
+	t.Helper()
+	g.deleteE2EHooksForWorkspace(ctx, t, workspaceName)
+	g.closeE2EIssuesForRun(ctx, t, runID, labelName)
+	_ = g.deleteLabel(ctx, labelName)
+	if shouldSweepStaleE2E() {
+		g.deleteE2EHooks(ctx, t)
+		g.cleanupE2EIssuesAndLabels(ctx, t)
+	}
+}
+
+func shouldSweepStaleE2E() bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv("ELASTICCLAW_E2E_SWEEP_STALE")), "1") ||
+		strings.EqualFold(strings.TrimSpace(os.Getenv("ELASTICCLAW_E2E_SWEEP_STALE")), "true")
+}
+
+func (g githubClient) deleteE2EHooksForWorkspace(ctx context.Context, t *testing.T, workspaceName string) {
+	t.Helper()
+	g.deleteE2EHooksMatching(ctx, t, func(url string) bool {
+		return githubE2EHookURLMatchesWorkspace(url, workspaceName)
+	})
+}
+
 func (g githubClient) deleteE2EHooks(ctx context.Context, t *testing.T) {
+	t.Helper()
+	g.deleteE2EHooksMatching(ctx, t, isGitHubE2EHookURL)
+}
+
+func (g githubClient) deleteE2EHooksMatching(ctx context.Context, t *testing.T, match func(string) bool) {
 	t.Helper()
 	var hooks []struct {
 		ID     int64 `json:"id"`
@@ -740,12 +771,20 @@ func (g githubClient) deleteE2EHooks(ctx context.Context, t *testing.T) {
 	}
 	g.api(ctx, t, http.MethodGet, "hooks", nil, &hooks)
 	for _, hook := range hooks {
-		if strings.Contains(hook.Config.URL, "/api/workspaces/") && strings.HasSuffix(hook.Config.URL, "/webhooks/github-issues") {
+		if match(hook.Config.URL) {
 			if err := g.deleteHook(ctx, hook.ID); err != nil {
 				t.Fatalf("delete orphaned E2E hook %d: %v", hook.ID, err)
 			}
 		}
 	}
+}
+
+func githubE2EHookURLMatchesWorkspace(hookURL, workspaceName string) bool {
+	return strings.Contains(hookURL, "/api/workspaces/"+workspaceName+"/webhooks/github-issues")
+}
+
+func isGitHubE2EHookURL(hookURL string) bool {
+	return strings.Contains(hookURL, "/api/workspaces/") && strings.HasSuffix(hookURL, "/webhooks/github-issues")
 }
 
 func (g githubClient) deleteHook(ctx context.Context, hookID int64) error {
@@ -772,6 +811,22 @@ func (g githubClient) cleanupE2EIssuesAndLabels(ctx context.Context, t *testing.
 
 func (g githubClient) closeE2EIssues(ctx context.Context, t *testing.T) {
 	t.Helper()
+	g.closeE2EIssuesMatching(ctx, t, isE2EIssue)
+}
+
+func (g githubClient) closeE2EIssuesForRun(ctx context.Context, t *testing.T, runID, labelName string) {
+	t.Helper()
+	g.closeE2EIssuesMatching(ctx, t, func(title, body string, labels []struct {
+		Name string `json:"name"`
+	}) bool {
+		return isE2EIssueForRun(title, body, labels, runID, labelName)
+	})
+}
+
+func (g githubClient) closeE2EIssuesMatching(ctx context.Context, t *testing.T, match func(string, string, []struct {
+	Name string `json:"name"`
+}) bool) {
+	t.Helper()
 	var issues []struct {
 		Number int    `json:"number"`
 		Title  string `json:"title"`
@@ -782,7 +837,7 @@ func (g githubClient) closeE2EIssues(ctx context.Context, t *testing.T) {
 	}
 	g.api(ctx, t, http.MethodGet, "issues?state=open&per_page=100", nil, &issues)
 	for _, issue := range issues {
-		if !isE2EIssue(issue.Title, issue.Body, issue.Labels) {
+		if !match(issue.Title, issue.Body, issue.Labels) {
 			continue
 		}
 		if err := g.closeIssue(ctx, issue.Number); err != nil {
@@ -802,6 +857,20 @@ func isE2EIssue(title, body string, labels []struct {
 	}
 	for _, label := range labels {
 		if strings.HasPrefix(label.Name, "agent-ready-") {
+			return true
+		}
+	}
+	return false
+}
+
+func isE2EIssueForRun(title, body string, labels []struct {
+	Name string `json:"name"`
+}, runID, labelName string) bool {
+	if runID != "" && strings.Contains(body, "ElasticClaw E2E run: "+runID) {
+		return true
+	}
+	for _, label := range labels {
+		if label.Name == labelName {
 			return true
 		}
 	}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -866,11 +866,21 @@ func isE2EIssue(title, body string, labels []struct {
 func isE2EIssueForRun(title, body string, labels []struct {
 	Name string `json:"name"`
 }, runID, labelName string) bool {
-	if runID != "" && strings.Contains(body, "ElasticClaw E2E run: "+runID) {
+	if runID != "" && bodyHasE2ERunID(body, runID) {
 		return true
 	}
 	for _, label := range labels {
 		if label.Name == labelName {
+			return true
+		}
+	}
+	return false
+}
+
+func bodyHasE2ERunID(body, runID string) bool {
+	marker := "ElasticClaw E2E run: " + runID
+	for _, line := range strings.Split(body, "\n") {
+		if strings.TrimSpace(line) == marker {
 			return true
 		}
 	}

--- a/test/e2e/isolation_helpers_test.go
+++ b/test/e2e/isolation_helpers_test.go
@@ -11,6 +11,12 @@ func TestE2EProviderPrefixIsRunScoped(t *testing.T) {
 	}
 }
 
+func TestSanitizeIDMatchesHostnameSafeRunID(t *testing.T) {
+	if got := sanitizeID("MY_RUN.123"); got != "my-run-123" {
+		t.Fatalf("sanitizeID = %q", got)
+	}
+}
+
 func TestGitHubE2EHookURLMatchesOnlyWorkspace(t *testing.T) {
 	current := "https://example.ngrok-free.app/api/workspaces/e2e-run-a/webhooks/github-issues"
 	other := "https://example.ngrok-free.app/api/workspaces/e2e-run-b/webhooks/github-issues"
@@ -48,6 +54,9 @@ func TestGitHubE2EIssueMatchesOnlyRun(t *testing.T) {
 
 	if !isE2EIssueForRun("Tell a dad joke. Do not make a PR.", "ElasticClaw E2E run: run-a", labels, "run-a", "agent-ready-run-a") {
 		t.Fatalf("current run issue did not match")
+	}
+	if isE2EIssueForRun("Tell a dad joke. Do not make a PR.", "ElasticClaw E2E run: run-a-extra", nil, "run-a", "agent-ready-run-a") {
+		t.Fatalf("run id prefix matched another run")
 	}
 	if isE2EIssueForRun("Tell a dad joke. Do not make a PR.", "ElasticClaw E2E run: run-b", labels, "run-c", "agent-ready-run-c") {
 		t.Fatalf("other run issue matched current run")

--- a/test/e2e/isolation_helpers_test.go
+++ b/test/e2e/isolation_helpers_test.go
@@ -1,0 +1,58 @@
+//go:build e2e
+
+package e2e
+
+import "testing"
+
+func TestE2EProviderPrefixIsRunScoped(t *testing.T) {
+	got := e2eProviderPrefix(daytonaPrefix, "run-123")
+	if got != "ec-e2e-run-123-" {
+		t.Fatalf("provider prefix = %q", got)
+	}
+}
+
+func TestGitHubE2EHookURLMatchesOnlyWorkspace(t *testing.T) {
+	current := "https://example.ngrok-free.app/api/workspaces/e2e-run-a/webhooks/github-issues"
+	other := "https://example.ngrok-free.app/api/workspaces/e2e-run-b/webhooks/github-issues"
+
+	if !githubE2EHookURLMatchesWorkspace(current, "e2e-run-a") {
+		t.Fatalf("current workspace hook did not match")
+	}
+	if githubE2EHookURLMatchesWorkspace(other, "e2e-run-a") {
+		t.Fatalf("other workspace hook matched current workspace")
+	}
+	if !isGitHubE2EHookURL(other) {
+		t.Fatalf("broad sweep matcher should still recognize E2E hook")
+	}
+}
+
+func TestLinearE2EWebhookURLMatchesOnlyWorkspace(t *testing.T) {
+	current := "https://example.ngrok-free.app/api/workspaces/e2e-linear-run-a/webhooks/linear"
+	other := "https://example.ngrok-free.app/api/workspaces/e2e-linear-run-b/webhooks/linear"
+
+	if !linearE2EWebhookURLMatchesWorkspace(current, "e2e-linear-run-a") {
+		t.Fatalf("current workspace webhook did not match")
+	}
+	if linearE2EWebhookURLMatchesWorkspace(other, "e2e-linear-run-a") {
+		t.Fatalf("other workspace webhook matched current workspace")
+	}
+	if !isLinearE2EWebhookURL(other) {
+		t.Fatalf("broad sweep matcher should still recognize E2E webhook")
+	}
+}
+
+func TestGitHubE2EIssueMatchesOnlyRun(t *testing.T) {
+	labels := []struct {
+		Name string `json:"name"`
+	}{{Name: "agent-ready-run-a"}}
+
+	if !isE2EIssueForRun("Tell a dad joke. Do not make a PR.", "ElasticClaw E2E run: run-a", labels, "run-a", "agent-ready-run-a") {
+		t.Fatalf("current run issue did not match")
+	}
+	if isE2EIssueForRun("Tell a dad joke. Do not make a PR.", "ElasticClaw E2E run: run-b", labels, "run-c", "agent-ready-run-c") {
+		t.Fatalf("other run issue matched current run")
+	}
+	if !isE2EIssue("Tell a dad joke. Do not make a PR.", "ElasticClaw E2E run: run-b", labels) {
+		t.Fatalf("broad sweep matcher should still recognize E2E issue")
+	}
+}

--- a/test/e2e/linear_test.go
+++ b/test/e2e/linear_test.go
@@ -81,7 +81,10 @@ func runLinearWorkflowE2E(t *testing.T, sandboxProvider string) {
 	})
 
 	team := linear.teamByKey(ctx, t, env.LinearTeamKey)
-	linear.deleteE2EWebhooks(ctx, t)
+	linear.deleteE2EWebhooksForWorkspace(ctx, t, workspaceName)
+	if shouldSweepStaleE2E() {
+		linear.deleteE2EWebhooks(ctx, t)
+	}
 	labelName := "elasticclaw-e2e-" + env.RunID
 	linear.deleteLabelsByName(ctx, t, labelName)
 	labelID = linear.createLabel(ctx, t, team.ID, labelName)
@@ -279,7 +282,19 @@ func (c linearClient) createWebhook(ctx context.Context, t *testing.T, url, team
 	return out.Data.WebhookCreate.Webhook.ID
 }
 
+func (c linearClient) deleteE2EWebhooksForWorkspace(ctx context.Context, t *testing.T, workspaceName string) {
+	t.Helper()
+	c.deleteE2EWebhooksMatching(ctx, t, func(url string) bool {
+		return linearE2EWebhookURLMatchesWorkspace(url, workspaceName)
+	})
+}
+
 func (c linearClient) deleteE2EWebhooks(ctx context.Context, t *testing.T) {
+	t.Helper()
+	c.deleteE2EWebhooksMatching(ctx, t, isLinearE2EWebhookURL)
+}
+
+func (c linearClient) deleteE2EWebhooksMatching(ctx context.Context, t *testing.T, match func(string) bool) {
 	t.Helper()
 	var out struct {
 		Data struct {
@@ -298,7 +313,7 @@ func (c linearClient) deleteE2EWebhooks(ctx context.Context, t *testing.T) {
 }`, nil, &out)
 	var deleteErr error
 	for _, webhook := range out.Data.Webhooks.Nodes {
-		if strings.Contains(webhook.URL, "/api/workspaces/e2e-linear-") && strings.HasSuffix(webhook.URL, "/webhooks/linear") {
+		if match(webhook.URL) {
 			if err := c.deleteWebhook(ctx, webhook.ID); err != nil {
 				t.Logf("delete stale Linear E2E webhook %s: %v", webhook.ID, err)
 				deleteErr = err
@@ -308,6 +323,14 @@ func (c linearClient) deleteE2EWebhooks(ctx context.Context, t *testing.T) {
 	if deleteErr != nil {
 		t.Fatalf("one or more stale Linear E2E webhooks could not be deleted")
 	}
+}
+
+func linearE2EWebhookURLMatchesWorkspace(webhookURL, workspaceName string) bool {
+	return strings.Contains(webhookURL, "/api/workspaces/"+workspaceName+"/webhooks/linear")
+}
+
+func isLinearE2EWebhookURL(webhookURL string) bool {
+	return strings.Contains(webhookURL, "/api/workspaces/e2e-linear-") && strings.HasSuffix(webhookURL, "/webhooks/linear")
 }
 
 func (c linearClient) deleteWebhook(ctx context.Context, id string) error {


### PR DESCRIPTION
## Summary
- generate one E2E run ID in the Makefile and reuse it for the ngrok hostname and Go E2E resource names
- scope Daytona/CMX provider prefixes to the run ID so provider cleanup does not delete other active E2E jobs
- narrow GitHub Issues and Linear pre-run cleanup to the current run/workspace by default
- keep broad stale sweeping available behind ELASTICCLAW_E2E_SWEEP_STALE=1
- add focused helper tests for run-scoped cleanup matching

## Verification
- env GOCACHE=/private/tmp/elasticclaw-go-build go test -tags e2e ./test/e2e -run 'TestE2EProviderPrefixIsRunScoped|TestGitHubE2EHookURLMatchesOnlyWorkspace|TestLinearE2EWebhookURLMatchesOnlyWorkspace|TestGitHubE2EIssueMatchesOnlyRun'
- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./...