### PR TITLE
Support Jira Automation issue-data payloads

### DIFF
--- a/pkg/hub/jira.go
+++ b/pkg/hub/jira.go
@@ -37,32 +37,34 @@ func (s *jiraString) UnmarshalJSON(data []byte) error {
 }
 
 type jiraWebhookPayload struct {
-	WebhookEvent string    `json:"webhookEvent"`
-	Timestamp    int64     `json:"timestamp"`
-	Issue        jiraIssue `json:"issue"`
-	User         jiraUser  `json:"user"`
-	Changelog    *struct {
-		ID    string `json:"id"`
-		Items []struct {
-			Field      string `json:"field"`
-			FromString string `json:"fromString"`
-			ToString   string `json:"toString"`
-		} `json:"items"`
-	} `json:"changelog,omitempty"`
+	WebhookEvent string                `json:"webhookEvent"`
+	Timestamp    int64                 `json:"timestamp"`
+	Issue        jiraIssue             `json:"issue"`
+	User         jiraUser              `json:"user"`
+	Changelog    *jiraWebhookChangelog `json:"changelog,omitempty"`
+}
+
+type jiraWebhookChangelog struct {
+	ID    string              `json:"id"`
+	Items []jiraChangelogItem `json:"items"`
+}
+
+type jiraChangelogItem struct {
+	Field      string `json:"field"`
+	FromString string `json:"fromString"`
+	ToString   string `json:"toString"`
 }
 
 type jiraAutomationIssuePayload struct {
 	jiraIssue
 	Changelog *struct {
-		Histories []struct {
-			ID    jiraString `json:"id"`
-			Items []struct {
-				Field      string `json:"field"`
-				FromString string `json:"fromString"`
-				ToString   string `json:"toString"`
-			} `json:"items"`
-		} `json:"histories"`
+		Histories []jiraAutomationHistory `json:"histories"`
 	} `json:"changelog,omitempty"`
+}
+
+type jiraAutomationHistory struct {
+	ID    jiraString          `json:"id"`
+	Items []jiraChangelogItem `json:"items"`
 }
 
 type jiraIssue struct {
@@ -153,20 +155,28 @@ func parseJiraWebhookPayload(body []byte) (jiraWebhookPayload, error) {
 	payload.Timestamp = time.Now().UnixMilli()
 	payload.Issue = issuePayload.jiraIssue
 	if issuePayload.Changelog != nil && len(issuePayload.Changelog.Histories) > 0 {
-		history := issuePayload.Changelog.Histories[len(issuePayload.Changelog.Histories)-1]
-		payload.Changelog = &struct {
-			ID    string `json:"id"`
-			Items []struct {
-				Field      string `json:"field"`
-				FromString string `json:"fromString"`
-				ToString   string `json:"toString"`
-			} `json:"items"`
-		}{
+		history := selectJiraAutomationHistory(issuePayload.Changelog.Histories)
+		payload.Changelog = &jiraWebhookChangelog{
 			ID:    string(history.ID),
 			Items: history.Items,
 		}
+	} else {
+		payload.Changelog = &jiraWebhookChangelog{
+			ID: "automation:" + firstNonEmpty(string(issuePayload.ID), issuePayload.Key) + ":" + string(issuePayload.Fields.Updated),
+		}
 	}
 	return payload, nil
+}
+
+func selectJiraAutomationHistory(histories []jiraAutomationHistory) jiraAutomationHistory {
+	for i := len(histories) - 1; i >= 0; i-- {
+		for _, item := range histories[i].Items {
+			if strings.EqualFold(item.Field, "status") {
+				return histories[i]
+			}
+		}
+	}
+	return histories[len(histories)-1]
 }
 
 func (s *Server) validateJiraWebhookSecret(workspaceName string, r *http.Request) bool {

--- a/pkg/hub/jira.go
+++ b/pkg/hub/jira.go
@@ -16,6 +16,26 @@ import (
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
 
+type jiraString string
+
+func (s *jiraString) UnmarshalJSON(data []byte) error {
+	if bytes.Equal(data, []byte("null")) {
+		*s = ""
+		return nil
+	}
+	var text string
+	if err := json.Unmarshal(data, &text); err == nil {
+		*s = jiraString(text)
+		return nil
+	}
+	var number json.Number
+	if err := json.Unmarshal(data, &number); err == nil {
+		*s = jiraString(number.String())
+		return nil
+	}
+	return fmt.Errorf("invalid Jira string value %s", string(data))
+}
+
 type jiraWebhookPayload struct {
 	WebhookEvent string    `json:"webhookEvent"`
 	Timestamp    int64     `json:"timestamp"`
@@ -31,15 +51,29 @@ type jiraWebhookPayload struct {
 	} `json:"changelog,omitempty"`
 }
 
+type jiraAutomationIssuePayload struct {
+	jiraIssue
+	Changelog *struct {
+		Histories []struct {
+			ID    jiraString `json:"id"`
+			Items []struct {
+				Field      string `json:"field"`
+				FromString string `json:"fromString"`
+				ToString   string `json:"toString"`
+			} `json:"items"`
+		} `json:"histories"`
+	} `json:"changelog,omitempty"`
+}
+
 type jiraIssue struct {
-	ID     string `json:"id"`
-	Key    string `json:"key"`
-	Self   string `json:"self"`
+	ID     jiraString `json:"id"`
+	Key    string     `json:"key"`
+	Self   string     `json:"self"`
 	Fields struct {
-		Summary     string   `json:"summary"`
-		Description any      `json:"description"`
-		Labels      []string `json:"labels"`
-		Updated     string   `json:"updated"`
+		Summary     string     `json:"summary"`
+		Description any        `json:"description"`
+		Labels      []string   `json:"labels"`
+		Updated     jiraString `json:"updated"`
 		Status      struct {
 			Name string `json:"name"`
 		} `json:"status"`
@@ -78,8 +112,8 @@ func (s *Server) handleJiraWebhook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var payload jiraWebhookPayload
-	if err := json.Unmarshal(body, &payload); err != nil {
+	payload, err := parseJiraWebhookPayload(body)
+	if err != nil {
 		http.Error(w, "invalid payload", http.StatusBadRequest)
 		return
 	}
@@ -96,6 +130,43 @@ func (s *Server) handleJiraWebhook(w http.ResponseWriter, r *http.Request) {
 
 	go s.processJiraEvent(workspaceName, payload)
 	w.WriteHeader(http.StatusOK)
+}
+
+func parseJiraWebhookPayload(body []byte) (jiraWebhookPayload, error) {
+	var payload jiraWebhookPayload
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return payload, err
+	}
+	if payload.Issue.Key != "" {
+		return payload, nil
+	}
+
+	var issuePayload jiraAutomationIssuePayload
+	if err := json.Unmarshal(body, &issuePayload); err != nil {
+		return payload, err
+	}
+	if issuePayload.Key == "" {
+		return payload, nil
+	}
+
+	payload.WebhookEvent = "jira:issue_updated"
+	payload.Timestamp = time.Now().UnixMilli()
+	payload.Issue = issuePayload.jiraIssue
+	if issuePayload.Changelog != nil && len(issuePayload.Changelog.Histories) > 0 {
+		history := issuePayload.Changelog.Histories[len(issuePayload.Changelog.Histories)-1]
+		payload.Changelog = &struct {
+			ID    string `json:"id"`
+			Items []struct {
+				Field      string `json:"field"`
+				FromString string `json:"fromString"`
+				ToString   string `json:"toString"`
+			} `json:"items"`
+		}{
+			ID:    string(history.ID),
+			Items: history.Items,
+		}
+	}
+	return payload, nil
 }
 
 func (s *Server) validateJiraWebhookSecret(workspaceName string, r *http.Request) bool {

--- a/pkg/hub/jira_workflow_test.go
+++ b/pkg/hub/jira_workflow_test.go
@@ -45,6 +45,36 @@ func TestJiraWorkflowWebhookCreatesClaw(t *testing.T) {
 	waitForJiraClawCount(t, db, "EC-123", 1)
 }
 
+func TestJiraWorkflowAutomationIssuePayloadCreatesClaw(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
+	cfg := jiraWorkflowTestConfig()
+	s, db := hub.NewTestServerWithConfig(t, cfg, "", "", "")
+	saveJiraWorkflowFixture(t, "workspace-a")
+	hub.SaveWorkspaceIssueTrackerWithBaseForTest(t, "workspace-a", "jira", "default", "https://jira.example.test", "", "jira-token", "jira-secret")
+
+	httpSrv := httptest.NewServer(s.Handler())
+	t.Cleanup(httpSrv.Close)
+
+	payload := jiraAutomationIssuePayload(t, "EC-123", "EC", "Backlog", "Ready for Agent", []string{"agent"})
+	req, err := http.NewRequest(http.MethodPost, httpSrv.URL+"/api/workspaces/workspace-a/webhooks/jira", strings.NewReader(string(payload)))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-ElasticClaw-Webhook-Secret", "jira-secret")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	waitForJiraClawCount(t, db, "EC-123", 1)
+}
+
 func TestJiraGlobalWebhookCreatesClaw(t *testing.T) {
 	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
 	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
@@ -367,6 +397,50 @@ func jiraWebhookPayload(t *testing.T, key, project, previousStatus, status strin
 	data, err := json.Marshal(body)
 	if err != nil {
 		t.Fatalf("marshal Jira payload: %v", err)
+	}
+	return data
+}
+
+func jiraAutomationIssuePayload(t *testing.T, key, project, previousStatus, status string, labels []string) []byte {
+	t.Helper()
+	body := map[string]interface{}{
+		"self": "https://jira.example.test/rest/api/2/issue/10001",
+		"id":   10001,
+		"key":  key,
+		"changelog": map[string]interface{}{
+			"startAt":    0,
+			"maxResults": 1,
+			"total":      1,
+			"histories": []map[string]interface{}{{
+				"id": "20001",
+				"items": []map[string]interface{}{{
+					"field":      "status",
+					"fromString": previousStatus,
+					"toString":   status,
+				}},
+			}},
+		},
+		"fields": map[string]interface{}{
+			"summary":     "Test Jira issue",
+			"description": "Do the Jira task",
+			"labels":      labels,
+			"updated":     int64(1710000000000),
+			"status": map[string]interface{}{
+				"name": status,
+			},
+			"project": map[string]interface{}{
+				"key":  project,
+				"name": "Test Project",
+			},
+			"assignee": map[string]interface{}{
+				"accountId":   "user-123",
+				"displayName": "Jira User",
+			},
+		},
+	}
+	data, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal Jira automation payload: %v", err)
 	}
 	return data
 }

--- a/pkg/hub/jira_workflow_test.go
+++ b/pkg/hub/jira_workflow_test.go
@@ -75,6 +75,70 @@ func TestJiraWorkflowAutomationIssuePayloadCreatesClaw(t *testing.T) {
 	waitForJiraClawCount(t, db, "EC-123", 1)
 }
 
+func TestJiraWorkflowAutomationIssuePayloadFindsStatusHistory(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
+	cfg := jiraWorkflowTestConfig()
+	s, db := hub.NewTestServerWithConfig(t, cfg, "", "", "")
+	saveJiraWorkflowFixture(t, "workspace-a")
+	hub.SaveWorkspaceIssueTrackerWithBaseForTest(t, "workspace-a", "jira", "default", "https://jira.example.test", "", "jira-token", "jira-secret")
+
+	httpSrv := httptest.NewServer(s.Handler())
+	t.Cleanup(httpSrv.Close)
+
+	payload := jiraAutomationIssuePayloadWithTrailingHistory(t, "EC-123", "EC", "Backlog", "Ready for Agent", []string{"agent"})
+	req, err := http.NewRequest(http.MethodPost, httpSrv.URL+"/api/workspaces/workspace-a/webhooks/jira", strings.NewReader(string(payload)))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-ElasticClaw-Webhook-Secret", "jira-secret")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	waitForJiraClawCount(t, db, "EC-123", 1)
+}
+
+func TestJiraWorkflowAutomationIssuePayloadWithoutChangelogDedupes(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
+	cfg := jiraWorkflowTestConfig()
+	s, db := hub.NewTestServerWithConfig(t, cfg, "", "", "")
+	saveJiraWorkflowFixture(t, "workspace-a")
+	hub.SaveWorkspaceIssueTrackerWithBaseForTest(t, "workspace-a", "jira", "default", "https://jira.example.test", "", "jira-token", "jira-secret")
+
+	httpSrv := httptest.NewServer(s.Handler())
+	t.Cleanup(httpSrv.Close)
+
+	payload := jiraAutomationIssuePayloadWithoutChangelog(t, "EC-123", "EC", "Ready for Agent", []string{"agent"})
+	for i := 0; i < 2; i++ {
+		req, err := http.NewRequest(http.MethodPost, httpSrv.URL+"/api/workspaces/workspace-a/webhooks/jira", strings.NewReader(string(payload)))
+		if err != nil {
+			t.Fatalf("request %d: %v", i, err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-ElasticClaw-Webhook-Secret", "jira-secret")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("post %d: %v", i, err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
+			t.Fatalf("status %d = %d, want 200", i, resp.StatusCode)
+		}
+		resp.Body.Close()
+	}
+
+	waitForJiraClawCount(t, db, "EC-123", 1)
+	assertJiraClawCountStable(t, db, "EC-123", 1)
+}
+
 func TestJiraGlobalWebhookCreatesClaw(t *testing.T) {
 	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
 	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
@@ -403,23 +467,49 @@ func jiraWebhookPayload(t *testing.T, key, project, previousStatus, status strin
 
 func jiraAutomationIssuePayload(t *testing.T, key, project, previousStatus, status string, labels []string) []byte {
 	t.Helper()
+	return jiraAutomationIssuePayloadWithHistories(t, key, project, status, labels, []map[string]interface{}{{
+		"id": "20001",
+		"items": []map[string]interface{}{{
+			"field":      "status",
+			"fromString": previousStatus,
+			"toString":   status,
+		}},
+	}})
+}
+
+func jiraAutomationIssuePayloadWithTrailingHistory(t *testing.T, key, project, previousStatus, status string, labels []string) []byte {
+	t.Helper()
+	return jiraAutomationIssuePayloadWithHistories(t, key, project, status, labels, []map[string]interface{}{
+		{
+			"id": "20001",
+			"items": []map[string]interface{}{{
+				"field":      "status",
+				"fromString": previousStatus,
+				"toString":   status,
+			}},
+		},
+		{
+			"id": "20002",
+			"items": []map[string]interface{}{{
+				"field":      "description",
+				"fromString": "old",
+				"toString":   "new",
+			}},
+		},
+	})
+}
+
+func jiraAutomationIssuePayloadWithoutChangelog(t *testing.T, key, project, status string, labels []string) []byte {
+	t.Helper()
+	return jiraAutomationIssuePayloadWithHistories(t, key, project, status, labels, nil)
+}
+
+func jiraAutomationIssuePayloadWithHistories(t *testing.T, key, project, status string, labels []string, histories []map[string]interface{}) []byte {
+	t.Helper()
 	body := map[string]interface{}{
 		"self": "https://jira.example.test/rest/api/2/issue/10001",
 		"id":   10001,
 		"key":  key,
-		"changelog": map[string]interface{}{
-			"startAt":    0,
-			"maxResults": 1,
-			"total":      1,
-			"histories": []map[string]interface{}{{
-				"id": "20001",
-				"items": []map[string]interface{}{{
-					"field":      "status",
-					"fromString": previousStatus,
-					"toString":   status,
-				}},
-			}},
-		},
 		"fields": map[string]interface{}{
 			"summary":     "Test Jira issue",
 			"description": "Do the Jira task",
@@ -437,6 +527,14 @@ func jiraAutomationIssuePayload(t *testing.T, key, project, previousStatus, stat
 				"displayName": "Jira User",
 			},
 		},
+	}
+	if histories != nil {
+		body["changelog"] = map[string]interface{}{
+			"startAt":    0,
+			"maxResults": len(histories),
+			"total":      len(histories),
+			"histories":  histories,
+		}
 	}
 	data, err := json.Marshal(body)
 	if err != nil {

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -2828,7 +2828,7 @@ function IntegrationsSection({ settings, onSave, saving, selectedWorkspace, hubP
               ) : activeTrackerType === "jira" ? (
                 <div className="space-y-2 text-sm text-muted-foreground">
                   <p>Connect Jira for this workspace. The token lets ElasticClaw read issues, add comments, and transition statuses.</p>
-                  <p>Create a Jira webhook for issue created and issue updated events, then use the payload URL below.</p>
+                  <p>Create a Jira Automation rule that sends a web request with the Issue data automation payload, then use the payload URL below.</p>
                 </div>
               ) : (
                 <p className="text-sm text-muted-foreground">
@@ -2856,7 +2856,7 @@ function IntegrationsSection({ settings, onSave, saving, selectedWorkspace, hubP
                         {copiedSetup === "jira-url" ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
                       </Button>
                     </div>
-                    <p className="text-xs text-muted-foreground mt-1">Use this URL for Jira issue created and issue updated webhooks.</p>
+                    <p className="text-xs text-muted-foreground mt-1">Use this URL from Jira Automation's Send web request action with the Issue data automation payload.</p>
                   </div>
                 </>
               )}


### PR DESCRIPTION
## Summary
- accept Atlassian Jira Automation Send web request Issue data payloads at the Jira webhook endpoint
- preserve support for native Jira webhook payloads
- tolerate string or numeric Jira issue id / updated values from Automation payloads
- update Jira setup UI copy to point users at the Automation Issue data payload

## Test
- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./pkg/hub
- npm run build (web)