### PR TITLE
Prioritize workflow [DONE] triggers before legacy completion

### DIFF
--- a/pkg/hub/done_signal_test.go
+++ b/pkg/hub/done_signal_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/elasticclaw/elasticclaw/pkg/types"
@@ -248,6 +249,63 @@ func TestHandleClawDoneSignal_BlockedByFailedRequiredGate(t *testing.T) {
 	}
 	if msgCount != 1 {
 		t.Fatalf("expected 1 user message, got %d", msgCount)
+	}
+}
+
+func TestHandleClawDoneSignal_PipelineDoneTriggerDoesNotRequirePRURL(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+	s.hubCfg.Factories = []*types.FactoryConfig{
+		{
+			Name:     "faster_apps",
+			Template: "elasticclaw",
+			PipelineYAML: `
+stages:
+  - id: working
+    label: Working
+    entry: true
+  - id: android_validation
+    label: Android Validation
+    triggers:
+      - message_contains: "[DONE]"
+    on_enter:
+      inject: "Android validation started"
+`,
+		},
+	}
+
+	const clawID = "claw-done-pipeline"
+	_, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, template, status, tags, linear_issue_id, pipeline_stage, created_at) VALUES(?,?,?,?,?,?,?,?,datetime('now'))`,
+		clawID, "test-tenant-id", "NEXT-257", "elasticclaw", "connected", `["factory:faster_apps"]`, "NEXT-257", "working",
+	)
+	if err != nil {
+		t.Fatalf("insert claw: %v", err)
+	}
+
+	s.handleClawDoneSignal(clawID, "[DONE]")
+
+	var stage string
+	if err := db.QueryRow(`SELECT pipeline_stage FROM claws WHERE id=?`, clawID).Scan(&stage); err != nil {
+		t.Fatalf("select pipeline_stage: %v", err)
+	}
+	if stage != "android_validation" {
+		t.Fatalf("pipeline_stage = %q, want android_validation", stage)
+	}
+
+	var noPRWarnings int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND role='user' AND content LIKE '%no PR URLs%'`, clawID).Scan(&noPRWarnings); err != nil {
+		t.Fatalf("count no-pr warnings: %v", err)
+	}
+	if noPRWarnings != 0 {
+		t.Fatalf("expected no PR URL warning to be suppressed, got %d", noPRWarnings)
+	}
+
+	var injected string
+	if err := db.QueryRow(`SELECT content FROM messages WHERE claw_id=? ORDER BY created_at DESC LIMIT 1`, clawID).Scan(&injected); err != nil {
+		t.Fatalf("select injected message: %v", err)
+	}
+	if !strings.Contains(injected, "Android validation started") {
+		t.Fatalf("injected message = %q, want validation inject", injected)
 	}
 }
 

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -1090,6 +1090,12 @@ func (s *Server) handleClawDoneSignal(clawID, rawMessage string) {
 	// Expected format: [DONE] https://github.com/org/repo/pull/1 https://...
 	prURLs := extractDonePRURLs(rawMessage)
 
+	if pipelineCtx, stage, ok := s.pipelineStageForMessageContains(clawID, rawMessage); ok {
+		s.trackDoneSignal(pipelineCtx.Name(), issueID, clawID, len(prURLs))
+		s.transitionPipelineStageWithContext(clawID, *stage, pipelineCtx)
+		return
+	}
+
 	// Validate PRs via GitHub API if we have a token.
 	ghToken := s.resolveGitHubToken()
 	if ghToken != "" {

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -1260,16 +1260,17 @@ func (s *Server) transitionPipelineStage(clawID string, stage pipeline.Stage, fa
 // checkPipelineMessageTriggers evaluates pipeline triggers against a claw message
 // and transitions to the matching stage if found. Returns true if a transition occurred.
 func (s *Server) checkPipelineMessageTriggers(clawID, message string) bool {
-	ctx, ok := s.findPipelineContextForClaw(clawID)
+	ctx, stage, ok := s.pipelineStageForMessageContains(clawID, message)
 	if !ok {
-		return false
-	}
-	pl := parsePipelineForContext(ctx)
-	if pl == nil {
-		return false
-	}
-	stage := pl.StageForMessageContains(message)
-	if stage == nil {
+		ctx, ok = s.findPipelineContextForClaw(clawID)
+		if !ok {
+			return false
+		}
+		pl := parsePipelineForContext(ctx)
+		if pl == nil {
+			return false
+		}
+		stage = nil
 		// Also check output_matches triggers against current pipeline outputs.
 		// Only evaluate if the claw has not already visited this stage, to
 		// prevent persistent DB state from re-triggering backwards regressions
@@ -1284,6 +1285,27 @@ func (s *Server) checkPipelineMessageTriggers(clawID, message string) bool {
 		return false
 	}
 	return s.transitionPipelineStageWithContext(clawID, *stage, ctx)
+}
+
+func (s *Server) hasPipelineMessageContainsTrigger(clawID, message string) bool {
+	_, _, ok := s.pipelineStageForMessageContains(clawID, message)
+	return ok
+}
+
+func (s *Server) pipelineStageForMessageContains(clawID, message string) (pipelineContext, *pipeline.Stage, bool) {
+	ctx, ok := s.findPipelineContextForClaw(clawID)
+	if !ok {
+		return pipelineContext{}, nil, false
+	}
+	pl := parsePipelineForContext(ctx)
+	if pl == nil {
+		return pipelineContext{}, nil, false
+	}
+	stage := pl.StageForMessageContains(message)
+	if stage == nil {
+		return pipelineContext{}, nil, false
+	}
+	return ctx, stage, true
 }
 
 func (s *Server) transitionPipelineStageWithContext(clawID string, stage pipeline.Stage, ctx pipelineContext) bool {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/elasticclaw/elasticclaw/internal/webui"
 
+	"github.com/elasticclaw/elasticclaw/pkg/hub/pipeline"
 	daytona "github.com/elasticclaw/elasticclaw/pkg/provider/daytona"
 	exedevProvider "github.com/elasticclaw/elasticclaw/pkg/provider/exedev"
 	replicatedpkg "github.com/elasticclaw/elasticclaw/pkg/provider/replicated"
@@ -2269,10 +2270,16 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				// [DONE] trigger, let it handle that signal instead of the
 				// legacy factory PR-URL completion path below.
 				pipelineHandledDone := false
+				var pipelineDoneCtx pipelineContext
+				var pipelineDoneStage *pipeline.Stage
 				if strings.Contains(hm.Content, "[DONE]") {
-					pipelineHandledDone = s.hasPipelineMessageContainsTrigger(clawID, hm.Content)
+					pipelineDoneCtx, pipelineDoneStage, pipelineHandledDone = s.pipelineStageForMessageContains(clawID, hm.Content)
 				}
-				if !strings.Contains(hm.Content, "[DONE]") || pipelineHandledDone {
+				if pipelineHandledDone {
+					prURLs := extractDonePRURLs(hm.Content)
+					s.trackDoneSignal(pipelineDoneCtx.Name(), pipelineDoneCtx.IssueID, clawID, len(prURLs))
+					go s.transitionPipelineStageWithContext(clawID, *pipelineDoneStage, pipelineDoneCtx)
+				} else if !strings.Contains(hm.Content, "[DONE]") {
 					go s.checkPipelineMessageTriggers(clawID, hm.Content)
 				}
 				// Clear typing indicator now that response is complete

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2265,8 +2265,14 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				)
 				s.broadcastToUsers(tenantID, types.WSMessage{Type: "message", Payload: hm})
 				s.handleInitialPlanResponse(clawID, tenantID, hm.Content)
-				// Evaluate pipeline triggers for non-[DONE] messages
-				if !strings.Contains(hm.Content, "[DONE]") {
+				// Evaluate pipeline triggers. If a pipeline explicitly owns a
+				// [DONE] trigger, let it handle that signal instead of the
+				// legacy factory PR-URL completion path below.
+				pipelineHandledDone := false
+				if strings.Contains(hm.Content, "[DONE]") {
+					pipelineHandledDone = s.hasPipelineMessageContainsTrigger(clawID, hm.Content)
+				}
+				if !strings.Contains(hm.Content, "[DONE]") || pipelineHandledDone {
 					go s.checkPipelineMessageTriggers(clawID, hm.Content)
 				}
 				// Clear typing indicator now that response is complete
@@ -2284,7 +2290,9 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 							log.Printf("[checkpoint] done request for %s failed: %v", shortID(clawID), err)
 						}
 					}()
-					go s.handleClawDoneSignal(clawID, hm.Content)
+					if !pipelineHandledDone {
+						go s.handleClawDoneSignal(clawID, hm.Content)
+					}
 				}
 				// Check for [TERMINATE] signal - allows claw to manage its own lifecycle
 				if strings.Contains(hm.Content, "[TERMINATE]") {

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"github.com/elasticclaw/elasticclaw/pkg/types"
+	"nhooyr.io/websocket"
+	"nhooyr.io/websocket/wsjson"
 )
 
 func TestSanitizeBootstrapOutputDropsExportedEnvironment(t *testing.T) {
@@ -979,6 +981,104 @@ func TestMessageTimelinePreservesDisplayedStateAcrossActivityRuns(t *testing.T) 
 				t.Fatalf("timeline[%d] expanded activity len = %d, want %d", i, len(expanded), wantItem.count)
 			}
 		}
+	}
+}
+
+func TestClawWSPipelineDoneTriggerTracksAnalytics(t *testing.T) {
+	ready := true
+	clawID := "claw-pipeline-done-ws"
+	cfg := &types.HubConfig{
+		Token:     "test-token",
+		ClawToken: "claw-token",
+		Factories: []*types.FactoryConfig{
+			{
+				Name:     "faster_apps",
+				Template: "elasticclaw",
+				PipelineYAML: `
+stages:
+  - id: working
+    label: Working
+    entry: true
+  - id: android_validation
+    label: Android Validation
+    triggers:
+      - message_contains: "[DONE]"
+    on_enter:
+      inject: "Android validation started"
+`,
+			},
+		},
+	}
+	s, db := NewTestServerWithConfig(t, cfg, "", "", "")
+	_, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, template, status, tags, linear_issue_id, pipeline_stage, created_at) VALUES(?,?,?,?,?,?,?,?,datetime('now'))`,
+		clawID, "test-tenant-id", "NEXT-257", "elasticclaw", "connected", `["factory:faster_apps"]`, "NEXT-257", "working",
+	)
+	if err != nil {
+		t.Fatalf("insert claw: %v", err)
+	}
+	ts := httptest.NewServer(s.Handler())
+	t.Cleanup(ts.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	clawWS, _, err := websocket.Dial(ctx, "ws"+strings.TrimPrefix(ts.URL, "http")+"/claw/ws", nil)
+	if err != nil {
+		t.Fatalf("dial claw ws: %v", err)
+	}
+	t.Cleanup(func() { _ = clawWS.Close(websocket.StatusNormalClosure, "done") })
+	if err := wsjson.Write(ctx, clawWS, types.WSMessage{
+		Type: "register",
+		Payload: types.RegisterPayload{
+			ClawID:       clawID,
+			Name:         "NEXT-257",
+			Template:     "elasticclaw",
+			Token:        "claw-token",
+			GatewayReady: &ready,
+		},
+	}); err != nil {
+		t.Fatalf("register claw: %v", err)
+	}
+	var registered types.WSMessage
+	if err := wsjson.Read(ctx, clawWS, &registered); err != nil {
+		t.Fatalf("read registration ack: %v", err)
+	}
+	if registered.Type != "registered" {
+		t.Fatalf("registration ack type = %q, want registered", registered.Type)
+	}
+	if err := wsjson.Write(ctx, clawWS, types.WSMessage{
+		Type: "message",
+		Payload: types.HubMessage{
+			Content: "[DONE]",
+		},
+	}); err != nil {
+		t.Fatalf("write done message: %v", err)
+	}
+
+	var stage string
+	var analyticsCount int
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		_ = db.QueryRow(`SELECT pipeline_stage FROM claws WHERE id=?`, clawID).Scan(&stage)
+		_ = db.QueryRow(`SELECT COUNT(*) FROM factory_analytics WHERE claw_id=? AND issue_id=? AND factory_name=? AND action='done_signal'`, clawID, "NEXT-257", "factory:faster_apps").Scan(&analyticsCount)
+		if stage == "android_validation" && analyticsCount == 1 {
+			break
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	if stage != "android_validation" {
+		t.Fatalf("pipeline_stage = %q, want android_validation", stage)
+	}
+	if analyticsCount != 1 {
+		t.Fatalf("done_signal analytics count = %d, want 1", analyticsCount)
+	}
+
+	var noPRWarnings int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND role='user' AND content LIKE '%no PR URLs%'`, clawID).Scan(&noPRWarnings); err != nil {
+		t.Fatalf("count no-pr warnings: %v", err)
+	}
+	if noPRWarnings != 0 {
+		t.Fatalf("expected no PR URL warning to be suppressed, got %d", noPRWarnings)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Let explicit pipeline `message_contains: "[DONE]"` triggers run instead of skipping them in the websocket message path
- Suppress the legacy factory PR-URL completion handler when a pipeline owns the `[DONE]` signal
- Add a regression test covering a bare `[DONE]` that advances to an Android validation stage without injecting the no-PR warning

## Finding
The CodeBuild stage did not run because `handleClawWS` only evaluated pipeline message triggers for non-`[DONE]` messages. The same message then fell through to `handleClawDoneSignal`, which validates legacy factory completion and injected the "no PR URLs" prompt before the workflow could transition to `android_validation`.

## Tests
- `env GOCACHE=/private/tmp/elasticclaw-go-build go test ./pkg/hub`
- `env GOCACHE=/private/tmp/elasticclaw-go-build go test ./...`