### PR TITLE
fix: make workflow show display the raw workflow YAML

### DIFF
--- a/cmd/workflow.go
+++ b/cmd/workflow.go
@@ -46,6 +46,7 @@ type workflowCLIView struct {
 	EnableManualTrigger  bool                     `json:"enableManualTrigger"`
 	SecretRefs           map[string]string        `json:"secretRefs"`
 	Inputs               []map[string]interface{} `json:"inputs"`
+	RawConfig            string                   `json:"rawConfig"`
 }
 
 func workflowListCmd() *cobra.Command {
@@ -111,6 +112,13 @@ func runWorkflowShow(workspace, name string) error {
 	}
 	if jsonOut {
 		return json.NewEncoder(os.Stdout).Encode(workflow)
+	}
+	if strings.TrimSpace(workflow.RawConfig) != "" {
+		fmt.Print(workflow.RawConfig)
+		if !strings.HasSuffix(workflow.RawConfig, "\n") {
+			fmt.Println()
+		}
+		return nil
 	}
 	out, err := yaml.Marshal(workflow)
 	if err != nil {

--- a/cmd/workflow.go
+++ b/cmd/workflow.go
@@ -46,7 +46,7 @@ type workflowCLIView struct {
 	EnableManualTrigger  bool                     `json:"enableManualTrigger"`
 	SecretRefs           map[string]string        `json:"secretRefs"`
 	Inputs               []map[string]interface{} `json:"inputs"`
-	RawConfig            string                   `json:"rawConfig"`
+	RawConfig            string                   `json:"rawConfig,omitempty"`
 }
 
 func workflowListCmd() *cobra.Command {

--- a/pkg/hub/workspace_api.go
+++ b/pkg/hub/workspace_api.go
@@ -51,6 +51,7 @@ type WorkflowView struct {
 	SecretRefs           map[string]string      `json:"secretRefs,omitempty"`
 	Volumes              []types.WorkflowVolume `json:"volumes,omitempty"`
 	Inputs               []types.FactoryInput   `json:"inputs,omitempty"`
+	RawConfig            string                 `json:"rawConfig,omitempty"`
 }
 
 func (s *Server) handleWorkspacesList(w http.ResponseWriter, _ *http.Request) {
@@ -501,6 +502,7 @@ func workflowToView(workspaceName string, workflow *types.WorkflowConfig) Workfl
 		SecretRefs:           cloneStringMap(workflow.SecretRefs),
 		Volumes:              append([]types.WorkflowVolume(nil), workflow.Volumes...),
 		Inputs:               append([]types.FactoryInput(nil), workflow.Inputs...),
+		RawConfig:            workflow.RawConfig,
 	}
 }
 

--- a/pkg/hub/workspace_api.go
+++ b/pkg/hub/workspace_api.go
@@ -211,12 +211,18 @@ func (s *Server) handleWorkspaceWorkflowDetail(w http.ResponseWriter, r *http.Re
 		http.Error(w, "workspace and workflow names required", http.StatusBadRequest)
 		return
 	}
-	workflow, ok := s.findWorkflowView(workspaceName, workflowName)
+	workspace, workflow, ok, err := s.resolveWorkflowConfig(workspaceName, workflowName)
+	if err != nil {
+		http.Error(w, "failed to load workflow: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
 	if !ok {
 		http.Error(w, "workflow not found", http.StatusNotFound)
 		return
 	}
-	jsonOK(w, workflow)
+	view := workflowToView(workspace.Name, workflow)
+	view.RawConfig = workflow.RawConfig
+	jsonOK(w, view)
 }
 
 type WorkflowPatchRequest struct {
@@ -416,20 +422,6 @@ func (s *Server) queryGitHubIssue(repo, token, base string, issueNumber int) (gi
 	return issue, nil
 }
 
-func (s *Server) findWorkflowView(workspaceName, workflowName string) (WorkflowView, bool) {
-	for _, workspace := range s.workspaceViews() {
-		if !strings.EqualFold(workspace.Name, workspaceName) {
-			continue
-		}
-		for _, workflow := range workspace.Workflows {
-			if strings.EqualFold(workflow.Name, workflowName) {
-				return workflow, true
-			}
-		}
-	}
-	return WorkflowView{}, false
-}
-
 func (s *Server) workspaceViews() []WorkspaceView {
 	persisted, err := loadExternalWorkspaces()
 	if err != nil {
@@ -502,7 +494,6 @@ func workflowToView(workspaceName string, workflow *types.WorkflowConfig) Workfl
 		SecretRefs:           cloneStringMap(workflow.SecretRefs),
 		Volumes:              append([]types.WorkflowVolume(nil), workflow.Volumes...),
 		Inputs:               append([]types.FactoryInput(nil), workflow.Inputs...),
-		RawConfig:            workflow.RawConfig,
 	}
 }
 


### PR DESCRIPTION
- The API detail response (/api/workspaces/{ws}/workflows/{name}) includes the raw workflow YAML as rawConfig.
- elasticclaw workflow show prints that raw YAML when it's available, so you see exactly what's on disk and what the runner uses.