### PR TITLE
Improve manual workflow trigger context

### DIFF
--- a/pkg/hub/factory_pr_policy_test.go
+++ b/pkg/hub/factory_pr_policy_test.go
@@ -82,7 +82,7 @@ func TestFactoryContextsIncludeDefaultPRPolicy(t *testing.T) {
 		"shortcut story":          buildShortcutContext(shortcut, "128"),
 		"external event":          buildExternalEventContext(externalPayload, externalFactory),
 		"manual factory trigger":  buildManualTriggerContext(manualFactory, map[string]string{"task": "fix issue 128"}),
-		"manual workflow trigger": buildWorkflowManualTriggerContext(manualWorkflow, map[string]string{"task": "fix issue 128"}),
+		"manual workflow trigger": buildWorkflowManualTriggerContext(manualWorkflow, map[string]string{"task": "fix issue 128"}, ""),
 	}
 
 	for name, content := range cases {
@@ -97,6 +97,38 @@ func TestFactoryContextsIncludeDefaultPRPolicy(t *testing.T) {
 				t.Fatalf("context missing DONE PR URL contract:\n%s", content)
 			}
 		})
+	}
+}
+
+func TestWorkflowManualTriggerContextIncludesTaskAndWorkspaceContext(t *testing.T) {
+	workflow := &types.WorkflowConfig{
+		Name: "dependency-update-go",
+		Stages: []types.WorkflowStage{{
+			ID:    "working",
+			Entry: true,
+			OnEnter: map[string]interface{}{
+				"inject": "Workflow task: run the Go dependency update maintenance workflow for vandoor.\n\nReview {{ .Outputs.dependency_updates.files_changed }}.",
+			},
+		}},
+	}
+
+	content := buildWorkflowManualTriggerContext(workflow, map[string]string{}, "Workspace context for vandoor")
+
+	for _, want := range []string{
+		"# Manual Workflow Trigger: dependency-update-go",
+		"No manual inputs were provided.",
+		"Workflow task: run the Go dependency update maintenance workflow for vandoor.",
+		"Review {{ .Outputs.dependency_updates.files_changed }}.",
+		"## Workspace Context",
+		"Workspace context for vandoor",
+		"## PR Completion Policy",
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("context missing %q:\n%s", want, content)
+		}
+	}
+	if strings.Contains(content, "Read the trigger inputs fully") {
+		t.Fatalf("context should not ask for trigger inputs when workflow has none:\n%s", content)
 	}
 }
 

--- a/pkg/hub/workflow_creator.go
+++ b/pkg/hub/workflow_creator.go
@@ -45,7 +45,7 @@ func (s *Server) createClawFromWorkflowWithOptions(workspace *types.WorkspaceCon
 	}
 
 	if opts.inputs != nil {
-		templateFiles["CONTEXT.md"] = buildWorkflowManualTriggerContext(workflow, opts.inputs)
+		templateFiles["CONTEXT.md"] = buildWorkflowManualTriggerContext(workflow, opts.inputs, templateFiles["CONTEXT.md"])
 		inputsJSON, _ := json.Marshal(opts.inputs)
 		templateFiles["TRIGGER_INPUTS.json"] = string(inputsJSON)
 	}
@@ -330,27 +330,68 @@ func (s *Server) resolveWorkflowGroupLimit(workflow *types.WorkflowConfig) (stri
 	return groupName, 0
 }
 
-func buildWorkflowManualTriggerContext(workflow *types.WorkflowConfig, inputs map[string]string) string {
+func buildWorkflowManualTriggerContext(workflow *types.WorkflowConfig, inputs map[string]string, workspaceContext string) string {
 	var b strings.Builder
-	b.WriteString(fmt.Sprintf("# Manual Trigger: %s\n\n", workflow.Name))
+	b.WriteString(fmt.Sprintf("# Manual Workflow Trigger: %s\n\n", workflow.Name))
 	b.WriteString("## Inputs\n\n")
-	for _, in := range workflow.Inputs {
-		val, ok := inputs[in.Name]
-		if !ok {
-			val = in.Default
-		}
-		b.WriteString(fmt.Sprintf("- **%s**: %s\n", in.Name, val))
-		if in.Description != "" {
-			b.WriteString(fmt.Sprintf("  - %s\n", in.Description))
+	if len(workflow.Inputs) == 0 {
+		b.WriteString("No manual inputs were provided.\n")
+	} else {
+		for _, in := range workflow.Inputs {
+			val, ok := inputs[in.Name]
+			if !ok {
+				val = in.Default
+			}
+			b.WriteString(fmt.Sprintf("- **%s**: %s\n", in.Name, val))
+			if in.Description != "" {
+				b.WriteString(fmt.Sprintf("  - %s\n", in.Description))
+			}
 		}
 	}
+	if inject := workflowEntryInject(workflow); inject != "" {
+		b.WriteString("\n## Workflow Task\n\n")
+		b.WriteString(inject)
+		if !strings.HasSuffix(inject, "\n") {
+			b.WriteString("\n")
+		}
+	}
+	if workspaceContext = strings.TrimSpace(workspaceContext); workspaceContext != "" {
+		b.WriteString("\n## Workspace Context\n\n")
+		b.WriteString(workspaceContext)
+		b.WriteString("\n")
+	}
 	b.WriteString("\n## Instructions\n\n")
-	b.WriteString("1. Read the trigger inputs fully\n")
-	b.WriteString("2. Explore the codebase\n")
-	b.WriteString("3. Implement the requested work\n")
-	b.WriteString("4. Follow the PR Completion Policy below\n")
+	if len(workflow.Inputs) > 0 {
+		b.WriteString("1. Read the trigger inputs fully\n")
+		b.WriteString("2. Follow the workflow task and workspace context\n")
+		b.WriteString("3. Explore the codebase as needed\n")
+		b.WriteString("4. Follow the PR Completion Policy below\n")
+	} else {
+		b.WriteString("1. Follow the workflow task and workspace context\n")
+		b.WriteString("2. Explore the codebase as needed\n")
+		b.WriteString("3. Follow the PR Completion Policy below\n")
+	}
 	appendDefaultFactoryPRPolicy(&b)
 	return b.String()
+}
+
+func workflowEntryInject(workflow *types.WorkflowConfig) string {
+	for _, stage := range workflow.Stages {
+		if !stage.Entry {
+			continue
+		}
+		if inject, ok := stage.OnEnter["inject"].(string); ok {
+			return strings.TrimSpace(inject)
+		}
+		return ""
+	}
+	if len(workflow.Stages) == 0 {
+		return ""
+	}
+	if inject, ok := workflow.Stages[0].OnEnter["inject"].(string); ok {
+		return strings.TrimSpace(inject)
+	}
+	return ""
 }
 
 func buildSecretsFile(resolved map[string]string) string {


### PR DESCRIPTION
## Summary
- preserve workspace CONTEXT.md when creating manually triggered workflow claws
- include the workflow entry inject task in the generated manual trigger context
- avoid telling no-input manual workflows to read trigger inputs

## Why
Manual workflow triggers with no inputs were bootstrapped with a generic CONTEXT.md, which could make workflows like dependency-update-go start without the operational task context that cron runs receive through the workflow pipeline.

## Test
- go test ./pkg/hub -run 'TestWorkflowManualTriggerContextIncludesTaskAndWorkspaceContext|TestFactoryContextsIncludePRCompletionPolicy'
- go test ./pkg/hub