### PR TITLE
fix(claw-bridge): WebSocket robustness — bounded writes, keepalive, goroutine leaks, turn delivery

### DIFF
--- a/cmd/claw-bridge/checkpoint.go
+++ b/cmd/claw-bridge/checkpoint.go
@@ -14,9 +14,13 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
+
+var hubHTTPClient = &http.Client{Timeout: 30 * time.Second}
+var hubTransferHTTPClient = &http.Client{Timeout: 10 * time.Minute}
 
 type checkpointLocalFile struct {
 	entry types.CheckpointFile
@@ -235,7 +239,7 @@ func checkpointJSON(ctx context.Context, req types.CheckpointCreatePayload, meth
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("X-Claw-Token", req.ClawToken)
-	resp, err := http.DefaultClient.Do(httpReq)
+	resp, err := hubHTTPClient.Do(httpReq)
 	if err != nil {
 		return err
 	}
@@ -257,7 +261,7 @@ func putCheckpointBlob(ctx context.Context, req types.CheckpointCreatePayload, s
 		return err
 	}
 	httpReq.Header.Set("X-Claw-Token", req.ClawToken)
-	resp, err := http.DefaultClient.Do(httpReq)
+	resp, err := hubTransferHTTPClient.Do(httpReq)
 	if err != nil {
 		return err
 	}

--- a/cmd/claw-bridge/files.go
+++ b/cmd/claw-bridge/files.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 	"nhooyr.io/websocket"
-	"nhooyr.io/websocket/wsjson"
 )
 
 // uploadDirPath lands files inside OpenClaw's workspace so the agent's
@@ -71,7 +70,7 @@ func handleFileMessage(ctx context.Context, conn *websocket.Conn, payload json.R
 }
 
 func sendAck(ctx context.Context, conn *websocket.Conn, ack types.FileAck) {
-	_ = wsjson.Write(ctx, conn, hubMsg{
+	_ = writeHubMessage(ctx, conn, hubMsg{
 		Type:    "file_ack",
 		Payload: mustJSON(ack),
 	})
@@ -92,7 +91,7 @@ func handleFileReadMessage(ctx context.Context, conn *websocket.Conn, payload js
 	}
 	resp := types.FileReadResp{RequestID: req.RequestID}
 	send := func() {
-		_ = wsjson.Write(ctx, conn, hubMsg{Type: "file_read_resp", Payload: mustJSON(resp)})
+		_ = writeHubMessage(ctx, conn, hubMsg{Type: "file_read_resp", Payload: mustJSON(resp)})
 	}
 
 	dir := uploadDirPath()

--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -66,6 +66,13 @@ type hubMsg struct {
 	Payload json.RawMessage `json:"payload,omitempty"`
 }
 
+func deliverInFlight(inf *inFlightState, result agentResult) {
+	select {
+	case inf.done <- result:
+	default:
+	}
+}
+
 // ─── Inbound message queue ───────────────────────────────────────────────────
 // Queues user messages when the hub connection is temporarily unavailable.
 // Messages older than msgQueueTTL are dropped to prevent unbounded growth.
@@ -864,8 +871,19 @@ func (gs *gatewaySession) getSessionKey() string {
 
 func (gs *gatewaySession) setSessionKey(key string) {
 	gs.sessionMu.Lock()
+	oldKey := gs.sessionKey
 	gs.sessionKey = key
 	gs.sessionMu.Unlock()
+
+	if oldKey == "" || oldKey == key {
+		return
+	}
+	gs.infMu.RLock()
+	inf := gs.inFlight
+	gs.infMu.RUnlock()
+	if inf != nil {
+		deliverInFlight(inf, agentResult{err: fmt.Errorf("gateway session key rotated")})
+	}
 }
 
 func (gs *gatewaySession) currentConn() *websocket.Conn {
@@ -1141,10 +1159,7 @@ func (gs *gatewaySession) readLoop(ctx context.Context) {
 			inf := gs.inFlight
 			gs.infMu.RUnlock()
 			if inf != nil {
-				select {
-				case inf.done <- agentResult{err: fmt.Errorf("gateway disconnected")}:
-				default:
-				}
+				deliverInFlight(inf, agentResult{err: fmt.Errorf("gateway disconnected")})
 			}
 			if gs.client == nil {
 				return
@@ -1273,7 +1288,7 @@ func (gs *gatewaySession) readLoop(ctx context.Context) {
 				switch agentPayload.Data.Phase {
 				case "end":
 					log.Printf("[gateway] agent turn complete")
-					inf.done <- agentResult{text: strings.TrimSpace(inf.fullText.String())}
+					deliverInFlight(inf, agentResult{text: strings.TrimSpace(inf.fullText.String())})
 				case "error":
 					msg := agentPayload.Data.Error
 					if msg == "" {
@@ -1284,7 +1299,7 @@ func (gs *gatewaySession) readLoop(ctx context.Context) {
 					}
 					log.Printf("[gateway] agent turn error: %s", msg)
 					inf.emitActivity(cleanAgentActivity(agentActivity{Kind: "session_error", Stream: "lifecycle", Phase: "error", Error: msg}))
-					inf.done <- agentResult{err: fmt.Errorf("%s", msg)}
+					deliverInFlight(inf, agentResult{err: fmt.Errorf("%s", msg)})
 				}
 			}
 		}
@@ -1567,10 +1582,7 @@ func markGatewayProcessExited() {
 	inf := gs.inFlight
 	gs.infMu.RUnlock()
 	if inf != nil {
-		select {
-		case inf.done <- agentResult{err: fmt.Errorf("gateway process exited")}:
-		default:
-		}
+		deliverInFlight(inf, agentResult{err: fmt.Errorf("gateway process exited")})
 	}
 }
 

--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -3617,6 +3617,9 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 			go handleFileReadMessage(connCtx, conn, msg.Payload)
 
 		case "checkpoint_create":
+			// Intentionally uses the signal ctx, not connCtx: the handler reports
+			// back over HTTP (never writes to conn), and an in-progress checkpoint
+			// upload must survive hub reconnects.
 			go handleCheckpointCreate(ctx, msg.Payload)
 
 		case "volume_attach":

--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -73,6 +73,44 @@ func deliverInFlight(inf *inFlightState, result agentResult) {
 	}
 }
 
+func writeHubMessage(ctx context.Context, conn *websocket.Conn, msg hubMsg) error {
+	writeCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	return wsjson.Write(writeCtx, conn, msg)
+}
+
+func startHubKeepalives(ctx context.Context, ping func(context.Context) error, onPingFailure func(), heartbeat func()) {
+	go func() {
+		ticker := time.NewTicker(30 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if err := ping(ctx); err != nil {
+					log.Printf("[hub] ping failed: %v", err)
+					onPingFailure()
+					return
+				}
+			}
+		}
+	}()
+
+	go func() {
+		ticker := time.NewTicker(15 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				heartbeat()
+			}
+		}
+	}()
+}
+
 // ─── Inbound message queue ───────────────────────────────────────────────────
 // Queues user messages when the hub connection is temporarily unavailable.
 // Messages older than msgQueueTTL are dropped to prevent unbounded growth.
@@ -3269,8 +3307,14 @@ func runStatusChannel(ctx context.Context, wsURL, clawID, clawName, templateName
 				case <-pingCtx.Done():
 					return
 				case <-ticker.C:
-					if err := conn.Ping(pingCtx); err != nil {
+					pingDeadlineCtx, pingDeadlineCancel := context.WithTimeout(pingCtx, 10*time.Second)
+					err := conn.Ping(pingDeadlineCtx)
+					pingDeadlineCancel()
+					if err != nil {
 						log.Printf("[status] ping failed: %v", err)
+						// Tear the connection down so the read loop unblocks and
+						// reconnects; a pong timeout does not close the conn itself.
+						conn.CloseNow()
 						return
 					}
 				}
@@ -3309,7 +3353,12 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 		return fmt.Errorf("dial hub: %w", err)
 	}
 	conn.SetReadLimit(32 * 1024 * 1024) // 32MB
+	connCtx, connCancel := context.WithCancel(ctx)
+	defer connCancel()
 	defer conn.CloseNow()
+	writeHub := func(msg hubMsg) error {
+		return writeHubMessage(connCtx, conn, msg)
+	}
 
 	// Register with the hub — gateway_ready=false until session is established
 	reg := hubMsg{
@@ -3322,7 +3371,7 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 			"gateway_ready": gwSession.IsReady(),
 		}),
 	}
-	if err := wsjson.Write(ctx, conn, reg); err != nil {
+	if err := writeHub(reg); err != nil {
 		return fmt.Errorf("register: %w", err)
 	}
 
@@ -3336,8 +3385,8 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 	}
 	log.Printf("registered with hub as %s", clawID)
 
-	writeActivity := func(connCtx context.Context, activity agentActivity) {
-		_ = wsjson.Write(connCtx, conn, hubMsg{
+	writeActivity := func(activity agentActivity) {
+		_ = writeHub(hubMsg{
 			Type:    "agent_activity",
 			Payload: mustJSON(cleanAgentActivity(activity)),
 		})
@@ -3346,23 +3395,22 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 	// Replay any queued messages that arrived while we were disconnected
 	if queued := queue.drain(); len(queued) > 0 {
 		log.Printf("[bridge] replaying %d queued message(s)", len(queued))
-		connCtx := ctx
 		for _, content := range queued {
 			go func(c string) {
 				agentCtx, agentCancel := context.WithTimeout(context.Background(), 30*time.Minute)
 				defer agentCancel()
 				reply, agentErr := gwSession.SendMessage(agentCtx, c, func(chunk string) {
-					_ = wsjson.Write(connCtx, conn, hubMsg{
+					_ = writeHub(hubMsg{
 						Type:    "chunk",
 						Payload: mustJSON(map[string]interface{}{"role": "claw", "content": chunk}),
 					})
 				}, func(activity agentActivity) {
-					writeActivity(connCtx, activity)
+					writeActivity(activity)
 				})
 				if agentErr != nil {
 					reply = fmt.Sprintf("⚠️ error: %v", agentErr)
 				}
-				if writeErr := wsjson.Write(connCtx, conn, hubMsg{
+				if writeErr := writeHub(hubMsg{
 					Type:    "message",
 					Payload: mustJSON(map[string]interface{}{"role": "claw", "content": reply}),
 				}); writeErr != nil {
@@ -3377,35 +3425,34 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 	// Wire up the HTTP proxy send function for this connection
 	proxy.mu.Lock()
 	proxy.send = func(msg hubMsg) error {
-		return wsjson.Write(ctx, conn, msg)
+		return writeHub(msg)
 	}
 	proxy.mu.Unlock()
 
-	// Heartbeat goroutine — includes context_usage from persistent session
-	go func() {
-		ticker := time.NewTicker(15 * time.Second)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				// Refresh context usage before sending heartbeat (best-effort)
-				go gwSession.refreshContextUsage(ctx)
-				health := !gatewayProcessExited() && checkGateway(gwClient.addr)
-				cu := gwSession.ContextUsage()
-				log.Printf("[heartbeat] sending: gateway_healthy=%v gateway_ready=%v context_usage=%d%%", health, gwSession.IsReady(), cu)
-				_ = wsjson.Write(ctx, conn, hubMsg{
-					Type: "heartbeat",
-					Payload: mustJSON(map[string]interface{}{
-						"gateway_healthy": health,
-						"gateway_ready":   gwSession.IsReady(),
-						"context_usage":   cu,
-					}),
-				})
-			}
-		}
-	}()
+	startHubKeepalives(connCtx, func(pingCtx context.Context) error {
+		pingCtx, cancel := context.WithTimeout(pingCtx, 10*time.Second)
+		defer cancel()
+		return conn.Ping(pingCtx)
+	}, func() {
+		// A failed ping means the connection is dead or half-open. The websocket
+		// library does not close the conn on a pong timeout, so tear it down
+		// explicitly to unblock the main read loop and trigger reconnection.
+		connCancel()
+		conn.CloseNow()
+	}, func() {
+		go gwSession.refreshContextUsage(connCtx)
+		health := !gatewayProcessExited() && checkGateway(gwClient.addr)
+		cu := gwSession.ContextUsage()
+		log.Printf("[heartbeat] sending: gateway_healthy=%v gateway_ready=%v context_usage=%d%%", health, gwSession.IsReady(), cu)
+		_ = writeHub(hubMsg{
+			Type: "heartbeat",
+			Payload: mustJSON(map[string]interface{}{
+				"gateway_healthy": health,
+				"gateway_ready":   gwSession.IsReady(),
+				"context_usage":   cu,
+			}),
+		})
+	})
 
 	// Main read loop
 	for {
@@ -3417,7 +3464,7 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 		log.Printf("recv type=%s", msg.Type)
 		switch msg.Type {
 		case "message":
-			go func(connCtx context.Context, payload json.RawMessage) {
+			go func(payload json.RawMessage) {
 				var m map[string]interface{}
 				if err := json.Unmarshal(payload, &m); err != nil {
 					log.Printf("payload unmarshal error: %v", err)
@@ -3439,7 +3486,7 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 				log.Printf("[bridge] → openclaw: %q", content[:min(len(content), 80)])
 
 				reply, agentErr := gwSession.SendMessage(agentCtx, content, func(chunk string) {
-					_ = wsjson.Write(connCtx, conn, hubMsg{
+					_ = writeHub(hubMsg{
 						Type: "chunk",
 						Payload: mustJSON(map[string]interface{}{
 							"role":    "claw",
@@ -3447,7 +3494,7 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 						}),
 					})
 				}, func(activity agentActivity) {
-					writeActivity(connCtx, activity)
+					writeActivity(activity)
 				})
 				if agentErr != nil {
 					log.Printf("[bridge] ✗ agent error: %v", agentErr)
@@ -3456,7 +3503,7 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 					log.Printf("[bridge] ← openclaw: %q", reply[:min(len(reply), 120)])
 				}
 
-				if writeErr := wsjson.Write(connCtx, conn, hubMsg{
+				if writeErr := writeHub(hubMsg{
 					Type:    "message",
 					Payload: mustJSON(map[string]interface{}{"role": "claw", "content": reply}),
 				}); writeErr != nil {
@@ -3464,7 +3511,7 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 					log.Printf("[bridge] hub write failed, queuing original message for replay: %v", writeErr)
 					queue.push(content)
 				}
-			}(ctx, msg.Payload)
+			}(msg.Payload)
 
 		case "http_proxy_res":
 			var res httpProxyRes
@@ -3473,19 +3520,19 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 			}
 
 		case "file":
-			go handleFileMessage(ctx, conn, msg.Payload)
+			go handleFileMessage(connCtx, conn, msg.Payload)
 
 		case "file_read":
-			go handleFileReadMessage(ctx, conn, msg.Payload)
+			go handleFileReadMessage(connCtx, conn, msg.Payload)
 
 		case "checkpoint_create":
 			go handleCheckpointCreate(ctx, msg.Payload)
 
 		case "volume_attach":
-			go handleVolumeAttach(ctx, conn, msg.Payload)
+			go handleVolumeAttach(connCtx, conn, msg.Payload)
 
 		case "volume_sync":
-			go handleVolumeSync(ctx, conn, msg.Payload)
+			go handleVolumeSync(connCtx, conn, msg.Payload)
 
 		default:
 			// ignore unknown message types

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -729,6 +730,78 @@ func TestSessionKeyRotationFailsInFlightTurn(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("session key rotation did not fail the in-flight turn")
+	}
+}
+
+func TestHubKeepalivesExitWhenConnectionContextIsCancelled(t *testing.T) {
+	before := runtime.NumGoroutine()
+	for range 10 {
+		ctx, cancel := context.WithCancel(context.Background())
+		startHubKeepalives(ctx, func(context.Context) error { return nil }, func() {}, func() {})
+		cancel()
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for runtime.NumGoroutine() > before+2 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := runtime.NumGoroutine(); got > before+2 {
+		t.Fatalf("goroutines after cancelled hub connections = %d, want at most %d", got, before+2)
+	}
+}
+
+// TestRunHubLoopDoesNotLeakKeepaliveGoroutinesAcrossReconnects drives the real
+// runHubLoop through several connect/disconnect cycles against an in-process
+// fake hub and asserts the keepalive goroutines started per connection do not
+// outlive it. This fails if the heartbeat/ping goroutines are keyed to the
+// process-lifetime context instead of the per-connection context.
+func TestRunHubLoopDoesNotLeakKeepaliveGoroutinesAcrossReconnects(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.CloseNow()
+
+		var reg hubMsg
+		if err := wsjson.Read(r.Context(), conn, &reg); err != nil {
+			return
+		}
+		if reg.Type != "register" {
+			t.Errorf("first frame type = %q, want register", reg.Type)
+			return
+		}
+		if err := wsjson.Write(r.Context(), conn, hubMsg{Type: "registered"}); err != nil {
+			return
+		}
+		// Close immediately to force the bridge onto its reconnect path.
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	gwClient := &gatewayClient{addr: "127.0.0.1:0"}
+	gwSession := &gatewaySession{}
+	proxy := newHTTPProxy(nil)
+	queue := &msgQueue{}
+
+	before := runtime.NumGoroutine()
+	const cycles = 5
+	for range cycles {
+		err := runHubLoop(ctx, wsURL, "claw-test", "test-claw", "test-template", "tok", gwClient, gwSession, proxy, queue)
+		if err == nil {
+			t.Fatal("runHubLoop returned nil error, want read error after hub-side close")
+		}
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for runtime.NumGoroutine() > before+2 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := runtime.NumGoroutine(); got > before+2 {
+		t.Fatalf("goroutines after %d hub reconnect cycles = %d, want at most %d (baseline %d)", cycles, got, before+2, before)
 	}
 }
 

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -734,8 +734,26 @@ func TestSessionKeyRotationFailsInFlightTurn(t *testing.T) {
 	}
 }
 
+// stableGoroutineCount samples runtime.NumGoroutine until two consecutive
+// readings agree, so leak assertions start from a settled baseline instead of
+// a count inflated by goroutines still winding down from earlier tests.
+func stableGoroutineCount(t *testing.T) int {
+	t.Helper()
+	prev := runtime.NumGoroutine()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		time.Sleep(20 * time.Millisecond)
+		cur := runtime.NumGoroutine()
+		if cur == prev {
+			return cur
+		}
+		prev = cur
+	}
+	return prev
+}
+
 func TestHubKeepalivesExitWhenConnectionContextIsCancelled(t *testing.T) {
-	before := runtime.NumGoroutine()
+	before := stableGoroutineCount(t)
 	for range 10 {
 		ctx, cancel := context.WithCancel(context.Background())
 		startHubKeepalives(ctx, func(context.Context) error { return nil }, func() {}, func() {})
@@ -784,11 +802,11 @@ func TestRunHubLoopDoesNotLeakKeepaliveGoroutinesAcrossReconnects(t *testing.T) 
 
 	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
 	gwClient := &gatewayClient{addr: "127.0.0.1:0"}
-	gwSession := &gatewaySession{}
+	gwSession := &gatewaySession{pending: make(map[string]chan gwFrame)}
 	proxy := newHTTPProxy(nil)
 	queue := &msgQueue{}
 
-	before := runtime.NumGoroutine()
+	before := stableGoroutineCount(t)
 	const cycles = 5
 	for range cycles {
 		err := runHubLoop(ctx, wsURL, "claw-test", "test-claw", "test-template", "tok", gwClient, gwSession, proxy, queue)

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -699,6 +699,39 @@ func TestGatewayReadLoopFailsPendingRequestsOnDisconnect(t *testing.T) {
 	}
 }
 
+func TestDeliverInFlightDoesNotBlockWhenTerminalResultRacesTeardown(t *testing.T) {
+	inf := &inFlightState{done: make(chan agentResult, 1)}
+	inf.done <- agentResult{text: "already complete"}
+
+	finished := make(chan struct{})
+	go func() {
+		deliverInFlight(inf, agentResult{text: "duplicate lifecycle end"})
+		close(finished)
+	}()
+
+	select {
+	case <-finished:
+	case <-time.After(time.Second):
+		t.Fatal("terminal lifecycle delivery blocked on a full in-flight channel")
+	}
+}
+
+func TestSessionKeyRotationFailsInFlightTurn(t *testing.T) {
+	inf := &inFlightState{done: make(chan agentResult, 1)}
+	gs := &gatewaySession{sessionKey: "old-session", inFlight: inf}
+
+	gs.setSessionKey("new-session")
+
+	select {
+	case result := <-inf.done:
+		if result.err == nil || !strings.Contains(result.err.Error(), "session key rotated") {
+			t.Fatalf("rotation result = %#v, want session key rotation error", result)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("session key rotation did not fail the in-flight turn")
+	}
+}
+
 func TestIsRecoverableSessionSendError(t *testing.T) {
 	tests := []struct {
 		name string

--- a/cmd/claw-bridge/volumes.go
+++ b/cmd/claw-bridge/volumes.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 	"nhooyr.io/websocket"
-	"nhooyr.io/websocket/wsjson"
 )
 
 func handleVolumeAttach(ctx context.Context, conn *websocket.Conn, payload json.RawMessage) {
@@ -29,7 +28,7 @@ func handleVolumeAttach(ctx context.Context, conn *websocket.Conn, payload json.
 	if err != nil {
 		ack.Error = err.Error()
 	}
-	_ = wsjson.Write(ctx, conn, hubMsg{Type: "volume_attach_ack", Payload: mustJSON(ack)})
+	_ = writeHubMessage(ctx, conn, hubMsg{Type: "volume_attach_ack", Payload: mustJSON(ack)})
 }
 
 func handleVolumeSync(ctx context.Context, conn *websocket.Conn, payload json.RawMessage) {
@@ -43,7 +42,7 @@ func handleVolumeSync(ctx context.Context, conn *websocket.Conn, payload json.Ra
 	if err != nil {
 		ack.Error = err.Error()
 	}
-	_ = wsjson.Write(ctx, conn, hubMsg{Type: "volume_sync_ack", Payload: mustJSON(ack)})
+	_ = writeHubMessage(ctx, conn, hubMsg{Type: "volume_sync_ack", Payload: mustJSON(ack)})
 }
 
 func attachVolume(ctx context.Context, req types.VolumeAttachPayload) error {
@@ -61,7 +60,7 @@ func attachVolume(ctx context.Context, req types.VolumeAttachPayload) error {
 	httpReq.Header.Set("X-Claw-Token", req.ClawToken)
 	httpReq.Header.Set("X-Claw-ID", req.ClawID)
 	httpReq.Header.Set("X-Volume-Token", req.LeaseToken)
-	resp, err := http.DefaultClient.Do(httpReq)
+	resp, err := hubTransferHTTPClient.Do(httpReq)
 	if err != nil {
 		return err
 	}
@@ -97,7 +96,7 @@ func syncVolume(ctx context.Context, req types.VolumeSyncPayload) error {
 	httpReq.Header.Set("X-Claw-Token", req.ClawToken)
 	httpReq.Header.Set("X-Claw-ID", req.ClawID)
 	httpReq.Header.Set("X-Volume-Token", req.LeaseToken)
-	resp, err := http.DefaultClient.Do(httpReq)
+	resp, err := hubTransferHTTPClient.Do(httpReq)
 	if err != nil {
 		_ = pr.CloseWithError(err)
 		<-writeDone

--- a/cmd/claw-bridge/volumes_test.go
+++ b/cmd/claw-bridge/volumes_test.go
@@ -18,14 +18,14 @@ func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 func TestSyncVolumeClosesPipeOnPutError(t *testing.T) {
-	oldClient := http.DefaultClient
-	http.DefaultClient = &http.Client{
+	oldClient := hubTransferHTTPClient
+	hubTransferHTTPClient = &http.Client{
 		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
 			return nil, errors.New("put failed before reading body")
 		}),
 	}
 	defer func() {
-		http.DefaultClient = oldClient
+		hubTransferHTTPClient = oldClient
 	}()
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)


### PR DESCRIPTION
## Summary

Fixes five bounded-but-real robustness bugs in the bridge's WebSocket handling, found by the liveness audit follow-up after #488. None were regressions — all pre-existing.

1. **Unbounded writes on the main hub channel could wedge the gateway readLoop.** Chunk/activity writes run on the gateway readLoop goroutine with the process-lifetime ctx and no per-write deadline, and the main channel had no ping/pong (only the status channel did). A half-open TCP connection blocked all gateway event processing for the kernel TCP timeout (15+ min). Now every main-channel write goes through `writeHubMessage` (10s deadline) and the main channel has a ping keepalive that tears the connection down on failure (`CloseNow`) — a nhooyr pong-wait timeout does not close the conn by itself. The status channel ping got the same deadline + teardown.
2. **Heartbeat goroutine leak per hub reconnect.** The heartbeat goroutine selected on the signal ctx, so each `runHubLoop` iteration leaked one. Heartbeat and ping goroutines are now tied to a per-connection context.
3. **Blocking `inf.done` sends in the gateway readLoop.** Terminal lifecycle end/error events used blocking sends while the disconnect path used select/default; racing them against the `inFlight=nil` teardown could permanently block the readLoop. All sites now use non-blocking `deliverInFlight`.
4. **Session-key rotation dropped in-flight lifecycle events.** After `createFreshSession`, the old session's end event was filtered out and the turn only terminated via the 30-min timeout. `setSessionKey` now fails the in-flight turn explicitly on rotation.
5. **(small)** checkpoint/volume HTTP used `http.DefaultClient` with no timeout — replaced with bounded package-level clients (30s control, 10m transfers).

## Tests

- `TestRunHubLoopDoesNotLeakKeepaliveGoroutinesAcrossReconnects` — drives the real `runHubLoop` through 5 reconnect cycles against a fake hub with goroutine-count assertions. Sanity-checked: reverting the heartbeat wiring to the process ctx makes it fail (13 goroutines vs baseline 3).
- `TestDeliverInFlightDoesNotBlockWhenTerminalResultRacesTeardown`, `TestSessionKeyRotationFailsInFlightTurn`, `TestHubKeepalivesExitWhenConnectionContextIsCancelled`.
- `go build ./...`, `go test ./cmd/claw-bridge/... -count=1` (also with `-race`), and `go vet` all green; each commit builds and passes tests independently.

## Process

Implemented by gpt-5.6 (Codex); reviewed by fable-5 and an independent gpt-5.6 pass. All three must-fix review findings (ping-failure teardown on both channels, status-channel ping deadline, real reconnect-loop leak test) are addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)