### PR TITLE
Add Playwright UI e2e coverage

### DIFF
--- a/.depot/workflows/test.yaml
+++ b/.depot/workflows/test.yaml
@@ -58,6 +58,7 @@ jobs:
   web:
     name: Web UI build
     runs-on: depot-ubuntu-24.04
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4
@@ -72,13 +73,21 @@ jobs:
 
       - name: Lint (smoke check — tolerates rule violations, still fails on tool/config errors)
         run: |
-          set +e
-          npm run lint
-          ec=$?
-          if [ $ec -eq 0 ] || [ $ec -eq 1 ]; then
-            exit 0
-          fi
-          exit $ec
+          npm run lint || {
+            ec=$?
+            if [ $ec -eq 1 ]; then
+              exit 0
+            fi
+            exit $ec
+          }
+        working-directory: web
+
+      - name: Install Playwright browsers
+        run: npm exec -- playwright install --with-deps chromium
+        working-directory: web
+
+      - name: Run UI E2E tests
+        run: npm run e2e
         working-directory: web
 
       - name: Build (static export)

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ web/.next/
 web/tsconfig.tsbuildinfo
 web/package-lock.json
 web/pnpm-lock.yaml
+web/test-results/
+web/playwright-report/
+test-results/
 
 # build artifacts (root-level binaries only, not cmd/claw-bridge/ source)
 /claw-bridge

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,6 +101,7 @@ rm -rf ~/.elasticclaw/hub.db
 
 ```bash
 make test                # Go unit tests
+make test-web-e2e        # mocked Playwright UI E2E tests
 make test-bootstrap      # bootstrap script tests (needs shellcheck)
 make test-install        # container integration test (needs Docker)
 ELASTICCLAW_INSTALL_TESTS=1 make test-install  # actually spins Ubuntu container

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-bridge build-bridge-linux test test-bootstrap test-container e2e e2e-github e2e-linear e2e-replicated-github e2e-replicated-linear e2e-run clean install lint tidy clawpatch-init clawpatch-review clawpatch-report clawpatch-show clawpatch-triage clawpatch-pr
+.PHONY: build build-bridge build-bridge-linux test test-bootstrap test-container test-web-e2e e2e e2e-github e2e-linear e2e-replicated-github e2e-replicated-linear e2e-run clean install lint tidy clawpatch-init clawpatch-review clawpatch-report clawpatch-show clawpatch-triage clawpatch-pr
 
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
@@ -122,6 +122,10 @@ test-bootstrap:
 # Run container integration tests (requires Docker + ELASTICCLAW_TEST_BRIDGE_URL)
 test-container:
 	ELASTICCLAW_CONTAINER_TESTS=1 go test -v ./pkg/hub/ -run TestBootstrap_ContainerRun -timeout 10m
+
+test-web-e2e:
+	@command -v npm >/dev/null 2>&1 || (echo "npm is required for make test-web-e2e" && exit 1)
+	cd web && npm install --no-package-lock && npm exec -- playwright install chromium && npm run e2e
 
 # Run install integration tests in a real Ubuntu container (requires Docker)
 test-install:

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -1,0 +1,72 @@
+import { expect, test } from "@playwright/test"
+import clawsFixture from "./fixtures/claws.json"
+import workspacesFixture from "./fixtures/workspaces.json"
+import { mockHubApi } from "./support/mock-api"
+import { installSession } from "./support/session"
+
+test.beforeEach(async ({ page }) => {
+  await installSession(page)
+})
+
+test("dashboard shows the empty state when no agents exist", async ({ page }) => {
+  await mockHubApi(page, { claws: clawsFixture.empty })
+
+  await page.goto("/")
+
+  await expect(page.getByText("0 Active Agents")).toBeVisible()
+  await expect(page.getByText("No agents running")).toBeVisible()
+  await expect(page.locator("aside").getByText("No agents found")).toBeVisible()
+})
+
+test("dashboard lists agents, filters sidebar results, and opens a conversation", async ({ page }) => {
+  await mockHubApi(page, { claws: clawsFixture.mixed })
+
+  await page.goto("/")
+  const sidebar = page.locator("aside")
+
+  await expect(page.getByText("4 Active Agents")).toBeVisible()
+  await expect(sidebar.getByText("alpha-agent")).toBeVisible()
+  await expect(sidebar.getByText("docs-agent")).toBeVisible()
+  await expect(page.getByText("starting...")).toBeVisible()
+
+  await sidebar.getByPlaceholder("Filter by name or workflow...").fill("alpha")
+  await expect(sidebar.getByText("alpha-agent")).toBeVisible()
+  await expect(sidebar.getByText("docs-agent")).not.toBeVisible()
+
+  await sidebar.getByPlaceholder("Filter by name or workflow...").fill("")
+  await sidebar.getByRole("button", { name: "Tags" }).click()
+  await page.getByRole("menuitem", { name: "billing" }).click()
+  await expect(sidebar.getByText("alpha-agent")).toBeVisible()
+  await expect(sidebar.getByText("docs-agent")).not.toBeVisible()
+
+  await sidebar.getByText("alpha-agent").click()
+  await expect(page.getByRole("heading", { name: "alpha-agent" })).toBeVisible()
+  await expect(page.getByText("connected")).toBeVisible()
+  await expect(page.getByText("Hello from alpha")).toBeVisible()
+  await expect(page.getByPlaceholder("Message agent, /stop, or attach files")).toBeVisible()
+})
+
+test("admin sees settings while non-admin does not", async ({ page }) => {
+  await mockHubApi(page, { claws: clawsFixture.empty, isAdmin: false })
+
+  await page.goto("/")
+
+  await expect(page.getByRole("button", { name: "Sign out" })).toBeVisible()
+  await expect(page.getByTitle("Settings")).not.toBeVisible()
+})
+
+test("manual workflow trigger opens and submits", async ({ page }) => {
+  const api = await mockHubApi(page, {
+    claws: clawsFixture.empty,
+    workspaces: workspacesFixture,
+  })
+
+  await page.goto("/")
+  await page.getByTitle("Create Agent").click()
+  await expect(page.getByRole("heading", { name: "Trigger manual-smoke" })).toBeVisible()
+  await expect(page.getByRole("dialog").locator("input").first()).toHaveValue("Run smoke workflow")
+  await page.getByRole("button", { name: "Confirm" }).click()
+
+  await expect(page.getByRole("heading", { name: "Trigger manual-smoke" })).not.toBeVisible()
+  expect(api.requests.some((request) => request.method === "POST" && request.pathname === "/api/workspaces/default/workflows/manual-smoke/trigger")).toBe(true)
+})

--- a/web/e2e/fixtures/claws.json
+++ b/web/e2e/fixtures/claws.json
@@ -1,0 +1,55 @@
+{
+  "empty": [],
+  "mixed": [
+    {
+      "id": "claw-alpha",
+      "name": "alpha-agent",
+      "template": "billing-workflow",
+      "status": "connected",
+      "last_seen": "2026-06-04T12:00:00Z",
+      "created_at": "2026-06-04T10:00:00Z",
+      "tenant_id": "tenant-test",
+      "context_usage": 24,
+      "tags": ["prod", "billing"],
+      "color": "emerald"
+    },
+    {
+      "id": "claw-docs",
+      "name": "docs-agent",
+      "template": "docs-workflow",
+      "status": "idle",
+      "last_seen": "2026-06-04T11:30:00Z",
+      "created_at": "2026-06-04T09:00:00Z",
+      "tenant_id": "tenant-test",
+      "context_usage": 51,
+      "tags": ["docs"],
+      "color": "sky"
+    },
+    {
+      "id": "claw-broken",
+      "name": "broken-agent",
+      "template": "triage-workflow",
+      "status": "error",
+      "last_seen": "2026-06-04T11:00:00Z",
+      "created_at": "2026-06-04T08:30:00Z",
+      "tenant_id": "tenant-test",
+      "context_usage": 0,
+      "tags": ["triage"],
+      "color": "rose",
+      "bootstrap_status": "provider failed"
+    },
+    {
+      "id": "claw-starter",
+      "name": "starter-agent",
+      "template": "setup-workflow",
+      "status": "starting",
+      "last_seen": "2026-06-04T12:05:00Z",
+      "created_at": "2026-06-04T12:03:00Z",
+      "tenant_id": "tenant-test",
+      "context_usage": 0,
+      "tags": ["setup"],
+      "color": "amber",
+      "bootstrap_status": "installing dependencies"
+    }
+  ]
+}

--- a/web/e2e/fixtures/messages.json
+++ b/web/e2e/fixtures/messages.json
@@ -1,0 +1,30 @@
+{
+  "claw-alpha": [
+    {
+      "id": "msg-alpha-user-1",
+      "claw_id": "claw-alpha",
+      "tenant_id": "tenant-test",
+      "role": "user",
+      "content": "Hello from user",
+      "created_at": "2026-06-04T12:01:00Z"
+    },
+    {
+      "id": "msg-alpha-claw-1",
+      "claw_id": "claw-alpha",
+      "tenant_id": "tenant-test",
+      "role": "claw",
+      "content": "Hello from alpha",
+      "created_at": "2026-06-04T12:01:10Z"
+    }
+  ],
+  "claw-docs": [
+    {
+      "id": "msg-docs-claw-1",
+      "claw_id": "claw-docs",
+      "tenant_id": "tenant-test",
+      "role": "claw",
+      "content": "Docs agent is idle",
+      "created_at": "2026-06-04T11:35:00Z"
+    }
+  ]
+}

--- a/web/e2e/fixtures/workspaces.json
+++ b/web/e2e/fixtures/workspaces.json
@@ -1,0 +1,31 @@
+[
+  {
+    "name": "default",
+    "source": "repo",
+    "access": {
+      "repositories": [],
+      "env": [],
+      "secrets": [],
+      "webhookSecrets": []
+    },
+    "workflows": [
+      {
+        "name": "manual-smoke",
+        "workspaceName": "default",
+        "source": "repo",
+        "integration": "manual",
+        "enabled": true,
+        "hasWebhookSecret": false,
+        "enableManualTrigger": true,
+        "inputs": [
+          {
+            "name": "prompt",
+            "type": "text",
+            "required": true,
+            "default": "Run smoke workflow"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/web/e2e/login.spec.ts
+++ b/web/e2e/login.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "@playwright/test"
+import clawsFixture from "./fixtures/claws.json"
+import { mockHubApi } from "./support/mock-api"
+import { installSession } from "./support/session"
+
+test("login page renders password sign-in", async ({ page }) => {
+  await mockHubApi(page)
+
+  await page.goto("/login")
+
+  await expect(page.getByRole("heading", { name: "ElasticClaw" })).toBeVisible()
+  await expect(page.getByText("Sign in to continue")).toBeVisible()
+  await expect(page.getByPlaceholder("Access token")).toBeVisible()
+  await expect(page.getByRole("button", { name: "Sign in" })).toBeDisabled()
+})
+
+test("invalid password shows an error", async ({ page }) => {
+  await mockHubApi(page, { auth: { validPassword: "correct-password" } })
+
+  await page.goto("/login")
+  await page.getByPlaceholder("Access token").fill("wrong-password")
+  await page.getByRole("button", { name: "Sign in" }).click()
+
+  await expect(page.getByText("Invalid password")).toBeVisible()
+})
+
+test("valid password stores the hub token and opens the dashboard", async ({ page }) => {
+  await mockHubApi(page, {
+    auth: { validPassword: "correct-password", hubToken: "login-token" },
+    claws: clawsFixture.empty,
+  })
+
+  await page.goto("/login")
+  await page.getByPlaceholder("Access token").fill("correct-password")
+  await page.getByRole("button", { name: "Sign in" }).click()
+
+  await expect(page).toHaveURL("/")
+  await expect(page.getByText("No agents running")).toBeVisible()
+  await expect.poll(() => page.evaluate(() => sessionStorage.getItem("ec_hub_token"))).toBe("login-token")
+})
+
+test("existing session opens the dashboard", async ({ page }) => {
+  await installSession(page, { hubToken: "existing-session-token" })
+  await mockHubApi(page, { claws: clawsFixture.empty })
+
+  await page.goto("/")
+
+  await expect(page.getByText("No agents running")).toBeVisible()
+  await expect(page.getByRole("button", { name: "Sign out" })).toBeVisible()
+})

--- a/web/e2e/messages.spec.ts
+++ b/web/e2e/messages.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "@playwright/test"
+import clawsFixture from "./fixtures/claws.json"
+import { mockHubApi } from "./support/mock-api"
+import { installSession } from "./support/session"
+
+test.beforeEach(async ({ page }) => {
+  await installSession(page)
+})
+
+test("conversation loads message history for a selected agent", async ({ page }) => {
+  await mockHubApi(page, { claws: clawsFixture.mixed })
+
+  await page.goto("/")
+  await page.locator("aside").getByText("alpha-agent").click()
+
+  await expect(page.getByRole("heading", { name: "alpha-agent" })).toBeVisible()
+  await expect(page.getByText("You")).toBeVisible()
+  await expect(page.getByText("Hello from user")).toBeVisible()
+  await expect(page.getByText("Hello from alpha")).toBeVisible()
+})
+
+test("conversation sends a message via the mocked API and shows it in the transcript", async ({ page }) => {
+  const api = await mockHubApi(page, { claws: clawsFixture.mixed })
+
+  await page.goto("/")
+  await page.locator("aside").getByText("alpha-agent").click()
+  await page.getByPlaceholder("Message agent, /stop, or attach files").fill("Draft status update")
+  await page.getByRole("button", { name: "Send message" }).click()
+
+  await expect(page.getByText("Draft status update")).toBeVisible()
+  expect(api.requests.some((request) => {
+    return request.method === "POST"
+      && request.pathname === "/api/messages/claw-alpha"
+      && typeof request.body === "object"
+      && request.body !== null
+      && "content" in request.body
+      && request.body.content === "Draft status update"
+  })).toBe(true)
+})

--- a/web/e2e/support/mock-api.ts
+++ b/web/e2e/support/mock-api.ts
@@ -1,0 +1,198 @@
+import type { Page, Route } from "@playwright/test"
+import clawsFixture from "../fixtures/claws.json"
+import messagesFixture from "../fixtures/messages.json"
+import workspacesFixture from "../fixtures/workspaces.json"
+
+type ApiClaw = typeof clawsFixture.mixed[number]
+type ApiMessage = typeof messagesFixture["claw-alpha"][number]
+type Workspace = typeof workspacesFixture[number]
+
+interface AuthScenario {
+  validPassword?: string
+  hubToken?: string
+  githubOAuthEnabled?: boolean
+  passwordAuthEnabled?: boolean
+}
+
+interface MockHubApiScenario {
+  auth?: AuthScenario
+  claws?: ApiClaw[]
+  messages?: Record<string, ApiMessage[]>
+  workspaces?: Workspace[]
+  isAdmin?: boolean
+  settingsStatus?: {
+    hasProvider: boolean
+    hasLLMKey: boolean
+  }
+}
+
+export interface ApiRequestRecord {
+  method: string
+  pathname: string
+  body: unknown
+}
+
+export interface MockHubApi {
+  requests: ApiRequestRecord[]
+  claws: ApiClaw[]
+  messages: Record<string, ApiMessage[]>
+}
+
+function json(route: Route, status: number, body: unknown) {
+  return route.fulfill({
+    status,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  })
+}
+
+function noContent(route: Route) {
+  return route.fulfill({ status: 204, body: "" })
+}
+
+function apiMessage(clawId: string, content: string): ApiMessage {
+  return {
+    id: `msg-${clawId}-${Date.now()}`,
+    claw_id: clawId,
+    tenant_id: "tenant-test",
+    role: "user",
+    content,
+    created_at: new Date().toISOString(),
+  }
+}
+
+export async function mockHubApi(page: Page, scenario: MockHubApiScenario = {}): Promise<MockHubApi> {
+  const state: MockHubApi = {
+    requests: [],
+    claws: [...(scenario.claws ?? clawsFixture.empty)],
+    messages: structuredClone(scenario.messages ?? messagesFixture),
+  }
+  const auth = scenario.auth ?? {}
+  const validPassword = auth.validPassword ?? "correct-password"
+  const hubToken = auth.hubToken ?? "mock-hub-token"
+
+  await page.route("**/api/**", async (route) => {
+    const request = route.request()
+    const url = new URL(request.url())
+    const method = request.method()
+    const pathname = url.pathname
+    let body: unknown = null
+
+    if (method !== "GET") {
+      try {
+        body = request.postDataJSON()
+      } catch {
+        body = request.postData()
+      }
+    }
+
+    state.requests.push({ method, pathname, body })
+
+    if (pathname === "/api/auth/config" && method === "GET") {
+      return json(route, 200, {
+        github_oauth_enabled: auth.githubOAuthEnabled ?? false,
+        password_auth_enabled: auth.passwordAuthEnabled ?? true,
+      })
+    }
+
+    if (pathname === "/api/auth/login" && method === "POST") {
+      const password = typeof body === "object" && body && "password" in body ? body.password : ""
+      if (password !== validPassword) return json(route, 401, { error: "invalid password" })
+      return json(route, 200, { hubToken })
+    }
+
+    if (pathname === "/api/auth/me" && method === "GET") {
+      return json(route, 200, { is_admin: scenario.isAdmin ?? true })
+    }
+
+    if (pathname === "/api/auth/logout" && method === "POST") {
+      return noContent(route)
+    }
+
+    if (pathname === "/api/settings/status" && method === "GET") {
+      return json(route, 200, scenario.settingsStatus ?? { hasProvider: true, hasLLMKey: true })
+    }
+
+    if (pathname === "/api/hub-config" && method === "GET") {
+      return json(route, 200, { token: hubToken, hubUrl: "", version: "e2e-test" })
+    }
+
+    if (pathname === "/api/claws" && method === "GET") {
+      return json(route, 200, state.claws)
+    }
+
+    if (pathname === "/api/claws" && method === "POST") {
+      const req = body as Partial<ApiClaw> & { provider?: string }
+      const claw: ApiClaw = {
+        id: `claw-${Date.now()}`,
+        name: req.name || "new-agent",
+        template: req.template || "manual",
+        status: "provisioning",
+        last_seen: new Date().toISOString(),
+        created_at: new Date().toISOString(),
+        tenant_id: "tenant-test",
+        context_usage: 0,
+        tags: [],
+        color: "blue",
+      }
+      state.claws = [claw, ...state.claws]
+      return json(route, 200, claw)
+    }
+
+    const clawPrsMatch = pathname.match(/^\/api\/claws\/([^/]+)\/prs$/)
+    if (clawPrsMatch && method === "GET") {
+      return json(route, 200, [])
+    }
+
+    const clawMatch = pathname.match(/^\/api\/claws\/([^/]+)$/)
+    if (clawMatch && method === "DELETE") {
+      const clawId = decodeURIComponent(clawMatch[1])
+      state.claws = state.claws.filter((claw) => claw.id !== clawId)
+      delete state.messages[clawId]
+      return noContent(route)
+    }
+
+    if (clawMatch && method === "PATCH") {
+      const clawId = decodeURIComponent(clawMatch[1])
+      const patch = body as Partial<ApiClaw>
+      state.claws = state.claws.map((claw) => claw.id === clawId ? { ...claw, ...patch } : claw)
+      return noContent(route)
+    }
+
+    const messagesMatch = pathname.match(/^\/api\/messages\/([^/]+)$/)
+    if (messagesMatch && method === "GET") {
+      const clawId = decodeURIComponent(messagesMatch[1])
+      return json(route, 200, state.messages[clawId] ?? [])
+    }
+
+    if (messagesMatch && method === "POST") {
+      const clawId = decodeURIComponent(messagesMatch[1])
+      const content = typeof body === "object" && body && "content" in body ? String(body.content) : ""
+      const message = apiMessage(clawId, content)
+      state.messages[clawId] = [...(state.messages[clawId] ?? []), message]
+      return json(route, 200, message)
+    }
+
+    if (pathname === "/api/workspaces" && method === "GET") {
+      return json(route, 200, scenario.workspaces ?? [])
+    }
+
+    const triggerMatch = pathname.match(/^\/api\/workspaces\/([^/]+)\/workflows\/([^/]+)\/trigger$/)
+    if (triggerMatch && method === "POST") {
+      return json(route, 200, { claw_id: "claw-triggered", status: "created" })
+    }
+
+    if (pathname === "/api/settings" && method === "GET") {
+      return json(route, 200, {
+        llmKeys: [],
+        providers: {},
+        github: [],
+        sshPublicKeys: [],
+      })
+    }
+
+    return json(route, 404, { error: `No mock for ${method} ${pathname}` })
+  })
+
+  return state
+}

--- a/web/e2e/support/session.ts
+++ b/web/e2e/support/session.ts
@@ -1,0 +1,24 @@
+import type { Page } from "@playwright/test"
+
+interface SessionOptions {
+  hubToken?: string
+  githubToken?: string
+}
+
+export async function installSession(page: Page, options: SessionOptions = {}) {
+  const hubToken = options.hubToken ?? "mock-hub-token"
+  const githubToken = options.githubToken ?? null
+
+  await page.addInitScript(
+    ({ hubToken, githubToken }) => {
+      sessionStorage.setItem("ec_hub_token", hubToken)
+      if (githubToken) sessionStorage.setItem("ec_github_token", githubToken)
+
+      localStorage.removeItem("elasticclaw_selected_claw")
+      localStorage.removeItem("elasticclaw_messages")
+      localStorage.removeItem("elasticclaw_pinned")
+      localStorage.removeItem("elasticclaw_claw_order")
+    },
+    { hubToken, githubToken }
+  )
+}

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,10 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "e2e": "playwright test",
+    "e2e:ui": "playwright test --ui",
+    "e2e:headed": "playwright test --headed"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -69,6 +72,7 @@
     "zod": "^3.24.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@tailwindcss/postcss": "^4.2.0",
     "@types/node": "^22",
     "@types/react": "^19",

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig, devices } from "@playwright/test"
+
+const port = Number(process.env.PLAYWRIGHT_PORT || 3100)
+const baseURL = process.env.PLAYWRIGHT_BASE_URL || `http://127.0.0.1:${port}`
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: false,
+  workers: 1,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? [["github"], ["html", { open: "never" }]] : "list",
+  use: {
+    baseURL,
+    trace: "on-first-retry",
+  },
+  webServer: {
+    command: `npm run dev -- --webpack --hostname 127.0.0.1 --port ${port}`,
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 300_000,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+})


### PR DESCRIPTION
## Summary

- Add a Playwright UI E2E test foundation under `web/e2e` with reusable API and session helpers.
- Cover initial mocked UI smoke flows for login, dashboard filtering/selection/manual workflow trigger, and conversation history/send.
- Run the Playwright suite in the Depot PR `web` job before the static web build.
- Add a local `make test-web-e2e` convenience target and ignore Playwright artifacts.

## Validation

- `make test-web-e2e`
- `cd web && npm exec -- eslint e2e playwright.config.ts`
- `ruby -e 'require "yaml"; YAML.load_file(".depot/workflows/test.yaml"); puts "ok"'`
