### PR TITLE
feat(hub): single typed config loader with SIGHUP hot reload

### DIFF
--- a/cmd/hub.go
+++ b/cmd/hub.go
@@ -2,9 +2,13 @@ package cmd
 
 import (
 	"fmt"
+	"log"
+	"log/slog"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/elasticclaw/elasticclaw/pkg/config"
 	"github.com/elasticclaw/elasticclaw/pkg/hub"
@@ -18,6 +22,7 @@ var (
 	hubToken      string
 	hubClawToken  string
 	hubUIPassword string
+	hubLogLevel   string
 	hubNoWebUI    bool
 )
 
@@ -38,8 +43,9 @@ The hub stores data in a SQLite database (~/.elasticclaw/hub.db by default).
 func init() {
 	rootCmd.AddCommand(hubCmd)
 
-	hubCmd.Flags().StringVar(&hubAddr, "addr", ":8080", "address to listen on")
+	hubCmd.Flags().StringVar(&hubAddr, "addr", "", "address to listen on (default: "+config.DefaultHubAddr+")")
 	hubCmd.Flags().StringVar(&hubDBPath, "db", "", "path to SQLite database (default: ~/.elasticclaw/hub.db)")
+	hubCmd.Flags().StringVar(&hubLogLevel, "log-level", "", "log level: debug, info, warn, error (default: info; hot-reloadable via SIGHUP)")
 	hubCmd.Flags().StringVar(&hubToken, "token", "", "create/update default tenant with this user token")
 	hubCmd.Flags().StringVar(&hubClawToken, "claw-token", "", "agent authentication token (required with --token)")
 	hubCmd.Flags().StringVar(&hubUIPassword, "ui-token", "", "web UI login password (default: value from hub.yaml ui_password, or 'admin')")
@@ -63,15 +69,29 @@ func runHub(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	dbPath := hubDBPath
+	// Consolidated loader: precedence flag > env (ELASTICCLAW_*) > hub.yaml > default.
+	boot, err := config.LoadHubBootConfig(config.HubBootFlags{
+		Addr:     hubAddr,
+		DBPath:   hubDBPath,
+		LogLevel: hubLogLevel,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to load hub config: %w", err)
+	}
+	hubCfg := boot.Cfg
+
+	dbPath := boot.DBPath
 	if dbPath == "" {
 		dbPath = filepath.Join(dir, "hub.db")
 	}
 
-	hubCfg, err := config.LoadHubConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load hub config: %w", err)
+	// Route the standard log package through slog with a swappable level so a
+	// SIGHUP log_level change takes effect without a restart.
+	levelVar := new(slog.LevelVar)
+	if lvl, err := config.ParseLogLevel(boot.LogLevel); err == nil {
+		levelVar.Set(lvl)
 	}
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: levelVar})))
 
 	// Apply LLM keys from env — backward compat: if ANTHROPIC_API_KEY set and no anthropic key configured, add it
 	if apiKey := os.Getenv("ANTHROPIC_API_KEY"); apiKey != "" {
@@ -105,7 +125,7 @@ func runHub(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to create external storage dirs: %w", err)
 	}
 
-	s, err := hub.NewServer(hubAddr, dbPath, dir, hubCfg)
+	s, err := hub.NewServer(boot.Addr, dbPath, dir, hubCfg)
 	if err != nil {
 		return fmt.Errorf("failed to start hub: %w", err)
 	}
@@ -157,7 +177,7 @@ func runHub(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("ElasticClaw Server\n")
-	fmt.Printf("  Address:    %s\n", hubAddr)
+	fmt.Printf("  Address:    %s\n", boot.Addr)
 	fmt.Printf("  Database:   %s\n", dbPath)
 	if hubCfg.URL != "" {
 		fmt.Printf("  URL:        %s\n", hubCfg.URL)
@@ -201,6 +221,31 @@ func runHub(cmd *cobra.Command, args []string) error {
 		}
 	}
 	fmt.Println()
+
+	// Hot reload on SIGHUP: re-read hub.yaml and apply the safe subset
+	// (log_level, allowed_origins, branding, integrations). Restart-required
+	// fields (listen_addr, db_path) are rejected inside ApplyHotReload.
+	sighup := make(chan os.Signal, 1)
+	signal.Notify(sighup, syscall.SIGHUP)
+	go func() {
+		for range sighup {
+			fresh, err := config.LoadHubConfig()
+			if err != nil {
+				log.Printf("[hub] SIGHUP reload failed: %v — keeping the running config", err)
+				continue
+			}
+			merged := s.ApplyHotReload(fresh)
+			// Re-apply precedence: a yaml edit must not override --log-level or env.
+			effective := config.ResolveSetting(hubLogLevel, config.EnvHubLogLevel, merged.LogLevel, config.DefaultHubLogLevel)
+			if lvl, err := config.ParseLogLevel(effective); err != nil {
+				log.Printf("[hub] SIGHUP reload: %v — keeping log level %s", err, levelVar.Level())
+			} else if lvl != levelVar.Level() {
+				// Bypass level filtering for this line so the change is always visible.
+				fmt.Fprintf(os.Stderr, "[hub] SIGHUP reload: log level %s -> %s\n", levelVar.Level(), lvl)
+				levelVar.Set(lvl)
+			}
+		}
+	}()
 
 	return s.Run(hub.RunOptions{NoWebUI: hubNoWebUI})
 }

--- a/pkg/config/hub.go
+++ b/pkg/config/hub.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -15,6 +16,195 @@ import (
 )
 
 var httpGet = http.Get
+
+// ─── Consolidated hub boot loader ─────────────────────────────────────────────
+//
+// The hub's configuration is owned by this package (Viper stays CLI-only).
+// Settings are resolved with the documented precedence:
+//
+//	flag > env (ELASTICCLAW_*) > hub.yaml > default
+//
+// Restart-required settings: listen_addr (ELASTICCLAW_ADDR / --addr) and
+// db_path (ELASTICCLAW_DB / --db). Hot-reloadable settings (applied on
+// SIGHUP via ApplyHotReload): log_level, allowed_origins, branding,
+// integrations.
+
+// Environment variable names honored by the hub loader.
+const (
+	EnvHubAddr           = "ELASTICCLAW_ADDR"
+	EnvHubDBPath         = "ELASTICCLAW_DB"
+	EnvHubLogLevel       = "ELASTICCLAW_LOG_LEVEL"
+	EnvHubAllowedOrigins = "ELASTICCLAW_ALLOWED_ORIGINS" // comma-separated
+)
+
+// Defaults applied when neither flag, env, nor hub.yaml set a value.
+const (
+	DefaultHubAddr     = ":8080"
+	DefaultHubLogLevel = "info"
+)
+
+// HubBootFlags carries the CLI flag values that participate in precedence
+// resolution. An empty string means "flag not set".
+type HubBootFlags struct {
+	Addr     string
+	DBPath   string
+	LogLevel string
+}
+
+// HubBootConfig is the fully resolved hub configuration at boot time.
+type HubBootConfig struct {
+	// Cfg is the parsed hub.yaml (never nil).
+	Cfg *types.HubConfig
+	// Addr is the resolved listen address (restart required to change).
+	Addr string
+	// DBPath is the resolved SQLite path. Empty means "use the caller's
+	// platform default" (~/.elasticclaw/hub.db or /var/lib/elasticclaw/hub.db).
+	DBPath string
+	// LogLevel is the resolved, validated log level (debug|info|warn|error).
+	LogLevel string
+	// AllowedOrigins is the resolved CORS origin allowlist (empty = allow all).
+	AllowedOrigins []string
+}
+
+// LoadHubBootConfig loads hub.yaml and resolves the process-level settings
+// with the precedence flag > env > hub.yaml > default, then validates them.
+// This is the single entry point the hub server uses at boot.
+func LoadHubBootConfig(flags HubBootFlags) (*HubBootConfig, error) {
+	cfg, err := LoadHubConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	boot := &HubBootConfig{
+		Cfg:            cfg,
+		Addr:           ResolveSetting(flags.Addr, EnvHubAddr, cfg.ListenAddr, DefaultHubAddr),
+		DBPath:         ResolveSetting(flags.DBPath, EnvHubDBPath, cfg.DBPath, ""),
+		LogLevel:       ResolveSetting(flags.LogLevel, EnvHubLogLevel, cfg.LogLevel, DefaultHubLogLevel),
+		AllowedOrigins: ResolveOrigins(cfg.AllowedOrigins),
+	}
+	if err := boot.validate(); err != nil {
+		return nil, err
+	}
+	return boot, nil
+}
+
+// ResolveSetting applies the documented precedence for a single setting:
+// flag > env > hub.yaml > default. Empty values mean "not set".
+func ResolveSetting(flagValue, envVar, yamlValue, defaultValue string) string {
+	if flagValue != "" {
+		return flagValue
+	}
+	if v := os.Getenv(envVar); v != "" {
+		return v
+	}
+	if yamlValue != "" {
+		return yamlValue
+	}
+	return defaultValue
+}
+
+// ResolveOrigins applies env > hub.yaml precedence for allowed_origins
+// (there is no CLI flag for it). The env value is comma-separated.
+func ResolveOrigins(yamlOrigins []string) []string {
+	if v := os.Getenv(EnvHubAllowedOrigins); v != "" {
+		var origins []string
+		for _, o := range strings.Split(v, ",") {
+			if o = strings.TrimSpace(o); o != "" {
+				origins = append(origins, o)
+			}
+		}
+		return origins
+	}
+	return yamlOrigins
+}
+
+// validate performs boot-time validation of the resolved settings.
+func (b *HubBootConfig) validate() error {
+	if _, err := ParseLogLevel(b.LogLevel); err != nil {
+		return err
+	}
+	if !strings.Contains(b.Addr, ":") {
+		return fmt.Errorf("invalid listen address %q: expected host:port or :port", b.Addr)
+	}
+	return nil
+}
+
+// ParseLogLevel converts a config string into an slog.Level.
+// Empty input defaults to info.
+func ParseLogLevel(s string) (slog.Level, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "info":
+		return slog.LevelInfo, nil
+	case "debug":
+		return slog.LevelDebug, nil
+	case "warn", "warning":
+		return slog.LevelWarn, nil
+	case "error":
+		return slog.LevelError, nil
+	default:
+		return slog.LevelInfo, fmt.Errorf("invalid log_level %q: must be one of debug, info, warn, error", s)
+	}
+}
+
+// ApplyHotReload merges a freshly loaded hub.yaml into the current in-memory
+// config, applying only the SIGHUP-safe subset: log_level, allowed_origins,
+// branding, and integrations. It returns the merged config (a shallow copy of
+// current — the input is never mutated), the names of the safe fields that
+// changed, and the names of restart-required fields whose on-disk value
+// changed and was therefore rejected.
+func ApplyHotReload(current, fresh *types.HubConfig) (merged *types.HubConfig, applied, rejected []string) {
+	cp := *current
+	merged = &cp
+
+	if fresh.LogLevel != current.LogLevel {
+		merged.LogLevel = fresh.LogLevel
+		applied = append(applied, "log_level")
+	}
+	if !slicesEqual(fresh.AllowedOrigins, current.AllowedOrigins) {
+		merged.AllowedOrigins = fresh.AllowedOrigins
+		applied = append(applied, "allowed_origins")
+	}
+	if !yamlEqual(fresh.Branding, current.Branding) {
+		merged.Branding = fresh.Branding
+		applied = append(applied, "branding")
+	}
+	if !yamlEqual(fresh.Integrations, current.Integrations) {
+		merged.Integrations = fresh.Integrations
+		applied = append(applied, "integrations")
+	}
+
+	// Restart-required fields: keep the current value and report the rejection.
+	if fresh.ListenAddr != current.ListenAddr {
+		rejected = append(rejected, "listen_addr")
+	}
+	if fresh.DBPath != current.DBPath {
+		rejected = append(rejected, "db_path")
+	}
+	return merged, applied, rejected
+}
+
+func slicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// yamlEqual compares two config subtrees by their YAML encoding. Good enough
+// for change detection on small structs; avoids hand-written DeepEqual quirks.
+func yamlEqual(a, b interface{}) bool {
+	ab, errA := yaml.Marshal(a)
+	bb, errB := yaml.Marshal(b)
+	if errA != nil || errB != nil {
+		return false
+	}
+	return bytes.Equal(ab, bb)
+}
 
 // LoadHubConfig loads the hub configuration from (in order):
 //  1. $ELASTICCLAW_HUB_CONFIG env var path

