### PR TITLE
fix: enforce claw view ACL on analytics summary and filter-options

### DIFF
--- a/pkg/hub/task_run_analytics_api.go
+++ b/pkg/hub/task_run_analytics_api.go
@@ -613,9 +613,10 @@ func (s *Server) readTaskRunAnalyticsFilterOptionsForRequest(tenantID, githubLog
 		}
 		sets[set][value] = true
 	}
-	// Default filters match the SQL variant's eligibility clause
+	// Same eligibility clause as the SQL variant
 	// (analytics_enabled=1 AND requires_pr=1).
-	filters := taskRunAnalyticsFilters{TenantID: tenantID}
+	eligible := true
+	filters := taskRunAnalyticsFilters{TenantID: tenantID, RequiresPR: &eligible, AnalyticsEnabled: &eligible}
 	err := s.forEachViewableTaskRunAnalyticsRun(filters, 0, "", githubLogin, accessCfg, func(run taskRunAnalyticsRunView) bool {
 		add("workspaces", run.WorkspaceName)
 		add("workflows", run.WorkflowName)

--- a/pkg/hub/task_run_analytics_api.go
+++ b/pkg/hub/task_run_analytics_api.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -236,7 +237,7 @@ func (s *Server) handleTaskRunAnalyticsSummary(w http.ResponseWriter, r *http.Re
 		jsonError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	response, err := s.readTaskRunAnalyticsSummary(filters)
+	response, err := s.readTaskRunAnalyticsSummaryForRequest(filters, githubLoginFromContext(r.Context()))
 	if err != nil {
 		jsonError(w, http.StatusInternalServerError, "db error")
 		return
@@ -347,7 +348,7 @@ func (s *Server) handleTaskRunAnalyticsFilterOptions(w http.ResponseWriter, r *h
 		jsonError(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
 	}
-	response, err := s.readTaskRunAnalyticsFilterOptions(tenantFromCtx(r))
+	response, err := s.readTaskRunAnalyticsFilterOptionsForRequest(tenantFromCtx(r), githubLoginFromContext(r.Context()))
 	if err != nil {
 		jsonError(w, http.StatusInternalServerError, "db error")
 		return
@@ -487,45 +488,171 @@ func (s *Server) readTaskRunAnalyticsRuns(filters taskRunAnalyticsFilters, limit
 }
 
 func (s *Server) readTaskRunAnalyticsRunsForRequest(filters taskRunAnalyticsFilters, limit int, cursorStartedAt int64, cursorRunID, githubLogin string) ([]taskRunAnalyticsRunView, string, error) {
-	if githubLogin == "" {
-		return s.readTaskRunAnalyticsRuns(filters, limit, cursorStartedAt, cursorRunID)
-	}
-	accessCfg := s.taskRunAnalyticsAccessConfig()
-	if accessCfg == nil || len(accessCfg.ViewRequiresTags) == 0 {
+	accessCfg := s.taskRunAnalyticsViewACL(githubLogin)
+	if accessCfg == nil {
 		return s.readTaskRunAnalyticsRuns(filters, limit, cursorStartedAt, cursorRunID)
 	}
 
-	const batchSize = taskRunAnalyticsMaxLimit
 	visible := make([]taskRunAnalyticsRunView, 0, limit+1)
+	nextCursor := ""
+	err := s.forEachViewableTaskRunAnalyticsRun(filters, cursorStartedAt, cursorRunID, githubLogin, accessCfg, func(run taskRunAnalyticsRunView) bool {
+		visible = append(visible, run)
+		if len(visible) == limit+1 {
+			last := visible[limit-1]
+			visible = visible[:limit]
+			nextCursor = encodeTaskRunAnalyticsCursor(last.StartedAt, last.RunID)
+			return false
+		}
+		return true
+	})
+	if err != nil {
+		return nil, "", err
+	}
+	return visible, nextCursor, nil
+}
+
+// taskRunAnalyticsViewACL returns the access config when the request is subject
+// to tag-based view filtering, or nil when the caller sees all tenant runs
+// (token auth, or no ViewRequiresTags configured).
+func (s *Server) taskRunAnalyticsViewACL(githubLogin string) *types.AccessConfig {
+	if githubLogin == "" {
+		return nil
+	}
+	accessCfg := s.taskRunAnalyticsAccessConfig()
+	if accessCfg == nil || len(accessCfg.ViewRequiresTags) == 0 {
+		return nil
+	}
+	return accessCfg
+}
+
+// forEachViewableTaskRunAnalyticsRun streams matching runs in batches, resolves
+// claw tags per batch, and invokes visit for each run the user can view.
+// visit returns false to stop early.
+func (s *Server) forEachViewableTaskRunAnalyticsRun(filters taskRunAnalyticsFilters, cursorStartedAt int64, cursorRunID, githubLogin string, accessCfg *types.AccessConfig, visit func(taskRunAnalyticsRunView) bool) error {
+	const batchSize = taskRunAnalyticsMaxLimit
 	batchStartedAt, batchRunID := cursorStartedAt, cursorRunID
 	for {
 		batch, batchNextCursor, err := s.readTaskRunAnalyticsRuns(filters, batchSize, batchStartedAt, batchRunID)
 		if err != nil {
-			return nil, "", err
+			return err
 		}
 		clawTags, err := s.readTaskRunAnalyticsClawTags(filters.TenantID, batch)
 		if err != nil {
-			return nil, "", err
+			return err
 		}
 		for _, run := range batch {
 			tags, found := clawTags[run.ClawID]
 			if !found || !canViewClaw(accessCfg, githubLogin, tags) {
 				continue
 			}
-			visible = append(visible, run)
-			if len(visible) == limit+1 {
-				last := visible[limit-1]
-				return visible[:limit], encodeTaskRunAnalyticsCursor(last.StartedAt, last.RunID), nil
+			if !visit(run) {
+				return nil
 			}
 		}
 		if batchNextCursor == "" {
-			return visible, "", nil
+			return nil
 		}
 		batchStartedAt, batchRunID, err = decodeTaskRunAnalyticsCursor(batchNextCursor)
 		if err != nil {
-			return nil, "", err
+			return err
 		}
 	}
+}
+
+// readTaskRunAnalyticsSummaryForRequest aggregates only over runs the caller can
+// view: for GitHub-OAuth callers under a tag ACL the totals, breakdowns, and PR
+// KPIs are computed from the ACL-filtered run stream instead of tenant-wide SQL.
+func (s *Server) readTaskRunAnalyticsSummaryForRequest(filters taskRunAnalyticsFilters, githubLogin string) (taskRunAnalyticsSummaryResponse, error) {
+	accessCfg := s.taskRunAnalyticsViewACL(githubLogin)
+	if accessCfg == nil {
+		return s.readTaskRunAnalyticsSummary(filters)
+	}
+	response := taskRunAnalyticsSummaryResponse{
+		ByStatus:         map[string]int{},
+		WarningBreakdown: map[string]int{},
+		FailureBreakdown: map[string]int{},
+	}
+	err := s.forEachViewableTaskRunAnalyticsRun(filters, 0, "", githubLogin, accessCfg, func(run taskRunAnalyticsRunView) bool {
+		response.TotalRuns++
+		response.HumanInteractions += run.HumanInteractionCount
+		response.PRCounts.Total += run.PRCount
+		response.PRCounts.Open += run.OpenPRCount
+		response.PRCounts.Merged += run.MergedPRCount
+		response.PRCounts.Closed += run.ClosedPRCount
+		if run.Status != "" {
+			response.ByStatus[run.Status]++
+		}
+		if run.FailureType != "" {
+			response.FailureBreakdown[run.FailureType]++
+		}
+		for _, warningType := range run.WarningTypes {
+			if warningType != "" {
+				response.WarningBreakdown[warningType]++
+			}
+		}
+		return true
+	})
+	return response, err
+}
+
+// readTaskRunAnalyticsFilterOptionsForRequest returns distinct filter values
+// computed only from runs the caller can view, so a restricted OAuth user does
+// not learn workspace/factory/repo/model names from runs hidden by the ACL.
+func (s *Server) readTaskRunAnalyticsFilterOptionsForRequest(tenantID, githubLogin string) (taskRunAnalyticsFilterOptionsResponse, error) {
+	accessCfg := s.taskRunAnalyticsViewACL(githubLogin)
+	if accessCfg == nil {
+		return s.readTaskRunAnalyticsFilterOptions(tenantID)
+	}
+	sets := map[string]map[string]bool{}
+	add := func(set string, value string) {
+		if value == "" {
+			return
+		}
+		if sets[set] == nil {
+			sets[set] = map[string]bool{}
+		}
+		sets[set][value] = true
+	}
+	// Default filters match the SQL variant's eligibility clause
+	// (analytics_enabled=1 AND requires_pr=1).
+	filters := taskRunAnalyticsFilters{TenantID: tenantID}
+	err := s.forEachViewableTaskRunAnalyticsRun(filters, 0, "", githubLogin, accessCfg, func(run taskRunAnalyticsRunView) bool {
+		add("workspaces", run.WorkspaceName)
+		add("workflows", run.WorkflowName)
+		add("factories", run.FactoryName)
+		add("integrations", run.Integration)
+		add("repos", run.Repo)
+		add("models", run.Model)
+		add("statuses", run.Status)
+		add("failureTypes", run.FailureType)
+		for _, warningType := range run.WarningTypes {
+			add("warningTypes", warningType)
+		}
+		return true
+	})
+	if err != nil {
+		return taskRunAnalyticsFilterOptionsResponse{}, err
+	}
+	return taskRunAnalyticsFilterOptionsResponse{
+		Workspaces:   sortedTaskRunAnalyticsValues(sets["workspaces"]),
+		Workflows:    sortedTaskRunAnalyticsValues(sets["workflows"]),
+		Factories:    sortedTaskRunAnalyticsValues(sets["factories"]),
+		Integrations: sortedTaskRunAnalyticsValues(sets["integrations"]),
+		Repos:        sortedTaskRunAnalyticsValues(sets["repos"]),
+		Models:       sortedTaskRunAnalyticsValues(sets["models"]),
+		Statuses:     sortedTaskRunAnalyticsValues(sets["statuses"]),
+		WarningTypes: sortedTaskRunAnalyticsValues(sets["warningTypes"]),
+		FailureTypes: sortedTaskRunAnalyticsValues(sets["failureTypes"]),
+	}, nil
+}
+
+func sortedTaskRunAnalyticsValues(set map[string]bool) []string {
+	values := make([]string, 0, len(set))
+	for value := range set {
+		values = append(values, value)
+	}
+	sort.Strings(values)
+	return values
 }
 
 func (s *Server) readTaskRunAnalyticsClawTags(tenantID string, runs []taskRunAnalyticsRunView) (map[string][]string, error) {

--- a/pkg/hub/task_run_analytics_api_test.go
+++ b/pkg/hub/task_run_analytics_api_test.go
@@ -349,6 +349,99 @@ func TestTaskRunAnalyticsAPIAccessControl(t *testing.T) {
 	}
 }
 
+func TestTaskRunAnalyticsAPIAccessControlAggregates(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{
+		Token: "test-token",
+		Auth: &types.AuthConfig{
+			SessionSecret: "analytics-session-secret",
+			Access:        &types.AccessConfig{ViewRequiresTags: []string{"owner={user}"}},
+		},
+	}, "", "", "")
+	ts := int64(1760000000000)
+	insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{
+		RunID: "run-alice", AttemptID: "attempt-alice", ClawID: "claw-alice", TenantID: "test-tenant-id",
+		Status: taskRunStatusFailed, Phase: taskRunPhaseTerminal, OwnerType: taskRunOwnerFactory,
+		Workspace: "alice-space", Factory: "alice-factory", Integration: "linear", Repo: "alice/repo", Model: "alice-model",
+		FailureType: taskRunFailureTimeout, StartedAt: ts + 100, HumanInteractions: 5, PRCount: 3, OpenPRCount: 3,
+	})
+	insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{
+		RunID: "run-bob", AttemptID: "attempt-bob", ClawID: "claw-bob", TenantID: "test-tenant-id",
+		Status: taskRunStatusWarningSuccess, Phase: taskRunPhaseTerminal, OwnerType: taskRunOwnerFactory,
+		Workspace: "bob-space", Factory: "bob-factory", Integration: "github", Repo: "bob/repo", Model: "bob-model",
+		WarningTypes: []string{taskRunWarningHumanPRComment}, StartedAt: ts, HumanInteractions: 1,
+		PRCount: 1, MergedPRCount: 1, MergedAt: ts + 500, FinishedAt: ts + 500,
+	})
+	for _, claw := range []struct{ id, tags string }{
+		{id: "claw-alice", tags: `["owner=alice"]`},
+		{id: "claw-bob", tags: `["owner=bob"]`},
+	} {
+		if _, err := db.Exec(`INSERT INTO claws(id, tenant_id, name, tags, created_at) VALUES(?,?,?,?,datetime('now'))`, claw.id, "test-tenant-id", claw.id, claw.tags); err != nil {
+			t.Fatalf("insert claw: %v", err)
+		}
+	}
+	bobSession, err := signGitHubSession("analytics-session-secret", "bob", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	summaryRR := requestTaskRunAnalyticsAPI(t, s, http.MethodGet, "/api/analytics/summary", bobSession)
+	var summary taskRunAnalyticsSummaryResponse
+	decodeTaskRunAnalyticsAPI(t, summaryRR, &summary)
+	if summary.TotalRuns != 1 || summary.HumanInteractions != 1 {
+		t.Fatalf("OAuth summary was not ACL-filtered: %#v", summary)
+	}
+	if summary.ByStatus[taskRunStatusWarningSuccess] != 1 || summary.ByStatus[taskRunStatusFailed] != 0 || len(summary.FailureBreakdown) != 0 {
+		t.Fatalf("OAuth summary leaked hidden run breakdowns: %#v", summary)
+	}
+	if summary.WarningBreakdown[taskRunWarningHumanPRComment] != 1 {
+		t.Fatalf("OAuth summary missing viewable warning counts: %#v", summary)
+	}
+	if summary.PRCounts.Total != 1 || summary.PRCounts.Open != 0 || summary.PRCounts.Merged != 1 || summary.PRCounts.Closed != 0 {
+		t.Fatalf("OAuth summary PR counts leaked hidden runs: %#v", summary.PRCounts)
+	}
+
+	optionsRR := requestTaskRunAnalyticsAPI(t, s, http.MethodGet, "/api/analytics/filter-options", bobSession)
+	var options taskRunAnalyticsFilterOptionsResponse
+	decodeTaskRunAnalyticsAPI(t, optionsRR, &options)
+	assertStringSliceEqual(t, options.Workspaces, []string{"bob-space"})
+	assertStringSliceEqual(t, options.Factories, []string{"bob-factory"})
+	assertStringSliceEqual(t, options.Integrations, []string{"github"})
+	assertStringSliceEqual(t, options.Repos, []string{"bob/repo"})
+	assertStringSliceEqual(t, options.Models, []string{"bob-model"})
+	assertStringSliceEqual(t, options.Statuses, []string{taskRunStatusWarningSuccess})
+	assertStringSliceEqual(t, options.WarningTypes, []string{taskRunWarningHumanPRComment})
+	assertStringSliceEqual(t, options.FailureTypes, []string{})
+	if strings.Contains(optionsRR.Body.String(), "alice") {
+		t.Fatalf("filter-options leaked hidden run values: %s", optionsRR.Body.String())
+	}
+
+	plainSummaryRR := requestTaskRunAnalyticsAPI(t, s, http.MethodGet, "/api/analytics/summary", "test-token")
+	var plainSummary taskRunAnalyticsSummaryResponse
+	decodeTaskRunAnalyticsAPI(t, plainSummaryRR, &plainSummary)
+	if plainSummary.TotalRuns != 2 || plainSummary.FailureBreakdown[taskRunFailureTimeout] != 1 {
+		t.Fatalf("plain token summary should be tenant-wide: %#v", plainSummary)
+	}
+	plainOptionsRR := requestTaskRunAnalyticsAPI(t, s, http.MethodGet, "/api/analytics/filter-options", "test-token")
+	var plainOptions taskRunAnalyticsFilterOptionsResponse
+	decodeTaskRunAnalyticsAPI(t, plainOptionsRR, &plainOptions)
+	assertStringSliceEqual(t, plainOptions.Workspaces, []string{"alice-space", "bob-space"})
+
+	if _, err := db.Exec(`DELETE FROM claws WHERE id=?`, "claw-bob"); err != nil {
+		t.Fatalf("delete claw: %v", err)
+	}
+	missingClawSummaryRR := requestTaskRunAnalyticsAPI(t, s, http.MethodGet, "/api/analytics/summary", bobSession)
+	var missingClawSummary taskRunAnalyticsSummaryResponse
+	decodeTaskRunAnalyticsAPI(t, missingClawSummaryRR, &missingClawSummary)
+	if missingClawSummary.TotalRuns != 0 || len(missingClawSummary.ByStatus) != 0 {
+		t.Fatalf("OAuth summary should exclude runs with missing claws when ACLs are configured: %#v", missingClawSummary)
+	}
+	missingClawOptionsRR := requestTaskRunAnalyticsAPI(t, s, http.MethodGet, "/api/analytics/filter-options", bobSession)
+	var missingClawOptions taskRunAnalyticsFilterOptionsResponse
+	decodeTaskRunAnalyticsAPI(t, missingClawOptionsRR, &missingClawOptions)
+	assertStringSliceEqual(t, missingClawOptions.Workspaces, []string{})
+	assertStringSliceEqual(t, missingClawOptions.Statuses, []string{})
+}
+
 func TestTaskRunAnalyticsAPIAllowsMissingClawsWithoutViewRestrictions(t *testing.T) {
 	s, db := NewTestServerWithConfig(t, &types.HubConfig{
 		Token: "test-token",
@@ -374,6 +467,17 @@ func TestTaskRunAnalyticsAPIAllowsMissingClawsWithoutViewRestrictions(t *testing
 	if detailRR.Code != http.StatusOK {
 		t.Fatalf("OAuth detail without configured ACL status = %d, body = %s", detailRR.Code, detailRR.Body.String())
 	}
+
+	summaryRR := requestTaskRunAnalyticsAPI(t, s, http.MethodGet, "/api/analytics/summary", session)
+	var summary taskRunAnalyticsSummaryResponse
+	decodeTaskRunAnalyticsAPI(t, summaryRR, &summary)
+	if summary.TotalRuns != 1 {
+		t.Fatalf("OAuth summary without configured ACL should be tenant-wide: %#v", summary)
+	}
+	optionsRR := requestTaskRunAnalyticsAPI(t, s, http.MethodGet, "/api/analytics/filter-options", session)
+	var options taskRunAnalyticsFilterOptionsResponse
+	decodeTaskRunAnalyticsAPI(t, optionsRR, &options)
+	assertStringSliceEqual(t, options.Factories, []string{"bugfix"})
 }
 
 func TestTaskRunAnalyticsAPIFilterOptionsAreTenantScoped(t *testing.T) {


### PR DESCRIPTION
## What

`GET /api/analytics/summary` and `GET /api/analytics/filter-options` now enforce the tag-based per-claw view ACL for GitHub-OAuth callers, matching the run list/detail/subresource endpoints.

## Why

Both endpoints aggregated over all tenant runs. A restricted OAuth user (under `auth.access.viewRequiresTags`) could therefore see aggregate run counts, status/failure/warning breakdowns, PR KPIs, and distinct workspace/factory/repo/model values covering runs the ACL hides from them — an information leak, and a UI inconsistency where the summary KPIs didn't match the visible run list.

**Policy decision:** aggregates are filtered by viewable claws rather than documented as tenant-wide, so the summary always reflects exactly the runs the caller can list. Token-authenticated callers and tenants without `viewRequiresTags` keep the tenant-wide SQL path unchanged.

## How

- Extracted the batched scan from `readTaskRunAnalyticsRunsForRequest` into `forEachViewableTaskRunAnalyticsRun`: pages `task_run_summaries` in batches of 200, resolves claw tags per batch (`readTaskRunAnalyticsClawTags`), and applies `canViewClaw` — including the existing behavior of hiding runs whose claw no longer exists.
- `readTaskRunAnalyticsSummaryForRequest`: on the restricted path, computes totals, breakdowns, and PR KPIs in Go over the filtered stream, replicating the SQL semantics (empty keys skipped, same eligibility filters).
- `readTaskRunAnalyticsFilterOptionsForRequest`: collects distinct values only from viewable runs, sorted, with default filters reproducing the SQL variant's `analytics_enabled=1 AND requires_pr=1` clause.

## Notes for reviewers

- The restricted path is O(tenant runs) per request (same mechanism the ACL-filtered run list already uses). Only OAuth callers under an ACL pay this; if it becomes a bottleneck, the viewable-claw set could be pushed into SQL.
- Tests: new `TestTaskRunAnalyticsAPIAccessControlAggregates` covers ACL-filtered summary/filter-options (no leakage of hidden dimensions), the tenant-wide token path, and missing-claw exclusion under ACL. Extended `TestTaskRunAnalyticsAPIAllowsMissingClawsWithoutViewRestrictions` to confirm OAuth without an ACL stays tenant-wide.
- `go build`, `go vet`, and the full `pkg/hub` suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)