### PR TITLE
fix: DB-backed message delivery for claw agents (P0 liveness)

### DIFF
--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -82,6 +82,33 @@ type msgQueue struct {
 	msgs []queuedMsg
 }
 
+type messageDeduper struct {
+	mu    sync.Mutex
+	ids   map[string]struct{}
+	order []string
+}
+
+func newMessageDeduper() *messageDeduper { return &messageDeduper{ids: make(map[string]struct{})} }
+
+// seen records id and reports whether it has already been processed.
+func (d *messageDeduper) seen(id string) bool {
+	if id == "" {
+		return false
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if _, ok := d.ids[id]; ok {
+		return true
+	}
+	d.ids[id] = struct{}{}
+	d.order = append(d.order, id)
+	if len(d.order) > 128 {
+		delete(d.ids, d.order[0])
+		d.order = d.order[1:]
+	}
+	return false
+}
+
 func (q *msgQueue) push(content string) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
@@ -3118,6 +3145,7 @@ func main() {
 	// via http://localhost:18790 without needing a public hub URL.
 	proxy := newHTTPProxy(nil) // send func wired up in runHubLoop
 	queue := &msgQueue{}
+	deduper := newMessageDeduper()
 	go func() {
 		log.Printf("[bridge] local HTTP proxy on 127.0.0.1:18790")
 		if err := http.ListenAndServe("127.0.0.1:18790", proxy); err != nil {
@@ -3163,7 +3191,7 @@ func main() {
 	go runStatusChannel(ctx, wsURL, clawID, clawName, templateName, token)
 
 	for {
-		if err := runHubLoop(ctx, wsURL, clawID, clawName, templateName, token, gwClient, gwSession, proxy, queue); err != nil {
+		if err := runHubLoop(ctx, wsURL, clawID, clawName, templateName, token, gwClient, gwSession, proxy, queue, deduper); err != nil {
 			if ctx.Err() != nil {
 				log.Printf("shutting down")
 				return
@@ -3286,7 +3314,7 @@ func runStatusChannel(ctx context.Context, wsURL, clawID, clawName, templateName
 	}
 }
 
-func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, token string, gwClient *gatewayClient, gwSession *gatewaySession, proxy *httpProxy, queue *msgQueue) error {
+func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, token string, gwClient *gatewayClient, gwSession *gatewaySession, proxy *httpProxy, queue *msgQueue, deduper *messageDeduper) error {
 	conn, _, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{
 		HTTPHeader: http.Header{
 			"User-Agent":                 {"claw-bridge/1.0"},
@@ -3413,6 +3441,11 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 				}
 				content, _ := m["content"].(string)
 				if content == "" {
+					return
+				}
+				id, _ := m["id"].(string)
+				if deduper.seen(id) {
+					log.Printf("[bridge] skipping duplicate message id=%s", id)
 					return
 				}
 				if !gwSession.IsReady() {

--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -3596,6 +3596,9 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 					return
 				}
 				id, _ := m["id"].(string)
+				if id == "" {
+					log.Printf("[bridge] warning: message without id, dedup disabled for it")
+				}
 				if deduper.seen(id) {
 					log.Printf("[bridge] skipping duplicate message id=%s", id)
 					return

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -30,6 +31,24 @@ func writeGatewayClientConfig(t *testing.T, home, config string) {
 	device := `{"deviceId":"device-1","publicKeyPem":"pub","privateKeyPem":"priv"}`
 	if err := os.WriteFile(filepath.Join(cfgDir, "identity", "device.json"), []byte(device), 0600); err != nil {
 		t.Fatalf("write device config: %v", err)
+	}
+}
+
+func TestMessageDeduperTracksDuplicatesAndEvictsOldest(t *testing.T) {
+	deduper := newMessageDeduper()
+	if deduper.seen("first") {
+		t.Fatal("fresh id reported as already seen")
+	}
+	if !deduper.seen("first") {
+		t.Fatal("repeated id was not reported as seen")
+	}
+	for i := 0; i < 128; i++ {
+		if deduper.seen(fmt.Sprintf("id-%d", i)) {
+			t.Fatalf("fresh id-%d reported as already seen", i)
+		}
+	}
+	if deduper.seen("first") {
+		t.Fatal("oldest id was not evicted after capacity was exceeded")
 	}
 }
 

--- a/pkg/hub/checkpoints.go
+++ b/pkg/hub/checkpoints.go
@@ -396,8 +396,9 @@ func (s *Server) provisionStoredClaw(clawID string) {
 	}
 	var restoreCheckpointID string
 	_ = s.db.QueryRow(`SELECT COALESCE(restore_checkpoint_id,'') FROM claws WHERE id=?`, clawID).Scan(&restoreCheckpointID)
-	_, _ = s.db.Exec(`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at,format) VALUES(?,?,?,?,?,?,?)`,
-		uuid.New().String(), clawID, tenantID, "system", fmt.Sprintf("[hub] Restoring from checkpoint %s.", restoreCheckpointID), now(), "pre")
+	createdAt := now()
+	_, _ = s.db.Exec(`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at,format,delivered_at) VALUES(?,?,?,?,?,?,?,?)`,
+		uuid.New().String(), clawID, tenantID, "system", fmt.Sprintf("[hub] Restoring from checkpoint %s.", restoreCheckpointID), createdAt, "pre", createdAt)
 }
 
 func (s *Server) requestCheckpoint(ctx context.Context, clawID, reason, createdBy string, wait bool, timeout time.Duration) (string, error) {

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -64,7 +64,11 @@ func migrate(db *sql.DB) error {
 	_, _ = db.Exec(`ALTER TABLE claw_prs ADD COLUMN last_review_id INTEGER NOT NULL DEFAULT 0`)
 	_, _ = db.Exec(`ALTER TABLE messages ADD COLUMN format TEXT NOT NULL DEFAULT ''`)
 	if _, err := db.Exec(`ALTER TABLE messages ADD COLUMN delivered_at DATETIME`); err == nil {
-		_, _ = db.Exec(`UPDATE messages SET delivered_at = created_at`)
+		// A failed backfill must abort startup: the column now exists, so a
+		// later start would skip this branch and replay all history as pending.
+		if _, backfillErr := db.Exec(`UPDATE messages SET delivered_at = created_at`); backfillErr != nil {
+			return fmt.Errorf("backfill messages.delivered_at: %w", backfillErr)
+		}
 	}
 	_, _ = db.Exec(`ALTER TABLE factory_triggers ADD COLUMN task_run_id TEXT NOT NULL DEFAULT ''`)
 	_, _ = db.Exec(`ALTER TABLE factory_triggers ADD COLUMN retry_count INTEGER NOT NULL DEFAULT 0`)

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -61,6 +61,9 @@ func migrate(db *sql.DB) error {
 	_, _ = db.Exec(`ALTER TABLE claw_prs ADD COLUMN last_review_comment_id INTEGER NOT NULL DEFAULT 0`)
 	_, _ = db.Exec(`ALTER TABLE claw_prs ADD COLUMN last_review_id INTEGER NOT NULL DEFAULT 0`)
 	_, _ = db.Exec(`ALTER TABLE messages ADD COLUMN format TEXT NOT NULL DEFAULT ''`)
+	if _, err := db.Exec(`ALTER TABLE messages ADD COLUMN delivered_at DATETIME`); err == nil {
+		_, _ = db.Exec(`UPDATE messages SET delivered_at = created_at`)
+	}
 	_, _ = db.Exec(`ALTER TABLE factory_triggers ADD COLUMN task_run_id TEXT NOT NULL DEFAULT ''`)
 	_, _ = db.Exec(`ALTER TABLE task_run_attempts ADD COLUMN restored_checkpoint_id TEXT`)
 
@@ -228,7 +231,8 @@ func migrate(db *sql.DB) error {
 		role       TEXT NOT NULL,
 		content    TEXT NOT NULL,
 		format     TEXT NOT NULL DEFAULT '',
-		created_at DATETIME NOT NULL
+		created_at DATETIME NOT NULL,
+		delivered_at DATETIME
 	);
 
 	CREATE TABLE IF NOT EXISTS factory_triggers (
@@ -250,6 +254,7 @@ func migrate(db *sql.DB) error {
 	CREATE INDEX IF NOT EXISTS idx_factory_triggers_claw ON factory_triggers(claw_id);
 
 	CREATE INDEX IF NOT EXISTS idx_messages_claw ON messages(claw_id, created_at);
+	CREATE INDEX IF NOT EXISTS idx_messages_pending ON messages(claw_id, created_at) WHERE delivered_at IS NULL;
 	CREATE INDEX IF NOT EXISTS idx_claws_tenant  ON claws(tenant_id);
 
 	CREATE TABLE IF NOT EXISTS task_runs (

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -15,7 +15,6 @@ import (
 	"github.com/elasticclaw/elasticclaw/pkg/hub/pipeline"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 	"github.com/google/uuid"
-	"nhooyr.io/websocket/wsjson"
 )
 
 var prURLRegex = regexp.MustCompile(`https://github\.com/([a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+)/pull/(\d+)`)
@@ -800,7 +799,7 @@ func (s *Server) injectMessage(clawID, content, role string) {
 		CreatedAt: now(),
 	}
 	_, err := s.db.Exec(
-		`INSERT INTO messages(id,claw_id,tenant_id,role,content,format,created_at) VALUES(?,?,?,?,?,?,?)`,
+		`INSERT INTO messages(id,claw_id,tenant_id,role,content,format,created_at,delivered_at) VALUES(?,?,?,?,?,?,?,NULL)`,
 		msg.ID, msg.ClawID, msg.TenantID, msg.Role, msg.Content, msg.Format, msg.CreatedAt,
 	)
 	if err != nil {
@@ -811,7 +810,7 @@ func (s *Server) injectMessage(clawID, content, role string) {
 	// Broadcast to dashboard immediately, even if delivery to the agent is queued.
 	s.broadcastToUsers(tenantID, types.WSMessage{Type: "message", Payload: msg})
 
-	// Forward to agent over WS, or queue behind the current turn.
+	// Deliver oldest pending message when the agent is idle.
 	s.mu.RLock()
 	cc, ok := s.claws[clawID]
 	s.mu.RUnlock()
@@ -819,48 +818,15 @@ func (s *Server) injectMessage(clawID, content, role string) {
 	if ok {
 		cc.mu.Lock()
 		cc.lastUserMessageAt = time.Now()
-		if cc.isBusyLocked() {
-			cc.messageQueue = append(cc.messageQueue, msg)
-			queueLen := len(cc.messageQueue)
-			cc.mu.Unlock()
-			acceptedForAgent = true
-			log.Printf("[pr-watcher] queued injected message for claw %s (queue length: %d)", shortID(clawID), queueLen)
-		} else {
-			conn := cc.conn
-			cc.mu.Unlock()
-
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			err := wsjson.Write(ctx, conn, types.WSMessage{Type: "message", Payload: msg})
-			cancel()
-			if err != nil {
-				log.Printf("[pr-watcher] failed to send injected message to claw %s: %v, queueing", shortID(clawID), err)
-				s.mu.RLock()
-				currentCC := s.claws[clawID]
-				s.mu.RUnlock()
-				if currentCC != nil {
-					currentCC.mu.Lock()
-					currentCC.messageQueue = append([]types.HubMessage{msg}, currentCC.messageQueue...)
-					queueLen := len(currentCC.messageQueue)
-					currentCC.mu.Unlock()
-					acceptedForAgent = true
-					log.Printf("[pr-watcher] queued injected message for claw %s after send failure (queue length: %d)", shortID(clawID), queueLen)
-					go s.sendNextQueuedMessage(currentCC)
-				}
-			} else {
-				acceptedForAgent = true
-				log.Printf("[pr-watcher] delivered injected message to claw %s", shortID(clawID))
-			}
+		busy := cc.isBusyLocked()
+		cc.mu.Unlock()
+		acceptedForAgent = true
+		if !busy {
+			s.sendNextQueuedMessage(cc)
 		}
 	}
 	if acceptedForAgent {
-		// Signal to UI that agent is working on the injected message
-		s.broadcastToUsers(tenantID, types.WSMessage{
-			Type: "agent_typing",
-			Payload: map[string]string{
-				"claw_id": clawID,
-				"status":  "typing",
-			},
-		})
+		log.Printf("[pr-watcher] injected message accepted for claw %s", shortID(clawID))
 	}
 
 	// If this is a user/hub message injection (not a claw response), move the issue

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -4921,7 +4921,8 @@ func (s *Server) checkClawStatus() {
 				s.broadcastToUsers(tenantID, types.WSMessage{Type: "message", Payload: types.HubMessage{ID: messageID, ClawID: id, TenantID: tenantID, Role: "claw", Content: content, CreatedAt: now}})
 			}
 			s.broadcastToUsers(tenantID, types.WSMessage{Type: "agent_typing", Payload: map[string]string{"claw_id": id, "status": "idle"}})
-			s.sendNextQueuedMessage(cc)
+			// The idle drain below delivers the next pending message; calling
+			// sendNextQueuedMessage here as well would send two back-to-back.
 			if escalate {
 				go s.stopAgentWithReason(id, "agent repeatedly stuck mid-turn", false)
 			}
@@ -6783,9 +6784,11 @@ func (s *Server) sendNextQueuedMessage(cc *clawConn) {
 		return
 	}
 
-	// Re-check the claw is still idle and on the same connection before writing.
+	// Re-check the claw is still idle before writing. A reconnect always
+	// allocates a fresh clawConn, so cc.conn cannot change under us; a write
+	// to a dead socket fails and leaves the row pending for the new connection.
 	cc.mu.Lock()
-	if cc.isBusyLocked() || cc.conn != conn {
+	if cc.isBusyLocked() {
 		cc.mu.Unlock()
 		return
 	}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -124,8 +124,7 @@ type clawConn struct {
 	streamingTimeoutSent  bool            // true once the 12-min timeout message has been injected this turn
 	contextWarningSent    bool            // true once the context-nearly-full warning has been injected this turn
 
-	// Message queue for when claw is busy processing
-	messageQueue []types.HubMessage // queued messages waiting to be sent
+	deliveryInFlight bool // serializes DB-backed delivery writes
 
 	pendingCheckpointReason string // coalesced checkpoint request to run after current turn
 	pendingCheckpointID     string
@@ -189,9 +188,9 @@ func (s *Server) flushStreamingSegment(clawID, tenantID string, cc *clawConn) er
 	cc.mu.Unlock()
 
 	_, err := s.db.Exec(
-		`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at) VALUES(?,?,?,?,?,?)
-		 ON CONFLICT(id) DO UPDATE SET content=excluded.content`,
-		msgID, clawID, tenantID, "claw", content, now(),
+		`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at,delivered_at) VALUES(?,?,?,?,?,?,?)
+		 ON CONFLICT(id) DO UPDATE SET content=excluded.content, delivered_at=excluded.delivered_at`,
+		msgID, clawID, tenantID, "claw", content, now(), now(),
 	)
 	return err
 }
@@ -1616,14 +1615,14 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 			Role: "user", Content: body.Content, CreatedAt: now(),
 		}
 		if _, err := s.db.Exec(
-			`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at) VALUES(?,?,?,?,?,?)`,
+			`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at,delivered_at) VALUES(?,?,?,?,?,?,NULL)`,
 			msg.ID, msg.ClawID, msg.TenantID, msg.Role, msg.Content, msg.CreatedAt,
 		); err != nil {
 			http.Error(w, "db error", http.StatusInternalServerError)
 			return
 		}
 		s.recordTaskRunDashboardMessage(clawID, ghLoginMsg, msg.ID)
-		// Forward to claw if connected (or queue if busy)
+		// Deliver oldest pending message if connected and idle.
 		s.mu.RLock()
 		cc := s.claws[clawID]
 		s.mu.RUnlock()
@@ -1631,26 +1630,12 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 			cc.mu.Lock()
 			cc.lastUserMessageAt = time.Now()
 			cc.unresponsiveWarnedAt = time.Time{}
-			// Check if claw is currently streaming/processing
-			isBusy := !cc.streamingStartedAt.IsZero() || cc.streamingMsgID != ""
-			if isBusy {
-				// Queue the message for later delivery
-				cc.messageQueue = append(cc.messageQueue, msg)
-				queueLen := len(cc.messageQueue)
-				cc.mu.Unlock()
-				log.Printf("[hub] message queued for %s (queue length: %d)", clawID[:8], queueLen)
+			busy := cc.isBusyLocked()
+			cc.mu.Unlock()
+			if !busy {
+				s.sendNextQueuedMessage(cc)
 			} else {
-				cc.mu.Unlock()
-				// Send immediately
-				_ = wsjson.Write(r.Context(), cc.conn, types.WSMessage{Type: "message", Payload: msg})
-				// Immediately signal to UI that agent is working, before first chunk arrives
-				s.broadcastToUsers(tenantID, types.WSMessage{
-					Type: "agent_typing",
-					Payload: map[string]string{
-						"claw_id": clawID,
-						"status":  "typing",
-					},
-				})
+				log.Printf("[hub] message pending for busy claw %s", clawID[:8])
 			}
 		}
 		jsonOK(w, msg)
@@ -2176,15 +2161,8 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 		old.mu.RLock()
 		cc.statusConn = old.statusConn
 		cc.lastStatusAt = old.lastStatusAt
-		// Copy message queue from old connection to preserve queued messages
-		if len(old.messageQueue) > 0 {
-			cc.messageQueue = make([]types.HubMessage, len(old.messageQueue))
-			copy(cc.messageQueue, old.messageQueue)
-		}
 		old.mu.RUnlock()
 	}
-	// Capture whether we have queued messages before unlocking
-	hasQueuedMessages := len(cc.messageQueue) > 0
 	s.claws[clawID] = cc
 	s.mu.Unlock()
 
@@ -2196,12 +2174,8 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 	// Broadcast initial status to user sessions
 	s.broadcastToUsers(tenantID, types.WSMessage{Type: "claw_status", Payload: map[string]string{"claw_id": clawID, "status": currentStatus}})
 
-	// Drain any queued messages that were copied from the old connection.
-	// This must happen after the connection is live but before the read loop starts.
-	// We call it synchronously (not in a goroutine) to avoid racing with new user messages.
-	if hasQueuedMessages {
-		s.sendNextQueuedMessage(cc)
-	}
+	// This is synchronous so reconnect delivery is ordered with new user messages.
+	s.sendNextQueuedMessage(cc)
 
 	// Initialize entry pipeline stage only after bridge connects so on_enter inject
 	// can be delivered over WS.
@@ -2232,9 +2206,9 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 		if partialContent != "" {
 			interruptedAt := now()
 			_, _ = s.db.Exec(
-				`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at) VALUES(?,?,?,?,?,?)
-				 ON CONFLICT(id) DO UPDATE SET content=excluded.content`,
-				partialMsgID, clawID, tenantID, "claw", partialContent, interruptedAt,
+				`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at,delivered_at) VALUES(?,?,?,?,?,?,?)
+				 ON CONFLICT(id) DO UPDATE SET content=excluded.content, delivered_at=excluded.delivered_at`,
+				partialMsgID, clawID, tenantID, "claw", partialContent, interruptedAt, interruptedAt,
 			)
 			s.broadcastToUsers(tenantID, types.WSMessage{Type: "message", Payload: types.HubMessage{
 				ID: partialMsgID, ClawID: clawID, TenantID: tenantID, Role: "claw",
@@ -2404,8 +2378,8 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 					if content != "" && !isUnhelpfulActivityContent(activity, content) {
 						format := "activity:" + string(payload)
 						_, _ = s.db.Exec(
-							`INSERT INTO messages(id,claw_id,tenant_id,role,content,format,created_at) VALUES(?,?,?,?,?,?,?)`,
-							uuid.New().String(), clawID, tenantID, "activity", content, format, createdAt,
+							`INSERT INTO messages(id,claw_id,tenant_id,role,content,format,created_at,delivered_at) VALUES(?,?,?,?,?,?,?,?)`,
+							uuid.New().String(), clawID, tenantID, "activity", content, format, createdAt, createdAt,
 						)
 					}
 					s.broadcastToUsers(tenantID, types.WSMessage{
@@ -2445,9 +2419,9 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 						cc.mu.Unlock()
 						// Upsert — insert on first chunk, update content on subsequent
 						_, _ = s.db.Exec(
-							`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at) VALUES(?,?,?,?,?,?)
-							 ON CONFLICT(id) DO UPDATE SET content=excluded.content`,
-							msgID, clawID, tenantID, "claw", bufContent, now(),
+							`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at,delivered_at) VALUES(?,?,?,?,?,?,?)
+							 ON CONFLICT(id) DO UPDATE SET content=excluded.content, delivered_at=excluded.delivered_at`,
+							msgID, clawID, tenantID, "claw", bufContent, now(), now(),
 						)
 					}
 				}
@@ -2498,9 +2472,9 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				}
 				if !skipPersist && strings.TrimSpace(persistContent) != "" {
 					_, _ = s.db.Exec(
-						`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at) VALUES(?,?,?,?,?,?)
-						 ON CONFLICT(id) DO UPDATE SET content=excluded.content`,
-						hm.ID, hm.ClawID, hm.TenantID, hm.Role, persistContent, hm.CreatedAt,
+						`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at,delivered_at) VALUES(?,?,?,?,?,?,?)
+						 ON CONFLICT(id) DO UPDATE SET content=excluded.content, delivered_at=excluded.delivered_at`,
+						hm.ID, hm.ClawID, hm.TenantID, hm.Role, persistContent, hm.CreatedAt, hm.CreatedAt,
 					)
 					s.broadcastToUsers(tenantID, types.WSMessage{Type: "message", Payload: hm})
 				}
@@ -2833,7 +2807,7 @@ func (s *Server) handleUserWS(w http.ResponseWriter, r *http.Request) {
 			hm.Role = "user"
 			hm.CreatedAt = now()
 			_, _ = s.db.Exec(
-				`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at) VALUES(?,?,?,?,?,?)`,
+				`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at,delivered_at) VALUES(?,?,?,?,?,?,NULL)`,
 				hm.ID, hm.ClawID, hm.TenantID, hm.Role, hm.Content, hm.CreatedAt,
 			)
 			s.recordTaskRunDashboardMessage(hm.ClawID, ghLogin, hm.ID)
@@ -2841,7 +2815,14 @@ func (s *Server) handleUserWS(w http.ResponseWriter, r *http.Request) {
 			cc := s.claws[hm.ClawID]
 			s.mu.RUnlock()
 			if cc != nil {
-				_ = wsjson.Write(ctx, cc.conn, types.WSMessage{Type: "message", Payload: hm})
+				cc.mu.Lock()
+				cc.lastUserMessageAt = time.Now()
+				cc.unresponsiveWarnedAt = time.Time{}
+				busy := cc.isBusyLocked()
+				cc.mu.Unlock()
+				if !busy {
+					s.sendNextQueuedMessage(cc)
+				}
 			}
 		}
 	}
@@ -4932,7 +4913,7 @@ func (s *Server) checkClawStatus() {
 			}
 			cc.mu.Unlock()
 			if content != "" {
-				_, _ = s.db.Exec(`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at) VALUES(?,?,?,?,?,?) ON CONFLICT(id) DO UPDATE SET content=excluded.content`, messageID, id, tenantID, "claw", content, now)
+				_, _ = s.db.Exec(`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at,delivered_at) VALUES(?,?,?,?,?,?,?) ON CONFLICT(id) DO UPDATE SET content=excluded.content, delivered_at=excluded.delivered_at`, messageID, id, tenantID, "claw", content, now, now)
 				s.broadcastToUsers(tenantID, types.WSMessage{Type: "message", Payload: types.HubMessage{ID: messageID, ClawID: id, TenantID: tenantID, Role: "claw", Content: content, CreatedAt: now}})
 			}
 			s.broadcastToUsers(tenantID, types.WSMessage{Type: "agent_typing", Payload: map[string]string{"claw_id": id, "status": "idle"}})
@@ -4940,6 +4921,12 @@ func (s *Server) checkClawStatus() {
 			if escalate {
 				go s.stopAgentWithReason(id, "agent repeatedly stuck mid-turn", false)
 			}
+		}
+		cc.mu.RLock()
+		idle := !cc.isBusyLocked()
+		cc.mu.RUnlock()
+		if idle {
+			s.sendNextQueuedMessage(cc)
 		}
 
 		// If user sent a message in the last 2 minutes, skip status broadcast
@@ -5184,8 +5171,8 @@ func (s *Server) sendWakeMessage(cc *clawConn, clawID string) {
 		CreatedAt: now(),
 	}
 	_, _ = s.db.Exec(
-		`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at) VALUES(?,?,?,?,?,?)`,
-		wakeMsg.ID, wakeMsg.ClawID, wakeMsg.TenantID, wakeMsg.Role, wakeMsg.Content, wakeMsg.CreatedAt,
+		`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at,delivered_at) VALUES(?,?,?,?,?,?,?)`,
+		wakeMsg.ID, wakeMsg.ClawID, wakeMsg.TenantID, wakeMsg.Role, wakeMsg.Content, wakeMsg.CreatedAt, wakeMsg.CreatedAt,
 	)
 	wakeMsg.Content = wakeContent
 	_ = wsjson.Write(context.Background(), cc.conn, types.WSMessage{Type: "message", Payload: wakeMsg})
@@ -5249,8 +5236,8 @@ func (s *Server) insertSystemMarker(clawID, tenantID, marker string) bool {
 		return false
 	}
 	res, err := s.db.Exec(
-		`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at) VALUES(?,?,?,?,?,?)`,
-		uuid.New().String(), clawID, tenantID, "system", marker, now(),
+		`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at,delivered_at) VALUES(?,?,?,?,?,?,?)`,
+		uuid.New().String(), clawID, tenantID, "system", marker, now(), now(),
 	)
 	if err != nil {
 		return false
@@ -6738,59 +6725,69 @@ func (s *Server) injectHubMessage(ctx context.Context, cc *clawConn, text string
 		CreatedAt: now(),
 	}
 	_, _ = s.db.Exec(
-		`INSERT INTO messages(id,claw_id,tenant_id,role,content,format,created_at) VALUES(?,?,?,?,?,?,?)`,
-		msg.ID, msg.ClawID, msg.TenantID, msg.Role, msg.Content, msg.Format, msg.CreatedAt,
+		`INSERT INTO messages(id,claw_id,tenant_id,role,content,format,created_at,delivered_at) VALUES(?,?,?,?,?,?,?,?)`,
+		msg.ID, msg.ClawID, msg.TenantID, msg.Role, msg.Content, msg.Format, msg.CreatedAt, msg.CreatedAt,
 	)
 	_ = wsjson.Write(ctx, cc.conn, types.WSMessage{Type: "message", Payload: msg})
 	s.broadcastToUsers(cc.tenantID, types.WSMessage{Type: "message", Payload: msg})
 }
 
-// sendNextQueuedMessage checks if there are queued messages for a claw and sends
-// the next one if the claw is not currently busy. Must be called with s.mu unlocked.
+// sendNextQueuedMessage delivers the oldest pending message if the claw is idle.
 func (s *Server) sendNextQueuedMessage(cc *clawConn) {
 	cc.mu.Lock()
-
-	// Check if there's anything to send
-	if len(cc.messageQueue) == 0 {
+	if cc.isBusyLocked() || cc.deliveryInFlight {
 		cc.mu.Unlock()
 		return
 	}
-
-	// Check if claw is still busy
-	if cc.isBusyLocked() {
-		cc.mu.Unlock()
-		return
-	}
-
-	// Send the next queued message - copy fields needed for sending
-	msg := cc.messageQueue[0]
-	cc.messageQueue = cc.messageQueue[1:]
-	remainingCount := len(cc.messageQueue)
+	// Claim the in-flight guard before querying so a concurrent caller cannot
+	// read the same pending row and re-deliver it after we mark it delivered.
+	cc.deliveryInFlight = true
 	conn := cc.conn
 	tenantID := cc.tenantID
 	clawID := cc.id
+	cc.mu.Unlock()
+	defer func() {
+		cc.mu.Lock()
+		cc.deliveryInFlight = false
+		cc.mu.Unlock()
+	}()
+
+	var msg types.HubMessage
+	err := s.db.QueryRow(`SELECT id, claw_id, tenant_id, role, content, COALESCE(format,''), created_at
+		FROM messages WHERE claw_id=? AND tenant_id=? AND delivered_at IS NULL
+		ORDER BY created_at, rowid LIMIT 1`, clawID, tenantID).Scan(
+		&msg.ID, &msg.ClawID, &msg.TenantID, &msg.Role, &msg.Content, &msg.Format, &msg.CreatedAt)
+	if err == sql.ErrNoRows {
+		return
+	}
+	if err != nil {
+		log.Printf("[hub] find pending message for %s: %v", shortID(clawID), err)
+		return
+	}
+
+	// Re-check the claw is still idle and on the same connection before writing.
+	cc.mu.Lock()
+	if cc.isBusyLocked() || cc.conn != conn {
+		cc.mu.Unlock()
+		return
+	}
+	cc.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err = wsjson.Write(ctx, conn, types.WSMessage{Type: "message", Payload: msg})
+	if err != nil {
+		log.Printf("[hub] failed to deliver pending message to %s: %v", shortID(clawID), err)
+		return
+	}
+	if _, err := s.db.Exec(`UPDATE messages SET delivered_at=? WHERE id=? AND delivered_at IS NULL`, now(), msg.ID); err != nil {
+		log.Printf("[hub] mark delivered message %s: %v", msg.ID, err)
+		return
+	}
+	cc.mu.Lock()
 	cc.lastUserMessageAt = time.Now()
 	cc.unresponsiveWarnedAt = time.Time{}
 	cc.mu.Unlock()
-
-	// Send via WebSocket (outside of lock to avoid blocking other goroutines)
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	err := wsjson.Write(ctx, conn, types.WSMessage{Type: "message", Payload: msg})
-
-	if err != nil {
-		// Write failed - re-enqueue the message at the front so it can be retried
-		log.Printf("[hub] failed to send queued message to %s: %v, re-enqueueing", clawID[:8], err)
-		s.mu.RLock()
-		if currentCC, ok := s.claws[clawID]; ok {
-			currentCC.mu.Lock()
-			// Prepend the message back to the front of the queue
-			currentCC.messageQueue = append([]types.HubMessage{msg}, currentCC.messageQueue...)
-			currentCC.mu.Unlock()
-		}
-		s.mu.RUnlock()
-		return
-	}
 
 	// Signal to UI that agent is working
 	s.broadcastToUsers(tenantID, types.WSMessage{
@@ -6801,5 +6798,5 @@ func (s *Server) sendNextQueuedMessage(cc *clawConn) {
 		},
 	})
 
-	log.Printf("[hub] sent queued message to %s (%d remaining in queue)", clawID[:8], remainingCount)
+	log.Printf("[hub] delivered pending message to %s", shortID(clawID))
 }

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -1968,7 +1968,7 @@ func TestReconnectDeliversQueuedMessagesInOrder(t *testing.T) {
 	if got := readTestHubMessage(t, clawWS).Content; got != "second" {
 		t.Fatalf("second delivered content = %q, want second", got)
 	}
-	assertMessagesDelivered(t, db, clawID, 2)
+	waitForMessagesDelivered(t, db, clawID, 2)
 }
 
 func TestReconnectRedeliversMessageUnmarkedAfterSuccessfulWrite(t *testing.T) {
@@ -1982,6 +1982,10 @@ func TestReconnectRedeliversMessageUnmarkedAfterSuccessfulWrite(t *testing.T) {
 	if got := readTestHubMessage(t, firstWS).Content; got != "deliver me again" {
 		t.Fatalf("initial delivered content = %q", got)
 	}
+	// The hub marks delivered_at after the WS write, so the frame can arrive
+	// here before the UPDATE runs. Wait for the mark before resetting it, or
+	// the hub's late UPDATE (WHERE delivered_at IS NULL) would re-mark the row.
+	waitForMessagesDelivered(t, db, clawID, 1)
 	// Model a hub crash after the bridge accepted the write but before the
 	// delivered_at update was committed.
 	if _, err := db.Exec(`UPDATE messages SET delivered_at=NULL WHERE claw_id=?`, clawID); err != nil {
@@ -1995,7 +1999,7 @@ func TestReconnectRedeliversMessageUnmarkedAfterSuccessfulWrite(t *testing.T) {
 	if got := readTestHubMessage(t, clawWS).Content; got != "deliver me again" {
 		t.Fatalf("redelivered content = %q", got)
 	}
-	assertMessagesDelivered(t, db, clawID, 1)
+	waitForMessagesDelivered(t, db, clawID, 1)
 }
 
 func TestSendNextQueuedMessageKeepsPendingAfterWriteFailure(t *testing.T) {
@@ -2025,7 +2029,7 @@ func TestSendNextQueuedMessageKeepsPendingAfterWriteFailure(t *testing.T) {
 	if got := readTestHubMessage(t, retryWS).Content; got != "retry me" {
 		t.Fatalf("retried content = %q", got)
 	}
-	assertMessagesDelivered(t, db, clawID, 1)
+	waitForMessagesDelivered(t, db, clawID, 1)
 }
 
 func insertPendingMessage(t *testing.T, db *sql.DB, clawID, content string, createdAt time.Time) {
@@ -2095,6 +2099,22 @@ func assertMessagesDelivered(t *testing.T, db *sql.DB, clawID string, want int) 
 	if got != want {
 		t.Fatalf("delivered messages = %d, want %d", got, want)
 	}
+}
+
+func waitForMessagesDelivered(t *testing.T, db *sql.DB, clawID string, want int) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		var got int
+		if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND role='user' AND delivered_at IS NOT NULL`, clawID).Scan(&got); err != nil {
+			t.Fatalf("count delivered messages: %v", err)
+		}
+		if got == want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d delivered messages", want)
 }
 
 func waitForTestClawDisconnect(t *testing.T, s *Server, clawID string) {

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -2,6 +2,7 @@ package hub
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -1934,23 +1935,179 @@ func TestInjectUserMessageQueuesWhenActivityOnlyTurnIsBusy(t *testing.T) {
 
 	s.injectUserMessage("claw-1", "New greptile review comment on PR #339")
 
-	cc.mu.Lock()
-	if len(cc.messageQueue) != 1 {
-		t.Fatalf("expected 1 queued message, got %d", len(cc.messageQueue))
-	}
-	queued := cc.messageQueue[0]
-	cc.mu.Unlock()
-	if queued.Role != "user" || queued.Content != "New greptile review comment on PR #339" {
-		t.Fatalf("queued message = %#v", queued)
-	}
-
-	var count int
-	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND content=?`, "claw-1", queued.Content).Scan(&count); err != nil {
+	var role, content string
+	var deliveredAt interface{}
+	if err := db.QueryRow(`SELECT role, content, delivered_at FROM messages WHERE claw_id=? AND content=?`, "claw-1", "New greptile review comment on PR #339").Scan(&role, &content, &deliveredAt); err != nil {
 		t.Fatal(err)
 	}
-	if count != 1 {
-		t.Fatalf("expected persisted injected message, got count %d", count)
+	if role != "user" || content != "New greptile review comment on PR #339" || deliveredAt != nil {
+		t.Fatalf("pending message = role=%q content=%q delivered_at=%v", role, content, deliveredAt)
 	}
+}
+
+func TestReconnectDeliversQueuedMessagesInOrder(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	const clawID = "claw-reconnect-pending"
+	insertPendingMessage(t, db, clawID, "first", now().Add(-time.Second))
+	insertPendingMessage(t, db, clawID, "second", now())
+
+	ts := httptest.NewServer(s.Handler())
+	t.Cleanup(ts.Close)
+	clawWS := connectTestClaw(t, ts, clawID)
+	t.Cleanup(func() { _ = clawWS.Close(websocket.StatusNormalClosure, "done") })
+
+	if got := readTestHubMessage(t, clawWS).Content; got != "first" {
+		t.Fatalf("first delivered content = %q, want first", got)
+	}
+	// A completed agent turn is the normal driver for the next queued message.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := wsjson.Write(ctx, clawWS, types.WSMessage{Type: "message", Payload: types.HubMessage{Content: "turn complete"}}); err != nil {
+		t.Fatalf("write completed turn: %v", err)
+	}
+	if got := readTestHubMessage(t, clawWS).Content; got != "second" {
+		t.Fatalf("second delivered content = %q, want second", got)
+	}
+	assertMessagesDelivered(t, db, clawID, 2)
+}
+
+func TestReconnectRedeliversMessageUnmarkedAfterSuccessfulWrite(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	const clawID = "claw-redeliver-pending"
+	insertPendingMessage(t, db, clawID, "deliver me again", now())
+
+	ts := httptest.NewServer(s.Handler())
+	t.Cleanup(ts.Close)
+	firstWS := connectTestClaw(t, ts, clawID)
+	if got := readTestHubMessage(t, firstWS).Content; got != "deliver me again" {
+		t.Fatalf("initial delivered content = %q", got)
+	}
+	// Model a hub crash after the bridge accepted the write but before the
+	// delivered_at update was committed.
+	if _, err := db.Exec(`UPDATE messages SET delivered_at=NULL WHERE claw_id=?`, clawID); err != nil {
+		t.Fatalf("restore unmarked delivery: %v", err)
+	}
+	_ = firstWS.Close(websocket.StatusNormalClosure, "restart hub")
+	waitForTestClawDisconnect(t, s, clawID)
+
+	clawWS := connectTestClaw(t, ts, clawID)
+	t.Cleanup(func() { _ = clawWS.Close(websocket.StatusNormalClosure, "done") })
+	if got := readTestHubMessage(t, clawWS).Content; got != "deliver me again" {
+		t.Fatalf("redelivered content = %q", got)
+	}
+	assertMessagesDelivered(t, db, clawID, 1)
+}
+
+func TestSendNextQueuedMessageKeepsPendingAfterWriteFailure(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	const clawID = "claw-write-failure"
+
+	ts := httptest.NewServer(s.Handler())
+	t.Cleanup(ts.Close)
+	failedWS := connectTestClaw(t, ts, clawID)
+	cc := s.claws[clawID]
+	insertPendingMessage(t, db, clawID, "retry me", now())
+	// Sever the client side abruptly (no close handshake) so the server's
+	// next write to this connection fails, without touching cc.conn directly
+	// (which would race the server's own read/close goroutines).
+	if err := failedWS.CloseNow(); err != nil {
+		t.Fatalf("close client websocket: %v", err)
+	}
+	waitForTestClawDisconnect(t, s, clawID)
+	// The closed peer makes the write fail; the row must remain eligible.
+	s.sendNextQueuedMessage(cc)
+	assertMessagesDelivered(t, db, clawID, 0)
+
+	retryWS := connectTestClaw(t, ts, clawID)
+	t.Cleanup(func() { _ = retryWS.Close(websocket.StatusNormalClosure, "done") })
+	if got := readTestHubMessage(t, retryWS).Content; got != "retry me" {
+		t.Fatalf("retried content = %q", got)
+	}
+	assertMessagesDelivered(t, db, clawID, 1)
+}
+
+func insertPendingMessage(t *testing.T, db *sql.DB, clawID, content string, createdAt time.Time) {
+	t.Helper()
+	if _, err := db.Exec(`INSERT OR IGNORE INTO claws(id,tenant_id,name,tags,created_at,status) VALUES(?,?,?,?,?,?)`, clawID, "test-tenant-id", clawID, `[]`, createdAt, "offline"); err != nil {
+		t.Fatalf("insert claw: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at) VALUES(?,?,?,?,?,?)`, "pending-"+content, clawID, "test-tenant-id", "user", content, createdAt); err != nil {
+		t.Fatalf("insert pending message: %v", err)
+	}
+}
+
+func connectTestClaw(t *testing.T, ts *httptest.Server, clawID string) *websocket.Conn {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, _, err := websocket.Dial(ctx, "ws"+strings.TrimPrefix(ts.URL, "http")+"/claw/ws", nil)
+	if err != nil {
+		t.Fatalf("dial claw websocket: %v", err)
+	}
+	ready := true
+	if err := wsjson.Write(ctx, conn, types.WSMessage{Type: "register", Payload: types.RegisterPayload{ClawID: clawID, Name: clawID, Template: "elasticclaw", Token: "claw-token", GatewayReady: &ready}}); err != nil {
+		t.Fatalf("register claw: %v", err)
+	}
+	var registered types.WSMessage
+	if err := wsjson.Read(ctx, conn, &registered); err != nil {
+		t.Fatalf("read registration ack: %v", err)
+	}
+	if registered.Type != "registered" {
+		t.Fatalf("registration ack type = %q, want registered", registered.Type)
+	}
+	return conn
+}
+
+func readTestHubMessage(t *testing.T, conn *websocket.Conn) types.HubMessage {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	// The connection bootstrap may deliver unrelated frames (e.g. an async
+	// checkpoint_create request) before the queued message; skip those.
+	var message types.WSMessage
+	for {
+		if err := wsjson.Read(ctx, conn, &message); err != nil {
+			t.Fatalf("read delivered message: %v", err)
+		}
+		if message.Type == "message" {
+			break
+		}
+	}
+	payload, err := json.Marshal(message.Payload)
+	if err != nil {
+		t.Fatalf("marshal message payload: %v", err)
+	}
+	var hubMessage types.HubMessage
+	if err := json.Unmarshal(payload, &hubMessage); err != nil {
+		t.Fatalf("decode message payload: %v", err)
+	}
+	return hubMessage
+}
+
+func assertMessagesDelivered(t *testing.T, db *sql.DB, clawID string, want int) {
+	t.Helper()
+	var got int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND role='user' AND delivered_at IS NOT NULL`, clawID).Scan(&got); err != nil {
+		t.Fatalf("count delivered messages: %v", err)
+	}
+	if got != want {
+		t.Fatalf("delivered messages = %d, want %d", got, want)
+	}
+}
+
+func waitForTestClawDisconnect(t *testing.T, s *Server, clawID string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		s.mu.RLock()
+		_, connected := s.claws[clawID]
+		s.mu.RUnlock()
+		if !connected {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for claw disconnect")
 }
 
 func TestInaccessibleGitHubReposMessage(t *testing.T) {

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -2005,7 +2005,9 @@ func TestSendNextQueuedMessageKeepsPendingAfterWriteFailure(t *testing.T) {
 	ts := httptest.NewServer(s.Handler())
 	t.Cleanup(ts.Close)
 	failedWS := connectTestClaw(t, ts, clawID)
+	s.mu.RLock()
 	cc := s.claws[clawID]
+	s.mu.RUnlock()
 	insertPendingMessage(t, db, clawID, "retry me", now())
 	// Sever the client side abruptly (no close handshake) so the server's
 	// next write to this connection fails, without touching cc.conn directly

--- a/pkg/hub/watchdog_enforcement_test.go
+++ b/pkg/hub/watchdog_enforcement_test.go
@@ -121,7 +121,7 @@ func TestWatchdogHealthyHeartbeatResetsUnhealthyCounter(t *testing.T) {
 }
 
 func TestWatchdogForceFinishesStaleTurnAndDeliversQueue(t *testing.T) {
-	s, _ := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
 	const clawID = "watchdog-force-finish"
 	conn := watchdogClaw(t, s, clawID)
 	cc := watchdogClawConn(t, s, clawID)
@@ -129,8 +129,10 @@ func TestWatchdogForceFinishesStaleTurnAndDeliversQueue(t *testing.T) {
 	cc.streamingStartedAt = time.Now().Add(-busyTurnMax - time.Minute)
 	cc.streamingMsgID = "partial-turn"
 	cc.streamingBuf.WriteString("partial response")
-	cc.messageQueue = []types.HubMessage{{ID: "queued-message", ClawID: clawID, TenantID: "test-tenant-id", Role: "user", Content: "next request", CreatedAt: time.Now()}}
 	cc.mu.Unlock()
+	if _, err := db.Exec(`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at,delivered_at) VALUES(?,?,?,?,?,?,NULL)`, "queued-message", clawID, "test-tenant-id", "user", "next request", time.Now()); err != nil {
+		t.Fatal(err)
+	}
 	s.checkClawStatus()
 	readCtx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
@@ -147,8 +149,12 @@ func TestWatchdogForceFinishesStaleTurnAndDeliversQueue(t *testing.T) {
 	}
 	cc.mu.RLock()
 	defer cc.mu.RUnlock()
-	if cc.isBusyLocked() || cc.forcedFinishCount != 1 || len(cc.messageQueue) != 0 {
-		t.Fatalf("turn not force-finished cleanly: busy=%v forced=%d queued=%d", cc.isBusyLocked(), cc.forcedFinishCount, len(cc.messageQueue))
+	if cc.isBusyLocked() || cc.forcedFinishCount != 1 {
+		t.Fatalf("turn not force-finished cleanly: busy=%v forced=%d", cc.isBusyLocked(), cc.forcedFinishCount)
+	}
+	var deliveredAt interface{}
+	if err := db.QueryRow(`SELECT delivered_at FROM messages WHERE id=?`, "queued-message").Scan(&deliveredAt); err != nil || deliveredAt == nil {
+		t.Fatalf("queued message not marked delivered: delivered_at=%v err=%v", deliveredAt, err)
 	}
 }
 


### PR DESCRIPTION
## Problem

Messages sent to a busy or disconnected agent were queued only in the in-memory `cc.messageQueue`. On WebSocket disconnect the handler's defer runs `delete(s.claws, clawID)`, destroying the queue; the copy on reconnect only survived an in-place reconnect race, never a real network drop. Messages sent while the claw was disconnected were INSERTed into `messages` and never delivered — the UI showed them in history but the agent never received them, so the agent idled forever ("the agent just stopped").

## Design

**Delivery state lives in the DB.** `messages` gains a nullable `delivered_at` column (`NULL` = pending delivery to the agent), a partial index on pending rows, and a migration that backfills existing rows only when the column is first added (so history is never replayed).

- **Agent-bound inserts** (user sends via HTTP and user-WS, `pr_watcher` injections) leave `delivered_at` NULL. All other inserts (claw responses, activity, system markers, hub notices, wake prompts) set `delivered_at` at insert time so they are never delivered to the agent.
- **`sendNextQueuedMessage`** is now DB-backed: it selects the oldest pending row (`ORDER BY created_at, rowid`), writes it to the WS, and marks `delivered_at` only after a successful write. A `deliveryInFlight` guard is claimed *before* the query so concurrent callers cannot re-deliver the same row.
- **Retry drivers:** a failed WS write just leaves the row pending (replacing the old front-of-queue re-enqueue that had no retry driver). Pending messages are drained on bridge (re)connect (unconditionally — the DB knows if anything is pending), at end of turn, on watchdog force-finish, and on every watchdog tick for idle claws.
- **Idempotency:** the hub is at-least-once (a crash between WS write and the `delivered_at` update redelivers on reconnect). The bridge now dedupes by message ID (ring of the last 128 delivered IDs), so a redelivery never runs the same request through the agent twice.
- The user-WS send path previously wrote directly to the claw WS ignoring errors and busy state; it now goes through the same reliable pending-delivery path.

Busy-turn semantics are preserved: a message arriving mid-turn stays pending and is delivered at the turn boundary, oldest first.

## Tests

- `TestReconnectDeliversQueuedMessagesInOrder` — messages inserted while the claw is disconnected are delivered in order after reconnect and marked delivered.
- `TestReconnectRedeliversMessageUnmarkedAfterSuccessfulWrite` — simulates a hub crash between write and mark; the row is redelivered on the next connect.
- `TestSendNextQueuedMessageKeepsPendingAfterWriteFailure` — a failed WS write leaves the row pending; a later delivery succeeds.
- `TestMessageDeduperTracksDuplicatesAndEvictsOldest` — bridge-side dedup and eviction.
- `TestInjectUserMessageQueuesWhenActivityOnlyTurnIsBusy` and `TestWatchdogForceFinishesStaleTurnAndDeliversQueue` rewritten against the DB-backed model.

`go build ./...` and `go test ./pkg/hub/... ./cmd/claw-bridge/` green, including `-race` on the new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)