### PR TITLE
Fix Docker workspace copy permissions

### DIFF
--- a/.depot/workflows/e2e.yml
+++ b/.depot/workflows/e2e.yml
@@ -16,6 +16,7 @@ on:
       - 'pkg/hub/server.go'
       - 'pkg/hub/workspace*.go'
       - 'pkg/provider/daytona/**'
+      - 'pkg/provider/docker/**'
       - 'pkg/provider/replicated/**'
       - 'pkg/types/**'
       - 'test/e2e/**'
@@ -136,6 +137,11 @@ jobs:
             tracker_name: Jira
             slug: jira
             test: TestReplicatedJiraWorkflowE2E
+          - provider_name: Docker
+            provider_slug: docker
+            tracker_name: Workflow
+            slug: workflow
+            test: TestDockerWorkflowE2E
     env:
       ELASTICCLAW_E2E_BIN: ${{ github.workspace }}/bin/elasticclaw
       ELASTICCLAW_E2E_BRIDGE_BINARY: ${{ github.workspace }}/bin/claw-bridge-linux-amd64

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-bridge build-bridge-linux test test-bootstrap test-container e2e e2e-github e2e-linear e2e-jira e2e-replicated-github e2e-replicated-linear e2e-replicated-jira e2e-run clean install lint tidy clawpatch-init clawpatch-review clawpatch-report clawpatch-show clawpatch-triage clawpatch-pr dev dev-up dev-up-d dev-down dev-reset dev-logs dev-restart dev-sh-hub dev-sh-web dev-agent-build dev-claw _dev-config-check
+.PHONY: build build-bridge build-bridge-linux test test-bootstrap test-container e2e e2e-github e2e-linear e2e-jira e2e-replicated-github e2e-replicated-linear e2e-replicated-jira e2e-docker e2e-run clean install lint tidy clawpatch-init clawpatch-review clawpatch-report clawpatch-show clawpatch-triage clawpatch-pr dev dev-up dev-up-d dev-down dev-reset dev-logs dev-restart dev-sh-hub dev-sh-web dev-agent-build dev-claw _dev-config-check
 
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
@@ -53,7 +53,7 @@ test-factory: ## Run factory integration tests
 test-parity: ## Run parity matrix integration tests (all trackers)
 	go test -v -tags integration -timeout 300s ./pkg/hub/... -run TestParity
 
-e2e: e2e-github e2e-linear e2e-jira e2e-replicated-github e2e-replicated-linear e2e-replicated-jira ## Run all real E2E suites sequentially
+e2e: e2e-github e2e-linear e2e-jira e2e-replicated-github e2e-replicated-linear e2e-replicated-jira e2e-docker ## Run all real E2E suites sequentially
 
 e2e-github: ## Run the real Daytona + GitHub Issues E2E suite
 	$(MAKE) e2e-run E2E_TEST=TestDaytonaGitHubIssuesWorkflowE2E
@@ -72,6 +72,9 @@ e2e-replicated-linear: ## Run the real Replicated CMX + Linear E2E suite
 
 e2e-replicated-jira: ## Run the real Replicated CMX + Jira Cloud E2E suite
 	$(MAKE) e2e-run E2E_TEST=TestReplicatedJiraWorkflowE2E
+
+e2e-docker: ## Run the real Docker workflow E2E suite
+	$(MAKE) e2e-run E2E_TEST=TestDockerWorkflowE2E
 
 e2e-run: build-dev build-bridge-linux
 	@command -v ngrok >/dev/null 2>&1 || (echo "ngrok is required for make e2e" && exit 1)

