### PR TITLE
Add notify pipeline action with workspace notifiers (Slack first)

### DIFF
--- a/examples/workflows/github-issue.yaml
+++ b/examples/workflows/github-issue.yaml
@@ -1,6 +1,13 @@
 schema_version: v1
 name: github-issue
 
+# Configure the referenced notifier at the workspace level:
+# notifiers:
+#   slack-releases:
+#     type: slack
+#     token_secret: slack_bot_token
+#     channel: "#eng-releases"
+
 trigger:
   github_issues:
     event: issue_labeled
@@ -58,13 +65,17 @@ stages:
       inject: |
         PR created. Watch for CI results and review comments.
 
-  - id: merged
-    label: Merged
+  - id: release_notification
+    label: Release Notification
     on_enter:
       add_labels:
         - done
       remove_labels:
         - "in review"
+      notify:
+        via: slack-releases
+        text: "Merged {{.Issue.Identifier}}: {{.Issue.Title}} ({{.Issue.URL}})"
+        target: "#eng-releases"
     triggers:
       - pr_merged: {}
     terminal: true

--- a/pkg/hub/doctor.go
+++ b/pkg/hub/doctor.go
@@ -529,41 +529,43 @@ func (s *Server) checkNotifiers(_ *types.HubConfig, diskCfg *types.HubConfig) []
 					continue
 				}
 
-				if notifier.Type != "slack" {
-					continue
-				}
-				tokenSecret, _ := notifier.Settings["token_secret"].(string)
-				if strings.TrimSpace(tokenSecret) == "" {
-					allNotifiersValid = false
-					checks = append(checks, DoctorCheck{
-						Category:    "workflows",
-						Severity:    "warning",
-						Title:       fmt.Sprintf("Notifier %q has no token_secret", via),
-						Description: fmt.Sprintf("Slack notifier %q in workspace %q must reference a secret containing its bot token.", via, workspace.Name),
-						OK:          false,
-						FixAction: &FixAction{
-							Type:   "navigate",
-							Target: "/settings/workspaces",
-							Label:  "Configure Notifier",
-						},
-					})
-					continue
-				}
-				_, inWorkspace := workspaceSecrets[tokenSecret]
-				if !inWorkspace && !secretNames[tokenSecret] {
-					allNotifiersValid = false
-					checks = append(checks, DoctorCheck{
-						Category:    "workflows",
-						Severity:    "warning",
-						Title:       fmt.Sprintf("Notifier %q token_secret references missing secret %q", via, tokenSecret),
-						Description: fmt.Sprintf("Notifier %q in workspace %q references secret %q, which is not in the secrets map.", via, workspace.Name, tokenSecret),
-						OK:          false,
-						FixAction: &FixAction{
-							Type:   "navigate",
-							Target: "/settings/secrets",
-							Label:  "Create Secret",
-						},
-					})
+				// Each provider declares which settings must name an existing
+				// secret (notify.SecretSettings), so new provider types get
+				// doctor coverage without changes here.
+				for _, settingKey := range notify.SecretSettings(notifier.Type) {
+					secretRef, _ := notifier.Settings[settingKey].(string)
+					if strings.TrimSpace(secretRef) == "" {
+						allNotifiersValid = false
+						checks = append(checks, DoctorCheck{
+							Category:    "workflows",
+							Severity:    "warning",
+							Title:       fmt.Sprintf("Notifier %q has no %s", via, settingKey),
+							Description: fmt.Sprintf("Notifier %q (type %q) in workspace %q must set %q to the name of a secret.", via, notifier.Type, workspace.Name, settingKey),
+							OK:          false,
+							FixAction: &FixAction{
+								Type:   "navigate",
+								Target: "/settings/workspaces",
+								Label:  "Configure Notifier",
+							},
+						})
+						continue
+					}
+					_, inWorkspace := workspaceSecrets[secretRef]
+					if !inWorkspace && !secretNames[secretRef] {
+						allNotifiersValid = false
+						checks = append(checks, DoctorCheck{
+							Category:    "workflows",
+							Severity:    "warning",
+							Title:       fmt.Sprintf("Notifier %q %s references missing secret %q", via, settingKey, secretRef),
+							Description: fmt.Sprintf("Notifier %q in workspace %q references secret %q, which is not in the secrets map.", via, workspace.Name, secretRef),
+							OK:          false,
+							FixAction: &FixAction{
+								Type:   "navigate",
+								Target: "/settings/secrets",
+								Label:  "Create Secret",
+							},
+						})
+					}
 				}
 			}
 		}

--- a/pkg/hub/doctor.go
+++ b/pkg/hub/doctor.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/elasticclaw/elasticclaw/pkg/config"
+	"github.com/elasticclaw/elasticclaw/pkg/hub/notify"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
 
@@ -106,6 +107,9 @@ func (s *Server) runDoctorChecks(ctx context.Context) DoctorResponse {
 
 	// --- Factories ---
 	checks = append(checks, s.checkFactories(hubCfg, diskCfg)...)
+
+	// --- Workflows ---
+	checks = append(checks, s.checkNotifiers(hubCfg, diskCfg)...)
 
 	// --- Templates ---
 	checks = append(checks, s.checkTemplates(hubCfg, diskCfg)...)
@@ -431,6 +435,149 @@ func (s *Server) checkProviders(cfg *types.HubConfig) []DoctorCheck {
 		})
 	}
 
+	return checks
+}
+
+// ==================== WORKFLOW CHECKS ====================
+
+func (s *Server) checkNotifiers(_ *types.HubConfig, diskCfg *types.HubConfig) []DoctorCheck {
+	workspaces, err := loadExternalWorkspaces()
+	if err != nil {
+		return nil
+	}
+
+	secretNames := make(map[string]bool)
+	if diskCfg != nil {
+		for name := range diskCfg.Secrets {
+			secretNames[name] = true
+		}
+	}
+
+	var checks []DoctorCheck
+	notifyActions := 0
+	allNotifiersValid := true
+	for _, workspace := range workspaces {
+		if workspace == nil {
+			continue
+		}
+		// Mirror the runtime resolution order (executeNotifyAction): workspace
+		// secrets first, then hub secrets.
+		workspaceSecrets, _ := loadWorkspaceSecrets(workspace.Name)
+		for _, workflow := range workspace.Workflows {
+			if workflow == nil {
+				continue
+			}
+			for _, stage := range workflow.Stages {
+				rawValue, present := stage.OnEnter["notify"]
+				if !present {
+					continue
+				}
+				rawNotify, _ := rawValue.(map[string]interface{})
+				via, _ := rawNotify["via"].(string)
+				if strings.TrimSpace(via) == "" {
+					// A notify block without a valid "via" is fatal at runtime:
+					// pipeline validation rejects it and the pipeline stops.
+					allNotifiersValid = false
+					checks = append(checks, DoctorCheck{
+						Category:    "workflows",
+						Severity:    "critical",
+						Title:       fmt.Sprintf("Workflow %q stage %q notify action has no valid \"via\"", workflow.Name, stage.ID),
+						Description: fmt.Sprintf("Workflow %q stage %q in workspace %q has a notify action without a \"via\" notifier name; the pipeline will fail to parse at runtime.", workflow.Name, stage.ID, workspace.Name),
+						OK:          false,
+						FixAction: &FixAction{
+							Type:   "navigate",
+							Target: "/settings/workspaces",
+							Label:  "Fix Workflow",
+						},
+					})
+					continue
+				}
+				notifyActions++
+
+				notifier, ok := workspace.Notifiers[via]
+				if !ok {
+					allNotifiersValid = false
+					checks = append(checks, DoctorCheck{
+						Category:    "workflows",
+						Severity:    "critical",
+						Title:       fmt.Sprintf("Workflow %q stage %q references missing notifier %q", workflow.Name, stage.ID, via),
+						Description: fmt.Sprintf("Workflow %q stage %q references notifier %q, which is not configured in workspace %q.", workflow.Name, stage.ID, via, workspace.Name),
+						OK:          false,
+						FixAction: &FixAction{
+							Type:   "navigate",
+							Target: "/settings/workspaces",
+							Label:  "Configure Notifier",
+						},
+					})
+					continue
+				}
+
+				if !notify.Supported(notifier.Type) {
+					allNotifiersValid = false
+					checks = append(checks, DoctorCheck{
+						Category:    "workflows",
+						Severity:    "critical",
+						Title:       fmt.Sprintf("Notifier %q has unsupported type %q", via, notifier.Type),
+						Description: fmt.Sprintf("Notifier %q in workspace %q uses a notifier type that is not supported.", via, workspace.Name),
+						OK:          false,
+						FixAction: &FixAction{
+							Type:   "navigate",
+							Target: "/settings/workspaces",
+							Label:  "Configure Notifier",
+						},
+					})
+					continue
+				}
+
+				if notifier.Type != "slack" {
+					continue
+				}
+				tokenSecret, _ := notifier.Settings["token_secret"].(string)
+				if strings.TrimSpace(tokenSecret) == "" {
+					allNotifiersValid = false
+					checks = append(checks, DoctorCheck{
+						Category:    "workflows",
+						Severity:    "warning",
+						Title:       fmt.Sprintf("Notifier %q has no token_secret", via),
+						Description: fmt.Sprintf("Slack notifier %q in workspace %q must reference a secret containing its bot token.", via, workspace.Name),
+						OK:          false,
+						FixAction: &FixAction{
+							Type:   "navigate",
+							Target: "/settings/workspaces",
+							Label:  "Configure Notifier",
+						},
+					})
+					continue
+				}
+				_, inWorkspace := workspaceSecrets[tokenSecret]
+				if !inWorkspace && !secretNames[tokenSecret] {
+					allNotifiersValid = false
+					checks = append(checks, DoctorCheck{
+						Category:    "workflows",
+						Severity:    "warning",
+						Title:       fmt.Sprintf("Notifier %q token_secret references missing secret %q", via, tokenSecret),
+						Description: fmt.Sprintf("Notifier %q in workspace %q references secret %q, which is not in the secrets map.", via, workspace.Name, tokenSecret),
+						OK:          false,
+						FixAction: &FixAction{
+							Type:   "navigate",
+							Target: "/settings/secrets",
+							Label:  "Create Secret",
+						},
+					})
+				}
+			}
+		}
+	}
+
+	if notifyActions > 0 && allNotifiersValid {
+		checks = append(checks, DoctorCheck{
+			Category:    "workflows",
+			Severity:    "info",
+			Title:       "Workflow notifiers configured",
+			Description: fmt.Sprintf("%d workflow notify action(s) configured with valid notifiers.", notifyActions),
+			OK:          true,
+		})
+	}
 	return checks
 }
 

