### PR TITLE
Report workflow agent failures

### DIFF
--- a/.depot/workflows/e2e.yml
+++ b/.depot/workflows/e2e.yml
@@ -192,8 +192,17 @@ jobs:
           printf 'version: "3"\nagent:\n  web_addr: "%s"\n' "$NGROK_API_ADDR" > ngrok.yml
           ngrok http 8080 --url "https://$NGROK_HOST" --authtoken "$NGROK_AUTHTOKEN" --config ngrok.yml --log stdout > ngrok.log 2>&1 &
           echo "$!" > ngrok.pid
-          for i in $(seq 1 30); do
-            url="$(curl -fsS "http://$NGROK_API_ADDR/api/tunnels" | python3 -c 'import json,sys; data=json.load(sys.stdin); print(next((t["public_url"] for t in data.get("tunnels", []) if t.get("proto") == "https"), ""))' 2>/dev/null || true)"
+          for i in $(seq 1 120); do
+            if ! kill -0 "$(cat ngrok.pid)" >/dev/null 2>&1; then
+              echo "ngrok exited before the local API became ready"
+              cat ngrok.log
+              exit 1
+            fi
+            if ! curl -fsS --connect-timeout 2 --max-time 5 "http://$NGROK_API_ADDR/api/tunnels" > ngrok-tunnels.json 2>/dev/null; then
+              sleep 1
+              continue
+            fi
+            url="$(python3 -c 'import json,sys; data=json.load(sys.stdin); print(next((t["public_url"] for t in data.get("tunnels", []) if t.get("proto") == "https"), ""))' < ngrok-tunnels.json 2>/dev/null || true)"
             if [ -n "$url" ]; then
               case "$url" in
                 *://elasticclaw.ngrok.app*)
@@ -206,6 +215,7 @@ jobs:
             fi
             sleep 1
           done
+          echo "ngrok tunnel did not become ready"
           cat ngrok.log
           exit 1
 
@@ -235,6 +245,7 @@ jobs:
             ngrok.log
             ngrok.pid
             ngrok.yml
+            ngrok-tunnels.json
             ngrok-domain.json
             ngrok-domain-id
             e2e-daytona-sandbox-ids

--- a/Makefile
+++ b/Makefile
@@ -110,9 +110,10 @@ e2e-run: build-dev build-bridge-linux
 	echo "Starting ngrok tunnel https://$$NGROK_HOST for localhost:$$HUB_PORT"; \
 	ngrok http "$$HUB_PORT" --url "https://$$NGROK_HOST" --authtoken "$$NGROK_AUTHTOKEN" --config "$$NGROK_CONFIG" --log stdout > "$$NGROK_LOG" 2>&1 & \
 	NGROK_PID="$$!"; \
-	echo "Waiting for ngrok tunnel on localhost:$$HUB_PORT..."; \
-	for i in $$(seq 1 30); do \
-		ELASTICCLAW_E2E_PUBLIC_URL="$$(curl -fsS "http://$$NGROK_API_ADDR/api/tunnels" 2>/dev/null | python3 -c 'import json,sys; data=json.load(sys.stdin); print(next((t["public_url"] for t in data.get("tunnels", []) if t.get("proto") == "https"), ""))' 2>/dev/null || true)"; \
+	echo "Waiting for ngrok tunnel https://$$NGROK_HOST on localhost:$$HUB_PORT..."; \
+	for i in $$(seq 1 90); do \
+		if ! kill -0 "$$NGROK_PID" >/dev/null 2>&1; then cat "$$NGROK_LOG"; echo "ngrok exited before tunnel was ready"; exit 1; fi; \
+		ELASTICCLAW_E2E_PUBLIC_URL="$$(curl -fsS "http://$$NGROK_API_ADDR/api/tunnels" 2>/dev/null | python3 -c 'import json,sys; data=json.load(sys.stdin); want="https://" + sys.argv[1]; print(next((t["public_url"] for t in data.get("tunnels", []) if t.get("proto") == "https" and t.get("public_url") == want), ""))' "$$NGROK_HOST" 2>/dev/null || true)"; \
 		if [ -n "$$ELASTICCLAW_E2E_PUBLIC_URL" ]; then \
 			case "$$ELASTICCLAW_E2E_PUBLIC_URL" in *://elasticclaw.ngrok.app*) echo "Refusing shared ngrok domain: $$ELASTICCLAW_E2E_PUBLIC_URL"; exit 1;; esac; \
 			echo "ngrok: $$ELASTICCLAW_E2E_PUBLIC_URL"; \

--- a/pkg/hub/agent_failure_feedback.go
+++ b/pkg/hub/agent_failure_feedback.go
@@ -31,6 +31,10 @@ type agentFailureFeedback struct {
 	ClawID           string
 }
 
