### PR TITLE
Add agent error policy for GitHub issues

### DIFF
--- a/pkg/hub/agent_error.go
+++ b/pkg/hub/agent_error.go
@@ -274,17 +274,11 @@ func fetchGitHubIssueOwners(baseURL, token, repo string, issueNumber int) ([]tra
 		Assignee *struct {
 			Login string `json:"login"`
 		} `json:"assignee"`
-		Assignees []struct {
-			Login string `json:"login"`
-		} `json:"assignees"`
 	}
 	if err := json.Unmarshal(body, &result); err != nil {
 		return nil, err
 	}
-	owners := make([]trackerOwner, 0, len(result.Assignees)+1)
-	for _, assignee := range result.Assignees {
-		owners = appendGitHubOwner(owners, assignee.Login)
-	}
+	var owners []trackerOwner
 	if result.Assignee != nil {
 		owners = appendGitHubOwner(owners, result.Assignee.Login)
 	}
@@ -404,9 +398,6 @@ func setGitHubHeaders(req *http.Request, token string) {
 
 func githubOwnersFromWebhook(payload githubIssuesWebhookPayload) []trackerOwner {
 	var owners []trackerOwner
-	for _, assignee := range payload.Issue.Assignees {
-		owners = appendGitHubOwner(owners, assignee.Login)
-	}
 	if payload.Issue.Assignee != nil {
 		owners = appendGitHubOwner(owners, payload.Issue.Assignee.Login)
 	}

--- a/pkg/hub/agent_error.go
+++ b/pkg/hub/agent_error.go
@@ -1,0 +1,502 @@
+package hub
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+const (
+	agentErrorReassignPreviousOwner = "previous_owner"
+	agentErrorReassignNone          = "none"
+	defaultAgentErrorComment        = `Agent stopped because of an unrecoverable error.
+
+Reason:
+{{ .Reason }}
+
+{{ .OriginalOwnerLine }}
+
+{{ .AssignmentResult }}`
+)
+
+type trackerOwner struct {
+	ID      string `json:"id,omitempty"`
+	Login   string `json:"login,omitempty"`
+	Name    string `json:"name,omitempty"`
+	Mention string `json:"mention,omitempty"`
+}
+
+type agentErrorPolicy struct {
+	Enabled    bool
+	Marker     string
+	Comment    string
+	ReassignTo string
+}
+
+type agentErrorContext struct {
+	ClawID          string
+	Reason          string
+	Integration     string
+	IssueID         string
+	OriginalOwners  []trackerOwner
+	AgentOwners     []trackerOwner
+	PipelineContext pipelineContext
+}
+
+func (s *Server) handleAgentError(clawID, reason string) {
+	ctx, ok := s.loadAgentErrorContext(clawID, reason)
+	if !ok {
+		return
+	}
+	policy := s.resolveAgentErrorPolicy(ctx)
+	if !policy.Enabled {
+		return
+	}
+	switch ctx.Integration {
+	case "github-issues":
+		if err := s.handleGitHubIssueAgentError(ctx, policy); err != nil {
+			log.Printf("[agent-error] github issue %s: %v", ctx.IssueID, err)
+		}
+	default:
+		// Other integrations continue to use their existing stop comments until
+		// their adapters grow marker/reassignment support.
+		return
+	}
+}
+
+func (s *Server) loadAgentErrorContext(clawID, reason string) (agentErrorContext, bool) {
+	ctx := agentErrorContext{ClawID: clawID, Reason: reason}
+	pctx, _ := s.findPipelineContextForClaw(clawID)
+	ctx.PipelineContext = pctx
+	ctx.IssueID = pctx.IssueID
+	ctx.Integration = pctx.Integration()
+
+	var integration, issueID, originalOwnersJSON, agentOwnersJSON string
+	err := s.db.QueryRow(`
+		SELECT integration, issue_id, original_owners, agent_owners
+		  FROM claw_tracker_contexts WHERE claw_id=?`,
+		clawID,
+	).Scan(&integration, &issueID, &originalOwnersJSON, &agentOwnersJSON)
+	if err == nil {
+		if integration != "" {
+			ctx.Integration = integration
+		}
+		if issueID != "" {
+			ctx.IssueID = issueID
+		}
+		_ = json.Unmarshal([]byte(originalOwnersJSON), &ctx.OriginalOwners)
+		_ = json.Unmarshal([]byte(agentOwnersJSON), &ctx.AgentOwners)
+	}
+
+	if ctx.Integration == "" || ctx.IssueID == "" {
+		return ctx, false
+	}
+	return ctx, true
+}
+
+func (s *Server) resolveAgentErrorPolicy(ctx agentErrorContext) agentErrorPolicy {
+	policy := agentErrorPolicy{
+		Enabled:    true,
+		Comment:    defaultAgentErrorComment,
+		ReassignTo: agentErrorReassignPreviousOwner,
+	}
+	switch ctx.Integration {
+	case "github-issues":
+		policy.Marker = "agent-error"
+	case "linear":
+		policy.Marker = "Agent Error"
+	}
+
+	var override *types.AgentErrorConfig
+	if ctx.PipelineContext.Workflow != nil {
+		override = ctx.PipelineContext.Workflow.AgentError
+	} else if ctx.PipelineContext.Factory != nil {
+		override = ctx.PipelineContext.Factory.AgentError
+	}
+	if override == nil {
+		return policy
+	}
+	if override.Enabled != nil {
+		policy.Enabled = *override.Enabled
+	}
+	if override.Marker != "" {
+		policy.Marker = override.Marker
+	}
+	if override.Comment != "" {
+		policy.Comment = override.Comment
+	}
+	if override.ReassignTo != "" {
+		policy.ReassignTo = override.ReassignTo
+	}
+	return policy
+}
+
+func (s *Server) saveTrackerContext(clawID, integration, issueID string, originalOwners, agentOwners []trackerOwner) {
+	if clawID == "" || integration == "" || issueID == "" {
+		return
+	}
+	originalJSON, _ := json.Marshal(originalOwners)
+	agentJSON, _ := json.Marshal(agentOwners)
+	if _, err := s.db.Exec(`
+		INSERT INTO claw_tracker_contexts(claw_id, integration, issue_id, original_owners, agent_owners, created_at)
+		VALUES(?,?,?,?,?,?)
+		ON CONFLICT(claw_id) DO UPDATE SET
+			integration=excluded.integration,
+			issue_id=excluded.issue_id,
+			original_owners=excluded.original_owners,
+			agent_owners=excluded.agent_owners`,
+		clawID, integration, issueID, string(originalJSON), string(agentJSON), time.Now().UTC(),
+	); err != nil {
+		log.Printf("[agent-error] failed to save tracker context for claw %s: %v", clawID, err)
+	}
+}
+
+func (s *Server) handleGitHubIssueAgentError(ctx agentErrorContext, policy agentErrorPolicy) error {
+	repo, issueNumber, ok := parseGitHubIssueID(ctx.IssueID)
+	if !ok {
+		return fmt.Errorf("invalid GitHub issue id %q", ctx.IssueID)
+	}
+	token := s.resolveGitHubIssuesTokenForPipeline(ctx.PipelineContext)
+	if token == "" {
+		return fmt.Errorf("no GitHub Issues token")
+	}
+	base := s.githubBaseURL
+	if base == "" {
+		base = "https://api.github.com"
+	}
+
+	currentOwners, err := fetchGitHubIssueOwners(base, token, repo, issueNumber)
+	if err != nil {
+		return fmt.Errorf("fetch current assignees: %w", err)
+	}
+	assignmentResult, err := s.applyGitHubAgentErrorAssignment(base, token, repo, issueNumber, currentOwners, ctx.OriginalOwners, ctx.AgentOwners, policy)
+	if err != nil {
+		assignmentResult = "Assignment was left unchanged because reassignment failed: " + err.Error()
+		log.Printf("[agent-error] github issue %s assignment failed: %v", ctx.IssueID, err)
+	}
+
+	if strings.TrimSpace(policy.Marker) != "" {
+		if err := addGitHubIssueLabelWithCreate(base, repo, issueNumber, strings.TrimSpace(policy.Marker), token); err != nil {
+			log.Printf("[agent-error] github issue %s label %q failed: %v", ctx.IssueID, policy.Marker, err)
+		}
+	}
+
+	comment := renderAgentErrorComment(policy.Comment, ctx, assignmentResult)
+	if err := commentGitHubIssueWithBase(base, token, repo, issueNumber, comment); err != nil {
+		return fmt.Errorf("comment: %w", err)
+	}
+	return nil
+}
+
+func (s *Server) applyGitHubAgentErrorAssignment(base, token, repo string, issueNumber int, current, original, agentOwners []trackerOwner, policy agentErrorPolicy) (string, error) {
+	if policy.ReassignTo == agentErrorReassignNone {
+		return "Assignment was left unchanged by policy.", nil
+	}
+	if len(original) == 0 {
+		return "No original owner was recorded. Assignment was left unchanged.", nil
+	}
+	mentions := ownerMentions(original)
+	if ownerSetsIntersect(current, original) {
+		return "Assignment was left unchanged because the issue is already assigned to an original owner.", nil
+	}
+	if len(current) > 0 && !onlyKnownOwners(current, agentOwners) {
+		return "Assignment was left unchanged because the issue is assigned to another user.", nil
+	}
+	if err := addGitHubIssueAssignees(base, token, repo, issueNumber, ownerLogins(original)); err != nil {
+		return "", err
+	}
+	if len(current) > 0 && len(agentOwners) > 0 {
+		if err := removeGitHubIssueAssignees(base, token, repo, issueNumber, ownerLogins(agentOwners)); err != nil {
+			return "", err
+		}
+	}
+	return "Reassigned this issue back to " + mentions + ".", nil
+}
+
+func renderAgentErrorComment(template string, ctx agentErrorContext, assignmentResult string) string {
+	originalLine := "No original owner was recorded."
+	if mentions := ownerMentions(ctx.OriginalOwners); mentions != "" {
+		originalLine = "Original owner: " + mentions
+	}
+	replacements := map[string]string{
+		"{{ .Reason }}":               ctx.Reason,
+		"{{ .OriginalOwnerLine }}":    originalLine,
+		"{{ .OriginalOwnerMention }}": ownerMentions(ctx.OriginalOwners),
+		"{{ .AssignmentResult }}":     assignmentResult,
+		"{{ .ClawID }}":               ctx.ClawID,
+	}
+	out := template
+	for from, to := range replacements {
+		out = strings.ReplaceAll(out, from, to)
+	}
+	return strings.TrimSpace(out)
+}
+
+func parseGitHubIssueID(issueID string) (string, int, bool) {
+	parts := strings.Split(issueID, "/")
+	if len(parts) != 3 {
+		return "", 0, false
+	}
+	n, err := strconv.Atoi(parts[2])
+	if err != nil || n <= 0 {
+		return "", 0, false
+	}
+	return parts[0] + "/" + parts[1], n, true
+}
+
+func fetchGitHubIssueOwners(baseURL, token, repo string, issueNumber int) ([]trackerOwner, error) {
+	if baseURL == "" {
+		baseURL = "https://api.github.com"
+	}
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/repos/%s/issues/%d", baseURL, repo, issueNumber), nil)
+	if err != nil {
+		return nil, err
+	}
+	setGitHubHeaders(req, token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("github API GET issue: %d %s", resp.StatusCode, string(body))
+	}
+	var result struct {
+		Assignee *struct {
+			Login string `json:"login"`
+		} `json:"assignee"`
+		Assignees []struct {
+			Login string `json:"login"`
+		} `json:"assignees"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, err
+	}
+	owners := make([]trackerOwner, 0, len(result.Assignees)+1)
+	for _, assignee := range result.Assignees {
+		owners = appendGitHubOwner(owners, assignee.Login)
+	}
+	if result.Assignee != nil {
+		owners = appendGitHubOwner(owners, result.Assignee.Login)
+	}
+	return owners, nil
+}
+
+func addGitHubIssueAssignees(baseURL, token, repo string, issueNumber int, logins []string) error {
+	if len(logins) == 0 {
+		return nil
+	}
+	return githubIssueAssigneesRequest(baseURL, token, repo, issueNumber, http.MethodPost, logins)
+}
+
+func removeGitHubIssueAssignees(baseURL, token, repo string, issueNumber int, logins []string) error {
+	if len(logins) == 0 {
+		return nil
+	}
+	return githubIssueAssigneesRequest(baseURL, token, repo, issueNumber, http.MethodDelete, logins)
+}
+
+func githubIssueAssigneesRequest(baseURL, token, repo string, issueNumber int, method string, logins []string) error {
+	if baseURL == "" {
+		baseURL = "https://api.github.com"
+	}
+	body, _ := json.Marshal(map[string][]string{"assignees": logins})
+	req, err := http.NewRequest(method, fmt.Sprintf("%s/repos/%s/issues/%d/assignees", baseURL, repo, issueNumber), bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	setGitHubHeaders(req, token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("github API %s assignees: %d %s", method, resp.StatusCode, string(respBody))
+	}
+	return nil
+}
+
+func addGitHubIssueLabelWithCreate(baseURL, repo string, issueNumber int, label, token string) error {
+	err := githubAPIAddLabel(baseURL, repo, issueNumber, label, token)
+	if err == nil {
+		return nil
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "label") && !strings.Contains(err.Error(), "404") {
+		return err
+	}
+	if createErr := createGitHubIssueLabel(baseURL, repo, label, token); createErr != nil {
+		return err
+	}
+	return githubAPIAddLabel(baseURL, repo, issueNumber, label, token)
+}
+
+func createGitHubIssueLabel(baseURL, repo, label, token string) error {
+	if baseURL == "" {
+		baseURL = "https://api.github.com"
+	}
+	body, _ := json.Marshal(map[string]string{
+		"name":        label,
+		"color":       "d73a4a",
+		"description": "Agent stopped because of an unrecoverable error",
+	})
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/repos/%s/labels", baseURL, repo), bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	setGitHubHeaders(req, token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode == http.StatusUnprocessableEntity && strings.Contains(string(respBody), "already_exists") {
+		return nil
+	}
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("github API create label: %d %s", resp.StatusCode, string(respBody))
+	}
+	return nil
+}
+
+func commentGitHubIssueWithBase(baseURL, token, repo string, issueNumber int, body string) error {
+	if baseURL == "" {
+		baseURL = "https://api.github.com"
+	}
+	commentBody := map[string]interface{}{"body": body}
+	b, _ := json.Marshal(commentBody)
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/repos/%s/issues/%d/comments", baseURL, repo, issueNumber), bytes.NewReader(b))
+	if err != nil {
+		return err
+	}
+	setGitHubHeaders(req, token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("github API comment: %d %s", resp.StatusCode, string(respBody))
+	}
+	return nil
+}
+
+func setGitHubHeaders(req *http.Request, token string) {
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+}
+
+func githubOwnersFromWebhook(payload githubIssuesWebhookPayload) []trackerOwner {
+	var owners []trackerOwner
+	for _, assignee := range payload.Issue.Assignees {
+		owners = appendGitHubOwner(owners, assignee.Login)
+	}
+	if payload.Issue.Assignee != nil {
+		owners = appendGitHubOwner(owners, payload.Issue.Assignee.Login)
+	}
+	return owners
+}
+
+func (s *Server) githubOriginalOwnersFromIssue(payload githubIssuesWebhookPayload) []trackerOwner {
+	return githubOwnersFromWebhook(payload)
+}
+
+func appendGitHubOwner(owners []trackerOwner, login string) []trackerOwner {
+	login = strings.TrimSpace(login)
+	if login == "" {
+		return owners
+	}
+	for _, owner := range owners {
+		if strings.EqualFold(owner.Login, login) {
+			return owners
+		}
+	}
+	return append(owners, trackerOwner{Login: login, Mention: "@" + login})
+}
+
+func ownerLogins(owners []trackerOwner) []string {
+	out := make([]string, 0, len(owners))
+	for _, owner := range owners {
+		login := strings.TrimSpace(owner.Login)
+		if login != "" {
+			out = append(out, login)
+		}
+	}
+	return out
+}
+
+func ownerMentions(owners []trackerOwner) string {
+	mentions := make([]string, 0, len(owners))
+	for _, owner := range owners {
+		mention := strings.TrimSpace(owner.Mention)
+		if mention == "" && owner.Login != "" {
+			mention = "@" + owner.Login
+		}
+		if mention == "" {
+			mention = strings.TrimSpace(owner.Name)
+		}
+		if mention != "" {
+			mentions = append(mentions, mention)
+		}
+	}
+	return strings.Join(mentions, ", ")
+}
+
+func ownerSetsIntersect(a, b []trackerOwner) bool {
+	for _, left := range a {
+		for _, right := range b {
+			if sameTrackerOwner(left, right) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func onlyKnownOwners(current, known []trackerOwner) bool {
+	if len(current) == 0 || len(known) == 0 {
+		return false
+	}
+	for _, owner := range current {
+		found := false
+		for _, knownOwner := range known {
+			if sameTrackerOwner(owner, knownOwner) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+func sameTrackerOwner(a, b trackerOwner) bool {
+	switch {
+	case a.ID != "" && b.ID != "":
+		return a.ID == b.ID
+	case a.Login != "" && b.Login != "":
+		return strings.EqualFold(a.Login, b.Login)
+	case a.Name != "" && b.Name != "":
+		return strings.EqualFold(a.Name, b.Name)
+	default:
+		return false
+	}
+}

--- a/pkg/hub/agent_error_test.go
+++ b/pkg/hub/agent_error_test.go
@@ -1,0 +1,231 @@
+package hub
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+type agentErrorGitHubMock struct {
+	*httptest.Server
+	mu        sync.Mutex
+	assignees []string
+	labels    []string
+	comments  []string
+}
+
+func newAgentErrorGitHubMock(t *testing.T, assignees []string) *agentErrorGitHubMock {
+	t.Helper()
+	m := &agentErrorGitHubMock{assignees: append([]string(nil), assignees...)}
+	m.Server = httptest.NewServer(http.HandlerFunc(m.handle))
+	t.Cleanup(m.Close)
+	return m
+}
+
+func (m *agentErrorGitHubMock) handle(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/repos/testorg/testrepo/issues/42" &&
+		r.URL.Path != "/repos/testorg/testrepo/issues/42/labels" &&
+		r.URL.Path != "/repos/testorg/testrepo/issues/42/comments" &&
+		r.URL.Path != "/repos/testorg/testrepo/issues/42/assignees" {
+		http.NotFound(w, r)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	switch {
+	case r.Method == http.MethodGet && r.URL.Path == "/repos/testorg/testrepo/issues/42":
+		assignees := make([]map[string]string, 0, len(m.assignees))
+		for _, login := range m.assignees {
+			assignees = append(assignees, map[string]string{"login": login})
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"number":    42,
+			"title":     "Test issue",
+			"state":     "open",
+			"assignees": assignees,
+		})
+	case r.Method == http.MethodPost && r.URL.Path == "/repos/testorg/testrepo/issues/42/labels":
+		var body struct {
+			Labels []string `json:"labels"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		m.labels = appendMissingStrings(m.labels, body.Labels...)
+		_ = json.NewEncoder(w).Encode([]map[string]string{{"name": "agent-error"}})
+	case r.Method == http.MethodPost && r.URL.Path == "/repos/testorg/testrepo/issues/42/comments":
+		var body struct {
+			Body string `json:"body"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		m.comments = append(m.comments, body.Body)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"id": len(m.comments)})
+	case r.Method == http.MethodPost && r.URL.Path == "/repos/testorg/testrepo/issues/42/assignees":
+		var body struct {
+			Assignees []string `json:"assignees"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		m.assignees = appendMissingStrings(m.assignees, body.Assignees...)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"assignees": m.assignees})
+	case r.Method == http.MethodDelete && r.URL.Path == "/repos/testorg/testrepo/issues/42/assignees":
+		var body struct {
+			Assignees []string `json:"assignees"`
+		}
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &body)
+		for _, remove := range body.Assignees {
+			m.assignees = removeString(m.assignees, remove)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"assignees": m.assignees})
+	default:
+		http.Error(w, "unexpected method/path", http.StatusInternalServerError)
+	}
+}
+
+func (m *agentErrorGitHubMock) snapshot() (assignees, labels, comments []string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string(nil), m.assignees...), append([]string(nil), m.labels...), append([]string(nil), m.comments...)
+}
+
+func TestGitHubAgentErrorLabelsCommentsAndLeavesOriginalAssignee(t *testing.T) {
+	github := newAgentErrorGitHubMock(t, []string{"ana"})
+	s, db := NewTestServerWithConfig(t, agentErrorGitHubConfig(), github.URL, "", "")
+
+	insertGitHubAgentErrorClaw(t, db, "claw-agent-error-original")
+	insertAgentErrorTrackerContext(t, db, "claw-agent-error-original", []trackerOwner{{Login: "ana", Mention: "@ana"}})
+
+	s.stopAgentWithReason("claw-agent-error-original", "Bootstrap failed: missing CONTEXT.md", true)
+
+	waitForAgentErrorComment(t, github, "already assigned to an original owner")
+	assignees, labels, comments := github.snapshot()
+	if !containsString(labels, "agent-error") {
+		t.Fatalf("labels = %v, want agent-error", labels)
+	}
+	if fmt.Sprint(assignees) != "[ana]" {
+		t.Fatalf("assignees = %v, want [ana]", assignees)
+	}
+	if !strings.Contains(comments[len(comments)-1], "Original owner: @ana") {
+		t.Fatalf("comment did not mention original owner:\n%s", comments[len(comments)-1])
+	}
+	if !strings.Contains(comments[len(comments)-1], "Bootstrap failed: missing CONTEXT.md") {
+		t.Fatalf("comment did not include sanitized reason:\n%s", comments[len(comments)-1])
+	}
+}
+
+func TestGitHubAgentErrorReassignsEmptyIssueToOriginalAssignee(t *testing.T) {
+	github := newAgentErrorGitHubMock(t, nil)
+	s, db := NewTestServerWithConfig(t, agentErrorGitHubConfig(), github.URL, "", "")
+
+	insertGitHubAgentErrorClaw(t, db, "claw-agent-error-empty")
+	insertAgentErrorTrackerContext(t, db, "claw-agent-error-empty", []trackerOwner{{Login: "ana", Mention: "@ana"}})
+
+	s.stopAgentWithReason("claw-agent-error-empty", "Provisioning failed: provider returned 503", true)
+
+	waitForAgentErrorComment(t, github, "Reassigned this issue back to @ana.")
+	assignees, labels, comments := github.snapshot()
+	if !containsString(labels, "agent-error") {
+		t.Fatalf("labels = %v, want agent-error", labels)
+	}
+	if fmt.Sprint(assignees) != "[ana]" {
+		t.Fatalf("assignees = %v, want [ana]", assignees)
+	}
+	if !strings.Contains(comments[len(comments)-1], "Provisioning failed: provider returned 503") {
+		t.Fatalf("comment did not include sanitized reason:\n%s", comments[len(comments)-1])
+	}
+}
+
+func agentErrorGitHubConfig() *types.HubConfig {
+	return &types.HubConfig{
+		ClawToken: "test-claw-token",
+		Factories: []*types.FactoryConfig{{
+			Name:        "github-agent-error",
+			Integration: "github-issues",
+			Workspace:   "test-workspace",
+			Template:    "elasticclaw",
+			Provider:    "noop",
+		}},
+		Integrations: &types.IntegrationsConfig{
+			GitHubIssues: []*types.GitHubIssuesIntegrationConfig{{
+				Workspace: "test-workspace",
+				Token:     "test-github-token",
+			}},
+		},
+		Providers: map[string]types.ProviderConfig{"noop": {Type: "noop"}},
+	}
+}
+
+func insertGitHubAgentErrorClaw(t *testing.T, db *sql.DB, clawID string) {
+	t.Helper()
+	_, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, template, status, factory_name, github_issue_id, tags, created_at)
+		 VALUES(?,?,?,?,?,?,?,?,datetime('now'))`,
+		clawID, "test-tenant-id", "test claw", "elasticclaw", "connected", "github-agent-error", "testorg/testrepo/42", `["factory:github-agent-error"]`,
+	)
+	if err != nil {
+		t.Fatalf("insert claw: %v", err)
+	}
+}
+
+func insertAgentErrorTrackerContext(t *testing.T, db *sql.DB, clawID string, owners []trackerOwner) {
+	t.Helper()
+	ownersJSON, _ := json.Marshal(owners)
+	_, err := db.Exec(
+		`INSERT INTO claw_tracker_contexts(claw_id, integration, issue_id, original_owners, agent_owners, created_at)
+		 VALUES(?,?,?,?,?,datetime('now'))`,
+		clawID, "github-issues", "testorg/testrepo/42", string(ownersJSON), "[]",
+	)
+	if err != nil {
+		t.Fatalf("insert tracker context: %v", err)
+	}
+}
+
+func waitForAgentErrorComment(t *testing.T, github *agentErrorGitHubMock, want string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		_, _, comments := github.snapshot()
+		if len(comments) > 0 && strings.Contains(comments[len(comments)-1], want) {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	_, _, comments := github.snapshot()
+	t.Fatalf("timed out waiting for comment containing %q; comments=%v", want, comments)
+}
+
+func appendMissingStrings(items []string, add ...string) []string {
+	for _, item := range add {
+		if !containsString(items, item) {
+			items = append(items, item)
+		}
+	}
+	return items
+}
+
+func removeString(items []string, remove string) []string {
+	out := items[:0]
+	for _, item := range items {
+		if item != remove {
+			out = append(out, item)
+		}
+	}
+	return out
+}
+
+func containsString(items []string, want string) bool {
+	for _, item := range items {
+		if item == want {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/hub/agent_error_test.go
+++ b/pkg/hub/agent_error_test.go
@@ -44,6 +44,10 @@ func (m *agentErrorGitHubMock) handle(w http.ResponseWriter, r *http.Request) {
 	defer m.mu.Unlock()
 	switch {
 	case r.Method == http.MethodGet && r.URL.Path == "/repos/testorg/testrepo/issues/42":
+		var assignee interface{}
+		if len(m.assignees) > 0 {
+			assignee = map[string]string{"login": m.assignees[len(m.assignees)-1]}
+		}
 		assignees := make([]map[string]string, 0, len(m.assignees))
 		for _, login := range m.assignees {
 			assignees = append(assignees, map[string]string{"login": login})
@@ -52,6 +56,7 @@ func (m *agentErrorGitHubMock) handle(w http.ResponseWriter, r *http.Request) {
 			"number":    42,
 			"title":     "Test issue",
 			"state":     "open",
+			"assignee":  assignee,
 			"assignees": assignees,
 		})
 	case r.Method == http.MethodPost && r.URL.Path == "/repos/testorg/testrepo/issues/42/labels":

--- a/pkg/hub/bootstrap.go
+++ b/pkg/hub/bootstrap.go
@@ -244,6 +244,11 @@ download_connector_once() {
     cp "$BINARY" /tmp/claw-bridge
     cd -
   fi
+  if [ ! -s /tmp/claw-bridge ]; then
+    echo "ERROR: ElasticClaw connector download produced no usable file at /tmp/claw-bridge"
+    ls -la /tmp/claw-bridge /tmp/claw-bridge-dl 2>/dev/null || true
+    return 1
+  fi
 }
 
 CONNECTOR_DELAYS=(5 10 20 40 60)
@@ -261,8 +266,13 @@ for attempt in $(seq 1 "$CONNECTOR_ATTEMPTS"); do
   echo "Retrying connector download in ${delay}s..."
   sleep "$delay"
 done
-chmod +x /tmp/claw-bridge
-sudo mv /tmp/claw-bridge /usr/local/bin/claw-bridge
+if [ ! -s /tmp/claw-bridge ]; then
+  echo "ERROR: ElasticClaw connector is missing after download retries"
+  exit 1
+fi
+sudo mkdir -p /usr/local/bin
+sudo install -m 0755 /tmp/claw-bridge /usr/local/bin/claw-bridge
+rm -f /tmp/claw-bridge
 echo "ElasticClaw connector installed"
 
 # ── Bootstrap + run ───────────────────────────────────────────────────────────

--- a/pkg/hub/bootstrap_test.go
+++ b/pkg/hub/bootstrap_test.go
@@ -105,6 +105,9 @@ func TestBootstrapScript_ConnectorDownloadRetriesWithUserFacingLabel(t *testing.
 	assertContains(t, script, "Downloading ElasticClaw connector", "user-facing connector label")
 	assertContains(t, script, "Retrying connector download in", "retry status")
 	assertContains(t, script, "could not download ElasticClaw connector", "user-facing failure")
+	assertContains(t, script, "[ ! -s /tmp/claw-bridge ]", "missing or empty connector is retried before install")
+	assertContains(t, script, "connector download produced no usable file", "missing connector has actionable error")
+	assertContains(t, script, "sudo install -m 0755 /tmp/claw-bridge /usr/local/bin/claw-bridge", "installs verified connector atomically")
 	assertNotContains(t, script, "Downloading claw-bridge from", "implementation name hidden from remote output")
 }
 
@@ -740,7 +743,21 @@ set +e
 for cmd in curl apt-get npm sudo systemctl git gh oras python3 gpg tee chmod mv nohup; do
   eval "${cmd}() { return 0; }"
 done
-curl() { echo stub_curl_output; return 0; }
+curl() {
+  local out=""
+  while [ "$#" -gt 0 ]; do
+    if [ "$1" = "-o" ]; then
+      shift
+      out="$1"
+    fi
+    shift || true
+  done
+  if [ -n "$out" ]; then
+    printf 'stub bridge binary' > "$out"
+  fi
+  echo stub_curl_output
+  return 0
+}
 openclaw() {
   if [ "$1" = "--version" ]; then echo "OpenClaw 2026.1.0"; fi
   return 0

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -60,6 +60,14 @@ func migrate(db *sql.DB) error {
 	_, _ = db.Exec(`ALTER TABLE claw_prs ADD COLUMN last_review_id INTEGER NOT NULL DEFAULT 0`)
 	_, _ = db.Exec(`ALTER TABLE messages ADD COLUMN format TEXT NOT NULL DEFAULT ''`)
 	_, _ = db.Exec(`ALTER TABLE factory_triggers ADD COLUMN task_run_id TEXT NOT NULL DEFAULT ''`)
+	_, _ = db.Exec(`CREATE TABLE IF NOT EXISTS claw_tracker_contexts (
+		claw_id         TEXT PRIMARY KEY,
+		integration     TEXT NOT NULL DEFAULT '',
+		issue_id        TEXT NOT NULL DEFAULT '',
+		original_owners TEXT NOT NULL DEFAULT '[]',
+		agent_owners    TEXT NOT NULL DEFAULT '[]',
+		created_at      DATETIME NOT NULL
+	)`)
 
 	_, _ = db.Exec(`CREATE TABLE IF NOT EXISTS claw_checkpoints (
 		id                    TEXT PRIMARY KEY,
@@ -241,6 +249,15 @@ func migrate(db *sql.DB) error {
 
 	CREATE INDEX IF NOT EXISTS idx_messages_claw ON messages(claw_id, created_at);
 	CREATE INDEX IF NOT EXISTS idx_claws_tenant  ON claws(tenant_id);
+
+	CREATE TABLE IF NOT EXISTS claw_tracker_contexts (
+		claw_id         TEXT PRIMARY KEY,
+		integration     TEXT NOT NULL DEFAULT '',
+		issue_id        TEXT NOT NULL DEFAULT '',
+		original_owners TEXT NOT NULL DEFAULT '[]',
+		agent_owners    TEXT NOT NULL DEFAULT '[]',
+		created_at      DATETIME NOT NULL
+	);
 
 	CREATE TABLE IF NOT EXISTS task_runs (
 		id                    TEXT PRIMARY KEY,

--- a/pkg/hub/factorytest/mock_github_issues.go
+++ b/pkg/hub/factorytest/mock_github_issues.go
@@ -21,6 +21,7 @@ type IssueState struct {
 	State     string
 	Labels    []string
 	Assignee  string
+	Assignees []string
 	UpdatedAt string // RFC3339
 }
 
@@ -254,6 +255,13 @@ func (m *MockGitHubIssues) BuildWebhookPayload(repo string, number int, prevStat
 		action = "reopened"
 	}
 
+	assignees := make([]map[string]string, 0, len(issue.Assignees))
+	for _, login := range issue.Assignees {
+		assignees = append(assignees, map[string]string{"login": login})
+	}
+	if issue.Assignee != "" && len(assignees) == 0 {
+		assignees = append(assignees, map[string]string{"login": issue.Assignee})
+	}
 	payload := map[string]interface{}{
 		"action": action,
 		"issue": map[string]interface{}{
@@ -266,6 +274,7 @@ func (m *MockGitHubIssues) BuildWebhookPayload(repo string, number int, prevStat
 			"state_reason": "",
 			"labels":       labelsToNameMaps(issue.Labels),
 			"assignee":     nil,
+			"assignees":    assignees,
 			"user":         map[string]interface{}{"login": "testuser", "type": "User"},
 		},
 		"repository": map[string]interface{}{
@@ -296,6 +305,13 @@ func issueToMap(number int, issue IssueState, owner, repo string) map[string]int
 	if issue.Assignee != "" {
 		assignee = map[string]interface{}{"login": issue.Assignee}
 	}
+	assignees := make([]map[string]string, 0, len(issue.Assignees))
+	for _, login := range issue.Assignees {
+		assignees = append(assignees, map[string]string{"login": login})
+	}
+	if issue.Assignee != "" && len(assignees) == 0 {
+		assignees = append(assignees, map[string]string{"login": issue.Assignee})
+	}
 	return map[string]interface{}{
 		"number":     number,
 		"title":      issue.Title,
@@ -305,6 +321,7 @@ func issueToMap(number int, issue IssueState, owner, repo string) map[string]int
 		"updated_at": issue.UpdatedAt,
 		"labels":     labels,
 		"assignee":   assignee,
+		"assignees":  assignees,
 		"user":       map[string]interface{}{"login": "testuser"},
 	}
 }

--- a/pkg/hub/factorytest/mock_github_issues.go
+++ b/pkg/hub/factorytest/mock_github_issues.go
@@ -21,7 +21,6 @@ type IssueState struct {
 	State     string
 	Labels    []string
 	Assignee  string
-	Assignees []string
 	UpdatedAt string // RFC3339
 }
 
@@ -255,12 +254,9 @@ func (m *MockGitHubIssues) BuildWebhookPayload(repo string, number int, prevStat
 		action = "reopened"
 	}
 
-	assignees := make([]map[string]string, 0, len(issue.Assignees))
-	for _, login := range issue.Assignees {
-		assignees = append(assignees, map[string]string{"login": login})
-	}
-	if issue.Assignee != "" && len(assignees) == 0 {
-		assignees = append(assignees, map[string]string{"login": issue.Assignee})
+	assignee := interface{}(nil)
+	if issue.Assignee != "" {
+		assignee = map[string]interface{}{"login": issue.Assignee}
 	}
 	payload := map[string]interface{}{
 		"action": action,
@@ -273,8 +269,7 @@ func (m *MockGitHubIssues) BuildWebhookPayload(repo string, number int, prevStat
 			"state":        newState,
 			"state_reason": "",
 			"labels":       labelsToNameMaps(issue.Labels),
-			"assignee":     nil,
-			"assignees":    assignees,
+			"assignee":     assignee,
 			"user":         map[string]interface{}{"login": "testuser", "type": "User"},
 		},
 		"repository": map[string]interface{}{
@@ -305,13 +300,6 @@ func issueToMap(number int, issue IssueState, owner, repo string) map[string]int
 	if issue.Assignee != "" {
 		assignee = map[string]interface{}{"login": issue.Assignee}
 	}
-	assignees := make([]map[string]string, 0, len(issue.Assignees))
-	for _, login := range issue.Assignees {
-		assignees = append(assignees, map[string]string{"login": login})
-	}
-	if issue.Assignee != "" && len(assignees) == 0 {
-		assignees = append(assignees, map[string]string{"login": issue.Assignee})
-	}
 	return map[string]interface{}{
 		"number":     number,
 		"title":      issue.Title,
@@ -321,7 +309,6 @@ func issueToMap(number int, issue IssueState, owner, repo string) map[string]int
 		"updated_at": issue.UpdatedAt,
 		"labels":     labels,
 		"assignee":   assignee,
-		"assignees":  assignees,
 		"user":       map[string]interface{}{"login": "testuser"},
 	}
 }

--- a/pkg/hub/github_issues.go
+++ b/pkg/hub/github_issues.go
@@ -38,9 +38,6 @@ type githubIssuesWebhookPayload struct {
 		Assignee *struct {
 			Login string `json:"login"`
 		} `json:"assignee"`
-		Assignees []struct {
-			Login string `json:"login"`
-		} `json:"assignees"`
 		User struct {
 			Login string `json:"login"`
 		} `json:"user"`

--- a/pkg/hub/github_issues.go
+++ b/pkg/hub/github_issues.go
@@ -38,6 +38,9 @@ type githubIssuesWebhookPayload struct {
 		Assignee *struct {
 			Login string `json:"login"`
 		} `json:"assignee"`
+		Assignees []struct {
+			Login string `json:"login"`
+		} `json:"assignees"`
 		User struct {
 			Login string `json:"login"`
 		} `json:"user"`
@@ -471,6 +474,7 @@ func (s *Server) createClawForGitHubIssueWorkflow(workspace *types.WorkspaceConf
 		return "", false, fmt.Errorf("complete workflow trigger: %w", err)
 	}
 	claimOpen = false
+	s.saveTrackerContext(clawID, "github-issues", issueID, s.githubOriginalOwnersFromIssue(payload), nil)
 	return clawID, true, nil
 }
 
@@ -750,6 +754,7 @@ func (s *Server) createClawForGitHubIssue(factory *types.FactoryConfig, payload 
 		return fmt.Errorf("complete factory trigger: %w", err)
 	}
 	claimOpen = false
+	s.saveTrackerContext(clawID, "github-issues", issueID, s.githubOriginalOwnersFromIssue(payload), nil)
 
 	log.Printf("[factory] created claw %s (%s) for GitHub issue %s (status=%s, reason=%s)", clawName, clawID[:8], issueID, initialStatus, reason)
 	// Notify connected dashboards immediately so the card appears

--- a/pkg/hub/github_issues_webhook_test.go
+++ b/pkg/hub/github_issues_webhook_test.go
@@ -248,10 +248,10 @@ func TestGitHubIssuesWorkflowStoresOriginalAssigneeSnapshot(t *testing.T) {
 	saveGitHubIssueWorkflowFixture(t, "workspace-a", "")
 
 	ghi.SetIssue("testorg/testrepo", 42, factorytest.IssueState{
-		Title:     "Test Issue",
-		Body:      "Test body",
-		State:     "open",
-		Assignees: []string{"ana", "matias"},
+		Title:    "Test Issue",
+		Body:     "Test body",
+		State:    "open",
+		Assignee: "ana",
 	})
 	s.PollIntegrationsForTest()
 
@@ -271,8 +271,8 @@ func TestGitHubIssuesWorkflowStoresOriginalAssigneeSnapshot(t *testing.T) {
 	if ownersJSON == "" {
 		t.Fatal("expected GitHub issue claw to store tracker context")
 	}
-	if !strings.Contains(ownersJSON, `"login":"ana"`) || !strings.Contains(ownersJSON, `"login":"matias"`) {
-		t.Fatalf("original owners snapshot = %s, want ana and matias", ownersJSON)
+	if !strings.Contains(ownersJSON, `"login":"ana"`) {
+		t.Fatalf("original owners snapshot = %s, want ana", ownersJSON)
 	}
 }
 

--- a/pkg/hub/github_issues_webhook_test.go
+++ b/pkg/hub/github_issues_webhook_test.go
@@ -232,6 +232,50 @@ func TestGitHubIssuesWorkflowPollCreatesOnceForMissedWebhook(t *testing.T) {
 	}
 }
 
+func TestGitHubIssuesWorkflowStoresOriginalAssigneeSnapshot(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
+	ghi := factorytest.NewMockGitHubIssues(t)
+	li := factorytest.NewMockLinear(t)
+
+	cfg := &types.HubConfig{
+		ClawToken: "test-claw-token",
+		Providers: map[string]types.ProviderConfig{
+			"noop": {Type: "noop"},
+		},
+	}
+	s, db := hub.NewTestServerWithConfig(t, cfg, ghi.URL, li.URL, "")
+	saveGitHubIssueWorkflowFixture(t, "workspace-a", "")
+
+	ghi.SetIssue("testorg/testrepo", 42, factorytest.IssueState{
+		Title:     "Test Issue",
+		Body:      "Test body",
+		State:     "open",
+		Assignees: []string{"ana", "matias"},
+	})
+	s.PollIntegrationsForTest()
+
+	var ownersJSON string
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		err := db.QueryRow(`
+			SELECT original_owners
+			  FROM claw_tracker_contexts
+			 WHERE integration='github-issues' AND issue_id='testorg/testrepo/42'`,
+		).Scan(&ownersJSON)
+		if err == nil && ownersJSON != "" {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if ownersJSON == "" {
+		t.Fatal("expected GitHub issue claw to store tracker context")
+	}
+	if !strings.Contains(ownersJSON, `"login":"ana"`) || !strings.Contains(ownersJSON, `"login":"matias"`) {
+		t.Fatalf("original owners snapshot = %s, want ana and matias", ownersJSON)
+	}
+}
+
 func TestGitHubIssuesWorkflowPollUsesActualLabeler(t *testing.T) {
 	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
 	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")

--- a/pkg/hub/integration_poller.go
+++ b/pkg/hub/integration_poller.go
@@ -838,9 +838,6 @@ type githubIssuesPollItem struct {
 	Assignee *struct {
 		Login string `json:"login"`
 	} `json:"assignee"`
-	Assignees []struct {
-		Login string `json:"login"`
-	} `json:"assignees"`
 	User struct {
 		Login string `json:"login"`
 	} `json:"user"`
@@ -1220,11 +1217,6 @@ func buildGitHubIssuesPollPayloadForAction(issue githubIssuesPollItem, repo, act
 		payload.Issue.Assignee = &struct {
 			Login string `json:"login"`
 		}{Login: issue.Assignee.Login}
-	}
-	for _, assignee := range issue.Assignees {
-		payload.Issue.Assignees = append(payload.Issue.Assignees, struct {
-			Login string `json:"login"`
-		}{Login: assignee.Login})
 	}
 	payload.Repository.FullName = repo
 	payload.Sender.Login = issue.User.Login

--- a/pkg/hub/integration_poller.go
+++ b/pkg/hub/integration_poller.go
@@ -838,6 +838,9 @@ type githubIssuesPollItem struct {
 	Assignee *struct {
 		Login string `json:"login"`
 	} `json:"assignee"`
+	Assignees []struct {
+		Login string `json:"login"`
+	} `json:"assignees"`
 	User struct {
 		Login string `json:"login"`
 	} `json:"user"`
@@ -1217,6 +1220,11 @@ func buildGitHubIssuesPollPayloadForAction(issue githubIssuesPollItem, repo, act
 		payload.Issue.Assignee = &struct {
 			Login string `json:"login"`
 		}{Login: issue.Assignee.Login}
+	}
+	for _, assignee := range issue.Assignees {
+		payload.Issue.Assignees = append(payload.Issue.Assignees, struct {
+			Login string `json:"login"`
+		}{Login: assignee.Login})
 	}
 	payload.Repository.FullName = repo
 	payload.Sender.Login = issue.User.Login

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -1703,13 +1703,18 @@ func (s *Server) stopAgentWithReason(clawID, reason string, skipVMTerminate bool
 	}
 	s.mu.Unlock()
 
-	// 4. Write issue-tracker comment without delaying agent shutdown.
+	// 4. Apply generic issue-tracker agent-error policy without delaying shutdown.
+	go s.handleAgentError(clawID, safeReason)
+
+	// 5. Write legacy issue-tracker comment without delaying agent shutdown.
 	if factory != nil && issueID != "" {
 		factoryCopy := *factory
-		go s.commentAgentStopToTracker(clawID, &factoryCopy, issueID, reason)
+		if factoryCopy.Integration != "github-issues" {
+			go s.commentAgentStopToTracker(clawID, &factoryCopy, issueID, reason)
+		}
 	}
 
-	// 5. Terminate VM if still running
+	// 6. Terminate VM if still running
 	if providerID != "" && !skipVMTerminate {
 		go s.terminateVM(provider, providerID)
 	}

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -586,26 +586,27 @@ type ConcurrencyGroup struct {
 type FactoryConfig struct {
 	// SchemaVersion is the schema version of this config file.
 	// Defaults to "v1" if not specified for backward compatibility.
-	SchemaVersion    string   `yaml:"schema_version,omitempty" json:"schemaVersion,omitempty"`
-	Name             string   `yaml:"name" json:"name"`
-	Enabled          *bool    `yaml:"enabled,omitempty" json:"enabled,omitempty"`                       // nil = true (default on); set false to pause
-	Integration      string   `yaml:"integration" json:"integration"`                                   // "linear", "shortcut", "github-issues", or "github"
-	Workspace        string   `yaml:"workspace,omitempty" json:"workspace,omitempty"`                   // matches integrations.<type>[].workspace
-	Team             string   `yaml:"team,omitempty" json:"team,omitempty"`                             // Linear team key (e.g. "ELA")
-	TriggerStatus    string   `yaml:"trigger_status,omitempty" json:"trigger_status,omitempty"`         // entering this status → create claw
-	WorkingStatus    string   `yaml:"working_status,omitempty" json:"working_status,omitempty"`         // claw moves issue here when it starts working
-	FinishedStatus   string   `yaml:"finished_status,omitempty" json:"finished_status,omitempty"`       // claw moves issue here when it finishes working
-	DoneStatus       string   `yaml:"done_status,omitempty" json:"done_status,omitempty"`               // claw moves issue here when done (PR merged)
-	TerminateOnLeave bool     `yaml:"terminate_on_leave,omitempty" json:"terminate_on_leave,omitempty"` // leaving trigger_status → kill claw
-	Template         string   `yaml:"template" json:"template"`                                         // template name (must be pushed to hub)
-	Provider         string   `yaml:"provider,omitempty" json:"provider,omitempty"`                     // override the default provider for this factory
-	NamePattern      string   `yaml:"name_pattern,omitempty" json:"name_pattern,omitempty"`             // claw name pattern, e.g. "{issue_id}"
-	WebhookSecret    string   `yaml:"webhook_secret,omitempty" json:"webhook_secret,omitempty"`         // HMAC-SHA256 secret for validating webhooks
-	Tags             []string `yaml:"tags,omitempty" json:"tags,omitempty"`                             // tags applied to created claws
-	Color            string   `yaml:"color,omitempty" json:"color,omitempty"`                           // color applied to created claws
-	RunKind          string   `yaml:"run_kind,omitempty" json:"run_kind,omitempty"`                     // analytics run kind: "code_task" or "pr_task"
-	AnalyticsEnabled *bool    `yaml:"analytics_enabled,omitempty" json:"analytics_enabled,omitempty"`   // nil = infer from integration
-	RequiresPR       *bool    `yaml:"requires_pr,omitempty" json:"requires_pr,omitempty"`               // nil = infer from analytics eligibility
+	SchemaVersion    string            `yaml:"schema_version,omitempty" json:"schemaVersion,omitempty"`
+	Name             string            `yaml:"name" json:"name"`
+	Enabled          *bool             `yaml:"enabled,omitempty" json:"enabled,omitempty"`                       // nil = true (default on); set false to pause
+	Integration      string            `yaml:"integration" json:"integration"`                                   // "linear", "shortcut", "github-issues", or "github"
+	Workspace        string            `yaml:"workspace,omitempty" json:"workspace,omitempty"`                   // matches integrations.<type>[].workspace
+	Team             string            `yaml:"team,omitempty" json:"team,omitempty"`                             // Linear team key (e.g. "ELA")
+	TriggerStatus    string            `yaml:"trigger_status,omitempty" json:"trigger_status,omitempty"`         // entering this status → create claw
+	WorkingStatus    string            `yaml:"working_status,omitempty" json:"working_status,omitempty"`         // claw moves issue here when it starts working
+	FinishedStatus   string            `yaml:"finished_status,omitempty" json:"finished_status,omitempty"`       // claw moves issue here when it finishes working
+	DoneStatus       string            `yaml:"done_status,omitempty" json:"done_status,omitempty"`               // claw moves issue here when done (PR merged)
+	AgentError       *AgentErrorConfig `yaml:"agent_error,omitempty" json:"agent_error,omitempty"`               // tracker update policy when the agent errors
+	TerminateOnLeave bool              `yaml:"terminate_on_leave,omitempty" json:"terminate_on_leave,omitempty"` // leaving trigger_status → kill claw
+	Template         string            `yaml:"template" json:"template"`                                         // template name (must be pushed to hub)
+	Provider         string            `yaml:"provider,omitempty" json:"provider,omitempty"`                     // override the default provider for this factory
+	NamePattern      string            `yaml:"name_pattern,omitempty" json:"name_pattern,omitempty"`             // claw name pattern, e.g. "{issue_id}"
+	WebhookSecret    string            `yaml:"webhook_secret,omitempty" json:"webhook_secret,omitempty"`         // HMAC-SHA256 secret for validating webhooks
+	Tags             []string          `yaml:"tags,omitempty" json:"tags,omitempty"`                             // tags applied to created claws
+	Color            string            `yaml:"color,omitempty" json:"color,omitempty"`                           // color applied to created claws
+	RunKind          string            `yaml:"run_kind,omitempty" json:"run_kind,omitempty"`                     // analytics run kind: "code_task" or "pr_task"
+	AnalyticsEnabled *bool             `yaml:"analytics_enabled,omitempty" json:"analytics_enabled,omitempty"`   // nil = infer from integration
+	RequiresPR       *bool             `yaml:"requires_pr,omitempty" json:"requires_pr,omitempty"`               // nil = infer from analytics eligibility
 	// Labels: all must be present on the issue to trigger (AND)
 	Labels []string `yaml:"labels,omitempty" json:"labels,omitempty"`
 	// AssignedTo filter: "@user", "!@user" (exclude), "any", "none"

--- a/pkg/types/workspace.go
+++ b/pkg/types/workspace.go
@@ -32,6 +32,7 @@ type WorkflowConfig struct {
 	TriggerStatus       string            `yaml:"trigger_status,omitempty" json:"trigger_status,omitempty"`
 	WorkingStatus       string            `yaml:"working_status,omitempty" json:"working_status,omitempty"`
 	FinishedStatus      string            `yaml:"finished_status,omitempty" json:"finished_status,omitempty"`
+	AgentError          *AgentErrorConfig `yaml:"agent_error,omitempty" json:"agent_error,omitempty"`
 	TerminateOnLeave    bool              `yaml:"terminate_on_leave,omitempty" json:"terminate_on_leave,omitempty"`
 	Provider            string            `yaml:"provider,omitempty" json:"provider,omitempty"`
 	NamePattern         string            `yaml:"name_pattern,omitempty" json:"name_pattern,omitempty"`
@@ -53,6 +54,15 @@ type WorkflowConfig struct {
 	Trigger             *WorkflowTrigger  `yaml:"trigger,omitempty" json:"trigger,omitempty"`
 	Stages              []WorkflowStage   `yaml:"stages,omitempty" json:"stages,omitempty"`
 	PipelineYAML        string            `yaml:"pipeline_yaml,omitempty" json:"pipelineYAML,omitempty"`
+}
+
+// AgentErrorConfig customizes issue-tracker updates when an agent stops with
+// an unrecoverable error.
+type AgentErrorConfig struct {
+	Enabled    *bool  `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+	Marker     string `yaml:"marker,omitempty" json:"marker,omitempty"`
+	Comment    string `yaml:"comment,omitempty" json:"comment,omitempty"`
+	ReassignTo string `yaml:"reassign_to,omitempty" json:"reassign_to,omitempty"`
 }
 
 // WorkflowVolume declares a hub-managed artifact-backed directory attached to


### PR DESCRIPTION
## Summary

- add a hub-level agent-error policy path invoked from `stopAgentWithReason`
- persist issue tracker owner snapshots for GitHub issue claws
- handle GitHub issue agent errors by adding `agent-error`, commenting with the sanitized reason and original owner, and conservatively reassigning when safe
- add workflow/factory `agent_error` override config fields

## Notes

The design spec document is intentionally not included in this branch. This PR only contains implementation and tests.

## Validation

- `go test ./...`
