### PR TITLE
feat(hub): encrypt secrets at rest in hub.yaml (AES-256-GCM envelope)

### DIFF
--- a/cmd/hub.go
+++ b/cmd/hub.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/elasticclaw/elasticclaw/pkg/config"
 	"github.com/elasticclaw/elasticclaw/pkg/hub"
+	"github.com/elasticclaw/elasticclaw/pkg/secrets"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 	"github.com/spf13/cobra"
 )
@@ -66,6 +67,13 @@ func runHub(cmd *cobra.Command, args []string) error {
 	dbPath := hubDBPath
 	if dbPath == "" {
 		dbPath = filepath.Join(dir, "hub.db")
+	}
+
+	// Ensure the secrets master key exists (created on first boot, 0600).
+	// It is required to decrypt enc:v1: values in hub.yaml and to encrypt
+	// sensitive fields on save.
+	if _, err := secrets.EnsureMasterKey(); err != nil {
+		return fmt.Errorf("failed to initialize secrets master key: %w", err)
 	}
 
 	hubCfg, err := config.LoadHubConfig()

--- a/cmd/hub_encrypt_secrets.go
+++ b/cmd/hub_encrypt_secrets.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/elasticclaw/elasticclaw/pkg/config"
+	"github.com/spf13/cobra"
+)
+
+var hubEncryptSecretsCmd = &cobra.Command{
+	Use:   "encrypt-secrets",
+	Short: "Encrypt all sensitive fields in hub.yaml at rest",
+	Long: `Rewrite hub.yaml so every sensitive field (tokens, passwords, private keys,
+webhook secrets) is stored as an enc:v1: AES-256-GCM envelope.
+
+The master key is read from the ELASTICCLAW_MASTER_KEY environment variable
+(32 bytes, base64) or from the master.key file next to the hub data
+(~/.elasticclaw/master.key by default); a new key is generated on first use.
+
+Plaintext secrets are also migrated automatically the next time the hub saves
+its config — this command just forces the full migration immediately.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, err := config.LoadHubConfig()
+		if err != nil {
+			return fmt.Errorf("failed to load hub config: %w", err)
+		}
+		if err := config.SaveHubConfig(cfg); err != nil {
+			return fmt.Errorf("failed to save hub config: %w", err)
+		}
+		path, err := config.ActiveHubConfigPath()
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Encrypted secrets in %s\n", path)
+		return nil
+	},
+}
+
+func init() {
+	hubCmd.AddCommand(hubEncryptSecretsCmd)
+}

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/elasticclaw/elasticclaw/pkg/install"
+	"github.com/elasticclaw/elasticclaw/pkg/secrets"
 	"github.com/spf13/cobra"
 	gossh "golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
@@ -102,12 +103,19 @@ func runInstall(cmd *cobra.Command, args []string) error {
 	}
 	clawToken := randomHex32()
 
+	// Master key for encrypting secrets at rest in hub.yaml (AES-256-GCM).
+	masterKey, err := secrets.NewMasterKey()
+	if err != nil {
+		return fmt.Errorf("failed to generate secrets master key: %w", err)
+	}
+
 	params := install.Params{
 		Domain:     installDomain,
 		Version:    version,
 		Token:      token,
 		ClawToken:  clawToken,
 		UIPassword: uiToken,
+		MasterKey:  masterKey,
 	}
 
 	// ── Preflight: DNS check (skipped with --skip-caddy) ─────────────────────
@@ -153,6 +161,7 @@ func runInstall(cmd *cobra.Command, args []string) error {
 		script string
 	}{
 		{"Installing hub binary", installBinaryScript},
+		{"Writing secrets master key", install.ScriptWriteMasterKeyEnv(masterKey, useSudo)},
 		{"Writing hub config", install.ScriptWriteConfig(params, useSudo)},
 		{"Installing systemd service", install.ScriptInstallSystemd(useSudo)},
 	}

--- a/docs/secrets-at-rest.md
+++ b/docs/secrets-at-rest.md
@@ -1,0 +1,63 @@
+# Secrets at rest in hub.yaml
+
+The hub encrypts sensitive fields in `hub.yaml` (tokens, passwords, LLM API
+keys, GitHub App private keys, integration tokens, webhook secrets) using
+AES-256-GCM. Encrypted values look like:
+
+```yaml
+token: enc:v1:xkQ2rn3...   # base64(nonce || ciphertext)
+```
+
+Non-sensitive fields stay plaintext, so `hub.yaml` remains readable and
+editable by hand.
+
+## Master key
+
+The 32-byte master key is resolved in this order:
+
+1. `ELASTICCLAW_MASTER_KEY` environment variable (base64-encoded 32 bytes).
+   The installer generates this and injects it into the systemd unit via a
+   0600 `EnvironmentFile` at `/etc/elasticclaw/master.env`.
+2. A `master.key` file, created automatically on first hub boot with 0600
+   permissions:
+   - next to the hub config when `ELASTICCLAW_HUB_CONFIG` points at a custom
+     path,
+   - `~/.elasticclaw/master.key` otherwise.
+
+When running CLI commands (e.g. `elasticclaw hub encrypt-secrets`) on a
+server installed with the systemd unit, source the key first so the CLI uses
+the same key as the service:
+
+```sh
+set -a; . /etc/elasticclaw/master.env; set +a
+```
+
+## Migration
+
+- Plaintext values (configs written before encryption existed, or edited by
+  hand) are accepted on load and rewritten encrypted the next time the hub
+  saves its config. No manual intervention is required on upgrade.
+- To force the full migration immediately:
+
+  ```sh
+  elasticclaw hub encrypt-secrets
+  ```
+
+## Runbook: lost master key
+
+Encrypted values cannot be recovered without the master key. If the key is
+lost (deleted `master.env`/`master.key` and no backup):
+
+1. Stop the hub.
+2. Edit `hub.yaml` and replace every `enc:v1:...` value with its plaintext
+   secret (re-issue tokens/keys you no longer have: GitHub App private key,
+   Linear/Shortcut/Jira tokens, LLM API keys, etc.).
+3. Delete the stale key so a fresh one is generated:
+   `rm -f ~/.elasticclaw/master.key /etc/elasticclaw/master.env` (adjust
+   paths to your install; recreate `master.env` if your systemd unit expects
+   it, using `ELASTICCLAW_MASTER_KEY=$(openssl rand -base64 32)`).
+4. Start the hub. Plaintext values load fine and are re-encrypted under the
+   new key on the next save, or run `elasticclaw hub encrypt-secrets`.
+
+Back up the master key (`/etc/elasticclaw/master.env` or
+`~/.elasticclaw/master.key`) separately from `hub.yaml`.

--- a/pkg/config/hub.go
+++ b/pkg/config/hub.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/elasticclaw/elasticclaw/pkg/secrets"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 	"gopkg.in/yaml.v3"
 )
@@ -34,9 +35,30 @@ func LoadHubConfig() (*types.HubConfig, error) {
 		if err := yaml.Unmarshal(data, cfg); err != nil {
 			return nil, fmt.Errorf("failed to parse hub config %s: %w", path, err)
 		}
+		if err := decryptHubSecrets(cfg, path); err != nil {
+			return nil, err
+		}
 		return cfg, nil
 	}
 	return &types.HubConfig{}, nil
+}
+
+// decryptHubSecrets transparently decrypts enc:v1: envelopes on fields tagged
+// secret:"true". Plaintext values (pre-encryption configs) pass through
+// unchanged and are re-written encrypted on the next save.
+func decryptHubSecrets(cfg *types.HubConfig, path string) error {
+	if !secrets.ContainsEncrypted(cfg) {
+		return nil
+	}
+	key, err := secrets.LoadMasterKey()
+	if err != nil {
+		return fmt.Errorf("hub config %s contains encrypted secrets but the master key is unavailable (set %s or restore master.key; if the key is lost, re-enter the secrets — see docs/secrets-at-rest.md): %w",
+			path, secrets.MasterKeyEnvVar, err)
+	}
+	if err := secrets.DecryptFields(cfg, key); err != nil {
+		return fmt.Errorf("failed to decrypt secrets in hub config %s (if the master key was lost, re-enter the secrets — see docs/secrets-at-rest.md): %w", path, err)
+	}
+	return nil
 }
 
 // SaveHubConfig writes hub config to ~/.elasticclaw/hub.yaml.
@@ -102,11 +124,33 @@ func saveHubConfig(cfg *types.HubConfig, mergeDiskSecrets bool) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return err
 	}
-	data, err := yaml.Marshal(&cfgToWrite)
+	data, err := encryptedHubConfigYAML(&cfgToWrite)
 	if err != nil {
 		return err
 	}
 	return os.WriteFile(path, data, 0600)
+}
+
+// encryptedHubConfigYAML marshals cfg with every secret:"true" field encrypted
+// under the master key (generated on first use). The caller's config is never
+// mutated: encryption happens on a deep copy obtained via a YAML round-trip.
+func encryptedHubConfigYAML(cfg *types.HubConfig) ([]byte, error) {
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return nil, err
+	}
+	encCfg := &types.HubConfig{}
+	if err := yaml.Unmarshal(data, encCfg); err != nil {
+		return nil, fmt.Errorf("failed to copy hub config for encryption: %w", err)
+	}
+	key, err := secrets.EnsureMasterKey()
+	if err != nil {
+		return nil, fmt.Errorf("cannot encrypt hub config secrets: %w", err)
+	}
+	if err := secrets.EncryptFields(encCfg, key); err != nil {
+		return nil, fmt.Errorf("failed to encrypt hub config secrets: %w", err)
+	}
+	return yaml.Marshal(encCfg)
 }
 
 func hubConfigPaths() []string {

--- a/pkg/config/hub_test.go
+++ b/pkg/config/hub_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/elasticclaw/elasticclaw/pkg/secrets"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 	"gopkg.in/yaml.v3"
 )
@@ -21,8 +22,136 @@ func TestSaveHubConfigUsesExplicitEnvPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read env hub config: %v", err)
 	}
-	if !strings.Contains(string(data), "token: test-token") {
-		t.Fatalf("saved config = %s", string(data))
+	// Secrets are encrypted at rest: the raw file must not contain the token.
+	if strings.Contains(string(data), "test-token") {
+		t.Fatalf("saved config leaks plaintext token: %s", string(data))
+	}
+	if !strings.Contains(string(data), secrets.EnvelopePrefix) {
+		t.Fatalf("saved config has no encryption envelope: %s", string(data))
+	}
+	// Loading decrypts transparently.
+	cfg, err := LoadHubConfig()
+	if err != nil {
+		t.Fatalf("LoadHubConfig: %v", err)
+	}
+	if cfg.Token != "test-token" {
+		t.Fatalf("loaded token = %q, want %q", cfg.Token, "test-token")
+	}
+}
+
+func TestHubConfigSecretsEncryptedAtRest(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "hub.yaml")
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", path)
+
+	cfg := &types.HubConfig{
+		URL:        "https://hub.example.com",
+		Token:      "hub-token",
+		ClawToken:  "claw-token",
+		UIPassword: "ui-pass",
+		LLMKeys:    types.LLMKeysList{{Name: "anthropic", Provider: "anthropic", APIKey: "sk-ant-123", Default: true}},
+		GitHubApps: []*types.GitHubAppConfig{{AppID: 42, PrivateKeyPEM: "-----BEGIN RSA PRIVATE KEY-----\nkeydata\n-----END RSA PRIVATE KEY-----"}},
+		Secrets:    map[string]string{"webhook": "hook-secret"},
+		Integrations: &types.IntegrationsConfig{
+			Linear: []*types.LinearIntegrationConfig{{Workspace: "acme", Token: "lin_api_abc", WebhookSecret: "lin-hook"}},
+			Jira:   []*types.JiraIntegrationConfig{{Workspace: "jira", Token: "jira-token"}},
+		},
+	}
+	if err := SaveHubConfig(cfg); err != nil {
+		t.Fatalf("SaveHubConfig: %v", err)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read hub config: %v", err)
+	}
+	for _, plaintext := range []string{"hub-token", "claw-token", "ui-pass", "sk-ant-123", "keydata", "hook-secret", "lin_api_abc", "lin-hook", "jira-token"} {
+		if strings.Contains(string(raw), plaintext) {
+			t.Errorf("hub.yaml leaks plaintext secret %q", plaintext)
+		}
+	}
+	// Non-secret fields stay readable.
+	if !strings.Contains(string(raw), "https://hub.example.com") {
+		t.Error("non-secret url should stay plaintext")
+	}
+	if !strings.Contains(string(raw), "workspace: acme") {
+		t.Error("non-secret workspace should stay plaintext")
+	}
+
+	// Caller's in-memory config must not be mutated by saving.
+	if cfg.Token != "hub-token" || cfg.LLMKeys[0].APIKey != "sk-ant-123" {
+		t.Fatal("SaveHubConfig mutated the caller's config")
+	}
+
+	loaded, err := LoadHubConfig()
+	if err != nil {
+		t.Fatalf("LoadHubConfig: %v", err)
+	}
+	if loaded.Token != "hub-token" || loaded.ClawToken != "claw-token" || loaded.UIPassword != "ui-pass" ||
+		loaded.LLMKeys[0].APIKey != "sk-ant-123" ||
+		loaded.Secrets["webhook"] != "hook-secret" ||
+		loaded.Integrations.Linear[0].Token != "lin_api_abc" ||
+		loaded.Integrations.Jira[0].Token != "jira-token" {
+		t.Fatalf("loaded config does not roundtrip: %+v", loaded)
+	}
+	if !strings.Contains(loaded.GitHubApps[0].PrivateKeyPEM, "keydata") {
+		t.Fatalf("github app private key does not roundtrip: %q", loaded.GitHubApps[0].PrivateKeyPEM)
+	}
+}
+
+func TestLoadHubConfigAcceptsPlaintextAndMigratesOnSave(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hub.yaml")
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", path)
+
+	// Pre-encryption config written by hand: plaintext secrets.
+	plaintext := "token: legacy-token\nui_password: legacy-pass\n"
+	if err := os.WriteFile(path, []byte(plaintext), 0600); err != nil {
+		t.Fatalf("write legacy config: %v", err)
+	}
+
+	cfg, err := LoadHubConfig()
+	if err != nil {
+		t.Fatalf("LoadHubConfig (plaintext): %v", err)
+	}
+	if cfg.Token != "legacy-token" || cfg.UIPassword != "legacy-pass" {
+		t.Fatalf("plaintext values not accepted: %+v", cfg)
+	}
+
+	// Saving migrates to encrypted form.
+	if err := SaveHubConfig(cfg); err != nil {
+		t.Fatalf("SaveHubConfig: %v", err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read migrated config: %v", err)
+	}
+	if strings.Contains(string(raw), "legacy-token") || strings.Contains(string(raw), "legacy-pass") {
+		t.Fatalf("migration left plaintext secrets: %s", string(raw))
+	}
+	reloaded, err := LoadHubConfig()
+	if err != nil {
+		t.Fatalf("LoadHubConfig (migrated): %v", err)
+	}
+	if reloaded.Token != "legacy-token" || reloaded.UIPassword != "legacy-pass" {
+		t.Fatalf("migrated config does not roundtrip: %+v", reloaded)
+	}
+}
+
+func TestLoadHubConfigMissingMasterKeyFails(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hub.yaml")
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", path)
+	t.Setenv(secrets.MasterKeyEnvVar, "")
+
+	if err := SaveHubConfig(&types.HubConfig{Token: "sekret"}); err != nil {
+		t.Fatalf("SaveHubConfig: %v", err)
+	}
+	// Simulate a lost master key.
+	if err := os.Remove(filepath.Join(dir, "master.key")); err != nil {
+		t.Fatalf("remove master.key: %v", err)
+	}
+	if _, err := LoadHubConfig(); err == nil {
+		t.Fatal("expected LoadHubConfig to fail without the master key")
 	}
 }
 

--- a/pkg/install/scripts.go
+++ b/pkg/install/scripts.go
@@ -3,7 +3,11 @@
 // All functions are side-effect free and easily testable.
 package install
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/elasticclaw/elasticclaw/pkg/secrets"
+)
 
 // Params holds all inputs needed to generate install scripts.
 type Params struct {
@@ -12,6 +16,10 @@ type Params struct {
 	Token      string
 	ClawToken  string
 	UIPassword string
+	// MasterKey is the base64-encoded 32-byte secrets master key. When set,
+	// sensitive values in the generated hub.yaml are written as enc:v1:
+	// AES-256-GCM envelopes instead of plaintext.
+	MasterKey string
 }
 
 // HubBinaryURL returns the GitHub releases download URL for the hub binary.
@@ -23,14 +31,58 @@ func HubBinaryURL(version string) string {
 }
 
 // HubConfig returns the hub.yaml config file content.
+// When p.MasterKey is set, token, claw_token, and ui_password are stored
+// encrypted so a fresh install's hub.yaml contains no cleartext secret.
 func HubConfig(p Params) string {
+	token, clawToken, uiPassword := p.Token, p.ClawToken, p.UIPassword
+	if p.MasterKey != "" {
+		if key, err := secrets.ParseMasterKey(p.MasterKey); err == nil {
+			token = encryptOrPlaintext(key, token)
+			clawToken = encryptOrPlaintext(key, clawToken)
+			uiPassword = encryptOrPlaintext(key, uiPassword)
+		}
+	}
 	return fmt.Sprintf(`url: https://%s
 public_url: https://%s
 token: %s
 claw_token: %s
 ui_password: %s
 address: :8080
-`, p.Domain, p.Domain, p.Token, p.ClawToken, p.UIPassword)
+`, p.Domain, p.Domain, token, clawToken, uiPassword)
+}
+
+// encryptOrPlaintext encrypts v, falling back to the plaintext value if
+// encryption fails (the hub then migrates it transparently on the next save).
+func encryptOrPlaintext(key []byte, v string) string {
+	enc, err := secrets.Encrypt(key, v)
+	if err != nil {
+		return v
+	}
+	return enc
+}
+
+// MasterKeyEnvFilePath is where the installer writes the systemd
+// EnvironmentFile that carries the secrets master key.
+const MasterKeyEnvFilePath = "/etc/elasticclaw/master.env"
+
+// MasterKeyEnvFile returns the systemd EnvironmentFile content carrying the
+// secrets master key.
+func MasterKeyEnvFile(masterKey string) string {
+	return fmt.Sprintf("%s=%s\n", secrets.MasterKeyEnvVar, masterKey)
+}
+
+// ScriptWriteMasterKeyEnv returns the shell script that writes the master key
+// EnvironmentFile (0600) referenced by the systemd unit. The file is always
+// overwritten together with hub.yaml so the key on disk matches the envelopes
+// in the freshly written config.
+func ScriptWriteMasterKeyEnv(masterKey string, useSudo bool) string {
+	sudo := sudoPrefix(useSudo)
+	return fmt.Sprintf(`umask 077
+cat > /tmp/master.env << 'KEYEOF'
+%sKEYEOF
+%s mkdir -p /etc/elasticclaw
+%s mv /tmp/master.env %q
+%s chmod 600 %q`, MasterKeyEnvFile(masterKey), sudo, sudo, MasterKeyEnvFilePath, sudo, MasterKeyEnvFilePath)
 }
 
 // SystemdUnit returns the systemd unit file for the hub service.