--- a/pkg/hub/doctor_test.go
+++ b/pkg/hub/doctor_test.go
@@ -42,3 +42,115 @@ func TestCheckLLMKeysAllowsBlankOllamaAPIKey(t *testing.T) {
 		t.Fatalf("expected one passing LLM key check, got %#v", checks)
 	}
 }
+
+func TestCheckNotifiersMissingNotifier(t *testing.T) {
+	checks := runNotifierDoctorCheck(t, nil, nil)
+
+	assertDoctorCheck(t, checks, "critical", `Workflow "release" stage "announce" references missing notifier "slack-releases"`, false)
+	if checks[0].FixAction == nil || checks[0].FixAction.Type != "navigate" || checks[0].FixAction.Target != "/settings/workspaces" {
+		t.Fatalf("unexpected fix action: %#v", checks[0].FixAction)
+	}
+}
+
+func TestCheckNotifiersUnsupportedType(t *testing.T) {
+	checks := runNotifierDoctorCheck(t, map[string]types.NotifierConfig{
+		"slack-releases": {Type: "carrier-pigeon"},
+	}, nil)
+
+	assertDoctorCheck(t, checks, "critical", `Notifier "slack-releases" has unsupported type "carrier-pigeon"`, false)
+}
+
+func TestCheckNotifiersMissingTokenSecret(t *testing.T) {
+	checks := runNotifierDoctorCheck(t, map[string]types.NotifierConfig{
+		"slack-releases": {Type: "slack"},
+	}, nil)
+
+	assertDoctorCheck(t, checks, "warning", `Notifier "slack-releases" has no token_secret`, false)
+}
+
+func TestCheckNotifiersMissingReferencedSecret(t *testing.T) {
+	checks := runNotifierDoctorCheck(t, map[string]types.NotifierConfig{
+		"slack-releases": {
+			Type:     "slack",
+			Settings: map[string]any{"token_secret": "slack_bot_token"},
+		},
+	}, nil)
+
+	assertDoctorCheck(t, checks, "warning", `Notifier "slack-releases" token_secret references missing secret "slack_bot_token"`, false)
+	if checks[0].FixAction == nil || checks[0].FixAction.Type != "navigate" || checks[0].FixAction.Target != "/settings/secrets" || checks[0].FixAction.Label != "Create Secret" {
+		t.Fatalf("unexpected fix action: %#v", checks[0].FixAction)
+	}
+}
+
+func TestCheckNotifiersConfigured(t *testing.T) {
+	checks := runNotifierDoctorCheck(t, map[string]types.NotifierConfig{
+		"slack-releases": {
+			Type:     "slack",
+			Settings: map[string]any{"token_secret": "slack_bot_token"},
+		},
+	}, map[string]string{"slack_bot_token": "secret"})
+
+	assertDoctorCheck(t, checks, "info", "Workflow notifiers configured", true)
+}
+
+func TestCheckNotifiersWorkspaceScopedSecret(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	saveNotifierDoctorWorkspace(t, map[string]types.NotifierConfig{
+		"slack-releases": {
+			Type:     "slack",
+			Settings: map[string]any{"token_secret": "slack_bot_token"},
+		},
+	}, map[string]interface{}{"via": "slack-releases"})
+	if err := saveWorkspaceSecret("engineering", "slack_bot_token", "xoxb"); err != nil {
+		t.Fatalf("save workspace secret: %v", err)
+	}
+
+	s := &Server{}
+	checks := s.checkNotifiers(&types.HubConfig{}, &types.HubConfig{})
+	assertDoctorCheck(t, checks, "info", "Workflow notifiers configured", true)
+}
+
+func TestCheckNotifiersMissingVia(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	saveNotifierDoctorWorkspace(t, nil, map[string]interface{}{"text": "hello"})
+
+	s := &Server{}
+	checks := s.checkNotifiers(&types.HubConfig{}, &types.HubConfig{})
+	assertDoctorCheck(t, checks, "critical", `Workflow "release" stage "announce" notify action has no valid "via"`, false)
+}
+
+func runNotifierDoctorCheck(t *testing.T, notifiers map[string]types.NotifierConfig, secrets map[string]string) []DoctorCheck {
+	t.Helper()
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	saveNotifierDoctorWorkspace(t, notifiers, map[string]interface{}{"via": "slack-releases"})
+
+	s := &Server{}
+	return s.checkNotifiers(&types.HubConfig{}, &types.HubConfig{Secrets: secrets})
+}
+
+func saveNotifierDoctorWorkspace(t *testing.T, notifiers map[string]types.NotifierConfig, notifyBlock map[string]interface{}) {
+	t.Helper()
+	SaveWorkspaceForTest(t, &types.WorkspaceConfig{
+		Name:      "engineering",
+		Notifiers: notifiers,
+	}, []*types.WorkflowConfig{{
+		Name: "release",
+		Stages: []types.WorkflowStage{{
+			ID: "announce",
+			OnEnter: map[string]interface{}{
+				"notify": notifyBlock,
+			},
+		}},
+	}})
+}
+
+func assertDoctorCheck(t *testing.T, checks []DoctorCheck, severity, title string, ok bool) {
+	t.Helper()
+	if len(checks) != 1 {
+		t.Fatalf("expected one doctor check, got %#v", checks)
+	}
+	check := checks[0]
+	if check.Category != "workflows" || check.Severity != severity || check.Title != title || check.OK != ok {
+		t.Fatalf("unexpected doctor check: %#v", check)
+	}
+}

--- a/pkg/hub/external_storage.go
+++ b/pkg/hub/external_storage.go
@@ -601,6 +601,11 @@ func marshalWorkspaceElasticClawConfig(workspace *types.WorkspaceConfig, existin
 	} else {
 		delete(values, "webhook_secrets")
 	}
