### PR TITLE
Add AWS Lambda MicroVMs sandbox provider

### DIFF
--- a/cmd/template.go
+++ b/cmd/template.go
@@ -60,7 +60,7 @@ func init() {
 	templateCmd.AddCommand(templateCreateCmd)
 	templateCmd.AddCommand(templateListCmd)
 
-	templateCreateCmd.Flags().StringVar(&templateCreateProvider, "provider", "replicated", "provider to use (replicated, daytona, exedev)")
+	templateCreateCmd.Flags().StringVar(&templateCreateProvider, "provider", "replicated", "provider to use (replicated, daytona, exedev, docker, lambda-microvms)")
 	templateCreateCmd.Flags().StringVar(&templateCreateInstanceType, "instance-type", "r1.large", "instance type (e.g. r1.small, r1.large)")
 	templateCreateCmd.Flags().StringVar(&templateCreateTTL, "ttl", "48h", "time-to-live for the VM (e.g. 4h, 24h, 48h)")
 }

--- a/pkg/hub/ai_config.go
+++ b/pkg/hub/ai_config.go
@@ -432,7 +432,7 @@ hub.yaml schema overview:
 - token: web UI password (shared secret)
 - claw_token: token agents use to connect (required)
 - default_model: default LLM model (e.g. "anthropic/claude-sonnet-4-6")
-- providers: daytona, replicated, exedev sandbox providers
+- providers: daytona, replicated, exedev, docker, lambda-microvms sandbox providers
 - github: list of GitHub App configs (app_id, private_key_pem, url)
 - integrations: linear, shortcut workspace tokens and webhook secrets
 - llm_keys: [{name, provider, api_key, default: bool}]

--- a/pkg/hub/checkpoints.go
+++ b/pkg/hub/checkpoints.go
@@ -384,6 +384,8 @@ func (s *Server) provisionStoredClaw(clawID string) {
 		provErr = s.provisionReplicated(ctx, clawID, req, provCfg, env)
 	case "exedev":
 		provErr = s.provisionExedev(ctx, clawID, req, provCfg, fileBytes, env)
+	case "lambda-microvms":
+		provErr = s.provisionLambdaMicroVMs(ctx, clawID, req, provCfg, fileBytes)
 	default:
 		provErr = fmt.Errorf("unsupported provider: %s", provider)
 	}

