### PR TITLE
Sync staged workspace files into OpenClaw workspace

### DIFF
--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -2500,8 +2500,14 @@ func syncStagedWorkspaceToOpenClawWorkspace() error {
 	}
 	stagedDir := filepath.Join(home, "workspace")
 	activeDir := filepath.Join(home, ".openclaw", "workspace")
-	stagedAbs, _ := filepath.Abs(stagedDir)
-	activeAbs, _ := filepath.Abs(activeDir)
+	stagedAbs, err := filepath.Abs(stagedDir)
+	if err != nil {
+		return fmt.Errorf("abs staged workspace: %w", err)
+	}
+	activeAbs, err := filepath.Abs(activeDir)
+	if err != nil {
+		return fmt.Errorf("abs OpenClaw workspace: %w", err)
+	}
 	if stagedAbs == activeAbs {
 		return nil
 	}
@@ -2528,6 +2534,10 @@ func syncStagedWorkspaceToOpenClawWorkspace() error {
 			return err
 		}
 		if rel == "." || rel == ".elasticclaw-workspace-ready" {
+			return nil
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			log.Printf("[bootstrap] skipping workspace symlink %s", src)
 			return nil
 		}
 		dst := filepath.Join(activeDir, rel)

--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -2478,6 +2478,77 @@ func waitForWorkspaceReadyIfRequested() error {
 	return fmt.Errorf("workspace files not ready after 300s")
 }
 
+var managedWorkspaceFiles = []string{
+	"elasticclaw-config.yaml",
+	"SOUL.md",
+	"AGENTS.md",
+	"TOOLS.md",
+	"IDENTITY.md",
+	"USER.md",
+	"MEMORY.md",
+	"BOOTSTRAP.md",
+	"HEARTBEAT.md",
+	"CONTEXT.md",
+	"SECRETS.md",
+	"TRIGGER_INPUTS.json",
+}
+
+func syncStagedWorkspaceToOpenClawWorkspace() error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("home dir: %w", err)
+	}
+	stagedDir := filepath.Join(home, "workspace")
+	activeDir := filepath.Join(home, ".openclaw", "workspace")
+	stagedAbs, _ := filepath.Abs(stagedDir)
+	activeAbs, _ := filepath.Abs(activeDir)
+	if stagedAbs == activeAbs {
+		return nil
+	}
+	if _, err := os.Stat(stagedDir); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("stat staged workspace: %w", err)
+	}
+	if err := os.MkdirAll(activeDir, 0755); err != nil {
+		return fmt.Errorf("create OpenClaw workspace: %w", err)
+	}
+	for _, name := range managedWorkspaceFiles {
+		if err := os.RemoveAll(filepath.Join(activeDir, name)); err != nil {
+			return fmt.Errorf("remove stale OpenClaw workspace file %s: %w", name, err)
+		}
+	}
+	if err := filepath.Walk(stagedDir, func(src string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(stagedDir, src)
+		if err != nil {
+			return err
+		}
+		if rel == "." || rel == ".elasticclaw-workspace-ready" {
+			return nil
+		}
+		dst := filepath.Join(activeDir, rel)
+		if info.IsDir() {
+			return os.MkdirAll(dst, info.Mode().Perm())
+		}
+		data, err := os.ReadFile(src)
+		if err != nil {
+			return err
+		}
+		if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+			return err
+		}
+		return os.WriteFile(dst, data, info.Mode().Perm())
+	}); err != nil {
+		return fmt.Errorf("sync OpenClaw workspace: %w", err)
+	}
+	log.Printf("[bootstrap] synced workspace files to %s", activeDir)
+	return nil
+}
+
 // runBootstrap executes all VM bootstrap steps, then returns so the caller
 // can continue into the normal bridge connect loop.
 func runBootstrap() error {
@@ -2534,6 +2605,9 @@ func runBootstrap() error {
 		}
 	} else {
 		log.Printf("[bootstrap] openclaw.json already exists, skipping onboard")
+	}
+	if err := syncStagedWorkspaceToOpenClawWorkspace(); err != nil {
+		return fmt.Errorf("syncStagedWorkspaceToOpenClawWorkspace: %w", err)
 	}
 
 	if err := syncOpenClawAPIKeyAuth(); err != nil {

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -120,6 +120,52 @@ func TestWaitForWorkspaceReadyIfRequested(t *testing.T) {
 	}
 }
 
