### PR TITLE
Load Fireworks models dynamically

### DIFF
--- a/pkg/hub/ai_config.go
+++ b/pkg/hub/ai_config.go
@@ -599,7 +599,7 @@ func aiConfigModelForKey(key *types.LLMKeyConfig, defaultModel string) string {
 	case "codex":
 		return "codex/o4-mini"
 	case "fireworks":
-		return "fireworks/accounts/fireworks/models/kimi-k2p6"
+		return defaultFireworksModel
 	case "groq":
 		return "groq/llama-3.3-70b-versatile"
 	case "deepseek":

--- a/pkg/hub/bootstrap_test.go
+++ b/pkg/hub/bootstrap_test.go
@@ -503,7 +503,7 @@ func TestBuildOpenClawProviderConfig_RemovesInvalidModelsCatalogAndStaleK2P5Alia
 	cmd := exec.Command("bash", "-c", snippet)
 	cmd.Env = append(os.Environ(),
 		"HOME="+home,
-		"OPENCLAW_DEFAULT_MODEL=fireworks/accounts/fireworks/models/kimi-k2p6",
+		"OPENCLAW_DEFAULT_MODEL="+defaultFireworksModel,
 		keys[0].EnvVarName()+"=fw-test",
 	)
 	if out, err := cmd.CombinedOutput(); err != nil {
@@ -529,7 +529,7 @@ func TestBuildOpenClawProviderConfig_RemovesInvalidModelsCatalogAndStaleK2P5Alia
 	if !ok {
 		t.Fatalf("agents.defaults missing or wrong type: %#v", agents["defaults"])
 	}
-	if defaults["model"] != "fireworks/accounts/fireworks/models/kimi-k2p6" {
+	if defaults["model"] != defaultFireworksModel {
 		t.Fatalf("default model not patched: %#v", defaults["model"])
 	}
 	agentModels, ok := defaults["models"].(map[string]interface{})

--- a/pkg/hub/external_webhook.go
+++ b/pkg/hub/external_webhook.go
@@ -775,7 +775,7 @@ func resolveDefaultModelForKeyLocal(hubDefaultModel string, key *types.LLMKeyCon
 	case "anthropic":
 		return "anthropic/claude-sonnet-4-6"
 	case "fireworks":
-		return "fireworks/accounts/fireworks/models/kimi-k2p6"
+		return defaultFireworksModel
 	case "openai":
 		return "openai/gpt-5.5"
 	case "groq":

--- a/pkg/hub/failure_summary.go
+++ b/pkg/hub/failure_summary.go
@@ -422,7 +422,7 @@ func modelForFailureSummary(key *types.LLMKeyConfig, defaultModel string) string
 	case "codex":
 		return "codex/o4-mini"
 	case "fireworks":
-		return "fireworks/accounts/fireworks/models/kimi-k2p6"
+		return defaultFireworksModel
 	case "groq":
 		return "groq/llama-3.3-70b-versatile"
 	case "deepseek":

--- a/pkg/hub/fireworks_models.go
+++ b/pkg/hub/fireworks_models.go
@@ -33,6 +33,12 @@ var fallbackFireworksModelOptions = []LLMModelOption{
 	{ID: "__custom", Name: "Custom Fireworks model"},
 }
 
+var (
+	kimiVersionRE          = regexp.MustCompile(`k(?:imi[-_ ]*)?2(?:p|\.)(\d+)`)
+	decimalVersionRE       = regexp.MustCompile(`(?:p|\.)(\d+)`)
+	slugVersionSeparatorRE = regexp.MustCompile(`(\d)p(\d)`)
+)
+
 func (s *Server) fireworksModelOptions(ctx context.Context, apiKey string) []LLMModelOption {
 	fallback := cloneModelOptions(fallbackFireworksModelOptions)
 	apiKey = strings.TrimSpace(apiKey)
@@ -221,8 +227,7 @@ func fireworksModelRank(option LLMModelOption) int {
 }
 
 func parseKimiVersion(value string) int {
-	re := regexp.MustCompile(`k(?:imi[-_ ]*)?2(?:p|\.)(\d+)`)
-	if match := re.FindStringSubmatch(value); len(match) == 2 {
+	if match := kimiVersionRE.FindStringSubmatch(value); len(match) == 2 {
 		n, _ := strconv.Atoi(match[1])
 		return n
 	}
@@ -230,8 +235,7 @@ func parseKimiVersion(value string) int {
 }
 
 func parseDecimalVersion(value string) int {
-	re := regexp.MustCompile(`(?:p|\.)(\d+)`)
-	if match := re.FindStringSubmatch(value); len(match) == 2 {
+	if match := decimalVersionRE.FindStringSubmatch(value); len(match) == 2 {
 		n, _ := strconv.Atoi(match[1])
 		return n
 	}
@@ -244,7 +248,7 @@ func humanizeFireworksModelName(id string) string {
 		return id
 	}
 	slug := parts[len(parts)-1]
-	slug = strings.ReplaceAll(slug, "p", ".")
+	slug = slugVersionSeparatorRE.ReplaceAllString(slug, "$1.$2")
 	words := strings.FieldsFunc(slug, func(r rune) bool {
 		return r == '-' || r == '_'
 	})

--- a/pkg/hub/fireworks_models.go
+++ b/pkg/hub/fireworks_models.go
@@ -1,0 +1,258 @@
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const defaultFireworksModel = "fireworks/accounts/fireworks/models/kimi-k2p7"
+
+type LLMModelOption struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+var fallbackFireworksModelOptions = []LLMModelOption{
+	{ID: defaultFireworksModel, Name: "Kimi K2.7"},
+	{ID: "fireworks/accounts/fireworks/models/glm-5p2", Name: "GLM 5.2"},
+	{ID: "fireworks/accounts/fireworks/models/deepseek-v4-pro", Name: "DeepSeek V4 Pro"},
+	{ID: "fireworks/accounts/fireworks/models/deepseek-v4-flash", Name: "DeepSeek V4 Flash"},
+	{ID: "fireworks/accounts/fireworks/models/minimax-m2p7", Name: "MiniMax M2.7"},
+	{ID: "fireworks/accounts/fireworks/models/qwen3p6-plus", Name: "Qwen3.6 Plus"},
+	{ID: "fireworks/accounts/fireworks/models/gpt-oss-120b", Name: "OpenAI gpt-oss-120b"},
+	{ID: "fireworks/accounts/fireworks/models/gpt-oss-20b", Name: "OpenAI gpt-oss-20b"},
+	{ID: "fireworks/accounts/fireworks/models/llama-v3p3-70b-instruct", Name: "Llama 3.3 70B Instruct"},
+	{ID: "__custom", Name: "Custom Fireworks model"},
+}
+
+func (s *Server) fireworksModelOptions(ctx context.Context, apiKey string) []LLMModelOption {
+	fallback := cloneModelOptions(fallbackFireworksModelOptions)
+	apiKey = strings.TrimSpace(apiKey)
+	if apiKey == "" {
+		return fallback
+	}
+
+	cacheKey := apiKey
+	now := time.Now()
+	s.fireworksModelsMu.Lock()
+	if s.fireworksModelsCacheKey == cacheKey && now.Before(s.fireworksModelsCacheUntil) && len(s.fireworksModelsCache) > 0 {
+		cached := cloneModelOptions(s.fireworksModelsCache)
+		s.fireworksModelsMu.Unlock()
+		return cached
+	}
+	s.fireworksModelsMu.Unlock()
+
+	options, err := s.fetchFireworksModelOptions(ctx, apiKey)
+	if err != nil || len(options) == 0 {
+		return fallback
+	}
+	options = appendCustomModelOption(options, "Custom Fireworks model")
+
+	s.fireworksModelsMu.Lock()
+	s.fireworksModelsCacheKey = cacheKey
+	s.fireworksModelsCache = cloneModelOptions(options)
+	s.fireworksModelsCacheUntil = now.Add(1 * time.Hour)
+	s.fireworksModelsMu.Unlock()
+
+	return options
+}
+
+func (s *Server) fetchFireworksModelOptions(ctx context.Context, apiKey string) ([]LLMModelOption, error) {
+	baseURL := strings.TrimRight(s.fireworksBaseURL, "/")
+	if baseURL == "" {
+		baseURL = "https://api.fireworks.ai"
+	}
+
+	var options []LLMModelOption
+	pageToken := ""
+	for {
+		u, err := url.Parse(baseURL + "/v1/accounts/fireworks/models")
+		if err != nil {
+			return nil, err
+		}
+		q := u.Query()
+		q.Set("pageSize", "200")
+		if pageToken != "" {
+			q.Set("pageToken", pageToken)
+		}
+		u.RawQuery = q.Encode()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+
+		client := &http.Client{Timeout: 10 * time.Second}
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, err
+		}
+
+		var body struct {
+			Models []struct {
+				Name               string `json:"name"`
+				DisplayName        string `json:"displayName"`
+				Public             bool   `json:"public"`
+				ContextLength      int    `json:"contextLength"`
+				SupportsServerless bool   `json:"supportsServerless"`
+				ConversationConfig struct {
+					Style    string `json:"style"`
+					System   string `json:"system"`
+					Template string `json:"template"`
+				} `json:"conversationConfig"`
+			} `json:"models"`
+			NextPageToken string `json:"nextPageToken"`
+		}
+		decodeErr := json.NewDecoder(resp.Body).Decode(&body)
+		resp.Body.Close()
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return nil, fmt.Errorf("fireworks list models returned %d", resp.StatusCode)
+		}
+		if decodeErr != nil {
+			return nil, decodeErr
+		}
+
+		for _, model := range body.Models {
+			if !fireworksModelSupported(model.Public, model.SupportsServerless, model.ContextLength, model.ConversationConfig.Style, model.ConversationConfig.System, model.ConversationConfig.Template) {
+				continue
+			}
+			id := fireworksModelID(model.Name)
+			if id == "" {
+				continue
+			}
+			name := strings.TrimSpace(model.DisplayName)
+			if name == "" {
+				name = humanizeFireworksModelName(id)
+			}
+			options = append(options, LLMModelOption{ID: id, Name: name})
+		}
+
+		pageToken = strings.TrimSpace(body.NextPageToken)
+		if pageToken == "" {
+			break
+		}
+	}
+
+	return sortFireworksModelOptions(dedupeModelOptions(options)), nil
+}
+
+func fireworksModelSupported(public, supportsServerless bool, contextLength int, conversationStyle, conversationSystem, conversationTemplate string) bool {
+	if !public || !supportsServerless || contextLength <= 0 {
+		return false
+	}
+	return strings.TrimSpace(conversationStyle) != "" ||
+		strings.TrimSpace(conversationSystem) != "" ||
+		strings.TrimSpace(conversationTemplate) != ""
+}
+
+func fireworksModelID(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return ""
+	}
+	if strings.HasPrefix(name, "fireworks/") {
+		return name
+	}
+	if strings.HasPrefix(name, "accounts/") {
+		return "fireworks/" + name
+	}
+	return "fireworks/accounts/fireworks/models/" + strings.TrimPrefix(name, "/")
+}
+
+func dedupeModelOptions(options []LLMModelOption) []LLMModelOption {
+	seen := make(map[string]bool, len(options))
+	out := make([]LLMModelOption, 0, len(options))
+	for _, option := range options {
+		if option.ID == "" || seen[option.ID] {
+			continue
+		}
+		seen[option.ID] = true
+		out = append(out, option)
+	}
+	return out
+}
+
+func appendCustomModelOption(options []LLMModelOption, name string) []LLMModelOption {
+	options = dedupeModelOptions(options)
+	for _, option := range options {
+		if option.ID == "__custom" {
+			return options
+		}
+	}
+	return append(options, LLMModelOption{ID: "__custom", Name: name})
+}
+
+func cloneModelOptions(options []LLMModelOption) []LLMModelOption {
+	if len(options) == 0 {
+		return nil
+	}
+	return append([]LLMModelOption(nil), options...)
+}
+
+func sortFireworksModelOptions(options []LLMModelOption) []LLMModelOption {
+	sort.SliceStable(options, func(i, j int) bool {
+		ai, aj := fireworksModelRank(options[i]), fireworksModelRank(options[j])
+		if ai != aj {
+			return ai < aj
+		}
+		return strings.ToLower(options[i].Name) < strings.ToLower(options[j].Name)
+	})
+	return options
+}
+
+func fireworksModelRank(option LLMModelOption) int {
+	normalized := strings.ToLower(option.ID + " " + option.Name)
+	if strings.Contains(normalized, "kimi") {
+		return 0 - parseKimiVersion(normalized)
+	}
+	if strings.Contains(normalized, "glm") {
+		return 100 - parseDecimalVersion(normalized)
+	}
+	return 1000
+}
+
+func parseKimiVersion(value string) int {
+	re := regexp.MustCompile(`k(?:imi[-_ ]*)?2(?:p|\.)(\d+)`)
+	if match := re.FindStringSubmatch(value); len(match) == 2 {
+		n, _ := strconv.Atoi(match[1])
+		return n
+	}
+	return 0
+}
+
+func parseDecimalVersion(value string) int {
+	re := regexp.MustCompile(`(?:p|\.)(\d+)`)
+	if match := re.FindStringSubmatch(value); len(match) == 2 {
+		n, _ := strconv.Atoi(match[1])
+		return n
+	}
+	return 0
+}
+
+func humanizeFireworksModelName(id string) string {
+	parts := strings.Split(strings.TrimSuffix(id, "/"), "/")
+	if len(parts) == 0 {
+		return id
+	}
+	slug := parts[len(parts)-1]
+	slug = strings.ReplaceAll(slug, "p", ".")
+	words := strings.FieldsFunc(slug, func(r rune) bool {
+		return r == '-' || r == '_'
+	})
+	for i, word := range words {
+		if word == "" {
+			continue
+		}
+		words[i] = strings.ToUpper(word[:1]) + word[1:]
+	}
+	return strings.Join(words, " ")
+}

--- a/pkg/hub/fireworks_models_test.go
+++ b/pkg/hub/fireworks_models_test.go
@@ -135,3 +135,17 @@ func TestFireworksModelOptionsFallsBackWithoutAPIKey(t *testing.T) {
 		t.Fatalf("fallback options = %#v", options)
 	}
 }
+
+func TestHumanizeFireworksModelNameOnlyReplacesVersionSeparator(t *testing.T) {
+	tests := map[string]string{
+		"fireworks/accounts/fireworks/models/deepseek-v4-pro": "Deepseek V4 Pro",
+		"fireworks/accounts/fireworks/models/qwen3p6-plus":    "Qwen3.6 Plus",
+		"fireworks/accounts/fireworks/models/gpt-oss-120b":    "Gpt Oss 120b",
+		"fireworks/accounts/fireworks/models/kimi-k2p7":       "Kimi K2.7",
+	}
+	for id, want := range tests {
+		if got := humanizeFireworksModelName(id); got != want {
+			t.Fatalf("humanizeFireworksModelName(%q) = %q, want %q", id, got, want)
+		}
+	}
+}

--- a/pkg/hub/fireworks_models_test.go
+++ b/pkg/hub/fireworks_models_test.go
@@ -1,0 +1,137 @@
+package hub
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func TestFetchFireworksModelOptionsFiltersAndSortsLatestKimi(t *testing.T) {
+	var requests int
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if got := r.Header.Get("Authorization"); got != "Bearer fw-test" {
+			t.Fatalf("authorization = %q", got)
+		}
+		if got := r.URL.Path; got != "/v1/accounts/fireworks/models" {
+			t.Fatalf("path = %q", got)
+		}
+		if got := r.URL.Query().Get("pageSize"); got != "200" {
+			t.Fatalf("pageSize = %q", got)
+		}
+
+		type model struct {
+			Name               string         `json:"name"`
+			DisplayName        string         `json:"displayName,omitempty"`
+			Public             bool           `json:"public"`
+			ContextLength      int            `json:"contextLength"`
+			SupportsServerless bool           `json:"supportsServerless"`
+			ConversationConfig map[string]any `json:"conversationConfig,omitempty"`
+		}
+		resp := map[string]any{}
+		switch r.URL.Query().Get("pageToken") {
+		case "":
+			resp["models"] = []model{
+				{Name: "accounts/fireworks/models/kimi-k2p6", DisplayName: "Kimi K2.6", Public: true, ContextLength: 131072, SupportsServerless: true, ConversationConfig: map[string]any{"template": "{{ .Prompt }}"}},
+				{Name: "accounts/fireworks/models/glm-5p2", DisplayName: "GLM 5.2", Public: true, ContextLength: 131072, SupportsServerless: true, ConversationConfig: map[string]any{"template": "{{ .Prompt }}"}},
+				{Name: "accounts/fireworks/models/private-kimi", DisplayName: "Private Kimi", Public: false, ContextLength: 131072, SupportsServerless: true, ConversationConfig: map[string]any{"template": "{{ .Prompt }}"}},
+				{Name: "accounts/fireworks/models/no-chat-template", DisplayName: "No Chat Template", Public: true, ContextLength: 131072, SupportsServerless: true},
+			}
+			resp["nextPageToken"] = "next"
+		case "next":
+			resp["models"] = []model{
+				{Name: "accounts/fireworks/models/kimi-k2p7", DisplayName: "Kimi K2.7", Public: true, ContextLength: 131072, SupportsServerless: true, ConversationConfig: map[string]any{"template": "{{ .Prompt }}"}},
+				{Name: "accounts/fireworks/models/batch-only", DisplayName: "Batch Only", Public: true, ContextLength: 131072, SupportsServerless: false, ConversationConfig: map[string]any{"template": "{{ .Prompt }}"}},
+			}
+		default:
+			t.Fatalf("unexpected pageToken %q", r.URL.Query().Get("pageToken"))
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Fatal(err)
+		}
+	}))
+	defer api.Close()
+
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{}, "", "", "")
+	s.fireworksBaseURL = api.URL
+
+	options, err := s.fetchFireworksModelOptions(t.Context(), "fw-test")
+	if err != nil {
+		t.Fatalf("fetch options: %v", err)
+	}
+	if requests != 2 {
+		t.Fatalf("requests = %d, want 2", requests)
+	}
+	if len(options) != 3 {
+		t.Fatalf("options = %#v", options)
+	}
+	if options[0].ID != defaultFireworksModel {
+		t.Fatalf("first option = %#v, want latest Kimi", options[0])
+	}
+	if options[1].ID != "fireworks/accounts/fireworks/models/kimi-k2p6" {
+		t.Fatalf("second option = %#v, want previous Kimi", options[1])
+	}
+	if options[2].ID != "fireworks/accounts/fireworks/models/glm-5p2" {
+		t.Fatalf("third option = %#v, want GLM 5.2", options[2])
+	}
+}
+
+func TestGetSettingsIncludesDynamicFireworksModelOptions(t *testing.T) {
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"models": []map[string]any{
+				{
+					"name":               "accounts/fireworks/models/kimi-k2p7",
+					"displayName":        "Kimi K2.7",
+					"public":             true,
+					"contextLength":      131072,
+					"supportsServerless": true,
+					"conversationConfig": map[string]any{"template": "{{ .Prompt }}"},
+				},
+			},
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}))
+	defer api.Close()
+
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{
+		LLMKeys: types.LLMKeysList{
+			{Name: "fireworks-main", Provider: "fireworks", APIKey: "fw-test", Default: true},
+		},
+	}, "", "", "")
+	s.fireworksBaseURL = api.URL
+
+	req := httptest.NewRequest(http.MethodGet, "/api/settings", nil)
+	rec := httptest.NewRecorder()
+	s.getSettings(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var view SettingsView
+	if err := json.NewDecoder(rec.Body).Decode(&view); err != nil {
+		t.Fatal(err)
+	}
+	options := view.ModelOptions["fireworks"]
+	if len(options) != 2 {
+		t.Fatalf("fireworks options = %#v", options)
+	}
+	if options[0].ID != defaultFireworksModel {
+		t.Fatalf("first option = %#v, want dynamic Kimi", options[0])
+	}
+	if options[1].ID != "__custom" {
+		t.Fatalf("last option = %#v, want custom option", options[1])
+	}
+}
+
+func TestFireworksModelOptionsFallsBackWithoutAPIKey(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{}, "", "", "")
+	options := s.fireworksModelOptions(t.Context(), "")
+	if len(options) == 0 || options[0].ID != defaultFireworksModel {
+		t.Fatalf("fallback options = %#v", options)
+	}
+}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -68,6 +68,12 @@ type Server struct {
 	linearBaseURL string
 	// shortcutBaseURL overrides the Shortcut API base for testing (default: https://api.app.shortcut.com)
 	shortcutBaseURL string
+	// fireworksBaseURL overrides the Fireworks API base for testing (default: https://api.fireworks.ai)
+	fireworksBaseURL          string
+	fireworksModelsMu         sync.Mutex
+	fireworksModelsCacheKey   string
+	fireworksModelsCache      []LLMModelOption
+	fireworksModelsCacheUntil time.Time
 
 	// webhookDedup prevents duplicate Linear webhook deliveries from creating
 	// duplicate claws. Keyed by issue transition fingerprint; entries expire after 30s.
@@ -5361,7 +5367,7 @@ func resolveDefaultModelForKey(hubCfg *types.HubConfig, key *types.LLMKeyConfig)
 	case "openai":
 		return "openai/gpt-5.5"
 	case "fireworks":
-		return "fireworks/accounts/fireworks/models/kimi-k2p6"
+		return defaultFireworksModel
 	case "groq":
 		return "groq/llama-3.3-70b-versatile"
 	case "deepseek":

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -178,7 +178,7 @@ func TestResolveDefaultModelForKey(t *testing.T) {
 			key: &types.LLMKeyConfig{
 				Provider: "fireworks",
 			},
-			expectedModel: "fireworks/accounts/fireworks/models/kimi-k2p6",
+			expectedModel: defaultFireworksModel,
 		},
 		{
 			name: "unknown provider - fall back to hub default",

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -33,15 +33,15 @@ type LLMKeyView struct {
 
 // MCPView is the redacted view of an MCP server config for the settings page.
 type MCPView struct {
-	Name      string            `json:"name"`
-	Source    string            `json:"source"`
-	Package   string            `json:"package,omitempty"`
-	Image     string            `json:"image,omitempty"`
-	URL       string            `json:"url,omitempty"`
-	Enabled   bool              `json:"enabled"`
-	Config    map[string]string `json:"config,omitempty"`
-	Secrets   []string          `json:"secrets,omitempty"` // env var names only, not values
-	Command   []string          `json:"command,omitempty"`
+	Name    string            `json:"name"`
+	Source  string            `json:"source"`
+	Package string            `json:"package,omitempty"`
+	Image   string            `json:"image,omitempty"`
+	URL     string            `json:"url,omitempty"`
+	Enabled bool              `json:"enabled"`
+	Config  map[string]string `json:"config,omitempty"`
+	Secrets []string          `json:"secrets,omitempty"` // env var names only, not values
+	Command []string          `json:"command,omitempty"`
 }
 
 // ConcurrencyGroupView is the JSON-safe view of a concurrency group.
@@ -53,15 +53,16 @@ type ConcurrencyGroupView struct {
 // SettingsView is the redacted view of hub config for the settings page.
 // Secrets are masked — never returned in full.
 type SettingsView struct {
-	LLMKeys       []LLMKeyView            `json:"llmKeys"`
-	Providers     map[string]ProviderView `json:"providers"`
-	GitHub        []GitHubAppView         `json:"github"`
-	SSHPublicKeys []string                `json:"sshPublicKeys"`
-	Integrations  *IntegrationsView       `json:"integrations"`
-	Factories     []FactoryView           `json:"factories"`
-	Secrets       []string                `json:"secrets"`
-	MCPServers    []MCPView               `json:"mcpServers,omitempty"`
-	Auth          *AuthView               `json:"auth,omitempty"`
+	LLMKeys       []LLMKeyView                `json:"llmKeys"`
+	ModelOptions  map[string][]LLMModelOption `json:"modelOptions,omitempty"`
+	Providers     map[string]ProviderView     `json:"providers"`
+	GitHub        []GitHubAppView             `json:"github"`
+	SSHPublicKeys []string                    `json:"sshPublicKeys"`
+	Integrations  *IntegrationsView           `json:"integrations"`
+	Factories     []FactoryView               `json:"factories"`
+	Secrets       []string                    `json:"secrets"`
+	MCPServers    []MCPView                   `json:"mcpServers,omitempty"`
+	Auth          *AuthView                   `json:"auth,omitempty"`
 	// ConcurrencyGroups limits simultaneously running claws per group. 0 = unlimited.
 	ConcurrencyGroups []ConcurrencyGroupView `json:"concurrencyGroups"`
 	// MaxConcurrentClaws limits simultaneously running claws. 0 = unlimited.
@@ -118,26 +119,26 @@ func isFactoryEnabled(f *types.FactoryConfig) bool {
 }
 
 type FactoryView struct {
-	Name                string   `json:"name"`
-	Integration         string   `json:"integration"`
-	Workspace           string   `json:"workspace"`
-	Team                string   `json:"team"`
-	TriggerStatus       string   `json:"triggerStatus"`
-	DoneStatus          string   `json:"doneStatus"`
-	TerminateOnLeave    bool     `json:"terminateOnLeave"`
-	Template            string   `json:"template"`
-	NamePattern         string   `json:"namePattern"`
-	WebhookSecretSet    bool     `json:"webhookSecretSet"`
-	WebhookSecretRef    string   `json:"webhookSecretRef,omitempty"`
-	PipelineYAML        string   `json:"pipelineYAML,omitempty"`
-	Tags                []string `json:"tags"`
-	Color               string   `json:"color"`
-	Labels              []string `json:"labels,omitempty"`
-	AssignedTo          string   `json:"assigned_to,omitempty"`
-	Enabled             bool     `json:"enabled"`
-	ConcurrencyGroup    string   `json:"concurrencyGroup,omitempty"`
-	EnableManualTrigger bool     `json:"enable_manual_trigger,omitempty"`
-	SecretRefs          map[string]string `json:"secret_refs,omitempty"`
+	Name                string                 `json:"name"`
+	Integration         string                 `json:"integration"`
+	Workspace           string                 `json:"workspace"`
+	Team                string                 `json:"team"`
+	TriggerStatus       string                 `json:"triggerStatus"`
+	DoneStatus          string                 `json:"doneStatus"`
+	TerminateOnLeave    bool                   `json:"terminateOnLeave"`
+	Template            string                 `json:"template"`
+	NamePattern         string                 `json:"namePattern"`
+	WebhookSecretSet    bool                   `json:"webhookSecretSet"`
+	WebhookSecretRef    string                 `json:"webhookSecretRef,omitempty"`
+	PipelineYAML        string                 `json:"pipelineYAML,omitempty"`
+	Tags                []string               `json:"tags"`
+	Color               string                 `json:"color"`
+	Labels              []string               `json:"labels,omitempty"`
+	AssignedTo          string                 `json:"assigned_to,omitempty"`
+	Enabled             bool                   `json:"enabled"`
+	ConcurrencyGroup    string                 `json:"concurrencyGroup,omitempty"`
+	EnableManualTrigger bool                   `json:"enable_manual_trigger,omitempty"`
+	SecretRefs          map[string]string      `json:"secret_refs,omitempty"`
 	ExternalTrigger     *types.ExternalTrigger `json:"externalTrigger,omitempty"`
 }
 
@@ -153,12 +154,12 @@ type ProviderView struct {
 	DefaultTTL          string `json:"defaultTtl,omitempty"`
 	DefaultInstanceType string `json:"defaultInstanceType,omitempty"`
 	// exe.dev
-	SSHKeySet       bool   `json:"sshKeySet,omitempty"`
-	SSHPublicKey    string `json:"sshPublicKey,omitempty"`
-	DefaultCPU      int    `json:"defaultCpu,omitempty"`
-	DefaultMemory   string `json:"defaultMemory,omitempty"`
-	DefaultDisk     string `json:"defaultDisk,omitempty"`
-	_sshKeyPath     string `json:"-"` // internal: path for file I/O outside lock
+	SSHKeySet     bool   `json:"sshKeySet,omitempty"`
+	SSHPublicKey  string `json:"sshPublicKey,omitempty"`
+	DefaultCPU    int    `json:"defaultCpu,omitempty"`
+	DefaultMemory string `json:"defaultMemory,omitempty"`
+	DefaultDisk   string `json:"defaultDisk,omitempty"`
+	_sshKeyPath   string `json:"-"` // internal: path for file I/O outside lock
 }
 
 // GitHubAppPermission is a single permission check result for a GitHub App.
@@ -170,12 +171,12 @@ type GitHubAppPermission struct {
 }
 
 type GitHubAppView struct {
-	AppID       int64                 `json:"appId"`
-	URL         string                `json:"url,omitempty"`
-	KeySet      bool                  `json:"keySet"`
-	Permissions []GitHubAppPermission `json:"permissions,omitempty"`
-	PermCheckOK *bool                 `json:"permCheckOk,omitempty"` // nil = not checked yet
-	PermCheckError string           `json:"permCheckError,omitempty"`
+	AppID          int64                 `json:"appId"`
+	URL            string                `json:"url,omitempty"`
+	KeySet         bool                  `json:"keySet"`
+	Permissions    []GitHubAppPermission `json:"permissions,omitempty"`
+	PermCheckOK    *bool                 `json:"permCheckOk,omitempty"` // nil = not checked yet
+	PermCheckError string                `json:"permCheckError,omitempty"`
 }
 
 // SettingsPatch is the request body for PATCH /api/settings.
@@ -279,30 +280,30 @@ type GitHubIssuesIntegrationPatch struct {
 }
 
 type FactoryPatch struct {
-	Name                string              `json:"name"`
-	OriginalName        string              `json:"originalName,omitempty"`
-	Integration         string              `json:"integration"`
-	Workspace           string              `json:"workspace"`
-	Team                string              `json:"team,omitempty"`
-	TriggerStatus       string              `json:"triggerStatus"`
-	DoneStatus          string              `json:"doneStatus,omitempty"`
-	TerminateOnLeave    bool                `json:"terminateOnLeave"`
-	Template            string              `json:"template"`
-	NamePattern         string              `json:"namePattern,omitempty"`
-	WebhookSecret       string              `json:"webhookSecret,omitempty"`
-	WebhookSecretRef    string              `json:"webhookSecretRef,omitempty"`
-	PipelineYAML        string              `json:"pipelineYAML,omitempty"`
-	Tags                []string            `json:"tags,omitempty"`
-	Color               string              `json:"color,omitempty"`
-	Labels              []string            `json:"labels,omitempty"`
-	AssignedTo          string              `json:"assigned_to,omitempty"`
-	Enabled             *bool               `json:"enabled,omitempty"`
-	ConcurrencyGroup    string              `json:"concurrencyGroup,omitempty"`
-	EnableManualTrigger bool                `json:"enable_manual_trigger,omitempty"`
-	SecretRefs          map[string]string   `json:"secret_refs,omitempty"`
-	Inputs              []types.FactoryInput `json:"inputs,omitempty"`
-	Repos               []string            `json:"repos,omitempty"`
-	Trigger             *types.GitHubTrigger `json:"trigger,omitempty"`
+	Name                string                 `json:"name"`
+	OriginalName        string                 `json:"originalName,omitempty"`
+	Integration         string                 `json:"integration"`
+	Workspace           string                 `json:"workspace"`
+	Team                string                 `json:"team,omitempty"`
+	TriggerStatus       string                 `json:"triggerStatus"`
+	DoneStatus          string                 `json:"doneStatus,omitempty"`
+	TerminateOnLeave    bool                   `json:"terminateOnLeave"`
+	Template            string                 `json:"template"`
+	NamePattern         string                 `json:"namePattern,omitempty"`
+	WebhookSecret       string                 `json:"webhookSecret,omitempty"`
+	WebhookSecretRef    string                 `json:"webhookSecretRef,omitempty"`
+	PipelineYAML        string                 `json:"pipelineYAML,omitempty"`
+	Tags                []string               `json:"tags,omitempty"`
+	Color               string                 `json:"color,omitempty"`
+	Labels              []string               `json:"labels,omitempty"`
+	AssignedTo          string                 `json:"assigned_to,omitempty"`
+	Enabled             *bool                  `json:"enabled,omitempty"`
+	ConcurrencyGroup    string                 `json:"concurrencyGroup,omitempty"`
+	EnableManualTrigger bool                   `json:"enable_manual_trigger,omitempty"`
+	SecretRefs          map[string]string      `json:"secret_refs,omitempty"`
+	Inputs              []types.FactoryInput   `json:"inputs,omitempty"`
+	Repos               []string               `json:"repos,omitempty"`
+	Trigger             *types.GitHubTrigger   `json:"trigger,omitempty"`
 	ExternalTrigger     *types.ExternalTrigger `json:"externalTrigger,omitempty"`
 }
 
@@ -387,9 +388,13 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.mu.RLock()
+	var fireworksAPIKey string
 	// LLM keys — mask actual key values
 	view.LLMKeys = []LLMKeyView{}
 	for _, k := range s.hubCfg.LLMKeys {
+		if k.Provider == "fireworks" && k.APIKey != "" && fireworksAPIKey == "" {
+			fireworksAPIKey = k.APIKey
+		}
 		view.LLMKeys = append(view.LLMKeys, LLMKeyView{
 			Name:         k.Name,
 			Provider:     k.Provider,
@@ -560,6 +565,9 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 	s.mu.RUnlock()
 
 	view.Auth = authView
+	view.ModelOptions = map[string][]LLMModelOption{
+		"fireworks": s.fireworksModelOptions(r.Context(), fireworksAPIKey),
+	}
 
 	// Read SSH public keys outside the lock (file I/O)
 	for name, pv := range view.Providers {

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -15,7 +15,7 @@ type LLMKeyConfig struct {
 	Provider     string `yaml:"provider"      json:"provider"`                // e.g. "anthropic", "fireworks", "moonshot"
 	APIKey       string `yaml:"api_key"       json:"-"`                       // the actual key (never exposed in API)
 	Default      bool   `yaml:"default"       json:"default"`                 // use when no llm_key specified
-	DefaultModel string `yaml:"default_model" json:"default_model,omitempty"` // preferred model for this key, e.g. "fireworks/accounts/fireworks/models/kimi-k2p6"
+	DefaultModel string `yaml:"default_model" json:"default_model,omitempty"` // preferred model for this key, e.g. "fireworks/accounts/fireworks/models/kimi-k2p7"
 }
 
 // LLMKeysList is a custom YAML type that handles both the legacy flat-map format

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -37,6 +37,11 @@ interface LLMKeyView {
   defaultModel?: string
 }
 
+interface LLMModelOption {
+  id: string
+  name: string
+}
+
 interface GitHubAppPermission {
   name: string
   granted: string
@@ -65,6 +70,7 @@ interface WorkspaceGitHubAppView {
 
 interface SettingsData {
   llmKeys: LLMKeyView[]
+  modelOptions?: Record<string, LLMModelOption[]>
   providers: Record<string, {
     type: string
     enabled: boolean
@@ -852,7 +858,7 @@ const PROVIDER_OPTIONS = [
   { value: "other",      label: "Other",      placeholder: "" },
 ]
 
-const PROVIDER_MODELS: Record<string, { id: string; name: string }[]> = {
+const PROVIDER_MODELS: Record<string, LLMModelOption[]> = {
   anthropic: [
     { id: "anthropic/claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
     { id: "anthropic/claude-opus-4-5",   name: "Claude Opus 4.5" },
@@ -860,11 +866,11 @@ const PROVIDER_MODELS: Record<string, { id: string; name: string }[]> = {
     { id: "__custom",                    name: "Custom Anthropic model" },
   ],
   fireworks: [
-    { id: "fireworks/accounts/fireworks/models/kimi-k2p6",                  name: "Kimi K2.6" },
+    { id: "fireworks/accounts/fireworks/models/kimi-k2p7",                  name: "Kimi K2.7" },
+    { id: "fireworks/accounts/fireworks/models/glm-5p2",                    name: "GLM 5.2" },
     { id: "fireworks/accounts/fireworks/models/deepseek-v4-pro",            name: "DeepSeek V4 Pro" },
     { id: "fireworks/accounts/fireworks/models/deepseek-v4-flash",          name: "DeepSeek V4 Flash" },
     { id: "fireworks/accounts/fireworks/models/minimax-m2p7",               name: "MiniMax M2.7" },
-    { id: "fireworks/accounts/fireworks/models/glm-5p1",                    name: "GLM 5.1" },
     { id: "fireworks/accounts/fireworks/models/qwen3p6-plus",               name: "Qwen3.6 Plus" },
     { id: "fireworks/accounts/fireworks/models/gpt-oss-120b",               name: "OpenAI gpt-oss-120b" },
     { id: "fireworks/accounts/fireworks/models/gpt-oss-20b",                name: "OpenAI gpt-oss-20b" },
@@ -917,6 +923,7 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
 
   const providerLabel = (p: string) => PROVIDER_OPTIONS.find(o => o.value === p)?.label ?? p
   const providerPlaceholder = (p: string) => PROVIDER_OPTIONS.find(o => o.value === p)?.placeholder ?? ""
+  const providerModels = (p: string) => settings.modelOptions?.[p] ?? PROVIDER_MODELS[p] ?? []
 
   const resetForm = () => {
     setFormName(""); setFormProvider("anthropic"); setFormCustomProvider(""); setFormKey(""); setFormDefault(false); setFormDefaultModel(""); setFormCustomModel(""); setEditIdx(null)
@@ -931,8 +938,8 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
     setFormCustomProvider(isCustom ? k.provider : "")
     setFormKey("")
     setFormDefault(k.default)
-    const providerModels = PROVIDER_MODELS[k.provider] || []
-    if (k.defaultModel && providerModels.length > 0 && !providerModels.some(m => m.id === k.defaultModel)) {
+    const options = providerModels(k.provider)
+    if (k.defaultModel && options.length > 0 && !options.some(m => m.id === k.defaultModel)) {
       setFormDefaultModel("__custom")
       setFormCustomModel(k.defaultModel)
     } else {
@@ -978,6 +985,8 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
   function setDefault(i: number) {
     onSave({ llmKeys: [{ name: llmKeys[i].name, default: true }] })
   }
+
+  const formProviderModels = providerModels(formProvider)
 
   return (
     <div className="space-y-6">
@@ -1144,21 +1153,21 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
               </div>
               <div>
                 <label className="text-xs text-muted-foreground mb-1 block">Default model <span className="text-muted-foreground/60">(optional)</span></label>
-                {PROVIDER_MODELS[formProvider] ? (
+                {formProviderModels.length > 0 ? (
                   <select
                     value={formDefaultModel}
                     onChange={e => setFormDefaultModel(e.target.value)}
                     className="h-8 text-sm w-full rounded-md border border-input bg-background px-2 py-1"
                   >
                     <option value="">— use provider default —</option>
-                    {PROVIDER_MODELS[formProvider].map(m => (
+                    {formProviderModels.map(m => (
                       <option key={m.id} value={m.id}>{m.name}</option>
                     ))}
                   </select>
                 ) : (
                   <Input value={formDefaultModel} onChange={e => setFormDefaultModel(e.target.value)} className="h-8 text-sm" placeholder="e.g. myprovider/model-name" />
                 )}
-                {PROVIDER_MODELS[formProvider] && formDefaultModel === "__custom" && (
+                {formProviderModels.length > 0 && formDefaultModel === "__custom" && (
                   <Input
                     value={formCustomModel}
                     onChange={e => setFormCustomModel(e.target.value)}


### PR DESCRIPTION
## Summary
- fetch Fireworks model options from the backend via the Fireworks List Models API
- expose dynamic Fireworks options through /api/settings and keep curated Kimi K2.7 / GLM 5.2 fallback options
- make Fireworks provider defaults use the latest Kimi fallback
- update the settings UI to use backend model options when available

## Tests
- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./pkg/hub ./pkg/types -run 'Test(FetchFireworksModelOptions|GetSettingsIncludesDynamicFireworksModelOptions|FireworksModelOptionsFallsBackWithoutAPIKey|ResolveDefaultModelForKey|BuildOpenClawProviderConfig|SelectFailureSummaryModel)'
- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./pkg/hub
- npm run build