### PR TITLE
feat(hub): graceful shutdown with root context and http.Server

### DIFF
--- a/pkg/hub/checkpoints.go
+++ b/pkg/hub/checkpoints.go
@@ -122,11 +122,16 @@ func checkpointManifestPath(id string) string {
 	return filepath.Join(checkpointsRoot(), "manifests", id+".json")
 }
 
-func (s *Server) checkpointScheduler() {
+func (s *Server) checkpointScheduler(ctx context.Context) {
 	ticker := time.NewTicker(time.Minute)
 	defer ticker.Stop()
-	for range ticker.C {
-		s.requestIdleCheckpoints()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.requestIdleCheckpoints()
+		}
 	}
 }
 

--- a/pkg/hub/checkpoints.go
+++ b/pkg/hub/checkpoints.go
@@ -130,12 +130,16 @@ func (s *Server) checkpointScheduler(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			s.requestIdleCheckpoints()
+			s.requestIdleCheckpoints(ctx)
 		}
 	}
 }
 
-func (s *Server) requestIdleCheckpoints() {
+// requestIdleCheckpoints asks idle claws for a checkpoint. Each request runs in
+// its own goroutine tracked by s.bg and receives the scheduler's context, so
+// shutdown both cancels in-flight requests and waits for them before closing
+// the database.
+func (s *Server) requestIdleCheckpoints(ctx context.Context) {
 	now := time.Now()
 	s.mu.RLock()
 	items := make([]struct {
@@ -162,11 +166,13 @@ func (s *Server) requestIdleCheckpoints() {
 		if s.hasRecentCheckpoint(item.id, checkpointMinInterval) {
 			continue
 		}
-		go func(clawID string) {
-			if _, err := s.requestCheckpoint(context.Background(), clawID, "idle-timer", "hub", false, checkpointRequestTimeout); err != nil {
+		clawID := item.id
+		s.bg.Go(func() error {
+			if _, err := s.requestCheckpoint(ctx, clawID, "idle-timer", "hub", false, checkpointRequestTimeout); err != nil {
 				log.Printf("[checkpoint] idle request for %s failed: %v", shortID(clawID), err)
 			}
-		}(item.id)
+			return nil
+		})
 	}
 }
 

--- a/pkg/hub/checkpoints_test.go
+++ b/pkg/hub/checkpoints_test.go
@@ -7,8 +7,10 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/elasticclaw/elasticclaw/pkg/types"
+	"golang.org/x/sync/errgroup"
 	"nhooyr.io/websocket"
 )
 
@@ -29,6 +31,65 @@ func newCheckpointCompletionTestServer(t *testing.T) *Server {
 		hubCfg:            &types.HubConfig{},
 		claws:             map[string]*clawConn{},
 		checkpointWaiters: map[string]chan error{},
+	}
+}
+
+// TestIdleCheckpointRequestTracked verifies that idle checkpoint requests are
+// spawned under the server errgroup: bg.Wait() only returns after the request
+// finished, so Shutdown cannot close the DB underneath an idle checkpoint.
+func TestIdleCheckpointRequestTracked(t *testing.T) {
+	s := newCheckpointCompletionTestServer(t)
+	s.bg = &errgroup.Group{}
+	serverConn, _ := newTestWSPair(t)
+	s.claws["claw"] = &clawConn{
+		id:                "claw",
+		tenantID:          "tenant",
+		conn:              serverConn,
+		lastUserMessageAt: time.Now().Add(-time.Hour),
+	}
+
+	s.requestIdleCheckpoints(context.Background())
+	if err := s.bg.Wait(); err != nil {
+		t.Fatalf("bg.Wait: %v", err)
+	}
+
+	var status string
+	if err := s.db.QueryRow(`SELECT status FROM claw_checkpoints WHERE claw_id='claw' AND reason='idle-timer'`).Scan(&status); err != nil {
+		t.Fatalf("idle checkpoint row not found: %v", err)
+	}
+	if status != "creating" {
+		t.Fatalf("idle checkpoint status = %q, want creating", status)
+	}
+}
+
+// TestIdleCheckpointRequestUsesSchedulerContext verifies the scheduler context
+// is propagated into the checkpoint request, so shutdown cancellation unblocks
+// in-flight idle checkpoint dispatches instead of leaving them running on
+// context.Background().
+func TestIdleCheckpointRequestUsesSchedulerContext(t *testing.T) {
+	s := newCheckpointCompletionTestServer(t)
+	s.bg = &errgroup.Group{}
+	serverConn, _ := newTestWSPair(t)
+	s.claws["claw"] = &clawConn{
+		id:                "claw",
+		tenantID:          "tenant",
+		conn:              serverConn,
+		lastUserMessageAt: time.Now().Add(-time.Hour),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // simulate shutdown already in progress
+	s.requestIdleCheckpoints(ctx)
+	if err := s.bg.Wait(); err != nil {
+		t.Fatalf("bg.Wait: %v", err)
+	}
+
+	var status string
+	if err := s.db.QueryRow(`SELECT status FROM claw_checkpoints WHERE claw_id='claw' AND reason='idle-timer'`).Scan(&status); err != nil {
+		t.Fatalf("idle checkpoint row not found: %v", err)
+	}
+	if status != "failed" {
+		t.Fatalf("idle checkpoint status with cancelled context = %q, want failed", status)
 	}
 }
 

--- a/pkg/hub/cron_scheduler.go
+++ b/pkg/hub/cron_scheduler.go
@@ -1,6 +1,7 @@
 package hub
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -75,15 +76,22 @@ func (cs *cronScheduler) start() error {
 	return nil
 }
 
-// stop gracefully shuts down the cron scheduler.
-func (cs *cronScheduler) stop() {
+// stop gracefully shuts down the cron scheduler. It waits for running jobs to
+// finish, but no longer than the drain context allows: a stuck job must not
+// hold up the rest of the hub shutdown sequence.
+func (cs *cronScheduler) stop(ctx context.Context) {
 	cs.mu.Lock()
 	defer cs.mu.Unlock()
 
-	if cs.cron != nil {
-		ctx := cs.cron.Stop()
-		<-ctx.Done()
+	if cs.cron == nil {
+		return
+	}
+	stopped := cs.cron.Stop()
+	select {
+	case <-stopped.Done():
 		log.Println("[cron] scheduler stopped")
+	case <-ctx.Done():
+		log.Printf("[cron] scheduler stop timed out with jobs still running: %v", ctx.Err())
 	}
 }
 

--- a/pkg/hub/cron_scheduler_test.go
+++ b/pkg/hub/cron_scheduler_test.go
@@ -1,12 +1,48 @@
 package hub
 
 import (
+	"context"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 	"github.com/robfig/cron/v3"
 )
+
+// TestCronStopBoundedByDrainContext verifies that a stuck cron job cannot
+// hold up hub shutdown: stop returns once the drain context expires even if
+// running jobs never finish.
+func TestCronStopBoundedByDrainContext(t *testing.T) {
+	cs := newCronScheduler(nil)
+	cs.cron = cron.New(cron.WithSeconds())
+
+	started := make(chan struct{})
+	block := make(chan struct{})
+	t.Cleanup(func() { close(block) })
+	var once sync.Once
+	cs.cron.Schedule(cron.Every(time.Second), cron.FuncJob(func() {
+		once.Do(func() { close(started) })
+		<-block
+	}))
+	cs.cron.Start()
+
+	select {
+	case <-started:
+	case <-time.After(10 * time.Second):
+		t.Fatal("cron job never started")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	done := make(chan struct{})
+	go func() { cs.stop(ctx); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("cron stop blocked past the drain window on a stuck job")
+	}
+}
 
 func TestParseCronSchedule(t *testing.T) {
 	tests := []struct {

--- a/pkg/hub/integration_poller.go
+++ b/pkg/hub/integration_poller.go
@@ -2,6 +2,7 @@ package hub
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -14,19 +15,21 @@ import (
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
 
-// startIntegrationPoller launches the background polling goroutine that queries
-// each configured integration's API every 30 seconds to detect missed webhook
-// events. It evaluates factory/workflow filters against current state and
-// creates agents when the matching trigger has not already claimed that
-// external item.
-func (s *Server) startIntegrationPoller() {
-	go func() {
-		ticker := time.NewTicker(30 * time.Second)
-		defer ticker.Stop()
-		for range ticker.C {
+// pollIntegrationsLoop queries each configured integration's API every 30
+// seconds to detect missed webhook events. It evaluates factory/workflow
+// filters against current state and creates agents when the matching trigger
+// has not already claimed that external item. Exits when ctx is cancelled.
+func (s *Server) pollIntegrationsLoop(ctx context.Context) {
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
 			s.pollTick()
 		}
-	}()
+	}
 }
 
 // pollTick queries integration platforms for recently updated items and

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -140,15 +140,18 @@ func (s *Server) scanMessageForPRs(clawID, content string) {
 	}
 }
 
-// startPRWatcher launches the background poller.
-func (s *Server) startPRWatcher() {
-	go func() {
-		ticker := time.NewTicker(10 * time.Second)
-		defer ticker.Stop()
-		for range ticker.C {
+// watchPRs runs the PR polling loop until ctx is cancelled.
+func (s *Server) watchPRs(ctx context.Context) {
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
 			s.pollAllPRs()
 		}
-	}()
+	}
 }
 
 type clawPR struct {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -16,12 +17,15 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path"
 	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/elasticclaw/elasticclaw/internal/webui"
@@ -35,6 +39,7 @@ import (
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 	"github.com/google/uuid"
 	gossh "golang.org/x/crypto/ssh"
+	"golang.org/x/sync/errgroup"
 	"nhooyr.io/websocket"
 	"nhooyr.io/websocket/wsjson"
 )
@@ -92,6 +97,19 @@ type Server struct {
 
 	// cronScheduler manages scheduled workflow runs
 	cronScheduler *cronScheduler
+
+	// Graceful shutdown machinery.
+	// bgCtx is the root context handed to every background goroutine; bgCancel
+	// cancels it during shutdown. bg waits for all background goroutines.
+	bgCtx    context.Context
+	bgCancel context.CancelFunc
+	bg       *errgroup.Group
+	// httpSrv is the HTTP server started by Run (nil in tests that use Handler()).
+	httpSrv *http.Server
+	// draining is set once shutdown starts; /healthz returns 503 while draining.
+	draining atomic.Bool
+	// shutdownOnce guards Shutdown so it runs at most once.
+	shutdownOnce sync.Once
 }
 
 type clawConn struct {
@@ -221,20 +239,24 @@ func NewServer(addr, dbPath, identityDir string, hubCfg *types.HubConfig) (*Serv
 		webhookDedup:      make(map[string]time.Time),
 	}
 
-	// Start background poller to keep provider VM status fresh
-	go srv.pollProviderStatus()
-	go srv.keepAliveDaytonaSandboxes()
-	go srv.pruneAnalytics()
-	go srv.statusWatchdog()
-	go srv.checkpointScheduler()
-	srv.startPRWatcher()
+	srv.bgCtx, srv.bgCancel = context.WithCancel(context.Background())
+	srv.bg = &errgroup.Group{}
+
+	// Start background pollers; each one exits when bgCtx is cancelled and is
+	// waited on by Shutdown via the errgroup.
+	srv.bg.Go(func() error { srv.pollProviderStatus(srv.bgCtx); return nil })
+	srv.bg.Go(func() error { srv.keepAliveDaytonaSandboxes(srv.bgCtx); return nil })
+	srv.bg.Go(func() error { srv.pruneAnalytics(srv.bgCtx); return nil })
+	srv.bg.Go(func() error { srv.statusWatchdog(srv.bgCtx); return nil })
+	srv.bg.Go(func() error { srv.checkpointScheduler(srv.bgCtx); return nil })
+	srv.bg.Go(func() error { srv.watchPRs(srv.bgCtx); return nil })
+	srv.bg.Go(func() error { srv.pollIntegrationsLoop(srv.bgCtx); return nil })
 
 	// Start cron scheduler for workflow triggers
 	srv.cronScheduler = newCronScheduler(srv)
 	if err := srv.cronScheduler.start(); err != nil {
 		log.Printf("[cron] failed to start scheduler: %v", err)
 	}
-	srv.startIntegrationPoller()
 
 	return srv, nil
 }
@@ -268,7 +290,113 @@ func (s *Server) Run(opts ...RunOptions) error {
 	if s.hubCfg.UIPassword == "" {
 		log.Printf("⚠️  Web UI password not set — using default: 'admin'. Set ui_password in hub.yaml to secure the UI.")
 	}
-	return http.ListenAndServe(s.addr, corsMiddleware(mux))
+
+	// Root context cancelled on SIGINT/SIGTERM so we can shut down gracefully.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	s.httpSrv = &http.Server{
+		Addr:              s.addr,
+		Handler:           corsMiddleware(mux),
+		ReadHeaderTimeout: 10 * time.Second,
+		IdleTimeout:       120 * time.Second,
+	}
+
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- s.httpSrv.ListenAndServe() }()
+
+	select {
+	case err := <-serveErr:
+		// Listener failed before any shutdown signal (e.g. port in use).
+		return err
+	case <-ctx.Done():
+		grace := s.shutdownGrace()
+		log.Printf("[hub] shutdown signal received — draining for up to %s", grace)
+		drainCtx, cancel := context.WithTimeout(context.Background(), grace)
+		defer cancel()
+		return s.Shutdown(drainCtx)
+	}
+}
+
+// shutdownGrace returns the configured drain timeout (hub.yaml: shutdown_grace),
+// defaulting to 15s.
+func (s *Server) shutdownGrace() time.Duration {
+	if s.hubCfg != nil && s.hubCfg.ShutdownGrace != "" {
+		if d, err := time.ParseDuration(s.hubCfg.ShutdownGrace); err == nil && d > 0 {
+			return d
+		}
+		log.Printf("[hub] invalid shutdown_grace %q — using default 15s", s.hubCfg.ShutdownGrace)
+	}
+	return 15 * time.Second
+}
+
+// Shutdown gracefully stops the hub:
+//  1. mark the server as draining (/healthz starts returning 503),
+//  2. stop accepting new connections and drain in-flight HTTP requests,
+//  3. close claw WebSocket connections with a close frame ("killed" is NOT
+//     sent — the sandboxes stay alive and reconnect when the hub returns),
+//  4. cancel the root context and wait for all background goroutines,
+//  5. stop the cron scheduler and close the database.
+//
+// It is safe to call Shutdown multiple times; only the first call runs.
+func (s *Server) Shutdown(ctx context.Context) error {
+	var err error
+	s.shutdownOnce.Do(func() {
+		s.draining.Store(true)
+
+		if s.httpSrv != nil {
+			log.Printf("[hub] draining HTTP connections")
+			if shutdownErr := s.httpSrv.Shutdown(ctx); shutdownErr != nil && !errors.Is(shutdownErr, http.ErrServerClosed) {
+				log.Printf("[hub] HTTP drain incomplete: %v", shutdownErr)
+				err = shutdownErr
+			}
+		}
+
+		log.Printf("[hub] closing claw connections")
+		s.closeClawConnections()
+
+		log.Printf("[hub] stopping background goroutines")
+		s.bgCancel()
+		_ = s.bg.Wait()
+
+		if s.cronScheduler != nil {
+			s.cronScheduler.stop()
+		}
+
+		log.Printf("[hub] closing database")
+		if dbErr := s.db.Close(); dbErr != nil {
+			log.Printf("[hub] db close: %v", dbErr)
+			if err == nil {
+				err = dbErr
+			}
+		}
+		log.Printf("[hub] shutdown complete")
+	})
+	return err
+}
+
+// closeClawConnections sends a close frame to every connected claw bridge so
+// the bridge knows the hub is going away (as opposed to a network failure).
+// The sandbox itself is left running; bridges reconnect when the hub is back.
+func (s *Server) closeClawConnections() {
+	s.mu.RLock()
+	conns := make([]*clawConn, 0, len(s.claws))
+	for _, cc := range s.claws {
+		conns = append(conns, cc)
+	}
+	s.mu.RUnlock()
+
+	for _, cc := range conns {
+		cc.mu.RLock()
+		conn, statusConn := cc.conn, cc.statusConn
+		cc.mu.RUnlock()
+		if statusConn != nil {
+			_ = statusConn.Close(websocket.StatusGoingAway, "hub shutting down")
+		}
+		if conn != nil {
+			_ = conn.Close(websocket.StatusGoingAway, "hub shutting down")
+		}
+	}
 }
 
 func (s *Server) registerRoutes(mux *http.ServeMux) {
@@ -359,8 +487,13 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/doctor", s.withWebAdminAuth(s.handleDoctor))
 	mux.HandleFunc("/api/troubleshoot/stream", s.withWebAdminAuth(s.handleTroubleshootStream))
 
-	// Health
+	// Health — returns 503 while the hub is draining so load balancers stop
+	// routing new traffic during shutdown.
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		if s.draining.Load() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
 		w.WriteHeader(http.StatusOK)
 	})
 	if bridgePath, bridgeToken := os.Getenv("ELASTICCLAW_E2E_BRIDGE_BINARY"), os.Getenv("ELASTICCLAW_E2E_BRIDGE_TOKEN"); bridgePath != "" && bridgeToken != "" {
@@ -4635,30 +4768,45 @@ func (s *Server) provisionReplicated(ctx context.Context, clawID string, req typ
 
 // ─── Provider status polling ──────────────────────────────────────────────────
 
-// pollProviderStatus runs forever, polling providers every 30s for VMs in
-// non-terminal states and updating claw status accordingly.
-func (s *Server) pollProviderStatus() {
+// pollProviderStatus polls providers for VMs in non-terminal states and
+// updates claw status accordingly. Exits when ctx is cancelled.
+func (s *Server) pollProviderStatus(ctx context.Context) {
 	ticker := time.NewTicker(3 * time.Second)
 	defer ticker.Stop()
-	for range ticker.C {
-		s.syncReplicatedVMs()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.syncReplicatedVMs()
+		}
 	}
 }
 
-func (s *Server) keepAliveDaytonaSandboxes() {
+func (s *Server) keepAliveDaytonaSandboxes(ctx context.Context) {
 	ticker := time.NewTicker(5 * time.Minute)
 	defer ticker.Stop()
-	for range ticker.C {
-		s.petDaytonaSandboxes()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.petDaytonaSandboxes()
+		}
 	}
 }
 
 // pruneAnalytics runs a daily cleanup of factory_analytics rows older than 1 year.
-func (s *Server) pruneAnalytics() {
+func (s *Server) pruneAnalytics(ctx context.Context) {
 	ticker := time.NewTicker(24 * time.Hour)
 	defer ticker.Stop()
-	for range ticker.C {
-		pruneFactoryAnalytics(s.db)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			pruneFactoryAnalytics(s.db)
+		}
 	}
 }
 
@@ -4715,11 +4863,16 @@ func (s *Server) petDaytonaSandboxes() {
 
 // statusWatchdog runs every 2 minutes to check claw health and request status
 // updates from the status channel. It also detects silent deaths and alerts the user.
-func (s *Server) statusWatchdog() {
+func (s *Server) statusWatchdog(ctx context.Context) {
 	ticker := time.NewTicker(2 * time.Minute)
 	defer ticker.Stop()
-	for range ticker.C {
-		s.checkClawStatus()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.checkClawStatus()
+		}
 	}
 }
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -344,12 +344,16 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	s.shutdownOnce.Do(func() {
 		s.draining.Store(true)
 
+		// Stop accepting new connections and drain in-flight HTTP requests in
+		// the background: http.Server.Shutdown closes the listeners immediately
+		// but blocks until active handlers finish (or ctx expires), and claw
+		// close frames must go out before the drain window is spent.
+		httpDone := make(chan error, 1)
 		if s.httpSrv != nil {
 			log.Printf("[hub] draining HTTP connections")
-			if shutdownErr := s.httpSrv.Shutdown(ctx); shutdownErr != nil && !errors.Is(shutdownErr, http.ErrServerClosed) {
-				log.Printf("[hub] HTTP drain incomplete: %v", shutdownErr)
-				err = shutdownErr
-			}
+			go func() { httpDone <- s.httpSrv.Shutdown(ctx) }()
+		} else {
+			httpDone <- nil
 		}
 
 		log.Printf("[hub] closing claw connections")
@@ -357,10 +361,26 @@ func (s *Server) Shutdown(ctx context.Context) error {
 
 		log.Printf("[hub] stopping background goroutines")
 		s.bgCancel()
-		_ = s.bg.Wait()
+		bgDone := make(chan struct{})
+		go func() { _ = s.bg.Wait(); close(bgDone) }()
+		select {
+		case <-bgDone:
+		case <-ctx.Done():
+			log.Printf("[hub] background goroutines did not finish within drain window: %v", ctx.Err())
+			err = ctx.Err()
+		}
+
+		// http.Server.Shutdown returns ctx.Err() itself once the drain
+		// context expires, so this wait is bounded by the drain window.
+		if shutdownErr := <-httpDone; shutdownErr != nil && !errors.Is(shutdownErr, http.ErrServerClosed) {
+			log.Printf("[hub] HTTP drain incomplete: %v", shutdownErr)
+			if err == nil {
+				err = shutdownErr
+			}
+		}
 
 		if s.cronScheduler != nil {
-			s.cronScheduler.stop()
+			s.cronScheduler.stop(ctx)
 		}
 
 		log.Printf("[hub] closing database")

--- a/pkg/hub/shutdown_test.go
+++ b/pkg/hub/shutdown_test.go
@@ -1,0 +1,117 @@
+package hub
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+// TestGracefulShutdown boots a full server (background goroutines included)
+// and verifies Shutdown cancels the root context, waits for all background
+// goroutines, and closes the database — all within the drain window.
+func TestGracefulShutdown(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	dir := t.TempDir()
+
+	s, err := NewServer("127.0.0.1:0", filepath.Join(dir, "hub.db"), dir, &types.HubConfig{})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		done <- s.Shutdown(ctx)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Shutdown: %v", err)
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatal("Shutdown did not complete within 20s")
+	}
+
+	// The root context must be cancelled so background goroutines exited.
+	select {
+	case <-s.bgCtx.Done():
+	default:
+		t.Fatal("background context not cancelled after Shutdown")
+	}
+
+	// All background goroutines must have returned (Wait does not block).
+	waitDone := make(chan struct{})
+	go func() {
+		_ = s.bg.Wait()
+		close(waitDone)
+	}()
+	select {
+	case <-waitDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("background goroutines still running after Shutdown")
+	}
+
+	// The database must be closed.
+	if err := s.db.Ping(); err == nil {
+		t.Fatal("database still open after Shutdown")
+	}
+
+	// A second Shutdown is a no-op and must not panic or error.
+	if err := s.Shutdown(context.Background()); err != nil {
+		t.Fatalf("second Shutdown: %v", err)
+	}
+}
+
+// TestHealthzReturns503WhileDraining verifies /healthz flips from 200 to 503
+// once shutdown starts, so load balancers stop routing traffic during drain.
+func TestHealthzReturns503WhileDraining(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, nil, "", "", "")
+	srv := httptest.NewServer(s.Handler())
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/healthz")
+	if err != nil {
+		t.Fatalf("GET /healthz: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("healthz before drain: got %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	s.draining.Store(true)
+
+	resp, err = http.Get(srv.URL + "/healthz")
+	if err != nil {
+		t.Fatalf("GET /healthz during drain: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("healthz during drain: got %d, want %d", resp.StatusCode, http.StatusServiceUnavailable)
+	}
+}
+
+func TestShutdownGraceConfig(t *testing.T) {
+	cases := []struct {
+		cfg  string
+		want time.Duration
+	}{
+		{"", 15 * time.Second},
+		{"30s", 30 * time.Second},
+		{"1m", time.Minute},
+		{"bogus", 15 * time.Second},
+		{"-5s", 15 * time.Second},
+	}
+	for _, tc := range cases {
+		s := &Server{hubCfg: &types.HubConfig{ShutdownGrace: tc.cfg}}
+		if got := s.shutdownGrace(); got != tc.want {
+			t.Errorf("shutdownGrace(%q) = %s, want %s", tc.cfg, got, tc.want)
+		}
+	}
+}

--- a/pkg/hub/shutdown_test.go
+++ b/pkg/hub/shutdown_test.go
@@ -2,14 +2,48 @@ package hub
 
 import (
 	"context"
+	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/elasticclaw/elasticclaw/pkg/types"
+	"nhooyr.io/websocket"
 )
+
+// newTestWSPair returns both ends of a live WebSocket connection: the
+// server-accepted conn (what the hub stores in s.claws) and the dialing
+// client conn (what a claw bridge would hold).
+func newTestWSPair(t *testing.T) (serverConn, clientConn *websocket.Conn) {
+	t.Helper()
+	connCh := make(chan *websocket.Conn, 1)
+	done := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		connCh <- c
+		<-done // keep the handler (and thus the conn) alive until test cleanup
+	}))
+	t.Cleanup(srv.Close)
+	t.Cleanup(func() { close(done) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	client, _, err := websocket.Dial(ctx, "ws"+strings.TrimPrefix(srv.URL, "http"), nil)
+	if err != nil {
+		t.Fatalf("websocket dial: %v", err)
+	}
+	t.Cleanup(func() { _ = client.CloseNow() })
+	server := <-connCh
+	t.Cleanup(func() { _ = server.CloseNow() })
+	return server, client
+}
 
 // TestGracefulShutdown boots a full server (background goroutines included)
 // and verifies Shutdown cancels the root context, waits for all background
@@ -94,6 +128,99 @@ func TestHealthzReturns503WhileDraining(t *testing.T) {
 	resp.Body.Close()
 	if resp.StatusCode != http.StatusServiceUnavailable {
 		t.Fatalf("healthz during drain: got %d, want %d", resp.StatusCode, http.StatusServiceUnavailable)
+	}
+}
+
+// TestShutdownBoundedByDrainWindow verifies that a background goroutine that
+// never observes cancellation cannot hold Shutdown past the drain context:
+// Shutdown must return once the drain window expires (Phase 0.1 acceptance:
+// SIGTERM exits within the drain window).
+func TestShutdownBoundedByDrainWindow(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	dir := t.TempDir()
+
+	s, err := NewServer("127.0.0.1:0", filepath.Join(dir, "hub.db"), dir, &types.HubConfig{})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	// A stuck goroutine that ignores the root context.
+	block := make(chan struct{})
+	s.bg.Go(func() error { <-block; return nil })
+	t.Cleanup(func() { close(block) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- s.Shutdown(ctx) }()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("Shutdown error = %v, want context.DeadlineExceeded", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Shutdown blocked past the drain window on a stuck goroutine")
+	}
+}
+
+// TestShutdownClosesClawsBeforeHTTPDrainCompletes verifies the Phase 0.1
+// shutdown order: claw WebSocket close frames must be sent as soon as the
+// listener stops accepting, not after in-flight HTTP requests finish draining.
+func TestShutdownClosesClawsBeforeHTTPDrainCompletes(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	dir := t.TempDir()
+
+	s, err := NewServer("127.0.0.1:0", filepath.Join(dir, "hub.db"), dir, &types.HubConfig{})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	serverConn, clientConn := newTestWSPair(t)
+	s.mu.Lock()
+	s.claws["claw-1"] = &clawConn{id: "claw-1", conn: serverConn}
+	s.mu.Unlock()
+
+	// HTTP server with one in-flight request that hangs until released.
+	handlerStarted := make(chan struct{})
+	release := make(chan struct{})
+	s.httpSrv = &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(handlerStarted)
+		<-release
+	})}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	go func() { _ = s.httpSrv.Serve(ln) }()
+	go func() { _, _ = http.Get("http://" + ln.Addr().String() + "/hang") }()
+	<-handlerStarted
+
+	shutdownDone := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		shutdownDone <- s.Shutdown(ctx)
+	}()
+
+	// The claw must see the close frame while the HTTP request is still draining.
+	readErr := make(chan error, 1)
+	go func() {
+		_, _, err := clientConn.Read(context.Background())
+		readErr <- err
+	}()
+	select {
+	case err := <-readErr:
+		if websocket.CloseStatus(err) != websocket.StatusGoingAway {
+			t.Fatalf("claw close status = %v, want StatusGoingAway", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("claw connection was not closed while HTTP drain was still in flight")
+	}
+
+	close(release)
+	if err := <-shutdownDone; err != nil {
+		t.Fatalf("Shutdown: %v", err)
 	}
 }
 

--- a/pkg/hub/testhelpers.go
+++ b/pkg/hub/testhelpers.go
@@ -3,12 +3,14 @@
 package hub
 
 import (
+	"context"
 	"database/sql"
 	"net/http"
 	"time"
 
 	"github.com/elasticclaw/elasticclaw/pkg/hub/artifact"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
+	"golang.org/x/sync/errgroup"
 )
 
 // NewTestServerWithConfig creates a Server for integration testing with mock backends.
@@ -62,6 +64,13 @@ func NewTestServerWithConfig(t interface {
 		linearBaseURL:    linearBaseURL,
 		shortcutBaseURL:  shortcutBaseURL,
 	}
+	s.bgCtx, s.bgCancel = context.WithCancel(context.Background())
+	s.bg = &errgroup.Group{}
+	t.Cleanup(func() {
+		s.bgCancel()
+		_ = s.bg.Wait()
+	})
+
 	// Register routes (same as Run but without serving web UI or starting relay)
 	mux := http.NewServeMux()
 	s.registerRoutes(mux)
@@ -142,7 +151,7 @@ func (s *Server) PollPRsForTest() {
 
 // StartPRWatcherForTest starts the PR watcher background goroutine.
 func (s *Server) StartPRWatcherForTest() {
-	s.startPRWatcher()
+	s.bg.Go(func() error { s.watchPRs(s.bgCtx); return nil })
 }
 
 // PollIntegrationsForTest triggers an immediate integration poll tick (for testing without waiting for the ticker).

--- a/pkg/hub/workspace_api_test.go
+++ b/pkg/hub/workspace_api_test.go
@@ -1,6 +1,7 @@
 package hub
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -281,7 +282,7 @@ func TestCronSchedulerStartLoadsExternalWorkflows(t *testing.T) {
 	if err := s.cronScheduler.start(); err != nil {
 		t.Fatalf("start cron scheduler: %v", err)
 	}
-	t.Cleanup(s.cronScheduler.stop)
+	t.Cleanup(func() { s.cronScheduler.stop(context.Background()) })
 
 	if _, ok := s.cronScheduler.entries["engineering/dependency-update-go"]; !ok {
 		t.Fatalf("cron workflow was not registered on startup: %#v", s.cronScheduler.entries)

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -536,6 +536,11 @@ type HubConfig struct {
 	// Factories can be assigned to a group; unassigned factories use the "global" group.
 	ConcurrencyGroups []*ConcurrencyGroup `yaml:"concurrency_groups,omitempty" json:"concurrencyGroups,omitempty"`
 
+	// ShutdownGrace is how long the hub waits for in-flight HTTP requests to
+	// drain after receiving SIGINT/SIGTERM before forcing exit.
+	// Accepts a Go duration string (e.g. "15s", "1m"). Defaults to 15s.
+	ShutdownGrace string `yaml:"shutdown_grace,omitempty" json:"shutdownGrace,omitempty"`
+
 	// MaxConcurrentClaws limits the number of simultaneously running claws.
 	// DEPRECATED: Use ConcurrencyGroups instead. Kept for backward compat.
 	// When the limit is reached, new factory-created claws enter 'pending' status


### PR DESCRIPTION
Implements item **0.1 Graceful shutdown** of the Phase 0 ("stop the bleeding") re-architecture plan.

## Motivation

The hub boots with bare `http.ListenAndServe` and 8+ background goroutines with no cancellation; SIGTERM kills the process mid-SQLite-write and drops WS connections without a goodbye.

Concrete evidence in the code before this change:

- `pkg/hub/server.go` `Run()` ended in `return http.ListenAndServe(s.addr, corsMiddleware(mux))` — no timeouts, no shutdown path at all.
- `NewServer` fired off `go srv.pollProviderStatus()`, `go srv.keepAliveDaytonaSandboxes()`, `go srv.pruneAnalytics()`, `go srv.statusWatchdog()`, `go srv.checkpointScheduler()`, plus the PR watcher (`startPRWatcher`), the cron scheduler, and the integration poller (`startIntegrationPoller`). Every one was a `for range ticker.C` loop with no context and no way to stop — the cron scheduler even had a `stop()` method that nothing ever called.
- `pollAllPRs` in `pr_watcher.go` already contains a workaround for the missing shutdown ordering: it string-matches `"database is closed"` on query errors, i.e. pollers were known to race a dying DB.
- `/healthz` unconditionally returned 200, so a load balancer would keep routing traffic to a process that was already being killed.

## Dependencies

None — branches directly from main.

Note: the spec's execution rules ask for a CHANGELOG note for observable-behavior changes, but the repo has no CHANGELOG file yet; the behavior change is documented here and in the `shutdown_grace` config comment instead.

## What changed

- **Root context + signal handling** (`pkg/hub/server.go`): `Run()` creates a root context via `signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)` and blocks until either the listener fails or a signal arrives.
- **Explicit `http.Server`**: replaces `http.ListenAndServe` with a server configured with `ReadHeaderTimeout: 10s` and `IdleTimeout: 120s`; on signal, `srv.Shutdown(drainCtx)` drains in-flight requests for up to 15s, configurable via a new `shutdown_grace` field in hub.yaml (`types.HubConfig`).
- **Cancellable background goroutines**: all seven ticker loops (`pollProviderStatus`, `keepAliveDaytonaSandboxes`, `pruneAnalytics`, `statusWatchdog`, `checkpointScheduler`, PR watcher — now `watchPRs` —, integration poller — now `pollIntegrationsLoop`) take a `context.Context` and exit on `ctx.Done()`. They run under a `golang.org/x/sync/errgroup.Group` (already a dependency) so shutdown can wait for all of them.
- **`Server.Shutdown(ctx)`** implements the specced order: mark draining → stop accepting / drain HTTP → close claw WebSocket connections (main + status channel) with a `StatusGoingAway` close frame — `"killed"` is NOT sent, so sandboxes stay alive and bridges reconnect when the hub returns → cancel root context and wait for the errgroup → stop the cron scheduler (its existing `stop()` is finally called) → close `sql.DB`. Guarded by `sync.Once` so repeated calls are safe.
- **`/healthz` returns 503 while draining** (was: always 200).
- **Test helpers** (`pkg/hub/testhelpers.go`): the test server gets the same context/errgroup wiring, cancelled via `t.Cleanup`, so `StartPRWatcherForTest` goroutines no longer leak across tests.

## Testing

- `go build ./...` — pass.
- `go vet ./pkg/hub/...` — pass.
- `go test ./...` — all packages pass (`pkg/hub` in 16.1s, plus cmd, claw-bridge, providers, e2e).
- `make test-factory` — pass.
- New tests in `pkg/hub/shutdown_test.go`:
  - `TestGracefulShutdown` boots a full `NewServer` (all background goroutines + cron) and verifies `Shutdown` returns within the drain window, cancels the root context, leaves no background goroutine running (`bg.Wait` returns immediately), closes the DB, and that a second `Shutdown` call is a safe no-op.
  - `TestHealthzReturns503WhileDraining` verifies `/healthz` flips 200 → 503 once draining starts.
  - `TestShutdownGraceConfig` covers default/valid/invalid/negative `shutdown_grace` values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
