### PR TITLE
feat(hub): recovery middleware and unified JSON error envelope

### DIFF
--- a/pkg/hub/ai_config.go
+++ b/pkg/hub/ai_config.go
@@ -61,28 +61,28 @@ type aiConfigBackupResponse struct {
 
 func (s *Server) handleAIConfig(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 		return
 	}
 	var req aiConfigRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "invalid request", http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid request")
 		return
 	}
 	if req.Message == "" {
-		http.Error(w, "message required", http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "message required")
 		return
 	}
 
 	// Load and sanitize current hub config
 	diskCfg, err := config.LoadHubConfig()
 	if err != nil {
-		http.Error(w, "failed to load hub config: "+err.Error(), http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", "failed to load hub config: "+err.Error())
 		return
 	}
 	sanitized, err := sanitizeHubConfig(diskCfg)
 	if err != nil {
-		http.Error(w, "failed to sanitize config: "+err.Error(), http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", "failed to sanitize config: "+err.Error())
 		return
 	}
 
@@ -94,7 +94,7 @@ func (s *Server) handleAIConfig(w http.ResponseWriter, r *http.Request) {
 
 	reply, err := callLLMForConfig(sanitized, req.Message, req.History, llmKeys, defaultModel)
 	if err != nil {
-		http.Error(w, "LLM error: "+err.Error(), http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", "LLM error: "+err.Error())
 		return
 	}
 
@@ -111,59 +111,59 @@ func (s *Server) handleAIConfig(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleAIConfigApply(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 		return
 	}
 	var req aiConfigApplyRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "invalid request", http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid request")
 		return
 	}
 	if req.ProposedYAML == "" {
-		http.Error(w, "proposed_yaml required", http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "proposed_yaml required")
 		return
 	}
 
 	// Substitute placeholders
 	finalYAML, err := substitutePlaceholders(req.ProposedYAML, req.Secrets)
 	if err != nil {
-		http.Error(w, "invalid yaml: "+err.Error(), http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid yaml: "+err.Error())
 		return
 	}
 
 	// Restore masked secrets (*** from sanitized config) from disk before parsing.
 	diskCfg, err := config.LoadHubConfig()
 	if err != nil {
-		http.Error(w, "failed to load hub config: "+err.Error(), http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", "failed to load hub config: "+err.Error())
 		return
 	}
 	finalYAML, err = restoreMaskedSecretsFromDisk(finalYAML, diskCfg)
 	if err != nil {
-		http.Error(w, "failed to restore masked secrets: "+err.Error(), http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", "failed to restore masked secrets: "+err.Error())
 		return
 	}
 
 	// Parse and validate
 	var newCfg types.HubConfig
 	if err := yaml.Unmarshal([]byte(finalYAML), &newCfg); err != nil {
-		http.Error(w, "invalid yaml: "+err.Error(), http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid yaml: "+err.Error())
 		return
 	}
 	if err := validateHubConfig(&newCfg); err != nil {
-		http.Error(w, "validation failed: "+err.Error(), http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "validation failed: "+err.Error())
 		return
 	}
 
 	// Backup current config
 	backupPath, err := backupHubConfig()
 	if err != nil {
-		http.Error(w, "backup failed: "+err.Error(), http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", "backup failed: "+err.Error())
 		return
 	}
 
 	// Save new config
 	if err := config.SaveHubConfigNoSecretMerge(&newCfg); err != nil {
-		http.Error(w, "save failed: "+err.Error(), http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", "save failed: "+err.Error())
 		return
 	}
 
@@ -177,56 +177,56 @@ func (s *Server) handleAIConfigApply(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleAIConfigRevert(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 		return
 	}
 	var req aiConfigRevertRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "invalid request", http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid request")
 		return
 	}
 	if req.BackupPath == "" {
-		http.Error(w, "backup_path required", http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "backup_path required")
 		return
 	}
 
 	// Validate path to prevent traversal
 	hubYAMLPath, err := config.ActiveHubConfigPath()
 	if err != nil {
-		http.Error(w, "cannot determine hub config path: "+err.Error(), http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", "cannot determine hub config path: "+err.Error())
 		return
 	}
 	cleanHubYAMLPath := filepath.Clean(hubYAMLPath)
 	cleanBackupPath := filepath.Clean(req.BackupPath)
 	expectedPrefix := cleanHubYAMLPath + ".bak."
 	if !strings.HasPrefix(cleanBackupPath, expectedPrefix) {
-		http.Error(w, "invalid backup path", http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid backup path")
 		return
 	}
 	suffix := strings.TrimPrefix(cleanBackupPath, expectedPrefix)
 	if !backupTimestampSuffixRe.MatchString(suffix) {
-		http.Error(w, "invalid backup path", http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid backup path")
 		return
 	}
 
 	data, err := os.ReadFile(cleanBackupPath)
 	if err != nil {
-		http.Error(w, "cannot read backup: "+err.Error(), http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", "cannot read backup: "+err.Error())
 		return
 	}
 
 	var restoredCfg types.HubConfig
 	if err := yaml.Unmarshal(data, &restoredCfg); err != nil {
-		http.Error(w, "backup file is corrupt: "+err.Error(), http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", "backup file is corrupt: "+err.Error())
 		return
 	}
 	if err := validateHubConfig(&restoredCfg); err != nil {
-		http.Error(w, "backup validation failed: "+err.Error(), http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "backup validation failed: "+err.Error())
 		return
 	}
 
 	if err := config.SaveHubConfigNoSecretMerge(&restoredCfg); err != nil {
-		http.Error(w, "save failed: "+err.Error(), http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", "save failed: "+err.Error())
 		return
 	}
 
@@ -240,7 +240,7 @@ func (s *Server) handleAIConfigRevert(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleAIConfigBackup(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 		return
 	}
 
@@ -288,12 +288,12 @@ func (s *Server) handleAIConfigBackup(w http.ResponseWriter, r *http.Request) {
 // By default, secrets are masked. Pass ?reveal=true to get the raw unmasked config.
 func (s *Server) handleAIConfigCurrentConfig(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 		return
 	}
 	diskCfg, err := config.LoadHubConfig()
 	if err != nil {
-		http.Error(w, "failed to load hub config: "+err.Error(), http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", "failed to load hub config: "+err.Error())
 		return
 	}
 
@@ -302,7 +302,7 @@ func (s *Server) handleAIConfigCurrentConfig(w http.ResponseWriter, r *http.Requ
 		// Return raw config with actual secret values
 		raw, err := yaml.Marshal(diskCfg)
 		if err != nil {
-			http.Error(w, "failed to marshal config: "+err.Error(), http.StatusInternalServerError)
+			writeErr(w, http.StatusInternalServerError, "internal", "failed to marshal config: "+err.Error())
 			return
 		}
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
@@ -312,7 +312,7 @@ func (s *Server) handleAIConfigCurrentConfig(w http.ResponseWriter, r *http.Requ
 
 	sanitized, err := sanitizeHubConfig(diskCfg)
 	if err != nil {
-		http.Error(w, "failed to sanitize config: "+err.Error(), http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", "failed to sanitize config: "+err.Error())
 		return
 	}
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
@@ -330,27 +330,27 @@ func (s *Server) handleAIConfigCurrentConfig(w http.ResponseWriter, r *http.Requ
 //	data: {"type":"done"}
 func (s *Server) handleAIConfigStream(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 		return
 	}
 	var req aiConfigRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "invalid request", http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid request")
 		return
 	}
 	if req.Message == "" {
-		http.Error(w, "message required", http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "message required")
 		return
 	}
 
 	diskCfg, err := config.LoadHubConfig()
 	if err != nil {
-		http.Error(w, "failed to load hub config: "+err.Error(), http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", "failed to load hub config: "+err.Error())
 		return
 	}
 	sanitized, err := sanitizeHubConfig(diskCfg)
 	if err != nil {
-		http.Error(w, "failed to sanitize config: "+err.Error(), http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", "failed to sanitize config: "+err.Error())
 		return
 	}
 
@@ -366,7 +366,7 @@ func (s *Server) handleAIConfigStream(w http.ResponseWriter, r *http.Request) {
 
 	flusher, ok := w.(http.Flusher)
 	if !ok {
-		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", "streaming not supported")
 		return
 	}
 

--- a/pkg/hub/auth_github.go
+++ b/pkg/hub/auth_github.go
@@ -124,7 +124,7 @@ func (s *Server) handleGitHubClientID(w http.ResponseWriter, r *http.Request) {
 	cfg := s.hubCfg.Auth
 	s.mu.RUnlock()
 	if cfg == nil || cfg.GitHubOAuth == nil || cfg.GitHubOAuth.ClientID == "" {
-		http.Error(w, "GitHub OAuth not configured", http.StatusNotFound)
+		writeErr(w, http.StatusNotFound, "not_found", "GitHub OAuth not configured")
 		return
 	}
 	w.Header().Set("Cache-Control", "no-store")
@@ -144,7 +144,7 @@ func (s *Server) handleGitHubClientID(w http.ResponseWriter, r *http.Request) {
 // exchanges it with GitHub, validates allowlist, and returns a session token.
 func (s *Server) handleGitHubOAuthExchange(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 		return
 	}
 
@@ -153,13 +153,13 @@ func (s *Server) handleGitHubOAuthExchange(w http.ResponseWriter, r *http.Reques
 	s.mu.RUnlock()
 
 	if cfg == nil || cfg.GitHubOAuth == nil {
-		http.Error(w, "GitHub OAuth not configured", http.StatusNotFound)
+		writeErr(w, http.StatusNotFound, "not_found", "GitHub OAuth not configured")
 		return
 	}
 	oauthCfg := cfg.GitHubOAuth
 	secret := s.webSessionSecret()
 	if secret == "" {
-		http.Error(w, "internal error", http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", "internal error")
 		return
 	}
 
@@ -168,7 +168,7 @@ func (s *Server) handleGitHubOAuthExchange(w http.ResponseWriter, r *http.Reques
 		RedirectURI string `json:"redirect_uri"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Code == "" {
-		http.Error(w, "invalid request", http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid request")
 		return
 	}
 
@@ -176,7 +176,7 @@ func (s *Server) handleGitHubOAuthExchange(w http.ResponseWriter, r *http.Reques
 	accessToken, err := s.githubExchangeCode(r.Context(), oauthCfg.ClientID, oauthCfg.ClientSecret, body.Code, body.RedirectURI)
 	if err != nil {
 		log.Printf("[github-oauth] token exchange error: %v", err)
-		http.Error(w, "token exchange failed", http.StatusBadGateway)
+		writeErr(w, http.StatusBadGateway, "upstream_error", "token exchange failed")
 		return
 	}
 
@@ -184,7 +184,7 @@ func (s *Server) handleGitHubOAuthExchange(w http.ResponseWriter, r *http.Reques
 	ghUser, err := s.githubFetchUser(r.Context(), accessToken)
 	if err != nil {
 		log.Printf("[github-oauth] fetch user error: %v", err)
-		http.Error(w, "fetch user failed", http.StatusBadGateway)
+		writeErr(w, http.StatusBadGateway, "upstream_error", "fetch user failed")
 		return
 	}
 
@@ -192,19 +192,19 @@ func (s *Server) handleGitHubOAuthExchange(w http.ResponseWriter, r *http.Reques
 	allowed, err := s.githubCheckAllowlist(r.Context(), oauthCfg, accessToken, ghUser.Login)
 	if err != nil {
 		log.Printf("[github-oauth] allowlist check error: %v", err)
-		http.Error(w, "allowlist check failed", http.StatusBadGateway)
+		writeErr(w, http.StatusBadGateway, "upstream_error", "allowlist check failed")
 		return
 	}
 	if !allowed {
 		log.Printf("[github-oauth] denied: user %s not in allowlist", ghUser.Login)
-		http.Error(w, "access denied", http.StatusForbidden)
+		writeErr(w, http.StatusForbidden, "forbidden", "access denied")
 		return
 	}
 
 	// Issue signed session token
 	sessionToken, err := signGitHubSession(secret, ghUser.Login, ghUser.Name, ghUser.AvatarURL)
 	if err != nil {
-		http.Error(w, "internal error", http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", "internal error")
 		return
 	}
 

--- a/pkg/hub/checkpoints.go
+++ b/pkg/hub/checkpoints.go
@@ -191,7 +191,7 @@ func (s *Server) handleClawCheckpoints(w http.ResponseWriter, r *http.Request, c
 	if r.Method == http.MethodPost && githubLoginFromContext(r.Context()) != "" {
 		var tagsJSON string
 		if err := s.db.QueryRow(`SELECT COALESCE(tags,'[]') FROM claws WHERE id=? AND tenant_id=?`, clawID, tenantID).Scan(&tagsJSON); err != nil {
-			http.Error(w, "not found", http.StatusNotFound)
+			writeErr(w, http.StatusNotFound, "not_found", "not found")
 			return
 		}
 		var tags []string
@@ -203,18 +203,18 @@ func (s *Server) handleClawCheckpoints(w http.ResponseWriter, r *http.Request, c
 		}
 		s.mu.RUnlock()
 		if !canModifyClaw(accessCfg, githubLoginFromContext(r.Context()), tags) {
-			http.Error(w, "forbidden", http.StatusForbidden)
+			writeErr(w, http.StatusForbidden, "forbidden", "forbidden")
 			return
 		}
 	}
 	parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/api/claws/"), "/")
 	if len(parts) == 4 && parts[1] == "checkpoints" && parts[3] == "restore" {
 		if r.Method != http.MethodPost {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			writeErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 			return
 		}
 		if err := s.restoreClawFromCheckpoint(r.Context(), tenantID, clawID, parts[2]); err != nil {
-			http.Error(w, err.Error(), http.StatusConflict)
+			writeErr(w, http.StatusConflict, "conflict", err.Error())
 			return
 		}
 		w.WriteHeader(http.StatusAccepted)
@@ -224,7 +224,7 @@ func (s *Server) handleClawCheckpoints(w http.ResponseWriter, r *http.Request, c
 	if r.Method == http.MethodGet {
 		rows, err := s.db.Query(`SELECT id, claw_id, status, reason, created_by, manifest_sha256, root_tree_sha256, message_tree_sha256, workspace_tree_sha256, message_count, pr_count, repo_count, error, created_at, completed_at FROM claw_checkpoints WHERE tenant_id=? AND claw_id=? ORDER BY created_at DESC`, tenantID, clawID)
 		if err != nil {
-			http.Error(w, "db error", http.StatusInternalServerError)
+			writeErr(w, http.StatusInternalServerError, "internal", "db error")
 			return
 		}
 		defer rows.Close()
@@ -257,14 +257,14 @@ func (s *Server) handleClawCheckpoints(w http.ResponseWriter, r *http.Request, c
 		}
 		id, err := s.requestCheckpoint(r.Context(), clawID, reason, "user", false, checkpointRequestTimeout)
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusConflict)
+			writeErr(w, http.StatusConflict, "conflict", err.Error())
 			return
 		}
 		w.WriteHeader(http.StatusAccepted)
 		jsonOK(w, map[string]string{"id": id, "status": "creating"})
 		return
 	}
-	http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	writeErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 }
 
 func (s *Server) restoreClawFromCheckpoint(ctx context.Context, tenantID, clawID, checkpointID string) error {

--- a/pkg/hub/error_envelope_test.go
+++ b/pkg/hub/error_envelope_test.go
@@ -1,0 +1,152 @@
+package hub
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+// decodeAPIError asserts the response is the unified JSON error envelope and
+// returns it.
+func decodeAPIError(t *testing.T, rec *httptest.ResponseRecorder) apiError {
+	t.Helper()
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("Content-Type = %q, want application/json (body: %q)", ct, rec.Body.String())
+	}
+	var envelope apiError
+	if err := json.Unmarshal(rec.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("body is not valid JSON: %v (body: %q)", err, rec.Body.String())
+	}
+	return envelope
+}
+
+// Phase 0.2: auth middleware wrapping UI routes must return the JSON error
+// envelope instead of plain-text http.Error.
+func TestAuthMiddlewareReturnsJSONEnvelope(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{
+		Token: "hub-token",
+		Auth: &types.AuthConfig{
+			SessionSecret: "session-secret",
+			Access:        &types.AccessConfig{Admins: []string{"admin-user"}},
+		},
+	}, "", "", "")
+
+	nonAdminSession, err := signGitHubSession("session-secret", "regular-user", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name       string
+		middleware func(http.HandlerFunc) http.HandlerFunc
+		token      string
+		wantStatus int
+		wantCode   string
+	}{
+		{"withAuth missing token", s.withAuth, "", http.StatusUnauthorized, "unauthorized"},
+		{"withAuth invalid token", s.withAuth, "bogus", http.StatusUnauthorized, "unauthorized"},
+		{"withWebAuth missing token", s.withWebAuth, "", http.StatusUnauthorized, "unauthorized"},
+		{"withWebAuth invalid token", s.withWebAuth, "bogus", http.StatusUnauthorized, "unauthorized"},
+		{"withWebAdminAuth invalid token", s.withWebAdminAuth, "bogus", http.StatusUnauthorized, "unauthorized"},
+		{"withWebAdminAuth non-admin session", s.withWebAdminAuth, nonAdminSession, http.StatusForbidden, "forbidden"},
+		{"withConfigMutationAuth missing token", s.withConfigMutationAuth, "", http.StatusUnauthorized, "unauthorized"},
+		{"withConfigMutationAuth non-admin session", s.withConfigMutationAuth, nonAdminSession, http.StatusForbidden, "forbidden"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/settings", nil)
+			if tc.token != "" {
+				req.Header.Set("Authorization", "Bearer "+tc.token)
+			}
+			rec := httptest.NewRecorder()
+			tc.middleware(func(w http.ResponseWriter, r *http.Request) {
+				t.Fatal("handler should not be called")
+			})(rec, req)
+
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d", rec.Code, tc.wantStatus)
+			}
+			envelope := decodeAPIError(t, rec)
+			if envelope.Code != tc.wantCode {
+				t.Fatalf("envelope = %+v, want code %q", envelope, tc.wantCode)
+			}
+		})
+	}
+}
+
+// Phase 0.2: the model-auth login status poll endpoint must return the JSON
+// envelope for a missing job (the frontend polls this URL).
+func TestModelAuthLoginStatusMissingJobReturnsEnvelope(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Token: "hub-token"}, "", "", "")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/settings/model-auth/login/does-not-exist", nil)
+	req.Header.Set("Authorization", "Bearer hub-token")
+	rec := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 (body: %q)", rec.Code, rec.Body.String())
+	}
+	envelope := decodeAPIError(t, rec)
+	if envelope.Code != "not_found" {
+		t.Fatalf("envelope = %+v, want code not_found", envelope)
+	}
+}
+
+// Phase 0.2: canViewMessages error paths (missing claw, OAuth session without
+// tag access) must return the JSON envelope on the timeline/activity routes.
+func TestMessageTimelineAccessErrorsReturnEnvelope(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{
+		Token: "hub-token",
+		Auth: &types.AuthConfig{
+			SessionSecret: "session-secret",
+			Access: &types.AccessConfig{
+				Admins:           []string{"admin-user"},
+				ViewRequiresTags: []string{"user:{user}"},
+			},
+		},
+	}, "", "", "")
+
+	_, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, tags, created_at) VALUES(?,?,?,?,datetime('now'))`,
+		"claw-restricted", "test-tenant-id", "restricted claw", `["user:someone-else"]`,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	session, err := signGitHubSession("session-secret", "regular-user", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name       string
+		url        string
+		wantStatus int
+		wantCode   string
+	}{
+		{"forbidden timeline", "/api/messages/claw-restricted/timeline", http.StatusForbidden, "forbidden"},
+		{"forbidden activity", "/api/messages/claw-restricted/activity", http.StatusForbidden, "forbidden"},
+		{"missing claw timeline", "/api/messages/no-such-claw/timeline", http.StatusNotFound, "not_found"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tc.url, nil)
+			req.Header.Set("Authorization", "Bearer "+session)
+			rec := httptest.NewRecorder()
+			s.Handler().ServeHTTP(rec, req)
+
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d (body: %q)", rec.Code, tc.wantStatus, rec.Body.String())
+			}
+			envelope := decodeAPIError(t, rec)
+			if envelope.Code != tc.wantCode {
+				t.Fatalf("envelope = %+v, want code %q", envelope, tc.wantCode)
+			}
+		})
+	}
+}

--- a/pkg/hub/middleware.go
+++ b/pkg/hub/middleware.go
@@ -1,0 +1,51 @@
+package hub
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"runtime/debug"
+)
+
+// apiError is the single JSON error envelope returned by API handlers.
+// The frontend (web/lib/api.ts) parses the "error" field and falls back to
+// plain text, so handlers can migrate to this envelope gradually.
+type apiError struct {
+	Error string `json:"error"`
+	Code  string `json:"code,omitempty"`
+}
+
+// writeErr writes the unified JSON error envelope with the given HTTP status.
+// code is a stable machine-readable identifier (e.g. "not_found"); msg is a
+// human-readable description safe to surface in the UI.
+func writeErr(w http.ResponseWriter, status int, code, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(apiError{Error: msg, Code: code})
+}
+
+// withRecovery is the outermost middleware: it recovers from panics in any
+// downstream handler, logs the stack trace with the request context available
+// at this phase (method, path, remote addr — request IDs arrive in Phase 1),
+// and responds with a 500 JSON envelope.
+func withRecovery(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			rec := recover()
+			if rec == nil {
+				return
+			}
+			// http.ErrAbortHandler is the stdlib's sentinel to abort a
+			// response without logging a stack trace; preserve that contract.
+			if rec == http.ErrAbortHandler {
+				panic(rec)
+			}
+			log.Printf("[hub] panic recovered: %v (%s %s from %s)\n%s",
+				rec, r.Method, r.URL.Path, r.RemoteAddr, debug.Stack())
+			// Best effort: if the handler already wrote a response this is a
+			// no-op apart from a superfluous-WriteHeader log line.
+			writeErr(w, http.StatusInternalServerError, "internal", "internal server error")
+		}()
+		next.ServeHTTP(w, r)
+	})
+}

--- a/pkg/hub/middleware_test.go
+++ b/pkg/hub/middleware_test.go
@@ -1,0 +1,103 @@
+package hub
+
+import (
+	"bytes"
+	"encoding/json"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestWithRecoveryPanic(t *testing.T) {
+	var logBuf bytes.Buffer
+	prev := log.Writer()
+	log.SetOutput(&logBuf)
+	defer log.SetOutput(prev)
+
+	h := withRecovery(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic("boom")
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("Content-Type = %q, want application/json", ct)
+	}
+	var envelope apiError
+	if err := json.Unmarshal(rec.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("body is not valid JSON: %v (body: %q)", err, rec.Body.String())
+	}
+	if envelope.Error != "internal server error" || envelope.Code != "internal" {
+		t.Fatalf("envelope = %+v, want error=internal server error code=internal", envelope)
+	}
+
+	logged := logBuf.String()
+	if !strings.Contains(logged, "panic recovered: boom") {
+		t.Fatalf("log missing panic message: %q", logged)
+	}
+	if !strings.Contains(logged, "GET /api/test") {
+		t.Fatalf("log missing request info: %q", logged)
+	}
+	if !strings.Contains(logged, "middleware_test.go") {
+		t.Fatalf("log missing stack trace: %q", logged)
+	}
+}
+
+func TestWithRecoveryPassthrough(t *testing.T) {
+	h := withRecovery(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+		_, _ = w.Write([]byte("ok"))
+	}))
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if rec.Code != http.StatusTeapot || rec.Body.String() != "ok" {
+		t.Fatalf("response altered by middleware: %d %q", rec.Code, rec.Body.String())
+	}
+}
+
+func TestWithRecoveryRepanicsOnAbortHandler(t *testing.T) {
+	h := withRecovery(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic(http.ErrAbortHandler)
+	}))
+
+	defer func() {
+		if rec := recover(); rec != http.ErrAbortHandler {
+			t.Fatalf("recover() = %v, want http.ErrAbortHandler", rec)
+		}
+	}()
+	h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+}
+
+func TestWriteErr(t *testing.T) {
+	rec := httptest.NewRecorder()
+	writeErr(rec, http.StatusNotFound, "not_found", "claw not found")
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+	var envelope apiError
+	if err := json.Unmarshal(rec.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("body is not valid JSON: %v", err)
+	}
+	if envelope.Error != "claw not found" || envelope.Code != "not_found" {
+		t.Fatalf("envelope = %+v", envelope)
+	}
+}
+
+func TestWriteErrOmitsEmptyCode(t *testing.T) {
+	rec := httptest.NewRecorder()
+	writeErr(rec, http.StatusBadRequest, "", "bad input")
+
+	if strings.Contains(rec.Body.String(), "code") {
+		t.Fatalf("empty code should be omitted from envelope: %q", rec.Body.String())
+	}
+}

--- a/pkg/hub/model_auth.go
+++ b/pkg/hub/model_auth.go
@@ -56,7 +56,7 @@ const (
 
 func (s *Server) handleModelAuthLogin(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 		return
 	}
 	var req struct {
@@ -65,7 +65,7 @@ func (s *Server) handleModelAuthLogin(w http.ResponseWriter, r *http.Request) {
 		Mode     string `json:"mode"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "invalid request", http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid request")
 		return
 	}
 	req.Provider = strings.TrimSpace(req.Provider)
@@ -77,11 +77,11 @@ func (s *Server) handleModelAuthLogin(w http.ResponseWriter, r *http.Request) {
 		req.Profile = req.Provider + "-default"
 	}
 	if req.Provider != "codex" && req.Provider != "grok" {
-		http.Error(w, "provider must be codex or grok", http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "provider must be codex or grok")
 		return
 	}
 	if req.Mode != "device" {
-		http.Error(w, "only device login is supported", http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "only device login is supported")
 		return
 	}
 
@@ -107,7 +107,7 @@ func (s *Server) handleModelAuthLogin(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleModelAuthLoginStatus(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 		return
 	}
 	id := r.PathValue("id")

--- a/pkg/hub/model_auth.go
+++ b/pkg/hub/model_auth.go
@@ -116,7 +116,7 @@ func (s *Server) handleModelAuthLoginStatus(w http.ResponseWriter, r *http.Reque
 	snapshot := snapshotModelAuthLoginJob(job)
 	s.modelAuthJobsMu.Unlock()
 	if job == nil {
-		http.NotFound(w, r)
+		writeErr(w, http.StatusNotFound, "not_found", "not found")
 		return
 	}
 	jsonOK(w, snapshot)

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -945,14 +945,14 @@ func githubAPIList(path, token string) ([]interface{}, error) {
 func (s *Server) handleClawSubresource(w http.ResponseWriter, r *http.Request) {
 	parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/api/claws/"), "/")
 	if len(parts) < 2 {
-		http.Error(w, "not found", http.StatusNotFound)
+		writeErr(w, http.StatusNotFound, "not_found", "not found")
 		return
 	}
 	clawID := parts[0]
 	sub := parts[1]
 
 	if sub != "prs" && sub != "checkpoints" {
-		http.Error(w, "not found", http.StatusNotFound)
+		writeErr(w, http.StatusNotFound, "not_found", "not found")
 		return
 	}
 
@@ -967,13 +967,13 @@ func (s *Server) handleClawSubresource(w http.ResponseWriter, r *http.Request) {
 
 		var tagsJSON string
 		if err := s.db.QueryRow(`SELECT COALESCE(tags,'[]') FROM claws WHERE id=? AND tenant_id=?`, clawID, tenantFromCtx(r)).Scan(&tagsJSON); err != nil {
-			http.Error(w, "not found", http.StatusNotFound)
+			writeErr(w, http.StatusNotFound, "not_found", "not found")
 			return
 		}
 		var clawTags []string
 		_ = json.Unmarshal([]byte(tagsJSON), &clawTags)
 		if !canViewClaw(accessCfg, ghLogin, clawTags) {
-			http.Error(w, "forbidden", http.StatusForbidden)
+			writeErr(w, http.StatusForbidden, "forbidden", "forbidden")
 			return
 		}
 	}
@@ -991,7 +991,7 @@ func (s *Server) handleClawSubresource(w http.ResponseWriter, r *http.Request) {
 // handleClawPRs returns the list of PRs detected for a claw.
 func (s *Server) handleClawPRs(w http.ResponseWriter, r *http.Request, clawID string) {
 	if r.Method != http.MethodGet {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 		return
 	}
 	tenantID := tenantFromCtx(r)
@@ -999,7 +999,7 @@ func (s *Server) handleClawPRs(w http.ResponseWriter, r *http.Request, clawID st
 	// Verify claw belongs to tenant
 	var exists int
 	if err := s.db.QueryRow(`SELECT 1 FROM claws WHERE id=? AND tenant_id=?`, clawID, tenantID).Scan(&exists); err != nil {
-		http.Error(w, "not found", http.StatusNotFound)
+		writeErr(w, http.StatusNotFound, "not_found", "not found")
 		return
 	}
 
@@ -1008,7 +1008,7 @@ func (s *Server) handleClawPRs(w http.ResponseWriter, r *http.Request, clawID st
 		clawID,
 	)
 	if err != nil {
-		http.Error(w, "db error", http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", "db error")
 		return
 	}
 	defer rows.Close()

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -268,7 +268,7 @@ func (s *Server) Run(opts ...RunOptions) error {
 	if s.hubCfg.UIPassword == "" {
 		log.Printf("⚠️  Web UI password not set — using default: 'admin'. Set ui_password in hub.yaml to secure the UI.")
 	}
-	return http.ListenAndServe(s.addr, corsMiddleware(mux))
+	return http.ListenAndServe(s.addr, withRecovery(corsMiddleware(mux)))
 }
 
 func (s *Server) registerRoutes(mux *http.ServeMux) {
@@ -679,25 +679,25 @@ func (s *Server) withWebAdminAuth(next http.HandlerFunc) http.HandlerFunc {
 
 func (s *Server) handleWebLogin(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 		return
 	}
 	s.mu.RLock()
 	disablePassword := s.hubCfg.Auth != nil && s.hubCfg.Auth.DisablePasswordAuth
 	s.mu.RUnlock()
 	if disablePassword {
-		http.Error(w, "password login disabled", http.StatusForbidden)
+		writeErr(w, http.StatusForbidden, "forbidden", "password login disabled")
 		return
 	}
 	var body struct {
 		Password string `json:"password"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		http.Error(w, "invalid request", http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid request")
 		return
 	}
 	if body.Password != s.resolveUIPassword() {
-		http.Error(w, "invalid password", http.StatusUnauthorized)
+		writeErr(w, http.StatusUnauthorized, "unauthorized", "invalid password")
 		return
 	}
 	s.mu.RLock()
@@ -955,7 +955,7 @@ func (s *Server) handleClaws(w http.ResponseWriter, r *http.Request) {
 	)
 	if err != nil {
 		log.Printf("handleClaws query error: %v", err)
-		http.Error(w, fmt.Sprintf("db error: %v", err), http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", fmt.Sprintf("db error: %v", err))
 		return
 	}
 	defer rows.Close()
@@ -1027,11 +1027,11 @@ func githubIssueURL(issueID string) string {
 func (s *Server) handleCreateClaw(w http.ResponseWriter, r *http.Request, tenantID string) {
 	var req types.CreateClawRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "invalid request", http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid request")
 		return
 	}
 	if req.Name == "" || req.Provider == "" {
-		http.Error(w, "name and provider are required", http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "name and provider are required")
 		return
 	}
 
@@ -1040,7 +1040,7 @@ func (s *Server) handleCreateClaw(w http.ResponseWriter, r *http.Request, tenant
 	provCfg, ok := s.hubCfg.Providers[req.Provider]
 	s.mu.RUnlock()
 	if !ok {
-		http.Error(w, fmt.Sprintf("provider %q is not configured on this hub", req.Provider), http.StatusUnprocessableEntity)
+		writeErr(w, http.StatusUnprocessableEntity, "unprocessable", fmt.Sprintf("provider %q is not configured on this hub", req.Provider))
 		return
 	}
 
@@ -1134,7 +1134,7 @@ func (s *Server) handleCreateClaw(w http.ResponseWriter, r *http.Request, tenant
 		githubReposJSON, linearWorkspace, nixEnabled, dockerEnabled, string(tagsJSON), color, req.LLMKey, "provisioning", now(),
 	)
 	if err != nil {
-		http.Error(w, "db error", http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", "db error")
 		return
 	}
 
@@ -1275,16 +1275,16 @@ func (s *Server) handleClawDetail(w http.ResponseWriter, r *http.Request) {
 			var tagsJSON string
 			if err := s.db.QueryRow(`SELECT COALESCE(tags,'[]') FROM claws WHERE id = ? AND tenant_id = ?`, clawID, tenantID).Scan(&tagsJSON); err != nil {
 				if err == sql.ErrNoRows {
-					http.Error(w, "not found", http.StatusNotFound)
+					writeErr(w, http.StatusNotFound, "not_found", "not found")
 				} else {
-					http.Error(w, "db error", http.StatusInternalServerError)
+					writeErr(w, http.StatusInternalServerError, "internal", "db error")
 				}
 				return
 			}
 			var clawTags []string
 			_ = json.Unmarshal([]byte(tagsJSON), &clawTags)
 			if !canModifyClaw(accessCfg, ghLogin, clawTags) {
-				http.Error(w, "forbidden", http.StatusForbidden)
+				writeErr(w, http.StatusForbidden, "forbidden", "forbidden")
 				return
 			}
 		}
@@ -1294,7 +1294,7 @@ func (s *Server) handleClawDetail(w http.ResponseWriter, r *http.Request) {
 			Color *string   `json:"color"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			http.Error(w, "invalid body", http.StatusBadRequest)
+			writeErr(w, http.StatusBadRequest, "bad_request", "invalid body")
 			return
 		}
 		if body.Name != nil && strings.TrimSpace(*body.Name) != "" {
@@ -1342,16 +1342,16 @@ func (s *Server) handleClawDetail(w http.ResponseWriter, r *http.Request) {
 			var tagsJSON string
 			if err := s.db.QueryRow(`SELECT COALESCE(tags,'[]') FROM claws WHERE id = ? AND tenant_id = ?`, clawID, tenantID).Scan(&tagsJSON); err != nil {
 				if err == sql.ErrNoRows {
-					http.Error(w, "not found", http.StatusNotFound)
+					writeErr(w, http.StatusNotFound, "not_found", "not found")
 				} else {
-					http.Error(w, "db error", http.StatusInternalServerError)
+					writeErr(w, http.StatusInternalServerError, "internal", "db error")
 				}
 				return
 			}
 			var clawTags []string
 			_ = json.Unmarshal([]byte(tagsJSON), &clawTags)
 			if !canModifyClaw(accessCfg, ghLogin, clawTags) {
-				http.Error(w, "forbidden", http.StatusForbidden)
+				writeErr(w, http.StatusForbidden, "forbidden", "forbidden")
 				return
 			}
 		}
@@ -1404,12 +1404,12 @@ func (s *Server) handleClawDetail(w http.ResponseWriter, r *http.Request) {
 		res, err := s.db.Exec(`UPDATE claws SET status='deleted', bootstrap_status='' WHERE id = ? AND tenant_id = ? AND status != 'deleted'`, clawID, tenantID)
 		if err != nil {
 			log.Printf("kill: db soft-delete error for claw %s: %v", clawID, err)
-			http.Error(w, fmt.Sprintf("db error: %v", err), http.StatusInternalServerError)
+			writeErr(w, http.StatusInternalServerError, "internal", fmt.Sprintf("db error: %v", err))
 			return
 		}
 		rowsAffected, err := res.RowsAffected()
 		if err != nil || rowsAffected == 0 {
-			http.Error(w, "not found", http.StatusNotFound)
+			writeErr(w, http.StatusNotFound, "not_found", "not found")
 			return
 		}
 		if clawStatus != "error" {
@@ -1453,15 +1453,15 @@ func (s *Server) handleClawDetail(w http.ResponseWriter, r *http.Request) {
 	).Scan(&c.ID, &c.Name, &c.Template, &c.Provider, &c.ProviderID, &c.Status, &lastSeen, &c.CreatedAt, &c.SSHHost, &c.SSHPort, &c.SSHUser, &tagsJSON, &c.Color, &c.BootstrapStatus, &c.BootstrapDiagnostic, &c.GitHubIssueID)
 	_ = json.Unmarshal([]byte(tagsJSON), &c.Tags)
 	if err == sql.ErrNoRows {
-		http.Error(w, "not found", http.StatusNotFound)
+		writeErr(w, http.StatusNotFound, "not_found", "not found")
 		return
 	}
 	if err != nil {
-		http.Error(w, "db error", http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", "db error")
 		return
 	}
 	if ghLogin != "" && !canViewClaw(accessCfg, ghLogin, c.Tags) {
-		http.Error(w, "forbidden", http.StatusForbidden)
+		writeErr(w, http.StatusForbidden, "forbidden", "forbidden")
 		return
 	}
 	c.TenantID = tenantID
@@ -1491,7 +1491,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	parts := strings.Split(path, "/")
 	clawID := parts[0]
 	if clawID == "" {
-		http.Error(w, "not found", http.StatusNotFound)
+		writeErr(w, http.StatusNotFound, "not_found", "not found")
 		return
 	}
 	if len(parts) > 1 {
@@ -1501,7 +1501,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		case "activity":
 			s.handleMessageActivity(w, r, tenantID, clawID)
 		default:
-			http.Error(w, "not found", http.StatusNotFound)
+			writeErr(w, http.StatusNotFound, "not_found", "not found")
 		}
 		return
 	}
@@ -1520,7 +1520,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 			Content string `json:"content"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Content == "" {
-			http.Error(w, "invalid request", http.StatusBadRequest)
+			writeErr(w, http.StatusBadRequest, "bad_request", "invalid request")
 			return
 		}
 
@@ -1530,16 +1530,16 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 			var tagsJSONMsg string
 			if err := s.db.QueryRow(`SELECT COALESCE(tags,'[]') FROM claws WHERE id = ? AND tenant_id = ?`, clawID, tenantID).Scan(&tagsJSONMsg); err != nil {
 				if err == sql.ErrNoRows {
-					http.Error(w, "not found", http.StatusNotFound)
+					writeErr(w, http.StatusNotFound, "not_found", "not found")
 				} else {
-					http.Error(w, "db error", http.StatusInternalServerError)
+					writeErr(w, http.StatusInternalServerError, "internal", "db error")
 				}
 				return
 			}
 			var clawTagsMsg []string
 			_ = json.Unmarshal([]byte(tagsJSONMsg), &clawTagsMsg)
 			if !canInteractWithClaw(accessCfgMsg, ghLoginMsg, clawTagsMsg) {
-				http.Error(w, "forbidden", http.StatusForbidden)
+				writeErr(w, http.StatusForbidden, "forbidden", "forbidden")
 				return
 			}
 		}
@@ -1552,7 +1552,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 			`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at) VALUES(?,?,?,?,?,?)`,
 			msg.ID, msg.ClawID, msg.TenantID, msg.Role, msg.Content, msg.CreatedAt,
 		); err != nil {
-			http.Error(w, "db error", http.StatusInternalServerError)
+			writeErr(w, http.StatusInternalServerError, "internal", "db error")
 			return
 		}
 		s.recordTaskRunDashboardMessage(clawID, ghLoginMsg, msg.ID)
@@ -1592,13 +1592,13 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		var tagsJSONMsg string
 		err := s.db.QueryRow(`SELECT COALESCE(tags,'[]') FROM claws WHERE id = ? AND tenant_id = ?`, clawID, tenantID).Scan(&tagsJSONMsg)
 		if err == sql.ErrNoRows {
-			http.Error(w, "not found", http.StatusNotFound)
+			writeErr(w, http.StatusNotFound, "not_found", "not found")
 			return
 		}
 		var clawTagsMsg []string
 		_ = json.Unmarshal([]byte(tagsJSONMsg), &clawTagsMsg)
 		if !canViewClaw(accessCfgMsg, ghLoginMsg, clawTagsMsg) {
-			http.Error(w, "forbidden", http.StatusForbidden)
+			writeErr(w, http.StatusForbidden, "forbidden", "forbidden")
 			return
 		}
 	}
@@ -1641,7 +1641,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		)
 	}
 	if err != nil {
-		http.Error(w, "db error", http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", "db error")
 		return
 	}
 	defer rows.Close()
@@ -1688,7 +1688,7 @@ func hiddenSystemMessagesSQL() string {
 
 func (s *Server) handleMessageTimeline(w http.ResponseWriter, r *http.Request, tenantID, clawID string) {
 	if r.Method != http.MethodGet {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 		return
 	}
 	if !s.canViewMessages(w, r, tenantID, clawID) {
@@ -1699,14 +1699,14 @@ func (s *Server) handleMessageTimeline(w http.ResponseWriter, r *http.Request, t
 	before := r.URL.Query().Get("before")
 	rows, err := s.queryConversationMessages(clawID, tenantID, before, limit)
 	if err != nil {
-		http.Error(w, "db error", http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", "db error")
 		return
 	}
 
 	if len(rows) == 0 {
 		summary, err := s.activitySummary(clawID, tenantID, nil, parseTimeCursor(before), "", before)
 		if err != nil {
-			http.Error(w, "db error", http.StatusInternalServerError)
+			writeErr(w, http.StatusInternalServerError, "internal", "db error")
 			return
 		}
 		if summary == nil {
@@ -1721,14 +1721,14 @@ func (s *Server) handleMessageTimeline(w http.ResponseWriter, r *http.Request, t
 	firstCreated := rows[0].CreatedAt
 	hasOlderConversation, err := s.hasConversationBefore(clawID, tenantID, firstCreated)
 	if err != nil {
-		http.Error(w, "db error", http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", "db error")
 		return
 	}
 	if !hasOlderConversation {
 		firstCursor := firstCreated.Format(time.RFC3339Nano)
 		summary, err := s.activitySummary(clawID, tenantID, nil, &firstCreated, "", firstCursor)
 		if err != nil {
-			http.Error(w, "db error", http.StatusInternalServerError)
+			writeErr(w, http.StatusInternalServerError, "internal", "db error")
 			return
 		}
 		if summary != nil {
@@ -1751,7 +1751,7 @@ func (s *Server) handleMessageTimeline(w http.ResponseWriter, r *http.Request, t
 		}
 		summary, err := s.activitySummary(clawID, tenantID, &lower, upper, lowerCursor, upperCursor)
 		if err != nil {
-			http.Error(w, "db error", http.StatusInternalServerError)
+			writeErr(w, http.StatusInternalServerError, "internal", "db error")
 			return
 		}
 		if summary != nil {
@@ -1763,7 +1763,7 @@ func (s *Server) handleMessageTimeline(w http.ResponseWriter, r *http.Request, t
 
 func (s *Server) handleMessageActivity(w http.ResponseWriter, r *http.Request, tenantID, clawID string) {
 	if r.Method != http.MethodGet {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 		return
 	}
 	if !s.canViewMessages(w, r, tenantID, clawID) {
@@ -1816,13 +1816,13 @@ func (s *Server) handleMessageActivity(w http.ResponseWriter, r *http.Request, t
 
 	rows, err := s.db.Query(query, args...)
 	if err != nil {
-		http.Error(w, "db error", http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", "db error")
 		return
 	}
 	defer rows.Close()
 	msgs, err := scanHubMessages(rows)
 	if err != nil {
-		http.Error(w, "db error", http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", "db error")
 		return
 	}
 	if msgs == nil {
@@ -2842,9 +2842,7 @@ func jsonOK(w http.ResponseWriter, v interface{}) {
 }
 
 func jsonError(w http.ResponseWriter, status int, msg string) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+	writeErr(w, status, "", msg)
 }
 
 // Provision creates or updates the default tenant (for alpha single-user setup).

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -418,12 +418,12 @@ func (s *Server) withAuth(next http.HandlerFunc) http.HandlerFunc {
 			token = r.URL.Query().Get("token")
 		}
 		if token == "" {
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			writeErr(w, http.StatusUnauthorized, "unauthorized", "unauthorized")
 			return
 		}
 		tenantID, githubLogin, ok := s.resolveAuthToken(token)
 		if !ok {
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			writeErr(w, http.StatusUnauthorized, "unauthorized", "unauthorized")
 			return
 		}
 		ctx := context.WithValue(r.Context(), ctxTenantKey{}, tenantID)
@@ -463,7 +463,7 @@ func (s *Server) withConfigMutationAuth(next http.HandlerFunc) http.HandlerFunc 
 			queryToken = token != ""
 		}
 		if token == "" {
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			writeErr(w, http.StatusUnauthorized, "unauthorized", "unauthorized")
 			return
 		}
 
@@ -480,7 +480,7 @@ func (s *Server) withConfigMutationAuth(next http.HandlerFunc) http.HandlerFunc 
 			return
 		}
 		if queryToken {
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			writeErr(w, http.StatusUnauthorized, "unauthorized", "unauthorized")
 			return
 		}
 
@@ -488,7 +488,7 @@ func (s *Server) withConfigMutationAuth(next http.HandlerFunc) http.HandlerFunc 
 		if sessionSecret != "" {
 			if payload, ok := verifyGitHubSession(sessionSecret, token); ok {
 				if !isAccessAdmin(accessCfg, payload.Login) {
-					http.Error(w, "forbidden", http.StatusForbidden)
+					writeErr(w, http.StatusForbidden, "forbidden", "forbidden")
 					return
 				}
 				ctx := context.WithValue(r.Context(), ctxGitHubLoginKey{}, payload.Login)
@@ -498,7 +498,7 @@ func (s *Server) withConfigMutationAuth(next http.HandlerFunc) http.HandlerFunc 
 			}
 		}
 
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		writeErr(w, http.StatusUnauthorized, "unauthorized", "unauthorized")
 	}
 }
 
@@ -594,7 +594,7 @@ func (s *Server) withWebAuth(next http.HandlerFunc) http.HandlerFunc {
 			token = r.Header.Get(webSessionHeader)
 		}
 		if token == "" {
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			writeErr(w, http.StatusUnauthorized, "unauthorized", "unauthorized")
 			return
 		}
 		s.mu.RLock()
@@ -619,7 +619,7 @@ func (s *Server) withWebAuth(next http.HandlerFunc) http.HandlerFunc {
 			}
 		}
 
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		writeErr(w, http.StatusUnauthorized, "unauthorized", "unauthorized")
 	}
 }
 
@@ -642,7 +642,7 @@ func (s *Server) withWebAdminAuth(next http.HandlerFunc) http.HandlerFunc {
 			token = r.Header.Get(webSessionHeader)
 		}
 		if token == "" {
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			writeErr(w, http.StatusUnauthorized, "unauthorized", "unauthorized")
 			return
 		}
 		s.mu.RLock()
@@ -663,7 +663,7 @@ func (s *Server) withWebAdminAuth(next http.HandlerFunc) http.HandlerFunc {
 		if sessionSecret != "" {
 			if payload, ok := verifyGitHubSession(sessionSecret, token); ok {
 				if !isAccessAdmin(accessCfg, payload.Login) {
-					http.Error(w, "forbidden", http.StatusForbidden)
+					writeErr(w, http.StatusForbidden, "forbidden", "forbidden")
 					return
 				}
 				ctx := context.WithValue(r.Context(), ctxGitHubLoginKey{}, payload.Login)
@@ -673,7 +673,7 @@ func (s *Server) withWebAdminAuth(next http.HandlerFunc) http.HandlerFunc {
 			}
 		}
 
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		writeErr(w, http.StatusUnauthorized, "unauthorized", "unauthorized")
 	}
 }
 
@@ -1970,17 +1970,17 @@ func (s *Server) canViewMessages(w http.ResponseWriter, r *http.Request, tenantI
 	var tagsJSONMsg string
 	err := s.db.QueryRow(`SELECT COALESCE(tags,'[]') FROM claws WHERE id = ? AND tenant_id = ?`, clawID, tenantID).Scan(&tagsJSONMsg)
 	if err == sql.ErrNoRows {
-		http.Error(w, "not found", http.StatusNotFound)
+		writeErr(w, http.StatusNotFound, "not_found", "not found")
 		return false
 	}
 	if err != nil {
-		http.Error(w, "db error", http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", "db error")
 		return false
 	}
 	var clawTagsMsg []string
 	_ = json.Unmarshal([]byte(tagsJSONMsg), &clawTagsMsg)
 	if !canViewClaw(accessCfgMsg, ghLoginMsg, clawTagsMsg) {
-		http.Error(w, "forbidden", http.StatusForbidden)
+		writeErr(w, http.StatusForbidden, "forbidden", "forbidden")
 		return false
 	}
 	return true

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -436,7 +436,7 @@ func (s *Server) handleSettings(w http.ResponseWriter, r *http.Request) {
 	case http.MethodPatch:
 		s.patchSettings(w, r)
 	default:
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 	}
 }
 
@@ -583,7 +583,7 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 	view.Factories = []FactoryView{}
 	factories, err := loadExternalFactories()
 	if err != nil {
-		http.Error(w, "failed to load factories: "+err.Error(), http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", "failed to load factories: "+err.Error())
 		return
 	}
 	// Sort by name for stable ordering
@@ -770,7 +770,7 @@ func (s *Server) buildGitHubAppView(ctx context.Context, app *types.GitHubAppCon
 // handleGitHubAppTest tests a GitHub App's permissions without saving it.
 func (s *Server) handleGitHubAppTest(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 		return
 	}
 	var req struct {
@@ -779,11 +779,11 @@ func (s *Server) handleGitHubAppTest(w http.ResponseWriter, r *http.Request) {
 		PrivateKeyPEM string `json:"privateKeyPem"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "invalid request", http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid request")
 		return
 	}
 	if req.AppID == 0 || req.PrivateKeyPEM == "" {
-		http.Error(w, "appId and privateKeyPem required", http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "appId and privateKeyPem required")
 		return
 	}
 
@@ -799,7 +799,7 @@ func (s *Server) handleGitHubAppTest(w http.ResponseWriter, r *http.Request) {
 func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 	var patch SettingsPatch
 	if err := json.NewDecoder(r.Body).Decode(&patch); err != nil {
-		http.Error(w, "invalid request", http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid request")
 		return
 	}
 
@@ -1306,11 +1306,11 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 			}
 
 			if err := disk.Validate(); err != nil {
-				http.Error(w, "validation error: "+err.Error(), http.StatusBadRequest)
+				writeErr(w, http.StatusBadRequest, "bad_request", "validation error: "+err.Error())
 				return
 			}
 			if err := saveExternalFactory(disk); err != nil {
-				http.Error(w, "failed to save factory "+fp.Name+": "+err.Error(), http.StatusInternalServerError)
+				writeErr(w, http.StatusInternalServerError, "internal", "failed to save factory "+fp.Name+": "+err.Error())
 				return
 			}
 
@@ -1318,7 +1318,7 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 			// appear as a phantom duplicate in listings.
 			if fp.OriginalName != "" && fp.OriginalName != fp.Name {
 				if err := deleteExternalFactory(fp.OriginalName); err != nil {
-					http.Error(w, "failed to delete old factory "+fp.OriginalName+": "+err.Error(), http.StatusInternalServerError)
+					writeErr(w, http.StatusInternalServerError, "internal", "failed to delete old factory "+fp.OriginalName+": "+err.Error())
 					return
 				}
 			}
@@ -1498,27 +1498,27 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 			}
 			// Validate new entry
 			if mp.Source == "" {
-				http.Error(w, "source required for mcp "+mp.Name, http.StatusBadRequest)
+				writeErr(w, http.StatusBadRequest, "bad_request", "source required for mcp "+mp.Name)
 				return
 			}
 			switch types.MCPSource(mp.Source) {
 			case types.MCPSourceNpx, types.MCPSourceUvx, types.MCPSourceSmithery:
 				if mp.Package == "" {
-					http.Error(w, "package required for mcp "+mp.Name+" source "+mp.Source, http.StatusBadRequest)
+					writeErr(w, http.StatusBadRequest, "bad_request", "package required for mcp "+mp.Name+" source "+mp.Source)
 					return
 				}
 			case types.MCPSourceDocker:
 				if mp.Image == "" {
-					http.Error(w, "image required for mcp "+mp.Name+" source docker", http.StatusBadRequest)
+					writeErr(w, http.StatusBadRequest, "bad_request", "image required for mcp "+mp.Name+" source docker")
 					return
 				}
 			case types.MCPSourceSSE:
 				if mp.URL == "" {
-					http.Error(w, "url required for mcp "+mp.Name+" source sse", http.StatusBadRequest)
+					writeErr(w, http.StatusBadRequest, "bad_request", "url required for mcp "+mp.Name+" source sse")
 					return
 				}
 			default:
-				http.Error(w, "invalid mcp source for "+mp.Name+": must be npx, uvx, smithery, docker, or sse", http.StatusBadRequest)
+				writeErr(w, http.StatusBadRequest, "bad_request", "invalid mcp source for "+mp.Name+": must be npx, uvx, smithery, docker, or sse")
 				return
 			}
 			mcp := &types.MCPServerHubConfig{
@@ -1545,7 +1545,7 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 
 	// Save to disk before applying to in-memory config
 	if err := config.SaveHubConfig(&updatedCfg); err != nil {
-		http.Error(w, "failed to save config: "+err.Error(), http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", "failed to save config: "+err.Error())
 		return
 	}
 


### PR DESCRIPTION
Implements item **0.2 Recovery middleware + error envelope** of the Phase 0 ("stop the bleeding") re-architecture plan.

## Motivation

No handler recovers from panics, and error responses alternate between plain-text http.Error and ad-hoc JSON; the UI needs a single machine-readable error envelope.

Concrete evidence in the code:

- `pkg/hub/server.go` booted with `http.ListenAndServe(s.addr, corsMiddleware(mux))` — nothing in the chain recovers, so a panic in any of the 100+ registered handlers kills the request goroutine, and handlers holding `s.mu` or mid-write can leave shared state corrupted.
- Error responses were inconsistent even within a single handler: `handleClawDetail` used plain-text `http.Error(w, "db error", ...)` while other paths used the ad-hoc `jsonError` helper that emitted `{"error": msg}` with no stable code.
- The frontend (`web/lib/api.ts:78-106`) already tries `JSON.parse` on error bodies and reads `parsed.error`, falling back to raw text — so a gradual migration to a JSON envelope is backward-compatible.

## Dependencies

None — branches directly from main.

Note: the recovery log includes method/path/remote addr only; request IDs arrive in Phase 1, and the remaining (non-UI) handlers migrate to the envelope in Phase 2 together with the `pkg/hub` reorganization, per the spec.

## What changed

- New `pkg/hub/middleware.go`:
  - `apiError` envelope (`{"error": "...", "code": "..."}`, `code` omitted when empty) and `writeErr(w, status, code, msg)` helper.
  - `withRecovery` middleware: recovers panics, logs the stack with method/path/remote addr, responds 500 with the JSON envelope. Re-panics on `http.ErrAbortHandler` to preserve the stdlib contract.
- Wired `withRecovery` at the top of the chain (before CORS) in `Server.Run`.
- Migrated only the handlers the UI uses, per the spec — `/api/claws*` (incl. subresources `prs`/`checkpoints`), `/api/messages*`, `/api/settings*` (incl. `ai-config` and `model-auth`), `/api/auth/*` — replacing `http.Error` with `writeErr` (122 call sites across `server.go`, `settings.go`, `ai_config.go`, `model_auth.go`, `auth_github.go`, `pr_watcher.go`, `checkpoints.go`). Status-derived stable codes: `bad_request`, `unauthorized`, `forbidden`, `not_found`, `method_not_allowed`, `conflict`, `internal`, `upstream_error`, `unprocessable`.
- `jsonError` now delegates to `writeErr` so both paths emit the identical envelope.
- New `pkg/hub/middleware_test.go`: injects a panic into a fake handler and verifies 500 + JSON envelope + logged stack (spec acceptance criterion), plus passthrough, `ErrAbortHandler` re-panic, and `writeErr` encoding tests.

## Testing

- `go build ./...` — pass.
- `go test ./...` (same as `make test` minus `-v`) — all packages pass, including `pkg/hub` (16s) and `pkg/hub/factorytest`.
- `go test ./pkg/hub/ -run "TestWithRecovery|TestWriteErr" -v` — 5/5 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
