### PR TITLE
fix(hub): stop swallowing migration errors on boot

### DIFF
--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	_ "modernc.org/sqlite" // pure-Go SQLite, no CGO required
@@ -20,155 +21,39 @@ func openDB(path string) (*sql.DB, error) {
 	return db, nil
 }
 
+// execIgnoreDuplicate runs an ALTER TABLE ... ADD COLUMN statement and treats
+// "duplicate column name" as success (the column already exists — SQLite has
+// no IF NOT EXISTS for ALTER TABLE). Any other error is returned so a real
+// migration failure (full disk, locked or read-only database, corrupt schema)
+// aborts boot instead of being silently ignored.
+func execIgnoreDuplicate(db *sql.DB, stmt string) error {
+	if _, err := db.Exec(stmt); err != nil {
+		if strings.Contains(err.Error(), "duplicate column name") {
+			return nil
+		}
+		return fmt.Errorf("statement %q: %w", summarizeStmt(stmt), err)
+	}
+	return nil
+}
+
+// summarizeStmt compacts a SQL statement for error messages: whitespace is
+// collapsed and long statements are truncated.
+func summarizeStmt(stmt string) string {
+	s := strings.Join(strings.Fields(stmt), " ")
+	const max = 120
+	if len(s) > max {
+		return s[:max] + "..."
+	}
+	return s
+}
+
 func migrate(db *sql.DB) error {
-	// Add columns that may be missing from older databases.
-	// SQLite doesn't support IF NOT EXISTS on ALTER TABLE, so ignore errors.
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN provider TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN provider_id TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN default_model TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN template_files TEXT NOT NULL DEFAULT '{}'`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN ssh_host TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN ssh_port INTEGER NOT NULL DEFAULT 0`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN ssh_user TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN github_installation_id INTEGER NOT NULL DEFAULT 0`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN github_repos TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN linear_workspace TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN nix INTEGER NOT NULL DEFAULT 0`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN docker INTEGER NOT NULL DEFAULT 0`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN tags TEXT NOT NULL DEFAULT '[]'`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN color TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN linear_issue_id TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN github_issue_id TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN shortcut_story_id TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN jira_issue_id TEXT NOT NULL DEFAULT ''`)
-	// Migrate existing Shortcut story IDs from linear_issue_id to shortcut_story_id
-	_, _ = db.Exec(`UPDATE claws SET shortcut_story_id = linear_issue_id WHERE linear_issue_id LIKE 'sc-%' AND shortcut_story_id = ''`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN llm_key TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN pipeline_stage TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN bootstrap_ok INTEGER NOT NULL DEFAULT 0`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN bootstrap_status TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN bootstrap_diagnostic TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN factory_name TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN concurrency_group TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN external_trigger_id TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN restore_checkpoint_id TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN restored_from_checkpoint_id TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN task_run_id TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN workflow_volumes TEXT NOT NULL DEFAULT '[]'`)
-	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN trigger_actor_json TEXT NOT NULL DEFAULT '{}'`)
-	_, _ = db.Exec(`ALTER TABLE claw_prs ADD COLUMN last_comment_at TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE claw_prs ADD COLUMN pr_conditions_fired INTEGER NOT NULL DEFAULT 0`)
-	_, _ = db.Exec(`ALTER TABLE claw_prs ADD COLUMN last_review_comment_id INTEGER NOT NULL DEFAULT 0`)
-	_, _ = db.Exec(`ALTER TABLE claw_prs ADD COLUMN last_review_id INTEGER NOT NULL DEFAULT 0`)
-	_, _ = db.Exec(`ALTER TABLE messages ADD COLUMN format TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`ALTER TABLE factory_triggers ADD COLUMN task_run_id TEXT NOT NULL DEFAULT ''`)
-
-	_, _ = db.Exec(`CREATE TABLE IF NOT EXISTS claw_checkpoints (
-		id                    TEXT PRIMARY KEY,
-		tenant_id             TEXT NOT NULL,
-		claw_id               TEXT NOT NULL,
-		status                TEXT NOT NULL DEFAULT 'creating',
-		reason                TEXT NOT NULL DEFAULT '',
-		created_by            TEXT NOT NULL DEFAULT 'hub',
-		provider              TEXT NOT NULL DEFAULT '',
-		provider_id_at_create TEXT NOT NULL DEFAULT '',
-		manifest_sha256       TEXT NOT NULL DEFAULT '',
-		manifest_path         TEXT NOT NULL DEFAULT '',
-		root_tree_sha256      TEXT NOT NULL DEFAULT '',
-		message_tree_sha256   TEXT NOT NULL DEFAULT '',
-		workspace_tree_sha256 TEXT NOT NULL DEFAULT '',
-		message_count         INTEGER NOT NULL DEFAULT 0,
-		pr_count              INTEGER NOT NULL DEFAULT 0,
-		repo_count            INTEGER NOT NULL DEFAULT 0,
-		error                 TEXT NOT NULL DEFAULT '',
-		created_at            DATETIME NOT NULL,
-		completed_at          DATETIME
-	)`)
-	_, _ = db.Exec(`CREATE INDEX IF NOT EXISTS idx_claw_checkpoints_claw ON claw_checkpoints(claw_id, created_at)`)
-	_, _ = db.Exec(`CREATE INDEX IF NOT EXISTS idx_claw_checkpoints_status ON claw_checkpoints(status, created_at)`)
-
-	_, _ = db.Exec(`CREATE TABLE IF NOT EXISTS ssh_known_hosts (
-		host          TEXT PRIMARY KEY,
-		key_type      TEXT NOT NULL,
-		key_data      TEXT NOT NULL,
-		fingerprint   TEXT NOT NULL,
-		first_seen_at DATETIME NOT NULL,
-		last_seen_at  DATETIME NOT NULL
-	)`)
-
-	_, _ = db.Exec(`CREATE TABLE IF NOT EXISTS factory_triggers (
-		id             TEXT PRIMARY KEY,
-		factory_name   TEXT NOT NULL,
-		integration    TEXT NOT NULL,
-		trigger_key    TEXT NOT NULL,
-		trigger_source TEXT NOT NULL DEFAULT '',
-		trigger_payload TEXT NOT NULL DEFAULT '{}',
-		claw_id        TEXT NOT NULL DEFAULT '',
-		task_run_id    TEXT NOT NULL DEFAULT '',
-		status         TEXT NOT NULL DEFAULT 'claimed',
-		first_seen_at  DATETIME NOT NULL,
-		last_seen_at   DATETIME NOT NULL,
-		created_at     DATETIME NOT NULL,
-		updated_at     DATETIME NOT NULL
-	)`)
-	_, _ = db.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_factory_triggers_key ON factory_triggers(factory_name, integration, trigger_key)`)
-	_, _ = db.Exec(`CREATE INDEX IF NOT EXISTS idx_factory_triggers_claw ON factory_triggers(claw_id)`)
-	_, _ = db.Exec(`
-		INSERT OR IGNORE INTO factory_triggers(id, factory_name, integration, trigger_key, trigger_source, trigger_payload, claw_id, status, first_seen_at, last_seen_at, created_at, updated_at)
-		SELECT lower(hex(randomblob(16))), factory_name, 'linear', 'linear:' || linear_issue_id, 'migration', '{}', id, 'active', created_at, created_at, created_at, created_at
-		  FROM claws
-		 WHERE factory_name != '' AND linear_issue_id != '' AND status != 'deleted'`)
-	_, _ = db.Exec(`
-		INSERT OR IGNORE INTO factory_triggers(id, factory_name, integration, trigger_key, trigger_source, trigger_payload, claw_id, status, first_seen_at, last_seen_at, created_at, updated_at)
-		SELECT lower(hex(randomblob(16))), factory_name, 'github-issues', 'github-issues:' || github_issue_id, 'migration', '{}', id, 'active', created_at, created_at, created_at, created_at
-		  FROM claws
-		 WHERE factory_name != '' AND github_issue_id != '' AND status != 'deleted'`)
-	_, _ = db.Exec(`
-		INSERT OR IGNORE INTO factory_triggers(id, factory_name, integration, trigger_key, trigger_source, trigger_payload, claw_id, status, first_seen_at, last_seen_at, created_at, updated_at)
-		SELECT lower(hex(randomblob(16))), factory_name, 'shortcut', 'shortcut:' || shortcut_story_id, 'migration', '{}', id, 'active', created_at, created_at, created_at, created_at
-		  FROM claws
-		 WHERE factory_name != '' AND shortcut_story_id != '' AND status != 'deleted'`)
-	_, _ = db.Exec(`
-		INSERT OR IGNORE INTO factory_triggers(id, factory_name, integration, trigger_key, trigger_source, trigger_payload, claw_id, status, first_seen_at, last_seen_at, created_at, updated_at)
-		SELECT lower(hex(randomblob(16))), factory_name, 'jira', 'jira:' || jira_issue_id, 'migration', '{}', id, 'active', created_at, created_at, created_at, created_at
-		  FROM claws
-		 WHERE factory_name != '' AND jira_issue_id != '' AND status != 'deleted'`)
-
-	// Factory analytics — persistent metrics table
-	_, _ = db.Exec(`CREATE TABLE IF NOT EXISTS factory_analytics (
-		id           TEXT PRIMARY KEY,
-		factory_name TEXT NOT NULL,
-		issue_id     TEXT NOT NULL DEFAULT '',
-		claw_id      TEXT NOT NULL DEFAULT '',
-		action       TEXT NOT NULL,  -- 'claw_created', 'claw_terminated', 'error', 'pr_opened', 'pr_merged', 'pr_closed', 'done_signal'
-		detail       TEXT NOT NULL DEFAULT '',
-		result       TEXT NOT NULL DEFAULT '', -- 'success', 'failure', 'timeout', 'cancelled'
-		created_at   DATETIME NOT NULL
-	)`)
-	_, _ = db.Exec(`CREATE INDEX IF NOT EXISTS idx_factory_analytics_factory ON factory_analytics(factory_name, created_at)`)
-	_, _ = db.Exec(`CREATE INDEX IF NOT EXISTS idx_factory_analytics_action ON factory_analytics(action, created_at)`)
-	_, _ = db.Exec(`CREATE INDEX IF NOT EXISTS idx_factory_analytics_claw ON factory_analytics(claw_id)`)
-
-	_, _ = db.Exec(`CREATE TABLE IF NOT EXISTS volume_leases (
-		id              TEXT PRIMARY KEY,
-		volume_id       TEXT NOT NULL,
-		repo            TEXT NOT NULL,
-		tag             TEXT NOT NULL,
-		claw_id         TEXT NOT NULL,
-		access_token    TEXT NOT NULL DEFAULT '',
-		mode            TEXT NOT NULL CHECK(mode IN ('ro','rw')),
-		mount           TEXT NOT NULL DEFAULT '',
-		manifest_digest TEXT NOT NULL DEFAULT '',
-		acquired_at     DATETIME NOT NULL,
-		expires_at      DATETIME NOT NULL,
-		heartbeat_at    DATETIME NOT NULL,
-		released_at     DATETIME
-	)`)
-	_, _ = db.Exec(`ALTER TABLE volume_leases ADD COLUMN access_token TEXT NOT NULL DEFAULT ''`)
-	_, _ = db.Exec(`CREATE INDEX IF NOT EXISTS idx_volume_leases_volume_active ON volume_leases(volume_id, released_at, expires_at)`)
-	_, _ = db.Exec(`CREATE INDEX IF NOT EXISTS idx_volume_leases_claw ON volume_leases(claw_id, released_at)`)
-
-	_, err := db.Exec(`
+	// Base schema first: every CREATE below is IF NOT EXISTS, so this is a
+	// no-op on existing databases and creates the full up-to-date schema on
+	// fresh ones. It must run before the ALTER TABLE statements so that on a
+	// fresh database those fail with "duplicate column name" (ignorable)
+	// rather than "no such table".
+	if _, err := db.Exec(`
 	CREATE TABLE IF NOT EXISTS tenants (
 		id        TEXT PRIMARY KEY,
 		name      TEXT NOT NULL,
@@ -570,8 +455,124 @@ func migrate(db *sql.DB) error {
 	CREATE INDEX IF NOT EXISTS idx_workflow_runs_workflow ON workflow_runs(tenant_id, workflow_name, workspace_name, created_at);
 	CREATE INDEX IF NOT EXISTS idx_workflow_runs_status ON workflow_runs(tenant_id, status, created_at);
 	CREATE INDEX IF NOT EXISTS idx_workflow_runs_claw ON workflow_runs(claw_id);
-	`)
-	return err
+
+	CREATE TABLE IF NOT EXISTS volume_leases (
+		id              TEXT PRIMARY KEY,
+		volume_id       TEXT NOT NULL,
+		repo            TEXT NOT NULL,
+		tag             TEXT NOT NULL,
+		claw_id         TEXT NOT NULL,
+		access_token    TEXT NOT NULL DEFAULT '',
+		mode            TEXT NOT NULL CHECK(mode IN ('ro','rw')),
+		mount           TEXT NOT NULL DEFAULT '',
+		manifest_digest TEXT NOT NULL DEFAULT '',
+		acquired_at     DATETIME NOT NULL,
+		expires_at      DATETIME NOT NULL,
+		heartbeat_at    DATETIME NOT NULL,
+		released_at     DATETIME
+	);
+	CREATE INDEX IF NOT EXISTS idx_volume_leases_volume_active ON volume_leases(volume_id, released_at, expires_at);
+	CREATE INDEX IF NOT EXISTS idx_volume_leases_claw ON volume_leases(claw_id, released_at);
+
+	-- Factory analytics — persistent metrics table
+	CREATE TABLE IF NOT EXISTS factory_analytics (
+		id           TEXT PRIMARY KEY,
+		factory_name TEXT NOT NULL,
+		issue_id     TEXT NOT NULL DEFAULT '',
+		claw_id      TEXT NOT NULL DEFAULT '',
+		action       TEXT NOT NULL,  -- 'claw_created', 'claw_terminated', 'error', 'pr_opened', 'pr_merged', 'pr_closed', 'done_signal'
+		detail       TEXT NOT NULL DEFAULT '',
+		result       TEXT NOT NULL DEFAULT '', -- 'success', 'failure', 'timeout', 'cancelled'
+		created_at   DATETIME NOT NULL
+	);
+	CREATE INDEX IF NOT EXISTS idx_factory_analytics_factory ON factory_analytics(factory_name, created_at);
+	CREATE INDEX IF NOT EXISTS idx_factory_analytics_action ON factory_analytics(action, created_at);
+	CREATE INDEX IF NOT EXISTS idx_factory_analytics_claw ON factory_analytics(claw_id);
+	`); err != nil {
+		return fmt.Errorf("apply base schema: %w", err)
+	}
+
+	// Add columns that may be missing from databases created by older
+	// versions. SQLite doesn't support IF NOT EXISTS on ALTER TABLE, so
+	// "duplicate column name" is expected and ignored; any other error
+	// aborts boot.
+	for _, stmt := range []string{
+		`ALTER TABLE claws ADD COLUMN provider TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE claws ADD COLUMN provider_id TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE claws ADD COLUMN default_model TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE claws ADD COLUMN template_files TEXT NOT NULL DEFAULT '{}'`,
+		`ALTER TABLE claws ADD COLUMN ssh_host TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE claws ADD COLUMN ssh_port INTEGER NOT NULL DEFAULT 0`,
+		`ALTER TABLE claws ADD COLUMN ssh_user TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE claws ADD COLUMN github_installation_id INTEGER NOT NULL DEFAULT 0`,
+		`ALTER TABLE claws ADD COLUMN github_repos TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE claws ADD COLUMN linear_workspace TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE claws ADD COLUMN nix INTEGER NOT NULL DEFAULT 0`,
+		`ALTER TABLE claws ADD COLUMN docker INTEGER NOT NULL DEFAULT 0`,
+		`ALTER TABLE claws ADD COLUMN tags TEXT NOT NULL DEFAULT '[]'`,
+		`ALTER TABLE claws ADD COLUMN color TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE claws ADD COLUMN linear_issue_id TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE claws ADD COLUMN github_issue_id TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE claws ADD COLUMN shortcut_story_id TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE claws ADD COLUMN jira_issue_id TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE claws ADD COLUMN llm_key TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE claws ADD COLUMN pipeline_stage TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE claws ADD COLUMN bootstrap_ok INTEGER NOT NULL DEFAULT 0`,
+		`ALTER TABLE claws ADD COLUMN bootstrap_status TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE claws ADD COLUMN bootstrap_diagnostic TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE claws ADD COLUMN factory_name TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE claws ADD COLUMN concurrency_group TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE claws ADD COLUMN external_trigger_id TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE claws ADD COLUMN restore_checkpoint_id TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE claws ADD COLUMN restored_from_checkpoint_id TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE claws ADD COLUMN task_run_id TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE claws ADD COLUMN workflow_volumes TEXT NOT NULL DEFAULT '[]'`,
+		`ALTER TABLE claws ADD COLUMN trigger_actor_json TEXT NOT NULL DEFAULT '{}'`,
+		`ALTER TABLE claw_prs ADD COLUMN last_comment_at TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE claw_prs ADD COLUMN pr_conditions_fired INTEGER NOT NULL DEFAULT 0`,
+		`ALTER TABLE claw_prs ADD COLUMN last_review_comment_id INTEGER NOT NULL DEFAULT 0`,
+		`ALTER TABLE claw_prs ADD COLUMN last_review_id INTEGER NOT NULL DEFAULT 0`,
+		`ALTER TABLE messages ADD COLUMN format TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE factory_triggers ADD COLUMN task_run_id TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE volume_leases ADD COLUMN access_token TEXT NOT NULL DEFAULT ''`,
+	} {
+		if err := execIgnoreDuplicate(db, stmt); err != nil {
+			return err
+		}
+	}
+
+	// Data migrations. These are idempotent by construction (guarded UPDATE,
+	// INSERT OR IGNORE) but any execution error is a real failure.
+	for _, stmt := range []string{
+		// Migrate existing Shortcut story IDs from linear_issue_id to shortcut_story_id
+		`UPDATE claws SET shortcut_story_id = linear_issue_id WHERE linear_issue_id LIKE 'sc-%' AND shortcut_story_id = ''`,
+		`
+		INSERT OR IGNORE INTO factory_triggers(id, factory_name, integration, trigger_key, trigger_source, trigger_payload, claw_id, status, first_seen_at, last_seen_at, created_at, updated_at)
+		SELECT lower(hex(randomblob(16))), factory_name, 'linear', 'linear:' || linear_issue_id, 'migration', '{}', id, 'active', created_at, created_at, created_at, created_at
+		  FROM claws
+		 WHERE factory_name != '' AND linear_issue_id != '' AND status != 'deleted'`,
+		`
+		INSERT OR IGNORE INTO factory_triggers(id, factory_name, integration, trigger_key, trigger_source, trigger_payload, claw_id, status, first_seen_at, last_seen_at, created_at, updated_at)
+		SELECT lower(hex(randomblob(16))), factory_name, 'github-issues', 'github-issues:' || github_issue_id, 'migration', '{}', id, 'active', created_at, created_at, created_at, created_at
+		  FROM claws
+		 WHERE factory_name != '' AND github_issue_id != '' AND status != 'deleted'`,
+		`
+		INSERT OR IGNORE INTO factory_triggers(id, factory_name, integration, trigger_key, trigger_source, trigger_payload, claw_id, status, first_seen_at, last_seen_at, created_at, updated_at)
+		SELECT lower(hex(randomblob(16))), factory_name, 'shortcut', 'shortcut:' || shortcut_story_id, 'migration', '{}', id, 'active', created_at, created_at, created_at, created_at
+		  FROM claws
+		 WHERE factory_name != '' AND shortcut_story_id != '' AND status != 'deleted'`,
+		`
+		INSERT OR IGNORE INTO factory_triggers(id, factory_name, integration, trigger_key, trigger_source, trigger_payload, claw_id, status, first_seen_at, last_seen_at, created_at, updated_at)
+		SELECT lower(hex(randomblob(16))), factory_name, 'jira', 'jira:' || jira_issue_id, 'migration', '{}', id, 'active', created_at, created_at, created_at, created_at
+		  FROM claws
+		 WHERE factory_name != '' AND jira_issue_id != '' AND status != 'deleted'`,
+	} {
+		if _, err := db.Exec(stmt); err != nil {
+			return fmt.Errorf("statement %q: %w", summarizeStmt(stmt), err)
+		}
+	}
+
+	return nil
 }
 
 // pruneFactoryAnalytics deletes factory_analytics rows older than 1 year.

--- a/pkg/hub/db_test.go
+++ b/pkg/hub/db_test.go
@@ -3,10 +3,83 @@ package hub
 import (
 	"database/sql"
 	"encoding/json"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
+
+func TestMigrateIsIdempotent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "hub.db")
+
+	for i := 0; i < 2; i++ {
+		db, err := openDB(path)
+		if err != nil {
+			t.Fatalf("open db (boot %d): %v", i+1, err)
+		}
+		if err := db.Close(); err != nil {
+			t.Fatalf("close db (boot %d): %v", i+1, err)
+		}
+	}
+}
+
+func TestMigrateFailsOnReadOnlyDatabase(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hub.db")
+
+	// Create a valid database first so the file exists.
+	db, err := openDB(path)
+	if err != nil {
+		t.Fatalf("initial open db: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	// Make the database unwritable: read-only file in a read-only directory
+	// (SQLite also needs the directory for the -wal/-journal files).
+	if err := os.Chmod(path, 0o444); err != nil {
+		t.Fatalf("chmod file: %v", err)
+	}
+	if err := os.Chmod(dir, 0o555); err != nil {
+		t.Fatalf("chmod dir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(dir, 0o755)
+		_ = os.Chmod(path, 0o644)
+	})
+
+	_, err = openDB(path)
+	if err == nil {
+		t.Fatal("expected openDB to fail on a read-only database, got nil error")
+	}
+	if !strings.Contains(err.Error(), "migrate") {
+		t.Fatalf("expected a migration error mentioning 'migrate', got: %v", err)
+	}
+}
+
+func TestExecIgnoreDuplicate(t *testing.T) {
+	db, err := openDB(filepath.Join(t.TempDir(), "hub.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	// Duplicate column errors are swallowed: the column already exists.
+	if err := execIgnoreDuplicate(db, `ALTER TABLE claws ADD COLUMN color TEXT NOT NULL DEFAULT ''`); err != nil {
+		t.Fatalf("expected duplicate column to be ignored, got: %v", err)
+	}
+
+	// Any other error surfaces with the offending statement in the message.
+	err = execIgnoreDuplicate(db, `ALTER TABLE no_such_table ADD COLUMN x TEXT`)
+	if err == nil {
+		t.Fatal("expected error for missing table, got nil")
+	}
+	if !strings.Contains(err.Error(), "no_such_table") {
+		t.Fatalf("expected error to mention the statement, got: %v", err)
+	}
+}
 
 func TestClawsTriggerActorJSONDefaultIsValidJSON(t *testing.T) {
 	t.Run("fresh schema", func(t *testing.T) {


### PR DESCRIPTION
Implements item **0.5 Migrations: stop swallowing errors** of the Phase 0 ("stop the bleeding") re-architecture plan.

## Motivation

pkg/hub/db.go runs ~30 ALTER TABLE statements discarding errors; real migration failures (full disk, lock) are invisible and boot continues on a broken schema.

Concretely, `migrate()` executed ~40 statements as `_, _ = db.Exec(...)`: 38 `ALTER TABLE ... ADD COLUMN` statements plus several data migrations (the Shortcut `linear_issue_id` → `shortcut_story_id` move and four `factory_triggers` backfill INSERTs). The blanket swallowing existed because the ALTERs ran *before* the base `CREATE TABLE IF NOT EXISTS` block, so on a fresh database every one of them failed with "no such table" — making it impossible to distinguish the benign "duplicate column name" case from a real failure such as a read-only or locked database. Replacing the migration mechanism itself is out of scope here (Phase 1.4).

## Dependencies

None — branches directly from main.

## What changed

- `pkg/hub/db.go`:
  - The base `IF NOT EXISTS` schema (SQL unchanged) now runs first and its error is checked. On a fresh database the ALTERs then fail with the classifiable "duplicate column name" instead of "no such table".
  - New helper `execIgnoreDuplicate(db *sql.DB, stmt string) error`: ignores only "duplicate column name"; any other error is wrapped with a compacted version of the offending statement and returned, aborting boot via `migrate` → `openDB`.
  - All 38 ALTER statements go through the helper; the data migrations (idempotent by construction: guarded UPDATE, `INSERT OR IGNORE`) now also return their errors.
  - No SQL statement was added, removed, or modified — only reordered and error-checked. The `volume_leases`/`factory_analytics` CREATEs and the duplicated `claw_checkpoints`/`ssh_known_hosts`/`factory_triggers` CREATEs were folded into the single base block so every table exists before its ALTER.
- `pkg/hub/db_test.go`: new tests — `TestMigrateIsIdempotent` (double boot on the same file), `TestMigrateFailsOnReadOnlyDatabase` (read-only file + directory aborts boot with a clear `migrate: ...` error), `TestExecIgnoreDuplicate` (duplicate ignored; other errors surfaced with the statement). The pre-existing `TestClawsTriggerActorJSONDefaultIsValidJSON/migrated_schema` test (old `claws` table upgraded in place) still passes, covering the old-database upgrade path.

## Testing

- `go build ./...` — pass.
- `go test ./pkg/hub/ -run 'TestMigrate|TestExecIgnoreDuplicate|TestClawsTriggerActorJSON' -v` — all pass.
- `go test ./...` (same package set as `make test`, without `-v`) — all packages pass, no failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
