### PR TITLE
Require admin auth for config mutations

### DIFF
--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -288,25 +288,25 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/workspaces/{workspace}/webhooks/github-issues", s.handleGitHubIssuesWebhook)
 	mux.HandleFunc("/api/workspaces/{workspace}/webhooks/shortcut", s.handleShortcutWebhook)
 	mux.HandleFunc("/api/workspaces/{workspace}/webhooks/external", s.handleExternalWebhook)
-	mux.HandleFunc("/api/factories/", s.withAuth(s.handleFactoryEvents))                    // GET /api/factories/:name/events
-	mux.HandleFunc("/api/factories/{name}/trigger", s.withAuth(s.handleFactoryTrigger))     // POST manual trigger
-	mux.HandleFunc("/api/factories/{name}/analytics", s.withAuth(s.handleFactoryAnalytics)) // GET factory analytics
-	mux.HandleFunc("/api/factories", s.withAuth(s.handleFactoriesCRUD))                     // factory CRUD (GET list, POST push)
-	mux.HandleFunc("/api/analytics/factories", s.withAuth(s.handleAllFactoriesAnalytics))   // GET all factories analytics
+	mux.HandleFunc("/api/factories/", s.withAuth(s.handleFactoryEvents))                                               // GET /api/factories/:name/events
+	mux.HandleFunc("/api/factories/{name}/trigger", s.withAuth(s.handleFactoryTrigger))                                // POST manual trigger
+	mux.HandleFunc("/api/factories/{name}/analytics", s.withAuth(s.handleFactoryAnalytics))                            // GET factory analytics
+	mux.HandleFunc("/api/factories", s.withAdminForMethods(s.handleFactoriesCRUD, http.MethodPost, http.MethodDelete)) // factory CRUD (GET list, POST push)
+	mux.HandleFunc("/api/analytics/factories", s.withAuth(s.handleAllFactoriesAnalytics))                              // GET all factories analytics
 	mux.HandleFunc("/api/analytics/summary", s.withAuth(s.handleTaskRunAnalyticsSummary))
 	mux.HandleFunc("/api/analytics/filter-options", s.withAuth(s.handleTaskRunAnalyticsFilterOptions))
 	mux.HandleFunc("/api/analytics/runs", s.withAuth(s.handleTaskRunAnalyticsRuns))
 	mux.HandleFunc("/api/analytics/runs/", s.withAuth(s.handleTaskRunAnalyticsRuns))
-	mux.HandleFunc("/api/workspaces", s.withAuth(s.handleWorkspacesCRUD)) // workspace CRUD
-	mux.HandleFunc("/api/workspaces/{name}/workflows", s.withAuth(s.handleWorkspaceWorkflowsList))
-	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}", s.withAuth(s.handleWorkspaceWorkflowDetail))
+	mux.HandleFunc("/api/workspaces", s.withAdminForMethods(s.handleWorkspacesCRUD, http.MethodPost, http.MethodDelete)) // workspace CRUD
+	mux.HandleFunc("/api/workspaces/{name}/workflows", s.withAdminForMethods(s.handleWorkspaceWorkflowsList, http.MethodPost))
+	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}", s.withAdminForMethods(s.handleWorkspaceWorkflowDetail, http.MethodPatch))
 	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}/trigger", s.withAuth(s.handleWorkspaceWorkflowTrigger))
 	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}/cron/trigger", s.withAuth(s.handleCronWorkflowTrigger)) // POST manual trigger
 	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}/cron/runs", s.withAuth(s.handleCronWorkflowRuns))       // GET run history
 	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}/cron/next", s.withAuth(s.handleCronWorkflowNextRun))    // GET next scheduled run
-	mux.HandleFunc("/api/workspaces/{workspace}/secrets", s.withAuth(s.handleWorkspaceSecretsCRUD))
-	mux.HandleFunc("/api/workspaces/{workspace}/github-apps", s.withAuth(s.handleWorkspaceGitHubAppsCRUD))
-	mux.HandleFunc("/api/workspaces/{workspace}/issue-trackers", s.withAuth(s.handleWorkspaceIssueTrackersCRUD))
+	mux.HandleFunc("/api/workspaces/{workspace}/secrets", s.withAdminForMethods(s.handleWorkspaceSecretsCRUD, http.MethodPut, http.MethodPost, http.MethodDelete))
+	mux.HandleFunc("/api/workspaces/{workspace}/github-apps", s.withAdminForMethods(s.handleWorkspaceGitHubAppsCRUD, http.MethodPut, http.MethodPost, http.MethodDelete))
+	mux.HandleFunc("/api/workspaces/{workspace}/issue-trackers", s.withAdminForMethods(s.handleWorkspaceIssueTrackersCRUD, http.MethodPut, http.MethodPost, http.MethodDelete))
 	mux.HandleFunc("/api/secrets", s.withWebAdminAuth(s.handleSecretsCRUD)) // secrets CRUD (GET names, PUT upsert, DELETE)
 	mux.HandleFunc("/api/mcp", s.withWebAdminAuth(s.handleMCPCrud))         // MCP server CRUD (GET list, PUT upsert, DELETE)
 	mux.HandleFunc("/api/claws", s.withAuth(s.handleClaws))