+	if len(workspace.Notifiers) > 0 {
+		values["notifiers"] = workspace.Notifiers
+	} else {
+		delete(values, "notifiers")
+	}
 	return marshalOrderedYAML(values, []string{
 		"schema_version",
 		"name",

--- a/pkg/hub/notify/notify.go
+++ b/pkg/hub/notify/notify.go
@@ -32,17 +32,38 @@ type SecretResolver func(name string) (string, bool)
 // resolved at construction time so misconfiguration fails fast.
 type Constructor func(cfg map[string]any, secrets SecretResolver) (Notifier, error)
 
-var registry = map[string]Constructor{
-	"slack": newSlack,
+// provider bundles a constructor with the metadata the doctor needs to
+// validate a notifier config without constructing it. New provider types add
+// one entry here, next to their implementation file, and doctor coverage is
+// inherited automatically.
+type provider struct {
+	construct Constructor
+	// secretSettings lists the config keys whose values must name an
+	// existing hub or workspace secret (e.g. "token_secret" for slack).
+	secretSettings []string
+}
+
+var registry = map[string]provider{
+	"slack": {construct: newSlack, secretSettings: []string{"token_secret"}},
 }
 
 // New builds a Notifier of the given type from its configuration.
 func New(typ string, cfg map[string]any, secrets SecretResolver) (Notifier, error) {
-	ctor, ok := registry[typ]
+	p, ok := registry[typ]
 	if !ok {
 		return nil, fmt.Errorf("unknown notifier type %q (supported: %s)", typ, supportedTypes())
 	}
-	return ctor(cfg, secrets)
+	return p.construct(cfg, secrets)
+}
+
+// SecretSettings returns the config keys of the given notifier type whose
+// values must reference an existing secret. Returns nil for unknown types.
+func SecretSettings(typ string) []string {
+	p, ok := registry[typ]
+	if !ok {
+		return nil
+	}
+	return p.secretSettings
 }
 
 // Supported reports whether the given notifier type is registered.

--- a/pkg/hub/notify/notify.go
+++ b/pkg/hub/notify/notify.go
@@ -1,0 +1,71 @@
+// Package notify provides outbound messaging from workflow pipelines to
+// external services (Slack today; email, Google Chat, Teams, etc. later).
+// Transport configuration lives in workspace-level notifiers; pipelines only
+// reference a notifier by name and supply the message.
+package notify
+
+import (
+	"context"
+	"fmt"
+)
+
+// Message is the provider-agnostic payload. Text is the lowest common
+// denominator; Subject is used by providers that have one (email), Target
+// optionally overrides the notifier's default destination, and Options is a
+// provider-specific passthrough (e.g. Slack thread_ts or blocks).
+type Message struct {
+	Text    string
+	Subject string
+	Target  string
+	Options map[string]any
+}
+
+// Notifier sends messages to one configured destination.
+type Notifier interface {
+	Send(ctx context.Context, msg Message) error
+}
+
+// SecretResolver resolves a hub secret by name.
+type SecretResolver func(name string) (string, bool)
+
+// Constructor builds a Notifier from its workspace configuration. Secrets are
+// resolved at construction time so misconfiguration fails fast.
+type Constructor func(cfg map[string]any, secrets SecretResolver) (Notifier, error)
+
+var registry = map[string]Constructor{
+	"slack": newSlack,
+}
+
+// New builds a Notifier of the given type from its configuration.
+func New(typ string, cfg map[string]any, secrets SecretResolver) (Notifier, error) {
+	ctor, ok := registry[typ]
+	if !ok {
+		return nil, fmt.Errorf("unknown notifier type %q (supported: %s)", typ, supportedTypes())
+	}
+	return ctor(cfg, secrets)
+}
+
+// Supported reports whether the given notifier type is registered.
+func Supported(typ string) bool {
+	_, ok := registry[typ]
+	return ok
+}
+
+func supportedTypes() string {
+	out := ""
+	for typ := range registry {
+		if out != "" {
+			out += ", "
+		}
+		out += typ
+	}
+	return out
+}
+
+// stringOption reads an optional string key from a notifier config map.
+func stringOption(cfg map[string]any, key string) string {
+	if v, ok := cfg[key].(string); ok {
+		return v
+	}
+	return ""
+}

--- a/pkg/hub/notify/notify_test.go
+++ b/pkg/hub/notify/notify_test.go
@@ -230,3 +230,13 @@ func TestSlackOptionsPassthrough(t *testing.T) {
 		t.Errorf("text = %v, want hi", got)
 	}
 }
+
+func TestSecretSettingsPerType(t *testing.T) {
+	got := SecretSettings("slack")
+	if len(got) != 1 || got[0] != "token_secret" {
+		t.Fatalf("SecretSettings(slack) = %v, want [token_secret]", got)
+	}
+	if got := SecretSettings("carrier-pigeon"); got != nil {
+		t.Fatalf("SecretSettings(unknown) = %v, want nil", got)
+	}
+}

--- a/pkg/hub/notify/notify_test.go
+++ b/pkg/hub/notify/notify_test.go
@@ -1,0 +1,232 @@
+package notify
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func noSecrets(name string) (string, bool) { return "", false }
+
+func secretsWith(m map[string]string) SecretResolver {
+	return func(name string) (string, bool) {
+		v, ok := m[name]
+		return v, ok
+	}
+}
+
+func TestNewUnknownTypeReturnsError(t *testing.T) {
+	_, err := New("carrier-pigeon", map[string]any{}, noSecrets)
+	if err == nil {
+		t.Fatal("expected error for unknown notifier type")
+	}
+	if !strings.Contains(err.Error(), "carrier-pigeon") {
+		t.Fatalf("error should name the unknown type, got: %v", err)
+	}
+}
+
+func TestNewSlackMissingTokenSecret(t *testing.T) {
+	_, err := New("slack", map[string]any{
+		"token_secret": "slack-bot-token",
+		"channel":      "#eng",
+	}, noSecrets)
+	if err == nil {
+		t.Fatal("expected error when token secret is not resolvable")
+	}
+	if !strings.Contains(err.Error(), "slack-bot-token") {
+		t.Fatalf("error should name the missing secret, got: %v", err)
+	}
+}
+
+func TestNewSlackRequiresTokenSecretKey(t *testing.T) {
+	_, err := New("slack", map[string]any{"channel": "#eng"}, noSecrets)
+	if err == nil {
+		t.Fatal("expected error when token_secret is not configured")
+	}
+	if !strings.Contains(err.Error(), "token_secret") {
+		t.Fatalf("error should name the missing key, got: %v", err)
+	}
+}
+
+type slackCall struct {
+	authorization string
+	body          map[string]any
+}
+
+func newSlackTestServer(t *testing.T, calls *[]slackCall, responses []func(w http.ResponseWriter)) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/chat.postMessage" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode request body: %v", err)
+		}
+		*calls = append(*calls, slackCall{
+			authorization: r.Header.Get("Authorization"),
+			body:          body,
+		})
+		idx := len(*calls) - 1
+		if idx >= len(responses) {
+			idx = len(responses) - 1
+		}
+		responses[idx](w)
+	}))
+}
+
+func okResponse(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Write([]byte(`{"ok":true}`))
+}
+
+func newSlackNotifier(t *testing.T, serverURL string, cfg map[string]any) Notifier {
+	t.Helper()
+	if cfg == nil {
+		cfg = map[string]any{}
+	}
+	cfg["token_secret"] = "slack-bot-token"
+	cfg["api_base"] = serverURL
+	n, err := New("slack", cfg, secretsWith(map[string]string{"slack-bot-token": "xoxb-test-token"}))
+	if err != nil {
+		t.Fatalf("New(slack): %v", err)
+	}
+	return n
+}
+
+func TestSlackSendPostsChatMessage(t *testing.T) {
+	var calls []slackCall
+	srv := newSlackTestServer(t, &calls, []func(http.ResponseWriter){okResponse})
+	defer srv.Close()
+
+	n := newSlackNotifier(t, srv.URL, map[string]any{"channel": "#eng-releases"})
+	err := n.Send(context.Background(), Message{Text: "PR merged"})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(calls))
+	}
+	if got := calls[0].authorization; got != "Bearer xoxb-test-token" {
+		t.Errorf("Authorization = %q, want Bearer token", got)
+	}
+	if got := calls[0].body["channel"]; got != "#eng-releases" {
+		t.Errorf("channel = %v, want #eng-releases", got)
+	}
+	if got := calls[0].body["text"]; got != "PR merged" {
+		t.Errorf("text = %v, want PR merged", got)
+	}
+}
+
+func TestSlackSendTargetOverridesChannel(t *testing.T) {
+	var calls []slackCall
+	srv := newSlackTestServer(t, &calls, []func(http.ResponseWriter){okResponse})
+	defer srv.Close()
+
+	n := newSlackNotifier(t, srv.URL, map[string]any{"channel": "#default"})
+	if err := n.Send(context.Background(), Message{Text: "hi", Target: "#override"}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if got := calls[0].body["channel"]; got != "#override" {
+		t.Errorf("channel = %v, want #override", got)
+	}
+}
+
+func TestSlackSendNoChannelConfigured(t *testing.T) {
+	var calls []slackCall
+	srv := newSlackTestServer(t, &calls, []func(http.ResponseWriter){okResponse})
+	defer srv.Close()
+
+	n := newSlackNotifier(t, srv.URL, nil)
+	err := n.Send(context.Background(), Message{Text: "hi"})
+	if err == nil {
+		t.Fatal("expected error when neither channel nor target is set")
+	}
+	if len(calls) != 0 {
+		t.Fatalf("expected no API calls, got %d", len(calls))
+	}
+}
+
+func TestSlackSendAPIErrorInBody(t *testing.T) {
+	var calls []slackCall
+	srv := newSlackTestServer(t, &calls, []func(http.ResponseWriter){func(w http.ResponseWriter) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"ok":false,"error":"channel_not_found"}`))
+	}})
+	defer srv.Close()
+
+	n := newSlackNotifier(t, srv.URL, map[string]any{"channel": "#missing"})
+	err := n.Send(context.Background(), Message{Text: "hi"})
+	if err == nil {
+		t.Fatal("expected error when Slack responds ok:false")
+	}
+	if !strings.Contains(err.Error(), "channel_not_found") {
+		t.Fatalf("error should include Slack error code, got: %v", err)
+	}
+}
+
+func TestSlackSendRetriesOn429(t *testing.T) {
+	var calls []slackCall
+	srv := newSlackTestServer(t, &calls, []func(http.ResponseWriter){
+		func(w http.ResponseWriter) {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+		},
+		okResponse,
+	})
+	defer srv.Close()
+
+	n := newSlackNotifier(t, srv.URL, map[string]any{"channel": "#eng"})
+	if err := n.Send(context.Background(), Message{Text: "hi"}); err != nil {
+		t.Fatalf("Send should succeed after retry: %v", err)
+	}
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 calls (retry after 429), got %d", len(calls))
+	}
+}
+
+func TestSlackSendServerErrorNoRetrySuccess(t *testing.T) {
+	var calls []slackCall
+	srv := newSlackTestServer(t, &calls, []func(http.ResponseWriter){
+		func(w http.ResponseWriter) { w.WriteHeader(http.StatusInternalServerError) },
+		func(w http.ResponseWriter) { w.WriteHeader(http.StatusInternalServerError) },
+	})
+	defer srv.Close()
+
+	n := newSlackNotifier(t, srv.URL, map[string]any{"channel": "#eng"})
+	err := n.Send(context.Background(), Message{Text: "hi"})
+	if err == nil {
+		t.Fatal("expected error when server keeps failing")
+	}
+	if len(calls) != 2 {
+		t.Fatalf("expected exactly 2 attempts (1 retry), got %d", len(calls))
+	}
+}
+
+func TestSlackOptionsPassthrough(t *testing.T) {
+	var calls []slackCall
+	srv := newSlackTestServer(t, &calls, []func(http.ResponseWriter){okResponse})
+	defer srv.Close()
+
+	n := newSlackNotifier(t, srv.URL, map[string]any{"channel": "#eng"})
+	err := n.Send(context.Background(), Message{
+		Text:    "hi",
+		Options: map[string]any{"unfurl_links": false, "thread_ts": "123.456"},
+	})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if got := calls[0].body["thread_ts"]; got != "123.456" {
+		t.Errorf("thread_ts = %v, want 123.456", got)
+	}
+	if got, ok := calls[0].body["unfurl_links"].(bool); !ok || got {
+		t.Errorf("unfurl_links = %v, want false", calls[0].body["unfurl_links"])
+	}
+	// Options must not override the core fields.
+	if got := calls[0].body["text"]; got != "hi" {
+		t.Errorf("text = %v, want hi", got)
+	}
+}

--- a/pkg/hub/notify/slack.go
+++ b/pkg/hub/notify/slack.go
@@ -1,0 +1,129 @@
+package notify
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+const defaultSlackAPIBase = "https://slack.com/api"
+
+// maxRetryAfter caps how long a 429 Retry-After can stall a pipeline action.
+const maxRetryAfter = 30 * time.Second
+
+type slackNotifier struct {
+	token   string
+	channel string
+	apiBase string
+	client  *http.Client
+}
+
+func newSlack(cfg map[string]any, secrets SecretResolver) (Notifier, error) {
+	secretName := stringOption(cfg, "token_secret")
+	if secretName == "" {
+		return nil, fmt.Errorf("slack notifier requires token_secret")
+	}
+	token, ok := secrets(secretName)
+	if !ok || token == "" {
+		return nil, fmt.Errorf("slack notifier secret %q not found in hub secrets", secretName)
+	}
+	apiBase := stringOption(cfg, "api_base")
+	if apiBase == "" {
+		apiBase = defaultSlackAPIBase
+	}
+	return &slackNotifier{
+		token:   token,
+		channel: stringOption(cfg, "channel"),
+		apiBase: apiBase,
+		client:  &http.Client{Timeout: 30 * time.Second},
+	}, nil
+}
+
+func (s *slackNotifier) Send(ctx context.Context, msg Message) error {
+	channel := msg.Target
+	if channel == "" {
+		channel = s.channel
+	}
+	if channel == "" {
+		return fmt.Errorf("slack notifier has no channel configured and the message sets no target")
+	}
+
+	payload := make(map[string]any, len(msg.Options)+2)
+	for k, v := range msg.Options {
+		payload[k] = v
+	}
+	payload["channel"] = channel
+	payload["text"] = msg.Text
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal slack payload: %w", err)
+	}
+
+	resp, err := s.post(ctx, body)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500 {
+		delay := retryAfter(resp)
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+		resp, err = s.post(ctx, body)
+		if err != nil {
+			return err
+		}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("slack API returned HTTP %d", resp.StatusCode)
+	}
+
+	var apiResp struct {
+		OK    bool   `json:"ok"`
+		Error string `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+		return fmt.Errorf("decode slack response: %w", err)
+	}
+	if !apiResp.OK {
+		return fmt.Errorf("slack API error: %s", apiResp.Error)
+	}
+	return nil
+}
+
+func (s *slackNotifier) post(ctx context.Context, body []byte) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.apiBase+"/chat.postMessage", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	req.Header.Set("Authorization", "Bearer "+s.token)
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("slack API request failed: %w", err)
+	}
+	return resp, nil
+}
+
+func retryAfter(resp *http.Response) time.Duration {
+	seconds, err := strconv.Atoi(resp.Header.Get("Retry-After"))
+	if err != nil || seconds < 0 {
+		return time.Second
+	}
+	delay := time.Duration(seconds) * time.Second
+	if delay > maxRetryAfter {
+		return maxRetryAfter
+	}
+	return delay
+}

