### PR TITLE
Sync Grok OAuth into OpenClaw SQLite auth store

### DIFF
--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -2584,6 +2584,18 @@ func syncOpenClawAPIKeyAuth() error {
 	return nil
 }
 
+func syncOpenClawOAuthAuth() error {
+	script := strings.TrimSpace(os.Getenv("ELASTICCLAW_OAUTH_AUTH_SYNC"))
+	if script == "" {
+		return nil
+	}
+	log.Printf("[bootstrap] syncing OpenClaw OAuth auth...")
+	if err := runShell(script); err != nil {
+		return fmt.Errorf("sync OpenClaw OAuth auth: %w", err)
+	}
+	return nil
+}
+
 var openClawWorkspaceManagedFiles = map[string]bool{
 	"elasticclaw-config.yaml": true,
 	"SOUL.md":                 true,
@@ -3268,6 +3280,9 @@ func runBootstrap() error {
 		}
 	} else {
 		log.Printf("[bootstrap] openclaw.json already exists, skipping onboard")
+	}
+	if err := syncOpenClawOAuthAuth(); err != nil {
+		return err
 	}
 
 	if err := syncStagedWorkspaceToOpenClawWorkspace(); err != nil {

--- a/pkg/hub/bootstrap.go
+++ b/pkg/hub/bootstrap.go
@@ -259,12 +259,15 @@ const store = existing ? JSON.parse(existing.store_json) : { version: 1, profile
 store.version = 1;
 if (!store.profiles || typeof store.profiles !== 'object') store.profiles = {};
 const parsedExpires = Date.parse(source.expires_at || '');
+if (!Number.isFinite(parsedExpires)) {
+  throw new Error('restored Grok OAuth credential is missing a valid expires_at timestamp');
+}
 store.profiles['xai:default'] = {
   type: 'oauth',
   provider: 'xai',
   access: source.key,
   refresh: source.refresh_token,
-  expires: Number.isFinite(parsedExpires) ? parsedExpires : 0,
+  expires: parsedExpires,
 };
 
 const now = Date.now();

--- a/pkg/hub/bootstrap.go
+++ b/pkg/hub/bootstrap.go
@@ -40,6 +40,7 @@ type BootstrapParams struct {
 	LLMKeyEnv      string // pre-built export lines
 	ModelAuthEnv   string // pre-built export lines for CLI-backed model auth state
 	APIKeyAuthSync string // shell script that persists API-key auth into OpenClaw's auth store
+	OAuthAuthSync  string // shell script that persists restored OAuth auth into OpenClaw's auth store
 	LinearEnv      string // pre-built export line
 	ProviderConfig string // python snippet to patch OpenClaw config
 	OnboardFlags   string // --auth-choice ... flags for openclaw onboard
@@ -211,6 +212,92 @@ func buildOpenClawAPIKeyAuthSyncShell(keys []*types.LLMKeyConfig, selectedKeyNam
 fi`, envVar, envVar)
 }
 
+// buildOpenClawOAuthAuthSyncShell returns a post-onboarding shell snippet that
+// imports restored Grok CLI OAuth into OpenClaw's per-agent SQLite auth store.
+// OpenClaw 2026.7.1-2 no longer reads credentials from auth-profiles.json at
+// runtime, and its broad `doctor --fix` migration also changes unrelated config.
+func buildOpenClawOAuthAuthSyncShell(keys []*types.LLMKeyConfig, selectedKeyName string) string {
+	activeKey := resolveActiveKey(keys, selectedKeyName)
+	if activeKey == nil || activeKey.Provider != "grok" || activeKey.AuthProfile == "" || activeKey.APIKey != "" {
+		return ""
+	}
+	return `set -euo pipefail
+# Let OpenClaw create and migrate its own SQLite schema. The short-lived
+# placeholder is replaced below before any gateway or model process starts.
+printf '%s\n' 'elasticclaw-auth-store-initializer' | openclaw models auth paste-token --provider xai --profile-id xai:default --expires-in 1m >/dev/null
+node <<'NODE'
+const fs = require('fs');
+const path = require('path');
+const { DatabaseSync } = require('node:sqlite');
+
+const home = process.env.HOME;
+const grokAuthPath = path.join(home, '.grok', 'auth.json');
+const grokAuth = JSON.parse(fs.readFileSync(grokAuthPath, 'utf8'));
+const source = Object.values(grokAuth).find((entry) =>
+  entry && typeof entry === 'object' && entry.key && entry.refresh_token
+);
+if (!source) {
+  throw new Error('restored Grok OAuth credential is missing access or refresh token');
+}
+
+const dbPath = path.join(home, '.openclaw', 'agents', 'main', 'agent', 'openclaw-agent.sqlite');
+if (!fs.existsSync(dbPath)) {
+  throw new Error('OpenClaw agent auth database does not exist after auth-store initialization');
+}
+const db = new DatabaseSync(dbPath);
+const table = db.prepare(
+  "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'auth_profile_store'"
+).get();
+if (!table) {
+  throw new Error('OpenClaw agent auth database has no auth_profile_store table');
+}
+
+const existing = db.prepare(
+  "SELECT store_json FROM auth_profile_store WHERE store_key = 'primary'"
+).get();
+const store = existing ? JSON.parse(existing.store_json) : { version: 1, profiles: {} };
+store.version = 1;
+if (!store.profiles || typeof store.profiles !== 'object') store.profiles = {};
+const parsedExpires = Date.parse(source.expires_at || '');
+store.profiles['xai:default'] = {
+  type: 'oauth',
+  provider: 'xai',
+  access: source.key,
+  refresh: source.refresh_token,
+  expires: Number.isFinite(parsedExpires) ? parsedExpires : 0,
+};
+
+const now = Date.now();
+db.exec('BEGIN IMMEDIATE');
+try {
+  db.prepare(
+    'INSERT INTO auth_profile_store (store_key, store_json, updated_at) ' +
+    'VALUES (?, ?, ?) ' +
+    'ON CONFLICT(store_key) DO UPDATE SET ' +
+    'store_json = excluded.store_json, updated_at = excluded.updated_at'
+  ).run('primary', JSON.stringify(store), now);
+  db.exec('COMMIT');
+} catch (error) {
+  db.exec('ROLLBACK');
+  throw error;
+} finally {
+  db.close();
+}
+NODE
+openclaw config set 'auth.profiles["xai:default"]' '{"provider":"xai","mode":"oauth"}' --strict-json >/dev/null
+openclaw models auth list --provider xai --json | node -e '
+let input = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => { input += chunk; });
+process.stdin.on("end", () => {
+  const result = JSON.parse(input);
+  if (!Array.isArray(result.profiles) || !result.profiles.some((profile) => profile.id === "xai:default" && profile.type === "oauth")) {
+    throw new Error("OpenClaw did not load the migrated xai:default OAuth profile");
+  }
+});
+'`
+}
+
 // GenerateReplicatedBootstrapScript returns a minimal bash script that downloads
 // claw-bridge and execs it with --bootstrap. All VM setup logic now lives inside
 // claw-bridge itself (runBootstrap in cmd/claw-bridge/main.go).
@@ -243,6 +330,11 @@ func GenerateReplicatedBootstrapScript(p BootstrapParams) string {
 		apiKeyAuthSyncLine = fmt.Sprintf("export ELASTICCLAW_API_KEY_AUTH_SYNC=%s",
 			shellQuote(p.APIKeyAuthSync))
 	}
+	oauthAuthSyncLine := "# No OAuth auth sync"
+	if p.OAuthAuthSync != "" {
+		oauthAuthSyncLine = fmt.Sprintf("export ELASTICCLAW_OAUTH_AUTH_SYNC=%s",
+			shellQuote(p.OAuthAuthSync))
+	}
 
 	linearEnvLine := p.LinearEnv
 	if linearEnvLine == "" {
@@ -262,6 +354,7 @@ export OPENCLAW_GATEWAY_PASSWORD="$ELASTICCLAW_GATEWAY_PASSWORD"
 export OPENCLAW_DEFAULT_MODEL=%s
 export ELASTICCLAW_NIX=%s
 export ELASTICCLAW_DOCKER=%s
+%s
 %s
 %s
 %s
@@ -392,7 +485,7 @@ exit 1
 `,
 		shellQuote(p.HubURL), shellQuote(p.ClawID), shellQuote(p.ClawToken), shellQuote(p.ClawName), shellQuote(p.GatewayPassword),
 		shellQuote(p.DefaultModel), shellQuote(nixFlag), shellQuote(dockerFlag),
-		p.LLMKeyEnv, p.ModelAuthEnv, linearEnvLine, apiKeyAuthSyncLine, shellQuote(p.OnboardFlags), providerConfigLine,
+		p.LLMKeyEnv, p.ModelAuthEnv, linearEnvLine, apiKeyAuthSyncLine, oauthAuthSyncLine, shellQuote(p.OnboardFlags), providerConfigLine,
 		shellQuote(p.BridgeURL),
 	)
 }

--- a/pkg/hub/bootstrap_test.go
+++ b/pkg/hub/bootstrap_test.go
@@ -228,6 +228,17 @@ func TestBootstrapScript_OpenClawAPIKeyAuthSyncInjected(t *testing.T) {
 	assertNotContains(t, script, "sk-ant-test", "does not embed the API key in the auth sync script")
 }
 
+func TestBootstrapScript_OpenClawOAuthAuthSyncInjected(t *testing.T) {
+	p := baseParams()
+	p.OAuthAuthSync = buildOpenClawOAuthAuthSyncShell(types.LLMKeysList{
+		{Name: "grok-main", Provider: "grok", AuthProfile: "grok-oauth", Default: true},
+	}, "grok-main")
+
+	script := GenerateReplicatedBootstrapScript(p)
+	assertContains(t, script, "ELASTICCLAW_OAUTH_AUTH_SYNC", "exports OAuth auth sync script for claw-bridge")
+	assertContains(t, script, "auth_profile_store", "includes SQLite auth-store migration")
+}
+
 func TestBootstrapScript_OnboardFlagsShellQuoted(t *testing.T) {
 	p := baseParams()
 	p.OnboardFlags = buildOnboardFlags(nil, "", p.DefaultModel)
@@ -416,6 +427,116 @@ func TestBuildOpenClawAPIKeyAuthSyncShellSkipsNonAnthropicKeys(t *testing.T) {
 
 	if shell != "" {
 		t.Fatalf("expected no auth sync shell for non-Anthropic key, got %q", shell)
+	}
+}
+
+func TestBuildOpenClawOAuthAuthSyncShellMigratesGrokIntoSQLite(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not in PATH")
+	}
+	if _, err := exec.LookPath("node"); err != nil {
+		t.Skip("node not in PATH")
+	}
+	if out, err := exec.Command("node", "-e", `require('node:sqlite')`).CombinedOutput(); err != nil {
+		t.Skipf("node:sqlite unavailable: %v: %s", err, out)
+	}
+
+	shell := buildOpenClawOAuthAuthSyncShell(types.LLMKeysList{
+		{Name: "grok-main", Provider: "grok", AuthProfile: "grok-oauth", Default: true},
+	}, "grok-main")
+	assertContains(t, shell, "auth_profile_store", "writes OpenClaw SQLite auth store")
+	assertContains(t, shell, "models auth paste-token --provider xai", "lets OpenClaw initialize its SQLite schema")
+	assertContains(t, shell, `auth.profiles["xai:default"]`, "sets xAI profile metadata")
+	assertContains(t, shell, `"mode":"oauth"`, "marks migrated profile as OAuth")
+	if strings.Contains(shell, "doctor --fix") {
+		t.Fatalf("OAuth sync must not run broad OpenClaw repairs:\n%s", shell)
+	}
+
+	home := t.TempDir()
+	grokDir := filepath.Join(home, ".grok")
+	if err := os.MkdirAll(grokDir, 0700); err != nil {
+		t.Fatalf("create Grok auth dir: %v", err)
+	}
+	grokAuth := `{"https://auth.x.ai::client":{"key":"access-token","refresh_token":"refresh-token","expires_at":"2030-01-02T03:04:05Z"}}`
+	if err := os.WriteFile(filepath.Join(grokDir, "auth.json"), []byte(grokAuth), 0600); err != nil {
+		t.Fatalf("write Grok auth: %v", err)
+	}
+
+	agentDir := filepath.Join(home, ".openclaw", "agents", "main", "agent")
+	if err := os.MkdirAll(agentDir, 0700); err != nil {
+		t.Fatalf("create OpenClaw agent dir: %v", err)
+	}
+	dbPath := filepath.Join(agentDir, "openclaw-agent.sqlite")
+	existingStore := `{"version":1,"profiles":{"anthropic:default":{"type":"api_key","provider":"anthropic","key":"keep-me"}}}`
+	setup := exec.Command("node", "-e", `
+const { DatabaseSync } = require('node:sqlite');
+const db = new DatabaseSync(process.argv[1]);
+db.exec('CREATE TABLE auth_profile_store (store_key TEXT NOT NULL PRIMARY KEY, store_json TEXT NOT NULL, updated_at INTEGER NOT NULL)');
+db.prepare('INSERT INTO auth_profile_store (store_key, store_json, updated_at) VALUES (?, ?, ?)').run('primary', process.argv[2], Date.now());
+db.close();
+`, dbPath, existingStore)
+	setup.Env = append(os.Environ(), "NODE_NO_WARNINGS=1")
+	if out, err := setup.CombinedOutput(); err != nil {
+		t.Fatalf("create SQLite auth fixture: %v\n%s", err, out)
+	}
+
+	fakeBin := t.TempDir()
+	fakeOpenClaw := filepath.Join(fakeBin, "openclaw")
+	if err := os.WriteFile(fakeOpenClaw, []byte("#!/bin/sh\nprintf '%s\\n' '{\"profiles\":[{\"id\":\"xai:default\",\"type\":\"oauth\"}]}'\n"), 0755); err != nil {
+		t.Fatalf("write fake openclaw: %v", err)
+	}
+	cmd := exec.Command("bash", "-c", shell)
+	cmd.Env = append(os.Environ(),
+		"HOME="+home,
+		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"NODE_NO_WARNINGS=1",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("run OAuth auth sync: %v\n%s", err, out)
+	}
+
+	read := exec.Command("node", "-e", `
+const { DatabaseSync } = require('node:sqlite');
+const db = new DatabaseSync(process.argv[1], { readOnly: true });
+console.log(db.prepare("SELECT store_json FROM auth_profile_store WHERE store_key = 'primary'").get().store_json);
+db.close();
+`, dbPath)
+	read.Env = append(os.Environ(), "NODE_NO_WARNINGS=1")
+	out, err := read.Output()
+	if err != nil {
+		t.Fatalf("read SQLite auth store: %v", err)
+	}
+	var store struct {
+		Profiles map[string]struct {
+			Type     string `json:"type"`
+			Provider string `json:"provider"`
+			Access   string `json:"access"`
+			Refresh  string `json:"refresh"`
+			Expires  int64  `json:"expires"`
+			Key      string `json:"key"`
+		} `json:"profiles"`
+	}
+	if err := json.Unmarshal(out, &store); err != nil {
+		t.Fatalf("parse SQLite auth store: %v\n%s", err, out)
+	}
+	xai := store.Profiles["xai:default"]
+	if xai.Type != "oauth" || xai.Provider != "xai" || xai.Access != "access-token" || xai.Refresh != "refresh-token" || xai.Expires != 1893553445000 {
+		t.Fatalf("unexpected migrated xAI auth: %#v", xai)
+	}
+	if got := store.Profiles["anthropic:default"].Key; got != "keep-me" {
+		t.Fatalf("existing auth profile was not preserved: key=%q", got)
+	}
+}
+
+func TestBuildOpenClawOAuthAuthSyncShellSkipsNonOAuthGrok(t *testing.T) {
+	tests := []types.LLMKeysList{
+		{{Name: "grok-api", Provider: "grok", APIKey: "xai-test", Default: true}},
+		{{Name: "anthropic", Provider: "anthropic", APIKey: "sk-ant-test", Default: true}},
+	}
+	for _, keys := range tests {
+		if shell := buildOpenClawOAuthAuthSyncShell(keys, keys[0].Name); shell != "" {
+			t.Fatalf("unexpected OAuth sync for %#v:\n%s", keys[0], shell)
+		}
 	}
 }
 

--- a/pkg/hub/bootstrap_test.go
+++ b/pkg/hub/bootstrap_test.go
@@ -482,18 +482,35 @@ db.close();
 
 	fakeBin := t.TempDir()
 	fakeOpenClaw := filepath.Join(fakeBin, "openclaw")
-	if err := os.WriteFile(fakeOpenClaw, []byte("#!/bin/sh\nprintf '%s\\n' '{\"profiles\":[{\"id\":\"xai:default\",\"type\":\"oauth\"}]}'\n"), 0755); err != nil {
+	invocationsPath := filepath.Join(home, "openclaw-invocations")
+	fakeOpenClawScript := `#!/bin/sh
+printf '%s\n' "$*" >> "$OPENCLAW_INVOCATIONS"
+if [ "$*" = "models auth list --provider xai --json" ]; then
+  printf '%s\n' '{"profiles":[{"id":"xai:default","type":"oauth"}]}'
+fi
+`
+	if err := os.WriteFile(fakeOpenClaw, []byte(fakeOpenClawScript), 0755); err != nil {
 		t.Fatalf("write fake openclaw: %v", err)
 	}
-	cmd := exec.Command("bash", "-c", shell)
-	cmd.Env = append(os.Environ(),
+	testEnv := append(os.Environ(),
 		"HOME="+home,
 		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
 		"NODE_NO_WARNINGS=1",
+		"OPENCLAW_INVOCATIONS="+invocationsPath,
 	)
+	cmd := exec.Command("bash", "-c", shell)
+	cmd.Env = testEnv
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("run OAuth auth sync: %v\n%s", err, out)
 	}
+	invocations, err := os.ReadFile(invocationsPath)
+	if err != nil {
+		t.Fatalf("read fake OpenClaw invocations: %v", err)
+	}
+	invocationLog := string(invocations)
+	assertContains(t, invocationLog, "models auth paste-token --provider xai --profile-id xai:default --expires-in 1m", "initializes the xAI auth profile")
+	assertContains(t, invocationLog, `config set auth.profiles["xai:default"] {"provider":"xai","mode":"oauth"} --strict-json`, "configures xAI OAuth metadata")
+	assertContains(t, invocationLog, "models auth list --provider xai --json", "verifies the migrated xAI profile")
 
 	read := exec.Command("node", "-e", `
 const { DatabaseSync } = require('node:sqlite');
@@ -526,6 +543,18 @@ db.close();
 	if got := store.Profiles["anthropic:default"].Key; got != "keep-me" {
 		t.Fatalf("existing auth profile was not preserved: key=%q", got)
 	}
+
+	invalidGrokAuth := `{"https://auth.x.ai::client":{"key":"access-token","refresh_token":"refresh-token"}}`
+	if err := os.WriteFile(filepath.Join(grokDir, "auth.json"), []byte(invalidGrokAuth), 0600); err != nil {
+		t.Fatalf("write invalid Grok auth: %v", err)
+	}
+	invalidCmd := exec.Command("bash", "-c", shell)
+	invalidCmd.Env = testEnv
+	invalidOut, err := invalidCmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("OAuth auth sync unexpectedly accepted a missing expiry:\n%s", invalidOut)
+	}
+	assertContains(t, string(invalidOut), "missing a valid expires_at timestamp", "fails closed on invalid OAuth expiry")
 }
 
 func TestBuildOpenClawOAuthAuthSyncShellSkipsNonOAuthGrok(t *testing.T) {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -3250,6 +3250,7 @@ docker --version`); err != nil {
 	llmKeyEnvDaytona := buildLLMKeyEnv(s.hubCfg.LLMKeys, llmKeyNameDaytona)
 	modelAuthEnvDaytona := buildModelAuthEnv(s.hubCfg, llmKeyNameDaytona)
 	apiKeyAuthSyncDaytona := buildOpenClawAPIKeyAuthSyncShell(s.hubCfg.LLMKeys, llmKeyNameDaytona)
+	oauthAuthSyncDaytona := buildOpenClawOAuthAuthSyncShell(s.hubCfg.LLMKeys, llmKeyNameDaytona)
 	onboardFlags := buildOnboardFlags(s.hubCfg.LLMKeys, llmKeyNameDaytona, defaultModelDaytona)
 	providerConfigScript := buildOpenClawProviderConfig(s.hubCfg.LLMKeys, llmKeyNameDaytona)
 	if activeKeyDaytona != nil {
@@ -3292,7 +3293,12 @@ docker --version`); err != nil {
 	} else {
 		log.Printf("[daytona] onboard openclaw done")
 	}
-
+	if oauthAuthSyncDaytona != "" {
+		syncCmd := `export HOME=/home/daytona; export NVM_DIR=/usr/local/share/nvm; export PATH=$NVM_DIR/current/bin:$PATH; ` + oauthAuthSyncDaytona
+		if err := exec("sync openclaw OAuth auth", 30*time.Second, syncCmd); err != nil {
+			return fmt.Errorf("sync openclaw OAuth auth: %w", err)
+		}
+	}
 	if apiKeyAuthSyncDaytona != "" {
 		syncCmd := `export HOME=/home/daytona; export NVM_DIR=/usr/local/share/nvm; export PATH=$NVM_DIR/current/bin:$PATH; ` + llmKeyEnvDaytona + apiKeyAuthSyncDaytona
 		if err := exec("sync openclaw api key auth", 30*time.Second, syncCmd); err != nil {
@@ -4398,6 +4404,7 @@ func (s *Server) bootstrapExedev(ctx context.Context, clawID, vmName string, p *
 		LLMKeyEnv:       llmKeyEnv,
 		ModelAuthEnv:    modelAuthEnv,
 		APIKeyAuthSync:  buildOpenClawAPIKeyAuthSyncShell(hubCfg.LLMKeys, llmKeyName),
+		OAuthAuthSync:   buildOpenClawOAuthAuthSyncShell(hubCfg.LLMKeys, llmKeyName),
 		LinearEnv:       buildLinearEnv(linearToken),
 		ProviderConfig:  buildOpenClawProviderConfig(hubCfg.LLMKeys, llmKeyName),
 		OnboardFlags:    buildOnboardFlags(hubCfg.LLMKeys, llmKeyName, defaultModel),
@@ -4483,6 +4490,7 @@ func (s *Server) provisionDocker(ctx context.Context, clawID string, req types.C
 	gatewayPassword := randomHex(16)
 	providerConfig := buildOpenClawProviderConfig(hubCfg.LLMKeys, llmKeyName)
 	apiKeyAuthSync := buildOpenClawAPIKeyAuthSyncShell(hubCfg.LLMKeys, llmKeyName)
+	oauthAuthSync := buildOpenClawOAuthAuthSyncShell(hubCfg.LLMKeys, llmKeyName)
 	onboardFlags := buildOnboardFlags(hubCfg.LLMKeys, llmKeyName, defaultModel)
 
 	// Build env map for the container — passed directly as -e flags (no shell escaping needed).
@@ -4504,6 +4512,7 @@ func (s *Server) provisionDocker(ctx context.Context, clawID string, req types.C
 		"ELASTICCLAW_DOCKER":             boolEnv(dockerEnabled != 0),
 		"ELASTICCLAW_PROVIDER_CONFIG":    providerConfig,
 		"ELASTICCLAW_API_KEY_AUTH_SYNC":  apiKeyAuthSync,
+		"ELASTICCLAW_OAUTH_AUTH_SYNC":    oauthAuthSync,
 		"ELASTICCLAW_ONBOARD_FLAGS":      onboardFlags,
 	})
 
@@ -4720,6 +4729,7 @@ func (s *Server) provisionLambdaMicroVMs(ctx context.Context, clawID string, req
 	}
 	providerConfig := buildOpenClawProviderConfig(hubCfg.LLMKeys, llmKeyName)
 	apiKeyAuthSync := buildOpenClawAPIKeyAuthSyncShell(hubCfg.LLMKeys, llmKeyName)
+	oauthAuthSync := buildOpenClawOAuthAuthSyncShell(hubCfg.LLMKeys, llmKeyName)
 	onboardFlags := buildOnboardFlags(hubCfg.LLMKeys, llmKeyName, defaultModel)
 	gatewayPassword := randomHex(16)
 
@@ -4738,6 +4748,7 @@ func (s *Server) provisionLambdaMicroVMs(ctx context.Context, clawID string, req
 		"ELASTICCLAW_DOCKER":             boolEnv(dockerEnabled != 0),
 		"ELASTICCLAW_PROVIDER_CONFIG":    providerConfig,
 		"ELASTICCLAW_API_KEY_AUTH_SYNC":  apiKeyAuthSync,
+		"ELASTICCLAW_OAUTH_AUTH_SYNC":    oauthAuthSync,
 		"ELASTICCLAW_ONBOARD_FLAGS":      onboardFlags,
 	}
 	for _, line := range strings.Split(llmKeyEnv+modelAuthEnv, "\n") {
@@ -5511,6 +5522,7 @@ func (s *Server) bootstrapReplicated(clawID, clawName, vmID string, cfg types.Pr
 		LLMKeyEnv:       llmKeyEnv,
 		ModelAuthEnv:    modelAuthEnv,
 		APIKeyAuthSync:  buildOpenClawAPIKeyAuthSyncShell(hubCfg.LLMKeys, llmKeyName),
+		OAuthAuthSync:   buildOpenClawOAuthAuthSyncShell(hubCfg.LLMKeys, llmKeyName),
 		LinearEnv:       buildLinearEnv(linearToken),
 		ProviderConfig:  buildOpenClawProviderConfig(hubCfg.LLMKeys, llmKeyName),
 		OnboardFlags:    buildOnboardFlags(hubCfg.LLMKeys, llmKeyName, defaultModel),


### PR DESCRIPTION
## Summary

- migrate restored Grok OAuth into the OpenClaw 2026.7.1-2 per-agent SQLite auth store
- initialize the schema through the OpenClaw auth CLI and preserve unrelated provider profiles
- apply the migration across Daytona and claw-bridge-backed providers, then verify the xAI profile before gateway startup

## Why

OpenClaw 2026.7.1-2 reads `openclaw-agent.sqlite`, while ElasticClaw restored Grok OAuth only to the legacy `auth-profiles.json`. New Grok Build claws therefore failed with `No API key found for provider "xai"`.

## Verification

- `go test ./...`
- Linux claw-bridge build with `CGO_ENABLED=0 GOOS=linux GOARCH=amd64`
- exact `openclaw@2026.7.1-2` container validation: `xai:default` is listed as OAuth and the gateway becomes healthy