### PR TITLE
fix: minor cost-tracking review findings

### DIFF
--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -640,6 +640,11 @@ func migrate(db *sql.DB) error {
 	if err != nil {
 		return err
 	}
+	// Backfill rows that predate the usage_day column so cost corrections land
+	// on the day the run's usage was last applied, not on the correction's day.
+	if _, err := db.Exec(`UPDATE task_run_usage SET usage_day = strftime('%Y-%m-%d', updated_at/1000, 'unixepoch') WHERE usage_day = '' AND updated_at > 0`); err != nil {
+		return fmt.Errorf("backfill task_run_usage.usage_day: %w", err)
+	}
 	for _, p := range []struct {
 		model                          string
 		in, out, cacheRead, cacheWrite float64

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -641,16 +641,18 @@ func migrate(db *sql.DB) error {
 		return err
 	}
 	for _, p := range []struct {
-		model   string
-		in, out float64
+		model                          string
+		in, out, cacheRead, cacheWrite float64
 	}{
-		{"claude-fable-5", 10, 50}, {"claude-opus-4-8", 5, 25}, {"claude-opus-4-7", 5, 25}, {"claude-opus-4-6", 5, 25},
-		{"claude-sonnet-5", 3, 15}, {"claude-sonnet-4-6", 3, 15}, {"claude-haiku-4-5", 1, 5},
+		{"claude-fable-5", 10, 50, 1, 12.5}, {"claude-opus-4-8", 5, 25, .5, 6.25}, {"claude-opus-4-7", 5, 25, .5, 6.25}, {"claude-opus-4-6", 5, 25, .5, 6.25},
+		{"claude-sonnet-5", 3, 15, .3, 3.75}, {"claude-sonnet-4-6", 3, 15, .3, 3.75}, {"claude-haiku-4-5", 1, 5, .1, 1.25},
+		{"gpt-5", 1.25, 10, .125, 0}, {"gpt-5-mini", .25, 2, .025, 0}, {"gpt-5-nano", .05, .40, .005, 0},
+		{"gpt-5.1", 1.25, 10, .125, 0}, {"gpt-5.6", 1.25, 10, .125, 0},
 	} {
 		// Upsert so price corrections in the static seed reach existing
 		// databases; rows from other sources are left untouched.
 		_, err = db.Exec(`INSERT INTO model_prices(model,input_cost_per_token,output_cost_per_token,cache_read_cost_per_token,cache_write_cost_per_token,source,updated_at) VALUES(?,?,?,?,?,?,?)
-			ON CONFLICT(model) DO UPDATE SET input_cost_per_token=excluded.input_cost_per_token,output_cost_per_token=excluded.output_cost_per_token,cache_read_cost_per_token=excluded.cache_read_cost_per_token,cache_write_cost_per_token=excluded.cache_write_cost_per_token,updated_at=excluded.updated_at WHERE model_prices.source='static'`, p.model, p.in/1e6, p.out/1e6, p.in/1e7, p.in*1.25/1e6, "static", now().UnixMilli())
+			ON CONFLICT(model) DO UPDATE SET input_cost_per_token=excluded.input_cost_per_token,output_cost_per_token=excluded.output_cost_per_token,cache_read_cost_per_token=excluded.cache_read_cost_per_token,cache_write_cost_per_token=excluded.cache_write_cost_per_token,updated_at=excluded.updated_at WHERE model_prices.source='static'`, p.model, p.in/1e6, p.out/1e6, p.cacheRead/1e6, p.cacheWrite/1e6, "static", now().UnixMilli())
 		if err != nil {
 			return err
 		}

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -87,6 +87,7 @@ func migrate(db *sql.DB) error {
 	_, _ = db.Exec(`ALTER TABLE task_run_usage ADD COLUMN committed_output_tokens INTEGER NOT NULL DEFAULT 0`)
 	_, _ = db.Exec(`ALTER TABLE task_run_usage ADD COLUMN committed_total_tokens INTEGER NOT NULL DEFAULT 0`)
 	_, _ = db.Exec(`ALTER TABLE task_run_usage ADD COLUMN committed_cost_usd REAL NOT NULL DEFAULT 0`)
+	_, _ = db.Exec(`ALTER TABLE task_run_usage ADD COLUMN usage_day TEXT NOT NULL DEFAULT ''`)
 
 	_, _ = db.Exec(`CREATE TABLE IF NOT EXISTS claw_checkpoints (
 		id                    TEXT PRIMARY KEY,
@@ -332,6 +333,7 @@ func migrate(db *sql.DB) error {
 		input_tokens INTEGER NOT NULL DEFAULT 0, output_tokens INTEGER NOT NULL DEFAULT 0, total_tokens INTEGER NOT NULL DEFAULT 0,
 		committed_input_tokens INTEGER NOT NULL DEFAULT 0, committed_output_tokens INTEGER NOT NULL DEFAULT 0, committed_total_tokens INTEGER NOT NULL DEFAULT 0, committed_cost_usd REAL NOT NULL DEFAULT 0,
 		cache_read_tokens INTEGER, cache_write_tokens INTEGER, estimated_cost_usd REAL, cost_source TEXT NOT NULL DEFAULT 'gateway' CHECK(cost_source IN ('gateway','hub_pricing')),
+		usage_day TEXT NOT NULL DEFAULT '',
 		first_seen_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, UNIQUE(tenant_id, run_id, session_key)
 	);
 	CREATE TABLE IF NOT EXISTS usage_daily (

--- a/pkg/hub/task_run_analytics_api.go
+++ b/pkg/hub/task_run_analytics_api.go
@@ -136,10 +136,10 @@ type taskRunAnalyticsRunView struct {
 	AnalyticsEnabled      bool     `json:"analyticsEnabled"`
 	RequiresPR            bool     `json:"requiresPr"`
 	ExcludedReason        string   `json:"excludedReason"`
-	InputTokens           int64    `json:"inputTokens,omitempty"`
-	OutputTokens          int64    `json:"outputTokens,omitempty"`
-	TotalTokens           int64    `json:"totalTokens,omitempty"`
-	EstimatedCostUsd      float64  `json:"estimatedCostUsd,omitempty"`
+	InputTokens           *int64   `json:"inputTokens,omitempty"`
+	OutputTokens          *int64   `json:"outputTokens,omitempty"`
+	TotalTokens           *int64   `json:"totalTokens,omitempty"`
+	EstimatedCostUsd      *float64 `json:"estimatedCostUsd,omitempty"`
 	IssueTitle            string   `json:"issueTitle,omitempty"`
 }
 
@@ -1186,7 +1186,7 @@ func taskRunAnalyticsRunColumns() string {
 		failure_type, human_interaction_count, started_at, queued_at, provision_started_at,
 		agent_started_at, pr_opened_at, merged_at, finished_at, timeout_at, last_event_at,
 		materialized_at, updated_at, analytics_enabled, requires_pr, excluded_reason,
-		input_tokens, output_tokens, total_tokens, estimated_cost_usd, issue_title`
+		input_tokens, output_tokens, total_tokens, estimated_cost_usd, usage_updated_at, issue_title`
 }
 
 func scanTaskRunAnalyticsRuns(rows *sql.Rows) ([]taskRunAnalyticsRunView, error) {
@@ -1195,6 +1195,8 @@ func scanTaskRunAnalyticsRuns(rows *sql.Rows) ([]taskRunAnalyticsRunView, error)
 		var run taskRunAnalyticsRunView
 		var warningsJSON string
 		var analyticsEnabled, requiresPR int
+		var inputTokens, outputTokens, totalTokens, usageUpdatedAt int64
+		var estimatedCostUSD float64
 		if err := rows.Scan(
 			&run.RunID, &run.InitialAttemptID, &run.CurrentAttemptID, &run.Status, &run.Phase, &run.AttemptCount,
 			&run.OwnerType, &run.WorkspaceName, &run.WorkflowName, &run.FactoryName, &run.OwnerID, &run.OwnerDisplayName,
@@ -1203,12 +1205,18 @@ func scanTaskRunAnalyticsRuns(rows *sql.Rows) ([]taskRunAnalyticsRunView, error)
 			&warningsJSON, &run.FailureType, &run.HumanInteractionCount, &run.StartedAt, &run.QueuedAt,
 			&run.ProvisionStartedAt, &run.AgentStartedAt, &run.PROpenedAt, &run.MergedAt, &run.FinishedAt,
 			&run.TimeoutAt, &run.LastEventAt, &run.MaterializedAt, &run.UpdatedAt, &analyticsEnabled, &requiresPR,
-			&run.ExcludedReason, &run.InputTokens, &run.OutputTokens, &run.TotalTokens, &run.EstimatedCostUsd, &run.IssueTitle,
+			&run.ExcludedReason, &inputTokens, &outputTokens, &totalTokens, &estimatedCostUSD, &usageUpdatedAt, &run.IssueTitle,
 		); err != nil {
 			return nil, err
 		}
 		run.AnalyticsEnabled = analyticsEnabled == 1
 		run.RequiresPR = requiresPR == 1
+		if usageUpdatedAt != 0 {
+			run.InputTokens = &inputTokens
+			run.OutputTokens = &outputTokens
+			run.TotalTokens = &totalTokens
+			run.EstimatedCostUsd = &estimatedCostUSD
+		}
 		run.WarningTypes = []string{}
 		if warningsJSON != "" {
 			if err := json.Unmarshal([]byte(warningsJSON), &run.WarningTypes); err != nil {

--- a/pkg/hub/task_run_analytics_api_test.go
+++ b/pkg/hub/task_run_analytics_api_test.go
@@ -246,7 +246,7 @@ func TestTaskRunAnalyticsAPIGeneralStatsIssueCreatedAtAtRunCreation(t *testing.T
 	var response taskRunGeneralStatsResponse
 	decodeTaskRunAnalyticsAPI(t, rr, &response)
 	if response.TicketToPr.AvgMs == nil || *response.TicketToPr.AvgMs != 5000 || response.TicketToPr.Samples != 1 ||
-		response.TicketToPr.Authoritative == nil || !*response.TicketToPr.Authoritative {
+		response.TicketToPr.AuthoritativeSamples == nil || *response.TicketToPr.AuthoritativeSamples != 1 {
 		t.Fatalf("ticket stats: %#v", response.TicketToPr)
 	}
 }
@@ -299,6 +299,51 @@ func TestTaskRunAnalyticsAPIRunDetailsAttemptsEventsAndPRs(t *testing.T) {
 	notFoundRR := requestTaskRunAnalyticsAPI(t, s, http.MethodGet, "/api/analytics/runs/run-other-tenant", "test-token")
 	if notFoundRR.Code != http.StatusNotFound {
 		t.Fatalf("cross-tenant detail status = %d, body = %s", notFoundRR.Code, notFoundRR.Body.String())
+	}
+}
+
+func TestTaskRunAnalyticsAPIUsageDistinguishesRecordedZeroFromMissing(t *testing.T) {
+	s, db := newTaskRunAnalyticsAPITestServer(t)
+	ts := int64(1760000000000)
+	insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{
+		RunID: "run-usage-zero", AttemptID: "attempt-usage-zero", ClawID: "claw-usage-zero", TenantID: "test-tenant-id",
+		OwnerType: taskRunOwnerFactory, StartedAt: ts + 1, UsageUpdatedAt: ts + 1,
+	})
+	insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{
+		RunID: "run-usage-missing", AttemptID: "attempt-usage-missing", ClawID: "claw-usage-missing", TenantID: "test-tenant-id",
+		OwnerType: taskRunOwnerFactory, StartedAt: ts,
+	})
+
+	rr := requestTaskRunAnalyticsAPI(t, s, http.MethodGet, "/api/analytics/runs", "test-token")
+	var response struct {
+		Runs []map[string]json.RawMessage `json:"runs"`
+	}
+	decodeTaskRunAnalyticsAPI(t, rr, &response)
+	if len(response.Runs) != 2 {
+		t.Fatalf("run count = %d, want 2", len(response.Runs))
+	}
+	assertTaskRunAnalyticsUsageJSON(t, response.Runs[0], true)
+	assertTaskRunAnalyticsUsageJSON(t, response.Runs[1], false)
+
+	detailRR := requestTaskRunAnalyticsAPI(t, s, http.MethodGet, "/api/analytics/runs/run-usage-zero", "test-token")
+	var detail struct {
+		Run map[string]json.RawMessage `json:"run"`
+	}
+	decodeTaskRunAnalyticsAPI(t, detailRR, &detail)
+	assertTaskRunAnalyticsUsageJSON(t, detail.Run, true)
+}
+
+func assertTaskRunAnalyticsUsageJSON(t *testing.T, run map[string]json.RawMessage, recorded bool) {
+	t.Helper()
+	for _, field := range []string{"inputTokens", "outputTokens", "totalTokens", "estimatedCostUsd"} {
+		value, ok := run[field]
+		if ok != recorded {
+			t.Errorf("%s present = %t, want %t; run = %v", field, ok, recorded, run)
+			continue
+		}
+		if recorded && string(value) != "0" {
+			t.Errorf("%s = %s, want 0", field, value)
+		}
 	}
 }
 
@@ -641,6 +686,7 @@ type apiRunFixture struct {
 	OutputTokens      int64
 	TotalTokens       int64
 	EstimatedCostUsd  float64
+	UsageUpdatedAt    int64
 	IssueTitle        string
 }
 
@@ -719,9 +765,9 @@ func insertTaskRunAnalyticsAPIRun(t *testing.T, db *sql.DB, fixture apiRunFixtur
 			integration, issue_id, issue_created_at, claw_id, model, repo, primary_pr_url, pr_count, open_pr_count,
 			merged_pr_count, closed_pr_count, warning_types, failure_type, human_interaction_count,
 			started_at, merged_at, finished_at, last_event_at, materialized_at, updated_at,
-			analytics_enabled, requires_pr, excluded_reason, input_tokens, output_tokens, total_tokens,
-			estimated_cost_usd, issue_title
-		) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		analytics_enabled, requires_pr, excluded_reason, input_tokens, output_tokens, total_tokens,
+			estimated_cost_usd, usage_updated_at, issue_title
+		) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
 		"summary-"+fixture.RunID, fixture.TenantID, fixture.RunID, fixture.AttemptID, fixture.AttemptID,
 		fixture.Status, fixture.Phase, 1, fixture.OwnerType, fixture.Workspace, fixture.Workflow, fixture.Factory,
 		firstNonEmpty(fixture.Workflow, fixture.Factory), taskRunKindPRTask, fixture.Integration,
@@ -730,7 +776,7 @@ func insertTaskRunAnalyticsAPIRun(t *testing.T, db *sql.DB, fixture apiRunFixtur
 		fixture.MergedPRCount, fixture.ClosedPRCount, warningsJSON, fixture.FailureType,
 		fixture.HumanInteractions, fixture.StartedAt, fixture.MergedAt, fixture.FinishedAt,
 		fixture.StartedAt, fixture.StartedAt, fixture.StartedAt, boolInt(analyticsEnabled), boolInt(requiresPR), fixture.ExcludedReason,
-		fixture.InputTokens, fixture.OutputTokens, fixture.TotalTokens, fixture.EstimatedCostUsd, fixture.IssueTitle,
+		fixture.InputTokens, fixture.OutputTokens, fixture.TotalTokens, fixture.EstimatedCostUsd, fixture.UsageUpdatedAt, fixture.IssueTitle,
 	)
 	if err != nil {
 		t.Fatalf("insert task run summary %s: %v", fixture.RunID, err)

--- a/pkg/hub/task_run_analytics_costs_api.go
+++ b/pkg/hub/task_run_analytics_costs_api.go
@@ -122,10 +122,11 @@ func (s *Server) readTaskRunAnalyticsCosts(filters taskRunAnalyticsFilters, now 
 	if hasProjectionData {
 		mean := averageTaskRunAnalyticsCosts(last7Costs)
 		daysInMonth := time.Date(today.Year(), today.Month()+1, 0, 0, 0, 0, 0, time.UTC).Day()
-		remainingDays := daysInMonth - today.Day()
+		// Project today as a full mean day because its recorded spend is still partial.
+		projectedCost := (response.Month.CostUsd - todayTotals.costUsd) + mean*float64(daysInMonth-today.Day()+1)
 		response.ProjectedMonth = &taskRunAnalyticsProjection{
-			CostUsd:    response.Month.CostUsd + mean*float64(remainingDays),
-			Confidence: taskRunAnalyticsProjectionConfidence(today.Day(), last7Costs, mean),
+			CostUsd:    projectedCost,
+			Confidence: taskRunAnalyticsProjectionConfidence(today.Day()-1, last7Costs, mean),
 			Basis:      "7d-avg",
 		}
 	}
@@ -149,7 +150,7 @@ func taskRunAnalyticsProjectionConfidence(elapsed int, costs []float64, mean flo
 		for _, cost := range costs {
 			variance += (cost - mean) * (cost - mean)
 		}
-		if math.Sqrt(variance/float64(len(costs)))/mean < 0.35 {
+		if len(costs) > 1 && math.Sqrt(variance/float64(len(costs)-1))/mean < 0.35 {
 			return "high"
 		}
 	}

--- a/pkg/hub/task_run_analytics_costs_api_test.go
+++ b/pkg/hub/task_run_analytics_costs_api_test.go
@@ -108,12 +108,12 @@ func TestTaskRunAnalyticsCostsHandler(t *testing.T) {
 
 func TestTaskRunAnalyticsRunUsageFields(t *testing.T) {
 	s, db := newTaskRunAnalyticsAPITestServer(t)
-	insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{RunID: "usage", AttemptID: "usage-attempt", ClawID: "usage-claw", TenantID: "test-tenant-id", OwnerType: taskRunOwnerFactory, Workspace: "eng", Factory: "factory", StartedAt: 1, InputTokens: 10, OutputTokens: 20, TotalTokens: 30, EstimatedCostUsd: 1.25, IssueTitle: "Fix the thing"})
+	insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{RunID: "usage", AttemptID: "usage-attempt", ClawID: "usage-claw", TenantID: "test-tenant-id", OwnerType: taskRunOwnerFactory, Workspace: "eng", Factory: "factory", StartedAt: 1, InputTokens: 10, OutputTokens: 20, TotalTokens: 30, EstimatedCostUsd: 1.25, UsageUpdatedAt: 1, IssueTitle: "Fix the thing"})
 	insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{RunID: "zero", AttemptID: "zero-attempt", ClawID: "zero-claw", TenantID: "test-tenant-id", OwnerType: taskRunOwnerFactory, Workspace: "eng", Factory: "factory", StartedAt: 2})
 	rr := requestTaskRunAnalyticsAPI(t, s, http.MethodGet, "/api/analytics/runs", "test-token")
 	var response taskRunAnalyticsRunsResponse
 	decodeTaskRunAnalyticsAPI(t, rr, &response)
-	if len(response.Runs) != 2 || response.Runs[0].RunID != "zero" || response.Runs[1].InputTokens != 10 || response.Runs[1].OutputTokens != 20 || response.Runs[1].TotalTokens != 30 || response.Runs[1].EstimatedCostUsd != 1.25 || response.Runs[1].IssueTitle != "Fix the thing" {
+	if len(response.Runs) != 2 || response.Runs[0].RunID != "zero" || response.Runs[1].InputTokens == nil || *response.Runs[1].InputTokens != 10 || response.Runs[1].OutputTokens == nil || *response.Runs[1].OutputTokens != 20 || response.Runs[1].TotalTokens == nil || *response.Runs[1].TotalTokens != 30 || response.Runs[1].EstimatedCostUsd == nil || *response.Runs[1].EstimatedCostUsd != 1.25 || response.Runs[1].IssueTitle != "Fix the thing" {
 		t.Fatalf("unexpected usage fields: %#v", response.Runs)
 	}
 	if strings.Contains(rr.Body.String(), `"inputTokens":0`) || strings.Contains(rr.Body.String(), `"issueTitle":""`) {
@@ -122,7 +122,7 @@ func TestTaskRunAnalyticsRunUsageFields(t *testing.T) {
 	detailRR := requestTaskRunAnalyticsAPI(t, s, http.MethodGet, "/api/analytics/runs/usage", "test-token")
 	var detail taskRunAnalyticsRunDetailResponse
 	decodeTaskRunAnalyticsAPI(t, detailRR, &detail)
-	if detail.Run.TotalTokens != 30 || detail.Run.IssueTitle != "Fix the thing" {
+	if detail.Run.TotalTokens == nil || *detail.Run.TotalTokens != 30 || detail.Run.IssueTitle != "Fix the thing" {
 		t.Fatalf("unexpected detail usage fields: %#v", detail.Run)
 	}
 }

--- a/pkg/hub/task_run_analytics_costs_api_test.go
+++ b/pkg/hub/task_run_analytics_costs_api_test.go
@@ -54,8 +54,8 @@ func TestTaskRunAnalyticsCostsDeltaAndProjection(t *testing.T) {
 		want  string
 	}{
 		{"low", time.Date(2026, time.July, 3, 0, 0, 0, 0, time.UTC), []float64{10, 10, 10, 10, 10, 10, 10}, "low"},
-		{"medium", time.Date(2026, time.July, 8, 0, 0, 0, 0, time.UTC), []float64{1, 100, 1, 100, 1, 100, 1}, "medium"},
-		{"high", time.Date(2026, time.July, 15, 0, 0, 0, 0, time.UTC), []float64{10, 10, 10, 10, 10, 10, 10}, "high"},
+		{"medium at 7 complete days", time.Date(2026, time.July, 8, 0, 0, 0, 0, time.UTC), []float64{1, 100, 1, 100, 1, 100, 1}, "medium"},
+		{"high at 14 complete days", time.Date(2026, time.July, 15, 0, 0, 0, 0, time.UTC), []float64{10, 10, 10, 10, 10, 10, 10}, "high"},
 		{"medium downgrade from high variance", time.Date(2026, time.July, 20, 0, 0, 0, 0, time.UTC), []float64{1, 100, 1, 100, 1, 100, 1}, "medium"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -68,6 +68,30 @@ func TestTaskRunAnalyticsCostsDeltaAndProjection(t *testing.T) {
 				t.Fatalf("response = %#v, err = %v", response, err)
 			}
 		})
+	}
+}
+
+func TestTaskRunAnalyticsCostsProjectionTreatsTodayAsFullDay(t *testing.T) {
+	s, db := newTaskRunAnalyticsAPITestServer(t)
+	now := time.Date(2026, time.July, 15, 12, 0, 0, 0, time.UTC)
+	for day := now.AddDate(0, 0, -7); day.Before(now); day = day.AddDate(0, 0, 1) {
+		seedTaskRunAnalyticsUsage(t, db, "test-tenant-id", day, "eng", "gpt-5", 10, 1)
+	}
+	seedTaskRunAnalyticsUsage(t, db, "test-tenant-id", now, "eng", "gpt-5", 2, 1)
+
+	response, err := s.readTaskRunAnalyticsCosts(taskRunAnalyticsFilters{TenantID: "test-tenant-id"}, now)
+	if err != nil || response.ProjectedMonth == nil {
+		t.Fatalf("response = %#v, err = %v", response, err)
+	}
+	if response.Month.CostUsd != 72 || response.ProjectedMonth.CostUsd != 240 {
+		t.Fatalf("month = %v, projected month = %v", response.Month.CostUsd, response.ProjectedMonth.CostUsd)
+	}
+}
+
+func TestTaskRunAnalyticsProjectionConfidenceUsesSampleStandardDeviation(t *testing.T) {
+	costs := []float64{36.5, 100, 100, 100, 100, 100, 163.5}
+	if got := taskRunAnalyticsProjectionConfidence(14, costs, averageTaskRunAnalyticsCosts(costs)); got != "medium" {
+		t.Fatalf("confidence = %q, want medium", got)
 	}
 }
 

--- a/pkg/hub/task_run_usage.go
+++ b/pkg/hub/task_run_usage.go
@@ -2,10 +2,14 @@ package hub
 
 import (
 	"database/sql"
+	"log"
 	"strings"
+	"sync"
 
 	"github.com/google/uuid"
 )
+
+var unmatchedUsagePriceModels sync.Map
 
 type taskRunUsageSnapshot struct {
 	SessionKey                             string
@@ -64,6 +68,10 @@ func (s *Server) recordTaskRunUsage(clawID string, snapshot taskRunUsageSnapshot
 		// The gateway did not report a cost; estimate this run from its tokens.
 		cost = sql.NullFloat64{Float64: estimated, Valid: true}
 		source = "hub_pricing"
+	} else if effectiveModel != "" {
+		if _, loaded := unmatchedUsagePriceModels.LoadOrStore(effectiveModel, struct{}{}); !loaded {
+			log.Printf("[usage] no static price for model %s", effectiveModel)
+		}
 	}
 	// OpenClaw overwrites a session entry after each reply with that run's
 	// totals. total_tokens is context occupancy, not billed token usage.

--- a/pkg/hub/task_run_usage.go
+++ b/pkg/hub/task_run_usage.go
@@ -32,13 +32,18 @@ func (s *Server) recordTaskRunUsage(clawID string, snapshot taskRunUsageSnapshot
 		return err
 	}
 	var oldIn, oldOut, oldTotal, comIn, comOut, comTotal int
+	var oldModel, oldUsageDay string
 	var oldCost sql.NullFloat64
 	var comCost float64
 	oldSource := "gateway"
-	err = tx.QueryRow(`SELECT input_tokens,output_tokens,total_tokens,committed_input_tokens,committed_output_tokens,committed_total_tokens,committed_cost_usd,estimated_cost_usd,cost_source FROM task_run_usage WHERE tenant_id=? AND run_id=? AND session_key=?`, tenant, runID, snapshot.SessionKey).Scan(&oldIn, &oldOut, &oldTotal, &comIn, &comOut, &comTotal, &comCost, &oldCost, &oldSource)
+	err = tx.QueryRow(`SELECT model,input_tokens,output_tokens,total_tokens,committed_input_tokens,committed_output_tokens,committed_total_tokens,committed_cost_usd,estimated_cost_usd,cost_source,usage_day FROM task_run_usage WHERE tenant_id=? AND run_id=? AND session_key=?`, tenant, runID, snapshot.SessionKey).Scan(&oldModel, &oldIn, &oldOut, &oldTotal, &comIn, &comOut, &comTotal, &comCost, &oldCost, &oldSource, &oldUsageDay)
 	found := err == nil
 	if err != nil && err != sql.ErrNoRows {
 		return err
+	}
+	effectiveModel := snapshot.Model
+	if effectiveModel == "" && found {
+		effectiveModel = oldModel
 	}
 	in, out, total := oldIn, oldOut, oldTotal
 	if snapshot.InputTokens != nil {
@@ -55,7 +60,7 @@ func (s *Server) recordTaskRunUsage(clawID string, snapshot taskRunUsageSnapshot
 	if snapshot.EstimatedCostUSD != nil {
 		cost = sql.NullFloat64{Float64: *snapshot.EstimatedCostUSD, Valid: true}
 		source = "gateway"
-	} else if estimated, ok := taskRunPrice(tx, snapshot.Model, in, out); ok {
+	} else if estimated, ok := taskRunPrice(tx, effectiveModel, in, out); ok {
 		// The gateway did not report a cost; estimate this run from its tokens.
 		cost = sql.NullFloat64{Float64: estimated, Valid: true}
 		source = "hub_pricing"
@@ -84,16 +89,21 @@ func (s *Server) recordTaskRunUsage(clawID string, snapshot taskRunUsageSnapshot
 		cost = oldCost
 		source = oldSource
 	}
-	ts := now().UnixMilli()
-	_, err = tx.Exec(`INSERT INTO task_run_usage(id,tenant_id,run_id,session_key,model,model_provider,input_tokens,output_tokens,total_tokens,committed_input_tokens,committed_output_tokens,committed_total_tokens,committed_cost_usd,estimated_cost_usd,cost_source,first_seen_at,updated_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?) ON CONFLICT(tenant_id,run_id,session_key) DO UPDATE SET model=excluded.model,model_provider=excluded.model_provider,input_tokens=excluded.input_tokens,output_tokens=excluded.output_tokens,total_tokens=excluded.total_tokens,committed_input_tokens=excluded.committed_input_tokens,committed_output_tokens=excluded.committed_output_tokens,committed_total_tokens=excluded.committed_total_tokens,committed_cost_usd=excluded.committed_cost_usd,estimated_cost_usd=excluded.estimated_cost_usd,cost_source=excluded.cost_source,updated_at=excluded.updated_at`, uuid.NewString(), tenant, runID, snapshot.SessionKey, snapshot.Model, snapshot.ModelProvider, in, out, total, comIn, comOut, comTotal, comCost, nullFloat(cost), source, ts, ts)
+	usageNow := now()
+	if s.nowFunc != nil {
+		usageNow = s.nowFunc()
+	}
+	ts := usageNow.UnixMilli()
+	day := usageNow.UTC().Format("2006-01-02")
+	usageDay := oldUsageDay
+	if newRun || usageDay == "" {
+		usageDay = day
+	}
+	_, err = tx.Exec(`INSERT INTO task_run_usage(id,tenant_id,run_id,session_key,model,model_provider,input_tokens,output_tokens,total_tokens,committed_input_tokens,committed_output_tokens,committed_total_tokens,committed_cost_usd,estimated_cost_usd,cost_source,usage_day,first_seen_at,updated_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?) ON CONFLICT(tenant_id,run_id,session_key) DO UPDATE SET model=excluded.model,model_provider=excluded.model_provider,input_tokens=excluded.input_tokens,output_tokens=excluded.output_tokens,total_tokens=excluded.total_tokens,committed_input_tokens=excluded.committed_input_tokens,committed_output_tokens=excluded.committed_output_tokens,committed_total_tokens=excluded.committed_total_tokens,committed_cost_usd=excluded.committed_cost_usd,estimated_cost_usd=excluded.estimated_cost_usd,cost_source=excluded.cost_source,usage_day=excluded.usage_day,updated_at=excluded.updated_at`, uuid.NewString(), tenant, runID, snapshot.SessionKey, effectiveModel, snapshot.ModelProvider, in, out, total, comIn, comOut, comTotal, comCost, nullFloat(cost), source, usageDay, ts, ts)
 	if err != nil {
 		return err
 	}
-	// A negative cost correction (gateway cost replacing a higher hub_pricing
-	// estimate) may land on a later day than the estimate it corrects; clamp
-	// the bucket at zero so per-day stats never go negative.
-	day := now().UTC().Format("2006-01-02")
-	_, err = tx.Exec(`INSERT INTO usage_daily(tenant_id,day,workspace_name,factory_name,workflow_name,model,input_tokens,output_tokens,total_tokens,cost_usd,updated_at) VALUES(?,?,?,?,?,?,?,?,?,MAX(0,?),?) ON CONFLICT(tenant_id,day,workspace_name,factory_name,workflow_name,model) DO UPDATE SET input_tokens=input_tokens+excluded.input_tokens,output_tokens=output_tokens+excluded.output_tokens,total_tokens=total_tokens+excluded.total_tokens,cost_usd=MAX(0,cost_usd+?),updated_at=excluded.updated_at`, tenant, day, workspace, factory, workflow, snapshot.Model, din, dout, dtotal, dcost, ts, dcost)
+	_, err = tx.Exec(`INSERT INTO usage_daily(tenant_id,day,workspace_name,factory_name,workflow_name,model,input_tokens,output_tokens,total_tokens,cost_usd,updated_at) VALUES(?,?,?,?,?,?,?,?,?,?,?) ON CONFLICT(tenant_id,day,workspace_name,factory_name,workflow_name,model) DO UPDATE SET input_tokens=input_tokens+excluded.input_tokens,output_tokens=output_tokens+excluded.output_tokens,total_tokens=total_tokens+excluded.total_tokens,cost_usd=cost_usd+excluded.cost_usd,updated_at=excluded.updated_at`, tenant, usageDay, workspace, factory, workflow, effectiveModel, din, dout, dtotal, dcost, ts)
 	if err != nil {
 		return err
 	}

--- a/pkg/hub/task_run_usage.go
+++ b/pkg/hub/task_run_usage.go
@@ -45,10 +45,6 @@ func (s *Server) recordTaskRunUsage(clawID string, snapshot taskRunUsageSnapshot
 	if err != nil && err != sql.ErrNoRows {
 		return err
 	}
-	effectiveModel := snapshot.Model
-	if effectiveModel == "" && found {
-		effectiveModel = oldModel
-	}
 	in, out, total := oldIn, oldOut, oldTotal
 	if snapshot.InputTokens != nil {
 		in = *snapshot.InputTokens
@@ -58,6 +54,16 @@ func (s *Server) recordTaskRunUsage(clawID string, snapshot taskRunUsageSnapshot
 	}
 	if snapshot.TotalTokens != nil {
 		total = *snapshot.TotalTokens
+	}
+	// OpenClaw overwrites a session entry after each reply with that run's
+	// totals. total_tokens is context occupancy, not billed token usage.
+	newRun := !found || in != oldIn || out != oldOut
+	// On cost-only heartbeats keep the stored model so corrections target the
+	// usage_daily bucket that received the run's tokens; a model change takes
+	// effect with the next run's snapshot.
+	effectiveModel := snapshot.Model
+	if found && (!newRun || effectiveModel == "") {
+		effectiveModel = oldModel
 	}
 	var cost sql.NullFloat64
 	source := oldSource
@@ -73,9 +79,6 @@ func (s *Server) recordTaskRunUsage(clawID string, snapshot taskRunUsageSnapshot
 			log.Printf("[usage] no static price for model %s", effectiveModel)
 		}
 	}
-	// OpenClaw overwrites a session entry after each reply with that run's
-	// totals. total_tokens is context occupancy, not billed token usage.
-	newRun := !found || in != oldIn || out != oldOut
 	din, dout, dtotal, dcost := 0, 0, 0, 0.0
 	if newRun {
 		din, dout, dtotal = in, out, in+out
@@ -97,10 +100,7 @@ func (s *Server) recordTaskRunUsage(clawID string, snapshot taskRunUsageSnapshot
 		cost = oldCost
 		source = oldSource
 	}
-	usageNow := now()
-	if s.nowFunc != nil {
-		usageNow = s.nowFunc()
-	}
+	usageNow := s.reaperNow()
 	ts := usageNow.UnixMilli()
 	day := usageNow.UTC().Format("2006-01-02")
 	usageDay := oldUsageDay

--- a/pkg/hub/task_run_usage_test.go
+++ b/pkg/hub/task_run_usage_test.go
@@ -255,6 +255,49 @@ func TestTaskRunUsageAttributesChangedRunToNewModel(t *testing.T) {
 	}
 }
 
+func TestTaskRunUsageCostCorrectionTargetsOriginalModelBucket(t *testing.T) {
+	s, db, claw := newUsageTestServer(t)
+	defer db.Close()
+	// Run recorded under sonnet with a hub_pricing estimate (no gateway cost).
+	if err := s.recordTaskRunUsage(claw, usageSnapshot("a", 100, 40, 140, "claude-sonnet-5")); err != nil {
+		t.Fatal(err)
+	}
+	// Same-token correction arrives with a gateway cost under a different
+	// model name: the delta must hit the sonnet bucket, not open an opus one.
+	correction := usageSnapshot("a", 100, 40, 140, "claude-opus-4-8")
+	correction.EstimatedCostUSD = ptr(0.0001)
+	if err := s.recordTaskRunUsage(claw, correction); err != nil {
+		t.Fatal(err)
+	}
+	rows, err := db.Query(`SELECT model,cost_usd FROM usage_daily WHERE tenant_id='tenant'`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	got := map[string]float64{}
+	for rows.Next() {
+		var model string
+		var cost float64
+		if err := rows.Scan(&model, &cost); err != nil {
+			t.Fatal(err)
+		}
+		got[model] = cost
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || math.Abs(got["claude-sonnet-5"]-0.0001) > 1e-9 {
+		t.Fatalf("usage_daily buckets = %#v, want only claude-sonnet-5 holding the corrected cost", got)
+	}
+	var model string
+	if err := db.QueryRow(`SELECT model FROM task_run_usage WHERE session_key='a'`).Scan(&model); err != nil {
+		t.Fatal(err)
+	}
+	if model != "claude-sonnet-5" {
+		t.Fatalf("stored model = %q, want claude-sonnet-5 until the next run", model)
+	}
+}
+
 func TestTaskRunUsageUnknownModelGetsNoEstimatedCost(t *testing.T) {
 	s, db, claw := newUsageTestServer(t)
 	defer db.Close()

--- a/pkg/hub/task_run_usage_test.go
+++ b/pkg/hub/task_run_usage_test.go
@@ -116,7 +116,7 @@ func TestTaskRunUsageRecordsEachRunAndIgnoresContextTotal(t *testing.T) {
 	}
 }
 
-func TestTaskRunUsageGatewayCostCorrectsSameRunEstimate(t *testing.T) {
+func TestTaskRunUsageGatewayCostSurvivesCostlessHeartbeat(t *testing.T) {
 	s, db, claw := newUsageTestServer(t)
 	defer db.Close()
 	const model = "anthropic/claude-sonnet-5-20260203"
@@ -128,7 +128,7 @@ func TestTaskRunUsageGatewayCostCorrectsSameRunEstimate(t *testing.T) {
 	if err := s.recordTaskRunUsage(claw, snap); err != nil {
 		t.Fatal(err)
 	}
-	var cost float64
+	var cost, committedCost float64
 	var source string
 	if err := db.QueryRow(`SELECT estimated_cost_usd,cost_source FROM task_run_usage WHERE session_key='a'`).Scan(&cost, &source); err != nil {
 		t.Fatal(err)
@@ -149,6 +149,12 @@ func TestTaskRunUsageGatewayCostCorrectsSameRunEstimate(t *testing.T) {
 	}
 	if cost != 3 || source != "gateway" {
 		t.Fatalf("omitted-cost heartbeat changed stored cost to %v/%q, want 3/gateway", cost, source)
+	}
+	if err := db.QueryRow(`SELECT committed_cost_usd FROM task_run_usage WHERE session_key='a'`).Scan(&committedCost); err != nil {
+		t.Fatal(err)
+	}
+	if committedCost != 3 {
+		t.Fatalf("omitted-cost heartbeat changed committed cost to %v, want 3", committedCost)
 	}
 	if err := db.QueryRow(`SELECT estimated_cost_usd FROM task_run_summaries WHERE run_id='run-usage'`).Scan(&cost); err != nil {
 		t.Fatal(err)

--- a/pkg/hub/task_run_usage_test.go
+++ b/pkg/hub/task_run_usage_test.go
@@ -168,27 +168,90 @@ func TestTaskRunUsageGatewayCostSurvivesCostlessHeartbeat(t *testing.T) {
 	}
 }
 
-func TestTaskRunUsageCrossDayCostCorrectionClampsAtZero(t *testing.T) {
+func TestTaskRunUsageCrossDayCostCorrectionUsesOriginalDay(t *testing.T) {
 	s, db, claw := newUsageTestServer(t)
 	defer db.Close()
-	// HB1: hub_pricing estimates $18.
+	day1 := time.Date(2026, time.January, 2, 12, 0, 0, 0, time.UTC)
+	day2 := day1.AddDate(0, 0, 1)
+	s.nowFunc = func() time.Time { return day1 }
+	// Session A's hub estimate is recorded on day 1.
 	if err := s.recordTaskRunUsage(claw, usageSnapshot("a", 1_000_000, 1_000_000, 2_000_000, "claude-sonnet-5")); err != nil {
 		t.Fatal(err)
 	}
-	// Simulate a day rollover: the estimate sits in yesterday's bucket.
-	if _, err := db.Exec(`DELETE FROM usage_daily`); err != nil {
+	// Session B records unrelated real spend in the same dimensions on day 2.
+	s.nowFunc = func() time.Time { return day2 }
+	b := usageSnapshot("b", 100, 50, 150, "claude-sonnet-5")
+	b.EstimatedCostUSD = ptr(7.0)
+	if err := s.recordTaskRunUsage(claw, b); err != nil {
 		t.Fatal(err)
 	}
-	// HB2: gateway reports a lower real cost; the negative correction lands on
-	// a fresh bucket and must clamp at zero instead of seeding a negative cost.
+	// A's lower gateway cost must correct its original bucket in full.
 	snap := usageSnapshot("a", 1_000_000, 1_000_000, 2_000_000, "claude-sonnet-5")
 	snap.EstimatedCostUSD = ptr(3.0)
 	if err := s.recordTaskRunUsage(claw, snap); err != nil {
 		t.Fatal(err)
 	}
-	_, _, _, dailyCost := queryUsageDaily(t, db)
-	if dailyCost != 0 {
-		t.Fatalf("usage_daily cost = %v, want 0 (never negative)", dailyCost)
+	var day1Cost, day2Cost, total float64
+	if err := db.QueryRow(`SELECT cost_usd FROM usage_daily WHERE tenant_id='tenant' AND day=?`, day1.Format("2006-01-02")).Scan(&day1Cost); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT cost_usd FROM usage_daily WHERE tenant_id='tenant' AND day=?`, day2.Format("2006-01-02")).Scan(&day2Cost); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT SUM(cost_usd) FROM usage_daily WHERE tenant_id='tenant'`).Scan(&total); err != nil {
+		t.Fatal(err)
+	}
+	if day1Cost != 3 || day2Cost != 7 || total != 10 {
+		t.Fatalf("daily costs day1/day2/total = %v/%v/%v, want 3/7/10", day1Cost, day2Cost, total)
+	}
+}
+
+func TestTaskRunUsageKeepsLastNonEmptyModel(t *testing.T) {
+	s, db, claw := newUsageTestServer(t)
+	defer db.Close()
+	if err := s.recordTaskRunUsage(claw, usageSnapshot("a", 10, 5, 15, "claude-sonnet-5")); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.recordTaskRunUsage(claw, usageSnapshot("a", 10, 5, 15, "")); err != nil {
+		t.Fatal(err)
+	}
+	var model string
+	if err := db.QueryRow(`SELECT model FROM task_run_usage WHERE session_key='a'`).Scan(&model); err != nil {
+		t.Fatal(err)
+	}
+	if model != "claude-sonnet-5" {
+		t.Fatalf("model = %q, want claude-sonnet-5", model)
+	}
+}
+
+func TestTaskRunUsageAttributesChangedRunToNewModel(t *testing.T) {
+	s, db, claw := newUsageTestServer(t)
+	defer db.Close()
+	if err := s.recordTaskRunUsage(claw, usageSnapshot("a", 10, 5, 15, "claude-sonnet-5")); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.recordTaskRunUsage(claw, usageSnapshot("a", 20, 8, 28, "gpt-5-mini")); err != nil {
+		t.Fatal(err)
+	}
+	rows, err := db.Query(`SELECT model,input_tokens,output_tokens FROM usage_daily WHERE tenant_id='tenant' ORDER BY model`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	got := map[string][2]int{}
+	for rows.Next() {
+		var model string
+		var in, out int
+		if err := rows.Scan(&model, &in, &out); err != nil {
+			t.Fatal(err)
+		}
+		got[model] = [2]int{in, out}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if got["claude-sonnet-5"] != [2]int{10, 5} || got["gpt-5-mini"] != [2]int{20, 8} {
+		t.Fatalf("usage_daily attribution = %#v, want separate old and new model rows", got)
 	}
 }
 

--- a/pkg/hub/task_run_usage_test.go
+++ b/pkg/hub/task_run_usage_test.go
@@ -307,3 +307,25 @@ func TestHeartbeatIngestsTaskRunUsage(t *testing.T) {
 		return sumTotal == 140
 	}, "summary usage columns updated")
 }
+
+func TestMigrateBackfillsUsageDayFromUpdatedAt(t *testing.T) {
+	s, db, _ := newUsageTestServer(t)
+	defer db.Close()
+	_ = s
+	// Simulate a pre-migration row: usage_day was introduced with DEFAULT ''.
+	updatedAt := time.Date(2026, 7, 10, 15, 30, 0, 0, time.UTC).UnixMilli()
+	if _, err := db.Exec(`INSERT INTO task_run_usage(id,tenant_id,run_id,session_key,model,model_provider,input_tokens,output_tokens,total_tokens,committed_input_tokens,committed_output_tokens,committed_total_tokens,committed_cost_usd,estimated_cost_usd,cost_source,usage_day,first_seen_at,updated_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		uuid.NewString(), "tenant", "run-usage", "sess-legacy", "claude-sonnet-5", "anthropic", 10, 5, 15, 10, 5, 15, 0.01, 0.01, "hub_pricing", "", updatedAt, updatedAt); err != nil {
+		t.Fatal(err)
+	}
+	if err := migrate(db); err != nil {
+		t.Fatal(err)
+	}
+	var day string
+	if err := db.QueryRow(`SELECT usage_day FROM task_run_usage WHERE session_key='sess-legacy'`).Scan(&day); err != nil {
+		t.Fatal(err)
+	}
+	if day != "2026-07-10" {
+		t.Fatalf("usage_day = %q, want 2026-07-10", day)
+	}
+}


### PR DESCRIPTION
Applies the MINOR findings from the AIEDEV-1 (Factory Stats v2) review of ff99597..3eb5514, re-evaluated against main after #506 (per-run usage semantics) merged.

Part of [AIEDEV-1](https://linear.app/nimble-la/issue/AIEDEV-1)

## Items

1. **hub_pricing must not override a known gateway cost** — verified already subsumed by the #506 guard (`!(oldSource == "gateway" && source == "hub_pricing")` + restore path); added a regression test pinning that a cost-less heartbeat leaves cost, `cost_source` and `committed_cost_usd` untouched. (594116f)
2. **usage_daily clamp could swallow other sessions' spend** — corrections now land on the day the run's cost was originally recorded (new `task_run_usage.usage_day` column, backfilled on migration from `updated_at`), so the `MAX(0, ...)` clamp is removed; a test proves one session's cross-day correction can't erase another session's spend. (bce09ac, 8db0a2c)
3. **Model attribution on empty/changed model** — an empty-model heartbeat no longer clobbers the stored model; each run's tokens are attributed to the model reported with that run. Folded into bce09ac (same lines as item 2's change; splitting would have left an inconsistent intermediate commit).
4. **Projection nits** — projection now excludes today's partial spend and projects today as a full mean day (`remaining = daysInMonth - day + 1`); confidence uses complete days (`day - 1`); CoV uses sample std dev (n-1). Tests updated, incl. boundary cases at 7/14 complete days. (3b37462)
5. **\$0.00 vs no-data ambiguity** — usage fields on the runs API are now pointers driven by `usage_updated_at`: recorded usage emits explicit values (including zeros), never-recorded runs omit the fields. Frontend needed no changes — `web/lib/types.ts` and the "—"/drill-down logic already distinguish `undefined` from `0` correctly, so no UI screenshots (rendering change only manifests for recorded-zero runs). (4b725ee)
6. **Static pricing coverage** — seeded the gpt-5 family (gpt-5, gpt-5-mini, gpt-5-nano, gpt-5.1, gpt-5.6) at current list prices with OpenAI-style cache pricing; cost-less heartbeats with no price match are logged once per model. (1f1318a)

Also fixes in passing (4b725ee): `pkg/hub/task_run_analytics_api_test.go:249` referenced the removed `TicketToPr.Authoritative` field, so `go test ./pkg/hub` did not compile on main.

## Review & tests

- Implemented via three parallel gpt-5.6 (Codex) streams; independently reviewed by opus-4.8 and gpt-5.6. The single converged finding (missing `usage_day` backfill for pre-migration rows) is fixed in 8db0a2c.
- `go build ./...` OK; `go test ./pkg/hub -count=1` OK (17s, includes 7 new/updated usage tests + migration backfill test); `cd web && npm run build` OK (TypeScript check passed, 34 static pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)