--- a/pkg/config/hub_test.go
+++ b/pkg/config/hub_test.go
@@ -208,3 +208,239 @@ provider: replicated
 		}
 	}
 }
+
+// ─── Consolidated hub boot loader tests ───────────────────────────────────────
+
+// writeHubYAML writes a hub.yaml into a temp dir and points
+// ELASTICCLAW_HUB_CONFIG at it. Returns the path.
+func writeHubYAML(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "hub.yaml")
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatalf("write hub.yaml: %v", err)
+	}
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", path)
+	return path
+}
+
+// TestHubBootPrecedenceMatrix covers the documented precedence:
+// flag > env (ELASTICCLAW_*) > hub.yaml > default.
+func TestHubBootPrecedenceMatrix(t *testing.T) {
+	yamlWithSettings := "listen_addr: \":7001\"\ndb_path: /yaml/hub.db\nlog_level: warn\n"
+
+	cases := []struct {
+		name      string
+		yaml      string
+		env       map[string]string
+		flags     HubBootFlags
+		wantAddr  string
+		wantDB    string
+		wantLevel string
+	}{
+		{
+			name:      "defaults when nothing is set",
+			yaml:      "",
+			wantAddr:  DefaultHubAddr,
+			wantDB:    "",
+			wantLevel: DefaultHubLogLevel,
+		},
+		{
+			name:      "yaml beats default",
+			yaml:      yamlWithSettings,
+			wantAddr:  ":7001",
+			wantDB:    "/yaml/hub.db",
+			wantLevel: "warn",
+		},
+		{
+			name: "env beats yaml",
+			yaml: yamlWithSettings,
+			env: map[string]string{
+				EnvHubAddr:     ":7002",
+				EnvHubDBPath:   "/env/hub.db",
+				EnvHubLogLevel: "error",
+			},
+			wantAddr:  ":7002",
+			wantDB:    "/env/hub.db",
+			wantLevel: "error",
+		},
+		{
+			name: "flag beats env and yaml",
+			yaml: yamlWithSettings,
+			env: map[string]string{
+				EnvHubAddr:     ":7002",
+				EnvHubDBPath:   "/env/hub.db",
+				EnvHubLogLevel: "error",
+			},
+			flags:     HubBootFlags{Addr: ":7003", DBPath: "/flag/hub.db", LogLevel: "debug"},
+			wantAddr:  ":7003",
+			wantDB:    "/flag/hub.db",
+			wantLevel: "debug",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			writeHubYAML(t, tc.yaml)
+			// Ensure a clean env for the vars under test.
+			for _, key := range []string{EnvHubAddr, EnvHubDBPath, EnvHubLogLevel, EnvHubAllowedOrigins} {
+				t.Setenv(key, "")
+				os.Unsetenv(key)
+			}
+			for k, v := range tc.env {
+				t.Setenv(k, v)
+			}
+
+			boot, err := LoadHubBootConfig(tc.flags)
+			if err != nil {
+				t.Fatalf("LoadHubBootConfig: %v", err)
+			}
+			if boot.Addr != tc.wantAddr {
+				t.Errorf("Addr = %q, want %q", boot.Addr, tc.wantAddr)
+			}
+			if boot.DBPath != tc.wantDB {
+				t.Errorf("DBPath = %q, want %q", boot.DBPath, tc.wantDB)
+			}
+			if boot.LogLevel != tc.wantLevel {
+				t.Errorf("LogLevel = %q, want %q", boot.LogLevel, tc.wantLevel)
+			}
+		})
+	}
+}
+
+func TestHubBootAllowedOriginsPrecedence(t *testing.T) {
+	writeHubYAML(t, "allowed_origins:\n  - https://yaml.example.com\n")
+
+	t.Setenv(EnvHubAllowedOrigins, "")
+	os.Unsetenv(EnvHubAllowedOrigins)
+	boot, err := LoadHubBootConfig(HubBootFlags{})
+	if err != nil {
+		t.Fatalf("LoadHubBootConfig: %v", err)
+	}
+	if len(boot.AllowedOrigins) != 1 || boot.AllowedOrigins[0] != "https://yaml.example.com" {
+		t.Errorf("yaml origins = %v", boot.AllowedOrigins)
+	}
+
+	t.Setenv(EnvHubAllowedOrigins, "https://a.example.com, https://b.example.com")
+	boot, err = LoadHubBootConfig(HubBootFlags{})
+	if err != nil {
+		t.Fatalf("LoadHubBootConfig: %v", err)
+	}
+	if len(boot.AllowedOrigins) != 2 || boot.AllowedOrigins[0] != "https://a.example.com" || boot.AllowedOrigins[1] != "https://b.example.com" {
+		t.Errorf("env origins = %v, want env to beat yaml", boot.AllowedOrigins)
+	}
+}
+
+func TestHubBootValidation(t *testing.T) {
+	writeHubYAML(t, "")
+
+	if _, err := LoadHubBootConfig(HubBootFlags{LogLevel: "loud"}); err == nil {
+		t.Error("expected error for invalid log level")
+	}
+	if _, err := LoadHubBootConfig(HubBootFlags{Addr: "8080"}); err == nil {
+		t.Error("expected error for address without a colon")
+	}
+	if _, err := LoadHubBootConfig(HubBootFlags{Addr: "127.0.0.1:8080", LogLevel: "WARN"}); err != nil {
+		t.Errorf("expected valid boot config, got %v", err)
+	}
+}
+
+func TestParseLogLevel(t *testing.T) {
+	for input, want := range map[string]string{
+		"":      "INFO",
+		"debug": "DEBUG",
+		"info":  "INFO",
+		"warn":  "WARN",
+		"error": "ERROR",
+		"WARN":  "WARN",
+	} {
+		lvl, err := ParseLogLevel(input)
+		if err != nil {
+			t.Errorf("ParseLogLevel(%q): %v", input, err)
+			continue
+		}
+		if lvl.String() != want {
+			t.Errorf("ParseLogLevel(%q) = %s, want %s", input, lvl, want)
+		}
+	}
+	if _, err := ParseLogLevel("verbose"); err == nil {
+		t.Error("expected error for invalid level")
+	}
+}
+
+func TestApplyHotReloadSafeSubset(t *testing.T) {
+	current := &types.HubConfig{
+		Token:          "boot-token",
+		ListenAddr:     ":8080",
+		DBPath:         "/var/lib/elasticclaw/hub.db",
+		LogLevel:       "info",
+		AllowedOrigins: []string{"https://old.example.com"},
+	}
+	fresh := &types.HubConfig{
+		Token:          "edited-token",
+		ListenAddr:     ":9999",           // restart required — must be rejected
+		DBPath:         "/tmp/other.db",   // restart required — must be rejected
+		LogLevel:       "debug",           // hot-reloadable
+		AllowedOrigins: []string{"https://new.example.com"}, // hot-reloadable
+		Branding:       &types.BrandingConfig{AppName: "NewBrand"},
+		Integrations:   &types.IntegrationsConfig{},
+	}
+
+	merged, applied, rejected := ApplyHotReload(current, fresh)
+
+	if merged.LogLevel != "debug" {
+		t.Errorf("LogLevel = %q, want debug", merged.LogLevel)
+	}
+	if len(merged.AllowedOrigins) != 1 || merged.AllowedOrigins[0] != "https://new.example.com" {
+		t.Errorf("AllowedOrigins = %v", merged.AllowedOrigins)
+	}
+	if merged.Branding == nil || merged.Branding.AppName != "NewBrand" {
+		t.Errorf("Branding not applied: %+v", merged.Branding)
+	}
+	if merged.Integrations == nil {
+		t.Error("Integrations not applied")
+	}
+	// Restart-required fields keep the running values.
+	if merged.ListenAddr != ":8080" {
+		t.Errorf("ListenAddr = %q, want :8080 (restart required)", merged.ListenAddr)
+	}
+	if merged.DBPath != "/var/lib/elasticclaw/hub.db" {
+		t.Errorf("DBPath = %q, want running value (restart required)", merged.DBPath)
+	}
+	// Fields outside the safe subset are not touched by SIGHUP reload.
+	if merged.Token != "boot-token" {
+		t.Errorf("Token = %q, want running value", merged.Token)
+	}
+
+	wantApplied := map[string]bool{"log_level": true, "allowed_origins": true, "branding": true, "integrations": true}
+	if len(applied) != len(wantApplied) {
+		t.Errorf("applied = %v", applied)
+	}
+	for _, f := range applied {
+		if !wantApplied[f] {
+			t.Errorf("unexpected applied field %q", f)
+		}
+	}
+	wantRejected := map[string]bool{"listen_addr": true, "db_path": true}
+	if len(rejected) != len(wantRejected) {
+		t.Errorf("rejected = %v", rejected)
+	}
+	for _, f := range rejected {
+		if !wantRejected[f] {
+			t.Errorf("unexpected rejected field %q", f)
+		}
+	}
+
+	// The inputs must not be mutated.
+	if current.LogLevel != "info" {
+		t.Error("ApplyHotReload mutated the current config")
+	}
+}
+
+func TestApplyHotReloadNoChanges(t *testing.T) {
+	current := &types.HubConfig{LogLevel: "info", Branding: &types.BrandingConfig{AppName: "X"}}
+	fresh := &types.HubConfig{LogLevel: "info", Branding: &types.BrandingConfig{AppName: "X"}}
+	_, applied, rejected := ApplyHotReload(current, fresh)
+	if len(applied) != 0 || len(rejected) != 0 {
+		t.Errorf("applied = %v, rejected = %v, want none", applied, rejected)
+	}
+}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -27,6 +27,7 @@ import (
 	"github.com/elasticclaw/elasticclaw/internal/webui"
 
 	"github.com/elasticclaw/elasticclaw/pkg/cliversion"
+	"github.com/elasticclaw/elasticclaw/pkg/config"
 	"github.com/elasticclaw/elasticclaw/pkg/hub/artifact"
 	"github.com/elasticclaw/elasticclaw/pkg/hub/pipeline"
 	daytona "github.com/elasticclaw/elasticclaw/pkg/provider/daytona"
@@ -268,7 +269,7 @@ func (s *Server) Run(opts ...RunOptions) error {
 	if s.hubCfg.UIPassword == "" {
 		log.Printf("⚠️  Web UI password not set — using default: 'admin'. Set ui_password in hub.yaml to secure the UI.")
 	}
-	return http.ListenAndServe(s.addr, corsMiddleware(mux))
+	return http.ListenAndServe(s.addr, s.corsMiddleware(mux))
 }
 
 func (s *Server) registerRoutes(mux *http.ServeMux) {
@@ -394,11 +395,19 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	}))
 }
 