+type linearGraphQLError struct {
+	Message string `json:"message"`
+}
+
 func (s *Server) handleAgentFailureFeedback(feedback agentFailureFeedback, token string) {
 	if feedback.Failure.UserMessage == "" {
 		feedback.Failure = classifyAgentFailure(feedback.Failure.SafeDetail)
@@ -90,21 +94,22 @@ func (s *Server) triggerActorForClaw(clawID string) triggerActor {
 }
 
 func buildAgentFailureFeedbackComment(feedback agentFailureFeedback) string {
-	actor := feedback.TriggerActor.Login
-	if actor != "" {
-		actor = "@" + actor
+	var actorPrefix string
+	if feedback.TriggerActor.Login != "" {
+		actorPrefix = "@" + feedback.TriggerActor.Login + " "
 	} else if feedback.TriggerActor.Name != "" {
-		actor = feedback.TriggerActor.Name
+		actor := feedback.TriggerActor.Name
 		if feedback.TriggerActor.URL != "" {
 			actor = fmt.Sprintf("[%s](%s)", actor, feedback.TriggerActor.URL)
 		}
-	} else {
-		actor = "ElasticClaw"
+		actorPrefix = actor + " "
 	}
 
 	var b strings.Builder
-	b.WriteString(fmt.Sprintf("%s ElasticClaw could not finish this implementation.\n\n", actor))
-	b.WriteString("The agent hit an error while preparing or running the workspace, so no reliable code change was completed. I marked this issue for review and assigned it back to you so you can decide whether to retry or update the setup.\n\n")
+	b.WriteString(fmt.Sprintf("%sElasticClaw could not finish this implementation.\n\n", actorPrefix))
+	b.WriteString("The agent hit an error while preparing or running the workspace, so no reliable code change was completed. ")
+	b.WriteString(agentFailureFeedbackActionText(feedback))
+	b.WriteString("\n\n")
 	b.WriteString(fmt.Sprintf("Status code: %d\n", feedback.Failure.StatusCode))
 	if feedback.ClawID != "" {
 		b.WriteString(fmt.Sprintf("Agent run: %s\n", feedback.ClawID))
@@ -114,6 +119,32 @@ func buildAgentFailureFeedbackComment(feedback agentFailureFeedback) string {
 	b.WriteString("\n\nNext step:\n")
 	b.WriteString(feedback.Failure.NextStep)
 	return clampFailureComment(b.String())
+}
+
+func agentFailureFeedbackActionText(feedback agentFailureFeedback) string {
+	canMark := strings.TrimSpace(feedback.AgentStatusError) != ""
+	canAssign := canAssignFailureFeedback(feedback)
+	switch {
+	case canMark && canAssign:
+		return "I marked this issue for review and assigned it back to you so you can decide whether to retry or update the setup."
+	case canMark:
+		return "I marked this issue for review so the workflow setup can be checked before retrying."
+	case canAssign:
+		return "I assigned this issue back to you so you can decide whether to retry or update the setup."
+	default:
+		return "Please review the workflow setup before retrying."
+	}
+}
+
+func canAssignFailureFeedback(feedback agentFailureFeedback) bool {
+	switch feedback.Integration {
+	case "github-issues":
+		return feedback.TriggerActor.Login != ""
+	case "linear":
+		return feedback.TriggerActor.ID != "" && strings.EqualFold(feedback.TriggerActor.Type, "user")
+	default:
+		return false
+	}
 }
 
 func commentGitHubIssueWithBase(base, token, repo string, issueNumber int, body string) error {
@@ -183,8 +214,12 @@ func assignLinearIssueWithBase(baseURL, token, issueIdentifier, assigneeID strin
 				ID string `json:"id"`
 			} `json:"issue"`
 		} `json:"data"`
+		Errors []linearGraphQLError `json:"errors"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return err
+	}
+	if err := linearGraphQLErrorsError(result.Errors); err != nil {
 		return err
 	}
 	if result.Data.Issue.ID == "" {
@@ -210,9 +245,37 @@ func assignLinearIssueWithBase(baseURL, token, issueIdentifier, assigneeID strin
 		return err
 	}
 	defer resp2.Body.Close()
+	body, _ := io.ReadAll(resp2.Body)
 	if resp2.StatusCode >= 400 {
-		body, _ := io.ReadAll(resp2.Body)
 		return fmt.Errorf("Linear API error %d: %s", resp2.StatusCode, string(body))
 	}
+	var mutationResult struct {
+		Data struct {
+			IssueUpdate struct {
+				Success bool `json:"success"`
+			} `json:"issueUpdate"`
+		} `json:"data"`
+		Errors []linearGraphQLError `json:"errors"`
+	}
+	if err := json.Unmarshal(body, &mutationResult); err != nil {
+		return err
+	}
+	if err := linearGraphQLErrorsError(mutationResult.Errors); err != nil {
+		return err
+	}
+	if !mutationResult.Data.IssueUpdate.Success {
+		return fmt.Errorf("issueUpdate returned success=false")
+	}
 	return nil
+}
+
+func linearGraphQLErrorsError(errs []linearGraphQLError) error {
+	if len(errs) == 0 {
+		return nil
+	}
+	messages := make([]string, 0, len(errs))
+	for _, err := range errs {
+		messages = append(messages, err.Message)
+	}
+	return fmt.Errorf("GraphQL error: %s", strings.Join(messages, "; "))
 }

--- a/pkg/hub/agent_failure_feedback.go
+++ b/pkg/hub/agent_failure_feedback.go
@@ -1,0 +1,218 @@
+package hub
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+)
+
+type triggerActor struct {
+	ID    string `json:"id,omitempty"`
+	Login string `json:"login,omitempty"`
+	Name  string `json:"name,omitempty"`
+	Email string `json:"email,omitempty"`
+	URL   string `json:"url,omitempty"`
+	Type  string `json:"type,omitempty"`
+}
+
+type agentFailureFeedback struct {
+	Integration      string
+	IssueID          string
+	GitHubRepo       string
+	GitHubIssueNum   int
+	LinearIdentifier string
+	TriggerActor     triggerActor
+	AgentStatusError string
+	Failure          agentFailureMessage
+	ClawID           string
+}
+
+func (s *Server) handleAgentFailureFeedback(feedback agentFailureFeedback, token string) {
+	if feedback.Failure.UserMessage == "" {
+		feedback.Failure = classifyAgentFailure(feedback.Failure.SafeDetail)
+	}
+	comment := buildAgentFailureFeedbackComment(feedback)
+
+	switch feedback.Integration {
+	case "github-issues":
+		base := s.githubBaseURL
+		if base == "" {
+			base = "https://api.github.com"
+		}
+		if err := commentGitHubIssueWithBase(base, token, feedback.GitHubRepo, feedback.GitHubIssueNum, comment); err != nil {
+			log.Printf("[agent-failure-feedback] failed to comment GitHub issue %s#%d: %v", feedback.GitHubRepo, feedback.GitHubIssueNum, err)
+		}
+		if feedback.AgentStatusError != "" {
+			if err := githubAPIAddLabel(base, feedback.GitHubRepo, feedback.GitHubIssueNum, feedback.AgentStatusError, token); err != nil {
+				log.Printf("[agent-failure-feedback] failed to mark GitHub issue %s#%d with label %q: %v", feedback.GitHubRepo, feedback.GitHubIssueNum, feedback.AgentStatusError, err)
+			}
+		}
+		if feedback.TriggerActor.Login != "" {
+			if err := assignGitHubIssueWithBase(base, token, feedback.GitHubRepo, feedback.GitHubIssueNum, feedback.TriggerActor.Login); err != nil {
+				log.Printf("[agent-failure-feedback] failed to assign GitHub issue %s#%d to %q: %v", feedback.GitHubRepo, feedback.GitHubIssueNum, feedback.TriggerActor.Login, err)
+			}
+		}
+	case "linear":
+		if err := s.commentLinearIssue(token, feedback.LinearIdentifier, comment); err != nil {
+			log.Printf("[agent-failure-feedback] failed to comment Linear issue %s: %v", feedback.LinearIdentifier, err)
+		}
+		if feedback.AgentStatusError != "" {
+			if err := s.moveLinearIssueOnServer(token, feedback.LinearIdentifier, feedback.AgentStatusError); err != nil {
+				log.Printf("[agent-failure-feedback] failed to mark Linear issue %s with status %q: %v", feedback.LinearIdentifier, feedback.AgentStatusError, err)
+			}
+		}
+		if feedback.TriggerActor.ID != "" && strings.EqualFold(feedback.TriggerActor.Type, "user") {
+			if err := s.assignLinearIssue(token, feedback.LinearIdentifier, feedback.TriggerActor.ID); err != nil {
+				log.Printf("[agent-failure-feedback] failed to assign Linear issue %s to %q: %v", feedback.LinearIdentifier, feedback.TriggerActor.ID, err)
+			}
+		}
+	}
+}
+
+func (s *Server) triggerActorForClaw(clawID string) triggerActor {
+	var actorJSON string
+	if err := s.db.QueryRow(`SELECT COALESCE(trigger_actor_json,'') FROM claws WHERE id=?`, clawID).Scan(&actorJSON); err != nil {
+		return triggerActor{}
+	}
+	if strings.TrimSpace(actorJSON) == "" {
+		return triggerActor{}
+	}
+	var actor triggerActor
+	if err := json.Unmarshal([]byte(actorJSON), &actor); err != nil {
+		log.Printf("[agent-failure-feedback] failed to parse trigger actor for claw %s: %v", shortID(clawID), err)
+		return triggerActor{}
+	}
+	return actor
+}
+
+func buildAgentFailureFeedbackComment(feedback agentFailureFeedback) string {
+	actor := feedback.TriggerActor.Login
+	if actor != "" {
+		actor = "@" + actor
+	} else if feedback.TriggerActor.Name != "" {
+		actor = feedback.TriggerActor.Name
+		if feedback.TriggerActor.URL != "" {
+			actor = fmt.Sprintf("[%s](%s)", actor, feedback.TriggerActor.URL)
+		}
+	} else {
+		actor = "ElasticClaw"
+	}
+
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("%s ElasticClaw could not finish this implementation.\n\n", actor))
+	b.WriteString("The agent hit an error while preparing or running the workspace, so no reliable code change was completed. I marked this issue for review and assigned it back to you so you can decide whether to retry or update the setup.\n\n")
+	b.WriteString(fmt.Sprintf("Status code: %d\n", feedback.Failure.StatusCode))
+	if feedback.ClawID != "" {
+		b.WriteString(fmt.Sprintf("Agent run: %s\n", feedback.ClawID))
+	}
+	b.WriteString("\nWhat happened:\n")
+	b.WriteString(feedback.Failure.UserMessage)
+	b.WriteString("\n\nNext step:\n")
+	b.WriteString(feedback.Failure.NextStep)
+	return clampFailureComment(b.String())
+}
+
+func commentGitHubIssueWithBase(base, token, repo string, issueNumber int, body string) error {
+	if base == "" {
+		base = "https://api.github.com"
+	}
+	commentBody := map[string]interface{}{"body": body}
+	b, _ := json.Marshal(commentBody)
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/repos/%s/issues/%d/comments", base, repo, issueNumber), bytes.NewReader(b))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("github API error %d: %s", resp.StatusCode, string(respBody))
+	}
+	return nil
+}
+
+func assignGitHubIssueWithBase(base, token, repo string, issueNumber int, login string) error {
+	_, err := githubAPIPostWithBase(base, fmt.Sprintf("repos/%s/issues/%d", repo, issueNumber), token, http.MethodPatch, map[string][]string{"assignees": []string{login}})
+	return err
+}
+
+func (s *Server) assignLinearIssue(token, issueIdentifier, assigneeID string) error {
+	base := s.linearBaseURL
+	if base == "" {
+		base = "https://api.linear.app"
+	}
+	return assignLinearIssueWithBase(base, token, issueIdentifier, assigneeID)
+}
+
+func assignLinearIssueWithBase(baseURL, token, issueIdentifier, assigneeID string) error {
+	queryBody := map[string]interface{}{
+		"query":     "query($id: String!) { issue(id: $id) { id } }",
+		"variables": map[string]string{"id": issueIdentifier},
+	}
+	queryJSON, _ := json.Marshal(queryBody)
+	req, err := http.NewRequest(http.MethodPost, baseURL+"/graphql", strings.NewReader(string(queryJSON)))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("Linear API error %d: %s", resp.StatusCode, string(body))
+	}
+	var result struct {
+		Data struct {
+			Issue struct {
+				ID string `json:"id"`
+			} `json:"issue"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return err
+	}
+	if result.Data.Issue.ID == "" {
+		return fmt.Errorf("issue %s not found", issueIdentifier)
+	}
+
+	mutationBody := map[string]interface{}{
+		"query": "mutation($id: String!, $assigneeId: String!) { issueUpdate(id: $id, input: { assigneeId: $assigneeId }) { success } }",
+		"variables": map[string]string{
+			"id":         result.Data.Issue.ID,
+			"assigneeId": assigneeID,
+		},
+	}
+	mutationJSON, _ := json.Marshal(mutationBody)
+	req2, err := http.NewRequest(http.MethodPost, baseURL+"/graphql", strings.NewReader(string(mutationJSON)))
+	if err != nil {
+		return err
+	}
+	req2.Header.Set("Authorization", token)
+	req2.Header.Set("Content-Type", "application/json")
+	resp2, err := http.DefaultClient.Do(req2)
+	if err != nil {
+		return err
+	}
+	defer resp2.Body.Close()
+	if resp2.StatusCode >= 400 {
+		body, _ := io.ReadAll(resp2.Body)
+		return fmt.Errorf("Linear API error %d: %s", resp2.StatusCode, string(body))
+	}
+	return nil
+}

--- a/pkg/hub/agent_failure_feedback.go
+++ b/pkg/hub/agent_failure_feedback.go
@@ -8,7 +8,10 @@ import (
 	"log"
 	"net/http"
 	"strings"
+	"time"
 )
+
+var issueTrackerHTTPClient = &http.Client{Timeout: 30 * time.Second}
 
 type triggerActor struct {
 	ID    string `json:"id,omitempty"`
@@ -55,7 +58,7 @@ func (s *Server) handleAgentFailureFeedback(feedback agentFailureFeedback, token
 				log.Printf("[agent-failure-feedback] failed to mark GitHub issue %s#%d with label %q: %v", feedback.GitHubRepo, feedback.GitHubIssueNum, feedback.AgentStatusError, err)
 			}
 		}
-		if feedback.TriggerActor.Login != "" {
+		if canAssignFailureFeedback(feedback) {
 			if err := assignGitHubIssueWithBase(base, token, feedback.GitHubRepo, feedback.GitHubIssueNum, feedback.TriggerActor.Login); err != nil {
 				log.Printf("[agent-failure-feedback] failed to assign GitHub issue %s#%d to %q: %v", feedback.GitHubRepo, feedback.GitHubIssueNum, feedback.TriggerActor.Login, err)
 			}
@@ -69,7 +72,7 @@ func (s *Server) handleAgentFailureFeedback(feedback agentFailureFeedback, token
 				log.Printf("[agent-failure-feedback] failed to mark Linear issue %s with status %q: %v", feedback.LinearIdentifier, feedback.AgentStatusError, err)
 			}
 		}
-		if feedback.TriggerActor.ID != "" && strings.EqualFold(feedback.TriggerActor.Type, "user") {
+		if canAssignFailureFeedback(feedback) {
 			if err := s.assignLinearIssue(token, feedback.LinearIdentifier, feedback.TriggerActor.ID); err != nil {
 				log.Printf("[agent-failure-feedback] failed to assign Linear issue %s to %q: %v", feedback.LinearIdentifier, feedback.TriggerActor.ID, err)
 			}
@@ -139,7 +142,7 @@ func agentFailureFeedbackActionText(feedback agentFailureFeedback) string {
 func canAssignFailureFeedback(feedback agentFailureFeedback) bool {
 	switch feedback.Integration {
 	case "github-issues":
-		return feedback.TriggerActor.Login != ""
+		return feedback.TriggerActor.Login != "" && strings.EqualFold(feedback.TriggerActor.Type, "user")
 	case "linear":
 		return feedback.TriggerActor.ID != "" && strings.EqualFold(feedback.TriggerActor.Type, "user")
 	default:
@@ -162,7 +165,7 @@ func commentGitHubIssueWithBase(base, token, repo string, issueNumber int, body 
 	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := issueTrackerHTTPClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -199,7 +202,7 @@ func assignLinearIssueWithBase(baseURL, token, issueIdentifier, assigneeID strin
 	}
 	req.Header.Set("Authorization", token)
 	req.Header.Set("Content-Type", "application/json")
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := issueTrackerHTTPClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -240,7 +243,7 @@ func assignLinearIssueWithBase(baseURL, token, issueIdentifier, assigneeID strin
 	}
 	req2.Header.Set("Authorization", token)
 	req2.Header.Set("Content-Type", "application/json")
-	resp2, err := http.DefaultClient.Do(req2)
+	resp2, err := issueTrackerHTTPClient.Do(req2)
 	if err != nil {
 		return err
 	}

--- a/pkg/hub/agent_failure_feedback_test.go
+++ b/pkg/hub/agent_failure_feedback_test.go
@@ -74,6 +74,103 @@ func TestStopAgentWithReasonWorkflowGitHubFailureFeedbackUsesPersistedTriggerAct
 	waitForMockGitHubIssueLabel(t, ghi, "testorg/testrepo", 42, "agent-error")
 }
 
+func TestBuildAgentFailureFeedbackCommentWithoutTriggerActor(t *testing.T) {
+	comment := buildAgentFailureFeedbackComment(agentFailureFeedback{
+		Integration: "github-issues",
+		Failure:     classifyAgentFailure("Bootstrap failed: HTTP 502"),
+	})
+	if strings.Contains(comment, "ElasticClaw ElasticClaw") {
+		t.Fatalf("comment duplicated product name:\n%s", comment)
+	}
+	if strings.Contains(comment, "assigned it back to you") {
+		t.Fatalf("comment claimed reassignment without an actor:\n%s", comment)
+	}
+	if !strings.Contains(comment, "Please review the workflow setup before retrying.") {
+		t.Fatalf("comment missing no-actor action text:\n%s", comment)
+	}
+}
+
+func TestCommentWorkflowAgentStopToTrackerHandlesMissingTriggerConfig(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	ghi := newStopFeedbackGitHubMock(t)
+
+	cfg := &types.HubConfig{ClawToken: "test-claw-token"}
+	s, _ := NewTestServerWithConfig(t, cfg, ghi.URL, "", "")
+	SaveWorkspaceForTest(t,
+		&types.WorkspaceConfig{
+			SchemaVersion: "v1",
+			Name:          "workspace-a",
+			Files:         map[string]string{"elasticclaw-config.yaml": "schema_version: v1\nname: workspace-a\n"},
+		},
+		nil,
+	)
+	SaveWorkspaceIssueTrackerForTest(t, "workspace-a", "github-issues", "default", "test-github-issues-token", "")
+
+	s.commentWorkflowAgentStopToTracker("claw-missing-trigger", pipelineContext{
+		Workspace: &types.WorkspaceConfig{Name: "workspace-a"},
+		Workflow:  &types.WorkflowConfig{Name: "test-workflow", Integration: "github-issues"},
+		IssueID:   "testorg/testrepo/42",
+	}, "Bootstrap failed: HTTP 502")
+
+	comment := waitForMockGitHubIssueComment(t, ghi, "testorg/testrepo", 42)
+	if !strings.Contains(comment, "ElasticClaw could not finish this implementation.") {
+		t.Fatalf("comment missing failure text:\n%s", comment)
+	}
+}
+
+func TestAssignLinearIssueReportsGraphQLErrors(t *testing.T) {
+	srv := newAssignLinearIssueMock(t, func(w http.ResponseWriter) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"errors": []map[string]string{{"message": "permission denied"}},
+		})
+	})
+
+	err := assignLinearIssueWithBase(srv.URL, "test-token", "ELA-123", "user-123")
+	if err == nil || !strings.Contains(err.Error(), "GraphQL error: permission denied") {
+		t.Fatalf("assignLinearIssueWithBase error = %v, want GraphQL error", err)
+	}
+}
+
+func TestAssignLinearIssueReportsSuccessFalse(t *testing.T) {
+	srv := newAssignLinearIssueMock(t, func(w http.ResponseWriter) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": map[string]interface{}{
+				"issueUpdate": map[string]interface{}{"success": false},
+			},
+		})
+	})
+
+	err := assignLinearIssueWithBase(srv.URL, "test-token", "ELA-123", "user-123")
+	if err == nil || !strings.Contains(err.Error(), "issueUpdate returned success=false") {
+		t.Fatalf("assignLinearIssueWithBase error = %v, want success=false error", err)
+	}
+}
+
+func newAssignLinearIssueMock(t *testing.T, mutationResponse func(http.ResponseWriter)) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Query string `json:"query"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(req.Query, "issueUpdate") {
+			mutationResponse(w)
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": map[string]interface{}{
+				"issue": map[string]interface{}{"id": "issue-uuid-123"},
+			},
+		})
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
 type stopFeedbackGitHubMock struct {
 	*httptest.Server
 	mu       sync.Mutex
@@ -98,7 +195,10 @@ func newStopFeedbackGitHubMock(t *testing.T) *stopFeedbackGitHubMock {
 		}
 		repo := parts[0] + "/" + parts[1]
 		var number int
-		fmt.Sscanf(parts[3], "%d", &number)
+		if _, err := fmt.Sscanf(parts[3], "%d", &number); err != nil {
+			http.Error(w, "bad issue number", http.StatusBadRequest)
+			return
+		}
 		key := fmt.Sprintf("%s#%d", repo, number)
 		switch {
 		case r.Method == http.MethodGet && len(parts) == 4:

--- a/pkg/hub/agent_failure_feedback_test.go
+++ b/pkg/hub/agent_failure_feedback_test.go
@@ -1,0 +1,224 @@
+package hub
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func TestStopAgentWithReasonWorkflowGitHubFailureFeedbackUsesPersistedTriggerActor(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	ghi := newStopFeedbackGitHubMock(t)
+
+	cfg := &types.HubConfig{ClawToken: "test-claw-token"}
+	s, db := NewTestServerWithConfig(t, cfg, ghi.URL, "", "")
+	SaveWorkspaceForTest(t,
+		&types.WorkspaceConfig{
+			SchemaVersion: "v1",
+			Name:          "workspace-a",
+			Files: map[string]string{
+				"elasticclaw-config.yaml": "schema_version: v1\nname: workspace-a\nprovider: noop\n",
+				"CONTEXT.md":              "Test context\n",
+			},
+		},
+		[]*types.WorkflowConfig{{
+			SchemaVersion: "v1",
+			Name:          "test-workflow",
+			Trigger: &types.WorkflowTrigger{
+				GitHubIssues: &types.GitHubIssuesWorkflowTrigger{
+					Event:            "issue_reopened",
+					Repositories:     []string{"testorg/testrepo"},
+					States:           []string{"open"},
+					AgentStatusError: "agent-error",
+				},
+			},
+			Stages: []types.WorkflowStage{{
+				ID:    "working",
+				Entry: true,
+			}},
+		}},
+	)
+	SaveWorkspaceIssueTrackerForTest(t, "workspace-a", "github-issues", "default", "test-github-issues-token", "")
+	ghi.setIssue("testorg/testrepo", 42)
+
+	_, err := db.Exec(`
+		INSERT INTO claws(id, tenant_id, name, template, provider, status, tags, github_issue_id, trigger_actor_json, created_at)
+		VALUES(?,?,?,?,?,?,?,?,?,datetime('now'))`,
+		"claw-github-feedback", "test-tenant-id", "testorg/testrepo/42", "workspace-a", "noop", "connected",
+		`["workspace:workspace-a","workflow:test-workflow"]`, "testorg/testrepo/42", `{"login":"alice","type":"User"}`,
+	)
+	if err != nil {
+		t.Fatalf("insert claw: %v", err)
+	}
+
+	s.stopAgentWithReason("claw-github-feedback", "Bootstrap failed: HTTP 502", true)
+
+	comment := waitForMockGitHubIssueComment(t, ghi, "testorg/testrepo", 42)
+	for _, want := range []string{
+		"@alice ElasticClaw could not finish this implementation.",
+		"Status code: 502",
+		"ElasticClaw started the workspace but could not finish preparing it.",
+	} {
+		if !strings.Contains(comment, want) {
+			t.Fatalf("comment missing %q:\n%s", want, comment)
+		}
+	}
+	waitForMockGitHubIssueAssignee(t, ghi, "testorg/testrepo", 42, "alice")
+	waitForMockGitHubIssueLabel(t, ghi, "testorg/testrepo", 42, "agent-error")
+}
+
+type stopFeedbackGitHubMock struct {
+	*httptest.Server
+	mu       sync.Mutex
+	comments map[string][]string
+	labels   map[string][]string
+	assignee map[string]string
+}
+
+func newStopFeedbackGitHubMock(t *testing.T) *stopFeedbackGitHubMock {
+	t.Helper()
+	m := &stopFeedbackGitHubMock{
+		comments: map[string][]string{},
+		labels:   map[string][]string{},
+		assignee: map[string]string{},
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/", func(w http.ResponseWriter, r *http.Request) {
+		parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/repos/"), "/")
+		if len(parts) < 4 || parts[2] != "issues" {
+			http.NotFound(w, r)
+			return
+		}
+		repo := parts[0] + "/" + parts[1]
+		var number int
+		fmt.Sscanf(parts[3], "%d", &number)
+		key := fmt.Sprintf("%s#%d", repo, number)
+		switch {
+		case r.Method == http.MethodGet && len(parts) == 4:
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"number":   number,
+				"title":    "Test Issue",
+				"body":     "Body",
+				"html_url": fmt.Sprintf("https://github.com/%s/issues/%d", repo, number),
+				"state":    "open",
+				"labels":   []map[string]string{},
+				"user":     map[string]string{"login": "alice"},
+			})
+		case r.Method == http.MethodPost && len(parts) == 5 && parts[4] == "comments":
+			var req struct {
+				Body string `json:"body"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			m.mu.Lock()
+			m.comments[key] = append(m.comments[key], req.Body)
+			m.mu.Unlock()
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]interface{}{"body": req.Body})
+		case r.Method == http.MethodPost && len(parts) == 5 && parts[4] == "labels":
+			var req struct {
+				Labels []string `json:"labels"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			m.mu.Lock()
+			m.labels[key] = append(m.labels[key], req.Labels...)
+			m.mu.Unlock()
+			json.NewEncoder(w).Encode(req.Labels)
+		case r.Method == http.MethodPatch && len(parts) == 4:
+			var req struct {
+				Assignees []string `json:"assignees"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			m.mu.Lock()
+			if len(req.Assignees) > 0 {
+				m.assignee[key] = req.Assignees[0]
+			}
+			m.mu.Unlock()
+			json.NewEncoder(w).Encode(map[string]interface{}{"number": number})
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	m.Server = httptest.NewServer(mux)
+	t.Cleanup(m.Close)
+	return m
+}
+
+func (m *stopFeedbackGitHubMock) setIssue(_ string, _ int) {}
+
+func waitForMockGitHubIssueComment(t *testing.T, ghi *stopFeedbackGitHubMock, repo string, number int) string {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		comments := ghi.commentsFor(repo, number)
+		if len(comments) > 0 {
+			return comments[len(comments)-1]
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for GitHub issue comment")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func waitForMockGitHubIssueAssignee(t *testing.T, ghi *stopFeedbackGitHubMock, repo string, number int, want string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if got := ghi.assigneeFor(repo, number); got == want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("assignee = %q, want %q", ghi.assigneeFor(repo, number), want)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func waitForMockGitHubIssueLabel(t *testing.T, ghi *stopFeedbackGitHubMock, repo string, number int, want string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if containsMockString(ghi.labelsFor(repo, number), want) {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("labels = %v, want %q", ghi.labelsFor(repo, number), want)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func (m *stopFeedbackGitHubMock) commentsFor(repo string, number int) []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string(nil), m.comments[fmt.Sprintf("%s#%d", repo, number)]...)
+}
+
+func (m *stopFeedbackGitHubMock) labelsFor(repo string, number int) []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string(nil), m.labels[fmt.Sprintf("%s#%d", repo, number)]...)
+}
+
+func (m *stopFeedbackGitHubMock) assigneeFor(repo string, number int) string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.assignee[fmt.Sprintf("%s#%d", repo, number)]
+}
+
+func containsMockString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/hub/agent_failure_feedback_test.go
+++ b/pkg/hub/agent_failure_feedback_test.go
@@ -90,6 +90,21 @@ func TestBuildAgentFailureFeedbackCommentWithoutTriggerActor(t *testing.T) {
 	}
 }
 
