### PR TITLE
Install pinned CLIs for Codex and Grok model auth

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -153,6 +153,7 @@ func runInstall(cmd *cobra.Command, args []string) error {
 		script string
 	}{
 		{"Installing hub binary", installBinaryScript},
+		{"Installing Node.js/npm", install.ScriptInstallNodeNPM(useSudo)},
 		{"Writing hub config", install.ScriptWriteConfig(params, useSudo)},
 		{"Installing systemd service", install.ScriptInstallSystemd(useSudo)},
 	}

--- a/pkg/hub/model_auth.go
+++ b/pkg/hub/model_auth.go
@@ -12,8 +12,10 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
+	"github.com/elasticclaw/elasticclaw/pkg/cliversion"
 	"github.com/elasticclaw/elasticclaw/pkg/config"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 	"github.com/google/uuid"
@@ -43,7 +45,22 @@ var (
 	modelAuthCodeRE        = regexp.MustCompile(`(?i:\b(?:device code|user code|verification code|code)\b)[^A-Za-z0-9]*([A-Za-z0-9][A-Za-z0-9-]{3,})\b`)
 	modelAuthOneTimeCodeRE = regexp.MustCompile(`(?is)\bone-time code\b.*?\n\s*([A-Z0-9]{4,5}-[A-Z0-9]{4,5})\b`)
 	modelAuth9DigitCodeRE  = regexp.MustCompile(`\b\d(?:[ -]?\d){8}\b`)
+	modelAuthCLIInstallMu  sync.Mutex
 )
