### PR TITLE
Update Codex CLI to 0.144.6

### DIFF
--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -2323,7 +2323,7 @@ echo "Git: $(git --version)"
 }
 
 const openClawVersion = cliversion.OpenClawVersion
-const codexCLIVersion = "0.141.0"
+const codexCLIVersion = cliversion.CodexCLIVersion
 const grokCLIVersion = "0.1.0"
 
 // installOpenClaw installs the pinned OpenClaw CLI via npm.

--- a/pkg/cliversion/cliversion.go
+++ b/pkg/cliversion/cliversion.go
@@ -5,7 +5,10 @@ import (
 	"strings"
 )
 
-const OpenClawVersion = "2026.6.9"
+const (
+	OpenClawVersion = "2026.6.9"
+	CodexCLIVersion = "0.144.6"
+)
 
 func FromEnv(envName, fallback string) string {
 	if v := strings.TrimSpace(os.Getenv(envName)); v != "" {

--- a/pkg/cliversion/cliversion_test.go
+++ b/pkg/cliversion/cliversion_test.go
@@ -2,6 +2,12 @@ package cliversion
 
 import "testing"
 
+func TestPinnedCodexCLIVersion(t *testing.T) {
+	if CodexCLIVersion != "0.144.6" {
+		t.Fatalf("CodexCLIVersion = %q, want 0.144.6", CodexCLIVersion)
+	}
+}
+
 func TestFromEnvAllowsPinnedOverride(t *testing.T) {
 	t.Setenv("ELASTICCLAW_TEST_CLI_VERSION", "9.8.7")
 	if got := FromEnv("ELASTICCLAW_TEST_CLI_VERSION", "1.2.3"); got != "9.8.7" {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -3753,7 +3753,7 @@ func daytonaInstallCodingModelCLICommand(model string) string {
 	var packageSpec, binary string
 	switch {
 	case strings.HasPrefix(model, "codex/"):
-		packageSpec = "@openai/codex@" + cliversion.FromEnv("ELASTICCLAW_CODEX_CLI_VERSION", "0.141.0")
+		packageSpec = "@openai/codex@" + cliversion.FromEnv("ELASTICCLAW_CODEX_CLI_VERSION", cliversion.CodexCLIVersion)
 		binary = "codex"
 	case strings.HasPrefix(model, "grok/"):
 		packageSpec = "@xai-official/grok@" + cliversion.FromEnv("ELASTICCLAW_GROK_CLI_VERSION", "0.1.0")


### PR DESCRIPTION
## Summary
- update the pinned Codex CLI to 0.144.6
- centralize the Codex CLI version used by auth and claw bootstrap paths
- add coverage for the shared version pin

## Tests
- go test ./...