### PR TITLE
feat: capture agent token usage and cost from gateway

### DIFF
--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -976,10 +976,18 @@ type gatewaySession struct {
 	// context usage (0-100), updated after each turn
 	ctxMu        sync.RWMutex
 	contextUsage int
+	usage        gatewayUsage
 
 	// ready is true once the gateway session is established and ready for messages
 	readyMu sync.RWMutex
 	ready   bool
+}
+
+type gatewayUsage struct {
+	sessionKey                             string
+	inputTokens, outputTokens, totalTokens *int
+	estimatedCostUSD                       *float64
+	model                                  string
 }
 
 // newGatewaySession creates a gatewaySession, establishes the gateway
@@ -1684,23 +1692,28 @@ func (gs *gatewaySession) refreshContextUsage(ctx context.Context) {
 	}
 	var payload struct {
 		Session struct {
-			TotalTokens   int `json:"totalTokens"`
-			ContextTokens int `json:"contextTokens"`
+			InputTokens      *int     `json:"inputTokens"`
+			OutputTokens     *int     `json:"outputTokens"`
+			TotalTokens      *int     `json:"totalTokens"`
+			EstimatedCostUSD *float64 `json:"estimatedCostUsd"`
+			Model            string   `json:"model"`
+			ModelProvider    string   `json:"modelProvider"`
+			ContextTokens    int      `json:"contextTokens"`
 		} `json:"session"`
 	}
 	if err := json.Unmarshal(resp.Payload, &payload); err != nil {
 		log.Printf("[session] unmarshal sessions.describe response: %v", err)
 		return
 	}
-	if payload.Session.ContextTokens == 0 {
-		return
-	}
-	usage := payload.Session.TotalTokens * 100 / payload.Session.ContextTokens
-	if usage > 100 {
-		usage = 100
-	}
 	gs.ctxMu.Lock()
-	gs.contextUsage = usage
+	gs.usage = gatewayUsage{sessionKey: gs.getSessionKey(), inputTokens: payload.Session.InputTokens, outputTokens: payload.Session.OutputTokens, totalTokens: payload.Session.TotalTokens, estimatedCostUSD: payload.Session.EstimatedCostUSD, model: payload.Session.Model}
+	if payload.Session.ContextTokens > 0 && payload.Session.TotalTokens != nil {
+		usage := *payload.Session.TotalTokens * 100 / payload.Session.ContextTokens
+		if usage > 100 {
+			usage = 100
+		}
+		gs.contextUsage = usage
+	}
 	gs.ctxMu.Unlock()
 }
 
@@ -1709,6 +1722,12 @@ func (gs *gatewaySession) ContextUsage() int {
 	gs.ctxMu.RLock()
 	defer gs.ctxMu.RUnlock()
 	return gs.contextUsage
+}
+
+func (gs *gatewaySession) Usage() gatewayUsage {
+	gs.ctxMu.RLock()
+	defer gs.ctxMu.RUnlock()
+	return gs.usage
 }
 
 // IsReady returns true once the persistent gateway session is established.
@@ -3661,17 +3680,29 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 		go gwSession.refreshContextUsage(connCtx)
 		health := !gatewayProcessExited() && checkGateway(gwClient.addr)
 		cu := gwSession.ContextUsage()
+		usage := gwSession.Usage()
 		restarts := gatewayRestartBase + gatewayRestartCount()
 		log.Printf("[heartbeat] sending: gateway_healthy=%v gateway_ready=%v context_usage=%d%% restart_count=%d", health, gwSession.IsReady(), cu, restarts)
-		_ = writeHub(hubMsg{
-			Type: "heartbeat",
-			Payload: mustJSON(map[string]interface{}{
-				"gateway_healthy": health,
-				"gateway_ready":   gwSession.IsReady(),
-				"context_usage":   cu,
-				"restart_count":   restarts,
-			}),
-		})
+		heartbeatPayload := map[string]interface{}{"gateway_healthy": health, "gateway_ready": gwSession.IsReady(), "context_usage": cu, "restart_count": restarts}
+		if usage.sessionKey != "" {
+			heartbeatPayload["session_key"] = usage.sessionKey
+		}
+		if usage.inputTokens != nil {
+			heartbeatPayload["input_tokens"] = usage.inputTokens
+		}
+		if usage.outputTokens != nil {
+			heartbeatPayload["output_tokens"] = usage.outputTokens
+		}
+		if usage.totalTokens != nil {
+			heartbeatPayload["total_tokens"] = usage.totalTokens
+		}
+		if usage.estimatedCostUSD != nil {
+			heartbeatPayload["estimated_cost_usd"] = usage.estimatedCostUSD
+		}
+		if usage.model != "" {
+			heartbeatPayload["model"] = usage.model
+		}
+		_ = writeHub(hubMsg{Type: "heartbeat", Payload: mustJSON(heartbeatPayload)})
 	})
 
 	// Main read loop

--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -988,6 +988,7 @@ type gatewayUsage struct {
 	inputTokens, outputTokens, totalTokens *int
 	estimatedCostUSD                       *float64
 	model                                  string
+	modelProvider                          string
 }
 
 // newGatewaySession creates a gatewaySession, establishes the gateway
