### PR TITLE
fix(daytona): materialize workflow env before bootstrap

### DIFF
--- a/pkg/hub/daytona_provision_test.go
+++ b/pkg/hub/daytona_provision_test.go
@@ -1,0 +1,79 @@
+package hub
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+type recordingDaytonaSandboxProvisioner struct {
+	calls         []string
+	configuredEnv map[string]string
+	configureErr  error
+}
+
+func (p *recordingDaytonaSandboxProvisioner) Create(_ context.Context, req types.CreateRequest) (*types.Instance, error) {
+	p.calls = append(p.calls, "create")
+	return &types.Instance{ID: "sandbox-123", Name: req.Name, Provider: "daytona"}, nil
+}
+
+func (p *recordingDaytonaSandboxProvisioner) ConfigureOpenClaw(_ context.Context, instanceID string, env map[string]string) error {
+	if !reflect.DeepEqual(p.calls, []string{"create"}) {
+		return errors.New("ConfigureOpenClaw was not called immediately after Create")
+	}
+	p.calls = append(p.calls, "configure-openclaw:"+instanceID)
+	p.configuredEnv = env
+	return p.configureErr
+}
+
+func TestCreateAndConfigureDaytonaSandboxMaterializesEnvBeforeBootstrap(t *testing.T) {
+	p := &recordingDaytonaSandboxProvisioner{}
+	env := map[string]string{
+		"ELASTICCLAW_CLAW_ID":   "claw-123",
+		"AWS_ACCESS_KEY_ID":     "resolved-workflow-access-key",
+		"AWS_SECRET_ACCESS_KEY": "resolved-workflow-secret-key",
+	}
+
+	instance, err := createAndConfigureDaytonaSandbox(context.Background(), p, types.CreateRequest{Name: "ec-claw123", Env: env}, env)
+	if err != nil {
+		t.Fatalf("createAndConfigureDaytonaSandbox: %v", err)
+	}
+	p.calls = append(p.calls, "bootstrap")
+
+	if instance.ID != "sandbox-123" {
+		t.Fatalf("instance ID = %q, want sandbox-123", instance.ID)
+	}
+	if !reflect.DeepEqual(p.calls, []string{"create", "configure-openclaw:sandbox-123", "bootstrap"}) {
+		t.Fatalf("call order = %v", p.calls)
+	}
+	if !reflect.DeepEqual(p.configuredEnv, env) {
+		t.Fatal("ConfigureOpenClaw did not receive the resolved workflow environment")
+	}
+}
+
+func TestCreateAndConfigureDaytonaSandboxStopsOnMaterializationFailureWithoutLeakingSecrets(t *testing.T) {
+	const secret = "must-not-appear-in-error"
+	p := &recordingDaytonaSandboxProvisioner{configureErr: errors.New("upload failed")}
+	env := map[string]string{"AWS_SECRET_ACCESS_KEY": secret}
+
+	instance, err := createAndConfigureDaytonaSandbox(context.Background(), p, types.CreateRequest{Env: env}, env)
+	if err == nil {
+		t.Fatal("expected configuration error")
+	}
+	if instance != nil {
+		t.Fatalf("instance = %#v, want nil on configuration failure", instance)
+	}
+	if !strings.Contains(err.Error(), "daytona configure OpenClaw environment for sandbox sandbox-123: upload failed") {
+		t.Fatalf("error lacks safe context: %v", err)
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Fatal("error leaked secret value")
+	}
+	if !reflect.DeepEqual(p.calls, []string{"create", "configure-openclaw:sandbox-123"}) {
+		t.Fatalf("provisioning continued after materialization failure: %v", p.calls)
+	}
+}

--- a/pkg/hub/daytona_provision_test.go
+++ b/pkg/hub/daytona_provision_test.go
@@ -52,7 +52,10 @@ func TestCreateAndConfigureDaytonaSandboxMaterializesEnvBeforeBootstrap(t *testi
 		"AWS_SECRET_ACCESS_KEY": "resolved-workflow-secret-key",
 	}
 
