### PR TITLE
feat(hub): remove token from query string, add single-use auth tickets

### DIFF
--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -422,8 +422,9 @@ func (s *Server) withAuth(next http.HandlerFunc) http.HandlerFunc {
 		token := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
 		if token == "" {
 			// Single-use ticket (see ticket.go) — the only supported query-string
-			// auth. Used by WS upgrades and <img src> loads that cannot set headers.
-			if ticket := r.URL.Query().Get("ticket"); ticket != "" {
+			// auth. Only honored on WS upgrades and <img src> loads that cannot
+			// set headers; on any other route the ticket is ignored.
+			if ticket := r.URL.Query().Get("ticket"); ticket != "" && ticketAuthAllowed(r.URL.Path) {
 				tenantID, githubLogin, ok := s.redeemAuthTicket(ticket)
 				if !ok {
 					http.Error(w, "unauthorized", http.StatusUnauthorized)
@@ -6129,21 +6130,23 @@ func remoteWriteFileCommand(dir, name, content string) string {
 func (s *Server) handleTerminal(w http.ResponseWriter, r *http.Request) {
 	// Auth: Authorization header, or a single-use ticket (browsers cannot set
 	// headers on WebSocket upgrades). The raw ?token= fallback is deprecated.
-	var tenantID string
+	// The GitHub login (when present) is preserved so the same per-claw access
+	// checks as the REST/WS paths apply below.
+	var tenantID, ghLogin string
 	if token := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "); token != "" {
-		tid, err := s.tenantByToken(token)
-		if err != nil {
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
-			return
-		}
-		tenantID = tid
-	} else if ticket := r.URL.Query().Get("ticket"); ticket != "" {
-		tid, _, ok := s.redeemAuthTicket(ticket)
+		tid, login, ok := s.resolveAuthToken(token)
 		if !ok {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}
-		tenantID = tid
+		tenantID, ghLogin = tid, login
+	} else if ticket := r.URL.Query().Get("ticket"); ticket != "" {
+		tid, login, ok := s.redeemAuthTicket(ticket)
+		if !ok {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		tenantID, ghLogin = tid, login
 	} else {
 		// Deprecated: raw token in the query string leaks into access logs and
 		// URL history. Kept for one release; removal planned for Phase 2.
@@ -6169,10 +6172,11 @@ func (s *Server) handleTerminal(w http.ResponseWriter, r *http.Request) {
 	var sshHost string
 	var sshPort int
 	var sshUser string
+	var tagsJSON string
 	err := s.db.QueryRow(
-		`SELECT ssh_host, ssh_port, ssh_user FROM claws WHERE id = ? AND tenant_id = ?`,
+		`SELECT ssh_host, ssh_port, ssh_user, COALESCE(tags,'[]') FROM claws WHERE id = ? AND tenant_id = ?`,
 		clawID, tenantID,
-	).Scan(&sshHost, &sshPort, &sshUser)
+	).Scan(&sshHost, &sshPort, &sshUser, &tagsJSON)
 	if err == sql.ErrNoRows {
 		http.Error(w, "not found", http.StatusNotFound)
 		return
@@ -6181,6 +6185,26 @@ func (s *Server) handleTerminal(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "db error", http.StatusInternalServerError)
 		return
 	}
+
+	// Terminal access grants shell control over the claw, so require the same
+	// permission as mutating endpoints (canModifyClaw), not just tenant
+	// ownership. Token-based auth (no login) keeps full access, matching the
+	// other handlers.
+	if ghLogin != "" {
+		var clawTags []string
+		_ = json.Unmarshal([]byte(tagsJSON), &clawTags)
+		s.mu.RLock()
+		var accessCfg *types.AccessConfig
+		if s.hubCfg.Auth != nil {
+			accessCfg = s.hubCfg.Auth.Access
+		}
+		s.mu.RUnlock()
+		if !canModifyClaw(accessCfg, ghLogin, clawTags) {
+			http.Error(w, "forbidden", http.StatusForbidden)
+			return
+		}
+	}
+
 	if sshHost == "" || sshPort == 0 {
 		http.Error(w, "ssh not available for this claw", http.StatusServiceUnavailable)
 		return

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -92,6 +92,11 @@ type Server struct {
 
 	// cronScheduler manages scheduled workflow runs
 	cronScheduler *cronScheduler
+
+	// tickets holds single-use auth tickets for WS/img endpoints (see ticket.go).
+	// Lazily initialized so zero-value Servers in tests keep working.
+	ticketMu sync.Mutex
+	tickets  map[string]authTicket
 }
 
 type clawConn struct {
@@ -283,6 +288,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/auth/login", s.handleWebLogin)
 	mux.HandleFunc("/api/auth/logout", s.handleWebLogout)
 	mux.HandleFunc("/api/auth/me", s.withWebAuth(s.handleWebMe))
+	mux.HandleFunc("/api/auth/ticket", s.handleAuthTicket)               // single-use ticket for WS/img auth (header auth inside handler)
 	mux.HandleFunc("/api/auth/config", s.handleAuthConfig)               // public — no auth required
 	mux.HandleFunc("/api/auth/github/client-id", s.handleGitHubClientID) // public
 	mux.HandleFunc("/api/auth/github/exchange", s.handleGitHubOAuthExchange)
@@ -415,7 +421,29 @@ func (s *Server) withAuth(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		token := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
 		if token == "" {
+			// Single-use ticket (see ticket.go) — the only supported query-string
+			// auth. Used by WS upgrades and <img src> loads that cannot set headers.
+			if ticket := r.URL.Query().Get("ticket"); ticket != "" {
+				tenantID, githubLogin, ok := s.redeemAuthTicket(ticket)
+				if !ok {
+					http.Error(w, "unauthorized", http.StatusUnauthorized)
+					return
+				}
+				ctx := context.WithValue(r.Context(), ctxTenantKey{}, tenantID)
+				if githubLogin != "" {
+					ctx = context.WithValue(ctx, ctxGitHubLoginKey{}, githubLogin)
+				}
+				next(w, r.WithContext(ctx))
+				return
+			}
+		}
+		if token == "" {
+			// Deprecated: raw token in the query string leaks into access logs and
+			// URL history. Kept for one release; removal planned for Phase 2.
 			token = r.URL.Query().Get("token")
+			if token != "" {
+				log.Printf("deprecated: token in query (path=%s remote=%s) — use Authorization header or a single-use ticket from POST /api/auth/ticket", r.URL.Path, r.RemoteAddr)
+			}
 		}
 		if token == "" {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
@@ -459,8 +487,13 @@ func (s *Server) withConfigMutationAuth(next http.HandlerFunc) http.HandlerFunc 
 		}
 		queryToken := false
 		if token == "" {
+			// Deprecated: raw token in the query string leaks into access logs and
+			// URL history. Kept for one release; removal planned for Phase 2.
 			token = r.URL.Query().Get("token")
 			queryToken = token != ""
+			if queryToken {
+				log.Printf("deprecated: token in query (path=%s remote=%s) — use Authorization header", r.URL.Path, r.RemoteAddr)
+			}
 		}
 		if token == "" {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
@@ -6092,17 +6125,38 @@ func remoteWriteFileCommand(dir, name, content string) string {
 // ─── Terminal WebSocket ───────────────────────────────────────────────────────
 
 // handleTerminal proxies a WebSocket connection to an SSH PTY on the claw's VM.
-// Route: GET /api/terminal/{clawID}?token=...
+// Route: GET /api/terminal/{clawID}?ticket=... (single-use ticket from POST /api/auth/ticket)
 func (s *Server) handleTerminal(w http.ResponseWriter, r *http.Request) {
-	// Auth via token query param
-	token := r.URL.Query().Get("token")
-	if token == "" {
-		token = strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
-	}
-	tenantID, err := s.tenantByToken(token)
-	if err != nil {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
-		return
+	// Auth: Authorization header, or a single-use ticket (browsers cannot set
+	// headers on WebSocket upgrades). The raw ?token= fallback is deprecated.
+	var tenantID string
+	if token := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "); token != "" {
+		tid, err := s.tenantByToken(token)
+		if err != nil {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		tenantID = tid
+	} else if ticket := r.URL.Query().Get("ticket"); ticket != "" {
+		tid, _, ok := s.redeemAuthTicket(ticket)
+		if !ok {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		tenantID = tid
+	} else {
+		// Deprecated: raw token in the query string leaks into access logs and
+		// URL history. Kept for one release; removal planned for Phase 2.
+		token := r.URL.Query().Get("token")
+		if token != "" {
+			log.Printf("deprecated: token in query (path=%s remote=%s) — use a single-use ticket from POST /api/auth/ticket", r.URL.Path, r.RemoteAddr)
+		}
+		tid, err := s.tenantByToken(token)
+		if err != nil {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		tenantID = tid
 	}
 
 	clawID := strings.TrimPrefix(r.URL.Path, "/api/terminal/")
@@ -6115,7 +6169,7 @@ func (s *Server) handleTerminal(w http.ResponseWriter, r *http.Request) {
 	var sshHost string
 	var sshPort int
 	var sshUser string
-	err = s.db.QueryRow(
+	err := s.db.QueryRow(
 		`SELECT ssh_host, ssh_port, ssh_user FROM claws WHERE id = ? AND tenant_id = ?`,
 		clawID, tenantID,
 	).Scan(&sshHost, &sshPort, &sshUser)

--- a/pkg/hub/ticket.go
+++ b/pkg/hub/ticket.go
@@ -1,0 +1,96 @@
+package hub
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Single-use auth tickets.
+//
+// Browsers cannot set the Authorization header on WebSocket upgrades or on
+// resources loaded via <img src>. Instead of leaking the long-lived bearer
+// token into query strings (access logs, proxy logs, URL history), the UI
+// calls POST /api/auth/ticket (authenticated via header) to obtain an opaque
+// single-use ticket with a short TTL, and passes it as ?ticket= on those
+// endpoints only.
+
+const authTicketTTL = 30 * time.Second
+
+type authTicket struct {
+	tenantID    string
+	githubLogin string
+	expiresAt   time.Time
+}
+
+// issueAuthTicket mints a single-use ticket bound to the given tenant/login.
+func (s *Server) issueAuthTicket(tenantID, githubLogin string) (string, error) {
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	id := hex.EncodeToString(buf)
+	now := time.Now()
+	s.ticketMu.Lock()
+	if s.tickets == nil {
+		s.tickets = make(map[string]authTicket)
+	}
+	// Opportunistically prune expired tickets so the map cannot grow unbounded.
+	for k, t := range s.tickets {
+		if now.After(t.expiresAt) {
+			delete(s.tickets, k)
+		}
+	}
+	s.tickets[id] = authTicket{tenantID: tenantID, githubLogin: githubLogin, expiresAt: now.Add(authTicketTTL)}
+	s.ticketMu.Unlock()
+	return id, nil
+}
+
+// redeemAuthTicket consumes a ticket. Each ticket is valid for exactly one
+// redemption within its TTL.
+func (s *Server) redeemAuthTicket(id string) (tenantID, githubLogin string, ok bool) {
+	if id == "" {
+		return "", "", false
+	}
+	s.ticketMu.Lock()
+	t, found := s.tickets[id]
+	if found {
+		delete(s.tickets, id)
+	}
+	s.ticketMu.Unlock()
+	if !found || time.Now().After(t.expiresAt) {
+		return "", "", false
+	}
+	return t.tenantID, t.githubLogin, true
+}
+
+// handleAuthTicket issues a single-use ticket for WS/img endpoints.
+// Route: POST /api/auth/ticket — authenticated via Authorization header only
+// (no query fallback: a leaked query token must not be able to mint tickets).
+func (s *Server) handleAuthTicket(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	token := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+	if token == "" {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	tenantID, githubLogin, ok := s.resolveAuthToken(token)
+	if !ok {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	ticket, err := s.issueAuthTicket(tenantID, githubLogin)
+	if err != nil {
+		http.Error(w, "ticket generation failed", http.StatusInternalServerError)
+		return
+	}
+	jsonOK(w, map[string]interface{}{
+		"ticket":     ticket,
+		"expires_in": int(authTicketTTL / time.Second),
+	})
+}

--- a/pkg/hub/ticket.go
+++ b/pkg/hub/ticket.go
@@ -19,6 +19,16 @@ import (
 
 const authTicketTTL = 30 * time.Second
 
+// ticketAuthAllowed reports whether a path may authenticate via ?ticket=.
+// Tickets exist only for endpoints where the browser cannot set the
+// Authorization header: WebSocket upgrades and <img src> resource loads.
+// Accepting them on arbitrary REST routes would widen the authority of a
+// leaked ticket beyond its purpose. (/api/terminal/ handles its own auth
+// outside withAuth.)
+func ticketAuthAllowed(path string) bool {
+	return path == "/api/ws" || strings.HasPrefix(path, "/api/files/view/")
+}
+
 type authTicket struct {
 	tenantID    string
 	githubLogin string

--- a/pkg/hub/ticket_test.go
+++ b/pkg/hub/ticket_test.go
@@ -99,7 +99,7 @@ func TestHandleAuthTicketRequiresHeaderAuth(t *testing.T) {
 	})
 
 	rec = httptest.NewRecorder()
-	protected(rec, httptest.NewRequest(http.MethodGet, "/api/claws?ticket="+resp.Ticket, nil))
+	protected(rec, httptest.NewRequest(http.MethodGet, "/api/ws?ticket="+resp.Ticket, nil))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("ticket auth: got %d, want 200", rec.Code)
 	}
@@ -109,9 +109,98 @@ func TestHandleAuthTicketRequiresHeaderAuth(t *testing.T) {
 
 	// Second use of the same ticket must fail.
 	rec = httptest.NewRecorder()
-	protected(rec, httptest.NewRequest(http.MethodGet, "/api/claws?ticket="+resp.Ticket, nil))
+	protected(rec, httptest.NewRequest(http.MethodGet, "/api/ws?ticket="+resp.Ticket, nil))
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("ticket reuse: got %d, want 401", rec.Code)
+	}
+}
+
+// Tickets exist for WS upgrades and <img src> loads only. Any other withAuth
+// route must reject ticket auth so a leaked single-use ticket cannot reach
+// generic (including mutating) REST endpoints.
+func TestTicketAuthRestrictedToTicketCapableRoutes(t *testing.T) {
+	s := newTicketTestServer(t)
+	protected := s.withAuth(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	allowed := []string{"/api/ws", "/api/files/view/claw-1"}
+	for _, path := range allowed {
+		ticket, err := s.issueAuthTicket("tenant", "")
+		if err != nil {
+			t.Fatalf("issue: %v", err)
+		}
+		rec := httptest.NewRecorder()
+		protected(rec, httptest.NewRequest(http.MethodGet, path+"?ticket="+ticket, nil))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("%s: got %d, want 200", path, rec.Code)
+		}
+	}
+
+	denied := []string{"/api/claws", "/api/claws/claw-1", "/api/messages/claw-1", "/api/workspaces"}
+	for _, path := range denied {
+		ticket, err := s.issueAuthTicket("tenant", "")
+		if err != nil {
+			t.Fatalf("issue: %v", err)
+		}
+		rec := httptest.NewRecorder()
+		protected(rec, httptest.NewRequest(http.MethodGet, path+"?ticket="+ticket, nil))
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("%s: got %d, want 401 (ticket must not authenticate generic REST routes)", path, rec.Code)
+		}
+		// The ignored ticket must not have been consumed by the rejected request.
+		if _, _, ok := s.redeemAuthTicket(ticket); !ok {
+			t.Fatalf("%s: ticket was consumed by a route that must ignore tickets", path)
+		}
+	}
+}
+
+// Terminal access requires canModifyClaw for GitHub OAuth users, not just
+// tenant ownership: a user whose tag filters hide a claw must not be able to
+// open an SSH terminal to it by guessing the claw ID.
+func TestHandleTerminalEnforcesClawAccess(t *testing.T) {
+	s := newTicketTestServer(t)
+	s.hubCfg.Auth = &types.AuthConfig{Access: &types.AccessConfig{
+		Admins:           []string{"admin-user"},
+		ViewRequiresTags: []string{"owner={user}"},
+	}}
+	if _, err := s.db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, created_at, tags) VALUES(?,?,?,?,?)`,
+		"claw-1", "tenant", "claw-1", now(), `["owner=alice"]`,
+	); err != nil {
+		t.Fatalf("insert claw: %v", err)
+	}
+
+	terminal := func(login string) *httptest.ResponseRecorder {
+		t.Helper()
+		ticket, err := s.issueAuthTicket("tenant", login)
+		if err != nil {
+			t.Fatalf("issue: %v", err)
+		}
+		rec := httptest.NewRecorder()
+		s.handleTerminal(rec, httptest.NewRequest(http.MethodGet, "/api/terminal/claw-1?ticket="+ticket, nil))
+		return rec
+	}
+
+	// A tenant user whose tags do not match the claw is forbidden.
+	if rec := terminal("mallory"); rec.Code != http.StatusForbidden {
+		t.Fatalf("unauthorized login: got %d, want 403", rec.Code)
+	}
+
+	// A user matching the tag filter passes the access check and reaches the
+	// SSH availability check (503: the test claw has no SSH endpoint).
+	if rec := terminal("alice"); rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("tagged login: got %d, want 503 (past access check)", rec.Code)
+	}
+
+	// Admins bypass tag checks.
+	if rec := terminal("admin-user"); rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("admin login: got %d, want 503 (past access check)", rec.Code)
+	}
+
+	// Token-based auth (no GitHub login) keeps full tenant access.
+	if rec := terminal(""); rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("token auth: got %d, want 503 (past access check)", rec.Code)
 	}
 }
 

--- a/pkg/hub/ticket_test.go
+++ b/pkg/hub/ticket_test.go
@@ -1,0 +1,128 @@
+package hub
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func newTicketTestServer(t *testing.T) *Server {
+	t.Helper()
+	db, err := openDB(":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	if _, err := db.Exec(`INSERT INTO tenants(id,name,token,claw_token,created_at) VALUES(?,?,?,?,?)`,
+		"tenant", "tenant", "secret-token", "claw-token", now()); err != nil {
+		t.Fatalf("insert tenant: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return &Server{db: db, hubCfg: &types.HubConfig{}}
+}
+
+func TestAuthTicketSingleUse(t *testing.T) {
+	s := newTicketTestServer(t)
+	ticket, err := s.issueAuthTicket("tenant", "octocat")
+	if err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+	tenantID, login, ok := s.redeemAuthTicket(ticket)
+	if !ok || tenantID != "tenant" || login != "octocat" {
+		t.Fatalf("redeem: got (%q,%q,%v)", tenantID, login, ok)
+	}
+	if _, _, ok := s.redeemAuthTicket(ticket); ok {
+		t.Fatal("ticket redeemed twice")
+	}
+}
+
+func TestAuthTicketExpiry(t *testing.T) {
+	s := newTicketTestServer(t)
+	ticket, err := s.issueAuthTicket("tenant", "")
+	if err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+	s.ticketMu.Lock()
+	tk := s.tickets[ticket]
+	tk.expiresAt = time.Now().Add(-time.Second)
+	s.tickets[ticket] = tk
+	s.ticketMu.Unlock()
+	if _, _, ok := s.redeemAuthTicket(ticket); ok {
+		t.Fatal("expired ticket accepted")
+	}
+}
+
+func TestHandleAuthTicketRequiresHeaderAuth(t *testing.T) {
+	s := newTicketTestServer(t)
+
+	// No auth header → 401.
+	rec := httptest.NewRecorder()
+	s.handleAuthTicket(rec, httptest.NewRequest(http.MethodPost, "/api/auth/ticket", nil))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("no header: got %d, want 401", rec.Code)
+	}
+
+	// Query token must not mint tickets.
+	rec = httptest.NewRecorder()
+	s.handleAuthTicket(rec, httptest.NewRequest(http.MethodPost, "/api/auth/ticket?token=secret-token", nil))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("query token: got %d, want 401", rec.Code)
+	}
+
+	// Header auth mints a ticket redeemable by withAuth via ?ticket=.
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/ticket", nil)
+	req.Header.Set("Authorization", "Bearer secret-token")
+	rec = httptest.NewRecorder()
+	s.handleAuthTicket(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("header auth: got %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Ticket    string `json:"ticket"`
+		ExpiresIn int    `json:"expires_in"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Ticket == "" || resp.ExpiresIn != 30 {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+
+	var gotTenant string
+	protected := s.withAuth(func(w http.ResponseWriter, r *http.Request) {
+		gotTenant = tenantFromCtx(r)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	rec = httptest.NewRecorder()
+	protected(rec, httptest.NewRequest(http.MethodGet, "/api/claws?ticket="+resp.Ticket, nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("ticket auth: got %d, want 200", rec.Code)
+	}
+	if gotTenant != "tenant" {
+		t.Fatalf("tenant from ctx: got %q", gotTenant)
+	}
+
+	// Second use of the same ticket must fail.
+	rec = httptest.NewRecorder()
+	protected(rec, httptest.NewRequest(http.MethodGet, "/api/claws?ticket="+resp.Ticket, nil))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("ticket reuse: got %d, want 401", rec.Code)
+	}
+}
+
+func TestWithAuthDeprecatedQueryTokenStillWorks(t *testing.T) {
+	s := newTicketTestServer(t)
+	protected := s.withAuth(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	rec := httptest.NewRecorder()
+	protected(rec, httptest.NewRequest(http.MethodGet, "/api/claws?token=secret-token", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("deprecated query token: got %d, want 200", rec.Code)
+	}
+}

--- a/web/components/attachment-chip.tsx
+++ b/web/components/attachment-chip.tsx
@@ -1,9 +1,30 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { AlertCircle, File as FileIcon, Loader2, X } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { getFileViewUrl } from "@/lib/api"
+
+// Resolves the hub file-view URL for history attachments. The URL carries a
+// single-use auth ticket, so it is fetched asynchronously and must not be
+// reused across loads.
+function useFileViewUrl(source?: AttachmentChipSource): string | undefined {
+  const clawId = source?.kind === "history" ? source.clawId : undefined
+  const path = source?.kind === "history" ? source.path : undefined
+  const [url, setUrl] = useState<string | undefined>(undefined)
+  useEffect(() => {
+    if (!clawId || !path) {
+      setUrl(undefined)
+      return
+    }
+    let cancelled = false
+    getFileViewUrl(clawId, path)
+      .then((u) => { if (!cancelled) setUrl(u) })
+      .catch(() => { if (!cancelled) setUrl(undefined) })
+    return () => { cancelled = true }
+  }, [clawId, path])
+  return url
+}
 
 // Source is either a Blob URL we already hold (pre-submit) or a (clawId, path)
 // pair the hub serves back from the claw (history). History renders fall back
@@ -43,11 +64,12 @@ export function AttachmentChip({
   const [broken, setBroken] = useState(false)
   const isImage = mimetype.startsWith("image/") && !broken && !!source
 
+  const historyUrl = useFileViewUrl(source)
   const imgSrc =
     source?.kind === "preview"
       ? source.url
       : source?.kind === "history"
-        ? getFileViewUrl(source.clawId, source.path)
+        ? historyUrl
         : undefined
 
   const thumbCls = size === "sm"
@@ -56,8 +78,18 @@ export function AttachmentChip({
 
   if (isImage && imgSrc) {
     const Wrap = source?.kind === "history" ? "a" : "div"
+    // The auth ticket embedded in imgSrc is single-use and already consumed by
+    // the <img> load, so opening in a new tab needs a freshly ticketed URL.
+    const openFresh = source?.kind === "history"
+      ? (e: React.MouseEvent) => {
+          e.preventDefault()
+          getFileViewUrl(source.clawId, source.path)
+            .then((u) => window.open(u, "_blank", "noreferrer"))
+            .catch(() => {})
+        }
+      : undefined
     const wrapProps = source?.kind === "history"
-      ? { href: imgSrc, target: "_blank", rel: "noreferrer", className: "relative block" }
+      ? { href: imgSrc, target: "_blank", rel: "noreferrer", className: "relative block", onClick: openFresh }
       : { className: "relative" }
     return (
       <Wrap {...wrapProps as object} title={`${name} (${sizeLabel})`}>

--- a/web/components/conversation-view.tsx
+++ b/web/components/conversation-view.tsx
@@ -29,7 +29,7 @@ import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sh
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog"
 import { cn } from "@/lib/utils"
 import type { ActivitySummary as ActivitySummaryMeta, Claw, DependencyStatus, Message, ClawStatus } from "@/lib/types"
-import { getTerminalWsUrl, fetchActivityMessages, fetchClawPRs, type ClawPR } from "@/lib/api"
+import { fetchActivityMessages, fetchClawPRs, type ClawPR } from "@/lib/api"
 import { buildAttachmentsFooter, splitAttachmentsFooter, formatBytes, type ParsedAttachment } from "@/lib/attachments"
 import { useAttachments } from "@/hooks/use-attachments"
 import { AttachmentChip } from "@/components/attachment-chip"
@@ -794,7 +794,6 @@ function ClawBoardCard({
           <div className="flex-1 min-h-0">
             <XTerminal
               clawId={claw.id}
-              wsUrl={getTerminalWsUrl(claw.id)}
               className="h-full w-full"
             />
           </div>
@@ -1633,7 +1632,6 @@ function ClawChatView({
               {terminalOpen && (
                 <XTerminal
                   clawId={claw.id}
-                  wsUrl={getTerminalWsUrl(claw.id)}
                   className="h-full w-full"
                 />
               )}

--- a/web/components/terminal.tsx
+++ b/web/components/terminal.tsx
@@ -1,19 +1,21 @@
 "use client"
 
 import { useEffect, useRef } from "react"
+import { getTerminalWsUrl } from "@/lib/api"
 import "@xterm/xterm/css/xterm.css"
 
 interface TerminalProps {
   clawId: string
-  wsUrl: string
   className?: string
 }
 
 /**
  * XTerminal — browser-only SSH terminal component.
  * Dynamically imports xterm.js to avoid SSR issues.
+ * Requests a single-use auth ticket per connection (browsers can't set the
+ * Authorization header on WebSocket upgrades).
  */
-export function XTerminal({ clawId, wsUrl, className }: TerminalProps) {
+export function XTerminal({ clawId, className }: TerminalProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const stateRef = useRef<{
     ws: WebSocket | null
@@ -68,7 +70,9 @@ export function XTerminal({ clawId, wsUrl, className }: TerminalProps) {
       stateRef.current.term = term
       stateRef.current.fitAddon = fitAddon
 
-      // Connect WebSocket
+      // Connect WebSocket — the URL carries a fresh single-use auth ticket
+      const wsUrl = await getTerminalWsUrl(clawId)
+      if (!mounted) return
       const ws = new WebSocket(wsUrl)
       stateRef.current.ws = ws
 
@@ -121,7 +125,7 @@ export function XTerminal({ clawId, wsUrl, className }: TerminalProps) {
       term?.dispose()
       stateRef.current = { ws: null, term: null, fitAddon: null, resizeObserver: null }
     }
-  }, [wsUrl]) // reconnect if wsUrl changes
+  }, [clawId]) // reconnect if the target claw changes
 
   return (
     <div

--- a/web/hooks/use-hub.ts
+++ b/web/hooks/use-hub.ts
@@ -45,9 +45,12 @@ function describeWsUrl(rawUrl: string): string {
     if (url.searchParams.has("token")) {
       url.searchParams.set("token", "[redacted]")
     }
+    if (url.searchParams.has("ticket")) {
+      url.searchParams.set("ticket", "[redacted]")
+    }
     return url.toString()
   } catch {
-    return rawUrl.replace(/token=[^&]+/, "token=[redacted]")
+    return rawUrl.replace(/token=[^&]+/, "token=[redacted]").replace(/ticket=[^&]+/, "ticket=[redacted]")
   }
 }
 
@@ -306,14 +309,29 @@ export function useHub(selectedClawId: string | null): HubState {
     }
   }, [persistMessages])
 
-  const connectWebSocket = useCallback(() => {
+  const connectWebSocket = useCallback(async () => {
     if (!shouldReconnectRef.current) return
     if (wsRef.current) {
       wsRef.current.onclose = null
       wsRef.current.onerror = null
       wsRef.current.close()
     }
-    const wsUrl = getHubWsUrl()
+    // getHubWsUrl requests a single-use auth ticket from the hub before opening
+    // the socket (raw tokens no longer go in the query string).
+    let wsUrl: string
+    try {
+      wsUrl = await getHubWsUrl()
+    } catch (err) {
+      console.warn("Failed to obtain WS auth ticket; retrying:", err)
+      if (!shouldReconnectRef.current) return
+      const attempt = reconnectAttemptRef.current
+      reconnectAttemptRef.current += 1
+      const delayMs = Math.min(30_000, 1000 * 2 ** Math.min(attempt, 5))
+      if (reconnectTimerRef.current) window.clearTimeout(reconnectTimerRef.current)
+      reconnectTimerRef.current = window.setTimeout(connectWebSocket, delayMs)
+      return
+    }
+    if (!shouldReconnectRef.current) return
     const safeWsUrl = describeWsUrl(wsUrl)
     let ws: WebSocket
     try {

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -162,15 +162,31 @@ export interface UploadedAttachment {
   mimetype: string
 }
 
+// fetchAuthTicket requests a single-use, short-lived auth ticket from the hub.
+// Tickets replace the raw bearer token in query strings for endpoints where
+// the browser cannot set the Authorization header (WebSocket upgrades and
+// <img src> loads). Each ticket is redeemable exactly once.
+export async function fetchAuthTicket(): Promise<string> {
+  const data = await apiFetch<{ ticket: string }>("/api/auth/ticket", { method: "POST" })
+  if (!data?.ticket) throw new Error("hub returned an empty auth ticket")
+  return data.ticket
+}
+
 // getFileViewUrl returns the hub URL that serves the bytes of an uploaded
-// file back to the browser. Suitable for <img src>. Auth is via ?token query
-// since browsers can't set Authorization on <img>.
-export function getFileViewUrl(clawId: string, path: string): string {
-  const token = getTokenSync()
+// file back to the browser. Suitable for <img src>. Auth is via a single-use
+// ?ticket query param since browsers can't set Authorization on <img>.
+// Falls back to the deprecated ?token param when the hub predates tickets.
+export async function getFileViewUrl(clawId: string, path: string): Promise<string> {
   const hubBase = getHubUrl()
   const base = hubBase ? `${hubBase}/api/files/view/${clawId}` : `/api/files/view/${clawId}`
-  const qs = new URLSearchParams({ path, token }).toString()
-  return `${base}?${qs}`
+  try {
+    const ticket = await fetchAuthTicket()
+    return `${base}?${new URLSearchParams({ path, ticket }).toString()}`
+  } catch {
+    // Deprecated fallback for hubs without POST /api/auth/ticket.
+    const token = await resolveToken()
+    return `${base}?${new URLSearchParams({ path, token }).toString()}`
+  }
 }
 
 export async function uploadFiles(clawId: string, files: File[]): Promise<UploadedAttachment[]> {
@@ -205,18 +221,32 @@ export async function killClaw(id: string): Promise<void> {
   return apiFetch<void>(`/api/claws/${id}`, { method: "DELETE" })
 }
 
-export function getHubWsUrl(): string {
-  const token = getTokenSync()
+function wsBaseUrl(): string {
   const hub = getHubUrl() || window.location.origin
-  const wsBase = hub.replace(/^https:/, "wss:").replace(/^http:/, "ws:")
-  return `${wsBase}/api/ws?token=${encodeURIComponent(token)}`
+  return hub.replace(/^https:/, "wss:").replace(/^http:/, "ws:")
 }
 
-export function getTerminalWsUrl(clawId: string): string {
-  const token = getTokenSync()
-  const hub = getHubUrl() || window.location.origin
-  const wsBase = hub.replace(/^https:/, "wss:").replace(/^http:/, "ws:")
-  return `${wsBase}/api/terminal/${clawId}?token=${encodeURIComponent(token)}`
+// buildWsUrl authenticates a WebSocket URL with a single-use ticket. Browsers
+// can't set the Authorization header on WS upgrades, so the ticket goes in the
+// query string. Falls back to the deprecated ?token param when the hub
+// predates tickets.
+async function buildWsUrl(path: string): Promise<string> {
+  try {
+    const ticket = await fetchAuthTicket()
+    return `${wsBaseUrl()}${path}?ticket=${encodeURIComponent(ticket)}`
+  } catch {
+    // Deprecated fallback for hubs without POST /api/auth/ticket.
+    const token = await resolveToken()
+    return `${wsBaseUrl()}${path}?token=${encodeURIComponent(token)}`
+  }
+}
+
+export async function getHubWsUrl(): Promise<string> {
+  return buildWsUrl("/api/ws")
+}
+
+export async function getTerminalWsUrl(clawId: string): Promise<string> {
+  return buildWsUrl(`/api/terminal/${clawId}`)
 }
 
 export function isConfigured(): boolean {

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -99,7 +99,9 @@ async function apiFetch<T>(path: string, options?: RequestInit): Promise<T> {
       if (typeof parsed.error === "string") message = parsed.error
     } catch { /* not JSON */ }
     if (!message) message = `API error ${res.status}`
-    throw new Error(message)
+    const err: Error & { status?: number } = new Error(message)
+    err.status = res.status
+    throw err
   }
   if (res.status === 204) return undefined as T
   return res.json()
@@ -172,17 +174,28 @@ export async function fetchAuthTicket(): Promise<string> {
   return data.ticket
 }
 
+// isTicketEndpointMissing reports whether the error means the hub predates
+// POST /api/auth/ticket (its mux answers 404/405). Only that case may fall
+// back to the deprecated ?token= query param — a transient ticket failure must
+// not leak the long-lived token into query strings and proxy/access logs.
+function isTicketEndpointMissing(err: unknown): boolean {
+  const status = (err as { status?: number } | null)?.status
+  return status === 404 || status === 405
+}
+
 // getFileViewUrl returns the hub URL that serves the bytes of an uploaded
 // file back to the browser. Suitable for <img src>. Auth is via a single-use
 // ?ticket query param since browsers can't set Authorization on <img>.
-// Falls back to the deprecated ?token param when the hub predates tickets.
+// Falls back to the deprecated ?token param only when the hub predates
+// tickets; any other ticket failure propagates to the caller.
 export async function getFileViewUrl(clawId: string, path: string): Promise<string> {
   const hubBase = getHubUrl()
   const base = hubBase ? `${hubBase}/api/files/view/${clawId}` : `/api/files/view/${clawId}`
   try {
     const ticket = await fetchAuthTicket()
     return `${base}?${new URLSearchParams({ path, ticket }).toString()}`
-  } catch {
+  } catch (err) {
+    if (!isTicketEndpointMissing(err)) throw err
     // Deprecated fallback for hubs without POST /api/auth/ticket.
     const token = await resolveToken()
     return `${base}?${new URLSearchParams({ path, token }).toString()}`
@@ -228,13 +241,15 @@ function wsBaseUrl(): string {
 
 // buildWsUrl authenticates a WebSocket URL with a single-use ticket. Browsers
 // can't set the Authorization header on WS upgrades, so the ticket goes in the
-// query string. Falls back to the deprecated ?token param when the hub
-// predates tickets.
+// query string. Falls back to the deprecated ?token param only when the hub
+// predates tickets; any other ticket failure propagates so callers retry
+// instead of leaking the long-lived token into the query string.
 async function buildWsUrl(path: string): Promise<string> {
   try {
     const ticket = await fetchAuthTicket()
     return `${wsBaseUrl()}${path}?ticket=${encodeURIComponent(ticket)}`
-  } catch {
+  } catch (err) {
+    if (!isTicketEndpointMissing(err)) throw err
     // Deprecated fallback for hubs without POST /api/auth/ticket.
     const token = await resolveToken()
     return `${wsBaseUrl()}${path}?token=${encodeURIComponent(token)}`


### PR DESCRIPTION
## Motivation

withAuth accepts ?token= as a fallback, so tokens leak into access logs, reverse-proxy logs and URL history. WS/img endpoints move to short-lived single-use tickets.

Concrete evidence in the code before this change:

- `pkg/hub/server.go` `withAuth` fell back to `r.URL.Query().Get("token")` for every `/api/*` route it guards.
- `handleTerminal` (`/api/terminal/{id}`) authenticated **query-param first** (`?token=` before the Authorization header).
- `withConfigMutationAuth` also read the hub token from `?token=`.
- The frontend actively put the long-lived bearer token in URLs: `web/lib/api.ts` built `/api/ws?token=...`, `/api/terminal/{id}?token=...` and `/api/files/view/{id}?path=...&token=...` (the latter used as `<img src>`, so the token also lands in browser history/cache and any intermediary logs). `web/hooks/use-hub.ts` even has redaction logic (`describeWsUrl`) to keep the token out of console logs — evidence the leak was a known hazard.

This implements item **0.3 "Token out of the query string"** of the Phase 0 re-architecture spec (`docs/re-arch/phase-0-stop-the-bleeding.md` on the `docs/re-arch` branch).

## Dependencies

None — branches directly from main.

Logical notes: independent of the other Phase 0 items; removal of the deprecated `?token=` fallback is scheduled for Phase 2.

## What changed

Backend (`pkg/hub`):

- New `pkg/hub/ticket.go`: in-memory single-use ticket store (32-byte random hex, 30s TTL, redeem-once, opportunistic pruning) plus `POST /api/auth/ticket`. The endpoint authenticates via the `Authorization: Bearer` header **only** — a leaked query token cannot mint tickets. Response: `{"ticket": "...", "expires_in": 30}`.
- `withAuth` now accepts `?ticket=` (redeemed once, resolves to the tenant/GitHub login captured at issue time). The `?token=` fallback still works for one release but logs `deprecated: token in query (path=... remote=...)`.
- `handleTerminal` (`/api/terminal/{id}`) now checks the Authorization header first, then `?ticket=`, and only then the deprecated `?token=` (with the same warning). Previously it checked the query param first.
- `withConfigMutationAuth` keeps its query fallback for the transition but logs the same deprecation warning.
- Grepping the server code for `Query().Get("token")` now only finds: the deprecated fallbacks (all of which warn) and the E2E bridge endpoint, which uses its own dedicated bridge token (out of scope).

Frontend (`web/`):

- `lib/api.ts`: new `fetchAuthTicket()`; `getHubWsUrl()`, `getTerminalWsUrl()` and `getFileViewUrl()` are now async and embed a fresh single-use `?ticket=` instead of the bearer token. If the hub predates `POST /api/auth/ticket` (mixed-version rollout), they fall back to the deprecated `?token=` so old hubs keep working.
- `hooks/use-hub.ts`: `connectWebSocket` awaits the ticketed URL and retries with the existing backoff if the ticket fetch fails. The URL-redaction logic (`describeWsUrl`) stays and now also redacts `?ticket=`.
- `components/terminal.tsx`: `XTerminal` takes only `clawId` and mints its own ticketed URL per connection (tickets are single-use, so a cached URL prop would break reconnects).
- `components/attachment-chip.tsx`: history image URLs are resolved asynchronously; clicking to open the image in a new tab mints a fresh ticket because the one embedded in the `<img>` src has already been consumed.

## Testing

All commands run locally on this branch:

- `go build ./...` — pass.
- `make test` (full `go test -v ./...`) — pass (exit 0). Includes the new `pkg/hub/ticket_test.go`: single-use redemption, expiry, header-only auth on `POST /api/auth/ticket` (query token rejected with 401), `withAuth` accepting `?ticket=` once and rejecting reuse, and the deprecated `?token=` fallback still authenticating.
- `cd web && npm install && npm run build` — pass (compile + TypeScript + static generation all green). The repo has no frontend unit-test script (`package.json` scripts: dev/build/start/lint), so none were run.

Not run: `make e2e` / terminal + file-preview browser E2E (requires ngrok/Daytona credentials not available in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
