### PR TITLE
Liveness observability: doctor runtime-state checks + watchdog thresholds in config

### DIFF
--- a/pkg/hub/claw_retry.go
+++ b/pkg/hub/claw_retry.go
@@ -74,11 +74,11 @@ const (
 	watchdogHealthEscalate
 )
 
-func heartbeatShouldEscalate(unhealthyCount int, status string, bootstrapOK bool) bool {
+func heartbeatShouldEscalate(unhealthyCount, gatewayUnhealthyMax int, status string, bootstrapOK bool) bool {
 	return unhealthyCount == gatewayUnhealthyMax && status == "connected" && bootstrapOK
 }
 
-func watchdogAction(nowAt time.Time, status string, bootstrapOK, gatewayReady bool, lastStatusAt, lastUserMessageAt, warnedAt time.Time) watchdogHealthAction {
+func watchdogAction(nowAt time.Time, status string, bootstrapOK, gatewayReady bool, lastStatusAt, lastUserMessageAt, warnedAt time.Time, silentDeathMax time.Duration) watchdogHealthAction {
 	if status != "connected" || !bootstrapOK || !gatewayReady {
 		return watchdogHealthNone
 	}

--- a/pkg/hub/claw_retry_test.go
+++ b/pkg/hub/claw_retry_test.go
@@ -288,25 +288,25 @@ func TestRetryCheckpointChoicePrecedesTerminationCheckpoint(t *testing.T) {
 }
 
 func TestHealthEscalationThresholds(t *testing.T) {
-	if heartbeatShouldEscalate(11, "connected", true) {
+	if heartbeatShouldEscalate(11, defaultGatewayUnhealthyMax, "connected", true) {
 		t.Fatal("heartbeat escalated before threshold")
 	}
-	if !heartbeatShouldEscalate(12, "connected", true) {
+	if !heartbeatShouldEscalate(12, defaultGatewayUnhealthyMax, "connected", true) {
 		t.Fatal("heartbeat did not escalate at threshold")
 	}
-	if heartbeatShouldEscalate(12, "provisioning", true) || heartbeatShouldEscalate(12, "connected", false) {
+	if heartbeatShouldEscalate(12, defaultGatewayUnhealthyMax, "provisioning", true) || heartbeatShouldEscalate(12, defaultGatewayUnhealthyMax, "connected", false) {
 		t.Fatal("heartbeat escalated an ineligible claw")
 	}
 
 	nowAt := time.Now()
 	lastActivity := nowAt.Add(-11 * time.Minute)
-	if got := watchdogAction(nowAt, "connected", true, true, lastActivity, lastActivity, time.Time{}); got != watchdogHealthWarn {
+	if got := watchdogAction(nowAt, "connected", true, true, lastActivity, lastActivity, time.Time{}, defaultSilentDeathMax); got != watchdogHealthWarn {
 		t.Fatalf("initial watchdog action=%v, want warn", got)
 	}
-	if got := watchdogAction(nowAt, "connected", true, true, lastActivity, lastActivity, nowAt.Add(-5*time.Minute)); got != watchdogHealthEscalate {
+	if got := watchdogAction(nowAt, "connected", true, true, lastActivity, lastActivity, nowAt.Add(-5*time.Minute), defaultSilentDeathMax); got != watchdogHealthEscalate {
 		t.Fatalf("continued watchdog action=%v, want escalate", got)
 	}
-	if got := watchdogAction(nowAt, "provisioning", true, true, lastActivity, lastActivity, nowAt.Add(-5*time.Minute)); got != watchdogHealthNone {
+	if got := watchdogAction(nowAt, "provisioning", true, true, lastActivity, lastActivity, nowAt.Add(-5*time.Minute), defaultSilentDeathMax); got != watchdogHealthNone {
 		t.Fatalf("provisioning watchdog action=%v, want none", got)
 	}
 }

--- a/pkg/hub/doctor.go
+++ b/pkg/hub/doctor.go
@@ -125,6 +125,9 @@ func (s *Server) runDoctorChecks(ctx context.Context) DoctorResponse {
 	// --- Hub Settings ---
 	checks = append(checks, s.checkHubSettings(hubCfg)...)
 
+	// --- Runtime state ---
+	checks = append(checks, s.checkRuntimeState(ctx)...)
+
 	// Compute summary: total = all checks, passed = OK checks
 	var report DoctorResponse
 	report.Checks = checks

--- a/pkg/hub/doctor_runtime.go
+++ b/pkg/hub/doctor_runtime.go
@@ -1,0 +1,88 @@
+package hub
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+const runtimeReaperHint = " The liveness reaper (pkg/hub/reaper.go, added in PR #488) should clear these; a nonzero steady-state count means the reaper is broken or disabled."
+
+// checkRuntimeState reports records which the liveness reaper should have repaired.
+func (s *Server) checkRuntimeState(_ context.Context) []DoctorCheck {
+	cfg, current := s.livenessSettings(), s.reaperNow()
+	var checks []DoctorCheck
+
+	appendTimestampCheck := func(title, query string, args ...any) {
+		var count int
+		var oldest sql.NullInt64
+		if err := s.db.QueryRow(query, args...).Scan(&count, &oldest); err != nil {
+			checks = append(checks, runtimeQueryErrorCheck(title, err))
+			return
+		}
+		if count == 0 {
+			return
+		}
+		checks = append(checks, runtimeStuckCheck(title, count, current.Sub(time.Unix(oldest.Int64, 0))))
+	}
+
+	appendTimestampCheck("Stuck claws", `
+		SELECT COUNT(*), MIN(CAST(strftime('%s', CASE WHEN status='offline' THEN COALESCE(last_seen, created_at) ELSE created_at END) AS INTEGER))
+		FROM claws WHERE (status='offline' AND COALESCE(last_seen, created_at) < ?)
+		OR (status IN ('provisioning', 'starting') AND created_at < ?)`,
+		current.Add(-cfg.offlineGrace), current.Add(-cfg.provisioningMaxAge))
+	appendTimestampCheck("Orphaned workflow runs", `
+		SELECT COUNT(*), MIN(CAST(strftime('%s', COALESCE(started_at, created_at)) AS INTEGER)) FROM workflow_runs
+		WHERE status='running' AND (claw_id='' OR NOT EXISTS (SELECT 1 FROM claws c WHERE c.id=workflow_runs.claw_id) OR EXISTS (SELECT 1 FROM claws c WHERE c.id=workflow_runs.claw_id AND c.status IN ('error','deleted')))`)
+	appendTimestampCheck("Unassigned claimed factory triggers", `
+		SELECT COUNT(*), MIN(CAST(strftime('%s', created_at) AS INTEGER)) FROM factory_triggers
+		WHERE status='claimed' AND claw_id='' AND created_at < ?`, current.Add(-cfg.claimTTL))
+	appendTimestampCheck("Stuck creating checkpoints", `
+		SELECT COUNT(*), MIN(CAST(strftime('%s', created_at) AS INTEGER)) FROM claw_checkpoints
+		WHERE status='creating' AND created_at < ?`, current.Add(-cfg.provisioningMaxAge))
+
+	var timeoutCount int
+	var oldestTimeout sql.NullInt64
+	if err := s.db.QueryRow(`
+		SELECT COUNT(*), MIN(tr.timeout_at) FROM task_runs tr
+		JOIN claws c ON c.id=tr.claw_id
+		WHERE tr.timeout_at > 0 AND tr.timeout_at < ?
+		AND c.status IN ('provisioning','starting','connected','idle','offline')`, current.UnixMilli()).Scan(&timeoutCount, &oldestTimeout); err != nil {
+		checks = append(checks, runtimeQueryErrorCheck("Timed out task runs", err))
+	} else if timeoutCount > 0 {
+		checks = append(checks, runtimeStuckCheck("Timed out task runs", timeoutCount, current.Sub(time.UnixMilli(oldestTimeout.Int64))))
+	}
+
+	if len(checks) == 0 {
+		return []DoctorCheck{{
+			Category:    "runtime",
+			Severity:    "info",
+			Title:       "No stuck runtime state",
+			Description: "No runtime records are awaiting liveness reaper recovery.",
+			OK:          true,
+		}}
+	}
+	return checks
+}
+
+func runtimeStuckCheck(title string, count int, oldestAge time.Duration) DoctorCheck {
+	return DoctorCheck{
+		Category:    "runtime",
+		Severity:    "warning",
+		Title:       title,
+		Description: fmt.Sprintf("%d record(s); oldest offender is %s old.%s", count, oldestAge.Round(time.Second), runtimeReaperHint),
+		OK:          false,
+	}
+}
+
+func runtimeQueryErrorCheck(title string, err error) DoctorCheck {
+	return DoctorCheck{
+		Category:    "runtime",
+		Severity:    "warning",
+		Title:       "Could not verify runtime state: " + title,
+		Description: "Could not verify runtime state; the liveness reaper may be broken or disabled.",
+		Error:       err.Error(),
+		OK:          false,
+	}
+}

--- a/pkg/hub/doctor_runtime.go
+++ b/pkg/hub/doctor_runtime.go
@@ -7,14 +7,18 @@ import (
 	"time"
 )
 
-const runtimeReaperHint = " The liveness reaper (pkg/hub/reaper.go, added in PR #488) should clear these; a nonzero steady-state count means the reaper is broken or disabled."
+const (
+	runtimeReaperHint             = " The periodic liveness reaper (pkg/hub/reaper.go) should clear these; a nonzero steady-state count means the reaper is broken or disabled."
+	runtimeBootReconciliationHint = " Boot reconciliation on hub restart (pkg/hub/reaper.go reconcileOnBoot) repairs these; a persistent count means they have survived restarts or the hub has not restarted since they got stuck."
+	runtimeAgeMarginHint          = " This check's threshold is twice the configured grace period to allow for the reaper's observation window."
+)
 
 // checkRuntimeState reports records which the liveness reaper should have repaired.
 func (s *Server) checkRuntimeState(_ context.Context) []DoctorCheck {
 	cfg, current := s.livenessSettings(), s.reaperNow()
 	var checks []DoctorCheck
 
-	appendTimestampCheck := func(title, query string, args ...any) {
+	appendTimestampCheck := func(title, hint, query string, args ...any) {
 		var count int
 		var oldest sql.NullInt64
 		if err := s.db.QueryRow(query, args...).Scan(&count, &oldest); err != nil {
@@ -24,23 +28,23 @@ func (s *Server) checkRuntimeState(_ context.Context) []DoctorCheck {
 		if count == 0 {
 			return
 		}
-		checks = append(checks, runtimeStuckCheck(title, count, current.Sub(time.Unix(oldest.Int64, 0))))
+		checks = append(checks, runtimeStuckCheck(title, count, current.Sub(time.Unix(oldest.Int64, 0)), hint))
 	}
 
-	appendTimestampCheck("Stuck claws", `
+	appendTimestampCheck("Stuck claws", runtimeReaperHint+runtimeAgeMarginHint, `
 		SELECT COUNT(*), MIN(CAST(strftime('%s', CASE WHEN status='offline' THEN COALESCE(last_seen, created_at) ELSE created_at END) AS INTEGER))
 		FROM claws WHERE (status='offline' AND COALESCE(last_seen, created_at) < ?)
 		OR (status IN ('provisioning', 'starting') AND created_at < ?)`,
-		current.Add(-cfg.offlineGrace), current.Add(-cfg.provisioningMaxAge))
-	appendTimestampCheck("Orphaned workflow runs", `
+		current.Add(-2*cfg.offlineGrace), current.Add(-2*cfg.provisioningMaxAge))
+	appendTimestampCheck("Orphaned workflow runs", runtimeBootReconciliationHint, `
 		SELECT COUNT(*), MIN(CAST(strftime('%s', COALESCE(started_at, created_at)) AS INTEGER)) FROM workflow_runs
 		WHERE status='running' AND (claw_id='' OR NOT EXISTS (SELECT 1 FROM claws c WHERE c.id=workflow_runs.claw_id) OR EXISTS (SELECT 1 FROM claws c WHERE c.id=workflow_runs.claw_id AND c.status IN ('error','deleted')))`)
-	appendTimestampCheck("Unassigned claimed factory triggers", `
+	appendTimestampCheck("Unassigned claimed factory triggers", runtimeReaperHint+runtimeAgeMarginHint, `
 		SELECT COUNT(*), MIN(CAST(strftime('%s', created_at) AS INTEGER)) FROM factory_triggers
-		WHERE status='claimed' AND claw_id='' AND created_at < ?`, current.Add(-cfg.claimTTL))
-	appendTimestampCheck("Stuck creating checkpoints", `
+		WHERE status='claimed' AND claw_id='' AND created_at < ?`, current.Add(-2*cfg.claimTTL))
+	appendTimestampCheck("Stuck creating checkpoints", runtimeBootReconciliationHint+runtimeAgeMarginHint, `
 		SELECT COUNT(*), MIN(CAST(strftime('%s', created_at) AS INTEGER)) FROM claw_checkpoints
-		WHERE status='creating' AND created_at < ?`, current.Add(-cfg.provisioningMaxAge))
+		WHERE status='creating' AND created_at < ?`, current.Add(-2*cfg.provisioningMaxAge))
 
 	var timeoutCount int
 	var oldestTimeout sql.NullInt64
@@ -51,7 +55,7 @@ func (s *Server) checkRuntimeState(_ context.Context) []DoctorCheck {
 		AND c.status IN ('provisioning','starting','connected','idle','offline')`, current.UnixMilli()).Scan(&timeoutCount, &oldestTimeout); err != nil {
 		checks = append(checks, runtimeQueryErrorCheck("Timed out task runs", err))
 	} else if timeoutCount > 0 {
-		checks = append(checks, runtimeStuckCheck("Timed out task runs", timeoutCount, current.Sub(time.UnixMilli(oldestTimeout.Int64))))
+		checks = append(checks, runtimeStuckCheck("Timed out task runs", timeoutCount, current.Sub(time.UnixMilli(oldestTimeout.Int64)), runtimeReaperHint))
 	}
 
 	if len(checks) == 0 {
@@ -66,12 +70,12 @@ func (s *Server) checkRuntimeState(_ context.Context) []DoctorCheck {
 	return checks
 }
 
-func runtimeStuckCheck(title string, count int, oldestAge time.Duration) DoctorCheck {
+func runtimeStuckCheck(title string, count int, oldestAge time.Duration, hint string) DoctorCheck {
 	return DoctorCheck{
 		Category:    "runtime",
 		Severity:    "warning",
 		Title:       title,
-		Description: fmt.Sprintf("%d record(s); oldest offender is %s old.%s", count, oldestAge.Round(time.Second), runtimeReaperHint),
+		Description: fmt.Sprintf("%d record(s); oldest offender is %s old.%s", count, oldestAge.Round(time.Second), hint),
 		OK:          false,
 	}
 }

--- a/pkg/hub/doctor_runtime.go
+++ b/pkg/hub/doctor_runtime.go
@@ -11,17 +11,18 @@ const (
 	runtimeReaperHint             = " The periodic liveness reaper (pkg/hub/reaper.go) should clear these; a nonzero steady-state count means the reaper is broken or disabled."
 	runtimeBootReconciliationHint = " Boot reconciliation on hub restart (pkg/hub/reaper.go reconcileOnBoot) repairs these; a persistent count means they have survived restarts or the hub has not restarted since they got stuck."
 	runtimeAgeMarginHint          = " This check's threshold is twice the configured grace period to allow for the reaper's observation window."
+	runtimeCheckpointMarginHint   = " This check's threshold is twice the configured provisioning grace to avoid flagging healthy in-flight checkpoints."
 )
 
 // checkRuntimeState reports records which the liveness reaper should have repaired.
-func (s *Server) checkRuntimeState(_ context.Context) []DoctorCheck {
+func (s *Server) checkRuntimeState(ctx context.Context) []DoctorCheck {
 	cfg, current := s.livenessSettings(), s.reaperNow()
 	var checks []DoctorCheck
 
 	appendTimestampCheck := func(title, hint, query string, args ...any) {
 		var count int
 		var oldest sql.NullInt64
-		if err := s.db.QueryRow(query, args...).Scan(&count, &oldest); err != nil {
+		if err := s.db.QueryRowContext(ctx, query, args...).Scan(&count, &oldest); err != nil {
 			checks = append(checks, runtimeQueryErrorCheck(title, err))
 			return
 		}
@@ -42,13 +43,13 @@ func (s *Server) checkRuntimeState(_ context.Context) []DoctorCheck {
 	appendTimestampCheck("Unassigned claimed factory triggers", runtimeReaperHint+runtimeAgeMarginHint, `
 		SELECT COUNT(*), MIN(CAST(strftime('%s', created_at) AS INTEGER)) FROM factory_triggers
 		WHERE status='claimed' AND claw_id='' AND created_at < ?`, current.Add(-2*cfg.claimTTL))
-	appendTimestampCheck("Stuck creating checkpoints", runtimeBootReconciliationHint+runtimeAgeMarginHint, `
+	appendTimestampCheck("Stuck creating checkpoints", runtimeBootReconciliationHint+runtimeCheckpointMarginHint, `
 		SELECT COUNT(*), MIN(CAST(strftime('%s', created_at) AS INTEGER)) FROM claw_checkpoints
 		WHERE status='creating' AND created_at < ?`, current.Add(-2*cfg.provisioningMaxAge))
 
 	var timeoutCount int
 	var oldestTimeout sql.NullInt64
-	if err := s.db.QueryRow(`
+	if err := s.db.QueryRowContext(ctx, `
 		SELECT COUNT(*), MIN(tr.timeout_at) FROM task_runs tr
 		JOIN claws c ON c.id=tr.claw_id
 		WHERE tr.timeout_at > 0 AND tr.timeout_at < ?

--- a/pkg/hub/doctor_runtime_test.go
+++ b/pkg/hub/doctor_runtime_test.go
@@ -1,0 +1,65 @@
+package hub
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func TestCheckRuntimeStateClean(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{}, "", "", "")
+	checks := s.checkRuntimeState(context.Background())
+	if len(checks) != 1 || !checks[0].OK || checks[0].Title != "No stuck runtime state" {
+		t.Fatalf("runtime checks = %#v, want one clean check", checks)
+	}
+}
+
+func TestCheckRuntimeStateFindsStuckRecords(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{}, "", "", "")
+	current := time.Now().UTC()
+	s.nowFunc = func() time.Time { return current }
+	old := current.Add(-time.Hour)
+	insertRuntimeClaw(t, db, "offline-claw", "offline", old, old)
+	insertRuntimeClaw(t, db, "error-claw", "error", old, old)
+	insertRuntimeClaw(t, db, "timeout-claw", "connected", old, old)
+
+	if _, err := db.Exec(`INSERT INTO workflow_runs(id, workflow_name, workspace_name, status, claw_id, created_at) VALUES(?,?,?,?,?,?)`, "orphaned-run", "workflow", "workspace", "running", "error-claw", old); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO factory_triggers(id, factory_name, integration, trigger_key, claw_id, status, first_seen_at, last_seen_at, created_at, updated_at) VALUES(?,?,?,?,?,?,?,?,?,?)`, "claimed-trigger", "factory", "test", "trigger", "", "claimed", old, old, old, old); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO claw_checkpoints(id, tenant_id, claw_id, status, created_at) VALUES(?,?,?,?,?)`, "creating-checkpoint", "test-tenant-id", "offline-claw", "creating", old); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO task_runs(id, tenant_id, initial_attempt_id, run_kind, owner_type, claw_id, timeout_at, created_at, updated_at) VALUES(?,?,?,?,?,?,?,?,?)`, "timed-out-run", "test-tenant-id", "attempt", taskRunKindCodeTask, taskRunOwnerManual, "timeout-claw", old.UnixMilli(), old.UnixMilli(), old.UnixMilli()); err != nil {
+		t.Fatal(err)
+	}
+
+	checks := s.checkRuntimeState(context.Background())
+	for _, title := range []string{"Stuck claws", "Orphaned workflow runs", "Unassigned claimed factory triggers", "Stuck creating checkpoints", "Timed out task runs"} {
+		if !hasFailedRuntimeCheck(checks, title) {
+			t.Errorf("missing failed %q check in %#v", title, checks)
+		}
+	}
+}
+
+func insertRuntimeClaw(t *testing.T, db *sql.DB, id, status string, createdAt, lastSeen time.Time) {
+	t.Helper()
+	if _, err := db.Exec(`INSERT INTO claws(id, tenant_id, name, status, created_at, last_seen) VALUES(?,?,?,?,?,?)`, id, "test-tenant-id", id, status, createdAt, lastSeen); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func hasFailedRuntimeCheck(checks []DoctorCheck, title string) bool {
+	for _, check := range checks {
+		if check.Title == title && !check.OK && check.Category == "runtime" && strings.Contains(check.Description, "oldest offender") {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/hub/doctor_runtime_test.go
+++ b/pkg/hub/doctor_runtime_test.go
@@ -22,7 +22,7 @@ func TestCheckRuntimeStateFindsStuckRecords(t *testing.T) {
 	s, db := NewTestServerWithConfig(t, &types.HubConfig{}, "", "", "")
 	current := time.Now().UTC()
 	s.nowFunc = func() time.Time { return current }
-	old := current.Add(-time.Hour)
+	old := current.Add(-2 * time.Hour)
 	insertRuntimeClaw(t, db, "offline-claw", "offline", old, old)
 	insertRuntimeClaw(t, db, "error-claw", "error", old, old)
 	insertRuntimeClaw(t, db, "timeout-claw", "connected", old, old)
@@ -45,6 +45,30 @@ func TestCheckRuntimeStateFindsStuckRecords(t *testing.T) {
 		if !hasFailedRuntimeCheck(checks, title) {
 			t.Errorf("missing failed %q check in %#v", title, checks)
 		}
+	}
+	for title, want := range map[string]string{
+		"Stuck claws":                         "threshold is twice the configured grace period",
+		"Orphaned workflow runs":              "Boot reconciliation on hub restart",
+		"Unassigned claimed factory triggers": "threshold is twice the configured grace period",
+		"Stuck creating checkpoints":          "Boot reconciliation on hub restart",
+	} {
+		for _, check := range checks {
+			if check.Title == title && !strings.Contains(check.Description, want) {
+				t.Errorf("%q description = %q, want %q", title, check.Description, want)
+			}
+		}
+	}
+}
+
+func TestCheckRuntimeStateAllowsReaperObservationWindow(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{}, "", "", "")
+	current := time.Now().UTC()
+	s.nowFunc = func() time.Time { return current }
+	insertRuntimeClaw(t, db, "recent-offline-claw", "offline", current.Add(-15*time.Minute), current.Add(-15*time.Minute))
+
+	checks := s.checkRuntimeState(context.Background())
+	if hasFailedRuntimeCheck(checks, "Stuck claws") {
+		t.Fatalf("offline claw within twice the configured grace period reported stuck: %#v", checks)
 	}
 }
 

--- a/pkg/hub/reaper.go
+++ b/pkg/hub/reaper.go
@@ -9,6 +9,8 @@ const reaperActionLimit = 20
 
 type livenessSettings struct {
 	offlineGrace, provisioningMaxAge, claimTTL, interval time.Duration
+	gatewayUnhealthyMax                                  int
+	busyTurnMax, silentDeathMax                          time.Duration
 }
 
 func (s *Server) livenessEnabled() bool {
@@ -19,7 +21,15 @@ func (s *Server) livenessEnabled() bool {
 }
 
 func (s *Server) livenessSettings() livenessSettings {
-	cfg := livenessSettings{10 * time.Minute, 30 * time.Minute, 15 * time.Minute, time.Minute}
+	cfg := livenessSettings{
+		offlineGrace:        10 * time.Minute,
+		provisioningMaxAge:  30 * time.Minute,
+		claimTTL:            15 * time.Minute,
+		interval:            time.Minute,
+		gatewayUnhealthyMax: defaultGatewayUnhealthyMax,
+		busyTurnMax:         defaultBusyTurnMax,
+		silentDeathMax:      defaultSilentDeathMax,
+	}
 	if s.hubCfg == nil || s.hubCfg.Liveness == nil {
 		return cfg
 	}
@@ -28,7 +38,7 @@ func (s *Server) livenessSettings() livenessSettings {
 			return fallback
 		}
 		d, err := time.ParseDuration(value)
-		if err != nil || d < 0 {
+		if err != nil || d <= 0 {
 			log.Printf("[reaper] invalid %s %q; using %s", name, value, fallback)
 			return fallback
 		}
@@ -39,8 +49,14 @@ func (s *Server) livenessSettings() livenessSettings {
 	cfg.provisioningMaxAge = parse(l.ProvisioningMaxAge, cfg.provisioningMaxAge, "provisioning_max_age")
 	cfg.claimTTL = parse(l.ClaimTTL, cfg.claimTTL, "claim_ttl")
 	cfg.interval = parse(l.ReaperInterval, cfg.interval, "reaper_interval")
-	if cfg.interval <= 0 {
-		cfg.interval = time.Minute
+	cfg.busyTurnMax = parse(l.BusyTurnMax, cfg.busyTurnMax, "busy_turn_max")
+	cfg.silentDeathMax = parse(l.SilentDeathMax, cfg.silentDeathMax, "silent_death_max")
+	if l.GatewayUnhealthyChecks != nil {
+		if *l.GatewayUnhealthyChecks <= 0 {
+			log.Printf("[reaper] invalid gateway_unhealthy_checks %d; using %d", *l.GatewayUnhealthyChecks, cfg.gatewayUnhealthyMax)
+		} else {
+			cfg.gatewayUnhealthyMax = *l.GatewayUnhealthyChecks
+		}
 	}
 	return cfg
 }

--- a/pkg/hub/reaper.go
+++ b/pkg/hub/reaper.go
@@ -3,6 +3,8 @@ package hub
 import (
 	"log"
 	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
 
 const reaperActionLimit = 20
@@ -14,10 +16,13 @@ type livenessSettings struct {
 }
 
 func (s *Server) livenessEnabled() bool {
-	if s.hubCfg == nil || s.hubCfg.Liveness == nil || s.hubCfg.Liveness.Enabled == nil {
+	s.mu.RLock()
+	liveness := livenessConfig(s.hubCfg)
+	s.mu.RUnlock()
+	if liveness == nil || liveness.Enabled == nil {
 		return true
 	}
-	return *s.hubCfg.Liveness.Enabled
+	return *liveness.Enabled
 }
 
 func (s *Server) livenessSettings() livenessSettings {
@@ -30,7 +35,10 @@ func (s *Server) livenessSettings() livenessSettings {
 		busyTurnMax:         defaultBusyTurnMax,
 		silentDeathMax:      defaultSilentDeathMax,
 	}
-	if s.hubCfg == nil || s.hubCfg.Liveness == nil {
+	s.mu.RLock()
+	l := livenessConfig(s.hubCfg)
+	s.mu.RUnlock()
+	if l == nil {
 		return cfg
 	}
 	parse := func(value string, fallback time.Duration, name string) time.Duration {
@@ -44,7 +52,6 @@ func (s *Server) livenessSettings() livenessSettings {
 		}
 		return d
 	}
-	l := s.hubCfg.Liveness
 	cfg.offlineGrace = parse(l.OfflineGrace, cfg.offlineGrace, "offline_grace")
 	cfg.provisioningMaxAge = parse(l.ProvisioningMaxAge, cfg.provisioningMaxAge, "provisioning_max_age")
 	cfg.claimTTL = parse(l.ClaimTTL, cfg.claimTTL, "claim_ttl")
@@ -59,6 +66,13 @@ func (s *Server) livenessSettings() livenessSettings {
 		}
 	}
 	return cfg
+}
+
+func livenessConfig(cfg *types.HubConfig) *types.LivenessConfig {
+	if cfg == nil {
+		return nil
+	}
+	return cfg.Liveness
 }
 
 func (s *Server) reaperNow() time.Time {

--- a/pkg/hub/reaper_settings_test.go
+++ b/pkg/hub/reaper_settings_test.go
@@ -1,0 +1,29 @@
+package hub
+
+import (
+	"testing"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func TestLivenessSettingsWatchdogDefaults(t *testing.T) {
+	s := &Server{}
+	cfg := s.livenessSettings()
+	if cfg.gatewayUnhealthyMax != defaultGatewayUnhealthyMax || cfg.busyTurnMax != defaultBusyTurnMax || cfg.silentDeathMax != defaultSilentDeathMax {
+		t.Fatalf("watchdog defaults = %#v, want %d/%s/%s", cfg, defaultGatewayUnhealthyMax, defaultBusyTurnMax, defaultSilentDeathMax)
+	}
+}
+
+func TestLivenessSettingsWatchdogConfig(t *testing.T) {
+	checks := 7
+	s := &Server{hubCfg: &types.HubConfig{Liveness: &types.LivenessConfig{
+		GatewayUnhealthyChecks: &checks,
+		BusyTurnMax:            "20m",
+		SilentDeathMax:         "8m",
+	}}}
+	cfg := s.livenessSettings()
+	if cfg.gatewayUnhealthyMax != 7 || cfg.busyTurnMax != 20*time.Minute || cfg.silentDeathMax != 8*time.Minute {
+		t.Fatalf("watchdog config = %#v, want 7/20m/8m", cfg)
+	}
+}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -141,9 +141,9 @@ type clawConn struct {
 }
 
 const (
-	gatewayUnhealthyMax = 12
-	busyTurnMax         = 45 * time.Minute
-	silentDeathMax      = 10 * time.Minute
+	defaultGatewayUnhealthyMax = 12
+	defaultBusyTurnMax         = 45 * time.Minute
+	defaultSilentDeathMax      = 10 * time.Minute
 )
 
 // initialStatus returns the claw status string to use on bridge registration.
@@ -2325,7 +2325,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 							if cc.gatewayUnhealthyCount == 4 && !cc.streamingStartedAt.IsZero() {
 								go s.injectHubMessageByID(clawID, "[hub] The gateway has been unresponsive for about a minute. If you're stuck in a long operation, consider sending [DONE] and starting fresh.")
 							}
-							if cc.gatewayUnhealthyCount == gatewayUnhealthyMax {
+							if cc.gatewayUnhealthyCount == s.livenessSettings().gatewayUnhealthyMax {
 								shouldEscalateGateway = true
 							}
 						}
@@ -2353,7 +2353,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 						// Re-read the claw state before escalating: idle/completed claws
 						// remain connected intentionally, and bootstrapping claws are
 						// handled by the bootstrap watchdog.
-						go s.escalateClawHealthFailure(clawID, fmt.Sprintf("agent process unhealthy for %d consecutive heartbeats", gatewayUnhealthyMax))
+						go s.escalateClawHealthFailure(clawID, fmt.Sprintf("agent process unhealthy for %d consecutive heartbeats", s.livenessSettings().gatewayUnhealthyMax))
 					}
 					if shouldWarnContext {
 						s.mu.RLock()
@@ -4914,11 +4914,11 @@ func (s *Server) checkClawStatus() {
 		// The bridge normally closes a turn with a message.  If that terminal
 		// message is lost, preserve the partial response and unblock the queue.
 		// A second consecutive recovery means the bridge is repeatedly wedged.
-		if !streamingStartedAt.IsZero() && now.Sub(streamingStartedAt) > busyTurnMax {
+		if !streamingStartedAt.IsZero() && now.Sub(streamingStartedAt) > s.livenessSettings().busyTurnMax {
 			var content, messageID string
 			var escalate bool
 			cc.mu.Lock()
-			if !cc.streamingStartedAt.IsZero() && now.Sub(cc.streamingStartedAt) > busyTurnMax {
+			if !cc.streamingStartedAt.IsZero() && now.Sub(cc.streamingStartedAt) > s.livenessSettings().busyTurnMax {
 				if cc.streamingBuf.Len() > 0 {
 					content = cc.streamingBuf.String() + " [interrupted]"
 					messageID = cc.streamingMsgID
@@ -4969,7 +4969,7 @@ func (s *Server) checkClawStatus() {
 
 		// Detect silent death while the claw is fully bootstrapped. Warn after five
 		// minutes, then escalate through the common failure funnel after ten.
-		healthAction := watchdogAction(now, status, bootstrapOK != 0, gatewayReady, lastStatusAt, lastUserMessageAt, unresponsiveWarnedAt)
+		healthAction := watchdogAction(now, status, bootstrapOK != 0, gatewayReady, lastStatusAt, lastUserMessageAt, unresponsiveWarnedAt, s.livenessSettings().silentDeathMax)
 		if healthAction == watchdogHealthWarn && now.Sub(lastStatusBroadcastAt) > 5*time.Minute {
 			msg := fmt.Sprintf("🚨 Agent %s appears unresponsive (no status in 5m). It may have crashed.", name)
 			log.Printf("[watchdog] %s", msg)

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2284,6 +2284,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 					ContextUsage   int   `json:"context_usage"`
 				}
 				if err := json.Unmarshal(payload, &hb); err == nil {
+					gatewayUnhealthyMax := s.livenessSettings().gatewayUnhealthyMax
 					var wakeConn *clawConn
 					var shouldWake bool
 					var shouldWarnContext bool
@@ -2325,7 +2326,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 							if cc.gatewayUnhealthyCount == 4 && !cc.streamingStartedAt.IsZero() {
 								go s.injectHubMessageByID(clawID, "[hub] The gateway has been unresponsive for about a minute. If you're stuck in a long operation, consider sending [DONE] and starting fresh.")
 							}
-							if cc.gatewayUnhealthyCount == s.livenessSettings().gatewayUnhealthyMax {
+							if cc.gatewayUnhealthyCount == gatewayUnhealthyMax {
 								shouldEscalateGateway = true
 							}
 						}
@@ -2353,7 +2354,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 						// Re-read the claw state before escalating: idle/completed claws
 						// remain connected intentionally, and bootstrapping claws are
 						// handled by the bootstrap watchdog.
-						go s.escalateClawHealthFailure(clawID, fmt.Sprintf("agent process unhealthy for %d consecutive heartbeats", s.livenessSettings().gatewayUnhealthyMax))
+						go s.escalateClawHealthFailure(clawID, fmt.Sprintf("agent process unhealthy for %d consecutive heartbeats", gatewayUnhealthyMax))
 					}
 					if shouldWarnContext {
 						s.mu.RLock()
@@ -4881,7 +4882,7 @@ func (s *Server) statusWatchdog() {
 // checkClawStatus queries active claws, sends status requests via the status channel,
 // and detects claws that have gone silent (no status response, no user message recently).
 func (s *Server) checkClawStatus() {
-	now := time.Now()
+	now, cfg := time.Now(), s.livenessSettings()
 
 	s.mu.RLock()
 	var clawIDs []string
@@ -4914,11 +4915,11 @@ func (s *Server) checkClawStatus() {
 		// The bridge normally closes a turn with a message.  If that terminal
 		// message is lost, preserve the partial response and unblock the queue.
 		// A second consecutive recovery means the bridge is repeatedly wedged.
-		if !streamingStartedAt.IsZero() && now.Sub(streamingStartedAt) > s.livenessSettings().busyTurnMax {
+		if !streamingStartedAt.IsZero() && now.Sub(streamingStartedAt) > cfg.busyTurnMax {
 			var content, messageID string
 			var escalate bool
 			cc.mu.Lock()
-			if !cc.streamingStartedAt.IsZero() && now.Sub(cc.streamingStartedAt) > s.livenessSettings().busyTurnMax {
+			if !cc.streamingStartedAt.IsZero() && now.Sub(cc.streamingStartedAt) > cfg.busyTurnMax {
 				if cc.streamingBuf.Len() > 0 {
 					content = cc.streamingBuf.String() + " [interrupted]"
 					messageID = cc.streamingMsgID
@@ -4969,7 +4970,7 @@ func (s *Server) checkClawStatus() {
 
 		// Detect silent death while the claw is fully bootstrapped. Warn after five
 		// minutes, then escalate through the common failure funnel after ten.
-		healthAction := watchdogAction(now, status, bootstrapOK != 0, gatewayReady, lastStatusAt, lastUserMessageAt, unresponsiveWarnedAt, s.livenessSettings().silentDeathMax)
+		healthAction := watchdogAction(now, status, bootstrapOK != 0, gatewayReady, lastStatusAt, lastUserMessageAt, unresponsiveWarnedAt, cfg.silentDeathMax)
 		if healthAction == watchdogHealthWarn && now.Sub(lastStatusBroadcastAt) > 5*time.Minute {
 			msg := fmt.Sprintf("🚨 Agent %s appears unresponsive (no status in 5m). It may have crashed.", name)
 			log.Printf("[watchdog] %s", msg)

--- a/pkg/hub/watchdog_enforcement_test.go
+++ b/pkg/hub/watchdog_enforcement_test.go
@@ -76,7 +76,7 @@ func TestWatchdogUnhealthyHeartbeatsScheduleClawRetry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create task run: %v", err)
 	}
-	for i := 0; i < gatewayUnhealthyMax; i++ {
+	for i := 0; i < defaultGatewayUnhealthyMax; i++ {
 		if err := wsjson.Write(context.Background(), conn, types.WSMessage{Type: "heartbeat", Payload: map[string]any{"gateway_healthy": false}}); err != nil {
 			t.Fatalf("write unhealthy heartbeat %d: %v", i, err)
 		}
@@ -100,23 +100,23 @@ func TestWatchdogHealthyHeartbeatResetsUnhealthyCounter(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	for i := 0; i < gatewayUnhealthyMax-1; i++ {
+	for i := 0; i < defaultGatewayUnhealthyMax-1; i++ {
 		writeHeartbeat(false)
 	}
 	eventuallyWatchdog(t, func() bool {
 		cc.mu.RLock()
 		defer cc.mu.RUnlock()
-		return cc.gatewayUnhealthyCount == gatewayUnhealthyMax-1
+		return cc.gatewayUnhealthyCount == defaultGatewayUnhealthyMax-1
 	}, "unhealthy heartbeat count")
 	writeHeartbeat(true)
 	eventuallyWatchdog(t, func() bool { cc.mu.RLock(); defer cc.mu.RUnlock(); return cc.gatewayUnhealthyCount == 0 }, "healthy reset")
-	for i := 0; i < gatewayUnhealthyMax-1; i++ {
+	for i := 0; i < defaultGatewayUnhealthyMax-1; i++ {
 		writeHeartbeat(false)
 	}
 	eventuallyWatchdog(t, func() bool {
 		cc.mu.RLock()
 		defer cc.mu.RUnlock()
-		return cc.gatewayUnhealthyCount == gatewayUnhealthyMax-1
+		return cc.gatewayUnhealthyCount == defaultGatewayUnhealthyMax-1
 	}, "post-reset unhealthy count")
 }
 
@@ -126,7 +126,7 @@ func TestWatchdogForceFinishesStaleTurnAndDeliversQueue(t *testing.T) {
 	conn := watchdogClaw(t, s, clawID)
 	cc := watchdogClawConn(t, s, clawID)
 	cc.mu.Lock()
-	cc.streamingStartedAt = time.Now().Add(-busyTurnMax - time.Minute)
+	cc.streamingStartedAt = time.Now().Add(-defaultBusyTurnMax - time.Minute)
 	cc.streamingMsgID = "partial-turn"
 	cc.streamingBuf.WriteString("partial response")
 	cc.messageQueue = []types.HubMessage{{ID: "queued-message", ClawID: clawID, TenantID: "test-tenant-id", Role: "user", Content: "next request", CreatedAt: time.Now()}}
@@ -159,7 +159,7 @@ func TestWatchdogSecondForcedFinishStopsClaw(t *testing.T) {
 	cc := watchdogClawConn(t, s, clawID)
 	for i := 0; i < 2; i++ {
 		cc.mu.Lock()
-		cc.streamingStartedAt = time.Now().Add(-busyTurnMax - time.Minute)
+		cc.streamingStartedAt = time.Now().Add(-defaultBusyTurnMax - time.Minute)
 		cc.mu.Unlock()
 		s.checkClawStatus()
 	}
@@ -179,8 +179,8 @@ func TestWatchdogSilentDeathStopsClaw(t *testing.T) {
 	}
 	cc := watchdogClawConn(t, s, clawID)
 	cc.mu.Lock()
-	cc.lastUserMessageAt = time.Now().Add(-silentDeathMax - time.Minute)
-	cc.lastStatusAt = time.Now().Add(-silentDeathMax - time.Minute)
+	cc.lastUserMessageAt = time.Now().Add(-defaultSilentDeathMax - time.Minute)
+	cc.lastStatusAt = time.Now().Add(-defaultSilentDeathMax - time.Minute)
 	cc.unresponsiveWarnedAt = time.Now().Add(-5 * time.Minute)
 	cc.mu.Unlock()
 	s.checkClawStatus()

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -551,11 +551,14 @@ type HubConfig struct {
 // LivenessConfig controls boot reconciliation and the periodic safety-net reaper.
 // Durations use Go duration strings. Empty values receive conservative defaults.
 type LivenessConfig struct {
-	Enabled            *bool  `yaml:"enabled,omitempty" json:"enabled,omitempty"`
-	OfflineGrace       string `yaml:"offline_grace,omitempty" json:"offlineGrace,omitempty"`
-	ProvisioningMaxAge string `yaml:"provisioning_max_age,omitempty" json:"provisioningMaxAge,omitempty"`
-	ClaimTTL           string `yaml:"claim_ttl,omitempty" json:"claimTtl,omitempty"`
-	ReaperInterval     string `yaml:"reaper_interval,omitempty" json:"reaperInterval,omitempty"`
+	Enabled                *bool  `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+	OfflineGrace           string `yaml:"offline_grace,omitempty" json:"offlineGrace,omitempty"`
+	ProvisioningMaxAge     string `yaml:"provisioning_max_age,omitempty" json:"provisioningMaxAge,omitempty"`
+	ClaimTTL               string `yaml:"claim_ttl,omitempty" json:"claimTtl,omitempty"`
+	ReaperInterval         string `yaml:"reaper_interval,omitempty" json:"reaperInterval,omitempty"`
+	GatewayUnhealthyChecks *int   `yaml:"gateway_unhealthy_checks,omitempty" json:"gatewayUnhealthyChecks,omitempty"`
+	BusyTurnMax            string `yaml:"busy_turn_max,omitempty" json:"busyTurnMax,omitempty"`
+	SilentDeathMax         string `yaml:"silent_death_max,omitempty" json:"silentDeathMax,omitempty"`
 }
 
 // IntegrationsConfig holds configs for external integrations.


### PR DESCRIPTION
Follow-up to #488 (agent liveness terminal state): observability and config hygiene so the failure class it fixed stays visible.

## What

**1. `refactor(hub): move watchdog thresholds into liveness config`**
The watchdog enforcement in #488 used package-level constants while the reaper got a proper `liveness` config section. The three thresholds now live in `LivenessConfig` with the previous constants as defaults:

| yaml key | default |
| --- | --- |
| `liveness.gateway_unhealthy_checks` | 12 |
| `liveness.busy_turn_max` | 45m |
| `liveness.silent_death_max` | 10m |

`heartbeatShouldEscalate` / `watchdogAction` stay pure (thresholds passed as parameters); existing watchdog tests remain green, plus new coverage that empty config yields the old defaults and yaml overrides take effect.

**2. `feat(hub): doctor checks for stuck runtime state`**
`doctor.go` only checked configuration; it now has a `runtime` category (`pkg/hub/doctor_runtime.go`) that queries the DB for state the liveness machinery should be clearing:

- claws `offline` / `provisioning` / `starting` older than the liveness thresholds
- `workflow_runs` still `running` with a missing/terminal claw
- `factory_triggers` `claimed` with empty `claw_id` past `claim_ttl`
- `claw_checkpoints` stuck in `creating`
- `task_runs` past `timeout_at` on a non-terminal claw

Each firing check reports count + oldest age + which mechanism should have repaired it (periodic reaper vs. boot reconciliation). A nonzero steady-state count means the reaper is broken or disabled. Clean DB yields a single OK check. Tested both ways (healthy DB and DB seeded with all five stuck conditions).

**3. `fix(hub): address review findings`** (dual review: gpt-5.6 + manual verification)
- `livenessSettings()` now snapshots the config pointer under `s.mu.RLock()`; hot paths hoist the read outside lock-held regions (heartbeat held `s.mu` at the old call site) and `checkClawStatus` parses once per tick
- Doctor hints attribute orphaned workflow runs / stuck checkpoints to boot reconciliation (`reconcileOnBoot`), which is what actually repairs them — not the periodic reaper
- Age-based doctor checks fire at 2× the configured threshold to avoid false positives from the reaper's first-observation grace window (the reaper measures from in-memory `firstSeen`, the doctor from persisted timestamps); test proves the 1×–2× window does not fire

## Testing
- `go test ./pkg/hub/... ./pkg/types/...` green
- `go test -race -run 'Watchdog|Liveness|Reaper|Doctor' ./pkg/hub/` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)