### PR TITLE
Show all Fireworks API models in settings

### DIFF
--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -2058,6 +2058,8 @@ echo "Git: $(git --version)"
 }
 
 const openClawVersion = "2026.6.9"
+const codexCLIVersion = "0.141.0"
+const grokCLIVersion = "0.1.0"
 
 // installOpenClaw installs the pinned OpenClaw CLI via npm.
 func installOpenClaw() error {
@@ -2068,6 +2070,58 @@ func installOpenClaw() error {
 	out, _ := exec.Command("openclaw", "--version").Output()
 	log.Printf("[bootstrap] OpenClaw: %s", strings.TrimSpace(string(out)))
 	return nil
+}
+
+func cliCodingProviderForModel(model string) string {
+	switch {
+	case strings.HasPrefix(model, "codex/"):
+		return "codex"
+	case strings.HasPrefix(model, "grok/"):
+		return "grok"
+	default:
+		return ""
+	}
+}
+
+func cliVersion(envName, fallback string) string {
+	if v := strings.TrimSpace(os.Getenv(envName)); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func installNPMCLI(packageName, version, binaryName string) error {
+	if strings.TrimSpace(version) == "" {
+		return fmt.Errorf("empty version for %s", packageName)
+	}
+	spec := packageName + "@" + version
+	log.Printf("[bootstrap] installing %s...", spec)
+	if err := runShell(fmt.Sprintf("sudo npm install -g %s --ignore-scripts", shellQuote(spec))); err != nil {
+		return fmt.Errorf("npm install %s: %w", spec, err)
+	}
+	out, err := exec.Command(binaryName, "--version").CombinedOutput()
+	if err != nil {
+		log.Printf("[bootstrap] %s version check warning: %v: %s", binaryName, err, strings.TrimSpace(string(out)))
+		return nil
+	}
+	log.Printf("[bootstrap] %s: %s", binaryName, strings.TrimSpace(string(out)))
+	return nil
+}
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'"'"'`) + "'"
+}
+
+func installSelectedCodingModelCLI() error {
+	model := envOr("OPENCLAW_DEFAULT_MODEL", "")
+	switch cliCodingProviderForModel(model) {
+	case "codex":
+		return installNPMCLI("@openai/codex", cliVersion("ELASTICCLAW_CODEX_CLI_VERSION", codexCLIVersion), "codex")
+	case "grok":
+		return installNPMCLI("@xai-official/grok", cliVersion("ELASTICCLAW_GROK_CLI_VERSION", grokCLIVersion), "grok")
+	default:
+		return nil
+	}
 }
 
 // configureOpenClaw patches ~/.openclaw/openclaw.json with model, LLM keys,
@@ -2403,6 +2457,11 @@ func runBootstrap() error {
 	// Step 3: Install OpenClaw (needs Node)
 	if err := installOpenClaw(); err != nil {
 		return fmt.Errorf("installOpenClaw: %w", err)
+	}
+
+	// Step 3b: Install pinned CLI-backed model providers when selected.
+	if err := installSelectedCodingModelCLI(); err != nil {
+		return fmt.Errorf("installSelectedCodingModelCLI: %w", err)
 	}
 
 	// Step 4: Run openclaw onboard (initializes ~/.openclaw directory)

--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -43,6 +43,8 @@ import (
 
 	"nhooyr.io/websocket"
 	"nhooyr.io/websocket/wsjson"
+
+	"github.com/elasticclaw/elasticclaw/pkg/cliversion"
 )
 
 var (
@@ -2087,13 +2089,6 @@ func cliCodingProviderForModel(model string) string {
 	}
 }
 
-func cliVersion(envName, fallback string) string {
-	if v := strings.TrimSpace(os.Getenv(envName)); v != "" {
-		return v
-	}
-	return fallback
-}
-
 func installNPMCLI(packageName, version, binaryName string) error {
 	if strings.TrimSpace(version) == "" {
 		return fmt.Errorf("empty version for %s", packageName)
@@ -2158,9 +2153,9 @@ func installSelectedCodingModelCLI() error {
 	model := envOr("OPENCLAW_DEFAULT_MODEL", "")
 	switch cliCodingProviderForModel(model) {
 	case "codex":
-		return installNPMCLI("@openai/codex", cliVersion("ELASTICCLAW_CODEX_CLI_VERSION", codexCLIVersion), "codex")
+		return installNPMCLI("@openai/codex", cliversion.FromEnv("ELASTICCLAW_CODEX_CLI_VERSION", codexCLIVersion), "codex")
 	case "grok":
-		return installNPMCLI("@xai-official/grok", cliVersion("ELASTICCLAW_GROK_CLI_VERSION", grokCLIVersion), "grok")
+		return installNPMCLI("@xai-official/grok", cliversion.FromEnv("ELASTICCLAW_GROK_CLI_VERSION", grokCLIVersion), "grok")
 	default:
 		return nil
 	}

--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -144,6 +144,10 @@ type bridgeSessionFile struct {
 	SessionKey string `json:"sessionKey"`
 }
 
+type cliAuthBundle struct {
+	Files map[string]string `json:"files"`
+}
+
 func bridgeSessionPath() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -2112,6 +2116,44 @@ func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'"'"'`) + "'"
 }
 
+func restoreCLIModelAuth() error {
+	state := strings.TrimSpace(os.Getenv("ELASTICCLAW_MODEL_AUTH_STATE"))
+	if state == "" {
+		return nil
+	}
+	data, err := base64.StdEncoding.DecodeString(state)
+	if err != nil {
+		return fmt.Errorf("decode auth state: %w", err)
+	}
+	var bundle cliAuthBundle
+	if err := json.Unmarshal(data, &bundle); err != nil {
+		return fmt.Errorf("parse auth state: %w", err)
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("home dir: %w", err)
+	}
+	for rel, encoded := range bundle.Files {
+		clean := filepath.Clean(rel)
+		if clean == "." || filepath.IsAbs(clean) || strings.HasPrefix(clean, ".."+string(filepath.Separator)) || clean == ".." {
+			continue
+		}
+		content, err := base64.StdEncoding.DecodeString(encoded)
+		if err != nil {
+			return fmt.Errorf("decode auth file %s: %w", rel, err)
+		}
+		path := filepath.Join(home, clean)
+		if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+			return fmt.Errorf("create auth dir %s: %w", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, content, 0600); err != nil {
+			return fmt.Errorf("write auth file %s: %w", rel, err)
+		}
+	}
+	log.Printf("[bootstrap] restored %d CLI auth files for %s", len(bundle.Files), os.Getenv("ELASTICCLAW_MODEL_AUTH_PROVIDER"))
+	return nil
+}
+
 func installSelectedCodingModelCLI() error {
 	model := envOr("OPENCLAW_DEFAULT_MODEL", "")
 	switch cliCodingProviderForModel(model) {
@@ -2462,6 +2504,10 @@ func runBootstrap() error {
 	// Step 3b: Install pinned CLI-backed model providers when selected.
 	if err := installSelectedCodingModelCLI(); err != nil {
 		return fmt.Errorf("installSelectedCodingModelCLI: %w", err)
+	}
+
+	if err := restoreCLIModelAuth(); err != nil {
+		return fmt.Errorf("restoreCLIModelAuth: %w", err)
 	}
 
 	// Step 4: Run openclaw onboard (initializes ~/.openclaw directory)

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
 	"net/http"
@@ -350,6 +351,33 @@ func TestCLIVersionAllowsPinnedOverride(t *testing.T) {
 	}
 	if got := cliVersion("ELASTICCLAW_MISSING_VERSION", "1.2.3"); got != "1.2.3" {
 		t.Fatalf("cliVersion fallback = %q", got)
+	}
+}
+
+func TestRestoreCLIModelAuthWritesBundleFiles(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	bundle := cliAuthBundle{
+		Files: map[string]string{
+			".codex/auth.json": base64.StdEncoding.EncodeToString([]byte(`{"token":"test"}`)),
+		},
+	}
+	data, err := json.Marshal(bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("ELASTICCLAW_MODEL_AUTH_PROVIDER", "codex")
+	t.Setenv("ELASTICCLAW_MODEL_AUTH_STATE", base64.StdEncoding.EncodeToString(data))
+
+	if err := restoreCLIModelAuth(); err != nil {
+		t.Fatalf("restore auth: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(home, ".codex", "auth.json"))
+	if err != nil {
+		t.Fatalf("read restored auth: %v", err)
+	}
+	if string(got) != `{"token":"test"}` {
+		t.Fatalf("restored auth = %q", string(got))
 	}
 }
 

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -329,6 +329,30 @@ func TestPatchOllamaLocalDevCatalogSetsRuntimeLimits(t *testing.T) {
 	}
 }
 
+func TestCLICodingProviderForModel(t *testing.T) {
+	tests := map[string]string{
+		"codex/gpt-5.5":        "codex",
+		"grok/grok-build-0.1":  "grok",
+		"anthropic/claude-foo": "",
+		"":                     "",
+	}
+	for model, want := range tests {
+		if got := cliCodingProviderForModel(model); got != want {
+			t.Fatalf("cliCodingProviderForModel(%q) = %q, want %q", model, got, want)
+		}
+	}
+}
+
+func TestCLIVersionAllowsPinnedOverride(t *testing.T) {
+	t.Setenv("ELASTICCLAW_CODEX_CLI_VERSION", "9.8.7")
+	if got := cliVersion("ELASTICCLAW_CODEX_CLI_VERSION", "1.2.3"); got != "9.8.7" {
+		t.Fatalf("cliVersion override = %q", got)
+	}
+	if got := cliVersion("ELASTICCLAW_MISSING_VERSION", "1.2.3"); got != "1.2.3" {
+		t.Fatalf("cliVersion fallback = %q", got)
+	}
+}
+
 func TestSanitizeActivityTextRedactsRepeatedSecretPrefixes(t *testing.T) {
 	input := `curl "https://api.example.com?access_token=abc&access_token=xyz" -H "Authorization: Bearer tok1" -H "X-Alt: Bearer tok2"`
 	got := sanitizeActivityText(input)

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -344,16 +344,6 @@ func TestCLICodingProviderForModel(t *testing.T) {
 	}
 }
 
-func TestCLIVersionAllowsPinnedOverride(t *testing.T) {
-	t.Setenv("ELASTICCLAW_CODEX_CLI_VERSION", "9.8.7")
-	if got := cliVersion("ELASTICCLAW_CODEX_CLI_VERSION", "1.2.3"); got != "9.8.7" {
-		t.Fatalf("cliVersion override = %q", got)
-	}
-	if got := cliVersion("ELASTICCLAW_MISSING_VERSION", "1.2.3"); got != "1.2.3" {
-		t.Fatalf("cliVersion fallback = %q", got)
-	}
-}
-
 func TestRestoreCLIModelAuthWritesBundleFiles(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/pkg/cliversion/cliversion.go
+++ b/pkg/cliversion/cliversion.go
@@ -1,0 +1,13 @@
+package cliversion
+
+import (
+	"os"
+	"strings"
+)
+
+func FromEnv(envName, fallback string) string {
+	if v := strings.TrimSpace(os.Getenv(envName)); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/pkg/cliversion/cliversion_test.go
+++ b/pkg/cliversion/cliversion_test.go
@@ -1,0 +1,13 @@
+package cliversion
+
+import "testing"
+
+func TestFromEnvAllowsPinnedOverride(t *testing.T) {
+	t.Setenv("ELASTICCLAW_TEST_CLI_VERSION", "9.8.7")
+	if got := FromEnv("ELASTICCLAW_TEST_CLI_VERSION", "1.2.3"); got != "9.8.7" {
+		t.Fatalf("FromEnv override = %q", got)
+	}
+	if got := FromEnv("ELASTICCLAW_MISSING_VERSION", "1.2.3"); got != "1.2.3" {
+		t.Fatalf("FromEnv fallback = %q", got)
+	}
+}

--- a/pkg/hub/ai_config.go
+++ b/pkg/hub/ai_config.go
@@ -568,7 +568,7 @@ func llmKeyHasRequiredAPIKey(key *types.LLMKeyConfig) bool {
 	if key == nil {
 		return false
 	}
-	return key.APIKey != "" || key.Provider == "ollama"
+	return key.APIKey != "" || key.Provider == "ollama" || key.AuthProfile != ""
 }
 
 func isOpenAICompatibleConfigProvider(provider string) bool {

--- a/pkg/hub/ai_config.go
+++ b/pkg/hub/ai_config.go
@@ -547,7 +547,7 @@ func selectAIConfigProvider(llmKeys types.LLMKeysList, defaultModel string) (*ai
 	if anthropicKey != nil {
 		return &aiConfigProviderChoice{Key: anthropicKey, Anthropic: true}, nil
 	}
-	for _, provider := range []string{"openai", "codex", "fireworks", "groq", "deepseek", "ollama"} {
+	for _, provider := range []string{"openai", "codex", "grok", "fireworks", "groq", "deepseek", "ollama"} {
 		if key := openAIKeys[provider]; key != nil {
 			return &aiConfigProviderChoice{
 				Key:      key,
@@ -559,9 +559,9 @@ func selectAIConfigProvider(llmKeys types.LLMKeysList, defaultModel string) (*ai
 
 	availableProviders := uniqueProviders(llmKeys)
 	if defaultProvider != "" {
-		return nil, fmt.Errorf("no supported LLM key configured for default_model provider %q (supported providers: anthropic, openai, codex, fireworks, groq, deepseek, ollama; configured: %s)", defaultProvider, strings.Join(availableProviders, ", "))
+		return nil, fmt.Errorf("no supported LLM key configured for default_model provider %q (supported providers: anthropic, openai, codex, grok, fireworks, groq, deepseek, ollama; configured: %s)", defaultProvider, strings.Join(availableProviders, ", "))
 	}
-	return nil, fmt.Errorf("no supported LLM key configured (supported providers: anthropic, openai, codex, fireworks, groq, deepseek, ollama; configured: %s)", strings.Join(availableProviders, ", "))
+	return nil, fmt.Errorf("no supported LLM key configured (supported providers: anthropic, openai, codex, grok, fireworks, groq, deepseek, ollama; configured: %s)", strings.Join(availableProviders, ", "))
 }
 
 func llmKeyHasRequiredAPIKey(key *types.LLMKeyConfig) bool {
@@ -573,7 +573,7 @@ func llmKeyHasRequiredAPIKey(key *types.LLMKeyConfig) bool {
 
 func isOpenAICompatibleConfigProvider(provider string) bool {
 	switch provider {
-	case "openai", "codex", "fireworks", "groq", "deepseek", "ollama":
+	case "openai", "codex", "grok", "fireworks", "groq", "deepseek", "ollama":
 		return true
 	default:
 		return false
@@ -597,7 +597,9 @@ func aiConfigModelForKey(key *types.LLMKeyConfig, defaultModel string) string {
 	case "openai":
 		return "openai/gpt-5.5"
 	case "codex":
-		return "codex/o4-mini"
+		return "codex/gpt-5.5"
+	case "grok":
+		return "grok/grok-build-0.1"
 	case "fireworks":
 		return defaultFireworksModel
 	case "groq":

--- a/pkg/hub/bootstrap.go
+++ b/pkg/hub/bootstrap.go
@@ -38,6 +38,7 @@ type BootstrapParams struct {
 
 	// Env injection
 	LLMKeyEnv      string // pre-built export lines
+	ModelAuthEnv   string // pre-built export lines for CLI-backed model auth state
 	LinearEnv      string // pre-built export line
 	ProviderConfig string // python snippet to patch OpenClaw config
 	OnboardFlags   string // --auth-choice ... flags for openclaw onboard
@@ -235,6 +236,7 @@ export ELASTICCLAW_NIX=%s
 export ELASTICCLAW_DOCKER=%s
 %s
 %s
+%s
 export ELASTICCLAW_ONBOARD_FLAGS=%s
 %s
 # ── Install claw-bridge ───────────────────────────────────────────────────────
@@ -322,7 +324,7 @@ exit 1
 `,
 		shellQuote(p.HubURL), shellQuote(p.ClawID), shellQuote(p.ClawToken), shellQuote(p.ClawName), shellQuote(p.GatewayPassword),
 		shellQuote(p.DefaultModel), shellQuote(nixFlag), shellQuote(dockerFlag),
-		p.LLMKeyEnv, linearEnvLine, shellQuote(p.OnboardFlags), providerConfigLine,
+		p.LLMKeyEnv, p.ModelAuthEnv, linearEnvLine, shellQuote(p.OnboardFlags), providerConfigLine,
 		shellQuote(p.BridgeURL),
 	)
 }

--- a/pkg/hub/bootstrap.go
+++ b/pkg/hub/bootstrap.go
@@ -156,6 +156,25 @@ if model.startswith('ollama/'):
             'compat': {'supportsTools': True, 'supportsUsageInStreaming': True},
         }],
     }
+if model.startswith('grok/'):
+    model_id = model.split('/', 1)[1]
+    config.setdefault('models', {})['mode'] = 'merge'
+    providers = config['models'].setdefault('providers', {})
+    providers['grok'] = {
+        'baseUrl': 'https://api.x.ai/v1',
+        'api': 'openai',
+        'apiKey': 'XAI_API_KEY',
+        'models': [{
+            'id': model_id,
+            'name': model_id,
+            'reasoning': True,
+            'input': ['text', 'image'],
+            'cost': {'input': 0, 'output': 0, 'cacheRead': 0, 'cacheWrite': 0},
+            'contextWindow': 256000,
+            'maxTokens': 8192,
+            'compat': {'supportsTools': True, 'supportsUsageInStreaming': True},
+        }],
+    }
 %sconfig.setdefault('gateway', {})['bind'] = 'loopback'
 config['gateway']['port'] = 18789
 gw_password = os.environ.get('ELASTICCLAW_GATEWAY_PASSWORD', '')
@@ -336,6 +355,8 @@ func buildOnboardFlags(keys []*types.LLMKeyConfig, selectedKeyName, defaultModel
 		return fmt.Sprintf(`--auth-choice deepseek-api-key --deepseek-api-key "${%s:-}"`, envVar)
 	case "codex":
 		return fmt.Sprintf(`--auth-choice codex-api-key --codex-api-key "${%s:-}"`, envVar)
+	case "grok":
+		return fmt.Sprintf(`--auth-choice openai-api-key --openai-api-key "${%s:-}"`, envVar)
 	case "ollama":
 		model := active.DefaultModel
 		if model == "" || !strings.HasPrefix(model, active.Provider+"/") {

--- a/pkg/hub/bootstrap_test.go
+++ b/pkg/hub/bootstrap_test.go
@@ -348,6 +348,22 @@ func TestBuildLLMKeyEnvSkipsBlankExternalKeys(t *testing.T) {
 	assertNotContains(t, env, "OPENAI_API_KEY", "does not export blank OpenAI key")
 }
 
+func TestBuildModelAuthEnvUsesSelectedProfile(t *testing.T) {
+	cfg := &types.HubConfig{
+		LLMKeys: types.LLMKeysList{
+			{Name: "codex-main", Provider: "codex", AuthProfile: "codex-profile", Default: true},
+		},
+		ModelAuthProfiles: []*types.ModelAuthProfileConfig{
+			{Name: "codex-profile", Provider: "codex", AuthState: "encoded-state"},
+		},
+	}
+
+	env := buildModelAuthEnv(cfg, "codex-main")
+
+	assertContains(t, env, "ELASTICCLAW_MODEL_AUTH_PROVIDER=\"codex\"", "exports auth provider")
+	assertContains(t, env, "ELASTICCLAW_MODEL_AUTH_STATE=\"encoded-state\"", "exports auth state")
+}
+
 func TestResolveModelAndLLMKeyReplacesUnusableSelectedKey(t *testing.T) {
 	hubCfg := &types.HubConfig{
 		LLMKeys: types.LLMKeysList{

--- a/pkg/hub/bootstrap_test.go
+++ b/pkg/hub/bootstrap_test.go
@@ -300,6 +300,13 @@ func TestBuildOnboardFlags_OpenAICompatibleProviders(t *testing.T) {
 			authChoice: "codex-api-key",
 			flagName:   "--codex-api-key",
 		},
+		{
+			name:       "grok",
+			provider:   "grok",
+			envVar:     "XAI_API_KEY",
+			authChoice: "openai-api-key",
+			flagName:   "--openai-api-key",
+		},
 	}
 
 	for _, tc := range cases {
@@ -415,6 +422,19 @@ func TestBuildOpenClawProviderConfig_ConfiguresOllamaProviderBaseURL(t *testing.
 	assertContains(t, snippet, "'compat': {'supportsTools': True, 'supportsUsageInStreaming': True}", "keeps tool support while lean mode reduces local model prompt pressure")
 	assertContains(t, snippet, "providers['ollama']", "writes only the built-in Ollama provider config")
 	assertNotContains(t, snippet, "'ollama-cloud'", "does not rewrite Ollama Cloud")
+}
+
+func TestBuildOpenClawProviderConfig_ConfiguresGrokProvider(t *testing.T) {
+	keys := []*types.LLMKeyConfig{
+		{Name: "grok-main", Provider: "grok", Default: true},
+	}
+
+	snippet := buildOpenClawProviderConfig(keys, "grok-main")
+
+	assertContains(t, snippet, "if model.startswith('grok/'):", "only configures Grok when selected model is Grok")
+	assertContains(t, snippet, "'baseUrl': 'https://api.x.ai/v1'", "uses xAI OpenAI-compatible base URL")
+	assertContains(t, snippet, "'apiKey': 'XAI_API_KEY'", "uses Grok API key env var")
+	assertContains(t, snippet, "providers['grok']", "writes Grok provider config")
 }
 
 func TestBuildOpenClawProviderConfig_DoesNotOverrideAnthropicModels(t *testing.T) {

--- a/pkg/hub/bootstrap_test.go
+++ b/pkg/hub/bootstrap_test.go
@@ -364,6 +364,13 @@ func TestBuildModelAuthEnvUsesSelectedProfile(t *testing.T) {
 	assertContains(t, env, "ELASTICCLAW_MODEL_AUTH_STATE=\"encoded-state\"", "exports auth state")
 }
 
+func TestBuildModelAuthRestoreShellRejectsParentDirectory(t *testing.T) {
+	shell := buildModelAuthRestoreShell("export ELASTICCLAW_MODEL_AUTH_STATE=\"encoded-state\"\n")
+
+	assertContains(t, shell, "clean == '..'", "rejects exact parent directory path")
+	assertContains(t, shell, "clean.startswith('../')", "rejects nested parent directory path")
+}
+
 func TestResolveModelAndLLMKeyReplacesUnusableSelectedKey(t *testing.T) {
 	hubCfg := &types.HubConfig{
 		LLMKeys: types.LLMKeysList{

--- a/pkg/hub/dependency_status.go
+++ b/pkg/hub/dependency_status.go
@@ -379,6 +379,8 @@ func modelDependency(provider string) (id, name string, ok bool) {
 		return "model:anthropic", "Anthropic", true
 	case "openai", "codex":
 		return "model:openai", "OpenAI", true
+	case "grok":
+		return "model:grok", "Grok", true
 	case "fireworks":
 		return "model:fireworks", "Fireworks", true
 	default:

--- a/pkg/hub/doctor.go
+++ b/pkg/hub/doctor.go
@@ -171,7 +171,7 @@ func (s *Server) checkLLMKeys(cfg *types.HubConfig) []DoctorCheck {
 	validProviders := map[string]bool{
 		"anthropic": true, "openai": true, "fireworks": true,
 		"moonshot": true, "google": true, "mistral": true,
-		"groq": true, "deepseek": true, "codex": true, "ollama": true,
+		"groq": true, "grok": true, "deepseek": true, "codex": true, "ollama": true,
 	}
 
 	allKeysValid := true

--- a/pkg/hub/external_webhook.go
+++ b/pkg/hub/external_webhook.go
@@ -778,6 +778,10 @@ func resolveDefaultModelForKeyLocal(hubDefaultModel string, key *types.LLMKeyCon
 		return defaultFireworksModel
 	case "openai":
 		return "openai/gpt-5.5"
+	case "codex":
+		return "codex/gpt-5.5"
+	case "grok":
+		return "grok/grok-build-0.1"
 	case "groq":
 		return "groq/llama-3.3-70b-versatile"
 	case "deepseek":

--- a/pkg/hub/failure_summary.go
+++ b/pkg/hub/failure_summary.go
@@ -363,7 +363,7 @@ func summarizeFailureWithLLM(ctx context.Context, sanitizedReason string, llmKey
 	switch key.Provider {
 	case "anthropic":
 		return callAnthropicModel(ctx, key.APIKey, stripProviderPrefix(model), systemPrompt, msgs, 700)
-	case "openai", "codex", "fireworks", "groq", "deepseek", "ollama":
+	case "openai", "codex", "grok", "fireworks", "groq", "deepseek", "ollama":
 		return callOpenAICompatible(ctx, openAICompatibleConfig(key.Provider), key.APIKey, stripProviderPrefix(model), systemPrompt, msgs)
 	default:
 		return "", fmt.Errorf("unsupported LLM provider %q", key.Provider)
@@ -397,7 +397,7 @@ func selectFailureSummaryModel(llmKeys types.LLMKeysList, defaultModel string) (
 
 func isFailureSummaryProvider(provider string) bool {
 	switch provider {
-	case "anthropic", "openai", "codex", "fireworks", "groq", "deepseek", "ollama":
+	case "anthropic", "openai", "codex", "grok", "fireworks", "groq", "deepseek", "ollama":
 		return true
 	default:
 		return false
@@ -420,7 +420,9 @@ func modelForFailureSummary(key *types.LLMKeyConfig, defaultModel string) string
 	case "openai":
 		return "openai/gpt-5.4-mini"
 	case "codex":
-		return "codex/o4-mini"
+		return "codex/gpt-5.5"
+	case "grok":
+		return "grok/grok-build-0.1"
 	case "fireworks":
 		return defaultFireworksModel
 	case "groq":
@@ -453,6 +455,8 @@ func openAICompatibleConfig(provider string) openAICompatibleProvider {
 		return openAICompatibleProvider{Name: "Fireworks", BaseURL: "https://api.fireworks.ai/inference/v1"}
 	case "groq":
 		return openAICompatibleProvider{Name: "Groq", BaseURL: "https://api.groq.com/openai/v1"}
+	case "grok":
+		return openAICompatibleProvider{Name: "Grok", BaseURL: "https://api.x.ai/v1"}
 	case "deepseek":
 		return openAICompatibleProvider{Name: "DeepSeek", BaseURL: "https://api.deepseek.com/v1"}
 	case "ollama":

--- a/pkg/hub/fireworks_models.go
+++ b/pkg/hub/fireworks_models.go
@@ -107,9 +107,9 @@ func (s *Server) fetchFireworksModelOptions(ctx context.Context, apiKey string) 
 			Models []struct {
 				Name               string `json:"name"`
 				DisplayName        string `json:"displayName"`
-				Public             bool   `json:"public"`
+				Public             *bool  `json:"public"`
 				ContextLength      int    `json:"contextLength"`
-				SupportsServerless bool   `json:"supportsServerless"`
+				SupportsServerless *bool  `json:"supportsServerless"`
 				ConversationConfig struct {
 					Style    string `json:"style"`
 					System   string `json:"system"`
@@ -128,7 +128,7 @@ func (s *Server) fetchFireworksModelOptions(ctx context.Context, apiKey string) 
 		}
 
 		for _, model := range body.Models {
-			if !fireworksModelSupported(model.Public, model.SupportsServerless, model.ContextLength, model.ConversationConfig.Style, model.ConversationConfig.System, model.ConversationConfig.Template) {
+			if !fireworksModelSupported(model.Public, model.SupportsServerless) {
 				continue
 			}
 			id := fireworksModelID(model.Name)
@@ -151,13 +151,14 @@ func (s *Server) fetchFireworksModelOptions(ctx context.Context, apiKey string) 
 	return sortFireworksModelOptions(dedupeModelOptions(options)), nil
 }
 
-func fireworksModelSupported(public, supportsServerless bool, contextLength int, conversationStyle, conversationSystem, conversationTemplate string) bool {
-	if !public || !supportsServerless || contextLength <= 0 {
+func fireworksModelSupported(public, supportsServerless *bool) bool {
+	if public != nil && !*public {
 		return false
 	}
-	return strings.TrimSpace(conversationStyle) != "" ||
-		strings.TrimSpace(conversationSystem) != "" ||
-		strings.TrimSpace(conversationTemplate) != ""
+	if supportsServerless != nil && !*supportsServerless {
+		return false
+	}
+	return true
 }
 
 func fireworksModelID(name string) string {

--- a/pkg/hub/fireworks_models_test.go
+++ b/pkg/hub/fireworks_models_test.go
@@ -65,7 +65,7 @@ func TestFetchFireworksModelOptionsFiltersAndSortsLatestKimi(t *testing.T) {
 	if requests != 2 {
 		t.Fatalf("requests = %d, want 2", requests)
 	}
-	if len(options) != 3 {
+	if len(options) != 4 {
 		t.Fatalf("options = %#v", options)
 	}
 	if options[0].ID != defaultFireworksModel {
@@ -76,6 +76,51 @@ func TestFetchFireworksModelOptionsFiltersAndSortsLatestKimi(t *testing.T) {
 	}
 	if options[2].ID != "fireworks/accounts/fireworks/models/glm-5p2" {
 		t.Fatalf("third option = %#v, want GLM 5.2", options[2])
+	}
+	if options[3].ID != "fireworks/accounts/fireworks/models/no-chat-template" {
+		t.Fatalf("fourth option = %#v, want model with omitted chat metadata", options[3])
+	}
+}
+
+func TestFetchFireworksModelOptionsIncludesModelsWithSparseMetadata(t *testing.T) {
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"models": []map[string]any{
+				{
+					"name":        "accounts/fireworks/models/sparse-model",
+					"displayName": "Sparse Model",
+				},
+				{
+					"name":               "accounts/fireworks/models/not-serverless",
+					"displayName":        "Not Serverless",
+					"public":             true,
+					"supportsServerless": false,
+				},
+				{
+					"name":               "accounts/fireworks/models/private-model",
+					"displayName":        "Private Model",
+					"public":             false,
+					"supportsServerless": true,
+				},
+			},
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}))
+	defer api.Close()
+
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{}, "", "", "")
+	s.fireworksBaseURL = api.URL
+
+	options, err := s.fetchFireworksModelOptions(t.Context(), "fw-test")
+	if err != nil {
+		t.Fatalf("fetch options: %v", err)
+	}
+	if len(options) != 1 {
+		t.Fatalf("options = %#v, want only sparse model", options)
+	}
+	if options[0].ID != "fireworks/accounts/fireworks/models/sparse-model" {
+		t.Fatalf("option = %#v, want sparse model", options[0])
 	}
 }
 

--- a/pkg/hub/model_auth.go
+++ b/pkg/hub/model_auth.go
@@ -1,7 +1,6 @@
 package hub
 
 import (
-	"bufio"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -40,7 +39,8 @@ type cliAuthBundle struct {
 
 var (
 	modelAuthANSIRE = regexp.MustCompile(`\x1b\[[0-?]*[ -/]*[@-~]`)
-	modelAuthURLRE  = regexp.MustCompile(`https?://[^\s"']+`)
+	modelAuthOSC8RE = regexp.MustCompile(`\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)`)
+	modelAuthURLRE  = regexp.MustCompile(`https?://[^\s"'\x00-\x1f\x7f]+`)
 	modelAuthCodeRE = regexp.MustCompile(`(?i)\b(?:code|device code|user code|verification code)\b[^A-Z0-9]*([A-Z0-9][A-Z0-9-]{3,})\b`)
 )
 
@@ -174,32 +174,56 @@ func (s *Server) runModelAuthLoginJob(job *modelAuthLoginJob) {
 
 func (s *Server) captureModelAuthOutput(job *modelAuthLoginJob, r io.Reader, done chan<- struct{}) {
 	defer func() { done <- struct{}{} }()
-	scanner := bufio.NewScanner(r)
-	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
-	for scanner.Scan() {
-		line := normalizeModelAuthOutput(scanner.Text())
-		s.modelAuthJobsMu.Lock()
-		if job.Output != "" {
-			job.Output += "\n"
+	buf := make([]byte, 4096)
+	for {
+		n, err := r.Read(buf)
+		if n > 0 {
+			s.appendModelAuthOutput(job, string(buf[:n]))
 		}
-		job.Output += line
-		if job.URL == "" {
-			if match := modelAuthURLRE.FindString(line); match != "" {
-				job.URL = strings.TrimRight(match, ".,)")
-			}
+		if err != nil {
+			return
 		}
-		if job.Code == "" {
-			if match := modelAuthCodeRE.FindStringSubmatch(line); len(match) == 2 {
-				job.Code = match[1]
-			}
+	}
+}
+
+func (s *Server) appendModelAuthOutput(job *modelAuthLoginJob, raw string) {
+	chunk := normalizeModelAuthOutput(raw)
+	s.modelAuthJobsMu.Lock()
+	defer s.modelAuthJobsMu.Unlock()
+	job.Output += chunk
+	if match := modelAuthURLRE.FindString(raw); match != "" {
+		updateModelAuthURL(job, match)
+	}
+	if match := modelAuthURLRE.FindString(job.Output); match != "" {
+		updateModelAuthURL(job, match)
+	}
+	if job.Code == "" {
+		if match := modelAuthCodeRE.FindStringSubmatch(job.Output); len(match) == 2 {
+			job.Code = match[1]
 		}
-		job.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
-		s.modelAuthJobsMu.Unlock()
+	}
+	job.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+}
+
+func updateModelAuthURL(job *modelAuthLoginJob, url string) {
+	url = strings.TrimRight(url, ".,)")
+	if len(url) > len(job.URL) {
+		job.URL = url
 	}
 }
 
 func normalizeModelAuthOutput(line string) string {
-	return modelAuthANSIRE.ReplaceAllString(line, "")
+	line = modelAuthOSC8RE.ReplaceAllString(line, "")
+	line = modelAuthANSIRE.ReplaceAllString(line, "")
+	var b strings.Builder
+	b.Grow(len(line))
+	for _, r := range line {
+		if (r >= 0 && r < 32 && r != '\n' && r != '\t') || r == 127 {
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
 }
 
 func (s *Server) finishModelAuthJob(job *modelAuthLoginJob, status, _ string, err error) {

--- a/pkg/hub/model_auth.go
+++ b/pkg/hub/model_auth.go
@@ -90,10 +90,11 @@ func (s *Server) handleModelAuthLogin(w http.ResponseWriter, r *http.Request) {
 		s.modelAuthJobs = map[string]*modelAuthLoginJob{}
 	}
 	s.modelAuthJobs[job.ID] = job
+	snapshot := snapshotModelAuthLoginJob(job)
 	s.modelAuthJobsMu.Unlock()
 
 	go s.runModelAuthLoginJob(job)
-	jsonOK(w, job)
+	jsonOK(w, snapshot)
 }
 
 func (s *Server) handleModelAuthLoginStatus(w http.ResponseWriter, r *http.Request) {
@@ -104,12 +105,22 @@ func (s *Server) handleModelAuthLoginStatus(w http.ResponseWriter, r *http.Reque
 	id := r.PathValue("id")
 	s.modelAuthJobsMu.Lock()
 	job := s.modelAuthJobs[id]
+	snapshot := snapshotModelAuthLoginJob(job)
 	s.modelAuthJobsMu.Unlock()
 	if job == nil {
 		http.NotFound(w, r)
 		return
 	}
-	jsonOK(w, job)
+	jsonOK(w, snapshot)
+}
+
+func snapshotModelAuthLoginJob(job *modelAuthLoginJob) *modelAuthLoginJob {
+	if job == nil {
+		return nil
+	}
+	snapshot := *job
+	snapshot.authDir = ""
+	return &snapshot
 }
 
 func (s *Server) runModelAuthLoginJob(job *modelAuthLoginJob) {

--- a/pkg/hub/model_auth.go
+++ b/pkg/hub/model_auth.go
@@ -30,7 +30,6 @@ type modelAuthLoginJob struct {
 	Error     string `json:"error,omitempty"`
 	StartedAt string `json:"startedAt"`
 	UpdatedAt string `json:"updatedAt"`
-	authDir   string
 }
 
 type cliAuthBundle struct {
@@ -119,7 +118,6 @@ func snapshotModelAuthLoginJob(job *modelAuthLoginJob) *modelAuthLoginJob {
 		return nil
 	}
 	snapshot := *job
-	snapshot.authDir = ""
 	return &snapshot
 }
 
@@ -130,7 +128,6 @@ func (s *Server) runModelAuthLoginJob(job *modelAuthLoginJob) {
 		return
 	}
 	defer os.RemoveAll(authDir)
-	job.authDir = authDir
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()

--- a/pkg/hub/model_auth.go
+++ b/pkg/hub/model_auth.go
@@ -38,11 +38,12 @@ type cliAuthBundle struct {
 }
 
 var (
-	modelAuthANSIRE       = regexp.MustCompile(`\x1b\[[0-?]*[ -/]*[@-~]`)
-	modelAuthOSC8RE       = regexp.MustCompile(`\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)`)
-	modelAuthURLRE        = regexp.MustCompile(`https?://[^\s"'\x00-\x1f\x7f]+`)
-	modelAuthCodeRE       = regexp.MustCompile(`(?i:\b(?:device code|user code|verification code|code)\b)[^A-Za-z0-9]*([A-Za-z0-9][A-Za-z0-9-]{3,})\b`)
-	modelAuth9DigitCodeRE = regexp.MustCompile(`\b\d(?:[ -]?\d){8}\b`)
+	modelAuthANSIRE        = regexp.MustCompile(`\x1b\[[0-?]*[ -/]*[@-~]`)
+	modelAuthOSC8RE        = regexp.MustCompile(`\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)`)
+	modelAuthURLRE         = regexp.MustCompile(`https?://[^\s"'\x00-\x1f\x7f]+`)
+	modelAuthCodeRE        = regexp.MustCompile(`(?i:\b(?:device code|user code|verification code|code)\b)[^A-Za-z0-9]*([A-Za-z0-9][A-Za-z0-9-]{3,})\b`)
+	modelAuthOneTimeCodeRE = regexp.MustCompile(`(?is)\bone-time code\b.*?\n\s*([A-Z0-9]{4,5}-[A-Z0-9]{4,5})\b`)
+	modelAuth9DigitCodeRE  = regexp.MustCompile(`\b\d(?:[ -]?\d){8}\b`)
 )
 
 func (s *Server) handleModelAuthLogin(w http.ResponseWriter, r *http.Request) {
@@ -212,6 +213,9 @@ func updateModelAuthURL(job *modelAuthLoginJob, url string) {
 }
 
 func extractModelAuthCode(output string) string {
+	if match := modelAuthOneTimeCodeRE.FindStringSubmatch(output); len(match) == 2 {
+		return match[1]
+	}
 	matches := modelAuthCodeRE.FindAllStringSubmatch(output, -1)
 	for _, match := range matches {
 		if len(match) != 2 {

--- a/pkg/hub/model_auth.go
+++ b/pkg/hub/model_auth.go
@@ -39,8 +39,9 @@ type cliAuthBundle struct {
 }
 
 var (
+	modelAuthANSIRE = regexp.MustCompile(`\x1b\[[0-?]*[ -/]*[@-~]`)
 	modelAuthURLRE  = regexp.MustCompile(`https?://[^\s"']+`)
-	modelAuthCodeRE = regexp.MustCompile(`(?i)(?:code|user code|verification code)[^A-Z0-9]*([A-Z0-9][A-Z0-9-]{3,})`)
+	modelAuthCodeRE = regexp.MustCompile(`(?i)\b(?:code|device code|user code|verification code)\b[^A-Z0-9]*([A-Z0-9][A-Z0-9-]{3,})\b`)
 )
 
 func (s *Server) handleModelAuthLogin(w http.ResponseWriter, r *http.Request) {
@@ -176,7 +177,7 @@ func (s *Server) captureModelAuthOutput(job *modelAuthLoginJob, r io.Reader, don
 	scanner := bufio.NewScanner(r)
 	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 	for scanner.Scan() {
-		line := scanner.Text()
+		line := normalizeModelAuthOutput(scanner.Text())
 		s.modelAuthJobsMu.Lock()
 		if job.Output != "" {
 			job.Output += "\n"
@@ -195,6 +196,10 @@ func (s *Server) captureModelAuthOutput(job *modelAuthLoginJob, r io.Reader, don
 		job.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
 		s.modelAuthJobsMu.Unlock()
 	}
+}
+
+func normalizeModelAuthOutput(line string) string {
+	return modelAuthANSIRE.ReplaceAllString(line, "")
 }
 
 func (s *Server) finishModelAuthJob(job *modelAuthLoginJob, status, _ string, err error) {

--- a/pkg/hub/model_auth.go
+++ b/pkg/hub/model_auth.go
@@ -115,6 +115,7 @@ func (s *Server) runModelAuthLoginJob(job *modelAuthLoginJob) {
 		s.finishModelAuthJob(job, "error", "", err)
 		return
 	}
+	defer os.RemoveAll(authDir)
 	job.authDir = authDir
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
@@ -151,9 +152,9 @@ func (s *Server) runModelAuthLoginJob(job *modelAuthLoginJob) {
 	done := make(chan struct{}, 2)
 	go s.captureModelAuthOutput(job, stdout, done)
 	go s.captureModelAuthOutput(job, stderr, done)
+	<-done
+	<-done
 	err = cmd.Wait()
-	<-done
-	<-done
 	if err != nil {
 		s.finishModelAuthJob(job, "error", "", err)
 		return
@@ -324,7 +325,7 @@ if state:
     home = os.path.expanduser('~')
     for rel, encoded in bundle.get('files', {}).items():
         clean = os.path.normpath(rel)
-        if clean == '.' or clean.startswith('../') or os.path.isabs(clean):
+        if clean == '.' or clean == '..' or clean.startswith('../') or os.path.isabs(clean):
             continue
         path = os.path.join(home, clean)
         os.makedirs(os.path.dirname(path), exist_ok=True)

--- a/pkg/hub/model_auth.go
+++ b/pkg/hub/model_auth.go
@@ -38,10 +38,11 @@ type cliAuthBundle struct {
 }
 
 var (
-	modelAuthANSIRE = regexp.MustCompile(`\x1b\[[0-?]*[ -/]*[@-~]`)
-	modelAuthOSC8RE = regexp.MustCompile(`\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)`)
-	modelAuthURLRE  = regexp.MustCompile(`https?://[^\s"'\x00-\x1f\x7f]+`)
-	modelAuthCodeRE = regexp.MustCompile(`(?i:\b(?:device code|user code|verification code|code)\b)[^A-Za-z0-9]*([A-Za-z0-9][A-Za-z0-9-]{3,})\b`)
+	modelAuthANSIRE       = regexp.MustCompile(`\x1b\[[0-?]*[ -/]*[@-~]`)
+	modelAuthOSC8RE       = regexp.MustCompile(`\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)`)
+	modelAuthURLRE        = regexp.MustCompile(`https?://[^\s"'\x00-\x1f\x7f]+`)
+	modelAuthCodeRE       = regexp.MustCompile(`(?i:\b(?:device code|user code|verification code|code)\b)[^A-Za-z0-9]*([A-Za-z0-9][A-Za-z0-9-]{3,})\b`)
+	modelAuth9DigitCodeRE = regexp.MustCompile(`\b\d(?:[ -]?\d){8}\b`)
 )
 
 func (s *Server) handleModelAuthLogin(w http.ResponseWriter, r *http.Request) {
@@ -220,6 +221,9 @@ func extractModelAuthCode(output string) string {
 		if isValidModelAuthCode(code) {
 			return code
 		}
+	}
+	if match := modelAuth9DigitCodeRE.FindString(output); match != "" {
+		return strings.NewReplacer(" ", "", "-", "").Replace(match)
 	}
 	return ""
 }

--- a/pkg/hub/model_auth.go
+++ b/pkg/hub/model_auth.go
@@ -41,7 +41,7 @@ var (
 	modelAuthANSIRE = regexp.MustCompile(`\x1b\[[0-?]*[ -/]*[@-~]`)
 	modelAuthOSC8RE = regexp.MustCompile(`\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)`)
 	modelAuthURLRE  = regexp.MustCompile(`https?://[^\s"'\x00-\x1f\x7f]+`)
-	modelAuthCodeRE = regexp.MustCompile(`(?i)\b(?:code|device code|user code|verification code)\b[^A-Z0-9]*([A-Z0-9][A-Z0-9-]{3,})\b`)
+	modelAuthCodeRE = regexp.MustCompile(`(?i:\b(?:device code|user code|verification code|code)\b)[^A-Za-z0-9]*([A-Za-z0-9][A-Za-z0-9-]{3,})\b`)
 )
 
 func (s *Server) handleModelAuthLogin(w http.ResponseWriter, r *http.Request) {
@@ -197,10 +197,8 @@ func (s *Server) appendModelAuthOutput(job *modelAuthLoginJob, raw string) {
 	if match := modelAuthURLRE.FindString(job.Output); match != "" {
 		updateModelAuthURL(job, match)
 	}
-	if job.Code == "" {
-		if match := modelAuthCodeRE.FindStringSubmatch(job.Output); len(match) == 2 {
-			job.Code = match[1]
-		}
+	if code := extractModelAuthCode(job.Output); code != "" {
+		job.Code = code
 	}
 	job.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
 }
@@ -210,6 +208,49 @@ func updateModelAuthURL(job *modelAuthLoginJob, url string) {
 	if len(url) > len(job.URL) {
 		job.URL = url
 	}
+}
+
+func extractModelAuthCode(output string) string {
+	matches := modelAuthCodeRE.FindAllStringSubmatch(output, -1)
+	for _, match := range matches {
+		if len(match) != 2 {
+			continue
+		}
+		code := strings.Trim(match[1], ".,)")
+		if isValidModelAuthCode(code) {
+			return code
+		}
+	}
+	return ""
+}
+
+func isValidModelAuthCode(code string) bool {
+	if len(code) < 4 {
+		return false
+	}
+	lower := strings.ToLower(code)
+	switch lower {
+	case "authorization", "authenticate", "authentication", "login", "device", "verify", "verification":
+		return false
+	}
+	hasDigit := false
+	hasHyphen := false
+	hasUpper := false
+	for _, r := range code {
+		switch {
+		case r >= '0' && r <= '9':
+			hasDigit = true
+		case r == '-':
+			hasHyphen = true
+		case r >= 'A' && r <= 'Z':
+			hasUpper = true
+		case r >= 'a' && r <= 'z':
+			// Lowercase-only English words are usually CLI prose, not device codes.
+		default:
+			return false
+		}
+	}
+	return hasDigit || hasHyphen || hasUpper
 }
 
 func normalizeModelAuthOutput(line string) string {

--- a/pkg/hub/model_auth.go
+++ b/pkg/hub/model_auth.go
@@ -1,0 +1,336 @@
+package hub
+
+import (
+	"bufio"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/config"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+	"github.com/google/uuid"
+)
+
+type modelAuthLoginJob struct {
+	ID        string `json:"id"`
+	Provider  string `json:"provider"`
+	Profile   string `json:"profile"`
+	Status    string `json:"status"`
+	URL       string `json:"url,omitempty"`
+	Code      string `json:"code,omitempty"`
+	Output    string `json:"output,omitempty"`
+	Error     string `json:"error,omitempty"`
+	StartedAt string `json:"startedAt"`
+	UpdatedAt string `json:"updatedAt"`
+	authDir   string
+}
+
+type cliAuthBundle struct {
+	Files map[string]string `json:"files"`
+}
+
+var (
+	modelAuthURLRE  = regexp.MustCompile(`https?://[^\s"']+`)
+	modelAuthCodeRE = regexp.MustCompile(`(?i)(?:code|user code|verification code)[^A-Z0-9]*([A-Z0-9][A-Z0-9-]{3,})`)
+)
+
+func (s *Server) handleModelAuthLogin(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req struct {
+		Provider string `json:"provider"`
+		Profile  string `json:"profile"`
+		Mode     string `json:"mode"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	req.Provider = strings.TrimSpace(req.Provider)
+	req.Profile = strings.TrimSpace(req.Profile)
+	if req.Mode == "" {
+		req.Mode = "device"
+	}
+	if req.Profile == "" {
+		req.Profile = req.Provider + "-default"
+	}
+	if req.Provider != "codex" && req.Provider != "grok" {
+		http.Error(w, "provider must be codex or grok", http.StatusBadRequest)
+		return
+	}
+	if req.Mode != "device" {
+		http.Error(w, "only device login is supported", http.StatusBadRequest)
+		return
+	}
+
+	job := &modelAuthLoginJob{
+		ID:        uuid.NewString(),
+		Provider:  req.Provider,
+		Profile:   req.Profile,
+		Status:    "running",
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+		UpdatedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+	s.modelAuthJobsMu.Lock()
+	if s.modelAuthJobs == nil {
+		s.modelAuthJobs = map[string]*modelAuthLoginJob{}
+	}
+	s.modelAuthJobs[job.ID] = job
+	s.modelAuthJobsMu.Unlock()
+
+	go s.runModelAuthLoginJob(job)
+	jsonOK(w, job)
+}
+
+func (s *Server) handleModelAuthLoginStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	id := r.PathValue("id")
+	s.modelAuthJobsMu.Lock()
+	job := s.modelAuthJobs[id]
+	s.modelAuthJobsMu.Unlock()
+	if job == nil {
+		http.NotFound(w, r)
+		return
+	}
+	jsonOK(w, job)
+}
+
+func (s *Server) runModelAuthLoginJob(job *modelAuthLoginJob) {
+	authDir, err := os.MkdirTemp("", "elasticclaw-model-auth-*")
+	if err != nil {
+		s.finishModelAuthJob(job, "error", "", err)
+		return
+	}
+	job.authDir = authDir
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	var args []string
+	switch job.Provider {
+	case "codex":
+		args = []string{"codex", "login", "--device-auth"}
+	case "grok":
+		args = []string{"grok", "login", "--device-auth"}
+	default:
+		s.finishModelAuthJob(job, "error", "", fmt.Errorf("unsupported provider %q", job.Provider))
+		return
+	}
+
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+	cmd.Env = append(os.Environ(), "HOME="+authDir)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		s.finishModelAuthJob(job, "error", "", err)
+		return
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		s.finishModelAuthJob(job, "error", "", err)
+		return
+	}
+	if err := cmd.Start(); err != nil {
+		s.finishModelAuthJob(job, "error", "", err)
+		return
+	}
+
+	done := make(chan struct{}, 2)
+	go s.captureModelAuthOutput(job, stdout, done)
+	go s.captureModelAuthOutput(job, stderr, done)
+	err = cmd.Wait()
+	<-done
+	<-done
+	if err != nil {
+		s.finishModelAuthJob(job, "error", "", err)
+		return
+	}
+	bundle, err := encodeCLIAuthBundle(authDir)
+	if err != nil {
+		s.finishModelAuthJob(job, "error", "", err)
+		return
+	}
+	if err := s.saveModelAuthProfile(job.Provider, job.Profile, "device", bundle); err != nil {
+		s.finishModelAuthJob(job, "error", "", err)
+		return
+	}
+	s.finishModelAuthJob(job, "complete", bundle, nil)
+}
+
+func (s *Server) captureModelAuthOutput(job *modelAuthLoginJob, r io.Reader, done chan<- struct{}) {
+	defer func() { done <- struct{}{} }()
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		s.modelAuthJobsMu.Lock()
+		if job.Output != "" {
+			job.Output += "\n"
+		}
+		job.Output += line
+		if job.URL == "" {
+			if match := modelAuthURLRE.FindString(line); match != "" {
+				job.URL = strings.TrimRight(match, ".,)")
+			}
+		}
+		if job.Code == "" {
+			if match := modelAuthCodeRE.FindStringSubmatch(line); len(match) == 2 {
+				job.Code = match[1]
+			}
+		}
+		job.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+		s.modelAuthJobsMu.Unlock()
+	}
+}
+
+func (s *Server) finishModelAuthJob(job *modelAuthLoginJob, status, _ string, err error) {
+	s.modelAuthJobsMu.Lock()
+	defer s.modelAuthJobsMu.Unlock()
+	job.Status = status
+	job.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	if err != nil {
+		job.Error = err.Error()
+	}
+}
+
+func encodeCLIAuthBundle(root string) (string, error) {
+	bundle := cliAuthBundle{Files: map[string]string{}}
+	var total int64
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			name := d.Name()
+			if name == "node_modules" || name == ".npm" || name == ".cache" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		if info.Size() > 2*1024*1024 {
+			return nil
+		}
+		total += info.Size()
+		if total > 10*1024*1024 {
+			return fmt.Errorf("auth bundle exceeds 10MiB")
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		bundle.Files[filepath.ToSlash(rel)] = base64.StdEncoding.EncodeToString(data)
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	data, err := json.Marshal(bundle)
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(data), nil
+}
+
+func (s *Server) saveModelAuthProfile(provider, name, mode, authState string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	updatedCfg := *s.hubCfg
+	profiles := make([]*types.ModelAuthProfileConfig, len(updatedCfg.ModelAuthProfiles))
+	for i, profile := range updatedCfg.ModelAuthProfiles {
+		if profile == nil {
+			continue
+		}
+		copy := *profile
+		profiles[i] = &copy
+	}
+	var found *types.ModelAuthProfileConfig
+	for _, profile := range profiles {
+		if profile != nil && profile.Name == name {
+			found = profile
+			break
+		}
+	}
+	if found == nil {
+		found = &types.ModelAuthProfileConfig{Name: name}
+		profiles = append(profiles, found)
+	}
+	found.Provider = provider
+	found.Mode = mode
+	found.AuthState = authState
+	found.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	updatedCfg.ModelAuthProfiles = profiles
+	if err := config.SaveHubConfig(&updatedCfg); err != nil {
+		return err
+	}
+	s.hubCfg = &updatedCfg
+	return nil
+}
+
+func buildModelAuthEnv(cfg *types.HubConfig, selectedKeyName string) string {
+	if cfg == nil {
+		return ""
+	}
+	key := resolveActiveKey(cfg.LLMKeys, selectedKeyName)
+	if key == nil || key.AuthProfile == "" {
+		return ""
+	}
+	for _, profile := range cfg.ModelAuthProfiles {
+		if profile == nil || profile.Name != key.AuthProfile || profile.AuthState == "" {
+			continue
+		}
+		if profile.Provider != key.Provider {
+			continue
+		}
+		return fmt.Sprintf("export ELASTICCLAW_MODEL_AUTH_PROVIDER=%q\nexport ELASTICCLAW_MODEL_AUTH_STATE=%q\n", profile.Provider, profile.AuthState)
+	}
+	return ""
+}
+
+func buildModelAuthRestoreShell(modelAuthEnv string) string {
+	if strings.TrimSpace(modelAuthEnv) == "" {
+		return ""
+	}
+	return modelAuthEnv + `
+python3 <<'PYEOF'
+import base64, json, os
+state = os.environ.get('ELASTICCLAW_MODEL_AUTH_STATE', '')
+if state:
+    bundle = json.loads(base64.b64decode(state).decode())
+    home = os.path.expanduser('~')
+    for rel, encoded in bundle.get('files', {}).items():
+        clean = os.path.normpath(rel)
+        if clean == '.' or clean.startswith('../') or os.path.isabs(clean):
+            continue
+        path = os.path.join(home, clean)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, 'wb') as f:
+            f.write(base64.b64decode(encoded))
+        os.chmod(path, 0o600)
+PYEOF
+`
+}

--- a/pkg/hub/model_auth_test.go
+++ b/pkg/hub/model_auth_test.go
@@ -1,0 +1,42 @@
+package hub
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCaptureModelAuthOutputStripsANSIFromURL(t *testing.T) {
+	s := &Server{}
+	job := &modelAuthLoginJob{}
+
+	s.captureModelAuthOutput(job, strings.NewReader("\x1b[32mhttps://auth.openai.com/codex/device_authorization\x1b[0m\n"), make(chan struct{}, 1))
+
+	if job.URL != "https://auth.openai.com/codex/device_authorization" {
+		t.Fatalf("URL = %q, want stripped device authorization URL", job.URL)
+	}
+	if strings.Contains(job.Output, "\x1b") || strings.Contains(job.Output, "[0m") {
+		t.Fatalf("Output = %q, want ANSI escape sequences stripped", job.Output)
+	}
+}
+
+func TestCaptureModelAuthOutputDoesNotTreatCodexURLAsCode(t *testing.T) {
+	s := &Server{}
+	job := &modelAuthLoginJob{}
+
+	s.captureModelAuthOutput(job, strings.NewReader("Open https://auth.openai.com/codex/device_authorization\n"), make(chan struct{}, 1))
+
+	if job.Code != "" {
+		t.Fatalf("Code = %q, want no code extracted from codex URL", job.Code)
+	}
+}
+
+func TestCaptureModelAuthOutputExtractsDeviceCode(t *testing.T) {
+	s := &Server{}
+	job := &modelAuthLoginJob{}
+
+	s.captureModelAuthOutput(job, strings.NewReader("User code: ABCD-EFGH\n"), make(chan struct{}, 1))
+
+	if job.Code != "ABCD-EFGH" {
+		t.Fatalf("Code = %q, want device code", job.Code)
+	}
+}

--- a/pkg/hub/model_auth_test.go
+++ b/pkg/hub/model_auth_test.go
@@ -41,6 +41,27 @@ func TestCaptureModelAuthOutputExtractsDeviceCode(t *testing.T) {
 	}
 }
 
+func TestCaptureModelAuthOutputExtractsCodexOneTimeCode(t *testing.T) {
+	s := &Server{}
+	job := &modelAuthLoginJob{}
+	output := `Follow these steps to sign in with ChatGPT using device code authorization:
+
+1. Open this link in your browser and sign in to your account
+   https://auth.openai.com/codex/device
+
+2. Enter this one-time code (expires in 15 minutes)
+   2VX0-20MIV
+
+Device codes are a common phishing target. Never share this code.
+`
+
+	s.captureModelAuthOutput(job, strings.NewReader(output), make(chan struct{}, 1))
+
+	if job.Code != "2VX0-20MIV" {
+		t.Fatalf("Code = %q, want Codex one-time code", job.Code)
+	}
+}
+
 func TestCaptureModelAuthOutputExtractsNumericDeviceCode(t *testing.T) {
 	s := &Server{}
 	job := &modelAuthLoginJob{}

--- a/pkg/hub/model_auth_test.go
+++ b/pkg/hub/model_auth_test.go
@@ -40,3 +40,40 @@ func TestCaptureModelAuthOutputExtractsDeviceCode(t *testing.T) {
 		t.Fatalf("Code = %q, want device code", job.Code)
 	}
 }
+
+func TestCaptureModelAuthOutputExtractsURLWithoutNewline(t *testing.T) {
+	s := &Server{}
+	job := &modelAuthLoginJob{}
+
+	s.captureModelAuthOutput(job, strings.NewReader("Open https://auth.openai.com/codex/device_authorization"), make(chan struct{}, 1))
+
+	if job.URL != "https://auth.openai.com/codex/device_authorization" {
+		t.Fatalf("URL = %q, want URL before process exits without newline", job.URL)
+	}
+}
+
+func TestAppendModelAuthOutputExtractsSplitURL(t *testing.T) {
+	s := &Server{}
+	job := &modelAuthLoginJob{}
+
+	s.appendModelAuthOutput(job, "Open https://auth.openai.com/codex/")
+	s.appendModelAuthOutput(job, "device_authorization")
+
+	if job.URL != "https://auth.openai.com/codex/device_authorization" {
+		t.Fatalf("URL = %q, want URL reconstructed from streamed chunks", job.URL)
+	}
+}
+
+func TestAppendModelAuthOutputExtractsOSCURL(t *testing.T) {
+	s := &Server{}
+	job := &modelAuthLoginJob{}
+
+	s.appendModelAuthOutput(job, "\x1b]8;;https://auth.openai.com/codex/device_authorization\x07click here\x1b]8;;\x07")
+
+	if job.URL != "https://auth.openai.com/codex/device_authorization" {
+		t.Fatalf("URL = %q, want URL from terminal hyperlink", job.URL)
+	}
+	if strings.Contains(job.Output, "\x1b") {
+		t.Fatalf("Output = %q, want terminal hyperlink escapes stripped", job.Output)
+	}
+}

--- a/pkg/hub/model_auth_test.go
+++ b/pkg/hub/model_auth_test.go
@@ -23,7 +23,7 @@ func TestCaptureModelAuthOutputDoesNotTreatCodexURLAsCode(t *testing.T) {
 	s := &Server{}
 	job := &modelAuthLoginJob{}
 
-	s.captureModelAuthOutput(job, strings.NewReader("Open https://auth.openai.com/codex/device_authorization\n"), make(chan struct{}, 1))
+	s.captureModelAuthOutput(job, strings.NewReader("Open https://auth.openai.com/codex/device_authorization\nCode: authorization\n"), make(chan struct{}, 1))
 
 	if job.Code != "" {
 		t.Fatalf("Code = %q, want no code extracted from codex URL", job.Code)
@@ -38,6 +38,29 @@ func TestCaptureModelAuthOutputExtractsDeviceCode(t *testing.T) {
 
 	if job.Code != "ABCD-EFGH" {
 		t.Fatalf("Code = %q, want device code", job.Code)
+	}
+}
+
+func TestCaptureModelAuthOutputExtractsNumericDeviceCode(t *testing.T) {
+	s := &Server{}
+	job := &modelAuthLoginJob{}
+
+	s.captureModelAuthOutput(job, strings.NewReader("Authorization code: 123-456-789\n"), make(chan struct{}, 1))
+
+	if job.Code != "123-456-789" {
+		t.Fatalf("Code = %q, want numeric device code", job.Code)
+	}
+}
+
+func TestAppendModelAuthOutputReplacesBadCodeWithRealCode(t *testing.T) {
+	s := &Server{}
+	job := &modelAuthLoginJob{}
+
+	s.appendModelAuthOutput(job, "Code: authorization\n")
+	s.appendModelAuthOutput(job, "Authorization code: 123-456-789\n")
+
+	if job.Code != "123-456-789" {
+		t.Fatalf("Code = %q, want real code after rejected prose token", job.Code)
 	}
 }
 

--- a/pkg/hub/model_auth_test.go
+++ b/pkg/hub/model_auth_test.go
@@ -52,6 +52,28 @@ func TestCaptureModelAuthOutputExtractsNumericDeviceCode(t *testing.T) {
 	}
 }
 
+func TestCaptureModelAuthOutputExtractsStandaloneNineDigitCode(t *testing.T) {
+	s := &Server{}
+	job := &modelAuthLoginJob{}
+
+	s.captureModelAuthOutput(job, strings.NewReader("Enter this authorization code:\n123 456 789\n"), make(chan struct{}, 1))
+
+	if job.Code != "123456789" {
+		t.Fatalf("Code = %q, want normalized 9 digit device code", job.Code)
+	}
+}
+
+func TestCaptureModelAuthOutputExtractsUnlabeledNineDigitCode(t *testing.T) {
+	s := &Server{}
+	job := &modelAuthLoginJob{}
+
+	s.captureModelAuthOutput(job, strings.NewReader("Open https://auth.openai.com/codex/device\n987654321\n"), make(chan struct{}, 1))
+
+	if job.Code != "987654321" {
+		t.Fatalf("Code = %q, want unlabeled 9 digit device code", job.Code)
+	}
+}
+
 func TestAppendModelAuthOutputReplacesBadCodeWithRealCode(t *testing.T) {
 	s := &Server{}
 	job := &modelAuthLoginJob{}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -76,6 +76,8 @@ type Server struct {
 	fireworksModelsCacheKey   string
 	fireworksModelsCache      []LLMModelOption
 	fireworksModelsCacheUntil time.Time
+	modelAuthJobsMu           sync.Mutex
+	modelAuthJobs             map[string]*modelAuthLoginJob
 
 	// webhookDedup prevents duplicate Linear webhook deliveries from creating
 	// duplicate claws. Keyed by issue transition fingerprint; entries expire after 30s.
@@ -287,6 +289,8 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/settings", s.withWebAdminAuth(s.handleSettings))
 	mux.HandleFunc("/api/settings/status", s.withWebAdminAuth(s.handleSettingsStatus))
 	mux.HandleFunc("/api/settings/github/test", s.withWebAdminAuth(s.handleGitHubAppTest))
+	mux.HandleFunc("/api/settings/model-auth/login", s.withWebAdminAuth(s.handleModelAuthLogin))
+	mux.HandleFunc("/api/settings/model-auth/login/{id}", s.withWebAdminAuth(s.handleModelAuthLoginStatus))
 
 	// Template store
 	mux.HandleFunc("/api/templates", s.withWebAuth(s.handleTemplates))
@@ -3074,6 +3078,7 @@ docker --version`); err != nil {
 	activeKeyDaytona := resolveActiveKey(s.hubCfg.LLMKeys, llmKeyNameDaytona)
 	defaultModelDaytona := resolveDefaultModelForKey(s.hubCfg, activeKeyDaytona)
 	llmKeyEnvDaytona := buildLLMKeyEnv(s.hubCfg.LLMKeys, llmKeyNameDaytona)
+	modelAuthEnvDaytona := buildModelAuthEnv(s.hubCfg, llmKeyNameDaytona)
 	onboardFlags := buildOnboardFlags(s.hubCfg.LLMKeys, llmKeyNameDaytona, defaultModelDaytona)
 	providerConfigScript := buildOpenClawProviderConfig(s.hubCfg.LLMKeys, llmKeyNameDaytona)
 	if activeKeyDaytona != nil {
@@ -3084,6 +3089,16 @@ docker --version`); err != nil {
 	log.Printf("[daytona] OpenClaw model resolution claw=%s selected_llm_key=%q active_llm_key=%q provider=%q default_model=%q config_patch=%t",
 		clawID, llmKeyNameDaytona, activeKeyNameDaytona, activeKeyProviderDaytona, defaultModelDaytona, providerConfigScript != "")
 	gatewayPassword := randomHex(16)
+	if restoreShell := buildModelAuthRestoreShell(modelAuthEnvDaytona); restoreShell != "" {
+		if err := exec("restore model auth", 30*time.Second, "export HOME=/home/daytona; "+restoreShell); err != nil {
+			return fmt.Errorf("restore model auth: %w", err)
+		}
+	}
+	if installCmd := daytonaInstallCodingModelCLICommand(defaultModelDaytona); installCmd != "" {
+		if err := exec("install selected model cli", 2*time.Minute, installCmd); err != nil {
+			return fmt.Errorf("install selected model cli: %w", err)
+		}
+	}
 	onboardCmd := fmt.Sprintf(
 		"%sexport NVM_DIR=/usr/local/share/nvm; export PATH=$NVM_DIR/current/bin:$PATH; openclaw onboard --non-interactive --accept-risk --skip-daemon --skip-health %s 2>&1",
 		llmKeyEnvDaytona,
@@ -3610,6 +3625,35 @@ STATUS=/tmp/openclaw-install.status
 rm -f "$LOG" "$STATUS"
 setsid nohup bash -c %s > "$LOG" 2>&1 </dev/null &
 echo "openclaw-install-status=started"`, shellQuote(installScript))
+}
+
+func daytonaInstallCodingModelCLICommand(model string) string {
+	var packageSpec, binary string
+	switch {
+	case strings.HasPrefix(model, "codex/"):
+		packageSpec = "@openai/codex@" + cliVersionFromEnv("ELASTICCLAW_CODEX_CLI_VERSION", "0.141.0")
+		binary = "codex"
+	case strings.HasPrefix(model, "grok/"):
+		packageSpec = "@xai-official/grok@" + cliVersionFromEnv("ELASTICCLAW_GROK_CLI_VERSION", "0.1.0")
+		binary = "grok"
+	default:
+		return ""
+	}
+	return fmt.Sprintf(`export HOME=/home/daytona
+export NVM_DIR=/usr/local/share/nvm
+NPM="$NVM_DIR/current/bin/npm"
+PREFIX="$("$NPM" config get prefix)"
+export PATH="$PREFIX/bin:$NVM_DIR/current/bin:/usr/local/bin:$PATH"
+sudo env PATH="$PREFIX/bin:$NVM_DIR/current/bin:/usr/local/bin:$PATH" "$NPM" install -g %s --prefix "$PREFIX" --ignore-scripts
+hash -r
+%s --version 2>&1 || true`, shellQuote(packageSpec), binary)
+}
+
+func cliVersionFromEnv(envName, fallback string) string {
+	if v := strings.TrimSpace(os.Getenv(envName)); v != "" {
+		return v
+	}
+	return fallback
 }
 
 func daytonaOpenClawInstallStatusCommand(version string) string {
@@ -4168,6 +4212,7 @@ func (s *Server) bootstrapExedev(ctx context.Context, clawID, vmName string, p *
 
 	s.mu.RLock()
 	llmKeyEnv := buildLLMKeyEnv(s.hubCfg.LLMKeys, llmKeyName)
+	modelAuthEnv := buildModelAuthEnv(s.hubCfg, llmKeyName)
 	clawToken := s.hubCfg.ClawToken
 	hubCfg := s.hubCfg
 	s.mu.RUnlock()
@@ -4203,6 +4248,7 @@ func (s *Server) bootstrapExedev(ctx context.Context, clawID, vmName string, p *
 		HubCfg:          hubCfg,
 		GitHubRepos:     githubRepos,
 		LLMKeyEnv:       llmKeyEnv,
+		ModelAuthEnv:    modelAuthEnv,
 		LinearEnv:       buildLinearEnv(linearToken),
 		ProviderConfig:  buildOpenClawProviderConfig(hubCfg.LLMKeys, llmKeyName),
 		OnboardFlags:    buildOnboardFlags(hubCfg.LLMKeys, llmKeyName, defaultModel),
@@ -4274,6 +4320,7 @@ func (s *Server) provisionDocker(ctx context.Context, clawID string, req types.C
 
 	s.mu.RLock()
 	llmKeyEnv := buildLLMKeyEnv(s.hubCfg.LLMKeys, llmKeyName)
+	modelAuthEnv := buildModelAuthEnv(s.hubCfg, llmKeyName)
 	clawToken := s.hubCfg.ClawToken
 	hubCfg := s.hubCfg
 	s.mu.RUnlock()
@@ -4307,7 +4354,7 @@ func (s *Server) provisionDocker(ctx context.Context, clawID string, req types.C
 	}
 
 	// Inject LLM keys: buildLLMKeyEnv returns "export VAR=val\n" lines — parse into k/v
-	for _, line := range strings.Split(llmKeyEnv, "\n") {
+	for _, line := range strings.Split(llmKeyEnv+modelAuthEnv, "\n") {
 		line = strings.TrimSpace(line)
 		if !strings.HasPrefix(line, "export ") {
 			continue
@@ -5038,6 +5085,7 @@ func (s *Server) bootstrapReplicated(clawID, clawName, vmID string, cfg types.Pr
 	s.mu.RLock()
 	// Inject all configured LLM keys, prioritizing the selected key if specified
 	llmKeyEnv := buildLLMKeyEnv(s.hubCfg.LLMKeys, llmKeyName)
+	modelAuthEnv := buildModelAuthEnv(s.hubCfg, llmKeyName)
 	clawToken := s.hubCfg.ClawToken
 	hubCfg := s.hubCfg
 	s.mu.RUnlock()
@@ -5056,6 +5104,7 @@ func (s *Server) bootstrapReplicated(clawID, clawName, vmID string, cfg types.Pr
 		HubCfg:          hubCfg,
 		GitHubRepos:     githubRepos,
 		LLMKeyEnv:       llmKeyEnv,
+		ModelAuthEnv:    modelAuthEnv,
 		LinearEnv:       buildLinearEnv(linearToken),
 		ProviderConfig:  buildOpenClawProviderConfig(hubCfg.LLMKeys, llmKeyName),
 		OnboardFlags:    buildOnboardFlags(hubCfg.LLMKeys, llmKeyName, defaultModel),

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -5370,6 +5370,10 @@ func resolveDefaultModelForKey(hubCfg *types.HubConfig, key *types.LLMKeyConfig)
 		return "anthropic/claude-sonnet-4-6"
 	case "openai":
 		return "openai/gpt-5.5"
+	case "codex":
+		return "codex/gpt-5.5"
+	case "grok":
+		return "grok/grok-build-0.1"
 	case "fireworks":
 		return defaultFireworksModel
 	case "groq":

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/elasticclaw/elasticclaw/internal/webui"
 
+	"github.com/elasticclaw/elasticclaw/pkg/cliversion"
 	"github.com/elasticclaw/elasticclaw/pkg/hub/artifact"
 	"github.com/elasticclaw/elasticclaw/pkg/hub/pipeline"
 	daytona "github.com/elasticclaw/elasticclaw/pkg/provider/daytona"
@@ -3631,10 +3632,10 @@ func daytonaInstallCodingModelCLICommand(model string) string {
 	var packageSpec, binary string
 	switch {
 	case strings.HasPrefix(model, "codex/"):
-		packageSpec = "@openai/codex@" + cliVersionFromEnv("ELASTICCLAW_CODEX_CLI_VERSION", "0.141.0")
+		packageSpec = "@openai/codex@" + cliversion.FromEnv("ELASTICCLAW_CODEX_CLI_VERSION", "0.141.0")
 		binary = "codex"
 	case strings.HasPrefix(model, "grok/"):
-		packageSpec = "@xai-official/grok@" + cliVersionFromEnv("ELASTICCLAW_GROK_CLI_VERSION", "0.1.0")
+		packageSpec = "@xai-official/grok@" + cliversion.FromEnv("ELASTICCLAW_GROK_CLI_VERSION", "0.1.0")
 		binary = "grok"
 	default:
 		return ""
@@ -3647,13 +3648,6 @@ export PATH="$PREFIX/bin:$NVM_DIR/current/bin:/usr/local/bin:$PATH"
 sudo env PATH="$PREFIX/bin:$NVM_DIR/current/bin:/usr/local/bin:$PATH" "$NPM" install -g %s --prefix "$PREFIX" --ignore-scripts
 hash -r
 %s --version 2>&1 || true`, shellQuote(packageSpec), binary)
-}
-
-func cliVersionFromEnv(envName, fallback string) string {
-	if v := strings.TrimSpace(os.Getenv(envName)); v != "" {
-		return v
-	}
-	return fallback
 }
 
 func daytonaOpenClawInstallStatusCommand(version string) string {

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -209,6 +209,26 @@ func TestResolveDefaultModelForKey(t *testing.T) {
 			expectedModel: "groq/llama-3.3-70b-versatile",
 		},
 		{
+			name: "codex provider",
+			hubCfg: &types.HubConfig{
+				DefaultModel: "",
+			},
+			key: &types.LLMKeyConfig{
+				Provider: "codex",
+			},
+			expectedModel: "codex/gpt-5.5",
+		},
+		{
+			name: "grok provider",
+			hubCfg: &types.HubConfig{
+				DefaultModel: "",
+			},
+			key: &types.LLMKeyConfig{
+				Provider: "grok",
+			},
+			expectedModel: "grok/grok-build-0.1",
+		},
+		{
 			name: "deepseek provider",
 			hubCfg: &types.HubConfig{
 				DefaultModel: "",

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -29,6 +29,15 @@ type LLMKeyView struct {
 	KeySet       bool   `json:"keySet"`
 	Default      bool   `json:"default"`
 	DefaultModel string `json:"defaultModel,omitempty"`
+	AuthProfile  string `json:"authProfile,omitempty"`
+}
+
+type ModelAuthProfileView struct {
+	Name          string `json:"name"`
+	Provider      string `json:"provider"`
+	Mode          string `json:"mode"`
+	Authenticated bool   `json:"authenticated"`
+	UpdatedAt     string `json:"updatedAt,omitempty"`
 }
 
 // MCPView is the redacted view of an MCP server config for the settings page.
@@ -53,16 +62,17 @@ type ConcurrencyGroupView struct {
 // SettingsView is the redacted view of hub config for the settings page.
 // Secrets are masked — never returned in full.
 type SettingsView struct {
-	LLMKeys       []LLMKeyView                `json:"llmKeys"`
-	ModelOptions  map[string][]LLMModelOption `json:"modelOptions,omitempty"`
-	Providers     map[string]ProviderView     `json:"providers"`
-	GitHub        []GitHubAppView             `json:"github"`
-	SSHPublicKeys []string                    `json:"sshPublicKeys"`
-	Integrations  *IntegrationsView           `json:"integrations"`
-	Factories     []FactoryView               `json:"factories"`
-	Secrets       []string                    `json:"secrets"`
-	MCPServers    []MCPView                   `json:"mcpServers,omitempty"`
-	Auth          *AuthView                   `json:"auth,omitempty"`
+	LLMKeys           []LLMKeyView                `json:"llmKeys"`
+	ModelOptions      map[string][]LLMModelOption `json:"modelOptions,omitempty"`
+	ModelAuthProfiles []ModelAuthProfileView      `json:"modelAuthProfiles,omitempty"`
+	Providers         map[string]ProviderView     `json:"providers"`
+	GitHub            []GitHubAppView             `json:"github"`
+	SSHPublicKeys     []string                    `json:"sshPublicKeys"`
+	Integrations      *IntegrationsView           `json:"integrations"`
+	Factories         []FactoryView               `json:"factories"`
+	Secrets           []string                    `json:"secrets"`
+	MCPServers        []MCPView                   `json:"mcpServers,omitempty"`
+	Auth              *AuthView                   `json:"auth,omitempty"`
 	// ConcurrencyGroups limits simultaneously running claws per group. 0 = unlimited.
 	ConcurrencyGroups []ConcurrencyGroupView `json:"concurrencyGroups"`
 	// MaxConcurrentClaws limits simultaneously running claws. 0 = unlimited.
@@ -191,6 +201,14 @@ type LLMKeyPatch struct {
 	Default      *bool   `json:"default,omitempty"`
 	Delete       bool    `json:"delete,omitempty"`
 	DefaultModel *string `json:"defaultModel,omitempty"`
+	AuthProfile  *string `json:"authProfile,omitempty"`
+}
+
+type ModelAuthProfilePatch struct {
+	Name     string `json:"name"`
+	Provider string `json:"provider,omitempty"`
+	Mode     string `json:"mode,omitempty"`
+	Delete   bool   `json:"delete,omitempty"`
 }
 
 // ConcurrencyGroupPatch is a patch for a concurrency group.
@@ -201,15 +219,16 @@ type ConcurrencyGroupPatch struct {
 }
 
 type SettingsPatch struct {
-	LLMKeys       []LLMKeyPatch            `json:"llmKeys,omitempty"`
-	Providers     map[string]ProviderPatch `json:"providers,omitempty"`
-	GitHub        []GitHubAppPatch         `json:"github,omitempty"`
-	UIPassword    string                   `json:"uiPassword,omitempty"`
-	SSHPublicKeys *[]string                `json:"sshPublicKeys,omitempty"`
-	Integrations  *IntegrationsPatch       `json:"integrations,omitempty"`
-	Factories     []FactoryPatch           `json:"factories,omitempty"`
-	MCPServers    []MCPPatch               `json:"mcpServers,omitempty"`
-	Auth          *AuthPatch               `json:"auth,omitempty"`
+	LLMKeys           []LLMKeyPatch            `json:"llmKeys,omitempty"`
+	ModelAuthProfiles []ModelAuthProfilePatch  `json:"modelAuthProfiles,omitempty"`
+	Providers         map[string]ProviderPatch `json:"providers,omitempty"`
+	GitHub            []GitHubAppPatch         `json:"github,omitempty"`
+	UIPassword        string                   `json:"uiPassword,omitempty"`
+	SSHPublicKeys     *[]string                `json:"sshPublicKeys,omitempty"`
+	Integrations      *IntegrationsPatch       `json:"integrations,omitempty"`
+	Factories         []FactoryPatch           `json:"factories,omitempty"`
+	MCPServers        []MCPPatch               `json:"mcpServers,omitempty"`
+	Auth              *AuthPatch               `json:"auth,omitempty"`
 	// ConcurrencyGroups replaces the full list of concurrency groups.
 	ConcurrencyGroups *[]ConcurrencyGroupPatch `json:"concurrencyGroups,omitempty"`
 	// MaxConcurrentClaws limits simultaneously running claws. 0 or omitted = unlimited.
@@ -403,6 +422,20 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 			KeySet:       llmKeyHasRequiredAPIKey(k),
 			Default:      k.Default,
 			DefaultModel: k.DefaultModel,
+			AuthProfile:  k.AuthProfile,
+		})
+	}
+	view.ModelAuthProfiles = []ModelAuthProfileView{}
+	for _, profile := range s.hubCfg.ModelAuthProfiles {
+		if profile == nil {
+			continue
+		}
+		view.ModelAuthProfiles = append(view.ModelAuthProfiles, ModelAuthProfileView{
+			Name:          profile.Name,
+			Provider:      profile.Provider,
+			Mode:          profile.Mode,
+			Authenticated: profile.AuthState != "",
+			UpdatedAt:     profile.UpdatedAt,
 		})
 	}
 
@@ -775,8 +808,55 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 			if kp.DefaultModel != nil {
 				found.DefaultModel = *kp.DefaultModel
 			}
+			if kp.AuthProfile != nil {
+				found.AuthProfile = *kp.AuthProfile
+			}
 		}
 		updatedCfg.LLMKeys = existing
+	}
+
+	if len(patch.ModelAuthProfiles) > 0 {
+		existing := make([]*types.ModelAuthProfileConfig, len(updatedCfg.ModelAuthProfiles))
+		for i, p := range updatedCfg.ModelAuthProfiles {
+			if p == nil {
+				continue
+			}
+			copy := *p
+			existing[i] = &copy
+		}
+		for _, pp := range patch.ModelAuthProfiles {
+			if pp.Name == "" {
+				continue
+			}
+			if pp.Delete {
+				filtered := existing[:0]
+				for _, p := range existing {
+					if p == nil || p.Name != pp.Name {
+						filtered = append(filtered, p)
+					}
+				}
+				existing = filtered
+				continue
+			}
+			var found *types.ModelAuthProfileConfig
+			for _, p := range existing {
+				if p != nil && p.Name == pp.Name {
+					found = p
+					break
+				}
+			}
+			if found == nil {
+				found = &types.ModelAuthProfileConfig{Name: pp.Name}
+				existing = append(existing, found)
+			}
+			if pp.Provider != "" {
+				found.Provider = pp.Provider
+			}
+			if pp.Mode != "" {
+				found.Mode = pp.Mode
+			}
+		}
+		updatedCfg.ModelAuthProfiles = existing
 	}
 
 	// Providers

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -64,6 +64,8 @@ func (k *LLMKeyConfig) EnvVarName() string {
 		return "FIREWORKS_API_KEY"
 	case "codex":
 		return "CODEX_API_KEY"
+	case "grok":
+		return "XAI_API_KEY"
 	default:
 		// Generic: PROVIDER_API_KEY uppercased
 		return strings.ToUpper(k.Provider) + "_API_KEY"

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -16,6 +16,15 @@ type LLMKeyConfig struct {
 	APIKey       string `yaml:"api_key"       json:"-"`                       // the actual key (never exposed in API)
 	Default      bool   `yaml:"default"       json:"default"`                 // use when no llm_key specified
 	DefaultModel string `yaml:"default_model" json:"default_model,omitempty"` // preferred model for this key, e.g. "fireworks/accounts/fireworks/models/kimi-k2p7"
+	AuthProfile  string `yaml:"auth_profile,omitempty" json:"auth_profile,omitempty"`
+}
+
+type ModelAuthProfileConfig struct {
+	Name      string `yaml:"name" json:"name"`
+	Provider  string `yaml:"provider" json:"provider"`
+	Mode      string `yaml:"mode" json:"mode"`
+	AuthState string `yaml:"auth_state,omitempty" json:"-"`
+	UpdatedAt string `yaml:"updated_at,omitempty" json:"updated_at,omitempty"`
 }
 
 // LLMKeysList is a custom YAML type that handles both the legacy flat-map format
@@ -481,6 +490,8 @@ type HubConfig struct {
 	// LLMKeys is a list of named LLM API keys. One can be marked default:true.
 	// Legacy flat map {"anthropic": "sk-..."} is still accepted for backwards compat.
 	LLMKeys LLMKeysList `yaml:"llm_keys,omitempty"`
+	// ModelAuthProfiles stores CLI-backed model login state for providers such as Codex and Grok.
+	ModelAuthProfiles []*ModelAuthProfileConfig `yaml:"model_auth_profiles,omitempty"`
 	// Linear is a list of Linear workspace configs for injecting API tokens into claws.
 	Linear []*LinearConfig `yaml:"linear,omitempty"`
 

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -1303,7 +1303,12 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
                       {loginJob.url && (
                         <a href={loginJob.url} target="_blank" rel="noopener noreferrer" className="underline break-all">{loginJob.url}</a>
                       )}
-                      {loginJob.code && <div>Code: <span className="font-mono">{loginJob.code}</span></div>}
+                      {loginJob.code && (
+                        <div className="rounded-md border border-primary/30 bg-primary/10 p-2">
+                          <div className="text-[11px] uppercase text-muted-foreground">One-time code</div>
+                          <div className="font-mono text-lg font-semibold tracking-wide text-foreground">{loginJob.code}</div>
+                        </div>
+                      )}
                       {!loginJob.code && loginJob.output && (
                         <pre className="max-h-24 overflow-auto whitespace-pre-wrap break-words rounded border border-border bg-background/60 p-2 text-[11px] text-muted-foreground">{loginJob.output}</pre>
                       )}

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -1044,6 +1044,16 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
     onSave({ llmKeys: [{ name: llmKeys[i].name, default: true }] })
   }
 
+  function renderLoginWindow(win: Window, text: string) {
+    win.document.body.style.margin = "0"
+    win.document.body.style.background = "#0a0a0a"
+    win.document.body.style.color = "#f5f5f5"
+    win.document.body.style.fontFamily = "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace"
+    win.document.body.style.whiteSpace = "pre-wrap"
+    win.document.body.style.padding = "24px"
+    win.document.body.textContent = text
+  }
+
   async function doStartLogin() {
     const profile = formAuthProfile.trim() || `${formProvider}-default`
     setFormAuthProfile(profile)
@@ -1051,7 +1061,7 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
     loginWindowRef.current = window.open("", "_blank")
     if (loginWindowRef.current) {
       loginWindowRef.current.document.title = "Model login"
-      loginWindowRef.current.document.body.textContent = "Waiting for login URL..."
+      renderLoginWindow(loginWindowRef.current, "Waiting for login URL...")
     }
     try {
       const job = await startModelAuthLogin(formProvider, profile)
@@ -1087,6 +1097,14 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
     loginWindowRef.current.location.href = loginJob.url
     loginWindowRef.current = null
   }, [loginJob?.url])
+
+  useEffect(() => {
+    if (!loginJob || !loginWindowRef.current || loginWindowRef.current.closed || loginJob.url) return
+    const lines = [`Login status: ${loginJob.status}`]
+    if (loginJob.error) lines.push("", loginJob.error)
+    if (loginJob.output) lines.push("", loginJob.output)
+    renderLoginWindow(loginWindowRef.current, lines.join("\n"))
+  }, [loginJob])
 
   const formProviderModels = providerModels(formProvider)
 

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -972,6 +972,7 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
   const [formAuthProfile, setFormAuthProfile] = useState("")
   const [loginJob, setLoginJob] = useState<ModelAuthLoginJob | null>(null)
   const [loginError, setLoginError] = useState("")
+  const [copiedLoginCode, setCopiedLoginCode] = useState(false)
   const loginWindowRef = useRef<Window | null>(null)
 
   const providerLabel = (p: string) => PROVIDER_OPTIONS.find(o => o.value === p)?.label ?? p
@@ -981,7 +982,7 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
   const authProfiles = (settings.modelAuthProfiles || []).filter(p => p.provider === formProvider)
 
   const resetForm = () => {
-    setFormName(""); setFormProvider("anthropic"); setFormCustomProvider(""); setFormKey(""); setFormDefault(false); setFormDefaultModel(""); setFormCustomModel(""); setFormAuthProfile(""); setLoginJob(null); setLoginError(""); setEditIdx(null)
+    setFormName(""); setFormProvider("anthropic"); setFormCustomProvider(""); setFormKey(""); setFormDefault(false); setFormDefaultModel(""); setFormCustomModel(""); setFormAuthProfile(""); setLoginJob(null); setLoginError(""); setCopiedLoginCode(false); setEditIdx(null)
   }
 
   const openAdd = () => { resetForm(); setModalMode("add"); setShowModal(true) }
@@ -1052,6 +1053,13 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
     win.document.body.style.whiteSpace = "pre-wrap"
     win.document.body.style.padding = "24px"
     win.document.body.textContent = text
+  }
+
+  function copyLoginCode(code: string) {
+    navigator.clipboard.writeText(code).then(() => {
+      setCopiedLoginCode(true)
+      setTimeout(() => setCopiedLoginCode(false), 2000)
+    })
   }
 
   async function doStartLogin() {
@@ -1305,8 +1313,16 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
                       )}
                       {loginJob.code && (
                         <div className="rounded-md border border-primary/30 bg-primary/10 p-2">
-                          <div className="text-[11px] uppercase text-muted-foreground">One-time code</div>
-                          <div className="font-mono text-lg font-semibold tracking-wide text-foreground">{loginJob.code}</div>
+                          <div className="flex items-center justify-between gap-3">
+                            <div className="min-w-0">
+                              <div className="text-[11px] uppercase text-muted-foreground">One-time code</div>
+                              <div className="font-mono text-lg font-semibold tracking-wide text-foreground">{loginJob.code}</div>
+                            </div>
+                            <Button type="button" size="sm" variant="outline" className="h-8 shrink-0 gap-1.5" onClick={() => copyLoginCode(loginJob.code || "")}>
+                              {copiedLoginCode ? <Check className="size-3.5 text-green-500" /> : <Copy className="size-3.5" />}
+                              {copiedLoginCode ? "Copied" : "Copy"}
+                            </Button>
+                          </div>
                         </div>
                       )}
                       {!loginJob.code && loginJob.output && (

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -855,6 +855,7 @@ const PROVIDER_OPTIONS = [
   { value: "fireworks",  label: "Fireworks",  placeholder: "fw_..." },
   { value: "openai",     label: "OpenAI",     placeholder: "sk-proj-..." },
   { value: "codex",      label: "Codex",      placeholder: "sk-proj-..." },
+  { value: "grok",       label: "Grok Build", placeholder: "xai-..." },
   { value: "ollama",     label: "Ollama",     placeholder: "ollama-local" },
   { value: "other",      label: "Other",      placeholder: "" },
 ]
@@ -892,11 +893,15 @@ const PROVIDER_MODELS: Record<string, LLMModelOption[]> = {
     { id: "__custom",             name: "Custom OpenAI model" },
   ],
   codex: [
-    // Codex is an autonomous agentic coding platform — it selects and routes to the
-    // appropriate underlying model (including special Codex checkpoints) on its own.
-    { id: "codex/codex",      name: "Codex (auto)" },
-    { id: "codex/codex-pro",  name: "Codex Pro (auto)" },
-    { id: "__custom",         name: "Custom Codex model" },
+    { id: "codex/gpt-5.5",      name: "GPT-5.5" },
+    { id: "codex/gpt-5.5-high", name: "GPT-5.5 High" },
+    { id: "codex/gpt-5.4",      name: "GPT-5.4" },
+    { id: "__custom",           name: "Custom Codex model" },
+  ],
+  grok: [
+    { id: "grok/grok-build-0.1", name: "Grok Build" },
+    { id: "grok/grok-4.3",       name: "Grok 4.3" },
+    { id: "__custom",            name: "Custom Grok model" },
   ],
   ollama: [
     { id: "ollama/qwen2.5-coder:1.5b", name: "Qwen2.5 Coder 1.5B" },

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -35,6 +35,26 @@ interface LLMKeyView {
   keySet: boolean
   default: boolean
   defaultModel?: string
+  authProfile?: string
+}
+
+interface ModelAuthProfileView {
+  name: string
+  provider: string
+  mode: string
+  authenticated: boolean
+  updatedAt?: string
+}
+
+interface ModelAuthLoginJob {
+  id: string
+  provider: string
+  profile: string
+  status: string
+  url?: string
+  code?: string
+  output?: string
+  error?: string
 }
 
 interface LLMModelOption {
@@ -71,6 +91,7 @@ interface WorkspaceGitHubAppView {
 interface SettingsData {
   llmKeys: LLMKeyView[]
   modelOptions?: Record<string, LLMModelOption[]>
+  modelAuthProfiles?: ModelAuthProfileView[]
   providers: Record<string, {
     type: string
     enabled: boolean
@@ -149,6 +170,28 @@ async function patchSettings(patch: object): Promise<void> {
     body: JSON.stringify(patch),
   })
   if (!res.ok) throw new Error(await res.text())
+}
+
+async function startModelAuthLogin(provider: string, profile: string): Promise<ModelAuthLoginJob> {
+  const hubUrl = getHubUrl()
+  const token = getAuthToken() || ""
+  const res = await fetch(`${hubUrl}/api/settings/model-auth/login`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+    body: JSON.stringify({ provider, profile, mode: "device" }),
+  })
+  if (!res.ok) throw new Error(await res.text())
+  return res.json()
+}
+
+async function fetchModelAuthLogin(id: string): Promise<ModelAuthLoginJob> {
+  const hubUrl = getHubUrl()
+  const token = getAuthToken() || ""
+  const res = await fetch(`${hubUrl}/api/settings/model-auth/login/${encodeURIComponent(id)}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  if (!res.ok) throw new Error(await res.text())
+  return res.json()
 }
 
 // Sentinel value used in static-export paths to represent "select first workspace"
@@ -926,13 +969,18 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
   const [formDefault, setFormDefault] = useState(false)
   const [formDefaultModel, setFormDefaultModel] = useState("")
   const [formCustomModel, setFormCustomModel] = useState("")
+  const [formAuthProfile, setFormAuthProfile] = useState("")
+  const [loginJob, setLoginJob] = useState<ModelAuthLoginJob | null>(null)
+  const [loginError, setLoginError] = useState("")
 
   const providerLabel = (p: string) => PROVIDER_OPTIONS.find(o => o.value === p)?.label ?? p
   const providerPlaceholder = (p: string) => PROVIDER_OPTIONS.find(o => o.value === p)?.placeholder ?? ""
   const providerModels = (p: string) => settings.modelOptions?.[p] ?? PROVIDER_MODELS[p] ?? []
+  const supportsCLIAuth = formProvider === "codex" || formProvider === "grok"
+  const authProfiles = (settings.modelAuthProfiles || []).filter(p => p.provider === formProvider)
 
   const resetForm = () => {
-    setFormName(""); setFormProvider("anthropic"); setFormCustomProvider(""); setFormKey(""); setFormDefault(false); setFormDefaultModel(""); setFormCustomModel(""); setEditIdx(null)
+    setFormName(""); setFormProvider("anthropic"); setFormCustomProvider(""); setFormKey(""); setFormDefault(false); setFormDefaultModel(""); setFormCustomModel(""); setFormAuthProfile(""); setLoginJob(null); setLoginError(""); setEditIdx(null)
   }
 
   const openAdd = () => { resetForm(); setModalMode("add"); setShowModal(true) }
@@ -944,6 +992,7 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
     setFormCustomProvider(isCustom ? k.provider : "")
     setFormKey("")
     setFormDefault(k.default)
+    setFormAuthProfile(k.authProfile || "")
     const options = providerModels(k.provider)
     if (k.defaultModel && options.length > 0 && !options.some(m => m.id === k.defaultModel)) {
       setFormDefaultModel("__custom")
@@ -963,9 +1012,10 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
   function doSave() {
     const actualProvider = formProvider === "other" ? formCustomProvider : formProvider
     const actualDefaultModel = formDefaultModel === "__custom" ? formCustomModel.trim() : formDefaultModel
+    const actualAuthProfile = supportsCLIAuth ? formAuthProfile.trim() : ""
     if (modalMode === "add") {
-      if (!formName.trim() || (!formKey.trim() && actualProvider !== "ollama")) return
-      onSave({ llmKeys: [{ name: formName.trim(), provider: actualProvider, apiKey: formKey.trim(), default: formDefault, defaultModel: actualDefaultModel || undefined }] })
+      if (!formName.trim() || (!formKey.trim() && actualProvider !== "ollama" && !actualAuthProfile)) return
+      onSave({ llmKeys: [{ name: formName.trim(), provider: actualProvider, apiKey: formKey.trim(), default: formDefault, defaultModel: actualDefaultModel || undefined, authProfile: actualAuthProfile || undefined }] })
     } else if (editIdx !== null) {
       const existing = llmKeys[editIdx]
       const patch: Record<string, unknown> = {
@@ -975,6 +1025,7 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
       if (formKey.trim()) patch.apiKey = formKey.trim()
       patch.default = formDefault       // always send so user can unset
       if (actualDefaultModel) patch.defaultModel = actualDefaultModel
+      patch.authProfile = actualAuthProfile
       if (actualProvider !== existing.provider) patch.provider = actualProvider
       onSave({ llmKeys: [patch] })
     }
@@ -991,6 +1042,31 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
   function setDefault(i: number) {
     onSave({ llmKeys: [{ name: llmKeys[i].name, default: true }] })
   }
+
+  async function doStartLogin() {
+    const profile = formAuthProfile.trim() || `${formProvider}-default`
+    setFormAuthProfile(profile)
+    setLoginError("")
+    try {
+      const job = await startModelAuthLogin(formProvider, profile)
+      setLoginJob(job)
+    } catch (err) {
+      setLoginError(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  useEffect(() => {
+    if (!loginJob || loginJob.status !== "running") return
+    const timer = window.setInterval(async () => {
+      try {
+        const next = await fetchModelAuthLogin(loginJob.id)
+        setLoginJob(next)
+      } catch (err) {
+        setLoginError(err instanceof Error ? err.message : String(err))
+      }
+    }, 1500)
+    return () => window.clearInterval(timer)
+  }, [loginJob])
 
   const formProviderModels = providerModels(formProvider)
 
@@ -1157,6 +1233,46 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
                   placeholder={modalMode === "edit" ? "Leave blank to keep existing" : providerPlaceholder(formProvider)}
                 />
               </div>
+              {supportsCLIAuth && (
+                <div className="space-y-2">
+                  <label className="text-xs text-muted-foreground mb-1 block">CLI auth profile <span className="text-muted-foreground/60">(optional)</span></label>
+                  <div className="flex gap-2">
+                    <Input
+                      value={formAuthProfile}
+                      onChange={e => setFormAuthProfile(e.target.value)}
+                      className="h-8 text-sm"
+                      placeholder={`${formProvider}-default`}
+                    />
+                    <Button type="button" size="sm" variant="outline" onClick={doStartLogin} disabled={saving}>
+                      Login
+                    </Button>
+                  </div>
+                  {authProfiles.length > 0 && (
+                    <select
+                      value={formAuthProfile}
+                      onChange={e => setFormAuthProfile(e.target.value)}
+                      className="h-8 text-sm w-full rounded-md border border-input bg-background px-2 py-1"
+                    >
+                      <option value="">No CLI auth profile</option>
+                      {authProfiles.map(p => (
+                        <option key={p.name} value={p.name}>{p.name}{p.authenticated ? " (authenticated)" : ""}</option>
+                      ))}
+                    </select>
+                  )}
+                  {loginJob && (
+                    <div className="rounded-md border border-border p-3 text-xs space-y-1">
+                      <div className="text-muted-foreground">Login status: {loginJob.status}</div>
+                      {loginJob.url && (
+                        <a href={loginJob.url} target="_blank" rel="noopener noreferrer" className="underline break-all">{loginJob.url}</a>
+                      )}
+                      {loginJob.code && <div>Code: <span className="font-mono">{loginJob.code}</span></div>}
+                      {loginJob.error && <div className="text-red-400">{loginJob.error}</div>}
+                      {loginJob.status === "complete" && <div className="text-green-400">Profile saved. Save this model key to use it.</div>}
+                    </div>
+                  )}
+                  {loginError && <div className="text-xs text-red-400">{loginError}</div>}
+                </div>
+              )}
               <div>
                 <label className="text-xs text-muted-foreground mb-1 block">Default model <span className="text-muted-foreground/60">(optional)</span></label>
                 {formProviderModels.length > 0 ? (
@@ -1198,7 +1314,7 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
                 <Button size="sm" variant="outline" onClick={() => { setShowModal(false); resetForm() }}>Cancel</Button>
                 <Button
                   size="sm"
-                  disabled={saving || !formName.trim() || (modalMode === "add" && !formKey.trim()) || (formProvider === "other" && !formCustomProvider.trim())}
+                  disabled={saving || !formName.trim() || (modalMode === "add" && !formKey.trim() && formProvider !== "ollama" && !formAuthProfile.trim()) || (formProvider === "other" && !formCustomProvider.trim())}
                   onClick={doSave}
                 >
                   {modalMode === "add" ? "Add Model Key" : "Save changes"}

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -1304,6 +1304,9 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
                         <a href={loginJob.url} target="_blank" rel="noopener noreferrer" className="underline break-all">{loginJob.url}</a>
                       )}
                       {loginJob.code && <div>Code: <span className="font-mono">{loginJob.code}</span></div>}
+                      {!loginJob.code && loginJob.output && (
+                        <pre className="max-h-24 overflow-auto whitespace-pre-wrap break-words rounded border border-border bg-background/60 p-2 text-[11px] text-muted-foreground">{loginJob.output}</pre>
+                      )}
                       {loginJob.error && <div className="text-red-400">{loginJob.error}</div>}
                       {loginJob.status === "complete" && <div className="text-green-400">Profile saved. Save this model key to use it.</div>}
                     </div>

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -972,6 +972,7 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
   const [formAuthProfile, setFormAuthProfile] = useState("")
   const [loginJob, setLoginJob] = useState<ModelAuthLoginJob | null>(null)
   const [loginError, setLoginError] = useState("")
+  const loginWindowRef = useRef<Window | null>(null)
 
   const providerLabel = (p: string) => PROVIDER_OPTIONS.find(o => o.value === p)?.label ?? p
   const providerPlaceholder = (p: string) => PROVIDER_OPTIONS.find(o => o.value === p)?.placeholder ?? ""
@@ -1047,10 +1048,23 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
     const profile = formAuthProfile.trim() || `${formProvider}-default`
     setFormAuthProfile(profile)
     setLoginError("")
+    loginWindowRef.current = window.open("", "_blank")
+    if (loginWindowRef.current) {
+      loginWindowRef.current.document.title = "Model login"
+      loginWindowRef.current.document.body.textContent = "Waiting for login URL..."
+    }
     try {
       const job = await startModelAuthLogin(formProvider, profile)
       setLoginJob(job)
+      if (job.url && loginWindowRef.current && !loginWindowRef.current.closed) {
+        loginWindowRef.current.location.href = job.url
+        loginWindowRef.current = null
+      }
     } catch (err) {
+      if (loginWindowRef.current && !loginWindowRef.current.closed) {
+        loginWindowRef.current.close()
+      }
+      loginWindowRef.current = null
       setLoginError(err instanceof Error ? err.message : String(err))
     }
   }
@@ -1067,6 +1081,12 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
     }, 1500)
     return () => window.clearInterval(timer)
   }, [loginJob])
+
+  useEffect(() => {
+    if (!loginJob?.url || !loginWindowRef.current || loginWindowRef.current.closed) return
+    loginWindowRef.current.location.href = loginJob.url
+    loginWindowRef.current = null
+  }, [loginJob?.url])
 
   const formProviderModels = providerModels(formProvider)
 


### PR DESCRIPTION
## Summary
- relax Fireworks model filtering so sparse List Models responses still populate the dropdown
- keep excluding models explicitly marked private or not serverless
- add regression coverage for sparse model metadata

## Tests
- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./pkg/hub -run 'Test.*Fireworks'
- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./pkg/hub
- npm run build