### PR TITLE
refactor(hub): remove deprecated ?token= fallback, finish error envelope migration

### DIFF
--- a/pkg/hub/analytics.go
+++ b/pkg/hub/analytics.go
@@ -52,13 +52,13 @@ type AnalyticsEvent struct {
 // handleFactoryAnalytics serves GET /api/factories/:name/analytics
 func (s *Server) handleFactoryAnalytics(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 		return
 	}
 	// Path: /api/factories/:name/analytics
 	parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/api/factories/"), "/")
 	if len(parts) < 2 || parts[1] != "analytics" {
-		http.Error(w, "not found", http.StatusNotFound)
+		writeErr(w, http.StatusNotFound, "not_found", "not found")
 		return
 	}
 	factoryName := parts[0]
@@ -79,7 +79,7 @@ func (s *Server) handleFactoryAnalytics(w http.ResponseWriter, r *http.Request) 
 	summary, err := s.computeFactoryAnalytics(factoryName, since)
 	if err != nil {
 		logfCtx(r.Context(), "[analytics] error computing analytics for %s: %v", factoryName, err)
-		http.Error(w, "db error", http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", "db error")
 		return
 	}
 
@@ -89,7 +89,7 @@ func (s *Server) handleFactoryAnalytics(w http.ResponseWriter, r *http.Request) 
 // handleAllFactoriesAnalytics serves GET /api/analytics/factories
 func (s *Server) handleAllFactoriesAnalytics(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 		return
 	}
 
@@ -113,7 +113,7 @@ func (s *Server) handleAllFactoriesAnalytics(w http.ResponseWriter, r *http.Requ
 	)
 	if err != nil {
 		logfCtx(r.Context(), "[analytics] error listing factories: %v", err)
-		http.Error(w, "db error", http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", "db error")
 		return
 	}
 	defer rows.Close()
@@ -128,7 +128,7 @@ func (s *Server) handleAllFactoriesAnalytics(w http.ResponseWriter, r *http.Requ
 	}
 	if err := rows.Err(); err != nil {
 		logfCtx(r.Context(), "[analytics] error iterating factory names: %v", err)
-		http.Error(w, "db error", http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", "db error")
 		return
 	}
 	var summaries []AnalyticsSummary

--- a/pkg/hub/auth.go
+++ b/pkg/hub/auth.go
@@ -87,7 +87,7 @@ func (s *Server) withConfigMutationAuth(next http.HandlerFunc) http.HandlerFunc 
 		if sessionSecret != "" {
 			if payload, ok := verifyGitHubSession(sessionSecret, token); ok {
 				if !isAccessAdmin(accessCfg, payload.Login) {
-					http.Error(w, "forbidden", http.StatusForbidden)
+					writeErr(w, http.StatusForbidden, "forbidden", "forbidden")
 					return
 				}
 				ctx := context.WithValue(r.Context(), ctxGitHubLoginKey{}, payload.Login)
@@ -97,7 +97,7 @@ func (s *Server) withConfigMutationAuth(next http.HandlerFunc) http.HandlerFunc 
 			}
 		}
 
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		writeErr(w, http.StatusUnauthorized, "unauthorized", "unauthorized")
 	}
 }
 
@@ -187,7 +187,7 @@ func (s *Server) withWebAuth(next http.HandlerFunc) http.HandlerFunc {
 			token = r.Header.Get(webSessionHeader)
 		}
 		if token == "" {
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			writeErr(w, http.StatusUnauthorized, "unauthorized", "unauthorized")
 			return
 		}
 		s.cfgMu.RLock()
@@ -212,7 +212,7 @@ func (s *Server) withWebAuth(next http.HandlerFunc) http.HandlerFunc {
 			}
 		}
 
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		writeErr(w, http.StatusUnauthorized, "unauthorized", "unauthorized")
 	}
 }
 
@@ -235,7 +235,7 @@ func (s *Server) withWebAdminAuth(next http.HandlerFunc) http.HandlerFunc {
 			token = r.Header.Get(webSessionHeader)
 		}
 		if token == "" {
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			writeErr(w, http.StatusUnauthorized, "unauthorized", "unauthorized")
 			return
 		}
 		s.cfgMu.RLock()
@@ -256,7 +256,7 @@ func (s *Server) withWebAdminAuth(next http.HandlerFunc) http.HandlerFunc {
 		if sessionSecret != "" {
 			if payload, ok := verifyGitHubSession(sessionSecret, token); ok {
 				if !isAccessAdmin(accessCfg, payload.Login) {
-					http.Error(w, "forbidden", http.StatusForbidden)
+					writeErr(w, http.StatusForbidden, "forbidden", "forbidden")
 					return
 				}
 				ctx := context.WithValue(r.Context(), ctxGitHubLoginKey{}, payload.Login)
@@ -266,7 +266,7 @@ func (s *Server) withWebAdminAuth(next http.HandlerFunc) http.HandlerFunc {
 			}
 		}
 
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		writeErr(w, http.StatusUnauthorized, "unauthorized", "unauthorized")
 	}
 }
 
