### PR TITLE
Stop swallowing migration errors

### DIFF
--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -4,10 +4,36 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	_ "modernc.org/sqlite" // pure-Go SQLite, no CGO required
 )
+
+// execIgnoreDuplicate runs stmt (expected to be an ALTER TABLE ... ADD COLUMN)
+// and ignores errors that are expected outcomes of this migration style rather
+// than real failures:
+//   - "duplicate column name": the column already exists — SQLite has no
+//     ALTER TABLE ... ADD COLUMN IF NOT EXISTS, so re-running against an
+//     already-migrated database always hits this.
+//   - "no such table": the table itself doesn't exist yet on a brand-new
+//     database — it gets created later in this same migration by the
+//     CREATE TABLE IF NOT EXISTS block below.
+//
+// Any other error (full disk, lock, permission denied, ...) is returned so the
+// caller can abort boot instead of silently continuing with a broken schema.
+func execIgnoreDuplicate(db *sql.DB, stmt string) error {
+	_, err := db.Exec(stmt)
+	if err == nil {
+		return nil
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "duplicate column name") || strings.Contains(msg, "no such table") {
+		return nil
+	}
+	log.Printf("[db] migration failed: %v", err)
+	return fmt.Errorf("migrate: %w", err)
+}
 
 func openDB(path string) (*sql.DB, error) {
 	db, err := sql.Open("sqlite", path+"?_time_format=sqlite&_pragma=journal_mode(WAL)&_pragma=foreign_keys(on)")
@@ -22,46 +48,62 @@ func openDB(path string) (*sql.DB, error) {
 
 func migrate(db *sql.DB) error {
 	// Add columns that may be missing from older databases.
-	// SQLite doesn't support IF NOT EXISTS on ALTER TABLE, so ignore errors.
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN provider TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN provider_id TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN default_model TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN template_files TEXT NOT NULL DEFAULT '{}'`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN ssh_host TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN ssh_port INTEGER NOT NULL DEFAULT 0`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN ssh_user TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN github_installation_id INTEGER NOT NULL DEFAULT 0`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN github_repos TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN linear_workspace TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN nix INTEGER NOT NULL DEFAULT 0`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN docker INTEGER NOT NULL DEFAULT 0`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN tags TEXT NOT NULL DEFAULT '[]'`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN color TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN linear_issue_id TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN github_issue_id TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN shortcut_story_id TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN jira_issue_id TEXT NOT NULL DEFAULT ''`)
+	// SQLite doesn't support IF NOT EXISTS on ALTER TABLE, so execIgnoreDuplicate
+	// swallows expected "already migrated" errors; any other error (full disk,
+	// lock, ...) aborts boot instead of being silently swallowed.
+	alterStmts := []string{
+		`ALTER TABLE claws ADD COLUMN provider TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE claws ADD COLUMN provider_id TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE claws ADD COLUMN default_model TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE claws ADD COLUMN template_files TEXT NOT NULL DEFAULT '{}'`,
+		`ALTER TABLE claws ADD COLUMN ssh_host TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE claws ADD COLUMN ssh_port INTEGER NOT NULL DEFAULT 0`,
+		`ALTER TABLE claws ADD COLUMN ssh_user TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE claws ADD COLUMN github_installation_id INTEGER NOT NULL DEFAULT 0`,
+		`ALTER TABLE claws ADD COLUMN github_repos TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE claws ADD COLUMN linear_workspace TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE claws ADD COLUMN nix INTEGER NOT NULL DEFAULT 0`,
+		`ALTER TABLE claws ADD COLUMN docker INTEGER NOT NULL DEFAULT 0`,
+		`ALTER TABLE claws ADD COLUMN tags TEXT NOT NULL DEFAULT '[]'`,
+		`ALTER TABLE claws ADD COLUMN color TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE claws ADD COLUMN linear_issue_id TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE claws ADD COLUMN github_issue_id TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE claws ADD COLUMN shortcut_story_id TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE claws ADD COLUMN jira_issue_id TEXT NOT NULL DEFAULT ''`,
+	}
+	for _, stmt := range alterStmts {
+		if err := execIgnoreDuplicate(db, stmt); err != nil {
+			return err
+		}
+	}
 	// Migrate existing Shortcut story IDs from linear_issue_id to shortcut_story_id
 	_, _ = db.Exec(`UPDATE claws SET shortcut_story_id = linear_issue_id WHERE linear_issue_id LIKE 'sc-%' AND shortcut_story_id = ''`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN llm_key TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN pipeline_stage TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN bootstrap_ok INTEGER NOT NULL DEFAULT 0`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN bootstrap_status TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN bootstrap_diagnostic TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN factory_name TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN concurrency_group TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN external_trigger_id TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN restore_checkpoint_id TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN restored_from_checkpoint_id TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN task_run_id TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN workflow_volumes TEXT NOT NULL DEFAULT '[]'`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN trigger_actor_json TEXT NOT NULL DEFAULT '{}'`)
-	_, _ = db.Exec(`ALTER TABLE claw_prs ADD COLUMN last_comment_at TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE claw_prs ADD COLUMN pr_conditions_fired INTEGER NOT NULL DEFAULT 0`)
-	_, _ = db.Exec(`ALTER TABLE claw_prs ADD COLUMN last_review_comment_id INTEGER NOT NULL DEFAULT 0`)
-	_, _ = db.Exec(`ALTER TABLE claw_prs ADD COLUMN last_review_id INTEGER NOT NULL DEFAULT 0`)
-	_, _ = db.Exec(`ALTER TABLE messages ADD COLUMN format TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE factory_triggers ADD COLUMN task_run_id TEXT NOT NULL DEFAULT ''`)
+	alterStmts = []string{
+		`ALTER TABLE claws ADD COLUMN llm_key TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE claws ADD COLUMN pipeline_stage TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE claws ADD COLUMN bootstrap_ok INTEGER NOT NULL DEFAULT 0`,
+		`ALTER TABLE claws ADD COLUMN bootstrap_status TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE claws ADD COLUMN bootstrap_diagnostic TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE claws ADD COLUMN factory_name TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE claws ADD COLUMN concurrency_group TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE claws ADD COLUMN external_trigger_id TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE claws ADD COLUMN restore_checkpoint_id TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE claws ADD COLUMN restored_from_checkpoint_id TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE claws ADD COLUMN task_run_id TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE claws ADD COLUMN workflow_volumes TEXT NOT NULL DEFAULT '[]'`,
+		`ALTER TABLE claws ADD COLUMN trigger_actor_json TEXT NOT NULL DEFAULT '{}'`,
+		`ALTER TABLE claw_prs ADD COLUMN last_comment_at TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE claw_prs ADD COLUMN pr_conditions_fired INTEGER NOT NULL DEFAULT 0`,
+		`ALTER TABLE claw_prs ADD COLUMN last_review_comment_id INTEGER NOT NULL DEFAULT 0`,
+		`ALTER TABLE claw_prs ADD COLUMN last_review_id INTEGER NOT NULL DEFAULT 0`,
+		`ALTER TABLE messages ADD COLUMN format TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE factory_triggers ADD COLUMN task_run_id TEXT NOT NULL DEFAULT ''`,
+	}
+	for _, stmt := range alterStmts {
+		if err := execIgnoreDuplicate(db, stmt); err != nil {
+			return err
+		}
+	}
 
 	_, _ = db.Exec(`CREATE TABLE IF NOT EXISTS claw_checkpoints (
 		id                    TEXT PRIMARY KEY,
@@ -164,7 +206,9 @@ func migrate(db *sql.DB) error {
 		heartbeat_at    DATETIME NOT NULL,
 		released_at     DATETIME
 	)`)
-	_, _ = db.Exec(`ALTER TABLE volume_leases ADD COLUMN access_token TEXT NOT NULL DEFAULT ''`)
+	if err := execIgnoreDuplicate(db, `ALTER TABLE volume_leases ADD COLUMN access_token TEXT NOT NULL DEFAULT ''`); err != nil {
+		return err
+	}
 	_, _ = db.Exec(`CREATE INDEX IF NOT EXISTS idx_volume_leases_volume_active ON volume_leases(volume_id, released_at, expires_at)`)
 	_, _ = db.Exec(`CREATE INDEX IF NOT EXISTS idx_volume_leases_claw ON volume_leases(claw_id, released_at)`)
 

--- a/pkg/hub/db_test.go
+++ b/pkg/hub/db_test.go
@@ -3,7 +3,9 @@ package hub
 import (
 	"database/sql"
 	"encoding/json"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -50,6 +52,67 @@ func TestClawsTriggerActorJSONDefaultIsValidJSON(t *testing.T) {
 
 		assertClawTriggerActorJSONIsValid(t, db, "claw-default")
 	})
+}
+
+// TestMigrateIdempotent verifies that running migrate() twice on the same
+// database (simulating a second boot against an already-migrated schema)
+// succeeds without error — the "duplicate column name" errors from re-running
+// ALTER TABLE ADD COLUMN must be swallowed.
+func TestMigrateIdempotent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "hub.db")
+	db, err := sql.Open("sqlite", path+"?_time_format=sqlite&_pragma=foreign_keys(on)")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	if err := migrate(db); err != nil {
+		t.Fatalf("first migrate: %v", err)
+	}
+	if err := migrate(db); err != nil {
+		t.Fatalf("second migrate (idempotent boot) failed: %v", err)
+	}
+}
+
+// TestMigrateAbortsOnRealError verifies that a genuine migration failure
+// (here: a read-only database, standing in for full-disk/lock conditions)
+// aborts boot with a clear error instead of being silently swallowed.
+func TestMigrateAbortsOnRealError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "hub.db")
+
+	// Create a bare "claws" table (no columns beyond id) so the very first
+	// ALTER TABLE ADD COLUMN in migrate() is a genuinely new column — not one
+	// already covered by the "duplicate column name"/"no such table"
+	// allowances — once the file is made read-only.
+	setup, err := sql.Open("sqlite", path+"?_time_format=sqlite&_pragma=foreign_keys(on)")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if _, err := setup.Exec(`CREATE TABLE claws (id TEXT PRIMARY KEY)`); err != nil {
+		t.Fatalf("create bare claws table: %v", err)
+	}
+	if err := setup.Close(); err != nil {
+		t.Fatalf("close setup db: %v", err)
+	}
+
+	if err := os.Chmod(path, 0o444); err != nil {
+		t.Fatalf("chmod read-only: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o644) })
+
+	db, err := sql.Open("sqlite", path+"?_time_format=sqlite&_pragma=foreign_keys(on)&mode=ro")
+	if err != nil {
+		t.Fatalf("open read-only db: %v", err)
+	}
+	defer db.Close()
+
+	err = migrate(db)
+	if err == nil {
+		t.Fatal("expected migrate to fail against a read-only database, got nil error")
+	}
+	if !strings.Contains(err.Error(), "migrate:") {
+		t.Fatalf("expected error to be wrapped with migrate context, got: %v", err)
+	}
 }
 
 func insertClawUsingTriggerActorDefault(t *testing.T, db *sql.DB, clawID string) {


### PR DESCRIPTION
## Summary

Implements docs/re-arch/phase-0-stop-the-bleeding.md item 0.5.

`pkg/hub/db.go` ran ~30 `ALTER TABLE ... ADD COLUMN` statements with `_, _ = db.Exec(...)`, so a real migration failure (full disk, lock, permission denied) was invisible and boot would continue against a broken schema.

## Changes

- Added `execIgnoreDuplicate(db *sql.DB, stmt string) error`: runs the statement and classifies the result.
  - `"duplicate column name"` (column already exists on a re-run) → ignored.
  - `"no such table"` (table not created yet on a brand-new DB — it's created later in the same `migrate()` call) → ignored.
  - Any other error is logged (`[db] migration failed: ...`) and returned, wrapped as `migrate: %w`, which aborts `openDB`/boot.
- Replaced every previously-swallowed `ALTER TABLE ... ADD COLUMN` call in `migrate()` (claws, claw_prs, messages, factory_triggers, volume_leases) with calls through `execIgnoreDuplicate`, looping over slices of statements to keep the diff readable.
- Left the `CREATE TABLE IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS` / data-backfill statements untouched — those already use idempotent SQL (`IF NOT EXISTS`, `INSERT OR IGNORE`) and aren't part of this item's scope.
- No change to the migration mechanism itself (no versioning) — that's phase 1.4.

## Verification

- `go build ./...` — passes.
- `go test ./pkg/hub/ -count=1` — passes (no `-tags integration`).
- Added two tests in `pkg/hub/db_test.go`:
  - `TestMigrateIdempotent`: runs `migrate()` twice against the same DB and asserts no error — confirms normal boot stays idempotent after re-running against an already-migrated schema.
  - `TestMigrateAbortsOnRealError`: creates a bare `claws` table, chmods the DB file read-only, opens it in `mode=ro`, and asserts `migrate()` returns a wrapped `migrate: ...` error (observed: `attempt to write a readonly database (8)`) instead of silently succeeding — this stands in for the full-disk/lock scenario from the spec.

```
$ go build ./...
(no output — success)

$ go test ./pkg/hub/ -count=1 -v -run 'TestMigrate'
=== RUN   TestMigrateIdempotent
--- PASS: TestMigrateIdempotent (0.03s)
=== RUN   TestMigrateAbortsOnRealError
2026/07/07 16:57:38 [db] migration failed: attempt to write a readonly database (8)
--- PASS: TestMigrateAbortsOnRealError (0.00s)
PASS

$ go test ./pkg/hub/ -count=1
ok  	github.com/elasticclaw/elasticclaw/pkg/hub	14.873s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)