### PR TITLE
Preserve workflow gates and parse noisy run outputs

### DIFF
--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -450,12 +450,9 @@ func (s *Server) persistPipelineOutput(clawID, stageID, outputName string, resul
 		return
 	}
 	var parsedJSON string
-	if strings.TrimSpace(result.Stdout) != "" {
-		var parsed map[string]interface{}
-		if err := json.Unmarshal([]byte(result.Stdout), &parsed); err == nil {
-			b, _ := json.Marshal(parsed)
-			parsedJSON = string(b)
-		}
+	if parsed, ok := parsePipelineOutputJSON(result.Stdout); ok {
+		b, _ := json.Marshal(parsed)
+		parsedJSON = string(b)
 	}
 	if parsedJSON == "" {
 		parsedJSON = "{}"
@@ -476,6 +473,30 @@ func (s *Server) persistPipelineOutput(clawID, stageID, outputName string, resul
 	} else {
 		log.Printf("[pipeline] persisted output %q for claw %s stage %s exit=%d", outputName, clawID[:8], stageID, result.ExitCode)
 	}
+}
+
+func parsePipelineOutputJSON(stdout string) (map[string]interface{}, bool) {
+	parse := func(s string) (map[string]interface{}, bool) {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			return nil, false
+		}
+		var parsed map[string]interface{}
+		if err := json.Unmarshal([]byte(s), &parsed); err != nil {
+			return nil, false
+		}
+		return parsed, true
+	}
+	if parsed, ok := parse(stdout); ok {
+		return parsed, true
+	}
+	lines := strings.Split(stdout, "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if parsed, ok := parse(lines[i]); ok {
+			return parsed, true
+		}
+	}
+	return nil, false
 }
 
 // loadPipelineOutputs returns all persisted outputs for a claw as a map of

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -4,11 +4,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
 	"net/url"
+	"os"
+	osexec "os/exec"
 	"path/filepath"
 	"strings"
 	"text/template"
@@ -430,9 +433,33 @@ func (s *Server) executePipelineRunAction(clawID string, action pipeline.RunActi
 	case "failing":
 		// Test-only provider that always fails workflow run actions
 		return &pipelineRunResult{ExitCode: 1, Stderr: "failing provider simulated run failure"}, fmt.Errorf("failing provider simulated run failure")
+	case "testexec":
+		// Test-only provider used by integration tests to exercise real run
+		// commands without provisioning a sandbox.
+		if os.Getenv("ELASTICCLAW_TESTEXEC_PROVIDER") == "" {
+			return &pipelineRunResult{ExitCode: 1, Stderr: "testexec provider requires ELASTICCLAW_TESTEXEC_PROVIDER=1"}, fmt.Errorf("testexec provider disabled")
+		}
+		return executeLocalPipelineRun(ctx, workspaceCommand)
 	default:
 		return nil, fmt.Errorf("provider %q does not support workflow run actions", providerName)
 	}
+}
+
+func executeLocalPipelineRun(ctx context.Context, command string) (*pipelineRunResult, error) {
+	cmd := osexec.CommandContext(ctx, "bash", "-lc", command)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	exitCode := 0
+	if err != nil {
+		exitCode = 1
+		var exitErr *osexec.ExitError
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		}
+	}
+	return &pipelineRunResult{ExitCode: exitCode, Stdout: stdout.String(), Stderr: stderr.String()}, err
 }
 
 func (s *Server) executeReplicatedPipelineRun(user, host, command string, timeout time.Duration) (*pipelineRunResult, error) {

--- a/pkg/hub/pipeline_runner_test.go
+++ b/pkg/hub/pipeline_runner_test.go
@@ -191,6 +191,51 @@ func TestPersistPipelineOutputNonJSON(t *testing.T) {
 	}
 }
 
