### PR TITLE
Add Jira issue tracker support

### DIFF
--- a/.depot/workflows/e2e.yml
+++ b/.depot/workflows/e2e.yml
@@ -10,6 +10,7 @@ on:
       - 'pkg/hub/github.go'
       - 'pkg/hub/github_issues.go'
       - 'pkg/hub/integration_poller.go'
+      - 'pkg/hub/jira*.go'
       - 'pkg/hub/linear.go'
       - 'pkg/hub/pipeline_runner.go'
       - 'pkg/hub/server.go'
@@ -115,6 +116,11 @@ jobs:
             tracker_name: Linear
             slug: linear
             test: TestDaytonaLinearWorkflowE2E
+          - provider_name: Daytona
+            provider_slug: daytona
+            tracker_name: Jira
+            slug: jira
+            test: TestDaytonaJiraWorkflowE2E
           - provider_name: Replicated
             provider_slug: replicated
             tracker_name: GitHub Issues
@@ -125,6 +131,11 @@ jobs:
             tracker_name: Linear
             slug: linear
             test: TestReplicatedLinearWorkflowE2E
+          - provider_name: Replicated
+            provider_slug: replicated
+            tracker_name: Jira
+            slug: jira
+            test: TestReplicatedJiraWorkflowE2E
     env:
       ELASTICCLAW_E2E_BIN: ${{ github.workspace }}/bin/elasticclaw
       ELASTICCLAW_E2E_BRIDGE_BINARY: ${{ github.workspace }}/bin/claw-bridge-linux-amd64
@@ -141,6 +152,11 @@ jobs:
       ELASTICCLAW_E2E_LINEAR_TEAM_KEY: ${{ secrets.ELASTICCLAW_E2E_LINEAR_TEAM_KEY }}
       ELASTICCLAW_E2E_LINEAR_TRIGGER_STATE: ${{ secrets.ELASTICCLAW_E2E_LINEAR_TRIGGER_STATE }}
       ELASTICCLAW_E2E_LINEAR_INITIAL_STATE: ${{ secrets.ELASTICCLAW_E2E_LINEAR_INITIAL_STATE }}
+      ELASTICCLAW_E2E_JIRA_BASE_URL: ${{ secrets.ELASTICCLAW_E2E_JIRA_BASE_URL }}
+      ELASTICCLAW_E2E_JIRA_USERNAME: ${{ secrets.ELASTICCLAW_E2E_JIRA_USERNAME }}
+      ELASTICCLAW_E2E_JIRA_TOKEN: ${{ secrets.ELASTICCLAW_E2E_JIRA_TOKEN }}
+      ELASTICCLAW_E2E_JIRA_PROJECT_KEY: ${{ secrets.ELASTICCLAW_E2E_JIRA_PROJECT_KEY }}
+      ELASTICCLAW_E2E_JIRA_MANUAL_WEBHOOK: "true"
       ELASTICCLAW_E2E_MODEL: fireworks/accounts/fireworks/models/kimi-k2p6
       ELASTICCLAW_E2E_RUN_ID: pr-${{ github.event.pull_request.number || github.run_number }}-${{ github.run_attempt }}-${{ matrix.provider_slug }}-${{ matrix.slug }}-${{ github.sha }}
       DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-bridge build-bridge-linux test test-bootstrap test-container e2e e2e-github e2e-linear e2e-replicated-github e2e-replicated-linear e2e-run clean install lint tidy clawpatch-init clawpatch-review clawpatch-report clawpatch-show clawpatch-triage clawpatch-pr dev dev-up dev-up-d dev-down dev-reset dev-logs dev-restart dev-sh-hub dev-sh-web dev-agent-build dev-claw _dev-config-check
+.PHONY: build build-bridge build-bridge-linux test test-bootstrap test-container e2e e2e-github e2e-linear e2e-jira e2e-replicated-github e2e-replicated-linear e2e-replicated-jira e2e-run clean install lint tidy clawpatch-init clawpatch-review clawpatch-report clawpatch-show clawpatch-triage clawpatch-pr dev dev-up dev-up-d dev-down dev-reset dev-logs dev-restart dev-sh-hub dev-sh-web dev-agent-build dev-claw _dev-config-check
 
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
@@ -53,7 +53,7 @@ test-factory: ## Run factory integration tests
 test-parity: ## Run parity matrix integration tests (all trackers)
 	go test -v -tags integration -timeout 120s ./pkg/hub/... -run TestParity
 
-e2e: e2e-github e2e-linear e2e-replicated-github e2e-replicated-linear ## Run all real E2E suites sequentially
+e2e: e2e-github e2e-linear e2e-jira e2e-replicated-github e2e-replicated-linear e2e-replicated-jira ## Run all real E2E suites sequentially
 
 e2e-github: ## Run the real Daytona + GitHub Issues E2E suite
 	$(MAKE) e2e-run E2E_TEST=TestDaytonaGitHubIssuesWorkflowE2E
@@ -61,11 +61,17 @@ e2e-github: ## Run the real Daytona + GitHub Issues E2E suite
 e2e-linear: ## Run the real Daytona + Linear E2E suite
 	$(MAKE) e2e-run E2E_TEST=TestDaytonaLinearWorkflowE2E
 
+e2e-jira: ## Run the real Daytona + Jira Cloud E2E suite
+	$(MAKE) e2e-run E2E_TEST=TestDaytonaJiraWorkflowE2E
+
 e2e-replicated-github: ## Run the real Replicated CMX + GitHub Issues E2E suite
 	$(MAKE) e2e-run E2E_TEST=TestReplicatedGitHubIssuesWorkflowE2E
 
 e2e-replicated-linear: ## Run the real Replicated CMX + Linear E2E suite
 	$(MAKE) e2e-run E2E_TEST=TestReplicatedLinearWorkflowE2E
+
+e2e-replicated-jira: ## Run the real Replicated CMX + Jira Cloud E2E suite
+	$(MAKE) e2e-run E2E_TEST=TestReplicatedJiraWorkflowE2E
 
 e2e-run: build-dev build-bridge-linux
 	@command -v ngrok >/dev/null 2>&1 || (echo "ngrok is required for make e2e" && exit 1)

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -40,6 +40,7 @@ func migrate(db *sql.DB) error {
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN linear_issue_id TEXT NOT NULL DEFAULT ''`)
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN github_issue_id TEXT NOT NULL DEFAULT ''`)
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN shortcut_story_id TEXT NOT NULL DEFAULT ''`)
+	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN jira_issue_id TEXT NOT NULL DEFAULT ''`)
 	// Migrate existing Shortcut story IDs from linear_issue_id to shortcut_story_id
 	_, _ = db.Exec(`UPDATE claws SET shortcut_story_id = linear_issue_id WHERE linear_issue_id LIKE 'sc-%' AND shortcut_story_id = ''`)
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN llm_key TEXT NOT NULL DEFAULT ''`)
@@ -127,6 +128,11 @@ func migrate(db *sql.DB) error {
 		SELECT lower(hex(randomblob(16))), factory_name, 'shortcut', 'shortcut:' || shortcut_story_id, 'migration', '{}', id, 'active', created_at, created_at, created_at, created_at
 		  FROM claws
 		 WHERE factory_name != '' AND shortcut_story_id != '' AND status != 'deleted'`)
+	_, _ = db.Exec(`
+		INSERT OR IGNORE INTO factory_triggers(id, factory_name, integration, trigger_key, trigger_source, trigger_payload, claw_id, status, first_seen_at, last_seen_at, created_at, updated_at)
+		SELECT lower(hex(randomblob(16))), factory_name, 'jira', 'jira:' || jira_issue_id, 'migration', '{}', id, 'active', created_at, created_at, created_at, created_at
+		  FROM claws
+		 WHERE factory_name != '' AND jira_issue_id != '' AND status != 'deleted'`)
 
 	// Factory analytics — persistent metrics table
 	_, _ = db.Exec(`CREATE TABLE IF NOT EXISTS factory_analytics (
@@ -196,6 +202,7 @@ func migrate(db *sql.DB) error {
 		linear_issue_id  TEXT NOT NULL DEFAULT '',
 		github_issue_id  TEXT NOT NULL DEFAULT '',
 		shortcut_story_id TEXT NOT NULL DEFAULT '',
+		jira_issue_id    TEXT NOT NULL DEFAULT '',
 		llm_key          TEXT NOT NULL DEFAULT '',
 		pipeline_stage   TEXT NOT NULL DEFAULT '',
 		bootstrap_ok        INTEGER NOT NULL DEFAULT 0,

--- a/pkg/hub/doctor.go
+++ b/pkg/hub/doctor.go
@@ -585,7 +585,7 @@ func (s *Server) checkFactories(cfg *types.HubConfig, diskCfg *types.HubConfig) 
 		// Check 5: overlapping triggers
 		var key triggerKey
 		switch f.Integration {
-		case "linear", "shortcut", "github-issues":
+		case "linear", "shortcut", "github-issues", "jira":
 			key = triggerKey{integration: f.Integration, workspace: f.Workspace, trigger: f.TriggerStatus}
 		case "github":
 			if f.Trigger != nil {
@@ -909,7 +909,70 @@ func (s *Server) checkIntegrations(cfg *types.HubConfig, diskCfg *types.HubConfi
 		}
 	}
 
-	if len(cfg.Integrations.Linear) == 0 && len(cfg.Integrations.Shortcut) == 0 && len(cfg.Integrations.GitHubIssues) == 0 {
+	for _, ji := range cfg.Integrations.Jira {
+		if ji.Token == "" {
+			checks = append(checks, DoctorCheck{
+				Category:    "integrations",
+				Severity:    "critical",
+				Title:       fmt.Sprintf("Jira workspace %q missing token", ji.Workspace),
+				Description: fmt.Sprintf("Jira integration workspace %q has no API token configured.", ji.Workspace),
+				OK:          false,
+				FixAction: &FixAction{
+					Type:   "navigate",
+					Target: "/settings/issue-trackers",
+					Label:  "Add Token",
+				},
+			})
+		}
+		if ji.BaseURL == "" {
+			checks = append(checks, DoctorCheck{
+				Category:    "integrations",
+				Severity:    "critical",
+				Title:       fmt.Sprintf("Jira workspace %q missing base URL", ji.Workspace),
+				Description: fmt.Sprintf("Jira integration workspace %q has no base URL configured.", ji.Workspace),
+				OK:          false,
+				FixAction: &FixAction{
+					Type:   "navigate",
+					Target: "/settings/issue-trackers",
+					Label:  "Add Base URL",
+				},
+			})
+		}
+		if ji.Token != "" && ji.BaseURL != "" {
+			checks = append(checks, DoctorCheck{
+				Category:    "integrations",
+				Severity:    "info",
+				Title:       fmt.Sprintf("Jira workspace %q configured", ji.Workspace),
+				Description: fmt.Sprintf("Jira workspace %q has a base URL and token configured.", ji.Workspace),
+				OK:          true,
+			})
+		}
+		if ji.WebhookSecret == "" {
+			checks = append(checks, DoctorCheck{
+				Category:    "integrations",
+				Severity:    "warning",
+				Title:       fmt.Sprintf("Jira workspace %q missing webhook secret", ji.Workspace),
+				Description: fmt.Sprintf("Jira workspace %q has no webhook secret. Webhooks will not be validated.", ji.Workspace),
+				OK:          false,
+				FixAction: &FixAction{
+					Type:   "navigate",
+					Target: "/settings/issue-trackers",
+					Label:  "Add Secret",
+				},
+			})
+		}
+		if !factoryWorkspaces["jira"][ji.Workspace] {
+			checks = append(checks, DoctorCheck{
+				Category:    "integrations",
+				Severity:    "info",
+				Title:       fmt.Sprintf("Jira workspace %q has no factory using it", ji.Workspace),
+				Description: fmt.Sprintf("Jira workspace %q is configured but no factory references it.", ji.Workspace),
+				OK:          false,
+			})
+		}
+	}
+
+	if len(cfg.Integrations.Linear) == 0 && len(cfg.Integrations.Shortcut) == 0 && len(cfg.Integrations.GitHubIssues) == 0 && len(cfg.Integrations.Jira) == 0 {
 		checks = append(checks, DoctorCheck{
 			Category:    "integrations",
 			Severity:    "info",

--- a/pkg/hub/factory_creator.go
+++ b/pkg/hub/factory_creator.go
@@ -132,6 +132,19 @@ func (s *Server) createClawFromFactory(factory *types.FactoryConfig, issueID str
 			env["LINEAR_API_KEY"] = linearToken
 		}
 	}
+	if factory.Integration == "jira" {
+		if tracker, ok := s.resolveJiraTrackerForFactory(factory); ok {
+			if tracker.Token != "" {
+				env["JIRA_API_KEY"] = tracker.Token
+			}
+			if tracker.BaseURL != "" {
+				env["JIRA_BASE_URL"] = tracker.BaseURL
+			}
+			if tracker.Username != "" {
+				env["JIRA_USERNAME"] = tracker.Username
+			}
+		}
+	}
 
 	// Resolve and inject template-requested secrets (deprecated list format)
 	resolvedSecrets := make(map[string]string)
@@ -332,7 +345,7 @@ func (s *Server) createClawFromFactory(factory *types.FactoryConfig, issueID str
 		initialStatus = "pending"
 	}
 
-	var linearIssueID, githubIssueID, shortcutStoryID string
+	var linearIssueID, githubIssueID, shortcutStoryID, jiraIssueID string
 	if factory.Integration == "linear" && issueID != "" {
 		linearIssueID = issueID
 	}
@@ -342,13 +355,16 @@ func (s *Server) createClawFromFactory(factory *types.FactoryConfig, issueID str
 	if factory.Integration == "shortcut" && issueID != "" {
 		shortcutStoryID = issueID
 	}
+	if factory.Integration == "jira" && issueID != "" {
+		jiraIssueID = issueID
+	}
 
 	_, err = s.db.Exec(`
-		INSERT INTO claws(id, tenant_id, name, template, provider, default_model, template_files, github_repos, linear_workspace, nix, docker, tags, color, llm_key, linear_issue_id, github_issue_id, shortcut_story_id, status, created_at, factory_name, concurrency_group)
-		VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		INSERT INTO claws(id, tenant_id, name, template, provider, default_model, template_files, github_repos, linear_workspace, nix, docker, tags, color, llm_key, linear_issue_id, github_issue_id, shortcut_story_id, jira_issue_id, status, created_at, factory_name, concurrency_group)
+		VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
 		clawID, tenantID, clawName, factory.Template, provider, defaultModel, string(filesJSON),
 		string(githubReposJSON), linearWorkspace, nixEnabled, dockerEnabled, string(tagsJSON), clawColor, llmKey,
-		linearIssueID, githubIssueID, shortcutStoryID, initialStatus, now, factory.Name, groupName,
+		linearIssueID, githubIssueID, shortcutStoryID, jiraIssueID, initialStatus, now, factory.Name, groupName,
 	)
 
 	s.promoteMu.Unlock()

