### PR TITLE
Update OpenClaw to 2026.7.1-2

### DIFF
--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -2325,8 +2325,50 @@ const openClawVersion = cliversion.OpenClawVersion
 const codexCLIVersion = cliversion.CodexCLIVersion
 const grokCLIVersion = cliversion.GrokCLIVersion
 
+// ensureUserNPMBinOnPath configures a user-owned npm prefix and makes binaries
+// installed there visible to this process and every child process it starts.
+// Some provider images run the bridge as an unprivileged user without sudo.
+func ensureUserNPMBinOnPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve user home: %w", err)
+	}
+	if strings.TrimSpace(home) == "" {
+		return "", fmt.Errorf("resolve user home: empty path")
+	}
+
+	prefix := filepath.Join(home, ".local")
+	binDir := filepath.Join(prefix, "bin")
+	pathEntries := filepath.SplitList(os.Getenv("PATH"))
+	for _, entry := range pathEntries {
+		if entry == binDir {
+			return prefix, nil
+		}
+	}
+	pathEntries = append([]string{binDir}, pathEntries...)
+	if err := os.Setenv("PATH", strings.Join(pathEntries, string(os.PathListSeparator))); err != nil {
+		return "", fmt.Errorf("prepend user npm bin to PATH: %w", err)
+	}
+	return prefix, nil
+}
+
+func installUserNPMPackage(spec string) error {
+	prefix, err := ensureUserNPMBinOnPath()
+	if err != nil {
+		return err
+	}
+	return runShell(fmt.Sprintf(
+		"npm install -g --prefix %s %s --ignore-scripts",
+		shellQuote(prefix),
+		shellQuote(spec),
+	))
+}
+
 // installOpenClaw installs the pinned OpenClaw CLI via npm.
 func installOpenClaw() error {
+	if _, err := ensureUserNPMBinOnPath(); err != nil {
+		return err
+	}
 	if out, err := exec.Command("openclaw", "--version").CombinedOutput(); err == nil {
 		version := strings.TrimSpace(string(out))
 		if strings.Contains(version, openClawVersion) {
@@ -2336,11 +2378,18 @@ func installOpenClaw() error {
 		log.Printf("[bootstrap] OpenClaw version %s found, installing pinned %s", version, openClawVersion)
 	}
 	log.Printf("[bootstrap] installing openclaw@%s...", openClawVersion)
-	if err := runShell(fmt.Sprintf("sudo npm install -g openclaw@%s --ignore-scripts", openClawVersion)); err != nil {
+	if err := installUserNPMPackage("openclaw@" + openClawVersion); err != nil {
 		return fmt.Errorf("npm install openclaw: %w", err)
 	}
-	out, _ := exec.Command("openclaw", "--version").Output()
-	log.Printf("[bootstrap] OpenClaw: %s", strings.TrimSpace(string(out)))
+	out, err := exec.Command("openclaw", "--version").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("verify openclaw install: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	version := strings.TrimSpace(string(out))
+	if !strings.Contains(version, openClawVersion) {
+		return fmt.Errorf("verify openclaw install: got %q, want version %s", version, openClawVersion)
+	}
+	log.Printf("[bootstrap] OpenClaw: %s", version)
 	return nil
 }
 
@@ -2361,7 +2410,7 @@ func installNPMCLI(packageName, version, binaryName string) error {
 	}
 	spec := packageName + "@" + version
 	log.Printf("[bootstrap] installing %s...", spec)
-	if err := runShell(fmt.Sprintf("sudo npm install -g %s --ignore-scripts", shellQuote(spec))); err != nil {
+	if err := installUserNPMPackage(spec); err != nil {
 		return fmt.Errorf("npm install %s: %w", spec, err)
 	}
 	out, err := exec.Command(binaryName, "--version").CombinedOutput()

--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -2291,12 +2291,11 @@ func installNodeGit() error {
 	log.Printf("[bootstrap] installing Node.js 24 + git...")
 	script := `
 set -euo pipefail
-node_major() {
-  if command -v node >/dev/null 2>&1; then
-    node --version | sed -E 's/^v([0-9]+).*/\1/'
-  fi
+node_compatible() {
+  command -v node >/dev/null 2>&1 &&
+    node -e 'const [major, minor] = process.versions.node.split(".").map(Number); process.exit(major === 24 && minor >= 15 ? 0 : 1)'
 }
-if command -v git >/dev/null 2>&1 && command -v npm >/dev/null 2>&1 && [ "$(node_major)" = "24" ]; then
+if command -v git >/dev/null 2>&1 && command -v npm >/dev/null 2>&1 && node_compatible; then
   echo "Node: $(node --version)"
   echo "Git: $(git --version)"
   exit 0
@@ -2305,7 +2304,7 @@ fi
 # dpkg state corruption from multiple overlapping install calls.
 sudo apt-get update -qq
 sudo apt-get install -y --fix-broken curl ca-certificates git gnupg
-if ! command -v npm >/dev/null 2>&1 || [ "$(node_major)" != "24" ]; then
+if ! command -v npm >/dev/null 2>&1 || ! node_compatible; then
   if [ ! -f /etc/apt/sources.list.d/nodesource.sources ] && [ ! -f /etc/apt/sources.list.d/nodesource.list ]; then
     sudo mkdir -p /etc/apt/keyrings
     curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | \

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -668,6 +669,72 @@ func TestCLICodingProviderForModel(t *testing.T) {
 		if got := cliCodingProviderForModel(model); got != want {
 			t.Fatalf("cliCodingProviderForModel(%q) = %q, want %q", model, got, want)
 		}
+	}
+}
+
+func TestInstallOpenClawWithoutSudoInstallsAndRunsPinnedVersion(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake npm executable uses POSIX shell")
+	}
+
+	home := t.TempDir()
+	fakeBin := t.TempDir()
+	npmLog := filepath.Join(t.TempDir(), "npm-args")
+	t.Setenv("HOME", home)
+	t.Setenv("FAKE_NPM_LOG", npmLog)
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	writeExecutable := func(path, content string) {
+		t.Helper()
+		if err := os.WriteFile(path, []byte(content), 0755); err != nil {
+			t.Fatalf("write executable %s: %v", path, err)
+		}
+	}
+	writeExecutable(filepath.Join(fakeBin, "openclaw"), "#!/bin/sh\necho 'OpenClaw 0.0.0'\n")
+	writeExecutable(filepath.Join(fakeBin, "npm"), fmt.Sprintf(`#!/bin/sh
+set -eu
+printf '%%s\n' "$*" > "$FAKE_NPM_LOG"
+mkdir -p "$HOME/.local/bin"
+cat > "$HOME/.local/bin/openclaw" <<'EOF'
+#!/bin/sh
+echo 'OpenClaw %s'
+EOF
+chmod +x "$HOME/.local/bin/openclaw"
+`, openClawVersion))
+
+	if err := installOpenClaw(); err != nil {
+		t.Fatalf("installOpenClaw(): %v", err)
+	}
+
+	args, err := os.ReadFile(npmLog)
+	if err != nil {
+		t.Fatalf("read npm arguments: %v", err)
+	}
+	gotArgs := strings.TrimSpace(string(args))
+	if strings.Contains(gotArgs, "sudo") {
+		t.Fatalf("npm install unexpectedly requires sudo: %s", gotArgs)
+	}
+	if !strings.Contains(gotArgs, "--prefix "+filepath.Join(home, ".local")) {
+		t.Fatalf("npm install does not use the user prefix: %s", gotArgs)
+	}
+	if !strings.Contains(gotArgs, "openclaw@"+openClawVersion) {
+		t.Fatalf("npm install does not pin OpenClaw: %s", gotArgs)
+	}
+
+	path, err := exec.LookPath("openclaw")
+	if err != nil {
+		t.Fatalf("find installed openclaw: %v", err)
+	}
+	wantPath := filepath.Join(home, ".local", "bin", "openclaw")
+	if path != wantPath {
+		t.Fatalf("openclaw path = %q, want %q", path, wantPath)
+	}
+	out, err := exec.Command("openclaw", "--version").CombinedOutput()
+	if err != nil {
+		t.Fatalf("run installed openclaw: %v: %s", err, out)
+	}
+	if got, want := strings.TrimSpace(string(out)), "OpenClaw "+openClawVersion; got != want {
+		t.Fatalf("openclaw --version = %q, want %q", got, want)
 	}
 }
 

--- a/docker/agent.Dockerfile
+++ b/docker/agent.Dockerfile
@@ -22,7 +22,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
     && rm -rf /var/lib/apt/lists/*
 
 # Pre-install OpenClaw globally so bootstrap skips the npm install step.
-RUN npm install -g openclaw@2026.6.9 --ignore-scripts
+RUN npm install -g openclaw@2026.7.1-2 --ignore-scripts
 
 # Create the 'claw' user (bridge runs as non-root; bootstrap expects this user)
 RUN useradd -m -s /bin/bash claw \

--- a/pkg/cliversion/cliversion.go
+++ b/pkg/cliversion/cliversion.go
@@ -5,7 +5,10 @@ import (
 	"strings"
 )
 
-const OpenClawVersion = "2026.6.9"
+const (
+	OpenClawVersion      = "2026.7.1-2"
+	OpenClawImageVersion = "2026.7.1"
+)
 
 func FromEnv(envName, fallback string) string {
 	if v := strings.TrimSpace(os.Getenv(envName)); v != "" {

--- a/pkg/cliversion/cliversion.go
+++ b/pkg/cliversion/cliversion.go
@@ -8,6 +8,7 @@ import (
 const (
 	OpenClawVersion      = "2026.7.1-2"
 	OpenClawImageVersion = "2026.7.1"
+	OpenClawImage        = "ghcr.io/openclaw/openclaw:" + OpenClawImageVersion
 )
 
 func FromEnv(envName, fallback string) string {

--- a/pkg/cliversion/cliversion_test.go
+++ b/pkg/cliversion/cliversion_test.go
@@ -9,6 +9,9 @@ func TestPinnedOpenClawVersions(t *testing.T) {
 	if got, want := OpenClawImageVersion, "2026.7.1"; got != want {
 		t.Fatalf("OpenClawImageVersion = %q, want %q", got, want)
 	}
+	if got, want := OpenClawImage, "ghcr.io/openclaw/openclaw:2026.7.1"; got != want {
+		t.Fatalf("OpenClawImage = %q, want %q", got, want)
+	}
 }
 
 func TestFromEnvAllowsPinnedOverride(t *testing.T) {

--- a/pkg/cliversion/cliversion_test.go
+++ b/pkg/cliversion/cliversion_test.go
@@ -2,6 +2,15 @@ package cliversion
 
 import "testing"
 
+func TestPinnedOpenClawVersions(t *testing.T) {
+	if got, want := OpenClawVersion, "2026.7.1-2"; got != want {
+		t.Fatalf("OpenClawVersion = %q, want %q", got, want)
+	}
+	if got, want := OpenClawImageVersion, "2026.7.1"; got != want {
+		t.Fatalf("OpenClawImageVersion = %q, want %q", got, want)
+	}
+}
+
 func TestFromEnvAllowsPinnedOverride(t *testing.T) {
 	t.Setenv("ELASTICCLAW_TEST_CLI_VERSION", "9.8.7")
 	if got := FromEnv("ELASTICCLAW_TEST_CLI_VERSION", "1.2.3"); got != "9.8.7" {

--- a/pkg/hub/bootstrap.go
+++ b/pkg/hub/bootstrap.go
@@ -190,7 +190,7 @@ PYEOF`, anthropicPatch)
 }
 
 // buildOpenClawAPIKeyAuthSyncShell returns a shell snippet that persists
-// direct API-key auth into OpenClaw's current auth store. OpenClaw 2026.6.9
+// direct API-key auth into OpenClaw's current auth store. OpenClaw 2026.7.1-2
 // resolves agent auth from openclaw-agent.sqlite, so writing only the legacy
 // auth-profiles.json file is not enough for embedded agents.
 func buildOpenClawAPIKeyAuthSyncShell(keys []*types.LLMKeyConfig, selectedKeyName string) string {

--- a/pkg/hub/bootstrap_test.go
+++ b/pkg/hub/bootstrap_test.go
@@ -103,20 +103,20 @@ func TestDaytonaAsyncBridgeCommandShellQuotesClawName(t *testing.T) {
 }
 
 func TestDaytonaOpenClawInstallCommands_AreAsyncAndPollable(t *testing.T) {
-	start := daytonaStartOpenClawInstallCommand("2026.6.9")
-	status := daytonaOpenClawInstallStatusCommand("2026.6.9")
+	start := daytonaStartOpenClawInstallCommand("2026.7.1-2")
+	status := daytonaOpenClawInstallStatusCommand("2026.7.1-2")
 
 	assertContains(t, start, "setsid nohup bash -c", "install starts in a detached process")
 	assertContains(t, start, "openclaw-install.log", "install writes a log for diagnostics")
 	assertContains(t, start, "openclaw-install.status", "install writes a status marker")
-	assertContains(t, start, "openclaw@2026.6.9", "install pins the expected openclaw version")
+	assertContains(t, start, "openclaw@2026.7.1-2", "install pins the expected openclaw version")
 	assertContains(t, start, "openclaw-install-status=started", "start command returns quickly after launching")
 
 	assertContains(t, status, "openclaw-install-status=ok", "status reports completion")
 	assertContains(t, status, "openclaw-install-status=pending", "status reports in-progress install")
 	assertContains(t, status, "openclaw-install-status=failed", "status reports failed install")
 	assertContains(t, status, "tail -n 120", "status includes install diagnostics")
-	assertContains(t, status, "openclaw@2026.6.9", "status checks the pinned install process")
+	assertContains(t, status, "openclaw@2026.7.1-2", "status checks the pinned install process")
 }
 
 func TestBootstrapScript_ConnectorDownloadRetriesWithUserFacingLabel(t *testing.T) {
@@ -843,7 +843,7 @@ for cmd in curl apt-get npm sudo systemctl git gh oras python3 gpg tee chmod mv 
 done
 curl() { echo stub_curl_output; return 0; }
 openclaw() {
-  if [ "$1" = "--version" ]; then echo "OpenClaw 2026.6.9"; fi
+  if [ "$1" = "--version" ]; then echo "OpenClaw 2026.7.1-2"; fi
   return 0
 }
 `

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -3112,8 +3112,9 @@ func (s *Server) bootstrapDaytona(ctx context.Context, clawID, clawName, instanc
 			// Prefix HOME so commands run in the sandbox user's home, not the caller's.
 			// Also source nvm and pin a compatible Node 24 LTS — Daytona snapshots may ship with
 			// non-LTS Node (e.g. v25) and each exec is a fresh shell session.
-			// OpenClaw requires Node 24.15.0 or newer on the Node 24 line.
-			nvmSetup := `export HOME=/home/daytona; export NVM_DIR=/usr/local/share/nvm; [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && { nvm use 24.15.0 >/dev/null 2>&1 || nvm install 24.15.0 >/dev/null 2>&1; } ; `
+			// OpenClaw requires Node 24.15.0 or newer on the Node 24 line. Reuse a
+			// compatible installed patch; otherwise install the latest Node 24.
+			nvmSetup := `export HOME=/home/daytona; export NVM_DIR=/usr/local/share/nvm; [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && { nvm use 24 >/dev/null 2>&1 || true; node -e 'const [major, minor] = process.versions.node.split(".").map(Number); process.exit(major === 24 && minor >= 15 ? 0 : 1)' >/dev/null 2>&1 || nvm install 24 >/dev/null 2>&1; } ; `
 			result, err := p.ExecWithTimeout(ctx, instanceID, []string{"bash", "-c", nvmSetup + cmd}, timeout)
 			if err != nil {
 				lastErr = fmt.Errorf("%s: %w", label, err)

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -3110,10 +3110,10 @@ func (s *Server) bootstrapDaytona(ctx context.Context, clawID, clawName, instanc
 				time.Sleep(5 * time.Second)
 			}
 			// Prefix HOME so commands run in the sandbox user's home, not the caller's.
-			// Also source nvm and pin Node 24 LTS — Daytona snapshots may ship with
+			// Also source nvm and pin a compatible Node 24 LTS — Daytona snapshots may ship with
 			// non-LTS Node (e.g. v25) and each exec is a fresh shell session.
-			// If nvm use 24 fails (not installed yet), we install it on the fly.
-			nvmSetup := `export HOME=/home/daytona; export NVM_DIR=/usr/local/share/nvm; [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && { nvm use 24 >/dev/null 2>&1 || nvm install 24 >/dev/null 2>&1; } ; `
+			// OpenClaw requires Node 24.15.0 or newer on the Node 24 line.
+			nvmSetup := `export HOME=/home/daytona; export NVM_DIR=/usr/local/share/nvm; [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && { nvm use 24.15.0 >/dev/null 2>&1 || nvm install 24.15.0 >/dev/null 2>&1; } ; `
 			result, err := p.ExecWithTimeout(ctx, instanceID, []string{"bash", "-c", nvmSetup + cmd}, timeout)
 			if err != nil {
 				lastErr = fmt.Errorf("%s: %w", label, err)

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -13,6 +13,7 @@ import (
 	"testing/fstest"
 	"time"
 
+	"github.com/elasticclaw/elasticclaw/pkg/cliversion"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 	"nhooyr.io/websocket"
 	"nhooyr.io/websocket/wsjson"
@@ -280,6 +281,9 @@ func TestGetSettingsTreatsBlankOllamaKeyAsConfigured(t *testing.T) {
 	var view SettingsView
 	if err := json.NewDecoder(rec.Body).Decode(&view); err != nil {
 		t.Fatal(err)
+	}
+	if view.DefaultOpenClawImage != cliversion.OpenClawImage {
+		t.Fatalf("default OpenClaw image = %q, want %q", view.DefaultOpenClawImage, cliversion.OpenClawImage)
 	}
 	byName := map[string]LLMKeyView{}
 	for _, key := range view.LLMKeys {

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"sort"
 
+	"github.com/elasticclaw/elasticclaw/pkg/cliversion"
 	"github.com/elasticclaw/elasticclaw/pkg/config"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
@@ -62,17 +63,18 @@ type ConcurrencyGroupView struct {
 // SettingsView is the redacted view of hub config for the settings page.
 // Secrets are masked — never returned in full.
 type SettingsView struct {
-	LLMKeys           []LLMKeyView                `json:"llmKeys"`
-	ModelOptions      map[string][]LLMModelOption `json:"modelOptions,omitempty"`
-	ModelAuthProfiles []ModelAuthProfileView      `json:"modelAuthProfiles,omitempty"`
-	Providers         map[string]ProviderView     `json:"providers"`
-	GitHub            []GitHubAppView             `json:"github"`
-	SSHPublicKeys     []string                    `json:"sshPublicKeys"`
-	Integrations      *IntegrationsView           `json:"integrations"`
-	Factories         []FactoryView               `json:"factories"`
-	Secrets           []string                    `json:"secrets"`
-	MCPServers        []MCPView                   `json:"mcpServers,omitempty"`
-	Auth              *AuthView                   `json:"auth,omitempty"`
+	DefaultOpenClawImage string                      `json:"defaultOpenClawImage"`
+	LLMKeys              []LLMKeyView                `json:"llmKeys"`
+	ModelOptions         map[string][]LLMModelOption `json:"modelOptions,omitempty"`
+	ModelAuthProfiles    []ModelAuthProfileView      `json:"modelAuthProfiles,omitempty"`
+	Providers            map[string]ProviderView     `json:"providers"`
+	GitHub               []GitHubAppView             `json:"github"`
+	SSHPublicKeys        []string                    `json:"sshPublicKeys"`
+	Integrations         *IntegrationsView           `json:"integrations"`
+	Factories            []FactoryView               `json:"factories"`
+	Secrets              []string                    `json:"secrets"`
+	MCPServers           []MCPView                   `json:"mcpServers,omitempty"`
+	Auth                 *AuthView                   `json:"auth,omitempty"`
 	// ConcurrencyGroups limits simultaneously running claws per group. 0 = unlimited.
 	ConcurrencyGroups []ConcurrencyGroupView `json:"concurrencyGroups"`
 	// MaxConcurrentClaws limits simultaneously running claws. 0 = unlimited.
@@ -442,8 +444,9 @@ func (s *Server) handleSettings(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 	view := SettingsView{
-		Providers: make(map[string]ProviderView),
-		GitHub:    []GitHubAppView{},
+		DefaultOpenClawImage: cliversion.OpenClawImage,
+		Providers:            make(map[string]ProviderView),
+		GitHub:               []GitHubAppView{},
 	}
 
 	s.mu.RLock()

--- a/pkg/provider/docker/docker.go
+++ b/pkg/provider/docker/docker.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	defaultImage   = "ghcr.io/openclaw/openclaw:" + cliversion.OpenClawVersion
+	defaultImage   = "ghcr.io/openclaw/openclaw:" + cliversion.OpenClawImageVersion
 	containerLabel = "elasticclaw.claw"
 )
 

--- a/pkg/provider/docker/docker.go
+++ b/pkg/provider/docker/docker.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	defaultImage   = "ghcr.io/openclaw/openclaw:" + cliversion.OpenClawImageVersion
+	defaultImage   = cliversion.OpenClawImage
 	containerLabel = "elasticclaw.claw"
 )
 

--- a/pkg/provider/docker/docker_test.go
+++ b/pkg/provider/docker/docker_test.go
@@ -25,7 +25,7 @@ func TestNewDefaultsToPinnedOpenClawImage(t *testing.T) {
 		t.Fatalf("new provider: %v", err)
 	}
 
-	if got, want := provider.cfg.Image, "ghcr.io/openclaw/openclaw:"+cliversion.OpenClawVersion; got != want {
+	if got, want := provider.cfg.Image, "ghcr.io/openclaw/openclaw:"+cliversion.OpenClawImageVersion; got != want {
 		t.Fatalf("default image = %q, want %q", got, want)
 	}
 }

--- a/pkg/provider/docker/docker_test.go
+++ b/pkg/provider/docker/docker_test.go
@@ -25,7 +25,7 @@ func TestNewDefaultsToPinnedOpenClawImage(t *testing.T) {
 		t.Fatalf("new provider: %v", err)
 	}
 
-	if got, want := provider.cfg.Image, "ghcr.io/openclaw/openclaw:"+cliversion.OpenClawImageVersion; got != want {
+	if got, want := provider.cfg.Image, cliversion.OpenClawImage; got != want {
 		t.Fatalf("default image = %q, want %q", got, want)
 	}
 }

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -990,10 +990,10 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
                     value={formDockerImage}
                     onChange={e => setFormDockerImage(e.target.value)}
                     className="h-8 text-sm font-mono"
-                    placeholder="ghcr.io/openclaw/openclaw:2026.6.9"
+                    placeholder="ghcr.io/openclaw/openclaw:2026.7.1"
                   />
                   <p className="text-[11px] text-muted-foreground mt-1">
-                    Leave blank to use the pinned OpenClaw image, ghcr.io/openclaw/openclaw:2026.6.9.
+                    Leave blank to use the pinned OpenClaw image, ghcr.io/openclaw/openclaw:2026.7.1.
                   </p>
                 </div>
                 <div>

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -90,6 +90,7 @@ interface WorkspaceGitHubAppView {
 }
 
 interface SettingsData {
+  defaultOpenClawImage: string
   llmKeys: LLMKeyView[]
   modelOptions?: Record<string, LLMModelOption[]>
   modelAuthProfiles?: ModelAuthProfileView[]
@@ -990,10 +991,10 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
                     value={formDockerImage}
                     onChange={e => setFormDockerImage(e.target.value)}
                     className="h-8 text-sm font-mono"
-                    placeholder="ghcr.io/openclaw/openclaw:2026.7.1"
+                    placeholder={settings.defaultOpenClawImage}
                   />
                   <p className="text-[11px] text-muted-foreground mt-1">
-                    Leave blank to use the pinned OpenClaw image, ghcr.io/openclaw/openclaw:2026.7.1.
+                    Leave blank to use the pinned OpenClaw image, {settings.defaultOpenClawImage}.
                   </p>
                 </div>
                 <div>


### PR DESCRIPTION
## Summary
- update the OpenClaw npm pin to 2026.7.1-2
- use the matching published GHCR image release, 2026.7.1
- enforce the new Node 24.15.0 minimum during bootstrap
- refresh Docker settings guidance and version expectations

## Tests
- go test ./...
- npm run build
- OpenClaw install and version smoke test on Node 24.15.0