### PR TITLE
test(web): vitest unit tests for mappers, attachments, auth-storage, message merge

### DIFF
--- a/.depot/workflows/test.yaml
+++ b/.depot/workflows/test.yaml
@@ -75,6 +75,10 @@ jobs:
         run: npm install
         working-directory: web
 
+      - name: Unit tests
+        run: npm test
+        working-directory: web
+
       - name: Lint (smoke check — tolerates rule violations, still fails on tool/config errors)
         run: |
           set +e

--- a/web/hooks/use-hub.ts
+++ b/web/hooks/use-hub.ts
@@ -14,7 +14,7 @@ import {
   isConfigured,
 } from "@/lib/api"
 import { mapApiClaw, mapApiMessage, mapApiStatus, computeUptime } from "@/lib/mappers"
-import { isTerminalAssistantMessage } from "@/lib/messages"
+import { isTerminalAssistantMessage, isTransientMessage, mergeTimelineMessages } from "@/lib/messages"
 import { useTypewriter, type TypewriterState } from "@/hooks/use-typewriter"
 
 export interface HubState {
@@ -49,10 +49,6 @@ function describeWsUrl(rawUrl: string): string {
   } catch {
     return rawUrl.replace(/token=[^&]+/, "token=[redacted]")
   }
-}
-
-function isTransientMessage(message: Message): boolean {
-  return message.id.startsWith("activity-") || message.id.startsWith("live-") || message.id.startsWith("thinking-")
 }
 
 function formatActivityContent(activity: AgentActivity): string {
@@ -277,17 +273,7 @@ export function useHub(selectedClawId: string | null): HubState {
 
       setMessages((prev) => {
         const existing = prev[clawId] || []
-        // Merge API result with cached state:
-        // 1. Keep non-optimistic existing messages not in API result (preserves cache beyond API limit)
-        // 2. Re-append any in-flight opt- messages so send() can still swap them with real UUIDs
-        const existingNonOpt = existing.filter((m) => !m.id.startsWith('opt-') && !isTransientMessage(m))
-        const apiIds = new Set(msgs.map((m) => m.id))
-        const cachedOnly = existingNonOpt.filter((m) => !apiIds.has(m.id))
-        const inflight = existing.filter((m) => m.id.startsWith('opt-') &&
-          !msgs.some((r) => r.content === m.content && r.role === m.role))
-        const merged = [...msgs, ...cachedOnly, ...inflight]
-        merged.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime())
-        const next = { ...prev, [clawId]: merged }
+        const next = { ...prev, [clawId]: mergeTimelineMessages(existing, msgs) }
         persistMessages(next)
         return next
       })

--- a/web/lib/__tests__/attachments.test.ts
+++ b/web/lib/__tests__/attachments.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest"
+import {
+  ATTACHMENTS_MARKER,
+  buildAttachmentsFooter,
+  formatBytes,
+  splitAttachmentsFooter,
+  type PendingAttachment,
+} from "@/lib/attachments"
+
+function att(overrides: Partial<PendingAttachment> = {}): PendingAttachment {
+  return {
+    localId: "l1",
+    name: "report.pdf",
+    size: 2048,
+    mimetype: "application/pdf",
+    path: "/workspace/uploads/report.pdf",
+    status: "ready",
+    ...overrides,
+  }
+}
+
+describe("formatBytes", () => {
+  it("formats bytes below 1 KB", () => {
+    expect(formatBytes(0)).toBe("0 B")
+    expect(formatBytes(1023)).toBe("1023 B")
+  })
+
+  it("formats kilobytes with one decimal", () => {
+    expect(formatBytes(1024)).toBe("1.0 KB")
+    expect(formatBytes(1536)).toBe("1.5 KB")
+  })
+
+  it("formats megabytes with one decimal", () => {
+    expect(formatBytes(1024 * 1024)).toBe("1.0 MB")
+    expect(formatBytes(20 * 1024 * 1024)).toBe("20.0 MB")
+  })
+})
+
+describe("buildAttachmentsFooter", () => {
+  it("returns an empty string for no attachments", () => {
+    expect(buildAttachmentsFooter([])).toBe("")
+  })
+
+  it("returns an empty string when no attachment is ready with a path", () => {
+    expect(
+      buildAttachmentsFooter([att({ status: "uploading" }), att({ path: undefined })])
+    ).toBe("")
+  })
+
+  it("renders one line per ready attachment", () => {
+    const footer = buildAttachmentsFooter([
+      att(),
+      att({ localId: "l2", name: "img.png", size: 1024, mimetype: "image/png", path: "/workspace/uploads/img.png" }),
+    ])
+    expect(footer).toBe(
+      `${ATTACHMENTS_MARKER}- report.pdf — /workspace/uploads/report.pdf (application/pdf, 2.0 KB)\n` +
+        `- img.png — /workspace/uploads/img.png (image/png, 1.0 KB)`
+    )
+  })
+
+  it("skips attachments that are not ready", () => {
+    const footer = buildAttachmentsFooter([att(), att({ localId: "l2", name: "x.txt", status: "error" })])
+    expect(footer).toContain("report.pdf")
+    expect(footer).not.toContain("x.txt")
+  })
+})
+
+describe("splitAttachmentsFooter", () => {
+  it("returns the content untouched when there is no marker", () => {
+    expect(splitAttachmentsFooter("just a message")).toEqual({
+      body: "just a message",
+      attachments: [],
+    })
+  })
+
+  it("round-trips a footer built by buildAttachmentsFooter", () => {
+    const content = `hello world${buildAttachmentsFooter([att()])}`
+    const { body, attachments } = splitAttachmentsFooter(content)
+    expect(body).toBe("hello world")
+    expect(attachments).toEqual([
+      {
+        name: "report.pdf",
+        path: "/workspace/uploads/report.pdf",
+        mimetype: "application/pdf",
+        sizeLabel: "2.0 KB",
+      },
+    ])
+  })
+
+  it("accepts the body-less leading-marker form", () => {
+    const content = "[Attachments]\n- a.txt — /tmp/a.txt (text/plain, 5 B)"
+    const { body, attachments } = splitAttachmentsFooter(content)
+    expect(body).toBe("")
+    expect(attachments).toEqual([
+      { name: "a.txt", path: "/tmp/a.txt", mimetype: "text/plain", sizeLabel: "5 B" },
+    ])
+  })
+
+  it("anchors on the last em-dash so em-dashes in names round-trip", () => {
+    const content = `${ATTACHMENTS_MARKER}- notes — draft.pdf — /tmp/notes-draft.pdf (application/pdf, 1.0 KB)`
+    const { attachments } = splitAttachmentsFooter(content)
+    expect(attachments).toEqual([
+      {
+        name: "notes — draft.pdf",
+        path: "/tmp/notes-draft.pdf",
+        mimetype: "application/pdf",
+        sizeLabel: "1.0 KB",
+      },
+    ])
+  })
+
+  it("handles parentheses inside filenames", () => {
+    const content = `body${ATTACHMENTS_MARKER}- shot (1).png — /tmp/shot (1).png (image/png, 3.0 KB)`
+    const { attachments } = splitAttachmentsFooter(content)
+    expect(attachments).toEqual([
+      { name: "shot (1).png", path: "/tmp/shot (1).png", mimetype: "image/png", sizeLabel: "3.0 KB" },
+    ])
+  })
+
+  it("falls back to the full content when no line after the marker parses", () => {
+    const content = `body${ATTACHMENTS_MARKER}garbage that is not an attachment line`
+    expect(splitAttachmentsFooter(content)).toEqual({ body: content, attachments: [] })
+  })
+
+  it("skips unparseable lines but keeps valid ones", () => {
+    const content = `body${ATTACHMENTS_MARKER}not a line\n- a.txt — /tmp/a.txt (text/plain, 5 B)`
+    const { body, attachments } = splitAttachmentsFooter(content)
+    expect(body).toBe("body")
+    expect(attachments).toHaveLength(1)
+    expect(attachments[0].name).toBe("a.txt")
+  })
+})

--- a/web/lib/__tests__/auth-storage.test.ts
+++ b/web/lib/__tests__/auth-storage.test.ts
@@ -1,0 +1,208 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+// jsdom does not implement BroadcastChannel, so install a deterministic fake
+// that delivers messages synchronously to the other channels with the same
+// name (a real BroadcastChannel never delivers to the sender).
+class FakeBroadcastChannel {
+  static instances: FakeBroadcastChannel[] = []
+  name: string
+  onmessage: ((event: MessageEvent) => void) | null = null
+  private listeners = new Set<(event: MessageEvent) => void>()
+  private closed = false
+
+  constructor(name: string) {
+    this.name = name
+    FakeBroadcastChannel.instances.push(this)
+  }
+
+  postMessage(data: unknown): void {
+    for (const other of FakeBroadcastChannel.instances) {
+      if (other === this || other.closed || other.name !== this.name) continue
+      other.deliver(data)
+    }
+  }
+
+  deliver(data: unknown): void {
+    const event = { data } as MessageEvent
+    this.onmessage?.(event)
+    for (const listener of this.listeners) listener(event)
+  }
+
+  addEventListener(_type: string, listener: (event: MessageEvent) => void): void {
+    this.listeners.add(listener)
+  }
+
+  removeEventListener(_type: string, listener: (event: MessageEvent) => void): void {
+    this.listeners.delete(listener)
+  }
+
+  close(): void {
+    this.closed = true
+  }
+
+  static reset(): void {
+    FakeBroadcastChannel.instances = []
+  }
+}
+
+type AuthStorage = typeof import("@/lib/auth-storage")
+
+// The module keeps a singleton channel and registers it at import time, so
+// each test gets a fresh copy via resetModules + dynamic import.
+async function importAuthStorage(): Promise<AuthStorage> {
+  vi.resetModules()
+  return await import("@/lib/auth-storage")
+}
+
+beforeEach(() => {
+  sessionStorage.clear()
+  FakeBroadcastChannel.reset()
+  vi.stubGlobal("BroadcastChannel", FakeBroadcastChannel)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe("token storage", () => {
+  it("stores and reads the GitHub and hub tokens from sessionStorage", async () => {
+    const auth = await importAuthStorage()
+    auth.setGitHubToken("gh-token")
+    auth.setHubToken("hub-token")
+    expect(auth.getGitHubToken()).toBe("gh-token")
+    expect(auth.getHubToken()).toBe("hub-token")
+    expect(sessionStorage.getItem("ec_github_token")).toBe("gh-token")
+    expect(sessionStorage.getItem("ec_hub_token")).toBe("hub-token")
+  })
+
+  it("getAuthToken prefers the GitHub token over the hub token", async () => {
+    const auth = await importAuthStorage()
+    expect(auth.getAuthToken()).toBeNull()
+    auth.setHubToken("hub-token")
+    expect(auth.getAuthToken()).toBe("hub-token")
+    auth.setGitHubToken("gh-token")
+    expect(auth.getAuthToken()).toBe("gh-token")
+  })
+
+  it("clearAuthTokens removes both tokens", async () => {
+    const auth = await importAuthStorage()
+    auth.setGitHubToken("gh-token")
+    auth.setHubToken("hub-token")
+    auth.clearAuthTokens()
+    expect(auth.getAuthToken()).toBeNull()
+    expect(sessionStorage.getItem("ec_github_token")).toBeNull()
+    expect(sessionStorage.getItem("ec_hub_token")).toBeNull()
+  })
+})
+
+describe("cross-tab broadcast", () => {
+  function otherTab(): FakeBroadcastChannel {
+    // The module opens its channel at import time, so a channel created after
+    // the import acts as "another tab" on the same channel name.
+    return new FakeBroadcastChannel("elasticclaw-auth")
+  }
+
+  it("broadcasts token updates to other tabs", async () => {
+    const auth = await importAuthStorage()
+    const tab = otherTab()
+    const received: unknown[] = []
+    tab.onmessage = (event) => received.push(event.data)
+    auth.setGitHubToken("gh-token")
+    expect(received).toEqual([
+      { type: "auth-token-updated", githubToken: "gh-token", hubToken: null },
+    ])
+  })
+
+  it("broadcasts a cleared event on clearAuthTokens", async () => {
+    const auth = await importAuthStorage()
+    const tab = otherTab()
+    const received: Array<{ type: string }> = []
+    tab.onmessage = (event) => received.push(event.data)
+    auth.clearAuthTokens()
+    expect(received).toEqual([{ type: "auth-token-cleared" }])
+  })
+
+  it("answers auth-token-request with the stored tokens", async () => {
+    const auth = await importAuthStorage()
+    auth.setHubToken("hub-token")
+    const tab = otherTab()
+    const received: Array<{ type: string }> = []
+    tab.addEventListener("message", (event) => received.push(event.data))
+    tab.postMessage({ type: "auth-token-request" })
+    expect(received).toEqual([
+      { type: "auth-token-response", githubToken: null, hubToken: "hub-token" },
+    ])
+  })
+
+  it("stays silent on auth-token-request when no token is stored", async () => {
+    await importAuthStorage()
+    const tab = otherTab()
+    const received: unknown[] = []
+    tab.addEventListener("message", (event) => received.push(event.data))
+    tab.postMessage({ type: "auth-token-request" })
+    expect(received).toEqual([])
+  })
+
+  it("adopts tokens broadcast by another tab", async () => {
+    const auth = await importAuthStorage()
+    const tab = otherTab()
+    tab.postMessage({ type: "auth-token-updated", githubToken: "gh-from-tab", hubToken: null })
+    expect(auth.getGitHubToken()).toBe("gh-from-tab")
+  })
+
+  it("clears tokens when another tab broadcasts auth-token-cleared", async () => {
+    const auth = await importAuthStorage()
+    auth.setHubToken("hub-token")
+    const tab = otherTab()
+    tab.postMessage({ type: "auth-token-cleared" })
+    expect(auth.getAuthToken()).toBeNull()
+  })
+})
+
+describe("requestAuthToken", () => {
+  it("resolves immediately when a token already exists", async () => {
+    const auth = await importAuthStorage()
+    auth.setGitHubToken("gh-token")
+    await expect(auth.requestAuthToken()).resolves.toBe("gh-token")
+  })
+
+  it("resolves with a token supplied by another tab", async () => {
+    const auth = await importAuthStorage()
+    const tab = otherAnsweringTab("gh-from-tab")
+    await expect(auth.requestAuthToken(1000)).resolves.toBe("gh-from-tab")
+    tab.close()
+  })
+
+  it("resolves null after the timeout when no tab answers", async () => {
+    const auth = await importAuthStorage()
+    await expect(auth.requestAuthToken(10)).resolves.toBeNull()
+  })
+
+  function otherAnsweringTab(githubToken: string): FakeBroadcastChannel {
+    const tab = new FakeBroadcastChannel("elasticclaw-auth")
+    tab.onmessage = (event) => {
+      if ((event.data as { type?: string })?.type === "auth-token-request") {
+        tab.postMessage({ type: "auth-token-response", githubToken, hubToken: null })
+      }
+    }
+    return tab
+  }
+})
+
+describe("OAuth flow state", () => {
+  it("stores, reads, and removes OAuth state and next URL", async () => {
+    const auth = await importAuthStorage()
+    expect(auth.getOAuthState()).toBeNull()
+    auth.setOAuthState("csrf-123")
+    expect(auth.getOAuthState()).toBe("csrf-123")
+    auth.removeOAuthState()
+    expect(auth.getOAuthState()).toBeNull()
+
+    expect(auth.getOAuthNext()).toBeNull()
+    auth.setOAuthNext("/settings")
+    expect(auth.getOAuthNext()).toBe("/settings")
+    auth.removeOAuthNext()
+    expect(auth.getOAuthNext()).toBeNull()
+  })
+})

--- a/web/lib/__tests__/mappers.test.ts
+++ b/web/lib/__tests__/mappers.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import {
+  CLAW_COLORS,
+  computeUptime,
+  mapApiClaw,
+  mapApiMessage,
+  mapApiStatus,
+  parseTagsFromName,
+} from "@/lib/mappers"
+import type { ApiClaw, ApiMessage } from "@/lib/types"
+
+function apiClaw(overrides: Partial<ApiClaw> = {}): ApiClaw {
+  return {
+    id: "claw-1",
+    name: "my-claw",
+    template: "default",
+    status: "connected",
+    last_seen: "2026-07-07T10:00:00Z",
+    created_at: "2026-07-07T09:00:00Z",
+    tenant_id: "tenant-1",
+    ...overrides,
+  }
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe("parseTagsFromName", () => {
+  it("extracts key=value pairs from the name", () => {
+    expect(parseTagsFromName("my-claw env=prod team=core")).toEqual({
+      env: "prod",
+      team: "core",
+    })
+  })
+
+  it("returns an empty object when there are no tags", () => {
+    expect(parseTagsFromName("just-a-name")).toEqual({})
+  })
+
+  it("ignores parts with an empty key or value", () => {
+    expect(parseTagsFromName("name =prod env= key=val")).toEqual({ key: "val" })
+  })
+
+  it("keeps everything after the first equals sign as the value", () => {
+    expect(parseTagsFromName("name expr=a=b")).toEqual({ expr: "a=b" })
+  })
+})
+
+describe("computeUptime", () => {
+  it("computes seconds since created_at for connected claws", () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-07-07T10:00:00Z"))
+    expect(computeUptime(apiClaw({ created_at: "2026-07-07T09:59:00Z" }))).toBe(60)
+  })
+
+  it("computes uptime for idle claws", () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-07-07T10:00:00Z"))
+    expect(computeUptime(apiClaw({ status: "idle", created_at: "2026-07-07T09:00:00Z" }))).toBe(3600)
+  })
+
+  it("returns 0 for non-running statuses", () => {
+    expect(computeUptime(apiClaw({ status: "offline" }))).toBe(0)
+    expect(computeUptime(apiClaw({ status: "provisioning" }))).toBe(0)
+    expect(computeUptime(apiClaw({ status: "error" }))).toBe(0)
+  })
+
+  it("returns 0 for an unparseable created_at", () => {
+    expect(computeUptime(apiClaw({ created_at: "not-a-date" }))).toBe(0)
+  })
+
+  it("clamps negative uptime (created_at in the future) to 0", () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-07-07T10:00:00Z"))
+    expect(computeUptime(apiClaw({ created_at: "2026-07-07T11:00:00Z" }))).toBe(0)
+  })
+})
+
+describe("mapApiStatus", () => {
+  it("maps passthrough statuses", () => {
+    expect(mapApiStatus("connected")).toBe("connected")
+    expect(mapApiStatus("idle")).toBe("idle")
+    expect(mapApiStatus("error")).toBe("error")
+  })
+
+  it("maps starting to provisioning", () => {
+    expect(mapApiStatus("provisioning")).toBe("provisioning")
+    expect(mapApiStatus("starting")).toBe("provisioning")
+  })
+
+  it("maps unknown statuses to offline", () => {
+    expect(mapApiStatus("offline")).toBe("offline")
+    // Statuses the backend may add later must degrade to offline, not crash.
+    expect(mapApiStatus("deleted" as ApiClaw["status"])).toBe("offline")
+  })
+})
+
+describe("mapApiClaw", () => {
+  it("maps API fields with defaults", () => {
+    const claw = mapApiClaw(apiClaw({ status: "offline", tags: ["a"], context_usage: 42 }))
+    expect(claw).toMatchObject({
+      id: "claw-1",
+      name: "my-claw",
+      template: "default",
+      status: "offline",
+      uptime: 0,
+      unreadCount: 0,
+      isStreaming: false,
+      pinned: false,
+      tags: ["a"],
+      contextUsage: 42,
+      tenant_id: "tenant-1",
+    })
+  })
+
+  it("assigns a deterministic auto color from the name when unset", () => {
+    const a = mapApiClaw(apiClaw({ color: undefined }))
+    const b = mapApiClaw(apiClaw({ color: undefined }))
+    expect(a.color).toBe(b.color)
+    expect(CLAW_COLORS).toContain(a.color)
+  })
+
+  it("prefers the explicit API color over the auto color", () => {
+    expect(mapApiClaw(apiClaw({ color: "teal" })).color).toBe("teal")
+  })
+
+  it("lets overrides win over API-derived values", () => {
+    const claw = mapApiClaw(apiClaw(), {
+      status: "error",
+      uptime: 123,
+      unreadCount: 7,
+      pinned: true,
+      color: "rose",
+      tags: ["x"],
+    })
+    expect(claw.status).toBe("error")
+    expect(claw.uptime).toBe(123)
+    expect(claw.unreadCount).toBe(7)
+    expect(claw.pinned).toBe(true)
+    expect(claw.color).toBe("rose")
+    expect(claw.tags).toEqual(["x"])
+  })
+})
+
+describe("mapApiMessage", () => {
+  function apiMessage(overrides: Partial<ApiMessage> = {}): ApiMessage {
+    return {
+      id: "msg-1",
+      claw_id: "claw-1",
+      tenant_id: "tenant-1",
+      role: "claw",
+      content: "hello",
+      created_at: "2026-07-07T10:00:00Z",
+      ...overrides,
+    }
+  }
+
+  it("maps plain messages and parses the timestamp", () => {
+    const msg = mapApiMessage(apiMessage({ format: "pre" }))
+    expect(msg.id).toBe("msg-1")
+    expect(msg.role).toBe("claw")
+    expect(msg.content).toBe("hello")
+    expect(msg.format).toBe("pre")
+    expect(msg.timestamp).toEqual(new Date("2026-07-07T10:00:00Z"))
+    expect(msg.activity).toBeUndefined()
+  })
+
+  it("parses activity payloads out of the format field", () => {
+    const msg = mapApiMessage(
+      apiMessage({ role: "activity", format: 'activity:{"kind":"tool","tool":"Bash"}' })
+    )
+    expect(msg.activity).toEqual({ kind: "tool", tool: "Bash" })
+    expect(msg.format).toBeUndefined()
+  })
+
+  it("parses activity_summary payloads out of the format field", () => {
+    const msg = mapApiMessage(
+      apiMessage({ role: "activity_summary", format: 'activity_summary:{"count":3}' })
+    )
+    expect(msg.activitySummary).toEqual({ count: 3 })
+    expect(msg.format).toBeUndefined()
+  })
+
+  it("swallows malformed activity JSON instead of throwing", () => {
+    const msg = mapApiMessage(apiMessage({ role: "activity", format: "activity:{not json" }))
+    expect(msg.activity).toBeUndefined()
+    expect(msg.format).toBeUndefined()
+  })
+
+  it("does not parse activity payloads for non-activity roles", () => {
+    const msg = mapApiMessage(apiMessage({ role: "claw", format: 'activity:{"kind":"tool"}' }))
+    expect(msg.activity).toBeUndefined()
+    // The raw activity format is still hidden from render code.
+    expect(msg.format).toBeUndefined()
+  })
+})

--- a/web/lib/__tests__/messages.test.ts
+++ b/web/lib/__tests__/messages.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest"
+import {
+  isOptimisticMessage,
+  isTerminalAssistantMessage,
+  isTransientMessage,
+  mergeTimelineMessages,
+} from "@/lib/messages"
+import type { Message } from "@/lib/types"
+
+function msg(overrides: Partial<Message> = {}): Message {
+  return {
+    id: "m1",
+    role: "claw",
+    content: "hello",
+    timestamp: new Date("2026-07-07T10:00:00Z"),
+    ...overrides,
+  }
+}
+
+describe("isTerminalAssistantMessage", () => {
+  it("detects [DONE] and [READY_TO_COMMIT] markers on claw messages", () => {
+    expect(isTerminalAssistantMessage(msg({ content: "all set [DONE]" }))).toBe(true)
+    expect(isTerminalAssistantMessage(msg({ content: "[READY_TO_COMMIT] see diff" }))).toBe(true)
+    expect(isTerminalAssistantMessage(msg({ content: "still working" }))).toBe(false)
+  })
+
+  it("ignores markers on non-claw roles", () => {
+    expect(isTerminalAssistantMessage(msg({ role: "user", content: "[DONE]" }))).toBe(false)
+  })
+})
+
+describe("isTransientMessage / isOptimisticMessage", () => {
+  it("classifies ids by prefix", () => {
+    expect(isTransientMessage(msg({ id: "activity-1" }))).toBe(true)
+    expect(isTransientMessage(msg({ id: "live-1" }))).toBe(true)
+    expect(isTransientMessage(msg({ id: "thinking-1" }))).toBe(true)
+    expect(isTransientMessage(msg({ id: "uuid-1" }))).toBe(false)
+    expect(isOptimisticMessage(msg({ id: "opt-1" }))).toBe(true)
+    expect(isOptimisticMessage(msg({ id: "uuid-1" }))).toBe(false)
+  })
+})
+
+describe("mergeTimelineMessages (optimistic merge from use-hub loadMessages)", () => {
+  const t = (s: string) => new Date(`2026-07-07T${s}Z`)
+
+  it("returns the API result when there is no cached state", () => {
+    const incoming = [msg({ id: "a" }), msg({ id: "b", timestamp: t("10:01:00") })]
+    expect(mergeTimelineMessages([], incoming)).toEqual(incoming)
+  })
+
+  it("dedupes messages present in both cache and API result by id", () => {
+    const shared = msg({ id: "a" })
+    const merged = mergeTimelineMessages([shared], [msg({ id: "a", content: "fresh" })])
+    expect(merged).toHaveLength(1)
+    // The API copy wins over the cached copy.
+    expect(merged[0].content).toBe("fresh")
+  })
+
+  it("preserves cached durable messages beyond the API fetch window", () => {
+    const old = msg({ id: "old", timestamp: t("09:00:00") })
+    const merged = mergeTimelineMessages([old], [msg({ id: "new", timestamp: t("10:00:00") })])
+    expect(merged.map((m) => m.id)).toEqual(["old", "new"])
+  })
+
+  it("drops transient messages from the cached state", () => {
+    const existing = [
+      msg({ id: "activity-1", timestamp: t("09:00:00") }),
+      msg({ id: "live-2", timestamp: t("09:01:00") }),
+      msg({ id: "thinking-3", timestamp: t("09:02:00") }),
+      msg({ id: "durable", timestamp: t("09:03:00") }),
+    ]
+    const merged = mergeTimelineMessages(existing, [msg({ id: "new", timestamp: t("10:00:00") })])
+    expect(merged.map((m) => m.id)).toEqual(["durable", "new"])
+  })
+
+  it("keeps in-flight optimistic messages the API has not confirmed", () => {
+    const opt = msg({ id: "opt-1", role: "user", content: "typed", timestamp: t("10:02:00") })
+    const merged = mergeTimelineMessages([opt], [msg({ id: "srv", timestamp: t("10:00:00") })])
+    expect(merged.map((m) => m.id)).toEqual(["srv", "opt-1"])
+  })
+
+  it("drops an optimistic message once the API confirms it (same role and content)", () => {
+    const opt = msg({ id: "opt-1", role: "user", content: "typed", timestamp: t("10:02:00") })
+    const confirmed = msg({ id: "srv-uuid", role: "user", content: "typed", timestamp: t("10:02:01") })
+    const merged = mergeTimelineMessages([opt], [confirmed])
+    expect(merged.map((m) => m.id)).toEqual(["srv-uuid"])
+  })
+
+  it("keeps an optimistic message whose content matches but role differs", () => {
+    const opt = msg({ id: "opt-1", role: "user", content: "same", timestamp: t("10:02:00") })
+    const clawEcho = msg({ id: "srv", role: "claw", content: "same", timestamp: t("10:00:00") })
+    const merged = mergeTimelineMessages([opt], [clawEcho])
+    expect(merged.map((m) => m.id)).toEqual(["srv", "opt-1"])
+  })
+
+  it("sorts the merged timeline by timestamp", () => {
+    const existing = [msg({ id: "cached", timestamp: t("10:01:00") })]
+    const incoming = [
+      msg({ id: "late", timestamp: t("10:02:00") }),
+      msg({ id: "early", timestamp: t("10:00:00") }),
+    ]
+    const merged = mergeTimelineMessages(existing, incoming)
+    expect(merged.map((m) => m.id)).toEqual(["early", "cached", "late"])
+  })
+
+  it("keeps API-first ordering for equal timestamps (stable sort)", () => {
+    const ts = t("10:00:00")
+    const existing = [msg({ id: "cached", timestamp: ts })]
+    const incoming = [msg({ id: "api", timestamp: ts })]
+    expect(mergeTimelineMessages(existing, incoming).map((m) => m.id)).toEqual(["api", "cached"])
+  })
+})

--- a/web/lib/messages.ts
+++ b/web/lib/messages.ts
@@ -3,3 +3,39 @@ import type { Message } from "@/lib/types"
 export function isTerminalAssistantMessage(message: Message): boolean {
   return message.role === "claw" && /\[(DONE|READY_TO_COMMIT)\]/.test(message.content)
 }
+
+// Transient messages are synthesized client-side (activity ticker, live
+// streaming, thinking indicator) and must never survive a timeline merge or
+// cache persistence.
+export function isTransientMessage(message: Message): boolean {
+  return message.id.startsWith("activity-") || message.id.startsWith("live-") || message.id.startsWith("thinking-")
+}
+
+// Optimistic messages are appended by send() with a local "opt-" id and are
+// swapped for the server-issued UUID once the API confirms them.
+export function isOptimisticMessage(message: Message): boolean {
+  return message.id.startsWith("opt-")
+}
+
+/**
+ * Merge an API timeline fetch with the locally cached/optimistic state:
+ * 1. Keep cached durable messages missing from the API result (the cache can
+ *    extend beyond the API fetch window).
+ * 2. Re-append in-flight optimistic messages that the API has not confirmed
+ *    yet (same role + content) so send() can still swap them with real UUIDs.
+ * 3. Drop transient messages; they are re-synthesized from live events.
+ * The result is sorted by timestamp (stable sort, so equal timestamps keep
+ * API-first ordering).
+ */
+export function mergeTimelineMessages(existing: Message[], incoming: Message[]): Message[] {
+  const incomingIds = new Set(incoming.map((m) => m.id))
+  const cachedOnly = existing.filter(
+    (m) => !isOptimisticMessage(m) && !isTransientMessage(m) && !incomingIds.has(m.id)
+  )
+  const inflight = existing.filter(
+    (m) => isOptimisticMessage(m) && !incoming.some((r) => r.content === m.content && r.role === m.role)
+  )
+  const merged = [...incoming, ...cachedOnly, ...inflight]
+  merged.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime())
+  return merged
+}

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -75,10 +77,12 @@
     "@types/react-dom": "^19",
     "eslint": "^9.39.4",
     "eslint-config-next": "^16.2.0",
