### PR TITLE
fix: sync OpenClaw API key auth

### DIFF
--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -2161,6 +2161,18 @@ func installSelectedCodingModelCLI() error {
 	}
 }
 
+func syncOpenClawAPIKeyAuth() error {
+	script := strings.TrimSpace(os.Getenv("ELASTICCLAW_API_KEY_AUTH_SYNC"))
+	if script == "" {
+		return nil
+	}
+	log.Printf("[bootstrap] syncing OpenClaw API-key auth...")
+	if err := runShell(script); err != nil {
+		return fmt.Errorf("sync OpenClaw API-key auth: %w", err)
+	}
+	return nil
+}
+
 // configureOpenClaw patches ~/.openclaw/openclaw.json with model, LLM keys,
 // gateway auth, and disables the bonjour plugin.
 func configureOpenClaw() error {
@@ -2514,6 +2526,10 @@ func runBootstrap() error {
 		}
 	} else {
 		log.Printf("[bootstrap] openclaw.json already exists, skipping onboard")
+	}
+
+	if err := syncOpenClawAPIKeyAuth(); err != nil {
+		return err
 	}
 
 	// Step 5: Set up flake environment BEFORE starting gateway if flake.nix exists

--- a/pkg/hub/bootstrap.go
+++ b/pkg/hub/bootstrap.go
@@ -39,6 +39,7 @@ type BootstrapParams struct {
 	// Env injection
 	LLMKeyEnv      string // pre-built export lines
 	ModelAuthEnv   string // pre-built export lines for CLI-backed model auth state
+	APIKeyAuthSync string // shell script that persists API-key auth into OpenClaw's auth store
 	LinearEnv      string // pre-built export line
 	ProviderConfig string // python snippet to patch OpenClaw config
 	OnboardFlags   string // --auth-choice ... flags for openclaw onboard
@@ -188,6 +189,21 @@ print('OpenClaw config patched')
 PYEOF`, anthropicPatch)
 }
 
+// buildOpenClawAPIKeyAuthSyncShell returns a shell snippet that persists
+// direct API-key auth into OpenClaw's current auth store. OpenClaw 2026.6.9
+// resolves agent auth from openclaw-agent.sqlite, so writing only the legacy
+// auth-profiles.json file is not enough for embedded agents.
+func buildOpenClawAPIKeyAuthSyncShell(keys []*types.LLMKeyConfig, selectedKeyName string) string {
+	activeKey := resolveActiveKey(keys, selectedKeyName)
+	if activeKey == nil || activeKey.Provider != "anthropic" || !llmKeyHasRequiredAPIKey(activeKey) {
+		return ""
+	}
+	envVar := activeKey.EnvVarName()
+	return fmt.Sprintf(`if [ -n "${%s:-}" ]; then
+  printf '%%s\n' "${%s}" | openclaw models auth paste-api-key --provider anthropic --profile-id anthropic:default
+fi`, envVar, envVar)
+}
+
 // GenerateReplicatedBootstrapScript returns a minimal bash script that downloads
 // claw-bridge and execs it with --bootstrap. All VM setup logic now lives inside
 // claw-bridge itself (runBootstrap in cmd/claw-bridge/main.go).
@@ -215,6 +231,11 @@ func GenerateReplicatedBootstrapScript(p BootstrapParams) string {
 		providerConfigLine = fmt.Sprintf("export ELASTICCLAW_PROVIDER_CONFIG=%s",
 			shellQuote(p.ProviderConfig))
 	}
+	apiKeyAuthSyncLine := "# No API key auth sync"
+	if p.APIKeyAuthSync != "" {
+		apiKeyAuthSyncLine = fmt.Sprintf("export ELASTICCLAW_API_KEY_AUTH_SYNC=%s",
+			shellQuote(p.APIKeyAuthSync))
+	}
 
 	linearEnvLine := p.LinearEnv
 	if linearEnvLine == "" {
@@ -234,6 +255,7 @@ export OPENCLAW_GATEWAY_PASSWORD="$ELASTICCLAW_GATEWAY_PASSWORD"
 export OPENCLAW_DEFAULT_MODEL=%s
 export ELASTICCLAW_NIX=%s
 export ELASTICCLAW_DOCKER=%s
+%s
 %s
 %s
 %s
@@ -324,7 +346,7 @@ exit 1
 `,
 		shellQuote(p.HubURL), shellQuote(p.ClawID), shellQuote(p.ClawToken), shellQuote(p.ClawName), shellQuote(p.GatewayPassword),
 		shellQuote(p.DefaultModel), shellQuote(nixFlag), shellQuote(dockerFlag),
-		p.LLMKeyEnv, p.ModelAuthEnv, linearEnvLine, shellQuote(p.OnboardFlags), providerConfigLine,
+		p.LLMKeyEnv, p.ModelAuthEnv, linearEnvLine, apiKeyAuthSyncLine, shellQuote(p.OnboardFlags), providerConfigLine,
 		shellQuote(p.BridgeURL),
 	)
 }