+
+const (
+	defaultCodexCLIVersion = "0.141.0"
+	defaultGrokCLIVersion  = "0.1.0"
+)
+
+type modelAuthCLISpec struct {
+	Provider      string
+	PackageName   string
+	Version       string
+	BinaryName    string
+	LoginArgs     []string
+	VersionEnvVar string
+}
 
 func (s *Server) handleModelAuthLogin(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -132,19 +149,14 @@ func (s *Server) runModelAuthLoginJob(job *modelAuthLoginJob) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
-	var args []string
-	switch job.Provider {
-	case "codex":
-		args = []string{"codex", "login", "--device-auth"}
-	case "grok":
-		args = []string{"grok", "login", "--device-auth"}
-	default:
-		s.finishModelAuthJob(job, "error", "", fmt.Errorf("unsupported provider %q", job.Provider))
+	cli, binDir, err := ensureModelAuthCLI(ctx, job.Provider)
+	if err != nil {
+		s.finishModelAuthJob(job, "error", "", err)
 		return
 	}
 
-	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
-	cmd.Env = append(os.Environ(), "HOME="+authDir)
+	cmd := exec.CommandContext(ctx, cli.BinaryName, cli.LoginArgs...)
+	cmd.Env = append(os.Environ(), "HOME="+authDir, "PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		s.finishModelAuthJob(job, "error", "", err)
@@ -180,6 +192,80 @@ func (s *Server) runModelAuthLoginJob(job *modelAuthLoginJob) {
 		return
 	}
 	s.finishModelAuthJob(job, "complete", bundle, nil)
+}
+
+func modelAuthCLI(provider string) (modelAuthCLISpec, error) {
+	switch provider {
+	case "codex":
+		return modelAuthCLISpec{
+			Provider:      "codex",
+			PackageName:   "@openai/codex",
+			Version:       cliversion.FromEnv("ELASTICCLAW_CODEX_CLI_VERSION", defaultCodexCLIVersion),
+			BinaryName:    "codex",
+			LoginArgs:     []string{"login", "--device-auth"},
+			VersionEnvVar: "ELASTICCLAW_CODEX_CLI_VERSION",
+		}, nil
+	case "grok":
+		return modelAuthCLISpec{
+			Provider:      "grok",
+			PackageName:   "@xai-official/grok",
+			Version:       cliversion.FromEnv("ELASTICCLAW_GROK_CLI_VERSION", defaultGrokCLIVersion),
+			BinaryName:    "grok",
+			LoginArgs:     []string{"login", "--device-auth"},
+			VersionEnvVar: "ELASTICCLAW_GROK_CLI_VERSION",
+		}, nil
+	default:
+		return modelAuthCLISpec{}, fmt.Errorf("unsupported provider %q", provider)
+	}
+}
+
+func ensureModelAuthCLI(ctx context.Context, provider string) (modelAuthCLISpec, string, error) {
+	cli, err := modelAuthCLI(provider)
+	if err != nil {
+		return modelAuthCLISpec{}, "", err
+	}
+	if strings.TrimSpace(cli.Version) == "" {
+		return modelAuthCLISpec{}, "", fmt.Errorf("empty %s for %s CLI", cli.VersionEnvVar, cli.Provider)
+	}
+	installDir := filepath.Join(modelAuthCLIRoot(), cli.Provider, cli.Version)
+	binDir := filepath.Join(installDir, "node_modules", ".bin")
+	binaryPath := filepath.Join(binDir, cli.BinaryName)
+	if _, err := os.Stat(binaryPath); err == nil {
+		cli.BinaryName = binaryPath
+		return cli, binDir, nil
+	}
+
+	modelAuthCLIInstallMu.Lock()
+	defer modelAuthCLIInstallMu.Unlock()
+	if _, err := os.Stat(binaryPath); err == nil {
+		cli.BinaryName = binaryPath
+		return cli, binDir, nil
+	}
+	if err := os.MkdirAll(installDir, 0750); err != nil {
+		return modelAuthCLISpec{}, "", fmt.Errorf("create model CLI install dir: %w", err)
+	}
+	npm, err := exec.LookPath("npm")
+	if err != nil {
+		return modelAuthCLISpec{}, "", fmt.Errorf("npm is required to install %s@%s for model login: %w", cli.PackageName, cli.Version, err)
+	}
+	spec := cli.PackageName + "@" + cli.Version
+	cmd := exec.CommandContext(ctx, npm, "install", "--prefix", installDir, "--ignore-scripts", spec)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return modelAuthCLISpec{}, "", fmt.Errorf("install %s: %w: %s", spec, err, strings.TrimSpace(string(out)))
+	}
+	if _, err := os.Stat(binaryPath); err != nil {
+		return modelAuthCLISpec{}, "", fmt.Errorf("installed %s but binary %s was not found: %w", spec, binaryPath, err)
+	}
+	cli.BinaryName = binaryPath
+	return cli, binDir, nil
+}
+
+func modelAuthCLIRoot() string {
+	if dir := strings.TrimSpace(os.Getenv("ELASTICCLAW_MODEL_CLI_DIR")); dir != "" {
+		return dir
+	}
+	return filepath.Join(hubDataDir(), "model-clis")
 }
 
 func (s *Server) captureModelAuthOutput(job *modelAuthLoginJob, r io.Reader, done chan<- struct{}) {

--- a/pkg/hub/model_auth.go
+++ b/pkg/hub/model_auth.go
@@ -39,13 +39,14 @@ type cliAuthBundle struct {
 }
 
 var (
-	modelAuthANSIRE        = regexp.MustCompile(`\x1b\[[0-?]*[ -/]*[@-~]`)
-	modelAuthOSC8RE        = regexp.MustCompile(`\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)`)
-	modelAuthURLRE         = regexp.MustCompile(`https?://[^\s"'\x00-\x1f\x7f]+`)
-	modelAuthCodeRE        = regexp.MustCompile(`(?i:\b(?:device code|user code|verification code|code)\b)[^A-Za-z0-9]*([A-Za-z0-9][A-Za-z0-9-]{3,})\b`)
-	modelAuthOneTimeCodeRE = regexp.MustCompile(`(?is)\bone-time code\b.*?\n\s*([A-Z0-9]{4,5}-[A-Z0-9]{4,5})\b`)
-	modelAuth9DigitCodeRE  = regexp.MustCompile(`\b\d(?:[ -]?\d){8}\b`)
-	modelAuthCLIInstallMu  sync.Mutex
+	modelAuthANSIRE          = regexp.MustCompile(`\x1b\[[0-?]*[ -/]*[@-~]`)
+	modelAuthOSC8RE          = regexp.MustCompile(`\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)`)
+	modelAuthURLRE           = regexp.MustCompile(`https?://[^\s"'\x00-\x1f\x7f]+`)
+	modelAuthCodeRE          = regexp.MustCompile(`(?i:\b(?:device code|user code|verification code|code)\b)[^A-Za-z0-9]*([A-Za-z0-9][A-Za-z0-9-]{3,})\b`)
+	modelAuthOneTimeCodeRE   = regexp.MustCompile(`(?is)\bone-time code\b.*?\n\s*([A-Z0-9]{4,5}-[A-Z0-9]{4,5})\b`)
+	modelAuth9DigitCodeRE    = regexp.MustCompile(`\b\d(?:[ -]?\d){8}\b`)
+	modelAuthCLIInstallMu    sync.Mutex
+	modelAuthCLIInstallLocks = map[string]*sync.Mutex{}
 )
 
 const (
@@ -235,8 +236,9 @@ func ensureModelAuthCLI(ctx context.Context, provider string) (modelAuthCLISpec,
 		return cli, binDir, nil
 	}
 
-	modelAuthCLIInstallMu.Lock()
-	defer modelAuthCLIInstallMu.Unlock()
+	installLock := modelAuthCLIInstallLock(installDir)
+	installLock.Lock()
+	defer installLock.Unlock()
 	if _, err := os.Stat(binaryPath); err == nil {
 		cli.BinaryName = binaryPath
 		return cli, binDir, nil
@@ -259,6 +261,17 @@ func ensureModelAuthCLI(ctx context.Context, provider string) (modelAuthCLISpec,
 	}
 	cli.BinaryName = binaryPath
 	return cli, binDir, nil
+}
+
+func modelAuthCLIInstallLock(installDir string) *sync.Mutex {
+	modelAuthCLIInstallMu.Lock()
+	defer modelAuthCLIInstallMu.Unlock()
+	if lock := modelAuthCLIInstallLocks[installDir]; lock != nil {
+		return lock
+	}
+	lock := &sync.Mutex{}
+	modelAuthCLIInstallLocks[installDir] = lock
+	return lock
 }
 
 func modelAuthCLIRoot() string {

--- a/pkg/hub/model_auth_test.go
+++ b/pkg/hub/model_auth_test.go
@@ -58,6 +58,19 @@ func TestEnsureModelAuthCLIUsesManagedBinary(t *testing.T) {
 	}
 }
 
+func TestModelAuthCLIInstallLockIsScopedByInstallDir(t *testing.T) {
+	first := modelAuthCLIInstallLock("/tmp/elasticclaw/model-clis/codex/1")
+	again := modelAuthCLIInstallLock("/tmp/elasticclaw/model-clis/codex/1")
+	other := modelAuthCLIInstallLock("/tmp/elasticclaw/model-clis/grok/1")
+
+	if first != again {
+		t.Fatal("same install dir returned different locks")
+	}
+	if first == other {
+		t.Fatal("different install dirs shared the same lock")
+	}
+}
+
 func TestCaptureModelAuthOutputStripsANSIFromURL(t *testing.T) {
 	s := &Server{}
 	job := &modelAuthLoginJob{}

--- a/pkg/hub/model_auth_test.go
+++ b/pkg/hub/model_auth_test.go
@@ -1,9 +1,62 @@
 package hub
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func TestModelAuthCLIUsesPinnedVersions(t *testing.T) {
+	t.Setenv("ELASTICCLAW_CODEX_CLI_VERSION", "1.2.3")
+	t.Setenv("ELASTICCLAW_GROK_CLI_VERSION", "4.5.6")
+
+	codex, err := modelAuthCLI("codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if codex.PackageName != "@openai/codex" || codex.Version != "1.2.3" || codex.BinaryName != "codex" {
+		t.Fatalf("codex CLI = %#v", codex)
+	}
+	if got := strings.Join(codex.LoginArgs, " "); got != "login --device-auth" {
+		t.Fatalf("codex login args = %q", got)
+	}
+
+	grok, err := modelAuthCLI("grok")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if grok.PackageName != "@xai-official/grok" || grok.Version != "4.5.6" || grok.BinaryName != "grok" {
+		t.Fatalf("grok CLI = %#v", grok)
+	}
+}
+
+func TestEnsureModelAuthCLIUsesManagedBinary(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("ELASTICCLAW_MODEL_CLI_DIR", filepath.Join(root, "model-clis"))
+	t.Setenv("ELASTICCLAW_GROK_CLI_VERSION", "9.9.9")
+
+	binDir := filepath.Join(root, "model-clis", "grok", "9.9.9", "node_modules", ".bin")
+	if err := os.MkdirAll(binDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	binaryPath := filepath.Join(binDir, "grok")
+	if err := os.WriteFile(binaryPath, []byte("#!/bin/sh\nexit 0\n"), 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	cli, gotBinDir, err := ensureModelAuthCLI(context.Background(), "grok")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cli.BinaryName != binaryPath {
+		t.Fatalf("BinaryName = %q, want managed binary %q", cli.BinaryName, binaryPath)
+	}
+	if gotBinDir != binDir {
+		t.Fatalf("binDir = %q, want %q", gotBinDir, binDir)
+	}
+}
 
 func TestCaptureModelAuthOutputStripsANSIFromURL(t *testing.T) {
 	s := &Server{}

--- a/pkg/install/scripts.go
+++ b/pkg/install/scripts.go
@@ -83,6 +83,43 @@ chmod +x /tmp/elasticclaw-bin
 %s mv /tmp/elasticclaw-bin /usr/local/bin/elasticclaw`, url, sudo)
 }
 
+// ScriptInstallNodeNPM installs Node.js/npm when they are not already present.
+func ScriptInstallNodeNPM(useSudo bool) string {
+	sudo := sudoPrefix(useSudo)
+	return fmt.Sprintf(`if ! command -v npm >/dev/null 2>&1; then
+  set -eu
+
+  SUDO=%q
+  sh_c() {
+    if [ -n "$SUDO" ]; then
+      sudo sh -c "$1"
+    else
+      sh -c "$1"
+    fi
+  }
+
+  if command -v apt-get >/dev/null 2>&1; then
+    sh_c 'apt-get update -qq'
+    sh_c 'apt-get install -y curl ca-certificates gnupg'
+    sh_c 'install -d /etc/apt/keyrings'
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sh_c 'gpg --batch --yes --dearmor -o /etc/apt/keyrings/nodesource.gpg'
+    echo 'deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_24.x nodistro main' | sh_c 'tee /etc/apt/sources.list.d/nodesource.list >/dev/null'
+    sh_c 'apt-get update -qq'
+    sh_c 'apt-get install -y nodejs'
+  elif command -v dnf >/dev/null 2>&1 || command -v yum >/dev/null 2>&1; then
+    PKG_MGR=dnf
+    if ! command -v dnf >/dev/null 2>&1; then
+      PKG_MGR=yum
+    fi
+    sh_c "$PKG_MGR install -y nodejs npm"
+  else
+    echo "unsupported Linux distribution for automatic Node.js/npm install" >&2
+    exit 1
+  fi
+fi
+npm --version >/dev/null`, sudo)
+}
+
 // ScriptWriteConfig returns the shell script to write the hub config.
 func ScriptWriteConfig(p Params, useSudo bool) string {
 	configDir := "$HOME/.elasticclaw"

--- a/pkg/install/scripts.go
+++ b/pkg/install/scripts.go
@@ -111,7 +111,10 @@ func ScriptInstallNodeNPM(useSudo bool) string {
     if ! command -v dnf >/dev/null 2>&1; then
       PKG_MGR=yum
     fi
-    sh_c "$PKG_MGR install -y nodejs npm"
+    sh_c "$PKG_MGR install -y curl"
+    curl -fsSL https://rpm.nodesource.com/setup_24.x -o /tmp/nodesource_setup.sh
+    sh_c 'bash /tmp/nodesource_setup.sh'
+    sh_c "$PKG_MGR install -y nodejs"
   else
     echo "unsupported Linux distribution for automatic Node.js/npm install" >&2
     exit 1

--- a/pkg/install/scripts_test.go
+++ b/pkg/install/scripts_test.go
@@ -115,6 +115,15 @@ func TestScriptInstallSystemd(t *testing.T) {
 	assertContains(t, s, "systemctl restart elasticclaw", "start service")
 }
 
+func TestScriptInstallNodeNPM(t *testing.T) {
+	s := install.ScriptInstallNodeNPM(true)
+	assertContains(t, s, "command -v npm", "npm detection")
+	assertContains(t, s, "https://deb.nodesource.com/node_24.x", "NodeSource Node 24 repo")
+	assertContains(t, s, "apt-get install -y nodejs", "apt node install")
+	assertContains(t, s, "$PKG_MGR install -y nodejs npm", "rpm node install")
+	assertContains(t, s, "npm --version", "npm verification")
+}
+
 func TestScriptWriteCaddyfile(t *testing.T) {
 	s := install.ScriptWriteCaddyfile("hub.example.com", true)
 	assertContains(t, s, "/etc/caddy/Caddyfile", "caddyfile path")
@@ -155,6 +164,7 @@ func TestScripts_Shellcheck(t *testing.T) {
 
 	scripts := map[string]string{
 		"install_binary":  install.ScriptInstallBinary("v0.0.3", true),
+		"install_node":    install.ScriptInstallNodeNPM(true),
 		"write_config":    install.ScriptWriteConfig(testParams, true),
 		"install_systemd": install.ScriptInstallSystemd(true),
 		"install_caddy":   install.ScriptInstallCaddy(true),

--- a/pkg/install/scripts_test.go
+++ b/pkg/install/scripts_test.go
@@ -120,7 +120,8 @@ func TestScriptInstallNodeNPM(t *testing.T) {
 	assertContains(t, s, "command -v npm", "npm detection")
 	assertContains(t, s, "https://deb.nodesource.com/node_24.x", "NodeSource Node 24 repo")
 	assertContains(t, s, "apt-get install -y nodejs", "apt node install")
-	assertContains(t, s, "$PKG_MGR install -y nodejs npm", "rpm node install")
+	assertContains(t, s, "https://rpm.nodesource.com/setup_24.x", "NodeSource RPM Node 24 setup")
+	assertContains(t, s, "$PKG_MGR install -y nodejs", "rpm node install")
 	assertContains(t, s, "npm --version", "npm verification")
 }
 


### PR DESCRIPTION
## Summary
- Fix model auth login to install and run pinned Codex/Grok CLIs from a managed hub cache instead of relying on PATH.
- Store managed CLIs under the hub data dir, overridable via ELASTICCLAW_MODEL_CLI_DIR.
- Add Node.js/npm provisioning to elasticclaw install so fresh installed hubs can install CLI-backed model providers.

## Notes
Existing installed hubs that do not have npm will need npm/Node installed once, or a fresh install with the updated installer. The login error is now explicit if npm is unavailable.

## Validation
- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./pkg/hub ./pkg/install ./cmd