+func TestSyncStagedWorkspaceToOpenClawWorkspace(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	staged := filepath.Join(home, "workspace")
+	active := filepath.Join(home, ".openclaw", "workspace")
+	if err := os.MkdirAll(filepath.Join(staged, "scripts"), 0700); err != nil {
+		t.Fatalf("mkdir staged workspace: %v", err)
+	}
+	if err := os.MkdirAll(active, 0700); err != nil {
+		t.Fatalf("mkdir active workspace: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(staged, "AGENTS.md"), []byte("elasticclaw instructions\n"), 0600); err != nil {
+		t.Fatalf("write staged AGENTS.md: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(staged, "scripts", "check.sh"), []byte("#!/bin/sh\n"), 0700); err != nil {
+		t.Fatalf("write staged script: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(staged, ".elasticclaw-workspace-ready"), []byte("ready\n"), 0600); err != nil {
+		t.Fatalf("write ready marker: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(active, "BOOTSTRAP.md"), []byte("default openclaw bootstrap\n"), 0600); err != nil {
+		t.Fatalf("write stale BOOTSTRAP.md: %v", err)
+	}
+
+	if err := syncStagedWorkspaceToOpenClawWorkspace(); err != nil {
+		t.Fatalf("syncStagedWorkspaceToOpenClawWorkspace(): %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(active, "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("read synced AGENTS.md: %v", err)
+	}
+	if string(data) != "elasticclaw instructions\n" {
+		t.Fatalf("AGENTS.md = %q", string(data))
+	}
+	if _, err := os.Stat(filepath.Join(active, "BOOTSTRAP.md")); !os.IsNotExist(err) {
+		t.Fatalf("BOOTSTRAP.md should have been removed, err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(active, ".elasticclaw-workspace-ready")); !os.IsNotExist(err) {
+		t.Fatalf("ready marker should not be copied, err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(active, "scripts", "check.sh")); err != nil {
+		t.Fatalf("script was not copied: %v", err)
+	}
+}
+
 func TestNestedStringExtractsToolCommandDetails(t *testing.T) {
 	tests := []struct {
 		name string

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -137,6 +137,9 @@ func TestSyncStagedWorkspaceToOpenClawWorkspace(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(staged, "scripts", "check.sh"), []byte("#!/bin/sh\n"), 0700); err != nil {
 		t.Fatalf("write staged script: %v", err)
 	}
+	if err := os.Symlink(filepath.Join(staged, "scripts"), filepath.Join(staged, "linked-scripts")); err != nil {
+		t.Fatalf("write staged symlink: %v", err)
+	}
 	if err := os.WriteFile(filepath.Join(staged, ".elasticclaw-workspace-ready"), []byte("ready\n"), 0600); err != nil {
 		t.Fatalf("write ready marker: %v", err)
 	}
@@ -163,6 +166,9 @@ func TestSyncStagedWorkspaceToOpenClawWorkspace(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(active, "scripts", "check.sh")); err != nil {
 		t.Fatalf("script was not copied: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(active, "linked-scripts")); !os.IsNotExist(err) {
+		t.Fatalf("symlink should not be copied, err=%v", err)
 	}
 }
 

--- a/pkg/provider/docker/docker.go
+++ b/pkg/provider/docker/docker.go
@@ -288,6 +288,9 @@ func (p *Provider) Destroy(ctx context.Context, instanceID string, keepState boo
 		if strings.Contains(err.Error(), "No such") || strings.Contains(err.Error(), "not found") {
 			return nil // already gone
 		}
+		if strings.Contains(err.Error(), "removal of container") && strings.Contains(err.Error(), "is already in progress") {
+			return nil
+		}
 		return fmt.Errorf("docker rm: %w", err)
 	}
 	return nil

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -662,11 +662,47 @@ func waitForAgentStatus(ctx context.Context, t *testing.T, hub *hubProcess, agen
 			return
 		}
 		if agent.Status == "error" {
+			logAgentProviderDiagnostics(ctx, t, hub, agentID)
 			t.Fatalf("agent %s entered error state", agentID)
 		}
 		time.Sleep(5 * time.Second)
 	}
+	logAgentProviderDiagnostics(ctx, t, hub, agentID)
 	t.Fatalf("timed out waiting for agent %s status %q", agentID, want)
+}
+
+func logAgentProviderDiagnostics(ctx context.Context, t *testing.T, hub *hubProcess, agentID string) {
+	t.Helper()
+	provider, providerID := hub.agentProvider(ctx, t, agentID)
+	if provider != "docker" || providerID == "" {
+		return
+	}
+	logDockerContainerDiagnostics(ctx, t, providerID)
+}
+
+func logDockerContainerDiagnostics(ctx context.Context, t *testing.T, containerID string) {
+	t.Helper()
+	commands := []struct {
+		name string
+		args []string
+	}{
+		{"docker inspect", []string{"inspect", "-f", "{{.State.Status}} {{.State.ExitCode}} {{.State.Error}}", containerID}},
+		{"docker ps", []string{"ps", "-a", "--filter", "name=" + containerID, "--format", "{{.Names}}\t{{.Status}}\t{{.Image}}"}},
+		{"docker bridge log", []string{"exec", containerID, "sh", "-lc", "tail -n 200 \"$HOME/claw-bridge.log\" 2>/dev/null || true"}},
+		{"docker gateway log", []string{"exec", containerID, "sh", "-lc", "tail -n 120 \"$HOME/openclaw-gateway.log\" 2>/dev/null || true"}},
+		{"docker workspace files", []string{"exec", containerID, "sh", "-lc", "find \"$HOME/workspace\" \"$HOME/.openclaw/workspace\" -maxdepth 2 -type f -print 2>/dev/null | sort || true"}},
+	}
+	for _, command := range commands {
+		cmd := exec.CommandContext(ctx, "docker", command.args...)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Logf("%s failed: %v\n%s", command.name, err, strings.TrimSpace(string(out)))
+			continue
+		}
+		if text := strings.TrimSpace(string(out)); text != "" {
+			t.Logf("%s:\n%s", command.name, text)
+		}
+	}
 }
 
 func waitForAgentReply(ctx context.Context, t *testing.T, hub *hubProcess, agentID string) {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -314,7 +314,7 @@ llm_keys:
 	}
 	t.Cleanup(func() { _ = logFile.Close() })
 
-	cmd := exec.Command(env.Bin, "hub", "--addr", env.HubAddr, "--db", dbPath, "--no-web-ui")
+	cmd := exec.Command(env.Bin, "hub", "--addr", hubListenAddr(env), "--db", dbPath, "--no-web-ui")
 	cmd.Env = append(os.Environ(),
 		"ELASTICCLAW_HUB_CONFIG="+configPath,
 		"DAYTONA_API_KEY="+env.DaytonaAPIKey,
@@ -1212,6 +1212,22 @@ func envOrDefault(name, fallback string) string {
 		return value
 	}
 	return fallback
+}
+
+func hubListenAddr(env e2eEnv) string {
+	if env.SandboxProvider != "docker" {
+		return env.HubAddr
+	}
+	host, port, ok := strings.Cut(env.HubAddr, ":")
+	if !ok || port == "" {
+		return env.HubAddr
+	}
+	switch host {
+	case "127.0.0.1", "localhost", "0.0.0.0":
+		return "0.0.0.0:" + port
+	default:
+		return env.HubAddr
+	}
 }
 
 func e2eRunID() string {


### PR DESCRIPTION
## Summary
- mirror ElasticClaw staged workspace files into OpenClaw's active ~/.openclaw/workspace during bridge bootstrap
- remove stale managed instruction files such as OpenClaw's default BOOTSTRAP.md before copying staged files
- make Docker container destroy idempotent when removal is already in progress

## Verification
- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./cmd/claw-bridge ./pkg/provider/docker
- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./pkg/hub
- source ~/elasticclaw-e2e-secrets.sh && make e2e-docker