### PR TITLE
Add Docker dev env with optional Ollama

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+bin/
+tmp/
+web/node_modules
+web/.next
+web/out
+internal/webui/out
+.elasticclaw
+memory/
+.demovoice
+coverage.out

--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,4 @@ internal/webui/out
 memory/
 .demovoice
 coverage.out
+docker/hub.dev.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ bootopt
 
 .demovoice/runs
 .demovoice/eval.yaml
+
+# Docker dev environment (contains secrets — never commit)
+docker/hub.dev.yaml
+tmp/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-bridge build-bridge-linux test test-bootstrap test-container e2e e2e-github e2e-linear e2e-replicated-github e2e-replicated-linear e2e-run clean install lint tidy clawpatch-init clawpatch-review clawpatch-report clawpatch-show clawpatch-triage clawpatch-pr
+.PHONY: build build-bridge build-bridge-linux test test-bootstrap test-container e2e e2e-github e2e-linear e2e-replicated-github e2e-replicated-linear e2e-run clean install lint tidy clawpatch-init clawpatch-review clawpatch-report clawpatch-show clawpatch-triage clawpatch-pr dev dev-up dev-up-d dev-down dev-reset dev-logs dev-restart dev-sh-hub dev-sh-web dev-agent-build dev-claw _dev-config-check
 
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
@@ -151,6 +151,69 @@ clawpatch-pr:
 clean:
 	rm -rf bin/
 	rm -rf .elasticclaw/
+
+# ── Docker dev environment ────────────────────────────────────────────────────
+# Prerequisites: Docker Desktop (or Docker Engine) running.
+# make is already installed on macOS via Xcode Command Line Tools.
+#
+# Quick start:
+#   cp docker/hub.dev.yaml.example docker/hub.dev.yaml   # once — add your LLM key
+#   make dev                                              # builds + starts everything
+#   open http://localhost:3000  (login: devpass)
+#   make dev-claw               # spawn a local agent (requires LLM key in hub.dev.yaml)
+
+COMPOSE := docker compose -f docker/compose.dev.yml
+
+# Ensure docker/hub.dev.yaml exists as a FILE before any compose command.
+# Docker creates an empty directory when a bind-mounted file is missing, which
+# breaks the hub config. This guard creates the file from the example and
+# prompts the user to fill in their LLM key.
+_dev-config-check:
+	@if [ ! -f docker/hub.dev.yaml ]; then \
+		cp docker/hub.dev.yaml.example docker/hub.dev.yaml; \
+		echo ""; \
+		echo "  Created docker/hub.dev.yaml from example."; \
+		echo "  Open docker/hub.dev.yaml and set your LLM key, then run make dev again."; \
+		echo ""; \
+		exit 1; \
+	fi
+
+dev: _dev-config-check dev-agent-build dev-up	## Build agent image then start hub + web (foreground)
+
+dev-up: _dev-config-check		## Start hub + web (builds hub image if needed)
+	$(COMPOSE) up --build
+
+dev-up-d:			## Start hub + web in background (detached)
+	$(COMPOSE) up --build -d
+
+dev-down:			## Stop containers (preserves DB volume)
+	$(COMPOSE) down
+
+dev-reset:			## Stop containers AND delete all volumes (clean slate)
+	$(COMPOSE) down -v
+
+dev-logs:			## Follow logs from hub and web
+	$(COMPOSE) logs -f
+
+dev-restart:			## Restart just the hub (picks up hub.dev.yaml changes)
+	$(COMPOSE) restart hub
+
+dev-sh-hub:			## Open a shell in the running hub container
+	$(COMPOSE) exec hub sh
+
+dev-sh-web:			## Open a shell in the running web container
+	$(COMPOSE) exec web sh
+
+dev-agent-build:		## Build the local agent container image (elasticclaw/claw-agent:dev)
+	docker build -f docker/agent.Dockerfile -t elasticclaw/claw-agent:dev .
+
+dev-claw:			## Spawn a one-off local agent via the docker provider
+	@curl -fsS -X POST http://localhost:8080/api/claws \
+	  -H "Authorization: Bearer devtoken" \
+	  -H "Content-Type: application/json" \
+	  -d '{"name":"local-agent","provider":"docker"}' | cat
+
+# ─────────────────────────────────────────────────────────────────────────────
 
 # Development helpers
 dev-template:

--- a/Makefile
+++ b/Makefile
@@ -157,12 +157,14 @@ clean:
 # make is already installed on macOS via Xcode Command Line Tools.
 #
 # Quick start:
-#   cp docker/hub.dev.yaml.example docker/hub.dev.yaml   # once — add your LLM key
+#   cp docker/hub.dev.yaml.example docker/hub.dev.yaml
 #   make dev                                              # builds + starts everything
+#   make dev-ollama-pull                                  # pulls the default local test model
 #   open http://localhost:3000  (login: devpass)
-#   make dev-claw               # spawn a local agent (requires LLM key in hub.dev.yaml)
+#   make dev-claw                                         # spawn a local agent
 
 COMPOSE := docker compose -f docker/compose.dev.yml
+MODEL ?= qwen2.5-coder:1.5b
 
 # Ensure docker/hub.dev.yaml exists as a FILE before any compose command.
 # Docker creates an empty directory when a bind-mounted file is missing, which
@@ -173,7 +175,8 @@ _dev-config-check:
 		cp docker/hub.dev.yaml.example docker/hub.dev.yaml; \
 		echo ""; \
 		echo "  Created docker/hub.dev.yaml from example."; \
-		echo "  Open docker/hub.dev.yaml and set your LLM key, then run make dev again."; \
+		echo "  It defaults to local Ollama. Run make dev again, then make dev-ollama-pull."; \
+		echo "  Edit docker/hub.dev.yaml if you want to use an external LLM API."; \
 		echo ""; \
 		exit 1; \
 	fi
@@ -183,7 +186,7 @@ dev: _dev-config-check dev-agent-build dev-up	## Build agent image then start hu
 dev-up: _dev-config-check		## Start hub + web (builds hub image if needed)
 	$(COMPOSE) up --build
 
-dev-up-d:			## Start hub + web in background (detached)
+dev-up-d: _dev-config-check		## Start hub + web in background (detached)
 	$(COMPOSE) up --build -d
 
 dev-down:			## Stop containers (preserves DB volume)
@@ -206,6 +209,9 @@ dev-sh-web:			## Open a shell in the running web container
 
 dev-agent-build:		## Build the local agent container image (elasticclaw/claw-agent:dev)
 	docker build -f docker/agent.Dockerfile -t elasticclaw/claw-agent:dev .
+
+dev-ollama-pull:		## Pull the local Ollama model (override with MODEL=model:tag)
+	$(COMPOSE) exec ollama ollama pull $(MODEL)
 
 dev-claw:			## Spawn a one-off local agent via the docker provider
 	@curl -fsS -X POST http://localhost:8080/api/claws \

--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -1811,51 +1811,84 @@ PYEOF`, defaultModelJSON, gatewayPasswordJSON)
 }
 
 func patchOllamaLocalDevCatalog(baseURL string) error {
-	baseURLJSON, _ := json.Marshal(baseURL)
-	script := fmt.Sprintf(`python3 <<'PYEOF'
-import json, os, time
-base_url = %s
-model = os.environ.get('OPENCLAW_DEFAULT_MODEL', '')
-model_id = model.split('/', 1)[1] if model.startswith('ollama/') else ''
-roots = [
-    os.path.expanduser('~/.openclaw/agents/main/agent/plugins/ollama/catalog.json'),
-]
-for attempt in range(10):
-    patched = 0
-    for path in roots:
-        if not os.path.exists(path):
-            continue
-        with open(path) as f:
-            catalog = json.load(f)
-        providers = catalog.get('providers')
-        if not isinstance(providers, dict):
-            continue
-        for provider_id, provider in providers.items():
-            if provider_id == 'ollama' and isinstance(provider, dict):
-                provider['baseUrl'] = base_url
-                for item in provider.get('models', []):
-                    if not isinstance(item, dict):
-                        continue
-                    if model_id and item.get('id') != model_id:
-                        continue
-                    item['baseUrl'] = base_url
-                    item['contextWindow'] = 32768
-                    item['maxTokens'] = 1024
-                    item['params'] = {'num_ctx': 32768, 'thinking': False, 'keep_alive': '15m'}
-                    compat = item.setdefault('compat', {})
-                    compat['supportsTools'] = True
-                    compat['supportsUsageInStreaming'] = True
-                patched += 1
-        with open(path, 'w') as f:
-            json.dump(catalog, f, indent=2)
-    if patched:
-        print(f'Patched Ollama local dev catalog: {base_url}')
-        break
-    time.sleep(1)
-else:
-    raise SystemExit('Ollama catalog not found')
-PYEOF`, baseURLJSON)
-	return runShell(script)
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("home dir: %w", err)
+	}
+	modelID := ""
+	if model := os.Getenv("OPENCLAW_DEFAULT_MODEL"); strings.HasPrefix(model, "ollama/") {
+		modelID = strings.TrimPrefix(model, "ollama/")
+	}
+	catalogPath := filepath.Join(home, ".openclaw", "agents", "main", "agent", "plugins", "ollama", "catalog.json")
+
+	var lastErr error
+	for attempt := 0; attempt < 10; attempt++ {
+		if err := patchOllamaLocalDevCatalogFile(catalogPath, baseURL, modelID); err == nil {
+			log.Printf("[bootstrap] patched Ollama local dev catalog: %s", baseURL)
+			return nil
+		} else {
+			lastErr = err
+		}
+		time.Sleep(time.Second)
+	}
+	return fmt.Errorf("patch Ollama catalog: %w", lastErr)
+}
+
+func patchOllamaLocalDevCatalogFile(path, baseURL, modelID string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	var catalog map[string]interface{}
+	if err := json.Unmarshal(data, &catalog); err != nil {
+		return fmt.Errorf("parse %s: %w", path, err)
+	}
+	providers, ok := catalog["providers"].(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("catalog has no providers object")
+	}
+	provider, ok := providers["ollama"].(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("catalog has no ollama provider")
+	}
+
+	provider["baseUrl"] = baseURL
+	if models, ok := provider["models"].([]interface{}); ok {
+		for _, item := range models {
+			model, ok := item.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if modelID != "" && model["id"] != modelID {
+				continue
+			}
+			model["baseUrl"] = baseURL
+			model["contextWindow"] = 32768
+			model["maxTokens"] = 1024
+			model["params"] = map[string]interface{}{
+				"num_ctx":    32768,
+				"thinking":   false,
+				"keep_alive": "15m",
+			}
+			compat, ok := model["compat"].(map[string]interface{})
+			if !ok {
+				compat = map[string]interface{}{}
+				model["compat"] = compat
+			}
+			compat["supportsTools"] = true
+			compat["supportsUsageInStreaming"] = true
+		}
+	}
+
+	patched, err := json.MarshalIndent(catalog, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode %s: %w", path, err)
+	}
+	if err := os.WriteFile(path, patched, 0600); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
 }
 
 // onboardOpenClaw runs openclaw onboard to initialize the identity/config.

--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -1701,26 +1701,43 @@ func installNodeGit() error {
 	log.Printf("[bootstrap] installing Node.js 24 + git...")
 	script := `
 set -euo pipefail
+node_major() {
+  if command -v node >/dev/null 2>&1; then
+    node --version | sed -E 's/^v([0-9]+).*/\1/'
+  fi
+}
+if command -v git >/dev/null 2>&1 && command -v npm >/dev/null 2>&1 && [ "$(node_major)" = "24" ]; then
+  echo "Node: $(node --version)"
+  echo "Git: $(git --version)"
+  exit 0
+fi
 # Single apt-get update then install everything in one pass to avoid
 # dpkg state corruption from multiple overlapping install calls.
 sudo apt-get update -qq
-sudo apt-get install -y --fix-broken curl ca-certificates git
-sudo mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | \
-  sudo gpg --batch --yes --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_24.x nodistro main" | \
-  sudo tee /etc/apt/sources.list.d/nodesource.list > /dev/null
-sudo apt-get update -qq
-sudo apt-get install -y --fix-broken nodejs
+sudo apt-get install -y --fix-broken curl ca-certificates git gnupg
+if ! command -v npm >/dev/null 2>&1 || [ "$(node_major)" != "24" ]; then
+  if [ ! -f /etc/apt/sources.list.d/nodesource.sources ] && [ ! -f /etc/apt/sources.list.d/nodesource.list ]; then
+    sudo mkdir -p /etc/apt/keyrings
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | \
+      sudo gpg --batch --yes --dearmor -o /etc/apt/keyrings/nodesource.gpg
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_24.x nodistro main" | \
+      sudo tee /etc/apt/sources.list.d/nodesource.list > /dev/null
+  fi
+  sudo apt-get update -qq
+  sudo apt-get install -y --fix-broken nodejs
+fi
 echo "Node: $(node --version)"
+echo "Git: $(git --version)"
 `
 	return runShell(script)
 }
 
-// installOpenClaw installs openclaw@2026.5.20 via npm.
+const openClawVersion = "2026.6.1"
+
+// installOpenClaw installs the pinned OpenClaw CLI via npm.
 func installOpenClaw() error {
-	log.Printf("[bootstrap] installing openclaw@2026.5.20...")
-	if err := runShell("sudo npm install -g openclaw@2026.5.20 --ignore-scripts"); err != nil {
+	log.Printf("[bootstrap] installing openclaw@%s...", openClawVersion)
+	if err := runShell(fmt.Sprintf("sudo npm install -g openclaw@%s --ignore-scripts", openClawVersion)); err != nil {
 		return fmt.Errorf("npm install openclaw: %w", err)
 	}
 	out, _ := exec.Command("openclaw", "--version").Output()
@@ -1791,6 +1808,54 @@ PYEOF`, defaultModelJSON, gatewayPasswordJSON)
 	_ = runShell("openclaw plugins disable bonjour 2>/dev/null || true")
 
 	return nil
