### PR TITLE
Forward PR inline review feedback

### DIFF
--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -428,6 +428,14 @@ func migrate(db *sql.DB) error {
 		UNIQUE(claw_id, pr_url)
 	);
 
+	CREATE TABLE IF NOT EXISTS claw_pr_feedback_deliveries (
+		claw_id       TEXT NOT NULL,
+		feedback_type TEXT NOT NULL,
+		github_id     INTEGER NOT NULL,
+		created_at    DATETIME NOT NULL,
+		PRIMARY KEY(claw_id, feedback_type, github_id)
+	);
+
 	CREATE TABLE IF NOT EXISTS claw_checkpoints (
 		id                    TEXT PRIMARY KEY,
 		tenant_id             TEXT NOT NULL,

--- a/pkg/hub/github_webhook.go
+++ b/pkg/hub/github_webhook.go
@@ -85,6 +85,26 @@ func (s *Server) handleGitHubWebhook(w http.ResponseWriter, r *http.Request) {
 			payload.Action, payload.Repository.FullName, payload.Number,
 			payload.PullRequest.User.Login, payload.PullRequest.Base.Ref)
 		go s.processGitHubPREvent(payload)
+	case "pull_request_review_comment":
+		var payload githubPRReviewCommentPayload
+		if err := json.Unmarshal(body, &payload); err != nil {
+			log.Printf("[github-webhook] failed to parse pull_request_review_comment payload: %v", err)
+			http.Error(w, "invalid payload", http.StatusBadRequest)
+			return
+		}
+		log.Printf("[github-webhook] pull_request_review_comment action=%q repo=%q pr=#%d author=%q",
+			payload.Action, payload.Repository.FullName, payload.PullRequest.Number, payload.Comment.User.Login)
+		go s.processGitHubPRReviewCommentEvent(payload)
+	case "pull_request_review":
+		var payload githubPRReviewPayload
+		if err := json.Unmarshal(body, &payload); err != nil {
+			log.Printf("[github-webhook] failed to parse pull_request_review payload: %v", err)
+			http.Error(w, "invalid payload", http.StatusBadRequest)
+			return
+		}
+		log.Printf("[github-webhook] pull_request_review action=%q state=%q repo=%q pr=#%d author=%q",
+			payload.Action, payload.Review.State, payload.Repository.FullName, payload.PullRequest.Number, payload.Review.User.Login)
+		go s.processGitHubPRReviewEvent(payload)
 	case "issue_comment":
 		var payload githubIssueCommentPayload
 		if err := json.Unmarshal(body, &payload); err != nil {
@@ -236,6 +256,95 @@ func (s *Server) processGitHubPREvent(payload githubPRPayload) {
 				payload.PullRequest.Title, "", payload.Action, "error", "", err.Error())
 		}
 	}
