### PR TITLE
Restrict CORS to configured origins

### DIFF
--- a/docker/hub.dev.yaml.example
+++ b/docker/hub.dev.yaml.example
@@ -8,6 +8,11 @@ url: http://localhost:8080
 # The service name "hub" resolves inside the elasticclaw-dev Docker network.
 public_url: http://hub:8080
 
+# Browser origins allowed to call the hub API (CORS). The dev compose runs
+# the Next.js UI on localhost:3000, separate from the hub's own origin.
+allowed_origins:
+  - http://localhost:3000
+
 # Auth tokens — keep these as-is for local dev (they only secure your laptop)
 token: devtoken
 claw_token: devclawtoken

--- a/pkg/hub/cors_test.go
+++ b/pkg/hub/cors_test.go
@@ -1,0 +1,82 @@
+package hub
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func TestCORSMiddlewareEchoesAllowedOrigin(t *testing.T) {
+	s := &Server{hubCfg: &types.HubConfig{AllowedOrigins: []string{"http://localhost:3000"}}}
+	handler := s.corsMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/claws", nil)
+	req.Header.Set("Origin", "http://localhost:3000")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if got := rr.Header().Get("Access-Control-Allow-Origin"); got != "http://localhost:3000" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want %q", got, "http://localhost:3000")
+	}
+	if got := rr.Header().Get("Vary"); got != "Origin" {
+		t.Errorf("Vary = %q, want %q", got, "Origin")
+	}
+}
+
+func TestCORSMiddlewareOmitsHeaderForUnlistedOrigin(t *testing.T) {
+	s := &Server{hubCfg: &types.HubConfig{AllowedOrigins: []string{"http://localhost:3000"}}}
+	handler := s.corsMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/claws", nil)
+	req.Header.Set("Origin", "http://evil.example.com")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if got := rr.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want empty", got)
+	}
+	if got := rr.Header().Get("Vary"); got != "Origin" {
+		t.Errorf("Vary = %q, want %q", got, "Origin")
+	}
+}
+
+func TestCORSMiddlewareAlwaysSetsVaryOrigin(t *testing.T) {
+	s := &Server{hubCfg: &types.HubConfig{}}
+	handler := s.corsMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// No Origin header at all — still expect Vary: Origin.
+	req := httptest.NewRequest(http.MethodGet, "/api/claws", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if got := rr.Header().Get("Vary"); got != "Origin" {
+		t.Errorf("Vary = %q, want %q", got, "Origin")
+	}
+	if got := rr.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want empty", got)
+	}
+}
+
+func TestCORSMiddlewareDefaultsToHubOwnOrigin(t *testing.T) {
+	s := &Server{hubCfg: &types.HubConfig{URL: "http://localhost:8080"}}
+	handler := s.corsMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/claws", nil)
+	req.Header.Set("Origin", "http://localhost:8080")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if got := rr.Header().Get("Access-Control-Allow-Origin"); got != "http://localhost:8080" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want %q", got, "http://localhost:8080")
+	}
+}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -268,7 +268,7 @@ func (s *Server) Run(opts ...RunOptions) error {
 	if s.hubCfg.UIPassword == "" {
 		log.Printf("⚠️  Web UI password not set — using default: 'admin'. Set ui_password in hub.yaml to secure the UI.")
 	}
-	return http.ListenAndServe(s.addr, corsMiddleware(mux))
+	return http.ListenAndServe(s.addr, s.corsMiddleware(mux))
 }
 
 func (s *Server) registerRoutes(mux *http.ServeMux) {
@@ -394,11 +394,34 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	}))
 }
 