--- a/pkg/hub/bootstrap_test.go
+++ b/pkg/hub/bootstrap_test.go
@@ -191,6 +191,21 @@ export OPENAI_API_KEY="sk-openai-key"`
 	assertContains(t, topSection, "OPENAI_API_KEY", "OPENAI_API_KEY before bridge start")
 }
 
+func TestBootstrapScript_OpenClawAPIKeyAuthSyncInjected(t *testing.T) {
+	p := baseParams()
+	p.APIKeyAuthSync = buildOpenClawAPIKeyAuthSyncShell(types.LLMKeysList{
+		{Name: "anthropic-main", Provider: "anthropic", APIKey: "sk-ant-test", Default: true},
+	}, "anthropic-main")
+
+	script := GenerateReplicatedBootstrapScript(p)
+
+	assertContains(t, script, "ELASTICCLAW_API_KEY_AUTH_SYNC", "exports API key auth sync script for claw-bridge")
+	assertContains(t, script, "openclaw models auth paste-api-key", "syncs API key through OpenClaw auth CLI")
+	assertContains(t, script, "--provider anthropic", "syncs Anthropic provider")
+	assertContains(t, script, "--profile-id anthropic:default", "uses stable Anthropic default profile")
+	assertNotContains(t, script, "sk-ant-test", "does not embed the API key in the auth sync script")
+}
+
 func TestBootstrapScript_OnboardFlagsShellQuoted(t *testing.T) {
 	p := baseParams()
 	p.OnboardFlags = buildOnboardFlags(nil, "", p.DefaultModel)
@@ -346,6 +361,28 @@ func TestBuildLLMKeyEnvSkipsBlankExternalKeys(t *testing.T) {
 	assertContains(t, env, "ANTHROPIC_API_KEY", "exports usable external key")
 	assertContains(t, env, "OLLAMA_API_KEY", "exports blank Ollama key because Ollama auth does not require an API key")
 	assertNotContains(t, env, "OPENAI_API_KEY", "does not export blank OpenAI key")
+}
+
+func TestBuildOpenClawAPIKeyAuthSyncShellUsesAnthropicPasteAPIKey(t *testing.T) {
+	shell := buildOpenClawAPIKeyAuthSyncShell(types.LLMKeysList{
+		{Name: "anthropic-main", Provider: "anthropic", APIKey: "sk-ant-test", Default: true},
+	}, "anthropic-main")
+
+	assertContains(t, shell, "ANTHROPIC_API_KEY", "reads exported Anthropic key")
+	assertContains(t, shell, "openclaw models auth paste-api-key", "uses OpenClaw to persist the auth store")
+	assertContains(t, shell, "--provider anthropic", "writes Anthropic auth")
+	assertContains(t, shell, "--profile-id anthropic:default", "uses the existing default profile id")
+	assertNotContains(t, shell, "sk-ant-test", "does not inline the secret value")
+}
+
+func TestBuildOpenClawAPIKeyAuthSyncShellSkipsNonAnthropicKeys(t *testing.T) {
+	shell := buildOpenClawAPIKeyAuthSyncShell(types.LLMKeysList{
+		{Name: "openai-main", Provider: "openai", APIKey: "sk-openai-test", Default: true},
+	}, "openai-main")
+
+	if shell != "" {
+		t.Fatalf("expected no auth sync shell for non-Anthropic key, got %q", shell)
+	}
 }
 
 func TestBuildModelAuthEnvUsesSelectedProfile(t *testing.T) {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -3082,6 +3082,7 @@ docker --version`); err != nil {
 	defaultModelDaytona := resolveDefaultModelForKey(s.hubCfg, activeKeyDaytona)
 	llmKeyEnvDaytona := buildLLMKeyEnv(s.hubCfg.LLMKeys, llmKeyNameDaytona)
 	modelAuthEnvDaytona := buildModelAuthEnv(s.hubCfg, llmKeyNameDaytona)
+	apiKeyAuthSyncDaytona := buildOpenClawAPIKeyAuthSyncShell(s.hubCfg.LLMKeys, llmKeyNameDaytona)
 	onboardFlags := buildOnboardFlags(s.hubCfg.LLMKeys, llmKeyNameDaytona, defaultModelDaytona)
 	providerConfigScript := buildOpenClawProviderConfig(s.hubCfg.LLMKeys, llmKeyNameDaytona)
 	if activeKeyDaytona != nil {
@@ -3123,6 +3124,13 @@ docker --version`); err != nil {
 		log.Printf("[daytona] onboard returned non-zero, but config file exists; continuing")
 	} else {
 		log.Printf("[daytona] onboard openclaw done")
+	}
+
+	if apiKeyAuthSyncDaytona != "" {
+		syncCmd := `export HOME=/home/daytona; export NVM_DIR=/usr/local/share/nvm; export PATH=$NVM_DIR/current/bin:$PATH; ` + llmKeyEnvDaytona + apiKeyAuthSyncDaytona
+		if err := exec("sync openclaw api key auth", 30*time.Second, syncCmd); err != nil {
+			return fmt.Errorf("sync openclaw api key auth: %w", err)
+		}
 	}
 
 	configPatch := fmt.Sprintf("export HOME=/home/daytona; export OPENCLAW_DEFAULT_MODEL=%q; export ELASTICCLAW_GATEWAY_PASSWORD=%q; ", defaultModelDaytona, gatewayPassword) + llmKeyEnvDaytona + providerConfigScript
@@ -4245,6 +4253,7 @@ func (s *Server) bootstrapExedev(ctx context.Context, clawID, vmName string, p *
 		GitHubRepos:     githubRepos,
 		LLMKeyEnv:       llmKeyEnv,
 		ModelAuthEnv:    modelAuthEnv,
+		APIKeyAuthSync:  buildOpenClawAPIKeyAuthSyncShell(hubCfg.LLMKeys, llmKeyName),
 		LinearEnv:       buildLinearEnv(linearToken),
 		ProviderConfig:  buildOpenClawProviderConfig(hubCfg.LLMKeys, llmKeyName),
 		OnboardFlags:    buildOnboardFlags(hubCfg.LLMKeys, llmKeyName, defaultModel),
@@ -4329,6 +4338,7 @@ func (s *Server) provisionDocker(ctx context.Context, clawID string, req types.C
 
 	gatewayPassword := randomHex(16)
 	providerConfig := buildOpenClawProviderConfig(hubCfg.LLMKeys, llmKeyName)
+	apiKeyAuthSync := buildOpenClawAPIKeyAuthSyncShell(hubCfg.LLMKeys, llmKeyName)
 	onboardFlags := buildOnboardFlags(hubCfg.LLMKeys, llmKeyName, defaultModel)
 
 	// Build env map for the container — passed directly as -e flags (no shell escaping needed)
@@ -4346,6 +4356,7 @@ func (s *Server) provisionDocker(ctx context.Context, clawID string, req types.C
 		"ELASTICCLAW_NIX":                boolEnv(nixEnabled != 0),
 		"ELASTICCLAW_DOCKER":             boolEnv(dockerEnabled != 0),
 		"ELASTICCLAW_PROVIDER_CONFIG":    providerConfig,
+		"ELASTICCLAW_API_KEY_AUTH_SYNC":  apiKeyAuthSync,
 		"ELASTICCLAW_ONBOARD_FLAGS":      onboardFlags,
 	}
 
@@ -4430,6 +4441,7 @@ func (s *Server) provisionLambdaMicroVMs(ctx context.Context, clawID string, req
 		defaultModel = hubCfg.DefaultModel
 	}
 	providerConfig := buildOpenClawProviderConfig(hubCfg.LLMKeys, llmKeyName)
+	apiKeyAuthSync := buildOpenClawAPIKeyAuthSyncShell(hubCfg.LLMKeys, llmKeyName)
 	onboardFlags := buildOnboardFlags(hubCfg.LLMKeys, llmKeyName, defaultModel)
 	gatewayPassword := randomHex(16)
 
@@ -4447,6 +4459,7 @@ func (s *Server) provisionLambdaMicroVMs(ctx context.Context, clawID string, req
 		"ELASTICCLAW_NIX":                boolEnv(nixEnabled != 0),
 		"ELASTICCLAW_DOCKER":             boolEnv(dockerEnabled != 0),
 		"ELASTICCLAW_PROVIDER_CONFIG":    providerConfig,
+		"ELASTICCLAW_API_KEY_AUTH_SYNC":  apiKeyAuthSync,
 		"ELASTICCLAW_ONBOARD_FLAGS":      onboardFlags,
 	}
 	for _, line := range strings.Split(llmKeyEnv+modelAuthEnv, "\n") {
@@ -5188,6 +5201,7 @@ func (s *Server) bootstrapReplicated(clawID, clawName, vmID string, cfg types.Pr
 		GitHubRepos:     githubRepos,
 		LLMKeyEnv:       llmKeyEnv,
 		ModelAuthEnv:    modelAuthEnv,
+		APIKeyAuthSync:  buildOpenClawAPIKeyAuthSyncShell(hubCfg.LLMKeys, llmKeyName),
 		LinearEnv:       buildLinearEnv(linearToken),
 		ProviderConfig:  buildOpenClawProviderConfig(hubCfg.LLMKeys, llmKeyName),
 		OnboardFlags:    buildOnboardFlags(hubCfg.LLMKeys, llmKeyName, defaultModel),


### PR DESCRIPTION
## Summary

- Persist Anthropic API-key auth through `openclaw models auth paste-api-key` so OpenClaw 2026.6.9 materializes `openclaw-agent.sqlite` for embedded agents.
- Pass the auth sync script through replicated/exedev/docker/lambda bootstrap paths and run it directly during Daytona bootstrap.
- Add regression coverage that verifies the sync script uses the OpenClaw CLI without embedding the raw API key.

## Root Cause

The hub still wrote Anthropic credentials to the legacy `auth-profiles.json` path, but OpenClaw 2026.6.9 resolves embedded-agent auth from the agent SQLite store. New Daytona agents could therefore bootstrap successfully and still fail at model response time with `No API key found for provider "anthropic"`.

## Validation

- `go test ./pkg/hub -run 'TestBootstrapScript_OpenClawAPIKeyAuthSyncInjected|TestBuildOpenClawAPIKeyAuthSyncShell'`
- `go test ./pkg/hub`
- `go test ./cmd/claw-bridge`
- `go test ./...`