+}
+
+func patchOllamaLocalDevCatalog(baseURL string) error {
+	baseURLJSON, _ := json.Marshal(baseURL)
+	script := fmt.Sprintf(`python3 <<'PYEOF'
+import json, os, time
+base_url = %s
+model = os.environ.get('OPENCLAW_DEFAULT_MODEL', '')
+model_id = model.split('/', 1)[1] if model.startswith('ollama/') else ''
+roots = [
+    os.path.expanduser('~/.openclaw/agents/main/agent/plugins/ollama/catalog.json'),
+]
+for attempt in range(10):
+    patched = 0
+    for path in roots:
+        if not os.path.exists(path):
+            continue
+        with open(path) as f:
+            catalog = json.load(f)
+        providers = catalog.get('providers')
+        if not isinstance(providers, dict):
+            continue
+        for provider_id, provider in providers.items():
+            if provider_id == 'ollama' and isinstance(provider, dict):
+                provider['baseUrl'] = base_url
+                for item in provider.get('models', []):
+                    if not isinstance(item, dict):
+                        continue
+                    if model_id and item.get('id') != model_id:
+                        continue
+                    item['baseUrl'] = base_url
+                    item['contextWindow'] = 32768
+                    item['maxTokens'] = 1024
+                    item['params'] = {'num_ctx': 32768, 'thinking': False, 'keep_alive': '15m'}
+                    compat = item.setdefault('compat', {})
+                    compat['supportsTools'] = True
+                    compat['supportsUsageInStreaming'] = True
+                patched += 1
+        with open(path, 'w') as f:
+            json.dump(catalog, f, indent=2)
+    if patched:
+        print(f'Patched Ollama local dev catalog: {base_url}')
+        break
+    time.sleep(1)
+else:
+    raise SystemExit('Ollama catalog not found')
+PYEOF`, baseURLJSON)
+	return runShell(script)
 }
 
 // onboardOpenClaw runs openclaw onboard to initialize the identity/config.
@@ -1927,10 +1992,31 @@ func hasWorkspaceFlake() bool {
 	return err == nil
 }
 
+func waitForWorkspaceReadyIfRequested() error {
+	if os.Getenv("ELASTICCLAW_WAIT_FOR_WORKSPACE") != "1" {
+		return nil
+	}
+	home, _ := os.UserHomeDir()
+	readyPath := filepath.Join(home, "workspace", ".elasticclaw-workspace-ready")
+	log.Printf("[bootstrap] waiting for workspace files at %s...", readyPath)
+	for i := 0; i < 300; i++ {
+		if _, err := os.Stat(readyPath); err == nil {
+			log.Printf("[bootstrap] workspace files ready after %ds", i)
+			return nil
+		}
+		time.Sleep(time.Second)
+	}
+	return fmt.Errorf("workspace files not ready after 300s")
+}
+
 // runBootstrap executes all VM bootstrap steps, then returns so the caller
 // can continue into the normal bridge connect loop.
 func runBootstrap() error {
 	log.Printf("[bootstrap] starting claw-bridge bootstrap mode")
+
+	if err := waitForWorkspaceReadyIfRequested(); err != nil {
+		return err
+	}
 
 	// Check early if we have a workspace flake - this affects how we start the gateway
 	hasFlake := hasWorkspaceFlake()
@@ -1998,6 +2084,17 @@ func runBootstrap() error {
 	gateway, err := startGatewayWithFlake(hasFlake)
 	if err != nil {
 		return fmt.Errorf("startGateway: %w", err)
+	}
+	if strings.HasPrefix(envOr("OPENCLAW_DEFAULT_MODEL", ""), "ollama/") {
+		if err := patchOllamaLocalDevCatalog("http://ollama:11434"); err != nil {
+			log.Printf("[bootstrap] warning: patch Ollama local dev catalog: %v", err)
+		} else {
+			stopGateway(gateway)
+			gateway, err = startGatewayWithFlake(hasFlake)
+			if err != nil {
+				return fmt.Errorf("restartGateway after Ollama catalog patch: %w", err)
+			}
+		}
 	}
 	go func() {
 		if err := gateway.Wait(); err != nil {

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -100,6 +100,23 @@ func TestLoadGatewayClientEnvVarFallbackWhenNoConfigPassword(t *testing.T) {
 	}
 }
 
+func TestWaitForWorkspaceReadyIfRequested(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("ELASTICCLAW_WAIT_FOR_WORKSPACE", "1")
+	workspaceDir := filepath.Join(home, "workspace")
+	if err := os.MkdirAll(workspaceDir, 0700); err != nil {
+		t.Fatalf("mkdir workspace: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workspaceDir, ".elasticclaw-workspace-ready"), []byte("ready\n"), 0600); err != nil {
+		t.Fatalf("write ready marker: %v", err)
+	}
+
+	if err := waitForWorkspaceReadyIfRequested(); err != nil {
+		t.Fatalf("waitForWorkspaceReadyIfRequested(): %v", err)
+	}
+}
+
 func TestNestedStringExtractsToolCommandDetails(t *testing.T) {
 	tests := []struct {
 		name string
@@ -201,6 +218,93 @@ func TestResolveToolActivityDetailUsesOpenClawMeta(t *testing.T) {
 				t.Fatalf("resolveToolActivityDetail() = (%q, %q, %q, %q), want (%q, %q, %q, %q)", command, path, url, detail, tt.wantCommand, tt.wantPath, tt.wantURL, tt.wantDetail)
 			}
 		})
+	}
+}
+
+func TestPatchOllamaLocalDevCatalogSetsRuntimeLimits(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("OPENCLAW_DEFAULT_MODEL", "ollama/qwen2.5-coder:1.5b")
+
+	catalogPath := filepath.Join(home, ".openclaw", "agents", "main", "agent", "plugins", "ollama", "catalog.json")
+	if err := os.MkdirAll(filepath.Dir(catalogPath), 0700); err != nil {
+		t.Fatalf("mkdir catalog dir: %v", err)
+	}
+	initial := map[string]interface{}{
+		"providers": map[string]interface{}{
+			"ollama": map[string]interface{}{
+				"baseUrl": "http://127.0.0.1:11434",
+				"models": []interface{}{
+					map[string]interface{}{
+						"id":            "qwen2.5-coder:1.5b",
+						"contextWindow": float64(128000),
+						"maxTokens":     float64(8192),
+						"compat": map[string]interface{}{
+							"supportsTools": true,
+						},
+					},
+				},
+			},
+			"ollama-cloud": map[string]interface{}{
+				"baseUrl": "https://ollama.com",
+			},
+		},
+	}
+	data, _ := json.Marshal(initial)
+	if err := os.WriteFile(catalogPath, data, 0600); err != nil {
+		t.Fatalf("write catalog: %v", err)
+	}
+
+	if err := patchOllamaLocalDevCatalog("http://ollama:11434"); err != nil {
+		t.Fatalf("patch catalog: %v", err)
+	}
+
+	data, err := os.ReadFile(catalogPath)
+	if err != nil {
+		t.Fatalf("read catalog: %v", err)
+	}
+	var got struct {
+		Providers map[string]struct {
+			BaseURL string `json:"baseUrl"`
+			Models  []struct {
+				ID            string `json:"id"`
+				BaseURL       string `json:"baseUrl"`
+				ContextWindow int    `json:"contextWindow"`
+				MaxTokens     int    `json:"maxTokens"`
+				Params        struct {
+					NumCtx    int    `json:"num_ctx"`
+					Thinking  bool   `json:"thinking"`
+					KeepAlive string `json:"keep_alive"`
+				} `json:"params"`
+				Compat struct {
+					SupportsTools            bool `json:"supportsTools"`
+					SupportsUsageInStreaming bool `json:"supportsUsageInStreaming"`
+				} `json:"compat"`
+			} `json:"models"`
+		} `json:"providers"`
+	}
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("parse catalog: %v", err)
+	}
+	local := got.Providers["ollama"]
+	if local.BaseURL != "http://ollama:11434" {
+		t.Fatalf("local baseUrl = %q", local.BaseURL)
+	}
+	if got.Providers["ollama-cloud"].BaseURL != "https://ollama.com" {
+		t.Fatalf("ollama-cloud was modified: %q", got.Providers["ollama-cloud"].BaseURL)
+	}
+	if len(local.Models) != 1 {
+		t.Fatalf("models len = %d", len(local.Models))
+	}
+	model := local.Models[0]
+	if model.BaseURL != "http://ollama:11434" || model.ContextWindow != 32768 || model.MaxTokens != 1024 {
+		t.Fatalf("model limits not patched: %+v", model)
+	}
+	if model.Params.NumCtx != 32768 || model.Params.Thinking || model.Params.KeepAlive != "15m" {
+		t.Fatalf("model params not patched: %+v", model.Params)
+	}
+	if !model.Compat.SupportsTools || !model.Compat.SupportsUsageInStreaming {
+		t.Fatalf("model compat not patched: %+v", model.Compat)
 	}
 }
 

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -243,6 +243,12 @@ func TestPatchOllamaLocalDevCatalogSetsRuntimeLimits(t *testing.T) {
 							"supportsTools": true,
 						},
 					},
