### PR TITLE
feat(hub): standard JWT sessions via golang-jwt with HKDF-derived key

### DIFF
--- a/pkg/hub/auth_github.go
+++ b/pkg/hub/auth_github.go
@@ -29,8 +29,11 @@ type githubSessionPayload struct {
 	Exp       int64  `json:"exp"`
 }
 
-// signGitHubSession creates a signed session token for a GitHub user.
+// signGitHubSession creates a legacy signed session token for a GitHub user.
 // Format: base64url(payload).base64url(hmac-sha256)
+//
+// Deprecated: new sessions are standard JWTs (see auth_session.go). This is
+// kept only as a fallback for servers without a master key.
 func signGitHubSession(secret, login, name, avatarURL string) (string, error) {
 	payload := githubSessionPayload{
 		Login:     login,
@@ -49,7 +52,11 @@ func signGitHubSession(secret, login, name, avatarURL string) (string, error) {
 	return encoded + "." + sig, nil
 }
 
-// verifyGitHubSession validates the token and returns the payload if valid and unexpired.
+// verifyGitHubSession validates a legacy token and returns the payload if
+// valid and unexpired.
+//
+// Deprecated: kept for one release so sessions issued before the JWT
+// migration keep working (dual verification in Server.verifySession).
 func verifyGitHubSession(secret, token string) (*githubSessionPayload, bool) {
 	parts := strings.SplitN(token, ".", 2)
 	if len(parts) != 2 {
@@ -104,7 +111,9 @@ func (s *Server) ghBaseURL() string {
 	return "https://api.github.com"
 }
 
-// webSessionSecret returns the HMAC key used to sign/verify web session tokens.
+// webSessionSecret returns the HMAC key for the legacy web session token
+// format. It is only used to verify pre-JWT sessions during the transition
+// window and to sign sessions when no master key is available.
 func (s *Server) webSessionSecret() string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -157,11 +166,6 @@ func (s *Server) handleGitHubOAuthExchange(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	oauthCfg := cfg.GitHubOAuth
-	secret := s.webSessionSecret()
-	if secret == "" {
-		http.Error(w, "internal error", http.StatusInternalServerError)
-		return
-	}
 
 	var body struct {
 		Code        string `json:"code"`
@@ -201,9 +205,10 @@ func (s *Server) handleGitHubOAuthExchange(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// Issue signed session token
-	sessionToken, err := signGitHubSession(secret, ghUser.Login, ghUser.Name, ghUser.AvatarURL)
+	// Issue signed session token (JWT; legacy HMAC fallback without a master key)
+	sessionToken, err := s.signSession(ghUser.Login, ghUser.Name, ghUser.AvatarURL)
 	if err != nil {
+		log.Printf("[github-oauth] session signing error: %v", err)
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}

--- a/pkg/hub/auth_session.go
+++ b/pkg/hub/auth_session.go
@@ -1,0 +1,131 @@
+package hub
+
+// Web session tokens as standard JWTs.
+//
+// Sessions are HS256 JWTs signed with a key derived from the master key
+// (pkg/secrets) via HKDF-SHA256 — no longer the raw hub token. The legacy
+// hand-rolled HMAC format (signGitHubSession/verifyGitHubSession in
+// auth_github.go) is still *accepted* for one release so existing sessions
+// survive the upgrade; issuance uses JWTs whenever a master key is available.
+// TODO(next release): drop the legacy verification fallback.
+
+import (
+	"crypto/hkdf"
+	"crypto/sha256"
+	"errors"
+	"log"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/elasticclaw/elasticclaw/pkg/secrets"
+)
+
+// sessionJWTInfo is the HKDF info string that binds the derived key to this
+// specific purpose (domain separation from other keys derived from the master key).
+const sessionJWTInfo = "elasticclaw/hub session-jwt v1"
+
+// sessionJWTKeySize is the size in bytes of the derived HS256 signing key.
+const sessionJWTKeySize = 32
+
+// sessionClaims are the JWT claims carried by web session tokens.
+type sessionClaims struct {
+	Login  string `json:"login"`
+	Name   string `json:"name,omitempty"`
+	Avatar string `json:"avatar,omitempty"`
+	jwt.RegisteredClaims
+}
+
+// deriveSessionJWTKey derives the HS256 session signing key from the master
+// key via HKDF-SHA256.
+func deriveSessionJWTKey(masterKey []byte) ([]byte, error) {
+	return hkdf.Key(sha256.New, masterKey, nil, sessionJWTInfo, sessionJWTKeySize)
+}
+
+// sessionSigningKey returns the HKDF-derived JWT signing key, deriving it from
+// the master key on first use. It returns nil when no master key is available;
+// callers then fall back to the legacy HMAC session format.
+func (s *Server) sessionSigningKey() []byte {
+	s.sessionJWTOnce.Do(func() {
+		if s.sessionJWTKey != nil {
+			return // preset (tests)
+		}
+		masterKey, err := secrets.LoadMasterKey()
+		if err != nil {
+			log.Printf("[session] master key unavailable, using legacy session signing: %v", err)
+			return
+		}
+		key, err := deriveSessionJWTKey(masterKey)
+		if err != nil {
+			log.Printf("[session] failed to derive session JWT key: %v", err)
+			return
+		}
+		s.sessionJWTKey = key
+	})
+	return s.sessionJWTKey
+}
+
+// signSession issues a session token for an authenticated GitHub user.
+// It produces a standard HS256 JWT when the master-key-derived signing key is
+// available, and falls back to the legacy HMAC format otherwise.
+func (s *Server) signSession(login, name, avatarURL string) (string, error) {
+	key := s.sessionSigningKey()
+	if key == nil {
+		secret := s.webSessionSecret()
+		if secret == "" {
+			return "", errors.New("no session signing key available")
+		}
+		return signGitHubSession(secret, login, name, avatarURL)
+	}
+	now := time.Now()
+	claims := sessionClaims{
+		Login:  login,
+		Name:   name,
+		Avatar: avatarURL,
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:   login,
+			IssuedAt:  jwt.NewNumericDate(now),
+			ExpiresAt: jwt.NewNumericDate(now.Add(githubSessionExpiry)),
+		},
+	}
+	return jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString(key)
+}
+
+// verifySession validates a web session token and returns its payload.
+// It first tries the standard JWT format, then falls back to the legacy
+// hand-rolled HMAC format (dual verification, kept for one release so
+// existing sessions are not logged out on upgrade).
+func (s *Server) verifySession(token string) (*githubSessionPayload, bool) {
+	if key := s.sessionSigningKey(); key != nil {
+		claims := &sessionClaims{}
+		parsed, err := jwt.ParseWithClaims(token, claims,
+			func(t *jwt.Token) (any, error) { return key, nil },
+			jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Alg()}),
+			jwt.WithExpirationRequired(),
+		)
+		if err == nil && parsed.Valid {
+			login := claims.Login
+			if login == "" {
+				login = claims.Subject
+			}
+			if login == "" {
+				return nil, false
+			}
+			var exp int64
+			if claims.ExpiresAt != nil {
+				exp = claims.ExpiresAt.Unix()
+			}
+			return &githubSessionPayload{
+				Login:     login,
+				Name:      claims.Name,
+				AvatarURL: claims.Avatar,
+				Exp:       exp,
+			}, true
+		}
+	}
+	// Legacy format fallback (remove after one release).
+	if secret := s.webSessionSecret(); secret != "" {
+		return verifyGitHubSession(secret, token)
+	}
+	return nil, false
+}

--- a/pkg/hub/auth_session_test.go
+++ b/pkg/hub/auth_session_test.go
@@ -1,0 +1,233 @@
+package hub
+
+import (
+	"bytes"
+	"encoding/base64"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/elasticclaw/elasticclaw/pkg/secrets"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+// newSessionTestServer returns a bare Server with a preset JWT signing key,
+// bypassing master key loading from the environment.
+func newSessionTestServer(key []byte, cfg *types.HubConfig) *Server {
+	if cfg == nil {
+		cfg = &types.HubConfig{}
+	}
+	return &Server{hubCfg: cfg, sessionJWTKey: key}
+}
+
+func testJWTKey(seed byte) []byte {
+	key := bytes.Repeat([]byte{seed}, sessionJWTKeySize)
+	return key
+}
+
+func TestSessionJWTRoundTrip(t *testing.T) {
+	s := newSessionTestServer(testJWTKey(1), nil)
+
+	token, err := s.signSession("octocat", "The Octocat", "https://example.com/a.png")
+	if err != nil {
+		t.Fatalf("signSession: %v", err)
+	}
+	if parts := strings.Split(token, "."); len(parts) != 3 {
+		t.Fatalf("expected a 3-part JWT, got %d parts", len(parts))
+	}
+
+	payload, ok := s.verifySession(token)
+	if !ok {
+		t.Fatal("verifySession rejected a freshly issued token")
+	}
+	if payload.Login != "octocat" || payload.Name != "The Octocat" || payload.AvatarURL != "https://example.com/a.png" {
+		t.Fatalf("unexpected payload: %+v", payload)
+	}
+
+	wantExp := time.Now().Add(githubSessionExpiry).Unix()
+	if diff := payload.Exp - wantExp; diff < -5 || diff > 5 {
+		t.Fatalf("exp not ~7d from now: got %d, want ~%d", payload.Exp, wantExp)
+	}
+}
+
+func TestSessionJWTStandardClaims(t *testing.T) {
+	s := newSessionTestServer(testJWTKey(1), nil)
+	token, err := s.signSession("octocat", "The Octocat", "https://example.com/a.png")
+	if err != nil {
+		t.Fatalf("signSession: %v", err)
+	}
+
+	claims := &sessionClaims{}
+	parsed, err := jwt.ParseWithClaims(token, claims, func(tok *jwt.Token) (any, error) {
+		return testJWTKey(1), nil
+	}, jwt.WithValidMethods([]string{"HS256"}))
+	if err != nil || !parsed.Valid {
+		t.Fatalf("token does not parse as a standard HS256 JWT: %v", err)
+	}
+	if claims.Subject != "octocat" {
+		t.Fatalf("sub = %q, want %q", claims.Subject, "octocat")
+	}
+	if claims.IssuedAt == nil || claims.ExpiresAt == nil {
+		t.Fatal("iat/exp claims missing")
+	}
+	if claims.Login != "octocat" || claims.Avatar != "https://example.com/a.png" {
+		t.Fatalf("custom claims wrong: %+v", claims)
+	}
+}
+
+func TestSessionJWTExpiredRejected(t *testing.T) {
+	key := testJWTKey(1)
+	s := newSessionTestServer(key, nil)
+
+	claims := sessionClaims{
+		Login: "octocat",
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:   "octocat",
+			IssuedAt:  jwt.NewNumericDate(time.Now().Add(-8 * 24 * time.Hour)),
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(-time.Hour)),
+		},
+	}
+	token, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := s.verifySession(token); ok {
+		t.Fatal("expired JWT was accepted")
+	}
+}
+
+func TestSessionJWTWrongKeyRejected(t *testing.T) {
+	signer := newSessionTestServer(testJWTKey(1), nil)
+	verifier := newSessionTestServer(testJWTKey(2), nil)
+
+	token, err := signer.signSession("octocat", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := verifier.verifySession(token); ok {
+		t.Fatal("JWT signed with a different key was accepted")
+	}
+}
+
+func TestSessionJWTTamperedRejected(t *testing.T) {
+	s := newSessionTestServer(testJWTKey(1), nil)
+	token, err := s.signSession("octocat", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	parts := strings.Split(token, ".")
+	forged := jwt.MapClaims{"sub": "attacker", "login": "attacker", "exp": time.Now().Add(time.Hour).Unix()}
+	body, err := jwt.NewWithClaims(jwt.SigningMethodHS256, forged).SignedString(testJWTKey(9))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tampered := parts[0] + "." + strings.Split(body, ".")[1] + "." + parts[2]
+	if _, ok := s.verifySession(tampered); ok {
+		t.Fatal("tampered JWT was accepted")
+	}
+}
+
+func TestSessionJWTAlgNoneRejected(t *testing.T) {
+	s := newSessionTestServer(testJWTKey(1), nil)
+	claims := jwt.MapClaims{"sub": "octocat", "login": "octocat", "exp": time.Now().Add(time.Hour).Unix()}
+	token, err := jwt.NewWithClaims(jwt.SigningMethodNone, claims).SignedString(jwt.UnsafeAllowNoneSignatureType)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := s.verifySession(token); ok {
+		t.Fatal("alg=none JWT was accepted")
+	}
+}
+
+// TestSessionLegacyTokenStillVerifies covers the upgrade transition window:
+// tokens issued by the old hand-rolled HMAC format must remain valid even
+// when a JWT signing key is present (dual verification).
+func TestSessionLegacyTokenStillVerifies(t *testing.T) {
+	cfg := &types.HubConfig{
+		Token: "hub-token",
+		Auth:  &types.AuthConfig{SessionSecret: "legacy-secret"},
+	}
+	s := newSessionTestServer(testJWTKey(1), cfg)
+
+	legacy, err := signGitHubSession("legacy-secret", "octocat", "The Octocat", "https://example.com/a.png")
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, ok := s.verifySession(legacy)
+	if !ok {
+		t.Fatal("legacy session token was rejected after the JWT upgrade")
+	}
+	if payload.Login != "octocat" || payload.Name != "The Octocat" {
+		t.Fatalf("unexpected legacy payload: %+v", payload)
+	}
+
+	if _, ok := s.verifySession("garbage.token"); ok {
+		t.Fatal("garbage token was accepted")
+	}
+}
+
+func TestSessionKeyDerivedFromMasterKeyViaHKDF(t *testing.T) {
+	masterKey := bytes.Repeat([]byte{7}, secrets.MasterKeySize)
+	encoded := base64.StdEncoding.EncodeToString(masterKey)
+	t.Setenv(secrets.MasterKeyEnvVar, encoded)
+
+	s := &Server{hubCfg: &types.HubConfig{}}
+	key := s.sessionSigningKey()
+	if key == nil {
+		t.Fatal("expected a derived signing key when a master key is set")
+	}
+	if bytes.Equal(key, masterKey) {
+		t.Fatal("signing key must not be the raw master key")
+	}
+
+	want, err := deriveSessionJWTKey(masterKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(key, want) {
+		t.Fatal("derived key does not match HKDF derivation")
+	}
+
+	// Derivation is deterministic: a second server derives the same key,
+	// so sessions survive hub restarts.
+	s2 := &Server{hubCfg: &types.HubConfig{}}
+	if !bytes.Equal(s2.sessionSigningKey(), key) {
+		t.Fatal("derivation is not deterministic across servers")
+	}
+}
+
+// TestSessionSignFallsBackToLegacyWithoutMasterKey ensures servers without a
+// master key (e.g. bare test setups) still issue working legacy tokens.
+func TestSessionSignFallsBackToLegacyWithoutMasterKey(t *testing.T) {
+	t.Setenv(secrets.MasterKeyEnvVar, "")
+	// Point the master.key lookup at an empty temp dir so a developer's real
+	// ~/.elasticclaw/master.key does not leak into the test.
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", filepath.Join(t.TempDir(), "hub.yaml"))
+
+	cfg := &types.HubConfig{
+		Token: "hub-token",
+		Auth:  &types.AuthConfig{SessionSecret: "legacy-secret"},
+	}
+	s := &Server{hubCfg: cfg}
+
+	token, err := s.signSession("octocat", "", "")
+	if err != nil {
+		t.Fatalf("signSession without master key: %v", err)
+	}
+	if parts := strings.Split(token, "."); len(parts) != 2 {
+		t.Fatalf("expected a 2-part legacy token, got %d parts", len(parts))
+	}
+	if _, ok := s.verifySession(token); !ok {
+		t.Fatal("legacy fallback token was rejected")
+	}
+
+	// With neither a master key nor a session secret, signing must fail
+	// instead of signing with an empty key.
+	empty := &Server{hubCfg: &types.HubConfig{}}
+	if _, err := empty.signSession("octocat", "", ""); err == nil {
+		t.Fatal("expected an error when no signing key material exists")
+	}
+}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -64,6 +64,12 @@ type Server struct {
 	checkpointMu      sync.Mutex
 	checkpointWaiters map[string]chan error // checkpoint_id -> waiter
 
+	// sessionJWTKey is the HS256 key for web session JWTs, derived from the
+	// master key via HKDF on first use (see auth_session.go). nil means no
+	// master key is available and the legacy HMAC format is used instead.
+	sessionJWTOnce sync.Once
+	sessionJWTKey  []byte
+
 	// githubBaseURL overrides the GitHub API base for testing (default: https://api.github.com)
 	githubBaseURL string
 	// linearBaseURL overrides the Linear API base for testing (default: https://api.linear.app)
@@ -484,18 +490,15 @@ func (s *Server) withConfigMutationAuth(next http.HandlerFunc) http.HandlerFunc 
 			return
 		}
 
-		sessionSecret := s.webSessionSecret()
-		if sessionSecret != "" {
-			if payload, ok := verifyGitHubSession(sessionSecret, token); ok {
-				if !isAccessAdmin(accessCfg, payload.Login) {
-					http.Error(w, "forbidden", http.StatusForbidden)
-					return
-				}
-				ctx := context.WithValue(r.Context(), ctxGitHubLoginKey{}, payload.Login)
-				r = r.WithContext(ctx)
-				next(w, r)
+		if payload, ok := s.verifySession(token); ok {
+			if !isAccessAdmin(accessCfg, payload.Login) {
+				http.Error(w, "forbidden", http.StatusForbidden)
 				return
 			}
+			ctx := context.WithValue(r.Context(), ctxGitHubLoginKey{}, payload.Login)
+			r = r.WithContext(ctx)
+			next(w, r)
+			return
 		}
 
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
@@ -528,11 +531,7 @@ func (s *Server) resolveAuthToken(token string) (tenantID, githubLogin string, o
 	if tenantID, err := s.tenantByToken(token); err == nil {
 		return tenantID, "", true
 	}
-	sessionSecret := s.webSessionSecret()
-	if sessionSecret == "" {
-		return "", "", false
-	}
-	payload, valid := verifyGitHubSession(sessionSecret, token)
+	payload, valid := s.verifySession(token)
 	if !valid {
 		return "", "", false
 	}
@@ -600,7 +599,6 @@ func (s *Server) withWebAuth(next http.HandlerFunc) http.HandlerFunc {
 		s.mu.RLock()
 		hubToken := s.hubCfg.Token
 		s.mu.RUnlock()
-		sessionSecret := s.webSessionSecret()
 
 		// Accept shared hub token (existing behavior)
 		if token == hubToken {
@@ -609,14 +607,12 @@ func (s *Server) withWebAuth(next http.HandlerFunc) http.HandlerFunc {
 		}
 
 		// Try GitHub OAuth session token
-		if sessionSecret != "" {
-			if payload, ok := verifyGitHubSession(sessionSecret, token); ok {
-				ctx := context.WithValue(r.Context(), ctxGitHubLoginKey{}, payload.Login)
-				ctx = context.WithValue(ctx, ctxGitHubSessionPayloadKey{}, payload)
-				r = r.WithContext(ctx)
-				next(w, r)
-				return
-			}
+		if payload, ok := s.verifySession(token); ok {
+			ctx := context.WithValue(r.Context(), ctxGitHubLoginKey{}, payload.Login)
+			ctx = context.WithValue(ctx, ctxGitHubSessionPayloadKey{}, payload)
+			r = r.WithContext(ctx)
+			next(w, r)
+			return
 		}
 
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
@@ -652,7 +648,6 @@ func (s *Server) withWebAdminAuth(next http.HandlerFunc) http.HandlerFunc {
 			accessCfg = s.hubCfg.Auth.Access
 		}
 		s.mu.RUnlock()
-		sessionSecret := s.webSessionSecret()
 
 		// Password-authenticated sessions keep existing admin access.
 		if token == hubToken {
@@ -660,17 +655,15 @@ func (s *Server) withWebAdminAuth(next http.HandlerFunc) http.HandlerFunc {
 			return
 		}
 
-		if sessionSecret != "" {
-			if payload, ok := verifyGitHubSession(sessionSecret, token); ok {
-				if !isAccessAdmin(accessCfg, payload.Login) {
-					http.Error(w, "forbidden", http.StatusForbidden)
-					return
-				}
-				ctx := context.WithValue(r.Context(), ctxGitHubLoginKey{}, payload.Login)
-				r = r.WithContext(ctx)
-				next(w, r)
+		if payload, ok := s.verifySession(token); ok {
+			if !isAccessAdmin(accessCfg, payload.Login) {
+				http.Error(w, "forbidden", http.StatusForbidden)
 				return
 			}
+			ctx := context.WithValue(r.Context(), ctxGitHubLoginKey{}, payload.Login)
+			r = r.WithContext(ctx)
+			next(w, r)
+			return
 		}
 
 		http.Error(w, "unauthorized", http.StatusUnauthorized)


### PR DESCRIPTION
## Motivation

`pkg/hub/auth_github.go` hand-rolls its own signed session token format — `base64url(json payload).base64url(hmac-sha256)` with manual `hmac.New(sha256.New, ...)` signing and verification (`signGitHubSession`/`verifyGitHubSession`) — even though `github.com/golang-jwt/jwt/v5 v5.3.1` is already in `go.mod` and used elsewhere in the hub (`pkg/hub/github.go` signs GitHub App JWTs with it). Worse, the HMAC key defaulted to the raw `hubCfg.Token` (the shared hub password) when no `session_secret` was configured, so session-forging key material was the same string users type to log in.

This PR implements re-arch item 3.5: sessions become standard HS256 JWTs (claims `sub`, `exp` 7d, `iat`, plus custom `login`/`name`/`avatar`), signed with a key derived from the 3.4 master key via HKDF-SHA256 with a purpose-bound info string (`elasticclaw/hub session-jwt v1`) — no longer the raw `hubCfg.Token`. Verification is dual for one release (JWT first, then the legacy format), so existing sessions survive the upgrade.

## Dependencies

This PR is STACKED on branch `feature/secrets-encryption` (item 3.4 — the master key this derives from). Depends on #450 — review and merge that first.

## What changed

- **`pkg/hub/auth_session.go` (new)** — JWT session module:
  - `deriveSessionJWTKey`: HKDF-SHA256 (stdlib `crypto/hkdf`, Go >= 1.24) from the 32-byte master key, domain-separated info string, 32-byte output.
  - `Server.sessionSigningKey()`: lazily loads the master key (`secrets.LoadMasterKey`, the same source `cmd/hub.go` ensures at boot) and caches the derived key via `sync.Once`; returns nil when no master key exists.
  - `Server.signSession()`: issues HS256 JWTs; falls back to the legacy HMAC format on servers without a master key; errors instead of signing with an empty key when neither exists.
  - `Server.verifySession()`: parses/validates the JWT (`WithValidMethods([HS256])`, `WithExpirationRequired`), then falls back to legacy `verifyGitHubSession` — the one-release transition window, marked with a `TODO(next release)` to drop it.
- **`pkg/hub/server.go`** — the four auth sites (admin middleware, `resolveAuthToken`, web session middleware, `withWebAdminAuth`) now call `s.verifySession(token)` instead of `verifyGitHubSession(s.webSessionSecret(), token)`. Added `sessionJWTOnce`/`sessionJWTKey` fields to `Server`.
- **`pkg/hub/auth_github.go`** — `handleGitHubOAuthExchange` issues tokens via `s.signSession(...)`; legacy `signGitHubSession`/`verifyGitHubSession`/`webSessionSecret` are kept but marked `Deprecated` (verification-only transition + no-master-key fallback).
- **`pkg/hub/auth_session_test.go` (new)** — issuance/validation/expiry tests: JWT round trip; standard claims (`sub`/`iat`/`exp`); expired, wrong-key, tampered, and `alg=none` tokens rejected; legacy tokens still verifying while a JWT key is present; deterministic HKDF derivation (sessions survive hub restarts) that never equals the raw master key; and the no-master-key legacy signing fallback.

No frontend changes: the token remains an opaque string to the web UI.

## Testing

- `go build ./...` — pass.
- `go test ./pkg/hub/ -run 'TestSession' -v` — all 9 new tests pass.
- `make test` (full `go test -v ./...`) — exit 0, no failures; the existing session tests in `pkg/hub/server_test.go` (which sign legacy-format tokens directly) still pass thanks to dual verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
