### PR TITLE
feat(hub): catch-up and retry-capable integration trigger polling

### DIFF
--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -116,6 +116,7 @@ func migrate(db *sql.DB) error {
 	)`)
 	_, _ = db.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_factory_triggers_key ON factory_triggers(factory_name, integration, trigger_key)`)
 	_, _ = db.Exec(`CREATE INDEX IF NOT EXISTS idx_factory_triggers_claw ON factory_triggers(claw_id)`)
+	_, _ = db.Exec(`CREATE TABLE IF NOT EXISTS integration_poll_state (integration TEXT PRIMARY KEY, last_success_at DATETIME NOT NULL)`)
 	_, _ = db.Exec(`
 		INSERT OR IGNORE INTO factory_triggers(id, factory_name, integration, trigger_key, trigger_source, trigger_payload, claw_id, status, first_seen_at, last_seen_at, created_at, updated_at)
 		SELECT lower(hex(randomblob(16))), factory_name, 'linear', 'linear:' || linear_issue_id, 'migration', '{}', id, 'active', created_at, created_at, created_at, created_at
@@ -251,6 +252,10 @@ func migrate(db *sql.DB) error {
 	);
 	CREATE UNIQUE INDEX IF NOT EXISTS idx_factory_triggers_key ON factory_triggers(factory_name, integration, trigger_key);
 	CREATE INDEX IF NOT EXISTS idx_factory_triggers_claw ON factory_triggers(claw_id);
+	CREATE TABLE IF NOT EXISTS integration_poll_state (
+		integration TEXT PRIMARY KEY,
+		last_success_at DATETIME NOT NULL
+	);
 
 	CREATE INDEX IF NOT EXISTS idx_messages_claw ON messages(claw_id, created_at);
 	CREATE INDEX IF NOT EXISTS idx_claws_tenant  ON claws(tenant_id);

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -62,6 +62,7 @@ func migrate(db *sql.DB) error {
 	_, _ = db.Exec(`ALTER TABLE claw_prs ADD COLUMN last_review_id INTEGER NOT NULL DEFAULT 0`)
 	_, _ = db.Exec(`ALTER TABLE messages ADD COLUMN format TEXT NOT NULL DEFAULT ''`)
 	_, _ = db.Exec(`ALTER TABLE factory_triggers ADD COLUMN task_run_id TEXT NOT NULL DEFAULT ''`)
+	_, _ = db.Exec(`ALTER TABLE factory_triggers ADD COLUMN retry_count INTEGER NOT NULL DEFAULT 0`)
 	_, _ = db.Exec(`ALTER TABLE task_run_attempts ADD COLUMN restored_checkpoint_id TEXT`)
 
 	_, _ = db.Exec(`CREATE TABLE IF NOT EXISTS claw_checkpoints (
@@ -107,6 +108,7 @@ func migrate(db *sql.DB) error {
 		claw_id        TEXT NOT NULL DEFAULT '',
 		task_run_id    TEXT NOT NULL DEFAULT '',
 		status         TEXT NOT NULL DEFAULT 'claimed',
+		retry_count     INTEGER NOT NULL DEFAULT 0,
 		first_seen_at  DATETIME NOT NULL,
 		last_seen_at   DATETIME NOT NULL,
 		created_at     DATETIME NOT NULL,
@@ -241,6 +243,7 @@ func migrate(db *sql.DB) error {
 		claw_id        TEXT NOT NULL DEFAULT '',
 		task_run_id    TEXT NOT NULL DEFAULT '',
 		status         TEXT NOT NULL DEFAULT 'claimed',
+		retry_count     INTEGER NOT NULL DEFAULT 0,
 		first_seen_at  DATETIME NOT NULL,
 		last_seen_at   DATETIME NOT NULL,
 		created_at     DATETIME NOT NULL,

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -116,6 +116,7 @@ func migrate(db *sql.DB) error {
 	)`)
 	_, _ = db.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_factory_triggers_key ON factory_triggers(factory_name, integration, trigger_key)`)
 	_, _ = db.Exec(`CREATE INDEX IF NOT EXISTS idx_factory_triggers_claw ON factory_triggers(claw_id)`)
+	_, _ = db.Exec(`CREATE INDEX IF NOT EXISTS idx_factory_triggers_integration_status ON factory_triggers(integration, status, claw_id)`)
 	_, _ = db.Exec(`CREATE TABLE IF NOT EXISTS integration_poll_state (integration TEXT PRIMARY KEY, last_success_at DATETIME NOT NULL)`)
 	_, _ = db.Exec(`
 		INSERT OR IGNORE INTO factory_triggers(id, factory_name, integration, trigger_key, trigger_source, trigger_payload, claw_id, status, first_seen_at, last_seen_at, created_at, updated_at)
@@ -252,6 +253,7 @@ func migrate(db *sql.DB) error {
 	);
 	CREATE UNIQUE INDEX IF NOT EXISTS idx_factory_triggers_key ON factory_triggers(factory_name, integration, trigger_key);
 	CREATE INDEX IF NOT EXISTS idx_factory_triggers_claw ON factory_triggers(claw_id);
+	CREATE INDEX IF NOT EXISTS idx_factory_triggers_integration_status ON factory_triggers(integration, status, claw_id);
 	CREATE TABLE IF NOT EXISTS integration_poll_state (
 		integration TEXT PRIMARY KEY,
 		last_success_at DATETIME NOT NULL

--- a/pkg/hub/factory_triggers.go
+++ b/pkg/hub/factory_triggers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 )
@@ -69,13 +70,15 @@ func (s *Server) claimFactoryTrigger(factoryName, integration, triggerKey, sourc
 	}
 
 	var clawID, triggerStatus, clawStatus string
+	var retryCount int
+	var updatedAt time.Time
 	err = tx.QueryRow(`
-		SELECT COALESCE(ft.claw_id,''), ft.status, COALESCE(c.status,'')
+		SELECT COALESCE(ft.claw_id,''), ft.status, COALESCE(c.status,''), ft.retry_count, ft.updated_at
 		  FROM factory_triggers ft
 		  LEFT JOIN claws c ON c.id = ft.claw_id
 		 WHERE ft.factory_name=? AND ft.integration=? AND ft.trigger_key=?`,
 		factoryName, integration, triggerKey,
-	).Scan(&clawID, &triggerStatus, &clawStatus)
+	).Scan(&clawID, &triggerStatus, &clawStatus, &retryCount, &updatedAt)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return false, fmt.Errorf("factory trigger disappeared while claiming")
@@ -107,6 +110,23 @@ func (s *Server) claimFactoryTrigger(factoryName, integration, triggerKey, sourc
 		}
 		return false, tx.Commit()
 	}
+	if clawID == "" && triggerStatus == "failed" && source != "webhook" {
+		// A failed attempt with count n waits min(30s * 2^n, 30m) before reclaiming.
+		backoff := 30 * time.Second
+		for i := 0; i < retryCount && backoff < 30*time.Minute; i++ {
+			backoff *= 2
+		}
+		if backoff > 30*time.Minute {
+			backoff = 30 * time.Minute
+		}
+		if now.Before(updatedAt.Add(backoff)) {
+			_, err = tx.Exec(`UPDATE factory_triggers SET last_seen_at=? WHERE factory_name=? AND integration=? AND trigger_key=?`, now, factoryName, integration, triggerKey)
+			if err != nil {
+				return false, err
+			}
+			return false, tx.Commit()
+		}
+	}
 
 	if clawID != "" && clawStatus != "" && clawStatus != "deleted" {
 		_, _ = tx.Exec(`UPDATE claws SET status='deleted' WHERE id=?`, clawID)
@@ -132,7 +152,7 @@ func (s *Server) completeFactoryTrigger(factoryName, integration, triggerKey, cl
 	}
 	res, err := s.db.Exec(`
 		UPDATE factory_triggers
-		   SET claw_id=?, status='active', updated_at=?
+		   SET claw_id=?, status='active', retry_count=0, updated_at=?
 		 WHERE factory_name=? AND integration=? AND trigger_key=?`,
 		clawID, now(), factoryName, integration, triggerKey,
 	)
@@ -149,7 +169,7 @@ func (s *Server) completeFactoryTrigger(factoryName, integration, triggerKey, cl
 func (s *Server) failFactoryTrigger(factoryName, integration, triggerKey string) {
 	_, _ = s.db.Exec(`
 		UPDATE factory_triggers
-		   SET status='failed', updated_at=?
+		   SET status='failed', retry_count=retry_count+1, updated_at=?
 		 WHERE factory_name=? AND integration=? AND trigger_key=? AND claw_id=''`,
 		now(), factoryName, integration, triggerKey,
 	)

--- a/pkg/hub/factory_triggers_test.go
+++ b/pkg/hub/factory_triggers_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 )
 
 func newFactoryTriggerTestServer(t *testing.T) *Server {
@@ -136,5 +137,68 @@ func TestCompleteFactoryTriggerReturnsMissingClaimError(t *testing.T) {
 	err := s.completeFactoryTrigger("missing", "linear", "linear:ELA-123", "claw-1")
 	if err == nil {
 		t.Fatal("expected missing claim error")
+	}
+}
+
+func TestFailedFactoryTriggerBackoffAndWebhookBypass(t *testing.T) {
+	s := newFactoryTriggerTestServer(t)
+	key := factoryTriggerKey("linear", "ELA-456")
+	claimed, err := s.claimFactoryTrigger("code", "linear", key, "poll", nil)
+	if err != nil || !claimed {
+		t.Fatalf("initial claim = %v, %v", claimed, err)
+	}
+	s.failFactoryTrigger("code", "linear", key)
+
+	var status string
+	var retryCount int
+	if err := s.db.QueryRow(`SELECT status, retry_count FROM factory_triggers WHERE trigger_key=?`, key).Scan(&status, &retryCount); err != nil {
+		t.Fatal(err)
+	}
+	if status != "failed" || retryCount != 1 {
+		t.Fatalf("failed trigger = status %q retry_count %d, want failed/1", status, retryCount)
+	}
+
+	claimed, err = s.claimFactoryTrigger("code", "linear", key, "poll", nil)
+	if err != nil || claimed {
+		t.Fatalf("claim before backoff = %v, %v; want false, nil", claimed, err)
+	}
+	_, err = s.db.Exec(`UPDATE factory_triggers SET updated_at=? WHERE trigger_key=?`, time.Now().UTC().Add(-61*time.Second), key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	claimed, err = s.claimFactoryTrigger("code", "linear", key, "poll", nil)
+	if err != nil || !claimed {
+		t.Fatalf("claim after backoff = %v, %v", claimed, err)
+	}
+
+	otherKey := factoryTriggerKey("linear", "ELA-457")
+	claimed, err = s.claimFactoryTrigger("code", "linear", otherKey, "poll", nil)
+	if err != nil || !claimed {
+		t.Fatalf("other initial claim = %v, %v", claimed, err)
+	}
+	s.failFactoryTrigger("code", "linear", otherKey)
+	claimed, err = s.claimFactoryTrigger("code", "linear", otherKey, "webhook", nil)
+	if err != nil || !claimed {
+		t.Fatalf("webhook bypass claim = %v, %v", claimed, err)
+	}
+}
+
+func TestCompleteFactoryTriggerResetsRetryCount(t *testing.T) {
+	s := newFactoryTriggerTestServer(t)
+	key := factoryTriggerKey("linear", "ELA-789")
+	claimed, err := s.claimFactoryTrigger("code", "linear", key, "poll", nil)
+	if err != nil || !claimed {
+		t.Fatalf("initial claim = %v, %v", claimed, err)
+	}
+	s.failFactoryTrigger("code", "linear", key)
+	if err := s.completeFactoryTrigger("code", "linear", key, "claw-789"); err != nil {
+		t.Fatal(err)
+	}
+	var retryCount int
+	if err := s.db.QueryRow(`SELECT retry_count FROM factory_triggers WHERE trigger_key=?`, key).Scan(&retryCount); err != nil {
+		t.Fatal(err)
+	}
+	if retryCount != 0 {
+		t.Fatalf("retry_count = %d, want 0", retryCount)
 	}
 }

--- a/pkg/hub/integration_poller.go
+++ b/pkg/hub/integration_poller.go
@@ -2,7 +2,6 @@ package hub
 
 import (
 	"bytes"
-	"database/sql"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -123,18 +122,15 @@ func (s *Server) pollSince(integration string, n time.Time) time.Time {
 	if hwm, ok := s.getPollHighWaterMark(integration); ok && hwm.Before(since) {
 		since = hwm
 	}
-	// first_seen_at is slightly after a tracker's updatedAt, so retain a safety margin.
-	// MIN() strips the column's DATETIME decltype, so the driver hands back a raw
-	// string; scan it and parse with the driver's sqlite time layout.
-	var failed sql.NullString
-	if err := s.db.QueryRow(`SELECT MIN(first_seen_at) FROM factory_triggers WHERE integration=? AND status='failed' AND claw_id='' AND first_seen_at >= ?`, integration, n.Add(-24*time.Hour)).Scan(&failed); err != nil {
+	// A failed trigger may have been first seen via catch-up long after the item's
+	// tracker updatedAt (up to the 24h catch-up clamp), so first_seen_at gives no
+	// usable lower bound on updatedAt. Poll the full 24h window until the trigger
+	// is reclaimed or ages out, so the item reappears and is retried.
+	var failed int
+	if err := s.db.QueryRow(`SELECT COUNT(1) FROM factory_triggers WHERE integration=? AND status='failed' AND claw_id='' AND first_seen_at >= ?`, integration, n.Add(-24*time.Hour)).Scan(&failed); err != nil {
 		log.Printf("[poll] failed-trigger window query for %q: %v", integration, err)
-	} else if failed.Valid {
-		if t, err := time.Parse("2006-01-02 15:04:05.999999999-07:00", failed.String); err != nil {
-			log.Printf("[poll] parse failed-trigger first_seen_at %q for %q: %v", failed.String, integration, err)
-		} else if t.Add(-5 * time.Minute).Before(since) {
-			since = t.Add(-5 * time.Minute)
-		}
+	} else if failed > 0 {
+		since = n.Add(-24 * time.Hour)
 	}
 	if min := n.Add(-24 * time.Hour); since.Before(min) {
 		since = min

--- a/pkg/hub/integration_poller.go
+++ b/pkg/hub/integration_poller.go
@@ -2,6 +2,7 @@ package hub
 
 import (
 	"bytes"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -33,7 +34,6 @@ func (s *Server) startIntegrationPoller() {
 // processes any trigger transitions that webhooks may have missed.
 func (s *Server) pollTick() {
 	now := time.Now().UTC()
-	since := now.Add(-2 * time.Minute).Format(time.RFC3339)
 
 	factories := s.resolveFactories()
 	linearWorkflowWorkspaces, err := loadExternalWorkflowsByIntegration("linear")
@@ -62,14 +62,20 @@ func (s *Server) pollTick() {
 	s.mu.RUnlock()
 
 	// === LINEAR ===
+	linearSince := s.pollSince("linear", now)
+	linearOK := true
 	if integrations != nil && len(integrations.Linear) > 0 {
-		s.pollLinear(factories, integrations.Linear, since)
+		linearOK = s.pollLinear(factories, integrations.Linear, linearSince.Format(time.RFC3339))
 	}
 	if len(linearWorkflowWorkspaces) > 0 {
-		s.pollLinearWorkflows(linearWorkflowWorkspaces, since)
+		linearOK = s.pollLinearWorkflows(linearWorkflowWorkspaces, linearSince.Format(time.RFC3339)) && linearOK
+	}
+	if ((integrations != nil && len(integrations.Linear) > 0) || len(linearWorkflowWorkspaces) > 0) && linearOK {
+		s.setPollHighWaterMark("linear", now)
 	}
 
 	// === SHORTCUT ===
+	since := now.Add(-2 * time.Minute).Format(time.RFC3339)
 	if integrations != nil && len(integrations.Shortcut) > 0 {
 		s.pollShortcut(factories, integrations.Shortcut, since)
 	}
@@ -100,9 +106,46 @@ func (s *Server) pollTick() {
 	}
 }
 
+func (s *Server) getPollHighWaterMark(integration string) (time.Time, bool) {
+	var t time.Time
+	if err := s.db.QueryRow(`SELECT last_success_at FROM integration_poll_state WHERE integration=?`, integration).Scan(&t); err != nil {
+		return time.Time{}, false
+	}
+	return t, true
+}
+
+func (s *Server) setPollHighWaterMark(integration string, t time.Time) {
+	_, _ = s.db.Exec(`INSERT INTO integration_poll_state(integration,last_success_at) VALUES(?,?) ON CONFLICT(integration) DO UPDATE SET last_success_at=excluded.last_success_at`, integration, t)
+}
+
+func (s *Server) pollSince(integration string, n time.Time) time.Time {
+	since := n.Add(-2 * time.Minute)
+	if hwm, ok := s.getPollHighWaterMark(integration); ok && hwm.Before(since) {
+		since = hwm
+	}
+	// first_seen_at is slightly after a tracker's updatedAt, so retain a safety margin.
+	// MIN() strips the column's DATETIME decltype, so the driver hands back a raw
+	// string; scan it and parse with the driver's sqlite time layout.
+	var failed sql.NullString
+	if err := s.db.QueryRow(`SELECT MIN(first_seen_at) FROM factory_triggers WHERE integration=? AND status='failed' AND claw_id='' AND first_seen_at >= ?`, integration, n.Add(-24*time.Hour)).Scan(&failed); err != nil {
+		log.Printf("[poll] failed-trigger window query for %q: %v", integration, err)
+	} else if failed.Valid {
+		if t, err := time.Parse("2006-01-02 15:04:05.999999999-07:00", failed.String); err != nil {
+			log.Printf("[poll] parse failed-trigger first_seen_at %q for %q: %v", failed.String, integration, err)
+		} else if t.Add(-5 * time.Minute).Before(since) {
+			since = t.Add(-5 * time.Minute)
+		}
+	}
+	if min := n.Add(-24 * time.Hour); since.Before(min) {
+		since = min
+	}
+	return since
+}
+
 // ── LINEAR POLLER ───────────────────────────────────────────────────────────
 
-func (s *Server) pollLinear(factories []*types.FactoryConfig, linearCfgs []*types.LinearIntegrationConfig, since string) {
+func (s *Server) pollLinear(factories []*types.FactoryConfig, linearCfgs []*types.LinearIntegrationConfig, since string) bool {
+	ok := true
 	// Group factories by workspace (team key) for efficient batching
 	workspaceFactories := map[string][]*types.FactoryConfig{}
 	for _, f := range factories {
@@ -138,6 +181,7 @@ func (s *Server) pollLinear(factories []*types.FactoryConfig, linearCfgs []*type
 		issues, err := s.queryLinearIssues(li.Token, since)
 		if err != nil {
 			log.Printf("[poll-linear] query failed for workspace %q: %v", ws, err)
+			ok = false
 			continue
 		}
 
@@ -145,6 +189,7 @@ func (s *Server) pollLinear(factories []*types.FactoryConfig, linearCfgs []*type
 			s.processLinearPollItem(issue, wsFactories, ws)
 		}
 	}
+	return ok
 }
 
 type linearWorkflowPollTarget struct {
@@ -152,7 +197,8 @@ type linearWorkflowPollTarget struct {
 	workflow  *types.WorkflowConfig
 }
 
-func (s *Server) pollLinearWorkflows(workspaces []*types.WorkspaceConfig, since string) {
+func (s *Server) pollLinearWorkflows(workspaces []*types.WorkspaceConfig, since string) bool {
+	ok := true
 	tokenTargets := map[string][]linearWorkflowPollTarget{}
 	for _, workspace := range workspaces {
 		if workspace == nil {
@@ -177,12 +223,14 @@ func (s *Server) pollLinearWorkflows(workspaces []*types.WorkspaceConfig, since 
 		issues, err := s.queryLinearIssues(token, since)
 		if err != nil {
 			log.Printf("[poll-linear] workflow query failed: %v", err)
+			ok = false
 			continue
 		}
 		for _, issue := range issues {
 			s.processLinearWorkflowPollItem(issue, targets)
 		}
 	}
+	return ok
 }
 
 // linearPollIssue is the subset of Linear GraphQL data we need for polling.

--- a/pkg/hub/integration_poller.go
+++ b/pkg/hub/integration_poller.go
@@ -301,12 +301,14 @@ func (s *Server) queryLinearIssues(token, since string) ([]linearPollIssue, erro
 		req.Header.Set("Content-Type", "application/json")
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
-			return nil, err
+			// Return issues fetched from earlier pages (if any) so this tick can
+			// still process them; the error keeps the high-water mark from advancing.
+			return issues, err
 		}
 		respBody, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
 		if resp.StatusCode >= 400 {
-			return nil, fmt.Errorf("linear API error %d: %s", resp.StatusCode, string(respBody))
+			return issues, fmt.Errorf("linear API error %d: %s", resp.StatusCode, string(respBody))
 		}
 		var result struct {
 			Errors []struct {
@@ -345,12 +347,13 @@ func (s *Server) queryLinearIssues(token, since string) ([]linearPollIssue, erro
 			} `json:"data"`
 		}
 		if err := json.Unmarshal(respBody, &result); err != nil {
-			return nil, fmt.Errorf("parse linear response: %w", err)
+			return issues, fmt.Errorf("parse linear response: %w", err)
 		}
 		// Linear returns HTTP 200 with a GraphQL errors array on failure; treat it
 		// as an error so the high-water mark does not advance past skipped items.
+		// Issues already fetched from earlier pages are still returned for this tick.
 		if len(result.Errors) > 0 {
-			return nil, fmt.Errorf("linear GraphQL error: %s", result.Errors[0].Message)
+			return issues, fmt.Errorf("linear GraphQL error: %s", result.Errors[0].Message)
 		}
 		for _, n := range result.Data.Issues.Nodes {
 			li := linearPollIssue{

--- a/pkg/hub/integration_poller.go
+++ b/pkg/hub/integration_poller.go
@@ -176,9 +176,10 @@ func (s *Server) pollLinear(factories []*types.FactoryConfig, linearCfgs []*type
 
 		issues, err := s.queryLinearIssues(li.Token, since)
 		if err != nil {
+			// Partial results (e.g. pagination cap) are still processed; ok=false
+			// keeps the high-water mark from advancing past the missing remainder.
 			log.Printf("[poll-linear] query failed for workspace %q: %v", ws, err)
 			ok = false
-			continue
 		}
 
 		for _, issue := range issues {
@@ -220,7 +221,6 @@ func (s *Server) pollLinearWorkflows(workspaces []*types.WorkspaceConfig, since 
 		if err != nil {
 			log.Printf("[poll-linear] workflow query failed: %v", err)
 			ok = false
-			continue
 		}
 		for _, issue := range issues {
 			s.processLinearWorkflowPollItem(issue, targets)
@@ -293,6 +293,9 @@ func (s *Server) queryLinearIssues(token, since string) ([]linearPollIssue, erro
 			return nil, fmt.Errorf("linear API error %d: %s", resp.StatusCode, string(respBody))
 		}
 		var result struct {
+			Errors []struct {
+				Message string `json:"message"`
+			} `json:"errors"`
 			Data struct {
 				Issues struct {
 					Nodes []struct {
@@ -328,6 +331,11 @@ func (s *Server) queryLinearIssues(token, since string) ([]linearPollIssue, erro
 		if err := json.Unmarshal(respBody, &result); err != nil {
 			return nil, fmt.Errorf("parse linear response: %w", err)
 		}
+		// Linear returns HTTP 200 with a GraphQL errors array on failure; treat it
+		// as an error so the high-water mark does not advance past skipped items.
+		if len(result.Errors) > 0 {
+			return nil, fmt.Errorf("linear GraphQL error: %s", result.Errors[0].Message)
+		}
 		for _, n := range result.Data.Issues.Nodes {
 			li := linearPollIssue{
 				ID:          n.ID,
@@ -352,11 +360,11 @@ func (s *Server) queryLinearIssues(token, since string) ([]linearPollIssue, erro
 			return issues, nil
 		}
 		after = result.Data.Issues.PageInfo.EndCursor
-		if page == 19 {
-			log.Printf("[poll-linear] pagination cap reached after fetching %d issues", len(issues))
-		}
 	}
-	return issues, nil
+	// Cap hit with hasNextPage still true: return the fetched issues so callers can
+	// process them, plus an error so the high-water mark does not advance past the
+	// unfetched remainder — the next tick resumes from the same window.
+	return issues, fmt.Errorf("pagination cap reached after fetching %d issues with more pages remaining", len(issues))
 }
 
 func (s *Server) processLinearPollItem(issue linearPollIssue, factories []*types.FactoryConfig, workspace string) {

--- a/pkg/hub/integration_poller.go
+++ b/pkg/hub/integration_poller.go
@@ -262,8 +262,8 @@ func (s *Server) queryLinearIssues(token, since string) ([]linearPollIssue, erro
 		base = "https://api.linear.app"
 	}
 
-	query := fmt.Sprintf(`query {
-		issues(filter: { updatedAt: { gt: "%s" } }) {
+	query := fmt.Sprintf(`query($after: String) {
+		issues(filter: { updatedAt: { gt: "%s" } }, first: 100, after: $after) {
 			nodes {
 				id
 				identifier
@@ -276,79 +276,89 @@ func (s *Server) queryLinearIssues(token, since string) ([]linearPollIssue, erro
 				labels { nodes { name } }
 				assignee { name }
 			}
+			pageInfo { hasNextPage endCursor }
 		}
 	}`, since)
-
-	body := map[string]interface{}{"query": query}
-	jsonBody, _ := json.Marshal(body)
-	req, _ := http.NewRequest("POST", base+"/graphql", bytes.NewReader(jsonBody))
-	req.Header.Set("Authorization", token)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	respBody, _ := io.ReadAll(resp.Body)
-
-	if resp.StatusCode >= 400 {
-		return nil, fmt.Errorf("linear API error %d: %s", resp.StatusCode, string(respBody))
-	}
-
-	var result struct {
-		Data struct {
-			Issues struct {
-				Nodes []struct {
-					ID          string `json:"id"`
-					Identifier  string `json:"identifier"`
-					Title       string `json:"title"`
-					Description string `json:"description"`
-					URL         string `json:"url"`
-					UpdatedAt   string `json:"updatedAt"`
-					State       struct {
-						Name string `json:"name"`
-					} `json:"state"`
-					Team struct {
-						Key  string `json:"key"`
-						Name string `json:"name"`
-					} `json:"team"`
-					Labels struct {
-						Nodes []struct {
-							Name string `json:"name"`
-						} `json:"nodes"`
-					} `json:"labels"`
-					Assignee *struct {
-						Name string `json:"name"`
-					} `json:"assignee"`
-				} `json:"nodes"`
-			} `json:"issues"`
-		} `json:"data"`
-	}
-	if err := json.Unmarshal(respBody, &result); err != nil {
-		return nil, fmt.Errorf("parse linear response: %w", err)
-	}
-
 	var issues []linearPollIssue
-	for _, n := range result.Data.Issues.Nodes {
-		li := linearPollIssue{
-			ID:          n.ID,
-			Identifier:  n.Identifier,
-			Title:       n.Title,
-			Description: n.Description,
-			URL:         n.URL,
-			UpdatedAt:   n.UpdatedAt,
-			State:       n.State,
-			Team:        n.Team,
-			Assignee:    n.Assignee,
+	after := interface{}(nil)
+	for page := 0; page < 20; page++ {
+		body := map[string]interface{}{"query": query, "variables": map[string]interface{}{"after": after}}
+		jsonBody, _ := json.Marshal(body)
+		req, _ := http.NewRequest("POST", base+"/graphql", bytes.NewReader(jsonBody))
+		req.Header.Set("Authorization", token)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return nil, err
 		}
-		for _, l := range n.Labels.Nodes {
-			label := struct {
-				Name string `json:"name"`
-			}{Name: l.Name}
-			li.Labels = append(li.Labels, label)
+		respBody, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode >= 400 {
+			return nil, fmt.Errorf("linear API error %d: %s", resp.StatusCode, string(respBody))
 		}
-		issues = append(issues, li)
+		var result struct {
+			Data struct {
+				Issues struct {
+					Nodes []struct {
+						ID          string `json:"id"`
+						Identifier  string `json:"identifier"`
+						Title       string `json:"title"`
+						Description string `json:"description"`
+						URL         string `json:"url"`
+						UpdatedAt   string `json:"updatedAt"`
+						State       struct {
+							Name string `json:"name"`
+						} `json:"state"`
+						Team struct {
+							Key  string `json:"key"`
+							Name string `json:"name"`
+						} `json:"team"`
+						Labels struct {
+							Nodes []struct {
+								Name string `json:"name"`
+							} `json:"nodes"`
+						} `json:"labels"`
+						Assignee *struct {
+							Name string `json:"name"`
+						} `json:"assignee"`
+					} `json:"nodes"`
+					PageInfo struct {
+						HasNextPage bool   `json:"hasNextPage"`
+						EndCursor   string `json:"endCursor"`
+					} `json:"pageInfo"`
+				} `json:"issues"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(respBody, &result); err != nil {
+			return nil, fmt.Errorf("parse linear response: %w", err)
+		}
+		for _, n := range result.Data.Issues.Nodes {
+			li := linearPollIssue{
+				ID:          n.ID,
+				Identifier:  n.Identifier,
+				Title:       n.Title,
+				Description: n.Description,
+				URL:         n.URL,
+				UpdatedAt:   n.UpdatedAt,
+				State:       n.State,
+				Team:        n.Team,
+				Assignee:    n.Assignee,
+			}
+			for _, l := range n.Labels.Nodes {
+				label := struct {
+					Name string `json:"name"`
+				}{Name: l.Name}
+				li.Labels = append(li.Labels, label)
+			}
+			issues = append(issues, li)
+		}
+		if !result.Data.Issues.PageInfo.HasNextPage {
+			return issues, nil
+		}
+		after = result.Data.Issues.PageInfo.EndCursor
+		if page == 19 {
+			log.Printf("[poll-linear] pagination cap reached after fetching %d issues", len(issues))
+		}
 	}
 	return issues, nil
 }

--- a/pkg/hub/integration_poller.go
+++ b/pkg/hub/integration_poller.go
@@ -74,34 +74,50 @@ func (s *Server) pollTick() {
 	}
 
 	// === SHORTCUT ===
-	since := now.Add(-2 * time.Minute).Format(time.RFC3339)
+	shortcutSince := s.pollSince("shortcut", now).Format(time.RFC3339)
+	shortcutOK := true
 	if integrations != nil && len(integrations.Shortcut) > 0 {
-		s.pollShortcut(factories, integrations.Shortcut, since)
+		shortcutOK = s.pollShortcut(factories, integrations.Shortcut, shortcutSince)
 	}
 	if len(shortcutWorkflowWorkspaces) > 0 {
-		s.pollShortcutWorkflows(shortcutWorkflowWorkspaces, since)
+		shortcutOK = s.pollShortcutWorkflows(shortcutWorkflowWorkspaces, shortcutSince) && shortcutOK
+	}
+	if ((integrations != nil && len(integrations.Shortcut) > 0) || len(shortcutWorkflowWorkspaces) > 0) && shortcutOK {
+		s.setPollHighWaterMark("shortcut", now)
 	}
 
 	// === GITHUB ISSUES ===
+	ghIssuesSince := s.pollSince("github-issues", now).Format(time.RFC3339)
+	ghIssuesOK := true
 	if integrations != nil && len(integrations.GitHubIssues) > 0 {
-		s.pollGitHubIssues(factories, integrations.GitHubIssues, since)
+		ghIssuesOK = s.pollGitHubIssues(factories, integrations.GitHubIssues, ghIssuesSince)
 	}
 	if len(githubIssueWorkflowWorkspaces) > 0 {
-		s.pollGitHubIssueWorkflows(githubIssueWorkflowWorkspaces, since)
+		ghIssuesOK = s.pollGitHubIssueWorkflows(githubIssueWorkflowWorkspaces, ghIssuesSince) && ghIssuesOK
+	}
+	if ((integrations != nil && len(integrations.GitHubIssues) > 0) || len(githubIssueWorkflowWorkspaces) > 0) && ghIssuesOK {
+		s.setPollHighWaterMark("github-issues", now)
 	}
 
 	// === JIRA ===
+	jiraSince := s.pollSince("jira", now)
+	jiraOK := true
 	if integrations != nil && len(integrations.Jira) > 0 {
-		s.pollJira(factories, integrations.Jira, now.Add(-2*time.Minute))
+		jiraOK = s.pollJira(factories, integrations.Jira, jiraSince)
 	}
 	if len(jiraWorkflowWorkspaces) > 0 {
-		s.pollJiraWorkflows(jiraWorkflowWorkspaces, now.Add(-2*time.Minute))
+		jiraOK = s.pollJiraWorkflows(jiraWorkflowWorkspaces, jiraSince) && jiraOK
+	}
+	if ((integrations != nil && len(integrations.Jira) > 0) || len(jiraWorkflowWorkspaces) > 0) && jiraOK {
+		s.setPollHighWaterMark("jira", now)
 	}
 
 	// === GITHUB PRs ===
 	// Use factories with integration=="github" to discover repos
 	if len(factories) > 0 {
-		s.pollGitHubPRs(factories, since)
+		if s.pollGitHubPRs(factories, s.pollSince("github", now).Format(time.RFC3339)) {
+			s.setPollHighWaterMark("github", now)
+		}
 	}
 }
 
@@ -489,7 +505,8 @@ func (s *Server) buildLinearPollPayload(issue linearPollIssue) linearWebhookPayl
 
 // ── SHORTCUT POLLER ─────────────────────────────────────────────────────────
 
-func (s *Server) pollShortcut(factories []*types.FactoryConfig, shortcutCfgs []*types.ShortcutIntegrationConfig, since string) {
+func (s *Server) pollShortcut(factories []*types.FactoryConfig, shortcutCfgs []*types.ShortcutIntegrationConfig, since string) bool {
+	ok := true
 	workspaceFactories := map[string][]*types.FactoryConfig{}
 	for _, f := range factories {
 		if f.Integration != "shortcut" {
@@ -521,6 +538,7 @@ func (s *Server) pollShortcut(factories []*types.FactoryConfig, shortcutCfgs []*
 		stories, err := s.queryShortcutStories(sc.Token, since)
 		if err != nil {
 			log.Printf("[poll-shortcut] query failed for workspace %q: %v", ws, err)
+			ok = false
 			continue
 		}
 
@@ -529,12 +547,14 @@ func (s *Server) pollShortcut(factories []*types.FactoryConfig, shortcutCfgs []*
 		stateNameMap := buildShortcutStateMap(s.resolveShortcutBaseURL(), sc.Token)
 		if len(stateNameMap) == 0 {
 			log.Printf("[poll-shortcut] failed to load workflow states for workspace %q — skipping %d stories", ws, len(stories))
+			ok = false
 			continue
 		}
 		for _, story := range stories {
 			s.processShortcutPollItem(story, wsFactories, ws, sc.Token, stateNameMap)
 		}
 	}
+	return ok
 }
 
 type shortcutPollStory struct {
@@ -583,7 +603,8 @@ func (s *Server) queryShortcutStories(token, since string) ([]shortcutPollStory,
 	return stories, nil
 }
 
-func (s *Server) pollShortcutWorkflows(workspaces []*types.WorkspaceConfig, since string) {
+func (s *Server) pollShortcutWorkflows(workspaces []*types.WorkspaceConfig, since string) bool {
+	ok := true
 	tokenTargets := map[string][]shortcutWorkflowPollTarget{}
 	for _, workspace := range workspaces {
 		if workspace == nil {
@@ -608,17 +629,20 @@ func (s *Server) pollShortcutWorkflows(workspaces []*types.WorkspaceConfig, sinc
 		stories, err := s.queryShortcutStories(token, since)
 		if err != nil {
 			log.Printf("[poll-shortcut] workflow query failed: %v", err)
+			ok = false
 			continue
 		}
 		stateNameMap := buildShortcutStateMap(s.resolveShortcutBaseURL(), token)
 		if len(stateNameMap) == 0 {
 			log.Printf("[poll-shortcut] failed to load workflow states for workflow polling — skipping %d stories", len(stories))
+			ok = false
 			continue
 		}
 		for _, story := range stories {
 			s.processShortcutWorkflowPollItem(story, targets, token, stateNameMap)
 		}
 	}
+	return ok
 }
 
 func (s *Server) processShortcutPollItem(story shortcutPollStory, factories []*types.FactoryConfig, workspace, token string, stateNameMap map[int64]string) {
@@ -755,7 +779,8 @@ func (s *Server) processShortcutWorkflowPollItem(story shortcutPollStory, target
 
 // ── GITHUB ISSUES POLLER ────────────────────────────────────────────────────
 
-func (s *Server) pollGitHubIssues(factories []*types.FactoryConfig, ghIssueCfgs []*types.GitHubIssuesIntegrationConfig, since string) {
+func (s *Server) pollGitHubIssues(factories []*types.FactoryConfig, ghIssueCfgs []*types.GitHubIssuesIntegrationConfig, since string) bool {
+	ok := true
 	// Discover repos to poll from factory configs
 	repoFactories := map[string][]*types.FactoryConfig{}
 	for _, f := range factories {
@@ -803,6 +828,7 @@ func (s *Server) pollGitHubIssues(factories []*types.FactoryConfig, ghIssueCfgs 
 		issues, err := s.queryGitHubIssues(repo, token, since, base)
 		if err != nil {
 			log.Printf("[poll-github-issues] query failed for repo %q: %v", repo, err)
+			ok = false
 			continue
 		}
 
@@ -810,6 +836,7 @@ func (s *Server) pollGitHubIssues(factories []*types.FactoryConfig, ghIssueCfgs 
 			s.processGitHubIssuesPollItem(issue, repoFactories, repo, token, base)
 		}
 	}
+	return ok
 }
 
 type githubIssueWorkflowPollTarget struct {
@@ -818,7 +845,8 @@ type githubIssueWorkflowPollTarget struct {
 	token     string
 }
 
-func (s *Server) pollGitHubIssueWorkflows(workspaces []*types.WorkspaceConfig, since string) {
+func (s *Server) pollGitHubIssueWorkflows(workspaces []*types.WorkspaceConfig, since string) bool {
+	ok := true
 	type repoTokenKey struct {
 		repo  string
 		token string
@@ -869,12 +897,14 @@ func (s *Server) pollGitHubIssueWorkflows(workspaces []*types.WorkspaceConfig, s
 		issues, err := s.queryGitHubIssues(key.repo, key.token, since, base)
 		if err != nil {
 			log.Printf("[poll-github-issues] workflow query failed for repo %q: %v", key.repo, err)
+			ok = false
 			continue
 		}
 		for _, issue := range issues {
 			s.processGitHubIssueWorkflowPollItem(issue, targets, key.repo, key.token, base)
 		}
 	}
+	return ok
 }
 
 func githubIssuesPollingRepos(factory *types.FactoryConfig) []string {
@@ -1281,7 +1311,8 @@ func buildGitHubIssuesPollPayloadForAction(issue githubIssuesPollItem, repo, act
 
 // ── JIRA POLLER ─────────────────────────────────────────────────────────────
 
-func (s *Server) pollJira(factories []*types.FactoryConfig, jiraCfgs []*types.JiraIntegrationConfig, since time.Time) {
+func (s *Server) pollJira(factories []*types.FactoryConfig, jiraCfgs []*types.JiraIntegrationConfig, since time.Time) bool {
+	ok := true
 	workspaceFactories := map[string][]*types.FactoryConfig{}
 	for _, f := range factories {
 		if f.Integration != "jira" {
@@ -1308,12 +1339,14 @@ func (s *Server) pollJira(factories []*types.FactoryConfig, jiraCfgs []*types.Ji
 		issues, err := s.queryJiraIssues(tracker, since, projects)
 		if err != nil {
 			log.Printf("[poll-jira] query failed for workspace %q: %v", ji.Workspace, err)
+			ok = false
 			continue
 		}
 		for _, issue := range issues {
 			s.processJiraPollItem(issue, factories, tracker)
 		}
 	}
+	return ok
 }
 
 type jiraWorkflowPollTarget struct {
@@ -1322,7 +1355,8 @@ type jiraWorkflowPollTarget struct {
 	tracker   workspaceIssueTracker
 }
 
-func (s *Server) pollJiraWorkflows(workspaces []*types.WorkspaceConfig, since time.Time) {
+func (s *Server) pollJiraWorkflows(workspaces []*types.WorkspaceConfig, since time.Time) bool {
+	ok := true
 	type trackerKey struct {
 		baseURL  string
 		username string
@@ -1357,12 +1391,14 @@ func (s *Server) pollJiraWorkflows(workspaces []*types.WorkspaceConfig, since ti
 		issues, err := s.queryJiraIssues(tracker, since, jiraWorkflowProjects(targets))
 		if err != nil {
 			log.Printf("[poll-jira] workflow query failed: %v", err)
+			ok = false
 			continue
 		}
 		for _, issue := range issues {
 			s.processJiraWorkflowPollItem(issue, targets)
 		}
 	}
+	return ok
 }
 
 func jiraFactoryProjects(factories []*types.FactoryConfig) []string {
@@ -1472,7 +1508,8 @@ func jiraPollPayload(issue jiraPollIssue) jiraWebhookPayload {
 
 // ── GITHUB PRs POLLER ─────────────────────────────────────────────────────────
 
-func (s *Server) pollGitHubPRs(factories []*types.FactoryConfig, since string) {
+func (s *Server) pollGitHubPRs(factories []*types.FactoryConfig, since string) bool {
+	ok := true
 	repoFactories := map[string][]*types.FactoryConfig{}
 	for _, f := range factories {
 		if f.Integration != "github" {
@@ -1510,6 +1547,7 @@ func (s *Server) pollGitHubPRs(factories []*types.FactoryConfig, since string) {
 		prs, err := s.queryGitHubPRs(repo, token, since, base)
 		if err != nil {
 			log.Printf("[poll-github-prs] query failed for repo %q: %v", repo, err)
+			ok = false
 			continue
 		}
 
@@ -1517,6 +1555,7 @@ func (s *Server) pollGitHubPRs(factories []*types.FactoryConfig, since string) {
 			s.processGitHubPRPollItem(pr, repoFactories, repo, base)
 		}
 	}
+	return ok
 }
 
 type githubPRPollItem struct {

--- a/pkg/hub/integration_poller_pagination_test.go
+++ b/pkg/hub/integration_poller_pagination_test.go
@@ -40,6 +40,36 @@ func TestQueryLinearIssuesPaginatesWithCursorVariable(t *testing.T) {
 	}
 }
 
+func TestQueryLinearIssuesReturnsErrorAtPaginationCap(t *testing.T) {
+	pages := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pages++
+		_, _ = w.Write([]byte(`{"data":{"issues":{"nodes":[{"id":"1","identifier":"ELA-1","title":"one","state":{"name":"Todo"},"team":{"key":"ELA"}}],"pageInfo":{"hasNextPage":true,"endCursor":"next"}}}}`))
+	}))
+	defer server.Close()
+	s := newFactoryTriggerTestServer(t)
+	s.linearBaseURL = server.URL
+	issues, err := s.queryLinearIssues("token", time.Now().UTC().Format(time.RFC3339))
+	if err == nil {
+		t.Fatal("expected error when pagination cap is hit with more pages remaining")
+	}
+	if pages != 20 || len(issues) != 20 {
+		t.Fatalf("pages = %d, issues = %d, want 20/20", pages, len(issues))
+	}
+}
+
+func TestQueryLinearIssuesReturnsGraphQLErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"errors":[{"message":"rate limited"}],"data":null}`))
+	}))
+	defer server.Close()
+	s := newFactoryTriggerTestServer(t)
+	s.linearBaseURL = server.URL
+	if _, err := s.queryLinearIssues("token", time.Now().UTC().Format(time.RFC3339)); err == nil || !strings.Contains(err.Error(), "rate limited") {
+		t.Fatalf("err = %v, want GraphQL error", err)
+	}
+}
+
 func TestLinearPollQueryUsesExpectedSince(t *testing.T) {
 	var query string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/hub/integration_poller_pagination_test.go
+++ b/pkg/hub/integration_poller_pagination_test.go
@@ -65,8 +65,34 @@ func TestQueryLinearIssuesReturnsGraphQLErrors(t *testing.T) {
 	defer server.Close()
 	s := newFactoryTriggerTestServer(t)
 	s.linearBaseURL = server.URL
-	if _, err := s.queryLinearIssues("token", time.Now().UTC().Format(time.RFC3339)); err == nil || !strings.Contains(err.Error(), "rate limited") {
+	issues, err := s.queryLinearIssues("token", time.Now().UTC().Format(time.RFC3339))
+	if err == nil || !strings.Contains(err.Error(), "rate limited") {
 		t.Fatalf("err = %v, want GraphQL error", err)
+	}
+	if len(issues) != 0 {
+		t.Fatalf("issues = %#v, want none fetched before the error", issues)
+	}
+}
+
+func TestQueryLinearIssuesReturnsPartialResultsOnMidPaginationGraphQLError(t *testing.T) {
+	page := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page++
+		if page == 1 {
+			_, _ = w.Write([]byte(`{"data":{"issues":{"nodes":[{"id":"1","identifier":"ELA-1","title":"one","state":{"name":"Todo"},"team":{"key":"ELA"}}],"pageInfo":{"hasNextPage":true,"endCursor":"cursor-1"}}}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"errors":[{"message":"rate limited"}],"data":null}`))
+	}))
+	defer server.Close()
+	s := newFactoryTriggerTestServer(t)
+	s.linearBaseURL = server.URL
+	issues, err := s.queryLinearIssues("token", time.Now().UTC().Format(time.RFC3339))
+	if err == nil || !strings.Contains(err.Error(), "rate limited") {
+		t.Fatalf("err = %v, want GraphQL error", err)
+	}
+	if len(issues) != 1 || issues[0].Identifier != "ELA-1" {
+		t.Fatalf("issues = %#v, want page-1 issues returned despite page-2 error", issues)
 	}
 }
 

--- a/pkg/hub/integration_poller_pagination_test.go
+++ b/pkg/hub/integration_poller_pagination_test.go
@@ -1,0 +1,63 @@
+package hub
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestQueryLinearIssuesPaginatesWithCursorVariable(t *testing.T) {
+	var cursors []interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request struct {
+			Variables map[string]interface{} `json:"variables"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatal(err)
+		}
+		cursors = append(cursors, request.Variables["after"])
+		if request.Variables["after"] == nil {
+			_, _ = w.Write([]byte(`{"data":{"issues":{"nodes":[{"id":"1","identifier":"ELA-1","title":"one","state":{"name":"Todo"},"team":{"key":"ELA"}}],"pageInfo":{"hasNextPage":true,"endCursor":"cursor-1"}}}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"data":{"issues":{"nodes":[{"id":"2","identifier":"ELA-2","title":"two","state":{"name":"Todo"},"team":{"key":"ELA"}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`))
+	}))
+	defer server.Close()
+	s := newFactoryTriggerTestServer(t)
+	s.linearBaseURL = server.URL
+	issues, err := s.queryLinearIssues("token", time.Now().UTC().Add(-2*time.Minute).Format(time.RFC3339))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(issues) != 2 || issues[0].Identifier != "ELA-1" || issues[1].Identifier != "ELA-2" {
+		t.Fatalf("issues = %#v", issues)
+	}
+	if len(cursors) != 2 || cursors[0] != nil || cursors[1] != "cursor-1" {
+		t.Fatalf("cursor variables = %#v", cursors)
+	}
+}
+
+func TestLinearPollQueryUsesExpectedSince(t *testing.T) {
+	var query string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request struct {
+			Query string `json:"query"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&request)
+		query = request.Query
+		_, _ = w.Write([]byte(`{"data":{"issues":{"nodes":[],"pageInfo":{"hasNextPage":false}}}}`))
+	}))
+	defer server.Close()
+	s := newFactoryTriggerTestServer(t)
+	s.linearBaseURL = server.URL
+	since := time.Now().UTC().Add(-2 * time.Minute).Truncate(time.Second).Format(time.RFC3339)
+	if _, err := s.queryLinearIssues("token", since); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(query, since) {
+		t.Fatalf("query %q does not contain since %q", query, since)
+	}
+}

--- a/pkg/hub/integration_poller_test.go
+++ b/pkg/hub/integration_poller_test.go
@@ -1,0 +1,57 @@
+package hub
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func TestPollSinceHighWaterMarkAndFailedWindow(t *testing.T) {
+	s := newFactoryTriggerTestServer(t)
+	n := time.Now().UTC().Truncate(time.Second)
+	cases := []struct {
+		name  string
+		setup func()
+		want  time.Time
+	}{
+		{"fresh database", func() {}, n.Add(-2 * time.Minute)},
+		{"catch up from high-water mark", func() { s.setPollHighWaterMark("linear", n.Add(-30*time.Minute)) }, n.Add(-30 * time.Minute)},
+		{"clamp old high-water mark", func() { s.setPollHighWaterMark("linear", n.Add(-72*time.Hour)) }, n.Add(-24 * time.Hour)},
+		{"extend for failed trigger", func() {
+			s.setPollHighWaterMark("linear", n)
+			_, _ = s.db.Exec(`INSERT INTO factory_triggers(id,factory_name,integration,trigger_key,status,first_seen_at,last_seen_at,created_at,updated_at) VALUES(?,?,?,?,?,?,?,?,?)`, "failed-window", "code", "linear", "linear:ELA-1", "failed", n.Add(-time.Hour), n, n, n)
+		}, n.Add(-65 * time.Minute)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _ = s.db.Exec(`DELETE FROM integration_poll_state`)
+			_, _ = s.db.Exec(`DELETE FROM factory_triggers`)
+			tc.setup()
+			if got := s.pollSince("linear", n); !got.Equal(tc.want) {
+				t.Fatalf("pollSince = %s, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPollHighWaterMarkAdvancesOnlyAfterSuccessfulLinearQuery(t *testing.T) {
+	s := newFactoryTriggerTestServer(t)
+	n := time.Now().UTC().Truncate(time.Second)
+	s.setPollHighWaterMark("linear", n.Add(-30*time.Minute))
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unavailable", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+	s.linearBaseURL = server.URL
+	factories := []*types.FactoryConfig{{Name: "code", Integration: "linear", Workspace: "eng"}}
+	if s.pollLinear(factories, []*types.LinearIntegrationConfig{{Workspace: "eng", Token: "token"}}, s.pollSince("linear", n).Format(time.RFC3339)) {
+		t.Fatal("failed query reported success")
+	}
+	got, ok := s.getPollHighWaterMark("linear")
+	if !ok || !got.Equal(n.Add(-30*time.Minute)) {
+		t.Fatalf("failed query advanced high-water mark to %s", got)
+	}
+}

--- a/pkg/hub/integration_poller_test.go
+++ b/pkg/hub/integration_poller_test.go
@@ -22,8 +22,10 @@ func TestPollSinceHighWaterMarkAndFailedWindow(t *testing.T) {
 		{"clamp old high-water mark", func() { s.setPollHighWaterMark("linear", n.Add(-72*time.Hour)) }, n.Add(-24 * time.Hour)},
 		{"extend for failed trigger", func() {
 			s.setPollHighWaterMark("linear", n)
+			// A failed trigger first seen via catch-up carries no bound on the
+			// item's updatedAt, so the window opens to the full 24h clamp.
 			_, _ = s.db.Exec(`INSERT INTO factory_triggers(id,factory_name,integration,trigger_key,status,first_seen_at,last_seen_at,created_at,updated_at) VALUES(?,?,?,?,?,?,?,?,?)`, "failed-window", "code", "linear", "linear:ELA-1", "failed", n.Add(-time.Hour), n, n, n)
-		}, n.Add(-65 * time.Minute)},
+		}, n.Add(-24 * time.Hour)},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Problem (P0, liveness audit follow-up to #488)

The integration poller used a fixed 2-minute lookback keyed on issue `updatedAt`:

- **Hub downtime > 2 min**: issues moved into trigger status during the outage were permanently missed.
- **Persistent claw-creation failures** (provider down, expired token): the `factory_triggers` row went `failed` (reclaimable), but the poll only re-saw the issue for ~4 ticks — never retried afterwards.
- **Linear poll had no pagination** (default page of 50), so catch-up bursts > 50 issues would be silently dropped.

## Changes

### Per-integration high-water mark
New `integration_poll_state` table (one row per family: `linear`, `shortcut`, `github-issues`, `jira`, `github`). Each tick polls from `min(now-2m, high-water mark)`, clamped to a 24h lookback to bound API cost. The mark only advances when **every** query for that family (factory and workflow pollers) succeeded, so a failed query means the next tick retries the same window. Linear GraphQL errors returned with HTTP 200 now count as failures.

### Failed-trigger retry
- New `retry_count` column on `factory_triggers`; `failFactoryTrigger` increments it, `completeFactoryTrigger` resets it.
- `claimFactoryTrigger` enforces exponential backoff on reclaiming `failed` rows (`30s * 2^n`, capped at 30 min). Webhook-sourced claims bypass the backoff — a webhook means tracker state genuinely changed.
- While an unclaimed `failed` trigger (< 24h old) exists for a family, the poll window opens to the full 24h clamp so the item reappears in poll results and creation is re-attempted through the normal claim path — re-validating current tracker state instead of replaying a stale payload.

### Linear pagination
`queryLinearIssues` now uses cursor pagination (`first: 100` + `after` as a real GraphQL variable), capped at 20 pages. Hitting the cap with `hasNextPage=true` processes the partial results but returns an error so the high-water mark does not advance past undrained items; the next tick resumes the same window.

## Acceptance criteria

- Hub down > 2 min then restart still triggers issues updated during the gap — covered by the catch-up-from-high-water-mark tests (`TestPollSinceHighWaterMarkAndFailedWindow`, downtime catch-up case in `integration_poller_test.go`).
- Creation failure lasting > 2 min is retried and eventually creates the claw — covered by backoff/reclaim tests in `factory_triggers_test.go` plus the failed-trigger window-extension test.
- Pagination: multi-page drain, cursor propagation, GraphQL-error and page-cap failure modes tested in `integration_poller_pagination_test.go`.
- `go test ./pkg/hub/...` green.

## Known limitations

- Triggers with integration `external` (inbound webhook API) have no poller and are still not retried.
- Retry/catch-up horizon is 24h; older failures/updates age out.
- While any `failed` trigger exists for a family, that family polls the full 24h window each tick (30s) until the trigger recovers or ages out — deliberate trade-off, bounded by the pagination cap and the claim-layer backoff.

## Review

Implemented and reviewed via multi-agent workflow: two independent reviews (Claude Fable 5 + GPT-5.6/Codex) produced 10 findings; all 7 critical/major findings were verified and fixed in the three `fix(hub):` commits (high-water mark extended to all families, GraphQL-200 errors, pagination-cap semantics, failed-window anchoring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)