### PR TITLE
Fix Codex OAuth routing and default to GPT-5.6 Sol

### DIFF
--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -2322,6 +2322,7 @@ echo "Git: $(git --version)"
 }
 
 const openClawVersion = cliversion.OpenClawVersion
+const codexPluginVersion = cliversion.CodexPluginVersion
 const codexCLIVersion = cliversion.CodexCLIVersion
 const grokCLIVersion = cliversion.GrokCLIVersion
 
@@ -2570,6 +2571,31 @@ func installSelectedCodingModelCLI() error {
 	default:
 		return nil
 	}
+}
+
+func installSelectedModelPlugin() error {
+	if strings.TrimSpace(os.Getenv("ELASTICCLAW_LLM_PROVIDER")) != "codex" {
+		return nil
+	}
+	if err := exec.Command("openclaw", "plugins", "info", "codex", "--json").Run(); err == nil {
+		log.Printf("[bootstrap] Codex plugin already installed")
+		return nil
+	}
+	version := cliversion.FromEnv("ELASTICCLAW_CODEX_PLUGIN_VERSION", codexPluginVersion)
+	if strings.TrimSpace(version) == "" {
+		return fmt.Errorf("empty version for @openclaw/codex")
+	}
+	spec := "npm:@openclaw/codex@" + version
+	log.Printf("[bootstrap] installing %s...", spec)
+	out, err := exec.Command("openclaw", "plugins", "install", spec).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("install %s: %w: %s", spec, err, strings.TrimSpace(string(out)))
+	}
+	if out, err := exec.Command("openclaw", "plugins", "info", "codex", "--json").CombinedOutput(); err != nil {
+		return fmt.Errorf("verify Codex plugin install: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	log.Printf("[bootstrap] Codex plugin: %s", version)
+	return nil
 }
 
 func syncOpenClawAPIKeyAuth() error {
@@ -3280,6 +3306,9 @@ func runBootstrap() error {
 		}
 	} else {
 		log.Printf("[bootstrap] openclaw.json already exists, skipping onboard")
+	}
+	if err := installSelectedModelPlugin(); err != nil {
+		return fmt.Errorf("installSelectedModelPlugin: %w", err)
 	}
 	if err := syncOpenClawOAuthAuth(); err != nil {
 		return err

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -738,6 +738,66 @@ chmod +x "$HOME/.local/bin/openclaw"
 	}
 }
 