@@ -407,6 +407,22 @@ func (s *Server) withAuth(next http.HandlerFunc) http.HandlerFunc {
 		}
 		r = r.WithContext(ctx)
 		next(w, r)
+	}
+}
+
+func (s *Server) withAdminForMethods(next http.HandlerFunc, methods ...string) http.HandlerFunc {
+	adminMethods := make(map[string]struct{}, len(methods))
+	for _, method := range methods {
+		adminMethods[method] = struct{}{}
+	}
+	authHandler := s.withAuth(next)
+	adminHandler := s.withWebAdminAuth(next)
+	return func(w http.ResponseWriter, r *http.Request) {
+		if _, ok := adminMethods[r.Method]; ok {
+			adminHandler(w, r)
+			return
+		}
+		authHandler(w, r)
 	}
 }
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -416,13 +416,64 @@ func (s *Server) withAdminForMethods(next http.HandlerFunc, methods ...string) h
 		adminMethods[method] = struct{}{}
 	}
 	authHandler := s.withAuth(next)
-	adminHandler := s.withWebAdminAuth(next)
+	adminHandler := s.withConfigMutationAuth(next)
 	return func(w http.ResponseWriter, r *http.Request) {
 		if _, ok := adminMethods[r.Method]; ok {
 			adminHandler(w, r)
 			return
 		}
 		authHandler(w, r)
+	}
+}
+
+func (s *Server) withConfigMutationAuth(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		token := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+		if token == "" {
+			token = r.Header.Get(webSessionHeader)
+		}
+		queryToken := false
+		if token == "" {
+			token = r.URL.Query().Get("token")
+			queryToken = token != ""
+		}
+		if token == "" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		s.mu.RLock()
+		hubToken := s.hubCfg.Token
+		var accessCfg *types.AccessConfig
+		if s.hubCfg.Auth != nil {
+			accessCfg = s.hubCfg.Auth.Access
+		}
+		s.mu.RUnlock()
+
+		if token == hubToken && hubToken != "" {
+			next(w, r)
+			return
+		}
+		if queryToken {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		sessionSecret := s.webSessionSecret()
+		if sessionSecret != "" {
+			if payload, ok := verifyGitHubSession(sessionSecret, token); ok {
+				if !isAccessAdmin(accessCfg, payload.Login) {
+					http.Error(w, "forbidden", http.StatusForbidden)
+					return
+				}
+				ctx := context.WithValue(r.Context(), ctxGitHubLoginKey{}, payload.Login)
+				r = r.WithContext(ctx)
+				next(w, r)
+				return
+			}
+		}
+
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
 	}
 }
 

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -1560,6 +1560,120 @@ func TestWebAdminAuthRequiresAccessAdminForGitHubSession(t *testing.T) {
 	}
 }
 
