### PR TITLE
feat: authoritative lifecycle timestamps and general stats endpoint

### DIFF
--- a/pkg/hub/analytics.go
+++ b/pkg/hub/analytics.go
@@ -295,6 +295,10 @@ func (s *Server) trackPROpened(factoryName, issueID, clawID, repo string, prNumb
 
 // trackPRMerged logs a PR merge for analytics.
 func (s *Server) trackPRMerged(factoryName, issueID, clawID, repo string, prNumber int) {
+	s.trackPRMergedAt(factoryName, issueID, clawID, repo, prNumber, now())
+}
+
+func (s *Server) trackPRMergedAt(factoryName, issueID, clawID, repo string, prNumber int, occurredAt time.Time) {
 	s.logFactoryAnalytics(factoryName, issueID, clawID, "pr_merged", fmt.Sprintf("%s#%d", repo, prNumber), "success")
 	if err := s.recordTaskRunEventForClaw(clawID, TaskRunEvent{
 		EventKey:        fmt.Sprintf("pr_merged:%s#%d", repo, prNumber),
@@ -305,7 +309,7 @@ func (s *Server) trackPRMerged(factoryName, issueID, clawID, repo string, prNumb
 		TargetType:      "pull_request",
 		TargetID:        fmt.Sprintf("%s#%d", repo, prNumber),
 		Detail:          map[string]any{"repo": repo, "prNumber": prNumber},
-		OccurredAt:      now(),
+		OccurredAt:      occurredAt,
 	}); err != nil {
 		log.Printf("[task-run-analytics] failed to record PR merge for claw %s: %v", clawID, err)
 	}

--- a/pkg/hub/analytics.go
+++ b/pkg/hub/analytics.go
@@ -299,7 +299,11 @@ func (s *Server) trackPRMerged(factoryName, issueID, clawID, repo string, prNumb
 }
 
 func (s *Server) trackPRMergedAt(factoryName, issueID, clawID, repo string, prNumber int, occurredAt time.Time) {
-	s.logFactoryAnalytics(factoryName, issueID, clawID, "pr_merged", fmt.Sprintf("%s#%d", repo, prNumber), "success")
+	// The task-run event is recorded even without pipeline context, but
+	// per-factory analytics rows keyed by an empty factory name are noise.
+	if factoryName != "" {
+		s.logFactoryAnalytics(factoryName, issueID, clawID, "pr_merged", fmt.Sprintf("%s#%d", repo, prNumber), "success")
+	}
 	if err := s.recordTaskRunEventForClaw(clawID, TaskRunEvent{
 		EventKey:        fmt.Sprintf("pr_merged:%s#%d", repo, prNumber),
 		Source:          taskRunSourceGitHub,

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -73,6 +73,8 @@ func migrate(db *sql.DB) error {
 	_, _ = db.Exec(`ALTER TABLE factory_triggers ADD COLUMN task_run_id TEXT NOT NULL DEFAULT ''`)
 	_, _ = db.Exec(`ALTER TABLE factory_triggers ADD COLUMN retry_count INTEGER NOT NULL DEFAULT 0`)
 	_, _ = db.Exec(`ALTER TABLE task_run_attempts ADD COLUMN restored_checkpoint_id TEXT`)
+	_, _ = db.Exec(`ALTER TABLE task_runs ADD COLUMN issue_created_at INTEGER NOT NULL DEFAULT 0`)
+	_, _ = db.Exec(`ALTER TABLE task_run_summaries ADD COLUMN issue_created_at INTEGER NOT NULL DEFAULT 0`)
 
 	_, _ = db.Exec(`CREATE TABLE IF NOT EXISTS claw_checkpoints (
 		id                    TEXT PRIMARY KEY,
@@ -292,6 +294,7 @@ func migrate(db *sql.DB) error {
 		trigger_id            TEXT NOT NULL DEFAULT '',
 		external_trigger_id   TEXT NOT NULL DEFAULT '',
 		issue_id              TEXT NOT NULL DEFAULT '',
+		issue_created_at      INTEGER NOT NULL DEFAULT 0,
 		claw_id               TEXT NOT NULL DEFAULT '',
 		model                 TEXT NOT NULL DEFAULT '',
 		llm_key               TEXT NOT NULL DEFAULT '',
@@ -419,6 +422,7 @@ func migrate(db *sql.DB) error {
 		integration             TEXT NOT NULL DEFAULT '',
 		integration_workspace   TEXT NOT NULL DEFAULT '',
 		issue_id                TEXT NOT NULL DEFAULT '',
+		issue_created_at        INTEGER NOT NULL DEFAULT 0,
 		claw_id                 TEXT NOT NULL DEFAULT '',
 		model                   TEXT NOT NULL DEFAULT '',
 		llm_key                 TEXT NOT NULL DEFAULT '',

--- a/pkg/hub/github_webhook.go
+++ b/pkg/hub/github_webhook.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/elasticclaw/elasticclaw/pkg/config"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
@@ -28,9 +29,12 @@ type githubPRPayload struct {
 		Type  string `json:"type"` // "Bot", "User", "Organization"
 	} `json:"sender"`
 	PullRequest struct {
-		HTMLURL string `json:"html_url"`
-		Title   string `json:"title"`
-		User    struct {
+		HTMLURL   string `json:"html_url"`
+		Title     string `json:"title"`
+		CreatedAt string `json:"created_at"`
+		MergedAt  string `json:"merged_at"`
+		Merged    bool   `json:"merged"`
+		User      struct {
 			Login string `json:"login"`
 		} `json:"user"`
 		Head struct {
@@ -231,6 +235,15 @@ func (s *Server) processGitHubPREvent(payload githubPRPayload) {
 		// Check if a claw already exists for this PR
 		existingClawID := s.findClawForGitHubPR(payload.PullRequest.HTMLURL)
 		if existingClawID != "" {
+			if payload.Action == "closed" {
+				if _, runID, _, ok, err := s.taskRunContextForClaw(existingClawID); err == nil && ok {
+					at := parseGitHubTimestamp(payload.PullRequest.MergedAt)
+					if !payload.PullRequest.Merged {
+						at = time.Time{}
+					}
+					_ = s.associateTaskRunPR(TaskRunPR{RunID: runID, Repo: repoFullName, PRNumber: payload.Number, URL: payload.PullRequest.HTMLURL, State: taskRunPRStateClosed, Merged: payload.PullRequest.Merged, OccurredAt: at})
+				}
+			}
 			switch payload.Action {
 			case "closed":
 				// Let the pr_watcher handle merged/closed — don't double-inject
@@ -930,6 +943,16 @@ func (s *Server) createClawForGitHubPR(factory *types.FactoryConfig, pr githubPR
 	if err != nil {
 		return fmt.Errorf("db insert: %w", err)
 	}
+	analyticsEnabled, requiresPR, excludedReason := taskRunAnalyticsContractForFactory(factory)
+	if _, _, err := s.ensureTaskRunForClaw(clawID, TaskRunStart{
+		RunKind: taskRunKindForFactory(factory), OwnerType: taskRunOwnerFactory, OwnerName: factory.Name,
+		OwnerDisplayName: factory.Name, WorkspaceName: factory.Workspace, FactoryName: factory.Name,
+		Integration: factory.Integration, Model: defaultModel, LLMKey: llmKey, Source: taskRunSourceFactory,
+		AnalyticsEnabled: analyticsEnabled, RequiresPR: requiresPR, ExcludedReason: excludedReason, StartedAt: createdAt,
+		EventKey: "task_start:claw:" + clawID,
+	}); err != nil {
+		return fmt.Errorf("task run analytics: %w", err)
+	}
 
 	// Store the PR immediately so the watcher picks it up. This claw_prs row is a
 	// hard prerequisite for completing the claim: the PR watcher and the existence
@@ -943,6 +966,12 @@ func (s *Server) createClawForGitHubPR(factory *types.FactoryConfig, pr githubPR
 			s.cronScheduler.finishRunByClawID(clawID, "failed", err.Error())
 		}
 		return fmt.Errorf("associate PR with claw: %w", err)
+	}
+	if _, runID, _, ok, err := s.taskRunContextForClaw(clawID); err == nil && ok {
+		occurredAt := parseGitHubTimestamp(pr.PullRequest.CreatedAt)
+		if err := s.associateTaskRunPR(TaskRunPR{RunID: runID, Repo: repoFullName, PRNumber: prNumber, URL: prURL, HeadSHA: pr.PullRequest.Head.SHA, HeadBranch: pr.PullRequest.Head.Ref, BaseBranch: pr.PullRequest.Base.Ref, State: taskRunPRStateOpen, OccurredAt: occurredAt}); err != nil {
+			log.Printf("[task-run-analytics] failed to record GitHub PR: %v", err)
+		}
 	}
 	if err := s.completeFactoryTrigger(factory.Name, "github-pr", triggerKey, clawID); err != nil {
 		_, _ = s.db.Exec(`UPDATE claws SET status='deleted' WHERE id=?`, clawID)
@@ -1019,6 +1048,14 @@ func (s *Server) createClawForGitHubPR(factory *types.FactoryConfig, pr githubPR
 	}()
 
 	return nil
+}
+
+func parseGitHubTimestamp(value string) time.Time {
+	t, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return time.Time{}
+	}
+	return t
 }
 
 // buildGitHubPRContext builds the BOOTSTRAP.md context for a GitHub PR assignment.

--- a/pkg/hub/github_webhook.go
+++ b/pkg/hub/github_webhook.go
@@ -237,7 +237,7 @@ func (s *Server) processGitHubPREvent(payload githubPRPayload) {
 		if existingClawID != "" {
 			if payload.Action == "closed" {
 				if _, runID, _, ok, err := s.taskRunContextForClaw(existingClawID); err == nil && ok {
-					at := parseGitHubTimestamp(payload.PullRequest.MergedAt)
+					at := parseRFC3339Timestamp(payload.PullRequest.MergedAt)
 					if !payload.PullRequest.Merged {
 						at = time.Time{}
 					}
@@ -951,6 +951,9 @@ func (s *Server) createClawForGitHubPR(factory *types.FactoryConfig, pr githubPR
 		AnalyticsEnabled: analyticsEnabled, RequiresPR: requiresPR, ExcludedReason: excludedReason, StartedAt: createdAt,
 		EventKey: "task_start:claw:" + clawID,
 	}); err != nil {
+		// Tear the claw down so the orphaned 'provisioning' row doesn't linger;
+		// the deferred failFactoryTrigger releases the claim so poll/webhook can retry.
+		_, _ = s.db.Exec(`UPDATE claws SET status='deleted' WHERE id=?`, clawID)
 		return fmt.Errorf("task run analytics: %w", err)
 	}
 
@@ -968,7 +971,7 @@ func (s *Server) createClawForGitHubPR(factory *types.FactoryConfig, pr githubPR
 		return fmt.Errorf("associate PR with claw: %w", err)
 	}
 	if _, runID, _, ok, err := s.taskRunContextForClaw(clawID); err == nil && ok {
-		occurredAt := parseGitHubTimestamp(pr.PullRequest.CreatedAt)
+		occurredAt := parseRFC3339Timestamp(pr.PullRequest.CreatedAt)
 		if err := s.associateTaskRunPR(TaskRunPR{RunID: runID, Repo: repoFullName, PRNumber: prNumber, URL: prURL, HeadSHA: pr.PullRequest.Head.SHA, HeadBranch: pr.PullRequest.Head.Ref, BaseBranch: pr.PullRequest.Base.Ref, State: taskRunPRStateOpen, OccurredAt: occurredAt}); err != nil {
 			log.Printf("[task-run-analytics] failed to record GitHub PR: %v", err)
 		}
@@ -1050,7 +1053,9 @@ func (s *Server) createClawForGitHubPR(factory *types.FactoryConfig, pr githubPR
 	return nil
 }
 
-func parseGitHubTimestamp(value string) time.Time {
+// parseRFC3339Timestamp parses an RFC3339 timestamp (as sent by GitHub and
+// Linear), returning the zero time when the value is absent or malformed.
+func parseRFC3339Timestamp(value string) time.Time {
 	t, err := time.Parse(time.RFC3339, value)
 	if err != nil {
 		return time.Time{}

--- a/pkg/hub/github_webhook_exclude_labels_test.go
+++ b/pkg/hub/github_webhook_exclude_labels_test.go
@@ -13,6 +13,16 @@ import (
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
 
+func TestGitHubPRPayloadParsesAuthoritativeTimestamps(t *testing.T) {
+	var payload githubPRPayload
+	if err := json.Unmarshal([]byte(`{"action":"closed","number":7,"pull_request":{"created_at":"2025-01-02T03:04:05Z","merged_at":"2025-01-03T04:05:06Z","merged":true}}`), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if !payload.PullRequest.Merged || payload.PullRequest.CreatedAt != "2025-01-02T03:04:05Z" || payload.PullRequest.MergedAt != "2025-01-03T04:05:06Z" {
+		t.Fatalf("timestamps not parsed: %#v", payload.PullRequest)
+	}
+}
+
 func TestGitHubPRFactoryExcludeLabelsUsesBackingIssueLabels(t *testing.T) {
 	ghi := newGitHubIssueLabelMock(t)
 	ghi.setIssueLabels("elastic/claw", 42, []string{"Bug"})

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -2031,6 +2031,7 @@ type linearIssueDetails struct {
 	Title       string `json:"title"`
 	URL         string `json:"url"`
 	Description string `json:"description"`
+	CreatedAt   string `json:"createdAt"`
 }
 
 // fetchLinearIssueDetails looks up an issue by its Linear identifier (e.g. "CAN-61")
@@ -2055,7 +2056,7 @@ func (s *Server) fetchLinearIssueDetails(token, issueIdentifier string) (*linear
 	// Linear's issue(id:) actually accepts the display identifier like "CAN-61"
 	// directly (not just UUID). This is documented in Linear's GraphQL examples.
 	queryBody := map[string]interface{}{
-		"query": "query($id: String!) { issue(id: $id) { identifier title url description } }",
+		"query": "query($id: String!) { issue(id: $id) { identifier title url description createdAt } }",
 		"variables": map[string]string{
 			"id": issueIdentifier,
 		},

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -534,11 +534,14 @@ func (s *Server) createClawForIssue(factory *types.FactoryConfig, payload linear
 	// Verify we can read the issue before spending money on a sandbox.
 	// Non-negotiable: if the issue is unreadable, we can't do any work.
 	linearToken := s.resolveLinearTokenForFactory(factory)
+	var issueCreatedAt time.Time
 	if linearToken != "" {
-		if _, err := s.fetchLinearIssueDetails(linearToken, issueID); err != nil {
+		details, err := s.fetchLinearIssueDetails(linearToken, issueID)
+		if err != nil {
 			log.Printf("[factory:%s] pre-flight FAILED for %s: %v", factory.Name, issueID, err)
 			return fmt.Errorf("cannot read issue %s from Linear (check token/workspace access): %w", issueID, err)
 		}
+		issueCreatedAt = parseRFC3339Timestamp(details.CreatedAt)
 	} else {
 		log.Printf("[factory:%s] warning: no Linear token, skipping pre-flight issue read for %s", factory.Name, issueID)
 	}
@@ -557,6 +560,7 @@ func (s *Server) createClawForIssue(factory *types.FactoryConfig, payload linear
 	if err != nil {
 		return err
 	}
+	s.recordTaskRunIssueCreatedAt(clawID, issueCreatedAt)
 	if err := s.completeFactoryTrigger(factory.Name, "linear", triggerKey, clawID); err != nil {
 		_, _ = s.finishClawTerminalTx(clawID, "deleted", "", "failed", err.Error(), terminalTxOpts{})
 		if s.cronScheduler != nil {

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -1103,6 +1103,10 @@ func (s *Server) checkPRMerged(pr clawPR, token string) bool {
 	_, _ = s.db.Exec(`UPDATE claw_prs SET permanent_failure_count=0 WHERE id=? AND permanent_failure_count != 0`, pr.id)
 	state, _ := data["state"].(string)
 	merged, _ := data["merged"].(bool)
+	mergedAtValue, _ := data["merged_at"].(string)
+	createdAtValue, _ := data["created_at"].(string)
+	mergedAt := parseGitHubTimestamp(mergedAtValue)
+	createdAt := parseGitHubTimestamp(createdAtValue)
 
 	log.Printf("[pr-watcher] checkPRMerged: claw=%s pr=%s state=%s merged=%v", pr.clawID[:8], pr.prURL, state, merged)
 
@@ -1151,7 +1155,15 @@ func (s *Server) checkPRMerged(pr clawPR, token string) bool {
 	// Track analytics for PR merge
 	mergeCtx, hasMergeCtx := s.findPipelineContextForClaw(clawID)
 	if hasMergeCtx {
-		s.trackPRMerged(mergeCtx.Name(), mergeCtx.IssueID, clawID, pr.repo, pr.prNumber)
+		s.trackPRMergedAt(mergeCtx.Name(), mergeCtx.IssueID, clawID, pr.repo, pr.prNumber, firstNonZeroTime(mergedAt, now()))
+	} else {
+		s.trackPRMergedAt("", "", clawID, pr.repo, pr.prNumber, firstNonZeroTime(mergedAt, now()))
+	}
+	if _, runID, _, ok, err := s.taskRunContextForClaw(clawID); err == nil && ok {
+		if !createdAt.IsZero() {
+			_, _ = s.db.Exec(`UPDATE task_run_prs SET opened_at=? WHERE tenant_id=? AND run_id=? AND repo=? AND pr_number=?`, epochMillis(createdAt), tenantID, runID, pr.repo, pr.prNumber)
+			_ = s.materializeTaskRun(runID)
+		}
 	}
 
 	// Check if the pipeline handles pr_merged (run on_enter before terminating)

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -148,14 +148,16 @@ func (s *Server) storePRMention(clawID, repo string, prNumber int, prURL string)
 	if _, runID, _, ok, err := s.taskRunContextForClaw(clawID); err != nil {
 		log.Printf("[task-run-analytics] failed to resolve task run for PR mention claw %s: %v", clawID, err)
 	} else if ok {
+		// OccurredAt is intentionally left zero: this is a detection time, so
+		// associateTaskRunPR treats it as a write-once fallback rather than an
+		// authoritative provider timestamp.
 		if err := s.associateTaskRunPR(TaskRunPR{
-			RunID:      runID,
-			Repo:       repo,
-			PRNumber:   prNumber,
-			URL:        prURL,
-			HeadSHA:    headSHA,
-			State:      taskRunPRStateOpen,
-			OccurredAt: now(),
+			RunID:    runID,
+			Repo:     repo,
+			PRNumber: prNumber,
+			URL:      prURL,
+			HeadSHA:  headSHA,
+			State:    taskRunPRStateOpen,
 		}); err != nil {
 			log.Printf("[task-run-analytics] failed to associate PR %s#%d for claw %s: %v", repo, prNumber, clawID, err)
 		}
@@ -1105,8 +1107,8 @@ func (s *Server) checkPRMerged(pr clawPR, token string) bool {
 	merged, _ := data["merged"].(bool)
 	mergedAtValue, _ := data["merged_at"].(string)
 	createdAtValue, _ := data["created_at"].(string)
-	mergedAt := parseGitHubTimestamp(mergedAtValue)
-	createdAt := parseGitHubTimestamp(createdAtValue)
+	mergedAt := parseRFC3339Timestamp(mergedAtValue)
+	createdAt := parseRFC3339Timestamp(createdAtValue)
 
 	log.Printf("[pr-watcher] checkPRMerged: claw=%s pr=%s state=%s merged=%v", pr.clawID[:8], pr.prURL, state, merged)
 

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -1163,8 +1163,12 @@ func (s *Server) checkPRMerged(pr clawPR, token string) bool {
 	}
 	if _, runID, _, ok, err := s.taskRunContextForClaw(clawID); err == nil && ok {
 		if !createdAt.IsZero() {
-			_, _ = s.db.Exec(`UPDATE task_run_prs SET opened_at=? WHERE tenant_id=? AND run_id=? AND repo=? AND pr_number=?`, epochMillis(createdAt), tenantID, runID, pr.repo, pr.prNumber)
-			_ = s.materializeTaskRun(runID)
+			if err := s.associateTaskRunPR(TaskRunPR{RunID: runID, Repo: pr.repo, PRNumber: pr.prNumber, URL: pr.prURL, State: taskRunPRStateOpen, OccurredAt: createdAt}); err != nil {
+				log.Printf("[pr-watcher] failed to backfill opened_at for run %s: %v", runID, err)
+			}
+		}
+		if err := s.associateTaskRunPR(TaskRunPR{RunID: runID, Repo: pr.repo, PRNumber: pr.prNumber, URL: pr.prURL, State: taskRunPRStateClosed, Merged: true, OccurredAt: firstNonZeroTime(mergedAt, now())}); err != nil {
+			log.Printf("[pr-watcher] failed to record merge for run %s: %v", runID, err)
 		}
 	}
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -390,6 +390,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/factories", s.withAdminForMethods(s.handleFactoriesCRUD, http.MethodPost, http.MethodDelete)) // factory CRUD (GET list, POST push)
 	mux.HandleFunc("/api/analytics/factories", s.withAuth(s.handleAllFactoriesAnalytics))                              // GET all factories analytics
 	mux.HandleFunc("/api/analytics/summary", s.withAuth(s.handleTaskRunAnalyticsSummary))
+	mux.HandleFunc("/api/analytics/general-stats", s.withAuth(s.handleTaskRunAnalyticsGeneralStats))
 	mux.HandleFunc("/api/analytics/filter-options", s.withAuth(s.handleTaskRunAnalyticsFilterOptions))
 	mux.HandleFunc("/api/analytics/runs", s.withAuth(s.handleTaskRunAnalyticsRuns))
 	mux.HandleFunc("/api/analytics/runs/", s.withAuth(s.handleTaskRunAnalyticsRuns))

--- a/pkg/hub/task_run_analytics.go
+++ b/pkg/hub/task_run_analytics.go
@@ -124,6 +124,7 @@ type TaskRunStart struct {
 	TriggerID            string
 	ExternalTriggerID    string
 	IssueID              string
+	IssueCreatedAt       time.Time
 	Model                string
 	LLMKey               string
 	Source               string
@@ -265,12 +266,12 @@ func (s *Server) ensureTaskRunForClaw(clawID string, opts TaskRunStart) (string,
 		INSERT INTO task_runs(
 			id, tenant_id, initial_attempt_id, current_attempt_id, attempt_count, run_kind,
 			owner_type, workspace_name, workflow_name, factory_name, owner_id, owner_display_name,
-			integration, integration_workspace, trigger_id, external_trigger_id, issue_id, claw_id, model, llm_key, tags,
+			integration, integration_workspace, trigger_id, external_trigger_id, issue_id, issue_created_at, claw_id, model, llm_key, tags,
 			analytics_enabled, requires_pr, excluded_reason, timeout_at, created_at, updated_at
-		) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
 		runID, opts.TenantID, attemptID, attemptID, 1, opts.RunKind, opts.OwnerType, opts.WorkspaceName,
 		opts.WorkflowName, opts.FactoryName, opts.OwnerID, opts.OwnerDisplayName, opts.Integration, opts.IntegrationWorkspace,
-		opts.TriggerID, opts.ExternalTriggerID, opts.IssueID, clawID, opts.Model, opts.LLMKey, tags, analyticsEnabled, requiresPR,
+		opts.TriggerID, opts.ExternalTriggerID, opts.IssueID, epochMillisOrZero(opts.IssueCreatedAt), clawID, opts.Model, opts.LLMKey, tags, analyticsEnabled, requiresPR,
 		opts.ExcludedReason, timeoutAt, ts, ts,
 	); err != nil {
 		return "", "", err
@@ -403,7 +404,7 @@ func (s *Server) associateTaskRunPR(input TaskRunPR) error {
 			base_branch=excluded.base_branch,
 			state=CASE WHEN task_run_prs.merged = 1 OR task_run_prs.state = 'closed' THEN task_run_prs.state ELSE excluded.state END,
 			merged=CASE WHEN excluded.merged = 1 THEN 1 ELSE task_run_prs.merged END,
-			opened_at=CASE WHEN task_run_prs.opened_at = 0 THEN excluded.opened_at ELSE task_run_prs.opened_at END,
+			opened_at=CASE WHEN excluded.opened_at != 0 THEN excluded.opened_at ELSE task_run_prs.opened_at END,
 			closed_at=CASE WHEN excluded.closed_at != 0 THEN excluded.closed_at ELSE task_run_prs.closed_at END,
 			merged_at=CASE WHEN excluded.merged_at != 0 THEN excluded.merged_at ELSE task_run_prs.merged_at END,
 			merged_by_login=CASE WHEN excluded.merged_by_login != '' THEN excluded.merged_by_login ELSE task_run_prs.merged_by_login END,
@@ -883,13 +884,13 @@ func materializeTaskRunTx(tx *sql.Tx, runID string) error {
 		INSERT INTO task_run_summaries(
 			id, tenant_id, run_id, initial_attempt_id, current_attempt_id, status, phase,
 			attempt_count, owner_type, workspace_name, workflow_name, factory_name, owner_id,
-			owner_display_name, run_kind, integration, integration_workspace, issue_id, claw_id,
+			owner_display_name, run_kind, integration, integration_workspace, issue_id, issue_created_at, claw_id,
 			model, llm_key, repo, primary_pr_url,
 			pr_count, open_pr_count, merged_pr_count, closed_pr_count, warning_types, failure_type,
 			human_interaction_count, started_at, queued_at, provision_started_at, agent_started_at,
 			pr_opened_at, merged_at, finished_at, timeout_at, last_event_at, materialized_at, updated_at,
 			analytics_enabled, requires_pr, excluded_reason
-		) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+		) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
 		ON CONFLICT(run_id) DO UPDATE SET
 			initial_attempt_id=excluded.initial_attempt_id,
 			current_attempt_id=excluded.current_attempt_id,
@@ -906,6 +907,7 @@ func materializeTaskRunTx(tx *sql.Tx, runID string) error {
 			integration=excluded.integration,
 			integration_workspace=excluded.integration_workspace,
 			issue_id=excluded.issue_id,
+			issue_created_at=excluded.issue_created_at,
 			claw_id=excluded.claw_id,
 			model=excluded.model,
 			llm_key=excluded.llm_key,
@@ -933,7 +935,7 @@ func materializeTaskRunTx(tx *sql.Tx, runID string) error {
 			excluded_reason=excluded.excluded_reason`,
 		uuid.New().String(), meta.tenantID, runID, meta.initialAttemptID, meta.currentAttemptID, status, phase, meta.attemptCount, meta.ownerType,
 		meta.workspaceName, meta.workflowName, meta.factoryName, meta.ownerID, meta.ownerDisplayName,
-		meta.runKind, meta.integration, meta.integrationWorkspace, meta.issueID, meta.clawID,
+		meta.runKind, meta.integration, meta.integrationWorkspace, meta.issueID, meta.issueCreatedAt, meta.clawID,
 		meta.model, meta.llmKey, counts.primaryRepo, primaryPRURL, counts.total, counts.open, counts.merged, counts.closed,
 		warningTypes, failureType, humanInteractions, meta.createdAt, phaseTimes.queuedAt, phaseTimes.provisionStartedAt,
 		phaseTimes.agentStartedAt, phaseTimes.prOpenedAt, counts.latestMergedAt, finishedAt, meta.timeoutAt,
@@ -1051,6 +1053,7 @@ type taskRunMeta struct {
 	integration          string
 	integrationWorkspace string
 	issueID              string
+	issueCreatedAt       int64
 	model                string
 	llmKey               string
 	analyticsEnabled     int
@@ -1068,7 +1071,7 @@ func readTaskRunMetaTx(tx *sql.Tx, runID string) (taskRunMeta, error) {
 		       tr.attempt_count, tr.owner_type, tr.workspace_name,
 		       tr.workflow_name, tr.factory_name, tr.owner_id, tr.owner_display_name,
 		       tr.integration,
-		       tr.integration_workspace, tr.issue_id, COALESCE(c.status,''), COALESCE(NULLIF(tr.model,''), c.default_model, ''),
+		       tr.integration_workspace, tr.issue_id, tr.issue_created_at, COALESCE(c.status,''), COALESCE(NULLIF(tr.model,''), c.default_model, ''),
 		       COALESCE(NULLIF(tr.llm_key,''), c.llm_key, ''), tr.analytics_enabled, tr.requires_pr, tr.excluded_reason,
 		       tr.timeout_at, tr.created_at, tr.updated_at
 		  FROM task_runs tr
@@ -1077,7 +1080,7 @@ func readTaskRunMetaTx(tx *sql.Tx, runID string) (taskRunMeta, error) {
 		&meta.tenantID, &meta.clawID, &meta.runKind, &meta.initialAttemptID, &meta.currentAttemptID,
 		&meta.attemptCount, &meta.ownerType,
 		&meta.workspaceName, &meta.workflowName, &meta.factoryName, &meta.ownerID, &meta.ownerDisplayName,
-		&meta.integration, &meta.integrationWorkspace, &meta.issueID, &meta.clawStatus, &meta.model, &meta.llmKey,
+		&meta.integration, &meta.integrationWorkspace, &meta.issueID, &meta.issueCreatedAt, &meta.clawStatus, &meta.model, &meta.llmKey,
 		&meta.analyticsEnabled, &meta.requiresPR, &meta.excludedReason,
 		&meta.timeoutAt, &meta.createdAt, &meta.updatedAt,
 	)

--- a/pkg/hub/task_run_analytics.go
+++ b/pkg/hub/task_run_analytics.go
@@ -377,6 +377,10 @@ func (s *Server) associateTaskRunPR(input TaskRunPR) error {
 	if input.State == "" {
 		input.State = taskRunPRStateOpen
 	}
+	// A caller-supplied OccurredAt is an authoritative provider timestamp and
+	// may overwrite an earlier detection-time opened_at; the now() fallback is
+	// write-once so it never clobbers an authoritative value.
+	authoritativeOpen := input.State == taskRunPRStateOpen && !input.OccurredAt.IsZero()
 	if input.OccurredAt.IsZero() {
 		input.OccurredAt = now()
 	}
@@ -404,7 +408,7 @@ func (s *Server) associateTaskRunPR(input TaskRunPR) error {
 			base_branch=excluded.base_branch,
 			state=CASE WHEN task_run_prs.merged = 1 OR task_run_prs.state = 'closed' THEN task_run_prs.state ELSE excluded.state END,
 			merged=CASE WHEN excluded.merged = 1 THEN 1 ELSE task_run_prs.merged END,
-			opened_at=CASE WHEN excluded.opened_at != 0 THEN excluded.opened_at ELSE task_run_prs.opened_at END,
+			opened_at=CASE WHEN excluded.opened_at != 0 AND (task_run_prs.opened_at = 0 OR ?) THEN excluded.opened_at ELSE task_run_prs.opened_at END,
 			closed_at=CASE WHEN excluded.closed_at != 0 THEN excluded.closed_at ELSE task_run_prs.closed_at END,
 			merged_at=CASE WHEN excluded.merged_at != 0 THEN excluded.merged_at ELSE task_run_prs.merged_at END,
 			merged_by_login=CASE WHEN excluded.merged_by_login != '' THEN excluded.merged_by_login ELSE task_run_prs.merged_by_login END,
@@ -412,6 +416,7 @@ func (s *Server) associateTaskRunPR(input TaskRunPR) error {
 		uuid.New().String(), input.TenantID, input.RunID, input.Repo, input.PRNumber, input.URL,
 		input.HeadSHA, input.HeadBranch, input.BaseBranch, input.State, boolInt(input.Merged),
 		openedAt, closedAt, mergedAt, input.MergedByLogin, at, at,
+		boolInt(authoritativeOpen),
 	); err != nil {
 		return err
 	}
@@ -494,6 +499,26 @@ func (s *Server) taskRunContextForClaw(clawID string) (tenantID, runID, attemptI
 		return tenantID, "", "", false, nil
 	}
 	return tenantID, runID, attemptID, true, nil
+}
+
+// recordTaskRunIssueCreatedAt backfills the authoritative issue-creation time
+// on the task run for a claw and refreshes its summary. Best-effort: analytics
+// must never fail the calling flow.
+func (s *Server) recordTaskRunIssueCreatedAt(clawID string, issueCreatedAt time.Time) {
+	if issueCreatedAt.IsZero() {
+		return
+	}
+	_, runID, _, ok, err := s.taskRunContextForClaw(clawID)
+	if err != nil || !ok {
+		return
+	}
+	if _, err := s.db.Exec(`UPDATE task_runs SET issue_created_at=? WHERE id=? AND issue_created_at=0`, epochMillis(issueCreatedAt), runID); err != nil {
+		log.Printf("[task-run-analytics] failed to record issue creation time for claw %s: %v", clawID, err)
+		return
+	}
+	if err := s.materializeTaskRun(runID); err != nil {
+		log.Printf("[task-run-analytics] failed to materialize run %s after issue creation backfill: %v", runID, err)
+	}
 }
 
 func loadTaskRunTenantTx(tx *sql.Tx, runID string) (string, error) {
@@ -847,6 +872,14 @@ func materializeTaskRunTx(tx *sql.Tx, runID string) error {
 
 	counts := taskRunPRCounts(prs)
 	phaseTimes := taskRunPhaseTimes(events)
+	// task_run_prs.opened_at may carry GitHub's authoritative created_at
+	// (backfilled by the PR watcher or webhook), while pr_opened events are
+	// stamped at detection time and never updated. Use the earliest known time.
+	for _, pr := range prs {
+		if pr.openedAt > 0 && (phaseTimes.prOpenedAt == 0 || pr.openedAt < phaseTimes.prOpenedAt) {
+			phaseTimes.prOpenedAt = pr.openedAt
+		}
+	}
 	if counts.merged > 0 && counts.closed > 0 {
 		warnings[taskRunWarningPRReplaced] = true
 	}

--- a/pkg/hub/task_run_analytics_api.go
+++ b/pkg/hub/task_run_analytics_api.go
@@ -227,6 +227,86 @@ type taskRunAnalyticsFilters struct {
 	AnalyticsEnabled *bool
 }
 
+type taskRunGeneralStat struct {
+	AvgMs         *int64 `json:"avgMs"`
+	Samples       int    `json:"samples"`
+	Authoritative *bool  `json:"authoritative,omitempty"`
+}
+
+type taskRunGeneralStatsResponse struct {
+	TicketToPr    taskRunGeneralStat `json:"ticketToPrMs"`
+	PROpenToMerge taskRunGeneralStat `json:"prOpenToMergeMs"`
+	AIImpl        taskRunGeneralStat `json:"aiImplMs"`
+}
+
+func (s *Server) handleTaskRunAnalyticsGeneralStats(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		jsonError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	filters, err := parseTaskRunAnalyticsFilters(r)
+	if err != nil {
+		jsonError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	response, err := s.readTaskRunAnalyticsGeneralStats(filters)
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "db error")
+		return
+	}
+	jsonOK(w, response)
+}
+
+func (s *Server) readTaskRunAnalyticsGeneralStats(filters taskRunAnalyticsFilters) (taskRunGeneralStatsResponse, error) {
+	where, args := taskRunAnalyticsSummaryWhere(filters)
+	rows, err := s.db.Query(`SELECT issue_created_at, started_at, agent_started_at, pr_opened_at, merged_at FROM task_run_summaries `+where, args...)
+	if err != nil {
+		return taskRunGeneralStatsResponse{}, err
+	}
+	defer rows.Close()
+	var ticketSum, prSum, aiSum int64
+	var ticketN, prN, aiN int
+	authoritative := true
+	for rows.Next() {
+		var issue, started, agent, opened, merged int64
+		if err := rows.Scan(&issue, &started, &agent, &opened, &merged); err != nil {
+			return taskRunGeneralStatsResponse{}, err
+		}
+		if opened > 0 && started > 0 {
+			base := issue
+			if base == 0 {
+				base = started
+				authoritative = false
+			}
+			ticketSum += opened - base
+			ticketN++
+		}
+		if opened > 0 && merged > 0 {
+			prSum += merged - opened
+			prN++
+		}
+		if agent > 0 && opened > 0 {
+			aiSum += opened - agent
+			aiN++
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return taskRunGeneralStatsResponse{}, err
+	}
+	average := func(sum int64, samples int) *int64 {
+		if samples == 0 {
+			return nil
+		}
+		value := sum / int64(samples)
+		return &value
+	}
+	return taskRunGeneralStatsResponse{
+		TicketToPr:    taskRunGeneralStat{AvgMs: average(ticketSum, ticketN), Samples: ticketN, Authoritative: &authoritative},
+		PROpenToMerge: taskRunGeneralStat{AvgMs: average(prSum, prN), Samples: prN},
+		AIImpl:        taskRunGeneralStat{AvgMs: average(aiSum, aiN), Samples: aiN},
+	}, nil
+}
+
 func (s *Server) handleTaskRunAnalyticsSummary(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		jsonError(w, http.StatusMethodNotAllowed, "method not allowed")

--- a/pkg/hub/task_run_analytics_api.go
+++ b/pkg/hub/task_run_analytics_api.go
@@ -272,20 +272,27 @@ func (s *Server) readTaskRunAnalyticsGeneralStats(filters taskRunAnalyticsFilter
 		if err := rows.Scan(&issue, &started, &agent, &opened, &merged); err != nil {
 			return taskRunGeneralStatsResponse{}, err
 		}
+		// Negative deltas are skipped: for GitHub-triggered claws the PR
+		// pre-dates the run, so opened-started/opened-agent are meaningless.
 		if opened > 0 && started > 0 {
 			base := issue
-			if base == 0 {
+			fallback := base == 0
+			if fallback {
 				base = started
-				authoritative = false
 			}
-			ticketSum += opened - base
-			ticketN++
+			if opened >= base {
+				ticketSum += opened - base
+				ticketN++
+				if fallback {
+					authoritative = false
+				}
+			}
 		}
-		if opened > 0 && merged > 0 {
+		if opened > 0 && merged > 0 && merged >= opened {
 			prSum += merged - opened
 			prN++
 		}
-		if agent > 0 && opened > 0 {
+		if agent > 0 && opened > 0 && opened >= agent {
 			aiSum += opened - agent
 			aiN++
 		}

--- a/pkg/hub/task_run_analytics_api_test.go
+++ b/pkg/hub/task_run_analytics_api_test.go
@@ -164,6 +164,34 @@ func TestTaskRunAnalyticsAPISummaryRunsFiltersAndPagination(t *testing.T) {
 	}
 }
 
+func TestTaskRunAnalyticsAPIGeneralStats(t *testing.T) {
+	s, db := newTaskRunAnalyticsAPITestServer(t)
+	base := int64(1760000000000)
+	insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{RunID: "stats-authoritative", AttemptID: "attempt-stats-authoritative", ClawID: "claw-stats-authoritative", TenantID: "test-tenant-id", OwnerType: taskRunOwnerFactory, StartedAt: base, PRCount: 1})
+	insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{RunID: "stats-fallback", AttemptID: "attempt-stats-fallback", ClawID: "claw-stats-fallback", TenantID: "test-tenant-id", OwnerType: taskRunOwnerFactory, StartedAt: base + 1000, PRCount: 1})
+	if _, err := db.Exec(`UPDATE task_run_summaries SET issue_created_at=?, agent_started_at=?, pr_opened_at=?, merged_at=? WHERE run_id='stats-authoritative'`, base-1000, base+100, base+5000, base+9000); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`UPDATE task_run_summaries SET agent_started_at=?, pr_opened_at=?, merged_at=? WHERE run_id='stats-fallback'`, base+1100, base+6000, base+10000); err != nil {
+		t.Fatal(err)
+	}
+	rr := requestTaskRunAnalyticsAPI(t, s, http.MethodGet, "/api/analytics/general-stats", "test-token")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	var response taskRunGeneralStatsResponse
+	decodeTaskRunAnalyticsAPI(t, rr, &response)
+	if response.TicketToPr.AvgMs == nil || *response.TicketToPr.AvgMs != 5500 || response.TicketToPr.Samples != 2 || response.TicketToPr.Authoritative == nil || *response.TicketToPr.Authoritative {
+		t.Fatalf("ticket stats: %#v", response.TicketToPr)
+	}
+	if response.PROpenToMerge.AvgMs == nil || *response.PROpenToMerge.AvgMs != 4000 || response.PROpenToMerge.Samples != 2 {
+		t.Fatalf("merge stats: %#v", response.PROpenToMerge)
+	}
+	if response.AIImpl.AvgMs == nil || *response.AIImpl.AvgMs != 4900 || response.AIImpl.Samples != 2 {
+		t.Fatalf("AI stats: %#v", response.AIImpl)
+	}
+}
+
 func TestTaskRunAnalyticsAPIRunDetailsAttemptsEventsAndPRs(t *testing.T) {
 	s, db := newTaskRunAnalyticsAPITestServer(t)
 	ts := int64(1760000000000)

--- a/pkg/hub/task_run_analytics_api_test.go
+++ b/pkg/hub/task_run_analytics_api_test.go
@@ -192,6 +192,36 @@ func TestTaskRunAnalyticsAPIGeneralStats(t *testing.T) {
 	}
 }
 
+func TestTaskRunAnalyticsAPIGeneralStatsEmptyAndAuthoritative(t *testing.T) {
+	s, db := newTaskRunAnalyticsAPITestServer(t)
+
+	// No qualifying rows: every avgMs must serialize as JSON null with samples 0.
+	rr := requestTaskRunAnalyticsAPI(t, s, http.MethodGet, "/api/analytics/general-stats", "test-token")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, `"ticketToPrMs":{"avgMs":null,"samples":0,"authoritative":true}`) ||
+		!strings.Contains(body, `"prOpenToMergeMs":{"avgMs":null,"samples":0}`) ||
+		!strings.Contains(body, `"aiImplMs":{"avgMs":null,"samples":0}`) {
+		t.Fatalf("unexpected empty-stats body: %s", body)
+	}
+
+	// A single run with issue_created_at set keeps authoritative=true.
+	base := int64(1760000000000)
+	insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{RunID: "stats-auth-only", AttemptID: "attempt-stats-auth-only", ClawID: "claw-stats-auth-only", TenantID: "test-tenant-id", OwnerType: taskRunOwnerFactory, StartedAt: base, PRCount: 1})
+	if _, err := db.Exec(`UPDATE task_run_summaries SET issue_created_at=?, pr_opened_at=? WHERE run_id='stats-auth-only'`, base-2000, base+3000); err != nil {
+		t.Fatal(err)
+	}
+	rr = requestTaskRunAnalyticsAPI(t, s, http.MethodGet, "/api/analytics/general-stats", "test-token")
+	var response taskRunGeneralStatsResponse
+	decodeTaskRunAnalyticsAPI(t, rr, &response)
+	if response.TicketToPr.AvgMs == nil || *response.TicketToPr.AvgMs != 5000 || response.TicketToPr.Samples != 1 ||
+		response.TicketToPr.Authoritative == nil || !*response.TicketToPr.Authoritative {
+		t.Fatalf("ticket stats: %#v", response.TicketToPr)
+	}
+}
+
 func TestTaskRunAnalyticsAPIRunDetailsAttemptsEventsAndPRs(t *testing.T) {
 	s, db := newTaskRunAnalyticsAPITestServer(t)
 	ts := int64(1760000000000)

--- a/pkg/hub/task_run_analytics_api_test.go
+++ b/pkg/hub/task_run_analytics_api_test.go
@@ -175,6 +175,12 @@ func TestTaskRunAnalyticsAPIGeneralStats(t *testing.T) {
 	if _, err := db.Exec(`UPDATE task_run_summaries SET agent_started_at=?, pr_opened_at=?, merged_at=? WHERE run_id='stats-fallback'`, base+1100, base+6000, base+10000); err != nil {
 		t.Fatal(err)
 	}
+	// GitHub-triggered shape: the PR pre-dates the run, so opened-started and
+	// opened-agent are negative and must be skipped; merged-opened still counts.
+	insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{RunID: "stats-github", AttemptID: "attempt-stats-github", ClawID: "claw-stats-github", TenantID: "test-tenant-id", OwnerType: taskRunOwnerFactory, StartedAt: base + 20000, PRCount: 1})
+	if _, err := db.Exec(`UPDATE task_run_summaries SET agent_started_at=?, pr_opened_at=?, merged_at=? WHERE run_id='stats-github'`, base+20100, base+15000, base+18000); err != nil {
+		t.Fatal(err)
+	}
 	rr := requestTaskRunAnalyticsAPI(t, s, http.MethodGet, "/api/analytics/general-stats", "test-token")
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
@@ -184,7 +190,7 @@ func TestTaskRunAnalyticsAPIGeneralStats(t *testing.T) {
 	if response.TicketToPr.AvgMs == nil || *response.TicketToPr.AvgMs != 5500 || response.TicketToPr.Samples != 2 || response.TicketToPr.Authoritative == nil || *response.TicketToPr.Authoritative {
 		t.Fatalf("ticket stats: %#v", response.TicketToPr)
 	}
-	if response.PROpenToMerge.AvgMs == nil || *response.PROpenToMerge.AvgMs != 4000 || response.PROpenToMerge.Samples != 2 {
+	if response.PROpenToMerge.AvgMs == nil || *response.PROpenToMerge.AvgMs != 3666 || response.PROpenToMerge.Samples != 3 {
 		t.Fatalf("merge stats: %#v", response.PROpenToMerge)
 	}
 	if response.AIImpl.AvgMs == nil || *response.AIImpl.AvgMs != 4900 || response.AIImpl.Samples != 2 {
@@ -211,6 +217,12 @@ func TestTaskRunAnalyticsAPIGeneralStatsEmptyAndAuthoritative(t *testing.T) {
 	base := int64(1760000000000)
 	insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{RunID: "stats-auth-only", AttemptID: "attempt-stats-auth-only", ClawID: "claw-stats-auth-only", TenantID: "test-tenant-id", OwnerType: taskRunOwnerFactory, StartedAt: base, PRCount: 1})
 	if _, err := db.Exec(`UPDATE task_run_summaries SET issue_created_at=?, pr_opened_at=? WHERE run_id='stats-auth-only'`, base-2000, base+3000); err != nil {
+		t.Fatal(err)
+	}
+	// A fallback row with a negative delta is skipped, not sampled, so it must
+	// not flip authoritative to false either.
+	insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{RunID: "stats-github-skip", AttemptID: "attempt-stats-github-skip", ClawID: "claw-stats-github-skip", TenantID: "test-tenant-id", OwnerType: taskRunOwnerFactory, StartedAt: base + 10000, PRCount: 1})
+	if _, err := db.Exec(`UPDATE task_run_summaries SET pr_opened_at=? WHERE run_id='stats-github-skip'`, base+8000); err != nil {
 		t.Fatal(err)
 	}
 	rr = requestTaskRunAnalyticsAPI(t, s, http.MethodGet, "/api/analytics/general-stats", "test-token")

--- a/pkg/hub/task_run_analytics_test.go
+++ b/pkg/hub/task_run_analytics_test.go
@@ -498,6 +498,81 @@ func TestTaskRunDetailSanitizationRedactsNestedText(t *testing.T) {
 	}
 }
 
+func TestTaskRunSummaryPrefersAuthoritativePROpenedAt(t *testing.T) {
+	s, db := newTaskRunAnalyticsTestServer(t, "claw-auth-open")
+	runID, _ := startTaskRunForTest(t, s, "claw-auth-open", "auth-open")
+
+	// Detection-time association: zero OccurredAt falls back to now() and is write-once.
+	if err := s.associateTaskRunPR(TaskRunPR{RunID: runID, Repo: "elastic/claw", PRNumber: 7, URL: "https://github.com/elastic/claw/pull/7", State: taskRunPRStateOpen}); err != nil {
+		t.Fatalf("fallback associate: %v", err)
+	}
+	var detectedAt int64
+	if err := db.QueryRow(`SELECT opened_at FROM task_run_prs WHERE run_id=?`, runID).Scan(&detectedAt); err != nil {
+		t.Fatalf("read opened_at: %v", err)
+	}
+	if detectedAt == 0 {
+		t.Fatal("expected fallback opened_at to be stamped")
+	}
+
+	// GitHub's authoritative created_at (earlier) overwrites the detection time.
+	authoritative := time.UnixMilli(detectedAt - 60000).UTC()
+	if err := s.associateTaskRunPR(TaskRunPR{RunID: runID, Repo: "elastic/claw", PRNumber: 7, URL: "https://github.com/elastic/claw/pull/7", State: taskRunPRStateOpen, OccurredAt: authoritative}); err != nil {
+		t.Fatalf("authoritative associate: %v", err)
+	}
+	var openedAt, summaryOpenedAt int64
+	if err := db.QueryRow(`SELECT opened_at FROM task_run_prs WHERE run_id=?`, runID).Scan(&openedAt); err != nil {
+		t.Fatalf("read opened_at: %v", err)
+	}
+	if openedAt != epochMillis(authoritative) {
+		t.Fatalf("opened_at=%d want %d", openedAt, epochMillis(authoritative))
+	}
+	if err := db.QueryRow(`SELECT pr_opened_at FROM task_run_summaries WHERE run_id=?`, runID).Scan(&summaryOpenedAt); err != nil {
+		t.Fatalf("read summary pr_opened_at: %v", err)
+	}
+	if summaryOpenedAt != epochMillis(authoritative) {
+		t.Fatalf("summary pr_opened_at=%d want %d", summaryOpenedAt, epochMillis(authoritative))
+	}
+
+	// A later fallback re-association must not clobber the authoritative value.
+	if err := s.associateTaskRunPR(TaskRunPR{RunID: runID, Repo: "elastic/claw", PRNumber: 7, URL: "https://github.com/elastic/claw/pull/7", State: taskRunPRStateOpen}); err != nil {
+		t.Fatalf("redelivered associate: %v", err)
+	}
+	if err := db.QueryRow(`SELECT opened_at FROM task_run_prs WHERE run_id=?`, runID).Scan(&openedAt); err != nil {
+		t.Fatalf("read opened_at: %v", err)
+	}
+	if openedAt != epochMillis(authoritative) {
+		t.Fatalf("redelivery clobbered opened_at: %d want %d", openedAt, epochMillis(authoritative))
+	}
+}
+
+func TestRecordTaskRunIssueCreatedAtBackfillsRunAndSummary(t *testing.T) {
+	s, db := newTaskRunAnalyticsTestServer(t, "claw-issue-created")
+	runID, _ := startTaskRunForTest(t, s, "claw-issue-created", "issue-created")
+
+	created := time.UnixMilli(1760000000000).UTC()
+	s.recordTaskRunIssueCreatedAt("claw-issue-created", created)
+
+	var runValue, summaryValue int64
+	if err := db.QueryRow(`SELECT issue_created_at FROM task_runs WHERE id=?`, runID).Scan(&runValue); err != nil {
+		t.Fatalf("read task run: %v", err)
+	}
+	if err := db.QueryRow(`SELECT issue_created_at FROM task_run_summaries WHERE run_id=?`, runID).Scan(&summaryValue); err != nil {
+		t.Fatalf("read summary: %v", err)
+	}
+	if runValue != 1760000000000 || summaryValue != 1760000000000 {
+		t.Fatalf("issue_created_at run=%d summary=%d want 1760000000000", runValue, summaryValue)
+	}
+
+	// Write-once: a second backfill must not overwrite the stored value.
+	s.recordTaskRunIssueCreatedAt("claw-issue-created", created.Add(time.Hour))
+	if err := db.QueryRow(`SELECT issue_created_at FROM task_runs WHERE id=?`, runID).Scan(&runValue); err != nil {
+		t.Fatalf("read task run: %v", err)
+	}
+	if runValue != 1760000000000 {
+		t.Fatalf("second backfill overwrote issue_created_at: %d", runValue)
+	}
+}
+
 func newTaskRunAnalyticsTestServer(t *testing.T, clawID string) (*Server, *sql.DB) {
 	t.Helper()
 	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")

--- a/pkg/hub/task_run_analytics_test.go
+++ b/pkg/hub/task_run_analytics_test.go
@@ -50,7 +50,7 @@ func TestTaskRunSchemaCreatesIssue350TablesColumnsConstraintsAndIndexes(t *testi
 	assertColumns(t, db, "task_runs", []string{
 		"id", "tenant_id", "initial_attempt_id", "current_attempt_id", "attempt_count", "run_kind",
 		"owner_type", "workspace_name", "workflow_name", "factory_name", "owner_id", "owner_display_name",
-		"integration", "integration_workspace", "trigger_id", "external_trigger_id", "issue_id", "claw_id", "model", "llm_key", "tags",
+		"integration", "integration_workspace", "trigger_id", "external_trigger_id", "issue_id", "issue_created_at", "claw_id", "model", "llm_key", "tags",
 		"analytics_enabled", "requires_pr", "excluded_reason", "timeout_at", "created_at", "updated_at",
 	})
 	assertColumns(t, db, "task_run_attempts", []string{
@@ -72,7 +72,7 @@ func TestTaskRunSchemaCreatesIssue350TablesColumnsConstraintsAndIndexes(t *testi
 	assertColumns(t, db, "task_run_summaries", []string{
 		"id", "tenant_id", "run_id", "status", "phase", "attempt_count", "owner_type",
 		"workspace_name", "workflow_name", "factory_name", "owner_id", "owner_display_name",
-		"run_kind", "integration", "integration_workspace", "issue_id", "claw_id",
+		"run_kind", "integration", "integration_workspace", "issue_id", "issue_created_at", "claw_id",
 		"model", "llm_key", "repo", "primary_pr_url", "pr_count", "open_pr_count", "merged_pr_count",
 		"closed_pr_count", "warning_types", "failure_type", "human_interaction_count",
 		"started_at", "queued_at", "provision_started_at", "agent_started_at", "pr_opened_at",
@@ -81,6 +81,8 @@ func TestTaskRunSchemaCreatesIssue350TablesColumnsConstraintsAndIndexes(t *testi
 	})
 
 	assertColumnDefault(t, db, "task_runs", "tags", "'[]'")
+	assertExecSucceeds(t, db, `UPDATE task_runs SET issue_created_at=123 WHERE id='missing'`)
+	assertExecSucceeds(t, db, `UPDATE task_run_summaries SET issue_created_at=123 WHERE run_id='missing'`)
 
 	now := int64(1760000000000)
 	insertValidRun(t, db, "run-valid", now)


### PR DESCRIPTION
## What

PR 4 of Factory Stats v2 — makes delivery-lifecycle timestamps authoritative and adds a general-stats analytics endpoint.

- **GitHub webhook** (`github_webhook.go`): parses `pull_request.created_at` / `merged_at` / `merged` and uses them as the authoritative times for `task_run_prs` and analytics events, falling back to `now()` when absent.
- **PR watcher** (`pr_watcher.go` `checkPRMerged`): reads `created_at` / `merged_at` from the pulls API response; merge events use GitHub's `merged_at` (via new `trackPRMergedAt`), and the authoritative open time is backfilled into `task_run_prs.opened_at`.
- **`associateTaskRunPR`**: honors a caller-supplied `OccurredAt` override; authoritative opens may overwrite a detection-time value, fallback opens are write-once. The summary materializer now prefers the earliest non-zero time across `pr_opened` events and `task_run_prs.opened_at`, so the backfill actually reaches `task_run_summaries`.
- **Linear ticket age**: `fetchLinearIssueDetails` now requests `createdAt`; it is persisted as `issue_created_at` (epoch millis, best-effort `ALTER TABLE` on `task_runs` + `task_run_summaries`) at claw creation and backfilled for existing runs. The webhook payload's `createdAt` is intentionally not used — it is the event time, not the issue creation time.
- **New endpoint `GET /api/analytics/general-stats`** (same auth, tenant scoping, and filters as `/api/analytics/summary`):
  - `ticketToPrMs` = `pr_opened_at − issue_created_at` (fallback `started_at`; `authoritative: false` if any sampled row used the fallback)
  - `prOpenToMergeMs` = `merged_at − pr_opened_at`
  - `aiImplMs` = `pr_opened_at − agent_started_at`
  - `avgMs` is `null` with `samples: 0` when no rows qualify.

## Why

`pr_opened_at` / `merged_at` were stamped with detection time (webhook processing / poll time), not GitHub's actual times, and no ticket-creation timestamp was stored — so ticket→PR, open→merge, and AI-implementation durations could not be measured reliably.

Part of [AIEDEV-1](https://linear.app/nimble-la/issue/AIEDEV-1). Independent of the other AIEDEV-1 PRs (no dependency on the usage/cost schema). The response shape is consumed by the parallel UI PR (`claude/aiedev-1-cost-ui`).

## Tests

- `go build ./...` — clean
- `go test ./pkg/hub -count=1` — ok (16.9s), including new coverage: webhook `created_at`/`merged_at` parsing, `issue_created_at` migration + backfill, summary preferring the authoritative open time over detection time, and general-stats math (averaging, fallback flag, and raw-JSON `null`/`samples: 0` on empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)