### PR TITLE
feat: per-metric authoritative sample counts in general stats

### DIFF
--- a/pkg/hub/task_run_analytics_api.go
+++ b/pkg/hub/task_run_analytics_api.go
@@ -233,9 +233,9 @@ type taskRunAnalyticsFilters struct {
 }
 
 type taskRunGeneralStat struct {
-	AvgMs         *int64 `json:"avgMs"`
-	Samples       int    `json:"samples"`
-	Authoritative *bool  `json:"authoritative,omitempty"`
+	AvgMs                *int64 `json:"avgMs"`
+	Samples              int    `json:"samples"`
+	AuthoritativeSamples *int   `json:"authoritativeSamples,omitempty"`
 }
 
 type taskRunGeneralStatsResponse struct {
@@ -270,8 +270,7 @@ func (s *Server) readTaskRunAnalyticsGeneralStats(filters taskRunAnalyticsFilter
 	}
 	defer rows.Close()
 	var ticketSum, prSum, aiSum int64
-	var ticketN, prN, aiN int
-	authoritative := true
+	var ticketN, ticketAuthN, prN, aiN int
 	for rows.Next() {
 		var issue, started, agent, opened, merged int64
 		if err := rows.Scan(&issue, &started, &agent, &opened, &merged); err != nil {
@@ -288,8 +287,8 @@ func (s *Server) readTaskRunAnalyticsGeneralStats(filters taskRunAnalyticsFilter
 			if opened >= base {
 				ticketSum += opened - base
 				ticketN++
-				if fallback {
-					authoritative = false
+				if !fallback {
+					ticketAuthN++
 				}
 			}
 		}
@@ -313,7 +312,7 @@ func (s *Server) readTaskRunAnalyticsGeneralStats(filters taskRunAnalyticsFilter
 		return &value
 	}
 	return taskRunGeneralStatsResponse{
-		TicketToPr:    taskRunGeneralStat{AvgMs: average(ticketSum, ticketN), Samples: ticketN, Authoritative: &authoritative},
+		TicketToPr:    taskRunGeneralStat{AvgMs: average(ticketSum, ticketN), Samples: ticketN, AuthoritativeSamples: &ticketAuthN},
 		PROpenToMerge: taskRunGeneralStat{AvgMs: average(prSum, prN), Samples: prN},
 		AIImpl:        taskRunGeneralStat{AvgMs: average(aiSum, aiN), Samples: aiN},
 	}, nil

--- a/pkg/hub/task_run_analytics_api_test.go
+++ b/pkg/hub/task_run_analytics_api_test.go
@@ -187,7 +187,7 @@ func TestTaskRunAnalyticsAPIGeneralStats(t *testing.T) {
 	}
 	var response taskRunGeneralStatsResponse
 	decodeTaskRunAnalyticsAPI(t, rr, &response)
-	if response.TicketToPr.AvgMs == nil || *response.TicketToPr.AvgMs != 5500 || response.TicketToPr.Samples != 2 || response.TicketToPr.Authoritative == nil || *response.TicketToPr.Authoritative {
+	if response.TicketToPr.AvgMs == nil || *response.TicketToPr.AvgMs != 5500 || response.TicketToPr.Samples != 2 || response.TicketToPr.AuthoritativeSamples == nil || *response.TicketToPr.AuthoritativeSamples != 1 {
 		t.Fatalf("ticket stats: %#v", response.TicketToPr)
 	}
 	if response.PROpenToMerge.AvgMs == nil || *response.PROpenToMerge.AvgMs != 3666 || response.PROpenToMerge.Samples != 3 {
@@ -198,7 +198,7 @@ func TestTaskRunAnalyticsAPIGeneralStats(t *testing.T) {
 	}
 }
 
-func TestTaskRunAnalyticsAPIGeneralStatsEmptyAndAuthoritative(t *testing.T) {
+func TestTaskRunAnalyticsAPIGeneralStatsEmptyAndAuthoritativeSamples(t *testing.T) {
 	s, db := newTaskRunAnalyticsAPITestServer(t)
 
 	// No qualifying rows: every avgMs must serialize as JSON null with samples 0.
@@ -207,20 +207,20 @@ func TestTaskRunAnalyticsAPIGeneralStatsEmptyAndAuthoritative(t *testing.T) {
 		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
 	}
 	body := rr.Body.String()
-	if !strings.Contains(body, `"ticketToPrMs":{"avgMs":null,"samples":0,"authoritative":true}`) ||
+	if !strings.Contains(body, `"ticketToPrMs":{"avgMs":null,"samples":0,"authoritativeSamples":0}`) ||
 		!strings.Contains(body, `"prOpenToMergeMs":{"avgMs":null,"samples":0}`) ||
 		!strings.Contains(body, `"aiImplMs":{"avgMs":null,"samples":0}`) {
 		t.Fatalf("unexpected empty-stats body: %s", body)
 	}
 
-	// A single run with issue_created_at set keeps authoritative=true.
+	// A single run with issue_created_at set contributes one authoritative sample.
 	base := int64(1760000000000)
 	insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{RunID: "stats-auth-only", AttemptID: "attempt-stats-auth-only", ClawID: "claw-stats-auth-only", TenantID: "test-tenant-id", OwnerType: taskRunOwnerFactory, StartedAt: base, PRCount: 1})
 	if _, err := db.Exec(`UPDATE task_run_summaries SET issue_created_at=?, pr_opened_at=? WHERE run_id='stats-auth-only'`, base-2000, base+3000); err != nil {
 		t.Fatal(err)
 	}
 	// A fallback row with a negative delta is skipped, not sampled, so it must
-	// not flip authoritative to false either.
+	// not affect either ticket sample count.
 	insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{RunID: "stats-github-skip", AttemptID: "attempt-stats-github-skip", ClawID: "claw-stats-github-skip", TenantID: "test-tenant-id", OwnerType: taskRunOwnerFactory, StartedAt: base + 10000, PRCount: 1})
 	if _, err := db.Exec(`UPDATE task_run_summaries SET pr_opened_at=? WHERE run_id='stats-github-skip'`, base+8000); err != nil {
 		t.Fatal(err)
@@ -229,7 +229,7 @@ func TestTaskRunAnalyticsAPIGeneralStatsEmptyAndAuthoritative(t *testing.T) {
 	var response taskRunGeneralStatsResponse
 	decodeTaskRunAnalyticsAPI(t, rr, &response)
 	if response.TicketToPr.AvgMs == nil || *response.TicketToPr.AvgMs != 5000 || response.TicketToPr.Samples != 1 ||
-		response.TicketToPr.Authoritative == nil || !*response.TicketToPr.Authoritative {
+		response.TicketToPr.AuthoritativeSamples == nil || *response.TicketToPr.AuthoritativeSamples != 1 {
 		t.Fatalf("ticket stats: %#v", response.TicketToPr)
 	}
 }

--- a/web/components/task-run-analytics-view.tsx
+++ b/web/components/task-run-analytics-view.tsx
@@ -351,7 +351,17 @@ export function TaskRunAnalyticsView({ workspaceScope }: { workspaceScope?: stri
             <div className="flex flex-col gap-2">
               <h3 className="text-xs font-medium uppercase text-muted-foreground">General Stats</h3>
               <div className="grid gap-2 sm:grid-cols-3">
-                <CostCard label="Avg ticket to PR" value={formatDurationMs(generalStats.ticketToPrMs.avgMs)} />
+                <CostCard
+                  label="Avg ticket to PR"
+                  value={formatDurationMs(generalStats.ticketToPrMs.avgMs)}
+                  sub={
+                    generalStats.ticketToPrMs.samples > 0 &&
+                    typeof generalStats.ticketToPrMs.authoritativeSamples === "number" &&
+                    generalStats.ticketToPrMs.authoritativeSamples < generalStats.ticketToPrMs.samples
+                      ? `${generalStats.ticketToPrMs.authoritativeSamples} of ${generalStats.ticketToPrMs.samples} samples use real ticket creation time`
+                      : undefined
+                  }
+                />
                 <CostCard label="Avg PR to merged" value={formatDurationMs(generalStats.prOpenToMergeMs.avgMs)} />
                 <CostCard label="Avg AI implementation time" value={formatDurationMs(generalStats.aiImplMs.avgMs)} />
               </div>

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -165,7 +165,7 @@ export interface CostOverview {
 export interface GeneralStatMetric {
   avgMs: number | null
   samples: number
-  authoritative?: boolean
+  authoritativeSamples?: number
 }
 
 export interface GeneralStats {


### PR DESCRIPTION
## What

Replaces the `authoritative` boolean on `ticketToPrMs` in `GET /api/analytics/general-stats` with a per-metric count, `authoritativeSamples` — the number of samples where the real `issue_created_at` was used as the base (rather than the `started_at` fallback). `samples` semantics are unchanged. `prOpenToMergeMs` and `aiImplMs` have no fallback path, so they stay as `{avgMs, samples}`.

Frontend: `GeneralStatMetric` type updated, and the "Avg ticket to PR" card now shows a subtle subtext ("N of M samples use real ticket creation time") only when some samples fell back — scoped strictly to the General Stats section.

## Why

The old boolean started `true` and flipped `false` on the *first* fallback sample in the filtered set. Since every pre-migration `task_run_summaries` row has `issue_created_at=0`, on any deployment with history the flag was permanently `false` and carried no signal. A count preserves the intent (how trustworthy is this average?) with actual resolution.

## Tests

- `go build ./...` ✅
- `go test ./pkg/hub -count=1` ✅ (`ok github.com/elasticclaw/elasticclaw/pkg/hub 17.5s`) — `TestTaskRunAnalyticsAPIGeneralStats` now asserts the mixed authoritative/fallback split (1 of 2); the empty/skip-case test renamed to `TestTaskRunAnalyticsAPIGeneralStatsEmptyAndAuthoritativeSamples`
- `cd web && npm run build` ✅ (TypeScript check passed, 34 pages generated)

Part of [AIEDEV-1](https://linear.app/nimble-la/issue/AIEDEV-1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)