### PR TITLE
Add workflow artifact volumes

### DIFF
--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -2816,6 +2816,12 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 		case "checkpoint_create":
 			go handleCheckpointCreate(ctx, msg.Payload)
 
+		case "volume_attach":
+			go handleVolumeAttach(ctx, conn, msg.Payload)
+
+		case "volume_sync":
+			go handleVolumeSync(ctx, conn, msg.Payload)
+
 		default:
 			// ignore unknown message types
 		}

--- a/cmd/claw-bridge/volumes.go
+++ b/cmd/claw-bridge/volumes.go
@@ -1,0 +1,218 @@
+package main
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+	"nhooyr.io/websocket"
+	"nhooyr.io/websocket/wsjson"
+)
+
+func handleVolumeAttach(ctx context.Context, conn *websocket.Conn, payload json.RawMessage) {
+	var req types.VolumeAttachPayload
+	if err := json.Unmarshal(payload, &req); err != nil {
+		log.Printf("[volume] bad attach payload: %v", err)
+		return
+	}
+	err := attachVolume(ctx, req)
+	ack := types.VolumeAttachAck{RequestID: req.RequestID, LeaseID: req.LeaseID, OK: err == nil}
+	if err != nil {
+		ack.Error = err.Error()
+	}
+	_ = wsjson.Write(ctx, conn, hubMsg{Type: "volume_attach_ack", Payload: mustJSON(ack)})
+}
+
+func handleVolumeSync(ctx context.Context, conn *websocket.Conn, payload json.RawMessage) {
+	var req types.VolumeSyncPayload
+	if err := json.Unmarshal(payload, &req); err != nil {
+		log.Printf("[volume] bad sync payload: %v", err)
+		return
+	}
+	err := syncVolume(ctx, req)
+	ack := types.VolumeSyncAck{RequestID: req.RequestID, LeaseID: req.LeaseID, OK: err == nil}
+	if err != nil {
+		ack.Error = err.Error()
+	}
+	_ = wsjson.Write(ctx, conn, hubMsg{Type: "volume_sync_ack", Payload: mustJSON(ack)})
+}
+
+func attachVolume(ctx context.Context, req types.VolumeAttachPayload) error {
+	if err := validateVolumeMount(req.Mount); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(req.Mount, 0o750); err != nil {
+		return fmt.Errorf("mkdir mount: %w", err)
+	}
+	url := fmt.Sprintf("%s/api/volumes/leases/%s/archive", strings.TrimRight(req.HubURL, "/"), req.LeaseID)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	httpReq.Header.Set("X-Claw-Token", req.ClawToken)
+	resp, err := http.DefaultClient.Do(httpReq)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("download volume archive: HTTP %d: %s", resp.StatusCode, string(body))
+	}
+	return extractTarGzip(resp.Body, req.Mount)
+}
+
+func syncVolume(ctx context.Context, req types.VolumeSyncPayload) error {
+	if req.Mode != "rw" {
+		return nil
+	}
+	if err := validateVolumeMount(req.Mount); err != nil {
+		return err
+	}
+	pr, pw := io.Pipe()
+	go func() {
+		pw.CloseWithError(writeTarGzip(pw, req.Mount))
+	}()
+	url := fmt.Sprintf("%s/api/volumes/leases/%s/archive", strings.TrimRight(req.HubURL, "/"), req.LeaseID)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPut, url, pr)
+	if err != nil {
+		_ = pr.Close()
+		return err
+	}
+	httpReq.Header.Set("X-Claw-Token", req.ClawToken)
+	resp, err := http.DefaultClient.Do(httpReq)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("upload volume archive: HTTP %d: %s", resp.StatusCode, string(body))
+	}
+	return nil
+}
+
+func validateVolumeMount(mount string) error {
+	mount = strings.TrimSpace(mount)
+	if mount == "" || !filepath.IsAbs(mount) {
+		return fmt.Errorf("volume mount must be absolute")
+	}
+	clean := filepath.Clean(mount)
+	if clean == "/" || strings.HasPrefix(clean, filepath.Join(os.Getenv("HOME"), ".openclaw", "workspace")) {
+		return fmt.Errorf("volume mount must be outside the repository workspace")
+	}
+	return nil
+}
+
+func extractTarGzip(r io.Reader, dest string) error {
+	gz, err := gzip.NewReader(r)
+	if err != nil {
+		return err
+	}
+	defer gz.Close()
+	tr := tar.NewReader(gz)
+	cleanDest, err := filepath.Abs(dest)
+	if err != nil {
+		return err
+	}
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		name := filepath.Clean(hdr.Name)
+		if name == "." || strings.HasPrefix(name, "..") || filepath.IsAbs(name) {
+			return fmt.Errorf("unsafe archive path %q", hdr.Name)
+		}
+		target := filepath.Join(cleanDest, name)
+		if !strings.HasPrefix(target, cleanDest+string(os.PathSeparator)) && target != cleanDest {
+			return fmt.Errorf("archive path escapes mount: %q", hdr.Name)
+		}
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, os.FileMode(hdr.Mode)&0o777); err != nil {
+				return err
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0o750); err != nil {
+				return err
+			}
+			f, err := os.OpenFile(target, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.FileMode(hdr.Mode)&0o777)
+			if err != nil {
+				return err
+			}
+			_, copyErr := io.Copy(f, tr)
+			closeErr := f.Close()
+			if copyErr != nil {
+				return copyErr
+			}
+			if closeErr != nil {
+				return closeErr
+			}
+		}
+	}
+}
+
+func writeTarGzip(w io.Writer, root string) error {
+	gz := gzip.NewWriter(w)
+	tw := tar.NewWriter(gz)
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if path == root {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		hdr, err := tar.FileInfoHeader(info, "")
+		if err != nil {
+			return err
+		}
+		hdr.Name = filepath.ToSlash(rel)
+		if err := tw.WriteHeader(hdr); err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		_, copyErr := io.Copy(tw, f)
+		closeErr := f.Close()
+		if copyErr != nil {
+			return copyErr
+		}
+		return closeErr
+	})
+	if closeErr := tw.Close(); err == nil {
+		err = closeErr
+	}
+	if closeErr := gz.Close(); err == nil {
+		err = closeErr
+	}
+	return err
+}

--- a/cmd/claw-bridge/volumes.go
+++ b/cmd/claw-bridge/volumes.go
@@ -107,7 +107,9 @@ func validateVolumeMount(mount string) error {
 		return fmt.Errorf("volume mount must be absolute")
 	}
 	clean := filepath.Clean(mount)
-	if clean == "/" || strings.HasPrefix(clean, filepath.Join(os.Getenv("HOME"), ".openclaw", "workspace")) {
+	if clean == "/" ||
+		strings.HasPrefix(clean, "/home/daytona/.openclaw/workspace") ||
+		strings.HasPrefix(clean, "/workspace") {
 		return fmt.Errorf("volume mount must be outside the repository workspace")
 	}
 	return nil

--- a/cmd/claw-bridge/volumes.go
+++ b/cmd/claw-bridge/volumes.go
@@ -79,24 +79,33 @@ func syncVolume(ctx context.Context, req types.VolumeSyncPayload) error {
 		return err
 	}
 	pr, pw := io.Pipe()
+	writeDone := make(chan error, 1)
 	go func() {
-		pw.CloseWithError(writeTarGzip(pw, req.Mount))
+		err := writeTarGzip(pw, req.Mount)
+		_ = pw.CloseWithError(err)
+		writeDone <- err
 	}()
 	url := fmt.Sprintf("%s/api/volumes/leases/%s/archive", strings.TrimRight(req.HubURL, "/"), req.LeaseID)
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPut, url, pr)
 	if err != nil {
-		_ = pr.Close()
+		_ = pr.CloseWithError(err)
+		<-writeDone
 		return err
 	}
 	httpReq.Header.Set("X-Claw-Token", req.ClawToken)
 	resp, err := http.DefaultClient.Do(httpReq)
 	if err != nil {
+		_ = pr.CloseWithError(err)
+		<-writeDone
 		return err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode >= 300 {
 		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("upload volume archive: HTTP %d: %s", resp.StatusCode, string(body))
+		err := fmt.Errorf("upload volume archive: HTTP %d: %s", resp.StatusCode, string(body))
+		_ = pr.CloseWithError(err)
+		<-writeDone
+		return err
 	}
 	return nil
 }

--- a/cmd/claw-bridge/volumes.go
+++ b/cmd/claw-bridge/volumes.go
@@ -107,7 +107,7 @@ func syncVolume(ctx context.Context, req types.VolumeSyncPayload) error {
 		<-writeDone
 		return err
 	}
