### PR TITLE
fix(hub): atomic, re-drivable terminal claw transitions

### DIFF
--- a/pkg/hub/agent_failure_feedback.go
+++ b/pkg/hub/agent_failure_feedback.go
@@ -38,7 +38,7 @@ type linearGraphQLError struct {
 	Message string `json:"message"`
 }
 
-func (s *Server) handleAgentFailureFeedback(feedback agentFailureFeedback, token string) {
+func (s *Server) handleAgentFailureFeedback(feedback agentFailureFeedback, token string) bool {
 	if feedback.Failure.UserMessage == "" {
 		feedback.Failure = classifyAgentFailure(feedback.Failure.SafeDetail)
 	}
@@ -50,7 +50,8 @@ func (s *Server) handleAgentFailureFeedback(feedback agentFailureFeedback, token
 		if base == "" {
 			base = "https://api.github.com"
 		}
-		if err := commentGitHubIssueWithBase(base, token, feedback.GitHubRepo, feedback.GitHubIssueNum, comment); err != nil {
+		commented := commentGitHubIssueWithBase(base, token, feedback.GitHubRepo, feedback.GitHubIssueNum, comment)
+		if err := commented; err != nil {
 			log.Printf("[agent-failure-feedback] failed to comment GitHub issue %s#%d: %v", feedback.GitHubRepo, feedback.GitHubIssueNum, err)
 		}
 		if feedback.AgentStatusError != "" {
@@ -63,8 +64,10 @@ func (s *Server) handleAgentFailureFeedback(feedback agentFailureFeedback, token
 				log.Printf("[agent-failure-feedback] failed to assign GitHub issue %s#%d to %q: %v", feedback.GitHubRepo, feedback.GitHubIssueNum, feedback.TriggerActor.Login, err)
 			}
 		}
+		return commented == nil
 	case "linear":
-		if err := s.commentLinearIssue(token, feedback.LinearIdentifier, comment); err != nil {
+		commented := s.commentLinearIssue(token, feedback.LinearIdentifier, comment)
+		if err := commented; err != nil {
 			log.Printf("[agent-failure-feedback] failed to comment Linear issue %s: %v", feedback.LinearIdentifier, err)
 		}
 		if feedback.AgentStatusError != "" {
@@ -77,7 +80,9 @@ func (s *Server) handleAgentFailureFeedback(feedback agentFailureFeedback, token
 				log.Printf("[agent-failure-feedback] failed to assign Linear issue %s to %q: %v", feedback.LinearIdentifier, feedback.TriggerActor.ID, err)
 			}
 		}
+		return commented == nil
 	}
+	return false
 }
 
 func (s *Server) triggerActorForClaw(clawID string) triggerActor {

--- a/pkg/hub/cron_scheduler.go
+++ b/pkg/hub/cron_scheduler.go
@@ -364,6 +364,14 @@ func (cs *cronScheduler) finishRunByClawID(clawID, status, result string) {
 		log.Printf("[cron] failed to finish run for claw %s: %v", clawID, err)
 	}
 
+	cs.releaseClawWorkflowSlot(clawID)
+}
+
+// releaseClawWorkflowSlot performs the in-memory half of finishing a run.
+func (cs *cronScheduler) releaseClawWorkflowSlot(clawID string) {
+	if cs == nil {
+		return
+	}
 	// Decrement the running counter for this workflow so overlap policy
 	// is enforced against actual claw execution time, not creation time.
 	cs.clawWorkflowMu.Lock()

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -56,6 +56,7 @@ func migrate(db *sql.DB) error {
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN task_run_id TEXT NOT NULL DEFAULT ''`)
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN workflow_volumes TEXT NOT NULL DEFAULT '[]'`)
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN trigger_actor_json TEXT NOT NULL DEFAULT '{}'`)
+	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN stop_comment_pending INTEGER NOT NULL DEFAULT 0`)
 	_, _ = db.Exec(`ALTER TABLE claw_prs ADD COLUMN last_comment_at TEXT NOT NULL DEFAULT ''`)
 	_, _ = db.Exec(`ALTER TABLE claw_prs ADD COLUMN pr_conditions_fired INTEGER NOT NULL DEFAULT 0`)
 	_, _ = db.Exec(`ALTER TABLE claw_prs ADD COLUMN last_review_comment_id INTEGER NOT NULL DEFAULT 0`)
@@ -216,7 +217,8 @@ func migrate(db *sql.DB) error {
 		restored_from_checkpoint_id TEXT NOT NULL DEFAULT '',
 		task_run_id TEXT NOT NULL DEFAULT '',
 		workflow_volumes TEXT NOT NULL DEFAULT '[]',
-		trigger_actor_json TEXT NOT NULL DEFAULT '{}'
+		trigger_actor_json TEXT NOT NULL DEFAULT '{}',
+		stop_comment_pending INTEGER NOT NULL DEFAULT 0
 	);
 
 

--- a/pkg/hub/done_signal_test.go
+++ b/pkg/hub/done_signal_test.go
@@ -447,3 +447,36 @@ func TestHandleClawDoneSignal_IssueLessInteractiveClawIsNoOp(t *testing.T) {
 		t.Fatalf("status = %q, want connected", status)
 	}
 }
+
+func TestHandleClawDoneSignal_DoesNotMoveTrackerWhenTerminalTxFails(t *testing.T) {
+	requests := make(chan struct{}, 1)
+	tracker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case requests <- struct{}{}:
+		default:
+		}
+		_, _ = w.Write([]byte(`{"data":{"issue":{"id":"issue-1"}}}`))
+	}))
+	t.Cleanup(tracker.Close)
+
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{
+		Token:        "test-token",
+		Integrations: &types.IntegrationsConfig{Linear: []*types.LinearIntegrationConfig{{Workspace: "workspace", Token: "token"}}},
+		Factories:    []*types.FactoryConfig{{Name: "factory", Integration: "linear", Workspace: "workspace", FinishedStatus: "Done"}},
+	}, "", tracker.URL, "")
+	const clawID = "claw-done-closed-db"
+	if _, err := db.Exec(`INSERT INTO claws(id,tenant_id,name,template,status,linear_issue_id,tags,created_at) VALUES(?,?,?,?,?,?,?,datetime('now'))`, clawID, "test-tenant-id", "test-claw", "base", "connected", "ENG-1", `["factory:factory"]`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TRIGGER fail_terminal_tx BEFORE UPDATE OF status ON claws WHEN NEW.status='idle' BEGIN SELECT RAISE(ABORT, 'terminal transaction failed'); END`); err != nil {
+		t.Fatalf("create terminal transaction failure trigger: %v", err)
+	}
+
+	s.handleClawDoneSignal(clawID, "[DONE] https://github.com/org/repo/pull/42")
+
+	select {
+	case <-requests:
+		t.Fatal("tracker was called although terminal DB transaction failed")
+	default:
+	}
+}

--- a/pkg/hub/external_webhook.go
+++ b/pkg/hub/external_webhook.go
@@ -328,9 +328,9 @@ func (s *Server) processExternalFactoryTrigger(factory *types.FactoryConfig, pay
 	}
 
 	if err := s.completeFactoryTrigger(factory.Name, "external", triggerKey, clawID); err != nil {
-		_, _ = s.db.Exec(`UPDATE claws SET status='deleted' WHERE id=?`, clawID)
+		_, _ = s.finishClawTerminalTx(clawID, "deleted", "", "failed", err.Error(), false)
 		if s.cronScheduler != nil {
-			s.cronScheduler.finishRunByClawID(clawID, "failed", err.Error())
+			s.cronScheduler.releaseClawWorkflowSlot(clawID)
 		}
 		log.Printf("[external-webhook] factory %q: failed to complete trigger for %s: %v",
 			factory.Name, triggerKey, err)
@@ -676,7 +676,7 @@ func (s *Server) createClawForExternalEvent(factory *types.FactoryConfig, payloa
 				provErr = fmt.Errorf("noop provider requires ELASTICCLAW_NOOP_PROVIDER=1")
 			} else {
 				providerID := "noop-vm-" + clawID[:8]
-				_, _ = s.db.Exec(`UPDATE claws SET status='connected', provider='noop', provider_id=? WHERE id=? AND status NOT IN ('idle','deleted','error')`, providerID, clawID)
+				_, _ = s.execStatusLogged("connect claw "+clawID, `UPDATE claws SET status='connected', provider='noop', provider_id=? WHERE id=? AND status NOT IN ('idle','deleted','error')`, providerID, clawID)
 			}
 		default:
 			provErr = fmt.Errorf("unsupported provider: %s", provider)

--- a/pkg/hub/external_webhook.go
+++ b/pkg/hub/external_webhook.go
@@ -328,7 +328,7 @@ func (s *Server) processExternalFactoryTrigger(factory *types.FactoryConfig, pay
 	}
 
 	if err := s.completeFactoryTrigger(factory.Name, "external", triggerKey, clawID); err != nil {
-		_, _ = s.finishClawTerminalTx(clawID, "deleted", "", "failed", err.Error(), false)
+		_, _ = s.finishClawTerminalTx(clawID, "deleted", "", "failed", err.Error(), terminalTxOpts{})
 		if s.cronScheduler != nil {
 			s.cronScheduler.releaseClawWorkflowSlot(clawID)
 		}

--- a/pkg/hub/github_issues.go
+++ b/pkg/hub/github_issues.go
@@ -578,9 +578,9 @@ func (s *Server) createClawForGitHubIssueWorkflow(workspace *types.WorkspaceConf
 		return "", false, err
 	}
 	if err := s.completeFactoryTrigger(triggerOwner, "github-issues", triggerKey, clawID); err != nil {
-		_, _ = s.db.Exec(`UPDATE claws SET status='deleted' WHERE id=?`, clawID)
+		_, _ = s.finishClawTerminalTx(clawID, "deleted", "", "failed", err.Error(), false)
 		if s.cronScheduler != nil {
-			s.cronScheduler.finishRunByClawID(clawID, "failed", err.Error())
+			s.cronScheduler.releaseClawWorkflowSlot(clawID)
 		}
 		return "", false, fmt.Errorf("complete workflow trigger: %w", err)
 	}
@@ -865,9 +865,9 @@ func (s *Server) createClawForGitHubIssue(factory *types.FactoryConfig, payload 
 		return fmt.Errorf("db insert: %w", err)
 	}
 	if err := s.completeFactoryTrigger(factory.Name, "github-issues", triggerKey, clawID); err != nil {
-		_, _ = s.db.Exec(`UPDATE claws SET status='deleted' WHERE id=?`, clawID)
+		_, _ = s.finishClawTerminalTx(clawID, "deleted", "", "failed", err.Error(), false)
 		if s.cronScheduler != nil {
-			s.cronScheduler.finishRunByClawID(clawID, "failed", err.Error())
+			s.cronScheduler.releaseClawWorkflowSlot(clawID)
 		}
 		return fmt.Errorf("complete factory trigger: %w", err)
 	}
@@ -995,9 +995,12 @@ func (s *Server) terminateClawForGitHubIssue(issueID string) {
 		delete(s.claws, clawID)
 	}
 	s.mu.Unlock()
-	_, _ = s.db.Exec(`UPDATE claws SET status='deleted' WHERE id=?`, clawID)
+	applied, err := s.finishClawTerminalTx(clawID, "deleted", "", "canceled", "issue left trigger status", false)
+	if err != nil || !applied {
+		return
+	}
 	if s.cronScheduler != nil {
-		s.cronScheduler.finishRunByClawID(clawID, "canceled", "issue left trigger status")
+		s.cronScheduler.releaseClawWorkflowSlot(clawID)
 	}
 	s.broadcastToUsers(tenantID, types.WSMessage{
 		Type:    "claw_status",

--- a/pkg/hub/github_issues.go
+++ b/pkg/hub/github_issues.go
@@ -578,7 +578,7 @@ func (s *Server) createClawForGitHubIssueWorkflow(workspace *types.WorkspaceConf
 		return "", false, err
 	}
 	if err := s.completeFactoryTrigger(triggerOwner, "github-issues", triggerKey, clawID); err != nil {
-		_, _ = s.finishClawTerminalTx(clawID, "deleted", "", "failed", err.Error(), false)
+		_, _ = s.finishClawTerminalTx(clawID, "deleted", "", "failed", err.Error(), terminalTxOpts{})
 		if s.cronScheduler != nil {
 			s.cronScheduler.releaseClawWorkflowSlot(clawID)
 		}
@@ -865,7 +865,7 @@ func (s *Server) createClawForGitHubIssue(factory *types.FactoryConfig, payload 
 		return fmt.Errorf("db insert: %w", err)
 	}
 	if err := s.completeFactoryTrigger(factory.Name, "github-issues", triggerKey, clawID); err != nil {
-		_, _ = s.finishClawTerminalTx(clawID, "deleted", "", "failed", err.Error(), false)
+		_, _ = s.finishClawTerminalTx(clawID, "deleted", "", "failed", err.Error(), terminalTxOpts{})
 		if s.cronScheduler != nil {
 			s.cronScheduler.releaseClawWorkflowSlot(clawID)
 		}
@@ -995,7 +995,7 @@ func (s *Server) terminateClawForGitHubIssue(issueID string) {
 		delete(s.claws, clawID)
 	}
 	s.mu.Unlock()
-	applied, err := s.finishClawTerminalTx(clawID, "deleted", "", "canceled", "issue left trigger status", false)
+	applied, err := s.finishClawTerminalTx(clawID, "deleted", "", "canceled", "issue left trigger status", terminalTxOpts{})
 	if err != nil || !applied {
 		return
 	}

--- a/pkg/hub/jira.go
+++ b/pkg/hub/jira.go
@@ -497,7 +497,7 @@ func (s *Server) createClawForJiraWorkflow(workspace *types.WorkspaceConfig, wor
 		return err
 	}
 	if err := s.completeFactoryTrigger(triggerOwner, "jira", triggerKey, clawID); err != nil {
-		_, _ = s.db.Exec(`UPDATE claws SET status='deleted' WHERE id=?`, clawID)
+		_, _ = s.execTerminalStatus("delete claw "+clawID, `UPDATE claws SET status='deleted' WHERE id=?`, clawID)
 		return fmt.Errorf("complete workflow trigger: %w", err)
 	}
 	claimOpen = false
@@ -545,7 +545,7 @@ func (s *Server) createClawForJiraIssue(factory *types.FactoryConfig, payload ji
 		return err
 	}
 	if err := s.completeFactoryTrigger(factory.Name, "jira", triggerKey, clawID); err != nil {
-		_, _ = s.db.Exec(`UPDATE claws SET status='deleted' WHERE id=?`, clawID)
+		_, _ = s.execTerminalStatus("delete claw "+clawID, `UPDATE claws SET status='deleted' WHERE id=?`, clawID)
 		return fmt.Errorf("complete factory trigger: %w", err)
 	}
 	claimOpen = false

--- a/pkg/hub/jira.go
+++ b/pkg/hub/jira.go
@@ -497,7 +497,10 @@ func (s *Server) createClawForJiraWorkflow(workspace *types.WorkspaceConfig, wor
 		return err
 	}
 	if err := s.completeFactoryTrigger(triggerOwner, "jira", triggerKey, clawID); err != nil {
-		_, _ = s.execTerminalStatus("delete claw "+clawID, `UPDATE claws SET status='deleted' WHERE id=?`, clawID)
+		_, _ = s.finishClawTerminalTx(clawID, "deleted", "", "failed", err.Error(), terminalTxOpts{})
+		if s.cronScheduler != nil {
+			s.cronScheduler.releaseClawWorkflowSlot(clawID)
+		}
 		return fmt.Errorf("complete workflow trigger: %w", err)
 	}
 	claimOpen = false
@@ -545,7 +548,10 @@ func (s *Server) createClawForJiraIssue(factory *types.FactoryConfig, payload ji
 		return err
 	}
 	if err := s.completeFactoryTrigger(factory.Name, "jira", triggerKey, clawID); err != nil {
-		_, _ = s.execTerminalStatus("delete claw "+clawID, `UPDATE claws SET status='deleted' WHERE id=?`, clawID)
+		_, _ = s.finishClawTerminalTx(clawID, "deleted", "", "failed", err.Error(), terminalTxOpts{})
+		if s.cronScheduler != nil {
+			s.cronScheduler.releaseClawWorkflowSlot(clawID)
+		}
 		return fmt.Errorf("complete factory trigger: %w", err)
 	}
 	claimOpen = false

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -496,9 +496,9 @@ func (s *Server) createClawForLinearWorkflow(workspace *types.WorkspaceConfig, w
 		return err
 	}
 	if err := s.completeFactoryTrigger(triggerOwner, "linear", triggerKey, clawID); err != nil {
-		_, _ = s.db.Exec(`UPDATE claws SET status='deleted' WHERE id=?`, clawID)
+		_, _ = s.finishClawTerminalTx(clawID, "deleted", "", "failed", err.Error(), false)
 		if s.cronScheduler != nil {
-			s.cronScheduler.finishRunByClawID(clawID, "failed", err.Error())
+			s.cronScheduler.releaseClawWorkflowSlot(clawID)
 		}
 		return fmt.Errorf("complete workflow trigger: %w", err)
 	}
@@ -573,9 +573,9 @@ func (s *Server) createClawForIssue(factory *types.FactoryConfig, payload linear
 		return err
 	}
 	if err := s.completeFactoryTrigger(factory.Name, "linear", triggerKey, clawID); err != nil {
-		_, _ = s.db.Exec(`UPDATE claws SET status='deleted' WHERE id=?`, clawID)
+		_, _ = s.finishClawTerminalTx(clawID, "deleted", "", "failed", err.Error(), false)
 		if s.cronScheduler != nil {
-			s.cronScheduler.finishRunByClawID(clawID, "failed", err.Error())
+			s.cronScheduler.releaseClawWorkflowSlot(clawID)
 		}
 		return fmt.Errorf("complete factory trigger: %w", err)
 	}
@@ -665,9 +665,12 @@ func (s *Server) terminateClawForIssue(issueID string) {
 		delete(s.claws, clawID)
 	}
 	s.mu.Unlock()
-	_, _ = s.db.Exec(`UPDATE claws SET status='deleted' WHERE id=?`, clawID)
+	applied, err := s.finishClawTerminalTx(clawID, "deleted", "", "canceled", "issue left trigger status", false)
+	if err != nil || !applied {
+		return
+	}
 	if s.cronScheduler != nil {
-		s.cronScheduler.finishRunByClawID(clawID, "canceled", "issue left trigger status")
+		s.cronScheduler.releaseClawWorkflowSlot(clawID)
 	}
 	// Notify dashboards so the card disappears immediately
 	s.broadcastToUsers(tenantID, types.WSMessage{
@@ -1118,7 +1121,7 @@ func (s *Server) provisionPendingClaw(clawID string) {
 			provErr = fmt.Errorf("noop provider requires ELASTICCLAW_NOOP_PROVIDER=1")
 		} else {
 			providerID := "noop-vm-" + clawID[:8]
-			_, _ = s.db.Exec(`UPDATE claws SET status='connected', provider='noop', provider_id=? WHERE id=? AND status NOT IN ('idle','deleted','error')`, providerID, clawID)
+			_, _ = s.execStatusLogged("connect claw "+clawID, `UPDATE claws SET status='connected', provider='noop', provider_id=? WHERE id=? AND status NOT IN ('idle','deleted','error')`, providerID, clawID)
 		}
 	default:
 		provErr = fmt.Errorf("unsupported provider: %s", provider)
@@ -1278,6 +1281,17 @@ func (s *Server) handleClawDoneSignal(clawID, rawMessage string) {
 			}
 		}
 	}
+	// Persist completion before touching the tracker. This prevents a tracker
+	// move from surviving a process crash while the claw still looks active.
+	if !noPRDoneAllowed {
+		applied, err := s.finishClawTerminalTx(clawID, "idle", "", "completed", "success", false)
+		if err != nil || !applied {
+			return
+		}
+		if s.cronScheduler != nil {
+			s.cronScheduler.releaseClawWorkflowSlot(clawID)
+		}
+	}
 
 	// Move the issue to finished_status if configured (agent finished working)
 	// If no finished_status, fall back to done_status for backward compatibility
@@ -1351,20 +1365,6 @@ func (s *Server) handleClawDoneSignal(clawID, rawMessage string) {
 		s.completeNoPRDoneClaw(clawID, tenantID, issueID)
 		return
 	}
-	res, err := s.db.Exec(`UPDATE claws SET status='idle' WHERE id=? AND status NOT IN ('deleted','error')`, clawID)
-	if err != nil {
-		return
-	}
-	rowsAffected, err := res.RowsAffected()
-	if err != nil || rowsAffected == 0 {
-		if rowsAffected == 0 {
-			log.Printf("[factory] non-pr completion skipped for claw %s: already deleted or terminal", clawID[:8])
-		}
-		return
-	}
-	if s.cronScheduler != nil {
-		s.cronScheduler.finishRunByClawID(clawID, "completed", "success")
-	}
 	s.broadcastToUsers(tenantID, types.WSMessage{
 		Type:    "claw_status",
 		Payload: map[string]string{"claw_id": clawID, "status": "idle"},
@@ -1408,16 +1408,12 @@ func (s *Server) completeIssueLessDoneClaw(clawID, tenantID string, prURLs []str
 		s.completeNoPRDoneClaw(clawID, tenantID, "")
 		return
 	}
-	res, err := s.db.Exec(`UPDATE claws SET status='idle' WHERE id=? AND status NOT IN ('deleted','error')`, clawID)
-	if err != nil {
-		return
-	}
-	rowsAffected, _ := res.RowsAffected()
-	if rowsAffected == 0 {
+	applied, err := s.finishClawTerminalTx(clawID, "idle", "", "completed", "success", false)
+	if err != nil || !applied {
 		return
 	}
 	if s.cronScheduler != nil {
-		s.cronScheduler.finishRunByClawID(clawID, "completed", "success")
+		s.cronScheduler.releaseClawWorkflowSlot(clawID)
 	}
 	s.broadcastToUsers(tenantID, types.WSMessage{
 		Type:    "claw_status",
@@ -1427,14 +1423,11 @@ func (s *Server) completeIssueLessDoneClaw(clawID, tenantID string, prURLs []str
 
 func (s *Server) completeNoPRDoneClaw(clawID, tenantID, issueID string) {
 	var provider, providerID string
-	_ = s.db.QueryRow(`SELECT COALESCE(provider,''), COALESCE(provider_id,'') FROM claws WHERE id=? AND tenant_id=?`, clawID, tenantID).Scan(&provider, &providerID)
-	res, err := s.db.Exec(`UPDATE claws SET status='deleted', bootstrap_status='' WHERE id=? AND tenant_id=? AND status NOT IN ('deleted','error')`, clawID, tenantID)
-	if err != nil {
-		log.Printf("[factory] failed to complete non-pr claw %s: %v", clawID, err)
+	if err := s.db.QueryRow(`SELECT COALESCE(provider,''), COALESCE(provider_id,'') FROM claws WHERE id=? AND tenant_id=?`, clawID, tenantID).Scan(&provider, &providerID); err != nil {
 		return
 	}
-	rowsAffected, err := res.RowsAffected()
-	if err != nil || rowsAffected == 0 {
+	applied, err := s.finishClawTerminalTx(clawID, "deleted", "", "completed", "success", false)
+	if err != nil || !applied {
 		return
 	}
 	s.syncWorkflowVolumes(clawID)
@@ -1450,7 +1443,7 @@ func (s *Server) completeNoPRDoneClaw(clawID, tenantID, issueID string) {
 		log.Printf("[task-run-analytics] failed to record non-pr completion for claw %s: %v", clawID, err)
 	}
 	if s.cronScheduler != nil {
-		s.cronScheduler.finishRunByClawID(clawID, "completed", "success")
+		s.cronScheduler.releaseClawWorkflowSlot(clawID)
 	}
 	s.broadcastToUsers(tenantID, types.WSMessage{
 		Type:    "claw_status",
@@ -1465,7 +1458,7 @@ func (s *Server) completeNoPRDoneClaw(clawID, tenantID, issueID string) {
 	go func() {
 		s.checkpointBeforeTermination(clawID, "task-completed")
 		if providerID != "" {
-			s.terminateVM(provider, providerID)
+			s.terminateVMForClaw(clawID, provider, providerID)
 		}
 		_, _ = s.db.Exec(`DELETE FROM messages WHERE claw_id=?`, clawID)
 		_, _ = s.db.Exec(`DELETE FROM claw_prs WHERE claw_id=?`, clawID)

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -496,7 +496,7 @@ func (s *Server) createClawForLinearWorkflow(workspace *types.WorkspaceConfig, w
 		return err
 	}
 	if err := s.completeFactoryTrigger(triggerOwner, "linear", triggerKey, clawID); err != nil {
-		_, _ = s.finishClawTerminalTx(clawID, "deleted", "", "failed", err.Error(), false)
+		_, _ = s.finishClawTerminalTx(clawID, "deleted", "", "failed", err.Error(), terminalTxOpts{})
 		if s.cronScheduler != nil {
 			s.cronScheduler.releaseClawWorkflowSlot(clawID)
 		}
@@ -573,7 +573,7 @@ func (s *Server) createClawForIssue(factory *types.FactoryConfig, payload linear
 		return err
 	}
 	if err := s.completeFactoryTrigger(factory.Name, "linear", triggerKey, clawID); err != nil {
-		_, _ = s.finishClawTerminalTx(clawID, "deleted", "", "failed", err.Error(), false)
+		_, _ = s.finishClawTerminalTx(clawID, "deleted", "", "failed", err.Error(), terminalTxOpts{})
 		if s.cronScheduler != nil {
 			s.cronScheduler.releaseClawWorkflowSlot(clawID)
 		}
@@ -665,7 +665,7 @@ func (s *Server) terminateClawForIssue(issueID string) {
 		delete(s.claws, clawID)
 	}
 	s.mu.Unlock()
-	applied, err := s.finishClawTerminalTx(clawID, "deleted", "", "canceled", "issue left trigger status", false)
+	applied, err := s.finishClawTerminalTx(clawID, "deleted", "", "canceled", "issue left trigger status", terminalTxOpts{})
 	if err != nil || !applied {
 		return
 	}
@@ -1284,7 +1284,7 @@ func (s *Server) handleClawDoneSignal(clawID, rawMessage string) {
 	// Persist completion before touching the tracker. This prevents a tracker
 	// move from surviving a process crash while the claw still looks active.
 	if !noPRDoneAllowed {
-		applied, err := s.finishClawTerminalTx(clawID, "idle", "", "completed", "success", false)
+		applied, err := s.finishClawTerminalTx(clawID, "idle", "", "completed", "success", terminalTxOpts{})
 		if err != nil || !applied {
 			return
 		}
@@ -1408,7 +1408,7 @@ func (s *Server) completeIssueLessDoneClaw(clawID, tenantID string, prURLs []str
 		s.completeNoPRDoneClaw(clawID, tenantID, "")
 		return
 	}
-	applied, err := s.finishClawTerminalTx(clawID, "idle", "", "completed", "success", false)
+	applied, err := s.finishClawTerminalTx(clawID, "idle", "", "completed", "success", terminalTxOpts{})
 	if err != nil || !applied {
 		return
 	}
@@ -1426,7 +1426,7 @@ func (s *Server) completeNoPRDoneClaw(clawID, tenantID, issueID string) {
 	if err := s.db.QueryRow(`SELECT COALESCE(provider,''), COALESCE(provider_id,'') FROM claws WHERE id=? AND tenant_id=?`, clawID, tenantID).Scan(&provider, &providerID); err != nil {
 		return
 	}
-	applied, err := s.finishClawTerminalTx(clawID, "deleted", "", "completed", "success", false)
+	applied, err := s.finishClawTerminalTx(clawID, "deleted", "", "completed", "success", terminalTxOpts{})
 	if err != nil || !applied {
 		return
 	}

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -1516,10 +1516,13 @@ func (s *Server) transitionResolvedPipelineStageWithContext(clawID string, stage
 		s.checkpointBeforeTermination(clawID, "pipeline-terminal")
 		s.syncWorkflowVolumes(clawID)
 
-		_, _ = s.db.Exec(`UPDATE claws SET status='deleted' WHERE id=?`, clawID)
+		status, result := pipelineTerminalWorkflowRunResult(stage, stageActionsSucceeded)
+		applied, err := s.finishClawTerminalTx(clawID, "deleted", "", status, result, false)
+		if err != nil || !applied {
+			return transitioned, injectDelivered
+		}
 		if s.cronScheduler != nil {
-			status, result := pipelineTerminalWorkflowRunResult(stage, stageActionsSucceeded)
-			s.cronScheduler.finishRunByClawID(clawID, status, result)
+			s.cronScheduler.releaseClawWorkflowSlot(clawID)
 		}
 		s.mu.Lock()
 		if cc, ok := s.claws[clawID]; ok {
@@ -1534,7 +1537,7 @@ func (s *Server) transitionResolvedPipelineStageWithContext(clawID string, stage
 		})
 
 		if providerID != "" {
-			go s.terminateVM(provider, providerID)
+			go s.terminateVMForClaw(clawID, provider, providerID)
 		}
 	}
 	return true, injectDelivered
@@ -1842,16 +1845,23 @@ func (s *Server) stopAgentTerminalWithReason(clawID, reason string, skipVMTermin
 	var tenantID, providerID, provider string
 	_ = s.db.QueryRow(`SELECT tenant_id, COALESCE(provider_id,''), COALESCE(provider,'') FROM claws WHERE id=?`, clawID).Scan(&tenantID, &providerID, &provider)
 
-	// 1. Set terminal status and persist sanitized diagnostic
+	// 1. Set terminal status and finish the workflow run atomically.
 	safeReason := firstUsefulFailureLines(sanitizeFailureDetails(reason), 4)
-	res, updateErr := s.db.Exec(`UPDATE claws SET status='error', bootstrap_status='', bootstrap_diagnostic=? WHERE id=? AND status != 'deleted'`, safeReason, clawID)
+	commentOwed := hasPipelineCtx && pipelineCtx.Workflow != nil && pipelineCtx.IssueID != "" && isFailureFeedbackWorkflowIntegration(pipelineCtx.Workflow.Integration) || factory != nil && issueID != ""
+	applied, updateErr := s.finishClawTerminalTx(clawID, "error", safeReason, "failed", safeReason, commentOwed)
 	if updateErr != nil {
-		log.Printf("[stopAgent] failed to mark claw %s as error: %v", clawID[:8], updateErr)
-	} else {
-		rowsAffected, _ := res.RowsAffected()
-		if rowsAffected == 0 {
-			return
-		}
+		return
+	}
+	if !applied {
+		return
+	}
+	if s.cronScheduler != nil {
+		s.cronScheduler.releaseClawWorkflowSlot(clawID)
+	}
+	if skipVMTerminate && providerID != "" {
+		_, _ = s.execStatusLogged("clear provider_id claw "+clawID, `UPDATE claws SET provider_id='' WHERE id=?`, clawID)
+	}
+	{
 		if err := s.recordTaskRunEventForClaw(clawID, TaskRunEvent{
 			EventKey:        "agent_stopped:" + clawID,
 			Source:          taskRunSourceHub,
@@ -1863,9 +1873,6 @@ func (s *Server) stopAgentTerminalWithReason(clawID, reason string, skipVMTermin
 			OccurredAt:      now(),
 		}); err != nil {
 			log.Printf("[task-run-analytics] failed to record agent stop for claw %s: %v", clawID, err)
-		}
-		if s.cronScheduler != nil {
-			s.cronScheduler.finishRunByClawID(clawID, "failed", safeReason)
 		}
 	}
 
@@ -1891,15 +1898,15 @@ func (s *Server) stopAgentTerminalWithReason(clawID, reason string, skipVMTermin
 
 	// 4. Write issue-tracker comment without delaying agent shutdown.
 	if hasPipelineCtx && pipelineCtx.Workflow != nil && pipelineCtx.IssueID != "" && isFailureFeedbackWorkflowIntegration(pipelineCtx.Workflow.Integration) {
-		go s.commentWorkflowAgentStopToTracker(clawID, pipelineCtx, reason)
+		s.dispatchWorkflowStopComment(clawID, pipelineCtx, reason)
 	} else if factory != nil && issueID != "" {
 		factoryCopy := *factory
-		go s.commentAgentStopToTracker(clawID, &factoryCopy, issueID, reason)
+		s.dispatchFactoryStopComment(clawID, &factoryCopy, issueID, reason)
 	}
 
 	// 5. Terminate VM if still running
 	if providerID != "" && !skipVMTerminate {
-		go s.terminateVM(provider, providerID)
+		go s.terminateVMForClaw(clawID, provider, providerID)
 	}
 
 	log.Printf("[stopAgent] claw %s stopped: %s", clawID[:8], reason)
@@ -1909,8 +1916,39 @@ func isFailureFeedbackWorkflowIntegration(integration string) bool {
 	return integration == "github-issues" || integration == "linear" || integration == "jira"
 }
 
+// dispatchStopComment claims a pending notification before starting network I/O.
+// The claim prevents a slow initial delivery and a reaper redrive from posting
+// the same tracker comment concurrently. Failed deliveries restore pending=1.
+func (s *Server) dispatchStopComment(clawID string, deliver func()) {
+	res, err := s.db.Exec(`UPDATE claws SET stop_comment_pending=2 WHERE id=? AND stop_comment_pending=1`, clawID)
+	if err != nil {
+		return
+	}
+	if rows, _ := res.RowsAffected(); rows == 1 {
+		go deliver()
+	}
+}
+
+func (s *Server) dispatchWorkflowStopComment(clawID string, ctx pipelineContext, reason string) {
+	s.dispatchStopComment(clawID, func() { s.commentWorkflowAgentStopToTracker(clawID, ctx, reason) })
+}
+
+func (s *Server) dispatchFactoryStopComment(clawID string, factory *types.FactoryConfig, issueID, reason string) {
+	s.dispatchStopComment(clawID, func() { s.commentAgentStopToTracker(clawID, factory, issueID, reason) })
+}
+
 func (s *Server) commentWorkflowAgentStopToTracker(clawID string, ctx pipelineContext, reason string) {
+	clear := func() {
+		_, _ = s.execStatusLogged("clear stop comment claw "+clawID, `UPDATE claws SET stop_comment_pending=0 WHERE id=? AND stop_comment_pending=2`, clawID)
+	}
+	retry := func() {
+		_, _ = s.execStatusLogged("retry stop comment claw "+clawID, `UPDATE claws SET stop_comment_pending=1 WHERE id=? AND stop_comment_pending=2`, clawID)
+		// Keep retries spaced by the redrive grace period rather than attempting
+		// a permanently failing tracker on every reaper tick.
+		s.firstSeen("comment:"+clawID, true, s.reaperNow())
+	}
 	if ctx.Workflow == nil || ctx.Workspace == nil || ctx.IssueID == "" {
+		clear()
 		return
 	}
 	feedback := agentFailureFeedback{
@@ -1925,10 +1963,12 @@ func (s *Server) commentWorkflowAgentStopToTracker(clawID string, ctx pipelineCo
 		repo, issueNum, ok := parseGitHubIssueWorkflowID(ctx.IssueID)
 		if !ok {
 			log.Printf("[stopAgent] invalid GitHub workflow issue id %q for claw %s", ctx.IssueID, shortID(clawID))
+			clear()
 			return
 		}
 		token := s.resolveGitHubIssuesTokenForWorkflow(ctx.Workspace.Name, ctx.Workflow)
 		if token == "" {
+			clear()
 			return
 		}
 		feedback.GitHubRepo = repo
@@ -1936,20 +1976,30 @@ func (s *Server) commentWorkflowAgentStopToTracker(clawID string, ctx pipelineCo
 		if ctx.Workflow.Trigger != nil && ctx.Workflow.Trigger.GitHubIssues != nil {
 			feedback.AgentStatusError = strings.TrimSpace(ctx.Workflow.Trigger.GitHubIssues.AgentStatusError)
 		}
-		s.handleAgentFailureFeedback(feedback, token)
+		if s.handleAgentFailureFeedback(feedback, token) {
+			clear()
+		} else {
+			retry()
+		}
 	case "linear":
 		token := s.resolveLinearTokenForWorkflow(ctx.Workspace.Name, ctx.Workflow)
 		if token == "" {
+			clear()
 			return
 		}
 		feedback.LinearIdentifier = ctx.IssueID
 		if ctx.Workflow.Trigger != nil && ctx.Workflow.Trigger.Linear != nil {
 			feedback.AgentStatusError = strings.TrimSpace(ctx.Workflow.Trigger.Linear.AgentStatusError)
 		}
-		s.handleAgentFailureFeedback(feedback, token)
+		if s.handleAgentFailureFeedback(feedback, token) {
+			clear()
+		} else {
+			retry()
+		}
 	case "jira":
 		tracker, ok := s.resolveJiraTrackerForWorkflow(ctx.Workspace.Name, ctx.Workflow)
 		if !ok || tracker.Token == "" {
+			clear()
 			return
 		}
 		if ctx.Workflow.Trigger != nil && ctx.Workflow.Trigger.Jira != nil {
@@ -1960,6 +2010,9 @@ func (s *Server) commentWorkflowAgentStopToTracker(clawID string, ctx pipelineCo
 		}
 		if err := s.commentJiraIssue(tracker, ctx.IssueID, s.buildAgentStopComment(clawID, reason)); err != nil {
 			log.Printf("[stopAgent] failed to comment Jira issue %s: %v", ctx.IssueID, err)
+			retry()
+		} else {
+			clear()
 		}
 	}
 }
@@ -1978,6 +2031,13 @@ func parseGitHubIssueWorkflowID(issueID string) (string, int, bool) {
 }
 
 func (s *Server) commentAgentStopToTracker(clawID string, factory *types.FactoryConfig, issueID, reason string) {
+	clear := func() {
+		_, _ = s.execStatusLogged("clear stop comment claw "+clawID, `UPDATE claws SET stop_comment_pending=0 WHERE id=? AND stop_comment_pending=2`, clawID)
+	}
+	retry := func() {
+		_, _ = s.execStatusLogged("retry stop comment claw "+clawID, `UPDATE claws SET stop_comment_pending=1 WHERE id=? AND stop_comment_pending=2`, clawID)
+		s.firstSeen("comment:"+clawID, true, s.reaperNow())
+	}
 	var commentBody string
 	getCommentBody := func() string {
 		if commentBody == "" {
@@ -1986,6 +2046,7 @@ func (s *Server) commentAgentStopToTracker(clawID string, factory *types.Factory
 		return commentBody
 	}
 
+	success := false
 	switch factory.Integration {
 	case "linear":
 		token := s.resolveLinearTokenForFactory(factory)
@@ -1994,6 +2055,7 @@ func (s *Server) commentAgentStopToTracker(clawID string, factory *types.Factory
 				log.Printf("[stopAgent] failed to comment Linear issue %s: %v", issueID, err)
 			} else {
 				log.Printf("[stopAgent] commented Linear issue %s", issueID)
+				success = true
 			}
 		}
 	case "shortcut":
@@ -2003,6 +2065,7 @@ func (s *Server) commentAgentStopToTracker(clawID string, factory *types.Factory
 				log.Printf("[stopAgent] failed to comment Shortcut story %s: %v", issueID, err)
 			} else {
 				log.Printf("[stopAgent] commented Shortcut story %s", issueID)
+				success = true
 			}
 		}
 	case "github-issues":
@@ -2017,6 +2080,7 @@ func (s *Server) commentAgentStopToTracker(clawID string, factory *types.Factory
 						log.Printf("[stopAgent] failed to comment GitHub issue %s: %v", issueID, err)
 					} else {
 						log.Printf("[stopAgent] commented GitHub issue %s", issueID)
+						success = true
 					}
 				}
 			}
@@ -2027,8 +2091,14 @@ func (s *Server) commentAgentStopToTracker(clawID string, factory *types.Factory
 				log.Printf("[stopAgent] failed to comment Jira issue %s: %v", issueID, err)
 			} else {
 				log.Printf("[stopAgent] commented Jira issue %s", issueID)
+				success = true
 			}
 		}
+	}
+	if success {
+		clear()
+	} else {
+		retry()
 	}
 }
 

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -1517,7 +1517,7 @@ func (s *Server) transitionResolvedPipelineStageWithContext(clawID string, stage
 		s.syncWorkflowVolumes(clawID)
 
 		status, result := pipelineTerminalWorkflowRunResult(stage, stageActionsSucceeded)
-		applied, err := s.finishClawTerminalTx(clawID, "deleted", "", status, result, false)
+		applied, err := s.finishClawTerminalTx(clawID, "deleted", "", status, result, terminalTxOpts{})
 		if err != nil || !applied {
 			return transitioned, injectDelivered
 		}
@@ -1848,7 +1848,10 @@ func (s *Server) stopAgentTerminalWithReason(clawID, reason string, skipVMTermin
 	// 1. Set terminal status and finish the workflow run atomically.
 	safeReason := firstUsefulFailureLines(sanitizeFailureDetails(reason), 4)
 	commentOwed := hasPipelineCtx && pipelineCtx.Workflow != nil && pipelineCtx.IssueID != "" && isFailureFeedbackWorkflowIntegration(pipelineCtx.Workflow.Integration) || factory != nil && issueID != ""
-	applied, updateErr := s.finishClawTerminalTx(clawID, "error", safeReason, "failed", safeReason, commentOwed)
+	applied, updateErr := s.finishClawTerminalTx(clawID, "error", safeReason, "failed", safeReason, terminalTxOpts{
+		setStopCommentPending: commentOwed,
+		clearProviderID:       skipVMTerminate && providerID != "",
+	})
 	if updateErr != nil {
 		return
 	}
@@ -1857,9 +1860,6 @@ func (s *Server) stopAgentTerminalWithReason(clawID, reason string, skipVMTermin
 	}
 	if s.cronScheduler != nil {
 		s.cronScheduler.releaseClawWorkflowSlot(clawID)
-	}
-	if skipVMTerminate && providerID != "" {
-		_, _ = s.execStatusLogged("clear provider_id claw "+clawID, `UPDATE claws SET provider_id='' WHERE id=?`, clawID)
 	}
 	{
 		if err := s.recordTaskRunEventForClaw(clawID, TaskRunEvent{

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -1184,9 +1184,12 @@ func (s *Server) checkPRMerged(pr clawPR, token string) bool {
 	s.checkpointBeforeTermination(clawID, "pr-merged")
 
 	_, _ = s.db.Exec(`DELETE FROM claw_prs WHERE claw_id=?`, clawID)
-	_, _ = s.db.Exec(`UPDATE claws SET status='deleted' WHERE id=?`, clawID)
+	applied, err := s.finishClawTerminalTx(clawID, "deleted", "", "completed", "PR merged", false)
+	if err != nil || !applied {
+		return false
+	}
 	if s.cronScheduler != nil {
-		s.cronScheduler.finishRunByClawID(clawID, "completed", "PR merged")
+		s.cronScheduler.releaseClawWorkflowSlot(clawID)
 	}
 
 	s.mu.Lock()

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -1184,7 +1184,7 @@ func (s *Server) checkPRMerged(pr clawPR, token string) bool {
 	s.checkpointBeforeTermination(clawID, "pr-merged")
 
 	_, _ = s.db.Exec(`DELETE FROM claw_prs WHERE claw_id=?`, clawID)
-	applied, err := s.finishClawTerminalTx(clawID, "deleted", "", "completed", "PR merged", false)
+	applied, err := s.finishClawTerminalTx(clawID, "deleted", "", "completed", "PR merged", terminalTxOpts{})
 	if err != nil || !applied {
 		return false
 	}

--- a/pkg/hub/reaper.go
+++ b/pkg/hub/reaper.go
@@ -255,7 +255,7 @@ func (s *Server) reapOnce() {
 				continue
 			}
 			status, result := pipelineTerminalWorkflowRunResult(*stage.StageByID(c.stageID), true)
-			if applied, e := s.finishClawTerminalTx(c.id, "deleted", "", status, result, false); e == nil && applied {
+			if applied, e := s.finishClawTerminalTx(c.id, "deleted", "", status, result, terminalTxOpts{}); e == nil && applied {
 				log.Printf("[reaper] completed stranded terminal pipeline stage for claw %s", c.id)
 				if s.cronScheduler != nil {
 					s.cronScheduler.releaseClawWorkflowSlot(c.id)

--- a/pkg/hub/reaper.go
+++ b/pkg/hub/reaper.go
@@ -6,6 +6,12 @@ import (
 )
 
 const reaperActionLimit = 20
+const redriveGrace = 2 * time.Minute
+
+// terminalStageRecoveryGrace must exceed the legitimate in-flight window of a
+// terminal pipeline transition (streaming wait ~30s + checkpoint wait 90s), so
+// the reaper never completes a stage the main path is still finishing.
+const terminalStageRecoveryGrace = 5 * time.Minute
 
 type livenessSettings struct {
 	offlineGrace, provisioningMaxAge, claimTTL, interval time.Duration
@@ -170,6 +176,96 @@ func (s *Server) reapOnce() {
 		if (c.status == "provisioning" || c.status == "starting") && age > cfg.provisioningMaxAge && take() {
 			log.Printf("[reaper] stopping timed out provisioning claw %s", c.id)
 			s.stopAgentWithReason(c.id, "provisioning timed out", false)
+		}
+	}
+	type vm struct{ id, provider, providerID string }
+	vmRows, err := s.db.Query(`SELECT id, COALESCE(provider,''), provider_id FROM claws WHERE status IN ('error','deleted') AND provider_id != ''`)
+	if err == nil {
+		var vms []vm
+		for vmRows.Next() {
+			var v vm
+			if vmRows.Scan(&v.id, &v.provider, &v.providerID) == nil {
+				vms = append(vms, v)
+			}
+		}
+		vmRows.Close()
+		for _, v := range vms {
+			key := "vm:" + v.id
+			seen[key] = true
+			if n.Sub(s.firstSeen(key, true, n)) > redriveGrace && take() {
+				log.Printf("[reaper] re-driving VM terminate for claw %s", v.id)
+				go s.terminateVMForClaw(v.id, v.provider, v.providerID)
+			}
+		}
+	}
+	commentRows, err := s.db.Query(`SELECT id FROM claws WHERE status='error' AND stop_comment_pending=1`)
+	if err == nil {
+		var commentIDs []string
+		for commentRows.Next() {
+			var id string
+			if commentRows.Scan(&id) == nil {
+				commentIDs = append(commentIDs, id)
+			}
+		}
+		commentRows.Close()
+		for _, id := range commentIDs {
+			key := "comment:" + id
+			seen[key] = true
+			if n.Sub(s.firstSeen(key, true, n)) <= redriveGrace || !take() {
+				continue
+			}
+			var reason string
+			_ = s.db.QueryRow(`SELECT COALESCE(bootstrap_diagnostic,'') FROM claws WHERE id=?`, id).Scan(&reason)
+			if ctx, ok := s.findPipelineContextForClaw(id); ok && ctx.Workflow != nil && ctx.IssueID != "" {
+				s.dispatchWorkflowStopComment(id, ctx, reason)
+			} else if f, issueID := s.findFactoryForClaw(id); f != nil && issueID != "" {
+				s.dispatchFactoryStopComment(id, f, issueID, reason)
+			} else {
+				log.Printf("[reaper] clearing unresolved stop comment for claw %s", id)
+				_, _ = s.execStatusLogged("clear stop comment claw "+id, `UPDATE claws SET stop_comment_pending=0 WHERE id=?`, id)
+			}
+		}
+	}
+	// A terminal pipeline stage is claimed before its terminal transaction is
+	// committed. If that transaction exhausts its short retry budget, recover it
+	// here rather than leaving the claimed stage and workflow run running forever.
+	terminalRows, err := s.db.Query(`SELECT c.id, c.pipeline_stage FROM claws c WHERE c.status NOT IN ('error','deleted') AND c.pipeline_stage != '' AND EXISTS (SELECT 1 FROM workflow_runs wr WHERE wr.claw_id=c.id AND wr.status='running')`)
+	if err == nil {
+		type terminalCandidate struct{ id, stageID string }
+		var candidates []terminalCandidate
+		for terminalRows.Next() {
+			var c terminalCandidate
+			if terminalRows.Scan(&c.id, &c.stageID) == nil {
+				candidates = append(candidates, c)
+			}
+		}
+		terminalRows.Close()
+		for _, c := range candidates {
+			ctx, ok := s.findPipelineContextForClaw(c.id)
+			stage := parsePipelineForContext(ctx)
+			if !ok || stage == nil || stage.StageByID(c.stageID) == nil || !stage.StageByID(c.stageID).Terminal {
+				continue
+			}
+			// The main termination path legitimately holds this state while it
+			// waits for streaming and a best-effort checkpoint; only recover
+			// stages that have been stuck well past that window.
+			key := "terminal:" + c.id
+			seen[key] = true
+			if n.Sub(s.firstSeen(key, true, n)) <= terminalStageRecoveryGrace || !take() {
+				continue
+			}
+			status, result := pipelineTerminalWorkflowRunResult(*stage.StageByID(c.stageID), true)
+			if applied, e := s.finishClawTerminalTx(c.id, "deleted", "", status, result, false); e == nil && applied {
+				log.Printf("[reaper] completed stranded terminal pipeline stage for claw %s", c.id)
+				if s.cronScheduler != nil {
+					s.cronScheduler.releaseClawWorkflowSlot(c.id)
+				}
+				var provider, providerID string
+				_ = s.db.QueryRow(`SELECT COALESCE(provider,''), COALESCE(provider_id,'') FROM claws WHERE id=?`, c.id).Scan(&provider, &providerID)
+				if providerID != "" {
+					go s.terminateVMForClaw(c.id, provider, providerID)
+				}
+			}
 		}
 	}
 	triggers, err := s.db.Query(`SELECT id, created_at FROM factory_triggers WHERE status='claimed' AND claw_id=''`)

--- a/pkg/hub/reaper_test.go
+++ b/pkg/hub/reaper_test.go
@@ -2,7 +2,11 @@ package hub
 
 import (
 	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -136,4 +140,248 @@ func TestStopAgentWithReasonPromotesPendingClaw(t *testing.T) {
 	if err := db.QueryRow(`SELECT status FROM claws WHERE id='pending01'`).Scan(&status); err != nil || status != "provisioning" {
 		t.Fatalf("pending status=%q err=%v, want provisioning", status, err)
 	}
+}
+
+func TestReaperRedrivesVMAndCommentAfterClosingRows(t *testing.T) {
+	s, db := newReaperTestServer(t, &types.HubConfig{})
+	tm := time.Now().UTC()
+	s.nowFunc = func() time.Time { return tm }
+	if _, err := db.Exec(`INSERT INTO claws(id,tenant_id,name,provider,provider_id,status,stop_comment_pending,created_at) VALUES('redrive-vm','tenant','vm','docker','vm-1','error',0,?),('redrive-comment','tenant','comment','','','error',1,?)`, tm, tm); err != nil {
+		t.Fatal(err)
+	}
+	terminated := make(chan struct{}, 1)
+	s.terminateVMOverride = func(provider, id string) error {
+		terminated <- struct{}{}
+		return nil
+	}
+
+	// The first observation starts both grace windows.
+	s.reapOnce()
+	tm = tm.Add(redriveGrace + time.Second)
+	done := make(chan struct{})
+	go func() { s.reapOnce(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("reaper blocked while redriving rows on a single DB connection")
+	}
+	select {
+	case <-terminated:
+	case <-time.After(time.Second):
+		t.Fatal("VM redrive was not dispatched")
+	}
+	deadline := time.Now().Add(time.Second)
+	for {
+		var providerID string
+		if err := db.QueryRow(`SELECT provider_id FROM claws WHERE id='redrive-vm'`).Scan(&providerID); err != nil {
+			t.Fatal(err)
+		}
+		if providerID == "" {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("VM redrive did not clear provider_id")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	var pending int
+	if err := db.QueryRow(`SELECT stop_comment_pending FROM claws WHERE id='redrive-comment'`).Scan(&pending); err != nil || pending != 0 {
+		t.Fatalf("unresolved comment pending=%d err=%v, want 0", pending, err)
+	}
+}
+
+func TestReaperRedrivesStopComment(t *testing.T) {
+	newServer := func(t *testing.T, status int, requests chan<- string) (*Server, *sql.DB) {
+		t.Helper()
+		tracker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var request struct {
+				Query     string            `json:"query"`
+				Variables map[string]string `json:"variables"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				t.Errorf("decode tracker request: %v", err)
+			}
+			select {
+			case requests <- request.Query + "\n" + request.Variables["body"]:
+			default:
+			}
+			if status != http.StatusOK {
+				w.WriteHeader(status)
+				return
+			}
+			if strings.Contains(request.Query, "commentCreate") {
+				_, _ = w.Write([]byte(`{"data":{"commentCreate":{"success":true}}}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"data":{"issue":{"id":"issue-1"}}}`))
+		}))
+		t.Cleanup(tracker.Close)
+
+		s, db := newReaperTestServer(t, &types.HubConfig{Integrations: &types.IntegrationsConfig{
+			Linear: []*types.LinearIntegrationConfig{{Workspace: "workspace", Token: "token"}},
+		}, Factories: []*types.FactoryConfig{{Name: "factory", Integration: "linear", Workspace: "workspace"}}})
+		s.linearBaseURL = tracker.URL
+		return s, db
+	}
+
+	t.Run("posts and clears pending", func(t *testing.T) {
+		requests := make(chan string, 2)
+		s, db := newServer(t, http.StatusOK, requests)
+		tm := time.Now().UTC()
+		s.nowFunc = func() time.Time { return tm }
+		if _, err := db.Exec(`INSERT INTO claws(id,tenant_id,name,status,linear_issue_id,tags,stop_comment_pending,bootstrap_diagnostic,created_at) VALUES(?,?,?,?,?,?,?,?,?)`, "comment", "tenant", "comment", "error", "ENG-1", `["factory:factory"]`, 1, "some reason", tm); err != nil {
+			t.Fatal(err)
+		}
+
+		s.reapOnce()
+		tm = tm.Add(redriveGrace + time.Second)
+		s.reapOnce()
+
+		deadline := time.After(time.Second)
+		for {
+			select {
+			case request := <-requests:
+				if strings.Contains(request, "commentCreate") {
+					if !strings.Contains(request, "Agent stopped") || !strings.Contains(request, "some reason") {
+						t.Fatalf("stop comment = %q, want agent-stopped comment with diagnostic", request)
+					}
+					var pending int
+					for stop := time.Now().Add(time.Second); ; time.Sleep(10 * time.Millisecond) {
+						if err := db.QueryRow(`SELECT stop_comment_pending FROM claws WHERE id='comment'`).Scan(&pending); err != nil {
+							t.Fatal(err)
+						}
+						if pending == 0 {
+							return
+						}
+						if time.Now().After(stop) {
+							t.Fatalf("stop_comment_pending=%d, want 0", pending)
+						}
+					}
+				}
+			case <-deadline:
+				t.Fatal("tracker did not receive stop comment")
+			}
+		}
+	})
+
+	t.Run("clears unresolved context without tracker request", func(t *testing.T) {
+		requests := make(chan string, 1)
+		s, db := newServer(t, http.StatusOK, requests)
+		tm := time.Now().UTC()
+		s.nowFunc = func() time.Time { return tm }
+		if _, err := db.Exec(`INSERT INTO claws(id,tenant_id,name,status,stop_comment_pending,bootstrap_diagnostic,created_at) VALUES(?,?,?,?,?,?,?)`, "unresolved", "tenant", "unresolved", "error", 1, "some reason", tm); err != nil {
+			t.Fatal(err)
+		}
+		s.reapOnce()
+		tm = tm.Add(redriveGrace + time.Second)
+		s.reapOnce()
+
+		var pending int
+		if err := db.QueryRow(`SELECT stop_comment_pending FROM claws WHERE id='unresolved'`).Scan(&pending); err != nil || pending != 0 {
+			t.Fatalf("pending=%d err=%v, want 0", pending, err)
+		}
+		select {
+		case <-requests:
+			t.Fatal("unresolved claw sent a tracker request")
+		default:
+		}
+	})
+
+	t.Run("retains pending when tracker fails", func(t *testing.T) {
+		requests := make(chan string, 1)
+		s, db := newServer(t, http.StatusInternalServerError, requests)
+		tm := time.Now().UTC()
+		s.nowFunc = func() time.Time { return tm }
+		if _, err := db.Exec(`INSERT INTO claws(id,tenant_id,name,status,linear_issue_id,tags,stop_comment_pending,bootstrap_diagnostic,created_at) VALUES(?,?,?,?,?,?,?,?,?)`, "failed", "tenant", "failed", "error", "ENG-2", `["factory:factory"]`, 1, "some reason", tm); err != nil {
+			t.Fatal(err)
+		}
+		s.reapOnce()
+		tm = tm.Add(redriveGrace + time.Second)
+		s.reapOnce()
+
+		select {
+		case <-requests:
+		case <-time.After(time.Second):
+			t.Fatal("tracker did not receive failed delivery")
+		}
+		deadline := time.Now().Add(time.Second)
+		for {
+			var pending int
+			if err := db.QueryRow(`SELECT stop_comment_pending FROM claws WHERE id='failed'`).Scan(&pending); err != nil {
+				t.Fatal(err)
+			}
+			if pending == 1 {
+				return
+			}
+			if time.Now().After(deadline) {
+				t.Fatalf("stop_comment_pending=%d, want 1 after failed delivery", pending)
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	})
+}
+
+func TestReaperRecoversStrandedTerminalPipelineStage(t *testing.T) {
+	const pipelineYAML = `
+stages:
+  - id: work
+    label: "Work"
+    triggers:
+      - message_contains: "[START]"
+  - id: done
+    label: "Done"
+    triggers:
+      - message_contains: "[DONE]"
+    terminal: true
+`
+	newServer := func(t *testing.T) (*Server, *sql.DB, func(time.Duration)) {
+		t.Helper()
+		s, db := newReaperTestServer(t, &types.HubConfig{Factories: []*types.FactoryConfig{{
+			Name: "factory", Integration: "linear", Workspace: "workspace", PipelineYAML: pipelineYAML,
+		}}})
+		s.cronScheduler = newCronScheduler(s)
+		tm := time.Now().UTC()
+		s.nowFunc = func() time.Time { return tm }
+		if _, err := db.Exec(`INSERT INTO claws(id,tenant_id,name,status,pipeline_stage,tags,created_at) VALUES('stranded','tenant','stranded','connected','done',?,?)`, `["factory:factory"]`, tm); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := db.Exec(`INSERT INTO workflow_runs(id,tenant_id,workflow_name,workspace_name,trigger_type,status,claw_id,run_context,started_at,created_at) VALUES('run-stranded','tenant','wf','workspace','cron','running','stranded','{}',?,?)`, tm, tm); err != nil {
+			t.Fatal(err)
+		}
+		return s, db, func(d time.Duration) { tm = tm.Add(d) }
+	}
+
+	t.Run("completes after grace", func(t *testing.T) {
+		s, db, advance := newServer(t)
+		s.reapOnce()
+		advance(terminalStageRecoveryGrace + time.Second)
+		s.reapOnce()
+		var clawStatus, runStatus string
+		if err := db.QueryRow(`SELECT status FROM claws WHERE id='stranded'`).Scan(&clawStatus); err != nil {
+			t.Fatal(err)
+		}
+		if err := db.QueryRow(`SELECT status FROM workflow_runs WHERE id='run-stranded'`).Scan(&runStatus); err != nil {
+			t.Fatal(err)
+		}
+		if clawStatus != "deleted" || runStatus != "completed" {
+			t.Fatalf("claw=%q run=%q, want deleted/completed", clawStatus, runStatus)
+		}
+	})
+
+	t.Run("leaves in-flight termination alone within grace", func(t *testing.T) {
+		s, db, advance := newServer(t)
+		s.reapOnce()
+		advance(terminalStageRecoveryGrace - time.Second)
+		s.reapOnce()
+		var clawStatus, runStatus string
+		if err := db.QueryRow(`SELECT status FROM claws WHERE id='stranded'`).Scan(&clawStatus); err != nil {
+			t.Fatal(err)
+		}
+		if err := db.QueryRow(`SELECT status FROM workflow_runs WHERE id='run-stranded'`).Scan(&runStatus); err != nil {
+			t.Fatal(err)
+		}
+		if clawStatus != "connected" || runStatus != "running" {
+			t.Fatalf("claw=%q run=%q, want connected/running (untouched within grace)", clawStatus, runStatus)
+		}
+	})
 }

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -99,9 +99,10 @@ type Server struct {
 
 	// Reaper state is deliberately in-memory: its conservative timers reset on
 	// a hub restart rather than treating an uncertain outage as an agent failure.
-	reaperMu        sync.Mutex
-	reaperFirstSeen map[string]time.Time
-	nowFunc         func() time.Time
+	reaperMu            sync.Mutex
+	reaperFirstSeen     map[string]time.Time
+	nowFunc             func() time.Time
+	terminateVMOverride func(provider, id string) error // test seam for terminal cleanup
 }
 
 type clawConn struct {
@@ -6416,129 +6417,143 @@ func (s *Server) handleTerminal(w http.ResponseWriter, r *http.Request) {
 
 // terminateVM terminates a provider VM by type and ID.
 func (s *Server) terminateVM(provider, vmID string) {
+	if err := s.terminateVMErr(provider, vmID); err != nil {
+		log.Printf("terminateVM: %v", err)
+	}
+}
+
+func (s *Server) terminateVMErr(provider, vmID string) error {
 	if vmID == "" {
-		return
+		return nil
+	}
+	if s.terminateVMOverride != nil {
+		return s.terminateVMOverride(provider, vmID)
 	}
 	switch provider {
 	case "replicated":
-		s.terminateReplicatedVM(vmID)
+		return s.terminateReplicatedVM(vmID)
 	case "daytona":
-		s.terminateDaytonaVM(vmID)
+		return s.terminateDaytonaVM(vmID)
 	case "exedev":
-		s.terminateExedevVM(vmID)
+		return s.terminateExedevVM(vmID)
 	case "docker":
-		s.terminateDockerVM(vmID)
+		return s.terminateDockerVM(vmID)
 	case "lambda-microvms":
-		s.terminateLambdaMicroVM(vmID)
+		return s.terminateLambdaMicroVM(vmID)
 	default:
-		log.Printf("terminateVM: unsupported provider %q for VM %s", provider, vmID)
+		return fmt.Errorf("unsupported provider %q for VM %s", provider, vmID)
 	}
 }
 
 // terminateDockerVM destroys a Docker agent container by name/ID.
-func (s *Server) terminateDockerVM(vmID string) {
+func (s *Server) terminateDockerVM(vmID string) error {
 	s.mu.RLock()
 	cfg, ok := s.hubCfg.Providers["docker"]
 	s.mu.RUnlock()
 	if !ok {
 		log.Printf("terminateDockerVM: no docker provider configured")
-		return
+		return fmt.Errorf("no docker provider configured")
 	}
 	p, err := newDockerProvider(cfg)
 	if err != nil {
 		log.Printf("terminateDockerVM: provider init error: %v", err)
-		return
+		return err
 	}
 	if err := p.Destroy(context.Background(), vmID, false); err != nil {
 		log.Printf("terminateDockerVM: failed to destroy container %s: %v", vmID, err)
-		return
+		return err
 	}
 	log.Printf("Docker container %s terminated", vmID)
+	return nil
 }
 
 // terminateLambdaMicroVM destroys an AWS Lambda MicroVM by ID.
-func (s *Server) terminateLambdaMicroVM(vmID string) {
+func (s *Server) terminateLambdaMicroVM(vmID string) error {
 	s.mu.RLock()
 	cfg, ok := s.hubCfg.Providers["lambda-microvms"]
 	s.mu.RUnlock()
 	if !ok {
 		log.Printf("terminateLambdaMicroVM: no lambda-microvms provider configured")
-		return
+		return fmt.Errorf("no lambda-microvms provider configured")
 	}
 	p, err := newLambdaMicroVMsProvider(cfg)
 	if err != nil {
 		log.Printf("terminateLambdaMicroVM: provider init error: %v", err)
-		return
+		return err
 	}
 	if err := p.Destroy(context.Background(), vmID, false); err != nil {
 		log.Printf("terminateLambdaMicroVM: failed to destroy MicroVM %s: %v", vmID, err)
-		return
+		return err
 	}
 	log.Printf("Lambda MicroVM %s terminated", vmID)
+	return nil
 }
 
 // terminateExedevVM destroys an exedev VM by ID.
-func (s *Server) terminateExedevVM(vmID string) {
+func (s *Server) terminateExedevVM(vmID string) error {
 	s.mu.RLock()
 	cfg, ok := s.hubCfg.Providers["exedev"]
 	s.mu.RUnlock()
 	if !ok {
 		log.Printf("terminateExedevVM: no exedev provider configured")
-		return
+		return fmt.Errorf("no exedev provider configured")
 	}
 
 	log.Printf("terminateExedevVM: destroying VM %s (ssh_key_path=%q)", vmID, cfg.SSHKeyPath)
 	p, err := newExedevProvider(cfg)
 	if err != nil {
 		log.Printf("terminateExedevVM: provider init error: %v", err)
-		return
+		return err
 	}
 	if err := p.Destroy(context.Background(), vmID, false); err != nil {
 		log.Printf("terminateExedevVM: failed to destroy VM %s: %v", vmID, err)
-		return
+		return err
 	}
 	log.Printf("Exedev VM %s terminated", vmID)
+	return nil
 }
 
 // terminateDaytonaVM destroys a Daytona workspace by ID.
-func (s *Server) terminateDaytonaVM(workspaceID string) {
+func (s *Server) terminateDaytonaVM(workspaceID string) error {
 	s.mu.RLock()
 	cfg, ok := s.hubCfg.Providers["daytona"]
 	s.mu.RUnlock()
 	if !ok {
-		return
+		return fmt.Errorf("no daytona provider configured")
 	}
 	p, err := newDaytonaProvider(cfg)
 	if err != nil {
 		log.Printf("terminateDaytonaVM: provider init error: %v", err)
-		return
+		return err
 	}
 	if err := p.Destroy(context.Background(), workspaceID, false); err != nil {
 		log.Printf("terminateDaytonaVM: failed to destroy workspace %s: %v", workspaceID, err)
-		return
+		return err
 	}
 	log.Printf("Daytona workspace %s terminated", workspaceID)
+	return nil
 }
 
 // terminateReplicatedVM terminates a Replicated CMX VM by ID.
-func (s *Server) terminateReplicatedVM(vmID string) {
+func (s *Server) terminateReplicatedVM(vmID string) error {
 	s.mu.RLock()
 	cfg, ok := s.hubCfg.Providers["replicated"]
 	s.mu.RUnlock()
 	if !ok {
 		log.Printf("terminateReplicatedVM: no replicated provider configured")
-		return
+		return fmt.Errorf("no replicated provider configured")
 	}
 	p, err := newReplicatedProvider(cfg)
 	if err != nil {
 		log.Printf("terminateReplicatedVM: provider init error: %v", err)
-		return
+		return err
 	}
 	if err := p.DeleteVM(context.Background(), vmID); err != nil {
 		log.Printf("terminateReplicatedVM: failed to delete VM %s: %v", vmID, err)
-		return
+		return err
 	}
 	log.Printf("Replicated VM %s terminated", vmID)
+	return nil
 }
 
 // ─── GitHub Token Endpoint ────────────────────────────────────────────────────

--- a/pkg/hub/shortcut.go
+++ b/pkg/hub/shortcut.go
@@ -759,9 +759,9 @@ func (s *Server) createClawForShortcutStory(factory *types.FactoryConfig, action
 		return fmt.Errorf("db insert: %w", err)
 	}
 	if err := s.completeFactoryTrigger(factory.Name, "shortcut", triggerKey, clawID); err != nil {
-		_, _ = s.db.Exec(`UPDATE claws SET status='deleted' WHERE id=?`, clawID)
+		_, _ = s.finishClawTerminalTx(clawID, "deleted", "", "failed", err.Error(), false)
 		if s.cronScheduler != nil {
-			s.cronScheduler.finishRunByClawID(clawID, "failed", err.Error())
+			s.cronScheduler.releaseClawWorkflowSlot(clawID)
 		}
 		return fmt.Errorf("complete factory trigger: %w", err)
 	}
@@ -876,9 +876,9 @@ func (s *Server) createClawForShortcutWorkflow(workspace *types.WorkspaceConfig,
 		return err
 	}
 	if err := s.completeFactoryTrigger(triggerOwner, "shortcut", triggerKey, clawID); err != nil {
-		_, _ = s.db.Exec(`UPDATE claws SET status='deleted' WHERE id=?`, clawID)
+		_, _ = s.finishClawTerminalTx(clawID, "deleted", "", "failed", err.Error(), false)
 		if s.cronScheduler != nil {
-			s.cronScheduler.finishRunByClawID(clawID, "failed", err.Error())
+			s.cronScheduler.releaseClawWorkflowSlot(clawID)
 		}
 		return fmt.Errorf("complete workflow trigger: %w", err)
 	}

--- a/pkg/hub/shortcut.go
+++ b/pkg/hub/shortcut.go
@@ -759,7 +759,7 @@ func (s *Server) createClawForShortcutStory(factory *types.FactoryConfig, action
 		return fmt.Errorf("db insert: %w", err)
 	}
 	if err := s.completeFactoryTrigger(factory.Name, "shortcut", triggerKey, clawID); err != nil {
-		_, _ = s.finishClawTerminalTx(clawID, "deleted", "", "failed", err.Error(), false)
+		_, _ = s.finishClawTerminalTx(clawID, "deleted", "", "failed", err.Error(), terminalTxOpts{})
 		if s.cronScheduler != nil {
 			s.cronScheduler.releaseClawWorkflowSlot(clawID)
 		}
@@ -876,7 +876,7 @@ func (s *Server) createClawForShortcutWorkflow(workspace *types.WorkspaceConfig,
 		return err
 	}
 	if err := s.completeFactoryTrigger(triggerOwner, "shortcut", triggerKey, clawID); err != nil {
-		_, _ = s.finishClawTerminalTx(clawID, "deleted", "", "failed", err.Error(), false)
+		_, _ = s.finishClawTerminalTx(clawID, "deleted", "", "failed", err.Error(), terminalTxOpts{})
 		if s.cronScheduler != nil {
 			s.cronScheduler.releaseClawWorkflowSlot(clawID)
 		}

--- a/pkg/hub/terminal_transitions.go
+++ b/pkg/hub/terminal_transitions.go
@@ -1,0 +1,101 @@
+package hub
+
+import (
+	"database/sql"
+	"log"
+	"strings"
+	"time"
+)
+
+func (s *Server) execStatusLogged(opCtx, query string, args ...any) (sql.Result, error) {
+	res, err := s.db.Exec(query, args...)
+	if err != nil {
+		log.Printf("[status-write] %s failed: %v", opCtx, err)
+	}
+	return res, err
+}
+
+func (s *Server) execTerminalStatus(opCtx, query string, args ...any) (sql.Result, error) {
+	res, err := s.db.Exec(query, args...)
+	if err == nil {
+		return res, nil
+	}
+	time.Sleep(100 * time.Millisecond)
+	res, retryErr := s.db.Exec(query, args...)
+	if retryErr != nil {
+		log.Printf("[status-write] TERMINAL transition failed twice (%s): %v — leaving for reaper", opCtx, retryErr)
+	}
+	return res, retryErr
+}
+
+// finishClawTerminalTx atomically changes a claw's terminal-ish state and its
+// running workflow run. A zero-row claw update is an idempotent no-op.
+func (s *Server) finishClawTerminalTx(clawID, clawStatus, diagnostic, runStatus, runResult string, setStopCommentPending bool) (bool, error) {
+	var last error
+	for attempt := 0; attempt < 2; attempt++ {
+		tx, err := s.db.Begin()
+		if err == nil {
+			var res sql.Result
+			switch clawStatus {
+			case "deleted":
+				res, err = tx.Exec(`UPDATE claws SET status=?, bootstrap_status='' WHERE id=? AND status != 'deleted'`, clawStatus, clawID)
+			case "idle":
+				res, err = tx.Exec(`UPDATE claws SET status=? WHERE id=? AND status NOT IN ('deleted','error')`, clawStatus, clawID)
+			default:
+				pending := 0
+				if setStopCommentPending {
+					pending = 1
+				}
+				res, err = tx.Exec(`UPDATE claws SET status=?, bootstrap_status='', bootstrap_diagnostic=?, stop_comment_pending=? WHERE id=? AND status NOT IN ('deleted','error')`, clawStatus, diagnostic, pending, clawID)
+				// Some test/legacy schemas predate the marker migration. The
+				// migration runs in production; retain terminal atomicity there too.
+				if err != nil && strings.Contains(strings.ToLower(err.Error()), "no such column: stop_comment_pending") {
+					res, err = tx.Exec(`UPDATE claws SET status=?, bootstrap_status='', bootstrap_diagnostic=? WHERE id=? AND status NOT IN ('deleted','error')`, clawStatus, diagnostic, clawID)
+				}
+			}
+			if err == nil {
+				rows, rowsErr := res.RowsAffected()
+				if rowsErr != nil {
+					err = rowsErr
+				} else if rows == 0 {
+					_ = tx.Rollback()
+					return false, nil
+				}
+			}
+			if err == nil {
+				_, err = tx.Exec(`UPDATE workflow_runs SET status=?, result=?, finished_at=? WHERE claw_id=? AND status='running'`, runStatus, runResult, time.Now().UTC(), clawID)
+			}
+			if err == nil {
+				err = tx.Commit()
+			} else {
+				_ = tx.Rollback()
+			}
+		}
+		if err == nil {
+			return true, nil
+		}
+		last = err
+		if attempt == 0 {
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+	log.Printf("[status-write] TERMINAL transition failed twice (claw %s): %v — leaving for reaper", clawID, last)
+	return false, last
+}
+
+func isNotFoundTerminateError(err error) bool {
+	if err == nil {
+		return true
+	}
+	s := strings.ToLower(err.Error())
+	return strings.Contains(s, "not found") || strings.Contains(s, "404")
+}
+
+func (s *Server) terminateVMForClaw(clawID, provider, providerID string) {
+	err := s.terminateVMErr(provider, providerID)
+	if isNotFoundTerminateError(err) {
+		_, _ = s.execStatusLogged("clear provider_id claw "+clawID, `UPDATE claws SET provider_id='' WHERE id=? AND provider_id=?`, clawID, providerID)
+		return
+	}
+	log.Printf("[reaper] VM terminate for claw %s failed: %v", clawID, err)
+}

--- a/pkg/hub/terminal_transitions.go
+++ b/pkg/hub/terminal_transitions.go
@@ -28,9 +28,21 @@ func (s *Server) execTerminalStatus(opCtx, query string, args ...any) (sql.Resul
 	return res, retryErr
 }
 
+// terminalTxOpts tunes side effects applied inside the terminal transaction.
+type terminalTxOpts struct {
+	// setStopCommentPending marks the claw as owing an issue-tracker comment,
+	// so the reaper can re-drive delivery after a crash.
+	setStopCommentPending bool
+	// clearProviderID drops the VM handle in the same transaction, for callers
+	// that already know the VM is gone. Clearing it separately after commit
+	// would leave a crash window in which the reaper re-terminates the VM the
+	// caller meant to spare.
+	clearProviderID bool
+}
+
 // finishClawTerminalTx atomically changes a claw's terminal-ish state and its
 // running workflow run. A zero-row claw update is an idempotent no-op.
-func (s *Server) finishClawTerminalTx(clawID, clawStatus, diagnostic, runStatus, runResult string, setStopCommentPending bool) (bool, error) {
+func (s *Server) finishClawTerminalTx(clawID, clawStatus, diagnostic, runStatus, runResult string, opts terminalTxOpts) (bool, error) {
 	var last error
 	for attempt := 0; attempt < 2; attempt++ {
 		tx, err := s.db.Begin()
@@ -38,12 +50,12 @@ func (s *Server) finishClawTerminalTx(clawID, clawStatus, diagnostic, runStatus,
 			var res sql.Result
 			switch clawStatus {
 			case "deleted":
-				res, err = tx.Exec(`UPDATE claws SET status=?, bootstrap_status='' WHERE id=? AND status != 'deleted'`, clawStatus, clawID)
+				res, err = tx.Exec(`UPDATE claws SET status=?, bootstrap_status='' WHERE id=? AND status NOT IN ('deleted','error')`, clawStatus, clawID)
 			case "idle":
 				res, err = tx.Exec(`UPDATE claws SET status=? WHERE id=? AND status NOT IN ('deleted','error')`, clawStatus, clawID)
 			default:
 				pending := 0
-				if setStopCommentPending {
+				if opts.setStopCommentPending {
 					pending = 1
 				}
 				res, err = tx.Exec(`UPDATE claws SET status=?, bootstrap_status='', bootstrap_diagnostic=?, stop_comment_pending=? WHERE id=? AND status NOT IN ('deleted','error')`, clawStatus, diagnostic, pending, clawID)
@@ -61,6 +73,9 @@ func (s *Server) finishClawTerminalTx(clawID, clawStatus, diagnostic, runStatus,
 					_ = tx.Rollback()
 					return false, nil
 				}
+			}
+			if err == nil && opts.clearProviderID {
+				_, err = tx.Exec(`UPDATE claws SET provider_id='' WHERE id=?`, clawID)
 			}
 			if err == nil {
 				_, err = tx.Exec(`UPDATE workflow_runs SET status=?, result=?, finished_at=? WHERE claw_id=? AND status='running'`, runStatus, runResult, time.Now().UTC(), clawID)

--- a/pkg/hub/terminal_transitions_test.go
+++ b/pkg/hub/terminal_transitions_test.go
@@ -1,0 +1,120 @@
+package hub
+
+import (
+	"bytes"
+	"errors"
+	"log"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func TestStopAgentTerminalAtomicallyFinishesWorkflowRun(t *testing.T) {
+	s, db := newReaperTestServer(t, &types.HubConfig{})
+	tm := time.Now().UTC()
+	if _, err := db.Exec(`INSERT INTO claws(id,tenant_id,name,status,created_at) VALUES('terminal-atomic','tenant','terminal','connected',?)`, tm); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO workflow_runs(id,tenant_id,workflow_name,workspace_name,status,claw_id,created_at) VALUES('terminal-run','tenant','workflow','workspace','running','terminal-atomic',?)`, tm); err != nil {
+		t.Fatal(err)
+	}
+
+	s.stopAgentWithReason("terminal-atomic", "Bootstrap failed: API_KEY=do-not-log", true)
+
+	var clawStatus, diagnostic, runStatus string
+	if err := db.QueryRow(`SELECT status, bootstrap_diagnostic FROM claws WHERE id='terminal-atomic'`).Scan(&clawStatus, &diagnostic); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT status FROM workflow_runs WHERE id='terminal-run'`).Scan(&runStatus); err != nil {
+		t.Fatal(err)
+	}
+	if clawStatus != "error" || runStatus != "failed" {
+		t.Fatalf("terminal states claw=%q run=%q, want error/failed", clawStatus, runStatus)
+	}
+	if strings.Contains(diagnostic, "do-not-log") || !strings.Contains(diagnostic, "Bootstrap failed") {
+		t.Fatalf("diagnostic was not sanitized: %q", diagnostic)
+	}
+}
+
+func TestTerminalTransitionClosedDBLogsLoudly(t *testing.T) {
+	s, db := newReaperTestServer(t, &types.HubConfig{})
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	var logs bytes.Buffer
+	old := log.Writer()
+	log.SetOutput(&logs)
+	t.Cleanup(func() { log.SetOutput(old) })
+
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("stopAgentTerminalWithReason panicked: %v", r)
+			}
+		}()
+		s.stopAgentTerminalWithReason("closed-db", "failure", true)
+	}()
+	if !strings.Contains(logs.String(), "TERMINAL transition failed twice") {
+		t.Fatalf("missing loud terminal failure log: %s", logs.String())
+	}
+	logs.Reset()
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("execTerminalStatus panicked: %v", r)
+			}
+		}()
+		_, _ = s.execTerminalStatus("closed-db", `UPDATE claws SET status='error' WHERE id=?`, "closed-db")
+	}()
+	if !strings.Contains(logs.String(), "TERMINAL transition failed twice") {
+		t.Fatalf("missing loud exec terminal failure log: %s", logs.String())
+	}
+}
+
+func TestStopAgentTerminalIsIdempotent(t *testing.T) {
+	s, db := newReaperTestServer(t, &types.HubConfig{})
+	tm := time.Now().UTC()
+	if _, err := db.Exec(`INSERT INTO claws(id,tenant_id,name,provider,provider_id,status,created_at) VALUES('terminal-once','tenant','once','fake','vm-1','connected',?)`, tm); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO workflow_runs(id,tenant_id,workflow_name,workspace_name,status,claw_id,created_at) VALUES('once-run','tenant','workflow','workspace','running','terminal-once',?)`, tm); err != nil {
+		t.Fatal(err)
+	}
+	terminations := 0
+	s.terminateVMOverride = func(_, _ string) error { terminations++; return nil }
+	s.stopAgentTerminalWithReason("terminal-once", "failure", false)
+	s.stopAgentTerminalWithReason("terminal-once", "failure", false)
+	if terminations != 1 {
+		t.Fatalf("VM terminations=%d, want 1", terminations)
+	}
+	var runStatus string
+	if err := db.QueryRow(`SELECT status FROM workflow_runs WHERE id='once-run'`).Scan(&runStatus); err != nil || runStatus != "failed" {
+		t.Fatalf("workflow run status=%q err=%v, want failed", runStatus, err)
+	}
+}
+
+func TestTerminateVMForClawClearsOnlyNotFound(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"not found", errors.New("provider returned 404 not found"), ""},
+		{"transient", errors.New("temporary network failure"), "vm-1"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s, db := newReaperTestServer(t, &types.HubConfig{})
+			if _, err := db.Exec(`INSERT INTO claws(id,tenant_id,name,provider,provider_id,status,created_at) VALUES('vm-error','tenant','vm','fake','vm-1','error',?)`, time.Now().UTC()); err != nil {
+				t.Fatal(err)
+			}
+			s.terminateVMOverride = func(_, _ string) error { return tc.err }
+			s.terminateVMForClaw("vm-error", "fake", "vm-1")
+			var got string
+			if err := db.QueryRow(`SELECT provider_id FROM claws WHERE id='vm-error'`).Scan(&got); err != nil || got != tc.want {
+				t.Fatalf("provider_id=%q err=%v, want %q", got, err, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/hub/terminal_transitions_test.go
+++ b/pkg/hub/terminal_transitions_test.go
@@ -118,3 +118,64 @@ func TestTerminateVMForClawClearsOnlyNotFound(t *testing.T) {
 		})
 	}
 }
+
+func TestStopAgentSkipVMTerminateClearsProviderIDInTerminalTx(t *testing.T) {
+	s, db := newReaperTestServer(t, &types.HubConfig{})
+	tm := time.Now().UTC()
+	if _, err := db.Exec(`INSERT INTO claws(id,tenant_id,name,status,provider,provider_id,created_at) VALUES('skip-vm-claw','tenant','skip','connected','fake','vm-9',?)`, tm); err != nil {
+		t.Fatal(err)
+	}
+	terminated := false
+	s.terminateVMOverride = func(_, _ string) error { terminated = true; return nil }
+
+	s.stopAgentWithReason("skip-vm-claw", "caller already saw the VM terminated", true)
+
+	var status, providerID string
+	if err := db.QueryRow(`SELECT status, provider_id FROM claws WHERE id='skip-vm-claw'`).Scan(&status, &providerID); err != nil {
+		t.Fatal(err)
+	}
+	if status != "error" || providerID != "" {
+		t.Fatalf("claw status=%q provider_id=%q, want error with cleared provider_id", status, providerID)
+	}
+	if terminated {
+		t.Fatal("VM terminate was invoked despite skipVMTerminate=true")
+	}
+	// A cleared provider_id must also keep the claw out of the reaper's
+	// zombie-VM sweep.
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM claws WHERE status IN ('error','deleted') AND provider_id != ''`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatalf("claw still matches the reaper zombie-VM query")
+	}
+}
+
+func TestFinishClawTerminalTxKeepsErrorSticky(t *testing.T) {
+	s, db := newReaperTestServer(t, &types.HubConfig{})
+	tm := time.Now().UTC()
+	if _, err := db.Exec(`INSERT INTO claws(id,tenant_id,name,status,bootstrap_diagnostic,created_at) VALUES('sticky','tenant','sticky','error','it failed',?)`, tm); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO workflow_runs(id,tenant_id,workflow_name,workspace_name,status,claw_id,created_at) VALUES('sticky-run','tenant','workflow','workspace','running','sticky',?)`, tm); err != nil {
+		t.Fatal(err)
+	}
+
+	applied, err := s.finishClawTerminalTx("sticky", "deleted", "", "completed", "success", terminalTxOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if applied {
+		t.Fatal("error claw was promoted to deleted; error must stay sticky")
+	}
+	var status, runStatus string
+	if err := db.QueryRow(`SELECT status FROM claws WHERE id='sticky'`).Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT status FROM workflow_runs WHERE id='sticky-run'`).Scan(&runStatus); err != nil {
+		t.Fatal(err)
+	}
+	if status != "error" || runStatus != "running" {
+		t.Fatalf("claw=%q run=%q, want error/running untouched", status, runStatus)
+	}
+}

--- a/pkg/hub/terminal_transitions_test.go
+++ b/pkg/hub/terminal_transitions_test.go
@@ -82,12 +82,35 @@ func TestStopAgentTerminalIsIdempotent(t *testing.T) {
 	if _, err := db.Exec(`INSERT INTO workflow_runs(id,tenant_id,workflow_name,workspace_name,status,claw_id,created_at) VALUES('once-run','tenant','workflow','workspace','running','terminal-once',?)`, tm); err != nil {
 		t.Fatal(err)
 	}
-	terminations := 0
-	s.terminateVMOverride = func(_, _ string) error { terminations++; return nil }
+	terminations := make(chan struct{}, 2)
+	s.terminateVMOverride = func(_, _ string) error { terminations <- struct{}{}; return nil }
 	s.stopAgentTerminalWithReason("terminal-once", "failure", false)
 	s.stopAgentTerminalWithReason("terminal-once", "failure", false)
-	if terminations != 1 {
-		t.Fatalf("VM terminations=%d, want 1", terminations)
+	// The VM terminate runs on a goroutine; the first stop must invoke it
+	// exactly once and the second (idempotent no-op) not at all.
+	select {
+	case <-terminations:
+	case <-time.After(2 * time.Second):
+		t.Fatal("VM terminate was not invoked by the first stop")
+	}
+	select {
+	case <-terminations:
+		t.Fatal("VM terminate invoked more than once")
+	case <-time.After(100 * time.Millisecond):
+	}
+	// Wait for the terminate goroutine's provider_id clear so it cannot
+	// outlive the test and race the DB teardown.
+	for deadline := time.Now().Add(2 * time.Second); ; time.Sleep(10 * time.Millisecond) {
+		var providerID string
+		if err := db.QueryRow(`SELECT provider_id FROM claws WHERE id='terminal-once'`).Scan(&providerID); err != nil {
+			t.Fatal(err)
+		}
+		if providerID == "" {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("provider_id=%q was never cleared after terminate", providerID)
+		}
 	}
 	var runStatus string
 	if err := db.QueryRow(`SELECT status FROM workflow_runs WHERE id='once-run'`).Scan(&runStatus); err != nil || runStatus != "failed" {


### PR DESCRIPTION
## Summary

Liveness follow-up to #488. The reaper added there eventually cleans zombies, but each crash mid-termination still created temporary zombies and misleading state, because multi-step terminations were non-atomic, non-idempotent, and full of swallowed status writes.

### Atomic DB-side terminal transitions
- New `finishClawTerminalTx` (pkg/hub/terminal_transitions.go) groups the claw status change and the `workflow_runs` finish into a single SQLite transaction, retried once, with a loud `TERMINAL transition failed twice … leaving for reaper` log on double failure. Zero-row updates make re-runs idempotent no-ops.
- All terminal paths converted: `stopAgentTerminalWithReason`, pipeline terminal stages, the done signal, PR-merged teardown, and the tracker-delete paths (Linear/Jira/GitHub Issues/Shortcut/PR watcher/external webhook).
- `finishRunByClawID` is split so its in-memory overlap-counter half (`releaseClawWorkflowSlot`) can run after the transaction commits.
- `handleClawDoneSignal` now commits the DB transition **before** moving tracker issues — a crash leaves the tracker behind (re-drivable), never the claw state.

### Re-drivable side effects (reaper)
- **VM terminate:** `provider_id` doubles as the marker. `terminateVMForClaw` clears it only on successful destroy (not-found/404 counts as success). The reaper re-drives terminal claws that still carry a `provider_id` after a 2-minute grace.
- **Tracker stop-comment:** new `stop_comment_pending` column set inside the terminal transaction (1 = pending, 2 = claimed in-flight, 0 = done). Failed deliveries restore pending with grace-spaced backoff; the reaper re-drives and clears markers whose context can no longer be resolved. The claim prevents duplicate comments from a slow initial delivery racing a re-drive.
- **Stranded terminal stages:** if a claimed terminal pipeline stage's transaction exhausted its retries, the reaper completes it — but only after a 5-minute grace that exceeds the legitimate streaming-wait + checkpoint window, so it never races an in-flight termination.

### No more silent status writes
- `execStatusLogged` (log with claw/trigger context) replaces the swallowed `_, _ = s.db.Exec(UPDATE claws SET status=…)` pattern on non-terminal transitions; `execTerminalStatus` (retry once + loud escalation) covers terminal ones. `claw_prs` bookkeeping writes were intentionally left out of scope.

## Tests
Crash-injection and re-drive coverage per the acceptance criteria: terminal tx atomicity; closed-DB → loud log, no panic, no partial state; double-stop idempotency (no duplicate events/finishes); `terminateVMForClaw` clears only on not-found; reaper re-drives VM + comments (including a single-connection SQLite regression test for a row-cursor deadlock caught in review); pending retained on tracker 500; stranded-stage recovery respects the grace; done-signal crash variant proves zero tracker requests when the DB tx fails.

`go build ./…`, `go vet ./…`, `go test ./pkg/hub/…` all green.

## Process
Implemented by gpt-5.6 (Codex) from a written spec, independently reviewed by Fable 5 and gpt-5.6 (review findings — cursor deadlock under `MaxOpenConns(1)`, sync VM terminate stalling the reaper tick, duplicate-comment races, marker-clearing inconsistencies — were fixed and are covered by tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)