--- a/pkg/hub/notify/slack.go
+++ b/pkg/hub/notify/slack.go
@@ -30,7 +30,7 @@ func newSlack(cfg map[string]any, secrets SecretResolver) (Notifier, error) {
 	}
 	token, ok := secrets(secretName)
 	if !ok || token == "" {
-		return nil, fmt.Errorf("slack notifier secret %q not found in hub secrets", secretName)
+		return nil, fmt.Errorf("slack notifier secret %q not found (checked workspace and hub secrets)", secretName)
 	}
 	apiBase := stringOption(cfg, "api_base")
 	if apiBase == "" {

--- a/pkg/hub/notify_action.go
+++ b/pkg/hub/notify_action.go
@@ -1,0 +1,163 @@
+package hub
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/hub/notify"
+	"github.com/elasticclaw/elasticclaw/pkg/hub/pipeline"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+const notifyActionTimeout = 30 * time.Second
+
+// executeNotifyAction sends a workflow notification. Notification failures are
+// deliberately advisory: they are logged and surfaced in the claw conversation
+// without blocking the rest of the stage transition.
+func (s *Server) executeNotifyAction(clawID string, stage pipeline.Stage, action pipeline.NotifyAction, pipelineCtx pipelineContext) {
+	workspace, err := s.workspaceForNotifyAction(clawID, pipelineCtx)
+	if err != nil {
+		s.warnNotifyAction(clawID, stage.ID, err)
+		return
+	}
+	config, ok := workspace.Notifiers[action.Via]
+	if !ok {
+		s.warnNotifyAction(clawID, stage.ID, fmt.Errorf("workspace %q has no notifier %q", workspace.Name, action.Via))
+		return
+	}
+
+	workspaceSecrets, err := loadWorkspaceSecrets(workspace.Name)
+	if err != nil {
+		s.warnNotifyAction(clawID, stage.ID, fmt.Errorf("load workspace secrets: %w", err))
+		return
+	}
+	s.mu.RLock()
+	hubSecrets := s.hubCfg.Secrets
+	s.mu.RUnlock()
+	// Workspace-scoped secrets take precedence over hub secrets, matching the
+	// resolution order used when creating workflow claws (workflow_creator.go).
+	resolver := func(name string) (string, bool) {
+		if value, ok := workspaceSecrets[name]; ok {
+			return value, true
+		}
+		value, ok := hubSecrets[name]
+		return value, ok
+	}
+	n, err := notify.New(config.Type, config.Settings, resolver)
+	if err != nil {
+		s.warnNotifyAction(clawID, stage.ID, fmt.Errorf("create notifier %q: %w", action.Via, err))
+		return
+	}
+
+	data := s.notifyTemplateData(clawID)
+	message := notify.Message{
+		Text:    renderInjectWithData(clawID, action.Text, data),
+		Subject: renderInjectWithData(clawID, action.Subject, data),
+		Target:  renderInjectWithData(clawID, action.Target, data),
+		Options: action.Options,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), notifyActionTimeout)
+	defer cancel()
+	if err := n.Send(ctx, message); err != nil {
+		s.warnNotifyAction(clawID, stage.ID, fmt.Errorf("send via notifier %q: %w", action.Via, err))
+		return
+	}
+	log.Printf("[pipeline] notify action sent for claw %s stage %q via %q", clawID, stage.ID, action.Via)
+}
+
+func (s *Server) workspaceForNotifyAction(clawID string, pipelineCtx pipelineContext) (*types.WorkspaceConfig, error) {
+	// Prefer the context the runner already resolved; only re-resolve from the
+	// claw's tags (and, failing that, the DB) when the caller had none.
+	if pipelineCtx.Workspace == nil && pipelineCtx.Factory == nil {
+		if found, ok := s.findPipelineContextForClaw(clawID); ok {
+			pipelineCtx = found
+		}
+	}
+	if pipelineCtx.Workspace != nil {
+		return pipelineCtx.Workspace, nil
+	}
+	if pipelineCtx.Factory != nil {
+		return loadNotifyWorkspace(pipelineCtx.Factory)
+	}
+
+	var factoryName string
+	if err := s.db.QueryRow(`SELECT COALESCE(factory_name,'') FROM claws WHERE id=?`, clawID).Scan(&factoryName); err != nil {
+		return nil, fmt.Errorf("resolve workspace for claw %q: %w", clawID, err)
+	}
+	for _, factory := range s.resolveFactories() {
+		if factory != nil && factory.Name == factoryName {
+			return loadNotifyWorkspace(factory)
+		}
+	}
+	if factoryName == "" {
+		return nil, fmt.Errorf("resolve workspace for claw %q: claw has no factory", clawID)
+	}
+	return nil, fmt.Errorf("resolve workspace for claw %q: factory %q was not found", clawID, factoryName)
+}
+
+func loadNotifyWorkspace(factory *types.FactoryConfig) (*types.WorkspaceConfig, error) {
+	workspaceName := strings.TrimSpace(factory.Workspace)
+	if workspaceName == "" {
+		return nil, fmt.Errorf("factory %q has no workspace configured", factory.Name)
+	}
+	workspace, err := loadExternalWorkspace(workspaceName)
+	if err != nil {
+		return nil, fmt.Errorf("load workspace %q for factory %q: %w", workspaceName, factory.Name, err)
+	}
+	return workspace, nil
+}
+
+func (s *Server) notifyTemplateData(clawID string) interface{} {
+	data := map[string]interface{}{}
+	if inputs := s.loadManualTriggerInputs(clawID); inputs != nil {
+		data["Inputs"] = inputs
+	}
+
+	pipelineCtx, _ := s.findPipelineContextForClaw(clawID)
+	issueID := pipelineCtx.IssueID
+	if issueID != "" {
+		data["Issue"] = s.notifyIssueTemplateData(clawID, pipelineCtx, issueID)
+	}
+	return s.injectTemplateData(clawID, data)
+}
+
+func (s *Server) notifyIssueTemplateData(clawID string, pipelineCtx pipelineContext, issueID string) interface{} {
+	if strings.Contains(issueID, "/") {
+		details := fallbackGitHubIssueDetails(issueID)
+		token := s.resolveGitHubIssuesTokenForPipeline(pipelineCtx)
+		parts := strings.Split(issueID, "/")
+		if token != "" && len(parts) == 3 {
+			var issueNumber int
+			if _, err := fmt.Sscanf(parts[2], "%d", &issueNumber); err == nil {
+				base := s.githubBaseURL
+				if fetched, err := s.fetchGitHubIssueDetails(token, parts[0]+"/"+parts[1], issueNumber, base); err == nil && fetched != nil {
+					return fetched
+				} else if err != nil {
+					log.Printf("[pipeline] notify issue template lookup failed for claw %s: %v", clawID, err)
+				}
+			}
+		}
+		return details
+	}
+
+	details := &linearIssueDetails{Identifier: issueID}
+	if !strings.HasPrefix(issueID, "sc-") {
+		if token := s.resolveLinearTokenForPipeline(pipelineCtx); token != "" {
+			if fetched, err := s.fetchLinearIssueDetails(token, issueID); err == nil && fetched != nil {
+				return fetched
+			} else if err != nil {
+				log.Printf("[pipeline] notify issue template lookup failed for claw %s: %v", clawID, err)
+			}
+		}
+	}
+	return details
+}
+
+func (s *Server) warnNotifyAction(clawID, stageID string, err error) {
+	msg := fmt.Sprintf("Notify action failed for stage %q: %v", stageID, err)
+	log.Printf("[pipeline] %s", msg)
+	s.injectHubMessageByID(clawID, "[hub] Warning: "+msg)
+}

