### PR TITLE
Preserve stream segment order after refresh

### DIFF
--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -81,6 +81,7 @@ type clawConn struct {
 	gatewayUnhealthyCount int             // consecutive unhealthy heartbeats
 	streamingBuf          strings.Builder // accumulates chunks for current in-flight response
 	streamingMsgID        string          // pre-assigned message ID for the current stream
+	streamingSplit        bool            // true once activity has split this turn into multiple persisted segments
 	streamingStartedAt    time.Time       // when the current streaming turn started (zero if not streaming)
 	streamingTimeoutSent  bool            // true once the 12-min timeout message has been injected this turn
 	contextWarningSent    bool            // true once the context-nearly-full warning has been injected this turn
@@ -120,9 +121,34 @@ func (cc *clawConn) isBusyLocked() bool {
 func (cc *clawConn) finishTurnLocked() {
 	cc.streamingMsgID = ""
 	cc.streamingBuf.Reset()
+	cc.streamingSplit = false
 	cc.streamingStartedAt = time.Time{}
 	cc.streamingTimeoutSent = false
 	cc.contextWarningSent = false
+}
+
+func (s *Server) flushStreamingSegment(clawID, tenantID string, cc *clawConn) error {
+	cc.mu.Lock()
+	if cc.streamingBuf.Len() == 0 {
+		cc.mu.Unlock()
+		return nil
+	}
+	msgID := cc.streamingMsgID
+	if msgID == "" {
+		msgID = uuid.New().String()
+	}
+	content := cc.streamingBuf.String()
+	cc.streamingMsgID = ""
+	cc.streamingBuf.Reset()
+	cc.streamingSplit = true
+	cc.mu.Unlock()
+
+	_, err := s.db.Exec(
+		`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at) VALUES(?,?,?,?,?,?)
+		 ON CONFLICT(id) DO UPDATE SET content=excluded.content`,
+		msgID, clawID, tenantID, "claw", content, now(),
+	)
+	return err
 }
 
 type userConn struct {
@@ -2142,6 +2168,9 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				}
 			} else if msg.Type == "agent_activity" {
 				if activity, payload, ok := normalizeAgentActivityPayload(msg.Payload); ok {
+					if err := s.flushStreamingSegment(clawID, tenantID, cc); err != nil {
+						log.Printf("[agent_activity] flush streaming segment for %s: %v", clawID[:8], err)
+					}
 					if isBusyAgentActivity(activity) {
 						cc.mu.Lock()
 						if cc.streamingStartedAt.IsZero() {
@@ -2220,10 +2249,16 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				// Use the outer cc (this goroutine's connection), not a fresh lookup.
 				// If the claw reconnected, a new handleClawWS goroutine handles the new cc.
 				cc.mu.Lock()
+				persistContent := hm.Content
+				skipPersist := false
 				if cc.streamingMsgID != "" {
 					hm.ID = cc.streamingMsgID
+					if cc.streamingBuf.Len() > 0 {
+						persistContent = cc.streamingBuf.String()
+					}
 				} else {
 					hm.ID = uuid.New().String()
+					skipPersist = cc.streamingSplit
 				}
 				cc.finishTurnLocked()
 				cc.mu.Unlock()
@@ -2243,11 +2278,13 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 					s.drainPendingCheckpoint(clawID)
 					continue
 				}
-				_, _ = s.db.Exec(
-					`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at) VALUES(?,?,?,?,?,?)
-					 ON CONFLICT(id) DO UPDATE SET content=excluded.content`,
-					hm.ID, hm.ClawID, hm.TenantID, hm.Role, hm.Content, hm.CreatedAt,
-				)
+				if !skipPersist && strings.TrimSpace(persistContent) != "" {
+					_, _ = s.db.Exec(
+						`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at) VALUES(?,?,?,?,?,?)
+						 ON CONFLICT(id) DO UPDATE SET content=excluded.content`,
+						hm.ID, hm.ClawID, hm.TenantID, hm.Role, persistContent, hm.CreatedAt,
+					)
+				}
 				s.broadcastToUsers(tenantID, types.WSMessage{Type: "message", Payload: hm})
 				s.handleInitialPlanResponse(clawID, tenantID, hm.Content)
 				// Evaluate pipeline triggers for non-[DONE] messages

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -982,6 +982,88 @@ func TestMessageTimelinePreservesDisplayedStateAcrossActivityRuns(t *testing.T) 
 	}
 }
 
+func TestStreamingSegmentsPersistAroundActivityForRefreshTimeline(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, nil, "", "", "")
+	_, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, tags, created_at) VALUES(?,?,?,?,?)`,
+		"claw-1", "test-tenant-id", "claw 1", `[]`, time.Date(2026, 6, 6, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := time.Date(2026, 6, 6, 12, 0, 0, 0, time.UTC)
+	cc := &clawConn{id: "claw-1", tenantID: "test-tenant-id"}
+	persistSegment := func(id, content string, offsetSeconds int) {
+		t.Helper()
+		cc.mu.Lock()
+		cc.streamingMsgID = id
+		cc.streamingBuf.WriteString(content)
+		cc.mu.Unlock()
+		if err := s.flushStreamingSegment("claw-1", "test-tenant-id", cc); err != nil {
+			t.Fatal(err)
+		}
+		_, err := db.Exec(`UPDATE messages SET created_at=? WHERE id=?`, base.Add(time.Duration(offsetSeconds)*time.Second), id)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	insertActivity := func(id string, offsetSeconds int) {
+		t.Helper()
+		_, err := db.Exec(
+			`INSERT INTO messages(id,claw_id,tenant_id,role,content,format,created_at) VALUES(?,?,?,?,?,?,?)`,
+			id, "claw-1", "test-tenant-id", "activity", "exec", `activity:{"kind":"tool","tool":"exec"}`, base.Add(time.Duration(offsetSeconds)*time.Second),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	persistSegment("seg-1", "Assistant segment 1", 1)
+	insertActivity("activity-1", 2)
+	persistSegment("seg-2", "Assistant segment 2", 3)
+	insertActivity("activity-2", 4)
+	_, err = db.Exec(
+		`INSERT INTO messages(id,claw_id,tenant_id,role,content,format,created_at) VALUES(?,?,?,?,?,?,?)`,
+		"seg-3", "claw-1", "test-tenant-id", "claw", "Assistant segment 3", "", base.Add(5*time.Second),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/messages/claw-1/timeline", nil)
+	req = req.WithContext(context.WithValue(req.Context(), ctxTenantKey{}, "test-tenant-id"))
+	rec := httptest.NewRecorder()
+
+	s.handleMessages(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+	var timeline []types.HubMessage
+	if err := json.NewDecoder(rec.Body).Decode(&timeline); err != nil {
+		t.Fatal(err)
+	}
+	if len(timeline) != 5 {
+		t.Fatalf("timeline len = %d, want 5: %#v", len(timeline), timeline)
+	}
+	wantRoles := []string{"claw", "activity_summary", "claw", "activity_summary", "claw"}
+	wantIDs := []string{"seg-1", "", "seg-2", "", "seg-3"}
+	for i := range wantRoles {
+		if timeline[i].Role != wantRoles[i] {
+			t.Fatalf("timeline[%d].role = %q, want %q; timeline=%#v", i, timeline[i].Role, wantRoles[i], timeline)
+		}
+		if wantIDs[i] != "" && timeline[i].ID != wantIDs[i] {
+			t.Fatalf("timeline[%d].id = %q, want %q", i, timeline[i].ID, wantIDs[i])
+		}
+		if timeline[i].Role == "activity_summary" {
+			meta := decodeActivitySummaryMeta(t, timeline[i])
+			if meta.Count != 1 {
+				t.Fatalf("timeline[%d] activity count = %d, want 1", i, meta.Count)
+			}
+		}
+	}
+}
+
 func decodeActivitySummaryMeta(t *testing.T, msg types.HubMessage) activitySummaryMeta {
 	t.Helper()
 	if !strings.HasPrefix(msg.Format, "activity_summary:") {


### PR DESCRIPTION
## Summary
- flush streamed assistant text into persisted message segments before activity/tool-call rows are recorded
- prevent final full-response payloads from overwriting those split segments after activity boundaries
- add a refresh-timeline regression test for assistant/tool-call/assistant ordering

## Tests
- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./...
- npm run build (from web/)