### PR TITLE
fix(claw-bridge): redeliver completed replies instead of re-running turns; no silent queue drops

### DIFF
--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -67,12 +67,26 @@ type hubMsg struct {
 }
 
 // ─── Inbound message queue ───────────────────────────────────────────────────
-// Queues user messages when the hub connection is temporarily unavailable.
-// Messages older than msgQueueTTL are dropped to prevent unbounded growth.
+// Queues entries when the hub connection is temporarily unavailable. Unprocessed
+// user inputs older than msgQueueTTL are dropped to avoid starting a stale turn
+// much later, but completed replies and error notices NEVER expire — losing a
+// finished reply would silently discard work (commits, PRs) the agent already did.
 
-const msgQueueTTL = 10 * time.Minute
+const (
+	msgQueueTTL = 10 * time.Minute
+	msgQueueMax = 256 // total entries; oldest inputs are evicted on overflow
+)
+
+type queuedKind int
+
+const (
+	queuedInput  queuedKind = iota // user message not yet processed
+	queuedReply                    // completed agent reply awaiting delivery
+	queuedNotice                   // error notice to surface to the hub
+)
 
 type queuedMsg struct {
+	kind     queuedKind
 	content  string
 	queuedAt time.Time
 }
@@ -80,28 +94,103 @@ type queuedMsg struct {
 type msgQueue struct {
 	mu   sync.Mutex
 	msgs []queuedMsg
+
+	// dropped tracks inputs discarded (TTL or overflow) while the hub was
+	// unreachable, so drain() can tell the hub instead of losing them silently.
+	dropped         int
+	droppedPreviews []string
 }
 
-func (q *msgQueue) push(content string) {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	q.msgs = append(q.msgs, queuedMsg{content: content, queuedAt: time.Now()})
+// recordDropLocked notes a dropped input for the reconnect notice. Caller holds mu.
+func (q *msgQueue) recordDropLocked(content string) {
+	q.dropped++
+	if len(q.droppedPreviews) < 10 {
+		q.droppedPreviews = append(q.droppedPreviews, content[:min(len(content), 60)])
+	}
 }
 
-// drain returns all non-expired messages and clears the queue.
-func (q *msgQueue) drain() []string {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	var out []string
-	for _, m := range q.msgs {
-		if time.Since(m.queuedAt) < msgQueueTTL {
-			out = append(out, m.content)
-		} else {
-			log.Printf("[bridge] dropped queued message (TTL exceeded): %q", m.content[:min(len(m.content), 60)])
+// enqueueLocked appends an entry, enforcing msgQueueMax by evicting the oldest
+// input. Replies/notices are never evicted; if no input can be evicted the queue
+// is allowed to grow so completed replies are never lost. Caller holds mu.
+func (q *msgQueue) enqueueLocked(m queuedMsg) {
+	if len(q.msgs) >= msgQueueMax {
+		for i, existing := range q.msgs {
+			if existing.kind == queuedInput {
+				q.recordDropLocked(existing.content)
+				q.msgs = append(q.msgs[:i], q.msgs[i+1:]...)
+				break
+			}
 		}
 	}
+	q.msgs = append(q.msgs, m)
+}
+
+// pushInput queues an unprocessed user message (subject to TTL).
+func (q *msgQueue) pushInput(content string) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.enqueueLocked(queuedMsg{kind: queuedInput, content: content, queuedAt: time.Now()})
+}
+
+// pushReply queues a completed agent reply awaiting delivery (never expires).
+func (q *msgQueue) pushReply(content string) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.enqueueLocked(queuedMsg{kind: queuedReply, content: content, queuedAt: time.Now()})
+}
+
+// requeue re-inserts an entry preserving its original queuedAt (used when a
+// queued reply/notice fails to deliver again).
+func (q *msgQueue) requeue(m queuedMsg) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.enqueueLocked(m)
+}
+
+// drain returns all deliverable entries and clears the queue. Expired inputs are
+// discarded but counted; if any were dropped a synthesized notice is prepended so
+// the hub learns about the loss on reconnect instead of it vanishing silently.
+func (q *msgQueue) drain() []queuedMsg {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	var out []queuedMsg
+	for _, m := range q.msgs {
+		if m.kind == queuedInput && time.Since(m.queuedAt) >= msgQueueTTL {
+			log.Printf("[bridge] dropped queued input (TTL exceeded): %q", m.content[:min(len(m.content), 60)])
+			q.recordDropLocked(m.content)
+			continue
+		}
+		out = append(out, m)
+	}
 	q.msgs = nil
+
+	if q.dropped > 0 {
+		notice := queuedMsg{
+			kind:     queuedNotice,
+			content:  fmt.Sprintf("⚠️ claw-bridge: %d queued message(s) were dropped while the hub was unreachable: %s", q.dropped, strings.Join(q.droppedPreviews, " | ")),
+			queuedAt: time.Now(),
+		}
+		out = append([]queuedMsg{notice}, out...)
+		q.dropped = 0
+		q.droppedPreviews = nil
+	}
 	return out
+}
+
+// replayQueued delivers queued entries after reconnect. Completed replies and
+// notices are written directly to the hub; only unprocessed inputs re-run a turn.
+func replayQueued(queue *msgQueue, deliver func(role, content string) error, runTurn func(content string)) {
+	for _, m := range queue.drain() {
+		switch m.kind {
+		case queuedReply, queuedNotice:
+			if err := deliver("claw", m.content); err != nil {
+				log.Printf("[bridge] replay deliver failed, re-queuing: %v", err)
+				queue.requeue(m)
+			}
+		default: // queuedInput
+			runTurn(m.content)
+		}
+	}
 }
 
 // ─── openclaw gateway wire types ────────────────────────────────────────────
@@ -3331,36 +3420,40 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 		})
 	}
 
