### PR TITLE
feat(hub): structured logging with slog and request IDs

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,25 @@
+version: "2"
+
+linters:
+  enable:
+    - forbidigo
+  settings:
+    forbidigo:
+      forbid:
+        # Structured logging only in the hub: use logger.FromContext(ctx) /
+        # the logf/logfCtx bridges instead of the stdlib printf-style loggers.
+        - pattern: '^log\.(Print|Printf|Println)$'
+          msg: use log/slog (logger.FromContext or the logf/logfCtx bridges) instead of the stdlib log package
+        - pattern: '^fmt\.(Print|Printf|Println)$'
+          msg: use log/slog instead of printing to stdout
+  exclusions:
+    rules:
+      # The structured-logging rule applies to the hub only (for now); the CLI
+      # under cmd/ legitimately prints to stdout.
+      - path-except: ^pkg/hub/
+        linters:
+          - forbidigo
+      # Test scaffolding (fake claw bridge) prints progress to stdout on purpose.
+      - path: ^pkg/hub/factorytest/
+        linters:
+          - forbidigo

--- a/cmd/hub.go
+++ b/cmd/hub.go
@@ -2,12 +2,14 @@ package cmd
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/elasticclaw/elasticclaw/pkg/config"
 	"github.com/elasticclaw/elasticclaw/pkg/hub"
+	"github.com/elasticclaw/elasticclaw/pkg/hub/logger"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 	"github.com/spf13/cobra"
 )
@@ -96,6 +98,10 @@ func runHub(cmd *cobra.Command, args []string) error {
 	if hubUIPassword != "" {
 		hubCfg.UIPassword = hubUIPassword
 	}
+
+	// Root structured logger: created once at boot and installed as the
+	// process default; the hub server picks it up via slog.Default().
+	slog.SetDefault(logger.New())
 
 	hub.Version = Version
 	hub.Commit = Commit

--- a/pkg/hub/agent_failure_feedback.go
+++ b/pkg/hub/agent_failure_feedback.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -51,30 +50,30 @@ func (s *Server) handleAgentFailureFeedback(feedback agentFailureFeedback, token
 			base = "https://api.github.com"
 		}
 		if err := commentGitHubIssueWithBase(base, token, feedback.GitHubRepo, feedback.GitHubIssueNum, comment); err != nil {
-			log.Printf("[agent-failure-feedback] failed to comment GitHub issue %s#%d: %v", feedback.GitHubRepo, feedback.GitHubIssueNum, err)
+			logf("[agent-failure-feedback] failed to comment GitHub issue %s#%d: %v", feedback.GitHubRepo, feedback.GitHubIssueNum, err)
 		}
 		if feedback.AgentStatusError != "" {
 			if err := githubAPIAddLabel(base, feedback.GitHubRepo, feedback.GitHubIssueNum, feedback.AgentStatusError, token); err != nil {
-				log.Printf("[agent-failure-feedback] failed to mark GitHub issue %s#%d with label %q: %v", feedback.GitHubRepo, feedback.GitHubIssueNum, feedback.AgentStatusError, err)
+				logf("[agent-failure-feedback] failed to mark GitHub issue %s#%d with label %q: %v", feedback.GitHubRepo, feedback.GitHubIssueNum, feedback.AgentStatusError, err)
 			}
 		}
 		if canAssignFailureFeedback(feedback) {
 			if err := assignGitHubIssueWithBase(base, token, feedback.GitHubRepo, feedback.GitHubIssueNum, feedback.TriggerActor.Login); err != nil {
-				log.Printf("[agent-failure-feedback] failed to assign GitHub issue %s#%d to %q: %v", feedback.GitHubRepo, feedback.GitHubIssueNum, feedback.TriggerActor.Login, err)
+				logf("[agent-failure-feedback] failed to assign GitHub issue %s#%d to %q: %v", feedback.GitHubRepo, feedback.GitHubIssueNum, feedback.TriggerActor.Login, err)
 			}
 		}
 	case "linear":
 		if err := s.commentLinearIssue(token, feedback.LinearIdentifier, comment); err != nil {
-			log.Printf("[agent-failure-feedback] failed to comment Linear issue %s: %v", feedback.LinearIdentifier, err)
+			logf("[agent-failure-feedback] failed to comment Linear issue %s: %v", feedback.LinearIdentifier, err)
 		}
 		if feedback.AgentStatusError != "" {
 			if err := s.moveLinearIssueOnServer(token, feedback.LinearIdentifier, feedback.AgentStatusError); err != nil {
-				log.Printf("[agent-failure-feedback] failed to mark Linear issue %s with status %q: %v", feedback.LinearIdentifier, feedback.AgentStatusError, err)
+				logf("[agent-failure-feedback] failed to mark Linear issue %s with status %q: %v", feedback.LinearIdentifier, feedback.AgentStatusError, err)
 			}
 		}
 		if canAssignFailureFeedback(feedback) {
 			if err := s.assignLinearIssue(token, feedback.LinearIdentifier, feedback.TriggerActor.ID); err != nil {
-				log.Printf("[agent-failure-feedback] failed to assign Linear issue %s to %q: %v", feedback.LinearIdentifier, feedback.TriggerActor.ID, err)
+				logf("[agent-failure-feedback] failed to assign Linear issue %s to %q: %v", feedback.LinearIdentifier, feedback.TriggerActor.ID, err)
 			}
 		}
 	}
@@ -90,7 +89,7 @@ func (s *Server) triggerActorForClaw(clawID string) triggerActor {
 	}
 	var actor triggerActor
 	if err := json.Unmarshal([]byte(actorJSON), &actor); err != nil {
-		log.Printf("[agent-failure-feedback] failed to parse trigger actor for claw %s: %v", shortID(clawID), err)
+		logf("[agent-failure-feedback] failed to parse trigger actor for claw %s: %v", shortID(clawID), err)
 		return triggerActor{}
 	}
 	return actor

--- a/pkg/hub/analytics.go
+++ b/pkg/hub/analytics.go
@@ -2,7 +2,6 @@ package hub
 
 import (
 	"fmt"
-	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -79,7 +78,7 @@ func (s *Server) handleFactoryAnalytics(w http.ResponseWriter, r *http.Request) 
 
 	summary, err := s.computeFactoryAnalytics(factoryName, since)
 	if err != nil {
-		log.Printf("[analytics] error computing analytics for %s: %v", factoryName, err)
+		logfCtx(r.Context(), "[analytics] error computing analytics for %s: %v", factoryName, err)
 		http.Error(w, "db error", http.StatusInternalServerError)
 		return
 	}
@@ -113,7 +112,7 @@ func (s *Server) handleAllFactoriesAnalytics(w http.ResponseWriter, r *http.Requ
 		since,
 	)
 	if err != nil {
-		log.Printf("[analytics] error listing factories: %v", err)
+		logfCtx(r.Context(), "[analytics] error listing factories: %v", err)
 		http.Error(w, "db error", http.StatusInternalServerError)
 		return
 	}
@@ -128,7 +127,7 @@ func (s *Server) handleAllFactoriesAnalytics(w http.ResponseWriter, r *http.Requ
 		factoryNames = append(factoryNames, name)
 	}
 	if err := rows.Err(); err != nil {
-		log.Printf("[analytics] error iterating factory names: %v", err)
+		logfCtx(r.Context(), "[analytics] error iterating factory names: %v", err)
 		http.Error(w, "db error", http.StatusInternalServerError)
 		return
 	}
@@ -307,7 +306,7 @@ func (s *Server) trackPRMerged(factoryName, issueID, clawID, repo string, prNumb
 		Detail:          map[string]any{"repo": repo, "prNumber": prNumber},
 		OccurredAt:      now(),
 	}); err != nil {
-		log.Printf("[task-run-analytics] failed to record PR merge for claw %s: %v", clawID, err)
+		logf("[task-run-analytics] failed to record PR merge for claw %s: %v", clawID, err)
 	}
 }
 
@@ -326,7 +325,7 @@ func (s *Server) trackPRClosed(factoryName, issueID, clawID, repo string, prNumb
 		Detail:          map[string]any{"repo": repo, "prNumber": prNumber},
 		OccurredAt:      now(),
 	}); err != nil {
-		log.Printf("[task-run-analytics] failed to record PR close for claw %s: %v", clawID, err)
+		logf("[task-run-analytics] failed to record PR close for claw %s: %v", clawID, err)
 	}
 }
 

--- a/pkg/hub/auth_github.go
+++ b/pkg/hub/auth_github.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"net/url"
 	"strings"
@@ -175,7 +174,7 @@ func (s *Server) handleGitHubOAuthExchange(w http.ResponseWriter, r *http.Reques
 	// Exchange code for GitHub access token
 	accessToken, err := s.githubExchangeCode(r.Context(), oauthCfg.ClientID, oauthCfg.ClientSecret, body.Code, body.RedirectURI)
 	if err != nil {
-		log.Printf("[github-oauth] token exchange error: %v", err)
+		logfCtx(r.Context(), "[github-oauth] token exchange error: %v", err)
 		writeErr(w, http.StatusBadGateway, "upstream_error", "token exchange failed")
 		return
 	}
@@ -183,7 +182,7 @@ func (s *Server) handleGitHubOAuthExchange(w http.ResponseWriter, r *http.Reques
 	// Fetch user info
 	ghUser, err := s.githubFetchUser(r.Context(), accessToken)
 	if err != nil {
-		log.Printf("[github-oauth] fetch user error: %v", err)
+		logfCtx(r.Context(), "[github-oauth] fetch user error: %v", err)
 		writeErr(w, http.StatusBadGateway, "upstream_error", "fetch user failed")
 		return
 	}
@@ -191,12 +190,12 @@ func (s *Server) handleGitHubOAuthExchange(w http.ResponseWriter, r *http.Reques
 	// Check allowlist
 	allowed, err := s.githubCheckAllowlist(r.Context(), oauthCfg, accessToken, ghUser.Login)
 	if err != nil {
-		log.Printf("[github-oauth] allowlist check error: %v", err)
+		logfCtx(r.Context(), "[github-oauth] allowlist check error: %v", err)
 		writeErr(w, http.StatusBadGateway, "upstream_error", "allowlist check failed")
 		return
 	}
 	if !allowed {
-		log.Printf("[github-oauth] denied: user %s not in allowlist", ghUser.Login)
+		logfCtx(r.Context(), "[github-oauth] denied: user %s not in allowlist", ghUser.Login)
 		writeErr(w, http.StatusForbidden, "forbidden", "access denied")
 		return
 	}
@@ -208,7 +207,7 @@ func (s *Server) handleGitHubOAuthExchange(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	log.Printf("[github-oauth] login: %s (%s)", ghUser.Login, ghUser.Name)
+	logfCtx(r.Context(), "[github-oauth] login: %s (%s)", ghUser.Login, ghUser.Name)
 
 	w.Header().Set("Cache-Control", "no-store")
 	jsonOK(w, map[string]string{"github_token": sessionToken})
@@ -317,7 +316,7 @@ func (s *Server) githubCheckAllowlist(ctx context.Context, cfg *types.GitHubOAut
 		org, team := parts[0], parts[1]
 		member, err := s.githubCheckTeamMembership(ctx, accessToken, org, team, login)
 		if err != nil {
-			log.Printf("[github-oauth] team check %s/%s: %v", org, team, err)
+			logfCtx(ctx, "[github-oauth] team check %s/%s: %v", org, team, err)
 			continue
 		}
 		if member {

--- a/pkg/hub/checkpoints.go
+++ b/pkg/hub/checkpoints.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -159,7 +158,7 @@ func (s *Server) requestIdleCheckpoints() {
 		}
 		go func(clawID string) {
 			if _, err := s.requestCheckpoint(context.Background(), clawID, "idle-timer", "hub", false, checkpointRequestTimeout); err != nil {
-				log.Printf("[checkpoint] idle request for %s failed: %v", shortID(clawID), err)
+				logf("[checkpoint] idle request for %s failed: %v", shortID(clawID), err)
 			}
 		}(item.id)
 	}
@@ -182,7 +181,7 @@ func (s *Server) requestBootstrapCheckpoint(clawID string) {
 		return
 	}
 	if _, err := s.requestCheckpoint(context.Background(), clawID, "bootstrap", "hub", false, checkpointRequestTimeout); err != nil {
-		log.Printf("[checkpoint] bootstrap request for %s failed: %v", shortID(clawID), err)
+		logf("[checkpoint] bootstrap request for %s failed: %v", shortID(clawID), err)
 	}
 }
 
@@ -322,7 +321,7 @@ func (s *Server) provisionStoredClaw(clawID string) {
 		clawID,
 	).Scan(&tenantID, &name, &template, &provider, &defaultModel, &templateFilesJSON, &githubReposJSON, &linearWorkspace, &nixEnabled, &dockerEnabled, &llmKey)
 	if err != nil {
-		log.Printf("[restore] failed to load claw %s: %v", shortID(clawID), err)
+		logf("[restore] failed to load claw %s: %v", shortID(clawID), err)
 		s.stopAgentWithReason(clawID, fmt.Sprintf("Restore failed: %v", err), false)
 		return
 	}
@@ -390,7 +389,7 @@ func (s *Server) provisionStoredClaw(clawID string) {
 		provErr = fmt.Errorf("unsupported provider: %s", provider)
 	}
 	if provErr != nil {
-		log.Printf("[restore] provision failed for claw %s: %v", clawID, provErr)
+		logf("[restore] provision failed for claw %s: %v", clawID, provErr)
 		s.stopAgentWithReason(clawID, fmt.Sprintf("Restore provision failed: %v", provErr), false)
 		return
 	}
@@ -546,14 +545,14 @@ func (s *Server) drainPendingCheckpoint(clawID string) {
 	}
 	go func() {
 		if _, err := s.dispatchCheckpoint(context.Background(), cc, clawID, checkpointID, reason, false, checkpointRequestTimeout); err != nil {
-			log.Printf("[checkpoint] queued request for %s failed: %v", shortID(clawID), err)
+			logf("[checkpoint] queued request for %s failed: %v", shortID(clawID), err)
 		}
 	}()
 }
 
 func (s *Server) checkpointBeforeTermination(clawID, reason string) {
 	if _, err := s.requestCheckpoint(context.Background(), clawID, "termination:"+reason, "hub", true, checkpointTerminationTimeout); err != nil {
-		log.Printf("[checkpoint] termination checkpoint for %s failed: %v", shortID(clawID), err)
+		logf("[checkpoint] termination checkpoint for %s failed: %v", shortID(clawID), err)
 	}
 }
 

--- a/pkg/hub/cron_scheduler.go
+++ b/pkg/hub/cron_scheduler.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"log"
 	"sync"
 	"time"
 
@@ -71,7 +70,7 @@ func (cs *cronScheduler) start() error {
 	}
 
 	cs.cron.Start()
-	log.Println("[cron] scheduler started")
+	logf("[cron] scheduler started")
 	return nil
 }
 
@@ -83,7 +82,7 @@ func (cs *cronScheduler) stop() {
 	if cs.cron != nil {
 		ctx := cs.cron.Stop()
 		<-ctx.Done()
-		log.Println("[cron] scheduler stopped")
+		logf("[cron] scheduler stopped")
 	}
 }
 
@@ -120,7 +119,7 @@ func (cs *cronScheduler) reloadWorkflows() error {
 			cs.cron.Remove(entryID)
 			delete(cs.entries, key)
 			delete(cs.workflows, key)
-			log.Printf("[cron] removed schedule for %s", key)
+			logf("[cron] removed schedule for %s", key)
 		}
 	}
 
@@ -143,7 +142,7 @@ func (cs *cronScheduler) reloadWorkflows() error {
 			var err error
 			loc, err = time.LoadLocation(sw.trigger.Timezone)
 			if err != nil {
-				log.Printf("[cron] invalid timezone %q for %s, using UTC: %v", sw.trigger.Timezone, key, err)
+				logf("[cron] invalid timezone %q for %s, using UTC: %v", sw.trigger.Timezone, key, err)
 				loc = time.UTC
 			}
 		}
@@ -152,7 +151,7 @@ func (cs *cronScheduler) reloadWorkflows() error {
 		// We use a wrapper approach: create schedule parser with timezone
 		schedule, err := parseCronSchedule(sw.trigger.Schedule, loc)
 		if err != nil {
-			log.Printf("[cron] invalid schedule %q for %s: %v", sw.trigger.Schedule, key, err)
+			logf("[cron] invalid schedule %q for %s: %v", sw.trigger.Schedule, key, err)
 			continue
 		}
 
@@ -163,7 +162,7 @@ func (cs *cronScheduler) reloadWorkflows() error {
 
 		cs.entries[key] = entryID
 		cs.workflows[key] = sw
-		log.Printf("[cron] scheduled %s with %q (timezone: %s)", key, sw.trigger.Schedule, sw.trigger.Timezone)
+		logf("[cron] scheduled %s with %q (timezone: %s)", key, sw.trigger.Schedule, sw.trigger.Timezone)
 	}
 
 	return nil
@@ -223,20 +222,20 @@ func (cs *cronScheduler) runWorkflow(sw *scheduledWorkflow) (workflowRunStartSta
 		switch sw.trigger.OverlapPolicy {
 		case "skip", "":
 			cs.runningMu.Unlock()
-			log.Printf("[cron] skipping %s (%d run(s) still active)", key, activeRuns)
+			logf("[cron] skipping %s (%d run(s) still active)", key, activeRuns)
 			cs.recordRun(uuid.New().String(), sw, "skipped", "", fmt.Sprintf("%d run(s) still active", activeRuns))
 			return workflowRunSkipped, nil
 		case "queue":
 			// Queue is not implemented in v1; treat as skip
 			cs.runningMu.Unlock()
-			log.Printf("[cron] skipping %s (queue not implemented, %d run(s) active)", key, activeRuns)
+			logf("[cron] skipping %s (queue not implemented, %d run(s) active)", key, activeRuns)
 			cs.recordRun(uuid.New().String(), sw, "skipped", "", fmt.Sprintf("%d run(s) active, queue not implemented", activeRuns))
 			return workflowRunSkipped, nil
 		case "parallel":
 			// Allow parallel execution
 		default:
 			cs.runningMu.Unlock()
-			log.Printf("[cron] unknown overlap policy %q for %s, skipping", sw.trigger.OverlapPolicy, key)
+			logf("[cron] unknown overlap policy %q for %s, skipping", sw.trigger.OverlapPolicy, key)
 			cs.recordRun(uuid.New().String(), sw, "skipped", "", "unknown overlap policy")
 			return workflowRunSkipped, nil
 		}
@@ -273,7 +272,7 @@ func (cs *cronScheduler) runWorkflow(sw *scheduledWorkflow) (workflowRunStartSta
 		},
 	)
 	if err != nil {
-		log.Printf("[cron] failed to create claw for %s: %v", key, err)
+		logf("[cron] failed to create claw for %s: %v", key, err)
 		cs.failRun(runID, fmt.Sprintf("failed to create claw: %v", err))
 		// No claw was created, so decrement the running counter immediately
 		cs.runningMu.Lock()
@@ -293,7 +292,7 @@ func (cs *cronScheduler) runWorkflow(sw *scheduledWorkflow) (workflowRunStartSta
 	cs.clawWorkflow[clawID] = key
 	cs.clawWorkflowMu.Unlock()
 
-	log.Printf("[cron] started run %s for %s (claw %s)", runID, key, clawID)
+	logf("[cron] started run %s for %s (claw %s)", runID, key, clawID)
 	return workflowRunStarted, nil
 }
 
@@ -310,7 +309,7 @@ func (cs *cronScheduler) recordRun(runID string, sw *scheduledWorkflow, status, 
 		runID, tenantID, sw.workflow.Name, sw.workspace.Name, "cron", status, clawID, context, now, now,
 	)
 	if err != nil {
-		log.Printf("[cron] failed to record run for %s: %v", sw.key, err)
+		logf("[cron] failed to record run for %s: %v", sw.key, err)
 	}
 }
 
@@ -321,7 +320,7 @@ func (cs *cronScheduler) updateRun(runID, clawID, status string) {
 		clawID, status, runID,
 	)
 	if err != nil {
-		log.Printf("[cron] failed to update run %s: %v", runID, err)
+		logf("[cron] failed to update run %s: %v", runID, err)
 	}
 }
 
@@ -333,7 +332,7 @@ func (cs *cronScheduler) finishRun(runID, result string) {
 		"completed", result, now, runID,
 	)
 	if err != nil {
-		log.Printf("[cron] failed to finish run %s: %v", runID, err)
+		logf("[cron] failed to finish run %s: %v", runID, err)
 	}
 }
 
@@ -345,7 +344,7 @@ func (cs *cronScheduler) failRun(runID, result string) {
 		"failed", result, now, runID,
 	)
 	if err != nil {
-		log.Printf("[cron] failed to mark run %s as failed: %v", runID, err)
+		logf("[cron] failed to mark run %s as failed: %v", runID, err)
 	}
 }
 
@@ -361,7 +360,7 @@ func (cs *cronScheduler) finishRunByClawID(clawID, status, result string) {
 		status, result, now, clawID,
 	)
 	if err != nil {
-		log.Printf("[cron] failed to finish run for claw %s: %v", clawID, err)
+		logf("[cron] failed to finish run for claw %s: %v", clawID, err)
 	}
 
 	// Decrement the running counter for this workflow so overlap policy

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -3,7 +3,6 @@ package hub
 import (
 	"database/sql"
 	"fmt"
-	"log"
 	"time"
 
 	_ "modernc.org/sqlite" // pure-Go SQLite, no CGO required
@@ -579,7 +578,7 @@ func migrate(db *sql.DB) error {
 func pruneFactoryAnalytics(db *sql.DB) {
 	_, err := db.Exec(`DELETE FROM factory_analytics WHERE created_at < datetime('now', '-1 year')`)
 	if err != nil {
-		log.Printf("[db] factory analytics prune error: %v", err)
+		logf("[db] factory analytics prune error: %v", err)
 	}
 }
 

--- a/pkg/hub/external_storage.go
+++ b/pkg/hub/external_storage.go
@@ -668,7 +668,7 @@ func (s *Server) MigrateLegacyTemplates() error {
 			continue
 		}
 		migrated++
-		fmt.Printf("[hub] migrated template %q to external storage\n", name)
+		logf("[hub] migrated template %q to external storage", name)
 	}
 	if err := rows.Err(); err != nil {
 		return fmt.Errorf("migrate templates: %w", err)

--- a/pkg/hub/external_storage.go
+++ b/pkg/hub/external_storage.go
@@ -682,7 +682,7 @@ func (s *Server) MigrateLegacyTemplates() error {
 		if _, err := s.db.Exec(`DROP TABLE IF EXISTS hub_templates`); err != nil {
 			return fmt.Errorf("drop hub_templates: %w", err)
 		}
-		fmt.Println("[hub] dropped legacy hub_templates table")
+		logf("[hub] dropped legacy hub_templates table")
 	}
 	return nil
 }
@@ -711,9 +711,9 @@ func MigrateLegacyFactories(cfg *types.HubConfig) ([]string, error) {
 		return migrated, fmt.Errorf("strip factories from hub.yaml: %w", err)
 	}
 	if len(migrated) > 0 {
-		fmt.Println("[hub] stripped migrated factories from hub.yaml")
+		logf("[hub] stripped migrated factories from hub.yaml")
 	} else {
-		fmt.Println("[hub] no inline factories to migrate — cleared factories from hub.yaml")
+		logf("[hub] no inline factories to migrate — cleared factories from hub.yaml")
 	}
 	return migrated, nil
 }

--- a/pkg/hub/external_webhook.go
+++ b/pkg/hub/external_webhook.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"os"
 	"path"
@@ -122,7 +121,7 @@ func (s *Server) handleExternalWebhook(w http.ResponseWriter, r *http.Request) {
 			} `json:"sender"`
 		}
 		if err := json.Unmarshal(body, &ghReleasePayload); err != nil {
-			log.Printf("[external-webhook] failed to parse release payload: %v", err)
+			logfCtx(r.Context(), "[external-webhook] failed to parse release payload: %v", err)
 			http.Error(w, "invalid payload", http.StatusBadRequest)
 			return
 		}
@@ -131,26 +130,26 @@ func (s *Server) handleExternalWebhook(w http.ResponseWriter, r *http.Request) {
 		payload.Release = &ghReleasePayload.Release
 		payload.Repository = ghReleasePayload.Repository
 		payload.Sender = ghReleasePayload.Sender
-		log.Printf("[external-webhook] release event: action=%q repo=%q tag=%q",
+		logfCtx(r.Context(), "[external-webhook] release event: action=%q repo=%q tag=%q",
 			ghReleasePayload.Action, ghReleasePayload.Repository.FullName, ghReleasePayload.Release.TagName)
 
 	case "ping":
-		log.Printf("[external-webhook] ping received — webhook configured correctly")
+		logfCtx(r.Context(), "[external-webhook] ping received — webhook configured correctly")
 		w.WriteHeader(http.StatusOK)
 		return
 
 	case "":
 		// Generic webhook - try to parse as our standard payload format
 		if err := json.Unmarshal(body, &payload); err != nil {
-			log.Printf("[external-webhook] failed to parse generic payload: %v", err)
+			logfCtx(r.Context(), "[external-webhook] failed to parse generic payload: %v", err)
 			http.Error(w, "invalid payload", http.StatusBadRequest)
 			return
 		}
-		log.Printf("[external-webhook] generic event: type=%q repo=%q",
+		logfCtx(r.Context(), "[external-webhook] generic event: type=%q repo=%q",
 			payload.EventType, payload.Repository.FullName)
 
 	default:
-		log.Printf("[external-webhook] unsupported event type %q — ignored", event)
+		logfCtx(r.Context(), "[external-webhook] unsupported event type %q — ignored", event)
 		w.WriteHeader(http.StatusOK)
 		return
 	}
@@ -163,7 +162,7 @@ func (s *Server) handleExternalWebhook(w http.ResponseWriter, r *http.Request) {
 	if deliveryID != "" {
 		fingerprint := fmt.Sprintf("external:%s:%s:%s", deliveryID, payload.Repository.FullName, payload.EventType)
 		if s.isDuplicateWebhook(fingerprint) {
-			log.Printf("[external-webhook] dedup: skipping duplicate delivery %s", deliveryID)
+			logfCtx(r.Context(), "[external-webhook] dedup: skipping duplicate delivery %s", deliveryID)
 			w.WriteHeader(http.StatusOK)
 			return
 		}
@@ -209,7 +208,7 @@ func (s *Server) processExternalEvent(payload externalWebhookPayload, body []byt
 		eventType = payload.Action
 	}
 
-	log.Printf("[external-webhook] processing event: type=%q repo=%q — checking %d factories",
+	logf("[external-webhook] processing event: type=%q repo=%q — checking %d factories",
 		eventType, repoFullName, len(factories))
 
 	for _, factory := range factories {
@@ -217,15 +216,15 @@ func (s *Server) processExternalEvent(payload externalWebhookPayload, body []byt
 			continue
 		}
 		if factory.Enabled != nil && !*factory.Enabled {
-			log.Printf("[external-webhook] factory %q: skipped (disabled)", factory.Name)
+			logf("[external-webhook] factory %q: skipped (disabled)", factory.Name)
 			continue
 		}
 		if factory.ExternalTrigger == nil {
-			log.Printf("[external-webhook] factory %q: skipped (no external_trigger configured)", factory.Name)
+			logf("[external-webhook] factory %q: skipped (no external_trigger configured)", factory.Name)
 			continue
 		}
 		if !s.validateExternalSignatureForFactory(factory, body, sig) {
-			log.Printf("[external-webhook] factory %q: skipped (signature mismatch)", factory.Name)
+			logf("[external-webhook] factory %q: skipped (signature mismatch)", factory.Name)
 			continue
 		}
 
@@ -238,7 +237,7 @@ func (s *Server) processExternalEvent(payload externalWebhookPayload, body []byt
 				// Only trigger on actual releases, not drafts
 				// "created" fires when a draft is saved - exclude it to avoid premature triggers
 				if eventType != "released" && eventType != "published" {
-					log.Printf("[external-webhook] factory %q: skipped (event type %q not a published release)",
+					logf("[external-webhook] factory %q: skipped (event type %q not a published release)",
 						factory.Name, eventType)
 					continue
 				}
@@ -246,7 +245,7 @@ func (s *Server) processExternalEvent(payload externalWebhookPayload, body []byt
 				// Accept any event type for generic webhooks
 			default:
 				// Unknown source type - skip
-				log.Printf("[external-webhook] factory %q: skipped (unknown source %q)",
+				logf("[external-webhook] factory %q: skipped (unknown source %q)",
 					factory.Name, trigger.Source)
 				continue
 			}
@@ -258,14 +257,14 @@ func (s *Server) processExternalEvent(payload externalWebhookPayload, body []byt
 
 			// Repository filter
 			if f.Repository != "" && !strings.EqualFold(f.Repository, repoFullName) {
-				log.Printf("[external-webhook] factory %q: skipped (repo mismatch: want %q, got %q)",
+				logf("[external-webhook] factory %q: skipped (repo mismatch: want %q, got %q)",
 					factory.Name, f.Repository, repoFullName)
 				continue
 			}
 
 			// Event type filter
 			if f.EventType != "" && !strings.EqualFold(f.EventType, eventType) {
-				log.Printf("[external-webhook] factory %q: skipped (event type mismatch: want %q, got %q)",
+				logf("[external-webhook] factory %q: skipped (event type mismatch: want %q, got %q)",
 					factory.Name, f.EventType, eventType)
 				continue
 			}
@@ -273,7 +272,7 @@ func (s *Server) processExternalEvent(payload externalWebhookPayload, body []byt
 			// Tag pattern filter (for releases)
 			if f.TagPattern != "" && payload.Release != nil {
 				if !matchGlob(f.TagPattern, payload.Release.TagName) {
-					log.Printf("[external-webhook] factory %q: skipped (tag pattern mismatch: want %q, got %q)",
+					logf("[external-webhook] factory %q: skipped (tag pattern mismatch: want %q, got %q)",
 						factory.Name, f.TagPattern, payload.Release.TagName)
 					continue
 				}
@@ -297,14 +296,14 @@ func (s *Server) processExternalFactoryTrigger(factory *types.FactoryConfig, pay
 		"event_type": eventType,
 	})
 	if err != nil {
-		log.Printf("[external-webhook] factory %q: failed to claim trigger for %s: %v",
+		logf("[external-webhook] factory %q: failed to claim trigger for %s: %v",
 			factory.Name, triggerKey, err)
 		s.logFactoryEvent(factory.Name, triggerKey, fmt.Sprintf("External event: %s", eventType),
 			"", eventType, "error", "", err.Error())
 		return
 	}
 	if !claimed {
-		log.Printf("[external-webhook] factory %q: trigger %s already claimed — treating as idempotent success",
+		logf("[external-webhook] factory %q: trigger %s already claimed — treating as idempotent success",
 			factory.Name, triggerKey)
 		return
 	}
@@ -316,11 +315,11 @@ func (s *Server) processExternalFactoryTrigger(factory *types.FactoryConfig, pay
 	}()
 
 	// Create claw
-	log.Printf("[external-webhook] factory %q: creating claw for %s (event=%s)",
+	logf("[external-webhook] factory %q: creating claw for %s (event=%s)",
 		factory.Name, triggerKey, eventType)
 	clawID, err := s.createClawForExternalEvent(factory, payload, triggerKey)
 	if err != nil {
-		log.Printf("[external-webhook] factory %q: failed to create claw for %s: %v",
+		logf("[external-webhook] factory %q: failed to create claw for %s: %v",
 			factory.Name, triggerKey, err)
 		s.logFactoryEvent(factory.Name, triggerKey, fmt.Sprintf("External event: %s", eventType),
 			"", eventType, "error", "", err.Error())
@@ -332,7 +331,7 @@ func (s *Server) processExternalFactoryTrigger(factory *types.FactoryConfig, pay
 		if s.cronScheduler != nil {
 			s.cronScheduler.finishRunByClawID(clawID, "failed", err.Error())
 		}
-		log.Printf("[external-webhook] factory %q: failed to complete trigger for %s: %v",
+		logf("[external-webhook] factory %q: failed to complete trigger for %s: %v",
 			factory.Name, triggerKey, err)
 		s.logFactoryEvent(factory.Name, triggerKey, fmt.Sprintf("External event: %s", eventType),
 			"", eventType, "error", "", err.Error())
@@ -488,13 +487,13 @@ func (s *Server) createClawForExternalEvent(factory *types.FactoryConfig, payloa
 
 	// Resolve and inject template-requested secrets
 	if tmplCfg != nil && len(tmplCfg.Secrets) > 0 {
-		log.Printf("[factory:%s] DEPRECATED: template %q uses 'secrets:' list — migrate to 'secret_refs:' map",
+		logf("[factory:%s] DEPRECATED: template %q uses 'secrets:' list — migrate to 'secret_refs:' map",
 			factory.Name, factory.Template)
 		for _, ref := range tmplCfg.Secrets {
 			val, envName, ok := resolveSecretRefLocal(integrations, ref, factory)
 			if ok {
 				env[envName] = val
-				log.Printf("[factory:%s] injected template secret %s as %s into claw env",
+				logf("[factory:%s] injected template secret %s as %s into claw env",
 					factory.Name, ref.Type, envName)
 			}
 		}
@@ -505,7 +504,7 @@ func (s *Server) createClawForExternalEvent(factory *types.FactoryConfig, payloa
 		for envName, secretRef := range tmplCfg.SecretRefs {
 			if val, ok := secrets[secretRef]; ok {
 				env[envName] = val
-				log.Printf("[factory:%s] injected template secret_ref %s as %s into claw env",
+				logf("[factory:%s] injected template secret_ref %s as %s into claw env",
 					factory.Name, secretRef, envName)
 			}
 		}
@@ -516,7 +515,7 @@ func (s *Server) createClawForExternalEvent(factory *types.FactoryConfig, payloa
 		for envName, secretRef := range factory.SecretRefs {
 			if val, ok := secrets[secretRef]; ok {
 				env[envName] = val
-				log.Printf("[factory:%s] injected factory secret_ref %s as %s into claw env",
+				logf("[factory:%s] injected factory secret_ref %s as %s into claw env",
 					factory.Name, secretRef, envName)
 			}
 		}
@@ -603,7 +602,7 @@ func (s *Server) createClawForExternalEvent(factory *types.FactoryConfig, payloa
 	isPending := false
 	if groupLimit > 0 && activeCount >= groupLimit {
 		isPending = true
-		log.Printf("[factory] concurrency limit reached for group %q (active=%d, limit=%d) — queueing claw for external trigger %s as pending",
+		logf("[factory] concurrency limit reached for group %q (active=%d, limit=%d) — queueing claw for external trigger %s as pending",
 			groupName, activeCount, groupLimit, triggerID)
 	}
 
@@ -625,7 +624,7 @@ func (s *Server) createClawForExternalEvent(factory *types.FactoryConfig, payloa
 		return "", fmt.Errorf("db insert: %w", err)
 	}
 
-	log.Printf("[factory] created claw %s (%s) for external trigger %s (status=%s)",
+	logf("[factory] created claw %s (%s) for external trigger %s (status=%s)",
 		clawName, clawID[:8], triggerID, initialStatus)
 	s.broadcastToUsers(tenantID, types.WSMessage{
 		Type:    "claw_status",
@@ -642,7 +641,7 @@ func (s *Server) createClawForExternalEvent(factory *types.FactoryConfig, payloa
 		var currentStatus string
 		_ = s.db.QueryRow(`SELECT status FROM claws WHERE id=?`, clawID).Scan(&currentStatus)
 		if currentStatus == "deleted" {
-			log.Printf("[factory] claw %s already deleted before provisioning, aborting", clawID[:8])
+			logf("[factory] claw %s already deleted before provisioning, aborting", clawID[:8])
 			return
 		}
 
@@ -682,7 +681,7 @@ func (s *Server) createClawForExternalEvent(factory *types.FactoryConfig, payloa
 			provErr = fmt.Errorf("unsupported provider: %s", provider)
 		}
 		if provErr != nil {
-			log.Printf("[factory] provision failed for %s: %v", clawID, provErr)
+			logf("[factory] provision failed for %s: %v", clawID, provErr)
 			s.stopAgentWithReason(clawID, fmt.Sprintf("Factory provision failed: %v", provErr), false)
 		}
 	}()

--- a/pkg/hub/factory_creator.go
+++ b/pkg/hub/factory_creator.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"strings"
 	"time"
@@ -59,7 +58,7 @@ func (s *Server) createClawFromFactory(factory *types.FactoryConfig, issueID str
 		var parseErr error
 		tmplCfg, parseErr = config.ParseTemplateConfig([]byte(cfgContent))
 		if parseErr != nil {
-			log.Printf("[factory:%s] warning: could not parse elasticclaw-config.yaml from template %q: %v", factory.Name, factory.Template, parseErr)
+			logf("[factory:%s] warning: could not parse elasticclaw-config.yaml from template %q: %v", factory.Name, factory.Template, parseErr)
 			tmplCfg = nil
 		}
 	}
@@ -149,13 +148,13 @@ func (s *Server) createClawFromFactory(factory *types.FactoryConfig, issueID str
 	// Resolve and inject template-requested secrets (deprecated list format)
 	resolvedSecrets := make(map[string]string)
 	if tmplCfg != nil && len(tmplCfg.Secrets) > 0 {
-		log.Printf("[factory:%s] DEPRECATED: template %q uses 'secrets:' list — migrate to 'secret_refs:' map", factory.Name, factory.Template)
+		logf("[factory:%s] DEPRECATED: template %q uses 'secrets:' list — migrate to 'secret_refs:' map", factory.Name, factory.Template)
 		for _, ref := range tmplCfg.Secrets {
 			val, envName, ok := s.resolveSecretRef(ref, factory)
 			if ok {
 				env[envName] = val
 				resolvedSecrets[envName] = val
-				log.Printf("[factory:%s] injected template secret %s as %s into claw env", factory.Name, ref.Type, envName)
+				logf("[factory:%s] injected template secret %s as %s into claw env", factory.Name, ref.Type, envName)
 			}
 		}
 	}
@@ -167,9 +166,9 @@ func (s *Server) createClawFromFactory(factory *types.FactoryConfig, issueID str
 			if val, ok := s.hubCfg.Secrets[secretRef]; ok {
 				env[envName] = val
 				resolvedSecrets[envName] = val
-				log.Printf("[factory:%s] injected template secret_ref %s as %s into claw env", factory.Name, secretRef, envName)
+				logf("[factory:%s] injected template secret_ref %s as %s into claw env", factory.Name, secretRef, envName)
 			} else {
-				log.Printf("[factory:%s] WARNING: template secret_ref %q not found in hub secrets", factory.Name, secretRef)
+				logf("[factory:%s] WARNING: template secret_ref %q not found in hub secrets", factory.Name, secretRef)
 			}
 		}
 	}
@@ -181,9 +180,9 @@ func (s *Server) createClawFromFactory(factory *types.FactoryConfig, issueID str
 			if val, ok := s.hubCfg.Secrets[secretRef]; ok {
 				env[envName] = val
 				resolvedSecrets[envName] = val
-				log.Printf("[factory:%s] injected factory secret_ref %s as %s into claw env", factory.Name, secretRef, envName)
+				logf("[factory:%s] injected factory secret_ref %s as %s into claw env", factory.Name, secretRef, envName)
 			} else {
-				log.Printf("[factory:%s] WARNING: secret_ref %q not found in hub secrets", factory.Name, secretRef)
+				logf("[factory:%s] WARNING: secret_ref %q not found in hub secrets", factory.Name, secretRef)
 			}
 		}
 	}
@@ -332,7 +331,7 @@ func (s *Server) createClawFromFactory(factory *types.FactoryConfig, issueID str
 	isPending := false
 	if groupLimit > 0 && activeCount >= groupLimit {
 		isPending = true
-		log.Printf("[factory] concurrency limit reached for group %q (active=%d, limit=%d) — queueing claw for factory %s as pending", groupName, activeCount, groupLimit, factory.Name)
+		logf("[factory] concurrency limit reached for group %q (active=%d, limit=%d) — queueing claw for factory %s as pending", groupName, activeCount, groupLimit, factory.Name)
 	}
 
 	// Insert claw record
@@ -393,13 +392,13 @@ func (s *Server) createClawFromFactory(factory *types.FactoryConfig, issueID str
 		EventKey:         "task_start:claw:" + clawID,
 	}); err != nil {
 		if _, cleanupErr := s.db.Exec(`DELETE FROM claws WHERE id=?`, clawID); cleanupErr != nil {
-			log.Printf("[factory] WARNING: failed to delete orphaned claw %s after task-run creation failure: %v", clawID[:8], cleanupErr)
+			logf("[factory] WARNING: failed to delete orphaned claw %s after task-run creation failure: %v", clawID[:8], cleanupErr)
 		}
 		go s.promotePendingClaws()
 		return "", false, fmt.Errorf("task run analytics: %w", err)
 	}
 
-	log.Printf("[factory] created claw %s (%s) for factory %s (status=%s, reason=%s)", clawName, clawID[:8], factory.Name, initialStatus, reason)
+	logf("[factory] created claw %s (%s) for factory %s (status=%s, reason=%s)", clawName, clawID[:8], factory.Name, initialStatus, reason)
 	s.broadcastToUsers(tenantID, types.WSMessage{
 		Type:    "claw_status",
 		Payload: map[string]string{"claw_id": clawID, "status": initialStatus},
@@ -415,7 +414,7 @@ func (s *Server) createClawFromFactory(factory *types.FactoryConfig, issueID str
 		var currentStatus string
 		_ = s.db.QueryRow(`SELECT status FROM claws WHERE id=?`, clawID).Scan(&currentStatus)
 		if currentStatus == "deleted" {
-			log.Printf("[factory] claw %s already deleted before provisioning, aborting", clawID[:8])
+			logf("[factory] claw %s already deleted before provisioning, aborting", clawID[:8])
 			return
 		}
 		ctx := context.Background()
@@ -454,7 +453,7 @@ func (s *Server) createClawFromFactory(factory *types.FactoryConfig, issueID str
 			provErr = fmt.Errorf("unsupported provider: %s", provider)
 		}
 		if provErr != nil {
-			log.Printf("[factory] provision failed for %s: %v", clawID, provErr)
+			logf("[factory] provision failed for %s: %v", clawID, provErr)
 			s.stopAgentWithReason(clawID, fmt.Sprintf("Factory provision failed: %v", provErr), false)
 		}
 	}()

--- a/pkg/hub/github_issues.go
+++ b/pkg/hub/github_issues.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"net/url"
 	"sort"
@@ -78,7 +77,7 @@ type githubIssueComment struct {
 
 func (s *Server) handleGitHubIssuesWebhook(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		log.Printf("[github-issues-webhook] %s %s → 405 method not allowed", r.Method, r.URL.Path)
+		logfCtx(r.Context(), "[github-issues-webhook] %s %s → 405 method not allowed", r.Method, r.URL.Path)
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
@@ -86,7 +85,7 @@ func (s *Server) handleGitHubIssuesWebhook(w http.ResponseWriter, r *http.Reques
 
 	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
 	if err != nil {
-		log.Printf("[github-issues-webhook] %s %s → 400 read error: %v", r.Method, r.URL.Path, err)
+		logfCtx(r.Context(), "[github-issues-webhook] %s %s → 400 read error: %v", r.Method, r.URL.Path, err)
 		http.Error(w, "read error", http.StatusBadRequest)
 		return
 	}
@@ -95,7 +94,7 @@ func (s *Server) handleGitHubIssuesWebhook(w http.ResponseWriter, r *http.Reques
 	sig := r.Header.Get("X-Hub-Signature-256")
 	reason := s.validateGitHubIssuesSignatureReason(workspaceName, body, sig)
 	if reason != "" {
-		log.Printf("[github-issues-webhook] %s %s → 401 %s (sig present=%v)", r.Method, r.URL.Path, reason, sig != "")
+		logfCtx(r.Context(), "[github-issues-webhook] %s %s → 401 %s (sig present=%v)", r.Method, r.URL.Path, reason, sig != "")
 		http.Error(w, "invalid signature", http.StatusUnauthorized)
 		return
 	}
@@ -116,7 +115,7 @@ func (s *Server) handleGitHubIssuesWebhook(w http.ResponseWriter, r *http.Reques
 	// Dedup: ignore duplicate webhook deliveries using GitHub's delivery ID
 	deliveryID := r.Header.Get("X-GitHub-Delivery")
 	if deliveryID != "" && s.isDuplicateWebhook("gh-issues:"+deliveryID) {
-		log.Printf("[github-issues-webhook] dedup: skipping duplicate delivery %s for issue #%d in %s", deliveryID, payload.Issue.Number, payload.Repository.FullName)
+		logfCtx(r.Context(), "[github-issues-webhook] dedup: skipping duplicate delivery %s for issue #%d in %s", deliveryID, payload.Issue.Number, payload.Repository.FullName)
 		w.WriteHeader(http.StatusOK)
 		return
 	}
@@ -181,7 +180,7 @@ func verifyGitHubHMAC(body []byte, sig, secret string) bool {
 
 func (s *Server) processGitHubIssuesEvent(workspaceName string, payload githubIssuesWebhookPayload) {
 	issueID := fmt.Sprintf("%s/%d", payload.Repository.FullName, payload.Issue.Number)
-	log.Printf("[github-issues-webhook] processing event: action=%q issue=%s title=%q sender=%q",
+	logf("[github-issues-webhook] processing event: action=%q issue=%s title=%q sender=%q",
 		payload.Action, issueID, payload.Issue.Title, payload.Sender.Login)
 
 	currentStatus := payload.Issue.State
@@ -205,7 +204,7 @@ func (s *Server) processGitHubIssuesEvent(workspaceName string, payload githubIs
 	for _, l := range payload.Issue.Labels {
 		issueLabels[strings.ToLower(l.Name)] = true
 	}
-	log.Printf("[github-issues-webhook] issue %s labels=%v assignee=%q currentStatus=%q previousStatus=%q",
+	logf("[github-issues-webhook] issue %s labels=%v assignee=%q currentStatus=%q previousStatus=%q",
 		issueID, func() []string {
 			out := make([]string, 0, len(issueLabels))
 			for k := range issueLabels {
@@ -229,7 +228,7 @@ func (s *Server) processGitHubIssuesEvent(workspaceName string, payload githubIs
 		if previousStatus == "" {
 			previousStatus = currentStatus
 		}
-		log.Printf("[github-issues-webhook] label '%s' added by %q — previousLabels=%v",
+		logf("[github-issues-webhook] label '%s' added by %q — previousLabels=%v",
 			payload.Label.Name, payload.Sender.Login, func() []string {
 				out := make([]string, 0, len(previousLabels))
 				for k := range previousLabels {
@@ -247,7 +246,7 @@ func (s *Server) processGitHubIssuesEvent(workspaceName string, payload githubIs
 
 	if workspaceName == "" {
 		if !s.processGitHubIssuesFactoryEvent(payload, issueID, currentStatus, issueLabels, assignee) {
-			log.Printf("[github-issues-webhook] no factory matched for issue %s", issueID)
+			logf("[github-issues-webhook] no factory matched for issue %s", issueID)
 		}
 		return
 	}
@@ -255,13 +254,13 @@ func (s *Server) processGitHubIssuesEvent(workspaceName string, payload githubIs
 	workflowWorkspaces, _ := loadExternalWorkflowsByIntegration("github-issues")
 	workflowWorkspaces = filterWorkflowWorkspacesByName(workflowWorkspaces, workspaceName)
 	if len(workflowWorkspaces) == 0 {
-		log.Printf("[github-issues-webhook] no workflows configured — nothing to do")
+		logf("[github-issues-webhook] no workflows configured — nothing to do")
 		return
 	}
-	log.Printf("[github-issues-webhook] checking %d workflow workspace(s)", len(workflowWorkspaces))
+	logf("[github-issues-webhook] checking %d workflow workspace(s)", len(workflowWorkspaces))
 
 	if !s.processGitHubIssuesWorkflowEvent(workflowWorkspaces, payload, issueID, issueTitle, currentStatus, previousStatus, previousLabels, issueLabels, assignee) {
-		log.Printf("[github-issues-webhook] no workflow matched for issue %s", issueID)
+		logf("[github-issues-webhook] no workflow matched for issue %s", issueID)
 	}
 }
 
@@ -320,12 +319,12 @@ func (s *Server) processGitHubIssuesFactoryEvent(payload githubIssuesWebhookPayl
 			}
 		}
 		matched = true
-		log.Printf("[factory:%s] GitHub issue %s matched factory trigger — creating claw", factory.Name, issueID)
+		logf("[factory:%s] GitHub issue %s matched factory trigger — creating claw", factory.Name, issueID)
 		if err := s.createClawForGitHubIssue(factory, payload, "github-issues webhook"); err != nil {
 			if isFactoryTriggerAlreadyClaimed(err) {
 				continue
 			}
-			log.Printf("[factory:%s] failed to create claw for issue %s: %v", factory.Name, issueID, err)
+			logf("[factory:%s] failed to create claw for issue %s: %v", factory.Name, issueID, err)
 			s.logFactoryEvent(factory.Name, issueID, payload.Issue.Title, "", currentStatus, "error", "", err.Error())
 		} else {
 			s.logFactoryEvent(factory.Name, issueID, payload.Issue.Title, "", currentStatus, "claw_created", "", "github-issues webhook")
@@ -385,12 +384,12 @@ func (s *Server) processGitHubIssuesWorkflowEvent(workspaces []*types.WorkspaceC
 				}
 			}
 			matched = true
-			log.Printf("[workflow:%s/%s] GitHub issue %s matched workflow trigger — creating claw", workspace.Name, workflow.Name, issueID)
+			logf("[workflow:%s/%s] GitHub issue %s matched workflow trigger — creating claw", workspace.Name, workflow.Name, issueID)
 			if _, _, err := s.createClawForGitHubIssueWorkflow(workspace, workflow, payload, "github-issues webhook"); err != nil {
 				if isFactoryTriggerAlreadyClaimed(err) {
 					continue
 				}
-				log.Printf("[workflow:%s/%s] failed to create claw for %s: %v", workspace.Name, workflow.Name, issueID, err)
+				logf("[workflow:%s/%s] failed to create claw for %s: %v", workspace.Name, workflow.Name, issueID, err)
 				s.notifyGitHubIssueWorkflowCreateFailure(workspace, workflow, payload, err)
 			}
 		}
@@ -404,7 +403,7 @@ func (s *Server) notifyGitHubIssueWorkflowCreateFailure(workspace *types.Workspa
 	}
 	token := s.resolveGitHubIssuesTokenForWorkflow(workspace.Name, workflow)
 	if token == "" {
-		log.Printf("[agent-failure-feedback] workflow %s/%s has no GitHub Issues token; skipping failure feedback", workspace.Name, workflow.Name)
+		logf("[agent-failure-feedback] workflow %s/%s has no GitHub Issues token; skipping failure feedback", workspace.Name, workflow.Name)
 		return
 	}
 	s.handleAgentFailureFeedback(agentFailureFeedback{
@@ -525,7 +524,7 @@ func (s *Server) createClawForGitHubIssueWorkflow(workspace *types.WorkspaceConf
 	var existing string
 	_ = s.db.QueryRow(`SELECT id FROM claws WHERE github_issue_id=? AND status NOT IN ('error','deleted') LIMIT 1`, issueID).Scan(&existing)
 	if existing != "" {
-		log.Printf("[workflow:%s/%s] GitHub issue %s already has active claw %s", workspace.Name, workflow.Name, issueID, existing[:8])
+		logf("[workflow:%s/%s] GitHub issue %s already has active claw %s", workspace.Name, workflow.Name, issueID, existing[:8])
 		return existing, false, nil
 	}
 
@@ -541,7 +540,7 @@ func (s *Server) createClawForGitHubIssueWorkflow(workspace *types.WorkspaceConf
 		return "", false, fmt.Errorf("claim workflow trigger: %w", err)
 	}
 	if !claimed {
-		log.Printf("[workflow:%s/%s] GitHub issue %s already has an active trigger claim", workspace.Name, workflow.Name, issueID)
+		logf("[workflow:%s/%s] GitHub issue %s already has an active trigger claim", workspace.Name, workflow.Name, issueID)
 		return "", false, errFactoryTriggerAlreadyClaimed
 	}
 	claimOpen := true
@@ -609,7 +608,7 @@ func (s *Server) createClawForGitHubIssue(factory *types.FactoryConfig, payload 
 	}
 	if !claimed {
 		if reason != "poll" {
-			log.Printf("[factory:%s] GitHub issue %s already has an active trigger claim — treating as idempotent success", factory.Name, issueID)
+			logf("[factory:%s] GitHub issue %s already has an active trigger claim — treating as idempotent success", factory.Name, issueID)
 		}
 		return errFactoryTriggerAlreadyClaimed
 	}
@@ -644,7 +643,7 @@ func (s *Server) createClawForGitHubIssue(factory *types.FactoryConfig, payload 
 		var parseErr error
 		tmplCfg, parseErr = config.ParseTemplateConfig([]byte(cfgContent))
 		if parseErr != nil {
-			log.Printf("[factory:%s] warning: elasticclaw-config.yaml parse error: %v", factory.Name, parseErr)
+			logf("[factory:%s] warning: elasticclaw-config.yaml parse error: %v", factory.Name, parseErr)
 			tmplCfg = nil
 		}
 	}
@@ -697,15 +696,15 @@ func (s *Server) createClawForGitHubIssue(factory *types.FactoryConfig, payload 
 	// Resolve and inject template-requested secrets
 	resolvedSecrets := make(map[string]string)
 	if tmplCfg != nil && len(tmplCfg.Secrets) > 0 {
-		log.Printf("[factory:%s] DEPRECATED: template %q uses 'secrets:' list — migrate to 'secret_refs:' map", factory.Name, factory.Template)
+		logf("[factory:%s] DEPRECATED: template %q uses 'secrets:' list — migrate to 'secret_refs:' map", factory.Name, factory.Template)
 		for _, ref := range tmplCfg.Secrets {
 			secretVal, envName, ok := s.resolveSecretRef(ref, factory)
 			if ok {
 				env[envName] = secretVal
 				resolvedSecrets[envName] = secretVal
-				log.Printf("[factory:%s] injected template secret %s as %s into claw env", factory.Name, ref.Type, envName)
+				logf("[factory:%s] injected template secret %s as %s into claw env", factory.Name, ref.Type, envName)
 			} else {
-				log.Printf("[factory:%s] warning: requested secret (type=%s name=%s workspace=%s) not found", factory.Name, ref.Type, ref.Name, ref.Workspace)
+				logf("[factory:%s] warning: requested secret (type=%s name=%s workspace=%s) not found", factory.Name, ref.Type, ref.Name, ref.Workspace)
 			}
 		}
 	}
@@ -716,9 +715,9 @@ func (s *Server) createClawForGitHubIssue(factory *types.FactoryConfig, payload 
 			if val, ok := s.hubCfg.Secrets[secretRef]; ok {
 				env[envName] = val
 				resolvedSecrets[envName] = val
-				log.Printf("[factory:%s] injected template secret_ref %s as %s into claw env", factory.Name, secretRef, envName)
+				logf("[factory:%s] injected template secret_ref %s as %s into claw env", factory.Name, secretRef, envName)
 			} else {
-				log.Printf("[factory:%s] WARNING: template secret_ref %q not found in hub secrets", factory.Name, secretRef)
+				logf("[factory:%s] WARNING: template secret_ref %q not found in hub secrets", factory.Name, secretRef)
 			}
 		}
 	}
@@ -729,9 +728,9 @@ func (s *Server) createClawForGitHubIssue(factory *types.FactoryConfig, payload 
 			if val, ok := s.hubCfg.Secrets[secretRef]; ok {
 				env[envName] = val
 				resolvedSecrets[envName] = val
-				log.Printf("[factory:%s] injected factory secret_ref %s as %s into claw env", factory.Name, secretRef, envName)
+				logf("[factory:%s] injected factory secret_ref %s as %s into claw env", factory.Name, secretRef, envName)
 			} else {
-				log.Printf("[factory:%s] WARNING: secret_ref %q not found in hub secrets", factory.Name, secretRef)
+				logf("[factory:%s] WARNING: secret_ref %q not found in hub secrets", factory.Name, secretRef)
 			}
 		}
 	}
@@ -837,7 +836,7 @@ func (s *Server) createClawForGitHubIssue(factory *types.FactoryConfig, payload 
 	isPending := false
 	if groupLimit > 0 && activeCount >= groupLimit {
 		isPending = true
-		log.Printf("[factory] concurrency limit reached for group %q (active=%d, limit=%d) — queueing claw for GitHub issue %s as pending", groupName, activeCount, groupLimit, issueID)
+		logf("[factory] concurrency limit reached for group %q (active=%d, limit=%d) — queueing claw for GitHub issue %s as pending", groupName, activeCount, groupLimit, issueID)
 	}
 
 	// Insert claw record
@@ -873,7 +872,7 @@ func (s *Server) createClawForGitHubIssue(factory *types.FactoryConfig, payload 
 	}
 	claimOpen = false
 
-	log.Printf("[factory] created claw %s (%s) for GitHub issue %s (status=%s, reason=%s)", clawName, clawID[:8], issueID, initialStatus, reason)
+	logf("[factory] created claw %s (%s) for GitHub issue %s (status=%s, reason=%s)", clawName, clawID[:8], issueID, initialStatus, reason)
 	// Notify connected dashboards immediately so the card appears
 	s.broadcastToUsers(tenantID, types.WSMessage{
 		Type:    "claw_status",
@@ -896,9 +895,9 @@ func (s *Server) createClawForGitHubIssue(factory *types.FactoryConfig, payload 
 						base = "https://api.github.com"
 					}
 					if err := moveGitHubIssue(ghToken, repo, issueNum, factory.WorkingStatus, base); err != nil {
-						log.Printf("[factory] failed to move GitHub issue %s to working status '%s': %v", issueID, factory.WorkingStatus, err)
+						logf("[factory] failed to move GitHub issue %s to working status '%s': %v", issueID, factory.WorkingStatus, err)
 					} else {
-						log.Printf("[factory] moved GitHub issue %s to working status '%s'", issueID, factory.WorkingStatus)
+						logf("[factory] moved GitHub issue %s to working status '%s'", issueID, factory.WorkingStatus)
 					}
 				}
 			}
@@ -915,7 +914,7 @@ func (s *Server) createClawForGitHubIssue(factory *types.FactoryConfig, payload 
 		var currentStatus string
 		_ = s.db.QueryRow(`SELECT status FROM claws WHERE id=?`, clawID).Scan(&currentStatus)
 		if currentStatus == "deleted" {
-			log.Printf("[factory] claw %s already deleted before provisioning, aborting", clawID[:8])
+			logf("[factory] claw %s already deleted before provisioning, aborting", clawID[:8])
 			return
 		}
 		ctx := context.Background()
@@ -950,11 +949,11 @@ func (s *Server) createClawForGitHubIssue(factory *types.FactoryConfig, payload 
 		}
 
 		if provErr != nil {
-			log.Printf("[factory] claw %s provision failed: %v", clawID[:8], provErr)
+			logf("[factory] claw %s provision failed: %v", clawID[:8], provErr)
 			s.stopAgentWithReason(clawID, fmt.Sprintf("Factory provision failed: %v", provErr), false)
 			return
 		}
-		log.Printf("[factory] claw %s provisioned successfully", clawID[:8])
+		logf("[factory] claw %s provisioned successfully", clawID[:8])
 	}()
 
 	return nil
@@ -965,7 +964,7 @@ func (s *Server) terminateClawForGitHubIssue(issueID string) {
 	if err := s.db.QueryRow(`SELECT id, tenant_id FROM claws WHERE github_issue_id = ? AND status NOT IN ('error','deleted') LIMIT 1`, issueID).Scan(&clawID, &tenantID); err != nil {
 		return
 	}
-	log.Printf("[factory] terminating claw %s for GitHub issue %s", clawID[:8], issueID)
+	logf("[factory] terminating claw %s for GitHub issue %s", clawID[:8], issueID)
 
 	// Post a comment on the linked GitHub issue before terminating
 	factory := s.findFactoryForIssue(issueID)
@@ -978,9 +977,9 @@ func (s *Server) terminateClawForGitHubIssue(issueID string) {
 				var issueNum int
 				if _, err := fmt.Sscanf(parts[2], "%d", &issueNum); err == nil {
 					if err := commentGitHubIssue(token, repo, issueNum, "Agent stopped: issue left trigger status"); err != nil {
-						log.Printf("[factory] failed to comment GitHub issue %s: %v", issueID, err)
+						logf("[factory] failed to comment GitHub issue %s: %v", issueID, err)
 					} else {
-						log.Printf("[factory] commented GitHub issue %s", issueID)
+						logf("[factory] commented GitHub issue %s", issueID)
 					}
 				}
 			}
@@ -1033,7 +1032,7 @@ func (s *Server) buildGitHubIssuesContextWithComments(payload githubIssuesWebhoo
 	}
 	comments, err := fetchGitHubIssueComments(base, payload.Repository.FullName, payload.Issue.Number, token)
 	if err != nil {
-		log.Printf("[github-issues] failed to fetch comments for %s#%d: %v", payload.Repository.FullName, payload.Issue.Number, err)
+		logf("[github-issues] failed to fetch comments for %s#%d: %v", payload.Repository.FullName, payload.Issue.Number, err)
 		return buildGitHubIssuesContext(payload, nil, "Issue comments could not be loaded automatically. Review the issue URL for additional context.")
 	}
 	return buildGitHubIssuesContext(payload, comments, "")
@@ -1245,7 +1244,7 @@ func (s *Server) closeGitHubIssueForClaw(clawID string) {
 		clawID,
 	).Scan(&issueURL)
 	if err != nil || issueURL == "" {
-		log.Printf("[pipeline] close_issue: no tracked GitHub issue for claw %s", clawID[:8])
+		logf("[pipeline] close_issue: no tracked GitHub issue for claw %s", clawID[:8])
 		return
 	}
 
@@ -1253,7 +1252,7 @@ func (s *Server) closeGitHubIssueForClaw(clawID string) {
 	// URL format: https://github.com/owner/repo/issues/123
 	parts := strings.Split(issueURL, "/")
 	if len(parts) < 2 {
-		log.Printf("[pipeline] close_issue: invalid issue URL %q", issueURL)
+		logf("[pipeline] close_issue: invalid issue URL %q", issueURL)
 		return
 	}
 	// Extract owner/repo from URL
@@ -1266,7 +1265,7 @@ func (s *Server) closeGitHubIssueForClaw(clawID string) {
 		}
 	}
 	if owner == "" || repo == "" {
-		log.Printf("[pipeline] close_issue: could not parse owner/repo from %q", issueURL)
+		logf("[pipeline] close_issue: could not parse owner/repo from %q", issueURL)
 		return
 	}
 	repoFullName := owner + "/" + repo
@@ -1275,14 +1274,14 @@ func (s *Server) closeGitHubIssueForClaw(clawID string) {
 	var issueNumber int
 	fmt.Sscanf(parts[len(parts)-1], "%d", &issueNumber)
 	if issueNumber == 0 {
-		log.Printf("[pipeline] close_issue: could not parse issue number from %q", issueURL)
+		logf("[pipeline] close_issue: could not parse issue number from %q", issueURL)
 		return
 	}
 
 	// Find token for this repo
 	token := s.resolveGitHubIssuesTokenForRepo(repoFullName)
 	if token == "" {
-		log.Printf("[pipeline] close_issue: no GitHub token for repo %s", repoFullName)
+		logf("[pipeline] close_issue: no GitHub token for repo %s", repoFullName)
 		s.injectHubMessageByID(clawID, fmt.Sprintf("[hub] close_issue: no GitHub token available for %s — cannot close issue.", repoFullName))
 		return
 	}
@@ -1295,12 +1294,12 @@ func (s *Server) closeGitHubIssueForClaw(clawID string) {
 	})
 	_, err = githubAPIPostWithBase(baseURL, fmt.Sprintf("repos/%s/issues/%d", repoFullName, issueNumber), token, "PATCH", body)
 	if err != nil {
-		log.Printf("[pipeline] close_issue: failed to close issue %s#%d: %v", repoFullName, issueNumber, err)
+		logf("[pipeline] close_issue: failed to close issue %s#%d: %v", repoFullName, issueNumber, err)
 		s.injectHubMessageByID(clawID, fmt.Sprintf("[hub] close_issue: failed to close issue #%d: %v", issueNumber, err))
 		return
 	}
 
-	log.Printf("[pipeline] close_issue: closed issue %s#%d", repoFullName, issueNumber)
+	logf("[pipeline] close_issue: closed issue %s#%d", repoFullName, issueNumber)
 	s.injectHubMessageByID(clawID, fmt.Sprintf("[hub] Closed GitHub issue #%d in %s.", issueNumber, repoFullName))
 }
 

--- a/pkg/hub/github_webhook.go
+++ b/pkg/hub/github_webhook.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"os"
 	"strings"
@@ -63,7 +62,7 @@ func (s *Server) handleGitHubWebhook(w http.ResponseWriter, r *http.Request) {
 	// Verify HMAC-SHA256 signature against any matching factory webhook secret.
 	sig := r.Header.Get("X-Hub-Signature-256")
 	if !s.validateGitHubSignature(body, sig) {
-		log.Printf("[github-webhook] signature validation failed for event=%q — check webhook secret", event)
+		logfCtx(r.Context(), "[github-webhook] signature validation failed for event=%q — check webhook secret", event)
 		http.Error(w, "invalid signature", http.StatusUnauthorized)
 		return
 	}
@@ -77,65 +76,65 @@ func (s *Server) handleGitHubWebhook(w http.ResponseWriter, r *http.Request) {
 	case "issues":
 		var payload githubIssuesWebhookPayload
 		if err := json.Unmarshal(body, &payload); err != nil {
-			log.Printf("[github-webhook] failed to parse issues payload: %v", err)
+			logfCtx(r.Context(), "[github-webhook] failed to parse issues payload: %v", err)
 			http.Error(w, "invalid payload", http.StatusBadRequest)
 			return
 		}
-		log.Printf("[github-webhook] issues action=%q repo=%q issue=#%d author=%q",
+		logfCtx(r.Context(), "[github-webhook] issues action=%q repo=%q issue=#%d author=%q",
 			payload.Action, payload.Repository.FullName, payload.Issue.Number, payload.Issue.User.Login)
 		go s.processGitHubIssueEvent(payload)
 	case "pull_request":
 		var payload githubPRPayload
 		if err := json.Unmarshal(body, &payload); err != nil {
-			log.Printf("[github-webhook] failed to parse pull_request payload: %v", err)
+			logfCtx(r.Context(), "[github-webhook] failed to parse pull_request payload: %v", err)
 			http.Error(w, "invalid payload", http.StatusBadRequest)
 			return
 		}
-		log.Printf("[github-webhook] pull_request action=%q repo=%q pr=#%d author=%q base=%q",
+		logfCtx(r.Context(), "[github-webhook] pull_request action=%q repo=%q pr=#%d author=%q base=%q",
 			payload.Action, payload.Repository.FullName, payload.Number,
 			payload.PullRequest.User.Login, payload.PullRequest.Base.Ref)
 		go s.processGitHubPREvent(payload)
 	case "pull_request_review_comment":
 		var payload githubPRReviewCommentPayload
 		if err := json.Unmarshal(body, &payload); err != nil {
-			log.Printf("[github-webhook] failed to parse pull_request_review_comment payload: %v", err)
+			logfCtx(r.Context(), "[github-webhook] failed to parse pull_request_review_comment payload: %v", err)
 			http.Error(w, "invalid payload", http.StatusBadRequest)
 			return
 		}
-		log.Printf("[github-webhook] pull_request_review_comment action=%q repo=%q pr=#%d author=%q",
+		logfCtx(r.Context(), "[github-webhook] pull_request_review_comment action=%q repo=%q pr=#%d author=%q",
 			payload.Action, payload.Repository.FullName, payload.PullRequest.Number, payload.Comment.User.Login)
 		go s.processGitHubPRReviewCommentEvent(payload)
 	case "pull_request_review":
 		var payload githubPRReviewPayload
 		if err := json.Unmarshal(body, &payload); err != nil {
-			log.Printf("[github-webhook] failed to parse pull_request_review payload: %v", err)
+			logfCtx(r.Context(), "[github-webhook] failed to parse pull_request_review payload: %v", err)
 			http.Error(w, "invalid payload", http.StatusBadRequest)
 			return
 		}
-		log.Printf("[github-webhook] pull_request_review action=%q state=%q repo=%q pr=#%d author=%q",
+		logfCtx(r.Context(), "[github-webhook] pull_request_review action=%q state=%q repo=%q pr=#%d author=%q",
 			payload.Action, payload.Review.State, payload.Repository.FullName, payload.PullRequest.Number, payload.Review.User.Login)
 		go s.processGitHubPRReviewEvent(payload)
 	case "issue_comment":
 		var payload githubIssueCommentPayload
 		if err := json.Unmarshal(body, &payload); err != nil {
-			log.Printf("[github-webhook] failed to parse issue_comment payload: %v", err)
+			logfCtx(r.Context(), "[github-webhook] failed to parse issue_comment payload: %v", err)
 			break
 		}
 		if payload.Issue.PullRequest.URL != "" {
 			// Comment on a pull request
-			log.Printf("[github-webhook] issue_comment action=%q repo=%q pr=#%d author=%q",
+			logfCtx(r.Context(), "[github-webhook] issue_comment action=%q repo=%q pr=#%d author=%q",
 				payload.Action, payload.Repository.FullName, payload.Issue.Number, payload.Comment.User.Login)
 			go s.processGitHubIssueCommentEvent(payload)
 		} else {
 			// Comment on a plain issue (not PR)
-			log.Printf("[github-webhook] issue_comment action=%q repo=%q issue=#%d author=%q",
+			logfCtx(r.Context(), "[github-webhook] issue_comment action=%q repo=%q issue=#%d author=%q",
 				payload.Action, payload.Repository.FullName, payload.Issue.Number, payload.Comment.User.Login)
 			go s.processGitHubIssueComment(payload)
 		}
 	case "ping":
-		log.Printf("[github-webhook] ping received — webhook configured correctly")
+		logfCtx(r.Context(), "[github-webhook] ping received — webhook configured correctly")
 	default:
-		log.Printf("[github-webhook] unsupported event type %q — ignored", event)
+		logfCtx(r.Context(), "[github-webhook] unsupported event type %q — ignored", event)
 	}
 
 	w.WriteHeader(http.StatusOK)
@@ -184,38 +183,38 @@ func (s *Server) processGitHubPREvent(payload githubPRPayload) {
 	factories := s.resolveFactories()
 
 	repoFullName := payload.Repository.FullName
-	log.Printf("[github-webhook] processing PR event: repo=%q action=%q — checking %d factories", repoFullName, payload.Action, len(factories))
+	logf("[github-webhook] processing PR event: repo=%q action=%q — checking %d factories", repoFullName, payload.Action, len(factories))
 
 	for _, factory := range factories {
 		if factory.Integration != "github" {
 			continue
 		}
 		if factory.Enabled != nil && !*factory.Enabled {
-			log.Printf("[github-webhook] factory %q: skipped (disabled)", factory.Name)
+			logf("[github-webhook] factory %q: skipped (disabled)", factory.Name)
 			continue
 		}
 		if factory.Trigger == nil {
-			log.Printf("[github-webhook] factory %q: skipped (no trigger configured)", factory.Name)
+			logf("[github-webhook] factory %q: skipped (no trigger configured)", factory.Name)
 			continue
 		}
 		if factory.Trigger.On != "pull_request" {
-			log.Printf("[github-webhook] factory %q: skipped (trigger.on=%q, not pull_request)", factory.Name, factory.Trigger.On)
+			logf("[github-webhook] factory %q: skipped (trigger.on=%q, not pull_request)", factory.Name, factory.Trigger.On)
 			continue
 		}
 		// Check repo match
 		if !githubRepoMatches(repoFullName, factory.Repos) {
-			log.Printf("[github-webhook] factory %q: skipped (repo %q not in %v)", factory.Name, repoFullName, factory.Repos)
+			logf("[github-webhook] factory %q: skipped (repo %q not in %v)", factory.Name, repoFullName, factory.Repos)
 			continue
 		}
 		// Check filter
 		if factory.Trigger.Filter != nil {
 			f := factory.Trigger.Filter
 			if f.Author != "" && !strings.EqualFold(f.Author, payload.PullRequest.User.Login) {
-				log.Printf("[github-webhook] factory %q: skipped (author mismatch: want %q, got %q)", factory.Name, f.Author, payload.PullRequest.User.Login)
+				logf("[github-webhook] factory %q: skipped (author mismatch: want %q, got %q)", factory.Name, f.Author, payload.PullRequest.User.Login)
 				continue
 			}
 			if f.BaseBranch != "" && !strings.EqualFold(f.BaseBranch, payload.PullRequest.Base.Ref) {
-				log.Printf("[github-webhook] factory %q: skipped (base_branch mismatch: want %q, got %q)", factory.Name, f.BaseBranch, payload.PullRequest.Base.Ref)
+				logf("[github-webhook] factory %q: skipped (base_branch mismatch: want %q, got %q)", factory.Name, f.BaseBranch, payload.PullRequest.Base.Ref)
 				continue
 			}
 		}
@@ -224,7 +223,7 @@ func (s *Server) processGitHubPREvent(payload githubPRPayload) {
 			continue
 		}
 		if !labelsAllowed(currentLabels, factory.Labels, factory.ExcludeLabels) {
-			log.Printf("[github-webhook] factory %q: skipped (PR backing issue labels did not match)", factory.Name)
+			logf("[github-webhook] factory %q: skipped (PR backing issue labels did not match)", factory.Name)
 			continue
 		}
 
@@ -238,7 +237,7 @@ func (s *Server) processGitHubPREvent(payload githubPRPayload) {
 				// Skip synchronize events triggered by the claw itself pushing commits.
 				// Only skip if the sender is our own GitHub App bot, not other bots (e.g. dependabot).
 				if payload.Action == "synchronize" && s.isOwnAppBot(payload.Sender.Login) {
-					log.Printf("[factory:%s] github PR #%d synchronize from own app bot %q — skipping", factory.Name, payload.Number, payload.Sender.Login)
+					logf("[factory:%s] github PR #%d synchronize from own app bot %q — skipping", factory.Name, payload.Number, payload.Sender.Login)
 					continue
 				}
 				// Only inject if the claw is connected and ready — otherwise the
@@ -249,7 +248,7 @@ func (s *Server) processGitHubPREvent(payload githubPRPayload) {
 				ready := connected && cc.gatewayReady
 				s.mu.RUnlock()
 				if !ready {
-					log.Printf("[factory:%s] github PR #%d action=%s — claw %s not ready yet, skipping inject", factory.Name, payload.Number, payload.Action, existingClawID[:8])
+					logf("[factory:%s] github PR #%d action=%s — claw %s not ready yet, skipping inject", factory.Name, payload.Number, payload.Action, existingClawID[:8])
 				} else {
 					msg := fmt.Sprintf("PR #%d update: %s.", payload.Number, payload.Action)
 					if payload.Action == "synchronize" {
@@ -257,19 +256,19 @@ func (s *Server) processGitHubPREvent(payload githubPRPayload) {
 					} else if payload.Action == "reopened" {
 						msg = fmt.Sprintf("PR #%d was reopened.", payload.Number)
 					}
-					log.Printf("[factory:%s] github PR #%d action=%s — injecting into claw %s", factory.Name, payload.Number, payload.Action, existingClawID[:8])
+					logf("[factory:%s] github PR #%d action=%s — injecting into claw %s", factory.Name, payload.Number, payload.Action, existingClawID[:8])
 					s.injectHubMessageByID(existingClawID, msg)
 				}
 			default:
-				log.Printf("[factory:%s] github PR #%d action=%s — claw exists, no action taken", factory.Name, payload.Number, payload.Action)
+				logf("[factory:%s] github PR #%d action=%s — claw exists, no action taken", factory.Name, payload.Number, payload.Action)
 			}
 			continue
 		}
 
 		// No existing claw — create one (regardless of action, first event wins)
-		log.Printf("[factory:%s] github PR #%d in %s (action=%s) — creating claw", factory.Name, payload.Number, repoFullName, payload.Action)
+		logf("[factory:%s] github PR #%d in %s (action=%s) — creating claw", factory.Name, payload.Number, repoFullName, payload.Action)
 		if err := s.createClawForGitHubPR(factory, payload, "github-pr webhook"); err != nil {
-			log.Printf("[factory:%s] failed to create claw for PR #%d: %v", factory.Name, payload.Number, err)
+			logf("[factory:%s] failed to create claw for PR #%d: %v", factory.Name, payload.Number, err)
 			s.logFactoryEvent(factory.Name, fmt.Sprintf("%s#%d", repoFullName, payload.Number),
 				payload.PullRequest.Title, "", payload.Action, "error", "", err.Error())
 		}
@@ -331,7 +330,7 @@ func (s *Server) processGitHubPRReviewCommentEvent(payload githubPRReviewComment
 	prURL := payload.PullRequest.HTMLURL
 	clawID := s.findClawForGitHubPR(prURL)
 	if clawID == "" {
-		log.Printf("[github-webhook] review_comment on PR #%d — no claw found for %s", payload.PullRequest.Number, prURL)
+		logf("[github-webhook] review_comment on PR #%d — no claw found for %s", payload.PullRequest.Number, prURL)
 		return
 	}
 	pr := clawPR{
@@ -353,7 +352,7 @@ func (s *Server) processGitHubPRReviewEvent(payload githubPRReviewPayload) {
 	prURL := payload.PullRequest.HTMLURL
 	clawID := s.findClawForGitHubPR(prURL)
 	if clawID == "" {
-		log.Printf("[github-webhook] review on PR #%d — no claw found for %s", payload.PullRequest.Number, prURL)
+		logf("[github-webhook] review on PR #%d — no claw found for %s", payload.PullRequest.Number, prURL)
 		return
 	}
 	pr := clawPR{
@@ -411,12 +410,12 @@ func (s *Server) processGitHubIssueComment(payload githubIssueCommentPayload) {
 
 	existingClawID := s.findClawForGitHubIssue(issueURL)
 	if existingClawID != "" {
-		log.Printf("[github-webhook] issue_comment on issue #%d — injecting into existing claw %s", payload.Issue.Number, existingClawID[:8])
+		logf("[github-webhook] issue_comment on issue #%d — injecting into existing claw %s", payload.Issue.Number, existingClawID[:8])
 		s.injectHubMessageByID(existingClawID, commentMsg)
 		return
 	}
 
-	log.Printf("[github-webhook] issue_comment on issue #%d — no claw found for %s", payload.Issue.Number, issueURL)
+	logf("[github-webhook] issue_comment on issue #%d — no claw found for %s", payload.Issue.Number, issueURL)
 }
 
 // processGitHubIssueCommentEvent handles issue_comment events on PRs.
@@ -445,7 +444,7 @@ func (s *Server) processGitHubIssueCommentEvent(payload githubIssueCommentPayloa
 	existingClawID := s.findClawForGitHubPR(prURL)
 	if existingClawID != "" {
 		// Inject the comment into the existing claw
-		log.Printf("[github-webhook] issue_comment on PR #%d — injecting into existing claw %s", prNumber, existingClawID[:8])
+		logf("[github-webhook] issue_comment on PR #%d — injecting into existing claw %s", prNumber, existingClawID[:8])
 		s.injectHubMessageByID(existingClawID, commentMsg)
 		return
 	}
@@ -475,7 +474,7 @@ func (s *Server) processGitHubIssueCommentEvent(payload githubIssueCommentPayloa
 		}
 		data, err := githubAPIWithBase(ghBase, fmt.Sprintf("repos/%s/pulls/%d", repoFullName, prNumber), token)
 		if err != nil {
-			log.Printf("[github-webhook] issue_comment: failed to fetch PR %s#%d: %v", repoFullName, prNumber, err)
+			logf("[github-webhook] issue_comment: failed to fetch PR %s#%d: %v", repoFullName, prNumber, err)
 			continue
 		}
 		var prPayload githubPRPayload
@@ -502,12 +501,12 @@ func (s *Server) processGitHubIssueCommentEvent(payload githubIssueCommentPayloa
 			f := factory.Trigger.Filter
 			// Author filter: check PR author, not commenter
 			if f.Author != "" && !strings.EqualFold(f.Author, prPayload.PullRequest.User.Login) {
-				log.Printf("[github-webhook] factory %q: issue_comment skipped (PR author mismatch: want %q, got %q)",
+				logf("[github-webhook] factory %q: issue_comment skipped (PR author mismatch: want %q, got %q)",
 					factory.Name, f.Author, prPayload.PullRequest.User.Login)
 				continue
 			}
 			if f.BaseBranch != "" && !strings.EqualFold(f.BaseBranch, prPayload.PullRequest.Base.Ref) {
-				log.Printf("[github-webhook] factory %q: issue_comment skipped (base_branch mismatch: want %q, got %q)",
+				logf("[github-webhook] factory %q: issue_comment skipped (base_branch mismatch: want %q, got %q)",
 					factory.Name, f.BaseBranch, prPayload.PullRequest.Base.Ref)
 				continue
 			}
@@ -517,17 +516,17 @@ func (s *Server) processGitHubIssueCommentEvent(payload githubIssueCommentPayloa
 			continue
 		}
 		if !labelsAllowed(currentLabels, factory.Labels, factory.ExcludeLabels) {
-			log.Printf("[github-webhook] factory %q: issue_comment skipped (PR backing issue labels did not match)", factory.Name)
+			logf("[github-webhook] factory %q: issue_comment skipped (PR backing issue labels did not match)", factory.Name)
 			continue
 		}
-		log.Printf("[factory:%s] issue_comment triggered claw creation for PR %s#%d", factory.Name, repoFullName, prNumber)
+		logf("[factory:%s] issue_comment triggered claw creation for PR %s#%d", factory.Name, repoFullName, prNumber)
 		if err := s.createClawForGitHubPR(factory, prPayload, "github-pr webhook (issue_comment)"); err != nil {
-			log.Printf("[factory:%s] failed to create claw for PR #%d: %v", factory.Name, prNumber, err)
+			logf("[factory:%s] failed to create claw for PR #%d: %v", factory.Name, prNumber, err)
 			continue // let next matching factory try
 		}
 		createdClawID := s.findClawForGitHubPR(prPayload.PullRequest.HTMLURL)
 		if createdClawID != "" {
-			log.Printf("[github-webhook] issue_comment on PR #%d — injecting into newly created claw %s", prNumber, createdClawID[:8])
+			logf("[github-webhook] issue_comment on PR #%d — injecting into newly created claw %s", prNumber, createdClawID[:8])
 			s.injectHubMessageByID(createdClawID, commentMsg)
 		}
 		break // success — one factory match is enough
@@ -563,15 +562,15 @@ func (s *Server) processGitHubIssueEvent(payload githubIssuesWebhookPayload) {
 			continue
 		}
 		if !labelsAllowed(currentLabels, factory.Labels, factory.ExcludeLabels) {
-			log.Printf("[github-webhook] factory %q: skipped issue %s (labels did not match)", factory.Name, issueID)
+			logf("[github-webhook] factory %q: skipped issue %s (labels did not match)", factory.Name, issueID)
 			continue
 		}
-		log.Printf("[factory:%s] github issue %s (action=%s) — creating claw", factory.Name, issueID, payload.Action)
+		logf("[factory:%s] github issue %s (action=%s) — creating claw", factory.Name, issueID, payload.Action)
 		if err := s.createClawForGitHubIssue(factory, payload, "github-issue webhook"); err != nil {
 			if isFactoryTriggerAlreadyClaimed(err) {
 				continue
 			}
-			log.Printf("[factory:%s] failed to create claw for issue %s: %v", factory.Name, issueID, err)
+			logf("[factory:%s] failed to create claw for issue %s: %v", factory.Name, issueID, err)
 			s.logFactoryEvent(factory.Name, issueID, payload.Issue.Title, "", payload.Action, "error", "", err.Error())
 		} else {
 			s.logFactoryEvent(factory.Name, issueID, payload.Issue.Title, "", payload.Action, "claw_created", "", "github-issue webhook")
@@ -585,7 +584,7 @@ func (s *Server) githubFactoryPRLabels(factory *types.FactoryConfig, repo string
 	}
 	labels, err := s.fetchGitHubIssueLabelsForFactory(factory, repo, prNumber)
 	if err != nil {
-		log.Printf("[github-webhook] factory %q: skipping PR %s#%d because backing issue labels could not be fetched: %v", factory.Name, repo, prNumber, err)
+		logf("[github-webhook] factory %q: skipping PR %s#%d because backing issue labels could not be fetched: %v", factory.Name, repo, prNumber, err)
 		return nil, false
 	}
 	return labels, true
@@ -761,14 +760,14 @@ func (s *Server) createClawForGitHubPR(factory *types.FactoryConfig, pr githubPR
 
 	// Resolve and inject template-requested secrets (typed refs + legacy)
 	if tmplCfg != nil && len(tmplCfg.Secrets) > 0 {
-		log.Printf("[factory:%s] DEPRECATED: template %q uses 'secrets:' list — migrate to 'secret_refs:' map", factory.Name, factory.Template)
+		logf("[factory:%s] DEPRECATED: template %q uses 'secrets:' list — migrate to 'secret_refs:' map", factory.Name, factory.Template)
 		for _, ref := range tmplCfg.Secrets {
 			val, envName, ok := s.resolveSecretRef(ref, factory)
 			if ok {
 				env[envName] = val
-				log.Printf("[factory:%s] injected template secret %s as %s into claw env", factory.Name, ref.Type, envName)
+				logf("[factory:%s] injected template secret %s as %s into claw env", factory.Name, ref.Type, envName)
 			} else {
-				log.Printf("[factory:%s] warning: requested secret (type=%s name=%s workspace=%s) not found", factory.Name, ref.Type, ref.Name, ref.Workspace)
+				logf("[factory:%s] warning: requested secret (type=%s name=%s workspace=%s) not found", factory.Name, ref.Type, ref.Name, ref.Workspace)
 			}
 		}
 	}
@@ -778,9 +777,9 @@ func (s *Server) createClawForGitHubPR(factory *types.FactoryConfig, pr githubPR
 		for envName, secretRef := range tmplCfg.SecretRefs {
 			if val, ok := s.hubCfg.Secrets[secretRef]; ok {
 				env[envName] = val
-				log.Printf("[factory:%s] injected template secret_ref %s as %s into claw env", factory.Name, secretRef, envName)
+				logf("[factory:%s] injected template secret_ref %s as %s into claw env", factory.Name, secretRef, envName)
 			} else {
-				log.Printf("[factory:%s] WARNING: template secret_ref %q not found in hub secrets", factory.Name, secretRef)
+				logf("[factory:%s] WARNING: template secret_ref %q not found in hub secrets", factory.Name, secretRef)
 			}
 		}
 	}
@@ -790,9 +789,9 @@ func (s *Server) createClawForGitHubPR(factory *types.FactoryConfig, pr githubPR
 		for envName, secretRef := range factory.SecretRefs {
 			if val, ok := s.hubCfg.Secrets[secretRef]; ok {
 				env[envName] = val
-				log.Printf("[factory:%s] injected factory secret_ref %s as %s into claw env", factory.Name, secretRef, envName)
+				logf("[factory:%s] injected factory secret_ref %s as %s into claw env", factory.Name, secretRef, envName)
 			} else {
-				log.Printf("[factory:%s] WARNING: secret_ref %q not found in hub secrets", factory.Name, secretRef)
+				logf("[factory:%s] WARNING: secret_ref %q not found in hub secrets", factory.Name, secretRef)
 			}
 		}
 	}
@@ -883,7 +882,7 @@ func (s *Server) createClawForGitHubPR(factory *types.FactoryConfig, pr githubPR
 	isPending := false
 	if groupLimit > 0 && activeCount >= groupLimit {
 		isPending = true
-		log.Printf("[factory] concurrency limit reached for group %q (active=%d, limit=%d) — queueing claw for GitHub PR %s#%d as pending", groupName, activeCount, groupLimit, repoFullName, prNumber)
+		logf("[factory] concurrency limit reached for group %q (active=%d, limit=%d) — queueing claw for GitHub PR %s#%d as pending", groupName, activeCount, groupLimit, repoFullName, prNumber)
 	}
 
 	initialStatus := "provisioning"
@@ -914,7 +913,7 @@ func (s *Server) createClawForGitHubPR(factory *types.FactoryConfig, pr githubPR
 		fmt.Sprintf("%s#%d", repoFullName, prNumber),
 		pr.PullRequest.Title, "", pr.Action, "claw_created", clawID, "")
 
-	log.Printf("[factory] created claw %s (%s) for GitHub PR %s#%d (status=%s, reason=%s)", clawName, clawID[:8], repoFullName, prNumber, initialStatus, reason)
+	logf("[factory] created claw %s (%s) for GitHub PR %s#%d (status=%s, reason=%s)", clawName, clawID[:8], repoFullName, prNumber, initialStatus, reason)
 	s.broadcastToUsers(tenantID, types.WSMessage{
 		Type:    "claw_status",
 		Payload: map[string]string{"claw_id": clawID, "status": initialStatus},
@@ -930,7 +929,7 @@ func (s *Server) createClawForGitHubPR(factory *types.FactoryConfig, pr githubPR
 		var currentStatus string
 		_ = s.db.QueryRow(`SELECT status FROM claws WHERE id=?`, clawID).Scan(&currentStatus)
 		if currentStatus == "deleted" {
-			log.Printf("[factory] claw %s already deleted before provisioning, aborting", clawID[:8])
+			logf("[factory] claw %s already deleted before provisioning, aborting", clawID[:8])
 			return
 		}
 		ctx := context.Background()
@@ -969,7 +968,7 @@ func (s *Server) createClawForGitHubPR(factory *types.FactoryConfig, pr githubPR
 			provErr = fmt.Errorf("unsupported provider: %s", provider)
 		}
 		if provErr != nil {
-			log.Printf("[factory] provision failed for %s: %v", clawID, provErr)
+			logf("[factory] provision failed for %s: %v", clawID, provErr)
 			s.stopAgentWithReason(clawID, fmt.Sprintf("Factory provision failed: %v", provErr), false)
 		}
 	}()
@@ -1007,13 +1006,13 @@ func (s *Server) mergePRForClaw(clawID string) {
 		clawID,
 	).Scan(&prURL, &repo, &prNumber)
 	if err != nil || prURL == "" {
-		log.Printf("[pipeline] merge_pr: no tracked PR for claw %s", clawID[:8])
+		logf("[pipeline] merge_pr: no tracked PR for claw %s", clawID[:8])
 		return
 	}
 
 	token := s.resolveGitHubTokenForRepo(repo)
 	if token == "" {
-		log.Printf("[pipeline] merge_pr: no GitHub token for repo %s", repo)
+		logf("[pipeline] merge_pr: no GitHub token for repo %s", repo)
 		s.injectHubMessageByID(clawID, fmt.Sprintf("[hub] merge_pr: no GitHub token available for %s — cannot auto-merge.", repo))
 		return
 	}
@@ -1027,7 +1026,7 @@ func (s *Server) mergePRForClaw(clawID string) {
 		bytes.NewReader(body),
 	)
 	if err != nil {
-		log.Printf("[pipeline] merge_pr: failed to build request for %s#%d: %v", repo, prNumber, err)
+		logf("[pipeline] merge_pr: failed to build request for %s#%d: %v", repo, prNumber, err)
 		s.injectHubMessageByID(clawID, fmt.Sprintf("[hub] merge_pr: failed to prepare merge request for PR #%d: %v", prNumber, err))
 		return
 	}
@@ -1038,7 +1037,7 @@ func (s *Server) mergePRForClaw(clawID string) {
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		log.Printf("[pipeline] merge_pr: request failed for %s#%d: %v", repo, prNumber, err)
+		logf("[pipeline] merge_pr: request failed for %s#%d: %v", repo, prNumber, err)
 		s.injectHubMessageByID(clawID, fmt.Sprintf("[hub] merge_pr: failed to merge PR #%d: %v", prNumber, err))
 		return
 	}
@@ -1046,10 +1045,10 @@ func (s *Server) mergePRForClaw(clawID string) {
 	respBody, _ := io.ReadAll(resp.Body)
 
 	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusCreated {
-		log.Printf("[pipeline] merge_pr: merged %s#%d successfully", repo, prNumber)
+		logf("[pipeline] merge_pr: merged %s#%d successfully", repo, prNumber)
 		s.injectHubMessageByID(clawID, fmt.Sprintf("[hub] PR #%d merged successfully.", prNumber))
 	} else {
-		log.Printf("[pipeline] merge_pr: failed to merge %s#%d: HTTP %d: %s", repo, prNumber, resp.StatusCode, string(respBody))
+		logf("[pipeline] merge_pr: failed to merge %s#%d: HTTP %d: %s", repo, prNumber, resp.StatusCode, string(respBody))
 		s.injectHubMessageByID(clawID, fmt.Sprintf("[hub] merge_pr: failed to merge PR #%d (HTTP %d). Check CI status and review requirements.", prNumber, resp.StatusCode))
 	}
 }

--- a/pkg/hub/integration_poller.go
+++ b/pkg/hub/integration_poller.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -38,22 +37,22 @@ func (s *Server) pollTick() {
 	factories := s.resolveFactories()
 	linearWorkflowWorkspaces, err := loadExternalWorkflowsByIntegration("linear")
 	if err != nil {
-		log.Printf("[poll] tick: failed to load linear workflows: %v", err)
+		logf("[poll] tick: failed to load linear workflows: %v", err)
 	}
 	shortcutWorkflowWorkspaces, err := loadExternalWorkflowsByIntegration("shortcut")
 	if err != nil {
-		log.Printf("[poll] tick: failed to load shortcut workflows: %v", err)
+		logf("[poll] tick: failed to load shortcut workflows: %v", err)
 	}
 	githubIssueWorkflowWorkspaces, err := loadExternalWorkflowsByIntegration("github-issues")
 	if err != nil {
-		log.Printf("[poll] tick: failed to load github-issues workflows: %v", err)
+		logf("[poll] tick: failed to load github-issues workflows: %v", err)
 	}
 	jiraWorkflowWorkspaces, err := loadExternalWorkflowsByIntegration("jira")
 	if err != nil {
-		log.Printf("[poll] tick: failed to load jira workflows: %v", err)
+		logf("[poll] tick: failed to load jira workflows: %v", err)
 	}
 	if len(factories) == 0 && len(linearWorkflowWorkspaces) == 0 && len(shortcutWorkflowWorkspaces) == 0 && len(githubIssueWorkflowWorkspaces) == 0 && len(jiraWorkflowWorkspaces) == 0 {
-		log.Printf("[poll] tick: no factories or workflows configured")
+		logf("[poll] tick: no factories or workflows configured")
 		return
 	}
 
@@ -137,7 +136,7 @@ func (s *Server) pollLinear(factories []*types.FactoryConfig, linearCfgs []*type
 
 		issues, err := s.queryLinearIssues(li.Token, since)
 		if err != nil {
-			log.Printf("[poll-linear] query failed for workspace %q: %v", ws, err)
+			logf("[poll-linear] query failed for workspace %q: %v", ws, err)
 			continue
 		}
 
@@ -167,7 +166,7 @@ func (s *Server) pollLinearWorkflows(workspaces []*types.WorkspaceConfig, since 
 			}
 			token := s.resolveLinearTokenForWorkflow(workspace.Name, workflow)
 			if token == "" {
-				log.Printf("[poll-linear] workflow %s/%s: no Linear token configured — skipping", workspace.Name, workflow.Name)
+				logf("[poll-linear] workflow %s/%s: no Linear token configured — skipping", workspace.Name, workflow.Name)
 				continue
 			}
 			tokenTargets[token] = append(tokenTargets[token], linearWorkflowPollTarget{workspace: workspace, workflow: workflow})
@@ -176,7 +175,7 @@ func (s *Server) pollLinearWorkflows(workspaces []*types.WorkspaceConfig, since 
 	for token, targets := range tokenTargets {
 		issues, err := s.queryLinearIssues(token, since)
 		if err != nil {
-			log.Printf("[poll-linear] workflow query failed: %v", err)
+			logf("[poll-linear] workflow query failed: %v", err)
 			continue
 		}
 		for _, issue := range issues {
@@ -346,10 +345,10 @@ func (s *Server) processLinearPollItem(issue linearPollIssue, factories []*types
 			if isFactoryTriggerAlreadyClaimed(err) {
 				continue
 			}
-			log.Printf("[poll-linear] failed to create claw for %s: %v", entityID, err)
+			logf("[poll-linear] failed to create claw for %s: %v", entityID, err)
 			s.trackFactoryCreationFailure(factory.Name, entityID, err.Error())
 		} else {
-			log.Printf("[poll-linear] created claw for %s via factory %s", entityID, factory.Name)
+			logf("[poll-linear] created claw for %s via factory %s", entityID, factory.Name)
 			s.logFactoryEvent(factory.Name, entityID, issue.Title, "", currentStatus, "claw_created", "", "poll")
 			var clawID string
 			_ = s.db.QueryRow(`SELECT id FROM claws WHERE linear_issue_id=? AND factory_name=? ORDER BY created_at DESC LIMIT 1`, entityID, factory.Name).Scan(&clawID)
@@ -392,9 +391,9 @@ func (s *Server) processLinearWorkflowPollItem(issue linearPollIssue, targets []
 			continue
 		}
 
-		log.Printf("[workflow:%s/%s] Linear issue %s matched workflow trigger via poll — creating claw", workspace.Name, workflow.Name, entityID)
+		logf("[workflow:%s/%s] Linear issue %s matched workflow trigger via poll — creating claw", workspace.Name, workflow.Name, entityID)
 		if err := s.createClawForLinearWorkflow(workspace, workflow, payload, "poll"); err != nil {
-			log.Printf("[workflow:%s/%s] failed to create claw for %s via poll: %v", workspace.Name, workflow.Name, entityID, err)
+			logf("[workflow:%s/%s] failed to create claw for %s via poll: %v", workspace.Name, workflow.Name, entityID, err)
 		}
 	}
 }
@@ -458,7 +457,7 @@ func (s *Server) pollShortcut(factories []*types.FactoryConfig, shortcutCfgs []*
 
 		stories, err := s.queryShortcutStories(sc.Token, since)
 		if err != nil {
-			log.Printf("[poll-shortcut] query failed for workspace %q: %v", ws, err)
+			logf("[poll-shortcut] query failed for workspace %q: %v", ws, err)
 			continue
 		}
 
@@ -466,7 +465,7 @@ func (s *Server) pollShortcut(factories []*types.FactoryConfig, shortcutCfgs []*
 		// not repeat the full /workflows API call for every story.
 		stateNameMap := buildShortcutStateMap(s.resolveShortcutBaseURL(), sc.Token)
 		if len(stateNameMap) == 0 {
-			log.Printf("[poll-shortcut] failed to load workflow states for workspace %q — skipping %d stories", ws, len(stories))
+			logf("[poll-shortcut] failed to load workflow states for workspace %q — skipping %d stories", ws, len(stories))
 			continue
 		}
 		for _, story := range stories {
@@ -536,7 +535,7 @@ func (s *Server) pollShortcutWorkflows(workspaces []*types.WorkspaceConfig, sinc
 			}
 			token := s.resolveShortcutTokenForWorkflow(workspace.Name, workflow)
 			if token == "" {
-				log.Printf("[poll-shortcut] workflow %s/%s: no Shortcut token configured — skipping", workspace.Name, workflow.Name)
+				logf("[poll-shortcut] workflow %s/%s: no Shortcut token configured — skipping", workspace.Name, workflow.Name)
 				continue
 			}
 			tokenTargets[token] = append(tokenTargets[token], shortcutWorkflowPollTarget{workspace: workspace, workflow: workflow, token: token})
@@ -545,12 +544,12 @@ func (s *Server) pollShortcutWorkflows(workspaces []*types.WorkspaceConfig, sinc
 	for token, targets := range tokenTargets {
 		stories, err := s.queryShortcutStories(token, since)
 		if err != nil {
-			log.Printf("[poll-shortcut] workflow query failed: %v", err)
+			logf("[poll-shortcut] workflow query failed: %v", err)
 			continue
 		}
 		stateNameMap := buildShortcutStateMap(s.resolveShortcutBaseURL(), token)
 		if len(stateNameMap) == 0 {
-			log.Printf("[poll-shortcut] failed to load workflow states for workflow polling — skipping %d stories", len(stories))
+			logf("[poll-shortcut] failed to load workflow states for workflow polling — skipping %d stories", len(stories))
 			continue
 		}
 		for _, story := range stories {
@@ -625,9 +624,9 @@ func (s *Server) processShortcutPollItem(story shortcutPollStory, factories []*t
 			if isFactoryTriggerAlreadyClaimed(err) {
 				continue
 			}
-			log.Printf("[poll-shortcut] failed to create claw for %s: %v", storyID, err)
+			logf("[poll-shortcut] failed to create claw for %s: %v", storyID, err)
 		} else {
-			log.Printf("[poll-shortcut] created claw for %s via factory %s", storyID, factory.Name)
+			logf("[poll-shortcut] created claw for %s via factory %s", storyID, factory.Name)
 			s.logFactoryEvent(factory.Name, storyID, story.Name, "", currentStateName, "claw_created", "", "poll")
 		}
 	}
@@ -684,9 +683,9 @@ func (s *Server) processShortcutWorkflowPollItem(story shortcutPollStory, target
 		if !labelSetAllowed(currentLabels, workflow.Labels, workflow.ExcludeLabels) {
 			continue
 		}
-		log.Printf("[workflow:%s/%s] Shortcut story %s matched workflow trigger via poll — creating claw", workspace.Name, workflow.Name, storyID)
+		logf("[workflow:%s/%s] Shortcut story %s matched workflow trigger via poll — creating claw", workspace.Name, workflow.Name, storyID)
 		if err := s.createClawForShortcutWorkflow(workspace, workflow, action, storyID, "poll"); err != nil {
-			log.Printf("[workflow:%s/%s] failed to create claw for %s via poll: %v", workspace.Name, workflow.Name, storyID, err)
+			logf("[workflow:%s/%s] failed to create claw for %s via poll: %v", workspace.Name, workflow.Name, storyID, err)
 		}
 	}
 }
@@ -705,7 +704,7 @@ func (s *Server) pollGitHubIssues(factories []*types.FactoryConfig, ghIssueCfgs 
 		}
 		triggerRepos := githubIssuesPollingRepos(f)
 		if len(triggerRepos) == 0 {
-			log.Printf("[poll-github-issues] factory %q: missing required 'trigger_repos' field — skipping", f.Name)
+			logf("[poll-github-issues] factory %q: missing required 'trigger_repos' field — skipping", f.Name)
 			continue
 		}
 		for _, repo := range triggerRepos {
@@ -713,7 +712,7 @@ func (s *Server) pollGitHubIssues(factories []*types.FactoryConfig, ghIssueCfgs 
 				continue
 			}
 			if strings.HasSuffix(repo, "/*") {
-				log.Printf("[poll-github-issues] factory %q: trigger_repos entry %q is an org wildcard; webhooks can match it, but polling requires exact owner/repo entries", f.Name, repo)
+				logf("[poll-github-issues] factory %q: trigger_repos entry %q is an org wildcard; webhooks can match it, but polling requires exact owner/repo entries", f.Name, repo)
 				continue
 			}
 			repoFactories[repo] = append(repoFactories[repo], f)
@@ -740,7 +739,7 @@ func (s *Server) pollGitHubIssues(factories []*types.FactoryConfig, ghIssueCfgs 
 
 		issues, err := s.queryGitHubIssues(repo, token, since, base)
 		if err != nil {
-			log.Printf("[poll-github-issues] query failed for repo %q: %v", repo, err)
+			logf("[poll-github-issues] query failed for repo %q: %v", repo, err)
 			continue
 		}
 
@@ -775,7 +774,7 @@ func (s *Server) pollGitHubIssueWorkflows(workspaces []*types.WorkspaceConfig, s
 			}
 			token := s.resolveGitHubIssuesTokenForWorkflow(workspace.Name, workflow)
 			if token == "" {
-				log.Printf("[poll-github-issues] workflow %s/%s: no GitHub Issues token configured — skipping", workspace.Name, workflow.Name)
+				logf("[poll-github-issues] workflow %s/%s: no GitHub Issues token configured — skipping", workspace.Name, workflow.Name)
 				continue
 			}
 			for _, repo := range githubIssuesWorkflowTriggerRepos(workflow) {
@@ -783,7 +782,7 @@ func (s *Server) pollGitHubIssueWorkflows(workspaces []*types.WorkspaceConfig, s
 					continue
 				}
 				if strings.HasSuffix(repo, "/*") {
-					log.Printf("[poll-github-issues] workflow %s/%s: repository %q is an org wildcard; polling requires exact owner/repo entries", workspace.Name, workflow.Name, repo)
+					logf("[poll-github-issues] workflow %s/%s: repository %q is an org wildcard; polling requires exact owner/repo entries", workspace.Name, workflow.Name, repo)
 					continue
 				}
 				key := repoTokenKey{repo: repo, token: token}
@@ -806,7 +805,7 @@ func (s *Server) pollGitHubIssueWorkflows(workspaces []*types.WorkspaceConfig, s
 		}
 		issues, err := s.queryGitHubIssues(key.repo, key.token, since, base)
 		if err != nil {
-			log.Printf("[poll-github-issues] workflow query failed for repo %q: %v", key.repo, err)
+			logf("[poll-github-issues] workflow query failed for repo %q: %v", key.repo, err)
 			continue
 		}
 		for _, issue := range issues {
@@ -930,7 +929,7 @@ func (s *Server) processGitHubIssuesPollItem(issue githubIssuesPollItem, factori
 		var err error
 		events, err = s.queryGitHubIssueEvents(repo, token, base, issue.Number)
 		if err != nil {
-			log.Printf("[poll-github-issues] failed to fetch events for %s: %v", issueID, err)
+			logf("[poll-github-issues] failed to fetch events for %s: %v", issueID, err)
 		}
 	}
 
@@ -995,9 +994,9 @@ func (s *Server) processGitHubIssuesPollItem(issue githubIssuesPollItem, factori
 			if isFactoryTriggerAlreadyClaimed(err) {
 				continue
 			}
-			log.Printf("[poll-github-issues] failed to create claw for %s: %v", issueID, err)
+			logf("[poll-github-issues] failed to create claw for %s: %v", issueID, err)
 		} else {
-			log.Printf("[poll-github-issues] created claw for %s via factory %s", issueID, factory.Name)
+			logf("[poll-github-issues] created claw for %s via factory %s", issueID, factory.Name)
 			s.logFactoryEvent(factory.Name, issueID, issue.Title, "", currentStatus, "claw_created", "", "poll")
 		}
 	}
@@ -1016,7 +1015,7 @@ func (s *Server) processGitHubIssueWorkflowPollItem(issue githubIssuesPollItem, 
 		var err error
 		events, err = s.queryGitHubIssueEvents(repo, token, base, issue.Number)
 		if err != nil {
-			log.Printf("[poll-github-issues] failed to fetch events for %s: %v", issueID, err)
+			logf("[poll-github-issues] failed to fetch events for %s: %v", issueID, err)
 		}
 	}
 
@@ -1034,7 +1033,7 @@ func (s *Server) processGitHubIssueWorkflowPollItem(issue githubIssuesPollItem, 
 			if isFactoryTriggerAlreadyClaimed(err) {
 				continue
 			}
-			log.Printf("[workflow:%s/%s] failed to create claw for %s via poll: %v", workspace.Name, workflow.Name, issueID, err)
+			logf("[workflow:%s/%s] failed to create claw for %s via poll: %v", workspace.Name, workflow.Name, issueID, err)
 		}
 	}
 }
@@ -1245,7 +1244,7 @@ func (s *Server) pollJira(factories []*types.FactoryConfig, jiraCfgs []*types.Ji
 		tracker := workspaceIssueTracker{BaseURL: ji.BaseURL, Username: ji.Username, Token: ji.Token, WebhookSecret: ji.WebhookSecret}
 		issues, err := s.queryJiraIssues(tracker, since, projects)
 		if err != nil {
-			log.Printf("[poll-jira] query failed for workspace %q: %v", ji.Workspace, err)
+			logf("[poll-jira] query failed for workspace %q: %v", ji.Workspace, err)
 			continue
 		}
 		for _, issue := range issues {
@@ -1280,7 +1279,7 @@ func (s *Server) pollJiraWorkflows(workspaces []*types.WorkspaceConfig, since ti
 			}
 			tracker, ok := s.resolveJiraTrackerForWorkflow(workspace.Name, workflow)
 			if !ok || tracker.Token == "" || tracker.BaseURL == "" {
-				log.Printf("[poll-jira] workflow %s/%s: no Jira tracker configured — skipping", workspace.Name, workflow.Name)
+				logf("[poll-jira] workflow %s/%s: no Jira tracker configured — skipping", workspace.Name, workflow.Name)
 				continue
 			}
 			key := trackerKey{baseURL: tracker.BaseURL, username: tracker.Username, token: tracker.Token}
@@ -1294,7 +1293,7 @@ func (s *Server) pollJiraWorkflows(workspaces []*types.WorkspaceConfig, since ti
 		tracker := targets[0].tracker
 		issues, err := s.queryJiraIssues(tracker, since, jiraWorkflowProjects(targets))
 		if err != nil {
-			log.Printf("[poll-jira] workflow query failed: %v", err)
+			logf("[poll-jira] workflow query failed: %v", err)
 			continue
 		}
 		for _, issue := range issues {
@@ -1363,7 +1362,7 @@ func (s *Server) processJiraPollItem(issue jiraPollIssue, factories []*types.Fac
 			if isFactoryTriggerAlreadyClaimed(err) {
 				continue
 			}
-			log.Printf("[poll-jira] failed to create claw for %s: %v", issue.Key, err)
+			logf("[poll-jira] failed to create claw for %s: %v", issue.Key, err)
 		}
 	}
 	_ = tracker
@@ -1395,7 +1394,7 @@ func (s *Server) processJiraWorkflowPollItem(issue jiraPollIssue, targets []jira
 			if isFactoryTriggerAlreadyClaimed(err) {
 				continue
 			}
-			log.Printf("[workflow:%s/%s] failed to create claw for Jira issue %s via poll: %v", workspace.Name, workflow.Name, issue.Key, err)
+			logf("[workflow:%s/%s] failed to create claw for Jira issue %s via poll: %v", workspace.Name, workflow.Name, issue.Key, err)
 		}
 	}
 }
@@ -1447,7 +1446,7 @@ func (s *Server) pollGitHubPRs(factories []*types.FactoryConfig, since string) {
 
 		prs, err := s.queryGitHubPRs(repo, token, since, base)
 		if err != nil {
-			log.Printf("[poll-github-prs] query failed for repo %q: %v", repo, err)
+			logf("[poll-github-prs] query failed for repo %q: %v", repo, err)
 			continue
 		}
 
@@ -1534,9 +1533,9 @@ func (s *Server) processGitHubPRPollItem(pr githubPRPollItem, factories []*types
 
 		payload := s.buildGitHubPRPollPayload(pr, repo)
 		if err := s.createClawForGitHubPR(factory, payload, "poll"); err != nil {
-			log.Printf("[poll-github-prs] failed to create claw for %s: %v", prID, err)
+			logf("[poll-github-prs] failed to create claw for %s: %v", prID, err)
 		} else {
-			log.Printf("[poll-github-prs] created claw for %s via factory %s", prID, factory.Name)
+			logf("[poll-github-prs] created claw for %s via factory %s", prID, factory.Name)
 			s.logFactoryEvent(factory.Name, prID, pr.Title, "", "open", "claw_created", "", "poll")
 		}
 	}

--- a/pkg/hub/jira.go
+++ b/pkg/hub/jira.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"net/url"
 	"strings"
@@ -271,7 +270,7 @@ func jiraWebhookDedupKey(payload jiraWebhookPayload) string {
 func (s *Server) processJiraEvent(workspaceName string, payload jiraWebhookPayload) {
 	workspaces, err := loadExternalWorkflowsByIntegration("jira")
 	if err != nil {
-		log.Printf("[jira-webhook] failed to load workflows: %v", err)
+		logf("[jira-webhook] failed to load workflows: %v", err)
 		return
 	}
 	workspaces = filterWorkflowWorkspacesByName(workspaces, workspaceName)
@@ -305,7 +304,7 @@ func (s *Server) processJiraEvent(workspaceName string, payload jiraWebhookPaylo
 			if isFactoryTriggerAlreadyClaimed(err) {
 				continue
 			}
-			log.Printf("[factory:%s] failed to create claw for Jira issue %s: %v", factory.Name, payload.Issue.Key, err)
+			logf("[factory:%s] failed to create claw for Jira issue %s: %v", factory.Name, payload.Issue.Key, err)
 			s.trackFactoryCreationFailure(factory.Name, payload.Issue.Key, err.Error())
 		}
 	}
@@ -360,7 +359,7 @@ func (s *Server) processJiraWorkflowEvent(workspaces []*types.WorkspaceConfig, p
 				if isFactoryTriggerAlreadyClaimed(err) {
 					continue
 				}
-				log.Printf("[workflow:%s/%s] failed to create claw for Jira issue %s: %v", workspace.Name, workflow.Name, payload.Issue.Key, err)
+				logf("[workflow:%s/%s] failed to create claw for Jira issue %s: %v", workspace.Name, workflow.Name, payload.Issue.Key, err)
 			}
 		}
 		for _, workflow := range workspace.Workflows {
@@ -504,7 +503,7 @@ func (s *Server) createClawForJiraWorkflow(workspace *types.WorkspaceConfig, wor
 	if !isPending && workflow.WorkingStatus != "" {
 		if tracker, ok := s.resolveJiraTrackerForWorkflow(workspace.Name, workflow); ok {
 			if err := s.moveJiraIssue(tracker, issueID, workflow.WorkingStatus); err != nil {
-				log.Printf("[workflow:%s/%s] failed to move Jira issue %s to %q: %v", workspace.Name, workflow.Name, issueID, workflow.WorkingStatus, err)
+				logf("[workflow:%s/%s] failed to move Jira issue %s to %q: %v", workspace.Name, workflow.Name, issueID, workflow.WorkingStatus, err)
 			}
 		}
 	}
@@ -552,7 +551,7 @@ func (s *Server) createClawForJiraIssue(factory *types.FactoryConfig, payload ji
 	if !isPending && factory.WorkingStatus != "" {
 		if tracker, ok := s.resolveJiraTrackerForFactory(factory); ok {
 			if err := s.moveJiraIssue(tracker, issueID, factory.WorkingStatus); err != nil {
-				log.Printf("[factory:%s] failed to move Jira issue %s to %q: %v", factory.Name, issueID, factory.WorkingStatus, err)
+				logf("[factory:%s] failed to move Jira issue %s to %q: %v", factory.Name, issueID, factory.WorkingStatus, err)
 			}
 		}
 	}

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"os"
 	"strings"
@@ -104,7 +103,7 @@ func (s *Server) handleLinearWebhook(w http.ResponseWriter, r *http.Request) {
 	}
 	dedupKey := payload.WebhookID + ":" + payload.Data.Identifier + ":" + createdAt
 	if payload.WebhookID != "" && s.isDuplicateWebhook(dedupKey) {
-		log.Printf("[linear-webhook] dedup: skipping duplicate delivery %s for %s (createdAt=%s)", payload.WebhookID, payload.Data.Identifier, createdAt)
+		logfCtx(r.Context(), "[linear-webhook] dedup: skipping duplicate delivery %s for %s (createdAt=%s)", payload.WebhookID, payload.Data.Identifier, createdAt)
 		w.WriteHeader(http.StatusOK)
 		return
 	}
@@ -299,13 +298,13 @@ func (s *Server) processLinearEvent(workspaceName string, payload linearWebhookP
 		// When previousStatus is empty (Linear omits it), EqualFold returns false, so the guard passes.
 		if strings.EqualFold(currentStatus, factory.TriggerStatus) && !strings.EqualFold(previousStatus, factory.TriggerStatus) {
 			matched = true
-			log.Printf("[factory:%s] issue %s entered '%s' — creating claw", factory.Name, issueID, factory.TriggerStatus)
+			logf("[factory:%s] issue %s entered '%s' — creating claw", factory.Name, issueID, factory.TriggerStatus)
 			clawID := ""
 			if err := s.createClawForIssue(factory, payload, "linear webhook"); err != nil {
 				if isFactoryTriggerAlreadyClaimed(err) {
 					continue
 				}
-				log.Printf("[factory:%s] failed to create claw for %s: %v", factory.Name, issueID, err)
+				logf("[factory:%s] failed to create claw for %s: %v", factory.Name, issueID, err)
 				s.logFactoryEvent(factory.Name, issueID, payload.Data.Title, previousStatus, currentStatus, "error", "", err.Error())
 				s.trackFactoryCreationFailure(factory.Name, issueID, err.Error())
 			} else {
@@ -328,7 +327,7 @@ func (s *Server) processLinearEvent(workspaceName string, payload linearWebhookP
 			).Scan(&activeClaw)
 			if activeClaw != "" {
 				matched = true
-				log.Printf("[factory:%s] issue %s moved to '%s' (not trigger) — terminating claw", factory.Name, issueID, currentStatus)
+				logf("[factory:%s] issue %s moved to '%s' (not trigger) — terminating claw", factory.Name, issueID, currentStatus)
 				s.terminateClawForIssue(issueID)
 				s.logFactoryEvent(factory.Name, issueID, payload.Data.Title, previousStatus, currentStatus, "claw_terminated", activeClaw, "terminated: issue left trigger status")
 			}
@@ -390,9 +389,9 @@ func (s *Server) processLinearWorkflowEvent(workspaces []*types.WorkspaceConfig,
 			}
 			if strings.EqualFold(currentStatus, workflow.TriggerStatus) && !strings.EqualFold(previousStatus, workflow.TriggerStatus) {
 				matched = true
-				log.Printf("[workflow:%s/%s] Linear issue %s entered %q — creating claw", workspace.Name, workflow.Name, issueID, workflow.TriggerStatus)
+				logf("[workflow:%s/%s] Linear issue %s entered %q — creating claw", workspace.Name, workflow.Name, issueID, workflow.TriggerStatus)
 				if err := s.createClawForLinearWorkflow(workspace, workflow, payload, "linear webhook"); err != nil {
-					log.Printf("[workflow:%s/%s] failed to create claw for %s: %v", workspace.Name, workflow.Name, issueID, err)
+					logf("[workflow:%s/%s] failed to create claw for %s: %v", workspace.Name, workflow.Name, issueID, err)
 					s.notifyLinearWorkflowCreateFailure(workspace, workflow, payload, err)
 				}
 			}
@@ -401,7 +400,7 @@ func (s *Server) processLinearWorkflowEvent(workspaces []*types.WorkspaceConfig,
 				_ = s.db.QueryRow(`SELECT id FROM claws WHERE linear_issue_id = ? AND status NOT IN ('error','deleted') LIMIT 1`, issueID).Scan(&activeClaw)
 				if activeClaw != "" {
 					matched = true
-					log.Printf("[workflow:%s/%s] Linear issue %s left trigger %q — terminating claw %s", workspace.Name, workflow.Name, issueID, workflow.TriggerStatus, activeClaw[:8])
+					logf("[workflow:%s/%s] Linear issue %s left trigger %q — terminating claw %s", workspace.Name, workflow.Name, issueID, workflow.TriggerStatus, activeClaw[:8])
 					s.terminateClawForIssue(issueID)
 				}
 			}
@@ -416,7 +415,7 @@ func (s *Server) notifyLinearWorkflowCreateFailure(workspace *types.WorkspaceCon
 	}
 	token := s.resolveLinearTokenForWorkflow(workspace.Name, workflow)
 	if token == "" {
-		log.Printf("[agent-failure-feedback] workflow %s/%s has no Linear token; skipping failure feedback", workspace.Name, workflow.Name)
+		logf("[agent-failure-feedback] workflow %s/%s has no Linear token; skipping failure feedback", workspace.Name, workflow.Name)
 		return
 	}
 	s.handleAgentFailureFeedback(agentFailureFeedback{
@@ -440,7 +439,7 @@ func (s *Server) createClawForLinearWorkflow(workspace *types.WorkspaceConfig, w
 	var existing string
 	_ = s.db.QueryRow(`SELECT id FROM claws WHERE linear_issue_id=? AND status NOT IN ('error','deleted') LIMIT 1`, issueID).Scan(&existing)
 	if existing != "" {
-		log.Printf("[workflow:%s/%s] Linear issue %s already has active claw %s", workspace.Name, workflow.Name, issueID, existing[:8])
+		logf("[workflow:%s/%s] Linear issue %s already has active claw %s", workspace.Name, workflow.Name, issueID, existing[:8])
 		return nil
 	}
 
@@ -456,7 +455,7 @@ func (s *Server) createClawForLinearWorkflow(workspace *types.WorkspaceConfig, w
 		return fmt.Errorf("claim workflow trigger: %w", err)
 	}
 	if !claimed {
-		log.Printf("[workflow:%s/%s] Linear issue %s already has an active trigger claim", workspace.Name, workflow.Name, issueID)
+		logf("[workflow:%s/%s] Linear issue %s already has an active trigger claim", workspace.Name, workflow.Name, issueID)
 		return nil
 	}
 	claimOpen := true
@@ -505,11 +504,11 @@ func (s *Server) createClawForLinearWorkflow(workspace *types.WorkspaceConfig, w
 	if !isPending && workflow.WorkingStatus != "" {
 		if token := s.resolveLinearTokenForWorkflow(workspace.Name, workflow); token != "" {
 			if err := s.moveLinearIssueOnServer(token, issueID, workflow.WorkingStatus); err != nil {
-				log.Printf("[workflow:%s/%s] failed to move issue %s to working status %q: %v", workspace.Name, workflow.Name, issueID, workflow.WorkingStatus, err)
+				logf("[workflow:%s/%s] failed to move issue %s to working status %q: %v", workspace.Name, workflow.Name, issueID, workflow.WorkingStatus, err)
 			}
 		}
 	}
-	log.Printf("[workflow:%s/%s] created claw %s for Linear issue %s", workspace.Name, workflow.Name, clawID[:8], issueID)
+	logf("[workflow:%s/%s] created claw %s for Linear issue %s", workspace.Name, workflow.Name, clawID[:8], issueID)
 	return nil
 }
 
@@ -534,7 +533,7 @@ func (s *Server) createClawForIssue(factory *types.FactoryConfig, payload linear
 	}
 	if !claimed {
 		if reason != "poll" {
-			log.Printf("[factory:%s] Linear issue %s already has an active trigger claim — treating as idempotent success", factory.Name, issueID)
+			logf("[factory:%s] Linear issue %s already has an active trigger claim — treating as idempotent success", factory.Name, issueID)
 		}
 		return errFactoryTriggerAlreadyClaimed
 	}
@@ -550,11 +549,11 @@ func (s *Server) createClawForIssue(factory *types.FactoryConfig, payload linear
 	linearToken := s.resolveLinearTokenForFactory(factory)
 	if linearToken != "" {
 		if _, err := s.fetchLinearIssueDetails(linearToken, issueID); err != nil {
-			log.Printf("[factory:%s] pre-flight FAILED for %s: %v", factory.Name, issueID, err)
+			logf("[factory:%s] pre-flight FAILED for %s: %v", factory.Name, issueID, err)
 			return fmt.Errorf("cannot read issue %s from Linear (check token/workspace access): %w", issueID, err)
 		}
 	} else {
-		log.Printf("[factory:%s] warning: no Linear token, skipping pre-flight issue read for %s", factory.Name, issueID)
+		logf("[factory:%s] warning: no Linear token, skipping pre-flight issue read for %s", factory.Name, issueID)
 	}
 
 	// Build Linear-specific context and inject into template files
@@ -579,7 +578,7 @@ func (s *Server) createClawForIssue(factory *types.FactoryConfig, payload linear
 		return fmt.Errorf("complete factory trigger: %w", err)
 	}
 	claimOpen = false
-	log.Printf("[factory] created claw %s for Linear issue %s", clawID[:8], issueID)
+	logf("[factory] created claw %s for Linear issue %s", clawID[:8], issueID)
 
 	// Move the issue to WorkingStatus if configured (only if not pending —
 	// a queued claw hasn't actually started working yet)
@@ -587,9 +586,9 @@ func (s *Server) createClawForIssue(factory *types.FactoryConfig, payload linear
 		linearToken := s.resolveLinearTokenForFactory(factory)
 		if linearToken != "" {
 			if err := s.moveLinearIssueOnServer(linearToken, issueID, factory.WorkingStatus); err != nil {
-				log.Printf("[factory] failed to move issue %s to working status '%s': %v", issueID, factory.WorkingStatus, err)
+				logf("[factory] failed to move issue %s to working status '%s': %v", issueID, factory.WorkingStatus, err)
 			} else {
-				log.Printf("[factory] moved issue %s to working status '%s'", issueID, factory.WorkingStatus)
+				logf("[factory] moved issue %s to working status '%s'", issueID, factory.WorkingStatus)
 			}
 		}
 	}
@@ -605,7 +604,7 @@ func (s *Server) terminateClawForIssue(issueID string) {
 	).Scan(&clawID, &tenantID, &factoryName); err != nil {
 		return
 	}
-	log.Printf("[factory] terminating claw %s for issue %s", clawID[:8], issueID)
+	logf("[factory] terminating claw %s for issue %s", clawID[:8], issueID)
 
 	// Post a comment on the linked issue/story before terminating
 	factory := s.findFactoryForIssue(issueID)
@@ -615,18 +614,18 @@ func (s *Server) terminateClawForIssue(issueID string) {
 			token := s.resolveLinearTokenForFactory(factory)
 			if token != "" {
 				if err := s.commentLinearIssue(token, issueID, "Agent stopped: issue left trigger status"); err != nil {
-					log.Printf("[factory] failed to comment Linear issue %s: %v", issueID, err)
+					logf("[factory] failed to comment Linear issue %s: %v", issueID, err)
 				} else {
-					log.Printf("[factory] commented Linear issue %s", issueID)
+					logf("[factory] commented Linear issue %s", issueID)
 				}
 			}
 		case "shortcut":
 			token := s.resolveShortcutToken(factory.Workspace)
 			if token != "" {
 				if err := commentShortcutIssue(s.resolveShortcutBaseURL(), token, issueID, "Agent stopped: issue left trigger status"); err != nil {
-					log.Printf("[factory] failed to comment Shortcut story %s: %v", issueID, err)
+					logf("[factory] failed to comment Shortcut story %s: %v", issueID, err)
 				} else {
-					log.Printf("[factory] commented Shortcut story %s", issueID)
+					logf("[factory] commented Shortcut story %s", issueID)
 				}
 			}
 		case "github-issues":
@@ -638,9 +637,9 @@ func (s *Server) terminateClawForIssue(issueID string) {
 					var issueNum int
 					if _, err := fmt.Sscanf(parts[2], "%d", &issueNum); err == nil {
 						if err := commentGitHubIssue(token, repo, issueNum, "Agent stopped: issue left trigger status"); err != nil {
-							log.Printf("[factory] failed to comment GitHub issue %s: %v", issueID, err)
+							logf("[factory] failed to comment GitHub issue %s: %v", issueID, err)
 						} else {
-							log.Printf("[factory] commented GitHub issue %s", issueID)
+							logf("[factory] commented GitHub issue %s", issueID)
 						}
 					}
 				}
@@ -648,9 +647,9 @@ func (s *Server) terminateClawForIssue(issueID string) {
 		case "jira":
 			if tracker, ok := s.resolveJiraTrackerForFactory(factory); ok {
 				if err := s.commentJiraIssue(tracker, issueID, "Agent stopped: issue left trigger status"); err != nil {
-					log.Printf("[factory] failed to comment Jira issue %s: %v", issueID, err)
+					logf("[factory] failed to comment Jira issue %s: %v", issueID, err)
 				} else {
-					log.Printf("[factory] commented Jira issue %s", issueID)
+					logf("[factory] commented Jira issue %s", issueID)
 				}
 			}
 		}
@@ -927,7 +926,7 @@ func (s *Server) promotePendingClaws() {
 
 		// Promote to provisioning — scope UPDATE to pending status so a
 		// concurrent hard-delete doesn't match zero rows silently.
-		log.Printf("[factory] promoting pending claw %s to provisioning (active=%d, group=%s, limit=%d)", clawID[:8], active, groupName, groupLimit)
+		logf("[factory] promoting pending claw %s to provisioning (active=%d, group=%s, limit=%d)", clawID[:8], active, groupName, groupLimit)
 		res, _ := s.db.Exec(`UPDATE claws SET status='provisioning' WHERE id=? AND status='pending'`, clawID)
 		n, _ := res.RowsAffected()
 		if n == 0 {
@@ -963,7 +962,7 @@ func (s *Server) provisionPendingClaw(clawID string) {
 		clawID,
 	).Scan(&tenantID, &name, &template, &provider, &defaultModel, &templateFilesJSON, &githubReposJSON, &linearWorkspace, &nixEnabled, &dockerEnabled, &tagsJSON, &color, &llmKey, &issueID)
 	if err != nil {
-		log.Printf("[factory] failed to fetch pending claw %s: %v", clawID[:8], err)
+		logf("[factory] failed to fetch pending claw %s: %v", clawID[:8], err)
 		s.stopAgentWithReason(clawID, fmt.Sprintf("Factory provision failed: failed to fetch pending claw: %v", err), false)
 		return
 	}
@@ -972,7 +971,7 @@ func (s *Server) provisionPendingClaw(clawID string) {
 	var currentStatus string
 	err2 := s.db.QueryRow(`SELECT status FROM claws WHERE id=?`, clawID).Scan(&currentStatus)
 	if err2 != nil || currentStatus == "deleted" {
-		log.Printf("[factory] claw %s already deleted before provisioning, aborting", clawID[:8])
+		logf("[factory] claw %s already deleted before provisioning, aborting", clawID[:8])
 		return
 	}
 
@@ -1034,21 +1033,21 @@ func (s *Server) provisionPendingClaw(clawID string) {
 		var parseErr error
 		tmplCfg, parseErr = config.ParseTemplateConfig([]byte(cfgContent))
 		if parseErr != nil {
-			log.Printf("[factory] warning: could not parse elasticclaw-config.yaml for pending claw %s: %v", clawID[:8], parseErr)
+			logf("[factory] warning: could not parse elasticclaw-config.yaml for pending claw %s: %v", clawID[:8], parseErr)
 			tmplCfg = nil
 		}
 	}
 
 	// Resolve and inject template-requested secrets (same as factory create paths).
 	if tmplCfg != nil && len(tmplCfg.Secrets) > 0 && factory != nil {
-		log.Printf("[factory] DEPRECATED: template %q uses 'secrets:' list — migrate to 'secret_refs:' map", template)
+		logf("[factory] DEPRECATED: template %q uses 'secrets:' list — migrate to 'secret_refs:' map", template)
 		for _, ref := range tmplCfg.Secrets {
 			secretVal, envName, ok := s.resolveSecretRef(ref, factory)
 			if ok {
 				env[envName] = secretVal
-				log.Printf("[factory] injected template secret %s as %s into pending claw %s env", ref.Type, envName, clawID[:8])
+				logf("[factory] injected template secret %s as %s into pending claw %s env", ref.Type, envName, clawID[:8])
 			} else {
-				log.Printf("[factory] warning: requested secret (type=%s name=%s workspace=%s) not found for pending claw %s", ref.Type, ref.Name, ref.Workspace, clawID[:8])
+				logf("[factory] warning: requested secret (type=%s name=%s workspace=%s) not found for pending claw %s", ref.Type, ref.Name, ref.Workspace, clawID[:8])
 			}
 		}
 	}
@@ -1058,9 +1057,9 @@ func (s *Server) provisionPendingClaw(clawID string) {
 		for envName, secretRef := range tmplCfg.SecretRefs {
 			if val, ok := s.hubCfg.Secrets[secretRef]; ok {
 				env[envName] = val
-				log.Printf("[factory] injected template secret_ref %s as %s into pending claw %s env", secretRef, envName, clawID[:8])
+				logf("[factory] injected template secret_ref %s as %s into pending claw %s env", secretRef, envName, clawID[:8])
 			} else {
-				log.Printf("[factory] WARNING: template secret_ref %q not found in hub secrets for pending claw %s", secretRef, clawID[:8])
+				logf("[factory] WARNING: template secret_ref %q not found in hub secrets for pending claw %s", secretRef, clawID[:8])
 			}
 		}
 	}
@@ -1070,9 +1069,9 @@ func (s *Server) provisionPendingClaw(clawID string) {
 		for envName, secretRef := range factory.SecretRefs {
 			if val, ok := s.hubCfg.Secrets[secretRef]; ok {
 				env[envName] = val
-				log.Printf("[factory] injected factory secret_ref %s as %s into pending claw %s env", secretRef, envName, clawID[:8])
+				logf("[factory] injected factory secret_ref %s as %s into pending claw %s env", secretRef, envName, clawID[:8])
 			} else {
-				log.Printf("[factory] WARNING: factory secret_ref %q not found in hub secrets for pending claw %s", secretRef, clawID[:8])
+				logf("[factory] WARNING: factory secret_ref %q not found in hub secrets for pending claw %s", secretRef, clawID[:8])
 			}
 		}
 	}
@@ -1123,7 +1122,7 @@ func (s *Server) provisionPendingClaw(clawID string) {
 		provErr = fmt.Errorf("unsupported provider: %s", provider)
 	}
 	if provErr != nil {
-		log.Printf("[factory] provision failed for pending claw %s: %v", clawID, provErr)
+		logf("[factory] provision failed for pending claw %s: %v", clawID, provErr)
 		s.stopAgentWithReason(clawID, fmt.Sprintf("Factory provision failed: %v", provErr), false)
 		// Slot is now free (error claws don't count toward limit); try to
 		// promote the next pending claw.
@@ -1177,7 +1176,7 @@ func (s *Server) handleClawDoneSignal(clawID, rawMessage string) {
 		return // not a factory claw
 	}
 
-	log.Printf("[factory] claw %s sent [DONE] for issue %s", clawID[:8], issueID)
+	logf("[factory] claw %s sent [DONE] for issue %s", clawID[:8], issueID)
 
 	// Extract PR URLs from the [DONE] line.
 	// Expected format: [DONE] https://github.com/org/repo/pull/1 https://...
@@ -1204,7 +1203,7 @@ func (s *Server) handleClawDoneSignal(clawID, rawMessage string) {
 				Detail:          map[string]any{"issueID": issueID},
 				OccurredAt:      now(),
 			}); err != nil {
-				log.Printf("[task-run-analytics] failed to record done_without_pr for claw %s: %v", clawID, err)
+				logf("[task-run-analytics] failed to record done_without_pr for claw %s: %v", clawID, err)
 			}
 			s.injectUserMessage(clawID, "[factory] `[DONE]` received with no PR URLs. Please open a PR and resend: `[DONE] https://github.com/org/repo/pull/N`")
 			return
@@ -1224,7 +1223,7 @@ func (s *Server) handleClawDoneSignal(clawID, rawMessage string) {
 	// Block PR creation if any required gate has failed.
 	if s.hasFailedRequiredGate(clawID) {
 		msg := "[factory] `[DONE]` blocked: a required tool gate has failed. Please fix the issues and retry."
-		log.Printf("[factory] claw %s [DONE] blocked by failed required gate", clawID[:8])
+		logf("[factory] claw %s [DONE] blocked by failed required gate", clawID[:8])
 		s.injectUserMessage(clawID, msg)
 		return
 	}
@@ -1276,9 +1275,9 @@ func (s *Server) handleClawDoneSignal(clawID, rawMessage string) {
 		case "jira":
 			if tracker, ok := s.resolveJiraTrackerForFactory(factory); ok {
 				if err := s.moveJiraIssue(tracker, issueID, targetStatus); err != nil {
-					log.Printf("[factory] failed to move Jira issue %s to '%s': %v", issueID, targetStatus, err)
+					logf("[factory] failed to move Jira issue %s to '%s': %v", issueID, targetStatus, err)
 				} else {
-					log.Printf("[factory] moved Jira issue %s to '%s'", issueID, targetStatus)
+					logf("[factory] moved Jira issue %s to '%s'", issueID, targetStatus)
 				}
 			}
 		case "shortcut":
@@ -1286,9 +1285,9 @@ func (s *Server) handleClawDoneSignal(clawID, rawMessage string) {
 			scToken := s.resolveShortcutToken(factory.Workspace)
 			if scToken != "" {
 				if err := moveShortcutStory(s.resolveShortcutBaseURL(), scToken, issueID, targetStatus); err != nil {
-					log.Printf("[factory] failed to move story %s to '%s': %v", issueID, targetStatus, err)
+					logf("[factory] failed to move story %s to '%s': %v", issueID, targetStatus, err)
 				} else {
-					log.Printf("[factory] moved story %s to '%s'", issueID, targetStatus)
+					logf("[factory] moved story %s to '%s'", issueID, targetStatus)
 				}
 			}
 		case "github-issues":
@@ -1308,9 +1307,9 @@ func (s *Server) handleClawDoneSignal(clawID, rawMessage string) {
 							base = "https://api.github.com"
 						}
 						if err := moveGitHubIssue(ghToken, repo, issueNum, targetStatus, base); err != nil {
-							log.Printf("[factory] failed to move GitHub issue %s to '%s': %v", issueID, targetStatus, err)
+							logf("[factory] failed to move GitHub issue %s to '%s': %v", issueID, targetStatus, err)
 						} else {
-							log.Printf("[factory] moved GitHub issue %s to '%s'", issueID, targetStatus)
+							logf("[factory] moved GitHub issue %s to '%s'", issueID, targetStatus)
 						}
 					}
 				}
@@ -1320,9 +1319,9 @@ func (s *Server) handleClawDoneSignal(clawID, rawMessage string) {
 			linearToken := s.resolveLinearTokenForFactory(factory)
 			if linearToken != "" {
 				if err := s.moveLinearIssueOnServer(linearToken, issueID, targetStatus); err != nil {
-					log.Printf("[factory] failed to move issue %s to '%s': %v", issueID, targetStatus, err)
+					logf("[factory] failed to move issue %s to '%s': %v", issueID, targetStatus, err)
 				} else {
-					log.Printf("[factory] moved issue %s to '%s'", issueID, targetStatus)
+					logf("[factory] moved issue %s to '%s'", issueID, targetStatus)
 				}
 			}
 		}
@@ -1344,7 +1343,7 @@ func (s *Server) handleClawDoneSignal(clawID, rawMessage string) {
 	rowsAffected, err := res.RowsAffected()
 	if err != nil || rowsAffected == 0 {
 		if rowsAffected == 0 {
-			log.Printf("[factory] non-pr completion skipped for claw %s: already deleted or terminal", clawID[:8])
+			logf("[factory] non-pr completion skipped for claw %s: already deleted or terminal", clawID[:8])
 		}
 		return
 	}
@@ -1376,7 +1375,7 @@ func (s *Server) completeNoPRDoneClaw(clawID, tenantID, issueID string) {
 	_ = s.db.QueryRow(`SELECT COALESCE(provider,''), COALESCE(provider_id,'') FROM claws WHERE id=? AND tenant_id=?`, clawID, tenantID).Scan(&provider, &providerID)
 	res, err := s.db.Exec(`UPDATE claws SET status='deleted', bootstrap_status='' WHERE id=? AND tenant_id=? AND status NOT IN ('deleted','error')`, clawID, tenantID)
 	if err != nil {
-		log.Printf("[factory] failed to complete non-pr claw %s: %v", clawID, err)
+		logf("[factory] failed to complete non-pr claw %s: %v", clawID, err)
 		return
 	}
 	rowsAffected, err := res.RowsAffected()
@@ -1393,7 +1392,7 @@ func (s *Server) completeNoPRDoneClaw(clawID, tenantID, issueID string) {
 		Detail:          map[string]any{"issueID": issueID, "requires_pr": false},
 		OccurredAt:      now(),
 	}); err != nil {
-		log.Printf("[task-run-analytics] failed to record non-pr completion for claw %s: %v", clawID, err)
+		logf("[task-run-analytics] failed to record non-pr completion for claw %s: %v", clawID, err)
 	}
 	s.broadcastToUsers(tenantID, types.WSMessage{
 		Type:    "claw_status",
@@ -1424,11 +1423,11 @@ func (s *Server) handleClawTerminateSignal(clawID, rawMessage string) {
 	// Get the tenant ID and issue ID for this claw
 	var issueID, tenantID, factoryName string
 	if err := s.db.QueryRow(`SELECT COALESCE(NULLIF(linear_issue_id,''),NULLIF(github_issue_id,''),NULLIF(shortcut_story_id,''),NULLIF(jira_issue_id,'')), tenant_id, factory_name FROM claws WHERE id = ?`, clawID).Scan(&issueID, &tenantID, &factoryName); err != nil {
-		log.Printf("[terminate] claw %s not found in DB: %v", clawID[:8], err)
+		logf("[terminate] claw %s not found in DB: %v", clawID[:8], err)
 		return
 	}
 
-	log.Printf("[terminate] claw %s sent [TERMINATE] for issue %s", clawID[:8], issueID)
+	logf("[terminate] claw %s sent [TERMINATE] for issue %s", clawID[:8], issueID)
 
 	// Find the factory config for this issue (for commenting)
 	factory := s.findFactoryForIssue(issueID)
@@ -1439,18 +1438,18 @@ func (s *Server) handleClawTerminateSignal(clawID, rawMessage string) {
 			token := s.resolveLinearTokenForFactory(factory)
 			if token != "" {
 				if err := s.commentLinearIssue(token, issueID, "Agent stopped: claw requested self-termination"); err != nil {
-					log.Printf("[terminate] failed to comment Linear issue %s: %v", issueID, err)
+					logf("[terminate] failed to comment Linear issue %s: %v", issueID, err)
 				} else {
-					log.Printf("[terminate] commented Linear issue %s", issueID)
+					logf("[terminate] commented Linear issue %s", issueID)
 				}
 			}
 		case "shortcut":
 			token := s.resolveShortcutToken(factory.Workspace)
 			if token != "" {
 				if err := commentShortcutIssue(s.resolveShortcutBaseURL(), token, issueID, "Agent stopped: claw requested self-termination"); err != nil {
-					log.Printf("[terminate] failed to comment Shortcut story %s: %v", issueID, err)
+					logf("[terminate] failed to comment Shortcut story %s: %v", issueID, err)
 				} else {
-					log.Printf("[terminate] commented Shortcut story %s", issueID)
+					logf("[terminate] commented Shortcut story %s", issueID)
 				}
 			}
 		case "github-issues":
@@ -1462,9 +1461,9 @@ func (s *Server) handleClawTerminateSignal(clawID, rawMessage string) {
 					var issueNum int
 					if _, err := fmt.Sscanf(parts[2], "%d", &issueNum); err == nil {
 						if err := commentGitHubIssue(token, repo, issueNum, "Agent stopped: claw requested self-termination"); err != nil {
-							log.Printf("[terminate] failed to comment GitHub issue %s: %v", issueID, err)
+							logf("[terminate] failed to comment GitHub issue %s: %v", issueID, err)
 						} else {
-							log.Printf("[terminate] commented GitHub issue %s", issueID)
+							logf("[terminate] commented GitHub issue %s", issueID)
 						}
 					}
 				}
@@ -1472,9 +1471,9 @@ func (s *Server) handleClawTerminateSignal(clawID, rawMessage string) {
 		case "jira":
 			if tracker, ok := s.resolveJiraTrackerForFactory(factory); ok {
 				if err := s.commentJiraIssue(tracker, issueID, "Agent stopped: claw requested self-termination"); err != nil {
-					log.Printf("[terminate] failed to comment Jira issue %s: %v", issueID, err)
+					logf("[terminate] failed to comment Jira issue %s: %v", issueID, err)
 				} else {
-					log.Printf("[terminate] commented Jira issue %s", issueID)
+					logf("[terminate] commented Jira issue %s", issueID)
 				}
 			}
 		}
@@ -1516,7 +1515,7 @@ func (s *Server) handleClawTerminateSignal(clawID, rawMessage string) {
 	// Promote any pending claws now that a slot is free
 	go s.promotePendingClaws()
 
-	log.Printf("[terminate] claw %s terminated successfully", clawID[:8])
+	logf("[terminate] claw %s terminated successfully", clawID[:8])
 }
 
 // extractDonePRURLs parses PR URLs from a [DONE] message.
@@ -1916,7 +1915,7 @@ func (s *Server) fetchLinearIssueDetails(token, issueIdentifier string) (*linear
 	} else if token != "" {
 		keyPrefix = token + "..."
 	}
-	log.Printf("[linear] fetchLinearIssueDetails: issue=%s base=%s keyPrefix=%s", issueIdentifier, base, keyPrefix)
+	logf("[linear] fetchLinearIssueDetails: issue=%s base=%s keyPrefix=%s", issueIdentifier, base, keyPrefix)
 
 	// Linear's issue(id:) actually accepts the display identifier like "CAN-61"
 	// directly (not just UUID). This is documented in Linear's GraphQL examples.
@@ -1937,7 +1936,7 @@ func (s *Server) fetchLinearIssueDetails(token, issueIdentifier string) (*linear
 	client := &http.Client{Timeout: 10 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
-		log.Printf("[linear] fetchLinearIssueDetails HTTP error for %s: %v", issueIdentifier, err)
+		logf("[linear] fetchLinearIssueDetails HTTP error for %s: %v", issueIdentifier, err)
 		return nil, err
 	}
 	defer resp.Body.Close()
@@ -1953,7 +1952,7 @@ func (s *Server) fetchLinearIssueDetails(token, issueIdentifier string) (*linear
 		} `json:"errors"`
 	}
 	if err := json.Unmarshal(bodyBytes, &result); err != nil {
-		log.Printf("[linear] fetchLinearIssueDetails JSON decode error for %s: %v", issueIdentifier, err)
+		logf("[linear] fetchLinearIssueDetails JSON decode error for %s: %v", issueIdentifier, err)
 		return nil, err
 	}
 	if len(result.Errors) > 0 {
@@ -1962,14 +1961,14 @@ func (s *Server) fetchLinearIssueDetails(token, issueIdentifier string) (*linear
 			errMsgs = append(errMsgs, e.Message)
 		}
 		combined := strings.Join(errMsgs, "; ")
-		log.Printf("[linear] fetchLinearIssueDetails GraphQL errors for %s: %s", issueIdentifier, combined)
-		log.Printf("[linear] fetchLinearIssueDetails response body for %s: %s", issueIdentifier, string(bodyBytes))
+		logf("[linear] fetchLinearIssueDetails GraphQL errors for %s: %s", issueIdentifier, combined)
+		logf("[linear] fetchLinearIssueDetails response body for %s: %s", issueIdentifier, string(bodyBytes))
 		return nil, fmt.Errorf("GraphQL error: %s", combined)
 	}
 	if result.Data.Issue.Identifier == "" {
-		log.Printf("[linear] fetchLinearIssueDetails: empty issue returned for %s", issueIdentifier)
+		logf("[linear] fetchLinearIssueDetails: empty issue returned for %s", issueIdentifier)
 		return nil, fmt.Errorf("issue %s not found", issueIdentifier)
 	}
-	log.Printf("[linear] fetchLinearIssueDetails success for %s: id=%s title=%s", issueIdentifier, result.Data.Issue.Identifier, result.Data.Issue.Title)
+	logf("[linear] fetchLinearIssueDetails success for %s: id=%s title=%s", issueIdentifier, result.Data.Issue.Identifier, result.Data.Issue.Title)
 	return &result.Data.Issue, nil
 }

--- a/pkg/hub/logger/logger.go
+++ b/pkg/hub/logger/logger.go
@@ -1,0 +1,45 @@
+// Package logger provides the hub's structured logging setup on top of
+// log/slog, plus context helpers so request-scoped attributes (request_id,
+// tenant_id) travel with a context.Context.
+package logger
+
+import (
+	"context"
+	"log/slog"
+	"os"
+)
+
+// ctxKey is the private context key under which the request-scoped logger is
+// stored.
+type ctxKey struct{}
+
+// New builds the root logger for the hub process. Output format is controlled
+// by ELASTICCLAW_LOG_FORMAT: "text" produces human-readable lines (dev),
+// anything else (including unset) produces JSON.
+func New() *slog.Logger {
+	var h slog.Handler
+	switch os.Getenv("ELASTICCLAW_LOG_FORMAT") {
+	case "text":
+		h = slog.NewTextHandler(os.Stderr, nil)
+	default:
+		h = slog.NewJSONHandler(os.Stderr, nil)
+	}
+	return slog.New(h)
+}
+
+// NewContext returns a copy of ctx carrying l as the request-scoped logger.
+func NewContext(ctx context.Context, l *slog.Logger) context.Context {
+	return context.WithValue(ctx, ctxKey{}, l)
+}
+
+// FromContext returns the request-scoped logger stored in ctx (with
+// request_id and, after auth, tenant_id already attached). It falls back to
+// slog.Default() when ctx carries no logger, so it is always safe to call.
+func FromContext(ctx context.Context) *slog.Logger {
+	if ctx != nil {
+		if l, ok := ctx.Value(ctxKey{}).(*slog.Logger); ok && l != nil {
+			return l
+		}
+	}
+	return slog.Default()
+}

--- a/pkg/hub/logger/logger_test.go
+++ b/pkg/hub/logger/logger_test.go
@@ -1,0 +1,36 @@
+package logger
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestFromContextFallsBackToDefault(t *testing.T) {
+	if got := FromContext(context.Background()); got != slog.Default() {
+		t.Fatalf("expected slog.Default() fallback, got %v", got)
+	}
+}
+
+func TestNewContextRoundTrip(t *testing.T) {
+	var buf bytes.Buffer
+	l := slog.New(slog.NewTextHandler(&buf, nil)).With("request_id", "abc123")
+	ctx := NewContext(context.Background(), l)
+	FromContext(ctx).Info("hello")
+	if out := buf.String(); !strings.Contains(out, "request_id=abc123") || !strings.Contains(out, "hello") {
+		t.Fatalf("logged line missing request_id or message: %q", out)
+	}
+}
+
+func TestNewFormatSelection(t *testing.T) {
+	t.Setenv("ELASTICCLAW_LOG_FORMAT", "text")
+	if _, ok := New().Handler().(*slog.TextHandler); !ok {
+		t.Fatalf("expected TextHandler for ELASTICCLAW_LOG_FORMAT=text")
+	}
+	t.Setenv("ELASTICCLAW_LOG_FORMAT", "")
+	if _, ok := New().Handler().(*slog.JSONHandler); !ok {
+		t.Fatalf("expected JSONHandler by default")
+	}
+}

--- a/pkg/hub/logging.go
+++ b/pkg/hub/logging.go
@@ -1,0 +1,36 @@
+package hub
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"regexp"
+
+	"github.com/elasticclaw/elasticclaw/pkg/hub/logger"
+)
+
+// componentTagRe matches the manual "[component] " prefix historically used by
+// log.Printf call sites (e.g. "[hub] ...", "[cron] ...").
+var componentTagRe = regexp.MustCompile(`^\[([A-Za-z0-9_.-]+)\] ?`)
+
+// logf is the printf-style bridge used by the mechanical log.Printf → slog
+// migration for call sites with no context available (boot code, background
+// goroutines). The message text is preserved verbatim, except that a leading
+// "[component] " tag is lifted into a component attribute.
+func logf(format string, args ...any) {
+	logMsg(slog.Default(), format, args...)
+}
+
+// logfCtx is the context-aware variant of logf: it logs through the
+// request-scoped logger, so lines carry request_id (and tenant_id after auth).
+func logfCtx(ctx context.Context, format string, args ...any) {
+	logMsg(logger.FromContext(ctx), format, args...)
+}
+
+func logMsg(l *slog.Logger, format string, args ...any) {
+	if m := componentTagRe.FindStringSubmatch(format); m != nil {
+		l.Info(fmt.Sprintf(format[len(m[0]):], args...), "component", m[1])
+		return
+	}
+	l.Info(fmt.Sprintf(format, args...))
+}

--- a/pkg/hub/manual_trigger.go
+++ b/pkg/hub/manual_trigger.go
@@ -3,7 +3,6 @@ package hub
 import (
 	"database/sql"
 	"encoding/json"
-	"log"
 	"strings"
 )
 
@@ -13,7 +12,7 @@ func (s *Server) loadManualTriggerInputs(clawID string) map[string]string {
 	var filesJSON, tagsJSON string
 	if err := s.db.QueryRow(`SELECT template_files, tags FROM claws WHERE id=?`, clawID).Scan(&filesJSON, &tagsJSON); err != nil {
 		if err != sql.ErrNoRows {
-			log.Printf("[manual-trigger] failed to load claw %s: %v", clawID[:8], err)
+			logf("[manual-trigger] failed to load claw %s: %v", clawID[:8], err)
 		}
 		return nil
 	}
@@ -35,7 +34,7 @@ func (s *Server) loadManualTriggerInputs(clawID string) map[string]string {
 
 	var files map[string]string
 	if err := json.Unmarshal([]byte(filesJSON), &files); err != nil {
-		log.Printf("[manual-trigger] failed to parse template_files for claw %s: %v", clawID[:8], err)
+		logf("[manual-trigger] failed to parse template_files for claw %s: %v", clawID[:8], err)
 		return nil
 	}
 
@@ -48,7 +47,7 @@ func (s *Server) loadManualTriggerInputs(clawID string) map[string]string {
 
 	var inputs map[string]string
 	if err := json.Unmarshal([]byte(inputsJSON), &inputs); err != nil {
-		log.Printf("[manual-trigger] failed to parse TRIGGER_INPUTS.json for claw %s: %v", clawID[:8], err)
+		logf("[manual-trigger] failed to parse TRIGGER_INPUTS.json for claw %s: %v", clawID[:8], err)
 		return nil
 	}
 	if len(inputs) == 0 {

--- a/pkg/hub/middleware.go
+++ b/pkg/hub/middleware.go
@@ -4,7 +4,6 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
-	"log"
 	"net/http"
 	"runtime/debug"
 
@@ -67,7 +66,7 @@ func withRecovery(next http.Handler) http.Handler {
 			if rec == http.ErrAbortHandler {
 				panic(rec)
 			}
-			log.Printf("[hub] panic recovered: %v (%s %s from %s)\n%s",
+			logfCtx(r.Context(), "[hub] panic recovered: %v (%s %s from %s)\n%s",
 				rec, r.Method, r.URL.Path, r.RemoteAddr, debug.Stack())
 			// Best effort: if the handler already wrote a response this is a
 			// no-op apart from a superfluous-WriteHeader log line.

--- a/pkg/hub/middleware.go
+++ b/pkg/hub/middleware.go
@@ -1,10 +1,14 @@
 package hub
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"log"
 	"net/http"
 	"runtime/debug"
+
+	"github.com/elasticclaw/elasticclaw/pkg/hub/logger"
 )
 
 // apiError is the single JSON error envelope returned by API handlers.
@@ -24,10 +28,33 @@ func writeErr(w http.ResponseWriter, status int, code, msg string) {
 	_ = json.NewEncoder(w).Encode(apiError{Error: msg, Code: code})
 }
 
+// newRequestID returns a short random hex ID, enough to correlate the log
+// lines of a single request.
+func newRequestID() string {
+	var b [4]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "00000000"
+	}
+	return hex.EncodeToString(b[:])
+}
+
+// withRequestID generates a short request ID for every incoming request,
+// echoes it back in the X-Request-ID response header, and stores a logger
+// carrying request_id in the request context. Downstream code retrieves it
+// via logger.FromContext(ctx).
+func (s *Server) withRequestID(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := newRequestID()
+		w.Header().Set("X-Request-ID", id)
+		l := s.logger.With("request_id", id)
+		next.ServeHTTP(w, r.WithContext(logger.NewContext(r.Context(), l)))
+	})
+}
+
 // withRecovery is the outermost middleware: it recovers from panics in any
 // downstream handler, logs the stack trace with the request context available
-// at this phase (method, path, remote addr — request IDs arrive in Phase 1),
-// and responds with a 500 JSON envelope.
+// at this phase (method, path, remote addr, request_id via the context
+// logger), and responds with a 500 JSON envelope.
 func withRecovery(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer func() {

--- a/pkg/hub/middleware_test.go
+++ b/pkg/hub/middleware_test.go
@@ -4,10 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"log"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/elasticclaw/elasticclaw/pkg/hub/logger"
 )
 
 func TestWithRecoveryPanic(t *testing.T) {
@@ -90,6 +93,67 @@ func TestWriteErr(t *testing.T) {
 	}
 	if envelope.Error != "claw not found" || envelope.Code != "not_found" {
 		t.Fatalf("envelope = %+v", envelope)
+	}
+}
+
+func TestWithRequestID(t *testing.T) {
+	var buf bytes.Buffer
+	s := &Server{logger: slog.New(slog.NewJSONHandler(&buf, nil))}
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		logger.FromContext(r.Context()).Info("first")
+		logger.FromContext(r.Context()).Info("second")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	rec := httptest.NewRecorder()
+	s.withRequestID(inner).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/claws", nil))
+
+	id := rec.Header().Get("X-Request-ID")
+	if len(id) != 8 {
+		t.Fatalf("expected 8-char X-Request-ID header, got %q", id)
+	}
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 log lines, got %d: %q", len(lines), buf.String())
+	}
+	for _, line := range lines {
+		var entry map[string]any
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			t.Fatalf("log line is not JSON: %q", line)
+		}
+		if entry["request_id"] != id {
+			t.Fatalf("log line request_id=%v does not match header %q", entry["request_id"], id)
+		}
+	}
+}
+
+func TestLogfComponentExtraction(t *testing.T) {
+	var buf bytes.Buffer
+	logMsg(slog.New(slog.NewJSONHandler(&buf, nil)), "[claw] instance %s started", "abc")
+	var entry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("log line is not JSON: %q", buf.String())
+	}
+	if entry["component"] != "claw" {
+		t.Fatalf("expected component=claw, got %v", entry["component"])
+	}
+	if entry["msg"] != "instance abc started" {
+		t.Fatalf("unexpected message: %v", entry["msg"])
+	}
+
+	buf.Reset()
+	entry = map[string]any{}
+	logMsg(slog.New(slog.NewJSONHandler(&buf, nil)), "no tag here %d", 7)
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("log line is not JSON: %q", buf.String())
+	}
+	if _, ok := entry["component"]; ok {
+		t.Fatalf("did not expect a component attribute: %v", entry)
+	}
+	if entry["msg"] != "no tag here 7" {
+		t.Fatalf("unexpected message: %v", entry["msg"])
 	}
 }
 

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -113,7 +112,7 @@ func (s *Server) fetchGitHubIssueDetailsWithRetry(clawID, token, repo string, is
 		if attempt == maxAttempts || !isRetryableGitHubError(err) {
 			break
 		}
-		log.Printf("[pipeline] fetchGitHubIssueDetails attempt %d/%d failed for %s/%d: %v — retrying in %s", attempt, maxAttempts, repo, issueNumber, err, backoff)
+		logf("[pipeline] fetchGitHubIssueDetails attempt %d/%d failed for %s/%d: %v — retrying in %s", attempt, maxAttempts, repo, issueNumber, err, backoff)
 		s.injectHubMessageByID(clawID, fmt.Sprintf("[hub] GitHub API temporarily unavailable — retry %d/%d in %s…", attempt, maxAttempts-1, backoff))
 		time.Sleep(backoff)
 		backoff *= 2
@@ -192,8 +191,8 @@ func parsePipelineForFactory(factory *types.FactoryConfig) *pipeline.Pipeline {
 	}
 	p, err := pipeline.Parse([]byte(factory.PipelineYAML))
 	if err != nil {
-		log.Printf("[pipeline] factory %q: failed to parse pipeline_yaml: %v", factory.Name, err)
-		log.Printf("[pipeline] factory %q: pipeline_yaml content:\n%s", factory.Name, factory.PipelineYAML)
+		logf("[pipeline] factory %q: failed to parse pipeline_yaml: %v", factory.Name, err)
+		logf("[pipeline] factory %q: pipeline_yaml content:\n%s", factory.Name, factory.PipelineYAML)
 		// NOTE: pipeline YAML may contain secrets in inject blocks. This log is
 		// only emitted on parse failure (not routine operation) to aid debugging.
 		// Audit your log aggregator retention policy if this is a concern.
@@ -258,8 +257,8 @@ func parsePipelineForContext(ctx pipelineContext) *pipeline.Pipeline {
 	}
 	p, err := pipeline.Parse([]byte(pipelineYAML))
 	if err != nil {
-		log.Printf("[pipeline] %s: failed to parse pipeline yaml: %v", ctx.Name(), err)
-		log.Printf("[pipeline] %s: pipeline yaml content:\n%s", ctx.Name(), pipelineYAML)
+		logf("[pipeline] %s: failed to parse pipeline yaml: %v", ctx.Name(), err)
+		logf("[pipeline] %s: pipeline yaml content:\n%s", ctx.Name(), pipelineYAML)
 		return nil
 	}
 	return p
@@ -267,19 +266,19 @@ func parsePipelineForContext(ctx pipelineContext) *pipeline.Pipeline {
 
 func (s *Server) warnPipelineRender(clawID, format string, args ...interface{}) {
 	msg := fmt.Sprintf(format, args...)
-	log.Printf("[pipeline] %s", msg)
+	logf("[pipeline] %s", msg)
 	s.injectHubMessageByID(clawID, "[hub] Warning: "+msg)
 }
 
 func renderInjectWithData(clawID, injectMsg string, data interface{}) string {
 	tmpl, err := template.New("inject").Parse(injectMsg)
 	if err != nil {
-		log.Printf("[pipeline] template PARSE FAILED for claw %s: %v", clawID[:8], err)
+		logf("[pipeline] template PARSE FAILED for claw %s: %v", clawID[:8], err)
 		return injectMsg
 	}
 	var buf bytes.Buffer
 	if err := tmpl.Execute(&buf, data); err != nil {
-		log.Printf("[pipeline] template EXECUTE FAILED for claw %s: %v", clawID[:8], err)
+		logf("[pipeline] template EXECUTE FAILED for claw %s: %v", clawID[:8], err)
 		return injectMsg
 	}
 	return buf.String()
@@ -521,9 +520,9 @@ func (s *Server) persistPipelineOutput(clawID, stageID, outputName string, resul
 			created_at=excluded.created_at`,
 		clawID, stageID, outputName, result.ExitCode, result.Stdout, result.Stderr, parsedJSON, now())
 	if err != nil {
-		log.Printf("[pipeline] failed to persist output %q for claw %s: %v", outputName, clawID[:8], err)
+		logf("[pipeline] failed to persist output %q for claw %s: %v", outputName, clawID[:8], err)
 	} else {
-		log.Printf("[pipeline] persisted output %q for claw %s stage %s exit=%d", outputName, clawID[:8], stageID, result.ExitCode)
+		logf("[pipeline] persisted output %q for claw %s stage %s exit=%d", outputName, clawID[:8], stageID, result.ExitCode)
 	}
 }
 
@@ -556,7 +555,7 @@ func parsePipelineOutputJSON(stdout string) (map[string]interface{}, bool) {
 func (s *Server) loadPipelineOutputs(clawID string) map[string]map[string]interface{} {
 	rows, err := s.db.Query(`SELECT output_name, parsed_json FROM pipeline_outputs WHERE claw_id=?`, clawID)
 	if err != nil {
-		log.Printf("[pipeline] failed to load outputs for claw %s: %v", clawID[:8], err)
+		logf("[pipeline] failed to load outputs for claw %s: %v", clawID[:8], err)
 		return nil
 	}
 	defer rows.Close()
@@ -572,7 +571,7 @@ func (s *Server) loadPipelineOutputs(clawID string) map[string]map[string]interf
 		}
 	}
 	if err := rows.Err(); err != nil {
-		log.Printf("[pipeline] rows error loading outputs for claw %s: %v", clawID[:8], err)
+		logf("[pipeline] rows error loading outputs for claw %s: %v", clawID[:8], err)
 	}
 	return outputs
 }
@@ -892,7 +891,7 @@ func formatPipelineRunFailure(action pipeline.RunAction, result *pipelineRunResu
 func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineContext) bool {
 	issueID := ctx.IssueID
 	if strings.TrimSpace(stage.OnEnter.Run.Command) != "" {
-		log.Printf("[pipeline] running workflow command for claw %s stage %q: %s", clawID[:8], stage.ID, stage.OnEnter.Run.Command)
+		logf("[pipeline] running workflow command for claw %s stage %q: %s", clawID[:8], stage.ID, stage.OnEnter.Run.Command)
 		result, err := s.executePipelineRunAction(clawID, stage.OnEnter.Run)
 		// Persist output so later stages can reference it via {{ .Outputs.<name>.<key> }}
 		if stage.OnEnter.Run.Output != "" && result != nil {
@@ -903,24 +902,24 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 			// If this stage has a gate, treat nonzero exit as a normal validation
 			// failure so the gate can still evaluate the captured JSON output.
 			if stage.Gate != nil && stage.OnEnter.Run.Output != "" && result != nil {
-				log.Printf("[pipeline] %s; continuing because stage has a gate configured", msg)
+				logf("[pipeline] %s; continuing because stage has a gate configured", msg)
 				s.injectHubMessageByID(clawID, "[hub] Warning: "+msg)
 			} else if stage.OnEnter.Run.ContinueOnError {
-				log.Printf("[pipeline] %s; continuing because continue_on_error=true", msg)
+				logf("[pipeline] %s; continuing because continue_on_error=true", msg)
 				s.injectHubMessageByID(clawID, "[hub] Warning: "+msg)
 			} else {
-				log.Printf("[pipeline] %s", msg)
+				logf("[pipeline] %s", msg)
 				s.injectHubMessageByID(clawID, "[hub] Error: "+msg)
 				return false
 			}
 		} else {
-			log.Printf("[pipeline] workflow command completed for claw %s stage %q", clawID[:8], stage.ID)
+			logf("[pipeline] workflow command completed for claw %s stage %q", clawID[:8], stage.ID)
 		}
 	}
 
 	if dependencyUpdatesConfigured(stage.OnEnter.DependencyUpdates) {
 		outputName := dependencyUpdatesOutputName(stage.OnEnter.DependencyUpdates)
-		log.Printf("[pipeline] running dependency updates for claw %s stage %q output %q", clawID[:8], stage.ID, outputName)
+		logf("[pipeline] running dependency updates for claw %s stage %q output %q", clawID[:8], stage.ID, outputName)
 		result, err := s.executeDependencyUpdatesAction(clawID, stage.ID, stage.OnEnter.DependencyUpdates)
 		if err != nil || (result != nil && result.ExitCode != 0) {
 			msg := "Dependency update step failed"
@@ -932,7 +931,7 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 			} else if err != nil {
 				msg += ": " + err.Error()
 			}
-			log.Printf("[pipeline] %s", msg)
+			logf("[pipeline] %s", msg)
 			s.injectHubMessageByID(clawID, "[hub] Error: "+msg)
 			if !stage.OnEnter.DependencyUpdates.ContinueOnError {
 				return false
@@ -942,17 +941,17 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 
 	// Execute judge action if configured
 	if stage.OnEnter.Judge.Instructions != "" {
-		log.Printf("[pipeline] running judge for claw %s stage %q", clawID[:8], stage.ID)
+		logf("[pipeline] running judge for claw %s stage %q", clawID[:8], stage.ID)
 		judgeResult, err := s.executeJudgeAction(clawID, stage.OnEnter.Judge, ctx)
 		if err != nil {
 			msg := fmt.Sprintf("Judge stage failed: %v", err)
-			log.Printf("[pipeline] %s", msg)
+			logf("[pipeline] %s", msg)
 			s.injectHubMessageByID(clawID, "[hub] Error: "+msg)
 			if !stage.OnEnter.Judge.ContinueOnError {
 				return false
 			}
 		} else {
-			log.Printf("[pipeline] judge completed for claw %s stage %q: verdict=%s", clawID[:8], stage.ID, judgeResult.Verdict)
+			logf("[pipeline] judge completed for claw %s stage %q: verdict=%s", clawID[:8], stage.ID, judgeResult.Verdict)
 			// Persist judge output so later stages can reference it
 			if stage.OnEnter.Judge.Output != "" {
 				result := &pipelineRunResult{
@@ -984,7 +983,7 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 			if stage.OnEnter.Judge.Require.Verdict != "" &&
 				!strings.EqualFold(judgeResult.Verdict, stage.OnEnter.Judge.Require.Verdict) {
 				msg := fmt.Sprintf("Judge verdict %q does not match required %q", judgeResult.Verdict, stage.OnEnter.Judge.Require.Verdict)
-				log.Printf("[pipeline] %s", msg)
+				logf("[pipeline] %s", msg)
 				if !stage.OnEnter.Judge.ContinueOnError {
 					s.injectHubMessageByID(clawID, "[hub] Error: "+msg)
 					return false
@@ -996,7 +995,7 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 	// Evaluate gate if configured
 	if stage.Gate != nil {
 		gateResult := s.evaluateGate(clawID, stage.ID, stage.Gate)
-		log.Printf("[pipeline] gate evaluated for claw %s stage %q: verdict=%s", clawID[:8], stage.ID, gateResult.Verdict)
+		logf("[pipeline] gate evaluated for claw %s stage %q: verdict=%s", clawID[:8], stage.ID, gateResult.Verdict)
 		// Inject gate result into claw chat
 		if gateResult.Verdict == "pass" {
 			s.injectHubMessageByID(clawID, fmt.Sprintf("[hub] Gate passed: %s", stage.Label))
@@ -1023,7 +1022,7 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 		// If gate is required and failed (or errored), block further on_enter actions
 		if stage.Gate.Required && (gateResult.Verdict == "fail" || gateResult.Verdict == "error") {
 			msg := fmt.Sprintf("Required gate %q %s — blocking further pipeline actions", stage.ID, gateResult.Verdict)
-			log.Printf("[pipeline] %s", msg)
+			logf("[pipeline] %s", msg)
 			s.injectHubMessageByID(clawID, "[hub] Error: "+msg)
 			return false
 		}
@@ -1035,7 +1034,7 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 		// Render {{.Issue.Identifier}}, {{.Issue.Title}}, {{.Issue.URL}} if this is a Linear claw
 		// GitHub Issues IDs are owner/repo/number format (contain "/"), Shortcut IDs start with "sc-"
 		if issueID != "" && !strings.HasPrefix(issueID, "sc-") && !strings.Contains(issueID, "/") {
-			log.Printf("[pipeline] attempting to render template for claw %s issue %s", clawID[:8], issueID)
+			logf("[pipeline] attempting to render template for claw %s issue %s", clawID[:8], issueID)
 			linearToken := s.resolveLinearTokenForPipeline(ctx)
 			if linearToken == "" {
 				s.warnPipelineRender(clawID, "%s: no Linear issue tracker token configured; rendering inject with fallback issue context", ctx.Name())
@@ -1099,7 +1098,7 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 			} else {
 				details = fetchedDetails
 			}
-			log.Printf("[pipeline] fetched GitHub issue %s: #%s title=%s", issueID, details.Identifier, details.Title)
+			logf("[pipeline] fetched GitHub issue %s: #%s title=%s", issueID, details.Identifier, details.Title)
 			tmpl, err := template.New("inject").Parse(injectMsg)
 			if err != nil {
 				s.warnPipelineRender(clawID, "%s: inject template parse failed: %v", ctx.Name(), err)
@@ -1115,7 +1114,7 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 			}
 			injectMsg = buf.String()
 		} else {
-			log.Printf("[pipeline] skipping template render for claw %s: issueID=%q", clawID[:8], issueID)
+			logf("[pipeline] skipping template render for claw %s: issueID=%q", clawID[:8], issueID)
 		}
 
 		// For manual triggers, also try rendering with {{ .Inputs.* }} variables
@@ -1168,16 +1167,16 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 						}
 						for _, label := range stage.OnEnter.AddLabels {
 							if err := githubAPIAddLabel(base, repo, issueNum, label, ghToken); err != nil {
-								log.Printf("[pipeline] failed to add label %q to issue %s: %v", label, issueID, err)
+								logf("[pipeline] failed to add label %q to issue %s: %v", label, issueID, err)
 							} else {
-								log.Printf("[pipeline] added label %q to issue %s", label, issueID)
+								logf("[pipeline] added label %q to issue %s", label, issueID)
 							}
 						}
 						for _, label := range stage.OnEnter.RemoveLabels {
 							if err := githubAPIDeleteLabel(base, repo, issueNum, label, ghToken); err != nil {
-								log.Printf("[pipeline] failed to remove label %q from issue %s: %v", label, issueID, err)
+								logf("[pipeline] failed to remove label %q from issue %s: %v", label, issueID, err)
 							} else {
-								log.Printf("[pipeline] removed label %q from issue %s", label, issueID)
+								logf("[pipeline] removed label %q from issue %s", label, issueID)
 							}
 						}
 					}
@@ -1290,13 +1289,13 @@ issueResolved:
 	if isJira {
 		tracker, ok := s.resolveJiraTrackerForPipeline(ctx)
 		if !ok {
-			log.Printf("[pipeline] %s: no Jira tracker for connection %q, skipping move_issue", ctx.Name(), ctx.TrackerName())
+			logf("[pipeline] %s: no Jira tracker for connection %q, skipping move_issue", ctx.Name(), ctx.TrackerName())
 			return true
 		}
 		if err := s.moveJiraIssue(tracker, resolvedIssueID, targetStatus); err != nil {
-			log.Printf("[pipeline] failed to move Jira issue %s to %q: %v", resolvedIssueID, targetStatus, err)
+			logf("[pipeline] failed to move Jira issue %s to %q: %v", resolvedIssueID, targetStatus, err)
 		} else {
-			log.Printf("[pipeline] moved Jira issue %s to %q", resolvedIssueID, targetStatus)
+			logf("[pipeline] moved Jira issue %s to %q", resolvedIssueID, targetStatus)
 		}
 	} else if isShortcut {
 		// Shortcut story — ensure sc- prefix if missing (e.g. template rendered bare number)
@@ -1306,48 +1305,48 @@ issueResolved:
 		}
 		scToken := s.resolveShortcutTokenForPipeline(ctx)
 		if scToken == "" {
-			log.Printf("[pipeline] %s: no Shortcut token for connection %q, skipping move_issue", ctx.Name(), ctx.TrackerName())
+			logf("[pipeline] %s: no Shortcut token for connection %q, skipping move_issue", ctx.Name(), ctx.TrackerName())
 			return true
 		}
 		if err := moveShortcutStory(s.resolveShortcutBaseURL(), scToken, scID, targetStatus); err != nil {
-			log.Printf("[pipeline] failed to move story %s to %q: %v", scID, targetStatus, err)
+			logf("[pipeline] failed to move story %s to %q: %v", scID, targetStatus, err)
 		} else {
-			log.Printf("[pipeline] moved story %s to %q", scID, targetStatus)
+			logf("[pipeline] moved story %s to %q", scID, targetStatus)
 		}
 	} else if isGitHub {
 		// GitHub issue (owner/repo/number format)
 		ghToken := s.resolveGitHubIssuesTokenForPipeline(ctx)
 		if ghToken == "" {
-			log.Printf("[pipeline] %s: no GitHub Issues token for move_issue, skipping", ctx.Name())
+			logf("[pipeline] %s: no GitHub Issues token for move_issue, skipping", ctx.Name())
 			return true
 		}
 		parts := strings.Split(resolvedIssueID, "/")
 		if len(parts) != 3 {
-			log.Printf("[pipeline] %s: GitHub issue ID %q is not owner/repo/number format — skipping move_issue", ctx.Name(), resolvedIssueID)
+			logf("[pipeline] %s: GitHub issue ID %q is not owner/repo/number format — skipping move_issue", ctx.Name(), resolvedIssueID)
 			return true
 		}
 		repo := parts[0] + "/" + parts[1]
 		var issueNum int
 		if _, err := fmt.Sscanf(parts[2], "%d", &issueNum); err != nil {
-			log.Printf("[pipeline] %s: invalid GitHub issue number in %q — skipping move_issue", ctx.Name(), resolvedIssueID)
+			logf("[pipeline] %s: invalid GitHub issue number in %q — skipping move_issue", ctx.Name(), resolvedIssueID)
 			return true
 		}
 		if err := moveGitHubIssue(ghToken, repo, issueNum, targetStatus, s.githubBaseURL); err != nil {
-			log.Printf("[pipeline] failed to move GitHub issue %s to %q: %v", resolvedIssueID, targetStatus, err)
+			logf("[pipeline] failed to move GitHub issue %s to %q: %v", resolvedIssueID, targetStatus, err)
 		} else {
-			log.Printf("[pipeline] moved GitHub issue %s to %q", resolvedIssueID, targetStatus)
+			logf("[pipeline] moved GitHub issue %s to %q", resolvedIssueID, targetStatus)
 		}
 	} else {
 		// Linear issue
 		linearToken := s.resolveLinearTokenForPipeline(ctx)
 		if linearToken == "" {
-			log.Printf("[pipeline] %s: no Linear token for connection %q, skipping move_issue", ctx.Name(), ctx.TrackerName())
+			logf("[pipeline] %s: no Linear token for connection %q, skipping move_issue", ctx.Name(), ctx.TrackerName())
 			return true
 		}
 		if err := s.moveLinearIssueOnServer(linearToken, resolvedIssueID, targetStatus); err != nil {
-			log.Printf("[pipeline] failed to move issue %s to %q: %v", resolvedIssueID, targetStatus, err)
+			logf("[pipeline] failed to move issue %s to %q: %v", resolvedIssueID, targetStatus, err)
 		} else {
-			log.Printf("[pipeline] moved issue %s to %q", resolvedIssueID, targetStatus)
+			logf("[pipeline] moved issue %s to %q", resolvedIssueID, targetStatus)
 		}
 	}
 	return true
@@ -1453,18 +1452,18 @@ func (s *Server) transitionPipelineStageWithContext(clawID string, stage pipelin
 
 func (s *Server) transitionResolvedPipelineStageWithContext(clawID string, stage pipeline.Stage, ctx pipelineContext) bool {
 	if !s.claimPipelineStageTransition(clawID, stage.ID) {
-		log.Printf("[pipeline] claw %s already in stage %q (%s), skipping duplicate transition", clawID[:8], stage.ID, stage.Label)
+		logf("[pipeline] claw %s already in stage %q (%s), skipping duplicate transition", clawID[:8], stage.ID, stage.Label)
 		return false
 	}
 	// Record that this claw has visited this stage, so one-shot triggers
 	// (like output_matches) don't re-fire on subsequent messages.
 	s.recordPipelineStageVisit(clawID, stage.ID)
-	log.Printf("[pipeline] claw %s → stage %q (%s)", clawID[:8], stage.ID, stage.Label)
+	logf("[pipeline] claw %s → stage %q (%s)", clawID[:8], stage.ID, stage.Label)
 	stageActionsSucceeded := s.runOnEnter(clawID, stage, ctx)
 
 	// If this is a terminal stage, terminate the claw
 	if stage.Terminal {
-		log.Printf("[pipeline] claw %s reached terminal stage %q — terminating", clawID[:8], stage.ID)
+		logf("[pipeline] claw %s reached terminal stage %q — terminating", clawID[:8], stage.ID)
 
 		// Wait for any streaming response to finish so injected terminal message
 		// is delivered before we close the connection.
@@ -1476,7 +1475,7 @@ func (s *Server) transitionResolvedPipelineStageWithContext(clawID string, stage
 			if !streaming {
 				break
 			}
-			log.Printf("[pipeline] claw %s is streaming, waiting before terminal termination...", clawID[:8])
+			logf("[pipeline] claw %s is streaming, waiting before terminal termination...", clawID[:8])
 			time.Sleep(500 * time.Millisecond)
 		}
 
@@ -1525,7 +1524,7 @@ func (s *Server) resolvePipelineStageSkips(clawID string, stage pipeline.Stage, 
 	visited := map[string]bool{}
 	for current != nil {
 		if visited[current.ID] {
-			log.Printf("[pipeline] claw %s: skip cycle reached at stage %q", clawID[:8], current.ID)
+			logf("[pipeline] claw %s: skip cycle reached at stage %q", clawID[:8], current.ID)
 			return *current
 		}
 		visited[current.ID] = true
@@ -1535,10 +1534,10 @@ func (s *Server) resolvePipelineStageSkips(clawID string, stage pipeline.Stage, 
 		}
 		target := pl.StageByID(targetID)
 		if target == nil {
-			log.Printf("[pipeline] claw %s: stage %q skip target %q not found", clawID[:8], current.ID, targetID)
+			logf("[pipeline] claw %s: stage %q skip target %q not found", clawID[:8], current.ID, targetID)
 			return *current
 		}
-		log.Printf("[pipeline] claw %s: skipping stage %q to %q", clawID[:8], current.ID, target.ID)
+		logf("[pipeline] claw %s: skipping stage %q to %q", clawID[:8], current.ID, target.ID)
 		current = target
 	}
 	return stage
@@ -1607,10 +1606,10 @@ func (s *Server) autoTransitionAfterJudge(clawID, verdict string, ctx pipelineCo
 	}
 	stage := pl.StageForJudgeVerdict(verdict)
 	if stage == nil {
-		log.Printf("[pipeline] claw %s: no stage with judge_verdict=%q trigger found", clawID[:8], verdict)
+		logf("[pipeline] claw %s: no stage with judge_verdict=%q trigger found", clawID[:8], verdict)
 		return
 	}
-	log.Printf("[pipeline] claw %s: auto-transitioning to stage %q after judge verdict=%s", clawID[:8], stage.ID, verdict)
+	logf("[pipeline] claw %s: auto-transitioning to stage %q after judge verdict=%s", clawID[:8], stage.ID, verdict)
 	s.transitionPipelineStageWithContext(clawID, *stage, ctx)
 }
 
@@ -1635,7 +1634,7 @@ func (s *Server) evaluateGate(clawID, stageID string, gate *pipeline.Gate) *Gate
 		} else {
 			result.Verdict = "error"
 		}
-		log.Printf("[pipeline] gate %q for claw %s: output %q not found, verdict=%s", stageID, clawID[:8], gate.Output, result.Verdict)
+		logf("[pipeline] gate %q for claw %s: output %q not found, verdict=%s", stageID, clawID[:8], gate.Output, result.Verdict)
 		s.persistGateResult(clawID, stageID, gate, result)
 		return result
 	}
@@ -1649,7 +1648,7 @@ func (s *Server) evaluateGate(clawID, stageID string, gate *pipeline.Gate) *Gate
 				result.Verdict = "pass"
 				result.MatchedPath = gate.Pass.Path
 				result.MatchedValue = strVal
-				log.Printf("[pipeline] gate %q for claw %s: pass matched path=%s value=%s", stageID, clawID[:8], gate.Pass.Path, strVal)
+				logf("[pipeline] gate %q for claw %s: pass matched path=%s value=%s", stageID, clawID[:8], gate.Pass.Path, strVal)
 				s.persistGateResult(clawID, stageID, gate, result)
 				return result
 			}
@@ -1665,7 +1664,7 @@ func (s *Server) evaluateGate(clawID, stageID string, gate *pipeline.Gate) *Gate
 				result.Verdict = "fail"
 				result.MatchedPath = gate.Fail.Path
 				result.MatchedValue = strVal
-				log.Printf("[pipeline] gate %q for claw %s: fail matched path=%s value=%s", stageID, clawID[:8], gate.Fail.Path, strVal)
+				logf("[pipeline] gate %q for claw %s: fail matched path=%s value=%s", stageID, clawID[:8], gate.Fail.Path, strVal)
 				s.persistGateResult(clawID, stageID, gate, result)
 				return result
 			}
@@ -1673,7 +1672,7 @@ func (s *Server) evaluateGate(clawID, stageID string, gate *pipeline.Gate) *Gate
 	}
 
 	// Neither pass nor fail matched — error
-	log.Printf("[pipeline] gate %q for claw %s: no conditions matched, verdict=error", stageID, clawID[:8])
+	logf("[pipeline] gate %q for claw %s: no conditions matched, verdict=error", stageID, clawID[:8])
 	s.persistGateResult(clawID, stageID, gate, result)
 	return result
 }
@@ -1692,7 +1691,7 @@ func (s *Server) persistGateResult(clawID, stageID string, gate *pipeline.Gate, 
 			created_at=excluded.created_at`,
 		clawID, stageID, gate.Output, result.Verdict, result.MatchedPath, result.MatchedValue, gate.Required, now())
 	if err != nil {
-		log.Printf("[pipeline] failed to persist gate result for claw %s stage %s: %v", clawID[:8], stageID, err)
+		logf("[pipeline] failed to persist gate result for claw %s stage %s: %v", clawID[:8], stageID, err)
 	}
 }
 
@@ -1737,10 +1736,10 @@ func (s *Server) autoTransitionAfterGate(clawID, stageID, verdict string, ctx pi
 	}
 	stage := pl.StageForGateResult(stageID, verdict)
 	if stage == nil {
-		log.Printf("[pipeline] claw %s: no stage with gate_result stage=%s verdict=%s trigger found", clawID[:8], stageID, verdict)
+		logf("[pipeline] claw %s: no stage with gate_result stage=%s verdict=%s trigger found", clawID[:8], stageID, verdict)
 		return
 	}
-	log.Printf("[pipeline] claw %s: auto-transitioning to stage %q after gate stage=%s verdict=%s", clawID[:8], stage.ID, stageID, verdict)
+	logf("[pipeline] claw %s: auto-transitioning to stage %q after gate stage=%s verdict=%s", clawID[:8], stage.ID, stageID, verdict)
 	s.transitionPipelineStageWithContext(clawID, *stage, ctx)
 }
 
@@ -1754,7 +1753,7 @@ func (s *Server) initializePipelineEntryIfNeeded(clawID string) bool {
 	}
 
 	ctx, ok := s.findPipelineContextForClaw(clawID)
-	log.Printf("[pipeline] initializePipelineEntryIfNeeded: claw=%s pipeline=%s found=%v issueID=%q", clawID[:8], ctx.Name(), ok, ctx.IssueID)
+	logf("[pipeline] initializePipelineEntryIfNeeded: claw=%s pipeline=%s found=%v issueID=%q", clawID[:8], ctx.Name(), ok, ctx.IssueID)
 	if !ok {
 		return false
 	}
@@ -1784,7 +1783,7 @@ func (s *Server) stopAgentWithReason(clawID, reason string, skipVMTerminate bool
 	pipelineCtx, hasPipelineCtx := s.findPipelineContextForClaw(clawID)
 	factory, issueID := s.findFactoryForClaw(clawID)
 	if factory == nil && (!hasPipelineCtx || pipelineCtx.Workflow == nil) {
-		log.Printf("[stopAgent] claw %s: no issue tracker context found, skipping issue tracker comment", clawID[:8])
+		logf("[stopAgent] claw %s: no issue tracker context found, skipping issue tracker comment", clawID[:8])
 	}
 
 	// Fetch tenantID + provider info for broadcast + VM cleanup
@@ -1795,7 +1794,7 @@ func (s *Server) stopAgentWithReason(clawID, reason string, skipVMTerminate bool
 	safeReason := firstUsefulFailureLines(sanitizeFailureDetails(reason), 4)
 	res, updateErr := s.db.Exec(`UPDATE claws SET status='error', bootstrap_status='', bootstrap_diagnostic=? WHERE id=? AND status != 'deleted'`, safeReason, clawID)
 	if updateErr != nil {
-		log.Printf("[stopAgent] failed to mark claw %s as error: %v", clawID[:8], updateErr)
+		logf("[stopAgent] failed to mark claw %s as error: %v", clawID[:8], updateErr)
 	} else {
 		rowsAffected, _ := res.RowsAffected()
 		if rowsAffected == 0 {
@@ -1811,7 +1810,7 @@ func (s *Server) stopAgentWithReason(clawID, reason string, skipVMTerminate bool
 			Detail:          map[string]any{"reason": safeReason},
 			OccurredAt:      now(),
 		}); err != nil {
-			log.Printf("[task-run-analytics] failed to record agent stop for claw %s: %v", clawID, err)
+			logf("[task-run-analytics] failed to record agent stop for claw %s: %v", clawID, err)
 		}
 		if s.cronScheduler != nil {
 			s.cronScheduler.finishRunByClawID(clawID, "failed", safeReason)
@@ -1845,7 +1844,7 @@ func (s *Server) stopAgentWithReason(clawID, reason string, skipVMTerminate bool
 		go s.terminateVM(provider, providerID)
 	}
 
-	log.Printf("[stopAgent] claw %s stopped: %s", clawID[:8], reason)
+	logf("[stopAgent] claw %s stopped: %s", clawID[:8], reason)
 }
 
 func isFailureFeedbackWorkflowIntegration(integration string) bool {
@@ -1867,7 +1866,7 @@ func (s *Server) commentWorkflowAgentStopToTracker(clawID string, ctx pipelineCo
 	case "github-issues":
 		repo, issueNum, ok := parseGitHubIssueWorkflowID(ctx.IssueID)
 		if !ok {
-			log.Printf("[stopAgent] invalid GitHub workflow issue id %q for claw %s", ctx.IssueID, shortID(clawID))
+			logf("[stopAgent] invalid GitHub workflow issue id %q for claw %s", ctx.IssueID, shortID(clawID))
 			return
 		}
 		token := s.resolveGitHubIssuesTokenForWorkflow(ctx.Workspace.Name, ctx.Workflow)
@@ -1902,7 +1901,7 @@ func (s *Server) commentWorkflowAgentStopToTracker(clawID string, ctx pipelineCo
 			_ = s.moveJiraIssue(tracker, ctx.IssueID, feedback.AgentStatusError)
 		}
 		if err := s.commentJiraIssue(tracker, ctx.IssueID, s.buildAgentStopComment(clawID, reason)); err != nil {
-			log.Printf("[stopAgent] failed to comment Jira issue %s: %v", ctx.IssueID, err)
+			logf("[stopAgent] failed to comment Jira issue %s: %v", ctx.IssueID, err)
 		}
 	}
 }
@@ -1934,18 +1933,18 @@ func (s *Server) commentAgentStopToTracker(clawID string, factory *types.Factory
 		token := s.resolveLinearTokenForFactory(factory)
 		if token != "" {
 			if err := s.commentLinearIssue(token, issueID, getCommentBody()); err != nil {
-				log.Printf("[stopAgent] failed to comment Linear issue %s: %v", issueID, err)
+				logf("[stopAgent] failed to comment Linear issue %s: %v", issueID, err)
 			} else {
-				log.Printf("[stopAgent] commented Linear issue %s", issueID)
+				logf("[stopAgent] commented Linear issue %s", issueID)
 			}
 		}
 	case "shortcut":
 		token := s.resolveShortcutToken(factory.Workspace)
 		if token != "" {
 			if err := commentShortcutIssue(s.resolveShortcutBaseURL(), token, issueID, getCommentBody()); err != nil {
-				log.Printf("[stopAgent] failed to comment Shortcut story %s: %v", issueID, err)
+				logf("[stopAgent] failed to comment Shortcut story %s: %v", issueID, err)
 			} else {
-				log.Printf("[stopAgent] commented Shortcut story %s", issueID)
+				logf("[stopAgent] commented Shortcut story %s", issueID)
 			}
 		}
 	case "github-issues":
@@ -1957,9 +1956,9 @@ func (s *Server) commentAgentStopToTracker(clawID string, factory *types.Factory
 				var issueNum int
 				if _, err := fmt.Sscanf(parts[2], "%d", &issueNum); err == nil {
 					if err := commentGitHubIssue(token, repo, issueNum, getCommentBody()); err != nil {
-						log.Printf("[stopAgent] failed to comment GitHub issue %s: %v", issueID, err)
+						logf("[stopAgent] failed to comment GitHub issue %s: %v", issueID, err)
 					} else {
-						log.Printf("[stopAgent] commented GitHub issue %s", issueID)
+						logf("[stopAgent] commented GitHub issue %s", issueID)
 					}
 				}
 			}
@@ -1967,9 +1966,9 @@ func (s *Server) commentAgentStopToTracker(clawID string, factory *types.Factory
 	case "jira":
 		if tracker, ok := s.resolveJiraTrackerForFactory(factory); ok {
 			if err := s.commentJiraIssue(tracker, issueID, getCommentBody()); err != nil {
-				log.Printf("[stopAgent] failed to comment Jira issue %s: %v", issueID, err)
+				logf("[stopAgent] failed to comment Jira issue %s: %v", issueID, err)
 			} else {
-				log.Printf("[stopAgent] commented Jira issue %s", issueID)
+				logf("[stopAgent] commented Jira issue %s", issueID)
 			}
 		}
 	}

--- a/pkg/hub/pipeline_state.go
+++ b/pkg/hub/pipeline_state.go
@@ -1,7 +1,5 @@
 package hub
 
-import "log"
-
 // getPipelineStage returns the current pipeline stage ID for a claw.
 // Returns "" if the claw has no pipeline stage set.
 func (s *Server) getPipelineStage(clawID string) string {
@@ -16,12 +14,12 @@ func (s *Server) getPipelineStage(clawID string) string {
 func (s *Server) claimPipelineStageTransition(clawID, stageID string) bool {
 	res, err := s.db.Exec(`UPDATE claws SET pipeline_stage=? WHERE id=? AND pipeline_stage<>?`, stageID, clawID, stageID)
 	if err != nil {
-		log.Printf("[pipeline] failed to set stage %q for claw %s: %v", stageID, clawID[:8], err)
+		logf("[pipeline] failed to set stage %q for claw %s: %v", stageID, clawID[:8], err)
 		return false
 	}
 	rows, err := res.RowsAffected()
 	if err != nil {
-		log.Printf("[pipeline] failed to inspect stage transition for claw %s: %v", clawID[:8], err)
+		logf("[pipeline] failed to inspect stage transition for claw %s: %v", clawID[:8], err)
 		return false
 	}
 	return rows > 0
@@ -36,7 +34,7 @@ func (s *Server) recordPipelineStageVisit(clawID, stageID string) {
 		ON CONFLICT(claw_id, stage_id) DO NOTHING`,
 		clawID, stageID, now())
 	if err != nil {
-		log.Printf("[pipeline] failed to record stage visit for claw %s stage %s: %v", clawID[:8], stageID, err)
+		logf("[pipeline] failed to record stage visit for claw %s stage %s: %v", clawID[:8], stageID, err)
 	}
 }
 

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"regexp"
 	"strconv"
@@ -112,11 +111,11 @@ func (s *Server) storePRMention(clawID, repo string, prNumber int, prURL string)
 		`INSERT INTO claw_prs(id,claw_id,repo,pr_number,pr_url,last_comment_id,last_comment_at,last_review_id,last_ci_sha,created_at) VALUES(?,?,?,?,?,?,?,?,?,?)`,
 		prID, clawID, repo, prNumber, prURL, maxCommentID, lastCommentAt, maxReviewID, headSHA, now(),
 	); err != nil {
-		log.Printf("[pr-watcher] failed to persist PR %s#%d for claw %s: %v", repo, prNumber, clawID[:8], err)
+		logf("[pr-watcher] failed to persist PR %s#%d for claw %s: %v", repo, prNumber, clawID[:8], err)
 		return
 	}
 	if _, runID, _, ok, err := s.taskRunContextForClaw(clawID); err != nil {
-		log.Printf("[task-run-analytics] failed to resolve task run for PR mention claw %s: %v", clawID, err)
+		logf("[task-run-analytics] failed to resolve task run for PR mention claw %s: %v", clawID, err)
 	} else if ok {
 		if err := s.associateTaskRunPR(TaskRunPR{
 			RunID:      runID,
@@ -127,10 +126,10 @@ func (s *Server) storePRMention(clawID, repo string, prNumber int, prURL string)
 			State:      taskRunPRStateOpen,
 			OccurredAt: now(),
 		}); err != nil {
-			log.Printf("[task-run-analytics] failed to associate PR %s#%d for claw %s: %v", repo, prNumber, clawID, err)
+			logf("[task-run-analytics] failed to associate PR %s#%d for claw %s: %v", repo, prNumber, clawID, err)
 		}
 	}
-	log.Printf("[pr-watcher] detected PR %s#%d for claw %s", repo, prNumber, clawID[:8])
+	logf("[pr-watcher] detected PR %s#%d for claw %s", repo, prNumber, clawID[:8])
 }
 
 // scanMessageForPRs extracts and stores any PR URLs found in a message.
@@ -179,7 +178,7 @@ func (s *Server) pollAllPRs() {
 		if strings.Contains(err.Error(), "database is closed") {
 			return
 		}
-		log.Printf("[pr-watcher] poll query error: %v", err)
+		logf("[pr-watcher] poll query error: %v", err)
 		return
 	}
 	defer rows.Close()
@@ -208,12 +207,12 @@ func (s *Server) pollAllPRs() {
 	}
 
 	if len(prs) > 0 {
-		log.Printf("[pr-watcher] poll: checking %d tracked PR(s)", len(prs))
+		logf("[pr-watcher] poll: checking %d tracked PR(s)", len(prs))
 	}
 
 	terminatedClaws := map[string]bool{}
 	for _, r := range prs {
-		log.Printf("[pr-watcher] poll: claw=%s status=%s pr=%s", r.pr.clawID[:8], r.clawStatus, r.pr.prURL)
+		logf("[pr-watcher] poll: claw=%s status=%s pr=%s", r.pr.clawID[:8], r.clawStatus, r.pr.prURL)
 		// Skip PRs for claws that were already terminated in this poll
 		if terminatedClaws[r.pr.clawID] {
 			continue
@@ -221,7 +220,7 @@ func (s *Server) pollAllPRs() {
 
 		pipelineCtx, hasPipelineCtx := s.findPipelineContextForClaw(r.pr.clawID)
 		isPipelineDriven := hasPipelineCtx && parsePipelineForContext(pipelineCtx) != nil
-		log.Printf("[pr-watcher] claw=%s pipeline=%s pipelineDriven=%v", r.pr.clawID[:8], pipelineCtx.Name(), isPipelineDriven)
+		logf("[pr-watcher] claw=%s pipeline=%s pipelineDriven=%v", r.pr.clawID[:8], pipelineCtx.Name(), isPipelineDriven)
 
 		// Check if PR is merged/closed for any non-terminal claw status.
 		if s.checkPRMerged(r.pr, token) {
@@ -237,13 +236,13 @@ func (s *Server) pollAllPRs() {
 		}
 		commentsData, err := githubAPIList(fmt.Sprintf("repos/%s/issues/%d/comments", r.pr.repo, r.pr.prNumber), repoToken)
 		if err != nil {
-			log.Printf("[pr-watcher] error fetching comments for %s: %v", r.pr.prURL, err)
+			logf("[pr-watcher] error fetching comments for %s: %v", r.pr.prURL, err)
 			continue
 		}
 		// Always check bugbot and greptile comments
 		s.checkBugbotComments(r.pr, commentsData)
 		s.checkGreptileComments(r.pr, commentsData)
-		log.Printf("[pr-watcher] checking %d comment(s) for claw %s (watermark=%d, forward=%v)", len(commentsData), r.pr.clawID[:8], r.pr.lastCommentID, isPipelineDriven)
+		logf("[pr-watcher] checking %d comment(s) for claw %s (watermark=%d, forward=%v)", len(commentsData), r.pr.clawID[:8], r.pr.lastCommentID, isPipelineDriven)
 		s.checkPRComments(r.pr, commentsData, prCommentOptions{
 			skipBugbot:   true,
 			skipGreptile: true,
@@ -255,7 +254,7 @@ func (s *Server) pollAllPRs() {
 		// Fetch and track them separately from issue comments.
 		reviewCommentsData, err := githubAPIList(fmt.Sprintf("repos/%s/pulls/%d/comments", r.pr.repo, r.pr.prNumber), repoToken)
 		if err != nil {
-			log.Printf("[pr-watcher] error fetching review comments for %s: %v", r.pr.prURL, err)
+			logf("[pr-watcher] error fetching review comments for %s: %v", r.pr.prURL, err)
 		} else {
 			s.checkGreptileReviewComments(r.pr, reviewCommentsData)
 			s.updateReviewCommentWatermark(r.pr, reviewCommentsData)
@@ -263,7 +262,7 @@ func (s *Server) pollAllPRs() {
 
 		reviewsData, err := githubAPIList(fmt.Sprintf("repos/%s/pulls/%d/reviews", r.pr.repo, r.pr.prNumber), repoToken)
 		if err != nil {
-			log.Printf("[pr-watcher] error fetching reviews for %s: %v", r.pr.prURL, err)
+			logf("[pr-watcher] error fetching reviews for %s: %v", r.pr.prURL, err)
 		} else {
 			s.checkPRReviews(r.pr, reviewsData)
 			s.updatePRReviewWatermark(r.pr, reviewsData)
@@ -419,7 +418,7 @@ func (s *Server) checkPRComments(pr clawPR, commentsData []interface{}, opts prC
 		return
 	}
 
-	log.Printf("[pr-watcher] forwarding %d new comment(s) to claw %s", len(newComments), pr.clawID[:8])
+	logf("[pr-watcher] forwarding %d new comment(s) to claw %s", len(newComments), pr.clawID[:8])
 	s.injectHubMessageByID(pr.clawID, strings.Join(newComments, "\n\n"))
 }
 
@@ -710,12 +709,12 @@ func (s *Server) claimPRFeedbackDelivery(clawID, feedbackType string, id int64) 
 		clawID, feedbackType, id, now(),
 	)
 	if err != nil {
-		log.Printf("[pr-watcher] failed to claim %s %d for claw %s: %v", feedbackType, id, clawID, err)
+		logf("[pr-watcher] failed to claim %s %d for claw %s: %v", feedbackType, id, clawID, err)
 		return true
 	}
 	affected, err := result.RowsAffected()
 	if err != nil {
-		log.Printf("[pr-watcher] failed to inspect %s claim %d for claw %s: %v", feedbackType, id, clawID, err)
+		logf("[pr-watcher] failed to inspect %s claim %d for claw %s: %v", feedbackType, id, clawID, err)
 		return true
 	}
 	return affected > 0
@@ -794,7 +793,7 @@ func (s *Server) injectMessage(clawID, content, role string) {
 		msg.ID, msg.ClawID, msg.TenantID, msg.Role, msg.Content, msg.Format, msg.CreatedAt,
 	)
 	if err != nil {
-		log.Printf("[pr-watcher] failed to insert message: %v", err)
+		logf("[pr-watcher] failed to insert message: %v", err)
 		return
 	}
 
@@ -814,7 +813,7 @@ func (s *Server) injectMessage(clawID, content, role string) {
 			queueLen := len(cc.messageQueue)
 			cc.mu.Unlock()
 			acceptedForAgent = true
-			log.Printf("[pr-watcher] queued injected message for claw %s (queue length: %d)", shortID(clawID), queueLen)
+			logf("[pr-watcher] queued injected message for claw %s (queue length: %d)", shortID(clawID), queueLen)
 		} else {
 			conn := cc.conn
 			cc.mu.Unlock()
@@ -823,7 +822,7 @@ func (s *Server) injectMessage(clawID, content, role string) {
 			err := wsjson.Write(ctx, conn, types.WSMessage{Type: "message", Payload: msg})
 			cancel()
 			if err != nil {
-				log.Printf("[pr-watcher] failed to send injected message to claw %s: %v, queueing", shortID(clawID), err)
+				logf("[pr-watcher] failed to send injected message to claw %s: %v, queueing", shortID(clawID), err)
 				s.mu.RLock()
 				currentCC := s.claws[clawID]
 				s.mu.RUnlock()
@@ -833,12 +832,12 @@ func (s *Server) injectMessage(clawID, content, role string) {
 					queueLen := len(currentCC.messageQueue)
 					currentCC.mu.Unlock()
 					acceptedForAgent = true
-					log.Printf("[pr-watcher] queued injected message for claw %s after send failure (queue length: %d)", shortID(clawID), queueLen)
+					logf("[pr-watcher] queued injected message for claw %s after send failure (queue length: %d)", shortID(clawID), queueLen)
 					go s.sendNextQueuedMessage(currentCC)
 				}
 			} else {
 				acceptedForAgent = true
-				log.Printf("[pr-watcher] delivered injected message to claw %s", shortID(clawID))
+				logf("[pr-watcher] delivered injected message to claw %s", shortID(clawID))
 			}
 		}
 	}
@@ -867,9 +866,9 @@ func (s *Server) injectMessage(clawID, content, role string) {
 					scToken := s.resolveShortcutToken(factory.Workspace)
 					if scToken != "" {
 						if err := moveShortcutStory(s.resolveShortcutBaseURL(), scToken, issueID, factory.WorkingStatus); err != nil {
-							log.Printf("[factory] failed to move story %s to working status '%s' on resume: %v", issueID, factory.WorkingStatus, err)
+							logf("[factory] failed to move story %s to working status '%s' on resume: %v", issueID, factory.WorkingStatus, err)
 						} else {
-							log.Printf("[factory] moved story %s to working status '%s' on resume", issueID, factory.WorkingStatus)
+							logf("[factory] moved story %s to working status '%s' on resume", issueID, factory.WorkingStatus)
 						}
 					}
 				} else if strings.HasPrefix(issueID, "gh-") {
@@ -887,9 +886,9 @@ func (s *Server) injectMessage(clawID, content, role string) {
 									base = "https://api.github.com"
 								}
 								if err := moveGitHubIssue(ghToken, repo, issueNum, factory.WorkingStatus, base); err != nil {
-									log.Printf("[factory] failed to move GitHub issue %s to working status '%s' on resume: %v", issueID, factory.WorkingStatus, err)
+									logf("[factory] failed to move GitHub issue %s to working status '%s' on resume: %v", issueID, factory.WorkingStatus, err)
 								} else {
-									log.Printf("[factory] moved GitHub issue %s to working status '%s' on resume", issueID, factory.WorkingStatus)
+									logf("[factory] moved GitHub issue %s to working status '%s' on resume", issueID, factory.WorkingStatus)
 								}
 							}
 						}
@@ -899,9 +898,9 @@ func (s *Server) injectMessage(clawID, content, role string) {
 					linearToken := s.resolveLinearTokenForFactory(factory)
 					if linearToken != "" {
 						if err := s.moveLinearIssueOnServer(linearToken, issueID, factory.WorkingStatus); err != nil {
-							log.Printf("[factory] failed to move issue %s to working status '%s' on resume: %v", issueID, factory.WorkingStatus, err)
+							logf("[factory] failed to move issue %s to working status '%s' on resume: %v", issueID, factory.WorkingStatus, err)
 						} else {
-							log.Printf("[factory] moved issue %s to working status '%s' on resume", issueID, factory.WorkingStatus)
+							logf("[factory] moved issue %s to working status '%s' on resume", issueID, factory.WorkingStatus)
 						}
 					}
 				}
@@ -909,7 +908,7 @@ func (s *Server) injectMessage(clawID, content, role string) {
 		}
 	}
 
-	log.Printf("[pr-watcher] injected message into claw %s", shortID(clawID))
+	logf("[pr-watcher] injected message into claw %s", shortID(clawID))
 }
 
 // githubAPI makes a GET request to the GitHub API and returns parsed JSON.
@@ -1051,7 +1050,7 @@ func (s *Server) checkPRMerged(pr clawPR, token string) bool {
 	state, _ := data["state"].(string)
 	merged, _ := data["merged"].(bool)
 
-	log.Printf("[pr-watcher] checkPRMerged: claw=%s pr=%s state=%s merged=%v", pr.clawID[:8], pr.prURL, state, merged)
+	logf("[pr-watcher] checkPRMerged: claw=%s pr=%s state=%s merged=%v", pr.clawID[:8], pr.prURL, state, merged)
 
 	if state != "closed" && !merged {
 		return false // still open
@@ -1065,7 +1064,7 @@ func (s *Server) checkPRMerged(pr clawPR, token string) bool {
 
 	// If the PR was closed without merging, notify the claw and let it decide — don't terminate.
 	if state == "closed" && !merged {
-		log.Printf("[pr-watcher] PR %s#%d closed without merge — stopping claw %s", pr.repo, pr.prNumber, clawID[:8])
+		logf("[pr-watcher] PR %s#%d closed without merge — stopping claw %s", pr.repo, pr.prNumber, clawID[:8])
 		_, _ = s.db.Exec(`DELETE FROM claw_prs WHERE id=?`, pr.id)
 
 		pipelineCtx, hasPipelineCtx := s.findPipelineContextForClaw(clawID)
@@ -1093,7 +1092,7 @@ func (s *Server) checkPRMerged(pr clawPR, token string) bool {
 	}
 
 	// PR was merged — run pipeline on_enter if applicable, then terminate the claw.
-	log.Printf("[pr-watcher] PR %s#%d merged — terminating claw %s", pr.repo, pr.prNumber, clawID[:8])
+	logf("[pr-watcher] PR %s#%d merged — terminating claw %s", pr.repo, pr.prNumber, clawID[:8])
 
 	// Track analytics for PR merge
 	mergeCtx, hasMergeCtx := s.findPipelineContextForClaw(clawID)
@@ -1122,9 +1121,9 @@ func (s *Server) checkPRMerged(pr clawPR, token string) bool {
 			scToken := s.resolveShortcutToken(mergeFactory.Workspace)
 			if scToken != "" {
 				if err := moveShortcutStory(s.resolveShortcutBaseURL(), scToken, mergeIssueID, mergeFactory.DoneStatus); err != nil {
-					log.Printf("[factory] failed to move story %s to done status '%s': %v", mergeIssueID, mergeFactory.DoneStatus, err)
+					logf("[factory] failed to move story %s to done status '%s': %v", mergeIssueID, mergeFactory.DoneStatus, err)
 				} else {
-					log.Printf("[factory] moved story %s to done status '%s'", mergeIssueID, mergeFactory.DoneStatus)
+					logf("[factory] moved story %s to done status '%s'", mergeIssueID, mergeFactory.DoneStatus)
 				}
 			}
 		} else if strings.HasPrefix(mergeIssueID, "gh-") {
@@ -1142,9 +1141,9 @@ func (s *Server) checkPRMerged(pr clawPR, token string) bool {
 							base = "https://api.github.com"
 						}
 						if err := moveGitHubIssue(ghToken, repo, issueNum, mergeFactory.DoneStatus, base); err != nil {
-							log.Printf("[factory] failed to move GitHub issue %s to done status '%s': %v", mergeIssueID, mergeFactory.DoneStatus, err)
+							logf("[factory] failed to move GitHub issue %s to done status '%s': %v", mergeIssueID, mergeFactory.DoneStatus, err)
 						} else {
-							log.Printf("[factory] moved GitHub issue %s to done status '%s'", mergeIssueID, mergeFactory.DoneStatus)
+							logf("[factory] moved GitHub issue %s to done status '%s'", mergeIssueID, mergeFactory.DoneStatus)
 						}
 					}
 				}
@@ -1154,9 +1153,9 @@ func (s *Server) checkPRMerged(pr clawPR, token string) bool {
 			linearToken := s.resolveLinearTokenForFactory(mergeFactory)
 			if linearToken != "" {
 				if err := s.moveLinearIssueOnServer(linearToken, mergeIssueID, mergeFactory.DoneStatus); err != nil {
-					log.Printf("[factory] failed to move issue %s to done status '%s': %v", mergeIssueID, mergeFactory.DoneStatus, err)
+					logf("[factory] failed to move issue %s to done status '%s': %v", mergeIssueID, mergeFactory.DoneStatus, err)
 				} else {
-					log.Printf("[factory] moved issue %s to done status '%s'", mergeIssueID, mergeFactory.DoneStatus)
+					logf("[factory] moved issue %s to done status '%s'", mergeIssueID, mergeFactory.DoneStatus)
 				}
 			}
 		}
@@ -1237,7 +1236,7 @@ func (s *Server) checkPRConditions(pr clawPR, token string, ctx pipelineContext)
 	if cond.CI == "passing" {
 		prData, err := githubAPIWithBase(ghBase, fmt.Sprintf("repos/%s/pulls/%d", pr.repo, pr.prNumber), repoToken)
 		if err != nil {
-			log.Printf("[pr-conditions] claw %s: failed to get PR data: %v", pr.clawID[:8], err)
+			logf("[pr-conditions] claw %s: failed to get PR data: %v", pr.clawID[:8], err)
 			return nil
 		}
 		headObj, _ := prData["head"].(map[string]interface{})
@@ -1247,7 +1246,7 @@ func (s *Server) checkPRConditions(pr clawPR, token string, ctx pipelineContext)
 		}
 		checksData, err := githubAPIWithBase(ghBase, fmt.Sprintf("repos/%s/commits/%s/check-runs", pr.repo, sha), repoToken)
 		if err != nil {
-			log.Printf("[pr-conditions] claw %s: failed to get check-runs: %v", pr.clawID[:8], err)
+			logf("[pr-conditions] claw %s: failed to get check-runs: %v", pr.clawID[:8], err)
 			return nil
 		}
 		checkRuns, _ := checksData["check_runs"].([]interface{})
@@ -1271,7 +1270,7 @@ func (s *Server) checkPRConditions(pr clawPR, token string, ctx pipelineContext)
 	if cond.Reviews == "clean" {
 		reviewsData, err := githubAPIListWithBase(ghBase, fmt.Sprintf("repos/%s/pulls/%d/reviews", pr.repo, pr.prNumber), repoToken)
 		if err != nil {
-			log.Printf("[pr-conditions] claw %s: failed to get reviews: %v", pr.clawID[:8], err)
+			logf("[pr-conditions] claw %s: failed to get reviews: %v", pr.clawID[:8], err)
 			return nil
 		}
 		latestReviewStateByUser := make(map[string]struct {
@@ -1308,7 +1307,7 @@ func (s *Server) checkPRConditions(pr clawPR, token string, ctx pipelineContext)
 	if cond.QuietFor != "" {
 		dur, err := time.ParseDuration(cond.QuietFor)
 		if err != nil {
-			log.Printf("[pr-conditions] claw %s: invalid quiet_for %q: %v", pr.clawID[:8], cond.QuietFor, err)
+			logf("[pr-conditions] claw %s: invalid quiet_for %q: %v", pr.clawID[:8], cond.QuietFor, err)
 			return nil
 		}
 		// If no comments yet, use PR creation time — a PR with no comments

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"io/fs"
 	"log"
+	"log/slog"
 	"mime"
 	"net/http"
 	"net/url"
@@ -28,6 +29,7 @@ import (
 
 	"github.com/elasticclaw/elasticclaw/pkg/cliversion"
 	"github.com/elasticclaw/elasticclaw/pkg/hub/artifact"
+	"github.com/elasticclaw/elasticclaw/pkg/hub/logger"
 	"github.com/elasticclaw/elasticclaw/pkg/hub/pipeline"
 	daytona "github.com/elasticclaw/elasticclaw/pkg/provider/daytona"
 	exedevProvider "github.com/elasticclaw/elasticclaw/pkg/provider/exedev"
@@ -43,6 +45,7 @@ import (
 type Server struct {
 	db        *sql.DB
 	addr      string
+	logger    *slog.Logger
 	hubCfg    *types.HubConfig
 	identity  *HubIdentity
 	mux       *http.ServeMux
@@ -209,6 +212,7 @@ func NewServer(addr, dbPath, identityDir string, hubCfg *types.HubConfig) (*Serv
 	srv := &Server{
 		db:                db,
 		addr:              addr,
+		logger:            slog.Default(),
 		hubCfg:            hubCfg,
 		identity:          id,
 		artifacts:         artifacts,
@@ -268,7 +272,7 @@ func (s *Server) Run(opts ...RunOptions) error {
 	if s.hubCfg.UIPassword == "" {
 		log.Printf("⚠️  Web UI password not set — using default: 'admin'. Set ui_password in hub.yaml to secure the UI.")
 	}
-	return http.ListenAndServe(s.addr, withRecovery(corsMiddleware(mux)))
+	return http.ListenAndServe(s.addr, withRecovery(s.withRequestID(corsMiddleware(mux))))
 }
 
 func (s *Server) registerRoutes(mux *http.ServeMux) {
@@ -427,6 +431,7 @@ func (s *Server) withAuth(next http.HandlerFunc) http.HandlerFunc {
 			return
 		}
 		ctx := context.WithValue(r.Context(), ctxTenantKey{}, tenantID)
+		ctx = logger.NewContext(ctx, logger.FromContext(ctx).With("tenant_id", tenantID))
 		if githubLogin != "" {
 			ctx = context.WithValue(ctx, ctxGitHubLoginKey{}, githubLogin)
 		}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"log"
 	"log/slog"
 	"mime"
 	"net/http"
@@ -208,7 +207,7 @@ func NewServer(addr, dbPath, identityDir string, hubCfg *types.HubConfig) (*Serv
 		_ = db.Close()
 		return nil, fmt.Errorf("hub identity: %w", err)
 	}
-	log.Printf("Hub SSH public key:\n%s", id.PublicKey)
+	logf("Hub SSH public key:\n%s", id.PublicKey)
 	srv := &Server{
 		db:                db,
 		addr:              addr,
@@ -236,7 +235,7 @@ func NewServer(addr, dbPath, identityDir string, hubCfg *types.HubConfig) (*Serv
 	// Start cron scheduler for workflow triggers
 	srv.cronScheduler = newCronScheduler(srv)
 	if err := srv.cronScheduler.start(); err != nil {
-		log.Printf("[cron] failed to start scheduler: %v", err)
+		logf("[cron] failed to start scheduler: %v", err)
 	}
 	srv.startIntegrationPoller()
 
@@ -258,19 +257,19 @@ func (s *Server) Run(opts ...RunOptions) error {
 
 	// Serve embedded web UI (static export)
 	if noWebUI {
-		log.Printf("[hub] web UI disabled (--no-web-ui)")
+		logf("[hub] web UI disabled (--no-web-ui)")
 	} else if webFS, err := webui.FS(); err == nil {
 		if _, indexErr := webFS.Open("index.html"); indexErr != nil {
-			log.Printf("[hub] web UI not built — run: make build-web")
+			logf("[hub] web UI not built — run: make build-web")
 		} else {
 			s.serveWebUI(mux, webFS)
-			log.Printf("[hub] serving embedded web UI")
+			logf("[hub] serving embedded web UI")
 		}
 	}
 
-	log.Printf("ElasticClaw Hub listening on %s", s.addr)
+	logf("ElasticClaw Hub listening on %s", s.addr)
 	if s.hubCfg.UIPassword == "" {
-		log.Printf("⚠️  Web UI password not set — using default: 'admin'. Set ui_password in hub.yaml to secure the UI.")
+		logf("⚠️  Web UI password not set — using default: 'admin'. Set ui_password in hub.yaml to secure the UI.")
 	}
 	return http.ListenAndServe(s.addr, withRecovery(s.withRequestID(corsMiddleware(mux))))
 }
@@ -787,7 +786,7 @@ func (s *Server) serveWebUI(mux *http.ServeMux, staticFS fs.FS) {
 		for _, e := range entries {
 			names = append(names, e.Name())
 		}
-		log.Printf("[webui] embedded files: %v", names)
+		logf("[webui] embedded files: %v", names)
 	}
 
 	// Wrap file server to serve index.html for directory requests
@@ -959,7 +958,7 @@ func (s *Server) handleClaws(w http.ResponseWriter, r *http.Request) {
 		tenantID,
 	)
 	if err != nil {
-		log.Printf("handleClaws query error: %v", err)
+		logfCtx(r.Context(), "handleClaws query error: %v", err)
 		writeErr(w, http.StatusInternalServerError, "internal", fmt.Sprintf("db error: %v", err))
 		return
 	}
@@ -1068,9 +1067,9 @@ func (s *Server) handleCreateClaw(w http.ResponseWriter, r *http.Request, tenant
 	for envName, secretRef := range req.SecretRefs {
 		if val, ok := hubSecrets[secretRef]; ok {
 			env[envName] = val
-			log.Printf("[create] injected secret_ref %s as %s into claw env", secretRef, envName)
+			logfCtx(r.Context(), "[create] injected secret_ref %s as %s into claw env", secretRef, envName)
 		} else {
-			log.Printf("[create] WARNING: secret_ref %q not found in hub secrets", secretRef)
+			logfCtx(r.Context(), "[create] WARNING: secret_ref %q not found in hub secrets", secretRef)
 		}
 	}
 	req.Env = env
@@ -1098,7 +1097,7 @@ func (s *Server) handleCreateClaw(w http.ResponseWriter, r *http.Request, tenant
 	if req.Docker {
 		dockerEnabled = 1
 	}
-	log.Printf("[create] claw %s: nix=%d docker=%d", req.Name, nixEnabled, dockerEnabled)
+	logfCtx(r.Context(), "[create] claw %s: nix=%d docker=%d", req.Name, nixEnabled, dockerEnabled)
 
 	// Resolve default model: explicit > llm_key lookup > default key > hub default
 	defaultModel := req.DefaultModel
@@ -1165,11 +1164,11 @@ func (s *Server) handleCreateClaw(w http.ResponseWriter, r *http.Request, tenant
 				}
 			}
 			if hubMCP == nil {
-				log.Printf("[create] MCP server %q not found in hub config, skipping", mcpRef.Name)
+				logfCtx(r.Context(), "[create] MCP server %q not found in hub config, skipping", mcpRef.Name)
 				continue
 			}
 			if !hubMCP.Enabled {
-				log.Printf("[create] MCP server %q is disabled, skipping", mcpRef.Name)
+				logfCtx(r.Context(), "[create] MCP server %q is disabled, skipping", mcpRef.Name)
 				continue
 			}
 			// Build command
@@ -1186,12 +1185,12 @@ func (s *Server) handleCreateClaw(w http.ResponseWriter, r *http.Request, tenant
 					cmd = []string{"docker", "run", "-i", "--rm", hubMCP.Image}
 				case types.MCPSourceSSE:
 					// SSE is remote — no local command, skip for now
-					log.Printf("[create] SSE MCP server %q not yet supported for local stdio", mcpRef.Name)
+					logfCtx(r.Context(), "[create] SSE MCP server %q not yet supported for local stdio", mcpRef.Name)
 					continue
 				}
 			}
 			if len(cmd) == 0 {
-				log.Printf("[create] MCP server %q has no command, skipping", mcpRef.Name)
+				logfCtx(r.Context(), "[create] MCP server %q has no command, skipping", mcpRef.Name)
 				continue
 			}
 			// Build env: merge hub config + template overrides + resolved secrets
@@ -1226,7 +1225,7 @@ func (s *Server) handleCreateClaw(w http.ResponseWriter, r *http.Request, tenant
 	}
 	req.ProviderName = providerNamePrefix + clawID[:8]
 	go func() {
-		log.Printf("Provisioning claw %s (%s) via %s (provider name: %s)...", req.Name, clawID, req.Provider, req.ProviderName)
+		logfCtx(r.Context(), "Provisioning claw %s (%s) via %s (provider name: %s)...", req.Name, clawID, req.Provider, req.ProviderName)
 		ctx := context.Background()
 		var provErr error
 
@@ -1246,7 +1245,7 @@ func (s *Server) handleCreateClaw(w http.ResponseWriter, r *http.Request, tenant
 		}
 
 		if provErr != nil {
-			log.Printf("provisioning failed for claw %s: %v", clawID, provErr)
+			logfCtx(r.Context(), "provisioning failed for claw %s: %v", clawID, provErr)
 			s.stopAgentWithReason(clawID, fmt.Sprintf("Provisioning failed: %v", provErr), false)
 		}
 	}()
@@ -1373,18 +1372,18 @@ func (s *Server) handleClawDetail(w http.ResponseWriter, r *http.Request) {
 				token := s.resolveLinearTokenForFactory(factory)
 				if token != "" {
 					if err := s.commentLinearIssue(token, issueID, "Agent stopped: killed manually via dashboard"); err != nil {
-						log.Printf("[kill] failed to comment Linear issue %s: %v", issueID, err)
+						logfCtx(r.Context(), "[kill] failed to comment Linear issue %s: %v", issueID, err)
 					} else {
-						log.Printf("[kill] commented Linear issue %s", issueID)
+						logfCtx(r.Context(), "[kill] commented Linear issue %s", issueID)
 					}
 				}
 			case "shortcut":
 				token := s.resolveShortcutToken(factory.Workspace)
 				if token != "" {
 					if err := commentShortcutIssue(s.resolveShortcutBaseURL(), token, issueID, "Agent stopped: killed manually via dashboard"); err != nil {
-						log.Printf("[kill] failed to comment Shortcut story %s: %v", issueID, err)
+						logfCtx(r.Context(), "[kill] failed to comment Shortcut story %s: %v", issueID, err)
 					} else {
-						log.Printf("[kill] commented Shortcut story %s", issueID)
+						logfCtx(r.Context(), "[kill] commented Shortcut story %s", issueID)
 					}
 				}
 			case "github-issues":
@@ -1396,9 +1395,9 @@ func (s *Server) handleClawDetail(w http.ResponseWriter, r *http.Request) {
 						var issueNum int
 						if _, err := fmt.Sscanf(parts[2], "%d", &issueNum); err == nil {
 							if err := commentGitHubIssue(token, repo, issueNum, "Agent stopped: killed manually via dashboard"); err != nil {
-								log.Printf("[kill] failed to comment GitHub issue %s: %v", issueID, err)
+								logfCtx(r.Context(), "[kill] failed to comment GitHub issue %s: %v", issueID, err)
 							} else {
-								log.Printf("[kill] commented GitHub issue %s", issueID)
+								logfCtx(r.Context(), "[kill] commented GitHub issue %s", issueID)
 							}
 						}
 					}
@@ -1408,7 +1407,7 @@ func (s *Server) handleClawDetail(w http.ResponseWriter, r *http.Request) {
 
 		res, err := s.db.Exec(`UPDATE claws SET status='deleted', bootstrap_status='' WHERE id = ? AND tenant_id = ? AND status != 'deleted'`, clawID, tenantID)
 		if err != nil {
-			log.Printf("kill: db soft-delete error for claw %s: %v", clawID, err)
+			logfCtx(r.Context(), "kill: db soft-delete error for claw %s: %v", clawID, err)
 			writeErr(w, http.StatusInternalServerError, "internal", fmt.Sprintf("db error: %v", err))
 			return
 		}
@@ -1575,7 +1574,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 				cc.messageQueue = append(cc.messageQueue, msg)
 				queueLen := len(cc.messageQueue)
 				cc.mu.Unlock()
-				log.Printf("[hub] message queued for %s (queue length: %d)", clawID[:8], queueLen)
+				logfCtx(r.Context(), "[hub] message queued for %s (queue length: %d)", clawID[:8], queueLen)
 			} else {
 				cc.mu.Unlock()
 				// Send immediately
@@ -2017,7 +2016,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 
 	tenantID, err := s.tenantByClawToken(rp.Token)
 	if err != nil {
-		log.Printf("[claw ws] invalid token for claw %.8s: received_len=%d configured_len=%d err=%v", rp.ClawID, len(rp.Token), len(s.hubCfg.ClawToken), err)
+		logfCtx(r.Context(), "[claw ws] invalid token for claw %.8s: received_len=%d configured_len=%d err=%v", rp.ClawID, len(rp.Token), len(s.hubCfg.ClawToken), err)
 		conn.Close(websocket.StatusPolicyViolation, "invalid token")
 		return
 	}
@@ -2075,7 +2074,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 			existing.statusConn = conn
 			existing.mu.Unlock()
 			s.mu.Unlock()
-			log.Printf("[bridge] ✓ status channel connected: %s (%s)", rp.Name, clawID[:8])
+			logfCtx(r.Context(), "[bridge] ✓ status channel connected: %s (%s)", rp.Name, clawID[:8])
 			_ = wsjson.Write(ctx, conn, types.WSMessage{Type: "registered", Payload: map[string]string{"claw_id": clawID, "channel": "status"}})
 			// Simple read loop for status channel — just keepalive
 			for {
@@ -2124,7 +2123,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 	s.claws[clawID] = cc
 	s.mu.Unlock()
 
-	log.Printf("[bridge] ✓ connected: %s (%s) gateway_ready=%v", rp.Name, clawID[:8], cc.gatewayReady)
+	logfCtx(r.Context(), "[bridge] ✓ connected: %s (%s) gateway_ready=%v", rp.Name, clawID[:8], cc.gatewayReady)
 
 	// Ack
 	_ = wsjson.Write(ctx, conn, types.WSMessage{Type: "registered", Payload: map[string]string{"claw_id": clawID}})
@@ -2194,7 +2193,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 			_, _ = s.db.Exec(`UPDATE claws SET status='offline', last_seen=? WHERE id=?`, now(), clawID)
 			s.broadcastToUsers(tenantID, types.WSMessage{Type: "claw_status", Payload: map[string]string{"claw_id": clawID, "status": "offline"}})
 		}
-		log.Printf("[bridge] ✗ disconnected: %s (%s)", rp.Name, clawID[:8])
+		logfCtx(r.Context(), "[bridge] ✗ disconnected: %s (%s)", rp.Name, clawID[:8])
 	}()
 
 	ticker := time.NewTicker(30 * time.Second)
@@ -2244,7 +2243,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 									Type:    "claw_status",
 									Payload: map[string]string{"claw_id": clawID, "status": "connected"},
 								})
-								log.Printf("[bridge] ✓ ready: %s (%s)", rp.Name, clawID[:8])
+								logfCtx(r.Context(), "[bridge] ✓ ready: %s (%s)", rp.Name, clawID[:8])
 								shouldWake = true
 								wakeConn = cc
 								go s.requestBootstrapCheckpoint(clawID)
@@ -2253,9 +2252,9 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 						if !hb.GatewayHealthy {
 							cc.gatewayUnhealthyCount++
 							if cc.gatewayUnhealthyCount == 1 {
-								log.Printf("[heartbeat] %s (%s): gateway unhealthy", rp.Name, clawID[:8])
+								logfCtx(r.Context(), "[heartbeat] %s (%s): gateway unhealthy", rp.Name, clawID[:8])
 							} else if cc.gatewayUnhealthyCount%4 == 0 {
-								log.Printf("[heartbeat] %s (%s): gateway unhealthy for %d consecutive checks", rp.Name, clawID[:8], cc.gatewayUnhealthyCount)
+								logfCtx(r.Context(), "[heartbeat] %s (%s): gateway unhealthy for %d consecutive checks", rp.Name, clawID[:8], cc.gatewayUnhealthyCount)
 							}
 							if cc.gatewayUnhealthyCount == 4 && !cc.streamingStartedAt.IsZero() {
 								go s.injectHubMessageByID(clawID, "[hub] The gateway has been unresponsive for about a minute. If you're stuck in a long operation, consider sending [DONE] and starting fresh.")
@@ -2264,10 +2263,10 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 						// Log context usage on every heartbeat when it crosses the 80% threshold,
 						// regardless of gateway health — don't silence diagnostics during outages.
 						if hb.ContextUsage != prevUsage && (hb.ContextUsage >= 80 || prevUsage >= 80) {
-							log.Printf("[heartbeat] %s (%s): context_usage=%d%%", rp.Name, clawID[:8], hb.ContextUsage)
+							logfCtx(r.Context(), "[heartbeat] %s (%s): context_usage=%d%%", rp.Name, clawID[:8], hb.ContextUsage)
 						}
 						if hb.GatewayHealthy && cc.gatewayUnhealthyCount > 0 {
-							log.Printf("[heartbeat] %s (%s): gateway recovered after %d unhealthy checks", rp.Name, clawID[:8], cc.gatewayUnhealthyCount)
+							logfCtx(r.Context(), "[heartbeat] %s (%s): gateway recovered after %d unhealthy checks", rp.Name, clawID[:8], cc.gatewayUnhealthyCount)
 							cc.gatewayUnhealthyCount = 0
 						}
 						// Inject context warning once per streaming turn when usage is >=95%
@@ -2312,7 +2311,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 			} else if msg.Type == "agent_activity" {
 				if activity, payload, ok := normalizeAgentActivityPayload(msg.Payload); ok {
 					if err := s.flushStreamingSegment(clawID, tenantID, cc); err != nil {
-						log.Printf("[agent_activity] flush streaming segment for %s: %v", clawID[:8], err)
+						logfCtx(r.Context(), "[agent_activity] flush streaming segment for %s: %v", clawID[:8], err)
 					}
 					if isBusyAgentActivity(activity) {
 						cc.mu.Lock()
@@ -2458,7 +2457,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				if strings.Contains(hm.Content, "[DONE]") {
 					go func() {
 						if _, err := s.requestCheckpoint(context.Background(), clawID, "done", "hub", false, checkpointRequestTimeout); err != nil {
-							log.Printf("[checkpoint] done request for %s failed: %v", shortID(clawID), err)
+							logfCtx(r.Context(), "[checkpoint] done request for %s failed: %v", shortID(clawID), err)
 						}
 					}()
 					if !pipelineHandledDone {
@@ -2558,10 +2557,10 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 						Header map[string]string `json:"header"`
 					}
 					if err := json.Unmarshal(rawPayload, &req); err != nil {
-						log.Printf("[hub-proxy] bad req payload: %v", err)
+						logfCtx(r.Context(), "[hub-proxy] bad req payload: %v", err)
 						return
 					}
-					log.Printf("[hub-proxy] req req_id=%s %s %s?%s", req.ReqID, req.Method, req.Path, req.Query)
+					logfCtx(r.Context(), "[hub-proxy] req req_id=%s %s %s?%s", req.ReqID, req.Method, req.Path, req.Query)
 					// Build an internal HTTP request
 					urls := req.Path
 					if req.Query != "" {
@@ -2569,7 +2568,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 					}
 					httpReq, err := http.NewRequest(req.Method, "http://localhost"+urls, strings.NewReader(req.Body))
 					if err != nil {
-						log.Printf("[hub-proxy] build request failed req_id=%s err=%v", req.ReqID, err)
+						logfCtx(r.Context(), "[hub-proxy] build request failed req_id=%s err=%v", req.ReqID, err)
 						s.sendHTTPProxyRes(ctx, conn, req.ReqID, 400, "bad request")
 						return
 					}
@@ -2587,7 +2586,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 					if w.status == 0 {
 						w.status = 200
 					}
-					log.Printf("[hub-proxy] res req_id=%s status=%d body_len=%d", req.ReqID, w.status, len(w.body))
+					logfCtx(r.Context(), "[hub-proxy] res req_id=%s status=%d body_len=%d", req.ReqID, w.status, len(w.body))
 					s.sendHTTPProxyRes(ctx, conn, req.ReqID, w.status, string(w.body))
 				}(mustJSONRaw(msg.Payload), conn)
 			}
@@ -2900,7 +2899,7 @@ func (s *Server) provisionDaytona(ctx context.Context, clawID string, req types.
 	if err != nil {
 		return fmt.Errorf("daytona create: %w", err)
 	}
-	log.Printf("daytona workspace created: %s (claw %s)", instance.ID, clawID)
+	logfCtx(ctx, "daytona workspace created: %s (claw %s)", instance.ID, clawID)
 	recordE2EDaytonaSandboxID(instance.ID)
 	_, _ = s.db.Exec(`UPDATE claws SET status='starting', provider='daytona', provider_id=? WHERE id=?`, instance.ID, clawID)
 
@@ -2913,7 +2912,7 @@ func (s *Server) provisionDaytona(ctx context.Context, clawID string, req types.
 		var lastErr error
 		for attempt := 1; attempt <= maxBootstrapAttempts; attempt++ {
 			if attempt > 1 {
-				log.Printf("[daytona] full bootstrap retry for claw %s in 15s...", clawName)
+				logfCtx(ctx, "[daytona] full bootstrap retry for claw %s in 15s...", clawName)
 				time.Sleep(15 * time.Second)
 			}
 			lastErr = s.bootstrapDaytona(context.Background(), clawID, clawName, instance.ID, p, env)
@@ -2921,12 +2920,12 @@ func (s *Server) provisionDaytona(ctx context.Context, clawID string, req types.
 				return
 			}
 			if s.daytonaBridgeRunning(context.Background(), instance.ID, p) {
-				log.Printf("[daytona] bootstrap attempt %d/%d for claw %s returned error after claw-bridge started; treating bootstrap as complete: %v", attempt, maxBootstrapAttempts, clawName, lastErr)
+				logfCtx(ctx, "[daytona] bootstrap attempt %d/%d for claw %s returned error after claw-bridge started; treating bootstrap as complete: %v", attempt, maxBootstrapAttempts, clawName, lastErr)
 				return
 			}
-			log.Printf("[daytona] bootstrap attempt %d/%d failed for claw %s: %v", attempt, maxBootstrapAttempts, clawName, lastErr)
+			logfCtx(ctx, "[daytona] bootstrap attempt %d/%d failed for claw %s: %v", attempt, maxBootstrapAttempts, clawName, lastErr)
 		}
-		log.Printf("[daytona] bootstrap failed for claw %s: %v", clawName, lastErr)
+		logfCtx(ctx, "[daytona] bootstrap failed for claw %s: %v", clawName, lastErr)
 		s.stopAgentWithReason(clawID, fmt.Sprintf("Daytona bootstrap failed: %v", lastErr), false)
 		// stopAgentWithReason already terminates the VM; no need to destroy again
 	}()
@@ -2934,7 +2933,7 @@ func (s *Server) provisionDaytona(ctx context.Context, clawID string, req types.
 }
 
 func (s *Server) bootstrapDaytona(ctx context.Context, clawID, clawName, instanceID string, p *daytona.Provider, env map[string]string) error {
-	log.Printf("[daytona] bootstrapping claw %s (instance %s)", clawID, instanceID)
+	logfCtx(ctx, "[daytona] bootstrapping claw %s (instance %s)", clawID, instanceID)
 	s.setBootstrapStatus(clawID, "Preparing runtime")
 
 	execResult := func(label string, timeout time.Duration, cmd string) (*types.ExecResult, error) {
@@ -2943,9 +2942,9 @@ func (s *Server) bootstrapDaytona(ctx context.Context, clawID, clawName, instanc
 		var lastErr error
 		for attempt := 1; attempt <= maxAttempts; attempt++ {
 			if attempt == 1 {
-				log.Printf("[daytona] %s...", label)
+				logfCtx(ctx, "[daytona] %s...", label)
 			} else {
-				log.Printf("[daytona] %s retry %d/%d...", label, attempt, maxAttempts)
+				logfCtx(ctx, "[daytona] %s retry %d/%d...", label, attempt, maxAttempts)
 				time.Sleep(5 * time.Second)
 			}
 			// Prefix HOME so commands run in the sandbox user's home, not the caller's.
@@ -2962,7 +2961,7 @@ func (s *Server) bootstrapDaytona(ctx context.Context, clawID, clawName, instanc
 				lastErr = fmt.Errorf("%s failed (exit %d): %s", label, result.ExitCode, sanitizeBootstrapOutput(result.Stdout))
 				continue
 			}
-			log.Printf("[daytona] %s done", label)
+			logfCtx(ctx, "[daytona] %s done", label)
 			return result, nil
 		}
 		return nil, lastErr
@@ -2984,7 +2983,7 @@ echo "npm=$NPM prefix=$PREFIX"; \
 sudo "$NPM" uninstall -g openclaw --prefix "$PREFIX" 2>&1 || true; \
 hash -r; \
 echo uninstalled`); err != nil {
-		log.Printf("[daytona] warning: uninstall failed (ok if not installed): %v", err)
+		logfCtx(ctx, "[daytona] warning: uninstall failed (ok if not installed): %v", err)
 	}
 
 	const daytonaOpenClawVersion = cliversion.OpenClawVersion
@@ -3044,7 +3043,7 @@ curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix 
   sh -s -- install linux --no-confirm --init none >> /tmp/nix-install.log 2>&1; \
 . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh 2>/dev/null || true; \
 nix --version`); err != nil {
-			log.Printf("[daytona] warning: nix install failed: %v", err)
+			logfCtx(ctx, "[daytona] warning: nix install failed: %v", err)
 		}
 	}
 
@@ -3072,7 +3071,7 @@ sudo apt-get update -qq && \
 sudo apt-get install -y --fix-broken docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin && \
 sudo usermod -aG docker daytona 2>/dev/null || true && \
 docker --version`); err != nil {
-			log.Printf("[daytona] warning: docker install failed: %v", err)
+			logfCtx(ctx, "[daytona] warning: docker install failed: %v", err)
 		}
 	}
 
@@ -3095,7 +3094,7 @@ docker --version`); err != nil {
 		activeKeyProviderDaytona = activeKeyDaytona.Provider
 	}
 	s.mu.RUnlock()
-	log.Printf("[daytona] OpenClaw model resolution claw=%s selected_llm_key=%q active_llm_key=%q provider=%q default_model=%q config_patch=%t",
+	logfCtx(ctx, "[daytona] OpenClaw model resolution claw=%s selected_llm_key=%q active_llm_key=%q provider=%q default_model=%q config_patch=%t",
 		clawID, llmKeyNameDaytona, activeKeyNameDaytona, activeKeyProviderDaytona, defaultModelDaytona, providerConfigScript != "")
 	gatewayPassword := randomHex(16)
 	if restoreShell := buildModelAuthRestoreShell(modelAuthEnvDaytona); restoreShell != "" {
@@ -3113,22 +3112,22 @@ docker --version`); err != nil {
 		llmKeyEnvDaytona,
 		onboardFlags,
 	)
-	log.Printf("[daytona] onboard openclaw...")
+	logfCtx(ctx, "[daytona] onboard openclaw...")
 	onboardResult, onboardErr := p.ExecWithTimeout(ctx, instanceID, []string{"bash", "-c", "export HOME=/home/daytona; " + onboardCmd}, 2*time.Minute)
 	if onboardErr != nil {
 		result, diagErr := p.ExecWithTimeout(ctx, instanceID, []string{"bash", "-c", `export HOME=/home/daytona; [ -f "$HOME/.openclaw/openclaw.json" ] && echo exists || echo missing`}, 10*time.Second)
 		if diagErr != nil || strings.TrimSpace(result.Stdout) != "exists" {
 			return fmt.Errorf("onboard openclaw: %w", onboardErr)
 		}
-		log.Printf("[daytona] onboard returned error, but config file exists; continuing")
+		logfCtx(ctx, "[daytona] onboard returned error, but config file exists; continuing")
 	} else if onboardResult.ExitCode != 0 {
 		result, diagErr := p.ExecWithTimeout(ctx, instanceID, []string{"bash", "-c", `export HOME=/home/daytona; [ -f "$HOME/.openclaw/openclaw.json" ] && echo exists || echo missing`}, 10*time.Second)
 		if diagErr != nil || strings.TrimSpace(result.Stdout) != "exists" {
 			return fmt.Errorf("onboard openclaw failed (exit %d): %s", onboardResult.ExitCode, onboardResult.Stdout)
 		}
-		log.Printf("[daytona] onboard returned non-zero, but config file exists; continuing")
+		logfCtx(ctx, "[daytona] onboard returned non-zero, but config file exists; continuing")
 	} else {
-		log.Printf("[daytona] onboard openclaw done")
+		logfCtx(ctx, "[daytona] onboard openclaw done")
 	}
 
 	if apiKeyAuthSyncDaytona != "" {
@@ -3157,7 +3156,7 @@ echo "preflight ok"`); err != nil {
 		`export NVM_DIR=/usr/local/share/nvm; export PATH=$NVM_DIR/current/bin:$PATH; \
 export OPENCLAW_EAGER_BUNDLED_PLUGIN_DEPS=1; \
 openclaw plugins deps --repair 2>&1 || echo "plugin deps staging completed with warnings"`); err != nil {
-		log.Printf("[daytona] warning: plugin deps staging failed: %v", err)
+		logfCtx(ctx, "[daytona] warning: plugin deps staging failed: %v", err)
 	}
 
 	// Step 2c: Configure gateway bind/port and start it.
@@ -3246,7 +3245,7 @@ cp "$BIN" /tmp/claw-bridge.download && chmod +x /tmp/claw-bridge.download && mv 
 			content := content
 			safeName, err := cleanWorkspaceFilePath(name)
 			if err != nil {
-				log.Printf("[daytona] warning: skipping invalid template file path %q: %v", name, err)
+				logfCtx(ctx, "[daytona] warning: skipping invalid template file path %q: %v", name, err)
 				continue
 			}
 			targetPath := "/home/daytona/.openclaw/workspace/" + safeName
@@ -3257,10 +3256,10 @@ cp "$BIN" /tmp/claw-bridge.download && chmod +x /tmp/claw-bridge.download && mv 
 ELASTICCLAW_EOF`,
 				shellQuote(targetDir), shellQuote(targetPath), content)
 			if err := exec("write "+name, 15*time.Second, writeCmd); err != nil {
-				log.Printf("[daytona] warning: failed to write %s: %v", name, err)
+				logfCtx(ctx, "[daytona] warning: failed to write %s: %v", name, err)
 			}
 		}
-		log.Printf("[daytona] template files written for claw %s", clawID)
+		logfCtx(ctx, "[daytona] template files written for claw %s", clawID)
 	}
 
 	// Step 5: GitHub credential helper (if GitHub Apps configured)
@@ -3337,7 +3336,7 @@ set +x
 command -v gh
 [ -n "${GH_TOKEN:-}" ]
 gh --version`
-			log.Printf("[daytona] configure gh token refresh (no retries)...")
+			logfCtx(ctx, "[daytona] configure gh token refresh (no retries)...")
 			ghAuthResult, ghAuthErr := p.ExecWithTimeout(ctx, instanceID, []string{"bash", "-c", configureGitHubTokenRefresh}, 30*time.Second)
 			if ghAuthErr != nil {
 				return fmt.Errorf("configure gh token refresh: %w", ghAuthErr)
@@ -3345,13 +3344,13 @@ gh --version`
 			if ghAuthResult.ExitCode != 0 {
 				return fmt.Errorf("configure gh token refresh failed (exit %d): %s", ghAuthResult.ExitCode, sanitizeBootstrapOutput(ghAuthResult.Stdout))
 			}
-			log.Printf("[daytona] configure gh token refresh done")
+			logfCtx(ctx, "[daytona] configure gh token refresh done")
 
 			ghStatusScript := `export HOME=/home/daytona
 set +x
 . /etc/profile.d/elasticclaw-github.sh
 gh auth status`
-			log.Printf("[daytona] verify gh auth (no retries)...")
+			logfCtx(ctx, "[daytona] verify gh auth (no retries)...")
 			ghStatusResult, ghStatusErr := p.ExecWithTimeout(ctx, instanceID, []string{"bash", "-c", ghStatusScript}, 20*time.Second)
 			if ghStatusErr != nil {
 				return fmt.Errorf("verify gh auth: %w", ghStatusErr)
@@ -3364,7 +3363,7 @@ gh auth status`
 				for _, repo := range repositories {
 					verifyReposScript += fmt.Sprintf("gh repo view %s >/dev/null || exit 1; ", shellQuote(repo.Repo))
 				}
-				log.Printf("[daytona] verify configured repositories (no retries)...")
+				logfCtx(ctx, "[daytona] verify configured repositories (no retries)...")
 				verifyReposResult, verifyReposErr := p.ExecWithTimeout(ctx, instanceID, []string{"bash", "-c", verifyReposScript}, 30*time.Second)
 				if verifyReposErr != nil {
 					return fmt.Errorf("verify configured repositories: %w", verifyReposErr)
@@ -3373,12 +3372,12 @@ gh auth status`
 					return fmt.Errorf("verify configured repositories failed (exit %d): %s", verifyReposResult.ExitCode, sanitizeBootstrapOutput(verifyReposResult.Stdout))
 				}
 			}
-			log.Printf("[daytona] verify gh auth done")
+			logfCtx(ctx, "[daytona] verify gh auth done")
 
-			log.Printf("[daytona] cloning %d repositories for claw %s", len(repositories), clawID)
+			logfCtx(ctx, "[daytona] cloning %d repositories for claw %s", len(repositories), clawID)
 			s.setBootstrapStatus(clawID, "Syncing repositories")
 			for i, repo := range repositories {
-				log.Printf("[daytona] repository[%d]: %s", i, repo.Repo)
+				logfCtx(ctx, "[daytona] repository[%d]: %s", i, repo.Repo)
 			}
 
 			cloneScript := buildDaytonaGitHubCloneScript(repositories)
@@ -3389,7 +3388,7 @@ gh auth status`
 			if cloneResult.ExitCode != 0 {
 				return fmt.Errorf("clone repos failed (exit %d): %s", cloneResult.ExitCode, sanitizeBootstrapOutput(cloneResult.Stdout))
 			}
-			log.Printf("[daytona] clone repos done")
+			logfCtx(ctx, "[daytona] clone repos done")
 
 			if len(repositories) > 0 {
 				verifyCloneScript := "export HOME=/home/daytona; cd ~/.openclaw/workspace; "
@@ -3403,13 +3402,13 @@ gh auth status`
 				if verifyResult.ExitCode != 0 {
 					return fmt.Errorf("verify cloned repos failed (exit %d): %s", verifyResult.ExitCode, sanitizeBootstrapOutput(verifyResult.Stdout))
 				}
-				log.Printf("[daytona] verify cloned repos done")
+				logfCtx(ctx, "[daytona] verify cloned repos done")
 			}
 			if discoveryScript := buildRepoInstructionDiscoveryScript("$HOME/.openclaw/workspace", repositories); discoveryScript != "" {
 				if err := exec("discover repo instructions", 20*time.Second, "export HOME=/home/daytona; "+discoveryScript); err != nil {
-					log.Printf("[daytona] warning: repo instruction discovery failed for claw %s: %v", clawID, err)
+					logfCtx(ctx, "[daytona] warning: repo instruction discovery failed for claw %s: %v", clawID, err)
 				} else {
-					log.Printf("[daytona] repo instruction discovery done")
+					logfCtx(ctx, "[daytona] repo instruction discovery done")
 				}
 			}
 		}
@@ -3440,11 +3439,11 @@ gh auth status`
 			s.setBootstrapStatusWithDiagnostic(clawID, "Workspace incomplete", diag)
 			return fmt.Errorf("workspace readiness failed (exit %d): %s", verifyResult.ExitCode, sanitizeBootstrapOutput(verifyResult.Stdout))
 		}
-		log.Printf("[daytona] workspace readiness verified for claw %s", clawID)
+		logfCtx(ctx, "[daytona] workspace readiness verified for claw %s", clawID)
 	}
 
 	s.markBootstrapReady(clawID)
-	log.Printf("[daytona] bootstrap gated ready for claw %s", clawID)
+	logfCtx(ctx, "[daytona] bootstrap gated ready for claw %s", clawID)
 	s.setBootstrapStatus(clawID, "Connecting to hub")
 
 	// Start the bridge last so the first registration happens only after the
@@ -3455,7 +3454,7 @@ gh auth status`
 		return err
 	}
 
-	log.Printf("[daytona] bootstrap complete for claw %s", clawID)
+	logfCtx(ctx, "[daytona] bootstrap complete for claw %s", clawID)
 	return nil
 }
 
@@ -3474,18 +3473,18 @@ func recordE2EProviderID(label, envName, id string) {
 	}
 	if dir := filepath.Dir(path); dir != "." && dir != "" {
 		if err := os.MkdirAll(dir, 0700); err != nil {
-			log.Printf("[e2e] record %s id: mkdir %s: %v", label, dir, err)
+			logf("[e2e] record %s id: mkdir %s: %v", label, dir, err)
 			return
 		}
 	}
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
 	if err != nil {
-		log.Printf("[e2e] record %s id: open %s: %v", label, path, err)
+		logf("[e2e] record %s id: open %s: %v", label, path, err)
 		return
 	}
 	defer f.Close()
 	if _, err := fmt.Fprintln(f, id); err != nil {
-		log.Printf("[e2e] record %s id: write %s: %v", label, path, err)
+		logf("[e2e] record %s id: write %s: %v", label, path, err)
 	}
 }
 
@@ -3499,7 +3498,7 @@ func (s *Server) startDaytonaBridge(ctx context.Context, instanceID string, p *d
 		return fmt.Errorf("start claw-bridge prep failed (exit %d): %s", result.ExitCode, sanitizeBootstrapOutput(result.Stdout))
 	}
 	if strings.Contains(result.Stdout, "claw-bridge already running") {
-		log.Printf("[daytona] claw-bridge already running")
+		logfCtx(ctx, "[daytona] claw-bridge already running")
 		return nil
 	}
 
@@ -3511,7 +3510,7 @@ func (s *Server) startDaytonaBridge(ctx context.Context, instanceID string, p *d
 	if err != nil {
 		return fmt.Errorf("start claw-bridge async: %w", err)
 	}
-	log.Printf("[daytona] claw-bridge async command started session=%s command=%s", sessionID, cmdID)
+	logfCtx(ctx, "[daytona] claw-bridge async command started session=%s command=%s", sessionID, cmdID)
 
 	verifyCmd := daytonaBridgeRunningCommand()
 	var lastVerify string
@@ -3525,7 +3524,7 @@ func (s *Server) startDaytonaBridge(ctx context.Context, instanceID string, p *d
 			continue
 		}
 		if result.ExitCode == 0 {
-			log.Printf("[daytona] start claw-bridge done: %s", strings.TrimSpace(result.Stdout))
+			logfCtx(ctx, "[daytona] start claw-bridge done: %s", strings.TrimSpace(result.Stdout))
 			return nil
 		}
 		lastVerify = result.Stdout
@@ -3702,11 +3701,11 @@ func (s *Server) downloadDaytonaConnector(ctx context.Context, clawID, instanceI
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		if attempt == 1 {
 			s.setBootstrapStatus(clawID, "Downloading ElasticClaw connector")
-			log.Printf("[daytona] download claw-bridge...")
+			logfCtx(ctx, "[daytona] download claw-bridge...")
 		} else {
 			delay := delays[attempt-2]
 			s.setBootstrapStatus(clawID, fmt.Sprintf("Retrying connector download in %s", formatRetryDelay(delay)))
-			log.Printf("[daytona] download claw-bridge retry %d/%d in %s...", attempt, maxAttempts, delay)
+			logfCtx(ctx, "[daytona] download claw-bridge retry %d/%d in %s...", attempt, maxAttempts, delay)
 			select {
 			case <-ctx.Done():
 				return fmt.Errorf("could not download ElasticClaw connector after %d attempts: %w", attempt-1, ctx.Err())
@@ -3719,17 +3718,17 @@ func (s *Server) downloadDaytonaConnector(ctx context.Context, clawID, instanceI
 		result, err := p.ExecWithTimeout(ctx, instanceID, []string{"bash", "-c", nvmSetup + downloadCmd}, 3*time.Minute)
 		if err != nil {
 			lastErr = err
-			log.Printf("[daytona] download claw-bridge attempt %d/%d failed: %v", attempt, maxAttempts, err)
+			logfCtx(ctx, "[daytona] download claw-bridge attempt %d/%d failed: %v", attempt, maxAttempts, err)
 			continue
 		}
 		if result.ExitCode != 0 {
 			lastErr = fmt.Errorf("exit %d: %s", result.ExitCode, sanitizeBootstrapOutput(result.Stdout))
-			log.Printf("[daytona] download claw-bridge attempt %d/%d failed: %v", attempt, maxAttempts, lastErr)
+			logfCtx(ctx, "[daytona] download claw-bridge attempt %d/%d failed: %v", attempt, maxAttempts, lastErr)
 			continue
 		}
 
 		s.setBootstrapStatus(clawID, "Starting ElasticClaw connector")
-		log.Printf("[daytona] download claw-bridge done")
+		logfCtx(ctx, "[daytona] download claw-bridge done")
 		return nil
 	}
 
@@ -3763,7 +3762,7 @@ func retryReplicatedBootstrapStep(s *Server, clawID string, opts replicatedBoots
 			if s != nil && clawID != "" {
 				s.setBootstrapStatus(clawID, fmt.Sprintf("%s in %s", opts.RetryLabel, formatRetryDelay(delay)))
 			}
-			log.Printf("[bootstrap] %s retry %d/%d in %s...", opts.Label, attempt, opts.Attempts, delay)
+			logf("[bootstrap] %s retry %d/%d in %s...", opts.Label, attempt, opts.Attempts, delay)
 			opts.Sleep(delay)
 		}
 		if s != nil && clawID != "" {
@@ -3771,7 +3770,7 @@ func retryReplicatedBootstrapStep(s *Server, clawID string, opts replicatedBoots
 		}
 		if err := opts.Run(); err != nil {
 			lastErr = err
-			log.Printf("[bootstrap] %s attempt %d/%d failed: %s", opts.Label, attempt, opts.Attempts, sanitizeBootstrapError(err))
+			logf("[bootstrap] %s attempt %d/%d failed: %s", opts.Label, attempt, opts.Attempts, sanitizeBootstrapError(err))
 			continue
 		}
 		return nil
@@ -3892,7 +3891,7 @@ func (s *Server) promoteBootstrapReadyClaw(clawID string) bool {
 		Type:    "claw_status",
 		Payload: map[string]string{"claw_id": clawID, "status": "connected"},
 	})
-	log.Printf("[bridge] ✓ ready after bootstrap: %s", clawID[:8])
+	logf("[bridge] ✓ ready after bootstrap: %s", clawID[:8])
 	go s.requestBootstrapCheckpoint(clawID)
 	s.startWorkflowAfterVolumes(context.Background(), cc, clawID)
 	return true
@@ -3915,7 +3914,7 @@ func (s *Server) startWorkflowAfterVolumes(ctx context.Context, cc *clawConn, cl
 			cc.mu.Lock()
 			cc.workflowStartPending = false
 			cc.mu.Unlock()
-			log.Printf("[volume] attach workflow volumes for %s failed: %v", clawID[:8], err)
+			logfCtx(ctx, "[volume] attach workflow volumes for %s failed: %v", clawID[:8], err)
 			s.releaseWorkflowVolumeLeases(clawID)
 			go s.stopAgentWithReason(clawID, fmt.Sprintf("Workflow volume attach failed: %v", err), false)
 			return
@@ -4110,13 +4109,13 @@ func (s *Server) provisionExedev(ctx context.Context, clawID string, req types.C
 	if err != nil {
 		return fmt.Errorf("exedev create: %w", err)
 	}
-	log.Printf("exedev VM created: %s (claw %s)", instance.ID, clawID)
+	logfCtx(ctx, "exedev VM created: %s (claw %s)", instance.ID, clawID)
 	_, _ = s.db.Exec(`UPDATE claws SET status='starting', provider='exedev', provider_id=? WHERE id=?`, instance.ID, clawID)
 
 	// Bootstrap asynchronously
 	go func() {
 		if err := s.bootstrapExedev(context.Background(), clawID, instance.ID, p, files); err != nil {
-			log.Printf("exedev bootstrap failed for claw %s: %v", clawID, err)
+			logfCtx(ctx, "exedev bootstrap failed for claw %s: %v", clawID, err)
 			s.stopAgentWithReason(clawID, fmt.Sprintf("Exedev bootstrap failed: %s", sanitizeBootstrapError(err)), false)
 		}
 	}()
@@ -4125,7 +4124,7 @@ func (s *Server) provisionExedev(ctx context.Context, clawID string, req types.C
 }
 
 func (s *Server) bootstrapExedev(ctx context.Context, clawID, vmName string, p *exedevProvider.Provider, files map[string][]byte) error {
-	log.Printf("[exedev] bootstrapping claw %s (vm %s)", clawID, vmName)
+	logfCtx(ctx, "[exedev] bootstrapping claw %s (vm %s)", clawID, vmName)
 	s.setBootstrapStatus(clawID, "Waiting for sandbox SSH")
 
 	// Wait for VM to be reachable
@@ -4175,7 +4174,7 @@ func (s *Server) bootstrapExedev(ctx context.Context, clawID, vmName string, p *
 	if defaultModel == "" {
 		defaultModel = hubCfg.DefaultModel
 	}
-	log.Printf("[exedev bootstrap] claw %.8s nix=%d docker=%d llm_key=%q template_default_model=%q hub_default_model=%q resolved_default_model=%q",
+	logfCtx(ctx, "[exedev bootstrap] claw %.8s nix=%d docker=%d llm_key=%q template_default_model=%q hub_default_model=%q resolved_default_model=%q",
 		clawID, nixEnabled, dockerEnabled, llmKeyName, templateDefaultModel, hubCfg.DefaultModel, defaultModel)
 
 	bridgeURL := s.bridgeDownloadURL()
@@ -4223,7 +4222,7 @@ func (s *Server) bootstrapExedev(ctx context.Context, clawID, vmName string, p *
 	if err := p.SetupScript(ctx, vmName, script); err != nil {
 		return fmt.Errorf("exedev bootstrap script failed: %s", sanitizeBootstrapError(err))
 	}
-	log.Printf("[exedev] bootstrap script completed on %s", vmName)
+	logfCtx(ctx, "[exedev] bootstrap script completed on %s", vmName)
 	s.setBootstrapStatus(clawID, "Writing workspace files")
 
 	// Write template files after bootstrap so openclaw onboard doesn't overwrite them
@@ -4248,11 +4247,11 @@ func (s *Server) bootstrapExedev(ctx context.Context, clawID, vmName string, p *
 		if err := p.SetupScript(ctx, vmName, credHelper); err != nil {
 			return fmt.Errorf("configure GitHub credentials and repo instructions: %w", err)
 		}
-		log.Printf("[exedev] GitHub credential helper and repo instruction discovery completed for claw %.8s", clawID)
+		logfCtx(ctx, "[exedev] GitHub credential helper and repo instruction discovery completed for claw %.8s", clawID)
 	}
 	s.markBootstrapReady(clawID)
 
-	log.Printf("[exedev] bootstrap complete for claw %.8s on %s", clawID, vmName)
+	logfCtx(ctx, "[exedev] bootstrap complete for claw %.8s on %s", clawID, vmName)
 	return nil
 }
 
@@ -4342,7 +4341,7 @@ func (s *Server) provisionDocker(ctx context.Context, clawID string, req types.C
 	if err != nil {
 		return fmt.Errorf("docker create: %w", err)
 	}
-	log.Printf("[docker] container started: %s (claw %s)", instance.ID, clawID)
+	logfCtx(ctx, "[docker] container started: %s (claw %s)", instance.ID, clawID)
 	_, _ = s.db.Exec(`UPDATE claws SET status='starting', provider='docker', provider_id=? WHERE id=?`, instance.ID, clawID)
 	homeDir, err := p.HomeDir(ctx, instance.ID)
 	if err != nil {
@@ -4368,7 +4367,7 @@ func (s *Server) provisionDocker(ctx context.Context, clawID string, req types.C
 		_ = p.Destroy(context.Background(), instance.ID, false)
 		return fmt.Errorf("docker workspace ready marker: %w", err)
 	}
-	log.Printf("[docker] workspace files copied for claw %.8s to %s", clawID, workspaceDir)
+	logfCtx(ctx, "[docker] workspace files copied for claw %.8s to %s", clawID, workspaceDir)
 	s.setBootstrapStatus(clawID, "Starting agent bridge")
 	if err := s.ensureDockerBridge(ctx, p, instance.ID, homeDir); err != nil {
 		_ = p.Destroy(context.Background(), instance.ID, false)
@@ -4410,7 +4409,7 @@ func (s *Server) ensureDockerBridge(ctx context.Context, p interface {
 	Exec(context.Context, string, []string) (*types.ExecResult, error)
 }, containerID, homeDir string) error {
 	if _, err := p.Exec(ctx, containerID, []string{"sh", "-lc", "command -v pgrep >/dev/null 2>&1 && pgrep -x claw-bridge >/dev/null"}); err == nil {
-		log.Printf("[docker] claw-bridge already running in container %s", containerID)
+		logfCtx(ctx, "[docker] claw-bridge already running in container %s", containerID)
 		return nil
 	}
 
@@ -4439,7 +4438,7 @@ func (s *Server) ensureDockerBridge(ctx context.Context, p interface {
 	if _, err := p.Exec(ctx, containerID, []string{"sh", "-lc", startCmd}); err != nil {
 		return fmt.Errorf("docker claw-bridge start failed: %w", err)
 	}
-	log.Printf("[docker] claw-bridge started in container %s", containerID)
+	logfCtx(ctx, "[docker] claw-bridge started in container %s", containerID)
 	return nil
 }
 
@@ -4566,7 +4565,7 @@ func (s *Server) provisionLambdaMicroVMs(ctx context.Context, clawID string, req
 	if err != nil {
 		return fmt.Errorf("lambda microvms create: %w", err)
 	}
-	log.Printf("[lambda-microvms] microvm started: %s (claw %s)", instance.ID, clawID)
+	logfCtx(ctx, "[lambda-microvms] microvm started: %s (claw %s)", instance.ID, clawID)
 	_, _ = s.db.Exec(`UPDATE claws SET status='starting', provider='lambda-microvms', provider_id=? WHERE id=?`, instance.ID, clawID)
 	return nil
 }
@@ -4606,7 +4605,7 @@ func (s *Server) provisionReplicated(ctx context.Context, clawID string, req typ
 	var currentStatus string
 	_ = s.db.QueryRow(`SELECT status FROM claws WHERE id=?`, clawID).Scan(&currentStatus)
 	if currentStatus == "deleted" {
-		log.Printf("[provision] claw %s deleted mid-provision, destroying VM %s", clawID[:8], vmID)
+		logfCtx(ctx, "[provision] claw %s deleted mid-provision, destroying VM %s", clawID[:8], vmID)
 		_ = p.DeleteVM(ctx, vmID)
 		return fmt.Errorf("claw deleted mid-provision")
 	}
@@ -4626,13 +4625,13 @@ func (s *Server) provisionReplicated(ctx context.Context, clawID string, req typ
 		}
 	}
 
-	log.Printf("Replicated VM provisioned")
-	log.Printf("  Claw:          %s (%s)", req.Name, clawID)
-	log.Printf("  VM ID:         %s", vmID)
-	log.Printf("  Instance type: %s", instanceType)
-	log.Printf("  TTL:           %s", ttl)
-	log.Printf("  SSH:           ssh %s", replicatedpkg.VMHostname(vmID))
-	log.Printf("  Status:        provisioning (waiting for VM to start)")
+	logfCtx(ctx, "Replicated VM provisioned")
+	logfCtx(ctx, "  Claw:          %s (%s)", req.Name, clawID)
+	logfCtx(ctx, "  VM ID:         %s", vmID)
+	logfCtx(ctx, "  Instance type: %s", instanceType)
+	logfCtx(ctx, "  TTL:           %s", ttl)
+	logfCtx(ctx, "  SSH:           ssh %s", replicatedpkg.VMHostname(vmID))
+	logfCtx(ctx, "  Status:        provisioning (waiting for VM to start)")
 	return nil
 }
 
@@ -4674,7 +4673,7 @@ func (s *Server) petDaytonaSandboxes() {
 		  AND status NOT IN ('idle','deleted','error','offline')
 	`)
 	if err != nil {
-		log.Printf("keepAliveDaytonaSandboxes: query error: %v", err)
+		logf("keepAliveDaytonaSandboxes: query error: %v", err)
 		return
 	}
 	defer rows.Close()
@@ -4695,12 +4694,12 @@ func (s *Server) petDaytonaSandboxes() {
 	cfg, ok := s.hubCfg.Providers["daytona"]
 	s.mu.RUnlock()
 	if !ok {
-		log.Printf("keepAliveDaytonaSandboxes: no daytona provider configured")
+		logf("keepAliveDaytonaSandboxes: no daytona provider configured")
 		return
 	}
 	p, err := newDaytonaProvider(cfg)
 	if err != nil {
-		log.Printf("keepAliveDaytonaSandboxes: provider init error: %v", err)
+		logf("keepAliveDaytonaSandboxes: provider init error: %v", err)
 		return
 	}
 
@@ -4709,10 +4708,10 @@ func (s *Server) petDaytonaSandboxes() {
 		_, err := p.ExecWithTimeout(ctx, c.providerID, []string{"bash", "-lc", "true"}, 20*time.Second)
 		cancel()
 		if err != nil {
-			log.Printf("[daytona] keepalive failed for %s (%s): %v", c.name, c.id[:8], err)
+			logf("[daytona] keepalive failed for %s (%s): %v", c.name, c.id[:8], err)
 			continue
 		}
-		log.Printf("[daytona] keepalive ok for %s (%s)", c.name, c.id[:8])
+		logf("[daytona] keepalive ok for %s (%s)", c.name, c.id[:8])
 	}
 }
 
@@ -4788,7 +4787,7 @@ func (s *Server) checkClawStatus() {
 			now.Sub(lastUserMessageAt) > 5*time.Minute &&
 			now.Sub(lastStatusBroadcastAt) > 5*time.Minute {
 			msg := fmt.Sprintf("🚨 Agent %s appears unresponsive (no status in 5m). It may have crashed.", name)
-			log.Printf("[watchdog] %s", msg)
+			logf("[watchdog] %s", msg)
 			// Inject as system message so user sees it in the chat stream
 			s.broadcastToUsers(tenantID, types.WSMessage{
 				Type: "message",
@@ -4811,7 +4810,7 @@ func (s *Server) checkClawStatus() {
 		cc.mu.RUnlock()
 		if contextUsage > 90 && !contextWarningSent && !streaming {
 			msg := fmt.Sprintf("⚠️ Agent %s is at %d%% context usage. It should wrap up soon or restart.", name, contextUsage)
-			log.Printf("[watchdog] %s", msg)
+			logf("[watchdog] %s", msg)
 			s.broadcastToUsers(tenantID, types.WSMessage{
 				Type: "message",
 				Payload: map[string]interface{}{
@@ -4846,7 +4845,7 @@ func (s *Server) syncReplicatedVMs() {
 		  AND status IN ('provisioning', 'starting')
 	`)
 	if err != nil {
-		log.Printf("pollProviderStatus: query error: %v", err)
+		logf("pollProviderStatus: query error: %v", err)
 		return
 	}
 	defer rows.Close()
@@ -4870,7 +4869,7 @@ func (s *Server) syncReplicatedVMs() {
 
 	p, err := newReplicatedProvider(replicatedCfg)
 	if err != nil {
-		log.Printf("pollProviderStatus: provider init error: %v", err)
+		logf("pollProviderStatus: provider init error: %v", err)
 		return
 	}
 
@@ -4879,7 +4878,7 @@ func (s *Server) syncReplicatedVMs() {
 		if err != nil {
 			// 404 means VM was deleted externally — clean up the claw
 			if strings.Contains(err.Error(), "HTTP 404") {
-				log.Printf("pollProviderStatus: VM %s not found (404) — marking claw %s offline", c.providerID, c.id[:8])
+				logf("pollProviderStatus: VM %s not found (404) — marking claw %s offline", c.providerID, c.id[:8])
 				res, execErr := s.db.Exec(
 					`UPDATE claws SET status='offline' WHERE id=? AND status IN ('provisioning','starting')`,
 					c.id)
@@ -4898,13 +4897,13 @@ func (s *Server) syncReplicatedVMs() {
 					}
 				}
 			} else {
-				log.Printf("pollProviderStatus: get VM %s error: %v", c.providerID, err)
+				logf("pollProviderStatus: get VM %s error: %v", c.providerID, err)
 			}
 			continue
 		}
 		// Only log if status changed or there's a problem
 		if vm.Status != c.status && vm.Status != "running" {
-			log.Printf("Claw %s (%s): VM %s %s → %s", c.name, c.id[:8], c.providerID, c.status, vm.Status)
+			logf("Claw %s (%s): VM %s %s → %s", c.name, c.id[:8], c.providerID, c.status, vm.Status)
 		}
 
 		// Map Replicated VM status to claw status
@@ -4914,11 +4913,11 @@ func (s *Server) syncReplicatedVMs() {
 			newStatus = "starting"
 			// First time we see running — trigger bootstrap
 			if c.status == "provisioning" {
-				log.Printf("Claw %s (%s): VM running, bootstrapping...", c.name, c.id[:8])
+				logf("Claw %s (%s): VM running, bootstrapping...", c.name, c.id[:8])
 				go s.bootstrapReplicated(c.id, c.name, c.providerID, replicatedCfg)
 			}
 		case "terminated", "error":
-			log.Printf("Replicated VM %s for claw %s (%s) terminated", c.providerID, c.name, c.id)
+			logf("Replicated VM %s for claw %s (%s) terminated", c.providerID, c.name, c.id)
 			go s.stopAgentWithReason(c.id, "Sandbox terminated (TTL expired or external shutdown)", true)
 			// Note: stopAgentWithReason handles disconnect, status, broadcast, VM cleanup
 			// Spawned in goroutine so slow issue-tracker APIs don't stall the poll loop.
@@ -4938,7 +4937,7 @@ func (s *Server) syncReplicatedVMs() {
 				newStatus, c.id)
 			if execErr == nil {
 				if n, _ := res.RowsAffected(); n > 0 {
-					log.Printf("Claw %s (%s): VM %s %s → hub status %s",
+					logf("Claw %s (%s): VM %s %s → hub status %s",
 						c.name, c.id[:8], c.providerID, vm.Status, newStatus)
 					s.broadcastToUsers(c.tenantID, types.WSMessage{
 						Type:    "claw_status",
@@ -5154,7 +5153,7 @@ func (s *Server) bootstrapReplicated(clawID, clawName, vmID string, cfg types.Pr
 	var checkStatus string
 	_ = s.db.QueryRow(`SELECT status FROM claws WHERE id=?`, clawID).Scan(&checkStatus)
 	if checkStatus == "deleted" {
-		log.Printf("[bootstrap] claw %s deleted before bootstrap, destroying VM %s", clawID[:8], vmID)
+		logf("[bootstrap] claw %s deleted before bootstrap, destroying VM %s", clawID[:8], vmID)
 		p, _ := newReplicatedProvider(cfg)
 		if p != nil {
 			_ = p.DeleteVM(context.Background(), vmID)
@@ -5187,23 +5186,23 @@ func (s *Server) bootstrapReplicated(clawID, clawName, vmID string, cfg types.Pr
 	// Read nix flag
 	var nixEnabled int
 	if err := s.db.QueryRow(`SELECT nix FROM claws WHERE id=?`, clawID).Scan(&nixEnabled); err != nil {
-		log.Printf("[bootstrap] warning: could not read nix flag for claw %s: %v", clawID[:8], err)
+		logf("[bootstrap] warning: could not read nix flag for claw %s: %v", clawID[:8], err)
 	}
 	var dockerEnabled int
 	if err := s.db.QueryRow(`SELECT docker FROM claws WHERE id=?`, clawID).Scan(&dockerEnabled); err != nil {
-		log.Printf("[bootstrap] warning: could not read docker flag for claw %s: %v", clawID[:8], err)
+		logf("[bootstrap] warning: could not read docker flag for claw %s: %v", clawID[:8], err)
 	}
-	log.Printf("[bootstrap] claw %s nix=%d docker=%d", clawID[:8], nixEnabled, dockerEnabled)
+	logf("[bootstrap] claw %s nix=%d docker=%d", clawID[:8], nixEnabled, dockerEnabled)
 	// Read llm_key selection
 	var llmKeyName string
 	_ = s.db.QueryRow(`SELECT COALESCE(llm_key,'') FROM claws WHERE id=?`, clawID).Scan(&llmKeyName)
 	defaultModel, llmKeyName = resolveModelAndLLMKey(s.hubCfg, llmKeyName, defaultModel)
-	log.Printf("[bootstrap] OpenClaw model resolution claw=%s llm_key=%q template_default_model=%q hub_default_model=%q resolved_default_model=%q",
+	logf("[bootstrap] OpenClaw model resolution claw=%s llm_key=%q template_default_model=%q hub_default_model=%q resolved_default_model=%q",
 		clawID[:8], llmKeyName, templateDefaultModel, s.hubCfg.DefaultModel, defaultModel)
 
 	bridgeURL := s.bridgeDownloadURL()
 	if bridgeURL == "" {
-		log.Printf("[bootstrap] ERROR: bridge_image not set and hub version is 'dev' — set bridge_image in hub.yaml")
+		logf("[bootstrap] ERROR: bridge_image not set and hub version is 'dev' — set bridge_image in hub.yaml")
 		s.stopAgentWithReason(clawID, "Bootstrap failed: bridge_image not configured", false)
 		return
 	}
@@ -5212,12 +5211,12 @@ func (s *Server) bootstrapReplicated(clawID, clawName, vmID string, cfg types.Pr
 	// Get the direct SSH endpoint from Replicated (IP:port, user is always root)
 	cp, err := newReplicatedProvider(cfg)
 	if err != nil {
-		log.Printf("bootstrap: provider init error: %v", err)
+		logf("bootstrap: provider init error: %v", err)
 		return
 	}
 	vm, err := cp.GetVM(context.Background(), vmID)
 	if err != nil || vm.DirectSSHEndpoint == "" || vm.DirectSSHPort == 0 {
-		log.Printf("bootstrap: could not get direct SSH endpoint for VM %s: %v", vmID, err)
+		logf("bootstrap: could not get direct SSH endpoint for VM %s: %v", vmID, err)
 		return
 	}
 	// Replicated uses the comment from the SSH public key as the Linux username.
@@ -5225,7 +5224,7 @@ func (s *Server) bootstrapReplicated(clawID, clawName, vmID string, cfg types.Pr
 	sshUser := replicatedpkg.SSHUserFromPublicKey(s.identity.PublicKey)
 	sshHome, err := sshHomeDir(sshUser)
 	if err != nil {
-		log.Printf("bootstrap: invalid SSH user %q: %v", sshUser, err)
+		logf("bootstrap: invalid SSH user %q: %v", sshUser, err)
 		s.stopAgentWithReason(clawID, fmt.Sprintf("Bootstrap failed: invalid SSH user: %s", sanitizeBootstrapError(err)), false)
 		return
 	}
@@ -5237,7 +5236,7 @@ func (s *Server) bootstrapReplicated(clawID, clawName, vmID string, cfg types.Pr
 		40 * time.Second,
 		60 * time.Second,
 	}
-	log.Printf("Bootstrap SSH: %s@%s", sshUser, sshHost)
+	logf("Bootstrap SSH: %s@%s", sshUser, sshHost)
 	// Store SSH connection details in the DB for terminal access
 	_, _ = s.db.Exec(
 		`UPDATE claws SET ssh_host=?, ssh_port=?, ssh_user=? WHERE id=?`,
@@ -5316,7 +5315,7 @@ Tokens are short-lived and refreshed automatically on each git/gh operation.
 				return s.sshWriteFiles(sshUser, sshHost, path.Join(sshHome, "workspace"), flakeFiles)
 			},
 		}); err != nil {
-			log.Printf("[bootstrap] failed to stage flake before bootstrap for claw %s: %v", clawID[:8], err)
+			logf("[bootstrap] failed to stage flake before bootstrap for claw %s: %v", clawID[:8], err)
 			s.stopAgentWithReason(clawID, fmt.Sprintf("Bootstrap failed: could not stage flake files: %s", err), false)
 			return
 		}
@@ -5334,7 +5333,7 @@ Tokens are short-lived and refreshed automatically on each git/gh operation.
 			return s.sshRun(sshUser, sshHost, script)
 		},
 	}); err != nil {
-		log.Printf("Bootstrap failed for claw %s: %v", clawID, err)
+		logf("Bootstrap failed for claw %s: %v", clawID, err)
 		s.stopAgentWithReason(clawID, fmt.Sprintf("Bootstrap failed: %s", err), false)
 		return
 	}
@@ -5348,7 +5347,7 @@ Tokens are short-lived and refreshed automatically on each git/gh operation.
 			fileNames = append(fileNames, k)
 		}
 		sort.Strings(fileNames)
-		log.Printf("[bootstrap] writing %d template files for claw %s: %v", len(files), clawName, fileNames)
+		logf("[bootstrap] writing %d template files for claw %s: %v", len(files), clawName, fileNames)
 		if err := retryReplicatedBootstrapStep(s, clawID, replicatedBootstrapRetryOptions{
 			Label:      "Writing workspace files",
 			RetryLabel: "Retrying workspace file write",
@@ -5373,11 +5372,11 @@ Tokens are short-lived and refreshed automatically on each git/gh operation.
 			s.stopAgentWithReason(clawID, fmt.Sprintf("Bootstrap failed: workspace files incomplete: %s", err), false)
 			return
 		}
-		log.Printf("Template files written for claw %s", clawName)
+		logf("Template files written for claw %s", clawName)
 	}
 
 	if err := s.restoreCheckpointToSSH(clawID, sshUser, sshHost); err != nil {
-		log.Printf("[bootstrap] restore checkpoint failed: %v", err)
+		logf("[bootstrap] restore checkpoint failed: %v", err)
 		s.stopAgentWithReason(clawID, fmt.Sprintf("Restore checkpoint failed: %s", sanitizeBootstrapError(err)), false)
 		return
 	}
@@ -5397,11 +5396,11 @@ Tokens are short-lived and refreshed automatically on each git/gh operation.
 			s.stopAgentWithReason(clawID, fmt.Sprintf("Bootstrap failed: could not configure GitHub credentials: %s", err), false)
 			return
 		}
-		log.Printf("[bootstrap] GitHub credential helper installed for claw %s", clawName)
+		logf("[bootstrap] GitHub credential helper installed for claw %s", clawName)
 	}
 	s.markBootstrapReady(clawID)
 
-	log.Printf("Bootstrap complete for claw %s (%s)", clawName, clawID[:8])
+	logf("Bootstrap complete for claw %s (%s)", clawName, clawID[:8])
 }
 
 // randomHex returns a random hex string of n bytes (2*n hex chars).
@@ -5943,7 +5942,7 @@ func (s *Server) sshRun(user, host, script string) error {
 	if err != nil {
 		return err
 	}
-	log.Printf("bootstrap output:\n%s", output)
+	logf("bootstrap output:\n%s", output)
 	return nil
 }
 
@@ -5952,8 +5951,8 @@ func (s *Server) sshRun(user, host, script string) error {
 func (s *Server) sshRunWithTimeout(user, host, script string, timeout time.Duration) (string, error) {
 	pubKeyType := s.identity.PrivateKey.PublicKey().Type()
 	pubKeyFP := gossh.FingerprintSHA256(s.identity.PrivateKey.PublicKey())
-	log.Printf("SSH attempting: user=%s host=%s key-type=%s fingerprint=%s", user, host, pubKeyType, pubKeyFP)
-	log.Printf("SSH public key being used:\n%s", s.identity.PublicKey)
+	logf("SSH attempting: user=%s host=%s key-type=%s fingerprint=%s", user, host, pubKeyType, pubKeyFP)
+	logf("SSH public key being used:\n%s", s.identity.PublicKey)
 
 	sshCfg := &gossh.ClientConfig{
 		User:            user,
@@ -6154,7 +6153,7 @@ func (s *Server) handleTerminal(w http.ResponseWriter, r *http.Request) {
 	sshAddr := fmt.Sprintf("%s:%d", sshHost, sshPort)
 	sshClient, err := gossh.Dial("tcp", sshAddr, sshCfg)
 	if err != nil {
-		log.Printf("terminal: ssh dial %s: %v", sshAddr, err)
+		logfCtx(r.Context(), "terminal: ssh dial %s: %v", sshAddr, err)
 		_ = conn.Close(websocket.StatusInternalError, "ssh connection failed")
 		return
 	}
@@ -6162,7 +6161,7 @@ func (s *Server) handleTerminal(w http.ResponseWriter, r *http.Request) {
 
 	sshSess, err := sshClient.NewSession()
 	if err != nil {
-		log.Printf("terminal: ssh session: %v", err)
+		logfCtx(r.Context(), "terminal: ssh session: %v", err)
 		_ = conn.Close(websocket.StatusInternalError, "ssh session failed")
 		return
 	}
@@ -6174,7 +6173,7 @@ func (s *Server) handleTerminal(w http.ResponseWriter, r *http.Request) {
 		gossh.TTY_OP_ISPEED: 14400,
 		gossh.TTY_OP_OSPEED: 14400,
 	}); err != nil {
-		log.Printf("terminal: request pty: %v", err)
+		logfCtx(r.Context(), "terminal: request pty: %v", err)
 		_ = conn.Close(websocket.StatusInternalError, "pty failed")
 		return
 	}
@@ -6193,7 +6192,7 @@ func (s *Server) handleTerminal(w http.ResponseWriter, r *http.Request) {
 	sshSess.Stderr = sshSess.Stdout // merge stderr
 
 	if err := sshSess.Shell(); err != nil {
-		log.Printf("terminal: shell: %v", err)
+		logfCtx(r.Context(), "terminal: shell: %v", err)
 		_ = conn.Close(websocket.StatusInternalError, "shell failed")
 		return
 	}
@@ -6255,7 +6254,7 @@ func (s *Server) terminateVM(provider, vmID string) {
 	case "lambda-microvms":
 		s.terminateLambdaMicroVM(vmID)
 	default:
-		log.Printf("terminateVM: unsupported provider %q for VM %s", provider, vmID)
+		logf("terminateVM: unsupported provider %q for VM %s", provider, vmID)
 	}
 }
 
@@ -6265,19 +6264,19 @@ func (s *Server) terminateDockerVM(vmID string) {
 	cfg, ok := s.hubCfg.Providers["docker"]
 	s.mu.RUnlock()
 	if !ok {
-		log.Printf("terminateDockerVM: no docker provider configured")
+		logf("terminateDockerVM: no docker provider configured")
 		return
 	}
 	p, err := newDockerProvider(cfg)
 	if err != nil {
-		log.Printf("terminateDockerVM: provider init error: %v", err)
+		logf("terminateDockerVM: provider init error: %v", err)
 		return
 	}
 	if err := p.Destroy(context.Background(), vmID, false); err != nil {
-		log.Printf("terminateDockerVM: failed to destroy container %s: %v", vmID, err)
+		logf("terminateDockerVM: failed to destroy container %s: %v", vmID, err)
 		return
 	}
-	log.Printf("Docker container %s terminated", vmID)
+	logf("Docker container %s terminated", vmID)
 }
 
 // terminateLambdaMicroVM destroys an AWS Lambda MicroVM by ID.
@@ -6286,19 +6285,19 @@ func (s *Server) terminateLambdaMicroVM(vmID string) {
 	cfg, ok := s.hubCfg.Providers["lambda-microvms"]
 	s.mu.RUnlock()
 	if !ok {
-		log.Printf("terminateLambdaMicroVM: no lambda-microvms provider configured")
+		logf("terminateLambdaMicroVM: no lambda-microvms provider configured")
 		return
 	}
 	p, err := newLambdaMicroVMsProvider(cfg)
 	if err != nil {
-		log.Printf("terminateLambdaMicroVM: provider init error: %v", err)
+		logf("terminateLambdaMicroVM: provider init error: %v", err)
 		return
 	}
 	if err := p.Destroy(context.Background(), vmID, false); err != nil {
-		log.Printf("terminateLambdaMicroVM: failed to destroy MicroVM %s: %v", vmID, err)
+		logf("terminateLambdaMicroVM: failed to destroy MicroVM %s: %v", vmID, err)
 		return
 	}
-	log.Printf("Lambda MicroVM %s terminated", vmID)
+	logf("Lambda MicroVM %s terminated", vmID)
 }
 
 // terminateExedevVM destroys an exedev VM by ID.
@@ -6307,21 +6306,21 @@ func (s *Server) terminateExedevVM(vmID string) {
 	cfg, ok := s.hubCfg.Providers["exedev"]
 	s.mu.RUnlock()
 	if !ok {
-		log.Printf("terminateExedevVM: no exedev provider configured")
+		logf("terminateExedevVM: no exedev provider configured")
 		return
 	}
 
-	log.Printf("terminateExedevVM: destroying VM %s (ssh_key_path=%q)", vmID, cfg.SSHKeyPath)
+	logf("terminateExedevVM: destroying VM %s (ssh_key_path=%q)", vmID, cfg.SSHKeyPath)
 	p, err := newExedevProvider(cfg)
 	if err != nil {
-		log.Printf("terminateExedevVM: provider init error: %v", err)
+		logf("terminateExedevVM: provider init error: %v", err)
 		return
 	}
 	if err := p.Destroy(context.Background(), vmID, false); err != nil {
-		log.Printf("terminateExedevVM: failed to destroy VM %s: %v", vmID, err)
+		logf("terminateExedevVM: failed to destroy VM %s: %v", vmID, err)
 		return
 	}
-	log.Printf("Exedev VM %s terminated", vmID)
+	logf("Exedev VM %s terminated", vmID)
 }
 
 // terminateDaytonaVM destroys a Daytona workspace by ID.
@@ -6334,14 +6333,14 @@ func (s *Server) terminateDaytonaVM(workspaceID string) {
 	}
 	p, err := newDaytonaProvider(cfg)
 	if err != nil {
-		log.Printf("terminateDaytonaVM: provider init error: %v", err)
+		logf("terminateDaytonaVM: provider init error: %v", err)
 		return
 	}
 	if err := p.Destroy(context.Background(), workspaceID, false); err != nil {
-		log.Printf("terminateDaytonaVM: failed to destroy workspace %s: %v", workspaceID, err)
+		logf("terminateDaytonaVM: failed to destroy workspace %s: %v", workspaceID, err)
 		return
 	}
-	log.Printf("Daytona workspace %s terminated", workspaceID)
+	logf("Daytona workspace %s terminated", workspaceID)
 }
 
 // terminateReplicatedVM terminates a Replicated CMX VM by ID.
@@ -6350,19 +6349,19 @@ func (s *Server) terminateReplicatedVM(vmID string) {
 	cfg, ok := s.hubCfg.Providers["replicated"]
 	s.mu.RUnlock()
 	if !ok {
-		log.Printf("terminateReplicatedVM: no replicated provider configured")
+		logf("terminateReplicatedVM: no replicated provider configured")
 		return
 	}
 	p, err := newReplicatedProvider(cfg)
 	if err != nil {
-		log.Printf("terminateReplicatedVM: provider init error: %v", err)
+		logf("terminateReplicatedVM: provider init error: %v", err)
 		return
 	}
 	if err := p.DeleteVM(context.Background(), vmID); err != nil {
-		log.Printf("terminateReplicatedVM: failed to delete VM %s: %v", vmID, err)
+		logf("terminateReplicatedVM: failed to delete VM %s: %v", vmID, err)
 		return
 	}
-	log.Printf("Replicated VM %s terminated", vmID)
+	logf("Replicated VM %s terminated", vmID)
 }
 
 // ─── GitHub Token Endpoint ────────────────────────────────────────────────────
@@ -6447,16 +6446,16 @@ func (s *Server) handleGitHubToken(w http.ResponseWriter, r *http.Request) {
 	for i, appCfg := range githubApps {
 		provider, err := NewGitHubTokenProvider(appCfg)
 		if err != nil {
-			log.Printf("github app[%d] (app_id=%d url=%s) config error: %v", i, appCfg.AppID, appCfg.URL, err)
+			logfCtx(r.Context(), "github app[%d] (app_id=%d url=%s) config error: %v", i, appCfg.AppID, appCfg.URL, err)
 			continue
 		}
 		token, expiresAt, err := provider.InstallationToken(r.Context(), 0, repos)
 		if err != nil {
 			// Debug-level only — expected when multiple apps configured and only one matches
-			log.Printf("[github] app[%d] app_id=%d: no match for repos (trying next): %v", i, appCfg.AppID, err)
+			logfCtx(r.Context(), "[github] app[%d] app_id=%d: no match for repos (trying next): %v", i, appCfg.AppID, err)
 			continue
 		}
-		log.Printf("github token issued via app_id=%d for claw %s", appCfg.AppID, clawID[:8])
+		logfCtx(r.Context(), "github token issued via app_id=%d for claw %s", appCfg.AppID, clawID[:8])
 		jsonOK(w, map[string]interface{}{
 			"token":      token,
 			"expires_at": expiresAt,
@@ -6464,7 +6463,7 @@ func (s *Server) handleGitHubToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Printf("no github app found with installation for repos %v (claw %s)", repos, clawID[:8])
+	logfCtx(r.Context(), "no github app found with installation for repos %v (claw %s)", repos, clawID[:8])
 	http.Error(w, "no github installation found for the requested repos", http.StatusNotFound)
 }
 
@@ -6538,7 +6537,7 @@ func (s *Server) sendNextQueuedMessage(cc *clawConn) {
 
 	if err != nil {
 		// Write failed - re-enqueue the message at the front so it can be retried
-		log.Printf("[hub] failed to send queued message to %s: %v, re-enqueueing", clawID[:8], err)
+		logf("[hub] failed to send queued message to %s: %v, re-enqueueing", clawID[:8], err)
 		s.mu.RLock()
 		if currentCC, ok := s.claws[clawID]; ok {
 			currentCC.mu.Lock()
@@ -6559,5 +6558,5 @@ func (s *Server) sendNextQueuedMessage(cc *clawConn) {
 		},
 	})
 
-	log.Printf("[hub] sent queued message to %s (%d remaining in queue)", clawID[:8], remainingCount)
+	logf("[hub] sent queued message to %s (%d remaining in queue)", clawID[:8], remainingCount)
 }

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -958,7 +957,7 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 				if existing.SSHKeyPath == "" {
 					_, privPath, err := GenerateExedevKey(filepath.Join(hubConfigDir(), "keys"))
 					if err != nil {
-						log.Printf("failed to generate exedev key: %v", err)
+						logfCtx(r.Context(), "failed to generate exedev key: %v", err)
 					} else {
 						existing.SSHKeyPath = privPath
 					}

--- a/pkg/hub/shortcut.go
+++ b/pkg/hub/shortcut.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -199,7 +198,7 @@ func (s *Server) processShortcutEvent(workspaceName string, payload shortcutWebh
 					storyFiltersByToken[token] = filterData
 				}
 				if filterData.loadErr != nil {
-					log.Printf("[factory:%s] skipping story %s: failed to load Shortcut story filters: %v", factory.Name, storyID, filterData.loadErr)
+					logf("[factory:%s] skipping story %s: failed to load Shortcut story filters: %v", factory.Name, storyID, filterData.loadErr)
 					continue
 				}
 
@@ -245,7 +244,7 @@ func (s *Server) processShortcutEvent(workspaceName string, payload shortcutWebh
 				if len(stateMap) > 0 {
 					stateNameCache[token] = stateMap
 				} else {
-					log.Printf("[shortcut-webhook] failed to load workflow states for workspace %q (empty response) — not caching", factory.Workspace)
+					logf("[shortcut-webhook] failed to load workflow states for workspace %q (empty response) — not caching", factory.Workspace)
 					continue
 				}
 			}
@@ -254,12 +253,12 @@ func (s *Server) processShortcutEvent(workspaceName string, payload shortcutWebh
 
 			// Issue entering trigger status → create claw
 			if strings.EqualFold(newStateName, factory.TriggerStatus) && !strings.EqualFold(oldStateName, factory.TriggerStatus) {
-				log.Printf("[factory:%s] story %s entered '%s' — creating claw", factory.Name, storyID, factory.TriggerStatus)
+				logf("[factory:%s] story %s entered '%s' — creating claw", factory.Name, storyID, factory.TriggerStatus)
 				if err := s.createClawForShortcutStory(factory, action, storyID, token, "shortcut webhook"); err != nil {
 					if isFactoryTriggerAlreadyClaimed(err) {
 						continue
 					}
-					log.Printf("[factory:%s] failed to create claw for %s: %v", factory.Name, storyID, err)
+					logf("[factory:%s] failed to create claw for %s: %v", factory.Name, storyID, err)
 					s.logFactoryEvent(factory.Name, storyID, action.Name, oldStateName, newStateName, "error", "", err.Error())
 					s.trackFactoryCreationFailure(factory.Name, storyID, err.Error())
 				} else {
@@ -280,7 +279,7 @@ func (s *Server) processShortcutEvent(workspaceName string, payload shortcutWebh
 					storyID,
 				).Scan(&activeClaw)
 				if activeClaw != "" {
-					log.Printf("[factory:%s] story %s left trigger — terminating claw", factory.Name, storyID)
+					logf("[factory:%s] story %s left trigger — terminating claw", factory.Name, storyID)
 					s.terminateClawForIssue(storyID)
 					s.logFactoryEvent(factory.Name, storyID, action.Name, oldStateName, newStateName, "claw_terminated", activeClaw, "")
 				} else {
@@ -328,7 +327,7 @@ func (s *Server) processShortcutWorkflowEvent(workspaces []*types.WorkspaceConfi
 
 				token := s.resolveShortcutTokenForWorkflow(workspace.Name, workflow)
 				if token == "" {
-					log.Printf("[workflow:%s/%s] no Shortcut token configured — skipping webhook story %s", workspace.Name, workflow.Name, storyID)
+					logf("[workflow:%s/%s] no Shortcut token configured — skipping webhook story %s", workspace.Name, workflow.Name, storyID)
 					continue
 				}
 
@@ -338,7 +337,7 @@ func (s *Server) processShortcutWorkflowEvent(workspaces []*types.WorkspaceConfi
 					if len(stateMap) > 0 {
 						stateNameCache[token] = stateMap
 					} else {
-						log.Printf("[shortcut-webhook] failed to load workflow states for workspace %q (empty response) — not caching", workflow.Workspace)
+						logf("[shortcut-webhook] failed to load workflow states for workspace %q (empty response) — not caching", workflow.Workspace)
 						continue
 					}
 				}
@@ -352,7 +351,7 @@ func (s *Server) processShortcutWorkflowEvent(workspaces []*types.WorkspaceConfi
 						storyFiltersByToken[token] = filterData
 					}
 					if filterData.loadErr != nil {
-						log.Printf("[workflow:%s/%s] skipping story %s: failed to load Shortcut story filters: %v", workspace.Name, workflow.Name, storyID, filterData.loadErr)
+						logf("[workflow:%s/%s] skipping story %s: failed to load Shortcut story filters: %v", workspace.Name, workflow.Name, storyID, filterData.loadErr)
 						continue
 					}
 					if !labelSetAllowed(filterData.labels, workflow.Labels, workflow.ExcludeLabels) {
@@ -368,7 +367,7 @@ func (s *Server) processShortcutWorkflowEvent(workspaces []*types.WorkspaceConfi
 					_ = s.db.QueryRow(`SELECT id FROM claws WHERE shortcut_story_id = ? AND status NOT IN ('error','deleted') LIMIT 1`, storyID).Scan(&activeClaw)
 					if activeClaw != "" {
 						matched = true
-						log.Printf("[workflow:%s/%s] Shortcut story %s left trigger %q — terminating claw %s", workspace.Name, workflow.Name, storyID, workflow.TriggerStatus, activeClaw[:8])
+						logf("[workflow:%s/%s] Shortcut story %s left trigger %q — terminating claw %s", workspace.Name, workflow.Name, storyID, workflow.TriggerStatus, activeClaw[:8])
 						s.terminateClawForIssue(storyID)
 					}
 				}
@@ -378,12 +377,12 @@ func (s *Server) processShortcutWorkflowEvent(workspaces []*types.WorkspaceConfi
 				}
 
 				matched = true
-				log.Printf("[workflow:%s/%s] Shortcut story %s entered %q — creating claw", workspace.Name, workflow.Name, storyID, workflow.TriggerStatus)
+				logf("[workflow:%s/%s] Shortcut story %s entered %q — creating claw", workspace.Name, workflow.Name, storyID, workflow.TriggerStatus)
 				if err := s.createClawForShortcutWorkflow(workspace, workflow, action, storyID, "shortcut webhook"); err != nil {
 					if isFactoryTriggerAlreadyClaimed(err) {
 						continue
 					}
-					log.Printf("[workflow:%s/%s] failed to create claw for %s: %v", workspace.Name, workflow.Name, storyID, err)
+					logf("[workflow:%s/%s] failed to create claw for %s: %v", workspace.Name, workflow.Name, storyID, err)
 				}
 			}
 		}
@@ -543,7 +542,7 @@ func (s *Server) createClawForShortcutStory(factory *types.FactoryConfig, action
 	}
 	if !claimed {
 		if reason != "poll" {
-			log.Printf("[factory:%s] Shortcut story %s already has an active trigger claim — treating as idempotent success", factory.Name, storyID)
+			logf("[factory:%s] Shortcut story %s already has an active trigger claim — treating as idempotent success", factory.Name, storyID)
 		}
 		return errFactoryTriggerAlreadyClaimed
 	}
@@ -559,7 +558,7 @@ func (s *Server) createClawForShortcutStory(factory *types.FactoryConfig, action
 	if _, err := shortcutAPI(s.resolveShortcutBaseURL(), fmt.Sprintf("stories/%s", storyID), token); err != nil {
 		return fmt.Errorf("cannot read story %s from Shortcut (check token/workspace access): %w", storyID, err)
 	}
-	log.Printf("[factory:%s] verified story %s is readable", factory.Name, storyID)
+	logf("[factory:%s] verified story %s is readable", factory.Name, storyID)
 
 	templateFiles, err := s.resolveTemplateFiles(factory.Template)
 	if err != nil {
@@ -573,7 +572,7 @@ func (s *Server) createClawForShortcutStory(factory *types.FactoryConfig, action
 		var parseErr error
 		tmplCfg, parseErr = config.ParseTemplateConfig([]byte(cfgContent))
 		if parseErr != nil {
-			log.Printf("[factory:%s] warning: could not parse elasticclaw-config.yaml from template %q: %v", factory.Name, factory.Template, parseErr)
+			logf("[factory:%s] warning: could not parse elasticclaw-config.yaml from template %q: %v", factory.Name, factory.Template, parseErr)
 			// Non-fatal — continue with defaults
 			tmplCfg = nil
 		}
@@ -615,14 +614,14 @@ func (s *Server) createClawForShortcutStory(factory *types.FactoryConfig, action
 
 	// Resolve and inject template-requested secrets (typed refs + legacy)
 	if tmplCfg != nil && len(tmplCfg.Secrets) > 0 {
-		log.Printf("[factory:%s] DEPRECATED: template %q uses 'secrets:' list — migrate to 'secret_refs:' map", factory.Name, factory.Template)
+		logf("[factory:%s] DEPRECATED: template %q uses 'secrets:' list — migrate to 'secret_refs:' map", factory.Name, factory.Template)
 		for _, ref := range tmplCfg.Secrets {
 			val, envName, ok := s.resolveSecretRef(ref, factory)
 			if ok {
 				env[envName] = val
-				log.Printf("[factory:%s] injected template secret %s as %s into claw env", factory.Name, ref.Type, envName)
+				logf("[factory:%s] injected template secret %s as %s into claw env", factory.Name, ref.Type, envName)
 			} else {
-				log.Printf("[factory:%s] warning: requested secret (type=%s name=%s workspace=%s) not found", factory.Name, ref.Type, ref.Name, ref.Workspace)
+				logf("[factory:%s] warning: requested secret (type=%s name=%s workspace=%s) not found", factory.Name, ref.Type, ref.Name, ref.Workspace)
 			}
 		}
 	}
@@ -632,9 +631,9 @@ func (s *Server) createClawForShortcutStory(factory *types.FactoryConfig, action
 		for envName, secretRef := range tmplCfg.SecretRefs {
 			if val, ok := s.hubCfg.Secrets[secretRef]; ok {
 				env[envName] = val
-				log.Printf("[factory:%s] injected template secret_ref %s as %s into claw env", factory.Name, secretRef, envName)
+				logf("[factory:%s] injected template secret_ref %s as %s into claw env", factory.Name, secretRef, envName)
 			} else {
-				log.Printf("[factory:%s] WARNING: template secret_ref %q not found in hub secrets", factory.Name, secretRef)
+				logf("[factory:%s] WARNING: template secret_ref %q not found in hub secrets", factory.Name, secretRef)
 			}
 		}
 	}
@@ -644,9 +643,9 @@ func (s *Server) createClawForShortcutStory(factory *types.FactoryConfig, action
 		for envName, secretRef := range factory.SecretRefs {
 			if val, ok := s.hubCfg.Secrets[secretRef]; ok {
 				env[envName] = val
-				log.Printf("[factory:%s] injected factory secret_ref %s as %s into claw env", factory.Name, secretRef, envName)
+				logf("[factory:%s] injected factory secret_ref %s as %s into claw env", factory.Name, secretRef, envName)
 			} else {
-				log.Printf("[factory:%s] WARNING: secret_ref %q not found in hub secrets", factory.Name, secretRef)
+				logf("[factory:%s] WARNING: secret_ref %q not found in hub secrets", factory.Name, secretRef)
 			}
 		}
 	}
@@ -731,7 +730,7 @@ func (s *Server) createClawForShortcutStory(factory *types.FactoryConfig, action
 	isPending := false
 	if groupLimit > 0 && activeCount >= groupLimit {
 		isPending = true
-		log.Printf("[factory] concurrency limit reached for group %q (active=%d, limit=%d) — queueing claw for Shortcut story %s as pending", groupName, activeCount, groupLimit, storyID)
+		logf("[factory] concurrency limit reached for group %q (active=%d, limit=%d) — queueing claw for Shortcut story %s as pending", groupName, activeCount, groupLimit, storyID)
 	}
 
 	clawID := uuid.New().String()
@@ -766,7 +765,7 @@ func (s *Server) createClawForShortcutStory(factory *types.FactoryConfig, action
 	}
 	claimOpen = false
 
-	log.Printf("[factory] created claw %s (%s) for Shortcut story %s (status=%s, reason=%s)", clawName, clawID[:8], storyID, initialStatus, reason)
+	logf("[factory] created claw %s (%s) for Shortcut story %s (status=%s, reason=%s)", clawName, clawID[:8], storyID, initialStatus, reason)
 	s.broadcastToUsers(tenantID, types.WSMessage{
 		Type:    "claw_status",
 		Payload: map[string]string{"claw_id": clawID, "status": initialStatus},
@@ -777,9 +776,9 @@ func (s *Server) createClawForShortcutStory(factory *types.FactoryConfig, action
 	if !isPending && factory.WorkingStatus != "" {
 		if token != "" {
 			if err := moveShortcutStory(s.resolveShortcutBaseURL(), token, storyID, factory.WorkingStatus); err != nil {
-				log.Printf("[factory] failed to move story %s to working status '%s': %v", storyID, factory.WorkingStatus, err)
+				logf("[factory] failed to move story %s to working status '%s': %v", storyID, factory.WorkingStatus, err)
 			} else {
-				log.Printf("[factory] moved story %s to working status '%s'", storyID, factory.WorkingStatus)
+				logf("[factory] moved story %s to working status '%s'", storyID, factory.WorkingStatus)
 			}
 		}
 	}
@@ -819,7 +818,7 @@ func (s *Server) createClawForShortcutStory(factory *types.FactoryConfig, action
 			provErr = fmt.Errorf("unsupported provider: %s", provider)
 		}
 		if provErr != nil {
-			log.Printf("[factory:%s] provision failed for %s: %v", factory.Name, clawID[:8], provErr)
+			logf("[factory:%s] provision failed for %s: %v", factory.Name, clawID[:8], provErr)
 			s.stopAgentWithReason(clawID, fmt.Sprintf("Factory provision failed: %v", provErr), false)
 		}
 	}()
@@ -831,7 +830,7 @@ func (s *Server) createClawForShortcutWorkflow(workspace *types.WorkspaceConfig,
 	var existing string
 	_ = s.db.QueryRow(`SELECT id FROM claws WHERE shortcut_story_id=? AND status NOT IN ('error','deleted') LIMIT 1`, storyID).Scan(&existing)
 	if existing != "" {
-		log.Printf("[workflow:%s/%s] Shortcut story %s already has active claw %s", workspace.Name, workflow.Name, storyID, existing[:8])
+		logf("[workflow:%s/%s] Shortcut story %s already has active claw %s", workspace.Name, workflow.Name, storyID, existing[:8])
 		return nil
 	}
 
@@ -847,7 +846,7 @@ func (s *Server) createClawForShortcutWorkflow(workspace *types.WorkspaceConfig,
 		return fmt.Errorf("claim workflow trigger: %w", err)
 	}
 	if !claimed {
-		log.Printf("[workflow:%s/%s] Shortcut story %s already has an active trigger claim", workspace.Name, workflow.Name, storyID)
+		logf("[workflow:%s/%s] Shortcut story %s already has an active trigger claim", workspace.Name, workflow.Name, storyID)
 		return nil
 	}
 	claimOpen := true

--- a/pkg/hub/task_run_analytics.go
+++ b/pkg/hub/task_run_analytics.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"log"
 	"sort"
 	"strconv"
 	"strings"
@@ -537,7 +536,7 @@ func (s *Server) recordTaskRunHumanEventForClaw(clawID, eventType, eventKey, act
 		Detail:          detail,
 		OccurredAt:      now(),
 	}); err != nil {
-		log.Printf("[task-run-analytics] failed to record human event %s for claw %s: %v", eventType, clawID, err)
+		logf("[task-run-analytics] failed to record human event %s for claw %s: %v", eventType, clawID, err)
 	}
 }
 
@@ -558,7 +557,7 @@ func (s *Server) recordTaskRunDashboardMessage(clawID, actorLogin, messageID str
 		Detail:          map[string]any{"message_id": messageID},
 		OccurredAt:      now(),
 	}); err != nil {
-		log.Printf("[task-run-analytics] failed to record dashboard message for claw %s: %v", clawID, err)
+		logf("[task-run-analytics] failed to record dashboard message for claw %s: %v", clawID, err)
 	}
 }
 
@@ -580,7 +579,7 @@ func (s *Server) recordTaskRunManualStopBeforeDelivery(clawID, actorLogin string
 		Detail:          map[string]any{"reason": "dashboard_delete"},
 		OccurredAt:      now(),
 	}); err != nil {
-		log.Printf("[task-run-analytics] failed to record manual stop for claw %s: %v", clawID, err)
+		logf("[task-run-analytics] failed to record manual stop for claw %s: %v", clawID, err)
 	}
 }
 

--- a/pkg/hub/task_run_analytics_api.go
+++ b/pkg/hub/task_run_analytics_api.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -527,7 +526,7 @@ func (s *Server) readTaskRunAnalyticsEvents(tenantID, runID string) ([]taskRunAn
 		event.Detail = map[string]any{}
 		if detailJSON != "" {
 			if err := json.Unmarshal([]byte(detailJSON), &event.Detail); err != nil {
-				log.Printf("[task-run-analytics] failed to unmarshal event detail for %s: %v", event.ID, err)
+				logf("[task-run-analytics] failed to unmarshal event detail for %s: %v", event.ID, err)
 			}
 		}
 		events = append(events, event)
@@ -769,7 +768,7 @@ func scanTaskRunAnalyticsRuns(rows *sql.Rows) ([]taskRunAnalyticsRunView, error)
 		run.WarningTypes = []string{}
 		if warningsJSON != "" {
 			if err := json.Unmarshal([]byte(warningsJSON), &run.WarningTypes); err != nil {
-				log.Printf("[task-run-analytics] failed to unmarshal warning types for run %s: %v", run.RunID, err)
+				logf("[task-run-analytics] failed to unmarshal warning types for run %s: %v", run.RunID, err)
 			}
 		}
 		runs = append(runs, run)

--- a/pkg/hub/volumes.go
+++ b/pkg/hub/volumes.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -322,7 +321,7 @@ func (s *Server) syncWorkflowVolumes(clawID string) {
 	s.mu.RUnlock()
 	if cc == nil {
 		if hasActiveWritableLease {
-			log.Printf("[volume] sync %s skipped: claw disconnected with writable volume lease; keeping lease until expiry", clawID)
+			logf("[volume] sync %s skipped: claw disconnected with writable volume lease; keeping lease until expiry", clawID)
 			return
 		}
 		s.releaseWorkflowVolumeLeases(clawID)
@@ -337,12 +336,12 @@ func (s *Server) syncWorkflowVolumes(clawID string) {
 			continue
 		}
 		if err := s.dispatchVolumeSync(context.Background(), cc, volume); err != nil {
-			log.Printf("[volume] sync %s/%s failed: %v", clawID, volume.Name, err)
+			logf("[volume] sync %s/%s failed: %v", clawID, volume.Name, err)
 			syncFailed = true
 		}
 	}
 	if syncFailed {
-		log.Printf("[volume] sync %s incomplete; keeping writable volume leases until expiry", clawID)
+		logf("[volume] sync %s incomplete; keeping writable volume leases until expiry", clawID)
 		return
 	}
 	s.releaseWorkflowVolumeLeases(clawID)
@@ -485,7 +484,7 @@ func (s *Server) handleVolumeArchivePut(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 	if _, err := s.db.Exec(`UPDATE volume_leases SET manifest_digest=?, heartbeat_at=? WHERE id=? AND claw_id=? AND access_token=?`, manifestDigest, time.Now().UTC(), leaseID, clawID, accessToken); err != nil {
-		log.Printf("[volume] lease %s: failed to update manifest_digest after successful tag: %v", leaseID, err)
+		logfCtx(r.Context(), "[volume] lease %s: failed to update manifest_digest after successful tag: %v", leaseID, err)
 	}
 	jsonOK(w, map[string]string{"manifest_digest": manifestDigest})
 }

--- a/pkg/hub/workflow_creator.go
+++ b/pkg/hub/workflow_creator.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"strings"
 	"time"
@@ -56,7 +55,7 @@ func (s *Server) createClawFromWorkflowWithOptions(workspace *types.WorkspaceCon
 		var err error
 		tmplCfg, err = config.ParseTemplateConfig([]byte(cfgContent))
 		if err != nil {
-			log.Printf("[workflow:%s/%s] warning: could not parse workspace elasticclaw-config.yaml: %v", workspace.Name, workflow.Name, err)
+			logf("[workflow:%s/%s] warning: could not parse workspace elasticclaw-config.yaml: %v", workspace.Name, workflow.Name, err)
 			tmplCfg = nil
 		}
 	}
@@ -260,9 +259,9 @@ func (s *Server) createClawFromWorkflowWithOptions(workspace *types.WorkspaceCon
 	if opts.triggerActor != nil {
 		actorJSON, err := json.Marshal(opts.triggerActor)
 		if err != nil {
-			log.Printf("[workflow] failed to marshal trigger actor for claw %s: %v", shortID(clawID), err)
+			logf("[workflow] failed to marshal trigger actor for claw %s: %v", shortID(clawID), err)
 		} else if _, err := s.db.Exec(`UPDATE claws SET trigger_actor_json=? WHERE id=?`, string(actorJSON), clawID); err != nil {
-			log.Printf("[workflow] failed to persist trigger actor for claw %s: %v", shortID(clawID), err)
+			logf("[workflow] failed to persist trigger actor for claw %s: %v", shortID(clawID), err)
 		}
 	}
 
@@ -286,13 +285,13 @@ func (s *Server) createClawFromWorkflowWithOptions(workspace *types.WorkspaceCon
 		EventKey:         "task_start:claw:" + clawID,
 	}); err != nil {
 		if _, cleanupErr := s.db.Exec(`DELETE FROM claws WHERE id=?`, clawID); cleanupErr != nil {
-			log.Printf("[workflow] WARNING: failed to delete orphaned claw %s after task-run creation failure: %v", clawID[:8], cleanupErr)
+			logf("[workflow] WARNING: failed to delete orphaned claw %s after task-run creation failure: %v", clawID[:8], cleanupErr)
 		}
 		go s.promotePendingClaws()
 		return "", false, fmt.Errorf("task run analytics: %w", err)
 	}
 
-	log.Printf("[workflow] created claw %s (%s) for workflow %s/%s (status=%s, reason=%s)", clawName, clawID[:8], workspace.Name, workflow.Name, initialStatus, opts.reason)
+	logf("[workflow] created claw %s (%s) for workflow %s/%s (status=%s, reason=%s)", clawName, clawID[:8], workspace.Name, workflow.Name, initialStatus, opts.reason)
 	s.broadcastToUsers(tenantID, types.WSMessage{
 		Type:    "claw_status",
 		Payload: map[string]string{"claw_id": clawID, "status": initialStatus},
@@ -349,7 +348,7 @@ func (s *Server) createClawFromWorkflowWithOptions(workspace *types.WorkspaceCon
 			provErr = fmt.Errorf("unsupported provider: %s", provider)
 		}
 		if provErr != nil {
-			log.Printf("[workflow] provision failed for %s: %v", clawID, provErr)
+			logf("[workflow] provision failed for %s: %v", clawID, provErr)
 			s.stopAgentWithReason(clawID, fmt.Sprintf("Workflow provision failed: %v", provErr), false)
 		}
 	}()

--- a/pkg/hub/workspace_api.go
+++ b/pkg/hub/workspace_api.go
@@ -3,7 +3,6 @@ package hub
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"sort"
@@ -185,7 +184,7 @@ func (s *Server) handleWorkspaceWorkflowsPush(w http.ResponseWriter, r *http.Req
 	}
 	if s.cronScheduler != nil {
 		if err := s.cronScheduler.reload(); err != nil {
-			log.Printf("[cron] failed to reload workflows after workflow push for workspace %s: %v", name, err)
+			logfCtx(r.Context(), "[cron] failed to reload workflows after workflow push for workspace %s: %v", name, err)
 		}
 	}
 	workflows := make([]WorkflowView, 0, len(req.Workflows))
@@ -270,7 +269,7 @@ func (s *Server) handleWorkspaceWorkflowPatch(w http.ResponseWriter, r *http.Req
 	}
 	if s.cronScheduler != nil {
 		if err := s.cronScheduler.reload(); err != nil {
-			log.Printf("[cron] failed to reload workflows after workflow patch for workspace %s workflow %s: %v", workspace.Name, workflow.Name, err)
+			logfCtx(r.Context(), "[cron] failed to reload workflows after workflow patch for workspace %s workflow %s: %v", workspace.Name, workflow.Name, err)
 		}
 	}
 	jsonOK(w, workflowToView(workspace.Name, workflow))


### PR DESCRIPTION
## Motivation

There are ~200 log.Printf calls with manual `[component]` tags and stray fmt.Println; log lines from the same request cannot be correlated. slog + withRequestID middleware fixes both.

Concrete evidence in the tree before this PR:

- 649 `log.Printf` calls across 26 non-test files in `pkg/hub` (top offenders: `server.go` with 177, `pipeline_runner.go` 77, `linear.go` 71, `github_webhook.go` 61), all tagged by hand with prefixes like `[hub]`, `[cron]`, `[create]`, `[pipeline]`.
- 2 `log.Println` calls in `cron_scheduler.go`.
- 3 stray `fmt.Println` calls in `external_storage.go` (lines 685/714/716) plus one `fmt.Printf` log line at line 671 — these bypass the log package entirely and write to stdout.
- No request ID anywhere: two interleaved claw-creation requests produce indistinguishable log lines.

Implements item **1.3 Structured logging + request ID** of `docs/re-arch/phase-1-contract-and-observability.md`.

## Dependencies

This PR is STACKED on branch `feature/recovery-middleware`. Depends on #441 — review and merge that first.

## What changed

- **`pkg/hub/logger`** (new package): `New()` builds the root slog logger — JSON handler by default, text when `ELASTICCLAW_LOG_FORMAT=text` (dev); `NewContext`/`FromContext` carry a request-scoped logger through `context.Context`, with `FromContext` always falling back to `slog.Default()`.
- **Root logger at boot**: `cmd/hub.go` installs the root logger via `slog.SetDefault` before the server starts; `NewServer` injects it into the `Server` struct (`Server.logger`).
- **`withRequestID` middleware** (`pkg/hub/middleware.go`): generates a short 8-hex-char ID per request, echoes it in the `X-Request-ID` response header, and stores a logger with `request_id` attached in the request context. `withAuth` additionally attaches `tenant_id` after resolving the token. Wired in `Server.Run` as `withRecovery(s.withRequestID(corsMiddleware(mux)))`, so even the panic-recovery log line carries the request ID.
- **Bridge helpers** (`pkg/hub/logging.go`): `logf(format, args...)` (no context in scope — boot code, background goroutines) and `logfCtx(ctx, format, args...)` (request scope). Both preserve the message text verbatim and lift a leading `"[component] "` tag into a `component` slog attribute.
- **Mechanical migration** (one commit per file group, message text unchanged): all 649 `log.Printf`, 2 `log.Println`, 3 `fmt.Println` and 1 log-like `fmt.Printf` in `pkg/hub` rewritten via an AST-based tool. Call sites inside functions with a `ctx context.Context` or `r *http.Request` parameter (including enclosing closures) became `logfCtx(ctx|r.Context(), ...)`; the rest became `logf(...)`. `pkg/hub` is now free of `log.Printf`/`fmt.Println`.
- **Lint guard**: new `.golangci.yml` (v2 schema) enabling `forbidigo` for `log.Print*`/`fmt.Print*` scoped to `pkg/hub` only (the CLI under `cmd/` legitimately prints to stdout; `pkg/hub/factorytest` scaffolding excluded). Picked up by the existing `make lint` target; no CI job added, per plan.
- **Tests**: `pkg/hub/logger` unit tests (context round-trip, fallback, format selection) and `TestWithRequestID` / `TestLogfComponentExtraction` in `pkg/hub/middleware_test.go` asserting that all log lines of one request share the `request_id` from the `X-Request-ID` header and that `[component]` tags become attributes.

Notes for reviewers:

- All migrated lines log at Info level — the migration is deliberately mechanical (per spec: "without changing messages"); per-line level triage is follow-up work.
- `logfCtx` in goroutines that outlive the request only *reads* the logger value from the context, so a canceled request context is harmless — and async claw-provisioning lines keep the creating request's `request_id`, which is exactly the acceptance criterion.

## Testing

- `go build ./...` — pass.
- `go test ./...` (what `make test` runs, without `-v`) — all packages pass, including `pkg/hub` (14.8s), `pkg/hub/logger`, and `pkg/hub/factorytest`.
- `golangci-lint run --config .golangci.yml --enable-only forbidigo ./pkg/hub/...` with golangci-lint 2.12.2 — `0 issues` after the migration; before the final straggler fix it correctly flagged the remaining `fmt.Printf`, confirming the guard works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