+}
+
+// githubPRReviewCommentPayload holds fields from a pull_request_review_comment webhook event.
+type githubPRReviewCommentPayload struct {
+	Action  string `json:"action"` // "created", "edited", "deleted"
+	Comment struct {
+		ID      int64  `json:"id"`
+		Body    string `json:"body"`
+		HTMLURL string `json:"html_url"`
+		Path    string `json:"path"`
+		Line    int    `json:"line"`
+		User    struct {
+			Login string `json:"login"`
+			Type  string `json:"type"`
+		} `json:"user"`
+	} `json:"comment"`
+	PullRequest struct {
+		Number  int    `json:"number"`
+		HTMLURL string `json:"html_url"`
+	} `json:"pull_request"`
+	Repository struct {
+		FullName string `json:"full_name"`
+	} `json:"repository"`
+}
+
+// githubPRReviewPayload holds fields from a pull_request_review webhook event.
+type githubPRReviewPayload struct {
+	Action string `json:"action"` // "submitted", "edited", "dismissed"
+	Review struct {
+		ID      int64  `json:"id"`
+		State   string `json:"state"` // "changes_requested", "approved", "commented"
+		Body    string `json:"body"`
+		HTMLURL string `json:"html_url"`
+		User    struct {
+			Login string `json:"login"`
+			Type  string `json:"type"`
+		} `json:"user"`
+	} `json:"review"`
+	PullRequest struct {
+		Number  int    `json:"number"`
+		HTMLURL string `json:"html_url"`
+	} `json:"pull_request"`
+	Repository struct {
+		FullName string `json:"full_name"`
+	} `json:"repository"`
+}
+
+func (s *Server) processGitHubPRReviewCommentEvent(payload githubPRReviewCommentPayload) {
+	if payload.Action != "created" {
+		return
+	}
+	if !s.isHumanGitHubActor(payload.Comment.User.Login, payload.Comment.User.Type) {
+		return
+	}
+	prURL := payload.PullRequest.HTMLURL
+	clawID := s.findClawForGitHubPR(prURL)
+	if clawID == "" {
+		log.Printf("[github-webhook] review_comment on PR #%d — no claw found for %s", payload.PullRequest.Number, prURL)
+		return
+	}
+	pr := clawPR{
+		clawID:   clawID,
+		repo:     payload.Repository.FullName,
+		prNumber: payload.PullRequest.Number,
+		prURL:    prURL,
+	}
+	s.forwardHumanReviewComment(pr, payload.Comment.ID, payload.Comment.User.Login, payload.Comment.Body, payload.Comment.HTMLURL, payload.Comment.Path, payload.Comment.Line)
+}
+
+func (s *Server) processGitHubPRReviewEvent(payload githubPRReviewPayload) {
+	if payload.Action != "submitted" || !strings.EqualFold(payload.Review.State, "changes_requested") {
+		return
+	}
+	if !s.isHumanGitHubActor(payload.Review.User.Login, payload.Review.User.Type) {
+		return
+	}
+	prURL := payload.PullRequest.HTMLURL
+	clawID := s.findClawForGitHubPR(prURL)
+	if clawID == "" {
+		log.Printf("[github-webhook] review on PR #%d — no claw found for %s", payload.PullRequest.Number, prURL)
+		return
+	}
+	pr := clawPR{
+		clawID:   clawID,
+		repo:     payload.Repository.FullName,
+		prNumber: payload.PullRequest.Number,
+		prURL:    prURL,
+	}
+	s.forwardHumanRequestedChangesReview(pr, payload.Review.ID, payload.Review.User.Login, payload.Review.Body, payload.Review.HTMLURL)
 }
 
 // githubIssueCommentPayload holds fields from an issue_comment webhook event.

