### PR TITLE
Preserve conversation history with activity summaries

### DIFF
--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1542,6 +1542,23 @@ func (s *Server) handleMessageTimeline(w http.ResponseWriter, r *http.Request, t
 	}
 
 	timeline := make([]types.HubMessage, 0, len(rows)*2)
+	firstCreated := rows[0].CreatedAt
+	hasOlderConversation, err := s.hasConversationBefore(clawID, tenantID, firstCreated)
+	if err != nil {
+		http.Error(w, "db error", http.StatusInternalServerError)
+		return
+	}
+	if !hasOlderConversation {
+		firstCursor := firstCreated.Format(time.RFC3339Nano)
+		summary, err := s.activitySummary(clawID, tenantID, nil, &firstCreated, "", firstCursor)
+		if err != nil {
+			http.Error(w, "db error", http.StatusInternalServerError)
+			return
+		}
+		if summary != nil {
+			timeline = append(timeline, *summary)
+		}
+	}
 	for i, msg := range rows {
 		timeline = append(timeline, msg)
 		lower := msg.CreatedAt
@@ -1581,6 +1598,10 @@ func (s *Server) handleMessageActivity(w http.ResponseWriter, r *http.Request, t
 	to := r.URL.Query().Get("to")
 	before := r.URL.Query().Get("before")
 	limit := parsePositiveLimit(r, 200, 500)
+	order := strings.ToLower(r.URL.Query().Get("order"))
+	if order != "desc" {
+		order = "asc"
+	}
 
 	query := `SELECT id, claw_id, tenant_id, role, content, COALESCE(format,''), created_at
 		FROM messages
@@ -1610,7 +1631,11 @@ func (s *Server) handleMessageActivity(w http.ResponseWriter, r *http.Request, t
 			args = append(args, before)
 		}
 	}
-	query += ` ORDER BY created_at ASC LIMIT ?`
+	if order == "desc" {
+		query += ` ORDER BY created_at DESC LIMIT ?`
+	} else {
+		query += ` ORDER BY created_at ASC LIMIT ?`
+	}
 	args = append(args, limit)
 
 	rows, err := s.db.Query(query, args...)
@@ -1697,6 +1722,18 @@ func (s *Server) queryConversationMessages(clawID, tenantID, before string, limi
 		msgs[i], msgs[j] = msgs[j], msgs[i]
 	}
 	return msgs, nil
+}
+
+func (s *Server) hasConversationBefore(clawID, tenantID string, before time.Time) (bool, error) {
+	query := `SELECT COUNT(*) FROM messages
+		WHERE claw_id = ? AND tenant_id = ? AND role != 'activity' AND created_at < ? ` + hiddenSystemMessagesSQL()
+	args := []interface{}{clawID, tenantID, before}
+	args = append(args, hiddenSystemMessagesArgs()...)
+	var count int
+	if err := s.db.QueryRow(query, args...).Scan(&count); err != nil {
+		return false, err
+	}
+	return count > 0, nil
 }
 
 func (s *Server) activitySummary(clawID, tenantID string, from, to *time.Time, fromCursor, toCursor string) (*types.HubMessage, error) {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1312,7 +1312,24 @@ func (s *Server) handleClawDetail(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	tenantID := tenantFromCtx(r)
-	clawID := strings.TrimPrefix(r.URL.Path, "/api/messages/")
+	path := strings.Trim(strings.TrimPrefix(r.URL.Path, "/api/messages/"), "/")
+	parts := strings.Split(path, "/")
+	clawID := parts[0]
+	if clawID == "" {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+	if len(parts) > 1 {
+		switch parts[1] {
+		case "timeline":
+			s.handleMessageTimeline(w, r, tenantID, clawID)
+		case "activity":
+			s.handleMessageActivity(w, r, tenantID, clawID)
+		default:
+			http.Error(w, "not found", http.StatusNotFound)
+		}
+		return
+	}
 	ghLoginMsg := githubLoginFromContext(r.Context())
 	var accessCfgMsg *types.AccessConfig
 	if ghLoginMsg != "" {
@@ -1470,6 +1487,290 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		msgs = []types.HubMessage{}
 	}
 	jsonOK(w, msgs)
+}
+
+type activitySummaryMeta struct {
+	Count int    `json:"count"`
+	From  string `json:"from"`
+	To    string `json:"to,omitempty"`
+}
+
+func hiddenSystemMessagesArgs() []interface{} {
+	return []interface{}{
+		wakeMessageMarker,
+		defaultWakeContent,
+		initialPlanWakeContent,
+		initialPlanRequiredMarker,
+		initialPlanAcceptedMarker,
+		initialPlanCorrectionSentMarker,
+	}
+}
+
+func hiddenSystemMessagesSQL() string {
+	return `AND NOT (role = 'system' AND content IN (?, ?, ?, ?, ?, ?))`
+}
+
+func (s *Server) handleMessageTimeline(w http.ResponseWriter, r *http.Request, tenantID, clawID string) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !s.canViewMessages(w, r, tenantID, clawID) {
+		return
+	}
+
+	limit := parsePositiveLimit(r, 50, 100)
+	before := r.URL.Query().Get("before")
+	rows, err := s.queryConversationMessages(clawID, tenantID, before, limit)
+	if err != nil {
+		http.Error(w, "db error", http.StatusInternalServerError)
+		return
+	}
+
+	if len(rows) == 0 {
+		summary, err := s.activitySummary(clawID, tenantID, nil, parseTimeCursor(before), "", before)
+		if err != nil {
+			http.Error(w, "db error", http.StatusInternalServerError)
+			return
+		}
+		if summary == nil {
+			jsonOK(w, []types.HubMessage{})
+			return
+		}
+		jsonOK(w, []types.HubMessage{*summary})
+		return
+	}
+
+	timeline := make([]types.HubMessage, 0, len(rows)*2)
+	for i, msg := range rows {
+		timeline = append(timeline, msg)
+		lower := msg.CreatedAt
+		lowerCursor := lower.Format(time.RFC3339Nano)
+		var upper *time.Time
+		upperCursor := ""
+		if i+1 < len(rows) {
+			nextCreated := rows[i+1].CreatedAt
+			upper = &nextCreated
+			upperCursor = nextCreated.Format(time.RFC3339Nano)
+		} else if before != "" {
+			upper = parseTimeCursor(before)
+			upperCursor = before
+		}
+		summary, err := s.activitySummary(clawID, tenantID, &lower, upper, lowerCursor, upperCursor)
+		if err != nil {
+			http.Error(w, "db error", http.StatusInternalServerError)
+			return
+		}
+		if summary != nil {
+			timeline = append(timeline, *summary)
+		}
+	}
+	jsonOK(w, timeline)
+}
+
+func (s *Server) handleMessageActivity(w http.ResponseWriter, r *http.Request, tenantID, clawID string) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !s.canViewMessages(w, r, tenantID, clawID) {
+		return
+	}
+
+	from := r.URL.Query().Get("from")
+	to := r.URL.Query().Get("to")
+	before := r.URL.Query().Get("before")
+	limit := parsePositiveLimit(r, 200, 500)
+
+	query := `SELECT id, claw_id, tenant_id, role, content, COALESCE(format,''), created_at
+		FROM messages
+		WHERE claw_id = ? AND tenant_id = ? AND role = 'activity'`
+	args := []interface{}{clawID, tenantID}
+	if from != "" {
+		query += ` AND created_at > ?`
+		if parsed := parseTimeCursor(from); parsed != nil {
+			args = append(args, *parsed)
+		} else {
+			args = append(args, from)
+		}
+	}
+	if to != "" {
+		query += ` AND created_at < ?`
+		if parsed := parseTimeCursor(to); parsed != nil {
+			args = append(args, *parsed)
+		} else {
+			args = append(args, to)
+		}
+	}
+	if before != "" {
+		query += ` AND created_at < ?`
+		if parsed := parseTimeCursor(before); parsed != nil {
+			args = append(args, *parsed)
+		} else {
+			args = append(args, before)
+		}
+	}
+	query += ` ORDER BY created_at ASC LIMIT ?`
+	args = append(args, limit)
+
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		http.Error(w, "db error", http.StatusInternalServerError)
+		return
+	}
+	defer rows.Close()
+	msgs, err := scanHubMessages(rows)
+	if err != nil {
+		http.Error(w, "db error", http.StatusInternalServerError)
+		return
+	}
+	if msgs == nil {
+		msgs = []types.HubMessage{}
+	}
+	jsonOK(w, msgs)
+}
+
+func parsePositiveLimit(r *http.Request, def, max int) int {
+	limit := def
+	if raw := r.URL.Query().Get("limit"); raw != "" {
+		if parsed, err := strconv.Atoi(raw); err == nil && parsed > 0 {
+			limit = parsed
+		}
+	}
+	if limit > max {
+		return max
+	}
+	return limit
+}
+
+func parseTimeCursor(raw string) *time.Time {
+	if raw == "" {
+		return nil
+	}
+	if parsed, err := time.Parse(time.RFC3339Nano, raw); err == nil {
+		return &parsed
+	}
+	if parsed, err := time.Parse(time.RFC3339, raw); err == nil {
+		return &parsed
+	}
+	return nil
+}
+
+func scanHubMessages(rows *sql.Rows) ([]types.HubMessage, error) {
+	var msgs []types.HubMessage
+	for rows.Next() {
+		var m types.HubMessage
+		if err := rows.Scan(&m.ID, &m.ClawID, &m.TenantID, &m.Role, &m.Content, &m.Format, &m.CreatedAt); err != nil {
+			return nil, err
+		}
+		msgs = append(msgs, m)
+	}
+	return msgs, rows.Err()
+}
+
+func (s *Server) queryConversationMessages(clawID, tenantID, before string, limit int) ([]types.HubMessage, error) {
+	query := `SELECT id, claw_id, tenant_id, role, content, COALESCE(format,''), created_at FROM messages
+		WHERE claw_id = ? AND tenant_id = ? AND role != 'activity' ` + hiddenSystemMessagesSQL()
+	args := []interface{}{clawID, tenantID}
+	args = append(args, hiddenSystemMessagesArgs()...)
+	if before != "" {
+		query += ` AND created_at < ?`
+		if parsed := parseTimeCursor(before); parsed != nil {
+			args = append(args, *parsed)
+		} else {
+			args = append(args, before)
+		}
+	}
+	query += ` ORDER BY created_at DESC LIMIT ?`
+	args = append(args, limit)
+
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	msgs, err := scanHubMessages(rows)
+	if err != nil {
+		return nil, err
+	}
+	for i, j := 0, len(msgs)-1; i < j; i, j = i+1, j-1 {
+		msgs[i], msgs[j] = msgs[j], msgs[i]
+	}
+	return msgs, nil
+}
+
+func (s *Server) activitySummary(clawID, tenantID string, from, to *time.Time, fromCursor, toCursor string) (*types.HubMessage, error) {
+	query := `SELECT COUNT(*), COALESCE(MIN(created_at), ''), COALESCE(MAX(created_at), '')
+		FROM messages WHERE claw_id = ? AND tenant_id = ? AND role = 'activity'`
+	args := []interface{}{clawID, tenantID}
+	if from != nil {
+		query += ` AND created_at > ?`
+		args = append(args, *from)
+	}
+	if to != nil {
+		query += ` AND created_at < ?`
+		args = append(args, *to)
+	}
+
+	var count int
+	var minCreated, maxCreated string
+	if err := s.db.QueryRow(query, args...).Scan(&count, &minCreated, &maxCreated); err != nil {
+		return nil, err
+	}
+	if count == 0 {
+		return nil, nil
+	}
+	meta := activitySummaryMeta{Count: count, From: fromCursor, To: toCursor}
+	data, err := json.Marshal(meta)
+	if err != nil {
+		return nil, err
+	}
+	createdAt := now()
+	if maxCreated != "" {
+		if parsed, err := time.Parse(time.RFC3339Nano, maxCreated); err == nil {
+			createdAt = parsed
+		}
+	}
+	return &types.HubMessage{
+		ID:        "activity-summary-" + uuid.NewSHA1(uuid.NameSpaceOID, []byte(clawID+"|"+fromCursor+"|"+toCursor)).String(),
+		ClawID:    clawID,
+		TenantID:  tenantID,
+		Role:      "activity_summary",
+		Content:   fmt.Sprintf("%d tool calls", count),
+		Format:    "activity_summary:" + string(data),
+		CreatedAt: createdAt,
+	}, nil
+}
+
+func (s *Server) canViewMessages(w http.ResponseWriter, r *http.Request, tenantID, clawID string) bool {
+	ghLoginMsg := githubLoginFromContext(r.Context())
+	if ghLoginMsg == "" {
+		return true
+	}
+	var accessCfgMsg *types.AccessConfig
+	s.mu.RLock()
+	if s.hubCfg.Auth != nil {
+		accessCfgMsg = s.hubCfg.Auth.Access
+	}
+	s.mu.RUnlock()
+
+	var tagsJSONMsg string
+	err := s.db.QueryRow(`SELECT COALESCE(tags,'[]') FROM claws WHERE id = ? AND tenant_id = ?`, clawID, tenantID).Scan(&tagsJSONMsg)
+	if err == sql.ErrNoRows {
+		http.Error(w, "not found", http.StatusNotFound)
+		return false
+	}
+	if err != nil {
+		http.Error(w, "db error", http.StatusInternalServerError)
+		return false
+	}
+	var clawTagsMsg []string
+	_ = json.Unmarshal([]byte(tagsJSONMsg), &clawTagsMsg)
+	if !canViewClaw(accessCfgMsg, ghLoginMsg, clawTagsMsg) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return false
+	}
+	return true
 }
 
 // ─── Claw WebSocket ───────────────────────────────────────────────────────────

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"testing/fstest"
@@ -798,6 +799,131 @@ func TestMessageActivityEndpointExpandsSummaryRange(t *testing.T) {
 	if len(msgs) != 2 || msgs[0].ID != "activity-0" || msgs[1].ID != "activity-1" {
 		t.Fatalf("activity messages = %#v, want first two", msgs)
 	}
+}
+
+func TestMessageTimelinePreservesDisplayedStateAcrossActivityRuns(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, nil, "", "", "")
+	_, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, tags, created_at) VALUES(?,?,?,?,?)`,
+		"claw-1", "test-tenant-id", "claw 1", `[]`, time.Date(2026, 6, 6, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := time.Date(2026, 6, 6, 12, 0, 0, 0, time.UTC)
+	offset := 0
+	insertMessage := func(id, role, content, format string) {
+		t.Helper()
+		offset++
+		_, err := db.Exec(
+			`INSERT INTO messages(id,claw_id,tenant_id,role,content,format,created_at) VALUES(?,?,?,?,?,?,?)`,
+			id, "claw-1", "test-tenant-id", role, content, format, base.Add(time.Duration(offset)*time.Second),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	insertActivityRun := func(prefix string, count int) {
+		t.Helper()
+		for i := 0; i < count; i++ {
+			insertMessage(fmt.Sprintf("%s-%03d", prefix, i), "activity", "tool", `activity:{"kind":"tool","tool":"exec"}`)
+		}
+	}
+
+	insertMessage("hub-1", "hub", "Injected proceed message", "")
+	insertActivityRun("activity-a", 35)
+	insertMessage("claw-1", "claw", "Assistant message 1", "")
+	insertActivityRun("activity-b", 65)
+	insertMessage("claw-2", "claw", "Assistant message 2", "")
+	insertActivityRun("activity-c", 150)
+	insertMessage("claw-3", "claw", "Assistant message 3", "")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/messages/claw-1/timeline", nil)
+	req = req.WithContext(context.WithValue(req.Context(), ctxTenantKey{}, "test-tenant-id"))
+	rec := httptest.NewRecorder()
+
+	s.handleMessages(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+	var timeline []types.HubMessage
+	if err := json.NewDecoder(rec.Body).Decode(&timeline); err != nil {
+		t.Fatal(err)
+	}
+
+	type expectedItem struct {
+		role    string
+		id      string
+		content string
+		count   int
+	}
+	want := []expectedItem{
+		{role: "hub", id: "hub-1", content: "Injected proceed message"},
+		{role: "activity_summary", count: 35},
+		{role: "claw", id: "claw-1", content: "Assistant message 1"},
+		{role: "activity_summary", count: 65},
+		{role: "claw", id: "claw-2", content: "Assistant message 2"},
+		{role: "activity_summary", count: 150},
+		{role: "claw", id: "claw-3", content: "Assistant message 3"},
+	}
+	if len(timeline) != len(want) {
+		t.Fatalf("timeline len = %d, want %d: %#v", len(timeline), len(want), timeline)
+	}
+
+	for i, wantItem := range want {
+		got := timeline[i]
+		if got.Role != wantItem.role {
+			t.Fatalf("timeline[%d].role = %q, want %q; item=%#v", i, got.Role, wantItem.role, got)
+		}
+		if wantItem.id != "" && got.ID != wantItem.id {
+			t.Fatalf("timeline[%d].id = %q, want %q", i, got.ID, wantItem.id)
+		}
+		if wantItem.content != "" && got.Content != wantItem.content {
+			t.Fatalf("timeline[%d].content = %q, want %q", i, got.Content, wantItem.content)
+		}
+		if wantItem.count > 0 {
+			meta := decodeActivitySummaryMeta(t, got)
+			if meta.Count != wantItem.count {
+				t.Fatalf("timeline[%d] summary count = %d, want %d", i, meta.Count, wantItem.count)
+			}
+			expanded := getActivityMessagesForSummary(t, s, got)
+			if len(expanded) != wantItem.count {
+				t.Fatalf("timeline[%d] expanded activity len = %d, want %d", i, len(expanded), wantItem.count)
+			}
+		}
+	}
+}
+
+func decodeActivitySummaryMeta(t *testing.T, msg types.HubMessage) activitySummaryMeta {
+	t.Helper()
+	if !strings.HasPrefix(msg.Format, "activity_summary:") {
+		t.Fatalf("summary format = %q, want activity_summary prefix", msg.Format)
+	}
+	var meta activitySummaryMeta
+	if err := json.Unmarshal([]byte(strings.TrimPrefix(msg.Format, "activity_summary:")), &meta); err != nil {
+		t.Fatalf("decode summary meta: %v", err)
+	}
+	return meta
+}
+
+func getActivityMessagesForSummary(t *testing.T, s *Server, msg types.HubMessage) []types.HubMessage {
+	t.Helper()
+	meta := decodeActivitySummaryMeta(t, msg)
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/messages/%s/activity?from=%s&to=%s&limit=500", msg.ClawID, url.QueryEscape(meta.From), url.QueryEscape(meta.To)), nil)
+	req = req.WithContext(context.WithValue(req.Context(), ctxTenantKey{}, msg.TenantID))
+	rec := httptest.NewRecorder()
+
+	s.handleMessages(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+	var msgs []types.HubMessage
+	if err := json.NewDecoder(rec.Body).Decode(&msgs); err != nil {
+		t.Fatal(err)
+	}
+	return msgs
 }
 
 func TestInitialPlanWakePromptRequiresVisiblePlanBeforeWork(t *testing.T) {

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -3,11 +3,13 @@ package hub
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"testing/fstest"
+	"time"
 
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
@@ -707,6 +709,94 @@ func TestHandleMessagesFiltersWakeMarkers(t *testing.T) {
 	}
 	if len(msgs) != 1 || msgs[0].ID != "user-1" {
 		t.Fatalf("expected only user message, got %#v", msgs)
+	}
+}
+
+func TestMessageTimelineSummarizesActivityWithoutCrowdingConversation(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, nil, "", "", "")
+	_, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, tags, created_at) VALUES(?,?,?,?,?)`,
+		"claw-1", "test-tenant-id", "claw 1", `[]`, time.Date(2026, 6, 6, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := time.Date(2026, 6, 6, 12, 0, 0, 0, time.UTC)
+	insertMessage := func(id, role, content string, offsetSeconds int) {
+		t.Helper()
+		_, err := db.Exec(
+			`INSERT INTO messages(id,claw_id,tenant_id,role,content,format,created_at) VALUES(?,?,?,?,?,?,?)`,
+			id, "claw-1", "test-tenant-id", role, content, "", base.Add(time.Duration(offsetSeconds)*time.Second),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	insertMessage("user-1", "user", "start", 1)
+	for i := 0; i < 120; i++ {
+		insertMessage(fmt.Sprintf("activity-%03d", i), "activity", "tool", 2+i)
+	}
+	insertMessage("claw-1", "claw", "done", 200)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/messages/claw-1/timeline", nil)
+	req = req.WithContext(context.WithValue(req.Context(), ctxTenantKey{}, "test-tenant-id"))
+	rec := httptest.NewRecorder()
+
+	s.handleMessages(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+	var msgs []types.HubMessage
+	if err := json.NewDecoder(rec.Body).Decode(&msgs); err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 3 {
+		t.Fatalf("timeline len = %d, want 3: %#v", len(msgs), msgs)
+	}
+	if msgs[0].ID != "user-1" || msgs[1].Role != "activity_summary" || msgs[2].ID != "claw-1" {
+		t.Fatalf("timeline did not preserve conversation with summary: %#v", msgs)
+	}
+	if !strings.Contains(msgs[1].Format, `"count":120`) {
+		t.Fatalf("summary format missing count: %s", msgs[1].Format)
+	}
+}
+
+func TestMessageActivityEndpointExpandsSummaryRange(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, nil, "", "", "")
+	_, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, tags, created_at) VALUES(?,?,?,?,?)`,
+		"claw-1", "test-tenant-id", "claw 1", `[]`, time.Date(2026, 6, 6, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := time.Date(2026, 6, 6, 12, 0, 0, 0, time.UTC)
+	for i := 0; i < 3; i++ {
+		_, err := db.Exec(
+			`INSERT INTO messages(id,claw_id,tenant_id,role,content,format,created_at) VALUES(?,?,?,?,?,?,?)`,
+			fmt.Sprintf("activity-%d", i), "claw-1", "test-tenant-id", "activity", "tool", `activity:{"kind":"tool"}`, base.Add(time.Duration(i+1)*time.Second),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/messages/claw-1/activity?limit=2", nil)
+	req = req.WithContext(context.WithValue(req.Context(), ctxTenantKey{}, "test-tenant-id"))
+	rec := httptest.NewRecorder()
+
+	s.handleMessages(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+	var msgs []types.HubMessage
+	if err := json.NewDecoder(rec.Body).Decode(&msgs); err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 2 || msgs[0].ID != "activity-0" || msgs[1].ID != "activity-1" {
+		t.Fatalf("activity messages = %#v, want first two", msgs)
 	}
 }
 

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -801,6 +801,93 @@ func TestMessageActivityEndpointExpandsSummaryRange(t *testing.T) {
 	}
 }
 
+func TestMessageActivityEndpointCanReturnNewestActivities(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, nil, "", "", "")
+	_, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, tags, created_at) VALUES(?,?,?,?,?)`,
+		"claw-1", "test-tenant-id", "claw 1", `[]`, time.Date(2026, 6, 6, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := time.Date(2026, 6, 6, 12, 0, 0, 0, time.UTC)
+	for i := 0; i < 6; i++ {
+		_, err := db.Exec(
+			`INSERT INTO messages(id,claw_id,tenant_id,role,content,format,created_at) VALUES(?,?,?,?,?,?,?)`,
+			fmt.Sprintf("activity-%d", i), "claw-1", "test-tenant-id", "activity", "tool", `activity:{"kind":"tool"}`, base.Add(time.Duration(i+1)*time.Second),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/messages/claw-1/activity?limit=2&order=desc", nil)
+	req = req.WithContext(context.WithValue(req.Context(), ctxTenantKey{}, "test-tenant-id"))
+	rec := httptest.NewRecorder()
+
+	s.handleMessages(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+	var msgs []types.HubMessage
+	if err := json.NewDecoder(rec.Body).Decode(&msgs); err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 2 || msgs[0].ID != "activity-5" || msgs[1].ID != "activity-4" {
+		t.Fatalf("activity messages = %#v, want newest two in descending order", msgs)
+	}
+}
+
+func TestMessageTimelineIncludesActivityBeforeFirstConversationMessage(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, nil, "", "", "")
+	_, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, tags, created_at) VALUES(?,?,?,?,?)`,
+		"claw-1", "test-tenant-id", "claw 1", `[]`, time.Date(2026, 6, 6, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := time.Date(2026, 6, 6, 12, 0, 0, 0, time.UTC)
+	for i := 0; i < 4; i++ {
+		_, err := db.Exec(
+			`INSERT INTO messages(id,claw_id,tenant_id,role,content,format,created_at) VALUES(?,?,?,?,?,?,?)`,
+			fmt.Sprintf("activity-%d", i), "claw-1", "test-tenant-id", "activity", "tool", `activity:{"kind":"tool"}`, base.Add(time.Duration(i+1)*time.Second),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	_, err = db.Exec(
+		`INSERT INTO messages(id,claw_id,tenant_id,role,content,format,created_at) VALUES(?,?,?,?,?,?,?)`,
+		"hub-1", "claw-1", "test-tenant-id", "hub", "Injected proceed message", "", base.Add(10*time.Second),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/messages/claw-1/timeline", nil)
+	req = req.WithContext(context.WithValue(req.Context(), ctxTenantKey{}, "test-tenant-id"))
+	rec := httptest.NewRecorder()
+
+	s.handleMessages(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+	var msgs []types.HubMessage
+	if err := json.NewDecoder(rec.Body).Decode(&msgs); err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 2 || msgs[0].Role != "activity_summary" || msgs[1].ID != "hub-1" {
+		t.Fatalf("timeline = %#v, want pre-message activity summary then hub message", msgs)
+	}
+	meta := decodeActivitySummaryMeta(t, msgs[0])
+	if meta.Count != 4 {
+		t.Fatalf("pre-message summary count = %d, want 4", meta.Count)
+	}
+}
+
 func TestMessageTimelinePreservesDisplayedStateAcrossActivityRuns(t *testing.T) {
 	s, db := NewTestServerWithConfig(t, nil, "", "", "")
 	_, err := db.Exec(

--- a/web/components/conversation-view.tsx
+++ b/web/components/conversation-view.tsx
@@ -20,7 +20,7 @@ import {
 } from "@dnd-kit/sortable"
 import { CSS } from "@dnd-kit/utilities"
 import { MarkdownContent } from "@/components/markdown-content"
-import { COLOR_CLASSES } from "@/lib/mappers"
+import { COLOR_CLASSES, mapApiMessage } from "@/lib/mappers"
 import { useWindowedMessages } from "@/hooks/use-windowed-messages"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -28,8 +28,8 @@ import { Badge } from "@/components/ui/badge"
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog"
 import { cn } from "@/lib/utils"
-import type { Claw, Message, ClawStatus } from "@/lib/types"
-import { getTerminalWsUrl, fetchClawPRs, type ClawPR } from "@/lib/api"
+import type { ActivitySummary as ActivitySummaryMeta, Claw, Message, ClawStatus } from "@/lib/types"
+import { getTerminalWsUrl, fetchActivityMessages, fetchClawPRs, type ClawPR } from "@/lib/api"
 import { buildAttachmentsFooter, splitAttachmentsFooter, formatBytes, type ParsedAttachment } from "@/lib/attachments"
 import { useAttachments } from "@/hooks/use-attachments"
 import { AttachmentChip } from "@/components/attachment-chip"
@@ -523,6 +523,7 @@ function ClawBoardCard({
                       item={item}
                       expanded={Boolean(expandedActivityGroups[item.id])}
                       onToggle={() => toggleActivityGroup(item.id)}
+                      clawId={claw.id}
                       variant="card"
                     />
                   )
@@ -943,7 +944,7 @@ function formatActivityAge(timestamp: Date, now: number): string {
 
 type ConversationItem =
   | { type: "message"; message: Message }
-  | { type: "activity-summary"; id: string; messages: Message[] }
+  | { type: "activity-summary"; id: string; messages: Message[]; summary?: ActivitySummaryMeta }
 
 function compactActivityRuns(messages: Message[]): ConversationItem[] {
   const items: ConversationItem[] = []
@@ -969,6 +970,11 @@ function compactActivityRuns(messages: Message[]): ConversationItem[] {
   }
 
   for (const message of messages) {
+    if (message.role === "activity_summary") {
+      flush()
+      items.push({ type: "activity-summary", id: message.id, messages: [], summary: message.activitySummary })
+      continue
+    }
     if (message.role === "activity") {
       run.push(message)
       continue
@@ -1008,7 +1014,10 @@ function coalesceActivityMessages(messages: Message[]): Message[] {
   return messages.filter((message) => !(isRunningActivity(message) && terminalKeys.has(activityGroupKey(message))))
 }
 
-function activitySummaryLabel(messages: Message[]): string {
+function activitySummaryLabel(messages: Message[], countOverride?: number): string {
+  if (countOverride && countOverride > 0) {
+    return `${countOverride} earlier tool call${countOverride === 1 ? "" : "s"}`
+  }
   const toolCount = messages.filter((message) => message.activity?.kind === "tool").length
   const noun = toolCount === messages.length ? "tool call" : "activity update"
   return `${messages.length} earlier ${noun}${messages.length === 1 ? "" : "s"}`
@@ -1108,24 +1117,45 @@ function ActivitySummary({
   item,
   expanded,
   onToggle,
+  clawId,
   variant = "full",
 }: {
   item: Extract<ConversationItem, { type: "activity-summary" }>
   expanded: boolean
   onToggle: () => void
+  clawId: string
   variant?: "card" | "full"
 }) {
-  const visibleMessages = coalesceActivityMessages(item.messages)
+  const [loadedMessages, setLoadedMessages] = useState<Message[] | null>(null)
+  const [loading, setLoading] = useState(false)
+  const visibleMessages = coalesceActivityMessages([...(item.messages || []), ...(loadedMessages || [])])
+  const countOverride = item.summary?.count
+  const handleToggle = () => {
+    onToggle()
+    if (expanded || !item.summary || loadedMessages || loading) return
+    setLoading(true)
+    fetchActivityMessages(clawId, {
+      from: item.summary.from,
+      to: item.summary.to,
+      limit: Math.max(200, Math.min(item.summary.count || 200, 500)),
+    })
+      .then((apiMsgs) => setLoadedMessages(apiMsgs.map(mapApiMessage)))
+      .catch(console.warn)
+      .finally(() => setLoading(false))
+  }
   if (variant === "card") {
     return (
       <div className="space-y-1">
         <button
           type="button"
-          onClick={onToggle}
+          onClick={handleToggle}
           className="w-full rounded border border-border/50 bg-muted/20 px-1.5 py-1 text-left text-[10px] text-muted-foreground hover:bg-muted/35"
         >
-          {expanded ? "Hide" : "Show"} {activitySummaryLabel(visibleMessages)}
+          {expanded ? "Hide" : "Show"} {activitySummaryLabel(visibleMessages, countOverride)}
         </button>
+        {expanded && loading && (
+          <div className="px-1.5 text-[10px] text-muted-foreground">Loading tool calls...</div>
+        )}
         {expanded && visibleMessages.map((message) => (
           <ActivityRow key={message.id} message={message} variant="card" />
         ))}
@@ -1139,13 +1169,16 @@ function ActivitySummary({
         <div className="flex-1 h-px bg-border/50" />
         <button
           type="button"
-          onClick={onToggle}
+          onClick={handleToggle}
           className="rounded border border-border/60 bg-muted/25 px-2.5 py-1 text-xs text-muted-foreground hover:bg-muted/40 hover:text-foreground"
         >
-          {expanded ? "Hide" : "Show"} {activitySummaryLabel(visibleMessages)}
+          {expanded ? "Hide" : "Show"} {activitySummaryLabel(visibleMessages, countOverride)}
         </button>
         <div className="flex-1 h-px bg-border/50" />
       </div>
+      {expanded && loading && (
+        <div className="text-center text-xs text-muted-foreground">Loading tool calls...</div>
+      )}
       {expanded && visibleMessages.map((message) => (
         <ActivityRow key={message.id} message={message} />
       ))}
@@ -1461,6 +1494,7 @@ function ClawChatView({
                   item={item}
                   expanded={Boolean(expandedActivityGroups[item.id])}
                   onToggle={() => toggleActivityGroup(item.id)}
+                  clawId={claw.id}
                 />
               ) : (
                 <MessageBubble key={item.message.id} message={item.message} clawId={claw.id} clawName={claw.name} clawColor={claw.color} />

--- a/web/components/conversation-view.tsx
+++ b/web/components/conversation-view.tsx
@@ -1130,16 +1130,25 @@ function ActivitySummary({
   const [loading, setLoading] = useState(false)
   const visibleMessages = coalesceActivityMessages([...(item.messages || []), ...(loadedMessages || [])])
   const countOverride = item.summary?.count
+  const loadedCount = loadedMessages?.length ?? item.messages.length
+  const isPartial = Boolean(countOverride && loadedMessages && loadedCount < countOverride)
   const handleToggle = () => {
     onToggle()
     if (expanded || !item.summary || loadedMessages || loading) return
+    const summaryCount = item.summary.count || 0
+    const limit = Math.max(200, Math.min(summaryCount || 200, 500))
+    const newestFirst = summaryCount > limit
     setLoading(true)
     fetchActivityMessages(clawId, {
       from: item.summary.from,
       to: item.summary.to,
-      limit: Math.max(200, Math.min(item.summary.count || 200, 500)),
+      limit,
+      order: newestFirst ? "desc" : "asc",
     })
-      .then((apiMsgs) => setLoadedMessages(apiMsgs.map(mapApiMessage)))
+      .then((apiMsgs) => {
+        const mapped = apiMsgs.map(mapApiMessage)
+        setLoadedMessages(newestFirst ? mapped.reverse() : mapped)
+      })
       .catch(console.warn)
       .finally(() => setLoading(false))
   }
@@ -1155,6 +1164,11 @@ function ActivitySummary({
         </button>
         {expanded && loading && (
           <div className="px-1.5 text-[10px] text-muted-foreground">Loading tool calls...</div>
+        )}
+        {expanded && isPartial && (
+          <div className="px-1.5 text-[10px] text-muted-foreground">
+            Showing latest {loadedCount} of {countOverride} tool calls
+          </div>
         )}
         {expanded && visibleMessages.map((message) => (
           <ActivityRow key={message.id} message={message} variant="card" />
@@ -1178,6 +1192,11 @@ function ActivitySummary({
       </div>
       {expanded && loading && (
         <div className="text-center text-xs text-muted-foreground">Loading tool calls...</div>
+      )}
+      {expanded && isPartial && (
+        <div className="text-center text-xs text-muted-foreground">
+          Showing latest {loadedCount} of {countOverride} tool calls
+        </div>
       )}
       {expanded && visibleMessages.map((message) => (
         <ActivityRow key={message.id} message={message} />

--- a/web/hooks/use-hub.ts
+++ b/web/hooks/use-hub.ts
@@ -4,7 +4,7 @@ import { useState, useEffect, useRef, useCallback } from "react"
 import type { AgentActivity, Claw, Message, CreateClawRequest } from "@/lib/types"
 import {
   fetchClaws,
-  fetchMessages,
+  fetchMessageTimeline,
   sendMessage as apiSendMessage,
   createClaw as apiCreateClaw,
   killClaw as apiKillClaw,
@@ -250,7 +250,7 @@ export function useHub(selectedClawId: string | null): HubState {
 
   const loadMessages = useCallback(async (clawId: string) => {
     try {
-      const apiMsgs = await fetchMessages(clawId)
+      const apiMsgs = await fetchMessageTimeline(clawId)
       const msgs = apiMsgs.map(mapApiMessage)
       
       // Capture existing IDs before updating so we can diff outside the updater.

--- a/web/hooks/use-windowed-messages.ts
+++ b/web/hooks/use-windowed-messages.ts
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState, useRef, useCallback, useEffect } from "react"
-import { fetchMessages } from "@/lib/api"
+import { fetchMessageTimeline } from "@/lib/api"
 import { mapApiMessage } from "@/lib/mappers"
 import type { Message } from "@/lib/types"
 
@@ -12,7 +12,8 @@ const ROLE_ORDER: Record<Message["role"], number> = {
   hub: 1,
   claw: 2,
   activity: 3,
-  system: 4,
+  activity_summary: 4,
+  system: 5,
 }
 
 interface UseWindowedMessagesOptions {
@@ -45,7 +46,7 @@ export function useWindowedMessages({ clawId, liveMessages }: UseWindowedMessage
     setHistoricalMsgs([])
     setHasOlder(false)
 
-    fetchMessages(clawId)
+    fetchMessageTimeline(clawId, { limit: PAGE_SIZE })
       .then((apiMsgs) => {
         const msgs = apiMsgs.map(mapApiMessage)
         setHistoricalMsgs(msgs)
@@ -66,7 +67,7 @@ export function useWindowedMessages({ clawId, liveMessages }: UseWindowedMessage
     const prevHeight = el?.scrollHeight ?? 0
 
     try {
-      const apiMsgs = await fetchMessages(clawId, { before: oldestTimestamp.current })
+      const apiMsgs = await fetchMessageTimeline(clawId, { before: oldestTimestamp.current, limit: PAGE_SIZE })
       const older = apiMsgs.map(mapApiMessage)
 
       if (older.length === 0) {

--- a/web/hooks/use-windowed-messages.ts
+++ b/web/hooks/use-windowed-messages.ts
@@ -16,6 +16,22 @@ const ROLE_ORDER: Record<Message["role"], number> = {
   system: 5,
 }
 
+function conversationMessages(messages: Message[]): Message[] {
+  return messages.filter((message) => message.role !== "activity" && message.role !== "activity_summary")
+}
+
+function oldestConversationCursor(messages: Message[]): string | null {
+  const oldest = conversationMessages(messages)[0]
+  if (!oldest) return null
+  return oldest.timestamp instanceof Date ? oldest.timestamp.toISOString() : String(oldest.timestamp)
+}
+
+function hasOlderConversationPage(messages: Message[], pageSize: number): boolean {
+  const conversations = conversationMessages(messages)
+  if (conversations.length < pageSize) return false
+  return messages[0]?.role !== "activity_summary"
+}
+
 interface UseWindowedMessagesOptions {
   clawId: string
   liveMessages: Message[] // streaming/new messages from websocket
@@ -50,10 +66,8 @@ export function useWindowedMessages({ clawId, liveMessages }: UseWindowedMessage
       .then((apiMsgs) => {
         const msgs = apiMsgs.map(mapApiMessage)
         setHistoricalMsgs(msgs)
-        if (msgs.length > 0) {
-          oldestTimestamp.current = msgs[0].timestamp instanceof Date ? msgs[0].timestamp.toISOString() : String(msgs[0].timestamp)
-        }
-        setHasOlder(apiMsgs.length >= PAGE_SIZE)
+        oldestTimestamp.current = oldestConversationCursor(msgs)
+        setHasOlder(hasOlderConversationPage(msgs, PAGE_SIZE))
       })
       .catch(console.warn)
   }, [clawId])
@@ -75,10 +89,8 @@ export function useWindowedMessages({ clawId, liveMessages }: UseWindowedMessage
         return
       }
 
-      setHasOlder(apiMsgs.length >= PAGE_SIZE)
-      if (older.length > 0) {
-        oldestTimestamp.current = older[0].timestamp instanceof Date ? older[0].timestamp.toISOString() : String(older[0].timestamp)
-      }
+      setHasOlder(hasOlderConversationPage(older, PAGE_SIZE))
+      oldestTimestamp.current = oldestConversationCursor(older)
 
       setHistoricalMsgs((prev) => {
         const combined = [...older, ...prev]

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -123,12 +123,13 @@ export async function fetchMessageTimeline(clawId: string, opts?: { before?: str
   return apiFetch<ApiMessage[]>(`/api/messages/${clawId}/timeline${qs}`)
 }
 
-export async function fetchActivityMessages(clawId: string, opts: { from?: string; to?: string; before?: string; limit?: number }): Promise<ApiMessage[]> {
+export async function fetchActivityMessages(clawId: string, opts: { from?: string; to?: string; before?: string; limit?: number; order?: "asc" | "desc" }): Promise<ApiMessage[]> {
   const params = new URLSearchParams()
   if (opts.from) params.set('from', opts.from)
   if (opts.to) params.set('to', opts.to)
   if (opts.before) params.set('before', opts.before)
   if (opts.limit) params.set('limit', String(opts.limit))
+  if (opts.order) params.set('order', opts.order)
   const qs = params.toString() ? '?' + params.toString() : ''
   return apiFetch<ApiMessage[]>(`/api/messages/${clawId}/activity${qs}`)
 }

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -115,6 +115,24 @@ export async function fetchMessages(clawId: string, opts?: { before?: string; af
   return apiFetch<ApiMessage[]>(`/api/messages/${clawId}${qs}`)
 }
 
+export async function fetchMessageTimeline(clawId: string, opts?: { before?: string; limit?: number }): Promise<ApiMessage[]> {
+  const params = new URLSearchParams()
+  if (opts?.before) params.set('before', opts.before)
+  if (opts?.limit) params.set('limit', String(opts.limit))
+  const qs = params.toString() ? '?' + params.toString() : ''
+  return apiFetch<ApiMessage[]>(`/api/messages/${clawId}/timeline${qs}`)
+}
+
+export async function fetchActivityMessages(clawId: string, opts: { from?: string; to?: string; before?: string; limit?: number }): Promise<ApiMessage[]> {
+  const params = new URLSearchParams()
+  if (opts.from) params.set('from', opts.from)
+  if (opts.to) params.set('to', opts.to)
+  if (opts.before) params.set('before', opts.before)
+  if (opts.limit) params.set('limit', String(opts.limit))
+  const qs = params.toString() ? '?' + params.toString() : ''
+  return apiFetch<ApiMessage[]>(`/api/messages/${clawId}/activity${qs}`)
+}
+
 
 export async function sendMessage(clawId: string, content: string): Promise<ApiMessage> {
   return apiFetch<ApiMessage>(`/api/messages/${clawId}`, {

--- a/web/lib/mappers.ts
+++ b/web/lib/mappers.ts
@@ -122,17 +122,24 @@ export function mapApiClaw(
 
 export function mapApiMessage(apiMsg: ApiMessage): Message {
   let activity
+  let activitySummary
   if (apiMsg.role === "activity" && apiMsg.format?.startsWith("activity:")) {
     try {
       activity = JSON.parse(apiMsg.format.slice("activity:".length))
+    } catch {}
+  }
+  if (apiMsg.role === "activity_summary" && apiMsg.format?.startsWith("activity_summary:")) {
+    try {
+      activitySummary = JSON.parse(apiMsg.format.slice("activity_summary:".length))
     } catch {}
   }
   return {
     id: apiMsg.id,
     role: apiMsg.role,
     content: apiMsg.content,
-    format: apiMsg.format?.startsWith("activity:") ? undefined : apiMsg.format,
+    format: apiMsg.format?.startsWith("activity:") || apiMsg.format?.startsWith("activity_summary:") ? undefined : apiMsg.format,
     activity,
+    activitySummary,
     timestamp: new Date(apiMsg.created_at),
     claw_id: apiMsg.claw_id,
     tenant_id: apiMsg.tenant_id,

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -29,14 +29,21 @@ export interface Claw {
 
 export interface Message {
   id: string
-  role: "user" | "claw" | "system" | "hub" | "activity"
+  role: "user" | "claw" | "system" | "hub" | "activity" | "activity_summary"
   content: string
   format?: string // "pre" = preserve whitespace
   timestamp: Date
   activity?: AgentActivity
+  activitySummary?: ActivitySummary
   // API fields
   claw_id?: string
   tenant_id?: string
+}
+
+export interface ActivitySummary {
+  count: number
+  from?: string
+  to?: string
 }
 
 export interface AgentActivity {
@@ -76,7 +83,7 @@ export interface ApiMessage {
   id: string
   claw_id: string
   tenant_id: string
-  role: "user" | "claw" | "hub" | "activity"
+  role: "user" | "claw" | "hub" | "activity" | "activity_summary"
   content: string
   format?: string
   created_at: string


### PR DESCRIPTION
## Summary
- add a timeline endpoint that pages conversation messages while representing activity runs as summary items
- add an activity detail endpoint for lazy expansion of summarized tool calls
- move dashboard/full history loading to timeline units so activity rows do not crowd out user/claw messages
- add tests covering activity-heavy history and activity expansion

Closes #362

## Tests
- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./...
- npm run build (from web/)