### PR TITLE
Fix workspace secret injection for Docker claws

### DIFF
--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -4287,8 +4287,11 @@ func (s *Server) provisionDocker(ctx context.Context, clawID string, req types.C
 	apiKeyAuthSync := buildOpenClawAPIKeyAuthSyncShell(hubCfg.LLMKeys, llmKeyName)
 	onboardFlags := buildOnboardFlags(hubCfg.LLMKeys, llmKeyName, defaultModel)
 
-	// Build env map for the container — passed directly as -e flags (no shell escaping needed)
-	containerEnv := map[string]string{
+	// Build env map for the container — passed directly as -e flags (no shell escaping needed).
+	// Start with the request environment so workflow and workspace secret refs reach
+	// Docker claws, then overlay hub-managed values to prevent callers from
+	// overriding the claw's identity or connection details.
+	containerEnv := mergeDockerContainerEnv(req.Env, map[string]string{
 		"ELASTICCLAW_HUB_URL":            dockerClawHubURL(hubCfg),
 		"ELASTICCLAW_CLAW_ID":            clawID,
 		"ELASTICCLAW_CLAW_TOKEN":         clawToken,
@@ -4304,7 +4307,7 @@ func (s *Server) provisionDocker(ctx context.Context, clawID string, req types.C
 		"ELASTICCLAW_PROVIDER_CONFIG":    providerConfig,
 		"ELASTICCLAW_API_KEY_AUTH_SYNC":  apiKeyAuthSync,
 		"ELASTICCLAW_ONBOARD_FLAGS":      onboardFlags,
-	}
+	})
 
 	// Inject LLM keys: buildLLMKeyEnv returns "export VAR=val\n" lines — parse into k/v
 	for _, line := range strings.Split(llmKeyEnv+modelAuthEnv, "\n") {
@@ -4373,6 +4376,17 @@ func (s *Server) provisionDocker(ctx context.Context, clawID string, req types.C
 	}
 
 	return nil
+}
+
+func mergeDockerContainerEnv(requestEnv, managedEnv map[string]string) map[string]string {
+	merged := make(map[string]string, len(requestEnv)+len(managedEnv))
+	for key, value := range requestEnv {
+		merged[key] = value
+	}
+	for key, value := range managedEnv {
+		merged[key] = value
+	}
+	return merged
 }
 
 func dockerClawHubURL(cfg *types.HubConfig) string {

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -1965,3 +1965,26 @@ func TestInaccessibleGitHubReposMessage(t *testing.T) {
 		t.Fatalf("message = %q, want %q", got, want)
 	}
 }
+
+func TestMergeDockerContainerEnvPreservesWorkflowSecrets(t *testing.T) {
+	requestEnv := map[string]string{
+		"JIRA_API_KEY":        "workspace-secret",
+		"ELASTICCLAW_HUB_URL": "http://untrusted.example",
+	}
+	managedEnv := map[string]string{
+		"ELASTICCLAW_HUB_URL": "http://host.docker.internal:8080",
+		"ELASTICCLAW_CLAW_ID": "claw-123",
+	}
+
+	got := mergeDockerContainerEnv(requestEnv, managedEnv)
+
+	if got["JIRA_API_KEY"] != "workspace-secret" {
+		t.Fatalf("JIRA_API_KEY = %q, want workspace secret", got["JIRA_API_KEY"])
+	}
+	if got["ELASTICCLAW_HUB_URL"] != managedEnv["ELASTICCLAW_HUB_URL"] {
+		t.Fatalf("ELASTICCLAW_HUB_URL = %q, want managed value %q", got["ELASTICCLAW_HUB_URL"], managedEnv["ELASTICCLAW_HUB_URL"])
+	}
+	if got["ELASTICCLAW_CLAW_ID"] != "claw-123" {
+		t.Fatalf("ELASTICCLAW_CLAW_ID = %q, want managed claw ID", got["ELASTICCLAW_CLAW_ID"])
+	}
+}


### PR DESCRIPTION
## Summary

- merge workflow/request environment variables into Docker container environments
- preserve Docker-managed claw identity and hub connection values as authoritative
- add regression coverage for workspace secret injection and managed-variable precedence

## Root cause

Workflow creation resolved workspace-managed secrets into `CreateClawRequest.Env`, but `provisionDocker` constructed a new environment map without copying `req.Env`. As a result, workspace and workflow secret refs were silently dropped for Docker claws.

## Verification

- `go test ./pkg/hub -count=1`