### PR TITLE
Run dependency updates inside workspace toolchain

### DIFF
--- a/pkg/hub/dependency_updates.go
+++ b/pkg/hub/dependency_updates.go
@@ -241,7 +241,7 @@ func buildDependencyUpdatesCommand(action pipeline.DependencyUpdatesAction) (str
 }
 
 func (s *Server) executeDependencyUpdatesAction(clawID, stageID string, action pipeline.DependencyUpdatesAction) (*pipelineRunResult, error) {
-	command, err := buildDependencyUpdatesCommand(action)
+	command, err := s.dependencyUpdatesCommandForClaw(clawID, action)
 	if err != nil {
 		return nil, err
 	}
@@ -254,6 +254,33 @@ func (s *Server) executeDependencyUpdatesAction(clawID, stageID string, action p
 		s.persistPipelineOutput(clawID, stageID, dependencyUpdatesOutputName(action), result)
 	}
 	return result, err
+}
+
+func (s *Server) dependencyUpdatesCommandForClaw(clawID string, action pipeline.DependencyUpdatesAction) (string, error) {
+	command, err := buildDependencyUpdatesCommand(action)
+	if err != nil {
+		return "", err
+	}
+	useNix, err := s.clawUsesNix(clawID)
+	if err != nil {
+		return "", err
+	}
+	return wrapDependencyUpdatesCommand(command, useNix), nil
+}
+
+func (s *Server) clawUsesNix(clawID string) (bool, error) {
+	var nixEnabled int
+	if err := s.db.QueryRow(`SELECT nix FROM claws WHERE id=?`, clawID).Scan(&nixEnabled); err != nil {
+		return false, fmt.Errorf("load agent nix setting: %w", err)
+	}
+	return nixEnabled != 0, nil
+}
+
+func wrapDependencyUpdatesCommand(command string, useNix bool) string {
+	if !useNix {
+		return command
+	}
+	return "nix develop --accept-flake-config -c bash -lc " + shellQuote(command)
 }
 
 const dependencyUpdatesPythonScript = `import base64

--- a/pkg/hub/dependency_updates_test.go
+++ b/pkg/hub/dependency_updates_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/elasticclaw/elasticclaw/pkg/hub/pipeline"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
 
 func TestNormalizeDependencyUpdatesConfigDefaults(t *testing.T) {
@@ -70,6 +71,42 @@ func TestDiscoverDependencyUpdateManifestsRejectsEscapingPath(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected escaping path error")
+	}
+}
+
+func TestWrapDependencyUpdatesCommandUsesNixDevShellWhenEnabled(t *testing.T) {
+	command := "python3 - <<'PY'\nprint('dependency update')\nPY"
+
+	wrapped := wrapDependencyUpdatesCommand(command, true)
+
+	want := "nix develop --accept-flake-config -c bash -lc " + shellQuote(command)
+	if wrapped != want {
+		t.Fatalf("wrapped command = %q, want %q", wrapped, want)
+	}
+	if got := wrapDependencyUpdatesCommand(command, false); got != command {
+		t.Fatalf("non-nix command = %q, want original command", got)
+	}
+}
+
+func TestDependencyUpdatesCommandForClawWrapsNixEnabledAgents(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+	_, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, template, status, nix, created_at) VALUES(?,?,?,?,?,?,datetime('now'))`,
+		"nix-claw", "test-tenant-id", "nix claw", "workspace", "connected", 1,
+	)
+	if err != nil {
+		t.Fatalf("insert claw: %v", err)
+	}
+
+	command, err := s.dependencyUpdatesCommandForClaw("nix-claw", pipeline.DependencyUpdatesAction{Enabled: true})
+	if err != nil {
+		t.Fatalf("build command: %v", err)
+	}
+	if !strings.HasPrefix(command, "nix develop --accept-flake-config -c bash -lc ") {
+		t.Fatalf("command was not wrapped with nix develop:\n%s", command)
+	}
+	if !strings.Contains(command, "python3 - <<") {
+		t.Fatalf("wrapped command missing dependency update script:\n%s", command)
 	}
 }
 


### PR DESCRIPTION
## Summary
- wrap built-in dependency update commands with the workspace Nix dev shell when the claw was created with Nix enabled
- keep non-Nix dependency update execution unchanged
- add coverage for the command wrapper and persisted claw nix flag behavior

## Why
Dependency update actions should use the workspace-declared toolchain instead of assuming language tools are globally installed in the agent environment.

## Test
- go test ./pkg/hub -run 'TestWrapDependencyUpdatesCommandUsesNixDevShellWhenEnabled|TestDependencyUpdatesCommandForClawWrapsNixEnabledAgents|TestDependencyUpdatesGeneratedCommandOutputsStructuredJSON|TestDependencyUpdatesGeneratedCommandHonorsFiltersAndMajorPolicy'
- go test ./pkg/hub