--- a/pkg/hub/doctor.go
+++ b/pkg/hub/doctor.go
@@ -335,7 +335,7 @@ func (s *Server) checkProviders(cfg *types.HubConfig) []DoctorCheck {
 			Category:    "sandboxes",
 			Severity:    "critical",
 			Title:       "No sandbox providers configured",
-			Description: "At least one sandbox provider (daytona, replicated, exedev) must be configured.",
+			Description: "At least one sandbox provider must be configured.",
 			OK:          false,
 			FixAction: &FixAction{
 				Type:   "navigate",
@@ -347,7 +347,7 @@ func (s *Server) checkProviders(cfg *types.HubConfig) []DoctorCheck {
 	}
 
 	validProviders := map[string]bool{
-		"daytona": true, "replicated": true, "exedev": true, "docker": true,
+		"daytona": true, "replicated": true, "exedev": true, "docker": true, "lambda-microvms": true,
 	}
 
 	allProvidersValid := true
@@ -358,7 +358,7 @@ func (s *Server) checkProviders(cfg *types.HubConfig) []DoctorCheck {
 				Category:    "sandboxes",
 				Severity:    "warning",
 				Title:       fmt.Sprintf("Unknown sandbox provider: %q", name),
-				Description: fmt.Sprintf("Provider %q is not a recognised sandbox provider (daytona, replicated, exedev, docker).", name),
+				Description: fmt.Sprintf("Provider %q is not a recognised sandbox provider.", name),
 				OK:          false,
 				FixAction: &FixAction{
 					Type:   "navigate",
@@ -403,6 +403,22 @@ func (s *Server) checkProviders(cfg *types.HubConfig) []DoctorCheck {
 			}
 		case "exedev":
 			// exe.dev uses SSH key authentication; no explicit API key needed in config
+		case "lambda-microvms":
+			if p.ImageIdentifier == "" {
+				allProvidersValid = false
+				checks = append(checks, DoctorCheck{
+					Category:    "sandboxes",
+					Severity:    "critical",
+					Title:       "AWS Lambda MicroVMs provider missing image identifier",
+					Description: "The AWS Lambda MicroVMs sandbox provider is configured but the image identifier is empty.",
+					OK:          false,
+					FixAction: &FixAction{
+						Type:   "navigate",
+						Target: "/settings/runtimes",
+						Label:  "Configure AWS Lambda MicroVMs",
+					},
+				})
+			}
 		}
 	}
 	if allProvidersValid {

--- a/pkg/hub/external_webhook.go
+++ b/pkg/hub/external_webhook.go
@@ -669,6 +669,8 @@ func (s *Server) createClawForExternalEvent(factory *types.FactoryConfig, payloa
 			provErr = s.provisionDaytona(ctx, clawID, req, provCfg, fileBytes, env)
 		case "exedev":
 			provErr = s.provisionExedev(ctx, clawID, req, provCfg, fileBytes, env)
+		case "lambda-microvms":
+			provErr = s.provisionLambdaMicroVMs(ctx, clawID, req, provCfg, fileBytes)
 		case "noop":
 			if os.Getenv("ELASTICCLAW_NOOP_PROVIDER") == "" {
 				provErr = fmt.Errorf("noop provider requires ELASTICCLAW_NOOP_PROVIDER=1")

--- a/pkg/hub/factory_creator.go
+++ b/pkg/hub/factory_creator.go
@@ -441,6 +441,8 @@ func (s *Server) createClawFromFactory(factory *types.FactoryConfig, issueID str
 			provErr = s.provisionDaytona(ctx, clawID, req, provCfg, fileBytes, env)
 		case "exedev":
 			provErr = s.provisionExedev(ctx, clawID, req, provCfg, fileBytes, env)
+		case "lambda-microvms":
+			provErr = s.provisionLambdaMicroVMs(ctx, clawID, req, provCfg, fileBytes)
 		case "noop":
 			if os.Getenv("ELASTICCLAW_NOOP_PROVIDER") == "" {
 				provErr = fmt.Errorf("noop provider requires ELASTICCLAW_NOOP_PROVIDER=1 (test use only)")

--- a/pkg/hub/github_issues.go
+++ b/pkg/hub/github_issues.go
@@ -931,6 +931,8 @@ func (s *Server) createClawForGitHubIssue(factory *types.FactoryConfig, payload 
 			provErr = s.provisionDaytona(ctx, clawID, req, provCfg, fileBytes, env)
 		case "exedev":
 			provErr = s.provisionExedev(ctx, clawID, req, provCfg, fileBytes, env)
+		case "lambda-microvms":
+			provErr = s.provisionLambdaMicroVMs(ctx, clawID, req, provCfg, fileBytes)
 		case "noop":
 			// Noop provider is not implemented; skip
 		default:

--- a/pkg/hub/github_webhook.go
+++ b/pkg/hub/github_webhook.go
@@ -956,6 +956,8 @@ func (s *Server) createClawForGitHubPR(factory *types.FactoryConfig, pr githubPR
 			provErr = s.provisionDaytona(ctx, clawID, req, provCfg, fileBytes, env)
 		case "exedev":
 			provErr = s.provisionExedev(ctx, clawID, req, provCfg, fileBytes, env)
+		case "lambda-microvms":
+			provErr = s.provisionLambdaMicroVMs(ctx, clawID, req, provCfg, fileBytes)
 		case "noop":
 			if os.Getenv("ELASTICCLAW_NOOP_PROVIDER") == "" {
 				provErr = fmt.Errorf("noop provider requires ELASTICCLAW_NOOP_PROVIDER=1 (test use only)")

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -1091,6 +1091,8 @@ func (s *Server) provisionPendingClaw(clawID string) {
 		provErr = s.provisionDaytona(ctx, clawID, req, provCfg, fileBytes, env)
 	case "exedev":
 		provErr = s.provisionExedev(ctx, clawID, req, provCfg, fileBytes, env)
+	case "lambda-microvms":
+		provErr = s.provisionLambdaMicroVMs(ctx, clawID, req, provCfg, fileBytes)
 	case "noop":
 		if os.Getenv("ELASTICCLAW_NOOP_PROVIDER") == "" {
 			provErr = fmt.Errorf("noop provider requires ELASTICCLAW_NOOP_PROVIDER=1")

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -436,6 +436,16 @@ func (s *Server) executePipelineCommand(clawID, command string, timeout time.Dur
 			return nil, err
 		}
 		return &pipelineRunResult{ExitCode: result.ExitCode, Stdout: result.Stdout, Stderr: result.Stderr}, err
+	case "lambda-microvms":
+		p, err := newLambdaMicroVMsProvider(provCfg)
+		if err != nil {
+			return nil, fmt.Errorf("lambda microvms init: %w", err)
+		}
+		result, err := p.Exec(ctx, providerID, []string{"bash", "-lc", workspaceCommand})
+		if result == nil {
+			return nil, err
+		}
+		return &pipelineRunResult{ExitCode: result.ExitCode, Stdout: result.Stdout, Stderr: result.Stderr}, err
 	case "replicated":
 		if sshHost == "" || sshPort == 0 || sshUser == "" {
 			return nil, fmt.Errorf("replicated agent has no SSH connection details")

--- a/pkg/hub/providers.go
+++ b/pkg/hub/providers.go
@@ -4,6 +4,7 @@ import (
 	"github.com/elasticclaw/elasticclaw/pkg/provider/daytona"
 	dockerpkg "github.com/elasticclaw/elasticclaw/pkg/provider/docker"
 	"github.com/elasticclaw/elasticclaw/pkg/provider/exedev"
+	lambdamicrovms "github.com/elasticclaw/elasticclaw/pkg/provider/lambdamicrovms"
 	replicated "github.com/elasticclaw/elasticclaw/pkg/provider/replicated"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
@@ -18,7 +19,7 @@ func newDaytonaProvider(cfg types.ProviderConfig) (*daytona.Provider, error) {
 
 func newExedevProvider(cfg types.ProviderConfig) (*exedev.Provider, error) {
 	return exedev.New(exedev.Config{
-		SSHKeyPath:  cfg.SSHKeyPath,
+		SSHKeyPath:    cfg.SSHKeyPath,
 		DefaultCPU:    cfg.DefaultCPU,
 		DefaultMemory: cfg.DefaultMemory,
 		DefaultDisk:   cfg.DefaultDisk,
@@ -32,13 +33,31 @@ func newDockerProvider(cfg types.ProviderConfig) (*dockerpkg.Provider, error) {
 	})
 }
 
+func newLambdaMicroVMsProvider(cfg types.ProviderConfig) (*lambdamicrovms.Provider, error) {
+	return lambdamicrovms.New(lambdamicrovms.Config{
+		Region:                   cfg.AWSRegion,
+		Profile:                  cfg.AWSProfile,
+		ImageIdentifier:          cfg.ImageIdentifier,
+		ImageVersion:             cfg.ImageVersion,
+		ExecutionRoleARN:         cfg.ExecutionRoleARN,
+		IngressNetworkConnectors: cfg.IngressNetworkConnectors,
+		EgressNetworkConnectors:  cfg.EgressNetworkConnectors,
+		IdleMaxDurationSeconds:   cfg.IdleMaxDurationSeconds,
+		SuspendedDurationSeconds: cfg.SuspendedDurationSeconds,
+		AutoResume:               cfg.AutoResume,
+		MaximumDurationSeconds:   cfg.MaximumDurationSeconds,
+		BridgePort:               cfg.MicroVMBridgePort,
+		TokenExpirationMinutes:   cfg.AuthTokenExpirationMinutes,
+	})
+}
+
 func newReplicatedProvider(cfg types.ProviderConfig) (*replicated.Provider, error) {
 	return replicated.New(replicated.Config{
-		Token:             cfg.Token,
-		APIURL:            cfg.APIURL,
-		DefaultTTL:        cfg.DefaultTTL,
-		DefaultType:       cfg.DefaultInstanceType,
-		HubPublicKey:      cfg.SSHPublicKey,
-		ExtraPublicKeys:   cfg.ExtraSSHPublicKeys,
+		Token:           cfg.Token,
+		APIURL:          cfg.APIURL,
+		DefaultTTL:      cfg.DefaultTTL,
+		DefaultType:     cfg.DefaultInstanceType,
+		HubPublicKey:    cfg.SSHPublicKey,
+		ExtraPublicKeys: cfg.ExtraSSHPublicKeys,
 	})
 }

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1233,6 +1233,8 @@ func (s *Server) handleCreateClaw(w http.ResponseWriter, r *http.Request, tenant
 			provErr = s.provisionExedev(ctx, clawID, req, provCfg, templateFiles, env)
 		case "docker":
 			provErr = s.provisionDocker(ctx, clawID, req, provCfg, templateFiles)
+		case "lambda-microvms":
+			provErr = s.provisionLambdaMicroVMs(ctx, clawID, req, provCfg, templateFiles)
 		default:
 			provErr = fmt.Errorf("unsupported provider: %s", req.Provider)
 		}
@@ -4400,6 +4402,93 @@ func (s *Server) provisionDocker(ctx context.Context, clawID string, req types.C
 	return nil
 }
 
+func (s *Server) provisionLambdaMicroVMs(ctx context.Context, clawID string, req types.CreateClawRequest, cfg types.ProviderConfig, files map[string][]byte) error {
+	p, err := newLambdaMicroVMsProvider(cfg)
+	if err != nil {
+		return fmt.Errorf("lambda microvms init: %w", err)
+	}
+
+	var clawName, githubReposJSON, linearWorkspace, templateDefaultModel, llmKeyName string
+	var nixEnabled, dockerEnabled int
+	if err := s.db.QueryRow(
+		`SELECT COALESCE(name,''), COALESCE(github_repos,'[]'), COALESCE(linear_workspace,''), COALESCE(default_model,''), nix, docker, COALESCE(llm_key,'') FROM claws WHERE id=?`,
+		clawID,
+	).Scan(&clawName, &githubReposJSON, &linearWorkspace, &templateDefaultModel, &nixEnabled, &dockerEnabled, &llmKeyName); err != nil {
+		return fmt.Errorf("load claw config: %w", err)
+	}
+
+	s.mu.RLock()
+	llmKeyEnv := buildLLMKeyEnv(s.hubCfg.LLMKeys, llmKeyName)
+	modelAuthEnv := buildModelAuthEnv(s.hubCfg, llmKeyName)
+	clawToken := s.hubCfg.ClawToken
+	hubCfg := s.hubCfg
+	s.mu.RUnlock()
+
+	linearToken := resolveLinearToken(hubCfg, linearWorkspace)
+	defaultModel := templateDefaultModel
+	if defaultModel == "" {
+		defaultModel = hubCfg.DefaultModel
+	}
+	providerConfig := buildOpenClawProviderConfig(hubCfg.LLMKeys, llmKeyName)
+	onboardFlags := buildOnboardFlags(hubCfg.LLMKeys, llmKeyName, defaultModel)
+	gatewayPassword := randomHex(16)
+
+	env := map[string]string{
+		"ELASTICCLAW_HUB_URL":            s.clawHubURL(),
+		"ELASTICCLAW_CLAW_ID":            clawID,
+		"ELASTICCLAW_CLAW_TOKEN":         clawToken,
+		"ELASTICCLAW_CLAW_NAME":          clawName,
+		"ELASTICCLAW_GITHUB_REPOS":       githubReposJSON,
+		"ELASTICCLAW_BOOTSTRAP":          "1",
+		"ELASTICCLAW_WAIT_FOR_WORKSPACE": "1",
+		"ELASTICCLAW_GATEWAY_PASSWORD":   gatewayPassword,
+		"OPENCLAW_GATEWAY_PASSWORD":      gatewayPassword,
+		"OPENCLAW_DEFAULT_MODEL":         defaultModel,
+		"ELASTICCLAW_NIX":                boolEnv(nixEnabled != 0),
+		"ELASTICCLAW_DOCKER":             boolEnv(dockerEnabled != 0),
+		"ELASTICCLAW_PROVIDER_CONFIG":    providerConfig,
+		"ELASTICCLAW_ONBOARD_FLAGS":      onboardFlags,
+	}
+	for _, line := range strings.Split(llmKeyEnv+modelAuthEnv, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "export ") {
+			continue
+		}
+		kv := strings.TrimPrefix(line, "export ")
+		if idx := strings.IndexByte(kv, '='); idx > 0 {
+			k := kv[:idx]
+			v := kv[idx+1:]
+			if unquoted, err := strconv.Unquote(v); err == nil {
+				v = unquoted
+			} else if len(v) >= 2 && strings.HasPrefix(v, "'") && strings.HasSuffix(v, "'") {
+				v = v[1 : len(v)-1]
+			}
+			env[k] = v
+		}
+	}
+	if linearToken != "" {
+		env["LINEAR_API_KEY"] = linearToken
+	}
+	for k, v := range req.Env {
+		if _, exists := env[k]; !exists {
+			env[k] = v
+		}
+	}
+
+	createReq := types.CreateRequest{
+		Name:          req.ProviderName,
+		Env:           env,
+		TemplateFiles: files,
+	}
+	instance, err := p.Create(ctx, createReq)
+	if err != nil {
+		return fmt.Errorf("lambda microvms create: %w", err)
+	}
+	log.Printf("[lambda-microvms] microvm started: %s (claw %s)", instance.ID, clawID)
+	_, _ = s.db.Exec(`UPDATE claws SET status='starting', provider='lambda-microvms', provider_id=? WHERE id=?`, instance.ID, clawID)
+	return nil
+}
+
 // boolEnv converts a bool to "true"/"false" for environment variable injection.
 func boolEnv(v bool) string {
 	if v {
@@ -5999,6 +6088,8 @@ func (s *Server) terminateVM(provider, vmID string) {
 		s.terminateExedevVM(vmID)
 	case "docker":
 		s.terminateDockerVM(vmID)
+	case "lambda-microvms":
+		s.terminateLambdaMicroVM(vmID)
 	default:
 		log.Printf("terminateVM: unsupported provider %q for VM %s", provider, vmID)
 	}
@@ -6023,6 +6114,27 @@ func (s *Server) terminateDockerVM(vmID string) {
 		return
 	}
 	log.Printf("Docker container %s terminated", vmID)
+}
+
+// terminateLambdaMicroVM destroys an AWS Lambda MicroVM by ID.
+func (s *Server) terminateLambdaMicroVM(vmID string) {
+	s.mu.RLock()
+	cfg, ok := s.hubCfg.Providers["lambda-microvms"]
+	s.mu.RUnlock()
+	if !ok {
+		log.Printf("terminateLambdaMicroVM: no lambda-microvms provider configured")
+		return
+	}
+	p, err := newLambdaMicroVMsProvider(cfg)
+	if err != nil {
+		log.Printf("terminateLambdaMicroVM: provider init error: %v", err)
+		return
+	}
+	if err := p.Destroy(context.Background(), vmID, false); err != nil {
+		log.Printf("terminateLambdaMicroVM: failed to destroy MicroVM %s: %v", vmID, err)
+		return
+	}
+	log.Printf("Lambda MicroVM %s terminated", vmID)
 }
 
 // terminateExedevVM destroys an exedev VM by ID.

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -346,6 +346,20 @@ func TestSettingsStatusProviderReadiness(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "lambda microvms requires image identifier",
+			provider: map[string]types.ProviderConfig{
+				"lambda-microvms": {},
+			},
+			want: false,
+		},
+		{
+			name: "lambda microvms with image identifier",
+			provider: map[string]types.ProviderConfig{
+				"lambda-microvms": {ImageIdentifier: "arn:aws:lambda:us-east-1:123456789012:microvm-image/elasticclaw"},
+			},
+			want: true,
+		},
+		{
 			name: "named provider uses explicit type",
 			provider: map[string]types.ProviderConfig{
 				"primary": {Type: "daytona", APIKey: "daytona-key"},

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -171,6 +171,20 @@ type ProviderView struct {
 	DefaultMemory string `json:"defaultMemory,omitempty"`
 	DefaultDisk   string `json:"defaultDisk,omitempty"`
 	_sshKeyPath   string `json:"-"` // internal: path for file I/O outside lock
+	// AWS Lambda MicroVMs
+	AWSRegion                  string   `json:"awsRegion,omitempty"`
+	AWSProfile                 string   `json:"awsProfile,omitempty"`
+	ImageIdentifier            string   `json:"imageIdentifier,omitempty"`
+	ImageVersion               string   `json:"imageVersion,omitempty"`
+	ExecutionRoleARN           string   `json:"executionRoleArn,omitempty"`
+	IngressNetworkConnectors   []string `json:"ingressNetworkConnectors,omitempty"`
+	EgressNetworkConnectors    []string `json:"egressNetworkConnectors,omitempty"`
+	IdleMaxDurationSeconds     int      `json:"idleMaxDurationSeconds,omitempty"`
+	SuspendedDurationSeconds   int      `json:"suspendedDurationSeconds,omitempty"`
+	AutoResume                 *bool    `json:"autoResume,omitempty"`
+	MaximumDurationSeconds     int      `json:"maximumDurationSeconds,omitempty"`
+	MicroVMBridgePort          int      `json:"bridgePort,omitempty"`
+	AuthTokenExpirationMinutes int      `json:"authTokenExpirationMinutes,omitempty"`
 }
 
 // GitHubAppPermission is a single permission check result for a GitHub App.
@@ -341,6 +355,20 @@ type ProviderPatch struct {
 	DefaultCPU    int    `json:"defaultCpu,omitempty"`
 	DefaultMemory string `json:"defaultMemory,omitempty"`
 	DefaultDisk   string `json:"defaultDisk,omitempty"`
+	// AWS Lambda MicroVMs
+	AWSRegion                  string   `json:"awsRegion,omitempty"`
+	AWSProfile                 string   `json:"awsProfile,omitempty"`
+	ImageIdentifier            string   `json:"imageIdentifier,omitempty"`
+	ImageVersion               string   `json:"imageVersion,omitempty"`
+	ExecutionRoleARN           string   `json:"executionRoleArn,omitempty"`
+	IngressNetworkConnectors   []string `json:"ingressNetworkConnectors,omitempty"`
+	EgressNetworkConnectors    []string `json:"egressNetworkConnectors,omitempty"`
+	IdleMaxDurationSeconds     int      `json:"idleMaxDurationSeconds,omitempty"`
+	SuspendedDurationSeconds   int      `json:"suspendedDurationSeconds,omitempty"`
+	AutoResume                 *bool    `json:"autoResume,omitempty"`
+	MaximumDurationSeconds     int      `json:"maximumDurationSeconds,omitempty"`
+	MicroVMBridgePort          int      `json:"bridgePort,omitempty"`
+	AuthTokenExpirationMinutes int      `json:"authTokenExpirationMinutes,omitempty"`
 	// Delete removes this provider when true.
 	Delete bool `json:"delete,omitempty"`
 }
@@ -382,6 +410,10 @@ func hasConfiguredProvider(providers map[string]types.ProviderConfig) bool {
 			}
 		case "exedev", "docker":
 			return true
+		case "lambda-microvms":
+			if p.ImageIdentifier != "" {
+				return true
+			}
 		default:
 			if p.Token != "" || p.APIKey != "" || p.AccessToken != "" {
 				return true
@@ -460,6 +492,20 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 			if p.SSHKeyPath != "" {
 				pv._sshKeyPath = p.SSHKeyPath
 			}
+		case "lambda-microvms":
+			pv.AWSRegion = p.AWSRegion
+			pv.AWSProfile = p.AWSProfile
+			pv.ImageIdentifier = p.ImageIdentifier
+			pv.ImageVersion = p.ImageVersion
+			pv.ExecutionRoleARN = p.ExecutionRoleARN
+			pv.IngressNetworkConnectors = append([]string(nil), p.IngressNetworkConnectors...)
+			pv.EgressNetworkConnectors = append([]string(nil), p.EgressNetworkConnectors...)
+			pv.IdleMaxDurationSeconds = p.IdleMaxDurationSeconds
+			pv.SuspendedDurationSeconds = p.SuspendedDurationSeconds
+			pv.AutoResume = p.AutoResume
+			pv.MaximumDurationSeconds = p.MaximumDurationSeconds
+			pv.MicroVMBridgePort = p.MicroVMBridgePort
+			pv.AuthTokenExpirationMinutes = p.AuthTokenExpirationMinutes
 		}
 		view.Providers[name] = pv
 	}
@@ -916,6 +962,46 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 				}
 				if pp.DefaultDisk != "" {
 					existing.DefaultDisk = pp.DefaultDisk
+				}
+			case "lambda-microvms":
+				if pp.AWSRegion != "" {
+					existing.AWSRegion = pp.AWSRegion
+				}
+				if pp.AWSProfile != "" {
+					existing.AWSProfile = pp.AWSProfile
+				}
+				if pp.ImageIdentifier != "" {
+					existing.ImageIdentifier = pp.ImageIdentifier
+				}
+				if pp.ImageVersion != "" {
+					existing.ImageVersion = pp.ImageVersion
+				}
+				if pp.ExecutionRoleARN != "" {
+					existing.ExecutionRoleARN = pp.ExecutionRoleARN
+				}
+				if pp.IngressNetworkConnectors != nil {
+					existing.IngressNetworkConnectors = append([]string(nil), pp.IngressNetworkConnectors...)
+				}
+				if pp.EgressNetworkConnectors != nil {
+					existing.EgressNetworkConnectors = append([]string(nil), pp.EgressNetworkConnectors...)
+				}
+				if pp.IdleMaxDurationSeconds > 0 {
+					existing.IdleMaxDurationSeconds = pp.IdleMaxDurationSeconds
+				}
+				if pp.SuspendedDurationSeconds > 0 {
+					existing.SuspendedDurationSeconds = pp.SuspendedDurationSeconds
+				}
+				if pp.AutoResume != nil {
+					existing.AutoResume = pp.AutoResume
+				}
+				if pp.MaximumDurationSeconds > 0 {
+					existing.MaximumDurationSeconds = pp.MaximumDurationSeconds
+				}
+				if pp.MicroVMBridgePort > 0 {
+					existing.MicroVMBridgePort = pp.MicroVMBridgePort
+				}
+				if pp.AuthTokenExpirationMinutes > 0 {
+					existing.AuthTokenExpirationMinutes = pp.AuthTokenExpirationMinutes
 				}
 			}
 			updatedCfg.Providers[name] = existing

--- a/pkg/hub/shortcut.go
+++ b/pkg/hub/shortcut.go
@@ -813,6 +813,8 @@ func (s *Server) createClawForShortcutStory(factory *types.FactoryConfig, action
 			provErr = s.provisionDaytona(context.Background(), clawID, req, provCfg, fileBytes, env)
 		case "exedev":
 			provErr = s.provisionExedev(context.Background(), clawID, req, provCfg, fileBytes, env)
+		case "lambda-microvms":
+			provErr = s.provisionLambdaMicroVMs(context.Background(), clawID, req, provCfg, fileBytes)
 		default:
 			provErr = fmt.Errorf("unsupported provider: %s", provider)
 		}

--- a/pkg/hub/workflow_creator.go
+++ b/pkg/hub/workflow_creator.go
@@ -316,6 +316,8 @@ func (s *Server) createClawFromWorkflowWithOptions(workspace *types.WorkspaceCon
 			provErr = s.provisionExedev(ctx, clawID, req, provCfg, fileBytes, env)
 		case "docker":
 			provErr = s.provisionDocker(ctx, clawID, req, provCfg, fileBytes)
+		case "lambda-microvms":
+			provErr = s.provisionLambdaMicroVMs(ctx, clawID, req, provCfg, fileBytes)
 		case "noop":
 			if os.Getenv("ELASTICCLAW_NOOP_PROVIDER") == "" {
 				provErr = fmt.Errorf("noop provider requires ELASTICCLAW_NOOP_PROVIDER=1 (test use only)")

--- a/pkg/provider/lambdamicrovms/lambdamicrovms.go
+++ b/pkg/provider/lambdamicrovms/lambdamicrovms.go
@@ -1,0 +1,392 @@
+package lambdamicrovms
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+const (
+	DefaultBridgePort             = 8080
+	DefaultTokenExpirationMinutes = 30
+	DefaultMaximumDurationSeconds = 28800
+)
+
+type Config struct {
+	Region                   string
+	Profile                  string
+	ImageIdentifier          string
+	ImageVersion             string
+	ExecutionRoleARN         string
+	IngressNetworkConnectors []string
+	EgressNetworkConnectors  []string
+	IdleMaxDurationSeconds   int
+	SuspendedDurationSeconds int
+	AutoResume               *bool
+	MaximumDurationSeconds   int
+	BridgePort               int
+	TokenExpirationMinutes   int
+}
+
+type Provider struct {
+	cfg  Config
+	http *http.Client
+}
+
+type runHookPayload struct {
+	Version       int               `json:"version"`
+	Name          string            `json:"name"`
+	Env           map[string]string `json:"env,omitempty"`
+	TemplateFiles map[string]string `json:"templateFiles,omitempty"`
+	StateMount    string            `json:"stateMount,omitempty"`
+}
+
+type runMicroVMResponse struct {
+	MicroVMID string `json:"microvmId"`
+	State     string `json:"state"`
+	Endpoint  string `json:"endpoint"`
+}
+
+type getMicroVMResponse struct {
+	MicroVMID string `json:"microvmId"`
+	State     string `json:"state"`
+	Endpoint  string `json:"endpoint"`
+}
+
+type authTokenResponse struct {
+	AuthToken map[string]string `json:"authToken"`
+}
+
+type execRequest struct {
+	Command []string `json:"command"`
+}
+
+type writeFileRequest struct {
+	Path    string `json:"path"`
+	Content string `json:"content"`
+}
+
+func New(cfg Config) (*Provider, error) {
+	cfg.ImageIdentifier = strings.TrimSpace(cfg.ImageIdentifier)
+	if cfg.ImageIdentifier == "" {
+		return nil, fmt.Errorf("lambda microvms provider requires image_identifier")
+	}
+	if cfg.BridgePort == 0 {
+		cfg.BridgePort = DefaultBridgePort
+	}
+	if cfg.TokenExpirationMinutes == 0 {
+		cfg.TokenExpirationMinutes = DefaultTokenExpirationMinutes
+	}
+	if cfg.MaximumDurationSeconds == 0 {
+		cfg.MaximumDurationSeconds = DefaultMaximumDurationSeconds
+	}
+	return &Provider{cfg: cfg, http: &http.Client{Timeout: 60 * time.Second}}, nil
+}
+
+func (p *Provider) Info() types.ProviderInfo {
+	return types.ProviderInfo{
+		Name:         "lambda-microvms",
+		Type:         types.ProviderTypeStateful,
+		Capabilities: []string{"alpha", "stateful", "https-bridge"},
+	}
+}
+
+func (p *Provider) Create(ctx context.Context, req types.CreateRequest) (*types.Instance, error) {
+	payload, err := buildRunHookPayload(req)
+	if err != nil {
+		return nil, err
+	}
+	args, err := p.runMicroVMArgs(payload)
+	if err != nil {
+		return nil, err
+	}
+	out, err := p.aws(ctx, args...)
+	if err != nil {
+		return nil, fmt.Errorf("run microvm: %w", err)
+	}
+	var resp runMicroVMResponse
+	if err := json.Unmarshal(out, &resp); err != nil {
+		return nil, fmt.Errorf("parse run microvm response: %w", err)
+	}
+	if resp.MicroVMID == "" {
+		return nil, fmt.Errorf("run microvm response missing microvmId")
+	}
+	return &types.Instance{
+		Name:      req.Name,
+		ID:        resp.MicroVMID,
+		Provider:  "lambda-microvms",
+		Status:    mapState(resp.State),
+		CreatedAt: time.Now().UTC(),
+		ProviderMeta: map[string]string{
+			"endpoint": resp.Endpoint,
+		},
+	}, nil
+}
+
+func (p *Provider) Status(ctx context.Context, instanceID string) (types.InstanceStatus, error) {
+	vm, err := p.get(ctx, instanceID)
+	if err != nil {
+		if strings.Contains(err.Error(), "ResourceNotFound") || strings.Contains(err.Error(), "NotFound") {
+			return types.StatusNotFound, nil
+		}
+		return types.StatusUnknown, err
+	}
+	return mapState(vm.State), nil
+}
+
+func (p *Provider) Exec(ctx context.Context, instanceID string, cmd []string) (*types.ExecResult, error) {
+	var result types.ExecResult
+	if err := p.bridgeJSON(ctx, instanceID, http.MethodPost, "/elasticclaw/v1/exec", execRequest{Command: cmd}, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func (p *Provider) WriteFile(ctx context.Context, instanceID string, path string, content []byte) error {
+	req := writeFileRequest{Path: path, Content: base64.StdEncoding.EncodeToString(content)}
+	return p.bridgeJSON(ctx, instanceID, http.MethodPost, "/elasticclaw/v1/write-file", req, nil)
+}
+
+func (p *Provider) Connect(ctx context.Context, instanceID string) (*types.ConnectInfo, error) {
+	vm, err := p.get(ctx, instanceID)
+	if err != nil {
+		return nil, err
+	}
+	return &types.ConnectInfo{
+		Web: "https://" + vm.Endpoint,
+		Shell: &types.ShellConnect{
+			Command: "aws",
+			Args:    append(p.awsBaseArgs(), "lambda-microvms", "create-microvm-auth-token", "--microvm-identifier", instanceID),
+		},
+	}, nil
+}
+
+func (p *Provider) Stop(ctx context.Context, instanceID string) error {
+	_, err := p.aws(ctx, "lambda-microvms", "suspend-microvm", "--microvm-identifier", instanceID)
+	return err
+}
+
+func (p *Provider) Start(ctx context.Context, instanceID string) error {
+	_, err := p.aws(ctx, "lambda-microvms", "resume-microvm", "--microvm-identifier", instanceID)
+	return err
+}
+
+func (p *Provider) Destroy(ctx context.Context, instanceID string, keepState bool) error {
+	if keepState {
+		return p.Stop(ctx, instanceID)
+	}
+	_, err := p.aws(ctx, "lambda-microvms", "terminate-microvm", "--microvm-identifier", instanceID)
+	return err
+}
+
+func (p *Provider) List(ctx context.Context) ([]*types.Instance, error) {
+	out, err := p.aws(ctx, "lambda-microvms", "list-microvms", "--output", "json")
+	if err != nil {
+		return nil, err
+	}
+	var resp struct {
+		MicroVMs []getMicroVMResponse `json:"microvms"`
+	}
+	if err := json.Unmarshal(out, &resp); err != nil {
+		return nil, fmt.Errorf("parse list microvms response: %w", err)
+	}
+	instances := make([]*types.Instance, 0, len(resp.MicroVMs))
+	for _, vm := range resp.MicroVMs {
+		instances = append(instances, &types.Instance{
+			ID:       vm.MicroVMID,
+			Name:     vm.MicroVMID,
+			Provider: "lambda-microvms",
+			Status:   mapState(vm.State),
+			ProviderMeta: map[string]string{
+				"endpoint": vm.Endpoint,
+			},
+		})
+	}
+	return instances, nil
+}
+
+func buildRunHookPayload(req types.CreateRequest) (string, error) {
+	files := make(map[string]string, len(req.TemplateFiles))
+	for path, content := range req.TemplateFiles {
+		files[path] = base64.StdEncoding.EncodeToString(content)
+	}
+	payload := runHookPayload{
+		Version:       1,
+		Name:          req.Name,
+		Env:           req.Env,
+		TemplateFiles: files,
+		StateMount:    req.StateMount,
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	if len(data) > 16*1024 {
+		return "", fmt.Errorf("lambda microvms run hook payload exceeds 16KiB")
+	}
+	return string(data), nil
+}
+
+func (p *Provider) runMicroVMArgs(runHookPayload string) ([]string, error) {
+	args := []string{"lambda-microvms", "run-microvm", "--image-identifier", p.cfg.ImageIdentifier}
+	if p.cfg.ImageVersion != "" {
+		args = append(args, "--image-version", p.cfg.ImageVersion)
+	}
+	if p.cfg.ExecutionRoleARN != "" {
+		args = append(args, "--execution-role-arn", p.cfg.ExecutionRoleARN)
+	}
+	if len(p.cfg.IngressNetworkConnectors) > 0 {
+		args = append(args, "--ingress-network-connectors")
+		args = append(args, p.cfg.IngressNetworkConnectors...)
+	}
+	if len(p.cfg.EgressNetworkConnectors) > 0 {
+		args = append(args, "--egress-network-connectors")
+		args = append(args, p.cfg.EgressNetworkConnectors...)
+	}
+	if p.cfg.IdleMaxDurationSeconds > 0 || p.cfg.SuspendedDurationSeconds > 0 || p.cfg.AutoResume != nil {
+		idle := map[string]interface{}{}
+		if p.cfg.IdleMaxDurationSeconds > 0 {
+			idle["maxIdleDurationSeconds"] = p.cfg.IdleMaxDurationSeconds
+		}
+		if p.cfg.SuspendedDurationSeconds > 0 {
+			idle["suspendedDurationSeconds"] = p.cfg.SuspendedDurationSeconds
+		}
+		if p.cfg.AutoResume != nil {
+			idle["autoResumeEnabled"] = *p.cfg.AutoResume
+		}
+		data, err := json.Marshal(idle)
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, "--idle-policy", string(data))
+	}
+	if p.cfg.MaximumDurationSeconds > 0 {
+		args = append(args, "--maximum-duration-in-seconds", strconv.Itoa(p.cfg.MaximumDurationSeconds))
+	}
+	if runHookPayload != "" {
+		args = append(args, "--run-hook-payload", runHookPayload)
+	}
+	args = append(args, "--output", "json")
+	return args, nil
+}
+
+func (p *Provider) get(ctx context.Context, instanceID string) (*getMicroVMResponse, error) {
+	out, err := p.aws(ctx, "lambda-microvms", "get-microvm", "--microvm-identifier", instanceID, "--output", "json")
+	if err != nil {
+		return nil, err
+	}
+	var resp getMicroVMResponse
+	if err := json.Unmarshal(out, &resp); err != nil {
+		return nil, fmt.Errorf("parse get microvm response: %w", err)
+	}
+	return &resp, nil
+}
+
+func (p *Provider) authToken(ctx context.Context, instanceID string) (string, error) {
+	allowedPorts := fmt.Sprintf(`[{"port":%d}]`, p.cfg.BridgePort)
+	out, err := p.aws(ctx,
+		"lambda-microvms", "create-microvm-auth-token",
+		"--microvm-identifier", instanceID,
+		"--expiration-in-minutes", strconv.Itoa(p.cfg.TokenExpirationMinutes),
+		"--allowed-ports", allowedPorts,
+		"--output", "json",
+	)
+	if err != nil {
+		return "", err
+	}
+	var resp authTokenResponse
+	if err := json.Unmarshal(out, &resp); err != nil {
+		return "", fmt.Errorf("parse microvm auth token response: %w", err)
+	}
+	if token := resp.AuthToken["X-aws-proxy-auth"]; token != "" {
+		return token, nil
+	}
+	return "", fmt.Errorf("microvm auth token response missing X-aws-proxy-auth")
+}
+
+func (p *Provider) bridgeJSON(ctx context.Context, instanceID, method, path string, body interface{}, out interface{}) error {
+	vm, err := p.get(ctx, instanceID)
+	if err != nil {
+		return err
+	}
+	token, err := p.authToken(ctx, instanceID)
+	if err != nil {
+		return err
+	}
+	var buf bytes.Buffer
+	if body != nil {
+		if err := json.NewEncoder(&buf).Encode(body); err != nil {
+			return err
+		}
+	}
+	req, err := http.NewRequestWithContext(ctx, method, "https://"+vm.Endpoint+path, &buf)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("X-aws-proxy-auth", token)
+	req.Header.Set("X-aws-proxy-port", strconv.Itoa(p.cfg.BridgePort))
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := p.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("microvm bridge %s %s returned HTTP %d", method, path, resp.StatusCode)
+	}
+	if out != nil {
+		if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *Provider) aws(ctx context.Context, args ...string) ([]byte, error) {
+	fullArgs := append(p.awsBaseArgs(), args...)
+	cmd := exec.CommandContext(ctx, "aws", fullArgs...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("aws %s: %w: %s", strings.Join(fullArgs, " "), err, strings.TrimSpace(string(out)))
+	}
+	return out, nil
+}
+
+func (p *Provider) awsBaseArgs() []string {
+	var args []string
+	if p.cfg.Region != "" {
+		args = append(args, "--region", p.cfg.Region)
+	}
+	if p.cfg.Profile != "" {
+		args = append(args, "--profile", p.cfg.Profile)
+	}
+	return args
+}
+
+func mapState(state string) types.InstanceStatus {
+	switch strings.ToUpper(strings.TrimSpace(state)) {
+	case "RUNNING", "ACTIVE":
+		return types.StatusRunning
+	case "PENDING", "CREATING", "STARTING":
+		return types.StatusStarting
+	case "SUSPENDED", "STOPPED":
+		return types.StatusStopped
+	case "TERMINATED", "DELETED":
+		return types.StatusNotFound
+	case "FAILED", "ERROR":
+		return types.StatusError
+	default:
+		return types.StatusUnknown
+	}
+}

--- a/pkg/provider/lambdamicrovms/lambdamicrovms.go
+++ b/pkg/provider/lambdamicrovms/lambdamicrovms.go
@@ -6,7 +6,9 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -105,7 +107,12 @@ func (p *Provider) Create(ctx context.Context, req types.CreateRequest) (*types.
 	if err != nil {
 		return nil, err
 	}
-	args, err := p.runMicroVMArgs(payload)
+	payloadArg, cleanup, err := writeRunHookPayloadFile(payload)
+	if err != nil {
+		return nil, err
+	}
+	defer cleanup()
+	args, err := p.runMicroVMArgs(payloadArg)
 	if err != nil {
 		return nil, err
 	}
@@ -236,7 +243,34 @@ func buildRunHookPayload(req types.CreateRequest) (string, error) {
 	return string(data), nil
 }
 
-func (p *Provider) runMicroVMArgs(runHookPayload string) ([]string, error) {
+func writeRunHookPayloadFile(payload string) (string, func(), error) {
+	if payload == "" {
+		return "", func() {}, nil
+	}
+	f, err := os.CreateTemp("", "elasticclaw-lambda-microvm-run-hook-*.json")
+	if err != nil {
+		return "", nil, fmt.Errorf("create run hook payload file: %w", err)
+	}
+	path := f.Name()
+	cleanup := func() { _ = os.Remove(path) }
+	if err := f.Chmod(0600); err != nil {
+		_ = f.Close()
+		cleanup()
+		return "", nil, fmt.Errorf("secure run hook payload file: %w", err)
+	}
+	if _, err := f.WriteString(payload); err != nil {
+		_ = f.Close()
+		cleanup()
+		return "", nil, fmt.Errorf("write run hook payload file: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("close run hook payload file: %w", err)
+	}
+	return "file://" + path, cleanup, nil
+}
+
+func (p *Provider) runMicroVMArgs(runHookPayloadArg string) ([]string, error) {
 	args := []string{"lambda-microvms", "run-microvm", "--image-identifier", p.cfg.ImageIdentifier}
 	if p.cfg.ImageVersion != "" {
 		args = append(args, "--image-version", p.cfg.ImageVersion)
@@ -272,8 +306,8 @@ func (p *Provider) runMicroVMArgs(runHookPayload string) ([]string, error) {
 	if p.cfg.MaximumDurationSeconds > 0 {
 		args = append(args, "--maximum-duration-in-seconds", strconv.Itoa(p.cfg.MaximumDurationSeconds))
 	}
-	if runHookPayload != "" {
-		args = append(args, "--run-hook-payload", runHookPayload)
+	if runHookPayloadArg != "" {
+		args = append(args, "--run-hook-payload", runHookPayloadArg)
 	}
 	args = append(args, "--output", "json")
 	return args, nil
@@ -343,7 +377,12 @@ func (p *Provider) bridgeJSON(ctx context.Context, instanceID, method, path stri
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("microvm bridge %s %s returned HTTP %d", method, path, resp.StatusCode)
+		bodySnippet, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		detail := strings.TrimSpace(string(bodySnippet))
+		if detail == "" {
+			return fmt.Errorf("microvm bridge %s %s returned HTTP %d", method, path, resp.StatusCode)
+		}
+		return fmt.Errorf("microvm bridge %s %s returned HTTP %d: %s", method, path, resp.StatusCode, detail)
 	}
 	if out != nil {
 		if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
@@ -356,9 +395,11 @@ func (p *Provider) bridgeJSON(ctx context.Context, instanceID, method, path stri
 func (p *Provider) aws(ctx context.Context, args ...string) ([]byte, error) {
 	fullArgs := append(p.awsBaseArgs(), args...)
 	cmd := exec.CommandContext(ctx, "aws", fullArgs...)
-	out, err := cmd.CombinedOutput()
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
 	if err != nil {
-		return nil, fmt.Errorf("aws %s: %w: %s", strings.Join(fullArgs, " "), err, strings.TrimSpace(string(out)))
+		return nil, fmt.Errorf("aws %s: %w: %s", strings.Join(fullArgs, " "), err, strings.TrimSpace(stderr.String()))
 	}
 	return out, nil
 }

--- a/pkg/provider/lambdamicrovms/lambdamicrovms_test.go
+++ b/pkg/provider/lambdamicrovms/lambdamicrovms_test.go
@@ -2,6 +2,7 @@ package lambdamicrovms
 
 import (
 	"encoding/json"
+	"os"
 	"strings"
 	"testing"
 
@@ -25,7 +26,7 @@ func TestRunMicroVMArgs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	args, err := p.runMicroVMArgs(`{"version":1}`)
+	args, err := p.runMicroVMArgs("file:///tmp/elasticclaw-run-hook.json")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -39,7 +40,7 @@ func TestRunMicroVMArgs(t *testing.T) {
 		"--ingress-network-connectors", "arn:aws:lambda:us-east-1:aws:network-connector:aws-network-connector:ALL_INGRESS",
 		"--egress-network-connectors", "arn:aws:lambda:us-east-1:aws:network-connector:aws-network-connector:INTERNET_EGRESS",
 		"--maximum-duration-in-seconds", "14400",
-		"--run-hook-payload", `{"version":1}`,
+		"--run-hook-payload", "file:///tmp/elasticclaw-run-hook.json",
 		"--output", "json",
 	} {
 		if !strings.Contains(joined, want) {
@@ -48,6 +49,38 @@ func TestRunMicroVMArgs(t *testing.T) {
 	}
 	if !strings.Contains(joined, `"autoResumeEnabled":true`) || !strings.Contains(joined, `"maxIdleDurationSeconds":900`) {
 		t.Fatalf("args %q missing idle policy JSON", args)
+	}
+}
+
+func TestWriteRunHookPayloadFileKeepsPayloadOutOfArgs(t *testing.T) {
+	payload := `{"env":{"ELASTICCLAW_CLAW_TOKEN":"secret-token"}}`
+
+	arg, cleanup, err := writeRunHookPayloadFile(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	if !strings.HasPrefix(arg, "file://") {
+		t.Fatalf("payload arg = %q, want file:// reference", arg)
+	}
+	if strings.Contains(arg, "secret-token") {
+		t.Fatalf("payload arg leaks secret: %q", arg)
+	}
+	path := strings.TrimPrefix(arg, "file://")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != payload {
+		t.Fatalf("payload file = %q, want original payload", string(data))
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0600 {
+		t.Fatalf("payload file permissions = %v, want 0600", got)
 	}
 }
 

--- a/pkg/provider/lambdamicrovms/lambdamicrovms_test.go
+++ b/pkg/provider/lambdamicrovms/lambdamicrovms_test.go
@@ -1,0 +1,84 @@
+package lambdamicrovms
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func TestRunMicroVMArgs(t *testing.T) {
+	autoResume := true
+	p, err := New(Config{
+		ImageIdentifier:          "arn:aws:lambda:us-east-1:123456789012:microvm-image:elasticclaw",
+		ImageVersion:             "1.0",
+		ExecutionRoleARN:         "arn:aws:iam::123456789012:role/MicroVMExecutionRole",
+		IngressNetworkConnectors: []string{"arn:aws:lambda:us-east-1:aws:network-connector:aws-network-connector:ALL_INGRESS"},
+		EgressNetworkConnectors:  []string{"arn:aws:lambda:us-east-1:aws:network-connector:aws-network-connector:INTERNET_EGRESS"},
+		IdleMaxDurationSeconds:   900,
+		SuspendedDurationSeconds: 300,
+		AutoResume:               &autoResume,
+		MaximumDurationSeconds:   14400,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	args, err := p.runMicroVMArgs(`{"version":1}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	joined := strings.Join(args, "\x00")
+
+	for _, want := range []string{
+		"lambda-microvms", "run-microvm",
+		"--image-identifier", "arn:aws:lambda:us-east-1:123456789012:microvm-image:elasticclaw",
+		"--image-version", "1.0",
+		"--execution-role-arn", "arn:aws:iam::123456789012:role/MicroVMExecutionRole",
+		"--ingress-network-connectors", "arn:aws:lambda:us-east-1:aws:network-connector:aws-network-connector:ALL_INGRESS",
+		"--egress-network-connectors", "arn:aws:lambda:us-east-1:aws:network-connector:aws-network-connector:INTERNET_EGRESS",
+		"--maximum-duration-in-seconds", "14400",
+		"--run-hook-payload", `{"version":1}`,
+		"--output", "json",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("args %q missing %q", args, want)
+		}
+	}
+	if !strings.Contains(joined, `"autoResumeEnabled":true`) || !strings.Contains(joined, `"maxIdleDurationSeconds":900`) {
+		t.Fatalf("args %q missing idle policy JSON", args)
+	}
+}
+
+func TestBuildRunHookPayloadEncodesTemplateFiles(t *testing.T) {
+	payload, err := buildRunHookPayload(types.CreateRequest{
+		Name: "ec-test",
+		Env:  map[string]string{"ELASTICCLAW_CLAW_ID": "claw-1"},
+		TemplateFiles: map[string][]byte{
+			"README.md": []byte("hello"),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded runHookPayload
+	if err := json.Unmarshal([]byte(payload), &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.TemplateFiles["README.md"] != "aGVsbG8=" {
+		t.Fatalf("encoded README = %q, want base64 content", decoded.TemplateFiles["README.md"])
+	}
+}
+
+func TestBuildRunHookPayloadRejectsOversizedPayload(t *testing.T) {
+	_, err := buildRunHookPayload(types.CreateRequest{
+		Name: "ec-test",
+		TemplateFiles: map[string][]byte{
+			"large.txt": []byte(strings.Repeat("x", 17*1024)),
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "exceeds 16KiB") {
+		t.Fatalf("err = %v, want payload size error", err)
+	}
+}

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -749,6 +749,21 @@ type ProviderConfig struct {
 	// Network is the Docker network to attach agent containers to so they can
 	// reach the hub by service name (e.g. "elasticclaw-dev").
 	Network string `yaml:"network,omitempty"`
+
+	// AWS Lambda MicroVMs (alpha)
+	AWSRegion                  string   `yaml:"aws_region,omitempty"`
+	AWSProfile                 string   `yaml:"aws_profile,omitempty"`
+	ImageIdentifier            string   `yaml:"image_identifier,omitempty"`
+	ImageVersion               string   `yaml:"image_version,omitempty"`
+	ExecutionRoleARN           string   `yaml:"execution_role_arn,omitempty"`
+	IngressNetworkConnectors   []string `yaml:"ingress_network_connectors,omitempty"`
+	EgressNetworkConnectors    []string `yaml:"egress_network_connectors,omitempty"`
+	IdleMaxDurationSeconds     int      `yaml:"idle_max_duration_seconds,omitempty"`
+	SuspendedDurationSeconds   int      `yaml:"suspended_duration_seconds,omitempty"`
+	AutoResume                 *bool    `yaml:"auto_resume,omitempty"`
+	MaximumDurationSeconds     int      `yaml:"maximum_duration_seconds,omitempty"`
+	MicroVMBridgePort          int      `yaml:"bridge_port,omitempty"`
+	AuthTokenExpirationMinutes int      `yaml:"auth_token_expiration_minutes,omitempty"`
 }
 
 // MCPConfig is the resolved MCP server configuration passed to a claw at creation time.

--- a/pkg/types/validation.go
+++ b/pkg/types/validation.go
@@ -37,8 +37,10 @@ func buildWorkflowIntegrations() map[string]bool {
 
 // Valid provider types
 var validProviders = map[string]bool{
-	"replicated": true, "daytona": true, "exedev": true, "docker": true,
+	"replicated": true, "daytona": true, "exedev": true, "docker": true, "lambda-microvms": true,
 }
+
+const validProviderList = "replicated, daytona, exedev, docker, lambda-microvms"
 
 // Valid MCP sources
 var validMCPSources = map[string]bool{
@@ -132,7 +134,7 @@ func (f *FactoryConfig) Validate() error {
 
 	// Validate provider if provided
 	if f.Provider != "" && !validProviders[f.Provider] {
-		return fmt.Errorf("factory %q: invalid provider %q (must be one of: replicated, daytona, exedev)", f.Name, f.Provider)
+		return fmt.Errorf("factory %q: invalid provider %q (must be one of: %s)", f.Name, f.Provider, validProviderList)
 	}
 
 	// Validate inputs
@@ -217,7 +219,7 @@ func (w *WorkflowConfig) Validate() error {
 		return fmt.Errorf("workflow %q: invalid name_pattern %q (must contain only alphanumeric, hyphens, underscores, and {placeholders})", w.Name, w.NamePattern)
 	}
 	if w.Provider != "" && !validProviders[w.Provider] {
-		return fmt.Errorf("workflow %q: invalid provider %q (must be one of: replicated, daytona, exedev)", w.Name, w.Provider)
+		return fmt.Errorf("workflow %q: invalid provider %q (must be one of: %s)", w.Name, w.Provider, validProviderList)
 	}
 	if w.Trigger != nil {
 		if err := validateWorkflowTrigger(w.Name, w.Trigger); err != nil {
@@ -594,7 +596,7 @@ func (t *TemplateConfig) Validate() error {
 		return fmt.Errorf("template provider is required")
 	}
 	if !validProviders[t.Provider] {
-		return fmt.Errorf("invalid provider %q (must be one of: replicated, daytona, exedev)", t.Provider)
+		return fmt.Errorf("invalid provider %q (must be one of: %s)", t.Provider, validProviderList)
 	}
 
 	// Validate color if provided
@@ -701,7 +703,7 @@ func ValidateProviderConfig(name string, cfg *ProviderConfig) error {
 	}
 
 	if !validProviders[providerType] {
-		return fmt.Errorf("invalid provider type %q (must be one of: replicated, daytona, exedev)", providerType)
+		return fmt.Errorf("invalid provider type %q (must be one of: %s)", providerType, validProviderList)
 	}
 
 	return nil

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -106,6 +106,19 @@ interface SettingsData {
     defaultDisk?: string
     sshKeySet?: boolean
     sshPublicKey?: string
+    awsRegion?: string
+    awsProfile?: string
+    imageIdentifier?: string
+    imageVersion?: string
+    executionRoleArn?: string
+    ingressNetworkConnectors?: string[]
+    egressNetworkConnectors?: string[]
+    idleMaxDurationSeconds?: number
+    suspendedDurationSeconds?: number
+    autoResume?: boolean
+    maximumDurationSeconds?: number
+    bridgePort?: number
+    authTokenExpirationMinutes?: number
   }>
   github: GitHubAppView[]
   sshPublicKeys: string[]
@@ -493,6 +506,7 @@ const SANDBOX_PROVIDER_OPTIONS = [
   { value: "replicated", label: "Replicated CMX", description: "Kubernetes-based VM provider" },
   { value: "daytona", label: "Daytona", description: "Development environment provider" },
   { value: "exedev", label: "exe.dev", description: "Persistent VM provider with SSH access" },
+  { value: "lambda-microvms", label: "AWS Lambda MicroVMs", description: "Serverless Firecracker MicroVM provider", alpha: true },
 ]
 
 interface SandboxProviderView {
@@ -500,6 +514,7 @@ interface SandboxProviderView {
   type: string
   label: string
   description: string
+  alpha?: boolean
   configured: boolean
   apiUrl?: string
   apiKeySet?: boolean
@@ -507,6 +522,7 @@ interface SandboxProviderView {
   tokenSet?: boolean
   defaultTtl?: string
   defaultInstanceType?: string
+  imageIdentifier?: string
 }
 
 function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData; onSave: (p: object) => void; saving: boolean }) {
@@ -522,13 +538,15 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
         type: p.type || name,
         label: opt?.label || name,
         description: opt?.description || "",
-        configured: !!(p.tokenSet || p.apiKeySet),
+        alpha: opt?.alpha,
+        configured: !!(p.tokenSet || p.apiKeySet || p.imageIdentifier || name === "exedev"),
         apiUrl: p.apiUrl,
         apiKeySet: p.apiKeySet,
         defaultSnapshot: p.defaultSnapshot,
         tokenSet: p.tokenSet,
         defaultTtl: p.defaultTtl,
         defaultInstanceType: p.defaultInstanceType,
+        imageIdentifier: p.imageIdentifier,
         defaultCpu: p.defaultCpu,
         defaultMemory: p.defaultMemory,
         defaultDisk: p.defaultDisk,
@@ -552,6 +570,19 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
   const [formDefaultCpu, setFormDefaultCpu] = useState("")
   const [formDefaultMemory, setFormDefaultMemory] = useState("")
   const [formDefaultDisk, setFormDefaultDisk] = useState("")
+  const [formAwsRegion, setFormAwsRegion] = useState("")
+  const [formAwsProfile, setFormAwsProfile] = useState("")
+  const [formImageIdentifier, setFormImageIdentifier] = useState("")
+  const [formImageVersion, setFormImageVersion] = useState("")
+  const [formExecutionRoleArn, setFormExecutionRoleArn] = useState("")
+  const [formIngressConnectors, setFormIngressConnectors] = useState("")
+  const [formEgressConnectors, setFormEgressConnectors] = useState("")
+  const [formIdleMaxDuration, setFormIdleMaxDuration] = useState("")
+  const [formSuspendedDuration, setFormSuspendedDuration] = useState("")
+  const [formAutoResume, setFormAutoResume] = useState(true)
+  const [formMaximumDuration, setFormMaximumDuration] = useState("")
+  const [formBridgePort, setFormBridgePort] = useState("")
+  const [formAuthTokenExpiration, setFormAuthTokenExpiration] = useState("")
 
   const resetForm = () => {
     setFormProvider("replicated")
@@ -564,6 +595,19 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
     setFormDefaultCpu("")
     setFormDefaultMemory("")
     setFormDefaultDisk("")
+    setFormAwsRegion("")
+    setFormAwsProfile("")
+    setFormImageIdentifier("")
+    setFormImageVersion("")
+    setFormExecutionRoleArn("")
+    setFormIngressConnectors("")
+    setFormEgressConnectors("")
+    setFormIdleMaxDuration("900")
+    setFormSuspendedDuration("300")
+    setFormAutoResume(true)
+    setFormMaximumDuration("28800")
+    setFormBridgePort("8080")
+    setFormAuthTokenExpiration("30")
     setEditName(null)
   }
 
@@ -594,12 +638,37 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
     setFormDefaultCpu(p?.defaultCpu?.toString() || "")
     setFormDefaultMemory(p?.defaultMemory ? p.defaultMemory.replace(/GB$/, "") : "")
     setFormDefaultDisk(p?.defaultDisk ? p.defaultDisk.replace(/GB$/, "") : "")
+    setFormAwsRegion(p?.awsRegion || "")
+    setFormAwsProfile(p?.awsProfile || "")
+    setFormImageIdentifier(p?.imageIdentifier || "")
+    setFormImageVersion(p?.imageVersion || "")
+    setFormExecutionRoleArn(p?.executionRoleArn || "")
+    setFormIngressConnectors((p?.ingressNetworkConnectors || []).join("\n"))
+    setFormEgressConnectors((p?.egressNetworkConnectors || []).join("\n"))
+    setFormIdleMaxDuration(p?.idleMaxDurationSeconds?.toString() || "900")
+    setFormSuspendedDuration(p?.suspendedDurationSeconds?.toString() || "300")
+    setFormAutoResume(p?.autoResume ?? true)
+    setFormMaximumDuration(p?.maximumDurationSeconds?.toString() || "28800")
+    setFormBridgePort(p?.bridgePort?.toString() || "8080")
+    setFormAuthTokenExpiration(p?.authTokenExpirationMinutes?.toString() || "30")
     setEditName(name)
     setModalMode("edit")
     setShowModal(true)
   }
 
   const availableProviders = SANDBOX_PROVIDER_OPTIONS.filter(o => !providers[o.value])
+
+  function splitConnectorList(value: string) {
+    return value
+      .split(/[\n,]/)
+      .map(v => v.trim())
+      .filter(Boolean)
+  }
+
+  function setPositiveInt(patch: Record<string, unknown>, key: string, value: string) {
+    const parsed = parseInt(value, 10)
+    if (value && !isNaN(parsed) && parsed > 0) patch[key] = parsed
+  }
 
   function doSave() {
     const patch: Record<string, unknown> = {}
@@ -618,6 +687,21 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
       if (formDefaultCpu && !isNaN(parsedCpu)) patch.defaultCpu = parsedCpu
       if (formDefaultMemory) patch.defaultMemory = formDefaultMemory + "GB"
       if (formDefaultDisk) patch.defaultDisk = formDefaultDisk + "GB"
+    } else if (formProvider === "lambda-microvms") {
+      patch.enabled = true
+      if (formAwsRegion) patch.awsRegion = formAwsRegion.trim()
+      if (formAwsProfile) patch.awsProfile = formAwsProfile.trim()
+      if (formImageIdentifier) patch.imageIdentifier = formImageIdentifier.trim()
+      if (formImageVersion) patch.imageVersion = formImageVersion.trim()
+      if (formExecutionRoleArn) patch.executionRoleArn = formExecutionRoleArn.trim()
+      patch.ingressNetworkConnectors = splitConnectorList(formIngressConnectors)
+      patch.egressNetworkConnectors = splitConnectorList(formEgressConnectors)
+      setPositiveInt(patch, "idleMaxDurationSeconds", formIdleMaxDuration)
+      setPositiveInt(patch, "suspendedDurationSeconds", formSuspendedDuration)
+      patch.autoResume = formAutoResume
+      setPositiveInt(patch, "maximumDurationSeconds", formMaximumDuration)
+      setPositiveInt(patch, "bridgePort", formBridgePort)
+      setPositiveInt(patch, "authTokenExpirationMinutes", formAuthTokenExpiration)
     }
     onSave({ providers: { [formProvider]: patch } })
     setShowModal(false)
@@ -663,6 +747,11 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
                 <div>
                   <div className="flex items-center gap-2">
                     <span className="text-sm font-medium">{p.label}</span>
+                    {p.alpha && (
+                      <span className="text-xs bg-amber-500/20 text-amber-300 px-1.5 py-0.5 rounded">
+                        Alpha
+                      </span>
+                    )}
                     {p.configured && (
                       <span className="text-xs bg-green-500/20 text-green-400 px-1.5 py-0.5 rounded flex items-center gap-1">
                         <CheckCircle2 className="size-3" /> Configured
@@ -744,7 +833,7 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
                   onChange={e => setFormProvider(e.target.value)}
                   className="w-full h-8 rounded-md border border-border bg-background px-2 text-sm"
                 >
-                  {availableProviders.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+                  {availableProviders.map(o => <option key={o.value} value={o.value}>{o.label}{o.alpha ? " (alpha)" : ""}</option>)}
                 </select>
               </div>
             )}
@@ -868,6 +957,103 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
                 </div>
               </>
             )}
+
+            {formProvider === "lambda-microvms" && (
+              <>
+                <div className="bg-amber-500/10 border border-amber-500/20 rounded-lg p-3">
+                  <div className="flex items-center gap-2 mb-1">
+                    <span className="text-xs bg-amber-500/20 text-amber-300 px-1.5 py-0.5 rounded">Alpha</span>
+                    <p className="text-xs font-medium">AWS Lambda MicroVMs</p>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    Requires an image that starts the Elastic Claw bridge from the MicroVM run hook payload.
+                  </p>
+                </div>
+                <div>
+                  <label className="text-xs text-muted-foreground mb-1 block">Image identifier</label>
+                  <Input
+                    value={formImageIdentifier}
+                    onChange={e => setFormImageIdentifier(e.target.value)}
+                    className="h-8 text-sm font-mono"
+                    placeholder="arn:aws:lambda:us-east-1:123456789012:microvm-image/elasticclaw"
+                  />
+                </div>
+                <div className="grid grid-cols-2 gap-3">
+                  <div>
+                    <label className="text-xs text-muted-foreground mb-1 block">AWS Region</label>
+                    <Input value={formAwsRegion} onChange={e => setFormAwsRegion(e.target.value)} className="h-8 text-sm" placeholder="us-east-1" />
+                  </div>
+                  <div>
+                    <label className="text-xs text-muted-foreground mb-1 block">AWS Profile</label>
+                    <Input value={formAwsProfile} onChange={e => setFormAwsProfile(e.target.value)} className="h-8 text-sm" placeholder="default" />
+                  </div>
+                </div>
+                <div>
+                  <label className="text-xs text-muted-foreground mb-1 block">Image version</label>
+                  <Input value={formImageVersion} onChange={e => setFormImageVersion(e.target.value)} className="h-8 text-sm" placeholder="latest" />
+                </div>
+                <div>
+                  <label className="text-xs text-muted-foreground mb-1 block">Execution role ARN</label>
+                  <Input
+                    value={formExecutionRoleArn}
+                    onChange={e => setFormExecutionRoleArn(e.target.value)}
+                    className="h-8 text-sm font-mono"
+                    placeholder="arn:aws:iam::123456789012:role/elasticclaw-microvm"
+                  />
+                </div>
+                <div>
+                  <label className="text-xs text-muted-foreground mb-1 block">Ingress network connectors</label>
+                  <textarea
+                    value={formIngressConnectors}
+                    onChange={e => setFormIngressConnectors(e.target.value)}
+                    className="min-h-16 w-full rounded-md border border-border bg-background px-2 py-1.5 text-sm font-mono"
+                    placeholder="One ARN per line"
+                  />
+                </div>
+                <div>
+                  <label className="text-xs text-muted-foreground mb-1 block">Egress network connectors</label>
+                  <textarea
+                    value={formEgressConnectors}
+                    onChange={e => setFormEgressConnectors(e.target.value)}
+                    className="min-h-16 w-full rounded-md border border-border bg-background px-2 py-1.5 text-sm font-mono"
+                    placeholder="One ARN per line"
+                  />
+                </div>
+                <div className="grid grid-cols-2 gap-3">
+                  <div>
+                    <label className="text-xs text-muted-foreground mb-1 block">Idle max seconds</label>
+                    <Input type="number" min={1} value={formIdleMaxDuration} onChange={e => setFormIdleMaxDuration(e.target.value)} className="h-8 text-sm" placeholder="900" />
+                  </div>
+                  <div>
+                    <label className="text-xs text-muted-foreground mb-1 block">Suspended seconds</label>
+                    <Input type="number" min={1} value={formSuspendedDuration} onChange={e => setFormSuspendedDuration(e.target.value)} className="h-8 text-sm" placeholder="300" />
+                  </div>
+                </div>
+                <div className="grid grid-cols-3 gap-3">
+                  <div>
+                    <label className="text-xs text-muted-foreground mb-1 block">Max seconds</label>
+                    <Input type="number" min={1} value={formMaximumDuration} onChange={e => setFormMaximumDuration(e.target.value)} className="h-8 text-sm" placeholder="28800" />
+                  </div>
+                  <div>
+                    <label className="text-xs text-muted-foreground mb-1 block">Bridge port</label>
+                    <Input type="number" min={1} value={formBridgePort} onChange={e => setFormBridgePort(e.target.value)} className="h-8 text-sm" placeholder="8080" />
+                  </div>
+                  <div>
+                    <label className="text-xs text-muted-foreground mb-1 block">Token minutes</label>
+                    <Input type="number" min={1} value={formAuthTokenExpiration} onChange={e => setFormAuthTokenExpiration(e.target.value)} className="h-8 text-sm" placeholder="30" />
+                  </div>
+                </div>
+                <label className="flex items-center gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    checked={formAutoResume}
+                    onChange={e => setFormAutoResume(e.target.checked)}
+                    className="size-4 rounded border-border"
+                  />
+                  Auto resume suspended MicroVMs
+                </label>
+              </>
+            )}
           </div>
 
           <div className="flex items-center justify-between px-5 py-4 border-t border-border">
@@ -880,7 +1066,7 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
               <Button size="sm" variant="outline" onClick={() => { setShowModal(false); resetForm() }}>Cancel</Button>
               <Button
                 size="sm"
-                disabled={saving || (modalMode === "add" && formProvider === "replicated" && !formToken) || (modalMode === "add" && formProvider === "daytona" && !formApiKey) || (modalMode === "add" && formProvider === "exedev" && (!formDefaultCpu || !formDefaultMemory || !formDefaultDisk))}
+                disabled={saving || (modalMode === "add" && formProvider === "replicated" && !formToken) || (modalMode === "add" && formProvider === "daytona" && !formApiKey) || (modalMode === "add" && formProvider === "exedev" && (!formDefaultCpu || !formDefaultMemory || !formDefaultDisk)) || (formProvider === "lambda-microvms" && !formImageIdentifier.trim())}
                 onClick={doSave}
               >
                 {modalMode === "add" ? "Add Provider" : "Save changes"}


### PR DESCRIPTION
## Summary
- add an alpha AWS Lambda MicroVMs sandbox provider backed by the AWS CLI lambda-microvms APIs
- wire the provider into manual, workflow, factory, issue tracker, webhook, checkpoint, cleanup, and pipeline-run paths
- expose Lambda MicroVMs runtime settings in the admin UI with an Alpha label
- validate lambda-microvms in template/factory/workflow config and doctor checks

## Alpha contract
This provider expects the configured MicroVM image to start the Elastic Claw bridge from the run hook payload. The hub sends environment and template files through runHookPayload, which is limited to 16KiB by AWS.

## Validation
- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./pkg/provider/lambdamicrovms ./pkg/hub ./pkg/types ./cmd
- npm run build