### PR TITLE
fix: graceful shutdown, panic recovery, sqlite busy_timeout, pr_conditions ordering

### DIFF
--- a/pkg/hub/cron_scheduler.go
+++ b/pkg/hub/cron_scheduler.go
@@ -63,7 +63,7 @@ func (cs *cronScheduler) start() error {
 	defer cs.mu.Unlock()
 
 	// Create cron with second-level precision (optional) and timezone support
-	cs.cron = cron.New(cron.WithSeconds())
+	cs.cron = cron.New(cron.WithSeconds(), cron.WithChain(cron.Recover(cron.DefaultLogger)))
 
 	// Load all workspaces and register cron workflows
 	if err := cs.reloadWorkflows(); err != nil {

--- a/pkg/hub/db_test.go
+++ b/pkg/hub/db_test.go
@@ -8,6 +8,22 @@ import (
 	"time"
 )
 
+func TestOpenDBSetsBusyTimeout(t *testing.T) {
+	db, err := openDB(filepath.Join(t.TempDir(), "hub.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	var timeout int
+	if err := db.QueryRow(`PRAGMA busy_timeout`).Scan(&timeout); err != nil {
+		t.Fatal(err)
+	}
+	if timeout != 5000 {
+		t.Fatalf("busy_timeout = %d, want 5000", timeout)
+	}
+}
+
 func TestClawsTriggerActorJSONDefaultIsValidJSON(t *testing.T) {
 	t.Run("fresh schema", func(t *testing.T) {
 		db, err := openDB(filepath.Join(t.TempDir(), "hub.db"))

--- a/pkg/hub/external_webhook.go
+++ b/pkg/hub/external_webhook.go
@@ -169,7 +169,7 @@ func (s *Server) handleExternalWebhook(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	go s.processExternalEvent(payload, body, sig)
+	s.safeGo("external webhook", func() { s.processExternalEvent(payload, body, sig) })
 	w.WriteHeader(http.StatusOK)
 }
 

--- a/pkg/hub/github_issues.go
+++ b/pkg/hub/github_issues.go
@@ -121,7 +121,7 @@ func (s *Server) handleGitHubIssuesWebhook(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	go s.processGitHubIssuesEvent(workspaceName, payload)
+	s.safeGo("github issues webhook", func() { s.processGitHubIssuesEvent(workspaceName, payload) })
 	w.WriteHeader(http.StatusOK)
 }
 

--- a/pkg/hub/github_webhook.go
+++ b/pkg/hub/github_webhook.go
@@ -83,7 +83,7 @@ func (s *Server) handleGitHubWebhook(w http.ResponseWriter, r *http.Request) {
 		}
 		log.Printf("[github-webhook] issues action=%q repo=%q issue=#%d author=%q",
 			payload.Action, payload.Repository.FullName, payload.Issue.Number, payload.Issue.User.Login)
-		go s.processGitHubIssueEvent(payload)
+		s.safeGo("github issue webhook", func() { s.processGitHubIssueEvent(payload) })
 	case "pull_request":
 		var payload githubPRPayload
 		if err := json.Unmarshal(body, &payload); err != nil {
@@ -94,7 +94,7 @@ func (s *Server) handleGitHubWebhook(w http.ResponseWriter, r *http.Request) {
 		log.Printf("[github-webhook] pull_request action=%q repo=%q pr=#%d author=%q base=%q",
 			payload.Action, payload.Repository.FullName, payload.Number,
 			payload.PullRequest.User.Login, payload.PullRequest.Base.Ref)
-		go s.processGitHubPREvent(payload)
+		s.safeGo("github PR webhook", func() { s.processGitHubPREvent(payload) })
 	case "pull_request_review_comment":
 		var payload githubPRReviewCommentPayload
 		if err := json.Unmarshal(body, &payload); err != nil {
@@ -104,7 +104,7 @@ func (s *Server) handleGitHubWebhook(w http.ResponseWriter, r *http.Request) {
 		}
 		log.Printf("[github-webhook] pull_request_review_comment action=%q repo=%q pr=#%d author=%q",
 			payload.Action, payload.Repository.FullName, payload.PullRequest.Number, payload.Comment.User.Login)
-		go s.processGitHubPRReviewCommentEvent(payload)
+		s.safeGo("github PR review comment webhook", func() { s.processGitHubPRReviewCommentEvent(payload) })
 	case "pull_request_review":
 		var payload githubPRReviewPayload
 		if err := json.Unmarshal(body, &payload); err != nil {
@@ -114,7 +114,7 @@ func (s *Server) handleGitHubWebhook(w http.ResponseWriter, r *http.Request) {
 		}
 		log.Printf("[github-webhook] pull_request_review action=%q state=%q repo=%q pr=#%d author=%q",
 			payload.Action, payload.Review.State, payload.Repository.FullName, payload.PullRequest.Number, payload.Review.User.Login)
-		go s.processGitHubPRReviewEvent(payload)
+		s.safeGo("github PR review webhook", func() { s.processGitHubPRReviewEvent(payload) })
 	case "issue_comment":
 		var payload githubIssueCommentPayload
 		if err := json.Unmarshal(body, &payload); err != nil {
@@ -125,12 +125,12 @@ func (s *Server) handleGitHubWebhook(w http.ResponseWriter, r *http.Request) {
 			// Comment on a pull request
 			log.Printf("[github-webhook] issue_comment action=%q repo=%q pr=#%d author=%q",
 				payload.Action, payload.Repository.FullName, payload.Issue.Number, payload.Comment.User.Login)
-			go s.processGitHubIssueCommentEvent(payload)
+			s.safeGo("github issue comment webhook", func() { s.processGitHubIssueCommentEvent(payload) })
 		} else {
 			// Comment on a plain issue (not PR)
 			log.Printf("[github-webhook] issue_comment action=%q repo=%q issue=#%d author=%q",
 				payload.Action, payload.Repository.FullName, payload.Issue.Number, payload.Comment.User.Login)
-			go s.processGitHubIssueComment(payload)
+			s.safeGo("github issue comment webhook", func() { s.processGitHubIssueComment(payload) })
 		}
 	case "ping":
 		log.Printf("[github-webhook] ping received — webhook configured correctly")

--- a/pkg/hub/integration_poller.go
+++ b/pkg/hub/integration_poller.go
@@ -20,13 +20,13 @@ import (
 // creates agents when the matching trigger has not already claimed that
 // external item.
 func (s *Server) startIntegrationPoller() {
-	go func() {
+	s.safeGo("integration poller", func() {
 		ticker := time.NewTicker(30 * time.Second)
 		defer ticker.Stop()
 		for range ticker.C {
-			s.pollTick()
+			s.safeGo("integration poll tick", s.pollTick)
 		}
-	}()
+	})
 }
 
 // pollTick queries integration platforms for recently updated items and

--- a/pkg/hub/jira.go
+++ b/pkg/hub/jira.go
@@ -132,7 +132,7 @@ func (s *Server) handleJiraWebhook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	go s.processJiraEvent(workspaceName, payload)
+	s.safeGo("jira webhook", func() { s.processJiraEvent(workspaceName, payload) })
 	w.WriteHeader(http.StatusOK)
 }
 

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -109,7 +109,8 @@ func (s *Server) handleLinearWebhook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	go s.processLinearEvent(strings.TrimSpace(r.PathValue("workspace")), payload)
+	workspace := strings.TrimSpace(r.PathValue("workspace"))
+	s.safeGo("linear webhook", func() { s.processLinearEvent(workspace, payload) })
 	w.WriteHeader(http.StatusOK)
 }
 

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -979,7 +979,7 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 				s.injectHubMessageByID(clawID, findingsMsg)
 			}
 			// Auto-transition to next stage if a judge_verdict trigger matches
-			go s.autoTransitionAfterJudge(clawID, judgeResult.Verdict, ctx)
+			s.safeGo("pipeline judge auto-transition", func() { s.autoTransitionAfterJudge(clawID, judgeResult.Verdict, ctx) })
 			// Check required verdict
 			if stage.OnEnter.Judge.Require.Verdict != "" &&
 				!strings.EqualFold(judgeResult.Verdict, stage.OnEnter.Judge.Require.Verdict) {
@@ -1019,7 +1019,7 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 		if autoTransitionVerdict == "skipped" && stage.Gate.TreatSkippedAsPass {
 			autoTransitionVerdict = "pass"
 		}
-		go s.autoTransitionAfterGate(clawID, stage.ID, autoTransitionVerdict, ctx)
+		s.safeGo("pipeline gate auto-transition", func() { s.autoTransitionAfterGate(clawID, stage.ID, autoTransitionVerdict, ctx) })
 		// If gate is required and failed (or errored), block further on_enter actions
 		if stage.Gate.Required && (gateResult.Verdict == "fail" || gateResult.Verdict == "error") {
 			msg := fmt.Sprintf("Required gate %q %s — blocking further pipeline actions", stage.ID, gateResult.Verdict)

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -272,10 +272,20 @@ func (s *Server) pollAllPRs() {
 		// For pipeline-driven claws, evaluate pr_conditions trigger.
 		if isPipelineDriven && !r.pr.prConditionsFired {
 			if stage := s.checkPRConditions(r.pr, token, pipelineCtx); stage != nil {
-				_, _ = s.db.Exec(`UPDATE claw_prs SET pr_conditions_fired=1 WHERE id=?`, r.pr.id)
-				s.transitionPipelineStageWithContext(r.pr.clawID, *stage, pipelineCtx)
+				s.firePRConditions(r.pr, *stage, pipelineCtx)
 			}
 		}
+	}
+}
+
+// firePRConditions consumes the one-shot trigger only after its transition
+// claims the stage. A failed claim remains eligible for the next poll.
+func (s *Server) firePRConditions(pr clawPR, stage pipeline.Stage, ctx pipelineContext) {
+	if !s.transitionPipelineStageWithContext(pr.clawID, stage, ctx) {
+		return
+	}
+	if _, err := s.db.Exec(`UPDATE claw_prs SET pr_conditions_fired=1 WHERE id=?`, pr.id); err != nil {
+		log.Printf("[pr-watcher] marking pr conditions fired for %s: %v", pr.prURL, err)
 	}
 }
 

--- a/pkg/hub/pr_watcher_test.go
+++ b/pkg/hub/pr_watcher_test.go
@@ -1,0 +1,31 @@
+package hub
+
+import (
+	"testing"
+
+	"github.com/elasticclaw/elasticclaw/pkg/hub/pipeline"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func TestPRConditionsRemainEligibleWhenTransitionFails(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+	const clawID = "claw-pr-conditions"
+	if _, err := db.Exec(`INSERT INTO claws(id, tenant_id, name, template, status, pipeline_stage, created_at) VALUES(?,?,?,?,?,?,datetime('now'))`, clawID, "test-tenant-id", "PR-1", "elasticclaw", "connected", "ready"); err != nil {
+		t.Fatal(err)
+	}
+	pr := clawPR{id: "pr-conditions", clawID: clawID, prURL: "https://github.com/o/r/pull/1"}
+	if _, err := db.Exec(`INSERT INTO claw_prs(id, claw_id, repo, pr_number, pr_url, created_at) VALUES(?,?,?,?,?,datetime('now'))`, pr.id, pr.clawID, "o/r", 1, pr.prURL); err != nil {
+		t.Fatal(err)
+	}
+	stage := pipeline.Stage{ID: "ready"} // already claimed: transition must fail
+	s.firePRConditions(pr, stage, pipelineContext{})
+	s.firePRConditions(pr, stage, pipelineContext{}) // next poll remains eligible
+
+	var fired int
+	if err := db.QueryRow(`SELECT pr_conditions_fired FROM claw_prs WHERE id=?`, pr.id).Scan(&fired); err != nil {
+		t.Fatal(err)
+	}
+	if fired != 0 {
+		t.Fatalf("pr_conditions_fired = %d, want 0 after failed transitions", fired)
+	}
+}

--- a/pkg/hub/safe_go_test.go
+++ b/pkg/hub/safe_go_test.go
@@ -1,0 +1,35 @@
+package hub
+
+import (
+	"bytes"
+	"log"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSafeGoRecoversAndLogsPanic(t *testing.T) {
+	var logs bytes.Buffer
+	oldOutput := log.Writer()
+	log.SetOutput(&logs)
+	t.Cleanup(func() { log.SetOutput(oldOutput) })
+
+	done := make(chan struct{})
+	(&Server{}).safeGo("test worker", func() {
+		defer close(done)
+		panic("malformed payload")
+	})
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("safeGo function did not run")
+	}
+	deadline := time.Now().Add(time.Second)
+	for !strings.Contains(logs.String(), "panic in test worker: malformed payload") && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if got := logs.String(); !strings.Contains(got, "panic in test worker: malformed payload") || !strings.Contains(got, "goroutine ") {
+		t.Fatalf("panic was not logged with stack: %q", got)
+	}
+}

--- a/pkg/hub/safe_go_test.go
+++ b/pkg/hub/safe_go_test.go
@@ -4,12 +4,30 @@ import (
 	"bytes"
 	"log"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
 
+type lockedBuffer struct {
+	mu sync.Mutex
+	b  bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.b.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.b.String()
+}
+
 func TestSafeGoRecoversAndLogsPanic(t *testing.T) {
-	var logs bytes.Buffer
+	var logs lockedBuffer
 	oldOutput := log.Writer()
 	log.SetOutput(&logs)
 	t.Cleanup(func() { log.SetOutput(oldOutput) })

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -288,11 +288,13 @@ func (s *Server) run(ctx context.Context, opts ...RunOptions) error {
 	}
 
 	srv := &http.Server{Addr: s.addr, Handler: corsMiddleware(mux)}
+	shutdownDone := make(chan struct{})
 	go func() {
 		<-ctx.Done()
 		log.Printf("[hub] shutting down")
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
+		defer close(shutdownDone)
 		if err := srv.Shutdown(shutdownCtx); err != nil {
 			log.Printf("[hub] shutdown error: %v", err)
 		}
@@ -304,6 +306,9 @@ func (s *Server) run(ctx context.Context, opts ...RunOptions) error {
 	}
 	err := srv.ListenAndServe()
 	if errors.Is(err, http.ErrServerClosed) {
+		// ListenAndServe returns as soon as Shutdown starts. Wait for it to
+		// finish draining active requests before closing their database.
+		<-shutdownDone
 		if closeErr := s.db.Close(); closeErr != nil {
 			return fmt.Errorf("close database: %w", closeErr)
 		}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -16,12 +17,15 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path"
 	"path/filepath"
+	"runtime/debug"
 	"sort"
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/elasticclaw/elasticclaw/internal/webui"
@@ -246,7 +250,25 @@ type RunOptions struct {
 	NoWebUI bool // skip serving embedded web UI (use in dev when Next.js runs separately)
 }
 
+// safeGo contains panics in goroutines that own agent or workflow progress.
+func (s *Server) safeGo(name string, fn func()) {
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Printf("[hub] panic in %s: %v\n%s", name, r, debug.Stack())
+			}
+		}()
+		fn()
+	}()
+}
+
 func (s *Server) Run(opts ...RunOptions) error {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	return s.run(ctx, opts...)
+}
+
+func (s *Server) run(ctx context.Context, opts ...RunOptions) error {
 	noWebUI := len(opts) > 0 && opts[0].NoWebUI
 	mux := http.NewServeMux()
 	s.mux = mux
@@ -265,11 +287,29 @@ func (s *Server) Run(opts ...RunOptions) error {
 		}
 	}
 
+	srv := &http.Server{Addr: s.addr, Handler: corsMiddleware(mux)}
+	go func() {
+		<-ctx.Done()
+		log.Printf("[hub] shutting down")
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := srv.Shutdown(shutdownCtx); err != nil {
+			log.Printf("[hub] shutdown error: %v", err)
+		}
+	}()
+
 	log.Printf("ElasticClaw Hub listening on %s", s.addr)
 	if s.hubCfg.UIPassword == "" {
 		log.Printf("⚠️  Web UI password not set — using default: 'admin'. Set ui_password in hub.yaml to secure the UI.")
 	}
-	return http.ListenAndServe(s.addr, corsMiddleware(mux))
+	err := srv.ListenAndServe()
+	if errors.Is(err, http.ErrServerClosed) {
+		if closeErr := s.db.Close(); closeErr != nil {
+			return fmt.Errorf("close database: %w", closeErr)
+		}
+		return nil
+	}
+	return err
 }
 
 func (s *Server) registerRoutes(mux *http.ServeMux) {
@@ -2447,9 +2487,9 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				if pipelineHandledDone {
 					prURLs := extractDonePRURLs(hm.Content)
 					s.trackDoneSignal(pipelineDoneCtx.Name(), pipelineDoneCtx.IssueID, clawID, len(prURLs))
-					go s.transitionPipelineStageWithContext(clawID, *pipelineDoneStage, pipelineDoneCtx)
+					s.safeGo("pipeline done transition", func() { s.transitionPipelineStageWithContext(clawID, *pipelineDoneStage, pipelineDoneCtx) })
 				} else if !strings.Contains(hm.Content, "[DONE]") {
-					go s.checkPipelineMessageTriggers(clawID, hm.Content)
+					s.safeGo("pipeline message triggers", func() { s.checkPipelineMessageTriggers(clawID, hm.Content) })
 				}
 				// Clear typing indicator now that response is complete
 				s.broadcastToUsers(tenantID, types.WSMessage{
@@ -2461,13 +2501,13 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				})
 				// Check for [DONE] signal from a factory-created claw
 				if strings.Contains(hm.Content, "[DONE]") {
-					go func() {
+					s.safeGo("done checkpoint", func() {
 						if _, err := s.requestCheckpoint(context.Background(), clawID, "done", "hub", false, checkpointRequestTimeout); err != nil {
 							log.Printf("[checkpoint] done request for %s failed: %v", shortID(clawID), err)
 						}
-					}()
+					})
 					if !pipelineHandledDone {
-						go s.handleClawDoneSignal(clawID, hm.Content)
+						s.safeGo("done signal", func() { s.handleClawDoneSignal(clawID, hm.Content) })
 					}
 				}
 				// Check for [TERMINATE] signal - allows claw to manage its own lifecycle

--- a/pkg/hub/server_shutdown_test.go
+++ b/pkg/hub/server_shutdown_test.go
@@ -1,0 +1,54 @@
+package hub
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func TestRunShutsDownCleanly(t *testing.T) {
+	db, err := openDB(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Skipf("network listener unavailable: %v", err)
+	}
+	addr := listener.Addr().String()
+	listener.Close()
+
+	s := &Server{addr: addr, db: db, hubCfg: &types.HubConfig{}}
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() { result <- s.run(ctx, RunOptions{NoWebUI: true}) }()
+
+	deadline := time.Now().Add(2 * time.Second)
+	var conn net.Conn
+	for time.Now().Before(deadline) {
+		conn, err = net.DialTimeout("tcp", addr, 100*time.Millisecond)
+		if err == nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if err != nil {
+		cancel()
+		t.Fatalf("server did not start: %v", err)
+	}
+	conn.Close()
+	cancel()
+
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatalf("Run returned %v, want clean exit", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after shutdown")
+	}
+}

--- a/pkg/hub/shortcut.go
+++ b/pkg/hub/shortcut.go
@@ -145,7 +145,8 @@ func (s *Server) handleShortcutWebhook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	go s.processShortcutEvent(strings.TrimSpace(r.PathValue("workspace")), payload)
+	workspace := strings.TrimSpace(r.PathValue("workspace"))
+	s.safeGo("shortcut webhook", func() { s.processShortcutEvent(workspace, payload) })
 	w.WriteHeader(http.StatusOK)
 }
 


### PR DESCRIPTION
## Summary

Agent runs could get stuck forever in non-terminal states: an unhandled panic in a run-owning goroutine silently killed background work with no recovery, a hard process exit during shutdown could interrupt in-flight requests and race with DB close, SQLite writers could contend without a bounded wait, and a crash between marking `pr_conditions_fired` and firing the pipeline transition could permanently strand a PR trigger. This change hardens the hub server against that class of liveness bug: goroutines recover and log instead of taking the process down, shutdown drains cleanly before closing resources, SQLite waits on `busy_timeout` instead of failing immediately on lock contention, and `pr_conditions` are only marked fired after the transition succeeds.

## Changes

- Graceful shutdown: `Server.Run` wraps `http.ListenAndServe` in an `http.Server` wired to `signal.NotifyContext(SIGINT, SIGTERM)`, calls `srv.Shutdown` with a 10s timeout, and only closes the DB after shutdown completes; `http.ErrServerClosed` is treated as a clean exit (`pkg/hub/server.go`).
- Panic recovery: added `Server.safeGo(name, fn)` (defer/recover + stack log) and applied it to all run-owning goroutines — pipeline judge/gate auto-transition, transition/message-trigger/done-signal goroutines, async webhook handlers (Linear, GitHub issues, Jira, Shortcut, GitHub webhook, external webhook), the integration poller and each tick, and cron job execution via `cron.WithChain(cron.Recover(...))`.
- SQLite `busy_timeout`: confirmed `busy_timeout(5000)` is set in the DSN pragma (`db.go`) and added a regression test asserting `PRAGMA busy_timeout` returns 5000.
- `pr_conditions` ordering: `pr_watcher.go` now runs the pipeline transition first via a new `firePRConditions` helper and only sets `pr_conditions_fired=1` after the transition claim succeeds, so a crash or failed transition leaves the trigger eligible for the next poll.
- Added/extended tests: `server_shutdown_test.go`, `safe_go_test.go`, `pr_watcher_test.go`, `db_test.go`.

## Testing

- `go build ./...` and `go test ./pkg/hub/...` passing.

## Review

Review verdict: needs_fixes with 4 finding(s). Blocking findings were fixed afterwards: Fixed both blocking review findings via Codex (gpt-5.6). (1) pkg/hub/server.go: added a shutdownDone channel closed after srv.Shutdown returns; Run() now waits on it in the ErrServerClosed branch before calling s.db.Close(), so the process no longer exits mid-drain and in-flight requests are no longer hard-killed nor racing with DB close. (2) pkg/hub/safe_go_test.go: replaced the raw bytes.Buffer with a mutex-guarded lockedBuffer (locking both Write and String) in TestSafeGoRecoversAndLogsPanic, eliminating the data race between safeGo's recover-handler log write and the test's polling read. Verified: go build ./... succeeds; go test ./pkg/hub/... passes (pkg/hub, artifact, factorytest, pipeline all ok); go test -race -run TestSafeGoRecoversAndLogsPanic ./pkg/hub and go test -race -run TestRunShutsDownCleanly ./pkg/hub both pass. Committed as c035a64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)