### PR TITLE
Reload cron workflows after workflow updates

### DIFF
--- a/pkg/hub/cron_scheduler.go
+++ b/pkg/hub/cron_scheduler.go
@@ -172,6 +172,9 @@ func (cs *cronScheduler) reloadWorkflows() error {
 func (cs *cronScheduler) reload() error {
 	cs.mu.Lock()
 	defer cs.mu.Unlock()
+	if cs.cron == nil {
+		return nil
+	}
 	return cs.reloadWorkflows()
 }
 

--- a/pkg/hub/cron_scheduler.go
+++ b/pkg/hub/cron_scheduler.go
@@ -169,6 +169,12 @@ func (cs *cronScheduler) reloadWorkflows() error {
 	return nil
 }
 
+func (cs *cronScheduler) reload() error {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	return cs.reloadWorkflows()
+}
+
 // parseCronSchedule parses a cron schedule with timezone support.
 // If the schedule has seconds field (6 fields), we use WithSeconds.
 func parseCronSchedule(schedule string, loc *time.Location) (cron.Schedule, error) {
@@ -514,25 +520,5 @@ func (cs *cronScheduler) getRunHistory(workspaceName, workflowName string, limit
 
 // loadAllWorkspaces loads all workspace configurations.
 func (s *Server) loadAllWorkspaces() ([]*types.WorkspaceConfig, error) {
-	rows, err := s.db.Query(`SELECT name, config FROM workspaces`)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	var workspaces []*types.WorkspaceConfig
-	for rows.Next() {
-		var name string
-		var configJSON []byte
-		if err := rows.Scan(&name, &configJSON); err != nil {
-			return nil, err
-		}
-		var ws types.WorkspaceConfig
-		if err := json.Unmarshal(configJSON, &ws); err != nil {
-			log.Printf("[cron] failed to unmarshal workspace %s: %v", name, err)
-			continue
-		}
-		workspaces = append(workspaces, &ws)
-	}
-	return workspaces, rows.Err()
+	return loadExternalWorkspaces()
 }

--- a/pkg/hub/workspace_api.go
+++ b/pkg/hub/workspace_api.go
@@ -3,6 +3,7 @@ package hub
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 	"sort"
@@ -182,8 +183,7 @@ func (s *Server) handleWorkspaceWorkflowsPush(w http.ResponseWriter, r *http.Req
 	}
 	if s.cronScheduler != nil {
 		if err := s.cronScheduler.reload(); err != nil {
-			http.Error(w, "reload cron workflows: "+err.Error(), http.StatusInternalServerError)
-			return
+			log.Printf("[cron] failed to reload workflows after workflow push for workspace %s: %v", name, err)
 		}
 	}
 	workflows := make([]WorkflowView, 0, len(req.Workflows))
@@ -268,8 +268,7 @@ func (s *Server) handleWorkspaceWorkflowPatch(w http.ResponseWriter, r *http.Req
 	}
 	if s.cronScheduler != nil {
 		if err := s.cronScheduler.reload(); err != nil {
-			http.Error(w, "reload cron workflows: "+err.Error(), http.StatusInternalServerError)
-			return
+			log.Printf("[cron] failed to reload workflows after workflow patch for workspace %s workflow %s: %v", workspace.Name, workflow.Name, err)
 		}
 	}
 	jsonOK(w, workflowToView(workspace.Name, workflow))

--- a/pkg/hub/workspace_api.go
+++ b/pkg/hub/workspace_api.go
@@ -180,6 +180,12 @@ func (s *Server) handleWorkspaceWorkflowsPush(w http.ResponseWriter, r *http.Req
 		http.Error(w, "save workflows: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
+	if s.cronScheduler != nil {
+		if err := s.cronScheduler.reload(); err != nil {
+			http.Error(w, "reload cron workflows: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
 	workflows := make([]WorkflowView, 0, len(req.Workflows))
 	for _, workflow := range req.Workflows {
 		workflows = append(workflows, workflowToView(name, workflow))
@@ -259,6 +265,12 @@ func (s *Server) handleWorkspaceWorkflowPatch(w http.ResponseWriter, r *http.Req
 	if err := saveExternalWorkflows(workspace.Name, []*types.WorkflowConfig{workflow}); err != nil {
 		http.Error(w, "save workflow: "+err.Error(), http.StatusInternalServerError)
 		return
+	}
+	if s.cronScheduler != nil {
+		if err := s.cronScheduler.reload(); err != nil {
+			http.Error(w, "reload cron workflows: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
 	}
 	jsonOK(w, workflowToView(workspace.Name, workflow))
 }

--- a/pkg/hub/workspace_api_test.go
+++ b/pkg/hub/workspace_api_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/elasticclaw/elasticclaw/pkg/types"
+	"github.com/robfig/cron/v3"
 )
 
 func TestWorkspacesEndpointReturnsPersistedWorkspacesOnly(t *testing.T) {
@@ -191,6 +192,75 @@ func TestWorkflowPushAcceptsNestedGitHubIssuesTrigger(t *testing.T) {
 	}
 }
 
+func TestWorkflowPushReloadsCronScheduler(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", configDir+"/hub.yaml")
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+	s.cronScheduler = newCronScheduler(s)
+	s.cronScheduler.cron = cron.New(cron.WithSeconds())
+
+	body := `{"workspaces":[{"name":"engineering"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/api/workspaces", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("workspace push status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+
+	body = `{"workflows":[{"schemaVersion":"v1","name":"dependency-update-go","trigger":{"cron":{"schedule":"*/1 * * * *","timezone":"America/Chicago","overlap_policy":"skip","timeout":"2h"}},"stages":[{"id":"working","entry":true}]}]}`
+	req = httptest.NewRequest(http.MethodPost, "/api/workspaces/engineering/workflows", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	rr = httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("workflow push status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+
+	if _, ok := s.cronScheduler.entries["engineering/dependency-update-go"]; !ok {
+		t.Fatalf("cron workflow was not registered: %#v", s.cronScheduler.entries)
+	}
+}
+
+func TestCronSchedulerStartLoadsExternalWorkflows(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", configDir+"/hub.yaml")
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+	SaveWorkspaceForTest(t,
+		&types.WorkspaceConfig{
+			SchemaVersion: "v1",
+			Name:          "engineering",
+		},
+		[]*types.WorkflowConfig{{
+			SchemaVersion: "v1",
+			Name:          "dependency-update-go",
+			Trigger: &types.WorkflowTrigger{
+				Cron: &types.CronWorkflowTrigger{
+					Schedule:      "*/1 * * * *",
+					Timezone:      "America/Chicago",
+					OverlapPolicy: "skip",
+				},
+			},
+			Stages: []types.WorkflowStage{{
+				ID:    "working",
+				Entry: true,
+			}},
+		}},
+	)
+
+	s.cronScheduler = newCronScheduler(s)
+	if err := s.cronScheduler.start(); err != nil {
+		t.Fatalf("start cron scheduler: %v", err)
+	}
+	t.Cleanup(s.cronScheduler.stop)
+
+	if _, ok := s.cronScheduler.entries["engineering/dependency-update-go"]; !ok {
+		t.Fatalf("cron workflow was not registered on startup: %#v", s.cronScheduler.entries)
+	}
+}
+
 func TestWorkspaceWorkflowPatchUpdatesTriggerControls(t *testing.T) {
 	configDir := t.TempDir()
 	t.Setenv("ELASTICCLAW_HUB_CONFIG", configDir+"/hub.yaml")
@@ -245,6 +315,50 @@ func TestWorkspaceWorkflowPatchUpdatesTriggerControls(t *testing.T) {
 	}
 	if persisted.Trigger == nil || persisted.Trigger.GitHubIssues == nil || len(persisted.Stages) != 1 {
 		t.Fatalf("patch did not preserve trigger/stages: %#v", persisted)
+	}
+}
+
+func TestWorkspaceWorkflowPatchReloadsCronScheduler(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", configDir+"/hub.yaml")
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+	s.cronScheduler = newCronScheduler(s)
+	s.cronScheduler.cron = cron.New(cron.WithSeconds())
+
+	body := `{"workspaces":[{"name":"engineering"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/api/workspaces", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("workspace push status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+
+	body = `{"workflows":[{"schemaVersion":"v1","name":"dependency-update-go","trigger":{"cron":{"schedule":"*/1 * * * *","timezone":"America/Chicago","overlap_policy":"skip"}},"stages":[{"id":"working","entry":true}]}]}`
+	req = httptest.NewRequest(http.MethodPost, "/api/workspaces/engineering/workflows", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	rr = httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("workflow push status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	if _, ok := s.cronScheduler.entries["engineering/dependency-update-go"]; !ok {
+		t.Fatalf("cron workflow was not registered: %#v", s.cronScheduler.entries)
+	}
+
+	req = httptest.NewRequest(http.MethodPatch, "/api/workspaces/engineering/workflows/dependency-update-go", strings.NewReader(`{"enabled":false}`))
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	rr = httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("patch status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+
+	if _, ok := s.cronScheduler.entries["engineering/dependency-update-go"]; ok {
+		t.Fatalf("disabled cron workflow remained registered: %#v", s.cronScheduler.entries)
 	}
 }
 

--- a/pkg/hub/workspace_api_test.go
+++ b/pkg/hub/workspace_api_test.go
@@ -224,6 +224,33 @@ func TestWorkflowPushReloadsCronScheduler(t *testing.T) {
 	}
 }
 
+func TestWorkflowPushWithUnstartedCronSchedulerStillSucceeds(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", configDir+"/hub.yaml")
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+	s.cronScheduler = newCronScheduler(s)
+
+	body := `{"workspaces":[{"name":"engineering"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/api/workspaces", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("workspace push status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+
+	body = `{"workflows":[{"schemaVersion":"v1","name":"dependency-update-go","trigger":{"cron":{"schedule":"*/1 * * * *","timezone":"America/Chicago","overlap_policy":"skip"}},"stages":[{"id":"working","entry":true}]}]}`
+	req = httptest.NewRequest(http.MethodPost, "/api/workspaces/engineering/workflows", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	rr = httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("workflow push status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+}
+
 func TestCronSchedulerStartLoadsExternalWorkflows(t *testing.T) {
 	configDir := t.TempDir()
 	t.Setenv("ELASTICCLAW_HUB_CONFIG", configDir+"/hub.yaml")


### PR DESCRIPTION
## Summary
- load cron schedules from external workspace storage, matching the workspace/workflow APIs
- reload the cron scheduler after workflow push and workflow patch
- add regression coverage for cron registration on push and removal when disabled

## Why
Pushed cron workflows could validate and persist but not run until the scheduler saw them. In practice the scheduler was also reading a legacy workspace table rather than the external workspace files used by workflow push.

## Tests
- go test ./pkg/hub
- make test