### PR TITLE
Add Docker sandbox provider settings UI

### DIFF
--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -2063,7 +2063,7 @@ echo "Git: $(git --version)"
 	return runShell(script)
 }
 
-const openClawVersion = "2026.6.9"
+const openClawVersion = cliversion.OpenClawVersion
 const codexCLIVersion = "0.141.0"
 const grokCLIVersion = "0.1.0"
 

--- a/pkg/cliversion/cliversion.go
+++ b/pkg/cliversion/cliversion.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 )
 
+const OpenClawVersion = "2026.6.9"
+
 func FromEnv(envName, fallback string) string {
 	if v := strings.TrimSpace(os.Getenv(envName)); v != "" {
 		return v

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2982,7 +2982,7 @@ echo uninstalled`); err != nil {
 		log.Printf("[daytona] warning: uninstall failed (ok if not installed): %v", err)
 	}
 
-	const daytonaOpenClawVersion = "2026.6.9"
+	const daytonaOpenClawVersion = cliversion.OpenClawVersion
 	if err := exec("start openclaw install", 20*time.Second, daytonaStartOpenClawInstallCommand(daytonaOpenClawVersion)); err != nil {
 		return err
 	}

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -973,8 +973,12 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 					existing.DefaultDisk = pp.DefaultDisk
 				}
 			case "docker":
-				existing.Image = pp.Image
-				existing.Network = pp.Network
+				if pp.Image != "" {
+					existing.Image = pp.Image
+				}
+				if pp.Network != "" {
+					existing.Network = pp.Network
+				}
 			case "lambda-microvms":
 				if pp.AWSRegion != "" {
 					existing.AWSRegion = pp.AWSRegion

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -171,6 +171,9 @@ type ProviderView struct {
 	DefaultMemory string `json:"defaultMemory,omitempty"`
 	DefaultDisk   string `json:"defaultDisk,omitempty"`
 	_sshKeyPath   string `json:"-"` // internal: path for file I/O outside lock
+	// Docker
+	Image   string `json:"image,omitempty"`
+	Network string `json:"network,omitempty"`
 	// AWS Lambda MicroVMs
 	AWSRegion                  string   `json:"awsRegion,omitempty"`
 	AWSProfile                 string   `json:"awsProfile,omitempty"`
@@ -355,6 +358,9 @@ type ProviderPatch struct {
 	DefaultCPU    int    `json:"defaultCpu,omitempty"`
 	DefaultMemory string `json:"defaultMemory,omitempty"`
 	DefaultDisk   string `json:"defaultDisk,omitempty"`
+	// Docker
+	Image   string `json:"image,omitempty"`
+	Network string `json:"network,omitempty"`
 	// AWS Lambda MicroVMs
 	AWSRegion                  string   `json:"awsRegion,omitempty"`
 	AWSProfile                 string   `json:"awsProfile,omitempty"`
@@ -492,6 +498,9 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 			if p.SSHKeyPath != "" {
 				pv._sshKeyPath = p.SSHKeyPath
 			}
+		case "docker":
+			pv.Image = p.Image
+			pv.Network = p.Network
 		case "lambda-microvms":
 			pv.AWSRegion = p.AWSRegion
 			pv.AWSProfile = p.AWSProfile
@@ -963,6 +972,9 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 				if pp.DefaultDisk != "" {
 					existing.DefaultDisk = pp.DefaultDisk
 				}
+			case "docker":
+				existing.Image = pp.Image
+				existing.Network = pp.Network
 			case "lambda-microvms":
 				if pp.AWSRegion != "" {
 					existing.AWSRegion = pp.AWSRegion

--- a/pkg/provider/docker/docker.go
+++ b/pkg/provider/docker/docker.go
@@ -13,17 +13,18 @@ import (
 	"strings"
 	"time"
 
+	"github.com/elasticclaw/elasticclaw/pkg/cliversion"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
 
 const (
-	defaultImage   = "elasticclaw/claw-agent:dev"
+	defaultImage   = "ghcr.io/openclaw/openclaw:" + cliversion.OpenClawVersion
 	containerLabel = "elasticclaw.claw"
 )
 
 // Config holds docker provider configuration (from hub.yaml providers.docker).
 type Config struct {
-	// Image is the agent container image. Defaults to elasticclaw/claw-agent:dev.
+	// Image is the agent container image. Defaults to the pinned OpenClaw image.
 	Image string
 	// Network is the Docker network to attach agent containers to so they can
 	// reach the hub by its service name (e.g. "elasticclaw-dev").

--- a/pkg/provider/docker/docker_test.go
+++ b/pkg/provider/docker/docker_test.go
@@ -3,6 +3,8 @@ package docker
 import (
 	"context"
 	"testing"
+
+	"github.com/elasticclaw/elasticclaw/pkg/cliversion"
 )
 
 func TestCopyInRejectsRelativeDestination(t *testing.T) {
@@ -14,5 +16,16 @@ func TestCopyInRejectsRelativeDestination(t *testing.T) {
 	err = provider.CopyIn(context.Background(), "container", "relative/path.txt", []byte("content"))
 	if err == nil {
 		t.Fatal("expected relative destination to be rejected")
+	}
+}
+
+func TestNewDefaultsToPinnedOpenClawImage(t *testing.T) {
+	provider, err := New(Config{})
+	if err != nil {
+		t.Fatalf("new provider: %v", err)
+	}
+
+	if got, want := provider.cfg.Image, "ghcr.io/openclaw/openclaw:"+cliversion.OpenClawVersion; got != want {
+		t.Fatalf("default image = %q, want %q", got, want)
 	}
 }

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -106,6 +106,8 @@ interface SettingsData {
     defaultDisk?: string
     sshKeySet?: boolean
     sshPublicKey?: string
+    image?: string
+    network?: string
     awsRegion?: string
     awsProfile?: string
     imageIdentifier?: string
@@ -506,6 +508,7 @@ const SANDBOX_PROVIDER_OPTIONS = [
   { value: "replicated", label: "Replicated CMX", description: "Kubernetes-based VM provider" },
   { value: "daytona", label: "Daytona", description: "Development environment provider" },
   { value: "exedev", label: "exe.dev", description: "Persistent VM provider with SSH access" },
+  { value: "docker", label: "Local Docker", description: "Local Docker daemon provider for development and testing" },
   { value: "lambda-microvms", label: "AWS Lambda MicroVMs", description: "Serverless Firecracker MicroVM provider", alpha: true },
 ]
 
@@ -522,6 +525,8 @@ interface SandboxProviderView {
   tokenSet?: boolean
   defaultTtl?: string
   defaultInstanceType?: string
+  image?: string
+  network?: string
   imageIdentifier?: string
 }
 
@@ -539,13 +544,15 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
         label: opt?.label || name,
         description: opt?.description || "",
         alpha: opt?.alpha,
-        configured: !!(p.tokenSet || p.apiKeySet || p.imageIdentifier || name === "exedev"),
+        configured: !!(p.tokenSet || p.apiKeySet || p.imageIdentifier || name === "exedev" || name === "docker"),
         apiUrl: p.apiUrl,
         apiKeySet: p.apiKeySet,
         defaultSnapshot: p.defaultSnapshot,
         tokenSet: p.tokenSet,
         defaultTtl: p.defaultTtl,
         defaultInstanceType: p.defaultInstanceType,
+        image: p.image,
+        network: p.network,
         imageIdentifier: p.imageIdentifier,
         defaultCpu: p.defaultCpu,
         defaultMemory: p.defaultMemory,
@@ -570,6 +577,8 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
   const [formDefaultCpu, setFormDefaultCpu] = useState("")
   const [formDefaultMemory, setFormDefaultMemory] = useState("")
   const [formDefaultDisk, setFormDefaultDisk] = useState("")
+  const [formDockerImage, setFormDockerImage] = useState("")
+  const [formDockerNetwork, setFormDockerNetwork] = useState("")
   const [formAwsRegion, setFormAwsRegion] = useState("")
   const [formAwsProfile, setFormAwsProfile] = useState("")
   const [formImageIdentifier, setFormImageIdentifier] = useState("")
@@ -595,6 +604,8 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
     setFormDefaultCpu("")
     setFormDefaultMemory("")
     setFormDefaultDisk("")
+    setFormDockerImage("")
+    setFormDockerNetwork("")
     setFormAwsRegion("")
     setFormAwsProfile("")
     setFormImageIdentifier("")
@@ -638,6 +649,8 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
     setFormDefaultCpu(p?.defaultCpu?.toString() || "")
     setFormDefaultMemory(p?.defaultMemory ? p.defaultMemory.replace(/GB$/, "") : "")
     setFormDefaultDisk(p?.defaultDisk ? p.defaultDisk.replace(/GB$/, "") : "")
+    setFormDockerImage(p?.image || "")
+    setFormDockerNetwork(p?.network || "")
     setFormAwsRegion(p?.awsRegion || "")
     setFormAwsProfile(p?.awsProfile || "")
     setFormImageIdentifier(p?.imageIdentifier || "")
@@ -687,6 +700,10 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
       if (formDefaultCpu && !isNaN(parsedCpu)) patch.defaultCpu = parsedCpu
       if (formDefaultMemory) patch.defaultMemory = formDefaultMemory + "GB"
       if (formDefaultDisk) patch.defaultDisk = formDefaultDisk + "GB"
+    } else if (formProvider === "docker") {
+      patch.enabled = true
+      patch.image = formDockerImage.trim()
+      patch.network = formDockerNetwork.trim()
     } else if (formProvider === "lambda-microvms") {
       patch.enabled = true
       if (formAwsRegion) patch.awsRegion = formAwsRegion.trim()
@@ -954,6 +971,41 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
                     className="h-8 text-sm"
                     placeholder="10"
                   />
+                </div>
+              </>
+            )}
+
+            {formProvider === "docker" && (
+              <>
+                <div className="bg-muted/50 rounded-lg p-3 space-y-2">
+                  <p className="text-xs font-medium">Local Docker provider</p>
+                  <p className="text-xs text-muted-foreground">
+                    Runs agent containers with the hub host&apos;s Docker daemon. If the hub runs in a container, mount the Docker socket so it can create sibling containers.
+                  </p>
+                </div>
+                <div>
+                  <label className="text-xs text-muted-foreground mb-1 block">Agent image</label>
+                  <Input
+                    value={formDockerImage}
+                    onChange={e => setFormDockerImage(e.target.value)}
+                    className="h-8 text-sm font-mono"
+                    placeholder="elasticclaw/claw-agent:dev"
+                  />
+                  <p className="text-[11px] text-muted-foreground mt-1">
+                    Leave blank to use the provider default image.
+                  </p>
+                </div>
+                <div>
+                  <label className="text-xs text-muted-foreground mb-1 block">Docker network</label>
+                  <Input
+                    value={formDockerNetwork}
+                    onChange={e => setFormDockerNetwork(e.target.value)}
+                    className="h-8 text-sm font-mono"
+                    placeholder="elasticclaw-dev"
+                  />
+                  <p className="text-[11px] text-muted-foreground mt-1">
+                    Optional. Use a network where agent containers can reach the hub.
+                  </p>
                 </div>
               </>
             )}

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -989,10 +989,10 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
                     value={formDockerImage}
                     onChange={e => setFormDockerImage(e.target.value)}
                     className="h-8 text-sm font-mono"
-                    placeholder="elasticclaw/claw-agent:dev"
+                    placeholder="ghcr.io/openclaw/openclaw:2026.6.9"
                   />
                   <p className="text-[11px] text-muted-foreground mt-1">
-                    Leave blank to use the provider default image.
+                    Leave blank to use the pinned OpenClaw image, ghcr.io/openclaw/openclaw:2026.6.9.
                   </p>
                 </div>
                 <div>


### PR DESCRIPTION
## Summary
- add Local Docker to the sandbox provider picker in Settings
- expose Docker agent image and network fields in the provider modal
- round-trip Docker image/network through the settings API

## Tests
- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./pkg/hub
- npm run build