-	instance, err := createAndConfigureDaytonaSandbox(context.Background(), p, types.CreateRequest{Name: "ec-claw123", Env: env}, env)
+	instance, err := createAndConfigureDaytonaSandboxWithRetry(context.Background(), p, types.CreateRequest{Name: "ec-claw123", Env: env}, env, func(instance *types.Instance) error {
+		p.calls = append(p.calls, "record:"+instance.ID)
+		return nil
+	}, nil)
 	if err != nil {
 		t.Fatalf("createAndConfigureDaytonaSandbox: %v", err)
 	}
@@ -61,7 +64,7 @@ func TestCreateAndConfigureDaytonaSandboxMaterializesEnvBeforeBootstrap(t *testi
 	if instance.ID != "sandbox-123" {
 		t.Fatalf("instance ID = %q, want sandbox-123", instance.ID)
 	}
-	if !reflect.DeepEqual(p.calls, []string{"create", "configure-openclaw:sandbox-123", "bootstrap"}) {
+	if !reflect.DeepEqual(p.calls, []string{"create", "record:sandbox-123", "configure-openclaw:sandbox-123", "bootstrap"}) {
 		t.Fatalf("call order = %v", p.calls)
 	}
 	if !reflect.DeepEqual(p.configuredEnv, env) {
@@ -74,7 +77,7 @@ func TestCreateAndConfigureDaytonaSandboxStopsOnMaterializationFailureWithoutLea
 	p := &recordingDaytonaSandboxProvisioner{configureErrors: []error{errors.New("upload failed")}}
 	env := map[string]string{"AWS_SECRET_ACCESS_KEY": secret}
 
-	instance, err := createAndConfigureDaytonaSandboxWithRetry(context.Background(), p, types.CreateRequest{Env: env}, env, nil)
+	instance, err := createAndConfigureDaytonaSandboxWithRetry(context.Background(), p, types.CreateRequest{Env: env}, env, nil, nil)
 	if err == nil {
 		t.Fatal("expected configuration error")
 	}
@@ -95,7 +98,7 @@ func TestCreateAndConfigureDaytonaSandboxStopsOnMaterializationFailureWithoutLea
 func TestCreateAndConfigureDaytonaSandboxRetriesUntilSandboxIsReady(t *testing.T) {
 	p := &recordingDaytonaSandboxProvisioner{configureErrors: []error{errors.New("sandbox not ready"), nil}}
 
-	instance, err := createAndConfigureDaytonaSandboxWithRetry(context.Background(), p, types.CreateRequest{}, nil, []time.Duration{0})
+	instance, err := createAndConfigureDaytonaSandboxWithRetry(context.Background(), p, types.CreateRequest{}, nil, nil, []time.Duration{0})
 	if err != nil {
 		t.Fatalf("createAndConfigureDaytonaSandboxWithRetry: %v", err)
 	}
@@ -107,12 +110,19 @@ func TestCreateAndConfigureDaytonaSandboxRetriesUntilSandboxIsReady(t *testing.T
 	}
 }
 
+func TestDaytonaConfigureUsesLongBootstrapRetryPolicy(t *testing.T) {
+	want := []time.Duration{5 * time.Second, 10 * time.Second, 20 * time.Second, 40 * time.Second, 60 * time.Second}
+	if !reflect.DeepEqual(daytonaLongRetryDelays, want) {
+		t.Fatalf("Daytona retry delays = %v, want %v", daytonaLongRetryDelays, want)
+	}
+}
+
 func TestCreateAndConfigureDaytonaSandboxCleansUpWithIndependentContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	p := &recordingDaytonaSandboxProvisioner{configureErrors: []error{errors.New("sandbox not ready")}}
 
-	_, err := createAndConfigureDaytonaSandboxWithRetry(ctx, p, types.CreateRequest{}, nil, nil)
+	_, err := createAndConfigureDaytonaSandboxWithRetry(ctx, p, types.CreateRequest{}, nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected configuration error")
 	}
@@ -120,6 +130,32 @@ func TestCreateAndConfigureDaytonaSandboxCleansUpWithIndependentContext(t *testi
 		t.Fatalf("cleanup inherited canceled context: %v", p.destroyContextErr)
 	}
 	if !reflect.DeepEqual(p.calls, []string{"create", "configure-openclaw:sandbox-123", "destroy:sandbox-123"}) {
+		t.Fatalf("call order = %v", p.calls)
+	}
+}
+
+func TestCreateAndConfigureDaytonaSandboxRecordsIDBeforeConfigurationAndCleanup(t *testing.T) {
+	p := &recordingDaytonaSandboxProvisioner{
+		configureErrors: []error{errors.New("upload failed")},
+		destroyErr:      errors.New("destroy timed out"),
+	}
+	recordedID := ""
+
+	_, err := createAndConfigureDaytonaSandboxWithRetry(context.Background(), p, types.CreateRequest{}, nil, func(instance *types.Instance) error {
+		recordedID = instance.ID
+		p.calls = append(p.calls, "record:"+instance.ID)
+		return nil
+	}, nil)
+	if err == nil {
+		t.Fatal("expected configuration and cleanup error")
+	}
+	if recordedID != "sandbox-123" {
+		t.Fatalf("recorded ID = %q, want sandbox-123", recordedID)
+	}
+	if !strings.Contains(err.Error(), "sandbox cleanup failed: destroy timed out") {
+		t.Fatalf("error lacks cleanup context: %v", err)
+	}
+	if !reflect.DeepEqual(p.calls, []string{"create", "record:sandbox-123", "configure-openclaw:sandbox-123", "destroy:sandbox-123"}) {
 		t.Fatalf("call order = %v", p.calls)
 	}
 }

--- a/pkg/hub/daytona_provision_test.go
+++ b/pkg/hub/daytona_provision_test.go
@@ -6,14 +6,17 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
 
 type recordingDaytonaSandboxProvisioner struct {
-	calls         []string
-	configuredEnv map[string]string
-	configureErr  error
+	calls             []string
+	configuredEnv     map[string]string
+	configureErrors   []error
+	destroyErr        error
+	destroyContextErr error
 }
 
 func (p *recordingDaytonaSandboxProvisioner) Create(_ context.Context, req types.CreateRequest) (*types.Instance, error) {
@@ -22,12 +25,23 @@ func (p *recordingDaytonaSandboxProvisioner) Create(_ context.Context, req types
 }
 
 func (p *recordingDaytonaSandboxProvisioner) ConfigureOpenClaw(_ context.Context, instanceID string, env map[string]string) error {
-	if !reflect.DeepEqual(p.calls, []string{"create"}) {
-		return errors.New("ConfigureOpenClaw was not called immediately after Create")
+	if len(p.calls) == 0 || p.calls[0] != "create" {
+		return errors.New("ConfigureOpenClaw was called before Create")
 	}
 	p.calls = append(p.calls, "configure-openclaw:"+instanceID)
 	p.configuredEnv = env
-	return p.configureErr
+	if len(p.configureErrors) == 0 {
+		return nil
+	}
+	err := p.configureErrors[0]
+	p.configureErrors = p.configureErrors[1:]
+	return err
+}
+
+func (p *recordingDaytonaSandboxProvisioner) Destroy(ctx context.Context, instanceID string, _ bool) error {
+	p.calls = append(p.calls, "destroy:"+instanceID)
+	p.destroyContextErr = ctx.Err()
+	return p.destroyErr
 }
 
 func TestCreateAndConfigureDaytonaSandboxMaterializesEnvBeforeBootstrap(t *testing.T) {
@@ -57,23 +71,55 @@ func TestCreateAndConfigureDaytonaSandboxMaterializesEnvBeforeBootstrap(t *testi
 
 func TestCreateAndConfigureDaytonaSandboxStopsOnMaterializationFailureWithoutLeakingSecrets(t *testing.T) {
 	const secret = "must-not-appear-in-error"
-	p := &recordingDaytonaSandboxProvisioner{configureErr: errors.New("upload failed")}
+	p := &recordingDaytonaSandboxProvisioner{configureErrors: []error{errors.New("upload failed")}}
 	env := map[string]string{"AWS_SECRET_ACCESS_KEY": secret}
 
-	instance, err := createAndConfigureDaytonaSandbox(context.Background(), p, types.CreateRequest{Env: env}, env)
+	instance, err := createAndConfigureDaytonaSandboxWithRetry(context.Background(), p, types.CreateRequest{Env: env}, env, nil)
 	if err == nil {
 		t.Fatal("expected configuration error")
 	}
 	if instance != nil {
 		t.Fatalf("instance = %#v, want nil on configuration failure", instance)
 	}
-	if !strings.Contains(err.Error(), "daytona configure OpenClaw environment for sandbox sandbox-123: upload failed") {
+	if !strings.Contains(err.Error(), "daytona configure OpenClaw environment for sandbox sandbox-123 after 1 attempts: upload failed") {
 		t.Fatalf("error lacks safe context: %v", err)
 	}
 	if strings.Contains(err.Error(), secret) {
 		t.Fatal("error leaked secret value")
 	}
-	if !reflect.DeepEqual(p.calls, []string{"create", "configure-openclaw:sandbox-123"}) {
+	if !reflect.DeepEqual(p.calls, []string{"create", "configure-openclaw:sandbox-123", "destroy:sandbox-123"}) {
 		t.Fatalf("provisioning continued after materialization failure: %v", p.calls)
+	}
+}
+
+func TestCreateAndConfigureDaytonaSandboxRetriesUntilSandboxIsReady(t *testing.T) {
+	p := &recordingDaytonaSandboxProvisioner{configureErrors: []error{errors.New("sandbox not ready"), nil}}
+
+	instance, err := createAndConfigureDaytonaSandboxWithRetry(context.Background(), p, types.CreateRequest{}, nil, []time.Duration{0})
+	if err != nil {
+		t.Fatalf("createAndConfigureDaytonaSandboxWithRetry: %v", err)
+	}
+	if instance == nil || instance.ID != "sandbox-123" {
+		t.Fatalf("instance = %#v, want sandbox-123", instance)
+	}
+	if !reflect.DeepEqual(p.calls, []string{"create", "configure-openclaw:sandbox-123", "configure-openclaw:sandbox-123"}) {
+		t.Fatalf("call order = %v", p.calls)
+	}
+}
+
+func TestCreateAndConfigureDaytonaSandboxCleansUpWithIndependentContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	p := &recordingDaytonaSandboxProvisioner{configureErrors: []error{errors.New("sandbox not ready")}}
+
+	_, err := createAndConfigureDaytonaSandboxWithRetry(ctx, p, types.CreateRequest{}, nil, nil)
+	if err == nil {
+		t.Fatal("expected configuration error")
+	}
+	if p.destroyContextErr != nil {
+		t.Fatalf("cleanup inherited canceled context: %v", p.destroyContextErr)
+	}
+	if !reflect.DeepEqual(p.calls, []string{"create", "configure-openclaw:sandbox-123", "destroy:sandbox-123"}) {
+		t.Fatalf("call order = %v", p.calls)
 	}
 }

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2882,14 +2882,32 @@ type daytonaSandboxProvisioner interface {
 	Destroy(context.Context, string, bool) error
 }
 
-func createAndConfigureDaytonaSandbox(ctx context.Context, p daytonaSandboxProvisioner, req types.CreateRequest, env map[string]string) (*types.Instance, error) {
-	return createAndConfigureDaytonaSandboxWithRetry(ctx, p, req, env, []time.Duration{2 * time.Second, 5 * time.Second})
+var daytonaLongRetryDelays = []time.Duration{
+	5 * time.Second,
+	10 * time.Second,
+	20 * time.Second,
+	40 * time.Second,
+	60 * time.Second,
 }
 
-func createAndConfigureDaytonaSandboxWithRetry(ctx context.Context, p daytonaSandboxProvisioner, req types.CreateRequest, env map[string]string, retryDelays []time.Duration) (*types.Instance, error) {
+func createAndConfigureDaytonaSandbox(ctx context.Context, p daytonaSandboxProvisioner, req types.CreateRequest, env map[string]string, recordCreated func(*types.Instance) error) (*types.Instance, error) {
+	return createAndConfigureDaytonaSandboxWithRetry(ctx, p, req, env, recordCreated, daytonaLongRetryDelays)
+}
+
+func createAndConfigureDaytonaSandboxWithRetry(ctx context.Context, p daytonaSandboxProvisioner, req types.CreateRequest, env map[string]string, recordCreated func(*types.Instance) error, retryDelays []time.Duration) (*types.Instance, error) {
 	instance, err := p.Create(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("daytona create: %w", err)
+	}
+	if recordCreated != nil {
+		if err := recordCreated(instance); err != nil {
+			cleanupCtx, cancelCleanup := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+			defer cancelCleanup()
+			if cleanupErr := p.Destroy(cleanupCtx, instance.ID, false); cleanupErr != nil {
+				return nil, fmt.Errorf("daytona record sandbox %s: %w (sandbox cleanup failed: %v)", instance.ID, err, cleanupErr)
+			}
+			return nil, fmt.Errorf("daytona record sandbox %s: %w", instance.ID, err)
+		}
 	}
 
 	var configureErr error
@@ -2938,13 +2956,17 @@ func (s *Server) provisionDaytona(ctx context.Context, clawID string, req types.
 		TemplateFiles: files,
 		Env:           env,
 	}
-	instance, err := createAndConfigureDaytonaSandbox(ctx, p, createReq, env)
+	instance, err := createAndConfigureDaytonaSandbox(ctx, p, createReq, env, func(created *types.Instance) error {
+		if _, err := s.db.Exec(`UPDATE claws SET status='starting', provider='daytona', provider_id=? WHERE id=?`, created.ID, clawID); err != nil {
+			return err
+		}
+		log.Printf("daytona workspace created: %s (claw %s)", created.ID, clawID)
+		recordE2EDaytonaSandboxID(created.ID)
+		return nil
+	})
 	if err != nil {
 		return err
 	}
-	log.Printf("daytona workspace created: %s (claw %s)", instance.ID, clawID)
-	recordE2EDaytonaSandboxID(instance.ID)
-	_, _ = s.db.Exec(`UPDATE claws SET status='starting', provider='daytona', provider_id=? WHERE id=?`, instance.ID, clawID)
 
 	// Bootstrap: install OpenClaw + claw-bridge via exec (retry up to 3x for transient Daytona API timeouts)
 	clawName := req.Name
@@ -3731,13 +3753,7 @@ sh -c 'echo $$ > "$1"; exec /usr/local/bin/claw-bridge' sh "$PIDFILE" >> "$LOG" 
 }
 
 func (s *Server) downloadDaytonaConnector(ctx context.Context, clawID, instanceID string, p *daytona.Provider, downloadCmd string) error {
-	delays := []time.Duration{
-		5 * time.Second,
-		10 * time.Second,
-		20 * time.Second,
-		40 * time.Second,
-		60 * time.Second,
-	}
+	delays := daytonaLongRetryDelays
 	const maxAttempts = 6
 	var lastErr error
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2876,6 +2876,22 @@ func (s *Server) Provision(token, clawToken string) (string, error) {
 
 // ─── Provisioning ─────────────────────────────────────────────────────────────
 
+type daytonaSandboxProvisioner interface {
+	Create(context.Context, types.CreateRequest) (*types.Instance, error)
+	ConfigureOpenClaw(context.Context, string, map[string]string) error
+}
+
+func createAndConfigureDaytonaSandbox(ctx context.Context, p daytonaSandboxProvisioner, req types.CreateRequest, env map[string]string) (*types.Instance, error) {
+	instance, err := p.Create(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("daytona create: %w", err)
+	}
+	if err := p.ConfigureOpenClaw(ctx, instance.ID, env); err != nil {
+		return nil, fmt.Errorf("daytona configure OpenClaw environment for sandbox %s: %w", instance.ID, err)
+	}
+	return instance, nil
+}
+
 func (s *Server) provisionDaytona(ctx context.Context, clawID string, req types.CreateClawRequest, cfg types.ProviderConfig, files map[string][]byte, env map[string]string) error {
 	p, err := newDaytonaProvider(cfg)
 	if err != nil {
@@ -2893,9 +2909,9 @@ func (s *Server) provisionDaytona(ctx context.Context, clawID string, req types.
 		TemplateFiles: files,
 		Env:           env,
 	}
-	instance, err := p.Create(ctx, createReq)
+	instance, err := createAndConfigureDaytonaSandbox(ctx, p, createReq, env)
 	if err != nil {
-		return fmt.Errorf("daytona create: %w", err)
+		return err
 	}
 	log.Printf("daytona workspace created: %s (claw %s)", instance.ID, clawID)
 	recordE2EDaytonaSandboxID(instance.ID)

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2879,17 +2879,46 @@ func (s *Server) Provision(token, clawToken string) (string, error) {
 type daytonaSandboxProvisioner interface {
 	Create(context.Context, types.CreateRequest) (*types.Instance, error)
 	ConfigureOpenClaw(context.Context, string, map[string]string) error
+	Destroy(context.Context, string, bool) error
 }
 
 func createAndConfigureDaytonaSandbox(ctx context.Context, p daytonaSandboxProvisioner, req types.CreateRequest, env map[string]string) (*types.Instance, error) {
+	return createAndConfigureDaytonaSandboxWithRetry(ctx, p, req, env, []time.Duration{2 * time.Second, 5 * time.Second})
+}
+
+func createAndConfigureDaytonaSandboxWithRetry(ctx context.Context, p daytonaSandboxProvisioner, req types.CreateRequest, env map[string]string, retryDelays []time.Duration) (*types.Instance, error) {
 	instance, err := p.Create(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("daytona create: %w", err)
 	}
-	if err := p.ConfigureOpenClaw(ctx, instance.ID, env); err != nil {
-		return nil, fmt.Errorf("daytona configure OpenClaw environment for sandbox %s: %w", instance.ID, err)
+
+	var configureErr error
+	attempts := 0
+configureLoop:
+	for {
+		attempts++
+		configureErr = p.ConfigureOpenClaw(ctx, instance.ID, env)
+		if configureErr == nil {
+			return instance, nil
+		}
+		if attempts > len(retryDelays) {
+			break
+		}
+		timer := time.NewTimer(retryDelays[attempts-1])
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			break configureLoop
+		case <-timer.C:
+		}
 	}
-	return instance, nil
+
+	cleanupCtx, cancelCleanup := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	defer cancelCleanup()
+	if cleanupErr := p.Destroy(cleanupCtx, instance.ID, false); cleanupErr != nil {
+		return nil, fmt.Errorf("daytona configure OpenClaw environment for sandbox %s after %d attempts: %w (sandbox cleanup failed: %v)", instance.ID, attempts, configureErr, cleanupErr)
+	}
+	return nil, fmt.Errorf("daytona configure OpenClaw environment for sandbox %s after %d attempts: %w", instance.ID, attempts, configureErr)
 }
 
 func (s *Server) provisionDaytona(ctx context.Context, clawID string, req types.CreateClawRequest, cfg types.ProviderConfig, files map[string][]byte, env map[string]string) error {

--- a/pkg/provider/daytona/daytona.go
+++ b/pkg/provider/daytona/daytona.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -21,6 +22,24 @@ type Provider struct {
 }
 
 var shellEnvNameRE = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+func buildOpenClawEnvFile(env map[string]string) ([]byte, error) {
+	keys := make([]string, 0, len(env))
+	for key := range env {
+		if !shellEnvNameRE.MatchString(key) {
+			return nil, fmt.Errorf("invalid environment variable name %q", key)
+		}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	envLines := make([]string, 0, len(keys))
+	for _, key := range keys {
+		escapedValue := strings.ReplaceAll(env[key], "'", "'\"'\"'")
+		envLines = append(envLines, fmt.Sprintf("export %s='%s'", key, escapedValue))
+	}
+	return []byte(strings.Join(envLines, "\n")), nil
+}
 
 // New creates a new Daytona provider
 func New(config map[string]interface{}) (*Provider, error) {
@@ -311,33 +330,30 @@ func (p *Provider) ConfigureOpenClaw(ctx context.Context, instanceID string, env
 	}
 
 	// Create openclaw config directory
-	response, err := sandbox.Process.ExecuteCommand(ctx, "bash -c 'mkdir -p ~/.openclaw'")
+	response, err := sandbox.Process.ExecuteCommand(ctx, "bash -c 'mkdir -p /home/daytona/.openclaw'")
 	if err != nil {
 		return fmt.Errorf("failed to create config dir: %w", err)
+	}
+	if response.ExitCode != 0 {
+		return fmt.Errorf("failed to create config dir: command exited with status %d", response.ExitCode)
 	}
 
 	// Write environment to a file that gets sourced
 	if len(env) > 0 {
-		var envLines []string
-		for k, v := range env {
-			if !shellEnvNameRE.MatchString(k) {
-				return fmt.Errorf("invalid environment variable name %q", k)
-			}
-			// Escape for shell
-			escapedV := strings.ReplaceAll(v, "'", "'\"'\"'")
-			envLines = append(envLines, fmt.Sprintf("export %s='%s'", k, escapedV))
+		envContent, err := buildOpenClawEnvFile(env)
+		if err != nil {
+			return err
 		}
-		envContent := strings.Join(envLines, "\n")
 
 		// Write env file
-		err = sandbox.FileSystem.UploadFile(ctx, []byte(envContent), "/home/daytona/.openclaw/env")
+		err = sandbox.FileSystem.UploadFile(ctx, envContent, "/home/daytona/.openclaw/env")
 		if err != nil {
 			return fmt.Errorf("failed to write env file: %w", err)
 		}
 
 		// Source it from bashrc
 		response, err = sandbox.Process.ExecuteCommand(ctx,
-			"bash -c 'grep -q openclaw/env ~/.bashrc || echo \"source ~/.openclaw/env\" >> ~/.bashrc'")
+			"bash -c 'grep -q openclaw/env /home/daytona/.bashrc || echo \"source ~/.openclaw/env\" >> /home/daytona/.bashrc'")
 		if err != nil || response.ExitCode != 0 {
 			// Non-fatal
 		}

--- a/pkg/provider/daytona/daytona_test.go
+++ b/pkg/provider/daytona/daytona_test.go
@@ -5,6 +5,31 @@ import (
 	"testing"
 )
 
+func TestBuildOpenClawEnvFileIncludesWorkflowSecrets(t *testing.T) {
+	env, err := buildOpenClawEnvFile(map[string]string{
+		"ELASTICCLAW_HUB_URL":   "https://hub.example.com",
+		"AWS_SECRET_ACCESS_KEY": "secret-with-'quote",
+		"AWS_ACCESS_KEY_ID":     "workflow-access-key",
+	})
+	if err != nil {
+		t.Fatalf("buildOpenClawEnvFile: %v", err)
+	}
+
+	content := string(env)
+	for _, want := range []string{
+		"export AWS_ACCESS_KEY_ID='workflow-access-key'",
+		"export AWS_SECRET_ACCESS_KEY='secret-with-'\"'\"'quote'",
+		"export ELASTICCLAW_HUB_URL='https://hub.example.com'",
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("OpenClaw env file missing expected variable")
+		}
+	}
+	if strings.Index(content, "AWS_ACCESS_KEY_ID") > strings.Index(content, "AWS_SECRET_ACCESS_KEY") {
+		t.Fatal("environment file should be deterministic")
+	}
+}
+
 func TestBuildStartOpenClawCommandQuotesWorkdir(t *testing.T) {
 	workdir := `/tmp/a'; touch /tmp/pwned; #'`
 


### PR DESCRIPTION
## Summary

- materialize the resolved provisioning environment in `/home/daytona/.openclaw/env` immediately after Daytona sandbox creation
- stop provisioning with contextual, secret-safe errors when the OpenClaw environment cannot be written
- make environment file generation deterministic and validate config-directory creation failures

## Root cause

Workflow `secret_refs` were resolved into the environment passed to Daytona sandbox creation, but the Daytona provisioning path did not call `ConfigureOpenClaw`. Commands that source `~/.openclaw/env` therefore could not see values such as AWS credentials, which caused the Android/CodeBuild gate to report missing credentials.

## Impact

All Daytona provisioning entry points converge on `provisionDaytona`, so manual creation, workflows, integrations, factories, webhooks, and checkpoint restore now materialize the environment before bootstrap, gateway startup, or workflow commands can run.

## Tests

- `go test ./pkg/provider/daytona ./pkg/hub`
- `go test ./...`
- focused coverage verifies resolved workflow environment reaches OpenClaw configuration, call ordering is Create → ConfigureOpenClaw → bootstrap, failures stop provisioning without exposing secret values, and shell-safe environment-file rendering includes workflow AWS secret refs