+func TestBuildAgentFailureFeedbackCommentDoesNotClaimBotAssignment(t *testing.T) {
+	comment := buildAgentFailureFeedbackComment(agentFailureFeedback{
+		Integration:      "github-issues",
+		TriggerActor:     triggerActor{Login: "elasticclaw-app[bot]", Type: "Bot"},
+		AgentStatusError: "agent-error",
+		Failure:          classifyAgentFailure("Bootstrap failed: HTTP 502"),
+	})
+	if strings.Contains(comment, "assigned it back to you") || strings.Contains(comment, "assigned this issue back to you") {
+		t.Fatalf("comment claimed bot reassignment:\n%s", comment)
+	}
+	if !strings.Contains(comment, "I marked this issue for review") {
+		t.Fatalf("comment missing status-only action text:\n%s", comment)
+	}
+}
+
 func TestCommentWorkflowAgentStopToTrackerHandlesMissingTriggerConfig(t *testing.T) {
 	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
 	ghi := newStopFeedbackGitHubMock(t)

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -54,6 +54,7 @@ func migrate(db *sql.DB) error {
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN restored_from_checkpoint_id TEXT NOT NULL DEFAULT ''`)
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN task_run_id TEXT NOT NULL DEFAULT ''`)
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN workflow_volumes TEXT NOT NULL DEFAULT '[]'`)
+	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN trigger_actor_json TEXT NOT NULL DEFAULT ''`)
 	_, _ = db.Exec(`ALTER TABLE claw_prs ADD COLUMN last_comment_at TEXT NOT NULL DEFAULT ''`)
 	_, _ = db.Exec(`ALTER TABLE claw_prs ADD COLUMN pr_conditions_fired INTEGER NOT NULL DEFAULT 0`)
 	_, _ = db.Exec(`ALTER TABLE claw_prs ADD COLUMN last_review_comment_id INTEGER NOT NULL DEFAULT 0`)
@@ -206,7 +207,8 @@ func migrate(db *sql.DB) error {
 		restore_checkpoint_id TEXT NOT NULL DEFAULT '',
 		restored_from_checkpoint_id TEXT NOT NULL DEFAULT '',
 		task_run_id TEXT NOT NULL DEFAULT '',
-		workflow_volumes TEXT NOT NULL DEFAULT '[]'
+		workflow_volumes TEXT NOT NULL DEFAULT '[]',
+		trigger_actor_json TEXT NOT NULL DEFAULT ''
 	);
 
 

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -54,7 +54,7 @@ func migrate(db *sql.DB) error {
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN restored_from_checkpoint_id TEXT NOT NULL DEFAULT ''`)
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN task_run_id TEXT NOT NULL DEFAULT ''`)
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN workflow_volumes TEXT NOT NULL DEFAULT '[]'`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN trigger_actor_json TEXT NOT NULL DEFAULT ''`)
+	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN trigger_actor_json TEXT NOT NULL DEFAULT '{}'`)
 	_, _ = db.Exec(`ALTER TABLE claw_prs ADD COLUMN last_comment_at TEXT NOT NULL DEFAULT ''`)
 	_, _ = db.Exec(`ALTER TABLE claw_prs ADD COLUMN pr_conditions_fired INTEGER NOT NULL DEFAULT 0`)
 	_, _ = db.Exec(`ALTER TABLE claw_prs ADD COLUMN last_review_comment_id INTEGER NOT NULL DEFAULT 0`)
@@ -208,7 +208,7 @@ func migrate(db *sql.DB) error {
 		restored_from_checkpoint_id TEXT NOT NULL DEFAULT '',
 		task_run_id TEXT NOT NULL DEFAULT '',
 		workflow_volumes TEXT NOT NULL DEFAULT '[]',
-		trigger_actor_json TEXT NOT NULL DEFAULT ''
+		trigger_actor_json TEXT NOT NULL DEFAULT '{}'
 	);
 
 

--- a/pkg/hub/db_test.go
+++ b/pkg/hub/db_test.go
@@ -1,0 +1,63 @@
+package hub
+
+import (
+	"database/sql"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestClawsTriggerActorJSONDefaultIsValidJSON(t *testing.T) {
+	t.Run("fresh schema", func(t *testing.T) {
+		db, err := openDB(filepath.Join(t.TempDir(), "hub.db"))
+		if err != nil {
+			t.Fatalf("open db: %v", err)
+		}
+		defer db.Close()
+
+		now := time.Now()
+		if _, err := db.Exec(`INSERT INTO tenants(id, name, token, claw_token, created_at) VALUES(?,?,?,?,?)`, "tenant", "Tenant", "token", "claw-token", now); err != nil {
+			t.Fatalf("insert tenant: %v", err)
+		}
+		if _, err := db.Exec(`INSERT INTO claws(id, tenant_id, name, template, provider, status, created_at) VALUES(?,?,?,?,?,?,?)`, "claw-default", "tenant", "Claw", "", "docker", "provisioning", now); err != nil {
+			t.Fatalf("insert claw: %v", err)
+		}
+
+		assertClawTriggerActorJSONIsValid(t, db, "claw-default")
+	})
+
+	t.Run("migrated schema", func(t *testing.T) {
+		db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "hub.db")+"?_time_format=sqlite&_pragma=foreign_keys(on)")
+		if err != nil {
+			t.Fatalf("open db: %v", err)
+		}
+		defer db.Close()
+
+		if _, err := db.Exec(`CREATE TABLE claws (id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL DEFAULT '')`); err != nil {
+			t.Fatalf("create old claws table: %v", err)
+		}
+		if err := migrate(db); err != nil {
+			t.Fatalf("migrate old claws table: %v", err)
+		}
+		if _, err := db.Exec(`INSERT INTO claws(id) VALUES(?)`, "claw-default"); err != nil {
+			t.Fatalf("insert migrated claw: %v", err)
+		}
+
+		assertClawTriggerActorJSONIsValid(t, db, "claw-default")
+	})
+}
+
+func assertClawTriggerActorJSONIsValid(t *testing.T, db *sql.DB, clawID string) {
+	t.Helper()
+
+	var raw string
+	if err := db.QueryRow(`SELECT trigger_actor_json FROM claws WHERE id=?`, clawID).Scan(&raw); err != nil {
+		t.Fatalf("select trigger_actor_json: %v", err)
+	}
+
+	var actor map[string]any
+	if err := json.Unmarshal([]byte(raw), &actor); err != nil {
+		t.Fatalf("expected trigger_actor_json default to be valid JSON, got %q: %v", raw, err)
+	}
+}

--- a/pkg/hub/db_test.go
+++ b/pkg/hub/db_test.go
@@ -16,13 +16,10 @@ func TestClawsTriggerActorJSONDefaultIsValidJSON(t *testing.T) {
 		}
 		defer db.Close()
 
-		now := time.Now()
-		if _, err := db.Exec(`INSERT INTO tenants(id, name, token, claw_token, created_at) VALUES(?,?,?,?,?)`, "tenant", "Tenant", "token", "claw-token", now); err != nil {
+		if _, err := db.Exec(`INSERT INTO tenants(id, name, token, claw_token, created_at) VALUES(?,?,?,?,?)`, "tenant", "Tenant", "token", "claw-token", time.Now()); err != nil {
 			t.Fatalf("insert tenant: %v", err)
 		}
-		if _, err := db.Exec(`INSERT INTO claws(id, tenant_id, name, template, provider, status, created_at) VALUES(?,?,?,?,?,?,?)`, "claw-default", "tenant", "Claw", "", "docker", "provisioning", now); err != nil {
-			t.Fatalf("insert claw: %v", err)
-		}
+		insertClawUsingTriggerActorDefault(t, db, "claw-default")
 
 		assertClawTriggerActorJSONIsValid(t, db, "claw-default")
 	})
@@ -34,18 +31,33 @@ func TestClawsTriggerActorJSONDefaultIsValidJSON(t *testing.T) {
 		}
 		defer db.Close()
 
-		if _, err := db.Exec(`CREATE TABLE claws (id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL DEFAULT '')`); err != nil {
+		if _, err := db.Exec(`
+			CREATE TABLE claws (
+				id TEXT PRIMARY KEY,
+				tenant_id TEXT NOT NULL,
+				name TEXT NOT NULL,
+				template TEXT NOT NULL DEFAULT '',
+				provider TEXT NOT NULL DEFAULT '',
+				status TEXT NOT NULL DEFAULT 'offline',
+				created_at DATETIME NOT NULL
+			)`); err != nil {
 			t.Fatalf("create old claws table: %v", err)
 		}
 		if err := migrate(db); err != nil {
 			t.Fatalf("migrate old claws table: %v", err)
 		}
-		if _, err := db.Exec(`INSERT INTO claws(id) VALUES(?)`, "claw-default"); err != nil {
-			t.Fatalf("insert migrated claw: %v", err)
-		}
+		insertClawUsingTriggerActorDefault(t, db, "claw-default")
 
 		assertClawTriggerActorJSONIsValid(t, db, "claw-default")
 	})
+}
+
+func insertClawUsingTriggerActorDefault(t *testing.T, db *sql.DB, clawID string) {
+	t.Helper()
+
+	if _, err := db.Exec(`INSERT INTO claws(id, tenant_id, name, template, provider, status, created_at) VALUES(?,?,?,?,?,?,?)`, clawID, "tenant", "Claw", "", "docker", "provisioning", time.Now()); err != nil {
+		t.Fatalf("insert claw: %v", err)
+	}
 }
 
 func assertClawTriggerActorJSONIsValid(t *testing.T, db *sql.DB, clawID string) {

--- a/pkg/hub/factorytest/mock_github_issues.go
+++ b/pkg/hub/factorytest/mock_github_issues.go
@@ -33,7 +33,8 @@ type IssueCommentState struct {
 }
 
 // MockGitHubIssues is a REST-style mock for the GitHub Issues API and webhook
-// delivery.
+// delivery. It handles issue reads/listing, comments, labels, issue patching,
+// issue events, and issue comments for the workflow/factory test paths.
 type MockGitHubIssues struct {
 	*httptest.Server
 	mu            sync.Mutex
@@ -54,7 +55,7 @@ func NewMockGitHubIssues(t *testing.T) *MockGitHubIssues {
 	}
 	mux := http.NewServeMux()
 
-	// /repos/:owner/:repo/issues endpoints.
+	// /repos/:owner/:repo/issues endpoints used by the workflow/factory tests.
 	mux.HandleFunc("/repos/", func(w http.ResponseWriter, r *http.Request) {
 		path := strings.TrimPrefix(r.URL.Path, "/repos/")
 		parts := strings.Split(path, "/")

--- a/pkg/hub/factorytest/mock_github_issues.go
+++ b/pkg/hub/factorytest/mock_github_issues.go
@@ -83,6 +83,11 @@ func NewMockGitHubIssues(t *testing.T) *MockGitHubIssues {
 				_ = json.NewDecoder(r.Body).Decode(&req)
 				key := fmt.Sprintf("%s/%s#%d", owner, repo, num)
 				m.mu.Lock()
+				if _, ok := m.Issues[key]; !ok {
+					m.mu.Unlock()
+					http.NotFound(w, r)
+					return
+				}
 				id := int64(len(m.IssueComments[key]) + 1)
 				m.IssueComments[key] = append(m.IssueComments[key], IssueCommentState{
 					ID:        id,
@@ -105,7 +110,12 @@ func NewMockGitHubIssues(t *testing.T) *MockGitHubIssues {
 				_ = json.NewDecoder(r.Body).Decode(&req)
 				key := fmt.Sprintf("%s/%s#%d", owner, repo, num)
 				m.mu.Lock()
-				issue := m.Issues[key]
+				issue, ok := m.Issues[key]
+				if !ok {
+					m.mu.Unlock()
+					http.NotFound(w, r)
+					return
+				}
 				for _, label := range req.Labels {
 					if !stringSliceContains(issue.Labels, label) {
 						issue.Labels = append(issue.Labels, label)
@@ -128,7 +138,12 @@ func NewMockGitHubIssues(t *testing.T) *MockGitHubIssues {
 				_ = json.NewDecoder(r.Body).Decode(&req)
 				key := fmt.Sprintf("%s/%s#%d", owner, repo, num)
 				m.mu.Lock()
-				issue := m.Issues[key]
+				issue, ok := m.Issues[key]
+				if !ok {
+					m.mu.Unlock()
+					http.NotFound(w, r)
+					return
+				}
 				if len(req.Assignees) > 0 {
 					issue.Assignee = req.Assignees[0]
 				}

--- a/pkg/hub/factorytest/mock_github_issues.go
+++ b/pkg/hub/factorytest/mock_github_issues.go
@@ -33,12 +33,7 @@ type IssueCommentState struct {
 }
 
 // MockGitHubIssues is a REST-style mock for the GitHub Issues API and webhook
-// delivery. It currently handles:
-//   - GET /repos/{owner}/{repo}/issues?since=...&state=all&sort=updated&direction=desc
-//   - GET /repos/{owner}/{repo}/issues/{number}
-//
-// POST endpoints for comments/labels are not yet implemented (needed for
-// move_issue parity tests in a future phase).
+// delivery.
 type MockGitHubIssues struct {
 	*httptest.Server
 	mu            sync.Mutex
@@ -59,12 +54,8 @@ func NewMockGitHubIssues(t *testing.T) *MockGitHubIssues {
 	}
 	mux := http.NewServeMux()
 
-	// GET /repos/:owner/:repo/issues — polling endpoint
+	// /repos/:owner/:repo/issues endpoints.
 	mux.HandleFunc("/repos/", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-			return
-		}
 		path := strings.TrimPrefix(r.URL.Path, "/repos/")
 		parts := strings.Split(path, "/")
 		if len(parts) < 2 {
@@ -82,6 +73,76 @@ func NewMockGitHubIssues(t *testing.T) *MockGitHubIssues {
 		// issues endpoint
 		if strings.HasPrefix(rest, "issues") {
 			parts2 := strings.Split(rest, "/")
+			if r.Method == http.MethodPost && len(parts2) == 3 && parts2[0] == "issues" && parts2[2] == "comments" {
+				var num int
+				fmt.Sscanf(parts2[1], "%d", &num)
+				var req struct {
+					Body string `json:"body"`
+				}
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				key := fmt.Sprintf("%s/%s#%d", owner, repo, num)
+				m.mu.Lock()
+				id := int64(len(m.IssueComments[key]) + 1)
+				m.IssueComments[key] = append(m.IssueComments[key], IssueCommentState{
+					ID:        id,
+					Body:      req.Body,
+					User:      "elasticclaw-bot",
+					CreatedAt: time.Now().UTC().Format(time.RFC3339),
+				})
+				m.mu.Unlock()
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusCreated)
+				json.NewEncoder(w).Encode(map[string]interface{}{"id": id, "body": req.Body})
+				return
+			}
+			if r.Method == http.MethodPost && len(parts2) == 3 && parts2[0] == "issues" && parts2[2] == "labels" {
+				var num int
+				fmt.Sscanf(parts2[1], "%d", &num)
+				var req struct {
+					Labels []string `json:"labels"`
+				}
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				key := fmt.Sprintf("%s/%s#%d", owner, repo, num)
+				m.mu.Lock()
+				issue := m.Issues[key]
+				for _, label := range req.Labels {
+					if !stringSliceContains(issue.Labels, label) {
+						issue.Labels = append(issue.Labels, label)
+					}
+				}
+				m.Issues[key] = issue
+				m.mu.Unlock()
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(labelsToNameMaps(req.Labels))
+				return
+			}
+			if r.Method == http.MethodPatch && len(parts2) == 2 && parts2[0] == "issues" {
+				var num int
+				fmt.Sscanf(parts2[1], "%d", &num)
+				var req struct {
+					Assignees []string `json:"assignees"`
+					State     string   `json:"state"`
+				}
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				key := fmt.Sprintf("%s/%s#%d", owner, repo, num)
+				m.mu.Lock()
+				issue := m.Issues[key]
+				if len(req.Assignees) > 0 {
+					issue.Assignee = req.Assignees[0]
+				}
+				if req.State != "" {
+					issue.State = req.State
+				}
+				m.Issues[key] = issue
+				m.mu.Unlock()
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(issueToMap(num, issue, owner, repo))
+				return
+			}
+			if r.Method != http.MethodGet {
+				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+				return
+			}
 			if len(parts2) == 3 && parts2[0] == "issues" && parts2[2] == "events" {
 				var num int
 				fmt.Sscanf(parts2[1], "%d", &num)
@@ -217,6 +278,23 @@ func (m *MockGitHubIssues) SawAPICall() bool {
 	return len(m.Calls) > 0
 }
 
+func (m *MockGitHubIssues) Issue(repo string, number int) IssueState {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.Issues[fmt.Sprintf("%s#%d", repo, number)]
+}
+
+func (m *MockGitHubIssues) PostedComments(repo string, number int) []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	states := m.IssueComments[fmt.Sprintf("%s#%d", repo, number)]
+	out := make([]string, 0, len(states))
+	for _, state := range states {
+		out = append(out, state.Body)
+	}
+	return out
+}
+
 func (m *MockGitHubIssues) AuthHeaderCount(header string) int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -345,4 +423,13 @@ func labelsToNameMaps(labels []string) []map[string]interface{} {
 		result = append(result, map[string]interface{}{"name": l})
 	}
 	return result
+}
+
+func stringSliceContains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/hub/factorytest/mock_github_issues.go
+++ b/pkg/hub/factorytest/mock_github_issues.go
@@ -112,9 +112,10 @@ func NewMockGitHubIssues(t *testing.T) *MockGitHubIssues {
 					}
 				}
 				m.Issues[key] = issue
+				allLabels := append([]string(nil), issue.Labels...)
 				m.mu.Unlock()
 				w.Header().Set("Content-Type", "application/json")
-				json.NewEncoder(w).Encode(labelsToNameMaps(req.Labels))
+				json.NewEncoder(w).Encode(labelsToNameMaps(allLabels))
 				return
 			}
 			if r.Method == http.MethodPatch && len(parts2) == 2 && parts2[0] == "issues" {

--- a/pkg/hub/factorytest/mock_github_issues_test.go
+++ b/pkg/hub/factorytest/mock_github_issues_test.go
@@ -1,0 +1,95 @@
+package factorytest
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestMockGitHubIssuesWriteHandlersReturnNotFoundForMissingIssue(t *testing.T) {
+	ghi := NewMockGitHubIssues(t)
+
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		body   string
+	}{
+		{
+			name:   "comment",
+			method: http.MethodPost,
+			path:   "/repos/testorg/testrepo/issues/42/comments",
+			body:   `{"body":"failed"}`,
+		},
+		{
+			name:   "labels",
+			method: http.MethodPost,
+			path:   "/repos/testorg/testrepo/issues/42/labels",
+			body:   `{"labels":["agent-error"]}`,
+		},
+		{
+			name:   "patch",
+			method: http.MethodPatch,
+			path:   "/repos/testorg/testrepo/issues/42",
+			body:   `{"assignees":["alice"]}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest(tt.method, ghi.URL+tt.path, bytes.NewBufferString(tt.body))
+			if err != nil {
+				t.Fatalf("request: %v", err)
+			}
+			req.Header.Set("Content-Type", "application/json")
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("do request: %v", err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusNotFound {
+				t.Fatalf("status = %d, want 404", resp.StatusCode)
+			}
+		})
+	}
+}
+
+func TestMockGitHubIssuesAddLabelsReturnsCompleteIssueLabels(t *testing.T) {
+	ghi := NewMockGitHubIssues(t)
+	ghi.SetIssue("testorg/testrepo", 42, IssueState{
+		Title:  "Test issue",
+		Body:   "Body",
+		State:  "open",
+		Labels: []string{"existing"},
+	})
+
+	req, err := http.NewRequest(http.MethodPost, ghi.URL+"/repos/testorg/testrepo/issues/42/labels", bytes.NewBufferString(`{"labels":["agent-error"]}`))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var labels []struct {
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&labels); err != nil {
+		t.Fatalf("decode labels: %v", err)
+	}
+	got := make(map[string]bool)
+	for _, label := range labels {
+		got[label.Name] = true
+	}
+	for _, want := range []string{"existing", "agent-error"} {
+		if !got[want] {
+			t.Fatalf("labels = %#v, missing %q", labels, want)
+		}
+	}
+}