-	// Replay any queued messages that arrived while we were disconnected
-	if queued := queue.drain(); len(queued) > 0 {
-		log.Printf("[bridge] replaying %d queued message(s)", len(queued))
-		connCtx := ctx
-		for _, content := range queued {
-			go func(c string) {
-				agentCtx, agentCancel := context.WithTimeout(context.Background(), 30*time.Minute)
-				defer agentCancel()
-				reply, agentErr := gwSession.SendMessage(agentCtx, c, func(chunk string) {
-					_ = wsjson.Write(connCtx, conn, hubMsg{
-						Type:    "chunk",
-						Payload: mustJSON(map[string]interface{}{"role": "claw", "content": chunk}),
-					})
-				}, func(activity agentActivity) {
-					writeActivity(connCtx, activity)
-				})
-				if agentErr != nil {
-					reply = fmt.Sprintf("⚠️ error: %v", agentErr)
-				}
-				if writeErr := wsjson.Write(connCtx, conn, hubMsg{
-					Type:    "message",
-					Payload: mustJSON(map[string]interface{}{"role": "claw", "content": reply}),
-				}); writeErr != nil {
-					// Hub connection dropped — queue original content for replay on reconnect
-					log.Printf("[bridge] hub write failed, queuing original message for replay: %v", writeErr)
-					queue.push(c)
-				}
-			}(content)
-		}
+	// Replay any queued entries that accumulated while we were disconnected.
+	// Completed replies/notices are delivered directly; only unprocessed inputs
+	// re-run an agent turn.
+	connCtx := ctx
+	deliver := func(role, content string) error {
+		return wsjson.Write(connCtx, conn, hubMsg{
+			Type:    "message",
+			Payload: mustJSON(map[string]interface{}{"role": role, "content": content}),
+		})
 	}
+	runTurn := func(content string) {
+		go func(c string) {
+			agentCtx, agentCancel := context.WithTimeout(context.Background(), 30*time.Minute)
+			defer agentCancel()
+			reply, agentErr := gwSession.SendMessage(agentCtx, c, func(chunk string) {
+				_ = wsjson.Write(connCtx, conn, hubMsg{
+					Type:    "chunk",
+					Payload: mustJSON(map[string]interface{}{"role": "claw", "content": chunk}),
+				})
+			}, func(activity agentActivity) {
+				writeActivity(connCtx, activity)
+			})
+			if agentErr != nil {
+				reply = fmt.Sprintf("⚠️ error: %v", agentErr)
+			}
+			if writeErr := deliver("claw", reply); writeErr != nil {
+				// Hub connection dropped — queue the completed reply, not the input,
+				// so the turn is not re-run (avoids duplicating side effects).
+				log.Printf("[bridge] hub write failed, queuing completed reply for redelivery: %v", writeErr)
+				queue.pushReply(reply)
+			}
+		}(content)
+	}
+	replayQueued(queue, deliver, runTurn)
 
 	// Wire up the HTTP proxy send function for this connection
 	proxy.mu.Lock()
@@ -3417,7 +3510,7 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 				}
 				if !gwSession.IsReady() {
 					log.Printf("[bridge] gateway not ready, queuing message for later")
-					queue.push(content)
+					queue.pushInput(content)
 					return
 				}
 
