### PR TITLE
refactor(hub): sentinel domain errors and typed WS payload decoding

### DIFF
--- a/pkg/hub/checkpoints/checkpoints.go
+++ b/pkg/hub/checkpoints/checkpoints.go
@@ -207,7 +207,7 @@ func (s *Service) HandleClawCheckpoints(w http.ResponseWriter, r *http.Request, 
 			return
 		}
 		if err := s.restoreClawFromCheckpoint(r.Context(), tenantID, clawID, parts[2]); err != nil {
-			httpserver.WriteErr(w, http.StatusConflict, "conflict", err.Error())
+			httpserver.WriteDomainErr(w, err)
 			return
 		}
 		w.WriteHeader(http.StatusAccepted)
@@ -264,15 +264,15 @@ func (s *Service) restoreClawFromCheckpoint(ctx context.Context, tenantID, clawI
 	var status, manifestPath string
 	if err := s.deps.DB.QueryRow(`SELECT status, manifest_path FROM claw_checkpoints WHERE id=? AND tenant_id=? AND claw_id=?`, checkpointID, tenantID, clawID).Scan(&status, &manifestPath); err != nil {
 		if err == sql.ErrNoRows {
-			return fmt.Errorf("checkpoint not found")
+			return types.ErrCheckpointNotFound
 		}
 		return err
 	}
 	if status != "ready" {
-		return fmt.Errorf("checkpoint is not ready")
+		return types.ErrCheckpointNotReady
 	}
 	if manifestPath == "" {
-		return fmt.Errorf("checkpoint has no manifest")
+		return fmt.Errorf("checkpoint has no manifest: %w", types.ErrCheckpointNotReady)
 	}
 
 	// Preserve the current state if the bridge is still reachable.

--- a/pkg/hub/claw_handlers.go
+++ b/pkg/hub/claw_handlers.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/elasticclaw/elasticclaw/pkg/hub/store"
+	"github.com/elasticclaw/elasticclaw/pkg/hub/httpserver"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 	"github.com/google/uuid"
 	"nhooyr.io/websocket"
@@ -502,7 +503,7 @@ func (s *Server) handleClawDetail(w http.ResponseWriter, r *http.Request) {
 
 	c, err := s.st().Claws().Get(r.Context(), clawID, tenantID)
 	if err == sql.ErrNoRows {
-		writeErr(w, http.StatusNotFound, "not_found", "not found")
+		httpserver.WriteDomainErr(w, types.ErrClawNotFound)
 		return
 	}
 	if err != nil {

--- a/pkg/hub/claw_handlers.go
+++ b/pkg/hub/claw_handlers.go
@@ -11,8 +11,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/elasticclaw/elasticclaw/pkg/hub/store"
 	"github.com/elasticclaw/elasticclaw/pkg/hub/httpserver"
+	"github.com/elasticclaw/elasticclaw/pkg/hub/store"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 	"github.com/google/uuid"
 	"nhooyr.io/websocket"

--- a/pkg/hub/claws/activity.go
+++ b/pkg/hub/claws/activity.go
@@ -29,11 +29,11 @@ func activityContent(activity map[string]interface{}) string {
 	return "Activity"
 }
 
-func NormalizeAgentActivityPayload(payload interface{}) (map[string]interface{}, []byte, bool) {
-	raw, err := json.Marshal(payload)
-	if err != nil {
-		return nil, nil, false
-	}
+// NormalizeAgentActivityPayload unmarshals a raw "agent_activity" WS payload
+// into a generic activity map. It returns the wire bytes untouched (they are
+// persisted verbatim in the message format column). ok is false when the
+// payload is absent, null, or not a JSON object.
+func NormalizeAgentActivityPayload(raw json.RawMessage) (map[string]interface{}, []byte, bool) {
 	var activity map[string]interface{}
 	if err := json.Unmarshal(raw, &activity); err != nil || activity == nil {
 		return nil, nil, false

--- a/pkg/hub/claws/deps.go
+++ b/pkg/hub/claws/deps.go
@@ -43,6 +43,13 @@ type Deps struct {
 	// serverMetrics.wsMessage, which is nil-receiver-safe).
 	WSMessageMetric func(direction, peer string)
 
+	// HTTP response writers injected by the composition root
+	// (httpserver.JSONOK / httpserver.WriteDomainErr) so claws never
+	// imports httpserver — the phase-2 dependency rule says httpserver
+	// knows the services, never the reverse.
+	JSONOK         func(w http.ResponseWriter, v interface{})
+	WriteDomainErr func(w http.ResponseWriter, err error)
+
 	// Auth helpers still owned by pkg/hub.
 	TenantByClawToken func(token string) (string, error)
 	TenantByToken     func(token string) (string, error)

--- a/pkg/hub/claws/files.go
+++ b/pkg/hub/claws/files.go
@@ -155,7 +155,7 @@ func (s *Service) HandleFileUpload(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	jsonOK(w, map[string]interface{}{"files": out})
+	s.jsonOK(w, map[string]interface{}{"files": out})
 }
 
 // isActiveContentType returns true if the content type or extension could

--- a/pkg/hub/claws/responses.go
+++ b/pkg/hub/claws/responses.go
@@ -1,8 +1,30 @@
 package claws
 
-// HTTP response helpers moved to pkg/hub/httpserver during the phase-2
-// split; the alias keeps the mechanically-moved handler bodies unchanged.
+// HTTP response helpers live in pkg/hub/httpserver; the claws service must
+// not import httpserver (phase-2 dependency rule: httpserver knows the
+// services, never the reverse), so the composition root injects the JSON-OK
+// and domain-error writers through Deps and the methods below keep the
+// mechanically-moved handler bodies unchanged.
 
-import "github.com/elasticclaw/elasticclaw/pkg/hub/httpserver"
+import "net/http"
 
-var jsonOK = httpserver.JSONOK
+// jsonOK writes v as a 200 JSON response via the injected writer. The
+// plain-text fallback only triggers in hand-built test services that skip
+// the hub wiring.
+func (s *Service) jsonOK(w http.ResponseWriter, v interface{}) {
+	if s.deps.JSONOK != nil {
+		s.deps.JSONOK(w, v)
+		return
+	}
+	http.Error(w, "response writer not wired", http.StatusInternalServerError)
+}
+
+// writeDomainErr maps err to the unified JSON error envelope via the
+// injected writer (httpserver.WriteDomainErr in production wiring).
+func (s *Service) writeDomainErr(w http.ResponseWriter, err error) {
+	if s.deps.WriteDomainErr != nil {
+		s.deps.WriteDomainErr(w, err)
+		return
+	}
+	http.Error(w, err.Error(), http.StatusInternalServerError)
+}

--- a/pkg/hub/claws/terminal.go
+++ b/pkg/hub/claws/terminal.go
@@ -14,6 +14,9 @@ import (
 
 	gossh "golang.org/x/crypto/ssh"
 	"nhooyr.io/websocket"
+
+	"github.com/elasticclaw/elasticclaw/pkg/hub/httpserver"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
 
 // HandleTerminal upgrades the request to a WebSocket and bridges it to an
@@ -26,7 +29,7 @@ func (s *Service) HandleTerminal(w http.ResponseWriter, r *http.Request) {
 	}
 	tenantID, err := s.tenantByToken(token)
 	if err != nil {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		httpserver.WriteDomainErr(w, types.ErrUnauthorized)
 		return
 	}
 
@@ -39,7 +42,7 @@ func (s *Service) HandleTerminal(w http.ResponseWriter, r *http.Request) {
 	// Look up SSH details, verify tenant owns the claw
 	sshHost, sshPort, sshUser, err := s.st.Claws().SSHEndpoint(r.Context(), clawID, tenantID)
 	if err == sql.ErrNoRows {
-		http.Error(w, "not found", http.StatusNotFound)
+		httpserver.WriteDomainErr(w, types.ErrClawNotFound)
 		return
 	}
 	if err != nil {

--- a/pkg/hub/claws/terminal.go
+++ b/pkg/hub/claws/terminal.go
@@ -15,7 +15,6 @@ import (
 	gossh "golang.org/x/crypto/ssh"
 	"nhooyr.io/websocket"
 
-	"github.com/elasticclaw/elasticclaw/pkg/hub/httpserver"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
 
@@ -29,7 +28,7 @@ func (s *Service) HandleTerminal(w http.ResponseWriter, r *http.Request) {
 	}
 	tenantID, err := s.tenantByToken(token)
 	if err != nil {
-		httpserver.WriteDomainErr(w, types.ErrUnauthorized)
+		s.writeDomainErr(w, types.ErrUnauthorized)
 		return
 	}
 
@@ -42,7 +41,7 @@ func (s *Service) HandleTerminal(w http.ResponseWriter, r *http.Request) {
 	// Look up SSH details, verify tenant owns the claw
 	sshHost, sshPort, sshUser, err := s.st.Claws().SSHEndpoint(r.Context(), clawID, tenantID)
 	if err == sql.ErrNoRows {
-		httpserver.WriteDomainErr(w, types.ErrClawNotFound)
+		s.writeDomainErr(w, types.ErrClawNotFound)
 		return
 	}
 	if err != nil {

--- a/pkg/hub/claws/ws.go
+++ b/pkg/hub/claws/ws.go
@@ -6,10 +6,17 @@ package claws
 // field names, registry/waiter access through the injected hooks, and the
 // pipeline-trigger block behind Deps.EvaluatePipelineMessageTriggers (it
 // builds workflows-package types that claws must not import).
+//
+// Phase-2 item 2.5 restructured the read loop: messages arrive as a
+// types.WSEnvelope ({type, payload: json.RawMessage} — the wire format is
+// unchanged) and are dispatched through a per-connection decoder registry
+// that unmarshals each payload straight into its concrete type. Malformed
+// payloads are logged protocol errors, never panics.
 
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 	"time"
@@ -33,15 +40,14 @@ func (s *Service) HandleClawWS(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	// First message must be registration
-	var reg types.WSMessage
+	var reg types.WSEnvelope
 	if err := wsjson.Read(ctx, conn, &reg); err != nil || reg.Type != "register" {
 		conn.Close(websocket.StatusPolicyViolation, "expected register")
 		return
 	}
 
-	payload, _ := json.Marshal(reg.Payload)
 	var rp types.RegisterPayload
-	if err := json.Unmarshal(payload, &rp); err != nil {
+	if err := json.Unmarshal(reg.Payload, &rp); err != nil {
 		conn.Close(websocket.StatusPolicyViolation, "invalid register payload")
 		return
 	}
@@ -98,8 +104,8 @@ func (s *Service) HandleClawWS(w http.ResponseWriter, r *http.Request) {
 			_ = wsjson.Write(ctx, conn, types.WSMessage{Type: "registered", Payload: map[string]string{"claw_id": clawID, "channel": "status"}})
 			// Simple read loop for status channel — just keepalive
 			for {
-				var msg types.WSMessage
-				if err := wsjson.Read(ctx, conn, &msg); err != nil {
+				var env types.WSEnvelope
+				if err := wsjson.Read(ctx, conn, &env); err != nil {
 					if existing2, ok2 := s.reg.Get(clawID); ok2 {
 						existing2.Mu.Lock()
 						// Only clear the slot if it still holds this
@@ -113,7 +119,7 @@ func (s *Service) HandleClawWS(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 				s.metrics.wsMessage("in", "claw")
-				if msg.Type == "status_pong" {
+				if env.Type == "status_pong" {
 					if existing2, ok2 := s.reg.Get(clawID); ok2 {
 						existing2.Mu.Lock()
 						existing2.LastStatusAt = time.Now()
@@ -245,6 +251,19 @@ func (s *Service) HandleClawWS(w http.ResponseWriter, r *http.Request) {
 	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()
 
+	sess := &clawSession{
+		s:        s,
+		r:        r,
+		ctx:      ctx,
+		conn:     conn,
+		cc:       cc,
+		clawID:   clawID,
+		tenantID: tenantID,
+		name:     rp.Name,
+		submit:   submit,
+	}
+	decoders := sess.decoders()
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -252,409 +271,531 @@ func (s *Service) HandleClawWS(w http.ResponseWriter, r *http.Request) {
 		case <-ticker.C:
 			_ = s.st.Claws().TouchLastSeen(ctx, clawID, now())
 		default:
-			var msg types.WSMessage
+			var env types.WSEnvelope
 			conn.SetReadLimit(32 << 20) // 32MB (file uploads ride this channel)
-			if err := wsjson.Read(ctx, conn, &msg); err != nil {
+			if err := wsjson.Read(ctx, conn, &env); err != nil {
 				return
 			}
 			s.metrics.wsMessage("in", "claw")
-			if msg.Type == "heartbeat" {
-				payload, _ := json.Marshal(msg.Payload)
-				var hb struct {
-					GatewayHealthy bool  `json:"gateway_healthy"`
-					GatewayReady   *bool `json:"gateway_ready,omitempty"`
-					ContextUsage   int   `json:"context_usage"`
-				}
-				if err := json.Unmarshal(payload, &hb); err == nil {
-					var wakeConn *Conn
-					var shouldWake bool
-					var shouldWarnContext bool
-					var prevUsage int
-					if cc, ok := s.reg.Get(clawID); ok {
-						cc.Mu.Lock()
-						// Log only on status changes, not every heartbeat
-						prevUsage = cc.ContextUsage
-						cc.ContextUsage = hb.ContextUsage
-						// Promote from 'starting' to 'connected' once gateway is ready.
-						// nil means field absent (old bridge) — treat as ready.
-						if gatewayReadyBool(hb.GatewayReady) {
-							rowsUpdated, _ := s.st.Claws().PromoteStartingToConnected(ctx, clawID)
-							cc.GatewayReady = true
-							if rowsUpdated > 0 {
-								s.broadcastToUsers(tenantID, types.WSMessage{
-									Type:    "claw_status",
-									Payload: map[string]string{"claw_id": clawID, "status": "connected"},
-								})
-								logfCtx(r.Context(), "[bridge] ✓ ready: %s (%s)", rp.Name, clawID[:8])
-								shouldWake = true
-								wakeConn = cc
-								submit(func() { s.requestBootstrapCheckpoint(clawID) })
-							}
-						}
-						if !hb.GatewayHealthy {
-							cc.GatewayUnhealthyCount++
-							if cc.GatewayUnhealthyCount == 1 {
-								logfCtx(r.Context(), "[heartbeat] %s (%s): gateway unhealthy", rp.Name, clawID[:8])
-							} else if cc.GatewayUnhealthyCount%4 == 0 {
-								logfCtx(r.Context(), "[heartbeat] %s (%s): gateway unhealthy for %d consecutive checks", rp.Name, clawID[:8], cc.GatewayUnhealthyCount)
-							}
-							if cc.GatewayUnhealthyCount == 4 && !cc.StreamingStartedAt.IsZero() {
-								submit(func() {
-									s.injectHubMessageByID(clawID, "[hub] The gateway has been unresponsive for about a minute. If you're stuck in a long operation, consider sending [DONE] and starting fresh.")
-								})
-							}
-						}
-						// Log context usage on every heartbeat when it crosses the 80% threshold,
-						// regardless of gateway health — don't silence diagnostics during outages.
-						if hb.ContextUsage != prevUsage && (hb.ContextUsage >= 80 || prevUsage >= 80) {
-							logfCtx(r.Context(), "[heartbeat] %s (%s): context_usage=%d%%", rp.Name, clawID[:8], hb.ContextUsage)
-						}
-						if hb.GatewayHealthy && cc.GatewayUnhealthyCount > 0 {
-							logfCtx(r.Context(), "[heartbeat] %s (%s): gateway recovered after %d unhealthy checks", rp.Name, clawID[:8], cc.GatewayUnhealthyCount)
-							cc.GatewayUnhealthyCount = 0
-						}
-						// Inject context warning once per streaming turn when usage is >=95%
-						if !cc.StreamingStartedAt.IsZero() &&
-							hb.ContextUsage >= 95 &&
-							!cc.ContextWarningSent {
-							cc.ContextWarningSent = true
-							shouldWarnContext = true
-						}
-						cc.Mu.Unlock()
-					}
-					s.heartbeatWorkflowVolumeLeases(clawID)
-					if shouldWarnContext {
-						warnCC := s.reg.Lookup(clawID)
-						if warnCC != nil {
-							submit(func() {
-								s.injectHubMessage(ctx, warnCC, "[hub] Context window is nearly full. Summarize your progress briefly and send [DONE] with any PR URL, or ask the user what to do next.")
-							})
-						}
-					}
-					if shouldWake {
-						s.startWorkflowAfterVolumes(ctx, wakeConn, clawID)
-					}
-					// Check for streaming turn timeout (12 minutes)
-					cc, ok := s.reg.Get(clawID)
-					if ok {
-						cc.Mu.Lock()
-						if !cc.StreamingStartedAt.IsZero() &&
-							!cc.StreamingTimeoutSent &&
-							time.Since(cc.StreamingStartedAt) > 12*time.Minute {
-							cc.StreamingTimeoutSent = true
-							cc.Mu.Unlock()
-							submit(func() {
-								s.injectHubMessage(ctx, cc, "[hub] Your current response has been running for over 12 minutes. Please wrap up and send your response.")
-							})
-						} else {
-							cc.Mu.Unlock()
-						}
-					}
-				}
-			} else if msg.Type == "agent_activity" {
-				if activity, payload, ok := NormalizeAgentActivityPayload(msg.Payload); ok {
-					if err := s.flushStreamingSegment(clawID, tenantID, cc); err != nil {
-						logfCtx(r.Context(), "[agent_activity] flush streaming segment for %s: %v", clawID[:8], err)
-					}
-					if IsBusyAgentActivity(activity) {
-						cc.Mu.Lock()
-						if cc.StreamingStartedAt.IsZero() {
-							cc.StreamingStartedAt = time.Now()
-							cc.StreamingTimeoutSent = false
-							cc.ContextWarningSent = false
-						}
-						cc.Mu.Unlock()
-					}
-					createdAt := now()
-					activity["claw_id"] = clawID
-					activity["created_at"] = createdAt.Format(time.RFC3339Nano)
-					content := activityContent(activity)
-					if content != "" && !isUnhelpfulActivityContent(activity, content) {
-						format := "activity:" + string(payload)
-						_ = s.st.Messages().Insert(ctx, types.HubMessage{
-							ID: uuid.New().String(), ClawID: clawID, TenantID: tenantID,
-							Role: "activity", Content: content, Format: format, CreatedAt: createdAt,
-						})
-					}
-					s.broadcastToUsers(tenantID, types.WSMessage{
-						Type:    "agent_activity",
-						Payload: activity,
-					})
-					s.handleInitialPlanActivity(clawID, tenantID, activity)
-				}
-			} else if msg.Type == "chunk" {
-				// Streaming chunk — forward to users immediately AND buffer server-side
-				payload, _ := json.Marshal(msg.Payload)
-				var chunk struct {
-					Content string `json:"content"`
-				}
-				if err := json.Unmarshal(payload, &chunk); err == nil && chunk.Content != "" {
-					s.broadcastToUsers(tenantID, types.WSMessage{
-						Type:    "chunk",
-						Payload: map[string]string{"claw_id": clawID, "content": chunk.Content},
-					})
-					// Buffer chunk and upsert partial message to DB so refreshes don't lose it
-					cc, ok := s.reg.Get(clawID)
-					if ok {
-						cc.Mu.Lock()
-						if cc.StreamingMsgID == "" {
-							cc.StreamingMsgID = uuid.New().String()
-							cc.StreamingTimeoutSent = false
-							cc.ContextWarningSent = false
-						}
-						if cc.StreamingStartedAt.IsZero() {
-							cc.StreamingStartedAt = time.Now()
-						}
-						cc.StreamingBuf.WriteString(chunk.Content)
-						msgID := cc.StreamingMsgID
-						// Periodic partial commit: persist the buffer on the
-						// first chunk and then every streamingFlushBytes /
-						// streamingFlushInterval, so a mid-stream disconnect
-						// or hub crash keeps everything up to the last window
-						// without one DB write per chunk.
-						var bufContent string
-						flush := cc.StreamingFlushedLen == 0 ||
-							cc.StreamingBuf.Len()-cc.StreamingFlushedLen >= streamingFlushBytes ||
-							time.Since(cc.StreamingFlushedAt) >= streamingFlushInterval
-						if flush {
-							bufContent = cc.StreamingBuf.String()
-							cc.StreamingFlushedLen = cc.StreamingBuf.Len()
-							cc.StreamingFlushedAt = time.Now()
-						}
-						cc.Mu.Unlock()
-						if flush {
-							// Upsert — insert on first commit, update content after
-							_ = s.st.Messages().Upsert(ctx, types.HubMessage{
-								ID: msgID, ClawID: clawID, TenantID: tenantID, Role: "claw",
-								Content: bufContent, CreatedAt: now(),
-							})
-						}
-					}
-				}
-			} else if msg.Type == "message" {
-				// Complete message — finalize the buffered stream or store fresh
-				payload, _ := json.Marshal(msg.Payload)
-				var hm types.HubMessage
-				if err := json.Unmarshal(payload, &hm); err != nil {
-					continue
-				}
-				hm.ClawID = clawID
-				hm.TenantID = tenantID
-				hm.Role = "claw"
-				hm.CreatedAt = now()
-				// Always clean up streaming state first, even for empty messages.
-				// Use the outer cc (this goroutine's connection), not a fresh lookup.
-				// If the claw reconnected, a new handleClawWS goroutine handles the new cc.
-				cc.Mu.Lock()
-				persistContent := hm.Content
-				skipPersist := false
-				if cc.StreamingMsgID != "" {
-					hm.ID = cc.StreamingMsgID
-					if cc.StreamingBuf.Len() > 0 {
-						persistContent = cc.StreamingBuf.String()
-					}
-				} else {
-					hm.ID = uuid.New().String()
-					skipPersist = cc.StreamingSplit
-				}
-				cc.FinishTurnLocked()
-				cc.Mu.Unlock()
-				// Drop empty messages — never store or broadcast
-				if strings.TrimSpace(hm.Content) == "" {
-					// Clear typing indicator first — always clear even if no queued messages
-					s.broadcastToUsers(tenantID, types.WSMessage{
-						Type: "agent_typing",
-						Payload: map[string]string{
-							"claw_id": clawID,
-							"status":  "idle",
-						},
-					})
-					// Drain queue using this goroutine's cc (the outer cc from line 1449).
-					// If the claw reconnected, a new handleClawWS goroutine handles the new cc.
-					s.sendNextQueuedMessage(cc)
-					s.drainPendingCheckpoint(clawID)
-					continue
-				}
-				if !skipPersist && strings.TrimSpace(persistContent) != "" {
-					_ = s.st.Messages().Upsert(ctx, types.HubMessage{
-						ID: hm.ID, ClawID: hm.ClawID, TenantID: hm.TenantID, Role: hm.Role,
-						Content: persistContent, CreatedAt: hm.CreatedAt,
-					})
-					s.broadcastToUsers(tenantID, types.WSMessage{Type: "message", Payload: hm})
-				}
-				s.handleInitialPlanResponse(clawID, tenantID, hm.Content)
-				// Evaluate pipeline triggers. If a pipeline explicitly owns a
-				// [DONE] trigger, let it handle that signal instead of the
-				// legacy factory PR-URL completion path below. The block lives
-				// behind a hub hook because it builds workflows-package
-				// pipeline contexts.
-				pipelineHandledDone, pipelineJob := s.deps.EvaluatePipelineMessageTriggers(clawID, hm.Content)
-				if pipelineJob != nil && !submit(pipelineJob) {
-					return
-				}
-				// Clear typing indicator now that response is complete
-				s.broadcastToUsers(tenantID, types.WSMessage{
-					Type: "agent_typing",
-					Payload: map[string]string{
-						"claw_id": clawID,
-						"status":  "idle",
-					},
-				})
-				// Check for [DONE] signal from a factory-created claw
-				if strings.Contains(hm.Content, "[DONE]") {
-					//nolint:contextcheck // the done-checkpoint outlives this request; it derives from the hub root context on purpose
-					if !submit(func() {
-						if _, err := s.requestCheckpoint(s.baseCtx(), clawID, "done", "hub", false, s.deps.CheckpointRequestTimeout); err != nil {
-							logfCtx(r.Context(), "[checkpoint] done request for %s failed: %v", shortID(clawID), err)
-						}
-					}) {
-						return
-					}
-					if !pipelineHandledDone {
-						if !submit(func() { s.handleClawDoneSignal(clawID, hm.Content) }) {
-							return
-						}
-					}
-				}
-				// Check for [TERMINATE] signal - allows claw to manage its own lifecycle
-				if strings.Contains(hm.Content, "[TERMINATE]") {
-					if !submit(func() { s.handleClawTerminateSignal(clawID, hm.Content) }) {
-						return
-					}
-				}
-				// Detect and store any PR URLs mentioned by the agent
-				if !submit(func() { s.scanMessageForPRs(clawID, hm.Content) }) {
-					return
-				}
-				// Detect tool error loops and inject a corrective message
-				if DetectToolLoop(hm.Content) {
-					loopCC := s.reg.Lookup(clawID)
-					if loopCC != nil {
-						if !submit(func() {
-							s.injectHubMessage(ctx, loopCC, "[hub] You've hit the same tool error 3+ times in a row. Stop retrying. Take a completely different approach or ask for help.")
-						}) {
-							return
-						}
-					}
-				}
-				// Check for queued messages and send the next one.
-				// Use this goroutine's cc (the outer cc from line 1449).
-				// If the claw reconnected, a new handleClawWS goroutine handles the new cc.
-				s.sendNextQueuedMessage(cc)
-				s.drainPendingCheckpoint(clawID)
-			} else if msg.Type == "file_ack" {
-				raw, _ := json.Marshal(msg.Payload)
-				var ack types.FileAck
-				if err := json.Unmarshal(raw, &ack); err == nil && ack.RequestID != "" {
-					s.fileAckMu.Lock()
-					ch := s.fileAckWaiters()[ack.RequestID]
-					delete(s.fileAckWaiters(), ack.RequestID)
-					s.fileAckMu.Unlock()
-					if ch != nil {
-						select {
-						case ch <- ack:
-						default:
-						}
-					}
-				}
-			} else if msg.Type == "file_read_resp" {
-				raw, _ := json.Marshal(msg.Payload)
-				var resp types.FileReadResp
-				if err := json.Unmarshal(raw, &resp); err == nil && resp.RequestID != "" {
-					s.fileAckMu.Lock()
-					ch := s.fileReadWaiters()[resp.RequestID]
-					delete(s.fileReadWaiters(), resp.RequestID)
-					s.fileAckMu.Unlock()
-					if ch != nil {
-						select {
-						case ch <- resp:
-						default:
-						}
-					}
-				}
-			} else if msg.Type == "volume_attach_ack" {
-				raw, _ := json.Marshal(msg.Payload)
-				var ack types.VolumeAttachAck
-				if err := json.Unmarshal(raw, &ack); err == nil && ack.RequestID != "" {
-					s.fileAckMu.Lock()
-					ch := s.volumeAttachWaiters()[ack.RequestID]
-					delete(s.volumeAttachWaiters(), ack.RequestID)
-					s.fileAckMu.Unlock()
-					if ch != nil {
-						select {
-						case ch <- ack:
-						default:
-						}
-					}
-				}
-			} else if msg.Type == "volume_sync_ack" {
-				raw, _ := json.Marshal(msg.Payload)
-				var ack types.VolumeSyncAck
-				if err := json.Unmarshal(raw, &ack); err == nil && ack.RequestID != "" {
-					s.fileAckMu.Lock()
-					ch := s.volumeSyncWaiters()[ack.RequestID]
-					delete(s.volumeSyncWaiters(), ack.RequestID)
-					s.fileAckMu.Unlock()
-					if ch != nil {
-						select {
-						case ch <- ack:
-						default:
-						}
-					}
-				}
-			} else if msg.Type == "http_proxy_req" {
-				// Proxy an HTTP request from the bridge to the hub's internal API.
-				// This allows tools in the sandbox to reach hub APIs without a public URL.
-				proxyFn := func(rawPayload json.RawMessage, conn *websocket.Conn) func() {
-					return func() {
-						var req struct {
-							ReqID  string            `json:"req_id"`
-							Method string            `json:"method"`
-							Path   string            `json:"path"`
-							Query  string            `json:"query"`
-							Body   string            `json:"body"`
-							Header map[string]string `json:"header"`
-						}
-						if err := json.Unmarshal(rawPayload, &req); err != nil {
-							logfCtx(ctx, "[hub-proxy] bad req payload: %v", err)
-							return
-						}
-						logfCtx(ctx, "[hub-proxy] req req_id=%s %s %s?%s", req.ReqID, req.Method, req.Path, req.Query)
-						// Build an internal HTTP request
-						urls := req.Path
-						if req.Query != "" {
-							urls += "?" + req.Query
-						}
-						httpReq, err := http.NewRequestWithContext(ctx, req.Method, "http://localhost"+urls, strings.NewReader(req.Body))
-						if err != nil {
-							logfCtx(ctx, "[hub-proxy] build request failed req_id=%s err=%v", req.ReqID, err)
-							s.sendHTTPProxyRes(ctx, conn, req.ReqID, 400, "bad request")
-							return
-						}
-						for k, v := range req.Header {
-							httpReq.Header.Set(k, v)
-						}
-						// Inject claw_token auth so withAuth middleware passes
-						s.cfgMu.RLock()
-						clawToken := s.hubCfg().ClawToken
-						s.cfgMu.RUnlock()
-						httpReq.Header.Set("X-Claw-Token", clawToken)
-						// Execute against internal mux
-						w := &proxyResponseWriter{header: make(http.Header)}
-						s.mux().ServeHTTP(w, httpReq)
-						if w.status == 0 {
-							w.status = 200
-						}
-						logfCtx(ctx, "[hub-proxy] res req_id=%s status=%d body_len=%d", req.ReqID, w.status, len(w.body))
-						s.sendHTTPProxyRes(ctx, conn, req.ReqID, w.status, string(w.body))
-					}
-				}
-				if !submit(proxyFn(mustJSONRaw(msg.Payload), conn)) {
-					return
-				}
+			decode, ok := decoders[env.Type]
+			if !ok {
+				continue // unknown message types are ignored, as before
+			}
+			handle, err := decode(env.Payload)
+			if err != nil {
+				// Malformed payload for a known type: a protocol error to
+				// log and skip, never a panic.
+				logfCtx(r.Context(), "[claw ws] protocol error: bad %q payload from %s (%s): %v", env.Type, rp.Name, shortID(clawID), err)
+				continue
+			}
+			if !handle() {
+				return
 			}
 		}
 	}
+}
+
+// ─── Typed payload decoding (phase-2 item 2.5) ────────────────────────────────
+
+// clawSession bundles the per-connection state one claw bridge WS read loop
+// hands to its message handlers.
+type clawSession struct {
+	s        *Service
+	r        *http.Request
+	ctx      context.Context
+	conn     *websocket.Conn
+	cc       *Conn
+	clawID   string
+	tenantID string
+	name     string
+	// submit runs fn on the hub's bounded worker pool; false means the
+	// connection was closed on overflow and the read loop must stop.
+	submit func(func()) bool
+}
+
+// wsHandlerFunc is a decoded claw WS message ready to be handled. It returns
+// false when the read loop must stop serving the connection (worker-pool
+// overflow closed it).
+type wsHandlerFunc func() bool
+
+// wsPayloadDecoder decodes the raw payload of one message type straight into
+// its concrete type and returns the handler to run. A non-nil error is a
+// protocol error: the read loop logs it and skips the message.
+type wsPayloadDecoder func(json.RawMessage) (wsHandlerFunc, error)
+
+// decoders is the message-type → decoder registry for the claw bridge WS.
+// The {type, payload} wire envelope is unchanged; each decoder unmarshals
+// json.RawMessage into the concrete payload type for that message type.
+func (sess *clawSession) decoders() map[string]wsPayloadDecoder {
+	return map[string]wsPayloadDecoder{
+		"heartbeat": func(raw json.RawMessage) (wsHandlerFunc, error) {
+			var hb types.HeartbeatPayload
+			if err := json.Unmarshal(raw, &hb); err != nil {
+				return nil, err
+			}
+			return func() bool { return sess.handleHeartbeat(hb) }, nil
+		},
+		"agent_activity": func(raw json.RawMessage) (wsHandlerFunc, error) {
+			activity, payload, ok := NormalizeAgentActivityPayload(raw)
+			if !ok {
+				return nil, errors.New("payload is not a JSON object")
+			}
+			return func() bool { return sess.handleAgentActivity(activity, payload) }, nil
+		},
+		"chunk": func(raw json.RawMessage) (wsHandlerFunc, error) {
+			var chunk types.ChunkPayload
+			if err := json.Unmarshal(raw, &chunk); err != nil {
+				return nil, err
+			}
+			return func() bool { return sess.handleChunk(chunk) }, nil
+		},
+		"message": func(raw json.RawMessage) (wsHandlerFunc, error) {
+			var hm types.HubMessage
+			if err := json.Unmarshal(raw, &hm); err != nil {
+				return nil, err
+			}
+			return func() bool { return sess.handleMessage(hm) }, nil
+		},
+		"file_ack": func(raw json.RawMessage) (wsHandlerFunc, error) {
+			var ack types.FileAck
+			if err := json.Unmarshal(raw, &ack); err != nil {
+				return nil, err
+			}
+			return func() bool { return sess.handleFileAck(ack) }, nil
+		},
+		"file_read_resp": func(raw json.RawMessage) (wsHandlerFunc, error) {
+			var resp types.FileReadResp
+			if err := json.Unmarshal(raw, &resp); err != nil {
+				return nil, err
+			}
+			return func() bool { return sess.handleFileReadResp(resp) }, nil
+		},
+		"volume_attach_ack": func(raw json.RawMessage) (wsHandlerFunc, error) {
+			var ack types.VolumeAttachAck
+			if err := json.Unmarshal(raw, &ack); err != nil {
+				return nil, err
+			}
+			return func() bool { return sess.handleVolumeAttachAck(ack) }, nil
+		},
+		"volume_sync_ack": func(raw json.RawMessage) (wsHandlerFunc, error) {
+			var ack types.VolumeSyncAck
+			if err := json.Unmarshal(raw, &ack); err != nil {
+				return nil, err
+			}
+			return func() bool { return sess.handleVolumeSyncAck(ack) }, nil
+		},
+		"http_proxy_req": func(raw json.RawMessage) (wsHandlerFunc, error) {
+			var req httpProxyRequest
+			if err := json.Unmarshal(raw, &req); err != nil {
+				return nil, err
+			}
+			return func() bool { return sess.handleHTTPProxyReq(req) }, nil
+		},
+	}
+}
+
+func (sess *clawSession) handleHeartbeat(hb types.HeartbeatPayload) bool {
+	s, ctx, r := sess.s, sess.ctx, sess.r
+	clawID, tenantID := sess.clawID, sess.tenantID
+	var wakeConn *Conn
+	var shouldWake bool
+	var shouldWarnContext bool
+	var prevUsage int
+	if cc, ok := s.reg.Get(clawID); ok {
+		cc.Mu.Lock()
+		// Log only on status changes, not every heartbeat
+		prevUsage = cc.ContextUsage
+		cc.ContextUsage = hb.ContextUsage
+		// Promote from 'starting' to 'connected' once gateway is ready.
+		// nil means field absent (old bridge) — treat as ready.
+		if gatewayReadyBool(hb.GatewayReady) {
+			rowsUpdated, _ := s.st.Claws().PromoteStartingToConnected(ctx, clawID)
+			cc.GatewayReady = true
+			if rowsUpdated > 0 {
+				s.broadcastToUsers(tenantID, types.WSMessage{
+					Type:    "claw_status",
+					Payload: map[string]string{"claw_id": clawID, "status": "connected"},
+				})
+				logfCtx(r.Context(), "[bridge] ✓ ready: %s (%s)", sess.name, clawID[:8])
+				shouldWake = true
+				wakeConn = cc
+				sess.submit(func() { s.requestBootstrapCheckpoint(clawID) })
+			}
+		}
+		if !hb.GatewayHealthy {
+			cc.GatewayUnhealthyCount++
+			if cc.GatewayUnhealthyCount == 1 {
+				logfCtx(r.Context(), "[heartbeat] %s (%s): gateway unhealthy", sess.name, clawID[:8])
+			} else if cc.GatewayUnhealthyCount%4 == 0 {
+				logfCtx(r.Context(), "[heartbeat] %s (%s): gateway unhealthy for %d consecutive checks", sess.name, clawID[:8], cc.GatewayUnhealthyCount)
+			}
+			if cc.GatewayUnhealthyCount == 4 && !cc.StreamingStartedAt.IsZero() {
+				sess.submit(func() {
+					s.injectHubMessageByID(clawID, "[hub] The gateway has been unresponsive for about a minute. If you're stuck in a long operation, consider sending [DONE] and starting fresh.")
+				})
+			}
+		}
+		// Log context usage on every heartbeat when it crosses the 80% threshold,
+		// regardless of gateway health — don't silence diagnostics during outages.
+		if hb.ContextUsage != prevUsage && (hb.ContextUsage >= 80 || prevUsage >= 80) {
+			logfCtx(r.Context(), "[heartbeat] %s (%s): context_usage=%d%%", sess.name, clawID[:8], hb.ContextUsage)
+		}
+		if hb.GatewayHealthy && cc.GatewayUnhealthyCount > 0 {
+			logfCtx(r.Context(), "[heartbeat] %s (%s): gateway recovered after %d unhealthy checks", sess.name, clawID[:8], cc.GatewayUnhealthyCount)
+			cc.GatewayUnhealthyCount = 0
+		}
+		// Inject context warning once per streaming turn when usage is >=95%
+		if !cc.StreamingStartedAt.IsZero() &&
+			hb.ContextUsage >= 95 &&
+			!cc.ContextWarningSent {
+			cc.ContextWarningSent = true
+			shouldWarnContext = true
+		}
+		cc.Mu.Unlock()
+	}
+	s.heartbeatWorkflowVolumeLeases(clawID)
+	if shouldWarnContext {
+		warnCC := s.reg.Lookup(clawID)
+		if warnCC != nil {
+			sess.submit(func() {
+				s.injectHubMessage(ctx, warnCC, "[hub] Context window is nearly full. Summarize your progress briefly and send [DONE] with any PR URL, or ask the user what to do next.")
+			})
+		}
+	}
+	if shouldWake {
+		s.startWorkflowAfterVolumes(ctx, wakeConn, clawID)
+	}
+	// Check for streaming turn timeout (12 minutes)
+	cc, ok := s.reg.Get(clawID)
+	if ok {
+		cc.Mu.Lock()
+		if !cc.StreamingStartedAt.IsZero() &&
+			!cc.StreamingTimeoutSent &&
+			time.Since(cc.StreamingStartedAt) > 12*time.Minute {
+			cc.StreamingTimeoutSent = true
+			cc.Mu.Unlock()
+			sess.submit(func() {
+				s.injectHubMessage(ctx, cc, "[hub] Your current response has been running for over 12 minutes. Please wrap up and send your response.")
+			})
+		} else {
+			cc.Mu.Unlock()
+		}
+	}
+	return true
+}
+
+func (sess *clawSession) handleAgentActivity(activity map[string]interface{}, payload []byte) bool {
+	s, ctx, r, cc := sess.s, sess.ctx, sess.r, sess.cc
+	clawID, tenantID := sess.clawID, sess.tenantID
+	if err := s.flushStreamingSegment(clawID, tenantID, cc); err != nil {
+		logfCtx(r.Context(), "[agent_activity] flush streaming segment for %s: %v", clawID[:8], err)
+	}
+	if IsBusyAgentActivity(activity) {
+		cc.Mu.Lock()
+		if cc.StreamingStartedAt.IsZero() {
+			cc.StreamingStartedAt = time.Now()
+			cc.StreamingTimeoutSent = false
+			cc.ContextWarningSent = false
+		}
+		cc.Mu.Unlock()
+	}
+	createdAt := now()
+	activity["claw_id"] = clawID
+	activity["created_at"] = createdAt.Format(time.RFC3339Nano)
+	content := activityContent(activity)
+	if content != "" && !isUnhelpfulActivityContent(activity, content) {
+		format := "activity:" + string(payload)
+		_ = s.st.Messages().Insert(ctx, types.HubMessage{
+			ID: uuid.New().String(), ClawID: clawID, TenantID: tenantID,
+			Role: "activity", Content: content, Format: format, CreatedAt: createdAt,
+		})
+	}
+	s.broadcastToUsers(tenantID, types.WSMessage{
+		Type:    "agent_activity",
+		Payload: activity,
+	})
+	s.handleInitialPlanActivity(clawID, tenantID, activity)
+	return true
+}
+
+func (sess *clawSession) handleChunk(chunk types.ChunkPayload) bool {
+	s, ctx := sess.s, sess.ctx
+	clawID, tenantID := sess.clawID, sess.tenantID
+	// Streaming chunk — forward to users immediately AND buffer server-side
+	if chunk.Content == "" {
+		return true
+	}
+	s.broadcastToUsers(tenantID, types.WSMessage{
+		Type:    "chunk",
+		Payload: map[string]string{"claw_id": clawID, "content": chunk.Content},
+	})
+	// Buffer chunk and upsert partial message to DB so refreshes don't lose it
+	cc, ok := s.reg.Get(clawID)
+	if ok {
+		cc.Mu.Lock()
+		if cc.StreamingMsgID == "" {
+			cc.StreamingMsgID = uuid.New().String()
+			cc.StreamingTimeoutSent = false
+			cc.ContextWarningSent = false
+		}
+		if cc.StreamingStartedAt.IsZero() {
+			cc.StreamingStartedAt = time.Now()
+		}
+		cc.StreamingBuf.WriteString(chunk.Content)
+		msgID := cc.StreamingMsgID
+		// Periodic partial commit: persist the buffer on the
+		// first chunk and then every streamingFlushBytes /
+		// streamingFlushInterval, so a mid-stream disconnect
+		// or hub crash keeps everything up to the last window
+		// without one DB write per chunk.
+		var bufContent string
+		flush := cc.StreamingFlushedLen == 0 ||
+			cc.StreamingBuf.Len()-cc.StreamingFlushedLen >= streamingFlushBytes ||
+			time.Since(cc.StreamingFlushedAt) >= streamingFlushInterval
+		if flush {
+			bufContent = cc.StreamingBuf.String()
+			cc.StreamingFlushedLen = cc.StreamingBuf.Len()
+			cc.StreamingFlushedAt = time.Now()
+		}
+		cc.Mu.Unlock()
+		if flush {
+			// Upsert — insert on first commit, update content after
+			_ = s.st.Messages().Upsert(ctx, types.HubMessage{
+				ID: msgID, ClawID: clawID, TenantID: tenantID, Role: "claw",
+				Content: bufContent, CreatedAt: now(),
+			})
+		}
+	}
+	return true
+}
+
+func (sess *clawSession) handleMessage(hm types.HubMessage) bool {
+	s, ctx, r, cc := sess.s, sess.ctx, sess.r, sess.cc
+	clawID, tenantID := sess.clawID, sess.tenantID
+	// Complete message — finalize the buffered stream or store fresh
+	hm.ClawID = clawID
+	hm.TenantID = tenantID
+	hm.Role = "claw"
+	hm.CreatedAt = now()
+	// Always clean up streaming state first, even for empty messages.
+	// Use the session's cc (this goroutine's connection), not a fresh lookup.
+	// If the claw reconnected, a new handleClawWS goroutine handles the new cc.
+	cc.Mu.Lock()
+	persistContent := hm.Content
+	skipPersist := false
+	if cc.StreamingMsgID != "" {
+		hm.ID = cc.StreamingMsgID
+		if cc.StreamingBuf.Len() > 0 {
+			persistContent = cc.StreamingBuf.String()
+		}
+	} else {
+		hm.ID = uuid.New().String()
+		skipPersist = cc.StreamingSplit
+	}
+	cc.FinishTurnLocked()
+	cc.Mu.Unlock()
+	// Drop empty messages — never store or broadcast
+	if strings.TrimSpace(hm.Content) == "" {
+		// Clear typing indicator first — always clear even if no queued messages
+		s.broadcastToUsers(tenantID, types.WSMessage{
+			Type: "agent_typing",
+			Payload: map[string]string{
+				"claw_id": clawID,
+				"status":  "idle",
+			},
+		})
+		// Drain queue using this goroutine's cc.
+		// If the claw reconnected, a new handleClawWS goroutine handles the new cc.
+		s.sendNextQueuedMessage(cc)
+		s.drainPendingCheckpoint(clawID)
+		return true
+	}
+	if !skipPersist && strings.TrimSpace(persistContent) != "" {
+		_ = s.st.Messages().Upsert(ctx, types.HubMessage{
+			ID: hm.ID, ClawID: hm.ClawID, TenantID: hm.TenantID, Role: hm.Role,
+			Content: persistContent, CreatedAt: hm.CreatedAt,
+		})
+		s.broadcastToUsers(tenantID, types.WSMessage{Type: "message", Payload: hm})
+	}
+	s.handleInitialPlanResponse(clawID, tenantID, hm.Content)
+	// Evaluate pipeline triggers. If a pipeline explicitly owns a
+	// [DONE] trigger, let it handle that signal instead of the
+	// legacy factory PR-URL completion path below. The block lives
+	// behind a hub hook because it builds workflows-package
+	// pipeline contexts.
+	pipelineHandledDone, pipelineJob := s.deps.EvaluatePipelineMessageTriggers(clawID, hm.Content)
+	if pipelineJob != nil && !sess.submit(pipelineJob) {
+		return false
+	}
+	// Clear typing indicator now that response is complete
+	s.broadcastToUsers(tenantID, types.WSMessage{
+		Type: "agent_typing",
+		Payload: map[string]string{
+			"claw_id": clawID,
+			"status":  "idle",
+		},
+	})
+	// Check for [DONE] signal from a factory-created claw
+	if strings.Contains(hm.Content, "[DONE]") {
+		//nolint:contextcheck // the done-checkpoint outlives this request; it derives from the hub root context on purpose
+		if !sess.submit(func() {
+			if _, err := s.requestCheckpoint(s.baseCtx(), clawID, "done", "hub", false, s.deps.CheckpointRequestTimeout); err != nil {
+				logfCtx(r.Context(), "[checkpoint] done request for %s failed: %v", shortID(clawID), err)
+			}
+		}) {
+			return false
+		}
+		if !pipelineHandledDone {
+			if !sess.submit(func() { s.handleClawDoneSignal(clawID, hm.Content) }) {
+				return false
+			}
+		}
+	}
+	// Check for [TERMINATE] signal - allows claw to manage its own lifecycle
+	if strings.Contains(hm.Content, "[TERMINATE]") {
+		if !sess.submit(func() { s.handleClawTerminateSignal(clawID, hm.Content) }) {
+			return false
+		}
+	}
+	// Detect and store any PR URLs mentioned by the agent
+	if !sess.submit(func() { s.scanMessageForPRs(clawID, hm.Content) }) {
+		return false
+	}
+	// Detect tool error loops and inject a corrective message
+	if DetectToolLoop(hm.Content) {
+		loopCC := s.reg.Lookup(clawID)
+		if loopCC != nil {
+			if !sess.submit(func() {
+				s.injectHubMessage(ctx, loopCC, "[hub] You've hit the same tool error 3+ times in a row. Stop retrying. Take a completely different approach or ask for help.")
+			}) {
+				return false
+			}
+		}
+	}
+	// Check for queued messages and send the next one.
+	// Use this goroutine's cc. If the claw reconnected, a new
+	// handleClawWS goroutine handles the new cc.
+	s.sendNextQueuedMessage(cc)
+	s.drainPendingCheckpoint(clawID)
+	return true
+}
+
+func (sess *clawSession) handleFileAck(ack types.FileAck) bool {
+	s := sess.s
+	if ack.RequestID == "" {
+		return true
+	}
+	s.fileAckMu.Lock()
+	ch := s.fileAckWaiters()[ack.RequestID]
+	delete(s.fileAckWaiters(), ack.RequestID)
+	s.fileAckMu.Unlock()
+	if ch != nil {
+		select {
+		case ch <- ack:
+		default:
+		}
+	}
+	return true
+}
+
+func (sess *clawSession) handleFileReadResp(resp types.FileReadResp) bool {
+	s := sess.s
+	if resp.RequestID == "" {
+		return true
+	}
+	s.fileAckMu.Lock()
+	ch := s.fileReadWaiters()[resp.RequestID]
+	delete(s.fileReadWaiters(), resp.RequestID)
+	s.fileAckMu.Unlock()
+	if ch != nil {
+		select {
+		case ch <- resp:
+		default:
+		}
+	}
+	return true
+}
+
+func (sess *clawSession) handleVolumeAttachAck(ack types.VolumeAttachAck) bool {
+	s := sess.s
+	if ack.RequestID == "" {
+		return true
+	}
+	s.fileAckMu.Lock()
+	ch := s.volumeAttachWaiters()[ack.RequestID]
+	delete(s.volumeAttachWaiters(), ack.RequestID)
+	s.fileAckMu.Unlock()
+	if ch != nil {
+		select {
+		case ch <- ack:
+		default:
+		}
+	}
+	return true
+}
+
+func (sess *clawSession) handleVolumeSyncAck(ack types.VolumeSyncAck) bool {
+	s := sess.s
+	if ack.RequestID == "" {
+		return true
+	}
+	s.fileAckMu.Lock()
+	ch := s.volumeSyncWaiters()[ack.RequestID]
+	delete(s.volumeSyncWaiters(), ack.RequestID)
+	s.fileAckMu.Unlock()
+	if ch != nil {
+		select {
+		case ch <- ack:
+		default:
+		}
+	}
+	return true
+}
+
+// httpProxyRequest is the payload of "http_proxy_req": an HTTP request the
+// bridge asks the hub to execute against its internal API. This allows tools
+// in the sandbox to reach hub APIs without a public URL.
+type httpProxyRequest struct {
+	ReqID  string            `json:"req_id"`
+	Method string            `json:"method"`
+	Path   string            `json:"path"`
+	Query  string            `json:"query"`
+	Body   string            `json:"body"`
+	Header map[string]string `json:"header"`
+}
+
+func (sess *clawSession) handleHTTPProxyReq(req httpProxyRequest) bool {
+	s, ctx, conn := sess.s, sess.ctx, sess.conn
+	return sess.submit(func() {
+		logfCtx(ctx, "[hub-proxy] req req_id=%s %s %s?%s", req.ReqID, req.Method, req.Path, req.Query)
+		// Build an internal HTTP request
+		urls := req.Path
+		if req.Query != "" {
+			urls += "?" + req.Query
+		}
+		httpReq, err := http.NewRequestWithContext(ctx, req.Method, "http://localhost"+urls, strings.NewReader(req.Body))
+		if err != nil {
+			logfCtx(ctx, "[hub-proxy] build request failed req_id=%s err=%v", req.ReqID, err)
+			s.sendHTTPProxyRes(ctx, conn, req.ReqID, 400, "bad request")
+			return
+		}
+		for k, v := range req.Header {
+			httpReq.Header.Set(k, v)
+		}
+		// Inject claw_token auth so withAuth middleware passes
+		s.cfgMu.RLock()
+		clawToken := s.hubCfg().ClawToken
+		s.cfgMu.RUnlock()
+		httpReq.Header.Set("X-Claw-Token", clawToken)
+		// Execute against internal mux
+		w := &proxyResponseWriter{header: make(http.Header)}
+		s.mux().ServeHTTP(w, httpReq)
+		if w.status == 0 {
+			w.status = 200
+		}
+		logfCtx(ctx, "[hub-proxy] res req_id=%s status=%d body_len=%d", req.ReqID, w.status, len(w.body))
+		s.sendHTTPProxyRes(ctx, conn, req.ReqID, w.status, string(w.body))
+	})
 }
 
 func (s *Service) sendHTTPProxyRes(ctx context.Context, conn *websocket.Conn, reqID string, status int, body string) {
@@ -680,11 +821,4 @@ func (w *proxyResponseWriter) Write(b []byte) (int, error) {
 }
 func (w *proxyResponseWriter) WriteHeader(status int) {
 	w.status = status
-}
-
-// mustJSONRaw mirrors the pkg/hub helper of the same name (a duplicate is
-// kept here so claws does not reach back into the hub package).
-func mustJSONRaw(v interface{}) json.RawMessage {
-	b, _ := json.Marshal(v)
-	return json.RawMessage(b)
 }

--- a/pkg/hub/claws/ws_decode_test.go
+++ b/pkg/hub/claws/ws_decode_test.go
@@ -1,0 +1,58 @@
+package claws
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestClawWSDecoders verifies the typed-payload decoder registry (phase-2
+// item 2.5): every claw-bound message type has a decoder, malformed payloads
+// come back as protocol errors (never a panic or a silent nil handler), and
+// well-formed payloads yield a ready-to-run handler without touching the
+// Service. Handlers are not invoked — decode is the unit under test.
+func TestClawWSDecoders(t *testing.T) {
+	sess := &clawSession{} // decode must not need Service state
+	decoders := sess.decoders()
+
+	wantTypes := []string{
+		"heartbeat", "agent_activity", "chunk", "message",
+		"file_ack", "file_read_resp", "volume_attach_ack", "volume_sync_ack",
+		"http_proxy_req",
+	}
+	for _, typ := range wantTypes {
+		if _, ok := decoders[typ]; !ok {
+			t.Errorf("no decoder registered for %q", typ)
+		}
+	}
+	if len(decoders) != len(wantTypes) {
+		t.Errorf("registry has %d decoders, want %d", len(decoders), len(wantTypes))
+	}
+
+	valid := map[string]string{
+		"heartbeat":         `{"gateway_healthy":true,"context_usage":42}`,
+		"agent_activity":    `{"kind":"tool","tool":"exec"}`,
+		"chunk":             `{"content":"hello"}`,
+		"message":           `{"content":"done"}`,
+		"file_ack":          `{"request_id":"r1","ok":true}`,
+		"file_read_resp":    `{"request_id":"r1","ok":true}`,
+		"volume_attach_ack": `{"request_id":"r1","lease_id":"l1","ok":true}`,
+		"volume_sync_ack":   `{"request_id":"r1","lease_id":"l1","ok":true}`,
+		"http_proxy_req":    `{"req_id":"q1","method":"GET","path":"/api/claws"}`,
+	}
+	for typ, payload := range valid {
+		handle, err := decoders[typ](json.RawMessage(payload))
+		if err != nil {
+			t.Errorf("decode %q with valid payload: unexpected error %v", typ, err)
+		}
+		if handle == nil {
+			t.Errorf("decode %q with valid payload: nil handler", typ)
+		}
+	}
+
+	for typ := range decoders {
+		handle, err := decoders[typ](json.RawMessage(`"not an object"`))
+		if err == nil {
+			t.Errorf("decode %q with malformed payload: want protocol error, got handler=%v", typ, handle)
+		}
+	}
+}

--- a/pkg/hub/claws_bridge.go
+++ b/pkg/hub/claws_bridge.go
@@ -17,6 +17,7 @@ import (
 	gossh "golang.org/x/crypto/ssh"
 
 	"github.com/elasticclaw/elasticclaw/pkg/hub/claws"
+	"github.com/elasticclaw/elasticclaw/pkg/hub/httpserver"
 	"github.com/elasticclaw/elasticclaw/pkg/hub/pipeline"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
@@ -42,6 +43,9 @@ func (s *Server) clawsSvc() *claws.Service {
 		HubCfg:          func() *types.HubConfig { return s.hubCfg },
 		Mux:             func() http.Handler { return s.mux },
 		WSMessageMetric: s.metrics.wsMessage,
+
+		JSONOK:         httpserver.JSONOK,
+		WriteDomainErr: httpserver.WriteDomainErr,
 
 		TenantByClawToken: s.tenantByClawToken,
 		TenantByToken:     s.tenantByToken,

--- a/pkg/hub/client.go
+++ b/pkg/hub/client.go
@@ -150,7 +150,7 @@ func (c *Client) WatchMessages(ctx context.Context, clawID string, onMessage fun
 	defer conn.CloseNow()
 
 	for {
-		var msg types.WSMessage
+		var msg types.WSEnvelope
 		if err := wsjson.Read(ctx, conn, &msg); err != nil {
 			if ctx.Err() != nil {
 				return nil
@@ -160,11 +160,9 @@ func (c *Client) WatchMessages(ctx context.Context, clawID string, onMessage fun
 		switch msg.Type {
 		case "message":
 			var hm types.HubMessage
-			if b, err := json.Marshal(msg.Payload); err == nil {
-				if err := json.Unmarshal(b, &hm); err == nil {
-					if hm.ClawID == clawID && hm.Role == "claw" {
-						onMessage(hm)
-					}
+			if err := json.Unmarshal(msg.Payload, &hm); err == nil {
+				if hm.ClawID == clawID && hm.Role == "claw" {
+					onMessage(hm)
 				}
 			}
 		}
@@ -189,7 +187,7 @@ func (c *Client) WatchStream(ctx context.Context, clawID string, onChunk func(ch
 	defer conn.CloseNow()
 
 	for {
-		var msg types.WSMessage
+		var msg types.WSEnvelope
 		if err := wsjson.Read(ctx, conn, &msg); err != nil {
 			if ctx.Err() != nil {
 				return nil
@@ -203,19 +201,15 @@ func (c *Client) WatchStream(ctx context.Context, clawID string, onChunk func(ch
 					ClawID  string `json:"claw_id"`
 					Content string `json:"content"`
 				}
-				if b, err := json.Marshal(msg.Payload); err == nil {
-					if err := json.Unmarshal(b, &c); err == nil && c.ClawID == clawID {
-						onChunk(c.Content)
-					}
+				if err := json.Unmarshal(msg.Payload, &c); err == nil && c.ClawID == clawID {
+					onChunk(c.Content)
 				}
 			}
 		case "message":
 			if onMessage != nil {
 				var hm types.HubMessage
-				if b, err := json.Marshal(msg.Payload); err == nil {
-					if err := json.Unmarshal(b, &hm); err == nil && hm.ClawID == clawID && hm.Role == "claw" {
-						onMessage(hm)
-					}
+				if err := json.Unmarshal(msg.Payload, &hm); err == nil && hm.ClawID == clawID && hm.Role == "claw" {
+					onMessage(hm)
 				}
 			}
 		}

--- a/pkg/hub/httpserver/errors.go
+++ b/pkg/hub/httpserver/errors.go
@@ -1,0 +1,53 @@
+package httpserver
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+// domainStatus is one row of the sentinel-error → HTTP status table.
+type domainStatus struct {
+	err    error
+	status int
+	code   string
+}
+
+// domainStatuses is the single errors.Is → HTTP status map for the sentinel
+// domain errors in pkg/types (phase-2 item 2.5). Handlers call WriteDomainErr
+// instead of mapping errors to statuses ad hoc.
+var domainStatuses = []domainStatus{
+	{types.ErrUnauthorized, http.StatusUnauthorized, "unauthorized"},
+	{types.ErrTenantMismatch, http.StatusForbidden, "forbidden"},
+	{types.ErrClawNotFound, http.StatusNotFound, "not_found"},
+	{types.ErrWorkflowNotFound, http.StatusNotFound, "not_found"},
+	{types.ErrWorkspaceNotFound, http.StatusNotFound, "not_found"},
+	{types.ErrCheckpointNotFound, http.StatusNotFound, "not_found"},
+	{types.ErrCheckpointNotReady, http.StatusConflict, "conflict"},
+}
+
+// StatusForError resolves err against the domain-error table with errors.Is
+// and returns the HTTP status plus the stable machine-readable code for the
+// JSON error envelope. Unrecognized errors map to 500/"internal".
+func StatusForError(err error) (status int, code string) {
+	for _, m := range domainStatuses {
+		if errors.Is(err, m.err) {
+			return m.status, m.code
+		}
+	}
+	return http.StatusInternalServerError, "internal"
+}
+
+// WriteDomainErr maps err to an HTTP status via StatusForError and writes the
+// unified JSON error envelope. Domain errors surface their message to the
+// client; unrecognized errors are written as a generic 500 so internal detail
+// (SQL text, file paths) never leaks into responses.
+func WriteDomainErr(w http.ResponseWriter, err error) {
+	status, code := StatusForError(err)
+	msg := "internal server error"
+	if status != http.StatusInternalServerError {
+		msg = err.Error()
+	}
+	WriteErr(w, status, code, msg)
+}

--- a/pkg/hub/httpserver/errors_test.go
+++ b/pkg/hub/httpserver/errors_test.go
@@ -1,0 +1,78 @@
+package httpserver
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+// TestStatusForError covers the full error→status mapping table, including
+// wrapped errors (errors.Is must see through fmt.Errorf %w chains) and the
+// 500 fallback for unrecognized errors.
+func TestStatusForError(t *testing.T) {
+	cases := []struct {
+		name       string
+		err        error
+		wantStatus int
+		wantCode   string
+	}{
+		{"unauthorized", types.ErrUnauthorized, http.StatusUnauthorized, "unauthorized"},
+		{"tenant mismatch", types.ErrTenantMismatch, http.StatusForbidden, "forbidden"},
+		{"claw not found", types.ErrClawNotFound, http.StatusNotFound, "not_found"},
+		{"workflow not found", types.ErrWorkflowNotFound, http.StatusNotFound, "not_found"},
+		{"workspace not found", types.ErrWorkspaceNotFound, http.StatusNotFound, "not_found"},
+		{"checkpoint not found", types.ErrCheckpointNotFound, http.StatusNotFound, "not_found"},
+		{"checkpoint not ready", types.ErrCheckpointNotReady, http.StatusConflict, "conflict"},
+		{"wrapped sentinel", fmt.Errorf("restore claw abc: %w", types.ErrCheckpointNotFound), http.StatusNotFound, "not_found"},
+		{"double wrapped sentinel", fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", types.ErrClawNotFound)), http.StatusNotFound, "not_found"},
+		{"unknown error", errors.New("disk on fire"), http.StatusInternalServerError, "internal"},
+		{"nil-safe unknown", fmt.Errorf("plain"), http.StatusInternalServerError, "internal"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			status, code := StatusForError(tc.err)
+			if status != tc.wantStatus || code != tc.wantCode {
+				t.Fatalf("StatusForError(%v) = (%d, %q), want (%d, %q)", tc.err, status, code, tc.wantStatus, tc.wantCode)
+			}
+		})
+	}
+}
+
+// TestWriteDomainErr verifies the envelope body: domain errors surface their
+// message, unknown errors are replaced by a generic message so internals
+// never leak into responses.
+func TestWriteDomainErr(t *testing.T) {
+	t.Run("domain error surfaces message", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		WriteDomainErr(rec, fmt.Errorf("claw %q: %w", "abc123", types.ErrClawNotFound))
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("status = %d, want 404", rec.Code)
+		}
+		var body APIError
+		if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+			t.Fatalf("unmarshal body: %v", err)
+		}
+		if body.Code != "not_found" || body.Error != `claw "abc123": claw not found` {
+			t.Fatalf("body = %+v", body)
+		}
+	})
+	t.Run("unknown error is masked", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		WriteDomainErr(rec, errors.New("SELECT failed: /var/lib/hub.db locked"))
+		if rec.Code != http.StatusInternalServerError {
+			t.Fatalf("status = %d, want 500", rec.Code)
+		}
+		var body APIError
+		if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+			t.Fatalf("unmarshal body: %v", err)
+		}
+		if body.Code != "internal" || body.Error != "internal server error" {
+			t.Fatalf("body = %+v", body)
+		}
+	})
+}

--- a/pkg/hub/hub_test.go
+++ b/pkg/hub/hub_test.go
@@ -1100,7 +1100,7 @@ func TestNormalizeAgentActivityPayloadRejectsNull(t *testing.T) {
 	if activity, raw, ok := normalizeAgentActivityPayload(nil); ok || activity != nil || raw != nil {
 		t.Fatalf("nil payload normalized to activity=%v raw=%q ok=%v", activity, raw, ok)
 	}
-	if activity, raw, ok := normalizeAgentActivityPayload(map[string]interface{}{"kind": "tool", "tool": "exec"}); !ok || activity["tool"] != "exec" || len(raw) == 0 {
+	if activity, raw, ok := normalizeAgentActivityPayload(json.RawMessage(`{"kind":"tool","tool":"exec"}`)); !ok || activity["tool"] != "exec" || len(raw) == 0 {
 		t.Fatalf("valid payload normalized to activity=%v raw=%q ok=%v", activity, raw, ok)
 	}
 }

--- a/pkg/hub/message_handlers.go
+++ b/pkg/hub/message_handlers.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/elasticclaw/elasticclaw/pkg/hub/store"
 	"github.com/elasticclaw/elasticclaw/pkg/hub/httpserver"
+	"github.com/elasticclaw/elasticclaw/pkg/hub/store"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 	"github.com/google/uuid"
 	"nhooyr.io/websocket/wsjson"

--- a/pkg/hub/message_handlers.go
+++ b/pkg/hub/message_handlers.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/elasticclaw/elasticclaw/pkg/hub/store"
+	"github.com/elasticclaw/elasticclaw/pkg/hub/httpserver"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 	"github.com/google/uuid"
 	"nhooyr.io/websocket/wsjson"
@@ -390,7 +391,7 @@ func (s *Server) canViewMessages(w http.ResponseWriter, r *http.Request, tenantI
 
 	clawTagsMsg, err := s.st().Claws().Tags(r.Context(), clawID, tenantID)
 	if err == sql.ErrNoRows {
-		http.Error(w, "not found", http.StatusNotFound)
+		httpserver.WriteDomainErr(w, types.ErrClawNotFound)
 		return false
 	}
 	if err != nil {

--- a/pkg/hub/terminal_errors_test.go
+++ b/pkg/hub/terminal_errors_test.go
@@ -1,0 +1,71 @@
+package hub
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+// newTerminalTestServer builds a minimal hub with one tenant so the
+// terminal handler can run its auth and claw-lookup steps.
+func newTerminalTestServer(t *testing.T) *Server {
+	t.Helper()
+	db, err := openDB(":memory:")
+	if err != nil {
+		t.Fatalf("openDB: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { db.Close() })
+	_, _ = db.Exec(`INSERT INTO tenants(id,name,token,claw_token,created_at) VALUES(?,?,?,?,?)`,
+		"tenant", "tenant", "token", "claw-token", now())
+	return &Server{db: db, hubCfg: &types.HubConfig{}}
+}
+
+// decodeAPIError parses the unified JSON error envelope written by
+// httpserver.WriteDomainErr (injected into the claws service through Deps).
+func decodeAPIError(t *testing.T, body []byte) (code, msg string) {
+	t.Helper()
+	var envelope struct {
+		Error string `json:"error"`
+		Code  string `json:"code"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		t.Fatalf("response body %q is not the JSON error envelope: %v", body, err)
+	}
+	return envelope.Code, envelope.Error
+}
+
+// TestHandleTerminalUnauthorizedEnvelope verifies that the terminal handler
+// (moved into pkg/hub/claws) writes the domain-error envelope through the
+// injected writer instead of importing httpserver directly.
+func TestHandleTerminalUnauthorizedEnvelope(t *testing.T) {
+	s := newTerminalTestServer(t)
+
+	r := httptest.NewRequest("GET", "/api/terminal/some-claw?token=wrong", nil)
+	w := httptest.NewRecorder()
+	s.handleTerminal(w, r)
+
+	if w.Code != 401 {
+		t.Fatalf("status = %d, want 401", w.Code)
+	}
+	if code, _ := decodeAPIError(t, w.Body.Bytes()); code != "unauthorized" {
+		t.Fatalf("code = %q, want %q", code, "unauthorized")
+	}
+}
+
+func TestHandleTerminalClawNotFoundEnvelope(t *testing.T) {
+	s := newTerminalTestServer(t)
+
+	r := httptest.NewRequest("GET", "/api/terminal/missing-claw?token=token", nil)
+	w := httptest.NewRecorder()
+	s.handleTerminal(w, r)
+
+	if w.Code != 404 {
+		t.Fatalf("status = %d, want 404", w.Code)
+	}
+	if code, _ := decodeAPIError(t, w.Body.Bytes()); code != "not_found" {
+		t.Fatalf("code = %q, want %q", code, "not_found")
+	}
+}

--- a/pkg/hub/userws.go
+++ b/pkg/hub/userws.go
@@ -173,16 +173,18 @@ func (s *Server) handleUserWS(w http.ResponseWriter, r *http.Request) {
 
 	// Read loop (user sends messages via REST, but we keep WS open for server-push)
 	for {
-		var msg types.WSMessage
-		if err := wsjson.Read(ctx, conn, &msg); err != nil {
+		var env types.WSEnvelope
+		if err := wsjson.Read(ctx, conn, &env); err != nil {
 			return
 		}
 		s.metrics.wsMessage("in", "user")
 		// Forward user messages to the specified claw
-		if msg.Type == "message" {
-			payload, _ := json.Marshal(msg.Payload)
+		if env.Type == "message" {
 			var hm types.HubMessage
-			if err := json.Unmarshal(payload, &hm); err != nil {
+			if err := json.Unmarshal(env.Payload, &hm); err != nil {
+				// Malformed payload for a known type: a protocol error to
+				// log and skip, never a panic.
+				logfCtx(ctx, "[user ws] protocol error: bad \"message\" payload: %v", err)
 				continue
 			}
 			// Apply tag-based interact filter for GitHub OAuth users

--- a/pkg/hub/workflows_bridge.go
+++ b/pkg/hub/workflows_bridge.go
@@ -48,7 +48,12 @@ func (s *Server) workflowsSvc() *workflows.Service {
 		},
 		ClawStreaming: func(clawID string) bool {
 			cc, connected := s.clawReg.Get(clawID)
-			return connected && cc.StreamingBuf.Len() > 0
+			if !connected {
+				return false
+			}
+			cc.Mu.RLock()
+			defer cc.Mu.RUnlock()
+			return cc.StreamingBuf.Len() > 0
 		},
 		CloseClawConn: func(clawID string, code websocket.StatusCode, reason string) {
 			s.clawReg.Do(func(conns map[string]*clawConn) {

--- a/pkg/hub/workspace_api.go
+++ b/pkg/hub/workspace_api.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/elasticclaw/elasticclaw/pkg/hub/httpserver"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
 
@@ -142,7 +143,7 @@ func (s *Server) handleWorkspaceWorkflowsList(w http.ResponseWriter, r *http.Req
 			return
 		}
 	}
-	http.Error(w, "workspace not found", http.StatusNotFound)
+	httpserver.WriteDomainErr(w, types.ErrWorkspaceNotFound)
 }
 
 type WorkflowPushRequest struct {
@@ -211,7 +212,7 @@ func (s *Server) handleWorkspaceWorkflowDetail(w http.ResponseWriter, r *http.Re
 	}
 	workflow, ok := s.findWorkflowView(workspaceName, workflowName)
 	if !ok {
-		http.Error(w, "workflow not found", http.StatusNotFound)
+		httpserver.WriteDomainErr(w, types.ErrWorkflowNotFound)
 		return
 	}
 	jsonOK(w, workflow)
@@ -250,7 +251,7 @@ func (s *Server) handleWorkspaceWorkflowPatch(w http.ResponseWriter, r *http.Req
 		return
 	}
 	if !ok {
-		http.Error(w, "workflow not found", http.StatusNotFound)
+		httpserver.WriteDomainErr(w, types.ErrWorkflowNotFound)
 		return
 	}
 	if req.Enabled != nil {
@@ -293,7 +294,7 @@ func (s *Server) handleWorkspaceWorkflowTrigger(w http.ResponseWriter, r *http.R
 		return
 	}
 	if !ok {
-		jsonError(w, http.StatusNotFound, "workflow not found")
+		httpserver.WriteDomainErr(w, types.ErrWorkflowNotFound)
 		return
 	}
 

--- a/pkg/types/errors.go
+++ b/pkg/types/errors.go
@@ -1,0 +1,37 @@
+package types
+
+import "errors"
+
+// Sentinel domain errors (phase-2 item 2.5). Services and stores return
+// these — or wrap them with fmt.Errorf("...: %w", ...) — instead of ad hoc
+// error strings, and pkg/hub/httpserver maps them to HTTP statuses with
+// errors.Is in a single place (StatusForError). This ends the per-handler
+// response inconsistency where the same condition produced different
+// statuses depending on the endpoint.
+var (
+	// ErrUnauthorized: the request carries no valid credential. Maps to 401.
+	ErrUnauthorized = errors.New("unauthorized")
+
+	// ErrTenantMismatch: the credential is valid but belongs to a different
+	// tenant than the resource. Maps to 403.
+	ErrTenantMismatch = errors.New("tenant mismatch")
+
+	// ErrClawNotFound: the claw does not exist (or is deleted) for the
+	// requesting tenant. Maps to 404.
+	ErrClawNotFound = errors.New("claw not found")
+
+	// ErrWorkflowNotFound: no workflow with that name in the workspace.
+	// Maps to 404.
+	ErrWorkflowNotFound = errors.New("workflow not found")
+
+	// ErrWorkspaceNotFound: no workspace with that name. Maps to 404.
+	ErrWorkspaceNotFound = errors.New("workspace not found")
+
+	// ErrCheckpointNotFound: the checkpoint does not exist for the
+	// requesting tenant/claw. Maps to 404.
+	ErrCheckpointNotFound = errors.New("checkpoint not found")
+
+	// ErrCheckpointNotReady: the checkpoint exists but is not in a
+	// restorable state. Maps to 409.
+	ErrCheckpointNotReady = errors.New("checkpoint is not ready")
+)

--- a/pkg/types/hub.go
+++ b/pkg/types/hub.go
@@ -1,6 +1,9 @@
 package types
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 // Claw represents an agent instance registered with the hub.
 type Claw struct {
@@ -46,6 +49,29 @@ type HubMessage struct {
 type WSMessage struct {
 	Type    string      `json:"type"`
 	Payload interface{} `json:"payload,omitempty"`
+}
+
+// WSEnvelope is the read side of WSMessage: the same {type, payload} wire
+// frame, but with the payload kept as raw JSON so receivers unmarshal it
+// straight into the concrete type registered for Type (phase-2 item 2.5)
+// instead of round-tripping through interface{}. The wire format is
+// identical to WSMessage; only the in-memory representation differs.
+type WSEnvelope struct {
+	Type    string          `json:"type"`
+	Payload json.RawMessage `json:"payload,omitempty"`
+}
+
+// HeartbeatPayload is sent periodically by the claw bridge (type "heartbeat").
+type HeartbeatPayload struct {
+	GatewayHealthy bool  `json:"gateway_healthy"`
+	GatewayReady   *bool `json:"gateway_ready,omitempty"` // nil means field absent (old bridge) — treat as ready
+	ContextUsage   int   `json:"context_usage"`
+}
+
+// ChunkPayload is one streaming chunk of an in-progress claw response
+// (type "chunk").
+type ChunkPayload struct {
+	Content string `json:"content"`
 }
 
 // FileAck is the claw-bridge's response after writing an uploaded file.


### PR DESCRIPTION
## Motivation

Handlers map errors to statuses ad hoc, and `WSMessage.Payload` is `interface{}` with panicky type assertions. Sentinel errors in `pkg/types` with a single `errors.Is` -> status map in `httpserver`, and a payload decoder registry unmarshalling into concrete types (wire envelope unchanged).

Concrete evidence in the code before this PR:

- The same "not found" condition produced different statuses and bodies depending on the endpoint: `restoreClawFromCheckpoint` returned `fmt.Errorf("checkpoint not found")` and the handler blanket-mapped every restore error to **409 Conflict**; the terminal proxy wrote plaintext `http.Error(w, "not found", 404)`; workspace workflow lookups mixed plaintext `http.Error` and the JSON `jsonError` envelope for the identical "workflow not found" case (`workspace_api.go:214/253/296`).
- Handlers checked `sql.ErrNoRows` inline at each call site (`claw_handlers.go`, `message_handlers.go`, `claws/terminal.go`, ...) and hand-picked a status each time.
- Every WS read path decoded payloads by round-tripping through `interface{}`: `payload, _ := json.Marshal(msg.Payload)` followed by `json.Unmarshal` into an anonymous struct — in the claw bridge read loop (9 message types in a 400-line if/else chain in `claws/ws.go`), the user WS loop (`userws.go`), and the CLI client (`client.go`). Malformed payloads for known types were silently dropped (`if err == nil { ... }`), hiding protocol bugs.

## Dependencies

This PR is STACKED on branch `feature/hub-ws-worker-pool`. Depends on #472 — review and merge that first.

## What changed

**1. Sentinel domain errors + single status map (spec item 2.5.1)**

- New `pkg/types/errors.go`: `ErrUnauthorized`, `ErrTenantMismatch`, `ErrClawNotFound`, `ErrWorkflowNotFound`, `ErrWorkspaceNotFound`, `ErrCheckpointNotFound`, `ErrCheckpointNotReady`.
- New `pkg/hub/httpserver/errors.go`: `StatusForError(err) (status, code)` resolves the sentinel table with `errors.Is` (sees through `%w` wrapping); `WriteDomainErr(w, err)` writes the unified JSON envelope. Unrecognized errors become a generic 500 so internal detail (SQL text, paths) never leaks into responses.
- Adopted in the handlers that mapped these conditions ad hoc: checkpoint restore, the SSH terminal proxy, workspace workflow/workspace lookups, claw detail, and the message tag check. Deliberate status corrections that fall out of the single map: checkpoint restore now returns **404** for a missing checkpoint and **409** only for not-ready (previously both were 409, and a DB error was also 409 — now 500).

**2. Typed WS payload decoding (spec item 2.5.2)**

- New `types.WSEnvelope{Type string; Payload json.RawMessage}` — the read side of `WSMessage`. The `{type, payload}` wire format is byte-for-byte unchanged (no protocol break); only the in-memory representation differs. New typed `HeartbeatPayload` and `ChunkPayload` join the existing wire types (`RegisterPayload`, `FileAck`, ...).
- The claw bridge read loop (`claws/ws.go`) now dispatches through a per-connection registry `map[string]func(json.RawMessage) (wsHandlerFunc, error)`: each decoder unmarshals straight into the concrete type and returns a ready-to-run handler; the 400-line if/else chain became one small method per message type on `clawSession`. Malformed payloads for known types are **logged protocol errors** (previously silently dropped), and can never panic. Unknown message types are ignored, as before.
- The user WS read loop and the client `WatchMessages`/`WatchStream` decode the same way; the `interface{}` marshal round-trips are gone from every read path.
- `NormalizeAgentActivityPayload` now takes the raw wire bytes (`json.RawMessage`), so the persisted `activity:` format stores the payload verbatim instead of a re-marshalled map. Its `pkg/hub` alias test was updated for the new signature (forced by the signature change, no behavioral relaxation).

**Acceptance criteria from the spec:** no type assertion on `Payload` outside the decoder (verified — no `.Payload.(` assertions and no read-path `json.Marshal(msg.Payload)` remain in `pkg/hub`); the error→status mapping table is covered by `pkg/hub/httpserver/errors_test.go`; the decoder registry by `pkg/hub/claws/ws_decode_test.go`.

## Testing

- `go build ./...` — pass
- `go vet ./pkg/...` — pass
- `make test` (`go test -v ./...`) — all packages `ok`, zero failures
- `make test-factory` — pass
- `make test-parity` — pass
- `go test -race -count=1 ./pkg/hub/ ./pkg/hub/claws/ ./pkg/hub/httpserver/` — `claws` and `httpserver` pass; `pkg/hub` fails on `TestMidStreamDisconnectPreservesReceivedContent` with a DATA RACE in the disconnect flush (`HandleClawWS`'s deferred `StreamingBuf.Reset()` vs. the chunk handler). **This race is pre-existing: the identical failure reproduces on the base branch `feature/hub-ws-worker-pool`** (verified in a clean worktree of that branch); it is not introduced by this PR and should be fixed on the base branch of the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
