### PR TITLE
Support issue label stage skips

### DIFF
--- a/pkg/hub/github_issues.go
+++ b/pkg/hub/github_issues.go
@@ -563,10 +563,12 @@ func (s *Server) createClawForGitHubIssueWorkflow(workspace *types.WorkspaceConf
 	}
 
 	clawID, _, err := s.createClawFromWorkflowWithOptions(workspace, workflow, workflowCreateOptions{
-		workspaceFiles: templateFiles,
-		clawName:       clawName,
-		githubIssueID:  issueID,
-		reason:         reason,
+		workspaceFiles:       templateFiles,
+		clawName:             clawName,
+		githubIssueID:        issueID,
+		issueLabels:          githubIssuePayloadLabels(payload),
+		issueLabelsAvailable: true,
+		reason:               reason,
 		triggerActor: &triggerActor{
 			Login: payload.Sender.Login,
 			Type:  payload.Sender.Type,
@@ -584,6 +586,14 @@ func (s *Server) createClawForGitHubIssueWorkflow(workspace *types.WorkspaceConf
 	}
 	claimOpen = false
 	return clawID, true, nil
+}
+
+func githubIssuePayloadLabels(payload githubIssuesWebhookPayload) []string {
+	labels := make([]string, 0, len(payload.Issue.Labels))
+	for _, label := range payload.Issue.Labels {
+		labels = append(labels, label.Name)
+	}
+	return labels
 }
 
 func (s *Server) createClawForGitHubIssue(factory *types.FactoryConfig, payload githubIssuesWebhookPayload, reason string) error {

--- a/pkg/hub/jira.go
+++ b/pkg/hub/jira.go
@@ -480,10 +480,12 @@ func (s *Server) createClawForJiraWorkflow(workspace *types.WorkspaceConfig, wor
 		clawName = strings.ReplaceAll(clawName, "{project}", payload.Issue.Fields.Project.Key)
 	}
 	clawID, isPending, err := s.createClawFromWorkflowWithOptions(workspace, workflow, workflowCreateOptions{
-		workspaceFiles: templateFiles,
-		clawName:       clawName,
-		jiraIssueID:    issueID,
-		reason:         reason,
+		workspaceFiles:       templateFiles,
+		clawName:             clawName,
+		jiraIssueID:          issueID,
+		issueLabels:          jiraIssueLabels(payload.Issue),
+		issueLabelsAvailable: true,
+		reason:               reason,
 		triggerActor: &triggerActor{
 			ID:    firstNonEmpty(payload.User.AccountID, payload.User.Name, payload.User.Key),
 			Type:  "User",

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -477,10 +477,12 @@ func (s *Server) createClawForLinearWorkflow(workspace *types.WorkspaceConfig, w
 	}
 
 	clawID, isPending, err := s.createClawFromWorkflowWithOptions(workspace, workflow, workflowCreateOptions{
-		workspaceFiles: templateFiles,
-		clawName:       clawName,
-		linearIssueID:  issueID,
-		reason:         reason,
+		workspaceFiles:       templateFiles,
+		clawName:             clawName,
+		linearIssueID:        issueID,
+		issueLabels:          linearPayloadLabels(payload),
+		issueLabelsAvailable: true,
+		reason:               reason,
 		triggerActor: &triggerActor{
 			ID:    payload.Actor.ID,
 			Type:  payload.Actor.Type,
@@ -509,6 +511,14 @@ func (s *Server) createClawForLinearWorkflow(workspace *types.WorkspaceConfig, w
 	}
 	log.Printf("[workflow:%s/%s] created claw %s for Linear issue %s", workspace.Name, workflow.Name, clawID[:8], issueID)
 	return nil
+}
+
+func linearPayloadLabels(payload linearWebhookPayload) []string {
+	labels := make([]string, 0, len(payload.Data.Labels))
+	for _, label := range payload.Data.Labels {
+		labels = append(labels, label.Name)
+	}
+	return labels
 }
 
 func (s *Server) createClawForIssue(factory *types.FactoryConfig, payload linearWebhookPayload, reason string) error {

--- a/pkg/hub/pipeline/pipeline.go
+++ b/pkg/hub/pipeline/pipeline.go
@@ -14,17 +14,31 @@ type Pipeline struct {
 
 // Stage represents a single stage in the pipeline.
 type Stage struct {
-	ID       string    `yaml:"id"`
-	Label    string    `yaml:"label"`
-	Entry    bool      `yaml:"entry"`
-	Terminal bool      `yaml:"terminal"`
-	Triggers []Trigger `yaml:"triggers"`
-	OnEnter  OnEnter   `yaml:"on_enter"`
+	ID         string     `yaml:"id"`
+	Label      string     `yaml:"label"`
+	Entry      bool       `yaml:"entry"`
+	Terminal   bool       `yaml:"terminal"`
+	Triggers   []Trigger  `yaml:"triggers"`
+	OnEnter    OnEnter    `yaml:"on_enter"`
+	SkipIf     *StageSkip `yaml:"skip_if,omitempty"`
+	SkipUnless *StageSkip `yaml:"skip_unless,omitempty"`
 	// Gate defines a deterministic review gate evaluated after the stage's
 	// on_enter actions complete. The gate inspects a named output (from a
 	// prior run action) and produces a pass/fail verdict that can drive
 	// automatic stage transitions via gate_result triggers.
 	Gate *Gate `yaml:"gate,omitempty"`
+}
+
+// StageSkip defines a pre-enter stage skip rule. When the condition evaluates
+// to true, the runner enters GoTo instead of the current stage.
+type StageSkip struct {
+	IssueLabels *IssueLabelsSkip `yaml:"issue_labels,omitempty"`
+	GoTo        string           `yaml:"go_to"`
+}
+
+// IssueLabelsSkip matches when the issue has any configured label.
+type IssueLabelsSkip struct {
+	Labels []string `yaml:"labels"`
 }
 
 // Trigger defines a condition that causes a transition into the parent stage.
@@ -338,13 +352,126 @@ func Parse(yamlBytes []byte) (*Pipeline, error) {
 	if err := yaml.Unmarshal(yamlBytes, &p); err != nil {
 		return nil, fmt.Errorf("pipeline YAML parse error: %w (hint: template expressions like {{.Issue.Identifier}} must be quoted when used as inline values, e.g. issue_id: \"{{.Issue.Identifier}}\"; literal blocks do not need quoting)", err)
 	}
+	if err := p.Validate(); err != nil {
+		return nil, err
+	}
 	return &p, nil
+}
+
+// Validate checks pipeline-level invariants needed by the runner.
+func (p *Pipeline) Validate() error {
+	if p == nil {
+		return nil
+	}
+	stageIDs := make(map[string]bool, len(p.Stages))
+	for _, stage := range p.Stages {
+		if strings.TrimSpace(stage.ID) != "" {
+			stageIDs[stage.ID] = true
+		}
+	}
+	skipEdges := make(map[string][]string)
+	for _, stage := range p.Stages {
+		for _, skip := range []struct {
+			name string
+			rule *StageSkip
+		}{
+			{name: "skip_if", rule: stage.SkipIf},
+			{name: "skip_unless", rule: stage.SkipUnless},
+		} {
+			if skip.rule == nil {
+				continue
+			}
+			if err := validateStageSkipRule(stage.ID, skip.name, skip.rule, stageIDs); err != nil {
+				return err
+			}
+			skipEdges[stage.ID] = append(skipEdges[stage.ID], skip.rule.GoTo)
+		}
+	}
+	if cycle := firstSkipCycle(skipEdges); len(cycle) > 0 {
+		return fmt.Errorf("pipeline skip cycle detected: %s", strings.Join(cycle, " -> "))
+	}
+	return nil
+}
+
+func validateStageSkipRule(stageID, name string, rule *StageSkip, stageIDs map[string]bool) error {
+	goTo := strings.TrimSpace(rule.GoTo)
+	if goTo == "" {
+		return fmt.Errorf("stage %q %s go_to is required", stageID, name)
+	}
+	if goTo == stageID {
+		return fmt.Errorf("stage %q %s go_to cannot point to itself", stageID, name)
+	}
+	if !stageIDs[goTo] {
+		return fmt.Errorf("stage %q %s go_to %q does not reference an existing stage", stageID, name, goTo)
+	}
+	if rule.IssueLabels == nil {
+		return fmt.Errorf("stage %q %s issue_labels is required", stageID, name)
+	}
+	if len(rule.IssueLabels.Labels) == 0 {
+		return fmt.Errorf("stage %q %s issue_labels labels cannot be empty", stageID, name)
+	}
+	for i, label := range rule.IssueLabels.Labels {
+		if strings.TrimSpace(label) == "" {
+			return fmt.Errorf("stage %q %s issue_labels labels[%d] cannot be blank", stageID, name, i)
+		}
+	}
+	return nil
+}
+
+func firstSkipCycle(edges map[string][]string) []string {
+	const (
+		unvisited = 0
+		visiting  = 1
+		visited   = 2
+	)
+	state := map[string]int{}
+	var stack []string
+	var visit func(string) []string
+	visit = func(stageID string) []string {
+		state[stageID] = visiting
+		stack = append(stack, stageID)
+		for _, next := range edges[stageID] {
+			switch state[next] {
+			case visiting:
+				for i, id := range stack {
+					if id == next {
+						return append(append([]string(nil), stack[i:]...), next)
+					}
+				}
+			case unvisited:
+				if cycle := visit(next); len(cycle) > 0 {
+					return cycle
+				}
+			}
+		}
+		stack = stack[:len(stack)-1]
+		state[stageID] = visited
+		return nil
+	}
+	for stageID := range edges {
+		if state[stageID] == unvisited {
+			if cycle := visit(stageID); len(cycle) > 0 {
+				return cycle
+			}
+		}
+	}
+	return nil
 }
 
 // EntryStage returns the first stage marked entry:true, or nil if none.
 func (p *Pipeline) EntryStage() *Stage {
 	for i := range p.Stages {
 		if p.Stages[i].Entry {
+			return &p.Stages[i]
+		}
+	}
+	return nil
+}
+
+// StageByID returns the stage with the given ID, or nil if none exists.
+func (p *Pipeline) StageByID(id string) *Stage {
+	for i := range p.Stages {
+		if p.Stages[i].ID == id {
 			return &p.Stages[i]
 		}
 	}

--- a/pkg/hub/pipeline/pipeline_test.go
+++ b/pkg/hub/pipeline/pipeline_test.go
@@ -1,6 +1,7 @@
 package pipeline_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/elasticclaw/elasticclaw/pkg/hub/pipeline"
@@ -46,6 +47,131 @@ func TestParse(t *testing.T) {
 	}
 	if len(p.Stages) != 4 {
 		t.Fatalf("expected 4 stages, got %d", len(p.Stages))
+	}
+}
+
+func TestParseStageIssueLabelSkips(t *testing.T) {
+	p, err := pipeline.Parse([]byte(`
+stages:
+  - id: review_loop
+    skip_if:
+      issue_labels:
+        labels:
+          - no review loop
+      go_to: detect_android_changes
+    skip_unless:
+      issue_labels:
+        labels:
+          - with review loop
+      go_to: detect_android_changes
+  - id: detect_android_changes
+`))
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	stage := p.Stages[0]
+	if stage.SkipIf == nil || stage.SkipIf.IssueLabels == nil {
+		t.Fatalf("expected skip_if issue_labels to parse: %#v", stage.SkipIf)
+	}
+	if got := stage.SkipIf.IssueLabels.Labels; len(got) != 1 || got[0] != "no review loop" {
+		t.Fatalf("skip_if labels = %#v, want [no review loop]", got)
+	}
+	if stage.SkipIf.GoTo != "detect_android_changes" {
+		t.Fatalf("skip_if go_to = %q, want detect_android_changes", stage.SkipIf.GoTo)
+	}
+	if stage.SkipUnless == nil || stage.SkipUnless.IssueLabels == nil {
+		t.Fatalf("expected skip_unless issue_labels to parse: %#v", stage.SkipUnless)
+	}
+	if got := stage.SkipUnless.IssueLabels.Labels; len(got) != 1 || got[0] != "with review loop" {
+		t.Fatalf("skip_unless labels = %#v, want [with review loop]", got)
+	}
+	if stage.SkipUnless.GoTo != "detect_android_changes" {
+		t.Fatalf("skip_unless go_to = %q, want detect_android_changes", stage.SkipUnless.GoTo)
+	}
+}
+
+func TestParseRejectsInvalidStageIssueLabelSkips(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		want string
+	}{
+		{
+			name: "go_to missing",
+			yaml: `
+stages:
+  - id: review_loop
+    skip_if:
+      issue_labels:
+        labels: [no review loop]
+`,
+			want: "go_to",
+		},
+		{
+			name: "unknown go_to",
+			yaml: `
+stages:
+  - id: review_loop
+    skip_if:
+      issue_labels:
+        labels: [no review loop]
+      go_to: missing
+`,
+			want: "missing",
+		},
+		{
+			name: "self go_to",
+			yaml: `
+stages:
+  - id: review_loop
+    skip_if:
+      issue_labels:
+        labels: [no review loop]
+      go_to: review_loop
+`,
+			want: "itself",
+		},
+		{
+			name: "skip cycle",
+			yaml: `
+stages:
+  - id: review_loop
+    skip_if:
+      issue_labels:
+        labels: [no review loop]
+      go_to: detect_android_changes
+  - id: detect_android_changes
+    skip_unless:
+      issue_labels:
+        labels: [with android changes]
+      go_to: review_loop
+`,
+			want: "cycle",
+		},
+		{
+			name: "empty labels",
+			yaml: `
+stages:
+  - id: review_loop
+    skip_if:
+      issue_labels:
+        labels: []
+      go_to: detect_android_changes
+  - id: detect_android_changes
+`,
+			want: "labels",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := pipeline.Parse([]byte(tt.yaml))
+			if err == nil {
+				t.Fatalf("Parse succeeded, want error containing %q", tt.want)
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Parse error = %v, want containing %q", err, tt.want)
+			}
+		})
 	}
 }
 

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -1448,6 +1448,10 @@ func (s *Server) pipelineStageForMessageContains(clawID, message string) (pipeli
 
 func (s *Server) transitionPipelineStageWithContext(clawID string, stage pipeline.Stage, ctx pipelineContext) bool {
 	stage = s.resolvePipelineStageSkips(clawID, stage, ctx)
+	return s.transitionResolvedPipelineStageWithContext(clawID, stage, ctx)
+}
+
+func (s *Server) transitionResolvedPipelineStageWithContext(clawID string, stage pipeline.Stage, ctx pipelineContext) bool {
 	if !s.claimPipelineStageTransition(clawID, stage.ID) {
 		log.Printf("[pipeline] claw %s already in stage %q (%s), skipping duplicate transition", clawID[:8], stage.ID, stage.Label)
 		return false
@@ -1764,7 +1768,7 @@ func (s *Server) initializePipelineEntryIfNeeded(clawID string) bool {
 	}
 
 	effectiveEntry := s.resolvePipelineStageSkips(clawID, *entry, ctx)
-	return s.transitionPipelineStageWithContext(clawID, *entry, ctx) && strings.TrimSpace(effectiveEntry.OnEnter.Inject) != ""
+	return s.transitionResolvedPipelineStageWithContext(clawID, effectiveEntry, ctx) && strings.TrimSpace(effectiveEntry.OnEnter.Inject) != ""
 }
 
 // stopAgentWithReason is the centralized handler for unexpected agent termination.
@@ -2067,7 +2071,7 @@ func (s *Server) clawIssueAndTags(clawID string) (string, []string) {
 	return issueID, tags
 }
 
-const issueLabelsTemplateFile = "ISSUE_LABELS.json"
+const issueLabelsTemplateFile = "__hub__/ISSUE_LABELS.json"
 
 func (s *Server) loadIssueLabelsForClaw(clawID string) ([]string, bool) {
 	var filesJSON string

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -203,10 +203,12 @@ func parsePipelineForFactory(factory *types.FactoryConfig) *pipeline.Pipeline {
 }
 
 type pipelineContext struct {
-	Factory   *types.FactoryConfig
-	Workspace *types.WorkspaceConfig
-	Workflow  *types.WorkflowConfig
-	IssueID   string
+	Factory              *types.FactoryConfig
+	Workspace            *types.WorkspaceConfig
+	Workflow             *types.WorkflowConfig
+	IssueID              string
+	IssueLabels          []string
+	IssueLabelsAvailable bool
 }
 
 func (ctx pipelineContext) Name() string {
@@ -1445,6 +1447,7 @@ func (s *Server) pipelineStageForMessageContains(clawID, message string) (pipeli
 }
 
 func (s *Server) transitionPipelineStageWithContext(clawID string, stage pipeline.Stage, ctx pipelineContext) bool {
+	stage = s.resolvePipelineStageSkips(clawID, stage, ctx)
 	if !s.claimPipelineStageTransition(clawID, stage.ID) {
 		log.Printf("[pipeline] claw %s already in stage %q (%s), skipping duplicate transition", clawID[:8], stage.ID, stage.Label)
 		return false
@@ -1501,6 +1504,93 @@ func (s *Server) transitionPipelineStageWithContext(clawID string, stage pipelin
 		}
 	}
 	return true
+}
+
+func (s *Server) resolvePipelineStageSkips(clawID string, stage pipeline.Stage, ctx pipelineContext) pipeline.Stage {
+	pl := parsePipelineForContext(ctx)
+	if pl == nil {
+		return stage
+	}
+	if !ctx.IssueLabelsAvailable {
+		if labels, ok := s.loadIssueLabelsForClaw(clawID); ok {
+			ctx.IssueLabels = labels
+			ctx.IssueLabelsAvailable = true
+		}
+	}
+	current := &stage
+	visited := map[string]bool{}
+	for current != nil {
+		if visited[current.ID] {
+			log.Printf("[pipeline] claw %s: skip cycle reached at stage %q", clawID[:8], current.ID)
+			return *current
+		}
+		visited[current.ID] = true
+		targetID, skip := pipelineStageSkipTarget(*current, ctx.IssueLabels, ctx.IssueLabelsAvailable)
+		if !skip {
+			return *current
+		}
+		target := pl.StageByID(targetID)
+		if target == nil {
+			log.Printf("[pipeline] claw %s: stage %q skip target %q not found", clawID[:8], current.ID, targetID)
+			return *current
+		}
+		log.Printf("[pipeline] claw %s: skipping stage %q to %q", clawID[:8], current.ID, target.ID)
+		current = target
+	}
+	return stage
+}
+
+func pipelineStageSkipTarget(stage pipeline.Stage, issueLabels []string, labelsAvailable bool) (string, bool) {
+	if stage.SkipIf != nil {
+		if labelsAvailable && issueLabelSkipMatches(stage.SkipIf, issueLabels) {
+			return stage.SkipIf.GoTo, true
+		}
+	}
+	if stage.SkipUnless != nil {
+		if !labelsAvailable || !issueLabelSkipMatches(stage.SkipUnless, issueLabels) {
+			return stage.SkipUnless.GoTo, true
+		}
+	}
+	return "", false
+}
+
+func issueLabelSkipMatches(rule *pipeline.StageSkip, issueLabels []string) bool {
+	if rule == nil || rule.IssueLabels == nil {
+		return false
+	}
+	actual := normalizedIssueLabelSet(issueLabels)
+	for _, label := range rule.IssueLabels.Labels {
+		if actual[strings.ToLower(strings.TrimSpace(label))] {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeIssueLabels(labels []string) []string {
+	seen := map[string]bool{}
+	normalized := make([]string, 0, len(labels))
+	for _, label := range labels {
+		label = strings.TrimSpace(label)
+		if label == "" {
+			continue
+		}
+		key := strings.ToLower(label)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		normalized = append(normalized, label)
+	}
+	return normalized
+}
+
+func normalizedIssueLabelSet(labels []string) map[string]bool {
+	set := make(map[string]bool, len(labels))
+	for _, label := range normalizeIssueLabels(labels) {
+		set[strings.ToLower(label)] = true
+	}
+	return set
 }
 
 // autoTransitionAfterJudge checks the pipeline for a stage with a judge_verdict
@@ -1673,7 +1763,8 @@ func (s *Server) initializePipelineEntryIfNeeded(clawID string) bool {
 		return false
 	}
 
-	return s.transitionPipelineStageWithContext(clawID, *entry, ctx) && strings.TrimSpace(entry.OnEnter.Inject) != ""
+	effectiveEntry := s.resolvePipelineStageSkips(clawID, *entry, ctx)
+	return s.transitionPipelineStageWithContext(clawID, *entry, ctx) && strings.TrimSpace(effectiveEntry.OnEnter.Inject) != ""
 }
 
 // stopAgentWithReason is the centralized handler for unexpected agent termination.
@@ -1974,6 +2065,28 @@ func (s *Server) clawIssueAndTags(clawID string) (string, []string) {
 	var tags []string
 	_ = json.Unmarshal([]byte(tagsJSON), &tags)
 	return issueID, tags
+}
+
+const issueLabelsTemplateFile = "ISSUE_LABELS.json"
+
+func (s *Server) loadIssueLabelsForClaw(clawID string) ([]string, bool) {
+	var filesJSON string
+	if err := s.db.QueryRow(`SELECT COALESCE(template_files,'{}') FROM claws WHERE id=?`, clawID).Scan(&filesJSON); err != nil {
+		return nil, false
+	}
+	var files map[string]string
+	if err := json.Unmarshal([]byte(filesJSON), &files); err != nil {
+		return nil, false
+	}
+	raw, ok := files[issueLabelsTemplateFile]
+	if !ok {
+		return nil, false
+	}
+	var labels []string
+	if err := json.Unmarshal([]byte(raw), &labels); err != nil {
+		return nil, false
+	}
+	return labels, true
 }
 
 func workflowTags(tags []string) (string, string) {

--- a/pkg/hub/pipeline_runner_test.go
+++ b/pkg/hub/pipeline_runner_test.go
@@ -3,6 +3,7 @@ package hub
 import (
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -44,6 +45,229 @@ func TestTransitionPipelineStageSkipsDuplicateCurrentStage(t *testing.T) {
 	}
 	if got := s.getPipelineStage(clawID); got != "pr_opened" {
 		t.Fatalf("pipeline stage = %q, want pr_opened", got)
+	}
+}
+
+func TestTransitionPipelineStageSkipIfIssueLabelMatchesBeforeOnEnter(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+
+	const clawID = "claw-skip-if-label"
+	_, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, template, status, pipeline_stage, created_at) VALUES(?,?,?,?,?,?,datetime('now'))`,
+		clawID, "test-tenant-id", "workflow claw", "elasticclaw", "connected", "working",
+	)
+	if err != nil {
+		t.Fatalf("insert claw: %v", err)
+	}
+
+	pipelineYAML := `
+stages:
+  - id: review_loop
+    skip_if:
+      issue_labels:
+        labels: [no review loop]
+      go_to: detect_android_changes
+    on_enter:
+      inject: "review loop should not run"
+  - id: detect_android_changes
+    on_enter:
+      inject: "detect android changes"
+`
+	pl, err := pipeline.Parse([]byte(pipelineYAML))
+	if err != nil {
+		t.Fatalf("parse pipeline: %v", err)
+	}
+	ctx := pipelineContext{
+		Workflow:             &types.WorkflowConfig{PipelineYAML: pipelineYAML},
+		IssueLabelsAvailable: true,
+		IssueLabels:          []string{"No Review Loop"},
+	}
+	if !s.transitionPipelineStageWithContext(clawID, pl.Stages[0], ctx) {
+		t.Fatalf("stage transition returned false")
+	}
+	if got := s.getPipelineStage(clawID); got != "detect_android_changes" {
+		t.Fatalf("pipeline stage = %q, want detect_android_changes", got)
+	}
+
+	var messages []string
+	rows, err := db.Query(`SELECT content FROM messages WHERE claw_id=? ORDER BY created_at, id`, clawID)
+	if err != nil {
+		t.Fatalf("select messages: %v", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var content string
+		if err := rows.Scan(&content); err != nil {
+			t.Fatalf("scan message: %v", err)
+		}
+		messages = append(messages, content)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("message rows: %v", err)
+	}
+	joined := strings.Join(messages, "\n")
+	if strings.Contains(joined, "review loop should not run") {
+		t.Fatalf("skipped stage on_enter ran unexpectedly:\n%s", joined)
+	}
+	if !strings.Contains(joined, "detect android changes") {
+		t.Fatalf("target stage on_enter did not run:\n%s", joined)
+	}
+}
+
+func TestTransitionPipelineStageIssueLabelSkipAvailabilityDefaults(t *testing.T) {
+	tests := []struct {
+		name                   string
+		pipelineYAML           string
+		issueLabels            []string
+		issueLabelsAvailable   bool
+		templateFileLabelsJSON string
+		wantStage              string
+		wantMessage            string
+		rejectMessage          string
+	}{
+		{
+			name: "skip_if does not skip without labels",
+			pipelineYAML: `
+stages:
+  - id: review_loop
+    skip_if:
+      issue_labels:
+        labels: [no review loop]
+      go_to: detect_android_changes
+    on_enter:
+      inject: "review loop ran"
+  - id: detect_android_changes
+    on_enter:
+      inject: "detect android changes"
+`,
+			wantStage:     "review_loop",
+			wantMessage:   "review loop ran",
+			rejectMessage: "detect android changes",
+		},
+		{
+			name: "skip_if skips with labels loaded from claw snapshot",
+			pipelineYAML: `
+stages:
+  - id: review_loop
+    skip_if:
+      issue_labels:
+        labels: [no review loop]
+      go_to: detect_android_changes
+    on_enter:
+      inject: "review loop ran"
+  - id: detect_android_changes
+    on_enter:
+      inject: "detect android changes"
+`,
+			templateFileLabelsJSON: `["no review loop"]`,
+			wantStage:              "detect_android_changes",
+			wantMessage:            "detect android changes",
+			rejectMessage:          "review loop ran",
+		},
+		{
+			name: "skip_unless skips without labels",
+			pipelineYAML: `
+stages:
+  - id: review_loop
+    skip_unless:
+      issue_labels:
+        labels: [with review loop]
+      go_to: detect_android_changes
+    on_enter:
+      inject: "review loop ran"
+  - id: detect_android_changes
+    on_enter:
+      inject: "detect android changes"
+`,
+			wantStage:     "detect_android_changes",
+			wantMessage:   "detect android changes",
+			rejectMessage: "review loop ran",
+		},
+		{
+			name: "skip_unless skips when available labels do not match",
+			pipelineYAML: `
+stages:
+  - id: review_loop
+    skip_unless:
+      issue_labels:
+        labels: [with review loop]
+      go_to: detect_android_changes
+    on_enter:
+      inject: "review loop ran"
+  - id: detect_android_changes
+    on_enter:
+      inject: "detect android changes"
+`,
+			issueLabelsAvailable: true,
+			issueLabels:          []string{"other label"},
+			wantStage:            "detect_android_changes",
+			wantMessage:          "detect android changes",
+			rejectMessage:        "review loop ran",
+		},
+		{
+			name: "skip_unless does not skip when available labels match",
+			pipelineYAML: `
+stages:
+  - id: review_loop
+    skip_unless:
+      issue_labels:
+        labels: [with review loop]
+      go_to: detect_android_changes
+    on_enter:
+      inject: "review loop ran"
+  - id: detect_android_changes
+    on_enter:
+      inject: "detect android changes"
+`,
+			issueLabelsAvailable: true,
+			issueLabels:          []string{"With Review Loop"},
+			wantStage:            "review_loop",
+			wantMessage:          "review loop ran",
+			rejectMessage:        "detect android changes",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+
+			clawID := "claw-" + strings.ReplaceAll(tt.name, " ", "-")
+			templateFiles := "{}"
+			if tt.templateFileLabelsJSON != "" {
+				templateFiles = `{"` + issueLabelsTemplateFile + `":` + strconv.Quote(tt.templateFileLabelsJSON) + `}`
+			}
+			_, err := db.Exec(
+				`INSERT INTO claws(id, tenant_id, name, template, status, pipeline_stage, template_files, created_at) VALUES(?,?,?,?,?,?,?,datetime('now'))`,
+				clawID, "test-tenant-id", "workflow claw", "elasticclaw", "connected", "working", templateFiles,
+			)
+			if err != nil {
+				t.Fatalf("insert claw: %v", err)
+			}
+			pl, err := pipeline.Parse([]byte(tt.pipelineYAML))
+			if err != nil {
+				t.Fatalf("parse pipeline: %v", err)
+			}
+			ctx := pipelineContext{
+				Workflow:             &types.WorkflowConfig{PipelineYAML: tt.pipelineYAML},
+				IssueLabelsAvailable: tt.issueLabelsAvailable,
+				IssueLabels:          tt.issueLabels,
+			}
+			if !s.transitionPipelineStageWithContext(clawID, pl.Stages[0], ctx) {
+				t.Fatalf("stage transition returned false")
+			}
+			if got := s.getPipelineStage(clawID); got != tt.wantStage {
+				t.Fatalf("pipeline stage = %q, want %s", got, tt.wantStage)
+			}
+			var content string
+			if err := db.QueryRow(`SELECT COALESCE(group_concat(content, '\n'),'') FROM messages WHERE claw_id=?`, clawID).Scan(&content); err != nil {
+				t.Fatalf("select messages: %v", err)
+			}
+			if !strings.Contains(content, tt.wantMessage) {
+				t.Fatalf("messages did not contain %q:\n%s", tt.wantMessage, content)
+			}
+			if strings.Contains(content, tt.rejectMessage) {
+				t.Fatalf("messages unexpectedly contained %q:\n%s", tt.rejectMessage, content)
+			}
+		})
 	}
 }
 

--- a/pkg/hub/pipeline_runner_test.go
+++ b/pkg/hub/pipeline_runner_test.go
@@ -1,6 +1,7 @@
 package hub
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -268,6 +269,56 @@ stages:
 				t.Fatalf("messages unexpectedly contained %q:\n%s", tt.rejectMessage, content)
 			}
 		})
+	}
+}
+
+func TestWorkflowIssueLabelsDoNotReplaceWorkspaceFile(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{
+		Token:     "test-token",
+		ClawToken: "test-claw-token",
+		Providers: map[string]types.ProviderConfig{
+			"noop": {Type: "noop"},
+		},
+	}, "", "", "")
+
+	workspace := &types.WorkspaceConfig{
+		SchemaVersion: "v1",
+		Name:          "workspace-with-label-file",
+		Files: map[string]string{
+			"elasticclaw-config.yaml": "schema_version: v1\nname: workspace-with-label-file\nprovider: noop\n",
+			"ISSUE_LABELS.json":       `{"user":"workspace file"}`,
+		},
+	}
+	workflow := &types.WorkflowConfig{Name: "workflow", Provider: "noop"}
+
+	clawID, _, err := s.createClawFromWorkflowWithOptions(workspace, workflow, workflowCreateOptions{
+		issueLabelsAvailable: true,
+		issueLabels:          []string{"with review loop"},
+		reason:               "test",
+	})
+	if err != nil {
+		t.Fatalf("createClawFromWorkflowWithOptions: %v", err)
+	}
+
+	var filesJSON string
+	if err := db.QueryRow(`SELECT template_files FROM claws WHERE id=?`, clawID).Scan(&filesJSON); err != nil {
+		t.Fatalf("select template files: %v", err)
+	}
+	var files map[string]string
+	if err := json.Unmarshal([]byte(filesJSON), &files); err != nil {
+		t.Fatalf("unmarshal template files: %v", err)
+	}
+	if got := files["ISSUE_LABELS.json"]; got != `{"user":"workspace file"}` {
+		t.Fatalf("workspace ISSUE_LABELS.json = %q, want user file", got)
+	}
+	labels, ok := s.loadIssueLabelsForClaw(clawID)
+	if !ok {
+		t.Fatalf("expected issue labels metadata to be available")
+	}
+	if len(labels) != 1 || labels[0] != "with review loop" {
+		t.Fatalf("issue labels = %#v, want [with review loop]", labels)
 	}
 }
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -3237,6 +3237,7 @@ cp "$BIN" /tmp/claw-bridge.download && chmod +x /tmp/claw-bridge.download && mv 
 	_ = s.db.QueryRow(`SELECT COALESCE(template_files,'{}') FROM claws WHERE id=?`, clawID).Scan(&filesJSON)
 	var templateFiles map[string]string
 	if err := json.Unmarshal([]byte(filesJSON), &templateFiles); err == nil && len(templateFiles) > 0 {
+		templateFiles = workspaceTemplateFiles(templateFiles)
 		for name, content := range templateFiles {
 			name := name
 			content := content
@@ -4215,6 +4216,7 @@ func (s *Server) bootstrapExedev(ctx context.Context, clawID, vmName string, p *
 	_ = json.Unmarshal([]byte(githubReposJSON), &githubRepos)
 	var templateFiles map[string]string
 	_ = json.Unmarshal([]byte(templateFilesJSON), &templateFiles)
+	templateFiles = workspaceTemplateFiles(templateFiles)
 
 	s.mu.RLock()
 	llmKeyEnv := buildLLMKeyEnv(s.hubCfg.LLMKeys, llmKeyName)

--- a/pkg/hub/workflow_creator.go
+++ b/pkg/hub/workflow_creator.go
@@ -28,6 +28,19 @@ type workflowCreateOptions struct {
 	triggerActor         *triggerActor
 }
 
+const hubInternalTemplateFilePrefix = "__hub__/"
+
+func workspaceTemplateFiles(files map[string]string) map[string]string {
+	filtered := make(map[string]string, len(files))
+	for name, content := range files {
+		if strings.HasPrefix(name, hubInternalTemplateFilePrefix) {
+			continue
+		}
+		filtered[name] = content
+	}
+	return filtered
+}
+
 func (s *Server) createClawFromWorkflow(workspace *types.WorkspaceConfig, workflow *types.WorkflowConfig, inputs map[string]string, reason string) (string, bool, error) {
 	return s.createClawFromWorkflowWithOptions(workspace, workflow, workflowCreateOptions{inputs: inputs, reason: reason})
 }
@@ -289,19 +302,20 @@ func (s *Server) createClawFromWorkflowWithOptions(workspace *types.WorkspaceCon
 		return clawID, true, nil
 	}
 
+	providerTemplateFiles := workspaceTemplateFiles(templateFiles)
 	req := types.CreateClawRequest{
 		Name:         clawName,
 		TemplateName: workspace.Name,
 		Provider:     provider,
 		DefaultModel: defaultModel,
 		LLMKey:       llmKey,
-		Files:        templateFiles,
+		Files:        providerTemplateFiles,
 		Env:          env,
 		InstanceType: instanceType,
 		ProviderName: "ec-" + clawID[:8],
 	}
-	fileBytes := make(map[string][]byte, len(templateFiles))
-	for k, v := range templateFiles {
+	fileBytes := make(map[string][]byte, len(providerTemplateFiles))
+	for k, v := range providerTemplateFiles {
 		fileBytes[k] = []byte(v)
 	}
 

--- a/pkg/hub/workflow_creator.go
+++ b/pkg/hub/workflow_creator.go
@@ -15,15 +15,17 @@ import (
 )
 
 type workflowCreateOptions struct {
-	inputs          map[string]string
-	workspaceFiles  map[string]string
-	clawName        string
-	githubIssueID   string
-	linearIssueID   string
-	shortcutStoryID string
-	jiraIssueID     string
-	reason          string
-	triggerActor    *triggerActor
+	inputs               map[string]string
+	workspaceFiles       map[string]string
+	clawName             string
+	githubIssueID        string
+	linearIssueID        string
+	shortcutStoryID      string
+	jiraIssueID          string
+	issueLabels          []string
+	issueLabelsAvailable bool
+	reason               string
+	triggerActor         *triggerActor
 }
 
 func (s *Server) createClawFromWorkflow(workspace *types.WorkspaceConfig, workflow *types.WorkflowConfig, inputs map[string]string, reason string) (string, bool, error) {
@@ -204,6 +206,10 @@ func (s *Server) createClawFromWorkflowWithOptions(workspace *types.WorkspaceCon
 		return "", false, err
 	}
 	workflowVolumesJSON, _ := json.Marshal(workflowVolumes)
+	if opts.issueLabelsAvailable {
+		labelsJSON, _ := json.Marshal(normalizeIssueLabels(opts.issueLabels))
+		templateFiles[issueLabelsTemplateFile] = string(labelsJSON)
+	}
 	s.promoteMu.Lock()
 	activeCount := s.countActiveClawsInGroup(groupName)
 	isPending := groupLimit > 0 && activeCount >= groupLimit

--- a/pkg/types/workflow_normalize_test.go
+++ b/pkg/types/workflow_normalize_test.go
@@ -113,6 +113,51 @@ stages:
 	}
 }
 
+func TestWorkflowNormalizePreservesStageIssueLabelSkips(t *testing.T) {
+	data := []byte(`
+schema_version: v1
+name: github-issue
+trigger:
+  github_issues:
+    event: issue_labeled
+    repositories:
+      - elasticclaw/elasticclaw
+    labels:
+      - agent-ready
+stages:
+  - id: review_loop
+    skip_if:
+      issue_labels:
+        labels:
+          - no review loop
+      go_to: detect_android_changes
+    skip_unless:
+      issue_labels:
+        labels:
+          - with review loop
+      go_to: detect_android_changes
+    on_enter:
+      inject: review
+  - id: detect_android_changes
+`)
+	var workflow WorkflowConfig
+	if err := yaml.Unmarshal(data, &workflow); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if err := NormalizeWorkflowConfig(&workflow); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if !strings.Contains(workflow.PipelineYAML, "skip_if:") {
+		t.Fatalf("pipeline yaml did not preserve skip_if: %q", workflow.PipelineYAML)
+	}
+	if !strings.Contains(workflow.PipelineYAML, "skip_unless:") {
+		t.Fatalf("pipeline yaml did not preserve skip_unless: %q", workflow.PipelineYAML)
+	}
+	if !strings.Contains(workflow.PipelineYAML, "no review loop") || !strings.Contains(workflow.PipelineYAML, "with review loop") {
+		t.Fatalf("pipeline yaml did not preserve skip labels: %q", workflow.PipelineYAML)
+	}
+}
+
 func TestWorkflowConfigRejectsInvalidRunKind(t *testing.T) {
 	workflow := &WorkflowConfig{Name: "invalid-kind", RunKind: "typo"}
 	err := workflow.Validate()

--- a/pkg/types/workspace.go
+++ b/pkg/types/workspace.go
@@ -162,13 +162,15 @@ type JiraWorkflowTrigger struct {
 // WorkflowStage is one step in a workflow state machine. It intentionally mirrors
 // the persisted pipeline stage shape without making pkg/types depend on hub.
 type WorkflowStage struct {
-	ID       string                   `yaml:"id" json:"id"`
-	Label    string                   `yaml:"label,omitempty" json:"label,omitempty"`
-	Entry    bool                     `yaml:"entry,omitempty" json:"entry,omitempty"`
-	Terminal bool                     `yaml:"terminal,omitempty" json:"terminal,omitempty"`
-	Triggers []map[string]interface{} `yaml:"triggers,omitempty" json:"triggers,omitempty"`
-	OnEnter  map[string]interface{}   `yaml:"on_enter,omitempty" json:"onEnter,omitempty"`
-	Gate     map[string]interface{}   `yaml:"gate,omitempty" json:"gate,omitempty"`
+	ID         string                   `yaml:"id" json:"id"`
+	Label      string                   `yaml:"label,omitempty" json:"label,omitempty"`
+	Entry      bool                     `yaml:"entry,omitempty" json:"entry,omitempty"`
+	Terminal   bool                     `yaml:"terminal,omitempty" json:"terminal,omitempty"`
+	Triggers   []map[string]interface{} `yaml:"triggers,omitempty" json:"triggers,omitempty"`
+	OnEnter    map[string]interface{}   `yaml:"on_enter,omitempty" json:"onEnter,omitempty"`
+	SkipIf     map[string]interface{}   `yaml:"skip_if,omitempty" json:"skipIf,omitempty"`
+	SkipUnless map[string]interface{}   `yaml:"skip_unless,omitempty" json:"skipUnless,omitempty"`
+	Gate       map[string]interface{}   `yaml:"gate,omitempty" json:"gate,omitempty"`
 }
 
 func (w *WorkspaceConfig) Validate() error {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -85,6 +85,42 @@ func TestDockerWorkflowE2E(t *testing.T) {
 	waitForAgentStatus(ctx, t, hub, agentID, "connected")
 }
 
+func TestHubListenAddrBindsDockerHubForContainerAccess(t *testing.T) {
+	tests := []struct {
+		name string
+		env  e2eEnv
+		want string
+	}{
+		{
+			name: "docker loopback",
+			env:  e2eEnv{SandboxProvider: "docker", HubAddr: "127.0.0.1:8080"},
+			want: "0.0.0.0:8080",
+		},
+		{
+			name: "docker localhost",
+			env:  e2eEnv{SandboxProvider: "docker", HubAddr: "localhost:8080"},
+			want: "0.0.0.0:8080",
+		},
+		{
+			name: "non docker unchanged",
+			env:  e2eEnv{SandboxProvider: "daytona", HubAddr: "127.0.0.1:8080"},
+			want: "127.0.0.1:8080",
+		},
+		{
+			name: "docker remote unchanged",
+			env:  e2eEnv{SandboxProvider: "docker", HubAddr: "10.0.0.5:8080"},
+			want: "10.0.0.5:8080",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hubListenAddr(tt.env); got != tt.want {
+				t.Fatalf("hubListenAddr() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func runGitHubIssuesWorkflowE2E(t *testing.T, sandboxProvider string) {
 	runID := e2eRunID()
 	env := newE2EEnv(t, runID, sandboxProvider)
@@ -314,7 +350,7 @@ llm_keys:
 	}
 	t.Cleanup(func() { _ = logFile.Close() })
 
-	cmd := exec.Command(env.Bin, "hub", "--addr", env.HubAddr, "--db", dbPath, "--no-web-ui")
+	cmd := exec.Command(env.Bin, "hub", "--addr", hubListenAddr(env), "--db", dbPath, "--no-web-ui")
 	cmd.Env = append(os.Environ(),
 		"ELASTICCLAW_HUB_CONFIG="+configPath,
 		"DAYTONA_API_KEY="+env.DaytonaAPIKey,
@@ -1176,6 +1212,22 @@ func envOrDefault(name, fallback string) string {
 		return value
 	}
 	return fallback
+}
+
+func hubListenAddr(env e2eEnv) string {
+	if env.SandboxProvider != "docker" {
+		return env.HubAddr
+	}
+	host, port, ok := strings.Cut(env.HubAddr, ":")
+	if !ok || port == "" {
+		return env.HubAddr
+	}
+	switch host {
+	case "127.0.0.1", "localhost", "0.0.0.0":
+		return "0.0.0.0:" + port
+	default:
+		return env.HubAddr
+	}
 }
 
 func e2eRunID() string {


### PR DESCRIPTION
## Summary

Adds hub support for workflow stage skips driven by issue labels:

```yaml
skip_if:
  issue_labels:
    labels:
      - no review loop
  go_to: detect_android_changes
```

and:

```yaml
skip_unless:
  issue_labels:
    labels:
      - with review loop
  go_to: detect_android_changes
```

## Contract supported

- `skip_if` skips the current stage when any configured issue label is present.
- `skip_unless` skips the current stage when none of the configured issue labels is present.
- If issue labels are unavailable, `skip_if` does not skip and `skip_unless` skips.
- Skip evaluation happens before the skipped stage's `on_enter` actions run.
- `go_to` is validated to reference an existing stage, not the same stage, and skip cycles are rejected while parsing.
- Workflow v1 stage normalization preserves `skip_if` and `skip_unless` in generated pipeline YAML.

## Notes

The hub persists available workflow issue labels as internal runtime metadata for GitHub Issues, Linear, Jira, and manual GitHub issue workflows so the runner can evaluate the condition when entering stages. No stage prompt/inject text is added for skip behavior.

## Tests

- `/usr/local/bin/go test ./pkg/hub/pipeline -run 'TestParseStageIssueLabelSkips|TestParseRejectsInvalidStageIssueLabelSkips'`
- `/usr/local/bin/go test ./pkg/types -run TestWorkflowNormalizePreservesStageIssueLabelSkips`
- `/usr/local/bin/go test ./pkg/hub -run 'TestTransitionPipelineStageSkipIfIssueLabelMatchesBeforeOnEnter|TestTransitionPipelineStageIssueLabelSkipAvailabilityDefaults'`
- `/usr/local/bin/go test ./pkg/hub/pipeline ./pkg/types ./pkg/hub`
- `git diff --check`
- `/usr/local/bin/go test ./...`
