### PR TITLE
feat: self-heal transient gateway/bridge crashes with supervised restarts

### DIFF
--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -2897,23 +2897,30 @@ func superviseGatewayLoop(wait func() error, restart func() (func() error, int, 
 		if now().Sub(startedAt) >= gatewayStableUptime {
 			attempts = 0
 		}
-		if attempts >= gatewayRestartBudget {
+
+		// Retry restarts here instead of re-waiting on the dead process: a
+		// failed attempt must not call the stale wait fn again.
+		replaced := false
+		for attempts < gatewayRestartBudget {
+			sleep(2 * time.Second << attempts)
+			attempts++
+			nextWait, pid, err := restart()
+			if err != nil {
+				log.Printf("[supervisor] gateway restart attempt %d failed: %v", attempts, err)
+				continue
+			}
+
+			restartCount := restarted()
+			running()
+			log.Printf("[supervisor] gateway restarted (pid=%d, restart_count=%d)", pid, restartCount)
+			wait = nextWait
+			replaced = true
+			break
+		}
+		if !replaced {
 			log.Printf("[supervisor] gateway restart budget exhausted after %d attempts — leaving unhealthy for hub watchdog", gatewayRestartBudget)
 			return
 		}
-
-		sleep(2 * time.Second << attempts)
-		attempts++
-		nextWait, pid, err := restart()
-		if err != nil {
-			log.Printf("[supervisor] gateway restart attempt %d failed: %v", attempts, err)
-			continue
-		}
-
-		restartCount := restarted()
-		running()
-		log.Printf("[supervisor] gateway restarted (pid=%d, restart_count=%d)", pid, restartCount)
-		wait = nextWait
 	}
 }
 

--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -37,6 +37,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -54,9 +55,11 @@ var (
 	BuildDate           = "unknown"
 	gatewayProcessState struct {
 		sync.RWMutex
-		exited  bool
-		session *gatewaySession
+		exited       bool
+		restartCount int
+		session      *gatewaySession
 	}
+	gatewayRestartBase int
 )
 
 // ─── hub wire types ─────────────────────────────────────────────────────────
@@ -1552,6 +1555,33 @@ func gatewayProcessExited() bool {
 	return gatewayProcessState.exited
 }
 
+func gatewayRestartCount() int {
+	gatewayProcessState.RLock()
+	defer gatewayProcessState.RUnlock()
+	return gatewayProcessState.restartCount
+}
+
+func markGatewayProcessRunning() {
+	gatewayProcessState.Lock()
+	gatewayProcessState.exited = false
+	gatewayProcessState.Unlock()
+}
+
+func incrementGatewayRestartCount() int {
+	gatewayProcessState.Lock()
+	defer gatewayProcessState.Unlock()
+	gatewayProcessState.restartCount++
+	return gatewayProcessState.restartCount
+}
+
+func gatewayRestartBaseFromEnv() int {
+	count, err := strconv.Atoi(os.Getenv("ELASTICCLAW_BRIDGE_RESTARTS"))
+	if err != nil || count < 0 {
+		return 0
+	}
+	return count
+}
+
 func markGatewayProcessExited() {
 	gatewayProcessState.Lock()
 	gatewayProcessState.exited = true
@@ -2706,6 +2736,70 @@ func stopGateway(cmd *exec.Cmd) {
 	}
 }
 
+const (
+	gatewayRestartBudget = 3
+	gatewayStableUptime  = 60 * time.Second
+)
+
+// superviseGatewayLoop waits for a gateway process and replaces it after an
+// unexpected exit. Its hooks keep the restart policy testable without starting
+// real processes.
+func superviseGatewayLoop(wait func() error, restart func() (func() error, int, error), sleep func(time.Duration), now func() time.Time, exited func(), running func(), restarted func() int) {
+	attempts := 0
+	for {
+		startedAt := now()
+		if err := wait(); err != nil {
+			log.Printf("[supervisor] gateway exited: %v", err)
+		} else {
+			log.Printf("[supervisor] gateway exited")
+		}
+		exited()
+
+		if now().Sub(startedAt) >= gatewayStableUptime {
+			attempts = 0
+		}
+		if attempts >= gatewayRestartBudget {
+			log.Printf("[supervisor] gateway restart budget exhausted after %d attempts — leaving unhealthy for hub watchdog", gatewayRestartBudget)
+			return
+		}
+
+		sleep(2 * time.Second << attempts)
+		attempts++
+		nextWait, pid, err := restart()
+		if err != nil {
+			log.Printf("[supervisor] gateway restart attempt %d failed: %v", attempts, err)
+			continue
+		}
+
+		restartCount := restarted()
+		running()
+		log.Printf("[supervisor] gateway restarted (pid=%d, restart_count=%d)", pid, restartCount)
+		wait = nextWait
+	}
+}
+
+func superviseGateway(gateway *exec.Cmd, hasFlake bool) {
+	superviseGatewayLoop(
+		gateway.Wait,
+		func() (func() error, int, error) {
+			cmd, err := startGatewayWithFlake(hasFlake)
+			if err != nil {
+				return nil, 0, err
+			}
+			if !checkGateway("localhost:18789") {
+				stopGateway(cmd)
+				return nil, 0, fmt.Errorf("gateway did not become healthy")
+			}
+			return cmd.Wait, cmd.Process.Pid, nil
+		},
+		time.Sleep,
+		time.Now,
+		markGatewayProcessExited,
+		markGatewayProcessRunning,
+		incrementGatewayRestartCount,
+	)
+}
+
 // waitForDeviceJSON waits up to 120s for ~/.openclaw/identity/device.json.
 func waitForDeviceJSON() error {
 	home, _ := os.UserHomeDir()
@@ -2889,14 +2983,7 @@ func runBootstrap() error {
 			}
 		}
 	}
