### PR TITLE
Make factory claws default to PR completion

### DIFF
--- a/pkg/hub/external_webhook.go
+++ b/pkg/hub/external_webhook.go
@@ -740,7 +740,8 @@ func buildExternalEventContext(payload externalWebhookPayload, factory *types.Fa
 	b.WriteString("1. Read this file fully to understand the external event context\n")
 	b.WriteString("2. Explore the codebase and identify what needs to be updated\n")
 	b.WriteString("3. Implement the necessary changes to handle this external event\n")
-	b.WriteString("4. When complete, send exactly: `[DONE] https://github.com/org/repo/pull/N` (with your PR URL)\n")
+	b.WriteString("4. Follow the PR Completion Policy below\n")
+	appendDefaultFactoryPRPolicy(&b)
 
 	return b.String()
 }

--- a/pkg/hub/factory_creator.go
+++ b/pkg/hub/factory_creator.go
@@ -433,6 +433,11 @@ func buildManualTriggerContext(factory *types.FactoryConfig, inputs map[string]s
 			b.WriteString(fmt.Sprintf("  - %s\n", in.Description))
 		}
 	}
-	b.WriteString("\n")
+	b.WriteString("\n## Instructions\n\n")
+	b.WriteString("1. Read the trigger inputs fully\n")
+	b.WriteString("2. Explore the codebase\n")
+	b.WriteString("3. Implement the requested work\n")
+	b.WriteString("4. Follow the PR Completion Policy below\n")
+	appendDefaultFactoryPRPolicy(&b)
 	return b.String()
 }

--- a/pkg/hub/factory_pr_policy.go
+++ b/pkg/hub/factory_pr_policy.go
@@ -1,0 +1,19 @@
+package hub
+
+import "strings"
+
+const defaultFactoryPRPolicy = "## PR Completion Policy\n\n" +
+	"Unless the issue, factory/workflow instructions, template instructions, or a later explicit user instruction says not to create a PR, finish implementation by creating a pull request.\n\n" +
+	"Before sending `[DONE]`:\n" +
+	"1. Commit the finished work.\n" +
+	"2. Push the branch.\n" +
+	"3. Open a pull request for the branch.\n" +
+	"4. Send exactly: `[DONE] https://github.com/org/repo/pull/N` with the actual PR URL.\n\n" +
+	"If you cannot create a PR because credentials, repository access, or remotes are missing, do not send `[DONE]`. Report the blocker and the verification already completed.\n"
+
+func appendDefaultFactoryPRPolicy(b *strings.Builder) {
+	if b.Len() > 0 {
+		b.WriteString("\n")
+	}
+	b.WriteString(defaultFactoryPRPolicy)
+}

--- a/pkg/hub/factory_pr_policy_test.go
+++ b/pkg/hub/factory_pr_policy_test.go
@@ -1,0 +1,121 @@
+package hub
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func TestDefaultFactoryPRPolicyText(t *testing.T) {
+	policy := defaultFactoryPRPolicy
+
+	required := []string{
+		"Unless the issue, factory/workflow instructions, template instructions, or a later explicit user instruction says not to create a PR",
+		"creating a pull request",
+		"Open a pull request for the branch",
+		"[DONE] https://github.com/org/repo/pull/N",
+		"do not send `[DONE]`",
+		"Report the blocker",
+	}
+	for _, want := range required {
+		if !strings.Contains(policy, want) {
+			t.Fatalf("defaultFactoryPRPolicy missing %q:\n%s", want, policy)
+		}
+	}
+}
+
+func TestFactoryContextsIncludeDefaultPRPolicy(t *testing.T) {
+	var linearPayload linearWebhookPayload
+	linearPayload.Data.Identifier = "ELA-128"
+	linearPayload.Data.Title = "Create PR by default"
+	linearPayload.Data.Description = "Agent should open a PR."
+
+	var githubIssuesPayload githubIssuesWebhookPayload
+	githubIssuesPayload.Issue.Number = 128
+	githubIssuesPayload.Issue.Title = "Create PR by default"
+	githubIssuesPayload.Issue.Body = "Agent should open a PR."
+	githubIssuesPayload.Repository.FullName = "elasticclaw/elasticclaw"
+
+	shortcut := shortcutAction{
+		Name:        "Create PR by default",
+		AppURL:      "https://app.shortcut.com/story/128",
+		Description: "Agent should open a PR.",
+	}
+
+	var externalPayload externalWebhookPayload
+	externalPayload.EventType = "generic"
+	externalPayload.Repository.FullName = "elasticclaw/elasticclaw"
+	externalFactory := &types.FactoryConfig{
+		Name:        "external-release",
+		Integration: "external",
+		Template:    "elasticclaw",
+		ExternalTrigger: &types.ExternalTrigger{
+			Source: "generic-webhook",
+		},
+	}
+
+	manualFactory := &types.FactoryConfig{
+		Name:        "manual-fix",
+		Integration: "linear",
+		Template:    "elasticclaw",
+		Inputs: []types.FactoryInput{{
+			Name:        "task",
+			Type:        "string",
+			Description: "Task to complete",
+		}},
+	}
+
+	manualWorkflow := &types.WorkflowConfig{
+		Name:        "manual-workflow",
+		Integration: "manual",
+		Inputs: []types.FactoryInput{{
+			Name:        "task",
+			Type:        "string",
+			Description: "Task to complete",
+		}},
+	}
+
+	cases := map[string]string{
+		"linear issue":            buildLinearContext(linearPayload),
+		"github issue":            buildGitHubIssuesContext(githubIssuesPayload),
+		"shortcut story":          buildShortcutContext(shortcut, "128"),
+		"external event":          buildExternalEventContext(externalPayload, externalFactory),
+		"manual factory trigger":  buildManualTriggerContext(manualFactory, map[string]string{"task": "fix issue 128"}),
+		"manual workflow trigger": buildWorkflowManualTriggerContext(manualWorkflow, map[string]string{"task": "fix issue 128"}),
+	}
+
+	for name, content := range cases {
+		t.Run(name, func(t *testing.T) {
+			if !strings.Contains(content, "## PR Completion Policy") {
+				t.Fatalf("context missing PR policy:\n%s", content)
+			}
+			if !strings.Contains(content, "Unless the issue, factory/workflow instructions") {
+				t.Fatalf("context missing unless-instructed-otherwise language:\n%s", content)
+			}
+			if !strings.Contains(content, "[DONE] https://github.com/org/repo/pull/N") {
+				t.Fatalf("context missing DONE PR URL contract:\n%s", content)
+			}
+		})
+	}
+}
+
+func TestGitHubPRContextDoesNotRequestNewPR(t *testing.T) {
+	var payload githubPRPayload
+	payload.Number = 7
+	payload.Repository.FullName = "elasticclaw/elasticclaw"
+	payload.PullRequest.HTMLURL = "https://github.com/elasticclaw/elasticclaw/pull/7"
+	payload.PullRequest.Title = "Existing PR"
+	payload.PullRequest.User.Login = "octocat"
+	payload.PullRequest.Head.Ref = "feature"
+	payload.PullRequest.Base.Ref = "main"
+
+	content := buildGitHubPRContext(payload)
+
+	if strings.Contains(content, "## PR Completion Policy") {
+		t.Fatalf("existing PR context must not request a new PR:\n%s", content)
+	}
+	if !strings.Contains(content, "gh pr checkout https://github.com/elasticclaw/elasticclaw/pull/7") {
+		t.Fatalf("existing PR checkout instruction missing:\n%s", content)
+	}
+}

