### PR TITLE
fix: cost cards vs filter consistency in analytics

### DIFF
--- a/web/components/task-run-analytics-view.tsx
+++ b/web/components/task-run-analytics-view.tsx
@@ -702,7 +702,8 @@ function hasUsageData(run: TaskRunSummary) {
   return run.inputTokens !== undefined || run.outputTokens !== undefined || run.totalTokens !== undefined || run.estimatedCostUsd !== undefined
 }
 
-const filterListFormatter = new Intl.ListFormat(undefined, { style: "long", type: "conjunction" })
+// Pinned to "en" so the conjunction matches the English filter labels and SSR/client output agree.
+const filterListFormatter = new Intl.ListFormat("en", { style: "long", type: "conjunction" })
 
 function formatFilterList(labels: string[]) {
   return filterListFormatter.format(labels)

--- a/web/components/task-run-analytics-view.tsx
+++ b/web/components/task-run-analytics-view.tsx
@@ -128,6 +128,7 @@ export function TaskRunAnalyticsView({ workspaceScope }: { workspaceScope?: stri
   const [error, setError] = useState<string | null>(null)
   const [detailError, setDetailError] = useState<string | null>(null)
   const optionsRef = useRef<TaskRunFilterOptions | null>(null)
+  const loadCancellationRef = useRef<Cancellation | null>(null)
 
   const selectedRun = useMemo(
     () => runs.find((run) => run.runId === selectedRunId) ?? null,
@@ -181,6 +182,7 @@ export function TaskRunAnalyticsView({ workspaceScope }: { workspaceScope?: stri
 
   useEffect(() => {
     const cancellation: Cancellation = { cancelled: false }
+    loadCancellationRef.current = cancellation
     queueMicrotask(() => {
       if (cancellation.cancelled) return
       void load(undefined, false, cancellation)
@@ -475,7 +477,7 @@ export function TaskRunAnalyticsView({ workspaceScope }: { workspaceScope?: stri
           </div>
           {nextCursor && (
             <div className="mt-3 flex justify-center">
-              <Button variant="outline" size="sm" onClick={() => load(nextCursor, true)} disabled={loading}>
+              <Button variant="outline" size="sm" onClick={() => load(nextCursor, true, loadCancellationRef.current ?? undefined)} disabled={loading}>
                 Load more
               </Button>
             </div>

--- a/web/components/task-run-analytics-view.tsx
+++ b/web/components/task-run-analytics-view.tsx
@@ -265,6 +265,17 @@ export function TaskRunAnalyticsView({ workspaceScope }: { workspaceScope?: stri
     [costOverview]
   )
 
+  const ignoredCostFilters = useMemo(() => {
+    const labels: string[] = []
+    if (filters.repo) labels.push("repo")
+    if (filters.status) labels.push("status")
+    if (filters.warningType) labels.push("warning")
+    if (filters.failureType) labels.push("failure")
+    if (filters.humanTouched !== undefined) labels.push("human touched")
+    if (filters.mergedPrs !== undefined) labels.push("merged PRs")
+    return labels
+  }, [filters.repo, filters.status, filters.warningType, filters.failureType, filters.humanTouched, filters.mergedPrs])
+
   const activeKpi = useMemo<KpiFilter | null>(() => {
     if (filters.humanTouched === true) return "humanTouches"
     if (filters.mergedPrs === true) return "mergedPrs"
@@ -293,8 +304,13 @@ export function TaskRunAnalyticsView({ workspaceScope }: { workspaceScope?: stri
             </div>
           </div>
           <div className="flex flex-col gap-2">
-            <h3 className="text-xs font-medium uppercase text-muted-foreground">AI Spend</h3>
-            <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
+            <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+              <h3 className="text-xs font-medium uppercase text-muted-foreground">AI Spend</h3>
+              {ignoredCostFilters.length > 0 && (
+                <span className="text-xs italic text-muted-foreground">Ignores {formatFilterList(ignoredCostFilters)} filters</span>
+              )}
+            </div>
+            <div className={cn("grid gap-2 sm:grid-cols-2 xl:grid-cols-4", ignoredCostFilters.length > 0 && "opacity-75")}>
               <CostCard
                 label="Today's Cost"
                 value={
@@ -682,6 +698,12 @@ function StatusBadge({ status }: { status: string }) {
 
 function hasUsageData(run: TaskRunSummary) {
   return run.inputTokens !== undefined || run.outputTokens !== undefined || run.totalTokens !== undefined || run.estimatedCostUsd !== undefined
+}
+
+const filterListFormatter = new Intl.ListFormat(undefined, { style: "long", type: "conjunction" })
+
+function formatFilterList(labels: string[]) {
+  return filterListFormatter.format(labels)
 }
 
 function formatLabel(value: string) {


### PR DESCRIPTION
## Problem

The AI Spend cost cards are fed by `GET /api/analytics/costs`, which aggregates the `usage_daily` table. That table only has workspace/factory/workflow/model dimension columns, so filters like repo, status, warning, failure, human touched, and merged PRs are silently dropped by the cost cards — while the runs table and the adjacent General Stats section apply the full filter set. Two card groups side by side responded differently to the same filters, with no indication.

## Approach: Option A (UI honesty)

When any filter outside {workspace, factory, workflow, model} is active, the AI Spend section shows a subtle caption ("Ignores repo and status filters", listing the actually-active ignored filters) and slightly de-emphasizes the cost cards. The request still sends the full filter set; the backend keeps applying the supported subset.

Option B (recomputing cost aggregates per-run from `task_run_summaries` with the full filter WHERE) was considered and rejected: it would change day bucketing from spend-day to run attribution — a run's whole cost lands on one day regardless of when the spend occurred — which silently changes the meaning of the daily chart and the today/week/month figures. Not a cheap correct path.

## Also fixed

- **Load more staleness**: the append path called `load(nextCursor, true)` without a cancellation token, so a stale append after a filter change could mix old-filter rows into the new result set. It now receives the current cancellation via a ref kept in sync by the existing load effect, mirroring the main load path.
- Pinned the filter-list `Intl.ListFormat` to `en` so the conjunction matches the English labels and SSR/client output agree (avoids a hydration mismatch under non-English locales).

Verified with `npm run build` (clean). Reviewed independently by two agents (approved). No screenshots — the dashboard needs a populated hub backend to render meaningful state.

Note: a parallel task adds a Duration column to the runs table in this file; changes here are scoped to the AI Spend section and the load-more handler to minimize conflicts.

Part of [AIEDEV-1](https://linear.app/nimble-la/issue/AIEDEV-1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)