### PR TITLE
feat: cost aggregation analytics endpoints

### DIFF
--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -390,6 +390,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/factories", s.withAdminForMethods(s.handleFactoriesCRUD, http.MethodPost, http.MethodDelete)) // factory CRUD (GET list, POST push)
 	mux.HandleFunc("/api/analytics/factories", s.withAuth(s.handleAllFactoriesAnalytics))                              // GET all factories analytics
 	mux.HandleFunc("/api/analytics/summary", s.withAuth(s.handleTaskRunAnalyticsSummary))
+	mux.HandleFunc("/api/analytics/costs", s.withAuth(s.handleTaskRunAnalyticsCosts))
 	mux.HandleFunc("/api/analytics/general-stats", s.withAuth(s.handleTaskRunAnalyticsGeneralStats))
 	mux.HandleFunc("/api/analytics/filter-options", s.withAuth(s.handleTaskRunAnalyticsFilterOptions))
 	mux.HandleFunc("/api/analytics/runs", s.withAuth(s.handleTaskRunAnalyticsRuns))

--- a/pkg/hub/task_run_analytics_api.go
+++ b/pkg/hub/task_run_analytics_api.go
@@ -136,6 +136,11 @@ type taskRunAnalyticsRunView struct {
 	AnalyticsEnabled      bool     `json:"analyticsEnabled"`
 	RequiresPR            bool     `json:"requiresPr"`
 	ExcludedReason        string   `json:"excludedReason"`
+	InputTokens           int64    `json:"inputTokens,omitempty"`
+	OutputTokens          int64    `json:"outputTokens,omitempty"`
+	TotalTokens           int64    `json:"totalTokens,omitempty"`
+	EstimatedCostUsd      float64  `json:"estimatedCostUsd,omitempty"`
+	IssueTitle            string   `json:"issueTitle,omitempty"`
 }
 
 type taskRunAnalyticsAttemptView struct {
@@ -1181,7 +1186,8 @@ func taskRunAnalyticsRunColumns() string {
 		primary_pr_url, pr_count, open_pr_count, merged_pr_count, closed_pr_count, warning_types,
 		failure_type, human_interaction_count, started_at, queued_at, provision_started_at,
 		agent_started_at, pr_opened_at, merged_at, finished_at, timeout_at, last_event_at,
-		materialized_at, updated_at, analytics_enabled, requires_pr, excluded_reason`
+		materialized_at, updated_at, analytics_enabled, requires_pr, excluded_reason,
+		input_tokens, output_tokens, total_tokens, estimated_cost_usd, issue_title`
 }
 
 func scanTaskRunAnalyticsRuns(rows *sql.Rows) ([]taskRunAnalyticsRunView, error) {
@@ -1198,7 +1204,7 @@ func scanTaskRunAnalyticsRuns(rows *sql.Rows) ([]taskRunAnalyticsRunView, error)
 			&warningsJSON, &run.FailureType, &run.HumanInteractionCount, &run.StartedAt, &run.QueuedAt,
 			&run.ProvisionStartedAt, &run.AgentStartedAt, &run.PROpenedAt, &run.MergedAt, &run.FinishedAt,
 			&run.TimeoutAt, &run.LastEventAt, &run.MaterializedAt, &run.UpdatedAt, &analyticsEnabled, &requiresPR,
-			&run.ExcludedReason,
+			&run.ExcludedReason, &run.InputTokens, &run.OutputTokens, &run.TotalTokens, &run.EstimatedCostUsd, &run.IssueTitle,
 		); err != nil {
 			return nil, err
 		}

--- a/pkg/hub/task_run_analytics_api_test.go
+++ b/pkg/hub/task_run_analytics_api_test.go
@@ -619,6 +619,11 @@ type apiRunFixture struct {
 	AnalyticsEnabled  *bool
 	RequiresPR        *bool
 	ExcludedReason    string
+	InputTokens       int64
+	OutputTokens      int64
+	TotalTokens       int64
+	EstimatedCostUsd  float64
+	IssueTitle        string
 }
 
 func newTaskRunAnalyticsAPITestServer(t *testing.T) (*Server, *sql.DB) {
@@ -696,8 +701,9 @@ func insertTaskRunAnalyticsAPIRun(t *testing.T, db *sql.DB, fixture apiRunFixtur
 			integration, issue_id, claw_id, model, repo, primary_pr_url, pr_count, open_pr_count,
 			merged_pr_count, closed_pr_count, warning_types, failure_type, human_interaction_count,
 			started_at, merged_at, finished_at, last_event_at, materialized_at, updated_at,
-			analytics_enabled, requires_pr, excluded_reason
-		) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+			analytics_enabled, requires_pr, excluded_reason, input_tokens, output_tokens, total_tokens,
+			estimated_cost_usd, issue_title
+		) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
 		"summary-"+fixture.RunID, fixture.TenantID, fixture.RunID, fixture.AttemptID, fixture.AttemptID,
 		fixture.Status, fixture.Phase, 1, fixture.OwnerType, fixture.Workspace, fixture.Workflow, fixture.Factory,
 		firstNonEmpty(fixture.Workflow, fixture.Factory), taskRunKindPRTask, fixture.Integration,
@@ -706,6 +712,7 @@ func insertTaskRunAnalyticsAPIRun(t *testing.T, db *sql.DB, fixture apiRunFixtur
 		fixture.MergedPRCount, fixture.ClosedPRCount, warningsJSON, fixture.FailureType,
 		fixture.HumanInteractions, fixture.StartedAt, fixture.MergedAt, fixture.FinishedAt,
 		fixture.StartedAt, fixture.StartedAt, fixture.StartedAt, boolInt(analyticsEnabled), boolInt(requiresPR), fixture.ExcludedReason,
+		fixture.InputTokens, fixture.OutputTokens, fixture.TotalTokens, fixture.EstimatedCostUsd, fixture.IssueTitle,
 	)
 	if err != nil {
 		t.Fatalf("insert task run summary %s: %v", fixture.RunID, err)

--- a/pkg/hub/task_run_analytics_costs_api.go
+++ b/pkg/hub/task_run_analytics_costs_api.go
@@ -1,0 +1,157 @@
+package hub
+
+import (
+	"math"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type taskRunAnalyticsCostsResponse struct {
+	Today          taskRunAnalyticsCostPeriod  `json:"today"`
+	Week           taskRunAnalyticsCostAmount  `json:"week"`
+	Month          taskRunAnalyticsCostAmount  `json:"month"`
+	ProjectedMonth *taskRunAnalyticsProjection `json:"projectedMonth"`
+	DailySeries    []taskRunAnalyticsDailyCost `json:"dailySeries"`
+}
+
+type taskRunAnalyticsCostPeriod struct {
+	CostUsd             float64  `json:"costUsd"`
+	TotalTokens         int64    `json:"totalTokens"`
+	DeltaPctVsYesterday *float64 `json:"deltaPctVsYesterday"`
+}
+
+type taskRunAnalyticsCostAmount struct {
+	CostUsd float64 `json:"costUsd"`
+}
+
+type taskRunAnalyticsProjection struct {
+	CostUsd    float64 `json:"costUsd"`
+	Confidence string  `json:"confidence"`
+	Basis      string  `json:"basis"`
+}
+
+type taskRunAnalyticsDailyCost struct {
+	Date        string  `json:"date"`
+	CostUsd     float64 `json:"costUsd"`
+	TotalTokens int64   `json:"totalTokens"`
+}
+
+type taskRunAnalyticsDailyCostTotals struct {
+	costUsd     float64
+	totalTokens int64
+}
+
+func (s *Server) handleTaskRunAnalyticsCosts(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		jsonError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	filters, err := parseTaskRunAnalyticsFilters(r)
+	if err != nil {
+		jsonError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	response, err := s.readTaskRunAnalyticsCosts(filters, time.Now().UTC())
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "db error")
+		return
+	}
+	jsonOK(w, response)
+}
+
+func (s *Server) readTaskRunAnalyticsCosts(filters taskRunAnalyticsFilters, now time.Time) (taskRunAnalyticsCostsResponse, error) {
+	today := time.Date(now.UTC().Year(), now.UTC().Month(), now.UTC().Day(), 0, 0, 0, 0, time.UTC)
+	seriesStart := today.AddDate(0, 0, -30)
+	monthStart := time.Date(today.Year(), today.Month(), 1, 0, 0, 0, 0, time.UTC)
+	where := []string{"tenant_id=?", "day >= ?", "day <= ?"}
+	args := []any{filters.TenantID, seriesStart.Format("2006-01-02"), today.Format("2006-01-02")}
+	addTaskRunAnalyticsInFilter(&where, &args, "workspace_name", filters.Workspace)
+	addTaskRunAnalyticsInFilter(&where, &args, "factory_name", filters.Factory)
+	addTaskRunAnalyticsInFilter(&where, &args, "workflow_name", filters.Workflow)
+	addTaskRunAnalyticsInFilter(&where, &args, "model", filters.Model)
+
+	rows, err := s.db.Query(`SELECT day, COALESCE(SUM(cost_usd), 0), COALESCE(SUM(total_tokens), 0) FROM usage_daily WHERE `+strings.Join(where, " AND ")+` GROUP BY day`, args...)
+	if err != nil {
+		return taskRunAnalyticsCostsResponse{}, err
+	}
+	defer rows.Close()
+	byDay := map[string]taskRunAnalyticsDailyCostTotals{}
+	for rows.Next() {
+		var day string
+		var totals taskRunAnalyticsDailyCostTotals
+		if err := rows.Scan(&day, &totals.costUsd, &totals.totalTokens); err != nil {
+			return taskRunAnalyticsCostsResponse{}, err
+		}
+		byDay[day] = totals
+	}
+	if err := rows.Err(); err != nil {
+		return taskRunAnalyticsCostsResponse{}, err
+	}
+
+	response := taskRunAnalyticsCostsResponse{DailySeries: make([]taskRunAnalyticsDailyCost, 0, 31)}
+	for day := seriesStart; !day.After(today); day = day.AddDate(0, 0, 1) {
+		key := day.Format("2006-01-02")
+		totals := byDay[key]
+		response.DailySeries = append(response.DailySeries, taskRunAnalyticsDailyCost{Date: key, CostUsd: totals.costUsd, TotalTokens: totals.totalTokens})
+	}
+	todayTotals := byDay[today.Format("2006-01-02")]
+	yesterdayTotals := byDay[today.AddDate(0, 0, -1).Format("2006-01-02")]
+	response.Today.CostUsd = todayTotals.costUsd
+	response.Today.TotalTokens = todayTotals.totalTokens
+	if yesterdayTotals.costUsd != 0 {
+		delta := (todayTotals.costUsd - yesterdayTotals.costUsd) / yesterdayTotals.costUsd * 100
+		response.Today.DeltaPctVsYesterday = &delta
+	}
+
+	last7Costs := make([]float64, 0, 7)
+	hasProjectionData := false
+	for day := monthStart; !day.After(today); day = day.AddDate(0, 0, 1) {
+		totals, exists := byDay[day.Format("2006-01-02")]
+		response.Month.CostUsd += totals.costUsd
+		hasProjectionData = hasProjectionData || exists
+	}
+	for day := today.AddDate(0, 0, -6); !day.After(today); day = day.AddDate(0, 0, 1) {
+		response.Week.CostUsd += byDay[day.Format("2006-01-02")].costUsd
+	}
+	for day := today.AddDate(0, 0, -7); day.Before(today); day = day.AddDate(0, 0, 1) {
+		totals, exists := byDay[day.Format("2006-01-02")]
+		last7Costs = append(last7Costs, totals.costUsd)
+		hasProjectionData = hasProjectionData || exists
+	}
+	if hasProjectionData {
+		mean := averageTaskRunAnalyticsCosts(last7Costs)
+		daysInMonth := time.Date(today.Year(), today.Month()+1, 0, 0, 0, 0, 0, time.UTC).Day()
+		remainingDays := daysInMonth - today.Day()
+		response.ProjectedMonth = &taskRunAnalyticsProjection{
+			CostUsd:    response.Month.CostUsd + mean*float64(remainingDays),
+			Confidence: taskRunAnalyticsProjectionConfidence(today.Day(), last7Costs, mean),
+			Basis:      "7d-avg",
+		}
+	}
+	return response, nil
+}
+
+func averageTaskRunAnalyticsCosts(costs []float64) float64 {
+	var total float64
+	for _, cost := range costs {
+		total += cost
+	}
+	return total / float64(len(costs))
+}
+
+func taskRunAnalyticsProjectionConfidence(elapsed int, costs []float64, mean float64) string {
+	if elapsed >= 14 && mean != 0 {
+		var variance float64
+		for _, cost := range costs {
+			variance += (cost - mean) * (cost - mean)
+		}
+		if math.Sqrt(variance/float64(len(costs)))/mean < 0.35 {
+			return "high"
+		}
+	}
+	if elapsed >= 7 {
+		return "medium"
+	}
+	return "low"
+}

--- a/pkg/hub/task_run_analytics_costs_api.go
+++ b/pkg/hub/task_run_analytics_costs_api.go
@@ -133,6 +133,9 @@ func (s *Server) readTaskRunAnalyticsCosts(filters taskRunAnalyticsFilters, now 
 }
 
 func averageTaskRunAnalyticsCosts(costs []float64) float64 {
+	if len(costs) == 0 {
+		return 0
+	}
 	var total float64
 	for _, cost := range costs {
 		total += cost

--- a/pkg/hub/task_run_analytics_costs_api_test.go
+++ b/pkg/hub/task_run_analytics_costs_api_test.go
@@ -56,6 +56,7 @@ func TestTaskRunAnalyticsCostsDeltaAndProjection(t *testing.T) {
 		{"low", time.Date(2026, time.July, 3, 0, 0, 0, 0, time.UTC), []float64{10, 10, 10, 10, 10, 10, 10}, "low"},
 		{"medium", time.Date(2026, time.July, 8, 0, 0, 0, 0, time.UTC), []float64{1, 100, 1, 100, 1, 100, 1}, "medium"},
 		{"high", time.Date(2026, time.July, 15, 0, 0, 0, 0, time.UTC), []float64{10, 10, 10, 10, 10, 10, 10}, "high"},
+		{"medium downgrade from high variance", time.Date(2026, time.July, 20, 0, 0, 0, 0, time.UTC), []float64{1, 100, 1, 100, 1, 100, 1}, "medium"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			s, db := newTaskRunAnalyticsAPITestServer(t)

--- a/pkg/hub/task_run_analytics_costs_api_test.go
+++ b/pkg/hub/task_run_analytics_costs_api_test.go
@@ -1,0 +1,111 @@
+package hub
+
+import (
+	"database/sql"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestTaskRunAnalyticsCostsAggregatesFiltersAndTenantScope(t *testing.T) {
+	s, db := newTaskRunAnalyticsAPITestServer(t)
+	now := time.Date(2026, time.July, 15, 12, 0, 0, 0, time.UTC)
+	seedTaskRunAnalyticsUsage(t, db, "test-tenant-id", now, "eng", "gpt-5", 10, 100)
+	seedTaskRunAnalyticsUsage(t, db, "test-tenant-id", now.AddDate(0, 0, -1), "eng", "gpt-5", 5, 50)
+	seedTaskRunAnalyticsUsage(t, db, "test-tenant-id", now.AddDate(0, 0, -5), "eng", "gpt-5", 7, 70)
+	seedTaskRunAnalyticsUsage(t, db, "test-tenant-id", now.AddDate(0, 0, -20), "eng", "gpt-5", 3, 30)
+	seedTaskRunAnalyticsUsage(t, db, "test-tenant-id", now, "other", "gpt-4", 100, 1000)
+	seedTaskRunAnalyticsUsage(t, db, "other-tenant-id", now, "eng", "gpt-5", 1000, 10000)
+
+	response, err := s.readTaskRunAnalyticsCosts(taskRunAnalyticsFilters{TenantID: "test-tenant-id", Workspace: []string{"eng"}, Model: []string{"gpt-5"}}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.Today.CostUsd != 10 || response.Today.TotalTokens != 100 || response.Week.CostUsd != 22 || response.Month.CostUsd != 22 {
+		t.Fatalf("unexpected aggregates: %#v", response)
+	}
+	if response.Today.DeltaPctVsYesterday == nil || *response.Today.DeltaPctVsYesterday != 100 {
+		t.Fatalf("unexpected delta: %#v", response.Today.DeltaPctVsYesterday)
+	}
+	if len(response.DailySeries) != 31 || response.DailySeries[0].Date != "2026-06-15" || response.DailySeries[0].CostUsd != 0 || response.DailySeries[30].CostUsd != 10 {
+		t.Fatalf("unexpected daily series: %#v", response.DailySeries)
+	}
+}
+
+func TestTaskRunAnalyticsCostsDeltaAndProjection(t *testing.T) {
+	t.Run("null delta and no data projection", func(t *testing.T) {
+		s, db := newTaskRunAnalyticsAPITestServer(t)
+		now := time.Date(2026, time.July, 3, 0, 0, 0, 0, time.UTC)
+		response, err := s.readTaskRunAnalyticsCosts(taskRunAnalyticsFilters{TenantID: "test-tenant-id"}, now)
+		if err != nil || response.ProjectedMonth != nil {
+			t.Fatalf("response = %#v, err = %v", response, err)
+		}
+		seedTaskRunAnalyticsUsage(t, db, "test-tenant-id", now, "eng", "gpt-5", 2, 20)
+		response, err = s.readTaskRunAnalyticsCosts(taskRunAnalyticsFilters{TenantID: "test-tenant-id"}, now)
+		if err != nil || response.Today.DeltaPctVsYesterday != nil {
+			t.Fatalf("response = %#v, err = %v", response, err)
+		}
+	})
+	for _, test := range []struct {
+		name  string
+		now   time.Time
+		costs []float64
+		want  string
+	}{
+		{"low", time.Date(2026, time.July, 3, 0, 0, 0, 0, time.UTC), []float64{10, 10, 10, 10, 10, 10, 10}, "low"},
+		{"medium", time.Date(2026, time.July, 8, 0, 0, 0, 0, time.UTC), []float64{1, 100, 1, 100, 1, 100, 1}, "medium"},
+		{"high", time.Date(2026, time.July, 15, 0, 0, 0, 0, time.UTC), []float64{10, 10, 10, 10, 10, 10, 10}, "high"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			s, db := newTaskRunAnalyticsAPITestServer(t)
+			for i, cost := range test.costs {
+				seedTaskRunAnalyticsUsage(t, db, "test-tenant-id", test.now.AddDate(0, 0, -7+i), "eng", "gpt-5", cost, 1)
+			}
+			response, err := s.readTaskRunAnalyticsCosts(taskRunAnalyticsFilters{TenantID: "test-tenant-id"}, test.now)
+			if err != nil || response.ProjectedMonth == nil || response.ProjectedMonth.Confidence != test.want {
+				t.Fatalf("response = %#v, err = %v", response, err)
+			}
+		})
+	}
+}
+
+func TestTaskRunAnalyticsCostsHandler(t *testing.T) {
+	s, db := newTaskRunAnalyticsAPITestServer(t)
+	seedTaskRunAnalyticsUsage(t, db, "test-tenant-id", time.Now().UTC(), "eng", "gpt-5", 12.5, 123)
+	rr := requestTaskRunAnalyticsAPI(t, s, http.MethodGet, "/api/analytics/costs", "test-token")
+	var response taskRunAnalyticsCostsResponse
+	decodeTaskRunAnalyticsAPI(t, rr, &response)
+	if response.Today.CostUsd != 12.5 || response.Today.TotalTokens != 123 {
+		t.Fatalf("unexpected handler response: %#v", response.Today)
+	}
+}
+
+func TestTaskRunAnalyticsRunUsageFields(t *testing.T) {
+	s, db := newTaskRunAnalyticsAPITestServer(t)
+	insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{RunID: "usage", AttemptID: "usage-attempt", ClawID: "usage-claw", TenantID: "test-tenant-id", OwnerType: taskRunOwnerFactory, Workspace: "eng", Factory: "factory", StartedAt: 1, InputTokens: 10, OutputTokens: 20, TotalTokens: 30, EstimatedCostUsd: 1.25, IssueTitle: "Fix the thing"})
+	insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{RunID: "zero", AttemptID: "zero-attempt", ClawID: "zero-claw", TenantID: "test-tenant-id", OwnerType: taskRunOwnerFactory, Workspace: "eng", Factory: "factory", StartedAt: 2})
+	rr := requestTaskRunAnalyticsAPI(t, s, http.MethodGet, "/api/analytics/runs", "test-token")
+	var response taskRunAnalyticsRunsResponse
+	decodeTaskRunAnalyticsAPI(t, rr, &response)
+	if len(response.Runs) != 2 || response.Runs[0].RunID != "zero" || response.Runs[1].InputTokens != 10 || response.Runs[1].OutputTokens != 20 || response.Runs[1].TotalTokens != 30 || response.Runs[1].EstimatedCostUsd != 1.25 || response.Runs[1].IssueTitle != "Fix the thing" {
+		t.Fatalf("unexpected usage fields: %#v", response.Runs)
+	}
+	if strings.Contains(rr.Body.String(), `"inputTokens":0`) || strings.Contains(rr.Body.String(), `"issueTitle":""`) {
+		t.Fatalf("zero usage fields were not omitted: %s", rr.Body.String())
+	}
+	detailRR := requestTaskRunAnalyticsAPI(t, s, http.MethodGet, "/api/analytics/runs/usage", "test-token")
+	var detail taskRunAnalyticsRunDetailResponse
+	decodeTaskRunAnalyticsAPI(t, detailRR, &detail)
+	if detail.Run.TotalTokens != 30 || detail.Run.IssueTitle != "Fix the thing" {
+		t.Fatalf("unexpected detail usage fields: %#v", detail.Run)
+	}
+}
+
+func seedTaskRunAnalyticsUsage(t *testing.T, db *sql.DB, tenant string, day time.Time, workspace, model string, cost float64, tokens int64) {
+	t.Helper()
+	_, err := db.Exec(`INSERT INTO usage_daily(tenant_id, day, workspace_name, factory_name, workflow_name, model, total_tokens, cost_usd, updated_at) VALUES(?,?,?,?,?,?,?,?,?)`, tenant, day.UTC().Format("2006-01-02"), workspace, "factory", "workflow", model, tokens, cost, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## What

PR 2 of Factory Stats v2 — cost aggregation on top of the usage ingestion landed in #500.

- **GET /api/analytics/costs**: new endpoint aggregating `usage_daily` with the same auth, tenant scoping, and shared filter parsing (workspace/factory/workflow/model) as the other analytics endpoints. Returns today (cost, tokens, delta % vs yesterday), last-7-days and month-to-date cost, a 31-day zero-filled daily series, and a month-end projection (`MTD + avg of last 7 complete days × remaining days`, basis `7d-avg`) with confidence tiers: high (≥14 elapsed days and 7d coefficient of variation < 0.35), medium (≥7 elapsed days), else low. `deltaPctVsYesterday` and `projectedMonth` are null when there is no data to compute them. All windows UTC. The `repo` filter is accepted but has no `usage_daily` dimension, so it is ignored for this endpoint.
- **Runs views**: `inputTokens`, `outputTokens`, `totalTokens`, `estimatedCostUsd`, `issueTitle` added to the analytics runs list and run detail responses (omitted when zero/absent).

## Why

Feeds the Factory Stats v2 cost dashboard (PR 3, branch `claude/aiedev-1-cost-ui`) with pre-aggregated cost/token data instead of per-run scans.

Part of [AIEDEV-1](https://linear.app/nimble-la/issue/AIEDEV-1)

## Notes

- Originally planned as a stacked PR on `claude/aiedev-1-usage-ingestion` (PR 1); that branch merged as #500 before this went up, so this PR is based on `main` directly.
- Window/aggregation logic takes an injected clock, so projection math is tested with fixed dates.

## Tests

`go build ./...` and `go test ./pkg/hub -count=1` pass:

```
ok  	github.com/elasticclaw/elasticclaw/pkg/hub	17.277s
```

Covers today/week/month aggregates and series zero-fill, delta null handling, projection math across all three confidence tiers including the high-variance downgrade, filter application, and tenant scoping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)