### PR TITLE
Support CLI coding models

### DIFF
--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -2058,6 +2058,8 @@ echo "Git: $(git --version)"
 }
 
 const openClawVersion = "2026.6.1"
+const codexCLIVersion = "0.141.0"
+const grokCLIVersion = "0.1.0"
 
 // installOpenClaw installs the pinned OpenClaw CLI via npm.
 func installOpenClaw() error {
@@ -2068,6 +2070,58 @@ func installOpenClaw() error {
 	out, _ := exec.Command("openclaw", "--version").Output()
 	log.Printf("[bootstrap] OpenClaw: %s", strings.TrimSpace(string(out)))
 	return nil
+}
+
+func cliCodingProviderForModel(model string) string {
+	switch {
+	case strings.HasPrefix(model, "codex/"):
+		return "codex"
+	case strings.HasPrefix(model, "grok/"):
+		return "grok"
+	default:
+		return ""
+	}
+}
+
+func cliVersion(envName, fallback string) string {
+	if v := strings.TrimSpace(os.Getenv(envName)); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func installNPMCLI(packageName, version, binaryName string) error {
+	if strings.TrimSpace(version) == "" {
+		return fmt.Errorf("empty version for %s", packageName)
+	}
+	spec := packageName + "@" + version
+	log.Printf("[bootstrap] installing %s...", spec)
+	if err := runShell(fmt.Sprintf("sudo npm install -g %s --ignore-scripts", shellQuote(spec))); err != nil {
+		return fmt.Errorf("npm install %s: %w", spec, err)
+	}
+	out, err := exec.Command(binaryName, "--version").CombinedOutput()
+	if err != nil {
+		log.Printf("[bootstrap] %s version check warning: %v: %s", binaryName, err, strings.TrimSpace(string(out)))
+		return nil
+	}
+	log.Printf("[bootstrap] %s: %s", binaryName, strings.TrimSpace(string(out)))
+	return nil
+}
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'"'"'`) + "'"
+}
+
+func installSelectedCodingModelCLI() error {
+	model := envOr("OPENCLAW_DEFAULT_MODEL", "")
+	switch cliCodingProviderForModel(model) {
+	case "codex":
+		return installNPMCLI("@openai/codex", cliVersion("ELASTICCLAW_CODEX_CLI_VERSION", codexCLIVersion), "codex")
+	case "grok":
+		return installNPMCLI("@xai-official/grok", cliVersion("ELASTICCLAW_GROK_CLI_VERSION", grokCLIVersion), "grok")
+	default:
+		return nil
+	}
 }
 
 // configureOpenClaw patches ~/.openclaw/openclaw.json with model, LLM keys,
@@ -2403,6 +2457,11 @@ func runBootstrap() error {
 	// Step 3: Install OpenClaw (needs Node)
 	if err := installOpenClaw(); err != nil {
 		return fmt.Errorf("installOpenClaw: %w", err)
+	}
+
+	// Step 3b: Install pinned CLI-backed model providers when selected.
+	if err := installSelectedCodingModelCLI(); err != nil {
+		return fmt.Errorf("installSelectedCodingModelCLI: %w", err)
 	}
 
 	// Step 4: Run openclaw onboard (initializes ~/.openclaw directory)

--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -43,6 +43,8 @@ import (
 
 	"nhooyr.io/websocket"
 	"nhooyr.io/websocket/wsjson"
+
+	"github.com/elasticclaw/elasticclaw/pkg/cliversion"
 )
 
 var (
@@ -2087,13 +2089,6 @@ func cliCodingProviderForModel(model string) string {
 	}
 }
 
-func cliVersion(envName, fallback string) string {
-	if v := strings.TrimSpace(os.Getenv(envName)); v != "" {
-		return v
-	}
-	return fallback
-}
-
 func installNPMCLI(packageName, version, binaryName string) error {
 	if strings.TrimSpace(version) == "" {
 		return fmt.Errorf("empty version for %s", packageName)
@@ -2158,9 +2153,9 @@ func installSelectedCodingModelCLI() error {
 	model := envOr("OPENCLAW_DEFAULT_MODEL", "")
 	switch cliCodingProviderForModel(model) {
 	case "codex":
-		return installNPMCLI("@openai/codex", cliVersion("ELASTICCLAW_CODEX_CLI_VERSION", codexCLIVersion), "codex")
+		return installNPMCLI("@openai/codex", cliversion.FromEnv("ELASTICCLAW_CODEX_CLI_VERSION", codexCLIVersion), "codex")
 	case "grok":
-		return installNPMCLI("@xai-official/grok", cliVersion("ELASTICCLAW_GROK_CLI_VERSION", grokCLIVersion), "grok")
+		return installNPMCLI("@xai-official/grok", cliversion.FromEnv("ELASTICCLAW_GROK_CLI_VERSION", grokCLIVersion), "grok")
 	default:
 		return nil
 	}

--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -144,6 +144,10 @@ type bridgeSessionFile struct {
 	SessionKey string `json:"sessionKey"`
 }
 
+type cliAuthBundle struct {
+	Files map[string]string `json:"files"`
+}
+
 func bridgeSessionPath() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -2112,6 +2116,44 @@ func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'"'"'`) + "'"
 }
 
+func restoreCLIModelAuth() error {
+	state := strings.TrimSpace(os.Getenv("ELASTICCLAW_MODEL_AUTH_STATE"))
+	if state == "" {
+		return nil
+	}
+	data, err := base64.StdEncoding.DecodeString(state)
+	if err != nil {
+		return fmt.Errorf("decode auth state: %w", err)
+	}
+	var bundle cliAuthBundle
+	if err := json.Unmarshal(data, &bundle); err != nil {
+		return fmt.Errorf("parse auth state: %w", err)
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("home dir: %w", err)
+	}
+	for rel, encoded := range bundle.Files {
+		clean := filepath.Clean(rel)
+		if clean == "." || filepath.IsAbs(clean) || strings.HasPrefix(clean, ".."+string(filepath.Separator)) || clean == ".." {
+			continue
+		}
+		content, err := base64.StdEncoding.DecodeString(encoded)
+		if err != nil {
+			return fmt.Errorf("decode auth file %s: %w", rel, err)
+		}
+		path := filepath.Join(home, clean)
+		if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+			return fmt.Errorf("create auth dir %s: %w", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, content, 0600); err != nil {
+			return fmt.Errorf("write auth file %s: %w", rel, err)
+		}
+	}
+	log.Printf("[bootstrap] restored %d CLI auth files for %s", len(bundle.Files), os.Getenv("ELASTICCLAW_MODEL_AUTH_PROVIDER"))
+	return nil
+}
+
 func installSelectedCodingModelCLI() error {
 	model := envOr("OPENCLAW_DEFAULT_MODEL", "")
 	switch cliCodingProviderForModel(model) {
@@ -2462,6 +2504,10 @@ func runBootstrap() error {
 	// Step 3b: Install pinned CLI-backed model providers when selected.
 	if err := installSelectedCodingModelCLI(); err != nil {
 		return fmt.Errorf("installSelectedCodingModelCLI: %w", err)
+	}
+
+	if err := restoreCLIModelAuth(); err != nil {
+		return fmt.Errorf("restoreCLIModelAuth: %w", err)
 	}
 
 	// Step 4: Run openclaw onboard (initializes ~/.openclaw directory)

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
 	"net/http"
@@ -350,6 +351,33 @@ func TestCLIVersionAllowsPinnedOverride(t *testing.T) {
 	}
 	if got := cliVersion("ELASTICCLAW_MISSING_VERSION", "1.2.3"); got != "1.2.3" {
 		t.Fatalf("cliVersion fallback = %q", got)
+	}
+}
+
+func TestRestoreCLIModelAuthWritesBundleFiles(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	bundle := cliAuthBundle{
+		Files: map[string]string{
+			".codex/auth.json": base64.StdEncoding.EncodeToString([]byte(`{"token":"test"}`)),
+		},
+	}
+	data, err := json.Marshal(bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("ELASTICCLAW_MODEL_AUTH_PROVIDER", "codex")
+	t.Setenv("ELASTICCLAW_MODEL_AUTH_STATE", base64.StdEncoding.EncodeToString(data))
+
+	if err := restoreCLIModelAuth(); err != nil {
+		t.Fatalf("restore auth: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(home, ".codex", "auth.json"))
+	if err != nil {
+		t.Fatalf("read restored auth: %v", err)
+	}
+	if string(got) != `{"token":"test"}` {
+		t.Fatalf("restored auth = %q", string(got))
 	}
 }
 

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -329,6 +329,30 @@ func TestPatchOllamaLocalDevCatalogSetsRuntimeLimits(t *testing.T) {
 	}
 }
 
+func TestCLICodingProviderForModel(t *testing.T) {
+	tests := map[string]string{
+		"codex/gpt-5.5":        "codex",
+		"grok/grok-build-0.1":  "grok",
+		"anthropic/claude-foo": "",
+		"":                     "",
+	}
+	for model, want := range tests {
+		if got := cliCodingProviderForModel(model); got != want {
+			t.Fatalf("cliCodingProviderForModel(%q) = %q, want %q", model, got, want)
+		}
+	}
+}
+
+func TestCLIVersionAllowsPinnedOverride(t *testing.T) {
+	t.Setenv("ELASTICCLAW_CODEX_CLI_VERSION", "9.8.7")
+	if got := cliVersion("ELASTICCLAW_CODEX_CLI_VERSION", "1.2.3"); got != "9.8.7" {
+		t.Fatalf("cliVersion override = %q", got)
+	}
+	if got := cliVersion("ELASTICCLAW_MISSING_VERSION", "1.2.3"); got != "1.2.3" {
+		t.Fatalf("cliVersion fallback = %q", got)
+	}
+}
+
 func TestSanitizeActivityTextRedactsRepeatedSecretPrefixes(t *testing.T) {
 	input := `curl "https://api.example.com?access_token=abc&access_token=xyz" -H "Authorization: Bearer tok1" -H "X-Alt: Bearer tok2"`
 	got := sanitizeActivityText(input)

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -344,16 +344,6 @@ func TestCLICodingProviderForModel(t *testing.T) {
 	}
 }
 
-func TestCLIVersionAllowsPinnedOverride(t *testing.T) {
-	t.Setenv("ELASTICCLAW_CODEX_CLI_VERSION", "9.8.7")
-	if got := cliVersion("ELASTICCLAW_CODEX_CLI_VERSION", "1.2.3"); got != "9.8.7" {
-		t.Fatalf("cliVersion override = %q", got)
-	}
-	if got := cliVersion("ELASTICCLAW_MISSING_VERSION", "1.2.3"); got != "1.2.3" {
-		t.Fatalf("cliVersion fallback = %q", got)
-	}
-}
-
 func TestRestoreCLIModelAuthWritesBundleFiles(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/pkg/cliversion/cliversion.go
+++ b/pkg/cliversion/cliversion.go
@@ -1,0 +1,13 @@
+package cliversion
+
+import (
+	"os"
+	"strings"
+)
+
+func FromEnv(envName, fallback string) string {
+	if v := strings.TrimSpace(os.Getenv(envName)); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/pkg/cliversion/cliversion_test.go
+++ b/pkg/cliversion/cliversion_test.go
@@ -1,0 +1,13 @@
+package cliversion
+
+import "testing"
+
+func TestFromEnvAllowsPinnedOverride(t *testing.T) {
+	t.Setenv("ELASTICCLAW_TEST_CLI_VERSION", "9.8.7")
+	if got := FromEnv("ELASTICCLAW_TEST_CLI_VERSION", "1.2.3"); got != "9.8.7" {
+		t.Fatalf("FromEnv override = %q", got)
+	}
+	if got := FromEnv("ELASTICCLAW_MISSING_VERSION", "1.2.3"); got != "1.2.3" {
+		t.Fatalf("FromEnv fallback = %q", got)
+	}
+}

--- a/pkg/hub/ai_config.go
+++ b/pkg/hub/ai_config.go
@@ -547,7 +547,7 @@ func selectAIConfigProvider(llmKeys types.LLMKeysList, defaultModel string) (*ai
 	if anthropicKey != nil {
 		return &aiConfigProviderChoice{Key: anthropicKey, Anthropic: true}, nil
 	}
-	for _, provider := range []string{"openai", "codex", "fireworks", "groq", "deepseek", "ollama"} {
+	for _, provider := range []string{"openai", "codex", "grok", "fireworks", "groq", "deepseek", "ollama"} {
 		if key := openAIKeys[provider]; key != nil {
 			return &aiConfigProviderChoice{
 				Key:      key,
@@ -559,9 +559,9 @@ func selectAIConfigProvider(llmKeys types.LLMKeysList, defaultModel string) (*ai
 
 	availableProviders := uniqueProviders(llmKeys)
 	if defaultProvider != "" {
-		return nil, fmt.Errorf("no supported LLM key configured for default_model provider %q (supported providers: anthropic, openai, codex, fireworks, groq, deepseek, ollama; configured: %s)", defaultProvider, strings.Join(availableProviders, ", "))
+		return nil, fmt.Errorf("no supported LLM key configured for default_model provider %q (supported providers: anthropic, openai, codex, grok, fireworks, groq, deepseek, ollama; configured: %s)", defaultProvider, strings.Join(availableProviders, ", "))
 	}
-	return nil, fmt.Errorf("no supported LLM key configured (supported providers: anthropic, openai, codex, fireworks, groq, deepseek, ollama; configured: %s)", strings.Join(availableProviders, ", "))
+	return nil, fmt.Errorf("no supported LLM key configured (supported providers: anthropic, openai, codex, grok, fireworks, groq, deepseek, ollama; configured: %s)", strings.Join(availableProviders, ", "))
 }
 
 func llmKeyHasRequiredAPIKey(key *types.LLMKeyConfig) bool {
@@ -573,7 +573,7 @@ func llmKeyHasRequiredAPIKey(key *types.LLMKeyConfig) bool {
 
 func isOpenAICompatibleConfigProvider(provider string) bool {
 	switch provider {
-	case "openai", "codex", "fireworks", "groq", "deepseek", "ollama":
+	case "openai", "codex", "grok", "fireworks", "groq", "deepseek", "ollama":
 		return true
 	default:
 		return false
@@ -597,7 +597,9 @@ func aiConfigModelForKey(key *types.LLMKeyConfig, defaultModel string) string {
 	case "openai":
 		return "openai/gpt-5.5"
 	case "codex":
-		return "codex/o4-mini"
+		return "codex/gpt-5.5"
+	case "grok":
+		return "grok/grok-build-0.1"
 	case "fireworks":
 		return "fireworks/accounts/fireworks/models/kimi-k2p6"
 	case "groq":

--- a/pkg/hub/ai_config.go
+++ b/pkg/hub/ai_config.go
@@ -568,7 +568,7 @@ func llmKeyHasRequiredAPIKey(key *types.LLMKeyConfig) bool {
 	if key == nil {
 		return false
 	}
-	return key.APIKey != "" || key.Provider == "ollama"
+	return key.APIKey != "" || key.Provider == "ollama" || key.AuthProfile != ""
 }
 
 func isOpenAICompatibleConfigProvider(provider string) bool {

--- a/pkg/hub/bootstrap.go
+++ b/pkg/hub/bootstrap.go
@@ -38,6 +38,7 @@ type BootstrapParams struct {
 
 	// Env injection
 	LLMKeyEnv      string // pre-built export lines
+	ModelAuthEnv   string // pre-built export lines for CLI-backed model auth state
 	LinearEnv      string // pre-built export line
 	ProviderConfig string // python snippet to patch OpenClaw config
 	OnboardFlags   string // --auth-choice ... flags for openclaw onboard
@@ -235,6 +236,7 @@ export ELASTICCLAW_NIX=%s
 export ELASTICCLAW_DOCKER=%s
 %s
 %s
+%s
 export ELASTICCLAW_ONBOARD_FLAGS=%s
 %s
 # ── Install claw-bridge ───────────────────────────────────────────────────────
@@ -322,7 +324,7 @@ exit 1
 `,
 		shellQuote(p.HubURL), shellQuote(p.ClawID), shellQuote(p.ClawToken), shellQuote(p.ClawName), shellQuote(p.GatewayPassword),
 		shellQuote(p.DefaultModel), shellQuote(nixFlag), shellQuote(dockerFlag),
-		p.LLMKeyEnv, linearEnvLine, shellQuote(p.OnboardFlags), providerConfigLine,
+		p.LLMKeyEnv, p.ModelAuthEnv, linearEnvLine, shellQuote(p.OnboardFlags), providerConfigLine,
 		shellQuote(p.BridgeURL),
 	)
 }

--- a/pkg/hub/bootstrap.go
+++ b/pkg/hub/bootstrap.go
@@ -156,6 +156,25 @@ if model.startswith('ollama/'):
             'compat': {'supportsTools': True, 'supportsUsageInStreaming': True},
         }],
     }
+if model.startswith('grok/'):
+    model_id = model.split('/', 1)[1]
+    config.setdefault('models', {})['mode'] = 'merge'
+    providers = config['models'].setdefault('providers', {})
+    providers['grok'] = {
+        'baseUrl': 'https://api.x.ai/v1',
+        'api': 'openai',
+        'apiKey': 'XAI_API_KEY',
+        'models': [{
+            'id': model_id,
+            'name': model_id,
+            'reasoning': True,
+            'input': ['text', 'image'],
+            'cost': {'input': 0, 'output': 0, 'cacheRead': 0, 'cacheWrite': 0},
+            'contextWindow': 256000,
+            'maxTokens': 8192,
+            'compat': {'supportsTools': True, 'supportsUsageInStreaming': True},
+        }],
+    }
 %sconfig.setdefault('gateway', {})['bind'] = 'loopback'
 config['gateway']['port'] = 18789
 gw_password = os.environ.get('ELASTICCLAW_GATEWAY_PASSWORD', '')
@@ -336,6 +355,8 @@ func buildOnboardFlags(keys []*types.LLMKeyConfig, selectedKeyName, defaultModel
 		return fmt.Sprintf(`--auth-choice deepseek-api-key --deepseek-api-key "${%s:-}"`, envVar)
 	case "codex":
 		return fmt.Sprintf(`--auth-choice codex-api-key --codex-api-key "${%s:-}"`, envVar)
+	case "grok":
+		return fmt.Sprintf(`--auth-choice openai-api-key --openai-api-key "${%s:-}"`, envVar)
 	case "ollama":
 		model := active.DefaultModel
 		if model == "" || !strings.HasPrefix(model, active.Provider+"/") {

--- a/pkg/hub/bootstrap_test.go
+++ b/pkg/hub/bootstrap_test.go
@@ -348,6 +348,22 @@ func TestBuildLLMKeyEnvSkipsBlankExternalKeys(t *testing.T) {
 	assertNotContains(t, env, "OPENAI_API_KEY", "does not export blank OpenAI key")
 }
 
+func TestBuildModelAuthEnvUsesSelectedProfile(t *testing.T) {
+	cfg := &types.HubConfig{
+		LLMKeys: types.LLMKeysList{
+			{Name: "codex-main", Provider: "codex", AuthProfile: "codex-profile", Default: true},
+		},
+		ModelAuthProfiles: []*types.ModelAuthProfileConfig{
+			{Name: "codex-profile", Provider: "codex", AuthState: "encoded-state"},
+		},
+	}
+
+	env := buildModelAuthEnv(cfg, "codex-main")
+
+	assertContains(t, env, "ELASTICCLAW_MODEL_AUTH_PROVIDER=\"codex\"", "exports auth provider")
+	assertContains(t, env, "ELASTICCLAW_MODEL_AUTH_STATE=\"encoded-state\"", "exports auth state")
+}
+
 func TestResolveModelAndLLMKeyReplacesUnusableSelectedKey(t *testing.T) {
 	hubCfg := &types.HubConfig{
 		LLMKeys: types.LLMKeysList{

--- a/pkg/hub/bootstrap_test.go
+++ b/pkg/hub/bootstrap_test.go
@@ -300,6 +300,13 @@ func TestBuildOnboardFlags_OpenAICompatibleProviders(t *testing.T) {
 			authChoice: "codex-api-key",
 			flagName:   "--codex-api-key",
 		},
+		{
+			name:       "grok",
+			provider:   "grok",
+			envVar:     "XAI_API_KEY",
+			authChoice: "openai-api-key",
+			flagName:   "--openai-api-key",
+		},
 	}
 
 	for _, tc := range cases {
@@ -415,6 +422,19 @@ func TestBuildOpenClawProviderConfig_ConfiguresOllamaProviderBaseURL(t *testing.
 	assertContains(t, snippet, "'compat': {'supportsTools': True, 'supportsUsageInStreaming': True}", "keeps tool support while lean mode reduces local model prompt pressure")
 	assertContains(t, snippet, "providers['ollama']", "writes only the built-in Ollama provider config")
 	assertNotContains(t, snippet, "'ollama-cloud'", "does not rewrite Ollama Cloud")
+}
+
+func TestBuildOpenClawProviderConfig_ConfiguresGrokProvider(t *testing.T) {
+	keys := []*types.LLMKeyConfig{
+		{Name: "grok-main", Provider: "grok", Default: true},
+	}
+
+	snippet := buildOpenClawProviderConfig(keys, "grok-main")
+
+	assertContains(t, snippet, "if model.startswith('grok/'):", "only configures Grok when selected model is Grok")
+	assertContains(t, snippet, "'baseUrl': 'https://api.x.ai/v1'", "uses xAI OpenAI-compatible base URL")
+	assertContains(t, snippet, "'apiKey': 'XAI_API_KEY'", "uses Grok API key env var")
+	assertContains(t, snippet, "providers['grok']", "writes Grok provider config")
 }
 
 func TestBuildOpenClawProviderConfig_DoesNotOverrideAnthropicModels(t *testing.T) {

--- a/pkg/hub/bootstrap_test.go
+++ b/pkg/hub/bootstrap_test.go
@@ -364,6 +364,13 @@ func TestBuildModelAuthEnvUsesSelectedProfile(t *testing.T) {
 	assertContains(t, env, "ELASTICCLAW_MODEL_AUTH_STATE=\"encoded-state\"", "exports auth state")
 }
 
+func TestBuildModelAuthRestoreShellRejectsParentDirectory(t *testing.T) {
+	shell := buildModelAuthRestoreShell("export ELASTICCLAW_MODEL_AUTH_STATE=\"encoded-state\"\n")
+
+	assertContains(t, shell, "clean == '..'", "rejects exact parent directory path")
+	assertContains(t, shell, "clean.startswith('../')", "rejects nested parent directory path")
+}
+
 func TestResolveModelAndLLMKeyReplacesUnusableSelectedKey(t *testing.T) {
 	hubCfg := &types.HubConfig{
 		LLMKeys: types.LLMKeysList{

--- a/pkg/hub/dependency_status.go
+++ b/pkg/hub/dependency_status.go
@@ -379,6 +379,8 @@ func modelDependency(provider string) (id, name string, ok bool) {
 		return "model:anthropic", "Anthropic", true
 	case "openai", "codex":
 		return "model:openai", "OpenAI", true
+	case "grok":
+		return "model:grok", "Grok", true
 	case "fireworks":
 		return "model:fireworks", "Fireworks", true
 	default:

--- a/pkg/hub/doctor.go
+++ b/pkg/hub/doctor.go
@@ -171,7 +171,7 @@ func (s *Server) checkLLMKeys(cfg *types.HubConfig) []DoctorCheck {
 	validProviders := map[string]bool{
 		"anthropic": true, "openai": true, "fireworks": true,
 		"moonshot": true, "google": true, "mistral": true,
-		"groq": true, "deepseek": true, "codex": true, "ollama": true,
+		"groq": true, "grok": true, "deepseek": true, "codex": true, "ollama": true,
 	}
 
 	allKeysValid := true

--- a/pkg/hub/external_webhook.go
+++ b/pkg/hub/external_webhook.go
@@ -778,6 +778,10 @@ func resolveDefaultModelForKeyLocal(hubDefaultModel string, key *types.LLMKeyCon
 		return "fireworks/accounts/fireworks/models/kimi-k2p6"
 	case "openai":
 		return "openai/gpt-5.5"
+	case "codex":
+		return "codex/gpt-5.5"
+	case "grok":
+		return "grok/grok-build-0.1"
 	case "groq":
 		return "groq/llama-3.3-70b-versatile"
 	case "deepseek":

--- a/pkg/hub/failure_summary.go
+++ b/pkg/hub/failure_summary.go
@@ -363,7 +363,7 @@ func summarizeFailureWithLLM(ctx context.Context, sanitizedReason string, llmKey
 	switch key.Provider {
 	case "anthropic":
 		return callAnthropicModel(ctx, key.APIKey, stripProviderPrefix(model), systemPrompt, msgs, 700)
-	case "openai", "codex", "fireworks", "groq", "deepseek", "ollama":
+	case "openai", "codex", "grok", "fireworks", "groq", "deepseek", "ollama":
 		return callOpenAICompatible(ctx, openAICompatibleConfig(key.Provider), key.APIKey, stripProviderPrefix(model), systemPrompt, msgs)
 	default:
 		return "", fmt.Errorf("unsupported LLM provider %q", key.Provider)
@@ -397,7 +397,7 @@ func selectFailureSummaryModel(llmKeys types.LLMKeysList, defaultModel string) (
 
 func isFailureSummaryProvider(provider string) bool {
 	switch provider {
-	case "anthropic", "openai", "codex", "fireworks", "groq", "deepseek", "ollama":
+	case "anthropic", "openai", "codex", "grok", "fireworks", "groq", "deepseek", "ollama":
 		return true
 	default:
 		return false
@@ -420,7 +420,9 @@ func modelForFailureSummary(key *types.LLMKeyConfig, defaultModel string) string
 	case "openai":
 		return "openai/gpt-5.4-mini"
 	case "codex":
-		return "codex/o4-mini"
+		return "codex/gpt-5.5"
+	case "grok":
+		return "grok/grok-build-0.1"
 	case "fireworks":
 		return "fireworks/accounts/fireworks/models/kimi-k2p6"
 	case "groq":
@@ -453,6 +455,8 @@ func openAICompatibleConfig(provider string) openAICompatibleProvider {
 		return openAICompatibleProvider{Name: "Fireworks", BaseURL: "https://api.fireworks.ai/inference/v1"}
 	case "groq":
 		return openAICompatibleProvider{Name: "Groq", BaseURL: "https://api.groq.com/openai/v1"}
+	case "grok":
+		return openAICompatibleProvider{Name: "Grok", BaseURL: "https://api.x.ai/v1"}
 	case "deepseek":
 		return openAICompatibleProvider{Name: "DeepSeek", BaseURL: "https://api.deepseek.com/v1"}
 	case "ollama":

--- a/pkg/hub/model_auth.go
+++ b/pkg/hub/model_auth.go
@@ -115,6 +115,7 @@ func (s *Server) runModelAuthLoginJob(job *modelAuthLoginJob) {
 		s.finishModelAuthJob(job, "error", "", err)
 		return
 	}
+	defer os.RemoveAll(authDir)
 	job.authDir = authDir
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
@@ -151,9 +152,9 @@ func (s *Server) runModelAuthLoginJob(job *modelAuthLoginJob) {
 	done := make(chan struct{}, 2)
 	go s.captureModelAuthOutput(job, stdout, done)
 	go s.captureModelAuthOutput(job, stderr, done)
+	<-done
+	<-done
 	err = cmd.Wait()
-	<-done
-	<-done
 	if err != nil {
 		s.finishModelAuthJob(job, "error", "", err)
 		return
@@ -324,7 +325,7 @@ if state:
     home = os.path.expanduser('~')
     for rel, encoded in bundle.get('files', {}).items():
         clean = os.path.normpath(rel)
-        if clean == '.' or clean.startswith('../') or os.path.isabs(clean):
+        if clean == '.' or clean == '..' or clean.startswith('../') or os.path.isabs(clean):
             continue
         path = os.path.join(home, clean)
         os.makedirs(os.path.dirname(path), exist_ok=True)

--- a/pkg/hub/model_auth.go
+++ b/pkg/hub/model_auth.go
@@ -1,0 +1,336 @@
+package hub
+
+import (
+	"bufio"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/config"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+	"github.com/google/uuid"
+)
+
+type modelAuthLoginJob struct {
+	ID        string `json:"id"`
+	Provider  string `json:"provider"`
+	Profile   string `json:"profile"`
+	Status    string `json:"status"`
+	URL       string `json:"url,omitempty"`
+	Code      string `json:"code,omitempty"`
+	Output    string `json:"output,omitempty"`
+	Error     string `json:"error,omitempty"`
+	StartedAt string `json:"startedAt"`
+	UpdatedAt string `json:"updatedAt"`
+	authDir   string
+}
+
+type cliAuthBundle struct {
+	Files map[string]string `json:"files"`
+}
+
+var (
+	modelAuthURLRE  = regexp.MustCompile(`https?://[^\s"']+`)
+	modelAuthCodeRE = regexp.MustCompile(`(?i)(?:code|user code|verification code)[^A-Z0-9]*([A-Z0-9][A-Z0-9-]{3,})`)
+)
+
+func (s *Server) handleModelAuthLogin(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req struct {
+		Provider string `json:"provider"`
+		Profile  string `json:"profile"`
+		Mode     string `json:"mode"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	req.Provider = strings.TrimSpace(req.Provider)
+	req.Profile = strings.TrimSpace(req.Profile)
+	if req.Mode == "" {
+		req.Mode = "device"
+	}
+	if req.Profile == "" {
+		req.Profile = req.Provider + "-default"
+	}
+	if req.Provider != "codex" && req.Provider != "grok" {
+		http.Error(w, "provider must be codex or grok", http.StatusBadRequest)
+		return
+	}
+	if req.Mode != "device" {
+		http.Error(w, "only device login is supported", http.StatusBadRequest)
+		return
+	}
+
+	job := &modelAuthLoginJob{
+		ID:        uuid.NewString(),
+		Provider:  req.Provider,
+		Profile:   req.Profile,
+		Status:    "running",
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+		UpdatedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+	s.modelAuthJobsMu.Lock()
+	if s.modelAuthJobs == nil {
+		s.modelAuthJobs = map[string]*modelAuthLoginJob{}
+	}
+	s.modelAuthJobs[job.ID] = job
+	s.modelAuthJobsMu.Unlock()
+
+	go s.runModelAuthLoginJob(job)
+	jsonOK(w, job)
+}
+
+func (s *Server) handleModelAuthLoginStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	id := r.PathValue("id")
+	s.modelAuthJobsMu.Lock()
+	job := s.modelAuthJobs[id]
+	s.modelAuthJobsMu.Unlock()
+	if job == nil {
+		http.NotFound(w, r)
+		return
+	}
+	jsonOK(w, job)
+}
+
+func (s *Server) runModelAuthLoginJob(job *modelAuthLoginJob) {
+	authDir, err := os.MkdirTemp("", "elasticclaw-model-auth-*")
+	if err != nil {
+		s.finishModelAuthJob(job, "error", "", err)
+		return
+	}
+	job.authDir = authDir
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	var args []string
+	switch job.Provider {
+	case "codex":
+		args = []string{"codex", "login", "--device-auth"}
+	case "grok":
+		args = []string{"grok", "login", "--device-auth"}
+	default:
+		s.finishModelAuthJob(job, "error", "", fmt.Errorf("unsupported provider %q", job.Provider))
+		return
+	}
+
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+	cmd.Env = append(os.Environ(), "HOME="+authDir)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		s.finishModelAuthJob(job, "error", "", err)
+		return
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		s.finishModelAuthJob(job, "error", "", err)
+		return
+	}
+	if err := cmd.Start(); err != nil {
+		s.finishModelAuthJob(job, "error", "", err)
+		return
+	}
+
+	done := make(chan struct{}, 2)
+	go s.captureModelAuthOutput(job, stdout, done)
+	go s.captureModelAuthOutput(job, stderr, done)
+	err = cmd.Wait()
+	<-done
+	<-done
+	if err != nil {
+		s.finishModelAuthJob(job, "error", "", err)
+		return
+	}
+	bundle, err := encodeCLIAuthBundle(authDir)
+	if err != nil {
+		s.finishModelAuthJob(job, "error", "", err)
+		return
+	}
+	if err := s.saveModelAuthProfile(job.Provider, job.Profile, "device", bundle); err != nil {
+		s.finishModelAuthJob(job, "error", "", err)
+		return
+	}
+	s.finishModelAuthJob(job, "complete", bundle, nil)
+}
+
+func (s *Server) captureModelAuthOutput(job *modelAuthLoginJob, r io.Reader, done chan<- struct{}) {
+	defer func() { done <- struct{}{} }()
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		s.modelAuthJobsMu.Lock()
+		if job.Output != "" {
+			job.Output += "\n"
+		}
+		job.Output += line
+		if job.URL == "" {
+			if match := modelAuthURLRE.FindString(line); match != "" {
+				job.URL = strings.TrimRight(match, ".,)")
+			}
+		}
+		if job.Code == "" {
+			if match := modelAuthCodeRE.FindStringSubmatch(line); len(match) == 2 {
+				job.Code = match[1]
+			}
+		}
+		job.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+		s.modelAuthJobsMu.Unlock()
+	}
+}
+
+func (s *Server) finishModelAuthJob(job *modelAuthLoginJob, status, _ string, err error) {
+	s.modelAuthJobsMu.Lock()
+	defer s.modelAuthJobsMu.Unlock()
+	job.Status = status
+	job.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	if err != nil {
+		job.Error = err.Error()
+	}
+}
+
+func encodeCLIAuthBundle(root string) (string, error) {
+	bundle := cliAuthBundle{Files: map[string]string{}}
+	var total int64
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			name := d.Name()
+			if name == "node_modules" || name == ".npm" || name == ".cache" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		if info.Size() > 2*1024*1024 {
+			return nil
+		}
+		total += info.Size()
+		if total > 10*1024*1024 {
+			return fmt.Errorf("auth bundle exceeds 10MiB")
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		bundle.Files[filepath.ToSlash(rel)] = base64.StdEncoding.EncodeToString(data)
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	data, err := json.Marshal(bundle)
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(data), nil
+}
+
+func (s *Server) saveModelAuthProfile(provider, name, mode, authState string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	updatedCfg := *s.hubCfg
+	profiles := make([]*types.ModelAuthProfileConfig, len(updatedCfg.ModelAuthProfiles))
+	for i, profile := range updatedCfg.ModelAuthProfiles {
+		if profile == nil {
+			continue
+		}
+		copy := *profile
+		profiles[i] = &copy
+	}
+	var found *types.ModelAuthProfileConfig
+	for _, profile := range profiles {
+		if profile != nil && profile.Name == name {
+			found = profile
+			break
+		}
+	}
+	if found == nil {
+		found = &types.ModelAuthProfileConfig{Name: name}
+		profiles = append(profiles, found)
+	}
+	found.Provider = provider
+	found.Mode = mode
+	found.AuthState = authState
+	found.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	updatedCfg.ModelAuthProfiles = profiles
+	if err := config.SaveHubConfig(&updatedCfg); err != nil {
+		return err
+	}
+	s.hubCfg = &updatedCfg
+	return nil
+}
+
+func buildModelAuthEnv(cfg *types.HubConfig, selectedKeyName string) string {
+	if cfg == nil {
+		return ""
+	}
+	key := resolveActiveKey(cfg.LLMKeys, selectedKeyName)
+	if key == nil || key.AuthProfile == "" {
+		return ""
+	}
+	for _, profile := range cfg.ModelAuthProfiles {
+		if profile == nil || profile.Name != key.AuthProfile || profile.AuthState == "" {
+			continue
+		}
+		if profile.Provider != key.Provider {
+			continue
+		}
+		return fmt.Sprintf("export ELASTICCLAW_MODEL_AUTH_PROVIDER=%q\nexport ELASTICCLAW_MODEL_AUTH_STATE=%q\n", profile.Provider, profile.AuthState)
+	}
+	return ""
+}
+
+func buildModelAuthRestoreShell(modelAuthEnv string) string {
+	if strings.TrimSpace(modelAuthEnv) == "" {
+		return ""
+	}
+	return modelAuthEnv + `
+python3 <<'PYEOF'
+import base64, json, os
+state = os.environ.get('ELASTICCLAW_MODEL_AUTH_STATE', '')
+if state:
+    bundle = json.loads(base64.b64decode(state).decode())
+    home = os.path.expanduser('~')
+    for rel, encoded in bundle.get('files', {}).items():
+        clean = os.path.normpath(rel)
+        if clean == '.' or clean.startswith('../') or os.path.isabs(clean):
+            continue
+        path = os.path.join(home, clean)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, 'wb') as f:
+            f.write(base64.b64decode(encoded))
+        os.chmod(path, 0o600)
+PYEOF
+`
+}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -5360,6 +5360,10 @@ func resolveDefaultModelForKey(hubCfg *types.HubConfig, key *types.LLMKeyConfig)
 		return "anthropic/claude-sonnet-4-6"
 	case "openai":
 		return "openai/gpt-5.5"
+	case "codex":
+		return "codex/gpt-5.5"
+	case "grok":
+		return "grok/grok-build-0.1"
 	case "fireworks":
 		return "fireworks/accounts/fireworks/models/kimi-k2p6"
 	case "groq":

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -68,6 +68,8 @@ type Server struct {
 	linearBaseURL string
 	// shortcutBaseURL overrides the Shortcut API base for testing (default: https://api.app.shortcut.com)
 	shortcutBaseURL string
+	modelAuthJobsMu sync.Mutex
+	modelAuthJobs   map[string]*modelAuthLoginJob
 
 	// webhookDedup prevents duplicate Linear webhook deliveries from creating
 	// duplicate claws. Keyed by issue transition fingerprint; entries expire after 30s.
@@ -279,6 +281,8 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/settings", s.withWebAdminAuth(s.handleSettings))
 	mux.HandleFunc("/api/settings/status", s.withWebAdminAuth(s.handleSettingsStatus))
 	mux.HandleFunc("/api/settings/github/test", s.withWebAdminAuth(s.handleGitHubAppTest))
+	mux.HandleFunc("/api/settings/model-auth/login", s.withWebAdminAuth(s.handleModelAuthLogin))
+	mux.HandleFunc("/api/settings/model-auth/login/{id}", s.withWebAdminAuth(s.handleModelAuthLoginStatus))
 
 	// Template store
 	mux.HandleFunc("/api/templates", s.withWebAuth(s.handleTemplates))
@@ -3064,6 +3068,7 @@ docker --version`); err != nil {
 	activeKeyDaytona := resolveActiveKey(s.hubCfg.LLMKeys, llmKeyNameDaytona)
 	defaultModelDaytona := resolveDefaultModelForKey(s.hubCfg, activeKeyDaytona)
 	llmKeyEnvDaytona := buildLLMKeyEnv(s.hubCfg.LLMKeys, llmKeyNameDaytona)
+	modelAuthEnvDaytona := buildModelAuthEnv(s.hubCfg, llmKeyNameDaytona)
 	onboardFlags := buildOnboardFlags(s.hubCfg.LLMKeys, llmKeyNameDaytona, defaultModelDaytona)
 	providerConfigScript := buildOpenClawProviderConfig(s.hubCfg.LLMKeys, llmKeyNameDaytona)
 	if activeKeyDaytona != nil {
@@ -3074,6 +3079,16 @@ docker --version`); err != nil {
 	log.Printf("[daytona] OpenClaw model resolution claw=%s selected_llm_key=%q active_llm_key=%q provider=%q default_model=%q config_patch=%t",
 		clawID, llmKeyNameDaytona, activeKeyNameDaytona, activeKeyProviderDaytona, defaultModelDaytona, providerConfigScript != "")
 	gatewayPassword := randomHex(16)
+	if restoreShell := buildModelAuthRestoreShell(modelAuthEnvDaytona); restoreShell != "" {
+		if err := exec("restore model auth", 30*time.Second, "export HOME=/home/daytona; "+restoreShell); err != nil {
+			return fmt.Errorf("restore model auth: %w", err)
+		}
+	}
+	if installCmd := daytonaInstallCodingModelCLICommand(defaultModelDaytona); installCmd != "" {
+		if err := exec("install selected model cli", 2*time.Minute, installCmd); err != nil {
+			return fmt.Errorf("install selected model cli: %w", err)
+		}
+	}
 	onboardCmd := fmt.Sprintf(
 		"%sexport NVM_DIR=/usr/local/share/nvm; export PATH=$NVM_DIR/current/bin:$PATH; openclaw onboard --non-interactive --accept-risk --skip-daemon --skip-health %s 2>&1",
 		llmKeyEnvDaytona,
@@ -3600,6 +3615,35 @@ STATUS=/tmp/openclaw-install.status
 rm -f "$LOG" "$STATUS"
 setsid nohup bash -c %s > "$LOG" 2>&1 </dev/null &
 echo "openclaw-install-status=started"`, shellQuote(installScript))
+}
+
+func daytonaInstallCodingModelCLICommand(model string) string {
+	var packageSpec, binary string
+	switch {
+	case strings.HasPrefix(model, "codex/"):
+		packageSpec = "@openai/codex@" + cliVersionFromEnv("ELASTICCLAW_CODEX_CLI_VERSION", "0.141.0")
+		binary = "codex"
+	case strings.HasPrefix(model, "grok/"):
+		packageSpec = "@xai-official/grok@" + cliVersionFromEnv("ELASTICCLAW_GROK_CLI_VERSION", "0.1.0")
+		binary = "grok"
+	default:
+		return ""
+	}
+	return fmt.Sprintf(`export HOME=/home/daytona
+export NVM_DIR=/usr/local/share/nvm
+NPM="$NVM_DIR/current/bin/npm"
+PREFIX="$("$NPM" config get prefix)"
+export PATH="$PREFIX/bin:$NVM_DIR/current/bin:/usr/local/bin:$PATH"
+sudo env PATH="$PREFIX/bin:$NVM_DIR/current/bin:/usr/local/bin:$PATH" "$NPM" install -g %s --prefix "$PREFIX" --ignore-scripts
+hash -r
+%s --version 2>&1 || true`, shellQuote(packageSpec), binary)
+}
+
+func cliVersionFromEnv(envName, fallback string) string {
+	if v := strings.TrimSpace(os.Getenv(envName)); v != "" {
+		return v
+	}
+	return fallback
 }
 
 func daytonaOpenClawInstallStatusCommand(version string) string {
@@ -4158,6 +4202,7 @@ func (s *Server) bootstrapExedev(ctx context.Context, clawID, vmName string, p *
 
 	s.mu.RLock()
 	llmKeyEnv := buildLLMKeyEnv(s.hubCfg.LLMKeys, llmKeyName)
+	modelAuthEnv := buildModelAuthEnv(s.hubCfg, llmKeyName)
 	clawToken := s.hubCfg.ClawToken
 	hubCfg := s.hubCfg
 	s.mu.RUnlock()
@@ -4193,6 +4238,7 @@ func (s *Server) bootstrapExedev(ctx context.Context, clawID, vmName string, p *
 		HubCfg:          hubCfg,
 		GitHubRepos:     githubRepos,
 		LLMKeyEnv:       llmKeyEnv,
+		ModelAuthEnv:    modelAuthEnv,
 		LinearEnv:       buildLinearEnv(linearToken),
 		ProviderConfig:  buildOpenClawProviderConfig(hubCfg.LLMKeys, llmKeyName),
 		OnboardFlags:    buildOnboardFlags(hubCfg.LLMKeys, llmKeyName, defaultModel),
@@ -4264,6 +4310,7 @@ func (s *Server) provisionDocker(ctx context.Context, clawID string, req types.C
 
 	s.mu.RLock()
 	llmKeyEnv := buildLLMKeyEnv(s.hubCfg.LLMKeys, llmKeyName)
+	modelAuthEnv := buildModelAuthEnv(s.hubCfg, llmKeyName)
 	clawToken := s.hubCfg.ClawToken
 	hubCfg := s.hubCfg
 	s.mu.RUnlock()
@@ -4297,7 +4344,7 @@ func (s *Server) provisionDocker(ctx context.Context, clawID string, req types.C
 	}
 
 	// Inject LLM keys: buildLLMKeyEnv returns "export VAR=val\n" lines — parse into k/v
-	for _, line := range strings.Split(llmKeyEnv, "\n") {
+	for _, line := range strings.Split(llmKeyEnv+modelAuthEnv, "\n") {
 		line = strings.TrimSpace(line)
 		if !strings.HasPrefix(line, "export ") {
 			continue
@@ -5028,6 +5075,7 @@ func (s *Server) bootstrapReplicated(clawID, clawName, vmID string, cfg types.Pr
 	s.mu.RLock()
 	// Inject all configured LLM keys, prioritizing the selected key if specified
 	llmKeyEnv := buildLLMKeyEnv(s.hubCfg.LLMKeys, llmKeyName)
+	modelAuthEnv := buildModelAuthEnv(s.hubCfg, llmKeyName)
 	clawToken := s.hubCfg.ClawToken
 	hubCfg := s.hubCfg
 	s.mu.RUnlock()
@@ -5046,6 +5094,7 @@ func (s *Server) bootstrapReplicated(clawID, clawName, vmID string, cfg types.Pr
 		HubCfg:          hubCfg,
 		GitHubRepos:     githubRepos,
 		LLMKeyEnv:       llmKeyEnv,
+		ModelAuthEnv:    modelAuthEnv,
 		LinearEnv:       buildLinearEnv(linearToken),
 		ProviderConfig:  buildOpenClawProviderConfig(hubCfg.LLMKeys, llmKeyName),
 		OnboardFlags:    buildOnboardFlags(hubCfg.LLMKeys, llmKeyName, defaultModel),

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/elasticclaw/elasticclaw/internal/webui"
 
+	"github.com/elasticclaw/elasticclaw/pkg/cliversion"
 	"github.com/elasticclaw/elasticclaw/pkg/hub/artifact"
 	"github.com/elasticclaw/elasticclaw/pkg/hub/pipeline"
 	daytona "github.com/elasticclaw/elasticclaw/pkg/provider/daytona"
@@ -3621,10 +3622,10 @@ func daytonaInstallCodingModelCLICommand(model string) string {
 	var packageSpec, binary string
 	switch {
 	case strings.HasPrefix(model, "codex/"):
-		packageSpec = "@openai/codex@" + cliVersionFromEnv("ELASTICCLAW_CODEX_CLI_VERSION", "0.141.0")
+		packageSpec = "@openai/codex@" + cliversion.FromEnv("ELASTICCLAW_CODEX_CLI_VERSION", "0.141.0")
 		binary = "codex"
 	case strings.HasPrefix(model, "grok/"):
-		packageSpec = "@xai-official/grok@" + cliVersionFromEnv("ELASTICCLAW_GROK_CLI_VERSION", "0.1.0")
+		packageSpec = "@xai-official/grok@" + cliversion.FromEnv("ELASTICCLAW_GROK_CLI_VERSION", "0.1.0")
 		binary = "grok"
 	default:
 		return ""
@@ -3637,13 +3638,6 @@ export PATH="$PREFIX/bin:$NVM_DIR/current/bin:/usr/local/bin:$PATH"
 sudo env PATH="$PREFIX/bin:$NVM_DIR/current/bin:/usr/local/bin:$PATH" "$NPM" install -g %s --prefix "$PREFIX" --ignore-scripts
 hash -r
 %s --version 2>&1 || true`, shellQuote(packageSpec), binary)
-}
-
-func cliVersionFromEnv(envName, fallback string) string {
-	if v := strings.TrimSpace(os.Getenv(envName)); v != "" {
-		return v
-	}
-	return fallback
 }
 
 func daytonaOpenClawInstallStatusCommand(version string) string {

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -209,6 +209,26 @@ func TestResolveDefaultModelForKey(t *testing.T) {
 			expectedModel: "groq/llama-3.3-70b-versatile",
 		},
 		{
+			name: "codex provider",
+			hubCfg: &types.HubConfig{
+				DefaultModel: "",
+			},
+			key: &types.LLMKeyConfig{
+				Provider: "codex",
+			},
+			expectedModel: "codex/gpt-5.5",
+		},
+		{
+			name: "grok provider",
+			hubCfg: &types.HubConfig{
+				DefaultModel: "",
+			},
+			key: &types.LLMKeyConfig{
+				Provider: "grok",
+			},
+			expectedModel: "grok/grok-build-0.1",
+		},
+		{
 			name: "deepseek provider",
 			hubCfg: &types.HubConfig{
 				DefaultModel: "",

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -29,19 +29,28 @@ type LLMKeyView struct {
 	KeySet       bool   `json:"keySet"`
 	Default      bool   `json:"default"`
 	DefaultModel string `json:"defaultModel,omitempty"`
+	AuthProfile  string `json:"authProfile,omitempty"`
+}
+
+type ModelAuthProfileView struct {
+	Name          string `json:"name"`
+	Provider      string `json:"provider"`
+	Mode          string `json:"mode"`
+	Authenticated bool   `json:"authenticated"`
+	UpdatedAt     string `json:"updatedAt,omitempty"`
 }
 
 // MCPView is the redacted view of an MCP server config for the settings page.
 type MCPView struct {
-	Name      string            `json:"name"`
-	Source    string            `json:"source"`
-	Package   string            `json:"package,omitempty"`
-	Image     string            `json:"image,omitempty"`
-	URL       string            `json:"url,omitempty"`
-	Enabled   bool              `json:"enabled"`
-	Config    map[string]string `json:"config,omitempty"`
-	Secrets   []string          `json:"secrets,omitempty"` // env var names only, not values
-	Command   []string          `json:"command,omitempty"`
+	Name    string            `json:"name"`
+	Source  string            `json:"source"`
+	Package string            `json:"package,omitempty"`
+	Image   string            `json:"image,omitempty"`
+	URL     string            `json:"url,omitempty"`
+	Enabled bool              `json:"enabled"`
+	Config  map[string]string `json:"config,omitempty"`
+	Secrets []string          `json:"secrets,omitempty"` // env var names only, not values
+	Command []string          `json:"command,omitempty"`
 }
 
 // ConcurrencyGroupView is the JSON-safe view of a concurrency group.
@@ -53,15 +62,16 @@ type ConcurrencyGroupView struct {
 // SettingsView is the redacted view of hub config for the settings page.
 // Secrets are masked — never returned in full.
 type SettingsView struct {
-	LLMKeys       []LLMKeyView            `json:"llmKeys"`
-	Providers     map[string]ProviderView `json:"providers"`
-	GitHub        []GitHubAppView         `json:"github"`
-	SSHPublicKeys []string                `json:"sshPublicKeys"`
-	Integrations  *IntegrationsView       `json:"integrations"`
-	Factories     []FactoryView           `json:"factories"`
-	Secrets       []string                `json:"secrets"`
-	MCPServers    []MCPView               `json:"mcpServers,omitempty"`
-	Auth          *AuthView               `json:"auth,omitempty"`
+	LLMKeys           []LLMKeyView            `json:"llmKeys"`
+	ModelAuthProfiles []ModelAuthProfileView  `json:"modelAuthProfiles,omitempty"`
+	Providers         map[string]ProviderView `json:"providers"`
+	GitHub            []GitHubAppView         `json:"github"`
+	SSHPublicKeys     []string                `json:"sshPublicKeys"`
+	Integrations      *IntegrationsView       `json:"integrations"`
+	Factories         []FactoryView           `json:"factories"`
+	Secrets           []string                `json:"secrets"`
+	MCPServers        []MCPView               `json:"mcpServers,omitempty"`
+	Auth              *AuthView               `json:"auth,omitempty"`
 	// ConcurrencyGroups limits simultaneously running claws per group. 0 = unlimited.
 	ConcurrencyGroups []ConcurrencyGroupView `json:"concurrencyGroups"`
 	// MaxConcurrentClaws limits simultaneously running claws. 0 = unlimited.
@@ -118,26 +128,26 @@ func isFactoryEnabled(f *types.FactoryConfig) bool {
 }
 
 type FactoryView struct {
-	Name                string   `json:"name"`
-	Integration         string   `json:"integration"`
-	Workspace           string   `json:"workspace"`
-	Team                string   `json:"team"`
-	TriggerStatus       string   `json:"triggerStatus"`
-	DoneStatus          string   `json:"doneStatus"`
-	TerminateOnLeave    bool     `json:"terminateOnLeave"`
-	Template            string   `json:"template"`
-	NamePattern         string   `json:"namePattern"`
-	WebhookSecretSet    bool     `json:"webhookSecretSet"`
-	WebhookSecretRef    string   `json:"webhookSecretRef,omitempty"`
-	PipelineYAML        string   `json:"pipelineYAML,omitempty"`
-	Tags                []string `json:"tags"`
-	Color               string   `json:"color"`
-	Labels              []string `json:"labels,omitempty"`
-	AssignedTo          string   `json:"assigned_to,omitempty"`
-	Enabled             bool     `json:"enabled"`
-	ConcurrencyGroup    string   `json:"concurrencyGroup,omitempty"`
-	EnableManualTrigger bool     `json:"enable_manual_trigger,omitempty"`
-	SecretRefs          map[string]string `json:"secret_refs,omitempty"`
+	Name                string                 `json:"name"`
+	Integration         string                 `json:"integration"`
+	Workspace           string                 `json:"workspace"`
+	Team                string                 `json:"team"`
+	TriggerStatus       string                 `json:"triggerStatus"`
+	DoneStatus          string                 `json:"doneStatus"`
+	TerminateOnLeave    bool                   `json:"terminateOnLeave"`
+	Template            string                 `json:"template"`
+	NamePattern         string                 `json:"namePattern"`
+	WebhookSecretSet    bool                   `json:"webhookSecretSet"`
+	WebhookSecretRef    string                 `json:"webhookSecretRef,omitempty"`
+	PipelineYAML        string                 `json:"pipelineYAML,omitempty"`
+	Tags                []string               `json:"tags"`
+	Color               string                 `json:"color"`
+	Labels              []string               `json:"labels,omitempty"`
+	AssignedTo          string                 `json:"assigned_to,omitempty"`
+	Enabled             bool                   `json:"enabled"`
+	ConcurrencyGroup    string                 `json:"concurrencyGroup,omitempty"`
+	EnableManualTrigger bool                   `json:"enable_manual_trigger,omitempty"`
+	SecretRefs          map[string]string      `json:"secret_refs,omitempty"`
 	ExternalTrigger     *types.ExternalTrigger `json:"externalTrigger,omitempty"`
 }
 
@@ -153,12 +163,12 @@ type ProviderView struct {
 	DefaultTTL          string `json:"defaultTtl,omitempty"`
 	DefaultInstanceType string `json:"defaultInstanceType,omitempty"`
 	// exe.dev
-	SSHKeySet       bool   `json:"sshKeySet,omitempty"`
-	SSHPublicKey    string `json:"sshPublicKey,omitempty"`
-	DefaultCPU      int    `json:"defaultCpu,omitempty"`
-	DefaultMemory   string `json:"defaultMemory,omitempty"`
-	DefaultDisk     string `json:"defaultDisk,omitempty"`
-	_sshKeyPath     string `json:"-"` // internal: path for file I/O outside lock
+	SSHKeySet     bool   `json:"sshKeySet,omitempty"`
+	SSHPublicKey  string `json:"sshPublicKey,omitempty"`
+	DefaultCPU    int    `json:"defaultCpu,omitempty"`
+	DefaultMemory string `json:"defaultMemory,omitempty"`
+	DefaultDisk   string `json:"defaultDisk,omitempty"`
+	_sshKeyPath   string `json:"-"` // internal: path for file I/O outside lock
 }
 
 // GitHubAppPermission is a single permission check result for a GitHub App.
@@ -170,12 +180,12 @@ type GitHubAppPermission struct {
 }
 
 type GitHubAppView struct {
-	AppID       int64                 `json:"appId"`
-	URL         string                `json:"url,omitempty"`
-	KeySet      bool                  `json:"keySet"`
-	Permissions []GitHubAppPermission `json:"permissions,omitempty"`
-	PermCheckOK *bool                 `json:"permCheckOk,omitempty"` // nil = not checked yet
-	PermCheckError string           `json:"permCheckError,omitempty"`
+	AppID          int64                 `json:"appId"`
+	URL            string                `json:"url,omitempty"`
+	KeySet         bool                  `json:"keySet"`
+	Permissions    []GitHubAppPermission `json:"permissions,omitempty"`
+	PermCheckOK    *bool                 `json:"permCheckOk,omitempty"` // nil = not checked yet
+	PermCheckError string                `json:"permCheckError,omitempty"`
 }
 
 // SettingsPatch is the request body for PATCH /api/settings.
@@ -189,6 +199,14 @@ type LLMKeyPatch struct {
 	Default      *bool   `json:"default,omitempty"`
 	Delete       bool    `json:"delete,omitempty"`
 	DefaultModel *string `json:"defaultModel,omitempty"`
+	AuthProfile  *string `json:"authProfile,omitempty"`
+}
+
+type ModelAuthProfilePatch struct {
+	Name     string `json:"name"`
+	Provider string `json:"provider,omitempty"`
+	Mode     string `json:"mode,omitempty"`
+	Delete   bool   `json:"delete,omitempty"`
 }
 
 // ConcurrencyGroupPatch is a patch for a concurrency group.
@@ -199,15 +217,16 @@ type ConcurrencyGroupPatch struct {
 }
 
 type SettingsPatch struct {
-	LLMKeys       []LLMKeyPatch            `json:"llmKeys,omitempty"`
-	Providers     map[string]ProviderPatch `json:"providers,omitempty"`
-	GitHub        []GitHubAppPatch         `json:"github,omitempty"`
-	UIPassword    string                   `json:"uiPassword,omitempty"`
-	SSHPublicKeys *[]string                `json:"sshPublicKeys,omitempty"`
-	Integrations  *IntegrationsPatch       `json:"integrations,omitempty"`
-	Factories     []FactoryPatch           `json:"factories,omitempty"`
-	MCPServers    []MCPPatch               `json:"mcpServers,omitempty"`
-	Auth          *AuthPatch               `json:"auth,omitempty"`
+	LLMKeys           []LLMKeyPatch            `json:"llmKeys,omitempty"`
+	ModelAuthProfiles []ModelAuthProfilePatch  `json:"modelAuthProfiles,omitempty"`
+	Providers         map[string]ProviderPatch `json:"providers,omitempty"`
+	GitHub            []GitHubAppPatch         `json:"github,omitempty"`
+	UIPassword        string                   `json:"uiPassword,omitempty"`
+	SSHPublicKeys     *[]string                `json:"sshPublicKeys,omitempty"`
+	Integrations      *IntegrationsPatch       `json:"integrations,omitempty"`
+	Factories         []FactoryPatch           `json:"factories,omitempty"`
+	MCPServers        []MCPPatch               `json:"mcpServers,omitempty"`
+	Auth              *AuthPatch               `json:"auth,omitempty"`
 	// ConcurrencyGroups replaces the full list of concurrency groups.
 	ConcurrencyGroups *[]ConcurrencyGroupPatch `json:"concurrencyGroups,omitempty"`
 	// MaxConcurrentClaws limits simultaneously running claws. 0 or omitted = unlimited.
@@ -279,30 +298,30 @@ type GitHubIssuesIntegrationPatch struct {
 }
 
 type FactoryPatch struct {
-	Name                string              `json:"name"`
-	OriginalName        string              `json:"originalName,omitempty"`
-	Integration         string              `json:"integration"`
-	Workspace           string              `json:"workspace"`
-	Team                string              `json:"team,omitempty"`
-	TriggerStatus       string              `json:"triggerStatus"`
-	DoneStatus          string              `json:"doneStatus,omitempty"`
-	TerminateOnLeave    bool                `json:"terminateOnLeave"`
-	Template            string              `json:"template"`
-	NamePattern         string              `json:"namePattern,omitempty"`
-	WebhookSecret       string              `json:"webhookSecret,omitempty"`
-	WebhookSecretRef    string              `json:"webhookSecretRef,omitempty"`
-	PipelineYAML        string              `json:"pipelineYAML,omitempty"`
-	Tags                []string            `json:"tags,omitempty"`
-	Color               string              `json:"color,omitempty"`
-	Labels              []string            `json:"labels,omitempty"`
-	AssignedTo          string              `json:"assigned_to,omitempty"`
-	Enabled             *bool               `json:"enabled,omitempty"`
-	ConcurrencyGroup    string              `json:"concurrencyGroup,omitempty"`
-	EnableManualTrigger bool                `json:"enable_manual_trigger,omitempty"`
-	SecretRefs          map[string]string   `json:"secret_refs,omitempty"`
-	Inputs              []types.FactoryInput `json:"inputs,omitempty"`
-	Repos               []string            `json:"repos,omitempty"`
-	Trigger             *types.GitHubTrigger `json:"trigger,omitempty"`
+	Name                string                 `json:"name"`
+	OriginalName        string                 `json:"originalName,omitempty"`
+	Integration         string                 `json:"integration"`
+	Workspace           string                 `json:"workspace"`
+	Team                string                 `json:"team,omitempty"`
+	TriggerStatus       string                 `json:"triggerStatus"`
+	DoneStatus          string                 `json:"doneStatus,omitempty"`
+	TerminateOnLeave    bool                   `json:"terminateOnLeave"`
+	Template            string                 `json:"template"`
+	NamePattern         string                 `json:"namePattern,omitempty"`
+	WebhookSecret       string                 `json:"webhookSecret,omitempty"`
+	WebhookSecretRef    string                 `json:"webhookSecretRef,omitempty"`
+	PipelineYAML        string                 `json:"pipelineYAML,omitempty"`
+	Tags                []string               `json:"tags,omitempty"`
+	Color               string                 `json:"color,omitempty"`
+	Labels              []string               `json:"labels,omitempty"`
+	AssignedTo          string                 `json:"assigned_to,omitempty"`
+	Enabled             *bool                  `json:"enabled,omitempty"`
+	ConcurrencyGroup    string                 `json:"concurrencyGroup,omitempty"`
+	EnableManualTrigger bool                   `json:"enable_manual_trigger,omitempty"`
+	SecretRefs          map[string]string      `json:"secret_refs,omitempty"`
+	Inputs              []types.FactoryInput   `json:"inputs,omitempty"`
+	Repos               []string               `json:"repos,omitempty"`
+	Trigger             *types.GitHubTrigger   `json:"trigger,omitempty"`
 	ExternalTrigger     *types.ExternalTrigger `json:"externalTrigger,omitempty"`
 }
 
@@ -396,6 +415,20 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 			KeySet:       llmKeyHasRequiredAPIKey(k),
 			Default:      k.Default,
 			DefaultModel: k.DefaultModel,
+			AuthProfile:  k.AuthProfile,
+		})
+	}
+	view.ModelAuthProfiles = []ModelAuthProfileView{}
+	for _, profile := range s.hubCfg.ModelAuthProfiles {
+		if profile == nil {
+			continue
+		}
+		view.ModelAuthProfiles = append(view.ModelAuthProfiles, ModelAuthProfileView{
+			Name:          profile.Name,
+			Provider:      profile.Provider,
+			Mode:          profile.Mode,
+			Authenticated: profile.AuthState != "",
+			UpdatedAt:     profile.UpdatedAt,
 		})
 	}
 
@@ -764,8 +797,55 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 			if kp.DefaultModel != nil {
 				found.DefaultModel = *kp.DefaultModel
 			}
+			if kp.AuthProfile != nil {
+				found.AuthProfile = *kp.AuthProfile
+			}
 		}
 		updatedCfg.LLMKeys = existing
+	}
+
+	if len(patch.ModelAuthProfiles) > 0 {
+		existing := make([]*types.ModelAuthProfileConfig, len(updatedCfg.ModelAuthProfiles))
+		for i, p := range updatedCfg.ModelAuthProfiles {
+			if p == nil {
+				continue
+			}
+			copy := *p
+			existing[i] = &copy
+		}
+		for _, pp := range patch.ModelAuthProfiles {
+			if pp.Name == "" {
+				continue
+			}
+			if pp.Delete {
+				filtered := existing[:0]
+				for _, p := range existing {
+					if p == nil || p.Name != pp.Name {
+						filtered = append(filtered, p)
+					}
+				}
+				existing = filtered
+				continue
+			}
+			var found *types.ModelAuthProfileConfig
+			for _, p := range existing {
+				if p != nil && p.Name == pp.Name {
+					found = p
+					break
+				}
+			}
+			if found == nil {
+				found = &types.ModelAuthProfileConfig{Name: pp.Name}
+				existing = append(existing, found)
+			}
+			if pp.Provider != "" {
+				found.Provider = pp.Provider
+			}
+			if pp.Mode != "" {
+				found.Mode = pp.Mode
+			}
+		}
+		updatedCfg.ModelAuthProfiles = existing
 	}
 
 	// Providers

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -64,6 +64,8 @@ func (k *LLMKeyConfig) EnvVarName() string {
 		return "FIREWORKS_API_KEY"
 	case "codex":
 		return "CODEX_API_KEY"
+	case "grok":
+		return "XAI_API_KEY"
 	default:
 		// Generic: PROVIDER_API_KEY uppercased
 		return strings.ToUpper(k.Provider) + "_API_KEY"

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -16,6 +16,15 @@ type LLMKeyConfig struct {
 	APIKey       string `yaml:"api_key"       json:"-"`                       // the actual key (never exposed in API)
 	Default      bool   `yaml:"default"       json:"default"`                 // use when no llm_key specified
 	DefaultModel string `yaml:"default_model" json:"default_model,omitempty"` // preferred model for this key, e.g. "fireworks/accounts/fireworks/models/kimi-k2p6"
+	AuthProfile  string `yaml:"auth_profile,omitempty" json:"auth_profile,omitempty"`
+}
+
+type ModelAuthProfileConfig struct {
+	Name      string `yaml:"name" json:"name"`
+	Provider  string `yaml:"provider" json:"provider"`
+	Mode      string `yaml:"mode" json:"mode"`
+	AuthState string `yaml:"auth_state,omitempty" json:"-"`
+	UpdatedAt string `yaml:"updated_at,omitempty" json:"updated_at,omitempty"`
 }
 
 // LLMKeysList is a custom YAML type that handles both the legacy flat-map format
@@ -479,6 +488,8 @@ type HubConfig struct {
 	// LLMKeys is a list of named LLM API keys. One can be marked default:true.
 	// Legacy flat map {"anthropic": "sk-..."} is still accepted for backwards compat.
 	LLMKeys LLMKeysList `yaml:"llm_keys,omitempty"`
+	// ModelAuthProfiles stores CLI-backed model login state for providers such as Codex and Grok.
+	ModelAuthProfiles []*ModelAuthProfileConfig `yaml:"model_auth_profiles,omitempty"`
 	// Linear is a list of Linear workspace configs for injecting API tokens into claws.
 	Linear []*LinearConfig `yaml:"linear,omitempty"`
 

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -848,6 +848,7 @@ const PROVIDER_OPTIONS = [
   { value: "fireworks",  label: "Fireworks",  placeholder: "fw_..." },
   { value: "openai",     label: "OpenAI",     placeholder: "sk-proj-..." },
   { value: "codex",      label: "Codex",      placeholder: "sk-proj-..." },
+  { value: "grok",       label: "Grok Build", placeholder: "xai-..." },
   { value: "ollama",     label: "Ollama",     placeholder: "ollama-local" },
   { value: "other",      label: "Other",      placeholder: "" },
 ]
@@ -885,11 +886,15 @@ const PROVIDER_MODELS: Record<string, { id: string; name: string }[]> = {
     { id: "__custom",             name: "Custom OpenAI model" },
   ],
   codex: [
-    // Codex is an autonomous agentic coding platform — it selects and routes to the
-    // appropriate underlying model (including special Codex checkpoints) on its own.
-    { id: "codex/codex",      name: "Codex (auto)" },
-    { id: "codex/codex-pro",  name: "Codex Pro (auto)" },
-    { id: "__custom",         name: "Custom Codex model" },
+    { id: "codex/gpt-5.5",      name: "GPT-5.5" },
+    { id: "codex/gpt-5.5-high", name: "GPT-5.5 High" },
+    { id: "codex/gpt-5.4",      name: "GPT-5.4" },
+    { id: "__custom",           name: "Custom Codex model" },
+  ],
+  grok: [
+    { id: "grok/grok-build-0.1", name: "Grok Build" },
+    { id: "grok/grok-4.3",       name: "Grok 4.3" },
+    { id: "__custom",            name: "Custom Grok model" },
   ],
   ollama: [
     { id: "ollama/qwen2.5-coder:1.5b", name: "Qwen2.5 Coder 1.5B" },

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -35,6 +35,26 @@ interface LLMKeyView {
   keySet: boolean
   default: boolean
   defaultModel?: string
+  authProfile?: string
+}
+
+interface ModelAuthProfileView {
+  name: string
+  provider: string
+  mode: string
+  authenticated: boolean
+  updatedAt?: string
+}
+
+interface ModelAuthLoginJob {
+  id: string
+  provider: string
+  profile: string
+  status: string
+  url?: string
+  code?: string
+  output?: string
+  error?: string
 }
 
 interface GitHubAppPermission {
@@ -65,6 +85,7 @@ interface WorkspaceGitHubAppView {
 
 interface SettingsData {
   llmKeys: LLMKeyView[]
+  modelAuthProfiles?: ModelAuthProfileView[]
   providers: Record<string, {
     type: string
     enabled: boolean
@@ -142,6 +163,28 @@ async function patchSettings(patch: object): Promise<void> {
     body: JSON.stringify(patch),
   })
   if (!res.ok) throw new Error(await res.text())
+}
+
+async function startModelAuthLogin(provider: string, profile: string): Promise<ModelAuthLoginJob> {
+  const hubUrl = getHubUrl()
+  const token = getAuthToken() || ""
+  const res = await fetch(`${hubUrl}/api/settings/model-auth/login`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+    body: JSON.stringify({ provider, profile, mode: "device" }),
+  })
+  if (!res.ok) throw new Error(await res.text())
+  return res.json()
+}
+
+async function fetchModelAuthLogin(id: string): Promise<ModelAuthLoginJob> {
+  const hubUrl = getHubUrl()
+  const token = getAuthToken() || ""
+  const res = await fetch(`${hubUrl}/api/settings/model-auth/login/${encodeURIComponent(id)}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  if (!res.ok) throw new Error(await res.text())
+  return res.json()
 }
 
 // Sentinel value used in static-export paths to represent "select first workspace"
@@ -919,12 +962,17 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
   const [formDefault, setFormDefault] = useState(false)
   const [formDefaultModel, setFormDefaultModel] = useState("")
   const [formCustomModel, setFormCustomModel] = useState("")
+  const [formAuthProfile, setFormAuthProfile] = useState("")
+  const [loginJob, setLoginJob] = useState<ModelAuthLoginJob | null>(null)
+  const [loginError, setLoginError] = useState("")
 
   const providerLabel = (p: string) => PROVIDER_OPTIONS.find(o => o.value === p)?.label ?? p
   const providerPlaceholder = (p: string) => PROVIDER_OPTIONS.find(o => o.value === p)?.placeholder ?? ""
+  const supportsCLIAuth = formProvider === "codex" || formProvider === "grok"
+  const authProfiles = (settings.modelAuthProfiles || []).filter(p => p.provider === formProvider)
 
   const resetForm = () => {
-    setFormName(""); setFormProvider("anthropic"); setFormCustomProvider(""); setFormKey(""); setFormDefault(false); setFormDefaultModel(""); setFormCustomModel(""); setEditIdx(null)
+    setFormName(""); setFormProvider("anthropic"); setFormCustomProvider(""); setFormKey(""); setFormDefault(false); setFormDefaultModel(""); setFormCustomModel(""); setFormAuthProfile(""); setLoginJob(null); setLoginError(""); setEditIdx(null)
   }
 
   const openAdd = () => { resetForm(); setModalMode("add"); setShowModal(true) }
@@ -936,6 +984,7 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
     setFormCustomProvider(isCustom ? k.provider : "")
     setFormKey("")
     setFormDefault(k.default)
+    setFormAuthProfile(k.authProfile || "")
     const providerModels = PROVIDER_MODELS[k.provider] || []
     if (k.defaultModel && providerModels.length > 0 && !providerModels.some(m => m.id === k.defaultModel)) {
       setFormDefaultModel("__custom")
@@ -955,9 +1004,10 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
   function doSave() {
     const actualProvider = formProvider === "other" ? formCustomProvider : formProvider
     const actualDefaultModel = formDefaultModel === "__custom" ? formCustomModel.trim() : formDefaultModel
+    const actualAuthProfile = supportsCLIAuth ? formAuthProfile.trim() : ""
     if (modalMode === "add") {
-      if (!formName.trim() || (!formKey.trim() && actualProvider !== "ollama")) return
-      onSave({ llmKeys: [{ name: formName.trim(), provider: actualProvider, apiKey: formKey.trim(), default: formDefault, defaultModel: actualDefaultModel || undefined }] })
+      if (!formName.trim() || (!formKey.trim() && actualProvider !== "ollama" && !actualAuthProfile)) return
+      onSave({ llmKeys: [{ name: formName.trim(), provider: actualProvider, apiKey: formKey.trim(), default: formDefault, defaultModel: actualDefaultModel || undefined, authProfile: actualAuthProfile || undefined }] })
     } else if (editIdx !== null) {
       const existing = llmKeys[editIdx]
       const patch: Record<string, unknown> = {
@@ -967,6 +1017,7 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
       if (formKey.trim()) patch.apiKey = formKey.trim()
       patch.default = formDefault       // always send so user can unset
       if (actualDefaultModel) patch.defaultModel = actualDefaultModel
+      patch.authProfile = actualAuthProfile
       if (actualProvider !== existing.provider) patch.provider = actualProvider
       onSave({ llmKeys: [patch] })
     }
@@ -983,6 +1034,31 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
   function setDefault(i: number) {
     onSave({ llmKeys: [{ name: llmKeys[i].name, default: true }] })
   }
+
+  async function doStartLogin() {
+    const profile = formAuthProfile.trim() || `${formProvider}-default`
+    setFormAuthProfile(profile)
+    setLoginError("")
+    try {
+      const job = await startModelAuthLogin(formProvider, profile)
+      setLoginJob(job)
+    } catch (err) {
+      setLoginError(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  useEffect(() => {
+    if (!loginJob || loginJob.status !== "running") return
+    const timer = window.setInterval(async () => {
+      try {
+        const next = await fetchModelAuthLogin(loginJob.id)
+        setLoginJob(next)
+      } catch (err) {
+        setLoginError(err instanceof Error ? err.message : String(err))
+      }
+    }, 1500)
+    return () => window.clearInterval(timer)
+  }, [loginJob])
 
   return (
     <div className="space-y-6">
@@ -1147,6 +1223,46 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
                   placeholder={modalMode === "edit" ? "Leave blank to keep existing" : providerPlaceholder(formProvider)}
                 />
               </div>
+              {supportsCLIAuth && (
+                <div className="space-y-2">
+                  <label className="text-xs text-muted-foreground mb-1 block">CLI auth profile <span className="text-muted-foreground/60">(optional)</span></label>
+                  <div className="flex gap-2">
+                    <Input
+                      value={formAuthProfile}
+                      onChange={e => setFormAuthProfile(e.target.value)}
+                      className="h-8 text-sm"
+                      placeholder={`${formProvider}-default`}
+                    />
+                    <Button type="button" size="sm" variant="outline" onClick={doStartLogin} disabled={saving}>
+                      Login
+                    </Button>
+                  </div>
+                  {authProfiles.length > 0 && (
+                    <select
+                      value={formAuthProfile}
+                      onChange={e => setFormAuthProfile(e.target.value)}
+                      className="h-8 text-sm w-full rounded-md border border-input bg-background px-2 py-1"
+                    >
+                      <option value="">No CLI auth profile</option>
+                      {authProfiles.map(p => (
+                        <option key={p.name} value={p.name}>{p.name}{p.authenticated ? " (authenticated)" : ""}</option>
+                      ))}
+                    </select>
+                  )}
+                  {loginJob && (
+                    <div className="rounded-md border border-border p-3 text-xs space-y-1">
+                      <div className="text-muted-foreground">Login status: {loginJob.status}</div>
+                      {loginJob.url && (
+                        <a href={loginJob.url} target="_blank" rel="noopener noreferrer" className="underline break-all">{loginJob.url}</a>
+                      )}
+                      {loginJob.code && <div>Code: <span className="font-mono">{loginJob.code}</span></div>}
+                      {loginJob.error && <div className="text-red-400">{loginJob.error}</div>}
+                      {loginJob.status === "complete" && <div className="text-green-400">Profile saved. Save this model key to use it.</div>}
+                    </div>
+                  )}
+                  {loginError && <div className="text-xs text-red-400">{loginError}</div>}
+                </div>
+              )}
               <div>
                 <label className="text-xs text-muted-foreground mb-1 block">Default model <span className="text-muted-foreground/60">(optional)</span></label>
                 {PROVIDER_MODELS[formProvider] ? (
@@ -1188,7 +1304,7 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
                 <Button size="sm" variant="outline" onClick={() => { setShowModal(false); resetForm() }}>Cancel</Button>
                 <Button
                   size="sm"
-                  disabled={saving || !formName.trim() || (modalMode === "add" && !formKey.trim()) || (formProvider === "other" && !formCustomProvider.trim())}
+                  disabled={saving || !formName.trim() || (modalMode === "add" && !formKey.trim() && formProvider !== "ollama" && !formAuthProfile.trim()) || (formProvider === "other" && !formCustomProvider.trim())}
                   onClick={doSave}
                 >
                   {modalMode === "add" ? "Add Model Key" : "Save changes"}


### PR DESCRIPTION
## Summary
- add Codex and Grok Build as OpenClaw-compatible model options
- add pinned CLI model bootstrap/auth profile support
- expose CLI auth status and login flows in settings

## Tests
- npm run build
- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./pkg/hub ./cmd/claw-bridge