--- a/pkg/hub/integration_poller.go
+++ b/pkg/hub/integration_poller.go
@@ -1374,7 +1374,7 @@ func (s *Server) processJiraPollItem(issue jiraPollIssue, factories []*types.Fac
 		if factory.TriggerStatus == "" || !strings.EqualFold(issue.Fields.Status.Name, factory.TriggerStatus) {
 			continue
 		}
-		if !s.labelsMatch(labels, factory.Labels) || !s.assigneeMatches(assignee, factory.AssignedTo) {
+		if !labelsAllowed(labels, factory.Labels, factory.ExcludeLabels) || !s.assigneeMatches(assignee, factory.AssignedTo) {
 			continue
 		}
 		if err := s.createClawForJiraIssue(factory, payload, "poll"); err != nil {
@@ -1406,7 +1406,7 @@ func (s *Server) processJiraWorkflowPollItem(issue jiraPollIssue, targets []jira
 		if workflow.AssignedTo != "" && !assignedToMatches(workflow.AssignedTo, assignee) {
 			continue
 		}
-		if !jiraLabelsMapMatches(labels, workflow.Labels) {
+		if !labelsAllowed(labels, workflow.Labels, workflow.ExcludeLabels) {
 			continue
 		}
 		if err := s.createClawForJiraWorkflow(workspace, workflow, payload, "poll"); err != nil {

--- a/pkg/hub/integration_poller.go
+++ b/pkg/hub/integration_poller.go
@@ -48,7 +48,11 @@ func (s *Server) pollTick() {
 	if err != nil {
 		log.Printf("[poll] tick: failed to load github-issues workflows: %v", err)
 	}
-	if len(factories) == 0 && len(linearWorkflowWorkspaces) == 0 && len(shortcutWorkflowWorkspaces) == 0 && len(githubIssueWorkflowWorkspaces) == 0 {
+	jiraWorkflowWorkspaces, err := loadExternalWorkflowsByIntegration("jira")
+	if err != nil {
+		log.Printf("[poll] tick: failed to load jira workflows: %v", err)
+	}
+	if len(factories) == 0 && len(linearWorkflowWorkspaces) == 0 && len(shortcutWorkflowWorkspaces) == 0 && len(githubIssueWorkflowWorkspaces) == 0 && len(jiraWorkflowWorkspaces) == 0 {
 		log.Printf("[poll] tick: no factories or workflows configured")
 		return
 	}
@@ -79,6 +83,14 @@ func (s *Server) pollTick() {
 	}
 	if len(githubIssueWorkflowWorkspaces) > 0 {
 		s.pollGitHubIssueWorkflows(githubIssueWorkflowWorkspaces, since)
+	}
+
+	// === JIRA ===
+	if integrations != nil && len(integrations.Jira) > 0 {
+		s.pollJira(factories, integrations.Jira, now.Add(-2*time.Minute))
+	}
+	if len(jiraWorkflowWorkspaces) > 0 {
+		s.pollJiraWorkflows(jiraWorkflowWorkspaces, now.Add(-2*time.Minute))
 	}
 
 	// === GITHUB PRs ===
@@ -1221,6 +1233,197 @@ func buildGitHubIssuesPollPayloadForAction(issue githubIssuesPollItem, repo, act
 	payload.Repository.FullName = repo
 	payload.Sender.Login = issue.User.Login
 	return payload
+}
+
+// ── JIRA POLLER ─────────────────────────────────────────────────────────────
+
+func (s *Server) pollJira(factories []*types.FactoryConfig, jiraCfgs []*types.JiraIntegrationConfig, since time.Time) {
+	workspaceFactories := map[string][]*types.FactoryConfig{}
+	for _, f := range factories {
+		if f.Integration != "jira" {
+			continue
+		}
+		if f.Enabled != nil && !*f.Enabled {
+			continue
+		}
+		workspaceFactories[f.Workspace] = append(workspaceFactories[f.Workspace], f)
+	}
+	for _, ji := range jiraCfgs {
+		if ji.Token == "" || ji.BaseURL == "" {
+			continue
+		}
+		factories := append([]*types.FactoryConfig{}, workspaceFactories[ji.Workspace]...)
+		if ji.Workspace != "" {
+			factories = append(factories, workspaceFactories[""]...)
+		}
+		if len(factories) == 0 {
+			continue
+		}
+		projects := jiraFactoryProjects(factories)
+		tracker := workspaceIssueTracker{BaseURL: ji.BaseURL, Username: ji.Username, Token: ji.Token, WebhookSecret: ji.WebhookSecret}
+		issues, err := s.queryJiraIssues(tracker, since, projects)
+		if err != nil {
+			log.Printf("[poll-jira] query failed for workspace %q: %v", ji.Workspace, err)
+			continue
+		}
+		for _, issue := range issues {
+			s.processJiraPollItem(issue, factories, tracker)
+		}
+	}
+}
+
+type jiraWorkflowPollTarget struct {
+	workspace *types.WorkspaceConfig
+	workflow  *types.WorkflowConfig
+	tracker   workspaceIssueTracker
+}
+
+func (s *Server) pollJiraWorkflows(workspaces []*types.WorkspaceConfig, since time.Time) {
+	type trackerKey struct {
+		baseURL  string
+		username string
+		token    string
+	}
+	targetsByTracker := map[trackerKey][]jiraWorkflowPollTarget{}
+	for _, workspace := range workspaces {
+		if workspace == nil {
+			continue
+		}
+		for _, workflow := range workspace.Workflows {
+			if workflow == nil || workflow.Integration != "jira" {
+				continue
+			}
+			if workflow.Enabled != nil && !*workflow.Enabled {
+				continue
+			}
+			tracker, ok := s.resolveJiraTrackerForWorkflow(workspace.Name, workflow)
+			if !ok || tracker.Token == "" || tracker.BaseURL == "" {
+				log.Printf("[poll-jira] workflow %s/%s: no Jira tracker configured — skipping", workspace.Name, workflow.Name)
+				continue
+			}
+			key := trackerKey{baseURL: tracker.BaseURL, username: tracker.Username, token: tracker.Token}
+			targetsByTracker[key] = append(targetsByTracker[key], jiraWorkflowPollTarget{workspace: workspace, workflow: workflow, tracker: tracker})
+		}
+	}
+	for _, targets := range targetsByTracker {
+		if len(targets) == 0 {
+			continue
+		}
+		tracker := targets[0].tracker
+		issues, err := s.queryJiraIssues(tracker, since, jiraWorkflowProjects(targets))
+		if err != nil {
+			log.Printf("[poll-jira] workflow query failed: %v", err)
+			continue
+		}
+		for _, issue := range issues {
+			s.processJiraWorkflowPollItem(issue, targets)
+		}
+	}
+}
+
+func jiraFactoryProjects(factories []*types.FactoryConfig) []string {
+	seen := map[string]bool{}
+	var projects []string
+	for _, factory := range factories {
+		for _, project := range factory.Projects {
+			project = strings.TrimSpace(project)
+			if project == "" || seen[strings.ToLower(project)] {
+				continue
+			}
+			seen[strings.ToLower(project)] = true
+			projects = append(projects, project)
+		}
+	}
+	return projects
+}
+
+func jiraWorkflowProjects(targets []jiraWorkflowPollTarget) []string {
+	seen := map[string]bool{}
+	var projects []string
+	for _, target := range targets {
+		if target.workflow == nil {
+			continue
+		}
+		values := target.workflow.TriggerRepos
+		if target.workflow.Trigger != nil && target.workflow.Trigger.Jira != nil && len(target.workflow.Trigger.Jira.Projects) > 0 {
+			values = target.workflow.Trigger.Jira.Projects
+		}
+		for _, project := range values {
+			project = strings.TrimSpace(project)
+			if project == "" || seen[strings.ToLower(project)] {
+				continue
+			}
+			seen[strings.ToLower(project)] = true
+			projects = append(projects, project)
+		}
+	}
+	return projects
+}
+
+func (s *Server) processJiraPollItem(issue jiraPollIssue, factories []*types.FactoryConfig, tracker workspaceIssueTracker) {
+	payload := jiraPollPayload(issue)
+	labels := jiraIssueLabels(issue)
+	assignee := jiraIssueAssignee(issue)
+	for _, factory := range factories {
+		if factory.Integration != "jira" {
+			continue
+		}
+		if !jiraProjectMatches(issue.Fields.Project.Key, factory.Projects) {
+			continue
+		}
+		if factory.TriggerStatus == "" || !strings.EqualFold(issue.Fields.Status.Name, factory.TriggerStatus) {
+			continue
+		}
+		if !s.labelsMatch(labels, factory.Labels) || !s.assigneeMatches(assignee, factory.AssignedTo) {
+			continue
+		}
+		if err := s.createClawForJiraIssue(factory, payload, "poll"); err != nil {
+			if isFactoryTriggerAlreadyClaimed(err) {
+				continue
+			}
+			log.Printf("[poll-jira] failed to create claw for %s: %v", issue.Key, err)
+		}
+	}
+	_ = tracker
+}
+
+func (s *Server) processJiraWorkflowPollItem(issue jiraPollIssue, targets []jiraWorkflowPollTarget) {
+	payload := jiraPollPayload(issue)
+	labels := jiraIssueLabels(issue)
+	assignee := jiraIssueAssignee(issue)
+	for _, target := range targets {
+		workspace := target.workspace
+		workflow := target.workflow
+		if workspace == nil || workflow == nil {
+			continue
+		}
+		if !jiraWorkflowMatchesProject(workflow, issue.Fields.Project.Key) {
+			continue
+		}
+		if workflow.TriggerStatus == "" || !strings.EqualFold(issue.Fields.Status.Name, workflow.TriggerStatus) {
+			continue
+		}
+		if workflow.AssignedTo != "" && !assignedToMatches(workflow.AssignedTo, assignee) {
+			continue
+		}
+		if !jiraLabelsMapMatches(labels, workflow.Labels) {
+			continue
+		}
+		if err := s.createClawForJiraWorkflow(workspace, workflow, payload, "poll"); err != nil {
+			if isFactoryTriggerAlreadyClaimed(err) {
+				continue
+			}
+			log.Printf("[workflow:%s/%s] failed to create claw for Jira issue %s via poll: %v", workspace.Name, workflow.Name, issue.Key, err)
+		}
+	}
+}
+
+func jiraPollPayload(issue jiraPollIssue) jiraWebhookPayload {
+	return jiraWebhookPayload{
+		WebhookEvent: "jira:issue_updated",
+		Timestamp:    time.Now().UnixMilli(),
+		Issue:        jiraIssue(issue),
+	}
 }
 
 // ── GITHUB PRs POLLER ─────────────────────────────────────────────────────────

--- a/pkg/hub/jira.go
+++ b/pkg/hub/jira.go
@@ -212,7 +212,7 @@ func (s *Server) processJiraEvent(workspaceName string, payload jiraWebhookPaylo
 		if factory.TriggerStatus == "" || !strings.EqualFold(currentStatus, factory.TriggerStatus) || strings.EqualFold(previousStatus, factory.TriggerStatus) {
 			continue
 		}
-		if !s.labelsMatch(labels, factory.Labels) || !s.assigneeMatches(assignee, factory.AssignedTo) {
+		if !labelsAllowed(labels, factory.Labels, factory.ExcludeLabels) || !s.assigneeMatches(assignee, factory.AssignedTo) {
 			continue
 		}
 		if err := s.createClawForJiraIssue(factory, payload, "jira webhook"); err != nil {
@@ -266,7 +266,7 @@ func (s *Server) processJiraWorkflowEvent(workspaces []*types.WorkspaceConfig, p
 			if workflow.AssignedTo != "" && !assignedToMatches(workflow.AssignedTo, assignee) {
 				continue
 			}
-			if !jiraLabelsMapMatches(labels, workflow.Labels) {
+			if !labelsAllowed(labels, workflow.Labels, workflow.ExcludeLabels) {
 				continue
 			}
 			matched = true
@@ -332,22 +332,6 @@ func jiraIssueAssignee(issue jiraIssue) string {
 		}
 	}
 	return ""
-}
-
-func jiraLabelsMapMatches(labels, required []string) bool {
-	if len(required) == 0 {
-		return true
-	}
-	set := map[string]bool{}
-	for _, label := range labels {
-		set[strings.ToLower(strings.TrimSpace(label))] = true
-	}
-	for _, label := range required {
-		if !set[strings.ToLower(strings.TrimSpace(label))] {
-			return false
-		}
-	}
-	return true
 }
 
 func jiraProjectMatches(project string, projects []string) bool {

--- a/pkg/hub/jira.go
+++ b/pkg/hub/jira.go
@@ -1,0 +1,705 @@
+package hub
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+type jiraWebhookPayload struct {
+	WebhookEvent string    `json:"webhookEvent"`
+	Timestamp    int64     `json:"timestamp"`
+	Issue        jiraIssue `json:"issue"`
+	User         jiraUser  `json:"user"`
+	Changelog    *struct {
+		ID    string `json:"id"`
+		Items []struct {
+			Field      string `json:"field"`
+			FromString string `json:"fromString"`
+			ToString   string `json:"toString"`
+		} `json:"items"`
+	} `json:"changelog,omitempty"`
+}
+
+type jiraIssue struct {
+	ID     string `json:"id"`
+	Key    string `json:"key"`
+	Self   string `json:"self"`
+	Fields struct {
+		Summary     string   `json:"summary"`
+		Description any      `json:"description"`
+		Labels      []string `json:"labels"`
+		Updated     string   `json:"updated"`
+		Status      struct {
+			Name string `json:"name"`
+		} `json:"status"`
+		Project struct {
+			Key  string `json:"key"`
+			Name string `json:"name"`
+		} `json:"project"`
+		Assignee *jiraUser `json:"assignee"`
+	} `json:"fields"`
+}
+
+type jiraUser struct {
+	AccountID    string `json:"accountId"`
+	Name         string `json:"name"`
+	Key          string `json:"key"`
+	DisplayName  string `json:"displayName"`
+	EmailAddress string `json:"emailAddress"`
+}
+
+type jiraPollIssue = jiraIssue
+
+func (s *Server) handleJiraWebhook(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	workspaceName := strings.TrimSpace(r.PathValue("workspace"))
+	if workspaceName == "" {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	if err != nil {
+		http.Error(w, "read error", http.StatusBadRequest)
+		return
+	}
+	if !s.validateJiraWebhookSecret(workspaceName, r) {
+		http.Error(w, "invalid signature", http.StatusUnauthorized)
+		return
+	}
+
+	var payload jiraWebhookPayload
+	if err := json.Unmarshal(body, &payload); err != nil {
+		http.Error(w, "invalid payload", http.StatusBadRequest)
+		return
+	}
+	if payload.Issue.Key == "" {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	dedupKey := jiraWebhookDedupKey(payload)
+	if dedupKey != "" && s.isDuplicateWebhook(dedupKey) {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	go s.processJiraEvent(workspaceName, payload)
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *Server) validateJiraWebhookSecret(workspaceName string, r *http.Request) bool {
+	secrets := workspaceIssueTrackerWebhookSecrets(workspaceName, "jira")
+	if len(secrets) == 0 {
+		return true
+	}
+	got := r.Header.Get("X-ElasticClaw-Webhook-Secret")
+	if got == "" {
+		got = r.URL.Query().Get("secret")
+	}
+	for _, secret := range secrets {
+		if got != "" && got == secret {
+			return true
+		}
+	}
+	return false
+}
+
+func jiraWebhookDedupKey(payload jiraWebhookPayload) string {
+	key := strings.TrimSpace(payload.Issue.Key)
+	if key == "" {
+		return ""
+	}
+	if payload.Changelog != nil && payload.Changelog.ID != "" {
+		return "jira:" + key + ":" + payload.Changelog.ID
+	}
+	if payload.Timestamp > 0 {
+		return fmt.Sprintf("jira:%s:%d", key, payload.Timestamp)
+	}
+	return ""
+}
+
+func (s *Server) processJiraEvent(workspaceName string, payload jiraWebhookPayload) {
+	workspaces, err := loadExternalWorkflowsByIntegration("jira")
+	if err != nil {
+		log.Printf("[jira-webhook] failed to load workflows: %v", err)
+		return
+	}
+	workspaces = filterWorkflowWorkspacesByName(workspaces, workspaceName)
+	_ = s.processJiraWorkflowEvent(workspaces, payload, "jira webhook")
+
+	factories := s.resolveFactories()
+	if len(factories) == 0 {
+		return
+	}
+
+	currentStatus, previousStatus := jiraWebhookStatuses(payload)
+	labels := jiraIssueLabels(payload.Issue)
+	assignee := jiraIssueAssignee(payload.Issue)
+	for _, factory := range factories {
+		if factory.Integration != "jira" {
+			continue
+		}
+		if factory.Enabled != nil && !*factory.Enabled {
+			continue
+		}
+		if !jiraProjectMatches(payload.Issue.Fields.Project.Key, factory.Projects) {
+			continue
+		}
+		if factory.TriggerStatus == "" || !strings.EqualFold(currentStatus, factory.TriggerStatus) || strings.EqualFold(previousStatus, factory.TriggerStatus) {
+			continue
+		}
+		if !s.labelsMatch(labels, factory.Labels) || !s.assigneeMatches(assignee, factory.AssignedTo) {
+			continue
+		}
+		if err := s.createClawForJiraIssue(factory, payload, "jira webhook"); err != nil {
+			if isFactoryTriggerAlreadyClaimed(err) {
+				continue
+			}
+			log.Printf("[factory:%s] failed to create claw for Jira issue %s: %v", factory.Name, payload.Issue.Key, err)
+			s.trackFactoryCreationFailure(factory.Name, payload.Issue.Key, err.Error())
+		}
+	}
+	for _, factory := range factories {
+		if factory.Integration != "jira" || !factory.TerminateOnLeave {
+			continue
+		}
+		if factory.Enabled != nil && !*factory.Enabled {
+			continue
+		}
+		if !jiraProjectMatches(payload.Issue.Fields.Project.Key, factory.Projects) {
+			continue
+		}
+		if factory.TriggerStatus == "" || strings.EqualFold(currentStatus, factory.TriggerStatus) {
+			continue
+		}
+		var activeClaw string
+		_ = s.db.QueryRow(`SELECT id FROM claws WHERE jira_issue_id = ? AND status NOT IN ('error','deleted') LIMIT 1`, payload.Issue.Key).Scan(&activeClaw)
+		if activeClaw != "" {
+			s.terminateClawForIssue(payload.Issue.Key)
+		}
+	}
+}
+
+func (s *Server) processJiraWorkflowEvent(workspaces []*types.WorkspaceConfig, payload jiraWebhookPayload, reason string) bool {
+	currentStatus, previousStatus := jiraWebhookStatuses(payload)
+	labels := jiraIssueLabels(payload.Issue)
+	assignee := jiraIssueAssignee(payload.Issue)
+	matched := false
+	for _, workspace := range workspaces {
+		for _, workflow := range workspace.Workflows {
+			if workflow == nil || workflow.Integration != "jira" {
+				continue
+			}
+			if workflow.Enabled != nil && !*workflow.Enabled {
+				continue
+			}
+			if !jiraWorkflowMatchesProject(workflow, payload.Issue.Fields.Project.Key) {
+				continue
+			}
+			if workflow.TriggerStatus == "" || !strings.EqualFold(currentStatus, workflow.TriggerStatus) || strings.EqualFold(previousStatus, workflow.TriggerStatus) {
+				continue
+			}
+			if workflow.AssignedTo != "" && !assignedToMatches(workflow.AssignedTo, assignee) {
+				continue
+			}
+			if !jiraLabelsMapMatches(labels, workflow.Labels) {
+				continue
+			}
+			matched = true
+			if err := s.createClawForJiraWorkflow(workspace, workflow, payload, reason); err != nil {
+				log.Printf("[workflow:%s/%s] failed to create claw for Jira issue %s: %v", workspace.Name, workflow.Name, payload.Issue.Key, err)
+			}
+		}
+		for _, workflow := range workspace.Workflows {
+			if workflow == nil || workflow.Integration != "jira" || !workflow.TerminateOnLeave {
+				continue
+			}
+			if workflow.Enabled != nil && !*workflow.Enabled {
+				continue
+			}
+			if !jiraWorkflowMatchesProject(workflow, payload.Issue.Fields.Project.Key) {
+				continue
+			}
+			if workflow.TriggerStatus == "" || strings.EqualFold(currentStatus, workflow.TriggerStatus) {
+				continue
+			}
+			var activeClaw string
+			_ = s.db.QueryRow(`SELECT id FROM claws WHERE jira_issue_id = ? AND status NOT IN ('error','deleted') LIMIT 1`, payload.Issue.Key).Scan(&activeClaw)
+			if activeClaw != "" {
+				matched = true
+				s.terminateClawForIssue(payload.Issue.Key)
+			}
+		}
+	}
+	return matched
+}
+
+func jiraWebhookStatuses(payload jiraWebhookPayload) (string, string) {
+	current := payload.Issue.Fields.Status.Name
+	previous := ""
+	if payload.Changelog != nil {
+		for _, item := range payload.Changelog.Items {
+			if strings.EqualFold(item.Field, "status") {
+				if item.ToString != "" {
+					current = item.ToString
+				}
+				previous = item.FromString
+				break
+			}
+		}
+	}
+	return current, previous
+}
+
+func jiraIssueLabels(issue jiraIssue) []string {
+	return append([]string(nil), issue.Fields.Labels...)
+}
+
+func jiraIssueAssignee(issue jiraIssue) string {
+	if issue.Fields.Assignee == nil {
+		return ""
+	}
+	for _, value := range []string{issue.Fields.Assignee.Name, issue.Fields.Assignee.DisplayName, issue.Fields.Assignee.EmailAddress, issue.Fields.Assignee.AccountID} {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func jiraLabelsMapMatches(labels, required []string) bool {
+	if len(required) == 0 {
+		return true
+	}
+	set := map[string]bool{}
+	for _, label := range labels {
+		set[strings.ToLower(strings.TrimSpace(label))] = true
+	}
+	for _, label := range required {
+		if !set[strings.ToLower(strings.TrimSpace(label))] {
+			return false
+		}
+	}
+	return true
+}
+
+func jiraProjectMatches(project string, projects []string) bool {
+	if len(projects) == 0 {
+		return true
+	}
+	for _, candidate := range projects {
+		if strings.EqualFold(strings.TrimSpace(candidate), project) {
+			return true
+		}
+	}
+	return false
+}
+
+func jiraWorkflowMatchesProject(workflow *types.WorkflowConfig, project string) bool {
+	if workflow == nil {
+		return false
+	}
+	projects := workflow.TriggerRepos
+	if workflow.Trigger != nil && workflow.Trigger.Jira != nil && len(workflow.Trigger.Jira.Projects) > 0 {
+		projects = workflow.Trigger.Jira.Projects
+	}
+	return jiraProjectMatches(project, projects)
+}
+
+func (s *Server) createClawForJiraWorkflow(workspace *types.WorkspaceConfig, workflow *types.WorkflowConfig, payload jiraWebhookPayload, reason string) error {
+	issueID := payload.Issue.Key
+	var existing string
+	_ = s.db.QueryRow(`SELECT id FROM claws WHERE jira_issue_id=? AND status NOT IN ('error','deleted') LIMIT 1`, issueID).Scan(&existing)
+	if existing != "" {
+		return nil
+	}
+
+	triggerKey := factoryTriggerKey("jira", issueID)
+	triggerOwner := fmt.Sprintf("workflow:%s/%s", workspace.Name, workflow.Name)
+	claimed, err := s.claimFactoryTrigger(triggerOwner, "jira", triggerKey, reason, map[string]string{
+		"issue_id":  issueID,
+		"source":    reason,
+		"workspace": workspace.Name,
+		"workflow":  workflow.Name,
+	})
+	if err != nil {
+		return fmt.Errorf("claim workflow trigger: %w", err)
+	}
+	if !claimed {
+		return errFactoryTriggerAlreadyClaimed
+	}
+	claimOpen := true
+	defer func() {
+		if claimOpen {
+			s.failFactoryTrigger(triggerOwner, "jira", triggerKey)
+		}
+	}()
+
+	templateFiles := cloneStringMap(workspace.Files)
+	templateFiles["CONTEXT.md"] = s.buildJiraContext(payload)
+	clawName := issueID
+	if workflow.NamePattern != "" {
+		clawName = strings.ReplaceAll(workflow.NamePattern, "{issue_id}", issueID)
+		clawName = strings.ReplaceAll(clawName, "{project}", payload.Issue.Fields.Project.Key)
+	}
+	clawID, isPending, err := s.createClawFromWorkflowWithOptions(workspace, workflow, workflowCreateOptions{
+		workspaceFiles: templateFiles,
+		clawName:       clawName,
+		jiraIssueID:    issueID,
+		reason:         reason,
+		triggerActor: &triggerActor{
+			ID:    firstNonEmpty(payload.User.AccountID, payload.User.Name, payload.User.Key),
+			Type:  "User",
+			Name:  payload.User.DisplayName,
+			Email: payload.User.EmailAddress,
+		},
+	})
+	if err != nil {
+		return err
+	}
+	if err := s.completeFactoryTrigger(triggerOwner, "jira", triggerKey, clawID); err != nil {
+		_, _ = s.db.Exec(`UPDATE claws SET status='deleted' WHERE id=?`, clawID)
+		return fmt.Errorf("complete workflow trigger: %w", err)
+	}
+	claimOpen = false
+	if !isPending && workflow.WorkingStatus != "" {
+		if tracker, ok := s.resolveJiraTrackerForWorkflow(workspace.Name, workflow); ok {
+			if err := s.moveJiraIssue(tracker, issueID, workflow.WorkingStatus); err != nil {
+				log.Printf("[workflow:%s/%s] failed to move Jira issue %s to %q: %v", workspace.Name, workflow.Name, issueID, workflow.WorkingStatus, err)
+			}
+		}
+	}
+	return nil
+}
+
+func (s *Server) createClawForJiraIssue(factory *types.FactoryConfig, payload jiraWebhookPayload, reason string) error {
+	issueID := payload.Issue.Key
+	triggerKey := factoryTriggerKey("jira", issueID)
+	claimed, err := s.claimFactoryTrigger(factory.Name, "jira", triggerKey, reason, map[string]string{
+		"issue_id": issueID,
+		"source":   reason,
+	})
+	if err != nil {
+		return fmt.Errorf("claim factory trigger: %w", err)
+	}
+	if !claimed {
+		return errFactoryTriggerAlreadyClaimed
+	}
+	claimOpen := true
+	defer func() {
+		if claimOpen {
+			s.failFactoryTrigger(factory.Name, "jira", triggerKey)
+		}
+	}()
+	if tracker, ok := s.resolveJiraTrackerForFactory(factory); ok {
+		if _, err := s.fetchJiraIssue(tracker, issueID); err != nil {
+			return fmt.Errorf("cannot read Jira issue %s: %w", issueID, err)
+		}
+	}
+	templateFiles, err := s.resolveTemplateFiles(factory.Template)
+	if err != nil {
+		return err
+	}
+	templateFiles["CONTEXT.md"] = s.buildJiraContext(payload)
+	clawID, isPending, err := s.createClawFromFactory(factory, issueID, nil, templateFiles, reason)
+	if err != nil {
+		return err
+	}
+	if err := s.completeFactoryTrigger(factory.Name, "jira", triggerKey, clawID); err != nil {
+		_, _ = s.db.Exec(`UPDATE claws SET status='deleted' WHERE id=?`, clawID)
+		return fmt.Errorf("complete factory trigger: %w", err)
+	}
+	claimOpen = false
+	if !isPending && factory.WorkingStatus != "" {
+		if tracker, ok := s.resolveJiraTrackerForFactory(factory); ok {
+			if err := s.moveJiraIssue(tracker, issueID, factory.WorkingStatus); err != nil {
+				log.Printf("[factory:%s] failed to move Jira issue %s to %q: %v", factory.Name, issueID, factory.WorkingStatus, err)
+			}
+		}
+	}
+	return nil
+}
+
+func (s *Server) buildJiraContext(payload jiraWebhookPayload) string {
+	issue := payload.Issue
+	url := s.jiraBrowseURL(issue)
+	var b strings.Builder
+	b.WriteString("# Jira Issue Context\n\n")
+	fmt.Fprintf(&b, "Issue: %s\n", issue.Key)
+	if url != "" {
+		fmt.Fprintf(&b, "URL: %s\n", url)
+	}
+	fmt.Fprintf(&b, "Project: %s\n", issue.Fields.Project.Key)
+	fmt.Fprintf(&b, "Status: %s\n", issue.Fields.Status.Name)
+	if len(issue.Fields.Labels) > 0 {
+		fmt.Fprintf(&b, "Labels: %s\n", strings.Join(issue.Fields.Labels, ", "))
+	}
+	if assignee := jiraIssueAssignee(issue); assignee != "" {
+		fmt.Fprintf(&b, "Assignee: %s\n", assignee)
+	}
+	fmt.Fprintf(&b, "Title: %s\n\n", issue.Fields.Summary)
+	if text := jiraDescriptionText(issue.Fields.Description); text != "" {
+		b.WriteString(text)
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+func (s *Server) jiraBrowseURL(issue jiraIssue) string {
+	if issue.Key == "" {
+		return ""
+	}
+	base := ""
+	if tracker, ok := s.resolveJiraTrackerByIssue(issue); ok {
+		base = tracker.BaseURL
+	}
+	if base == "" {
+		base = s.jiraBaseURL
+	}
+	if base == "" && issue.Self != "" {
+		if u, err := url.Parse(issue.Self); err == nil {
+			base = u.Scheme + "://" + u.Host
+		}
+	}
+	if base == "" {
+		return ""
+	}
+	return strings.TrimRight(base, "/") + "/browse/" + url.PathEscape(issue.Key)
+}
+
+func jiraDescriptionText(v any) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	case nil:
+		return ""
+	default:
+		b, _ := json.MarshalIndent(t, "", "  ")
+		return string(b)
+	}
+}
+
+func (s *Server) resolveJiraTrackerForWorkflow(workspaceName string, workflow *types.WorkflowConfig) (workspaceIssueTracker, bool) {
+	if workflow == nil {
+		return workspaceIssueTracker{}, false
+	}
+	return findWorkspaceIssueTracker(workspaceName, "jira", workflow.Workspace)
+}
+
+func (s *Server) resolveJiraTrackerForFactory(factory *types.FactoryConfig) (workspaceIssueTracker, bool) {
+	if factory == nil {
+		return workspaceIssueTracker{}, false
+	}
+	if s.hubCfg.Integrations != nil {
+		for _, ji := range s.hubCfg.Integrations.Jira {
+			if factory.Workspace == "" || strings.EqualFold(ji.Workspace, factory.Workspace) {
+				return workspaceIssueTracker{BaseURL: ji.BaseURL, Username: ji.Username, Token: ji.Token, WebhookSecret: ji.WebhookSecret}, true
+			}
+		}
+	}
+	return workspaceIssueTracker{}, false
+}
+
+func (s *Server) resolveJiraTrackerByIssue(issue jiraIssue) (workspaceIssueTracker, bool) {
+	if s.hubCfg.Integrations != nil {
+		for _, ji := range s.hubCfg.Integrations.Jira {
+			if ji.BaseURL != "" {
+				return workspaceIssueTracker{BaseURL: ji.BaseURL, Username: ji.Username, Token: ji.Token, WebhookSecret: ji.WebhookSecret}, true
+			}
+		}
+	}
+	return workspaceIssueTracker{}, false
+}
+
+func (s *Server) jiraBaseForTracker(tracker workspaceIssueTracker) string {
+	if tracker.BaseURL != "" {
+		return strings.TrimRight(tracker.BaseURL, "/")
+	}
+	if s.jiraBaseURL != "" {
+		return strings.TrimRight(s.jiraBaseURL, "/")
+	}
+	return ""
+}
+
+func (s *Server) fetchJiraIssue(tracker workspaceIssueTracker, key string) (jiraIssue, error) {
+	var issue jiraIssue
+	base := s.jiraBaseForTracker(tracker)
+	if base == "" {
+		return issue, fmt.Errorf("missing Jira base URL")
+	}
+	req, err := http.NewRequest(http.MethodGet, base+"/rest/api/2/issue/"+url.PathEscape(key)+"?fields=summary,description,status,labels,assignee,project,updated", nil)
+	if err != nil {
+		return issue, err
+	}
+	applyJiraAuth(req, tracker)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return issue, err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return issue, fmt.Errorf("jira API error %d: %s", resp.StatusCode, string(body))
+	}
+	if err := json.Unmarshal(body, &issue); err != nil {
+		return issue, err
+	}
+	return issue, nil
+}
+
+func (s *Server) queryJiraIssues(tracker workspaceIssueTracker, since time.Time, projects []string) ([]jiraPollIssue, error) {
+	base := s.jiraBaseForTracker(tracker)
+	if base == "" {
+		return nil, fmt.Errorf("missing Jira base URL")
+	}
+	jql := fmt.Sprintf("updated >= %q", since.Format("2006-01-02 15:04"))
+	if len(projects) > 0 {
+		quoted := make([]string, 0, len(projects))
+		for _, project := range projects {
+			project = strings.TrimSpace(project)
+			if project != "" {
+				quoted = append(quoted, fmt.Sprintf("%q", project))
+			}
+		}
+		if len(quoted) > 0 {
+			jql = "project in (" + strings.Join(quoted, ",") + ") AND " + jql
+		}
+	}
+	body, _ := json.Marshal(map[string]any{
+		"jql":        jql,
+		"maxResults": 100,
+		"fields":     []string{"summary", "description", "status", "labels", "assignee", "project", "updated"},
+	})
+	req, err := http.NewRequest(http.MethodPost, base+"/rest/api/2/search", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	applyJiraAuth(req, tracker)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("jira API error %d: %s", resp.StatusCode, string(respBody))
+	}
+	var result struct {
+		Issues []jiraPollIssue `json:"issues"`
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, err
+	}
+	return result.Issues, nil
+}
+
+func (s *Server) moveJiraIssue(tracker workspaceIssueTracker, key, targetStatus string) error {
+	base := s.jiraBaseForTracker(tracker)
+	if base == "" {
+		return fmt.Errorf("missing Jira base URL")
+	}
+	req, err := http.NewRequest(http.MethodGet, base+"/rest/api/2/issue/"+url.PathEscape(key)+"/transitions", nil)
+	if err != nil {
+		return err
+	}
+	applyJiraAuth(req, tracker)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("jira transitions API error %d: %s", resp.StatusCode, string(body))
+	}
+	var result struct {
+		Transitions []struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+			To   struct {
+				Name string `json:"name"`
+			} `json:"to"`
+		} `json:"transitions"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return err
+	}
+	transitionID := ""
+	for _, transition := range result.Transitions {
+		if strings.EqualFold(transition.Name, targetStatus) || strings.EqualFold(transition.To.Name, targetStatus) {
+			transitionID = transition.ID
+			break
+		}
+	}
+	if transitionID == "" {
+		return fmt.Errorf("no Jira transition to status %q", targetStatus)
+	}
+	payload, _ := json.Marshal(map[string]any{"transition": map[string]string{"id": transitionID}})
+	req, err = http.NewRequest(http.MethodPost, base+"/rest/api/2/issue/"+url.PathEscape(key)+"/transitions", bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	applyJiraAuth(req, tracker)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	body, _ = io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("jira transition API error %d: %s", resp.StatusCode, string(body))
+	}
+	return nil
+}
+
+func (s *Server) commentJiraIssue(tracker workspaceIssueTracker, key, text string) error {
+	base := s.jiraBaseForTracker(tracker)
+	if base == "" {
+		return fmt.Errorf("missing Jira base URL")
+	}
+	payload, _ := json.Marshal(map[string]string{"body": text})
+	req, err := http.NewRequest(http.MethodPost, base+"/rest/api/2/issue/"+url.PathEscape(key)+"/comment", bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	applyJiraAuth(req, tracker)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("jira comment API error %d: %s", resp.StatusCode, string(body))
+	}
+	return nil
+}
+
+func applyJiraAuth(req *http.Request, tracker workspaceIssueTracker) {
+	if tracker.Token == "" {
+		return
+	}
+	if tracker.Username != "" {
+		raw := tracker.Username + ":" + tracker.Token
+		req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(raw)))
+		return
+	}
+	req.Header.Set("Authorization", "Bearer "+tracker.Token)
+}

--- a/pkg/hub/jira.go
+++ b/pkg/hub/jira.go
@@ -2,6 +2,7 @@ package hub
 
 import (
 	"bytes"
+	"crypto/subtle"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -107,15 +108,19 @@ func (s *Server) validateJiraWebhookSecret(workspaceName string, r *http.Request
 		return true
 	}
 	got := r.Header.Get("X-ElasticClaw-Webhook-Secret")
-	if got == "" {
-		got = r.URL.Query().Get("secret")
-	}
 	for _, secret := range secrets {
-		if got != "" && got == secret {
+		if constantTimeStringEqual(got, secret) {
 			return true
 		}
 	}
 	return false
+}
+
+func constantTimeStringEqual(a, b string) bool {
+	if a == "" || b == "" || len(a) != len(b) {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
 }
 
 func jiraWebhookDedupKey(payload jiraWebhookPayload) string {
@@ -221,6 +226,9 @@ func (s *Server) processJiraWorkflowEvent(workspaces []*types.WorkspaceConfig, p
 			}
 			matched = true
 			if err := s.createClawForJiraWorkflow(workspace, workflow, payload, reason); err != nil {
+				if isFactoryTriggerAlreadyClaimed(err) {
+					continue
+				}
 				log.Printf("[workflow:%s/%s] failed to create claw for Jira issue %s: %v", workspace.Name, workflow.Name, payload.Issue.Key, err)
 			}
 		}
@@ -515,11 +523,25 @@ func (s *Server) resolveJiraTrackerForFactory(factory *types.FactoryConfig) (wor
 }
 
 func (s *Server) resolveJiraTrackerByIssue(issue jiraIssue) (workspaceIssueTracker, bool) {
-	if s.hubCfg.Integrations != nil {
-		for _, ji := range s.hubCfg.Integrations.Jira {
-			if ji.BaseURL != "" {
-				return workspaceIssueTracker{BaseURL: ji.BaseURL, Username: ji.Username, Token: ji.Token, WebhookSecret: ji.WebhookSecret}, true
+	if s.hubCfg.Integrations == nil {
+		return workspaceIssueTracker{}, false
+	}
+	if issue.Self != "" {
+		if u, err := url.Parse(issue.Self); err == nil {
+			issueHost := strings.ToLower(u.Host)
+			for _, ji := range s.hubCfg.Integrations.Jira {
+				if ji.BaseURL == "" {
+					continue
+				}
+				if bu, err := url.Parse(ji.BaseURL); err == nil && strings.ToLower(bu.Host) == issueHost {
+					return workspaceIssueTracker{BaseURL: ji.BaseURL, Username: ji.Username, Token: ji.Token, WebhookSecret: ji.WebhookSecret}, true
+				}
 			}
+		}
+	}
+	for _, ji := range s.hubCfg.Integrations.Jira {
+		if ji.BaseURL != "" {
+			return workspaceIssueTracker{BaseURL: ji.BaseURL, Username: ji.Username, Token: ji.Token, WebhookSecret: ji.WebhookSecret}, true
 		}
 	}
 	return workspaceIssueTracker{}, false

--- a/pkg/hub/jira.go
+++ b/pkg/hub/jira.go
@@ -67,10 +67,6 @@ func (s *Server) handleJiraWebhook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	workspaceName := strings.TrimSpace(r.PathValue("workspace"))
-	if workspaceName == "" {
-		w.WriteHeader(http.StatusOK)
-		return
-	}
 
 	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
 	if err != nil {
@@ -104,6 +100,9 @@ func (s *Server) handleJiraWebhook(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) validateJiraWebhookSecret(workspaceName string, r *http.Request) bool {
 	secrets := workspaceIssueTrackerWebhookSecrets(workspaceName, "jira")
+	if workspaceName == "" {
+		secrets = append(secrets, s.globalJiraWebhookSecrets()...)
+	}
 	if len(secrets) == 0 {
 		return true
 	}
@@ -114,6 +113,52 @@ func (s *Server) validateJiraWebhookSecret(workspaceName string, r *http.Request
 		}
 	}
 	return false
+}
+
+func (s *Server) globalJiraWebhookSecrets() []string {
+	s.mu.RLock()
+	integrations := s.hubCfg.Integrations
+	secretRefs := s.hubCfg.Secrets
+	s.mu.RUnlock()
+
+	var secrets []string
+	if integrations != nil {
+		for _, ji := range integrations.Jira {
+			if ji.WebhookSecret != "" {
+				secrets = append(secrets, ji.WebhookSecret)
+			}
+		}
+	}
+
+	for _, factory := range s.resolveFactories() {
+		if factory.Integration != "jira" {
+			continue
+		}
+		secret := factory.WebhookSecret
+		if secret == "" && factory.WebhookSecretRef != "" && secretRefs != nil {
+			secret = secretRefs[factory.WebhookSecretRef]
+		}
+		if secret != "" {
+			secrets = append(secrets, secret)
+		}
+	}
+
+	workspaces, err := loadExternalWorkflowsByIntegration("jira")
+	if err != nil {
+		return secrets
+	}
+	for _, workspace := range workspaces {
+		secrets = append(secrets, workspaceIssueTrackerWebhookSecrets(workspace.Name, "jira")...)
+		for _, secretRef := range workspace.WebhookSecrets {
+			if secretRef == "" || secretRefs == nil {
+				continue
+			}
+			if secret := secretRefs[secretRef]; secret != "" {
+				secrets = append(secrets, secret)
+			}
+		}
+	}
+	return secrets
 }
 
 func constantTimeStringEqual(a, b string) bool {

--- a/pkg/hub/jira.go
+++ b/pkg/hub/jira.go
@@ -107,6 +107,9 @@ func (s *Server) validateJiraWebhookSecret(workspaceName string, r *http.Request
 		return true
 	}
 	got := r.Header.Get("X-ElasticClaw-Webhook-Secret")
+	if got == "" {
+		got = r.URL.Query().Get("secret")
+	}
 	for _, secret := range secrets {
 		if constantTimeStringEqual(got, secret) {
 			return true

--- a/pkg/hub/jira_workflow_test.go
+++ b/pkg/hub/jira_workflow_test.go
@@ -43,6 +43,36 @@ func TestJiraWorkflowWebhookCreatesClaw(t *testing.T) {
 	waitForJiraClawCount(t, db, "EC-123", 1)
 }
 
+func TestJiraGlobalWebhookCreatesClaw(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
+	cfg := jiraWorkflowTestConfig()
+	s, db := hub.NewTestServerWithConfig(t, cfg, "", "", "")
+	saveJiraWorkflowFixture(t, "workspace-a")
+	hub.SaveWorkspaceIssueTrackerWithBaseForTest(t, "workspace-a", "jira", "default", "https://jira.example.test", "", "jira-token", "jira-secret")
+
+	httpSrv := httptest.NewServer(s.Handler())
+	t.Cleanup(httpSrv.Close)
+
+	payload := jiraWebhookPayload(t, "EC-123", "EC", "Backlog", "Ready for Agent", []string{"agent"})
+	req, err := http.NewRequest(http.MethodPost, httpSrv.URL+"/api/integrations/jira/webhook", strings.NewReader(string(payload)))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-ElasticClaw-Webhook-Secret", "jira-secret")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	waitForJiraClawCount(t, db, "EC-123", 1)
+}
+
 func TestJiraWorkflowPollCreatesOnceForMissedWebhook(t *testing.T) {
 	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
 	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")

--- a/pkg/hub/jira_workflow_test.go
+++ b/pkg/hub/jira_workflow_test.go
@@ -75,6 +75,35 @@ func TestJiraGlobalWebhookCreatesClaw(t *testing.T) {
 	waitForJiraClawCount(t, db, "EC-123", 1)
 }
 
+func TestJiraGlobalWebhookAcceptsSecretQueryParam(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
+	cfg := jiraWorkflowTestConfig()
+	s, db := hub.NewTestServerWithConfig(t, cfg, "", "", "")
+	saveJiraWorkflowFixture(t, "workspace-a")
+	hub.SaveWorkspaceIssueTrackerWithBaseForTest(t, "workspace-a", "jira", "default", "https://jira.example.test", "", "jira-token", "jira-secret")
+
+	httpSrv := httptest.NewServer(s.Handler())
+	t.Cleanup(httpSrv.Close)
+
+	payload := jiraWebhookPayload(t, "EC-123", "EC", "Backlog", "Ready for Agent", []string{"agent"})
+	req, err := http.NewRequest(http.MethodPost, httpSrv.URL+"/api/integrations/jira/webhook?secret=jira-secret", strings.NewReader(string(payload)))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	waitForJiraClawCount(t, db, "EC-123", 1)
+}
+
 func TestJiraWorkflowPollCreatesOnceForMissedWebhook(t *testing.T) {
 	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
 	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")

--- a/pkg/hub/jira_workflow_test.go
+++ b/pkg/hub/jira_workflow_test.go
@@ -97,6 +97,66 @@ func TestJiraWorkflowPollCreatesOnceForMissedWebhook(t *testing.T) {
 	}
 }
 
+func TestJiraWorkflowExcludeLabelsBlockWebhook(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
+	cfg := jiraWorkflowTestConfig()
+	s, db := hub.NewTestServerWithConfig(t, cfg, "", "", "")
+	saveJiraWorkflowFixtureWithExclude(t, "workspace-a", []string{"blocked"})
+	hub.SaveWorkspaceIssueTrackerWithBaseForTest(t, "workspace-a", "jira", "default", "https://jira.example.test", "", "jira-token", "jira-secret")
+
+	httpSrv := httptest.NewServer(s.Handler())
+	t.Cleanup(httpSrv.Close)
+
+	payload := jiraWebhookPayload(t, "EC-123", "EC", "Backlog", "Ready for Agent", []string{"agent", "blocked"})
+	req, err := http.NewRequest(http.MethodPost, httpSrv.URL+"/api/workspaces/workspace-a/webhooks/jira", strings.NewReader(string(payload)))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-ElasticClaw-Webhook-Secret", "jira-secret")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	assertJiraClawCountStable(t, db, "EC-123", 0)
+}
+
+func TestJiraFactoryExcludeLabelsBlockWebhook(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
+	jira := newMockJira(t)
+	cfg := jiraFactoryTestConfig(jira.URL)
+	cfg.Factories[0].ExcludeLabels = []string{"blocked"}
+	s, db := hub.NewTestServerWithConfig(t, cfg, "", "", "")
+	jira.setIssue("EC-123", "EC", "Ready for Agent", []string{"agent", "blocked"})
+
+	httpSrv := httptest.NewServer(s.Handler())
+	t.Cleanup(httpSrv.Close)
+
+	payload := jiraWebhookPayload(t, "EC-123", "EC", "Backlog", "Ready for Agent", []string{"agent", "blocked"})
+	req, err := http.NewRequest(http.MethodPost, httpSrv.URL+"/api/integrations/jira/webhook", strings.NewReader(string(payload)))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	assertJiraClawCountStable(t, db, "EC-123", 0)
+}
+
 func TestJiraTerminateSignalCommentsIssue(t *testing.T) {
 	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
 	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
@@ -153,6 +213,21 @@ func waitForJiraClawCount(t *testing.T, db *sql.DB, issueID string, want int) {
 	t.Fatalf("created %d Jira claws, want %d", last, want)
 }
 
+func assertJiraClawCountStable(t *testing.T, db *sql.DB, issueID string, want int) {
+	t.Helper()
+	deadline := time.Now().Add(300 * time.Millisecond)
+	var last int
+	for time.Now().Before(deadline) {
+		if err := db.QueryRow(`SELECT COUNT(*) FROM claws WHERE jira_issue_id=?`, issueID).Scan(&last); err != nil {
+			t.Fatalf("count claws: %v", err)
+		}
+		if last != want {
+			t.Fatalf("created %d Jira claws, want %d", last, want)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
 func jiraWorkflowTestConfig() *types.HubConfig {
 	return &types.HubConfig{
 		ClawToken: "test-claw-token",
@@ -189,6 +264,10 @@ func jiraFactoryTestConfig(jiraURL string) *types.HubConfig {
 }
 
 func saveJiraWorkflowFixture(t *testing.T, workspace string) {
+	saveJiraWorkflowFixtureWithExclude(t, workspace, nil)
+}
+
+func saveJiraWorkflowFixtureWithExclude(t *testing.T, workspace string, excludeLabels []string) {
 	t.Helper()
 	hub.SaveWorkspaceForTest(t,
 		&types.WorkspaceConfig{
@@ -204,10 +283,11 @@ func saveJiraWorkflowFixture(t *testing.T, workspace string) {
 			Name:          "jira-workflow",
 			Trigger: &types.WorkflowTrigger{
 				Jira: &types.JiraWorkflowTrigger{
-					Event:    "status_changed",
-					Projects: []string{"EC"},
-					States:   []string{"Ready for Agent"},
-					Labels:   []string{"agent"},
+					Event:         "status_changed",
+					Projects:      []string{"EC"},
+					States:        []string{"Ready for Agent"},
+					Labels:        []string{"agent"},
+					ExcludeLabels: append([]string(nil), excludeLabels...),
 				},
 			},
 			Stages: []types.WorkflowStage{{

--- a/pkg/hub/jira_workflow_test.go
+++ b/pkg/hub/jira_workflow_test.go
@@ -25,11 +25,12 @@ func TestJiraWorkflowWebhookCreatesClaw(t *testing.T) {
 	t.Cleanup(httpSrv.Close)
 
 	payload := jiraWebhookPayload(t, "EC-123", "EC", "Backlog", "Ready for Agent", []string{"agent"})
-	req, err := http.NewRequest(http.MethodPost, httpSrv.URL+"/api/workspaces/workspace-a/webhooks/jira?secret=jira-secret", strings.NewReader(string(payload)))
+	req, err := http.NewRequest(http.MethodPost, httpSrv.URL+"/api/workspaces/workspace-a/webhooks/jira", strings.NewReader(string(payload)))
 	if err != nil {
 		t.Fatalf("request: %v", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-ElasticClaw-Webhook-Secret", "jira-secret")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("post: %v", err)

--- a/pkg/hub/jira_workflow_test.go
+++ b/pkg/hub/jira_workflow_test.go
@@ -1,0 +1,205 @@
+package hub_test
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/hub"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func TestJiraWorkflowWebhookCreatesClaw(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
+	cfg := jiraWorkflowTestConfig()
+	s, db := hub.NewTestServerWithConfig(t, cfg, "", "", "")
+	saveJiraWorkflowFixture(t, "workspace-a")
+	hub.SaveWorkspaceIssueTrackerWithBaseForTest(t, "workspace-a", "jira", "default", "https://jira.example.test", "", "jira-token", "jira-secret")
+
+	httpSrv := httptest.NewServer(s.Handler())
+	t.Cleanup(httpSrv.Close)
+
+	payload := jiraWebhookPayload(t, "EC-123", "EC", "Backlog", "Ready for Agent", []string{"agent"})
+	req, err := http.NewRequest(http.MethodPost, httpSrv.URL+"/api/workspaces/workspace-a/webhooks/jira?secret=jira-secret", strings.NewReader(string(payload)))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	waitForJiraClawCount(t, db, "EC-123", 1)
+}
+
+func TestJiraWorkflowPollCreatesOnceForMissedWebhook(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
+	jira := newMockJira(t)
+	cfg := jiraWorkflowTestConfig()
+	s, db := hub.NewTestServerWithConfig(t, cfg, "", "", "")
+	saveJiraWorkflowFixture(t, "workspace-a")
+	hub.SaveWorkspaceIssueTrackerWithBaseForTest(t, "workspace-a", "jira", "default", jira.URL, "", "jira-token", "")
+	jira.setIssue("EC-123", "EC", "Ready for Agent", []string{"agent"})
+
+	s.PollIntegrationsForTest()
+	s.PollIntegrationsForTest()
+
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM claws WHERE jira_issue_id='EC-123'`).Scan(&count); err != nil {
+		t.Fatalf("count claws: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("poll created %d claws for the same Jira issue, want 1", count)
+	}
+}
+
+func waitForJiraClawCount(t *testing.T, db *sql.DB, issueID string, want int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	var last int
+	for time.Now().Before(deadline) {
+		if err := db.QueryRow(`SELECT COUNT(*) FROM claws WHERE jira_issue_id=?`, issueID).Scan(&last); err != nil {
+			t.Fatalf("count claws: %v", err)
+		}
+		if last == want {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("created %d Jira claws, want %d", last, want)
+}
+
+func jiraWorkflowTestConfig() *types.HubConfig {
+	return &types.HubConfig{
+		ClawToken: "test-claw-token",
+		Providers: map[string]types.ProviderConfig{
+			"noop": {Type: "noop"},
+		},
+	}
+}
+
+func saveJiraWorkflowFixture(t *testing.T, workspace string) {
+	t.Helper()
+	hub.SaveWorkspaceForTest(t,
+		&types.WorkspaceConfig{
+			SchemaVersion: "v1",
+			Name:          workspace,
+			Files: map[string]string{
+				"elasticclaw-config.yaml": "schema_version: v1\nname: " + workspace + "\nprovider: noop\n",
+				"CONTEXT.md":              "Test context\n",
+			},
+		},
+		[]*types.WorkflowConfig{{
+			SchemaVersion: "v1",
+			Name:          "jira-workflow",
+			Trigger: &types.WorkflowTrigger{
+				Jira: &types.JiraWorkflowTrigger{
+					Event:    "status_changed",
+					Projects: []string{"EC"},
+					States:   []string{"Ready for Agent"},
+					Labels:   []string{"agent"},
+				},
+			},
+			Stages: []types.WorkflowStage{{
+				ID:    "working",
+				Label: "Working",
+				Entry: true,
+				OnEnter: map[string]interface{}{
+					"inject": "Read your CONTEXT.md and start working on the Jira issue.\n",
+				},
+			}},
+		}},
+	)
+}
+
+func jiraWebhookPayload(t *testing.T, key, project, previousStatus, status string, labels []string) []byte {
+	t.Helper()
+	body := map[string]interface{}{
+		"webhookEvent": "jira:issue_updated",
+		"timestamp":    int64(1710000000000),
+		"user": map[string]interface{}{
+			"accountId":   "user-123",
+			"displayName": "Jira User",
+		},
+		"issue": map[string]interface{}{
+			"id":  "10001",
+			"key": key,
+			"fields": map[string]interface{}{
+				"summary":     "Test Jira issue",
+				"description": "Do the Jira task",
+				"labels":      labels,
+				"status": map[string]interface{}{
+					"name": status,
+				},
+				"project": map[string]interface{}{
+					"key": project,
+				},
+			},
+		},
+		"changelog": map[string]interface{}{
+			"id": "20001",
+			"items": []map[string]interface{}{{
+				"field":      "status",
+				"fromString": previousStatus,
+				"toString":   status,
+			}},
+		},
+	}
+	data, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal Jira payload: %v", err)
+	}
+	return data
+}
+
+type mockJira struct {
+	*httptest.Server
+	issue map[string]interface{}
+}
+
+func newMockJira(t *testing.T) *mockJira {
+	t.Helper()
+	m := &mockJira{}
+	m.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/rest/api/2/search":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"issues": []interface{}{m.issue}})
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/rest/api/2/issue/"):
+			_ = json.NewEncoder(w).Encode(m.issue)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(m.Close)
+	return m
+}
+
+func (m *mockJira) setIssue(key, project, status string, labels []string) {
+	m.issue = map[string]interface{}{
+		"id":   "10001",
+		"key":  key,
+		"self": m.URL + "/rest/api/2/issue/" + key,
+		"fields": map[string]interface{}{
+			"summary":     "Test Jira issue",
+			"description": "Do the Jira task",
+			"labels":      labels,
+			"status": map[string]interface{}{
+				"name": status,
+			},
+			"project": map[string]interface{}{
+				"key": project,
+			},
+		},
+	}
+}

--- a/pkg/hub/jira_workflow_test.go
+++ b/pkg/hub/jira_workflow_test.go
@@ -6,10 +6,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/elasticclaw/elasticclaw/pkg/hub"
+	"github.com/elasticclaw/elasticclaw/pkg/hub/factorytest"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
 
@@ -95,6 +97,46 @@ func TestJiraWorkflowPollCreatesOnceForMissedWebhook(t *testing.T) {
 	}
 }
 
+func TestJiraTerminateSignalCommentsIssue(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
+	jira := newMockJira(t)
+	cfg := jiraFactoryTestConfig(jira.URL)
+	s, db := hub.NewTestServerWithConfig(t, cfg, "", "", "")
+	jira.setIssue("EC-123", "EC", "Ready for Agent", []string{"agent"})
+
+	httpSrv := httptest.NewServer(s.Handler())
+	t.Cleanup(httpSrv.Close)
+
+	payload := jiraWebhookPayload(t, "EC-123", "EC", "Backlog", "Ready for Agent", []string{"agent"})
+	req, err := http.NewRequest(http.MethodPost, httpSrv.URL+"/api/integrations/jira/webhook", strings.NewReader(string(payload)))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	waitForJiraClawCount(t, db, "EC-123", 1)
+	var clawID string
+	if err := db.QueryRow(`SELECT id FROM claws WHERE jira_issue_id='EC-123'`).Scan(&clawID); err != nil {
+		t.Fatalf("find claw: %v", err)
+	}
+	bridge := factorytest.ConnectFakeBridge(t, httpSrv.URL, clawID, "EC-123", "test-claw-token")
+	bridge.SendMessage("Stopping now. [TERMINATE]")
+
+	comment := jira.waitForComment(t, "EC-123")
+	if !strings.Contains(comment, "Agent stopped: claw requested self-termination") {
+		t.Fatalf("comment = %q, want self-termination message", comment)
+	}
+}
+
 func waitForJiraClawCount(t *testing.T, db *sql.DB, issueID string, want int) {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)
@@ -117,6 +159,32 @@ func jiraWorkflowTestConfig() *types.HubConfig {
 		Providers: map[string]types.ProviderConfig{
 			"noop": {Type: "noop"},
 		},
+	}
+}
+
+func jiraFactoryTestConfig(jiraURL string) *types.HubConfig {
+	return &types.HubConfig{
+		ClawToken: "test-claw-token",
+		Providers: map[string]types.ProviderConfig{
+			"noop": {Type: "noop"},
+		},
+		Integrations: &types.IntegrationsConfig{
+			Jira: []*types.JiraIntegrationConfig{{
+				Workspace: "workspace-a",
+				BaseURL:   jiraURL,
+				Token:     "jira-token",
+			}},
+		},
+		Factories: []*types.FactoryConfig{{
+			Name:          "jira-factory",
+			Integration:   "jira",
+			Workspace:     "workspace-a",
+			Projects:      []string{"EC"},
+			Labels:        []string{"agent"},
+			TriggerStatus: "Ready for Agent",
+			Template:      "jira-template",
+			Provider:      "noop",
+		}},
 	}
 }
 
@@ -196,17 +264,35 @@ func jiraWebhookPayload(t *testing.T, key, project, previousStatus, status strin
 
 type mockJira struct {
 	*httptest.Server
-	issue map[string]interface{}
+	mu       sync.Mutex
+	issue    map[string]interface{}
+	comments map[string][]string
 }
 
 func newMockJira(t *testing.T) *mockJira {
 	t.Helper()
-	m := &mockJira{}
+	m := &mockJira{comments: map[string][]string{}}
 	m.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodPost && r.URL.Path == "/rest/api/2/search":
+			m.mu.Lock()
+			defer m.mu.Unlock()
 			_ = json.NewEncoder(w).Encode(map[string]interface{}{"issues": []interface{}{m.issue}})
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/rest/api/2/issue/") && strings.HasSuffix(r.URL.Path, "/comment"):
+			var payload struct {
+				Body string `json:"body"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&payload)
+			key := strings.TrimPrefix(r.URL.Path, "/rest/api/2/issue/")
+			key = strings.TrimSuffix(key, "/comment")
+			m.mu.Lock()
+			m.comments[key] = append(m.comments[key], payload.Body)
+			m.mu.Unlock()
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"id": "comment-1"})
 		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/rest/api/2/issue/"):
+			m.mu.Lock()
+			defer m.mu.Unlock()
 			_ = json.NewEncoder(w).Encode(m.issue)
 		default:
 			http.NotFound(w, r)
@@ -217,6 +303,8 @@ func newMockJira(t *testing.T) *mockJira {
 }
 
 func (m *mockJira) setIssue(key, project, status string, labels []string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.issue = map[string]interface{}{
 		"id":   "10001",
 		"key":  key,
@@ -233,4 +321,20 @@ func (m *mockJira) setIssue(key, project, status string, labels []string) {
 			},
 		},
 	}
+}
+
+func (m *mockJira) waitForComment(t *testing.T, key string) string {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		m.mu.Lock()
+		comments := append([]string(nil), m.comments[key]...)
+		m.mu.Unlock()
+		if len(comments) > 0 {
+			return comments[len(comments)-1]
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for Jira comment on %s", key)
+	return ""
 }

--- a/pkg/hub/label_match.go
+++ b/pkg/hub/label_match.go
@@ -1,0 +1,54 @@
+package hub
+
+import "strings"
+
+func labelsAllowed(currentLabels []string, requiredLabels []string, excludedLabels []string) bool {
+	return labelSetAllowed(labelSetFromSlice(currentLabels), requiredLabels, excludedLabels)
+}
+
+func labelSetAllowed(current map[string]bool, requiredLabels []string, excludedLabels []string) bool {
+	normalized := make(map[string]bool, len(current))
+	for label, present := range current {
+		if !present {
+			continue
+		}
+		key := normalizeLabel(label)
+		if key != "" {
+			normalized[key] = true
+		}
+	}
+	for _, required := range requiredLabels {
+		key := normalizeLabel(required)
+		if key == "" {
+			continue
+		}
+		if !normalized[key] {
+			return false
+		}
+	}
+	for _, excluded := range excludedLabels {
+		key := normalizeLabel(excluded)
+		if key == "" {
+			continue
+		}
+		if normalized[key] {
+			return false
+		}
+	}
+	return true
+}
+
+func labelSetFromSlice(labels []string) map[string]bool {
+	set := make(map[string]bool, len(labels))
+	for _, label := range labels {
+		key := normalizeLabel(label)
+		if key != "" {
+			set[key] = true
+		}
+	}
+	return set
+}
+
+func normalizeLabel(label string) string {
+	return strings.ToLower(strings.TrimSpace(label))
+}

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -1295,9 +1295,6 @@ func (s *Server) handleClawDoneSignal(clawID, rawMessage string) {
 			if ghToken != "" {
 				// Parse gh-owner/repo/number from issueID
 				rest := strings.TrimPrefix(issueID, "gh-")
-				if rest == issueID {
-					rest = issueID
-				}
 				lastSlash := strings.LastIndex(rest, "/")
 				if lastSlash > 0 {
 					repo := rest[:lastSlash]

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -609,8 +609,8 @@ func (s *Server) createClawForIssue(factory *types.FactoryConfig, payload linear
 func (s *Server) terminateClawForIssue(issueID string) {
 	var clawID, tenantID, factoryName string
 	if err := s.db.QueryRow(
-		`SELECT id, tenant_id, factory_name FROM claws WHERE (linear_issue_id = ? OR shortcut_story_id = ?) AND status NOT IN ('error','deleted') LIMIT 1`,
-		issueID, issueID,
+		`SELECT id, tenant_id, factory_name FROM claws WHERE (linear_issue_id = ? OR shortcut_story_id = ? OR jira_issue_id = ?) AND status NOT IN ('error','deleted') LIMIT 1`,
+		issueID, issueID, issueID,
 	).Scan(&clawID, &tenantID, &factoryName); err != nil {
 		return
 	}
@@ -652,6 +652,14 @@ func (s *Server) terminateClawForIssue(issueID string) {
 							log.Printf("[factory] commented GitHub issue %s", issueID)
 						}
 					}
+				}
+			}
+		case "jira":
+			if tracker, ok := s.resolveJiraTrackerForFactory(factory); ok {
+				if err := s.commentJiraIssue(tracker, issueID, "Agent stopped: issue left trigger status"); err != nil {
+					log.Printf("[factory] failed to comment Jira issue %s: %v", issueID, err)
+				} else {
+					log.Printf("[factory] commented Jira issue %s", issueID)
 				}
 			}
 		}
@@ -766,6 +774,20 @@ func (s *Server) resolveSecretRef(ref types.SecretRef, factory *types.FactoryCon
 		for _, gi := range s.hubCfg.Integrations.GitHubIssues {
 			if ws == "" || strings.EqualFold(gi.Workspace, ws) {
 				return gi.Token, envName, true
+			}
+		}
+		return "", envName, false
+	case "jira":
+		if s.hubCfg.Integrations == nil {
+			return "", envName, false
+		}
+		ws := ref.Workspace
+		if ws == "" && factory != nil {
+			ws = factory.Workspace
+		}
+		for _, ji := range s.hubCfg.Integrations.Jira {
+			if ws == "" || strings.EqualFold(ji.Workspace, ws) {
+				return ji.Token, envName, true
 			}
 		}
 		return "", envName, false
@@ -937,7 +959,7 @@ func (s *Server) provisionPendingClaw(clawID string) {
 		tenantID                                                  string
 	)
 	err := s.db.QueryRow(
-		`SELECT tenant_id, name, template, provider, default_model, template_files, github_repos, linear_workspace, nix, docker, tags, color, llm_key, COALESCE(NULLIF(linear_issue_id,''),NULLIF(github_issue_id,'')) FROM claws WHERE id=?`,
+		`SELECT tenant_id, name, template, provider, default_model, template_files, github_repos, linear_workspace, nix, docker, tags, color, llm_key, COALESCE(NULLIF(linear_issue_id,''),NULLIF(github_issue_id,''),NULLIF(shortcut_story_id,''),NULLIF(jira_issue_id,'')) FROM claws WHERE id=?`,
 		clawID,
 	).Scan(&tenantID, &name, &template, &provider, &defaultModel, &templateFilesJSON, &githubReposJSON, &linearWorkspace, &nixEnabled, &dockerEnabled, &tagsJSON, &color, &llmKey, &issueID)
 	if err != nil {
@@ -964,12 +986,15 @@ func (s *Server) provisionPendingClaw(clawID string) {
 		factory = s.findFactoryForIssue(issueID)
 	}
 
-	// Resolve tokens for env (Linear, GitHub Issues, Shortcut)
+	// Resolve tokens for env (Linear, GitHub Issues, Shortcut, Jira)
 	var linearToken, githubToken, shortcutToken string
+	var jiraTracker workspaceIssueTracker
+	var hasJiraTracker bool
 	if factory != nil {
 		linearToken = s.resolveLinearTokenForFactory(factory)
 		githubToken = s.resolveGitHubIssuesTokenForFactory(factory)
 		shortcutToken = s.resolveShortcutToken(factory.Workspace)
+		jiraTracker, hasJiraTracker = s.resolveJiraTrackerForFactory(factory)
 	}
 
 	s.mu.RLock()
@@ -991,6 +1016,15 @@ func (s *Server) provisionPendingClaw(clawID string) {
 	}
 	if shortcutToken != "" {
 		env["SHORTCUT_API_KEY"] = shortcutToken
+	}
+	if hasJiraTracker && jiraTracker.Token != "" {
+		env["JIRA_API_KEY"] = jiraTracker.Token
+		if jiraTracker.BaseURL != "" {
+			env["JIRA_BASE_URL"] = jiraTracker.BaseURL
+		}
+		if jiraTracker.Username != "" {
+			env["JIRA_USERNAME"] = jiraTracker.Username
+		}
 	}
 
 	// Parse elasticclaw-config.yaml from recovered template files to honour
@@ -1135,9 +1169,9 @@ func buildLinearContext(payload linearWebhookPayload, requiresPR bool) string {
 // If no valid open PRs are found (and a GH App is configured), it injects an
 // error message back so the claw can retry.
 func (s *Server) handleClawDoneSignal(clawID, rawMessage string) {
-	// Get the issue ID and tenant for this claw (linear or github-issues)
+	// Get the issue ID and tenant for this claw.
 	var issueID, tenantID string
-	if err := s.db.QueryRow(`SELECT COALESCE(NULLIF(linear_issue_id,''),NULLIF(github_issue_id,'')), tenant_id FROM claws WHERE id = ?`, clawID).Scan(&issueID, &tenantID); err != nil || issueID == "" {
+	if err := s.db.QueryRow(`SELECT COALESCE(NULLIF(linear_issue_id,''),NULLIF(github_issue_id,''),NULLIF(shortcut_story_id,''),NULLIF(jira_issue_id,'')), tenant_id FROM claws WHERE id = ?`, clawID).Scan(&issueID, &tenantID); err != nil || issueID == "" {
 		return // not a factory claw
 	}
 
@@ -1236,7 +1270,16 @@ func (s *Server) handleClawDoneSignal(clawID, rawMessage string) {
 		targetStatus = factory.DoneStatus
 	}
 	if !pipelineHandledDone && targetStatus != "" {
-		if strings.HasPrefix(issueID, "sc-") {
+		switch factory.Integration {
+		case "jira":
+			if tracker, ok := s.resolveJiraTrackerForFactory(factory); ok {
+				if err := s.moveJiraIssue(tracker, issueID, targetStatus); err != nil {
+					log.Printf("[factory] failed to move Jira issue %s to '%s': %v", issueID, targetStatus, err)
+				} else {
+					log.Printf("[factory] moved Jira issue %s to '%s'", issueID, targetStatus)
+				}
+			}
+		case "shortcut":
 			// Shortcut story
 			scToken := s.resolveShortcutToken(factory.Workspace)
 			if scToken != "" {
@@ -1246,12 +1289,15 @@ func (s *Server) handleClawDoneSignal(clawID, rawMessage string) {
 					log.Printf("[factory] moved story %s to '%s'", issueID, targetStatus)
 				}
 			}
-		} else if strings.HasPrefix(issueID, "gh-") {
+		case "github-issues":
 			// GitHub issue
 			ghToken := s.resolveGitHubIssuesTokenForFactory(factory)
 			if ghToken != "" {
 				// Parse gh-owner/repo/number from issueID
 				rest := strings.TrimPrefix(issueID, "gh-")
+				if rest == issueID {
+					rest = issueID
+				}
 				lastSlash := strings.LastIndex(rest, "/")
 				if lastSlash > 0 {
 					repo := rest[:lastSlash]
@@ -1270,7 +1316,7 @@ func (s *Server) handleClawDoneSignal(clawID, rawMessage string) {
 					}
 				}
 			}
-		} else {
+		default:
 			// Linear issue
 			linearToken := s.resolveLinearTokenForFactory(factory)
 			if linearToken != "" {
@@ -1378,7 +1424,7 @@ func (s *Server) completeNoPRDoneClaw(clawID, tenantID, issueID string) {
 func (s *Server) handleClawTerminateSignal(clawID, rawMessage string) {
 	// Get the tenant ID and issue ID for this claw
 	var issueID, tenantID, factoryName string
-	if err := s.db.QueryRow(`SELECT COALESCE(NULLIF(linear_issue_id,''),NULLIF(github_issue_id,''),NULLIF(shortcut_story_id,'')), tenant_id, factory_name FROM claws WHERE id = ?`, clawID).Scan(&issueID, &tenantID, &factoryName); err != nil {
+	if err := s.db.QueryRow(`SELECT COALESCE(NULLIF(linear_issue_id,''),NULLIF(github_issue_id,''),NULLIF(shortcut_story_id,''),NULLIF(jira_issue_id,'')), tenant_id, factory_name FROM claws WHERE id = ?`, clawID).Scan(&issueID, &tenantID, &factoryName); err != nil {
 		log.Printf("[terminate] claw %s not found in DB: %v", clawID[:8], err)
 		return
 	}
@@ -1540,6 +1586,22 @@ func (s *Server) findFactoryForIssue(issueID string) *types.FactoryConfig {
 	}
 	// Also check github_issue_id column
 	if err := s.db.QueryRow(`SELECT tags FROM claws WHERE github_issue_id = ? AND status NOT IN ('error','deleted') LIMIT 1`, issueID).Scan(&tagsJSON); err == nil {
+		var tags []string
+		if json.Unmarshal([]byte(tagsJSON), &tags) == nil {
+			if factory := s.factoryFromTags(tags, factories); factory != nil {
+				return factory
+			}
+		}
+	}
+	if err := s.db.QueryRow(`SELECT tags FROM claws WHERE shortcut_story_id = ? AND status NOT IN ('error','deleted') LIMIT 1`, issueID).Scan(&tagsJSON); err == nil {
+		var tags []string
+		if json.Unmarshal([]byte(tagsJSON), &tags) == nil {
+			if factory := s.factoryFromTags(tags, factories); factory != nil {
+				return factory
+			}
+		}
+	}
+	if err := s.db.QueryRow(`SELECT tags FROM claws WHERE jira_issue_id = ? AND status NOT IN ('error','deleted') LIMIT 1`, issueID).Scan(&tagsJSON); err == nil {
 		var tags []string
 		if json.Unmarshal([]byte(tagsJSON), &tags) == nil {
 			if factory := s.factoryFromTags(tags, factories); factory != nil {

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -1467,6 +1467,14 @@ func (s *Server) handleClawTerminateSignal(clawID, rawMessage string) {
 					}
 				}
 			}
+		case "jira":
+			if tracker, ok := s.resolveJiraTrackerForFactory(factory); ok {
+				if err := s.commentJiraIssue(tracker, issueID, "Agent stopped: claw requested self-termination"); err != nil {
+					log.Printf("[terminate] failed to comment Jira issue %s: %v", issueID, err)
+				} else {
+					log.Printf("[terminate] commented Jira issue %s", issueID)
+				}
+			}
 		}
 	}
 

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -354,6 +354,16 @@ func (s *Server) resolveGitHubIssuesTokenForPipeline(ctx pipelineContext) string
 	return ""
 }
 
+func (s *Server) resolveJiraTrackerForPipeline(ctx pipelineContext) (workspaceIssueTracker, bool) {
+	if ctx.Workflow != nil && ctx.Workspace != nil {
+		return findWorkspaceIssueTracker(ctx.Workspace.Name, "jira", ctx.Workflow.Workspace)
+	}
+	if ctx.Factory != nil {
+		return s.resolveJiraTrackerForFactory(ctx.Factory)
+	}
+	return workspaceIssueTracker{}, false
+}
+
 const defaultPipelineRunTimeout = 10 * time.Minute
 
 type pipelineRunResult struct {
@@ -1252,18 +1262,31 @@ issueResolved:
 
 	// Determine issue tracker: explicit workflow/factory integration takes precedence,
 	// fall back to ID-format heuristics only when integration is empty.
-	var isShortcut, isGitHub bool
+	var isShortcut, isGitHub, isJira bool
 	switch ctx.Integration() {
 	case "shortcut":
 		isShortcut = true
 	case "github", "github-issues":
 		isGitHub = true
+	case "jira":
+		isJira = true
 	default:
 		isShortcut = strings.HasPrefix(resolvedIssueID, "sc-")
 		isGitHub = strings.Contains(resolvedIssueID, "/")
 	}
 
-	if isShortcut {
+	if isJira {
+		tracker, ok := s.resolveJiraTrackerForPipeline(ctx)
+		if !ok {
+			log.Printf("[pipeline] %s: no Jira tracker for connection %q, skipping move_issue", ctx.Name(), ctx.TrackerName())
+			return true
+		}
+		if err := s.moveJiraIssue(tracker, resolvedIssueID, targetStatus); err != nil {
+			log.Printf("[pipeline] failed to move Jira issue %s to %q: %v", resolvedIssueID, targetStatus, err)
+		} else {
+			log.Printf("[pipeline] moved Jira issue %s to %q", resolvedIssueID, targetStatus)
+		}
+	} else if isShortcut {
 		// Shortcut story — ensure sc- prefix if missing (e.g. template rendered bare number)
 		scID := resolvedIssueID
 		if !strings.HasPrefix(scID, "sc-") {
@@ -1721,7 +1744,7 @@ func (s *Server) stopAgentWithReason(clawID, reason string, skipVMTerminate bool
 }
 
 func isFailureFeedbackWorkflowIntegration(integration string) bool {
-	return integration == "github-issues" || integration == "linear"
+	return integration == "github-issues" || integration == "linear" || integration == "jira"
 }
 
 func (s *Server) commentWorkflowAgentStopToTracker(clawID string, ctx pipelineContext, reason string) {
@@ -1762,6 +1785,20 @@ func (s *Server) commentWorkflowAgentStopToTracker(clawID string, ctx pipelineCo
 			feedback.AgentStatusError = strings.TrimSpace(ctx.Workflow.Trigger.Linear.AgentStatusError)
 		}
 		s.handleAgentFailureFeedback(feedback, token)
+	case "jira":
+		tracker, ok := s.resolveJiraTrackerForWorkflow(ctx.Workspace.Name, ctx.Workflow)
+		if !ok || tracker.Token == "" {
+			return
+		}
+		if ctx.Workflow.Trigger != nil && ctx.Workflow.Trigger.Jira != nil {
+			feedback.AgentStatusError = strings.TrimSpace(ctx.Workflow.Trigger.Jira.AgentStatusError)
+		}
+		if feedback.AgentStatusError != "" {
+			_ = s.moveJiraIssue(tracker, ctx.IssueID, feedback.AgentStatusError)
+		}
+		if err := s.commentJiraIssue(tracker, ctx.IssueID, s.buildAgentStopComment(clawID, reason)); err != nil {
+			log.Printf("[stopAgent] failed to comment Jira issue %s: %v", ctx.IssueID, err)
+		}
 	}
 }
 
@@ -1822,22 +1859,32 @@ func (s *Server) commentAgentStopToTracker(clawID string, factory *types.Factory
 				}
 			}
 		}
+	case "jira":
+		if tracker, ok := s.resolveJiraTrackerForFactory(factory); ok {
+			if err := s.commentJiraIssue(tracker, issueID, getCommentBody()); err != nil {
+				log.Printf("[stopAgent] failed to comment Jira issue %s: %v", issueID, err)
+			} else {
+				log.Printf("[stopAgent] commented Jira issue %s", issueID)
+			}
+		}
 	}
 }
 
 // findFactoryForClaw looks up the factory that created a claw by its claw ID.
 // It uses the factory:<name> tag stored on the claw to identify the factory.
 func (s *Server) findFactoryForClaw(clawID string) (*types.FactoryConfig, string) {
-	var issueID, githubIssueID, shortcutStoryID, tagsJSON string
-	if err := s.db.QueryRow(`SELECT COALESCE(linear_issue_id,''), COALESCE(github_issue_id,''), COALESCE(shortcut_story_id,''), COALESCE(tags,'[]') FROM claws WHERE id=?`, clawID).Scan(&issueID, &githubIssueID, &shortcutStoryID, &tagsJSON); err != nil {
+	var issueID, githubIssueID, shortcutStoryID, jiraIssueID, tagsJSON string
+	if err := s.db.QueryRow(`SELECT COALESCE(linear_issue_id,''), COALESCE(github_issue_id,''), COALESCE(shortcut_story_id,''), COALESCE(jira_issue_id,''), COALESCE(tags,'[]') FROM claws WHERE id=?`, clawID).Scan(&issueID, &githubIssueID, &shortcutStoryID, &jiraIssueID, &tagsJSON); err != nil {
 		return nil, ""
 	}
 
-	// Prefer github_issue_id for GitHub issue-based claws, then shortcut
+	// Prefer provider-specific IDs for non-Linear issue-based claws.
 	if githubIssueID != "" {
 		issueID = githubIssueID
 	} else if shortcutStoryID != "" {
 		issueID = shortcutStoryID
+	} else if jiraIssueID != "" {
+		issueID = jiraIssueID
 	}
 
 	if issueID != "" {
@@ -1892,6 +1939,7 @@ func (s *Server) findPipelineContextForIssue(issueID string) (pipelineContext, b
 		`SELECT id FROM claws WHERE linear_issue_id=? AND status NOT IN ('error','deleted') ORDER BY created_at DESC LIMIT 1`,
 		`SELECT id FROM claws WHERE github_issue_id=? AND status NOT IN ('error','deleted') ORDER BY created_at DESC LIMIT 1`,
 		`SELECT id FROM claws WHERE shortcut_story_id=? AND status NOT IN ('error','deleted') ORDER BY created_at DESC LIMIT 1`,
+		`SELECT id FROM claws WHERE jira_issue_id=? AND status NOT IN ('error','deleted') ORDER BY created_at DESC LIMIT 1`,
 	}
 	for _, query := range queries {
 		if err := s.db.QueryRow(query, issueID).Scan(&clawID); err == nil && clawID != "" {
@@ -1902,14 +1950,16 @@ func (s *Server) findPipelineContextForIssue(issueID string) (pipelineContext, b
 }
 
 func (s *Server) clawIssueAndTags(clawID string) (string, []string) {
-	var issueID, githubIssueID, shortcutStoryID, tagsJSON string
-	if err := s.db.QueryRow(`SELECT COALESCE(linear_issue_id,''), COALESCE(github_issue_id,''), COALESCE(shortcut_story_id,''), COALESCE(tags,'[]') FROM claws WHERE id=?`, clawID).Scan(&issueID, &githubIssueID, &shortcutStoryID, &tagsJSON); err != nil {
+	var issueID, githubIssueID, shortcutStoryID, jiraIssueID, tagsJSON string
+	if err := s.db.QueryRow(`SELECT COALESCE(linear_issue_id,''), COALESCE(github_issue_id,''), COALESCE(shortcut_story_id,''), COALESCE(jira_issue_id,''), COALESCE(tags,'[]') FROM claws WHERE id=?`, clawID).Scan(&issueID, &githubIssueID, &shortcutStoryID, &jiraIssueID, &tagsJSON); err != nil {
 		return "", nil
 	}
 	if githubIssueID != "" {
 		issueID = githubIssueID
 	} else if shortcutStoryID != "" {
 		issueID = shortcutStoryID
+	} else if jiraIssueID != "" {
+		issueID = jiraIssueID
 	}
 	var tags []string
 	_ = json.Unmarshal([]byte(tagsJSON), &tags)

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -68,6 +68,8 @@ type Server struct {
 	linearBaseURL string
 	// shortcutBaseURL overrides the Shortcut API base for testing (default: https://api.app.shortcut.com)
 	shortcutBaseURL string
+	// jiraBaseURL overrides the Jira API base for testing.
+	jiraBaseURL string
 
 	// webhookDedup prevents duplicate Linear webhook deliveries from creating
 	// duplicate claws. Keyed by issue transition fingerprint; entries expire after 30s.
@@ -289,11 +291,13 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/integrations/github/webhook", s.handleGitHubWebhook)
 	mux.HandleFunc("/api/integrations/github-issues/webhook", s.handleGitHubIssuesWebhook)
 	mux.HandleFunc("/api/integrations/shortcut/webhook", s.handleShortcutWebhook)
+	mux.HandleFunc("/api/integrations/jira/webhook", s.handleJiraWebhook)
 	mux.HandleFunc("/api/integrations/external/webhook", s.handleExternalWebhook)
 	mux.HandleFunc("/api/workspaces/{workspace}/webhooks/linear", s.handleLinearWebhook)
 	mux.HandleFunc("/api/workspaces/{workspace}/webhooks/github", s.handleGitHubWebhook)
 	mux.HandleFunc("/api/workspaces/{workspace}/webhooks/github-issues", s.handleGitHubIssuesWebhook)
 	mux.HandleFunc("/api/workspaces/{workspace}/webhooks/shortcut", s.handleShortcutWebhook)
+	mux.HandleFunc("/api/workspaces/{workspace}/webhooks/jira", s.handleJiraWebhook)
 	mux.HandleFunc("/api/workspaces/{workspace}/webhooks/external", s.handleExternalWebhook)
 	mux.HandleFunc("/api/factories/", s.withAuth(s.handleFactoryEvents))                                               // GET /api/factories/:name/events
 	mux.HandleFunc("/api/factories/{name}/trigger", s.withAuth(s.handleFactoryTrigger))                                // POST manual trigger

--- a/pkg/hub/task_run_analytics.go
+++ b/pkg/hub/task_run_analytics.go
@@ -204,20 +204,20 @@ func (s *Server) ensureTaskRunForClaw(clawID string, opts TaskRunStart) (string,
 	}
 	defer tx.Rollback()
 
-	var tenantID, existingRunID, rawTags, clawModel, clawLLMKey, clawFactory, externalTriggerID, linearIssue, githubIssue, shortcutStory, clawStatus string
+	var tenantID, existingRunID, rawTags, clawModel, clawLLMKey, clawFactory, externalTriggerID, linearIssue, githubIssue, shortcutStory, jiraIssue, clawStatus string
 	err = tx.QueryRow(`
 		SELECT tenant_id, COALESCE(task_run_id,''), COALESCE(tags,'[]'), COALESCE(default_model,''),
 		       COALESCE(llm_key,''), COALESCE(factory_name,''), COALESCE(external_trigger_id,''),
-		       COALESCE(linear_issue_id,''), COALESCE(github_issue_id,''), COALESCE(shortcut_story_id,''), COALESCE(status,'')
+		       COALESCE(linear_issue_id,''), COALESCE(github_issue_id,''), COALESCE(shortcut_story_id,''), COALESCE(jira_issue_id,''), COALESCE(status,'')
 		  FROM claws
-		 WHERE id=?`, clawID).Scan(&tenantID, &existingRunID, &rawTags, &clawModel, &clawLLMKey, &clawFactory, &externalTriggerID, &linearIssue, &githubIssue, &shortcutStory, &clawStatus)
+		 WHERE id=?`, clawID).Scan(&tenantID, &existingRunID, &rawTags, &clawModel, &clawLLMKey, &clawFactory, &externalTriggerID, &linearIssue, &githubIssue, &shortcutStory, &jiraIssue, &clawStatus)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return "", "", fmt.Errorf("ensure task run: claw %s not found", clawID)
 		}
 		return "", "", err
 	}
-	normalizeTaskRunStart(&opts, tenantID, clawModel, clawLLMKey, clawFactory, externalTriggerID, firstNonEmpty(githubIssue, linearIssue, shortcutStory))
+	normalizeTaskRunStart(&opts, tenantID, clawModel, clawLLMKey, clawFactory, externalTriggerID, firstNonEmpty(githubIssue, linearIssue, shortcutStory, jiraIssue))
 
 	if existingRunID != "" {
 		attemptID, err := ensureTaskRunAttemptTx(tx, existingRunID, opts.TenantID, clawID, opts.TriggerID, ts)
@@ -691,7 +691,7 @@ func (s *Server) taskRunRequiresPRForClaw(clawID string) bool {
 
 func isTaskRunAnalyticsIntegration(integration string) bool {
 	switch integration {
-	case "linear", "shortcut", "github-issues", "github":
+	case "linear", "shortcut", "github-issues", "jira", "github":
 		return true
 	default:
 		return false

--- a/pkg/hub/testhelpers.go
+++ b/pkg/hub/testhelpers.go
@@ -113,6 +113,23 @@ func SaveWorkspaceIssueTrackerForTest(t interface {
 	}
 }
 
+// SaveWorkspaceIssueTrackerWithBaseForTest writes a workspace-managed issue tracker
+// with tracker-specific connection details.
+func SaveWorkspaceIssueTrackerWithBaseForTest(t interface {
+	Helper()
+	Fatalf(string, ...interface{})
+}, workspace, trackerType, name, baseURL, username, token, webhookSecret string) {
+	t.Helper()
+	if err := saveWorkspaceIssueTracker(workspace, trackerType, name, workspaceIssueTracker{
+		BaseURL:       baseURL,
+		Username:      username,
+		Token:         token,
+		WebhookSecret: webhookSecret,
+	}); err != nil {
+		t.Fatalf("save workspace issue tracker: %v", err)
+	}
+}
+
 // Handler returns the server's HTTP handler (mux). Must be called after setupRoutes.
 func (s *Server) Handler() http.Handler {
 	return s.mux

--- a/pkg/hub/workflow_creator.go
+++ b/pkg/hub/workflow_creator.go
@@ -21,6 +21,7 @@ type workflowCreateOptions struct {
 	githubIssueID   string
 	linearIssueID   string
 	shortcutStoryID string
+	jiraIssueID     string
 	reason          string
 	triggerActor    *triggerActor
 }
@@ -117,6 +118,18 @@ func (s *Server) createClawFromWorkflowWithOptions(workspace *types.WorkspaceCon
 		if token := s.resolveLinearTokenForWorkflow(workspace.Name, workflow); token != "" {
 			env["LINEAR_API_KEY"] = token
 			resolvedSecrets["LINEAR_API_KEY"] = "Linear integration token"
+		}
+	}
+	if workflow.Integration == "jira" {
+		if tracker, ok := s.resolveJiraTrackerForWorkflow(workspace.Name, workflow); ok && tracker.Token != "" {
+			env["JIRA_API_KEY"] = tracker.Token
+			resolvedSecrets["JIRA_API_KEY"] = "Jira integration token"
+			if tracker.BaseURL != "" {
+				env["JIRA_BASE_URL"] = tracker.BaseURL
+			}
+			if tracker.Username != "" {
+				env["JIRA_USERNAME"] = tracker.Username
+			}
 		}
 	}
 	if tmplCfg != nil {
@@ -222,6 +235,9 @@ func (s *Server) createClawFromWorkflowWithOptions(workspace *types.WorkspaceCon
 	if opts.shortcutStoryID != "" {
 		_, _ = s.db.Exec(`UPDATE claws SET shortcut_story_id=? WHERE id=?`, opts.shortcutStoryID, clawID)
 	}
+	if opts.jiraIssueID != "" {
+		_, _ = s.db.Exec(`UPDATE claws SET jira_issue_id=? WHERE id=?`, opts.jiraIssueID, clawID)
+	}
 	if opts.triggerActor != nil {
 		actorJSON, err := json.Marshal(opts.triggerActor)
 		if err != nil {
@@ -240,7 +256,7 @@ func (s *Server) createClawFromWorkflowWithOptions(workspace *types.WorkspaceCon
 		WorkspaceName:    workspace.Name,
 		WorkflowName:     workflow.Name,
 		Integration:      workflow.Integration,
-		IssueID:          firstNonEmpty(opts.githubIssueID, opts.linearIssueID, opts.shortcutStoryID),
+		IssueID:          firstNonEmpty(opts.githubIssueID, opts.linearIssueID, opts.shortcutStoryID, opts.jiraIssueID),
 		Model:            defaultModel,
 		LLMKey:           llmKey,
 		Source:           taskRunSourceWorkflow,

--- a/pkg/hub/workspace_managed.go
+++ b/pkg/hub/workspace_managed.go
@@ -29,9 +29,12 @@ type workspaceIssueTrackers struct {
 	Linear       map[string]workspaceIssueTracker `yaml:"linear,omitempty"`
 	Shortcut     map[string]workspaceIssueTracker `yaml:"shortcut,omitempty"`
 	GitHubIssues map[string]workspaceIssueTracker `yaml:"github_issues,omitempty"`
+	Jira         map[string]workspaceIssueTracker `yaml:"jira,omitempty"`
 }
 
 type workspaceIssueTracker struct {
+	BaseURL       string `yaml:"base_url,omitempty" json:"baseUrl,omitempty"`
+	Username      string `yaml:"username,omitempty" json:"username,omitempty"`
 	Token         string `yaml:"token,omitempty" json:"token,omitempty"`
 	WebhookSecret string `yaml:"webhook_secret,omitempty" json:"webhookSecret,omitempty"`
 }
@@ -41,6 +44,8 @@ type workspaceIssueTrackerView struct {
 	Workspace        string `json:"workspace"`
 	TokenSet         bool   `json:"tokenSet"`
 	WebhookSecretSet bool   `json:"webhookSecretSet"`
+	BaseURL          string `json:"baseUrl,omitempty"`
+	Username         string `json:"username,omitempty"`
 }
 
 type workspaceGitHubApp struct {
@@ -159,6 +164,8 @@ func saveWorkspaceIssueTracker(workspace, trackerType, name string, tracker work
 		trackers.Shortcut[name] = tracker
 	case "github-issues":
 		trackers.GitHubIssues[name] = tracker
+	case "jira":
+		trackers.Jira[name] = tracker
 	default:
 		return fmt.Errorf("invalid issue tracker type %q", trackerType)
 	}
@@ -180,6 +187,8 @@ func deleteWorkspaceIssueTracker(workspace, trackerType, name string) error {
 		delete(trackers.Shortcut, name)
 	case "github-issues":
 		delete(trackers.GitHubIssues, name)
+	case "jira":
+		delete(trackers.Jira, name)
 	default:
 		return fmt.Errorf("invalid issue tracker type %q", trackerType)
 	}
@@ -191,7 +200,7 @@ func workspaceIssueTrackerViews(workspace string) ([]workspaceIssueTrackerView, 
 	if err != nil {
 		return nil, err
 	}
-	views := make([]workspaceIssueTrackerView, 0, len(trackers.Linear)+len(trackers.Shortcut)+len(trackers.GitHubIssues))
+	views := make([]workspaceIssueTrackerView, 0, len(trackers.Linear)+len(trackers.Shortcut)+len(trackers.GitHubIssues)+len(trackers.Jira))
 	appendViews := func(trackerType string, values map[string]workspaceIssueTracker) {
 		names := make([]string, 0, len(values))
 		for name := range values {
@@ -205,12 +214,15 @@ func workspaceIssueTrackerViews(workspace string) ([]workspaceIssueTrackerView, 
 				Workspace:        name,
 				TokenSet:         tracker.Token != "",
 				WebhookSecretSet: tracker.WebhookSecret != "",
+				BaseURL:          tracker.BaseURL,
+				Username:         tracker.Username,
 			})
 		}
 	}
 	appendViews("linear", trackers.Linear)
 	appendViews("shortcut", trackers.Shortcut)
 	appendViews("github-issues", trackers.GitHubIssues)
+	appendViews("jira", trackers.Jira)
 	return views, nil
 }
 
@@ -242,6 +254,8 @@ func findWorkspaceIssueTracker(workspace, trackerType, name string) (workspaceIs
 		return find(trackers.Shortcut)
 	case "github-issues":
 		return find(trackers.GitHubIssues)
+	case "jira":
+		return find(trackers.Jira)
 	default:
 		return workspaceIssueTracker{}, false
 	}
@@ -260,6 +274,8 @@ func workspaceIssueTrackerWebhookSecrets(workspace, trackerType string) []string
 		values = trackers.Shortcut
 	case "github-issues":
 		values = trackers.GitHubIssues
+	case "jira":
+		values = trackers.Jira
 	default:
 		return nil
 	}
@@ -281,6 +297,9 @@ func ensureIssueTrackerMaps(trackers *workspaceIssueTrackers) {
 	}
 	if trackers.GitHubIssues == nil {
 		trackers.GitHubIssues = map[string]workspaceIssueTracker{}
+	}
+	if trackers.Jira == nil {
+		trackers.Jira = map[string]workspaceIssueTracker{}
 	}
 }
 

--- a/pkg/hub/workspace_managed_api.go
+++ b/pkg/hub/workspace_managed_api.go
@@ -172,6 +172,8 @@ type workspaceIssueTrackerUpsertRequest struct {
 	Type              string `json:"type"`
 	Workspace         string `json:"workspace"`
 	OriginalWorkspace string `json:"originalWorkspace,omitempty"`
+	BaseURL           string `json:"baseUrl,omitempty"`
+	Username          string `json:"username,omitempty"`
 	Token             string `json:"token,omitempty"`
 	WebhookSecret     string `json:"webhookSecret,omitempty"`
 }
@@ -198,6 +200,8 @@ func (s *Server) handleWorkspaceIssueTrackersCRUD(w http.ResponseWriter, r *http
 		}
 		req.Type = strings.TrimSpace(req.Type)
 		req.Workspace = strings.TrimSpace(req.Workspace)
+		req.BaseURL = strings.TrimSpace(req.BaseURL)
+		req.Username = strings.TrimSpace(req.Username)
 		if req.Workspace == "" {
 			req.Workspace = workspaceName
 		}
@@ -215,10 +219,20 @@ func (s *Server) handleWorkspaceIssueTrackersCRUD(w http.ResponseWriter, r *http
 				if req.WebhookSecret == "" {
 					req.WebhookSecret = existing.WebhookSecret
 				}
+				if req.BaseURL == "" {
+					req.BaseURL = existing.BaseURL
+				}
+				if req.Username == "" {
+					req.Username = existing.Username
+				}
 			}
 		}
 		if req.Token == "" {
 			http.Error(w, "token required", http.StatusBadRequest)
+			return
+		}
+		if req.Type == "jira" && req.BaseURL == "" {
+			http.Error(w, "baseUrl required", http.StatusBadRequest)
 			return
 		}
 		if req.OriginalWorkspace != "" && !strings.EqualFold(req.OriginalWorkspace, req.Workspace) {
@@ -228,6 +242,8 @@ func (s *Server) handleWorkspaceIssueTrackersCRUD(w http.ResponseWriter, r *http
 			}
 		}
 		if err := saveWorkspaceIssueTracker(workspaceName, req.Type, req.Workspace, workspaceIssueTracker{
+			BaseURL:       req.BaseURL,
+			Username:      req.Username,
 			Token:         req.Token,
 			WebhookSecret: req.WebhookSecret,
 		}); err != nil {

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -188,6 +188,8 @@ func (r SecretRef) EnvVarName() string {
 		return "SHORTCUT_API_KEY"
 	case "github-issues":
 		return "GITHUB_ISSUES_API_KEY"
+	case "jira":
+		return "JIRA_API_KEY"
 	case "github":
 		return "GITHUB_TOKEN"
 	case "custom":
@@ -534,6 +536,7 @@ type IntegrationsConfig struct {
 	Linear       []*LinearIntegrationConfig       `yaml:"linear,omitempty"`
 	Shortcut     []*ShortcutIntegrationConfig     `yaml:"shortcut,omitempty"`
 	GitHubIssues []*GitHubIssuesIntegrationConfig `yaml:"github_issues,omitempty"`
+	Jira         []*JiraIntegrationConfig         `yaml:"jira,omitempty"`
 }
 
 // ExternalTriggerConfig holds config for external webhook triggers.
@@ -561,6 +564,15 @@ type GitHubIssuesIntegrationConfig struct {
 	Workspace     string `yaml:"workspace"`                // human label (e.g. "my-org")
 	Token         string `yaml:"token"`                    // GitHub personal access token
 	WebhookSecret string `yaml:"webhook_secret,omitempty"` // HMAC secret for validating webhooks
+}
+
+// JiraIntegrationConfig holds credentials for one Jira site.
+type JiraIntegrationConfig struct {
+	Workspace     string `yaml:"workspace"`                // human label
+	BaseURL       string `yaml:"base_url,omitempty"`       // Jira base URL, e.g. https://jira.example.com
+	Username      string `yaml:"username,omitempty"`       // optional for basic auth
+	Token         string `yaml:"token"`                    // Jira PAT/API token
+	WebhookSecret string `yaml:"webhook_secret,omitempty"` // shared webhook secret
 }
 
 // FactoryInput defines a user-provided input for manual factory triggers.
@@ -610,6 +622,8 @@ type FactoryConfig struct {
 	Labels []string `yaml:"labels,omitempty" json:"labels,omitempty"`
 	// AssignedTo filter: "@user", "!@user" (exclude), "any", "none"
 	AssignedTo string `yaml:"assigned_to,omitempty" json:"assigned_to,omitempty"`
+	// Projects limits Jira factory triggers to these project keys.
+	Projects []string `yaml:"projects,omitempty" json:"projects,omitempty"`
 	// AllowedLabelers restricts who can trigger claw creation by labeling an issue.
 	// Only users in this list (GitHub logins, case-insensitive) can trigger.
 	// If empty, any user with label permissions can trigger.

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -620,6 +620,8 @@ type FactoryConfig struct {
 	RequiresPR       *bool    `yaml:"requires_pr,omitempty" json:"requires_pr,omitempty"`               // nil = infer from analytics eligibility
 	// Labels: all must be present on the issue to trigger (AND)
 	Labels []string `yaml:"labels,omitempty" json:"labels,omitempty"`
+	// ExcludeLabels: none may be present on the issue to trigger (NOT)
+	ExcludeLabels []string `yaml:"exclude_labels,omitempty" json:"exclude_labels,omitempty"`
 	// AssignedTo filter: "@user", "!@user" (exclude), "any", "none"
 	AssignedTo string `yaml:"assigned_to,omitempty" json:"assigned_to,omitempty"`
 	// Projects limits Jira factory triggers to these project keys.

--- a/pkg/types/validation.go
+++ b/pkg/types/validation.go
@@ -19,7 +19,7 @@ var validColors = map[string]bool{
 
 // Valid integration types
 var validIntegrations = map[string]bool{
-	"linear": true, "shortcut": true, "github-issues": true, "github": true, "external": true,
+	"linear": true, "shortcut": true, "github-issues": true, "jira": true, "github": true, "external": true,
 }
 
 // Valid workflow integration types. Cron is workflow-only; factories still use
@@ -106,7 +106,7 @@ func (f *FactoryConfig) Validate() error {
 		return fmt.Errorf("factory %q: integration is required", f.Name)
 	}
 	if !validIntegrations[f.Integration] {
-		return fmt.Errorf("factory %q: invalid integration %q (must be one of: linear, shortcut, github-issues, github, external)", f.Name, f.Integration)
+		return fmt.Errorf("factory %q: invalid integration %q (must be one of: linear, shortcut, github-issues, jira, github, external)", f.Name, f.Integration)
 	}
 
 	// Template is required
@@ -181,6 +181,11 @@ func (f *FactoryConfig) Validate() error {
 			return fmt.Errorf("factory %q: trigger_repos[%d] invalid format %q (expected owner/repo or owner/*)", f.Name, i, repo)
 		}
 	}
+	for i, project := range f.Projects {
+		if strings.TrimSpace(project) == "" {
+			return fmt.Errorf("factory %q: projects[%d] cannot be empty", f.Name, i)
+		}
+	}
 
 	return nil
 }
@@ -194,7 +199,7 @@ func (w *WorkflowConfig) Validate() error {
 		return fmt.Errorf("workflow name is required")
 	}
 	if w.Integration != "" && !validWorkflowIntegrations[w.Integration] {
-		return fmt.Errorf("workflow %q: invalid integration %q (must be one of: linear, shortcut, github-issues, github, external, cron)", w.Name, w.Integration)
+		return fmt.Errorf("workflow %q: invalid integration %q (must be one of: linear, shortcut, github-issues, jira, github, external, cron)", w.Name, w.Integration)
 	}
 	if w.Color != "" && !validColors[w.Color] {
 		return fmt.Errorf("workflow %q: invalid color %q", w.Name, w.Color)
@@ -301,6 +306,9 @@ func validateWorkflowTrigger(workflowName string, trigger *WorkflowTrigger) erro
 	if trigger.Shortcut != nil {
 		nestedCount++
 	}
+	if trigger.Jira != nil {
+		nestedCount++
+	}
 	if trigger.Cron != nil {
 		nestedCount++
 	}
@@ -315,6 +323,9 @@ func validateWorkflowTrigger(workflowName string, trigger *WorkflowTrigger) erro
 	}
 	if trigger.Cron != nil {
 		return validateCronWorkflowTrigger(workflowName, trigger.Cron)
+	}
+	if trigger.Jira != nil {
+		return validateJiraWorkflowTrigger(workflowName, trigger.Jira)
 	}
 	return validateShortcutWorkflowTrigger(workflowName, trigger.Shortcut)
 }
@@ -406,6 +417,34 @@ func validateShortcutWorkflowTrigger(workflowName string, trigger *ShortcutWorkf
 		if strings.TrimSpace(state) == "" {
 			return fmt.Errorf("workflow %q: trigger.shortcut.states[%d] cannot be empty", workflowName, i)
 		}
+	}
+	return nil
+}
+
+func validateJiraWorkflowTrigger(workflowName string, trigger *JiraWorkflowTrigger) error {
+	if trigger.Event == "" {
+		return fmt.Errorf("workflow %q: trigger.jira.event is required", workflowName)
+	}
+	switch trigger.Event {
+	case "status", "status_changed", "issue_status_changed", "issue_created", "issue_updated":
+	default:
+		return fmt.Errorf("workflow %q: invalid trigger.jira.event %q", workflowName, trigger.Event)
+	}
+	if len(trigger.States) == 0 {
+		return fmt.Errorf("workflow %q: trigger.jira.states must include at least one status", workflowName)
+	}
+	for i, state := range trigger.States {
+		if strings.TrimSpace(state) == "" {
+			return fmt.Errorf("workflow %q: trigger.jira.states[%d] cannot be empty", workflowName, i)
+		}
+	}
+	for i, project := range trigger.Projects {
+		if strings.TrimSpace(project) == "" {
+			return fmt.Errorf("workflow %q: trigger.jira.projects[%d] cannot be empty", workflowName, i)
+		}
+	}
+	if trigger.AgentStatusError != "" && strings.TrimSpace(trigger.AgentStatusError) == "" {
+		return fmt.Errorf("workflow %q: trigger.jira.agent_status_error cannot be blank", workflowName)
 	}
 	return nil
 }
@@ -558,9 +597,9 @@ func validateSecretRef(path string, secret SecretRef) error {
 		return fmt.Errorf("%s: type is required", path)
 	}
 
-	validTypes := map[string]bool{"linear": true, "shortcut": true, "github": true, "github-issues": true, "custom": true}
+	validTypes := map[string]bool{"linear": true, "shortcut": true, "github": true, "github-issues": true, "jira": true, "custom": true}
 	if !validTypes[secret.Type] {
-		return fmt.Errorf("%s: invalid type %q (must be one of: linear, shortcut, github, github-issues, custom)", path, secret.Type)
+		return fmt.Errorf("%s: invalid type %q (must be one of: linear, shortcut, github, github-issues, jira, custom)", path, secret.Type)
 	}
 
 	if secret.Type == "custom" && secret.Name == "" {

--- a/pkg/types/validation.go
+++ b/pkg/types/validation.go
@@ -226,12 +226,14 @@ func (w *WorkflowConfig) Validate() error {
 			return fmt.Errorf("workflow %q: repos[%d] invalid format %q (expected owner/repo or owner/*)", w.Name, i, repo)
 		}
 	}
-	for i, repo := range w.TriggerRepos {
-		if repo == "" {
-			return fmt.Errorf("workflow %q: trigger_repos[%d] cannot be empty", w.Name, i)
-		}
-		if !validRepoSelector(repo) {
-			return fmt.Errorf("workflow %q: trigger_repos[%d] invalid format %q (expected owner/repo or owner/*)", w.Name, i, repo)
+	if workflowTriggerReposAreRepoSelectors(w) {
+		for i, repo := range w.TriggerRepos {
+			if repo == "" {
+				return fmt.Errorf("workflow %q: trigger_repos[%d] cannot be empty", w.Name, i)
+			}
+			if !validRepoSelector(repo) {
+				return fmt.Errorf("workflow %q: trigger_repos[%d] invalid format %q (expected owner/repo or owner/*)", w.Name, i, repo)
+			}
 		}
 	}
 	for i, input := range w.Inputs {
@@ -251,6 +253,18 @@ func (w *WorkflowConfig) Validate() error {
 		}
 	}
 	return nil
+}
+
+func workflowTriggerReposAreRepoSelectors(w *WorkflowConfig) bool {
+	if w == nil || len(w.TriggerRepos) == 0 {
+		return false
+	}
+	switch w.Integration {
+	case "", "github", "github-issues":
+		return true
+	default:
+		return false
+	}
 }
 
 func validateWorkflowVolume(workflowName string, index int, volume WorkflowVolume, seen map[string]struct{}) error {

--- a/pkg/types/workflow_normalize.go
+++ b/pkg/types/workflow_normalize.go
@@ -48,6 +48,17 @@ func NormalizeWorkflowConfig(workflow *WorkflowConfig) error {
 			if len(workflow.Trigger.Shortcut.States) > 0 {
 				workflow.TriggerStatus = workflow.Trigger.Shortcut.States[0]
 			}
+		case workflow.Trigger.Jira != nil:
+			workflow.Integration = "jira"
+			workflow.Workspace = workflow.Trigger.Jira.Workspace
+			workflow.Labels = append([]string(nil), workflow.Trigger.Jira.Labels...)
+			workflow.AssignedTo = workflow.Trigger.Jira.AssignedTo
+			if len(workflow.Trigger.Jira.Projects) > 0 {
+				workflow.TriggerRepos = append([]string(nil), workflow.Trigger.Jira.Projects...)
+			}
+			if len(workflow.Trigger.Jira.States) > 0 {
+				workflow.TriggerStatus = workflow.Trigger.Jira.States[0]
+			}
 		case workflow.Trigger.Cron != nil:
 			workflow.Integration = "cron"
 		}

--- a/pkg/types/workflow_normalize.go
+++ b/pkg/types/workflow_normalize.go
@@ -52,6 +52,7 @@ func NormalizeWorkflowConfig(workflow *WorkflowConfig) error {
 			workflow.Integration = "jira"
 			workflow.Workspace = workflow.Trigger.Jira.Workspace
 			workflow.Labels = append([]string(nil), workflow.Trigger.Jira.Labels...)
+			workflow.ExcludeLabels = append([]string(nil), workflow.Trigger.Jira.ExcludeLabels...)
 			workflow.AssignedTo = workflow.Trigger.Jira.AssignedTo
 			if len(workflow.Trigger.Jira.Projects) > 0 {
 				workflow.TriggerRepos = append([]string(nil), workflow.Trigger.Jira.Projects...)

--- a/pkg/types/workflow_normalize_test.go
+++ b/pkg/types/workflow_normalize_test.go
@@ -46,6 +46,42 @@ stages:
 	}
 }
 
+func TestWorkflowV1JiraProjectsValidateAsProjectKeys(t *testing.T) {
+	data := []byte(`
+schema_version: v1
+name: jira-issue
+trigger:
+  jira:
+    event: status_changed
+    workspace: default
+    projects:
+      - KAN
+    states:
+      - Ready for Agent
+stages:
+  - id: working
+    entry: true
+    on_enter:
+      inject: start
+`)
+	var workflow WorkflowConfig
+	if err := yaml.Unmarshal(data, &workflow); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if err := NormalizeWorkflowConfig(&workflow); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if got := workflow.Integration; got != "jira" {
+		t.Fatalf("integration = %q, want jira", got)
+	}
+	if got := workflow.TriggerRepos; len(got) != 1 || got[0] != "KAN" {
+		t.Fatalf("trigger repos = %#v, want KAN project key", got)
+	}
+	if err := workflow.Validate(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+}
+
 func TestWorkflowV1GitHubIssuesTriggerPreservesAgentStatusError(t *testing.T) {
 	data := []byte(`
 schema_version: v1

--- a/pkg/types/workspace.go
+++ b/pkg/types/workspace.go
@@ -88,6 +88,7 @@ type WorkflowTrigger struct {
 	GitHubIssues *GitHubIssuesWorkflowTrigger `yaml:"github_issues,omitempty" json:"github_issues,omitempty"`
 	Linear       *LinearWorkflowTrigger       `yaml:"linear,omitempty" json:"linear,omitempty"`
 	Shortcut     *ShortcutWorkflowTrigger     `yaml:"shortcut,omitempty" json:"shortcut,omitempty"`
+	Jira         *JiraWorkflowTrigger         `yaml:"jira,omitempty" json:"jira,omitempty"`
 	Cron         *CronWorkflowTrigger         `yaml:"cron,omitempty" json:"cron,omitempty"`
 }
 
@@ -141,6 +142,16 @@ type ShortcutWorkflowTrigger struct {
 	States     []string `yaml:"states,omitempty" json:"states,omitempty"`
 	Labels     []string `yaml:"labels,omitempty" json:"labels,omitempty"`
 	AssignedTo string   `yaml:"assigned_to,omitempty" json:"assigned_to,omitempty"`
+}
+
+type JiraWorkflowTrigger struct {
+	Event            string   `yaml:"event,omitempty" json:"event,omitempty"`
+	Workspace        string   `yaml:"workspace,omitempty" json:"workspace,omitempty"`
+	Projects         []string `yaml:"projects,omitempty" json:"projects,omitempty"`
+	States           []string `yaml:"states,omitempty" json:"states,omitempty"`
+	Labels           []string `yaml:"labels,omitempty" json:"labels,omitempty"`
+	AssignedTo       string   `yaml:"assigned_to,omitempty" json:"assigned_to,omitempty"`
+	AgentStatusError string   `yaml:"agent_status_error,omitempty" json:"agent_status_error,omitempty"`
 }
 
 // WorkflowStage is one step in a workflow state machine. It intentionally mirrors

--- a/pkg/types/workspace.go
+++ b/pkg/types/workspace.go
@@ -41,6 +41,7 @@ type WorkflowConfig struct {
 	AnalyticsEnabled    *bool             `yaml:"analytics_enabled,omitempty" json:"analytics_enabled,omitempty"`
 	RequiresPR          *bool             `yaml:"requires_pr,omitempty" json:"requires_pr,omitempty"`
 	Labels              []string          `yaml:"labels,omitempty" json:"labels,omitempty"`
+	ExcludeLabels       []string          `yaml:"exclude_labels,omitempty" json:"exclude_labels,omitempty"`
 	AssignedTo          string            `yaml:"assigned_to,omitempty" json:"assigned_to,omitempty"`
 	AllowedLabelers     []string          `yaml:"allowed_labelers,omitempty" json:"allowed_labelers,omitempty"`
 	SecretRefs          map[string]string `yaml:"secret_refs,omitempty" json:"secret_refs,omitempty"`
@@ -150,6 +151,7 @@ type JiraWorkflowTrigger struct {
 	Projects         []string `yaml:"projects,omitempty" json:"projects,omitempty"`
 	States           []string `yaml:"states,omitempty" json:"states,omitempty"`
 	Labels           []string `yaml:"labels,omitempty" json:"labels,omitempty"`
+	ExcludeLabels    []string `yaml:"exclude_labels,omitempty" json:"exclude_labels,omitempty"`
 	AssignedTo       string   `yaml:"assigned_to,omitempty" json:"assigned_to,omitempty"`
 	AgentStatusError string   `yaml:"agent_status_error,omitempty" json:"agent_status_error,omitempty"`
 }

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -91,6 +91,8 @@ ELASTICCLAW_E2E_LINEAR_INITIAL_STATE=Backlog
 ELASTICCLAW_E2E_REPLICATED_API_URL=https://api.replicated.com/vendor/v3
 ELASTICCLAW_E2E_REPLICATED_INSTANCE_TYPE=r1.small
 ELASTICCLAW_E2E_REPLICATED_TTL=1h
+ELASTICCLAW_E2E_JIRA=false
+ELASTICCLAW_E2E_JIRA_IMAGE=atlassian/jira-software:latest
 ```
 
 The GitHub token needs access to the fixture repo with:
@@ -110,6 +112,13 @@ The Linear API key must be able to create webhooks and issues for the team in
 workflow to watch. Set `ELASTICCLAW_E2E_LINEAR_INITIAL_STATE` only if the test
 cannot infer a non-trigger state for the initial issue creation.
 
+Jira E2E should run as a separate gated job because the Atlassian Jira Software
+container is heavier than the API-backed tracker tests and may require instance
+bootstrap/licensing. The intended path is: start `atlassian/jira-software`,
+create a project/workflow/statuses, configure `/api/workspaces/{workspace}/webhooks/jira`,
+transition an issue into the trigger status, then verify webhook delivery and
+polling recovery both create exactly one agent.
+
 ## Planned Matrix
 
 The suite should grow in separate jobs so failures stay attributable:
@@ -118,6 +127,7 @@ The suite should grow in separate jobs so failures stay attributable:
 github-issues: webhook, polling recovery, duplicate prevention
 linear: webhook, polling recovery, duplicate prevention
 shortcut: webhook, polling recovery, duplicate prevention
+jira: container-backed webhook, polling recovery, duplicate prevention
 exedev: provisioning reaches agent connected
 daytona: provisioning reaches agent connected and repositories clone
 replicated: provisioning reaches agent connected and repositories clone

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -98,9 +98,6 @@ ELASTICCLAW_E2E_GITHUB_APP_URL=https://github.com/settings/apps/...
 ELASTICCLAW_E2E_GITHUB_APP_INSTALLATION=elasticclaw
 ELASTICCLAW_E2E_LINEAR_TRIGGER_STATE=Todo
 ELASTICCLAW_E2E_LINEAR_INITIAL_STATE=Backlog
-ELASTICCLAW_E2E_JIRA_ISSUE_TYPE=Task
-ELASTICCLAW_E2E_JIRA_TRIGGER_STATE="In Progress"
-ELASTICCLAW_E2E_JIRA_INITIAL_STATE=
 ELASTICCLAW_E2E_JIRA_MANUAL_WEBHOOK=true
 ELASTICCLAW_E2E_REPLICATED_API_URL=https://api.replicated.com/vendor/v3
 ELASTICCLAW_E2E_REPLICATED_INSTANCE_TYPE=r1.small
@@ -128,8 +125,7 @@ The Jira Cloud user is configured with `ELASTICCLAW_E2E_JIRA_USERNAME` and
 `ELASTICCLAW_E2E_JIRA_TOKEN`. It must be able to browse the project, create
 issues, edit issues, transition issues, add labels, and delete issues for
 cleanup. `ELASTICCLAW_E2E_JIRA_PROJECT_KEY` must point at an existing project
-whose workflow has a transition to `ELASTICCLAW_E2E_JIRA_TRIGGER_STATE`, which
-defaults to `In Progress`.
+whose workflow supports `Bug` issues moving from `To do` to `Ready for Agent`.
 
 Jira Cloud dynamic webhook registration is restricted to Connect and OAuth apps,
 so the default E2E mode uses real Jira Cloud REST mutations and then posts a

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -8,6 +8,7 @@ The E2E paths run against real services:
 ```text
 Depot CI -> ngrok -> ElasticClaw Server -> GitHub Issues -> Daytona -> OpenClaw -> Fireworks Kimi
 Depot CI -> ngrok -> ElasticClaw Server -> Linear -> Daytona -> OpenClaw -> Fireworks Kimi
+Depot CI -> ngrok -> ElasticClaw Server -> Jira Cloud -> Daytona -> OpenClaw -> Fireworks Kimi
 ```
 
 Each test creates a workspace and workflow with the ElasticClaw CLI, configures
@@ -15,7 +16,10 @@ a workspace GitHub App with the CLI so repositories can clone in Daytona, then
 configures the issue tracker through the server API. The GitHub Issues test
 creates a real GitHub issue and labels it. The Linear test creates a real Linear
 webhook, creates a real Linear issue in a non-trigger state, moves it into the
-trigger state, then waits for one Daytona-backed agent to connect and reply.
+trigger state, then waits for one Daytona-backed agent to connect and reply. The
+Jira test creates a real Jira Cloud issue, labels it, transitions it into the
+trigger state, delivers a Jira-shaped webhook payload to the E2E hub, and lets
+the poller run long enough to verify duplicate prevention.
 
 ## Fixture Repo
 
@@ -42,8 +46,10 @@ Run one suite:
 ```sh
 make e2e-github
 make e2e-linear
+make e2e-jira
 make e2e-replicated-github
 make e2e-replicated-linear
+make e2e-replicated-jira
 ```
 
 The make targets build `bin/elasticclaw` and `bin/claw-bridge-linux-amd64`,
@@ -73,6 +79,10 @@ ELASTICCLAW_E2E_GITHUB_APP_ID
 ELASTICCLAW_E2E_GITHUB_APP_PRIVATE_KEY
 ELASTICCLAW_E2E_LINEAR_API_KEY
 ELASTICCLAW_E2E_LINEAR_TEAM_KEY
+ELASTICCLAW_E2E_JIRA_BASE_URL
+ELASTICCLAW_E2E_JIRA_USERNAME
+ELASTICCLAW_E2E_JIRA_TOKEN
+ELASTICCLAW_E2E_JIRA_PROJECT_KEY
 DAYTONA_API_KEY
 REPLICATED_API_TOKEN
 FIREWORKS_API_KEY
@@ -88,11 +98,13 @@ ELASTICCLAW_E2E_GITHUB_APP_URL=https://github.com/settings/apps/...
 ELASTICCLAW_E2E_GITHUB_APP_INSTALLATION=elasticclaw
 ELASTICCLAW_E2E_LINEAR_TRIGGER_STATE=Todo
 ELASTICCLAW_E2E_LINEAR_INITIAL_STATE=Backlog
+ELASTICCLAW_E2E_JIRA_ISSUE_TYPE=Task
+ELASTICCLAW_E2E_JIRA_TRIGGER_STATE="In Progress"
+ELASTICCLAW_E2E_JIRA_INITIAL_STATE=
+ELASTICCLAW_E2E_JIRA_MANUAL_WEBHOOK=true
 ELASTICCLAW_E2E_REPLICATED_API_URL=https://api.replicated.com/vendor/v3
 ELASTICCLAW_E2E_REPLICATED_INSTANCE_TYPE=r1.small
 ELASTICCLAW_E2E_REPLICATED_TTL=1h
-ELASTICCLAW_E2E_JIRA=false
-ELASTICCLAW_E2E_JIRA_IMAGE=atlassian/jira-software:latest
 ```
 
 The GitHub token needs access to the fixture repo with:
@@ -112,12 +124,19 @@ The Linear API key must be able to create webhooks and issues for the team in
 workflow to watch. Set `ELASTICCLAW_E2E_LINEAR_INITIAL_STATE` only if the test
 cannot infer a non-trigger state for the initial issue creation.
 
-Jira E2E should run as a separate gated job because the Atlassian Jira Software
-container is heavier than the API-backed tracker tests and may require instance
-bootstrap/licensing. The intended path is: start `atlassian/jira-software`,
-create a project/workflow/statuses, configure `/api/workspaces/{workspace}/webhooks/jira`,
-transition an issue into the trigger status, then verify webhook delivery and
-polling recovery both create exactly one agent.
+The Jira Cloud user is configured with `ELASTICCLAW_E2E_JIRA_USERNAME` and
+`ELASTICCLAW_E2E_JIRA_TOKEN`. It must be able to browse the project, create
+issues, edit issues, transition issues, add labels, and delete issues for
+cleanup. `ELASTICCLAW_E2E_JIRA_PROJECT_KEY` must point at an existing project
+whose workflow has a transition to `ELASTICCLAW_E2E_JIRA_TRIGGER_STATE`, which
+defaults to `In Progress`.
+
+Jira Cloud dynamic webhook registration is restricted to Connect and OAuth apps,
+so the default E2E mode uses real Jira Cloud REST mutations and then posts a
+Jira-shaped webhook payload to the ngrok-backed ElasticClaw webhook endpoint.
+Leave `ELASTICCLAW_E2E_JIRA_MANUAL_WEBHOOK=true` for CI. Set it to `false` only
+when a separate Jira app or automation rule is already delivering real Jira
+webhooks to the current E2E ngrok URL.
 
 ## Planned Matrix
 
@@ -127,7 +146,7 @@ The suite should grow in separate jobs so failures stay attributable:
 github-issues: webhook, polling recovery, duplicate prevention
 linear: webhook, polling recovery, duplicate prevention
 shortcut: webhook, polling recovery, duplicate prevention
-jira: container-backed webhook, polling recovery, duplicate prevention
+jira: Jira Cloud REST mutation, webhook processing, polling duplicate prevention
 exedev: provisioning reaches agent connected
 daytona: provisioning reaches agent connected and repositories clone
 replicated: provisioning reaches agent connected and repositories clone

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -125,7 +125,8 @@ The Jira Cloud user is configured with `ELASTICCLAW_E2E_JIRA_USERNAME` and
 `ELASTICCLAW_E2E_JIRA_TOKEN`. It must be able to browse the project, create
 issues, edit issues, transition issues, add labels, and delete issues for
 cleanup. `ELASTICCLAW_E2E_JIRA_PROJECT_KEY` must point at an existing project
-whose workflow supports `Bug` issues moving from `To do` to `Ready for Agent`.
+whose workflow supports `Bug` issues moving from `To do` to `Ready for Agent`
+and then to `Agent Working`.
 
 Jira Cloud dynamic webhook registration is restricted to Connect and OAuth apps,
 so the default E2E mode uses real Jira Cloud REST mutations and then posts a

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -130,6 +130,12 @@ type e2eEnv struct {
 	LinearTeamKey       string
 	LinearTriggerState  string
 	LinearInitialState  string
+	JiraBaseURL         string
+	JiraUsername        string
+	JiraToken           string
+	JiraProjectKey      string
+	JiraTriggerState    string
+	JiraInitialState    string
 	DaytonaAPIKey       string
 	ReplicatedToken     string
 	ReplicatedAPIURL    string
@@ -160,6 +166,12 @@ func newE2EEnv(t *testing.T, runID, sandboxProvider string) e2eEnv {
 		LinearTeamKey:       os.Getenv("ELASTICCLAW_E2E_LINEAR_TEAM_KEY"),
 		LinearTriggerState:  envOrDefault("ELASTICCLAW_E2E_LINEAR_TRIGGER_STATE", "Todo"),
 		LinearInitialState:  os.Getenv("ELASTICCLAW_E2E_LINEAR_INITIAL_STATE"),
+		JiraBaseURL:         strings.TrimRight(os.Getenv("ELASTICCLAW_E2E_JIRA_BASE_URL"), "/"),
+		JiraUsername:        os.Getenv("ELASTICCLAW_E2E_JIRA_USERNAME"),
+		JiraToken:           os.Getenv("ELASTICCLAW_E2E_JIRA_TOKEN"),
+		JiraProjectKey:      os.Getenv("ELASTICCLAW_E2E_JIRA_PROJECT_KEY"),
+		JiraTriggerState:    envOrDefault("ELASTICCLAW_E2E_JIRA_TRIGGER_STATE", "In Progress"),
+		JiraInitialState:    os.Getenv("ELASTICCLAW_E2E_JIRA_INITIAL_STATE"),
 		FireworksAPIKey:     requiredEnv(t, "FIREWORKS_API_KEY"),
 		BridgeBinary:        requiredEnv(t, "ELASTICCLAW_E2E_BRIDGE_BINARY"),
 		BridgeToken:         "bridge-" + runID,
@@ -407,12 +419,16 @@ func runCLI(ctx context.Context, t *testing.T, workdir string, env e2eEnv, args 
 
 func (h *hubProcess) putIssueTracker(ctx context.Context, t *testing.T, workspaceName, trackerType, name, token, webhookSecret string) {
 	t.Helper()
-	body := map[string]string{
+	h.putIssueTrackerWithConfig(ctx, t, workspaceName, map[string]string{
 		"type":          trackerType,
 		"workspace":     name,
 		"token":         token,
 		"webhookSecret": webhookSecret,
-	}
+	})
+}
+
+func (h *hubProcess) putIssueTrackerWithConfig(ctx context.Context, t *testing.T, workspaceName string, body map[string]string) {
+	t.Helper()
 	h.api(ctx, t, http.MethodPut, "/api/workspaces/"+workspaceName+"/issue-trackers", body, nil)
 }
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -134,8 +134,6 @@ type e2eEnv struct {
 	JiraUsername        string
 	JiraToken           string
 	JiraProjectKey      string
-	JiraTriggerState    string
-	JiraInitialState    string
 	DaytonaAPIKey       string
 	ReplicatedToken     string
 	ReplicatedAPIURL    string
@@ -170,8 +168,6 @@ func newE2EEnv(t *testing.T, runID, sandboxProvider string) e2eEnv {
 		JiraUsername:        os.Getenv("ELASTICCLAW_E2E_JIRA_USERNAME"),
 		JiraToken:           os.Getenv("ELASTICCLAW_E2E_JIRA_TOKEN"),
 		JiraProjectKey:      os.Getenv("ELASTICCLAW_E2E_JIRA_PROJECT_KEY"),
-		JiraTriggerState:    envOrDefault("ELASTICCLAW_E2E_JIRA_TRIGGER_STATE", "In Progress"),
-		JiraInitialState:    os.Getenv("ELASTICCLAW_E2E_JIRA_INITIAL_STATE"),
 		FireworksAPIKey:     requiredEnv(t, "FIREWORKS_API_KEY"),
 		BridgeBinary:        requiredEnv(t, "ELASTICCLAW_E2E_BRIDGE_BINARY"),
 		BridgeToken:         "bridge-" + runID,

--- a/test/e2e/jira_test.go
+++ b/test/e2e/jira_test.go
@@ -18,6 +18,12 @@ import (
 	"time"
 )
 
+const (
+	jiraE2EIssueType    = "Bug"
+	jiraE2EInitialState = "To do"
+	jiraE2ETriggerState = "Ready for Agent"
+)
+
 func TestDaytonaJiraWorkflowE2E(t *testing.T) {
 	runJiraWorkflowE2E(t, "daytona")
 }
@@ -97,15 +103,15 @@ func runJiraWorkflowE2E(t *testing.T, sandboxProvider string) {
 	issue := jira.createIssue(ctx, t, env.JiraProjectKey, labelName, "Tell a dad joke. Do not make a PR.", "Tell a dad joke. Do not make a PR.\n\nElasticClaw E2E run: "+env.RunID)
 	issueKey = issue.Key
 	before := jira.getIssue(ctx, t, issueKey)
-	if env.JiraInitialState != "" && !strings.EqualFold(before.Fields.Status.Name, env.JiraInitialState) {
-		jira.transitionIssue(ctx, t, issueKey, env.JiraInitialState)
+	if !strings.EqualFold(before.Fields.Status.Name, jiraE2EInitialState) {
+		jira.transitionIssue(ctx, t, issueKey, jiraE2EInitialState)
 		before = jira.getIssue(ctx, t, issueKey)
 	}
-	jira.transitionIssue(ctx, t, issueKey, env.JiraTriggerState)
+	jira.transitionIssue(ctx, t, issueKey, jiraE2ETriggerState)
 	after := jira.getIssue(ctx, t, issueKey)
 
 	if jiraManualWebhookDelivery() {
-		payload := jiraWebhookPayloadForE2E(after, before.Fields.Status.Name, env.JiraTriggerState, env.RunID)
+		payload := jiraWebhookPayloadForE2E(after, before.Fields.Status.Name, jiraE2ETriggerState, env.RunID)
 		jira.postElasticClawWebhook(ctx, t, env.PublicURL+"/api/workspaces/"+workspaceName+"/webhooks/jira", webhookSecret, payload)
 	}
 
@@ -166,7 +172,7 @@ stages:
 
         Do exactly what this issue asks.
         Do not create a pull request.
-`, workflowName, env.JiraProjectKey, env.JiraTriggerState, labelName, env.RunID))
+`, workflowName, env.JiraProjectKey, jiraE2ETriggerState, labelName, env.RunID))
 	return root
 }
 
@@ -205,7 +211,7 @@ func (c jiraClient) createIssue(ctx context.Context, t *testing.T, projectKey, l
 	body := map[string]any{
 		"fields": map[string]any{
 			"project":     map[string]string{"key": projectKey},
-			"issuetype":   map[string]string{"name": envOrDefault("ELASTICCLAW_E2E_JIRA_ISSUE_TYPE", "Task")},
+			"issuetype":   map[string]string{"name": jiraE2EIssueType},
 			"summary":     summary,
 			"description": jiraADFDocument(description),
 			"labels":      []string{labelName},

--- a/test/e2e/jira_test.go
+++ b/test/e2e/jira_test.go
@@ -289,11 +289,12 @@ func (c jiraClient) postElasticClawWebhook(ctx context.Context, t *testing.T, we
 	if err != nil {
 		t.Fatalf("marshal Jira webhook payload: %v", err)
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, webhookURL+"?secret="+url.QueryEscape(secret), bytes.NewReader(data))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, webhookURL, bytes.NewReader(data))
 	if err != nil {
 		t.Fatalf("build Jira webhook request: %v", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-ElasticClaw-Webhook-Secret", secret)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("post Jira webhook: %v", err)

--- a/test/e2e/jira_test.go
+++ b/test/e2e/jira_test.go
@@ -22,6 +22,7 @@ const (
 	jiraE2EIssueType    = "Bug"
 	jiraE2EInitialState = "To do"
 	jiraE2ETriggerState = "Ready for Agent"
+	jiraE2EWorkingState = "Agent Working"
 )
 
 func TestDaytonaJiraWorkflowE2E(t *testing.T) {
@@ -116,6 +117,7 @@ func runJiraWorkflowE2E(t *testing.T, sandboxProvider string) {
 	}
 
 	agentID = waitForOneAgent(ctx, t, hub, issueKey)
+	jira.waitForIssueStatus(ctx, t, issueKey, jiraE2EWorkingState)
 	waitForAgentStatus(ctx, t, hub, agentID, "connected")
 	waitForAgentReply(ctx, t, hub, agentID)
 
@@ -160,6 +162,7 @@ trigger:
       - %s
 
 concurrency_group: e2e-jira-%s
+working_status: %s
 
 stages:
   - id: working
@@ -172,7 +175,7 @@ stages:
 
         Do exactly what this issue asks.
         Do not create a pull request.
-`, workflowName, env.JiraProjectKey, jiraE2ETriggerState, labelName, env.RunID))
+`, workflowName, env.JiraProjectKey, jiraE2ETriggerState, labelName, env.RunID, jiraE2EWorkingState))
 	return root
 }
 
@@ -263,6 +266,21 @@ func (c jiraClient) transitionIssue(ctx context.Context, t *testing.T, key, targ
 	c.api(ctx, t, http.MethodPost, "/rest/api/3/issue/"+url.PathEscape(key)+"/transitions", map[string]any{
 		"transition": map[string]string{"id": transitionID},
 	}, nil)
+}
+
+func (c jiraClient) waitForIssueStatus(ctx context.Context, t *testing.T, key, targetStatus string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Minute)
+	var lastStatus string
+	for time.Now().Before(deadline) {
+		issue := c.getIssue(ctx, t, key)
+		lastStatus = issue.Fields.Status.Name
+		if strings.EqualFold(lastStatus, targetStatus) {
+			return
+		}
+		time.Sleep(2 * time.Second)
+	}
+	t.Fatalf("timed out waiting for Jira issue %s status %q; last status %q", key, targetStatus, lastStatus)
 }
 
 func (c jiraClient) deleteIssue(ctx context.Context, key string) error {

--- a/test/e2e/jira_test.go
+++ b/test/e2e/jira_test.go
@@ -1,0 +1,400 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDaytonaJiraWorkflowE2E(t *testing.T) {
+	runJiraWorkflowE2E(t, "daytona")
+}
+
+func TestReplicatedJiraWorkflowE2E(t *testing.T) {
+	runJiraWorkflowE2E(t, "replicated")
+}
+
+func runJiraWorkflowE2E(t *testing.T, sandboxProvider string) {
+	runID := e2eRunID()
+	env := newE2EEnv(t, runID, sandboxProvider)
+	env.JiraBaseURL = strings.TrimRight(requiredEnv(t, "ELASTICCLAW_E2E_JIRA_BASE_URL"), "/")
+	env.JiraUsername = requiredEnv(t, "ELASTICCLAW_E2E_JIRA_USERNAME")
+	env.JiraToken = requiredEnv(t, "ELASTICCLAW_E2E_JIRA_TOKEN")
+	env.JiraProjectKey = requiredEnv(t, "ELASTICCLAW_E2E_JIRA_PROJECT_KEY")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Minute)
+	defer cancel()
+
+	workspaceName := "e2e-jira-" + env.RunID
+	workflowName := "jira-" + env.RunID
+	labelName := "elasticclaw-e2e-" + env.RunID
+	webhookSecret := "jira-e2e-secret-" + env.RunID
+
+	cleanupProvider(ctx, t, env)
+	hub := startHub(ctx, t, env)
+	root := writeJiraWorkspaceFixture(t, env, workspaceName, workflowName, labelName)
+	keyPath := writeGitHubAppPrivateKey(t, root, env.GitHubAppPrivateKey)
+	jira := jiraClient{baseURL: env.JiraBaseURL, username: env.JiraUsername, token: env.JiraToken}
+
+	var issueKey string
+	var agentID string
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 4*time.Minute)
+		defer cleanupCancel()
+		var provider, providerID string
+		if agentID != "" {
+			provider, providerID = hub.agentProvider(cleanupCtx, t, agentID)
+			_ = hub.deleteAgent(cleanupCtx, agentID)
+		}
+		if providerID != "" {
+			destroyProviderInstanceByID(cleanupCtx, t, env, provider, providerID)
+		}
+	})
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 4*time.Minute)
+		defer cleanupCancel()
+		cleanupProvider(cleanupCtx, t, env)
+	})
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 4*time.Minute)
+		defer cleanupCancel()
+		if issueKey != "" {
+			_ = jira.deleteIssue(cleanupCtx, issueKey)
+		}
+		_ = hub.deleteWorkspace(cleanupCtx, workspaceName)
+	})
+
+	runCLI(ctx, t, root, env, "workspace", "push", workspaceName)
+	runCLI(ctx, t, root, env, "github-app", "create", "e2e",
+		"--workspace", workspaceName,
+		"--app-id", env.GitHubAppID,
+		"--url", env.GitHubAppURL,
+		"--installation", env.GitHubInstallation,
+		"--private-key-file", keyPath,
+	)
+	hub.putIssueTrackerWithConfig(ctx, t, workspaceName, map[string]string{
+		"type":          "jira",
+		"workspace":     "default",
+		"baseUrl":       env.JiraBaseURL,
+		"username":      env.JiraUsername,
+		"token":         env.JiraToken,
+		"webhookSecret": webhookSecret,
+	})
+	runCLI(ctx, t, root, env, "workflow", "push", "--workspace", workspaceName, filepath.Join(root, ".elasticclaw", "workflows", "jira.yaml"))
+
+	issue := jira.createIssue(ctx, t, env.JiraProjectKey, labelName, "Tell a dad joke. Do not make a PR.", "Tell a dad joke. Do not make a PR.\n\nElasticClaw E2E run: "+env.RunID)
+	issueKey = issue.Key
+	before := jira.getIssue(ctx, t, issueKey)
+	if env.JiraInitialState != "" && !strings.EqualFold(before.Fields.Status.Name, env.JiraInitialState) {
+		jira.transitionIssue(ctx, t, issueKey, env.JiraInitialState)
+		before = jira.getIssue(ctx, t, issueKey)
+	}
+	jira.transitionIssue(ctx, t, issueKey, env.JiraTriggerState)
+	after := jira.getIssue(ctx, t, issueKey)
+
+	if jiraManualWebhookDelivery() {
+		payload := jiraWebhookPayloadForE2E(after, before.Fields.Status.Name, env.JiraTriggerState, env.RunID)
+		jira.postElasticClawWebhook(ctx, t, env.PublicURL+"/api/workspaces/"+workspaceName+"/webhooks/jira", webhookSecret, payload)
+	}
+
+	agentID = waitForOneAgent(ctx, t, hub, issueKey)
+	waitForAgentStatus(ctx, t, hub, agentID, "connected")
+	waitForAgentReply(ctx, t, hub, agentID)
+
+	if jiraManualWebhookDelivery() {
+		waitForSingleAgentToRemain(ctx, t, hub, issueKey, 40*time.Second)
+	}
+}
+
+func writeJiraWorkspaceFixture(t *testing.T, env e2eEnv, workspaceName, workflowName, labelName string) string {
+	t.Helper()
+	root := t.TempDir()
+	workspaceDir := filepath.Join(root, ".elasticclaw", "workspaces", workspaceName)
+	workflowDir := filepath.Join(root, ".elasticclaw", "workflows")
+	if err := os.MkdirAll(workspaceDir, 0750); err != nil {
+		t.Fatalf("mkdir workspace fixture: %v", err)
+	}
+	if err := os.MkdirAll(workflowDir, 0750); err != nil {
+		t.Fatalf("mkdir workflow fixture: %v", err)
+	}
+	writeFile(t, filepath.Join(workspaceDir, "elasticclaw-config.yaml"), fmt.Sprintf(`schema_version: v1
+name: %s
+provider: %s
+repositories:
+  - repo: %s
+    permissions: write
+`, workspaceName, env.SandboxProvider, env.GitHubRepo))
+	writeFile(t, filepath.Join(workspaceDir, "AGENTS.md"), "You are an ElasticClaw E2E agent. Keep responses concise.\n")
+	writeFile(t, filepath.Join(workspaceDir, "TOOLS.md"), "Use tools only when the issue asks for them.\n")
+	writeFile(t, filepath.Join(workspaceDir, "CONTEXT.md"), "This is an ElasticClaw Jira E2E test. Follow the Jira issue exactly.\n")
+	writeFile(t, filepath.Join(workflowDir, "jira.yaml"), fmt.Sprintf(`schema_version: v1
+name: %s
+
+trigger:
+  jira:
+    event: status_changed
+    workspace: default
+    projects:
+      - %s
+    states:
+      - %s
+    labels:
+      - %s
+
+concurrency_group: e2e-jira-%s
+
+stages:
+  - id: working
+    label: Working
+    entry: true
+    on_enter:
+      inject: |
+        Issue: {{.Issue.Identifier}} - {{.Issue.Title}}
+        URL: {{.Issue.URL}}
+
+        Do exactly what this issue asks.
+        Do not create a pull request.
+`, workflowName, env.JiraProjectKey, env.JiraTriggerState, labelName, env.RunID))
+	return root
+}
+
+type jiraClient struct {
+	baseURL  string
+	username string
+	token    string
+}
+
+type jiraE2EIssue struct {
+	ID     string `json:"id"`
+	Key    string `json:"key"`
+	Self   string `json:"self"`
+	Fields struct {
+		Summary     string   `json:"summary"`
+		Description any      `json:"description"`
+		Labels      []string `json:"labels"`
+		Updated     string   `json:"updated"`
+		Status      struct {
+			Name string `json:"name"`
+		} `json:"status"`
+		Project struct {
+			Key  string `json:"key"`
+			Name string `json:"name"`
+		} `json:"project"`
+		Assignee *struct {
+			AccountID    string `json:"accountId"`
+			DisplayName  string `json:"displayName"`
+			EmailAddress string `json:"emailAddress"`
+		} `json:"assignee"`
+	} `json:"fields"`
+}
+
+func (c jiraClient) createIssue(ctx context.Context, t *testing.T, projectKey, labelName, summary, description string) jiraE2EIssue {
+	t.Helper()
+	body := map[string]any{
+		"fields": map[string]any{
+			"project":     map[string]string{"key": projectKey},
+			"issuetype":   map[string]string{"name": envOrDefault("ELASTICCLAW_E2E_JIRA_ISSUE_TYPE", "Task")},
+			"summary":     summary,
+			"description": jiraADFDocument(description),
+			"labels":      []string{labelName},
+		},
+	}
+	var out jiraE2EIssue
+	c.api(ctx, t, http.MethodPost, "/rest/api/3/issue", body, &out)
+	if out.Key == "" {
+		t.Fatalf("Jira issueCreate did not return an issue key")
+	}
+	return out
+}
+
+func (c jiraClient) getIssue(ctx context.Context, t *testing.T, key string) jiraE2EIssue {
+	t.Helper()
+	var out jiraE2EIssue
+	c.api(ctx, t, http.MethodGet, "/rest/api/3/issue/"+url.PathEscape(key)+"?fields=summary,description,status,labels,assignee,project,updated", nil, &out)
+	if out.Key == "" {
+		t.Fatalf("Jira issue %q did not return an issue key", key)
+	}
+	return out
+}
+
+func (c jiraClient) transitionIssue(ctx context.Context, t *testing.T, key, targetStatus string) {
+	t.Helper()
+	if strings.TrimSpace(targetStatus) == "" {
+		return
+	}
+	var transitions struct {
+		Transitions []struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+			To   struct {
+				Name string `json:"name"`
+			} `json:"to"`
+		} `json:"transitions"`
+	}
+	c.api(ctx, t, http.MethodGet, "/rest/api/3/issue/"+url.PathEscape(key)+"/transitions", nil, &transitions)
+	transitionID := ""
+	for _, transition := range transitions.Transitions {
+		if strings.EqualFold(transition.Name, targetStatus) || strings.EqualFold(transition.To.Name, targetStatus) {
+			transitionID = transition.ID
+			break
+		}
+	}
+	if transitionID == "" {
+		t.Fatalf("Jira issue %s has no transition to status %q", key, targetStatus)
+	}
+	c.api(ctx, t, http.MethodPost, "/rest/api/3/issue/"+url.PathEscape(key)+"/transitions", map[string]any{
+		"transition": map[string]string{"id": transitionID},
+	}, nil)
+}
+
+func (c jiraClient) deleteIssue(ctx context.Context, key string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.baseURL+"/rest/api/3/issue/"+url.PathEscape(key), nil)
+	if err != nil {
+		return err
+	}
+	c.applyAuth(req)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 && resp.StatusCode != http.StatusNotFound {
+		data, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("delete Jira issue: %s: %s", resp.Status, strings.TrimSpace(string(data)))
+	}
+	return nil
+}
+
+func (c jiraClient) postElasticClawWebhook(ctx context.Context, t *testing.T, webhookURL, secret string, body map[string]any) {
+	t.Helper()
+	data, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal Jira webhook payload: %v", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, webhookURL+"?secret="+url.QueryEscape(secret), bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("build Jira webhook request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post Jira webhook: %v", err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 300 {
+		t.Fatalf("Jira webhook returned %s: %s", resp.Status, strings.TrimSpace(string(respBody)))
+	}
+}
+
+func (c jiraClient) api(ctx context.Context, t *testing.T, method, path string, body interface{}, out interface{}) {
+	t.Helper()
+	var reader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal Jira %s %s: %v", method, path, err)
+		}
+		reader = bytes.NewReader(data)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reader)
+	if err != nil {
+		t.Fatalf("build Jira %s %s: %v", method, path, err)
+	}
+	c.applyAuth(req)
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Jira %s %s: %v", method, path, err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 300 {
+		t.Fatalf("Jira %s %s returned %s: %s", method, path, resp.Status, strings.TrimSpace(string(respBody)))
+	}
+	if out != nil {
+		if err := json.Unmarshal(respBody, out); err != nil {
+			t.Fatalf("decode Jira %s %s: %v\n%s", method, path, err, string(respBody))
+		}
+	}
+}
+
+func (c jiraClient) applyAuth(req *http.Request) {
+	req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(c.username+":"+c.token)))
+}
+
+func jiraADFDocument(text string) map[string]any {
+	return map[string]any{
+		"type":    "doc",
+		"version": 1,
+		"content": []map[string]any{{
+			"type": "paragraph",
+			"content": []map[string]string{{
+				"type": "text",
+				"text": text,
+			}},
+		}},
+	}
+}
+
+func jiraWebhookPayloadForE2E(issue jiraE2EIssue, previousStatus, currentStatus, runID string) map[string]any {
+	user := map[string]any{"displayName": "ElasticClaw E2E"}
+	if issue.Fields.Assignee != nil {
+		user = map[string]any{
+			"accountId":    issue.Fields.Assignee.AccountID,
+			"displayName":  issue.Fields.Assignee.DisplayName,
+			"emailAddress": issue.Fields.Assignee.EmailAddress,
+		}
+	}
+	return map[string]any{
+		"webhookEvent": "jira:issue_updated",
+		"timestamp":    time.Now().UnixMilli(),
+		"user":         user,
+		"issue":        issue,
+		"changelog": map[string]any{
+			"id": "elasticclaw-e2e-" + runID,
+			"items": []map[string]string{{
+				"field":      "status",
+				"fromString": previousStatus,
+				"toString":   currentStatus,
+			}},
+		},
+	}
+}
+
+func jiraManualWebhookDelivery() bool {
+	value := strings.TrimSpace(os.Getenv("ELASTICCLAW_E2E_JIRA_MANUAL_WEBHOOK"))
+	return value == "" || strings.EqualFold(value, "1") || strings.EqualFold(value, "true")
+}
+
+func waitForSingleAgentToRemain(ctx context.Context, t *testing.T, hub *hubProcess, name string, duration time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(duration)
+	for time.Now().Before(deadline) {
+		count := 0
+		for _, agent := range hub.listAgents(ctx, t) {
+			if agent.Name == name {
+				count++
+			}
+		}
+		if count != 1 {
+			t.Fatalf("found %d agents named %s after Jira poller ran, want exactly 1", count, name)
+		}
+		time.Sleep(5 * time.Second)
+	}
+}

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -86,6 +86,7 @@ interface SettingsData {
     linear?: Array<{ workspace: string; tokenSet: boolean; webhookSecretSet: boolean }>
     shortcut?: Array<{ workspace: string; tokenSet: boolean }>
     githubIssues?: Array<{ workspace: string; tokenSet: boolean; webhookSecretSet: boolean }>
+    jira?: Array<{ workspace: string; baseUrl?: string; username?: string; tokenSet: boolean; webhookSecretSet: boolean }>
   }
   secrets?: string[]
   mcpServers?: Array<{
@@ -1939,12 +1940,14 @@ function AuthenticationSection({ settings, onSave, saving }: { settings: Setting
     </div>
   )
 }
-type TrackerType = "linear" | "shortcut" | "github-issues"
+type TrackerType = "linear" | "shortcut" | "github-issues" | "jira"
 
 interface TrackerItem {
   type: TrackerType
   workspace: string
   tokenSet: boolean
+  baseUrl?: string
+  username?: string
 }
 
 function IntegrationsSection({ settings, onSave, saving, selectedWorkspace, hubPublicUrl }: { settings: SettingsData; onSave: (p: object) => void; saving: boolean; selectedWorkspace: string; hubPublicUrl: string }) {
@@ -1958,6 +1961,7 @@ function IntegrationsSection({ settings, onSave, saving, selectedWorkspace, hubP
   const linear = workspaceTrackers.filter(t => t.type === "linear")
   const shortcut = workspaceTrackers.filter(t => t.type === "shortcut")
   const githubIssues = workspaceTrackers.filter(t => t.type === "github-issues")
+  const jira = workspaceTrackers.filter(t => t.type === "jira")
 
   const allTrackers: TrackerItem[] = workspaceTrackers
 
@@ -2009,6 +2013,8 @@ function IntegrationsSection({ settings, onSave, saving, selectedWorkspace, hubP
   const [modalType, setModalType] = useState<TrackerType>("linear")
   const [editIdx, setEditIdx] = useState<number | null>(null)
   const [editType, setEditType] = useState<TrackerType>("linear")
+  const [baseUrl, setBaseUrl] = useState("")
+  const [username, setUsername] = useState("")
   const [token, setToken] = useState("")
   const [webhookSecret, setWebhookSecret] = useState("")
   const [copiedSetup, setCopiedSetup] = useState<string | null>(null)
@@ -2030,7 +2036,7 @@ function IntegrationsSection({ settings, onSave, saving, selectedWorkspace, hubP
   }, [showAddMenu])
 
   const resetModal = () => {
-    setToken(""); setWebhookSecret(""); setEditIdx(null); setEditType("linear"); setSetupTab("token")
+    setBaseUrl(""); setUsername(""); setToken(""); setWebhookSecret(""); setEditIdx(null); setEditType("linear"); setSetupTab("token")
   }
 
   const openAdd = (type: TrackerType) => {
@@ -2043,6 +2049,8 @@ function IntegrationsSection({ settings, onSave, saving, selectedWorkspace, hubP
 
   const openEdit = (tracker: TrackerItem, idx: number) => {
     setToken("")
+    setBaseUrl(tracker.baseUrl || "")
+    setUsername(tracker.username || "")
     setWebhookSecret("")
     setEditIdx(idx)
     setEditType(tracker.type)
@@ -2055,13 +2063,17 @@ function IntegrationsSection({ settings, onSave, saving, selectedWorkspace, hubP
     if (modalMode === "add" && !token.trim()) return
 
     const type = modalMode === "add" ? modalType : editType
+    if (type === "jira" && !baseUrl.trim()) {
+      setError("Jira base URL is required")
+      return
+    }
     const trackerWorkspace = selectedWorkspace
     const originalWorkspace = modalMode === "edit" && editIdx !== null ? allTrackers[editIdx]?.workspace : ""
     setError("")
     const res = await fetch(`${hubUrl}${issueTrackersPath}`, {
       method: "PUT",
       headers: { Authorization: `Bearer ${authToken()}`, "Content-Type": "application/json" },
-      body: JSON.stringify({ type, workspace: trackerWorkspace, originalWorkspace, token: token.trim(), webhookSecret: webhookSecret.trim() }),
+      body: JSON.stringify({ type, workspace: trackerWorkspace, originalWorkspace, baseUrl: baseUrl.trim(), username: username.trim(), token: token.trim(), webhookSecret: webhookSecret.trim() }),
     })
     if (!res.ok) {
       setError(await res.text())
@@ -2095,6 +2107,7 @@ function IntegrationsSection({ settings, onSave, saving, selectedWorkspace, hubP
       case "linear": return "Linear"
       case "shortcut": return "Shortcut"
       case "github-issues": return "GitHub Issues"
+      case "jira": return "Jira"
     }
   }
 
@@ -2106,6 +2119,8 @@ function IntegrationsSection({ settings, onSave, saving, selectedWorkspace, hubP
     ? <Zap className="size-4" />
     : (modalMode === "add" ? modalType : editType) === "shortcut"
     ? <span className="text-[#F4603C]">⚡</span>
+    : (modalMode === "add" ? modalType : editType) === "jira"
+    ? <span className="text-[#0052CC] font-semibold text-sm">J</span>
     : <Github className="size-4" />
 
   const githubIssuesTokenParams = new URLSearchParams({
@@ -2125,12 +2140,15 @@ function IntegrationsSection({ settings, onSave, saving, selectedWorkspace, hubP
     ? <>Use a Shortcut API token from Shortcut settings. The token lets ElasticClaw read and update stories.</>
     : (modalMode === "add" ? modalType : editType) === "github-issues"
     ? <>Use a <a href={githubIssuesTokenUrl} target="_blank" rel="noopener noreferrer" className="underline">fine-grained GitHub PAT</a> for issue API actions. {githubOwnerHint ? <>The link starts with <code>{githubOwnerHint}</code> as the resource owner. </> : null}Grant repository access to the repos this workspace watches.</>
+    : (modalMode === "add" ? modalType : editType) === "jira"
+    ? <>Use a Jira personal access token or API token with issue read/write permissions.</>
     : null
   const activeTrackerType = modalMode === "add" ? modalType : editType
-  const canGenerateWebhookSecret = activeTrackerType === "github-issues" || activeTrackerType === "shortcut"
+  const canGenerateWebhookSecret = activeTrackerType === "github-issues" || activeTrackerType === "shortcut" || activeTrackerType === "jira"
   const workspaceWebhookBase = hubPublicUrl || hubUrl
   const linearWebhookUrl = `${workspaceWebhookBase}/api/workspaces/${encodeURIComponent(selectedWorkspace)}/webhooks/linear`
   const githubIssuesWebhookUrl = `${workspaceWebhookBase}/api/workspaces/${encodeURIComponent(selectedWorkspace)}/webhooks/github-issues`
+  const jiraWebhookUrl = `${workspaceWebhookBase}/api/workspaces/${encodeURIComponent(selectedWorkspace)}/webhooks/jira`
 
   function generateWebhookSecret() {
     const bytes = new Uint8Array(32)
@@ -2165,6 +2183,9 @@ function IntegrationsSection({ settings, onSave, saving, selectedWorkspace, hubP
           {githubIssues.length > 0 && (
             <span className="text-xs bg-muted text-muted-foreground px-1.5 py-0.5 rounded">GitHub Issues: {githubIssues.length}</span>
           )}
+          {jira.length > 0 && (
+            <span className="text-xs bg-muted text-muted-foreground px-1.5 py-0.5 rounded">Jira: {jira.length}</span>
+          )}
         </div>
       </div>
 
@@ -2186,6 +2207,8 @@ function IntegrationsSection({ settings, onSave, saving, selectedWorkspace, hubP
                   <Zap className="size-4 text-muted-foreground" />
                 ) : tracker.type === "shortcut" ? (
                   <span className="text-[#F4603C]">⚡</span>
+                ) : tracker.type === "jira" ? (
+                  <span className="text-[#0052CC] font-semibold text-sm">J</span>
                 ) : (
                   <Github className="size-4 text-muted-foreground" />
                 )}
@@ -2193,6 +2216,12 @@ function IntegrationsSection({ settings, onSave, saving, selectedWorkspace, hubP
                   <p className="text-sm font-medium">{tracker.workspace}</p>
                   <div className="flex items-center gap-1.5 mt-0.5">
                     <span className="text-xs text-muted-foreground capitalize">{tracker.type === "github-issues" ? "github issues" : tracker.type}</span>
+                    {tracker.type === "jira" && tracker.baseUrl ? (
+                      <>
+                        <span className="text-xs text-muted-foreground">·</span>
+                        <span className="text-xs text-muted-foreground">{tracker.baseUrl}</span>
+                      </>
+                    ) : null}
                     <span className="text-xs text-muted-foreground">·</span>
                     {tracker.tokenSet ? (
                       <span className="text-xs text-green-400 flex items-center gap-1">
@@ -2248,6 +2277,13 @@ function IntegrationsSection({ settings, onSave, saving, selectedWorkspace, hubP
             >
               <Github className="size-4" />
               <span>GitHub Issues</span>
+            </button>
+            <button
+              onClick={() => openAdd("jira")}
+              className="w-full flex items-center gap-2 px-3 py-2 text-sm hover:bg-muted transition-colors text-left"
+            >
+              <span className="text-[#0052CC] font-semibold text-sm">J</span>
+              <span>Jira</span>
             </button>
           </div>
         )}
@@ -2359,6 +2395,11 @@ function IntegrationsSection({ settings, onSave, saving, selectedWorkspace, hubP
                   <p>Connect Shortcut for this workspace. The API token lets ElasticClaw read stories and update workflow states.</p>
                   <p>Create a Shortcut webhook using the Shortcut URL from the Webhooks page. If Shortcut signs the payload with a secret, paste that same secret below.</p>
                 </div>
+              ) : activeTrackerType === "jira" ? (
+                <div className="space-y-2 text-sm text-muted-foreground">
+                  <p>Connect Jira for this workspace. The token lets ElasticClaw read issues, add comments, and transition statuses.</p>
+                  <p>Create a Jira webhook for issue created and issue updated events, then use the payload URL below.</p>
+                </div>
               ) : (
                 <p className="text-sm text-muted-foreground">
                   Connect {trackerTypeLabel(activeTrackerType)} for this workspace.
@@ -2366,6 +2407,29 @@ function IntegrationsSection({ settings, onSave, saving, selectedWorkspace, hubP
               )}
               {activeTrackerType !== "github-issues" && activeTrackerType !== "linear" && (
                 <>
+              {activeTrackerType === "jira" && (
+                <>
+                  <div>
+                    <label className="text-xs text-muted-foreground mb-1 block">Jira Base URL</label>
+                    <Input value={baseUrl} onChange={e => setBaseUrl(e.target.value)} className="h-9 text-sm" placeholder="https://jira.example.com" />
+                  </div>
+                  <div>
+                    <label className="text-xs text-muted-foreground mb-1 block">Username <span className="text-muted-foreground/60">(optional)</span></label>
+                    <Input value={username} onChange={e => setUsername(e.target.value)} className="h-9 text-sm" placeholder="admin@example.com" />
+                    <p className="text-xs text-muted-foreground mt-1">Set for basic auth. Leave blank to send the token as a bearer token.</p>
+                  </div>
+                  <div>
+                    <label className="text-xs text-muted-foreground mb-1 block">Payload URL</label>
+                    <div className="flex gap-2">
+                      <Input readOnly value={jiraWebhookUrl} className="h-9 text-xs font-mono" />
+                      <Button type="button" size="sm" variant="outline" onClick={() => copySetupValue(jiraWebhookUrl, "jira-url")}>
+                        {copiedSetup === "jira-url" ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+                      </Button>
+                    </div>
+                    <p className="text-xs text-muted-foreground mt-1">Use this URL for Jira issue created and issue updated webhooks.</p>
+                  </div>
+                </>
+              )}
               <div>
                 <label className="text-xs text-muted-foreground mb-1 block">API Token</label>
                 <Input type="password" value={token} onChange={e => setToken(e.target.value)} className="h-9 text-sm" placeholder={`${trackerTypeLabel(activeTrackerType)} API token`} />
@@ -2384,6 +2448,8 @@ function IntegrationsSection({ settings, onSave, saving, selectedWorkspace, hubP
                 <p className="text-xs text-muted-foreground mt-1">
                   {activeTrackerType === "shortcut"
                     ? "Generate one here, then use the same value when configuring the Shortcut webhook signature secret."
+                    : activeTrackerType === "jira"
+                    ? "Generate one here, then add it to the Jira webhook URL as a secret query parameter or send it in X-ElasticClaw-Webhook-Secret."
                     : "Used to verify incoming webhook signatures. Leave blank to keep existing."}
                 </p>
               </div>
@@ -2398,7 +2464,7 @@ function IntegrationsSection({ settings, onSave, saving, selectedWorkspace, hubP
               )}
               <div className="flex items-center gap-2 ml-auto">
                 <Button size="sm" variant="outline" onClick={() => { setShowModal(false); resetModal() }}>Cancel</Button>
-                <Button size="sm" disabled={saving || (modalMode === "add" && !token.trim())} onClick={saveTracker}>
+                <Button size="sm" disabled={saving || (modalMode === "add" && !token.trim()) || (activeTrackerType === "jira" && !baseUrl.trim())} onClick={saveTracker}>
                   {modalMode === "add" ? "Add tracker" : "Save changes"}
                 </Button>
               </div>
@@ -2431,6 +2497,11 @@ function WebhooksSection({ hubUrl, selectedWorkspace }: { hubUrl: string; select
       name: "GitHub Issues",
       url: workspaceWebhookBase ? `${workspaceWebhookBase}/github-issues` : "",
       hint: "Use in GitHub repo or org settings. Subscribe to: Issues events.",
+    },
+    {
+      name: "Jira",
+      url: workspaceWebhookBase ? `${workspaceWebhookBase}/jira` : "",
+      hint: "Use in Jira webhook settings. Subscribe to issue created and issue updated events.",
     },
     {
       name: "GitHub (PRs)",

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -2449,7 +2449,7 @@ function IntegrationsSection({ settings, onSave, saving, selectedWorkspace, hubP
                   {activeTrackerType === "shortcut"
                     ? "Generate one here, then use the same value when configuring the Shortcut webhook signature secret."
                     : activeTrackerType === "jira"
-                    ? "Generate one here, then add it to the Jira webhook URL as a secret query parameter or send it in X-ElasticClaw-Webhook-Secret."
+                    ? "Generate one here, then send it in the X-ElasticClaw-Webhook-Secret header."
                     : "Used to verify incoming webhook signatures. Leave blank to keep existing."}
                 </p>
               </div>


### PR DESCRIPTION
## Summary
- add Jira as a first-class issue tracker with workflow schema, managed tracker settings, DB storage, webhooks, polling recovery, status transitions, comments, and token injection
- add Jira tracker configuration to the settings UI and webhook copy list
- document the intended gated Jira Software container E2E path

## Tests
- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./pkg/types ./pkg/hub
- npm run build

## Notes
- Jira webhook validation supports a shared secret via the `secret` query parameter or `X-ElasticClaw-Webhook-Secret` header because Jira Data Center does not expose the same HMAC webhook contract as GitHub/Shortcut.
- Container-backed Jira E2E remains a follow-up gated job due Jira bootstrap/licensing/startup cost.