+func TestInstallSelectedModelPluginInstallsPinnedCodexPluginOnce(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake openclaw executable uses POSIX shell")
+	}
+
+	home := t.TempDir()
+	fakeBin := t.TempDir()
+	invocations := filepath.Join(t.TempDir(), "openclaw-args")
+	installedMarker := filepath.Join(t.TempDir(), "codex-installed")
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("ELASTICCLAW_LLM_PROVIDER", "codex")
+	t.Setenv("OPENCLAW_INVOCATIONS", invocations)
+	t.Setenv("CODEX_INSTALLED_MARKER", installedMarker)
+
+	fakeOpenClaw := `#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "$OPENCLAW_INVOCATIONS"
+if [ "$*" = "plugins info codex --json" ]; then
+  test -f "$CODEX_INSTALLED_MARKER"
+  exit $?
+fi
+case "$*" in
+  "plugins install "*) touch "$CODEX_INSTALLED_MARKER" ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(fakeBin, "openclaw"), []byte(fakeOpenClaw), 0755); err != nil {
+		t.Fatalf("write fake openclaw: %v", err)
+	}
+
+	if err := installSelectedModelPlugin(); err != nil {
+		t.Fatalf("installSelectedModelPlugin(): %v", err)
+	}
+	if err := installSelectedModelPlugin(); err != nil {
+		t.Fatalf("second installSelectedModelPlugin(): %v", err)
+	}
+
+	logData, err := os.ReadFile(invocations)
+	if err != nil {
+		t.Fatalf("read OpenClaw invocations: %v", err)
+	}
+	logText := string(logData)
+	wantInstall := "plugins install npm:@openclaw/codex@" + codexPluginVersion
+	if strings.Count(logText, wantInstall) != 1 {
+		t.Fatalf("Codex plugin install count = %d, want 1\n%s", strings.Count(logText, wantInstall), logText)
+	}
+	if strings.Count(logText, "plugins info codex --json") != 3 {
+		t.Fatalf("Codex plugin verification count = %d, want 3\n%s", strings.Count(logText, "plugins info codex --json"), logText)
+	}
+}
+
+func TestInstallSelectedModelPluginSkipsNonCodexProvider(t *testing.T) {
+	t.Setenv("ELASTICCLAW_LLM_PROVIDER", "openai")
+	t.Setenv("PATH", t.TempDir())
+
+	if err := installSelectedModelPlugin(); err != nil {
+		t.Fatalf("installSelectedModelPlugin(): %v", err)
+	}
+}
+
 func TestRestoreCLIModelAuthWritesBundleFiles(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/pkg/cliversion/cliversion.go
+++ b/pkg/cliversion/cliversion.go
@@ -9,6 +9,7 @@ const (
 	OpenClawVersion      = "2026.7.1-2"
 	OpenClawImageVersion = "2026.7.1"
 	OpenClawImage        = "ghcr.io/openclaw/openclaw:" + OpenClawImageVersion
+	CodexPluginVersion   = "2026.7.1-1"
 	CodexCLIVersion      = "0.144.6"
 	GrokCLIVersion       = "0.2.103"
 )

--- a/pkg/hub/ai_config.go
+++ b/pkg/hub/ai_config.go
@@ -585,19 +585,16 @@ func aiConfigModelForKey(key *types.LLMKeyConfig, defaultModel string) string {
 		return defaultModel
 	}
 	if key.DefaultModel != "" {
-		if strings.HasPrefix(key.DefaultModel, key.Provider+"/") {
-			return key.DefaultModel
-		}
-		return key.Provider + "/" + key.DefaultModel
+		return normalizeModelForProvider(key.Provider, key.DefaultModel)
 	}
-	if defaultModel != "" && strings.HasPrefix(defaultModel, key.Provider+"/") {
-		return defaultModel
+	if defaultModel != "" && modelMatchesProvider(key.Provider, defaultModel) {
+		return normalizeModelForProvider(key.Provider, defaultModel)
 	}
 	switch key.Provider {
 	case "openai":
 		return "openai/gpt-5.5"
 	case "codex":
-		return "codex/gpt-5.5"
+		return defaultCodexModel
 	case "grok":
 		return "grok/grok-build-0.1"
 	case "fireworks":

--- a/pkg/hub/bootstrap.go
+++ b/pkg/hub/bootstrap.go
@@ -21,6 +21,7 @@ type BootstrapParams struct {
 	// OpenClaw config
 	DefaultModel    string
 	GatewayPassword string
+	LLMProvider     string
 
 	// claw-bridge binary source (HTTPS URL or OCI ref)
 	BridgeURL string
@@ -68,6 +69,13 @@ func resolveActiveKey(keys []*types.LLMKeyConfig, selectedKeyName string) *types
 	return nil
 }
 
+func resolveActiveProvider(keys []*types.LLMKeyConfig, selectedKeyName string) string {
+	if key := resolveActiveKey(keys, selectedKeyName); key != nil {
+		return key.Provider
+	}
+	return ""
+}
+
 // buildOpenClawProviderConfig returns a python snippet that patches
 // ~/.openclaw/openclaw.json with the agent default, gateway settings, and any
 // auth-profile compatibility writes needed after openclaw onboard.
@@ -76,9 +84,19 @@ func buildOpenClawProviderConfig(keys []*types.LLMKeyConfig, selectedKeyName str
 	// Determine active key
 	activeKey := resolveActiveKey(keys, selectedKeyName)
 	grokOAuth := activeKey != nil && activeKey.Provider == "grok" && activeKey.AuthProfile != "" && activeKey.APIKey == ""
+	codexSelected := activeKey != nil && activeKey.Provider == "codex"
+	openAISelected := activeKey != nil && activeKey.Provider == "openai"
 	grokOAuthLiteral := "False"
 	if grokOAuth {
 		grokOAuthLiteral = "True"
+	}
+	codexSelectedLiteral := "False"
+	if codexSelected {
+		codexSelectedLiteral = "True"
+	}
+	openAISelectedLiteral := "False"
+	if openAISelected {
+		openAISelectedLiteral = "True"
 	}
 
 	anthropicEnvVar := ""
@@ -133,6 +151,8 @@ except Exception:
 model = os.environ.get('OPENCLAW_DEFAULT_MODEL', 'anthropic/claude-sonnet-4-6')
 if %s and model.startswith('grok/'):
     model = 'xai/' + model.split('/', 1)[1]
+if %s and model.startswith('codex/'):
+    model = 'openai/' + model.split('/', 1)[1]
 agent_defaults = config.setdefault('agents', {}).setdefault('defaults', {})
 agent_defaults['model'] = model
 agent_models = agent_defaults.get('models')
@@ -140,6 +160,26 @@ if isinstance(agent_models, dict):
     for key in list(agent_models.keys()):
         if 'kimi-k2p5' in key:
             agent_models.pop(key, None)
+if %s:
+    agent_defaults['thinkingDefault'] = 'medium'
+    if not isinstance(agent_models, dict):
+        agent_models = {}
+        agent_defaults['models'] = agent_models
+    model_config = agent_models.setdefault(model, {})
+    if not isinstance(model_config, dict):
+        model_config = {}
+        agent_models[model] = model_config
+    model_config['agentRuntime'] = {'id': 'codex'}
+    config.setdefault('plugins', {}).setdefault('entries', {}).setdefault('codex', {})['enabled'] = True
+if %s:
+    if not isinstance(agent_models, dict):
+        agent_models = {}
+        agent_defaults['models'] = agent_models
+    model_config = agent_models.setdefault(model, {})
+    if not isinstance(model_config, dict):
+        model_config = {}
+        agent_models[model] = model_config
+    model_config['agentRuntime'] = {'id': 'openclaw'}
 # OpenClaw rejects the legacy top-level models provider catalog shape we used
 # to write. Onboard handles provider auth; keep only agent default.
 models = config.get('models')
@@ -194,7 +234,7 @@ if gw_password:
 with open(path, 'w') as f:
     json.dump(config, f, indent=2)
 print('OpenClaw config patched')
-PYEOF`, grokOAuthLiteral, anthropicPatch)
+PYEOF`, grokOAuthLiteral, codexSelectedLiteral, codexSelectedLiteral, openAISelectedLiteral, anthropicPatch)
 }
 
 // buildOpenClawAPIKeyAuthSyncShell returns a shell snippet that persists
@@ -218,7 +258,13 @@ fi`, envVar, envVar)
 // runtime, and its broad `doctor --fix` migration also changes unrelated config.
 func buildOpenClawOAuthAuthSyncShell(keys []*types.LLMKeyConfig, selectedKeyName string) string {
 	activeKey := resolveActiveKey(keys, selectedKeyName)
-	if activeKey == nil || activeKey.Provider != "grok" || activeKey.AuthProfile == "" || activeKey.APIKey != "" {
+	if activeKey == nil || activeKey.AuthProfile == "" || activeKey.APIKey != "" {
+		return ""
+	}
+	if activeKey.Provider == "codex" {
+		return buildOpenClawCodexOAuthAuthSyncShell()
+	}
+	if activeKey.Provider != "grok" {
 		return ""
 	}
 	return `set -euo pipefail
@@ -301,6 +347,41 @@ process.stdin.on("end", () => {
 '`
 }
 
+// buildOpenClawCodexOAuthAuthSyncShell verifies that OpenClaw discovers the
+// restored Codex CLI credential as its canonical OpenAI auth profile. The
+// current OpenClaw runtime reads openai:default from ~/.codex/auth.json, so this
+// deliberately uses the supported CLI path instead of writing the SQLite store
+// directly.
+func buildOpenClawCodexOAuthAuthSyncShell() string {
+	return `set -euo pipefail
+node <<'NODE'
+const fs = require('fs');
+const path = require('path');
+
+const authPath = path.join(process.env.HOME, '.codex', 'auth.json');
+const auth = JSON.parse(fs.readFileSync(authPath, 'utf8'));
+const tokens = auth && typeof auth === 'object' ? auth.tokens : null;
+if (!tokens || typeof tokens.access_token !== 'string' || !tokens.access_token ||
+    typeof tokens.refresh_token !== 'string' || !tokens.refresh_token) {
+  throw new Error('restored Codex OAuth credential is missing access or refresh token');
+}
+NODE
+openclaw models auth list --provider openai --json | node -e '
+let input = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => { input += chunk; });
+process.stdin.on("end", () => {
+  const result = JSON.parse(input);
+  if (!Array.isArray(result.profiles) || !result.profiles.some((profile) =>
+    profile.id === "openai:default" && profile.type === "oauth"
+  )) {
+    throw new Error("OpenClaw did not discover the restored Codex OAuth profile");
+  }
+});
+'
+openclaw config set 'auth.profiles["openai:default"]' '{"provider":"openai","mode":"oauth"}' --strict-json >/dev/null`
+}
+
 // GenerateReplicatedBootstrapScript returns a minimal bash script that downloads
 // claw-bridge and execs it with --bootstrap. All VM setup logic now lives inside
 // claw-bridge itself (runBootstrap in cmd/claw-bridge/main.go).
@@ -355,6 +436,7 @@ export ELASTICCLAW_CLAW_NAME=%s
 export ELASTICCLAW_GATEWAY_PASSWORD=%s
 export OPENCLAW_GATEWAY_PASSWORD="$ELASTICCLAW_GATEWAY_PASSWORD"
 export OPENCLAW_DEFAULT_MODEL=%s
+export ELASTICCLAW_LLM_PROVIDER=%s
 export ELASTICCLAW_NIX=%s
 export ELASTICCLAW_DOCKER=%s
 %s
@@ -487,7 +569,7 @@ echo "ERROR: timed out waiting for claw-bridge bootstrap to complete"
 exit 1
 `,
 		shellQuote(p.HubURL), shellQuote(p.ClawID), shellQuote(p.ClawToken), shellQuote(p.ClawName), shellQuote(p.GatewayPassword),
-		shellQuote(p.DefaultModel), shellQuote(nixFlag), shellQuote(dockerFlag),
+		shellQuote(p.DefaultModel), shellQuote(p.LLMProvider), shellQuote(nixFlag), shellQuote(dockerFlag),
 		p.LLMKeyEnv, p.ModelAuthEnv, linearEnvLine, apiKeyAuthSyncLine, oauthAuthSyncLine, shellQuote(p.OnboardFlags), providerConfigLine,
 		shellQuote(p.BridgeURL),
 	)
@@ -520,7 +602,10 @@ func buildOnboardFlags(keys []*types.LLMKeyConfig, selectedKeyName, defaultModel
 	case "deepseek":
 		return fmt.Sprintf(`--auth-choice deepseek-api-key --deepseek-api-key "${%s:-}"`, envVar)
 	case "codex":
-		return fmt.Sprintf(`--auth-choice codex-api-key --codex-api-key "${%s:-}"`, envVar)
+		if active.AuthProfile != "" && active.APIKey == "" {
+			return `--auth-choice skip`
+		}
+		return fmt.Sprintf(`--auth-choice openai-api-key --openai-api-key "${%s:-}"`, envVar)
 	case "grok":
 		if active.AuthProfile != "" && active.APIKey == "" {
 			return `--auth-choice skip`

--- a/pkg/hub/bootstrap_test.go
+++ b/pkg/hub/bootstrap_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/elasticclaw/elasticclaw/pkg/cliversion"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
 
@@ -118,6 +119,26 @@ func TestDaytonaOpenClawInstallCommands_AreAsyncAndPollable(t *testing.T) {
 	assertContains(t, status, "openclaw-install-status=failed", "status reports failed install")
 	assertContains(t, status, "tail -n 120", "status includes install diagnostics")
 	assertContains(t, status, "openclaw@2026.7.1-2", "status checks the pinned install process")
+}
+
+func TestDaytonaInstallModelPluginCommandPinsCodexPlugin(t *testing.T) {
+	cmd := daytonaInstallModelPluginCommand("codex")
+
+	assertContains(t, cmd, "plugins info codex --json", "checks for an existing Codex plugin")
+	assertContains(t, cmd, "npm:@openclaw/codex@"+cliversion.CodexPluginVersion, "pins the Codex plugin version")
+	assertContains(t, cmd, "plugins install", "installs the missing Codex plugin")
+	if got := daytonaInstallModelPluginCommand("openai"); got != "" {
+		t.Fatalf("OpenAI plugin install command = %q, want empty", got)
+	}
+}
+
+func TestBootstrapScriptExportsSelectedLLMProvider(t *testing.T) {
+	p := baseParams()
+	p.LLMProvider = "codex"
+
+	script := GenerateReplicatedBootstrapScript(p)
+
+	assertContains(t, script, "export ELASTICCLAW_LLM_PROVIDER='codex'", "exports the selected provider for model plugin setup")
 }
 
 func TestBootstrapScript_ConnectorDownloadRetriesWithUserFacingLabel(t *testing.T) {
@@ -345,8 +366,8 @@ func TestBuildOnboardFlags_OpenAICompatibleProviders(t *testing.T) {
 			name:       "codex",
 			provider:   "codex",
 			envVar:     "CODEX_API_KEY",
-			authChoice: "codex-api-key",
-			flagName:   "--codex-api-key",
+			authChoice: "openai-api-key",
+			flagName:   "--openai-api-key",
 		},
 		{
 			name:       "grok",
@@ -388,6 +409,18 @@ func TestBuildOnboardFlagsGrokOAuthSkipsAPIKeyOnboarding(t *testing.T) {
 	}
 
 	flags := buildOnboardFlags(keys, "grok-main", "grok/grok-build-0.1")
+
+	if flags != "--auth-choice skip" {
+		t.Fatalf("flags = %q, want OAuth bootstrap to skip API-key onboarding", flags)
+	}
+}
+
+func TestBuildOnboardFlagsCodexOAuthSkipsAPIKeyOnboarding(t *testing.T) {
+	keys := []*types.LLMKeyConfig{
+		{Name: "codex-main", Provider: "codex", AuthProfile: "codex-oauth", Default: true},
+	}
+
+	flags := buildOnboardFlags(keys, "codex-main", defaultCodexModel)
 
 	if flags != "--auth-choice skip" {
 		t.Fatalf("flags = %q, want OAuth bootstrap to skip API-key onboarding", flags)
@@ -557,9 +590,94 @@ db.close();
 	assertContains(t, string(invalidOut), "missing a valid expires_at timestamp", "fails closed on invalid OAuth expiry")
 }
 
-func TestBuildOpenClawOAuthAuthSyncShellSkipsNonOAuthGrok(t *testing.T) {
+func TestBuildOpenClawOAuthAuthSyncShellDiscoversCodexOAuth(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not in PATH")
+	}
+	if _, err := exec.LookPath("node"); err != nil {
+		t.Skip("node not in PATH")
+	}
+
+	shell := buildOpenClawOAuthAuthSyncShell(types.LLMKeysList{
+		{Name: "codex-main", Provider: "codex", AuthProfile: "codex-oauth", Default: true},
+	}, "codex-main")
+	assertContains(t, shell, "models auth list --provider openai --json", "discovers Codex OAuth through OpenClaw")
+	assertContains(t, shell, `auth.profiles["openai:default"]`, "sets canonical OpenAI profile metadata")
+	assertNotContains(t, shell, "auth_profile_store", "does not manipulate the OpenClaw auth database directly")
+
+	home := t.TempDir()
+	codexDir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(codexDir, 0700); err != nil {
+		t.Fatalf("create Codex auth dir: %v", err)
+	}
+	codexAuth := `{"auth_mode":"chatgpt","tokens":{"access_token":"access-token","refresh_token":"refresh-token"}}`
+	if err := os.WriteFile(filepath.Join(codexDir, "auth.json"), []byte(codexAuth), 0600); err != nil {
+		t.Fatalf("write Codex auth: %v", err)
+	}
+
+	fakeBin := t.TempDir()
+	fakeOpenClaw := filepath.Join(fakeBin, "openclaw")
+	invocationsPath := filepath.Join(home, "openclaw-invocations")
+	fakeOpenClawScript := `#!/bin/sh
+printf '%s\n' "$*" >> "$OPENCLAW_INVOCATIONS"
+if [ "$*" = "models auth list --provider openai --json" ]; then
+  printf '%s\n' '{"profiles":[{"id":"openai:default","type":"oauth"}]}'
+fi
+`
+	if err := os.WriteFile(fakeOpenClaw, []byte(fakeOpenClawScript), 0755); err != nil {
+		t.Fatalf("write fake openclaw: %v", err)
+	}
+	cmd := exec.Command("bash", "-c", shell)
+	cmd.Env = append(os.Environ(),
+		"HOME="+home,
+		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"OPENCLAW_INVOCATIONS="+invocationsPath,
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("run Codex OAuth auth sync: %v\n%s", err, out)
+	}
+	invocations, err := os.ReadFile(invocationsPath)
+	if err != nil {
+		t.Fatalf("read fake OpenClaw invocations: %v", err)
+	}
+	invocationLog := string(invocations)
+	assertContains(t, invocationLog, "models auth list --provider openai --json", "verifies the discovered profile")
+	assertContains(t, invocationLog, `config set auth.profiles["openai:default"] {"provider":"openai","mode":"oauth"} --strict-json`, "configures profile metadata")
+}
+
+func TestBuildOpenClawOAuthAuthSyncShellRejectsIncompleteCodexOAuth(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not in PATH")
+	}
+	if _, err := exec.LookPath("node"); err != nil {
+		t.Skip("node not in PATH")
+	}
+
+	home := t.TempDir()
+	codexDir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(codexDir, 0700); err != nil {
+		t.Fatalf("create Codex auth dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(codexDir, "auth.json"), []byte(`{"tokens":{"access_token":"access-token"}}`), 0600); err != nil {
+		t.Fatalf("write Codex auth: %v", err)
+	}
+
+	shell := buildOpenClawOAuthAuthSyncShell(types.LLMKeysList{
+		{Name: "codex-main", Provider: "codex", AuthProfile: "codex-oauth", Default: true},
+	}, "codex-main")
+	cmd := exec.Command("bash", "-c", shell)
+	cmd.Env = append(os.Environ(), "HOME="+home)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected incomplete Codex OAuth credential to fail, output: %s", out)
+	}
+	assertContains(t, string(out), "missing access or refresh token", "reports incomplete restored credential")
+}
+
+func TestBuildOpenClawOAuthAuthSyncShellSkipsNonOAuthKeys(t *testing.T) {
 	tests := []types.LLMKeysList{
 		{{Name: "grok-api", Provider: "grok", APIKey: "xai-test", Default: true}},
+		{{Name: "codex-api", Provider: "codex", APIKey: "sk-test", Default: true}},
 		{{Name: "anthropic", Provider: "anthropic", APIKey: "sk-ant-test", Default: true}},
 	}
 	for _, keys := range tests {
@@ -787,6 +905,98 @@ func TestBuildOpenClawProviderConfig_UsesNativeXAIForGrokOAuth(t *testing.T) {
 				t.Fatalf("OAuth config retained legacy Grok API-key provider: %#v", providers)
 			}
 		}
+	}
+}
+
+func TestBuildOpenClawProviderConfig_UsesCodexRuntimeAndMediumThinking(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not in PATH")
+	}
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not in PATH")
+	}
+
+	keys := []*types.LLMKeyConfig{
+		{Name: "codex-main", Provider: "codex", AuthProfile: "codex-oauth", Default: true},
+	}
+	snippet := buildOpenClawProviderConfig(keys, "codex-main")
+	home := t.TempDir()
+	cmd := exec.Command("bash", "-c", snippet)
+	cmd.Env = append(os.Environ(),
+		"HOME="+home,
+		"OPENCLAW_DEFAULT_MODEL=codex/gpt-5.6-sol",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("run config snippet: %v\n%s", err, out)
+	}
+
+	configData, err := os.ReadFile(filepath.Join(home, ".openclaw", "openclaw.json"))
+	if err != nil {
+		t.Fatalf("read patched config: %v", err)
+	}
+	var config map[string]any
+	if err := json.Unmarshal(configData, &config); err != nil {
+		t.Fatalf("parse patched config: %v", err)
+	}
+	agents := config["agents"].(map[string]any)
+	defaults := agents["defaults"].(map[string]any)
+	if defaults["model"] != defaultCodexModel {
+		t.Fatalf("default model = %#v, want %q", defaults["model"], defaultCodexModel)
+	}
+	if defaults["thinkingDefault"] != "medium" {
+		t.Fatalf("thinking default = %#v, want medium", defaults["thinkingDefault"])
+	}
+	models := defaults["models"].(map[string]any)
+	modelConfig := models[defaultCodexModel].(map[string]any)
+	runtime := modelConfig["agentRuntime"].(map[string]any)
+	if runtime["id"] != "codex" {
+		t.Fatalf("Codex runtime = %#v, want codex", runtime["id"])
+	}
+	plugins := config["plugins"].(map[string]any)
+	entries := plugins["entries"].(map[string]any)
+	codexPlugin := entries["codex"].(map[string]any)
+	if codexPlugin["enabled"] != true {
+		t.Fatalf("Codex plugin enabled = %#v, want true", codexPlugin["enabled"])
+	}
+}
+
+func TestBuildOpenClawProviderConfig_KeepsOpenAIAPIKeysOnOpenClawRuntime(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not in PATH")
+	}
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not in PATH")
+	}
+
+	keys := []*types.LLMKeyConfig{
+		{Name: "openai-main", Provider: "openai", APIKey: "sk-test", Default: true},
+	}
+	snippet := buildOpenClawProviderConfig(keys, "openai-main")
+	home := t.TempDir()
+	cmd := exec.Command("bash", "-c", snippet)
+	cmd.Env = append(os.Environ(),
+		"HOME="+home,
+		"OPENCLAW_DEFAULT_MODEL=openai/gpt-5.5",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("run config snippet: %v\n%s", err, out)
+	}
+
+	configData, err := os.ReadFile(filepath.Join(home, ".openclaw", "openclaw.json"))
+	if err != nil {
+		t.Fatalf("read patched config: %v", err)
+	}
+	var config map[string]any
+	if err := json.Unmarshal(configData, &config); err != nil {
+		t.Fatalf("parse patched config: %v", err)
+	}
+	agents := config["agents"].(map[string]any)
+	defaults := agents["defaults"].(map[string]any)
+	models := defaults["models"].(map[string]any)
+	modelConfig := models["openai/gpt-5.5"].(map[string]any)
+	runtime := modelConfig["agentRuntime"].(map[string]any)
+	if runtime["id"] != "openclaw" {
+		t.Fatalf("OpenAI runtime = %#v, want openclaw", runtime["id"])
 	}
 }
 

--- a/pkg/hub/external_webhook.go
+++ b/pkg/hub/external_webhook.go
@@ -781,16 +781,12 @@ func resolveDefaultModelForKeyLocal(hubDefaultModel string, key *types.LLMKeyCon
 
 	// Use per-key default model if set; normalize to include provider prefix
 	if key.DefaultModel != "" {
-		prefix := key.Provider + "/"
-		if !strings.HasPrefix(key.DefaultModel, prefix) {
-			return prefix + key.DefaultModel
-		}
-		return key.DefaultModel
+		return normalizeModelForProvider(key.Provider, key.DefaultModel)
 	}
 
 	// Check if hub's DefaultModel matches this key's provider
-	if hubDefaultModel != "" && strings.HasPrefix(hubDefaultModel, key.Provider+"/") {
-		return hubDefaultModel
+	if hubDefaultModel != "" && modelMatchesProvider(key.Provider, hubDefaultModel) {
+		return normalizeModelForProvider(key.Provider, hubDefaultModel)
 	}
 
 	// Construct a provider-specific default model
@@ -802,7 +798,7 @@ func resolveDefaultModelForKeyLocal(hubDefaultModel string, key *types.LLMKeyCon
 	case "openai":
 		return "openai/gpt-5.5"
 	case "codex":
-		return "codex/gpt-5.5"
+		return defaultCodexModel
 	case "grok":
 		return "grok/grok-build-0.1"
 	case "groq":

--- a/pkg/hub/failure_summary.go
+++ b/pkg/hub/failure_summary.go
@@ -408,13 +408,10 @@ func isFailureSummaryProvider(provider string) bool {
 
 func modelForFailureSummary(key *types.LLMKeyConfig, defaultModel string) string {
 	if key.DefaultModel != "" {
-		if strings.HasPrefix(key.DefaultModel, key.Provider+"/") {
-			return key.DefaultModel
-		}
-		return key.Provider + "/" + key.DefaultModel
+		return normalizeModelForProvider(key.Provider, key.DefaultModel)
 	}
-	if defaultModel != "" && strings.HasPrefix(defaultModel, key.Provider+"/") {
-		return defaultModel
+	if defaultModel != "" && modelMatchesProvider(key.Provider, defaultModel) {
+		return normalizeModelForProvider(key.Provider, defaultModel)
 	}
 	switch key.Provider {
 	case "anthropic":
@@ -422,7 +419,7 @@ func modelForFailureSummary(key *types.LLMKeyConfig, defaultModel string) string
 	case "openai":
 		return "openai/gpt-5.4-mini"
 	case "codex":
-		return "codex/gpt-5.5"
+		return defaultCodexModel
 	case "grok":
 		return "grok/grok-build-0.1"
 	case "fireworks":

--- a/pkg/hub/model_defaults.go
+++ b/pkg/hub/model_defaults.go
@@ -1,0 +1,31 @@
+package hub
+
+import "strings"
+
+const defaultCodexModel = "openai/gpt-5.6-sol"
+
+func canonicalModelProvider(provider string) string {
+	if provider == "codex" {
+		return "openai"
+	}
+	return provider
+}
+
+func modelMatchesProvider(provider, model string) bool {
+	canonicalProvider := canonicalModelProvider(provider)
+	if strings.HasPrefix(model, canonicalProvider+"/") {
+		return true
+	}
+	return provider == "codex" && strings.HasPrefix(model, "codex/")
+}
+
+func normalizeModelForProvider(provider, model string) string {
+	canonicalProvider := canonicalModelProvider(provider)
+	if strings.HasPrefix(model, canonicalProvider+"/") {
+		return model
+	}
+	if provider == "codex" && strings.HasPrefix(model, "codex/") {
+		return canonicalProvider + "/" + strings.TrimPrefix(model, "codex/")
+	}
+	return canonicalProvider + "/" + model
+}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -3293,6 +3293,11 @@ docker --version`); err != nil {
 	} else {
 		log.Printf("[daytona] onboard openclaw done")
 	}