--- a/pkg/hub/notify_action_test.go
+++ b/pkg/hub/notify_action_test.go
@@ -1,0 +1,269 @@
+package hub
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/elasticclaw/elasticclaw/pkg/hub/pipeline"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func TestNotifyActionSendsRenderedSlackMessage(t *testing.T) {
+	var payload map[string]any
+	slack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Errorf("decode Slack payload: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer slack.Close()
+
+	s, db, clawID := newNotifyActionTestServer(t, map[string]types.NotifierConfig{
+		"team-slack": {
+			Type: "slack",
+			Settings: map[string]any{
+				"token_secret": "slack-token",
+				"channel":      "#agents",
+				"api_base":     slack.URL,
+			},
+		},
+	})
+	s.persistPipelineOutput(clawID, "build", "result", &pipelineRunResult{
+		ExitCode: 0,
+		Stdout:   `{"status":"passed","channel":"#releases"}`,
+	})
+
+	stage := pipeline.Stage{ID: "announce", OnEnter: pipeline.OnEnter{Notify: pipeline.NotifyAction{
+		Enabled: true,
+		Via:     "team-slack",
+		Text:    "Build {{.Outputs.result.status}}",
+		Target:  "{{.Outputs.result.channel}}",
+	}}}
+	if proceeded := s.runOnEnter(clawID, stage, pipelineContext{}); !proceeded {
+		t.Fatal("notify action blocked the stage transition")
+	}
+	if payload["text"] != "Build passed" {
+		t.Fatalf("Slack text = %#v, want %q", payload["text"], "Build passed")
+	}
+	if payload["channel"] != "#releases" {
+		t.Fatalf("Slack channel = %#v, want %q", payload["channel"], "#releases")
+	}
+
+	var warningCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND content LIKE '%Notify action failed%'`, clawID).Scan(&warningCount); err != nil {
+		t.Fatalf("count warnings: %v", err)
+	}
+	if warningCount != 0 {
+		t.Fatalf("warning count = %d, want 0", warningCount)
+	}
+}
+
+func TestNotifyActionResolvesWorkspaceSecretFirst(t *testing.T) {
+	var authorization string
+	slack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authorization = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer slack.Close()
+
+	s, db, clawID := newNotifyActionTestServer(t, map[string]types.NotifierConfig{
+		"team-slack": {
+			Type: "slack",
+			Settings: map[string]any{
+				"token_secret": "slack-token",
+				"channel":      "#agents",
+				"api_base":     slack.URL,
+			},
+		},
+	})
+	// The same secret name exists at hub level ("xoxb-test"); the
+	// workspace-scoped value must win, matching workflow_creator resolution.
+	if err := saveWorkspaceSecret("notify-workspace", "slack-token", "xoxb-workspace"); err != nil {
+		t.Fatalf("save workspace secret: %v", err)
+	}
+
+	stage := pipeline.Stage{ID: "announce", OnEnter: pipeline.OnEnter{Notify: pipeline.NotifyAction{
+		Enabled: true, Via: "team-slack", Text: "hello",
+	}}}
+	if proceeded := s.runOnEnter(clawID, stage, pipelineContext{}); !proceeded {
+		t.Fatal("notify action blocked the stage transition")
+	}
+	if authorization != "Bearer xoxb-workspace" {
+		t.Fatalf("Authorization = %q, want workspace-scoped token", authorization)
+	}
+	if contents := notifyActionMessageContents(t, db, clawID); strings.Contains(contents, "Notify action failed") {
+		t.Fatalf("unexpected notify warning: %q", contents)
+	}
+}
+
+func TestNotifyActionResolvesWorkspaceOnlySecret(t *testing.T) {
+	slack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer slack.Close()
+
+	s, db, clawID := newNotifyActionTestServer(t, map[string]types.NotifierConfig{
+		"team-slack": {
+			Type: "slack",
+			Settings: map[string]any{
+				"token_secret": "ws-only-token",
+				"channel":      "#agents",
+				"api_base":     slack.URL,
+			},
+		},
+	})
+	if err := saveWorkspaceSecret("notify-workspace", "ws-only-token", "xoxb-ws-only"); err != nil {
+		t.Fatalf("save workspace secret: %v", err)
+	}
+
+	stage := pipeline.Stage{ID: "announce", OnEnter: pipeline.OnEnter{Notify: pipeline.NotifyAction{
+		Enabled: true, Via: "team-slack", Text: "hello",
+	}}}
+	if proceeded := s.runOnEnter(clawID, stage, pipelineContext{}); !proceeded {
+		t.Fatal("notify action blocked the stage transition")
+	}
+	if contents := notifyActionMessageContents(t, db, clawID); strings.Contains(contents, "Notify action failed") {
+		t.Fatalf("workspace-scoped secret was not resolved: %q", contents)
+	}
+}
+
+func TestNotifyActionUsesPipelineContextWorkspace(t *testing.T) {
+	var payload map[string]any
+	slack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&payload)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer slack.Close()
+
+	s, db, _ := newNotifyActionTestServer(t, map[string]types.NotifierConfig{
+		"team-slack": {
+			Type: "slack",
+			Settings: map[string]any{
+				"token_secret": "slack-token",
+				"channel":      "#agents",
+				"api_base":     slack.URL,
+			},
+		},
+	})
+	// A claw with no factory/workflow tags: the workspace must come from the
+	// pipelineContext handed to runOnEnter, not from re-resolution.
+	const clawID = "claw-notify-ctx"
+	if _, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, template, status, pipeline_stage, tags, created_at) VALUES(?,?,?,?,?,?,?,datetime('now'))`,
+		clawID, "test-tenant-id", "ctx-claw", "base", "connected", "", `[]`,
+	); err != nil {
+		t.Fatalf("insert claw: %v", err)
+	}
+	workspace, err := loadExternalWorkspace("notify-workspace")
+	if err != nil {
+		t.Fatalf("load workspace: %v", err)
+	}
+
+	stage := pipeline.Stage{ID: "announce", OnEnter: pipeline.OnEnter{Notify: pipeline.NotifyAction{
+		Enabled: true, Via: "team-slack", Text: "hello",
+	}}}
+	if proceeded := s.runOnEnter(clawID, stage, pipelineContext{Workspace: workspace}); !proceeded {
+		t.Fatal("notify action blocked the stage transition")
+	}
+	if payload["text"] != "hello" {
+		t.Fatalf("Slack text = %#v, want %q", payload["text"], "hello")
+	}
+	if contents := notifyActionMessageContents(t, db, clawID); strings.Contains(contents, "Notify action failed") {
+		t.Fatalf("pipeline context workspace was not used: %q", contents)
+	}
+}
+
+func TestNotifyActionUnknownViaIsNonBlocking(t *testing.T) {
+	s, db, clawID := newNotifyActionTestServer(t, nil)
+	stage := pipeline.Stage{ID: "announce", OnEnter: pipeline.OnEnter{
+		Inject: "transition continued",
+		Notify: pipeline.NotifyAction{Enabled: true, Via: "missing", Text: "hello"},
+	}}
+
+	if proceeded := s.runOnEnter(clawID, stage, pipelineContext{}); !proceeded {
+		t.Fatal("unknown notifier blocked the stage transition")
+	}
+	contents := notifyActionMessageContents(t, db, clawID)
+	if !strings.Contains(contents, "transition continued") {
+		t.Fatalf("messages do not contain subsequent action: %q", contents)
+	}
+	if !strings.Contains(contents, "[hub] Warning: Notify action failed") || !strings.Contains(contents, `notifier "missing"`) {
+		t.Fatalf("messages do not contain clear notify warning: %q", contents)
+	}
+}
+
+func TestNotifyActionSendFailureIsNonBlocking(t *testing.T) {
+	slack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":false,"error":"channel_not_found"}`))
+	}))
+	defer slack.Close()
+
+	s, db, clawID := newNotifyActionTestServer(t, map[string]types.NotifierConfig{
+		"team-slack": {
+			Type: "slack",
+			Settings: map[string]any{
+				"token_secret": "slack-token",
+				"channel":      "#agents",
+				"api_base":     slack.URL,
+			},
+		},
+	})
+	stage := pipeline.Stage{ID: "announce", OnEnter: pipeline.OnEnter{Notify: pipeline.NotifyAction{
+		Enabled: true, Via: "team-slack", Text: "hello",
+	}}}
+
+	if proceeded := s.runOnEnter(clawID, stage, pipelineContext{}); !proceeded {
+		t.Fatal("Slack send failure blocked the stage transition")
+	}
+	contents := notifyActionMessageContents(t, db, clawID)
+	if !strings.Contains(contents, "[hub] Warning: Notify action failed") || !strings.Contains(contents, "channel_not_found") {
+		t.Fatalf("messages do not contain Slack failure warning: %q", contents)
+	}
+}
+
+func newNotifyActionTestServer(t *testing.T, notifiers map[string]types.NotifierConfig) (*Server, *sql.DB, string) {
+	t.Helper()
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	const clawID = "claw-notify-action"
+	factory := &types.FactoryConfig{Name: "notify-factory", Workspace: "notify-workspace"}
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{
+		Token:     "test-token",
+		Secrets:   map[string]string{"slack-token": "xoxb-test"},
+		Factories: []*types.FactoryConfig{factory},
+	}, "", "", "")
+	SaveWorkspaceForTest(t, &types.WorkspaceConfig{Name: "notify-workspace", Notifiers: notifiers}, nil)
+	if _, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, template, status, pipeline_stage, tags, created_at) VALUES(?,?,?,?,?,?,?,datetime('now'))`,
+		clawID, "test-tenant-id", "test-claw", "base", "connected", "", `["factory:notify-factory"]`,
+	); err != nil {
+		t.Fatalf("insert claw: %v", err)
+	}
+	return s, db, clawID
+}
+
+func notifyActionMessageContents(t *testing.T, db *sql.DB, clawID string) string {
+	t.Helper()
+	rows, err := db.Query(`SELECT content FROM messages WHERE claw_id=? ORDER BY created_at`, clawID)
+	if err != nil {
+		t.Fatalf("query messages: %v", err)
+	}
+	defer rows.Close()
+	var contents []string
+	for rows.Next() {
+		var content string
+		if err := rows.Scan(&content); err != nil {
+			t.Fatalf("scan message: %v", err)
+		}
+		contents = append(contents, content)
+	}
+	return strings.Join(contents, "\n")
+}

--- a/pkg/hub/pipeline/pipeline.go
+++ b/pkg/hub/pipeline/pipeline.go
@@ -269,6 +269,35 @@ type JudgeAction struct {
 	Timeout string `yaml:"timeout,omitempty"`
 }
 
+// NotifyAction sends a message through a workspace-configured notifier
+// (Slack, and eventually email, Google Chat, Teams, ...). Via names the
+// notifier; Text supports the same template variables as inject
+// ({{.Issue.*}}, {{.Inputs.*}}, {{.Outputs.*}}).
+type NotifyAction struct {
+	Enabled bool `yaml:"-" json:"-"`
+	// Via is the name of the workspace notifier to send through.
+	Via string `yaml:"via"`
+	// Text is the message body (templated).
+	Text string `yaml:"text"`
+	// Subject is used by providers that have one (e.g. email); templated.
+	Subject string `yaml:"subject,omitempty"`
+	// Target overrides the notifier's default destination (channel, address).
+	Target string `yaml:"target,omitempty"`
+	// Options is a provider-specific passthrough (e.g. Slack thread_ts).
+	Options map[string]any `yaml:"options,omitempty"`
+}
+
+// Validate checks the action's own invariants.
+func (n NotifyAction) Validate() error {
+	if !n.Enabled {
+		return nil
+	}
+	if strings.TrimSpace(n.Via) == "" {
+		return fmt.Errorf("notify action requires via (the notifier name)")
+	}
+	return nil
+}
+
 // OnEnter holds the actions to run when entering a stage.
 type OnEnter struct {
 	// Run executes a command in the agent workspace.
@@ -289,6 +318,8 @@ type OnEnter struct {
 	AddLabels []string `yaml:"add_labels,omitempty"`
 	// RemoveLabels removes the specified labels from the associated GitHub issue.
 	RemoveLabels []string `yaml:"remove_labels,omitempty"`
+	// Notify sends a message through a workspace-configured notifier.
+	Notify NotifyAction `yaml:"notify,omitempty"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler for OnEnter so that move_issue can
@@ -305,6 +336,7 @@ func (oe *OnEnter) UnmarshalYAML(value *yaml.Node) error {
 		CloseIssue           bool        `yaml:"close_issue,omitempty"`
 		AddLabels            []string    `yaml:"add_labels,omitempty"`
 		RemoveLabels         []string    `yaml:"remove_labels,omitempty"`
+		NotifyRaw            yaml.Node   `yaml:"notify"`
 	}
 	var raw rawOnEnter
 	if err := value.Decode(&raw); err != nil {
@@ -326,6 +358,15 @@ func (oe *OnEnter) UnmarshalYAML(value *yaml.Node) error {
 		}
 		dua.Enabled = true
 		oe.DependencyUpdates = dua
+	}
+
+	if raw.NotifyRaw.Kind != 0 {
+		var na NotifyAction
+		if err := raw.NotifyRaw.Decode(&na); err != nil {
+			return err
+		}
+		na.Enabled = true
+		oe.Notify = na
 	}
 
 	if raw.MoveIssueRaw.Kind == 0 {
@@ -385,6 +426,9 @@ func (p *Pipeline) Validate() error {
 				return err
 			}
 			skipEdges[stage.ID] = append(skipEdges[stage.ID], skip.rule.GoTo)
+		}
+		if err := stage.OnEnter.Notify.Validate(); err != nil {
+			return fmt.Errorf("stage %q: %w", stage.ID, err)
 		}
 	}
 	if cycle := firstSkipCycle(skipEdges); len(cycle) > 0 {

--- a/pkg/hub/pipeline/pipeline_test.go
+++ b/pkg/hub/pipeline/pipeline_test.go
@@ -723,3 +723,68 @@ func TestGetJSONPath(t *testing.T) {
 		t.Fatalf("details.missing = %v, want nil", v)
 	}
 }
