### PR TITLE
Update OpenClaw to v2026.6.9

### DIFF
--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -2057,7 +2057,7 @@ echo "Git: $(git --version)"
 	return runShell(script)
 }
 
-const openClawVersion = "2026.6.1"
+const openClawVersion = "2026.6.9"
 
 // installOpenClaw installs the pinned OpenClaw CLI via npm.
 func installOpenClaw() error {

--- a/docker/agent.Dockerfile
+++ b/docker/agent.Dockerfile
@@ -22,7 +22,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
     && rm -rf /var/lib/apt/lists/*
 
 # Pre-install OpenClaw globally so bootstrap skips the npm install step.
-RUN npm install -g openclaw@2026.6.1 --ignore-scripts
+RUN npm install -g openclaw@2026.6.9 --ignore-scripts
 
 # Create the 'claw' user (bridge runs as non-root; bootstrap expects this user)
 RUN useradd -m -s /bin/bash claw \

--- a/pkg/hub/bootstrap_test.go
+++ b/pkg/hub/bootstrap_test.go
@@ -82,20 +82,20 @@ func TestDaytonaAsyncBridgeCommandShellQuotesClawName(t *testing.T) {
 }
 
 func TestDaytonaOpenClawInstallCommands_AreAsyncAndPollable(t *testing.T) {
-	start := daytonaStartOpenClawInstallCommand("2026.6.1")
-	status := daytonaOpenClawInstallStatusCommand("2026.6.1")
+	start := daytonaStartOpenClawInstallCommand("2026.6.9")
+	status := daytonaOpenClawInstallStatusCommand("2026.6.9")
 
 	assertContains(t, start, "setsid nohup bash -c", "install starts in a detached process")
 	assertContains(t, start, "openclaw-install.log", "install writes a log for diagnostics")
 	assertContains(t, start, "openclaw-install.status", "install writes a status marker")
-	assertContains(t, start, "openclaw@2026.6.1", "install pins the expected openclaw version")
+	assertContains(t, start, "openclaw@2026.6.9", "install pins the expected openclaw version")
 	assertContains(t, start, "openclaw-install-status=started", "start command returns quickly after launching")
 
 	assertContains(t, status, "openclaw-install-status=ok", "status reports completion")
 	assertContains(t, status, "openclaw-install-status=pending", "status reports in-progress install")
 	assertContains(t, status, "openclaw-install-status=failed", "status reports failed install")
 	assertContains(t, status, "tail -n 120", "status includes install diagnostics")
-	assertContains(t, status, "openclaw@2026.6.1", "status checks the pinned install process")
+	assertContains(t, status, "openclaw@2026.6.9", "status checks the pinned install process")
 }
 
 func TestBootstrapScript_ConnectorDownloadRetriesWithUserFacingLabel(t *testing.T) {
@@ -742,7 +742,7 @@ for cmd in curl apt-get npm sudo systemctl git gh oras python3 gpg tee chmod mv 
 done
 curl() { echo stub_curl_output; return 0; }
 openclaw() {
-  if [ "$1" = "--version" ]; then echo "OpenClaw 2026.1.0"; fi
+  if [ "$1" = "--version" ]; then echo "OpenClaw 2026.6.9"; fi
   return 0
 }
 `

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2965,7 +2965,7 @@ echo uninstalled`); err != nil {
 		log.Printf("[daytona] warning: uninstall failed (ok if not installed): %v", err)
 	}
 
-	const daytonaOpenClawVersion = "2026.6.1"
+	const daytonaOpenClawVersion = "2026.6.9"
 	if err := exec("start openclaw install", 20*time.Second, daytonaStartOpenClawInstallCommand(daytonaOpenClawVersion)); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
- bump Daytona bootstrap OpenClaw install pin to v2026.6.9
- bump claw-bridge bootstrap OpenClaw install pin to v2026.6.9
- bump Docker agent image preinstalled OpenClaw package to v2026.6.9
- update matching bootstrap tests and stubs

## Test
- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./pkg/hub -run 'TestDaytonaOpenClawInstallCommands|TestGenerateReplicatedBootstrapScript'
- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./cmd/claw-bridge