+func TestParsePipelineOutputJSONUsesLastJSONLine(t *testing.T) {
+	stdout := `$ git rev-parse --is-inside-work-tree
+$ git status --porcelain
+{"reason": "next_mobile matches main", "source_dir": "/home/daytona/.openclaw/workspace/next_mobile", "status": "skipped"}
+`
+	parsed, ok := parsePipelineOutputJSON(stdout)
+	if !ok {
+		t.Fatal("expected noisy stdout with final JSON line to parse")
+	}
+	if parsed["status"] != "skipped" {
+		t.Fatalf("status = %v, want skipped", parsed["status"])
+	}
+	if parsed["reason"] != "next_mobile matches main" {
+		t.Fatalf("reason = %v, want next_mobile matches main", parsed["reason"])
+	}
+}
+
+func TestPersistPipelineOutputNoisyJSON(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+
+	const clawID = "claw-output-noisy-json"
+	_, err := s.db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, template, status, pipeline_stage, created_at) VALUES(?,?,?,?,?,?,datetime('now'))`,
+		clawID, "test-tenant-id", "test-claw", "base", "connected", "",
+	)
+	if err != nil {
+		t.Fatalf("insert claw: %v", err)
+	}
+
+	s.persistPipelineOutput(clawID, "stage-1", "android_validation", &pipelineRunResult{
+		ExitCode: 0,
+		Stdout: `$ git status --porcelain
+{"status":"skipped","reason":"next_mobile matches main"}`,
+	})
+
+	outputs := s.loadPipelineOutputs(clawID)
+	validation, ok := outputs["android_validation"]
+	if !ok {
+		t.Fatal("expected android_validation in outputs")
+	}
+	if validation["status"] != "skipped" {
+		t.Fatalf("status = %v, want skipped", validation["status"])
+	}
+}
+
 func TestPersistPipelineOutputOverwrite(t *testing.T) {
 	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
 

--- a/pkg/hub/testdata/workflows/deterministic-gate-pass.yaml
+++ b/pkg/hub/testdata/workflows/deterministic-gate-pass.yaml
@@ -1,0 +1,40 @@
+name: deterministic-gate-pass
+entry: entry
+
+stages:
+  - id: entry
+    label: Entry
+    entry: true
+    on_enter:
+      inject: |
+        Starting deterministic validation. Say [DONE] to run the validator.
+
+  - id: validation
+    label: Validation
+    triggers:
+      - message_contains: "[DONE]"
+    on_enter:
+      run:
+        command: "python3 scripts/deterministic_gate.py --mode pass"
+        output: validation
+    gate:
+      output: validation
+      pass:
+        path: status
+        values:
+          - clean
+      fail:
+        path: status
+        values:
+          - issues
+      required: true
+
+  - id: complete
+    label: Complete
+    triggers:
+      - gate_result:
+          stage: validation
+          verdict: pass
+    on_enter:
+      inject: |
+        No issues found. Workflow complete.

--- a/pkg/hub/testdata/workflows/deterministic-gate-retry.yaml
+++ b/pkg/hub/testdata/workflows/deterministic-gate-retry.yaml
@@ -1,0 +1,51 @@
+name: deterministic-gate-retry
+entry: entry
+
+stages:
+  - id: entry
+    label: Entry
+    entry: true
+    on_enter:
+      inject: |
+        Starting deterministic validation. Say [DONE] to run the validator.
+
+  - id: validation
+    label: Validation
+    triggers:
+      - message_contains: "[DONE]"
+      - message_contains: "[RETRY]"
+    on_enter:
+      run:
+        command: "python3 scripts/deterministic_gate.py --mode retry"
+        output: validation
+    gate:
+      output: validation
+      pass:
+        path: status
+        values:
+          - clean
+      fail:
+        path: status
+        values:
+          - issues
+      required: true
+
+  - id: fix
+    label: Fix
+    triggers:
+      - gate_result:
+          stage: validation
+          verdict: fail
+    on_enter:
+      inject: |
+        1 issue found. Apply the deterministic fix and say [RETRY].
+
+  - id: complete
+    label: Complete
+    triggers:
+      - gate_result:
+          stage: validation
+          verdict: pass
+    on_enter:
+      inject: |
+        No issues found. Workflow complete.

--- a/pkg/hub/workflow_harness_integration_test.go
+++ b/pkg/hub/workflow_harness_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -34,8 +35,9 @@ func newWorkflowHarnessServerWithProvider(t *testing.T, fixtureName, provider st
 	li := factorytest.NewMockLinear(t)
 
 	providers := map[string]types.ProviderConfig{
-		"noop":    {Type: "noop"},
-		"failing": {Type: "failing"},
+		"noop":     {Type: "noop"},
+		"failing":  {Type: "failing"},
+		"testexec": {Type: "testexec"},
 	}
 
 	cfg := &types.HubConfig{
@@ -89,6 +91,81 @@ func triggerFactoryWebhook(t *testing.T, ts *factorytest.TestServer, issueID, pr
 	}
 	if resp.StatusCode != 200 {
 		t.Fatalf("webhook post failed: status=%d", resp.StatusCode)
+	}
+}
+
+func prepareDeterministicGateWorkspace(t *testing.T) {
+	t.Helper()
+	home := t.TempDir()
+	workspaceDir := filepath.Join(home, ".openclaw", "workspace")
+	scriptPath := filepath.Join(workspaceDir, "scripts", "deterministic_gate.py")
+	writeHarnessFile(t, scriptPath, `#!/usr/bin/env python3
+import argparse
+import json
+from pathlib import Path
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--mode", choices=["pass", "retry"], required=True)
+args = parser.parse_args()
+
+print("$ deterministic validator")
+
+if args.mode == "retry":
+    state = Path(".deterministic-gate-state")
+    if not state.exists():
+        state.write_text("failed-once")
+        print(json.dumps({"message": "1 issue found", "status": "issues"}))
+    else:
+        print(json.dumps({"message": "No issues found", "status": "clean"}))
+else:
+    print(json.dumps({"message": "No issues found", "status": "clean"}))
+`)
+	t.Setenv("HOME", home)
+	t.Setenv("ELASTICCLAW_TESTEXEC_PROVIDER", "1")
+}
+
+func writeHarnessFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func useTestExecProvider(t *testing.T, ts *factorytest.TestServer, clawID string) {
+	t.Helper()
+	_, err := ts.DB.Exec(`UPDATE claws SET provider='testexec', provider_id=? WHERE id=?`, "testexec-"+clawID[:8], clawID)
+	if err != nil {
+		t.Fatalf("set testexec provider: %v", err)
+	}
+}
+
+func assertGateVerdict(t *testing.T, ts *factorytest.TestServer, clawID, stageID, want string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		var verdict string
+		err := ts.DB.QueryRow(`SELECT verdict FROM pipeline_gate_results WHERE claw_id=? AND stage_id=?`, clawID, stageID).Scan(&verdict)
+		if err == nil && verdict == want {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	var verdict string
+	_ = ts.DB.QueryRow(`SELECT COALESCE(verdict,'') FROM pipeline_gate_results WHERE claw_id=? AND stage_id=?`, clawID, stageID).Scan(&verdict)
+	t.Fatalf("gate verdict for stage %q = %q, want %q", stageID, verdict, want)
+}
+
+func assertPipelineStage(t *testing.T, ts *factorytest.TestServer, clawID, want string) {
+	t.Helper()
+	var stage string
+	if err := ts.DB.QueryRow(`SELECT pipeline_stage FROM claws WHERE id=?`, clawID).Scan(&stage); err != nil {
+		t.Fatalf("select pipeline stage: %v", err)
+	}
+	if stage != want {
+		t.Fatalf("pipeline_stage = %q, want %q", stage, want)
 	}
 }
 
@@ -163,6 +240,57 @@ func TestWorkflowHarness_RunFailsStop(t *testing.T) {
 	if stage != "run-fail" {
 		t.Fatalf("expected pipeline_stage=run-fail, got %q", stage)
 	}
+}
+
+func TestWorkflowHarness_DeterministicGatePass(t *testing.T) {
+	prepareDeterministicGateWorkspace(t)
+	ts := newWorkflowHarnessServer(t, "deterministic-gate-pass")
+
+	issueID := "ELA-654"
+	triggerFactoryWebhook(t, ts, issueID, "Backlog", "In Progress")
+
+	clawID := ts.WaitForClawWithIssue(t, issueID, 5*time.Second)
+	useTestExecProvider(t, ts, clawID)
+	bridge := factorytest.ConnectFakeBridge(t, ts.URL(), clawID, issueID, ts.ClawToken())
+
+	bridge.WaitForMessage(t, "Initial plan required", 5*time.Second)
+	bridge.WaitForMessage(t, "Starting deterministic validation", 5*time.Second)
+
+	bridge.SendMessage("Ready for validation. [DONE]")
+
+	bridge.WaitForMessage(t, "Gate passed: Validation", 5*time.Second)
+	bridge.WaitForMessage(t, "No issues found. Workflow complete.", 5*time.Second)
+	assertGateVerdict(t, ts, clawID, "validation", "pass")
+	assertPipelineStage(t, ts, clawID, "complete")
+}
+
+func TestWorkflowHarness_DeterministicGateRetryLoop(t *testing.T) {
+	prepareDeterministicGateWorkspace(t)
+	ts := newWorkflowHarnessServer(t, "deterministic-gate-retry")
+
+	issueID := "ELA-655"
+	triggerFactoryWebhook(t, ts, issueID, "Backlog", "In Progress")
+
+	clawID := ts.WaitForClawWithIssue(t, issueID, 5*time.Second)
+	useTestExecProvider(t, ts, clawID)
+	bridge := factorytest.ConnectFakeBridge(t, ts.URL(), clawID, issueID, ts.ClawToken())
+
+	bridge.WaitForMessage(t, "Initial plan required", 5*time.Second)
+	bridge.WaitForMessage(t, "Starting deterministic validation", 5*time.Second)
+
+	bridge.SendMessage("Ready for validation. [DONE]")
+
+	bridge.WaitForMessage(t, "Gate failed: Validation", 5*time.Second)
+	bridge.WaitForMessage(t, "1 issue found. Apply the deterministic fix and say [RETRY].", 5*time.Second)
+	assertGateVerdict(t, ts, clawID, "validation", "fail")
+	assertPipelineStage(t, ts, clawID, "fix")
+
+	bridge.SendMessage("Retrying after deterministic fix. [RETRY]")
+
+	bridge.WaitForMessage(t, "Gate passed: Validation", 5*time.Second)
+	bridge.WaitForMessage(t, "No issues found. Workflow complete.", 5*time.Second)
+	assertGateVerdict(t, ts, clawID, "validation", "pass")
+	assertPipelineStage(t, ts, clawID, "complete")
 }
 
 func TestWorkflowHarness_RunFailsContinue(t *testing.T) {

--- a/pkg/types/workflow_normalize_test.go
+++ b/pkg/types/workflow_normalize_test.go
@@ -96,6 +96,59 @@ stages:
 	}
 }
 
+func TestWorkflowNormalizePreservesStageGate(t *testing.T) {
+	data := []byte(`
+schema_version: v1
+name: linear-story
+trigger:
+  linear:
+    event: status_changed
+    workspace: Fasterway
+    states:
+      - Todo
+stages:
+  - id: android_validation
+    label: Android Validation
+    triggers:
+      - message_contains: "[DONE]"
+    on_enter:
+      run:
+        command: python3 scripts/run_android_codebuild.py --source-dir next_mobile
+        output: android_validation
+    gate:
+      output: android_validation
+      pass:
+        path: status
+        values:
+          - passed
+          - skipped
+      fail:
+        path: status
+        values:
+          - failed
+          - error
+      required: true
+      treat_skipped_as_pass: true
+`)
+	var workflow WorkflowConfig
+	if err := yaml.Unmarshal(data, &workflow); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if err := NormalizeWorkflowConfig(&workflow); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	for _, want := range []string{
+		"gate:",
+		"output: android_validation",
+		"path: status",
+		"treat_skipped_as_pass: true",
+	} {
+		if !strings.Contains(workflow.PipelineYAML, want) {
+			t.Fatalf("pipeline yaml did not contain %q: %s", want, workflow.PipelineYAML)
+		}
+	}
+}
+
 func TestWorkflowV1ShortcutTriggerValidates(t *testing.T) {
 	data := []byte(`
 schema_version: v1