-// corsMiddleware adds permissive CORS headers so the web UI can connect
-// from any origin (browser same-origin restrictions apply to REST + WS).
-func corsMiddleware(next http.Handler) http.Handler {
+// allowedOrigins returns the configured CORS allow-list, defaulting to the
+// hub's own origin (its configured URL) when unset.
+func (s *Server) allowedOrigins() []string {
+	if s.hubCfg != nil && len(s.hubCfg.AllowedOrigins) > 0 {
+		return s.hubCfg.AllowedOrigins
+	}
+	if s.hubCfg != nil && s.hubCfg.URL != "" {
+		return []string{s.hubCfg.URL}
+	}
+	return nil
+}
+
+// corsMiddleware echoes Access-Control-Allow-Origin only for origins on the
+// configured allow-list (hub.yaml: allowed_origins); requests from other
+// origins get no CORS header. Vary: Origin is always set since the response
+// depends on the request's Origin header.
+func (s *Server) corsMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Add("Vary", "Origin")
+		origin := r.Header.Get("Origin")
+		if origin != "" {
+			for _, allowed := range s.allowedOrigins() {
+				if origin == allowed {
+					w.Header().Set("Access-Control-Allow-Origin", origin)
+					break
+				}
+			}
+		}
 		w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, ngrok-skip-browser-warning")
 		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
 		if r.Method == http.MethodOptions {

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -476,9 +476,13 @@ type HubConfig struct {
 	// Hub server fields
 	// PublicURL is the URL claws use to connect back to the hub from remote VMs.
 	// If not set, falls back to URL.
-	PublicURL string                    `yaml:"public_url,omitempty"`
-	ClawToken string                    `yaml:"claw_token,omitempty"`
-	Providers map[string]ProviderConfig `yaml:"providers,omitempty"`
+	PublicURL string `yaml:"public_url,omitempty"`
+	// AllowedOrigins lists the browser origins allowed to make cross-origin
+	// requests to the hub API (CORS). Defaults to the hub's own origin (URL)
+	// if not set.
+	AllowedOrigins []string                  `yaml:"allowed_origins,omitempty"`
+	ClawToken      string                    `yaml:"claw_token,omitempty"`
+	Providers      map[string]ProviderConfig `yaml:"providers,omitempty"`
 	// SSHPublicKeys are extra keys added to every provisioned VM for debug access.
 	SSHPublicKeys []string `yaml:"ssh_public_keys,omitempty"`
 	// BridgeImage is the OCI artifact reference for the claw-bridge binary.


### PR DESCRIPTION
## Summary
Replaces the wide-open `Access-Control-Allow-Origin: *` on the hub API with an allow-list driven by hub config, per Phase 0 item 0.4.

## Changes
- `pkg/types/template.go`: add `HubConfig.AllowedOrigins []string` (`yaml:"allowed_origins"`).
- `pkg/hub/server.go`: `corsMiddleware` is now a `*Server` method. It echoes `Access-Control-Allow-Origin: <origin>` only when the request's `Origin` matches an entry in `hubCfg.AllowedOrigins` (defaulting to the hub's own configured `URL` if the list is empty). `Vary: Origin` is always set, regardless of whether the request has an `Origin` header. Unlisted origins get no CORS header at all.
- `docker/hub.dev.yaml.example`: added `allowed_origins: [http://localhost:3000]` so the dev compose (web:3000 → hub:8080) keeps working.
- `pkg/hub/cors_test.go` (new): unit tests covering an allowed origin being echoed, an unlisted origin getting no header, `Vary: Origin` always being set (including with no `Origin` header at all), and the default-to-hub's-own-URL behavior.

## Verification
```
$ go build ./...
(no output — success)

$ go test ./pkg/hub/ -count=1
ok  	github.com/elasticclaw/elasticclaw/pkg/hub	16.244s

$ go test ./pkg/hub/ -run TestCORS -v -count=1
=== RUN   TestCORSMiddlewareEchoesAllowedOrigin
--- PASS: TestCORSMiddlewareEchoesAllowedOrigin (0.00s)
=== RUN   TestCORSMiddlewareOmitsHeaderForUnlistedOrigin
--- PASS: TestCORSMiddlewareOmitsHeaderForUnlistedOrigin (0.00s)
=== RUN   TestCORSMiddlewareAlwaysSetsVaryOrigin
--- PASS: TestCORSMiddlewareAlwaysSetsVaryOrigin (0.00s)
=== RUN   TestCORSMiddlewareDefaultsToHubOwnOrigin
--- PASS: TestCORSMiddlewareDefaultsToHubOwnOrigin (0.00s)
PASS
ok  	github.com/elasticclaw/elasticclaw/pkg/hub	2.459s

$ gofmt -l pkg/hub/server.go pkg/hub/cors_test.go pkg/types/template.go
(no output — clean)

$ go vet ./pkg/hub/... ./pkg/types/...
(no output — clean)
```

Implements docs/re-arch/phase-0-stop-the-bleeding.md item 0.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)