--- a/pkg/hub/pr_review_feedback_test.go
+++ b/pkg/hub/pr_review_feedback_test.go
@@ -1,0 +1,513 @@
+package hub
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func TestPollHumanInlineReviewCommentForwardsToClaw(t *testing.T) {
+	s, db := newPRReviewFeedbackTestServer(t)
+	seedTrackedPRForReviewFeedback(t, db, "claw-inline-poll", "elastic/claw", 75, 20, 0)
+	startTaskRunForTest(t, s, "claw-inline-poll", "inline-poll")
+
+	pr := clawPR{
+		id:                  "pr-claw-inline-poll",
+		clawID:              "claw-inline-poll",
+		repo:                "elastic/claw",
+		prNumber:            75,
+		prURL:               "https://github.com/elastic/claw/pull/75",
+		lastReviewCommentID: 20,
+	}
+
+	s.checkGreptileReviewComments(pr, []interface{}{
+		map[string]interface{}{
+			"id":       float64(21),
+			"user":     map[string]interface{}{"login": "reviewer", "type": "User"},
+			"body":     "inline concern",
+			"html_url": "https://github.com/elastic/claw/pull/75#discussion_r21",
+			"path":     "pkg/hub/server.go",
+			"line":     float64(42),
+		},
+	})
+
+	assertMessageContains(t, db, "claw-inline-poll", "hub", []string{
+		"@reviewer",
+		"inline review comment",
+		"pkg/hub/server.go:42",
+		"inline concern",
+		"https://github.com/elastic/claw/pull/75#discussion_r21",
+	})
+}
+
+func TestPollHumanRequestedChangesReviewForwardsToClaw(t *testing.T) {
+	s, db := newPRReviewFeedbackTestServer(t)
+	seedTrackedPRForReviewFeedback(t, db, "claw-review-poll", "elastic/claw", 77, 0, 200)
+	startTaskRunForTest(t, s, "claw-review-poll", "review-poll")
+
+	pr := clawPR{
+		id:           "pr-claw-review-poll",
+		clawID:       "claw-review-poll",
+		repo:         "elastic/claw",
+		prNumber:     77,
+		prURL:        "https://github.com/elastic/claw/pull/77",
+		lastReviewID: 200,
+	}
+
+	s.checkPRReviews(pr, []interface{}{
+		map[string]interface{}{
+			"id":       float64(201),
+			"state":    "CHANGES_REQUESTED",
+			"body":     "Please address the inline comments.",
+			"html_url": "https://github.com/elastic/claw/pull/77#pullrequestreview-201",
+			"user":     map[string]interface{}{"login": "reviewer", "type": "User"},
+		},
+	})
+
+	assertMessageContains(t, db, "claw-review-poll", "hub", []string{
+		"@reviewer",
+		"requested changes",
+		"Please address the inline comments.",
+		"https://github.com/elastic/claw/pull/77#pullrequestreview-201",
+	})
+}
+
+func TestGitHubPullRequestReviewCommentWebhookInjectsHumanInlineComment(t *testing.T) {
+	s, db := newPRReviewFeedbackTestServer(t)
+	seedTrackedPRForReviewFeedback(t, db, "claw-inline-webhook", "elastic/claw", 81, 20, 0)
+	startTaskRunForTest(t, s, "claw-inline-webhook", "inline-webhook")
+
+	body := map[string]interface{}{
+		"action": "created",
+		"comment": map[string]interface{}{
+			"id":       21,
+			"body":     "inline webhook concern",
+			"html_url": "https://github.com/elastic/claw/pull/81#discussion_r21",
+			"path":     "pkg/hub/github_webhook.go",
+			"line":     88,
+			"user":     map[string]interface{}{"login": "reviewer", "type": "User"},
+		},
+		"pull_request": map[string]interface{}{
+			"number":   81,
+			"html_url": "https://github.com/elastic/claw/pull/81",
+		},
+		"repository": map[string]interface{}{"full_name": "elastic/claw"},
+	}
+
+	postSignedGitHubWebhook(t, s, "pull_request_review_comment", body)
+
+	waitForMessageContains(t, db, "claw-inline-webhook", "hub", []string{
+		"@reviewer",
+		"inline review comment",
+		"pkg/hub/github_webhook.go:88",
+		"inline webhook concern",
+	})
+}
+
+func TestGitHubPullRequestReviewWebhookInjectsChangesRequested(t *testing.T) {
+	s, db := newPRReviewFeedbackTestServer(t)
+	seedTrackedPRForReviewFeedback(t, db, "claw-review-webhook", "elastic/claw", 82, 0, 200)
+	startTaskRunForTest(t, s, "claw-review-webhook", "review-webhook")
+
+	body := map[string]interface{}{
+		"action": "submitted",
+		"review": map[string]interface{}{
+			"id":       201,
+			"state":    "changes_requested",
+			"body":     "Please fix the review findings.",
+			"html_url": "https://github.com/elastic/claw/pull/82#pullrequestreview-201",
+			"user":     map[string]interface{}{"login": "reviewer", "type": "User"},
+		},
+		"pull_request": map[string]interface{}{
+			"number":   82,
+			"html_url": "https://github.com/elastic/claw/pull/82",
+		},
+		"repository": map[string]interface{}{"full_name": "elastic/claw"},
+	}
+
+	postSignedGitHubWebhook(t, s, "pull_request_review", body)
+
+	waitForMessageContains(t, db, "claw-review-webhook", "hub", []string{
+		"@reviewer",
+		"requested changes",
+		"Please fix the review findings.",
+		"https://github.com/elastic/claw/pull/82#pullrequestreview-201",
+	})
+}
+
+func TestReviewCommentWebhookAndStalePollDoNotDuplicateMessage(t *testing.T) {
+	s, db := newPRReviewFeedbackTestServer(t)
+	seedTrackedPRForReviewFeedback(t, db, "claw-inline-race", "elastic/claw", 83, 20, 0)
+	startTaskRunForTest(t, s, "claw-inline-race", "inline-race")
+
+	body := map[string]interface{}{
+		"action": "created",
+		"comment": map[string]interface{}{
+			"id":       21,
+			"body":     "race inline concern",
+			"html_url": "https://github.com/elastic/claw/pull/83#discussion_r21",
+			"path":     "pkg/hub/pr_watcher.go",
+			"line":     620,
+			"user":     map[string]interface{}{"login": "reviewer", "type": "User"},
+		},
+		"pull_request": map[string]interface{}{
+			"number":   83,
+			"html_url": "https://github.com/elastic/claw/pull/83",
+		},
+		"repository": map[string]interface{}{"full_name": "elastic/claw"},
+	}
+
+	postSignedGitHubWebhook(t, s, "pull_request_review_comment", body)
+	waitForMessageContains(t, db, "claw-inline-race", "hub", []string{"race inline concern"})
+
+	stalePollSnapshot := clawPR{
+		id:                  "pr-claw-inline-race",
+		clawID:              "claw-inline-race",
+		repo:                "elastic/claw",
+		prNumber:            83,
+		prURL:               "https://github.com/elastic/claw/pull/83",
+		lastReviewCommentID: 20,
+	}
+	s.checkGreptileReviewComments(stalePollSnapshot, []interface{}{
+		map[string]interface{}{
+			"id":       float64(21),
+			"user":     map[string]interface{}{"login": "reviewer", "type": "User"},
+			"body":     "race inline concern",
+			"html_url": "https://github.com/elastic/claw/pull/83#discussion_r21",
+			"path":     "pkg/hub/pr_watcher.go",
+			"line":     float64(620),
+		},
+	})
+
+	assertMessageCountContaining(t, db, "claw-inline-race", "hub", "race inline concern", 1)
+}
+
+func TestReviewWebhookAndStalePollDoNotDuplicateMessage(t *testing.T) {
+	s, db := newPRReviewFeedbackTestServer(t)
+	seedTrackedPRForReviewFeedback(t, db, "claw-review-race", "elastic/claw", 84, 0, 200)
+	startTaskRunForTest(t, s, "claw-review-race", "review-race")
+
+	body := map[string]interface{}{
+		"action": "submitted",
+		"review": map[string]interface{}{
+			"id":       201,
+			"state":    "changes_requested",
+			"body":     "race requested changes",
+			"html_url": "https://github.com/elastic/claw/pull/84#pullrequestreview-201",
+			"user":     map[string]interface{}{"login": "reviewer", "type": "User"},
+		},
+		"pull_request": map[string]interface{}{
+			"number":   84,
+			"html_url": "https://github.com/elastic/claw/pull/84",
+		},
+		"repository": map[string]interface{}{"full_name": "elastic/claw"},
+	}
+
+	postSignedGitHubWebhook(t, s, "pull_request_review", body)
+	waitForMessageContains(t, db, "claw-review-race", "hub", []string{"race requested changes"})
+
+	stalePollSnapshot := clawPR{
+		id:           "pr-claw-review-race",
+		clawID:       "claw-review-race",
+		repo:         "elastic/claw",
+		prNumber:     84,
+		prURL:        "https://github.com/elastic/claw/pull/84",
+		lastReviewID: 200,
+	}
+	s.checkPRReviews(stalePollSnapshot, []interface{}{
+		map[string]interface{}{
+			"id":       float64(201),
+			"state":    "CHANGES_REQUESTED",
+			"body":     "race requested changes",
+			"html_url": "https://github.com/elastic/claw/pull/84#pullrequestreview-201",
+			"user":     map[string]interface{}{"login": "reviewer", "type": "User"},
+		},
+	})
+
+	assertMessageCountContaining(t, db, "claw-review-race", "hub", "race requested changes", 1)
+}
+
+func TestOutOfOrderReviewCommentWebhooksDeliverEachComment(t *testing.T) {
+	s, db := newPRReviewFeedbackTestServer(t)
+	seedTrackedPRForReviewFeedback(t, db, "claw-inline-order", "elastic/claw", 85, 20, 0)
+	startTaskRunForTest(t, s, "claw-inline-order", "inline-order")
+
+	postSignedGitHubWebhook(t, s, "pull_request_review_comment", map[string]interface{}{
+		"action": "created",
+		"comment": map[string]interface{}{
+			"id":       23,
+			"body":     "newer inline concern",
+			"html_url": "https://github.com/elastic/claw/pull/85#discussion_r23",
+			"path":     "pkg/hub/newer.go",
+			"line":     23,
+			"user":     map[string]interface{}{"login": "reviewer", "type": "User"},
+		},
+		"pull_request": map[string]interface{}{"number": 85, "html_url": "https://github.com/elastic/claw/pull/85"},
+		"repository":   map[string]interface{}{"full_name": "elastic/claw"},
+	})
+	waitForMessageContains(t, db, "claw-inline-order", "hub", []string{"newer inline concern"})
+
+	postSignedGitHubWebhook(t, s, "pull_request_review_comment", map[string]interface{}{
+		"action": "created",
+		"comment": map[string]interface{}{
+			"id":       21,
+			"body":     "older inline concern",
+			"html_url": "https://github.com/elastic/claw/pull/85#discussion_r21",
+			"path":     "pkg/hub/older.go",
+			"line":     21,
+			"user":     map[string]interface{}{"login": "reviewer", "type": "User"},
+		},
+		"pull_request": map[string]interface{}{"number": 85, "html_url": "https://github.com/elastic/claw/pull/85"},
+		"repository":   map[string]interface{}{"full_name": "elastic/claw"},
+	})
+
+	waitForMessageContains(t, db, "claw-inline-order", "hub", []string{"older inline concern"})
+	assertMessageCountContaining(t, db, "claw-inline-order", "hub", "inline concern", 2)
+}
+
+func TestPollRecoversLowerReviewCommentAfterHigherWebhook(t *testing.T) {
+	s, db := newPRReviewFeedbackTestServer(t)
+	seedTrackedPRForReviewFeedback(t, db, "claw-inline-recover", "elastic/claw", 86, 20, 0)
+	startTaskRunForTest(t, s, "claw-inline-recover", "inline-recover")
+
+	postSignedGitHubWebhook(t, s, "pull_request_review_comment", map[string]interface{}{
+		"action": "created",
+		"comment": map[string]interface{}{
+			"id":       23,
+			"body":     "webhook comment 23",
+			"html_url": "https://github.com/elastic/claw/pull/86#discussion_r23",
+			"path":     "pkg/hub/newer.go",
+			"line":     23,
+			"user":     map[string]interface{}{"login": "reviewer", "type": "User"},
+		},
+		"pull_request": map[string]interface{}{"number": 86, "html_url": "https://github.com/elastic/claw/pull/86"},
+		"repository":   map[string]interface{}{"full_name": "elastic/claw"},
+	})
+	waitForMessageContains(t, db, "claw-inline-recover", "hub", []string{"webhook comment 23"})
+
+	stalePollSnapshot := clawPR{
+		id:                  "pr-claw-inline-recover",
+		clawID:              "claw-inline-recover",
+		repo:                "elastic/claw",
+		prNumber:            86,
+		prURL:               "https://github.com/elastic/claw/pull/86",
+		lastReviewCommentID: 20,
+	}
+	s.checkGreptileReviewComments(stalePollSnapshot, []interface{}{
+		map[string]interface{}{
+			"id":       float64(21),
+			"user":     map[string]interface{}{"login": "reviewer", "type": "User"},
+			"body":     "poll recovered comment 21",
+			"html_url": "https://github.com/elastic/claw/pull/86#discussion_r21",
+			"path":     "pkg/hub/older.go",
+			"line":     float64(21),
+		},
+		map[string]interface{}{
+			"id":       float64(23),
+			"user":     map[string]interface{}{"login": "reviewer", "type": "User"},
+			"body":     "webhook comment 23",
+			"html_url": "https://github.com/elastic/claw/pull/86#discussion_r23",
+			"path":     "pkg/hub/newer.go",
+			"line":     float64(23),
+		},
+	})
+
+	assertMessageCountContaining(t, db, "claw-inline-recover", "hub", "poll recovered comment 21", 1)
+	assertMessageCountContaining(t, db, "claw-inline-recover", "hub", "webhook comment 23", 1)
+}
+
+func TestOutOfOrderReviewWebhooksDeliverEachReview(t *testing.T) {
+	s, db := newPRReviewFeedbackTestServer(t)
+	seedTrackedPRForReviewFeedback(t, db, "claw-review-order", "elastic/claw", 87, 0, 200)
+	startTaskRunForTest(t, s, "claw-review-order", "review-order")
+
+	postSignedGitHubWebhook(t, s, "pull_request_review", map[string]interface{}{
+		"action": "submitted",
+		"review": map[string]interface{}{
+			"id":       203,
+			"state":    "changes_requested",
+			"body":     "newer requested changes",
+			"html_url": "https://github.com/elastic/claw/pull/87#pullrequestreview-203",
+			"user":     map[string]interface{}{"login": "reviewer", "type": "User"},
+		},
+		"pull_request": map[string]interface{}{"number": 87, "html_url": "https://github.com/elastic/claw/pull/87"},
+		"repository":   map[string]interface{}{"full_name": "elastic/claw"},
+	})
+	waitForMessageContains(t, db, "claw-review-order", "hub", []string{"newer requested changes"})
+
+	postSignedGitHubWebhook(t, s, "pull_request_review", map[string]interface{}{
+		"action": "submitted",
+		"review": map[string]interface{}{
+			"id":       201,
+			"state":    "changes_requested",
+			"body":     "older requested changes",
+			"html_url": "https://github.com/elastic/claw/pull/87#pullrequestreview-201",
+			"user":     map[string]interface{}{"login": "reviewer", "type": "User"},
+		},
+		"pull_request": map[string]interface{}{"number": 87, "html_url": "https://github.com/elastic/claw/pull/87"},
+		"repository":   map[string]interface{}{"full_name": "elastic/claw"},
+	})
+
+	waitForMessageContains(t, db, "claw-review-order", "hub", []string{"older requested changes"})
+	assertMessageCountContaining(t, db, "claw-review-order", "hub", "requested changes", 2)
+}
+
+func newPRReviewFeedbackTestServer(t *testing.T) (*Server, *sql.DB) {
+	t.Helper()
+	cfg := &types.HubConfig{
+		ClawToken: "test-claw-token",
+		Factories: []*types.FactoryConfig{{
+			Name:          "github-prs",
+			Integration:   "github",
+			Template:      "elasticclaw",
+			Provider:      "noop",
+			Repos:         []string{"elastic/claw"},
+			WebhookSecret: "test-webhook-secret",
+			Trigger:       &types.GitHubTrigger{On: "pull_request"},
+		}},
+		Providers: map[string]types.ProviderConfig{"noop": {Type: "noop"}},
+	}
+	return NewTestServerWithConfig(t, cfg, "", "", "")
+}
+
+func seedTrackedPRForReviewFeedback(t *testing.T, db execer, clawID, repo string, prNumber int, lastReviewCommentID, lastReviewID int64) {
+	t.Helper()
+	if _, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, template, provider, status, created_at) VALUES(?,?,?,?,?,?,datetime('now'))`,
+		clawID, "test-tenant-id", clawID, "elasticclaw", "noop", "connected",
+	); err != nil {
+		t.Fatalf("insert claw: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO claw_prs(id, claw_id, repo, pr_number, pr_url, last_review_comment_id, last_review_id, created_at)
+		 VALUES(?,?,?,?,?,?,?,datetime('now'))`,
+		"pr-"+clawID, clawID, repo, prNumber, "https://github.com/"+repo+"/pull/"+strconv.Itoa(prNumber), lastReviewCommentID, lastReviewID,
+	); err != nil {
+		t.Fatalf("insert claw_prs: %v", err)
+	}
+}
+
+type execer interface {
+	Exec(query string, args ...interface{}) (sql.Result, error)
+}
+
+func postSignedGitHubWebhook(t *testing.T, s *Server, event string, body map[string]interface{}) {
+	t.Helper()
+	payload, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal webhook payload: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/integrations/github/webhook", strings.NewReader(string(payload)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Event", event)
+	req.Header.Set("X-Hub-Signature-256", signGitHubWebhookForReviewFeedback(payload, "test-webhook-secret"))
+	rr := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("webhook status = %d, want 200 body=%q", rr.Code, rr.Body.String())
+	}
+}
+
+func signGitHubWebhookForReviewFeedback(body []byte, secret string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+func waitForMessageContains(t *testing.T, db querier, clawID, role string, parts []string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if messageContains(t, db, clawID, role, parts) {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("message for claw %s role %s did not contain %v", clawID, role, parts)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func assertMessageContains(t *testing.T, db querier, clawID, role string, parts []string) {
+	t.Helper()
+	if !messageContains(t, db, clawID, role, parts) {
+		t.Fatalf("message for claw %s role %s did not contain %v", clawID, role, parts)
+	}
+}
+
+func assertMessageCountContaining(t *testing.T, db querier, clawID, role, content string, want int) {
+	t.Helper()
+	rows, err := db.Query(`SELECT content FROM messages WHERE claw_id=? AND role=?`, clawID, role)
+	if err != nil {
+		t.Fatalf("query messages: %v", err)
+	}
+	defer rows.Close()
+	got := 0
+	for rows.Next() {
+		var message string
+		if err := rows.Scan(&message); err != nil {
+			t.Fatalf("scan message: %v", err)
+		}
+		if strings.Contains(message, content) {
+			got++
+		}
+	}
+	if got != want {
+		t.Fatalf("messages containing %q = %d, want %d", content, got, want)
+	}
+}
+
+type querier interface {
+	Query(query string, args ...interface{}) (*sql.Rows, error)
+	QueryRow(query string, args ...interface{}) *sql.Row
+}
+
+func messageContains(t *testing.T, db querier, clawID, role string, parts []string) bool {
+	t.Helper()
+	rows, err := db.Query(`SELECT content FROM messages WHERE claw_id=? AND role=?`, clawID, role)
+	if err != nil {
+		t.Fatalf("query messages: %v", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var content string
+		if err := rows.Scan(&content); err != nil {
+			t.Fatalf("scan message: %v", err)
+		}
+		matches := true
+		for _, part := range parts {
+			if !strings.Contains(content, part) {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			return true
+		}
+	}
+	return false
+}
+
+func assertReviewWatermark(t *testing.T, db querier, clawID, column string, want int64) {
+	t.Helper()
+	if column != "last_review_comment_id" && column != "last_review_id" {
+		t.Fatalf("unexpected watermark column %q", column)
+	}
+	var got int64
+	if err := db.QueryRow(`SELECT `+column+` FROM claw_prs WHERE claw_id=?`, clawID).Scan(&got); err != nil {
+		t.Fatalf("query watermark: %v", err)
+	}
+	if got != want {
+		t.Fatalf("%s = %d, want %d", column, got, want)
+	}
+}

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -552,23 +552,18 @@ func (s *Server) checkGreptileReviewComments(pr clawPR, reviewCommentsData []int
 		body, _ := comment["body"].(string)
 		htmlURL, _ := comment["html_url"].(string)
 		path, _ := comment["path"].(string)
-		lineF, _ := comment["line"].(float64)
+		line := githubReviewCommentLine(comment)
 		userType, _ := user["type"].(string)
-		if !isGreptileComment(login, body) && !strings.EqualFold(userType, "bot") && !strings.HasSuffix(login, "[bot]") {
-			s.recordTaskRunHumanEventForClaw(pr.clawID, taskRunEventHumanReviewComment, fmt.Sprintf("human_review_comment:%d", id), login, htmlURL, map[string]any{
-				"repo":       pr.repo,
-				"pr_number":  pr.prNumber,
-				"comment_id": id,
-				"path":       path,
-			})
+		if !isGreptileComment(login, body) && s.isHumanGitHubActor(login, userType) {
+			s.forwardHumanReviewComment(pr, id, login, body, htmlURL, path, line)
 			continue
 		}
 		if isGreptileComment(login, body) {
 			loc := ""
 			if path != "" {
 				loc = fmt.Sprintf("`%s", path)
-				if lineF > 0 {
-					loc += fmt.Sprintf(":%d", int(lineF))
+				if line > 0 {
+					loc += fmt.Sprintf(":%d", line)
 				}
 				loc += "`"
 			}
@@ -617,12 +612,113 @@ func (s *Server) checkPRReviews(pr clawPR, reviewsData []interface{}) {
 		if htmlURL == "" {
 			htmlURL = pr.prURL
 		}
-		s.recordTaskRunHumanEventForClaw(pr.clawID, taskRunEventHumanRequestedChanges, fmt.Sprintf("human_requested_changes:%d", reviewID), login, htmlURL, map[string]any{
-			"repo":      pr.repo,
-			"pr_number": pr.prNumber,
-			"review_id": reviewID,
-		})
+		body, _ := review["body"].(string)
+		s.forwardHumanRequestedChangesReview(pr, reviewID, login, body, htmlURL)
 	}
+}
+
+func (s *Server) forwardHumanReviewComment(pr clawPR, id int64, login, body, htmlURL, path string, line int) {
+	if !s.claimPRReviewComment(pr.clawID, id) {
+		return
+	}
+	s.recordTaskRunHumanEventForClaw(pr.clawID, taskRunEventHumanReviewComment, fmt.Sprintf("human_review_comment:%d", id), login, htmlURL, map[string]any{
+		"repo":       pr.repo,
+		"pr_number":  pr.prNumber,
+		"comment_id": id,
+		"path":       path,
+	})
+	s.injectHubMessageByID(pr.clawID, formatHumanReviewCommentMessage(login, pr.prNumber, body, htmlURL, path, line))
+}
+
+func (s *Server) forwardHumanRequestedChangesReview(pr clawPR, id int64, login, body, htmlURL string) {
+	if !s.claimPRReview(pr.clawID, id) {
+		return
+	}
+	s.recordTaskRunHumanEventForClaw(pr.clawID, taskRunEventHumanRequestedChanges, fmt.Sprintf("human_requested_changes:%d", id), login, htmlURL, map[string]any{
+		"repo":      pr.repo,
+		"pr_number": pr.prNumber,
+		"review_id": id,
+	})
+	s.injectHubMessageByID(pr.clawID, formatHumanRequestedChangesMessage(login, pr.prNumber, body, htmlURL))
+}
+
+func (s *Server) isHumanGitHubActor(login, userType string) bool {
+	if login == "" {
+		return false
+	}
+	if strings.EqualFold(userType, "bot") || strings.HasSuffix(login, "[bot]") {
+		return false
+	}
+	if s.isOwnAppBot(login) {
+		return false
+	}
+	return true
+}
+
+func formatHumanReviewCommentMessage(login string, prNumber int, body, htmlURL, path string, line int) string {
+	location := ""
+	if path != "" {
+		location = fmt.Sprintf(" at `%s", path)
+		if line > 0 {
+			location += fmt.Sprintf(":%d", line)
+		}
+		location += "`"
+	}
+	msg := fmt.Sprintf("**@%s** left an inline review comment on PR #%d%s:\n> %s", login, prNumber, location, strings.TrimSpace(body))
+	if htmlURL != "" {
+		msg += fmt.Sprintf("\n[View](%s)", htmlURL)
+	}
+	return msg
+}
+
+func formatHumanRequestedChangesMessage(login string, prNumber int, body, htmlURL string) string {
+	body = strings.TrimSpace(body)
+	msg := fmt.Sprintf("**@%s** requested changes on PR #%d:", login, prNumber)
+	if body != "" {
+		msg += fmt.Sprintf("\n> %s", body)
+	}
+	if htmlURL != "" {
+		msg += fmt.Sprintf("\n[View review](%s)", htmlURL)
+	}
+	return msg
+}
+
+func githubReviewCommentLine(comment map[string]interface{}) int {
+	if lineF, ok := comment["line"].(float64); ok && lineF > 0 {
+		return int(lineF)
+	}
+	if lineF, ok := comment["original_line"].(float64); ok && lineF > 0 {
+		return int(lineF)
+	}
+	return 0
+}
+
+func (s *Server) claimPRReviewComment(clawID string, id int64) bool {
+	return s.claimPRFeedbackDelivery(clawID, "review_comment", id)
+}
+
+func (s *Server) claimPRReview(clawID string, id int64) bool {
+	return s.claimPRFeedbackDelivery(clawID, "review", id)
+}
+
+func (s *Server) claimPRFeedbackDelivery(clawID, feedbackType string, id int64) bool {
+	if id <= 0 {
+		return false
+	}
+	result, err := s.db.Exec(
+		`INSERT OR IGNORE INTO claw_pr_feedback_deliveries(claw_id, feedback_type, github_id, created_at) VALUES(?,?,?,?)`,
+		clawID, feedbackType, id, now(),
+	)
+	if err != nil {
+		log.Printf("[pr-watcher] failed to claim %s %d for claw %s: %v", feedbackType, id, clawID, err)
+		return true
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		log.Printf("[pr-watcher] failed to inspect %s claim %d for claw %s: %v", feedbackType, id, clawID, err)
+		return true
+	}
+	return affected > 0
 }
 
 func (s *Server) updatePRReviewWatermark(pr clawPR, reviewsData []interface{}) {


### PR DESCRIPTION
## Summary
- handle GitHub `pull_request_review_comment` and `pull_request_review` webhooks for tracked PRs
- forward human inline review comments and requested-changes reviews to the claw
- keep existing PR review watermarks moving forward so polling does not re-deliver webhook feedback

## Root cause
Human inline review comments were only recorded as task-run warning events in the poller, while only Greptile inline comments were forwarded to the claw. GitHub review webhooks were also ignored entirely.

## Validation
- `go test ./pkg/hub -run 'Test(PollHumanInlineReviewCommentForwardsToClaw|PollHumanRequestedChangesReviewForwardsToClaw|GitHubPullRequestReviewCommentWebhookInjectsHumanInlineComment|GitHubPullRequestReviewWebhookInjectsChangesRequested)' -count=1`\n- `go test ./pkg/hub -count=1`\n- `go test ./... -count=1`