### PR TITLE
Default to the sole configured sandbox provider

### DIFF
--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -672,11 +672,20 @@ func (s *Server) terminateClawForIssue(issueID string) {
 }
 
 func (s *Server) defaultProvider() string {
+	var singleName string
+	singleCount := 0
 	for name, p := range s.hubCfg.Providers {
 		// Only consider providers with real credentials, not Type-only stubs (e.g. noop)
 		if p.Token != "" || p.APIKey != "" || p.AccessToken != "" {
 			return name
 		}
+		if name != "noop" && p.Type != "noop" {
+			singleName = name
+			singleCount++
+		}
+	}
+	if singleCount == 1 {
+		return singleName
 	}
 	return ""
 }

--- a/pkg/hub/provider_precedence_test.go
+++ b/pkg/hub/provider_precedence_test.go
@@ -46,3 +46,66 @@ func TestResolveProviderPrecedence(t *testing.T) {
 		})
 	}
 }
+
+func TestDefaultProviderFallsBackToSingleConfiguredProvider(t *testing.T) {
+	cases := []struct {
+		name      string
+		provider  map[string]types.ProviderConfig
+		want      string
+		wantEmpty bool
+	}{
+		{
+			name: "single docker without credentials",
+			provider: map[string]types.ProviderConfig{
+				"docker": {},
+			},
+			want: "docker",
+		},
+		{
+			name: "single empty credentialed provider",
+			provider: map[string]types.ProviderConfig{
+				"daytona": {},
+			},
+			want: "daytona",
+		},
+		{
+			name: "credentialed provider wins over single-provider fallback",
+			provider: map[string]types.ProviderConfig{
+				"docker":  {},
+				"daytona": {APIKey: "daytona-key"},
+			},
+			want: "daytona",
+		},
+		{
+			name: "multiple credentialless providers do not guess",
+			provider: map[string]types.ProviderConfig{
+				"docker": {},
+				"exedev": {},
+			},
+			wantEmpty: true,
+		},
+		{
+			name: "noop stub is ignored",
+			provider: map[string]types.ProviderConfig{
+				"noop": {Type: "noop"},
+			},
+			wantEmpty: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &Server{hubCfg: &types.HubConfig{Providers: tc.provider}}
+			got := s.defaultProvider()
+			if tc.wantEmpty {
+				if got != "" {
+					t.Fatalf("defaultProvider() = %q, want empty", got)
+				}
+				return
+			}
+			if got != tc.want {
+				t.Fatalf("defaultProvider() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/hub/provider_precedence_test.go
+++ b/pkg/hub/provider_precedence_test.go
@@ -62,7 +62,7 @@ func TestDefaultProviderFallsBackToSingleConfiguredProvider(t *testing.T) {
 			want: "docker",
 		},
 		{
-			name: "single empty credentialed provider",
+			name: "single provider without credentials",
 			provider: map[string]types.ProviderConfig{
 				"daytona": {},
 			},
@@ -90,6 +90,14 @@ func TestDefaultProviderFallsBackToSingleConfiguredProvider(t *testing.T) {
 				"noop": {Type: "noop"},
 			},
 			wantEmpty: true,
+		},
+		{
+			name: "noop stub does not block single real provider fallback",
+			provider: map[string]types.ProviderConfig{
+				"noop":   {Type: "noop"},
+				"docker": {},
+			},
+			want: "docker",
 		},
 	}
 


### PR DESCRIPTION
## Summary
- make runtime provider fallback choose the only configured non-noop provider, even when it has no credentials
- keeps credentialed providers preferred when present
- preserves no-guess behavior when multiple credentialless providers are configured
- covers providers.docker: {} so workflows do not need provider: docker when Docker is the only sandbox provider

## Verification
- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./pkg/hub