--- a/pkg/hub/github_issues.go
+++ b/pkg/hub/github_issues.go
@@ -910,7 +910,8 @@ func buildGitHubIssuesContext(payload githubIssuesWebhookPayload) string {
 	b.WriteString("1. Read this file fully\n")
 	b.WriteString("2. Explore the codebase\n")
 	b.WriteString("3. Implement the feature/fix described above\n")
-	b.WriteString("4. When complete, send exactly: `[DONE] https://github.com/org/repo/pull/N` (with your PR URL)\n")
+	b.WriteString("4. Follow the PR Completion Policy below\n")
+	appendDefaultFactoryPRPolicy(&b)
 	return b.String()
 }
 

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -1066,7 +1066,8 @@ func buildLinearContext(payload linearWebhookPayload) string {
 	b.WriteString("1. Read this file fully\n")
 	b.WriteString("2. Explore the codebase\n")
 	b.WriteString("3. Implement the feature/fix described above\n")
-	b.WriteString("4. When complete, send exactly: `[DONE] https://github.com/org/repo/pull/N` (with your PR URL)\n")
+	b.WriteString("4. Follow the PR Completion Policy below\n")
+	appendDefaultFactoryPRPolicy(&b)
 	return b.String()
 }
 

--- a/pkg/hub/shortcut.go
+++ b/pkg/hub/shortcut.go
@@ -788,7 +788,8 @@ func buildShortcutContext(action shortcutAction, storyID string) string {
 	b.WriteString("1. Read this file fully\n")
 	b.WriteString("2. Explore the codebase\n")
 	b.WriteString("3. Implement the feature/fix described above\n")
-	b.WriteString("4. When complete, send exactly: `[DONE] https://github.com/org/repo/pull/N` (with your PR URL)\n")
+	b.WriteString("4. Follow the PR Completion Policy below\n")
+	appendDefaultFactoryPRPolicy(&b)
 	return b.String()
 }
 

--- a/pkg/hub/workflow_creator.go
+++ b/pkg/hub/workflow_creator.go
@@ -316,7 +316,12 @@ func buildWorkflowManualTriggerContext(workflow *types.WorkflowConfig, inputs ma
 			b.WriteString(fmt.Sprintf("  - %s\n", in.Description))
 		}
 	}
-	b.WriteString("\n")
+	b.WriteString("\n## Instructions\n\n")
+	b.WriteString("1. Read the trigger inputs fully\n")
+	b.WriteString("2. Explore the codebase\n")
+	b.WriteString("3. Implement the requested work\n")
+	b.WriteString("4. Follow the PR Completion Policy below\n")
+	appendDefaultFactoryPRPolicy(&b)
 	return b.String()
 }
 


### PR DESCRIPTION
## Summary

- Add a shared factory PR completion policy for generated agent contexts.
- Apply the policy to Linear, GitHub issue, Shortcut, external event, manual factory, and manual workflow contexts.
- Add coverage proving those contexts include the policy while existing PR assignment contexts do not request a new PR.

## Validation

- `go test ./pkg/hub`
- `go test ./...`
- `cr --base feat/docker-web-env` returned `No findings`

Fixes #128.
