### PR TITLE
fix: harden Daytona keepalives and polling logs

### DIFF
--- a/pkg/hub/daytona_keepalive_test.go
+++ b/pkg/hub/daytona_keepalive_test.go
@@ -1,0 +1,56 @@
+package hub
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+type keepaliveExecutorStub struct {
+	errors   []error
+	calls    int
+	timeouts []time.Duration
+}
+
+func (s *keepaliveExecutorStub) ExecWithTimeout(_ context.Context, _ string, _ []string, timeout time.Duration) (*types.ExecResult, error) {
+	s.timeouts = append(s.timeouts, timeout)
+	var err error
+	if s.calls < len(s.errors) {
+		err = s.errors[s.calls]
+	}
+	s.calls++
+	if err != nil {
+		return nil, err
+	}
+	return &types.ExecResult{}, nil
+}
+
+func TestPetDaytonaSandboxRetriesTransientTimeout(t *testing.T) {
+	executor := &keepaliveExecutorStub{errors: []error{errors.New("Daytona error (status 408): request timeout: command execution timeout"), nil}}
+	if err := petDaytonaSandboxWithRetry(context.Background(), executor, "sandbox-id", []time.Duration{0}); err != nil {
+		t.Fatalf("petDaytonaSandboxWithRetry: %v", err)
+	}
+	if executor.calls != 2 {
+		t.Fatalf("keepalive attempts = %d, want 2", executor.calls)
+	}
+	for _, timeout := range executor.timeouts {
+		if timeout != 5*time.Second {
+			t.Fatalf("keepalive command timeout = %s, want 5s", timeout)
+		}
+	}
+}
+
+func TestPetDaytonaSandboxDoesNotRetryPermanentFailure(t *testing.T) {
+	wantErr := errors.New("resource not found")
+	executor := &keepaliveExecutorStub{errors: []error{wantErr}}
+	err := petDaytonaSandboxWithRetry(context.Background(), executor, "sandbox-id", []time.Duration{0, 0})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("petDaytonaSandboxWithRetry error = %v, want %v", err, wantErr)
+	}
+	if executor.calls != 1 {
+		t.Fatalf("keepalive attempts = %d, want 1", executor.calls)
+	}
+}

--- a/pkg/hub/integration_poller.go
+++ b/pkg/hub/integration_poller.go
@@ -133,6 +133,25 @@ func (s *Server) setPollHighWaterMark(integration string, t time.Time) {
 	_, _ = s.db.Exec(`INSERT INTO integration_poll_state(integration,last_success_at) VALUES(?,?) ON CONFLICT(integration) DO UPDATE SET last_success_at=excluded.last_success_at`, integration, t)
 }
 
