### PR TITLE
fix(hub): deflake concurrent claw-retry test with immediate transactions

### DIFF
--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -10,7 +10,7 @@ import (
 )
 
 func openDB(path string) (*sql.DB, error) {
-	db, err := sql.Open("sqlite", path+"?_time_format=sqlite&_pragma=journal_mode(WAL)&_pragma=foreign_keys(on)&_pragma=busy_timeout(5000)")
+	db, err := sql.Open("sqlite", path+"?_time_format=sqlite&_txlock=immediate&_pragma=journal_mode(WAL)&_pragma=foreign_keys(on)&_pragma=busy_timeout(5000)")
 	if err != nil {
 		return nil, fmt.Errorf("open db: %w", err)
 	}


### PR DESCRIPTION
## What

Adds `_txlock=immediate` to the SQLite DSN in `pkg/hub/db.go` (`openDB`), so every transaction issues `BEGIN IMMEDIATE` and acquires its write lock up front.

## Why

`TestConcurrentPrepareClawRetryHasSingleWinner` intermittently failed in Depot CI with `prepare retry: database is locked (5) (SQLITE_BUSY)` (observed 2026-07-17 on #502, unrelated to its diff).

Root cause: `prepareClawRetryOnce` opens a **deferred** transaction, runs SELECTs, and only writes later. Under WAL with modernc.org/sqlite, the read snapshot is taken at the first SELECT; if the winning goroutine commits after that, the loser's write-lock upgrade is unwinnable and SQLite returns `SQLITE_BUSY` immediately **without invoking the busy handler** — `busy_timeout(5000)` never applies to this stale-snapshot class of BUSY. Only `prepareClawRetry`'s ~30ms 3-attempt retry loop absorbed the race, which is not enough when the winner's WAL commit is slow on a loaded CI runner.

With `BEGIN IMMEDIATE`, lock acquisition moves to BEGIN, where `busy_timeout` does apply: the losing goroutine blocks until the winner commits, then reads `status='error'` and returns "already handled". Single-winner semantics preserved; the test is untouched.

## Notes for reviewers

- One-line production change; no test changes (assertions not weakened).
- Other `Begin()`/`BeginTx` callers in `pkg/hub` are short write transactions; IMMEDIATE only moves lock acquisition earlier (bounded by `busy_timeout`) and removes the deferred-upgrade failure class. Minor cost: read-mostly transactions now take the WAL write lock — acceptable at the hub's concurrency level.
- Verified: `go test ./pkg/hub -run TestConcurrentPrepareClawRetryHasSingleWinner -count=50` (also `-count=30 -race`), full `go test ./pkg/hub`, `go build ./...`, `go vet ./pkg/hub` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)