### PR TITLE
Add dependency update workflow action

### DIFF
--- a/pkg/hub/dependency_updates.go
+++ b/pkg/hub/dependency_updates.go
@@ -1,0 +1,491 @@
+package hub
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/hub/pipeline"
+)
+
+const (
+	defaultDependencyUpdatesOutput  = "dependency_updates"
+	defaultDependencyUpdatesTimeout = 30 * time.Minute
+)
+
+type dependencyUpdatesConfig struct {
+	Ecosystems       []string `json:"ecosystems"`
+	Paths            []string `json:"paths"`
+	Grouping         string   `json:"grouping"`
+	IncludeMajor     bool     `json:"include_major"`
+	SeparateMajor    bool     `json:"separate_major"`
+	SeparateSecurity bool     `json:"separate_security"`
+	SeparateRuntime  bool     `json:"separate_runtime"`
+	Allow            []string `json:"allow"`
+	Ignore           []string `json:"ignore"`
+}
+
+type dependencyUpdateManifest struct {
+	Ecosystem string   `json:"ecosystem"`
+	Path      string   `json:"path"`
+	Lockfiles []string `json:"lockfiles,omitempty"`
+}
+
+func normalizeDependencyUpdatesConfig(action pipeline.DependencyUpdatesAction) dependencyUpdatesConfig {
+	cfg := dependencyUpdatesConfig{
+		Ecosystems:       cleanStringList(action.Ecosystems),
+		Paths:            cleanStringList(action.Paths),
+		Grouping:         strings.TrimSpace(action.Grouping),
+		IncludeMajor:     action.IncludeMajor,
+		SeparateMajor:    boolDefault(action.SeparateMajor, true),
+		SeparateSecurity: boolDefault(action.SeparateSecurity, true),
+		SeparateRuntime:  boolDefault(action.SeparateRuntime, true),
+		Allow:            cleanStringList(action.Allow),
+		Ignore:           cleanStringList(action.Ignore),
+	}
+	if len(cfg.Ecosystems) == 0 {
+		cfg.Ecosystems = []string{"auto"}
+	}
+	if len(cfg.Paths) == 0 {
+		cfg.Paths = []string{"."}
+	}
+	if cfg.Grouping == "" {
+		cfg.Grouping = "all"
+	}
+	if len(cfg.Allow) == 0 {
+		cfg.Allow = []string{"*"}
+	}
+	return cfg
+}
+
+func boolDefault(value *bool, fallback bool) bool {
+	if value == nil {
+		return fallback
+	}
+	return *value
+}
+
+func dependencyUpdatesOutputName(action pipeline.DependencyUpdatesAction) string {
+	if strings.TrimSpace(action.Output) != "" {
+		return strings.TrimSpace(action.Output)
+	}
+	return defaultDependencyUpdatesOutput
+}
+
+func dependencyUpdatesTimeout(action pipeline.DependencyUpdatesAction) (time.Duration, error) {
+	if strings.TrimSpace(action.Timeout) == "" {
+		return defaultDependencyUpdatesTimeout, nil
+	}
+	timeout, err := time.ParseDuration(strings.TrimSpace(action.Timeout))
+	if err != nil {
+		return 0, fmt.Errorf("invalid dependency_updates timeout %q: %w", action.Timeout, err)
+	}
+	return timeout, nil
+}
+
+func cleanStringList(values []string) []string {
+	var result []string
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			result = append(result, value)
+		}
+	}
+	return result
+}
+
+func dependencyUpdatesConfigured(action pipeline.DependencyUpdatesAction) bool {
+	return action.Enabled ||
+		len(action.Ecosystems) > 0 ||
+		len(action.Paths) > 0 ||
+		strings.TrimSpace(action.Grouping) != "" ||
+		action.IncludeMajor ||
+		action.SeparateMajor != nil ||
+		action.SeparateSecurity != nil ||
+		action.SeparateRuntime != nil ||
+		len(action.Allow) > 0 ||
+		len(action.Ignore) > 0 ||
+		strings.TrimSpace(action.Output) != "" ||
+		strings.TrimSpace(action.Timeout) != "" ||
+		action.ContinueOnError
+}
+
+func discoverDependencyUpdateManifests(root string, cfg dependencyUpdatesConfig) ([]dependencyUpdateManifest, error) {
+	ecosystems := dependencyUpdateEcosystems(cfg.Ecosystems)
+	root, err := filepath.Abs(root)
+	if err != nil {
+		return nil, err
+	}
+	var manifests []dependencyUpdateManifest
+	seen := map[string]bool{}
+	for _, rel := range cfg.Paths {
+		base, err := filepath.Abs(filepath.Join(root, rel))
+		if err != nil {
+			return nil, err
+		}
+		baseRel, err := filepath.Rel(root, base)
+		if err != nil || baseRel == ".." || strings.HasPrefix(baseRel, ".."+string(os.PathSeparator)) {
+			return nil, fmt.Errorf("dependency update path %q escapes workspace", rel)
+		}
+		info, err := os.Stat(base)
+		if err != nil {
+			continue
+		}
+		if !info.IsDir() {
+			base = filepath.Dir(base)
+		}
+		err = filepath.WalkDir(base, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() && shouldSkipDependencyUpdateDir(d.Name()) {
+				if path == base {
+					return nil
+				}
+				return filepath.SkipDir
+			}
+			if d.IsDir() {
+				return nil
+			}
+			name := d.Name()
+			dir := filepath.Dir(path)
+			relPath, err := filepath.Rel(root, path)
+			if err != nil {
+				return err
+			}
+			relPath = filepath.ToSlash(relPath)
+			switch {
+			case ecosystems["go"] && name == "go.mod":
+				lock := filepath.Join(dir, "go.sum")
+				lockfiles := existingRelFiles(root, lock)
+				key := "go:" + relPath
+				if !seen[key] {
+					seen[key] = true
+					manifests = append(manifests, dependencyUpdateManifest{Ecosystem: "go", Path: relPath, Lockfiles: lockfiles})
+				}
+			case ecosystems["npm"] && name == "package.json":
+				lockfiles := existingRelFiles(root,
+					filepath.Join(dir, "package-lock.json"),
+					filepath.Join(dir, "npm-shrinkwrap.json"),
+				)
+				key := "npm:" + relPath
+				if !seen[key] {
+					seen[key] = true
+					manifests = append(manifests, dependencyUpdateManifest{Ecosystem: "npm", Path: relPath, Lockfiles: lockfiles})
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	sort.Slice(manifests, func(i, j int) bool {
+		if manifests[i].Ecosystem == manifests[j].Ecosystem {
+			return manifests[i].Path < manifests[j].Path
+		}
+		return manifests[i].Ecosystem < manifests[j].Ecosystem
+	})
+	return manifests, nil
+}
+
+func dependencyUpdateEcosystems(values []string) map[string]bool {
+	result := map[string]bool{}
+	for _, value := range values {
+		value = strings.ToLower(strings.TrimSpace(value))
+		if value == "" || value == "auto" {
+			result["go"] = true
+			result["npm"] = true
+			continue
+		}
+		result[value] = true
+	}
+	return result
+}
+
+func shouldSkipDependencyUpdateDir(name string) bool {
+	switch name {
+	case ".git", "node_modules", "vendor", ".next", "dist", "build":
+		return true
+	default:
+		return false
+	}
+}
+
+func existingRelFiles(root string, paths ...string) []string {
+	var result []string
+	for _, path := range paths {
+		if _, err := os.Stat(path); err == nil {
+			rel, relErr := filepath.Rel(root, path)
+			if relErr == nil {
+				result = append(result, filepath.ToSlash(rel))
+			}
+		}
+	}
+	return result
+}
+
+func buildDependencyUpdatesCommand(action pipeline.DependencyUpdatesAction) (string, error) {
+	cfg := normalizeDependencyUpdatesConfig(action)
+	cfgJSON, err := json.Marshal(cfg)
+	if err != nil {
+		return "", err
+	}
+	encoded := base64.StdEncoding.EncodeToString(cfgJSON)
+	return fmt.Sprintf("python3 - <<'PY'\n%s\nPY", strings.ReplaceAll(dependencyUpdatesPythonScript, "__CONFIG_B64__", encoded)), nil
+}
+
+func (s *Server) executeDependencyUpdatesAction(clawID, stageID string, action pipeline.DependencyUpdatesAction) (*pipelineRunResult, error) {
+	command, err := buildDependencyUpdatesCommand(action)
+	if err != nil {
+		return nil, err
+	}
+	timeout, err := dependencyUpdatesTimeout(action)
+	if err != nil {
+		return nil, err
+	}
+	result, err := s.executePipelineCommand(clawID, command, timeout)
+	if result != nil {
+		s.persistPipelineOutput(clawID, stageID, dependencyUpdatesOutputName(action), result)
+	}
+	return result, err
+}
+
+const dependencyUpdatesPythonScript = `import base64
+import fnmatch
+import json
+import os
+import pathlib
+import re
+import shutil
+import subprocess
+import sys
+
+CONFIG = json.loads(base64.b64decode("__CONFIG_B64__").decode("utf-8"))
+ROOT = pathlib.Path.cwd()
+SKIP_DIRS = {".git", "node_modules", "vendor", ".next", "dist", "build"}
+
+result = {
+    "ecosystems": [],
+    "manifests": [],
+    "updates": [],
+    "commands": [],
+    "files_changed": [],
+}
+had_failure = False
+
+def enabled_ecosystems():
+    values = [str(v).strip().lower() for v in CONFIG.get("ecosystems") or ["auto"] if str(v).strip()]
+    if not values or "auto" in values:
+        return {"go", "npm"}
+    return set(values)
+
+ECOSYSTEMS = enabled_ecosystems()
+result["ecosystems"] = sorted(ECOSYSTEMS)
+
+def rel(path):
+    return path.relative_to(ROOT).as_posix()
+
+def should_skip(path):
+    return any(part in SKIP_DIRS for part in path.parts)
+
+def allowed(name):
+    allow = CONFIG.get("allow") or ["*"]
+    ignore = CONFIG.get("ignore") or []
+    return any(fnmatch.fnmatch(name, p) for p in allow) and not any(fnmatch.fnmatch(name, p) for p in ignore)
+
+def version_parts(version):
+    version = str(version or "").strip().lstrip("v")
+    match = re.search(r"(\d+)(?:\.(\d+))?(?:\.(\d+))?", version)
+    if not match:
+        return None
+    return tuple(int(p or 0) for p in match.groups())
+
+def update_type(old, new):
+    old_parts = version_parts(old)
+    new_parts = version_parts(new)
+    if not old_parts or not new_parts:
+        return "unknown"
+    if new_parts[0] > old_parts[0]:
+        return "major"
+    if new_parts[1] > old_parts[1]:
+        return "minor"
+    if new_parts[2] > old_parts[2]:
+        return "patch"
+    return "unknown"
+
+def run_command(cwd, command, allowed_exit_codes=(0,)):
+    global had_failure
+    proc = subprocess.run(command, cwd=str(cwd), shell=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    result["commands"].append({
+        "command": command,
+        "cwd": rel(cwd),
+        "exit_code": proc.returncode,
+        "stdout": proc.stdout[-4000:],
+        "stderr": proc.stderr[-4000:],
+    })
+    if proc.returncode not in allowed_exit_codes:
+        had_failure = True
+    return proc
+
+def discover():
+    manifests = []
+    paths = CONFIG.get("paths") or ["."]
+    for configured in paths:
+        base = (ROOT / configured).resolve()
+        try:
+            base.relative_to(ROOT)
+        except ValueError:
+            continue
+        if not base.exists():
+            continue
+        if base.is_file():
+            base = base.parent
+        for current, dirs, files in os.walk(base):
+            current_path = pathlib.Path(current)
+            dirs[:] = [d for d in dirs if d not in SKIP_DIRS]
+            if should_skip(current_path.relative_to(ROOT)):
+                continue
+            file_set = set(files)
+            if "go" in ECOSYSTEMS and "go.mod" in file_set:
+                locks = []
+                if "go.sum" in file_set:
+                    locks.append(rel(current_path / "go.sum"))
+                manifests.append({"ecosystem": "go", "path": rel(current_path / "go.mod"), "lockfiles": locks})
+            if "npm" in ECOSYSTEMS and "package.json" in file_set:
+                locks = []
+                for lock in ("package-lock.json", "npm-shrinkwrap.json"):
+                    if lock in file_set:
+                        locks.append(rel(current_path / lock))
+                manifests.append({"ecosystem": "npm", "path": rel(current_path / "package.json"), "lockfiles": locks})
+    manifests.sort(key=lambda item: (item["ecosystem"], item["path"]))
+    return manifests
+
+def file_snapshot(files):
+    snap = {}
+    for file in files:
+        path = ROOT / file
+        if path.exists():
+            snap[file] = path.read_bytes()
+        else:
+            snap[file] = None
+    return snap
+
+def changed_files(before):
+    changed = []
+    for file, old in before.items():
+        path = ROOT / file
+        new = path.read_bytes() if path.exists() else None
+        if new != old:
+            changed.append(file)
+    return changed
+
+def parse_go_modules(raw):
+    decoder = json.JSONDecoder()
+    idx = 0
+    modules = []
+    raw = raw.strip()
+    while idx < len(raw):
+        obj, next_idx = decoder.raw_decode(raw, idx)
+        modules.append(obj)
+        idx = next_idx
+        while idx < len(raw) and raw[idx].isspace():
+            idx += 1
+    return modules
+
+def collect_files(manifests):
+    files = []
+    for manifest in manifests:
+        files.append(manifest["path"])
+        files.extend(manifest.get("lockfiles") or [])
+    return sorted(set(files))
+
+manifests = discover()
+result["manifests"] = manifests
+before = file_snapshot(collect_files(manifests))
+
+for manifest in manifests:
+    manifest_path = ROOT / manifest["path"]
+    cwd = manifest_path.parent
+    if manifest["ecosystem"] == "go":
+        if shutil.which("go") is None:
+            result["commands"].append({"command": "go", "cwd": rel(cwd), "exit_code": 127, "stderr": "go executable not found"})
+            had_failure = True
+            continue
+        listed = run_command(cwd, "go list -m -u -json all")
+        if listed.returncode == 0:
+            try:
+                for module in parse_go_modules(listed.stdout):
+                    update = module.get("Update") or {}
+                    name = module.get("Path", "")
+                    if not update or not allowed(name):
+                        continue
+                    from_version = module.get("Version", "")
+                    to_version = update.get("Version", "")
+                    kind = update_type(from_version, to_version)
+                    applied = not (kind == "major" and not CONFIG.get("include_major"))
+                    result["updates"].append({
+                        "ecosystem": "go",
+                        "name": name,
+                        "from": from_version,
+                        "to": to_version,
+                        "type": kind,
+                        "applied": applied,
+                        "group": "default",
+                        **({} if applied else {"skipped_reason": "major updates disabled"}),
+                    })
+            except Exception as exc:
+                result["commands"].append({"command": "parse go list output", "cwd": rel(cwd), "exit_code": 1, "stderr": str(exc)})
+                had_failure = True
+        run_command(cwd, "go get -u ./...")
+        run_command(cwd, "go mod tidy")
+    elif manifest["ecosystem"] == "npm":
+        if shutil.which("npm") is None:
+            result["commands"].append({"command": "npm", "cwd": rel(cwd), "exit_code": 127, "stderr": "npm executable not found"})
+            had_failure = True
+            continue
+        outdated = run_command(cwd, "npm outdated --json", allowed_exit_codes=(0, 1))
+        if outdated.stdout.strip():
+            try:
+                data = json.loads(outdated.stdout)
+                for name, info in sorted(data.items()):
+                    if not allowed(name):
+                        continue
+                    current = str(info.get("current", ""))
+                    wanted = str(info.get("wanted", ""))
+                    latest = str(info.get("latest", ""))
+                    kind = update_type(current, wanted)
+                    result["updates"].append({
+                        "ecosystem": "npm",
+                        "name": name,
+                        "from": current,
+                        "to": wanted,
+                        "type": kind,
+                        "applied": True,
+                        "group": "default",
+                    })
+                    if latest and latest != wanted and update_type(current, latest) == "major" and not CONFIG.get("include_major"):
+                        result["updates"].append({
+                            "ecosystem": "npm",
+                            "name": name,
+                            "from": current,
+                            "to": latest,
+                            "type": "major",
+                            "applied": False,
+                            "group": "major",
+                            "skipped_reason": "major updates disabled",
+                        })
+            except Exception as exc:
+                result["commands"].append({"command": "parse npm outdated output", "cwd": rel(cwd), "exit_code": 1, "stderr": str(exc)})
+                had_failure = True
+        run_command(cwd, "npm update --package-lock-only")
+
+result["files_changed"] = changed_files(before)
+print(json.dumps(result, sort_keys=True))
+sys.exit(1 if had_failure else 0)
+`

--- a/pkg/hub/dependency_updates.go
+++ b/pkg/hub/dependency_updates.go
@@ -262,6 +262,7 @@ import json
 import os
 import pathlib
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -298,6 +299,20 @@ def allowed(name):
     allow = CONFIG.get("allow") or ["*"]
     ignore = CONFIG.get("ignore") or []
     return any(fnmatch.fnmatch(name, p) for p in allow) and not any(fnmatch.fnmatch(name, p) for p in ignore)
+
+def update_record(ecosystem, name, from_version, to_version, kind, applied, group="default", skipped_reason=None):
+    record = {
+        "ecosystem": ecosystem,
+        "name": name,
+        "from": from_version,
+        "to": to_version,
+        "type": kind,
+        "applied": applied,
+        "group": group,
+    }
+    if skipped_reason:
+        record["skipped_reason"] = skipped_reason
+    result["updates"].append(record)
 
 def version_parts(version):
     version = str(version or "").strip().lstrip("v")
@@ -420,30 +435,29 @@ for manifest in manifests:
         listed = run_command(cwd, "go list -m -u -json all")
         if listed.returncode == 0:
             try:
+                apply_updates = []
                 for module in parse_go_modules(listed.stdout):
                     update = module.get("Update") or {}
                     name = module.get("Path", "")
-                    if not update or not allowed(name):
+                    if not update:
                         continue
                     from_version = module.get("Version", "")
                     to_version = update.get("Version", "")
                     kind = update_type(from_version, to_version)
-                    applied = not (kind == "major" and not CONFIG.get("include_major"))
-                    result["updates"].append({
-                        "ecosystem": "go",
-                        "name": name,
-                        "from": from_version,
-                        "to": to_version,
-                        "type": kind,
-                        "applied": applied,
-                        "group": "default",
-                        **({} if applied else {"skipped_reason": "major updates disabled"}),
-                    })
+                    if not allowed(name):
+                        update_record("go", name, from_version, to_version, kind, False, skipped_reason="filtered by allow/ignore")
+                        continue
+                    if kind == "major" and not CONFIG.get("include_major"):
+                        update_record("go", name, from_version, to_version, kind, False, skipped_reason="major updates disabled")
+                        continue
+                    update_record("go", name, from_version, to_version, kind, True)
+                    apply_updates.append(f"{name}@{to_version}")
+                if apply_updates:
+                    run_command(cwd, "go get " + " ".join(shlex.quote(value) for value in apply_updates))
+                    run_command(cwd, "go mod tidy")
             except Exception as exc:
                 result["commands"].append({"command": "parse go list output", "cwd": rel(cwd), "exit_code": 1, "stderr": str(exc)})
                 had_failure = True
-        run_command(cwd, "go get -u ./...")
-        run_command(cwd, "go mod tidy")
     elif manifest["ecosystem"] == "npm":
         if shutil.which("npm") is None:
             result["commands"].append({"command": "npm", "cwd": rel(cwd), "exit_code": 127, "stderr": "npm executable not found"})
@@ -452,38 +466,28 @@ for manifest in manifests:
         outdated = run_command(cwd, "npm outdated --json", allowed_exit_codes=(0, 1))
         if outdated.stdout.strip():
             try:
+                apply_updates = []
                 data = json.loads(outdated.stdout)
                 for name, info in sorted(data.items()):
-                    if not allowed(name):
-                        continue
                     current = str(info.get("current", ""))
                     wanted = str(info.get("wanted", ""))
                     latest = str(info.get("latest", ""))
                     kind = update_type(current, wanted)
-                    result["updates"].append({
-                        "ecosystem": "npm",
-                        "name": name,
-                        "from": current,
-                        "to": wanted,
-                        "type": kind,
-                        "applied": True,
-                        "group": "default",
-                    })
+                    if not allowed(name):
+                        update_record("npm", name, current, wanted, kind, False, skipped_reason="filtered by allow/ignore")
+                        continue
+                    if kind == "major" and not CONFIG.get("include_major"):
+                        update_record("npm", name, current, wanted, kind, False, skipped_reason="major updates disabled")
+                    else:
+                        update_record("npm", name, current, wanted, kind, True)
+                        apply_updates.append(name)
                     if latest and latest != wanted and update_type(current, latest) == "major" and not CONFIG.get("include_major"):
-                        result["updates"].append({
-                            "ecosystem": "npm",
-                            "name": name,
-                            "from": current,
-                            "to": latest,
-                            "type": "major",
-                            "applied": False,
-                            "group": "major",
-                            "skipped_reason": "major updates disabled",
-                        })
+                        update_record("npm", name, current, latest, "major", False, group="major", skipped_reason="major updates disabled")
+                if apply_updates:
+                    run_command(cwd, "npm update --package-lock-only " + " ".join(shlex.quote(value) for value in apply_updates))
             except Exception as exc:
                 result["commands"].append({"command": "parse npm outdated output", "cwd": rel(cwd), "exit_code": 1, "stderr": str(exc)})
                 had_failure = True
-        run_command(cwd, "npm update --package-lock-only")
 
 result["files_changed"] = changed_files(before)
 print(json.dumps(result, sort_keys=True))

--- a/pkg/hub/dependency_updates_test.go
+++ b/pkg/hub/dependency_updates_test.go
@@ -85,7 +85,11 @@ if [ "$*" = "list -m -u -json all" ]; then
   printf '%s\n' '{"Path":"example.com/root","Version":"v1.0.0","Update":{"Version":"v1.1.0"}}'
   exit 0
 fi
-if [ "$1 $2" = "get -u" ]; then
+if [ "$1" = "get" ]; then
+  if [[ "$*" != *"example.com/root@v1.1.0"* ]]; then
+    echo "missing selected module in go get: $*" >&2
+    exit 1
+  fi
   echo changed >> go.sum
   exit 0
 fi
@@ -115,9 +119,9 @@ exit 0
 	if err != nil {
 		t.Fatalf("build command: %v", err)
 	}
-	cmd := osexec.Command("bash", "-lc", command)
+	cmd := osexec.Command("bash", "-c", command)
 	cmd.Dir = root
-	cmd.Env = append(os.Environ(), "PATH="+bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	cmd.Env = testEnvWithPath(bin)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("dependency update command failed: %v\n%s", err, out)
@@ -139,6 +143,125 @@ exit 0
 	if !ok || len(updates) < 2 {
 		t.Fatalf("updates = %#v, want applied and skipped update records", parsed["updates"])
 	}
+}
+
+func TestDependencyUpdatesGeneratedCommandHonorsFiltersAndMajorPolicy(t *testing.T) {
+	root := t.TempDir()
+	bin := filepath.Join(root, "bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeExecutable(t, bin, "go", `#!/usr/bin/env bash
+set -e
+if [ "$*" = "list -m -u -json all" ]; then
+  printf '%s\n' '{"Path":"example.com/root","Version":"v1.0.0","Update":{"Version":"v1.1.0"}}'
+  printf '%s\n' '{"Path":"ignored.com/risky","Version":"v1.0.0","Update":{"Version":"v1.1.0"}}'
+  printf '%s\n' '{"Path":"example.com/major","Version":"v0.9.0","Update":{"Version":"v1.0.0"}}'
+  exit 0
+fi
+if [ "$1" = "get" ]; then
+  if [[ "$*" == *"ignored.com/risky"* || "$*" == *"example.com/major"* ]]; then
+    echo "go get included skipped dependency: $*" >&2
+    exit 1
+  fi
+  if [[ "$*" != *"example.com/root@v1.1.0"* ]]; then
+    echo "go get omitted selected dependency: $*" >&2
+    exit 1
+  fi
+  echo changed >> go.sum
+  exit 0
+fi
+if [ "$1 $2" = "mod tidy" ]; then
+  exit 0
+fi
+exit 0
+`)
+	writeExecutable(t, bin, "npm", `#!/usr/bin/env bash
+set -e
+if [ "$1 $2" = "outdated --json" ]; then
+  printf '%s\n' '{"left-pad":{"current":"1.0.0","wanted":"1.1.0","latest":"2.0.0"},"risky-lib":{"current":"1.0.0","wanted":"1.1.0","latest":"1.1.0"},"major-lib":{"current":"0.9.0","wanted":"1.0.0","latest":"1.0.0"}}'
+  exit 1
+fi
+if [ "$1 $2" = "update --package-lock-only" ]; then
+  if [[ "$*" == *"risky-lib"* || "$*" == *"major-lib"* ]]; then
+    echo "npm update included skipped dependency: $*" >&2
+    exit 1
+  fi
+  if [[ "$*" != *"left-pad"* ]]; then
+    echo "npm update omitted selected dependency: $*" >&2
+    exit 1
+  fi
+  printf '%s\n' '{"lockfileVersion":3,"updated":true}' > package-lock.json
+  exit 0
+fi
+exit 0
+`)
+	writeFile(t, root, "go.mod", "module example.com/root\n")
+	writeFile(t, root, "go.sum", "")
+	writeFile(t, root, "package.json", `{"name":"root","dependencies":{"left-pad":"^1.0.0","risky-lib":"^1.0.0","major-lib":"^0.9.0"}}`)
+	writeFile(t, root, "package-lock.json", `{"lockfileVersion":3}`)
+
+	command, err := buildDependencyUpdatesCommand(pipeline.DependencyUpdatesAction{
+		Enabled: true,
+		Ignore:  []string{"ignored.com/risky", "risky-lib"},
+	})
+	if err != nil {
+		t.Fatalf("build command: %v", err)
+	}
+	cmd := osexec.Command("bash", "-c", command)
+	cmd.Dir = root
+	cmd.Env = testEnvWithPath(bin)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("dependency update command failed: %v\n%s", err, out)
+	}
+
+	parsed, ok := parsePipelineOutputJSON(string(out))
+	if !ok {
+		t.Fatalf("command did not emit JSON:\n%s", out)
+	}
+	assertUpdateStatus(t, parsed, "go", "ignored.com/risky", false, "filtered by allow/ignore")
+	assertUpdateStatus(t, parsed, "go", "example.com/major", false, "major updates disabled")
+	assertUpdateStatus(t, parsed, "npm", "risky-lib", false, "filtered by allow/ignore")
+	assertUpdateStatus(t, parsed, "npm", "major-lib", false, "major updates disabled")
+}
+
+func assertUpdateStatus(t *testing.T, parsed map[string]interface{}, ecosystem, name string, applied bool, skippedReason string) {
+	t.Helper()
+	updates, ok := parsed["updates"].([]interface{})
+	if !ok {
+		t.Fatalf("updates = %#v, want list", parsed["updates"])
+	}
+	for _, raw := range updates {
+		update, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if update["ecosystem"] == ecosystem && update["name"] == name {
+			if update["applied"] != applied {
+				t.Fatalf("%s %s applied = %#v, want %v", ecosystem, name, update["applied"], applied)
+			}
+			if skippedReason != "" && update["skipped_reason"] != skippedReason {
+				t.Fatalf("%s %s skipped_reason = %#v, want %q", ecosystem, name, update["skipped_reason"], skippedReason)
+			}
+			return
+		}
+	}
+	b, _ := json.MarshalIndent(parsed["updates"], "", "  ")
+	commands, _ := json.MarshalIndent(parsed["commands"], "", "  ")
+	t.Fatalf("missing update %s %s in:\n%s\ncommands:\n%s", ecosystem, name, b, commands)
+}
+
+func testEnvWithPath(bin string) []string {
+	env := []string{
+		"PATH=" + bin + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+	for _, key := range []string{"HOME", "TMPDIR"} {
+		if value := os.Getenv(key); value != "" {
+			env = append(env, key+"="+value)
+		}
+	}
+	return env
 }
 
 func writeFile(t *testing.T, root, rel, content string) {

--- a/pkg/hub/dependency_updates_test.go
+++ b/pkg/hub/dependency_updates_test.go
@@ -1,0 +1,161 @@
+package hub
+
+import (
+	"encoding/json"
+	"os"
+	osexec "os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/elasticclaw/elasticclaw/pkg/hub/pipeline"
+)
+
+func TestNormalizeDependencyUpdatesConfigDefaults(t *testing.T) {
+	cfg := normalizeDependencyUpdatesConfig(pipeline.DependencyUpdatesAction{Enabled: true})
+
+	if strings.Join(cfg.Ecosystems, ",") != "auto" {
+		t.Fatalf("ecosystems = %#v, want auto", cfg.Ecosystems)
+	}
+	if strings.Join(cfg.Paths, ",") != "." {
+		t.Fatalf("paths = %#v, want .", cfg.Paths)
+	}
+	if cfg.Grouping != "all" {
+		t.Fatalf("grouping = %q, want all", cfg.Grouping)
+	}
+	if cfg.IncludeMajor {
+		t.Fatal("include_major default should be false")
+	}
+	if !cfg.SeparateMajor || !cfg.SeparateSecurity || !cfg.SeparateRuntime {
+		t.Fatalf("separate defaults not enabled: %#v", cfg)
+	}
+	if strings.Join(cfg.Allow, ",") != "*" {
+		t.Fatalf("allow = %#v, want *", cfg.Allow)
+	}
+	if dependencyUpdatesOutputName(pipeline.DependencyUpdatesAction{}) != defaultDependencyUpdatesOutput {
+		t.Fatalf("default output mismatch")
+	}
+}
+
+func TestDiscoverDependencyUpdateManifests(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "go.mod", "module example.com/root\n")
+	writeFile(t, root, "go.sum", "")
+	writeFile(t, root, "web/package.json", `{"name":"web"}`)
+	writeFile(t, root, "web/package-lock.json", `{"lockfileVersion":3}`)
+	writeFile(t, root, "web/node_modules/ignored/package.json", `{"name":"ignored"}`)
+
+	manifests, err := discoverDependencyUpdateManifests(root, normalizeDependencyUpdatesConfig(pipeline.DependencyUpdatesAction{Enabled: true}))
+	if err != nil {
+		t.Fatalf("discover manifests: %v", err)
+	}
+	got := make([]string, 0, len(manifests))
+	for _, manifest := range manifests {
+		got = append(got, manifest.Ecosystem+":"+manifest.Path+":"+strings.Join(manifest.Lockfiles, ","))
+	}
+	want := []string{
+		"go:go.mod:go.sum",
+		"npm:web/package.json:web/package-lock.json",
+	}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("manifests:\n%s\nwant:\n%s", strings.Join(got, "\n"), strings.Join(want, "\n"))
+	}
+}
+
+func TestDiscoverDependencyUpdateManifestsRejectsEscapingPath(t *testing.T) {
+	root := t.TempDir()
+	_, err := discoverDependencyUpdateManifests(root, dependencyUpdatesConfig{
+		Ecosystems: []string{"go"},
+		Paths:      []string{"../outside"},
+	})
+	if err == nil {
+		t.Fatal("expected escaping path error")
+	}
+}
+
+func TestDependencyUpdatesGeneratedCommandOutputsStructuredJSON(t *testing.T) {
+	root := t.TempDir()
+	bin := filepath.Join(root, "bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeExecutable(t, bin, "go", `#!/usr/bin/env bash
+set -e
+if [ "$*" = "list -m -u -json all" ]; then
+  printf '%s\n' '{"Path":"example.com/root","Version":"v1.0.0","Update":{"Version":"v1.1.0"}}'
+  exit 0
+fi
+if [ "$1 $2" = "get -u" ]; then
+  echo changed >> go.sum
+  exit 0
+fi
+if [ "$1 $2" = "mod tidy" ]; then
+  exit 0
+fi
+exit 0
+`)
+	writeExecutable(t, bin, "npm", `#!/usr/bin/env bash
+set -e
+if [ "$1 $2" = "outdated --json" ]; then
+  printf '%s\n' '{"left-pad":{"current":"1.0.0","wanted":"1.1.0","latest":"2.0.0"}}'
+  exit 1
+fi
+if [ "$1 $2" = "update --package-lock-only" ]; then
+  printf '%s\n' '{"lockfileVersion":3,"updated":true}' > package-lock.json
+  exit 0
+fi
+exit 0
+`)
+	writeFile(t, root, "go.mod", "module example.com/root\n")
+	writeFile(t, root, "go.sum", "")
+	writeFile(t, root, "package.json", `{"name":"root","dependencies":{"left-pad":"^1.0.0"}}`)
+	writeFile(t, root, "package-lock.json", `{"lockfileVersion":3}`)
+
+	command, err := buildDependencyUpdatesCommand(pipeline.DependencyUpdatesAction{Enabled: true})
+	if err != nil {
+		t.Fatalf("build command: %v", err)
+	}
+	cmd := osexec.Command("bash", "-lc", command)
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(), "PATH="+bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("dependency update command failed: %v\n%s", err, out)
+	}
+
+	parsed, ok := parsePipelineOutputJSON(string(out))
+	if !ok {
+		t.Fatalf("command did not emit JSON:\n%s", out)
+	}
+	if parsed["ecosystems"] == nil || parsed["manifests"] == nil || parsed["updates"] == nil || parsed["commands"] == nil || parsed["files_changed"] == nil {
+		b, _ := json.MarshalIndent(parsed, "", "  ")
+		t.Fatalf("output missing structured fields:\n%s", b)
+	}
+	filesChanged, ok := parsed["files_changed"].([]interface{})
+	if !ok || len(filesChanged) == 0 {
+		t.Fatalf("files_changed = %#v, want at least one changed file", parsed["files_changed"])
+	}
+	updates, ok := parsed["updates"].([]interface{})
+	if !ok || len(updates) < 2 {
+		t.Fatalf("updates = %#v, want applied and skipped update records", parsed["updates"])
+	}
+}
+
+func writeFile(t *testing.T, root, rel, content string) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeExecutable(t *testing.T, root, name, content string) {
+	t.Helper()
+	path := filepath.Join(root, name)
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/hub/pipeline/pipeline.go
+++ b/pkg/hub/pipeline/pipeline.go
@@ -197,6 +197,24 @@ type RunAction struct {
 	Output string `yaml:"output,omitempty"`
 }
 
+// DependencyUpdatesAction updates repository dependencies using ecosystem-native
+// tooling and emits structured JSON output for later workflow stages.
+type DependencyUpdatesAction struct {
+	Enabled          bool     `yaml:"-" json:"-"`
+	Ecosystems       []string `yaml:"ecosystems,omitempty"`
+	Paths            []string `yaml:"paths,omitempty"`
+	Grouping         string   `yaml:"grouping,omitempty"`
+	IncludeMajor     bool     `yaml:"include_major,omitempty"`
+	SeparateMajor    *bool    `yaml:"separate_major,omitempty"`
+	SeparateSecurity *bool    `yaml:"separate_security,omitempty"`
+	SeparateRuntime  *bool    `yaml:"separate_runtime,omitempty"`
+	Allow            []string `yaml:"allow,omitempty"`
+	Ignore           []string `yaml:"ignore,omitempty"`
+	Output           string   `yaml:"output,omitempty"`
+	Timeout          string   `yaml:"timeout,omitempty"`
+	ContinueOnError  bool     `yaml:"continue_on_error,omitempty"`
+}
+
 // JudgeInput defines a constrained input source for a judge stage.
 type JudgeInput string
 
@@ -241,6 +259,8 @@ type JudgeAction struct {
 type OnEnter struct {
 	// Run executes a command in the agent workspace.
 	Run RunAction `yaml:"run,omitempty"`
+	// DependencyUpdates updates supported dependency manifests with native package managers.
+	DependencyUpdates DependencyUpdatesAction `yaml:"dependency_updates,omitempty"`
 	// Judge runs a model-backed review pass with constrained inputs.
 	Judge JudgeAction `yaml:"judge,omitempty"`
 	// Inject sends this message to the claw as a user message.
@@ -262,14 +282,15 @@ type OnEnter struct {
 func (oe *OnEnter) UnmarshalYAML(value *yaml.Node) error {
 	// Use a shadow type to avoid infinite recursion.
 	type rawOnEnter struct {
-		Run          RunAction `yaml:"run,omitempty"`
-		Judge        JudgeAction `yaml:"judge,omitempty"`
-		Inject       string    `yaml:"inject"`
-		MoveIssueRaw yaml.Node `yaml:"move_issue"`
-		MergePR      bool      `yaml:"merge_pr,omitempty"`
-		CloseIssue   bool      `yaml:"close_issue,omitempty"`
-		AddLabels    []string  `yaml:"add_labels,omitempty"`
-		RemoveLabels []string  `yaml:"remove_labels,omitempty"`
+		Run                  RunAction   `yaml:"run,omitempty"`
+		DependencyUpdatesRaw yaml.Node   `yaml:"dependency_updates"`
+		Judge                JudgeAction `yaml:"judge,omitempty"`
+		Inject               string      `yaml:"inject"`
+		MoveIssueRaw         yaml.Node   `yaml:"move_issue"`
+		MergePR              bool        `yaml:"merge_pr,omitempty"`
+		CloseIssue           bool        `yaml:"close_issue,omitempty"`
+		AddLabels            []string    `yaml:"add_labels,omitempty"`
+		RemoveLabels         []string    `yaml:"remove_labels,omitempty"`
 	}
 	var raw rawOnEnter
 	if err := value.Decode(&raw); err != nil {
@@ -283,6 +304,15 @@ func (oe *OnEnter) UnmarshalYAML(value *yaml.Node) error {
 	oe.CloseIssue = raw.CloseIssue
 	oe.AddLabels = raw.AddLabels
 	oe.RemoveLabels = raw.RemoveLabels
+
+	if raw.DependencyUpdatesRaw.Kind != 0 {
+		var dua DependencyUpdatesAction
+		if err := raw.DependencyUpdatesRaw.Decode(&dua); err != nil {
+			return err
+		}
+		dua.Enabled = true
+		oe.DependencyUpdates = dua
+	}
 
 	if raw.MoveIssueRaw.Kind == 0 {
 		// move_issue not present

--- a/pkg/hub/pipeline/pipeline_test.go
+++ b/pkg/hub/pipeline/pipeline_test.go
@@ -102,6 +102,53 @@ stages:
 	}
 }
 
+func TestParseDependencyUpdatesAction(t *testing.T) {
+	p, err := pipeline.Parse([]byte(`
+stages:
+  - id: deps
+    on_enter:
+      dependency_updates:
+        ecosystems: [go, npm]
+        paths: ["."]
+        grouping: all
+        include_major: false
+        output: deps
+        timeout: 20m
+        continue_on_error: true
+`))
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	action := p.Stages[0].OnEnter.DependencyUpdates
+	if !action.Enabled {
+		t.Fatal("dependency_updates should be marked enabled when present")
+	}
+	if action.Output != "deps" {
+		t.Fatalf("output = %q, want deps", action.Output)
+	}
+	if action.Timeout != "20m" {
+		t.Fatalf("timeout = %q, want 20m", action.Timeout)
+	}
+	if !action.ContinueOnError {
+		t.Fatal("expected continue_on_error")
+	}
+}
+
+func TestParseEmptyDependencyUpdatesAction(t *testing.T) {
+	p, err := pipeline.Parse([]byte(`
+stages:
+  - id: deps
+    on_enter:
+      dependency_updates: {}
+`))
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	if !p.Stages[0].OnEnter.DependencyUpdates.Enabled {
+		t.Fatal("empty dependency_updates block should still enable the action")
+	}
+}
+
 func TestEntryStage(t *testing.T) {
 	p, _ := pipeline.Parse([]byte(sampleYAML))
 	entry := p.EntryStage()

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -378,7 +378,10 @@ func (s *Server) executePipelineRunAction(clawID string, action pipeline.RunActi
 		}
 		timeout = parsed
 	}
+	return s.executePipelineCommand(clawID, command, timeout)
+}
 
+func (s *Server) executePipelineCommand(clawID, command string, timeout time.Duration) (*pipelineRunResult, error) {
 	var providerName, providerID, sshHost, sshUser string
 	var sshPort int
 	if err := s.db.QueryRow(`
@@ -890,6 +893,28 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 			}
 		} else {
 			log.Printf("[pipeline] workflow command completed for claw %s stage %q", clawID[:8], stage.ID)
+		}
+	}
+
+	if dependencyUpdatesConfigured(stage.OnEnter.DependencyUpdates) {
+		outputName := dependencyUpdatesOutputName(stage.OnEnter.DependencyUpdates)
+		log.Printf("[pipeline] running dependency updates for claw %s stage %q output %q", clawID[:8], stage.ID, outputName)
+		result, err := s.executeDependencyUpdatesAction(clawID, stage.ID, stage.OnEnter.DependencyUpdates)
+		if err != nil || (result != nil && result.ExitCode != 0) {
+			msg := "Dependency update step failed"
+			if result != nil {
+				details := strings.TrimSpace(result.Stdout + "\n" + result.Stderr)
+				if details != "" {
+					msg += ": " + truncateString(details, 2000)
+				}
+			} else if err != nil {
+				msg += ": " + err.Error()
+			}
+			log.Printf("[pipeline] %s", msg)
+			s.injectHubMessageByID(clawID, "[hub] Error: "+msg)
+			if !stage.OnEnter.DependencyUpdates.ContinueOnError {
+				return false
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Add a built-in `on_enter.dependency_updates` workflow action for issue #383.
- Discover Go and npm manifests, run ecosystem-native update tooling, and persist structured JSON output for later stages.
- Support config defaults for ecosystems, paths, grouping, major-update behavior, allow/ignore filters, output name, timeout, and continue-on-error behavior.
- Add tests for YAML parsing, config defaults, manifest discovery, path containment, and generated command output shape.

## Accurate workflow example

This PR implements the dependency updater as a workflow stage `on_enter` action, not as a `steps[].uses` action. A cron workflow should use the current workflow/stage shape:

```yaml
schema_version: v1
name: dependency-maintenance
enabled: true

trigger:
  cron:
    schedule: "0 9 * * 1"
    timezone: "America/Chicago"
    overlap_policy: skip

provider: daytona
tags: ["dependencies"]

stages:
  - id: update_dependencies
    label: Update Dependencies
    entry: true
    on_enter:
      dependency_updates:
        ecosystems: [go, npm]
        paths: ["."]
        grouping: all
        include_major: false
        separate_major: true
        separate_security: true
        separate_runtime: true
        allow: ["*"]
        ignore: []
        output: dependency_updates
        timeout: 30m
      inject: |
        Dependency update metadata:
        {{ .Outputs.dependency_updates.files_changed }}

        Run tests. If files changed and tests pass, open one grouped PR.
        If tests fail, fix the failures or explain why the update should be skipped.
        Say [DONE] when finished.

  - id: complete
    label: Complete
    triggers:
      - message_contains: "[DONE]"
    terminal: true
```

The action updates files and emits structured metadata. It does not run tests, commit changes, or open a PR by itself; later workflow stages and agent instructions handle those decisions.

## Validation

- `env GOCACHE=/private/tmp/elasticclaw-go-build go test ./...`

Closes #383