+					map[string]interface{}{
+						"id":            "llama3.2:3b",
+						"baseUrl":       "http://127.0.0.1:11434",
+						"contextWindow": float64(4096),
+						"maxTokens":     float64(2048),
+					},
 				},
 			},
 			"ollama-cloud": map[string]interface{}{
@@ -293,7 +299,7 @@ func TestPatchOllamaLocalDevCatalogSetsRuntimeLimits(t *testing.T) {
 	if got.Providers["ollama-cloud"].BaseURL != "https://ollama.com" {
 		t.Fatalf("ollama-cloud was modified: %q", got.Providers["ollama-cloud"].BaseURL)
 	}
-	if len(local.Models) != 1 {
+	if len(local.Models) != 2 {
 		t.Fatalf("models len = %d", len(local.Models))
 	}
 	model := local.Models[0]
@@ -305,6 +311,10 @@ func TestPatchOllamaLocalDevCatalogSetsRuntimeLimits(t *testing.T) {
 	}
 	if !model.Compat.SupportsTools || !model.Compat.SupportsUsageInStreaming {
 		t.Fatalf("model compat not patched: %+v", model.Compat)
+	}
+	otherModel := local.Models[1]
+	if otherModel.BaseURL != "http://127.0.0.1:11434" || otherModel.ContextWindow != 4096 || otherModel.MaxTokens != 2048 {
+		t.Fatalf("non-selected model was modified: %+v", otherModel)
 	}
 }
 

--- a/docker/.air.toml
+++ b/docker/.air.toml
@@ -1,0 +1,21 @@
+root = "."
+tmp_dir = "tmp"
+
+[build]
+  # Compile the hub binary; args_bin are passed to it on each restart.
+  # Token/ui-password come from hub.yaml mounted at /root/.elasticclaw/hub.yaml.
+  cmd = "go build -o ./tmp/hub ."
+  bin = "./tmp/hub"
+  args_bin = ["hub", "--addr", ":8080", "--no-web-ui"]
+  include_ext = ["go"]
+  exclude_dir  = ["web", "bin", "tmp", "internal/webui/out", ".git", "test"]
+  delay = 800         # ms to wait after a change before rebuilding
+  stop_on_error = true
+  kill_delay = "1s"
+
+[log]
+  time = false
+
+[color]
+  build  = "yellow"
+  runner = "green"

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,6 +1,6 @@
 # Local dev environment
 
-Runs the full ElasticClaw stack locally — hub, web UI, and real coding agents — without any cloud provider. Agents run as Docker containers on your machine.
+Runs the full ElasticClaw stack locally — hub, web UI, Ollama, and real coding agents — without any cloud provider. Agents run as Docker containers on your machine.
 
 ## Prerequisites
 
@@ -14,18 +14,20 @@ Runs the full ElasticClaw stack locally — hub, web UI, and real coding agents 
 cp docker/hub.dev.yaml.example docker/hub.dev.yaml
 ```
 
-Open `docker/hub.dev.yaml` and fill in your LLM API key. Change `provider` and `default_model` to match your preferred provider (OpenAI, Groq, DeepSeek, etc.):
+The example config defaults to the local Ollama service:
 
 ```yaml
-default_model: openai/gpt-5.5
+default_model: ollama/qwen2.5-coder:1.5b
 llm_keys:
-  - name: primary
-    provider: openai          # → OPENAI_API_KEY env var
-    api_key: "sk-..."
+  - name: local-ollama
+    provider: ollama          # → OLLAMA_API_KEY env var
+    api_key: "ollama-local"   # placeholder for local Ollama
     default: true
 ```
 
-The file is gitignored and will never be committed.
+The file is gitignored and will never be committed. To use a stronger external model while testing, add an external key entry, mark it `default: true`, set `local-ollama` to `default: false`, and change `default_model` to the matching provider/model.
+
+The default local Ollama agent profile is intentionally conservative for Docker dev: it uses OpenClaw lean mode and an explicit Ollama runtime context for the small default model. That keeps local message smoke tests stable on ordinary laptops. Use an external provider entry when you need stronger tool-heavy coding-agent behavior or prompt tuning against a production-like model.
 
 ## Start the environment
 
@@ -36,6 +38,19 @@ make dev
 This builds the agent image (`elasticclaw/claw-agent:dev`) and starts:
 - **hub** on `http://localhost:8080` — Go server with hot reload via `air`
 - **web** on `http://localhost:3000` — Next.js dev server with fast refresh
+- **ollama** on `http://localhost:11434` — local LLM service available to hub and agents as `http://ollama:11434`
+
+Pull the default local model once:
+
+```bash
+make dev-ollama-pull
+```
+
+To use a different local model:
+
+```bash
+make dev-ollama-pull MODEL=llama3.2:3b
+```
 
 Open `http://localhost:3000` and log in with password `devpass`.
 
@@ -53,9 +68,10 @@ You can also trigger agents via workflows configured with `provider: docker` in 
 
 | Command | Description |
 |---------|-------------|
-| `make dev` | Build agent image + start hub + web (foreground) |
+| `make dev` | Build agent image + start hub + web + Ollama (foreground) |
 | `make dev-up-d` | Start in background (detached) |
-| `make dev-logs` | Follow logs from hub and web |
+| `make dev-ollama-pull` | Pull the local Ollama model, override with `MODEL=model:tag` |
+| `make dev-logs` | Follow logs from hub, web, and Ollama |
 | `make dev-down` | Stop containers (DB preserved) |
 | `make dev-reset` | Stop + delete all volumes (clean slate) |
 | `make dev-restart` | Restart just the hub |
@@ -65,11 +81,13 @@ You can also trigger agents via workflows configured with `provider: docker` in 
 
 ## Architecture notes
 
-**Docker-out-of-Docker**: the hub container has the Docker socket mounted (`/var/run/docker.sock`), so it can spawn sibling agent containers. Agent containers join the `elasticclaw-dev` network and reach the hub at `http://hub:8080` (the `public_url` in `hub.dev.yaml`).
+**Docker-out-of-Docker**: the hub container has the Docker socket mounted (`/var/run/docker.sock`), so it can spawn sibling agent containers. Agent containers join the `elasticclaw-dev` network and reach the hub at `http://hub:8080` (the `public_url` in `hub.dev.yaml`) and Ollama at `http://ollama:11434`.
+
+**Local vs external models**: Ollama is optional but available by default for cheap local testing. External API providers still work by editing `docker/hub.dev.yaml`; use them when you need stronger model behavior or want to tune prompts against a production-like model.
 
 **Browser → hub**: the web UI at `:3000` calls the hub at `localhost:8080` directly (the hub has permissive CORS). The `NEXT_PUBLIC_HUB_URL` points to `localhost:8080`, not the internal Docker hostname.
 
-**Persistence**: the SQLite DB lives in the `hub-data` volume. `make dev-down` preserves it; `make dev-reset` wipes everything.
+**Persistence**: the SQLite DB lives in the `hub-data` volume. Ollama model data lives in the `ollama-data` volume. `make dev-down` preserves both; `make dev-reset` wipes everything.
 
 **Hot reload Go**: edit any `.go` file and `air` recompiles the hub automatically (watch the logs). Hot reload for the web UI is handled by Next.js fast refresh.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,78 @@
+# Local dev environment
+
+Runs the full ElasticClaw stack locally — hub, web UI, and real coding agents — without any cloud provider. Agents run as Docker containers on your machine.
+
+## Prerequisites
+
+- **Docker Desktop** (or Docker Engine) running
+- **`make`** — already installed on macOS via Xcode Command Line Tools (`xcode-select --install`)
+- No Go or Node.js required on the host; everything compiles inside containers
+
+## One-time setup
+
+```bash
+cp docker/hub.dev.yaml.example docker/hub.dev.yaml
+```
+
+Open `docker/hub.dev.yaml` and fill in your LLM API key. Change `provider` and `default_model` to match your preferred provider (OpenAI, Groq, DeepSeek, etc.):
+
+```yaml
+default_model: openai/gpt-5.5
+llm_keys:
+  - name: primary
+    provider: openai          # → OPENAI_API_KEY env var
+    api_key: "sk-..."
+    default: true
+```
+
+The file is gitignored and will never be committed.
+
+## Start the environment
+
+```bash
+make dev
+```
+
+This builds the agent image (`elasticclaw/claw-agent:dev`) and starts:
+- **hub** on `http://localhost:8080` — Go server with hot reload via `air`
+- **web** on `http://localhost:3000` — Next.js dev server with fast refresh
+
+Open `http://localhost:3000` and log in with password `devpass`.
+
+## Spawn a local agent
+
+```bash
+make dev-claw
+```
+
+This creates a claw using the `docker` provider. The hub starts a sibling container with `elasticclaw/claw-agent:dev`, which bootstraps OpenClaw and connects back to the hub. The agent appears in the dashboard in a few seconds.
+
+You can also trigger agents via workflows configured with `provider: docker` in `hub.dev.yaml`.
+
+## Useful commands
+
+| Command | Description |
+|---------|-------------|
+| `make dev` | Build agent image + start hub + web (foreground) |
+| `make dev-up-d` | Start in background (detached) |
+| `make dev-logs` | Follow logs from hub and web |
+| `make dev-down` | Stop containers (DB preserved) |
+| `make dev-reset` | Stop + delete all volumes (clean slate) |
+| `make dev-restart` | Restart just the hub |
+| `make dev-sh-hub` | Shell into the hub container |
+| `make dev-agent-build` | Rebuild the agent image after code changes |
+| `make dev-claw` | Spawn a one-off local agent |
+
+## Architecture notes
+
+**Docker-out-of-Docker**: the hub container has the Docker socket mounted (`/var/run/docker.sock`), so it can spawn sibling agent containers. Agent containers join the `elasticclaw-dev` network and reach the hub at `http://hub:8080` (the `public_url` in `hub.dev.yaml`).
+
+**Browser → hub**: the web UI at `:3000` calls the hub at `localhost:8080` directly (the hub has permissive CORS). The `NEXT_PUBLIC_HUB_URL` points to `localhost:8080`, not the internal Docker hostname.
+
+**Persistence**: the SQLite DB lives in the `hub-data` volume. `make dev-down` preserves it; `make dev-reset` wipes everything.
+
+**Hot reload Go**: edit any `.go` file and `air` recompiles the hub automatically (watch the logs). Hot reload for the web UI is handled by Next.js fast refresh.
+
+## Limitations
+
+This environment is for local development only. For end-to-end testing with real issue trackers and PRs you still need a public URL (see `make e2e` in the root Makefile). Do not use this compose file in production.

--- a/docker/agent.Dockerfile
+++ b/docker/agent.Dockerfile
@@ -1,0 +1,42 @@
+# stage 1: compile claw-bridge statically (no Go required on the host)
+FROM golang:1.25 AS bridge-builder
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+    -ldflags "-X main.Version=dev -X main.Commit=local -X main.BuildDate=0" \
+    -o /out/claw-bridge ./cmd/claw-bridge
+
+# stage 2: agent runtime — Ubuntu with Node + OpenClaw pre-installed
+FROM ubuntu:22.04
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      curl ca-certificates git gnupg sudo python3 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Node.js 24 (same version claw-bridge would install at bootstrap time)
+RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Pre-install OpenClaw globally so bootstrap skips the npm install step
+RUN npm install -g openclaw@2026.5.20 --ignore-scripts 2>&1 || true
+
+# Create the 'claw' user (bridge runs as non-root; bootstrap expects this user)
+RUN useradd -m -s /bin/bash claw \
+    && echo 'claw ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+# Copy the pre-built bridge binary
+COPY --from=bridge-builder /out/claw-bridge /usr/local/bin/claw-bridge
+RUN chmod +x /usr/local/bin/claw-bridge
+
+ENV ELASTICCLAW_GATEWAY=localhost:18789
+ENV OPENCLAW_NO_RESPAWN=1
+ENV OPENCLAW_DISABLE_BONJOUR=1
+
+USER claw
+WORKDIR /home/claw
+
+ENTRYPOINT ["/usr/local/bin/claw-bridge", "--bootstrap"]

--- a/docker/agent.Dockerfile
+++ b/docker/agent.Dockerfile
@@ -21,8 +21,8 @@ RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
     && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
 
-# Pre-install OpenClaw globally so bootstrap skips the npm install step
-RUN npm install -g openclaw@2026.5.20 --ignore-scripts 2>&1 || true
+# Pre-install OpenClaw globally so bootstrap skips the npm install step.
+RUN npm install -g openclaw@2026.6.1 --ignore-scripts
 
 # Create the 'claw' user (bridge runs as non-root; bootstrap expects this user)
 RUN useradd -m -s /bin/bash claw \

--- a/docker/compose.dev.yml
+++ b/docker/compose.dev.yml
@@ -50,8 +50,18 @@ services:
     depends_on:
       - hub
 
+  ollama:
+    image: ollama/ollama:latest
+    ports:
+      - "11434:11434"
+    networks:
+      - elasticclaw
+    volumes:
+      - ollama-data:/root/.ollama
+
 volumes:
   hub-data:
   go-mod:
   go-build:
   web-node-modules:
+  ollama-data:

--- a/docker/compose.dev.yml
+++ b/docker/compose.dev.yml
@@ -1,0 +1,57 @@
+name: elasticclaw-dev
+
+# Shared network so agent containers can reach the hub by service name.
+networks:
+  elasticclaw:
+    name: elasticclaw-dev
+
+services:
+  hub:
+    build:
+      context: ..
+      dockerfile: docker/hub.Dockerfile
+    working_dir: /app
+    ports:
+      - "8080:8080"
+    networks:
+      - elasticclaw
+    volumes:
+      # Source code — air watches for .go changes and rebuilds
+      - ..:/app
+      # Persistent SQLite DB and hub.yaml config
+      - hub-data:/root/.elasticclaw
+      # Dev config: copy hub.dev.yaml.example → hub.dev.yaml and fill in your keys.
+      # Not read-only — the hub rewrites hub.yaml during migrations (stripping legacy fields).
+      - ./hub.dev.yaml:/root/.elasticclaw/hub.yaml
+      # Go module and build caches speed up rebuilds significantly
+      - go-mod:/go/pkg/mod
+      - go-build:/root/.cache/go-build
+      # Docker socket so the hub can spawn sibling agent containers (Docker-out-of-Docker)
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - GOFLAGS=-buildvcs=false
+
+  web:
+    image: node:22-slim
+    working_dir: /app
+    # npm install runs on every start so adding packages works without rebuilding the image
+    command: sh -c "npm install && npm run dev"
+    ports:
+      - "3000:3000"
+    networks:
+      - elasticclaw
+    volumes:
+      - ../web:/app
+      - web-node-modules:/app/node_modules
+    environment:
+      # Browser calls the hub directly on localhost:8080 (hub has permissive CORS).
+      # Do NOT use the Docker service name here — this is consumed by the browser, not the container.
+      - NEXT_PUBLIC_HUB_URL=http://localhost:8080
+    depends_on:
+      - hub
+
+volumes:
+  hub-data:
+  go-mod:
+  go-build:
+  web-node-modules:

--- a/docker/compose.dev.yml
+++ b/docker/compose.dev.yml
@@ -51,7 +51,7 @@ services:
       - hub
 
   ollama:
-    image: ollama/ollama:latest
+    image: ollama/ollama:0.6.5
     ports:
       - "11434:11434"
     networks:

--- a/docker/hub.Dockerfile
+++ b/docker/hub.Dockerfile
@@ -1,0 +1,12 @@
+# Hub development image: Go toolchain + air (hot reload) + docker CLI (for spawning agent containers)
+FROM golang:1.25-alpine
+
+RUN apk add --no-cache git ca-certificates tzdata docker-cli
+
+# Install air for hot reload on .go file changes
+RUN go install github.com/air-verse/air@latest
+
+WORKDIR /app
+EXPOSE 8080
+
+CMD ["air", "-c", "docker/.air.toml"]

--- a/docker/hub.Dockerfile
+++ b/docker/hub.Dockerfile
@@ -4,7 +4,7 @@ FROM golang:1.25-alpine
 RUN apk add --no-cache git ca-certificates tzdata docker-cli
 
 # Install air for hot reload on .go file changes
-RUN go install github.com/air-verse/air@latest
+RUN go install github.com/air-verse/air@v1.61.7
 
 WORKDIR /app
 EXPOSE 8080

--- a/docker/hub.dev.yaml.example
+++ b/docker/hub.dev.yaml.example
@@ -1,5 +1,5 @@
 # ElasticClaw local dev configuration
-# Copy to docker/hub.dev.yaml (gitignored) and fill in your values before running `make dev`.
+# Copy to docker/hub.dev.yaml (gitignored) before running `make dev`.
 
 # Address the CLI uses to reach the hub
 url: http://localhost:8080
@@ -14,21 +14,41 @@ claw_token: devclawtoken
 ui_password: devpass
 
 # Default model in the format "provider/model-name".
-# Examples:
-#   anthropic: anthropic/claude-sonnet-4-6
-#   openai:    openai/gpt-4.1
-#   groq:      groq/llama-3.3-70b-versatile
-#   deepseek:  deepseek/deepseek-chat
-#   fireworks: fireworks/accounts/fireworks/models/kimi-k2p6
-default_model: openai/gpt-4.1
+# Local smoke testing uses the Ollama service from docker/compose.dev.yml.
+# The Docker agent config treats this small default model conservatively:
+# lean prompt surface and explicit Ollama context.
+# Use an external provider below for tool-heavy agent testing or prompt tuning.
+# Run `make dev-ollama-pull` once after the stack is up to pull this model.
+default_model: ollama/qwen2.5-coder:1.5b
 
 llm_keys:
-  - name: primary
+  - name: local-ollama
     # provider maps to the env var: <PROVIDER in uppercase>_API_KEY
-    # e.g. "openai" → OPENAI_API_KEY, "groq" → GROQ_API_KEY
-    provider: openai
-    api_key: "PASTE_YOUR_API_KEY_HERE"
+    # e.g. "ollama" → OLLAMA_API_KEY, "openai" → OPENAI_API_KEY
+    # Local Ollama only needs a placeholder key.
+    provider: ollama
+    api_key: "ollama-local"
     default: true
+
+  # For stronger models or prompt tuning, add an external key and either:
+  # - set this entry to default: true and local-ollama to default: false
+  # - change default_model to the matching provider/model
+  #
+  # - name: openai-dev
+  #   provider: openai
+  #   api_key: "sk-proj-..."
+  #   default_model: openai/gpt-5.5
+  #   default: false
+  #
+  # - name: anthropic-dev
+  #   provider: anthropic
+  #   api_key: "sk-ant-..."
+  #   default_model: anthropic/claude-sonnet-4-6
+  #   default: false
+  #
+  # Other OpenAI-compatible providers remain supported, for example:
+  # groq/llama-3.3-70b-versatile, deepseek/deepseek-chat, or
+  # fireworks/accounts/fireworks/models/kimi-k2p6.
 
 providers:
   docker:

--- a/docker/hub.dev.yaml.example
+++ b/docker/hub.dev.yaml.example
@@ -1,0 +1,38 @@
+# ElasticClaw local dev configuration
+# Copy to docker/hub.dev.yaml (gitignored) and fill in your values before running `make dev`.
+
+# Address the CLI uses to reach the hub
+url: http://localhost:8080
+
+# URL agent containers use to connect back to the hub over the Docker network.
+# The service name "hub" resolves inside the elasticclaw-dev Docker network.
+public_url: http://hub:8080
+
+# Auth tokens — keep these as-is for local dev (they only secure your laptop)
+token: devtoken
+claw_token: devclawtoken
+ui_password: devpass
+
+# Default model in the format "provider/model-name".
+# Examples:
+#   anthropic: anthropic/claude-sonnet-4-6
+#   openai:    openai/gpt-4.1
+#   groq:      groq/llama-3.3-70b-versatile
+#   deepseek:  deepseek/deepseek-chat
+#   fireworks: fireworks/accounts/fireworks/models/kimi-k2p6
+default_model: openai/gpt-4.1
+
+llm_keys:
+  - name: primary
+    # provider maps to the env var: <PROVIDER in uppercase>_API_KEY
+    # e.g. "openai" → OPENAI_API_KEY, "groq" → GROQ_API_KEY
+    provider: openai
+    api_key: "PASTE_YOUR_API_KEY_HERE"
+    default: true
+
+providers:
+  docker:
+    # Agent container image built by `make dev-agent-build`
+    image: elasticclaw/claw-agent:dev
+    # Docker network shared between hub and agent containers
+    network: elasticclaw-dev

--- a/pkg/hub/ai_config.go
+++ b/pkg/hub/ai_config.go
@@ -468,57 +468,14 @@ func callLLMForConfig(sanitizedYAML, message string, history []aiChatMessage, ll
 	msgs = append(msgs, sanitizeAIChatHistory(history)...)
 	msgs = append(msgs, aiChatMessage{Role: "user", Content: message})
 
-	// Select provider: prefer defaultModel provider, then fall back to first available
-	var anthropicKey, openaiKey, codexKey string
-	for _, k := range llmKeys {
-		if k.Provider == "anthropic" && anthropicKey == "" {
-			anthropicKey = k.APIKey
-		}
-		if k.Provider == "openai" && openaiKey == "" {
-			openaiKey = k.APIKey
-		}
-		if k.Provider == "codex" && codexKey == "" {
-			codexKey = k.APIKey
-		}
+	choice, err := selectAIConfigProvider(llmKeys, defaultModel)
+	if err != nil {
+		return "", err
 	}
-
-	if len(llmKeys) == 0 {
-		return "", fmt.Errorf("no LLM keys configured")
+	if choice.Anthropic {
+		return callAnthropic(choice.Key.APIKey, systemPrompt, msgs)
 	}
-
-	// Try defaultModel provider first
-	defaultProvider := strings.TrimSpace(strings.SplitN(defaultModel, "/", 2)[0])
-	switch defaultProvider {
-	case "anthropic":
-		if anthropicKey != "" {
-			return callAnthropic(anthropicKey, systemPrompt, msgs)
-		}
-	case "openai":
-		if openaiKey != "" {
-			return callOpenAI(openaiKey, systemPrompt, msgs, "gpt-5.5")
-		}
-	case "codex":
-		if codexKey != "" {
-			return callOpenAI(codexKey, systemPrompt, msgs, "o4-mini")
-		}
-	}
-
-	// Fall back to hard-coded priority
-	if anthropicKey != "" {
-		return callAnthropic(anthropicKey, systemPrompt, msgs)
-	}
-	if openaiKey != "" {
-		return callOpenAI(openaiKey, systemPrompt, msgs, "gpt-5.5")
-	}
-	if codexKey != "" {
-		return callOpenAI(codexKey, systemPrompt, msgs, "o4-mini")
-	}
-
-	availableProviders := uniqueProviders(llmKeys)
-	if defaultProvider != "" {
-		return "", fmt.Errorf("no supported LLM key configured for default_model provider %q (supported providers: anthropic, openai, codex; configured: %s)", defaultProvider, strings.Join(availableProviders, ", "))
-	}
-	return "", fmt.Errorf("no supported LLM key configured (supported providers: anthropic, openai, codex; configured: %s)", strings.Join(availableProviders, ", "))
+	return callOpenAI(choice.Provider, choice.Key.APIKey, systemPrompt, msgs, choice.Model)
 }
 
 // callLLMForConfigStream selects the best available provider and streams tokens via onToken.
@@ -535,58 +492,123 @@ func callLLMForConfigStream(ctx context.Context, sanitizedYAML, message string, 
 // streamLLMWithSystemPrompt selects a provider from llmKeys/defaultModel and streams tokens via onToken.
 // Callers supply a fully-built system prompt and message list.
 func streamLLMWithSystemPrompt(ctx context.Context, systemPrompt string, msgs []aiChatMessage, llmKeys types.LLMKeysList, defaultModel string, onToken func(string)) error {
-	var anthropicKey, openaiKey, codexKey string
-	var firstKey *types.LLMKeyConfig
-	for _, k := range llmKeys {
-		if firstKey == nil {
-			firstKey = k
-		}
-		if k.Provider == "anthropic" && anthropicKey == "" {
-			anthropicKey = k.APIKey
-		}
-		if k.Provider == "openai" && openaiKey == "" {
-			openaiKey = k.APIKey
-		}
-		if k.Provider == "codex" && codexKey == "" {
-			codexKey = k.APIKey
-		}
+	choice, err := selectAIConfigProvider(llmKeys, defaultModel)
+	if err != nil {
+		return err
+	}
+	if choice.Anthropic {
+		return streamAnthropic(ctx, choice.Key.APIKey, systemPrompt, msgs, onToken)
+	}
+	return streamOpenAI(ctx, choice.Provider, choice.Key.APIKey, systemPrompt, msgs, onToken, choice.Model)
+}
+
+type aiConfigProviderChoice struct {
+	Key       *types.LLMKeyConfig
+	Anthropic bool
+	Provider  openAICompatibleProvider
+	Model     string
+}
+
+func selectAIConfigProvider(llmKeys types.LLMKeysList, defaultModel string) (*aiConfigProviderChoice, error) {
+	if len(llmKeys) == 0 {
+		return nil, fmt.Errorf("no LLM keys configured")
 	}
 
-	if firstKey == nil {
-		return fmt.Errorf("no LLM keys configured")
+	var anthropicKey *types.LLMKeyConfig
+	openAIKeys := map[string]*types.LLMKeyConfig{}
+	for _, k := range llmKeys {
+		if k == nil || !llmKeyHasRequiredAPIKey(k) {
+			continue
+		}
+		if k.Provider == "anthropic" && anthropicKey == nil {
+			anthropicKey = k
+		}
+		if isOpenAICompatibleConfigProvider(k.Provider) && openAIKeys[k.Provider] == nil {
+			openAIKeys[k.Provider] = k
+		}
 	}
 
 	defaultProvider := strings.TrimSpace(strings.SplitN(defaultModel, "/", 2)[0])
 	switch defaultProvider {
 	case "anthropic":
-		if anthropicKey != "" {
-			return streamAnthropic(ctx, anthropicKey, systemPrompt, msgs, onToken)
+		if anthropicKey != nil {
+			return &aiConfigProviderChoice{Key: anthropicKey, Anthropic: true}, nil
 		}
-	case "openai":
-		if openaiKey != "" {
-			return streamOpenAI(ctx, openaiKey, systemPrompt, msgs, onToken, "gpt-5.5")
-		}
-	case "codex":
-		if codexKey != "" {
-			return streamOpenAI(ctx, codexKey, systemPrompt, msgs, onToken, "o4-mini")
+	default:
+		if key := openAIKeys[defaultProvider]; key != nil {
+			return &aiConfigProviderChoice{
+				Key:      key,
+				Provider: openAICompatibleConfig(key.Provider),
+				Model:    stripProviderPrefix(aiConfigModelForKey(key, defaultModel)),
+			}, nil
 		}
 	}
 
-	if anthropicKey != "" {
-		return streamAnthropic(ctx, anthropicKey, systemPrompt, msgs, onToken)
+	if anthropicKey != nil {
+		return &aiConfigProviderChoice{Key: anthropicKey, Anthropic: true}, nil
 	}
-	if openaiKey != "" {
-		return streamOpenAI(ctx, openaiKey, systemPrompt, msgs, onToken, "gpt-5.5")
-	}
-	if codexKey != "" {
-		return streamOpenAI(ctx, codexKey, systemPrompt, msgs, onToken, "o4-mini")
+	for _, provider := range []string{"openai", "codex", "fireworks", "groq", "deepseek", "ollama"} {
+		if key := openAIKeys[provider]; key != nil {
+			return &aiConfigProviderChoice{
+				Key:      key,
+				Provider: openAICompatibleConfig(key.Provider),
+				Model:    stripProviderPrefix(aiConfigModelForKey(key, defaultModel)),
+			}, nil
+		}
 	}
 
 	availableProviders := uniqueProviders(llmKeys)
 	if defaultProvider != "" {
-		return fmt.Errorf("no supported LLM key configured for default_model provider %q (supported providers: anthropic, openai, codex; configured: %s)", defaultProvider, strings.Join(availableProviders, ", "))
+		return nil, fmt.Errorf("no supported LLM key configured for default_model provider %q (supported providers: anthropic, openai, codex, fireworks, groq, deepseek, ollama; configured: %s)", defaultProvider, strings.Join(availableProviders, ", "))
 	}
-	return fmt.Errorf("no supported LLM key configured (supported providers: anthropic, openai, codex; configured: %s)", strings.Join(availableProviders, ", "))
+	return nil, fmt.Errorf("no supported LLM key configured (supported providers: anthropic, openai, codex, fireworks, groq, deepseek, ollama; configured: %s)", strings.Join(availableProviders, ", "))
+}
+
+func llmKeyHasRequiredAPIKey(key *types.LLMKeyConfig) bool {
+	if key == nil {
+		return false
+	}
+	return key.APIKey != "" || key.Provider == "ollama"
+}
+
+func isOpenAICompatibleConfigProvider(provider string) bool {
+	switch provider {
+	case "openai", "codex", "fireworks", "groq", "deepseek", "ollama":
+		return true
+	default:
+		return false
+	}
+}
+
+func aiConfigModelForKey(key *types.LLMKeyConfig, defaultModel string) string {
+	if key == nil {
+		return defaultModel
+	}
+	if key.DefaultModel != "" {
+		if strings.HasPrefix(key.DefaultModel, key.Provider+"/") {
+			return key.DefaultModel
+		}
+		return key.Provider + "/" + key.DefaultModel
+	}
+	if defaultModel != "" && strings.HasPrefix(defaultModel, key.Provider+"/") {
+		return defaultModel
+	}
+	switch key.Provider {
+	case "openai":
+		return "openai/gpt-5.5"
+	case "codex":
+		return "codex/o4-mini"
+	case "fireworks":
+		return "fireworks/accounts/fireworks/models/kimi-k2p6"
+	case "groq":
+		return "groq/llama-3.3-70b-versatile"
+	case "deepseek":
+		return "deepseek/deepseek-chat"
+	case "ollama":
+		return "ollama/qwen2.5-coder:1.5b"
+	default:
+		return defaultModel
+	}
 }
 
 // streamAnthropic calls Anthropic Messages API with stream:true, forwarding text_delta events.
@@ -681,8 +703,9 @@ func streamAnthropic(ctx context.Context, apiKey, systemPrompt string, msgs []ai
 	return scanner.Err()
 }
 
-// streamOpenAI calls OpenAI Chat Completions API with stream:true, forwarding delta.content.
-func streamOpenAI(ctx context.Context, apiKey, systemPrompt string, msgs []aiChatMessage, onToken func(string), model string) error {
+// streamOpenAI calls an OpenAI-compatible Chat Completions API with stream:true,
+// forwarding delta.content.
+func streamOpenAI(ctx context.Context, provider openAICompatibleProvider, apiKey, systemPrompt string, msgs []aiChatMessage, onToken func(string), model string) error {
 	type openAIMsg struct {
 		Role    string `json:"role"`
 		Content string `json:"content"`
@@ -703,7 +726,7 @@ func streamOpenAI(ctx context.Context, apiKey, systemPrompt string, msgs []aiCha
 		Stream:   true,
 	})
 
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", "https://api.openai.com/v1/chat/completions", bytes.NewReader(body))
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", strings.TrimRight(provider.BaseURL, "/")+"/chat/completions", bytes.NewReader(body))
 	if err != nil {
 		return err
 	}
@@ -724,9 +747,9 @@ func streamOpenAI(ctx context.Context, apiKey, systemPrompt string, msgs []aiCha
 			} `json:"error"`
 		}
 		if json.Unmarshal(data, &errResp) == nil && errResp.Error.Message != "" {
-			return fmt.Errorf("OpenAI error: %s", errResp.Error.Message)
+			return fmt.Errorf("%s error: %s", provider.Name, errResp.Error.Message)
 		}
-		return fmt.Errorf("OpenAI error %d: %s", resp.StatusCode, string(data))
+		return fmt.Errorf("%s error %d: %s", provider.Name, resp.StatusCode, string(data))
 	}
 
 	type streamChoice struct {
@@ -830,7 +853,7 @@ func callAnthropic(apiKey, systemPrompt string, msgs []aiChatMessage) (string, e
 	return "", fmt.Errorf("no text content in Anthropic response")
 }
 
-func callOpenAI(apiKey, systemPrompt string, msgs []aiChatMessage, model string) (string, error) {
+func callOpenAI(provider openAICompatibleProvider, apiKey, systemPrompt string, msgs []aiChatMessage, model string) (string, error) {
 	type openAIMsg struct {
 		Role    string `json:"role"`
 		Content string `json:"content"`
@@ -859,7 +882,7 @@ func callOpenAI(apiKey, systemPrompt string, msgs []aiChatMessage, model string)
 		Messages: openAIMsgs,
 	})
 
-	req, err := http.NewRequest("POST", "https://api.openai.com/v1/chat/completions", bytes.NewReader(body))
+	req, err := http.NewRequest("POST", strings.TrimRight(provider.BaseURL, "/")+"/chat/completions", bytes.NewReader(body))
 	if err != nil {
 		return "", err
 	}
@@ -874,17 +897,17 @@ func callOpenAI(apiKey, systemPrompt string, msgs []aiChatMessage, model string)
 
 	data, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("OpenAI error %d: %s", resp.StatusCode, string(data))
+		return "", fmt.Errorf("%s error %d: %s", provider.Name, resp.StatusCode, string(data))
 	}
 	var or openAIResp
 	if err := json.Unmarshal(data, &or); err != nil {
-		return "", fmt.Errorf("invalid OpenAI response: %w", err)
+		return "", fmt.Errorf("invalid %s response: %w", provider.Name, err)
 	}
 	if or.Error != nil {
-		return "", fmt.Errorf("OpenAI error: %s", or.Error.Message)
+		return "", fmt.Errorf("%s error: %s", provider.Name, or.Error.Message)
 	}
 	if len(or.Choices) == 0 {
-		return "", fmt.Errorf("no choices in OpenAI response")
+		return "", fmt.Errorf("no choices in %s response", provider.Name)
 	}
 	return or.Choices[0].Message.Content, nil
 }

--- a/pkg/hub/ai_config_provider_test.go
+++ b/pkg/hub/ai_config_provider_test.go
@@ -1,0 +1,91 @@
+package hub
+
+import (
+	"testing"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func TestSelectAIConfigProviderSupportsOllamaDefaultModel(t *testing.T) {
+	keys := types.LLMKeysList{
+		{Name: "openai-main", Provider: "openai", APIKey: "sk-test", Default: true},
+		{Name: "ollama-main", Provider: "ollama", APIKey: "ollama-local"},
+	}
+
+	choice, err := selectAIConfigProvider(keys, "ollama/qwen2.5-coder:7b")
+	if err != nil {
+		t.Fatalf("select provider: %v", err)
+	}
+
+	if choice.Anthropic {
+		t.Fatal("ollama should use OpenAI-compatible routing, not Anthropic")
+	}
+	if choice.Key.Provider != "ollama" {
+		t.Fatalf("provider = %q, want ollama", choice.Key.Provider)
+	}
+	if choice.Provider.BaseURL != "http://ollama:11434/v1" {
+		t.Fatalf("base URL = %q, want Ollama OpenAI-compatible URL", choice.Provider.BaseURL)
+	}
+	if choice.Model != "qwen2.5-coder:7b" {
+		t.Fatalf("model = %q, want qwen2.5-coder:7b", choice.Model)
+	}
+}
+
+func TestSelectAIConfigProviderFallsBackToExternalPriority(t *testing.T) {
+	keys := types.LLMKeysList{
+		{Name: "ollama-main", Provider: "ollama", APIKey: "ollama-local", Default: true},
+		{Name: "openai-main", Provider: "openai", APIKey: "sk-test"},
+	}
+
+	choice, err := selectAIConfigProvider(keys, "")
+	if err != nil {
+		t.Fatalf("select provider: %v", err)
+	}
+
+	if choice.Key.Provider != "openai" {
+		t.Fatalf("provider = %q, want openai priority before ollama", choice.Key.Provider)
+	}
+	if choice.Model != "gpt-5.5" {
+		t.Fatalf("model = %q, want gpt-5.5", choice.Model)
+	}
+}
+
+func TestSelectAIConfigProviderUsesOllamaWhenOnlySupportedKey(t *testing.T) {
+	keys := types.LLMKeysList{
+		{Name: "ollama-main", Provider: "ollama", APIKey: "ollama-local", Default: true},
+	}
+
+	choice, err := selectAIConfigProvider(keys, "")
+	if err != nil {
+		t.Fatalf("select provider: %v", err)
+	}
+
+	if choice.Key.Provider != "ollama" || choice.Model != "qwen2.5-coder:1.5b" {
+		t.Fatalf("choice = provider %q model %q, want ollama/qwen2.5-coder:1.5b", choice.Key.Provider, choice.Model)
+	}
+}
+
+func TestSelectAIConfigProviderAllowsBlankOllamaAPIKey(t *testing.T) {
+	keys := types.LLMKeysList{
+		{Name: "ollama-main", Provider: "ollama", Default: true},
+	}
+
+	choice, err := selectAIConfigProvider(keys, "")
+	if err != nil {
+		t.Fatalf("select provider: %v", err)
+	}
+
+	if choice.Key.Provider != "ollama" || choice.Model != "qwen2.5-coder:1.5b" {
+		t.Fatalf("choice = provider %q model %q, want ollama/qwen2.5-coder:1.5b", choice.Key.Provider, choice.Model)
+	}
+}
+
+func TestSelectAIConfigProviderRejectsBlankExternalAPIKey(t *testing.T) {
+	keys := types.LLMKeysList{
+		{Name: "openai-main", Provider: "openai", Default: true},
+	}
+
+	if _, err := selectAIConfigProvider(keys, ""); err == nil {
+		t.Fatal("expected blank external API key to be rejected")
+	}
+}

--- a/pkg/hub/bootstrap.go
+++ b/pkg/hub/bootstrap.go
@@ -126,11 +126,32 @@ if isinstance(agent_models, dict):
     for key in list(agent_models.keys()):
         if 'kimi-k2p5' in key:
             agent_models.pop(key, None)
-# OpenClaw 2026.5.20 rejects the legacy top-level models provider catalog
-# shape we used to write. Onboard handles provider auth; keep only agent default.
+# OpenClaw rejects the legacy top-level models provider catalog shape we used
+# to write. Onboard handles provider auth; keep only agent default.
 models = config.get('models')
 if isinstance(models, dict) and any(k in models for k in ('providers', 'routers', 'mode')):
     config.pop('models', None)
+if model.startswith('ollama/'):
+    model_id = model.split('/', 1)[1]
+    agent_defaults.setdefault('experimental', {})['localModelLean'] = True
+    config.setdefault('models', {})['mode'] = 'merge'
+    providers = config['models'].setdefault('providers', {})
+    providers['ollama'] = {
+        'baseUrl': 'http://ollama:11434',
+        'api': 'ollama',
+        'apiKey': 'OLLAMA_API_KEY',
+        'models': [{
+            'id': model_id,
+            'name': model_id,
+            'reasoning': False,
+            'input': ['text'],
+            'cost': {'input': 0, 'output': 0, 'cacheRead': 0, 'cacheWrite': 0},
+            'contextWindow': 32768,
+            'maxTokens': 1024,
+            'params': {'num_ctx': 32768, 'thinking': False, 'keep_alive': '15m'},
+            'compat': {'supportsTools': True, 'supportsUsageInStreaming': True},
+        }],
+    }
 %sconfig.setdefault('gateway', {})['bind'] = 'loopback'
 config['gateway']['port'] = 18789
 gw_password = os.environ.get('ELASTICCLAW_GATEWAY_PASSWORD', '')
@@ -290,9 +311,9 @@ func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'"'"'`) + "'"
 }
 
-// buildOnboardFlags returns the --auth-choice flags for openclaw onboard
-// based on the active LLM key (selected > default > first).
-func buildOnboardFlags(keys []*types.LLMKeyConfig, selectedKeyName string) string {
+// buildOnboardFlags returns the --auth-choice flags for openclaw onboard based
+// on the active LLM key (selected > default > first).
+func buildOnboardFlags(keys []*types.LLMKeyConfig, selectedKeyName, defaultModel string) string {
 	active := resolveActiveKey(keys, selectedKeyName)
 	if active == nil {
 		return `--auth-choice anthropic-api-key --anthropic-api-key "${ANTHROPIC_API_KEY:-placeholder}"`
@@ -311,6 +332,15 @@ func buildOnboardFlags(keys []*types.LLMKeyConfig, selectedKeyName string) strin
 		return fmt.Sprintf(`--auth-choice deepseek-api-key --deepseek-api-key "${%s:-}"`, envVar)
 	case "codex":
 		return fmt.Sprintf(`--auth-choice codex-api-key --codex-api-key "${%s:-}"`, envVar)
+	case "ollama":
+		model := active.DefaultModel
+		if model == "" || !strings.HasPrefix(model, active.Provider+"/") {
+			model = defaultModel
+		}
+		if model == "" || !strings.HasPrefix(model, active.Provider+"/") {
+			model = "ollama/qwen2.5-coder:1.5b"
+		}
+		return fmt.Sprintf(`--auth-choice ollama --custom-base-url "http://ollama:11434" --custom-model-id %s`, shellQuote(stripProviderPrefix(model)))
 	default:
 		return `--auth-choice anthropic-api-key --anthropic-api-key "${ANTHROPIC_API_KEY:-placeholder}"`
 	}

--- a/pkg/hub/bootstrap_test.go
+++ b/pkg/hub/bootstrap_test.go
@@ -167,7 +167,7 @@ export OPENAI_API_KEY="sk-openai-key"`
 
 func TestBootstrapScript_OnboardFlagsShellQuoted(t *testing.T) {
 	p := baseParams()
-	p.OnboardFlags = buildOnboardFlags(nil, "")
+	p.OnboardFlags = buildOnboardFlags(nil, "", p.DefaultModel)
 	script := GenerateReplicatedBootstrapScript(p)
 
 	assertContains(t, script, `export ELASTICCLAW_ONBOARD_FLAGS='--auth-choice anthropic-api-key --anthropic-api-key "${ANTHROPIC_API_KEY:-placeholder}"'`, "onboard flags shell quoted")
@@ -281,12 +281,35 @@ func TestBuildOnboardFlags_OpenAICompatibleProviders(t *testing.T) {
 			keys := []*types.LLMKeyConfig{
 				{Name: tc.name + "-key", Provider: tc.provider, Default: true},
 			}
-			flags := buildOnboardFlags(keys, "")
+			flags := buildOnboardFlags(keys, "", "")
 			assertContains(t, flags, "--auth-choice "+tc.authChoice, "provider auth choice")
 			assertContains(t, flags, tc.flagName+` "${`+tc.envVar+`:-}"`, "provider api key flag")
 			assertNotContains(t, flags, "anthropic-api-key", "should not fallback to anthropic")
 		})
 	}
+}
+
+func TestBuildOnboardFlags_OllamaUsesNativeBaseURLAndModelID(t *testing.T) {
+	keys := []*types.LLMKeyConfig{
+		{Name: "ollama-main", Provider: "ollama", Default: true},
+	}
+
+	flags := buildOnboardFlags(keys, "", "ollama/qwen2.5-coder:7b")
+
+	assertContains(t, flags, "--auth-choice ollama", "ollama auth choice")
+	assertContains(t, flags, `--custom-base-url "http://ollama:11434"`, "ollama native base URL")
+	assertContains(t, flags, `--custom-model-id 'qwen2.5-coder:7b'`, "ollama model id without provider prefix")
+	assertNotContains(t, flags, "/v1", "OpenClaw Ollama base URL must use native API, not OpenAI-compatible path")
+}
+
+func TestBuildOnboardFlags_OllamaPrefersKeyDefaultModel(t *testing.T) {
+	keys := []*types.LLMKeyConfig{
+		{Name: "ollama-main", Provider: "ollama", Default: true, DefaultModel: "ollama/llama3.2:3b"},
+	}
+
+	flags := buildOnboardFlags(keys, "", "ollama/qwen2.5-coder:7b")
+
+	assertContains(t, flags, `--custom-model-id 'llama3.2:3b'`, "ollama key default model")
 }
 
 func TestBuildOpenClawProviderConfig_DoesNotWriteLegacyProviderCatalog(t *testing.T) {
@@ -305,6 +328,25 @@ func TestBuildOpenClawProviderConfig_DoesNotWriteLegacyProviderCatalog(t *testin
 	assertNotContains(t, snippet, "providers.update", "does not write legacy provider catalog")
 	assertNotContains(t, snippet, "'fireworks': {", "does not write fireworks provider entry")
 	assertNotContains(t, snippet, "'openai': {", "does not write openai provider entry")
+}
+
+func TestBuildOpenClawProviderConfig_ConfiguresOllamaProviderBaseURL(t *testing.T) {
+	keys := []*types.LLMKeyConfig{
+		{Name: "ollama-main", Provider: "ollama", Default: true},
+	}
+
+	snippet := buildOpenClawProviderConfig(keys, "ollama-main")
+
+	assertContains(t, snippet, "if model.startswith('ollama/'):", "only configures Ollama when selected model is Ollama")
+	assertContains(t, snippet, "agent_defaults.setdefault('experimental', {})['localModelLean'] = True", "uses lean mode for weak local dev models")
+	assertContains(t, snippet, "'baseUrl': 'http://ollama:11434'", "uses Compose Ollama service URL")
+	assertContains(t, snippet, "'apiKey': 'OLLAMA_API_KEY'", "keeps Ollama API key env reference")
+	assertContains(t, snippet, "'contextWindow': 32768", "keeps OpenClaw local model prompt budget within Docker Ollama limits")
+	assertContains(t, snippet, "'maxTokens': 1024", "keeps local dev generation bounded")
+	assertContains(t, snippet, "'params': {'num_ctx': 32768, 'thinking': False, 'keep_alive': '15m'}", "sets native Ollama runtime context explicitly")
+	assertContains(t, snippet, "'compat': {'supportsTools': True, 'supportsUsageInStreaming': True}", "keeps tool support while lean mode reduces local model prompt pressure")
+	assertContains(t, snippet, "providers['ollama']", "writes only the built-in Ollama provider config")
+	assertNotContains(t, snippet, "'ollama-cloud'", "does not rewrite Ollama Cloud")
 }
 
 func TestBuildOpenClawProviderConfig_DoesNotOverrideAnthropicModels(t *testing.T) {

--- a/pkg/hub/doctor.go
+++ b/pkg/hub/doctor.go
@@ -171,6 +171,7 @@ func (s *Server) checkLLMKeys(cfg *types.HubConfig) []DoctorCheck {
 	validProviders := map[string]bool{
 		"anthropic": true, "openai": true, "fireworks": true,
 		"moonshot": true, "google": true, "mistral": true,
+		"groq": true, "deepseek": true, "codex": true, "ollama": true,
 	}
 
 	allKeysValid := true
@@ -190,7 +191,7 @@ func (s *Server) checkLLMKeys(cfg *types.HubConfig) []DoctorCheck {
 				},
 			})
 		}
-		if key.APIKey == "" {
+		if !llmKeyHasRequiredAPIKey(key) {
 			allKeysValid = false
 			checks = append(checks, DoctorCheck{
 				Category:    "models",

--- a/pkg/hub/doctor.go
+++ b/pkg/hub/doctor.go
@@ -346,7 +346,7 @@ func (s *Server) checkProviders(cfg *types.HubConfig) []DoctorCheck {
 	}
 
 	validProviders := map[string]bool{
-		"daytona": true, "replicated": true, "exedev": true,
+		"daytona": true, "replicated": true, "exedev": true, "docker": true,
 	}
 
 	allProvidersValid := true
@@ -357,7 +357,7 @@ func (s *Server) checkProviders(cfg *types.HubConfig) []DoctorCheck {
 				Category:    "sandboxes",
 				Severity:    "warning",
 				Title:       fmt.Sprintf("Unknown sandbox provider: %q", name),
-				Description: fmt.Sprintf("Provider %q is not a recognised sandbox provider (daytona, replicated, exedev).", name),
+				Description: fmt.Sprintf("Provider %q is not a recognised sandbox provider (daytona, replicated, exedev, docker).", name),
 				OK:          false,
 				FixAction: &FixAction{
 					Type:   "navigate",

--- a/pkg/hub/doctor_test.go
+++ b/pkg/hub/doctor_test.go
@@ -1,0 +1,44 @@
+package hub
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func TestCheckLLMKeysRecognizesOllama(t *testing.T) {
+	s := &Server{}
+	checks := s.checkLLMKeys(&types.HubConfig{
+		LLMKeys: types.LLMKeysList{
+			{Name: "local-ollama", Provider: "ollama", APIKey: "ollama-local", Default: true},
+		},
+	})
+
+	for _, check := range checks {
+		if strings.Contains(check.Title, "Unknown LLM provider") {
+			t.Fatalf("ollama was reported as unknown: %#v", check)
+		}
+	}
+	if len(checks) != 1 || !checks[0].OK {
+		t.Fatalf("expected one passing LLM key check, got %#v", checks)
+	}
+}
+
+func TestCheckLLMKeysAllowsBlankOllamaAPIKey(t *testing.T) {
+	s := &Server{}
+	checks := s.checkLLMKeys(&types.HubConfig{
+		LLMKeys: types.LLMKeysList{
+			{Name: "local-ollama", Provider: "ollama", Default: true},
+		},
+	})
+
+	for _, check := range checks {
+		if strings.Contains(check.Title, "has no API key") {
+			t.Fatalf("blank ollama key was reported as invalid: %#v", check)
+		}
+	}
+	if len(checks) != 1 || !checks[0].OK {
+		t.Fatalf("expected one passing LLM key check, got %#v", checks)
+	}
+}

--- a/pkg/hub/external_webhook.go
+++ b/pkg/hub/external_webhook.go
@@ -747,6 +747,14 @@ func resolveDefaultModelForKeyLocal(hubDefaultModel string, key *types.LLMKeyCon
 		return "anthropic/claude-sonnet-4-6"
 	case "fireworks":
 		return "fireworks/accounts/fireworks/models/kimi-k2p6"
+	case "openai":
+		return "openai/gpt-5.5"
+	case "groq":
+		return "groq/llama-3.3-70b-versatile"
+	case "deepseek":
+		return "deepseek/deepseek-chat"
+	case "ollama":
+		return "ollama/qwen2.5-coder:1.5b"
 	case "moonshot":
 		return "moonshot/moonshot-v1-8k"
 	default:

--- a/pkg/hub/failure_summary.go
+++ b/pkg/hub/failure_summary.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -273,7 +274,11 @@ func openAICompatibleConfig(provider string) openAICompatibleProvider {
 	case "deepseek":
 		return openAICompatibleProvider{Name: "DeepSeek", BaseURL: "https://api.deepseek.com/v1"}
 	case "ollama":
-		return openAICompatibleProvider{Name: "Ollama", BaseURL: "http://ollama:11434/v1"}
+		baseURL := os.Getenv("OLLAMA_BASE_URL")
+		if baseURL == "" {
+			baseURL = "http://ollama:11434"
+		}
+		return openAICompatibleProvider{Name: "Ollama", BaseURL: strings.TrimRight(baseURL, "/") + "/v1"}
 	default:
 		return openAICompatibleProvider{Name: "OpenAI", BaseURL: "https://api.openai.com/v1"}
 	}

--- a/pkg/hub/failure_summary.go
+++ b/pkg/hub/failure_summary.go
@@ -180,7 +180,7 @@ func summarizeFailureWithLLM(ctx context.Context, sanitizedReason string, llmKey
 	switch key.Provider {
 	case "anthropic":
 		return callAnthropicModel(ctx, key.APIKey, stripProviderPrefix(model), systemPrompt, msgs, 700)
-	case "openai", "codex", "fireworks", "groq", "deepseek":
+	case "openai", "codex", "fireworks", "groq", "deepseek", "ollama":
 		return callOpenAICompatible(ctx, openAICompatibleConfig(key.Provider), key.APIKey, stripProviderPrefix(model), systemPrompt, msgs)
 	default:
 		return "", fmt.Errorf("unsupported LLM provider %q", key.Provider)
@@ -194,18 +194,18 @@ func selectFailureSummaryModel(llmKeys types.LLMKeysList, defaultModel string) (
 	defaultProvider := strings.TrimSpace(strings.SplitN(defaultModel, "/", 2)[0])
 	if defaultProvider != "" {
 		for _, key := range llmKeys {
-			if key != nil && key.APIKey != "" && key.Provider == defaultProvider && isFailureSummaryProvider(key.Provider) {
+			if key != nil && llmKeyHasRequiredAPIKey(key) && key.Provider == defaultProvider && isFailureSummaryProvider(key.Provider) {
 				return key, modelForFailureSummary(key, defaultModel), nil
 			}
 		}
 	}
 	for _, key := range llmKeys {
-		if key != nil && key.APIKey != "" && key.Default && isFailureSummaryProvider(key.Provider) {
+		if key != nil && llmKeyHasRequiredAPIKey(key) && key.Default && isFailureSummaryProvider(key.Provider) {
 			return key, modelForFailureSummary(key, defaultModel), nil
 		}
 	}
 	for _, key := range llmKeys {
-		if key != nil && key.APIKey != "" && isFailureSummaryProvider(key.Provider) {
+		if key != nil && llmKeyHasRequiredAPIKey(key) && isFailureSummaryProvider(key.Provider) {
 			return key, modelForFailureSummary(key, defaultModel), nil
 		}
 	}
@@ -214,7 +214,7 @@ func selectFailureSummaryModel(llmKeys types.LLMKeysList, defaultModel string) (
 
 func isFailureSummaryProvider(provider string) bool {
 	switch provider {
-	case "anthropic", "openai", "codex", "fireworks", "groq", "deepseek":
+	case "anthropic", "openai", "codex", "fireworks", "groq", "deepseek", "ollama":
 		return true
 	default:
 		return false
@@ -244,6 +244,8 @@ func modelForFailureSummary(key *types.LLMKeyConfig, defaultModel string) string
 		return "groq/llama-3.3-70b-versatile"
 	case "deepseek":
 		return "deepseek/deepseek-chat"
+	case "ollama":
+		return "ollama/qwen2.5-coder:1.5b"
 	default:
 		return defaultModel
 	}
@@ -270,6 +272,8 @@ func openAICompatibleConfig(provider string) openAICompatibleProvider {
 		return openAICompatibleProvider{Name: "Groq", BaseURL: "https://api.groq.com/openai/v1"}
 	case "deepseek":
 		return openAICompatibleProvider{Name: "DeepSeek", BaseURL: "https://api.deepseek.com/v1"}
+	case "ollama":
+		return openAICompatibleProvider{Name: "Ollama", BaseURL: "http://ollama:11434/v1"}
 	default:
 		return openAICompatibleProvider{Name: "OpenAI", BaseURL: "https://api.openai.com/v1"}
 	}

--- a/pkg/hub/failure_summary_test.go
+++ b/pkg/hub/failure_summary_test.go
@@ -112,6 +112,15 @@ func TestSelectFailureSummaryModelSupportsOllama(t *testing.T) {
 	}
 }
 
+func TestOpenAICompatibleConfigUsesOllamaBaseURLEnv(t *testing.T) {
+	t.Setenv("OLLAMA_BASE_URL", "http://localhost:11434/")
+
+	provider := openAICompatibleConfig("ollama")
+	if provider.Name != "Ollama" || provider.BaseURL != "http://localhost:11434/v1" {
+		t.Fatalf("ollama provider config = %#v", provider)
+	}
+}
+
 func TestSelectFailureSummaryModelAllowsBlankOllamaAPIKey(t *testing.T) {
 	keys := types.LLMKeysList{
 		{Name: "ollama-main", Provider: "ollama", Default: true},

--- a/pkg/hub/failure_summary_test.go
+++ b/pkg/hub/failure_summary_test.go
@@ -94,3 +94,42 @@ func TestSelectFailureSummaryModelSupportsOpenAICompatibleProviders(t *testing.T
 		t.Fatalf("provider/model = %s/%s", key.Provider, model)
 	}
 }
+
+func TestSelectFailureSummaryModelSupportsOllama(t *testing.T) {
+	keys := types.LLMKeysList{
+		{Name: "ollama-main", Provider: "ollama", APIKey: "ollama-local", Default: true},
+	}
+	key, model, err := selectFailureSummaryModel(keys, "")
+	if err != nil {
+		t.Fatalf("select model: %v", err)
+	}
+	if key.Provider != "ollama" || model != "ollama/qwen2.5-coder:1.5b" {
+		t.Fatalf("provider/model = %s/%s", key.Provider, model)
+	}
+	provider := openAICompatibleConfig("ollama")
+	if provider.Name != "Ollama" || provider.BaseURL != "http://ollama:11434/v1" {
+		t.Fatalf("ollama provider config = %#v", provider)
+	}
+}
+
+func TestSelectFailureSummaryModelAllowsBlankOllamaAPIKey(t *testing.T) {
+	keys := types.LLMKeysList{
+		{Name: "ollama-main", Provider: "ollama", Default: true},
+	}
+	key, model, err := selectFailureSummaryModel(keys, "")
+	if err != nil {
+		t.Fatalf("select model: %v", err)
+	}
+	if key.Provider != "ollama" || model != "ollama/qwen2.5-coder:1.5b" {
+		t.Fatalf("provider/model = %s/%s", key.Provider, model)
+	}
+}
+
+func TestSelectFailureSummaryModelRejectsBlankExternalAPIKey(t *testing.T) {
+	keys := types.LLMKeysList{
+		{Name: "openai-main", Provider: "openai", Default: true},
+	}
+	if _, _, err := selectFailureSummaryModel(keys, ""); err == nil {
+		t.Fatal("expected blank external API key to be rejected")
+	}
+}

--- a/pkg/hub/providers.go
+++ b/pkg/hub/providers.go
@@ -2,6 +2,7 @@ package hub
 
 import (
 	"github.com/elasticclaw/elasticclaw/pkg/provider/daytona"
+	dockerpkg "github.com/elasticclaw/elasticclaw/pkg/provider/docker"
 	"github.com/elasticclaw/elasticclaw/pkg/provider/exedev"
 	replicated "github.com/elasticclaw/elasticclaw/pkg/provider/replicated"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
@@ -21,6 +22,13 @@ func newExedevProvider(cfg types.ProviderConfig) (*exedev.Provider, error) {
 		DefaultCPU:    cfg.DefaultCPU,
 		DefaultMemory: cfg.DefaultMemory,
 		DefaultDisk:   cfg.DefaultDisk,
+	})
+}
+
+func newDockerProvider(cfg types.ProviderConfig) (*dockerpkg.Provider, error) {
+	return dockerpkg.New(dockerpkg.Config{
+		Image:   cfg.Image,
+		Network: cfg.Network,
 	})
 }
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -2399,7 +2400,7 @@ echo uninstalled`); err != nil {
 		log.Printf("[daytona] warning: uninstall failed (ok if not installed): %v", err)
 	}
 
-	const daytonaOpenClawVersion = "2026.5.20"
+	const daytonaOpenClawVersion = "2026.6.1"
 	if err := exec("install openclaw", 3*time.Minute,
 		fmt.Sprintf(`export NVM_DIR=/usr/local/share/nvm; \
 NPM="$NVM_DIR/current/bin/npm"; \
@@ -2480,7 +2481,7 @@ docker --version`); err != nil {
 	activeKeyDaytona := resolveActiveKey(s.hubCfg.LLMKeys, llmKeyNameDaytona)
 	defaultModelDaytona := resolveDefaultModelForKey(s.hubCfg, activeKeyDaytona)
 	llmKeyEnvDaytona := buildLLMKeyEnv(s.hubCfg.LLMKeys, llmKeyNameDaytona)
-	onboardFlags := buildOnboardFlags(s.hubCfg.LLMKeys, llmKeyNameDaytona)
+	onboardFlags := buildOnboardFlags(s.hubCfg.LLMKeys, llmKeyNameDaytona, defaultModelDaytona)
 	providerConfigScript := buildOpenClawProviderConfig(s.hubCfg.LLMKeys, llmKeyNameDaytona)
 	if activeKeyDaytona != nil {
 		activeKeyNameDaytona = activeKeyDaytona.Name
@@ -3346,7 +3347,7 @@ func (s *Server) bootstrapExedev(ctx context.Context, clawID, vmName string, p *
 		LLMKeyEnv:       llmKeyEnv,
 		LinearEnv:       buildLinearEnv(linearToken),
 		ProviderConfig:  buildOpenClawProviderConfig(hubCfg.LLMKeys, llmKeyName),
-		OnboardFlags:    buildOnboardFlags(hubCfg.LLMKeys, llmKeyName),
+		OnboardFlags:    buildOnboardFlags(hubCfg.LLMKeys, llmKeyName, defaultModel),
 	})
 
 	if flakeFiles := templateFlakeFiles(templateFiles); len(flakeFiles) > 0 {
@@ -3420,7 +3421,7 @@ func (s *Server) provisionDocker(ctx context.Context, clawID string, req types.C
 
 	gatewayPassword := randomHex(16)
 	providerConfig := buildOpenClawProviderConfig(hubCfg.LLMKeys, llmKeyName)
-	onboardFlags := buildOnboardFlags(hubCfg.LLMKeys, llmKeyName)
+	onboardFlags := buildOnboardFlags(hubCfg.LLMKeys, llmKeyName, defaultModel)
 
 	// Build env map for the container — passed directly as -e flags (no shell escaping needed)
 	containerEnv := map[string]string{
@@ -3428,7 +3429,9 @@ func (s *Server) provisionDocker(ctx context.Context, clawID string, req types.C
 		"ELASTICCLAW_CLAW_ID":            clawID,
 		"ELASTICCLAW_CLAW_TOKEN":         clawToken,
 		"ELASTICCLAW_CLAW_NAME":          clawName,
+		"ELASTICCLAW_GITHUB_REPOS":       githubReposJSON,
 		"ELASTICCLAW_BOOTSTRAP":          "1",
+		"ELASTICCLAW_WAIT_FOR_WORKSPACE": "1",
 		"ELASTICCLAW_GATEWAY_PASSWORD":   gatewayPassword,
 		"OPENCLAW_GATEWAY_PASSWORD":      gatewayPassword,
 		"OPENCLAW_DEFAULT_MODEL":         defaultModel,
@@ -3447,7 +3450,12 @@ func (s *Server) provisionDocker(ctx context.Context, clawID string, req types.C
 		kv := strings.TrimPrefix(line, "export ")
 		if idx := strings.IndexByte(kv, '='); idx > 0 {
 			k := kv[:idx]
-			v := strings.Trim(kv[idx+1:], `"`)
+			v := kv[idx+1:]
+			if unquoted, err := strconv.Unquote(v); err == nil {
+				v = unquoted
+			} else if len(v) >= 2 && strings.HasPrefix(v, "'") && strings.HasSuffix(v, "'") {
+				v = v[1 : len(v)-1]
+			}
 			containerEnv[k] = v
 		}
 	}
@@ -3469,26 +3477,19 @@ func (s *Server) provisionDocker(ctx context.Context, clawID string, req types.C
 	log.Printf("[docker] container started: %s (claw %s)", instance.ID, clawID)
 	_, _ = s.db.Exec(`UPDATE claws SET status='starting', provider='docker', provider_id=? WHERE id=?`, instance.ID, clawID)
 
-	// Copy template files into workspace asynchronously
-	go func() {
-		bgCtx := context.Background()
-		p2, err := newDockerProvider(cfg)
-		if err != nil {
-			log.Printf("[docker] provider reinit failed for claw %s: %v", clawID, err)
-			s.stopAgentWithReason(clawID, fmt.Sprintf("Docker provider init failed: %v", err), false)
-			return
+	s.setBootstrapStatus(clawID, "Copying workspace files")
+	for path, content := range files {
+		dest := "/home/claw/workspace/" + path
+		if err := p.CopyIn(ctx, instance.ID, dest, content); err != nil {
+			_ = p.Destroy(context.Background(), instance.ID, false)
+			return fmt.Errorf("docker file copy failed: %s: %w", path, err)
 		}
-		s.setBootstrapStatus(clawID, "Copying workspace files")
-		for path, content := range files {
-			dest := "/home/claw/workspace/" + path
-			if err := p2.CopyIn(bgCtx, instance.ID, dest, content); err != nil {
-				log.Printf("[docker] copy %s failed for claw %s: %v", path, clawID, err)
-				s.stopAgentWithReason(clawID, fmt.Sprintf("Docker file copy failed: %s: %v", path, err), false)
-				return
-			}
-		}
-		log.Printf("[docker] workspace files copied for claw %.8s", clawID)
-	}()
+	}
+	if err := p.CopyIn(ctx, instance.ID, "/home/claw/workspace/.elasticclaw-workspace-ready", []byte("ready\n")); err != nil {
+		_ = p.Destroy(context.Background(), instance.ID, false)
+		return fmt.Errorf("docker workspace ready marker: %w", err)
+	}
+	log.Printf("[docker] workspace files copied for claw %.8s", clawID)
 
 	return nil
 }
@@ -4178,7 +4179,7 @@ func (s *Server) bootstrapReplicated(clawID, clawName, vmID string, cfg types.Pr
 		LLMKeyEnv:       llmKeyEnv,
 		LinearEnv:       buildLinearEnv(linearToken),
 		ProviderConfig:  buildOpenClawProviderConfig(hubCfg.LLMKeys, llmKeyName),
-		OnboardFlags:    buildOnboardFlags(hubCfg.LLMKeys, llmKeyName),
+		OnboardFlags:    buildOnboardFlags(hubCfg.LLMKeys, llmKeyName, defaultModel),
 	})
 	// Inject GitHub tools context into TOOLS.md if GitHub is configured
 	s.mu.RLock()
@@ -4466,6 +4467,8 @@ func resolveDefaultModelForKey(hubCfg *types.HubConfig, key *types.LLMKeyConfig)
 		return "groq/llama-3.3-70b-versatile"
 	case "deepseek":
 		return "deepseek/deepseek-chat"
+	case "ollama":
+		return "ollama/qwen2.5-coder:1.5b"
 	case "moonshot":
 		return "moonshot/moonshot-v1-8k"
 	default:

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1055,6 +1055,8 @@ func (s *Server) handleCreateClaw(w http.ResponseWriter, r *http.Request, tenant
 			provErr = s.provisionReplicated(ctx, clawID, req, provCfg, env)
 		case "exedev":
 			provErr = s.provisionExedev(ctx, clawID, req, provCfg, templateFiles, env)
+		case "docker":
+			provErr = s.provisionDocker(ctx, clawID, req, provCfg, templateFiles)
 		default:
 			provErr = fmt.Errorf("unsupported provider: %s", req.Provider)
 		}
@@ -3386,6 +3388,117 @@ func (s *Server) bootstrapExedev(ctx context.Context, clawID, vmName string, p *
 
 	log.Printf("[exedev] bootstrap complete for claw %.8s on %s", clawID, vmName)
 	return nil
+}
+
+func (s *Server) provisionDocker(ctx context.Context, clawID string, req types.CreateClawRequest, cfg types.ProviderConfig, files map[string][]byte) error {
+	p, err := newDockerProvider(cfg)
+	if err != nil {
+		return fmt.Errorf("docker init: %w", err)
+	}
+
+	// Load claw configuration from DB
+	var clawName, githubReposJSON, linearWorkspace, templateDefaultModel, llmKeyName string
+	var nixEnabled, dockerEnabled int
+	if err := s.db.QueryRow(
+		`SELECT COALESCE(name,''), COALESCE(github_repos,'[]'), COALESCE(linear_workspace,''), COALESCE(default_model,''), nix, docker, COALESCE(llm_key,'') FROM claws WHERE id=?`,
+		clawID,
+	).Scan(&clawName, &githubReposJSON, &linearWorkspace, &templateDefaultModel, &nixEnabled, &dockerEnabled, &llmKeyName); err != nil {
+		return fmt.Errorf("load claw config: %w", err)
+	}
+
+	s.mu.RLock()
+	llmKeyEnv := buildLLMKeyEnv(s.hubCfg.LLMKeys, llmKeyName)
+	clawToken := s.hubCfg.ClawToken
+	hubCfg := s.hubCfg
+	s.mu.RUnlock()
+
+	linearToken := resolveLinearToken(hubCfg, linearWorkspace)
+	defaultModel := templateDefaultModel
+	if defaultModel == "" {
+		defaultModel = hubCfg.DefaultModel
+	}
+
+	gatewayPassword := randomHex(16)
+	providerConfig := buildOpenClawProviderConfig(hubCfg.LLMKeys, llmKeyName)
+	onboardFlags := buildOnboardFlags(hubCfg.LLMKeys, llmKeyName)
+
+	// Build env map for the container — passed directly as -e flags (no shell escaping needed)
+	containerEnv := map[string]string{
+		"ELASTICCLAW_HUB_URL":            s.clawHubURL(),
+		"ELASTICCLAW_CLAW_ID":            clawID,
+		"ELASTICCLAW_CLAW_TOKEN":         clawToken,
+		"ELASTICCLAW_CLAW_NAME":          clawName,
+		"ELASTICCLAW_BOOTSTRAP":          "1",
+		"ELASTICCLAW_GATEWAY_PASSWORD":   gatewayPassword,
+		"OPENCLAW_GATEWAY_PASSWORD":      gatewayPassword,
+		"OPENCLAW_DEFAULT_MODEL":         defaultModel,
+		"ELASTICCLAW_NIX":                boolEnv(nixEnabled != 0),
+		"ELASTICCLAW_DOCKER":             boolEnv(dockerEnabled != 0),
+		"ELASTICCLAW_PROVIDER_CONFIG":    providerConfig,
+		"ELASTICCLAW_ONBOARD_FLAGS":      onboardFlags,
+	}
+
+	// Inject LLM keys: buildLLMKeyEnv returns "export VAR=val\n" lines — parse into k/v
+	for _, line := range strings.Split(llmKeyEnv, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "export ") {
+			continue
+		}
+		kv := strings.TrimPrefix(line, "export ")
+		if idx := strings.IndexByte(kv, '='); idx > 0 {
+			k := kv[:idx]
+			v := strings.Trim(kv[idx+1:], `"`)
+			containerEnv[k] = v
+		}
+	}
+
+	// Inject LINEAR_API_KEY if configured
+	if linearToken != "" {
+		containerEnv["LINEAR_API_KEY"] = linearToken
+	}
+
+	createReq := types.CreateRequest{
+		Name: req.ProviderName,
+		Env:  containerEnv,
+	}
+
+	instance, err := p.Create(ctx, createReq)
+	if err != nil {
+		return fmt.Errorf("docker create: %w", err)
+	}
+	log.Printf("[docker] container started: %s (claw %s)", instance.ID, clawID)
+	_, _ = s.db.Exec(`UPDATE claws SET status='starting', provider='docker', provider_id=? WHERE id=?`, instance.ID, clawID)
+
+	// Copy template files into workspace asynchronously
+	go func() {
+		bgCtx := context.Background()
+		p2, err := newDockerProvider(cfg)
+		if err != nil {
+			log.Printf("[docker] provider reinit failed for claw %s: %v", clawID, err)
+			s.stopAgentWithReason(clawID, fmt.Sprintf("Docker provider init failed: %v", err), false)
+			return
+		}
+		s.setBootstrapStatus(clawID, "Copying workspace files")
+		for path, content := range files {
+			dest := "/home/claw/workspace/" + path
+			if err := p2.CopyIn(bgCtx, instance.ID, dest, content); err != nil {
+				log.Printf("[docker] copy %s failed for claw %s: %v", path, clawID, err)
+				s.stopAgentWithReason(clawID, fmt.Sprintf("Docker file copy failed: %s: %v", path, err), false)
+				return
+			}
+		}
+		log.Printf("[docker] workspace files copied for claw %.8s", clawID)
+	}()
+
+	return nil
+}
+
+// boolEnv converts a bool to "true"/"false" for environment variable injection.
+func boolEnv(v bool) string {
+	if v {
+		return "true"
+	}
+	return "false"
 }
 
 func (s *Server) provisionReplicated(ctx context.Context, clawID string, req types.CreateClawRequest, cfg types.ProviderConfig, env map[string]string) error {

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -148,6 +148,16 @@ func TestResolveDefaultModelForKey(t *testing.T) {
 			},
 			expectedModel: "deepseek/deepseek-chat",
 		},
+		{
+			name: "ollama provider",
+			hubCfg: &types.HubConfig{
+				DefaultModel: "",
+			},
+			key: &types.LLMKeyConfig{
+				Provider: "ollama",
+			},
+			expectedModel: "ollama/qwen2.5-coder:1.5b",
+		},
 	}
 
 	for _, tt := range tests {
@@ -157,6 +167,38 @@ func TestResolveDefaultModelForKey(t *testing.T) {
 				t.Errorf("expected %s, got %s", tt.expectedModel, result)
 			}
 		})
+	}
+}
+
+func TestGetSettingsTreatsBlankOllamaKeyAsConfigured(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{
+		LLMKeys: types.LLMKeysList{
+			{Name: "local-ollama", Provider: "ollama", Default: true},
+			{Name: "openai-missing", Provider: "openai"},
+		},
+	}, "", "", "")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/settings", nil)
+	rec := httptest.NewRecorder()
+
+	s.getSettings(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var view SettingsView
+	if err := json.NewDecoder(rec.Body).Decode(&view); err != nil {
+		t.Fatal(err)
+	}
+	byName := map[string]LLMKeyView{}
+	for _, key := range view.LLMKeys {
+		byName[key.Name] = key
+	}
+	if !byName["local-ollama"].KeySet {
+		t.Fatalf("blank ollama key should be treated as configured: %#v", byName["local-ollama"])
+	}
+	if byName["openai-missing"].KeySet {
+		t.Fatalf("blank external key should not be treated as configured: %#v", byName["openai-missing"])
 	}
 }
 

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -373,7 +373,7 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 		view.LLMKeys = append(view.LLMKeys, LLMKeyView{
 			Name:         k.Name,
 			Provider:     k.Provider,
-			KeySet:       k.APIKey != "",
+			KeySet:       llmKeyHasRequiredAPIKey(k),
 			Default:      k.Default,
 			DefaultModel: k.DefaultModel,
 		})

--- a/pkg/provider/docker/docker.go
+++ b/pkg/provider/docker/docker.go
@@ -1,0 +1,265 @@
+// Package docker implements an ElasticClaw provider that spawns agent containers
+// using the local Docker daemon. This is intended for local development and testing
+// without any cloud provider. The hub container must have the Docker socket mounted
+// (/var/run/docker.sock) so it can manage sibling containers.
+package docker
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+const (
+	defaultImage   = "elasticclaw/claw-agent:dev"
+	containerLabel = "elasticclaw.claw"
+)
+
+// Config holds docker provider configuration (from hub.yaml providers.docker).
+type Config struct {
+	// Image is the agent container image. Defaults to elasticclaw/claw-agent:dev.
+	Image string
+	// Network is the Docker network to attach agent containers to so they can
+	// reach the hub by its service name (e.g. "elasticclaw-dev").
+	Network string
+}
+
+// Provider implements the ElasticClaw Provider interface using the Docker CLI.
+type Provider struct {
+	cfg Config
+}
+
+// New creates a new docker provider.
+func New(cfg Config) (*Provider, error) {
+	if cfg.Image == "" {
+		cfg.Image = defaultImage
+	}
+	return &Provider{cfg: cfg}, nil
+}
+
+// Info returns provider metadata.
+func (p *Provider) Info() types.ProviderInfo {
+	return types.ProviderInfo{
+		Name:         "docker",
+		Type:         types.ProviderTypeStateful,
+		Capabilities: []string{"exec"},
+	}
+}
+
+// Create launches an agent container. req.Name is used as the container name;
+// req.Env is passed as environment variables via -e flags.
+func (p *Provider) Create(ctx context.Context, req types.CreateRequest) (*types.Instance, error) {
+	args := []string{
+		"run", "-d",
+		"--name", req.Name,
+		"--label", containerLabel + "=" + req.Name,
+	}
+	if p.cfg.Network != "" {
+		args = append(args, "--network", p.cfg.Network)
+	}
+	for k, v := range req.Env {
+		args = append(args, "-e", k+"="+v)
+	}
+	args = append(args, p.cfg.Image)
+
+	out, err := dockerRun(ctx, args...)
+	if err != nil {
+		return nil, fmt.Errorf("docker create: %w", err)
+	}
+
+	containerID := strings.TrimSpace(string(out))
+	return &types.Instance{
+		Name:      req.Name,
+		ID:        req.Name, // use name as stable ID; full ID in ProviderMeta
+		Provider:  "docker",
+		Status:    types.StatusRunning,
+		CreatedAt: time.Now().UTC(),
+		ProviderMeta: map[string]string{
+			"container_id":   containerID,
+			"container_name": req.Name,
+		},
+	}, nil
+}
+
+// CopyIn copies content into a running container using a tar stream piped to docker cp.
+// dest is an absolute path inside the container (e.g. "/home/claw/workspace/AGENTS.md").
+func (p *Provider) CopyIn(ctx context.Context, containerName, dest string, content []byte) error {
+	// Build a single-file tar in memory
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	// Extract the filename from the destination path
+	filename := dest
+	if idx := strings.LastIndex(dest, "/"); idx >= 0 {
+		filename = dest[idx+1:]
+	}
+	if err := tw.WriteHeader(&tar.Header{
+		Name:    filename,
+		Mode:    0644,
+		Size:    int64(len(content)),
+		ModTime: time.Now(),
+	}); err != nil {
+		return fmt.Errorf("docker cp tar header: %w", err)
+	}
+	if _, err := tw.Write(content); err != nil {
+		return fmt.Errorf("docker cp tar write: %w", err)
+	}
+	tw.Close()
+
+	// Determine destination directory
+	destDir := "/"
+	if idx := strings.LastIndex(dest, "/"); idx > 0 {
+		destDir = dest[:idx]
+	}
+
+	cmd := exec.CommandContext(ctx, "docker", "cp", "-", containerName+":"+destDir)
+	cmd.Stdin = &buf
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("docker cp %s: %w (out: %s)", dest, err, string(out))
+	}
+	return nil
+}
+
+// Exec runs a command inside a running container.
+func (p *Provider) Exec(ctx context.Context, instanceID string, cmdArgs []string) (*types.ExecResult, error) {
+	args := append([]string{"exec", instanceID}, cmdArgs...)
+	cmd := exec.CommandContext(ctx, "docker", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	exitCode := 0
+	if err != nil {
+		if exit, ok := err.(*exec.ExitError); ok {
+			exitCode = exit.ExitCode()
+		} else {
+			return nil, fmt.Errorf("docker exec: %w", err)
+		}
+	}
+	res := &types.ExecResult{
+		ExitCode: exitCode,
+		Stdout:   stdout.String(),
+		Stderr:   stderr.String(),
+	}
+	if exitCode != 0 {
+		return res, fmt.Errorf("docker exec: command exited %d: %s", exitCode, stderr.String())
+	}
+	return res, nil
+}
+
+// Connect returns a shell command to exec into the container.
+func (p *Provider) Connect(ctx context.Context, instanceID string) (*types.ConnectInfo, error) {
+	return &types.ConnectInfo{
+		Shell: &types.ShellConnect{
+			Command: "docker",
+			Args:    []string{"exec", "-it", instanceID, "bash"},
+		},
+	}, nil
+}
+
+// Status returns the current container state.
+func (p *Provider) Status(ctx context.Context, instanceID string) (types.InstanceStatus, error) {
+	out, err := dockerRun(ctx, "inspect", "-f", "{{.State.Status}}", instanceID)
+	if err != nil {
+		if strings.Contains(err.Error(), "No such") || strings.Contains(err.Error(), "not found") {
+			return types.StatusNotFound, nil
+		}
+		return types.StatusUnknown, fmt.Errorf("docker inspect: %w", err)
+	}
+	switch strings.TrimSpace(string(out)) {
+	case "running":
+		return types.StatusRunning, nil
+	case "exited", "dead":
+		return types.StatusStopped, nil
+	case "created", "paused":
+		return types.StatusStarting, nil
+	default:
+		return types.StatusUnknown, nil
+	}
+}
+
+// Stop stops a running container.
+func (p *Provider) Stop(ctx context.Context, instanceID string) error {
+	_, err := dockerRun(ctx, "stop", instanceID)
+	return err
+}
+
+// Start restarts a stopped container.
+func (p *Provider) Start(ctx context.Context, instanceID string) error {
+	_, err := dockerRun(ctx, "start", instanceID)
+	return err
+}
+
+// Destroy removes the container (forcefully if still running).
+func (p *Provider) Destroy(ctx context.Context, instanceID string, keepState bool) error {
+	_, err := dockerRun(ctx, "rm", "-f", instanceID)
+	if err != nil {
+		if strings.Contains(err.Error(), "No such") || strings.Contains(err.Error(), "not found") {
+			return nil // already gone
+		}
+		return fmt.Errorf("docker rm: %w", err)
+	}
+	return nil
+}
+
+// List returns all containers managed by this provider (labeled with elasticclaw.claw).
+func (p *Provider) List(ctx context.Context) ([]*types.Instance, error) {
+	out, err := dockerRun(ctx, "ps", "-a",
+		"--filter", "label="+containerLabel,
+		"--format", "{{.Names}}\t{{.Status}}")
+	if err != nil {
+		return nil, fmt.Errorf("docker ps: %w", err)
+	}
+
+	var instances []*types.Instance
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, "\t", 2)
+		name := parts[0]
+		status := types.StatusUnknown
+		if len(parts) == 2 {
+			st := strings.ToLower(parts[1])
+			switch {
+			case strings.HasPrefix(st, "up"):
+				status = types.StatusRunning
+			case strings.HasPrefix(st, "exited"):
+				status = types.StatusStopped
+			}
+		}
+		instances = append(instances, &types.Instance{
+			Name:     name,
+			ID:       name,
+			Provider: "docker",
+			Status:   status,
+		})
+	}
+	return instances, nil
+}
+
+// dockerRun executes a docker CLI command and returns its stdout.
+func dockerRun(ctx context.Context, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "docker", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return stdout.Bytes(), fmt.Errorf("docker %s: %w (stderr: %s)", strings.Join(args[:min(len(args), 2)], " "), err, stderr.String())
+	}
+	return stdout.Bytes(), nil
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/pkg/provider/docker/docker.go
+++ b/pkg/provider/docker/docker.go
@@ -267,10 +267,3 @@ func dockerRun(ctx context.Context, args ...string) ([]byte, error) {
 	}
 	return stdout.Bytes(), nil
 }
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}

--- a/pkg/provider/docker/docker.go
+++ b/pkg/provider/docker/docker.go
@@ -90,6 +90,10 @@ func (p *Provider) Create(ctx context.Context, req types.CreateRequest) (*types.
 // CopyIn copies content into a running container using a tar stream piped to docker cp.
 // dest is an absolute path inside the container (e.g. "/home/claw/workspace/AGENTS.md").
 func (p *Provider) CopyIn(ctx context.Context, containerName, dest string, content []byte) error {
+	if !strings.HasPrefix(dest, "/") {
+		return fmt.Errorf("docker cp: dest must be an absolute path, got %q", dest)
+	}
+
 	// Build a single-file tar in memory
 	var buf bytes.Buffer
 	tw := tar.NewWriter(&buf)
@@ -109,12 +113,19 @@ func (p *Provider) CopyIn(ctx context.Context, containerName, dest string, conte
 	if _, err := tw.Write(content); err != nil {
 		return fmt.Errorf("docker cp tar write: %w", err)
 	}
-	tw.Close()
+	if err := tw.Close(); err != nil {
+		return fmt.Errorf("docker cp tar close: %w", err)
+	}
 
 	// Determine destination directory
 	destDir := "/"
 	if idx := strings.LastIndex(dest, "/"); idx > 0 {
 		destDir = dest[:idx]
+	}
+
+	mkdirCmd := exec.CommandContext(ctx, "docker", "exec", containerName, "mkdir", "-p", destDir)
+	if out, err := mkdirCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("docker mkdir -p %s: %w (out: %s)", destDir, err, string(out))
 	}
 
 	cmd := exec.CommandContext(ctx, "docker", "cp", "-", containerName+":"+destDir)

--- a/pkg/provider/docker/docker_test.go
+++ b/pkg/provider/docker/docker_test.go
@@ -1,0 +1,18 @@
+package docker
+
+import (
+	"context"
+	"testing"
+)
+
+func TestCopyInRejectsRelativeDestination(t *testing.T) {
+	provider, err := New(Config{})
+	if err != nil {
+		t.Fatalf("new provider: %v", err)
+	}
+
+	err = provider.CopyIn(context.Background(), "container", "relative/path.txt", []byte("content"))
+	if err == nil {
+		t.Fatal("expected relative destination to be rejected")
+	}
+}

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -686,6 +686,13 @@ type ProviderConfig struct {
 
 	// local provider
 	Enabled bool `yaml:"enabled,omitempty"`
+
+	// docker (local) provider
+	// Image is the agent container image to run (default: elasticclaw/claw-agent:dev).
+	Image string `yaml:"image,omitempty"`
+	// Network is the Docker network to attach agent containers to so they can
+	// reach the hub by service name (e.g. "elasticclaw-dev").
+	Network string `yaml:"network,omitempty"`
 }
 
 // MCPConfig is the resolved MCP server configuration passed to a claw at creation time.

--- a/pkg/types/validation.go
+++ b/pkg/types/validation.go
@@ -21,7 +21,7 @@ var validIntegrations = map[string]bool{
 
 // Valid provider types
 var validProviders = map[string]bool{
-	"replicated": true, "daytona": true, "exedev": true,
+	"replicated": true, "daytona": true, "exedev": true, "docker": true,
 }
 
 // Valid MCP sources

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -826,6 +826,7 @@ const PROVIDER_OPTIONS = [
   { value: "fireworks",  label: "Fireworks",  placeholder: "fw_..." },
   { value: "openai",     label: "OpenAI",     placeholder: "sk-proj-..." },
   { value: "codex",      label: "Codex",      placeholder: "sk-proj-..." },
+  { value: "ollama",     label: "Ollama",     placeholder: "ollama-local" },
   { value: "other",      label: "Other",      placeholder: "" },
 ]
 
@@ -834,6 +835,7 @@ const PROVIDER_MODELS: Record<string, { id: string; name: string }[]> = {
     { id: "anthropic/claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
     { id: "anthropic/claude-opus-4-5",   name: "Claude Opus 4.5" },
     { id: "anthropic/claude-sonnet-4-5", name: "Claude Sonnet 4.5" },
+    { id: "__custom",                    name: "Custom Anthropic model" },
   ],
   fireworks: [
     { id: "fireworks/accounts/fireworks/models/kimi-k2p6",                  name: "Kimi K2.6" },
@@ -846,6 +848,7 @@ const PROVIDER_MODELS: Record<string, { id: string; name: string }[]> = {
     { id: "fireworks/accounts/fireworks/models/gpt-oss-20b",                name: "OpenAI gpt-oss-20b" },
     { id: "fireworks/accounts/fireworks/models/minimax-m2p5",               name: "MiniMax M2.5" },
     { id: "fireworks/accounts/fireworks/models/llama-v3p3-70b-instruct",    name: "Llama 3.3 70B Instruct" },
+    { id: "__custom",                                                       name: "Custom Fireworks model" },
   ],
   openai: [
     { id: "openai/gpt-5.5",      name: "GPT-5.5" },
@@ -857,12 +860,21 @@ const PROVIDER_MODELS: Record<string, { id: string; name: string }[]> = {
     { id: "openai/o3",           name: "o3" },
     // coding-tuned variants available via regular OpenAI API
     { id: "openai/gpt-5.3-codex", name: "GPT-5.3 Codex (coding tuned)" },
+    { id: "__custom",             name: "Custom OpenAI model" },
   ],
   codex: [
     // Codex is an autonomous agentic coding platform — it selects and routes to the
     // appropriate underlying model (including special Codex checkpoints) on its own.
     { id: "codex/codex",      name: "Codex (auto)" },
     { id: "codex/codex-pro",  name: "Codex Pro (auto)" },
+    { id: "__custom",         name: "Custom Codex model" },
+  ],
+  ollama: [
+    { id: "ollama/qwen2.5-coder:1.5b", name: "Qwen2.5 Coder 1.5B" },
+    { id: "ollama/qwen2.5-coder:7b", name: "Qwen2.5 Coder 7B" },
+    { id: "ollama/llama3.2:3b",      name: "Llama 3.2 3B" },
+    { id: "ollama/gpt-oss:20b",      name: "gpt-oss 20B" },
+    { id: "__custom",                name: "Custom Ollama model" },
   ],
 }
 
@@ -879,12 +891,13 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
   const [formKey, setFormKey] = useState("")
   const [formDefault, setFormDefault] = useState(false)
   const [formDefaultModel, setFormDefaultModel] = useState("")
+  const [formCustomModel, setFormCustomModel] = useState("")
 
   const providerLabel = (p: string) => PROVIDER_OPTIONS.find(o => o.value === p)?.label ?? p
   const providerPlaceholder = (p: string) => PROVIDER_OPTIONS.find(o => o.value === p)?.placeholder ?? ""
 
   const resetForm = () => {
-    setFormName(""); setFormProvider("anthropic"); setFormCustomProvider(""); setFormKey(""); setFormDefault(false); setFormDefaultModel(""); setEditIdx(null)
+    setFormName(""); setFormProvider("anthropic"); setFormCustomProvider(""); setFormKey(""); setFormDefault(false); setFormDefaultModel(""); setFormCustomModel(""); setEditIdx(null)
   }
 
   const openAdd = () => { resetForm(); setModalMode("add"); setShowModal(true) }
@@ -896,7 +909,14 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
     setFormCustomProvider(isCustom ? k.provider : "")
     setFormKey("")
     setFormDefault(k.default)
-    setFormDefaultModel(k.defaultModel || "")
+    const providerModels = PROVIDER_MODELS[k.provider] || []
+    if (k.defaultModel && providerModels.length > 0 && !providerModels.some(m => m.id === k.defaultModel)) {
+      setFormDefaultModel("__custom")
+      setFormCustomModel(k.defaultModel)
+    } else {
+      setFormDefaultModel(k.defaultModel || "")
+      setFormCustomModel("")
+    }
     setEditIdx(i)
     setModalMode("edit")
     setShowModal(true)
@@ -907,9 +927,10 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
 
   function doSave() {
     const actualProvider = formProvider === "other" ? formCustomProvider : formProvider
+    const actualDefaultModel = formDefaultModel === "__custom" ? formCustomModel.trim() : formDefaultModel
     if (modalMode === "add") {
-      if (!formName.trim() || !formKey.trim()) return
-      onSave({ llmKeys: [{ name: formName.trim(), provider: actualProvider, apiKey: formKey.trim(), default: formDefault, defaultModel: formDefaultModel || undefined }] })
+      if (!formName.trim() || (!formKey.trim() && actualProvider !== "ollama")) return
+      onSave({ llmKeys: [{ name: formName.trim(), provider: actualProvider, apiKey: formKey.trim(), default: formDefault, defaultModel: actualDefaultModel || undefined }] })
     } else if (editIdx !== null) {
       const existing = llmKeys[editIdx]
       const patch: Record<string, unknown> = {
@@ -918,7 +939,7 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
       }
       if (formKey.trim()) patch.apiKey = formKey.trim()
       patch.default = formDefault       // always send so user can unset
-      if (formDefaultModel) patch.defaultModel = formDefaultModel
+      if (actualDefaultModel) patch.defaultModel = actualDefaultModel
       if (actualProvider !== existing.provider) patch.provider = actualProvider
       onSave({ llmKeys: [patch] })
     }
@@ -1076,7 +1097,7 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
                   <label className="text-xs text-muted-foreground mb-1 block">Provider</label>
                   <select
                     value={formProvider}
-                    onChange={e => { setFormProvider(e.target.value); setFormDefaultModel("") }}
+                    onChange={e => { setFormProvider(e.target.value); setFormDefaultModel(""); setFormCustomModel("") }}
                     className="w-full h-8 rounded-md border border-border bg-background px-2 text-sm"
                   >
                     {PROVIDER_OPTIONS.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
@@ -1114,6 +1135,14 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
                   </select>
                 ) : (
                   <Input value={formDefaultModel} onChange={e => setFormDefaultModel(e.target.value)} className="h-8 text-sm" placeholder="e.g. myprovider/model-name" />
+                )}
+                {PROVIDER_MODELS[formProvider] && formDefaultModel === "__custom" && (
+                  <Input
+                    value={formCustomModel}
+                    onChange={e => setFormCustomModel(e.target.value)}
+                    className="h-8 text-sm mt-2"
+                    placeholder={formProvider === "ollama" ? "e.g. ollama/qwen3:14b" : "e.g. provider/model-name"}
+                  />
                 )}
               </div>
               <label className="flex items-center gap-2 text-sm cursor-pointer">

--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary

Adds a local Docker dev environment with optional Ollama support while keeping external LLM providers easy to use for stronger model testing.

## What changed

- Adds Ollama to the dev Compose stack with persistent model storage and a `make dev-ollama-pull` helper.
- Updates the dev hub config example and Docker docs for local-only Ollama testing and external-provider testing.
- Supports `ollama` across hub-side AI config, streaming, failure summaries, settings, and doctor checks.
- Uses OpenClaw native Ollama onboarding for Docker agents with `http://ollama:11434` and strips the `ollama/` model prefix.
- Stabilizes Docker agent bootstrap by waiting for workspace files before starting OpenClaw bootstrap work.
- Pins OpenClaw consistently and fails the agent image build if the pinned install fails.
- Adds focused tests for Ollama provider selection, doctor checks, bootstrap flags/config, Docker copy behavior, and settings display.

## Validation

- `docker run --rm -e GOFLAGS=-buildvcs=false -v "$PWD":/app -w /app golang:1.25 go test ./cmd/claw-bridge ./pkg/provider/docker ./pkg/hub ./pkg/types`
- `docker compose -f docker/compose.dev.yml config`
- `make dev-agent-build`

`npm run lint` was also attempted, but it currently fails on existing repo-wide React hook lint errors unrelated to this change.


## Linked issue

Closes #328
