### PR TITLE
refactor(web): adopt generated API types, extract useWebSocket and useMessageCache

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -9,11 +9,12 @@ import { useHub } from "@/hooks/use-hub"
 import type { Message } from "@/lib/types"
 import { isConfigured, type Workflow } from "@/lib/api"
 import { requestAuthToken } from "@/lib/auth-storage"
+import { STORAGE_KEY_SELECTED_CLAW } from "@/lib/constants"
 
 export default function Home() {
   const [selectedClawId, setSelectedClawId] = useState<string | null>(() => {
     if (typeof window === 'undefined') return null
-    return localStorage.getItem('elasticclaw_selected_claw') ?? null
+    return localStorage.getItem(STORAGE_KEY_SELECTED_CLAW) ?? null
   })
   const [searchQuery, setSearchQuery] = useState("")
   const [activeTagFilters, setActiveTagFilters] = useState<string[]>([])
@@ -155,7 +156,7 @@ export default function Home() {
   const handleSelectClaw = useCallback(
     (id: string) => {
       setSelectedClawId(id)
-      localStorage.setItem('elasticclaw_selected_claw', id)
+      localStorage.setItem(STORAGE_KEY_SELECTED_CLAW, id)
       hub.setUnreadCount(id, 0)
       hub.loadMessages(id)
     },
@@ -212,7 +213,7 @@ export default function Home() {
     if (!selectedClawId) return
     hub.killClaw(selectedClawId)
     setSelectedClawId(null)
-    localStorage.removeItem('elasticclaw_selected_claw')
+    localStorage.removeItem(STORAGE_KEY_SELECTED_CLAW)
   }, [selectedClawId, hub])
 
   const handleKillClaw = useCallback(
@@ -220,7 +221,7 @@ export default function Home() {
       hub.killClaw(clawId)
       if (selectedClawId === clawId) {
         setSelectedClawId(null)
-        localStorage.removeItem('elasticclaw_selected_claw')
+        localStorage.removeItem(STORAGE_KEY_SELECTED_CLAW)
       }
     },
     [selectedClawId, hub]
@@ -270,7 +271,7 @@ export default function Home() {
           onKill={handleKill}
           onKillClaw={handleKillClaw}
           onSelectClaw={handleSelectClaw}
-          onDeselectClaw={() => { setSelectedClawId(null); localStorage.removeItem('elasticclaw_selected_claw') }}
+          onDeselectClaw={() => { setSelectedClawId(null); localStorage.removeItem(STORAGE_KEY_SELECTED_CLAW) }}
           onReorderClaws={reorderClaws}
           loading={loading}
           hubError={hubError}

--- a/web/components/terminal.tsx
+++ b/web/components/terminal.tsx
@@ -1,6 +1,7 @@
 "use client"
 
-import { useEffect, useRef } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
+import { useWebSocket } from "@/hooks/use-websocket"
 import "@xterm/xterm/css/xterm.css"
 
 interface TerminalProps {
@@ -11,21 +12,46 @@ interface TerminalProps {
 
 /**
  * XTerminal — browser-only SSH terminal component.
- * Dynamically imports xterm.js to avoid SSR issues.
+ * Dynamically imports xterm.js to avoid SSR issues. The WebSocket lifecycle
+ * is owned by the shared useWebSocket hook (no auto-reconnect: an SSH session
+ * cannot be resumed transparently, so a dropped connection stays closed).
  */
 export function XTerminal({ clawId, wsUrl, className }: TerminalProps) {
   const containerRef = useRef<HTMLDivElement>(null)
-  const stateRef = useRef<{
-    ws: WebSocket | null
-    term: import("@xterm/xterm").Terminal | null
-    fitAddon: import("@xterm/addon-fit").FitAddon | null
-    resizeObserver: ResizeObserver | null
-  }>({ ws: null, term: null, fitAddon: null, resizeObserver: null })
+  const termRef = useRef<import("@xterm/xterm").Terminal | null>(null)
+  const fitAddonRef = useRef<import("@xterm/addon-fit").FitAddon | null>(null)
+  const [termReady, setTermReady] = useState(false)
+
+  const getUrl = useCallback(() => wsUrl, [wsUrl])
+
+  const { send } = useWebSocket({
+    getUrl,
+    enabled: termReady,
+    reconnect: false,
+    onOpen: (ws) => {
+      const term = termRef.current
+      if (!term) return
+      term.writeln("\r\n\x1b[32mConnected to SSH terminal\x1b[0m\r\n")
+      fitAddonRef.current?.fit()
+      // Send initial size
+      ws.send(JSON.stringify({ type: "resize", cols: term.cols, rows: term.rows }))
+    },
+    onMessage: (e) => {
+      termRef.current?.write(typeof e.data === "string" ? e.data : new Uint8Array(e.data))
+    },
+    onError: () => {
+      termRef.current?.writeln("\r\n\x1b[31mWebSocket error — connection failed\x1b[0m\r\n")
+    },
+    onClose: () => {
+      termRef.current?.writeln("\r\n\x1b[33mConnection closed\x1b[0m\r\n")
+    },
+  })
 
   useEffect(() => {
     if (!containerRef.current) return
     const el = containerRef.current
     let mounted = true
+    let resizeObserver: ResizeObserver | null = null
 
     async function init() {
       const { Terminal } = await import("@xterm/xterm")
@@ -65,63 +91,38 @@ export function XTerminal({ clawId, wsUrl, className }: TerminalProps) {
       term.open(containerRef.current)
       fitAddon.fit()
 
-      stateRef.current.term = term
-      stateRef.current.fitAddon = fitAddon
-
-      // Connect WebSocket
-      const ws = new WebSocket(wsUrl)
-      stateRef.current.ws = ws
-
-      ws.onopen = () => {
-        term.writeln("\r\n\x1b[32mConnected to SSH terminal\x1b[0m\r\n")
-        fitAddon.fit()
-        // Send initial size
-        ws.send(JSON.stringify({ type: "resize", cols: term.cols, rows: term.rows }))
-      }
-
-      ws.onmessage = (e) => {
-        term.write(typeof e.data === "string" ? e.data : new Uint8Array(e.data))
-      }
-
-      ws.onerror = () => {
-        term.writeln("\r\n\x1b[31mWebSocket error — connection failed\x1b[0m\r\n")
-      }
-
-      ws.onclose = () => {
-        term.writeln("\r\n\x1b[33mConnection closed\x1b[0m\r\n")
-      }
+      termRef.current = term
+      fitAddonRef.current = fitAddon
 
       term.onData((data) => {
-        if (ws.readyState === WebSocket.OPEN) {
-          ws.send(data)
-        }
+        send(data)
       })
 
       term.onResize(({ cols, rows }) => {
-        if (ws.readyState === WebSocket.OPEN) {
-          ws.send(JSON.stringify({ type: "resize", cols, rows }))
-        }
+        send(JSON.stringify({ type: "resize", cols, rows }))
       })
 
       // Observe container resize
-      const resizeObserver = new ResizeObserver(() => {
+      resizeObserver = new ResizeObserver(() => {
         if (mounted) fitAddon.fit()
       })
       resizeObserver.observe(el)
-      stateRef.current.resizeObserver = resizeObserver
+
+      // Terminal is ready — let useWebSocket open the connection
+      setTermReady(true)
     }
 
     init().catch(console.error)
 
     return () => {
       mounted = false
-      const { ws, term, fitAddon, resizeObserver } = stateRef.current
       resizeObserver?.disconnect()
-      ws?.close()
-      term?.dispose()
-      stateRef.current = { ws: null, term: null, fitAddon: null, resizeObserver: null }
+      termRef.current?.dispose()
+      termRef.current = null
+      fitAddonRef.current = null
+      setTermReady(false)
     }
-  }, [wsUrl]) // reconnect if wsUrl changes
+  }, [send])
 
   return (
     <div

--- a/web/hooks/use-hub.ts
+++ b/web/hooks/use-hub.ts
@@ -15,7 +15,15 @@ import {
 } from "@/lib/api"
 import { mapApiClaw, mapApiMessage, mapApiStatus, computeUptime, isDeletedClaw } from "@/lib/mappers"
 import { isTerminalAssistantMessage } from "@/lib/messages"
+import {
+  CLAW_POLL_INTERVAL_MS,
+  DEPENDENCY_POLL_INTERVAL_MS,
+  STORAGE_KEY_CLAW_ORDER,
+  STORAGE_KEY_PINNED,
+} from "@/lib/constants"
 import { useTypewriter, type TypewriterState } from "@/hooks/use-typewriter"
+import { useWebSocket } from "@/hooks/use-websocket"
+import { useMessageCache, isTransientMessage } from "@/hooks/use-message-cache"
 
 export interface HubState {
   claws: Claw[]
@@ -35,24 +43,6 @@ export interface HubState {
   setUnreadCount: (clawId: string, count: number) => void
   refreshClaws: () => Promise<void>
   reorderClaws: (ids: string[]) => void
-}
-
-const ORDER_KEY = "elasticclaw_claw_order"
-
-function describeWsUrl(rawUrl: string): string {
-  try {
-    const url = new URL(rawUrl)
-    if (url.searchParams.has("token")) {
-      url.searchParams.set("token", "[redacted]")
-    }
-    return url.toString()
-  } catch {
-    return rawUrl.replace(/token=[^&]+/, "token=[redacted]")
-  }
-}
-
-function isTransientMessage(message: Message): boolean {
-  return message.id.startsWith("activity-") || message.id.startsWith("live-") || message.id.startsWith("thinking-")
 }
 
 function formatActivityContent(activity: AgentActivity): string {
@@ -83,7 +73,7 @@ function withoutModelWaitActivities(messages: Message[]): Message[] {
 
 function loadSavedOrder(): string[] {
   try {
-    const raw = localStorage.getItem(ORDER_KEY)
+    const raw = localStorage.getItem(STORAGE_KEY_CLAW_ORDER)
     return raw ? JSON.parse(raw) : []
   } catch {
     return []
@@ -92,17 +82,21 @@ function loadSavedOrder(): string[] {
 
 function saveOrder(ids: string[]) {
   try {
-    localStorage.setItem(ORDER_KEY, JSON.stringify(ids))
+    localStorage.setItem(STORAGE_KEY_CLAW_ORDER, JSON.stringify(ids))
   } catch {}
 }
 
+/**
+ * useHub — composition root for the hub UI state: claw list (poll + reorder +
+ * pin), dependency status, hub WebSocket events, and the message transcript.
+ * Connection management lives in useWebSocket; message persistence and the
+ * durable/transient merge live in useMessageCache.
+ */
 export function useHub(selectedClawId: string | null): HubState {
   const [claws, setClaws] = useState<Claw[]>([])
   const [dependencies, setDependencies] = useState<DependencyStatus[]>([])
   const orderRef = useRef<string[]>([])
-  const [messages, setMessages] = useState<Record<string, Message[]>>({})
-  const messagesRef = useRef<Record<string, Message[]>>({})
-  const [connected, setConnected] = useState(false)
+  const { messages, messagesRef, loadCachedMessages, updateMessages, mergeTimeline, removeClaw } = useMessageCache()
   const {
     displayBuffers: streamingBuffers,
     pushChunk,
@@ -113,6 +107,7 @@ export function useHub(selectedClawId: string | null): HubState {
   const [configured, setConfigured] = useState(false)
   const [loading, setLoading] = useState(true) // true until first claws fetch completes
   const [hubError, setHubError] = useState<string | null>(null)
+  const [wsEnabled, setWsEnabled] = useState(false)
   const segmentedStreamRef = useRef<Record<string, boolean>>({})
   const clientMessageSeqRef = useRef(0)
 
@@ -125,41 +120,6 @@ export function useHub(selectedClawId: string | null): HubState {
   // Track pinned state from localStorage
   const pinnedRef = useRef<Record<string, boolean>>({})
 
-  // ── localStorage message cache ──────────────────────────────────────────────
-  const MESSAGES_KEY = "elasticclaw_messages"
-  const MAX_CACHED_PER_CLAW = 200
-
-  const loadCachedMessages = useCallback(() => {
-    try {
-      const raw = localStorage.getItem(MESSAGES_KEY)
-      if (!raw) return
-      const parsed: Record<string, Array<{ id: string; role: string; content: string; timestamp: string }>> = JSON.parse(raw)
-      const hydrated: Record<string, Message[]> = {}
-      for (const [clawId, msgs] of Object.entries(parsed)) {
-        hydrated[clawId] = msgs.map((m) => ({ ...m, role: m.role as Message["role"], timestamp: new Date(m.timestamp) }))
-      }
-      setMessages(hydrated)
-    } catch {}
-  }, [])
-
-  const persistMessages = useCallback((msgs: Record<string, Message[]>) => {
-    try {
-      const toSave: Record<string, unknown[]> = {}
-      for (const [clawId, clawMsgs] of Object.entries(msgs)) {
-        // Keep last N durable messages per claw. Live stream segments and activity
-        // rows are per-tab transcript state; the API stores canonical messages.
-        toSave[clawId] = clawMsgs
-          .filter((m) => !m.id.startsWith("opt-") && m.role !== "system" && !isTransientMessage(m))
-          .slice(-MAX_CACHED_PER_CLAW)
-      }
-      localStorage.setItem(MESSAGES_KEY, JSON.stringify(toSave))
-    } catch {}
-  }, [])
-  const wsRef = useRef<WebSocket | null>(null)
-  const reconnectTimerRef = useRef<number | null>(null)
-  const reconnectAttemptRef = useRef(0)
-  const shouldReconnectRef = useRef(false)
-  const lastWsErrorLogRef = useRef(0)
   const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const dependencyPollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const selectedClawIdRef = useRef<string | null>(selectedClawId)
@@ -168,14 +128,10 @@ export function useHub(selectedClawId: string | null): HubState {
     selectedClawIdRef.current = selectedClawId
   }, [selectedClawId])
 
-  useEffect(() => {
-    messagesRef.current = messages
-  }, [messages])
-
   // Load pinned state + message cache + order from localStorage on mount
   useEffect(() => {
     try {
-      const saved = localStorage.getItem("elasticclaw_pinned")
+      const saved = localStorage.getItem(STORAGE_KEY_PINNED)
       if (saved) pinnedRef.current = JSON.parse(saved)
     } catch {}
     orderRef.current = loadSavedOrder()
@@ -185,7 +141,7 @@ export function useHub(selectedClawId: string | null): HubState {
   const savePinned = useCallback((pinned: Record<string, boolean>) => {
     pinnedRef.current = pinned
     try {
-      localStorage.setItem("elasticclaw_pinned", JSON.stringify(pinned))
+      localStorage.setItem(STORAGE_KEY_PINNED, JSON.stringify(pinned))
     } catch {}
   }, [])
 
@@ -271,28 +227,13 @@ export function useHub(selectedClawId: string | null): HubState {
     try {
       const apiMsgs = await fetchMessageTimeline(clawId)
       const msgs = apiMsgs.map(mapApiMessage)
-      
+
       // Capture existing IDs before updating so we can diff outside the updater.
       // React 18 batches state updates — side effects inside updaters are unreliable.
       const existingIds = new Set((messagesRef.current[clawId] || []).map((m) => m.id))
       const newClawMsgs = msgs.filter((m) => !existingIds.has(m.id) && m.role !== 'user' && m.role !== 'system')
 
-      setMessages((prev) => {
-        const existing = prev[clawId] || []
-        // Merge API result with cached state:
-        // 1. Keep non-optimistic existing messages not in API result (preserves cache beyond API limit)
-        // 2. Re-append any in-flight opt- messages so send() can still swap them with real UUIDs
-        const existingNonOpt = existing.filter((m) => !m.id.startsWith('opt-') && !isTransientMessage(m))
-        const apiIds = new Set(msgs.map((m) => m.id))
-        const cachedOnly = existingNonOpt.filter((m) => !apiIds.has(m.id))
-        const inflight = existing.filter((m) => m.id.startsWith('opt-') &&
-          !msgs.some((r) => r.content === m.content && r.role === m.role))
-        const merged = [...msgs, ...cachedOnly, ...inflight]
-        merged.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime())
-        const next = { ...prev, [clawId]: merged }
-        persistMessages(next)
-        return next
-      })
+      mergeTimeline(clawId, msgs)
 
       if (newClawMsgs.length > 0 && selectedClawIdRef.current !== clawId) {
         setClaws((prevClaws) =>
@@ -306,126 +247,110 @@ export function useHub(selectedClawId: string | null): HubState {
     } catch (err) {
       console.warn(`Failed to load messages for ${clawId}:`, err)
     }
-  }, [persistMessages])
+  }, [mergeTimeline, messagesRef])
 
-  const connectWebSocket = useCallback(() => {
-    if (!shouldReconnectRef.current) return
-    if (wsRef.current) {
-      wsRef.current.onclose = null
-      wsRef.current.onerror = null
-      wsRef.current.close()
-    }
-    const wsUrl = getHubWsUrl()
-    const safeWsUrl = describeWsUrl(wsUrl)
-    let ws: WebSocket
+  const handleWsMessage = useCallback((event: MessageEvent) => {
     try {
-      ws = new WebSocket(wsUrl)
-    } catch (err) {
-      console.error(`WS create failed for ${safeWsUrl}:`, err)
-      return
-    }
-    wsRef.current = ws
+      const data = JSON.parse(event.data)
+      const { type, payload } = data
 
-    ws.onopen = () => {
-      reconnectAttemptRef.current = 0
-      setConnected(true)
-    }
-
-    ws.onclose = (event) => {
-      if (wsRef.current !== ws) return
-      setConnected(false)
-      if (!shouldReconnectRef.current) return
-      const attempt = reconnectAttemptRef.current
-      reconnectAttemptRef.current += 1
-      const delayMs = Math.min(30_000, 1000 * 2 ** Math.min(attempt, 5))
-      if (event.code !== 1000) {
-        console.warn(
-          `WS closed for ${safeWsUrl}: code=${event.code} reason=${event.reason || "none"}; reconnecting in ${Math.round(delayMs / 1000)}s`
-        )
-      }
-      if (reconnectTimerRef.current) window.clearTimeout(reconnectTimerRef.current)
-      reconnectTimerRef.current = window.setTimeout(connectWebSocket, delayMs)
-    }
-
-    ws.onerror = () => {
-      const nowMs = Date.now()
-      if (nowMs - lastWsErrorLogRef.current < 10_000) return
-      lastWsErrorLogRef.current = nowMs
-      console.warn(`WS error for ${safeWsUrl}; check the Network tab for /api/ws status and close code`)
-    }
-
-    ws.onmessage = (event) => {
-      try {
-        const data = JSON.parse(event.data)
-        const { type, payload } = data
-
-        if (type === "chunk") {
-          // Streaming chunk — feed into typewriter
-          const { claw_id, content } = payload
-          pushChunk(claw_id, content)
-          setClaws((prev) =>
-            prev.map((c) =>
-                c.id === claw_id ? { ...c, isStreaming: true } : c
-            )
+      if (type === "chunk") {
+        // Streaming chunk — feed into typewriter
+        const { claw_id, content } = payload
+        pushChunk(claw_id, content)
+        setClaws((prev) =>
+          prev.map((c) =>
+              c.id === claw_id ? { ...c, isStreaming: true } : c
           )
-        } else if (type === "agent_activity") {
-          const clawId = payload.claw_id
-          if (!clawId) return
-          const activity: AgentActivity = {
-            kind: payload.kind || "activity",
-            stream: payload.stream,
-            phase: payload.phase,
-            tool: payload.tool,
-            detail: payload.detail,
-            command: payload.command,
-            path: payload.path,
-            url: payload.url,
-            message: payload.message,
-            error: payload.error,
-          }
-          if (isUnhelpfulActivity(activity)) return
-          const currentMessages = messagesRef.current[clawId] || []
-          const lastDurable = [...currentMessages].reverse().find((message) => !isTransientMessage(message) && message.role !== "activity")
-          if (activity.kind === "model_started" && lastDurable && isTerminalAssistantMessage(lastDurable)) return
-          const segment = splitTypewriter(clawId)
-          const createdAt = payload.created_at ? new Date(payload.created_at) : new Date()
-          const segmentId = segment.trim() ? nextClientMessageId("live-segment", clawId) : null
-          const activityId = nextClientMessageId("activity", clawId)
-          segmentedStreamRef.current[clawId] = true
-          setMessages((prev) => {
-            const nextMessages = [...(prev[clawId] || [])]
-            if (segmentId) {
-              nextMessages.push({
-                id: segmentId,
-                role: "claw",
-                content: segment,
-                timestamp: createdAt,
-              })
-            }
+        )
+      } else if (type === "agent_activity") {
+        const clawId = payload.claw_id
+        if (!clawId) return
+        const activity: AgentActivity = {
+          kind: payload.kind || "activity",
+          stream: payload.stream,
+          phase: payload.phase,
+          tool: payload.tool,
+          detail: payload.detail,
+          command: payload.command,
+          path: payload.path,
+          url: payload.url,
+          message: payload.message,
+          error: payload.error,
+        }
+        if (isUnhelpfulActivity(activity)) return
+        const currentMessages = messagesRef.current[clawId] || []
+        const lastDurable = [...currentMessages].reverse().find((message) => !isTransientMessage(message) && message.role !== "activity")
+        if (activity.kind === "model_started" && lastDurable && isTerminalAssistantMessage(lastDurable)) return
+        const segment = splitTypewriter(clawId)
+        const createdAt = payload.created_at ? new Date(payload.created_at) : new Date()
+        const segmentId = segment.trim() ? nextClientMessageId("live-segment", clawId) : null
+        const activityId = nextClientMessageId("activity", clawId)
+        segmentedStreamRef.current[clawId] = true
+        updateMessages((prev) => {
+          const nextMessages = [...(prev[clawId] || [])]
+          if (segmentId) {
             nextMessages.push({
-              id: activityId,
-              role: "activity",
-              content: formatActivityContent(activity),
-              activity,
+              id: segmentId,
+              role: "claw",
+              content: segment,
               timestamp: createdAt,
             })
-            const next = { ...prev, [clawId]: nextMessages }
-            persistMessages(next)
-            return next
+          }
+          nextMessages.push({
+            id: activityId,
+            role: "activity",
+            content: formatActivityContent(activity),
+            activity,
+            timestamp: createdAt,
           })
+          return { ...prev, [clawId]: nextMessages }
+        })
+        setClaws((prev) =>
+          prev.map((c) =>
+            c.id === clawId ? { ...c, isStreaming: true } : c
+          )
+        )
+      } else if (type === "message") {
+        // Final message — hold until typewriter drains, then commit
+        const msg = mapApiMessage(payload)
+        const clawId = payload.claw_id
+        if (segmentedStreamRef.current[clawId]) {
+          const tail = clearTypewriter(clawId)
+          delete segmentedStreamRef.current[clawId]
+          const tailId = tail.trim() ? nextClientMessageId("live-segment", clawId) : null
+          // Called once typewriter is fully drained — safe to add final message
           setClaws((prev) =>
             prev.map((c) =>
-              c.id === clawId ? { ...c, isStreaming: true } : c
+              c.id === clawId
+                ? {
+                    ...c,
+                    isStreaming: false,
+                    unreadCount:
+                      selectedClawIdRef.current !== clawId && msg.role === "claw"
+                        ? c.unreadCount + 1
+                        : c.unreadCount,
+                  }
+                : c
             )
           )
-        } else if (type === "message") {
-          // Final message — hold until typewriter drains, then commit
-          const msg = mapApiMessage(payload)
-          const clawId = payload.claw_id
-          if (segmentedStreamRef.current[clawId]) {
-            const tail = clearTypewriter(clawId)
-            delete segmentedStreamRef.current[clawId]
-            const tailId = tail.trim() ? nextClientMessageId("live-segment", clawId) : null
+          updateMessages((prev) => {
+            const nextMessages = withoutModelWaitActivities(prev[clawId] || [])
+            const hasLiveSegment = nextMessages.some((m) => m.id.startsWith(`live-segment-${clawId}-`))
+            if (tailId) {
+              nextMessages.push({
+                id: tailId,
+                role: "claw",
+                content: tail,
+                timestamp: msg.timestamp,
+              })
+            } else if (!hasLiveSegment && msg.content.trim()) {
+              nextMessages.push(msg)
+            }
+            return { ...prev, [clawId]: nextMessages }
+          })
+        } else {
+          finalizeTypewriter(clawId, () => {
             // Called once typewriter is fully drained — safe to add final message
             setClaws((prev) =>
               prev.map((c) =>
@@ -441,82 +366,49 @@ export function useHub(selectedClawId: string | null): HubState {
                   : c
               )
             )
-            setMessages((prev) => {
-              const nextMessages = withoutModelWaitActivities(prev[clawId] || [])
-              const hasLiveSegment = nextMessages.some((m) => m.id.startsWith(`live-segment-${clawId}-`))
-              if (tailId) {
-                nextMessages.push({
-                  id: tailId,
-                  role: "claw",
-                  content: tail,
-                  timestamp: msg.timestamp,
-                })
-              } else if (!hasLiveSegment && msg.content.trim()) {
-                nextMessages.push(msg)
-              }
-              const next = { ...prev, [clawId]: nextMessages }
-              persistMessages(next)
-              return next
-            })
-          } else {
-            finalizeTypewriter(clawId, () => {
-              // Called once typewriter is fully drained — safe to add final message
-              setClaws((prev) =>
-                prev.map((c) =>
-                  c.id === clawId
-                    ? {
-                        ...c,
-                        isStreaming: false,
-                        unreadCount:
-                          selectedClawIdRef.current !== clawId && msg.role === "claw"
-                            ? c.unreadCount + 1
-                            : c.unreadCount,
-                      }
-                    : c
-                )
-              )
-              setMessages((prev) => {
-                const next = { ...prev, [clawId]: [...withoutModelWaitActivities(prev[clawId] || []), msg] }
-                persistMessages(next)
-                return next
-              })
-            })
-          }
-        } else if (type === "claw_status") {
-          const { claw_id, status } = payload
-          if (status === "deleted") {
-            // Remove immediately — don't wait for next poll
-            setClaws((prev) => prev.filter((c) => c.id !== claw_id))
-          } else {
-            setClaws((prev) =>
-              prev.map((c) =>
-                c.id === claw_id
-                  ? {
-                      ...c,
-                      status: mapApiStatus(status),
-                      isStreaming: status !== "connected" ? false : c.isStreaming,
-                      reason: status === "error" ? payload.reason : undefined,
-                      bootstrap_status: status === "connected" || status === "error" ? undefined : payload.bootstrap_status ?? c.bootstrap_status,
-                      githubIssueId: payload.github_issue_id ?? c.githubIssueId,
-                      githubIssueUrl: payload.github_issue_url ?? c.githubIssueUrl,
-                    }
-                  : c
-              )
-            )
-            // If a new claw came online that we don't know about, refresh
-            setClaws((prev) => {
-              if (!prev.find((c) => c.id === claw_id)) {
-                refreshClaws()
-              }
-              return prev
-            })
-          }
+            updateMessages((prev) => ({ ...prev, [clawId]: [...withoutModelWaitActivities(prev[clawId] || []), msg] }))
+          })
         }
-      } catch (err) {
-        console.warn("Failed to parse WS message:", err)
+      } else if (type === "claw_status") {
+        const { claw_id, status } = payload
+        if (status === "deleted") {
+          // Remove immediately — don't wait for next poll
+          setClaws((prev) => prev.filter((c) => c.id !== claw_id))
+        } else {
+          setClaws((prev) =>
+            prev.map((c) =>
+              c.id === claw_id
+                ? {
+                    ...c,
+                    status: mapApiStatus(status),
+                    isStreaming: status !== "connected" ? false : c.isStreaming,
+                    reason: status === "error" ? payload.reason : undefined,
+                    bootstrap_status: status === "connected" || status === "error" ? undefined : payload.bootstrap_status ?? c.bootstrap_status,
+                    githubIssueId: payload.github_issue_id ?? c.githubIssueId,
+                    githubIssueUrl: payload.github_issue_url ?? c.githubIssueUrl,
+                  }
+                : c
+            )
+          )
+          // If a new claw came online that we don't know about, refresh
+          setClaws((prev) => {
+            if (!prev.find((c) => c.id === claw_id)) {
+              refreshClaws()
+            }
+            return prev
+          })
+        }
       }
+    } catch (err) {
+      console.warn("Failed to parse WS message:", err)
     }
-  }, [clearTypewriter, finalizeTypewriter, nextClientMessageId, persistMessages, pushChunk, refreshClaws, splitTypewriter])
+  }, [clearTypewriter, finalizeTypewriter, messagesRef, nextClientMessageId, pushChunk, refreshClaws, splitTypewriter, updateMessages])
+
+  const { connected } = useWebSocket({
+    getUrl: getHubWsUrl,
+    enabled: wsEnabled,
+    onMessage: handleWsMessage,
+  })
 
   // Initialize
   useEffect(() => {
@@ -529,24 +421,18 @@ export function useHub(selectedClawId: string | null): HubState {
     refreshDependencies().then(() => {})
 
     // Poll claws frequently; dependency status is slower-moving and separately cached by the hub.
-    pollIntervalRef.current = setInterval(refreshClaws, 10_000)
-    dependencyPollIntervalRef.current = setInterval(refreshDependencies, 60_000)
+    pollIntervalRef.current = setInterval(refreshClaws, CLAW_POLL_INTERVAL_MS)
+    dependencyPollIntervalRef.current = setInterval(refreshDependencies, DEPENDENCY_POLL_INTERVAL_MS)
 
     // Wait for token then connect WS
-    shouldReconnectRef.current = true
-    resolveToken().then(() => connectWebSocket())
+    resolveToken().then(() => setWsEnabled(true))
 
     return () => {
-      shouldReconnectRef.current = false
+      setWsEnabled(false)
       if (pollIntervalRef.current) clearInterval(pollIntervalRef.current)
       if (dependencyPollIntervalRef.current) clearInterval(dependencyPollIntervalRef.current)
-      if (reconnectTimerRef.current) window.clearTimeout(reconnectTimerRef.current)
-      if (wsRef.current) {
-        wsRef.current.onclose = null
-        wsRef.current.onerror = null
-        wsRef.current.close()
-      }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []) // run once on mount
 
   const send = useCallback(async (clawId: string, content: string) => {
@@ -559,11 +445,7 @@ export function useHub(selectedClawId: string | null): HubState {
       content: content.trim(),
       timestamp: new Date(),
     }
-    setMessages((prev) => {
-      const next = { ...prev, [clawId]: [...(prev[clawId] || []), optimistic] }
-      persistMessages(next)
-      return next
-    })
+    updateMessages((prev) => ({ ...prev, [clawId]: [...(prev[clawId] || []), optimistic] }))
 
     setClaws((prev) =>
       prev.map((c) => (c.id === clawId ? { ...c, isStreaming: true } : c))
@@ -576,12 +458,10 @@ export function useHub(selectedClawId: string | null): HubState {
       // Replace the optimistic message with the real one from the DB
       // so it survives cache persistence (opt- IDs are filtered out)
       const realMsg = mapApiMessage(sent)
-      setMessages((prev) => {
+      updateMessages((prev) => {
         const msgs = prev[clawId] || []
         const replaced = msgs.map((m) => m.id === optimistic.id ? realMsg : m)
-        const next = { ...prev, [clawId]: replaced }
-        persistMessages(next)
-        return next
+        return { ...prev, [clawId]: replaced }
       })
       // WS events will handle the response (chunk/message)
     } catch (err) {
@@ -590,7 +470,7 @@ export function useHub(selectedClawId: string | null): HubState {
         prev.map((c) => (c.id === clawId ? { ...c, isStreaming: false } : c))
       )
     }
-  }, [nextClientMessageId, persistMessages, pushChunk])
+  }, [nextClientMessageId, pushChunk, updateMessages])
 
   const createClaw = useCallback(async (req: { name: string; template: string }) => {
     const apiClaw = await apiCreateClaw({
@@ -605,14 +485,8 @@ export function useHub(selectedClawId: string | null): HubState {
   const killClaw = useCallback(async (clawId: string) => {
     await apiKillClaw(clawId)
     setClaws((prev) => prev.filter((c) => c.id !== clawId))
-    setMessages((prev) => {
-      const next = { ...prev }
-      delete next[clawId]
-      persistMessages(next)
-      return next
-    })
-
-  }, [persistMessages])
+    removeClaw(clawId)
+  }, [removeClaw])
 
   const downtimeDependencies = dependencies.filter((dependency) => dependency.status === "downtime")
 

--- a/web/hooks/use-message-cache.test.ts
+++ b/web/hooks/use-message-cache.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest"
+import { isTransientMessage, mergeMessageTimeline } from "./use-message-cache"
+import { describeWsUrl } from "./use-websocket"
+import type { Message } from "@/lib/types"
+
+function msg(id: string, content: string, ts: number, role: Message["role"] = "claw"): Message {
+  return { id, role, content, timestamp: new Date(ts) }
+}
+
+describe("isTransientMessage", () => {
+  it("flags live segments, activity rows and thinking placeholders", () => {
+    expect(isTransientMessage(msg("live-segment-c1-1", "x", 0))).toBe(true)
+    expect(isTransientMessage(msg("activity-c1-1", "x", 0))).toBe(true)
+    expect(isTransientMessage(msg("thinking-1", "x", 0))).toBe(true)
+  })
+
+  it("does not flag durable or optimistic messages", () => {
+    expect(isTransientMessage(msg("a3f9", "x", 0))).toBe(false)
+    expect(isTransientMessage(msg("opt-c1-1", "x", 0))).toBe(false)
+  })
+})
+
+describe("mergeMessageTimeline", () => {
+  it("keeps cached durable messages missing from the API result (beyond fetch limit)", () => {
+    const cached = [msg("old-1", "ancient", 1000), msg("new-1", "recent", 3000)]
+    const fresh = [msg("new-1", "recent", 3000), msg("new-2", "newer", 4000)]
+    const merged = mergeMessageTimeline(cached, fresh)
+    expect(merged.map((m) => m.id)).toEqual(["old-1", "new-1", "new-2"])
+  })
+
+  it("drops transient messages from the cached side", () => {
+    const cached = [msg("live-segment-c1-1", "stream", 1000), msg("activity-c1-1", "tool", 2000, "activity")]
+    const fresh = [msg("real-1", "final", 3000)]
+    expect(mergeMessageTimeline(cached, fresh).map((m) => m.id)).toEqual(["real-1"])
+  })
+
+  it("re-appends in-flight optimistic messages the API has not confirmed", () => {
+    const cached = [msg("opt-c1-1", "hello", 5000, "user")]
+    const fresh = [msg("real-1", "earlier", 1000)]
+    const merged = mergeMessageTimeline(cached, fresh)
+    expect(merged.map((m) => m.id)).toEqual(["real-1", "opt-c1-1"])
+  })
+
+  it("drops optimistic messages once the API returns the confirmed copy", () => {
+    const cached = [msg("opt-c1-1", "hello", 5000, "user")]
+    const fresh = [msg("real-1", "hello", 5000, "user")]
+    expect(mergeMessageTimeline(cached, fresh).map((m) => m.id)).toEqual(["real-1"])
+  })
+
+  it("sorts the merged timeline by timestamp", () => {
+    const cached = [msg("cached-late", "z", 9000)]
+    const fresh = [msg("fresh-early", "a", 1000), msg("fresh-mid", "b", 5000)]
+    expect(mergeMessageTimeline(cached, fresh).map((m) => m.id)).toEqual([
+      "fresh-early",
+      "fresh-mid",
+      "cached-late",
+    ])
+  })
+})
+
+describe("describeWsUrl", () => {
+  it("redacts the token query parameter", () => {
+    expect(describeWsUrl("ws://hub.local/api/ws?token=secret123")).toBe(
+      "ws://hub.local/api/ws?token=%5Bredacted%5D"
+    )
+  })
+
+  it("redacts tokens even when the URL does not parse", () => {
+    expect(describeWsUrl("not a url token=secret&x=1")).toBe("not a url token=[redacted]&x=1")
+  })
+
+  it("leaves token-free URLs untouched", () => {
+    expect(describeWsUrl("wss://hub.local/api/ws")).toBe("wss://hub.local/api/ws")
+  })
+})

--- a/web/hooks/use-message-cache.ts
+++ b/web/hooks/use-message-cache.ts
@@ -1,0 +1,118 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState, type MutableRefObject } from "react"
+import type { Message } from "@/lib/types"
+import { MAX_CACHED_MESSAGES_PER_CLAW, STORAGE_KEY_MESSAGES } from "@/lib/constants"
+
+/**
+ * Transient messages are per-tab transcript state (live stream segments,
+ * activity rows, thinking placeholders); the API stores canonical messages.
+ */
+export function isTransientMessage(message: Message): boolean {
+  return message.id.startsWith("activity-") || message.id.startsWith("live-") || message.id.startsWith("thinking-")
+}
+
+/**
+ * Merges a fresh API timeline into the cached transcript for one claw:
+ * 1. Keep non-optimistic cached messages missing from the API result
+ *    (preserves history beyond the API fetch limit).
+ * 2. Re-append in-flight `opt-` messages that the API has not confirmed yet,
+ *    so send() can still swap them with real UUIDs.
+ */
+export function mergeMessageTimeline(existing: Message[], fresh: Message[]): Message[] {
+  const existingDurable = existing.filter((m) => !m.id.startsWith("opt-") && !isTransientMessage(m))
+  const freshIds = new Set(fresh.map((m) => m.id))
+  const cachedOnly = existingDurable.filter((m) => !freshIds.has(m.id))
+  const inflight = existing.filter(
+    (m) => m.id.startsWith("opt-") && !fresh.some((r) => r.content === m.content && r.role === m.role)
+  )
+  const merged = [...fresh, ...cachedOnly, ...inflight]
+  merged.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime())
+  return merged
+}
+
+export interface MessageCache {
+  messages: Record<string, Message[]>
+  /** Always-current snapshot for reads inside event handlers. */
+  messagesRef: MutableRefObject<Record<string, Message[]>>
+  /** Hydrates the state from localStorage (call once on mount). */
+  loadCachedMessages: () => void
+  /** setState + persist: every durable mutation goes through here. */
+  updateMessages: (updater: (prev: Record<string, Message[]>) => Record<string, Message[]>) => void
+  /** Merges a fresh API timeline for one claw (durable/transient merge). */
+  mergeTimeline: (clawId: string, fresh: Message[]) => void
+  /** Drops a claw's transcript (e.g. after kill). */
+  removeClaw: (clawId: string) => void
+}
+
+/**
+ * useMessageCache — owns the per-claw message map and its localStorage
+ * persistence. Only durable messages are persisted: optimistic (`opt-`),
+ * system and transient messages are filtered out, and each claw keeps at
+ * most MAX_CACHED_MESSAGES_PER_CLAW entries.
+ */
+export function useMessageCache(): MessageCache {
+  const [messages, setMessages] = useState<Record<string, Message[]>>({})
+  const messagesRef = useRef<Record<string, Message[]>>({})
+
+  useEffect(() => {
+    messagesRef.current = messages
+  }, [messages])
+
+  const persistMessages = useCallback((msgs: Record<string, Message[]>) => {
+    try {
+      const toSave: Record<string, unknown[]> = {}
+      for (const [clawId, clawMsgs] of Object.entries(msgs)) {
+        toSave[clawId] = clawMsgs
+          .filter((m) => !m.id.startsWith("opt-") && m.role !== "system" && !isTransientMessage(m))
+          .slice(-MAX_CACHED_MESSAGES_PER_CLAW)
+      }
+      localStorage.setItem(STORAGE_KEY_MESSAGES, JSON.stringify(toSave))
+    } catch {}
+  }, [])
+
+  const loadCachedMessages = useCallback(() => {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY_MESSAGES)
+      if (!raw) return
+      const parsed: Record<string, Array<{ id: string; role: string; content: string; timestamp: string }>> =
+        JSON.parse(raw)
+      const hydrated: Record<string, Message[]> = {}
+      for (const [clawId, msgs] of Object.entries(parsed)) {
+        hydrated[clawId] = msgs.map((m) => ({ ...m, role: m.role as Message["role"], timestamp: new Date(m.timestamp) }))
+      }
+      setMessages(hydrated)
+    } catch {}
+  }, [])
+
+  const updateMessages = useCallback(
+    (updater: (prev: Record<string, Message[]>) => Record<string, Message[]>) => {
+      setMessages((prev) => {
+        const next = updater(prev)
+        persistMessages(next)
+        return next
+      })
+    },
+    [persistMessages]
+  )
+
+  const mergeTimeline = useCallback(
+    (clawId: string, fresh: Message[]) => {
+      updateMessages((prev) => ({ ...prev, [clawId]: mergeMessageTimeline(prev[clawId] || [], fresh) }))
+    },
+    [updateMessages]
+  )
+
+  const removeClaw = useCallback(
+    (clawId: string) => {
+      updateMessages((prev) => {
+        const next = { ...prev }
+        delete next[clawId]
+        return next
+      })
+    },
+    [updateMessages]
+  )
+
+  return { messages, messagesRef, loadCachedMessages, updateMessages, mergeTimeline, removeClaw }
+}

--- a/web/hooks/use-websocket.ts
+++ b/web/hooks/use-websocket.ts
@@ -1,0 +1,159 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+import {
+  WS_BASE_RECONNECT_DELAY_MS,
+  WS_ERROR_LOG_THROTTLE_MS,
+  WS_MAX_BACKOFF_EXPONENT,
+  WS_MAX_RECONNECT_DELAY_MS,
+} from "@/lib/constants"
+
+/** Redacts credentials from a WebSocket URL so it is safe to log. */
+export function describeWsUrl(rawUrl: string): string {
+  try {
+    const url = new URL(rawUrl)
+    if (url.searchParams.has("token")) {
+      url.searchParams.set("token", "[redacted]")
+    }
+    return url.toString()
+  } catch {
+    return rawUrl.replace(/token=[^&]+/, "token=[redacted]")
+  }
+}
+
+export interface UseWebSocketOptions {
+  /**
+   * Builds the connection URL. Called on every (re)connect attempt so
+   * rotating credentials (e.g. a refreshed token) are picked up.
+   */
+  getUrl: () => string
+  /** The connection is only opened while `enabled` is true. */
+  enabled: boolean
+  /** Reconnect with exponential backoff when the socket closes. Default true. */
+  reconnect?: boolean
+  onOpen?: (ws: WebSocket) => void
+  onMessage?: (event: MessageEvent, ws: WebSocket) => void
+  onClose?: (event: CloseEvent) => void
+  /**
+   * Custom error handling. When omitted, errors are logged with the
+   * redacted URL, throttled to one warning per WS_ERROR_LOG_THROTTLE_MS.
+   */
+  onError?: (event: Event) => void
+}
+
+export interface UseWebSocketResult {
+  connected: boolean
+  /** Sends if the socket is open; returns false (and drops the data) otherwise. */
+  send: (data: string | ArrayBufferLike | Blob | ArrayBufferView) => boolean
+}
+
+/**
+ * useWebSocket — owns a single WebSocket connection: lifecycle, exponential
+ * backoff reconnection, and URL redaction in logs. Event handlers are read
+ * through a ref, so passing new callback identities does not reconnect.
+ */
+export function useWebSocket(options: UseWebSocketOptions): UseWebSocketResult {
+  const { getUrl, enabled, reconnect = true } = options
+  const [connected, setConnected] = useState(false)
+  const wsRef = useRef<WebSocket | null>(null)
+  const reconnectTimerRef = useRef<number | null>(null)
+  const reconnectAttemptRef = useRef(0)
+  const shouldReconnectRef = useRef(false)
+  const lastErrorLogRef = useRef(0)
+  const optionsRef = useRef(options)
+
+  useEffect(() => {
+    optionsRef.current = options
+  })
+
+  useEffect(() => {
+    if (!enabled) return
+    shouldReconnectRef.current = true
+
+    function connect() {
+      if (!shouldReconnectRef.current) return
+      if (wsRef.current) {
+        wsRef.current.onclose = null
+        wsRef.current.onerror = null
+        wsRef.current.close()
+      }
+      const wsUrl = optionsRef.current.getUrl()
+      const safeWsUrl = describeWsUrl(wsUrl)
+      let ws: WebSocket
+      try {
+        ws = new WebSocket(wsUrl)
+      } catch (err) {
+        console.error(`WS create failed for ${safeWsUrl}:`, err)
+        return
+      }
+      wsRef.current = ws
+
+      ws.onopen = () => {
+        reconnectAttemptRef.current = 0
+        setConnected(true)
+        optionsRef.current.onOpen?.(ws)
+      }
+
+      ws.onclose = (event) => {
+        if (wsRef.current !== ws) return
+        setConnected(false)
+        optionsRef.current.onClose?.(event)
+        if (!shouldReconnectRef.current || optionsRef.current.reconnect === false) return
+        const attempt = reconnectAttemptRef.current
+        reconnectAttemptRef.current += 1
+        const delayMs = Math.min(
+          WS_MAX_RECONNECT_DELAY_MS,
+          WS_BASE_RECONNECT_DELAY_MS * 2 ** Math.min(attempt, WS_MAX_BACKOFF_EXPONENT)
+        )
+        if (event.code !== 1000) {
+          console.warn(
+            `WS closed for ${safeWsUrl}: code=${event.code} reason=${event.reason || "none"}; reconnecting in ${Math.round(delayMs / 1000)}s`
+          )
+        }
+        if (reconnectTimerRef.current) window.clearTimeout(reconnectTimerRef.current)
+        reconnectTimerRef.current = window.setTimeout(connect, delayMs)
+      }
+
+      ws.onerror = (event) => {
+        if (optionsRef.current.onError) {
+          optionsRef.current.onError(event)
+          return
+        }
+        const nowMs = Date.now()
+        if (nowMs - lastErrorLogRef.current < WS_ERROR_LOG_THROTTLE_MS) return
+        lastErrorLogRef.current = nowMs
+        console.warn(`WS error for ${safeWsUrl}; check the Network tab for /api/ws status and close code`)
+      }
+
+      ws.onmessage = (event) => {
+        optionsRef.current.onMessage?.(event, ws)
+      }
+    }
+
+    connect()
+    return () => {
+      shouldReconnectRef.current = false
+      if (reconnectTimerRef.current) window.clearTimeout(reconnectTimerRef.current)
+      reconnectTimerRef.current = null
+      if (wsRef.current) {
+        wsRef.current.onclose = null
+        wsRef.current.onerror = null
+        wsRef.current.close()
+        wsRef.current = null
+      }
+      setConnected(false)
+    }
+    // getUrl identity change means "connect somewhere else" — reconnect.
+  }, [enabled, getUrl, reconnect])
+
+  const send = useCallback((data: string | ArrayBufferLike | Blob | ArrayBufferView): boolean => {
+    const ws = wsRef.current
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(data)
+      return true
+    }
+    return false
+  }, [])
+
+  return { connected, send }
+}

--- a/web/lib/constants.ts
+++ b/web/lib/constants.ts
@@ -1,0 +1,47 @@
+// Shared UI constants. Centralizes the magic values that were previously
+// inlined in hooks/components (localStorage keys, polling intervals, cache
+// limits, WebSocket backoff tuning).
+
+// ─── localStorage keys ───────────────────────────────────────────────────────
+
+/** Persisted manual ordering of the claw board (array of claw IDs). */
+export const STORAGE_KEY_CLAW_ORDER = "elasticclaw_claw_order"
+
+/** Persisted pinned flags per claw ID. */
+export const STORAGE_KEY_PINNED = "elasticclaw_pinned"
+
+/** Persisted per-claw message cache (durable messages only). */
+export const STORAGE_KEY_MESSAGES = "elasticclaw_messages"
+
+/** Last selected claw, restored on reload. */
+export const STORAGE_KEY_SELECTED_CLAW = "elasticclaw_selected_claw"
+
+// ─── Polling ─────────────────────────────────────────────────────────────────
+
+/** How often the claw list is re-fetched. */
+export const CLAW_POLL_INTERVAL_MS = 10_000
+
+/**
+ * How often dependency status is re-fetched. Slower-moving than claws and
+ * separately cached by the hub.
+ */
+export const DEPENDENCY_POLL_INTERVAL_MS = 60_000
+
+// ─── Message cache ───────────────────────────────────────────────────────────
+
+/** Maximum durable messages persisted to localStorage per claw. */
+export const MAX_CACHED_MESSAGES_PER_CLAW = 200
+
+// ─── WebSocket reconnect ─────────────────────────────────────────────────────
+
+/** First reconnect delay; doubles per attempt. */
+export const WS_BASE_RECONNECT_DELAY_MS = 1_000
+
+/** Ceiling for the exponential backoff delay. */
+export const WS_MAX_RECONNECT_DELAY_MS = 30_000
+
+/** Backoff exponent cap: delays stop growing after this many attempts. */
+export const WS_MAX_BACKOFF_EXPONENT = 5
+
+/** Minimum interval between logged WS error warnings. */
+export const WS_ERROR_LOG_THROTTLE_MS = 10_000

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,12 @@
+import { fileURLToPath } from "node:url"
+import { defineConfig } from "vitest/config"
+
+// Mirrors the "@/*" path alias from tsconfig.json so unit tests can import
+// modules the same way application code does.
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL(".", import.meta.url)),
+    },
+  },
+})


### PR DESCRIPTION
## Motivation

`web/lib/types.ts` used to hand-mirror Go types; the Phase 1 OpenAPI work (#451) already rewired the `Api*` wire types (`ApiClaw`, `ApiMessage`, `ApiClawStatus`, `CreateClawRequest`, `TaskRun*`) to derive from the generated `web/lib/gen/api.d.ts`, leaving only presentation types hand-written. What remained of spec item 3.2 was the hook debt: `web/hooks/use-hub.ts` was a 636-line hook mixing three concerns — WebSocket connection management (backoff, token redaction), localStorage message caching (persistence + the durable/transient merge), and hub state composition. Meanwhile `web/components/terminal.tsx` hand-rolled its own `new WebSocket(...)` wiring, duplicating connection logic. Extracting `useWebSocket` and `useMessageCache` lets the terminal reuse the connection logic and shrinks `useHub` to composition.

## Dependencies

This PR is STACKED on branch `feature/openapi-contract`. Depends on #451 — review and merge that first.

## What changed

- **`web/lib/constants.ts` (new):** localStorage keys (`elasticclaw_claw_order`, `elasticclaw_pinned`, `elasticclaw_messages`, `elasticclaw_selected_claw`), the 10s claw / 60s dependency polling intervals, the 200-message cache cap, and the WS backoff tuning values (1s base, 30s ceiling, exponent cap 5, 10s error-log throttle). `app/page.tsx` now uses the shared selected-claw key.
- **`web/hooks/use-websocket.ts` (new):** `useWebSocket` — connection lifecycle, exponential backoff reconnect, and `describeWsUrl` token redaction, lifted verbatim from `use-hub.ts`. Handlers are read through a ref so new callback identities do not reconnect; `getUrl` is called on every attempt so rotated tokens are picked up.
- **`web/components/terminal.tsx`:** the SSH terminal drops its hand-rolled WebSocket code and uses `useWebSocket` (with `reconnect: false`, matching its previous no-reconnect behavior — an SSH session cannot be resumed transparently).
- **`web/hooks/use-message-cache.ts` (new):** `useMessageCache` — per-claw message map, localStorage persistence (durable messages only, capped per claw), and the durable/transient/optimistic timeline merge extracted as the pure `mergeMessageTimeline` function.
- **`web/hooks/use-hub.ts`:** 636 → 512 LOC; now composes `useWebSocket` + `useMessageCache` + `useTypewriter`. The WS event handling (chunk/agent_activity/message/claw_status) and claw-list state stay put. Same WS events, same cache format and keys, same reconnect policy.
- **`web/hooks/use-message-cache.test.ts` + `web/vitest.config.ts` (new):** unit tests for `mergeMessageTimeline`, `isTransientMessage` and `describeWsUrl`; the vitest config mirrors the tsconfig `@/*` alias.
- **Note on 3.2.1:** no further `types.ts` changes were needed — the wire types already derive from the generated contract on the base branch, and the remaining hand-written types (`Claw`, `Message`, `DependencyStatus`, ...) are presentation types with no counterpart schema in `api/openapi.yaml`.

## Testing

- `cd web && npm install && npm test` — 2 files, 22 tests passed (existing `mappers.test.ts` + new `use-message-cache.test.ts`).
- `cd web && npm run build` — compiled successfully, TypeScript check passed, all 34 pages generated.
- `cd web && npm run lint` — repo-wide problems went from 32 (baseline on the base branch) to 27; all new/changed files are lint-clean except one pre-existing `react-hooks/set-state-in-effect` error in `use-hub.ts` that exists identically in the original code.
- No Go changes, so `go build`/`make test` were not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