+
+func TestParseNotifyAction(t *testing.T) {
+	p, err := pipeline.Parse([]byte(`
+stages:
+  - id: done
+    on_enter:
+      notify:
+        via: eng-releases
+        text: "PR merged for {{.Issue.Identifier}}"
+        subject: "PR merged"
+        target: "#override"
+        options:
+          thread_ts: "123.456"
+`))
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	action := p.Stages[0].OnEnter.Notify
+	if !action.Enabled {
+		t.Fatal("notify should be marked enabled when present")
+	}
+	if action.Via != "eng-releases" {
+		t.Fatalf("via = %q, want eng-releases", action.Via)
+	}
+	if action.Text != "PR merged for {{.Issue.Identifier}}" {
+		t.Fatalf("text = %q", action.Text)
+	}
+	if action.Subject != "PR merged" {
+		t.Fatalf("subject = %q", action.Subject)
+	}
+	if action.Target != "#override" {
+		t.Fatalf("target = %q", action.Target)
+	}
+	if action.Options["thread_ts"] != "123.456" {
+		t.Fatalf("options.thread_ts = %v", action.Options["thread_ts"])
+	}
+}
+
+func TestParseNotifyActionRequiresVia(t *testing.T) {
+	_, err := pipeline.Parse([]byte(`
+stages:
+  - id: done
+    on_enter:
+      notify:
+        text: "hello"
+`))
+	if err == nil {
+		t.Fatal("expected validation error when notify.via is missing")
+	}
+}
+
+func TestParseNotifyActionAbsent(t *testing.T) {
+	p, err := pipeline.Parse([]byte(`
+stages:
+  - id: done
+    on_enter:
+      inject: "hello"
+`))
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	if p.Stages[0].OnEnter.Notify.Enabled {
+		t.Fatal("notify should not be enabled when absent")
+	}
+}

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -1186,6 +1186,10 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 		}
 	}
 