-// corsMiddleware adds permissive CORS headers so the web UI can connect
-// from any origin (browser same-origin restrictions apply to REST + WS).
-func corsMiddleware(next http.Handler) http.Handler {
+// corsMiddleware adds CORS headers so the web UI can connect. When
+// allowed_origins is empty (the default) it keeps the historical allow-all
+// behavior; otherwise only the listed origins are allowed. The list is read
+// per-request so a SIGHUP reload takes effect without a restart.
+func (s *Server) corsMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Access-Control-Allow-Origin", "*")
+		allowOrigin := s.resolveCORSOrigin(r.Header.Get("Origin"))
+		if allowOrigin != "" {
+			w.Header().Set("Access-Control-Allow-Origin", allowOrigin)
+			if allowOrigin != "*" {
+				w.Header().Add("Vary", "Origin")
+			}
+		}
 		w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, ngrok-skip-browser-warning")
 		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
 		if r.Method == http.MethodOptions {
@@ -407,6 +416,48 @@ func corsMiddleware(next http.Handler) http.Handler {
 		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+// resolveCORSOrigin returns the Access-Control-Allow-Origin value for a
+// request origin: "*" when no allowlist is configured (or it contains "*"),
+// the echoed origin when it matches the allowlist, "" otherwise.
+func (s *Server) resolveCORSOrigin(requestOrigin string) string {
+	s.mu.RLock()
+	origins := config.ResolveOrigins(s.hubCfg.AllowedOrigins)
+	s.mu.RUnlock()
+	if len(origins) == 0 {
+		return "*"
+	}
+	for _, o := range origins {
+		if o == "*" {
+			return "*"
+		}
+		if requestOrigin != "" && strings.EqualFold(o, requestOrigin) {
+			return requestOrigin
+		}
+	}
+	return ""
+}
+
+// ApplyHotReload applies the SIGHUP-safe subset of a freshly loaded hub.yaml
+// (log_level, allowed_origins, branding, integrations) to the running server.
+// Restart-required fields (listen_addr, db_path) are rejected with a clear log.
+// It returns the new effective config so the caller can propagate the log level.
+func (s *Server) ApplyHotReload(fresh *types.HubConfig) *types.HubConfig {
+	s.mu.Lock()
+	merged, applied, rejected := config.ApplyHotReload(s.hubCfg, fresh)
+	s.hubCfg = merged
+	s.mu.Unlock()
+
+	for _, field := range rejected {
+		log.Printf("[hub] SIGHUP reload: %q changed on disk but requires a restart — keeping the running value", field)
+	}
+	if len(applied) > 0 {
+		log.Printf("[hub] SIGHUP reload: applied %s", strings.Join(applied, ", "))
+	} else {
+		log.Printf("[hub] SIGHUP reload: no hot-reloadable changes detected")
+	}
+	return merged
 }
 
 // ─── Auth ────────────────────────────────────────────────────────────────────

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -473,6 +473,19 @@ type HubConfig struct {
 	URL   string `yaml:"url"`
 	Token string `yaml:"token"`
 
+	// Server process settings. Resolved at boot by the consolidated loader in
+	// pkg/config/hub.go with precedence: flag > env (ELASTICCLAW_*) > hub.yaml > default.
+	//
+	// ListenAddr and DBPath require a restart: changes on SIGHUP reload are
+	// rejected with a log message. LogLevel and AllowedOrigins are hot-reloadable.
+	ListenAddr string `yaml:"listen_addr,omitempty"` // restart required
+	DBPath     string `yaml:"db_path,omitempty"`     // restart required
+	// LogLevel is one of debug, info, warn, error. Default: info. Hot-reloadable via SIGHUP.
+	LogLevel string `yaml:"log_level,omitempty"`
+	// AllowedOrigins restricts CORS to the listed origins. Empty (default) or
+	// a "*" entry keeps the historical allow-all behavior. Hot-reloadable via SIGHUP.
+	AllowedOrigins []string `yaml:"allowed_origins,omitempty"`
+
 	// Hub server fields
 	// PublicURL is the URL claws use to connect back to the hub from remote VMs.
 	// If not set, falls back to URL.


### PR DESCRIPTION
Implements item **3.6 Config consolidation** from the re-architecture plan (`docs/re-arch/phase-3-frontend-and-hardening.md` on `docs/re-arch`).

## Motivation

Two config systems coexist (Viper for the CLI, manual YAML for the hub) and hub.yaml has no hot reload. A single typed loader in pkg/config/hub.go with documented precedence and SIGHUP reload for the safe subset consolidates it.

Concrete evidence in the code before this change:

- `cmd/root.go` configures Viper (`SetEnvPrefix("ELASTICCLAW")`, `AutomaticEnv`, `~/.elasticclaw/config.yaml`) for the CLI, while `cmd/hub.go` loaded `hub.yaml` through the manual `config.LoadHubConfig()` — two unrelated resolution paths in the same binary.
- The hub's process settings were flag-only: `--addr` and `--db` had no env or hub.yaml equivalents, and there was no log level at all, so no documented precedence existed for the server.
- Any hub.yaml edit (CORS, branding, integrations) required a full restart; `corsMiddleware` in `pkg/hub/server.go` hard-coded `Access-Control-Allow-Origin: *`.

## Dependencies

None — branches directly from main.

Logical notes: this deliberately does **not** touch the Phase 3.4 secrets envelope or 3.5 JWT work; the settings API's existing `s.hubCfg = &updatedCfg` swap pattern is reused for the reload path.

## What changed

- **New hub.yaml fields** (`pkg/types/template.go`): `listen_addr`, `db_path` (restart required), `log_level`, `allowed_origins` (hot-reloadable). All optional; omitted fields keep the previous behavior exactly.
- **Consolidated loader** (`pkg/config/hub.go`): `LoadHubBootConfig` resolves addr / db path / log level / allowed origins with the documented precedence **flag > env (`ELASTICCLAW_ADDR`, `ELASTICCLAW_DB`, `ELASTICCLAW_LOG_LEVEL`, `ELASTICCLAW_ALLOWED_ORIGINS`) > hub.yaml > default**, and validates them at boot (log level enum, address shape). Viper stays CLI-only — the hub never touches it.
- **SIGHUP hot reload**: `cmd/hub.go` installs a SIGHUP handler; `Server.ApplyHotReload` (backed by `config.ApplyHotReload`) applies the safe subset — `log_level`, `allowed_origins`, `branding`, `integrations` — under the server mutex. Changes to `listen_addr`/`db_path` on disk are rejected with a clear log stating a restart is required. Flag/env-pinned log levels are re-resolved on reload so a yaml edit cannot override `--log-level` or the env var.
- **Live log level**: the standard `log` package is routed through `slog` with a `slog.LevelVar`, so `kill -HUP` after a `log_level` change takes effect immediately (e.g. `error` silences the hub's info logging). Side effect: hub log lines now carry the slog text format (`time=... level=... msg=...`).
- **CORS honors `allowed_origins`**: `corsMiddleware` is now a `Server` method; an empty list keeps the historical `*` behavior, otherwise only listed origins are echoed (with `Vary: Origin`), read per request so reloads apply instantly.
- **Tests** (`pkg/config/hub_test.go`): precedence matrix (default / yaml / env / flag) for addr, db path, and log level; env-beats-yaml for allowed origins; boot validation failures; `ParseLogLevel`; hot-reload safe-subset application, restart-field rejection, and input non-mutation.

## Testing

- `go build ./...` — pass.
- `go test ./...` (same packages as `make test`, without `-v`) — all packages pass, no failures.
- `go test ./pkg/config/` — pass, including the new precedence matrix and hot-reload tests.
- Manual acceptance run of the built binary:
  - started `elasticclaw hub --addr :18099` with a temp `hub.yaml` (`log_level: info`), edited it to `error`, sent `kill -HUP` → log shows `SIGHUP reload: applied log_level` and `log level INFO -> ERROR`; a second reload's info-level line was correctly suppressed at `error`, and a later `debug` edit + HUP switched to `DEBUG` — no restart.
  - CORS: default responses carry `Access-Control-Allow-Origin: *`; after appending `allowed_origins: [https://good.example.com]` and `kill -HUP`, a matching `Origin` is echoed with `Vary: Origin` and a non-matching origin gets no `Access-Control-Allow-Origin` header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
