### PR TITLE
Add exclude label filters to hub workflows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ test-factory: ## Run factory integration tests
 	go test -v -tags integration -timeout 60s ./pkg/hub/... -run TestFactory
 
 test-parity: ## Run parity matrix integration tests (all trackers)
-	go test -v -tags integration -timeout 120s ./pkg/hub/... -run TestParity
+	go test -v -tags integration -timeout 300s ./pkg/hub/... -run TestParity
 
 e2e: e2e-github e2e-linear e2e-replicated-github e2e-replicated-linear ## Run all real E2E suites sequentially
 

--- a/pkg/hub/external_storage.go
+++ b/pkg/hub/external_storage.go
@@ -245,6 +245,9 @@ func saveExternalFactory(f *types.FactoryConfig) error {
 	if f == nil || f.Name == "" {
 		return fmt.Errorf("factory name required")
 	}
+	if err := f.Validate(); err != nil {
+		return err
+	}
 	if err := validateName(f.Name); err != nil {
 		return err
 	}

--- a/pkg/hub/external_storage_validation_test.go
+++ b/pkg/hub/external_storage_validation_test.go
@@ -1,0 +1,26 @@
+package hub
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func TestSaveExternalFactoryRejectsInvalidExcludeLabels(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+
+	err := saveExternalFactory(&types.FactoryConfig{
+		Name:          "invalid-label-filter",
+		Integration:   "linear",
+		TriggerStatus: "Ready",
+		Template:      "elasticclaw",
+		ExcludeLabels: []string{" "},
+	})
+	if err == nil {
+		t.Fatal("saveExternalFactory succeeded, want validation error")
+	}
+	if !strings.Contains(err.Error(), "exclude_labels[0] cannot be blank") {
+		t.Fatalf("error = %v, want exclude_labels validation", err)
+	}
+}

--- a/pkg/hub/factory_api.go
+++ b/pkg/hub/factory_api.go
@@ -34,19 +34,20 @@ func (s *Server) handleFactoriesCRUD(w http.ResponseWriter, r *http.Request) {
 
 // FactoryPushView is the JSON-safe view of a factory returned by push/list API (secrets masked).
 type FactoryPushView struct {
-	Name                string              `json:"name"`
-	Integration         string              `json:"integration"`
-	Workspace           string              `json:"workspace"`
-	TriggerStatus       string              `json:"trigger_status"`
-	DoneStatus          string              `json:"done_status,omitempty"`
-	Template            string              `json:"template"`
-	Labels              []string            `json:"labels,omitempty"`
-	AssignedTo          string              `json:"assigned_to,omitempty"`
-	Enabled             *bool               `json:"enabled,omitempty"`
-	HasWebhookSecret    bool                `json:"has_webhook_secret"`
-	WebhookSecretRef    string              `json:"webhook_secret_ref,omitempty"`
-	PipelineYAML        string              `json:"pipeline_yaml,omitempty"`
-	EnableManualTrigger bool                `json:"enable_manual_trigger,omitempty"`
+	Name                string               `json:"name"`
+	Integration         string               `json:"integration"`
+	Workspace           string               `json:"workspace"`
+	TriggerStatus       string               `json:"trigger_status"`
+	DoneStatus          string               `json:"done_status,omitempty"`
+	Template            string               `json:"template"`
+	Labels              []string             `json:"labels,omitempty"`
+	ExcludeLabels       []string             `json:"exclude_labels,omitempty"`
+	AssignedTo          string               `json:"assigned_to,omitempty"`
+	Enabled             *bool                `json:"enabled,omitempty"`
+	HasWebhookSecret    bool                 `json:"has_webhook_secret"`
+	WebhookSecretRef    string               `json:"webhook_secret_ref,omitempty"`
+	PipelineYAML        string               `json:"pipeline_yaml,omitempty"`
+	EnableManualTrigger bool                 `json:"enable_manual_trigger,omitempty"`
 	SecretRefs          map[string]string    `json:"secret_refs,omitempty"`
 	Inputs              []types.FactoryInput `json:"inputs,omitempty"`
 }
@@ -60,6 +61,7 @@ func factoryToPushView(f *types.FactoryConfig) FactoryPushView {
 		DoneStatus:          f.DoneStatus,
 		Template:            f.Template,
 		Labels:              f.Labels,
+		ExcludeLabels:       f.ExcludeLabels,
 		AssignedTo:          f.AssignedTo,
 		Enabled:             f.Enabled,
 		HasWebhookSecret:    f.WebhookSecret != "" || f.WebhookSecretRef != "",

--- a/pkg/hub/github_issues.go
+++ b/pkg/hub/github_issues.go
@@ -164,7 +164,7 @@ func (s *Server) validateGitHubIssuesSignatureReason(workspaceName string, body 
 		}
 		return "no configured factory webhook secret"
 	}
-	return "no configured workspace webhook secret"
+	return ""
 }
 
 func verifyGitHubHMAC(body []byte, sig, secret string) bool {

--- a/pkg/hub/github_issues.go
+++ b/pkg/hub/github_issues.go
@@ -162,8 +162,9 @@ func (s *Server) validateGitHubIssuesSignatureReason(workspaceName string, body 
 		if factorySecretCount > 0 {
 			return fmt.Sprintf("signature did not match any configured factory webhook secret (%d checked)", factorySecretCount)
 		}
+		return "no configured factory webhook secret"
 	}
-	return ""
+	return "no configured workspace webhook secret"
 }
 
 func verifyGitHubHMAC(body []byte, sig, secret string) bool {

--- a/pkg/hub/github_issues.go
+++ b/pkg/hub/github_issues.go
@@ -83,11 +83,6 @@ func (s *Server) handleGitHubIssuesWebhook(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	workspaceName := strings.TrimSpace(r.PathValue("workspace"))
-	if workspaceName == "" {
-		log.Printf("[github-issues-webhook] %s ignored; use /api/workspaces/{workspace}/webhooks/github-issues", r.URL.Path)
-		w.WriteHeader(http.StatusOK)
-		return
-	}
 
 	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
 	if err != nil {
@@ -143,6 +138,31 @@ func (s *Server) validateGitHubIssuesSignatureReason(workspaceName string, body 
 	if workspaceSecretCount > 0 {
 		return fmt.Sprintf("signature did not match any configured workspace webhook secret (%d checked)", workspaceSecretCount)
 	}
+	if workspaceName == "" {
+		factorySecretCount := 0
+		s.mu.RLock()
+		secrets := s.hubCfg.Secrets
+		s.mu.RUnlock()
+		for _, factory := range s.resolveFactories() {
+			if factory.Integration != "github-issues" {
+				continue
+			}
+			secret := factory.WebhookSecret
+			if secret == "" && factory.WebhookSecretRef != "" && secrets != nil {
+				secret = secrets[factory.WebhookSecretRef]
+			}
+			if secret == "" {
+				continue
+			}
+			factorySecretCount++
+			if verifyGitHubHMAC(body, sig, secret) {
+				return ""
+			}
+		}
+		if factorySecretCount > 0 {
+			return fmt.Sprintf("signature did not match any configured factory webhook secret (%d checked)", factorySecretCount)
+		}
+	}
 	return ""
 }
 
@@ -162,14 +182,6 @@ func (s *Server) processGitHubIssuesEvent(workspaceName string, payload githubIs
 	issueID := fmt.Sprintf("%s/%d", payload.Repository.FullName, payload.Issue.Number)
 	log.Printf("[github-issues-webhook] processing event: action=%q issue=%s title=%q sender=%q",
 		payload.Action, issueID, payload.Issue.Title, payload.Sender.Login)
-
-	workflowWorkspaces, _ := loadExternalWorkflowsByIntegration("github-issues")
-	workflowWorkspaces = filterWorkflowWorkspacesByName(workflowWorkspaces, workspaceName)
-	if len(workflowWorkspaces) == 0 {
-		log.Printf("[github-issues-webhook] no workflows configured — nothing to do")
-		return
-	}
-	log.Printf("[github-issues-webhook] checking %d workflow workspace(s)", len(workflowWorkspaces))
 
 	currentStatus := payload.Issue.State
 	previousStatus := ""
@@ -232,6 +244,21 @@ func (s *Server) processGitHubIssuesEvent(workspaceName string, payload githubIs
 		}
 	}
 
+	if workspaceName == "" {
+		if !s.processGitHubIssuesFactoryEvent(payload, issueID, currentStatus, issueLabels, assignee) {
+			log.Printf("[github-issues-webhook] no factory matched for issue %s", issueID)
+		}
+		return
+	}
+
+	workflowWorkspaces, _ := loadExternalWorkflowsByIntegration("github-issues")
+	workflowWorkspaces = filterWorkflowWorkspacesByName(workflowWorkspaces, workspaceName)
+	if len(workflowWorkspaces) == 0 {
+		log.Printf("[github-issues-webhook] no workflows configured — nothing to do")
+		return
+	}
+	log.Printf("[github-issues-webhook] checking %d workflow workspace(s)", len(workflowWorkspaces))
+
 	if !s.processGitHubIssuesWorkflowEvent(workflowWorkspaces, payload, issueID, issueTitle, currentStatus, previousStatus, previousLabels, issueLabels, assignee) {
 		log.Printf("[github-issues-webhook] no workflow matched for issue %s", issueID)
 	}
@@ -253,6 +280,57 @@ func githubIssuesWorkflowTriggerRepos(workflow *types.WorkflowConfig) []string {
 		return workflow.TriggerRepos
 	}
 	return workflow.Repos
+}
+
+func (s *Server) processGitHubIssuesFactoryEvent(payload githubIssuesWebhookPayload, issueID, currentStatus string, issueLabels map[string]bool, assignee string) bool {
+	matched := false
+	for _, factory := range s.resolveFactories() {
+		if factory.Integration != "github-issues" {
+			continue
+		}
+		if factory.Enabled != nil && !*factory.Enabled {
+			continue
+		}
+		if !githubRepoMatches(payload.Repository.FullName, githubIssuesTriggerRepos(factory)) {
+			continue
+		}
+		if factory.TriggerStatus == "" {
+			continue
+		}
+		if !strings.EqualFold(currentStatus, factory.TriggerStatus) && !issueLabels[strings.ToLower(factory.TriggerStatus)] {
+			continue
+		}
+		if !labelSetAllowed(issueLabels, factory.Labels, factory.ExcludeLabels) {
+			continue
+		}
+		if !s.assigneeMatches(assignee, factory.AssignedTo) {
+			continue
+		}
+		if len(factory.AllowedLabelers) > 0 && payload.Action == "labeled" {
+			allowed := false
+			for _, labeler := range factory.AllowedLabelers {
+				if strings.EqualFold(labeler, payload.Sender.Login) {
+					allowed = true
+					break
+				}
+			}
+			if !allowed {
+				continue
+			}
+		}
+		matched = true
+		log.Printf("[factory:%s] GitHub issue %s matched factory trigger — creating claw", factory.Name, issueID)
+		if err := s.createClawForGitHubIssue(factory, payload, "github-issues webhook"); err != nil {
+			if isFactoryTriggerAlreadyClaimed(err) {
+				continue
+			}
+			log.Printf("[factory:%s] failed to create claw for issue %s: %v", factory.Name, issueID, err)
+			s.logFactoryEvent(factory.Name, issueID, payload.Issue.Title, "", currentStatus, "error", "", err.Error())
+		} else {
+			s.logFactoryEvent(factory.Name, issueID, payload.Issue.Title, "", currentStatus, "claw_created", "", "github-issues webhook")
+		}
+	}
+	return matched
 }
 
 func (s *Server) processGitHubIssuesWorkflowEvent(workspaces []*types.WorkspaceConfig, payload githubIssuesWebhookPayload, issueID, issueTitle, currentStatus, previousStatus string, previousLabels, issueLabels map[string]bool, assignee string) bool {

--- a/pkg/hub/github_issues.go
+++ b/pkg/hub/github_issues.go
@@ -277,17 +277,8 @@ func (s *Server) processGitHubIssuesWorkflowEvent(workspaces []*types.WorkspaceC
 					continue
 				}
 			} else {
-				if len(workflow.Labels) > 0 {
-					allMatch := true
-					for _, required := range workflow.Labels {
-						if !issueLabels[strings.ToLower(required)] {
-							allMatch = false
-							break
-						}
-					}
-					if !allMatch {
-						continue
-					}
+				if !labelSetAllowed(issueLabels, workflow.Labels, workflow.ExcludeLabels) {
+					continue
 				}
 				if len(workflow.AllowedLabelers) > 0 && (payload.Action == "labeled" || payload.Action == "unlabeled") {
 					allowed := false
@@ -353,12 +344,12 @@ func githubIssuesWorkflowTriggerMatches(trigger *types.WorkflowTrigger, payload 
 		return false
 	}
 	if trigger.GitHubIssues != nil {
-		return githubIssuesWorkflowSourceMatches(trigger.GitHubIssues.Event, trigger.GitHubIssues.States, trigger.GitHubIssues.Labels, trigger.GitHubIssues.Labelers, payload, currentStatus, issueLabels)
+		return githubIssuesWorkflowSourceMatches(trigger.GitHubIssues.Event, trigger.GitHubIssues.States, trigger.GitHubIssues.Labels, trigger.GitHubIssues.ExcludeLabels, trigger.GitHubIssues.Labelers, payload, currentStatus, issueLabels)
 	}
 	return false
 }
 
-func githubIssuesWorkflowSourceMatches(event string, states, labels, labelers []string, payload githubIssuesWebhookPayload, currentStatus string, issueLabels map[string]bool) bool {
+func githubIssuesWorkflowSourceMatches(event string, states, labels, excludeLabels, labelers []string, payload githubIssuesWebhookPayload, currentStatus string, issueLabels map[string]bool) bool {
 	switch event {
 	case "issue_labeled":
 		if payload.Action != "labeled" {
@@ -402,10 +393,8 @@ func githubIssuesWorkflowSourceMatches(event string, states, labels, labelers []
 			return false
 		}
 	}
-	for _, required := range labels {
-		if !issueLabels[strings.ToLower(required)] {
-			return false
-		}
+	if !labelSetAllowed(issueLabels, labels, excludeLabels) {
+		return false
 	}
 	if len(labelers) > 0 && (payload.Action == "labeled" || payload.Action == "unlabeled") {
 		for _, labeler := range labelers {

--- a/pkg/hub/github_issues_webhook_test.go
+++ b/pkg/hub/github_issues_webhook_test.go
@@ -187,6 +187,42 @@ func TestGitHubIssuesIntegrationWebhookRejectsUnsignedWithoutConfiguredSecret(t 
 	}
 }
 
+func TestGitHubIssuesWorkspaceWebhookAllowsUnsignedWithoutConfiguredSecret(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	ghi := factorytest.NewMockGitHubIssues(t)
+	li := factorytest.NewMockLinear(t)
+
+	cfg := &types.HubConfig{
+		ClawToken: "test-claw-token",
+		Providers: map[string]types.ProviderConfig{
+			"noop": {Type: "noop"},
+		},
+	}
+	s, _ := hub.NewTestServerWithConfig(t, cfg, ghi.URL, li.URL, "")
+	saveGitHubIssueWorkflowFixture(t, "workspace-a", "")
+
+	httpSrv := httptest.NewServer(s.Handler())
+	t.Cleanup(httpSrv.Close)
+
+	ghi.SetIssue("testorg/testrepo", 45, factorytest.IssueState{Title: "Unsigned Workspace Issue", Body: "Test body", State: "open"})
+	payload, _ := ghi.BuildWebhookPayload("testorg/testrepo", 45, "closed", "open")
+	req, err := http.NewRequest(http.MethodPost, httpSrv.URL+"/api/workspaces/workspace-a/webhooks/github-issues", strings.NewReader(string(payload)))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Delivery", "delivery-workspace-unsigned-no-secret")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+}
+
 func TestGitHubIssuesWorkspaceWebhookOnlyDispatchesThatWorkspace(t *testing.T) {
 	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
 	ghi := factorytest.NewMockGitHubIssues(t)

--- a/pkg/hub/github_issues_webhook_test.go
+++ b/pkg/hub/github_issues_webhook_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
 
-func TestGitHubIssuesIntegrationWebhookIsIgnored(t *testing.T) {
+func TestGitHubIssuesIntegrationWebhookCreatesFactoryClaw(t *testing.T) {
 	ghi := factorytest.NewMockGitHubIssues(t)
 	ghi.WebhookSecret = "test-webhook-secret"
 	li := factorytest.NewMockLinear(t)
@@ -74,8 +74,69 @@ func TestGitHubIssuesIntegrationWebhookIsIgnored(t *testing.T) {
 	if err := db.QueryRow(`SELECT COUNT(*) FROM claws WHERE github_issue_id='testorg/testrepo/42'`).Scan(&count); err != nil {
 		t.Fatalf("count claws: %v", err)
 	}
+	if count != 1 {
+		t.Fatalf("github issues integration webhook created %d claw(s), want 1", count)
+	}
+}
+
+func TestGitHubIssuesIntegrationWebhookHonorsExcludeLabels(t *testing.T) {
+	ghi := factorytest.NewMockGitHubIssues(t)
+	ghi.WebhookSecret = "test-webhook-secret"
+	li := factorytest.NewMockLinear(t)
+
+	cfg := &types.HubConfig{
+		ClawToken: "test-claw-token",
+		Factories: []*types.FactoryConfig{{
+			Name:          "legacy",
+			Integration:   "github-issues",
+			Workspace:     "test-workspace",
+			TriggerStatus: "open",
+			Template:      "elasticclaw",
+			Provider:      "noop",
+			TriggerRepos:  []string{"testorg/testrepo"},
+			WebhookSecret: "test-webhook-secret",
+			ExcludeLabels: []string{"Bug"},
+		}},
+		Integrations: &types.IntegrationsConfig{
+			GitHubIssues: []*types.GitHubIssuesIntegrationConfig{{
+				Workspace:     "test-workspace",
+				Token:         "test-github-issues-token",
+				WebhookSecret: "test-webhook-secret",
+			}},
+		},
+		Providers: map[string]types.ProviderConfig{"noop": {Type: "noop"}},
+	}
+
+	s, db := hub.NewTestServerWithConfig(t, cfg, ghi.URL, li.URL, "")
+	httpSrv := httptest.NewServer(s.Handler())
+	t.Cleanup(httpSrv.Close)
+
+	ghi.SetIssue("testorg/testrepo", 43, factorytest.IssueState{Title: "Bug Issue", Body: "Test body", State: "open", Labels: []string{"Bug"}})
+	payload, sig := ghi.BuildWebhookPayload("testorg/testrepo", 43, "closed", "open")
+	req, err := http.NewRequest(http.MethodPost, httpSrv.URL+"/api/integrations/github-issues/webhook", strings.NewReader(string(payload)))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Hub-Signature-256", sig)
+	req.Header.Set("X-GitHub-Delivery", "delivery-testorg-testrepo-43")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM claws WHERE github_issue_id='testorg/testrepo/43'`).Scan(&count); err != nil {
+		t.Fatalf("count claws: %v", err)
+	}
 	if count != 0 {
-		t.Fatalf("legacy integration webhook created %d claw(s), want 0", count)
+		t.Fatalf("github issues integration webhook created %d claw(s), want 0", count)
 	}
 }
 

--- a/pkg/hub/github_issues_webhook_test.go
+++ b/pkg/hub/github_issues_webhook_test.go
@@ -140,6 +140,53 @@ func TestGitHubIssuesIntegrationWebhookHonorsExcludeLabels(t *testing.T) {
 	}
 }
 
+func TestGitHubIssuesIntegrationWebhookRejectsUnsignedWithoutConfiguredSecret(t *testing.T) {
+	ghi := factorytest.NewMockGitHubIssues(t)
+	li := factorytest.NewMockLinear(t)
+
+	cfg := &types.HubConfig{
+		ClawToken: "test-claw-token",
+		Factories: []*types.FactoryConfig{{
+			Name:          "legacy",
+			Integration:   "github-issues",
+			Workspace:     "test-workspace",
+			TriggerStatus: "open",
+			Template:      "elasticclaw",
+			Provider:      "noop",
+			TriggerRepos:  []string{"testorg/testrepo"},
+		}},
+		Integrations: &types.IntegrationsConfig{
+			GitHubIssues: []*types.GitHubIssuesIntegrationConfig{{
+				Workspace: "test-workspace",
+				Token:     "test-github-issues-token",
+			}},
+		},
+		Providers: map[string]types.ProviderConfig{"noop": {Type: "noop"}},
+	}
+
+	s, _ := hub.NewTestServerWithConfig(t, cfg, ghi.URL, li.URL, "")
+	httpSrv := httptest.NewServer(s.Handler())
+	t.Cleanup(httpSrv.Close)
+
+	ghi.SetIssue("testorg/testrepo", 44, factorytest.IssueState{Title: "Unsigned Issue", Body: "Test body", State: "open"})
+	payload, _ := ghi.BuildWebhookPayload("testorg/testrepo", 44, "closed", "open")
+	req, err := http.NewRequest(http.MethodPost, httpSrv.URL+"/api/integrations/github-issues/webhook", strings.NewReader(string(payload)))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Delivery", "delivery-unsigned-no-secret")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", resp.StatusCode)
+	}
+}
+
 func TestGitHubIssuesWorkspaceWebhookOnlyDispatchesThatWorkspace(t *testing.T) {
 	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
 	ghi := factorytest.NewMockGitHubIssues(t)

--- a/pkg/hub/github_webhook.go
+++ b/pkg/hub/github_webhook.go
@@ -74,6 +74,16 @@ func (s *Server) handleGitHubWebhook(w http.ResponseWriter, r *http.Request) {
 	}
 
 	switch event {
+	case "issues":
+		var payload githubIssuesWebhookPayload
+		if err := json.Unmarshal(body, &payload); err != nil {
+			log.Printf("[github-webhook] failed to parse issues payload: %v", err)
+			http.Error(w, "invalid payload", http.StatusBadRequest)
+			return
+		}
+		log.Printf("[github-webhook] issues action=%q repo=%q issue=#%d author=%q",
+			payload.Action, payload.Repository.FullName, payload.Issue.Number, payload.Issue.User.Login)
+		go s.processGitHubIssueEvent(payload)
 	case "pull_request":
 		var payload githubPRPayload
 		if err := json.Unmarshal(body, &payload); err != nil {
@@ -208,6 +218,14 @@ func (s *Server) processGitHubPREvent(payload githubPRPayload) {
 				log.Printf("[github-webhook] factory %q: skipped (base_branch mismatch: want %q, got %q)", factory.Name, f.BaseBranch, payload.PullRequest.Base.Ref)
 				continue
 			}
+		}
+		currentLabels, labelsOK := s.githubFactoryPRLabels(factory, repoFullName, payload.Number)
+		if !labelsOK {
+			continue
+		}
+		if !labelsAllowed(currentLabels, factory.Labels, factory.ExcludeLabels) {
+			log.Printf("[github-webhook] factory %q: skipped (PR backing issue labels did not match)", factory.Name)
+			continue
 		}
 
 		// Check if a claw already exists for this PR
@@ -494,6 +512,14 @@ func (s *Server) processGitHubIssueCommentEvent(payload githubIssueCommentPayloa
 				continue
 			}
 		}
+		currentLabels, labelsOK := s.githubFactoryPRLabels(factory, repoFullName, prNumber)
+		if !labelsOK {
+			continue
+		}
+		if !labelsAllowed(currentLabels, factory.Labels, factory.ExcludeLabels) {
+			log.Printf("[github-webhook] factory %q: issue_comment skipped (PR backing issue labels did not match)", factory.Name)
+			continue
+		}
 		log.Printf("[factory:%s] issue_comment triggered claw creation for PR %s#%d", factory.Name, repoFullName, prNumber)
 		if err := s.createClawForGitHubPR(factory, prPayload, "github-pr webhook (issue_comment)"); err != nil {
 			log.Printf("[factory:%s] failed to create claw for PR #%d: %v", factory.Name, prNumber, err)
@@ -506,6 +532,90 @@ func (s *Server) processGitHubIssueCommentEvent(payload githubIssueCommentPayloa
 		}
 		break // success — one factory match is enough
 	}
+}
+
+func (s *Server) processGitHubIssueEvent(payload githubIssuesWebhookPayload) {
+	if payload.Issue.Number == 0 {
+		return
+	}
+	factories := s.resolveFactories()
+	repoFullName := payload.Repository.FullName
+	issueID := fmt.Sprintf("%s/%d", repoFullName, payload.Issue.Number)
+	currentLabels := make([]string, 0, len(payload.Issue.Labels))
+	for _, label := range payload.Issue.Labels {
+		currentLabels = append(currentLabels, label.Name)
+	}
+
+	for _, factory := range factories {
+		if factory.Integration != "github" {
+			continue
+		}
+		if factory.Enabled != nil && !*factory.Enabled {
+			continue
+		}
+		if factory.Trigger == nil || factory.Trigger.On != "issue" {
+			continue
+		}
+		if factory.Trigger.Action != "" && !strings.EqualFold(factory.Trigger.Action, payload.Action) {
+			continue
+		}
+		if !githubRepoMatches(repoFullName, factory.Repos) {
+			continue
+		}
+		if !labelsAllowed(currentLabels, factory.Labels, factory.ExcludeLabels) {
+			log.Printf("[github-webhook] factory %q: skipped issue %s (labels did not match)", factory.Name, issueID)
+			continue
+		}
+		log.Printf("[factory:%s] github issue %s (action=%s) — creating claw", factory.Name, issueID, payload.Action)
+		if err := s.createClawForGitHubIssue(factory, payload, "github-issue webhook"); err != nil {
+			if isFactoryTriggerAlreadyClaimed(err) {
+				continue
+			}
+			log.Printf("[factory:%s] failed to create claw for issue %s: %v", factory.Name, issueID, err)
+			s.logFactoryEvent(factory.Name, issueID, payload.Issue.Title, "", payload.Action, "error", "", err.Error())
+		}
+	}
+}
+
+func (s *Server) githubFactoryPRLabels(factory *types.FactoryConfig, repo string, prNumber int) ([]string, bool) {
+	if len(factory.Labels) == 0 && len(factory.ExcludeLabels) == 0 {
+		return nil, true
+	}
+	labels, err := s.fetchGitHubIssueLabelsForFactory(factory, repo, prNumber)
+	if err != nil {
+		log.Printf("[github-webhook] factory %q: skipping PR %s#%d because backing issue labels could not be fetched: %v", factory.Name, repo, prNumber, err)
+		return nil, false
+	}
+	return labels, true
+}
+
+func (s *Server) fetchGitHubIssueLabelsForFactory(factory *types.FactoryConfig, repo string, issueNumber int) ([]string, error) {
+	token := s.resolveGitHubTokenForRepo(repo)
+	if token == "" {
+		token = s.resolveGitHubIssuesTokenForFactory(factory)
+	}
+	if token == "" {
+		return nil, fmt.Errorf("no GitHub token available")
+	}
+	base := s.githubBaseURL
+	if base == "" {
+		base = "https://api.github.com"
+	}
+	data, err := githubAPIWithBase(base, fmt.Sprintf("repos/%s/issues/%d", repo, issueNumber), token)
+	if err != nil {
+		return nil, err
+	}
+	rawLabels, _ := data["labels"].([]interface{})
+	labels := make([]string, 0, len(rawLabels))
+	for _, raw := range rawLabels {
+		label, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		name, _ := label["name"].(string)
+		labels = append(labels, name)
+	}
+	return labels, nil
 }
 
 // githubRepoMatches returns true if fullName matches any entry in repos.

--- a/pkg/hub/github_webhook.go
+++ b/pkg/hub/github_webhook.go
@@ -573,6 +573,8 @@ func (s *Server) processGitHubIssueEvent(payload githubIssuesWebhookPayload) {
 			}
 			log.Printf("[factory:%s] failed to create claw for issue %s: %v", factory.Name, issueID, err)
 			s.logFactoryEvent(factory.Name, issueID, payload.Issue.Title, "", payload.Action, "error", "", err.Error())
+		} else {
+			s.logFactoryEvent(factory.Name, issueID, payload.Issue.Title, "", payload.Action, "claw_created", "", "github-issue webhook")
 		}
 	}
 }

--- a/pkg/hub/github_webhook_exclude_labels_test.go
+++ b/pkg/hub/github_webhook_exclude_labels_test.go
@@ -1,0 +1,271 @@
+package hub
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func TestGitHubPRFactoryExcludeLabelsUsesBackingIssueLabels(t *testing.T) {
+	ghi := newGitHubIssueLabelMock(t)
+	ghi.setIssueLabels("elastic/claw", 42, []string{"Bug"})
+
+	s, db := newGitHubLabelFactoryTestServer(t, ghi.URL(), []*types.FactoryConfig{{
+		Name:          "generic-pr",
+		Integration:   "github",
+		Template:      "elasticclaw",
+		Provider:      "noop",
+		Repos:         []string{"elastic/claw"},
+		WebhookSecret: "test-webhook-secret",
+		Labels:        []string{"agent-ready"},
+		ExcludeLabels: []string{"Bug"},
+		Trigger:       &types.GitHubTrigger{On: "pull_request"},
+	}})
+
+	postSignedGitHubWebhook(t, s, "pull_request", githubPRWebhookBody("opened", "elastic/claw", 42, "alice", "main"))
+	assertNoGitHubPRClaw(t, db, "https://github.com/elastic/claw/pull/42")
+}
+
+func TestGitHubPRFactoryLabelsAndExcludeLabelsMatchBackingIssueLabels(t *testing.T) {
+	ghi := newGitHubIssueLabelMock(t)
+	ghi.setIssueLabels("elastic/claw", 43, []string{"agent-ready"})
+
+	s, db := newGitHubLabelFactoryTestServer(t, ghi.URL(), []*types.FactoryConfig{{
+		Name:          "generic-pr",
+		Integration:   "github",
+		Template:      "elasticclaw",
+		Provider:      "noop",
+		Repos:         []string{"elastic/claw"},
+		WebhookSecret: "test-webhook-secret",
+		Labels:        []string{"agent-ready"},
+		ExcludeLabels: []string{"Bug"},
+		Trigger:       &types.GitHubTrigger{On: "pull_request"},
+	}})
+
+	postSignedGitHubWebhook(t, s, "pull_request", githubPRWebhookBody("opened", "elastic/claw", 43, "alice", "main"))
+	waitForGitHubPRClaw(t, db, "https://github.com/elastic/claw/pull/43")
+}
+
+func TestGitHubIssueFactoryExcludeLabelsAllowsIssueWithoutExcludedLabel(t *testing.T) {
+	ghi := newGitHubIssueLabelMock(t)
+	ghi.setIssueLabels("elastic/claw", 44, []string{"agent-ready"})
+
+	s, db := newGitHubLabelFactoryTestServer(t, ghi.URL(), []*types.FactoryConfig{{
+		Name:          "generic-issue",
+		Integration:   "github",
+		Template:      "elasticclaw",
+		Provider:      "noop",
+		Repos:         []string{"elastic/claw"},
+		WebhookSecret: "test-webhook-secret",
+		Labels:        []string{"agent-ready"},
+		ExcludeLabels: []string{"Bug"},
+		Trigger:       &types.GitHubTrigger{On: "issue", Action: "opened"},
+	}})
+
+	postSignedGitHubWebhook(t, s, "issues", githubIssueWebhookBody("opened", "elastic/claw", 44, []string{"agent-ready"}))
+	waitForGitHubIssueClaw(t, db, "elastic/claw/44")
+}
+
+func TestGitHubIssueFactoryExcludeLabelsSkipsIssueWithExcludedLabel(t *testing.T) {
+	ghi := newGitHubIssueLabelMock(t)
+	ghi.setIssueLabels("elastic/claw", 45, []string{"agent-ready", "Bug"})
+
+	s, db := newGitHubLabelFactoryTestServer(t, ghi.URL(), []*types.FactoryConfig{{
+		Name:          "generic-issue",
+		Integration:   "github",
+		Template:      "elasticclaw",
+		Provider:      "noop",
+		Repos:         []string{"elastic/claw"},
+		WebhookSecret: "test-webhook-secret",
+		Labels:        []string{"agent-ready"},
+		ExcludeLabels: []string{"Bug"},
+		Trigger:       &types.GitHubTrigger{On: "issue", Action: "opened"},
+	}})
+
+	postSignedGitHubWebhook(t, s, "issues", githubIssueWebhookBody("opened", "elastic/claw", 45, []string{"agent-ready", "Bug"}))
+	assertNoGitHubIssueClaw(t, db, "elastic/claw/45")
+}
+
+func newGitHubLabelFactoryTestServer(t *testing.T, githubBaseURL string, factories []*types.FactoryConfig) (*Server, *sql.DB) {
+	t.Helper()
+	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
+	cfg := &types.HubConfig{
+		ClawToken: "test-claw-token",
+		Factories: factories,
+		Integrations: &types.IntegrationsConfig{
+			GitHubIssues: []*types.GitHubIssuesIntegrationConfig{{
+				Workspace: "default",
+				Token:     "test-github-token",
+			}},
+		},
+		Providers: map[string]types.ProviderConfig{"noop": {Type: "noop"}},
+	}
+	return NewTestServerWithConfig(t, cfg, githubBaseURL, "", "")
+}
+
+type githubIssueLabelMock struct {
+	server *httptest.Server
+	labels map[string][]string
+}
+
+func newGitHubIssueLabelMock(t *testing.T) *githubIssueLabelMock {
+	t.Helper()
+	mock := &githubIssueLabelMock{labels: map[string][]string{}}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/", func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/repos/")
+		parts := strings.Split(path, "/")
+		if r.Method != http.MethodGet || len(parts) != 4 || parts[2] != "issues" {
+			if r.Method == http.MethodGet && len(parts) == 5 && parts[2] == "issues" && parts[4] == "comments" {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte("[]"))
+				return
+			}
+			http.NotFound(w, r)
+			return
+		}
+		var number int
+		fmt.Sscanf(parts[3], "%d", &number)
+		key := fmt.Sprintf("%s/%s#%d", parts[0], parts[1], number)
+		labels, ok := mock.labels[key]
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		respLabels := make([]map[string]string, 0, len(labels))
+		for _, label := range labels {
+			respLabels = append(respLabels, map[string]string{"name": label})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"number": number,
+			"labels": respLabels,
+		})
+	})
+	mock.server = httptest.NewServer(mux)
+	t.Cleanup(mock.server.Close)
+	return mock
+}
+
+func githubIssueWebhookBody(action, repo string, number int, labels []string) map[string]interface{} {
+	rawLabels := make([]map[string]string, 0, len(labels))
+	for _, label := range labels {
+		rawLabels = append(rawLabels, map[string]string{"name": label})
+	}
+	return map[string]interface{}{
+		"action": action,
+		"issue": map[string]interface{}{
+			"id":       number,
+			"number":   number,
+			"title":    "Test Issue",
+			"body":     "Test body",
+			"html_url": fmt.Sprintf("https://github.com/%s/issues/%d", repo, number),
+			"state":    "open",
+			"labels":   rawLabels,
+			"user":     map[string]interface{}{"login": "alice", "type": "User"},
+		},
+		"repository": map[string]interface{}{
+			"full_name": repo,
+		},
+		"sender": map[string]interface{}{"login": "alice", "type": "User"},
+	}
+}
+
+func (m *githubIssueLabelMock) URL() string {
+	return m.server.URL
+}
+
+func (m *githubIssueLabelMock) setIssueLabels(repo string, number int, labels []string) {
+	m.labels[fmt.Sprintf("%s#%d", repo, number)] = append([]string(nil), labels...)
+}
+
+func githubPRWebhookBody(action, repo string, number int, author, baseBranch string) map[string]interface{} {
+	return map[string]interface{}{
+		"action": action,
+		"number": number,
+		"sender": map[string]interface{}{"login": author, "type": "User"},
+		"repository": map[string]interface{}{
+			"full_name": repo,
+		},
+		"pull_request": map[string]interface{}{
+			"html_url": fmt.Sprintf("https://github.com/%s/pull/%d", repo, number),
+			"title":    "Test PR",
+			"user":     map[string]interface{}{"login": author},
+			"head":     map[string]interface{}{"ref": "feature", "sha": "abc123"},
+			"base":     map[string]interface{}{"ref": baseBranch},
+		},
+	}
+}
+
+func waitForGitHubPRClaw(t *testing.T, db *sql.DB, prURL string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		var count int
+		if err := db.QueryRow(`SELECT COUNT(*) FROM claw_prs WHERE pr_url=?`, prURL).Scan(&count); err != nil {
+			t.Fatalf("count PR claws: %v", err)
+		}
+		if count > 0 {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for PR claw for %s", prURL)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func assertNoGitHubPRClaw(t *testing.T, db *sql.DB, prURL string) {
+	t.Helper()
+	deadline := time.Now().Add(300 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		var count int
+		if err := db.QueryRow(`SELECT COUNT(*) FROM claw_prs WHERE pr_url=?`, prURL).Scan(&count); err != nil {
+			t.Fatalf("count PR claws: %v", err)
+		}
+		if count != 0 {
+			t.Fatalf("created %d PR claw(s) for %s, want 0", count, prURL)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func waitForGitHubIssueClaw(t *testing.T, db *sql.DB, issueID string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		var count int
+		if err := db.QueryRow(`SELECT COUNT(*) FROM claws WHERE github_issue_id=?`, issueID).Scan(&count); err != nil {
+			t.Fatalf("count issue claws: %v", err)
+		}
+		if count > 0 {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for issue claw for %s", issueID)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func assertNoGitHubIssueClaw(t *testing.T, db *sql.DB, issueID string) {
+	t.Helper()
+	deadline := time.Now().Add(300 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		var count int
+		if err := db.QueryRow(`SELECT COUNT(*) FROM claws WHERE github_issue_id=?`, issueID).Scan(&count); err != nil {
+			t.Fatalf("count issue claws: %v", err)
+		}
+		if count != 0 {
+			t.Fatalf("created %d issue claw(s) for %s, want 0", count, issueID)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/pkg/hub/integration_poller.go
+++ b/pkg/hub/integration_poller.go
@@ -321,7 +321,7 @@ func (s *Server) processLinearPollItem(issue linearPollIssue, factories []*types
 		if !strings.EqualFold(currentStatus, factory.TriggerStatus) {
 			continue
 		}
-		if !s.labelsMatch(currentLabels, factory.Labels) {
+		if !s.labelsMatch(currentLabels, factory.Labels, factory.ExcludeLabels) {
 			continue
 		}
 		if !s.assigneeMatches(currentAssignee, factory.AssignedTo) {
@@ -376,14 +376,7 @@ func (s *Server) processLinearWorkflowPollItem(issue linearPollIssue, targets []
 		if workflow.AssignedTo != "" && !assignedToMatches(workflow.AssignedTo, currentAssignee) {
 			continue
 		}
-		labelsMatched := true
-		for _, required := range workflow.Labels {
-			if !currentLabels[strings.ToLower(required)] {
-				labelsMatched = false
-				break
-			}
-		}
-		if !labelsMatched {
+		if !labelSetAllowed(currentLabels, workflow.Labels, workflow.ExcludeLabels) {
 			continue
 		}
 
@@ -601,7 +594,7 @@ func (s *Server) processShortcutPollItem(story shortcutPollStory, factories []*t
 		if !strings.EqualFold(currentStateName, factory.TriggerStatus) {
 			continue
 		}
-		if !s.labelsMatch(currentLabels, factory.Labels) {
+		if !s.labelsMatch(currentLabels, factory.Labels, factory.ExcludeLabels) {
 			continue
 		}
 		if !s.assigneeMatches(currentAssignee, factory.AssignedTo) {
@@ -676,14 +669,7 @@ func (s *Server) processShortcutWorkflowPollItem(story shortcutPollStory, target
 		if workflow.AssignedTo != "" && !assignedToMatches(workflow.AssignedTo, currentAssignee) {
 			continue
 		}
-		labelsMatched := true
-		for _, required := range workflow.Labels {
-			if !currentLabels[strings.ToLower(required)] {
-				labelsMatched = false
-				break
-			}
-		}
-		if !labelsMatched {
+		if !labelSetAllowed(currentLabels, workflow.Labels, workflow.ExcludeLabels) {
 			continue
 		}
 		log.Printf("[workflow:%s/%s] Shortcut story %s matched workflow trigger via poll — creating claw", workspace.Name, workflow.Name, storyID)
@@ -958,7 +944,7 @@ func (s *Server) processGitHubIssuesPollItem(issue githubIssuesPollItem, factori
 			continue
 		}
 
-		if !s.labelsMatch(currentLabels, factory.Labels) {
+		if !s.labelsMatch(currentLabels, factory.Labels, factory.ExcludeLabels) {
 			continue
 		}
 		if !s.assigneeMatches(currentAssignee, factory.AssignedTo) {
@@ -1079,12 +1065,8 @@ func buildGitHubIssuesWorkflowPollPayload(issue githubIssuesPollItem, repo strin
 		}
 		return payload, true
 	}
-	if len(workflow.Labels) > 0 {
-		for _, required := range workflow.Labels {
-			if !issueLabels[strings.ToLower(required)] {
-				return payload, false
-			}
-		}
+	if !labelSetAllowed(issueLabels, workflow.Labels, workflow.ExcludeLabels) {
+		return payload, false
 	}
 	triggerStatus := workflow.TriggerStatus
 	if triggerStatus == "" {
@@ -1339,6 +1321,13 @@ func (s *Server) processGitHubPRPollItem(pr githubPRPollItem, factories []*types
 				continue
 			}
 		}
+		currentLabels, labelsOK := s.githubFactoryPRLabels(factory, repo, pr.Number)
+		if !labelsOK {
+			continue
+		}
+		if !labelsAllowed(currentLabels, factory.Labels, factory.ExcludeLabels) {
+			continue
+		}
 
 		payload := s.buildGitHubPRPollPayload(pr, repo)
 		if err := s.createClawForGitHubPR(factory, payload, "poll"); err != nil {
@@ -1379,24 +1368,8 @@ func (s *Server) factoryMatchesWorkspace(factory *types.FactoryConfig, workspace
 	return true
 }
 
-func (s *Server) labelsMatch(currentLabels []string, requiredLabels []string) bool {
-	if len(requiredLabels) == 0 {
-		return true
-	}
-	currentSet := map[string]bool{}
-	for _, l := range currentLabels {
-		currentSet[strings.ToLower(strings.TrimSpace(l))] = true
-	}
-	for _, required := range requiredLabels {
-		required = strings.ToLower(strings.TrimSpace(required))
-		if required == "" {
-			continue
-		}
-		if !currentSet[required] {
-			return false
-		}
-	}
-	return true
+func (s *Server) labelsMatch(currentLabels []string, requiredLabels []string, excludedLabels []string) bool {
+	return labelsAllowed(currentLabels, requiredLabels, excludedLabels)
 }
 
 func (s *Server) assigneeMatches(currentAssignee, filter string) bool {

--- a/pkg/hub/label_match.go
+++ b/pkg/hub/label_match.go
@@ -1,0 +1,54 @@
+package hub
+
+import "strings"
+
+func labelsAllowed(currentLabels []string, requiredLabels []string, excludedLabels []string) bool {
+	return labelSetAllowed(labelSetFromSlice(currentLabels), requiredLabels, excludedLabels)
+}
+
+func labelSetAllowed(current map[string]bool, requiredLabels []string, excludedLabels []string) bool {
+	normalized := make(map[string]bool, len(current))
+	for label, present := range current {
+		if !present {
+			continue
+		}
+		key := normalizeLabel(label)
+		if key != "" {
+			normalized[key] = true
+		}
+	}
+	for _, required := range requiredLabels {
+		key := normalizeLabel(required)
+		if key == "" {
+			continue
+		}
+		if !normalized[key] {
+			return false
+		}
+	}
+	for _, excluded := range excludedLabels {
+		key := normalizeLabel(excluded)
+		if key == "" {
+			continue
+		}
+		if normalized[key] {
+			return false
+		}
+	}
+	return true
+}
+
+func labelSetFromSlice(labels []string) map[string]bool {
+	set := make(map[string]bool, len(labels))
+	for _, label := range labels {
+		key := normalizeLabel(label)
+		if key != "" {
+			set[key] = true
+		}
+	}
+	return set
+}
+
+func normalizeLabel(label string) string {
+	return strings.ToLower(strings.TrimSpace(label))
+}

--- a/pkg/hub/label_match_test.go
+++ b/pkg/hub/label_match_test.go
@@ -1,0 +1,59 @@
+package hub
+
+import "testing"
+
+func TestLabelsAllowed(t *testing.T) {
+	tests := []struct {
+		name     string
+		current  []string
+		required []string
+		excluded []string
+		want     bool
+	}{
+		{
+			name:     "required labels all present",
+			current:  []string{"agent-ready", "backend"},
+			required: []string{"agent-ready"},
+			want:     true,
+		},
+		{
+			name:     "missing required label fails",
+			current:  []string{"backend"},
+			required: []string{"agent-ready"},
+			want:     false,
+		},
+		{
+			name:     "excluded label absent passes",
+			current:  []string{"agent-ready"},
+			excluded: []string{"Bug"},
+			want:     true,
+		},
+		{
+			name:     "excluded label present fails",
+			current:  []string{"agent-ready", "bug"},
+			excluded: []string{"Bug"},
+			want:     false,
+		},
+		{
+			name:     "matching is case-insensitive and trims whitespace",
+			current:  []string{" Agent-Ready ", "BUG"},
+			required: []string{"agent-ready"},
+			excluded: []string{" bug "},
+			want:     false,
+		},
+		{
+			name:     "same label required and excluded does not match",
+			current:  []string{"bug"},
+			required: []string{"Bug"},
+			excluded: []string{" bug "},
+			want:     false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := labelsAllowed(tt.current, tt.required, tt.excluded); got != tt.want {
+				t.Fatalf("labelsAllowed(%v, %v, %v) = %v, want %v", tt.current, tt.required, tt.excluded, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -257,22 +257,12 @@ func (s *Server) processLinearEvent(workspaceName string, payload linearWebhookP
 			continue
 		}
 
-		// Labels filter: all configured labels must be present on the issue (AND)
-		if len(factory.Labels) > 0 {
-			issueLabels := map[string]bool{}
-			for _, l := range payload.Data.Labels {
-				issueLabels[strings.ToLower(l.Name)] = true
-			}
-			allMatch := true
-			for _, required := range factory.Labels {
-				if !issueLabels[strings.ToLower(required)] {
-					allMatch = false
-					break
-				}
-			}
-			if !allMatch {
-				continue
-			}
+		currentLabels := make([]string, 0, len(payload.Data.Labels))
+		for _, label := range payload.Data.Labels {
+			currentLabels = append(currentLabels, label.Name)
+		}
+		if !labelsAllowed(currentLabels, factory.Labels, factory.ExcludeLabels) {
+			continue
 		}
 
 		// AssignedTo filter
@@ -389,17 +379,8 @@ func (s *Server) processLinearWorkflowEvent(workspaces []*types.WorkspaceConfig,
 			if workflow.Team != "" && !strings.EqualFold(workflow.Team, teamKey) {
 				continue
 			}
-			if len(workflow.Labels) > 0 {
-				allMatch := true
-				for _, required := range workflow.Labels {
-					if !issueLabels[strings.ToLower(required)] {
-						allMatch = false
-						break
-					}
-				}
-				if !allMatch {
-					continue
-				}
+			if !labelSetAllowed(issueLabels, workflow.Labels, workflow.ExcludeLabels) {
+				continue
 			}
 			if workflow.AssignedTo != "" && !assignedToMatches(workflow.AssignedTo, assignee) {
 				continue

--- a/pkg/hub/linear_webhook_test.go
+++ b/pkg/hub/linear_webhook_test.go
@@ -1,6 +1,7 @@
 package hub_test
 
 import (
+	"database/sql"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -100,6 +101,143 @@ func TestLinearWorkflowCreateFailureDoesNotReprocessErrorStatusWebhook(t *testin
 	}))
 
 	assertLinearIssueCommentCountStable(t, linear, "ELA-123", 1)
+}
+
+func TestLinearWorkflowExcludeLabelsRoutesGenericAndBugWorkflows(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
+	linear := factorytest.NewMockLinear(t)
+
+	cfg := &types.HubConfig{
+		ClawToken: "test-claw-token",
+		Providers: map[string]types.ProviderConfig{
+			"noop": {Type: "noop"},
+		},
+	}
+	s, db := hub.NewTestServerWithConfig(t, cfg, "", linear.URL, "")
+	saveLinearRoutingWorkflowFixture(t, "workspace-a")
+
+	httpSrv := httptest.NewServer(s.Handler())
+	t.Cleanup(httpSrv.Close)
+
+	postLinearWebhook(t, httpSrv.URL, "workspace-a", linearWebhookPayloadWithLabels(t, linear, "ELA-124", "Backlog", "Ready For Agent", nil))
+	waitForLinearClawCount(t, db, "ELA-124", 1)
+
+	postLinearWebhook(t, httpSrv.URL, "workspace-a", linearWebhookPayloadWithLabels(t, linear, "ELA-125", "Backlog", "Ready For Agent", []string{"Bug"}))
+	waitForLinearClawCount(t, db, "ELA-125", 1)
+	assertLinearClawTagsContain(t, db, "ELA-125", "workflow:bug-workflow")
+}
+
+func saveLinearRoutingWorkflowFixture(t *testing.T, workspace string) {
+	t.Helper()
+	hub.SaveWorkspaceForTest(t,
+		&types.WorkspaceConfig{
+			SchemaVersion: "v1",
+			Name:          workspace,
+			Files: map[string]string{
+				"elasticclaw-config.yaml": "schema_version: v1\nname: " + workspace + "\nprovider: noop\n",
+				"CONTEXT.md":              "Test context\n",
+			},
+		},
+		[]*types.WorkflowConfig{
+			{
+				SchemaVersion: "v1",
+				Name:          "generic-workflow",
+				Trigger: &types.WorkflowTrigger{
+					Linear: &types.LinearWorkflowTrigger{
+						Event:         "status_changed",
+						Team:          "ELA",
+						States:        []string{"Ready For Agent"},
+						ExcludeLabels: []string{"Bug"},
+					},
+				},
+				Stages: workflowPollTestStages(),
+			},
+			{
+				SchemaVersion: "v1",
+				Name:          "bug-workflow",
+				Trigger: &types.WorkflowTrigger{
+					Linear: &types.LinearWorkflowTrigger{
+						Event:  "status_changed",
+						Team:   "ELA",
+						States: []string{"Ready For Agent"},
+						Labels: []string{"Bug"},
+					},
+				},
+				Stages: workflowPollTestStages(),
+			},
+		},
+	)
+}
+
+func linearWebhookPayloadWithLabels(t *testing.T, linear *factorytest.MockLinear, issueID, prevStatus, newStatus string, labels []string) []byte {
+	t.Helper()
+	payload, _ := linear.BuildWebhookPayload(issueID, prevStatus, newStatus)
+	var data map[string]interface{}
+	if err := json.Unmarshal(payload, &data); err != nil {
+		t.Fatalf("parse payload: %v", err)
+	}
+	rawLabels := make([]map[string]string, 0, len(labels))
+	for _, label := range labels {
+		rawLabels = append(rawLabels, map[string]string{"name": label})
+	}
+	dataMap := data["data"].(map[string]interface{})
+	dataMap["labels"] = rawLabels
+	out, err := json.Marshal(data)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	return out
+}
+
+func waitForLinearClawCount(t *testing.T, db interface {
+	QueryRow(string, ...interface{}) *sql.Row
+}, issueID string, want int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		var count int
+		if err := db.QueryRow(`SELECT COUNT(*) FROM claws WHERE linear_issue_id=?`, issueID).Scan(&count); err != nil {
+			t.Fatalf("count claws: %v", err)
+		}
+		if count == want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("claws for %s = %d, want %d", issueID, count, want)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func assertLinearClawCountStable(t *testing.T, db interface {
+	QueryRow(string, ...interface{}) *sql.Row
+}, issueID string, want int) {
+	t.Helper()
+	deadline := time.Now().Add(300 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		var count int
+		if err := db.QueryRow(`SELECT COUNT(*) FROM claws WHERE linear_issue_id=?`, issueID).Scan(&count); err != nil {
+			t.Fatalf("count claws: %v", err)
+		}
+		if count != want {
+			t.Fatalf("claws for %s = %d, want %d", issueID, count, want)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func assertLinearClawTagsContain(t *testing.T, db interface {
+	QueryRow(string, ...interface{}) *sql.Row
+}, issueID, want string) {
+	t.Helper()
+	var tags string
+	if err := db.QueryRow(`SELECT tags FROM claws WHERE linear_issue_id=? LIMIT 1`, issueID).Scan(&tags); err != nil {
+		t.Fatalf("query claw tags: %v", err)
+	}
+	if !strings.Contains(tags, want) {
+		t.Fatalf("tags for %s = %s, want %q", issueID, tags, want)
+	}
 }
 
 func saveLinearIssueWorkflowFixtureWithProviderAndErrorStatus(t *testing.T, workspace, provider, agentStatusError string) {

--- a/pkg/hub/linear_webhook_test.go
+++ b/pkg/hub/linear_webhook_test.go
@@ -210,23 +210,6 @@ func waitForLinearClawCount(t *testing.T, db interface {
 	}
 }
 
-func assertLinearClawCountStable(t *testing.T, db interface {
-	QueryRow(string, ...interface{}) *sql.Row
-}, issueID string, want int) {
-	t.Helper()
-	deadline := time.Now().Add(300 * time.Millisecond)
-	for time.Now().Before(deadline) {
-		var count int
-		if err := db.QueryRow(`SELECT COUNT(*) FROM claws WHERE linear_issue_id=?`, issueID).Scan(&count); err != nil {
-			t.Fatalf("count claws: %v", err)
-		}
-		if count != want {
-			t.Fatalf("claws for %s = %d, want %d", issueID, count, want)
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-}
-
 func assertLinearClawTagsContain(t *testing.T, db interface {
 	QueryRow(string, ...interface{}) *sql.Row
 }, issueID, want string) {

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -33,15 +33,15 @@ type LLMKeyView struct {
 
 // MCPView is the redacted view of an MCP server config for the settings page.
 type MCPView struct {
-	Name      string            `json:"name"`
-	Source    string            `json:"source"`
-	Package   string            `json:"package,omitempty"`
-	Image     string            `json:"image,omitempty"`
-	URL       string            `json:"url,omitempty"`
-	Enabled   bool              `json:"enabled"`
-	Config    map[string]string `json:"config,omitempty"`
-	Secrets   []string          `json:"secrets,omitempty"` // env var names only, not values
-	Command   []string          `json:"command,omitempty"`
+	Name    string            `json:"name"`
+	Source  string            `json:"source"`
+	Package string            `json:"package,omitempty"`
+	Image   string            `json:"image,omitempty"`
+	URL     string            `json:"url,omitempty"`
+	Enabled bool              `json:"enabled"`
+	Config  map[string]string `json:"config,omitempty"`
+	Secrets []string          `json:"secrets,omitempty"` // env var names only, not values
+	Command []string          `json:"command,omitempty"`
 }
 
 // ConcurrencyGroupView is the JSON-safe view of a concurrency group.
@@ -118,26 +118,27 @@ func isFactoryEnabled(f *types.FactoryConfig) bool {
 }
 
 type FactoryView struct {
-	Name                string   `json:"name"`
-	Integration         string   `json:"integration"`
-	Workspace           string   `json:"workspace"`
-	Team                string   `json:"team"`
-	TriggerStatus       string   `json:"triggerStatus"`
-	DoneStatus          string   `json:"doneStatus"`
-	TerminateOnLeave    bool     `json:"terminateOnLeave"`
-	Template            string   `json:"template"`
-	NamePattern         string   `json:"namePattern"`
-	WebhookSecretSet    bool     `json:"webhookSecretSet"`
-	WebhookSecretRef    string   `json:"webhookSecretRef,omitempty"`
-	PipelineYAML        string   `json:"pipelineYAML,omitempty"`
-	Tags                []string `json:"tags"`
-	Color               string   `json:"color"`
-	Labels              []string `json:"labels,omitempty"`
-	AssignedTo          string   `json:"assigned_to,omitempty"`
-	Enabled             bool     `json:"enabled"`
-	ConcurrencyGroup    string   `json:"concurrencyGroup,omitempty"`
-	EnableManualTrigger bool     `json:"enable_manual_trigger,omitempty"`
-	SecretRefs          map[string]string `json:"secret_refs,omitempty"`
+	Name                string                 `json:"name"`
+	Integration         string                 `json:"integration"`
+	Workspace           string                 `json:"workspace"`
+	Team                string                 `json:"team"`
+	TriggerStatus       string                 `json:"triggerStatus"`
+	DoneStatus          string                 `json:"doneStatus"`
+	TerminateOnLeave    bool                   `json:"terminateOnLeave"`
+	Template            string                 `json:"template"`
+	NamePattern         string                 `json:"namePattern"`
+	WebhookSecretSet    bool                   `json:"webhookSecretSet"`
+	WebhookSecretRef    string                 `json:"webhookSecretRef,omitempty"`
+	PipelineYAML        string                 `json:"pipelineYAML,omitempty"`
+	Tags                []string               `json:"tags"`
+	Color               string                 `json:"color"`
+	Labels              []string               `json:"labels,omitempty"`
+	ExcludeLabels       []string               `json:"exclude_labels,omitempty"`
+	AssignedTo          string                 `json:"assigned_to,omitempty"`
+	Enabled             bool                   `json:"enabled"`
+	ConcurrencyGroup    string                 `json:"concurrencyGroup,omitempty"`
+	EnableManualTrigger bool                   `json:"enable_manual_trigger,omitempty"`
+	SecretRefs          map[string]string      `json:"secret_refs,omitempty"`
 	ExternalTrigger     *types.ExternalTrigger `json:"externalTrigger,omitempty"`
 }
 
@@ -153,12 +154,12 @@ type ProviderView struct {
 	DefaultTTL          string `json:"defaultTtl,omitempty"`
 	DefaultInstanceType string `json:"defaultInstanceType,omitempty"`
 	// exe.dev
-	SSHKeySet       bool   `json:"sshKeySet,omitempty"`
-	SSHPublicKey    string `json:"sshPublicKey,omitempty"`
-	DefaultCPU      int    `json:"defaultCpu,omitempty"`
-	DefaultMemory   string `json:"defaultMemory,omitempty"`
-	DefaultDisk     string `json:"defaultDisk,omitempty"`
-	_sshKeyPath     string `json:"-"` // internal: path for file I/O outside lock
+	SSHKeySet     bool   `json:"sshKeySet,omitempty"`
+	SSHPublicKey  string `json:"sshPublicKey,omitempty"`
+	DefaultCPU    int    `json:"defaultCpu,omitempty"`
+	DefaultMemory string `json:"defaultMemory,omitempty"`
+	DefaultDisk   string `json:"defaultDisk,omitempty"`
+	_sshKeyPath   string `json:"-"` // internal: path for file I/O outside lock
 }
 
 // GitHubAppPermission is a single permission check result for a GitHub App.
@@ -170,12 +171,12 @@ type GitHubAppPermission struct {
 }
 
 type GitHubAppView struct {
-	AppID       int64                 `json:"appId"`
-	URL         string                `json:"url,omitempty"`
-	KeySet      bool                  `json:"keySet"`
-	Permissions []GitHubAppPermission `json:"permissions,omitempty"`
-	PermCheckOK *bool                 `json:"permCheckOk,omitempty"` // nil = not checked yet
-	PermCheckError string           `json:"permCheckError,omitempty"`
+	AppID          int64                 `json:"appId"`
+	URL            string                `json:"url,omitempty"`
+	KeySet         bool                  `json:"keySet"`
+	Permissions    []GitHubAppPermission `json:"permissions,omitempty"`
+	PermCheckOK    *bool                 `json:"permCheckOk,omitempty"` // nil = not checked yet
+	PermCheckError string                `json:"permCheckError,omitempty"`
 }
 
 // SettingsPatch is the request body for PATCH /api/settings.
@@ -279,30 +280,31 @@ type GitHubIssuesIntegrationPatch struct {
 }
 
 type FactoryPatch struct {
-	Name                string              `json:"name"`
-	OriginalName        string              `json:"originalName,omitempty"`
-	Integration         string              `json:"integration"`
-	Workspace           string              `json:"workspace"`
-	Team                string              `json:"team,omitempty"`
-	TriggerStatus       string              `json:"triggerStatus"`
-	DoneStatus          string              `json:"doneStatus,omitempty"`
-	TerminateOnLeave    bool                `json:"terminateOnLeave"`
-	Template            string              `json:"template"`
-	NamePattern         string              `json:"namePattern,omitempty"`
-	WebhookSecret       string              `json:"webhookSecret,omitempty"`
-	WebhookSecretRef    string              `json:"webhookSecretRef,omitempty"`
-	PipelineYAML        string              `json:"pipelineYAML,omitempty"`
-	Tags                []string            `json:"tags,omitempty"`
-	Color               string              `json:"color,omitempty"`
-	Labels              []string            `json:"labels,omitempty"`
-	AssignedTo          string              `json:"assigned_to,omitempty"`
-	Enabled             *bool               `json:"enabled,omitempty"`
-	ConcurrencyGroup    string              `json:"concurrencyGroup,omitempty"`
-	EnableManualTrigger bool                `json:"enable_manual_trigger,omitempty"`
-	SecretRefs          map[string]string   `json:"secret_refs,omitempty"`
-	Inputs              []types.FactoryInput `json:"inputs,omitempty"`
-	Repos               []string            `json:"repos,omitempty"`
-	Trigger             *types.GitHubTrigger `json:"trigger,omitempty"`
+	Name                string                 `json:"name"`
+	OriginalName        string                 `json:"originalName,omitempty"`
+	Integration         string                 `json:"integration"`
+	Workspace           string                 `json:"workspace"`
+	Team                string                 `json:"team,omitempty"`
+	TriggerStatus       string                 `json:"triggerStatus"`
+	DoneStatus          string                 `json:"doneStatus,omitempty"`
+	TerminateOnLeave    bool                   `json:"terminateOnLeave"`
+	Template            string                 `json:"template"`
+	NamePattern         string                 `json:"namePattern,omitempty"`
+	WebhookSecret       string                 `json:"webhookSecret,omitempty"`
+	WebhookSecretRef    string                 `json:"webhookSecretRef,omitempty"`
+	PipelineYAML        string                 `json:"pipelineYAML,omitempty"`
+	Tags                []string               `json:"tags,omitempty"`
+	Color               string                 `json:"color,omitempty"`
+	Labels              []string               `json:"labels,omitempty"`
+	ExcludeLabels       []string               `json:"exclude_labels,omitempty"`
+	AssignedTo          string                 `json:"assigned_to,omitempty"`
+	Enabled             *bool                  `json:"enabled,omitempty"`
+	ConcurrencyGroup    string                 `json:"concurrencyGroup,omitempty"`
+	EnableManualTrigger bool                   `json:"enable_manual_trigger,omitempty"`
+	SecretRefs          map[string]string      `json:"secret_refs,omitempty"`
+	Inputs              []types.FactoryInput   `json:"inputs,omitempty"`
+	Repos               []string               `json:"repos,omitempty"`
+	Trigger             *types.GitHubTrigger   `json:"trigger,omitempty"`
 	ExternalTrigger     *types.ExternalTrigger `json:"externalTrigger,omitempty"`
 }
 
@@ -523,6 +525,7 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 			Tags:                f.Tags,
 			Color:               f.Color,
 			Labels:              f.Labels,
+			ExcludeLabels:       f.ExcludeLabels,
 			AssignedTo:          f.AssignedTo,
 			Enabled:             isFactoryEnabled(f),
 			ConcurrencyGroup:    f.ConcurrencyGroup,
@@ -1081,6 +1084,9 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 			}
 			if fp.Labels != nil {
 				disk.Labels = fp.Labels
+			}
+			if fp.ExcludeLabels != nil {
+				disk.ExcludeLabels = fp.ExcludeLabels
 			}
 			if fp.AssignedTo != "" {
 				disk.AssignedTo = fp.AssignedTo

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -1115,6 +1115,10 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 				disk.ExternalTrigger = fp.ExternalTrigger
 			}
 
+			if err := disk.Validate(); err != nil {
+				http.Error(w, "validation error: "+err.Error(), http.StatusBadRequest)
+				return
+			}
 			if err := saveExternalFactory(disk); err != nil {
 				http.Error(w, "failed to save factory "+fp.Name+": "+err.Error(), http.StatusInternalServerError)
 				return

--- a/pkg/hub/shortcut.go
+++ b/pkg/hub/shortcut.go
@@ -188,7 +188,7 @@ func (s *Server) processShortcutEvent(payload shortcutWebhookPayload) {
 				continue
 			}
 
-			if len(factory.Labels) > 0 || factory.AssignedTo != "" {
+			if len(factory.Labels) > 0 || len(factory.ExcludeLabels) > 0 || factory.AssignedTo != "" {
 				filterData, ok := storyFiltersByToken[token]
 				if !ok {
 					filterData = s.loadShortcutStoryFilterData(token, action.ID)
@@ -199,22 +199,8 @@ func (s *Server) processShortcutEvent(payload shortcutWebhookPayload) {
 					continue
 				}
 
-				// Labels filter: all configured labels must be present on the story (AND)
-				if len(factory.Labels) > 0 {
-					allMatch := true
-					for _, required := range factory.Labels {
-						required = strings.ToLower(strings.TrimSpace(required))
-						if required == "" {
-							continue
-						}
-						if !filterData.labels[required] {
-							allMatch = false
-							break
-						}
-					}
-					if !allMatch {
-						continue
-					}
+				if !labelSetAllowed(filterData.labels, factory.Labels, factory.ExcludeLabels) {
+					continue
 				}
 
 				// AssignedTo filter

--- a/pkg/hub/shortcut.go
+++ b/pkg/hub/shortcut.go
@@ -344,9 +344,6 @@ func (s *Server) processShortcutWorkflowEvent(workspaces []*types.WorkspaceConfi
 				}
 				newStateName := stateMap[newStateID]
 				oldStateName := stateMap[oldStateID]
-				if !strings.EqualFold(newStateName, workflow.TriggerStatus) || strings.EqualFold(oldStateName, workflow.TriggerStatus) {
-					continue
-				}
 
 				if len(workflow.Labels) > 0 || len(workflow.ExcludeLabels) > 0 || workflow.AssignedTo != "" {
 					filterData, ok := storyFiltersByToken[token]
@@ -364,6 +361,20 @@ func (s *Server) processShortcutWorkflowEvent(workspaces []*types.WorkspaceConfi
 					if workflow.AssignedTo != "" && !shortcutAssigneeFilterMatches(workflow.AssignedTo, filterData) {
 						continue
 					}
+				}
+
+				if workflow.TerminateOnLeave && !strings.EqualFold(newStateName, workflow.TriggerStatus) {
+					var activeClaw string
+					_ = s.db.QueryRow(`SELECT id FROM claws WHERE shortcut_story_id = ? AND status NOT IN ('error','deleted') LIMIT 1`, storyID).Scan(&activeClaw)
+					if activeClaw != "" {
+						matched = true
+						log.Printf("[workflow:%s/%s] Shortcut story %s left trigger %q — terminating claw %s", workspace.Name, workflow.Name, storyID, workflow.TriggerStatus, activeClaw[:8])
+						s.terminateClawForIssue(storyID)
+					}
+				}
+
+				if !strings.EqualFold(newStateName, workflow.TriggerStatus) || strings.EqualFold(oldStateName, workflow.TriggerStatus) {
+					continue
 				}
 
 				matched = true

--- a/pkg/hub/shortcut.go
+++ b/pkg/hub/shortcut.go
@@ -145,11 +145,15 @@ func (s *Server) handleShortcutWebhook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	go s.processShortcutEvent(payload)
+	go s.processShortcutEvent(strings.TrimSpace(r.PathValue("workspace")), payload)
 	w.WriteHeader(http.StatusOK)
 }
 
-func (s *Server) processShortcutEvent(payload shortcutWebhookPayload) {
+func (s *Server) processShortcutEvent(workspaceName string, payload shortcutWebhookPayload) {
+	workflowWorkspaces, _ := loadExternalWorkflowsByIntegration("shortcut")
+	workflowWorkspaces = filterWorkflowWorkspacesByName(workflowWorkspaces, workspaceName)
+	_ = s.processShortcutWorkflowEvent(workflowWorkspaces, payload)
+
 	factories := s.resolveFactories()
 
 	// Build a per-token state-name cache so we only fetch the workflow list once
@@ -285,6 +289,112 @@ func (s *Server) processShortcutEvent(payload shortcutWebhookPayload) {
 				}
 			}
 		}
+	}
+}
+
+func (s *Server) processShortcutWorkflowEvent(workspaces []*types.WorkspaceConfig, payload shortcutWebhookPayload) bool {
+	if len(workspaces) == 0 {
+		return false
+	}
+
+	stateNameCache := map[string]map[int64]string{}
+	matched := false
+
+	for _, action := range payload.Actions {
+		if action.EntityType != "story" || action.Action != "update" {
+			continue
+		}
+		stateChange, ok := action.Changes["workflow_state_id"]
+		if !ok {
+			continue
+		}
+
+		newStateID := toInt64(stateChange.New)
+		oldStateID := toInt64(stateChange.Old)
+		storyID := fmt.Sprintf("sc-%d", action.ID)
+		storyFiltersByToken := map[string]*shortcutStoryFilterData{}
+
+		for _, workspace := range workspaces {
+			for _, workflow := range workspace.Workflows {
+				if workflow == nil || workflow.Integration != "shortcut" {
+					continue
+				}
+				if workflow.Enabled != nil && !*workflow.Enabled {
+					continue
+				}
+				if workflow.TriggerStatus == "" {
+					continue
+				}
+
+				token := s.resolveShortcutTokenForWorkflow(workspace.Name, workflow)
+				if token == "" {
+					log.Printf("[workflow:%s/%s] no Shortcut token configured — skipping webhook story %s", workspace.Name, workflow.Name, storyID)
+					continue
+				}
+
+				stateMap, ok := stateNameCache[token]
+				if !ok {
+					stateMap = buildShortcutStateMap(s.resolveShortcutBaseURL(), token)
+					if len(stateMap) > 0 {
+						stateNameCache[token] = stateMap
+					} else {
+						log.Printf("[shortcut-webhook] failed to load workflow states for workspace %q (empty response) — not caching", workflow.Workspace)
+						continue
+					}
+				}
+				newStateName := stateMap[newStateID]
+				oldStateName := stateMap[oldStateID]
+				if !strings.EqualFold(newStateName, workflow.TriggerStatus) || strings.EqualFold(oldStateName, workflow.TriggerStatus) {
+					continue
+				}
+
+				if len(workflow.Labels) > 0 || len(workflow.ExcludeLabels) > 0 || workflow.AssignedTo != "" {
+					filterData, ok := storyFiltersByToken[token]
+					if !ok {
+						filterData = s.loadShortcutStoryFilterData(token, action.ID)
+						storyFiltersByToken[token] = filterData
+					}
+					if filterData.loadErr != nil {
+						log.Printf("[workflow:%s/%s] skipping story %s: failed to load Shortcut story filters: %v", workspace.Name, workflow.Name, storyID, filterData.loadErr)
+						continue
+					}
+					if !labelSetAllowed(filterData.labels, workflow.Labels, workflow.ExcludeLabels) {
+						continue
+					}
+					if workflow.AssignedTo != "" && !shortcutAssigneeFilterMatches(workflow.AssignedTo, filterData) {
+						continue
+					}
+				}
+
+				matched = true
+				log.Printf("[workflow:%s/%s] Shortcut story %s entered %q — creating claw", workspace.Name, workflow.Name, storyID, workflow.TriggerStatus)
+				if err := s.createClawForShortcutWorkflow(workspace, workflow, action, storyID, "shortcut webhook"); err != nil {
+					if isFactoryTriggerAlreadyClaimed(err) {
+						continue
+					}
+					log.Printf("[workflow:%s/%s] failed to create claw for %s: %v", workspace.Name, workflow.Name, storyID, err)
+				}
+			}
+		}
+	}
+	return matched
+}
+
+func shortcutAssigneeFilterMatches(filter string, data *shortcutStoryFilterData) bool {
+	wanted := strings.ToLower(strings.TrimSpace(filter))
+	switch {
+	case wanted == "":
+		return true
+	case wanted == "any":
+		return data.hasOwner
+	case wanted == "none":
+		return !data.hasOwner
+	case strings.HasPrefix(wanted, "!"):
+		excluded := strings.TrimPrefix(strings.TrimPrefix(wanted, "!"), "@")
+		return excluded != "" && !data.assignees[excluded]
+	default:
+		target := strings.TrimPrefix(wanted, "@")
+		return target != "" && data.assignees[target]
 	}
 }
 

--- a/pkg/hub/shortcut_webhook_test.go
+++ b/pkg/hub/shortcut_webhook_test.go
@@ -61,6 +61,122 @@ func TestShortcutWorkflowWebhookExcludeLabelsRoutesBugWorkflow(t *testing.T) {
 	waitForShortcutClawTagsContain(t, db, "sc-126", "workflow:bug-workflow")
 }
 
+func TestShortcutWorkflowWebhookTerminatesOnLeave(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
+	shortcut := factorytest.NewMockShortcut(t)
+
+	cfg := &types.HubConfig{
+		ClawToken: "test-claw-token",
+		Integrations: &types.IntegrationsConfig{
+			Shortcut: []*types.ShortcutIntegrationConfig{{Workspace: "default", Token: "test-shortcut-token"}},
+		},
+		Providers: map[string]types.ProviderConfig{
+			"noop": {Type: "noop"},
+		},
+	}
+	s, db := hub.NewTestServerWithConfig(t, cfg, "", "", shortcut.URL)
+	saveShortcutTerminateWorkflowFixture(t, "workspace-a")
+	hub.SaveWorkspaceIssueTrackerForTest(t, "workspace-a", "shortcut", "default", "test-shortcut-token", "")
+
+	shortcut.SetStory(127, factorytest.StoryState{
+		Name:            "Leaving Story",
+		Description:     "Test description",
+		WorkflowStateID: shortcut.StateIDForName("Backlog"),
+	})
+	var tenantID string
+	if err := db.QueryRow(`SELECT id FROM tenants LIMIT 1`).Scan(&tenantID); err != nil {
+		t.Fatalf("read tenant: %v", err)
+	}
+	_, err := db.Exec(`INSERT INTO claws(id, tenant_id, name, template, status, shortcut_story_id, created_at) VALUES(?,?,?,?,?,?,datetime('now'))`,
+		"claw-shortcut-leave", tenantID, "Shortcut claw", "elasticclaw", "connected", "sc-127")
+	if err != nil {
+		t.Fatalf("insert claw: %v", err)
+	}
+
+	payload, sig := shortcut.BuildWebhookPayload(127, shortcut.StateIDForName("In Progress"), shortcut.StateIDForName("Backlog"), "")
+
+	httpSrv := httptest.NewServer(s.Handler())
+	t.Cleanup(httpSrv.Close)
+	req, err := http.NewRequest(http.MethodPost, httpSrv.URL+"/api/workspaces/workspace-a/webhooks/shortcut", strings.NewReader(string(payload)))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if sig != "" {
+		req.Header.Set("Payload-Signature", sig)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	waitForShortcutClawStatus(t, db, "sc-127", "deleted")
+}
+
+func TestShortcutWorkflowWebhookTerminateOnLeaveHonorsExcludeLabels(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
+	shortcut := factorytest.NewMockShortcut(t)
+
+	cfg := &types.HubConfig{
+		ClawToken: "test-claw-token",
+		Integrations: &types.IntegrationsConfig{
+			Shortcut: []*types.ShortcutIntegrationConfig{{Workspace: "default", Token: "test-shortcut-token"}},
+		},
+		Providers: map[string]types.ProviderConfig{
+			"noop": {Type: "noop"},
+		},
+	}
+	s, db := hub.NewTestServerWithConfig(t, cfg, "", "", shortcut.URL)
+	saveShortcutTerminateExcludedWorkflowFixture(t, "workspace-a")
+	hub.SaveWorkspaceIssueTrackerForTest(t, "workspace-a", "shortcut", "default", "test-shortcut-token", "")
+
+	shortcut.SetStory(128, factorytest.StoryState{
+		Name:            "Bug Leaving Story",
+		Description:     "Test description",
+		WorkflowStateID: shortcut.StateIDForName("Backlog"),
+		Labels:          []string{"Bug"},
+	})
+	var tenantID string
+	if err := db.QueryRow(`SELECT id FROM tenants LIMIT 1`).Scan(&tenantID); err != nil {
+		t.Fatalf("read tenant: %v", err)
+	}
+	_, err := db.Exec(`INSERT INTO claws(id, tenant_id, name, template, status, shortcut_story_id, created_at) VALUES(?,?,?,?,?,?,datetime('now'))`,
+		"claw-shortcut-bug-leave", tenantID, "Shortcut bug claw", "elasticclaw", "connected", "sc-128")
+	if err != nil {
+		t.Fatalf("insert claw: %v", err)
+	}
+
+	payload, sig := shortcut.BuildWebhookPayload(128, shortcut.StateIDForName("In Progress"), shortcut.StateIDForName("Backlog"), "")
+
+	httpSrv := httptest.NewServer(s.Handler())
+	t.Cleanup(httpSrv.Close)
+	req, err := http.NewRequest(http.MethodPost, httpSrv.URL+"/api/workspaces/workspace-a/webhooks/shortcut", strings.NewReader(string(payload)))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if sig != "" {
+		req.Header.Set("Payload-Signature", sig)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	assertShortcutClawStatus(t, db, "sc-128", "connected")
+}
+
 func saveShortcutRoutingWorkflowFixture(t *testing.T, workspace string) {
 	t.Helper()
 	hub.SaveWorkspaceForTest(t,
@@ -101,6 +217,51 @@ func saveShortcutRoutingWorkflowFixture(t *testing.T, workspace string) {
 	)
 }
 
+func saveShortcutTerminateWorkflowFixture(t *testing.T, workspace string) {
+	t.Helper()
+	hub.SaveWorkspaceForTest(t,
+		&types.WorkspaceConfig{
+			SchemaVersion: "v1",
+			Name:          workspace,
+			Files: map[string]string{
+				"elasticclaw-config.yaml": "schema_version: v1\nname: " + workspace + "\nprovider: noop\n",
+				"CONTEXT.md":              "Test context\n",
+			},
+		},
+		[]*types.WorkflowConfig{{
+			SchemaVersion:    "v1",
+			Name:             "terminating-workflow",
+			Integration:      "shortcut",
+			TriggerStatus:    "In Progress",
+			TerminateOnLeave: true,
+			Stages:           workflowPollTestStages(),
+		}},
+	)
+}
+
+func saveShortcutTerminateExcludedWorkflowFixture(t *testing.T, workspace string) {
+	t.Helper()
+	hub.SaveWorkspaceForTest(t,
+		&types.WorkspaceConfig{
+			SchemaVersion: "v1",
+			Name:          workspace,
+			Files: map[string]string{
+				"elasticclaw-config.yaml": "schema_version: v1\nname: " + workspace + "\nprovider: noop\n",
+				"CONTEXT.md":              "Test context\n",
+			},
+		},
+		[]*types.WorkflowConfig{{
+			SchemaVersion:    "v1",
+			Name:             "generic-workflow",
+			Integration:      "shortcut",
+			TriggerStatus:    "In Progress",
+			ExcludeLabels:    []string{"Bug"},
+			TerminateOnLeave: true,
+			Stages:           workflowPollTestStages(),
+		}},
+	)
+}
+
 func waitForShortcutClawTagsContain(t *testing.T, db *sql.DB, storyID, want string) {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)
@@ -114,5 +275,32 @@ func waitForShortcutClawTagsContain(t *testing.T, db *sql.DB, storyID, want stri
 			t.Fatalf("shortcut claw tags for %s missing %q, last tags=%q err=%v", storyID, want, tags, err)
 		}
 		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func waitForShortcutClawStatus(t *testing.T, db *sql.DB, storyID, want string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		var status string
+		err := db.QueryRow(`SELECT status FROM claws WHERE shortcut_story_id=? LIMIT 1`, storyID).Scan(&status)
+		if err == nil && status == want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("shortcut claw status for %s = %q, want %q err=%v", storyID, status, want, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func assertShortcutClawStatus(t *testing.T, db *sql.DB, storyID, want string) {
+	t.Helper()
+	var status string
+	if err := db.QueryRow(`SELECT status FROM claws WHERE shortcut_story_id=? LIMIT 1`, storyID).Scan(&status); err != nil {
+		t.Fatalf("read shortcut claw status for %s: %v", storyID, err)
+	}
+	if status != want {
+		t.Fatalf("shortcut claw status for %s = %q, want %q", storyID, status, want)
 	}
 }

--- a/pkg/hub/shortcut_webhook_test.go
+++ b/pkg/hub/shortcut_webhook_test.go
@@ -1,0 +1,118 @@
+package hub_test
+
+import (
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/hub"
+	"github.com/elasticclaw/elasticclaw/pkg/hub/factorytest"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func TestShortcutWorkflowWebhookExcludeLabelsRoutesBugWorkflow(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
+	shortcut := factorytest.NewMockShortcut(t)
+
+	cfg := &types.HubConfig{
+		ClawToken: "test-claw-token",
+		Integrations: &types.IntegrationsConfig{
+			Shortcut: []*types.ShortcutIntegrationConfig{{Workspace: "default", Token: "test-shortcut-token"}},
+		},
+		Providers: map[string]types.ProviderConfig{
+			"noop": {Type: "noop"},
+		},
+	}
+	s, db := hub.NewTestServerWithConfig(t, cfg, "", "", shortcut.URL)
+	saveShortcutRoutingWorkflowFixture(t, "workspace-a")
+	hub.SaveWorkspaceIssueTrackerForTest(t, "workspace-a", "shortcut", "default", "test-shortcut-token", "")
+
+	shortcut.SetStory(126, factorytest.StoryState{
+		Name:            "Bug Story",
+		Description:     "Test description",
+		WorkflowStateID: shortcut.StateIDForName("In Progress"),
+		Labels:          []string{"Bug"},
+	})
+	payload, sig := shortcut.BuildWebhookPayload(126, shortcut.StateIDForName("Backlog"), shortcut.StateIDForName("In Progress"), "")
+
+	httpSrv := httptest.NewServer(s.Handler())
+	t.Cleanup(httpSrv.Close)
+	req, err := http.NewRequest(http.MethodPost, httpSrv.URL+"/api/workspaces/workspace-a/webhooks/shortcut", strings.NewReader(string(payload)))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if sig != "" {
+		req.Header.Set("Payload-Signature", sig)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	waitForShortcutClawTagsContain(t, db, "sc-126", "workflow:bug-workflow")
+}
+
+func saveShortcutRoutingWorkflowFixture(t *testing.T, workspace string) {
+	t.Helper()
+	hub.SaveWorkspaceForTest(t,
+		&types.WorkspaceConfig{
+			SchemaVersion: "v1",
+			Name:          workspace,
+			Files: map[string]string{
+				"elasticclaw-config.yaml": "schema_version: v1\nname: " + workspace + "\nprovider: noop\n",
+				"CONTEXT.md":              "Test context\n",
+			},
+		},
+		[]*types.WorkflowConfig{
+			{
+				SchemaVersion: "v1",
+				Name:          "generic-workflow",
+				Trigger: &types.WorkflowTrigger{
+					Shortcut: &types.ShortcutWorkflowTrigger{
+						Event:         "status_changed",
+						States:        []string{"In Progress"},
+						ExcludeLabels: []string{"Bug"},
+					},
+				},
+				Stages: workflowPollTestStages(),
+			},
+			{
+				SchemaVersion: "v1",
+				Name:          "bug-workflow",
+				Trigger: &types.WorkflowTrigger{
+					Shortcut: &types.ShortcutWorkflowTrigger{
+						Event:  "status_changed",
+						States: []string{"In Progress"},
+						Labels: []string{"Bug"},
+					},
+				},
+				Stages: workflowPollTestStages(),
+			},
+		},
+	)
+}
+
+func waitForShortcutClawTagsContain(t *testing.T, db *sql.DB, storyID, want string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		var tags string
+		err := db.QueryRow(`SELECT tags FROM claws WHERE shortcut_story_id=? LIMIT 1`, storyID).Scan(&tags)
+		if err == nil && strings.Contains(tags, want) {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("shortcut claw tags for %s missing %q, last tags=%q err=%v", storyID, want, tags, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/pkg/hub/workflow_poller_test.go
+++ b/pkg/hub/workflow_poller_test.go
@@ -1,6 +1,8 @@
 package hub_test
 
 import (
+	"database/sql"
+	"strings"
 	"testing"
 
 	"github.com/elasticclaw/elasticclaw/pkg/hub"
@@ -89,6 +91,106 @@ func TestShortcutWorkflowPollCreatesOnceForMissedWebhook(t *testing.T) {
 	}
 }
 
+func TestLinearWorkflowPollExcludeLabelsRoutesBugWorkflow(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
+	linear := factorytest.NewMockLinear(t)
+
+	cfg := &types.HubConfig{
+		ClawToken: "test-claw-token",
+		Providers: map[string]types.ProviderConfig{
+			"noop": {Type: "noop"},
+		},
+	}
+	s, db := hub.NewTestServerWithConfig(t, cfg, "", linear.URL, "")
+	saveWorkflowPollWorkspaceFixture(t, "workspace-a", []*types.WorkflowConfig{
+		{
+			SchemaVersion: "v1",
+			Name:          "generic-workflow",
+			Trigger: &types.WorkflowTrigger{
+				Linear: &types.LinearWorkflowTrigger{
+					Event:         "status_changed",
+					Team:          "ELA",
+					States:        []string{"Ready For Agent"},
+					ExcludeLabels: []string{"Bug"},
+				},
+			},
+			Stages: workflowPollTestStages(),
+		},
+		{
+			SchemaVersion: "v1",
+			Name:          "bug-workflow",
+			Trigger: &types.WorkflowTrigger{
+				Linear: &types.LinearWorkflowTrigger{
+					Event:  "status_changed",
+					Team:   "ELA",
+					States: []string{"Ready For Agent"},
+					Labels: []string{"Bug"},
+				},
+			},
+			Stages: workflowPollTestStages(),
+		},
+	})
+	hub.SaveWorkspaceIssueTrackerForTest(t, "workspace-a", "linear", "default", "test-linear-token", "")
+	linear.SetIssueStateName("ELA-123", "Ready For Agent")
+	linear.PollingIssues["ELA-123"]["labels"] = map[string]interface{}{"nodes": []map[string]interface{}{{"name": "Bug"}}}
+
+	s.PollIntegrationsForTest()
+
+	assertPollClawTagsContain(t, db, "linear_issue_id", "ELA-123", "workflow:bug-workflow")
+}
+
+func TestShortcutWorkflowPollExcludeLabelsRoutesBugWorkflow(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
+	shortcut := factorytest.NewMockShortcut(t)
+
+	cfg := &types.HubConfig{
+		ClawToken: "test-claw-token",
+		Providers: map[string]types.ProviderConfig{
+			"noop": {Type: "noop"},
+		},
+	}
+	s, db := hub.NewTestServerWithConfig(t, cfg, "", "", shortcut.URL)
+	saveWorkflowPollWorkspaceFixture(t, "workspace-a", []*types.WorkflowConfig{
+		{
+			SchemaVersion: "v1",
+			Name:          "generic-workflow",
+			Trigger: &types.WorkflowTrigger{
+				Shortcut: &types.ShortcutWorkflowTrigger{
+					Event:         "status_changed",
+					States:        []string{"In Progress"},
+					ExcludeLabels: []string{"Bug"},
+				},
+			},
+			Stages: workflowPollTestStages(),
+		},
+		{
+			SchemaVersion: "v1",
+			Name:          "bug-workflow",
+			Trigger: &types.WorkflowTrigger{
+				Shortcut: &types.ShortcutWorkflowTrigger{
+					Event:  "status_changed",
+					States: []string{"In Progress"},
+					Labels: []string{"Bug"},
+				},
+			},
+			Stages: workflowPollTestStages(),
+		},
+	})
+	hub.SaveWorkspaceIssueTrackerForTest(t, "workspace-a", "shortcut", "default", "test-shortcut-token", "")
+	shortcut.SetStory(124, factorytest.StoryState{
+		Name:            "Bug Story",
+		Description:     "Test description",
+		WorkflowStateID: shortcut.StateIDForName("In Progress"),
+		Labels:          []string{"Bug"},
+	})
+
+	s.PollIntegrationsForTest()
+
+	assertPollClawTagsContain(t, db, "shortcut_story_id", "sc-124", "workflow:bug-workflow")
+}
+
 func saveWorkflowPollWorkspaceFixture(t *testing.T, workspace string, workflows []*types.WorkflowConfig) {
 	t.Helper()
 	hub.SaveWorkspaceForTest(t,
@@ -102,6 +204,17 @@ func saveWorkflowPollWorkspaceFixture(t *testing.T, workspace string, workflows 
 		},
 		workflows,
 	)
+}
+
+func assertPollClawTagsContain(t *testing.T, db *sql.DB, idColumn, idValue, want string) {
+	t.Helper()
+	var tags string
+	if err := db.QueryRow(`SELECT tags FROM claws WHERE `+idColumn+`=? LIMIT 1`, idValue).Scan(&tags); err != nil {
+		t.Fatalf("query claw tags: %v", err)
+	}
+	if !strings.Contains(tags, want) {
+		t.Fatalf("tags for %s = %s, want %q", idValue, tags, want)
+	}
 }
 
 func workflowPollTestStages() []types.WorkflowStage {

--- a/pkg/hub/workspace_api.go
+++ b/pkg/hub/workspace_api.go
@@ -41,6 +41,7 @@ type WorkflowView struct {
 	TriggerStatus        string                 `json:"triggerStatus,omitempty"`
 	DoneStatus           string                 `json:"doneStatus,omitempty"`
 	Labels               []string               `json:"labels,omitempty"`
+	ExcludeLabels        []string               `json:"exclude_labels,omitempty"`
 	AssignedTo           string                 `json:"assignedTo,omitempty"`
 	Enabled              bool                   `json:"enabled"`
 	HasWebhookSecret     bool                   `json:"hasWebhookSecret"`
@@ -493,6 +494,7 @@ func workflowToView(workspaceName string, workflow *types.WorkflowConfig) Workfl
 		IntegrationWorkspace: workflow.Workspace,
 		TriggerStatus:        workflow.TriggerStatus,
 		Labels:               append([]string(nil), workflow.Labels...),
+		ExcludeLabels:        append([]string(nil), workflow.ExcludeLabels...),
 		AssignedTo:           workflow.AssignedTo,
 		Enabled:              workflow.Enabled == nil || *workflow.Enabled,
 		EnableManualTrigger:  workflow.EnableManualTrigger,

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -608,6 +608,8 @@ type FactoryConfig struct {
 	RequiresPR       *bool    `yaml:"requires_pr,omitempty" json:"requires_pr,omitempty"`               // nil = infer from analytics eligibility
 	// Labels: all must be present on the issue to trigger (AND)
 	Labels []string `yaml:"labels,omitempty" json:"labels,omitempty"`
+	// ExcludeLabels: none may be present on the issue to trigger (NOT)
+	ExcludeLabels []string `yaml:"exclude_labels,omitempty" json:"exclude_labels,omitempty"`
 	// AssignedTo filter: "@user", "!@user" (exclude), "any", "none"
 	AssignedTo string `yaml:"assigned_to,omitempty" json:"assigned_to,omitempty"`
 	// AllowedLabelers restricts who can trigger claw creation by labeling an issue.

--- a/pkg/types/validation.go
+++ b/pkg/types/validation.go
@@ -121,6 +121,9 @@ func (f *FactoryConfig) Validate() error {
 	if err := validateRunKind("factory", f.Name, f.RunKind); err != nil {
 		return err
 	}
+	if err := validateLabelList("factory", f.Name, "exclude_labels", f.ExcludeLabels); err != nil {
+		return err
+	}
 
 	// Validate name_pattern if provided
 	if f.NamePattern != "" && !namePatternRegex.MatchString(f.NamePattern) {
@@ -200,6 +203,9 @@ func (w *WorkflowConfig) Validate() error {
 		return fmt.Errorf("workflow %q: invalid color %q", w.Name, w.Color)
 	}
 	if err := validateRunKind("workflow", w.Name, w.RunKind); err != nil {
+		return err
+	}
+	if err := validateLabelList("workflow", w.Name, "exclude_labels", w.ExcludeLabels); err != nil {
 		return err
 	}
 	if w.NamePattern != "" && !namePatternRegex.MatchString(w.NamePattern) {
@@ -364,6 +370,9 @@ func validateGitHubIssuesWorkflowTrigger(workflowName string, trigger *GitHubIss
 	if trigger.AgentStatusError != "" && strings.TrimSpace(trigger.AgentStatusError) == "" {
 		return fmt.Errorf("workflow %q: trigger.github_issues.agent_status_error cannot be blank", workflowName)
 	}
+	if err := validateLabelList("workflow", workflowName, "trigger.github_issues.exclude_labels", trigger.ExcludeLabels); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -387,6 +396,9 @@ func validateLinearWorkflowTrigger(workflowName string, trigger *LinearWorkflowT
 	if trigger.AgentStatusError != "" && strings.TrimSpace(trigger.AgentStatusError) == "" {
 		return fmt.Errorf("workflow %q: trigger.linear.agent_status_error cannot be blank", workflowName)
 	}
+	if err := validateLabelList("workflow", workflowName, "trigger.linear.exclude_labels", trigger.ExcludeLabels); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -405,6 +417,18 @@ func validateShortcutWorkflowTrigger(workflowName string, trigger *ShortcutWorkf
 	for i, state := range trigger.States {
 		if strings.TrimSpace(state) == "" {
 			return fmt.Errorf("workflow %q: trigger.shortcut.states[%d] cannot be empty", workflowName, i)
+		}
+	}
+	if err := validateLabelList("workflow", workflowName, "trigger.shortcut.exclude_labels", trigger.ExcludeLabels); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateLabelList(entityType, entityName, field string, labels []string) error {
+	for i, label := range labels {
+		if strings.TrimSpace(label) == "" {
+			return fmt.Errorf("%s %q: %s[%d] cannot be blank", entityType, entityName, field, i)
 		}
 	}
 	return nil

--- a/pkg/types/validation_test.go
+++ b/pkg/types/validation_test.go
@@ -3,6 +3,8 @@ package types
 import (
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 func TestFactoryConfigValidate(t *testing.T) {
@@ -204,6 +206,35 @@ func TestFactoryConfigValidate(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "valid factory exclude labels",
+			factory: &FactoryConfig{
+				Name:          "test-factory",
+				Integration:   "github",
+				Template:      "base",
+				ExcludeLabels: []string{"Bug"},
+				Trigger: &GitHubTrigger{
+					On:     "issue",
+					Action: "opened",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid factory blank exclude label",
+			factory: &FactoryConfig{
+				Name:          "test-factory",
+				Integration:   "github",
+				Template:      "base",
+				ExcludeLabels: []string{" "},
+				Trigger: &GitHubTrigger{
+					On:     "issue",
+					Action: "opened",
+				},
+			},
+			wantErr: true,
+			errMsg:  "exclude_labels[0] cannot be blank",
+		},
+		{
 			name: "github factory missing trigger",
 			factory: &FactoryConfig{
 				Name:        "test-factory",
@@ -379,6 +410,33 @@ func TestFactoryConfigValidate(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestGitHubFactoryConfigLoadsExcludeLabels(t *testing.T) {
+	data := []byte(`
+name: github-pr
+integration: github
+template: base
+repos:
+  - elastic/claw
+labels:
+  - agent-ready
+exclude_labels:
+  - Bug
+trigger:
+  on: pull_request
+  action: opened
+`)
+	var factory FactoryConfig
+	if err := yaml.Unmarshal(data, &factory); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if err := factory.Validate(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if got := strings.Join(factory.ExcludeLabels, ","); got != "Bug" {
+		t.Fatalf("ExcludeLabels = %q, want Bug", got)
 	}
 }
 

--- a/pkg/types/workflow_normalize.go
+++ b/pkg/types/workflow_normalize.go
@@ -18,6 +18,7 @@ func NormalizeWorkflowConfig(workflow *WorkflowConfig) error {
 			workflow.Integration = "github-issues"
 			workflow.TriggerRepos = append([]string(nil), workflow.Trigger.GitHubIssues.Repositories...)
 			workflow.Labels = append([]string(nil), workflow.Trigger.GitHubIssues.Labels...)
+			workflow.ExcludeLabels = append([]string(nil), workflow.Trigger.GitHubIssues.ExcludeLabels...)
 			workflow.AssignedTo = workflow.Trigger.GitHubIssues.AssignedTo
 			workflow.AllowedLabelers = nil
 			for _, labeler := range workflow.Trigger.GitHubIssues.Labelers {
@@ -36,6 +37,7 @@ func NormalizeWorkflowConfig(workflow *WorkflowConfig) error {
 			workflow.Workspace = workflow.Trigger.Linear.Workspace
 			workflow.Team = workflow.Trigger.Linear.Team
 			workflow.Labels = append([]string(nil), workflow.Trigger.Linear.Labels...)
+			workflow.ExcludeLabels = append([]string(nil), workflow.Trigger.Linear.ExcludeLabels...)
 			workflow.AssignedTo = workflow.Trigger.Linear.AssignedTo
 			if len(workflow.Trigger.Linear.States) > 0 {
 				workflow.TriggerStatus = workflow.Trigger.Linear.States[0]
@@ -44,6 +46,7 @@ func NormalizeWorkflowConfig(workflow *WorkflowConfig) error {
 			workflow.Integration = "shortcut"
 			workflow.Workspace = workflow.Trigger.Shortcut.Workspace
 			workflow.Labels = append([]string(nil), workflow.Trigger.Shortcut.Labels...)
+			workflow.ExcludeLabels = append([]string(nil), workflow.Trigger.Shortcut.ExcludeLabels...)
 			workflow.AssignedTo = workflow.Trigger.Shortcut.AssignedTo
 			if len(workflow.Trigger.Shortcut.States) > 0 {
 				workflow.TriggerStatus = workflow.Trigger.Shortcut.States[0]

--- a/pkg/types/workflow_normalize_test.go
+++ b/pkg/types/workflow_normalize_test.go
@@ -138,6 +138,77 @@ stages:
 	}
 }
 
+func TestWorkflowNormalizePreservesExcludeLabels(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{
+			name: "linear",
+			data: []byte(`
+schema_version: v1
+name: linear-story
+trigger:
+  linear:
+    event: status_changed
+    states: [Todo]
+    exclude_labels: [Bug]
+stages:
+  - id: working
+    entry: true
+`),
+		},
+		{
+			name: "shortcut",
+			data: []byte(`
+schema_version: v1
+name: shortcut-story
+trigger:
+  shortcut:
+    event: status_changed
+    states: [Todo]
+    exclude_labels: [Bug]
+stages:
+  - id: working
+    entry: true
+`),
+		},
+		{
+			name: "github issues",
+			data: []byte(`
+schema_version: v1
+name: github-issue
+trigger:
+  github_issues:
+    event: issue_labeled
+    repositories: [elasticclaw/elasticclaw]
+    labels: [agent-ready]
+    exclude_labels: [Bug]
+stages:
+  - id: working
+    entry: true
+`),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var workflow WorkflowConfig
+			if err := yaml.Unmarshal(tt.data, &workflow); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if err := NormalizeWorkflowConfig(&workflow); err != nil {
+				t.Fatalf("normalize: %v", err)
+			}
+			if got := strings.Join(workflow.ExcludeLabels, ","); got != "Bug" {
+				t.Fatalf("ExcludeLabels = %q, want Bug", got)
+			}
+			if err := workflow.Validate(); err != nil {
+				t.Fatalf("validate: %v", err)
+			}
+		})
+	}
+}
+
 func TestWorkflowV1LinearTriggerPreservesAgentStatusError(t *testing.T) {
 	data := []byte(`
 schema_version: v1

--- a/pkg/types/workspace.go
+++ b/pkg/types/workspace.go
@@ -41,6 +41,7 @@ type WorkflowConfig struct {
 	AnalyticsEnabled    *bool             `yaml:"analytics_enabled,omitempty" json:"analytics_enabled,omitempty"`
 	RequiresPR          *bool             `yaml:"requires_pr,omitempty" json:"requires_pr,omitempty"`
 	Labels              []string          `yaml:"labels,omitempty" json:"labels,omitempty"`
+	ExcludeLabels       []string          `yaml:"exclude_labels,omitempty" json:"exclude_labels,omitempty"`
 	AssignedTo          string            `yaml:"assigned_to,omitempty" json:"assigned_to,omitempty"`
 	AllowedLabelers     []string          `yaml:"allowed_labelers,omitempty" json:"allowed_labelers,omitempty"`
 	SecretRefs          map[string]string `yaml:"secret_refs,omitempty" json:"secret_refs,omitempty"`
@@ -120,6 +121,7 @@ type GitHubIssuesWorkflowTrigger struct {
 	Repositories     []string `yaml:"repositories,omitempty" json:"repositories,omitempty"`
 	States           []string `yaml:"states,omitempty" json:"states,omitempty"`
 	Labels           []string `yaml:"labels,omitempty" json:"labels,omitempty"`
+	ExcludeLabels    []string `yaml:"exclude_labels,omitempty" json:"exclude_labels,omitempty"`
 	Labelers         []string `yaml:"labelers,omitempty" json:"labelers,omitempty"`
 	AssignedTo       string   `yaml:"assigned_to,omitempty" json:"assigned_to,omitempty"`
 	AgentStatusError string   `yaml:"agent_status_error,omitempty" json:"agent_status_error,omitempty"`
@@ -131,16 +133,18 @@ type LinearWorkflowTrigger struct {
 	Team             string   `yaml:"team,omitempty" json:"team,omitempty"`
 	States           []string `yaml:"states,omitempty" json:"states,omitempty"`
 	Labels           []string `yaml:"labels,omitempty" json:"labels,omitempty"`
+	ExcludeLabels    []string `yaml:"exclude_labels,omitempty" json:"exclude_labels,omitempty"`
 	AssignedTo       string   `yaml:"assigned_to,omitempty" json:"assigned_to,omitempty"`
 	AgentStatusError string   `yaml:"agent_status_error,omitempty" json:"agent_status_error,omitempty"`
 }
 
 type ShortcutWorkflowTrigger struct {
-	Event      string   `yaml:"event,omitempty" json:"event,omitempty"`
-	Workspace  string   `yaml:"workspace,omitempty" json:"workspace,omitempty"`
-	States     []string `yaml:"states,omitempty" json:"states,omitempty"`
-	Labels     []string `yaml:"labels,omitempty" json:"labels,omitempty"`
-	AssignedTo string   `yaml:"assigned_to,omitempty" json:"assigned_to,omitempty"`
+	Event         string   `yaml:"event,omitempty" json:"event,omitempty"`
+	Workspace     string   `yaml:"workspace,omitempty" json:"workspace,omitempty"`
+	States        []string `yaml:"states,omitempty" json:"states,omitempty"`
+	Labels        []string `yaml:"labels,omitempty" json:"labels,omitempty"`
+	ExcludeLabels []string `yaml:"exclude_labels,omitempty" json:"exclude_labels,omitempty"`
+	AssignedTo    string   `yaml:"assigned_to,omitempty" json:"assigned_to,omitempty"`
 }
 
 // WorkflowStage is one step in a workflow state machine. It intentionally mirrors


### PR DESCRIPTION
## Summary
- add `exclude_labels` support for factory/workflow trigger matching
- apply label exclusion across Linear, Shortcut, GitHub Issues, and GitHub issue/PR factories
- fetch GitHub PR backing issue labels before applying label filters
- validate excluded label config and expose it through API/settings views

## Tests
- `go test -count=1 ./pkg/types ./pkg/hub`