### PR TITLE
Allow cron workflow validation

### DIFF
--- a/cmd/workflow_test.go
+++ b/cmd/workflow_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -44,5 +45,44 @@ func TestExampleGitHubIssueWorkflowPublishesNestedTrigger(t *testing.T) {
 	}
 	if strings.Contains(string(payload), `"githubIssues"`) {
 		t.Fatalf("payload used camelCase githubIssues source: %s", payload)
+	}
+}
+
+func TestCronWorkflowFileValidatesForPush(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "dependency-update.yaml")
+	data := []byte(`
+schema_version: v1
+name: dependency-update
+trigger:
+  cron:
+    schedule: "0 9 * * 1"
+    timezone: America/Chicago
+    overlap_policy: skip
+stages:
+  - id: working
+    entry: true
+    on_enter:
+      inject: start
+`)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+
+	workflows, err := readWorkflowFiles([]string{path})
+	if err != nil {
+		t.Fatalf("read workflow files: %v", err)
+	}
+	if len(workflows) != 1 {
+		t.Fatalf("workflow count = %d, want 1", len(workflows))
+	}
+	workflow := workflows[0]
+	if err := workflow.Validate(); err != nil {
+		t.Fatalf("validate workflow: %v", err)
+	}
+	if workflow.Integration != "cron" {
+		t.Fatalf("integration = %q, want cron", workflow.Integration)
+	}
+	if workflow.Trigger == nil || workflow.Trigger.Cron == nil {
+		t.Fatalf("cron trigger missing: %#v", workflow.Trigger)
 	}
 }

--- a/pkg/types/validation.go
+++ b/pkg/types/validation.go
@@ -24,8 +24,15 @@ var validIntegrations = map[string]bool{
 
 // Valid workflow integration types. Cron is workflow-only; factories still use
 // validIntegrations above.
-var validWorkflowIntegrations = map[string]bool{
-	"linear": true, "shortcut": true, "github-issues": true, "github": true, "external": true, "cron": true,
+var validWorkflowIntegrations = buildWorkflowIntegrations()
+
+func buildWorkflowIntegrations() map[string]bool {
+	integrations := make(map[string]bool, len(validIntegrations)+1)
+	for integration := range validIntegrations {
+		integrations[integration] = true
+	}
+	integrations["cron"] = true
+	return integrations
 }
 
 // Valid provider types

--- a/pkg/types/validation.go
+++ b/pkg/types/validation.go
@@ -22,6 +22,12 @@ var validIntegrations = map[string]bool{
 	"linear": true, "shortcut": true, "github-issues": true, "github": true, "external": true,
 }
 
+// Valid workflow integration types. Cron is workflow-only; factories still use
+// validIntegrations above.
+var validWorkflowIntegrations = map[string]bool{
+	"linear": true, "shortcut": true, "github-issues": true, "github": true, "external": true, "cron": true,
+}
+
 // Valid provider types
 var validProviders = map[string]bool{
 	"replicated": true, "daytona": true, "exedev": true, "docker": true,
@@ -179,8 +185,8 @@ func (w *WorkflowConfig) Validate() error {
 	if strings.TrimSpace(w.Name) == "" {
 		return fmt.Errorf("workflow name is required")
 	}
-	if w.Integration != "" && !validIntegrations[w.Integration] {
-		return fmt.Errorf("workflow %q: invalid integration %q (must be one of: linear, shortcut, github-issues, github, external)", w.Name, w.Integration)
+	if w.Integration != "" && !validWorkflowIntegrations[w.Integration] {
+		return fmt.Errorf("workflow %q: invalid integration %q (must be one of: linear, shortcut, github-issues, github, external, cron)", w.Name, w.Integration)
 	}
 	if w.Color != "" && !validColors[w.Color] {
 		return fmt.Errorf("workflow %q: invalid color %q", w.Name, w.Color)

--- a/pkg/types/workflow_normalize_test.go
+++ b/pkg/types/workflow_normalize_test.go
@@ -201,6 +201,40 @@ stages:
 	}
 }
 
+func TestWorkflowV1CronTriggerValidates(t *testing.T) {
+	data := []byte(`
+schema_version: v1
+name: dependency-update
+trigger:
+  cron:
+    schedule: "0 9 * * 1"
+    timezone: America/Chicago
+    overlap_policy: skip
+    timeout: 2h
+stages:
+  - id: working
+    entry: true
+    on_enter:
+      inject: start
+`)
+	var workflow WorkflowConfig
+	if err := yaml.Unmarshal(data, &workflow); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if err := NormalizeWorkflowConfig(&workflow); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if err := workflow.Validate(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if workflow.Integration != "cron" {
+		t.Fatalf("integration = %q, want cron", workflow.Integration)
+	}
+	if !strings.Contains(workflow.PipelineYAML, "stages:") {
+		t.Fatalf("pipeline yaml did not contain stages: %q", workflow.PipelineYAML)
+	}
+}
+
 func TestWorkflowV1RejectsLegacyFlatTrigger(t *testing.T) {
 	data := []byte(`
 schema_version: v1


### PR DESCRIPTION
## Summary
- allow cron as a workflow-only integration during validation
- keep factory integration validation unchanged
- add cron workflow regression coverage for normalization and workflow push file loading

## Tests
- make test