### PR TITLE
fix: make pipeline on_enter/gate failures terminal and handle issue-less [DONE]

### DIFF
--- a/pkg/hub/done_signal_test.go
+++ b/pkg/hub/done_signal_test.go
@@ -375,3 +375,52 @@ func TestHandleClawDoneSignal_AllowedWhenNoFailedRequiredGate(t *testing.T) {
 		t.Fatalf("expected 0 PRs stored (no GH App), got %d", count)
 	}
 }
+
+func TestHandleClawDoneSignal_IssueLessWorkflowCompletesWithoutPR(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+	s.cronScheduler = newCronScheduler(s)
+	const clawID = "claw-issue-less-done"
+	_, err := db.Exec(`INSERT INTO claws(id, tenant_id, name, template, status, created_at) VALUES(?,?,?,?,?,datetime('now'))`, clawID, "test-tenant-id", "workflow claw", "base", "connected")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = db.Exec(`INSERT INTO workflow_runs(id, tenant_id, workflow_name, workspace_name, trigger_type, status, claw_id, run_context, started_at, created_at) VALUES(?,?,?,?,?,?,?,?,datetime('now'),datetime('now'))`, "run-issue-less-done", "test-tenant-id", "nightly", "engineering", "cron", "running", clawID, "{}")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.handleClawDoneSignal(clawID, "[DONE]")
+	var clawStatus, runStatus string
+	if err := db.QueryRow(`SELECT status FROM claws WHERE id=?`, clawID).Scan(&clawStatus); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT status FROM workflow_runs WHERE id=?`, "run-issue-less-done").Scan(&runStatus); err != nil {
+		t.Fatal(err)
+	}
+	if clawStatus != "deleted" || runStatus != "completed" {
+		t.Fatalf("statuses = claw %q, run %q; want deleted, completed", clawStatus, runStatus)
+	}
+}
+
+func TestHandleClawDoneSignal_IssueLessWorkflowWatchesPR(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+	const clawID = "claw-issue-less-pr"
+	_, err := db.Exec(`INSERT INTO claws(id, tenant_id, name, template, status, created_at) VALUES(?,?,?,?,?,datetime('now'))`, clawID, "test-tenant-id", "workflow claw", "base", "connected")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.handleClawDoneSignal(clawID, "[DONE] https://github.com/org/repo/pull/42")
+	var status string
+	if err := db.QueryRow(`SELECT status FROM claws WHERE id=?`, clawID).Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	if status != "idle" {
+		t.Fatalf("status = %q, want idle", status)
+	}
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM claw_prs WHERE claw_id=?`, clawID).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("claw_prs count = %d, want 1", count)
+	}
+}