@@ -1685,7 +1686,10 @@ func (gs *gatewaySession) refreshContextUsage(ctx context.Context) {
 	pollCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	resp, err := gs.sendReq(pollCtx, "sessions.describe", map[string]string{"key": gs.getSessionKey()})
+	// Capture the key once so the stored snapshot is attributed to the session
+	// we actually described, even if the session rotates while we wait.
+	sessionKey := gs.getSessionKey()
+	resp, err := gs.sendReq(pollCtx, "sessions.describe", map[string]string{"key": sessionKey})
 	if err != nil {
 		log.Printf("[session] sessions.describe for context usage: %v", err)
 		return
@@ -1706,7 +1710,7 @@ func (gs *gatewaySession) refreshContextUsage(ctx context.Context) {
 		return
 	}
 	gs.ctxMu.Lock()
-	gs.usage = gatewayUsage{sessionKey: gs.getSessionKey(), inputTokens: payload.Session.InputTokens, outputTokens: payload.Session.OutputTokens, totalTokens: payload.Session.TotalTokens, estimatedCostUSD: payload.Session.EstimatedCostUSD, model: payload.Session.Model}
+	gs.usage = gatewayUsage{sessionKey: sessionKey, inputTokens: payload.Session.InputTokens, outputTokens: payload.Session.OutputTokens, totalTokens: payload.Session.TotalTokens, estimatedCostUSD: payload.Session.EstimatedCostUSD, model: payload.Session.Model, modelProvider: payload.Session.ModelProvider}
 	if payload.Session.ContextTokens > 0 && payload.Session.TotalTokens != nil {
 		usage := *payload.Session.TotalTokens * 100 / payload.Session.ContextTokens
 		if usage > 100 {
@@ -3701,6 +3705,9 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 		}
 		if usage.model != "" {
 			heartbeatPayload["model"] = usage.model
+		}
+		if usage.modelProvider != "" {
+			heartbeatPayload["model_provider"] = usage.modelProvider
 		}
 		_ = writeHub(hubMsg{Type: "heartbeat", Payload: mustJSON(heartbeatPayload)})
 	})

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -81,6 +81,10 @@ func migrate(db *sql.DB) error {
 	_, _ = db.Exec(`ALTER TABLE task_run_summaries ADD COLUMN total_tokens INTEGER NOT NULL DEFAULT 0`)
 	_, _ = db.Exec(`ALTER TABLE task_run_summaries ADD COLUMN estimated_cost_usd REAL NOT NULL DEFAULT 0`)
 	_, _ = db.Exec(`ALTER TABLE task_run_summaries ADD COLUMN usage_updated_at INTEGER NOT NULL DEFAULT 0`)
+	_, _ = db.Exec(`ALTER TABLE task_run_usage ADD COLUMN committed_input_tokens INTEGER NOT NULL DEFAULT 0`)
+	_, _ = db.Exec(`ALTER TABLE task_run_usage ADD COLUMN committed_output_tokens INTEGER NOT NULL DEFAULT 0`)
+	_, _ = db.Exec(`ALTER TABLE task_run_usage ADD COLUMN committed_total_tokens INTEGER NOT NULL DEFAULT 0`)
+	_, _ = db.Exec(`ALTER TABLE task_run_usage ADD COLUMN committed_cost_usd REAL NOT NULL DEFAULT 0`)
 
 	_, _ = db.Exec(`CREATE TABLE IF NOT EXISTS claw_checkpoints (
 		id                    TEXT PRIMARY KEY,
@@ -323,6 +327,7 @@ func migrate(db *sql.DB) error {
 		id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL, run_id TEXT NOT NULL REFERENCES task_runs(id) ON DELETE CASCADE,
 		session_key TEXT NOT NULL, model TEXT NOT NULL DEFAULT '', model_provider TEXT NOT NULL DEFAULT '',
 		input_tokens INTEGER NOT NULL DEFAULT 0, output_tokens INTEGER NOT NULL DEFAULT 0, total_tokens INTEGER NOT NULL DEFAULT 0,
+		committed_input_tokens INTEGER NOT NULL DEFAULT 0, committed_output_tokens INTEGER NOT NULL DEFAULT 0, committed_total_tokens INTEGER NOT NULL DEFAULT 0, committed_cost_usd REAL NOT NULL DEFAULT 0,
 		cache_read_tokens INTEGER, cache_write_tokens INTEGER, estimated_cost_usd REAL, cost_source TEXT NOT NULL DEFAULT 'gateway' CHECK(cost_source IN ('gateway','hub_pricing')),
 		first_seen_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, UNIQUE(tenant_id, run_id, session_key)
 	);

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -636,7 +636,10 @@ func migrate(db *sql.DB) error {
 		{"claude-fable-5", 10, 50}, {"claude-opus-4-8", 5, 25}, {"claude-opus-4-7", 5, 25}, {"claude-opus-4-6", 5, 25},
 		{"claude-sonnet-5", 3, 15}, {"claude-sonnet-4-6", 3, 15}, {"claude-haiku-4-5", 1, 5},
 	} {
-		_, err = db.Exec(`INSERT OR IGNORE INTO model_prices(model,input_cost_per_token,output_cost_per_token,cache_read_cost_per_token,cache_write_cost_per_token,source,updated_at) VALUES(?,?,?,?,?,?,?)`, p.model, p.in/1e6, p.out/1e6, p.in/1e7, p.in*1.25/1e6, "static", now().UnixMilli())
+		// Upsert so price corrections in the static seed reach existing
+		// databases; rows from other sources are left untouched.
+		_, err = db.Exec(`INSERT INTO model_prices(model,input_cost_per_token,output_cost_per_token,cache_read_cost_per_token,cache_write_cost_per_token,source,updated_at) VALUES(?,?,?,?,?,?,?)
+			ON CONFLICT(model) DO UPDATE SET input_cost_per_token=excluded.input_cost_per_token,output_cost_per_token=excluded.output_cost_per_token,cache_read_cost_per_token=excluded.cache_read_cost_per_token,cache_write_cost_per_token=excluded.cache_write_cost_per_token,updated_at=excluded.updated_at WHERE model_prices.source='static'`, p.model, p.in/1e6, p.out/1e6, p.in/1e7, p.in*1.25/1e6, "static", now().UnixMilli())
 		if err != nil {
 			return err
 		}

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -54,6 +54,7 @@ func migrate(db *sql.DB) error {
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN restore_checkpoint_id TEXT NOT NULL DEFAULT ''`)
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN restored_from_checkpoint_id TEXT NOT NULL DEFAULT ''`)
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN task_run_id TEXT NOT NULL DEFAULT ''`)
+	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN issue_title TEXT NOT NULL DEFAULT ''`)
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN workflow_volumes TEXT NOT NULL DEFAULT '[]'`)
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN trigger_actor_json TEXT NOT NULL DEFAULT '{}'`)
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN stop_comment_pending INTEGER NOT NULL DEFAULT 0`)
@@ -73,6 +74,13 @@ func migrate(db *sql.DB) error {
 	_, _ = db.Exec(`ALTER TABLE factory_triggers ADD COLUMN task_run_id TEXT NOT NULL DEFAULT ''`)
 	_, _ = db.Exec(`ALTER TABLE factory_triggers ADD COLUMN retry_count INTEGER NOT NULL DEFAULT 0`)
 	_, _ = db.Exec(`ALTER TABLE task_run_attempts ADD COLUMN restored_checkpoint_id TEXT`)
+	_, _ = db.Exec(`ALTER TABLE task_runs ADD COLUMN issue_title TEXT NOT NULL DEFAULT ''`)
+	_, _ = db.Exec(`ALTER TABLE task_run_summaries ADD COLUMN issue_title TEXT NOT NULL DEFAULT ''`)
+	_, _ = db.Exec(`ALTER TABLE task_run_summaries ADD COLUMN input_tokens INTEGER NOT NULL DEFAULT 0`)
+	_, _ = db.Exec(`ALTER TABLE task_run_summaries ADD COLUMN output_tokens INTEGER NOT NULL DEFAULT 0`)
+	_, _ = db.Exec(`ALTER TABLE task_run_summaries ADD COLUMN total_tokens INTEGER NOT NULL DEFAULT 0`)
+	_, _ = db.Exec(`ALTER TABLE task_run_summaries ADD COLUMN estimated_cost_usd REAL NOT NULL DEFAULT 0`)
+	_, _ = db.Exec(`ALTER TABLE task_run_summaries ADD COLUMN usage_updated_at INTEGER NOT NULL DEFAULT 0`)
 
 	_, _ = db.Exec(`CREATE TABLE IF NOT EXISTS claw_checkpoints (
 		id                    TEXT PRIMARY KEY,
@@ -217,6 +225,7 @@ func migrate(db *sql.DB) error {
 		github_issue_id  TEXT NOT NULL DEFAULT '',
 		shortcut_story_id TEXT NOT NULL DEFAULT '',
 		jira_issue_id    TEXT NOT NULL DEFAULT '',
+		issue_title      TEXT NOT NULL DEFAULT '',
 		llm_key          TEXT NOT NULL DEFAULT '',
 		pipeline_stage   TEXT NOT NULL DEFAULT '',
 		bootstrap_ok        INTEGER NOT NULL DEFAULT 0,
@@ -292,6 +301,7 @@ func migrate(db *sql.DB) error {
 		trigger_id            TEXT NOT NULL DEFAULT '',
 		external_trigger_id   TEXT NOT NULL DEFAULT '',
 		issue_id              TEXT NOT NULL DEFAULT '',
+		issue_title           TEXT NOT NULL DEFAULT '',
 		claw_id               TEXT NOT NULL DEFAULT '',
 		model                 TEXT NOT NULL DEFAULT '',
 		llm_key               TEXT NOT NULL DEFAULT '',
@@ -308,6 +318,20 @@ func migrate(db *sql.DB) error {
 	CREATE INDEX IF NOT EXISTS idx_task_runs_claw ON task_runs(claw_id);
 	CREATE INDEX IF NOT EXISTS idx_task_runs_trigger ON task_runs(trigger_id);
 	CREATE INDEX IF NOT EXISTS idx_task_runs_owner ON task_runs(workspace_name, owner_type, owner_display_name, created_at DESC);
+
+	CREATE TABLE IF NOT EXISTS task_run_usage (
+		id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL, run_id TEXT NOT NULL REFERENCES task_runs(id) ON DELETE CASCADE,
+		session_key TEXT NOT NULL, model TEXT NOT NULL DEFAULT '', model_provider TEXT NOT NULL DEFAULT '',
+		input_tokens INTEGER NOT NULL DEFAULT 0, output_tokens INTEGER NOT NULL DEFAULT 0, total_tokens INTEGER NOT NULL DEFAULT 0,
+		cache_read_tokens INTEGER, cache_write_tokens INTEGER, estimated_cost_usd REAL, cost_source TEXT NOT NULL DEFAULT 'gateway' CHECK(cost_source IN ('gateway','hub_pricing')),
+		first_seen_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, UNIQUE(tenant_id, run_id, session_key)
+	);
+	CREATE TABLE IF NOT EXISTS usage_daily (
+		tenant_id TEXT NOT NULL, day TEXT NOT NULL, workspace_name TEXT NOT NULL DEFAULT '', factory_name TEXT NOT NULL DEFAULT '', workflow_name TEXT NOT NULL DEFAULT '', model TEXT NOT NULL DEFAULT '',
+		input_tokens INTEGER NOT NULL DEFAULT 0, output_tokens INTEGER NOT NULL DEFAULT 0, total_tokens INTEGER NOT NULL DEFAULT 0, cache_read_tokens INTEGER NOT NULL DEFAULT 0, cache_write_tokens INTEGER NOT NULL DEFAULT 0, cost_usd REAL NOT NULL DEFAULT 0, updated_at INTEGER NOT NULL,
+		PRIMARY KEY(tenant_id, day, workspace_name, factory_name, workflow_name, model)
+	);
+	CREATE TABLE IF NOT EXISTS model_prices (model TEXT PRIMARY KEY, input_cost_per_token REAL NOT NULL, output_cost_per_token REAL NOT NULL, cache_read_cost_per_token REAL NOT NULL, cache_write_cost_per_token REAL NOT NULL, source TEXT NOT NULL, updated_at INTEGER NOT NULL);
 
 	CREATE TABLE IF NOT EXISTS task_run_attempts (
 		id             TEXT PRIMARY KEY,
@@ -419,8 +443,14 @@ func migrate(db *sql.DB) error {
 		integration             TEXT NOT NULL DEFAULT '',
 		integration_workspace   TEXT NOT NULL DEFAULT '',
 		issue_id                TEXT NOT NULL DEFAULT '',
+		issue_title             TEXT NOT NULL DEFAULT '',
 		claw_id                 TEXT NOT NULL DEFAULT '',
 		model                   TEXT NOT NULL DEFAULT '',
+		input_tokens            INTEGER NOT NULL DEFAULT 0,
+		output_tokens           INTEGER NOT NULL DEFAULT 0,
+		total_tokens            INTEGER NOT NULL DEFAULT 0,
+		estimated_cost_usd      REAL NOT NULL DEFAULT 0,
+		usage_updated_at        INTEGER NOT NULL DEFAULT 0,
 		llm_key                 TEXT NOT NULL DEFAULT '',
 		repo                    TEXT NOT NULL DEFAULT '',
 		primary_pr_url          TEXT NOT NULL DEFAULT '',
@@ -596,7 +626,22 @@ func migrate(db *sql.DB) error {
 	CREATE INDEX IF NOT EXISTS idx_workflow_runs_status ON workflow_runs(tenant_id, status, created_at);
 	CREATE INDEX IF NOT EXISTS idx_workflow_runs_claw ON workflow_runs(claw_id);
 	`)
-	return err
+	if err != nil {
+		return err
+	}
+	for _, p := range []struct {
+		model   string
+		in, out float64
+	}{
+		{"claude-fable-5", 10, 50}, {"claude-opus-4-8", 5, 25}, {"claude-opus-4-7", 5, 25}, {"claude-opus-4-6", 5, 25},
+		{"claude-sonnet-5", 3, 15}, {"claude-sonnet-4-6", 3, 15}, {"claude-haiku-4-5", 1, 5},
+	} {
+		_, err = db.Exec(`INSERT OR IGNORE INTO model_prices(model,input_cost_per_token,output_cost_per_token,cache_read_cost_per_token,cache_write_cost_per_token,source,updated_at) VALUES(?,?,?,?,?,?,?)`, p.model, p.in/1e6, p.out/1e6, p.in/1e7, p.in*1.25/1e6, "static", now().UnixMilli())
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // pruneFactoryAnalytics deletes factory_analytics rows older than 1 year.

--- a/pkg/hub/github_issues.go
+++ b/pkg/hub/github_issues.go
@@ -561,6 +561,7 @@ func (s *Server) createClawForGitHubIssueWorkflow(workspace *types.WorkspaceConf
 	if err != nil {
 		return "", false, err
 	}
+	s.setClawIssueTitle(clawID, payload.Issue.Title)
 	if err := s.completeFactoryTrigger(triggerOwner, "github-issues", triggerKey, clawID); err != nil {
 		_, _ = s.finishClawTerminalTx(clawID, "deleted", "", "failed", err.Error(), terminalTxOpts{})
 		if s.cronScheduler != nil {
@@ -856,6 +857,7 @@ func (s *Server) createClawForGitHubIssue(factory *types.FactoryConfig, payload 
 		return fmt.Errorf("complete factory trigger: %w", err)
 	}
 	claimOpen = false
+	s.setClawIssueTitle(clawID, payload.Issue.Title)
 
 	log.Printf("[factory] created claw %s (%s) for GitHub issue %s (status=%s, reason=%s)", clawName, clawID[:8], issueID, initialStatus, reason)
 	// Notify connected dashboards immediately so the card appears

--- a/pkg/hub/jira.go
+++ b/pkg/hub/jira.go
@@ -498,6 +498,7 @@ func (s *Server) createClawForJiraWorkflow(workspace *types.WorkspaceConfig, wor
 	if err != nil {
 		return err
 	}
+	s.setClawIssueTitle(clawID, payload.Issue.Fields.Summary)
 	if err := s.completeFactoryTrigger(triggerOwner, "jira", triggerKey, clawID); err != nil {
 		_, _ = s.finishClawTerminalTx(clawID, "deleted", "", "failed", err.Error(), terminalTxOpts{})
 		if s.cronScheduler != nil {
@@ -549,6 +550,7 @@ func (s *Server) createClawForJiraIssue(factory *types.FactoryConfig, payload ji
 	if err != nil {
 		return err
 	}
+	s.setClawIssueTitle(clawID, payload.Issue.Fields.Summary)
 	if err := s.completeFactoryTrigger(factory.Name, "jira", triggerKey, clawID); err != nil {
 		_, _ = s.finishClawTerminalTx(clawID, "deleted", "", "failed", err.Error(), terminalTxOpts{})
 		if s.cronScheduler != nil {

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -557,6 +557,13 @@ func (s *Server) createClawForIssue(factory *types.FactoryConfig, payload linear
 	if err != nil {
 		return err
 	}
+	// Keep the tracker title with the run; the dashboard can then display it
+	// without another tracker request.
+	if payload.Data.Title != "" {
+		_, _ = s.db.Exec(`UPDATE claws SET issue_title=? WHERE id=?`, payload.Data.Title, clawID)
+		_, _ = s.db.Exec(`UPDATE task_runs SET issue_title=? WHERE claw_id=?`, payload.Data.Title, clawID)
+		_, _ = s.db.Exec(`UPDATE task_run_summaries SET issue_title=? WHERE run_id=(SELECT task_run_id FROM claws WHERE id=?)`, payload.Data.Title, clawID)
+	}
 	if err := s.completeFactoryTrigger(factory.Name, "linear", triggerKey, clawID); err != nil {
 		_, _ = s.finishClawTerminalTx(clawID, "deleted", "", "failed", err.Error(), terminalTxOpts{})
 		if s.cronScheduler != nil {

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -480,6 +480,7 @@ func (s *Server) createClawForLinearWorkflow(workspace *types.WorkspaceConfig, w
 	if err != nil {
 		return err
 	}
+	s.setClawIssueTitle(clawID, payload.Data.Title)
 	if err := s.completeFactoryTrigger(triggerOwner, "linear", triggerKey, clawID); err != nil {
 		_, _ = s.finishClawTerminalTx(clawID, "deleted", "", "failed", err.Error(), terminalTxOpts{})
 		if s.cronScheduler != nil {
@@ -559,11 +560,7 @@ func (s *Server) createClawForIssue(factory *types.FactoryConfig, payload linear
 	}
 	// Keep the tracker title with the run; the dashboard can then display it
 	// without another tracker request.
-	if payload.Data.Title != "" {
-		_, _ = s.db.Exec(`UPDATE claws SET issue_title=? WHERE id=?`, payload.Data.Title, clawID)
-		_, _ = s.db.Exec(`UPDATE task_runs SET issue_title=? WHERE claw_id=?`, payload.Data.Title, clawID)
-		_, _ = s.db.Exec(`UPDATE task_run_summaries SET issue_title=? WHERE run_id=(SELECT task_run_id FROM claws WHERE id=?)`, payload.Data.Title, clawID)
-	}
+	s.setClawIssueTitle(clawID, payload.Data.Title)
 	if err := s.completeFactoryTrigger(factory.Name, "linear", triggerKey, clawID); err != nil {
 		_, _ = s.finishClawTerminalTx(clawID, "deleted", "", "failed", err.Error(), terminalTxOpts{})
 		if s.cronScheduler != nil {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2263,12 +2263,21 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 			if msg.Type == "heartbeat" {
 				payload, _ := json.Marshal(msg.Payload)
 				var hb struct {
-					GatewayHealthy bool  `json:"gateway_healthy"`
-					GatewayReady   *bool `json:"gateway_ready,omitempty"`
-					ContextUsage   int   `json:"context_usage"`
-					RestartCount   int   `json:"restart_count"`
+					GatewayHealthy   bool     `json:"gateway_healthy"`
+					GatewayReady     *bool    `json:"gateway_ready,omitempty"`
+					ContextUsage     int      `json:"context_usage"`
+					RestartCount     int      `json:"restart_count"`
+					SessionKey       string   `json:"session_key"`
+					InputTokens      *int     `json:"input_tokens"`
+					OutputTokens     *int     `json:"output_tokens"`
+					TotalTokens      *int     `json:"total_tokens"`
+					EstimatedCostUSD *float64 `json:"estimated_cost_usd"`
+					Model            string   `json:"model"`
 				}
 				if err := json.Unmarshal(payload, &hb); err == nil {
+					if err := s.recordTaskRunUsage(clawID, taskRunUsageSnapshot{SessionKey: hb.SessionKey, InputTokens: hb.InputTokens, OutputTokens: hb.OutputTokens, TotalTokens: hb.TotalTokens, EstimatedCostUSD: hb.EstimatedCostUSD, Model: hb.Model}); err != nil {
+						log.Printf("[usage] heartbeat for %s: %v", clawID, err)
+					}
 					gatewayUnhealthyMax := s.livenessSettings().gatewayUnhealthyMax
 					var wakeConn *clawConn
 					var shouldWake bool

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2273,9 +2273,10 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 					TotalTokens      *int     `json:"total_tokens"`
 					EstimatedCostUSD *float64 `json:"estimated_cost_usd"`
 					Model            string   `json:"model"`
+					ModelProvider    string   `json:"model_provider"`
 				}
 				if err := json.Unmarshal(payload, &hb); err == nil {
-					if err := s.recordTaskRunUsage(clawID, taskRunUsageSnapshot{SessionKey: hb.SessionKey, InputTokens: hb.InputTokens, OutputTokens: hb.OutputTokens, TotalTokens: hb.TotalTokens, EstimatedCostUSD: hb.EstimatedCostUSD, Model: hb.Model}); err != nil {
+					if err := s.recordTaskRunUsage(clawID, taskRunUsageSnapshot{SessionKey: hb.SessionKey, InputTokens: hb.InputTokens, OutputTokens: hb.OutputTokens, TotalTokens: hb.TotalTokens, EstimatedCostUSD: hb.EstimatedCostUSD, Model: hb.Model, ModelProvider: hb.ModelProvider}); err != nil {
 						log.Printf("[usage] heartbeat for %s: %v", clawID, err)
 					}
 					gatewayUnhealthyMax := s.livenessSettings().gatewayUnhealthyMax

--- a/pkg/hub/shortcut.go
+++ b/pkg/hub/shortcut.go
@@ -768,6 +768,7 @@ func (s *Server) createClawForShortcutStory(factory *types.FactoryConfig, action
 		return fmt.Errorf("complete factory trigger: %w", err)
 	}
 	claimOpen = false
+	s.setClawIssueTitle(clawID, action.Name)
 
 	log.Printf("[factory] created claw %s (%s) for Shortcut story %s (status=%s, reason=%s)", clawName, clawID[:8], storyID, initialStatus, reason)
 	s.broadcastToUsers(tenantID, types.WSMessage{
@@ -884,6 +885,7 @@ func (s *Server) createClawForShortcutWorkflow(workspace *types.WorkspaceConfig,
 	if err != nil {
 		return err
 	}
+	s.setClawIssueTitle(clawID, action.Name)
 	if err := s.completeFactoryTrigger(triggerOwner, "shortcut", triggerKey, clawID); err != nil {
 		_, _ = s.finishClawTerminalTx(clawID, "deleted", "", "failed", err.Error(), terminalTxOpts{})
 		if s.cronScheduler != nil {

--- a/pkg/hub/task_run_analytics.go
+++ b/pkg/hub/task_run_analytics.go
@@ -190,6 +190,19 @@ func rfc3339FromEpochMillis(ms int64) string {
 	return time.UnixMilli(ms).UTC().Format(time.RFC3339)
 }
 
+// setClawIssueTitle persists the tracker issue/story title on the claw and its
+// task run so it flows into task_run_summaries via the materializer. Best
+// effort: a missing title never fails claw creation.
+func (s *Server) setClawIssueTitle(clawID, title string) {
+	title = strings.TrimSpace(title)
+	if clawID == "" || title == "" {
+		return
+	}
+	_, _ = s.db.Exec(`UPDATE claws SET issue_title=? WHERE id=?`, title, clawID)
+	_, _ = s.db.Exec(`UPDATE task_runs SET issue_title=? WHERE claw_id=?`, title, clawID)
+	_, _ = s.db.Exec(`UPDATE task_run_summaries SET issue_title=? WHERE run_id IN (SELECT id FROM task_runs WHERE claw_id=?)`, title, clawID)
+}
+
 func (s *Server) ensureTaskRunForClaw(clawID string, opts TaskRunStart) (string, string, error) {
 	if s == nil || s.db == nil {
 		return "", "", fmt.Errorf("ensure task run: missing server db")
@@ -208,13 +221,13 @@ func (s *Server) ensureTaskRunForClaw(clawID string, opts TaskRunStart) (string,
 	}
 	defer tx.Rollback()
 
-	var tenantID, existingRunID, rawTags, clawModel, clawLLMKey, clawFactory, externalTriggerID, linearIssue, githubIssue, shortcutStory, jiraIssue, clawStatus string
+	var tenantID, existingRunID, rawTags, clawModel, clawLLMKey, clawFactory, externalTriggerID, linearIssue, githubIssue, shortcutStory, jiraIssue, clawStatus, clawIssueTitle string
 	err = tx.QueryRow(`
 		SELECT tenant_id, COALESCE(task_run_id,''), COALESCE(tags,'[]'), COALESCE(default_model,''),
 		       COALESCE(llm_key,''), COALESCE(factory_name,''), COALESCE(external_trigger_id,''),
-		       COALESCE(linear_issue_id,''), COALESCE(github_issue_id,''), COALESCE(shortcut_story_id,''), COALESCE(jira_issue_id,''), COALESCE(status,'')
+		       COALESCE(linear_issue_id,''), COALESCE(github_issue_id,''), COALESCE(shortcut_story_id,''), COALESCE(jira_issue_id,''), COALESCE(status,''), COALESCE(issue_title,'')
 		  FROM claws
-		 WHERE id=?`, clawID).Scan(&tenantID, &existingRunID, &rawTags, &clawModel, &clawLLMKey, &clawFactory, &externalTriggerID, &linearIssue, &githubIssue, &shortcutStory, &jiraIssue, &clawStatus)
+		 WHERE id=?`, clawID).Scan(&tenantID, &existingRunID, &rawTags, &clawModel, &clawLLMKey, &clawFactory, &externalTriggerID, &linearIssue, &githubIssue, &shortcutStory, &jiraIssue, &clawStatus, &clawIssueTitle)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return "", "", fmt.Errorf("ensure task run: claw %s not found", clawID)
@@ -265,12 +278,12 @@ func (s *Server) ensureTaskRunForClaw(clawID string, opts TaskRunStart) (string,
 		INSERT INTO task_runs(
 			id, tenant_id, initial_attempt_id, current_attempt_id, attempt_count, run_kind,
 			owner_type, workspace_name, workflow_name, factory_name, owner_id, owner_display_name,
-			integration, integration_workspace, trigger_id, external_trigger_id, issue_id, claw_id, model, llm_key, tags,
+			integration, integration_workspace, trigger_id, external_trigger_id, issue_id, issue_title, claw_id, model, llm_key, tags,
 			analytics_enabled, requires_pr, excluded_reason, timeout_at, created_at, updated_at
-		) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
 		runID, opts.TenantID, attemptID, attemptID, 1, opts.RunKind, opts.OwnerType, opts.WorkspaceName,
 		opts.WorkflowName, opts.FactoryName, opts.OwnerID, opts.OwnerDisplayName, opts.Integration, opts.IntegrationWorkspace,
-		opts.TriggerID, opts.ExternalTriggerID, opts.IssueID, clawID, opts.Model, opts.LLMKey, tags, analyticsEnabled, requiresPR,
+		opts.TriggerID, opts.ExternalTriggerID, opts.IssueID, clawIssueTitle, clawID, opts.Model, opts.LLMKey, tags, analyticsEnabled, requiresPR,
 		opts.ExcludedReason, timeoutAt, ts, ts,
 	); err != nil {
 		return "", "", err
@@ -883,13 +896,13 @@ func materializeTaskRunTx(tx *sql.Tx, runID string) error {
 		INSERT INTO task_run_summaries(
 			id, tenant_id, run_id, initial_attempt_id, current_attempt_id, status, phase,
 			attempt_count, owner_type, workspace_name, workflow_name, factory_name, owner_id,
-			owner_display_name, run_kind, integration, integration_workspace, issue_id, claw_id,
+			owner_display_name, run_kind, integration, integration_workspace, issue_id, issue_title, claw_id,
 			model, llm_key, repo, primary_pr_url,
 			pr_count, open_pr_count, merged_pr_count, closed_pr_count, warning_types, failure_type,
 			human_interaction_count, started_at, queued_at, provision_started_at, agent_started_at,
 			pr_opened_at, merged_at, finished_at, timeout_at, last_event_at, materialized_at, updated_at,
 			analytics_enabled, requires_pr, excluded_reason
-		) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+		) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
 		ON CONFLICT(run_id) DO UPDATE SET
 			initial_attempt_id=excluded.initial_attempt_id,
 			current_attempt_id=excluded.current_attempt_id,
@@ -906,6 +919,7 @@ func materializeTaskRunTx(tx *sql.Tx, runID string) error {
 			integration=excluded.integration,
 			integration_workspace=excluded.integration_workspace,
 			issue_id=excluded.issue_id,
+			issue_title=excluded.issue_title,
 			claw_id=excluded.claw_id,
 			model=excluded.model,
 			llm_key=excluded.llm_key,
@@ -933,7 +947,7 @@ func materializeTaskRunTx(tx *sql.Tx, runID string) error {
 			excluded_reason=excluded.excluded_reason`,
 		uuid.New().String(), meta.tenantID, runID, meta.initialAttemptID, meta.currentAttemptID, status, phase, meta.attemptCount, meta.ownerType,
 		meta.workspaceName, meta.workflowName, meta.factoryName, meta.ownerID, meta.ownerDisplayName,
-		meta.runKind, meta.integration, meta.integrationWorkspace, meta.issueID, meta.clawID,
+		meta.runKind, meta.integration, meta.integrationWorkspace, meta.issueID, meta.issueTitle, meta.clawID,
 		meta.model, meta.llmKey, counts.primaryRepo, primaryPRURL, counts.total, counts.open, counts.merged, counts.closed,
 		warningTypes, failureType, humanInteractions, meta.createdAt, phaseTimes.queuedAt, phaseTimes.provisionStartedAt,
 		phaseTimes.agentStartedAt, phaseTimes.prOpenedAt, counts.latestMergedAt, finishedAt, meta.timeoutAt,
@@ -1051,6 +1065,7 @@ type taskRunMeta struct {
 	integration          string
 	integrationWorkspace string
 	issueID              string
+	issueTitle           string
 	model                string
 	llmKey               string
 	analyticsEnabled     int
@@ -1068,7 +1083,7 @@ func readTaskRunMetaTx(tx *sql.Tx, runID string) (taskRunMeta, error) {
 		       tr.attempt_count, tr.owner_type, tr.workspace_name,
 		       tr.workflow_name, tr.factory_name, tr.owner_id, tr.owner_display_name,
 		       tr.integration,
-		       tr.integration_workspace, tr.issue_id, COALESCE(c.status,''), COALESCE(NULLIF(tr.model,''), c.default_model, ''),
+		       tr.integration_workspace, tr.issue_id, COALESCE(NULLIF(tr.issue_title,''), c.issue_title, ''), COALESCE(c.status,''), COALESCE(NULLIF(tr.model,''), c.default_model, ''),
 		       COALESCE(NULLIF(tr.llm_key,''), c.llm_key, ''), tr.analytics_enabled, tr.requires_pr, tr.excluded_reason,
 		       tr.timeout_at, tr.created_at, tr.updated_at
 		  FROM task_runs tr
@@ -1077,7 +1092,7 @@ func readTaskRunMetaTx(tx *sql.Tx, runID string) (taskRunMeta, error) {
 		&meta.tenantID, &meta.clawID, &meta.runKind, &meta.initialAttemptID, &meta.currentAttemptID,
 		&meta.attemptCount, &meta.ownerType,
 		&meta.workspaceName, &meta.workflowName, &meta.factoryName, &meta.ownerID, &meta.ownerDisplayName,
-		&meta.integration, &meta.integrationWorkspace, &meta.issueID, &meta.clawStatus, &meta.model, &meta.llmKey,
+		&meta.integration, &meta.integrationWorkspace, &meta.issueID, &meta.issueTitle, &meta.clawStatus, &meta.model, &meta.llmKey,
 		&meta.analyticsEnabled, &meta.requiresPR, &meta.excludedReason,
 		&meta.timeoutAt, &meta.createdAt, &meta.updatedAt,
 	)

--- a/pkg/hub/task_run_usage.go
+++ b/pkg/hub/task_run_usage.go
@@ -1,0 +1,107 @@
+package hub
+
+import (
+	"database/sql"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type taskRunUsageSnapshot struct {
+	SessionKey                             string
+	InputTokens, OutputTokens, TotalTokens *int
+	EstimatedCostUSD                       *float64
+	Model                                  string
+}
+
+func (s *Server) recordTaskRunUsage(clawID string, snapshot taskRunUsageSnapshot) error {
+	if snapshot.SessionKey == "" || (snapshot.InputTokens == nil && snapshot.OutputTokens == nil && snapshot.TotalTokens == nil) {
+		return nil
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	var tenant, runID, workspace, factory, workflow string
+	if err = tx.QueryRow(`SELECT tr.tenant_id,tr.id,tr.workspace_name,tr.factory_name,tr.workflow_name FROM claws c JOIN task_runs tr ON tr.id=c.task_run_id WHERE c.id=?`, clawID).Scan(&tenant, &runID, &workspace, &factory, &workflow); err != nil {
+		if err == sql.ErrNoRows {
+			return nil
+		}
+		return err
+	}
+	var oldIn, oldOut, oldTotal int
+	var oldCost sql.NullFloat64
+	err = tx.QueryRow(`SELECT input_tokens,output_tokens,total_tokens,estimated_cost_usd FROM task_run_usage WHERE tenant_id=? AND run_id=? AND session_key=?`, tenant, runID, snapshot.SessionKey).Scan(&oldIn, &oldOut, &oldTotal, &oldCost)
+	if err != nil && err != sql.ErrNoRows {
+		return err
+	}
+	in, out, total := oldIn, oldOut, oldTotal
+	if snapshot.InputTokens != nil {
+		in = *snapshot.InputTokens
+	}
+	if snapshot.OutputTokens != nil {
+		out = *snapshot.OutputTokens
+	}
+	if snapshot.TotalTokens != nil {
+		total = *snapshot.TotalTokens
+	}
+	cost := oldCost
+	if snapshot.EstimatedCostUSD != nil {
+		cost = sql.NullFloat64{Float64: *snapshot.EstimatedCostUSD, Valid: true}
+	}
+	delta := func(n, old int) int {
+		if n < old {
+			return n
+		}
+		return n - old
+	}
+	din, dout, dtotal := delta(in, oldIn), delta(out, oldOut), delta(total, oldTotal)
+	dcost := 0.0
+	if cost.Valid {
+		if !oldCost.Valid || cost.Float64 < oldCost.Float64 {
+			dcost = cost.Float64
+		} else {
+			dcost = cost.Float64 - oldCost.Float64
+		}
+	}
+	source := "gateway"
+	if !cost.Valid {
+		if estimated, ok := taskRunPrice(tx, snapshot.Model, din, dout); ok {
+			dcost = estimated
+			cost = sql.NullFloat64{Float64: estimated + oldCost.Float64, Valid: true}
+			source = "hub_pricing"
+		}
+	}
+	ts := now().UnixMilli()
+	_, err = tx.Exec(`INSERT INTO task_run_usage(id,tenant_id,run_id,session_key,model,input_tokens,output_tokens,total_tokens,estimated_cost_usd,cost_source,first_seen_at,updated_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?) ON CONFLICT(tenant_id,run_id,session_key) DO UPDATE SET model=excluded.model,input_tokens=excluded.input_tokens,output_tokens=excluded.output_tokens,total_tokens=excluded.total_tokens,estimated_cost_usd=excluded.estimated_cost_usd,cost_source=excluded.cost_source,updated_at=excluded.updated_at`, uuid.NewString(), tenant, runID, snapshot.SessionKey, snapshot.Model, in, out, total, nullFloat(cost), source, ts, ts)
+	if err != nil {
+		return err
+	}
+	day := time.Now().UTC().Format("2006-01-02")
+	_, err = tx.Exec(`INSERT INTO usage_daily(tenant_id,day,workspace_name,factory_name,workflow_name,model,input_tokens,output_tokens,total_tokens,cost_usd,updated_at) VALUES(?,?,?,?,?,?,?,?,?,?,?) ON CONFLICT(tenant_id,day,workspace_name,factory_name,workflow_name,model) DO UPDATE SET input_tokens=input_tokens+excluded.input_tokens,output_tokens=output_tokens+excluded.output_tokens,total_tokens=total_tokens+excluded.total_tokens,cost_usd=cost_usd+excluded.cost_usd,updated_at=excluded.updated_at`, tenant, day, workspace, factory, workflow, snapshot.Model, din, dout, dtotal, dcost, ts)
+	if err != nil {
+		return err
+	}
+	_, err = tx.Exec(`UPDATE task_run_summaries SET input_tokens=(SELECT COALESCE(SUM(input_tokens),0) FROM task_run_usage WHERE run_id=?),output_tokens=(SELECT COALESCE(SUM(output_tokens),0) FROM task_run_usage WHERE run_id=?),total_tokens=(SELECT COALESCE(SUM(total_tokens),0) FROM task_run_usage WHERE run_id=?),estimated_cost_usd=(SELECT COALESCE(SUM(estimated_cost_usd),0) FROM task_run_usage WHERE run_id=?),usage_updated_at=? WHERE run_id=?`, runID, runID, runID, runID, ts, runID)
+	if err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func nullFloat(v sql.NullFloat64) interface{} {
+	if v.Valid {
+		return v.Float64
+	}
+	return nil
+}
+func taskRunPrice(tx *sql.Tx, model string, in, out int) (float64, bool) {
+	var ip, op float64
+	err := tx.QueryRow(`SELECT input_cost_per_token,output_cost_per_token FROM model_prices WHERE ? LIKE model || '%' OR model LIKE ? || '%' ORDER BY length(model) DESC LIMIT 1`, strings.ToLower(model), strings.ToLower(model)).Scan(&ip, &op)
+	if err != nil {
+		return 0, false
+	}
+	return float64(in)*ip + float64(out)*op, true
+}

--- a/pkg/hub/task_run_usage.go
+++ b/pkg/hub/task_run_usage.go
@@ -13,6 +13,7 @@ type taskRunUsageSnapshot struct {
 	InputTokens, OutputTokens, TotalTokens *int
 	EstimatedCostUSD                       *float64
 	Model                                  string
+	ModelProvider                          string
 }
 
 func (s *Server) recordTaskRunUsage(clawID string, snapshot taskRunUsageSnapshot) error {
@@ -25,7 +26,7 @@ func (s *Server) recordTaskRunUsage(clawID string, snapshot taskRunUsageSnapshot
 	}
 	defer tx.Rollback()
 	var tenant, runID, workspace, factory, workflow string
-	if err = tx.QueryRow(`SELECT tr.tenant_id,tr.id,tr.workspace_name,tr.factory_name,tr.workflow_name FROM claws c JOIN task_runs tr ON tr.id=c.task_run_id WHERE c.id=?`, clawID).Scan(&tenant, &runID, &workspace, &factory, &workflow); err != nil {
+	if err = tx.QueryRow(`SELECT tr.tenant_id,tr.id,tr.workspace_name,tr.factory_name,tr.workflow_name FROM claws c JOIN task_runs tr ON tr.id=c.task_run_id AND tr.tenant_id=c.tenant_id WHERE c.id=?`, clawID).Scan(&tenant, &runID, &workspace, &factory, &workflow); err != nil {
 		if err == sql.ErrNoRows {
 			return nil
 		}
@@ -33,7 +34,8 @@ func (s *Server) recordTaskRunUsage(clawID string, snapshot taskRunUsageSnapshot
 	}
 	var oldIn, oldOut, oldTotal int
 	var oldCost sql.NullFloat64
-	err = tx.QueryRow(`SELECT input_tokens,output_tokens,total_tokens,estimated_cost_usd FROM task_run_usage WHERE tenant_id=? AND run_id=? AND session_key=?`, tenant, runID, snapshot.SessionKey).Scan(&oldIn, &oldOut, &oldTotal, &oldCost)
+	oldSource := "gateway"
+	err = tx.QueryRow(`SELECT input_tokens,output_tokens,total_tokens,estimated_cost_usd,cost_source FROM task_run_usage WHERE tenant_id=? AND run_id=? AND session_key=?`, tenant, runID, snapshot.SessionKey).Scan(&oldIn, &oldOut, &oldTotal, &oldCost, &oldSource)
 	if err != nil && err != sql.ErrNoRows {
 		return err
 	}
@@ -47,35 +49,37 @@ func (s *Server) recordTaskRunUsage(clawID string, snapshot taskRunUsageSnapshot
 	if snapshot.TotalTokens != nil {
 		total = *snapshot.TotalTokens
 	}
-	cost := oldCost
+	// A drop in any cumulative counter means the gateway reset the session
+	// stats; treat the whole snapshot as a fresh baseline.
+	reset := in < oldIn || out < oldOut || total < oldTotal
+	din, dout, dtotal := in-oldIn, out-oldOut, total-oldTotal
+	if reset {
+		din, dout, dtotal = in, out, total
+	}
+	var cost sql.NullFloat64
+	source := oldSource
 	if snapshot.EstimatedCostUSD != nil {
 		cost = sql.NullFloat64{Float64: *snapshot.EstimatedCostUSD, Valid: true}
+		source = "gateway"
+	} else if estimated, ok := taskRunPrice(tx, snapshot.Model, in, out); ok {
+		// The gateway did not report a cost (older gateway / empty pricing
+		// cache); estimate the cumulative cost from the cumulative tokens so
+		// the estimate keeps growing across heartbeats.
+		cost = sql.NullFloat64{Float64: estimated, Valid: true}
+		source = "hub_pricing"
 	}
-	delta := func(n, old int) int {
-		if n < old {
-			return n
-		}
-		return n - old
-	}
-	din, dout, dtotal := delta(in, oldIn), delta(out, oldOut), delta(total, oldTotal)
 	dcost := 0.0
 	if cost.Valid {
-		if !oldCost.Valid || cost.Float64 < oldCost.Float64 {
+		if reset || !oldCost.Valid || cost.Float64 < oldCost.Float64 {
 			dcost = cost.Float64
 		} else {
 			dcost = cost.Float64 - oldCost.Float64
 		}
-	}
-	source := "gateway"
-	if !cost.Valid {
-		if estimated, ok := taskRunPrice(tx, snapshot.Model, din, dout); ok {
-			dcost = estimated
-			cost = sql.NullFloat64{Float64: estimated + oldCost.Float64, Valid: true}
-			source = "hub_pricing"
-		}
+	} else {
+		cost = oldCost
 	}
 	ts := now().UnixMilli()
-	_, err = tx.Exec(`INSERT INTO task_run_usage(id,tenant_id,run_id,session_key,model,input_tokens,output_tokens,total_tokens,estimated_cost_usd,cost_source,first_seen_at,updated_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?) ON CONFLICT(tenant_id,run_id,session_key) DO UPDATE SET model=excluded.model,input_tokens=excluded.input_tokens,output_tokens=excluded.output_tokens,total_tokens=excluded.total_tokens,estimated_cost_usd=excluded.estimated_cost_usd,cost_source=excluded.cost_source,updated_at=excluded.updated_at`, uuid.NewString(), tenant, runID, snapshot.SessionKey, snapshot.Model, in, out, total, nullFloat(cost), source, ts, ts)
+	_, err = tx.Exec(`INSERT INTO task_run_usage(id,tenant_id,run_id,session_key,model,model_provider,input_tokens,output_tokens,total_tokens,estimated_cost_usd,cost_source,first_seen_at,updated_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?) ON CONFLICT(tenant_id,run_id,session_key) DO UPDATE SET model=excluded.model,model_provider=excluded.model_provider,input_tokens=excluded.input_tokens,output_tokens=excluded.output_tokens,total_tokens=excluded.total_tokens,estimated_cost_usd=excluded.estimated_cost_usd,cost_source=excluded.cost_source,updated_at=excluded.updated_at`, uuid.NewString(), tenant, runID, snapshot.SessionKey, snapshot.Model, snapshot.ModelProvider, in, out, total, nullFloat(cost), source, ts, ts)
 	if err != nil {
 		return err
 	}
@@ -84,7 +88,7 @@ func (s *Server) recordTaskRunUsage(clawID string, snapshot taskRunUsageSnapshot
 	if err != nil {
 		return err
 	}
-	_, err = tx.Exec(`UPDATE task_run_summaries SET input_tokens=(SELECT COALESCE(SUM(input_tokens),0) FROM task_run_usage WHERE run_id=?),output_tokens=(SELECT COALESCE(SUM(output_tokens),0) FROM task_run_usage WHERE run_id=?),total_tokens=(SELECT COALESCE(SUM(total_tokens),0) FROM task_run_usage WHERE run_id=?),estimated_cost_usd=(SELECT COALESCE(SUM(estimated_cost_usd),0) FROM task_run_usage WHERE run_id=?),usage_updated_at=? WHERE run_id=?`, runID, runID, runID, runID, ts, runID)
+	_, err = tx.Exec(`UPDATE task_run_summaries SET input_tokens=(SELECT COALESCE(SUM(input_tokens),0) FROM task_run_usage WHERE tenant_id=? AND run_id=?),output_tokens=(SELECT COALESCE(SUM(output_tokens),0) FROM task_run_usage WHERE tenant_id=? AND run_id=?),total_tokens=(SELECT COALESCE(SUM(total_tokens),0) FROM task_run_usage WHERE tenant_id=? AND run_id=?),estimated_cost_usd=(SELECT COALESCE(SUM(estimated_cost_usd),0) FROM task_run_usage WHERE tenant_id=? AND run_id=?),usage_updated_at=? WHERE tenant_id=? AND run_id=?`, tenant, runID, tenant, runID, tenant, runID, tenant, runID, ts, tenant, runID)
 	if err != nil {
 		return err
 	}
@@ -97,9 +101,21 @@ func nullFloat(v sql.NullFloat64) interface{} {
 	}
 	return nil
 }
+
+// taskRunPrice estimates the cumulative cost of a session from cumulative
+// token counts using the seeded model_prices table. Gateway model ids are
+// matched loosely: lowercased, provider prefixes stripped, and the longest
+// seeded model name that prefixes the id wins.
 func taskRunPrice(tx *sql.Tx, model string, in, out int) (float64, bool) {
+	model = strings.ToLower(strings.TrimSpace(model))
+	if i := strings.LastIndex(model, "/"); i >= 0 {
+		model = model[i+1:]
+	}
+	if model == "" {
+		return 0, false
+	}
 	var ip, op float64
-	err := tx.QueryRow(`SELECT input_cost_per_token,output_cost_per_token FROM model_prices WHERE ? LIKE model || '%' OR model LIKE ? || '%' ORDER BY length(model) DESC LIMIT 1`, strings.ToLower(model), strings.ToLower(model)).Scan(&ip, &op)
+	err := tx.QueryRow(`SELECT input_cost_per_token,output_cost_per_token FROM model_prices WHERE ? LIKE model || '%' ORDER BY length(model) DESC LIMIT 1`, model).Scan(&ip, &op)
 	if err != nil {
 		return 0, false
 	}

--- a/pkg/hub/task_run_usage.go
+++ b/pkg/hub/task_run_usage.go
@@ -79,9 +79,13 @@ func (s *Server) recordTaskRunUsage(clawID string, snapshot taskRunUsageSnapshot
 	}
 	dcost := 0.0
 	if cost.Valid {
-		if reset || !oldCost.Valid || cost.Float64 < oldCost.Float64 {
+		if reset || !oldCost.Valid {
 			dcost = cost.Float64
 		} else {
+			// Signed delta: when a real (lower) gateway cost replaces a prior
+			// hub_pricing estimate the negative correction converges
+			// usage_daily to the true cumulative cost. Cost resets only
+			// happen together with token resets, which the reset flag covers.
 			dcost = cost.Float64 - oldCost.Float64
 		}
 	} else {

--- a/pkg/hub/task_run_usage.go
+++ b/pkg/hub/task_run_usage.go
@@ -3,7 +3,6 @@ package hub
 import (
 	"database/sql"
 	"strings"
-	"time"
 
 	"github.com/google/uuid"
 )
@@ -32,10 +31,11 @@ func (s *Server) recordTaskRunUsage(clawID string, snapshot taskRunUsageSnapshot
 		}
 		return err
 	}
-	var oldIn, oldOut, oldTotal int
+	var oldIn, oldOut, oldTotal, comIn, comOut, comTotal int
 	var oldCost sql.NullFloat64
+	var comCost float64
 	oldSource := "gateway"
-	err = tx.QueryRow(`SELECT input_tokens,output_tokens,total_tokens,estimated_cost_usd,cost_source FROM task_run_usage WHERE tenant_id=? AND run_id=? AND session_key=?`, tenant, runID, snapshot.SessionKey).Scan(&oldIn, &oldOut, &oldTotal, &oldCost, &oldSource)
+	err = tx.QueryRow(`SELECT input_tokens,output_tokens,total_tokens,committed_input_tokens,committed_output_tokens,committed_total_tokens,committed_cost_usd,estimated_cost_usd,cost_source FROM task_run_usage WHERE tenant_id=? AND run_id=? AND session_key=?`, tenant, runID, snapshot.SessionKey).Scan(&oldIn, &oldOut, &oldTotal, &comIn, &comOut, &comTotal, &comCost, &oldCost, &oldSource)
 	if err != nil && err != sql.ErrNoRows {
 		return err
 	}
@@ -50,11 +50,20 @@ func (s *Server) recordTaskRunUsage(clawID string, snapshot taskRunUsageSnapshot
 		total = *snapshot.TotalTokens
 	}
 	// A drop in any cumulative counter means the gateway reset the session
-	// stats; treat the whole snapshot as a fresh baseline.
+	// stats; treat the whole snapshot as a fresh baseline and fold the
+	// pre-reset totals into the committed_* columns so run summaries keep
+	// counting them.
 	reset := in < oldIn || out < oldOut || total < oldTotal
 	din, dout, dtotal := in-oldIn, out-oldOut, total-oldTotal
 	if reset {
 		din, dout, dtotal = in, out, total
+		comIn += oldIn
+		comOut += oldOut
+		comTotal += oldTotal
+		if oldCost.Valid {
+			comCost += oldCost.Float64
+			oldCost = sql.NullFloat64{}
+		}
 	}
 	var cost sql.NullFloat64
 	source := oldSource
@@ -79,16 +88,16 @@ func (s *Server) recordTaskRunUsage(clawID string, snapshot taskRunUsageSnapshot
 		cost = oldCost
 	}
 	ts := now().UnixMilli()
-	_, err = tx.Exec(`INSERT INTO task_run_usage(id,tenant_id,run_id,session_key,model,model_provider,input_tokens,output_tokens,total_tokens,estimated_cost_usd,cost_source,first_seen_at,updated_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?) ON CONFLICT(tenant_id,run_id,session_key) DO UPDATE SET model=excluded.model,model_provider=excluded.model_provider,input_tokens=excluded.input_tokens,output_tokens=excluded.output_tokens,total_tokens=excluded.total_tokens,estimated_cost_usd=excluded.estimated_cost_usd,cost_source=excluded.cost_source,updated_at=excluded.updated_at`, uuid.NewString(), tenant, runID, snapshot.SessionKey, snapshot.Model, snapshot.ModelProvider, in, out, total, nullFloat(cost), source, ts, ts)
+	_, err = tx.Exec(`INSERT INTO task_run_usage(id,tenant_id,run_id,session_key,model,model_provider,input_tokens,output_tokens,total_tokens,committed_input_tokens,committed_output_tokens,committed_total_tokens,committed_cost_usd,estimated_cost_usd,cost_source,first_seen_at,updated_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?) ON CONFLICT(tenant_id,run_id,session_key) DO UPDATE SET model=excluded.model,model_provider=excluded.model_provider,input_tokens=excluded.input_tokens,output_tokens=excluded.output_tokens,total_tokens=excluded.total_tokens,committed_input_tokens=excluded.committed_input_tokens,committed_output_tokens=excluded.committed_output_tokens,committed_total_tokens=excluded.committed_total_tokens,committed_cost_usd=excluded.committed_cost_usd,estimated_cost_usd=excluded.estimated_cost_usd,cost_source=excluded.cost_source,updated_at=excluded.updated_at`, uuid.NewString(), tenant, runID, snapshot.SessionKey, snapshot.Model, snapshot.ModelProvider, in, out, total, comIn, comOut, comTotal, comCost, nullFloat(cost), source, ts, ts)
 	if err != nil {
 		return err
 	}
-	day := time.Now().UTC().Format("2006-01-02")
+	day := now().UTC().Format("2006-01-02")
 	_, err = tx.Exec(`INSERT INTO usage_daily(tenant_id,day,workspace_name,factory_name,workflow_name,model,input_tokens,output_tokens,total_tokens,cost_usd,updated_at) VALUES(?,?,?,?,?,?,?,?,?,?,?) ON CONFLICT(tenant_id,day,workspace_name,factory_name,workflow_name,model) DO UPDATE SET input_tokens=input_tokens+excluded.input_tokens,output_tokens=output_tokens+excluded.output_tokens,total_tokens=total_tokens+excluded.total_tokens,cost_usd=cost_usd+excluded.cost_usd,updated_at=excluded.updated_at`, tenant, day, workspace, factory, workflow, snapshot.Model, din, dout, dtotal, dcost, ts)
 	if err != nil {
 		return err
 	}
-	_, err = tx.Exec(`UPDATE task_run_summaries SET input_tokens=(SELECT COALESCE(SUM(input_tokens),0) FROM task_run_usage WHERE tenant_id=? AND run_id=?),output_tokens=(SELECT COALESCE(SUM(output_tokens),0) FROM task_run_usage WHERE tenant_id=? AND run_id=?),total_tokens=(SELECT COALESCE(SUM(total_tokens),0) FROM task_run_usage WHERE tenant_id=? AND run_id=?),estimated_cost_usd=(SELECT COALESCE(SUM(estimated_cost_usd),0) FROM task_run_usage WHERE tenant_id=? AND run_id=?),usage_updated_at=? WHERE tenant_id=? AND run_id=?`, tenant, runID, tenant, runID, tenant, runID, tenant, runID, ts, tenant, runID)
+	_, err = tx.Exec(`UPDATE task_run_summaries SET input_tokens=(SELECT COALESCE(SUM(input_tokens+committed_input_tokens),0) FROM task_run_usage WHERE tenant_id=? AND run_id=?),output_tokens=(SELECT COALESCE(SUM(output_tokens+committed_output_tokens),0) FROM task_run_usage WHERE tenant_id=? AND run_id=?),total_tokens=(SELECT COALESCE(SUM(total_tokens+committed_total_tokens),0) FROM task_run_usage WHERE tenant_id=? AND run_id=?),estimated_cost_usd=(SELECT COALESCE(SUM(COALESCE(estimated_cost_usd,0)+committed_cost_usd),0) FROM task_run_usage WHERE tenant_id=? AND run_id=?),usage_updated_at=? WHERE tenant_id=? AND run_id=?`, tenant, runID, tenant, runID, tenant, runID, tenant, runID, ts, tenant, runID)
 	if err != nil {
 		return err
 	}

--- a/pkg/hub/task_run_usage.go
+++ b/pkg/hub/task_run_usage.go
@@ -96,8 +96,11 @@ func (s *Server) recordTaskRunUsage(clawID string, snapshot taskRunUsageSnapshot
 	if err != nil {
 		return err
 	}
+	// A negative cost correction (gateway cost replacing a higher hub_pricing
+	// estimate) may land on a later day than the estimate it corrects; clamp
+	// the bucket at zero so per-day stats never go negative.
 	day := now().UTC().Format("2006-01-02")
-	_, err = tx.Exec(`INSERT INTO usage_daily(tenant_id,day,workspace_name,factory_name,workflow_name,model,input_tokens,output_tokens,total_tokens,cost_usd,updated_at) VALUES(?,?,?,?,?,?,?,?,?,?,?) ON CONFLICT(tenant_id,day,workspace_name,factory_name,workflow_name,model) DO UPDATE SET input_tokens=input_tokens+excluded.input_tokens,output_tokens=output_tokens+excluded.output_tokens,total_tokens=total_tokens+excluded.total_tokens,cost_usd=cost_usd+excluded.cost_usd,updated_at=excluded.updated_at`, tenant, day, workspace, factory, workflow, snapshot.Model, din, dout, dtotal, dcost, ts)
+	_, err = tx.Exec(`INSERT INTO usage_daily(tenant_id,day,workspace_name,factory_name,workflow_name,model,input_tokens,output_tokens,total_tokens,cost_usd,updated_at) VALUES(?,?,?,?,?,?,?,?,?,MAX(0,?),?) ON CONFLICT(tenant_id,day,workspace_name,factory_name,workflow_name,model) DO UPDATE SET input_tokens=input_tokens+excluded.input_tokens,output_tokens=output_tokens+excluded.output_tokens,total_tokens=total_tokens+excluded.total_tokens,cost_usd=MAX(0,cost_usd+?),updated_at=excluded.updated_at`, tenant, day, workspace, factory, workflow, snapshot.Model, din, dout, dtotal, dcost, ts, dcost)
 	if err != nil {
 		return err
 	}

--- a/pkg/hub/task_run_usage_test.go
+++ b/pkg/hub/task_run_usage_test.go
@@ -169,6 +169,30 @@ func TestTaskRunUsageGatewayCostCorrectsHubEstimate(t *testing.T) {
 	}
 }
 
+func TestTaskRunUsageCrossDayCostCorrectionClampsAtZero(t *testing.T) {
+	s, db, claw := newUsageTestServer(t)
+	defer db.Close()
+	// HB1: hub_pricing estimates $18.
+	if err := s.recordTaskRunUsage(claw, usageSnapshot("a", 1_000_000, 1_000_000, 2_000_000, "claude-sonnet-5")); err != nil {
+		t.Fatal(err)
+	}
+	// Simulate a day rollover: the estimate sits in yesterday's bucket.
+	if _, err := db.Exec(`DELETE FROM usage_daily`); err != nil {
+		t.Fatal(err)
+	}
+	// HB2: gateway reports a lower real cost; the negative correction lands on
+	// a fresh bucket and must clamp at zero instead of seeding a negative cost.
+	snap := usageSnapshot("a", 1_000_000, 1_000_000, 2_000_000, "claude-sonnet-5")
+	snap.EstimatedCostUSD = ptr(3.0)
+	if err := s.recordTaskRunUsage(claw, snap); err != nil {
+		t.Fatal(err)
+	}
+	_, _, _, dailyCost := queryUsageDaily(t, db)
+	if dailyCost != 0 {
+		t.Fatalf("usage_daily cost = %v, want 0 (never negative)", dailyCost)
+	}
+}
+
 func TestTaskRunUsageUnknownModelGetsNoEstimatedCost(t *testing.T) {
 	s, db, claw := newUsageTestServer(t)
 	defer db.Close()

--- a/pkg/hub/task_run_usage_test.go
+++ b/pkg/hub/task_run_usage_test.go
@@ -1,0 +1,73 @@
+package hub
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func newUsageTestServer(t *testing.T) (*Server, *sql.DB, string) {
+	t.Helper()
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "hub.db")+"?_pragma=foreign_keys(on)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := migrate(db); err != nil {
+		t.Fatal(err)
+	}
+	// The production migration enables foreign keys; this minimal fixture does
+	// not need the attempt row referenced by task_runs.
+	if _, err := db.Exec(`PRAGMA foreign_keys=OFF`); err != nil {
+		t.Fatal(err)
+	}
+	clawID, runID := "claw-usage", "run-usage"
+	if _, err := db.Exec(`INSERT INTO task_runs(id,tenant_id,initial_attempt_id,run_kind,owner_type,claw_id,created_at,updated_at) VALUES(?,?,?,?,?,?,?,?)`, runID, "tenant", uuid.NewString(), "code_task", "manual", clawID, 0, 0); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO claws(id,tenant_id,name,template,status,task_run_id,created_at) VALUES(?,?,?,?,?,?,?)`, clawID, "tenant", "claw", "base", "connected", runID, now()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO task_run_summaries(id,tenant_id,run_id,status,phase,started_at,last_event_at,materialized_at,updated_at) VALUES(?,?,?,?,?,?,?,?,?)`, uuid.NewString(), "tenant", runID, "running", "claimed", 0, 0, 0, 0); err != nil {
+		t.Fatal(err)
+	}
+	return &Server{db: db}, db, clawID
+}
+
+func ptr[T any](v T) *T { return &v }
+
+func TestTaskRunUsageSnapshotsAndReset(t *testing.T) {
+	s, db, claw := newUsageTestServer(t)
+	defer db.Close()
+	if err := s.recordTaskRunUsage(claw, taskRunUsageSnapshot{SessionKey: "a", InputTokens: ptr(10), OutputTokens: ptr(5), TotalTokens: ptr(15), Model: "claude-sonnet-5"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.recordTaskRunUsage(claw, taskRunUsageSnapshot{SessionKey: "a", InputTokens: ptr(10), OutputTokens: ptr(5), TotalTokens: ptr(15), Model: "claude-sonnet-5"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.recordTaskRunUsage(claw, taskRunUsageSnapshot{SessionKey: "b", InputTokens: ptr(3), OutputTokens: ptr(2), TotalTokens: ptr(5), Model: "claude-sonnet-5"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.recordTaskRunUsage(claw, taskRunUsageSnapshot{SessionKey: "a", InputTokens: ptr(2), OutputTokens: ptr(1), TotalTokens: ptr(3), Model: "claude-sonnet-5"}); err != nil {
+		t.Fatal(err)
+	}
+	var in, out, total int
+	var cost float64
+	if err := db.QueryRow(`SELECT input_tokens,output_tokens,total_tokens,estimated_cost_usd FROM task_run_summaries WHERE run_id='run-usage'`).Scan(&in, &out, &total, &cost); err != nil {
+		t.Fatal(err)
+	}
+	if in != 5 || out != 3 || total != 8 {
+		t.Fatalf("summary = %d/%d/%d, want 5/3/8", in, out, total)
+	}
+	if cost <= 0 {
+		t.Fatalf("expected pricing fallback cost, got %v", cost)
+	}
+	var rows int
+	if err := db.QueryRow(`SELECT count(*) FROM task_run_usage`).Scan(&rows); err != nil {
+		t.Fatal(err)
+	}
+	if rows != 2 {
+		t.Fatalf("usage rows=%d, want 2", rows)
+	}
+}

--- a/pkg/hub/task_run_usage_test.go
+++ b/pkg/hub/task_run_usage_test.go
@@ -1,11 +1,15 @@
 package hub
 
 import (
+	"context"
 	"database/sql"
 	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/elasticclaw/elasticclaw/pkg/types"
 	"github.com/google/uuid"
+	"nhooyr.io/websocket/wsjson"
 )
 
 func newUsageTestServer(t *testing.T) (*Server, *sql.DB, string) {
@@ -37,20 +41,31 @@ func newUsageTestServer(t *testing.T) (*Server, *sql.DB, string) {
 
 func ptr[T any](v T) *T { return &v }
 
+func usageSnapshot(session string, in, out, total int, model string) taskRunUsageSnapshot {
+	return taskRunUsageSnapshot{SessionKey: session, InputTokens: ptr(in), OutputTokens: ptr(out), TotalTokens: ptr(total), Model: model}
+}
+
+func queryUsageDaily(t *testing.T, db *sql.DB) (in, out, total int, cost float64) {
+	t.Helper()
+	day := time.Now().UTC().Format("2006-01-02")
+	if err := db.QueryRow(`SELECT input_tokens,output_tokens,total_tokens,cost_usd FROM usage_daily WHERE tenant_id='tenant' AND day=?`, day).Scan(&in, &out, &total, &cost); err != nil {
+		t.Fatal(err)
+	}
+	return
+}
+
 func TestTaskRunUsageSnapshotsAndReset(t *testing.T) {
 	s, db, claw := newUsageTestServer(t)
 	defer db.Close()
-	if err := s.recordTaskRunUsage(claw, taskRunUsageSnapshot{SessionKey: "a", InputTokens: ptr(10), OutputTokens: ptr(5), TotalTokens: ptr(15), Model: "claude-sonnet-5"}); err != nil {
-		t.Fatal(err)
-	}
-	if err := s.recordTaskRunUsage(claw, taskRunUsageSnapshot{SessionKey: "a", InputTokens: ptr(10), OutputTokens: ptr(5), TotalTokens: ptr(15), Model: "claude-sonnet-5"}); err != nil {
-		t.Fatal(err)
-	}
-	if err := s.recordTaskRunUsage(claw, taskRunUsageSnapshot{SessionKey: "b", InputTokens: ptr(3), OutputTokens: ptr(2), TotalTokens: ptr(5), Model: "claude-sonnet-5"}); err != nil {
-		t.Fatal(err)
-	}
-	if err := s.recordTaskRunUsage(claw, taskRunUsageSnapshot{SessionKey: "a", InputTokens: ptr(2), OutputTokens: ptr(1), TotalTokens: ptr(3), Model: "claude-sonnet-5"}); err != nil {
-		t.Fatal(err)
+	for _, snap := range []taskRunUsageSnapshot{
+		usageSnapshot("a", 10, 5, 15, "claude-sonnet-5"),
+		usageSnapshot("a", 10, 5, 15, "claude-sonnet-5"), // idempotent re-delivery: no delta
+		usageSnapshot("b", 3, 2, 5, "claude-sonnet-5"),
+		usageSnapshot("a", 2, 1, 3, "claude-sonnet-5"), // gateway reset: new values become the delta
+	} {
+		if err := s.recordTaskRunUsage(claw, snap); err != nil {
+			t.Fatal(err)
+		}
 	}
 	var in, out, total int
 	var cost float64
@@ -70,4 +85,108 @@ func TestTaskRunUsageSnapshotsAndReset(t *testing.T) {
 	if rows != 2 {
 		t.Fatalf("usage rows=%d, want 2", rows)
 	}
+	// usage_daily accumulates deltas: 10/5/15 + 0 (idempotent) + 3/2/5 + 2/1/3 (reset).
+	din, dout, dtotal, _ := queryUsageDaily(t, db)
+	if din != 15 || dout != 8 || dtotal != 23 {
+		t.Fatalf("usage_daily = %d/%d/%d, want 15/8/23", din, dout, dtotal)
+	}
+}
+
+func TestTaskRunUsagePartialResetTreatedAsFullReset(t *testing.T) {
+	s, db, claw := newUsageTestServer(t)
+	defer db.Close()
+	if err := s.recordTaskRunUsage(claw, usageSnapshot("a", 10, 5, 15, "claude-sonnet-5")); err != nil {
+		t.Fatal(err)
+	}
+	// input drops (reset) but output is higher than before: the whole snapshot
+	// must be treated as a fresh baseline, not mixed per-field deltas.
+	if err := s.recordTaskRunUsage(claw, usageSnapshot("a", 4, 9, 13, "claude-sonnet-5")); err != nil {
+		t.Fatal(err)
+	}
+	din, dout, dtotal, _ := queryUsageDaily(t, db)
+	if din != 14 || dout != 14 || dtotal != 28 {
+		t.Fatalf("usage_daily = %d/%d/%d, want 14/14/28", din, dout, dtotal)
+	}
+}
+
+func TestTaskRunUsagePricingFallbackKeepsGrowing(t *testing.T) {
+	s, db, claw := newUsageTestServer(t)
+	defer db.Close()
+	// Provider-qualified gateway model id must still match the seeded price.
+	const model = "anthropic/claude-sonnet-5-20260203"
+	if err := s.recordTaskRunUsage(claw, usageSnapshot("a", 1_000_000, 1_000_000, 2_000_000, model)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.recordTaskRunUsage(claw, usageSnapshot("a", 2_000_000, 2_000_000, 4_000_000, model)); err != nil {
+		t.Fatal(err)
+	}
+	var cost float64
+	var source string
+	if err := db.QueryRow(`SELECT estimated_cost_usd,cost_source FROM task_run_usage WHERE session_key='a'`).Scan(&cost, &source); err != nil {
+		t.Fatal(err)
+	}
+	// claude-sonnet-5 is $3/$15 per MTok: 2 MTok in + 2 MTok out = $36.
+	if cost < 35.99 || cost > 36.01 {
+		t.Fatalf("cumulative estimated cost = %v, want ~36 (estimate must keep growing)", cost)
+	}
+	if source != "hub_pricing" {
+		t.Fatalf("cost_source = %q, want hub_pricing", source)
+	}
+	_, _, _, dailyCost := queryUsageDaily(t, db)
+	if dailyCost < 35.99 || dailyCost > 36.01 {
+		t.Fatalf("usage_daily cost = %v, want ~36", dailyCost)
+	}
+}
+
+func TestTaskRunUsageUnknownModelGetsNoEstimatedCost(t *testing.T) {
+	s, db, claw := newUsageTestServer(t)
+	defer db.Close()
+	for _, model := range []string{"", "gpt-9-mega"} {
+		if err := s.recordTaskRunUsage(claw, usageSnapshot("sess-"+model, 10, 5, 15, model)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var withCost int
+	if err := db.QueryRow(`SELECT count(*) FROM task_run_usage WHERE estimated_cost_usd IS NOT NULL`).Scan(&withCost); err != nil {
+		t.Fatal(err)
+	}
+	if withCost != 0 {
+		t.Fatalf("unknown/missing models must not be priced, got %d costed rows", withCost)
+	}
+}
+
+func TestHeartbeatIngestsTaskRunUsage(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	const clawID = "usage-heartbeat"
+	conn := watchdogClaw(t, s, clawID)
+	runID, _, err := s.ensureTaskRunForClaw(clawID, TaskRunStart{RunKind: taskRunKindPRTask, OwnerType: taskRunOwnerFactory, AnalyticsEnabled: true, Tags: []string{}})
+	if err != nil {
+		t.Fatalf("create task run: %v", err)
+	}
+	if err := wsjson.Write(context.Background(), conn, types.WSMessage{Type: "heartbeat", Payload: map[string]any{
+		"gateway_healthy": true, "session_key": "sess-1",
+		"input_tokens": 100, "output_tokens": 40, "total_tokens": 140,
+		"estimated_cost_usd": 0.05, "model": "claude-sonnet-5", "model_provider": "anthropic",
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	eventuallyWatchdog(t, func() bool {
+		var n int
+		_ = db.QueryRow(`SELECT count(*) FROM task_run_usage WHERE run_id=? AND session_key='sess-1'`, runID).Scan(&n)
+		return n == 1
+	}, "usage row ingested from heartbeat")
+	var in, out, total int
+	var cost float64
+	var model, provider, source string
+	if err := db.QueryRow(`SELECT input_tokens,output_tokens,total_tokens,estimated_cost_usd,model,model_provider,cost_source FROM task_run_usage WHERE run_id=?`, runID).Scan(&in, &out, &total, &cost, &model, &provider, &source); err != nil {
+		t.Fatal(err)
+	}
+	if in != 100 || out != 40 || total != 140 || cost != 0.05 || model != "claude-sonnet-5" || provider != "anthropic" || source != "gateway" {
+		t.Fatalf("unexpected usage row: %d/%d/%d cost=%v model=%q provider=%q source=%q", in, out, total, cost, model, provider, source)
+	}
+	eventuallyWatchdog(t, func() bool {
+		var sumTotal int
+		_ = db.QueryRow(`SELECT total_tokens FROM task_run_summaries WHERE run_id=?`, runID).Scan(&sumTotal)
+		return sumTotal == 140
+	}, "summary usage columns updated")
 }

--- a/pkg/hub/task_run_usage_test.go
+++ b/pkg/hub/task_run_usage_test.go
@@ -72,8 +72,10 @@ func TestTaskRunUsageSnapshotsAndReset(t *testing.T) {
 	if err := db.QueryRow(`SELECT input_tokens,output_tokens,total_tokens,estimated_cost_usd FROM task_run_summaries WHERE run_id='run-usage'`).Scan(&in, &out, &total, &cost); err != nil {
 		t.Fatal(err)
 	}
-	if in != 5 || out != 3 || total != 8 {
-		t.Fatalf("summary = %d/%d/%d, want 5/3/8", in, out, total)
+	// Summary keeps pre-reset usage: session a = 10/5/15 committed + 2/1/3
+	// current, session b = 3/2/5.
+	if in != 15 || out != 8 || total != 23 {
+		t.Fatalf("summary = %d/%d/%d, want 15/8/23", in, out, total)
 	}
 	if cost <= 0 {
 		t.Fatalf("expected pricing fallback cost, got %v", cost)

--- a/pkg/hub/task_run_usage_test.go
+++ b/pkg/hub/task_run_usage_test.go
@@ -140,6 +140,35 @@ func TestTaskRunUsagePricingFallbackKeepsGrowing(t *testing.T) {
 	}
 }
 
+func TestTaskRunUsageGatewayCostCorrectsHubEstimate(t *testing.T) {
+	s, db, claw := newUsageTestServer(t)
+	defer db.Close()
+	// HB1: gateway omits cost, hub_pricing estimates $18 (1 MTok in + 1 MTok
+	// out on claude-sonnet-5).
+	if err := s.recordTaskRunUsage(claw, usageSnapshot("a", 1_000_000, 1_000_000, 2_000_000, "claude-sonnet-5")); err != nil {
+		t.Fatal(err)
+	}
+	// HB2: gateway reports the real cumulative cost, lower than the estimate
+	// (cache discounts). usage_daily must converge to it, not add it on top.
+	snap := usageSnapshot("a", 1_100_000, 1_100_000, 2_200_000, "claude-sonnet-5")
+	snap.EstimatedCostUSD = ptr(3.0)
+	if err := s.recordTaskRunUsage(claw, snap); err != nil {
+		t.Fatal(err)
+	}
+	_, _, _, dailyCost := queryUsageDaily(t, db)
+	if dailyCost < 2.99 || dailyCost > 3.01 {
+		t.Fatalf("usage_daily cost = %v, want ~3 (negative correction must apply)", dailyCost)
+	}
+	var cost float64
+	var source string
+	if err := db.QueryRow(`SELECT estimated_cost_usd,cost_source FROM task_run_usage WHERE session_key='a'`).Scan(&cost, &source); err != nil {
+		t.Fatal(err)
+	}
+	if cost != 3.0 || source != "gateway" {
+		t.Fatalf("snapshot cost=%v source=%q, want 3.0/gateway", cost, source)
+	}
+}
+
 func TestTaskRunUsageUnknownModelGetsNoEstimatedCost(t *testing.T) {
 	s, db, claw := newUsageTestServer(t)
 	defer db.Close()


### PR DESCRIPTION
## What

Captures per-session token usage and cost from the OpenClaw gateway and persists it in the hub, laying the data foundation for Factory Stats v2 (agents cost tracking and monthly estimate).

- **Bridge**: `refreshContextUsage` now also parses `inputTokens`, `outputTokens`, `estimatedCostUsd`, `model`, `modelProvider` from `sessions.describe` and reports them (plus `session_key`) on every heartbeat. `estimated_cost_usd` is a pointer so absence is distinguishable from 0; all fields tolerate older gateways.
- **Hub schema**: new `task_run_usage` (cumulative snapshot per gateway session, `UNIQUE(tenant_id, run_id, session_key)`), `usage_daily` (per-day delta rollup keyed by tenant/day/workspace/factory/workflow/model), and `model_prices` (statically seeded, no network). `task_run_summaries` gains usage columns; `task_runs`/`task_run_summaries` gain `issue_title`, persisted at claw creation for Linear/Jira/Shortcut/GitHub and flowed through the materializer.
- **Ingestion**: heartbeat handler resolves claw → run + tenant, upserts the snapshot, computes per-heartbeat deltas (a negative delta is treated as a gateway reset for the whole snapshot), accumulates into `usage_daily`, falls back to `model_prices` when the gateway omits cost (`cost_source='hub_pricing'`), and rolls totals up into the run summary.

## Why

Run cost/usage today is invisible: the gateway computes it per session but the hub discards everything except context %. With cumulative snapshots + daily deltas stored, PR 2 (`claude/aiedev-1-cost-endpoints`) can serve filterable cost endpoints cheaply.

Part of [AIEDEV-1](https://linear.app/nimble-la/issue/AIEDEV-1)

## Tests

`go build ./... && go test ./pkg/hub ./cmd/claw-bridge -count=1`

```
ok  github.com/elasticclaw/elasticclaw/pkg/hub        17.197s
ok  github.com/elasticclaw/elasticclaw/cmd/claw-bridge 0.870s
```

Covers migration, idempotent snapshot upsert, multi-session summation, negative-delta reset, pricing fallback (including cumulative re-estimation), and the heartbeat handler path.

Implementation by gpt-5.6 (Codex); reviewed by fable-5 and an independent gpt-5.6 pass — all 15 findings addressed in the final commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