-	go func() {
-		if err := gateway.Wait(); err != nil {
-			log.Printf("[bootstrap] gateway exited: %v", err)
-		} else {
-			log.Printf("[bootstrap] gateway exited")
-		}
-		markGatewayProcessExited()
-	}()
+	go superviseGateway(gateway, hasFlake)
 
 	// Step 9: Wait for device.json
 	if err := waitForDeviceJSON(); err != nil {
@@ -3050,6 +3137,9 @@ func printVersion() {
 }
 
 func main() {
+	// Retain restart history when an external supervisor relaunches this bridge.
+	gatewayRestartBase = gatewayRestartBaseFromEnv()
+
 	// Handle version requests very early, before any env var requirements.
 	// Supports: claw-bridge version, claw-bridge --version, claw-bridge -v
 	if len(os.Args) > 1 {
@@ -3382,13 +3472,15 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 				go gwSession.refreshContextUsage(ctx)
 				health := !gatewayProcessExited() && checkGateway(gwClient.addr)
 				cu := gwSession.ContextUsage()
-				log.Printf("[heartbeat] sending: gateway_healthy=%v gateway_ready=%v context_usage=%d%%", health, gwSession.IsReady(), cu)
+				restarts := gatewayRestartBase + gatewayRestartCount()
+				log.Printf("[heartbeat] sending: gateway_healthy=%v gateway_ready=%v context_usage=%d%% restart_count=%d", health, gwSession.IsReady(), cu, restarts)
 				_ = wsjson.Write(ctx, conn, hubMsg{
 					Type: "heartbeat",
 					Payload: mustJSON(map[string]interface{}{
 						"gateway_healthy": health,
 						"gateway_ready":   gwSession.IsReady(),
 						"context_usage":   cu,
+						"restart_count":   restarts,
 					}),
 				})
 			}

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -48,10 +48,14 @@ func TestSuperviseGatewayLoopRestartsAndSupervisesNewProcess(t *testing.T) {
 	var sleeps []time.Duration
 	restarts := 0
 	nextWaitSignaled := false
+	initialWaitCalls := 0
 
 	go func() {
 		superviseGatewayLoop(
-			func() error { return errors.New("initial exit") },
+			func() error {
+				initialWaitCalls++
+				return errors.New("initial exit")
+			},
 			func() (func() error, int, error) {
 				restarts++
 				if restarts == 1 {
@@ -88,6 +92,11 @@ func TestSuperviseGatewayLoopRestartsAndSupervisesNewProcess(t *testing.T) {
 	if len(sleeps) != 2 || sleeps[0] != 2*time.Second || sleeps[1] != 4*time.Second {
 		t.Fatalf("restart delays = %v, want [2s 4s]", sleeps)
 	}
+	// The first restart attempt failed; the supervisor must retry the restart
+	// without re-invoking the stale wait fn of the already-exited process.
+	if initialWaitCalls != 1 {
+		t.Fatalf("initial wait called %d times, want 1 (failed restart must not re-wait a dead process)", initialWaitCalls)
+	}
 	close(releaseNextWait)
 	<-done
 }
@@ -95,8 +104,12 @@ func TestSuperviseGatewayLoopRestartsAndSupervisesNewProcess(t *testing.T) {
 func TestSuperviseGatewayLoopExhaustsRestartBudget(t *testing.T) {
 	resetGatewayProcessState(t)
 	var sleeps []time.Duration
+	waitCalls := 0
 	superviseGatewayLoop(
-		func() error { return errors.New("exit") },
+		func() error {
+			waitCalls++
+			return errors.New("exit")
+		},
 		func() (func() error, int, error) { return nil, 0, errors.New("start failed") },
 		func(d time.Duration) { sleeps = append(sleeps, d) },
 		time.Now,
@@ -106,6 +119,9 @@ func TestSuperviseGatewayLoopExhaustsRestartBudget(t *testing.T) {
 	)
 	if !gatewayProcessExited() {
 		t.Fatal("gateway marked running after exhausted restart budget")
+	}
+	if waitCalls != 1 {
+		t.Fatalf("wait called %d times, want 1 (only real process exits should be awaited)", waitCalls)
 	}
 	want := []time.Duration{2 * time.Second, 4 * time.Second, 8 * time.Second}
 	if len(sleeps) != len(want) {

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -17,6 +18,155 @@ import (
 	"nhooyr.io/websocket"
 	"nhooyr.io/websocket/wsjson"
 )
+
+func resetGatewayProcessState(t *testing.T) {
+	t.Helper()
+	gatewayProcessState.Lock()
+	oldExited := gatewayProcessState.exited
+	oldRestartCount := gatewayProcessState.restartCount
+	oldSession := gatewayProcessState.session
+	gatewayProcessState.exited = false
+	gatewayProcessState.restartCount = 0
+	gatewayProcessState.session = nil
+	gatewayProcessState.Unlock()
+	t.Cleanup(func() {
+		gatewayProcessState.Lock()
+		gatewayProcessState.exited = oldExited
+		gatewayProcessState.restartCount = oldRestartCount
+		gatewayProcessState.session = oldSession
+		gatewayProcessState.Unlock()
+	})
+}
+
+func TestSuperviseGatewayLoopRestartsAndSupervisesNewProcess(t *testing.T) {
+	resetGatewayProcessState(t)
+	nextWaitStarted := make(chan struct{})
+	releaseNextWait := make(chan struct{})
+	done := make(chan struct{})
+	var sleeps []time.Duration
+	restarts := 0
+	nextWaitSignaled := false
+
+	go func() {
+		superviseGatewayLoop(
+			func() error { return errors.New("initial exit") },
+			func() (func() error, int, error) {
+				restarts++
+				if restarts == 1 {
+					return nil, 0, errors.New("start failed")
+				}
+				if restarts > 2 {
+					return nil, 0, errors.New("start failed")
+				}
+				return func() error {
+					if !nextWaitSignaled {
+						close(nextWaitStarted)
+						nextWaitSignaled = true
+					}
+					<-releaseNextWait
+					return errors.New("replacement exit")
+				}, 1234, nil
+			},
+			func(d time.Duration) { sleeps = append(sleeps, d) },
+			time.Now,
+			markGatewayProcessExited,
+			markGatewayProcessRunning,
+			incrementGatewayRestartCount,
+		)
+		close(done)
+	}()
+
+	<-nextWaitStarted
+	if gatewayProcessExited() {
+		t.Fatal("gateway remains exited after successful restart")
+	}
+	if got := gatewayRestartCount(); got != 1 {
+		t.Fatalf("restart count = %d, want 1", got)
+	}
+	if len(sleeps) != 2 || sleeps[0] != 2*time.Second || sleeps[1] != 4*time.Second {
+		t.Fatalf("restart delays = %v, want [2s 4s]", sleeps)
+	}
+	close(releaseNextWait)
+	<-done
+}
+
+func TestSuperviseGatewayLoopExhaustsRestartBudget(t *testing.T) {
+	resetGatewayProcessState(t)
+	var sleeps []time.Duration
+	superviseGatewayLoop(
+		func() error { return errors.New("exit") },
+		func() (func() error, int, error) { return nil, 0, errors.New("start failed") },
+		func(d time.Duration) { sleeps = append(sleeps, d) },
+		time.Now,
+		markGatewayProcessExited,
+		markGatewayProcessRunning,
+		incrementGatewayRestartCount,
+	)
+	if !gatewayProcessExited() {
+		t.Fatal("gateway marked running after exhausted restart budget")
+	}
+	want := []time.Duration{2 * time.Second, 4 * time.Second, 8 * time.Second}
+	if len(sleeps) != len(want) {
+		t.Fatalf("restart delays = %v, want %v", sleeps, want)
+	}
+	for i := range want {
+		if sleeps[i] != want[i] {
+			t.Fatalf("restart delay %d = %v, want %v", i, sleeps[i], want[i])
+		}
+	}
+}
+
+func TestSuperviseGatewayLoopStableUptimeResetsBudget(t *testing.T) {
+	resetGatewayProcessState(t)
+	var sleeps []time.Duration
+	times := []time.Time{
+		time.Unix(0, 0), time.Unix(0, 0),
+		time.Unix(0, 0), time.Unix(60, 0),
+	}
+	nowCalls := 0
+	now := func() time.Time {
+		if nowCalls >= len(times) {
+			return times[len(times)-1]
+		}
+		v := times[nowCalls]
+		nowCalls++
+		return v
+	}
+	restarts := 0
+	superviseGatewayLoop(
+		func() error { return errors.New("exit") },
+		func() (func() error, int, error) {
+			restarts++
+			if restarts == 1 {
+				return func() error { return errors.New("stable replacement exit") }, 1234, nil
+			}
+			return nil, 0, errors.New("start failed")
+		},
+		func(d time.Duration) { sleeps = append(sleeps, d) },
+		now,
+		markGatewayProcessExited,
+		markGatewayProcessRunning,
+		incrementGatewayRestartCount,
+	)
+	if len(sleeps) < 2 || sleeps[0] != 2*time.Second || sleeps[1] != 2*time.Second {
+		t.Fatalf("restart delays = %v, want stable restart to reset second delay to 2s", sleeps)
+	}
+}
+
+func TestGatewayRestartBaseFromEnv(t *testing.T) {
+	t.Setenv("ELASTICCLAW_BRIDGE_RESTARTS", "")
+	if got := gatewayRestartBaseFromEnv(); got != 0 {
+		t.Fatalf("unset restart base = %d, want 0", got)
+	}
+	t.Setenv("ELASTICCLAW_BRIDGE_RESTARTS", "2")
+	if got := gatewayRestartBaseFromEnv(); got != 2 {
+		t.Fatalf("restart base = %d, want 2", got)
+	}
+	t.Setenv("ELASTICCLAW_BRIDGE_RESTARTS", "garbage")
+	if got := gatewayRestartBaseFromEnv(); got != 0 {
+		t.Fatalf("invalid restart base = %d, want 0", got)
+	}
+}
 
 func writeGatewayClientConfig(t *testing.T, home, config string) {
 	t.Helper()

--- a/pkg/hub/bootstrap.go
+++ b/pkg/hub/bootstrap.go
@@ -328,7 +328,38 @@ chmod 600 "$HOME/.claw-bridge.env"
 export ELASTICCLAW_BOOTSTRAP=1
 export ELASTICCLAW_BOOTSTRAP_NOTIFY_FILE="$HOME/.claw-bridge.bootstrap.ready"
 rm -f "$ELASTICCLAW_BOOTSTRAP_NOTIFY_FILE"
-nohup /usr/local/bin/claw-bridge >> "$HOME/claw-bridge.log" 2>&1 </dev/null &
+cat > "$HOME/.claw-bridge-supervisor.sh" <<'EOF'
+#!/bin/sh
+. "$HOME/.claw-bridge.env"
+export ELASTICCLAW_BOOTSTRAP ELASTICCLAW_BOOTSTRAP_NOTIFY_FILE
+restarts=0
+backoff=5
+while :; do
+  started_at=$(date +%%s)
+  export ELASTICCLAW_BRIDGE_RESTARTS="$restarts"
+  /usr/local/bin/claw-bridge >> "$HOME/claw-bridge.log" 2>&1
+  rc=$?
+  if [ "$rc" -eq 0 ]; then
+    echo "[supervisor] claw-bridge exited cleanly"
+    exit 0
+  fi
+  now=$(date +%%s)
+  if [ $((now - started_at)) -ge 300 ]; then
+    restarts=0
+    backoff=5
+  fi
+  if [ "$restarts" -ge 3 ]; then
+    echo "[supervisor] claw-bridge restart budget exhausted after 3 attempts"
+    exit 1
+  fi
+  restarts=$((restarts + 1))
+  echo "[supervisor] claw-bridge exited (code=$rc); restarting (attempt $restarts/3) in ${backoff}s"
+  sleep "$backoff"
+  backoff=$((backoff * 2))
+done
+EOF
+chmod 700 "$HOME/.claw-bridge-supervisor.sh"
+nohup "$HOME/.claw-bridge-supervisor.sh" >> "$HOME/claw-bridge.log" 2>&1 </dev/null &
 BRIDGE_PID=$!
 for _ in {1..1800}; do
   if [ -f "$ELASTICCLAW_BOOTSTRAP_NOTIFY_FILE" ]; then

--- a/pkg/hub/bootstrap.go
+++ b/pkg/hub/bootstrap.go
@@ -329,15 +329,19 @@ export ELASTICCLAW_BOOTSTRAP=1
 export ELASTICCLAW_BOOTSTRAP_NOTIFY_FILE="$HOME/.claw-bridge.bootstrap.ready"
 rm -f "$ELASTICCLAW_BOOTSTRAP_NOTIFY_FILE"
 cat > "$HOME/.claw-bridge-supervisor.sh" <<'EOF'
-#!/bin/sh
+#!/bin/bash
 . "$HOME/.claw-bridge.env"
 export ELASTICCLAW_BOOTSTRAP ELASTICCLAW_BOOTSTRAP_NOTIFY_FILE
 restarts=0
+total_restarts=0
 backoff=5
 while :; do
   started_at=$(date +%%s)
-  export ELASTICCLAW_BRIDGE_RESTARTS="$restarts"
-  /usr/local/bin/claw-bridge >> "$HOME/claw-bridge.log" 2>&1
+  export ELASTICCLAW_BRIDGE_RESTARTS="$total_restarts"
+  /usr/local/bin/claw-bridge >> "$HOME/claw-bridge.log" 2>&1 &
+  child=$!
+  trap 'kill "$child" 2>/dev/null; wait "$child" 2>/dev/null; exit 0' TERM INT
+  wait "$child"
   rc=$?
   if [ "$rc" -eq 0 ]; then
     echo "[supervisor] claw-bridge exited cleanly"
@@ -353,7 +357,9 @@ while :; do
     exit 1
   fi
   restarts=$((restarts + 1))
+  total_restarts=$((total_restarts + 1))
   echo "[supervisor] claw-bridge exited (code=$rc); restarting (attempt $restarts/3) in ${backoff}s"
+  unset ELASTICCLAW_BOOTSTRAP ELASTICCLAW_BOOTSTRAP_NOTIFY_FILE
   sleep "$backoff"
   backoff=$((backoff * 2))
 done

--- a/pkg/hub/bootstrap.go
+++ b/pkg/hub/bootstrap.go
@@ -335,14 +335,16 @@ export ELASTICCLAW_BOOTSTRAP ELASTICCLAW_BOOTSTRAP_NOTIFY_FILE
 restarts=0
 total_restarts=0
 backoff=5
+child=""
+trap 'if [ -n "$child" ]; then kill "$child" 2>/dev/null; wait "$child" 2>/dev/null; fi; exit 0' TERM INT
 while :; do
   started_at=$(date +%%s)
   export ELASTICCLAW_BRIDGE_RESTARTS="$total_restarts"
   /usr/local/bin/claw-bridge >> "$HOME/claw-bridge.log" 2>&1 &
   child=$!
-  trap 'kill "$child" 2>/dev/null; wait "$child" 2>/dev/null; exit 0' TERM INT
   wait "$child"
   rc=$?
+  child=""
   if [ "$rc" -eq 0 ]; then
     echo "[supervisor] claw-bridge exited cleanly"
     exit 0

--- a/pkg/hub/bootstrap_test.go
+++ b/pkg/hub/bootstrap_test.go
@@ -39,6 +39,9 @@ func TestBootstrapScript_ContainsBootstrapMode(t *testing.T) {
 	assertContains(t, script, `cat > "$HOME/.claw-bridge-supervisor.sh" <<'EOF'`, "writes bootstrap supervisor")
 	assertContains(t, script, `nohup "$HOME/.claw-bridge-supervisor.sh" >> "$HOME/claw-bridge.log" 2>&1 </dev/null &`, "supervisor backgrounded in bootstrap mode")
 	assertContains(t, script, "ELASTICCLAW_BRIDGE_RESTARTS", "supervisor reports cumulative restart count")
+	assertContains(t, script, "total_restarts=0", "supervisor keeps a cumulative counter separate from its retry budget")
+	assertContains(t, script, "unset ELASTICCLAW_BOOTSTRAP ELASTICCLAW_BOOTSTRAP_NOTIFY_FILE", "only the first supervised bridge runs bootstrap")
+	assertContains(t, script, "#!/bin/bash", "persisted bash-quoted environment is sourced by bash")
 	assertContains(t, script, "restarting (attempt $restarts/3)", "supervisor caps restarts")
 	assertContains(t, script, "sleep \"$backoff\"", "supervisor backs off restarts")
 	assertContains(t, script, "ELASTICCLAW_BOOTSTRAP_NOTIFY_FILE", "bootstrap completion notify file set")
@@ -71,6 +74,9 @@ func TestDaytonaBridgeCommands_AreAsyncAndIdempotent(t *testing.T) {
 	assertContains(t, cmd, "trap", "installs supervisor exit trap")
 	assertContains(t, cmd, `rm -f "$PIDFILE"`, "removes supervisor pid file on exit")
 	assertContains(t, cmd, "ELASTICCLAW_BRIDGE_RESTARTS", "exports restart count to bridge")
+	assertContains(t, cmd, "total_restarts=0", "keeps a cumulative restart count")
+	assertContains(t, cmd, "child=$!", "supervisor tracks its bridge child")
+	assertContains(t, cmd, "kill \"$child\"", "supervisor forwards termination to its bridge child")
 	assertContains(t, cmd, "restart budget exhausted after 3 attempts", "caps rapid restart flapping")
 	assertContains(t, cmd, `ELASTICCLAW_CLAW_ID='claw-123'`, "passes claw id to bridge")
 	assertNotContains(t, cmd, "nohup /tmp/claw-bridge", "does not execute bridge directly from tmp")
@@ -78,6 +84,7 @@ func TestDaytonaBridgeCommands_AreAsyncAndIdempotent(t *testing.T) {
 
 	assertContains(t, running, "claw-bridge.pid", "retry guard checks bridge pid file")
 	assertContains(t, running, "pgrep -x claw-bridge", "retry guard detects already running bridge")
+	assertContains(t, running, "if pgrep -x claw-bridge", "pidfile alone does not mask a crash-looping supervisor")
 }
 
 func TestDaytonaAsyncBridgeCommandShellQuotesClawName(t *testing.T) {

--- a/pkg/hub/bootstrap_test.go
+++ b/pkg/hub/bootstrap_test.go
@@ -43,6 +43,12 @@ func TestBootstrapScript_ContainsBootstrapMode(t *testing.T) {
 	assertContains(t, script, "unset ELASTICCLAW_BOOTSTRAP ELASTICCLAW_BOOTSTRAP_NOTIFY_FILE", "only the first supervised bridge runs bootstrap")
 	assertContains(t, script, "#!/bin/bash", "persisted bash-quoted environment is sourced by bash")
 	assertContains(t, script, "restarting (attempt $restarts/3)", "supervisor caps restarts")
+	supervisorTrap := `trap 'if [ -n "$child" ]; then kill "$child" 2>/dev/null; wait "$child" 2>/dev/null; fi; exit 0' TERM INT`
+	assertContains(t, script, supervisorTrap, "supervisor installs guarded exit trap")
+	if trapIdx, loopIdx := strings.Index(script, supervisorTrap), strings.Index(script, "while :; do"); trapIdx == -1 || loopIdx == -1 || trapIdx > loopIdx {
+		t.Errorf("supervisor trap must be installed before the restart loop (trap at %d, loop at %d)", trapIdx, loopIdx)
+	}
+	assertNotContains(t, script, "child=$!\n  trap", "trap must not be reinstalled inside the loop after spawning the child")
 	assertContains(t, script, "sleep \"$backoff\"", "supervisor backs off restarts")
 	assertContains(t, script, "ELASTICCLAW_BOOTSTRAP_NOTIFY_FILE", "bootstrap completion notify file set")
 	assertNotContains(t, script, "exec /usr/local/bin/claw-bridge", "bridge must not block SSH session")

--- a/pkg/hub/bootstrap_test.go
+++ b/pkg/hub/bootstrap_test.go
@@ -36,7 +36,11 @@ func TestBootstrapScript_ContainsBootstrapMode(t *testing.T) {
 	// Node/OpenClaw/gateway steps live inside claw-bridge Go code.
 	script := GenerateReplicatedBootstrapScript(baseParams())
 	assertContains(t, script, "ELASTICCLAW_BOOTSTRAP=1", "bootstrap env var set")
-	assertContains(t, script, "/usr/local/bin/claw-bridge >> \"$HOME/claw-bridge.log\" 2>&1 </dev/null &", "bridge backgrounded in bootstrap mode")
+	assertContains(t, script, `cat > "$HOME/.claw-bridge-supervisor.sh" <<'EOF'`, "writes bootstrap supervisor")
+	assertContains(t, script, `nohup "$HOME/.claw-bridge-supervisor.sh" >> "$HOME/claw-bridge.log" 2>&1 </dev/null &`, "supervisor backgrounded in bootstrap mode")
+	assertContains(t, script, "ELASTICCLAW_BRIDGE_RESTARTS", "supervisor reports cumulative restart count")
+	assertContains(t, script, "restarting (attempt $restarts/3)", "supervisor caps restarts")
+	assertContains(t, script, "sleep \"$backoff\"", "supervisor backs off restarts")
 	assertContains(t, script, "ELASTICCLAW_BOOTSTRAP_NOTIFY_FILE", "bootstrap completion notify file set")
 	assertNotContains(t, script, "exec /usr/local/bin/claw-bridge", "bridge must not block SSH session")
 	// Node/OpenClaw installs are NOT in the bash script anymore
@@ -61,9 +65,13 @@ func TestDaytonaBridgeCommands_AreAsyncAndIdempotent(t *testing.T) {
 	assertContains(t, prep, "[ ! -s /tmp/claw-bridge ]", "reports missing downloaded bridge before install")
 	assertContains(t, prep, "sudo install -m 0755 /tmp/claw-bridge /usr/local/bin/claw-bridge", "installs bridge outside tmp before execution")
 	assertContains(t, prep, "claw-bridge installed at /usr/local/bin/claw-bridge is not executable", "reports non-executable install")
-	assertContains(t, cmd, "exec /usr/local/bin/claw-bridge", "runs installed bridge from async session command")
+	assertContains(t, cmd, "/usr/local/bin/claw-bridge", "runs installed bridge from async session command")
 	assertContains(t, cmd, "claw-bridge.pid", "writes pid file for idempotent retries")
 	assertContains(t, cmd, "kill -0", "validates existing and newly started process")
+	assertContains(t, cmd, "trap", "installs supervisor exit trap")
+	assertContains(t, cmd, `rm -f "$PIDFILE"`, "removes supervisor pid file on exit")
+	assertContains(t, cmd, "ELASTICCLAW_BRIDGE_RESTARTS", "exports restart count to bridge")
+	assertContains(t, cmd, "restart budget exhausted after 3 attempts", "caps rapid restart flapping")
 	assertContains(t, cmd, `ELASTICCLAW_CLAW_ID='claw-123'`, "passes claw id to bridge")
 	assertNotContains(t, cmd, "nohup /tmp/claw-bridge", "does not execute bridge directly from tmp")
 	assertNotContains(t, cmd, "setsid", "does not rely on shell detach when Daytona async sessions are available")
@@ -163,7 +171,7 @@ func TestBootstrapScript_BridgeStartsBeforeCredentialHelper(t *testing.T) {
 	p.GitHubRepos = []types.GitHubRepoAccess{{Repo: "owner/repo", Permissions: "write"}}
 	script := GenerateReplicatedBootstrapScript(p)
 
-	assertContains(t, script, "/usr/local/bin/claw-bridge >> \"$HOME/claw-bridge.log\" 2>&1 </dev/null &", "bridge started")
+	assertContains(t, script, `nohup "$HOME/.claw-bridge-supervisor.sh" >> "$HOME/claw-bridge.log" 2>&1 </dev/null &`, "bridge supervisor started")
 	// Credential helper is NOT in the generated script — it runs as a separate SSH step
 	assertNotContains(t, script, "elasticclaw-git-credentials", "cred helper not in bootstrap script")
 }

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -55,6 +55,8 @@ type Server struct {
 	mu    sync.RWMutex
 	claws map[string]*clawConn // claw_id -> conn
 	users map[string]*userConn // tenant_id -> []conn (broadcast)
+	// gatewayRestartCounts retains the heartbeat counter across WebSocket reconnects.
+	gatewayRestartCounts map[string]int
 	// one-time oauth_code -> signed GitHub session token
 
 	dependencyStatus *dependencyStatusService
@@ -226,20 +228,21 @@ func NewServer(addr, dbPath, identityDir string, hubCfg *types.HubConfig) (*Serv
 	}
 	log.Printf("Hub SSH public key:\n%s", id.PublicKey)
 	srv := &Server{
-		db:                db,
-		addr:              addr,
-		hubCfg:            hubCfg,
-		identity:          id,
-		artifacts:         artifacts,
-		claws:             make(map[string]*clawConn),
-		users:             make(map[string]*userConn),
-		dependencyStatus:  newDependencyStatusService(hubCfg),
-		fileAckWaiters:    make(map[string]chan types.FileAck),
-		fileReadWaiters:   make(map[string]chan types.FileReadResp),
-		checkpointWaiters: make(map[string]chan error),
-		webhookDedup:      make(map[string]time.Time),
-		reaperFirstSeen:   make(map[string]time.Time),
-		nowFunc:           now,
+		db:                   db,
+		addr:                 addr,
+		hubCfg:               hubCfg,
+		identity:             id,
+		artifacts:            artifacts,
+		claws:                make(map[string]*clawConn),
+		users:                make(map[string]*userConn),
+		gatewayRestartCounts: make(map[string]int),
+		dependencyStatus:     newDependencyStatusService(hubCfg),
+		fileAckWaiters:       make(map[string]chan types.FileAck),
+		fileReadWaiters:      make(map[string]chan types.FileReadResp),
+		checkpointWaiters:    make(map[string]chan error),
+		webhookDedup:         make(map[string]time.Time),
+		reaperFirstSeen:      make(map[string]time.Time),
+		nowFunc:              now,
 	}
 	if srv.livenessEnabled() {
 		srv.reconcileOnBoot()
@@ -2173,6 +2176,9 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 
 	cc := &clawConn{id: clawID, tenantID: tenantID, conn: conn, gatewayReady: gatewayReadyBool(rp.GatewayReady), tags: registrationTags, lastUserMessageAt: time.Now(), lastStatusAt: time.Now()}
 	s.mu.Lock()
+	if s.gatewayRestartCounts != nil {
+		cc.gatewayRestartCount = s.gatewayRestartCounts[clawID]
+	}
 	if old, ok := s.claws[clawID]; ok {
 		old.mu.RLock()
 		cc.statusConn = old.statusConn
@@ -2297,10 +2303,15 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 						// Log only on status changes, not every heartbeat
 						prevUsage = cc.contextUsage
 						cc.contextUsage = hb.ContextUsage
-						if hb.RestartCount > cc.gatewayRestartCount {
-							log.Printf("[heartbeat] %s (%s): agent process restarted (restart_count=%d)", rp.Name, clawID[:8], hb.RestartCount)
+						if s.gatewayRestartCounts == nil {
+							s.gatewayRestartCounts = make(map[string]int)
 						}
-						cc.gatewayRestartCount = hb.RestartCount
+						lastRestartCount := s.gatewayRestartCounts[clawID]
+						if hb.RestartCount > lastRestartCount {
+							log.Printf("[heartbeat] %s (%s): agent process restarted (restart_count=%d)", rp.Name, clawID[:8], hb.RestartCount)
+							s.gatewayRestartCounts[clawID] = hb.RestartCount
+						}
+						cc.gatewayRestartCount = s.gatewayRestartCounts[clawID]
 						// Promote from 'starting' to 'connected' once gateway is ready.
 						// nil means field absent (old bridge) — treat as ready.
 						if gatewayReadyBool(hb.GatewayReady) {
@@ -3698,8 +3709,10 @@ func daytonaBridgeRunningCommand() string {
 	return `export HOME=/home/daytona
 PIDFILE=/home/daytona/.openclaw/run/claw-bridge.pid
 if [ -s "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE")" 2>/dev/null; then
-  echo "claw-bridge running pid=$(cat "$PIDFILE")"
-  exit 0
+  if pgrep -x claw-bridge >/dev/null 2>&1; then
+    echo "claw-bridge running pid=$(cat "$PIDFILE")"
+    exit 0
+  fi
 fi
 if pgrep -x claw-bridge >/dev/null 2>&1; then
   echo "claw-bridge running"
@@ -3835,14 +3848,19 @@ PIDFILE="$1"
 LOG="$2"
 echo $$ > "$PIDFILE"
 trap '\''rm -f "$PIDFILE"'\'' 0
-trap '\''exit 0'\'' TERM INT
+child=""
+trap '\''if [ -n "$child" ]; then kill "$child" 2>/dev/null; wait "$child" 2>/dev/null; fi; exit 0'\'' TERM INT
 restarts=0
+total_restarts=0
 backoff=5
 while :; do
   started_at=$(date +%%s)
-  export ELASTICCLAW_BRIDGE_RESTARTS="$restarts"
-  /usr/local/bin/claw-bridge >> "$LOG" 2>&1
+  export ELASTICCLAW_BRIDGE_RESTARTS="$total_restarts"
+  /usr/local/bin/claw-bridge >> "$LOG" 2>&1 &
+  child=$!
+  wait "$child"
   rc=$?
+  child=""
   if [ "$rc" -eq 0 ]; then
     echo "[supervisor] claw-bridge exited cleanly" >> "$LOG"
     exit 0
@@ -3857,6 +3875,7 @@ while :; do
     exit 1
   fi
   restarts=$((restarts + 1))
+  total_restarts=$((total_restarts + 1))
   echo "[supervisor] claw-bridge exited (code=$rc); restarting (attempt $restarts/3) in ${backoff}s" >> "$LOG"
   sleep "$backoff"
   backoff=$((backoff * 2))

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2311,7 +2311,10 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 							s.gatewayRestartCounts = make(map[string]int)
 						}
 						lastRestartCount := s.gatewayRestartCounts[clawID]
-						if hb.RestartCount > lastRestartCount {
+						// Any change signals a restart: an increase is an in-process
+						// gateway restart; a decrease means the bridge process itself
+						// was relaunched and its counter reset.
+						if hb.RestartCount != lastRestartCount {
 							log.Printf("[heartbeat] %s (%s): agent process restarted (restart_count=%d)", rp.Name, clawID[:8], hb.RestartCount)
 							s.gatewayRestartCounts[clawID] = hb.RestartCount
 						}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -114,6 +114,7 @@ type clawConn struct {
 	contextUsage          int             // 0-100, updated from heartbeats
 	gatewayReady          bool            // true once bridge reports gateway session established
 	gatewayUnhealthyCount int             // consecutive unhealthy heartbeats
+	gatewayRestartCount   int             // cumulative bridge restarts reported by heartbeats
 	forcedFinishCount     int             // consecutive watchdog-forced streaming turn finishes
 	workflowStartPending  bool            // true while initial volume attach / wake is in flight
 	workflowStartDone     bool            // true once initial volume attach / wake has completed
@@ -2282,6 +2283,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 					GatewayHealthy bool  `json:"gateway_healthy"`
 					GatewayReady   *bool `json:"gateway_ready,omitempty"`
 					ContextUsage   int   `json:"context_usage"`
+					RestartCount   int   `json:"restart_count"`
 				}
 				if err := json.Unmarshal(payload, &hb); err == nil {
 					var wakeConn *clawConn
@@ -2295,6 +2297,10 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 						// Log only on status changes, not every heartbeat
 						prevUsage = cc.contextUsage
 						cc.contextUsage = hb.ContextUsage
+						if hb.RestartCount > cc.gatewayRestartCount {
+							log.Printf("[heartbeat] %s (%s): agent process restarted (restart_count=%d)", rp.Name, clawID[:8], hb.RestartCount)
+						}
+						cc.gatewayRestartCount = hb.RestartCount
 						// Promote from 'starting' to 'connected' once gateway is ready.
 						// nil means field absent (old bridge) — treat as ready.
 						if gatewayReadyBool(hb.GatewayReady) {
@@ -3824,7 +3830,38 @@ if pgrep -x claw-bridge >/dev/null 2>&1; then
 fi
 rm -f "$PIDFILE"
 ELASTICCLAW_HUB_URL=%s ELASTICCLAW_CLAW_ID=%s ELASTICCLAW_CLAW_TOKEN=%s ELASTICCLAW_CLAW_NAME=%s \
-sh -c 'echo $$ > "$1"; exec /usr/local/bin/claw-bridge' sh "$PIDFILE" >> "$LOG" 2>&1`,
+sh -c '
+PIDFILE="$1"
+LOG="$2"
+echo $$ > "$PIDFILE"
+trap '\''rm -f "$PIDFILE"'\'' 0
+trap '\''exit 0'\'' TERM INT
+restarts=0
+backoff=5
+while :; do
+  started_at=$(date +%%s)
+  export ELASTICCLAW_BRIDGE_RESTARTS="$restarts"
+  /usr/local/bin/claw-bridge >> "$LOG" 2>&1
+  rc=$?
+  if [ "$rc" -eq 0 ]; then
+    echo "[supervisor] claw-bridge exited cleanly" >> "$LOG"
+    exit 0
+  fi
+  now=$(date +%%s)
+  if [ $((now - started_at)) -ge 300 ]; then
+    restarts=0
+    backoff=5
+  fi
+  if [ "$restarts" -ge 3 ]; then
+    echo "[supervisor] claw-bridge restart budget exhausted after 3 attempts" >> "$LOG"
+    exit 1
+  fi
+  restarts=$((restarts + 1))
+  echo "[supervisor] claw-bridge exited (code=$rc); restarting (attempt $restarts/3) in ${backoff}s" >> "$LOG"
+  sleep "$backoff"
+  backoff=$((backoff * 2))
+done
+' sh "$PIDFILE" "$LOG"`,
 		shellQuote(hubURL),
 		shellQuote(clawID),
 		shellQuote(clawToken),

--- a/pkg/hub/watchdog_enforcement_test.go
+++ b/pkg/hub/watchdog_enforcement_test.go
@@ -120,6 +120,31 @@ func TestWatchdogHealthyHeartbeatResetsUnhealthyCounter(t *testing.T) {
 	}, "post-reset unhealthy count")
 }
 
+func TestHeartbeatRestartCountChangeDetectedInBothDirections(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	const clawID = "heartbeat-restart-count"
+	conn := watchdogClaw(t, s, clawID)
+	cc := watchdogClawConn(t, s, clawID)
+	writeRestartCount := func(n int) {
+		t.Helper()
+		if err := wsjson.Write(context.Background(), conn, types.WSMessage{Type: "heartbeat", Payload: map[string]any{"gateway_healthy": true, "restart_count": n}}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	restartCount := func() int {
+		cc.mu.RLock()
+		defer cc.mu.RUnlock()
+		return cc.gatewayRestartCount
+	}
+	writeRestartCount(3)
+	eventuallyWatchdog(t, func() bool { return restartCount() == 3 }, "restart count increase recorded")
+	// A shell-supervisor bridge relaunch resets the bridge's counter, so the
+	// reported restart_count can drop below the stored baseline. The baseline
+	// must follow the decrease or the relaunch goes permanently undetected.
+	writeRestartCount(1)
+	eventuallyWatchdog(t, func() bool { return restartCount() == 1 }, "restart count decrease (bridge relaunch) recorded")
+}
+
 func TestWatchdogForceFinishesStaleTurnAndDeliversQueue(t *testing.T) {
 	s, _ := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
 	const clawID = "watchdog-force-finish"


### PR DESCRIPTION
Liveness audit follow-up to #488: that PR made agent/bridge death produce an explicit agent error via the hub watchdog; this PR adds **recovery**, so a transient crash no longer costs the whole run — while keeping every existing failure signal intact.

## 1. Bridge restarts the OpenClaw gateway (`cmd/claw-bridge`)

- `superviseGateway` replaces the fire-and-forget `gateway.Wait()` goroutine in bootstrap step 8. On unexpected gateway exit it restarts the process with capped exponential backoff: **3 attempts, 2s/4s/8s**; a run that stays healthy ≥60s resets the budget, so only rapid flapping exhausts it.
- Each crash still fails the in-flight turn immediately (`markGatewayProcessExited`) and flips heartbeats to unhealthy; a successful restart clears the flag. A restart whose process starts but never passes `checkGateway` is stopped and counted as a failed attempt.
- After the budget is exhausted the bridge keeps reporting unhealthy and the existing hub watchdog escalation (12 × 15s heartbeats) takes over unchanged.
- Session state is preserved naturally: the gateway persists sessions on disk and the bridge's `readLoop` already reconnects/re-subscribes every 5s once the process is healthy again.
- Heartbeats gain `restart_count` = gateway restarts + `ELASTICCLAW_BRIDGE_RESTARTS` base (set by the external supervisor below), so the hub sees combined flapping.
- The restart policy is factored into `superviseGatewayLoop` with injected hooks and covered by unit tests (restart on 2nd attempt, exhaustion with exact backoff sequence, stable-uptime reset, env-base parsing).

## 2. Hub supervises the bridge launch (`pkg/hub`)

Both fire-and-forget launches are wrapped in a lightweight shell supervisor loop (**3 restarts, 5s/10s/20s backoff, budget reset after ≥300s uptime**, per-restart log lines, cumulative `ELASTICCLAW_BRIDGE_RESTARTS` export):

- `bootstrap.go`: the bootstrap script writes `~/.claw-bridge-supervisor.sh` (bash) and launches it via `nohup`, so it survives the SSH session. Restarts unset `ELASTICCLAW_BOOTSTRAP`, so a relaunched bridge just reconnects (and adopts an already-running gateway) instead of re-running bootstrap against an orphaned gateway's port.
- `server.go` `daytonaAsyncBridgeCommand`: the same policy inlined; the pidfile now holds the supervisor PID (liveness holds across backoff sleeps) and is removed by trap on exit. `daytonaBridgeRunningCommand` additionally requires an actual `claw-bridge` process (`pgrep`), so a crash-looping supervisor can't mask a bootstrap failure.
- **Not masking failures:** supervisor exhaustion exits non-zero with no `claw-bridge` process and no pidfile — exactly the dead-bridge signal the reaper/offline detection already handles.
- The hub parses `restart_count`, keeps a per-claw baseline that survives WebSocket reconnects, and logs `agent process restarted (restart_count=N)` whenever it increases, surfacing flapping.

## Review process

Implemented by two independent gpt-5.6 (Codex) agents; reviewed independently by fable-5 and gpt-5.6 (7 findings, all confirmed and fixed in the final commit — pidfile masking, orphan-gateway health attribution, bootstrap re-entry on restart, inert TERM/INT trap, non-monotonic restart_count, dash-incompatible env sourcing, reconnect-reset flapping baseline).

## Verification

- `go build ./...`, `go test ./cmd/claw-bridge/...`, `go test ./pkg/hub -run 'Bootstrap|Daytona|Bridge|Heartbeat'` — all green; `gofmt` clean.
- New unit tests for the gateway supervisor loop and for the supervisor shell scripts / pidfile semantics.

### e2e note (manual sandbox check)

In a Daytona/Replicated sandbox with a run in progress:
1. `kill -9` the `openclaw gateway` process → in-flight turn fails with an explicit error, the bridge logs `[supervisor] gateway restarted (restart_count=1)` within ~2s, heartbeats return to healthy, and the run continues (no watchdog escalation).
2. `kill -9` the `claw-bridge` process → the shell supervisor relaunches it within 5s (log: `[supervisor] claw-bridge exited (code=...); restarting (attempt 1/3)`); the claw reconnects and the hub logs `agent process restarted` from the heartbeat `restart_count`.
3. Force ≥4 rapid crashes of either process → budget exhausts; the gateway path pins heartbeats unhealthy until the watchdog errors the run; the bridge path removes the pidfile and exits non-zero so the existing offline/reaper path errors the run. Both end in the same explicit agent error introduced by #488.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