--- a/pkg/hub/done_signal_test.go
+++ b/pkg/hub/done_signal_test.go
@@ -408,6 +408,10 @@ func TestHandleClawDoneSignal_IssueLessWorkflowWatchesPR(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	_, err = db.Exec(`INSERT INTO workflow_runs(id, tenant_id, workflow_name, workspace_name, trigger_type, status, claw_id, run_context, started_at, created_at) VALUES(?,?,?,?,?,?,?,?,datetime('now'),datetime('now'))`, "run-issue-less-pr", "test-tenant-id", "nightly", "engineering", "cron", "running", clawID, "{}")
+	if err != nil {
+		t.Fatal(err)
+	}
 	s.handleClawDoneSignal(clawID, "[DONE] https://github.com/org/repo/pull/42")
 	var status string
 	if err := db.QueryRow(`SELECT status FROM claws WHERE id=?`, clawID).Scan(&status); err != nil {
@@ -422,5 +426,24 @@ func TestHandleClawDoneSignal_IssueLessWorkflowWatchesPR(t *testing.T) {
 	}
 	if count != 1 {
 		t.Fatalf("claw_prs count = %d, want 1", count)
+	}
+}
+
+func TestHandleClawDoneSignal_IssueLessInteractiveClawIsNoOp(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+	const clawID = "claw-issue-less-interactive"
+	_, err := db.Exec(`INSERT INTO claws(id, tenant_id, name, template, status, created_at) VALUES(?,?,?,?,?,datetime('now'))`, clawID, "test-tenant-id", "interactive claw", "base", "connected")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s.handleClawDoneSignal(clawID, "[DONE]")
+
+	var status string
+	if err := db.QueryRow(`SELECT status FROM claws WHERE id=?`, clawID).Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	if status != "connected" {
+		t.Fatalf("status = %q, want connected", status)
 	}
 }

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -1171,23 +1171,30 @@ func buildLinearContext(payload linearWebhookPayload, requiresPR bool) string {
 // If no valid open PRs are found (and a GH App is configured), it injects an
 // error message back so the claw can retry.
 func (s *Server) handleClawDoneSignal(clawID, rawMessage string) {
-	// Get the issue ID and tenant for this claw.
+	// Get the issue ID and tenant for this claw. Workflow claws may not have an
+	// issue, but [DONE] must still give those runs a terminal path.
 	var issueID, tenantID string
-	if err := s.db.QueryRow(`SELECT COALESCE(NULLIF(linear_issue_id,''),NULLIF(github_issue_id,''),NULLIF(shortcut_story_id,''),NULLIF(jira_issue_id,'')), tenant_id FROM claws WHERE id = ?`, clawID).Scan(&issueID, &tenantID); err != nil || issueID == "" {
-		return // not a factory claw
+	if err := s.db.QueryRow(`SELECT COALESCE(NULLIF(linear_issue_id,''),NULLIF(github_issue_id,''),NULLIF(shortcut_story_id,''),NULLIF(jira_issue_id,''),''), tenant_id FROM claws WHERE id = ?`, clawID).Scan(&issueID, &tenantID); err != nil {
+		return
 	}
-
-	log.Printf("[factory] claw %s sent [DONE] for issue %s", clawID[:8], issueID)
 
 	// Extract PR URLs from the [DONE] line.
 	// Expected format: [DONE] https://github.com/org/repo/pull/1 https://...
 	prURLs := extractDonePRURLs(rawMessage)
 
 	if pipelineCtx, stage, ok := s.pipelineStageForMessageContains(clawID, rawMessage); ok {
-		s.trackDoneSignal(pipelineCtx.Name(), issueID, clawID, len(prURLs))
+		if issueID != "" {
+			s.trackDoneSignal(pipelineCtx.Name(), issueID, clawID, len(prURLs))
+		}
 		s.transitionPipelineStageWithContext(clawID, *stage, pipelineCtx)
 		return
 	}
+	if issueID == "" {
+		s.completeIssueLessDoneClaw(clawID, tenantID, prURLs)
+		return
+	}
+
+	log.Printf("[factory] claw %s sent [DONE] for issue %s", clawID[:8], issueID)
 
 	noPRDoneAllowed := false
 	if len(prURLs) == 0 {
@@ -1371,6 +1378,46 @@ func (s *Server) handleClawDoneSignal(clawID, rawMessage string) {
 	}
 }
 
+// completeIssueLessDoneClaw completes a workflow/manual claw that has no
+// tracker issue. PR-bearing runs stay idle to watch their PRs; all other runs
+// use the normal non-PR teardown path.
+func (s *Server) completeIssueLessDoneClaw(clawID, tenantID string, prURLs []string) {
+	if len(prURLs) > 0 {
+		if ghToken := s.resolveGitHubToken(); ghToken != "" {
+			if rejected, reason := s.validateDonePRs(clawID, prURLs, ghToken); rejected {
+				s.injectUserMessage(clawID, reason)
+				return
+			}
+		}
+	}
+	if s.hasFailedRequiredGate(clawID) {
+		s.injectUserMessage(clawID, "[factory] `[DONE]` blocked: a required tool gate has failed. Please fix the issues and retry.")
+		return
+	}
+	for _, pr := range extractPRs(strings.Join(prURLs, " ")) {
+		s.storePRMention(clawID, pr.repo, pr.number, pr.url)
+	}
+	if len(prURLs) == 0 {
+		s.completeNoPRDoneClaw(clawID, tenantID, "")
+		return
+	}
+	res, err := s.db.Exec(`UPDATE claws SET status='idle' WHERE id=? AND status NOT IN ('deleted','error')`, clawID)
+	if err != nil {
+		return
+	}
+	rowsAffected, _ := res.RowsAffected()
+	if rowsAffected == 0 {
+		return
+	}
+	if s.cronScheduler != nil {
+		s.cronScheduler.finishRunByClawID(clawID, "completed", "success")
+	}
+	s.broadcastToUsers(tenantID, types.WSMessage{
+		Type:    "claw_status",
+		Payload: map[string]string{"claw_id": clawID, "status": "idle"},
+	})
+}
+
 func (s *Server) completeNoPRDoneClaw(clawID, tenantID, issueID string) {
 	var provider, providerID string
 	_ = s.db.QueryRow(`SELECT COALESCE(provider,''), COALESCE(provider_id,'') FROM claws WHERE id=? AND tenant_id=?`, clawID, tenantID).Scan(&provider, &providerID)
@@ -1394,6 +1441,9 @@ func (s *Server) completeNoPRDoneClaw(clawID, tenantID, issueID string) {
 		OccurredAt:      now(),
 	}); err != nil {
 		log.Printf("[task-run-analytics] failed to record non-pr completion for claw %s: %v", clawID, err)
+	}
+	if s.cronScheduler != nil {
+		s.cronScheduler.finishRunByClawID(clawID, "completed", "success")
 	}
 	s.broadcastToUsers(tenantID, types.WSMessage{
 		Type:    "claw_status",

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -1190,6 +1190,12 @@ func (s *Server) handleClawDoneSignal(clawID, rawMessage string) {
 		return
 	}
 	if issueID == "" {
+		var runningWorkflowRun bool
+		if err := s.db.QueryRow(`SELECT EXISTS(SELECT 1 FROM workflow_runs WHERE claw_id=? AND status='running')`, clawID).Scan(&runningWorkflowRun); err != nil || !runningWorkflowRun {
+			// Interactive claws have no tracker issue or workflow run; [DONE] is
+			// ordinary conversation for them, not a teardown signal.
+			return
+		}
 		s.completeIssueLessDoneClaw(clawID, tenantID, prURLs)
 		return
 	}

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -889,7 +889,7 @@ func formatPipelineRunFailure(action pipeline.RunAction, result *pipelineRunResu
 //
 // issueID is the default issue from the trigger; it can be overridden by
 // MoveIssue.IssueID (including template references like {{.Inputs.xxx}}).
-func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineContext) bool {
+func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineContext) (injectDelivered bool, err error) {
 	issueID := ctx.IssueID
 	if strings.TrimSpace(stage.OnEnter.Run.Command) != "" {
 		log.Printf("[pipeline] running workflow command for claw %s stage %q: %s", clawID[:8], stage.ID, stage.OnEnter.Run.Command)
@@ -911,7 +911,7 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 			} else {
 				log.Printf("[pipeline] %s", msg)
 				s.injectHubMessageByID(clawID, "[hub] Error: "+msg)
-				return false
+				return false, fmt.Errorf("run action failed: %s", msg)
 			}
 		} else {
 			log.Printf("[pipeline] workflow command completed for claw %s stage %q", clawID[:8], stage.ID)
@@ -935,7 +935,7 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 			log.Printf("[pipeline] %s", msg)
 			s.injectHubMessageByID(clawID, "[hub] Error: "+msg)
 			if !stage.OnEnter.DependencyUpdates.ContinueOnError {
-				return false
+				return false, fmt.Errorf("dependency update step failed: %s", msg)
 			}
 		}
 	}
@@ -949,7 +949,7 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 			log.Printf("[pipeline] %s", msg)
 			s.injectHubMessageByID(clawID, "[hub] Error: "+msg)
 			if !stage.OnEnter.Judge.ContinueOnError {
-				return false
+				return false, fmt.Errorf("judge action failed: %s", msg)
 			}
 		} else {
 			log.Printf("[pipeline] judge completed for claw %s stage %q: verdict=%s", clawID[:8], stage.ID, judgeResult.Verdict)
@@ -987,7 +987,7 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 				log.Printf("[pipeline] %s", msg)
 				if !stage.OnEnter.Judge.ContinueOnError {
 					s.injectHubMessageByID(clawID, "[hub] Error: "+msg)
-					return false
+					return false, fmt.Errorf("judge requirement failed: %s", msg)
 				}
 			}
 		}
@@ -1019,13 +1019,13 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 		if autoTransitionVerdict == "skipped" && stage.Gate.TreatSkippedAsPass {
 			autoTransitionVerdict = "pass"
 		}
-		go s.autoTransitionAfterGate(clawID, stage.ID, autoTransitionVerdict, ctx)
+		go s.autoTransitionAfterGate(clawID, stage.ID, autoTransitionVerdict, ctx, gateResult.Reason)
 		// If gate is required and failed (or errored), block further on_enter actions
 		if stage.Gate.Required && (gateResult.Verdict == "fail" || gateResult.Verdict == "error") {
 			msg := fmt.Sprintf("Required gate %q %s — blocking further pipeline actions", stage.ID, gateResult.Verdict)
 			log.Printf("[pipeline] %s", msg)
 			s.injectHubMessageByID(clawID, "[hub] Error: "+msg)
-			return false
+			return false, fmt.Errorf("required gate %q %s", stage.ID, gateResult.Verdict)
 		}
 	}
 
@@ -1142,6 +1142,7 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 			injectMsg = initialPlanWakeContent + "\n\nTask context:\n" + injectMsg
 		}
 		s.injectHubMessageByID(clawID, injectMsg)
+		injectDelivered = true
 	}
 
 	if stage.OnEnter.MergePR {
@@ -1188,7 +1189,7 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 
 	targetStatus := stage.OnEnter.MoveIssue.Status
 	if targetStatus == "" {
-		return true
+		return injectDelivered, nil
 	}
 
 	// If pipeline specifies an explicit issue_id, resolve it from templates or use directly
@@ -1269,7 +1270,7 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 	}
 issueResolved:
 	if resolvedIssueID == "" {
-		return true
+		return injectDelivered, nil
 	}
 
 	// Determine issue tracker: explicit workflow/factory integration takes precedence,