--- a/pkg/types/workspace.go
+++ b/pkg/types/workspace.go
@@ -111,6 +111,7 @@ type WorkflowStage struct {
 	Terminal bool                     `yaml:"terminal,omitempty" json:"terminal,omitempty"`
 	Triggers []map[string]interface{} `yaml:"triggers,omitempty" json:"triggers,omitempty"`
 	OnEnter  map[string]interface{}   `yaml:"on_enter,omitempty" json:"onEnter,omitempty"`
+	Gate     map[string]interface{}   `yaml:"gate,omitempty" json:"gate,omitempty"`
 }
 
 func (w *WorkspaceConfig) Validate() error {


### PR DESCRIPTION
Summary
- Preserve stage gate blocks when normalizing workspace workflow YAML into runtime pipeline YAML.
- Parse the final JSON object line from workflow run stdout so noisy scripts can still produce structured gate outputs.
- Add regression coverage for normalized workflow gates and noisy CodeBuild-style stdout.

Why
In prod, the android_validation run command executed and persisted output, but no gate evaluated and the UI stayed silent. The workspace workflow file had a gate, but types.WorkflowStage did not carry gate through normalization, so runtime pipeline YAML dropped it. The same output showed shell trace lines before the JSON status, which made parsed_json become an empty object.

Verification
- go test ./pkg/types ./pkg/hub -run targeted workflow and output parser tests
- go test ./...