### PR TITLE
Ignore unusable LLM keys for workflow bootstrap

### DIFF
--- a/pkg/hub/bootstrap.go
+++ b/pkg/hub/bootstrap.go
@@ -46,17 +46,21 @@ type BootstrapParams struct {
 // resolveActiveKey selects the active key by selected name, then default, then first.
 func resolveActiveKey(keys []*types.LLMKeyConfig, selectedKeyName string) *types.LLMKeyConfig {
 	for _, k := range keys {
-		if k.Name == selectedKeyName {
+		if k.Name == selectedKeyName && llmKeyHasRequiredAPIKey(k) {
 			return k
 		}
 	}
 	for _, k := range keys {
-		if k.Default {
+		if k.Default && llmKeyHasRequiredAPIKey(k) {
 			return k
 		}
 	}
 	if len(keys) > 0 {
-		return keys[0]
+		for _, k := range keys {
+			if llmKeyHasRequiredAPIKey(k) {
+				return k
+			}
+		}
 	}
 	return nil
 }

--- a/pkg/hub/bootstrap_test.go
+++ b/pkg/hub/bootstrap_test.go
@@ -305,7 +305,7 @@ func TestBuildOnboardFlags_OpenAICompatibleProviders(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			keys := []*types.LLMKeyConfig{
-				{Name: tc.name + "-key", Provider: tc.provider, Default: true},
+				{Name: tc.name + "-key", Provider: tc.provider, APIKey: "test-key", Default: true},
 			}
 			flags := buildOnboardFlags(keys, "", "")
 			assertContains(t, flags, "--auth-choice "+tc.authChoice, "provider auth choice")
@@ -313,6 +313,32 @@ func TestBuildOnboardFlags_OpenAICompatibleProviders(t *testing.T) {
 			assertNotContains(t, flags, "anthropic-api-key", "should not fallback to anthropic")
 		})
 	}
+}
+
+func TestBuildOnboardFlagsSkipsBlankExternalKeys(t *testing.T) {
+	keys := []*types.LLMKeyConfig{
+		{Name: "openai-empty", Provider: "openai", Default: true},
+		{Name: "anthropic-main", Provider: "anthropic", APIKey: "sk-ant-test"},
+	}
+
+	flags := buildOnboardFlags(keys, "", "")
+
+	assertContains(t, flags, "--auth-choice anthropic-api-key", "uses usable external key")
+	assertNotContains(t, flags, "openai-api-key", "does not select blank OpenAI key")
+}
+
+func TestBuildLLMKeyEnvSkipsBlankExternalKeys(t *testing.T) {
+	keys := []*types.LLMKeyConfig{
+		{Name: "openai-empty", Provider: "openai", Default: true},
+		{Name: "anthropic-main", Provider: "anthropic", APIKey: "sk-ant-test"},
+		{Name: "ollama-local", Provider: "ollama"},
+	}
+
+	env := buildLLMKeyEnv(keys, "")
+
+	assertContains(t, env, "ANTHROPIC_API_KEY", "exports usable external key")
+	assertContains(t, env, "OLLAMA_API_KEY", "exports blank Ollama key because Ollama auth does not require an API key")
+	assertNotContains(t, env, "OPENAI_API_KEY", "does not export blank OpenAI key")
 }
 
 func TestBuildOnboardFlags_OllamaUsesNativeBaseURLAndModelID(t *testing.T) {

--- a/pkg/hub/bootstrap_test.go
+++ b/pkg/hub/bootstrap_test.go
@@ -341,6 +341,21 @@ func TestBuildLLMKeyEnvSkipsBlankExternalKeys(t *testing.T) {
 	assertNotContains(t, env, "OPENAI_API_KEY", "does not export blank OpenAI key")
 }
 
+func TestResolveModelAndLLMKeyReplacesUnusableSelectedKey(t *testing.T) {
+	hubCfg := &types.HubConfig{
+		LLMKeys: types.LLMKeysList{
+			{Name: "openai-empty", Provider: "openai", Default: true},
+			{Name: "anthropic-main", Provider: "anthropic", APIKey: "sk-ant-test"},
+		},
+	}
+
+	model, llmKey := resolveModelAndLLMKey(hubCfg, "openai-empty", "")
+
+	if model != "anthropic/claude-sonnet-4-6" || llmKey != "anthropic-main" {
+		t.Fatalf("model/llm_key = %q/%q, want anthropic fallback", model, llmKey)
+	}
+}
+
 func TestBuildOnboardFlags_OllamaUsesNativeBaseURLAndModelID(t *testing.T) {
 	keys := []*types.LLMKeyConfig{
 		{Name: "ollama-main", Provider: "ollama", Default: true},

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -5328,7 +5328,7 @@ func resolveModelAndLLMKey(hubCfg *types.HubConfig, selectedKeyName, defaultMode
 	if resolvedModel == "" {
 		activeKey := resolveActiveKey(hubCfg.LLMKeys, selectedKeyName)
 		if activeKey != nil {
-			if resolvedKeyName == "" {
+			if resolvedKeyName == "" || resolvedKeyName != activeKey.Name {
 				resolvedKeyName = activeKey.Name
 			}
 			resolvedModel = resolveDefaultModelForKey(hubCfg, activeKey)

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -4918,6 +4918,7 @@ func (s *Server) bootstrapReplicated(clawID, clawName, vmID string, cfg types.Pr
 	// Read llm_key selection
 	var llmKeyName string
 	_ = s.db.QueryRow(`SELECT COALESCE(llm_key,'') FROM claws WHERE id=?`, clawID).Scan(&llmKeyName)
+	defaultModel, llmKeyName = resolveModelAndLLMKey(s.hubCfg, llmKeyName, defaultModel)
 	log.Printf("[bootstrap] OpenClaw model resolution claw=%s llm_key=%q template_default_model=%q hub_default_model=%q resolved_default_model=%q",
 		clawID[:8], llmKeyName, templateDefaultModel, s.hubCfg.DefaultModel, defaultModel)
 
@@ -5239,7 +5240,7 @@ func buildLLMKeyEnv(keys []*types.LLMKeyConfig, selectedKeyName string) string {
 	// First pass: export the selected key if specified
 	if selectedKeyName != "" {
 		for _, k := range keys {
-			if k.Name == selectedKeyName {
+			if k.Name == selectedKeyName && llmKeyHasRequiredAPIKey(k) {
 				envVar := k.EnvVarName()
 				seen[envVar] = true
 				fmt.Fprintf(&b, "export %s=%q\n", envVar, k.APIKey)
@@ -5250,7 +5251,7 @@ func buildLLMKeyEnv(keys []*types.LLMKeyConfig, selectedKeyName string) string {
 
 	// Second pass: export default keys for providers not yet seen
 	for _, k := range keys {
-		if !k.Default {
+		if !k.Default || !llmKeyHasRequiredAPIKey(k) {
 			continue
 		}
 		envVar := k.EnvVarName()
@@ -5262,6 +5263,9 @@ func buildLLMKeyEnv(keys []*types.LLMKeyConfig, selectedKeyName string) string {
 	}
 	// Third pass: export non-default keys for providers not yet seen
 	for _, k := range keys {
+		if !llmKeyHasRequiredAPIKey(k) {
+			continue
+		}
 		envVar := k.EnvVarName()
 		if seen[envVar] {
 			continue
@@ -5313,6 +5317,27 @@ func resolveDefaultModelForKey(hubCfg *types.HubConfig, key *types.LLMKeyConfig)
 		// Fall back to hub default even if provider doesn't match
 		return hubCfg.DefaultModel
 	}
+}
+
+func resolveModelAndLLMKey(hubCfg *types.HubConfig, selectedKeyName, defaultModel string) (string, string) {
+	if hubCfg == nil {
+		return defaultModel, selectedKeyName
+	}
+	resolvedModel := defaultModel
+	resolvedKeyName := selectedKeyName
+	if resolvedModel == "" {
+		activeKey := resolveActiveKey(hubCfg.LLMKeys, selectedKeyName)
+		if activeKey != nil {
+			if resolvedKeyName == "" {
+				resolvedKeyName = activeKey.Name
+			}
+			resolvedModel = resolveDefaultModelForKey(hubCfg, activeKey)
+		}
+	}
+	if resolvedModel == "" {
+		resolvedModel = hubCfg.DefaultModel
+	}
+	return resolvedModel, resolvedKeyName
 }
 
 // buildGitHubCloneScript returns shell lines that clone repos into the current directory.

--- a/pkg/hub/workflow_creator.go
+++ b/pkg/hub/workflow_creator.go
@@ -172,16 +172,9 @@ func (s *Server) createClawFromWorkflowWithOptions(workspace *types.WorkspaceCon
 			linearWorkspace = tmplCfg.Linear.Workspace
 		}
 	}
-	if defaultModel == "" && llmKey != "" {
-		s.mu.RLock()
-		for _, k := range s.hubCfg.LLMKeys {
-			if k.Name == llmKey {
-				defaultModel = resolveDefaultModelForKey(s.hubCfg, k)
-				break
-			}
-		}
-		s.mu.RUnlock()
-	}
+	s.mu.RLock()
+	defaultModel, llmKey = resolveModelAndLLMKey(s.hubCfg, llmKey, defaultModel)
+	s.mu.RUnlock()
 
 	tags := mergeTags(workspace.Name, workflow.Tags, nil)
 	tags = append(tags, "workspace:"+workspace.Name, "workflow:"+workflow.Name)

--- a/pkg/hub/workspace_api_test.go
+++ b/pkg/hub/workspace_api_test.go
@@ -500,6 +500,40 @@ func TestWorkspaceWorkflowTriggerAllowsPausedManualWorkflow(t *testing.T) {
 	}
 }
 
+func TestWorkflowCreationUsesDefaultUsableLLMKey(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{
+		Token:     "test-token",
+		ClawToken: "test-claw-token",
+		Providers: map[string]types.ProviderConfig{
+			"noop": {Type: "noop"},
+		},
+		LLMKeys: types.LLMKeysList{
+			{Name: "openai-empty", Provider: "openai", Default: true},
+			{Name: "anthropic-main", Provider: "anthropic", APIKey: "sk-ant-test"},
+		},
+	}, "", "", "")
+	workspace := &types.WorkspaceConfig{
+		Name:  "engineering",
+		Files: map[string]string{"elasticclaw-config.yaml": "schema_version: v1\nname: engineering\nprovider: noop\n"},
+	}
+	workflow := &types.WorkflowConfig{Name: "dependency-update-go", Provider: "noop"}
+
+	clawID, _, err := s.createClawFromWorkflow(workspace, workflow, nil, "cron run")
+	if err != nil {
+		t.Fatalf("create workflow claw: %v", err)
+	}
+
+	var model, llmKey string
+	if err := db.QueryRow(`SELECT default_model, llm_key FROM claws WHERE id=?`, clawID).Scan(&model, &llmKey); err != nil {
+		t.Fatalf("read claw model: %v", err)
+	}
+	if model != "anthropic/claude-sonnet-4-6" || llmKey != "anthropic-main" {
+		t.Fatalf("model/llm_key = %q/%q, want anthropic default", model, llmKey)
+	}
+}
+
 func TestWorkspaceWorkflowTriggerCreatesGitHubIssueWorkflowFromIssueNumber(t *testing.T) {
 	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
 	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")


### PR DESCRIPTION
## Summary
- skip blank external LLM keys when selecting OpenClaw onboard/auth defaults
- skip exporting blank external LLM key env vars while preserving blank Ollama support
- resolve workflow-created claws to the active usable hub LLM key/model when no workflow model is configured
- repair empty model/key resolution during replicated bootstrap for already-created claws

## Root cause
Cron workflow claws can be created with empty default_model and llm_key when the workspace/workflow does not specify them. If the hub has a stale blank OpenAI key, bootstrap still selected/exported it, leaving OpenClaw to ask for OpenAI auth even though the workflow never requested OpenAI.

## Tests
- go test ./pkg/hub
- make test