### PR TITLE
docs: add depot ci log reading instructions to workspace

### DIFF
--- a/.elasticclaw/workspaces/elasticclaw/AGENTS.md
+++ b/.elasticclaw/workspaces/elasticclaw/AGENTS.md
@@ -157,9 +157,18 @@ CI runs on Depot. Workflows in `.depot/workflows/`:
 
 ## Reading Depot CI Logs
 
-If you need to inspect CI logs for a Depot build, use the Depot CI API directly. The `DEPOT_TOKEN` env var is injected into the workspace (set via hub secrets). It is a Bearer token for `https://api.depot.dev`.
+If you need to inspect CI logs for a Depot build, use the Depot CI API directly. `DEPOT_TOKEN` is a Bearer token for `https://api.depot.dev`. Store it as a named secret in the hub (global or workspace-scoped) and inject it only where needed.
 
-**Security note:** `DEPOT_TOKEN` is exposed to every process in the workspace, just like any other injected secret. Store it in hub secrets with the narrowest scope possible — ideally a token that can only read CI logs and metrics, not trigger builds or access other Depot resources. If you only need the token occasionally, you can also omit it from the workspace config and set it manually when asked.
+**Recommended: scope it to the workflow.** Add a `secret_refs` entry to the workflow that needs to read Depot logs:
+
+```yaml
+secret_refs:
+  DEPOT_TOKEN: depot_token
+```
+
+This injects `DEPOT_TOKEN` only into claws created by that workflow, so other workflows in the workspace do not receive it. `secret_refs` resolves from workflow-scoped secrets first, then workspace secrets, then global hub secrets.
+
+**Security note:** Injected secrets are exposed to every process in the claw, so scope the Depot token as narrowly as possible — ideally a token that can only read CI logs and metrics, not trigger builds or access other Depot resources. If you only need the token occasionally, omit it and set it manually when asked.
 
 Useful API calls (Connect RPC over HTTP, JSON encoding):
 

--- a/.elasticclaw/workspaces/elasticclaw/AGENTS.md
+++ b/.elasticclaw/workspaces/elasticclaw/AGENTS.md
@@ -155,6 +155,46 @@ CI runs on Depot. Workflows in `.depot/workflows/`:
 
 **Important:** Depot does NOT support `release` event trigger — only `push`/`pull_request`/`tag`.
 
+## Reading Depot CI Logs
+
+If you need to inspect CI logs for a Depot build, use the Depot CI API directly. The `DEPOT_TOKEN` env var is injected into the workspace (set via hub secrets). It is a Bearer token for `https://api.depot.dev`.
+
+Useful API calls (Connect RPC over HTTP, JSON encoding):
+
+```bash
+# List recent CI runs for a repo
+curl -fsSL https://api.depot.dev/depot.ci.v1.CIService/ListRuns \
+  -H "Authorization: Bearer $DEPOT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Connect-Protocol-Version: 1" \
+  --json '{"repo": "elasticclaw/elasticclaw", "pageSize": 10}'
+
+# Get run status with nested workflows, jobs, and attempts
+curl -fsSL https://api.depot.dev/depot.ci.v1.CIService/GetRunStatus \
+  -H "Authorization: Bearer $DEPOT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Connect-Protocol-Version: 1" \
+  --json '{"runId": "<run-id>"}'
+
+# Get logs for a job attempt (use current attemptId from GetRunStatus)
+curl -fsSL https://api.depot.dev/depot.ci.v1.CIService/GetJobAttemptLogs \
+  -H "Authorization: Bearer $DEPOT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Connect-Protocol-Version: 1" \
+  --json '{"jobId": "<job-id>", "attemptId": "<attempt-id>"}'
+
+# Get failure diagnosis for a failed run/workflow/job/attempt
+curl -fsSL https://api.depot.dev/depot.ci.v1.CIService/GetFailureDiagnosis \
+  -H "Authorization: Bearer $DEPOT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Connect-Protocol-Version: 1" \
+  --json '{"runId": "<run-id>"}'
+```
+
+Full reference: https://depot.dev/docs/api/ci/reference
+
+When asked to read CI logs, start by listing recent runs, identify the relevant run/workflow/job, then fetch the attempt logs. Use `GetFailureDiagnosis` when the run failed to get a summarized reason.
+
 ## Key Files
 
 ```

--- a/.elasticclaw/workspaces/elasticclaw/AGENTS.md
+++ b/.elasticclaw/workspaces/elasticclaw/AGENTS.md
@@ -159,6 +159,8 @@ CI runs on Depot. Workflows in `.depot/workflows/`:
 
 If you need to inspect CI logs for a Depot build, use the Depot CI API directly. The `DEPOT_TOKEN` env var is injected into the workspace (set via hub secrets). It is a Bearer token for `https://api.depot.dev`.
 
+**Security note:** `DEPOT_TOKEN` is exposed to every process in the workspace, just like any other injected secret. Store it in hub secrets with the narrowest scope possible — ideally a token that can only read CI logs and metrics, not trigger builds or access other Depot resources. If you only need the token occasionally, you can also omit it from the workspace config and set it manually when asked.
+
 Useful API calls (Connect RPC over HTTP, JSON encoding):
 
 ```bash

--- a/.elasticclaw/workspaces/elasticclaw/elasticclaw-config.yaml
+++ b/.elasticclaw/workspaces/elasticclaw/elasticclaw-config.yaml
@@ -14,6 +14,4 @@ repositories:
 env:
   LINEAR_API_KEY:
     secret: LINEAR_API_KEY
-  DEPOT_TOKEN:
-    secret: DEPOT_TOKEN
   ENVIRONMENT: dev

--- a/.elasticclaw/workspaces/elasticclaw/elasticclaw-config.yaml
+++ b/.elasticclaw/workspaces/elasticclaw/elasticclaw-config.yaml
@@ -14,4 +14,6 @@ repositories:
 env:
   LINEAR_API_KEY:
     secret: LINEAR_API_KEY
+  DEPOT_TOKEN:
+    secret: DEPOT_TOKEN
   ENVIRONMENT: dev


### PR DESCRIPTION
This PR documents how to read Depot CI logs directly from the Depot API in the elasticclaw workspace, without installing the Depot CLI on claw-bridge VMs.

Changes:
- Add a 'Reading Depot CI Logs' section to  with example  commands for , , , and .
- Add  env reference to  so the token can be injected from hub secrets.

Note: this intentionally uses the API directly rather than installing the Depot CLI, per the discussion that the CLI install was overkill for this use case.