-	return nil
+	return <-writeDone
 }
 
 func validateVolumeMount(mount string) error {

--- a/cmd/claw-bridge/volumes.go
+++ b/cmd/claw-bridge/volumes.go
@@ -59,6 +59,8 @@ func attachVolume(ctx context.Context, req types.VolumeAttachPayload) error {
 		return err
 	}
 	httpReq.Header.Set("X-Claw-Token", req.ClawToken)
+	httpReq.Header.Set("X-Claw-ID", req.ClawID)
+	httpReq.Header.Set("X-Volume-Token", req.LeaseToken)
 	resp, err := http.DefaultClient.Do(httpReq)
 	if err != nil {
 		return err
@@ -93,6 +95,8 @@ func syncVolume(ctx context.Context, req types.VolumeSyncPayload) error {
 		return err
 	}
 	httpReq.Header.Set("X-Claw-Token", req.ClawToken)
+	httpReq.Header.Set("X-Claw-ID", req.ClawID)
+	httpReq.Header.Set("X-Volume-Token", req.LeaseToken)
 	resp, err := http.DefaultClient.Do(httpReq)
 	if err != nil {
 		_ = pr.CloseWithError(err)

--- a/cmd/claw-bridge/volumes_test.go
+++ b/cmd/claw-bridge/volumes_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestSyncVolumeClosesPipeOnPutError(t *testing.T) {
+	oldClient := http.DefaultClient
+	http.DefaultClient = &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return nil, errors.New("put failed before reading body")
+		}),
+	}
+	defer func() {
+		http.DefaultClient = oldClient
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	err := syncVolume(ctx, types.VolumeSyncPayload{
+		LeaseID:   "lease-1",
+		Mode:      "rw",
+		Mount:     t.TempDir(),
+		HubURL:    "http://hub.example",
+		ClawToken: "token",
+	})
+	if err == nil || !strings.Contains(err.Error(), "put failed before reading body") {
+		t.Fatalf("syncVolume error = %v, want transport error", err)
+	}
+}

--- a/pkg/hub/artifact/store.go
+++ b/pkg/hub/artifact/store.go
@@ -14,6 +14,7 @@ const (
 	MediaTypeCheckpointV1      = "application/vnd.elasticclaw.checkpoint.v1+json"
 	MediaTypeVolumeV1          = "application/vnd.elasticclaw.volume.v1+json"
 	MediaTypeVolumeLayerTarZst = "application/vnd.elasticclaw.volume.layer.v1.tar+zstd"
+	MediaTypeVolumeLayerTarGz  = "application/vnd.elasticclaw.volume.layer.v1.tar+gzip"
 )
 
 type Store interface {

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -148,6 +148,7 @@ func migrate(db *sql.DB) error {
 		repo            TEXT NOT NULL,
 		tag             TEXT NOT NULL,
 		claw_id         TEXT NOT NULL,
+		access_token    TEXT NOT NULL DEFAULT '',
 		mode            TEXT NOT NULL CHECK(mode IN ('ro','rw')),
 		mount           TEXT NOT NULL DEFAULT '',
 		manifest_digest TEXT NOT NULL DEFAULT '',
@@ -156,6 +157,7 @@ func migrate(db *sql.DB) error {
 		heartbeat_at    DATETIME NOT NULL,
 		released_at     DATETIME
 	)`)
+	_, _ = db.Exec(`ALTER TABLE volume_leases ADD COLUMN access_token TEXT NOT NULL DEFAULT ''`)
 	_, _ = db.Exec(`CREATE INDEX IF NOT EXISTS idx_volume_leases_volume_active ON volume_leases(volume_id, released_at, expires_at)`)
 	_, _ = db.Exec(`CREATE INDEX IF NOT EXISTS idx_volume_leases_claw ON volume_leases(claw_id, released_at)`)
 

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -53,6 +53,7 @@ func migrate(db *sql.DB) error {
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN restore_checkpoint_id TEXT NOT NULL DEFAULT ''`)
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN restored_from_checkpoint_id TEXT NOT NULL DEFAULT ''`)
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN task_run_id TEXT NOT NULL DEFAULT ''`)
+	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN workflow_volumes TEXT NOT NULL DEFAULT '[]'`)
 	_, _ = db.Exec(`ALTER TABLE claw_prs ADD COLUMN last_comment_at TEXT NOT NULL DEFAULT ''`)
 	_, _ = db.Exec(`ALTER TABLE claw_prs ADD COLUMN pr_conditions_fired INTEGER NOT NULL DEFAULT 0`)
 	_, _ = db.Exec(`ALTER TABLE claw_prs ADD COLUMN last_review_comment_id INTEGER NOT NULL DEFAULT 0`)
@@ -141,6 +142,23 @@ func migrate(db *sql.DB) error {
 	_, _ = db.Exec(`CREATE INDEX IF NOT EXISTS idx_factory_analytics_action ON factory_analytics(action, created_at)`)
 	_, _ = db.Exec(`CREATE INDEX IF NOT EXISTS idx_factory_analytics_claw ON factory_analytics(claw_id)`)
 
+	_, _ = db.Exec(`CREATE TABLE IF NOT EXISTS volume_leases (
+		id              TEXT PRIMARY KEY,
+		volume_id       TEXT NOT NULL,
+		repo            TEXT NOT NULL,
+		tag             TEXT NOT NULL,
+		claw_id         TEXT NOT NULL,
+		mode            TEXT NOT NULL CHECK(mode IN ('ro','rw')),
+		mount           TEXT NOT NULL DEFAULT '',
+		manifest_digest TEXT NOT NULL DEFAULT '',
+		acquired_at     DATETIME NOT NULL,
+		expires_at      DATETIME NOT NULL,
+		heartbeat_at    DATETIME NOT NULL,
+		released_at     DATETIME
+	)`)
+	_, _ = db.Exec(`CREATE INDEX IF NOT EXISTS idx_volume_leases_volume_active ON volume_leases(volume_id, released_at, expires_at)`)
+	_, _ = db.Exec(`CREATE INDEX IF NOT EXISTS idx_volume_leases_claw ON volume_leases(claw_id, released_at)`)
+
 	_, err := db.Exec(`
 	CREATE TABLE IF NOT EXISTS tenants (
 		id        TEXT PRIMARY KEY,
@@ -185,7 +203,8 @@ func migrate(db *sql.DB) error {
 		external_trigger_id TEXT NOT NULL DEFAULT '',
 		restore_checkpoint_id TEXT NOT NULL DEFAULT '',
 		restored_from_checkpoint_id TEXT NOT NULL DEFAULT '',
-		task_run_id TEXT NOT NULL DEFAULT ''
+		task_run_id TEXT NOT NULL DEFAULT '',
+		workflow_volumes TEXT NOT NULL DEFAULT '[]'
 	);
 
 

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -1298,6 +1298,7 @@ func (s *Server) completeNoPRDoneClaw(clawID, tenantID, issueID string) {
 	if err != nil || rowsAffected == 0 {
 		return
 	}
+	s.syncWorkflowVolumes(clawID)
 	if err := s.recordTaskRunEventForClaw(clawID, TaskRunEvent{
 		EventKey:        "task_completed:" + clawID,
 		Source:          taskRunSourceHub,

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -1444,6 +1444,7 @@ func (s *Server) transitionPipelineStageWithContext(clawID string, stage pipelin
 		_ = s.db.QueryRow(`SELECT tenant_id, COALESCE(provider_id,''), COALESCE(provider,'') FROM claws WHERE id=?`, clawID).Scan(&tenantID, &providerID, &provider)
 
 		s.checkpointBeforeTermination(clawID, "pipeline-terminal")
+		s.syncWorkflowVolumes(clawID)
 
 		_, _ = s.db.Exec(`UPDATE claws SET status='deleted' WHERE id=?`, clawID)
 		if s.cronScheduler != nil {
@@ -1649,6 +1650,7 @@ func (s *Server) initializePipelineEntryIfNeeded(clawID string) bool {
 // poll saw "terminated") to avoid redundant delete attempts that spam the logs with 404 errors.
 func (s *Server) stopAgentWithReason(clawID, reason string, skipVMTerminate bool) {
 	s.checkpointBeforeTermination(clawID, "stop-agent")
+	s.syncWorkflowVolumes(clawID)
 
 	// Resolve factory + issueID
 	factory, issueID := s.findFactoryForClaw(clawID)

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -53,9 +53,11 @@ type Server struct {
 
 	dependencyStatus *dependencyStatusService
 
-	fileAckMu       sync.Mutex
-	fileAckWaiters  map[string]chan types.FileAck      // request_id -> waiter
-	fileReadWaiters map[string]chan types.FileReadResp // request_id -> waiter
+	fileAckMu           sync.Mutex
+	fileAckWaiters      map[string]chan types.FileAck      // request_id -> waiter
+	fileReadWaiters     map[string]chan types.FileReadResp // request_id -> waiter
+	volumeAttachWaiters map[string]chan types.VolumeAttachAck
+	volumeSyncWaiters   map[string]chan types.VolumeSyncAck
 
 	checkpointMu      sync.Mutex
 	checkpointWaiters map[string]chan error // checkpoint_id -> waiter
@@ -317,6 +319,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/claws/{id}", s.withAuth(s.handleClawDetail))
 	mux.HandleFunc("/api/checkpoints/blob/", s.handleCheckpointBlobUpload)
 	mux.HandleFunc("/api/checkpoints/", s.handleCheckpointInternal)
+	mux.HandleFunc("/api/volumes/leases/{lease}/archive", s.handleVolumeArchive)
 	mux.HandleFunc("/api/terminal/", s.handleTerminal)
 	mux.HandleFunc("/api/github/token/", s.handleGitHubToken) // credential helper endpoint (claw-token auth)
 	mux.HandleFunc("/api/messages/", s.withAuth(s.handleMessages))
@@ -2103,6 +2106,13 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 	// Broadcast initial status to user sessions
 	s.broadcastToUsers(tenantID, types.WSMessage{Type: "claw_status", Payload: map[string]string{"claw_id": clawID, "status": currentStatus}})
 
+	if allowWake && cc.gatewayReady && currentStatus == "connected" {
+		if err := s.attachWorkflowVolumes(ctx, cc, clawID); err != nil {
+			go s.stopAgentWithReason(clawID, fmt.Sprintf("Workflow volume attach failed: %v", err), false)
+			return
+		}
+	}
+
 	// Drain any queued messages that were copied from the old connection.
 	// This must happen after the connection is live but before the read loop starts.
 	// We call it synchronously (not in a goroutine) to avoid racing with new user messages.
@@ -2262,6 +2272,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 						cc.mu.Unlock()
 					}
 					s.mu.Unlock()
+					s.heartbeatWorkflowVolumeLeases(clawID)
 					if shouldWarnContext {
 						s.mu.RLock()
 						warnCC := s.claws[clawID]
@@ -2496,6 +2507,36 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 					if ch != nil {
 						select {
 						case ch <- resp:
+						default:
+						}
+					}
+				}
+			} else if msg.Type == "volume_attach_ack" {
+				raw, _ := json.Marshal(msg.Payload)
+				var ack types.VolumeAttachAck
+				if err := json.Unmarshal(raw, &ack); err == nil && ack.RequestID != "" {
+					s.fileAckMu.Lock()
+					ch := s.volumeAttachWaiters[ack.RequestID]
+					delete(s.volumeAttachWaiters, ack.RequestID)
+					s.fileAckMu.Unlock()
+					if ch != nil {
+						select {
+						case ch <- ack:
+						default:
+						}
+					}
+				}
+			} else if msg.Type == "volume_sync_ack" {
+				raw, _ := json.Marshal(msg.Payload)
+				var ack types.VolumeSyncAck
+				if err := json.Unmarshal(raw, &ack); err == nil && ack.RequestID != "" {
+					s.fileAckMu.Lock()
+					ch := s.volumeSyncWaiters[ack.RequestID]
+					delete(s.volumeSyncWaiters, ack.RequestID)
+					s.fileAckMu.Unlock()
+					if ch != nil {
+						select {
+						case ch <- ack:
 						default:
 						}
 					}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -3910,6 +3910,7 @@ func (s *Server) startWorkflowAfterVolumes(ctx context.Context, cc *clawConn, cl
 			cc.workflowStartPending = false
 			cc.mu.Unlock()
 			log.Printf("[volume] attach workflow volumes for %s failed: %v", clawID[:8], err)
+			s.releaseWorkflowVolumeLeases(clawID)
 			go s.stopAgentWithReason(clawID, fmt.Sprintf("Workflow volume attach failed: %v", err), false)
 			return
 		}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -92,6 +92,8 @@ type clawConn struct {
 	contextUsage          int             // 0-100, updated from heartbeats
 	gatewayReady          bool            // true once bridge reports gateway session established
 	gatewayUnhealthyCount int             // consecutive unhealthy heartbeats
+	workflowStartPending  bool            // true while initial volume attach / wake is in flight
+	workflowStartDone     bool            // true once initial volume attach / wake has completed
 	streamingBuf          strings.Builder // accumulates chunks for current in-flight response
 	streamingMsgID        string          // pre-assigned message ID for the current stream
 	streamingSplit        bool            // true once activity has split this turn into multiple persisted segments
@@ -2106,13 +2108,6 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 	// Broadcast initial status to user sessions
 	s.broadcastToUsers(tenantID, types.WSMessage{Type: "claw_status", Payload: map[string]string{"claw_id": clawID, "status": currentStatus}})
 
-	if allowWake && cc.gatewayReady && currentStatus == "connected" {
-		if err := s.attachWorkflowVolumes(ctx, cc, clawID); err != nil {
-			go s.stopAgentWithReason(clawID, fmt.Sprintf("Workflow volume attach failed: %v", err), false)
-			return
-		}
-	}
-
 	// Drain any queued messages that were copied from the old connection.
 	// This must happen after the connection is live but before the read loop starts.
 	// We call it synchronously (not in a goroutine) to avoid racing with new user messages.
@@ -2122,19 +2117,8 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 
 	// Initialize entry pipeline stage only after bridge connects so on_enter inject
 	// can be delivered over WS.
-	usedPipelineEntryInject := false
 	if allowWake && cc.gatewayReady && currentStatus == "connected" {
-		usedPipelineEntryInject = s.initializePipelineEntryIfNeeded(clawID)
-		if usedPipelineEntryInject {
-			go s.sendInitialPlanInstruction(cc, clawID)
-		}
-	}
-	// If no pipeline entry inject was sent, fire the default wake message.
-	// But don't re-wake claws that already have a pipeline stage (hub restart reconnect).
-	if allowWake && cc.gatewayReady && currentStatus == "connected" && !usedPipelineEntryInject {
-		if s.getPipelineStage(clawID) == "" && !s.clawHasMessages(clawID) {
-			go s.sendWakeMessage(cc, clawID)
-		}
+		s.startWorkflowAfterVolumes(ctx, cc, clawID)
 	}
 	if allowWake && cc.gatewayReady && currentStatus == "connected" && !s.hasRecentCheckpoint(clawID, time.Hour) {
 		go s.requestBootstrapCheckpoint(clawID)
@@ -2282,11 +2266,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 						}
 					}
 					if shouldWake {
-						if s.initializePipelineEntryIfNeeded(clawID) {
-							go s.sendInitialPlanInstruction(wakeConn, clawID)
-						} else if s.getPipelineStage(clawID) == "" && !s.clawHasMessages(clawID) {
-							go s.sendWakeMessage(wakeConn, clawID)
-						}
+						s.startWorkflowAfterVolumes(ctx, wakeConn, clawID)
 					}
 					// Check for streaming turn timeout (12 minutes)
 					s.mu.RLock()
@@ -3908,12 +3888,43 @@ func (s *Server) promoteBootstrapReadyClaw(clawID string) bool {
 	})
 	log.Printf("[bridge] ✓ ready after bootstrap: %s", clawID[:8])
 	go s.requestBootstrapCheckpoint(clawID)
-	if s.initializePipelineEntryIfNeeded(clawID) {
-		go s.sendInitialPlanInstruction(cc, clawID)
-	} else if s.getPipelineStage(clawID) == "" && !s.clawHasMessages(clawID) {
-		go s.sendWakeMessage(cc, clawID)
-	}
+	s.startWorkflowAfterVolumes(context.Background(), cc, clawID)
 	return true
+}
+
+func (s *Server) startWorkflowAfterVolumes(ctx context.Context, cc *clawConn, clawID string) {
+	if cc == nil {
+		return
+	}
+	cc.mu.Lock()
+	if cc.workflowStartPending || cc.workflowStartDone {
+		cc.mu.Unlock()
+		return
+	}
+	cc.workflowStartPending = true
+	cc.mu.Unlock()
+
+	go func() {
+		if err := s.attachWorkflowVolumes(ctx, cc, clawID); err != nil {
+			cc.mu.Lock()
+			cc.workflowStartPending = false
+			cc.mu.Unlock()
+			log.Printf("[volume] attach workflow volumes for %s failed: %v", clawID[:8], err)
+			go s.stopAgentWithReason(clawID, fmt.Sprintf("Workflow volume attach failed: %v", err), false)
+			return
+		}
+
+		cc.mu.Lock()
+		cc.workflowStartPending = false
+		cc.workflowStartDone = true
+		cc.mu.Unlock()
+
+		if s.initializePipelineEntryIfNeeded(clawID) {
+			s.sendInitialPlanInstruction(cc, clawID)
+		} else if s.getPipelineStage(clawID) == "" && !s.clawHasMessages(clawID) {
+			s.sendWakeMessage(cc, clawID)
+		}
+	}()
 }
 
 func daytonaRepoReadinessSnippet(repoFullName string) string {

--- a/pkg/hub/testhelpers.go
+++ b/pkg/hub/testhelpers.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/elasticclaw/elasticclaw/pkg/hub/artifact"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
 
@@ -44,10 +45,15 @@ func NewTestServerWithConfig(t interface {
 			)
 		}
 	}
+	artifacts, err := artifact.NewLocalStore(tTempDir(t))
+	if err != nil {
+		panic("NewTestServerWithConfig: artifact store: " + err.Error())
+	}
 
 	s := &Server{
 		db:               db,
 		hubCfg:           cfg,
+		artifacts:        artifacts,
 		claws:            make(map[string]*clawConn),
 		users:            make(map[string]*userConn),
 		dependencyStatus: newDependencyStatusService(cfg),
@@ -61,6 +67,19 @@ func NewTestServerWithConfig(t interface {
 	s.registerRoutes(mux)
 	s.mux = mux
 	return s, db
+}
+
+func tTempDir(t interface {
+	Helper()
+	Cleanup(func())
+}) string {
+	type tempDir interface {
+		TempDir() string
+	}
+	if td, ok := t.(tempDir); ok {
+		return td.TempDir()
+	}
+	return ""
 }
 
 // SaveWorkspaceForTest writes a workspace and its workflows through the same

--- a/pkg/hub/volumes.go
+++ b/pkg/hub/volumes.go
@@ -208,6 +208,12 @@ func (s *Server) heartbeatWorkflowVolumeLeases(clawID string) {
 	_, _ = s.db.Exec(`UPDATE volume_leases SET heartbeat_at=?, expires_at=? WHERE claw_id=? AND released_at IS NULL`, now, now.Add(volumeLeaseTTL), clawID)
 }
 
+func (s *Server) workflowVolumeLeaseActive(leaseID string) bool {
+	var active int
+	err := s.db.QueryRow(`SELECT COUNT(*) FROM volume_leases WHERE id=? AND released_at IS NULL AND expires_at > ?`, leaseID, time.Now().UTC()).Scan(&active)
+	return err == nil && active > 0
+}
+
 func (s *Server) workflowVolumesForClaw(clawID string) ([]workflowVolumeRuntime, error) {
 	var raw string
 	if err := s.db.QueryRow(`SELECT COALESCE(workflow_volumes,'[]') FROM claws WHERE id=?`, clawID).Scan(&raw); err != nil {
@@ -296,10 +302,10 @@ func (s *Server) syncWorkflowVolumes(clawID string) {
 	if err != nil || len(volumes) == 0 {
 		return
 	}
-	hasWritableLease := false
+	hasActiveWritableLease := false
 	for _, volume := range volumes {
-		if volume.Mode == volumeModeRW && volume.LeaseID != "" {
-			hasWritableLease = true
+		if volume.Mode == volumeModeRW && volume.LeaseID != "" && s.workflowVolumeLeaseActive(volume.LeaseID) {
+			hasActiveWritableLease = true
 			break
 		}
 	}
@@ -307,7 +313,7 @@ func (s *Server) syncWorkflowVolumes(clawID string) {
 	cc := s.claws[clawID]
 	s.mu.RUnlock()
 	if cc == nil {
-		if hasWritableLease {
+		if hasActiveWritableLease {
 			log.Printf("[volume] sync %s skipped: claw disconnected with writable volume lease; keeping lease until expiry", clawID)
 			return
 		}
@@ -317,6 +323,9 @@ func (s *Server) syncWorkflowVolumes(clawID string) {
 	syncFailed := false
 	for _, volume := range volumes {
 		if volume.Mode != volumeModeRW || volume.LeaseID == "" {
+			continue
+		}
+		if !s.workflowVolumeLeaseActive(volume.LeaseID) {
 			continue
 		}
 		if err := s.dispatchVolumeSync(context.Background(), cc, volume); err != nil {

--- a/pkg/hub/volumes.go
+++ b/pkg/hub/volumes.go
@@ -153,7 +153,8 @@ func (s *Server) resolveVolumeManifest(ctx context.Context, repo, tag string) (s
 	if err == nil {
 		return digest, nil
 	}
-	if !strings.Contains(err.Error(), "no such file") && !strings.Contains(err.Error(), "not found") {
+	msg := strings.ToLower(err.Error())
+	if !strings.Contains(msg, "no such file") && !strings.Contains(msg, "not found") {
 		return "", err
 	}
 	return s.createEmptyVolumeManifest(ctx, repo, tag)
@@ -441,7 +442,9 @@ func (s *Server) handleVolumeArchivePut(w http.ResponseWriter, r *http.Request, 
 		http.Error(w, "tag volume: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
-	_, _ = s.db.Exec(`UPDATE volume_leases SET manifest_digest=?, heartbeat_at=? WHERE id=?`, manifestDigest, time.Now().UTC(), leaseID)
+	if _, err := s.db.Exec(`UPDATE volume_leases SET manifest_digest=?, heartbeat_at=? WHERE id=?`, manifestDigest, time.Now().UTC(), leaseID); err != nil {
+		log.Printf("[volume] lease %s: failed to update manifest_digest after successful tag: %v", leaseID, err)
+	}
 	jsonOK(w, map[string]string{"manifest_digest": manifestDigest})
 }
 

--- a/pkg/hub/volumes.go
+++ b/pkg/hub/volumes.go
@@ -1,0 +1,470 @@
+package hub
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/hub/artifact"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+	"github.com/google/uuid"
+	"nhooyr.io/websocket/wsjson"
+)
+
+const (
+	volumeModeRO       = "ro"
+	volumeModeRW       = "rw"
+	volumeDefaultTag   = "latest"
+	volumeLeaseTTL     = 24 * time.Hour
+	volumeAttachWait   = 2 * time.Minute
+	volumeSyncWait     = 3 * time.Minute
+	emptyVolumeArchive = "empty"
+)
+
+type workflowVolumeRuntime struct {
+	types.WorkflowVolume
+	LeaseID        string `json:"lease_id,omitempty"`
+	Repo           string `json:"repo,omitempty"`
+	Tag            string `json:"tag,omitempty"`
+	ManifestDigest string `json:"manifest_digest,omitempty"`
+}
+
+type volumeManifest struct {
+	SchemaVersion string              `json:"schemaVersion"`
+	MediaType     string              `json:"mediaType"`
+	CreatedAt     time.Time           `json:"createdAt"`
+	Layer         volumeManifestLayer `json:"layer"`
+	Annotations   map[string]string   `json:"annotations,omitempty"`
+}
+
+type volumeManifestLayer struct {
+	MediaType string `json:"mediaType"`
+	Digest    string `json:"digest"`
+	Size      int64  `json:"size"`
+}
+
+func parseVolumeSource(source string) (repo, tag string, err error) {
+	source = strings.TrimSpace(source)
+	const prefix = "hub://volumes/"
+	if !strings.HasPrefix(source, prefix) {
+		return "", "", fmt.Errorf("volume source %q must use hub://volumes/<name>", source)
+	}
+	ref := strings.TrimPrefix(source, prefix)
+	if ref == "" {
+		return "", "", fmt.Errorf("volume source is missing a name")
+	}
+	tag = volumeDefaultTag
+	if before, after, ok := strings.Cut(ref, ":"); ok {
+		ref = before
+		if strings.TrimSpace(after) != "" {
+			tag = strings.TrimSpace(after)
+		}
+	}
+	repo = "volumes/" + strings.Trim(ref, "/")
+	if err := artifact.ValidateRef(repo, tag); err != nil {
+		return "", "", err
+	}
+	return repo, tag, nil
+}
+
+func normalizeWorkflowVolumes(workflow *types.WorkflowConfig) ([]workflowVolumeRuntime, error) {
+	if workflow == nil || len(workflow.Volumes) == 0 {
+		return nil, nil
+	}
+	out := make([]workflowVolumeRuntime, 0, len(workflow.Volumes))
+	for _, v := range workflow.Volumes {
+		mode := strings.TrimSpace(v.Mode)
+		if mode == "" {
+			mode = volumeModeRO
+		}
+		repo, tag, err := parseVolumeSource(v.Source)
+		if err != nil {
+			return nil, fmt.Errorf("volume %q: %w", v.Name, err)
+		}
+		out = append(out, workflowVolumeRuntime{
+			WorkflowVolume: types.WorkflowVolume{
+				Name:   strings.TrimSpace(v.Name),
+				Source: strings.TrimSpace(v.Source),
+				Mount:  strings.TrimSpace(v.Mount),
+				Mode:   mode,
+			},
+			Repo: repo,
+			Tag:  tag,
+		})
+	}
+	return out, nil
+}
+
+func (s *Server) acquireWorkflowVolumeLeases(ctx context.Context, clawID string, volumes []workflowVolumeRuntime) ([]workflowVolumeRuntime, error) {
+	if len(volumes) == 0 {
+		return nil, nil
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	now := time.Now().UTC()
+	expires := now.Add(volumeLeaseTTL)
+	acquired := make([]workflowVolumeRuntime, 0, len(volumes))
+	for _, volume := range volumes {
+		manifestDigest, err := s.resolveVolumeManifest(ctx, volume.Repo, volume.Tag)
+		if err != nil {
+			return nil, err
+		}
+		var conflicting int
+		if volume.Mode == volumeModeRO {
+			err = tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM volume_leases WHERE volume_id=? AND mode='rw' AND released_at IS NULL AND expires_at > ?`, volume.Repo, now).Scan(&conflicting)
+		} else {
+			err = tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM volume_leases WHERE volume_id=? AND released_at IS NULL AND expires_at > ?`, volume.Repo, now).Scan(&conflicting)
+		}
+		if err != nil {
+			return nil, err
+		}
+		if conflicting > 0 {
+			return nil, fmt.Errorf("volume %q is locked by an active lease", volume.Name)
+		}
+		volume.LeaseID = uuid.New().String()
+		volume.ManifestDigest = manifestDigest
+		if _, err := tx.ExecContext(ctx, `INSERT INTO volume_leases(id, volume_id, repo, tag, claw_id, mode, mount, manifest_digest, acquired_at, expires_at, heartbeat_at) VALUES(?,?,?,?,?,?,?,?,?,?,?)`,
+			volume.LeaseID, volume.Repo, volume.Repo, volume.Tag, clawID, volume.Mode, volume.Mount, manifestDigest, now, expires, now); err != nil {
+			return nil, err
+		}
+		acquired = append(acquired, volume)
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return acquired, nil
+}
+
+func (s *Server) resolveVolumeManifest(ctx context.Context, repo, tag string) (string, error) {
+	digest, err := s.artifacts.ResolveRef(ctx, repo, tag)
+	if err == nil {
+		return digest, nil
+	}
+	if !strings.Contains(err.Error(), "no such file") && !strings.Contains(err.Error(), "not found") {
+		return "", err
+	}
+	return s.createEmptyVolumeManifest(ctx, repo, tag)
+}
+
+func (s *Server) createEmptyVolumeManifest(ctx context.Context, repo, tag string) (string, error) {
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	if err := tw.Close(); err != nil {
+		return "", err
+	}
+	if err := gz.Close(); err != nil {
+		return "", err
+	}
+	layerDigest, size, err := s.artifacts.PutBlob(ctx, bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		return "", err
+	}
+	manifest := volumeManifest{
+		SchemaVersion: "v1",
+		MediaType:     artifact.MediaTypeVolumeV1,
+		CreatedAt:     time.Now().UTC(),
+		Layer: volumeManifestLayer{
+			MediaType: artifact.MediaTypeVolumeLayerTarGz,
+			Digest:    layerDigest,
+			Size:      size,
+		},
+		Annotations: map[string]string{"elasticclaw.volume.empty": emptyVolumeArchive},
+	}
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		return "", err
+	}
+	manifestDigest, err := s.artifacts.PutManifest(ctx, data)
+	if err != nil {
+		return "", err
+	}
+	if err := s.artifacts.Tag(ctx, repo, tag, manifestDigest); err != nil {
+		return "", err
+	}
+	return manifestDigest, nil
+}
+
+func (s *Server) releaseWorkflowVolumeLeases(clawID string) {
+	_, _ = s.db.Exec(`UPDATE volume_leases SET released_at=? WHERE claw_id=? AND released_at IS NULL`, time.Now().UTC(), clawID)
+}
+
+func (s *Server) heartbeatWorkflowVolumeLeases(clawID string) {
+	now := time.Now().UTC()
+	_, _ = s.db.Exec(`UPDATE volume_leases SET heartbeat_at=?, expires_at=? WHERE claw_id=? AND released_at IS NULL`, now, now.Add(volumeLeaseTTL), clawID)
+}
+
+func (s *Server) workflowVolumesForClaw(clawID string) ([]workflowVolumeRuntime, error) {
+	var raw string
+	if err := s.db.QueryRow(`SELECT COALESCE(workflow_volumes,'[]') FROM claws WHERE id=?`, clawID).Scan(&raw); err != nil {
+		return nil, err
+	}
+	var volumes []workflowVolumeRuntime
+	if err := json.Unmarshal([]byte(raw), &volumes); err != nil {
+		return nil, err
+	}
+	return volumes, nil
+}
+
+func (s *Server) storeWorkflowVolumes(clawID string, volumes []workflowVolumeRuntime) error {
+	data, err := json.Marshal(volumes)
+	if err != nil {
+		return err
+	}
+	_, err = s.db.Exec(`UPDATE claws SET workflow_volumes=? WHERE id=?`, string(data), clawID)
+	return err
+}
+
+func (s *Server) attachWorkflowVolumes(ctx context.Context, cc *clawConn, clawID string) error {
+	volumes, err := s.workflowVolumesForClaw(clawID)
+	if err != nil || len(volumes) == 0 {
+		return err
+	}
+	if volumes[0].LeaseID == "" {
+		volumes, err = s.acquireWorkflowVolumeLeases(ctx, clawID, volumes)
+		if err != nil {
+			return err
+		}
+		if err := s.storeWorkflowVolumes(clawID, volumes); err != nil {
+			s.releaseWorkflowVolumeLeases(clawID)
+			return err
+		}
+	}
+	for _, volume := range volumes {
+		if err := s.dispatchVolumeAttach(ctx, cc, volume); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Server) dispatchVolumeAttach(ctx context.Context, cc *clawConn, volume workflowVolumeRuntime) error {
+	reqID := uuid.New().String()
+	ch := make(chan types.VolumeAttachAck, 1)
+	s.fileAckMu.Lock()
+	if s.volumeAttachWaiters == nil {
+		s.volumeAttachWaiters = make(map[string]chan types.VolumeAttachAck)
+	}
+	s.volumeAttachWaiters[reqID] = ch
+	s.fileAckMu.Unlock()
+	defer func() {
+		s.fileAckMu.Lock()
+		delete(s.volumeAttachWaiters, reqID)
+		s.fileAckMu.Unlock()
+	}()
+	payload := types.VolumeAttachPayload{
+		RequestID: reqID,
+		LeaseID:   volume.LeaseID,
+		Name:      volume.Name,
+		Mode:      volume.Mode,
+		Mount:     volume.Mount,
+		HubURL:    s.clawHubURL(),
+		ClawToken: s.hubCfg.ClawToken,
+	}
+	if err := wsjson.Write(ctx, cc.conn, types.WSMessage{Type: "volume_attach", Payload: payload}); err != nil {
+		return err
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, volumeAttachWait)
+	defer cancel()
+	select {
+	case ack := <-ch:
+		if !ack.OK {
+			return fmt.Errorf("attach volume %q: %s", volume.Name, ack.Error)
+		}
+		return nil
+	case <-waitCtx.Done():
+		return fmt.Errorf("attach volume %q: %w", volume.Name, waitCtx.Err())
+	}
+}
+
+func (s *Server) syncWorkflowVolumes(clawID string) {
+	volumes, err := s.workflowVolumesForClaw(clawID)
+	if err != nil || len(volumes) == 0 {
+		return
+	}
+	s.mu.RLock()
+	cc := s.claws[clawID]
+	s.mu.RUnlock()
+	if cc == nil {
+		s.releaseWorkflowVolumeLeases(clawID)
+		return
+	}
+	for _, volume := range volumes {
+		if volume.Mode != volumeModeRW || volume.LeaseID == "" {
+			continue
+		}
+		if err := s.dispatchVolumeSync(context.Background(), cc, volume); err != nil {
+			log.Printf("[volume] sync %s/%s failed: %v", clawID, volume.Name, err)
+		}
+	}
+	s.releaseWorkflowVolumeLeases(clawID)
+}
+
+func (s *Server) dispatchVolumeSync(ctx context.Context, cc *clawConn, volume workflowVolumeRuntime) error {
+	reqID := uuid.New().String()
+	ch := make(chan types.VolumeSyncAck, 1)
+	s.fileAckMu.Lock()
+	if s.volumeSyncWaiters == nil {
+		s.volumeSyncWaiters = make(map[string]chan types.VolumeSyncAck)
+	}
+	s.volumeSyncWaiters[reqID] = ch
+	s.fileAckMu.Unlock()
+	defer func() {
+		s.fileAckMu.Lock()
+		delete(s.volumeSyncWaiters, reqID)
+		s.fileAckMu.Unlock()
+	}()
+	payload := types.VolumeSyncPayload{
+		RequestID: reqID,
+		LeaseID:   volume.LeaseID,
+		Name:      volume.Name,
+		Mode:      volume.Mode,
+		Mount:     volume.Mount,
+		HubURL:    s.clawHubURL(),
+		ClawToken: s.hubCfg.ClawToken,
+	}
+	if err := wsjson.Write(ctx, cc.conn, types.WSMessage{Type: "volume_sync", Payload: payload}); err != nil {
+		return err
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, volumeSyncWait)
+	defer cancel()
+	select {
+	case ack := <-ch:
+		if !ack.OK {
+			return fmt.Errorf("sync volume %q: %s", volume.Name, ack.Error)
+		}
+		return nil
+	case <-waitCtx.Done():
+		return fmt.Errorf("sync volume %q: %w", volume.Name, waitCtx.Err())
+	}
+}
+
+func (s *Server) handleVolumeArchive(w http.ResponseWriter, r *http.Request) {
+	leaseID := strings.TrimSpace(r.PathValue("lease"))
+	if leaseID == "" {
+		http.Error(w, "lease required", http.StatusBadRequest)
+		return
+	}
+	if !s.authenticateClawToken(w, r) {
+		return
+	}
+	switch r.Method {
+	case http.MethodGet:
+		s.handleVolumeArchiveGet(w, r, leaseID)
+	case http.MethodPut:
+		s.handleVolumeArchivePut(w, r, leaseID)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *Server) handleVolumeArchiveGet(w http.ResponseWriter, r *http.Request, leaseID string) {
+	manifestDigest, err := s.volumeLeaseManifest(r.Context(), leaseID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	data, err := s.artifacts.GetManifest(r.Context(), manifestDigest)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	var manifest volumeManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	body, err := s.artifacts.GetBlob(r.Context(), manifest.Layer.Digest)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer body.Close()
+	w.Header().Set("Content-Type", manifest.Layer.MediaType)
+	_, _ = io.Copy(w, body)
+}
+
+func (s *Server) handleVolumeArchivePut(w http.ResponseWriter, r *http.Request, leaseID string) {
+	var repo, tag, mode, attachedDigest string
+	if err := s.db.QueryRow(`SELECT repo, tag, mode, manifest_digest FROM volume_leases WHERE id=? AND released_at IS NULL AND expires_at > ?`, leaseID, time.Now().UTC()).Scan(&repo, &tag, &mode, &attachedDigest); err != nil {
+		http.Error(w, "active lease not found", http.StatusNotFound)
+		return
+	}
+	if mode != volumeModeRW {
+		http.Error(w, "volume is read-only", http.StatusForbidden)
+		return
+	}
+	currentDigest, err := s.artifacts.ResolveRef(r.Context(), repo, tag)
+	if err != nil {
+		http.Error(w, "resolve volume ref: "+err.Error(), http.StatusConflict)
+		return
+	}
+	if currentDigest != attachedDigest {
+		http.Error(w, "volume changed since lease was acquired", http.StatusConflict)
+		return
+	}
+	layerDigest, size, err := s.artifacts.PutBlob(r.Context(), r.Body)
+	if err != nil {
+		http.Error(w, "store volume layer: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	manifest := volumeManifest{
+		SchemaVersion: "v1",
+		MediaType:     artifact.MediaTypeVolumeV1,
+		CreatedAt:     time.Now().UTC(),
+		Layer: volumeManifestLayer{
+			MediaType: artifact.MediaTypeVolumeLayerTarGz,
+			Digest:    layerDigest,
+			Size:      size,
+		},
+	}
+	data, _ := json.Marshal(manifest)
+	manifestDigest, err := s.artifacts.PutManifest(r.Context(), data)
+	if err != nil {
+		http.Error(w, "store volume manifest: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if err := s.artifacts.Tag(r.Context(), repo, tag, manifestDigest); err != nil {
+		http.Error(w, "tag volume: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	_, _ = s.db.Exec(`UPDATE volume_leases SET manifest_digest=?, heartbeat_at=? WHERE id=?`, manifestDigest, time.Now().UTC(), leaseID)
+	jsonOK(w, map[string]string{"manifest_digest": manifestDigest})
+}
+
+func (s *Server) volumeLeaseManifest(ctx context.Context, leaseID string) (string, error) {
+	var digest string
+	err := s.db.QueryRowContext(ctx, `SELECT manifest_digest FROM volume_leases WHERE id=? AND released_at IS NULL AND expires_at > ?`, leaseID, time.Now().UTC()).Scan(&digest)
+	if err == sql.ErrNoRows {
+		return "", fmt.Errorf("active lease not found")
+	}
+	return digest, err
+}
+
+func (s *Server) authenticateClawToken(w http.ResponseWriter, r *http.Request) bool {
+	token := r.Header.Get("X-Claw-Token")
+	if token == "" {
+		token = strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+	}
+	s.mu.RLock()
+	want := s.hubCfg.ClawToken
+	s.mu.RUnlock()
+	if token == "" || want == "" || token != want {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return false
+	}
+	return true
+}

--- a/pkg/hub/volumes.go
+++ b/pkg/hub/volumes.go
@@ -296,20 +296,37 @@ func (s *Server) syncWorkflowVolumes(clawID string) {
 	if err != nil || len(volumes) == 0 {
 		return
 	}
+	hasWritableLease := false
+	for _, volume := range volumes {
+		if volume.Mode == volumeModeRW && volume.LeaseID != "" {
+			hasWritableLease = true
+			break
+		}
+	}
 	s.mu.RLock()
 	cc := s.claws[clawID]
 	s.mu.RUnlock()
 	if cc == nil {
+		if hasWritableLease {
+			log.Printf("[volume] sync %s skipped: claw disconnected with writable volume lease; keeping lease until expiry", clawID)
+			return
+		}
 		s.releaseWorkflowVolumeLeases(clawID)
 		return
 	}
+	syncFailed := false
 	for _, volume := range volumes {
 		if volume.Mode != volumeModeRW || volume.LeaseID == "" {
 			continue
 		}
 		if err := s.dispatchVolumeSync(context.Background(), cc, volume); err != nil {
 			log.Printf("[volume] sync %s/%s failed: %v", clawID, volume.Name, err)
+			syncFailed = true
 		}
+	}
+	if syncFailed {
+		log.Printf("[volume] sync %s incomplete; keeping writable volume leases until expiry", clawID)
+		return
 	}
 	s.releaseWorkflowVolumeLeases(clawID)
 }

--- a/pkg/hub/volumes.go
+++ b/pkg/hub/volumes.go
@@ -108,7 +108,7 @@ func (s *Server) acquireWorkflowVolumeLeases(ctx context.Context, clawID string,
 	if len(volumes) == 0 {
 		return nil, nil
 	}
-	tx, err := s.db.BeginTx(ctx, nil)
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/hub/volumes.go
+++ b/pkg/hub/volumes.go
@@ -33,6 +33,7 @@ const (
 type workflowVolumeRuntime struct {
 	types.WorkflowVolume
 	LeaseID        string `json:"lease_id,omitempty"`
+	AccessToken    string `json:"access_token,omitempty"`
 	Repo           string `json:"repo,omitempty"`
 	Tag            string `json:"tag,omitempty"`
 	ManifestDigest string `json:"manifest_digest,omitempty"`
@@ -52,7 +53,11 @@ type volumeManifestLayer struct {
 	Size      int64  `json:"size"`
 }
 
-func parseVolumeSource(source string) (repo, tag string, err error) {
+func parseVolumeSource(tenantID, source string) (repo, tag string, err error) {
+	tenantID = strings.TrimSpace(tenantID)
+	if tenantID == "" {
+		return "", "", fmt.Errorf("tenant id is required")
+	}
 	source = strings.TrimSpace(source)
 	const prefix = "hub://volumes/"
 	if !strings.HasPrefix(source, prefix) {
@@ -69,14 +74,14 @@ func parseVolumeSource(source string) (repo, tag string, err error) {
 			tag = strings.TrimSpace(after)
 		}
 	}
-	repo = "volumes/" + strings.Trim(ref, "/")
+	repo = "volumes/" + tenantID + "/" + strings.Trim(ref, "/")
 	if err := artifact.ValidateRef(repo, tag); err != nil {
 		return "", "", err
 	}
 	return repo, tag, nil
 }
 
-func normalizeWorkflowVolumes(workflow *types.WorkflowConfig) ([]workflowVolumeRuntime, error) {
+func normalizeWorkflowVolumes(tenantID string, workflow *types.WorkflowConfig) ([]workflowVolumeRuntime, error) {
 	if workflow == nil || len(workflow.Volumes) == 0 {
 		return nil, nil
 	}
@@ -86,7 +91,7 @@ func normalizeWorkflowVolumes(workflow *types.WorkflowConfig) ([]workflowVolumeR
 		if mode == "" {
 			mode = volumeModeRO
 		}
-		repo, tag, err := parseVolumeSource(v.Source)
+		repo, tag, err := parseVolumeSource(tenantID, v.Source)
 		if err != nil {
 			return nil, fmt.Errorf("volume %q: %w", v.Name, err)
 		}
@@ -135,9 +140,10 @@ func (s *Server) acquireWorkflowVolumeLeases(ctx context.Context, clawID string,
 			return nil, fmt.Errorf("volume %q is locked by an active lease", volume.Name)
 		}
 		volume.LeaseID = uuid.New().String()
+		volume.AccessToken = uuid.New().String()
 		volume.ManifestDigest = manifestDigest
-		if _, err := tx.ExecContext(ctx, `INSERT INTO volume_leases(id, volume_id, repo, tag, claw_id, mode, mount, manifest_digest, acquired_at, expires_at, heartbeat_at) VALUES(?,?,?,?,?,?,?,?,?,?,?)`,
-			volume.LeaseID, volume.Repo, volume.Repo, volume.Tag, clawID, volume.Mode, volume.Mount, manifestDigest, now, expires, now); err != nil {
+		if _, err := tx.ExecContext(ctx, `INSERT INTO volume_leases(id, volume_id, repo, tag, claw_id, access_token, mode, mount, manifest_digest, acquired_at, expires_at, heartbeat_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?)`,
+			volume.LeaseID, volume.Repo, volume.Repo, volume.Tag, clawID, volume.AccessToken, volume.Mode, volume.Mount, manifestDigest, now, expires, now); err != nil {
 			return nil, err
 		}
 		acquired = append(acquired, volume)
@@ -273,13 +279,15 @@ func (s *Server) dispatchVolumeAttach(ctx context.Context, cc *clawConn, volume 
 		s.fileAckMu.Unlock()
 	}()
 	payload := types.VolumeAttachPayload{
-		RequestID: reqID,
-		LeaseID:   volume.LeaseID,
-		Name:      volume.Name,
-		Mode:      volume.Mode,
-		Mount:     volume.Mount,
-		HubURL:    s.clawHubURL(),
-		ClawToken: s.hubCfg.ClawToken,
+		RequestID:  reqID,
+		LeaseID:    volume.LeaseID,
+		ClawID:     cc.id,
+		LeaseToken: volume.AccessToken,
+		Name:       volume.Name,
+		Mode:       volume.Mode,
+		Mount:      volume.Mount,
+		HubURL:     s.clawHubURL(),
+		ClawToken:  s.hubCfg.ClawToken,
 	}
 	if err := wsjson.Write(ctx, cc.conn, types.WSMessage{Type: "volume_attach", Payload: payload}); err != nil {
 		return err
@@ -355,13 +363,15 @@ func (s *Server) dispatchVolumeSync(ctx context.Context, cc *clawConn, volume wo
 		s.fileAckMu.Unlock()
 	}()
 	payload := types.VolumeSyncPayload{
-		RequestID: reqID,
-		LeaseID:   volume.LeaseID,
-		Name:      volume.Name,
-		Mode:      volume.Mode,
-		Mount:     volume.Mount,
-		HubURL:    s.clawHubURL(),
-		ClawToken: s.hubCfg.ClawToken,
+		RequestID:  reqID,
+		LeaseID:    volume.LeaseID,
+		ClawID:     cc.id,
+		LeaseToken: volume.AccessToken,
+		Name:       volume.Name,
+		Mode:       volume.Mode,
+		Mount:      volume.Mount,
+		HubURL:     s.clawHubURL(),
+		ClawToken:  s.hubCfg.ClawToken,
 	}
 	if err := wsjson.Write(ctx, cc.conn, types.WSMessage{Type: "volume_sync", Payload: payload}); err != nil {
 		return err
@@ -388,18 +398,24 @@ func (s *Server) handleVolumeArchive(w http.ResponseWriter, r *http.Request) {
 	if !s.authenticateClawToken(w, r) {
 		return
 	}
+	clawID := strings.TrimSpace(r.Header.Get("X-Claw-ID"))
+	accessToken := strings.TrimSpace(r.Header.Get("X-Volume-Token"))
+	if clawID == "" || accessToken == "" {
+		http.Error(w, "volume lease credentials required", http.StatusUnauthorized)
+		return
+	}
 	switch r.Method {
 	case http.MethodGet:
-		s.handleVolumeArchiveGet(w, r, leaseID)
+		s.handleVolumeArchiveGet(w, r, leaseID, clawID, accessToken)
 	case http.MethodPut:
-		s.handleVolumeArchivePut(w, r, leaseID)
+		s.handleVolumeArchivePut(w, r, leaseID, clawID, accessToken)
 	default:
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 	}
 }
 
-func (s *Server) handleVolumeArchiveGet(w http.ResponseWriter, r *http.Request, leaseID string) {
-	manifestDigest, err := s.volumeLeaseManifest(r.Context(), leaseID)
+func (s *Server) handleVolumeArchiveGet(w http.ResponseWriter, r *http.Request, leaseID, clawID, accessToken string) {
+	manifestDigest, err := s.volumeLeaseManifest(r.Context(), leaseID, clawID, accessToken)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
@@ -424,9 +440,9 @@ func (s *Server) handleVolumeArchiveGet(w http.ResponseWriter, r *http.Request, 
 	_, _ = io.Copy(w, body)
 }
 
-func (s *Server) handleVolumeArchivePut(w http.ResponseWriter, r *http.Request, leaseID string) {
+func (s *Server) handleVolumeArchivePut(w http.ResponseWriter, r *http.Request, leaseID, clawID, accessToken string) {
 	var repo, tag, mode, attachedDigest string
-	if err := s.db.QueryRow(`SELECT repo, tag, mode, manifest_digest FROM volume_leases WHERE id=? AND released_at IS NULL AND expires_at > ?`, leaseID, time.Now().UTC()).Scan(&repo, &tag, &mode, &attachedDigest); err != nil {
+	if err := s.db.QueryRow(`SELECT repo, tag, mode, manifest_digest FROM volume_leases WHERE id=? AND claw_id=? AND access_token=? AND released_at IS NULL AND expires_at > ?`, leaseID, clawID, accessToken, time.Now().UTC()).Scan(&repo, &tag, &mode, &attachedDigest); err != nil {
 		http.Error(w, "active lease not found", http.StatusNotFound)
 		return
 	}
@@ -468,15 +484,15 @@ func (s *Server) handleVolumeArchivePut(w http.ResponseWriter, r *http.Request, 
 		http.Error(w, "tag volume: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
-	if _, err := s.db.Exec(`UPDATE volume_leases SET manifest_digest=?, heartbeat_at=? WHERE id=?`, manifestDigest, time.Now().UTC(), leaseID); err != nil {
+	if _, err := s.db.Exec(`UPDATE volume_leases SET manifest_digest=?, heartbeat_at=? WHERE id=? AND claw_id=? AND access_token=?`, manifestDigest, time.Now().UTC(), leaseID, clawID, accessToken); err != nil {
 		log.Printf("[volume] lease %s: failed to update manifest_digest after successful tag: %v", leaseID, err)
 	}
 	jsonOK(w, map[string]string{"manifest_digest": manifestDigest})
 }
 
-func (s *Server) volumeLeaseManifest(ctx context.Context, leaseID string) (string, error) {
+func (s *Server) volumeLeaseManifest(ctx context.Context, leaseID, clawID, accessToken string) (string, error) {
 	var digest string
-	err := s.db.QueryRowContext(ctx, `SELECT manifest_digest FROM volume_leases WHERE id=? AND released_at IS NULL AND expires_at > ?`, leaseID, time.Now().UTC()).Scan(&digest)
+	err := s.db.QueryRowContext(ctx, `SELECT manifest_digest FROM volume_leases WHERE id=? AND claw_id=? AND access_token=? AND released_at IS NULL AND expires_at > ?`, leaseID, clawID, accessToken, time.Now().UTC()).Scan(&digest)
 	if err == sql.ErrNoRows {
 		return "", fmt.Errorf("active lease not found")
 	}

--- a/pkg/hub/volumes_test.go
+++ b/pkg/hub/volumes_test.go
@@ -87,6 +87,36 @@ func TestVolumeArchivePutAndGetUsesArtifactStore(t *testing.T) {
 	}
 }
 
+func TestSyncWorkflowVolumesKeepsWritableLeaseWhenDisconnected(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	volumes := []workflowVolumeRuntime{{
+		WorkflowVolume: types.WorkflowVolume{Name: "scratch", Source: "hub://volumes/scratch", Mount: "/mnt/elasticclaw/scratch", Mode: "rw"},
+		Repo:           "volumes/scratch",
+		Tag:            "latest",
+	}}
+	acquired, err := s.acquireWorkflowVolumeLeases(context.Background(), "claw-rw", volumes)
+	if err != nil {
+		t.Fatalf("acquire rw lease: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO claws(id, tenant_id, name, template, status, created_at) VALUES(?,?,?,?,?,datetime('now'))`,
+		"claw-rw", "test-tenant-id", "claw rw", "test", "connected"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.storeWorkflowVolumes("claw-rw", acquired); err != nil {
+		t.Fatalf("store workflow volumes: %v", err)
+	}
+
+	s.syncWorkflowVolumes("claw-rw")
+
+	var active int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM volume_leases WHERE claw_id=? AND released_at IS NULL`, "claw-rw").Scan(&active); err != nil {
+		t.Fatal(err)
+	}
+	if active != 1 {
+		t.Fatalf("active writable leases after disconnected sync = %d, want 1", active)
+	}
+}
+
 func testVolumeArchive(t *testing.T, files map[string]string) []byte {
 	t.Helper()
 	var buf bytes.Buffer

--- a/pkg/hub/volumes_test.go
+++ b/pkg/hub/volumes_test.go
@@ -117,6 +117,40 @@ func TestSyncWorkflowVolumesKeepsWritableLeaseWhenDisconnected(t *testing.T) {
 	}
 }
 
+func TestSyncWorkflowVolumesSkipsReleasedWritableLease(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	volumes := []workflowVolumeRuntime{{
+		WorkflowVolume: types.WorkflowVolume{Name: "scratch", Source: "hub://volumes/scratch", Mount: "/mnt/elasticclaw/scratch", Mode: "rw"},
+		Repo:           "volumes/scratch",
+		Tag:            "latest",
+	}}
+	acquired, err := s.acquireWorkflowVolumeLeases(context.Background(), "claw-rw", volumes)
+	if err != nil {
+		t.Fatalf("acquire rw lease: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO claws(id, tenant_id, name, template, status, created_at) VALUES(?,?,?,?,?,datetime('now'))`,
+		"claw-rw", "test-tenant-id", "claw rw", "test", "connected"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.storeWorkflowVolumes("claw-rw", acquired); err != nil {
+		t.Fatalf("store workflow volumes: %v", err)
+	}
+	s.releaseWorkflowVolumeLeases("claw-rw")
+	s.mu.Lock()
+	s.claws["claw-rw"] = &clawConn{id: "claw-rw", tenantID: "test-tenant-id"}
+	s.mu.Unlock()
+
+	s.syncWorkflowVolumes("claw-rw")
+
+	var active int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM volume_leases WHERE claw_id=? AND released_at IS NULL`, "claw-rw").Scan(&active); err != nil {
+		t.Fatal(err)
+	}
+	if active != 0 {
+		t.Fatalf("active writable leases after released sync = %d, want 0", active)
+	}
+}
+
 func testVolumeArchive(t *testing.T, files map[string]string) []byte {
 	t.Helper()
 	var buf bytes.Buffer

--- a/pkg/hub/volumes_test.go
+++ b/pkg/hub/volumes_test.go
@@ -1,0 +1,136 @@
+package hub
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func TestWorkflowVolumeLeaseModes(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	ro := []workflowVolumeRuntime{{
+		WorkflowVolume: types.WorkflowVolume{Name: "fixtures", Source: "hub://volumes/fixtures", Mount: "/mnt/elasticclaw/fixtures", Mode: "ro"},
+		Repo:           "volumes/fixtures",
+		Tag:            "latest",
+	}}
+	firstRO, err := s.acquireWorkflowVolumeLeases(context.Background(), "claw-ro-1", ro)
+	if err != nil {
+		t.Fatalf("first ro lease: %v", err)
+	}
+	secondRO, err := s.acquireWorkflowVolumeLeases(context.Background(), "claw-ro-2", ro)
+	if err != nil {
+		t.Fatalf("second ro lease should share: %v", err)
+	}
+	rw := []workflowVolumeRuntime{{
+		WorkflowVolume: types.WorkflowVolume{Name: "fixtures", Source: "hub://volumes/fixtures", Mount: "/mnt/elasticclaw/fixtures", Mode: "rw"},
+		Repo:           "volumes/fixtures",
+		Tag:            "latest",
+	}}
+	if _, err := s.acquireWorkflowVolumeLeases(context.Background(), "claw-rw", rw); err == nil || !strings.Contains(err.Error(), "locked") {
+		t.Fatalf("rw lease with active ro leases error = %v, want locked", err)
+	}
+
+	s.releaseWorkflowVolumeLeases("claw-ro-1")
+	s.releaseWorkflowVolumeLeases("claw-ro-2")
+	if _, err := s.acquireWorkflowVolumeLeases(context.Background(), "claw-rw", rw); err != nil {
+		t.Fatalf("rw lease after ro release: %v", err)
+	}
+	if _, err := s.acquireWorkflowVolumeLeases(context.Background(), "claw-ro-3", ro); err == nil || !strings.Contains(err.Error(), "locked") {
+		t.Fatalf("ro lease with active rw lease error = %v, want locked", err)
+	}
+	if firstRO[0].ManifestDigest == "" || secondRO[0].ManifestDigest == "" {
+		t.Fatal("expected leases to pin a manifest digest")
+	}
+}
+
+func TestVolumeArchivePutAndGetUsesArtifactStore(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	volumes := []workflowVolumeRuntime{{
+		WorkflowVolume: types.WorkflowVolume{Name: "scratch", Source: "hub://volumes/scratch", Mount: "/mnt/elasticclaw/scratch", Mode: "rw"},
+		Repo:           "volumes/scratch",
+		Tag:            "latest",
+	}}
+	acquired, err := s.acquireWorkflowVolumeLeases(context.Background(), "claw-rw", volumes)
+	if err != nil {
+		t.Fatalf("acquire rw lease: %v", err)
+	}
+	archive := testVolumeArchive(t, map[string]string{"state.txt": "hello volume"})
+
+	putReq := httptest.NewRequest(http.MethodPut, "/api/volumes/leases/"+acquired[0].LeaseID+"/archive", bytes.NewReader(archive))
+	putReq.SetPathValue("lease", acquired[0].LeaseID)
+	putReq.Header.Set("X-Claw-Token", "claw-token")
+	putRec := httptest.NewRecorder()
+	s.handleVolumeArchive(putRec, putReq)
+	if putRec.Code != http.StatusOK {
+		t.Fatalf("put status = %d: %s", putRec.Code, putRec.Body.String())
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/api/volumes/leases/"+acquired[0].LeaseID+"/archive", nil)
+	getReq.SetPathValue("lease", acquired[0].LeaseID)
+	getReq.Header.Set("X-Claw-Token", "claw-token")
+	getRec := httptest.NewRecorder()
+	s.handleVolumeArchive(getRec, getReq)
+	if getRec.Code != http.StatusOK {
+		t.Fatalf("get status = %d: %s", getRec.Code, getRec.Body.String())
+	}
+	files := readTestVolumeArchive(t, getRec.Body.Bytes())
+	if files["state.txt"] != "hello volume" {
+		t.Fatalf("archive files = %#v, want state.txt", files)
+	}
+}
+
+func testVolumeArchive(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for name, content := range files {
+		data := []byte(content)
+		if err := tw.WriteHeader(&tar.Header{Name: name, Mode: 0o640, Size: int64(len(data))}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write(data); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func readTestVolumeArchive(t *testing.T, data []byte) map[string]string {
+	t.Helper()
+	gz, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer gz.Close()
+	tr := tar.NewReader(gz)
+	files := map[string]string{}
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			return files
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		body, err := io.ReadAll(tr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		files[hdr.Name] = string(body)
+	}
+}

--- a/pkg/hub/volumes_test.go
+++ b/pkg/hub/volumes_test.go
@@ -66,7 +66,7 @@ func TestVolumeArchivePutAndGetUsesArtifactStore(t *testing.T) {
 
 	putReq := httptest.NewRequest(http.MethodPut, "/api/volumes/leases/"+acquired[0].LeaseID+"/archive", bytes.NewReader(archive))
 	putReq.SetPathValue("lease", acquired[0].LeaseID)
-	putReq.Header.Set("X-Claw-Token", "claw-token")
+	setVolumeArchiveAuth(putReq, "claw-token", "claw-rw", acquired[0].AccessToken)
 	putRec := httptest.NewRecorder()
 	s.handleVolumeArchive(putRec, putReq)
 	if putRec.Code != http.StatusOK {
@@ -75,7 +75,7 @@ func TestVolumeArchivePutAndGetUsesArtifactStore(t *testing.T) {
 
 	getReq := httptest.NewRequest(http.MethodGet, "/api/volumes/leases/"+acquired[0].LeaseID+"/archive", nil)
 	getReq.SetPathValue("lease", acquired[0].LeaseID)
-	getReq.Header.Set("X-Claw-Token", "claw-token")
+	setVolumeArchiveAuth(getReq, "claw-token", "claw-rw", acquired[0].AccessToken)
 	getRec := httptest.NewRecorder()
 	s.handleVolumeArchive(getRec, getReq)
 	if getRec.Code != http.StatusOK {
@@ -84,6 +84,62 @@ func TestVolumeArchivePutAndGetUsesArtifactStore(t *testing.T) {
 	files := readTestVolumeArchive(t, getRec.Body.Bytes())
 	if files["state.txt"] != "hello volume" {
 		t.Fatalf("archive files = %#v, want state.txt", files)
+	}
+}
+
+func TestNormalizeWorkflowVolumesNamespacesTenant(t *testing.T) {
+	workflow := &types.WorkflowConfig{Volumes: []types.WorkflowVolume{{
+		Name:   "cache",
+		Source: "hub://volumes/cache",
+		Mount:  "/mnt/elasticclaw/cache",
+		Mode:   "rw",
+	}}}
+	tenantA, err := normalizeWorkflowVolumes("tenant-a", workflow)
+	if err != nil {
+		t.Fatalf("normalize tenant a: %v", err)
+	}
+	tenantB, err := normalizeWorkflowVolumes("tenant-b", workflow)
+	if err != nil {
+		t.Fatalf("normalize tenant b: %v", err)
+	}
+	if tenantA[0].Repo != "volumes/tenant-a/cache" {
+		t.Fatalf("tenant a repo = %q", tenantA[0].Repo)
+	}
+	if tenantB[0].Repo != "volumes/tenant-b/cache" {
+		t.Fatalf("tenant b repo = %q", tenantB[0].Repo)
+	}
+	if tenantA[0].Repo == tenantB[0].Repo {
+		t.Fatalf("tenant repos should be distinct: %q", tenantA[0].Repo)
+	}
+}
+
+func TestVolumeArchiveRejectsWrongLeaseCredentials(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	volumes := []workflowVolumeRuntime{{
+		WorkflowVolume: types.WorkflowVolume{Name: "scratch", Source: "hub://volumes/scratch", Mount: "/mnt/elasticclaw/scratch", Mode: "rw"},
+		Repo:           "volumes/test-tenant/scratch",
+		Tag:            "latest",
+	}}
+	acquired, err := s.acquireWorkflowVolumeLeases(context.Background(), "claw-rw", volumes)
+	if err != nil {
+		t.Fatalf("acquire rw lease: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/volumes/leases/"+acquired[0].LeaseID+"/archive", nil)
+	req.SetPathValue("lease", acquired[0].LeaseID)
+	setVolumeArchiveAuth(req, "claw-token", "other-claw", acquired[0].AccessToken)
+	rec := httptest.NewRecorder()
+	s.handleVolumeArchive(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("get with wrong claw status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/volumes/leases/"+acquired[0].LeaseID+"/archive", nil)
+	req.SetPathValue("lease", acquired[0].LeaseID)
+	setVolumeArchiveAuth(req, "claw-token", "claw-rw", "wrong-token")
+	rec = httptest.NewRecorder()
+	s.handleVolumeArchive(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("get with wrong lease token status = %d, want %d", rec.Code, http.StatusNotFound)
 	}
 }
 
@@ -149,6 +205,12 @@ func TestSyncWorkflowVolumesSkipsReleasedWritableLease(t *testing.T) {
 	if active != 0 {
 		t.Fatalf("active writable leases after released sync = %d, want 0", active)
 	}
+}
+
+func setVolumeArchiveAuth(req *http.Request, clawToken, clawID, leaseToken string) {
+	req.Header.Set("X-Claw-Token", clawToken)
+	req.Header.Set("X-Claw-ID", clawID)
+	req.Header.Set("X-Volume-Token", leaseToken)
 }
 
 func testVolumeArchive(t *testing.T, files map[string]string) []byte {

--- a/pkg/hub/workflow_creator.go
+++ b/pkg/hub/workflow_creator.go
@@ -185,7 +185,7 @@ func (s *Server) createClawFromWorkflowWithOptions(workspace *types.WorkspaceCon
 	repositoriesJSON, _ := json.Marshal(repositories)
 
 	groupName, groupLimit := s.resolveWorkflowGroupLimit(workflow)
-	workflowVolumes, err := normalizeWorkflowVolumes(workflow)
+	workflowVolumes, err := normalizeWorkflowVolumes(tenantID, workflow)
 	if err != nil {
 		return "", false, err
 	}

--- a/pkg/hub/workflow_creator.go
+++ b/pkg/hub/workflow_creator.go
@@ -185,6 +185,11 @@ func (s *Server) createClawFromWorkflowWithOptions(workspace *types.WorkspaceCon
 	repositoriesJSON, _ := json.Marshal(repositories)
 
 	groupName, groupLimit := s.resolveWorkflowGroupLimit(workflow)
+	workflowVolumes, err := normalizeWorkflowVolumes(workflow)
+	if err != nil {
+		return "", false, err
+	}
+	workflowVolumesJSON, _ := json.Marshal(workflowVolumes)
 	s.promoteMu.Lock()
 	activeCount := s.countActiveClawsInGroup(groupName)
 	isPending := groupLimit > 0 && activeCount >= groupLimit
@@ -196,11 +201,11 @@ func (s *Server) createClawFromWorkflowWithOptions(workspace *types.WorkspaceCon
 	filesJSON, _ := json.Marshal(templateFiles)
 	now := time.Now().UTC()
 	_, err = s.db.Exec(`
-		INSERT INTO claws(id, tenant_id, name, template, provider, default_model, template_files, github_repos, linear_workspace, nix, docker, tags, color, llm_key, status, created_at, factory_name, concurrency_group)
-		VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		INSERT INTO claws(id, tenant_id, name, template, provider, default_model, template_files, github_repos, linear_workspace, nix, docker, tags, color, llm_key, status, created_at, factory_name, concurrency_group, workflow_volumes)
+		VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
 		clawID, tenantID, clawName, workspace.Name, provider, defaultModel, string(filesJSON),
 		string(repositoriesJSON), linearWorkspace, nixEnabled, dockerEnabled, string(tagsJSON), workflow.Color, llmKey,
-		initialStatus, now, "", groupName,
+		initialStatus, now, "", groupName, string(workflowVolumesJSON),
 	)
 	s.promoteMu.Unlock()
 	if err != nil {

--- a/pkg/hub/workspace_api.go
+++ b/pkg/hub/workspace_api.go
@@ -33,22 +33,23 @@ type WorkspaceAccess struct {
 
 // WorkflowView is a workflow-shaped projection of a legacy factory.
 type WorkflowView struct {
-	Name                 string               `json:"name"`
-	WorkspaceName        string               `json:"workspaceName"`
-	Source               string               `json:"source"`
-	Integration          string               `json:"integration"`
-	IntegrationWorkspace string               `json:"integrationWorkspace,omitempty"`
-	TriggerStatus        string               `json:"triggerStatus,omitempty"`
-	DoneStatus           string               `json:"doneStatus,omitempty"`
-	Labels               []string             `json:"labels,omitempty"`
-	AssignedTo           string               `json:"assignedTo,omitempty"`
-	Enabled              bool                 `json:"enabled"`
-	HasWebhookSecret     bool                 `json:"hasWebhookSecret"`
-	WebhookSecretRef     string               `json:"webhookSecretRef,omitempty"`
-	PipelineYAML         string               `json:"pipelineYAML,omitempty"`
-	EnableManualTrigger  bool                 `json:"enableManualTrigger,omitempty"`
-	SecretRefs           map[string]string    `json:"secretRefs,omitempty"`
-	Inputs               []types.FactoryInput `json:"inputs,omitempty"`
+	Name                 string                 `json:"name"`
+	WorkspaceName        string                 `json:"workspaceName"`
+	Source               string                 `json:"source"`
+	Integration          string                 `json:"integration"`
+	IntegrationWorkspace string                 `json:"integrationWorkspace,omitempty"`
+	TriggerStatus        string                 `json:"triggerStatus,omitempty"`
+	DoneStatus           string                 `json:"doneStatus,omitempty"`
+	Labels               []string               `json:"labels,omitempty"`
+	AssignedTo           string                 `json:"assignedTo,omitempty"`
+	Enabled              bool                   `json:"enabled"`
+	HasWebhookSecret     bool                   `json:"hasWebhookSecret"`
+	WebhookSecretRef     string                 `json:"webhookSecretRef,omitempty"`
+	PipelineYAML         string                 `json:"pipelineYAML,omitempty"`
+	EnableManualTrigger  bool                   `json:"enableManualTrigger,omitempty"`
+	SecretRefs           map[string]string      `json:"secretRefs,omitempty"`
+	Volumes              []types.WorkflowVolume `json:"volumes,omitempty"`
+	Inputs               []types.FactoryInput   `json:"inputs,omitempty"`
 }
 
 func (s *Server) handleWorkspacesList(w http.ResponseWriter, _ *http.Request) {
@@ -496,6 +497,7 @@ func workflowToView(workspaceName string, workflow *types.WorkflowConfig) Workfl
 		Enabled:              workflow.Enabled == nil || *workflow.Enabled,
 		EnableManualTrigger:  workflow.EnableManualTrigger,
 		SecretRefs:           cloneStringMap(workflow.SecretRefs),
+		Volumes:              append([]types.WorkflowVolume(nil), workflow.Volumes...),
 		Inputs:               append([]types.FactoryInput(nil), workflow.Inputs...),
 	}
 }

--- a/pkg/types/hub.go
+++ b/pkg/types/hub.go
@@ -109,3 +109,37 @@ type CheckpointComplete struct {
 	RootSHA256   string `json:"root_sha256"`
 	Error        string `json:"error,omitempty"`
 }
+
+type VolumeAttachPayload struct {
+	RequestID string `json:"request_id"`
+	LeaseID   string `json:"lease_id"`
+	Name      string `json:"name"`
+	Mode      string `json:"mode"`
+	Mount     string `json:"mount"`
+	HubURL    string `json:"hub_url"`
+	ClawToken string `json:"claw_token"`
+}
+
+type VolumeAttachAck struct {
+	RequestID string `json:"request_id"`
+	LeaseID   string `json:"lease_id"`
+	OK        bool   `json:"ok"`
+	Error     string `json:"error,omitempty"`
+}
+
+type VolumeSyncPayload struct {
+	RequestID string `json:"request_id"`
+	LeaseID   string `json:"lease_id"`
+	Name      string `json:"name"`
+	Mode      string `json:"mode"`
+	Mount     string `json:"mount"`
+	HubURL    string `json:"hub_url"`
+	ClawToken string `json:"claw_token"`
+}
+
+type VolumeSyncAck struct {
+	RequestID string `json:"request_id"`
+	LeaseID   string `json:"lease_id"`
+	OK        bool   `json:"ok"`
+	Error     string `json:"error,omitempty"`
+}

--- a/pkg/types/hub.go
+++ b/pkg/types/hub.go
@@ -111,13 +111,15 @@ type CheckpointComplete struct {
 }
 
 type VolumeAttachPayload struct {
-	RequestID string `json:"request_id"`
-	LeaseID   string `json:"lease_id"`
-	Name      string `json:"name"`
-	Mode      string `json:"mode"`
-	Mount     string `json:"mount"`
-	HubURL    string `json:"hub_url"`
-	ClawToken string `json:"claw_token"`
+	RequestID  string `json:"request_id"`
+	LeaseID    string `json:"lease_id"`
+	ClawID     string `json:"claw_id"`
+	LeaseToken string `json:"lease_token"`
+	Name       string `json:"name"`
+	Mode       string `json:"mode"`
+	Mount      string `json:"mount"`
+	HubURL     string `json:"hub_url"`
+	ClawToken  string `json:"claw_token"`
 }
 
 type VolumeAttachAck struct {
@@ -128,13 +130,15 @@ type VolumeAttachAck struct {
 }
 
 type VolumeSyncPayload struct {
-	RequestID string `json:"request_id"`
-	LeaseID   string `json:"lease_id"`
-	Name      string `json:"name"`
-	Mode      string `json:"mode"`
-	Mount     string `json:"mount"`
-	HubURL    string `json:"hub_url"`
-	ClawToken string `json:"claw_token"`
+	RequestID  string `json:"request_id"`
+	LeaseID    string `json:"lease_id"`
+	ClawID     string `json:"claw_id"`
+	LeaseToken string `json:"lease_token"`
+	Name       string `json:"name"`
+	Mode       string `json:"mode"`
+	Mount      string `json:"mount"`
+	HubURL     string `json:"hub_url"`
+	ClawToken  string `json:"claw_token"`
 }
 
 type VolumeSyncAck struct {

--- a/pkg/types/validation.go
+++ b/pkg/types/validation.go
@@ -81,6 +81,7 @@ var repoWildcardRegex = regexp.MustCompile(`^[a-zA-Z0-9_.-]+/\*$`)
 // namePatternRegex validates that name_pattern only contains allowed placeholders.
 // Allows multiple placeholders separated by literal characters, e.g. {issue_id}-{title}.
 var namePatternRegex = regexp.MustCompile(`^([a-zA-Z0-9_-]*\{[a-zA-Z0-9_]+\})*[a-zA-Z0-9_-]*$`)
+var volumeNameRegex = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 
 func validateRunKind(entityType, entityName, runKind string) error {
 	if runKind != "" && !validTaskRunKinds[runKind] {
@@ -233,10 +234,53 @@ func (w *WorkflowConfig) Validate() error {
 			return err
 		}
 	}
+	seenVolumes := map[string]struct{}{}
+	for i, volume := range w.Volumes {
+		if err := validateWorkflowVolume(w.Name, i, volume, seenVolumes); err != nil {
+			return err
+		}
+	}
 	for i, stage := range w.Stages {
 		if strings.TrimSpace(stage.ID) == "" {
 			return fmt.Errorf("workflow %q: stages[%d].id is required", w.Name, i)
 		}
+	}
+	return nil
+}
+
+func validateWorkflowVolume(workflowName string, index int, volume WorkflowVolume, seen map[string]struct{}) error {
+	name := strings.TrimSpace(volume.Name)
+	if name == "" {
+		return fmt.Errorf("workflow %q: volumes[%d].name is required", workflowName, index)
+	}
+	if !volumeNameRegex.MatchString(name) {
+		return fmt.Errorf("workflow %q: volumes[%d].name %q must contain only alphanumeric, hyphens, or underscores", workflowName, index, volume.Name)
+	}
+	lowerName := strings.ToLower(name)
+	if _, ok := seen[lowerName]; ok {
+		return fmt.Errorf("workflow %q: duplicate volume name %q", workflowName, volume.Name)
+	}
+	seen[lowerName] = struct{}{}
+	source := strings.TrimSpace(volume.Source)
+	if !strings.HasPrefix(source, "hub://volumes/") || strings.TrimPrefix(source, "hub://volumes/") == "" {
+		return fmt.Errorf("workflow %q: volumes[%d].source must use hub://volumes/<name>", workflowName, index)
+	}
+	mount := strings.TrimSpace(volume.Mount)
+	if mount == "" || !strings.HasPrefix(mount, "/") {
+		return fmt.Errorf("workflow %q: volumes[%d].mount must be an absolute path outside the repository", workflowName, index)
+	}
+	if strings.Contains(mount, "..") {
+		return fmt.Errorf("workflow %q: volumes[%d].mount must not contain path traversal", workflowName, index)
+	}
+	if mount == "/" || strings.HasPrefix(mount, "/home/daytona/.openclaw/workspace") || strings.HasPrefix(mount, "/workspace") {
+		return fmt.Errorf("workflow %q: volumes[%d].mount must be outside the repository workspace", workflowName, index)
+	}
+	mode := strings.TrimSpace(volume.Mode)
+	if mode == "" {
+		mode = "ro"
+	}
+	if mode != "ro" && mode != "rw" {
+		return fmt.Errorf("workflow %q: volumes[%d].mode must be ro or rw", workflowName, index)
 	}
 	return nil
 }

--- a/pkg/types/validation.go
+++ b/pkg/types/validation.go
@@ -275,6 +275,11 @@ func validateWorkflowVolume(workflowName string, index int, volume WorkflowVolum
 	if mount == "/" || strings.HasPrefix(mount, "/home/daytona/.openclaw/workspace") || strings.HasPrefix(mount, "/workspace") {
 		return fmt.Errorf("workflow %q: volumes[%d].mount must be outside the repository workspace", workflowName, index)
 	}
+	mountKey := "mount:" + mount
+	if _, ok := seen[mountKey]; ok {
+		return fmt.Errorf("workflow %q: duplicate volume mount %q", workflowName, mount)
+	}
+	seen[mountKey] = struct{}{}
 	mode := strings.TrimSpace(volume.Mode)
 	if mode == "" {
 		mode = "ro"

--- a/pkg/types/workflow_volume_test.go
+++ b/pkg/types/workflow_volume_test.go
@@ -24,6 +24,24 @@ func TestWorkflowVolumeValidation(t *testing.T) {
 		t.Fatalf("valid workflow volume config rejected: %v", err)
 	}
 
+	duplicateMount := &WorkflowConfig{
+		Name: "volume-workflow",
+		Volumes: []WorkflowVolume{{
+			Name:   "fixtures",
+			Source: "hub://volumes/test-fixtures",
+			Mount:  "/mnt/elasticclaw/shared",
+			Mode:   "ro",
+		}, {
+			Name:   "scratch",
+			Source: "hub://volumes/scratch",
+			Mount:  "/mnt/elasticclaw/shared",
+			Mode:   "rw",
+		}},
+	}
+	if err := duplicateMount.Validate(); err == nil || !strings.Contains(err.Error(), "duplicate volume mount") {
+		t.Fatalf("duplicate mount Validate() error = %v, want duplicate volume mount", err)
+	}
+
 	tests := []struct {
 		name string
 		vol  WorkflowVolume

--- a/pkg/types/workflow_volume_test.go
+++ b/pkg/types/workflow_volume_test.go
@@ -1,0 +1,46 @@
+package types
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestWorkflowVolumeValidation(t *testing.T) {
+	valid := &WorkflowConfig{
+		Name: "volume-workflow",
+		Volumes: []WorkflowVolume{{
+			Name:   "fixtures",
+			Source: "hub://volumes/test-fixtures",
+			Mount:  "/mnt/elasticclaw/test-fixtures",
+			Mode:   "ro",
+		}, {
+			Name:   "scratch",
+			Source: "hub://volumes/scratch:latest",
+			Mount:  "/mnt/elasticclaw/scratch",
+			Mode:   "rw",
+		}},
+	}
+	if err := valid.Validate(); err != nil {
+		t.Fatalf("valid workflow volume config rejected: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		vol  WorkflowVolume
+		want string
+	}{
+		{name: "bad source", vol: WorkflowVolume{Name: "data", Source: "s3://bucket/data", Mount: "/mnt/elasticclaw/data", Mode: "ro"}, want: "source must use hub://volumes/<name>"},
+		{name: "relative mount", vol: WorkflowVolume{Name: "data", Source: "hub://volumes/data", Mount: "data", Mode: "ro"}, want: "mount must be an absolute path"},
+		{name: "workspace mount", vol: WorkflowVolume{Name: "data", Source: "hub://volumes/data", Mount: "/home/daytona/.openclaw/workspace/data", Mode: "ro"}, want: "outside the repository workspace"},
+		{name: "bad mode", vol: WorkflowVolume{Name: "data", Source: "hub://volumes/data", Mount: "/mnt/elasticclaw/data", Mode: "rwx"}, want: "mode must be ro or rw"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			workflow := &WorkflowConfig{Name: "volume-workflow", Volumes: []WorkflowVolume{tt.vol}}
+			err := workflow.Validate()
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Validate() error = %v, want containing %q", err, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/types/workspace.go
+++ b/pkg/types/workspace.go
@@ -44,6 +44,7 @@ type WorkflowConfig struct {
 	AssignedTo          string            `yaml:"assigned_to,omitempty" json:"assigned_to,omitempty"`
 	AllowedLabelers     []string          `yaml:"allowed_labelers,omitempty" json:"allowed_labelers,omitempty"`
 	SecretRefs          map[string]string `yaml:"secret_refs,omitempty" json:"secret_refs,omitempty"`
+	Volumes             []WorkflowVolume  `yaml:"volumes,omitempty" json:"volumes,omitempty"`
 	Inputs              []FactoryInput    `yaml:"inputs,omitempty" json:"inputs,omitempty"`
 	ConcurrencyGroup    string            `yaml:"concurrency_group,omitempty" json:"concurrency_group,omitempty"`
 	EnableManualTrigger bool              `yaml:"enable_manual_trigger,omitempty" json:"enable_manual_trigger,omitempty"`
@@ -52,6 +53,15 @@ type WorkflowConfig struct {
 	Trigger             *WorkflowTrigger  `yaml:"trigger,omitempty" json:"trigger,omitempty"`
 	Stages              []WorkflowStage   `yaml:"stages,omitempty" json:"stages,omitempty"`
 	PipelineYAML        string            `yaml:"pipeline_yaml,omitempty" json:"pipelineYAML,omitempty"`
+}
+
+// WorkflowVolume declares a hub-managed artifact-backed directory attached to
+// claws created by a workflow.
+type WorkflowVolume struct {
+	Name   string `yaml:"name" json:"name"`
+	Source string `yaml:"source" json:"source"`
+	Mount  string `yaml:"mount" json:"mount"`
+	Mode   string `yaml:"mode,omitempty" json:"mode,omitempty"`
 }
 
 // UnmarshalYAML rejects removed workflow keys so old workflow files fail loudly
@@ -83,10 +93,10 @@ type WorkflowTrigger struct {
 
 // CronWorkflowTrigger defines a cron-based schedule for a workflow.
 type CronWorkflowTrigger struct {
-	Schedule       string `yaml:"schedule" json:"schedule"`                             // cron expression, e.g. "0 9 * * 1"
-	Timezone       string `yaml:"timezone,omitempty" json:"timezone,omitempty"`           // IANA timezone, e.g. "America/Chicago"
-	OverlapPolicy  string `yaml:"overlap_policy,omitempty" json:"overlap_policy,omitempty"` // skip, queue, parallel (default: skip)
-	Timeout        string `yaml:"timeout,omitempty" json:"timeout,omitempty"`             // e.g. "2h", "30m"
+	Schedule      string `yaml:"schedule" json:"schedule"`                                 // cron expression, e.g. "0 9 * * 1"
+	Timezone      string `yaml:"timezone,omitempty" json:"timezone,omitempty"`             // IANA timezone, e.g. "America/Chicago"
+	OverlapPolicy string `yaml:"overlap_policy,omitempty" json:"overlap_policy,omitempty"` // skip, queue, parallel (default: skip)
+	Timeout       string `yaml:"timeout,omitempty" json:"timeout,omitempty"`               // e.g. "2h", "30m"
 }
 
 // WorkflowRun represents a single execution of a workflow.
@@ -95,8 +105,8 @@ type WorkflowRun struct {
 	TenantID      string                 `json:"tenant_id,omitempty"`
 	WorkflowName  string                 `json:"workflow_name"`
 	WorkspaceName string                 `json:"workspace_name"`
-	TriggerType   string                 `json:"trigger_type"`   // "cron", "manual"
-	Status        string                 `json:"status"`         // "pending", "running", "completed", "failed", "skipped", "timed_out", "canceled"
+	TriggerType   string                 `json:"trigger_type"`     // "cron", "manual"
+	Status        string                 `json:"status"`           // "pending", "running", "completed", "failed", "skipped", "timed_out", "canceled"
 	Result        string                 `json:"result,omitempty"` // "success", "failure", "skipped", "timed_out", "canceled"
 	ClawID        string                 `json:"claw_id,omitempty"`
 	RunContext    map[string]interface{} `json:"run_context,omitempty"`


### PR DESCRIPTION
## Summary
- add workflow `volumes:` schema for hub-managed artifact-backed directories
- add hub volume leases with shared RO and single-writer RW semantics
- add claw-bridge attach/sync messages and artifact archive endpoints for volume transfer
- sync RW volumes before hub-driven terminal shutdown and heartbeat active leases

## Notes
- Uses tar+gzip archives for the first portable volume layer implementation. The artifact layer media type is explicit so zstd can be added later without changing the lease model.
- RWX/shared-writer semantics are intentionally not implemented.

Closes #392

## Tests
- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./...