### PR TITLE
Include manual trigger values in workflow task context

### DIFF
--- a/pkg/hub/manual_trigger.go
+++ b/pkg/hub/manual_trigger.go
@@ -92,3 +92,14 @@ func (s *Server) loadManualTriggerInputsFromContextMD(files map[string]string) m
 	}
 	return inputs
 }
+
+func formatManualTriggerInputs(inputs map[string]string) string {
+	if len(inputs) == 0 {
+		return ""
+	}
+	data, err := json.MarshalIndent(inputs, "", "  ")
+	if err != nil {
+		return ""
+	}
+	return "Manual trigger inputs (use these exact values):\n\n```json\n" + string(data) + "\n```"
+}

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -1138,6 +1138,9 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 		}
 
 	injectMessage:
+		if inputContext := formatManualTriggerInputs(s.loadManualTriggerInputs(clawID)); inputContext != "" {
+			injectMsg = inputContext + "\n\n" + injectMsg
+		}
 		if s.clawNeedsInitialPlan(clawID) && s.insertSystemMarker(clawID, s.tenantIDForClaw(clawID), initialPlanRequiredMarker) {
 			injectMsg = initialPlanWakeContent + "\n\nTask context:\n" + injectMsg
 		}

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -1031,6 +1031,7 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 
 	if stage.OnEnter.Inject != "" {
 		injectMsg := stage.OnEnter.Inject
+		manualInputs := s.loadManualTriggerInputs(clawID)
 
 		// Render {{.Issue.Identifier}}, {{.Issue.Title}}, {{.Issue.URL}} if this is a Linear claw
 		// GitHub Issues IDs are owner/repo/number format (contain "/"), Shortcut IDs start with "sc-"
@@ -1124,11 +1125,9 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 			tmpl, err := template.New("inject").Parse(injectMsg)
 			if err == nil {
 				var buf bytes.Buffer
-				// Load inputs from CONTEXT.md (stored during manual trigger)
-				inputs := s.loadManualTriggerInputs(clawID)
-				if inputs != nil {
+				if manualInputs != nil {
 					data := s.injectTemplateData(clawID, map[string]interface{}{
-						"Inputs": inputs,
+						"Inputs": manualInputs,
 					})
 					if err := tmpl.Execute(&buf, data); err == nil {
 						injectMsg = buf.String()
@@ -1138,7 +1137,7 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 		}
 
 	injectMessage:
-		if inputContext := formatManualTriggerInputs(s.loadManualTriggerInputs(clawID)); inputContext != "" {
+		if inputContext := formatManualTriggerInputs(manualInputs); inputContext != "" {
 			injectMsg = inputContext + "\n\n" + injectMsg
 		}
 		if s.clawNeedsInitialPlan(clawID) && s.insertSystemMarker(clawID, s.tenantIDForClaw(clawID), initialPlanRequiredMarker) {

--- a/pkg/hub/pipeline_runner_test.go
+++ b/pkg/hub/pipeline_runner_test.go
@@ -357,6 +357,46 @@ func TestPipelineEntryInjectIncludesInitialPlanInstruction(t *testing.T) {
 	}
 }
 
+func TestPipelineInjectIncludesExactManualTriggerInputs(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+
+	const clawID = "claw-manual-workflow-input"
+	_, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, template, status, tags, template_files, pipeline_stage, created_at) VALUES(?,?,?,?,?,?,?,?,datetime('now'))`,
+		clawID, "test-tenant-id", "jira-AWB-2420", "lexipol", "connected",
+		`["workspace:lexipol","workflow:jira-ticket-test","manual-trigger"]`,
+		`{"TRIGGER_INPUTS.json":"{\"jira_ticket\":\"AWB-2420\"}"}`, "",
+	)
+	if err != nil {
+		t.Fatalf("insert claw: %v", err)
+	}
+
+	stage := pipeline.Stage{
+		ID:    "working",
+		Label: "Working",
+		OnEnter: pipeline.OnEnter{
+			Inject: "Use the single manual input `jira_ticket` as the Jira issue to investigate.",
+		},
+	}
+	if !s.transitionPipelineStageWithContext(clawID, stage, pipelineContext{}) {
+		t.Fatalf("stage transition returned false")
+	}
+
+	var content string
+	if err := db.QueryRow(`SELECT content FROM messages WHERE claw_id=? AND role='hub'`, clawID).Scan(&content); err != nil {
+		t.Fatalf("select injected message: %v", err)
+	}
+	for _, want := range []string{
+		"Manual trigger inputs (use these exact values):",
+		`"jira_ticket": "AWB-2420"`,
+		"Use the single manual input `jira_ticket` as the Jira issue to investigate.",
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("pipeline inject missing %q:\n%s", want, content)
+		}
+	}
+}
+
 func TestGitHubAPIDeleteLabelIgnoresMissingLabel(t *testing.T) {
 	var sawDelete bool
 	var handlerErr string


### PR DESCRIPTION
## Summary

- prepend exact manual-trigger input values to pipeline inject messages
- keep existing `{{ .Inputs.* }}` template rendering behavior
- add regression coverage for a Jira workflow receiving `jira_ticket=AWB-2420`

## Root cause

Manual workflow creation persisted the submitted inputs and used them for the claw name, but the entry pipeline message only sent the raw `on_enter.inject` text. Workflows that referred to an input by name without explicit Go-template syntax left the agent to rediscover the value from files or the claw name.

## Result

The agent now receives an explicit JSON block such as:

```json
{
  "jira_ticket": "AWB-2420"
}
```

before the workflow task instructions.

## Verification

- `go test ./pkg/hub -count=1`