### PR TITLE
Preserve workspace identity for GitHub App auth

### DIFF
--- a/pkg/hub/bootstrap.go
+++ b/pkg/hub/bootstrap.go
@@ -11,9 +11,10 @@ import (
 // It is intentionally a pure value type — no DB, no server, no side effects.
 type BootstrapParams struct {
 	// Claw identity
-	ClawID    string
-	ClawName  string
-	ClawToken string
+	ClawID       string
+	ClawName     string
+	ClawToken    string
+	TemplateName string
 
 	// Hub connectivity
 	HubURL string
@@ -433,6 +434,7 @@ export ELASTICCLAW_HUB_URL=%s
 export ELASTICCLAW_CLAW_ID=%s
 export ELASTICCLAW_CLAW_TOKEN=%s
 export ELASTICCLAW_CLAW_NAME=%s
+export ELASTICCLAW_TEMPLATE=%s
 export ELASTICCLAW_GATEWAY_PASSWORD=%s
 export OPENCLAW_GATEWAY_PASSWORD="$ELASTICCLAW_GATEWAY_PASSWORD"
 export OPENCLAW_DEFAULT_MODEL=%s
@@ -502,6 +504,7 @@ echo "ElasticClaw connector installed"
   printf 'export ELASTICCLAW_CLAW_ID=%%q\n' "$ELASTICCLAW_CLAW_ID"
   printf 'export ELASTICCLAW_CLAW_TOKEN=%%q\n' "$ELASTICCLAW_CLAW_TOKEN"
   printf 'export ELASTICCLAW_CLAW_NAME=%%q\n' "$ELASTICCLAW_CLAW_NAME"
+  printf 'export ELASTICCLAW_TEMPLATE=%%q\n' "$ELASTICCLAW_TEMPLATE"
   printf 'export ELASTICCLAW_GATEWAY_PASSWORD=%%q\n' "$ELASTICCLAW_GATEWAY_PASSWORD"
   printf 'export OPENCLAW_GATEWAY_PASSWORD=%%q\n' "$OPENCLAW_GATEWAY_PASSWORD"
 } > "$HOME/.claw-bridge.env"
@@ -568,7 +571,7 @@ done
 echo "ERROR: timed out waiting for claw-bridge bootstrap to complete"
 exit 1
 `,
-		shellQuote(p.HubURL), shellQuote(p.ClawID), shellQuote(p.ClawToken), shellQuote(p.ClawName), shellQuote(p.GatewayPassword),
+		shellQuote(p.HubURL), shellQuote(p.ClawID), shellQuote(p.ClawToken), shellQuote(p.ClawName), shellQuote(p.TemplateName), shellQuote(p.GatewayPassword),
 		shellQuote(p.DefaultModel), shellQuote(p.LLMProvider), shellQuote(nixFlag), shellQuote(dockerFlag),
 		p.LLMKeyEnv, p.ModelAuthEnv, linearEnvLine, apiKeyAuthSyncLine, oauthAuthSyncLine, shellQuote(p.OnboardFlags), providerConfigLine,
 		shellQuote(p.BridgeURL),

--- a/pkg/hub/bootstrap_test.go
+++ b/pkg/hub/bootstrap_test.go
@@ -19,6 +19,7 @@ func baseParams() BootstrapParams {
 		ClawID:          "test-claw-id-1234",
 		ClawName:        "test-claw",
 		ClawToken:       "test-token",
+		TemplateName:    "adversarylabs",
 		HubURL:          "https://hub.example.com",
 		DefaultModel:    "anthropic/claude-sonnet-4-6",
 		GatewayPassword: "test-gw-password",
@@ -68,7 +69,7 @@ func TestBootstrapScript_ContainsBridgeURL(t *testing.T) {
 
 func TestDaytonaBridgeCommands_AreAsyncAndIdempotent(t *testing.T) {
 	prep := daytonaPrepareBridgeCommand()
-	cmd := daytonaAsyncBridgeCommand("https://hub.example.com", "claw-123", "token-123", "NEXT-156")
+	cmd := daytonaAsyncBridgeCommand("https://hub.example.com", "claw-123", "token-123", "NEXT-156", "adversarylabs")
 	running := daytonaBridgeRunningCommand()
 
 	assertContains(t, prep, "pgrep -x claw-bridge", "detects already running bridge from previous start behavior")
@@ -87,6 +88,7 @@ func TestDaytonaBridgeCommands_AreAsyncAndIdempotent(t *testing.T) {
 	assertContains(t, cmd, "kill \"$child\"", "supervisor forwards termination to its bridge child")
 	assertContains(t, cmd, "restart budget exhausted after 3 attempts", "caps rapid restart flapping")
 	assertContains(t, cmd, `ELASTICCLAW_CLAW_ID='claw-123'`, "passes claw id to bridge")
+	assertContains(t, cmd, `ELASTICCLAW_TEMPLATE='adversarylabs'`, "passes workspace identity to bridge")
 	assertNotContains(t, cmd, "nohup /tmp/claw-bridge", "does not execute bridge directly from tmp")
 	assertNotContains(t, cmd, "setsid", "does not rely on shell detach when Daytona async sessions are available")
 
@@ -97,11 +99,14 @@ func TestDaytonaBridgeCommands_AreAsyncAndIdempotent(t *testing.T) {
 
 func TestDaytonaAsyncBridgeCommandShellQuotesClawName(t *testing.T) {
 	clawName := `$(touch /tmp/elasticclaw-pwned)' "quoted"`
-	cmd := daytonaAsyncBridgeCommand("https://hub.example.com", "claw-123", "token-123", clawName)
+	templateName := `$(touch /tmp/elasticclaw-template-pwned)' "quoted"`
+	cmd := daytonaAsyncBridgeCommand("https://hub.example.com", "claw-123", "token-123", clawName, templateName)
 
 	assertContains(t, cmd, "ELASTICCLAW_CLAW_NAME="+shellQuote(clawName), "shell-quotes command-substitution payload")
 	assertNotContains(t, cmd, `ELASTICCLAW_CLAW_NAME="$(touch`, "must not place claw name in shell double quotes")
 	assertContains(t, cmd, "ELASTICCLAW_CLAW_NAME='", "claw name assignment must use single-quote wrapping")
+	assertContains(t, cmd, "ELASTICCLAW_TEMPLATE="+shellQuote(templateName), "shell-quotes workspace identity")
+	assertNotContains(t, cmd, `ELASTICCLAW_TEMPLATE="$(touch`, "must not place workspace identity in shell double quotes")
 }
 
 func TestDaytonaOpenClawInstallCommands_AreAsyncAndPollable(t *testing.T) {
@@ -170,12 +175,14 @@ func TestBootstrapScript_BridgeEnvVars(t *testing.T) {
 	assertContains(t, script, `ELASTICCLAW_CLAW_ID='test-claw-id-1234'`, "claw ID env var")
 	assertContains(t, script, `ELASTICCLAW_CLAW_TOKEN='test-token'`, "claw token env var")
 	assertContains(t, script, `ELASTICCLAW_CLAW_NAME='test-claw'`, "claw name env var")
+	assertContains(t, script, `ELASTICCLAW_TEMPLATE='adversarylabs'`, "workspace identity env var")
 	assertContains(t, script, `ELASTICCLAW_GATEWAY_PASSWORD='test-gw-password'`, "gateway password env var")
 }
 
 func TestBootstrapScript_BridgeEnvFileQuotesValues(t *testing.T) {
 	script := GenerateReplicatedBootstrapScript(baseParams())
 	assertContains(t, script, `printf 'export ELASTICCLAW_CLAW_NAME=%q\n' "$ELASTICCLAW_CLAW_NAME"`, "claw name quoted in persisted env")
+	assertContains(t, script, `printf 'export ELASTICCLAW_TEMPLATE=%q\n' "$ELASTICCLAW_TEMPLATE"`, "workspace identity quoted in persisted env")
 	assertContains(t, script, `printf 'export ELASTICCLAW_GATEWAY_PASSWORD=%q\n' "$ELASTICCLAW_GATEWAY_PASSWORD"`, "gateway password quoted in persisted env")
 }
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -5479,12 +5479,13 @@ func (s *Server) bootstrapReplicated(clawID, clawName, vmID string, cfg types.Pr
 		return
 	}
 
-	var filesJSON string
-	_ = s.db.QueryRow(`SELECT COALESCE(template_files,'{}') FROM claws WHERE id=?`, clawID).Scan(&filesJSON)
+	var filesJSON, templateName string
+	_ = s.db.QueryRow(
+		`SELECT COALESCE(template_files,'{}'), COALESCE(template,'') FROM claws WHERE id=?`,
+		clawID,
+	).Scan(&filesJSON, &templateName)
 	var files map[string]string
 	_ = json.Unmarshal([]byte(filesJSON), &files)
-	var templateName string
-	_ = s.db.QueryRow(`SELECT COALESCE(template,'') FROM claws WHERE id=?`, clawID).Scan(&templateName)
 
 	// Load github repos config for this claw
 	var githubReposJSON string

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1137,6 +1137,8 @@ func (s *Server) handleCreateClaw(w http.ResponseWriter, r *http.Request, tenant
 	for k, v := range req.Env {
 		env[k] = v
 	}
+	// Workspace identity is hub-managed and must not be overridden by request env.
+	env["ELASTICCLAW_TEMPLATE"] = req.TemplateName
 	for envName, secretRef := range req.SecretRefs {
 		if val, ok := hubSecrets[secretRef]; ok {
 			env[envName] = val
@@ -2105,7 +2107,8 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 		currentStatus = desiredStatus
 		_ = s.db.QueryRow(
 			`INSERT INTO claws(id,tenant_id,name,template,status,last_seen,created_at) VALUES(?,?,?,?,?,?,?)
-			 ON CONFLICT(id) DO UPDATE SET name=excluded.name, template=excluded.template,
+			 ON CONFLICT(id) DO UPDATE SET name=excluded.name,
+			 template=COALESCE(NULLIF(excluded.template,''), claws.template),
 			 status=CASE WHEN claws.status IN ('idle','deleted') THEN claws.status ELSE excluded.status END,
 			 last_seen=excluded.last_seen
 			 RETURNING status`,
@@ -3626,7 +3629,11 @@ gh auth status`
 	// workspace, template files, GitHub setup, and bootstrap_ok gate are ready.
 	// The bridge (and therefore the agent) must run inside the workspace
 	// directory so that repo-relative paths resolve correctly.
-	if err := s.startDaytonaBridge(ctx, instanceID, p, s.clawHubURL(), clawID, clawToken, clawName); err != nil {
+	var templateName string
+	if err := s.db.QueryRow(`SELECT COALESCE(template,'') FROM claws WHERE id=?`, clawID).Scan(&templateName); err != nil {
+		return fmt.Errorf("load claw template: %w", err)
+	}
+	if err := s.startDaytonaBridge(ctx, instanceID, p, s.clawHubURL(), clawID, clawToken, clawName, templateName); err != nil {
 		return err
 	}
 
@@ -3664,7 +3671,7 @@ func recordE2EProviderID(label, envName, id string) {
 	}
 }
 
-func (s *Server) startDaytonaBridge(ctx context.Context, instanceID string, p *daytona.Provider, hubURL, clawID, clawToken, clawName string) error {
+func (s *Server) startDaytonaBridge(ctx context.Context, instanceID string, p *daytona.Provider, hubURL, clawID, clawToken, clawName, templateName string) error {
 	prepCmd := daytonaPrepareBridgeCommand()
 	result, err := p.ExecWithTimeout(ctx, instanceID, []string{prepCmd}, 15*time.Second)
 	if err != nil {
@@ -3682,7 +3689,7 @@ func (s *Server) startDaytonaBridge(ctx context.Context, instanceID string, p *d
 	if err := p.EnsureSession(ctx, instanceID, sessionID); err != nil {
 		return fmt.Errorf("start claw-bridge session: %w", err)
 	}
-	cmdID, err := p.ExecSessionAsync(ctx, instanceID, sessionID, daytonaAsyncBridgeCommand(hubURL, clawID, clawToken, clawName))
+	cmdID, err := p.ExecSessionAsync(ctx, instanceID, sessionID, daytonaAsyncBridgeCommand(hubURL, clawID, clawToken, clawName, templateName))
 	if err != nil {
 		return fmt.Errorf("start claw-bridge async: %w", err)
 	}
@@ -3858,7 +3865,7 @@ test -x /usr/local/bin/claw-bridge || { echo "claw-bridge installed at /usr/loca
 rm -f "$PIDFILE"`
 }
 
-func daytonaAsyncBridgeCommand(hubURL, clawID, clawToken, clawName string) string {
+func daytonaAsyncBridgeCommand(hubURL, clawID, clawToken, clawName, templateName string) string {
 	return fmt.Sprintf(`export HOME=/home/daytona
 mkdir -p /home/daytona/.openclaw/workspace /home/daytona/.openclaw/run
 cd /home/daytona/.openclaw/workspace
@@ -3873,7 +3880,7 @@ if pgrep -x claw-bridge >/dev/null 2>&1; then
   exit 0
 fi
 rm -f "$PIDFILE"
-ELASTICCLAW_HUB_URL=%s ELASTICCLAW_CLAW_ID=%s ELASTICCLAW_CLAW_TOKEN=%s ELASTICCLAW_CLAW_NAME=%s \
+ELASTICCLAW_HUB_URL=%s ELASTICCLAW_CLAW_ID=%s ELASTICCLAW_CLAW_TOKEN=%s ELASTICCLAW_CLAW_NAME=%s ELASTICCLAW_TEMPLATE=%s \
 sh -c '
 PIDFILE="$1"
 LOG="$2"
@@ -3916,6 +3923,7 @@ done
 		shellQuote(clawID),
 		shellQuote(clawToken),
 		shellQuote(clawName),
+		shellQuote(templateName),
 	)
 }
 
@@ -4375,10 +4383,10 @@ func (s *Server) bootstrapExedev(ctx context.Context, clawID, vmName string, p *
 	s.setBootstrapStatus(clawID, "Preparing ElasticClaw connector")
 
 	// Load claw configuration from DB in a single atomic query
-	var clawName, githubReposJSON, linearWorkspace, templateDefaultModel, llmKeyName, templateFilesJSON string
+	var clawName, templateName, githubReposJSON, linearWorkspace, templateDefaultModel, llmKeyName, templateFilesJSON string
 	var nixEnabled, dockerEnabled int
-	if err := s.db.QueryRow(`SELECT COALESCE(name,''), COALESCE(github_repos,'[]'), COALESCE(linear_workspace,''), COALESCE(default_model,''), nix, docker, COALESCE(llm_key,''), COALESCE(template_files,'{}') FROM claws WHERE id=?`, clawID).Scan(
-		&clawName, &githubReposJSON, &linearWorkspace, &templateDefaultModel, &nixEnabled, &dockerEnabled, &llmKeyName, &templateFilesJSON,
+	if err := s.db.QueryRow(`SELECT COALESCE(name,''), COALESCE(template,''), COALESCE(github_repos,'[]'), COALESCE(linear_workspace,''), COALESCE(default_model,''), nix, docker, COALESCE(llm_key,''), COALESCE(template_files,'{}') FROM claws WHERE id=?`, clawID).Scan(
+		&clawName, &templateName, &githubReposJSON, &linearWorkspace, &templateDefaultModel, &nixEnabled, &dockerEnabled, &llmKeyName, &templateFilesJSON,
 	); err != nil {
 		return fmt.Errorf("load claw config: %w", err)
 	}
@@ -4416,6 +4424,7 @@ func (s *Server) bootstrapExedev(ctx context.Context, clawID, vmName string, p *
 		ClawID:          clawID,
 		ClawName:        clawName,
 		ClawToken:       clawToken,
+		TemplateName:    templateName,
 		HubURL:          s.clawHubURL(),
 		DefaultModel:    defaultModel,
 		LLMProvider:     resolveActiveProvider(hubCfg.LLMKeys, llmKeyName),
@@ -4490,12 +4499,12 @@ func (s *Server) provisionDocker(ctx context.Context, clawID string, req types.C
 	}
 
 	// Load claw configuration from DB
-	var clawName, githubReposJSON, linearWorkspace, templateDefaultModel, llmKeyName string
+	var clawName, templateName, githubReposJSON, linearWorkspace, templateDefaultModel, llmKeyName string
 	var nixEnabled, dockerEnabled int
 	if err := s.db.QueryRow(
-		`SELECT COALESCE(name,''), COALESCE(github_repos,'[]'), COALESCE(linear_workspace,''), COALESCE(default_model,''), nix, docker, COALESCE(llm_key,'') FROM claws WHERE id=?`,
+		`SELECT COALESCE(name,''), COALESCE(template,''), COALESCE(github_repos,'[]'), COALESCE(linear_workspace,''), COALESCE(default_model,''), nix, docker, COALESCE(llm_key,'') FROM claws WHERE id=?`,
 		clawID,
-	).Scan(&clawName, &githubReposJSON, &linearWorkspace, &templateDefaultModel, &nixEnabled, &dockerEnabled, &llmKeyName); err != nil {
+	).Scan(&clawName, &templateName, &githubReposJSON, &linearWorkspace, &templateDefaultModel, &nixEnabled, &dockerEnabled, &llmKeyName); err != nil {
 		return fmt.Errorf("load claw config: %w", err)
 	}
 
@@ -4527,6 +4536,7 @@ func (s *Server) provisionDocker(ctx context.Context, clawID string, req types.C
 		"ELASTICCLAW_CLAW_ID":            clawID,
 		"ELASTICCLAW_CLAW_TOKEN":         clawToken,
 		"ELASTICCLAW_CLAW_NAME":          clawName,
+		"ELASTICCLAW_TEMPLATE":           templateName,
 		"ELASTICCLAW_GITHUB_REPOS":       githubReposJSON,
 		"ELASTICCLAW_BOOTSTRAP":          "1",
 		"ELASTICCLAW_WAIT_FOR_WORKSPACE": "1",
@@ -4732,12 +4742,12 @@ func (s *Server) provisionLambdaMicroVMs(ctx context.Context, clawID string, req
 		return fmt.Errorf("lambda microvms init: %w", err)
 	}
 
-	var clawName, githubReposJSON, linearWorkspace, templateDefaultModel, llmKeyName string
+	var clawName, templateName, githubReposJSON, linearWorkspace, templateDefaultModel, llmKeyName string
 	var nixEnabled, dockerEnabled int
 	if err := s.db.QueryRow(
-		`SELECT COALESCE(name,''), COALESCE(github_repos,'[]'), COALESCE(linear_workspace,''), COALESCE(default_model,''), nix, docker, COALESCE(llm_key,'') FROM claws WHERE id=?`,
+		`SELECT COALESCE(name,''), COALESCE(template,''), COALESCE(github_repos,'[]'), COALESCE(linear_workspace,''), COALESCE(default_model,''), nix, docker, COALESCE(llm_key,'') FROM claws WHERE id=?`,
 		clawID,
-	).Scan(&clawName, &githubReposJSON, &linearWorkspace, &templateDefaultModel, &nixEnabled, &dockerEnabled, &llmKeyName); err != nil {
+	).Scan(&clawName, &templateName, &githubReposJSON, &linearWorkspace, &templateDefaultModel, &nixEnabled, &dockerEnabled, &llmKeyName); err != nil {
 		return fmt.Errorf("load claw config: %w", err)
 	}
 
@@ -4764,6 +4774,7 @@ func (s *Server) provisionLambdaMicroVMs(ctx context.Context, clawID string, req
 		"ELASTICCLAW_CLAW_ID":            clawID,
 		"ELASTICCLAW_CLAW_TOKEN":         clawToken,
 		"ELASTICCLAW_CLAW_NAME":          clawName,
+		"ELASTICCLAW_TEMPLATE":           templateName,
 		"ELASTICCLAW_GITHUB_REPOS":       githubReposJSON,
 		"ELASTICCLAW_BOOTSTRAP":          "1",
 		"ELASTICCLAW_WAIT_FOR_WORKSPACE": "1",
@@ -5472,6 +5483,8 @@ func (s *Server) bootstrapReplicated(clawID, clawName, vmID string, cfg types.Pr
 	_ = s.db.QueryRow(`SELECT COALESCE(template_files,'{}') FROM claws WHERE id=?`, clawID).Scan(&filesJSON)
 	var files map[string]string
 	_ = json.Unmarshal([]byte(filesJSON), &files)
+	var templateName string
+	_ = s.db.QueryRow(`SELECT COALESCE(template,'') FROM claws WHERE id=?`, clawID).Scan(&templateName)
 
 	// Load github repos config for this claw
 	var githubReposJSON string
@@ -5565,6 +5578,7 @@ func (s *Server) bootstrapReplicated(clawID, clawName, vmID string, cfg types.Pr
 		ClawID:          clawID,
 		ClawName:        clawName,
 		ClawToken:       clawToken,
+		TemplateName:    templateName,
 		HubURL:          s.clawHubURL(),
 		DefaultModel:    defaultModel,
 		LLMProvider:     resolveActiveProvider(hubCfg.LLMKeys, llmKeyName),
@@ -6711,14 +6725,16 @@ func (s *Server) handleGitHubToken(w http.ResponseWriter, r *http.Request) {
 
 	var workspaceName string
 	var reposJSON string
+	var tagsJSON string
 	err := s.db.QueryRow(
-		`SELECT COALESCE(template,''), github_repos FROM claws WHERE id = ?`,
+		`SELECT COALESCE(template,''), github_repos, COALESCE(tags,'[]') FROM claws WHERE id = ?`,
 		clawID,
-	).Scan(&workspaceName, &reposJSON)
+	).Scan(&workspaceName, &reposJSON, &tagsJSON)
 	if err != nil {
 		http.Error(w, "claw not found", http.StatusNotFound)
 		return
 	}
+	workspaceName = clawWorkspaceName(workspaceName, tagsJSON)
 
 	var repos []RepoAccess
 	if reposJSON != "" && reposJSON != "[]" {
@@ -6802,6 +6818,20 @@ func (s *Server) handleGitHubToken(w http.ResponseWriter, r *http.Request) {
 
 	log.Printf("no github app found with installation for repos %v (claw %s)", repos, clawID[:8])
 	http.Error(w, "no github installation found for the requested repos", http.StatusNotFound)
+}
+
+func clawWorkspaceName(templateName, tagsJSON string) string {
+	if templateName = strings.TrimSpace(templateName); templateName != "" {
+		return templateName
+	}
+	var tags []string
+	if err := json.Unmarshal([]byte(tagsJSON), &tags); err != nil {
+		return ""
+	}
+	if workspaceName, workflowName := workflowTags(tags); workspaceName != "" && workflowName != "" {
+		return workspaceName
+	}
+	return ""
 }
 
 func inaccessibleGitHubReposMessage(repos []string) string {

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -1192,6 +1192,73 @@ func TestStreamingSegmentsPersistAroundActivityForRefreshTimeline(t *testing.T) 
 	}
 }
 
+func TestClawRegistrationPreservesTemplateWhenBridgeOmitsIt(t *testing.T) {
+	ready := true
+	clawID := "claw-empty-template-registration"
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	if _, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, template, status, created_at) VALUES(?,?,?,?,?,datetime('now'))`,
+		clawID, "test-tenant-id", "AMB-6", "adversarylabs", "starting",
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	ts := httptest.NewServer(s.Handler())
+	t.Cleanup(ts.Close)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, _, err := websocket.Dial(ctx, "ws"+strings.TrimPrefix(ts.URL, "http")+"/claw/ws", nil)
+	if err != nil {
+		t.Fatalf("dial claw ws: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close(websocket.StatusNormalClosure, "done") })
+	if err := wsjson.Write(ctx, conn, types.WSMessage{
+		Type: "register",
+		Payload: types.RegisterPayload{
+			ClawID:       clawID,
+			Name:         "AMB-6",
+			Template:     "",
+			Token:        "claw-token",
+			GatewayReady: &ready,
+		},
+	}); err != nil {
+		t.Fatalf("register claw: %v", err)
+	}
+	var registered types.WSMessage
+	if err := wsjson.Read(ctx, conn, &registered); err != nil {
+		t.Fatalf("read registration ack: %v", err)
+	}
+
+	var templateName string
+	if err := db.QueryRow(`SELECT template FROM claws WHERE id=?`, clawID).Scan(&templateName); err != nil {
+		t.Fatal(err)
+	}
+	if templateName != "adversarylabs" {
+		t.Fatalf("template = %q, want adversarylabs", templateName)
+	}
+}
+
+func TestClawWorkspaceNameFallsBackToTags(t *testing.T) {
+	tests := []struct {
+		name         string
+		templateName string
+		tagsJSON     string
+		want         string
+	}{
+		{name: "database value", templateName: "stored-workspace", tagsJSON: `["workspace:tagged-workspace"]`, want: "stored-workspace"},
+		{name: "workflow workspace tags", tagsJSON: `["template:legacy-workspace","workspace:adversarylabs","workflow:linear-todo"]`, want: "adversarylabs"},
+		{name: "unpaired workspace tag", tagsJSON: `["workspace:adversarylabs","linear"]`, want: ""},
+		{name: "invalid tags", tagsJSON: `{`, want: ""},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := clawWorkspaceName(test.templateName, test.tagsJSON); got != test.want {
+				t.Fatalf("clawWorkspaceName(%q, %q) = %q, want %q", test.templateName, test.tagsJSON, got, test.want)
+			}
+		})
+	}
+}
+
 func TestSplitStreamingTurnDoesNotBroadcastGhostFinalMessage(t *testing.T) {
 	ready := true
 	clawID := "claw-ghost-final-message"

--- a/pkg/hub/workflow_creator.go
+++ b/pkg/hub/workflow_creator.go
@@ -172,6 +172,9 @@ func (s *Server) createClawFromWorkflowWithOptions(workspace *types.WorkspaceCon
 			resolvedSecrets[envName] = "workflow secret_ref"
 		}
 	}
+	// Workspace identity is hub-managed and must not be overridden by
+	// workspace or workflow environment configuration.
+	env["ELASTICCLAW_TEMPLATE"] = workspace.Name
 	templateFiles["SECRETS.md"] = buildSecretsFile(resolvedSecrets)
 	templateFiles = injectFigmaAPIDocs(templateFiles, env)
 


### PR DESCRIPTION
## Summary

- Preserve a claw's stored workspace identity when its bridge reconnects without a template value.
- Pass `ELASTICCLAW_TEMPLATE` through Daytona, Replicated, Exe.dev, Docker, and Lambda MicroVM bridge launches.
- Recover workspace-scoped GitHub App lookup for already-affected workflow claws from their paired workflow tags.
- Prevent workspace and workflow environment configuration from overriding the hub-managed identity.

## Root cause

The bridge defaulted `ELASTICCLAW_TEMPLATE` to an empty value. Provider launch paths did not consistently set it, and WebSocket registration then overwrote the existing `claws.template` value with that empty string.

GitHub token resolution uses `claws.template` to locate workspace-scoped GitHub Apps, so affected claws received `no github apps configured` even though the app was correctly configured in the workspace settings.

## Verification

- `nix develop -c go test ./...`
- `nix develop -c go test ./pkg/hub` after rebasing onto the latest `main`
- `nix develop -c go build ./...`