@@ -1291,7 +1292,7 @@ issueResolved:
 		tracker, ok := s.resolveJiraTrackerForPipeline(ctx)
 		if !ok {
 			log.Printf("[pipeline] %s: no Jira tracker for connection %q, skipping move_issue", ctx.Name(), ctx.TrackerName())
-			return true
+			return injectDelivered, nil
 		}
 		if err := s.moveJiraIssue(tracker, resolvedIssueID, targetStatus); err != nil {
 			log.Printf("[pipeline] failed to move Jira issue %s to %q: %v", resolvedIssueID, targetStatus, err)
@@ -1307,7 +1308,7 @@ issueResolved:
 		scToken := s.resolveShortcutTokenForPipeline(ctx)
 		if scToken == "" {
 			log.Printf("[pipeline] %s: no Shortcut token for connection %q, skipping move_issue", ctx.Name(), ctx.TrackerName())
-			return true
+			return injectDelivered, nil
 		}
 		if err := moveShortcutStory(s.resolveShortcutBaseURL(), scToken, scID, targetStatus); err != nil {
 			log.Printf("[pipeline] failed to move story %s to %q: %v", scID, targetStatus, err)
@@ -1319,18 +1320,18 @@ issueResolved:
 		ghToken := s.resolveGitHubIssuesTokenForPipeline(ctx)
 		if ghToken == "" {
 			log.Printf("[pipeline] %s: no GitHub Issues token for move_issue, skipping", ctx.Name())
-			return true
+			return injectDelivered, nil
 		}
 		parts := strings.Split(resolvedIssueID, "/")
 		if len(parts) != 3 {
 			log.Printf("[pipeline] %s: GitHub issue ID %q is not owner/repo/number format — skipping move_issue", ctx.Name(), resolvedIssueID)
-			return true
+			return injectDelivered, nil
 		}
 		repo := parts[0] + "/" + parts[1]
 		var issueNum int
 		if _, err := fmt.Sscanf(parts[2], "%d", &issueNum); err != nil {
 			log.Printf("[pipeline] %s: invalid GitHub issue number in %q — skipping move_issue", ctx.Name(), resolvedIssueID)
-			return true
+			return injectDelivered, nil
 		}
 		if err := moveGitHubIssue(ghToken, repo, issueNum, targetStatus, s.githubBaseURL); err != nil {
 			log.Printf("[pipeline] failed to move GitHub issue %s to %q: %v", resolvedIssueID, targetStatus, err)
@@ -1342,7 +1343,7 @@ issueResolved:
 		linearToken := s.resolveLinearTokenForPipeline(ctx)
 		if linearToken == "" {
 			log.Printf("[pipeline] %s: no Linear token for connection %q, skipping move_issue", ctx.Name(), ctx.TrackerName())
-			return true
+			return injectDelivered, nil
 		}
 		if err := s.moveLinearIssueOnServer(linearToken, resolvedIssueID, targetStatus); err != nil {
 			log.Printf("[pipeline] failed to move issue %s to %q: %v", resolvedIssueID, targetStatus, err)
@@ -1350,7 +1351,7 @@ issueResolved:
 			log.Printf("[pipeline] moved issue %s to %q", resolvedIssueID, targetStatus)
 		}
 	}
-	return true
+	return injectDelivered, nil
 }
 
 func pipelineTerminalWorkflowRunResult(stage pipeline.Stage, stageActionsSucceeded bool) (status, result string) {
@@ -1448,19 +1449,25 @@ func (s *Server) pipelineStageForMessageContains(clawID, message string) (pipeli
 
 func (s *Server) transitionPipelineStageWithContext(clawID string, stage pipeline.Stage, ctx pipelineContext) bool {
 	stage = s.resolvePipelineStageSkips(clawID, stage, ctx)
-	return s.transitionResolvedPipelineStageWithContext(clawID, stage, ctx)
+	transitioned, _ := s.transitionResolvedPipelineStageWithContext(clawID, stage, ctx)
+	return transitioned
 }
 
-func (s *Server) transitionResolvedPipelineStageWithContext(clawID string, stage pipeline.Stage, ctx pipelineContext) bool {
+func (s *Server) transitionResolvedPipelineStageWithContext(clawID string, stage pipeline.Stage, ctx pipelineContext) (transitioned, injectDelivered bool) {
 	if !s.claimPipelineStageTransition(clawID, stage.ID) {
 		log.Printf("[pipeline] claw %s already in stage %q (%s), skipping duplicate transition", clawID[:8], stage.ID, stage.Label)
-		return false
+		return false, false
 	}
 	// Record that this claw has visited this stage, so one-shot triggers
 	// (like output_matches) don't re-fire on subsequent messages.
 	s.recordPipelineStageVisit(clawID, stage.ID)
 	log.Printf("[pipeline] claw %s → stage %q (%s)", clawID[:8], stage.ID, stage.Label)
-	stageActionsSucceeded := s.runOnEnter(clawID, stage, ctx)
+	injectDelivered, onEnterErr := s.runOnEnter(clawID, stage, ctx)
+	stageActionsSucceeded := onEnterErr == nil
+	if onEnterErr != nil && !stage.Terminal {
+		s.stopAgentWithReason(clawID, fmt.Sprintf("pipeline stage %q on_enter failed: %v", stage.ID, onEnterErr), false)
+		return true, false
+	}
 
 	// If this is a terminal stage, terminate the claw
 	if stage.Terminal {
@@ -1507,7 +1514,7 @@ func (s *Server) transitionResolvedPipelineStageWithContext(clawID string, stage
 			go s.terminateVM(provider, providerID)
 		}
 	}
-	return true
+	return true, injectDelivered
 }
 
 func (s *Server) resolvePipelineStageSkips(clawID string, stage pipeline.Stage, ctx pipelineContext) pipeline.Stage {
@@ -1619,6 +1626,7 @@ type GateEvaluationResult struct {
 	Verdict      string // "pass", "fail", "skipped", "error"
 	MatchedPath  string
 	MatchedValue string
+	Reason       string
 }
 
 // evaluateGate inspects a named pipeline output and evaluates the gate
@@ -1634,6 +1642,7 @@ func (s *Server) evaluateGate(clawID, stageID string, gate *pipeline.Gate) *Gate
 			result.Verdict = "skipped"
 		} else {
 			result.Verdict = "error"
+			result.Reason = fmt.Sprintf("required output %q was not found", gate.Output)
 		}
 		log.Printf("[pipeline] gate %q for claw %s: output %q not found, verdict=%s", stageID, clawID[:8], gate.Output, result.Verdict)
 		s.persistGateResult(clawID, stageID, gate, result)
@@ -1673,6 +1682,7 @@ func (s *Server) evaluateGate(clawID, stageID string, gate *pipeline.Gate) *Gate
 	}
 
 	// Neither pass nor fail matched — error
+	result.Reason = "no gate condition matched"
 	log.Printf("[pipeline] gate %q for claw %s: no conditions matched, verdict=error", stageID, clawID[:8])
 	s.persistGateResult(clawID, stageID, gate, result)
 	return result
@@ -1730,7 +1740,7 @@ func (s *Server) hasFailedRequiredGate(clawID string) bool {
 
 // autoTransitionAfterGate checks the pipeline for a stage with a gate_result
 // trigger matching the given stage ID and verdict, and transitions to it.
-func (s *Server) autoTransitionAfterGate(clawID, stageID, verdict string, ctx pipelineContext) {
+func (s *Server) autoTransitionAfterGate(clawID, stageID, verdict string, ctx pipelineContext, errorReasons ...string) {
 	pl := parsePipelineForContext(ctx)
 	if pl == nil {
 		return
@@ -1738,6 +1748,13 @@ func (s *Server) autoTransitionAfterGate(clawID, stageID, verdict string, ctx pi
 	stage := pl.StageForGateResult(stageID, verdict)
 	if stage == nil {
 		log.Printf("[pipeline] claw %s: no stage with gate_result stage=%s verdict=%s trigger found", clawID[:8], stageID, verdict)
+		if verdict == "error" {
+			reason := "no gate condition matched"
+			if len(errorReasons) > 0 && strings.TrimSpace(errorReasons[0]) != "" {
+				reason = errorReasons[0]
+			}
+			s.stopAgentWithReason(clawID, fmt.Sprintf("pipeline gate %q errored: %s", stageID, reason), false)
+		}
 		return
 	}
 	log.Printf("[pipeline] claw %s: auto-transitioning to stage %q after gate stage=%s verdict=%s", clawID[:8], stage.ID, stageID, verdict)
@@ -1768,7 +1785,8 @@ func (s *Server) initializePipelineEntryIfNeeded(clawID string) bool {
 	}
 
 	effectiveEntry := s.resolvePipelineStageSkips(clawID, *entry, ctx)
-	return s.transitionResolvedPipelineStageWithContext(clawID, effectiveEntry, ctx) && strings.TrimSpace(effectiveEntry.OnEnter.Inject) != ""
+	_, injectDelivered := s.transitionResolvedPipelineStageWithContext(clawID, effectiveEntry, ctx)
+	return injectDelivered
 }
 
 // stopAgentWithReason is the centralized handler for unexpected agent termination.

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -881,6 +881,18 @@ func formatPipelineRunFailure(action pipeline.RunAction, result *pipelineRunResu
 	return fmt.Sprintf("Workflow command failed: `%s`\n\n%s", command, sanitizeBootstrapOutput(details))
 }
 
+// routedRequiredGateError means a required gate prevented subsequent on_enter
+// actions, but its verdict has a declared gate_result route that will handle it.
+// It must not terminate the source stage before that route can transition.
+type routedRequiredGateError struct {
+	stageID string
+	verdict string
+}
+
+func (e *routedRequiredGateError) Error() string {
+	return fmt.Sprintf("required gate %q %s", e.stageID, e.verdict)
+}
+
 // runOnEnter executes the on_enter actions for a given stage.
 //
 // - stage.OnEnter.Run: executes a command in the agent workspace
@@ -1025,6 +1037,9 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 			msg := fmt.Sprintf("Required gate %q %s — blocking further pipeline actions", stage.ID, gateResult.Verdict)
 			log.Printf("[pipeline] %s", msg)
 			s.injectHubMessageByID(clawID, "[hub] Error: "+msg)
+			if pl := parsePipelineForContext(ctx); pl != nil && pl.StageForGateResult(stage.ID, gateResult.Verdict) != nil {
+				return false, &routedRequiredGateError{stageID: stage.ID, verdict: gateResult.Verdict}
+			}
 			return false, fmt.Errorf("required gate %q %s", stage.ID, gateResult.Verdict)
 		}
 	}
@@ -1464,6 +1479,12 @@ func (s *Server) transitionResolvedPipelineStageWithContext(clawID string, stage
 	log.Printf("[pipeline] claw %s → stage %q (%s)", clawID[:8], stage.ID, stage.Label)
 	injectDelivered, onEnterErr := s.runOnEnter(clawID, stage, ctx)
 	stageActionsSucceeded := onEnterErr == nil
+	var routedGateErr *routedRequiredGateError
+	if errors.As(onEnterErr, &routedGateErr) {
+		// autoTransitionAfterGate was started by runOnEnter and owns the declared
+		// gate_result route. Do not race it by terminating this source stage.
+		return true, false
+	}
 	if onEnterErr != nil && !stage.Terminal {
 		s.stopAgentWithReason(clawID, fmt.Sprintf("pipeline stage %q on_enter failed: %v", stage.ID, onEnterErr), false)
 		return true, false

--- a/pkg/hub/pipeline_runner_test.go
+++ b/pkg/hub/pipeline_runner_test.go
@@ -739,6 +739,71 @@ func TestTerminalPipelineFailureStageMarksWorkflowRunFailed(t *testing.T) {
 	}
 }
 
+func TestNonTerminalPipelineOnEnterFailureMarksWorkflowRunFailed(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+	s.cronScheduler = newCronScheduler(s)
+	const clawID = "claw-nonterminal-failure"
+	_, err := db.Exec(`INSERT INTO claws(id, tenant_id, name, template, status, created_at) VALUES(?,?,?,?,?,datetime('now'))`, clawID, "test-tenant-id", "workflow claw", "elasticclaw", "connected")
+	if err != nil {
+		t.Fatalf("insert claw: %v", err)
+	}
+	_, err = db.Exec(`INSERT INTO workflow_runs(id, tenant_id, workflow_name, workspace_name, trigger_type, status, claw_id, run_context, started_at, created_at) VALUES(?,?,?,?,?,?,?,?,datetime('now'),datetime('now'))`, "run-nonterminal-failure", "test-tenant-id", "nightly", "engineering", "cron", "running", clawID, "{}")
+	if err != nil {
+		t.Fatalf("insert workflow run: %v", err)
+	}
+
+	stage := pipeline.Stage{ID: "validate", OnEnter: pipeline.OnEnter{Judge: pipeline.JudgeAction{Instructions: "review", Inputs: []pipeline.JudgeInput{pipeline.JudgeInputIssue}}}}
+	if !s.transitionPipelineStageWithContext(clawID, stage, pipelineContext{}) {
+		t.Fatal("transition returned false")
+	}
+	var clawStatus, runStatus string
+	if err := db.QueryRow(`SELECT status FROM claws WHERE id=?`, clawID).Scan(&clawStatus); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT status FROM workflow_runs WHERE id=?`, "run-nonterminal-failure").Scan(&runStatus); err != nil {
+		t.Fatal(err)
+	}
+	if clawStatus != "error" || runStatus != "failed" {
+		t.Fatalf("statuses = claw %q, run %q; want error, failed", clawStatus, runStatus)
+	}
+}
+
+func TestGateErrorWithoutRouteMarksWorkflowRunFailed(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+	s.cronScheduler = newCronScheduler(s)
+	const clawID = "claw-gate-error-no-route"
+	_, err := db.Exec(`INSERT INTO claws(id, tenant_id, name, template, status, created_at) VALUES(?,?,?,?,?,datetime('now'))`, clawID, "test-tenant-id", "workflow claw", "elasticclaw", "connected")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = db.Exec(`INSERT INTO workflow_runs(id, tenant_id, workflow_name, workspace_name, trigger_type, status, claw_id, run_context, started_at, created_at) VALUES(?,?,?,?,?,?,?,?,datetime('now'),datetime('now'))`, "run-gate-error", "test-tenant-id", "nightly", "engineering", "cron", "running", clawID, "{}")
+	if err != nil {
+		t.Fatal(err)
+	}
+	factory := &types.FactoryConfig{Name: "gate-no-route", PipelineYAML: "stages:\n  - id: validate\n    entry: true\n"}
+	s.autoTransitionAfterGate(clawID, "validate", "error", pipelineContext{Factory: factory}, "output was malformed")
+	var clawStatus, runStatus string
+	_ = db.QueryRow(`SELECT status FROM claws WHERE id=?`, clawID).Scan(&clawStatus)
+	_ = db.QueryRow(`SELECT status FROM workflow_runs WHERE id=?`, "run-gate-error").Scan(&runStatus)
+	if clawStatus != "error" || runStatus != "failed" {
+		t.Fatalf("statuses = claw %q, run %q; want error, failed", clawStatus, runStatus)
+	}
+}
+
+func TestGateErrorRouteTransitions(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+	const clawID = "claw-gate-error-route"
+	_, err := db.Exec(`INSERT INTO claws(id, tenant_id, name, template, status, pipeline_stage, created_at) VALUES(?,?,?,?,?,?,datetime('now'))`, clawID, "test-tenant-id", "workflow claw", "elasticclaw", "connected", "validate")
+	if err != nil {
+		t.Fatal(err)
+	}
+	factory := &types.FactoryConfig{Name: "gate-error-route", PipelineYAML: "stages:\n  - id: validate\n    entry: true\n  - id: recover\n    triggers:\n      - gate_result:\n          stage: validate\n          verdict: error\n"}
+	s.autoTransitionAfterGate(clawID, "validate", "error", pipelineContext{Factory: factory}, "output was malformed")
+	if got := s.getPipelineStage(clawID); got != "recover" {
+		t.Fatalf("stage = %q, want recover", got)
+	}
+}
+
 func TestParseJudgeResponseValid(t *testing.T) {
 	raw := `{"verdict":"pass","summary":"Looks good","findings":[],"required_fixes":[]}`
 	result, err := parseJudgeResponse(raw)


### PR DESCRIPTION
## Summary

Fixes a class of liveness bugs where agent runs could get stuck forever in non-terminal states. Several code paths silently swallowed failures instead of terminating the run: a failing `on_enter` action would drop remaining actions (including injects) without stopping the claw/workflow run; a gate verdict of `error` with no declared route would leave the pipeline stalled instead of failing; and `[DONE]` signals from issue-less workflow claws were discarded instead of driving the claw to `idle` or completing the run.

## Changes

- `runOnEnter` now returns a descriptive error; non-terminal stage `on_enter` failures call `stopAgentWithReason` (claw -> `error`, workflow run -> `failed`) instead of silently succeeding while dropping remaining actions.
- `autoTransitionAfterGate` calls `stopAgentWithReason` when a gate verdict is `error` and no stage declares an `error` gate_result route; pipelines with a declared error route still transition normally.
- `initializePipelineEntryIfNeeded` now only reports the inject as delivered when it was actually sent (defense in depth alongside the `on_enter` fix).
- `handleClawDoneSignal` (linear.go) no longer discards `[DONE]` signals from issue-less workflow claws: it validates/stores PR URLs, sets the claw to `idle` if PRs are pending, otherwise runs the terminal teardown and calls the cron scheduler's `finishRunByClawID("completed")`.
- Added tests in `pipeline_runner_test.go` (non-terminal on_enter failure, gate error without route, gate error with declared route) and `done_signal_test.go` (issue-less `[DONE]` with/without PRs).

## Testing

- `go build` and `go test ./pkg/hub/...` passing.

## Review

Review verdict: needs_fixes with 5 finding(s). Blocking findings were fixed afterwards: Fixed both blocking review findings via Codex CLI (gpt-5.6). (1) pkg/hub/pipeline_runner.go: added a routedRequiredGateError type so a required-gate fail/error whose verdict has a declared gate_result route no longer triggers stopAgentWithReason in transitionResolvedPipelineStageWithContext — it now lets autoTransitionAfterGate's goroutine own the declared route, restoring the gate retry-loop pattern. Unrouted required-gate failures still terminate the run (liveness preserved). (2) pkg/hub/linear.go: handleClawDoneSignal now checks for an associated running workflow_runs row before calling completeIssueLessDoneClaw on an issue-less claw; interactive claws with no workflow run are a no-op again, as before. Added test coverage in pkg/hub/done_signal_test.go (new TestHandleClawDoneSignal_IssueLessInteractiveClawIsNoOp, plus a workflow_runs row inserted into the existing issue-less PR test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)