### PR TITLE
Update Grok Build CLI to 0.2.103

### DIFF
--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -2324,7 +2324,7 @@ echo "Git: $(git --version)"
 
 const openClawVersion = cliversion.OpenClawVersion
 const codexCLIVersion = "0.141.0"
-const grokCLIVersion = "0.1.0"
+const grokCLIVersion = cliversion.GrokCLIVersion
 
 // installOpenClaw installs the pinned OpenClaw CLI via npm.
 func installOpenClaw() error {

--- a/pkg/cliversion/cliversion.go
+++ b/pkg/cliversion/cliversion.go
@@ -5,7 +5,10 @@ import (
 	"strings"
 )
 
-const OpenClawVersion = "2026.6.9"
+const (
+	OpenClawVersion = "2026.6.9"
+	GrokCLIVersion  = "0.2.103"
+)
 
 func FromEnv(envName, fallback string) string {
 	if v := strings.TrimSpace(os.Getenv(envName)); v != "" {

--- a/pkg/cliversion/cliversion_test.go
+++ b/pkg/cliversion/cliversion_test.go
@@ -2,6 +2,12 @@ package cliversion
 
 import "testing"
 
+func TestPinnedGrokCLIVersion(t *testing.T) {
+	if GrokCLIVersion != "0.2.103" {
+		t.Fatalf("GrokCLIVersion = %q, want 0.2.103", GrokCLIVersion)
+	}
+}
+
 func TestFromEnvAllowsPinnedOverride(t *testing.T) {
 	t.Setenv("ELASTICCLAW_TEST_CLI_VERSION", "9.8.7")
 	if got := FromEnv("ELASTICCLAW_TEST_CLI_VERSION", "1.2.3"); got != "9.8.7" {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -3756,7 +3756,7 @@ func daytonaInstallCodingModelCLICommand(model string) string {
 		packageSpec = "@openai/codex@" + cliversion.FromEnv("ELASTICCLAW_CODEX_CLI_VERSION", "0.141.0")
 		binary = "codex"
 	case strings.HasPrefix(model, "grok/"):
-		packageSpec = "@xai-official/grok@" + cliversion.FromEnv("ELASTICCLAW_GROK_CLI_VERSION", "0.1.0")
+		packageSpec = "@xai-official/grok@" + cliversion.FromEnv("ELASTICCLAW_GROK_CLI_VERSION", cliversion.GrokCLIVersion)
 		binary = "grok"
 	default:
 		return ""


### PR DESCRIPTION
## Summary
- update the pinned Grok Build CLI to 0.2.103
- centralize the Grok CLI version used by auth and claw bootstrap paths
- add coverage for the shared version pin

## Tests
- go test ./...