+func (s *Server) logPollWarningOnce(key, format string, args ...interface{}) {
+	s.pollWarningMu.Lock()
+	defer s.pollWarningMu.Unlock()
+	if s.pollWarnings == nil {
+		s.pollWarnings = make(map[string]struct{})
+	}
+	if _, exists := s.pollWarnings[key]; exists {
+		return
+	}
+	s.pollWarnings[key] = struct{}{}
+	log.Printf(format, args...)
+}
+
+func (s *Server) clearPollWarning(key string) {
+	s.pollWarningMu.Lock()
+	defer s.pollWarningMu.Unlock()
+	delete(s.pollWarnings, key)
+}
+
 func (s *Server) pollSince(integration string, n time.Time) time.Time {
 	since := n.Add(-2 * time.Minute)
 	if hwm, ok := s.getPollHighWaterMark(integration); ok && hwm.Before(since) {
@@ -878,10 +897,12 @@ func (s *Server) pollGitHubIssueWorkflows(workspaces []*types.WorkspaceConfig, s
 				continue
 			}
 			token := s.resolveGitHubIssuesTokenForWorkflow(workspace.Name, workflow)
+			warningKey := "github-issues-token:" + workspace.Name + "/" + workflow.Name
 			if token == "" {
-				log.Printf("[poll-github-issues] workflow %s/%s: no GitHub Issues token configured — skipping", workspace.Name, workflow.Name)
+				s.logPollWarningOnce(warningKey, "[poll-github-issues] workflow %s/%s: no GitHub Issues token configured — skipping", workspace.Name, workflow.Name)
 				continue
 			}
+			s.clearPollWarning(warningKey)
 			for _, repo := range githubIssuesWorkflowTriggerRepos(workflow) {
 				if repo == "" {
 					continue

--- a/pkg/hub/integration_poller_test.go
+++ b/pkg/hub/integration_poller_test.go
@@ -1,8 +1,11 @@
 package hub
 
 import (
+	"bytes"
+	"log"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -36,6 +39,48 @@ func TestPollSinceHighWaterMarkAndFailedWindow(t *testing.T) {
 				t.Fatalf("pollSince = %s, want %s", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestPollGitHubIssueWorkflowsLogsMissingTokenOnce(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	s := newFactoryTriggerTestServer(t)
+	workspace := &types.WorkspaceConfig{
+		Name: "autoci",
+		Workflows: []*types.WorkflowConfig{{
+			Name:        "github-issue",
+			Integration: "github-issues",
+		}},
+	}
+
+	var logs bytes.Buffer
+	previous := log.Writer()
+	log.SetOutput(&logs)
+	t.Cleanup(func() { log.SetOutput(previous) })
+
+	s.pollGitHubIssueWorkflows([]*types.WorkspaceConfig{workspace}, time.Now().UTC().Format(time.RFC3339))
+	s.pollGitHubIssueWorkflows([]*types.WorkspaceConfig{workspace}, time.Now().UTC().Format(time.RFC3339))
+
+	const warning = "workflow autoci/github-issue: no GitHub Issues token configured"
+	if count := strings.Count(logs.String(), warning); count != 1 {
+		t.Fatalf("missing-token warning count = %d, want 1; logs:\n%s", count, logs.String())
+	}
+}
+
+func TestPollWarningCanBeRearmed(t *testing.T) {
+	s := &Server{}
+	var logs bytes.Buffer
+	previous := log.Writer()
+	log.SetOutput(&logs)
+	t.Cleanup(func() { log.SetOutput(previous) })
+
+	s.logPollWarningOnce("key", "warning")
+	s.logPollWarningOnce("key", "warning")
+	s.clearPollWarning("key")
+	s.logPollWarningOnce("key", "warning")
+
+	if count := strings.Count(logs.String(), "warning"); count != 2 {
+		t.Fatalf("warning count after rearm = %d, want 2; logs:\n%s", count, logs.String())
 	}
 }
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -88,6 +88,8 @@ type Server struct {
 	fireworksModelsCacheUntil time.Time
 	modelAuthJobsMu           sync.Mutex
 	modelAuthJobs             map[string]*modelAuthLoginJob
+	pollWarningMu             sync.Mutex
+	pollWarnings              map[string]struct{}
 
 	// webhookDedup prevents duplicate Linear webhook deliveries from creating
 	// duplicate claws. Keyed by issue transition fingerprint; entries expire after 30s.
@@ -4925,15 +4927,43 @@ func (s *Server) petDaytonaSandboxes() {
 	}
 
 	for _, c := range claws {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		_, err := p.ExecWithTimeout(ctx, c.providerID, []string{"bash", "-lc", "true"}, 20*time.Second)
-		cancel()
+		err := petDaytonaSandboxWithRetry(context.Background(), p, c.providerID, daytonaKeepaliveRetryDelays)
 		if err != nil {
 			log.Printf("[daytona] keepalive failed for %s (%s): %v", c.name, c.id[:8], err)
 			continue
 		}
 		log.Printf("[daytona] keepalive ok for %s (%s)", c.name, c.id[:8])
 	}
+}
+
+type daytonaKeepaliveExecutor interface {
+	ExecWithTimeout(context.Context, string, []string, time.Duration) (*types.ExecResult, error)
+}
+
+var daytonaKeepaliveRetryDelays = []time.Duration{2 * time.Second, 5 * time.Second}
+
+func petDaytonaSandboxWithRetry(ctx context.Context, executor daytonaKeepaliveExecutor, providerID string, retryDelays []time.Duration) error {
+	var lastErr error
+	for attempt := 0; attempt <= len(retryDelays); attempt++ {
+		attemptCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		_, lastErr = executor.ExecWithTimeout(attemptCtx, providerID, []string{"bash", "-lc", "true"}, 5*time.Second)
+		cancel()
+		if lastErr == nil {
+			return nil
+		}
+		if !daytona.IsTransientExecError(lastErr) || attempt == len(retryDelays) {
+			return lastErr
+		}
+
+		timer := time.NewTimer(retryDelays[attempt])
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+	return lastErr
 }
 
 // statusWatchdog runs every 2 minutes to check claw health and request status

--- a/pkg/provider/daytona/daytona.go
+++ b/pkg/provider/daytona/daytona.go
@@ -2,7 +2,9 @@ package daytona
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"regexp"
 	"sort"
@@ -10,6 +12,7 @@ import (
 	"time"
 
 	"github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+	daytonaerrors "github.com/daytonaio/daytona/libs/sdk-go/pkg/errors"
 	daytonaopts "github.com/daytonaio/daytona/libs/sdk-go/pkg/options"
 	daytonatypes "github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
@@ -217,6 +220,32 @@ func (p *Provider) ExecWithTimeout(ctx context.Context, instanceID string, cmdAr
 		ExitCode: response.ExitCode,
 		Stdout:   response.Result,
 	}, nil
+}
+
+// IsTransientExecError reports whether a failed Daytona command is safe to
+// retry. Keepalive commands are idempotent, but permanent failures such as a
+// missing sandbox should still fail immediately.
+func IsTransientExecError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+
+	var timeoutErr *daytonaerrors.DaytonaTimeoutError
+	if errors.As(err, &timeoutErr) {
+		return true
+	}
+	var daytonaErr *daytonaerrors.DaytonaError
+	if errors.As(err, &daytonaErr) {
+		return daytonaErr.StatusCode == http.StatusRequestTimeout ||
+			daytonaErr.StatusCode == http.StatusTooManyRequests ||
+			daytonaErr.StatusCode >= http.StatusInternalServerError
+	}
+
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "timeout") || strings.Contains(message, "timed out")
 }
 
 func (p *Provider) EnsureSession(ctx context.Context, instanceID, sessionID string) error {

--- a/pkg/provider/daytona/daytona_test.go
+++ b/pkg/provider/daytona/daytona_test.go
@@ -1,8 +1,13 @@
 package daytona
 
 import (
+	"context"
+	"fmt"
+	"net/http"
 	"strings"
 	"testing"
+
+	daytonaerrors "github.com/daytonaio/daytona/libs/sdk-go/pkg/errors"
 )
 
 func TestBuildOpenClawEnvFileIncludesWorkflowSecrets(t *testing.T) {
@@ -59,5 +64,28 @@ func TestShellEnvNameValidation(t *testing.T) {
 		if shellEnvNameRE.MatchString(name) {
 			t.Fatalf("invalid env name %q accepted", name)
 		}
+	}
+}
+
+func TestIsTransientExecError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "request timeout", err: fmt.Errorf("execute: %w", daytonaerrors.NewDaytonaError("request timeout", http.StatusRequestTimeout, nil)), want: true},
+		{name: "rate limited", err: daytonaerrors.NewDaytonaError("slow down", http.StatusTooManyRequests, nil), want: true},
+		{name: "server error", err: daytonaerrors.NewDaytonaError("unavailable", http.StatusServiceUnavailable, nil), want: true},
+		{name: "deadline exceeded", err: context.DeadlineExceeded, want: true},
+		{name: "not found", err: daytonaerrors.NewDaytonaError("missing", http.StatusNotFound, nil), want: false},
+		{name: "ordinary error", err: fmt.Errorf("permission denied"), want: false},
+		{name: "nil", err: nil, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsTransientExecError(tt.err); got != tt.want {
+				t.Fatalf("IsTransientExecError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- retry transient Daytona keepalive timeouts with bounded short probes and backoff
- keep permanent Daytona errors fail-fast
- log missing GitHub Issues workflow tokens once per missing period instead of every 30 seconds
- re-arm the warning after token configuration recovers

## Validation

- nix develop --accept-flake-config -c go test ./pkg/provider/daytona ./pkg/hub
- nix develop --accept-flake-config -c go test ./...
- nix develop --accept-flake-config -c go build ./...