+func TestAdminForMethodsRequiresAdminForMutations(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{
+		Token: "hub-token",
+		Auth: &types.AuthConfig{
+			SessionSecret: "session-secret",
+			GitHubOAuth:   &types.GitHubOAuthConfig{ClientSecret: "oauth-secret"},
+			Access:        &types.AccessConfig{Admins: []string{"admin-user"}},
+		},
+	}, "", "", "")
+
+	regularSession, err := signGitHubSession("session-secret", "regular-user", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	adminSession, err := signGitHubSession("session-secret", "admin-user", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var calls int
+	handler := s.withAdminForMethods(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusNoContent)
+	}, http.MethodPost)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
+	req.Header.Set("Authorization", "Bearer "+regularSession)
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected read method to allow regular user, got %d", rec.Code)
+	}
+	if calls != 1 {
+		t.Fatalf("expected handler to be called once, got %d", calls)
+	}
+
+	req = httptest.NewRequest(http.MethodPost, "/api/config", nil)
+	req.Header.Set("Authorization", "Bearer "+regularSession)
+	rec = httptest.NewRecorder()
+	handler(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected mutation method to reject regular user with %d, got %d", http.StatusForbidden, rec.Code)
+	}
+	if calls != 1 {
+		t.Fatalf("expected handler not to be called for rejected mutation, got %d calls", calls)
+	}
+
+	req = httptest.NewRequest(http.MethodPost, "/api/config", nil)
+	req.Header.Set("Authorization", "Bearer "+adminSession)
+	rec = httptest.NewRecorder()
+	handler(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected mutation method to allow admin user, got %d", rec.Code)
+	}
+
+	req = httptest.NewRequest(http.MethodPost, "/api/config", nil)
+	req.Header.Set("Authorization", "Bearer hub-token")
+	rec = httptest.NewRecorder()
+	handler(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected mutation method to allow hub token, got %d", rec.Code)
+	}
+}
+
+func TestConfigMutationRoutesRequireWebAdminForGitHubSessions(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{
+		Token: "hub-token",
+		Auth: &types.AuthConfig{
+			SessionSecret: "session-secret",
+			GitHubOAuth:   &types.GitHubOAuthConfig{ClientSecret: "oauth-secret"},
+			Access:        &types.AccessConfig{Admins: []string{"admin-user"}},
+		},
+	}, "", "", "")
+	session, err := signGitHubSession("session-secret", "regular-user", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mux := http.NewServeMux()
+	s.registerRoutes(mux)
+
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		body   string
+	}{
+		{name: "factory push", method: http.MethodPost, path: "/api/factories", body: `{"factories":[]}`},
+		{name: "factory delete", method: http.MethodDelete, path: "/api/factories?name=demo"},
+		{name: "workspace push", method: http.MethodPost, path: "/api/workspaces", body: `{"workspaces":[]}`},
+		{name: "workspace delete", method: http.MethodDelete, path: "/api/workspaces?name=demo"},
+		{name: "workflow push", method: http.MethodPost, path: "/api/workspaces/demo/workflows", body: `{"workflows":[]}`},
+		{name: "workflow patch", method: http.MethodPatch, path: "/api/workspaces/demo/workflows/build", body: `{"enabled":true}`},
+		{name: "workspace secret upsert", method: http.MethodPut, path: "/api/workspaces/demo/secrets", body: `{"name":"TOKEN","value":"secret"}`},
+		{name: "workspace secret delete", method: http.MethodDelete, path: "/api/workspaces/demo/secrets?name=TOKEN"},
+		{name: "workspace github app upsert", method: http.MethodPost, path: "/api/workspaces/demo/github-apps", body: `{"name":"app","appId":1}`},
+		{name: "workspace github app delete", method: http.MethodDelete, path: "/api/workspaces/demo/github-apps?name=app"},
+		{name: "workspace issue tracker upsert", method: http.MethodPost, path: "/api/workspaces/demo/issue-trackers", body: `{"type":"linear","workspace":"eng","token":"token"}`},
+		{name: "workspace issue tracker delete", method: http.MethodDelete, path: "/api/workspaces/demo/issue-trackers?type=linear&workspace=eng"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, tt.path, strings.NewReader(tt.body))
+			req.Header.Set("Authorization", "Bearer "+session)
+			rec := httptest.NewRecorder()
+
+			mux.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("expected status %d, got %d: %s", http.StatusForbidden, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
 func TestProvisionReplicatedDefersEnvInjectionToBootstrap(t *testing.T) {
 	var createRequests int
 	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -1614,6 +1614,9 @@ func TestAdminForMethodsRequiresAdminForMutations(t *testing.T) {
 	if rec.Code != http.StatusNoContent {
 		t.Fatalf("expected mutation method to allow admin user, got %d", rec.Code)
 	}
+	if calls != 2 {
+		t.Fatalf("expected handler to be called for admin mutation, got %d calls", calls)
+	}
 
 	req = httptest.NewRequest(http.MethodPost, "/api/config", nil)
 	req.Header.Set("Authorization", "Bearer hub-token")
@@ -1621,6 +1624,29 @@ func TestAdminForMethodsRequiresAdminForMutations(t *testing.T) {
 	handler(rec, req)
 	if rec.Code != http.StatusNoContent {
 		t.Fatalf("expected mutation method to allow hub token, got %d", rec.Code)
+	}
+	if calls != 3 {
+		t.Fatalf("expected handler to be called for hub-token mutation, got %d calls", calls)
+	}
+
+	req = httptest.NewRequest(http.MethodPost, "/api/config?token=hub-token", nil)
+	rec = httptest.NewRecorder()
+	handler(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected mutation method to allow hub query token, got %d", rec.Code)
+	}
+	if calls != 4 {
+		t.Fatalf("expected handler to be called for hub query-token mutation, got %d calls", calls)
+	}
+
+	req = httptest.NewRequest(http.MethodPost, "/api/config?token=test-token", nil)
+	rec = httptest.NewRecorder()
+	handler(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected mutation method to reject tenant query token with %d, got %d", http.StatusUnauthorized, rec.Code)
+	}
+	if calls != 4 {
+		t.Fatalf("expected handler not to be called for tenant query-token mutation, got %d calls", calls)
 	}
 }
 


### PR DESCRIPTION
## Summary
- require web admin auth for mutating factory, workspace, workflow, secret, GitHub App, and issue tracker config routes
- keep read and manual trigger routes on normal authenticated access
- add auth helper and route-level tests covering regular GitHub users being blocked from config mutations

## Tests
- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./pkg/hub -run 'TestWebAdminAuthRequiresAccessAdminForGitHubSession|TestAdminForMethodsRequiresAdminForMutations|TestConfigMutationRoutesRequireWebAdminForGitHubSessions'
- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./...