### PR TITLE
fix: treat gateway usage snapshots as per-run totals, not cumulative

### DIFF
--- a/pkg/hub/task_run_usage.go
+++ b/pkg/hub/task_run_usage.go
@@ -73,14 +73,14 @@ func (s *Server) recordTaskRunUsage(clawID string, snapshot taskRunUsageSnapshot
 			dcost = cost.Float64
 			comCost += dcost
 		}
-	} else if cost.Valid && (!oldCost.Valid || cost.Float64 != oldCost.Float64) {
+	} else if cost.Valid && (!oldCost.Valid || cost.Float64 != oldCost.Float64) && !(oldSource == "gateway" && source == "hub_pricing") {
 		// A real gateway cost can replace a hub estimate for the same run.
 		dcost = cost.Float64
 		if oldCost.Valid {
 			dcost -= oldCost.Float64
 		}
 		comCost += dcost
-	} else if !cost.Valid {
+	} else if !cost.Valid || (oldSource == "gateway" && source == "hub_pricing") {
 		cost = oldCost
 		source = oldSource
 	}

--- a/pkg/hub/task_run_usage.go
+++ b/pkg/hub/task_run_usage.go
@@ -36,6 +36,7 @@ func (s *Server) recordTaskRunUsage(clawID string, snapshot taskRunUsageSnapshot
 	var comCost float64
 	oldSource := "gateway"
 	err = tx.QueryRow(`SELECT input_tokens,output_tokens,total_tokens,committed_input_tokens,committed_output_tokens,committed_total_tokens,committed_cost_usd,estimated_cost_usd,cost_source FROM task_run_usage WHERE tenant_id=? AND run_id=? AND session_key=?`, tenant, runID, snapshot.SessionKey).Scan(&oldIn, &oldOut, &oldTotal, &comIn, &comOut, &comTotal, &comCost, &oldCost, &oldSource)
+	found := err == nil
 	if err != nil && err != sql.ErrNoRows {
 		return err
 	}
@@ -49,47 +50,39 @@ func (s *Server) recordTaskRunUsage(clawID string, snapshot taskRunUsageSnapshot
 	if snapshot.TotalTokens != nil {
 		total = *snapshot.TotalTokens
 	}
-	// A drop in any cumulative counter means the gateway reset the session
-	// stats; treat the whole snapshot as a fresh baseline and fold the
-	// pre-reset totals into the committed_* columns so run summaries keep
-	// counting them.
-	reset := in < oldIn || out < oldOut || total < oldTotal
-	din, dout, dtotal := in-oldIn, out-oldOut, total-oldTotal
-	if reset {
-		din, dout, dtotal = in, out, total
-		comIn += oldIn
-		comOut += oldOut
-		comTotal += oldTotal
-		if oldCost.Valid {
-			comCost += oldCost.Float64
-			oldCost = sql.NullFloat64{}
-		}
-	}
 	var cost sql.NullFloat64
 	source := oldSource
 	if snapshot.EstimatedCostUSD != nil {
 		cost = sql.NullFloat64{Float64: *snapshot.EstimatedCostUSD, Valid: true}
 		source = "gateway"
 	} else if estimated, ok := taskRunPrice(tx, snapshot.Model, in, out); ok {
-		// The gateway did not report a cost (older gateway / empty pricing
-		// cache); estimate the cumulative cost from the cumulative tokens so
-		// the estimate keeps growing across heartbeats.
+		// The gateway did not report a cost; estimate this run from its tokens.
 		cost = sql.NullFloat64{Float64: estimated, Valid: true}
 		source = "hub_pricing"
 	}
-	dcost := 0.0
-	if cost.Valid {
-		if reset || !oldCost.Valid {
+	// OpenClaw overwrites a session entry after each reply with that run's
+	// totals. total_tokens is context occupancy, not billed token usage.
+	newRun := !found || in != oldIn || out != oldOut
+	din, dout, dtotal, dcost := 0, 0, 0, 0.0
+	if newRun {
+		din, dout, dtotal = in, out, in+out
+		comIn += in
+		comOut += out
+		comTotal += in + out
+		if cost.Valid {
 			dcost = cost.Float64
-		} else {
-			// Signed delta: when a real (lower) gateway cost replaces a prior
-			// hub_pricing estimate the negative correction converges
-			// usage_daily to the true cumulative cost. Cost resets only
-			// happen together with token resets, which the reset flag covers.
-			dcost = cost.Float64 - oldCost.Float64
+			comCost += dcost
 		}
-	} else {
+	} else if cost.Valid && (!oldCost.Valid || cost.Float64 != oldCost.Float64) {
+		// A real gateway cost can replace a hub estimate for the same run.
+		dcost = cost.Float64
+		if oldCost.Valid {
+			dcost -= oldCost.Float64
+		}
+		comCost += dcost
+	} else if !cost.Valid {
 		cost = oldCost
+		source = oldSource
 	}
 	ts := now().UnixMilli()
 	_, err = tx.Exec(`INSERT INTO task_run_usage(id,tenant_id,run_id,session_key,model,model_provider,input_tokens,output_tokens,total_tokens,committed_input_tokens,committed_output_tokens,committed_total_tokens,committed_cost_usd,estimated_cost_usd,cost_source,first_seen_at,updated_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?) ON CONFLICT(tenant_id,run_id,session_key) DO UPDATE SET model=excluded.model,model_provider=excluded.model_provider,input_tokens=excluded.input_tokens,output_tokens=excluded.output_tokens,total_tokens=excluded.total_tokens,committed_input_tokens=excluded.committed_input_tokens,committed_output_tokens=excluded.committed_output_tokens,committed_total_tokens=excluded.committed_total_tokens,committed_cost_usd=excluded.committed_cost_usd,estimated_cost_usd=excluded.estimated_cost_usd,cost_source=excluded.cost_source,updated_at=excluded.updated_at`, uuid.NewString(), tenant, runID, snapshot.SessionKey, snapshot.Model, snapshot.ModelProvider, in, out, total, comIn, comOut, comTotal, comCost, nullFloat(cost), source, ts, ts)
@@ -104,7 +97,7 @@ func (s *Server) recordTaskRunUsage(clawID string, snapshot taskRunUsageSnapshot
 	if err != nil {
 		return err
 	}
-	_, err = tx.Exec(`UPDATE task_run_summaries SET input_tokens=(SELECT COALESCE(SUM(input_tokens+committed_input_tokens),0) FROM task_run_usage WHERE tenant_id=? AND run_id=?),output_tokens=(SELECT COALESCE(SUM(output_tokens+committed_output_tokens),0) FROM task_run_usage WHERE tenant_id=? AND run_id=?),total_tokens=(SELECT COALESCE(SUM(total_tokens+committed_total_tokens),0) FROM task_run_usage WHERE tenant_id=? AND run_id=?),estimated_cost_usd=(SELECT COALESCE(SUM(COALESCE(estimated_cost_usd,0)+committed_cost_usd),0) FROM task_run_usage WHERE tenant_id=? AND run_id=?),usage_updated_at=? WHERE tenant_id=? AND run_id=?`, tenant, runID, tenant, runID, tenant, runID, tenant, runID, ts, tenant, runID)
+	_, err = tx.Exec(`UPDATE task_run_summaries SET input_tokens=(SELECT COALESCE(SUM(committed_input_tokens),0) FROM task_run_usage WHERE tenant_id=? AND run_id=?),output_tokens=(SELECT COALESCE(SUM(committed_output_tokens),0) FROM task_run_usage WHERE tenant_id=? AND run_id=?),total_tokens=(SELECT COALESCE(SUM(committed_total_tokens),0) FROM task_run_usage WHERE tenant_id=? AND run_id=?),estimated_cost_usd=(SELECT COALESCE(SUM(committed_cost_usd),0) FROM task_run_usage WHERE tenant_id=? AND run_id=?),usage_updated_at=? WHERE tenant_id=? AND run_id=?`, tenant, runID, tenant, runID, tenant, runID, tenant, runID, ts, tenant, runID)
 	if err != nil {
 		return err
 	}
@@ -118,8 +111,8 @@ func nullFloat(v sql.NullFloat64) interface{} {
 	return nil
 }
 
-// taskRunPrice estimates the cumulative cost of a session from cumulative
-// token counts using the seeded model_prices table. Gateway model ids are
+// taskRunPrice estimates a run's cost from its token counts using the seeded
+// model_prices table. Gateway model ids are
 // matched loosely: lowercased, provider prefixes stripped, and the longest
 // seeded model name that prefixes the id wins.
 func taskRunPrice(tx *sql.Tx, model string, in, out int) (float64, bool) {

--- a/pkg/hub/task_run_usage_test.go
+++ b/pkg/hub/task_run_usage_test.go
@@ -3,6 +3,7 @@ package hub
 import (
 	"context"
 	"database/sql"
+	"math"
 	"path/filepath"
 	"testing"
 	"time"
@@ -74,9 +75,13 @@ func TestTaskRunUsageRecordsEachRunAndIgnoresContextTotal(t *testing.T) {
 	if initialIn != 60_000 || initialOut != 3_000 || initialCost != 0.25 {
 		t.Fatalf("first two runs = %d/%d cost=%v, want 60000/3000 cost=0.25", initialIn, initialOut, initialCost)
 	}
-	run3 := usageSnapshot("a", 5_000, 500, 123_456, "claude-sonnet-5")
-	run3.EstimatedCostUSD = ptr(0.01)
-	for _, snap := range []taskRunUsageSnapshot{run3, usageSnapshot("b", 3_000, 300, 42, "claude-sonnet-5")} {
+	// This run's raw total grows from run2's 7, but it is still a distinct
+	// per-reply total rather than a cumulative counter.
+	run3 := usageSnapshot("a", 60_000, 2_500, 60_000, "claude-sonnet-5")
+	run3.EstimatedCostUSD = ptr(0.30)
+	run4 := usageSnapshot("a", 5_000, 500, 123_456, "claude-sonnet-5")
+	run4.EstimatedCostUSD = ptr(0.01)
+	for _, snap := range []taskRunUsageSnapshot{run3, run4, usageSnapshot("b", 3_000, 300, 42, "claude-sonnet-5")} {
 		if err := s.recordTaskRunUsage(claw, snap); err != nil {
 			t.Fatal(err)
 		}
@@ -88,11 +93,12 @@ func TestTaskRunUsageRecordsEachRunAndIgnoresContextTotal(t *testing.T) {
 	}
 	// Each changed input/output snapshot is a complete run. Raw total_tokens
 	// is context occupancy and is deliberately absent from these sums.
-	if in != 68_000 || out != 3_800 || total != 71_800 {
-		t.Fatalf("summary = %d/%d/%d, want 68000/3800/71800", in, out, total)
+	if in != 128_000 || out != 6_300 || total != 134_300 {
+		t.Fatalf("summary = %d/%d/%d, want 128000/6300/134300", in, out, total)
 	}
-	if cost <= 0.26 { // includes $0.25 gateway costs plus priced session b
-		t.Fatalf("expected accumulated cost, got %v", cost)
+	const wantCost = 0.5735 // $0.56 gateway costs + $0.0135 hub pricing for session b.
+	if math.Abs(cost-wantCost) > 1e-9 {
+		t.Fatalf("summary cost = %v, want %v", cost, wantCost)
 	}
 	var rows int
 	if err := db.QueryRow(`SELECT count(*) FROM task_run_usage`).Scan(&rows); err != nil {
@@ -101,9 +107,12 @@ func TestTaskRunUsageRecordsEachRunAndIgnoresContextTotal(t *testing.T) {
 	if rows != 2 {
 		t.Fatalf("usage rows=%d, want 2", rows)
 	}
-	din, dout, dtotal, _ := queryUsageDaily(t, db)
-	if din != 68_000 || dout != 3_800 || dtotal != 71_800 {
-		t.Fatalf("usage_daily = %d/%d/%d, want 68000/3800/71800", din, dout, dtotal)
+	din, dout, dtotal, dailyCost := queryUsageDaily(t, db)
+	if din != 128_000 || dout != 6_300 || dtotal != 134_300 {
+		t.Fatalf("usage_daily = %d/%d/%d, want 128000/6300/134300", din, dout, dtotal)
+	}
+	if math.Abs(dailyCost-wantCost) > 1e-9 {
+		t.Fatalf("usage_daily cost = %v, want %v", dailyCost, wantCost)
 	}
 }
 
@@ -131,6 +140,21 @@ func TestTaskRunUsageGatewayCostCorrectsSameRunEstimate(t *testing.T) {
 	}
 	if source != "gateway" {
 		t.Fatalf("cost_source = %q, want gateway", source)
+	}
+	if err := s.recordTaskRunUsage(claw, usageSnapshot("a", 1_000_000, 1_000_000, 10, model)); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT estimated_cost_usd,cost_source FROM task_run_usage WHERE session_key='a'`).Scan(&cost, &source); err != nil {
+		t.Fatal(err)
+	}
+	if cost != 3 || source != "gateway" {
+		t.Fatalf("omitted-cost heartbeat changed stored cost to %v/%q, want 3/gateway", cost, source)
+	}
+	if err := db.QueryRow(`SELECT estimated_cost_usd FROM task_run_summaries WHERE run_id='run-usage'`).Scan(&cost); err != nil {
+		t.Fatal(err)
+	}
+	if cost != 3 {
+		t.Fatalf("summary cost = %v, want 3", cost)
 	}
 	_, _, _, dailyCost := queryUsageDaily(t, db)
 	if dailyCost != 3 {

--- a/pkg/hub/task_run_usage_test.go
+++ b/pkg/hub/task_run_usage_test.go
@@ -97,7 +97,7 @@ func TestTaskRunUsageRecordsEachRunAndIgnoresContextTotal(t *testing.T) {
 		t.Fatalf("summary = %d/%d/%d, want 128000/6300/134300", in, out, total)
 	}
 	const wantCost = 0.5735 // $0.56 gateway costs + $0.0135 hub pricing for session b.
-	if math.Abs(cost-wantCost) > 1e-9 {
+	if math.Abs(cost-wantCost) > 1e-6 {
 		t.Fatalf("summary cost = %v, want %v", cost, wantCost)
 	}
 	var rows int
@@ -111,7 +111,7 @@ func TestTaskRunUsageRecordsEachRunAndIgnoresContextTotal(t *testing.T) {
 	if din != 128_000 || dout != 6_300 || dtotal != 134_300 {
 		t.Fatalf("usage_daily = %d/%d/%d, want 128000/6300/134300", din, dout, dtotal)
 	}
-	if math.Abs(dailyCost-wantCost) > 1e-9 {
+	if math.Abs(dailyCost-wantCost) > 1e-6 {
 		t.Fatalf("usage_daily cost = %v, want %v", dailyCost, wantCost)
 	}
 }

--- a/pkg/hub/task_run_usage_test.go
+++ b/pkg/hub/task_run_usage_test.go
@@ -54,15 +54,29 @@ func queryUsageDaily(t *testing.T, db *sql.DB) (in, out, total int, cost float64
 	return
 }
 
-func TestTaskRunUsageSnapshotsAndReset(t *testing.T) {
+func TestTaskRunUsageRecordsEachRunAndIgnoresContextTotal(t *testing.T) {
 	s, db, claw := newUsageTestServer(t)
 	defer db.Close()
-	for _, snap := range []taskRunUsageSnapshot{
-		usageSnapshot("a", 10, 5, 15, "claude-sonnet-5"),
-		usageSnapshot("a", 10, 5, 15, "claude-sonnet-5"), // idempotent re-delivery: no delta
-		usageSnapshot("b", 3, 2, 5, "claude-sonnet-5"),
-		usageSnapshot("a", 2, 1, 3, "claude-sonnet-5"), // gateway reset: new values become the delta
-	} {
+	run1 := usageSnapshot("a", 10_000, 1_000, 99_999, "claude-sonnet-5")
+	run1.EstimatedCostUSD = ptr(0.05)
+	run2 := usageSnapshot("a", 50_000, 2_000, 7, "claude-sonnet-5")
+	run2.EstimatedCostUSD = ptr(0.20)
+	for _, snap := range []taskRunUsageSnapshot{run1, run1, run2} { // repeated heartbeat
+		if err := s.recordTaskRunUsage(claw, snap); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var initialIn, initialOut int
+	var initialCost float64
+	if err := db.QueryRow(`SELECT input_tokens,output_tokens,estimated_cost_usd FROM task_run_summaries WHERE run_id='run-usage'`).Scan(&initialIn, &initialOut, &initialCost); err != nil {
+		t.Fatal(err)
+	}
+	if initialIn != 60_000 || initialOut != 3_000 || initialCost != 0.25 {
+		t.Fatalf("first two runs = %d/%d cost=%v, want 60000/3000 cost=0.25", initialIn, initialOut, initialCost)
+	}
+	run3 := usageSnapshot("a", 5_000, 500, 123_456, "claude-sonnet-5")
+	run3.EstimatedCostUSD = ptr(0.01)
+	for _, snap := range []taskRunUsageSnapshot{run3, usageSnapshot("b", 3_000, 300, 42, "claude-sonnet-5")} {
 		if err := s.recordTaskRunUsage(claw, snap); err != nil {
 			t.Fatal(err)
 		}
@@ -72,13 +86,13 @@ func TestTaskRunUsageSnapshotsAndReset(t *testing.T) {
 	if err := db.QueryRow(`SELECT input_tokens,output_tokens,total_tokens,estimated_cost_usd FROM task_run_summaries WHERE run_id='run-usage'`).Scan(&in, &out, &total, &cost); err != nil {
 		t.Fatal(err)
 	}
-	// Summary keeps pre-reset usage: session a = 10/5/15 committed + 2/1/3
-	// current, session b = 3/2/5.
-	if in != 15 || out != 8 || total != 23 {
-		t.Fatalf("summary = %d/%d/%d, want 15/8/23", in, out, total)
+	// Each changed input/output snapshot is a complete run. Raw total_tokens
+	// is context occupancy and is deliberately absent from these sums.
+	if in != 68_000 || out != 3_800 || total != 71_800 {
+		t.Fatalf("summary = %d/%d/%d, want 68000/3800/71800", in, out, total)
 	}
-	if cost <= 0 {
-		t.Fatalf("expected pricing fallback cost, got %v", cost)
+	if cost <= 0.26 { // includes $0.25 gateway costs plus priced session b
+		t.Fatalf("expected accumulated cost, got %v", cost)
 	}
 	var rows int
 	if err := db.QueryRow(`SELECT count(*) FROM task_run_usage`).Scan(&rows); err != nil {
@@ -87,85 +101,40 @@ func TestTaskRunUsageSnapshotsAndReset(t *testing.T) {
 	if rows != 2 {
 		t.Fatalf("usage rows=%d, want 2", rows)
 	}
-	// usage_daily accumulates deltas: 10/5/15 + 0 (idempotent) + 3/2/5 + 2/1/3 (reset).
 	din, dout, dtotal, _ := queryUsageDaily(t, db)
-	if din != 15 || dout != 8 || dtotal != 23 {
-		t.Fatalf("usage_daily = %d/%d/%d, want 15/8/23", din, dout, dtotal)
+	if din != 68_000 || dout != 3_800 || dtotal != 71_800 {
+		t.Fatalf("usage_daily = %d/%d/%d, want 68000/3800/71800", din, dout, dtotal)
 	}
 }
 
-func TestTaskRunUsagePartialResetTreatedAsFullReset(t *testing.T) {
+func TestTaskRunUsageGatewayCostCorrectsSameRunEstimate(t *testing.T) {
 	s, db, claw := newUsageTestServer(t)
 	defer db.Close()
-	if err := s.recordTaskRunUsage(claw, usageSnapshot("a", 10, 5, 15, "claude-sonnet-5")); err != nil {
-		t.Fatal(err)
-	}
-	// input drops (reset) but output is higher than before: the whole snapshot
-	// must be treated as a fresh baseline, not mixed per-field deltas.
-	if err := s.recordTaskRunUsage(claw, usageSnapshot("a", 4, 9, 13, "claude-sonnet-5")); err != nil {
-		t.Fatal(err)
-	}
-	din, dout, dtotal, _ := queryUsageDaily(t, db)
-	if din != 14 || dout != 14 || dtotal != 28 {
-		t.Fatalf("usage_daily = %d/%d/%d, want 14/14/28", din, dout, dtotal)
-	}
-}
-
-func TestTaskRunUsagePricingFallbackKeepsGrowing(t *testing.T) {
-	s, db, claw := newUsageTestServer(t)
-	defer db.Close()
-	// Provider-qualified gateway model id must still match the seeded price.
 	const model = "anthropic/claude-sonnet-5-20260203"
 	if err := s.recordTaskRunUsage(claw, usageSnapshot("a", 1_000_000, 1_000_000, 2_000_000, model)); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.recordTaskRunUsage(claw, usageSnapshot("a", 2_000_000, 2_000_000, 4_000_000, model)); err != nil {
-		t.Fatal(err)
-	}
-	var cost float64
-	var source string
-	if err := db.QueryRow(`SELECT estimated_cost_usd,cost_source FROM task_run_usage WHERE session_key='a'`).Scan(&cost, &source); err != nil {
-		t.Fatal(err)
-	}
-	// claude-sonnet-5 is $3/$15 per MTok: 2 MTok in + 2 MTok out = $36.
-	if cost < 35.99 || cost > 36.01 {
-		t.Fatalf("cumulative estimated cost = %v, want ~36 (estimate must keep growing)", cost)
-	}
-	if source != "hub_pricing" {
-		t.Fatalf("cost_source = %q, want hub_pricing", source)
-	}
-	_, _, _, dailyCost := queryUsageDaily(t, db)
-	if dailyCost < 35.99 || dailyCost > 36.01 {
-		t.Fatalf("usage_daily cost = %v, want ~36", dailyCost)
-	}
-}
-
-func TestTaskRunUsageGatewayCostCorrectsHubEstimate(t *testing.T) {
-	s, db, claw := newUsageTestServer(t)
-	defer db.Close()
-	// HB1: gateway omits cost, hub_pricing estimates $18 (1 MTok in + 1 MTok
-	// out on claude-sonnet-5).
-	if err := s.recordTaskRunUsage(claw, usageSnapshot("a", 1_000_000, 1_000_000, 2_000_000, "claude-sonnet-5")); err != nil {
-		t.Fatal(err)
-	}
-	// HB2: gateway reports the real cumulative cost, lower than the estimate
-	// (cache discounts). usage_daily must converge to it, not add it on top.
-	snap := usageSnapshot("a", 1_100_000, 1_100_000, 2_200_000, "claude-sonnet-5")
+	snap := usageSnapshot("a", 1_000_000, 1_000_000, 9, model)
 	snap.EstimatedCostUSD = ptr(3.0)
 	if err := s.recordTaskRunUsage(claw, snap); err != nil {
 		t.Fatal(err)
 	}
-	_, _, _, dailyCost := queryUsageDaily(t, db)
-	if dailyCost < 2.99 || dailyCost > 3.01 {
-		t.Fatalf("usage_daily cost = %v, want ~3 (negative correction must apply)", dailyCost)
-	}
 	var cost float64
 	var source string
 	if err := db.QueryRow(`SELECT estimated_cost_usd,cost_source FROM task_run_usage WHERE session_key='a'`).Scan(&cost, &source); err != nil {
 		t.Fatal(err)
 	}
-	if cost != 3.0 || source != "gateway" {
-		t.Fatalf("snapshot cost=%v source=%q, want 3.0/gateway", cost, source)
+	// claude-sonnet-5 prices the omitted-cost run at $18, then the gateway
+	// correction replaces rather than adds to that amount.
+	if cost != 3 {
+		t.Fatalf("estimated cost = %v, want 3", cost)
+	}
+	if source != "gateway" {
+		t.Fatalf("cost_source = %q, want gateway", source)
+	}
+	_, _, _, dailyCost := queryUsageDaily(t, db)
+	if dailyCost != 3 {
+		t.Fatalf("usage_daily cost = %v, want 3", dailyCost)
 	}
 }
 


### PR DESCRIPTION
## Problem

`recordTaskRunUsage` assumed the per-session usage snapshot in bridge heartbeats (`input_tokens`, `output_tokens`, `total_tokens`, `estimated_cost_usd`) was **cumulative** per gateway session, accumulating per-heartbeat deltas and treating any counter drop as a "session reset" (folding the old snapshot into `committed_*` and taking the new value as the delta).

That premise is wrong. In OpenClaw v2026.6.9 (the pinned version), the session entry's `inputTokens`/`outputTokens`/`estimatedCostUsd` are **overwritten after each reply run with that run's totals** (`src/auto-reply/reply/session-usage.ts` — `patch.inputTokens = params.usage?.input ?? 0`; cost is a per-run snapshot since openclaw fix #69347, "snapshot instead of accumulating"). And `totalTokens` is **current context occupancy** (the bridge uses it for context %), not billed tokens.

Consequences: whenever a new run's counters were all ≥ the previous run's, only the inter-run difference was recorded — a systematic undercount in `usage_daily` and `task_run_summaries`. Only when a counter dropped did the reset branch accidentally record the full run.

## Fix

- Each **changed** snapshot (input or output tokens differ from the stored one for that `(tenant, run_id, session_key)`) is treated as a new run's totals: the full values are added to `usage_daily` and to the run's `committed_*` accumulation. Identical snapshots (heartbeats repeat between runs) contribute delta 0.
- `total_tokens` (context occupancy) is no longer summed as billed tokens: `usage_daily.total_tokens` and `task_run_summaries.total_tokens` now accumulate `input + output`; the raw snapshot is still stored on `task_run_usage` for observability.
- `task_run_summaries` totals are now `SUM(committed_*)` only — the current snapshot no longer represents an unfinished cumulative tail.
- Cost is per run: gateway cost when reported, otherwise a `hub_pricing` estimate from that run's tokens. When a gateway cost arrives later for the same run (tokens unchanged), it corrects the stored estimate (signed delta, `usage_daily` still clamped at ≥ 0); a `hub_pricing` estimate never downgrades a stored gateway cost.
- The reset branch is gone — subsumed by change detection.

Rows written under the old semantics stay as-is; no historical migration — numbers are correct going forward.

## Tests

`pkg/hub/task_run_usage_test.go` rewritten with per-run fixtures: repeated heartbeats (no double count), larger and smaller subsequent runs (both added in full), raw `total_tokens` wildly different from `input+output` (proves it is ignored), new `session_key` mid-run, `hub_pricing` fallback converging to a later gateway cost, cross-day negative correction clamping at zero, exact cost sums.

```
go build ./...
ok  github.com/elasticclaw/elasticclaw/pkg/hub        17.5s
ok  github.com/elasticclaw/elasticclaw/cmd/claw-bridge 0.9s
```

Part of [AIEDEV-1](https://linear.app/nimble-la/issue/AIEDEV-1)

Note: a separate cleanup task will address smaller issues in this file; this PR is focused on the semantics change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)