@@ -340,19 +340,19 @@ func (s *Server) handleAuthConfig(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 		return
 	}
 	var body struct {
 		Token string `json:"token"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Token == "" {
-		http.Error(w, "invalid request", http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid request")
 		return
 	}
 	tenantID, err := s.tenantByToken(body.Token)
 	if err != nil {
-		http.Error(w, "invalid token", http.StatusUnauthorized)
+		writeErr(w, http.StatusUnauthorized, "unauthorized", "invalid token")
 		return
 	}
 	jsonOK(w, map[string]string{"tenant_id": tenantID, "token": body.Token})
@@ -374,19 +374,19 @@ func (s *Server) handleGitHubToken(w http.ResponseWriter, r *http.Request) {
 	hubClawToken := s.hubCfg.ClawToken
 	s.cfgMu.RUnlock()
 	if clawToken != hubClawToken {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		writeErr(w, http.StatusUnauthorized, "unauthorized", "unauthorized")
 		return
 	}
 
 	clawID := strings.TrimPrefix(r.URL.Path, "/api/github/token/")
 	if clawID == "" {
-		http.Error(w, "missing claw id", http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "missing claw id")
 		return
 	}
 
 	workspaceName, reposJSON, err := s.st().Claws().WorkspaceRepos(r.Context(), clawID)
 	if err != nil {
-		http.Error(w, "claw not found", http.StatusNotFound)
+		writeErr(w, http.StatusNotFound, "not_found", "claw not found")
 		return
 	}
 
@@ -429,7 +429,7 @@ func (s *Server) handleGitHubToken(w http.ResponseWriter, r *http.Request) {
 		githubApps = append(workspaceApps, githubApps...)
 	}
 	if len(githubApps) == 0 {
-		http.Error(w, "no github apps configured", http.StatusNotImplemented)
+		writeErr(w, http.StatusNotImplemented, "not_implemented", "no github apps configured")
 		return
 	}
 	for i, appCfg := range githubApps {
@@ -453,5 +453,5 @@ func (s *Server) handleGitHubToken(w http.ResponseWriter, r *http.Request) {
 	}
 
 	logfCtx(r.Context(), "no github app found with installation for repos %v (claw %s)", repos, clawID[:8])
-	http.Error(w, "no github installation found for the requested repos", http.StatusNotFound)
+	writeErr(w, http.StatusNotFound, "not_found", "no github installation found for the requested repos")
 }

--- a/pkg/hub/auth.go
+++ b/pkg/hub/auth.go
@@ -17,17 +17,18 @@ import (
 
 func (s *Server) withAuth(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		// Authorization header only. The deprecated ?token= query fallback was
+		// removed (Phase 2.6): tokens in URLs leak into access logs, proxy logs,
+		// and browser history. Endpoints that cannot set headers (WS upgrades,
+		// <img src>) authenticate with a single-use ticket instead.
 		token := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
 		if token == "" {
-			token = r.URL.Query().Get("token")
-		}
-		if token == "" {
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			writeErr(w, http.StatusUnauthorized, "unauthorized", "unauthorized")
 			return
 		}
 		tenantID, githubLogin, ok := s.resolveAuthToken(token)
 		if !ok {
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			writeErr(w, http.StatusUnauthorized, "unauthorized", "unauthorized")
 			return
 		}
 		ctx := context.WithValue(r.Context(), ctxTenantKey{}, tenantID)
@@ -58,17 +59,14 @@ func (s *Server) withAdminForMethods(next http.HandlerFunc, methods ...string) h
 
 func (s *Server) withConfigMutationAuth(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		// Authorization header or web session header only. The deprecated
+		// ?token= query fallback was removed (Phase 2.6).
 		token := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
 		if token == "" {
 			token = r.Header.Get(webSessionHeader)
 		}
-		queryToken := false
 		if token == "" {
-			token = r.URL.Query().Get("token")
-			queryToken = token != ""
-		}
-		if token == "" {
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			writeErr(w, http.StatusUnauthorized, "unauthorized", "unauthorized")
 			return
 		}
 
@@ -82,10 +80,6 @@ func (s *Server) withConfigMutationAuth(next http.HandlerFunc) http.HandlerFunc 
 
 		if token == hubToken && hubToken != "" {
 			next(w, r)
-			return
-		}
-		if queryToken {
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}
 

--- a/pkg/hub/auth_ticket.go
+++ b/pkg/hub/auth_ticket.go
@@ -1,0 +1,138 @@
+// Single-use auth tickets for endpoints that cannot send an Authorization
+// header from the browser: WebSocket upgrades (/api/ws, /api/terminal/{id})
+// and resources loaded via <img src> (/api/files/view/...).
+//
+// Flow (phase 0.3 of the re-arch plan, prerequisite for the phase 2.6
+// removal of the deprecated ?token= query fallback): the frontend calls
+// POST /api/auth/ticket with its normal Authorization header, receives an
+// opaque ticket with a short TTL that is redeemable exactly once, and
+// appends it as ?ticket= to the browser-only URL. Tickets never carry the
+// long-lived token, so a leaked URL (access logs, proxy logs, browser
+// history) is worthless after redemption or expiry.
+package hub
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/hub/logger"
+)
+
+// authTicketTTL is how long an issued ticket stays redeemable. Long enough
+// for the browser to turn around and open the WS / load the image, short
+// enough that a logged URL is stale almost immediately.
+const authTicketTTL = 30 * time.Second
+
+type authTicket struct {
+	tenantID    string
+	githubLogin string
+	expiresAt   time.Time
+}
+
+// authTicketStore is an in-memory single-use ticket registry. The zero
+// value is ready to use (hand-built test servers need no wiring); tickets
+// are process-local by design — a hub restart invalidates them, and the
+// frontend simply requests a new one.
+type authTicketStore struct {
+	mu      sync.Mutex
+	tickets map[string]authTicket
+}
+
+func (st *authTicketStore) issue(tenantID, githubLogin string) (string, error) {
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	ticket := hex.EncodeToString(buf)
+	now := time.Now()
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	if st.tickets == nil {
+		st.tickets = make(map[string]authTicket)
+	}
+	// Lazy purge keeps the map from growing with never-redeemed tickets
+	// without needing a background goroutine.
+	for k, v := range st.tickets {
+		if now.After(v.expiresAt) {
+			delete(st.tickets, k)
+		}
+	}
+	st.tickets[ticket] = authTicket{tenantID: tenantID, githubLogin: githubLogin, expiresAt: now.Add(authTicketTTL)}
+	return ticket, nil
+}
+
+// redeem consumes the ticket: a second redemption (or an expired ticket)
+// fails.
+func (st *authTicketStore) redeem(ticket string) (tenantID, githubLogin string, ok bool) {
+	if ticket == "" {
+		return "", "", false
+	}
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	entry, found := st.tickets[ticket]
+	if !found {
+		return "", "", false
+	}
+	delete(st.tickets, ticket)
+	if time.Now().After(entry.expiresAt) {
+		return "", "", false
+	}
+	return entry.tenantID, entry.githubLogin, true
+}
+
+// handleAuthTicket issues a single-use ticket for the authenticated caller.
+// Mounted behind withAuth, so the tenant (and GitHub login, when present)
+// come from the request context.
+func (s *Server) handleAuthTicket(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
+		return
+	}
+	githubLogin, _ := r.Context().Value(ctxGitHubLoginKey{}).(string)
+	ticket, err := s.authTickets.issue(tenantFromCtx(r), githubLogin)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, "internal", "failed to issue ticket")
+		return
+	}
+	jsonOK(w, map[string]interface{}{
+		"ticket":     ticket,
+		"expires_in": int(authTicketTTL.Seconds()),
+	})
+}
+
+// redeemAuthTicket exposes ticket redemption to subpackages (the claws
+// terminal handler authenticates on its own, outside withAuth).
+func (s *Server) redeemAuthTicket(ticket string) (tenantID string, ok bool) {
+	tenantID, _, ok = s.authTickets.redeem(ticket)
+	return tenantID, ok
+}
+
+// withAuthOrTicket authenticates like withAuth but additionally accepts a
+// single-use ?ticket= query parameter. It guards only the browser-only
+// endpoints that cannot set headers (WS upgrade, <img src>); everything
+// else keeps the header-only withAuth.
+func (s *Server) withAuthOrTicket(next http.HandlerFunc) http.HandlerFunc {
+	authed := s.withAuth(next)
+	return func(w http.ResponseWriter, r *http.Request) {
+		ticket := r.URL.Query().Get("ticket")
+		if ticket == "" {
+			authed(w, r)
+			return
+		}
+		tenantID, githubLogin, ok := s.authTickets.redeem(ticket)
+		if !ok {
+			writeErr(w, http.StatusUnauthorized, "unauthorized", "invalid or expired ticket")
+			return
+		}
+		ctx := context.WithValue(r.Context(), ctxTenantKey{}, tenantID)
+		ctx = logger.NewContext(ctx, logger.FromContext(ctx).With("tenant_id", tenantID))
+		if githubLogin != "" {
+			ctx = context.WithValue(ctx, ctxGitHubLoginKey{}, githubLogin)
+		}
+		next(w, r.WithContext(ctx))
+	}
+}

--- a/pkg/hub/auth_ticket_test.go
+++ b/pkg/hub/auth_ticket_test.go
@@ -1,0 +1,140 @@
+package hub
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func TestAuthTicketStoreSingleUseAndExpiry(t *testing.T) {
+	var st authTicketStore
+
+	ticket, err := st.issue("tenant-a", "octocat")
+	if err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+	tenantID, login, ok := st.redeem(ticket)
+	if !ok || tenantID != "tenant-a" || login != "octocat" {
+		t.Fatalf("redeem = (%q, %q, %v), want (tenant-a, octocat, true)", tenantID, login, ok)
+	}
+	if _, _, ok := st.redeem(ticket); ok {
+		t.Fatal("second redemption must fail (single-use)")
+	}
+	if _, _, ok := st.redeem("no-such-ticket"); ok {
+		t.Fatal("unknown ticket must fail")
+	}
+
+	expired, err := st.issue("tenant-b", "")
+	if err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+	st.mu.Lock()
+	entry := st.tickets[expired]
+	entry.expiresAt = time.Now().Add(-time.Second)
+	st.tickets[expired] = entry
+	st.mu.Unlock()
+	if _, _, ok := st.redeem(expired); ok {
+		t.Fatal("expired ticket must fail")
+	}
+}
+
+func TestAuthTicketEndToEndAuthorizesBrowserOnlyEndpoint(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{}, "", "", "")
+
+	// 1. Issue a ticket through the authenticated handler.
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/ticket", nil)
+	req.Header.Set("Authorization", "Bearer test-token")
+	rec := httptest.NewRecorder()
+	s.withAuth(s.handleAuthTicket)(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("issue ticket status = %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Ticket    string `json:"ticket"`
+		ExpiresIn int    `json:"expires_in"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode ticket response: %v", err)
+	}
+	if resp.Ticket == "" || resp.ExpiresIn <= 0 {
+		t.Fatalf("unexpected ticket response: %+v", resp)
+	}
+
+	// 2. Redeem it on a ticket-enabled endpoint: the tenant must land in ctx.
+	var gotTenant string
+	handler := s.withAuthOrTicket(func(w http.ResponseWriter, r *http.Request) {
+		gotTenant = tenantFromCtx(r)
+		w.WriteHeader(http.StatusNoContent)
+	})
+	wsReq := httptest.NewRequest(http.MethodGet, "/api/ws?ticket="+resp.Ticket, nil)
+	wsRec := httptest.NewRecorder()
+	handler(wsRec, wsReq)
+	if wsRec.Code != http.StatusNoContent {
+		t.Fatalf("ticket request status = %d: %s", wsRec.Code, wsRec.Body.String())
+	}
+	if gotTenant != "test-tenant-id" {
+		t.Fatalf("tenant from ticket = %q, want test-tenant-id", gotTenant)
+	}
+
+	// 3. Same ticket again: rejected (single-use).
+	wsReq = httptest.NewRequest(http.MethodGet, "/api/ws?ticket="+resp.Ticket, nil)
+	wsRec = httptest.NewRecorder()
+	handler(wsRec, wsReq)
+	if wsRec.Code != http.StatusUnauthorized {
+		t.Fatalf("reused ticket status = %d, want %d", wsRec.Code, http.StatusUnauthorized)
+	}
+
+	// 4. Without a ticket the middleware behaves like withAuth: header works,
+	// nothing at all does not.
+	wsReq = httptest.NewRequest(http.MethodGet, "/api/ws", nil)
+	wsReq.Header.Set("Authorization", "Bearer test-token")
+	wsRec = httptest.NewRecorder()
+	handler(wsRec, wsReq)
+	if wsRec.Code != http.StatusNoContent {
+		t.Fatalf("header auth status = %d, want %d", wsRec.Code, http.StatusNoContent)
+	}
+	wsReq = httptest.NewRequest(http.MethodGet, "/api/ws", nil)
+	wsRec = httptest.NewRecorder()
+	handler(wsRec, wsReq)
+	if wsRec.Code != http.StatusUnauthorized {
+		t.Fatalf("no-credential status = %d, want %d", wsRec.Code, http.StatusUnauthorized)
+	}
+
+	// 5. The deprecated ?token= stays rejected even on ticket endpoints.
+	wsReq = httptest.NewRequest(http.MethodGet, "/api/ws?token=test-token", nil)
+	wsRec = httptest.NewRecorder()
+	handler(wsRec, wsReq)
+	if wsRec.Code != http.StatusUnauthorized {
+		t.Fatalf("query token status = %d, want %d", wsRec.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestTerminalAcceptsTicketAuth(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{}, "", "", "")
+
+	ticket, err := s.authTickets.issue("test-tenant-id", "")
+	if err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+
+	// A valid ticket passes auth and reaches claw resolution (404: the claw
+	// does not exist), instead of failing with 401.
+	req := httptest.NewRequest(http.MethodGet, "/api/terminal/no-such-claw?ticket="+ticket, nil)
+	rec := httptest.NewRecorder()
+	s.handleTerminal(rec, req)
+	if rec.Code == http.StatusUnauthorized {
+		t.Fatalf("valid ticket rejected with 401: %s", rec.Body.String())
+	}
+
+	// A reused or bogus ticket is a 401.
+	req = httptest.NewRequest(http.MethodGet, "/api/terminal/no-such-claw?ticket="+ticket, nil)
+	rec = httptest.NewRecorder()
+	s.handleTerminal(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("reused ticket status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+}

--- a/pkg/hub/checkpoints/checkpoints.go
+++ b/pkg/hub/checkpoints/checkpoints.go
@@ -576,7 +576,7 @@ func (s *Service) InsertCheckpoint(id, tenantID, clawID, reason, createdBy, prov
 func (s *Service) HandleCheckpointInternal(w http.ResponseWriter, r *http.Request) {
 	parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/api/checkpoints/"), "/")
 	if len(parts) != 2 {
-		http.Error(w, "not found", http.StatusNotFound)
+		httpserver.WriteErr(w, http.StatusNotFound, "not_found", "not found")
 		return
 	}
 	checkpointID, action := parts[0], parts[1]
@@ -587,12 +587,12 @@ func (s *Service) HandleCheckpointInternal(w http.ResponseWriter, r *http.Reques
 	switch action {
 	case "plan":
 		if r.Method != http.MethodPost {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			httpserver.WriteErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 			return
 		}
 		var plan types.CheckpointPlan
 		if err := json.NewDecoder(r.Body).Decode(&plan); err != nil {
-			http.Error(w, "invalid plan", http.StatusBadRequest)
+			httpserver.WriteErr(w, http.StatusBadRequest, "bad_request", "invalid plan")
 			return
 		}
 		plan.CheckpointID = checkpointID
@@ -608,12 +608,12 @@ func (s *Service) HandleCheckpointInternal(w http.ResponseWriter, r *http.Reques
 		httpserver.JSONOK(w, types.CheckpointPlanAck{Upload: missing})
 	case "complete":
 		if r.Method != http.MethodPost {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			httpserver.WriteErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 			return
 		}
 		var complete types.CheckpointComplete
 		if err := json.NewDecoder(r.Body).Decode(&complete); err != nil {
-			http.Error(w, "invalid complete", http.StatusBadRequest)
+			httpserver.WriteErr(w, http.StatusBadRequest, "bad_request", "invalid complete")
 			return
 		}
 		if complete.Error != "" {
@@ -629,7 +629,7 @@ func (s *Service) HandleCheckpointInternal(w http.ResponseWriter, r *http.Reques
 			s.notifyCheckpointWaiter(checkpointID, err)
 			s.finishCheckpointRequest(clawID, checkpointID)
 			s.DrainPendingCheckpoint(clawID)
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			httpserver.WriteErr(w, http.StatusInternalServerError, "internal", err.Error())
 			return
 		}
 		s.notifyCheckpointWaiter(checkpointID, nil)
@@ -637,18 +637,18 @@ func (s *Service) HandleCheckpointInternal(w http.ResponseWriter, r *http.Reques
 		s.DrainPendingCheckpoint(clawID)
 		httpserver.JSONOK(w, map[string]string{"status": "ready"})
 	default:
-		http.Error(w, "not found", http.StatusNotFound)
+		httpserver.WriteErr(w, http.StatusNotFound, "not_found", "not found")
 	}
 }
 
 func (s *Service) HandleCheckpointBlobUpload(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPut {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		httpserver.WriteErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 		return
 	}
 	sha := strings.TrimPrefix(r.URL.Path, "/api/checkpoints/blob/")
 	if !validSHA256(sha) {
-		http.Error(w, "bad sha", http.StatusBadRequest)
+		httpserver.WriteErr(w, http.StatusBadRequest, "bad_request", "bad sha")
 		return
 	}
 	token := r.Header.Get("X-Claw-Token")
@@ -656,7 +656,7 @@ func (s *Service) HandleCheckpointBlobUpload(w http.ResponseWriter, r *http.Requ
 		token = r.URL.Query().Get("claw_token")
 	}
 	if _, err := s.tenantByClawToken(token); err != nil {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		httpserver.WriteErr(w, http.StatusUnauthorized, "unauthorized", "unauthorized")
 		return
 	}
 	r.Body = http.MaxBytesReader(w, r.Body, maxCheckpointBlobBytes)
@@ -666,13 +666,13 @@ func (s *Service) HandleCheckpointBlobUpload(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
-		http.Error(w, "storage error", http.StatusInternalServerError)
+		httpserver.WriteErr(w, http.StatusInternalServerError, "internal", "storage error")
 		return
 	}
 	tmp := path + ".tmp-" + uuid.New().String()
 	f, err := os.OpenFile(tmp, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o640)
 	if err != nil {
-		http.Error(w, "storage error", http.StatusInternalServerError)
+		httpserver.WriteErr(w, http.StatusInternalServerError, "internal", "storage error")
 		return
 	}
 	h := sha256.New()
@@ -682,15 +682,15 @@ func (s *Service) HandleCheckpointBlobUpload(w http.ResponseWriter, r *http.Requ
 		_ = os.Remove(tmp)
 		var maxBytesErr *http.MaxBytesError
 		if errors.As(copyErr, &maxBytesErr) {
-			http.Error(w, "blob too large", http.StatusRequestEntityTooLarge)
+			httpserver.WriteErr(w, http.StatusRequestEntityTooLarge, "request_too_large", "blob too large")
 			return
 		}
-		http.Error(w, "write error", http.StatusInternalServerError)
+		httpserver.WriteErr(w, http.StatusInternalServerError, "internal", "write error")
 		return
 	}
 	if got := hex.EncodeToString(h.Sum(nil)); got != sha {
 		_ = os.Remove(tmp)
-		http.Error(w, "sha mismatch", http.StatusBadRequest)
+		httpserver.WriteErr(w, http.StatusBadRequest, "bad_request", "sha mismatch")
 		return
 	}
 	if err := os.Rename(tmp, path); err != nil {
@@ -699,7 +699,7 @@ func (s *Service) HandleCheckpointBlobUpload(w http.ResponseWriter, r *http.Requ
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}
-		http.Error(w, "storage error", http.StatusInternalServerError)
+		httpserver.WriteErr(w, http.StatusInternalServerError, "internal", "storage error")
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
@@ -712,20 +712,20 @@ func (s *Service) authenticateCheckpointClaw(w http.ResponseWriter, r *http.Requ
 	}
 	resolvedTenant, err := s.tenantByClawToken(token)
 	if err != nil {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		httpserver.WriteErr(w, http.StatusUnauthorized, "unauthorized", "unauthorized")
 		return "", "", false
 	}
 	err = s.deps.DB.QueryRow(`SELECT tenant_id, claw_id FROM claw_checkpoints WHERE id=?`, checkpointID).Scan(&tenantID, &clawID)
 	if err == sql.ErrNoRows {
-		http.Error(w, "not found", http.StatusNotFound)
+		httpserver.WriteErr(w, http.StatusNotFound, "not_found", "not found")
 		return "", "", false
 	}
 	if err != nil {
-		http.Error(w, "db error", http.StatusInternalServerError)
+		httpserver.WriteErr(w, http.StatusInternalServerError, "internal", "db error")
 		return "", "", false
 	}
 	if tenantID != resolvedTenant {
-		http.Error(w, "forbidden", http.StatusForbidden)
+		httpserver.WriteErr(w, http.StatusForbidden, "forbidden", "forbidden")
 		return "", "", false
 	}
 	return tenantID, clawID, true

--- a/pkg/hub/checkpoints/volumes.go
+++ b/pkg/hub/checkpoints/volumes.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -407,8 +408,15 @@ func (s *Service) HandleVolumeArchive(w http.ResponseWriter, r *http.Request) {
 
 func (s *Service) handleVolumeArchiveGet(w http.ResponseWriter, r *http.Request, leaseID, clawID, accessToken string) {
 	manifestDigest, err := s.volumeLeaseManifest(r.Context(), leaseID, clawID, accessToken)
+	if errors.Is(err, errVolumeLeaseNotFound) {
+		httpserver.WriteErr(w, http.StatusNotFound, "not_found", errVolumeLeaseNotFound.Error())
+		return
+	}
 	if err != nil {
-		httpserver.WriteErr(w, http.StatusNotFound, "not_found", err.Error())
+		// DB/backend failure — not a missing lease. Log the detail; do not
+		// leak raw backend errors to the client.
+		logfCtx(r.Context(), "[volume] lease %s: manifest lookup failed: %v", leaseID, err)
+		httpserver.WriteErr(w, http.StatusInternalServerError, "internal", "volume lease lookup failed")
 		return
 	}
 	data, err := s.artifacts().GetManifest(r.Context(), manifestDigest)
@@ -434,16 +442,23 @@ func (s *Service) handleVolumeArchiveGet(w http.ResponseWriter, r *http.Request,
 func (s *Service) handleVolumeArchivePut(w http.ResponseWriter, r *http.Request, leaseID, clawID, accessToken string) {
 	var repo, tag, mode, attachedDigest string
 	if err := s.deps.DB.QueryRow(`SELECT repo, tag, mode, manifest_digest FROM volume_leases WHERE id=? AND claw_id=? AND access_token=? AND released_at IS NULL AND expires_at > ?`, leaseID, clawID, accessToken, time.Now().UTC()).Scan(&repo, &tag, &mode, &attachedDigest); err != nil {
-		httpserver.WriteErr(w, http.StatusNotFound, "not_found", "active lease not found")
+		if errors.Is(err, sql.ErrNoRows) {
+			httpserver.WriteErr(w, http.StatusNotFound, "not_found", "active lease not found")
+			return
+		}
+		logfCtx(r.Context(), "[volume] lease %s: lease lookup failed: %v", leaseID, err)
+		httpserver.WriteErr(w, http.StatusInternalServerError, "internal", "volume lease lookup failed")
 		return
 	}
 	if mode != volumeModeRW {
 		httpserver.WriteErr(w, http.StatusForbidden, "forbidden", "volume is read-only")
 		return
 	}
+	// A ref-resolution failure is an internal lookup error; 409 conflict is
+	// reserved for the digest-mismatch case below.
 	currentDigest, err := s.artifacts().ResolveRef(r.Context(), repo, tag)
 	if err != nil {
-		httpserver.WriteErr(w, http.StatusConflict, "conflict", "resolve volume ref: "+err.Error())
+		httpserver.WriteErr(w, http.StatusInternalServerError, "internal", "resolve volume ref: "+err.Error())
 		return
 	}
 	if currentDigest != attachedDigest {
@@ -481,11 +496,15 @@ func (s *Service) handleVolumeArchivePut(w http.ResponseWriter, r *http.Request,
 	httpserver.JSONOK(w, map[string]string{"manifest_digest": manifestDigest})
 }
 
+// errVolumeLeaseNotFound distinguishes a missing/expired lease (client 404)
+// from DB/backend failures (server 500) in the archive handlers.
+var errVolumeLeaseNotFound = errors.New("active lease not found")
+
 func (s *Service) volumeLeaseManifest(ctx context.Context, leaseID, clawID, accessToken string) (string, error) {
 	var digest string
 	err := s.deps.DB.QueryRowContext(ctx, `SELECT manifest_digest FROM volume_leases WHERE id=? AND claw_id=? AND access_token=? AND released_at IS NULL AND expires_at > ?`, leaseID, clawID, accessToken, time.Now().UTC()).Scan(&digest)
-	if err == sql.ErrNoRows {
-		return "", fmt.Errorf("active lease not found")
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", errVolumeLeaseNotFound
 	}
 	return digest, err
 }

--- a/pkg/hub/checkpoints/volumes.go
+++ b/pkg/hub/checkpoints/volumes.go
@@ -383,7 +383,7 @@ func (s *Service) dispatchVolumeSync(ctx context.Context, cc Conn, volume Workfl
 func (s *Service) HandleVolumeArchive(w http.ResponseWriter, r *http.Request) {
 	leaseID := strings.TrimSpace(r.PathValue("lease"))
 	if leaseID == "" {
-		http.Error(w, "lease required", http.StatusBadRequest)
+		httpserver.WriteErr(w, http.StatusBadRequest, "bad_request", "lease required")
 		return
 	}
 	if !s.authenticateClawToken(w, r) {
@@ -392,7 +392,7 @@ func (s *Service) HandleVolumeArchive(w http.ResponseWriter, r *http.Request) {
 	clawID := strings.TrimSpace(r.Header.Get("X-Claw-ID"))
 	accessToken := strings.TrimSpace(r.Header.Get("X-Volume-Token"))
 	if clawID == "" || accessToken == "" {
-		http.Error(w, "volume lease credentials required", http.StatusUnauthorized)
+		httpserver.WriteErr(w, http.StatusUnauthorized, "unauthorized", "volume lease credentials required")
 		return
 	}
 	switch r.Method {
@@ -401,29 +401,29 @@ func (s *Service) HandleVolumeArchive(w http.ResponseWriter, r *http.Request) {
 	case http.MethodPut:
 		s.handleVolumeArchivePut(w, r, leaseID, clawID, accessToken)
 	default:
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		httpserver.WriteErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 	}
 }
 
 func (s *Service) handleVolumeArchiveGet(w http.ResponseWriter, r *http.Request, leaseID, clawID, accessToken string) {
 	manifestDigest, err := s.volumeLeaseManifest(r.Context(), leaseID, clawID, accessToken)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusNotFound)
+		httpserver.WriteErr(w, http.StatusNotFound, "not_found", err.Error())
 		return
 	}
 	data, err := s.artifacts().GetManifest(r.Context(), manifestDigest)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		httpserver.WriteErr(w, http.StatusInternalServerError, "internal", err.Error())
 		return
 	}
 	var manifest volumeManifest
 	if err := json.Unmarshal(data, &manifest); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		httpserver.WriteErr(w, http.StatusInternalServerError, "internal", err.Error())
 		return
 	}
 	body, err := s.artifacts().GetBlob(r.Context(), manifest.Layer.Digest)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		httpserver.WriteErr(w, http.StatusInternalServerError, "internal", err.Error())
 		return
 	}
 	defer body.Close()
@@ -434,25 +434,25 @@ func (s *Service) handleVolumeArchiveGet(w http.ResponseWriter, r *http.Request,
 func (s *Service) handleVolumeArchivePut(w http.ResponseWriter, r *http.Request, leaseID, clawID, accessToken string) {
 	var repo, tag, mode, attachedDigest string
 	if err := s.deps.DB.QueryRow(`SELECT repo, tag, mode, manifest_digest FROM volume_leases WHERE id=? AND claw_id=? AND access_token=? AND released_at IS NULL AND expires_at > ?`, leaseID, clawID, accessToken, time.Now().UTC()).Scan(&repo, &tag, &mode, &attachedDigest); err != nil {
-		http.Error(w, "active lease not found", http.StatusNotFound)
+		httpserver.WriteErr(w, http.StatusNotFound, "not_found", "active lease not found")
 		return
 	}
 	if mode != volumeModeRW {
-		http.Error(w, "volume is read-only", http.StatusForbidden)
+		httpserver.WriteErr(w, http.StatusForbidden, "forbidden", "volume is read-only")
 		return
 	}
 	currentDigest, err := s.artifacts().ResolveRef(r.Context(), repo, tag)
 	if err != nil {
-		http.Error(w, "resolve volume ref: "+err.Error(), http.StatusConflict)
+		httpserver.WriteErr(w, http.StatusConflict, "conflict", "resolve volume ref: "+err.Error())
 		return
 	}
 	if currentDigest != attachedDigest {
-		http.Error(w, "volume changed since lease was acquired", http.StatusConflict)
+		httpserver.WriteErr(w, http.StatusConflict, "conflict", "volume changed since lease was acquired")
 		return
 	}
 	layerDigest, size, err := s.artifacts().PutBlob(r.Context(), r.Body)
 	if err != nil {
-		http.Error(w, "store volume layer: "+err.Error(), http.StatusInternalServerError)
+		httpserver.WriteErr(w, http.StatusInternalServerError, "internal", "store volume layer: "+err.Error())
 		return
 	}
 	manifest := volumeManifest{
@@ -468,11 +468,11 @@ func (s *Service) handleVolumeArchivePut(w http.ResponseWriter, r *http.Request,
 	data, _ := json.Marshal(manifest)
 	manifestDigest, err := s.artifacts().PutManifest(r.Context(), data)
 	if err != nil {
-		http.Error(w, "store volume manifest: "+err.Error(), http.StatusInternalServerError)
+		httpserver.WriteErr(w, http.StatusInternalServerError, "internal", "store volume manifest: "+err.Error())
 		return
 	}
 	if err := s.artifacts().Tag(r.Context(), repo, tag, manifestDigest); err != nil {
-		http.Error(w, "tag volume: "+err.Error(), http.StatusInternalServerError)
+		httpserver.WriteErr(w, http.StatusInternalServerError, "internal", "tag volume: "+err.Error())
 		return
 	}
 	if _, err := s.deps.DB.Exec(`UPDATE volume_leases SET manifest_digest=?, heartbeat_at=? WHERE id=? AND claw_id=? AND access_token=?`, manifestDigest, time.Now().UTC(), leaseID, clawID, accessToken); err != nil {
@@ -499,7 +499,7 @@ func (s *Service) authenticateClawToken(w http.ResponseWriter, r *http.Request) 
 	want := s.hubCfg().ClawToken
 	s.deps.CfgMu.RUnlock()
 	if token == "" || want == "" || token != want {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		httpserver.WriteErr(w, http.StatusUnauthorized, "unauthorized", "unauthorized")
 		return false
 	}
 	return true

--- a/pkg/hub/claws/deps.go
+++ b/pkg/hub/claws/deps.go
@@ -54,6 +54,11 @@ type Deps struct {
 	TenantByClawToken func(token string) (string, error)
 	TenantByToken     func(token string) (string, error)
 	TenantFromRequest func(r *http.Request) string
+	// RedeemAuthTicket resolves a single-use ?ticket= (issued by
+	// POST /api/auth/ticket) to a tenant. Browser WS upgrades cannot set
+	// an Authorization header, so the terminal handler authenticates with
+	// a ticket instead. May be nil in hand-built test servers.
+	RedeemAuthTicket func(ticket string) (tenantID string, ok bool)
 
 	// FileAckMu guards the file/volume ack waiter maps below; the
 	// accessors return the hub-owned maps and must be called with
@@ -163,6 +168,13 @@ func (s *Service) tenantByClawToken(token string) (string, error) {
 
 func (s *Service) tenantByToken(token string) (string, error) {
 	return s.deps.TenantByToken(token)
+}
+
+func (s *Service) redeemAuthTicket(ticket string) (string, bool) {
+	if s.deps.RedeemAuthTicket == nil {
+		return "", false
+	}
+	return s.deps.RedeemAuthTicket(ticket)
 }
 
 func (s *Service) broadcastToUsers(tenantID string, msg types.WSMessage) {

--- a/pkg/hub/claws/files.go
+++ b/pkg/hub/claws/files.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/elasticclaw/elasticclaw/pkg/hub/httpserver"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 	"github.com/google/uuid"
 	"nhooyr.io/websocket/wsjson"
@@ -47,7 +48,7 @@ type uploadedAttachment struct {
 // subsequent message submission.
 func (s *Service) HandleFileUpload(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		httpserver.WriteErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 		return
 	}
 	clawID := r.PathValue("clawID")
@@ -55,53 +56,53 @@ func (s *Service) HandleFileUpload(w http.ResponseWriter, r *http.Request) {
 		clawID = strings.TrimPrefix(r.URL.Path, "/api/files/")
 	}
 	if clawID == "" {
-		http.Error(w, "missing claw id", http.StatusBadRequest)
+		httpserver.WriteErr(w, http.StatusBadRequest, "bad_request", "missing claw id")
 		return
 	}
 
 	// Bound the request body before parsing multipart.
 	r.Body = http.MaxBytesReader(w, r.Body, maxTotalBytes+(1<<20))
 	if err := r.ParseMultipartForm(maxTotalBytes); err != nil {
-		http.Error(w, "upload too large or malformed", http.StatusBadRequest)
+		httpserver.WriteErr(w, http.StatusBadRequest, "bad_request", "upload too large or malformed")
 		return
 	}
 	files := r.MultipartForm.File[uploadFormField]
 	if len(files) == 0 {
-		http.Error(w, "no files", http.StatusBadRequest)
+		httpserver.WriteErr(w, http.StatusBadRequest, "bad_request", "no files")
 		return
 	}
 	if len(files) > maxFilesPerReq {
-		http.Error(w, "too many files", http.StatusBadRequest)
+		httpserver.WriteErr(w, http.StatusBadRequest, "bad_request", "too many files")
 		return
 	}
 
 	cc := s.reg.Lookup(clawID)
 	if cc == nil {
-		http.Error(w, "claw not connected", http.StatusConflict)
+		httpserver.WriteErr(w, http.StatusConflict, "conflict", "claw not connected")
 		return
 	}
 
 	tenantID := s.tenantFromCtx(r)
 	if cc.TenantID != tenantID {
-		http.Error(w, "forbidden", http.StatusForbidden)
+		httpserver.WriteErr(w, http.StatusForbidden, "forbidden", "forbidden")
 		return
 	}
 
 	out := make([]uploadedAttachment, 0, len(files))
 	for _, fh := range files {
 		if fh.Size > maxFileBytes {
-			http.Error(w, "file too large: "+fh.Filename, http.StatusRequestEntityTooLarge)
+			httpserver.WriteErr(w, http.StatusRequestEntityTooLarge, "request_too_large", "file too large: "+fh.Filename)
 			return
 		}
 		f, err := fh.Open()
 		if err != nil {
-			http.Error(w, "open: "+fh.Filename, http.StatusBadRequest)
+			httpserver.WriteErr(w, http.StatusBadRequest, "bad_request", "open: "+fh.Filename)
 			return
 		}
 		data, err := io.ReadAll(f)
 		_ = f.Close()
 		if err != nil {
-			http.Error(w, "read: "+fh.Filename, http.StatusBadRequest)
+			httpserver.WriteErr(w, http.StatusBadRequest, "bad_request", "read: "+fh.Filename)
 			return
 		}
 		mime := fh.Header.Get("Content-Type")
@@ -128,7 +129,7 @@ func (s *Service) HandleFileUpload(w http.ResponseWriter, r *http.Request) {
 			s.fileAckMu.Lock()
 			delete(s.fileAckWaiters(), reqID)
 			s.fileAckMu.Unlock()
-			http.Error(w, "send to claw failed", http.StatusBadGateway)
+			httpserver.WriteErr(w, http.StatusBadGateway, "bad_gateway", "send to claw failed")
 			return
 		}
 
@@ -136,7 +137,7 @@ func (s *Service) HandleFileUpload(w http.ResponseWriter, r *http.Request) {
 		case ack := <-ch:
 			cancel()
 			if !ack.OK {
-				http.Error(w, "claw rejected file: "+ack.Error, http.StatusBadGateway)
+				httpserver.WriteErr(w, http.StatusBadGateway, "bad_gateway", "claw rejected file: "+ack.Error)
 				return
 			}
 			out = append(out, uploadedAttachment{
@@ -150,7 +151,7 @@ func (s *Service) HandleFileUpload(w http.ResponseWriter, r *http.Request) {
 			s.fileAckMu.Lock()
 			delete(s.fileAckWaiters(), reqID)
 			s.fileAckMu.Unlock()
-			http.Error(w, "timeout waiting for claw ack", http.StatusGatewayTimeout)
+			httpserver.WriteErr(w, http.StatusGatewayTimeout, "gateway_timeout", "timeout waiting for claw ack")
 			return
 		}
 	}
@@ -181,7 +182,7 @@ func isActiveContentType(ct, ext string) bool {
 // rejected at the claw even if a caller crafts a malicious path query.
 func (s *Service) HandleFileView(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		httpserver.WriteErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 		return
 	}
 	clawID := r.PathValue("clawID")
@@ -190,19 +191,19 @@ func (s *Service) HandleFileView(w http.ResponseWriter, r *http.Request) {
 	}
 	path := r.URL.Query().Get("path")
 	if clawID == "" || path == "" {
-		http.Error(w, "missing claw id or path", http.StatusBadRequest)
+		httpserver.WriteErr(w, http.StatusBadRequest, "bad_request", "missing claw id or path")
 		return
 	}
 
 	cc := s.reg.Lookup(clawID)
 	if cc == nil {
-		http.Error(w, "claw not connected", http.StatusConflict)
+		httpserver.WriteErr(w, http.StatusConflict, "conflict", "claw not connected")
 		return
 	}
 
 	tenantID := s.tenantFromCtx(r)
 	if cc.TenantID != tenantID {
-		http.Error(w, "forbidden", http.StatusForbidden)
+		httpserver.WriteErr(w, http.StatusForbidden, "forbidden", "forbidden")
 		return
 	}
 
@@ -222,19 +223,19 @@ func (s *Service) HandleFileView(w http.ResponseWriter, r *http.Request) {
 		s.fileAckMu.Lock()
 		delete(s.fileReadWaiters(), reqID)
 		s.fileAckMu.Unlock()
-		http.Error(w, "send to claw failed", http.StatusBadGateway)
+		httpserver.WriteErr(w, http.StatusBadGateway, "bad_gateway", "send to claw failed")
 		return
 	}
 
 	select {
 	case resp := <-ch:
 		if !resp.OK {
-			http.Error(w, "claw read failed: "+resp.Error, http.StatusBadGateway)
+			httpserver.WriteErr(w, http.StatusBadGateway, "bad_gateway", "claw read failed: "+resp.Error)
 			return
 		}
 		data, err := base64.StdEncoding.DecodeString(resp.Data)
 		if err != nil {
-			http.Error(w, "decode failed", http.StatusBadGateway)
+			httpserver.WriteErr(w, http.StatusBadGateway, "bad_gateway", "decode failed")
 			return
 		}
 		ext := strings.ToLower(filepath.Ext(path))
@@ -258,6 +259,6 @@ func (s *Service) HandleFileView(w http.ResponseWriter, r *http.Request) {
 		s.fileAckMu.Lock()
 		delete(s.fileReadWaiters(), reqID)
 		s.fileAckMu.Unlock()
-		http.Error(w, "timeout waiting for claw", http.StatusGatewayTimeout)
+		httpserver.WriteErr(w, http.StatusGatewayTimeout, "gateway_timeout", "timeout waiting for claw")
 	}
 }

--- a/pkg/hub/claws/terminal.go
+++ b/pkg/hub/claws/terminal.go
@@ -15,20 +15,33 @@ import (
 	gossh "golang.org/x/crypto/ssh"
 	"nhooyr.io/websocket"
 
+	"github.com/elasticclaw/elasticclaw/pkg/hub/httpserver"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
 
 // HandleTerminal upgrades the request to a WebSocket and bridges it to an
 // SSH PTY session on the claw's VM.
 func (s *Service) HandleTerminal(w http.ResponseWriter, r *http.Request) {
-	// Auth: Authorization header only. The deprecated ?token= query fallback
-	// was removed (Phase 2.6); browser clients that cannot set headers on a
-	// WebSocket upgrade authenticate with a single-use ticket.
-	token := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
-	tenantID, err := s.tenantByToken(token)
-	if err != nil {
-		s.writeDomainErr(w, types.ErrUnauthorized)
-		return
+	// Auth: Authorization header, or a single-use ?ticket= (issued by
+	// POST /api/auth/ticket) for browsers, which cannot set headers on a
+	// WebSocket upgrade. The deprecated ?token= query fallback was removed
+	// (Phase 2.6).
+	var tenantID string
+	if ticket := r.URL.Query().Get("ticket"); ticket != "" {
+		var ok bool
+		tenantID, ok = s.redeemAuthTicket(ticket)
+		if !ok {
+			s.writeDomainErr(w, types.ErrUnauthorized)
+			return
+		}
+	} else {
+		token := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+		var err error
+		tenantID, err = s.tenantByToken(token)
+		if err != nil {
+			s.writeDomainErr(w, types.ErrUnauthorized)
+			return
+		}
 	}
 
 	clawID := strings.TrimPrefix(r.URL.Path, "/api/terminal/")

--- a/pkg/hub/claws/terminal.go
+++ b/pkg/hub/claws/terminal.go
@@ -33,7 +33,7 @@ func (s *Service) HandleTerminal(w http.ResponseWriter, r *http.Request) {
 
 	clawID := strings.TrimPrefix(r.URL.Path, "/api/terminal/")
 	if clawID == "" {
-		http.Error(w, "missing claw id", http.StatusBadRequest)
+		httpserver.WriteErr(w, http.StatusBadRequest, "bad_request", "missing claw id")
 		return
 	}
 
@@ -44,11 +44,11 @@ func (s *Service) HandleTerminal(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err != nil {
-		http.Error(w, "db error", http.StatusInternalServerError)
+		httpserver.WriteErr(w, http.StatusInternalServerError, "internal", "db error")
 		return
 	}
 	if sshHost == "" || sshPort == 0 {
-		http.Error(w, "ssh not available for this claw", http.StatusServiceUnavailable)
+		httpserver.WriteErr(w, http.StatusServiceUnavailable, "unavailable", "ssh not available for this claw")
 		return
 	}
 

--- a/pkg/hub/claws/terminal.go
+++ b/pkg/hub/claws/terminal.go
@@ -21,11 +21,10 @@ import (
 // HandleTerminal upgrades the request to a WebSocket and bridges it to an
 // SSH PTY session on the claw's VM.
 func (s *Service) HandleTerminal(w http.ResponseWriter, r *http.Request) {
-	// Auth via token query param
-	token := r.URL.Query().Get("token")
-	if token == "" {
-		token = strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
-	}
+	// Auth: Authorization header only. The deprecated ?token= query fallback
+	// was removed (Phase 2.6); browser clients that cannot set headers on a
+	// WebSocket upgrade authenticate with a single-use ticket.
+	token := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
 	tenantID, err := s.tenantByToken(token)
 	if err != nil {
 		s.writeDomainErr(w, types.ErrUnauthorized)

--- a/pkg/hub/claws_bridge.go
+++ b/pkg/hub/claws_bridge.go
@@ -50,6 +50,7 @@ func (s *Server) clawsSvc() *claws.Service {
 		TenantByClawToken: s.tenantByClawToken,
 		TenantByToken:     s.tenantByToken,
 		TenantFromRequest: tenantFromCtx,
+		RedeemAuthTicket:  s.redeemAuthTicket,
 
 		FileAckMu: &s.fileAckMu,
 		FileAckWaiters: func() map[string]chan types.FileAck {

--- a/pkg/hub/client.go
+++ b/pkg/hub/client.go
@@ -141,9 +141,13 @@ func (c *Client) WatchMessages(ctx context.Context, clawID string, onMessage fun
 	} else if strings.HasPrefix(wsURL, "https://") {
 		wsURL = "wss://" + wsURL[8:]
 	}
-	wsURL += "/api/ws?token=" + c.token
+	// The deprecated ?token= query auth was removed (Phase 2.6); Go clients
+	// can set headers on the upgrade request, so send the Bearer token there.
+	wsURL += "/api/ws"
 
-	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	conn, _, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{
+		HTTPHeader: http.Header{"Authorization": {"Bearer " + c.token}},
+	})
 	if err != nil {
 		return fmt.Errorf("ws connect: %w", err)
 	}
@@ -178,9 +182,13 @@ func (c *Client) WatchStream(ctx context.Context, clawID string, onChunk func(ch
 	} else if strings.HasPrefix(wsURL, "https://") {
 		wsURL = "wss://" + wsURL[8:]
 	}
-	wsURL += "/api/ws?token=" + c.token
+	// The deprecated ?token= query auth was removed (Phase 2.6); Go clients
+	// can set headers on the upgrade request, so send the Bearer token there.
+	wsURL += "/api/ws"
 
-	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	conn, _, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{
+		HTTPHeader: http.Header{"Authorization": {"Bearer " + c.token}},
+	})
 	if err != nil {
 		return fmt.Errorf("ws connect: %w", err)
 	}

--- a/pkg/hub/dependency_status.go
+++ b/pkg/hub/dependency_status.go
@@ -302,7 +302,7 @@ func (s *dependencyStatusService) checkTargets(ctx context.Context, targets []de
 
 func (s *Server) handleDependencyStatus(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 		return
 	}
 	s.cfgMu.RLock()

--- a/pkg/hub/httpserver/router.go
+++ b/pkg/hub/httpserver/router.go
@@ -11,6 +11,11 @@ import (
 type Auth interface {
 	// WithAuth requires a valid API token (tenant or web session).
 	WithAuth(next http.HandlerFunc) http.HandlerFunc
+	// WithAuthOrTicket is WithAuth plus acceptance of a single-use
+	// ?ticket= query parameter (issued by POST /api/auth/ticket) for
+	// browser-only endpoints that cannot send headers: WebSocket
+	// upgrades and <img src> resources.
+	WithAuthOrTicket(next http.HandlerFunc) http.HandlerFunc
 	// WithWebAuth requires a valid web UI session.
 	WithWebAuth(next http.HandlerFunc) http.HandlerFunc
 	// WithWebAdminAuth requires a web UI session with admin rights.
@@ -35,6 +40,7 @@ type Handlers struct {
 
 	// Auth + branding
 	Login               http.HandlerFunc
+	AuthTicket          http.HandlerFunc
 	WebLogin            http.HandlerFunc
 	WebLogout           http.HandlerFunc
 	WebMe               http.HandlerFunc
@@ -130,11 +136,13 @@ func RegisterRoutes(mux *http.ServeMux, auth Auth, h Handlers) {
 	// Claw WebSocket
 	mux.HandleFunc("/claw/ws", h.ClawWS)
 
-	// Browser WebSocket
-	mux.HandleFunc("/api/ws", auth.WithAuth(h.UserWS))
+	// Browser WebSocket (browsers cannot set Authorization on the WS
+	// upgrade, so a single-use ticket is accepted as well)
+	mux.HandleFunc("/api/ws", auth.WithAuthOrTicket(h.UserWS))
 
 	// REST API
 	mux.HandleFunc("/api/login", h.Login)
+	mux.HandleFunc("/api/auth/ticket", auth.WithAuth(h.AuthTicket))
 	mux.HandleFunc("/api/auth/login", h.WebLogin)
 	mux.HandleFunc("/api/auth/logout", h.WebLogout)
 	mux.HandleFunc("/api/auth/me", auth.WithWebAuth(h.WebMe))
@@ -197,7 +205,9 @@ func RegisterRoutes(mux *http.ServeMux, auth Auth, h Handlers) {
 	mux.HandleFunc("/api/github/token/", h.GitHubToken) // credential helper endpoint (claw-token auth)
 	mux.HandleFunc("/api/messages/", auth.WithAuth(h.Messages))
 	mux.HandleFunc("/api/files/", auth.WithAuth(h.FileUpload))
-	mux.HandleFunc("/api/files/view/", auth.WithAuth(h.FileView))
+	// File preview is loaded via <img src>, which cannot set headers —
+	// accept a single-use ticket as well.
+	mux.HandleFunc("/api/files/view/", auth.WithAuthOrTicket(h.FileView))
 	mux.HandleFunc("/api/claws/", auth.WithAuth(h.ClawSubresource)) // /api/claws/:id/prs, /api/claws/:id/settings
 
 	// AI Config

--- a/pkg/hub/httpserver/router.go
+++ b/pkg/hub/httpserver/router.go
@@ -225,7 +225,7 @@ func RegisterRoutes(mux *http.ServeMux, auth Auth, h Handlers) {
 				return
 			}
 			if r.URL.Query().Get("token") != bridgeToken {
-				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				WriteErr(w, http.StatusUnauthorized, "unauthorized", "unauthorized")
 				return
 			}
 			http.ServeFile(w, r, bridgePath)

--- a/pkg/hub/hub.go
+++ b/pkg/hub/hub.go
@@ -62,6 +62,9 @@ type Server struct {
 	wsPool claws.WorkerPool
 	// userReg is the user-session registry (own lock, zero value ready).
 	userReg userRegistry
+	// authTickets holds single-use tickets for browser-only endpoints that
+	// cannot send Authorization headers (own lock, zero value ready).
+	authTickets authTicketStore
 	// one-time oauth_code -> signed GitHub session token
 
 	dependencyStatus *dependencyStatusService
@@ -227,6 +230,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 		UserWS: s.handleUserWS,
 
 		Login:               s.handleLogin,
+		AuthTicket:          s.handleAuthTicket,
 		WebLogin:            s.handleWebLogin,
 		WebLogout:           s.handleWebLogout,
 		WebMe:               s.handleWebMe,
@@ -317,6 +321,10 @@ func (s *Server) base() context.Context {
 type serverAuth struct{ s *Server }
 
 func (a serverAuth) WithAuth(next http.HandlerFunc) http.HandlerFunc { return a.s.withAuth(next) }
+
+func (a serverAuth) WithAuthOrTicket(next http.HandlerFunc) http.HandlerFunc {
+	return a.s.withAuthOrTicket(next)
+}
 
 func (a serverAuth) WithWebAuth(next http.HandlerFunc) http.HandlerFunc {
 	return a.s.withWebAuth(next)

--- a/pkg/hub/hub_test.go
+++ b/pkg/hub/hub_test.go
@@ -910,14 +910,16 @@ func TestAdminForMethodsRequiresAdminForMutations(t *testing.T) {
 		t.Fatalf("expected handler to be called for hub-token mutation, got %d calls", calls)
 	}
 
+	// The deprecated ?token= query fallback was removed (Phase 2.6): even a
+	// valid hub token in the query string is rejected.
 	req = httptest.NewRequest(http.MethodPost, "/api/config?token=hub-token", nil)
 	rec = httptest.NewRecorder()
 	handler(rec, req)
-	if rec.Code != http.StatusNoContent {
-		t.Fatalf("expected mutation method to allow hub query token, got %d", rec.Code)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected mutation method to reject hub query token with %d, got %d", http.StatusUnauthorized, rec.Code)
 	}
-	if calls != 4 {
-		t.Fatalf("expected handler to be called for hub query-token mutation, got %d calls", calls)
+	if calls != 3 {
+		t.Fatalf("expected handler not to be called for hub query-token mutation, got %d calls", calls)
 	}
 
 	req = httptest.NewRequest(http.MethodPost, "/api/config?token=test-token", nil)
@@ -926,7 +928,7 @@ func TestAdminForMethodsRequiresAdminForMutations(t *testing.T) {
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("expected mutation method to reject tenant query token with %d, got %d", http.StatusUnauthorized, rec.Code)
 	}
-	if calls != 4 {
+	if calls != 3 {
 		t.Fatalf("expected handler not to be called for tenant query-token mutation, got %d calls", calls)
 	}
 }

--- a/pkg/hub/integrations/external_webhook.go
+++ b/pkg/hub/integrations/external_webhook.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"strings"
 
+	"github.com/elasticclaw/elasticclaw/pkg/hub/httpserver"
 	"github.com/elasticclaw/elasticclaw/pkg/hub/settings"
 
 	"github.com/elasticclaw/elasticclaw/pkg/config"
@@ -62,13 +63,13 @@ type ExternalWebhookPayload struct {
 // This endpoint accepts generic webhooks and GitHub release events.
 func (s *Service) HandleExternalWebhook(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		httpserver.WriteErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 		return
 	}
 
 	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
 	if err != nil {
-		http.Error(w, "read error", http.StatusBadRequest)
+		httpserver.WriteErr(w, http.StatusBadRequest, "bad_request", "read error")
 		return
 	}
 
@@ -120,7 +121,7 @@ func (s *Service) HandleExternalWebhook(w http.ResponseWriter, r *http.Request) 
 		}
 		if err := json.Unmarshal(body, &ghReleasePayload); err != nil {
 			logfCtx(r.Context(), "[external-webhook] failed to parse release payload: %v", err)
-			http.Error(w, "invalid payload", http.StatusBadRequest)
+			httpserver.WriteErr(w, http.StatusBadRequest, "bad_request", "invalid payload")
 			return
 		}
 		payload.EventType = ghReleasePayload.Action
@@ -140,7 +141,7 @@ func (s *Service) HandleExternalWebhook(w http.ResponseWriter, r *http.Request) 
 		// Generic webhook - try to parse as our standard payload format
 		if err := json.Unmarshal(body, &payload); err != nil {
 			logfCtx(r.Context(), "[external-webhook] failed to parse generic payload: %v", err)
-			http.Error(w, "invalid payload", http.StatusBadRequest)
+			httpserver.WriteErr(w, http.StatusBadRequest, "bad_request", "invalid payload")
 			return
 		}
 		logfCtx(r.Context(), "[external-webhook] generic event: type=%q repo=%q",

--- a/pkg/hub/integrations/github_issues.go
+++ b/pkg/hub/integrations/github_issues.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/elasticclaw/elasticclaw/pkg/config"
+	"github.com/elasticclaw/elasticclaw/pkg/hub/httpserver"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 	"github.com/google/uuid"
 )
@@ -75,7 +76,7 @@ type GitHubIssueComment struct {
 func (s *Service) HandleGitHubIssuesWebhook(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		logfCtx(r.Context(), "[github-issues-webhook] %s %s → 405 method not allowed", r.Method, r.URL.Path)
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		httpserver.WriteErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 		return
 	}
 	workspaceName := strings.TrimSpace(r.PathValue("workspace"))
@@ -83,7 +84,7 @@ func (s *Service) HandleGitHubIssuesWebhook(w http.ResponseWriter, r *http.Reque
 	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
 	if err != nil {
 		logfCtx(r.Context(), "[github-issues-webhook] %s %s → 400 read error: %v", r.Method, r.URL.Path, err)
-		http.Error(w, "read error", http.StatusBadRequest)
+		httpserver.WriteErr(w, http.StatusBadRequest, "bad_request", "read error")
 		return
 	}
 
@@ -92,13 +93,13 @@ func (s *Service) HandleGitHubIssuesWebhook(w http.ResponseWriter, r *http.Reque
 	reason := s.validateGitHubIssuesSignatureReason(workspaceName, body, sig)
 	if reason != "" {
 		logfCtx(r.Context(), "[github-issues-webhook] %s %s → 401 %s (sig present=%v)", r.Method, r.URL.Path, reason, sig != "")
-		http.Error(w, "invalid signature", http.StatusUnauthorized)
+		httpserver.WriteErr(w, http.StatusUnauthorized, "unauthorized", "invalid signature")
 		return
 	}
 
 	var payload GitHubIssuesWebhookPayload
 	if err := json.Unmarshal(body, &payload); err != nil {
-		http.Error(w, "invalid payload", http.StatusBadRequest)
+		httpserver.WriteErr(w, http.StatusBadRequest, "bad_request", "invalid payload")
 		return
 	}
 

--- a/pkg/hub/integrations/github_webhook.go
+++ b/pkg/hub/integrations/github_webhook.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/elasticclaw/elasticclaw/pkg/config"
+	"github.com/elasticclaw/elasticclaw/pkg/hub/httpserver"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 	"github.com/google/uuid"
 )
@@ -44,13 +45,13 @@ type GitHubPRPayload struct {
 // HandleGitHubWebhook processes incoming GitHub webhook events.
 func (s *Service) HandleGitHubWebhook(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		httpserver.WriteErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 		return
 	}
 
 	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
 	if err != nil {
-		http.Error(w, "read error", http.StatusBadRequest)
+		httpserver.WriteErr(w, http.StatusBadRequest, "bad_request", "read error")
 		return
 	}
 
@@ -59,12 +60,12 @@ func (s *Service) HandleGitHubWebhook(w http.ResponseWriter, r *http.Request) {
 	sig := r.Header.Get("X-Hub-Signature-256")
 	if !s.validateGitHubSignature(body, sig) {
 		logfCtx(r.Context(), "[github-webhook] signature validation failed for event=%q — check webhook secret", event)
-		http.Error(w, "invalid signature", http.StatusUnauthorized)
+		httpserver.WriteErr(w, http.StatusUnauthorized, "unauthorized", "invalid signature")
 		return
 	}
 
 	if event == "" {
-		http.Error(w, "missing X-GitHub-Event", http.StatusBadRequest)
+		httpserver.WriteErr(w, http.StatusBadRequest, "bad_request", "missing X-GitHub-Event")
 		return
 	}
 
@@ -73,7 +74,7 @@ func (s *Service) HandleGitHubWebhook(w http.ResponseWriter, r *http.Request) {
 		var payload GitHubIssuesWebhookPayload
 		if err := json.Unmarshal(body, &payload); err != nil {
 			logfCtx(r.Context(), "[github-webhook] failed to parse issues payload: %v", err)
-			http.Error(w, "invalid payload", http.StatusBadRequest)
+			httpserver.WriteErr(w, http.StatusBadRequest, "bad_request", "invalid payload")
 			return
 		}
 		logfCtx(r.Context(), "[github-webhook] issues action=%q repo=%q issue=#%d author=%q",
@@ -83,7 +84,7 @@ func (s *Service) HandleGitHubWebhook(w http.ResponseWriter, r *http.Request) {
 		var payload GitHubPRPayload
 		if err := json.Unmarshal(body, &payload); err != nil {
 			logfCtx(r.Context(), "[github-webhook] failed to parse pull_request payload: %v", err)
-			http.Error(w, "invalid payload", http.StatusBadRequest)
+			httpserver.WriteErr(w, http.StatusBadRequest, "bad_request", "invalid payload")
 			return
 		}
 		logfCtx(r.Context(), "[github-webhook] pull_request action=%q repo=%q pr=#%d author=%q base=%q",
@@ -94,7 +95,7 @@ func (s *Service) HandleGitHubWebhook(w http.ResponseWriter, r *http.Request) {
 		var payload githubPRReviewCommentPayload
 		if err := json.Unmarshal(body, &payload); err != nil {
 			logfCtx(r.Context(), "[github-webhook] failed to parse pull_request_review_comment payload: %v", err)
-			http.Error(w, "invalid payload", http.StatusBadRequest)
+			httpserver.WriteErr(w, http.StatusBadRequest, "bad_request", "invalid payload")
 			return
 		}
 		logfCtx(r.Context(), "[github-webhook] pull_request_review_comment action=%q repo=%q pr=#%d author=%q",
@@ -104,7 +105,7 @@ func (s *Service) HandleGitHubWebhook(w http.ResponseWriter, r *http.Request) {
 		var payload githubPRReviewPayload
 		if err := json.Unmarshal(body, &payload); err != nil {
 			logfCtx(r.Context(), "[github-webhook] failed to parse pull_request_review payload: %v", err)
-			http.Error(w, "invalid payload", http.StatusBadRequest)
+			httpserver.WriteErr(w, http.StatusBadRequest, "bad_request", "invalid payload")
 			return
 		}
 		logfCtx(r.Context(), "[github-webhook] pull_request_review action=%q state=%q repo=%q pr=#%d author=%q",

--- a/pkg/hub/integrations/jira.go
+++ b/pkg/hub/integrations/jira.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/elasticclaw/elasticclaw/pkg/hub/httpserver"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
 
@@ -99,24 +100,24 @@ type jiraPollIssue = jiraIssue
 
 func (s *Service) HandleJiraWebhook(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		httpserver.WriteErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 		return
 	}
 	workspaceName := strings.TrimSpace(r.PathValue("workspace"))
 
 	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
 	if err != nil {
-		http.Error(w, "read error", http.StatusBadRequest)
+		httpserver.WriteErr(w, http.StatusBadRequest, "bad_request", "read error")
 		return
 	}
 	if !s.validateJiraWebhookSecret(workspaceName, r) {
-		http.Error(w, "invalid signature", http.StatusUnauthorized)
+		httpserver.WriteErr(w, http.StatusUnauthorized, "unauthorized", "invalid signature")
 		return
 	}
 
 	payload, err := parseJiraWebhookPayload(body)
 	if err != nil {
-		http.Error(w, "invalid payload", http.StatusBadRequest)
+		httpserver.WriteErr(w, http.StatusBadRequest, "bad_request", "invalid payload")
 		return
 	}
 	if payload.Issue.Key == "" {

--- a/pkg/hub/integrations/linear.go
+++ b/pkg/hub/integrations/linear.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/elasticclaw/elasticclaw/pkg/hub/analytics"
+	"github.com/elasticclaw/elasticclaw/pkg/hub/httpserver"
 
 	"github.com/elasticclaw/elasticclaw/pkg/config"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
@@ -59,26 +60,26 @@ type LinearWebhookPayload struct {
 
 func (s *Service) HandleLinearWebhook(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		httpserver.WriteErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 		return
 	}
 
 	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
 	if err != nil {
-		http.Error(w, "read error", http.StatusBadRequest)
+		httpserver.WriteErr(w, http.StatusBadRequest, "bad_request", "read error")
 		return
 	}
 
 	// Validate signature if any Linear integration has a webhook_secret
 	sig := r.Header.Get("Linear-Signature")
 	if !s.validateLinearSignature(r.PathValue("workspace"), body, sig) {
-		http.Error(w, "invalid signature", http.StatusUnauthorized)
+		httpserver.WriteErr(w, http.StatusUnauthorized, "unauthorized", "invalid signature")
 		return
 	}
 
 	var payload LinearWebhookPayload
 	if err := json.Unmarshal(body, &payload); err != nil {
-		http.Error(w, "invalid payload", http.StatusBadRequest)
+		httpserver.WriteErr(w, http.StatusBadRequest, "bad_request", "invalid payload")
 		return
 	}
 
@@ -1813,13 +1814,13 @@ func (s *Service) logFactoryEvent(factoryName, issueID, issueTitle, prevStatus, 
 // HandleFactoryEvents serves GET /api/factories/:name/events
 func (s *Service) HandleFactoryEvents(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		httpserver.WriteErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 		return
 	}
 	// Path: /api/factories/:name/events
 	parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/api/factories/"), "/")
 	if len(parts) < 2 || parts[1] != "events" {
-		http.Error(w, "not found", http.StatusNotFound)
+		httpserver.WriteErr(w, http.StatusNotFound, "not_found", "not found")
 		return
 	}
 	factoryName := parts[0]
@@ -1830,7 +1831,7 @@ func (s *Service) HandleFactoryEvents(w http.ResponseWriter, r *http.Request) {
 		factoryName,
 	)
 	if err != nil {
-		http.Error(w, "db error", http.StatusInternalServerError)
+		httpserver.WriteErr(w, http.StatusInternalServerError, "internal", "db error")
 		return
 	}
 	defer rows.Close()

--- a/pkg/hub/integrations/shortcut.go
+++ b/pkg/hub/integrations/shortcut.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/elasticclaw/elasticclaw/pkg/config"
+	"github.com/elasticclaw/elasticclaw/pkg/hub/httpserver"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 	"github.com/google/uuid"
 )
@@ -104,19 +105,19 @@ func (s *Service) validateShortcutWebhook() bool {
 
 func (s *Service) HandleShortcutWebhook(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		httpserver.WriteErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 		return
 	}
 
 	// Validate that at least one Shortcut integration is configured
 	if !s.validateShortcutWebhook() {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		httpserver.WriteErr(w, http.StatusUnauthorized, "unauthorized", "unauthorized")
 		return
 	}
 
 	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
 	if err != nil {
-		http.Error(w, "read error", http.StatusBadRequest)
+		httpserver.WriteErr(w, http.StatusBadRequest, "bad_request", "read error")
 		return
 	}
 
@@ -124,13 +125,13 @@ func (s *Service) HandleShortcutWebhook(w http.ResponseWriter, r *http.Request) 
 	// Shortcut sends: Payload-Signature: sha256=<hex>
 	sig := r.Header.Get("Payload-Signature")
 	if !s.validateShortcutSignature(r.PathValue("workspace"), body, sig) {
-		http.Error(w, "invalid signature", http.StatusUnauthorized)
+		httpserver.WriteErr(w, http.StatusUnauthorized, "unauthorized", "invalid signature")
 		return
 	}
 
 	var payload shortcutWebhookPayload
 	if err := json.Unmarshal(body, &payload); err != nil {
-		http.Error(w, "invalid payload", http.StatusBadRequest)
+		httpserver.WriteErr(w, http.StatusBadRequest, "bad_request", "invalid payload")
 		return
 	}
 

--- a/pkg/hub/mcp_api.go
+++ b/pkg/hub/mcp_api.go
@@ -22,12 +22,12 @@ func (s *Server) handleMCPCrud(w http.ResponseWriter, r *http.Request) {
 	case http.MethodDelete:
 		name := r.URL.Query().Get("name")
 		if name == "" {
-			http.Error(w, "name required", http.StatusBadRequest)
+			writeErr(w, http.StatusBadRequest, "bad_request", "name required")
 			return
 		}
 		s.handleMCPDelete(w, r, name)
 	default:
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 	}
 }
 
@@ -77,35 +77,35 @@ type mcpUpsertRequest struct {
 func (s *Server) handleMCPUpsert(w http.ResponseWriter, r *http.Request) {
 	var req mcpUpsertRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid JSON: "+err.Error())
 		return
 	}
 	if req.Name == "" {
-		http.Error(w, "name required", http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "name required")
 		return
 	}
 	if req.Source == "" {
-		http.Error(w, "source required", http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "source required")
 		return
 	}
 	switch types.MCPSource(req.Source) {
 	case types.MCPSourceNpx, types.MCPSourceUvx, types.MCPSourceSmithery:
 		if req.Package == "" {
-			http.Error(w, "package required for source "+req.Source, http.StatusBadRequest)
+			writeErr(w, http.StatusBadRequest, "bad_request", "package required for source "+req.Source)
 			return
 		}
 	case types.MCPSourceDocker:
 		if req.Image == "" {
-			http.Error(w, "image required for source docker", http.StatusBadRequest)
+			writeErr(w, http.StatusBadRequest, "bad_request", "image required for source docker")
 			return
 		}
 	case types.MCPSourceSSE:
 		if req.URL == "" {
-			http.Error(w, "url required for source sse", http.StatusBadRequest)
+			writeErr(w, http.StatusBadRequest, "bad_request", "url required for source sse")
 			return
 		}
 	default:
-		http.Error(w, "invalid source: must be npx, uvx, smithery, docker, or sse", http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid source: must be npx, uvx, smithery, docker, or sse")
 		return
 	}
 
@@ -159,7 +159,7 @@ func (s *Server) handleMCPUpsert(w http.ResponseWriter, r *http.Request) {
 	cfgCopy.MCPServers = mcps
 	if err := config.SaveHubConfig(&cfgCopy); err != nil {
 		s.cfgMu.Unlock()
-		http.Error(w, "failed to save config: "+err.Error(), http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", "failed to save config: "+err.Error())
 		return
 	}
 	s.hubCfg = &cfgCopy
@@ -182,13 +182,13 @@ func (s *Server) handleMCPDelete(w http.ResponseWriter, _ *http.Request, name st
 	}
 	if !found {
 		s.cfgMu.Unlock()
-		http.Error(w, "mcp server not found", http.StatusNotFound)
+		writeErr(w, http.StatusNotFound, "not_found", "mcp server not found")
 		return
 	}
 	cfgCopy.MCPServers = mcps
 	if err := config.SaveHubConfig(&cfgCopy); err != nil {
 		s.cfgMu.Unlock()
-		http.Error(w, "failed to save config: "+err.Error(), http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", "failed to save config: "+err.Error())
 		return
 	}
 	s.hubCfg = &cfgCopy

--- a/pkg/hub/message_handlers.go
+++ b/pkg/hub/message_handlers.go
@@ -395,11 +395,11 @@ func (s *Server) canViewMessages(w http.ResponseWriter, r *http.Request, tenantI
 		return false
 	}
 	if err != nil {
-		http.Error(w, "db error", http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", "db error")
 		return false
 	}
 	if !canViewClaw(accessCfgMsg, ghLoginMsg, clawTagsMsg) {
-		http.Error(w, "forbidden", http.StatusForbidden)
+		writeErr(w, http.StatusForbidden, "forbidden", "forbidden")
 		return false
 	}
 	return true

--- a/pkg/hub/message_handlers_test.go
+++ b/pkg/hub/message_handlers_test.go
@@ -419,7 +419,9 @@ func TestSplitStreamingTurnDoesNotBroadcastGhostFinalMessage(t *testing.T) {
 
 	userCtx, cancelUser := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancelUser()
-	userWS, _, err := websocket.Dial(userCtx, "ws"+strings.TrimPrefix(ts.URL, "http")+"/api/ws?token=test-token", nil)
+	userWS, _, err := websocket.Dial(userCtx, "ws"+strings.TrimPrefix(ts.URL, "http")+"/api/ws", &websocket.DialOptions{
+		HTTPHeader: http.Header{"Authorization": {"Bearer test-token"}},
+	})
 	if err != nil {
 		t.Fatalf("dial user ws: %v", err)
 	}

--- a/pkg/hub/provision.go
+++ b/pkg/hub/provision.go
@@ -353,7 +353,8 @@ func (s *Server) clawHubURL() string {
 // ─── Terminal WebSocket ───────────────────────────────────────────────────────
 
 // handleTerminal proxies a WebSocket connection to an SSH PTY on the claw's VM.
-// Route: GET /api/terminal/{clawID}?token=...
+// Route: GET /api/terminal/{clawID} (Authorization header auth; the deprecated
+// ?token= query fallback was removed in Phase 2.6).
 // terminateVM terminates a provider VM by type and ID.
 func (s *Server) terminateVM(provider, vmID string) {
 	if vmID == "" {

--- a/pkg/hub/secrets_api.go
+++ b/pkg/hub/secrets_api.go
@@ -21,12 +21,12 @@ func (s *Server) handleSecretsCRUD(w http.ResponseWriter, r *http.Request) {
 	case http.MethodDelete:
 		name := r.URL.Query().Get("name")
 		if name == "" {
-			http.Error(w, "name required", http.StatusBadRequest)
+			writeErr(w, http.StatusBadRequest, "bad_request", "name required")
 			return
 		}
 		s.handleSecretDelete(w, r, name)
 	default:
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 	}
 }
 
@@ -52,11 +52,11 @@ type secretUpsertRequest struct {
 func (s *Server) handleSecretUpsert(w http.ResponseWriter, r *http.Request) {
 	var req secretUpsertRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid JSON: "+err.Error())
 		return
 	}
 	if req.Name == "" {
-		http.Error(w, "name required", http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "name required")
 		return
 	}
 
@@ -72,7 +72,7 @@ func (s *Server) handleSecretUpsert(w http.ResponseWriter, r *http.Request) {
 	s.cfgMu.Unlock()
 
 	if err := config.SaveHubConfig(&cfgCopy); err != nil {
-		http.Error(w, "failed to save config: "+err.Error(), http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", "failed to save config: "+err.Error())
 		return
 	}
 
@@ -82,7 +82,7 @@ func (s *Server) handleSecretUpsert(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleSecretDelete(w http.ResponseWriter, _ *http.Request, name string) {
 	diskCfg, err := config.LoadHubConfig()
 	if err != nil {
-		http.Error(w, "failed to load config: "+err.Error(), http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", "failed to load config: "+err.Error())
 		return
 	}
 
@@ -94,7 +94,7 @@ func (s *Server) handleSecretDelete(w http.ResponseWriter, _ *http.Request, name
 	}
 	if !inMemory && !onDisk {
 		s.cfgMu.Unlock()
-		http.Error(w, "secret not found", http.StatusNotFound)
+		writeErr(w, http.StatusNotFound, "not_found", "secret not found")
 		return
 	}
 	cfgCopy := *s.hubCfg
@@ -128,7 +128,7 @@ func (s *Server) handleSecretDelete(w http.ResponseWriter, _ *http.Request, name
 		cfgToSave.Secrets = mergedSecrets
 	}
 	if err := config.SaveHubConfigNoSecretMerge(&cfgToSave); err != nil {
-		http.Error(w, "failed to save config: "+err.Error(), http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", "failed to save config: "+err.Error())
 		return
 	}
 

--- a/pkg/hub/settings/doctor.go
+++ b/pkg/hub/settings/doctor.go
@@ -62,7 +62,7 @@ var (
 // HandleDoctor handles GET /api/doctor.
 func (s *Service) HandleDoctor(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		httpserver.WriteErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 		return
 	}
 

--- a/pkg/hub/templates.go
+++ b/pkg/hub/templates.go
@@ -17,7 +17,7 @@ func (s *Server) handleTemplates(w http.ResponseWriter, r *http.Request) {
 	case http.MethodPost:
 		s.pushTemplate(w, r)
 	default:
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 	}
 }
 
@@ -25,14 +25,14 @@ func (s *Server) handleTemplates(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleTemplateDetail(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue("name")
 	if name == "" {
-		http.Error(w, "missing template name", http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "missing template name")
 		return
 	}
 	switch r.Method {
 	case http.MethodGet:
 		files, err := s.loadHubTemplate(name)
 		if err != nil {
-			http.Error(w, "template not found", http.StatusNotFound)
+			writeErr(w, http.StatusNotFound, "not_found", "template not found")
 			return
 		}
 		jsonOK(w, map[string]interface{}{
@@ -41,14 +41,14 @@ func (s *Server) handleTemplateDetail(w http.ResponseWriter, r *http.Request) {
 		})
 	case http.MethodDelete:
 		if err := deleteExternalTemplate(name); err != nil {
-			http.Error(w, "delete error: "+err.Error(), http.StatusInternalServerError)
+			writeErr(w, http.StatusInternalServerError, "internal", "delete error: "+err.Error())
 			return
 		}
 		// Also clean up legacy DB row if present
 		_ = s.st().Settings().DeleteTemplate(r.Context(), name)
 		w.WriteHeader(http.StatusNoContent)
 	default:
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 	}
 }
 
@@ -56,7 +56,7 @@ func (s *Server) listTemplates(w http.ResponseWriter, r *http.Request) {
 	// List from external storage first
 	names, err := listExternalTemplates()
 	if err != nil {
-		http.Error(w, "fs error: "+err.Error(), http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", "fs error: "+err.Error())
 		return
 	}
 
@@ -104,34 +104,34 @@ func (s *Server) pushTemplate(w http.ResponseWriter, r *http.Request) {
 		Files map[string]string `json:"files"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Name == "" {
-		http.Error(w, "invalid request: name and files required", http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid request: name and files required")
 		return
 	}
 	// Validate name
 	if strings.ContainsAny(body.Name, "/\\") || strings.Contains(body.Name, "..") {
-		http.Error(w, "invalid template name", http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid template name")
 		return
 	}
 
 	// Validate template configuration (required)
 	configData, ok := body.Files["elasticclaw-config.yaml"]
 	if !ok {
-		http.Error(w, "elasticclaw-config.yaml is required", http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "elasticclaw-config.yaml is required")
 		return
 	}
 	cfg, err := config.ParseTemplateConfig([]byte(configData))
 	if err != nil {
-		http.Error(w, "invalid elasticclaw-config.yaml: "+err.Error(), http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid elasticclaw-config.yaml: "+err.Error())
 		return
 	}
 	if err := cfg.Validate(); err != nil {
-		http.Error(w, "validation error: "+err.Error(), http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "validation error: "+err.Error())
 		return
 	}
 
 	// Write to external storage
 	if err := saveExternalTemplate(body.Name, body.Files); err != nil {
-		http.Error(w, "save error: "+err.Error(), http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", "save error: "+err.Error())
 		return
 	}
 

--- a/pkg/hub/terminal_errors_test.go
+++ b/pkg/hub/terminal_errors_test.go
@@ -43,7 +43,8 @@ func decodeAPIError(t *testing.T, body []byte) (code, msg string) {
 func TestHandleTerminalUnauthorizedEnvelope(t *testing.T) {
 	s := newTerminalTestServer(t)
 
-	r := httptest.NewRequest("GET", "/api/terminal/some-claw?token=wrong", nil)
+	r := httptest.NewRequest("GET", "/api/terminal/some-claw", nil)
+	r.Header.Set("Authorization", "Bearer wrong")
 	w := httptest.NewRecorder()
 	s.handleTerminal(w, r)
 
@@ -58,7 +59,8 @@ func TestHandleTerminalUnauthorizedEnvelope(t *testing.T) {
 func TestHandleTerminalClawNotFoundEnvelope(t *testing.T) {
 	s := newTerminalTestServer(t)
 
-	r := httptest.NewRequest("GET", "/api/terminal/missing-claw?token=token", nil)
+	r := httptest.NewRequest("GET", "/api/terminal/missing-claw", nil)
+	r.Header.Set("Authorization", "Bearer token")
 	w := httptest.NewRecorder()
 	s.handleTerminal(w, r)
 

--- a/pkg/hub/troubleshoot.go
+++ b/pkg/hub/troubleshoot.go
@@ -27,16 +27,16 @@ const maxProblemLen = 4000
 
 func (s *Server) handleTroubleshootStream(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 		return
 	}
 	var req troubleshootRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "invalid request", http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid request")
 		return
 	}
 	if req.Problem == "" {
-		http.Error(w, "problem required", http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "problem required")
 		return
 	}
 	if len(req.Problem) > maxProblemLen {
@@ -55,7 +55,7 @@ func (s *Server) handleTroubleshootStream(w http.ResponseWriter, r *http.Request
 
 	flusher, ok := w.(http.Flusher)
 	if !ok {
-		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", "streaming not supported")
 		return
 	}
 	flusher.Flush()

--- a/pkg/hub/volumes_test.go
+++ b/pkg/hub/volumes_test.go
@@ -143,6 +143,46 @@ func TestVolumeArchiveRejectsWrongLeaseCredentials(t *testing.T) {
 	}
 }
 
+func TestVolumeArchiveDBFailureIsInternalNotNotFound(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	volumes := []workflowVolumeRuntime{{
+		WorkflowVolume: types.WorkflowVolume{Name: "scratch", Source: "hub://volumes/scratch", Mount: "/mnt/elasticclaw/scratch", Mode: "rw"},
+		Repo:           "volumes/scratch",
+		Tag:            "latest",
+	}}
+	acquired, err := s.acquireWorkflowVolumeLeases(context.Background(), "claw-rw", volumes)
+	if err != nil {
+		t.Fatalf("acquire rw lease: %v", err)
+	}
+
+	// Break the lease table so the lookup fails for a reason other than a
+	// missing row: operational DB failures must surface as 500, not 404.
+	if _, err := db.Exec(`ALTER TABLE volume_leases RENAME TO volume_leases_broken`); err != nil {
+		t.Fatalf("rename volume_leases: %v", err)
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/api/volumes/leases/"+acquired[0].LeaseID+"/archive", nil)
+	getReq.SetPathValue("lease", acquired[0].LeaseID)
+	setVolumeArchiveAuth(getReq, "claw-token", "claw-rw", acquired[0].AccessToken)
+	getRec := httptest.NewRecorder()
+	s.handleVolumeArchive(getRec, getReq)
+	if getRec.Code != http.StatusInternalServerError {
+		t.Fatalf("get with broken DB status = %d, want %d", getRec.Code, http.StatusInternalServerError)
+	}
+	if strings.Contains(getRec.Body.String(), "volume_leases") {
+		t.Fatalf("get error body leaks backend detail: %s", getRec.Body.String())
+	}
+
+	putReq := httptest.NewRequest(http.MethodPut, "/api/volumes/leases/"+acquired[0].LeaseID+"/archive", bytes.NewReader([]byte("data")))
+	putReq.SetPathValue("lease", acquired[0].LeaseID)
+	setVolumeArchiveAuth(putReq, "claw-token", "claw-rw", acquired[0].AccessToken)
+	putRec := httptest.NewRecorder()
+	s.handleVolumeArchive(putRec, putReq)
+	if putRec.Code != http.StatusInternalServerError {
+		t.Fatalf("put with broken DB status = %d, want %d", putRec.Code, http.StatusInternalServerError)
+	}
+}
+
 func TestSyncWorkflowVolumesKeepsWritableLeaseWhenDisconnected(t *testing.T) {
 	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
 	volumes := []workflowVolumeRuntime{{

--- a/pkg/hub/workflows/cron_api.go
+++ b/pkg/hub/workflows/cron_api.go
@@ -6,13 +6,15 @@ import (
 	"net/http"
 	"strconv"
 	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/hub/httpserver"
 )
 
 // handleCronWorkflowTrigger handles POST /api/workspaces/{workspace}/workflows/{workflow}/cron/trigger
 // Manually triggers a cron workflow run.
 func (s *Service) handleCronWorkflowTrigger(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		httpserver.WriteErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed")
 		return
 	}
 
@@ -20,20 +22,20 @@ func (s *Service) handleCronWorkflowTrigger(w http.ResponseWriter, r *http.Reque
 	workflow := r.PathValue("workflow")
 
 	if s.cronScheduler() == nil {
-		http.Error(w, "Cron scheduler not available", http.StatusServiceUnavailable)
+		httpserver.WriteErr(w, http.StatusServiceUnavailable, "unavailable", "Cron scheduler not available")
 		return
 	}
 
 	key, err := s.cronScheduler().manualTrigger(workspace, workflow)
 	if err != nil {
 		if _, ok := err.(*cronTriggerNotFoundError); ok {
-			http.Error(w, err.Error(), http.StatusNotFound)
+			httpserver.WriteErr(w, http.StatusNotFound, "not_found", err.Error())
 		} else if _, ok := err.(*cronTriggerDisabledError); ok {
-			http.Error(w, err.Error(), http.StatusForbidden)
+			httpserver.WriteErr(w, http.StatusForbidden, "forbidden", err.Error())
 		} else if _, ok := err.(*cronTriggerSkippedError); ok {
-			http.Error(w, err.Error(), http.StatusConflict)
+			httpserver.WriteErr(w, http.StatusConflict, "conflict", err.Error())
 		} else {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			httpserver.WriteErr(w, http.StatusInternalServerError, "internal", err.Error())
 		}
 		return
 	}
@@ -49,7 +51,7 @@ func (s *Service) handleCronWorkflowTrigger(w http.ResponseWriter, r *http.Reque
 // Returns the run history for a cron workflow.
 func (s *Service) handleCronWorkflowRuns(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
-		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		httpserver.WriteErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed")
 		return
 	}
 
@@ -57,7 +59,7 @@ func (s *Service) handleCronWorkflowRuns(w http.ResponseWriter, r *http.Request)
 	workflow := r.PathValue("workflow")
 
 	if s.cronScheduler() == nil {
-		http.Error(w, "Cron scheduler not available", http.StatusServiceUnavailable)
+		httpserver.WriteErr(w, http.StatusServiceUnavailable, "unavailable", "Cron scheduler not available")
 		return
 	}
 
@@ -71,7 +73,7 @@ func (s *Service) handleCronWorkflowRuns(w http.ResponseWriter, r *http.Request)
 
 	runs, err := s.cronScheduler().getRunHistory(workspace, workflow, limit)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("Failed to get run history: %v", err), http.StatusInternalServerError)
+		httpserver.WriteErr(w, http.StatusInternalServerError, "internal", fmt.Sprintf("Failed to get run history: %v", err))
 		return
 	}
 
@@ -86,7 +88,7 @@ func (s *Service) handleCronWorkflowRuns(w http.ResponseWriter, r *http.Request)
 // Returns the next scheduled run time for a cron workflow.
 func (s *Service) handleCronWorkflowNextRun(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
-		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		httpserver.WriteErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed")
 		return
 	}
 
@@ -94,7 +96,7 @@ func (s *Service) handleCronWorkflowNextRun(w http.ResponseWriter, r *http.Reque
 	workflow := r.PathValue("workflow")
 
 	if s.cronScheduler() == nil {
-		http.Error(w, "Cron scheduler not available", http.StatusServiceUnavailable)
+		httpserver.WriteErr(w, http.StatusServiceUnavailable, "unavailable", "Cron scheduler not available")
 		return
 	}
 
@@ -103,7 +105,7 @@ func (s *Service) handleCronWorkflowNextRun(w http.ResponseWriter, r *http.Reque
 
 	nextRun, ok := nextRuns[key]
 	if !ok {
-		http.Error(w, "Workflow not found or not cron-triggered", http.StatusNotFound)
+		httpserver.WriteErr(w, http.StatusNotFound, "not_found", "Workflow not found or not cron-triggered")
 		return
 	}
 

--- a/pkg/hub/workflows/factory_api.go
+++ b/pkg/hub/workflows/factory_api.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/elasticclaw/elasticclaw/pkg/hub/httpserver"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
 
@@ -23,12 +24,12 @@ func (s *Service) handleFactoriesCRUD(w http.ResponseWriter, r *http.Request) {
 	case http.MethodDelete:
 		name := r.URL.Query().Get("name")
 		if name == "" {
-			http.Error(w, "name required", http.StatusBadRequest)
+			httpserver.WriteErr(w, http.StatusBadRequest, "bad_request", "name required")
 			return
 		}
 		s.handleFactoryDelete(w, r, name)
 	default:
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		httpserver.WriteErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 	}
 }
 
@@ -78,7 +79,7 @@ func (s *Service) handleFactoriesList(w http.ResponseWriter, r *http.Request) {
 
 	factories, err := loadExternalFactories()
 	if err != nil {
-		http.Error(w, "fs error: "+err.Error(), http.StatusInternalServerError)
+		httpserver.WriteErr(w, http.StatusInternalServerError, "internal", "fs error: "+err.Error())
 		return
 	}
 
@@ -103,22 +104,22 @@ type FactoryPushRequest struct {
 func (s *Service) handleFactoriesPush(w http.ResponseWriter, r *http.Request) {
 	var req FactoryPushRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
+		httpserver.WriteErr(w, http.StatusBadRequest, "bad_request", "invalid JSON: "+err.Error())
 		return
 	}
 	if len(req.Factories) == 0 {
-		http.Error(w, "no factories provided", http.StatusBadRequest)
+		httpserver.WriteErr(w, http.StatusBadRequest, "bad_request", "no factories provided")
 		return
 	}
 
 	// Validate all factories before saving
 	for _, f := range req.Factories {
 		if f == nil {
-			http.Error(w, "factory cannot be nil", http.StatusBadRequest)
+			httpserver.WriteErr(w, http.StatusBadRequest, "bad_request", "factory cannot be nil")
 			return
 		}
 		if err := f.Validate(); err != nil {
-			http.Error(w, "validation error: "+err.Error(), http.StatusBadRequest)
+			httpserver.WriteErr(w, http.StatusBadRequest, "bad_request", "validation error: "+err.Error())
 			return
 		}
 	}
@@ -148,7 +149,7 @@ func (s *Service) handleFactoriesPush(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if len(saveErrs) > 0 {
-		http.Error(w, strings.Join(saveErrs, "; "), http.StatusInternalServerError)
+		httpserver.WriteErr(w, http.StatusInternalServerError, "internal", strings.Join(saveErrs, "; "))
 		return
 	}
 
@@ -167,7 +168,7 @@ func (s *Service) handleFactoriesPush(w http.ResponseWriter, r *http.Request) {
 
 func (s *Service) handleFactoryDelete(w http.ResponseWriter, _ *http.Request, name string) {
 	if err := deleteExternalFactory(name); err != nil {
-		http.Error(w, "delete error: "+err.Error(), http.StatusInternalServerError)
+		httpserver.WriteErr(w, http.StatusInternalServerError, "internal", "delete error: "+err.Error())
 		return
 	}
 	jsonOK(w, map[string]string{"deleted": name})

--- a/pkg/hub/workspace_api.go
+++ b/pkg/hub/workspace_api.go
@@ -66,12 +66,12 @@ func (s *Server) handleWorkspacesCRUD(w http.ResponseWriter, r *http.Request) {
 	case http.MethodDelete:
 		name := r.URL.Query().Get("name")
 		if name == "" {
-			http.Error(w, "name required", http.StatusBadRequest)
+			writeErr(w, http.StatusBadRequest, "bad_request", "name required")
 			return
 		}
 		s.handleWorkspaceDelete(w, r, name)
 	default:
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 	}
 }
 
@@ -82,11 +82,11 @@ type WorkspacePushRequest struct {
 func (s *Server) handleWorkspacesPush(w http.ResponseWriter, r *http.Request) {
 	var req WorkspacePushRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid JSON: "+err.Error())
 		return
 	}
 	if len(req.Workspaces) == 0 {
-		http.Error(w, "no workspaces provided", http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "no workspaces provided")
 		return
 	}
 
@@ -101,7 +101,7 @@ func (s *Server) handleWorkspacesPush(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if len(saveErrs) > 0 {
-		http.Error(w, strings.Join(saveErrs, "; "), http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", strings.Join(saveErrs, "; "))
 		return
 	}
 
@@ -117,7 +117,7 @@ func (s *Server) handleWorkspacesPush(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleWorkspaceDelete(w http.ResponseWriter, _ *http.Request, name string) {
 	if err := deleteExternalWorkspace(name); err != nil {
-		http.Error(w, "delete error: "+err.Error(), http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", "delete error: "+err.Error())
 		return
 	}
 	jsonOK(w, map[string]string{"deleted": name})
@@ -129,12 +129,12 @@ func (s *Server) handleWorkspaceWorkflowsList(w http.ResponseWriter, r *http.Req
 		return
 	}
 	if r.Method != http.MethodGet {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 		return
 	}
 	name := strings.TrimSpace(r.PathValue("name"))
 	if name == "" {
-		http.Error(w, "workspace name required", http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "workspace name required")
 		return
 	}
 	for _, workspace := range s.workspaceViews() {
@@ -153,34 +153,34 @@ type WorkflowPushRequest struct {
 func (s *Server) handleWorkspaceWorkflowsPush(w http.ResponseWriter, r *http.Request) {
 	name := strings.TrimSpace(r.PathValue("name"))
 	if name == "" {
-		http.Error(w, "workspace name required", http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "workspace name required")
 		return
 	}
 	var req WorkflowPushRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid JSON: "+err.Error())
 		return
 	}
 	if len(req.Workflows) == 0 {
-		http.Error(w, "no workflows provided", http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "no workflows provided")
 		return
 	}
 	for _, workflow := range req.Workflows {
 		if workflow == nil {
-			http.Error(w, "workflow cannot be nil", http.StatusBadRequest)
+			writeErr(w, http.StatusBadRequest, "bad_request", "workflow cannot be nil")
 			return
 		}
 		if err := types.NormalizeWorkflowConfig(workflow); err != nil {
-			http.Error(w, "invalid workflow: "+err.Error(), http.StatusBadRequest)
+			writeErr(w, http.StatusBadRequest, "bad_request", "invalid workflow: "+err.Error())
 			return
 		}
 		if err := workflow.Validate(); err != nil {
-			http.Error(w, "invalid workflow: "+err.Error(), http.StatusBadRequest)
+			writeErr(w, http.StatusBadRequest, "bad_request", "invalid workflow: "+err.Error())
 			return
 		}
 	}
 	if err := saveExternalWorkflows(name, req.Workflows); err != nil {
-		http.Error(w, "save workflows: "+err.Error(), http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", "save workflows: "+err.Error())
 		return
 	}
 	if s.cronScheduler != nil {
@@ -201,13 +201,13 @@ func (s *Server) handleWorkspaceWorkflowDetail(w http.ResponseWriter, r *http.Re
 		return
 	}
 	if r.Method != http.MethodGet {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 		return
 	}
 	workspaceName := strings.TrimSpace(r.PathValue("workspace"))
 	workflowName := strings.TrimSpace(r.PathValue("workflow"))
 	if workspaceName == "" || workflowName == "" {
-		http.Error(w, "workspace and workflow names required", http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "workspace and workflow names required")
 		return
 	}
 	workflow, ok := s.findWorkflowView(workspaceName, workflowName)
@@ -228,26 +228,26 @@ func (s *Server) handleWorkspaceWorkflowPatch(w http.ResponseWriter, r *http.Req
 	workspaceName := strings.TrimSpace(r.PathValue("workspace"))
 	workflowName := strings.TrimSpace(r.PathValue("workflow"))
 	if workspaceName == "" || workflowName == "" {
-		http.Error(w, "workspace and workflow names required", http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "workspace and workflow names required")
 		return
 	}
 	var req WorkflowPatchRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid JSON: "+err.Error())
 		return
 	}
 	if req.Enabled == nil && req.EnableManualTrigger == nil && req.EnableManualTriggerSnake == nil {
-		http.Error(w, "no workflow fields provided", http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "no workflow fields provided")
 		return
 	}
 	if req.EnableManualTrigger != nil && req.EnableManualTriggerSnake != nil {
-		http.Error(w, "provide only one of enableManualTrigger or enable_manual_trigger", http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "provide only one of enableManualTrigger or enable_manual_trigger")
 		return
 	}
 
 	workspace, workflow, ok, err := s.resolveWorkflowConfig(workspaceName, workflowName)
 	if err != nil {
-		http.Error(w, "failed to load workflow: "+err.Error(), http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", "failed to load workflow: "+err.Error())
 		return
 	}
 	if !ok {
@@ -265,7 +265,7 @@ func (s *Server) handleWorkspaceWorkflowPatch(w http.ResponseWriter, r *http.Req
 	}
 	workflow.RawConfig = ""
 	if err := saveExternalWorkflows(workspace.Name, []*types.WorkflowConfig{workflow}); err != nil {
-		http.Error(w, "save workflow: "+err.Error(), http.StatusInternalServerError)
+		writeErr(w, http.StatusInternalServerError, "internal", "save workflow: "+err.Error())
 		return
 	}
 	if s.cronScheduler != nil {

--- a/pkg/hub/workspace_managed_api.go
+++ b/pkg/hub/workspace_managed_api.go
@@ -17,46 +17,46 @@ type workspaceSecretUpsertRequest struct {
 func (s *Server) handleWorkspaceSecretsCRUD(w http.ResponseWriter, r *http.Request) {
 	workspace := strings.TrimSpace(r.PathValue("workspace"))
 	if workspace == "" {
-		http.Error(w, "workspace required", http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "workspace required")
 		return
 	}
 	switch r.Method {
 	case http.MethodGet:
 		names, err := workspaceSecretNames(workspace)
 		if err != nil {
-			http.Error(w, "list secrets: "+err.Error(), http.StatusInternalServerError)
+			writeErr(w, http.StatusInternalServerError, "internal", "list secrets: "+err.Error())
 			return
 		}
 		jsonOK(w, map[string][]string{"secrets": names})
 	case http.MethodPut, http.MethodPost:
 		var req workspaceSecretUpsertRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			http.Error(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
+			writeErr(w, http.StatusBadRequest, "bad_request", "invalid JSON: "+err.Error())
 			return
 		}
 		req.Name = strings.TrimSpace(req.Name)
 		if req.Name == "" {
-			http.Error(w, "name required", http.StatusBadRequest)
+			writeErr(w, http.StatusBadRequest, "bad_request", "name required")
 			return
 		}
 		if err := saveWorkspaceSecret(workspace, req.Name, req.Value); err != nil {
-			http.Error(w, "save secret: "+err.Error(), http.StatusInternalServerError)
+			writeErr(w, http.StatusInternalServerError, "internal", "save secret: "+err.Error())
 			return
 		}
 		jsonOK(w, map[string]string{"upserted": req.Name})
 	case http.MethodDelete:
 		name := strings.TrimSpace(r.URL.Query().Get("name"))
 		if name == "" {
-			http.Error(w, "name required", http.StatusBadRequest)
+			writeErr(w, http.StatusBadRequest, "bad_request", "name required")
 			return
 		}
 		if err := deleteWorkspaceSecret(workspace, name); err != nil {
-			http.Error(w, "delete secret: "+err.Error(), http.StatusInternalServerError)
+			writeErr(w, http.StatusInternalServerError, "internal", "delete secret: "+err.Error())
 			return
 		}
 		jsonOK(w, map[string]string{"deleted": name})
 	default:
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 	}
 }
 
@@ -71,14 +71,14 @@ type workspaceGitHubAppUpsertRequest struct {
 func (s *Server) handleWorkspaceGitHubAppsCRUD(w http.ResponseWriter, r *http.Request) {
 	workspace := strings.TrimSpace(r.PathValue("workspace"))
 	if workspace == "" {
-		http.Error(w, "workspace required", http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "workspace required")
 		return
 	}
 	switch r.Method {
 	case http.MethodGet:
 		apps, err := workspaceGitHubAppViews(workspace)
 		if err != nil {
-			http.Error(w, "list github apps: "+err.Error(), http.StatusInternalServerError)
+			writeErr(w, http.StatusInternalServerError, "internal", "list github apps: "+err.Error())
 			return
 		}
 		enrichWorkspaceGitHubAppInstallations(r, apps, workspace)
@@ -86,16 +86,16 @@ func (s *Server) handleWorkspaceGitHubAppsCRUD(w http.ResponseWriter, r *http.Re
 	case http.MethodPut, http.MethodPost:
 		var req workspaceGitHubAppUpsertRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			http.Error(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
+			writeErr(w, http.StatusBadRequest, "bad_request", "invalid JSON: "+err.Error())
 			return
 		}
 		req.Name = strings.TrimSpace(req.Name)
 		if req.Name == "" {
-			http.Error(w, "name required", http.StatusBadRequest)
+			writeErr(w, http.StatusBadRequest, "bad_request", "name required")
 			return
 		}
 		if req.AppID == 0 {
-			http.Error(w, "appId required", http.StatusBadRequest)
+			writeErr(w, http.StatusBadRequest, "bad_request", "appId required")
 			return
 		}
 		app := workspaceGitHubApp{
@@ -111,23 +111,23 @@ func (s *Server) handleWorkspaceGitHubAppsCRUD(w http.ResponseWriter, r *http.Re
 			}
 		}
 		if err := saveWorkspaceGitHubApp(workspace, req.Name, app); err != nil {
-			http.Error(w, "save github app: "+err.Error(), http.StatusInternalServerError)
+			writeErr(w, http.StatusInternalServerError, "internal", "save github app: "+err.Error())
 			return
 		}
 		jsonOK(w, map[string]string{"upserted": req.Name})
 	case http.MethodDelete:
 		name := strings.TrimSpace(r.URL.Query().Get("name"))
 		if name == "" {
-			http.Error(w, "name required", http.StatusBadRequest)
+			writeErr(w, http.StatusBadRequest, "bad_request", "name required")
 			return
 		}
 		if err := deleteWorkspaceGitHubApp(workspace, name); err != nil {
-			http.Error(w, "delete github app: "+err.Error(), http.StatusInternalServerError)
+			writeErr(w, http.StatusInternalServerError, "internal", "delete github app: "+err.Error())
 			return
 		}
 		jsonOK(w, map[string]string{"deleted": name})
 	default:
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 	}
 }
 
@@ -181,21 +181,21 @@ type workspaceIssueTrackerUpsertRequest struct {
 func (s *Server) handleWorkspaceIssueTrackersCRUD(w http.ResponseWriter, r *http.Request) {
 	workspaceName := strings.TrimSpace(r.PathValue("workspace"))
 	if workspaceName == "" {
-		http.Error(w, "workspace required", http.StatusBadRequest)
+		writeErr(w, http.StatusBadRequest, "bad_request", "workspace required")
 		return
 	}
 	switch r.Method {
 	case http.MethodGet:
 		trackers, err := workspaceIssueTrackerViews(workspaceName)
 		if err != nil {
-			http.Error(w, "list issue trackers: "+err.Error(), http.StatusInternalServerError)
+			writeErr(w, http.StatusInternalServerError, "internal", "list issue trackers: "+err.Error())
 			return
 		}
 		jsonOK(w, map[string][]workspaceIssueTrackerView{"issueTrackers": trackers})
 	case http.MethodPut, http.MethodPost:
 		var req workspaceIssueTrackerUpsertRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			http.Error(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
+			writeErr(w, http.StatusBadRequest, "bad_request", "invalid JSON: "+err.Error())
 			return
 		}
 		req.Type = strings.TrimSpace(req.Type)
@@ -206,7 +206,7 @@ func (s *Server) handleWorkspaceIssueTrackersCRUD(w http.ResponseWriter, r *http
 			req.Workspace = workspaceName
 		}
 		if req.Type == "" {
-			http.Error(w, "type required", http.StatusBadRequest)
+			writeErr(w, http.StatusBadRequest, "bad_request", "type required")
 			return
 		}
 		if req.Token == "" {
@@ -228,16 +228,16 @@ func (s *Server) handleWorkspaceIssueTrackersCRUD(w http.ResponseWriter, r *http
 			}
 		}
 		if req.Token == "" {
-			http.Error(w, "token required", http.StatusBadRequest)
+			writeErr(w, http.StatusBadRequest, "bad_request", "token required")
 			return
 		}
 		if req.Type == "jira" && req.BaseURL == "" {
-			http.Error(w, "baseUrl required", http.StatusBadRequest)
+			writeErr(w, http.StatusBadRequest, "bad_request", "baseUrl required")
 			return
 		}
 		if req.OriginalWorkspace != "" && !strings.EqualFold(req.OriginalWorkspace, req.Workspace) {
 			if err := deleteWorkspaceIssueTracker(workspaceName, req.Type, req.OriginalWorkspace); err != nil {
-				http.Error(w, "rename issue tracker: "+err.Error(), http.StatusInternalServerError)
+				writeErr(w, http.StatusInternalServerError, "internal", "rename issue tracker: "+err.Error())
 				return
 			}
 		}
@@ -247,7 +247,7 @@ func (s *Server) handleWorkspaceIssueTrackersCRUD(w http.ResponseWriter, r *http
 			Token:         req.Token,
 			WebhookSecret: req.WebhookSecret,
 		}); err != nil {
-			http.Error(w, "save issue tracker: "+err.Error(), http.StatusInternalServerError)
+			writeErr(w, http.StatusInternalServerError, "internal", "save issue tracker: "+err.Error())
 			return
 		}
 		jsonOK(w, map[string]string{"upserted": req.Workspace})
@@ -255,15 +255,15 @@ func (s *Server) handleWorkspaceIssueTrackersCRUD(w http.ResponseWriter, r *http
 		trackerType := strings.TrimSpace(r.URL.Query().Get("type"))
 		name := strings.TrimSpace(r.URL.Query().Get("workspace"))
 		if trackerType == "" || name == "" {
-			http.Error(w, "type and workspace required", http.StatusBadRequest)
+			writeErr(w, http.StatusBadRequest, "bad_request", "type and workspace required")
 			return
 		}
 		if err := deleteWorkspaceIssueTracker(workspaceName, trackerType, name); err != nil {
-			http.Error(w, "delete issue tracker: "+err.Error(), http.StatusInternalServerError)
+			writeErr(w, http.StatusInternalServerError, "internal", "delete issue tracker: "+err.Error())
 			return
 		}
 		jsonOK(w, map[string]string{"deleted": name})
 	default:
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 	}
 }

--- a/web/components/attachment-chip.tsx
+++ b/web/components/attachment-chip.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { AlertCircle, File as FileIcon, Loader2, X } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { getFileViewUrl } from "@/lib/api"
@@ -43,12 +43,34 @@ export function AttachmentChip({
   const [broken, setBroken] = useState(false)
   const isImage = mimetype.startsWith("image/") && !broken && !!source
 
-  const imgSrc =
-    source?.kind === "preview"
-      ? source.url
-      : source?.kind === "history"
-        ? getFileViewUrl(source.clawId, source.path)
-        : undefined
+  // History files are served by the hub behind a single-use auth ticket, so
+  // the <img> URL must be resolved asynchronously (one fresh ticket per URL).
+  const historyClawId = source?.kind === "history" ? source.clawId : undefined
+  const historyPath = source?.kind === "history" ? source.path : undefined
+  const [historySrc, setHistorySrc] = useState<string | undefined>(undefined)
+  useEffect(() => {
+    if (!historyClawId || !historyPath) return
+    let cancelled = false
+    getFileViewUrl(historyClawId, historyPath)
+      .then((url) => { if (!cancelled) setHistorySrc(url) })
+      .catch(() => { if (!cancelled) setBroken(true) })
+    return () => { cancelled = true }
+  }, [historyClawId, historyPath])
+
+  const imgSrc = source?.kind === "preview" ? source.url : historySrc
+
+  // Opening the full image in a new tab needs its own fresh ticket — the
+  // ticket in imgSrc was already redeemed by the <img> load.
+  const openHistoryFile = async (e: React.MouseEvent) => {
+    e.preventDefault()
+    if (!historyClawId || !historyPath) return
+    try {
+      const url = await getFileViewUrl(historyClawId, historyPath)
+      window.open(url, "_blank", "noreferrer")
+    } catch {
+      /* hub unreachable — keep the chip as-is */
+    }
+  }
 
   const thumbCls = size === "sm"
     ? "max-h-16 max-w-[6rem]"
@@ -57,7 +79,7 @@ export function AttachmentChip({
   if (isImage && imgSrc) {
     const Wrap = source?.kind === "history" ? "a" : "div"
     const wrapProps = source?.kind === "history"
-      ? { href: imgSrc, target: "_blank", rel: "noreferrer", className: "relative block" }
+      ? { href: "#", onClick: openHistoryFile, className: "relative block" }
       : { className: "relative" }
     return (
       <Wrap {...wrapProps as object} title={`${name} (${sizeLabel})`}>

--- a/web/components/conversation-view.tsx
+++ b/web/components/conversation-view.tsx
@@ -794,7 +794,7 @@ function ClawBoardCard({
           <div className="flex-1 min-h-0">
             <XTerminal
               clawId={claw.id}
-              wsUrl={getTerminalWsUrl(claw.id)}
+              getWsUrl={() => getTerminalWsUrl(claw.id)}
               className="h-full w-full"
             />
           </div>
@@ -1633,7 +1633,7 @@ function ClawChatView({
               {terminalOpen && (
                 <XTerminal
                   clawId={claw.id}
-                  wsUrl={getTerminalWsUrl(claw.id)}
+                  getWsUrl={() => getTerminalWsUrl(claw.id)}
                   className="h-full w-full"
                 />
               )}

--- a/web/components/terminal.tsx
+++ b/web/components/terminal.tsx
@@ -5,7 +5,9 @@ import "@xterm/xterm/css/xterm.css"
 
 interface TerminalProps {
   clawId: string
-  wsUrl: string
+  // Async provider so each (re)connection can fetch a fresh single-use
+  // auth ticket — WS URLs are not reusable across connections.
+  getWsUrl: () => Promise<string>
   className?: string
 }
 
@@ -13,8 +15,14 @@ interface TerminalProps {
  * XTerminal — browser-only SSH terminal component.
  * Dynamically imports xterm.js to avoid SSR issues.
  */
-export function XTerminal({ clawId, wsUrl, className }: TerminalProps) {
+export function XTerminal({ clawId, getWsUrl, className }: TerminalProps) {
   const containerRef = useRef<HTMLDivElement>(null)
+  // Keep the latest provider in a ref so an inline arrow prop does not
+  // retrigger the connect effect on every parent render.
+  const getWsUrlRef = useRef(getWsUrl)
+  useEffect(() => {
+    getWsUrlRef.current = getWsUrl
+  }, [getWsUrl])
   const stateRef = useRef<{
     ws: WebSocket | null
     term: import("@xterm/xterm").Terminal | null
@@ -68,7 +76,9 @@ export function XTerminal({ clawId, wsUrl, className }: TerminalProps) {
       stateRef.current.term = term
       stateRef.current.fitAddon = fitAddon
 
-      // Connect WebSocket
+      // Connect WebSocket (fresh single-use ticket per connection)
+      const wsUrl = await getWsUrlRef.current()
+      if (!mounted) return
       const ws = new WebSocket(wsUrl)
       stateRef.current.ws = ws
 
@@ -121,7 +131,7 @@ export function XTerminal({ clawId, wsUrl, className }: TerminalProps) {
       term?.dispose()
       stateRef.current = { ws: null, term: null, fitAddon: null, resizeObserver: null }
     }
-  }, [wsUrl]) // reconnect if wsUrl changes
+  }, [clawId]) // reconnect if the target claw changes
 
   return (
     <div

--- a/web/hooks/use-hub.ts
+++ b/web/hooks/use-hub.ts
@@ -42,12 +42,14 @@ const ORDER_KEY = "elasticclaw_claw_order"
 function describeWsUrl(rawUrl: string): string {
   try {
     const url = new URL(rawUrl)
-    if (url.searchParams.has("token")) {
-      url.searchParams.set("token", "[redacted]")
+    for (const param of ["token", "ticket"]) {
+      if (url.searchParams.has(param)) {
+        url.searchParams.set(param, "[redacted]")
+      }
     }
     return url.toString()
   } catch {
-    return rawUrl.replace(/token=[^&]+/, "token=[redacted]")
+    return rawUrl.replace(/token=[^&]+/, "token=[redacted]").replace(/ticket=[^&]+/, "ticket=[redacted]")
   }
 }
 
@@ -306,14 +308,27 @@ export function useHub(selectedClawId: string | null): HubState {
     }
   }, [persistMessages])
 
-  const connectWebSocket = useCallback(() => {
+  const connectWebSocket = useCallback(async () => {
     if (!shouldReconnectRef.current) return
     if (wsRef.current) {
       wsRef.current.onclose = null
       wsRef.current.onerror = null
       wsRef.current.close()
     }
-    const wsUrl = getHubWsUrl()
+    // Each connection attempt needs a fresh single-use ticket.
+    let wsUrl: string
+    try {
+      wsUrl = await getHubWsUrl()
+    } catch (err) {
+      console.warn("WS ticket request failed; retrying:", err)
+      const attempt = reconnectAttemptRef.current
+      reconnectAttemptRef.current += 1
+      const delayMs = Math.min(30_000, 1000 * 2 ** Math.min(attempt, 5))
+      if (reconnectTimerRef.current) window.clearTimeout(reconnectTimerRef.current)
+      reconnectTimerRef.current = window.setTimeout(() => void connectWebSocket(), delayMs)
+      return
+    }
+    if (!shouldReconnectRef.current) return
     const safeWsUrl = describeWsUrl(wsUrl)
     let ws: WebSocket
     try {

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -162,14 +162,23 @@ export interface UploadedAttachment {
   mimetype: string
 }
 
+// issueAuthTicket requests a single-use, short-TTL ticket for endpoints the
+// browser cannot send Authorization headers to (WebSocket upgrades and
+// <img src> resources). Each URL needs its own fresh ticket: tickets are
+// redeemable exactly once.
+async function issueAuthTicket(): Promise<string> {
+  const res = await apiFetch<{ ticket: string }>("/api/auth/ticket", { method: "POST" })
+  return res.ticket
+}
+
 // getFileViewUrl returns the hub URL that serves the bytes of an uploaded
-// file back to the browser. Suitable for <img src>. Auth is via ?token query
-// since browsers can't set Authorization on <img>.
-export function getFileViewUrl(clawId: string, path: string): string {
-  const token = getTokenSync()
+// file back to the browser. Suitable for <img src>. Auth is via a single-use
+// ?ticket query since browsers can't set Authorization on <img>.
+export async function getFileViewUrl(clawId: string, path: string): Promise<string> {
+  const ticket = await issueAuthTicket()
   const hubBase = getHubUrl()
   const base = hubBase ? `${hubBase}/api/files/view/${clawId}` : `/api/files/view/${clawId}`
-  const qs = new URLSearchParams({ path, token }).toString()
+  const qs = new URLSearchParams({ path, ticket }).toString()
   return `${base}?${qs}`
 }
 
@@ -205,18 +214,18 @@ export async function killClaw(id: string): Promise<void> {
   return apiFetch<void>(`/api/claws/${id}`, { method: "DELETE" })
 }
 
-export function getHubWsUrl(): string {
-  const token = getTokenSync()
+export async function getHubWsUrl(): Promise<string> {
+  const ticket = await issueAuthTicket()
   const hub = getHubUrl() || window.location.origin
   const wsBase = hub.replace(/^https:/, "wss:").replace(/^http:/, "ws:")
-  return `${wsBase}/api/ws?token=${encodeURIComponent(token)}`
+  return `${wsBase}/api/ws?ticket=${encodeURIComponent(ticket)}`
 }
 
-export function getTerminalWsUrl(clawId: string): string {
-  const token = getTokenSync()
+export async function getTerminalWsUrl(clawId: string): Promise<string> {
+  const ticket = await issueAuthTicket()
   const hub = getHubUrl() || window.location.origin
   const wsBase = hub.replace(/^https:/, "wss:").replace(/^http:/, "ws:")
-  return `${wsBase}/api/terminal/${clawId}?token=${encodeURIComponent(token)}`
+  return `${wsBase}/api/terminal/${clawId}?ticket=${encodeURIComponent(ticket)}`
 }
 
 export function isConfigured(): boolean {


### PR DESCRIPTION
## Motivation

Closes the transitions opened earlier: the deprecated `?token=` query fallback (Phase 0.3) is removed, and the remaining handlers migrate to the unified JSON error envelope (Phase 0.2).

Concretely, on the base branch:

- `withAuth` and `withConfigMutationAuth` (pkg/hub/auth.go) still fell back to `r.URL.Query().Get("token")` when the `Authorization` header was empty, and `claws/terminal.go` even preferred the query param. Tokens in URLs leak into access logs, proxy logs, and browser history.
- 224 handler call sites across `pkg/hub` still wrote plain-text errors via `http.Error` instead of the `{"error", "code"}` envelope that `httpserver.WriteErr` produces (the `.golangci.yml` depguard notes explicitly tolerate services importing `httpserver` for these helpers until this migration lands).

## Dependencies

This PR is STACKED on branch `feature/domain-errors-typed-ws` — depends on #473 — review and merge that first.

Logically also depends on `feature/auth-token-hardening` (Phase 0.3) and `feature/recovery-middleware` (Phase 0.2) being merged first — this PR removes the transition paths they introduced. Those changes are **not** visible on the base branch of this stack, so the removal was implemented against the current code: the base still had the raw pre-deprecation `?token=` fallback (no single-use ticket mechanism, no deprecation warning), and `web/lib/api.ts` still builds WS/terminal URLs with `?token=`. Browser WebSocket clients cannot set headers, so this PR must land **after** the single-use-ticket work (hub tickets + the web change to use them); merging it standalone would break the web UI's WS and terminal connections. Expect small merge conflicts in `auth.go`/`terminal.go` where the ticket branch adds `?ticket=` handling next to the code removed here.

## What changed

- `pkg/hub/auth.go`: `withAuth` and `withConfigMutationAuth` accept the `Authorization` header (plus the web-session header for config mutations) only; the query-token branches are gone.
- `pkg/hub/claws/terminal.go`: the terminal WS handler authenticates via the `Authorization` header only.
- `pkg/hub/client.go`: the Go client sends `Authorization: Bearer <token>` on the `/api/ws` upgrade request instead of appending `?token=`.
- Tests updated: `hub_test.go` now asserts query tokens are rejected with 401; `message_handlers_test.go` dials the user WS with a Bearer header.
- Error envelope: all remaining `http.Error` calls in hub handlers (24 files, 224 call sites — auth, workspaces, templates, MCP, secrets, analytics, troubleshoot, claws files/terminal, checkpoints, volumes, cron/factory workflows, integrations webhooks, settings doctor, httpserver router) were mechanically rewritten to `writeErr`/`httpserver.WriteErr` with a stable status-derived `code` (`bad_request`, `unauthorized`, `not_found`, `internal`, …). Messages and HTTP statuses are unchanged; `factorytest` mocks (which emulate external services such as GitHub/Shortcut) keep plain text.

## Testing

- `go build ./...` — pass.
- `go test ./...` (equivalent to `make test`, minus `-v`) — all packages pass, including `pkg/hub` and `test/e2e`.
- `go test ./pkg/...` after the final commit — pass.
- `golangci-lint run ./pkg/hub/...` — 115 issues, identical to the base-branch baseline (all pre-existing; this diff adds none).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