--- a/pkg/hub/factorytest/mock_linear.go
+++ b/pkg/hub/factorytest/mock_linear.go
@@ -60,8 +60,13 @@ func NewMockLinear(t *testing.T) *MockLinear {
 			}
 			_ = json.Unmarshal(body, &req)
 			comment, _ := req.Variables["body"].(string)
+			issueID, _ := req.Variables["issueId"].(string)
 			m.mu.Lock()
-			m.IssueComments["ELA-123"] = append(m.IssueComments["ELA-123"], comment)
+			identifier := m.issueIdentifierLocked(issueID)
+			if identifier == "" {
+				identifier = issueID
+			}
+			m.IssueComments[identifier] = append(m.IssueComments[identifier], comment)
 			m.mu.Unlock()
 			json.NewEncoder(w).Encode(map[string]interface{}{
 				"data": map[string]interface{}{
@@ -75,36 +80,44 @@ func NewMockLinear(t *testing.T) *MockLinear {
 		}
 		// issueUpdate mutation (moveIssue)
 		if strings.Contains(bodyStr, "issueUpdate") {
-			// Extract issueId and stateId from variables - best effort
 			var req struct {
 				Variables map[string]interface{} `json:"variables"`
 			}
 			json.Unmarshal(body, &req)
 			if id, ok := req.Variables["id"].(string); ok {
+				m.mu.Lock()
+				identifier := m.issueIdentifierLocked(id)
+				if identifier == "" {
+					identifier = id
+				}
+				m.mu.Unlock()
 				if stateID, ok := req.Variables["stateId"].(string); ok {
 					m.mu.Lock()
 					m.IssueStates[id] = stateID
-					m.IssueStateNames["ELA-123"] = linearStateNameForID(stateID)
-					if issue, ok := m.PollingIssues["ELA-123"]; ok {
+					m.IssueStateNames[identifier] = linearStateNameForID(stateID)
+					if issue, ok := m.PollingIssues[identifier]; ok {
 						issue["state"] = map[string]interface{}{"name": linearStateNameForID(stateID)}
 					}
 					m.mu.Unlock()
 				}
 				if assigneeID, ok := req.Variables["assigneeId"].(string); ok {
 					m.mu.Lock()
-					m.IssueAssignees["ELA-123"] = assigneeID
+					m.IssueAssignees[identifier] = assigneeID
 					m.mu.Unlock()
 				}
 				if input, ok := req.Variables["input"].(map[string]interface{}); ok {
 					if stateID, ok := input["stateId"].(string); ok {
 						m.mu.Lock()
 						m.IssueStates[id] = stateID
-						m.IssueStateNames["ELA-123"] = linearStateNameForID(stateID)
+						m.IssueStateNames[identifier] = linearStateNameForID(stateID)
+						if issue, ok := m.PollingIssues[identifier]; ok {
+							issue["state"] = map[string]interface{}{"name": linearStateNameForID(stateID)}
+						}
 						m.mu.Unlock()
 					}
 					if assigneeID, ok := input["assigneeId"].(string); ok {
 						m.mu.Lock()
-						m.IssueAssignees["ELA-123"] = assigneeID
+						m.IssueAssignees[identifier] = assigneeID
 						m.mu.Unlock()
 					}
 				}
@@ -150,27 +163,39 @@ func NewMockLinear(t *testing.T) *MockLinear {
 		}
 		// issue(id:) query — returns a single issue directly
 		if strings.Contains(bodyStr, "issue(") || strings.Contains(bodyStr, `"issue"`) {
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"data": map[string]interface{}{
-					"issue": map[string]interface{}{
-						"id":          "issue-uuid-123",
-						"identifier":  "ELA-123",
-						"title":       "Add hello world to README",
-						"description": "Please add a 'Hello World' section to the README.md file.",
-						"url":         "https://linear.app/test/issue/ELA-123",
-						"state":       map[string]interface{}{"name": "In Progress", "id": "in-progress-id"},
-						"team": map[string]interface{}{
-							"name": "Engineering",
-							"key":  "ELA",
-							"states": map[string]interface{}{
-								"nodes": []map[string]interface{}{
-									{"id": "done-state-id", "name": "Done", "type": "completed"},
-									{"id": "in-progress-id", "name": "In Progress", "type": "started"},
-									{"id": "agent-error-id", "name": "Agent Error", "type": "canceled"},
-								},
+			var req struct {
+				Variables map[string]interface{} `json:"variables"`
+			}
+			_ = json.Unmarshal(body, &req)
+			id, _ := req.Variables["id"].(string)
+			m.mu.Lock()
+			issue := cloneMap(m.issueByIDLocked(id))
+			m.mu.Unlock()
+			if issue == nil {
+				issue = map[string]interface{}{
+					"id":          "issue-uuid-123",
+					"identifier":  "ELA-123",
+					"title":       "Add hello world to README",
+					"description": "Please add a 'Hello World' section to the README.md file.",
+					"url":         "https://linear.app/test/issue/ELA-123",
+					"state":       map[string]interface{}{"name": "In Progress", "id": "in-progress-id"},
+					"team": map[string]interface{}{
+						"name": "Engineering",
+						"key":  "ELA",
+						"states": map[string]interface{}{
+							"nodes": []map[string]interface{}{
+								{"id": "done-state-id", "name": "Done", "type": "completed"},
+								{"id": "in-progress-id", "name": "In Progress", "type": "started"},
+								{"id": "agent-error-id", "name": "Agent Error", "type": "canceled"},
 							},
 						},
 					},
+				}
+			}
+			ensureMockLinearIssueStates(issue)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": map[string]interface{}{
+					"issue": issue,
 				},
 			})
 			return
@@ -183,6 +208,9 @@ func NewMockLinear(t *testing.T) *MockLinear {
 }
 
 func cloneMap(in map[string]interface{}) map[string]interface{} {
+	if in == nil {
+		return nil
+	}
 	out := make(map[string]interface{}, len(in))
 	for k, v := range in {
 		switch typed := v.(type) {
@@ -195,6 +223,48 @@ func cloneMap(in map[string]interface{}) map[string]interface{} {
 		}
 	}
 	return out
+}
+
+func (m *MockLinear) issueByIDLocked(id string) map[string]interface{} {
+	if issue, ok := m.PollingIssues[id]; ok {
+		return issue
+	}
+	for _, issue := range m.PollingIssues {
+		if issueID, _ := issue["id"].(string); issueID == id {
+			return issue
+		}
+	}
+	return nil
+}
+
+func (m *MockLinear) issueIdentifierLocked(id string) string {
+	if _, ok := m.PollingIssues[id]; ok {
+		return id
+	}
+	for identifier, issue := range m.PollingIssues {
+		if issueID, _ := issue["id"].(string); issueID == id {
+			return identifier
+		}
+	}
+	return ""
+}
+
+func ensureMockLinearIssueStates(issue map[string]interface{}) {
+	team, _ := issue["team"].(map[string]interface{})
+	if team == nil {
+		team = map[string]interface{}{"name": "Engineering", "key": "ELA"}
+		issue["team"] = team
+	}
+	if _, ok := team["states"]; ok {
+		return
+	}
+	team["states"] = map[string]interface{}{
+		"nodes": []map[string]interface{}{
+			{"id": "done-state-id", "name": "Done", "type": "completed"},
+			{"id": "in-progress-id", "name": "In Progress", "type": "started"},
+			{"id": "agent-error-id", "name": "Agent Error", "type": "canceled"},
+		},
+	}
 }
 
 // SetIssueStateName updates the state name of a polling issue.

--- a/pkg/hub/factorytest/mock_linear.go
+++ b/pkg/hub/factorytest/mock_linear.go
@@ -12,9 +12,12 @@ import (
 
 type MockLinear struct {
 	*httptest.Server
-	mu           sync.Mutex
-	IssueStates  map[string]string // issueID → state ID (from mutations)
-	GraphQLCalls []string
+	mu              sync.Mutex
+	IssueStates     map[string]string // issueID → state ID (from mutations)
+	IssueStateNames map[string]string // identifier → state name
+	IssueAssignees  map[string]string // identifier → assignee ID
+	IssueComments   map[string][]string
+	GraphQLCalls    []string
 	// PollingIssues holds issue data returned by the issues(filter:) polling query.
 	// Key is identifier (e.g. "ELA-123"). Call SetIssueStateName to mutate state.
 	PollingIssues map[string]map[string]interface{}
@@ -23,8 +26,11 @@ type MockLinear struct {
 func NewMockLinear(t *testing.T) *MockLinear {
 	t.Helper()
 	m := &MockLinear{
-		IssueStates:   make(map[string]string),
-		PollingIssues: make(map[string]map[string]interface{}),
+		IssueStates:     make(map[string]string),
+		IssueStateNames: make(map[string]string),
+		IssueAssignees:  make(map[string]string),
+		IssueComments:   make(map[string][]string),
+		PollingIssues:   make(map[string]map[string]interface{}),
 	}
 	// Default polling issue
 	m.PollingIssues["ELA-123"] = map[string]interface{}{
@@ -47,6 +53,26 @@ func NewMockLinear(t *testing.T) *MockLinear {
 		m.GraphQLCalls = append(m.GraphQLCalls, bodyStr)
 		m.mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
+		// commentCreate mutation
+		if strings.Contains(bodyStr, "commentCreate") {
+			var req struct {
+				Variables map[string]interface{} `json:"variables"`
+			}
+			_ = json.Unmarshal(body, &req)
+			comment, _ := req.Variables["body"].(string)
+			m.mu.Lock()
+			m.IssueComments["ELA-123"] = append(m.IssueComments["ELA-123"], comment)
+			m.mu.Unlock()
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": map[string]interface{}{
+					"commentCreate": map[string]interface{}{
+						"success": true,
+						"comment": map[string]interface{}{"id": "comment-1"},
+					},
+				},
+			})
+			return
+		}
 		// issueUpdate mutation (moveIssue)
 		if strings.Contains(bodyStr, "issueUpdate") {
 			// Extract issueId and stateId from variables - best effort
@@ -55,10 +81,30 @@ func NewMockLinear(t *testing.T) *MockLinear {
 			}
 			json.Unmarshal(body, &req)
 			if id, ok := req.Variables["id"].(string); ok {
+				if stateID, ok := req.Variables["stateId"].(string); ok {
+					m.mu.Lock()
+					m.IssueStates[id] = stateID
+					m.IssueStateNames["ELA-123"] = linearStateNameForID(stateID)
+					if issue, ok := m.PollingIssues["ELA-123"]; ok {
+						issue["state"] = map[string]interface{}{"name": linearStateNameForID(stateID)}
+					}
+					m.mu.Unlock()
+				}
+				if assigneeID, ok := req.Variables["assigneeId"].(string); ok {
+					m.mu.Lock()
+					m.IssueAssignees["ELA-123"] = assigneeID
+					m.mu.Unlock()
+				}
 				if input, ok := req.Variables["input"].(map[string]interface{}); ok {
 					if stateID, ok := input["stateId"].(string); ok {
 						m.mu.Lock()
 						m.IssueStates[id] = stateID
+						m.IssueStateNames["ELA-123"] = linearStateNameForID(stateID)
+						m.mu.Unlock()
+					}
+					if assigneeID, ok := input["assigneeId"].(string); ok {
+						m.mu.Lock()
+						m.IssueAssignees["ELA-123"] = assigneeID
 						m.mu.Unlock()
 					}
 				}
@@ -78,6 +124,7 @@ func NewMockLinear(t *testing.T) *MockLinear {
 						"nodes": []map[string]interface{}{
 							{"id": "done-state-id", "name": "Done", "type": "completed"},
 							{"id": "in-progress-id", "name": "In Progress", "type": "started"},
+							{"id": "agent-error-id", "name": "Agent Error", "type": "canceled"},
 						},
 					},
 				},
@@ -112,7 +159,17 @@ func NewMockLinear(t *testing.T) *MockLinear {
 						"description": "Please add a 'Hello World' section to the README.md file.",
 						"url":         "https://linear.app/test/issue/ELA-123",
 						"state":       map[string]interface{}{"name": "In Progress", "id": "in-progress-id"},
-						"team":        map[string]interface{}{"name": "Engineering", "key": "ELA"},
+						"team": map[string]interface{}{
+							"name": "Engineering",
+							"key":  "ELA",
+							"states": map[string]interface{}{
+								"nodes": []map[string]interface{}{
+									{"id": "done-state-id", "name": "Done", "type": "completed"},
+									{"id": "in-progress-id", "name": "In Progress", "type": "started"},
+									{"id": "agent-error-id", "name": "Agent Error", "type": "canceled"},
+								},
+							},
+						},
 					},
 				},
 			})
@@ -148,6 +205,7 @@ func (m *MockLinear) SetIssueStateName(identifier, stateName string) {
 		issue["state"] = map[string]interface{}{"name": stateName}
 		issue["updatedAt"] = "2026-05-10T00:01:00Z"
 	}
+	m.IssueStateNames[identifier] = stateName
 }
 
 // SawPollCall returns true if the mock has received an issues(filter:) GraphQL query
@@ -179,6 +237,34 @@ func (m *MockLinear) SawAPICall() bool {
 	return len(m.GraphQLCalls) > 0
 }
 
+func (m *MockLinear) Comments(issueID string) []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string(nil), m.IssueComments[issueID]...)
+}
+
+func (m *MockLinear) IssueStateName(issueID string) string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if state := m.IssueStateNames[issueID]; state != "" {
+		return state
+	}
+	if issue, ok := m.PollingIssues[issueID]; ok {
+		if state, ok := issue["state"].(map[string]interface{}); ok {
+			if name, ok := state["name"].(string); ok {
+				return name
+			}
+		}
+	}
+	return ""
+}
+
+func (m *MockLinear) IssueAssigneeID(issueID string) string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.IssueAssignees[issueID]
+}
+
 // BuildWebhookPayload returns a JSON webhook payload and the HMAC-SHA256
 // signature for the given issue state transition.
 func (m *MockLinear) BuildWebhookPayload(issueID, prevStatus, newStatus string) ([]byte, string) {
@@ -207,4 +293,17 @@ func (m *MockLinear) BuildWebhookPayload(issueID, prevStatus, newStatus string) 
 	}
 	b, _ := json.Marshal(payload)
 	return b, ""
+}
+
+func linearStateNameForID(id string) string {
+	switch id {
+	case "done-state-id":
+		return "Done"
+	case "in-progress-id":
+		return "In Progress"
+	case "agent-error-id":
+		return "Agent Error"
+	default:
+		return id
+	}
 }

--- a/pkg/hub/factorytest/mock_linear_test.go
+++ b/pkg/hub/factorytest/mock_linear_test.go
@@ -1,0 +1,70 @@
+package factorytest
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestMockLinearRecordsMutationsByIssueIdentifier(t *testing.T) {
+	linear := NewMockLinear(t)
+	linear.PollingIssues["ELA-456"] = map[string]interface{}{
+		"id":          "issue-uuid-456",
+		"identifier":  "ELA-456",
+		"title":       "Second issue",
+		"description": "Body",
+		"url":         "https://linear.app/test/issue/ELA-456",
+		"state":       map[string]interface{}{"name": "Backlog"},
+		"team": map[string]interface{}{
+			"name": "Engineering",
+			"key":  "ELA",
+			"states": map[string]interface{}{
+				"nodes": []map[string]interface{}{
+					{"id": "agent-error-id", "name": "Agent Error", "type": "canceled"},
+				},
+			},
+		},
+	}
+
+	postMockLinearGraphQL(t, linear.URL, map[string]interface{}{
+		"query": "mutation($issueId: String!, $body: String!) { commentCreate(input: { issueId: $issueId, body: $body }) { success } }",
+		"variables": map[string]string{
+			"issueId": "issue-uuid-456",
+			"body":    "failure comment",
+		},
+	})
+	postMockLinearGraphQL(t, linear.URL, map[string]interface{}{
+		"query": "mutation($id: String!, $assigneeId: String!) { issueUpdate(id: $id, input: { assigneeId: $assigneeId }) { success } }",
+		"variables": map[string]string{
+			"id":         "issue-uuid-456",
+			"assigneeId": "user-456",
+		},
+	})
+
+	if comments := linear.Comments("ELA-456"); len(comments) != 1 || comments[0] != "failure comment" {
+		t.Fatalf("Comments(ELA-456) = %v, want failure comment", comments)
+	}
+	if got := linear.IssueAssigneeID("ELA-456"); got != "user-456" {
+		t.Fatalf("IssueAssigneeID(ELA-456) = %q, want user-456", got)
+	}
+	if comments := linear.Comments("ELA-123"); len(comments) != 0 {
+		t.Fatalf("Comments(ELA-123) = %v, want none", comments)
+	}
+}
+
+func postMockLinearGraphQL(t *testing.T, baseURL string, payload map[string]interface{}) {
+	t.Helper()
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	resp, err := http.Post(baseURL+"/graphql", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("post graphql: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		t.Fatalf("status = %d, want <400", resp.StatusCode)
+	}
+}

--- a/pkg/hub/failure_summary.go
+++ b/pkg/hub/failure_summary.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -29,7 +30,188 @@ var (
 	longOpaqueRE      = regexp.MustCompile(`\b[A-Za-z0-9+/=_-]{80,}\b`)
 	pemBlockRE        = regexp.MustCompile(`(?s)-----BEGIN [^-]+-----.*?-----END [^-]+-----`)
 	secretLikeValueRE = regexp.MustCompile(`(?i)(sk-[A-Za-z0-9_-]{12,}|gh[pousr]_[A-Za-z0-9_]{12,}|xox[baprs]-[A-Za-z0-9-]{12,})`)
+	httpStatusRE      = regexp.MustCompile(`(?i)\b(?:HTTP|status|github API error|Linear API error|github API [A-Z]+ [^:]+:)\s+([1-5][0-9]{2})\b`)
 )
+
+type agentFailureKind string
+
+const (
+	agentFailureUnknown            agentFailureKind = "unknown"
+	agentFailureTrackerRead        agentFailureKind = "tracker_read"
+	agentFailureTemplate           agentFailureKind = "template"
+	agentFailureProviderConfig     agentFailureKind = "provider_config"
+	agentFailureHubPersistence     agentFailureKind = "hub_persistence"
+	agentFailureWorkspaceSecrets   agentFailureKind = "workspace_secrets"
+	agentFailureTriggerClaim       agentFailureKind = "trigger_claim"
+	agentFailureTaskRunAnalytics   agentFailureKind = "task_run_analytics"
+	agentFailureProvisioning       agentFailureKind = "provisioning"
+	agentFailureBootstrap          agentFailureKind = "bootstrap"
+	agentFailureWorkspaceReadiness agentFailureKind = "workspace_readiness"
+	agentFailureWorkspaceFiles     agentFailureKind = "workspace_files"
+	agentFailureGitHubCredentials  agentFailureKind = "github_credentials"
+	agentFailureWorkflowVolume     agentFailureKind = "workflow_volume"
+	agentFailureRestore            agentFailureKind = "restore"
+	agentFailureWorkflowCommand    agentFailureKind = "workflow_command"
+	agentFailureDependencyUpdate   agentFailureKind = "dependency_update"
+	agentFailureJudge              agentFailureKind = "judge"
+	agentFailureGate               agentFailureKind = "gate"
+	agentFailurePullRequestAction  agentFailureKind = "pull_request_action"
+	agentFailureIssueAction        agentFailureKind = "issue_action"
+	agentFailureSandboxTerminated  agentFailureKind = "sandbox_terminated"
+	agentFailureTrackerAPI         agentFailureKind = "tracker_api"
+)
+
+type agentFailureMessage struct {
+	Kind        agentFailureKind
+	StatusCode  int
+	Title       string
+	UserMessage string
+	NextStep    string
+	SafeDetail  string
+}
+
+type agentFailureRule struct {
+	kind    agentFailureKind
+	signals []string
+}
+
+var agentFailureRules = []agentFailureRule{
+	{agentFailureTrackerRead, []string{"cannot read issue", "fetchgithubissuedetails", "fetchlinearissuedetails"}},
+	{agentFailureTemplate, []string{"template \"", "template '", "resolvetemplatefiles"}},
+	{agentFailureProviderConfig, []string{"no provider configured", "provider \"", " is not configured", "unsupported provider", "unknown provider"}},
+	{agentFailureHubPersistence, []string{"no tenant", "db insert", "artifact storage", "hub identity"}},
+	{agentFailureWorkspaceSecrets, []string{"load workspace secrets", "secret_ref"}},
+	{agentFailureTriggerClaim, []string{"claim workflow trigger", "claim factory trigger", "complete workflow trigger", "complete factory trigger"}},
+	{agentFailureTaskRunAnalytics, []string{"task run analytics"}},
+	{agentFailureProvisioning, []string{"provisioning failed", "factory provision failed", "workflow provision failed", "restore provision failed", "provision failed"}},
+	{agentFailureBootstrap, []string{"bootstrap failed", "daytona bootstrap failed", "exedev bootstrap failed", "install openclaw failed", "start claw-bridge", "connector download"}},
+	{agentFailureWorkspaceReadiness, []string{"workspace readiness failed", "workspace incomplete"}},
+	{agentFailureWorkspaceFiles, []string{"could not write workspace files", "workspace files incomplete", "template file staging failed", "docker file copy failed", "invalid template file path", "path must stay inside workspace"}},
+	{agentFailureGitHubCredentials, []string{"could not configure github credentials", "auth gh cli failed", "verify gh auth failed", "fetch github bootstrap token"}},
+	{agentFailureWorkflowVolume, []string{"workflow volume attach failed"}},
+	{agentFailureRestore, []string{"restore failed", "restore checkpoint failed", "checkpoint not found", "checkpoint is not ready", "checkpoint has no manifest", "checkpoint blob", "checkpoint tree"}},
+	{agentFailureWorkflowCommand, []string{"workflow command failed", "invalid run timeout", "does not support workflow run actions", "script command", "command failed"}},
+	{agentFailureDependencyUpdate, []string{"dependency update step failed"}},
+	{agentFailureJudge, []string{"judge stage failed", "judge llm call failed", "judge response parse failed", "no judge inputs", "no llm keys configured for judge", "invalid verdict", "missing verdict"}},
+	{agentFailureGate, []string{"gate error", "gate failed", "required gate"}},
+	{agentFailurePullRequestAction, []string{"merge_pr: failed", "pr validation failed", "pr closed without merge"}},
+	{agentFailureIssueAction, []string{"close_issue: failed", "failed to move github issue", "failed to move issue", "failed to add label", "failed to remove label"}},
+	{agentFailureSandboxTerminated, []string{"sandbox terminated", "ttl expired", "external shutdown"}},
+	{agentFailureTrackerAPI, []string{"github api error", "linear api error", "graphql error", "commentcreate returned success=false", "issue or state not found"}},
+}
+
+func classifyAgentFailure(reason string) agentFailureMessage {
+	sanitized := sanitizeFailureDetails(reason)
+	lower := strings.ToLower(sanitized)
+	kind := agentFailureUnknown
+	for _, rule := range agentFailureRules {
+		if containsAny(lower, rule.signals) {
+			kind = rule.kind
+			break
+		}
+	}
+	msg := agentFailureMessage{
+		Kind:        kind,
+		StatusCode:  extractFailureStatusCode(sanitized),
+		UserMessage: agentFailureUserMessage(kind),
+		NextStep:    agentFailureNextStep(kind),
+		SafeDetail:  agentFailureSafeDetail(sanitized),
+	}
+	msg.Title = msg.UserMessage
+	return msg
+}
+
+func containsAny(s string, needles []string) bool {
+	for _, needle := range needles {
+		if strings.Contains(s, strings.ToLower(needle)) {
+			return true
+		}
+	}
+	return false
+}
+
+func extractFailureStatusCode(s string) int {
+	for _, match := range httpStatusRE.FindAllStringSubmatch(s, -1) {
+		if len(match) < 2 {
+			continue
+		}
+		code, err := strconv.Atoi(match[1])
+		if err == nil && code >= 100 && code <= 599 {
+			return code
+		}
+	}
+	return http.StatusInternalServerError
+}
+
+func agentFailureUserMessage(kind agentFailureKind) string {
+	switch kind {
+	case agentFailureTrackerRead:
+		return "ElasticClaw could not read the source issue/ticket."
+	case agentFailureTemplate:
+		return "ElasticClaw could not load the workspace template."
+	case agentFailureProviderConfig:
+		return "ElasticClaw could not find a valid execution provider."
+	case agentFailureHubPersistence:
+		return "ElasticClaw could not save or load required hub data."
+	case agentFailureWorkspaceSecrets:
+		return "ElasticClaw could not load a required workspace secret."
+	case agentFailureTriggerClaim:
+		return "ElasticClaw could not reserve or finalize this automation run."
+	case agentFailureTaskRunAnalytics:
+		return "ElasticClaw could not create the run tracking record."
+	case agentFailureProvisioning:
+		return "ElasticClaw could not start the agent workspace."
+	case agentFailureBootstrap:
+		return "ElasticClaw started the workspace but could not finish preparing it."
+	case agentFailureWorkspaceReadiness:
+		return "ElasticClaw could not verify that the workspace was ready."
+	case agentFailureWorkspaceFiles:
+		return "ElasticClaw could not place the required files in the workspace."
+	case agentFailureGitHubCredentials:
+		return "ElasticClaw could not configure GitHub access inside the workspace."
+	case agentFailureWorkflowVolume:
+		return "ElasticClaw could not attach a required workflow volume."
+	case agentFailureRestore:
+		return "ElasticClaw could not restore the previous agent checkpoint."
+	case agentFailureWorkflowCommand:
+		return "A workflow command failed while the agent was running."
+	case agentFailureDependencyUpdate:
+		return "The dependency update step did not complete successfully."
+	case agentFailureJudge:
+		return "ElasticClaw could not complete an automated review step."
+	case agentFailureGate:
+		return "A workflow gate blocked the run."
+	case agentFailurePullRequestAction:
+		return "ElasticClaw could not complete the pull request action."
+	case agentFailureIssueAction:
+		return "ElasticClaw could not update the source issue/ticket."
+	case agentFailureSandboxTerminated:
+		return "The agent workspace stopped before ElasticClaw could finish."
+	case agentFailureTrackerAPI:
+		return "ElasticClaw received an error from the issue tracker API."
+	default:
+		return "ElasticClaw hit an unexpected error while running the agent."
+	}
+}
+
+func agentFailureNextStep(kind agentFailureKind) string {
+	switch kind {
+	case agentFailureTrackerRead, agentFailureTrackerAPI:
+		return "Check the issue tracker token permissions, then re-trigger the workflow."
+	case agentFailureTemplate, agentFailureProviderConfig, agentFailureWorkspaceSecrets, agentFailureGitHubCredentials, agentFailureWorkflowVolume:
+		return "Check the ElasticClaw workspace/workflow configuration, then re-trigger the workflow."
+	case agentFailureProvisioning, agentFailureBootstrap, agentFailureWorkspaceReadiness, agentFailureWorkspaceFiles, agentFailureRestore, agentFailureSandboxTerminated:
+		return "Check the ElasticClaw run logs and provider status, then retry the workflow."
+	case agentFailureWorkflowCommand, agentFailureDependencyUpdate, agentFailureJudge, agentFailureGate, agentFailurePullRequestAction, agentFailureIssueAction:
+		return "Review the workflow result, fix the command/review/PR issue, then retry from the appropriate stage."
+	default:
+		return "Review the failure details and retry after the configuration or hub issue is fixed."
+	}
+}
+
+func agentFailureSafeDetail(sanitized string) string {
+	return firstUsefulFailureLines(sanitized, 2)
+}
 
 func (s *Server) buildAgentStopComment(clawID, reason string) string {
 	sanitized := sanitizeFailureDetails(reason)

--- a/pkg/hub/failure_summary_test.go
+++ b/pkg/hub/failure_summary_test.go
@@ -66,6 +66,107 @@ func TestClampFailureCommentPreservesUTF8(t *testing.T) {
 	}
 }
 
+func TestClassifyAgentFailureMapsKnownErrorsToGenericMessages(t *testing.T) {
+	tests := []struct {
+		name       string
+		reason     string
+		wantKind   agentFailureKind
+		wantStatus int
+		wantMsg    string
+		wantNext   string
+	}{
+		{
+			name:       "tracker read",
+			reason:     "cannot read issue ELA-123 from Linear (check token/workspace access): Linear API error 403",
+			wantKind:   agentFailureTrackerRead,
+			wantStatus: 403,
+			wantMsg:    "ElasticClaw could not read the source issue/ticket.",
+			wantNext:   "Check the issue tracker token permissions, then re-trigger the workflow.",
+		},
+		{
+			name:       "template",
+			reason:     `template "missing" not found: not found`,
+			wantKind:   agentFailureTemplate,
+			wantStatus: 500,
+			wantMsg:    "ElasticClaw could not load the workspace template.",
+			wantNext:   "Check the ElasticClaw workspace/workflow configuration, then re-trigger the workflow.",
+		},
+		{
+			name:       "provider config",
+			reason:     `provider "daytona" is not configured on this hub`,
+			wantKind:   agentFailureProviderConfig,
+			wantStatus: 500,
+			wantMsg:    "ElasticClaw could not find a valid execution provider.",
+			wantNext:   "Check the ElasticClaw workspace/workflow configuration, then re-trigger the workflow.",
+		},
+		{
+			name:       "bootstrap",
+			reason:     "Bootstrap failed: install openclaw failed: status 22",
+			wantKind:   agentFailureBootstrap,
+			wantStatus: 500,
+			wantMsg:    "ElasticClaw started the workspace but could not finish preparing it.",
+			wantNext:   "Check the ElasticClaw run logs and provider status, then retry the workflow.",
+		},
+		{
+			name:       "judge",
+			reason:     "Judge stage failed: no LLM keys configured for judge",
+			wantKind:   agentFailureJudge,
+			wantStatus: 500,
+			wantMsg:    "ElasticClaw could not complete an automated review step.",
+			wantNext:   "Review the workflow result, fix the command/review/PR issue, then retry from the appropriate stage.",
+		},
+		{
+			name:       "tracker api",
+			reason:     "github API error 404: label not found",
+			wantKind:   agentFailureTrackerAPI,
+			wantStatus: 404,
+			wantMsg:    "ElasticClaw received an error from the issue tracker API.",
+			wantNext:   "Check the issue tracker token permissions, then re-trigger the workflow.",
+		},
+		{
+			name:       "unknown",
+			reason:     "unexpected internal failure",
+			wantKind:   agentFailureUnknown,
+			wantStatus: 500,
+			wantMsg:    "ElasticClaw hit an unexpected error while running the agent.",
+			wantNext:   "Review the failure details and retry after the configuration or hub issue is fixed.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifyAgentFailure(tt.reason)
+			if got.Kind != tt.wantKind {
+				t.Fatalf("Kind = %q, want %q", got.Kind, tt.wantKind)
+			}
+			if got.StatusCode != tt.wantStatus {
+				t.Fatalf("StatusCode = %d, want %d", got.StatusCode, tt.wantStatus)
+			}
+			if got.UserMessage != tt.wantMsg {
+				t.Fatalf("UserMessage = %q, want %q", got.UserMessage, tt.wantMsg)
+			}
+			if got.NextStep != tt.wantNext {
+				t.Fatalf("NextStep = %q, want %q", got.NextStep, tt.wantNext)
+			}
+		})
+	}
+}
+
+func TestClassifyAgentFailureDoesNotExposeRawSecrets(t *testing.T) {
+	got := classifyAgentFailure("Bootstrap failed: OPENAI_API_KEY=sk-secret-token\nreal error: HTTP 401")
+	if got.StatusCode != 401 {
+		t.Fatalf("StatusCode = %d, want 401", got.StatusCode)
+	}
+	for _, forbidden := range []string{"sk-secret-token", "OPENAI_API_KEY=sk-secret-token"} {
+		if strings.Contains(got.SafeDetail, forbidden) {
+			t.Fatalf("SafeDetail leaked %q in:\n%s", forbidden, got.SafeDetail)
+		}
+	}
+	if got.UserMessage == "" || got.NextStep == "" {
+		t.Fatalf("expected generic user message and next step: %#v", got)
+	}
+}
+
 func TestCloneLLMKeysCopiesStructValues(t *testing.T) {
 	original := types.LLMKeysList{
 		{Name: "openai-main", Provider: "openai", APIKey: "old-key", DefaultModel: "gpt-4o-mini"},

--- a/pkg/hub/github_issues.go
+++ b/pkg/hub/github_issues.go
@@ -321,10 +321,31 @@ func (s *Server) processGitHubIssuesWorkflowEvent(workspaces []*types.WorkspaceC
 					continue
 				}
 				log.Printf("[workflow:%s/%s] failed to create claw for %s: %v", workspace.Name, workflow.Name, issueID, err)
+				s.notifyGitHubIssueWorkflowCreateFailure(workspace, workflow, payload, err)
 			}
 		}
 	}
 	return matched
+}
+
+func (s *Server) notifyGitHubIssueWorkflowCreateFailure(workspace *types.WorkspaceConfig, workflow *types.WorkflowConfig, payload githubIssuesWebhookPayload, createErr error) {
+	if workspace == nil || workflow == nil || workflow.Trigger == nil || workflow.Trigger.GitHubIssues == nil {
+		return
+	}
+	token := s.resolveGitHubIssuesTokenForWorkflow(workspace.Name, workflow)
+	if token == "" {
+		log.Printf("[agent-failure-feedback] workflow %s/%s has no GitHub Issues token; skipping failure feedback", workspace.Name, workflow.Name)
+		return
+	}
+	s.handleAgentFailureFeedback(agentFailureFeedback{
+		Integration:      "github-issues",
+		IssueID:          fmt.Sprintf("%s/%d", payload.Repository.FullName, payload.Issue.Number),
+		GitHubRepo:       payload.Repository.FullName,
+		GitHubIssueNum:   payload.Issue.Number,
+		TriggerActor:     triggerActor{Login: payload.Sender.Login, Type: payload.Sender.Type},
+		AgentStatusError: strings.TrimSpace(workflow.Trigger.GitHubIssues.AgentStatusError),
+		Failure:          classifyAgentFailure(createErr.Error()),
+	}, token)
 }
 
 func githubIssuesWorkflowTriggerMatches(trigger *types.WorkflowTrigger, payload githubIssuesWebhookPayload, currentStatus string, issueLabels map[string]bool) bool {
@@ -459,6 +480,10 @@ func (s *Server) createClawForGitHubIssueWorkflow(workspace *types.WorkspaceConf
 		clawName:       clawName,
 		githubIssueID:  issueID,
 		reason:         reason,
+		triggerActor: &triggerActor{
+			Login: payload.Sender.Login,
+			Type:  payload.Sender.Type,
+		},
 	})
 	if err != nil {
 		return "", false, err
@@ -1064,27 +1089,7 @@ func nextGitHubPagePath(linkHeader, baseURL string) string {
 
 // commentGitHubIssue adds a comment to a GitHub issue.
 func commentGitHubIssue(token, repo string, issueNumber int, body string) error {
-	base := "https://api.github.com"
-	commentBody := map[string]interface{}{"body": body}
-	b, _ := json.Marshal(commentBody)
-	req, _ := http.NewRequest("POST",
-		fmt.Sprintf("%s/repos/%s/issues/%d/comments", base, repo, issueNumber),
-		bytes.NewReader(b))
-	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("Accept", "application/vnd.github+json")
-	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode >= 400 {
-		respBody, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("github API error %d: %s", resp.StatusCode, string(respBody))
-	}
-	return nil
+	return commentGitHubIssueWithBase("https://api.github.com", token, repo, issueNumber, body)
 }
 
 // githubAPIPostWithBase makes a POST/PATCH/PUT request to the GitHub API.

--- a/pkg/hub/github_issues.go
+++ b/pkg/hub/github_issues.go
@@ -1040,7 +1040,7 @@ func fetchGitHubIssueCommentsPage(ctx context.Context, baseURL, path, token stri
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := issueTrackerHTTPClient.Do(req)
 	if err != nil {
 		return nil, "", err
 	}
@@ -1112,7 +1112,7 @@ func githubAPIPostWithBase(baseURL, path, token, method string, body interface{}
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := issueTrackerHTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/hub/github_issues.go
+++ b/pkg/hub/github_issues.go
@@ -364,6 +364,9 @@ func githubIssuesWorkflowSourceMatches(event string, states, labels, labelers []
 		if payload.Action != "labeled" {
 			return false
 		}
+		if len(labels) > 0 && !githubIssuesPayloadLabelMatches(payload, labels) {
+			return false
+		}
 	case "issue_opened":
 		if payload.Action != "opened" {
 			return false
@@ -413,6 +416,22 @@ func githubIssuesWorkflowSourceMatches(event string, states, labels, labelers []
 		return false
 	}
 	return true
+}
+
+func githubIssuesPayloadLabelMatches(payload githubIssuesWebhookPayload, labels []string) bool {
+	if payload.Label == nil {
+		return false
+	}
+	added := strings.ToLower(strings.TrimSpace(payload.Label.Name))
+	if added == "" {
+		return false
+	}
+	for _, label := range labels {
+		if strings.EqualFold(added, strings.TrimSpace(label)) {
+			return true
+		}
+	}
+	return false
 }
 
 func assignedToMatches(filter, assignee string) bool {

--- a/pkg/hub/github_issues_webhook_test.go
+++ b/pkg/hub/github_issues_webhook_test.go
@@ -415,6 +415,63 @@ func TestGitHubIssuesWorkflowPollContextIncludesAllIssueComments(t *testing.T) {
 	}
 }
 
+func TestGitHubIssuesWorkflowCreateFailureCommentsLabelsAndAssignsTriggerActor(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	ghi := factorytest.NewMockGitHubIssues(t)
+	ghi.WebhookSecret = "secret"
+	li := factorytest.NewMockLinear(t)
+
+	cfg := &types.HubConfig{ClawToken: "test-claw-token"}
+	s, db := hub.NewTestServerWithConfig(t, cfg, ghi.URL, li.URL, "")
+	saveGitHubIssueWorkflowFixtureWithProviderAndErrorLabel(t, "workspace-a", "secret", "missing-provider", "agent-error")
+
+	httpSrv := httptest.NewServer(s.Handler())
+	t.Cleanup(httpSrv.Close)
+
+	ghi.SetIssue("testorg/testrepo", 42, factorytest.IssueState{Title: "Test Issue", Body: "Main issue body", State: "open"})
+	payload, _ := ghi.BuildWebhookPayload("testorg/testrepo", 42, "closed", "open")
+	req, err := http.NewRequest(http.MethodPost, httpSrv.URL+"/api/workspaces/workspace-a/webhooks/github-issues", strings.NewReader(string(payload)))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Hub-Signature-256", hmacSHA256(payload, "secret"))
+	req.Header.Set("X-GitHub-Delivery", "delivery-create-failure")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	comment := waitForGitHubIssuePostedComment(t, ghi, "testorg/testrepo", 42)
+	for _, want := range []string{
+		"@testuser ElasticClaw could not finish this implementation.",
+		"Status code: 500",
+		"ElasticClaw could not find a valid execution provider.",
+		"Check the ElasticClaw workspace/workflow configuration, then re-trigger the workflow.",
+	} {
+		if !strings.Contains(comment, want) {
+			t.Fatalf("comment missing %q:\n%s", want, comment)
+		}
+	}
+	if strings.Contains(comment, "provider \"missing-provider\" is not configured") {
+		t.Fatalf("comment exposed raw provider error:\n%s", comment)
+	}
+	waitForGitHubIssueAssignee(t, ghi, "testorg/testrepo", 42, "testuser")
+	waitForGitHubIssueLabel(t, ghi, "testorg/testrepo", 42, "agent-error")
+	var claws int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM claws WHERE github_issue_id='testorg/testrepo/42'`).Scan(&claws); err != nil {
+		t.Fatalf("count claws: %v", err)
+	}
+	if claws != 0 {
+		t.Fatalf("created %d claws, want 0 for creation failure", claws)
+	}
+}
+
 func waitForGitHubIssueContext(t *testing.T, db *sql.DB, issueID string) string {
 	t.Helper()
 	var filesJSON string
@@ -436,14 +493,62 @@ func waitForGitHubIssueContext(t *testing.T, db *sql.DB, issueID string) string 
 	return files["CONTEXT.md"]
 }
 
+func waitForGitHubIssuePostedComment(t *testing.T, ghi *factorytest.MockGitHubIssues, repo string, number int) string {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		comments := ghi.PostedComments(repo, number)
+		if len(comments) > 0 {
+			return comments[len(comments)-1]
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for GitHub issue comment")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func waitForGitHubIssueAssignee(t *testing.T, ghi *factorytest.MockGitHubIssues, repo string, number int, want string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if got := ghi.Issue(repo, number).Assignee; got == want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("assignee = %q, want %q", ghi.Issue(repo, number).Assignee, want)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func waitForGitHubIssueLabel(t *testing.T, ghi *factorytest.MockGitHubIssues, repo string, number int, want string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if containsString(ghi.Issue(repo, number).Labels, want) {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("labels = %v, want %q", ghi.Issue(repo, number).Labels, want)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
 func saveGitHubIssueWorkflowFixture(t *testing.T, workspace, secret string) {
+	t.Helper()
+	saveGitHubIssueWorkflowFixtureWithProviderAndErrorLabel(t, workspace, secret, "noop", "")
+}
+
+func saveGitHubIssueWorkflowFixtureWithProviderAndErrorLabel(t *testing.T, workspace, secret, provider, agentStatusError string) {
 	t.Helper()
 	hub.SaveWorkspaceForTest(t,
 		&types.WorkspaceConfig{
 			SchemaVersion: "v1",
 			Name:          workspace,
 			Files: map[string]string{
-				"elasticclaw-config.yaml": "schema_version: v1\nname: " + workspace + "\nprovider: noop\n",
+				"elasticclaw-config.yaml": "schema_version: v1\nname: " + workspace + "\nprovider: " + provider + "\n",
 				"CONTEXT.md":              "Test context\n",
 			},
 		},
@@ -452,9 +557,10 @@ func saveGitHubIssueWorkflowFixture(t *testing.T, workspace, secret string) {
 			Name:          "test-workflow",
 			Trigger: &types.WorkflowTrigger{
 				GitHubIssues: &types.GitHubIssuesWorkflowTrigger{
-					Event:        "issue_reopened",
-					Repositories: []string{"testorg/testrepo"},
-					States:       []string{"open"},
+					Event:            "issue_reopened",
+					Repositories:     []string{"testorg/testrepo"},
+					States:           []string{"open"},
+					AgentStatusError: agentStatusError,
 				},
 			},
 			Stages: []types.WorkflowStage{{
@@ -468,6 +574,15 @@ func saveGitHubIssueWorkflowFixture(t *testing.T, workspace, secret string) {
 		}},
 	)
 	hub.SaveWorkspaceIssueTrackerForTest(t, workspace, "github-issues", "default", "test-github-issues-token", secret)
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }
 
 func saveGitHubIssueLabeledWorkflowFixture(t *testing.T, workspace string) {

--- a/pkg/hub/github_issues_webhook_test.go
+++ b/pkg/hub/github_issues_webhook_test.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -472,6 +473,33 @@ func TestGitHubIssuesWorkflowCreateFailureCommentsLabelsAndAssignsTriggerActor(t
 	}
 }
 
+func TestGitHubIssuesWorkflowCreateFailureIgnoresErrorLabelWebhook(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	ghi := factorytest.NewMockGitHubIssues(t)
+	ghi.WebhookSecret = "secret"
+	li := factorytest.NewMockLinear(t)
+
+	cfg := &types.HubConfig{ClawToken: "test-claw-token"}
+	s, _ := hub.NewTestServerWithConfig(t, cfg, ghi.URL, li.URL, "")
+	saveGitHubIssueLabeledWorkflowFixtureWithProviderAndErrorLabel(t, "workspace-a", "secret", "missing-provider", "agent-error")
+
+	httpSrv := httptest.NewServer(s.Handler())
+	t.Cleanup(httpSrv.Close)
+
+	ghi.SetIssue("testorg/testrepo", 42, factorytest.IssueState{
+		Title:  "Test Issue",
+		Body:   "Main issue body",
+		State:  "open",
+		Labels: []string{"agent-ready"},
+	})
+	postGitHubIssuesWebhook(t, httpSrv.URL, "workspace-a", "delivery-ready", labeledGitHubIssuePayload(t, ghi, "testorg/testrepo", 42, "agent-ready"))
+
+	waitForGitHubIssueLabel(t, ghi, "testorg/testrepo", 42, "agent-error")
+	postGitHubIssuesWebhook(t, httpSrv.URL, "workspace-a", "delivery-error-label", labeledGitHubIssuePayload(t, ghi, "testorg/testrepo", 42, "agent-error"))
+
+	assertGitHubIssueCommentCountStable(t, ghi, "testorg/testrepo", 42, 1)
+}
+
 func waitForGitHubIssueContext(t *testing.T, db *sql.DB, issueID string) string {
 	t.Helper()
 	var filesJSON string
@@ -495,14 +523,32 @@ func waitForGitHubIssueContext(t *testing.T, db *sql.DB, issueID string) string 
 
 func waitForGitHubIssuePostedComment(t *testing.T, ghi *factorytest.MockGitHubIssues, repo string, number int) string {
 	t.Helper()
+	comments := waitForGitHubIssuePostedComments(t, ghi, repo, number, 1)
+	return comments[len(comments)-1]
+}
+
+func waitForGitHubIssuePostedComments(t *testing.T, ghi *factorytest.MockGitHubIssues, repo string, number, wantAtLeast int) []string {
+	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)
 	for {
 		comments := ghi.PostedComments(repo, number)
-		if len(comments) > 0 {
-			return comments[len(comments)-1]
+		if len(comments) >= wantAtLeast {
+			return comments
 		}
 		if time.Now().After(deadline) {
 			t.Fatalf("timed out waiting for GitHub issue comment")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func assertGitHubIssueCommentCountStable(t *testing.T, ghi *factorytest.MockGitHubIssues, repo string, number, want int) {
+	t.Helper()
+	deadline := time.Now().Add(300 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		comments := ghi.PostedComments(repo, number)
+		if len(comments) != want {
+			t.Fatalf("posted %d failure comments, want %d: %#v", len(comments), want, comments)
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
@@ -574,6 +620,103 @@ func saveGitHubIssueWorkflowFixtureWithProviderAndErrorLabel(t *testing.T, works
 		}},
 	)
 	hub.SaveWorkspaceIssueTrackerForTest(t, workspace, "github-issues", "default", "test-github-issues-token", secret)
+}
+
+func saveGitHubIssueLabeledWorkflowFixtureWithProviderAndErrorLabel(t *testing.T, workspace, secret, provider, agentStatusError string) {
+	t.Helper()
+	hub.SaveWorkspaceForTest(t,
+		&types.WorkspaceConfig{
+			SchemaVersion: "v1",
+			Name:          workspace,
+			Files: map[string]string{
+				"elasticclaw-config.yaml": "schema_version: v1\nname: " + workspace + "\nprovider: " + provider + "\n",
+				"CONTEXT.md":              "Test context\n",
+			},
+		},
+		[]*types.WorkflowConfig{{
+			SchemaVersion: "v1",
+			Name:          "test-workflow",
+			Trigger: &types.WorkflowTrigger{
+				GitHubIssues: &types.GitHubIssuesWorkflowTrigger{
+					Event:            "issue_labeled",
+					Repositories:     []string{"testorg/testrepo"},
+					States:           []string{"open"},
+					Labels:           []string{"agent-ready"},
+					Labelers:         []string{"*"},
+					AgentStatusError: agentStatusError,
+				},
+			},
+			Stages: []types.WorkflowStage{{
+				ID:    "working",
+				Label: "Working",
+				Entry: true,
+				OnEnter: map[string]interface{}{
+					"inject": "Read your CONTEXT.md and start working on the issue.\n",
+				},
+			}},
+		}},
+	)
+	hub.SaveWorkspaceIssueTrackerForTest(t, workspace, "github-issues", "default", "test-github-issues-token", secret)
+}
+
+func postGitHubIssuesWebhook(t *testing.T, serverURL, workspace, deliveryID string, payload []byte) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, serverURL+"/api/workspaces/"+workspace+"/webhooks/github-issues", strings.NewReader(string(payload)))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Hub-Signature-256", hmacSHA256(payload, "secret"))
+	req.Header.Set("X-GitHub-Delivery", deliveryID)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func labeledGitHubIssuePayload(t *testing.T, ghi *factorytest.MockGitHubIssues, repo string, number int, label string) []byte {
+	t.Helper()
+	issue := ghi.Issue(repo, number)
+	if !containsString(issue.Labels, label) {
+		issue.Labels = append(issue.Labels, label)
+		ghi.SetIssue(repo, number, issue)
+	}
+	payload := map[string]interface{}{
+		"action": "labeled",
+		"issue": map[string]interface{}{
+			"id":           number,
+			"number":       number,
+			"title":        issue.Title,
+			"body":         issue.Body,
+			"html_url":     fmt.Sprintf("https://github.com/%s/issues/%d", repo, number),
+			"state":        issue.State,
+			"state_reason": "",
+			"labels":       labelsToNameMapsForTest(issue.Labels),
+			"assignee":     nil,
+			"user":         map[string]interface{}{"login": "testuser", "type": "User"},
+		},
+		"repository": map[string]interface{}{"full_name": repo},
+		"sender":     map[string]interface{}{"login": "testuser", "type": "User"},
+		"label":      map[string]interface{}{"name": label},
+	}
+	out, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	return out
+}
+
+func labelsToNameMapsForTest(labels []string) []map[string]string {
+	out := make([]map[string]string, 0, len(labels))
+	for _, label := range labels {
+		out = append(out, map[string]string{"name": label})
+	}
+	return out
 }
 
 func containsString(values []string, want string) bool {

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -50,6 +50,13 @@ type linearWebhookPayload struct {
 			Name string `json:"name"`
 		} `json:"state,omitempty"`
 	} `json:"updatedFrom,omitempty"`
+	Actor struct {
+		ID    string `json:"id"`
+		Type  string `json:"type"`
+		Name  string `json:"name"`
+		Email string `json:"email"`
+		URL   string `json:"url"`
+	} `json:"actor,omitempty"`
 	WebhookID string `json:"webhookId,omitempty"`
 }
 
@@ -405,6 +412,7 @@ func (s *Server) processLinearWorkflowEvent(workspaces []*types.WorkspaceConfig,
 				log.Printf("[workflow:%s/%s] Linear issue %s entered %q — creating claw", workspace.Name, workflow.Name, issueID, workflow.TriggerStatus)
 				if err := s.createClawForLinearWorkflow(workspace, workflow, payload, "linear webhook"); err != nil {
 					log.Printf("[workflow:%s/%s] failed to create claw for %s: %v", workspace.Name, workflow.Name, issueID, err)
+					s.notifyLinearWorkflowCreateFailure(workspace, workflow, payload, err)
 				}
 			}
 			if workflow.TerminateOnLeave && !strings.EqualFold(currentStatus, workflow.TriggerStatus) {
@@ -419,6 +427,31 @@ func (s *Server) processLinearWorkflowEvent(workspaces []*types.WorkspaceConfig,
 		}
 	}
 	return matched
+}
+
+func (s *Server) notifyLinearWorkflowCreateFailure(workspace *types.WorkspaceConfig, workflow *types.WorkflowConfig, payload linearWebhookPayload, createErr error) {
+	if workspace == nil || workflow == nil || workflow.Trigger == nil || workflow.Trigger.Linear == nil {
+		return
+	}
+	token := s.resolveLinearTokenForWorkflow(workspace.Name, workflow)
+	if token == "" {
+		log.Printf("[agent-failure-feedback] workflow %s/%s has no Linear token; skipping failure feedback", workspace.Name, workflow.Name)
+		return
+	}
+	s.handleAgentFailureFeedback(agentFailureFeedback{
+		Integration:      "linear",
+		IssueID:          payload.Data.Identifier,
+		LinearIdentifier: payload.Data.Identifier,
+		TriggerActor: triggerActor{
+			ID:    payload.Actor.ID,
+			Type:  payload.Actor.Type,
+			Name:  payload.Actor.Name,
+			Email: payload.Actor.Email,
+			URL:   payload.Actor.URL,
+		},
+		AgentStatusError: strings.TrimSpace(workflow.Trigger.Linear.AgentStatusError),
+		Failure:          classifyAgentFailure(createErr.Error()),
+	}, token)
 }
 
 func (s *Server) createClawForLinearWorkflow(workspace *types.WorkspaceConfig, workflow *types.WorkflowConfig, payload linearWebhookPayload, reason string) error {
@@ -467,6 +500,13 @@ func (s *Server) createClawForLinearWorkflow(workspace *types.WorkspaceConfig, w
 		clawName:       clawName,
 		linearIssueID:  issueID,
 		reason:         reason,
+		triggerActor: &triggerActor{
+			ID:    payload.Actor.ID,
+			Type:  payload.Actor.Type,
+			Name:  payload.Actor.Name,
+			Email: payload.Actor.Email,
+			URL:   payload.Actor.URL,
+		},
 	})
 	if err != nil {
 		return err

--- a/pkg/hub/linear_webhook_test.go
+++ b/pkg/hub/linear_webhook_test.go
@@ -72,6 +72,36 @@ func TestLinearWorkflowCreateFailureCommentsMovesAndAssignsTriggerActor(t *testi
 	}
 }
 
+func TestLinearWorkflowCreateFailureDoesNotReprocessErrorStatusWebhook(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	linear := factorytest.NewMockLinear(t)
+
+	cfg := &types.HubConfig{ClawToken: "test-claw-token"}
+	s, _ := hub.NewTestServerWithConfig(t, cfg, "", linear.URL, "")
+	saveLinearIssueWorkflowFixtureWithProviderAndErrorStatus(t, "workspace-a", "missing-provider", "Agent Error")
+	hub.SaveWorkspaceIssueTrackerForTest(t, "workspace-a", "linear", "default", "test-linear-token", "")
+
+	httpSrv := httptest.NewServer(s.Handler())
+	t.Cleanup(httpSrv.Close)
+
+	postLinearWebhook(t, httpSrv.URL, "workspace-a", linearWebhookPayloadWithActor(t, linear, "ELA-123", "Backlog", "Todo", map[string]interface{}{
+		"id":   "user-123",
+		"type": "user",
+		"name": "Marc Developer",
+		"url":  "https://linear.app/test/profiles/user-123",
+	}))
+	waitForLinearIssueState(t, linear, "ELA-123", "Agent Error")
+
+	postLinearWebhook(t, httpSrv.URL, "workspace-a", linearWebhookPayloadWithActor(t, linear, "ELA-123", "Todo", "Agent Error", map[string]interface{}{
+		"id":   "user-123",
+		"type": "user",
+		"name": "Marc Developer",
+		"url":  "https://linear.app/test/profiles/user-123",
+	}))
+
+	assertLinearIssueCommentCountStable(t, linear, "ELA-123", 1)
+}
+
 func saveLinearIssueWorkflowFixtureWithProviderAndErrorStatus(t *testing.T, workspace, provider, agentStatusError string) {
 	t.Helper()
 	hub.SaveWorkspaceForTest(t,
@@ -121,6 +151,24 @@ func linearWebhookPayloadWithActor(t *testing.T, linear *factorytest.MockLinear,
 	return out
 }
 
+func postLinearWebhook(t *testing.T, serverURL, workspace string, payload []byte) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, serverURL+"/api/workspaces/"+workspace+"/webhooks/linear", strings.NewReader(string(payload)))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+}
+
 func waitForLinearIssuePostedComment(t *testing.T, linear *factorytest.MockLinear, issueID string) string {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)
@@ -131,6 +179,18 @@ func waitForLinearIssuePostedComment(t *testing.T, linear *factorytest.MockLinea
 		}
 		if time.Now().After(deadline) {
 			t.Fatalf("timed out waiting for Linear issue comment")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func assertLinearIssueCommentCountStable(t *testing.T, linear *factorytest.MockLinear, issueID string, want int) {
+	t.Helper()
+	deadline := time.Now().Add(300 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		comments := linear.Comments(issueID)
+		if len(comments) != want {
+			t.Fatalf("posted %d failure comments, want %d: %#v", len(comments), want, comments)
 		}
 		time.Sleep(10 * time.Millisecond)
 	}

--- a/pkg/hub/linear_webhook_test.go
+++ b/pkg/hub/linear_webhook_test.go
@@ -1,0 +1,165 @@
+package hub_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/hub"
+	"github.com/elasticclaw/elasticclaw/pkg/hub/factorytest"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func TestLinearWorkflowCreateFailureCommentsMovesAndAssignsTriggerActor(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	linear := factorytest.NewMockLinear(t)
+
+	cfg := &types.HubConfig{ClawToken: "test-claw-token"}
+	s, db := hub.NewTestServerWithConfig(t, cfg, "", linear.URL, "")
+	saveLinearIssueWorkflowFixtureWithProviderAndErrorStatus(t, "workspace-a", "missing-provider", "Agent Error")
+	hub.SaveWorkspaceIssueTrackerForTest(t, "workspace-a", "linear", "default", "test-linear-token", "")
+
+	httpSrv := httptest.NewServer(s.Handler())
+	t.Cleanup(httpSrv.Close)
+
+	payload := linearWebhookPayloadWithActor(t, linear, "ELA-123", "Backlog", "Todo", map[string]interface{}{
+		"id":   "user-123",
+		"type": "user",
+		"name": "Marc Developer",
+		"url":  "https://linear.app/test/profiles/user-123",
+	})
+	req, err := http.NewRequest(http.MethodPost, httpSrv.URL+"/api/workspaces/workspace-a/webhooks/linear", strings.NewReader(string(payload)))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	comment := waitForLinearIssuePostedComment(t, linear, "ELA-123")
+	for _, want := range []string{
+		"Marc Developer",
+		"ElasticClaw could not finish this implementation.",
+		"Status code: 500",
+		"ElasticClaw could not find a valid execution provider.",
+		"Check the ElasticClaw workspace/workflow configuration, then re-trigger the workflow.",
+	} {
+		if !strings.Contains(comment, want) {
+			t.Fatalf("comment missing %q:\n%s", want, comment)
+		}
+	}
+	if strings.Contains(comment, "missing-provider") {
+		t.Fatalf("comment exposed raw provider error:\n%s", comment)
+	}
+	waitForLinearIssueState(t, linear, "ELA-123", "Agent Error")
+	waitForLinearIssueAssignee(t, linear, "ELA-123", "user-123")
+	var claws int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM claws WHERE linear_issue_id='ELA-123'`).Scan(&claws); err != nil {
+		t.Fatalf("count claws: %v", err)
+	}
+	if claws != 0 {
+		t.Fatalf("created %d claws, want 0 for creation failure", claws)
+	}
+}
+
+func saveLinearIssueWorkflowFixtureWithProviderAndErrorStatus(t *testing.T, workspace, provider, agentStatusError string) {
+	t.Helper()
+	hub.SaveWorkspaceForTest(t,
+		&types.WorkspaceConfig{
+			SchemaVersion: "v1",
+			Name:          workspace,
+			Files: map[string]string{
+				"elasticclaw-config.yaml": "schema_version: v1\nname: " + workspace + "\nprovider: " + provider + "\n",
+				"CONTEXT.md":              "Test context\n",
+			},
+		},
+		[]*types.WorkflowConfig{{
+			SchemaVersion: "v1",
+			Name:          "linear-workflow",
+			Trigger: &types.WorkflowTrigger{
+				Linear: &types.LinearWorkflowTrigger{
+					Event:            "status_changed",
+					Team:             "ELA",
+					States:           []string{"Todo"},
+					AgentStatusError: agentStatusError,
+				},
+			},
+			Stages: []types.WorkflowStage{{
+				ID:    "working",
+				Label: "Working",
+				Entry: true,
+				OnEnter: map[string]interface{}{
+					"inject": "Read your CONTEXT.md and start working on the issue.\n",
+				},
+			}},
+		}},
+	)
+}
+
+func linearWebhookPayloadWithActor(t *testing.T, linear *factorytest.MockLinear, issueID, prevStatus, newStatus string, actor map[string]interface{}) []byte {
+	t.Helper()
+	payload, _ := linear.BuildWebhookPayload(issueID, prevStatus, newStatus)
+	var data map[string]interface{}
+	if err := json.Unmarshal(payload, &data); err != nil {
+		t.Fatalf("parse payload: %v", err)
+	}
+	data["actor"] = actor
+	out, err := json.Marshal(data)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	return out
+}
+
+func waitForLinearIssuePostedComment(t *testing.T, linear *factorytest.MockLinear, issueID string) string {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		comments := linear.Comments(issueID)
+		if len(comments) > 0 {
+			return comments[len(comments)-1]
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for Linear issue comment")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func waitForLinearIssueState(t *testing.T, linear *factorytest.MockLinear, issueID, want string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if got := linear.IssueStateName(issueID); got == want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("Linear state = %q, want %q", linear.IssueStateName(issueID), want)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func waitForLinearIssueAssignee(t *testing.T, linear *factorytest.MockLinear, issueID, want string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if got := linear.IssueAssigneeID(issueID); got == want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("Linear assignee = %q, want %q", linear.IssueAssigneeID(issueID), want)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -1652,10 +1652,11 @@ func (s *Server) stopAgentWithReason(clawID, reason string, skipVMTerminate bool
 	s.checkpointBeforeTermination(clawID, "stop-agent")
 	s.syncWorkflowVolumes(clawID)
 
-	// Resolve factory + issueID
+	// Resolve workflow/factory + issueID
+	pipelineCtx, hasPipelineCtx := s.findPipelineContextForClaw(clawID)
 	factory, issueID := s.findFactoryForClaw(clawID)
-	if factory == nil {
-		log.Printf("[stopAgent] claw %s: no factory found, skipping issue tracker comment", clawID[:8])
+	if factory == nil && (!hasPipelineCtx || pipelineCtx.Workflow == nil) {
+		log.Printf("[stopAgent] claw %s: no issue tracker context found, skipping issue tracker comment", clawID[:8])
 	}
 
 	// Fetch tenantID + provider info for broadcast + VM cleanup
@@ -1704,7 +1705,9 @@ func (s *Server) stopAgentWithReason(clawID, reason string, skipVMTerminate bool
 	s.mu.Unlock()
 
 	// 4. Write issue-tracker comment without delaying agent shutdown.
-	if factory != nil && issueID != "" {
+	if hasPipelineCtx && pipelineCtx.Workflow != nil && pipelineCtx.IssueID != "" && isFailureFeedbackWorkflowIntegration(pipelineCtx.Workflow.Integration) {
+		go s.commentWorkflowAgentStopToTracker(clawID, pipelineCtx, reason)
+	} else if factory != nil && issueID != "" {
 		factoryCopy := *factory
 		go s.commentAgentStopToTracker(clawID, &factoryCopy, issueID, reason)
 	}
@@ -1715,6 +1718,60 @@ func (s *Server) stopAgentWithReason(clawID, reason string, skipVMTerminate bool
 	}
 
 	log.Printf("[stopAgent] claw %s stopped: %s", clawID[:8], reason)
+}
+
+func isFailureFeedbackWorkflowIntegration(integration string) bool {
+	return integration == "github-issues" || integration == "linear"
+}
+
+func (s *Server) commentWorkflowAgentStopToTracker(clawID string, ctx pipelineContext, reason string) {
+	if ctx.Workflow == nil || ctx.Workspace == nil || ctx.IssueID == "" {
+		return
+	}
+	feedback := agentFailureFeedback{
+		Integration:  ctx.Workflow.Integration,
+		IssueID:      ctx.IssueID,
+		TriggerActor: s.triggerActorForClaw(clawID),
+		Failure:      classifyAgentFailure(reason),
+		ClawID:       clawID,
+	}
+	switch ctx.Workflow.Integration {
+	case "github-issues":
+		repo, issueNum, ok := parseGitHubIssueWorkflowID(ctx.IssueID)
+		if !ok {
+			log.Printf("[stopAgent] invalid GitHub workflow issue id %q for claw %s", ctx.IssueID, shortID(clawID))
+			return
+		}
+		token := s.resolveGitHubIssuesTokenForWorkflow(ctx.Workspace.Name, ctx.Workflow)
+		if token == "" {
+			return
+		}
+		feedback.GitHubRepo = repo
+		feedback.GitHubIssueNum = issueNum
+		feedback.AgentStatusError = strings.TrimSpace(ctx.Workflow.Trigger.GitHubIssues.AgentStatusError)
+		s.handleAgentFailureFeedback(feedback, token)
+	case "linear":
+		token := s.resolveLinearTokenForWorkflow(ctx.Workspace.Name, ctx.Workflow)
+		if token == "" {
+			return
+		}
+		feedback.LinearIdentifier = ctx.IssueID
+		feedback.AgentStatusError = strings.TrimSpace(ctx.Workflow.Trigger.Linear.AgentStatusError)
+		s.handleAgentFailureFeedback(feedback, token)
+	}
+}
+
+func parseGitHubIssueWorkflowID(issueID string) (string, int, bool) {
+	lastSlash := strings.LastIndex(issueID, "/")
+	if lastSlash <= 0 || lastSlash == len(issueID)-1 {
+		return "", 0, false
+	}
+	repo := issueID[:lastSlash]
+	var issueNum int
+	if _, err := fmt.Sscanf(issueID[lastSlash+1:], "%d", &issueNum); err != nil || issueNum <= 0 {
+		return "", 0, false
+	}
+	return repo, issueNum, true
 }
 
 func (s *Server) commentAgentStopToTracker(clawID string, factory *types.FactoryConfig, issueID, reason string) {

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -1748,7 +1748,9 @@ func (s *Server) commentWorkflowAgentStopToTracker(clawID string, ctx pipelineCo
 		}
 		feedback.GitHubRepo = repo
 		feedback.GitHubIssueNum = issueNum
-		feedback.AgentStatusError = strings.TrimSpace(ctx.Workflow.Trigger.GitHubIssues.AgentStatusError)
+		if ctx.Workflow.Trigger != nil && ctx.Workflow.Trigger.GitHubIssues != nil {
+			feedback.AgentStatusError = strings.TrimSpace(ctx.Workflow.Trigger.GitHubIssues.AgentStatusError)
+		}
 		s.handleAgentFailureFeedback(feedback, token)
 	case "linear":
 		token := s.resolveLinearTokenForWorkflow(ctx.Workspace.Name, ctx.Workflow)
@@ -1756,7 +1758,9 @@ func (s *Server) commentWorkflowAgentStopToTracker(clawID string, ctx pipelineCo
 			return
 		}
 		feedback.LinearIdentifier = ctx.IssueID
-		feedback.AgentStatusError = strings.TrimSpace(ctx.Workflow.Trigger.Linear.AgentStatusError)
+		if ctx.Workflow.Trigger != nil && ctx.Workflow.Trigger.Linear != nil {
+			feedback.AgentStatusError = strings.TrimSpace(ctx.Workflow.Trigger.Linear.AgentStatusError)
+		}
 		s.handleAgentFailureFeedback(feedback, token)
 	}
 }

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -44,7 +44,7 @@ func (s *Server) fetchGitHubIssueDetails(token, repo string, issueNumber int, ba
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := issueTrackerHTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +142,7 @@ func githubAPIAddLabel(baseURL, repo string, issueNumber int, label, token strin
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
 	req.Header.Set("Content-Type", "application/json")
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := issueTrackerHTTPClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -169,7 +169,7 @@ func githubAPIDeleteLabel(baseURL, repo string, issueNumber int, label, token st
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := issueTrackerHTTPClient.Do(req)
 	if err != nil {
 		return err
 	}

--- a/pkg/hub/workflow_creator.go
+++ b/pkg/hub/workflow_creator.go
@@ -223,8 +223,11 @@ func (s *Server) createClawFromWorkflowWithOptions(workspace *types.WorkspaceCon
 		_, _ = s.db.Exec(`UPDATE claws SET shortcut_story_id=? WHERE id=?`, opts.shortcutStoryID, clawID)
 	}
 	if opts.triggerActor != nil {
-		if actorJSON, err := json.Marshal(opts.triggerActor); err == nil {
-			_, _ = s.db.Exec(`UPDATE claws SET trigger_actor_json=? WHERE id=?`, string(actorJSON), clawID)
+		actorJSON, err := json.Marshal(opts.triggerActor)
+		if err != nil {
+			log.Printf("[workflow] failed to marshal trigger actor for claw %s: %v", shortID(clawID), err)
+		} else if _, err := s.db.Exec(`UPDATE claws SET trigger_actor_json=? WHERE id=?`, string(actorJSON), clawID); err != nil {
+			log.Printf("[workflow] failed to persist trigger actor for claw %s: %v", shortID(clawID), err)
 		}
 	}
 

--- a/pkg/hub/workflow_creator.go
+++ b/pkg/hub/workflow_creator.go
@@ -22,6 +22,7 @@ type workflowCreateOptions struct {
 	linearIssueID   string
 	shortcutStoryID string
 	reason          string
+	triggerActor    *triggerActor
 }
 
 func (s *Server) createClawFromWorkflow(workspace *types.WorkspaceConfig, workflow *types.WorkflowConfig, inputs map[string]string, reason string) (string, bool, error) {
@@ -220,6 +221,11 @@ func (s *Server) createClawFromWorkflowWithOptions(workspace *types.WorkspaceCon
 	}
 	if opts.shortcutStoryID != "" {
 		_, _ = s.db.Exec(`UPDATE claws SET shortcut_story_id=? WHERE id=?`, opts.shortcutStoryID, clawID)
+	}
+	if opts.triggerActor != nil {
+		if actorJSON, err := json.Marshal(opts.triggerActor); err == nil {
+			_, _ = s.db.Exec(`UPDATE claws SET trigger_actor_json=? WHERE id=?`, string(actorJSON), clawID)
+		}
 	}
 
 	analyticsEnabled, requiresPR, excludedReason := taskRunAnalyticsContractForWorkflow(workflow)

--- a/pkg/hub/workflow_trigger_test.go
+++ b/pkg/hub/workflow_trigger_test.go
@@ -19,10 +19,18 @@ func TestGitHubIssuesWorkflowTriggerMatchesLabelEvent(t *testing.T) {
 	var payload githubIssuesWebhookPayload
 	payload.Action = "labeled"
 	payload.Sender.Login = "marc"
+	payload.Label = &struct {
+		Name string `json:"name"`
+	}{Name: "agent-ready"}
 
 	if !githubIssuesWorkflowTriggerMatches(trigger, payload, "open", map[string]bool{"agent-ready": true}) {
 		t.Fatal("expected trigger to match labeled open issue with required label")
 	}
+	payload.Label.Name = "agent-error"
+	if githubIssuesWorkflowTriggerMatches(trigger, payload, "open", map[string]bool{"agent-ready": true, "agent-error": true}) {
+		t.Fatal("expected non-trigger label event to be ignored")
+	}
+	payload.Label.Name = "agent-ready"
 	if githubIssuesWorkflowTriggerMatches(trigger, payload, "closed", map[string]bool{"agent-ready": true}) {
 		t.Fatal("expected state filter to reject closed issue")
 	}

--- a/pkg/types/validation.go
+++ b/pkg/types/validation.go
@@ -361,6 +361,9 @@ func validateGitHubIssuesWorkflowTrigger(workflowName string, trigger *GitHubIss
 			return fmt.Errorf("workflow %q: trigger.github_issues.repositories[%d] invalid format %q (expected owner/repo or owner/*)", workflowName, i, repo)
 		}
 	}
+	if trigger.AgentStatusError != "" && strings.TrimSpace(trigger.AgentStatusError) == "" {
+		return fmt.Errorf("workflow %q: trigger.github_issues.agent_status_error cannot be blank", workflowName)
+	}
 	return nil
 }
 
@@ -380,6 +383,9 @@ func validateLinearWorkflowTrigger(workflowName string, trigger *LinearWorkflowT
 		if strings.TrimSpace(state) == "" {
 			return fmt.Errorf("workflow %q: trigger.linear.states[%d] cannot be empty", workflowName, i)
 		}
+	}
+	if trigger.AgentStatusError != "" && strings.TrimSpace(trigger.AgentStatusError) == "" {
+		return fmt.Errorf("workflow %q: trigger.linear.agent_status_error cannot be blank", workflowName)
 	}
 	return nil
 }

--- a/pkg/types/workflow_normalize_test.go
+++ b/pkg/types/workflow_normalize_test.go
@@ -46,6 +46,37 @@ stages:
 	}
 }
 
+func TestWorkflowV1GitHubIssuesTriggerPreservesAgentStatusError(t *testing.T) {
+	data := []byte(`
+schema_version: v1
+name: github-issue
+trigger:
+  github_issues:
+    event: issue_labeled
+    repositories:
+      - elasticclaw/elasticclaw
+    labels:
+      - agent-ready
+    agent_status_error: agent-error
+stages:
+  - id: working
+    entry: true
+`)
+	var workflow WorkflowConfig
+	if err := yaml.Unmarshal(data, &workflow); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if err := NormalizeWorkflowConfig(&workflow); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if err := workflow.Validate(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if got := workflow.Trigger.GitHubIssues.AgentStatusError; got != "agent-error" {
+		t.Fatalf("agent_status_error = %q, want agent-error", got)
+	}
+}
+
 func TestWorkflowConfigRejectsInvalidRunKind(t *testing.T) {
 	workflow := &WorkflowConfig{Name: "invalid-kind", RunKind: "typo"}
 	err := workflow.Validate()
@@ -104,6 +135,79 @@ stages:
 	}
 	if !strings.Contains(workflow.PipelineYAML, "move_issue:") {
 		t.Fatalf("pipeline yaml did not contain move_issue: %q", workflow.PipelineYAML)
+	}
+}
+
+func TestWorkflowV1LinearTriggerPreservesAgentStatusError(t *testing.T) {
+	data := []byte(`
+schema_version: v1
+name: linear-story
+trigger:
+  linear:
+    event: status_changed
+    states:
+      - Todo
+    agent_status_error: Agent Error
+stages:
+  - id: working
+    entry: true
+`)
+	var workflow WorkflowConfig
+	if err := yaml.Unmarshal(data, &workflow); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if err := NormalizeWorkflowConfig(&workflow); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if err := workflow.Validate(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if got := workflow.Trigger.Linear.AgentStatusError; got != "Agent Error" {
+		t.Fatalf("agent_status_error = %q, want Agent Error", got)
+	}
+}
+
+func TestWorkflowV1TriggersRejectBlankAgentStatusError(t *testing.T) {
+	tests := []struct {
+		name string
+		wf   *WorkflowConfig
+		want string
+	}{
+		{
+			name: "github issues",
+			wf: &WorkflowConfig{
+				Name: "github-issue",
+				Trigger: &WorkflowTrigger{GitHubIssues: &GitHubIssuesWorkflowTrigger{
+					Event:            "issue_labeled",
+					Repositories:     []string{"elasticclaw/elasticclaw"},
+					AgentStatusError: "   ",
+				}},
+			},
+			want: "trigger.github_issues.agent_status_error cannot be blank",
+		},
+		{
+			name: "linear",
+			wf: &WorkflowConfig{
+				Name: "linear-story",
+				Trigger: &WorkflowTrigger{Linear: &LinearWorkflowTrigger{
+					Event:            "status_changed",
+					States:           []string{"Todo"},
+					AgentStatusError: "   ",
+				}},
+			},
+			want: "trigger.linear.agent_status_error cannot be blank",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.wf.Validate()
+			if err == nil {
+				t.Fatal("Validate() expected error")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Validate() error = %v, want %q", err, tt.want)
+			}
+		})
 	}
 }
 

--- a/pkg/types/workspace.go
+++ b/pkg/types/workspace.go
@@ -116,21 +116,23 @@ type WorkflowRun struct {
 }
 
 type GitHubIssuesWorkflowTrigger struct {
-	Event        string   `yaml:"event,omitempty" json:"event,omitempty"`
-	Repositories []string `yaml:"repositories,omitempty" json:"repositories,omitempty"`
-	States       []string `yaml:"states,omitempty" json:"states,omitempty"`
-	Labels       []string `yaml:"labels,omitempty" json:"labels,omitempty"`
-	Labelers     []string `yaml:"labelers,omitempty" json:"labelers,omitempty"`
-	AssignedTo   string   `yaml:"assigned_to,omitempty" json:"assigned_to,omitempty"`
+	Event            string   `yaml:"event,omitempty" json:"event,omitempty"`
+	Repositories     []string `yaml:"repositories,omitempty" json:"repositories,omitempty"`
+	States           []string `yaml:"states,omitempty" json:"states,omitempty"`
+	Labels           []string `yaml:"labels,omitempty" json:"labels,omitempty"`
+	Labelers         []string `yaml:"labelers,omitempty" json:"labelers,omitempty"`
+	AssignedTo       string   `yaml:"assigned_to,omitempty" json:"assigned_to,omitempty"`
+	AgentStatusError string   `yaml:"agent_status_error,omitempty" json:"agent_status_error,omitempty"`
 }
 
 type LinearWorkflowTrigger struct {
-	Event      string   `yaml:"event,omitempty" json:"event,omitempty"`
-	Workspace  string   `yaml:"workspace,omitempty" json:"workspace,omitempty"`
-	Team       string   `yaml:"team,omitempty" json:"team,omitempty"`
-	States     []string `yaml:"states,omitempty" json:"states,omitempty"`
-	Labels     []string `yaml:"labels,omitempty" json:"labels,omitempty"`
-	AssignedTo string   `yaml:"assigned_to,omitempty" json:"assigned_to,omitempty"`
+	Event            string   `yaml:"event,omitempty" json:"event,omitempty"`
+	Workspace        string   `yaml:"workspace,omitempty" json:"workspace,omitempty"`
+	Team             string   `yaml:"team,omitempty" json:"team,omitempty"`
+	States           []string `yaml:"states,omitempty" json:"states,omitempty"`
+	Labels           []string `yaml:"labels,omitempty" json:"labels,omitempty"`
+	AssignedTo       string   `yaml:"assigned_to,omitempty" json:"assigned_to,omitempty"`
+	AgentStatusError string   `yaml:"agent_status_error,omitempty" json:"agent_status_error,omitempty"`
 }
 
 type ShortcutWorkflowTrigger struct {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -271,6 +271,7 @@ llm_keys:
 		}
 	})
 	waitForHub(ctx, t, hub)
+	waitForPublicHub(ctx, t, env.PublicURL)
 	return hub
 }
 
@@ -290,6 +291,30 @@ func waitForHub(ctx context.Context, t *testing.T, hub *hubProcess) {
 		time.Sleep(250 * time.Millisecond)
 	}
 	t.Fatalf("hub did not become ready at %s", hub.baseURL)
+}
+
+func waitForPublicHub(ctx context.Context, t *testing.T, publicURL string) {
+	t.Helper()
+	deadline := time.Now().Add(90 * time.Second)
+	healthURL := strings.TrimRight(publicURL, "/") + "/healthz"
+	var lastErr string
+	for time.Now().Before(deadline) {
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
+		req.Header.Set("ngrok-skip-browser-warning", "true")
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return
+			}
+			lastErr = fmt.Sprintf("status %d", resp.StatusCode)
+		} else {
+			lastErr = err.Error()
+		}
+		time.Sleep(1 * time.Second)
+	}
+	t.Fatalf("public hub URL %s did not become reachable: %s", healthURL, lastErr)
 }
 
 func writeWorkspaceFixture(t *testing.T, env e2eEnv, workspaceName, workflowName, labelName string) string {


### PR DESCRIPTION
## Summary
- add workflow failure feedback for GitHub Issues and Linear triggers
- comment failures with status code, user-facing explanation, and next step
- optionally mark GitHub issues with `trigger.github_issues.agent_status_error` labels and Linear tickets with `trigger.linear.agent_status_error` statuses
- persist the trigger actor and reassign failed issue/ticket feedback to that actor

## Tests
- `go test ./pkg/hub/... ./pkg/types/...`

Note: the local spec under `docs/` was intentionally left uncommitted.