@@ -3448,9 +3541,10 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 					Type:    "message",
 					Payload: mustJSON(map[string]interface{}{"role": "claw", "content": reply}),
 				}); writeErr != nil {
-					// Hub connection dropped — queue original content for replay on reconnect
-					log.Printf("[bridge] hub write failed, queuing original message for replay: %v", writeErr)
-					queue.push(content)
+					// Hub connection dropped — queue the completed reply for redelivery,
+					// not the input, so the turn is not re-run on reconnect.
+					log.Printf("[bridge] hub write failed, queuing completed reply for redelivery: %v", writeErr)
+					queue.pushReply(reply)
 				}
 			}(ctx, msg.Payload)
 

--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -3537,10 +3537,7 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 					log.Printf("[bridge] ← openclaw: %q", reply[:min(len(reply), 120)])
 				}
 
-				if writeErr := wsjson.Write(connCtx, conn, hubMsg{
-					Type:    "message",
-					Payload: mustJSON(map[string]interface{}{"role": "claw", "content": reply}),
-				}); writeErr != nil {
+				if writeErr := deliver("claw", reply); writeErr != nil {
 					// Hub connection dropped — queue the completed reply for redelivery,
 					// not the input, so the turn is not re-run on reconnect.
 					log.Printf("[bridge] hub write failed, queuing completed reply for redelivery: %v", writeErr)

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -1007,3 +1008,149 @@ func testPEM(typ string) string {
 type errString string
 
 func (e errString) Error() string { return string(e) }
+
+func TestMsgQueueReplyNeverExpires(t *testing.T) {
+	q := &msgQueue{}
+	q.pushReply("completed reply")
+	// Backdate well beyond the TTL — replies must still survive.
+	q.msgs[0].queuedAt = time.Now().Add(-2 * msgQueueTTL)
+
+	out := q.drain()
+	if len(out) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(out))
+	}
+	if out[0].kind != queuedReply || out[0].content != "completed reply" {
+		t.Fatalf("expected surviving reply, got kind=%d content=%q", out[0].kind, out[0].content)
+	}
+}
+
+func TestMsgQueueExpiredInputBecomesNotice(t *testing.T) {
+	q := &msgQueue{}
+	q.pushInput("stale user input")
+	q.msgs[0].queuedAt = time.Now().Add(-2 * msgQueueTTL)
+
+	out := q.drain()
+	if len(out) != 1 {
+		t.Fatalf("expected 1 entry (notice only), got %d", len(out))
+	}
+	notice := out[0]
+	if notice.kind != queuedNotice {
+		t.Fatalf("expected queuedNotice, got kind=%d", notice.kind)
+	}
+	if notice.content == "stale user input" {
+		t.Fatalf("raw input must not be returned")
+	}
+	if !strings.Contains(notice.content, "dropped") {
+		t.Fatalf("notice should mention the drop: %q", notice.content)
+	}
+	if !strings.Contains(notice.content, "stale user input") {
+		t.Fatalf("notice should include the preview: %q", notice.content)
+	}
+}
+
+func TestMsgQueueOverflowEvictsOldestInputAndSurfacesNotice(t *testing.T) {
+	q := &msgQueue{}
+	for i := 0; i < msgQueueMax+5; i++ {
+		q.pushInput(fmt.Sprintf("input-%d", i))
+	}
+	if len(q.msgs) != msgQueueMax {
+		t.Fatalf("expected queue capped at %d, got %d", msgQueueMax, len(q.msgs))
+	}
+	// The 5 oldest inputs (input-0..input-4) must have been evicted.
+	if q.msgs[0].content != "input-5" {
+		t.Fatalf("expected oldest surviving input to be input-5, got %q", q.msgs[0].content)
+	}
+
+	out := q.drain()
+	if len(out) == 0 || out[0].kind != queuedNotice {
+		t.Fatalf("expected a leading notice about evictions")
+	}
+	if !strings.Contains(out[0].content, "5 queued message") {
+		t.Fatalf("notice should count the 5 evictions: %q", out[0].content)
+	}
+
+	// Replies must never be evicted, even when the queue is full.
+	q2 := &msgQueue{}
+	for i := 0; i < msgQueueMax; i++ {
+		q2.pushReply(fmt.Sprintf("reply-%d", i))
+	}
+	q2.pushReply("reply-overflow")
+	if len(q2.msgs) != msgQueueMax+1 {
+		t.Fatalf("expected replies to grow beyond cap, got %d", len(q2.msgs))
+	}
+	if q2.dropped != 0 {
+		t.Fatalf("expected no drops when queue is full of replies, got %d", q2.dropped)
+	}
+}
+
+func TestReplayQueuedDeliversReplyWithoutRerun(t *testing.T) {
+	q := &msgQueue{}
+	q.pushReply("finished reply")
+
+	var delivered []string
+	deliver := func(role, content string) error {
+		if role != "claw" {
+			t.Fatalf("expected role claw, got %q", role)
+		}
+		delivered = append(delivered, content)
+		return nil
+	}
+	runTurn := func(content string) {
+		t.Fatalf("runTurn must not be called for a completed reply (content=%q)", content)
+	}
+
+	replayQueued(q, deliver, runTurn)
+
+	if len(delivered) != 1 || delivered[0] != "finished reply" {
+		t.Fatalf("expected reply delivered exactly once, got %v", delivered)
+	}
+}
+
+func TestReplayQueuedRequeuesReplyOnDeliverFailure(t *testing.T) {
+	q := &msgQueue{}
+	q.pushReply("undelivered reply")
+	originalAt := q.msgs[0].queuedAt
+
+	deliver := func(role, content string) error {
+		return errString("hub write failed")
+	}
+	runTurn := func(content string) {
+		t.Fatalf("runTurn must not be called")
+	}
+
+	replayQueued(q, deliver, runTurn)
+
+	if len(q.msgs) != 1 {
+		t.Fatalf("expected reply re-queued, got %d entries", len(q.msgs))
+	}
+	if q.msgs[0].kind != queuedReply || q.msgs[0].content != "undelivered reply" {
+		t.Fatalf("expected the reply back in the queue, got %+v", q.msgs[0])
+	}
+	if !q.msgs[0].queuedAt.Equal(originalAt) {
+		t.Fatalf("expected original queuedAt preserved: got %v want %v", q.msgs[0].queuedAt, originalAt)
+	}
+}
+
+func TestReplayQueuedRunsTurnForInputs(t *testing.T) {
+	q := &msgQueue{}
+	q.pushInput("do the work")
+
+	var deliverCalled bool
+	deliver := func(role, content string) error {
+		deliverCalled = true
+		return nil
+	}
+	var ran []string
+	runTurn := func(content string) {
+		ran = append(ran, content)
+	}
+
+	replayQueued(q, deliver, runTurn)
+
+	if deliverCalled {
+		t.Fatalf("deliver must not be called for a queued input")
+	}
+	if len(ran) != 1 || ran[0] != "do the work" {
+		t.Fatalf("expected runTurn invoked with the input, got %v", ran)
+	}
+}


### PR DESCRIPTION
## Problem (P0, correctness — liveness audit follow-up after #488)

1. In `cmd/claw-bridge/main.go`, when writing the **final turn reply** to the hub failed, the bridge re-queued the **original user message** and re-ran the entire turn on reconnect. The completed reply was discarded and every side effect (commits, PR creation) was duplicated.
2. The bridge `msgQueue` silently dropped queued entries after a 10-minute TTL with only a local log line — if the hub was unreachable for >10 min, the message (or a finished reply) evaporated and the hub was never told.

## Changes

- **Typed queue entries** (`queuedInput` / `queuedReply` / `queuedNotice`). On final-reply write failure, both failure sites now `pushReply(reply)` — the completed reply is persisted, not the input.
- **`replayQueued` on reconnect**: replies and notices are delivered directly to the hub (no turn re-execution); only genuinely unprocessed inputs re-run a turn. Failed deliveries are re-queued preserving their original timestamp.
- **No silent drops**: TTL applies only to inputs (a stale input must not start a 30-min turn much later); replies/notices never expire. A 256-entry cap evicts only the oldest inputs. Every drop (TTL or overflow) is counted with a preview and surfaced to the hub on reconnect as an explicit ⚠️ notice.
- Bounded-turn semantics unchanged (30-min turn timeout).

## Tests

- `TestReplayQueuedDeliversReplyWithoutRerun` — the acceptance case: simulated hub-write failure after a completed turn delivers the original reply on reconnect and never invokes `runTurn`.
- `TestReplayQueuedRequeuesReplyOnDeliverFailure`, `TestReplayQueuedRunsTurnForInputs`
- `TestMsgQueueReplyNeverExpires`, `TestMsgQueueExpiredInputBecomesNotice`, `TestMsgQueueOverflowEvictsOldestInputAndSurfacesNotice`
- `go build ./...` green; `go test -race ./cmd/claw-bridge/...` green (all existing tests pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)