### PR TITLE
Include GitHub issue comments in agent context

### DIFF
--- a/pkg/hub/factorytest/mock_github_issues.go
+++ b/pkg/hub/factorytest/mock_github_issues.go
@@ -24,6 +24,14 @@ type IssueState struct {
 	UpdatedAt string // RFC3339
 }
 
+type IssueCommentState struct {
+	ID        int64
+	Body      string
+	User      string
+	CreatedAt string
+	HTMLURL   string
+}
+
 // MockGitHubIssues is a REST-style mock for the GitHub Issues API and webhook
 // delivery. It currently handles:
 //   - GET /repos/{owner}/{repo}/issues?since=...&state=all&sort=updated&direction=desc
@@ -36,6 +44,7 @@ type MockGitHubIssues struct {
 	mu            sync.Mutex
 	Issues        map[string]IssueState // key: "owner/repo#number"
 	IssueEvents   map[string][]map[string]interface{}
+	IssueComments map[string][]IssueCommentState
 	Calls         []string
 	AuthHeaders   []string
 	WebhookSecret string
@@ -44,8 +53,9 @@ type MockGitHubIssues struct {
 func NewMockGitHubIssues(t *testing.T) *MockGitHubIssues {
 	t.Helper()
 	m := &MockGitHubIssues{
-		Issues:      make(map[string]IssueState),
-		IssueEvents: make(map[string][]map[string]interface{}),
+		Issues:        make(map[string]IssueState),
+		IssueEvents:   make(map[string][]map[string]interface{}),
+		IssueComments: make(map[string][]IssueCommentState),
 	}
 	mux := http.NewServeMux()
 
@@ -81,6 +91,17 @@ func NewMockGitHubIssues(t *testing.T) *MockGitHubIssues {
 				m.mu.Unlock()
 				w.Header().Set("Content-Type", "application/json")
 				json.NewEncoder(w).Encode(events)
+				return
+			}
+			if len(parts2) == 3 && parts2[0] == "issues" && parts2[2] == "comments" {
+				var num int
+				fmt.Sscanf(parts2[1], "%d", &num)
+				key := fmt.Sprintf("%s/%s#%d", owner, repo, num)
+				m.mu.Lock()
+				comments := append([]IssueCommentState(nil), m.IssueComments[key]...)
+				m.mu.Unlock()
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(issueCommentsToMaps(comments, owner, repo, num))
 				return
 			}
 			// Single issue fetch: /repos/{owner}/{repo}/issues/{number}
@@ -142,6 +163,13 @@ func (m *MockGitHubIssues) SetIssueEvents(repo string, number int, events []map[
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.IssueEvents[fmt.Sprintf("%s#%d", repo, number)] = append([]map[string]interface{}(nil), events...)
+}
+
+func (m *MockGitHubIssues) SetIssueComments(repo string, number int, comments []IssueCommentState) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	// repo must be in "owner/repo" format to match handler lookup keys.
+	m.IssueComments[fmt.Sprintf("%s#%d", repo, number)] = append([]IssueCommentState(nil), comments...)
 }
 
 func (m *MockGitHubIssues) SetIssueState(repo string, number int, state string) {
@@ -279,6 +307,36 @@ func issueToMap(number int, issue IssueState, owner, repo string) map[string]int
 		"assignee":   assignee,
 		"user":       map[string]interface{}{"login": "testuser"},
 	}
+}
+
+func issueCommentsToMaps(comments []IssueCommentState, owner, repo string, number int) []map[string]interface{} {
+	out := make([]map[string]interface{}, 0, len(comments))
+	for idx, comment := range comments {
+		id := comment.ID
+		if id == 0 {
+			id = int64(idx + 1)
+		}
+		user := comment.User
+		if user == "" {
+			user = "testuser"
+		}
+		createdAt := comment.CreatedAt
+		if createdAt == "" {
+			createdAt = time.Now().UTC().Format(time.RFC3339)
+		}
+		htmlURL := comment.HTMLURL
+		if htmlURL == "" {
+			htmlURL = fmt.Sprintf("https://github.com/%s/%s/issues/%d#issuecomment-%d", owner, repo, number, id)
+		}
+		out = append(out, map[string]interface{}{
+			"id":         id,
+			"body":       comment.Body,
+			"html_url":   htmlURL,
+			"created_at": createdAt,
+			"user":       map[string]interface{}{"login": user, "type": "User"},
+		})
+	}
+	return out
 }
 
 func labelsToNameMaps(labels []string) []map[string]interface{} {

--- a/pkg/hub/github_issues.go
+++ b/pkg/hub/github_issues.go
@@ -11,7 +11,10 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
+	"sort"
 	"strings"
+	"time"
 
 	"github.com/elasticclaw/elasticclaw/pkg/config"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
@@ -58,6 +61,19 @@ type githubIssuesWebhookPayload struct {
 		} `json:"body,omitempty"`
 	} `json:"changes,omitempty"`
 	// GitHub sends X-GitHub-Delivery header as unique delivery ID
+}
+
+type githubIssueCommentUser struct {
+	Login string `json:"login"`
+	Type  string `json:"type"`
+}
+
+type githubIssueComment struct {
+	ID        int64                  `json:"id"`
+	Body      string                 `json:"body"`
+	HTMLURL   string                 `json:"html_url"`
+	CreatedAt string                 `json:"created_at"`
+	User      githubIssueCommentUser `json:"user"`
 }
 
 func (s *Server) handleGitHubIssuesWebhook(w http.ResponseWriter, r *http.Request) {
@@ -428,7 +444,8 @@ func (s *Server) createClawForGitHubIssueWorkflow(workspace *types.WorkspaceConf
 	}()
 
 	templateFiles := cloneStringMap(workspace.Files)
-	templateFiles["CONTEXT.md"] = buildGitHubIssuesContext(payload)
+	ghToken := s.resolveGitHubIssuesTokenForWorkflow(workspace.Name, workflow)
+	templateFiles["CONTEXT.md"] = s.buildGitHubIssuesContextWithComments(payload, ghToken)
 
 	clawName := issueID
 	if workflow.NamePattern != "" {
@@ -508,7 +525,7 @@ func (s *Server) createClawForGitHubIssue(factory *types.FactoryConfig, payload 
 	}
 
 	// Build context file
-	ctxFile := buildGitHubIssuesContext(payload)
+	ctxFile := s.buildGitHubIssuesContextWithComments(payload, ghToken)
 	templateFiles["CONTEXT.md"] = ctxFile
 
 	// Build claw name
@@ -876,7 +893,20 @@ func (s *Server) resolveGitHubIssuesTokenForWorkflow(workspaceName string, workf
 	return ""
 }
 
-func buildGitHubIssuesContext(payload githubIssuesWebhookPayload) string {
+func (s *Server) buildGitHubIssuesContextWithComments(payload githubIssuesWebhookPayload, token string) string {
+	base := s.githubBaseURL
+	if base == "" {
+		base = "https://api.github.com"
+	}
+	comments, err := fetchGitHubIssueComments(base, payload.Repository.FullName, payload.Issue.Number, token)
+	if err != nil {
+		log.Printf("[github-issues] failed to fetch comments for %s#%d: %v", payload.Repository.FullName, payload.Issue.Number, err)
+		return buildGitHubIssuesContext(payload, nil, "Issue comments could not be loaded automatically. Review the issue URL for additional context.")
+	}
+	return buildGitHubIssuesContext(payload, comments, "")
+}
+
+func buildGitHubIssuesContext(payload githubIssuesWebhookPayload, comments []githubIssueComment, commentWarning string) string {
 	i := payload.Issue
 	var b strings.Builder
 	b.WriteString("# Issue Context\n\n")
@@ -892,8 +922,8 @@ func buildGitHubIssuesContext(payload githubIssuesWebhookPayload) string {
 	}
 	if len(i.Labels) > 0 {
 		b.WriteString("**Labels:** ")
-		for i, l := range i.Labels {
-			if i > 0 {
+		for idx, l := range i.Labels {
+			if idx > 0 {
 				b.WriteString(", ")
 			}
 			b.WriteString(l.Name)
@@ -905,6 +935,29 @@ func buildGitHubIssuesContext(payload githubIssuesWebhookPayload) string {
 		b.WriteString(i.Body)
 		b.WriteString("\n")
 	}
+	if len(comments) > 0 || commentWarning != "" {
+		b.WriteString("\n## Comments\n\n")
+		if commentWarning != "" {
+			b.WriteString(commentWarning)
+			b.WriteString("\n\n")
+		}
+		for idx, comment := range comments {
+			b.WriteString(fmt.Sprintf("### Comment %d\n\n", idx+1))
+			if comment.User.Login != "" {
+				b.WriteString(fmt.Sprintf("**Author:** @%s\n\n", comment.User.Login))
+			}
+			if comment.CreatedAt != "" {
+				b.WriteString(fmt.Sprintf("**Created:** %s\n\n", comment.CreatedAt))
+			}
+			if comment.HTMLURL != "" {
+				b.WriteString(fmt.Sprintf("**URL:** %s\n\n", comment.HTMLURL))
+			}
+			if strings.TrimSpace(comment.Body) != "" {
+				b.WriteString(comment.Body)
+				b.WriteString("\n\n")
+			}
+		}
+	}
 	b.WriteString("\n---\n\n")
 	b.WriteString("## Instructions\n\n")
 	b.WriteString("1. Read this file fully\n")
@@ -912,6 +965,87 @@ func buildGitHubIssuesContext(payload githubIssuesWebhookPayload) string {
 	b.WriteString("3. Implement the feature/fix described above\n")
 	b.WriteString("4. When complete, send exactly: `[DONE] https://github.com/org/repo/pull/N` (with your PR URL)\n")
 	return b.String()
+}
+
+func fetchGitHubIssueComments(baseURL, repo string, issueNumber int, token string) ([]githubIssueComment, error) {
+	if token == "" {
+		return nil, nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	path := fmt.Sprintf("repos/%s/issues/%d/comments?per_page=100", repo, issueNumber)
+	var comments []githubIssueComment
+	pagesRemaining := 100
+	for path != "" && pagesRemaining > 0 {
+		page, next, err := fetchGitHubIssueCommentsPage(ctx, baseURL, path, token)
+		if err != nil {
+			return nil, err
+		}
+		comments = append(comments, page...)
+		path = next
+		pagesRemaining--
+	}
+	if path != "" {
+		return nil, fmt.Errorf("github comments pagination exceeded 100 pages for %s#%d", repo, issueNumber)
+	}
+	sort.SliceStable(comments, func(i, j int) bool {
+		if comments[i].CreatedAt != "" && comments[j].CreatedAt != "" && comments[i].CreatedAt != comments[j].CreatedAt {
+			return comments[i].CreatedAt < comments[j].CreatedAt
+		}
+		return comments[i].ID < comments[j].ID
+	})
+	return comments, nil
+}
+
+func fetchGitHubIssueCommentsPage(ctx context.Context, baseURL, path, token string) ([]githubIssueComment, string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/"+path, nil)
+	if err != nil {
+		return nil, "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, "", err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, "", fmt.Errorf("github comments response read error: %w", err)
+	}
+	if resp.StatusCode >= 400 {
+		return nil, "", fmt.Errorf("github comments API returned status %d: %s", resp.StatusCode, string(body))
+	}
+	var comments []githubIssueComment
+	if err := json.Unmarshal(body, &comments); err != nil {
+		return nil, "", fmt.Errorf("github comments parse error: %w", err)
+	}
+	return comments, nextGitHubPagePath(resp.Header.Get("Link")), nil
+}
+
+func nextGitHubPagePath(linkHeader string) string {
+	for _, part := range strings.Split(linkHeader, ",") {
+		part = strings.TrimSpace(part)
+		if !strings.Contains(part, `rel="next"`) {
+			continue
+		}
+		start := strings.Index(part, "<")
+		end := strings.Index(part, ">")
+		if start < 0 || end <= start {
+			return ""
+		}
+		u, err := url.Parse(part[start+1 : end])
+		if err != nil {
+			return ""
+		}
+		nextPath := strings.TrimPrefix(u.Path, "/")
+		if u.RawQuery != "" {
+			nextPath += "?" + u.RawQuery
+		}
+		return nextPath
+	}
+	return ""
 }
 
 // commentGitHubIssue adds a comment to a GitHub issue.

--- a/pkg/hub/github_issues.go
+++ b/pkg/hub/github_issues.go
@@ -971,13 +971,13 @@ func fetchGitHubIssueComments(baseURL, repo string, issueNumber int, token strin
 	if token == "" {
 		return nil, nil
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
 	path := fmt.Sprintf("repos/%s/issues/%d/comments?per_page=100", repo, issueNumber)
 	var comments []githubIssueComment
 	pagesRemaining := 100
 	for path != "" && pagesRemaining > 0 {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		page, next, err := fetchGitHubIssueCommentsPage(ctx, baseURL, path, token)
+		cancel()
 		if err != nil {
 			return nil, err
 		}
@@ -1021,10 +1021,10 @@ func fetchGitHubIssueCommentsPage(ctx context.Context, baseURL, path, token stri
 	if err := json.Unmarshal(body, &comments); err != nil {
 		return nil, "", fmt.Errorf("github comments parse error: %w", err)
 	}
-	return comments, nextGitHubPagePath(resp.Header.Get("Link")), nil
+	return comments, nextGitHubPagePath(resp.Header.Get("Link"), baseURL), nil
 }
 
-func nextGitHubPagePath(linkHeader string) string {
+func nextGitHubPagePath(linkHeader, baseURL string) string {
 	for _, part := range strings.Split(linkHeader, ",") {
 		part = strings.TrimSpace(part)
 		if !strings.Contains(part, `rel="next"`) {
@@ -1037,6 +1037,10 @@ func nextGitHubPagePath(linkHeader string) string {
 		}
 		u, err := url.Parse(part[start+1 : end])
 		if err != nil {
+			return ""
+		}
+		base, baseErr := url.Parse(baseURL + "/")
+		if baseErr != nil || (base.Host != "" && u.Host != "" && u.Host != base.Host) {
 			return ""
 		}
 		nextPath := strings.TrimPrefix(u.Path, "/")

--- a/pkg/hub/github_issues_context_test.go
+++ b/pkg/hub/github_issues_context_test.go
@@ -1,0 +1,130 @@
+package hub
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestBuildGitHubIssuesContextIncludesAllComments(t *testing.T) {
+	payload := githubIssuesWebhookPayload{}
+	payload.Issue.Number = 358
+	payload.Issue.Title = "Agents dont read all the content of an issue"
+	payload.Issue.Body = "Main issue body"
+	payload.Issue.HTMLURL = "https://github.com/elasticclaw/elasticclaw/issues/358"
+	payload.Issue.User.Login = "AnaBerg"
+	payload.Repository.FullName = "elasticclaw/elasticclaw"
+
+	comments := []githubIssueComment{{
+		ID:        101,
+		Body:      "First comment with required detail",
+		HTMLURL:   "https://github.com/elasticclaw/elasticclaw/issues/358#issuecomment-101",
+		CreatedAt: "2026-06-05T20:37:00Z",
+		User: githubIssueCommentUser{
+			Login: "alice",
+		},
+	}, {
+		ID:        102,
+		Body:      "Second comment with extra acceptance criteria",
+		HTMLURL:   "https://github.com/elasticclaw/elasticclaw/issues/358#issuecomment-102",
+		CreatedAt: "2026-06-05T20:38:00Z",
+		User: githubIssueCommentUser{
+			Login: "bob",
+		},
+	}, {
+		ID:        103,
+		Body:      "Third comment with final instruction",
+		HTMLURL:   "https://github.com/elasticclaw/elasticclaw/issues/358#issuecomment-103",
+		CreatedAt: "2026-06-05T20:39:00Z",
+		User: githubIssueCommentUser{
+			Login: "carol",
+		},
+	}}
+
+	got := buildGitHubIssuesContext(payload, comments, "")
+	for _, want := range []string{
+		"Main issue body",
+		"## Comments",
+		"First comment with required detail",
+		"Second comment with extra acceptance criteria",
+		"Third comment with final instruction",
+		"**Author:** @alice",
+		"**Author:** @bob",
+		"**Author:** @carol",
+		"**Created:** 2026-06-05T20:37:00Z",
+		"**Created:** 2026-06-05T20:38:00Z",
+		"**Created:** 2026-06-05T20:39:00Z",
+		"https://github.com/elasticclaw/elasticclaw/issues/358#issuecomment-101",
+		"https://github.com/elasticclaw/elasticclaw/issues/358#issuecomment-102",
+		"https://github.com/elasticclaw/elasticclaw/issues/358#issuecomment-103",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("context missing %q:\n%s", want, got)
+		}
+	}
+	firstPos := strings.Index(got, "First comment with required detail")
+	secondPos := strings.Index(got, "Second comment with extra acceptance criteria")
+	thirdPos := strings.Index(got, "Third comment with final instruction")
+	if firstPos > secondPos {
+		t.Fatalf("comments rendered out of order: first at %d, second at %d:\n%s", firstPos, secondPos, got)
+	}
+	if secondPos > thirdPos {
+		t.Fatalf("comments rendered out of order: second at %d, third at %d:\n%s", secondPos, thirdPos, got)
+	}
+}
+
+func TestBuildGitHubIssuesContextIncludesCommentFetchWarning(t *testing.T) {
+	payload := githubIssuesWebhookPayload{}
+	payload.Issue.Number = 358
+	payload.Issue.Title = "Agents dont read all the content of an issue"
+	payload.Repository.FullName = "elasticclaw/elasticclaw"
+
+	got := buildGitHubIssuesContext(payload, nil, "Issue comments could not be loaded automatically. Review the issue URL for additional context.")
+	if !strings.Contains(got, "Issue comments could not be loaded automatically. Review the issue URL for additional context.") {
+		t.Fatalf("context missing fetch warning:\n%s", got)
+	}
+}
+
+func TestFetchGitHubIssueCommentsFollowsPagination(t *testing.T) {
+	var srvURL string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/testorg/testrepo/issues/42/comments" {
+			t.Fatalf("unexpected comments request path: %q", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Fatalf("Authorization header = %q, want bearer token", got)
+		}
+		switch r.URL.RawQuery {
+		case "per_page=100":
+			w.Header().Set("Link", fmt.Sprintf(`<%s/repos/testorg/testrepo/issues/42/comments?per_page=100&page=2>; rel="next"`, srvURL))
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"id":2,"body":"second by date","created_at":"2026-06-05T20:38:00Z","user":{"login":"bob"}}]`))
+		case "per_page=100&page=2":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"id":1,"body":"first by date","created_at":"2026-06-05T20:37:00Z","user":{"login":"alice"}}]`))
+		default:
+			t.Fatalf("unexpected comments request query: %q", r.URL.RawQuery)
+		}
+	}))
+	defer srv.Close()
+	srvURL = srv.URL
+
+	comments, err := fetchGitHubIssueComments(srv.URL, "testorg/testrepo", 42, "test-token")
+	if err != nil {
+		t.Fatalf("fetch comments: %v", err)
+	}
+	if len(comments) != 2 {
+		t.Fatalf("comments len = %d, want 2", len(comments))
+	}
+	if comments[0].Body != "first by date" || comments[1].Body != "second by date" {
+		t.Fatalf("comments were not fetched and sorted oldest-first: %#v", comments)
+	}
+	if comments[0].ID != 1 || comments[0].CreatedAt != "2026-06-05T20:37:00Z" || comments[0].User.Login != "alice" {
+		t.Fatalf("first comment fields incorrect: %#v", comments[0])
+	}
+	if comments[1].ID != 2 || comments[1].CreatedAt != "2026-06-05T20:38:00Z" || comments[1].User.Login != "bob" {
+		t.Fatalf("second comment fields incorrect: %#v", comments[1])
+	}
+}

--- a/pkg/hub/github_issues_context_test.go
+++ b/pkg/hub/github_issues_context_test.go
@@ -128,3 +128,28 @@ func TestFetchGitHubIssueCommentsFollowsPagination(t *testing.T) {
 		t.Fatalf("second comment fields incorrect: %#v", comments[1])
 	}
 }
+
+func TestFetchGitHubIssueCommentsIgnoresForeignNextPageHost(t *testing.T) {
+	requests := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.URL.Path != "/repos/testorg/testrepo/issues/42/comments" {
+			t.Fatalf("unexpected comments request path: %q", r.URL.Path)
+		}
+		w.Header().Set("Link", `<https://evil.example/repos/testorg/testrepo/issues/42/comments?per_page=100&page=2>; rel="next"`)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"id":1,"body":"only trusted page","created_at":"2026-06-05T20:37:00Z","user":{"login":"alice"}}]`))
+	}))
+	defer srv.Close()
+
+	comments, err := fetchGitHubIssueComments(srv.URL, "testorg/testrepo", 42, "test-token")
+	if err != nil {
+		t.Fatalf("fetch comments: %v", err)
+	}
+	if requests != 1 {
+		t.Fatalf("requests = %d, want only the first page", requests)
+	}
+	if len(comments) != 1 || comments[0].Body != "only trusted page" {
+		t.Fatalf("comments = %#v, want trusted first page only", comments)
+	}
+}

--- a/pkg/hub/github_issues_webhook_test.go
+++ b/pkg/hub/github_issues_webhook_test.go
@@ -3,7 +3,9 @@ package hub_test
 import (
 	"crypto/hmac"
 	"crypto/sha256"
+	"database/sql"
 	"encoding/hex"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -295,12 +297,143 @@ func TestGitHubIssuesWorkflowPollQueriesEachWorkspaceToken(t *testing.T) {
 
 	s.PollIntegrationsForTest()
 
-	if got := ghi.AuthHeaderCount("Bearer token-a"); got != 1 {
-		t.Fatalf("poll used token-a %d times, want 1", got)
+	gotA := ghi.AuthHeaderCount("Bearer token-a")
+	gotB := ghi.AuthHeaderCount("Bearer token-b")
+	if gotA < 1 {
+		t.Fatalf("poll used token-a %d times, want at least 1", gotA)
 	}
-	if got := ghi.AuthHeaderCount("Bearer token-b"); got != 1 {
-		t.Fatalf("poll used token-b %d times, want 1", got)
+	if gotB < 1 {
+		t.Fatalf("poll used token-b %d times, want at least 1", gotB)
 	}
+	if gotA+gotB != 3 {
+		t.Fatalf("poll auth calls = token-a:%d token-b:%d, want two issue polls plus one comments fetch", gotA, gotB)
+	}
+}
+
+func TestGitHubIssuesWorkspaceWebhookContextIncludesAllIssueComments(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
+	ghi := factorytest.NewMockGitHubIssues(t)
+	ghi.WebhookSecret = "secret"
+	li := factorytest.NewMockLinear(t)
+
+	cfg := &types.HubConfig{
+		ClawToken: "test-claw-token",
+		Providers: map[string]types.ProviderConfig{
+			"noop": {Type: "noop"},
+		},
+	}
+	s, db := hub.NewTestServerWithConfig(t, cfg, ghi.URL, li.URL, "")
+	saveGitHubIssueWorkflowFixture(t, "workspace-a", "secret")
+
+	httpSrv := httptest.NewServer(s.Handler())
+	t.Cleanup(httpSrv.Close)
+
+	ghi.SetIssue("testorg/testrepo", 42, factorytest.IssueState{Title: "Test Issue", Body: "Main issue body", State: "open"})
+	ghi.SetIssueComments("testorg/testrepo", 42, []factorytest.IssueCommentState{{
+		ID:        101,
+		Body:      "First existing comment",
+		User:      "alice",
+		CreatedAt: "2026-06-05T20:37:00Z",
+	}, {
+		ID:        102,
+		Body:      "Second existing comment",
+		User:      "bob",
+		CreatedAt: "2026-06-05T20:38:00Z",
+	}, {
+		ID:        103,
+		Body:      "Third existing comment",
+		User:      "carol",
+		CreatedAt: "2026-06-05T20:39:00Z",
+	}})
+	payload, _ := ghi.BuildWebhookPayload("testorg/testrepo", 42, "closed", "open")
+	req, err := http.NewRequest(http.MethodPost, httpSrv.URL+"/api/workspaces/workspace-a/webhooks/github-issues", strings.NewReader(string(payload)))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Hub-Signature-256", hmacSHA256(payload, "secret"))
+	req.Header.Set("X-GitHub-Delivery", "delivery-comments-context")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	context := waitForGitHubIssueContext(t, db, "testorg/testrepo/42")
+	for _, want := range []string{"Main issue body", "First existing comment", "Second existing comment", "Third existing comment", "**Author:** @alice", "**Author:** @bob", "**Author:** @carol"} {
+		if !strings.Contains(context, want) {
+			t.Fatalf("CONTEXT.md missing %q:\n%s", want, context)
+		}
+	}
+}
+
+func TestGitHubIssuesWorkflowPollContextIncludesAllIssueComments(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
+	ghi := factorytest.NewMockGitHubIssues(t)
+	li := factorytest.NewMockLinear(t)
+
+	cfg := &types.HubConfig{
+		ClawToken: "test-claw-token",
+		Providers: map[string]types.ProviderConfig{
+			"noop": {Type: "noop"},
+		},
+	}
+	s, db := hub.NewTestServerWithConfig(t, cfg, ghi.URL, li.URL, "")
+	saveGitHubIssueLabeledWorkflowFixture(t, "workspace-a")
+
+	ghi.SetIssue("testorg/testrepo", 42, factorytest.IssueState{
+		Title:  "Test Issue",
+		Body:   "Main issue body",
+		State:  "open",
+		Labels: []string{"agent-ready"},
+	})
+	ghi.SetIssueComments("testorg/testrepo", 42, []factorytest.IssueCommentState{{
+		ID:        201,
+		Body:      "First poll comment",
+		User:      "alice",
+		CreatedAt: "2026-06-05T20:37:00Z",
+	}, {
+		ID:        202,
+		Body:      "Second poll comment",
+		User:      "bob",
+		CreatedAt: "2026-06-05T20:38:00Z",
+	}})
+
+	s.PollIntegrationsForTest()
+
+	context := waitForGitHubIssueContext(t, db, "testorg/testrepo/42")
+	for _, want := range []string{"Main issue body", "First poll comment", "Second poll comment", "**Author:** @alice", "**Author:** @bob"} {
+		if !strings.Contains(context, want) {
+			t.Fatalf("CONTEXT.md missing %q:\n%s", want, context)
+		}
+	}
+}
+
+func waitForGitHubIssueContext(t *testing.T, db *sql.DB, issueID string) string {
+	t.Helper()
+	var filesJSON string
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		err := db.QueryRow(`SELECT template_files FROM claws WHERE github_issue_id=? LIMIT 1`, issueID).Scan(&filesJSON)
+		if err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("query claw template files for %s: %v", issueID, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	var files map[string]string
+	if err := json.Unmarshal([]byte(filesJSON), &files); err != nil {
+		t.Fatalf("parse template files: %v", err)
+	}
+	return files["CONTEXT.md"]
 }
 
 func saveGitHubIssueWorkflowFixture(t *testing.T, workspace, secret string) {

--- a/pkg/hub/workspace_api_test.go
+++ b/pkg/hub/workspace_api_test.go
@@ -363,22 +363,38 @@ func TestWorkspaceWorkflowTriggerCreatesGitHubIssueWorkflowFromIssueNumber(t *te
 	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
 	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
 	var authHeaders []string
+	var requestPaths []string
 	ghi := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		authHeaders = append(authHeaders, r.Header.Get("Authorization"))
-		if r.Method != http.MethodGet || r.URL.Path != "/repos/testorg/testrepo/issues/42" {
+		requestPaths = append(requestPaths, r.URL.Path)
+		if r.Method != http.MethodGet {
 			http.NotFound(w, r)
 			return
 		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{
-			"number": 42,
-			"title": "Manual trigger issue",
-			"body": "Issue body",
-			"html_url": "https://github.com/testorg/testrepo/issues/42",
-			"state": "open",
-			"labels": [{"name": "dev-only"}],
-			"user": {"login": "testuser"}
-		}`))
+		switch r.URL.Path {
+		case "/repos/testorg/testrepo/issues/42":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"number": 42,
+				"title": "Manual trigger issue",
+				"body": "Issue body",
+				"html_url": "https://github.com/testorg/testrepo/issues/42",
+				"state": "open",
+				"labels": [{"name": "dev-only"}],
+				"user": {"login": "testuser"}
+			}`))
+		case "/repos/testorg/testrepo/issues/42/comments":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{
+				"id": 501,
+				"body": "First manual comment",
+				"html_url": "https://github.com/testorg/testrepo/issues/42#issuecomment-501",
+				"created_at": "2026-06-05T20:37:00Z",
+				"user": {"login": "manual-reviewer", "type": "User"}
+			}]`))
+		default:
+			http.NotFound(w, r)
+		}
 	}))
 	t.Cleanup(ghi.Close)
 	s, db := NewTestServerWithConfig(t, &types.HubConfig{
@@ -452,11 +468,14 @@ func TestWorkspaceWorkflowTriggerCreatesGitHubIssueWorkflowFromIssueNumber(t *te
 	if issueID != "testorg/testrepo/42" {
 		t.Fatalf("github_issue_id = %q, want testorg/testrepo/42", issueID)
 	}
-	if !strings.Contains(filesJSON, "Manual trigger issue") || !strings.Contains(filesJSON, "Issue body") {
+	if !strings.Contains(filesJSON, "Manual trigger issue") || !strings.Contains(filesJSON, "Issue body") || !strings.Contains(filesJSON, "First manual comment") {
 		t.Fatalf("template_files missing GitHub issue context: %s", filesJSON)
 	}
-	if len(authHeaders) != 1 || authHeaders[0] != "Bearer test-github-issues-token" {
-		t.Fatalf("GitHub issue fetch auth headers = %#v, want one bearer token", authHeaders)
+	if len(authHeaders) != 2 || authHeaders[0] != "Bearer test-github-issues-token" || authHeaders[1] != "Bearer test-github-issues-token" {
+		t.Fatalf("GitHub issue fetch auth headers = %#v, want two bearer token calls", authHeaders)
+	}
+	if strings.Join(requestPaths, ",") != "/repos/testorg/testrepo/issues/42,/repos/testorg/testrepo/issues/42/comments" {
+		t.Fatalf("GitHub issue fetch paths = %#v, want issue then comments", requestPaths)
 	}
 
 	req = httptest.NewRequest(http.MethodPost, "/api/workspaces/engineering/workflows/github-issue/trigger", strings.NewReader(`{"inputs":{"issue_number":42}}`))


### PR DESCRIPTION
## Summary

- Fetch GitHub issue comments when creating GitHub Issues claws.
- Render all fetched comments in `CONTEXT.md` with author, timestamp, URL, and body.
- Cover webhook, poller, manual trigger, pagination, and context rendering paths in tests.

Fixes #358