### PR TITLE
feat: filter Linear workflows by project

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,23 @@ Watch the installation walkthrough: [YouTube quick start](https://www.youtube.co
 
 Full setup guide: [elasticclaw.ai/docs/installation](https://elasticclaw.ai/docs/installation)
 
+### Linear workflow triggers
+
+`trigger.linear` supports `event`, `workspace`, `team`, `projects`, `states`, `labels`, `exclude_labels`, `assigned_to`, and `agent_status_error`. When `projects` is omitted or empty, issues in any Linear project—including issues with no project—can match. Otherwise, an issue must belong to one of the listed project IDs or names.
+
+```yaml
+trigger:
+  linear:
+    event: status_changed
+    team: ADV
+    projects:
+      - Adversary Labs
+    states:
+      - Todo
+```
+
+See the [Linear issue workflow example](examples/workflows/linear-issue.yaml).
+
 ## Three ways to start work
 
 **From an issue tracker**

--- a/examples/workflows/linear-issue.yaml
+++ b/examples/workflows/linear-issue.yaml
@@ -1,0 +1,42 @@
+schema_version: v1
+name: linear-issue
+
+trigger:
+  linear:
+    event: status_changed
+    team: ADV
+    projects:
+      - Adversary Labs
+    states:
+      - Todo
+
+concurrency_group: example-linear-issue
+
+stages:
+  - id: working
+    label: Working
+    entry: true
+    on_enter:
+      move_issue: In Progress
+      inject: |
+        Issue: {{.Issue.Identifier}} - {{.Issue.Title}}
+        URL: {{.Issue.URL}}
+
+        Read the issue and CONTEXT.md, then start working on it.
+        Narrate your progress as you go. Keep me updated.
+
+  - id: merged
+    label: Merged
+    triggers:
+      - pr_merged: {}
+    on_enter:
+      move_issue: Done
+    terminal: true
+
+  - id: closed_no_merge
+    label: Closed Without Merge
+    triggers:
+      - pr_closed: {}
+    on_enter:
+      move_issue: Canceled
+    terminal: true

--- a/pkg/hub/integration_poller.go
+++ b/pkg/hub/integration_poller.go
@@ -261,7 +261,8 @@ type linearPollIssue struct {
 		Key  string `json:"key"`
 		Name string `json:"name"`
 	} `json:"team"`
-	Labels []struct {
+	Project *linearProjectRef `json:"project"`
+	Labels  []struct {
 		Name string `json:"name"`
 	} `json:"labels"`
 	Assignee *struct {
@@ -287,6 +288,7 @@ func (s *Server) queryLinearIssues(token, since string) ([]linearPollIssue, erro
 				updatedAt
 				state { name }
 				team { key name }
+				project { id name }
 				labels { nodes { name } }
 				assignee { name }
 			}
@@ -333,7 +335,8 @@ func (s *Server) queryLinearIssues(token, since string) ([]linearPollIssue, erro
 							Key  string `json:"key"`
 							Name string `json:"name"`
 						} `json:"team"`
-						Labels struct {
+						Project *linearProjectRef `json:"project"`
+						Labels  struct {
 							Nodes []struct {
 								Name string `json:"name"`
 							} `json:"nodes"`
@@ -369,6 +372,7 @@ func (s *Server) queryLinearIssues(token, since string) ([]linearPollIssue, erro
 				UpdatedAt:   n.UpdatedAt,
 				State:       n.State,
 				Team:        n.Team,
+				Project:     n.Project,
 				Assignee:    n.Assignee,
 			}
 			for _, l := range n.Labels.Nodes {
@@ -464,16 +468,12 @@ func (s *Server) processLinearWorkflowPollItem(issue linearPollIssue, targets []
 		if workspace == nil || workflow == nil {
 			continue
 		}
-		if workflow.Team != "" && !strings.EqualFold(workflow.Team, issue.Team.Key) {
-			continue
+		projectID, projectName := "", ""
+		if issue.Project != nil {
+			projectID = issue.Project.ID
+			projectName = issue.Project.Name
 		}
-		if workflow.TriggerStatus == "" || !strings.EqualFold(currentStatus, workflow.TriggerStatus) {
-			continue
-		}
-		if workflow.AssignedTo != "" && !assignedToMatches(workflow.AssignedTo, currentAssignee) {
-			continue
-		}
-		if !labelSetAllowed(currentLabels, workflow.Labels, workflow.ExcludeLabels) {
+		if !linearWorkflowMatchesIssue(workflow, issue.Team.Key, currentStatus, projectID, projectName, currentLabels, currentAssignee) {
 			continue
 		}
 
@@ -498,6 +498,10 @@ func (s *Server) buildLinearPollPayload(issue linearPollIssue) linearWebhookPayl
 	payload.Data.State.Name = issue.State.Name
 	payload.Data.Team.Key = issue.Team.Key
 	payload.Data.Team.Name = issue.Team.Name
+	payload.Data.Project = issue.Project
+	if issue.Project != nil {
+		payload.Data.ProjectID = issue.Project.ID
+	}
 	for _, l := range issue.Labels {
 		label := struct {
 			Name string `json:"name"`

--- a/pkg/hub/integration_poller_pagination_test.go
+++ b/pkg/hub/integration_poller_pagination_test.go
@@ -21,7 +21,7 @@ func TestQueryLinearIssuesPaginatesWithCursorVariable(t *testing.T) {
 		}
 		cursors = append(cursors, request.Variables["after"])
 		if request.Variables["after"] == nil {
-			_, _ = w.Write([]byte(`{"data":{"issues":{"nodes":[{"id":"1","identifier":"ELA-1","title":"one","createdAt":"2026-07-01T10:00:00.000Z","state":{"name":"Todo"},"team":{"key":"ELA"}}],"pageInfo":{"hasNextPage":true,"endCursor":"cursor-1"}}}}`))
+			_, _ = w.Write([]byte(`{"data":{"issues":{"nodes":[{"id":"1","identifier":"ELA-1","title":"one","createdAt":"2026-07-01T10:00:00.000Z","state":{"name":"Todo"},"team":{"key":"ELA"},"project":{"id":"project-1","name":"Adversary Labs"}}],"pageInfo":{"hasNextPage":true,"endCursor":"cursor-1"}}}}`))
 			return
 		}
 		_, _ = w.Write([]byte(`{"data":{"issues":{"nodes":[{"id":"2","identifier":"ELA-2","title":"two","state":{"name":"Todo"},"team":{"key":"ELA"}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`))
@@ -38,6 +38,9 @@ func TestQueryLinearIssuesPaginatesWithCursorVariable(t *testing.T) {
 	}
 	if issues[0].CreatedAt != "2026-07-01T10:00:00.000Z" {
 		t.Fatalf("issues[0].CreatedAt = %q, want createdAt propagated from GraphQL response", issues[0].CreatedAt)
+	}
+	if issues[0].Project == nil || issues[0].Project.ID != "project-1" || issues[0].Project.Name != "Adversary Labs" {
+		t.Fatalf("issues[0].Project = %#v, want project ID and name", issues[0].Project)
 	}
 	if len(cursors) != 2 || cursors[0] != nil || cursors[1] != "cursor-1" {
 		t.Fatalf("cursor variables = %#v", cursors)
@@ -180,5 +183,8 @@ func TestLinearPollQueryUsesExpectedSince(t *testing.T) {
 	}
 	if !strings.Contains(query, since) {
 		t.Fatalf("query %q does not contain since %q", query, since)
+	}
+	if !strings.Contains(query, "project { id name }") {
+		t.Fatalf("query %q does not request Linear project ID and name", query)
 	}
 }

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -21,6 +21,11 @@ import (
 )
 
 // linearWebhookPayload is the relevant subset of a Linear webhook event.
+type linearProjectRef struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
 type linearWebhookPayload struct {
 	Action    string `json:"action"`    // "create", "update", "remove"
 	Type      string `json:"type"`      // "Issue", "IssueLabel", etc.
@@ -39,7 +44,9 @@ type linearWebhookPayload struct {
 			Key  string `json:"key"`
 			Name string `json:"name"`
 		} `json:"team"`
-		Labels []struct {
+		Project   *linearProjectRef `json:"project,omitempty"`
+		ProjectID string            `json:"projectId,omitempty"`
+		Labels    []struct {
 			Name string `json:"name"`
 		} `json:"labels,omitempty"`
 		Assignee *struct {
@@ -368,6 +375,7 @@ func (s *Server) processLinearWorkflowEvent(workspaces []*types.WorkspaceConfig,
 	if payload.Data.Assignee != nil {
 		assignee = payload.Data.Assignee.Name
 	}
+	projectID, projectName := linearWebhookProject(payload)
 
 	matched := false
 	for _, workspace := range workspaces {
@@ -378,13 +386,7 @@ func (s *Server) processLinearWorkflowEvent(workspaces []*types.WorkspaceConfig,
 			if workflow.Enabled != nil && !*workflow.Enabled {
 				continue
 			}
-			if workflow.Team != "" && !strings.EqualFold(workflow.Team, teamKey) {
-				continue
-			}
-			if !labelSetAllowed(issueLabels, workflow.Labels, workflow.ExcludeLabels) {
-				continue
-			}
-			if workflow.AssignedTo != "" && !assignedToMatches(workflow.AssignedTo, assignee) {
+			if !linearWorkflowFiltersMatch(workflow, teamKey, projectID, projectName, issueLabels, assignee) {
 				continue
 			}
 			if workflow.TriggerStatus == "" {
@@ -410,6 +412,72 @@ func (s *Server) processLinearWorkflowEvent(workspaces []*types.WorkspaceConfig,
 		}
 	}
 	return matched
+}
+
+func linearWebhookProject(payload linearWebhookPayload) (string, string) {
+	projectID := strings.TrimSpace(payload.Data.ProjectID)
+	if payload.Data.Project == nil {
+		return projectID, ""
+	}
+	if nestedID := strings.TrimSpace(payload.Data.Project.ID); nestedID != "" {
+		projectID = nestedID
+	}
+	return projectID, strings.TrimSpace(payload.Data.Project.Name)
+}
+
+func linearWorkflowProjects(workflow *types.WorkflowConfig) []string {
+	if workflow == nil {
+		return nil
+	}
+	if workflow.Trigger != nil && workflow.Trigger.Linear != nil {
+		return workflow.Trigger.Linear.Projects
+	}
+	// Compatibility for already-normalized workflow values.
+	return workflow.TriggerRepos
+}
+
+func linearProjectMatches(projectID, projectName string, projects []string) bool {
+	if len(projects) == 0 {
+		return true
+	}
+	projectID = strings.TrimSpace(projectID)
+	projectName = strings.TrimSpace(projectName)
+	if projectID == "" && projectName == "" {
+		return false
+	}
+	for _, configured := range projects {
+		configured = strings.TrimSpace(configured)
+		if projectID != "" && configured == projectID {
+			return true
+		}
+		if projectName != "" && strings.EqualFold(configured, projectName) {
+			return true
+		}
+	}
+	return false
+}
+
+func linearWorkflowFiltersMatch(workflow *types.WorkflowConfig, teamKey, projectID, projectName string, issueLabels map[string]bool, assignee string) bool {
+	if workflow == nil {
+		return false
+	}
+	if workflow.Team != "" && !strings.EqualFold(workflow.Team, teamKey) {
+		return false
+	}
+	if !linearProjectMatches(projectID, projectName, linearWorkflowProjects(workflow)) {
+		return false
+	}
+	if !labelSetAllowed(issueLabels, workflow.Labels, workflow.ExcludeLabels) {
+		return false
+	}
+	return workflow.AssignedTo == "" || assignedToMatches(workflow.AssignedTo, assignee)
+}
+
+func linearWorkflowMatchesIssue(workflow *types.WorkflowConfig, teamKey, state, projectID, projectName string, issueLabels map[string]bool, assignee string) bool {
+	if workflow == nil || workflow.TriggerStatus == "" || !strings.EqualFold(workflow.TriggerStatus, state) {
+		return false
+	}
+	return linearWorkflowFiltersMatch(workflow, teamKey, projectID, projectName, issueLabels, assignee)
 }
 
 func (s *Server) notifyLinearWorkflowCreateFailure(workspace *types.WorkspaceConfig, workflow *types.WorkflowConfig, payload linearWebhookPayload, createErr error) {

--- a/pkg/hub/linear_project_filter_test.go
+++ b/pkg/hub/linear_project_filter_test.go
@@ -1,0 +1,71 @@
+package hub
+
+import (
+	"testing"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func TestLinearProjectMatches(t *testing.T) {
+	tests := []struct {
+		name        string
+		projectID   string
+		projectName string
+		configured  []string
+		want        bool
+	}{
+		{name: "omitted filter matches project", projectName: "Anything", want: true},
+		{name: "empty filter matches no project", configured: []string{}, want: true},
+		{name: "configured filter rejects no project", configured: []string{"Adversary Labs"}, want: false},
+		{name: "stable ID", projectID: "68f0d971-0db2-4c27-b3b6-cf1f67d827a5", projectName: "Renamed", configured: []string{"68f0d971-0db2-4c27-b3b6-cf1f67d827a5"}, want: true},
+		{name: "name ignores case and whitespace", projectName: " Adversary Labs ", configured: []string{"  adversary labs  "}, want: true},
+		{name: "multiple projects use OR", projectName: "Adversary Labs", configured: []string{"Platform", "Adversary Labs", "Website"}, want: true},
+		{name: "different project", projectName: "Platform", configured: []string{"Adversary Labs"}, want: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := linearProjectMatches(test.projectID, test.projectName, test.configured); got != test.want {
+				t.Fatalf("linearProjectMatches(%q, %q, %#v) = %v, want %v", test.projectID, test.projectName, test.configured, got, test.want)
+			}
+		})
+	}
+}
+
+func TestLinearWorkflowFiltersComposeWithANDSemantics(t *testing.T) {
+	workflow := &types.WorkflowConfig{
+		Team:          "ADV",
+		TriggerStatus: "Todo",
+		Labels:        []string{"agent-ready"},
+		ExcludeLabels: []string{"blocked"},
+		AssignedTo:    "@Marc",
+		Trigger: &types.WorkflowTrigger{Linear: &types.LinearWorkflowTrigger{
+			Projects: []string{"Adversary Labs"},
+		}},
+	}
+	matchingLabels := map[string]bool{"agent-ready": true}
+	tests := []struct {
+		name        string
+		team        string
+		state       string
+		projectName string
+		labels      map[string]bool
+		assignee    string
+		want        bool
+	}{
+		{name: "all filters", team: "ADV", state: "Todo", projectName: "Adversary Labs", labels: matchingLabels, assignee: "marc", want: true},
+		{name: "team mismatch", team: "OTHER", state: "Todo", projectName: "Adversary Labs", labels: matchingLabels, assignee: "marc"},
+		{name: "state mismatch", team: "ADV", state: "Backlog", projectName: "Adversary Labs", labels: matchingLabels, assignee: "marc"},
+		{name: "project mismatch", team: "ADV", state: "Todo", projectName: "Platform", labels: matchingLabels, assignee: "marc"},
+		{name: "required label missing", team: "ADV", state: "Todo", projectName: "Adversary Labs", labels: map[string]bool{}, assignee: "marc"},
+		{name: "excluded label present", team: "ADV", state: "Todo", projectName: "Adversary Labs", labels: map[string]bool{"agent-ready": true, "blocked": true}, assignee: "marc"},
+		{name: "assignee mismatch", team: "ADV", state: "Todo", projectName: "Adversary Labs", labels: matchingLabels, assignee: "alex"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := linearWorkflowMatchesIssue(workflow, test.team, test.state, "", test.projectName, test.labels, test.assignee)
+			if got != test.want {
+				t.Fatalf("linearWorkflowMatchesIssue() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}

--- a/pkg/hub/linear_project_filter_test.go
+++ b/pkg/hub/linear_project_filter_test.go
@@ -15,7 +15,7 @@ func TestLinearProjectMatches(t *testing.T) {
 		want        bool
 	}{
 		{name: "omitted filter matches project", projectName: "Anything", want: true},
-		{name: "empty filter matches no project", configured: []string{}, want: true},
+		{name: "empty configured filter is a wildcard including no project", configured: []string{}, want: true},
 		{name: "configured filter rejects no project", configured: []string{"Adversary Labs"}, want: false},
 		{name: "stable ID", projectID: "68f0d971-0db2-4c27-b3b6-cf1f67d827a5", projectName: "Renamed", configured: []string{"68f0d971-0db2-4c27-b3b6-cf1f67d827a5"}, want: true},
 		{name: "name ignores case and whitespace", projectName: " Adversary Labs ", configured: []string{"  adversary labs  "}, want: true},

--- a/pkg/hub/linear_webhook_test.go
+++ b/pkg/hub/linear_webhook_test.go
@@ -128,6 +128,66 @@ func TestLinearWorkflowExcludeLabelsRoutesGenericAndBugWorkflows(t *testing.T) {
 	assertLinearClawTagsContain(t, db, "ELA-125", "workflow:bug-workflow")
 }
 
+func TestLinearWorkflowWebhookFiltersProjects(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
+	linear := factorytest.NewMockLinear(t)
+	s, db := hub.NewTestServerWithConfig(t, &types.HubConfig{
+		ClawToken: "test-claw-token",
+		Providers: map[string]types.ProviderConfig{"noop": {Type: "noop"}},
+	}, "", linear.URL, "")
+	saveWorkflowPollWorkspaceFixture(t, "workspace-a", []*types.WorkflowConfig{{
+		SchemaVersion: "v1",
+		Name:          "linear-project-workflow",
+		Trigger: &types.WorkflowTrigger{Linear: &types.LinearWorkflowTrigger{
+			Event:    "status_changed",
+			Team:     "ELA",
+			Projects: []string{"Adversary Labs", "project-id-allowed"},
+			States:   []string{"Todo"},
+		}},
+		Stages: workflowPollTestStages(),
+	}})
+
+	httpSrv := httptest.NewServer(s.Handler())
+	t.Cleanup(httpSrv.Close)
+
+	postLinearWebhook(t, httpSrv.URL, "workspace-a", linearWebhookPayloadWithProject(t, linear, "ELA-201", "Backlog", "Todo", "project-adv", " adversary labs "))
+	waitForLinearClawCount(t, db, "ELA-201", 1)
+	postLinearWebhook(t, httpSrv.URL, "workspace-a", linearWebhookPayloadWithProject(t, linear, "ELA-205", "Backlog", "Todo", "project-id-allowed", "Renamed Project"))
+	waitForLinearClawCount(t, db, "ELA-205", 1)
+
+	postLinearWebhook(t, httpSrv.URL, "workspace-a", linearWebhookPayloadWithProject(t, linear, "ELA-202", "Backlog", "Todo", "project-platform", "Platform"))
+	assertNoLinearClawCreated(t, db, "ELA-202")
+
+	postLinearWebhook(t, httpSrv.URL, "workspace-a", linearWebhookPayloadWithProject(t, linear, "ELA-203", "Backlog", "Todo", "", ""))
+	assertNoLinearClawCreated(t, db, "ELA-203")
+}
+
+func TestLinearWorkflowWebhookWithoutProjectsMatchesUnprojectedIssue(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
+	linear := factorytest.NewMockLinear(t)
+	s, db := hub.NewTestServerWithConfig(t, &types.HubConfig{
+		ClawToken: "test-claw-token",
+		Providers: map[string]types.ProviderConfig{"noop": {Type: "noop"}},
+	}, "", linear.URL, "")
+	saveWorkflowPollWorkspaceFixture(t, "workspace-a", []*types.WorkflowConfig{{
+		SchemaVersion: "v1",
+		Name:          "linear-unfiltered-workflow",
+		Trigger: &types.WorkflowTrigger{Linear: &types.LinearWorkflowTrigger{
+			Event:  "status_changed",
+			Team:   "ELA",
+			States: []string{"Todo"},
+		}},
+		Stages: workflowPollTestStages(),
+	}})
+
+	httpSrv := httptest.NewServer(s.Handler())
+	t.Cleanup(httpSrv.Close)
+	postLinearWebhook(t, httpSrv.URL, "workspace-a", linearWebhookPayloadWithProject(t, linear, "ELA-204", "Backlog", "Todo", "", ""))
+	waitForLinearClawCount(t, db, "ELA-204", 1)
+}
+
 func saveLinearRoutingWorkflowFixture(t *testing.T, workspace string) {
 	t.Helper()
 	hub.SaveWorkspaceForTest(t,
@@ -190,6 +250,23 @@ func linearWebhookPayloadWithLabels(t *testing.T, linear *factorytest.MockLinear
 	return out
 }
 
+func linearWebhookPayloadWithProject(t *testing.T, linear *factorytest.MockLinear, issueID, prevStatus, newStatus, projectID, projectName string) []byte {
+	t.Helper()
+	payload, _ := linear.BuildWebhookPayload(issueID, prevStatus, newStatus)
+	var data map[string]interface{}
+	if err := json.Unmarshal(payload, &data); err != nil {
+		t.Fatalf("parse payload: %v", err)
+	}
+	if projectID != "" || projectName != "" {
+		data["data"].(map[string]interface{})["project"] = map[string]string{"id": projectID, "name": projectName}
+	}
+	out, err := json.Marshal(data)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	return out
+}
+
 func waitForLinearClawCount(t *testing.T, db interface {
 	QueryRow(string, ...interface{}) *sql.Row
 }, issueID string, want int) {
@@ -205,6 +282,23 @@ func waitForLinearClawCount(t *testing.T, db interface {
 		}
 		if time.Now().After(deadline) {
 			t.Fatalf("claws for %s = %d, want %d", issueID, count, want)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func assertNoLinearClawCreated(t *testing.T, db interface {
+	QueryRow(string, ...interface{}) *sql.Row
+}, issueID string) {
+	t.Helper()
+	deadline := time.Now().Add(300 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		var count int
+		if err := db.QueryRow(`SELECT COUNT(*) FROM claws WHERE linear_issue_id=?`, issueID).Scan(&count); err != nil {
+			t.Fatalf("count claws: %v", err)
+		}
+		if count != 0 {
+			t.Fatalf("claws for %s = %d, want 0", issueID, count)
 		}
 		time.Sleep(10 * time.Millisecond)
 	}

--- a/pkg/hub/linear_webhook_test.go
+++ b/pkg/hub/linear_webhook_test.go
@@ -291,7 +291,7 @@ func assertNoLinearClawCreated(t *testing.T, db interface {
 	QueryRow(string, ...interface{}) *sql.Row
 }, issueID string) {
 	t.Helper()
-	deadline := time.Now().Add(300 * time.Millisecond)
+	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
 		var count int
 		if err := db.QueryRow(`SELECT COUNT(*) FROM claws WHERE linear_issue_id=?`, issueID).Scan(&count); err != nil {

--- a/pkg/hub/task_run_analytics_api_test.go
+++ b/pkg/hub/task_run_analytics_api_test.go
@@ -246,7 +246,7 @@ func TestTaskRunAnalyticsAPIGeneralStatsIssueCreatedAtAtRunCreation(t *testing.T
 	var response taskRunGeneralStatsResponse
 	decodeTaskRunAnalyticsAPI(t, rr, &response)
 	if response.TicketToPr.AvgMs == nil || *response.TicketToPr.AvgMs != 5000 || response.TicketToPr.Samples != 1 ||
-		response.TicketToPr.Authoritative == nil || !*response.TicketToPr.Authoritative {
+		response.TicketToPr.AuthoritativeSamples == nil || *response.TicketToPr.AuthoritativeSamples != 1 {
 		t.Fatalf("ticket stats: %#v", response.TicketToPr)
 	}
 }

--- a/pkg/hub/workflow_poller_test.go
+++ b/pkg/hub/workflow_poller_test.go
@@ -49,6 +49,39 @@ func TestLinearWorkflowPollCreatesOnceForMissedWebhook(t *testing.T) {
 	}
 }
 
+func TestLinearWorkflowPollFiltersProjectsLikeWebhook(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
+	linear := factorytest.NewMockLinear(t)
+	s, db := hub.NewTestServerWithConfig(t, &types.HubConfig{
+		ClawToken: "test-claw-token",
+		Providers: map[string]types.ProviderConfig{"noop": {Type: "noop"}},
+	}, "", linear.URL, "")
+	saveWorkflowPollWorkspaceFixture(t, "workspace-a", []*types.WorkflowConfig{{
+		SchemaVersion: "v1",
+		Name:          "linear-project-workflow",
+		Trigger: &types.WorkflowTrigger{Linear: &types.LinearWorkflowTrigger{
+			Event:    "status_changed",
+			Team:     "ELA",
+			Projects: []string{"Adversary Labs"},
+			States:   []string{"Todo"},
+		}},
+		Stages: workflowPollTestStages(),
+	}})
+	hub.SaveWorkspaceIssueTrackerForTest(t, "workspace-a", "linear", "default", "test-linear-token", "")
+
+	linear.SetIssueStateName("ELA-123", "Todo")
+	linear.PollingIssues["ELA-123"]["project"] = map[string]interface{}{"id": "project-adv", "name": "Adversary Labs"}
+	linear.PollingIssues["ELA-124"] = linearPollTestIssue("ELA-124", "Todo", map[string]interface{}{"id": "project-platform", "name": "Platform"})
+	linear.PollingIssues["ELA-125"] = linearPollTestIssue("ELA-125", "Todo", nil)
+
+	s.PollIntegrationsForTest()
+
+	assertLinearPollClawCount(t, db, "ELA-123", 1)
+	assertLinearPollClawCount(t, db, "ELA-124", 0)
+	assertLinearPollClawCount(t, db, "ELA-125", 0)
+}
+
 func TestShortcutWorkflowPollCreatesOnceForMissedWebhook(t *testing.T) {
 	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
 	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
@@ -214,6 +247,33 @@ func assertPollClawTagsContain(t *testing.T, db *sql.DB, idColumn, idValue, want
 	}
 	if !strings.Contains(tags, want) {
 		t.Fatalf("tags for %s = %s, want %q", idValue, tags, want)
+	}
+}
+
+func linearPollTestIssue(identifier, state string, project interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"id":          "issue-uuid-" + identifier,
+		"identifier":  identifier,
+		"title":       "Project filter test",
+		"description": "Test description",
+		"url":         "https://linear.app/test/issue/" + identifier,
+		"updatedAt":   "2026-07-19T00:00:00Z",
+		"state":       map[string]interface{}{"name": state},
+		"team":        map[string]interface{}{"name": "Engineering", "key": "ELA"},
+		"project":     project,
+		"labels":      map[string]interface{}{"nodes": []map[string]interface{}{}},
+		"assignee":    nil,
+	}
+}
+
+func assertLinearPollClawCount(t *testing.T, db *sql.DB, issueID string, want int) {
+	t.Helper()
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM claws WHERE linear_issue_id=?`, issueID).Scan(&count); err != nil {
+		t.Fatalf("count claws for %s: %v", issueID, err)
+	}
+	if count != want {
+		t.Fatalf("claws for %s = %d, want %d", issueID, count, want)
 	}
 }
 

--- a/pkg/hub/workspace_api.go
+++ b/pkg/hub/workspace_api.go
@@ -40,6 +40,7 @@ type WorkflowView struct {
 	IntegrationWorkspace string                 `json:"integrationWorkspace,omitempty"`
 	TriggerStatus        string                 `json:"triggerStatus,omitempty"`
 	DoneStatus           string                 `json:"doneStatus,omitempty"`
+	Projects             []string               `json:"projects,omitempty"`
 	Labels               []string               `json:"labels,omitempty"`
 	ExcludeLabels        []string               `json:"exclude_labels,omitempty"`
 	AssignedTo           string                 `json:"assignedTo,omitempty"`
@@ -479,6 +480,10 @@ func workspaceEnvNames(env types.WorkspaceEnv) []string {
 }
 
 func workflowToView(workspaceName string, workflow *types.WorkflowConfig) WorkflowView {
+	var projects []string
+	if workflow.Integration == "linear" || (workflow.Trigger != nil && workflow.Trigger.Linear != nil) {
+		projects = append([]string(nil), linearWorkflowProjects(workflow)...)
+	}
 	return WorkflowView{
 		Name:                 workflow.Name,
 		WorkspaceName:        workspaceName,
@@ -486,6 +491,7 @@ func workflowToView(workspaceName string, workflow *types.WorkflowConfig) Workfl
 		Integration:          workflow.Integration,
 		IntegrationWorkspace: workflow.Workspace,
 		TriggerStatus:        workflow.TriggerStatus,
+		Projects:             projects,
 		Labels:               append([]string(nil), workflow.Labels...),
 		ExcludeLabels:        append([]string(nil), workflow.ExcludeLabels...),
 		AssignedTo:           workflow.AssignedTo,

--- a/pkg/hub/workspace_api_test.go
+++ b/pkg/hub/workspace_api_test.go
@@ -192,6 +192,47 @@ func TestWorkflowPushAcceptsNestedGitHubIssuesTrigger(t *testing.T) {
 	}
 }
 
+func TestWorkflowPushPreservesAndSerializesLinearProjects(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", configDir+"/hub.yaml")
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+
+	workspaceBody := `{"workspaces":[{"name":"engineering"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/api/workspaces", strings.NewReader(workspaceBody))
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("workspace push status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+
+	workflowBody := `{"workflows":[{"schemaVersion":"v1","name":"linear-project","trigger":{"linear":{"event":"status_changed","team":"ADV","projects":["Adversary Labs"],"states":["Todo"]}},"stages":[{"id":"working","entry":true}]}]}`
+	req = httptest.NewRequest(http.MethodPost, "/api/workspaces/engineering/workflows", strings.NewReader(workflowBody))
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	rr = httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("workflow push status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), `"projects":["Adversary Labs"]`) {
+		t.Fatalf("workflow API response does not expose projects: %s", rr.Body.String())
+	}
+
+	workspace, err := loadExternalWorkspace("engineering")
+	if err != nil {
+		t.Fatalf("load workspace: %v", err)
+	}
+	if len(workspace.Workflows) != 1 || workspace.Workflows[0].Trigger == nil || workspace.Workflows[0].Trigger.Linear == nil {
+		t.Fatalf("Linear workflow not preserved: %#v", workspace.Workflows)
+	}
+	projects := workspace.Workflows[0].Trigger.Linear.Projects
+	if len(projects) != 1 || projects[0] != "Adversary Labs" {
+		t.Fatalf("persisted projects = %#v, want Adversary Labs", projects)
+	}
+}
+
 func TestWorkflowPushReloadsCronScheduler(t *testing.T) {
 	configDir := t.TempDir()
 	t.Setenv("ELASTICCLAW_HUB_CONFIG", configDir+"/hub.yaml")

--- a/pkg/types/linear_workflow_projects_test.go
+++ b/pkg/types/linear_workflow_projects_test.go
@@ -1,0 +1,111 @@
+package types
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestLinearWorkflowProjectsSchemaNormalizeAndRoundTrip(t *testing.T) {
+	const source = `schema_version: v1
+name: adversary-labs
+trigger:
+  linear:
+    event: status_changed
+    team: ADV
+    projects:
+      - Adversary Labs
+      - 68f0d971-0db2-4c27-b3b6-cf1f67d827a5
+    states:
+      - Todo
+stages:
+  - id: working
+    entry: true
+`
+	var workflow WorkflowConfig
+	if err := yaml.Unmarshal([]byte(source), &workflow); err != nil {
+		t.Fatalf("unmarshal YAML: %v", err)
+	}
+	if err := workflow.Validate(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if err := NormalizeWorkflowConfig(&workflow); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	want := []string{"Adversary Labs", "68f0d971-0db2-4c27-b3b6-cf1f67d827a5"}
+	if got := workflow.Trigger.Linear.Projects; !equalStrings(got, want) {
+		t.Fatalf("trigger.linear.projects = %#v, want %#v", got, want)
+	}
+	if got := workflow.TriggerRepos; !equalStrings(got, want) {
+		t.Fatalf("normalized trigger_repos = %#v, want %#v", got, want)
+	}
+
+	encoded, err := json.Marshal(&workflow)
+	if err != nil {
+		t.Fatalf("marshal JSON: %v", err)
+	}
+	if !strings.Contains(string(encoded), `"projects":["Adversary Labs","68f0d971-0db2-4c27-b3b6-cf1f67d827a5"]`) {
+		t.Fatalf("JSON does not preserve trigger.linear.projects: %s", encoded)
+	}
+}
+
+func TestLinearWorkflowProjectsValidation(t *testing.T) {
+	for _, projects := range [][]string{{""}, {" \t "}} {
+		workflow := &WorkflowConfig{
+			Name: "linear-projects",
+			Trigger: &WorkflowTrigger{Linear: &LinearWorkflowTrigger{
+				Event:    "status_changed",
+				Projects: projects,
+				States:   []string{"Todo"},
+			}},
+		}
+		err := workflow.Validate()
+		if err == nil || !strings.Contains(err.Error(), "trigger.linear.projects[0] cannot be blank") {
+			t.Fatalf("Validate() error = %v, want blank project error", err)
+		}
+	}
+}
+
+func TestLinearWorkflowProjectsMalformedListFailsParsing(t *testing.T) {
+	const source = `name: malformed
+trigger:
+  linear:
+    event: status_changed
+    projects: Adversary Labs
+    states: [Todo]
+`
+	var workflow WorkflowConfig
+	if err := yaml.Unmarshal([]byte(source), &workflow); err == nil {
+		t.Fatal("expected scalar trigger.linear.projects to fail parsing")
+	}
+}
+
+func TestLinearWorkflowWithoutProjectsNormalizesAsUnfiltered(t *testing.T) {
+	workflow := &WorkflowConfig{
+		Name: "all-projects",
+		Trigger: &WorkflowTrigger{Linear: &LinearWorkflowTrigger{
+			Event:  "status_changed",
+			States: []string{"Todo"},
+		}},
+	}
+	if err := NormalizeWorkflowConfig(workflow); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if len(workflow.TriggerRepos) != 0 {
+		t.Fatalf("normalized trigger_repos = %#v, want empty", workflow.TriggerRepos)
+	}
+}
+
+func equalStrings(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/types/validation.go
+++ b/pkg/types/validation.go
@@ -427,6 +427,11 @@ func validateLinearWorkflowTrigger(workflowName string, trigger *LinearWorkflowT
 			return fmt.Errorf("workflow %q: trigger.linear.states[%d] cannot be empty", workflowName, i)
 		}
 	}
+	for i, project := range trigger.Projects {
+		if strings.TrimSpace(project) == "" {
+			return fmt.Errorf("workflow %q: trigger.linear.projects[%d] cannot be blank", workflowName, i)
+		}
+	}
 	if trigger.AgentStatusError != "" && strings.TrimSpace(trigger.AgentStatusError) == "" {
 		return fmt.Errorf("workflow %q: trigger.linear.agent_status_error cannot be blank", workflowName)
 	}

--- a/pkg/types/workflow_normalize.go
+++ b/pkg/types/workflow_normalize.go
@@ -36,6 +36,7 @@ func NormalizeWorkflowConfig(workflow *WorkflowConfig) error {
 			workflow.Integration = "linear"
 			workflow.Workspace = workflow.Trigger.Linear.Workspace
 			workflow.Team = workflow.Trigger.Linear.Team
+			workflow.TriggerRepos = append([]string(nil), workflow.Trigger.Linear.Projects...)
 			workflow.Labels = append([]string(nil), workflow.Trigger.Linear.Labels...)
 			workflow.ExcludeLabels = append([]string(nil), workflow.Trigger.Linear.ExcludeLabels...)
 			workflow.AssignedTo = workflow.Trigger.Linear.AssignedTo

--- a/pkg/types/workspace.go
+++ b/pkg/types/workspace.go
@@ -132,6 +132,7 @@ type LinearWorkflowTrigger struct {
 	Event            string   `yaml:"event,omitempty" json:"event,omitempty"`
 	Workspace        string   `yaml:"workspace,omitempty" json:"workspace,omitempty"`
 	Team             string   `yaml:"team,omitempty" json:"team,omitempty"`
+	Projects         []string `yaml:"projects,omitempty" json:"projects,omitempty"`
 	States           []string `yaml:"states,omitempty" json:"states,omitempty"`
 	Labels           []string `yaml:"labels,omitempty" json:"labels,omitempty"`
 	ExcludeLabels    []string `yaml:"exclude_labels,omitempty" json:"exclude_labels,omitempty"`

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -3137,6 +3137,7 @@ function WorkflowSummaryRow({
           <p className="text-xs text-muted-foreground truncate">
             {workflow.workspaceName} · {workflow.integration || "manual"}
             {workflow.triggerStatus ? ` · ${workflow.triggerStatus}` : ""}
+            {workflow.projects?.length ? ` · projects: ${workflow.projects.join(", ")}` : ""}
           </p>
         </div>
         <div className="flex flex-wrap items-center gap-x-4 gap-y-2 shrink-0">

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -306,6 +306,7 @@ export interface Workflow {
   integrationWorkspace?: string
   triggerStatus?: string
   doneStatus?: string
+  projects?: string[]
   labels?: string[]
   assignedTo?: string
   enabled: boolean


### PR DESCRIPTION
## Summary

- add `trigger.linear.projects` to the v1 workflow schema with validation, normalization, persistence, API, and UI support
- apply shared project matching to Linear webhooks and missed-event polling using stable IDs or trimmed, case-insensitive names
- preserve wildcard behavior for omitted/empty project lists and document the new field with a Linear workflow example

## Matching semantics

- configured projects use OR semantics
- project IDs match exactly after trimming
- project names match case-insensitively after trimming
- issues without a project do not match a configured project filter
- team, state, project, required/excluded labels, and assignee compose with AND semantics

## Tests

- `GOCACHE=/tmp/elasticclaw-go-cache go test ./pkg/types`
- focused Linear webhook, poller, matcher, GraphQL, persistence, and API tests
- `GOCACHE=/tmp/elasticclaw-go-cache go build ./...`
- `npx tsc --noEmit`
- `npm run build`
- `git diff --check`

## Existing baseline issues

- the full `pkg/hub` test package currently does not compile because `task_run_analytics_api_test.go` references the absent `taskRunGeneralStat.Authoritative` field
- `npm run lint` currently reports 23 existing errors and 7 warnings in unrelated React hook/UI code
