### PR TITLE
Add public branding endpoint

### DIFF
--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -219,7 +219,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/auth/config", s.handleAuthConfig)               // public — no auth required
 	mux.HandleFunc("/api/auth/github/client-id", s.handleGitHubClientID) // public
 	mux.HandleFunc("/api/auth/github/exchange", s.handleGitHubOAuthExchange)
-	mux.HandleFunc("/api/branding", s.handleBranding)
+	mux.HandleFunc("/api/branding", s.handleBranding) // public — no auth required
 	mux.HandleFunc("/api/hub-config", s.withWebAdminAuth(s.handleHubConfig))
 	mux.HandleFunc("/api/settings", s.withWebAdminAuth(s.handleSettings))
 	mux.HandleFunc("/api/settings/status", s.withWebAdminAuth(s.handleSettingsStatus))

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -219,6 +219,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/auth/config", s.handleAuthConfig)               // public — no auth required
 	mux.HandleFunc("/api/auth/github/client-id", s.handleGitHubClientID) // public
 	mux.HandleFunc("/api/auth/github/exchange", s.handleGitHubOAuthExchange)
+	mux.HandleFunc("/api/branding", s.handleBranding)
 	mux.HandleFunc("/api/hub-config", s.withWebAdminAuth(s.handleHubConfig))
 	mux.HandleFunc("/api/settings", s.withWebAdminAuth(s.handleSettings))
 	mux.HandleFunc("/api/settings/status", s.withWebAdminAuth(s.handleSettingsStatus))
@@ -594,6 +595,20 @@ func (s *Server) handleAuthConfig(w http.ResponseWriter, r *http.Request) {
 	jsonOK(w, map[string]bool{
 		"github_oauth_enabled":  githubOAuthEnabled,
 		"password_auth_enabled": passwordAuthEnabled,
+	})
+}
+
+func (s *Server) handleBranding(w http.ResponseWriter, r *http.Request) {
+	s.mu.RLock()
+	var appName, logoURL string
+	if s.hubCfg.Branding != nil {
+		appName = s.hubCfg.Branding.AppName
+		logoURL = s.hubCfg.Branding.LogoURL
+	}
+	s.mu.RUnlock()
+	jsonOK(w, map[string]string{
+		"appName": appName,
+		"logoUrl": logoURL,
 	})
 }
 

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -1193,6 +1193,38 @@ func TestWebAdminAuthRequiresAccessAdminForGitHubSession(t *testing.T) {
 	}
 }
 
+func TestBrandingEndpointIsPublicAndDoesNotExposeToken(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{
+		Token: "hub-token",
+		Branding: &types.BrandingConfig{
+			AppName: "Customer Claw",
+			LogoURL: "https://example.com/logo.png",
+		},
+	}, "", "", "")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/branding", nil)
+	rec := httptest.NewRecorder()
+
+	s.handleBranding(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+	var body map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if body["appName"] != "Customer Claw" {
+		t.Fatalf("appName = %q", body["appName"])
+	}
+	if body["logoUrl"] != "https://example.com/logo.png" {
+		t.Fatalf("logoUrl = %q", body["logoUrl"])
+	}
+	if _, ok := body["token"]; ok {
+		t.Fatalf("branding response exposed token: %#v", body)
+	}
+}
+
 func TestBroadcastToUsersFiltersGitHubSessionsByClawTags(t *testing.T) {
 	s, _ := NewTestServerWithConfig(t, &types.HubConfig{
 		Auth: &types.AuthConfig{

--- a/web/hooks/use-branding.ts
+++ b/web/hooks/use-branding.ts
@@ -2,7 +2,6 @@
 
 import { useState, useEffect } from "react"
 import { getHubUrl } from "@/lib/hub-url"
-import { getHubToken } from "@/lib/auth-storage"
 
 interface Branding {
   appName: string
@@ -12,25 +11,36 @@ interface Branding {
 const DEFAULT: Branding = { appName: "ElasticClaw", logoUrl: "" }
 
 let cached: Branding | null = null
+let pending: Promise<Branding> | null = null
+
+function loadBranding(): Promise<Branding> {
+  if (cached) return Promise.resolve(cached)
+  if (pending) return pending
+
+  const hubUrl = getHubUrl()
+  pending = fetch(`${hubUrl}/api/branding`)
+    .then(r => r.ok ? r.json() : DEFAULT)
+    .then(d => {
+      const branding: Branding = {
+        appName: d.appName || DEFAULT.appName,
+        logoUrl: d.logoUrl || DEFAULT.logoUrl,
+      }
+      cached = branding
+      return branding
+    })
+    .catch(() => DEFAULT)
+    .finally(() => {
+      pending = null
+    })
+  return pending
+}
 
 export function useBranding(): Branding {
   const [branding, setBranding] = useState<Branding>(cached ?? DEFAULT)
 
   useEffect(() => {
     if (cached) return
-    const hubUrl = getHubUrl()
-    const token = typeof window !== "undefined" ? getHubToken() || "" : ""
-    fetch(`${hubUrl}/api/hub-config`, { headers: { Authorization: `Bearer ${token}` } })
-      .then(r => r.json())
-      .then(d => {
-        const b: Branding = {
-          appName: d.appName || "ElasticClaw",
-          logoUrl: d.logoUrl || "",
-        }
-        cached = b
-        setBranding(b)
-      })
-      .catch(() => {})
+    loadBranding().then(setBranding)
   }, [])
 
   return branding

--- a/web/hooks/use-branding.ts
+++ b/web/hooks/use-branding.ts
@@ -19,16 +19,21 @@ function loadBranding(): Promise<Branding> {
 
   const hubUrl = getHubUrl()
   pending = fetch(`${hubUrl}/api/branding`)
-    .then(r => r.ok ? r.json() : DEFAULT)
+    .then(r => r.ok ? r.json() : null)
     .then(d => {
+      // Branding is non-critical; cache the fallback for this page lifetime
+      // so shared layout consumers do not repeatedly retry a failed endpoint.
       const branding: Branding = {
-        appName: d.appName || DEFAULT.appName,
-        logoUrl: d.logoUrl || DEFAULT.logoUrl,
+        appName: d?.appName || DEFAULT.appName,
+        logoUrl: d?.logoUrl || DEFAULT.logoUrl,
       }
       cached = branding
       return branding
     })
-    .catch(() => DEFAULT)
+    .catch(() => {
+      cached = DEFAULT
+      return DEFAULT
+    })
     .finally(() => {
       pending = null
     })


### PR DESCRIPTION
## Summary
- add public /api/branding for non-secret app name and logo metadata
- update useBranding to stop calling admin-gated /api/hub-config
- dedupe concurrent branding fetches across shared page consumers

## Tests
- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./pkg/hub -run TestBrandingEndpointIsPublicAndDoesNotExposeToken
- npm run build (from web/)