### PR TITLE
Recover closed gateway sends

### DIFF
--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -778,11 +778,15 @@ func redactActivityPrefix(value, prefix, replacement string) string {
 // gatewaySession is a long-lived connection to the OpenClaw gateway that
 // maintains a single persistent agent session across all messages.
 type gatewaySession struct {
-	client     *gatewayClient
+	client *gatewayClient
+
+	sessionMu  sync.RWMutex
 	sessionKey string
 
 	connMu sync.Mutex
 	conn   *websocket.Conn
+
+	reconnectMu sync.Mutex
 
 	// pending req/res tracking (reqID → response channel)
 	pendMu  sync.Mutex
@@ -840,6 +844,30 @@ func (gs *gatewaySession) connect(ctx context.Context) error {
 	return nil
 }
 
+func (gs *gatewaySession) getSessionKey() string {
+	gs.sessionMu.RLock()
+	defer gs.sessionMu.RUnlock()
+	return gs.sessionKey
+}
+
+func (gs *gatewaySession) setSessionKey(key string) {
+	gs.sessionMu.Lock()
+	gs.sessionKey = key
+	gs.sessionMu.Unlock()
+}
+
+func (gs *gatewaySession) currentConn() *websocket.Conn {
+	gs.connMu.Lock()
+	defer gs.connMu.Unlock()
+	return gs.conn
+}
+
+func (gs *gatewaySession) isCurrentConn(conn *websocket.Conn) bool {
+	gs.connMu.Lock()
+	defer gs.connMu.Unlock()
+	return gs.conn == conn
+}
+
 // sendReq sends a gateway request and waits for the corresponding response.
 func (gs *gatewaySession) sendReq(ctx context.Context, method string, params interface{}) (gwFrame, error) {
 	paramsJSON, _ := json.Marshal(params)
@@ -884,6 +912,36 @@ func (gs *gatewaySession) sendReq(ctx context.Context, method string, params int
 	}
 }
 
+func sendReqOnConn(ctx context.Context, conn *websocket.Conn, method string, params interface{}) (gwFrame, error) {
+	paramsJSON, _ := json.Marshal(params)
+	reqID := randomID()
+	if err := wsjson.Write(ctx, conn, gwFrame{
+		Type:   "req",
+		ID:     reqID,
+		Method: method,
+		Params: paramsJSON,
+	}); err != nil {
+		return gwFrame{}, fmt.Errorf("%s write: %w", method, err)
+	}
+	for {
+		var resp gwFrame
+		if err := wsjson.Read(ctx, conn, &resp); err != nil {
+			return gwFrame{}, fmt.Errorf("%s read response: %w", method, err)
+		}
+		if resp.Type != "res" || resp.ID != reqID {
+			continue
+		}
+		if !resp.OK {
+			msg := "unknown"
+			if resp.Error != nil {
+				msg = resp.Error.Message
+			}
+			return resp, fmt.Errorf("%s failed: %s", method, msg)
+		}
+		return resp, nil
+	}
+}
+
 func (gs *gatewaySession) failPendingRequests(err error) {
 	gs.pendMu.Lock()
 	pending := gs.pending
@@ -910,7 +968,7 @@ func (gs *gatewaySession) initSession(ctx context.Context) error {
 		_, err := gs.sendReq(ctx, "sessions.get", map[string]string{"key": key})
 		if err == nil {
 			log.Printf("[session] restored existing session: %s", key)
-			gs.sessionKey = key
+			gs.setSessionKey(key)
 			if err := gs.subscribe(ctx); err != nil {
 				return err
 			}
@@ -932,9 +990,9 @@ func (gs *gatewaySession) initSession(ctx context.Context) error {
 	if payload.Key == "" {
 		return fmt.Errorf("sessions.create returned empty key")
 	}
-	gs.sessionKey = payload.Key
+	gs.setSessionKey(payload.Key)
 	saveBridgeSession(payload.Key)
-	log.Printf("[session] created new session: %s", gs.sessionKey)
+	log.Printf("[session] created new session: %s", gs.getSessionKey())
 
 	if err := gs.subscribe(ctx); err != nil {
 		return err
@@ -945,11 +1003,103 @@ func (gs *gatewaySession) initSession(ctx context.Context) error {
 
 // subscribe registers for events on the current session key.
 func (gs *gatewaySession) subscribe(ctx context.Context) error {
-	_, err := gs.sendReq(ctx, "sessions.subscribe", map[string]string{"sessionKey": gs.sessionKey})
+	_, err := gs.sendReq(ctx, "sessions.subscribe", map[string]string{"sessionKey": gs.getSessionKey()})
 	if err != nil {
 		return fmt.Errorf("sessions.subscribe: %w", err)
 	}
 	log.Printf("[session] subscribed to session events")
+	return nil
+}
+
+func (gs *gatewaySession) subscribeOnConn(ctx context.Context, conn *websocket.Conn) error {
+	_, err := sendReqOnConn(ctx, conn, "sessions.subscribe", map[string]string{"sessionKey": gs.getSessionKey()})
+	if err != nil {
+		return fmt.Errorf("sessions.subscribe: %w", err)
+	}
+	log.Printf("[session] subscribed to session events")
+	return nil
+}
+
+func (gs *gatewaySession) createFreshSessionOnConn(ctx context.Context, conn *websocket.Conn, reason string) error {
+	log.Printf("[session] creating fresh session after %s", reason)
+	resp, err := sendReqOnConn(ctx, conn, "sessions.create", map[string]string{"agentId": "main"})
+	if err != nil {
+		return fmt.Errorf("sessions.create: %w", err)
+	}
+	var payload struct {
+		Key string `json:"key"`
+	}
+	_ = json.Unmarshal(resp.Payload, &payload)
+	if payload.Key == "" {
+		return fmt.Errorf("sessions.create returned empty key")
+	}
+	gs.setSessionKey(payload.Key)
+	saveBridgeSession(payload.Key)
+	if err := gs.subscribeOnConn(ctx, conn); err != nil {
+		return err
+	}
+	gs.ctxMu.Lock()
+	gs.contextUsage = 0
+	gs.ctxMu.Unlock()
+	log.Printf("[session] recovered with fresh session: %s", gs.getSessionKey())
+	return nil
+}
+
+func (gs *gatewaySession) reconnectGateway(ctx context.Context, expectedOld *websocket.Conn) error {
+	gs.reconnectMu.Lock()
+	defer gs.reconnectMu.Unlock()
+
+	if expectedOld != nil && !gs.isCurrentConn(expectedOld) {
+		return nil
+	}
+
+	conn, err := gs.client.connectToGateway(ctx)
+	if err != nil {
+		return err
+	}
+	installed := false
+	defer func() {
+		if !installed {
+			conn.CloseNow()
+		}
+	}()
+
+	createdFresh := false
+	if gs.getSessionKey() != "" {
+		if err := gs.subscribeOnConn(ctx, conn); err == nil {
+			createdFresh = false
+		} else {
+			log.Printf("[gateway] re-subscribe failed after reconnect: %v", err)
+			if !isMissingGatewaySessionError(err) {
+				return err
+			}
+			if err := gs.createFreshSessionOnConn(ctx, conn, "gateway reconnect"); err != nil {
+				return err
+			}
+			createdFresh = true
+		}
+	} else {
+		if err := gs.createFreshSessionOnConn(ctx, conn, "gateway reconnect"); err != nil {
+			return err
+		}
+		createdFresh = true
+	}
+
+	if expectedOld != nil && !gs.isCurrentConn(expectedOld) {
+		return nil
+	}
+	gs.failPendingRequests(fmt.Errorf("gateway disconnected"))
+	gs.connMu.Lock()
+	old := gs.conn
+	gs.conn = conn
+	gs.connMu.Unlock()
+	installed = true
+	if old != nil && old != conn {
+		old.CloseNow()
+	}
+	if createdFresh {
+		gs.setReady()
+	}
 	return nil
 }
 
@@ -967,7 +1117,10 @@ func (gs *gatewaySession) readLoop(ctx context.Context) {
 			if ctx.Err() != nil {
 				return // shutting down
 			}
-			log.Printf("[gateway] read error: %v — reconnecting in 3s", err)
+			if !gs.isCurrentConn(conn) {
+				continue
+			}
+			log.Printf("[gateway] read error: %v — reconnecting", err)
 
 			gs.failPendingRequests(fmt.Errorf("gateway disconnected"))
 
@@ -981,19 +1134,22 @@ func (gs *gatewaySession) readLoop(ctx context.Context) {
 				default:
 				}
 			}
+			if gs.client == nil {
+				return
+			}
 
-			time.Sleep(3 * time.Second)
 			for {
 				if ctx.Err() != nil {
 					return
 				}
-				if err := gs.connect(ctx); err != nil {
-					log.Printf("[gateway] reconnect failed: %v — retrying in 5s", err)
-					time.Sleep(5 * time.Second)
-					continue
+				if !gs.isCurrentConn(conn) {
+					break
 				}
-				if err := gs.subscribe(ctx); err != nil {
-					log.Printf("[gateway] re-subscribe failed: %v — retrying in 5s", err)
+				if err := gs.reconnectGateway(ctx, conn); err != nil {
+					if !gs.isCurrentConn(conn) {
+						break
+					}
+					log.Printf("[gateway] reconnect failed: %v — retrying in 5s", err)
 					time.Sleep(5 * time.Second)
 					continue
 				}
@@ -1044,7 +1200,7 @@ func (gs *gatewaySession) readLoop(ctx context.Context) {
 				Data map[string]interface{} `json:"data"`
 			}
 			_ = json.Unmarshal(frame.Payload, &rawAgentPayload)
-			if agentPayload.SessionKey != gs.sessionKey {
+			if agentPayload.SessionKey != gs.getSessionKey() {
 				continue
 			}
 
@@ -1337,7 +1493,7 @@ func (gs *gatewaySession) refreshContextUsage(ctx context.Context) {
 	pollCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	resp, err := gs.sendReq(pollCtx, "sessions.describe", map[string]string{"key": gs.sessionKey})
+	resp, err := gs.sendReq(pollCtx, "sessions.describe", map[string]string{"key": gs.getSessionKey()})
 	if err != nil {
 		log.Printf("[session] sessions.describe for context usage: %v", err)
 		return
@@ -1399,7 +1555,7 @@ func (gs *gatewaySession) createFreshSession(ctx context.Context, reason string)
 	if payload.Key == "" {
 		return fmt.Errorf("sessions.create returned empty key")
 	}
-	gs.sessionKey = payload.Key
+	gs.setSessionKey(payload.Key)
 	saveBridgeSession(payload.Key)
 	if err := gs.subscribe(ctx); err != nil {
 		return err
@@ -1408,15 +1564,16 @@ func (gs *gatewaySession) createFreshSession(ctx context.Context, reason string)
 	gs.contextUsage = 0
 	gs.ctxMu.Unlock()
 	gs.setReady()
-	log.Printf("[session] recovered with fresh session: %s", gs.sessionKey)
+	log.Printf("[session] recovered with fresh session: %s", gs.getSessionKey())
 	return nil
 }
 
 func isRecoverableSessionSendError(err error) bool {
-	if err == nil {
+	var sendErr *sessionSendRequestError
+	if !errors.As(err, &sendErr) {
 		return false
 	}
-	msg := strings.ToLower(err.Error())
+	msg := strings.ToLower(sendErr.err.Error())
 	return strings.Contains(msg, "context overflow") ||
 		strings.Contains(msg, "prompt too large")
 }
@@ -1429,7 +1586,9 @@ func (gs *gatewaySession) SendMessage(ctx context.Context, message string, onChu
 	defer gs.sendMu.Unlock()
 
 	delays := []time.Duration{2 * time.Second, 5 * time.Second}
+	gatewayRetried := false
 	for attempt := 0; ; attempt++ {
+		conn := gs.currentConn()
 		reply, err := gs.sendMessageOnce(ctx, message, onChunk, onActivity)
 		// Retry only failures from the initial sessions.send request. Once the
 		// request is accepted, chunks may already be visible to the UI, so stream
@@ -1445,6 +1604,20 @@ func (gs *gatewaySession) SendMessage(ctx context.Context, message string, onChu
 			case <-ctx.Done():
 				return "", ctx.Err()
 			}
+			continue
+		}
+		if !gatewayRetried && isRetryableGatewaySendRequestError(err) {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return "", ctxErr
+			}
+			reconnectCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+			reconnectErr := gs.reconnectGateway(reconnectCtx, conn)
+			cancel()
+			if reconnectErr != nil {
+				return "", fmt.Errorf("%w; gateway reconnect failed: %v", err, reconnectErr)
+			}
+			gatewayRetried = true
+			log.Printf("[gateway] retrying message after reconnecting closed gateway connection")
 			continue
 		}
 		if !isRecoverableSessionSendError(err) {
@@ -1483,7 +1656,7 @@ func (gs *gatewaySession) sendMessageOnce(ctx context.Context, message string, o
 
 	// Send the message
 	_, err := gs.sendReq(ctx, "sessions.send", map[string]string{
-		"key":     gs.sessionKey,
+		"key":     gs.getSessionKey(),
 		"message": message,
 	})
 	if err != nil {
@@ -1538,6 +1711,45 @@ func isRetryableLLMSendRequestError(err error) bool {
 		return false
 	}
 	return isRetryableLLMSendError(sendErr.err)
+}
+
+func isRetryableGatewaySendRequestError(err error) bool {
+	var sendErr *sessionSendRequestError
+	if !errors.As(err, &sendErr) {
+		return false
+	}
+	return isRetryableGatewaySendWriteError(sendErr.err)
+}
+
+func isRetryableGatewaySendWriteError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	if !strings.HasPrefix(msg, "sessions.send write:") {
+		return false
+	}
+	if strings.Contains(msg, "i/o timeout") ||
+		strings.Contains(msg, "context deadline") ||
+		strings.Contains(msg, "deadline exceeded") {
+		return false
+	}
+	return strings.Contains(msg, "use of closed network connection") ||
+		strings.Contains(msg, "closed network connection") ||
+		strings.Contains(msg, "connection reset by peer") ||
+		strings.Contains(msg, "broken pipe") ||
+		strings.Contains(msg, "unexpected eof") ||
+		(strings.Contains(msg, "websocket") && strings.Contains(msg, "closed"))
+}
+
+func isMissingGatewaySessionError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "session not found") ||
+		strings.Contains(msg, "not found") ||
+		strings.Contains(msg, "unknown session")
 }
 
 func isRetryableLLMSendError(err error) bool {
@@ -2504,7 +2716,7 @@ func main() {
 		}
 		break
 	}
-	log.Printf("[bridge] gateway session ready: %s", gwSession.sessionKey)
+	log.Printf("[bridge] gateway session ready: %s", gwSession.getSessionKey())
 
 	// Start status channel goroutine (lightweight second WS to hub)
 	go runStatusChannel(ctx, wsURL, clawID, clawName, templateName, token)

--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -1045,17 +1045,17 @@ func (gs *gatewaySession) createFreshSessionOnConn(ctx context.Context, conn *we
 	return nil
 }
 
-func (gs *gatewaySession) reconnectGateway(ctx context.Context, expectedOld *websocket.Conn) error {
+func (gs *gatewaySession) reconnectGateway(ctx context.Context, expectedOld *websocket.Conn) (bool, error) {
 	gs.reconnectMu.Lock()
 	defer gs.reconnectMu.Unlock()
 
 	if expectedOld != nil && !gs.isCurrentConn(expectedOld) {
-		return nil
+		return false, nil
 	}
 
 	conn, err := gs.client.connectToGateway(ctx)
 	if err != nil {
-		return err
+		return false, err
 	}
 	installed := false
 	defer func() {
@@ -1071,22 +1071,22 @@ func (gs *gatewaySession) reconnectGateway(ctx context.Context, expectedOld *web
 		} else {
 			log.Printf("[gateway] re-subscribe failed after reconnect: %v", err)
 			if !isMissingGatewaySessionError(err) {
-				return err
+				return false, err
 			}
 			if err := gs.createFreshSessionOnConn(ctx, conn, "gateway reconnect"); err != nil {
-				return err
+				return false, err
 			}
 			createdFresh = true
 		}
 	} else {
 		if err := gs.createFreshSessionOnConn(ctx, conn, "gateway reconnect"); err != nil {
-			return err
+			return false, err
 		}
 		createdFresh = true
 	}
 
 	if expectedOld != nil && !gs.isCurrentConn(expectedOld) {
-		return nil
+		return false, nil
 	}
 	gs.failPendingRequests(fmt.Errorf("gateway disconnected"))
 	gs.connMu.Lock()
@@ -1100,7 +1100,7 @@ func (gs *gatewaySession) reconnectGateway(ctx context.Context, expectedOld *web
 	if createdFresh {
 		gs.setReady()
 	}
-	return nil
+	return true, nil
 }
 
 // readLoop reads frames from the gateway forever, dispatching responses to
@@ -1145,7 +1145,7 @@ func (gs *gatewaySession) readLoop(ctx context.Context) {
 				if !gs.isCurrentConn(conn) {
 					break
 				}
-				if err := gs.reconnectGateway(ctx, conn); err != nil {
+				if _, err := gs.reconnectGateway(ctx, conn); err != nil {
 					if !gs.isCurrentConn(conn) {
 						break
 					}
@@ -1611,13 +1611,17 @@ func (gs *gatewaySession) SendMessage(ctx context.Context, message string, onChu
 				return "", ctxErr
 			}
 			reconnectCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-			reconnectErr := gs.reconnectGateway(reconnectCtx, conn)
+			reconnected, reconnectErr := gs.reconnectGateway(reconnectCtx, conn)
 			cancel()
 			if reconnectErr != nil {
 				return "", fmt.Errorf("%w; gateway reconnect failed: %v", err, reconnectErr)
 			}
-			gatewayRetried = true
-			log.Printf("[gateway] retrying message after reconnecting closed gateway connection")
+			if reconnected {
+				gatewayRetried = true
+				log.Printf("[gateway] retrying message after reconnecting closed gateway connection")
+			} else {
+				log.Printf("[gateway] retrying message after another goroutine reconnected gateway")
+			}
 			continue
 		}
 		if !isRecoverableSessionSendError(err) {
@@ -1748,7 +1752,7 @@ func isMissingGatewaySessionError(err error) bool {
 	}
 	msg := strings.ToLower(err.Error())
 	return strings.Contains(msg, "session not found") ||
-		strings.Contains(msg, "not found") ||
+		strings.Contains(msg, "session key not found") ||
 		strings.Contains(msg, "unknown session")
 }
 

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -3,11 +3,13 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"encoding/pem"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -522,8 +524,10 @@ func TestIsRecoverableSessionSendError(t *testing.T) {
 	}{
 		{name: "nil", err: nil, want: false},
 		{name: "caller deadline", err: context.DeadlineExceeded, want: false},
-		{name: "context overflow", err: errString("context overflow detected"), want: true},
-		{name: "prompt too large", err: errString("Context overflow: prompt too large for the model"), want: true},
+		{name: "lifecycle context overflow not retryable", err: errString("context overflow detected"), want: false},
+		{name: "lifecycle prompt too large not retryable", err: errString("Context overflow: prompt too large for the model"), want: false},
+		{name: "send request context overflow", err: &sessionSendRequestError{err: errString("context overflow detected")}, want: true},
+		{name: "send request prompt too large", err: &sessionSendRequestError{err: errString("Context overflow: prompt too large for the model")}, want: true},
 		{name: "send failure", err: errString("sessions.send failed: tool crashed"), want: false},
 	}
 	for _, tt := range tests {
@@ -581,6 +585,220 @@ func TestIsRetryableLLMSendRequestError(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIsRetryableGatewaySendRequestError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "context deadline", err: context.DeadlineExceeded, want: false},
+		{name: "plain non-wrapped closed connection", err: errString("sessions.send write: use of closed network connection"), want: false},
+		{name: "wrapped closed network connection", err: &sessionSendRequestError{err: errString("sessions.send write: use of closed network connection")}, want: true},
+		{name: "wrapped marshaler closed connection string", err: &sessionSendRequestError{err: errString("sessions.send write: failed to marshal JSON: use of closed network connection")}, want: true},
+		{name: "wrapped connection reset", err: &sessionSendRequestError{err: errString("sessions.send write: write tcp 127.0.0.1:123->127.0.0.1:456: connection reset by peer")}, want: true},
+		{name: "wrapped broken pipe", err: &sessionSendRequestError{err: errString("sessions.send write: write tcp 127.0.0.1:123->127.0.0.1:456: broken pipe")}, want: true},
+		{name: "wrapped websocket close unexpected eof", err: &sessionSendRequestError{err: errString("sessions.send write: failed to write msg: WebSocket closed: unexpected EOF")}, want: true},
+		{name: "wrapped gateway disconnected after accept", err: &sessionSendRequestError{err: errString("sessions.send failed: gateway disconnected")}, want: false},
+		{name: "wrapped io timeout", err: &sessionSendRequestError{err: errString("sessions.send write: i/o timeout")}, want: false},
+		{name: "lifecycle closed connection not wrapped", err: errString("lifecycle: use of closed network connection"), want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isRetryableGatewaySendRequestError(tt.err); got != tt.want {
+				t.Fatalf("isRetryableGatewaySendRequestError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsMissingGatewaySessionError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "session not found", err: errString("sessions.subscribe: sessions.subscribe failed: session not found"), want: true},
+		{name: "not found", err: errString("sessions.subscribe: not found"), want: true},
+		{name: "unknown session", err: errString("sessions.subscribe failed: unknown session key"), want: true},
+		{name: "permission denied", err: errString("sessions.subscribe failed: permission denied"), want: false},
+		{name: "transport timeout", err: errString("sessions.subscribe write: i/o timeout"), want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isMissingGatewaySessionError(tt.err); got != tt.want {
+				t.Fatalf("isMissingGatewaySessionError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGatewaySessionRetriesSendAfterClosedGatewayWrite(t *testing.T) {
+	var connections atomic.Int32
+	var acceptedSends atomic.Int32
+	firstHandshakeDone := make(chan struct{})
+	firstGatewayClosed := make(chan struct{})
+	testDone := make(chan struct{})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Errorf("accept websocket: %v", err)
+			return
+		}
+		defer conn.CloseNow()
+
+		connID := connections.Add(1)
+		ctx := r.Context()
+		challengePayload, _ := json.Marshal(map[string]string{"nonce": "nonce"})
+		if err := wsjson.Write(ctx, conn, gwFrame{Type: "event", Event: "connect.challenge", Payload: challengePayload}); err != nil {
+			t.Errorf("write challenge: %v", err)
+			return
+		}
+		var connectReq gwFrame
+		if err := wsjson.Read(ctx, conn, &connectReq); err != nil {
+			t.Errorf("read connect request: %v", err)
+			return
+		}
+		if connectReq.Method != "connect" {
+			t.Errorf("first request method = %q, want connect", connectReq.Method)
+			return
+		}
+		if err := wsjson.Write(ctx, conn, gwFrame{Type: "res", ID: connectReq.ID, OK: true}); err != nil {
+			t.Errorf("write connect response: %v", err)
+			return
+		}
+
+		if connID == 1 {
+			close(firstHandshakeDone)
+			conn.CloseNow()
+			close(firstGatewayClosed)
+			return
+		}
+
+		var subReq gwFrame
+		if err := wsjson.Read(ctx, conn, &subReq); err != nil {
+			t.Errorf("read subscribe request: %v", err)
+			return
+		}
+		if subReq.Method != "sessions.subscribe" {
+			t.Errorf("reconnect request method = %q, want sessions.subscribe", subReq.Method)
+			return
+		}
+		if err := wsjson.Write(ctx, conn, gwFrame{Type: "res", ID: subReq.ID, OK: true}); err != nil {
+			t.Errorf("write subscribe response: %v", err)
+			return
+		}
+
+		var sendReq gwFrame
+		if err := wsjson.Read(ctx, conn, &sendReq); err != nil {
+			t.Errorf("read sessions.send request: %v", err)
+			return
+		}
+		if sendReq.Method != "sessions.send" {
+			t.Errorf("retry request method = %q, want sessions.send", sendReq.Method)
+			return
+		}
+		acceptedSends.Add(1)
+		if err := wsjson.Write(ctx, conn, gwFrame{Type: "res", ID: sendReq.ID, OK: true}); err != nil {
+			t.Errorf("write sessions.send response: %v", err)
+			return
+		}
+
+		assistantPayload, _ := json.Marshal(map[string]interface{}{
+			"stream":     "assistant",
+			"sessionKey": "session-1",
+			"data":       map[string]string{"delta": "hello"},
+		})
+		if err := wsjson.Write(ctx, conn, gwFrame{Type: "event", Event: "agent", Payload: assistantPayload}); err != nil {
+			t.Errorf("write assistant event: %v", err)
+			return
+		}
+		endPayload, _ := json.Marshal(map[string]interface{}{
+			"stream":     "lifecycle",
+			"sessionKey": "session-1",
+			"data":       map[string]string{"phase": "end"},
+		})
+		if err := wsjson.Write(ctx, conn, gwFrame{Type: "event", Event: "agent", Payload: endPayload}); err != nil {
+			t.Errorf("write lifecycle event: %v", err)
+			return
+		}
+		<-testDone
+	}))
+	defer srv.Close()
+	defer close(testDone)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	client := &gatewayClient{
+		addr:  strings.TrimPrefix(wsURL, "ws://"),
+		token: "token",
+		device: &deviceIdentity{
+			DeviceID:      "device-1",
+			PublicKeyPem:  testPEM("PUBLIC KEY"),
+			PrivateKeyPem: testPEM("PRIVATE KEY"),
+		},
+		home: t.TempDir(),
+	}
+	conn, err := client.connectToGateway(ctx)
+	if err != nil {
+		t.Fatalf("connect to gateway: %v", err)
+	}
+	select {
+	case <-firstHandshakeDone:
+	case <-time.After(time.Second):
+		t.Fatal("first gateway handshake did not complete")
+	}
+	select {
+	case <-firstGatewayClosed:
+	case <-time.After(time.Second):
+		t.Fatal("first gateway did not close")
+	}
+	conn.CloseNow()
+
+	gs := &gatewaySession{
+		client:     client,
+		sessionKey: "session-1",
+		conn:       conn,
+		pending:    make(map[string]chan gwFrame),
+	}
+	go gs.readLoop(ctx)
+
+	var chunks []string
+	start := time.Now()
+	reply, err := gs.SendMessage(ctx, "hi", func(chunk string) {
+		chunks = append(chunks, chunk)
+	}, nil)
+	if err != nil {
+		t.Fatalf("SendMessage returned error: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("SendMessage took %s, want retry to complete without waiting for readLoop reconnect backoff", elapsed)
+	}
+	if reply != "hello" {
+		t.Fatalf("reply = %q, want hello", reply)
+	}
+	if strings.Join(chunks, "") != "hello" {
+		t.Fatalf("chunks = %q, want hello", strings.Join(chunks, ""))
+	}
+	if got := acceptedSends.Load(); got != 1 {
+		t.Fatalf("accepted sends = %d, want 1", got)
+	}
+	if got := connections.Load(); got != 2 {
+		t.Fatalf("connections = %d, want 2", got)
+	}
+}
+
+func testPEM(typ string) string {
+	return string(pem.EncodeToMemory(&pem.Block{
+		Type:  typ,
+		Bytes: []byte("01234567890123456789012345678901"),
+	}))
 }
 
 type errString string

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -622,8 +622,11 @@ func TestIsMissingGatewaySessionError(t *testing.T) {
 	}{
 		{name: "nil", err: nil, want: false},
 		{name: "session not found", err: errString("sessions.subscribe: sessions.subscribe failed: session not found"), want: true},
-		{name: "not found", err: errString("sessions.subscribe: not found"), want: true},
+		{name: "session key not found", err: errString("sessions.subscribe failed: session key not found"), want: true},
 		{name: "unknown session", err: errString("sessions.subscribe failed: unknown session key"), want: true},
+		{name: "plain not found", err: errString("sessions.subscribe: not found"), want: false},
+		{name: "user not found", err: errString("sessions.subscribe failed: user not found"), want: false},
+		{name: "route not found", err: errString("sessions.subscribe failed: route not found"), want: false},
 		{name: "permission denied", err: errString("sessions.subscribe failed: permission denied"), want: false},
 		{name: "transport timeout", err: errString("sessions.subscribe write: i/o timeout"), want: false},
 	}
@@ -633,6 +636,23 @@ func TestIsMissingGatewaySessionError(t *testing.T) {
 				t.Fatalf("isMissingGatewaySessionError(%v) = %v, want %v", tt.err, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestReconnectGatewayReportsStaleConnectionNoop(t *testing.T) {
+	current := &websocket.Conn{}
+	stale := &websocket.Conn{}
+	gs := &gatewaySession{conn: current}
+
+	reconnected, err := gs.reconnectGateway(context.Background(), stale)
+	if err != nil {
+		t.Fatalf("reconnectGateway returned error: %v", err)
+	}
+	if reconnected {
+		t.Fatal("reconnectGateway reported reconnect for stale expected connection")
+	}
+	if got := gs.currentConn(); got != current {
+		t.Fatalf("current connection changed on stale reconnect: got %p, want %p", got, current)
 	}
 }
 


### PR DESCRIPTION
Fixes #407.

## Summary
- classify closed `sessions.send` write failures as retryable gateway transport failures only before gateway acceptance
- reconnect and re-subscribe to the OpenClaw gateway, recreating the session only when the session is missing
- keep lifecycle/stream errors and accepted-send disconnects non-retryable to avoid replaying visible turns
- add regression coverage for the closed-connection send path

## Tests
- `go test ./cmd/claw-bridge -run 'Test(IsRecoverableSessionSendError|IsRetryableGatewaySendRequestError|IsMissingGatewaySessionError|GatewaySessionRetriesSendAfterClosedGatewayWrite|GatewayReadLoopFailsPendingRequestsOnDisconnect)$' -count=1 -v`\n- `go test -race ./cmd/claw-bridge -count=1`\n- `go test ./cmd/claw-bridge -count=1`\n- `go test ./... -count=1`