### PR TITLE
fix(hub): unify tracker failure feedback across webhook, poll, and factory paths

### DIFF
--- a/pkg/hub/agent_failure_feedback.go
+++ b/pkg/hub/agent_failure_feedback.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -85,7 +87,10 @@ func (s *Server) notifyWorkflowCreateFailure(workspace *types.WorkspaceConfig, w
 		log.Printf("[agent-failure-feedback] workflow %s/%s has no %s token; skipping failure feedback", workspace.Name, workflow.Name, ref.Integration)
 		return
 	}
-	s.handleAgentFailureFeedback(f, token)
+	// Feedback delivery retries status moves with backoff; run it off the
+	// caller's goroutine so webhook and poll handlers are never blocked on a
+	// slow or failing tracker.
+	go s.handleAgentFailureFeedback(f, token)
 }
 
 type linearGraphQLError struct {
@@ -169,11 +174,29 @@ func (s *Server) handleAgentFailureFeedback(feedback agentFailureFeedback, token
 	return false
 }
 
+var trackerAPIErrStatusRe = regexp.MustCompile(`(?i)\bAPI error (\d{3})\b`)
+
+// isPermanentTrackerMoveErr reports whether a tracker move failed for a
+// reason retrying cannot fix (bad token, missing issue, insufficient scope),
+// so retryTrackerMove fails fast instead of sleeping through doomed attempts.
+func isPermanentTrackerMoveErr(err error) bool {
+	msg := err.Error()
+	if m := trackerAPIErrStatusRe.FindStringSubmatch(msg); m != nil {
+		code, _ := strconv.Atoi(m[1])
+		return code >= 400 && code < 500 && code != http.StatusRequestTimeout && code != http.StatusTooManyRequests
+	}
+	return strings.Contains(msg, "not found")
+}
+
 func (s *Server) retryTrackerMove(op string, fn func() error) error {
 	var err error
 	for attempt := 0; attempt < 3; attempt++ {
 		if err = fn(); err == nil {
 			return nil
+		}
+		if isPermanentTrackerMoveErr(err) {
+			log.Printf("[tracker-move] %s failed permanently, not retrying: %v", op, err)
+			return err
 		}
 		log.Printf("[tracker-move] %s attempt %d/3 failed: %v", op, attempt+1, err)
 		if attempt < 2 {

--- a/pkg/hub/agent_failure_feedback.go
+++ b/pkg/hub/agent_failure_feedback.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
 
 var issueTrackerHTTPClient = &http.Client{Timeout: 30 * time.Second}
@@ -32,6 +34,58 @@ type agentFailureFeedback struct {
 	AgentStatusError string
 	Failure          agentFailureMessage
 	ClawID           string
+	JiraTracker      workspaceIssueTracker
+}
+
+// workflowIssueRef contains the tracker-native identity needed to report workflow failures.
+type workflowIssueRef struct {
+	Integration, IssueID, LinearIdentifier, GitHubRepo string
+	GitHubIssueNum                                     int
+	JiraTracker                                        workspaceIssueTracker
+}
+
+func (s *Server) notifyWorkflowCreateFailure(workspace *types.WorkspaceConfig, workflow *types.WorkflowConfig, ref workflowIssueRef, actor triggerActor, createErr error) {
+	if workspace == nil || workflow == nil || workflow.Trigger == nil {
+		return
+	}
+	f := agentFailureFeedback{Integration: ref.Integration, IssueID: ref.IssueID, LinearIdentifier: ref.LinearIdentifier, GitHubRepo: ref.GitHubRepo, GitHubIssueNum: ref.GitHubIssueNum, JiraTracker: ref.JiraTracker, TriggerActor: actor, Failure: classifyAgentFailure(createErr.Error())}
+	var token string
+	switch ref.Integration {
+	case "linear":
+		if workflow.Trigger.Linear == nil {
+			return
+		}
+		token = s.resolveLinearTokenForWorkflow(workspace.Name, workflow)
+		f.AgentStatusError = strings.TrimSpace(workflow.Trigger.Linear.AgentStatusError)
+	case "github-issues":
+		if workflow.Trigger.GitHubIssues == nil {
+			return
+		}
+		token = s.resolveGitHubIssuesTokenForWorkflow(workspace.Name, workflow)
+		f.AgentStatusError = strings.TrimSpace(workflow.Trigger.GitHubIssues.AgentStatusError)
+	case "shortcut":
+		if workflow.Trigger.Shortcut == nil {
+			return
+		}
+		token = s.resolveShortcutTokenForWorkflow(workspace.Name, workflow)
+		f.AgentStatusError = strings.TrimSpace(workflow.Trigger.Shortcut.AgentStatusError)
+	case "jira":
+		if workflow.Trigger.Jira == nil {
+			return
+		}
+		if f.JiraTracker.Token == "" {
+			f.JiraTracker, _ = s.resolveJiraTrackerForWorkflow(workspace.Name, workflow)
+		}
+		token = f.JiraTracker.Token
+		f.AgentStatusError = strings.TrimSpace(workflow.Trigger.Jira.AgentStatusError)
+	default:
+		return
+	}
+	if token == "" {
+		log.Printf("[agent-failure-feedback] workflow %s/%s has no %s token; skipping failure feedback", workspace.Name, workflow.Name, ref.Integration)
+		return
+	}
+	s.handleAgentFailureFeedback(f, token)
 }
 
 type linearGraphQLError struct {
@@ -54,7 +108,9 @@ func (s *Server) handleAgentFailureFeedback(feedback agentFailureFeedback, token
 			log.Printf("[agent-failure-feedback] failed to comment GitHub issue %s#%d: %v", feedback.GitHubRepo, feedback.GitHubIssueNum, err)
 		}
 		if feedback.AgentStatusError != "" {
-			if err := githubAPIAddLabel(base, feedback.GitHubRepo, feedback.GitHubIssueNum, feedback.AgentStatusError, token); err != nil {
+			if err := s.retryTrackerMove("mark GitHub issue", func() error {
+				return githubAPIAddLabel(base, feedback.GitHubRepo, feedback.GitHubIssueNum, feedback.AgentStatusError, token)
+			}); err != nil {
 				log.Printf("[agent-failure-feedback] failed to mark GitHub issue %s#%d with label %q: %v", feedback.GitHubRepo, feedback.GitHubIssueNum, feedback.AgentStatusError, err)
 			}
 		}
@@ -68,7 +124,9 @@ func (s *Server) handleAgentFailureFeedback(feedback agentFailureFeedback, token
 			log.Printf("[agent-failure-feedback] failed to comment Linear issue %s: %v", feedback.LinearIdentifier, err)
 		}
 		if feedback.AgentStatusError != "" {
-			if err := s.moveLinearIssueOnServer(token, feedback.LinearIdentifier, feedback.AgentStatusError); err != nil {
+			if err := s.retryTrackerMove("move Linear issue", func() error {
+				return s.moveLinearIssueOnServer(token, feedback.LinearIdentifier, feedback.AgentStatusError)
+			}); err != nil {
 				log.Printf("[agent-failure-feedback] failed to mark Linear issue %s with status %q: %v", feedback.LinearIdentifier, feedback.AgentStatusError, err)
 			}
 		}
@@ -77,7 +135,52 @@ func (s *Server) handleAgentFailureFeedback(feedback agentFailureFeedback, token
 				log.Printf("[agent-failure-feedback] failed to assign Linear issue %s to %q: %v", feedback.LinearIdentifier, feedback.TriggerActor.ID, err)
 			}
 		}
+	case "shortcut":
+		if err := commentShortcutIssue(s.resolveShortcutBaseURL(), token, feedback.IssueID, comment); err != nil {
+			log.Printf("[agent-failure-feedback] failed to comment Shortcut story %s: %v", feedback.IssueID, err)
+		}
+		if feedback.AgentStatusError != "" {
+			if err := s.retryTrackerMove("move Shortcut story", func() error {
+				return moveShortcutStory(s.resolveShortcutBaseURL(), token, feedback.IssueID, feedback.AgentStatusError)
+			}); err != nil {
+				log.Printf("[agent-failure-feedback] failed to mark Shortcut story %s: %v", feedback.IssueID, err)
+			}
+		}
+	case "jira":
+		if err := s.commentJiraIssue(feedback.JiraTracker, feedback.IssueID, comment); err != nil {
+			log.Printf("[agent-failure-feedback] failed to comment Jira issue %s: %v", feedback.IssueID, err)
+		}
+		if feedback.AgentStatusError != "" {
+			if err := s.retryTrackerMove("move Jira issue", func() error {
+				return s.moveJiraIssue(feedback.JiraTracker, feedback.IssueID, feedback.AgentStatusError)
+			}); err != nil {
+				log.Printf("[agent-failure-feedback] failed to mark Jira issue %s: %v", feedback.IssueID, err)
+			}
+		}
 	}
+}
+
+func (s *Server) retryTrackerMove(op string, fn func() error) error {
+	var err error
+	for attempt := 0; attempt < 3; attempt++ {
+		if err = fn(); err == nil {
+			return nil
+		}
+		log.Printf("[tracker-move] %s attempt %d/3 failed: %v", op, attempt+1, err)
+		if attempt < 2 {
+			d := time.Duration(0)
+			if s.trackerMoveBackoff != nil {
+				d = s.trackerMoveBackoff(attempt)
+			} else if attempt == 0 {
+				d = time.Second
+			} else {
+				d = 4 * time.Second
+			}
+			time.Sleep(d)
+		}
+	}
+	log.Printf("[tracker-move] giving up %s after 3 attempts", op)
+	return err
 }
 
 func (s *Server) triggerActorForClaw(clawID string) triggerActor {

--- a/pkg/hub/agent_failure_feedback_test.go
+++ b/pkg/hub/agent_failure_feedback_test.go
@@ -283,6 +283,14 @@ func TestCommentWorkflowAgentStopToTrackerHandlesMissingTriggerConfig(t *testing
 	}
 }
 
+func TestFailureFeedbackWorkflowIntegrationsIncludeShortcut(t *testing.T) {
+	for _, integration := range []string{"github-issues", "linear", "shortcut", "jira"} {
+		if !isFailureFeedbackWorkflowIntegration(integration) {
+			t.Errorf("isFailureFeedbackWorkflowIntegration(%q) = false, want true", integration)
+		}
+	}
+}
+
 func TestAssignLinearIssueReportsGraphQLErrors(t *testing.T) {
 	srv := newAssignLinearIssueMock(t, func(w http.ResponseWriter) {
 		json.NewEncoder(w).Encode(map[string]interface{}{

--- a/pkg/hub/agent_failure_feedback_test.go
+++ b/pkg/hub/agent_failure_feedback_test.go
@@ -105,6 +105,156 @@ func TestBuildAgentFailureFeedbackCommentDoesNotClaimBotAssignment(t *testing.T)
 	}
 }
 
+// Keep all tracker-specific create-failure feedback assertions at the shared
+// notifier boundary: it is used by both webhook and poll paths.
+func TestWorkflowPollCreateFailureFeedbackMovesAndComments(t *testing.T) {
+	for _, tc := range []struct {
+		name, integration string
+		configure         func(*types.WorkflowTrigger)
+		ref               workflowIssueRef
+	}{
+		{"linear", "linear", func(tr *types.WorkflowTrigger) { tr.Linear = &types.LinearWorkflowTrigger{AgentStatusError: "Error"} }, workflowIssueRef{Integration: "linear", IssueID: "ELA-1", LinearIdentifier: "ELA-1"}},
+		{"shortcut", "shortcut", func(tr *types.WorkflowTrigger) {
+			tr.Shortcut = &types.ShortcutWorkflowTrigger{AgentStatusError: "Error"}
+		}, workflowIssueRef{Integration: "shortcut", IssueID: "sc-1"}},
+		{"github", "github-issues", func(tr *types.WorkflowTrigger) {
+			tr.GitHubIssues = &types.GitHubIssuesWorkflowTrigger{AgentStatusError: "Error"}
+		}, workflowIssueRef{Integration: "github-issues", IssueID: "acme/repo/1", GitHubRepo: "acme/repo", GitHubIssueNum: 1}},
+		{"jira", "jira", func(tr *types.WorkflowTrigger) { tr.Jira = &types.JiraWorkflowTrigger{AgentStatusError: "Error"} }, workflowIssueRef{Integration: "jira", IssueID: "PROJ-1"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+			tracker := newFailureFeedbackTracker(t)
+			s, _ := NewTestServerWithConfig(t, &types.HubConfig{}, tracker.URL, tracker.URL, tracker.URL)
+			s.jiraBaseURL = tracker.URL
+			s.trackerMoveBackoff = func(int) time.Duration { return 0 }
+			workflow := &types.WorkflowConfig{Name: "workflow", Integration: tc.integration, TriggerStatus: "In Progress", Trigger: &types.WorkflowTrigger{}}
+			tc.configure(workflow.Trigger)
+			workspace := &types.WorkspaceConfig{Name: "workspace"}
+			SaveWorkspaceForTest(t, workspace, []*types.WorkflowConfig{workflow})
+			if tc.integration == "jira" {
+				SaveWorkspaceIssueTrackerWithBaseForTest(t, "workspace", "jira", "default", tracker.URL, "user", "token", "")
+			} else {
+				SaveWorkspaceIssueTrackerForTest(t, "workspace", tc.integration, "default", "token", "")
+			}
+			if tc.integration == "jira" {
+				tc.ref.JiraTracker = workspaceIssueTracker{BaseURL: tracker.URL, Username: "user", Token: "token"}
+			}
+			s.notifyWorkflowCreateFailure(workspace, workflow, tc.ref, triggerActor{}, fmt.Errorf("Bootstrap failed: HTTP 500"))
+			if tracker.comments != 1 || tracker.moves != 1 {
+				t.Fatalf("comments=%d moves=%d, want one of each", tracker.comments, tracker.moves)
+			}
+		})
+	}
+}
+
+func TestJiraWebhookCreateFailureFeedbackMovesAndComments(t *testing.T) {
+	// Jira carries its resolved tracker into the shared notifier.
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	tracker := newFailureFeedbackTracker(t)
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{}, "", "", "")
+	s.jiraBaseURL, s.trackerMoveBackoff = tracker.URL, func(int) time.Duration { return 0 }
+	w := &types.WorkflowConfig{Name: "jira", Integration: "jira", Trigger: &types.WorkflowTrigger{Jira: &types.JiraWorkflowTrigger{AgentStatusError: "Error"}}}
+	ws := &types.WorkspaceConfig{Name: "workspace"}
+	SaveWorkspaceForTest(t, ws, []*types.WorkflowConfig{w})
+	SaveWorkspaceIssueTrackerWithBaseForTest(t, "workspace", "jira", "default", tracker.URL, "user", "token", "")
+	s.notifyWorkflowCreateFailure(ws, w, workflowIssueRef{Integration: "jira", IssueID: "PROJ-1", JiraTracker: workspaceIssueTracker{BaseURL: tracker.URL, Username: "user", Token: "token"}}, triggerActor{}, fmt.Errorf("Bootstrap failed"))
+	if tracker.comments != 1 || tracker.moves != 1 {
+		t.Fatalf("comments=%d moves=%d, want one of each", tracker.comments, tracker.moves)
+	}
+}
+
+func TestFactoryAgentStopMovesOnlyWhenErrorStatusConfigured(t *testing.T) {
+	for _, tc := range []struct {
+		name, status string
+		wantMoves    int
+	}{{"configured", "Error", 1}, {"unset", "", 0}} {
+		t.Run(tc.name, func(t *testing.T) {
+			tracker := newFailureFeedbackTracker(t)
+			s, _ := NewTestServerWithConfig(t, &types.HubConfig{Integrations: &types.IntegrationsConfig{Jira: []*types.JiraIntegrationConfig{{Workspace: "workspace", BaseURL: tracker.URL, Token: "token"}}}}, "", "", "")
+			s.trackerMoveBackoff = func(int) time.Duration { return 0 }
+			s.commentAgentStopToTracker("claw", &types.FactoryConfig{Integration: "jira", Workspace: "workspace", AgentStatusError: tc.status}, "PROJ-1", "failed")
+			if tracker.comments != 1 || tracker.moves != tc.wantMoves {
+				t.Fatalf("comments=%d moves=%d, want 1/%d", tracker.comments, tracker.moves, tc.wantMoves)
+			}
+		})
+	}
+}
+
+func TestRetryTrackerMove(t *testing.T) {
+	for _, tc := range []struct {
+		name                string
+		failures, wantCalls int
+		wantErr             bool
+	}{{"succeeds third attempt", 2, 3, false}, {"gives up", 3, 3, true}} {
+		t.Run(tc.name, func(t *testing.T) {
+			s, _ := NewTestServerWithConfig(t, &types.HubConfig{}, "", "", "")
+			s.trackerMoveBackoff = func(int) time.Duration { return 0 }
+			calls := 0
+			err := s.retryTrackerMove("test", func() error {
+				calls++
+				if calls <= tc.failures {
+					return fmt.Errorf("no")
+				}
+				return nil
+			})
+			if calls != tc.wantCalls || (err != nil) != tc.wantErr {
+				t.Fatalf("calls=%d err=%v", calls, err)
+			}
+		})
+	}
+}
+
+type failureFeedbackTracker struct {
+	*httptest.Server
+	comments, moves int
+}
+
+func newFailureFeedbackTracker(t *testing.T) *failureFeedbackTracker {
+	t.Helper()
+	m := &failureFeedbackTracker{}
+	m.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/graphql":
+			var q struct {
+				Query string `json:"query"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&q)
+			if strings.Contains(q.Query, "commentCreate") {
+				m.comments++
+				json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"commentCreate": map[string]any{"success": true}}})
+				return
+			}
+			if strings.Contains(q.Query, "issueUpdate") {
+				m.moves++
+				json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"issueUpdate": map[string]any{"success": true}}})
+				return
+			}
+			json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"issue": map[string]any{"id": "id", "team": map[string]any{"states": map[string]any{"nodes": []map[string]string{{"id": "state", "name": "Error"}}}}}}})
+		case strings.Contains(r.URL.Path, "/comments") || strings.HasSuffix(r.URL.Path, "/comment"):
+			m.comments++
+			w.WriteHeader(http.StatusCreated)
+		case strings.HasSuffix(r.URL.Path, "/labels"):
+			m.moves++
+			json.NewEncoder(w).Encode([]string{"Error"})
+		case strings.HasSuffix(r.URL.Path, "/transitions") && r.Method == http.MethodGet:
+			json.NewEncoder(w).Encode(map[string]any{"transitions": []map[string]any{{"id": "1", "name": "Error", "to": map[string]string{"name": "Error"}}}})
+		case strings.HasSuffix(r.URL.Path, "/transitions"):
+			m.moves++
+			w.WriteHeader(http.StatusNoContent)
+		case r.URL.Path == "/api/v3/workflows":
+			json.NewEncoder(w).Encode([]map[string]any{{"states": []map[string]any{{"id": float64(1), "name": "Error"}}}})
+		case strings.Contains(r.URL.Path, "/api/v3/stories/") && r.Method == http.MethodPut:
+			m.moves++
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(m.Close)
+	return m
+}
+
 func TestCommentWorkflowAgentStopToTrackerHandlesMissingTriggerConfig(t *testing.T) {
 	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
 	ghi := newStopFeedbackGitHubMock(t)

--- a/pkg/hub/agent_failure_feedback_test.go
+++ b/pkg/hub/agent_failure_feedback_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -141,9 +142,7 @@ func TestWorkflowPollCreateFailureFeedbackMovesAndComments(t *testing.T) {
 				tc.ref.JiraTracker = workspaceIssueTracker{BaseURL: tracker.URL, Username: "user", Token: "token"}
 			}
 			s.notifyWorkflowCreateFailure(workspace, workflow, tc.ref, triggerActor{}, fmt.Errorf("Bootstrap failed: HTTP 500"))
-			if tracker.comments != 1 || tracker.moves != 1 {
-				t.Fatalf("comments=%d moves=%d, want one of each", tracker.comments, tracker.moves)
-			}
+			tracker.waitForCounts(t, 1, 1)
 		})
 	}
 }
@@ -159,9 +158,7 @@ func TestJiraWebhookCreateFailureFeedbackMovesAndComments(t *testing.T) {
 	SaveWorkspaceForTest(t, ws, []*types.WorkflowConfig{w})
 	SaveWorkspaceIssueTrackerWithBaseForTest(t, "workspace", "jira", "default", tracker.URL, "user", "token", "")
 	s.notifyWorkflowCreateFailure(ws, w, workflowIssueRef{Integration: "jira", IssueID: "PROJ-1", JiraTracker: workspaceIssueTracker{BaseURL: tracker.URL, Username: "user", Token: "token"}}, triggerActor{}, fmt.Errorf("Bootstrap failed"))
-	if tracker.comments != 1 || tracker.moves != 1 {
-		t.Fatalf("comments=%d moves=%d, want one of each", tracker.comments, tracker.moves)
-	}
+	tracker.waitForCounts(t, 1, 1)
 }
 
 func TestFactoryAgentStopMovesOnlyWhenErrorStatusConfigured(t *testing.T) {
@@ -174,8 +171,8 @@ func TestFactoryAgentStopMovesOnlyWhenErrorStatusConfigured(t *testing.T) {
 			s, _ := NewTestServerWithConfig(t, &types.HubConfig{Integrations: &types.IntegrationsConfig{Jira: []*types.JiraIntegrationConfig{{Workspace: "workspace", BaseURL: tracker.URL, Token: "token"}}}}, "", "", "")
 			s.trackerMoveBackoff = func(int) time.Duration { return 0 }
 			s.commentAgentStopToTracker("claw", &types.FactoryConfig{Integration: "jira", Workspace: "workspace", AgentStatusError: tc.status}, "PROJ-1", "failed")
-			if tracker.comments != 1 || tracker.moves != tc.wantMoves {
-				t.Fatalf("comments=%d moves=%d, want 1/%d", tracker.comments, tracker.moves, tc.wantMoves)
+			if c, m := tracker.comments.Load(), tracker.moves.Load(); c != 1 || m != int64(tc.wantMoves) {
+				t.Fatalf("comments=%d moves=%d, want 1/%d", c, m, tc.wantMoves)
 			}
 		})
 	}
@@ -185,8 +182,15 @@ func TestRetryTrackerMove(t *testing.T) {
 	for _, tc := range []struct {
 		name                string
 		failures, wantCalls int
+		errMsg              string
 		wantErr             bool
-	}{{"succeeds third attempt", 2, 3, false}, {"gives up", 3, 3, true}} {
+	}{
+		{"succeeds third attempt", 2, 3, "temporary", false},
+		{"gives up", 3, 3, "temporary", true},
+		{"fails fast on permanent API error", 3, 1, "jira transition API error 404: gone", true},
+		{"fails fast on missing entity", 3, 1, "issue or state not found", true},
+		{"retries rate limiting", 3, 3, "github API error 429: slow down", true},
+	} {
 		t.Run(tc.name, func(t *testing.T) {
 			s, _ := NewTestServerWithConfig(t, &types.HubConfig{}, "", "", "")
 			s.trackerMoveBackoff = func(int) time.Duration { return 0 }
@@ -194,7 +198,7 @@ func TestRetryTrackerMove(t *testing.T) {
 			err := s.retryTrackerMove("test", func() error {
 				calls++
 				if calls <= tc.failures {
-					return fmt.Errorf("no")
+					return fmt.Errorf("%s", tc.errMsg)
 				}
 				return nil
 			})
@@ -207,7 +211,24 @@ func TestRetryTrackerMove(t *testing.T) {
 
 type failureFeedbackTracker struct {
 	*httptest.Server
-	comments, moves int
+	comments, moves atomic.Int64
+}
+
+// waitForCounts polls until the tracker has received the expected number of
+// comment and move calls; feedback delivery runs on its own goroutine.
+func (m *failureFeedbackTracker) waitForCounts(t *testing.T, wantComments, wantMoves int64) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		c, mv := m.comments.Load(), m.moves.Load()
+		if c == wantComments && mv == wantMoves {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("comments=%d moves=%d, want %d/%d", c, mv, wantComments, wantMoves)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 }
 
 func newFailureFeedbackTracker(t *testing.T) *failureFeedbackTracker {
@@ -221,31 +242,31 @@ func newFailureFeedbackTracker(t *testing.T) *failureFeedbackTracker {
 			}
 			_ = json.NewDecoder(r.Body).Decode(&q)
 			if strings.Contains(q.Query, "commentCreate") {
-				m.comments++
+				m.comments.Add(1)
 				json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"commentCreate": map[string]any{"success": true}}})
 				return
 			}
 			if strings.Contains(q.Query, "issueUpdate") {
-				m.moves++
+				m.moves.Add(1)
 				json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"issueUpdate": map[string]any{"success": true}}})
 				return
 			}
 			json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"issue": map[string]any{"id": "id", "team": map[string]any{"states": map[string]any{"nodes": []map[string]string{{"id": "state", "name": "Error"}}}}}}})
 		case strings.Contains(r.URL.Path, "/comments") || strings.HasSuffix(r.URL.Path, "/comment"):
-			m.comments++
+			m.comments.Add(1)
 			w.WriteHeader(http.StatusCreated)
 		case strings.HasSuffix(r.URL.Path, "/labels"):
-			m.moves++
+			m.moves.Add(1)
 			json.NewEncoder(w).Encode([]string{"Error"})
 		case strings.HasSuffix(r.URL.Path, "/transitions") && r.Method == http.MethodGet:
 			json.NewEncoder(w).Encode(map[string]any{"transitions": []map[string]any{{"id": "1", "name": "Error", "to": map[string]string{"name": "Error"}}}})
 		case strings.HasSuffix(r.URL.Path, "/transitions"):
-			m.moves++
+			m.moves.Add(1)
 			w.WriteHeader(http.StatusNoContent)
 		case r.URL.Path == "/api/v3/workflows":
 			json.NewEncoder(w).Encode([]map[string]any{{"states": []map[string]any{{"id": float64(1), "name": "Error"}}}})
 		case strings.Contains(r.URL.Path, "/api/v3/stories/") && r.Method == http.MethodPut:
-			m.moves++
+			m.moves.Add(1)
 			w.WriteHeader(http.StatusOK)
 		default:
 			http.NotFound(w, r)

--- a/pkg/hub/github_issues.go
+++ b/pkg/hub/github_issues.go
@@ -399,23 +399,7 @@ func (s *Server) processGitHubIssuesWorkflowEvent(workspaces []*types.WorkspaceC
 }
 
 func (s *Server) notifyGitHubIssueWorkflowCreateFailure(workspace *types.WorkspaceConfig, workflow *types.WorkflowConfig, payload githubIssuesWebhookPayload, createErr error) {
-	if workspace == nil || workflow == nil || workflow.Trigger == nil || workflow.Trigger.GitHubIssues == nil {
-		return
-	}
-	token := s.resolveGitHubIssuesTokenForWorkflow(workspace.Name, workflow)
-	if token == "" {
-		log.Printf("[agent-failure-feedback] workflow %s/%s has no GitHub Issues token; skipping failure feedback", workspace.Name, workflow.Name)
-		return
-	}
-	s.handleAgentFailureFeedback(agentFailureFeedback{
-		Integration:      "github-issues",
-		IssueID:          fmt.Sprintf("%s/%d", payload.Repository.FullName, payload.Issue.Number),
-		GitHubRepo:       payload.Repository.FullName,
-		GitHubIssueNum:   payload.Issue.Number,
-		TriggerActor:     triggerActor{Login: payload.Sender.Login, Type: payload.Sender.Type},
-		AgentStatusError: strings.TrimSpace(workflow.Trigger.GitHubIssues.AgentStatusError),
-		Failure:          classifyAgentFailure(createErr.Error()),
-	}, token)
+	s.notifyWorkflowCreateFailure(workspace, workflow, workflowIssueRef{Integration: "github-issues", IssueID: fmt.Sprintf("%s/%d", payload.Repository.FullName, payload.Issue.Number), GitHubRepo: payload.Repository.FullName, GitHubIssueNum: payload.Issue.Number}, triggerActor{Login: payload.Sender.Login, Type: payload.Sender.Type}, createErr)
 }
 
 func githubIssuesWorkflowTriggerMatches(trigger *types.WorkflowTrigger, payload githubIssuesWebhookPayload, currentStatus string, issueLabels map[string]bool) bool {

--- a/pkg/hub/integration_poller.go
+++ b/pkg/hub/integration_poller.go
@@ -395,6 +395,7 @@ func (s *Server) processLinearWorkflowPollItem(issue linearPollIssue, targets []
 		log.Printf("[workflow:%s/%s] Linear issue %s matched workflow trigger via poll — creating claw", workspace.Name, workflow.Name, entityID)
 		if err := s.createClawForLinearWorkflow(workspace, workflow, payload, "poll"); err != nil {
 			log.Printf("[workflow:%s/%s] failed to create claw for %s via poll: %v", workspace.Name, workflow.Name, entityID, err)
+			s.notifyWorkflowCreateFailure(workspace, workflow, workflowIssueRef{Integration: "linear", IssueID: entityID, LinearIdentifier: entityID}, triggerActor{}, err)
 		}
 	}
 }
@@ -687,6 +688,7 @@ func (s *Server) processShortcutWorkflowPollItem(story shortcutPollStory, target
 		log.Printf("[workflow:%s/%s] Shortcut story %s matched workflow trigger via poll — creating claw", workspace.Name, workflow.Name, storyID)
 		if err := s.createClawForShortcutWorkflow(workspace, workflow, action, storyID, "poll"); err != nil {
 			log.Printf("[workflow:%s/%s] failed to create claw for %s via poll: %v", workspace.Name, workflow.Name, storyID, err)
+			s.notifyWorkflowCreateFailure(workspace, workflow, workflowIssueRef{Integration: "shortcut", IssueID: storyID}, triggerActor{}, err)
 		}
 	}
 }
@@ -1035,6 +1037,8 @@ func (s *Server) processGitHubIssueWorkflowPollItem(issue githubIssuesPollItem, 
 				continue
 			}
 			log.Printf("[workflow:%s/%s] failed to create claw for %s via poll: %v", workspace.Name, workflow.Name, issueID, err)
+			repo, num, _ := parseGitHubIssueWorkflowID(issueID)
+			s.notifyWorkflowCreateFailure(workspace, workflow, workflowIssueRef{Integration: "github-issues", IssueID: issueID, GitHubRepo: repo, GitHubIssueNum: num}, triggerActor{}, err)
 		}
 	}
 }
@@ -1396,6 +1400,8 @@ func (s *Server) processJiraWorkflowPollItem(issue jiraPollIssue, targets []jira
 				continue
 			}
 			log.Printf("[workflow:%s/%s] failed to create claw for Jira issue %s via poll: %v", workspace.Name, workflow.Name, issue.Key, err)
+			tracker, _ := s.resolveJiraTrackerForWorkflow(workspace.Name, workflow)
+			s.notifyWorkflowCreateFailure(workspace, workflow, workflowIssueRef{Integration: "jira", IssueID: issue.Key, JiraTracker: tracker}, triggerActor{}, err)
 		}
 	}
 }

--- a/pkg/hub/jira.go
+++ b/pkg/hub/jira.go
@@ -361,6 +361,8 @@ func (s *Server) processJiraWorkflowEvent(workspaces []*types.WorkspaceConfig, p
 					continue
 				}
 				log.Printf("[workflow:%s/%s] failed to create claw for Jira issue %s: %v", workspace.Name, workflow.Name, payload.Issue.Key, err)
+				tracker, _ := s.resolveJiraTrackerForWorkflow(workspace.Name, workflow)
+				s.notifyWorkflowCreateFailure(workspace, workflow, workflowIssueRef{Integration: "jira", IssueID: payload.Issue.Key, JiraTracker: tracker}, triggerActor{}, err)
 			}
 		}
 		for _, workflow := range workspace.Workflows {

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -1271,60 +1271,10 @@ func (s *Server) handleClawDoneSignal(clawID, rawMessage string) {
 		targetStatus = factory.DoneStatus
 	}
 	if !pipelineHandledDone && targetStatus != "" {
-		switch factory.Integration {
-		case "jira":
-			if tracker, ok := s.resolveJiraTrackerForFactory(factory); ok {
-				if err := s.retryTrackerMove("move Jira issue", func() error { return s.moveJiraIssue(tracker, issueID, targetStatus) }); err != nil {
-					log.Printf("[factory] failed to move Jira issue %s to '%s': %v", issueID, targetStatus, err)
-				} else {
-					log.Printf("[factory] moved Jira issue %s to '%s'", issueID, targetStatus)
-				}
-			}
-		case "shortcut":
-			// Shortcut story
-			scToken := s.resolveShortcutToken(factory.Workspace)
-			if scToken != "" {
-				if err := s.retryTrackerMove("move Shortcut story", func() error { return moveShortcutStory(s.resolveShortcutBaseURL(), scToken, issueID, targetStatus) }); err != nil {
-					log.Printf("[factory] failed to move story %s to '%s': %v", issueID, targetStatus, err)
-				} else {
-					log.Printf("[factory] moved story %s to '%s'", issueID, targetStatus)
-				}
-			}
-		case "github-issues":
-			// GitHub issue
-			ghToken := s.resolveGitHubIssuesTokenForFactory(factory)
-			if ghToken != "" {
-				// Parse gh-owner/repo/number from issueID
-				rest := strings.TrimPrefix(issueID, "gh-")
-				lastSlash := strings.LastIndex(rest, "/")
-				if lastSlash > 0 {
-					repo := rest[:lastSlash]
-					issueNumStr := rest[lastSlash+1:]
-					var issueNum int
-					if _, err := fmt.Sscanf(issueNumStr, "%d", &issueNum); err == nil {
-						base := s.githubBaseURL
-						if base == "" {
-							base = "https://api.github.com"
-						}
-						if err := s.retryTrackerMove("move GitHub issue", func() error { return moveGitHubIssue(ghToken, repo, issueNum, targetStatus, base) }); err != nil {
-							log.Printf("[factory] failed to move GitHub issue %s to '%s': %v", issueID, targetStatus, err)
-						} else {
-							log.Printf("[factory] moved GitHub issue %s to '%s'", issueID, targetStatus)
-						}
-					}
-				}
-			}
-		default:
-			// Linear issue
-			linearToken := s.resolveLinearTokenForFactory(factory)
-			if linearToken != "" {
-				if err := s.retryTrackerMove("move Linear issue", func() error { return s.moveLinearIssueOnServer(linearToken, issueID, targetStatus) }); err != nil {
-					log.Printf("[factory] failed to move issue %s to '%s': %v", issueID, targetStatus, err)
-				} else {
-					log.Printf("[factory] moved issue %s to '%s'", issueID, targetStatus)
-				}
-			}
-		}
+		// The move is retried with backoff; run it off the done-signal path so
+		// a slow or failing tracker cannot delay marking the claw idle.
+		factoryCopy := *factory
+		go s.moveFactoryIssueToStatus(&factoryCopy, issueID, targetStatus)
 	}
 
 	// Keep the claw running — it stays connected to watch for CI failures,
@@ -1367,6 +1317,65 @@ func (s *Server) handleClawDoneSignal(clawID, rawMessage string) {
 			issueTracker = "Linear issue"
 		}
 		s.injectUserMessage(clawID, fmt.Sprintf("PR created and %s updated. Staying connected to watch for CI failures and review comments. Will terminate when PR is merged; if it is closed without merge, I'll notify you and decide next steps.", issueTracker))
+	}
+}
+
+// moveFactoryIssueToStatus moves a factory-tracked issue to the given
+// tracker status, retrying with backoff on failure.
+func (s *Server) moveFactoryIssueToStatus(factory *types.FactoryConfig, issueID, targetStatus string) {
+	switch factory.Integration {
+	case "jira":
+		if tracker, ok := s.resolveJiraTrackerForFactory(factory); ok {
+			if err := s.retryTrackerMove("move Jira issue", func() error { return s.moveJiraIssue(tracker, issueID, targetStatus) }); err != nil {
+				log.Printf("[factory] failed to move Jira issue %s to '%s': %v", issueID, targetStatus, err)
+			} else {
+				log.Printf("[factory] moved Jira issue %s to '%s'", issueID, targetStatus)
+			}
+		}
+	case "shortcut":
+		// Shortcut story
+		scToken := s.resolveShortcutToken(factory.Workspace)
+		if scToken != "" {
+			if err := s.retryTrackerMove("move Shortcut story", func() error { return moveShortcutStory(s.resolveShortcutBaseURL(), scToken, issueID, targetStatus) }); err != nil {
+				log.Printf("[factory] failed to move story %s to '%s': %v", issueID, targetStatus, err)
+			} else {
+				log.Printf("[factory] moved story %s to '%s'", issueID, targetStatus)
+			}
+		}
+	case "github-issues":
+		// GitHub issue
+		ghToken := s.resolveGitHubIssuesTokenForFactory(factory)
+		if ghToken != "" {
+			// Parse gh-owner/repo/number from issueID
+			rest := strings.TrimPrefix(issueID, "gh-")
+			lastSlash := strings.LastIndex(rest, "/")
+			if lastSlash > 0 {
+				repo := rest[:lastSlash]
+				issueNumStr := rest[lastSlash+1:]
+				var issueNum int
+				if _, err := fmt.Sscanf(issueNumStr, "%d", &issueNum); err == nil {
+					base := s.githubBaseURL
+					if base == "" {
+						base = "https://api.github.com"
+					}
+					if err := s.retryTrackerMove("move GitHub issue", func() error { return moveGitHubIssue(ghToken, repo, issueNum, targetStatus, base) }); err != nil {
+						log.Printf("[factory] failed to move GitHub issue %s to '%s': %v", issueID, targetStatus, err)
+					} else {
+						log.Printf("[factory] moved GitHub issue %s to '%s'", issueID, targetStatus)
+					}
+				}
+			}
+		}
+	default:
+		// Linear issue
+		linearToken := s.resolveLinearTokenForFactory(factory)
+		if linearToken != "" {
+			if err := s.retryTrackerMove("move Linear issue", func() error { return s.moveLinearIssueOnServer(linearToken, issueID, targetStatus) }); err != nil {
+				log.Printf("[factory] failed to move issue %s to '%s': %v", issueID, targetStatus, err)
+			} else {
+				log.Printf("[factory] moved issue %s to '%s'", issueID, targetStatus)
+			}
+		}
 	}
 }
 

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -412,28 +412,13 @@ func (s *Server) processLinearWorkflowEvent(workspaces []*types.WorkspaceConfig,
 }
 
 func (s *Server) notifyLinearWorkflowCreateFailure(workspace *types.WorkspaceConfig, workflow *types.WorkflowConfig, payload linearWebhookPayload, createErr error) {
-	if workspace == nil || workflow == nil || workflow.Trigger == nil || workflow.Trigger.Linear == nil {
-		return
-	}
-	token := s.resolveLinearTokenForWorkflow(workspace.Name, workflow)
-	if token == "" {
-		log.Printf("[agent-failure-feedback] workflow %s/%s has no Linear token; skipping failure feedback", workspace.Name, workflow.Name)
-		return
-	}
-	s.handleAgentFailureFeedback(agentFailureFeedback{
-		Integration:      "linear",
-		IssueID:          payload.Data.Identifier,
-		LinearIdentifier: payload.Data.Identifier,
-		TriggerActor: triggerActor{
-			ID:    payload.Actor.ID,
-			Type:  payload.Actor.Type,
-			Name:  payload.Actor.Name,
-			Email: payload.Actor.Email,
-			URL:   payload.Actor.URL,
-		},
-		AgentStatusError: strings.TrimSpace(workflow.Trigger.Linear.AgentStatusError),
-		Failure:          classifyAgentFailure(createErr.Error()),
-	}, token)
+	s.notifyWorkflowCreateFailure(workspace, workflow, workflowIssueRef{Integration: "linear", IssueID: payload.Data.Identifier, LinearIdentifier: payload.Data.Identifier}, triggerActor{
+		ID:    payload.Actor.ID,
+		Type:  payload.Actor.Type,
+		Name:  payload.Actor.Name,
+		Email: payload.Actor.Email,
+		URL:   payload.Actor.URL,
+	}, createErr)
 }
 
 func (s *Server) createClawForLinearWorkflow(workspace *types.WorkspaceConfig, workflow *types.WorkflowConfig, payload linearWebhookPayload, reason string) error {
@@ -1289,7 +1274,7 @@ func (s *Server) handleClawDoneSignal(clawID, rawMessage string) {
 		switch factory.Integration {
 		case "jira":
 			if tracker, ok := s.resolveJiraTrackerForFactory(factory); ok {
-				if err := s.moveJiraIssue(tracker, issueID, targetStatus); err != nil {
+				if err := s.retryTrackerMove("move Jira issue", func() error { return s.moveJiraIssue(tracker, issueID, targetStatus) }); err != nil {
 					log.Printf("[factory] failed to move Jira issue %s to '%s': %v", issueID, targetStatus, err)
 				} else {
 					log.Printf("[factory] moved Jira issue %s to '%s'", issueID, targetStatus)
@@ -1299,7 +1284,7 @@ func (s *Server) handleClawDoneSignal(clawID, rawMessage string) {
 			// Shortcut story
 			scToken := s.resolveShortcutToken(factory.Workspace)
 			if scToken != "" {
-				if err := moveShortcutStory(s.resolveShortcutBaseURL(), scToken, issueID, targetStatus); err != nil {
+				if err := s.retryTrackerMove("move Shortcut story", func() error { return moveShortcutStory(s.resolveShortcutBaseURL(), scToken, issueID, targetStatus) }); err != nil {
 					log.Printf("[factory] failed to move story %s to '%s': %v", issueID, targetStatus, err)
 				} else {
 					log.Printf("[factory] moved story %s to '%s'", issueID, targetStatus)
@@ -1321,7 +1306,7 @@ func (s *Server) handleClawDoneSignal(clawID, rawMessage string) {
 						if base == "" {
 							base = "https://api.github.com"
 						}
-						if err := moveGitHubIssue(ghToken, repo, issueNum, targetStatus, base); err != nil {
+						if err := s.retryTrackerMove("move GitHub issue", func() error { return moveGitHubIssue(ghToken, repo, issueNum, targetStatus, base) }); err != nil {
 							log.Printf("[factory] failed to move GitHub issue %s to '%s': %v", issueID, targetStatus, err)
 						} else {
 							log.Printf("[factory] moved GitHub issue %s to '%s'", issueID, targetStatus)
@@ -1333,7 +1318,7 @@ func (s *Server) handleClawDoneSignal(clawID, rawMessage string) {
 			// Linear issue
 			linearToken := s.resolveLinearTokenForFactory(factory)
 			if linearToken != "" {
-				if err := s.moveLinearIssueOnServer(linearToken, issueID, targetStatus); err != nil {
+				if err := s.retryTrackerMove("move Linear issue", func() error { return s.moveLinearIssueOnServer(linearToken, issueID, targetStatus) }); err != nil {
 					log.Printf("[factory] failed to move issue %s to '%s': %v", issueID, targetStatus, err)
 				} else {
 					log.Printf("[factory] moved issue %s to '%s'", issueID, targetStatus)

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -1906,7 +1906,7 @@ func (s *Server) stopAgentTerminalWithReason(clawID, reason string, skipVMTermin
 }
 
 func isFailureFeedbackWorkflowIntegration(integration string) bool {
-	return integration == "github-issues" || integration == "linear" || integration == "jira"
+	return integration == "github-issues" || integration == "linear" || integration == "shortcut" || integration == "jira"
 }
 
 func (s *Server) commentWorkflowAgentStopToTracker(clawID string, ctx pipelineContext, reason string) {
@@ -1945,6 +1945,15 @@ func (s *Server) commentWorkflowAgentStopToTracker(clawID string, ctx pipelineCo
 		feedback.LinearIdentifier = ctx.IssueID
 		if ctx.Workflow.Trigger != nil && ctx.Workflow.Trigger.Linear != nil {
 			feedback.AgentStatusError = strings.TrimSpace(ctx.Workflow.Trigger.Linear.AgentStatusError)
+		}
+		s.handleAgentFailureFeedback(feedback, token)
+	case "shortcut":
+		token := s.resolveShortcutTokenForWorkflow(ctx.Workspace.Name, ctx.Workflow)
+		if token == "" {
+			return
+		}
+		if ctx.Workflow.Trigger != nil && ctx.Workflow.Trigger.Shortcut != nil {
+			feedback.AgentStatusError = strings.TrimSpace(ctx.Workflow.Trigger.Shortcut.AgentStatusError)
 		}
 		s.handleAgentFailureFeedback(feedback, token)
 	case "jira":

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -1955,12 +1955,8 @@ func (s *Server) commentWorkflowAgentStopToTracker(clawID string, ctx pipelineCo
 		if ctx.Workflow.Trigger != nil && ctx.Workflow.Trigger.Jira != nil {
 			feedback.AgentStatusError = strings.TrimSpace(ctx.Workflow.Trigger.Jira.AgentStatusError)
 		}
-		if feedback.AgentStatusError != "" {
-			_ = s.moveJiraIssue(tracker, ctx.IssueID, feedback.AgentStatusError)
-		}
-		if err := s.commentJiraIssue(tracker, ctx.IssueID, s.buildAgentStopComment(clawID, reason)); err != nil {
-			log.Printf("[stopAgent] failed to comment Jira issue %s: %v", ctx.IssueID, err)
-		}
+		feedback.JiraTracker = tracker
+		s.handleAgentFailureFeedback(feedback, tracker.Token)
 	}
 }
 
@@ -1990,6 +1986,11 @@ func (s *Server) commentAgentStopToTracker(clawID string, factory *types.Factory
 	case "linear":
 		token := s.resolveLinearTokenForFactory(factory)
 		if token != "" {
+			if factory.AgentStatusError != "" {
+				if err := s.retryTrackerMove("move Linear issue", func() error { return s.moveLinearIssueOnServer(token, issueID, factory.AgentStatusError) }); err != nil {
+					log.Printf("[stopAgent] failed to move Linear issue %s: %v", issueID, err)
+				}
+			}
 			if err := s.commentLinearIssue(token, issueID, getCommentBody()); err != nil {
 				log.Printf("[stopAgent] failed to comment Linear issue %s: %v", issueID, err)
 			} else {
@@ -1999,6 +2000,13 @@ func (s *Server) commentAgentStopToTracker(clawID string, factory *types.Factory
 	case "shortcut":
 		token := s.resolveShortcutToken(factory.Workspace)
 		if token != "" {
+			if factory.AgentStatusError != "" {
+				if err := s.retryTrackerMove("move Shortcut story", func() error {
+					return moveShortcutStory(s.resolveShortcutBaseURL(), token, issueID, factory.AgentStatusError)
+				}); err != nil {
+					log.Printf("[stopAgent] failed to move Shortcut story %s: %v", issueID, err)
+				}
+			}
 			if err := commentShortcutIssue(s.resolveShortcutBaseURL(), token, issueID, getCommentBody()); err != nil {
 				log.Printf("[stopAgent] failed to comment Shortcut story %s: %v", issueID, err)
 			} else {
@@ -2013,6 +2021,15 @@ func (s *Server) commentAgentStopToTracker(clawID string, factory *types.Factory
 				repo := parts[0] + "/" + parts[1]
 				var issueNum int
 				if _, err := fmt.Sscanf(parts[2], "%d", &issueNum); err == nil {
+					if factory.AgentStatusError != "" {
+						base := s.githubBaseURL
+						if base == "" {
+							base = "https://api.github.com"
+						}
+						if err := s.retryTrackerMove("mark GitHub issue", func() error { return githubAPIAddLabel(base, repo, issueNum, factory.AgentStatusError, token) }); err != nil {
+							log.Printf("[stopAgent] failed to mark GitHub issue %s: %v", issueID, err)
+						}
+					}
 					if err := commentGitHubIssue(token, repo, issueNum, getCommentBody()); err != nil {
 						log.Printf("[stopAgent] failed to comment GitHub issue %s: %v", issueID, err)
 					} else {
@@ -2023,6 +2040,11 @@ func (s *Server) commentAgentStopToTracker(clawID string, factory *types.Factory
 		}
 	case "jira":
 		if tracker, ok := s.resolveJiraTrackerForFactory(factory); ok {
+			if factory.AgentStatusError != "" {
+				if err := s.retryTrackerMove("move Jira issue", func() error { return s.moveJiraIssue(tracker, issueID, factory.AgentStatusError) }); err != nil {
+					log.Printf("[stopAgent] failed to move Jira issue %s: %v", issueID, err)
+				}
+			}
 			if err := s.commentJiraIssue(tracker, issueID, getCommentBody()); err != nil {
 				log.Printf("[stopAgent] failed to comment Jira issue %s: %v", issueID, err)
 			} else {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -75,7 +75,8 @@ type Server struct {
 	// shortcutBaseURL overrides the Shortcut API base for testing (default: https://api.app.shortcut.com)
 	shortcutBaseURL string
 	// jiraBaseURL overrides the Jira API base for testing.
-	jiraBaseURL string
+	jiraBaseURL        string
+	trackerMoveBackoff func(int) time.Duration
 	// fireworksBaseURL overrides the Fireworks API base for testing (default: https://api.fireworks.ai)
 	fireworksBaseURL          string
 	fireworksModelsMu         sync.Mutex

--- a/pkg/hub/shortcut.go
+++ b/pkg/hub/shortcut.go
@@ -385,6 +385,7 @@ func (s *Server) processShortcutWorkflowEvent(workspaces []*types.WorkspaceConfi
 						continue
 					}
 					log.Printf("[workflow:%s/%s] failed to create claw for %s: %v", workspace.Name, workflow.Name, storyID, err)
+					s.notifyWorkflowCreateFailure(workspace, workflow, workflowIssueRef{Integration: "shortcut", IssueID: storyID}, triggerActor{}, err)
 				}
 			}
 		}

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -635,6 +635,7 @@ type FactoryConfig struct {
 	WorkingStatus    string   `yaml:"working_status,omitempty" json:"working_status,omitempty"`         // claw moves issue here when it starts working
 	FinishedStatus   string   `yaml:"finished_status,omitempty" json:"finished_status,omitempty"`       // claw moves issue here when it finishes working
 	DoneStatus       string   `yaml:"done_status,omitempty" json:"done_status,omitempty"`               // claw moves issue here when done (PR merged)
+	AgentStatusError string   `yaml:"agent_status_error,omitempty" json:"agent_status_error,omitempty"` // claw moves issue here when agent stops with an error
 	TerminateOnLeave bool     `yaml:"terminate_on_leave,omitempty" json:"terminate_on_leave,omitempty"` // leaving trigger_status → kill claw
 	Template         string   `yaml:"template" json:"template"`                                         // template name (must be pushed to hub)
 	Provider         string   `yaml:"provider,omitempty" json:"provider,omitempty"`                     // override the default provider for this factory

--- a/pkg/types/workspace.go
+++ b/pkg/types/workspace.go
@@ -140,12 +140,13 @@ type LinearWorkflowTrigger struct {
 }
 
 type ShortcutWorkflowTrigger struct {
-	Event         string   `yaml:"event,omitempty" json:"event,omitempty"`
-	Workspace     string   `yaml:"workspace,omitempty" json:"workspace,omitempty"`
-	States        []string `yaml:"states,omitempty" json:"states,omitempty"`
-	Labels        []string `yaml:"labels,omitempty" json:"labels,omitempty"`
-	ExcludeLabels []string `yaml:"exclude_labels,omitempty" json:"exclude_labels,omitempty"`
-	AssignedTo    string   `yaml:"assigned_to,omitempty" json:"assigned_to,omitempty"`
+	Event            string   `yaml:"event,omitempty" json:"event,omitempty"`
+	Workspace        string   `yaml:"workspace,omitempty" json:"workspace,omitempty"`
+	States           []string `yaml:"states,omitempty" json:"states,omitempty"`
+	Labels           []string `yaml:"labels,omitempty" json:"labels,omitempty"`
+	ExcludeLabels    []string `yaml:"exclude_labels,omitempty" json:"exclude_labels,omitempty"`
+	AssignedTo       string   `yaml:"assigned_to,omitempty" json:"assigned_to,omitempty"`
+	AgentStatusError string   `yaml:"agent_status_error,omitempty" json:"agent_status_error,omitempty"`
 }
 
 type JiraWorkflowTrigger struct {


### PR DESCRIPTION
## Problem

When agent creation or execution failed, only the Linear and GitHub Issues **webhook** paths moved the tracker issue to the configured `agent_status_error` status with a comment. Every other path only wrote to the hub log, leaving issues stuck in "In Progress" with no agent and no signal to the operator:

- All four **poll-path** workflow create failures (Linear, Shortcut, GitHub Issues, Jira) only logged.
- The **Jira webhook** create-failure path had no feedback at all, despite `JiraWorkflowTrigger.AgentStatusError` existing.
- **Factories** had no error-status config; agent-death only commented, and only when a token resolved.
- `handleClawDoneSignal` finished-status move failures were never retried — the board stayed stale even after successful runs.

## Changes

- **Unified notifier**: new `notifyWorkflowCreateFailure` in `pkg/hub/agent_failure_feedback.go` is now the single entry point for every workflow create failure — webhook and poll, all four trackers. `handleAgentFailureFeedback` gained `jira` and `shortcut` support (comment + status move), so the death path (`commentWorkflowAgentStopToTracker`) shares the same format too. `isFactoryTriggerAlreadyClaimed` failures still skip feedback.
- **Shortcut parity**: `ShortcutWorkflowTrigger` gained `agent_status_error`; the Shortcut webhook path and the death-path predicate now include Shortcut (caught by review).
- **Factory error status**: `FactoryConfig` gained `agent_status_error`, honored on agent death — move and comment are attempted independently.
- **Bounded retry**: `retryTrackerMove` (3 attempts, exponential backoff, injectable for tests) wraps every tracker status move, including the `handleClawDoneSignal` finished/done-status moves. Comments and assigns are not retried (non-idempotent).

## Tests

Table-driven tests in `pkg/hub/agent_failure_feedback_test.go` with httptest tracker stubs asserting both the comment and the status-move calls:
- `TestWorkflowPollCreateFailureFeedbackMovesAndComments` (all four trackers)
- `TestJiraWebhookCreateFailureFeedbackMovesAndComments`
- `TestFactoryAgentStopMovesOnlyWhenErrorStatusConfigured`
- `TestRetryTrackerMove` (fails-twice-then-succeeds, and give-up-after-3)
- `TestFailureFeedbackWorkflowIntegrationsIncludeShortcut`

`go build ./...` and `go test ./pkg/hub/... ./pkg/types/...` green.

Follow-up to #488 (liveness audit, P1 operator trust).

🤖 Generated with [Claude Code](https://claude.com/claude-code)