+    "jsdom": "^29.1.1",
     "postcss": "^8.5",
     "tailwindcss": "^4.2.0",
     "tw-animate-css": "1.3.3",
-    "typescript": "5.7.3"
+    "typescript": "5.7.3",
+    "vitest": "^4.1.10"
   },
   "optionalDependencies": {
     "@tailwindcss/oxide-linux-arm64-gnu": "4.2.0",

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,16 @@
+import path from "node:path"
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "."),
+    },
+  },
+  test: {
+    // Pure-function tests run in node; DOM-dependent suites opt into jsdom
+    // with a `// @vitest-environment jsdom` docblock.
+    environment: "node",
+    include: ["**/__tests__/**/*.test.ts"],
+  },
+})

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -11,6 +11,6 @@ export default defineConfig({
     // Pure-function tests run in node; DOM-dependent suites opt into jsdom
     // with a `// @vitest-environment jsdom` docblock.
     environment: "node",
-    include: ["**/__tests__/**/*.test.ts"],
+    include: ["**/__tests__/**/*.{test,spec}.{ts,tsx}"],
   },
 })


### PR DESCRIPTION
## Motivation

The frontend has zero tests, so the settings split and hook extraction have no safety net. Per the spec, pure-function tests come first, before any refactor: mappers, attachments, auth-storage, then the optimistic message-merge logic.

