### PR TITLE
Use Jira JQL search API for polling

### DIFF
--- a/pkg/hub/jira.go
+++ b/pkg/hub/jira.go
@@ -714,33 +714,46 @@ func (s *Server) queryJiraIssues(tracker workspaceIssueTracker, since time.Time,
 			jql = "project in (" + strings.Join(quoted, ",") + ") AND " + jql
 		}
 	}
-	body, _ := json.Marshal(map[string]any{
-		"jql":        jql,
-		"maxResults": 100,
-		"fields":     []string{"summary", "description", "status", "labels", "assignee", "project", "updated"},
-	})
-	req, err := http.NewRequest(http.MethodPost, base+"/rest/api/2/search", bytes.NewReader(body))
-	if err != nil {
-		return nil, err
+	var issues []jiraPollIssue
+	var nextPageToken string
+	for {
+		requestBody := map[string]any{
+			"jql":        jql,
+			"maxResults": 100,
+			"fields":     []string{"summary", "description", "status", "labels", "assignee", "project", "updated"},
+		}
+		if nextPageToken != "" {
+			requestBody["nextPageToken"] = nextPageToken
+		}
+		body, _ := json.Marshal(requestBody)
+		req, err := http.NewRequest(http.MethodPost, base+"/rest/api/3/search/jql", bytes.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		applyJiraAuth(req, tracker)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		respBody, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if resp.StatusCode >= 400 {
+			return nil, fmt.Errorf("jira API error %d: %s", resp.StatusCode, string(respBody))
+		}
+		var result struct {
+			Issues        []jiraPollIssue `json:"issues"`
+			NextPageToken string          `json:"nextPageToken"`
+		}
+		if err := json.Unmarshal(respBody, &result); err != nil {
+			return nil, err
+		}
+		issues = append(issues, result.Issues...)
+		nextPageToken = strings.TrimSpace(result.NextPageToken)
+		if nextPageToken == "" {
+			return issues, nil
+		}
 	}
-	req.Header.Set("Content-Type", "application/json")
-	applyJiraAuth(req, tracker)
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	respBody, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode >= 400 {
-		return nil, fmt.Errorf("jira API error %d: %s", resp.StatusCode, string(respBody))
-	}
-	var result struct {
-		Issues []jiraPollIssue `json:"issues"`
-	}
-	if err := json.Unmarshal(respBody, &result); err != nil {
-		return nil, err
-	}
-	return result.Issues, nil
 }
 
 func (s *Server) moveJiraIssue(tracker workspaceIssueTracker, key, targetStatus string) error {

--- a/pkg/hub/jira.go
+++ b/pkg/hub/jira.go
@@ -18,6 +18,8 @@ import (
 
 type jiraString string
 
+const jiraSearchMaxPages = 1000
+
 func (s *jiraString) UnmarshalJSON(data []byte) error {
 	if bytes.Equal(data, []byte("null")) {
 		*s = ""
@@ -716,7 +718,7 @@ func (s *Server) queryJiraIssues(tracker workspaceIssueTracker, since time.Time,
 	}
 	var issues []jiraPollIssue
 	var nextPageToken string
-	for {
+	for page := 0; page < jiraSearchMaxPages; page++ {
 		requestBody := map[string]any{
 			"jql":        jql,
 			"maxResults": 100,
@@ -749,11 +751,12 @@ func (s *Server) queryJiraIssues(tracker workspaceIssueTracker, since time.Time,
 			return nil, err
 		}
 		issues = append(issues, result.Issues...)
-		nextPageToken = strings.TrimSpace(result.NextPageToken)
+		nextPageToken = result.NextPageToken
 		if nextPageToken == "" {
 			return issues, nil
 		}
 	}
+	return nil, fmt.Errorf("jira search exceeded %d pages", jiraSearchMaxPages)
 }
 
 func (s *Server) moveJiraIssue(tracker workspaceIssueTracker, key, targetStatus string) error {

--- a/pkg/hub/jira_workflow_test.go
+++ b/pkg/hub/jira_workflow_test.go
@@ -218,6 +218,9 @@ func TestJiraWorkflowPollCreatesOnceForMissedWebhook(t *testing.T) {
 	if count != 1 {
 		t.Fatalf("poll created %d claws for the same Jira issue, want 1", count)
 	}
+	if got := jira.searchRequestTokens(); len(got) < 2 || got[0] != "" || got[1] != "next" {
+		t.Fatalf("Jira search nextPageToken requests = %#v, want first empty then next", got)
+	}
 }
 
 func TestJiraWorkflowExcludeLabelsBlockWebhook(t *testing.T) {
@@ -545,9 +548,17 @@ func jiraAutomationIssuePayloadWithHistories(t *testing.T, key, project, status 
 
 type mockJira struct {
 	*httptest.Server
-	mu       sync.Mutex
-	issue    map[string]interface{}
-	comments map[string][]string
+	mu             sync.Mutex
+	issue          map[string]interface{}
+	comments       map[string][]string
+	searchRequests []jiraSearchRequest
+}
+
+type jiraSearchRequest struct {
+	JQL           string   `json:"jql"`
+	MaxResults    int      `json:"maxResults"`
+	Fields        []string `json:"fields"`
+	NextPageToken string   `json:"nextPageToken"`
 }
 
 func newMockJira(t *testing.T) *mockJira {
@@ -555,9 +566,16 @@ func newMockJira(t *testing.T) *mockJira {
 	m := &mockJira{comments: map[string][]string{}}
 	m.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.Method == http.MethodPost && r.URL.Path == "/rest/api/2/search":
+		case r.Method == http.MethodPost && r.URL.Path == "/rest/api/3/search/jql":
+			var payload jiraSearchRequest
+			_ = json.NewDecoder(r.Body).Decode(&payload)
 			m.mu.Lock()
 			defer m.mu.Unlock()
+			m.searchRequests = append(m.searchRequests, payload)
+			if payload.NextPageToken == "" {
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{"issues": []interface{}{}, "nextPageToken": "next"})
+				return
+			}
 			_ = json.NewEncoder(w).Encode(map[string]interface{}{"issues": []interface{}{m.issue}})
 		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/rest/api/2/issue/") && strings.HasSuffix(r.URL.Path, "/comment"):
 			var payload struct {
@@ -581,6 +599,16 @@ func newMockJira(t *testing.T) *mockJira {
 	}))
 	t.Cleanup(m.Close)
 	return m
+}
+
+func (m *mockJira) searchRequestTokens() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	tokens := make([]string, 0, len(m.searchRequests))
+	for _, req := range m.searchRequests {
+		tokens = append(tokens, req.NextPageToken)
+	}
+	return tokens
 }
 
 func (m *mockJira) setIssue(key, project, status string, labels []string) {

--- a/pkg/hub/jira_workflow_test.go
+++ b/pkg/hub/jira_workflow_test.go
@@ -223,6 +223,31 @@ func TestJiraWorkflowPollCreatesOnceForMissedWebhook(t *testing.T) {
 	}
 }
 
+func TestJiraWorkflowPollStopsAfterSearchPageCap(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
+	jira := newMockJira(t)
+	jira.setSearchRepeatsToken(true)
+	cfg := jiraWorkflowTestConfig()
+	s, db := hub.NewTestServerWithConfig(t, cfg, "", "", "")
+	saveJiraWorkflowFixture(t, "workspace-a")
+	hub.SaveWorkspaceIssueTrackerWithBaseForTest(t, "workspace-a", "jira", "default", jira.URL, "", "jira-token", "")
+	jira.setIssue("EC-123", "EC", "Ready for Agent", []string{"agent"})
+
+	s.PollIntegrationsForTest()
+
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM claws WHERE jira_issue_id='EC-123'`).Scan(&count); err != nil {
+		t.Fatalf("count claws: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("poll created %d claws after capped Jira search, want 0", count)
+	}
+	if got := jira.searchRequestCount(); got != 1000 {
+		t.Fatalf("Jira search request count = %d, want 1000", got)
+	}
+}
+
 func TestJiraWorkflowExcludeLabelsBlockWebhook(t *testing.T) {
 	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
 	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
@@ -548,10 +573,11 @@ func jiraAutomationIssuePayloadWithHistories(t *testing.T, key, project, status 
 
 type mockJira struct {
 	*httptest.Server
-	mu             sync.Mutex
-	issue          map[string]interface{}
-	comments       map[string][]string
-	searchRequests []jiraSearchRequest
+	mu                sync.Mutex
+	issue             map[string]interface{}
+	comments          map[string][]string
+	searchRequests    []jiraSearchRequest
+	repeatSearchToken bool
 }
 
 type jiraSearchRequest struct {
@@ -572,6 +598,10 @@ func newMockJira(t *testing.T) *mockJira {
 			m.mu.Lock()
 			defer m.mu.Unlock()
 			m.searchRequests = append(m.searchRequests, payload)
+			if m.repeatSearchToken {
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{"issues": []interface{}{}, "nextPageToken": "same-token"})
+				return
+			}
 			if payload.NextPageToken == "" {
 				_ = json.NewEncoder(w).Encode(map[string]interface{}{"issues": []interface{}{}, "nextPageToken": "next"})
 				return
@@ -599,6 +629,18 @@ func newMockJira(t *testing.T) *mockJira {
 	}))
 	t.Cleanup(m.Close)
 	return m
+}
+
+func (m *mockJira) setSearchRepeatsToken(repeat bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.repeatSearchToken = repeat
+}
+
+func (m *mockJira) searchRequestCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.searchRequests)
 }
 
 func (m *mockJira) searchRequestTokens() []string {


### PR DESCRIPTION
## Summary
- move Jira polling from the removed /rest/api/2/search endpoint to /rest/api/3/search/jql
- support nextPageToken pagination for Jira search results
- update the Jira workflow poll test mock to validate the new endpoint and pagination token flow

## Verification
- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./pkg/hub

Fixes Jira Cloud 410 responses: "The requested API has been removed. Please migrate to the /rest/api/3/search/jql API."