@@ -42,6 +94,7 @@ After=network.target
 [Service]
 Type=simple
 Environment=HOME=/root
+EnvironmentFile=-/etc/elasticclaw/master.env
 ExecStart=/usr/local/bin/elasticclaw hub
 Restart=always
 RestartSec=5

--- a/pkg/install/scripts_test.go
+++ b/pkg/install/scripts_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/elasticclaw/elasticclaw/pkg/install"
+	"github.com/elasticclaw/elasticclaw/pkg/secrets"
 )
 
 var testParams = install.Params{
@@ -51,6 +52,40 @@ func TestHubConfig_DoesNotContainOtherTokens(t *testing.T) {
 	}
 }
 
+func TestHubConfig_EncryptsSecretsWithMasterKey(t *testing.T) {
+	masterKey, err := secrets.NewMasterKey()
+	if err != nil {
+		t.Fatalf("NewMasterKey: %v", err)
+	}
+	p := testParams
+	p.MasterKey = masterKey
+
+	cfg := install.HubConfig(p)
+	assertContains(t, cfg, "hub.example.com", "domain stays plaintext")
+	assertContains(t, cfg, secrets.EnvelopePrefix, "encryption envelope present")
+	for _, secret := range []string{"test-hub-token", "test-claw-token", "test-ui-password"} {
+		if strings.Contains(cfg, secret) {
+			t.Errorf("hub.yaml leaks plaintext secret %q:\n%s", secret, cfg)
+		}
+	}
+}
+
+func TestMasterKeyEnvFile(t *testing.T) {
+	content := install.MasterKeyEnvFile("dGVzdA==")
+	if content != "ELASTICCLAW_MASTER_KEY=dGVzdA==\n" {
+		t.Fatalf("MasterKeyEnvFile = %q", content)
+	}
+}
+
+func TestScriptWriteMasterKeyEnv(t *testing.T) {
+	s := install.ScriptWriteMasterKeyEnv("dGVzdA==", true)
+	assertContains(t, s, "umask 077", "restrict env file permissions")
+	assertContains(t, s, "ELASTICCLAW_MASTER_KEY=dGVzdA==", "master key embedded")
+	assertContains(t, s, "/etc/elasticclaw/master.env", "env file path")
+	assertContains(t, s, "chmod 600", "tighten env file mode")
+	assertContains(t, s, "sudo ", "sudo prefix")
+}
+
 // ── SystemdUnit ───────────────────────────────────────────────────────────────
 
 func TestSystemdUnit(t *testing.T) {
@@ -60,6 +95,7 @@ func TestSystemdUnit(t *testing.T) {
 	assertContains(t, unit, "[Install]", "Install section")
 	assertContains(t, unit, "/usr/local/bin/elasticclaw hub", "ExecStart command")
 	assertContains(t, unit, "Restart=always", "Restart policy")
+	assertContains(t, unit, "EnvironmentFile=-/etc/elasticclaw/master.env", "master key environment file")
 }
 
 // ── Caddyfile ─────────────────────────────────────────────────────────────────
@@ -156,6 +192,7 @@ func TestScripts_Shellcheck(t *testing.T) {
 	scripts := map[string]string{
 		"install_binary":  install.ScriptInstallBinary("v0.0.3", true),
 		"write_config":    install.ScriptWriteConfig(testParams, true),
+		"write_masterkey": install.ScriptWriteMasterKeyEnv("dGVzdA==", true),
 		"install_systemd": install.ScriptInstallSystemd(true),
 		"install_caddy":   install.ScriptInstallCaddy(true),
 		"write_caddyfile": install.ScriptWriteCaddyfile("hub.example.com", true),

--- a/pkg/secrets/envelope.go
+++ b/pkg/secrets/envelope.go
@@ -1,0 +1,85 @@
+// Package secrets implements encryption at rest for sensitive hub.yaml values.
+//
+// Sensitive values are stored as an envelope string:
+//
+//	enc:v1:<base64(nonce || ciphertext)>
+//
+// encrypted with AES-256-GCM under a 32-byte master key. The master key comes
+// from the ELASTICCLAW_MASTER_KEY environment variable (base64) or from a
+// master.key file created on first boot (0600).
+package secrets
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"strings"
+)
+
+// EnvelopePrefix marks a value encrypted with the v1 scheme (AES-256-GCM).
+const EnvelopePrefix = "enc:v1:"
+
+// envelopeMarker is the generic prefix reserved for encrypted values of any version.
+const envelopeMarker = "enc:"
+
+// IsEncrypted reports whether a value carries an encryption envelope
+// (any version, not just v1).
+func IsEncrypted(value string) bool {
+	return strings.HasPrefix(value, envelopeMarker)
+}
+
+// Encrypt seals plaintext with AES-256-GCM and returns an enc:v1: envelope.
+func Encrypt(key []byte, plaintext string) (string, error) {
+	gcm, err := newGCM(key)
+	if err != nil {
+		return "", err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return "", fmt.Errorf("failed to generate nonce: %w", err)
+	}
+	sealed := gcm.Seal(nonce, nonce, []byte(plaintext), nil)
+	return EnvelopePrefix + base64.StdEncoding.EncodeToString(sealed), nil
+}
+
+// Decrypt opens an enc:v1: envelope and returns the plaintext.
+// Values without an enc: prefix are returned unchanged (plaintext passthrough,
+// used for transparent migration of pre-encryption configs).
+func Decrypt(key []byte, value string) (string, error) {
+	if !IsEncrypted(value) {
+		return value, nil
+	}
+	if !strings.HasPrefix(value, EnvelopePrefix) {
+		return "", fmt.Errorf("unsupported secret envelope version (expected %q prefix)", EnvelopePrefix)
+	}
+	raw, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(value, EnvelopePrefix))
+	if err != nil {
+		return "", fmt.Errorf("invalid secret envelope encoding: %w", err)
+	}
+	gcm, err := newGCM(key)
+	if err != nil {
+		return "", err
+	}
+	if len(raw) < gcm.NonceSize() {
+		return "", fmt.Errorf("invalid secret envelope: too short")
+	}
+	nonce, ciphertext := raw[:gcm.NonceSize()], raw[gcm.NonceSize():]
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to decrypt secret (wrong master key?): %w", err)
+	}
+	return string(plaintext), nil
+}
+
+func newGCM(key []byte) (cipher.AEAD, error) {
+	if len(key) != MasterKeySize {
+		return nil, fmt.Errorf("master key must be %d bytes, got %d", MasterKeySize, len(key))
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	return cipher.NewGCM(block)
+}

--- a/pkg/secrets/fields.go
+++ b/pkg/secrets/fields.go
@@ -1,0 +1,144 @@
+package secrets
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// secretTag marks struct fields whose values are sensitive and must be
+// encrypted at rest: `secret:"true"`. Supported field types are string and
+// map[string]string (each map value is treated as sensitive).
+const secretTag = "secret"
+
+// EncryptFields walks v (a pointer to a struct) and encrypts every field
+// tagged `secret:"true"` in place. Empty and already-encrypted values are
+// left untouched, so the operation is idempotent.
+func EncryptFields(v any, key []byte) error {
+	return walkSecrets(reflect.ValueOf(v), func(s string) (string, error) {
+		if s == "" || IsEncrypted(s) {
+			return s, nil
+		}
+		return Encrypt(key, s)
+	})
+}
+
+// DecryptFields walks v (a pointer to a struct) and decrypts every field
+// tagged `secret:"true"` in place. Plaintext values (no enc: prefix) are
+// accepted unchanged — this is the transparent migration path for configs
+// written before encryption at rest existed.
+func DecryptFields(v any, key []byte) error {
+	return walkSecrets(reflect.ValueOf(v), func(s string) (string, error) {
+		return Decrypt(key, s)
+	})
+}
+
+// ContainsEncrypted reports whether any field tagged `secret:"true"` in v
+// carries an encryption envelope.
+func ContainsEncrypted(v any) bool {
+	found := false
+	_ = walkSecrets(reflect.ValueOf(v), func(s string) (string, error) {
+		if IsEncrypted(s) {
+			found = true
+		}
+		return s, nil
+	})
+	return found
+}
+
+type transformFunc func(string) (string, error)
+
+// walkSecrets recursively visits structs, pointers, slices, and maps looking
+// for fields tagged `secret:"true"` and applies fn to their values.
+func walkSecrets(v reflect.Value, fn transformFunc) error {
+	switch v.Kind() {
+	case reflect.Ptr, reflect.Interface:
+		if v.IsNil() {
+			return nil
+		}
+		return walkSecrets(v.Elem(), fn)
+	case reflect.Struct:
+		t := v.Type()
+		for i := 0; i < v.NumField(); i++ {
+			field := v.Field(i)
+			sf := t.Field(i)
+			if !sf.IsExported() {
+				continue
+			}
+			if sf.Tag.Get(secretTag) == "true" {
+				if err := applySecret(field, fn); err != nil {
+					return fmt.Errorf("%s.%s: %w", t.Name(), sf.Name, err)
+				}
+				continue
+			}
+			if err := walkSecrets(field, fn); err != nil {
+				return err
+			}
+		}
+	case reflect.Slice, reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			if err := walkSecrets(v.Index(i), fn); err != nil {
+				return err
+			}
+		}
+	case reflect.Map:
+		if v.IsNil() {
+			return nil
+		}
+		for _, k := range v.MapKeys() {
+			elem := v.MapIndex(k)
+			if !containsStruct(elem.Type()) {
+				continue
+			}
+			// Map values are not addressable: walk an addressable copy and
+			// write it back.
+			copyVal := reflect.New(elem.Type()).Elem()
+			copyVal.Set(elem)
+			if err := walkSecrets(copyVal, fn); err != nil {
+				return err
+			}
+			v.SetMapIndex(k, copyVal)
+		}
+	}
+	return nil
+}
+
+// applySecret transforms a tagged field value. Supported kinds: string and
+// map[string]string.
+func applySecret(v reflect.Value, fn transformFunc) error {
+	switch {
+	case v.Kind() == reflect.String:
+		out, err := fn(v.String())
+		if err != nil {
+			return err
+		}
+		v.SetString(out)
+		return nil
+	case v.Kind() == reflect.Map && v.Type().Key().Kind() == reflect.String && v.Type().Elem().Kind() == reflect.String:
+		if v.IsNil() {
+			return nil
+		}
+		for _, k := range v.MapKeys() {
+			out, err := fn(v.MapIndex(k).String())
+			if err != nil {
+				return fmt.Errorf("key %q: %w", k.String(), err)
+			}
+			v.SetMapIndex(k, reflect.ValueOf(out))
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported secret field type %s (want string or map[string]string)", v.Type())
+	}
+}
+
+// containsStruct reports whether t can (transitively) hold struct values that
+// may carry secret-tagged fields. Used to skip walking plain map values.
+func containsStruct(t reflect.Type) bool {
+	switch t.Kind() {
+	case reflect.Struct, reflect.Interface:
+		return true
+	case reflect.Ptr, reflect.Slice, reflect.Array, reflect.Map:
+		return containsStruct(t.Elem())
+	default:
+		return false
+	}
+}

--- a/pkg/secrets/masterkey.go
+++ b/pkg/secrets/masterkey.go
@@ -1,0 +1,109 @@
+package secrets
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// MasterKeyEnvVar holds the base64-encoded 32-byte master key when set.
+const MasterKeyEnvVar = "ELASTICCLAW_MASTER_KEY"
+
+// MasterKeySize is the AES-256 key size in bytes.
+const MasterKeySize = 32
+
+// masterKeyFileName is the on-disk key file created on first boot.
+const masterKeyFileName = "master.key"
+
+// ErrNoMasterKey indicates no master key is available from env or disk.
+var ErrNoMasterKey = errors.New("no master key available: set " + MasterKeyEnvVar + " or restore the master.key file")
+
+// NewMasterKey generates a fresh random 32-byte key, base64-encoded.
+func NewMasterKey() (string, error) {
+	key := make([]byte, MasterKeySize)
+	if _, err := rand.Read(key); err != nil {
+		return "", fmt.Errorf("failed to generate master key: %w", err)
+	}
+	return base64.StdEncoding.EncodeToString(key), nil
+}
+
+// ParseMasterKey decodes a base64 master key and validates its length.
+func ParseMasterKey(encoded string) ([]byte, error) {
+	key, err := base64.StdEncoding.DecodeString(strings.TrimSpace(encoded))
+	if err != nil {
+		return nil, fmt.Errorf("master key is not valid base64: %w", err)
+	}
+	if len(key) != MasterKeySize {
+		return nil, fmt.Errorf("master key must be %d bytes after base64 decoding, got %d", MasterKeySize, len(key))
+	}
+	return key, nil
+}
+
+// MasterKeyFilePath returns the path of the master key file:
+//   - next to the hub config when ELASTICCLAW_HUB_CONFIG points at a custom path
+//   - ~/.elasticclaw/master.key otherwise
+func MasterKeyFilePath() (string, error) {
+	if cfgPath := os.Getenv("ELASTICCLAW_HUB_CONFIG"); cfgPath != "" {
+		return filepath.Join(filepath.Dir(cfgPath), masterKeyFileName), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine master key path: %w", err)
+	}
+	return filepath.Join(home, ".elasticclaw", masterKeyFileName), nil
+}
+
+// LoadMasterKey returns the master key from ELASTICCLAW_MASTER_KEY or the
+// master.key file. It returns ErrNoMasterKey (wrapped) when neither exists.
+func LoadMasterKey() ([]byte, error) {
+	if env := os.Getenv(MasterKeyEnvVar); env != "" {
+		return ParseMasterKey(env)
+	}
+	path, err := MasterKeyFilePath()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("%w (looked for %s)", ErrNoMasterKey, path)
+		}
+		return nil, fmt.Errorf("failed to read master key file %s: %w", path, err)
+	}
+	key, err := ParseMasterKey(string(data))
+	if err != nil {
+		return nil, fmt.Errorf("invalid master key file %s: %w", path, err)
+	}
+	return key, nil
+}
+
+// EnsureMasterKey returns the master key, generating and persisting a new
+// master.key file (0600) on first use when no key exists yet.
+func EnsureMasterKey() ([]byte, error) {
+	key, err := LoadMasterKey()
+	if err == nil {
+		return key, nil
+	}
+	if !errors.Is(err, ErrNoMasterKey) {
+		return nil, err
+	}
+	path, err := MasterKeyFilePath()
+	if err != nil {
+		return nil, err
+	}
+	encoded, err := NewMasterKey()
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return nil, fmt.Errorf("failed to create master key directory: %w", err)
+	}
+	if err := os.WriteFile(path, []byte(encoded+"\n"), 0600); err != nil {
+		return nil, fmt.Errorf("failed to write master key file %s: %w", path, err)
+	}
+	return ParseMasterKey(encoded)
+}

