### PR TITLE
Fix Grok OAuth claw bootstrap

### DIFF
--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -2412,7 +2412,103 @@ func restoreCLIModelAuth() error {
 			return fmt.Errorf("write auth file %s: %w", rel, err)
 		}
 	}
+	if os.Getenv("ELASTICCLAW_MODEL_AUTH_PROVIDER") == "grok" {
+		if err := migrateGrokOAuthToOpenClaw(home); err != nil {
+			return fmt.Errorf("migrate Grok OAuth to OpenClaw: %w", err)
+		}
+	}
 	log.Printf("[bootstrap] restored %d CLI auth files for %s", len(bundle.Files), os.Getenv("ELASTICCLAW_MODEL_AUTH_PROVIDER"))
+	return nil
+}
+
+func migrateGrokOAuthToOpenClaw(home string) error {
+	type grokAuthEntry struct {
+		Key          string `json:"key"`
+		RefreshToken string `json:"refresh_token"`
+		ExpiresAt    string `json:"expires_at"`
+		Email        string `json:"email"`
+		UserID       string `json:"user_id"`
+		OIDCIssuer   string `json:"oidc_issuer"`
+	}
+
+	data, err := os.ReadFile(filepath.Join(home, ".grok", "auth.json"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	var grokAuth map[string]grokAuthEntry
+	if err := json.Unmarshal(data, &grokAuth); err != nil {
+		return fmt.Errorf("parse Grok auth: %w", err)
+	}
+	var selected grokAuthEntry
+	for _, entry := range grokAuth {
+		if entry.Key != "" && entry.RefreshToken != "" {
+			selected = entry
+			break
+		}
+	}
+	if selected.Key == "" || selected.RefreshToken == "" {
+		return nil
+	}
+
+	expires := int64(0)
+	if parsed, err := time.Parse(time.RFC3339Nano, selected.ExpiresAt); err == nil {
+		expires = parsed.UnixMilli()
+	}
+	issuer := strings.TrimRight(selected.OIDCIssuer, "/")
+	if issuer == "" {
+		issuer = "https://auth.x.ai"
+	}
+	credential := map[string]interface{}{
+		"type":          "oauth",
+		"provider":      "xai",
+		"access":        selected.Key,
+		"refresh":       selected.RefreshToken,
+		"expires":       expires,
+		"issuer":        issuer,
+		"tokenEndpoint": issuer + "/oauth2/token",
+	}
+	if selected.Email != "" {
+		credential["email"] = selected.Email
+	}
+	if selected.UserID != "" {
+		credential["accountId"] = selected.UserID
+	}
+
+	authPath := filepath.Join(home, ".openclaw", "agents", "main", "agent", "auth-profiles.json")
+	authStore := map[string]interface{}{}
+	if existing, err := os.ReadFile(authPath); err == nil {
+		if err := json.Unmarshal(existing, &authStore); err != nil {
+			return fmt.Errorf("parse OpenClaw auth profiles: %w", err)
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	profiles, _ := authStore["profiles"].(map[string]interface{})
+	if profiles == nil {
+		profiles = map[string]interface{}{}
+	}
+	profiles["xai:default"] = credential
+	authStore["version"] = 1
+	authStore["profiles"] = profiles
+
+	encoded, err := json.MarshalIndent(authStore, "", "  ")
+	if err != nil {
+		return err
+	}
+	encoded = append(encoded, '\n')
+	if err := os.MkdirAll(filepath.Dir(authPath), 0700); err != nil {
+		return err
+	}
+	tempPath := authPath + ".tmp"
+	if err := os.WriteFile(tempPath, encoded, 0600); err != nil {
+		return err
+	}
+	if err := os.Rename(tempPath, authPath); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -698,6 +698,55 @@ func TestRestoreCLIModelAuthWritesBundleFiles(t *testing.T) {
 	}
 }
 
+func TestRestoreCLIModelAuthMigratesGrokOAuthToOpenClaw(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	bundle := cliAuthBundle{
+		Files: map[string]string{
+			".grok/auth.json": base64.StdEncoding.EncodeToString([]byte(`{"https://auth.x.ai::client":{"key":"access-token","refresh_token":"refresh-token","expires_at":"2030-01-02T03:04:05Z","email":"dev@example.com","user_id":"user-123","oidc_issuer":"https://auth.x.ai"}}`)),
+		},
+	}
+	data, err := json.Marshal(bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("ELASTICCLAW_MODEL_AUTH_PROVIDER", "grok")
+	t.Setenv("ELASTICCLAW_MODEL_AUTH_STATE", base64.StdEncoding.EncodeToString(data))
+
+	if err := restoreCLIModelAuth(); err != nil {
+		t.Fatalf("restore auth: %v", err)
+	}
+	authData, err := os.ReadFile(filepath.Join(home, ".openclaw", "agents", "main", "agent", "auth-profiles.json"))
+	if err != nil {
+		t.Fatalf("read OpenClaw auth profile: %v", err)
+	}
+	var auth struct {
+		Version  int `json:"version"`
+		Profiles map[string]struct {
+			Type      string `json:"type"`
+			Provider  string `json:"provider"`
+			Access    string `json:"access"`
+			Refresh   string `json:"refresh"`
+			Expires   int64  `json:"expires"`
+			Email     string `json:"email"`
+			AccountID string `json:"accountId"`
+		} `json:"profiles"`
+	}
+	if err := json.Unmarshal(authData, &auth); err != nil {
+		t.Fatalf("parse OpenClaw auth profile: %v", err)
+	}
+	credential := auth.Profiles["xai:default"]
+	if auth.Version != 1 || credential.Type != "oauth" || credential.Provider != "xai" {
+		t.Fatalf("unexpected OpenClaw auth profile: %#v", auth)
+	}
+	if credential.Access != "access-token" || credential.Refresh != "refresh-token" || credential.Expires != 1893553445000 {
+		t.Fatalf("OAuth tokens were not migrated: %#v", credential)
+	}
+	if credential.Email != "dev@example.com" || credential.AccountID != "user-123" {
+		t.Fatalf("OAuth metadata was not migrated: %#v", credential)
+	}
+}
+
 func TestSanitizeActivityTextRedactsRepeatedSecretPrefixes(t *testing.T) {
 	input := `curl "https://api.example.com?access_token=abc&access_token=xyz" -H "Authorization: Bearer tok1" -H "X-Alt: Bearer tok2"`
 	got := sanitizeActivityText(input)

--- a/pkg/hub/bootstrap.go
+++ b/pkg/hub/bootstrap.go
@@ -74,6 +74,11 @@ func resolveActiveKey(keys []*types.LLMKeyConfig, selectedKeyName string) *types
 func buildOpenClawProviderConfig(keys []*types.LLMKeyConfig, selectedKeyName string) string {
 	// Determine active key
 	activeKey := resolveActiveKey(keys, selectedKeyName)
+	grokOAuth := activeKey != nil && activeKey.Provider == "grok" && activeKey.AuthProfile != "" && activeKey.APIKey == ""
+	grokOAuthLiteral := "False"
+	if grokOAuth {
+		grokOAuthLiteral = "True"
+	}
 
 	anthropicEnvVar := ""
 	if activeKey != nil && activeKey.Provider == "anthropic" {
@@ -125,6 +130,8 @@ except FileNotFoundError:
 except Exception:
     config = {}
 model = os.environ.get('OPENCLAW_DEFAULT_MODEL', 'anthropic/claude-sonnet-4-6')
+if %s and model.startswith('grok/'):
+    model = 'xai/' + model.split('/', 1)[1]
 agent_defaults = config.setdefault('agents', {}).setdefault('defaults', {})
 agent_defaults['model'] = model
 agent_models = agent_defaults.get('models')
@@ -186,7 +193,7 @@ if gw_password:
 with open(path, 'w') as f:
     json.dump(config, f, indent=2)
 print('OpenClaw config patched')
-PYEOF`, anthropicPatch)
+PYEOF`, grokOAuthLiteral, anthropicPatch)
 }
 
 // buildOpenClawAPIKeyAuthSyncShell returns a shell snippet that persists
@@ -419,6 +426,9 @@ func buildOnboardFlags(keys []*types.LLMKeyConfig, selectedKeyName, defaultModel
 	case "codex":
 		return fmt.Sprintf(`--auth-choice codex-api-key --codex-api-key "${%s:-}"`, envVar)
 	case "grok":
+		if active.AuthProfile != "" && active.APIKey == "" {
+			return `--auth-choice skip`
+		}
 		return fmt.Sprintf(`--auth-choice openai-api-key --openai-api-key "${%s:-}"`, envVar)
 	case "ollama":
 		model := active.DefaultModel

--- a/pkg/hub/bootstrap_test.go
+++ b/pkg/hub/bootstrap_test.go
@@ -450,7 +450,7 @@ func TestBuildModelAuthRestoreShellMigratesGrokOAuthToOpenClaw(t *testing.T) {
 		t.Skip("python3 not in PATH")
 	}
 
-	grokAuth := `{"https://auth.x.ai::client":{"key":"access-token","refresh_token":"refresh-token","expires_at":"2030-01-02T03:04:05Z","email":"dev@example.com","user_id":"user-123","oidc_issuer":"https://auth.x.ai"}}`
+	grokAuth := `{"stale":{"key":"stale-token"},"https://auth.x.ai::client":{"key":"access-token","refresh_token":"refresh-token","expires_at":"2030-01-02T03:04:05Z","email":"dev@example.com","user_id":"user-123","oidc_issuer":"https://auth.x.ai/"}}`
 	bundle, err := json.Marshal(map[string]any{
 		"files": map[string]string{
 			".grok/auth.json": base64.StdEncoding.EncodeToString([]byte(grokAuth)),
@@ -485,6 +485,8 @@ func TestBuildModelAuthRestoreShellMigratesGrokOAuthToOpenClaw(t *testing.T) {
 			Expires   int64  `json:"expires"`
 			Email     string `json:"email"`
 			AccountID string `json:"accountId"`
+			Issuer    string `json:"issuer"`
+			Endpoint  string `json:"tokenEndpoint"`
 		} `json:"profiles"`
 	}
 	if err := json.Unmarshal(authData, &auth); err != nil {
@@ -499,6 +501,9 @@ func TestBuildModelAuthRestoreShellMigratesGrokOAuthToOpenClaw(t *testing.T) {
 	}
 	if credential.Expires != 1893553445000 || credential.Email != "dev@example.com" || credential.AccountID != "user-123" {
 		t.Fatalf("OAuth metadata was not migrated: %#v", credential)
+	}
+	if credential.Issuer != "https://auth.x.ai" || credential.Endpoint != "https://auth.x.ai/oauth2/token" {
+		t.Fatalf("OAuth issuer URLs were not normalized: %#v", credential)
 	}
 }
 

--- a/pkg/hub/bootstrap_test.go
+++ b/pkg/hub/bootstrap_test.go
@@ -1,6 +1,7 @@
 package hub
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"os"
 	"os/exec"
@@ -370,6 +371,18 @@ func TestBuildOnboardFlagsSkipsBlankExternalKeys(t *testing.T) {
 	assertNotContains(t, flags, "openai-api-key", "does not select blank OpenAI key")
 }
 
+func TestBuildOnboardFlagsGrokOAuthSkipsAPIKeyOnboarding(t *testing.T) {
+	keys := []*types.LLMKeyConfig{
+		{Name: "grok-main", Provider: "grok", AuthProfile: "grok-oauth", Default: true},
+	}
+
+	flags := buildOnboardFlags(keys, "grok-main", "grok/grok-build-0.1")
+
+	if flags != "--auth-choice skip" {
+		t.Fatalf("flags = %q, want OAuth bootstrap to skip API-key onboarding", flags)
+	}
+}
+
 func TestBuildLLMKeyEnvSkipsBlankExternalKeys(t *testing.T) {
 	keys := []*types.LLMKeyConfig{
 		{Name: "openai-empty", Provider: "openai", Default: true},
@@ -427,6 +440,66 @@ func TestBuildModelAuthRestoreShellRejectsParentDirectory(t *testing.T) {
 
 	assertContains(t, shell, "clean == '..'", "rejects exact parent directory path")
 	assertContains(t, shell, "clean.startswith('../')", "rejects nested parent directory path")
+}
+
+func TestBuildModelAuthRestoreShellMigratesGrokOAuthToOpenClaw(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not in PATH")
+	}
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not in PATH")
+	}
+
+	grokAuth := `{"https://auth.x.ai::client":{"key":"access-token","refresh_token":"refresh-token","expires_at":"2030-01-02T03:04:05Z","email":"dev@example.com","user_id":"user-123","oidc_issuer":"https://auth.x.ai"}}`
+	bundle, err := json.Marshal(map[string]any{
+		"files": map[string]string{
+			".grok/auth.json": base64.StdEncoding.EncodeToString([]byte(grokAuth)),
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal auth bundle: %v", err)
+	}
+	state := base64.StdEncoding.EncodeToString(bundle)
+	modelAuthEnv := "export ELASTICCLAW_MODEL_AUTH_PROVIDER=\"grok\"\nexport ELASTICCLAW_MODEL_AUTH_STATE=\"" + state + "\"\n"
+	shell := buildModelAuthRestoreShell(modelAuthEnv)
+
+	home := t.TempDir()
+	cmd := exec.Command("bash", "-c", shell)
+	cmd.Env = append(os.Environ(), "HOME="+home)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("run auth restore shell: %v\n%s", err, string(out))
+	}
+
+	authPath := filepath.Join(home, ".openclaw", "agents", "main", "agent", "auth-profiles.json")
+	authData, err := os.ReadFile(authPath)
+	if err != nil {
+		t.Fatalf("read OpenClaw auth profile: %v", err)
+	}
+	var auth struct {
+		Version  int `json:"version"`
+		Profiles map[string]struct {
+			Type      string `json:"type"`
+			Provider  string `json:"provider"`
+			Access    string `json:"access"`
+			Refresh   string `json:"refresh"`
+			Expires   int64  `json:"expires"`
+			Email     string `json:"email"`
+			AccountID string `json:"accountId"`
+		} `json:"profiles"`
+	}
+	if err := json.Unmarshal(authData, &auth); err != nil {
+		t.Fatalf("parse OpenClaw auth profile: %v", err)
+	}
+	credential := auth.Profiles["xai:default"]
+	if auth.Version != 1 || credential.Type != "oauth" || credential.Provider != "xai" {
+		t.Fatalf("unexpected OpenClaw auth profile: %#v", auth)
+	}
+	if credential.Access != "access-token" || credential.Refresh != "refresh-token" {
+		t.Fatalf("OAuth tokens were not migrated: %#v", credential)
+	}
+	if credential.Expires != 1893553445000 || credential.Email != "dev@example.com" || credential.AccountID != "user-123" {
+		t.Fatalf("OAuth metadata was not migrated: %#v", credential)
+	}
 }
 
 func TestResolveModelAndLLMKeyReplacesUnusableSelectedKey(t *testing.T) {
@@ -516,6 +589,50 @@ func TestBuildOpenClawProviderConfig_ConfiguresGrokProvider(t *testing.T) {
 	assertContains(t, snippet, "'baseUrl': 'https://api.x.ai/v1'", "uses xAI OpenAI-compatible base URL")
 	assertContains(t, snippet, "'apiKey': 'XAI_API_KEY'", "uses Grok API key env var")
 	assertContains(t, snippet, "providers['grok']", "writes Grok provider config")
+}
+
+func TestBuildOpenClawProviderConfig_UsesNativeXAIForGrokOAuth(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not in PATH")
+	}
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not in PATH")
+	}
+
+	keys := []*types.LLMKeyConfig{
+		{Name: "grok-main", Provider: "grok", AuthProfile: "grok-oauth", Default: true},
+	}
+	snippet := buildOpenClawProviderConfig(keys, "grok-main")
+	home := t.TempDir()
+	cmd := exec.Command("bash", "-c", snippet)
+	cmd.Env = append(os.Environ(),
+		"HOME="+home,
+		"OPENCLAW_DEFAULT_MODEL=grok/grok-build-0.1",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("run config snippet: %v\n%s", err, string(out))
+	}
+
+	configData, err := os.ReadFile(filepath.Join(home, ".openclaw", "openclaw.json"))
+	if err != nil {
+		t.Fatalf("read patched config: %v", err)
+	}
+	var config map[string]any
+	if err := json.Unmarshal(configData, &config); err != nil {
+		t.Fatalf("parse patched config: %v", err)
+	}
+	agents := config["agents"].(map[string]any)
+	defaults := agents["defaults"].(map[string]any)
+	if defaults["model"] != "xai/grok-build-0.1" {
+		t.Fatalf("default model = %#v, want native xAI model", defaults["model"])
+	}
+	if models, ok := config["models"].(map[string]any); ok {
+		if providers, ok := models["providers"].(map[string]any); ok {
+			if _, ok := providers["grok"]; ok {
+				t.Fatalf("OAuth config retained legacy Grok API-key provider: %#v", providers)
+			}
+		}
+	}
 }
 
 func TestBuildOpenClawProviderConfig_DoesNotOverrideAnthropicModels(t *testing.T) {

--- a/pkg/hub/model_auth.go
+++ b/pkg/hub/model_auth.go
@@ -793,7 +793,7 @@ func buildModelAuthRestoreShell(modelAuthEnv string) string {
 	}
 	return modelAuthEnv + `
 python3 <<'PYEOF'
-import base64, json, os
+import base64, datetime, json, os
 state = os.environ.get('ELASTICCLAW_MODEL_AUTH_STATE', '')
 if state:
     bundle = json.loads(base64.b64decode(state).decode())
@@ -807,6 +807,61 @@ if state:
         with open(path, 'wb') as f:
             f.write(base64.b64decode(encoded))
         os.chmod(path, 0o600)
+
+    # ElasticClaw historically stored Grok device auth only in the Grok CLI's
+    # auth file. OpenClaw 2026.6.x has a native xAI OAuth provider, so migrate
+    # that restored credential into its canonical per-agent auth store. This
+    # also upgrades auth profiles captured before native xAI support was wired
+    # into claw bootstrap.
+    if os.environ.get('ELASTICCLAW_MODEL_AUTH_PROVIDER') == 'grok':
+        grok_auth_path = os.path.join(home, '.grok', 'auth.json')
+        try:
+            with open(grok_auth_path) as f:
+                grok_auth = json.load(f)
+        except (FileNotFoundError, json.JSONDecodeError):
+            grok_auth = {}
+
+        entry = next((value for value in grok_auth.values() if isinstance(value, dict)), None)
+        if entry and entry.get('key') and entry.get('refresh_token'):
+            expires = 0
+            expires_at = entry.get('expires_at', '')
+            if isinstance(expires_at, str) and expires_at:
+                try:
+                    expires = int(datetime.datetime.fromisoformat(expires_at.replace('Z', '+00:00')).timestamp() * 1000)
+                except ValueError:
+                    pass
+
+            credential = {
+                'type': 'oauth',
+                'provider': 'xai',
+                'access': entry['key'],
+                'refresh': entry['refresh_token'],
+                'expires': expires,
+                'issuer': entry.get('oidc_issuer', 'https://auth.x.ai'),
+                'tokenEndpoint': entry.get('oidc_issuer', 'https://auth.x.ai').rstrip('/') + '/oauth2/token',
+            }
+            for source, target in (
+                ('email', 'email'),
+                ('user_id', 'accountId'),
+            ):
+                if entry.get(source):
+                    credential[target] = entry[source]
+
+            auth_path = os.path.join(home, '.openclaw', 'agents', 'main', 'agent', 'auth-profiles.json')
+            os.makedirs(os.path.dirname(auth_path), exist_ok=True)
+            try:
+                with open(auth_path) as f:
+                    auth = json.load(f)
+            except (FileNotFoundError, json.JSONDecodeError):
+                auth = {}
+            auth['version'] = 1
+            auth.setdefault('profiles', {})['xai:default'] = credential
+            temp_path = auth_path + '.tmp'
+            with open(temp_path, 'w') as f:
+                json.dump(auth, f, indent=2)
+                f.write('\n')
+            os.chmod(temp_path, 0o600)
+            os.replace(temp_path, auth_path)
 PYEOF
 `
 }

--- a/pkg/hub/model_auth.go
+++ b/pkg/hub/model_auth.go
@@ -821,8 +821,11 @@ if state:
         except (FileNotFoundError, json.JSONDecodeError):
             grok_auth = {}
 
-        entry = next((value for value in grok_auth.values() if isinstance(value, dict)), None)
-        if entry and entry.get('key') and entry.get('refresh_token'):
+        entry = next((
+            value for value in grok_auth.values()
+            if isinstance(value, dict) and value.get('key') and value.get('refresh_token')
+        ), None)
+        if entry:
             expires = 0
             expires_at = entry.get('expires_at', '')
             if isinstance(expires_at, str) and expires_at:
@@ -831,14 +834,15 @@ if state:
                 except ValueError:
                     pass
 
+            issuer = entry.get('oidc_issuer', 'https://auth.x.ai').rstrip('/')
             credential = {
                 'type': 'oauth',
                 'provider': 'xai',
                 'access': entry['key'],
                 'refresh': entry['refresh_token'],
                 'expires': expires,
-                'issuer': entry.get('oidc_issuer', 'https://auth.x.ai'),
-                'tokenEndpoint': entry.get('oidc_issuer', 'https://auth.x.ai').rstrip('/') + '/oauth2/token',
+                'issuer': issuer,
+                'tokenEndpoint': issuer + '/oauth2/token',
             }
             for source, target in (
                 ('email', 'email'),

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -3279,13 +3279,13 @@ docker --version`); err != nil {
 	if onboardErr != nil {
 		result, diagErr := p.ExecWithTimeout(ctx, instanceID, []string{"bash", "-c", `export HOME=/home/daytona; [ -f "$HOME/.openclaw/openclaw.json" ] && echo exists || echo missing`}, 10*time.Second)
 		if diagErr != nil || strings.TrimSpace(result.Stdout) != "exists" {
-			return fmt.Errorf("onboard openclaw: %w", onboardErr)
+			return fmt.Errorf("onboard openclaw: %s", sanitizeBootstrapError(onboardErr))
 		}
 		log.Printf("[daytona] onboard returned error, but config file exists; continuing")
 	} else if onboardResult.ExitCode != 0 {
 		result, diagErr := p.ExecWithTimeout(ctx, instanceID, []string{"bash", "-c", `export HOME=/home/daytona; [ -f "$HOME/.openclaw/openclaw.json" ] && echo exists || echo missing`}, 10*time.Second)
 		if diagErr != nil || strings.TrimSpace(result.Stdout) != "exists" {
-			return fmt.Errorf("onboard openclaw failed (exit %d): %s", onboardResult.ExitCode, onboardResult.Stdout)
+			return fmt.Errorf("onboard openclaw failed (exit %d): %s", onboardResult.ExitCode, sanitizeBootstrapOutput(onboardResult.Stdout))
 		}
 		log.Printf("[daytona] onboard returned non-zero, but config file exists; continuing")
 	} else {


### PR DESCRIPTION
## Summary
- map Grok OAuth credentials into OpenClaw native xAI authentication
- select the xai/grok-build-0.1 model for OAuth-backed Grok claws
- avoid OpenAI API-key onboarding for Grok and sanitize bootstrap diagnostics

## Tests
- go test ./...