+	if installCmd := daytonaInstallModelPluginCommand(activeKeyProviderDaytona); installCmd != "" {
+		if err := exec("install selected model plugin", 3*time.Minute, installCmd); err != nil {
+			return fmt.Errorf("install selected model plugin: %w", err)
+		}
+	}
 	if oauthAuthSyncDaytona != "" {
 		syncCmd := `export HOME=/home/daytona; export NVM_DIR=/usr/local/share/nvm; export PATH=$NVM_DIR/current/bin:$PATH; ` + oauthAuthSyncDaytona
 		if err := exec("sync openclaw OAuth auth", 30*time.Second, syncCmd); err != nil {
@@ -3776,6 +3781,23 @@ export PATH="$PREFIX/bin:$NVM_DIR/current/bin:/usr/local/bin:$PATH"
 sudo env PATH="$PREFIX/bin:$NVM_DIR/current/bin:/usr/local/bin:$PATH" "$NPM" install -g %s --prefix "$PREFIX" --ignore-scripts
 hash -r
 %s --version 2>&1 || true`, shellQuote(packageSpec), binary)
+}
+
+func daytonaInstallModelPluginCommand(provider string) string {
+	if provider != "codex" {
+		return ""
+	}
+	version := cliversion.FromEnv("ELASTICCLAW_CODEX_PLUGIN_VERSION", cliversion.CodexPluginVersion)
+	spec := "npm:@openclaw/codex@" + version
+	return fmt.Sprintf(`export HOME=/home/daytona
+export NVM_DIR=/usr/local/share/nvm
+export PATH="$NVM_DIR/current/bin:/usr/local/bin:$PATH"
+if openclaw plugins info codex --json >/dev/null 2>&1; then
+  echo "Codex plugin already installed"
+else
+  openclaw plugins install %s
+fi
+openclaw plugins info codex --json >/dev/null`, shellQuote(spec))
 }
 
 func daytonaOpenClawInstallStatusCommand(version string) string {
@@ -4394,6 +4416,7 @@ func (s *Server) bootstrapExedev(ctx context.Context, clawID, vmName string, p *
 		ClawToken:       clawToken,
 		HubURL:          s.clawHubURL(),
 		DefaultModel:    defaultModel,
+		LLMProvider:     resolveActiveProvider(hubCfg.LLMKeys, llmKeyName),
 		GatewayPassword: gatewayPassword,
 		BridgeURL:       bridgeURL,
 		Nix:             nixEnabled != 0,
@@ -4508,6 +4531,7 @@ func (s *Server) provisionDocker(ctx context.Context, clawID string, req types.C
 		"ELASTICCLAW_GATEWAY_PASSWORD":   gatewayPassword,
 		"OPENCLAW_GATEWAY_PASSWORD":      gatewayPassword,
 		"OPENCLAW_DEFAULT_MODEL":         defaultModel,
+		"ELASTICCLAW_LLM_PROVIDER":       resolveActiveProvider(hubCfg.LLMKeys, llmKeyName),
 		"ELASTICCLAW_NIX":                boolEnv(nixEnabled != 0),
 		"ELASTICCLAW_DOCKER":             boolEnv(dockerEnabled != 0),
 		"ELASTICCLAW_PROVIDER_CONFIG":    providerConfig,
@@ -4744,6 +4768,7 @@ func (s *Server) provisionLambdaMicroVMs(ctx context.Context, clawID string, req
 		"ELASTICCLAW_GATEWAY_PASSWORD":   gatewayPassword,
 		"OPENCLAW_GATEWAY_PASSWORD":      gatewayPassword,
 		"OPENCLAW_DEFAULT_MODEL":         defaultModel,
+		"ELASTICCLAW_LLM_PROVIDER":       resolveActiveProvider(hubCfg.LLMKeys, llmKeyName),
 		"ELASTICCLAW_NIX":                boolEnv(nixEnabled != 0),
 		"ELASTICCLAW_DOCKER":             boolEnv(dockerEnabled != 0),
 		"ELASTICCLAW_PROVIDER_CONFIG":    providerConfig,
@@ -5512,6 +5537,7 @@ func (s *Server) bootstrapReplicated(clawID, clawName, vmID string, cfg types.Pr
 		ClawToken:       clawToken,
 		HubURL:          s.clawHubURL(),
 		DefaultModel:    defaultModel,
+		LLMProvider:     resolveActiveProvider(hubCfg.LLMKeys, llmKeyName),
 		GatewayPassword: gatewayPassword,
 		BridgeURL:       bridgeURL,
 		Nix:             nixEnabled != 0,
@@ -5819,16 +5845,12 @@ func resolveDefaultModelForKey(hubCfg *types.HubConfig, key *types.LLMKeyConfig)
 
 	// Use per-key default model if set; normalize to include provider prefix
 	if key.DefaultModel != "" {
-		prefix := key.Provider + "/"
-		if !strings.HasPrefix(key.DefaultModel, prefix) {
-			return prefix + key.DefaultModel
-		}
-		return key.DefaultModel
+		return normalizeModelForProvider(key.Provider, key.DefaultModel)
 	}
 
 	// Check if hub's DefaultModel matches this key's provider
-	if hubCfg.DefaultModel != "" && strings.HasPrefix(hubCfg.DefaultModel, key.Provider+"/") {
-		return hubCfg.DefaultModel
+	if hubCfg.DefaultModel != "" && modelMatchesProvider(key.Provider, hubCfg.DefaultModel) {
+		return normalizeModelForProvider(key.Provider, hubCfg.DefaultModel)
 	}
 
 	// Construct a provider-specific default model
@@ -5838,7 +5860,7 @@ func resolveDefaultModelForKey(hubCfg *types.HubConfig, key *types.LLMKeyConfig)
 	case "openai":
 		return "openai/gpt-5.5"
 	case "codex":
-		return "codex/gpt-5.5"
+		return defaultCodexModel
 	case "grok":
 		return "grok/grok-build-0.1"
 	case "fireworks":

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -218,7 +218,29 @@ func TestResolveDefaultModelForKey(t *testing.T) {
 			key: &types.LLMKeyConfig{
 				Provider: "codex",
 			},
-			expectedModel: "codex/gpt-5.5",
+			expectedModel: defaultCodexModel,
+		},
+		{
+			name: "codex provider normalizes legacy namespaced model",
+			hubCfg: &types.HubConfig{
+				DefaultModel: "anthropic/claude-sonnet-4-6",
+			},
+			key: &types.LLMKeyConfig{
+				Provider:     "codex",
+				DefaultModel: "codex/gpt-5.5",
+			},
+			expectedModel: "openai/gpt-5.5",
+		},
+		{
+			name: "codex provider normalizes bare model",
+			hubCfg: &types.HubConfig{
+				DefaultModel: "anthropic/claude-sonnet-4-6",
+			},
+			key: &types.LLMKeyConfig{
+				Provider:     "codex",
+				DefaultModel: "gpt-5.6-terra",
+			},
+			expectedModel: "openai/gpt-5.6-terra",
 		},
 		{
 			name: "grok provider",

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -1176,10 +1176,11 @@ const PROVIDER_MODELS: Record<string, LLMModelOption[]> = {
     { id: "__custom",             name: "Custom OpenAI model" },
   ],
   codex: [
-    { id: "codex/gpt-5.5",      name: "GPT-5.5" },
-    { id: "codex/gpt-5.5-high", name: "GPT-5.5 High" },
-    { id: "codex/gpt-5.4",      name: "GPT-5.4" },
-    { id: "__custom",           name: "Custom Codex model" },
+    { id: "openai/gpt-5.6-sol",   name: "GPT-5.6 Sol" },
+    { id: "openai/gpt-5.6-terra", name: "GPT-5.6 Terra" },
+    { id: "openai/gpt-5.6-luna",  name: "GPT-5.6 Luna" },
+    { id: "openai/gpt-5.5",       name: "GPT-5.5" },
+    { id: "__custom",             name: "Custom Codex model" },
   ],
   grok: [
     { id: "grok/grok-build-0.1", name: "Grok Build" },


### PR DESCRIPTION
## Summary

- route ElasticClaw Codex keys through the canonical OpenClaw `openai` provider and Codex app-server runtime
- restore Codex OAuth through native `~/.codex/auth.json` discovery and skip empty API-key onboarding
- install the pinned `@openclaw/codex` plugin when Codex is selected
- default Codex to `openai/gpt-5.6-sol` with medium reasoning and migrate legacy `codex/*` model refs
- keep ordinary OpenAI API-key keys explicitly on the embedded OpenClaw runtime

## Verification

- `go test ./...`
- `npm run build` in `web/`
- OpenClaw `2026.7.1-2` discovered a synthetic restored credential as `openai:default`
- installed `@openclaw/codex@2026.7.1-1` and validated the final config with zero warnings