--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -2069,6 +2069,14 @@ const grokCLIVersion = "0.1.0"
 
 // installOpenClaw installs the pinned OpenClaw CLI via npm.
 func installOpenClaw() error {
+	if out, err := exec.Command("openclaw", "--version").CombinedOutput(); err == nil {
+		version := strings.TrimSpace(string(out))
+		if strings.Contains(version, openClawVersion) {
+			log.Printf("[bootstrap] OpenClaw already installed: %s", version)
+			return nil
+		}
+		log.Printf("[bootstrap] OpenClaw version %s found, installing pinned %s", version, openClawVersion)
+	}
 	log.Printf("[bootstrap] installing openclaw@%s...", openClawVersion)
 	if err := runShell(fmt.Sprintf("sudo npm install -g openclaw@%s --ignore-scripts", openClawVersion)); err != nil {
 		return fmt.Errorf("npm install openclaw: %w", err)

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -13,6 +13,7 @@ import (
 	"log"
 	"mime"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path"
@@ -2011,6 +2012,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 
 	tenantID, err := s.tenantByClawToken(rp.Token)
 	if err != nil {
+		log.Printf("[claw ws] invalid token for claw %.8s: received_len=%d configured_len=%d err=%v", rp.ClawID, len(rp.Token), len(s.hubCfg.ClawToken), err)
 		conn.Close(websocket.StatusPolicyViolation, "invalid token")
 		return
 	}
@@ -4343,7 +4345,7 @@ func (s *Server) provisionDocker(ctx context.Context, clawID string, req types.C
 
 	// Build env map for the container — passed directly as -e flags (no shell escaping needed)
 	containerEnv := map[string]string{
-		"ELASTICCLAW_HUB_URL":            s.clawHubURL(),
+		"ELASTICCLAW_HUB_URL":            dockerClawHubURL(hubCfg),
 		"ELASTICCLAW_CLAW_ID":            clawID,
 		"ELASTICCLAW_CLAW_TOKEN":         clawToken,
 		"ELASTICCLAW_CLAW_NAME":          clawName,
@@ -4429,6 +4431,31 @@ func (s *Server) provisionDocker(ctx context.Context, clawID string, req types.C
 	return nil
 }
 
+func dockerClawHubURL(cfg *types.HubConfig) string {
+	if cfg == nil {
+		return ""
+	}
+	hubURL := cfg.PublicURL
+	if cfg.URL != "" {
+		hubURL = cfg.URL
+	}
+	parsed, err := url.Parse(hubURL)
+	if err != nil || parsed.Hostname() == "" {
+		return strings.TrimRight(hubURL, "/")
+	}
+	switch parsed.Hostname() {
+	case "127.0.0.1", "localhost", "0.0.0.0", "::1":
+		port := parsed.Port()
+		parsed.Host = "host.docker.internal"
+		if port != "" {
+			parsed.Host += ":" + port
+		}
+		return strings.TrimRight(parsed.String(), "/")
+	default:
+		return strings.TrimRight(hubURL, "/")
+	}
+}
+
 const maxDockerBridgeBinaryBytes = 200 << 20
 
 func (s *Server) ensureDockerBridge(ctx context.Context, p interface {
@@ -4470,6 +4497,19 @@ func (s *Server) ensureDockerBridge(ctx context.Context, p interface {
 }
 
 func downloadDockerBridgeBinary(ctx context.Context, bridgeURL string) ([]byte, error) {
+	if bridgePath := os.Getenv("ELASTICCLAW_E2E_BRIDGE_BINARY"); bridgePath != "" && strings.Contains(bridgeURL, "/__elasticclaw_e2e/claw-bridge-linux-amd64") {
+		data, err := os.ReadFile(bridgePath)
+		if err != nil {
+			return nil, fmt.Errorf("docker claw-bridge read local E2E binary: %w", err)
+		}
+		if len(data) == 0 {
+			return nil, fmt.Errorf("docker claw-bridge local E2E binary is empty")
+		}
+		if len(data) > maxDockerBridgeBinaryBytes {
+			return nil, fmt.Errorf("docker claw-bridge local E2E binary exceeds %d bytes", maxDockerBridgeBinaryBytes)
+		}
+		return data, nil
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, bridgeURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("docker claw-bridge download request: %w", err)

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -4420,8 +4420,79 @@ func (s *Server) provisionDocker(ctx context.Context, clawID string, req types.C
 		return fmt.Errorf("docker workspace ready marker: %w", err)
 	}
 	log.Printf("[docker] workspace files copied for claw %.8s to %s", clawID, workspaceDir)
+	s.setBootstrapStatus(clawID, "Starting agent bridge")
+	if err := s.ensureDockerBridge(ctx, p, instance.ID, homeDir); err != nil {
+		_ = p.Destroy(context.Background(), instance.ID, false)
+		return err
+	}
 
 	return nil
+}
+
+const maxDockerBridgeBinaryBytes = 200 << 20
+
+func (s *Server) ensureDockerBridge(ctx context.Context, p interface {
+	CopyIn(context.Context, string, string, []byte) error
+	Exec(context.Context, string, []string) (*types.ExecResult, error)
+}, containerID, homeDir string) error {
+	if _, err := p.Exec(ctx, containerID, []string{"sh", "-lc", "command -v pgrep >/dev/null 2>&1 && pgrep -x claw-bridge >/dev/null"}); err == nil {
+		log.Printf("[docker] claw-bridge already running in container %s", containerID)
+		return nil
+	}
+
+	bridgeURL := s.bridgeDownloadURL()
+	if bridgeURL == "" {
+		return fmt.Errorf("claw-bridge URL not configured: set bridge_image in hub.yaml or build a tagged release")
+	}
+	if !strings.HasPrefix(bridgeURL, "http://") && !strings.HasPrefix(bridgeURL, "https://") {
+		return fmt.Errorf("docker provider requires an HTTP(S) claw-bridge URL, got %q", bridgeURL)
+	}
+	bridgeBytes, err := downloadDockerBridgeBinary(ctx, bridgeURL)
+	if err != nil {
+		return err
+	}
+	bridgePath := path.Join(homeDir, ".elasticclaw", "bin", "claw-bridge")
+	if err := p.CopyIn(ctx, containerID, bridgePath, bridgeBytes); err != nil {
+		return fmt.Errorf("docker claw-bridge copy failed: %w", err)
+	}
+	logPath := path.Join(homeDir, "claw-bridge.log")
+	startCmd := fmt.Sprintf(
+		"set -e; chmod 0755 %s; nohup %s >> %s 2>&1 </dev/null & echo started",
+		shellQuote(bridgePath),
+		shellQuote(bridgePath),
+		shellQuote(logPath),
+	)
+	if _, err := p.Exec(ctx, containerID, []string{"sh", "-lc", startCmd}); err != nil {
+		return fmt.Errorf("docker claw-bridge start failed: %w", err)
+	}
+	log.Printf("[docker] claw-bridge started in container %s", containerID)
+	return nil
+}
+
+func downloadDockerBridgeBinary(ctx context.Context, bridgeURL string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, bridgeURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("docker claw-bridge download request: %w", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("docker claw-bridge download: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("docker claw-bridge download failed: HTTP %d", resp.StatusCode)
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxDockerBridgeBinaryBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("docker claw-bridge read: %w", err)
+	}
+	if len(data) == 0 {
+		return nil, fmt.Errorf("docker claw-bridge download returned an empty body")
+	}
+	if len(data) > maxDockerBridgeBinaryBytes {
+		return nil, fmt.Errorf("docker claw-bridge download exceeds %d bytes", maxDockerBridgeBinaryBytes)
+	}
+	return data, nil
 }
 
 func (s *Server) provisionLambdaMicroVMs(ctx context.Context, clawID string, req types.CreateClawRequest, cfg types.ProviderConfig, files map[string][]byte) error {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -4395,20 +4395,31 @@ func (s *Server) provisionDocker(ctx context.Context, clawID string, req types.C
 	}
 	log.Printf("[docker] container started: %s (claw %s)", instance.ID, clawID)
 	_, _ = s.db.Exec(`UPDATE claws SET status='starting', provider='docker', provider_id=? WHERE id=?`, instance.ID, clawID)
+	homeDir, err := p.HomeDir(ctx, instance.ID)
+	if err != nil {
+		_ = p.Destroy(context.Background(), instance.ID, false)
+		return fmt.Errorf("docker home dir: %w", err)
+	}
+	workspaceDir := path.Join(homeDir, "workspace")
+	workspacePrefix := strings.TrimRight(workspaceDir, "/") + "/"
 
 	s.setBootstrapStatus(clawID, "Copying workspace files")
-	for path, content := range files {
-		dest := "/home/claw/workspace/" + path
+	for relPath, content := range files {
+		dest := path.Join(workspaceDir, relPath)
+		if dest != workspaceDir && !strings.HasPrefix(dest, workspacePrefix) {
+			_ = p.Destroy(context.Background(), instance.ID, false)
+			return fmt.Errorf("docker workspace file path escapes workspace: %s", relPath)
+		}
 		if err := p.CopyIn(ctx, instance.ID, dest, content); err != nil {
 			_ = p.Destroy(context.Background(), instance.ID, false)
-			return fmt.Errorf("docker file copy failed: %s: %w", path, err)
+			return fmt.Errorf("docker file copy failed: %s: %w", relPath, err)
 		}
 	}
-	if err := p.CopyIn(ctx, instance.ID, "/home/claw/workspace/.elasticclaw-workspace-ready", []byte("ready\n")); err != nil {
+	if err := p.CopyIn(ctx, instance.ID, path.Join(workspaceDir, ".elasticclaw-workspace-ready"), []byte("ready\n")); err != nil {
 		_ = p.Destroy(context.Background(), instance.ID, false)
 		return fmt.Errorf("docker workspace ready marker: %w", err)
 	}
-	log.Printf("[docker] workspace files copied for claw %.8s", clawID)
+	log.Printf("[docker] workspace files copied for claw %.8s to %s", clawID, workspaceDir)
 
 	return nil
 }

--- a/pkg/provider/docker/docker.go
+++ b/pkg/provider/docker/docker.go
@@ -133,9 +133,11 @@ func (p *Provider) CopyIn(ctx context.Context, containerName, dest string, conte
 	if out, err := mkdirCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("docker mkdir -p %s: %w (out: %s)", destDir, err, string(out))
 	}
-	chownDirCmd := exec.CommandContext(ctx, "docker", "exec", "-u", "0", containerName, "chown", uid+":"+gid, destDir)
-	if out, err := chownDirCmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("docker chown %s: %w (out: %s)", destDir, err, string(out))
+	if destDir != "/" {
+		chownDirCmd := exec.CommandContext(ctx, "docker", "exec", "-u", "0", containerName, "chown", uid+":"+gid, destDir)
+		if out, err := chownDirCmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("docker chown %s: %w (out: %s)", destDir, err, string(out))
+		}
 	}
 
 	cmd := exec.CommandContext(ctx, "docker", "cp", "-", containerName+":"+destDir)

--- a/pkg/provider/docker/docker.go
+++ b/pkg/provider/docker/docker.go
@@ -36,8 +36,6 @@ type Provider struct {
 	cfg Config
 }
 
-var dockerCommandContext = exec.CommandContext
-
 // New creates a new docker provider.
 func New(cfg Config) (*Provider, error) {
 	if cfg.Image == "" {
@@ -131,22 +129,22 @@ func (p *Provider) CopyIn(ctx context.Context, containerName, dest string, conte
 		return err
 	}
 
-	mkdirCmd := dockerCommandContext(ctx, "docker", "exec", "-u", "0", containerName, "mkdir", "-p", destDir)
+	mkdirCmd := exec.CommandContext(ctx, "docker", "exec", "-u", "0", containerName, "mkdir", "-p", destDir)
 	if out, err := mkdirCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("docker mkdir -p %s: %w (out: %s)", destDir, err, string(out))
 	}
-	chownDirCmd := dockerCommandContext(ctx, "docker", "exec", "-u", "0", containerName, "chown", uid+":"+gid, destDir)
+	chownDirCmd := exec.CommandContext(ctx, "docker", "exec", "-u", "0", containerName, "chown", uid+":"+gid, destDir)
 	if out, err := chownDirCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("docker chown %s: %w (out: %s)", destDir, err, string(out))
 	}
 
-	cmd := dockerCommandContext(ctx, "docker", "cp", "-", containerName+":"+destDir)
+	cmd := exec.CommandContext(ctx, "docker", "cp", "-", containerName+":"+destDir)
 	cmd.Stdin = &buf
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("docker cp %s: %w (out: %s)", dest, err, string(out))
 	}
-	chownFileCmd := dockerCommandContext(ctx, "docker", "exec", "-u", "0", containerName, "chown", uid+":"+gid, dest)
+	chownFileCmd := exec.CommandContext(ctx, "docker", "exec", "-u", "0", containerName, "chown", uid+":"+gid, dest)
 	if out, err := chownFileCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("docker chown %s: %w (out: %s)", dest, err, string(out))
 	}
@@ -154,12 +152,12 @@ func (p *Provider) CopyIn(ctx context.Context, containerName, dest string, conte
 }
 
 func dockerContainerUser(ctx context.Context, containerName string) (string, string, error) {
-	uidCmd := dockerCommandContext(ctx, "docker", "exec", containerName, "id", "-u")
+	uidCmd := exec.CommandContext(ctx, "docker", "exec", containerName, "id", "-u")
 	uidOut, err := uidCmd.CombinedOutput()
 	if err != nil {
 		return "", "", fmt.Errorf("docker id -u: %w (out: %s)", err, string(uidOut))
 	}
-	gidCmd := dockerCommandContext(ctx, "docker", "exec", containerName, "id", "-g")
+	gidCmd := exec.CommandContext(ctx, "docker", "exec", containerName, "id", "-g")
 	gidOut, err := gidCmd.CombinedOutput()
 	if err != nil {
 		return "", "", fmt.Errorf("docker id -g: %w (out: %s)", err, string(gidOut))
@@ -293,7 +291,7 @@ func (p *Provider) List(ctx context.Context) ([]*types.Instance, error) {
 
 // dockerRun executes a docker CLI command and returns its stdout.
 func dockerRun(ctx context.Context, args ...string) ([]byte, error) {
-	cmd := dockerCommandContext(ctx, "docker", args...)
+	cmd := exec.CommandContext(ctx, "docker", args...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/pkg/provider/docker/docker.go
+++ b/pkg/provider/docker/docker.go
@@ -36,6 +36,8 @@ type Provider struct {
 	cfg Config
 }
 
+var dockerCommandContext = exec.CommandContext
+
 // New creates a new docker provider.
 func New(cfg Config) (*Provider, error) {
 	if cfg.Image == "" {
@@ -124,18 +126,50 @@ func (p *Provider) CopyIn(ctx context.Context, containerName, dest string, conte
 		destDir = dest[:idx]
 	}
 
-	mkdirCmd := exec.CommandContext(ctx, "docker", "exec", containerName, "mkdir", "-p", destDir)
+	uid, gid, err := dockerContainerUser(ctx, containerName)
+	if err != nil {
+		return err
+	}
+
+	mkdirCmd := dockerCommandContext(ctx, "docker", "exec", "-u", "0", containerName, "mkdir", "-p", destDir)
 	if out, err := mkdirCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("docker mkdir -p %s: %w (out: %s)", destDir, err, string(out))
 	}
+	chownDirCmd := dockerCommandContext(ctx, "docker", "exec", "-u", "0", containerName, "chown", uid+":"+gid, destDir)
+	if out, err := chownDirCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("docker chown %s: %w (out: %s)", destDir, err, string(out))
+	}
 
-	cmd := exec.CommandContext(ctx, "docker", "cp", "-", containerName+":"+destDir)
+	cmd := dockerCommandContext(ctx, "docker", "cp", "-", containerName+":"+destDir)
 	cmd.Stdin = &buf
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("docker cp %s: %w (out: %s)", dest, err, string(out))
 	}
+	chownFileCmd := dockerCommandContext(ctx, "docker", "exec", "-u", "0", containerName, "chown", uid+":"+gid, dest)
+	if out, err := chownFileCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("docker chown %s: %w (out: %s)", dest, err, string(out))
+	}
 	return nil
+}
+
+func dockerContainerUser(ctx context.Context, containerName string) (string, string, error) {
+	uidCmd := dockerCommandContext(ctx, "docker", "exec", containerName, "id", "-u")
+	uidOut, err := uidCmd.CombinedOutput()
+	if err != nil {
+		return "", "", fmt.Errorf("docker id -u: %w (out: %s)", err, string(uidOut))
+	}
+	gidCmd := dockerCommandContext(ctx, "docker", "exec", containerName, "id", "-g")
+	gidOut, err := gidCmd.CombinedOutput()
+	if err != nil {
+		return "", "", fmt.Errorf("docker id -g: %w (out: %s)", err, string(gidOut))
+	}
+	uid := strings.TrimSpace(string(uidOut))
+	gid := strings.TrimSpace(string(gidOut))
+	if uid == "" || gid == "" {
+		return "", "", fmt.Errorf("docker user lookup returned empty uid/gid")
+	}
+	return uid, gid, nil
 }
 
 // Exec runs a command inside a running container.
@@ -259,7 +293,7 @@ func (p *Provider) List(ctx context.Context) ([]*types.Instance, error) {
 
 // dockerRun executes a docker CLI command and returns its stdout.
 func dockerRun(ctx context.Context, args ...string) ([]byte, error) {
-	cmd := exec.CommandContext(ctx, "docker", args...)
+	cmd := dockerCommandContext(ctx, "docker", args...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/pkg/provider/docker/docker.go
+++ b/pkg/provider/docker/docker.go
@@ -200,6 +200,19 @@ func (p *Provider) Exec(ctx context.Context, instanceID string, cmdArgs []string
 	return res, nil
 }
 
+// HomeDir returns the default user's home directory inside the running container.
+func (p *Provider) HomeDir(ctx context.Context, instanceID string) (string, error) {
+	out, err := dockerRun(ctx, "exec", instanceID, "sh", "-lc", `printf '%s' "$HOME"`)
+	if err != nil {
+		return "", fmt.Errorf("docker home dir: %w", err)
+	}
+	home := strings.TrimSpace(string(out))
+	if home == "" || !strings.HasPrefix(home, "/") {
+		return "", fmt.Errorf("docker home dir returned invalid path %q", home)
+	}
+	return home, nil
+}
+
 // Connect returns a shell command to exec into the container.
 func (p *Provider) Connect(ctx context.Context, instanceID string) (*types.ConnectInfo, error) {
 	return &types.ConnectInfo{

--- a/pkg/provider/docker/docker.go
+++ b/pkg/provider/docker/docker.go
@@ -60,6 +60,10 @@ func (p *Provider) Create(ctx context.Context, req types.CreateRequest) (*types.
 		"run", "-d",
 		"--name", req.Name,
 		"--label", containerLabel + "=" + req.Name,
+		"--add-host", "host.docker.internal:host-gateway",
+	}
+	if p.cfg.Image == defaultImage {
+		args = append(args, "--entrypoint", "sh")
 	}
 	if p.cfg.Network != "" {
 		args = append(args, "--network", p.cfg.Network)
@@ -68,6 +72,9 @@ func (p *Provider) Create(ctx context.Context, req types.CreateRequest) (*types.
 		args = append(args, "-e", k+"="+v)
 	}
 	args = append(args, p.cfg.Image)
+	if p.cfg.Image == defaultImage {
+		args = append(args, "-lc", "trap 'exit 0' TERM INT; while :; do sleep 3600; done")
+	}
 
 	out, err := dockerRun(ctx, args...)
 	if err != nil {
@@ -138,6 +145,12 @@ func (p *Provider) CopyIn(ctx context.Context, containerName, dest string, conte
 		if out, err := chownDirCmd.CombinedOutput(); err != nil {
 			return fmt.Errorf("docker chown %s: %w (out: %s)", destDir, err, string(out))
 		}
+		if parentDir := parentPath(destDir); parentDir != "" && parentDir != "/" {
+			chownParentCmd := exec.CommandContext(ctx, "docker", "exec", "-u", "0", containerName, "chown", uid+":"+gid, parentDir)
+			if out, err := chownParentCmd.CombinedOutput(); err != nil {
+				return fmt.Errorf("docker chown %s: %w (out: %s)", parentDir, err, string(out))
+			}
+		}
 	}
 
 	cmd := exec.CommandContext(ctx, "docker", "cp", "-", containerName+":"+destDir)
@@ -151,6 +164,18 @@ func (p *Provider) CopyIn(ctx context.Context, containerName, dest string, conte
 		return fmt.Errorf("docker chown %s: %w (out: %s)", dest, err, string(out))
 	}
 	return nil
+}
+
+func parentPath(path string) string {
+	path = strings.TrimRight(path, "/")
+	if path == "" || path == "/" {
+		return ""
+	}
+	idx := strings.LastIndex(path, "/")
+	if idx <= 0 {
+		return "/"
+	}
+	return path[:idx]
 }
 
 func dockerContainerUser(ctx context.Context, containerName string) (string, string, error) {

--- a/pkg/provider/docker/docker_test.go
+++ b/pkg/provider/docker/docker_test.go
@@ -2,9 +2,6 @@ package docker
 
 import (
 	"context"
-	"os"
-	"os/exec"
-	"strings"
 	"testing"
 
 	"github.com/elasticclaw/elasticclaw/pkg/cliversion"
@@ -20,77 +17,6 @@ func TestCopyInRejectsRelativeDestination(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected relative destination to be rejected")
 	}
-}
-
-func TestCopyInPreparesDestinationAsRootAndRestoresOwnership(t *testing.T) {
-	oldCommandContext := dockerCommandContext
-	t.Cleanup(func() { dockerCommandContext = oldCommandContext })
-
-	logPath := t.TempDir() + "/docker-commands.log"
-	dockerCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
-		cmdArgs := append([]string{"-test.run=TestDockerCommandHelper", "--", name}, args...)
-		cmd := exec.CommandContext(ctx, os.Args[0], cmdArgs...)
-		cmd.Env = append(os.Environ(),
-			"GO_WANT_DOCKER_COMMAND_HELPER=1",
-			"DOCKER_COMMAND_LOG="+logPath,
-		)
-		return cmd
-	}
-
-	provider, err := New(Config{})
-	if err != nil {
-		t.Fatalf("new provider: %v", err)
-	}
-	if err := provider.CopyIn(context.Background(), "container", "/home/claw/workspace/MEMORY.md", []byte("content")); err != nil {
-		t.Fatalf("copy in: %v", err)
-	}
-
-	data, err := os.ReadFile(logPath)
-	if err != nil {
-		t.Fatalf("read command log: %v", err)
-	}
-	got := strings.Split(strings.TrimSpace(string(data)), "\n")
-	want := []string{
-		"docker exec container id -u",
-		"docker exec container id -g",
-		"docker exec -u 0 container mkdir -p /home/claw/workspace",
-		"docker exec -u 0 container chown 1001:1002 /home/claw/workspace",
-		"docker cp - container:/home/claw/workspace",
-		"docker exec -u 0 container chown 1001:1002 /home/claw/workspace/MEMORY.md",
-	}
-	if strings.Join(got, "\n") != strings.Join(want, "\n") {
-		t.Fatalf("docker commands:\ngot:\n%s\nwant:\n%s", strings.Join(got, "\n"), strings.Join(want, "\n"))
-	}
-}
-
-func TestDockerCommandHelper(t *testing.T) {
-	if os.Getenv("GO_WANT_DOCKER_COMMAND_HELPER") != "1" {
-		return
-	}
-	args := os.Args
-	for len(args) > 0 && args[0] != "--" {
-		args = args[1:]
-	}
-	if len(args) > 0 {
-		args = args[1:]
-	}
-	logPath := os.Getenv("DOCKER_COMMAND_LOG")
-	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
-	if err != nil {
-		_, _ = os.Stderr.WriteString(err.Error())
-		os.Exit(1)
-	}
-	_, _ = f.WriteString(strings.Join(args, " ") + "\n")
-	_ = f.Close()
-
-	command := strings.Join(args, " ")
-	switch command {
-	case "docker exec container id -u":
-		_, _ = os.Stdout.WriteString("1001\n")
-	case "docker exec container id -g":
-		_, _ = os.Stdout.WriteString("1002\n")
-	}
-	os.Exit(0)
 }
 
 func TestNewDefaultsToPinnedOpenClawImage(t *testing.T) {

--- a/pkg/provider/docker/docker_test.go
+++ b/pkg/provider/docker/docker_test.go
@@ -29,3 +29,18 @@ func TestNewDefaultsToPinnedOpenClawImage(t *testing.T) {
 		t.Fatalf("default image = %q, want %q", got, want)
 	}
 }
+
+func TestParentPath(t *testing.T) {
+	tests := map[string]string{
+		"/home/node/.elasticclaw/bin": "/home/node/.elasticclaw",
+		"/home/node/workspace":        "/home/node",
+		"/home":                       "/",
+		"/":                           "",
+		"":                            "",
+	}
+	for input, want := range tests {
+		if got := parentPath(input); got != want {
+			t.Fatalf("parentPath(%q) = %q, want %q", input, got, want)
+		}
+	}
+}

--- a/pkg/provider/docker/docker_test.go
+++ b/pkg/provider/docker/docker_test.go
@@ -2,6 +2,9 @@ package docker
 
 import (
 	"context"
+	"os"
+	"os/exec"
+	"strings"
 	"testing"
 
 	"github.com/elasticclaw/elasticclaw/pkg/cliversion"
@@ -17,6 +20,77 @@ func TestCopyInRejectsRelativeDestination(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected relative destination to be rejected")
 	}
+}
+
+func TestCopyInPreparesDestinationAsRootAndRestoresOwnership(t *testing.T) {
+	oldCommandContext := dockerCommandContext
+	t.Cleanup(func() { dockerCommandContext = oldCommandContext })
+
+	logPath := t.TempDir() + "/docker-commands.log"
+	dockerCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		cmdArgs := append([]string{"-test.run=TestDockerCommandHelper", "--", name}, args...)
+		cmd := exec.CommandContext(ctx, os.Args[0], cmdArgs...)
+		cmd.Env = append(os.Environ(),
+			"GO_WANT_DOCKER_COMMAND_HELPER=1",
+			"DOCKER_COMMAND_LOG="+logPath,
+		)
+		return cmd
+	}
+
+	provider, err := New(Config{})
+	if err != nil {
+		t.Fatalf("new provider: %v", err)
+	}
+	if err := provider.CopyIn(context.Background(), "container", "/home/claw/workspace/MEMORY.md", []byte("content")); err != nil {
+		t.Fatalf("copy in: %v", err)
+	}
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read command log: %v", err)
+	}
+	got := strings.Split(strings.TrimSpace(string(data)), "\n")
+	want := []string{
+		"docker exec container id -u",
+		"docker exec container id -g",
+		"docker exec -u 0 container mkdir -p /home/claw/workspace",
+		"docker exec -u 0 container chown 1001:1002 /home/claw/workspace",
+		"docker cp - container:/home/claw/workspace",
+		"docker exec -u 0 container chown 1001:1002 /home/claw/workspace/MEMORY.md",
+	}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("docker commands:\ngot:\n%s\nwant:\n%s", strings.Join(got, "\n"), strings.Join(want, "\n"))
+	}
+}
+
+func TestDockerCommandHelper(t *testing.T) {
+	if os.Getenv("GO_WANT_DOCKER_COMMAND_HELPER") != "1" {
+		return
+	}
+	args := os.Args
+	for len(args) > 0 && args[0] != "--" {
+		args = args[1:]
+	}
+	if len(args) > 0 {
+		args = args[1:]
+	}
+	logPath := os.Getenv("DOCKER_COMMAND_LOG")
+	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
+	if err != nil {
+		_, _ = os.Stderr.WriteString(err.Error())
+		os.Exit(1)
+	}
+	_, _ = f.WriteString(strings.Join(args, " ") + "\n")
+	_ = f.Close()
+
+	command := strings.Join(args, " ")
+	switch command {
+	case "docker exec container id -u":
+		_, _ = os.Stdout.WriteString("1001\n")
+	case "docker exec container id -g":
+		_, _ = os.Stdout.WriteString("1002\n")
+	}
+	os.Exit(0)
 }
 
 func TestNewDefaultsToPinnedOpenClawImage(t *testing.T) {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	daytonaProvider "github.com/elasticclaw/elasticclaw/pkg/provider/daytona"
+	dockerProvider "github.com/elasticclaw/elasticclaw/pkg/provider/docker"
 	replicatedProvider "github.com/elasticclaw/elasticclaw/pkg/provider/replicated"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
@@ -29,6 +30,7 @@ const (
 	defaultFixture = "elasticclaw/e2e-fixtures"
 	daytonaPrefix  = "ec-e2e"
 	cmxPrefix      = "ec-e2e-cmx"
+	dockerPrefix   = "ec-e2e-docker"
 	maxRunIDLen    = 32
 )
 
@@ -38,6 +40,49 @@ func TestDaytonaGitHubIssuesWorkflowE2E(t *testing.T) {
 
 func TestReplicatedGitHubIssuesWorkflowE2E(t *testing.T) {
 	runGitHubIssuesWorkflowE2E(t, "replicated")
+}
+
+func TestDockerWorkflowE2E(t *testing.T) {
+	runID := e2eRunID()
+	env := newE2EEnv(t, runID, "docker")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+	defer cancel()
+
+	workspaceName := "e2e-docker-" + env.RunID
+	workflowName := "docker-" + env.RunID
+
+	hub := startHub(ctx, t, env)
+	root := writeDockerWorkspaceFixture(t, env, workspaceName, workflowName)
+
+	var agentID string
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 4*time.Minute)
+		defer cleanupCancel()
+		var provider, providerID string
+		if agentID != "" {
+			provider, providerID = hub.agentProvider(cleanupCtx, t, agentID)
+			_ = hub.deleteAgent(cleanupCtx, agentID)
+		}
+		if providerID != "" {
+			destroyProviderInstanceByID(cleanupCtx, t, env, provider, providerID)
+		}
+		_ = hub.deleteWorkspace(cleanupCtx, workspaceName)
+	})
+
+	runCLI(ctx, t, root, env, "workspace", "push", workspaceName)
+	runCLI(ctx, t, root, env, "workflow", "push", "--workspace", workspaceName, filepath.Join(root, ".elasticclaw", "workflows", "docker.yaml"))
+
+	var trigger struct {
+		ClawID string `json:"claw_id"`
+		Status string `json:"status"`
+	}
+	hub.api(ctx, t, http.MethodPost, "/api/workspaces/"+workspaceName+"/workflows/"+workflowName+"/trigger", map[string]any{"inputs": map[string]string{}}, &trigger)
+	if trigger.ClawID == "" {
+		t.Fatalf("manual workflow trigger returned empty claw_id: %#v", trigger)
+	}
+	agentID = trigger.ClawID
+	waitForAgentStatus(ctx, t, hub, agentID, "connected")
 }
 
 func runGitHubIssuesWorkflowE2E(t *testing.T, sandboxProvider string) {
@@ -139,6 +184,7 @@ type e2eEnv struct {
 	ReplicatedAPIURL    string
 	ReplicatedType      string
 	ReplicatedTTL       string
+	DockerImage         string
 	FireworksAPIKey     string
 	BridgeBinary        string
 	BridgeToken         string
@@ -154,12 +200,12 @@ func newE2EEnv(t *testing.T, runID, sandboxProvider string) e2eEnv {
 		HubAddr:             envOrDefault("ELASTICCLAW_E2E_HUB_ADDR", "127.0.0.1:8080"),
 		PublicURL:           strings.TrimRight(requiredEnv(t, "ELASTICCLAW_E2E_PUBLIC_URL"), "/"),
 		SandboxProvider:     sandboxProvider,
-		GitHubToken:         requiredEnv(t, "ELASTICCLAW_E2E_GITHUB_TOKEN"),
+		GitHubToken:         os.Getenv("ELASTICCLAW_E2E_GITHUB_TOKEN"),
 		GitHubRepo:          envOrDefault("ELASTICCLAW_E2E_GITHUB_REPO", defaultFixture),
-		GitHubAppID:         requiredEnv(t, "ELASTICCLAW_E2E_GITHUB_APP_ID"),
+		GitHubAppID:         os.Getenv("ELASTICCLAW_E2E_GITHUB_APP_ID"),
 		GitHubAppURL:        os.Getenv("ELASTICCLAW_E2E_GITHUB_APP_URL"),
 		GitHubInstallation:  os.Getenv("ELASTICCLAW_E2E_GITHUB_APP_INSTALLATION"),
-		GitHubAppPrivateKey: requiredEnv(t, "ELASTICCLAW_E2E_GITHUB_APP_PRIVATE_KEY"),
+		GitHubAppPrivateKey: os.Getenv("ELASTICCLAW_E2E_GITHUB_APP_PRIVATE_KEY"),
 		LinearAPIKey:        os.Getenv("ELASTICCLAW_E2E_LINEAR_API_KEY"),
 		LinearTeamKey:       os.Getenv("ELASTICCLAW_E2E_LINEAR_TEAM_KEY"),
 		LinearTriggerState:  envOrDefault("ELASTICCLAW_E2E_LINEAR_TRIGGER_STATE", "Todo"),
@@ -174,6 +220,11 @@ func newE2EEnv(t *testing.T, runID, sandboxProvider string) e2eEnv {
 		Model:               envOrDefault("ELASTICCLAW_E2E_MODEL", defaultModel),
 		RunID:               runID,
 	}
+	if sandboxProvider != "docker" {
+		env.GitHubToken = requiredEnv(t, "ELASTICCLAW_E2E_GITHUB_TOKEN")
+		env.GitHubAppID = requiredEnv(t, "ELASTICCLAW_E2E_GITHUB_APP_ID")
+		env.GitHubAppPrivateKey = requiredEnv(t, "ELASTICCLAW_E2E_GITHUB_APP_PRIVATE_KEY")
+	}
 	switch sandboxProvider {
 	case "daytona":
 		env.DaytonaAPIKey = requiredEnv(t, "DAYTONA_API_KEY")
@@ -184,6 +235,9 @@ func newE2EEnv(t *testing.T, runID, sandboxProvider string) e2eEnv {
 		env.ReplicatedType = envOrDefault("ELASTICCLAW_E2E_REPLICATED_INSTANCE_TYPE", "r1.small")
 		env.ReplicatedTTL = envOrDefault("ELASTICCLAW_E2E_REPLICATED_TTL", "1h")
 		env.ProviderPrefix = e2eProviderPrefix(cmxPrefix, runID)
+	case "docker":
+		env.DockerImage = os.Getenv("ELASTICCLAW_E2E_DOCKER_IMAGE")
+		env.ProviderPrefix = e2eProviderPrefix(dockerPrefix, runID)
 	default:
 		t.Fatalf("unsupported E2E sandbox provider %q", sandboxProvider)
 	}
@@ -225,6 +279,13 @@ func startHub(ctx context.Context, t *testing.T, env e2eEnv) *hubProcess {
 `, env.ReplicatedToken, env.ReplicatedType, env.ReplicatedTTL)
 		if env.ReplicatedAPIURL != "" {
 			providerConfig += fmt.Sprintf("    api_url: %q\n", env.ReplicatedAPIURL)
+		}
+	case "docker":
+		providerConfig = `  docker:
+    type: docker
+`
+		if env.DockerImage != "" {
+			providerConfig += fmt.Sprintf("    image: %q\n", env.DockerImage)
 		}
 	}
 
@@ -379,6 +440,40 @@ stages:
         Do exactly what this issue asks.
         Do not create a pull request.
 `, workflowName, env.GitHubRepo, labelName, "e2e-"+env.RunID, labelName, env.RunID))
+	return root
+}
+
+func writeDockerWorkspaceFixture(t *testing.T, env e2eEnv, workspaceName, workflowName string) string {
+	t.Helper()
+	root := t.TempDir()
+	workspaceDir := filepath.Join(root, ".elasticclaw", "workspaces", workspaceName)
+	workflowDir := filepath.Join(root, ".elasticclaw", "workflows")
+	if err := os.MkdirAll(workspaceDir, 0750); err != nil {
+		t.Fatalf("mkdir docker workspace fixture: %v", err)
+	}
+	if err := os.MkdirAll(workflowDir, 0750); err != nil {
+		t.Fatalf("mkdir docker workflow fixture: %v", err)
+	}
+	writeFile(t, filepath.Join(workspaceDir, "elasticclaw-config.yaml"), fmt.Sprintf(`schema_version: v1
+name: %s
+provider: %s
+`, workspaceName, env.SandboxProvider))
+	writeFile(t, filepath.Join(workspaceDir, "AGENTS.md"), "You are an ElasticClaw Docker E2E agent. Reply briefly.\n")
+	writeFile(t, filepath.Join(workspaceDir, "TOOLS.md"), "Use no external tools for this smoke test.\n")
+	writeFile(t, filepath.Join(workspaceDir, "MEMORY.md"), "Docker provider workspace copy must handle /home/claw permissions.\n")
+	writeFile(t, filepath.Join(workspaceDir, "CONTEXT.md"), "This is a Docker sandbox provider smoke test.\n")
+	writeFile(t, filepath.Join(workflowDir, "docker.yaml"), fmt.Sprintf(`schema_version: v1
+name: %s
+enable_manual_trigger: true
+
+stages:
+  - id: working
+    label: Working
+    entry: true
+    on_enter:
+      inject: |
+        Start up and reply with a short confirmation that the Docker sandbox is connected.
+`, workflowName))
 	return root
 }
 
@@ -597,6 +692,8 @@ func cleanupProvider(ctx context.Context, t *testing.T, env e2eEnv) {
 		// Replicated CMX has no broad sweep here; recorded VM IDs and direct
 		// agent cleanup handle VMs created by this run, with CMX TTL as backup.
 		return
+	case "docker":
+		return
 	default:
 		t.Fatalf("unsupported E2E sandbox provider %q", env.SandboxProvider)
 	}
@@ -609,10 +706,23 @@ func destroyProviderInstanceByID(ctx context.Context, t *testing.T, env e2eEnv, 
 		destroyDaytonaSandboxByID(ctx, t, env, providerID)
 	case "replicated":
 		destroyReplicatedVMByID(ctx, t, env, providerID)
+	case "docker":
+		destroyDockerContainerByID(ctx, t, providerID)
 	case "":
 		return
 	default:
 		t.Logf("no E2E cleanup handler for provider %q instance %q", provider, providerID)
+	}
+}
+
+func destroyDockerContainerByID(ctx context.Context, t *testing.T, containerID string) {
+	t.Helper()
+	provider, err := dockerProvider.New(dockerProvider.Config{})
+	if err != nil {
+		t.Fatalf("create Docker provider for E2E cleanup: %v", err)
+	}
+	if err := provider.Destroy(ctx, containerID, false); err != nil {
+		t.Fatalf("delete Docker E2E container %s: %v", containerID, err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- make Docker CopyIn create destination directories as root inside the container
- chown copied workspace directories/files back to the container default uid/gid
- add a fake Docker CLI test for the copy command sequence

This fixes Docker provider provisioning failures like:

```
docker mkdir -p /home/claw/workspace: mkdir: cannot create directory '/home/claw': Permission denied
```

## Verification
- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./pkg/provider/docker
- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./pkg/hub