### PR TITLE
Agent logs in analytics drill-down

### DIFF
--- a/pkg/hub/task_run_analytics_api.go
+++ b/pkg/hub/task_run_analytics_api.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
 
 const taskRunAnalyticsDefaultLimit = 50
@@ -72,6 +74,10 @@ type taskRunAnalyticsEventsResponse struct {
 
 type taskRunAnalyticsPRsResponse struct {
 	PRs []taskRunAnalyticsPRView `json:"prs"`
+}
+
+type taskRunAnalyticsOutputsResponse struct {
+	Outputs []taskRunAnalyticsOutputView `json:"outputs"`
 }
 
 type taskRunAnalyticsFilterOptionsResponse struct {
@@ -188,6 +194,17 @@ type taskRunAnalyticsPRView struct {
 	UpdatedAt        int64  `json:"updatedAt"`
 }
 
+type taskRunAnalyticsOutputView struct {
+	ClawID     string `json:"clawId"`
+	AttemptID  string `json:"attemptId,omitempty"`
+	StageID    string `json:"stageId"`
+	OutputName string `json:"outputName"`
+	Stdout     string `json:"stdout"`
+	Stderr     string `json:"stderr"`
+	ExitCode   int    `json:"exitCode"`
+	CreatedAt  int64  `json:"createdAt"`
+}
+
 type taskRunAnalyticsFilters struct {
 	TenantID         string
 	FromStartedAt    int64
@@ -247,7 +264,7 @@ func (s *Server) handleTaskRunAnalyticsRuns(w http.ResponseWriter, r *http.Reque
 		jsonError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	runs, nextCursor, err := s.readTaskRunAnalyticsRuns(filters, limit, cursorStartedAt, cursorRunID)
+	runs, nextCursor, err := s.readTaskRunAnalyticsRunsForRequest(filters, limit, cursorStartedAt, cursorRunID, githubLoginFromContext(r.Context()))
 	if err != nil {
 		jsonError(w, http.StatusInternalServerError, "db error")
 		return
@@ -271,24 +288,23 @@ func (s *Server) handleTaskRunAnalyticsRunSubresource(w http.ResponseWriter, r *
 		jsonError(w, http.StatusBadRequest, "invalid run id")
 		return
 	}
+	run, found, err := s.readTaskRunAnalyticsRun(tenantID, runID)
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "db error")
+		return
+	}
+	if !found {
+		jsonError(w, http.StatusNotFound, "not found")
+		return
+	}
+	if !s.canViewTaskRunAnalyticsRun(w, r, tenantID, run.ClawID) {
+		return
+	}
 	if len(parts) == 1 {
-		run, found, err := s.readTaskRunAnalyticsRun(tenantID, runID)
-		if err != nil {
-			jsonError(w, http.StatusInternalServerError, "db error")
-			return
-		}
-		if !found {
-			jsonError(w, http.StatusNotFound, "not found")
-			return
-		}
 		jsonOK(w, taskRunAnalyticsRunDetailResponse{Run: run})
 		return
 	}
 	if len(parts) != 2 {
-		jsonError(w, http.StatusNotFound, "not found")
-		return
-	}
-	if !s.taskRunAnalyticsRunExists(tenantID, runID) {
 		jsonError(w, http.StatusNotFound, "not found")
 		return
 	}
@@ -314,6 +330,13 @@ func (s *Server) handleTaskRunAnalyticsRunSubresource(w http.ResponseWriter, r *
 			return
 		}
 		jsonOK(w, taskRunAnalyticsPRsResponse{PRs: prs})
+	case "outputs":
+		outputs, err := s.readTaskRunAnalyticsOutputs(tenantID, runID, run.ClawID)
+		if err != nil {
+			jsonError(w, http.StatusInternalServerError, "db error")
+			return
+		}
+		jsonOK(w, taskRunAnalyticsOutputsResponse{Outputs: outputs})
 	default:
 		jsonError(w, http.StatusNotFound, "not found")
 	}
@@ -463,6 +486,89 @@ func (s *Server) readTaskRunAnalyticsRuns(filters taskRunAnalyticsFilters, limit
 	return runs, nextCursor, nil
 }
 
+func (s *Server) readTaskRunAnalyticsRunsForRequest(filters taskRunAnalyticsFilters, limit int, cursorStartedAt int64, cursorRunID, githubLogin string) ([]taskRunAnalyticsRunView, string, error) {
+	if githubLogin == "" {
+		return s.readTaskRunAnalyticsRuns(filters, limit, cursorStartedAt, cursorRunID)
+	}
+	accessCfg := s.taskRunAnalyticsAccessConfig()
+	if accessCfg == nil || len(accessCfg.ViewRequiresTags) == 0 {
+		return s.readTaskRunAnalyticsRuns(filters, limit, cursorStartedAt, cursorRunID)
+	}
+
+	const batchSize = taskRunAnalyticsMaxLimit
+	visible := make([]taskRunAnalyticsRunView, 0, limit+1)
+	batchStartedAt, batchRunID := cursorStartedAt, cursorRunID
+	for {
+		batch, batchNextCursor, err := s.readTaskRunAnalyticsRuns(filters, batchSize, batchStartedAt, batchRunID)
+		if err != nil {
+			return nil, "", err
+		}
+		clawTags, err := s.readTaskRunAnalyticsClawTags(filters.TenantID, batch)
+		if err != nil {
+			return nil, "", err
+		}
+		for _, run := range batch {
+			tags, found := clawTags[run.ClawID]
+			if !found || !canViewClaw(accessCfg, githubLogin, tags) {
+				continue
+			}
+			visible = append(visible, run)
+			if len(visible) == limit+1 {
+				last := visible[limit-1]
+				return visible[:limit], encodeTaskRunAnalyticsCursor(last.StartedAt, last.RunID), nil
+			}
+		}
+		if batchNextCursor == "" {
+			return visible, "", nil
+		}
+		batchStartedAt, batchRunID, err = decodeTaskRunAnalyticsCursor(batchNextCursor)
+		if err != nil {
+			return nil, "", err
+		}
+	}
+}
+
+func (s *Server) readTaskRunAnalyticsClawTags(tenantID string, runs []taskRunAnalyticsRunView) (map[string][]string, error) {
+	clawIDs := make([]string, 0, len(runs))
+	seen := make(map[string]bool, len(runs))
+	for _, run := range runs {
+		if run.ClawID == "" || seen[run.ClawID] {
+			continue
+		}
+		seen[run.ClawID] = true
+		clawIDs = append(clawIDs, run.ClawID)
+	}
+	tagsByClawID := make(map[string][]string, len(clawIDs))
+	if len(clawIDs) == 0 {
+		return tagsByClawID, nil
+	}
+
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(clawIDs)), ",")
+	args := make([]any, 0, len(clawIDs)+1)
+	args = append(args, tenantID)
+	for _, clawID := range clawIDs {
+		args = append(args, clawID)
+	}
+	rows, err := s.db.Query(`
+		SELECT id, COALESCE(tags,'[]')
+		  FROM claws
+		 WHERE tenant_id=? AND id IN (`+placeholders+`)`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var clawID, tagsJSON string
+		if err := rows.Scan(&clawID, &tagsJSON); err != nil {
+			return nil, err
+		}
+		var tags []string
+		_ = json.Unmarshal([]byte(tagsJSON), &tags)
+		tagsByClawID[clawID] = tags
+	}
+	return tagsByClawID, rows.Err()
+}
+
 func (s *Server) readTaskRunAnalyticsRun(tenantID, runID string) (taskRunAnalyticsRunView, bool, error) {
 	rows, err := s.db.Query(`
 		SELECT `+taskRunAnalyticsRunColumns()+`
@@ -557,6 +663,123 @@ func (s *Server) readTaskRunAnalyticsPRs(tenantID, runID string) ([]taskRunAnaly
 		prs = append(prs, pr)
 	}
 	return prs, rows.Err()
+}
+
+func (s *Server) readTaskRunAnalyticsOutputs(tenantID, runID, runClawID string) ([]taskRunAnalyticsOutputView, error) {
+	attemptRows, err := s.db.Query(`
+		SELECT attempt_id, claw_id
+		  FROM task_run_attempts
+		 WHERE tenant_id=? AND run_id=?
+		 ORDER BY attempt_number ASC`, tenantID, runID)
+	if err != nil {
+		return nil, err
+	}
+	attemptByClaw := map[string]string{}
+	clawIDs := []string{}
+	seenClaws := map[string]bool{}
+	if runClawID != "" {
+		clawIDs = append(clawIDs, runClawID)
+		seenClaws[runClawID] = true
+	}
+	for attemptRows.Next() {
+		var attemptID, clawID string
+		if err := attemptRows.Scan(&attemptID, &clawID); err != nil {
+			attemptRows.Close()
+			return nil, err
+		}
+		if clawID == "" {
+			continue
+		}
+		attemptByClaw[clawID] = attemptID
+		if !seenClaws[clawID] {
+			clawIDs = append(clawIDs, clawID)
+			seenClaws[clawID] = true
+		}
+	}
+	if err := attemptRows.Err(); err != nil {
+		attemptRows.Close()
+		return nil, err
+	}
+	attemptRows.Close()
+	if len(clawIDs) == 0 {
+		return []taskRunAnalyticsOutputView{}, nil
+	}
+
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(clawIDs)), ",")
+	args := make([]any, 0, len(clawIDs))
+	for _, clawID := range clawIDs {
+		args = append(args, clawID)
+	}
+	rows, err := s.db.Query(`
+		SELECT claw_id, stage_id, output_name, stdout, stderr, exit_code, created_at
+		  FROM pipeline_outputs
+		 WHERE claw_id IN (`+placeholders+`)
+		 ORDER BY created_at ASC, claw_id ASC, output_name ASC`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	outputs := []taskRunAnalyticsOutputView{}
+	for rows.Next() {
+		var output taskRunAnalyticsOutputView
+		var createdAt time.Time
+		if err := rows.Scan(&output.ClawID, &output.StageID, &output.OutputName, &output.Stdout, &output.Stderr, &output.ExitCode, &createdAt); err != nil {
+			return nil, err
+		}
+		output.AttemptID = attemptByClaw[output.ClawID]
+		output.CreatedAt = epochMillis(createdAt)
+		outputs = append(outputs, output)
+	}
+	return outputs, rows.Err()
+}
+
+func (s *Server) canViewTaskRunAnalyticsRun(w http.ResponseWriter, r *http.Request, tenantID, clawID string) bool {
+	githubLogin := githubLoginFromContext(r.Context())
+	if githubLogin == "" {
+		return true
+	}
+	allowed, found, err := s.taskRunAnalyticsClawAccess(tenantID, clawID, githubLogin)
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "db error")
+		return false
+	}
+	if !found {
+		jsonError(w, http.StatusNotFound, "not found")
+		return false
+	}
+	if !allowed {
+		jsonError(w, http.StatusForbidden, "forbidden")
+		return false
+	}
+	return true
+}
+
+func (s *Server) taskRunAnalyticsClawAccess(tenantID, clawID, githubLogin string) (allowed, found bool, err error) {
+	accessCfg := s.taskRunAnalyticsAccessConfig()
+	if accessCfg == nil || len(accessCfg.ViewRequiresTags) == 0 {
+		return true, true, nil
+	}
+
+	var tagsJSON string
+	err = s.db.QueryRow(`SELECT COALESCE(tags,'[]') FROM claws WHERE id=? AND tenant_id=?`, clawID, tenantID).Scan(&tagsJSON)
+	if err == sql.ErrNoRows {
+		return false, false, nil
+	}
+	if err != nil {
+		return false, false, err
+	}
+	var clawTags []string
+	_ = json.Unmarshal([]byte(tagsJSON), &clawTags)
+	return canViewClaw(accessCfg, githubLogin, clawTags), true, nil
+}
+
+func (s *Server) taskRunAnalyticsAccessConfig() *types.AccessConfig {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.hubCfg.Auth != nil {
+		return s.hubCfg.Auth.Access
+	}
+	return nil
 }
 
 func (s *Server) readTaskRunAnalyticsFilterOptions(tenantID string) (taskRunAnalyticsFilterOptionsResponse, error) {

--- a/pkg/hub/task_run_analytics_api_test.go
+++ b/pkg/hub/task_run_analytics_api_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
@@ -211,6 +212,167 @@ func TestTaskRunAnalyticsAPIRunDetailsAttemptsEventsAndPRs(t *testing.T) {
 	notFoundRR := requestTaskRunAnalyticsAPI(t, s, http.MethodGet, "/api/analytics/runs/run-other-tenant", "test-token")
 	if notFoundRR.Code != http.StatusNotFound {
 		t.Fatalf("cross-tenant detail status = %d, body = %s", notFoundRR.Code, notFoundRR.Body.String())
+	}
+}
+
+func TestTaskRunAnalyticsAPIOutputs(t *testing.T) {
+	s, db := newTaskRunAnalyticsAPITestServer(t)
+	ts := int64(1760000000000)
+	insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{
+		RunID: "run-outputs", AttemptID: "attempt-one", ClawID: "claw-one", TenantID: "test-tenant-id",
+		Status: taskRunStatusCleanSuccess, Phase: taskRunPhaseTerminal, OwnerType: taskRunOwnerFactory,
+		Factory: "bugfix", StartedAt: ts,
+	})
+	if _, err := db.Exec(`
+		INSERT INTO task_run_attempts(id, tenant_id, run_id, attempt_id, attempt_number, claw_id, status, started_at, created_at, updated_at)
+		VALUES(?,?,?,?,?,?,?,?,?,?)`,
+		"attempt-two", "test-tenant-id", "run-outputs", "attempt-two", 2, "claw-two", "succeeded", ts+100, ts+100, ts+100,
+	); err != nil {
+		t.Fatalf("insert second attempt: %v", err)
+	}
+	for _, output := range []struct {
+		clawID, stageID, name, stdout, stderr string
+		exitCode                              int
+		createdAt                             time.Time
+	}{
+		{clawID: "claw-one", stageID: "prepare", name: "checkout", stdout: "ready", createdAt: time.UnixMilli(ts)},
+		{clawID: "claw-two", stageID: "verify", name: "tests", stderr: "failed test", exitCode: 1, createdAt: time.UnixMilli(ts + 200)},
+		{clawID: "unrelated", stageID: "hidden", name: "other", stdout: "ignore", createdAt: time.UnixMilli(ts + 300)},
+	} {
+		if _, err := db.Exec(`
+			INSERT INTO pipeline_outputs(claw_id, stage_id, output_name, stdout, stderr, exit_code, created_at)
+			VALUES(?,?,?,?,?,?,?)`, output.clawID, output.stageID, output.name, output.stdout, output.stderr, output.exitCode, output.createdAt); err != nil {
+			t.Fatalf("insert pipeline output: %v", err)
+		}
+	}
+
+	rr := requestTaskRunAnalyticsAPI(t, s, http.MethodGet, "/api/analytics/runs/run-outputs/outputs", "test-token")
+	var response taskRunAnalyticsOutputsResponse
+	decodeTaskRunAnalyticsAPI(t, rr, &response)
+	if len(response.Outputs) != 2 {
+		t.Fatalf("outputs = %#v", response.Outputs)
+	}
+	if response.Outputs[0].AttemptID != "attempt-one" || response.Outputs[0].Stdout != "ready" || response.Outputs[0].CreatedAt != ts {
+		t.Fatalf("unexpected first output: %#v", response.Outputs[0])
+	}
+	if response.Outputs[1].AttemptID != "attempt-two" || response.Outputs[1].ExitCode != 1 || response.Outputs[1].Stderr != "failed test" {
+		t.Fatalf("unexpected second output: %#v", response.Outputs[1])
+	}
+
+	insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{
+		RunID: "run-empty", AttemptID: "attempt-empty", ClawID: "claw-empty", TenantID: "test-tenant-id",
+		OwnerType: taskRunOwnerFactory, Factory: "bugfix", StartedAt: ts + 1000,
+	})
+	emptyRR := requestTaskRunAnalyticsAPI(t, s, http.MethodGet, "/api/analytics/runs/run-empty/outputs", "test-token")
+	var empty taskRunAnalyticsOutputsResponse
+	decodeTaskRunAnalyticsAPI(t, emptyRR, &empty)
+	if empty.Outputs == nil || len(empty.Outputs) != 0 {
+		t.Fatalf("empty outputs should be an empty array, got %#v", empty.Outputs)
+	}
+}
+
+func TestTaskRunAnalyticsAPIAccessControl(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{
+		Token: "test-token",
+		Auth: &types.AuthConfig{
+			SessionSecret: "analytics-session-secret",
+			Access:        &types.AccessConfig{ViewRequiresTags: []string{"owner={user}"}},
+		},
+	}, "", "", "")
+	ts := int64(1760000000000)
+	insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{
+		RunID: "run-alice", AttemptID: "attempt-alice", ClawID: "claw-alice", TenantID: "test-tenant-id",
+		Status: taskRunStatusCleanSuccess, OwnerType: taskRunOwnerFactory, Factory: "bugfix", StartedAt: ts + 100,
+	})
+	insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{
+		RunID: "run-bob", AttemptID: "attempt-bob", ClawID: "claw-bob", TenantID: "test-tenant-id",
+		Status: taskRunStatusCleanSuccess, OwnerType: taskRunOwnerFactory, Factory: "bugfix", StartedAt: ts,
+	})
+	for _, claw := range []struct{ id, tags string }{
+		{id: "claw-alice", tags: `["owner=alice"]`},
+		{id: "claw-bob", tags: `["owner=bob"]`},
+	} {
+		if _, err := db.Exec(`INSERT INTO claws(id, tenant_id, name, tags, created_at) VALUES(?,?,?,?,datetime('now'))`, claw.id, "test-tenant-id", claw.id, claw.tags); err != nil {
+			t.Fatalf("insert claw: %v", err)
+		}
+	}
+	bobSession, err := signGitHubSession("analytics-session-secret", "bob", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	listRR := requestTaskRunAnalyticsAPI(t, s, http.MethodGet, "/api/analytics/runs", bobSession)
+	var list taskRunAnalyticsRunsResponse
+	decodeTaskRunAnalyticsAPI(t, listRR, &list)
+	if len(list.Runs) != 1 || list.Runs[0].RunID != "run-bob" {
+		t.Fatalf("OAuth list was not ACL-filtered: %#v", list.Runs)
+	}
+	for _, path := range []string{
+		"/api/analytics/runs/run-alice",
+		"/api/analytics/runs/run-alice/attempts",
+		"/api/analytics/runs/run-alice/events",
+		"/api/analytics/runs/run-alice/prs",
+		"/api/analytics/runs/run-alice/outputs",
+	} {
+		rr := requestTaskRunAnalyticsAPI(t, s, http.MethodGet, path, bobSession)
+		if rr.Code != http.StatusForbidden && rr.Code != http.StatusNotFound {
+			t.Fatalf("OAuth request %s status = %d, body = %s", path, rr.Code, rr.Body.String())
+		}
+	}
+	allowedRR := requestTaskRunAnalyticsAPI(t, s, http.MethodGet, "/api/analytics/runs/run-bob", bobSession)
+	if allowedRR.Code != http.StatusOK {
+		t.Fatalf("allowed OAuth detail status = %d, body = %s", allowedRR.Code, allowedRR.Body.String())
+	}
+	if _, err := db.Exec(`DELETE FROM claws WHERE id=?`, "claw-bob"); err != nil {
+		t.Fatalf("delete claw: %v", err)
+	}
+	missingClawListRR := requestTaskRunAnalyticsAPI(t, s, http.MethodGet, "/api/analytics/runs", bobSession)
+	var missingClawList taskRunAnalyticsRunsResponse
+	decodeTaskRunAnalyticsAPI(t, missingClawListRR, &missingClawList)
+	if len(missingClawList.Runs) != 0 {
+		t.Fatalf("OAuth list should hide runs with missing claws when ACLs are configured: %#v", missingClawList.Runs)
+	}
+	missingClawDetailRR := requestTaskRunAnalyticsAPI(t, s, http.MethodGet, "/api/analytics/runs/run-bob", bobSession)
+	if missingClawDetailRR.Code != http.StatusNotFound {
+		t.Fatalf("OAuth detail with configured ACL and missing claw status = %d, body = %s", missingClawDetailRR.Code, missingClawDetailRR.Body.String())
+	}
+
+	plainListRR := requestTaskRunAnalyticsAPI(t, s, http.MethodGet, "/api/analytics/runs", "test-token")
+	var plainList taskRunAnalyticsRunsResponse
+	decodeTaskRunAnalyticsAPI(t, plainListRR, &plainList)
+	if len(plainList.Runs) != 2 {
+		t.Fatalf("plain token list should be unrestricted: %#v", plainList.Runs)
+	}
+	plainDetailRR := requestTaskRunAnalyticsAPI(t, s, http.MethodGet, "/api/analytics/runs/run-alice/attempts", "test-token")
+	if plainDetailRR.Code != http.StatusOK {
+		t.Fatalf("plain token detail status = %d, body = %s", plainDetailRR.Code, plainDetailRR.Body.String())
+	}
+}
+
+func TestTaskRunAnalyticsAPIAllowsMissingClawsWithoutViewRestrictions(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{
+		Token: "test-token",
+		Auth:  &types.AuthConfig{SessionSecret: "analytics-session-secret"},
+	}, "", "", "")
+	insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{
+		RunID: "run-deleted-claw", AttemptID: "attempt-deleted-claw", ClawID: "claw-deleted", TenantID: "test-tenant-id",
+		Status: taskRunStatusCleanSuccess, OwnerType: taskRunOwnerFactory, Factory: "bugfix", StartedAt: 1760000000000,
+	})
+	session, err := signGitHubSession("analytics-session-secret", "alice", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	listRR := requestTaskRunAnalyticsAPI(t, s, http.MethodGet, "/api/analytics/runs", session)
+	var list taskRunAnalyticsRunsResponse
+	decodeTaskRunAnalyticsAPI(t, listRR, &list)
+	if len(list.Runs) != 1 || list.Runs[0].RunID != "run-deleted-claw" {
+		t.Fatalf("OAuth list should include persisted run without claw when ACLs are unrestricted: %#v", list.Runs)
+	}
+
+	detailRR := requestTaskRunAnalyticsAPI(t, s, http.MethodGet, "/api/analytics/runs/run-deleted-claw", session)
+	if detailRR.Code != http.StatusOK {
+		t.Fatalf("OAuth detail without configured ACL status = %d, body = %s", detailRR.Code, detailRR.Body.String())
 	}
 }
 

--- a/web/components/run-logs-dialog.tsx
+++ b/web/components/run-logs-dialog.tsx
@@ -16,6 +16,7 @@ const activityPageSize = 100
 
 export function RunLogsDialog({ run, attempts }: { run: TaskRunSummary; attempts: TaskRunAttempt[] }) {
   const [open, setOpen] = useState(false)
+  const [tab, setTab] = useState("actions")
   const attemptOptions = useMemo(() => attempts.filter((attempt) => attempt.clawId), [attempts])
   const defaultClawId = useMemo(
     () => attemptOptions.find((attempt) => attempt.attemptId === run.currentAttemptId)?.clawId || run.clawId,
@@ -44,13 +45,13 @@ export function RunLogsDialog({ run, attempts }: { run: TaskRunSummary; attempts
             <DialogTitle>Agent logs</DialogTitle>
             <DialogDescription>Agent activity and pipeline output for {run.ownerDisplayName || run.runId}.</DialogDescription>
           </DialogHeader>
-          <Tabs defaultValue="actions" className="min-h-0 flex-1 gap-0 px-6 pb-6">
+          <Tabs value={tab} onValueChange={setTab} className="min-h-0 flex-1 gap-0 px-6 pb-6">
             <div className="flex shrink-0 items-center justify-between gap-3 pb-3">
               <TabsList>
                 <TabsTrigger value="actions">Actions</TabsTrigger>
                 <TabsTrigger value="output">Output</TabsTrigger>
               </TabsList>
-              {attemptOptions.length > 1 && (
+              {tab === "actions" && attemptOptions.length > 1 && (
                 <Select value={clawId} onValueChange={setSelectedClawId}>
                   <SelectTrigger size="sm" className="w-44">
                     <SelectValue placeholder="Select attempt" />
@@ -170,7 +171,7 @@ function ActivityLine({ message }: { message: ApiMessage }) {
       </div>
       <div className="min-w-0 space-y-1">
         {detailItems.length > 0 ? detailItems.map((item, index) => (
-          item.kind === "url" ? (
+          item.kind === "url" && isSafeHttpUrl(item.value) ? (
             <a key={`${item.kind}-${index}`} href={item.value} target="_blank" rel="noreferrer" className="block truncate text-primary underline-offset-4 hover:underline">{item.value}</a>
           ) : (
             <div key={`${item.kind}-${index}`} className={cn("break-words text-muted-foreground", item.kind === "command" && "rounded bg-muted px-2 py-1 font-mono text-foreground", item.kind === "error" && "text-destructive")}>{item.value}</div>
@@ -242,6 +243,15 @@ function OutputBlock({ output }: { output: TaskRunOutput }) {
 
 function LogStream({ label, value, error = false }: { label: string; value: string; error?: boolean }) {
   return <div><div className={cn("mb-1 text-xs font-medium text-muted-foreground", error && "text-destructive")}>{label}</div><pre className="max-h-64 overflow-auto whitespace-pre-wrap break-words rounded-md bg-muted p-3 font-mono text-xs">{value}</pre></div>
+}
+
+function isSafeHttpUrl(value: string) {
+  try {
+    const protocol = new URL(value).protocol
+    return protocol === "http:" || protocol === "https:"
+  } catch {
+    return false
+  }
 }
 
 function parseActivity(message: ApiMessage): AgentActivity | null {

--- a/web/components/run-logs-dialog.tsx
+++ b/web/components/run-logs-dialog.tsx
@@ -1,0 +1,270 @@
+"use client"
+
+import { useEffect, useMemo, useState, type ReactNode } from "react"
+import { AlertCircle, FileTerminal, Loader2 } from "lucide-react"
+import { ApiError, fetchActivityMessages, fetchTaskRunOutputs } from "@/lib/api"
+import type { AgentActivity, ApiMessage, TaskRunAttempt, TaskRunOutput, TaskRunSummary } from "@/lib/types"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+import { cn } from "@/lib/utils"
+
+const activityPageSize = 100
+
+export function RunLogsDialog({ run, attempts }: { run: TaskRunSummary; attempts: TaskRunAttempt[] }) {
+  const [open, setOpen] = useState(false)
+  const attemptOptions = useMemo(() => attempts.filter((attempt) => attempt.clawId), [attempts])
+  const defaultClawId = useMemo(
+    () => attemptOptions.find((attempt) => attempt.attemptId === run.currentAttemptId)?.clawId || run.clawId,
+    [attemptOptions, run.clawId, run.currentAttemptId]
+  )
+  const [selectedClawId, setSelectedClawId] = useState<string | null>(null)
+  const clawId = selectedClawId ?? defaultClawId
+
+  const disabled = !run.clawId
+  return (
+    <>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="inline-flex" tabIndex={disabled ? 0 : undefined}>
+            <Button variant="outline" size="sm" disabled={disabled} onClick={() => setOpen(true)}>
+              <FileTerminal className="size-4" />
+              Agent logs
+            </Button>
+          </span>
+        </TooltipTrigger>
+        {disabled && <TooltipContent>This run is not linked to an agent, so logs are unavailable.</TooltipContent>}
+      </Tooltip>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="flex h-[min(85vh,800px)] flex-col gap-3 overflow-hidden p-0 sm:max-w-5xl">
+          <DialogHeader className="shrink-0 border-b px-6 py-5 pr-12">
+            <DialogTitle>Agent logs</DialogTitle>
+            <DialogDescription>Agent activity and pipeline output for {run.ownerDisplayName || run.runId}.</DialogDescription>
+          </DialogHeader>
+          <Tabs defaultValue="actions" className="min-h-0 flex-1 gap-0 px-6 pb-6">
+            <div className="flex shrink-0 items-center justify-between gap-3 pb-3">
+              <TabsList>
+                <TabsTrigger value="actions">Actions</TabsTrigger>
+                <TabsTrigger value="output">Output</TabsTrigger>
+              </TabsList>
+              {attemptOptions.length > 1 && (
+                <Select value={clawId} onValueChange={setSelectedClawId}>
+                  <SelectTrigger size="sm" className="w-44">
+                    <SelectValue placeholder="Select attempt" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {attemptOptions.map((attempt) => (
+                      <SelectItem key={attempt.id} value={attempt.clawId}>Attempt {attempt.attemptNumber}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            </div>
+            <TabsContent value="actions" className="min-h-0 overflow-hidden">
+              <ActionsTab open={open} clawId={clawId} />
+            </TabsContent>
+            <TabsContent value="output" className="min-h-0 overflow-auto">
+              <OutputTab open={open} runId={run.runId} />
+            </TabsContent>
+          </Tabs>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}
+
+function ActionsTab({ open, clawId }: { open: boolean; clawId: string }) {
+  const [messages, setMessages] = useState<ApiMessage[]>([])
+  const [loading, setLoading] = useState(false)
+  const [loadingOlder, setLoadingOlder] = useState(false)
+  const [hasOlder, setHasOlder] = useState(false)
+  const [accessDenied, setAccessDenied] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!open || !clawId) return
+    let cancelled = false
+    queueMicrotask(() => {
+      if (cancelled) return
+      setLoading(true)
+      setMessages([])
+      setAccessDenied(false)
+      setError(null)
+      fetchActivityMessages(clawId, { limit: activityPageSize, order: "desc" })
+        .then((page) => {
+          if (cancelled) return
+          setMessages(page.reverse())
+          setHasOlder(page.length === activityPageSize)
+        })
+        .catch((err) => {
+          if (cancelled) return
+          if (err instanceof ApiError && err.status === 403) setAccessDenied(true)
+          else setError(err instanceof Error ? err.message : "Unable to load agent activity")
+        })
+        .finally(() => { if (!cancelled) setLoading(false) })
+    })
+    return () => { cancelled = true }
+  }, [clawId, open])
+
+  const loadOlder = async () => {
+    const before = messages[0]?.created_at
+    if (!before || loadingOlder) return
+    setLoadingOlder(true)
+    setError(null)
+    try {
+      const page = await fetchActivityMessages(clawId, { before, limit: activityPageSize, order: "desc" })
+      setMessages((current) => [...page.reverse(), ...current])
+      setHasOlder(page.length === activityPageSize)
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 403) setAccessDenied(true)
+      else setError(err instanceof Error ? err.message : "Unable to load older activity")
+    } finally {
+      setLoadingOlder(false)
+    }
+  }
+
+  if (loading) return <LoadingState label="Loading agent activity..." />
+  if (accessDenied) return <Notice>You don&apos;t have access to this agent&apos;s logs.</Notice>
+  if (error && messages.length === 0) return <Notice destructive>{error}</Notice>
+  if (messages.length === 0) return <EmptyState>No agent actions were recorded for this attempt.</EmptyState>
+
+  return (
+    <div className="flex h-full min-h-0 flex-col rounded-md border">
+      <div className="shrink-0 border-b p-2 text-center">
+        {hasOlder ? (
+          <Button variant="ghost" size="sm" onClick={loadOlder} disabled={loadingOlder}>
+            {loadingOlder && <Loader2 className="size-4 animate-spin" />}
+            Load older
+          </Button>
+        ) : <span className="text-xs text-muted-foreground">Beginning of activity</span>}
+      </div>
+      {error && <div className="border-b px-3 py-2 text-sm text-destructive">{error}</div>}
+      <div className="min-h-0 flex-1 divide-y overflow-auto">
+        {messages.map((message) => <ActivityLine key={message.id} message={message} />)}
+      </div>
+    </div>
+  )
+}
+
+function ActivityLine({ message }: { message: ApiMessage }) {
+  const activity = parseActivity(message)
+  const label = activity?.tool || activity?.kind || "activity"
+  const detailItems = activity ? [
+    activity.command && { kind: "command", value: activity.command },
+    activity.path && { kind: "path", value: activity.path },
+    activity.url && { kind: "url", value: activity.url },
+    activity.detail && { kind: "detail", value: activity.detail },
+    activity.error && { kind: "error", value: activity.error },
+    !activity.detail && !activity.error && activity.message && { kind: "message", value: activity.message },
+  ].filter((item): item is { kind: string; value: string } => Boolean(item)) : []
+
+  return (
+    <div className="grid gap-2 px-3 py-3 text-sm sm:grid-cols-[8rem_10rem_minmax(0,1fr)]">
+      <time className="text-xs text-muted-foreground">{formatTimestamp(message.created_at)}</time>
+      <div className="flex min-w-0 items-start gap-2">
+        <span className="truncate font-medium">{label}</span>
+        {activity?.phase && <Badge variant="outline" className="shrink-0 text-[10px]">{activity.phase}</Badge>}
+      </div>
+      <div className="min-w-0 space-y-1">
+        {detailItems.length > 0 ? detailItems.map((item, index) => (
+          item.kind === "url" ? (
+            <a key={`${item.kind}-${index}`} href={item.value} target="_blank" rel="noreferrer" className="block truncate text-primary underline-offset-4 hover:underline">{item.value}</a>
+          ) : (
+            <div key={`${item.kind}-${index}`} className={cn("break-words text-muted-foreground", item.kind === "command" && "rounded bg-muted px-2 py-1 font-mono text-foreground", item.kind === "error" && "text-destructive")}>{item.value}</div>
+          )
+        )) : <span className="text-muted-foreground">{message.content || "No details"}</span>}
+      </div>
+    </div>
+  )
+}
+
+function OutputTab({ open, runId }: { open: boolean; runId: string }) {
+  const [outputs, setOutputs] = useState<TaskRunOutput[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  useEffect(() => {
+    if (!open) return
+    let cancelled = false
+    queueMicrotask(() => {
+      if (cancelled) return
+      setLoading(true)
+      setError(null)
+      fetchTaskRunOutputs(runId)
+        .then((response) => { if (!cancelled) setOutputs(response.outputs) })
+        .catch((err) => { if (!cancelled) setError(err instanceof Error ? err.message : "Unable to load pipeline output") })
+        .finally(() => { if (!cancelled) setLoading(false) })
+    })
+    return () => { cancelled = true }
+  }, [open, runId])
+
+  const groups = useMemo(() => {
+    const grouped = new Map<string, TaskRunOutput[]>()
+    for (const output of outputs) grouped.set(output.stageId || "Unspecified stage", [...(grouped.get(output.stageId || "Unspecified stage") || []), output])
+    return [...grouped.entries()]
+  }, [outputs])
+
+  if (loading) return <LoadingState label="Loading pipeline output..." />
+  if (error) return <Notice destructive>{error}</Notice>
+  if (outputs.length === 0) return <EmptyState>No pipeline output was recorded for this run.</EmptyState>
+  return (
+    <div className="space-y-4">
+      {groups.map(([stage, stageOutputs]) => (
+        <section key={stage} className="rounded-md border">
+          <h3 className="border-b bg-muted/40 px-4 py-2 text-sm font-semibold">{stage}</h3>
+          <div className="divide-y">
+            {stageOutputs.map((output) => <OutputBlock key={`${output.clawId}-${output.outputName}`} output={output} />)}
+          </div>
+        </section>
+      ))}
+    </div>
+  )
+}
+
+function OutputBlock({ output }: { output: TaskRunOutput }) {
+  return (
+    <div className="space-y-3 p-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <div className="text-sm font-medium">{output.outputName}</div>
+          {output.attemptId && <div className="text-xs text-muted-foreground">{output.attemptId}</div>}
+        </div>
+        <Badge className={cn("border", output.exitCode === 0 ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300" : "border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-300")}>Exit {output.exitCode}</Badge>
+      </div>
+      {output.stdout && <LogStream label="stdout" value={output.stdout} />}
+      {output.stderr && <LogStream label="stderr" value={output.stderr} error />}
+      {!output.stdout && !output.stderr && <p className="text-sm text-muted-foreground">This output did not write to stdout or stderr.</p>}
+    </div>
+  )
+}
+
+function LogStream({ label, value, error = false }: { label: string; value: string; error?: boolean }) {
+  return <div><div className={cn("mb-1 text-xs font-medium text-muted-foreground", error && "text-destructive")}>{label}</div><pre className="max-h-64 overflow-auto whitespace-pre-wrap break-words rounded-md bg-muted p-3 font-mono text-xs">{value}</pre></div>
+}
+
+function parseActivity(message: ApiMessage): AgentActivity | null {
+  if (!message.format?.startsWith("activity:")) return null
+  try {
+    return JSON.parse(message.format.slice("activity:".length)) as AgentActivity
+  } catch {
+    return null
+  }
+}
+
+function LoadingState({ label }: { label: string }) {
+  return <div className="flex h-40 items-center justify-center gap-2 text-sm text-muted-foreground"><Loader2 className="size-4 animate-spin" />{label}</div>
+}
+
+function EmptyState({ children }: { children: ReactNode }) {
+  return <div className="flex h-40 items-center justify-center rounded-md border border-dashed text-sm text-muted-foreground">{children}</div>
+}
+
+function Notice({ children, destructive = false }: { children: ReactNode; destructive?: boolean }) {
+  return <div className={cn("flex items-center gap-2 rounded-md border px-4 py-3 text-sm", destructive && "border-destructive/30 bg-destructive/10 text-destructive")}><AlertCircle className="size-4 shrink-0" />{children}</div>
+}
+
+function formatTimestamp(value: string) {
+  return new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit", second: "2-digit" }).format(new Date(value))
+}

--- a/web/components/task-run-analytics-view.tsx
+++ b/web/components/task-run-analytics-view.tsx
@@ -22,6 +22,7 @@ import type {
 } from "@/lib/types"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { RunLogsDialog } from "@/components/run-logs-dialog"
 import { Input } from "@/components/ui/input"
 import { Select, SelectContent, SelectItem, SelectTrigger } from "@/components/ui/select"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
@@ -434,6 +435,7 @@ function RunDetailPanel({ run, details, loading, error, onClose }: { run: TaskRu
             {error}
           </div>
         )}
+        <RunLogsDialog key={run.runId} run={run} attempts={details?.attempts ?? []} />
         <section className="grid grid-cols-2 gap-2 text-sm">
           <DetailItem label="Status" value={<StatusBadge status={run.status} />} />
           <DetailItem label="Phase" value={formatLabel(run.phase)} />

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -8,6 +8,7 @@ import type {
   TaskRunAttempt,
   TaskRunEvent,
   TaskRunFilterOptions,
+  TaskRunOutput,
   TaskRunPR,
   TaskRunsResponse,
   TaskRunSummary,
@@ -75,6 +76,13 @@ if (typeof window !== "undefined") {
   resolveToken()
 }
 
+export class ApiError extends Error {
+  constructor(message: string, readonly status: number) {
+    super(message)
+    this.name = "ApiError"
+  }
+}
+
 async function apiFetch<T>(path: string, options?: RequestInit): Promise<T> {
   const token = await resolveToken()
   const hubBase = getHubUrl()
@@ -99,7 +107,7 @@ async function apiFetch<T>(path: string, options?: RequestInit): Promise<T> {
       if (typeof parsed.error === "string") message = parsed.error
     } catch { /* not JSON */ }
     if (!message) message = `API error ${res.status}`
-    throw new Error(message)
+    throw new ApiError(message, res.status)
   }
   if (res.status === 204) return undefined as T
   return res.json()
@@ -403,6 +411,10 @@ export async function fetchTaskRunEvents(runId: string): Promise<{ events: TaskR
 
 export async function fetchTaskRunPRs(runId: string): Promise<{ prs: TaskRunPR[] }> {
   return apiFetch<{ prs: TaskRunPR[] }>(`/api/analytics/runs/${encodeURIComponent(runId)}/prs`)
+}
+
+export async function fetchTaskRunOutputs(runId: string): Promise<{ outputs: TaskRunOutput[] }> {
+  return apiFetch<{ outputs: TaskRunOutput[] }>(`/api/analytics/runs/${encodeURIComponent(runId)}/outputs`)
 }
 
 export async function fetchTaskRunFilterOptions(): Promise<TaskRunFilterOptions> {

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -221,6 +221,17 @@ export interface TaskRunEvent {
   createdAt: number
 }
 
+export interface TaskRunOutput {
+  clawId: string
+  attemptId?: string
+  stageId: string
+  outputName: string
+  stdout: string
+  stderr: string
+  exitCode: number
+  createdAt: number
+}
+
 export interface TaskRunPR {
   id: string
   repo: string


### PR DESCRIPTION
## What

Adds an **Agent logs** dialog to the task-run analytics drill-down (`RunDetailPanel`), with two tabs:

- **Actions** — the agent activity stream (tool calls, commands, paths, errors) for the selected attempt, fetched from the existing `GET /api/messages/{clawId}/activity` endpoint, with an attempt selector for multi-attempt runs and "Load older" pagination.
- **Output** — pipeline stage stdout/stderr with exit-code badges, via a new `GET /api/analytics/runs/{runId}/outputs` endpoint that exposes `pipeline_outputs` for the run's claws (run claw + each attempt's claw), tenant-scoped.

## Why

The drill-down previously showed only summary/attempts/events/PRs; there was no way to see what an agent actually did during a run without leaving the analytics screen.

## Security fix included

The analytics endpoints only enforced tenant scoping, while the messages endpoints enforce the tag-based per-claw ACL (`canViewClaw`). Linking analytics to logs made that gap visible, so this PR mirrors the ACL on the analytics run detail and all `/runs/{runId}/*` subresources (403/404 for restricted GitHub-OAuth callers) and filters restricted runs out of the list.

Notes for reviewers:
- The ACL check short-circuits when no view restrictions are configured — important because claw rows are hard-deleted on run completion while `task_run_summaries` persist; without the short-circuit, OAuth users would lose all historical analytics.
- List filtering batch-fetches claw tags per page (single `IN (...)` query) to avoid N+1.
- Known follow-up (intentionally out of scope): `GET /api/analytics/summary` and `/filter-options` aggregates are still tenant-wide, so a tag-restricted user can see counts/breakdowns covering runs they cannot open.

## Testing

- New Go tests for the `/outputs` endpoint and ACL enforcement (including deleted-claw behavior, restricted and unrestricted): `go test ./pkg/hub/` passes.
- `go build ./...`, `tsc --noEmit`, eslint on touched files, and `next build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)