+	if stage.OnEnter.Notify.Enabled {
+		s.executeNotifyAction(clawID, stage, stage.OnEnter.Notify, ctx)
+	}
+
 	targetStatus := stage.OnEnter.MoveIssue.Status
 	if targetStatus == "" {
 		return true

--- a/pkg/types/workspace.go
+++ b/pkg/types/workspace.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -10,14 +11,80 @@ import (
 // WorkspaceConfig defines a persisted workspace. Workflows live beside this
 // file in external storage and are loaded into Workflows at API boundaries.
 type WorkspaceConfig struct {
-	SchemaVersion  string               `yaml:"schema_version,omitempty" json:"schemaVersion,omitempty"`
-	Name           string               `yaml:"name" json:"name"`
-	Repositories   RepositoryAccessList `yaml:"repositories,omitempty" json:"repositories,omitempty"`
-	Env            WorkspaceEnv         `yaml:"env,omitempty" json:"env,omitempty"`
-	Secrets        []string             `yaml:"secrets,omitempty" json:"secrets,omitempty"`
-	WebhookSecrets []string             `yaml:"webhook_secrets,omitempty" json:"webhookSecrets,omitempty"`
-	Workflows      []*WorkflowConfig    `yaml:"-" json:"workflows,omitempty"`
-	Files          map[string]string    `yaml:"-" json:"files,omitempty"`
+	SchemaVersion  string                    `yaml:"schema_version,omitempty" json:"schemaVersion,omitempty"`
+	Name           string                    `yaml:"name" json:"name"`
+	Repositories   RepositoryAccessList      `yaml:"repositories,omitempty" json:"repositories,omitempty"`
+	Env            WorkspaceEnv              `yaml:"env,omitempty" json:"env,omitempty"`
+	Secrets        []string                  `yaml:"secrets,omitempty" json:"secrets,omitempty"`
+	WebhookSecrets []string                  `yaml:"webhook_secrets,omitempty" json:"webhookSecrets,omitempty"`
+	Notifiers      map[string]NotifierConfig `yaml:"notifiers,omitempty" json:"notifiers,omitempty"`
+	Workflows      []*WorkflowConfig         `yaml:"-" json:"workflows,omitempty"`
+	Files          map[string]string         `yaml:"-" json:"files,omitempty"`
+}
+
+// NotifierConfig defines an outbound messaging transport and its
+// provider-specific settings.
+type NotifierConfig struct {
+	Type     string         `yaml:"type"`
+	Settings map[string]any `yaml:",inline"`
+}
+
+func (n *NotifierConfig) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind != yaml.MappingNode {
+		return fmt.Errorf("notifier: expected a mapping")
+	}
+	var flattened map[string]any
+	if err := value.Decode(&flattened); err != nil {
+		return err
+	}
+	return n.fromFlattened(flattened)
+}
+
+func (n NotifierConfig) MarshalYAML() (interface{}, error) {
+	return n.flattened(), nil
+}
+
+func (n *NotifierConfig) UnmarshalJSON(data []byte) error {
+	var flattened map[string]any
+	if err := json.Unmarshal(data, &flattened); err != nil {
+		return err
+	}
+	if flattened == nil {
+		return fmt.Errorf("notifier: expected an object")
+	}
+	return n.fromFlattened(flattened)
+}
+
+func (n NotifierConfig) MarshalJSON() ([]byte, error) {
+	return json.Marshal(n.flattened())
+}
+
+func (n *NotifierConfig) fromFlattened(flattened map[string]any) error {
+	n.Type = ""
+	n.Settings = make(map[string]any, len(flattened))
+	for key, value := range flattened {
+		if key == "type" {
+			var ok bool
+			n.Type, ok = value.(string)
+			if !ok {
+				return fmt.Errorf("notifier type must be a string")
+			}
+			continue
+		}
+		n.Settings[key] = value
+	}
+	return nil
+}
+
+func (n NotifierConfig) flattened() map[string]any {
+	flattened := make(map[string]any, len(n.Settings)+1)
+	for key, value := range n.Settings {
+		if key != "type" {
+			flattened[key] = value
+		}
+	}
+	flattened["type"] = n.Type
+	return flattened
 }
 
 // WorkflowConfig is the persisted workflow schema.
@@ -182,6 +249,14 @@ func (w *WorkspaceConfig) Validate() error {
 	}
 	if err := validateRepositoryAccessList("repositories", w.Repositories); err != nil {
 		return fmt.Errorf("workspace %q: %w", w.Name, err)
+	}
+	for name, notifier := range w.Notifiers {
+		if name == "" {
+			return fmt.Errorf("workspace %q: notifier name is required", w.Name)
+		}
+		if notifier.Type == "" {
+			return fmt.Errorf("workspace %q: notifier %q: notifier type is required", w.Name, name)
+		}
 	}
 	for _, workflow := range w.Workflows {
 		if workflow == nil {

--- a/pkg/types/workspace_test.go
+++ b/pkg/types/workspace_test.go
@@ -1,0 +1,115 @@
+package types
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestWorkspaceConfigNotifiersYAMLRoundTrip(t *testing.T) {
+	want := WorkspaceConfig{
+		Name: "example",
+		Notifiers: map[string]NotifierConfig{
+			"team-slack": {
+				Type: "slack",
+				Settings: map[string]any{
+					"token_secret": "slack-bot-token",
+					"channel":      "#agents",
+				},
+			},
+		},
+	}
+
+	data, err := yaml.Marshal(&want)
+	if err != nil {
+		t.Fatalf("marshal workspace: %v", err)
+	}
+	text := string(data)
+	if strings.Contains(text, "settings:") {
+		t.Fatalf("marshaled notifier contains nested settings: %s", text)
+	}
+	for _, field := range []string{"type: slack", "token_secret: slack-bot-token", "channel: '#agents'"} {
+		if !strings.Contains(text, field) {
+			t.Fatalf("marshaled workspace does not contain %q: %s", field, text)
+		}
+	}
+
+	var got WorkspaceConfig
+	if err := yaml.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal workspace: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("round-trip workspace = %#v, want %#v", got, want)
+	}
+}
+
+func TestWorkspaceConfigNotifierValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		notifiers map[string]NotifierConfig
+		want      string
+	}{
+		{
+			name:      "missing type",
+			notifiers: map[string]NotifierConfig{"team-slack": {}},
+			want:      "notifier type is required",
+		},
+		{
+			name:      "empty name",
+			notifiers: map[string]NotifierConfig{"": {Type: "slack"}},
+			want:      "notifier name is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			workspace := &WorkspaceConfig{Name: "example", Notifiers: tt.notifiers}
+			err := workspace.Validate()
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Validate() error = %v, want containing %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestWorkspaceConfigNotifiersJSONRoundTrip(t *testing.T) {
+	want := WorkspaceConfig{
+		Name: "example",
+		Notifiers: map[string]NotifierConfig{
+			"team-slack": {
+				Type: "slack",
+				Settings: map[string]any{
+					"token_secret": "slack-bot-token",
+					"channel":      "#agents",
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(&want)
+	if err != nil {
+		t.Fatalf("marshal workspace: %v", err)
+	}
+	var shape map[string]any
+	if err := json.Unmarshal(data, &shape); err != nil {
+		t.Fatalf("unmarshal JSON shape: %v", err)
+	}
+	notifier := shape["notifiers"].(map[string]any)["team-slack"].(map[string]any)
+	if _, ok := notifier["settings"]; ok {
+		t.Fatalf("marshaled notifier contains nested settings: %s", data)
+	}
+	if notifier["type"] != "slack" || notifier["token_secret"] != "slack-bot-token" || notifier["channel"] != "#agents" {
+		t.Fatalf("marshaled notifier has unexpected shape: %#v", notifier)
+	}
+
+	var got WorkspaceConfig
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal workspace: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("round-trip workspace = %#v, want %#v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Workflows can now send outbound messages from pipeline stages via a new `notify` `on_enter` action, backed by workspace-level named **notifiers**. Slack is the first provider; the design makes adding email, Google Chat, Teams, etc. a single new file in `pkg/hub/notify` (register a constructor — no pipeline, runner, or schema changes).

```yaml
# workspace.yaml — transport, configured once
notifiers:
  eng-releases:
    type: slack
    token_secret: slack-bot-token
    channel: "#eng-releases"
```

```yaml
# workflow stage — logic only, provider-agnostic
on_enter:
  notify:
    via: eng-releases
    text: "✅ {{.Issue.Identifier}}: PR merged — {{.Issue.URL}}"
```

## Design

- **Two layers**: transport + credentials live in `WorkspaceConfig.Notifiers`; stages reference a notifier by name (`via`) and supply the message. Swapping Slack for another provider never touches workflow definitions.
- **`pkg/hub/notify`**: `Notifier` interface + provider registry. Slack provider posts `chat.postMessage` with bot token, retries once on 429/5xx honoring `Retry-After`, and treats HTTP-200 `{"ok":false}` as an error.
- **Action contract**: `via`, `text`, `subject`, `target`, `options` (provider passthrough, e.g. `thread_ts`). `text`/`subject`/`target` support the same template variables as `inject` (`{{.Issue.*}}`, `{{.Inputs.*}}`, `{{.Outputs.*}}`).
- **Non-blocking**: notification failures inject a warning into the claw but never block the stage transition.
- **Secrets**: resolved workspace-scoped first, then hub-level, matching the existing workflow secret contract; snapshot taken under `s.mu.RLock` per codebase convention.
- **Doctor**: validates that `via` references an existing notifier, the type is supported, `token_secret` resolves (same order as runtime), and flags `notify` blocks without a valid `via` (fatal at pipeline parse time).

## Testing

- TDD throughout; all new behavior covered at parse level (`pkg/hub/pipeline`), provider level (`pkg/hub/notify` with httptest Slack servers), runner level (`notify_action_test.go`), schema round-trip (`pkg/types`), and doctor checks.
- Independent dual review (Claude + Codex) found 6 issues — workspace-secret resolution, doctor/runtime parity, a data race, context re-resolution, and a silently skipped invalid `via` — all fixed with failing tests first.
- `go build ./...`, `go vet`, `go test ./...`, and `gofmt` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)