### PR TITLE
Add repo flake environment guidance

### DIFF
--- a/pkg/hub/repo_instructions_test.go
+++ b/pkg/hub/repo_instructions_test.go
@@ -87,6 +87,25 @@ func TestBuildRepoInstructionDiscoveryScriptRemovesStaleIndexWhenNoInstructionFi
 	}
 }
 
+func TestBuildRepoInstructionDiscoveryScriptRemovesStaleEnvironmentWhenNoFlakes(t *testing.T) {
+	dir := t.TempDir()
+	repoDir := filepath.Join(dir, "elasticclaw")
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stalePath := filepath.Join(dir, "REPO_ENVIRONMENT.md")
+	if err := os.WriteFile(stalePath, []byte("stale\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	script := buildRepoInstructionDiscoveryScript(dir, []types.GitHubRepoAccess{{Repo: "elasticclaw/elasticclaw"}})
+	runBashScript(t, script)
+
+	if _, err := os.Stat(stalePath); !os.IsNotExist(err) {
+		t.Fatalf("stale REPO_ENVIRONMENT.md should be removed, stat err=%v", err)
+	}
+}
+
 func TestBuildRepoInstructionDiscoveryScriptWritesRepoEnvironmentForFlakes(t *testing.T) {
 	dir := t.TempDir()
 	repoDir := filepath.Join(dir, "elasticclaw")

--- a/pkg/hub/repo_instructions_test.go
+++ b/pkg/hub/repo_instructions_test.go
@@ -23,7 +23,7 @@ func TestRepoInstructionFileNamesIncludesAgents(t *testing.T) {
 
 func TestBuildRepoInstructionDiscoveryScriptReferencesKnownFiles(t *testing.T) {
 	script := buildRepoInstructionDiscoveryScript("$HOME/.openclaw/workspace", []types.GitHubRepoAccess{{Repo: "elasticclaw/elasticclaw"}})
-	for _, want := range []string{"AGENTS.md", "CLAUDE.md", "GEMINI.md", "REPO_INSTRUCTIONS.md"} {
+	for _, want := range []string{"AGENTS.md", "CLAUDE.md", "GEMINI.md", "REPO_INSTRUCTIONS.md", "REPO_ENVIRONMENT.md", "nix develop --accept-flake-config"} {
 		if !strings.Contains(script, want) {
 			t.Fatalf("script missing %q:\n%s", want, script)
 		}
@@ -84,6 +84,38 @@ func TestBuildRepoInstructionDiscoveryScriptRemovesStaleIndexWhenNoInstructionFi
 
 	if _, err := os.Stat(stalePath); !os.IsNotExist(err) {
 		t.Fatalf("stale REPO_INSTRUCTIONS.md should be removed, stat err=%v", err)
+	}
+}
+
+func TestBuildRepoInstructionDiscoveryScriptWritesRepoEnvironmentForFlakes(t *testing.T) {
+	dir := t.TempDir()
+	repoDir := filepath.Join(dir, "elasticclaw")
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, "flake.nix"), []byte("{ description = \"test\"; }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	script := buildRepoInstructionDiscoveryScript(dir, []types.GitHubRepoAccess{{Repo: "elasticclaw/elasticclaw"}})
+	runBashScript(t, script)
+	runBashScript(t, script)
+
+	envIndex, err := os.ReadFile(filepath.Join(dir, "REPO_ENVIRONMENT.md"))
+	if err != nil {
+		t.Fatalf("read generated environment index: %v", err)
+	}
+	envText := string(envIndex)
+	if !strings.Contains(envText, "cd elasticclaw && nix develop --accept-flake-config -c <command>") {
+		t.Fatalf("generated environment index missing native nix guidance:\n%s", envText)
+	}
+
+	agents, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("read workspace AGENTS.md: %v", err)
+	}
+	if count := strings.Count(string(agents), "## Repository Environments"); count != 1 {
+		t.Fatalf("workspace AGENTS.md should contain one repo environment section, got %d:\n%s", count, agents)
 	}
 }
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -5362,9 +5362,15 @@ var repoInstructionFileNames = []string{"AGENTS.md", "CLAUDE.md", "GEMINI.md"}
 
 const repoInstructionsIndexName = "REPO_INSTRUCTIONS.md"
 
+const repoEnvironmentIndexName = "REPO_ENVIRONMENT.md"
+
 const repoInstructionsAgentsSection = `## Repository Instructions
 
 If ` + "`REPO_INSTRUCTIONS.md`" + ` exists, read it before working inside any cloned repository. It lists repository-owned instruction files such as ` + "`AGENTS.md`" + `, ` + "`CLAUDE.md`" + `, and ` + "`GEMINI.md`" + `.`
+
+const repoEnvironmentAgentsSection = `## Repository Environments
+
+If ` + "`REPO_ENVIRONMENT.md`" + ` exists, read it before running commands inside cloned repositories. Repositories with ` + "`flake.nix`" + ` should run repo-local commands with that repository's own Nix development shell, for example ` + "`cd <repo> && nix develop --accept-flake-config -c <command>`" + `.`
 
 func buildRepoInstructionDiscoveryScript(workspaceDir string, repos []types.GitHubRepoAccess) string {
 	if len(repos) == 0 {
@@ -5375,6 +5381,7 @@ func buildRepoInstructionDiscoveryScript(workspaceDir string, repos []types.GitH
 WORKSPACE_DIR=%s
 mkdir -p "$WORKSPACE_DIR"
 cd "$WORKSPACE_DIR"
+
 TMP="$(mktemp "$WORKSPACE_DIR/.repo-instructions.XXXXXX")"
 FOUND=0
 {
@@ -5407,6 +5414,30 @@ else
   rm -f "$TMP" "$WORKSPACE_DIR/%s"
 fi
 
+ENV_TMP="$(mktemp "$WORKSPACE_DIR/.repo-environment.XXXXXX")"
+ENV_FOUND=0
+{
+  printf '%%s\n\n' '# Repository Environments'
+  printf '%%s\n\n' 'ElasticClaw detected repository-local Nix flakes. Run commands for each repository with that repository flake instead of assuming one global project environment.'
+  printf '%%s\n\n' 'For one command, use: cd <repo> && nix develop --accept-flake-config -c <command>'
+  printf '%%s\n\n' 'For a sequence of commands in one repository, use: cd <repo> && nix develop --accept-flake-config'
+`, repoInstructionsIndexName, repoInstructionsIndexName)
+	for _, repo := range repos {
+		repoName := repoDirectoryName(repo.Repo)
+		fmt.Fprintf(&b, `  REPO_DIR=%s
+  if [ -f "$REPO_DIR/flake.nix" ]; then
+    ENV_FOUND=1
+    printf -- '- %s: cd %s && nix develop --accept-flake-config -c <command>\n'
+  fi
+`, shellQuote(repoName), repoName, repoName)
+	}
+	fmt.Fprintf(&b, `} > "$ENV_TMP"
+if [ "$ENV_FOUND" -eq 1 ]; then
+  mv "$ENV_TMP" "$WORKSPACE_DIR/%s"
+else
+  rm -f "$ENV_TMP" "$WORKSPACE_DIR/%s"
+fi
+
 AGENTS_FILE="$WORKSPACE_DIR/AGENTS.md"
 SECTION='## Repository Instructions'
 if [ ! -f "$AGENTS_FILE" ]; then
@@ -5419,7 +5450,19 @@ elif ! grep -Fqx "$SECTION" "$AGENTS_FILE"; then
 %s
 ELASTICCLAW_REPO_AGENTS
 fi
-`, repoInstructionsIndexName, repoInstructionsIndexName, repoInstructionsAgentsSection, repoInstructionsAgentsSection)
+
+ENV_SECTION='## Repository Environments'
+if [ ! -f "$AGENTS_FILE" ]; then
+  cat > "$AGENTS_FILE" << 'ELASTICCLAW_REPO_ENV'
+%s
+ELASTICCLAW_REPO_ENV
+elif ! grep -Fqx "$ENV_SECTION" "$AGENTS_FILE"; then
+  cat >> "$AGENTS_FILE" << 'ELASTICCLAW_REPO_ENV'
+
+%s
+ELASTICCLAW_REPO_ENV
+fi
+`, repoEnvironmentIndexName, repoEnvironmentIndexName, repoInstructionsAgentsSection, repoInstructionsAgentsSection, repoEnvironmentAgentsSection, repoEnvironmentAgentsSection)
 	return b.String()
 }
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -5452,17 +5452,13 @@ ELASTICCLAW_REPO_AGENTS
 fi
 
 ENV_SECTION='## Repository Environments'
-if [ ! -f "$AGENTS_FILE" ]; then
-  cat > "$AGENTS_FILE" << 'ELASTICCLAW_REPO_ENV'
-%s
-ELASTICCLAW_REPO_ENV
-elif ! grep -Fqx "$ENV_SECTION" "$AGENTS_FILE"; then
+if ! grep -Fqx "$ENV_SECTION" "$AGENTS_FILE"; then
   cat >> "$AGENTS_FILE" << 'ELASTICCLAW_REPO_ENV'
 
 %s
 ELASTICCLAW_REPO_ENV
 fi
-`, repoEnvironmentIndexName, repoEnvironmentIndexName, repoInstructionsAgentsSection, repoInstructionsAgentsSection, repoEnvironmentAgentsSection, repoEnvironmentAgentsSection)
+`, repoEnvironmentIndexName, repoEnvironmentIndexName, repoInstructionsAgentsSection, repoInstructionsAgentsSection, repoEnvironmentAgentsSection)
 	return b.String()
 }
 


### PR DESCRIPTION
## Summary
- detect cloned repositories with repo-local flake.nix during repo instruction discovery
- generate REPO_ENVIRONMENT.md with native nix develop commands for each flake-backed repo
- append a Repository Environments section to workspace AGENTS.md so agents know to use the repo flake for repo-local commands

## Notes
- Keeps workspace flake behavior as the global claw/tooling environment.
- Does not introduce a custom helper command; generated guidance uses native nix develop directly.

## Tests
- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./pkg/hub
- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./...