Concrete evidence from the code:

- `web/package.json` had no test script and no test framework installed at all.
- The optimistic merge in `web/hooks/use-hub.ts` (formerly lines 276–303) is the most fragile logic in the frontend: it reconciles the API timeline with locally cached messages, filters transient (`activity-`/`live-`/`thinking-`) and optimistic (`opt-`) ids, keeps cached history beyond the API fetch window, and drops optimistic messages once the server confirms them by role + content. Any regression here silently duplicates or loses chat messages.
- `web/lib/mappers.ts` already encodes contract-drift workarounds (e.g. `mapApiStatus` maps unknown backend statuses to `offline`, and `starting` to `provisioning`) that were previously undocumented by any test.
- `web/lib/attachments.ts` contains a hand-tuned regex for round-tripping the attachments footer (em-dashes and parentheses in filenames) whose comments describe edge cases nothing verified.

## Dependencies

None — branches directly from main.

Note: this is item 3.3 of the phase 3 spec (safety-net-first ordering); items 3.1/3.2 (settings split, hook extraction) should land after this.

## What changed

- **Extracted the merge logic into a pure function** (`refactor` commit): `isTransientMessage` moved from `use-hub.ts` to `web/lib/messages.ts`, plus new `isOptimisticMessage` and `mergeTimelineMessages(existing, incoming)`. `loadMessages` in `use-hub.ts` now calls the extracted function. No behavior change: same filters, same stable sort, API-first ordering on equal timestamps.
- **Vitest setup**: `vitest` + `jsdom` devDependencies, `web/vitest.config.ts` (node environment by default, `@` path alias; DOM-dependent suites opt into jsdom via a per-file docblock), and `npm test` / `npm run test:watch` scripts.
- **Unit tests** (60 tests, 4 files under `web/lib/__tests__/`):
  - `mappers.test.ts` — `parseTagsFromName`, `computeUptime` (fake timers, future `created_at` clamped, unparseable dates), `mapApiStatus` (including unknown statuses degrading to `offline`), `mapApiClaw` (deterministic auto color, override precedence), `mapApiMessage` (activity/activity_summary payload parsing, malformed JSON swallowed).
  - `attachments.test.ts` — `formatBytes`, `buildAttachmentsFooter` (empty/not-ready filtering), `splitAttachmentsFooter` (build/split round-trip, body-less leading-marker form, em-dashes in names, parentheses in filenames, unparseable lines).
  - `auth-storage.test.ts` — sessionStorage token get/set/clear, GitHub-over-hub token precedence, cross-tab BroadcastChannel sync (request/response/update/clear) with a deterministic fake channel, `requestAuthToken` resolution and timeout, OAuth state helpers.
  - `messages.test.ts` — the optimistic merge: id dedupe (API copy wins), cache preserved beyond the API window, transient messages dropped, unconfirmed optimistic messages kept, confirmed ones dropped (role + content match), stable timestamp sort.

Intentionally **not** in this pass (per instructions): the Playwright smoke spec and the CI job in `.depot/workflows/main.yaml`.

## Testing

- `cd web && npm install` — OK.
- `cd web && npm test` — **4 test files, 60 tests, all passing** (vitest 4.1.10).
- `cd web && npm run build` — passes (next build, all routes generated).
- `cd web && npm run lint` — 30 pre-existing problems; verified by stashing this change and re-running lint on `main`: identical 30 problems, so this PR introduces none.
- No Go changes, so `go build` / `make test` were not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
