### PR TITLE
fix: persist issue creation time for workflow-triggered runs

### DIFF
--- a/pkg/hub/github_issues.go
+++ b/pkg/hub/github_issues.go
@@ -30,6 +30,7 @@ type githubIssuesWebhookPayload struct {
 		Title       string `json:"title"`
 		Body        string `json:"body"`
 		HTMLURL     string `json:"html_url"`
+		CreatedAt   string `json:"created_at"`
 		State       string `json:"state"`                  // "open", "closed"
 		StateReason string `json:"state_reason,omitempty"` // "completed", "not_planned", "reopened"
 		Labels      []struct {
@@ -506,6 +507,7 @@ func assignedToMatches(filter, assignee string) bool {
 
 func (s *Server) createClawForGitHubIssueWorkflow(workspace *types.WorkspaceConfig, workflow *types.WorkflowConfig, payload githubIssuesWebhookPayload, reason string) (string, bool, error) {
 	issueID := fmt.Sprintf("%s/%d", payload.Repository.FullName, payload.Issue.Number)
+	issueCreatedAt := parseRFC3339Timestamp(payload.Issue.CreatedAt)
 	var existing string
 	_ = s.db.QueryRow(`SELECT id FROM claws WHERE github_issue_id=? AND status NOT IN ('error','deleted') LIMIT 1`, issueID).Scan(&existing)
 	if existing != "" {
@@ -550,6 +552,7 @@ func (s *Server) createClawForGitHubIssueWorkflow(workspace *types.WorkspaceConf
 		workspaceFiles:       templateFiles,
 		clawName:             clawName,
 		githubIssueID:        issueID,
+		issueCreatedAt:       issueCreatedAt,
 		issueLabels:          githubIssuePayloadLabels(payload),
 		issueLabelsAvailable: true,
 		reason:               reason,

--- a/pkg/hub/integration_poller.go
+++ b/pkg/hub/integration_poller.go
@@ -324,6 +324,7 @@ func (s *Server) queryLinearIssues(token, since string) ([]linearPollIssue, erro
 						Title       string `json:"title"`
 						Description string `json:"description"`
 						URL         string `json:"url"`
+						CreatedAt   string `json:"createdAt"`
 						UpdatedAt   string `json:"updatedAt"`
 						State       struct {
 							Name string `json:"name"`
@@ -364,6 +365,7 @@ func (s *Server) queryLinearIssues(token, since string) ([]linearPollIssue, erro
 				Title:       n.Title,
 				Description: n.Description,
 				URL:         n.URL,
+				CreatedAt:   n.CreatedAt,
 				UpdatedAt:   n.UpdatedAt,
 				State:       n.State,
 				Team:        n.Team,
@@ -929,6 +931,7 @@ type githubIssuesPollItem struct {
 	Body      string `json:"body"`
 	HTMLURL   string `json:"html_url"`
 	State     string `json:"state"`
+	CreatedAt string `json:"created_at"`
 	UpdatedAt string `json:"updated_at"`
 	Labels    []struct {
 		Name string `json:"name"`
@@ -1302,6 +1305,7 @@ func buildGitHubIssuesPollPayloadForAction(issue githubIssuesPollItem, repo, act
 	payload.Issue.Body = issue.Body
 	payload.Issue.HTMLURL = issue.HTMLURL
 	payload.Issue.State = issue.State
+	payload.Issue.CreatedAt = issue.CreatedAt
 	payload.Issue.User.Login = issue.User.Login
 	for _, l := range issue.Labels {
 		label := struct {

--- a/pkg/hub/integration_poller.go
+++ b/pkg/hub/integration_poller.go
@@ -252,6 +252,7 @@ type linearPollIssue struct {
 	Title       string `json:"title"`
 	Description string `json:"description"`
 	URL         string `json:"url"`
+	CreatedAt   string `json:"createdAt"`
 	UpdatedAt   string `json:"updatedAt"`
 	State       struct {
 		Name string `json:"name"`
@@ -282,6 +283,7 @@ func (s *Server) queryLinearIssues(token, since string) ([]linearPollIssue, erro
 				title
 				description
 				url
+				createdAt
 				updatedAt
 				state { name }
 				team { key name }
@@ -490,6 +492,7 @@ func (s *Server) buildLinearPollPayload(issue linearPollIssue) linearWebhookPayl
 	payload.Data.Title = issue.Title
 	payload.Data.Description = issue.Description
 	payload.Data.URL = issue.URL
+	payload.Data.CreatedAt = issue.CreatedAt
 	payload.Data.State.Name = issue.State.Name
 	payload.Data.Team.Key = issue.Team.Key
 	payload.Data.Team.Name = issue.Team.Name

--- a/pkg/hub/integration_poller_pagination_test.go
+++ b/pkg/hub/integration_poller_pagination_test.go
@@ -21,7 +21,7 @@ func TestQueryLinearIssuesPaginatesWithCursorVariable(t *testing.T) {
 		}
 		cursors = append(cursors, request.Variables["after"])
 		if request.Variables["after"] == nil {
-			_, _ = w.Write([]byte(`{"data":{"issues":{"nodes":[{"id":"1","identifier":"ELA-1","title":"one","state":{"name":"Todo"},"team":{"key":"ELA"}}],"pageInfo":{"hasNextPage":true,"endCursor":"cursor-1"}}}}`))
+			_, _ = w.Write([]byte(`{"data":{"issues":{"nodes":[{"id":"1","identifier":"ELA-1","title":"one","createdAt":"2026-07-01T10:00:00.000Z","state":{"name":"Todo"},"team":{"key":"ELA"}}],"pageInfo":{"hasNextPage":true,"endCursor":"cursor-1"}}}}`))
 			return
 		}
 		_, _ = w.Write([]byte(`{"data":{"issues":{"nodes":[{"id":"2","identifier":"ELA-2","title":"two","state":{"name":"Todo"},"team":{"key":"ELA"}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`))
@@ -35,6 +35,9 @@ func TestQueryLinearIssuesPaginatesWithCursorVariable(t *testing.T) {
 	}
 	if len(issues) != 2 || issues[0].Identifier != "ELA-1" || issues[1].Identifier != "ELA-2" {
 		t.Fatalf("issues = %#v", issues)
+	}
+	if issues[0].CreatedAt != "2026-07-01T10:00:00.000Z" {
+		t.Fatalf("issues[0].CreatedAt = %q, want createdAt propagated from GraphQL response", issues[0].CreatedAt)
 	}
 	if len(cursors) != 2 || cursors[0] != nil || cursors[1] != "cursor-1" {
 		t.Fatalf("cursor variables = %#v", cursors)

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -27,6 +27,7 @@ type linearWebhookPayload struct {
 	CreatedAt string `json:"createdAt"` // ISO 8601 timestamp of the webhook event
 	Data      struct {
 		ID          string `json:"id"`
+		CreatedAt   string `json:"createdAt"`
 		Identifier  string `json:"identifier"` // e.g. "ELA-123"
 		Title       string `json:"title"`
 		Description string `json:"description"`
@@ -423,6 +424,7 @@ func (s *Server) notifyLinearWorkflowCreateFailure(workspace *types.WorkspaceCon
 
 func (s *Server) createClawForLinearWorkflow(workspace *types.WorkspaceConfig, workflow *types.WorkflowConfig, payload linearWebhookPayload, reason string) error {
 	issueID := payload.Data.Identifier
+	issueCreatedAt := parseRFC3339Timestamp(payload.Data.CreatedAt)
 	var existing string
 	_ = s.db.QueryRow(`SELECT id FROM claws WHERE linear_issue_id=? AND status NOT IN ('error','deleted') LIMIT 1`, issueID).Scan(&existing)
 	if existing != "" {
@@ -466,6 +468,7 @@ func (s *Server) createClawForLinearWorkflow(workspace *types.WorkspaceConfig, w
 		workspaceFiles:       templateFiles,
 		clawName:             clawName,
 		linearIssueID:        issueID,
+		issueCreatedAt:       issueCreatedAt,
 		issueLabels:          linearPayloadLabels(payload),
 		issueLabelsAvailable: true,
 		reason:               reason,

--- a/pkg/hub/task_run_analytics_api_test.go
+++ b/pkg/hub/task_run_analytics_api_test.go
@@ -234,6 +234,23 @@ func TestTaskRunAnalyticsAPIGeneralStatsEmptyAndAuthoritative(t *testing.T) {
 	}
 }
 
+func TestTaskRunAnalyticsAPIGeneralStatsIssueCreatedAtAtRunCreation(t *testing.T) {
+	s, db := newTaskRunAnalyticsAPITestServer(t)
+	base := int64(1760000000000)
+	insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{RunID: "stats-created-at-run-start", AttemptID: "attempt-stats-created-at-run-start", ClawID: "claw-stats-created-at-run-start", TenantID: "test-tenant-id", OwnerType: taskRunOwnerFactory, StartedAt: base, IssueCreatedAt: base - 2000, PRCount: 1})
+	if _, err := db.Exec(`UPDATE task_run_summaries SET pr_opened_at=? WHERE run_id='stats-created-at-run-start'`, base+3000); err != nil {
+		t.Fatal(err)
+	}
+
+	rr := requestTaskRunAnalyticsAPI(t, s, http.MethodGet, "/api/analytics/general-stats", "test-token")
+	var response taskRunGeneralStatsResponse
+	decodeTaskRunAnalyticsAPI(t, rr, &response)
+	if response.TicketToPr.AvgMs == nil || *response.TicketToPr.AvgMs != 5000 || response.TicketToPr.Samples != 1 ||
+		response.TicketToPr.Authoritative == nil || !*response.TicketToPr.Authoritative {
+		t.Fatalf("ticket stats: %#v", response.TicketToPr)
+	}
+}
+
 func TestTaskRunAnalyticsAPIRunDetailsAttemptsEventsAndPRs(t *testing.T) {
 	s, db := newTaskRunAnalyticsAPITestServer(t)
 	ts := int64(1760000000000)
@@ -609,6 +626,7 @@ type apiRunFixture struct {
 	WarningTypes      []string
 	FailureType       string
 	StartedAt         int64
+	IssueCreatedAt    int64
 	MergedAt          int64
 	FinishedAt        int64
 	HumanInteractions int
@@ -667,11 +685,11 @@ func insertTaskRunAnalyticsAPIRun(t *testing.T, db *sql.DB, fixture apiRunFixtur
 		INSERT INTO task_runs(
 			id, tenant_id, initial_attempt_id, current_attempt_id, run_kind, owner_type,
 			workspace_name, workflow_name, factory_name, owner_display_name, integration,
-			issue_id, claw_id, model, tags, analytics_enabled, requires_pr, excluded_reason, created_at, updated_at
-		) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+			issue_id, issue_created_at, claw_id, model, tags, analytics_enabled, requires_pr, excluded_reason, created_at, updated_at
+		) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
 		fixture.RunID, fixture.TenantID, fixture.AttemptID, fixture.AttemptID, taskRunKindPRTask, fixture.OwnerType,
 		fixture.Workspace, fixture.Workflow, fixture.Factory, firstNonEmpty(fixture.Workflow, fixture.Factory),
-		fixture.Integration, "ISSUE-"+fixture.RunID, fixture.ClawID, fixture.Model, "[]", boolInt(analyticsEnabled), boolInt(requiresPR), fixture.ExcludedReason,
+		fixture.Integration, "ISSUE-"+fixture.RunID, fixture.IssueCreatedAt, fixture.ClawID, fixture.Model, "[]", boolInt(analyticsEnabled), boolInt(requiresPR), fixture.ExcludedReason,
 		fixture.StartedAt, fixture.StartedAt,
 	)
 	if err != nil {
@@ -698,16 +716,16 @@ func insertTaskRunAnalyticsAPIRun(t *testing.T, db *sql.DB, fixture apiRunFixtur
 		INSERT INTO task_run_summaries(
 			id, tenant_id, run_id, initial_attempt_id, current_attempt_id, status, phase, attempt_count,
 			owner_type, workspace_name, workflow_name, factory_name, owner_display_name, run_kind,
-			integration, issue_id, claw_id, model, repo, primary_pr_url, pr_count, open_pr_count,
+		integration, issue_id, issue_created_at, claw_id, model, repo, primary_pr_url, pr_count, open_pr_count,
 			merged_pr_count, closed_pr_count, warning_types, failure_type, human_interaction_count,
 			started_at, merged_at, finished_at, last_event_at, materialized_at, updated_at,
 			analytics_enabled, requires_pr, excluded_reason, input_tokens, output_tokens, total_tokens,
 			estimated_cost_usd, issue_title
-		) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
 		"summary-"+fixture.RunID, fixture.TenantID, fixture.RunID, fixture.AttemptID, fixture.AttemptID,
 		fixture.Status, fixture.Phase, 1, fixture.OwnerType, fixture.Workspace, fixture.Workflow, fixture.Factory,
 		firstNonEmpty(fixture.Workflow, fixture.Factory), taskRunKindPRTask, fixture.Integration,
-		"ISSUE-"+fixture.RunID, fixture.ClawID, fixture.Model, fixture.Repo,
+		"ISSUE-"+fixture.RunID, fixture.IssueCreatedAt, fixture.ClawID, fixture.Model, fixture.Repo,
 		"https://github.com/"+fixture.Repo+"/pull/1", fixture.PRCount, fixture.OpenPRCount,
 		fixture.MergedPRCount, fixture.ClosedPRCount, warningsJSON, fixture.FailureType,
 		fixture.HumanInteractions, fixture.StartedAt, fixture.MergedAt, fixture.FinishedAt,

--- a/pkg/hub/task_run_analytics_api_test.go
+++ b/pkg/hub/task_run_analytics_api_test.go
@@ -716,7 +716,7 @@ func insertTaskRunAnalyticsAPIRun(t *testing.T, db *sql.DB, fixture apiRunFixtur
 		INSERT INTO task_run_summaries(
 			id, tenant_id, run_id, initial_attempt_id, current_attempt_id, status, phase, attempt_count,
 			owner_type, workspace_name, workflow_name, factory_name, owner_display_name, run_kind,
-		integration, issue_id, issue_created_at, claw_id, model, repo, primary_pr_url, pr_count, open_pr_count,
+			integration, issue_id, issue_created_at, claw_id, model, repo, primary_pr_url, pr_count, open_pr_count,
 			merged_pr_count, closed_pr_count, warning_types, failure_type, human_interaction_count,
 			started_at, merged_at, finished_at, last_event_at, materialized_at, updated_at,
 			analytics_enabled, requires_pr, excluded_reason, input_tokens, output_tokens, total_tokens,

--- a/pkg/hub/task_run_analytics_test.go
+++ b/pkg/hub/task_run_analytics_test.go
@@ -573,6 +573,55 @@ func TestRecordTaskRunIssueCreatedAtBackfillsRunAndSummary(t *testing.T) {
 	}
 }
 
+func TestWorkflowTaskRunStoresIssueCreatedAtAtCreation(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{
+		Token:     "test-token",
+		ClawToken: "test-claw-token",
+		Providers: map[string]types.ProviderConfig{"noop": {Type: "noop"}},
+	}, "", "", "")
+
+	workspace := &types.WorkspaceConfig{
+		SchemaVersion: "v1",
+		Name:          "issue-created-workspace",
+		Files: map[string]string{
+			"elasticclaw-config.yaml": "schema_version: v1\nname: issue-created-workspace\nprovider: noop\n",
+		},
+	}
+	workflow := &types.WorkflowConfig{Name: "issue-created-workflow", Provider: "noop"}
+	created := time.UnixMilli(1760000000000).UTC()
+
+	for _, tc := range []struct {
+		name    string
+		created time.Time
+		want    int64
+	}{
+		{name: "set", created: created, want: created.UnixMilli()},
+		{name: "unset", want: 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clawID, _, err := s.createClawFromWorkflowWithOptions(workspace, workflow, workflowCreateOptions{
+				issueCreatedAt: tc.created,
+				reason:         "test",
+			})
+			if err != nil {
+				t.Fatalf("create workflow claw: %v", err)
+			}
+			var runValue, summaryValue int64
+			if err := db.QueryRow(`SELECT issue_created_at FROM task_runs WHERE claw_id=?`, clawID).Scan(&runValue); err != nil {
+				t.Fatalf("read task run: %v", err)
+			}
+			if err := db.QueryRow(`SELECT issue_created_at FROM task_run_summaries WHERE run_id=(SELECT task_run_id FROM claws WHERE id=?)`, clawID).Scan(&summaryValue); err != nil {
+				t.Fatalf("read task run summary: %v", err)
+			}
+			if runValue != tc.want || summaryValue != tc.want {
+				t.Fatalf("issue_created_at run=%d summary=%d want %d", runValue, summaryValue, tc.want)
+			}
+		})
+	}
+}
+
 func newTaskRunAnalyticsTestServer(t *testing.T, clawID string) (*Server, *sql.DB) {
 	t.Helper()
 	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")

--- a/pkg/hub/workflow_creator.go
+++ b/pkg/hub/workflow_creator.go
@@ -24,6 +24,7 @@ type workflowCreateOptions struct {
 	jiraIssueID          string
 	issueLabels          []string
 	issueLabelsAvailable bool
+	issueCreatedAt       time.Time
 	reason               string
 	triggerActor         *triggerActor
 }
@@ -276,6 +277,7 @@ func (s *Server) createClawFromWorkflowWithOptions(workspace *types.WorkspaceCon
 		WorkflowName:     workflow.Name,
 		Integration:      workflow.Integration,
 		IssueID:          firstNonEmpty(opts.githubIssueID, opts.linearIssueID, opts.shortcutStoryID, opts.jiraIssueID),
+		IssueCreatedAt:   opts.issueCreatedAt,
 		Model:            defaultModel,
 		LLMKey:           llmKey,
 		Source:           taskRunSourceWorkflow,


### PR DESCRIPTION
## What

Workflow-triggered runs always persisted `issue_created_at=0` — only the Linear **factory** path recorded the issue creation time (via the post-hoc `recordTaskRunIssueCreatedAt` backfill). This made every workflow-triggered ticket→PR sample in `GET /api/analytics/general-stats` fall back to `pr_opened_at − started_at` and dragged `authoritative` to `false`.

## How

- Added `issueCreatedAt` to `workflowCreateOptions` and wired it into `TaskRunStart.IssueCreatedAt`, which was already plumbed into the `task_runs` INSERT but had no caller setting it — the value is now persisted at run creation instead of backfilled.
- **Linear**: webhook payload now decodes `data.createdAt`; the poller requests/propagates `createdAt` on its existing GraphQL query (no new API calls). Both feed `createClawForLinearWorkflow`.
- **GitHub issues**: webhook payload and poll item now carry `issue.created_at`, threaded through `createClawForGitHubIssueWorkflow` the same way. The GitHub issues *factory* path was left untouched — it never creates a task run at that point, so there is nothing to record.
- **Jira/Shortcut**: skipped. Jira's `created` uses a non-RFC3339 offset format, and Shortcut action payloads don't carry story creation time; neither is worth new parsing or API calls here.
- The `recordTaskRunIssueCreatedAt` backfill and the Linear factory path are unchanged (its `AND issue_created_at=0` guard means it can't overwrite creation-time values).

## Tests

- `TestWorkflowTaskRunStoresIssueCreatedAtAtCreation`: workflow-created run persists the expected epoch millis in `task_runs` and `task_run_summaries` (and stays 0 when unset).
- `TestTaskRunAnalyticsAPIGeneralStatsIssueCreatedAtAtRunCreation`: general-stats produces an authoritative ticket→PR sample measured from `issue_created_at`.
- Extended the Linear pagination test to assert `createdAt` survives the GraphQL decode (would have caught a bug found in review where the response struct dropped the field).

```
go build ./...                 # clean
go test ./pkg/hub -count=1     # ok  17.2s
```

Reviewed by fable-5 and gpt-5.6 (Codex); both poll-path gaps found in review are fixed in the last commit.

Part of [AIEDEV-1](https://linear.app/nimble-la/issue/AIEDEV-1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)