--- a/pkg/secrets/secrets_test.go
+++ b/pkg/secrets/secrets_test.go
@@ -1,0 +1,186 @@
+package secrets
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func testKey(t *testing.T) []byte {
+	t.Helper()
+	encoded, err := NewMasterKey()
+	if err != nil {
+		t.Fatalf("NewMasterKey: %v", err)
+	}
+	key, err := ParseMasterKey(encoded)
+	if err != nil {
+		t.Fatalf("ParseMasterKey: %v", err)
+	}
+	return key
+}
+
+func TestEncryptDecryptRoundtrip(t *testing.T) {
+	key := testKey(t)
+	for _, plaintext := range []string{"hunter2", "", "-----BEGIN RSA PRIVATE KEY-----\nabc\n-----END RSA PRIVATE KEY-----"} {
+		env, err := Encrypt(key, plaintext)
+		if err != nil {
+			t.Fatalf("Encrypt(%q): %v", plaintext, err)
+		}
+		if !strings.HasPrefix(env, EnvelopePrefix) {
+			t.Fatalf("envelope %q missing prefix", env)
+		}
+		if strings.Contains(env, plaintext) && plaintext != "" {
+			t.Fatalf("envelope leaks plaintext: %q", env)
+		}
+		got, err := Decrypt(key, env)
+		if err != nil {
+			t.Fatalf("Decrypt: %v", err)
+		}
+		if got != plaintext {
+			t.Fatalf("roundtrip = %q, want %q", got, plaintext)
+		}
+	}
+}
+
+func TestDecryptPlaintextPassthrough(t *testing.T) {
+	got, err := Decrypt(testKey(t), "plain-value")
+	if err != nil {
+		t.Fatalf("Decrypt: %v", err)
+	}
+	if got != "plain-value" {
+		t.Fatalf("got %q, want plaintext passthrough", got)
+	}
+}
+
+func TestDecryptWrongKeyFails(t *testing.T) {
+	env, err := Encrypt(testKey(t), "secret")
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	if _, err := Decrypt(testKey(t), env); err == nil {
+		t.Fatal("expected decrypt with wrong key to fail")
+	}
+}
+
+func TestDecryptUnknownVersionFails(t *testing.T) {
+	if _, err := Decrypt(testKey(t), "enc:v9:abcd"); err == nil {
+		t.Fatal("expected unknown envelope version to fail")
+	}
+}
+
+type nestedSecret struct {
+	Token  string `secret:"true"`
+	Public string
+}
+
+type testConfig struct {
+	Name     string
+	Password string            `secret:"true"`
+	Secrets  map[string]string `secret:"true"`
+	Nested   *nestedSecret
+	List     []*nestedSecret
+	ByName   map[string]nestedSecret
+}
+
+func TestEncryptDecryptFields(t *testing.T) {
+	key := testKey(t)
+	cfg := &testConfig{
+		Name:     "visible",
+		Password: "p4ss",
+		Secrets:  map[string]string{"a": "secret-a", "empty": ""},
+		Nested:   &nestedSecret{Token: "tok-1", Public: "pub"},
+		List:     []*nestedSecret{{Token: "tok-2"}, nil},
+		ByName:   map[string]nestedSecret{"x": {Token: "tok-3"}},
+	}
+	if err := EncryptFields(cfg, key); err != nil {
+		t.Fatalf("EncryptFields: %v", err)
+	}
+	if cfg.Name != "visible" || cfg.Nested.Public != "pub" {
+		t.Fatal("non-secret fields must be untouched")
+	}
+	for desc, v := range map[string]string{
+		"Password":        cfg.Password,
+		"Secrets[a]":      cfg.Secrets["a"],
+		"Nested.Token":    cfg.Nested.Token,
+		"List[0].Token":   cfg.List[0].Token,
+		"ByName[x].Token": cfg.ByName["x"].Token,
+	} {
+		if !IsEncrypted(v) {
+			t.Fatalf("%s = %q, want encrypted", desc, v)
+		}
+	}
+	if cfg.Secrets["empty"] != "" {
+		t.Fatal("empty values must stay empty")
+	}
+	if !ContainsEncrypted(cfg) {
+		t.Fatal("ContainsEncrypted = false, want true")
+	}
+
+	// Idempotence: encrypting twice must not double-wrap.
+	once := cfg.Password
+	if err := EncryptFields(cfg, key); err != nil {
+		t.Fatalf("EncryptFields (2nd): %v", err)
+	}
+	if cfg.Password != once {
+		t.Fatal("EncryptFields is not idempotent")
+	}
+
+	if err := DecryptFields(cfg, key); err != nil {
+		t.Fatalf("DecryptFields: %v", err)
+	}
+	if cfg.Password != "p4ss" || cfg.Secrets["a"] != "secret-a" ||
+		cfg.Nested.Token != "tok-1" || cfg.List[0].Token != "tok-2" ||
+		cfg.ByName["x"].Token != "tok-3" {
+		t.Fatalf("decrypt mismatch: %+v", cfg)
+	}
+	if ContainsEncrypted(cfg) {
+		t.Fatal("ContainsEncrypted = true after decrypt, want false")
+	}
+}
+
+func TestMasterKeyFromEnv(t *testing.T) {
+	encoded, err := NewMasterKey()
+	if err != nil {
+		t.Fatalf("NewMasterKey: %v", err)
+	}
+	t.Setenv(MasterKeyEnvVar, encoded)
+	key, err := LoadMasterKey()
+	if err != nil {
+		t.Fatalf("LoadMasterKey: %v", err)
+	}
+	if base64.StdEncoding.EncodeToString(key) != encoded {
+		t.Fatal("env key mismatch")
+	}
+}
+
+func TestEnsureMasterKeyCreatesFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(MasterKeyEnvVar, "")
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", filepath.Join(dir, "hub.yaml"))
+
+	if _, err := LoadMasterKey(); err == nil {
+		t.Fatal("expected LoadMasterKey to fail before EnsureMasterKey")
+	}
+	key1, err := EnsureMasterKey()
+	if err != nil {
+		t.Fatalf("EnsureMasterKey: %v", err)
+	}
+	path := filepath.Join(dir, "master.key")
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat master.key: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0600 {
+		t.Fatalf("master.key mode = %o, want 0600", perm)
+	}
+	// Second call reuses the same key.
+	key2, err := EnsureMasterKey()
+	if err != nil {
+		t.Fatalf("EnsureMasterKey (2nd): %v", err)
+	}
+	if string(key1) != string(key2) {
+		t.Fatal("EnsureMasterKey generated a different key on second call")
+	}
+}

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -11,11 +11,11 @@ import (
 
 // LLMKeyConfig represents a named LLM API key entry in hub.yaml.
 type LLMKeyConfig struct {
-	Name         string `yaml:"name"          json:"name"`                    // unique label, e.g. "anthropic-prod"
-	Provider     string `yaml:"provider"      json:"provider"`                // e.g. "anthropic", "fireworks", "moonshot"
-	APIKey       string `yaml:"api_key"       json:"-"`                       // the actual key (never exposed in API)
-	Default      bool   `yaml:"default"       json:"default"`                 // use when no llm_key specified
-	DefaultModel string `yaml:"default_model" json:"default_model,omitempty"` // preferred model for this key, e.g. "fireworks/accounts/fireworks/models/kimi-k2p7"
+	Name         string `yaml:"name"          json:"name"`                        // unique label, e.g. "anthropic-prod"
+	Provider     string `yaml:"provider"      json:"provider"`                    // e.g. "anthropic", "fireworks", "moonshot"
+	APIKey       string `yaml:"api_key"       json:"-"             secret:"true"` // the actual key (never exposed in API)
+	Default      bool   `yaml:"default"       json:"default"`                     // use when no llm_key specified
+	DefaultModel string `yaml:"default_model" json:"default_model,omitempty"`     // preferred model for this key, e.g. "fireworks/accounts/fireworks/models/kimi-k2p7"
 	AuthProfile  string `yaml:"auth_profile,omitempty" json:"auth_profile,omitempty"`
 }
 
@@ -23,7 +23,7 @@ type ModelAuthProfileConfig struct {
 	Name      string `yaml:"name" json:"name"`
 	Provider  string `yaml:"provider" json:"provider"`
 	Mode      string `yaml:"mode" json:"mode"`
-	AuthState string `yaml:"auth_state,omitempty" json:"-"`
+	AuthState string `yaml:"auth_state,omitempty" json:"-" secret:"true"`
 	UpdatedAt string `yaml:"updated_at,omitempty" json:"updated_at,omitempty"`
 }
 
@@ -157,7 +157,7 @@ type TemplateResources struct {
 // LinearConfig holds a Linear API token for one workspace.
 // Configure in hub.yaml under 'linear:' as a list.
 type LinearConfig struct {
-	Token     string `yaml:"token"`               // Linear API key (lin_api_...)
+	Token     string `yaml:"token" secret:"true"` // Linear API key (lin_api_...)
 	Workspace string `yaml:"workspace,omitempty"` // human label for matching; defaults to first entry
 }
 
@@ -278,7 +278,7 @@ type MCPRef struct {
 type GitHubAppConfig struct {
 	URL           string `yaml:"url,omitempty"` // GitHub App URL for reference/logging only
 	AppID         int64  `yaml:"app_id"`
-	PrivateKeyPEM string `yaml:"private_key_pem"` // PEM-encoded RSA private key (paste directly in yaml)
+	PrivateKeyPEM string `yaml:"private_key_pem" secret:"true"` // PEM-encoded RSA private key (paste directly in yaml)
 }
 
 // GitHubRepoAccess specifies a repo and the permissions needed.
@@ -421,14 +421,14 @@ type BrandingConfig struct {
 type AuthConfig struct {
 	GitHubOAuth         *GitHubOAuthConfig `yaml:"github_oauth,omitempty"`
 	Access              *AccessConfig      `yaml:"access,omitempty"`
-	SessionSecret       string             `yaml:"session_secret,omitempty"`
+	SessionSecret       string             `yaml:"session_secret,omitempty" secret:"true"`
 	DisablePasswordAuth bool               `yaml:"disable_password_auth,omitempty"`
 }
 
 // GitHubOAuthConfig holds GitHub OAuth app credentials and allowlist.
 type GitHubOAuthConfig struct {
 	ClientID     string   `yaml:"client_id"`
-	ClientSecret string   `yaml:"client_secret"`
+	ClientSecret string   `yaml:"client_secret" secret:"true"`
 	AllowedUsers []string `yaml:"allowed_users,omitempty"` // GitHub logins
 	AllowedOrgs  []string `yaml:"allowed_orgs,omitempty"`  // GitHub org names
 	AllowedTeams []string `yaml:"allowed_teams,omitempty"` // "org/team" format
@@ -459,8 +459,8 @@ type S3ArtifactStorageConfig struct {
 	Endpoint        string `yaml:"endpoint,omitempty" json:"endpoint,omitempty"`
 	Prefix          string `yaml:"prefix,omitempty" json:"prefix,omitempty"`
 	AccessKeyID     string `yaml:"access_key_id,omitempty" json:"accessKeyId,omitempty"`
-	SecretAccessKey string `yaml:"secret_access_key,omitempty" json:"secretAccessKey,omitempty"`
-	SessionToken    string `yaml:"session_token,omitempty" json:"sessionToken,omitempty"`
+	SecretAccessKey string `yaml:"secret_access_key,omitempty" json:"secretAccessKey,omitempty" secret:"true"`
+	SessionToken    string `yaml:"session_token,omitempty" json:"sessionToken,omitempty" secret:"true"`
 	PathStyle       bool   `yaml:"path_style,omitempty" json:"pathStyle,omitempty"`
 }
 
@@ -471,13 +471,13 @@ type HubConfig struct {
 
 	// CLI connection fields
 	URL   string `yaml:"url"`
-	Token string `yaml:"token"`
+	Token string `yaml:"token" secret:"true"`
 
 	// Hub server fields
 	// PublicURL is the URL claws use to connect back to the hub from remote VMs.
 	// If not set, falls back to URL.
 	PublicURL string                    `yaml:"public_url,omitempty"`
-	ClawToken string                    `yaml:"claw_token,omitempty"`
+	ClawToken string                    `yaml:"claw_token,omitempty" secret:"true"`
 	Providers map[string]ProviderConfig `yaml:"providers,omitempty"`
 	// SSHPublicKeys are extra keys added to every provisioned VM for debug access.
 	SSHPublicKeys []string `yaml:"ssh_public_keys,omitempty"`
@@ -508,7 +508,7 @@ type HubConfig struct {
 	GitHubApps []*GitHubAppConfig `yaml:"github,omitempty"`
 
 	// UIPassword is the password for the web UI. If not set, defaults to "admin".
-	UIPassword string `yaml:"ui_password,omitempty"`
+	UIPassword string `yaml:"ui_password,omitempty" secret:"true"`
 
 	// Branding allows white-labeling the web UI.
 	Branding *BrandingConfig `yaml:"branding,omitempty"`
@@ -519,7 +519,7 @@ type HubConfig struct {
 	// Factories defines automation rules that spin up claws based on integration events.
 	Factories []*FactoryConfig `yaml:"factories,omitempty"`
 	// Secrets is a named map of secret values referenced by factories via webhook_secret_ref.
-	Secrets map[string]string `yaml:"secrets,omitempty"`
+	Secrets map[string]string `yaml:"secrets,omitempty" secret:"true"`
 
 	// MCPServers is a list of MCP server configurations available to claws.
 	MCPServers []*MCPServerHubConfig `yaml:"mcp_servers,omitempty"`
@@ -555,37 +555,37 @@ type IntegrationsConfig struct {
 // ExternalTriggerConfig holds config for external webhook triggers.
 // Unlike other integrations, this doesn't need API tokens - just webhook secrets.
 type ExternalTriggerConfig struct {
-	Name          string `yaml:"name" json:"name"`                                        // unique identifier for this trigger source
-	WebhookSecret string `yaml:"webhook_secret,omitempty" json:"webhookSecret,omitempty"` // HMAC secret for validating webhooks
+	Name          string `yaml:"name" json:"name"`                                                      // unique identifier for this trigger source
+	WebhookSecret string `yaml:"webhook_secret,omitempty" json:"webhookSecret,omitempty" secret:"true"` // HMAC secret for validating webhooks
 }
 
 // ShortcutIntegrationConfig holds credentials for one Shortcut workspace.
 type ShortcutIntegrationConfig struct {
-	Workspace string `yaml:"workspace"` // human label
-	Token     string `yaml:"token"`     // Shortcut API token
+	Workspace string `yaml:"workspace"`           // human label
+	Token     string `yaml:"token" secret:"true"` // Shortcut API token
 }
 
 // LinearIntegrationConfig holds credentials for one Linear workspace.
 type LinearIntegrationConfig struct {
-	Workspace     string `yaml:"workspace"`                // human label
-	Token         string `yaml:"token"`                    // Linear API token (lin_api_...)
-	WebhookSecret string `yaml:"webhook_secret,omitempty"` // HMAC secret for validating webhooks
+	Workspace     string `yaml:"workspace"`                              // human label
+	Token         string `yaml:"token" secret:"true"`                    // Linear API token (lin_api_...)
+	WebhookSecret string `yaml:"webhook_secret,omitempty" secret:"true"` // HMAC secret for validating webhooks
 }
 
 // GitHubIssuesIntegrationConfig holds credentials for one GitHub Issues integration.
 type GitHubIssuesIntegrationConfig struct {
-	Workspace     string `yaml:"workspace"`                // human label (e.g. "my-org")
-	Token         string `yaml:"token"`                    // GitHub personal access token
-	WebhookSecret string `yaml:"webhook_secret,omitempty"` // HMAC secret for validating webhooks
+	Workspace     string `yaml:"workspace"`                              // human label (e.g. "my-org")
+	Token         string `yaml:"token" secret:"true"`                    // GitHub personal access token
+	WebhookSecret string `yaml:"webhook_secret,omitempty" secret:"true"` // HMAC secret for validating webhooks
 }
 
 // JiraIntegrationConfig holds credentials for one Jira site.
 type JiraIntegrationConfig struct {
-	Workspace     string `yaml:"workspace"`                // human label
-	BaseURL       string `yaml:"base_url,omitempty"`       // Jira base URL, e.g. https://jira.example.com
-	Username      string `yaml:"username,omitempty"`       // optional for basic auth
-	Token         string `yaml:"token"`                    // Jira PAT/API token
-	WebhookSecret string `yaml:"webhook_secret,omitempty"` // shared webhook secret
+	Workspace     string `yaml:"workspace"`                              // human label
+	BaseURL       string `yaml:"base_url,omitempty"`                     // Jira base URL, e.g. https://jira.example.com
+	Username      string `yaml:"username,omitempty"`                     // optional for basic auth
+	Token         string `yaml:"token" secret:"true"`                    // Jira PAT/API token
+	WebhookSecret string `yaml:"webhook_secret,omitempty" secret:"true"` // shared webhook secret
 }
 
 // FactoryInput defines a user-provided input for manual factory triggers.
@@ -613,24 +613,24 @@ type FactoryConfig struct {
 	// Defaults to "v1" if not specified for backward compatibility.
 	SchemaVersion    string   `yaml:"schema_version,omitempty" json:"schemaVersion,omitempty"`
 	Name             string   `yaml:"name" json:"name"`
-	Enabled          *bool    `yaml:"enabled,omitempty" json:"enabled,omitempty"`                       // nil = true (default on); set false to pause
-	Integration      string   `yaml:"integration" json:"integration"`                                   // "linear", "shortcut", "github-issues", or "github"
-	Workspace        string   `yaml:"workspace,omitempty" json:"workspace,omitempty"`                   // matches integrations.<type>[].workspace
-	Team             string   `yaml:"team,omitempty" json:"team,omitempty"`                             // Linear team key (e.g. "ELA")
-	TriggerStatus    string   `yaml:"trigger_status,omitempty" json:"trigger_status,omitempty"`         // entering this status → create claw
-	WorkingStatus    string   `yaml:"working_status,omitempty" json:"working_status,omitempty"`         // claw moves issue here when it starts working
-	FinishedStatus   string   `yaml:"finished_status,omitempty" json:"finished_status,omitempty"`       // claw moves issue here when it finishes working
-	DoneStatus       string   `yaml:"done_status,omitempty" json:"done_status,omitempty"`               // claw moves issue here when done (PR merged)
-	TerminateOnLeave bool     `yaml:"terminate_on_leave,omitempty" json:"terminate_on_leave,omitempty"` // leaving trigger_status → kill claw
-	Template         string   `yaml:"template" json:"template"`                                         // template name (must be pushed to hub)
-	Provider         string   `yaml:"provider,omitempty" json:"provider,omitempty"`                     // override the default provider for this factory
-	NamePattern      string   `yaml:"name_pattern,omitempty" json:"name_pattern,omitempty"`             // claw name pattern, e.g. "{issue_id}"
-	WebhookSecret    string   `yaml:"webhook_secret,omitempty" json:"webhook_secret,omitempty"`         // HMAC-SHA256 secret for validating webhooks
-	Tags             []string `yaml:"tags,omitempty" json:"tags,omitempty"`                             // tags applied to created claws
-	Color            string   `yaml:"color,omitempty" json:"color,omitempty"`                           // color applied to created claws
-	RunKind          string   `yaml:"run_kind,omitempty" json:"run_kind,omitempty"`                     // analytics run kind: "code_task" or "pr_task"
-	AnalyticsEnabled *bool    `yaml:"analytics_enabled,omitempty" json:"analytics_enabled,omitempty"`   // nil = infer from integration
-	RequiresPR       *bool    `yaml:"requires_pr,omitempty" json:"requires_pr,omitempty"`               // nil = infer from analytics eligibility
+	Enabled          *bool    `yaml:"enabled,omitempty" json:"enabled,omitempty"`                             // nil = true (default on); set false to pause
+	Integration      string   `yaml:"integration" json:"integration"`                                         // "linear", "shortcut", "github-issues", or "github"
+	Workspace        string   `yaml:"workspace,omitempty" json:"workspace,omitempty"`                         // matches integrations.<type>[].workspace
+	Team             string   `yaml:"team,omitempty" json:"team,omitempty"`                                   // Linear team key (e.g. "ELA")
+	TriggerStatus    string   `yaml:"trigger_status,omitempty" json:"trigger_status,omitempty"`               // entering this status → create claw
+	WorkingStatus    string   `yaml:"working_status,omitempty" json:"working_status,omitempty"`               // claw moves issue here when it starts working
+	FinishedStatus   string   `yaml:"finished_status,omitempty" json:"finished_status,omitempty"`             // claw moves issue here when it finishes working
+	DoneStatus       string   `yaml:"done_status,omitempty" json:"done_status,omitempty"`                     // claw moves issue here when done (PR merged)
+	TerminateOnLeave bool     `yaml:"terminate_on_leave,omitempty" json:"terminate_on_leave,omitempty"`       // leaving trigger_status → kill claw
+	Template         string   `yaml:"template" json:"template"`                                               // template name (must be pushed to hub)
+	Provider         string   `yaml:"provider,omitempty" json:"provider,omitempty"`                           // override the default provider for this factory
+	NamePattern      string   `yaml:"name_pattern,omitempty" json:"name_pattern,omitempty"`                   // claw name pattern, e.g. "{issue_id}"
+	WebhookSecret    string   `yaml:"webhook_secret,omitempty" json:"webhook_secret,omitempty" secret:"true"` // HMAC-SHA256 secret for validating webhooks
+	Tags             []string `yaml:"tags,omitempty" json:"tags,omitempty"`                                   // tags applied to created claws
+	Color            string   `yaml:"color,omitempty" json:"color,omitempty"`                                 // color applied to created claws
+	RunKind          string   `yaml:"run_kind,omitempty" json:"run_kind,omitempty"`                           // analytics run kind: "code_task" or "pr_task"
+	AnalyticsEnabled *bool    `yaml:"analytics_enabled,omitempty" json:"analytics_enabled,omitempty"`         // nil = infer from integration
+	RequiresPR       *bool    `yaml:"requires_pr,omitempty" json:"requires_pr,omitempty"`                     // nil = infer from analytics eligibility
 	// Labels: all must be present on the issue to trigger (AND)
 	Labels []string `yaml:"labels,omitempty" json:"labels,omitempty"`
 	// ExcludeLabels: none may be present on the issue to trigger (NOT)
@@ -715,7 +715,7 @@ type ProviderConfig struct {
 
 	// Daytona
 	APIURL string `yaml:"api_url,omitempty"`
-	APIKey string `yaml:"api_key,omitempty"`
+	APIKey string `yaml:"api_key,omitempty" secret:"true"`
 	Target string `yaml:"target,omitempty"`
 
 	// Daytona snapshot size (maps to Daytona SnapshotParams.Snapshot)
@@ -723,12 +723,12 @@ type ProviderConfig struct {
 	DefaultSnapshot string `yaml:"default_snapshot,omitempty"`
 
 	// Vercel Sandbox
-	AccessToken string `yaml:"access_token,omitempty"` // Vercel access token
-	TeamID      string `yaml:"team_id,omitempty"`      // optional Vercel team ID
-	ProjectID   string `yaml:"project_id,omitempty"`   // optional Vercel project ID
+	AccessToken string `yaml:"access_token,omitempty" secret:"true"` // Vercel access token
+	TeamID      string `yaml:"team_id,omitempty"`                    // optional Vercel team ID
+	ProjectID   string `yaml:"project_id,omitempty"`                 // optional Vercel project ID
 
 	// Replicated CMX
-	Token               string `yaml:"token,omitempty"`
+	Token               string `yaml:"token,omitempty" secret:"true"`
 	DefaultTTL          string `yaml:"default_ttl,omitempty"`
 	DefaultInstanceType string `yaml:"default_instance_type,omitempty"`
 	// SSHPublicKey is injected automatically from the hub's generated identity — do not configure manually.


### PR DESCRIPTION
Implements item **3.4 Secrets at rest** of the Phase 3 re-architecture spec (`docs/re-arch/phase-3-frontend-and-hardening.md` on `docs/re-arch`).

## Motivation

hub.yaml stores the GitHub App private key, tracker tokens and passwords in plaintext. Sensitive fields get an `enc:v1:` AES-256-GCM envelope with a master key from env or `~/.elasticclaw/master.key`, with transparent migration on save.

Concrete evidence in the code before this change:

- `types.HubConfig` (`pkg/types/template.go`) carries `Token`, `ClawToken`, `UIPassword`, `Auth.SessionSecret`, `GitHubApps[].PrivateKeyPEM` (PEM-encoded RSA key pasted directly in yaml), `LLMKeys[].APIKey`, provider credentials (`ProviderConfig.APIKey`/`AccessToken`/`Token`), the `Secrets` map, and Linear/Shortcut/Jira/GitHub-Issues integration tokens and webhook secrets — all serialized verbatim by `yaml.Marshal` in `pkg/config/hub.go` and written to disk.
- The installer (`pkg/install/scripts.go`, `HubConfig()`) emitted `token`, `claw_token` and `ui_password` in cleartext in the generated hub.yaml on every fresh install.

## Dependencies

None — branches directly from main.

Note: spec item 3.5 (golang-jwt sessions) derives its signing key from this master key via HKDF, so it should branch from (or follow) this PR.

## What changed

- **New `pkg/secrets` package**
  - `enc:v1:<base64(nonce || ciphertext)>` envelope, AES-256-GCM under a 32-byte master key.
  - Master key resolution: `ELASTICCLAW_MASTER_KEY` (base64) first, then a `master.key` file (created on first boot, 0600) — `~/.elasticclaw/master.key`, or next to the config when `ELASTICCLAW_HUB_CONFIG` is set.
  - Reflective `EncryptFields`/`DecryptFields` walk structs for fields tagged `secret:"true"` (string and `map[string]string`); idempotent, plaintext passthrough on decrypt for transparent migration.
- **`pkg/types/template.go`**: `secret:"true"` tags on all sensitive fields (hub tokens, UI password, session secret, GitHub App private key, LLM API keys, provider credentials, tracker tokens, webhook secrets, the `secrets` map). Non-sensitive fields stay plaintext, so hub.yaml remains readable/editable.
- **`pkg/config/hub.go`**: `SaveHubConfig` encrypts tagged fields on a deep copy (the caller's in-memory config is never mutated); `LoadHubConfig` transparently decrypts and still accepts plaintext values, which are re-written encrypted on the next save. Loading an encrypted config without the master key fails with a message pointing at the runbook.
- **`cmd/hub_encrypt_secrets.go`**: new `elasticclaw hub encrypt-secrets` command forces the full migration immediately.
- **`cmd/hub.go`**: the hub ensures the master key exists on boot (first-boot generation, 0600).
- **Installer** (`pkg/install/scripts.go`, `cmd/install.go`): generates a master key, writes it to a 0600 `EnvironmentFile` at `/etc/elasticclaw/master.env`, references it from the systemd unit (`EnvironmentFile=-/etc/elasticclaw/master.env`), and writes `token`/`claw_token`/`ui_password` in the generated hub.yaml as `enc:v1:` envelopes — a fresh install's hub.yaml contains no cleartext secret.
- **`docs/secrets-at-rest.md`**: format, key resolution, migration, and the lost-master-key runbook (re-enter secrets).

## Testing

All run locally on this branch:

- `go build ./...` — pass.
- `go test ./...` (same package set as `make test`, without `-v`) — all packages pass, no failures.

New tests:

- `pkg/secrets/secrets_test.go`: envelope roundtrip, wrong-key failure, plaintext passthrough, tagged-field walking, master key load/ensure.
- `pkg/config/hub_test.go`: secrets encrypted at rest (raw file contains no plaintext secret, non-secret fields stay readable), load decrypts transparently, plaintext legacy config accepted and migrated on save, missing master key fails loudly, save does not mutate the caller's config.
- `pkg/install/scripts_test.go`: generated hub.yaml has no cleartext secrets when a master key is set, master.env content/script (umask 077 + chmod 600, shellcheck-clean), systemd unit references the EnvironmentFile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
