### PR TITLE
test(provider): in-memory mock provider and handler unit tests

### DIFF
--- a/pkg/hub/claw_ws_bench_test.go
+++ b/pkg/hub/claw_ws_bench_test.go
@@ -1,0 +1,107 @@
+package hub
+
+// BenchmarkClawWSMessage measures the claw WebSocket message hot path
+// (decode -> persist -> broadcast) end to end: a registered claw connection
+// sends a complete "message" frame, the hub decodes it, persists it to the
+// in-memory SQLite store, and broadcasts it to a connected user WebSocket.
+// This is the baseline for future optimizations (re-architecture plan 3.7).
+//
+// Run with:
+//
+//	go test ./pkg/hub/ -run '^$' -bench BenchmarkClawWSMessage -benchmem
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+	"nhooyr.io/websocket"
+	"nhooyr.io/websocket/wsjson"
+)
+
+func BenchmarkClawWSMessage(b *testing.B) {
+	b.Setenv("ELASTICCLAW_HUB_CONFIG", b.TempDir()+"/hub.yaml")
+	// Silence per-message hub logging during the benchmark.
+	prevOut := log.Writer()
+	log.SetOutput(io.Discard)
+	b.Cleanup(func() { log.SetOutput(prevOut) })
+
+	s, _ := NewTestServerWithConfig(b, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	ts := httptest.NewServer(s.Handler())
+	b.Cleanup(ts.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	wsBase := "ws" + strings.TrimPrefix(ts.URL, "http")
+
+	// User connection that receives the broadcast.
+	userWS, _, err := websocket.Dial(ctx, wsBase+"/api/ws?token=test-token", nil)
+	if err != nil {
+		b.Fatalf("dial user ws: %v", err)
+	}
+	b.Cleanup(func() { _ = userWS.Close(websocket.StatusNormalClosure, "done") })
+
+	// Claw connection that produces messages.
+	clawWS, _, err := websocket.Dial(ctx, wsBase+"/claw/ws", nil)
+	if err != nil {
+		b.Fatalf("dial claw ws: %v", err)
+	}
+	b.Cleanup(func() { _ = clawWS.Close(websocket.StatusNormalClosure, "done") })
+
+	ready := true
+	if err := wsjson.Write(ctx, clawWS, types.WSMessage{
+		Type: "register",
+		Payload: types.RegisterPayload{
+			ClawID:       "claw-bench",
+			Name:         "bench claw",
+			Template:     "elasticclaw",
+			Token:        "claw-token",
+			GatewayReady: &ready,
+		},
+	}); err != nil {
+		b.Fatalf("register claw: %v", err)
+	}
+	var registered types.WSMessage
+	if err := wsjson.Read(ctx, clawWS, &registered); err != nil || registered.Type != "registered" {
+		b.Fatalf("registration ack = %+v, err = %v", registered, err)
+	}
+
+	// readBroadcast reads user WS frames until it sees the persisted claw
+	// message with the given content (skipping claw_status/typing events).
+	readBroadcast := func(content string) {
+		for {
+			var msg types.WSMessage
+			if err := wsjson.Read(ctx, userWS, &msg); err != nil {
+				b.Fatalf("read broadcast: %v", err)
+			}
+			if msg.Type != "message" {
+				continue
+			}
+			payload, _ := json.Marshal(msg.Payload)
+			var hm types.HubMessage
+			if err := json.Unmarshal(payload, &hm); err == nil && hm.Content == content {
+				return
+			}
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		content := fmt.Sprintf("benchmark message %d", i)
+		if err := wsjson.Write(ctx, clawWS, types.WSMessage{
+			Type:    "message",
+			Payload: types.HubMessage{Content: content},
+		}); err != nil {
+			b.Fatalf("write message %d: %v", i, err)
+		}
+		readBroadcast(content)
+	}
+	b.StopTimer()
+}

--- a/pkg/hub/handler_unit_test.go
+++ b/pkg/hub/handler_unit_test.go
@@ -1,0 +1,319 @@
+package hub
+
+// Direct unit tests for the main HTTP handlers, using the in-memory SQLite
+// store from NewTestServerWithConfig. No Daytona/Docker or network access is
+// required (re-architecture plan item 3.7).
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func linearSignature(secret string, body []byte) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+func withTenant(req *http.Request) *http.Request {
+	return req.WithContext(context.WithValue(req.Context(), ctxTenantKey{}, "test-tenant-id"))
+}
+
+func TestHandleCreateClawValidation(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{
+		Providers: map[string]types.ProviderConfig{"mock": {}},
+	}, "", "", "")
+
+	tests := []struct {
+		name string
+		body string
+		want int
+	}{
+		{name: "invalid json", body: "{not json", want: http.StatusBadRequest},
+		{name: "missing name", body: `{"provider":"mock"}`, want: http.StatusBadRequest},
+		{name: "missing provider", body: `{"name":"claw-a"}`, want: http.StatusBadRequest},
+		{name: "unconfigured provider", body: `{"name":"claw-a","provider":"daytona"}`, want: http.StatusUnprocessableEntity},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := withTenant(httptest.NewRequest(http.MethodPost, "/api/claws", strings.NewReader(tt.body)))
+			rec := httptest.NewRecorder()
+			s.handleClaws(rec, req)
+			if rec.Code != tt.want {
+				t.Fatalf("status = %d, want %d (body: %s)", rec.Code, tt.want, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestHandleCreateClawPersistsAndReturnsAccepted(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{
+		Providers: map[string]types.ProviderConfig{"mock": {}},
+	}, "", "", "")
+
+	body := `{"name":"claw-a","provider":"mock","template_name":"tpl"}`
+	req := withTenant(httptest.NewRequest(http.MethodPost, "/api/claws", strings.NewReader(body)))
+	rec := httptest.NewRecorder()
+	s.handleClaws(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202 (body: %s)", rec.Code, rec.Body.String())
+	}
+	var claw types.Claw
+	if err := json.NewDecoder(rec.Body).Decode(&claw); err != nil {
+		t.Fatal(err)
+	}
+	if claw.ID == "" || claw.Name != "claw-a" || claw.Status != "provisioning" {
+		t.Fatalf("unexpected response claw: %+v", claw)
+	}
+
+	// The row is pre-registered synchronously; provisioning itself is async
+	// (and fails for the unroutable "mock" provider), so only assert the
+	// stable columns.
+	var name, provider string
+	if err := db.QueryRow(`SELECT name, provider FROM claws WHERE id=? AND tenant_id=?`, claw.ID, "test-tenant-id").Scan(&name, &provider); err != nil {
+		t.Fatalf("claw row not persisted: %v", err)
+	}
+	if name != "claw-a" || provider != "mock" {
+		t.Fatalf("persisted row = (%q, %q), want (claw-a, mock)", name, provider)
+	}
+
+	// Wait for the async provisioning goroutine to fail and mark the claw as
+	// error, so it does not touch the test DB after cleanup.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		var status string
+		_ = db.QueryRow(`SELECT status FROM claws WHERE id=?`, claw.ID).Scan(&status)
+		if status == "error" {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("claw status = %q, expected async provisioning failure to set error", status)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestHandleMessagesPostPersistsUserMessage(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	s, db := NewTestServerWithConfig(t, nil, "", "", "")
+	if _, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, tags, created_at, status) VALUES(?,?,?,?,datetime('now'),?)`,
+		"claw-1", "test-tenant-id", "claw 1", `[]`, "connected",
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	req := withTenant(httptest.NewRequest(http.MethodPost, "/api/messages/claw-1", strings.NewReader(`{"content":"hello agent"}`)))
+	rec := httptest.NewRecorder()
+	s.handleMessages(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	var msg types.HubMessage
+	if err := json.NewDecoder(rec.Body).Decode(&msg); err != nil {
+		t.Fatal(err)
+	}
+	if msg.Role != "user" || msg.Content != "hello agent" || msg.ClawID != "claw-1" {
+		t.Fatalf("unexpected response message: %+v", msg)
+	}
+
+	var content, role string
+	if err := db.QueryRow(`SELECT content, role FROM messages WHERE id=?`, msg.ID).Scan(&content, &role); err != nil {
+		t.Fatalf("message row not persisted: %v", err)
+	}
+	if content != "hello agent" || role != "user" {
+		t.Fatalf("persisted message = (%q, %q)", content, role)
+	}
+
+	t.Run("empty content is rejected", func(t *testing.T) {
+		req := withTenant(httptest.NewRequest(http.MethodPost, "/api/messages/claw-1", strings.NewReader(`{"content":""}`)))
+		rec := httptest.NewRecorder()
+		s.handleMessages(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400", rec.Code)
+		}
+	})
+}
+
+func TestHandleClawsListMarksStaleConnectedAsOffline(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	s, db := NewTestServerWithConfig(t, nil, "", "", "")
+	seed := []struct{ id, status string }{
+		{"claw-stale", "connected"}, // no live WS conn: must be reported offline
+		{"claw-prov", "provisioning"},
+		{"claw-err", "error"},
+	}
+	for _, c := range seed {
+		if _, err := db.Exec(
+			`INSERT INTO claws(id, tenant_id, name, tags, created_at, status) VALUES(?,?,?,?,datetime('now'),?)`,
+			c.id, "test-tenant-id", c.id, `[]`, c.status,
+		); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	req := withTenant(httptest.NewRequest(http.MethodGet, "/api/claws", nil))
+	rec := httptest.NewRecorder()
+	s.handleClaws(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var claws []types.Claw
+	if err := json.NewDecoder(rec.Body).Decode(&claws); err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]string{}
+	for _, c := range claws {
+		got[c.ID] = string(c.Status)
+	}
+	want := map[string]string{
+		"claw-stale": "offline",
+		"claw-prov":  "provisioning",
+		"claw-err":   "error",
+	}
+	for id, status := range want {
+		if got[id] != status {
+			t.Fatalf("claw %s status = %q, want %q (all: %v)", id, got[id], status, got)
+		}
+	}
+}
+
+func TestSettingsGetMasksLLMKeySecrets(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	const secret = "sk-super-secret-value"
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{
+		LLMKeys: types.LLMKeysList{
+			{Name: "main", Provider: "anthropic", APIKey: secret, Default: true},
+		},
+	}, "", "", "")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/settings", nil)
+	rec := httptest.NewRecorder()
+	s.handleSettings(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if strings.Contains(rec.Body.String(), secret) {
+		t.Fatal("settings response leaks the raw LLM API key")
+	}
+	var view SettingsView
+	if err := json.Unmarshal(rec.Body.Bytes(), &view); err != nil {
+		t.Fatal(err)
+	}
+	if len(view.LLMKeys) != 1 || !view.LLMKeys[0].KeySet {
+		t.Fatalf("expected one configured LLM key, got %+v", view.LLMKeys)
+	}
+}
+
+func TestSettingsPatchUpsertsLLMKeyAndPersists(t *testing.T) {
+	cfgPath := t.TempDir() + "/hub.yaml"
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", cfgPath)
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{}, "", "", "")
+
+	body := `{"llmKeys":[{"name":"main","provider":"anthropic","apiKey":"sk-new-key","default":true}]}`
+	req := httptest.NewRequest(http.MethodPatch, "/api/settings", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	s.handleSettings(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+
+	// In-memory config updated
+	if len(s.hubCfg.LLMKeys) != 1 || s.hubCfg.LLMKeys[0].Name != "main" ||
+		s.hubCfg.LLMKeys[0].APIKey != "sk-new-key" || !s.hubCfg.LLMKeys[0].Default {
+		t.Fatalf("in-memory LLM keys = %+v", s.hubCfg.LLMKeys)
+	}
+
+	// Persisted to hub.yaml before being applied
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("hub.yaml not written: %v", err)
+	}
+	if !strings.Contains(string(data), "sk-new-key") {
+		t.Fatalf("hub.yaml does not contain the new key:\n%s", data)
+	}
+
+	t.Run("method not allowed", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPut, "/api/settings", nil)
+		rec := httptest.NewRecorder()
+		s.handleSettings(rec, req)
+		if rec.Code != http.StatusMethodNotAllowed {
+			t.Fatalf("status = %d, want 405", rec.Code)
+		}
+	})
+}
+
+func TestHandleLinearWebhook(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	const secret = "linear-hmac-secret"
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{
+		Integrations: &types.IntegrationsConfig{
+			Linear: []*types.LinearIntegrationConfig{
+				{Workspace: "acme", Token: "lin_api_x", WebhookSecret: secret},
+			},
+		},
+	}, "", "", "")
+
+	post := func(body []byte, sig string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPost, "/api/integrations/linear/webhook", strings.NewReader(string(body)))
+		if sig != "" {
+			req.Header.Set("Linear-Signature", sig)
+		}
+		rec := httptest.NewRecorder()
+		s.handleLinearWebhook(rec, req)
+		return rec
+	}
+
+	t.Run("method not allowed", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/integrations/linear/webhook", nil)
+		rec := httptest.NewRecorder()
+		s.handleLinearWebhook(rec, req)
+		if rec.Code != http.StatusMethodNotAllowed {
+			t.Fatalf("status = %d, want 405", rec.Code)
+		}
+	})
+
+	body := []byte(`{"action":"update","type":"Comment","data":{"id":"1"}}`)
+
+	t.Run("missing signature is rejected", func(t *testing.T) {
+		if rec := post(body, ""); rec.Code != http.StatusUnauthorized {
+			t.Fatalf("status = %d, want 401", rec.Code)
+		}
+	})
+
+	t.Run("wrong signature is rejected", func(t *testing.T) {
+		if rec := post(body, linearSignature("other-secret", body)); rec.Code != http.StatusUnauthorized {
+			t.Fatalf("status = %d, want 401", rec.Code)
+		}
+	})
+
+	t.Run("valid signature non-issue event is acknowledged", func(t *testing.T) {
+		if rec := post(body, linearSignature(secret, body)); rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rec.Code)
+		}
+	})
+
+	t.Run("invalid payload with valid signature is rejected", func(t *testing.T) {
+		bad := []byte(`{not json`)
+		if rec := post(bad, linearSignature(secret, bad)); rec.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400", rec.Code)
+		}
+	})
+}

--- a/pkg/provider/mock/mock.go
+++ b/pkg/provider/mock/mock.go
@@ -1,0 +1,283 @@
+// Package mock provides an in-memory implementation of the provider.Provider
+// interface for unit tests. It requires no external services (Daytona, Docker,
+// AWS, ...): instance state lives in a map, states are programmable via
+// SetStatus, and failures can be injected per operation with Fail/FailOnce.
+package mock
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/provider"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+// Compile-time check that Provider satisfies the provider.Provider interface.
+var _ provider.Provider = (*Provider)(nil)
+
+// Op identifies a Provider operation for failure injection and call recording.
+type Op string
+
+const (
+	OpCreate  Op = "create"
+	OpStatus  Op = "status"
+	OpExec    Op = "exec"
+	OpConnect Op = "connect"
+	OpStop    Op = "stop"
+	OpStart   Op = "start"
+	OpDestroy Op = "destroy"
+	OpList    Op = "list"
+)
+
+// Call records a single invocation of a Provider method.
+type Call struct {
+	Op         Op
+	InstanceID string
+}
+
+// Provider is an in-memory, thread-safe Provider implementation.
+type Provider struct {
+	mu sync.Mutex
+
+	info       types.ProviderInfo
+	instances  map[string]*types.Instance
+	nextID     int
+	execResult types.ExecResult
+	connect    types.ConnectInfo
+
+	failures     map[Op]error // persistent injected failures
+	failuresOnce map[Op]error // consumed on first matching call
+
+	calls []Call
+}
+
+// New returns a mock Provider with default metadata.
+func New() *Provider {
+	return &Provider{
+		info: types.ProviderInfo{
+			Name:         "mock",
+			Type:         types.ProviderTypeStateful,
+			Capabilities: []string{"exec", "stop", "start"},
+		},
+		instances:    make(map[string]*types.Instance),
+		execResult:   types.ExecResult{ExitCode: 0},
+		connect:      types.ConnectInfo{Shell: &types.ShellConnect{Command: "true"}},
+		failures:     make(map[Op]error),
+		failuresOnce: make(map[Op]error),
+	}
+}
+
+// SetInfo overrides the provider metadata returned by Info.
+func (p *Provider) SetInfo(info types.ProviderInfo) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.info = info
+}
+
+// Fail injects a persistent failure for op. Pass err == nil to clear it.
+func (p *Provider) Fail(op Op, err error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if err == nil {
+		delete(p.failures, op)
+		return
+	}
+	p.failures[op] = err
+}
+
+// FailOnce injects a failure that is consumed by the next call to op.
+func (p *Provider) FailOnce(op Op, err error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.failuresOnce[op] = err
+}
+
+// SetStatus programs the state of an existing instance. It creates the
+// instance record if it does not exist yet, so tests can seed arbitrary states.
+func (p *Provider) SetStatus(instanceID string, status types.InstanceStatus) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	inst, ok := p.instances[instanceID]
+	if !ok {
+		inst = &types.Instance{
+			ID:        instanceID,
+			Name:      instanceID,
+			Provider:  p.info.Name,
+			CreatedAt: time.Now().UTC(),
+		}
+		p.instances[instanceID] = inst
+	}
+	inst.Status = status
+}
+
+// SetExecResult programs the result returned by Exec.
+func (p *Provider) SetExecResult(res types.ExecResult) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.execResult = res
+}
+
+// SetConnectInfo programs the result returned by Connect.
+func (p *Provider) SetConnectInfo(info types.ConnectInfo) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.connect = info
+}
+
+// Calls returns a copy of all recorded Provider method invocations.
+func (p *Provider) Calls() []Call {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]Call, len(p.calls))
+	copy(out, p.calls)
+	return out
+}
+
+// checkLocked records the call and returns any injected failure or context error.
+// Callers must hold p.mu.
+func (p *Provider) checkLocked(ctx context.Context, op Op, instanceID string) error {
+	p.calls = append(p.calls, Call{Op: op, InstanceID: instanceID})
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err, ok := p.failuresOnce[op]; ok {
+		delete(p.failuresOnce, op)
+		return err
+	}
+	if err, ok := p.failures[op]; ok {
+		return err
+	}
+	return nil
+}
+
+// Info returns provider metadata.
+func (p *Provider) Info() types.ProviderInfo {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.info
+}
+
+// Create provisions a new in-memory instance in the running state.
+func (p *Provider) Create(ctx context.Context, req types.CreateRequest) (*types.Instance, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if err := p.checkLocked(ctx, OpCreate, req.Name); err != nil {
+		return nil, err
+	}
+	p.nextID++
+	inst := &types.Instance{
+		ID:        fmt.Sprintf("mock-%d", p.nextID),
+		Name:      req.Name,
+		Provider:  p.info.Name,
+		Status:    types.StatusRunning,
+		CreatedAt: time.Now().UTC(),
+	}
+	p.instances[inst.ID] = inst
+	cp := *inst
+	return &cp, nil
+}
+
+// Status returns the current (possibly programmed) state of an instance.
+func (p *Provider) Status(ctx context.Context, instanceID string) (types.InstanceStatus, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if err := p.checkLocked(ctx, OpStatus, instanceID); err != nil {
+		return types.StatusUnknown, err
+	}
+	inst, ok := p.instances[instanceID]
+	if !ok {
+		return types.StatusNotFound, nil
+	}
+	return inst.Status, nil
+}
+
+// Exec returns the programmed exec result.
+func (p *Provider) Exec(ctx context.Context, instanceID string, cmd []string) (*types.ExecResult, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if err := p.checkLocked(ctx, OpExec, instanceID); err != nil {
+		return nil, err
+	}
+	if _, ok := p.instances[instanceID]; !ok {
+		return nil, fmt.Errorf("mock: instance %q not found", instanceID)
+	}
+	res := p.execResult
+	return &res, nil
+}
+
+// Connect returns the programmed connection info.
+func (p *Provider) Connect(ctx context.Context, instanceID string) (*types.ConnectInfo, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if err := p.checkLocked(ctx, OpConnect, instanceID); err != nil {
+		return nil, err
+	}
+	if _, ok := p.instances[instanceID]; !ok {
+		return nil, fmt.Errorf("mock: instance %q not found", instanceID)
+	}
+	info := p.connect
+	return &info, nil
+}
+
+// Stop transitions an instance to the stopped state.
+func (p *Provider) Stop(ctx context.Context, instanceID string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if err := p.checkLocked(ctx, OpStop, instanceID); err != nil {
+		return err
+	}
+	inst, ok := p.instances[instanceID]
+	if !ok {
+		return fmt.Errorf("mock: instance %q not found", instanceID)
+	}
+	inst.Status = types.StatusStopped
+	return nil
+}
+
+// Start transitions a stopped instance back to running.
+func (p *Provider) Start(ctx context.Context, instanceID string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if err := p.checkLocked(ctx, OpStart, instanceID); err != nil {
+		return err
+	}
+	inst, ok := p.instances[instanceID]
+	if !ok {
+		return fmt.Errorf("mock: instance %q not found", instanceID)
+	}
+	inst.Status = types.StatusRunning
+	return nil
+}
+
+// Destroy removes the instance from the in-memory map.
+func (p *Provider) Destroy(ctx context.Context, instanceID string, keepState bool) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if err := p.checkLocked(ctx, OpDestroy, instanceID); err != nil {
+		return err
+	}
+	if _, ok := p.instances[instanceID]; !ok {
+		return fmt.Errorf("mock: instance %q not found", instanceID)
+	}
+	delete(p.instances, instanceID)
+	return nil
+}
+
+// List returns copies of all instances, sorted by ID for determinism.
+func (p *Provider) List(ctx context.Context) ([]*types.Instance, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if err := p.checkLocked(ctx, OpList, ""); err != nil {
+		return nil, err
+	}
+	out := make([]*types.Instance, 0, len(p.instances))
+	for _, inst := range p.instances {
+		cp := *inst
+		out = append(out, &cp)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out, nil
+}

--- a/pkg/provider/mock/mock_test.go
+++ b/pkg/provider/mock/mock_test.go
@@ -1,0 +1,185 @@
+package mock
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/provider"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func TestLifecycle(t *testing.T) {
+	p := New()
+	ctx := context.Background()
+
+	inst, err := p.Create(ctx, types.CreateRequest{Name: "claw-1"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if inst.ID == "" || inst.Name != "claw-1" {
+		t.Fatalf("unexpected instance: %+v", inst)
+	}
+
+	st, err := p.Status(ctx, inst.ID)
+	if err != nil || st != types.StatusRunning {
+		t.Fatalf("Status after create = %v, %v; want running, nil", st, err)
+	}
+
+	if err := p.Stop(ctx, inst.ID); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if st, _ := p.Status(ctx, inst.ID); st != types.StatusStopped {
+		t.Fatalf("Status after stop = %v; want stopped", st)
+	}
+
+	if err := p.Start(ctx, inst.ID); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if st, _ := p.Status(ctx, inst.ID); st != types.StatusRunning {
+		t.Fatalf("Status after start = %v; want running", st)
+	}
+
+	if err := p.Destroy(ctx, inst.ID, false); err != nil {
+		t.Fatalf("Destroy: %v", err)
+	}
+	if st, _ := p.Status(ctx, inst.ID); st != types.StatusNotFound {
+		t.Fatalf("Status after destroy = %v; want not_found", st)
+	}
+}
+
+func TestProgrammableStatus(t *testing.T) {
+	p := New()
+	p.SetStatus("seeded", types.StatusUnhealthy)
+
+	st, err := p.Status(context.Background(), "seeded")
+	if err != nil || st != types.StatusUnhealthy {
+		t.Fatalf("Status = %v, %v; want unhealthy, nil", st, err)
+	}
+
+	list, err := p.List(context.Background())
+	if err != nil || len(list) != 1 || list[0].ID != "seeded" {
+		t.Fatalf("List = %+v, %v; want single seeded instance", list, err)
+	}
+}
+
+func TestFailureInjection(t *testing.T) {
+	p := New()
+	boom := errors.New("boom")
+
+	p.Fail(OpCreate, boom)
+	if _, err := p.Create(context.Background(), types.CreateRequest{Name: "x"}); !errors.Is(err, boom) {
+		t.Fatalf("Create with injected failure = %v; want boom", err)
+	}
+	p.Fail(OpCreate, nil)
+	if _, err := p.Create(context.Background(), types.CreateRequest{Name: "x"}); err != nil {
+		t.Fatalf("Create after clearing failure: %v", err)
+	}
+
+	p.FailOnce(OpList, boom)
+	if _, err := p.List(context.Background()); !errors.Is(err, boom) {
+		t.Fatalf("List first call = %v; want boom", err)
+	}
+	if _, err := p.List(context.Background()); err != nil {
+		t.Fatalf("List second call = %v; want nil (FailOnce consumed)", err)
+	}
+}
+
+func TestContextCancellation(t *testing.T) {
+	p := New()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := p.Create(ctx, types.CreateRequest{Name: "x"}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Create with cancelled ctx = %v; want context.Canceled", err)
+	}
+	if _, err := p.Status(ctx, "x"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Status with cancelled ctx = %v; want context.Canceled", err)
+	}
+}
+
+func TestExecAndConnectProgrammableResults(t *testing.T) {
+	p := New()
+	ctx := context.Background()
+	inst, err := p.Create(ctx, types.CreateRequest{Name: "x"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p.SetExecResult(types.ExecResult{ExitCode: 3, Stderr: "nope"})
+	res, err := p.Exec(ctx, inst.ID, []string{"false"})
+	if err != nil || res.ExitCode != 3 || res.Stderr != "nope" {
+		t.Fatalf("Exec = %+v, %v; want programmed result", res, err)
+	}
+
+	p.SetConnectInfo(types.ConnectInfo{Web: "https://example.test"})
+	ci, err := p.Connect(ctx, inst.ID)
+	if err != nil || ci.Web != "https://example.test" {
+		t.Fatalf("Connect = %+v, %v; want programmed info", ci, err)
+	}
+
+	if _, err := p.Exec(ctx, "missing", nil); err == nil {
+		t.Fatal("Exec on missing instance should fail")
+	}
+	if _, err := p.Connect(ctx, "missing"); err == nil {
+		t.Fatal("Connect on missing instance should fail")
+	}
+}
+
+func TestCallRecording(t *testing.T) {
+	p := New()
+	ctx := context.Background()
+	inst, _ := p.Create(ctx, types.CreateRequest{Name: "x"})
+	_, _ = p.Status(ctx, inst.ID)
+	_ = p.Stop(ctx, inst.ID)
+
+	calls := p.Calls()
+	want := []Op{OpCreate, OpStatus, OpStop}
+	if len(calls) != len(want) {
+		t.Fatalf("calls = %+v; want %d entries", calls, len(want))
+	}
+	for i, op := range want {
+		if calls[i].Op != op {
+			t.Fatalf("calls[%d].Op = %q; want %q", i, calls[i].Op, op)
+		}
+	}
+}
+
+func TestRegistryIntegration(t *testing.T) {
+	reg := provider.NewRegistry()
+	reg.Register("mock", New())
+
+	got, ok := reg.Get("mock")
+	if !ok {
+		t.Fatal("registry did not return mock provider")
+	}
+	if got.Info().Name != "mock" {
+		t.Fatalf("Info().Name = %q; want mock", got.Info().Name)
+	}
+	infos := reg.ListWithInfo()
+	if len(infos) != 1 || infos[0].Name != "mock" {
+		t.Fatalf("ListWithInfo = %+v", infos)
+	}
+}
+
+func TestConcurrentAccess(t *testing.T) {
+	p := New()
+	ctx := context.Background()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 100; i++ {
+			_, _ = p.Create(ctx, types.CreateRequest{Name: "c"})
+		}
+	}()
+	for i := 0; i < 100; i++ {
+		_, _ = p.List(ctx)
+		p.SetStatus("seeded", types.StatusRunning)
+	}
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("concurrent creates did not finish")
+	}
+}


### PR DESCRIPTION
## Motivation

Handler tests today need Daytona/Docker. An in-memory Provider implementation with programmable states and injectable failures enables direct unit tests for the main handlers and a BenchmarkClawWSMessage baseline.

Concrete evidence from the code:

- Every concrete `provider.Provider` implementation (`pkg/provider/daytona`, `docker`, `exedev`, `lambdamicrovms`, `replicated`) talks to an external service or daemon, so nothing implementing the interface could be used in unit tests.
- `pkg/hub/server.go` is ~6,560 lines and, before this PR, the main claw/message handlers (`handleCreateClaw`, `handleMessages`, `handleClaws`) had no direct request/response unit tests for their core success paths, and neither did `handleSettings` GET/PATCH (`pkg/hub/settings.go`) beyond `getSettings` edge cases; the Linear webhook tests (`pkg/hub/linear_webhook_test.go`) covered workflow behavior but not the handler's method/signature/payload validation.
- The claw WebSocket hot path (decode -> persist -> broadcast in `handleClawWS`) had no benchmark, so there was no baseline to measure future optimizations against.

This implements item 3.7 (Backend testability) of the re-architecture plan.

## Dependencies

None — branches directly from main.

Note: Phase 2's handler extraction has not landed on main yet, so the unit tests target the handlers where they live today (`pkg/hub/server.go`, `settings.go`, `linear.go`). They exercise handlers directly via `httptest`, so they will survive a later extraction. Also note the create-claw path dispatches provisioning by provider name (`provisionDaytona`/`provisionDocker`/...) rather than through the `provider.Provider` interface, so the mock cannot be wired into that path yet; the handler tests use the in-memory SQLite store from `NewTestServerWithConfig`, and the mock is exercised through its own suite and the provider registry.

## What changed

- **`pkg/provider/mock`** (new): in-memory, thread-safe implementation of `provider.Provider` with:
  - programmable instance states (`SetStatus`) and programmable `Exec`/`Connect` results;
  - injectable failures per operation, persistent (`Fail`) or one-shot (`FailOnce`);
  - context-cancellation awareness and call recording (`Calls`) for assertions;
  - full test suite: lifecycle, failure injection, cancellation, registry integration, concurrency.
- **`pkg/hub/handler_unit_test.go`** (new): direct unit tests for 5 main handlers against the in-memory store:
  - create claw: validation (400/422) and success (202 + persisted row);
  - send message: persistence + response shape, empty content rejected;
  - list claws: stale `connected` rows are normalized to `offline`, `provisioning`/`error` preserved;
  - settings GET: raw LLM API keys are never leaked (masked as `keySet`);
  - settings PATCH: LLM key upsert applied in memory and persisted to hub.yaml, 405 for other methods;
  - Linear webhook: 405 on GET, 401 on missing/wrong HMAC signature, 200 on valid non-Issue events, 400 on invalid JSON with a valid signature.
- **`pkg/hub/claw_ws_bench_test.go`** (new): `BenchmarkClawWSMessage` exercises the real hot path end to end over WebSockets (claw sends a `message` frame -> hub decodes -> persists to SQLite -> broadcasts to a connected user WS). Baseline on a dev laptop (VirtualApple @ 2.50GHz): ~262µs/op, ~10.2KB/op, 251 allocs/op.

No production code was changed — this PR is tests only.

## Testing

- `go build ./...` — pass.
- `go test ./pkg/provider/mock/...` — pass (spec acceptance).
- `go test ./pkg/hub/ -run 'TestHandleCreateClaw|TestHandleMessagesPost|TestHandleClawsListMarks|TestSettingsGetMasks|TestSettingsPatchUpserts|TestHandleLinearWebhook' -v` — all pass.
- `go test ./pkg/hub/ -run '^$' -bench BenchmarkClawWSMessage -benchmem -benchtime 200x` — pass (262244 ns/op, 10249 B/op, 251 allocs/op).
- `go test ./...` (equivalent of `make test` without `-v`) — full suite passes, no failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
