### PR TITLE
Rework analytics run status: PR outcome and human touch

### DIFF
--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -670,39 +670,64 @@ func migrate(db *sql.DB) error {
 }
 
 // backfillTaskRunAnalyticsStatusV2 re-materializes existing summaries once so
-// their status follows the PR-outcome and human-interaction rules.
+// their status follows the PR-outcome and human-interaction rules. Each run is
+// processed in its own transaction and failures are logged and skipped, so a
+// single bad run cannot keep blocking startup; the hub_migrations sentinel is
+// written at the end regardless (re-materialization is idempotent, and skipped
+// runs are corrected the next time an event touches them).
 func backfillTaskRunAnalyticsStatusV2(db *sql.DB) error {
 	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS hub_migrations (name TEXT PRIMARY KEY, applied_at INTEGER NOT NULL)`); err != nil {
 		return fmt.Errorf("create hub migrations: %w", err)
 	}
+	var applied int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM hub_migrations WHERE name='task_run_analytics_status_v2'`).Scan(&applied); err != nil {
+		return fmt.Errorf("check task run analytics status backfill: %w", err)
+	}
+	if applied > 0 {
+		return nil
+	}
+	rows, err := db.Query(`SELECT id FROM task_runs ORDER BY created_at, id`)
+	if err != nil {
+		return fmt.Errorf("list task runs for status backfill: %w", err)
+	}
+	var runIDs []string
+	for rows.Next() {
+		var runID string
+		if err := rows.Scan(&runID); err != nil {
+			rows.Close()
+			return err
+		}
+		runIDs = append(runIDs, runID)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return err
+	}
+	rows.Close()
+	skipped := 0
+	for _, runID := range runIDs {
+		if err := backfillTaskRunStatus(db, runID); err != nil {
+			skipped++
+			log.Printf("[task-run-analytics] status backfill skipped run %s: %v", runID, err)
+		}
+	}
+	if skipped > 0 {
+		log.Printf("[task-run-analytics] status backfill skipped %d of %d run(s)", skipped, len(runIDs))
+	}
+	if _, err := db.Exec(`INSERT INTO hub_migrations(name, applied_at) VALUES('task_run_analytics_status_v2', ?) ON CONFLICT(name) DO NOTHING`, now().UnixMilli()); err != nil {
+		return fmt.Errorf("mark task run analytics status backfill: %w", err)
+	}
+	return nil
+}
+
+// backfillTaskRunStatus re-materializes a single run in its own transaction.
+func backfillTaskRunStatus(db *sql.DB, runID string) error {
 	tx, err := db.Begin()
 	if err != nil {
 		return err
 	}
 	defer tx.Rollback()
-	result, err := tx.Exec(`INSERT INTO hub_migrations(name, applied_at) VALUES('task_run_analytics_status_v2', ?) ON CONFLICT(name) DO NOTHING`, now().UnixMilli())
-	if err != nil {
-		return fmt.Errorf("mark task run analytics status backfill: %w", err)
-	}
-	affected, err := result.RowsAffected()
-	if err != nil || affected == 0 {
-		return err
-	}
-	rows, err := tx.Query(`SELECT id FROM task_runs ORDER BY created_at, id`)
-	if err != nil {
-		return fmt.Errorf("list task runs for status backfill: %w", err)
-	}
-	defer rows.Close()
-	for rows.Next() {
-		var runID string
-		if err := rows.Scan(&runID); err != nil {
-			return err
-		}
-		if err := materializeTaskRunTx(tx, runID); err != nil {
-			return fmt.Errorf("backfill task run %s: %w", runID, err)
-		}
-	}
-	if err := rows.Err(); err != nil {
+	if err := materializeTaskRunTx(tx, runID); err != nil {
 		return err
 	}
 	return tx.Commit()

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -88,6 +88,7 @@ func migrate(db *sql.DB) error {
 	_, _ = db.Exec(`ALTER TABLE task_run_usage ADD COLUMN committed_total_tokens INTEGER NOT NULL DEFAULT 0`)
 	_, _ = db.Exec(`ALTER TABLE task_run_usage ADD COLUMN committed_cost_usd REAL NOT NULL DEFAULT 0`)
 	_, _ = db.Exec(`ALTER TABLE task_run_usage ADD COLUMN usage_day TEXT NOT NULL DEFAULT ''`)
+	_, _ = db.Exec(`ALTER TABLE task_run_prs ADD COLUMN last_agent_head_sha TEXT NOT NULL DEFAULT ''`)
 
 	_, _ = db.Exec(`CREATE TABLE IF NOT EXISTS claw_checkpoints (
 		id                    TEXT PRIMARY KEY,

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -645,6 +645,9 @@ func migrate(db *sql.DB) error {
 	if _, err := db.Exec(`UPDATE task_run_usage SET usage_day = strftime('%Y-%m-%d', updated_at/1000, 'unixepoch') WHERE usage_day = '' AND updated_at > 0`); err != nil {
 		return fmt.Errorf("backfill task_run_usage.usage_day: %w", err)
 	}
+	if err := backfillTaskRunAnalyticsStatusV2(db); err != nil {
+		return err
+	}
 	for _, p := range []struct {
 		model                          string
 		in, out, cacheRead, cacheWrite float64
@@ -663,6 +666,45 @@ func migrate(db *sql.DB) error {
 		}
 	}
 	return nil
+}
+
+// backfillTaskRunAnalyticsStatusV2 re-materializes existing summaries once so
+// their status follows the PR-outcome and human-interaction rules.
+func backfillTaskRunAnalyticsStatusV2(db *sql.DB) error {
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS hub_migrations (name TEXT PRIMARY KEY, applied_at INTEGER NOT NULL)`); err != nil {
+		return fmt.Errorf("create hub migrations: %w", err)
+	}
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	result, err := tx.Exec(`INSERT INTO hub_migrations(name, applied_at) VALUES('task_run_analytics_status_v2', ?) ON CONFLICT(name) DO NOTHING`, now().UnixMilli())
+	if err != nil {
+		return fmt.Errorf("mark task run analytics status backfill: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil || affected == 0 {
+		return err
+	}
+	rows, err := tx.Query(`SELECT id FROM task_runs ORDER BY created_at, id`)
+	if err != nil {
+		return fmt.Errorf("list task runs for status backfill: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var runID string
+		if err := rows.Scan(&runID); err != nil {
+			return err
+		}
+		if err := materializeTaskRunTx(tx, runID); err != nil {
+			return fmt.Errorf("backfill task run %s: %w", runID, err)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 // pruneFactoryAnalytics deletes factory_analytics rows older than 1 year.

--- a/pkg/hub/github_webhook.go
+++ b/pkg/hub/github_webhook.go
@@ -235,10 +235,15 @@ func (s *Server) processGitHubPREvent(payload githubPRPayload) {
 		// Check if a claw already exists for this PR
 		existingClawID := s.findClawForGitHubPR(payload.PullRequest.HTMLURL)
 		if existingClawID != "" {
-			if payload.Action == "synchronize" && s.isHumanGitHubActor(payload.Sender.Login, payload.Sender.Type) {
-				s.recordTaskRunHumanEventForClaw(existingClawID, taskRunWarningHumanManualCodePush,
-					fmt.Sprintf("human_manual_code_push:%s#%d:%s", repoFullName, payload.Number, payload.PullRequest.Head.SHA),
-					payload.Sender.Login, payload.PullRequest.HTMLURL, map[string]any{"repo": repoFullName, "pr_number": payload.Number, "head_sha": payload.PullRequest.Head.SHA})
+			if payload.Action == "synchronize" {
+				// Run the same detection as the poller (SHA comparison against
+				// the agent baseline plus commit attribution) rather than
+				// trusting the webhook sender: "Update branch" base merges and
+				// agent pushes must advance the baseline, not count as human.
+				if _, runID, _, ok, err := s.taskRunContextForClaw(existingClawID); err == nil && ok {
+					s.detectHumanCodePush(existingClawID, runID, repoFullName, payload.Number,
+						payload.PullRequest.HTMLURL, payload.PullRequest.Head.SHA, s.resolveGitHubIssuesTokenForFactory(factory))
+				}
 			}
 			if payload.Action == "closed" {
 				if _, runID, _, ok, err := s.taskRunContextForClaw(existingClawID); err == nil && ok {
@@ -977,6 +982,11 @@ func (s *Server) createClawForGitHubPR(factory *types.FactoryConfig, pr githubPR
 	}
 	if _, runID, _, ok, err := s.taskRunContextForClaw(clawID); err == nil && ok {
 		occurredAt := parseRFC3339Timestamp(pr.PullRequest.CreatedAt)
+		// AgentHeadSHA: the triggering PR's head may be human-authored (a
+		// factory reacting to an external PR), but the run only measures human
+		// touch after the agent takes over — so the head at claw creation is
+		// the detection baseline, exactly what empty-baseline adoption in
+		// detectHumanCodePush would otherwise record on the first pass.
 		if err := s.associateTaskRunPR(TaskRunPR{RunID: runID, Repo: repoFullName, PRNumber: prNumber, URL: prURL, HeadSHA: pr.PullRequest.Head.SHA, HeadBranch: pr.PullRequest.Head.Ref, BaseBranch: pr.PullRequest.Base.Ref, AgentHeadSHA: true, State: taskRunPRStateOpen, OccurredAt: occurredAt}); err != nil {
 			log.Printf("[task-run-analytics] failed to record GitHub PR: %v", err)
 		}

--- a/pkg/hub/github_webhook.go
+++ b/pkg/hub/github_webhook.go
@@ -235,6 +235,11 @@ func (s *Server) processGitHubPREvent(payload githubPRPayload) {
 		// Check if a claw already exists for this PR
 		existingClawID := s.findClawForGitHubPR(payload.PullRequest.HTMLURL)
 		if existingClawID != "" {
+			if payload.Action == "synchronize" && s.isHumanGitHubActor(payload.Sender.Login, payload.Sender.Type) {
+				s.recordTaskRunHumanEventForClaw(existingClawID, taskRunWarningHumanManualCodePush,
+					fmt.Sprintf("human_manual_code_push:%s#%d:%s", repoFullName, payload.Number, payload.PullRequest.Head.SHA),
+					payload.Sender.Login, payload.PullRequest.HTMLURL, map[string]any{"repo": repoFullName, "pr_number": payload.Number, "head_sha": payload.PullRequest.Head.SHA})
+			}
 			if payload.Action == "closed" {
 				if _, runID, _, ok, err := s.taskRunContextForClaw(existingClawID); err == nil && ok {
 					at := parseRFC3339Timestamp(payload.PullRequest.MergedAt)
@@ -972,7 +977,7 @@ func (s *Server) createClawForGitHubPR(factory *types.FactoryConfig, pr githubPR
 	}
 	if _, runID, _, ok, err := s.taskRunContextForClaw(clawID); err == nil && ok {
 		occurredAt := parseRFC3339Timestamp(pr.PullRequest.CreatedAt)
-		if err := s.associateTaskRunPR(TaskRunPR{RunID: runID, Repo: repoFullName, PRNumber: prNumber, URL: prURL, HeadSHA: pr.PullRequest.Head.SHA, HeadBranch: pr.PullRequest.Head.Ref, BaseBranch: pr.PullRequest.Base.Ref, State: taskRunPRStateOpen, OccurredAt: occurredAt}); err != nil {
+		if err := s.associateTaskRunPR(TaskRunPR{RunID: runID, Repo: repoFullName, PRNumber: prNumber, URL: prURL, HeadSHA: pr.PullRequest.Head.SHA, HeadBranch: pr.PullRequest.Head.Ref, BaseBranch: pr.PullRequest.Base.Ref, AgentHeadSHA: true, State: taskRunPRStateOpen, OccurredAt: occurredAt}); err != nil {
 			log.Printf("[task-run-analytics] failed to record GitHub PR: %v", err)
 		}
 	}

--- a/pkg/hub/github_webhook_human_push_test.go
+++ b/pkg/hub/github_webhook_human_push_test.go
@@ -1,0 +1,186 @@
+package hub
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+// mockGitHubCommitServer serves the PR head endpoint plus per-SHA commit
+// bodies, so tests can model authorship and parents (base merges).
+func mockGitHubCommitServer(t *testing.T, headSHA string, commits map[string]map[string]interface{}) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/pulls/21") {
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"state": "open",
+				"head":  map[string]interface{}{"sha": headSHA},
+			})
+			return
+		}
+		for sha, body := range commits {
+			if strings.HasSuffix(r.URL.Path, "/commits/"+sha) {
+				json.NewEncoder(w).Encode(body)
+				return
+			}
+		}
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{"message": "Not Found"})
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func commitBody(login, userType string, parents ...string) map[string]interface{} {
+	body := map[string]interface{}{}
+	if login != "" {
+		body["author"] = map[string]interface{}{"login": login, "type": userType}
+	}
+	parentObjs := make([]interface{}, 0, len(parents))
+	for _, sha := range parents {
+		parentObjs = append(parentObjs, map[string]interface{}{"sha": sha})
+	}
+	body["parents"] = parentObjs
+	return body
+}
+
+// newWebhookHumanPushTestRun builds a server with a pull_request factory, an
+// existing claw tracking PR elastic/claw#21, and a task run whose tracked PR
+// has agentSHA as the agent baseline.
+func newWebhookHumanPushTestRun(t *testing.T, ghBase, clawID, agentSHA string) (*Server, *sql.DB, string, *types.FactoryConfig) {
+	t.Helper()
+	factory := &types.FactoryConfig{
+		Name:        "pr-factory",
+		Integration: "github",
+		Template:    "elasticclaw",
+		Provider:    "noop",
+		Repos:       []string{"elastic/claw"},
+		Trigger:     &types.GitHubTrigger{On: "pull_request"},
+	}
+	cfg := &types.HubConfig{
+		ClawToken: "test-claw-token",
+		Factories: []*types.FactoryConfig{factory},
+		Integrations: &types.IntegrationsConfig{
+			GitHubIssues: []*types.GitHubIssuesIntegrationConfig{{Workspace: "default", Token: "test-github-token"}},
+		},
+		Providers: map[string]types.ProviderConfig{"noop": {Type: "noop"}},
+	}
+	s, db := NewTestServerWithConfig(t, cfg, ghBase, "", "")
+	prURL := "https://github.com/elastic/claw/pull/21"
+	if _, err := db.Exec(`
+		INSERT INTO claws(id, tenant_id, name, template, status, created_at)
+		VALUES(?,?,?,?,?,?)`, clawID, "test-tenant-id", clawID, "elasticclaw", "running", now()); err != nil {
+		t.Fatalf("insert claw: %v", err)
+	}
+	if _, err := db.Exec(`
+		INSERT INTO claw_prs(id, claw_id, repo, pr_number, pr_url, created_at)
+		VALUES(?,?,?,?,?,?)`, clawID+"-pr", clawID, "elastic/claw", 21, prURL, now()); err != nil {
+		t.Fatalf("insert claw PR: %v", err)
+	}
+	runID, _ := startTaskRunForTest(t, s, clawID, clawID)
+	if err := s.associateTaskRunPR(TaskRunPR{
+		TenantID:     "test-tenant-id",
+		RunID:        runID,
+		Repo:         "elastic/claw",
+		PRNumber:     21,
+		URL:          prURL,
+		HeadSHA:      agentSHA,
+		AgentHeadSHA: agentSHA != "",
+		State:        taskRunPRStateOpen,
+		OccurredAt:   now(),
+	}); err != nil {
+		t.Fatalf("associate PR: %v", err)
+	}
+	return s, db, runID, factory
+}
+
+func synchronizePayload(headSHA, senderLogin, senderType string) githubPRPayload {
+	payload := githubPRPayload{Action: "synchronize", Number: 21}
+	payload.Repository.FullName = "elastic/claw"
+	payload.PullRequest.HTMLURL = "https://github.com/elastic/claw/pull/21"
+	payload.PullRequest.Head.SHA = headSHA
+	payload.Sender.Login = senderLogin
+	payload.Sender.Type = senderType
+	return payload
+}
+
+func TestGitHubWebhookSynchronizeRecordsHumanPush(t *testing.T) {
+	srv := mockGitHubCommitServer(t, "human-sha-2", map[string]map[string]interface{}{
+		"human-sha-2": commitBody("alice", "User", "agent-sha-1"),
+	})
+	s, db, runID, _ := newWebhookHumanPushTestRun(t, srv.URL, "claw-wh-human", "agent-sha-1")
+
+	s.processGitHubPREvent(synchronizePayload("human-sha-2", "alice", "User"))
+
+	if got := humanPushEventCount(t, db, runID); got != 1 {
+		t.Fatalf("expected 1 human_manual_code_push event, got %d", got)
+	}
+	if got := lastAgentHeadSHA(t, db, runID); got != "agent-sha-1" {
+		t.Fatalf("expected baseline agent-sha-1, got %q", got)
+	}
+
+	// A replayed webhook for the same head SHA must not duplicate the event.
+	s.processGitHubPREvent(synchronizePayload("human-sha-2", "alice", "User"))
+	if got := humanPushEventCount(t, db, runID); got != 1 {
+		t.Fatalf("expected dedup to keep 1 event, got %d", got)
+	}
+}
+
+func TestGitHubWebhookSynchronizeIgnoresBaseMerge(t *testing.T) {
+	// GitHub's "Update branch" button: the clicking human is the sender and
+	// commit author, but the commit is a merge of base into the agent's head.
+	srv := mockGitHubCommitServer(t, "merge-sha", map[string]map[string]interface{}{
+		"merge-sha": commitBody("alice", "User", "agent-sha-1", "base-sha"),
+	})
+	s, db, runID, _ := newWebhookHumanPushTestRun(t, srv.URL, "claw-wh-merge", "agent-sha-1")
+
+	s.processGitHubPREvent(synchronizePayload("merge-sha", "alice", "User"))
+
+	if got := humanPushEventCount(t, db, runID); got != 0 {
+		t.Fatalf("expected no human_manual_code_push event for base merge, got %d", got)
+	}
+	if got := lastAgentHeadSHA(t, db, runID); got != "merge-sha" {
+		t.Fatalf("expected baseline advanced to merge-sha, got %q", got)
+	}
+}
+
+func TestGitHubWebhookSynchronizeIgnoresAgentPush(t *testing.T) {
+	srv := mockGitHubCommitServer(t, "agent-sha-2", map[string]map[string]interface{}{
+		"agent-sha-2": commitBody("myclaw[bot]", "Bot", "agent-sha-1"),
+	})
+	s, db, runID, _ := newWebhookHumanPushTestRun(t, srv.URL, "claw-wh-agent", "agent-sha-1")
+
+	s.processGitHubPREvent(synchronizePayload("agent-sha-2", "myclaw[bot]", "Bot"))
+
+	if got := humanPushEventCount(t, db, runID); got != 0 {
+		t.Fatalf("expected no human_manual_code_push event for agent push, got %d", got)
+	}
+	if got := lastAgentHeadSHA(t, db, runID); got != "agent-sha-2" {
+		t.Fatalf("expected baseline advanced to agent-sha-2, got %q", got)
+	}
+}
+
+func TestGitHubWebhookAndPollerDedupHumanPush(t *testing.T) {
+	srv := mockGitHubCommitServer(t, "human-sha-2", map[string]map[string]interface{}{
+		"human-sha-2": commitBody("alice", "User", "agent-sha-1"),
+	})
+	s, db, runID, _ := newWebhookHumanPushTestRun(t, srv.URL, "claw-wh-dedup", "agent-sha-1")
+
+	s.processGitHubPREvent(synchronizePayload("human-sha-2", "alice", "User"))
+	// The poller sees the same head SHA afterwards and must not double-count.
+	s.checkHumanCodePush(clawPR{
+		clawID:   "claw-wh-dedup",
+		repo:     "elastic/claw",
+		prNumber: 21,
+		prURL:    "https://github.com/elastic/claw/pull/21",
+	}, "test-token")
+
+	if got := humanPushEventCount(t, db, runID); got != 1 {
+		t.Fatalf("expected 1 human_manual_code_push event across webhook and poller, got %d", got)
+	}
+}

--- a/pkg/hub/github_webhook_human_push_test.go
+++ b/pkg/hub/github_webhook_human_push_test.go
@@ -173,7 +173,7 @@ func TestGitHubWebhookAndPollerDedupHumanPush(t *testing.T) {
 
 	s.processGitHubPREvent(synchronizePayload("human-sha-2", "alice", "User"))
 	// The poller sees the same head SHA afterwards and must not double-count.
-	s.checkHumanCodePush(clawPR{
+	s.checkPRMerged(clawPR{
 		clawID:   "claw-wh-dedup",
 		repo:     "elastic/claw",
 		prNumber: 21,

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -267,10 +267,9 @@ func (s *Server) pollAllPRs() {
 		isPipelineDriven := hasPipelineCtx && parsePipelineForContext(pipelineCtx) != nil
 		log.Printf("[pr-watcher] claw=%s pipeline=%s pipelineDriven=%v", r.pr.clawID[:8], pipelineCtx.Name(), isPipelineDriven)
 
-		// Detect human pushes before the merge check so a human commit present
-		// at merge time is still recorded before the claw is terminated.
-		s.checkHumanCodePush(r.pr, token)
 		// Check if PR is merged/closed for any non-terminal claw status.
+		// checkPRMerged also runs human code push detection off the same PR
+		// fetch, before any termination handling.
 		if s.checkPRMerged(r.pr, token) {
 			terminatedClaws[r.pr.clawID] = true
 			continue // claw is being terminated, skip other checks
@@ -712,27 +711,13 @@ func (s *Server) forwardHumanRequestedChangesReview(pr clawPR, id int64, login, 
 	s.injectHubMessageByID(pr.clawID, formatHumanRequestedChangesMessage(login, pr.prNumber, body, htmlURL))
 }
 
-// checkHumanCodePush detects commits pushed to a tracked PR branch by a human.
-// The poller compares the PR's current head SHA (fetched from GitHub) against
-// the last agent-authored head SHA recorded in task_run_prs; the shared
-// detection logic lives in detectHumanCodePush so the 'synchronize' webhook
-// path applies identical rules.
-func (s *Server) checkHumanCodePush(pr clawPR, token string) {
-	_, runID, _, ok, err := s.taskRunContextForClaw(pr.clawID)
-	if err != nil || !ok {
-		return
-	}
-	s.detectHumanCodePush(pr.clawID, runID, pr.repo, pr.prNumber, pr.prURL, "", token)
-}
-
 // detectHumanCodePush compares a tracked PR's head SHA against the last
 // agent-authored head SHA in task_run_prs. A head commit linked to a human
 // GitHub account is recorded as a human_manual_code_push event; agent (or
 // unattributable) pushes and base merges advance the baseline instead, so the
-// agent's own work never counts as a human interaction. headSHA may be empty
-// (poller path), in which case the PR's current head is fetched from GitHub.
-// The event key format is shared, so the poller and webhook paths dedupe
-// against each other.
+// agent's own work never counts as a human interaction. headSHA may be empty,
+// in which case the PR's current head is fetched from GitHub. The event key
+// format is shared, so the poller and webhook paths dedupe against each other.
 func (s *Server) detectHumanCodePush(clawID, runID, repo string, prNumber int, prURL, headSHA, token string) {
 	var lastAgentSHA string
 	if err := s.db.QueryRow(`SELECT last_agent_head_sha FROM task_run_prs WHERE run_id=? AND repo=? AND pr_number=?`,
@@ -1223,6 +1208,14 @@ func (s *Server) checkPRMerged(pr clawPR, token string) bool {
 		return false
 	}
 	_, _ = s.db.Exec(`UPDATE claw_prs SET permanent_failure_count=0 WHERE id=? AND permanent_failure_count != 0`, pr.id)
+	// Detect human pushes off this same PR fetch, before any merge handling,
+	// so a human commit present at merge time is still recorded before the
+	// claw is terminated.
+	headObj, _ := data["head"].(map[string]interface{})
+	headSHA, _ := headObj["sha"].(string)
+	if _, runID, _, ok, err := s.taskRunContextForClaw(pr.clawID); err == nil && ok {
+		s.detectHumanCodePush(pr.clawID, runID, pr.repo, pr.prNumber, pr.prURL, headSHA, token)
+	}
 	state, _ := data["state"].(string)
 	merged, _ := data["merged"].(bool)
 	mergedAtValue, _ := data["merged_at"].(string)

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -152,12 +152,13 @@ func (s *Server) storePRMention(clawID, repo string, prNumber int, prURL string)
 		// associateTaskRunPR treats it as a write-once fallback rather than an
 		// authoritative provider timestamp.
 		if err := s.associateTaskRunPR(TaskRunPR{
-			RunID:    runID,
-			Repo:     repo,
-			PRNumber: prNumber,
-			URL:      prURL,
-			HeadSHA:  headSHA,
-			State:    taskRunPRStateOpen,
+			RunID:        runID,
+			Repo:         repo,
+			PRNumber:     prNumber,
+			URL:          prURL,
+			HeadSHA:      headSHA,
+			AgentHeadSHA: true,
+			State:        taskRunPRStateOpen,
 		}); err != nil {
 			log.Printf("[task-run-analytics] failed to associate PR %s#%d for claw %s: %v", repo, prNumber, clawID, err)
 		}

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -713,24 +713,34 @@ func (s *Server) forwardHumanRequestedChangesReview(pr clawPR, id int64, login, 
 }
 
 // checkHumanCodePush detects commits pushed to a tracked PR branch by a human.
-// The 'synchronize' webhook path only covers runs whose factory is triggered by
-// pull_request events, so the poller compares the PR's current head SHA against
-// the last agent-authored head SHA recorded in task_run_prs. A head commit
-// linked to a human GitHub account is recorded as a human_manual_code_push
-// event; agent (or unattributable) pushes advance the baseline instead, so the
-// agent's own work never counts as a human interaction.
+// The poller compares the PR's current head SHA (fetched from GitHub) against
+// the last agent-authored head SHA recorded in task_run_prs; the shared
+// detection logic lives in detectHumanCodePush so the 'synchronize' webhook
+// path applies identical rules.
 func (s *Server) checkHumanCodePush(pr clawPR, token string) {
 	_, runID, _, ok, err := s.taskRunContextForClaw(pr.clawID)
 	if err != nil || !ok {
 		return
 	}
+	s.detectHumanCodePush(pr.clawID, runID, pr.repo, pr.prNumber, pr.prURL, "", token)
+}
+
+// detectHumanCodePush compares a tracked PR's head SHA against the last
+// agent-authored head SHA in task_run_prs. A head commit linked to a human
+// GitHub account is recorded as a human_manual_code_push event; agent (or
+// unattributable) pushes and base merges advance the baseline instead, so the
+// agent's own work never counts as a human interaction. headSHA may be empty
+// (poller path), in which case the PR's current head is fetched from GitHub.
+// The event key format is shared, so the poller and webhook paths dedupe
+// against each other.
+func (s *Server) detectHumanCodePush(clawID, runID, repo string, prNumber int, prURL, headSHA, token string) {
 	var lastAgentSHA string
 	if err := s.db.QueryRow(`SELECT last_agent_head_sha FROM task_run_prs WHERE run_id=? AND repo=? AND pr_number=?`,
-		runID, pr.repo, pr.prNumber).Scan(&lastAgentSHA); err != nil {
+		runID, repo, prNumber).Scan(&lastAgentSHA); err != nil {
 		return // PR not tracked for analytics
 	}
 
-	repoToken := s.resolveGitHubTokenForRepo(pr.repo)
+	repoToken := s.resolveGitHubTokenForRepo(repo)
 	if repoToken == "" {
 		repoToken = token
 	}
@@ -738,39 +748,48 @@ func (s *Server) checkHumanCodePush(pr clawPR, token string) {
 	if ghBase == "" {
 		ghBase = "https://api.github.com"
 	}
-	prData, err := githubAPIWithBase(ghBase, fmt.Sprintf("repos/%s/pulls/%d", pr.repo, pr.prNumber), repoToken)
-	if err != nil {
-		return
+	if headSHA == "" {
+		prData, err := githubAPIWithBase(ghBase, fmt.Sprintf("repos/%s/pulls/%d", repo, prNumber), repoToken)
+		if err != nil {
+			return
+		}
+		headObj, _ := prData["head"].(map[string]interface{})
+		headSHA, _ = headObj["sha"].(string)
 	}
-	headObj, _ := prData["head"].(map[string]interface{})
-	headSHA, _ := headObj["sha"].(string)
 	if headSHA == "" || headSHA == lastAgentSHA {
 		return
 	}
 	if lastAgentSHA == "" {
 		// No agent baseline yet (rows that predate this feature): adopt the
 		// current head as the agent's SHA rather than risk a false positive.
-		s.setTaskRunAgentHeadSHA(runID, pr.repo, pr.prNumber, headSHA)
+		s.setTaskRunAgentHeadSHA(runID, repo, prNumber, headSHA)
 		return
 	}
-	eventKey := fmt.Sprintf("human_manual_code_push:%s#%d:%s", pr.repo, pr.prNumber, headSHA)
+	eventKey := fmt.Sprintf("human_manual_code_push:%s#%d:%s", repo, prNumber, headSHA)
 	var seen int
 	_ = s.db.QueryRow(`SELECT 1 FROM task_run_events WHERE run_id=? AND event_key=?`, runID, eventKey).Scan(&seen)
 	if seen == 1 {
 		return // this head SHA was already recorded (poller or webhook)
 	}
-	commitData, err := githubAPIWithBase(ghBase, fmt.Sprintf("repos/%s/commits/%s", pr.repo, headSHA), repoToken)
+	commitData, err := githubAPIWithBase(ghBase, fmt.Sprintf("repos/%s/commits/%s", repo, headSHA), repoToken)
 	if err != nil {
 		return
 	}
+	if parents := githubCommitParents(commitData); len(parents) >= 2 && parents[lastAgentSHA] {
+		// Merge commit whose parent is the agent's head: a base merge (e.g.
+		// GitHub's "Update branch" button) brings no human code even though the
+		// clicking human is the commit author. Advance the baseline instead.
+		s.setTaskRunAgentHeadSHA(runID, repo, prNumber, headSHA)
+		return
+	}
 	if login, userType := githubCommitActor(commitData); login != "" && s.isHumanGitHubActor(login, userType) {
-		s.recordTaskRunHumanEventForClaw(pr.clawID, taskRunWarningHumanManualCodePush, eventKey,
-			login, pr.prURL, map[string]any{"repo": pr.repo, "pr_number": pr.prNumber, "head_sha": headSHA})
+		s.recordTaskRunHumanEventForClaw(clawID, taskRunWarningHumanManualCodePush, eventKey,
+			login, prURL, map[string]any{"repo": repo, "pr_number": prNumber, "head_sha": headSHA})
 		return
 	}
 	// Agent's own push (or a commit with no linked GitHub account): advance the
 	// baseline so the next human push is compared against the agent's latest work.
-	s.setTaskRunAgentHeadSHA(runID, pr.repo, pr.prNumber, headSHA)
+	s.setTaskRunAgentHeadSHA(runID, repo, prNumber, headSHA)
 }
 
 // setTaskRunAgentHeadSHA records the given SHA as the agent's latest head for a
@@ -780,6 +799,19 @@ func (s *Server) setTaskRunAgentHeadSHA(runID, repo string, prNumber int, sha st
 		sha, runID, repo, prNumber); err != nil {
 		log.Printf("[pr-watcher] failed to update agent head SHA for run %s %s#%d: %v", runID, repo, prNumber, err)
 	}
+}
+
+// githubCommitParents returns the parent SHAs of a commit as a set.
+func githubCommitParents(commitData map[string]interface{}) map[string]bool {
+	raw, _ := commitData["parents"].([]interface{})
+	parents := make(map[string]bool, len(raw))
+	for _, p := range raw {
+		parent, _ := p.(map[string]interface{})
+		if sha, _ := parent["sha"].(string); sha != "" {
+			parents[sha] = true
+		}
+	}
+	return parents
 }
 
 // githubCommitActor returns the GitHub account linked to a commit, preferring

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -267,6 +267,9 @@ func (s *Server) pollAllPRs() {
 		isPipelineDriven := hasPipelineCtx && parsePipelineForContext(pipelineCtx) != nil
 		log.Printf("[pr-watcher] claw=%s pipeline=%s pipelineDriven=%v", r.pr.clawID[:8], pipelineCtx.Name(), isPipelineDriven)
 
+		// Detect human pushes before the merge check so a human commit present
+		// at merge time is still recorded before the claw is terminated.
+		s.checkHumanCodePush(r.pr, token)
 		// Check if PR is merged/closed for any non-terminal claw status.
 		if s.checkPRMerged(r.pr, token) {
 			terminatedClaws[r.pr.clawID] = true
@@ -707,6 +710,90 @@ func (s *Server) forwardHumanRequestedChangesReview(pr clawPR, id int64, login, 
 		"review_id": id,
 	})
 	s.injectHubMessageByID(pr.clawID, formatHumanRequestedChangesMessage(login, pr.prNumber, body, htmlURL))
+}
+
+// checkHumanCodePush detects commits pushed to a tracked PR branch by a human.
+// The 'synchronize' webhook path only covers runs whose factory is triggered by
+// pull_request events, so the poller compares the PR's current head SHA against
+// the last agent-authored head SHA recorded in task_run_prs. A head commit
+// linked to a human GitHub account is recorded as a human_manual_code_push
+// event; agent (or unattributable) pushes advance the baseline instead, so the
+// agent's own work never counts as a human interaction.
+func (s *Server) checkHumanCodePush(pr clawPR, token string) {
+	_, runID, _, ok, err := s.taskRunContextForClaw(pr.clawID)
+	if err != nil || !ok {
+		return
+	}
+	var lastAgentSHA string
+	if err := s.db.QueryRow(`SELECT last_agent_head_sha FROM task_run_prs WHERE run_id=? AND repo=? AND pr_number=?`,
+		runID, pr.repo, pr.prNumber).Scan(&lastAgentSHA); err != nil {
+		return // PR not tracked for analytics
+	}
+
+	repoToken := s.resolveGitHubTokenForRepo(pr.repo)
+	if repoToken == "" {
+		repoToken = token
+	}
+	ghBase := s.githubBaseURL
+	if ghBase == "" {
+		ghBase = "https://api.github.com"
+	}
+	prData, err := githubAPIWithBase(ghBase, fmt.Sprintf("repos/%s/pulls/%d", pr.repo, pr.prNumber), repoToken)
+	if err != nil {
+		return
+	}
+	headObj, _ := prData["head"].(map[string]interface{})
+	headSHA, _ := headObj["sha"].(string)
+	if headSHA == "" || headSHA == lastAgentSHA {
+		return
+	}
+	if lastAgentSHA == "" {
+		// No agent baseline yet (rows that predate this feature): adopt the
+		// current head as the agent's SHA rather than risk a false positive.
+		s.setTaskRunAgentHeadSHA(runID, pr.repo, pr.prNumber, headSHA)
+		return
+	}
+	eventKey := fmt.Sprintf("human_manual_code_push:%s#%d:%s", pr.repo, pr.prNumber, headSHA)
+	var seen int
+	_ = s.db.QueryRow(`SELECT 1 FROM task_run_events WHERE run_id=? AND event_key=?`, runID, eventKey).Scan(&seen)
+	if seen == 1 {
+		return // this head SHA was already recorded (poller or webhook)
+	}
+	commitData, err := githubAPIWithBase(ghBase, fmt.Sprintf("repos/%s/commits/%s", pr.repo, headSHA), repoToken)
+	if err != nil {
+		return
+	}
+	if login, userType := githubCommitActor(commitData); login != "" && s.isHumanGitHubActor(login, userType) {
+		s.recordTaskRunHumanEventForClaw(pr.clawID, taskRunWarningHumanManualCodePush, eventKey,
+			login, pr.prURL, map[string]any{"repo": pr.repo, "pr_number": pr.prNumber, "head_sha": headSHA})
+		return
+	}
+	// Agent's own push (or a commit with no linked GitHub account): advance the
+	// baseline so the next human push is compared against the agent's latest work.
+	s.setTaskRunAgentHeadSHA(runID, pr.repo, pr.prNumber, headSHA)
+}
+
+// setTaskRunAgentHeadSHA records the given SHA as the agent's latest head for a
+// tracked PR, resetting the baseline used by human code push detection.
+func (s *Server) setTaskRunAgentHeadSHA(runID, repo string, prNumber int, sha string) {
+	if _, err := s.db.Exec(`UPDATE task_run_prs SET last_agent_head_sha=? WHERE run_id=? AND repo=? AND pr_number=?`,
+		sha, runID, repo, prNumber); err != nil {
+		log.Printf("[pr-watcher] failed to update agent head SHA for run %s %s#%d: %v", runID, repo, prNumber, err)
+	}
+}
+
+// githubCommitActor returns the GitHub account linked to a commit, preferring
+// the author over the committer (a web UI edit has the human as author and
+// GitHub's web-flow as committer). Empty when no account is linked.
+func githubCommitActor(commitData map[string]interface{}) (login, userType string) {
+	for _, key := range []string{"author", "committer"} {
+		user, _ := commitData[key].(map[string]interface{})
+		if l, _ := user["login"].(string); l != "" {
+			t, _ := user["type"].(string)
+			return l, t
+		}
+	}
+	return "", ""
 }
 
 func (s *Server) isHumanGitHubActor(login, userType string) bool {

--- a/pkg/hub/pr_watcher_human_push_test.go
+++ b/pkg/hub/pr_watcher_human_push_test.go
@@ -1,0 +1,161 @@
+package hub
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+// mockGitHubHeadServer serves the two endpoints human code push detection
+// hits: the PR (for its head SHA) and the head commit (for authorship).
+// commitActor may be nil to simulate a commit with no linked GitHub account.
+func mockGitHubHeadServer(t *testing.T, headSHA string, commitActor map[string]string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/pulls/21"):
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"state": "open",
+				"head":  map[string]interface{}{"sha": headSHA},
+			})
+		case strings.HasSuffix(r.URL.Path, "/commits/"+headSHA):
+			body := map[string]interface{}{}
+			if commitActor != nil {
+				body["author"] = map[string]interface{}{
+					"login": commitActor["login"],
+					"type":  commitActor["type"],
+				}
+			}
+			json.NewEncoder(w).Encode(body)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			json.NewEncoder(w).Encode(map[string]string{"message": "Not Found"})
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// newHumanPushTestRun creates a server pointed at the mock GitHub API with a
+// claw, a task run, and a tracked PR whose agent baseline is agentSHA.
+func newHumanPushTestRun(t *testing.T, ghBase, clawID, agentSHA string) (*Server, *sql.DB, string, clawPR) {
+	t.Helper()
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, ghBase, "", "")
+	if _, err := db.Exec(`
+		INSERT INTO claws(id, tenant_id, name, template, status, created_at)
+		VALUES(?,?,?,?,?,?)`, clawID, "test-tenant-id", clawID, "elasticclaw", "running", now()); err != nil {
+		t.Fatalf("insert claw: %v", err)
+	}
+	runID, _ := startTaskRunForTest(t, s, clawID, clawID)
+	prURL := "https://github.com/elastic/claw/pull/21"
+	if err := s.associateTaskRunPR(TaskRunPR{
+		TenantID:     "test-tenant-id",
+		RunID:        runID,
+		Repo:         "elastic/claw",
+		PRNumber:     21,
+		URL:          prURL,
+		HeadSHA:      agentSHA,
+		AgentHeadSHA: agentSHA != "",
+		State:        taskRunPRStateOpen,
+		OccurredAt:   now(),
+	}); err != nil {
+		t.Fatalf("associate PR: %v", err)
+	}
+	return s, db, runID, clawPR{clawID: clawID, repo: "elastic/claw", prNumber: 21, prURL: prURL}
+}
+
+func humanPushEventCount(t *testing.T, db *sql.DB, runID string) int {
+	t.Helper()
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM task_run_events WHERE run_id=? AND event_type='human_manual_code_push'`, runID).Scan(&count); err != nil {
+		t.Fatalf("count human push events: %v", err)
+	}
+	return count
+}
+
+func lastAgentHeadSHA(t *testing.T, db *sql.DB, runID string) string {
+	t.Helper()
+	var sha string
+	if err := db.QueryRow(`SELECT last_agent_head_sha FROM task_run_prs WHERE run_id=?`, runID).Scan(&sha); err != nil {
+		t.Fatalf("read last_agent_head_sha: %v", err)
+	}
+	return sha
+}
+
+func TestCheckHumanCodePushRecordsHumanCommit(t *testing.T) {
+	srv := mockGitHubHeadServer(t, "human-sha-2", map[string]string{"login": "alice", "type": "User"})
+	s, db, runID, pr := newHumanPushTestRun(t, srv.URL, "claw-push-human", "agent-sha-1")
+
+	s.checkHumanCodePush(pr, "test-token")
+
+	if got := humanPushEventCount(t, db, runID); got != 1 {
+		t.Fatalf("expected 1 human_manual_code_push event, got %d", got)
+	}
+	// The human push must not advance the agent baseline.
+	if got := lastAgentHeadSHA(t, db, runID); got != "agent-sha-1" {
+		t.Fatalf("expected baseline agent-sha-1, got %q", got)
+	}
+	var humanCount int
+	var warnings string
+	if err := db.QueryRow(`SELECT human_interaction_count, warning_types FROM task_run_summaries WHERE run_id=?`, runID).Scan(&humanCount, &warnings); err != nil {
+		t.Fatalf("read summary: %v", err)
+	}
+	if humanCount != 1 || !strings.Contains(warnings, "human_manual_code_push") {
+		t.Fatalf("expected human interaction with human_manual_code_push warning, got count=%d warnings=%s", humanCount, warnings)
+	}
+
+	// A second poll of the same head SHA must not duplicate the event.
+	s.checkHumanCodePush(pr, "test-token")
+	if got := humanPushEventCount(t, db, runID); got != 1 {
+		t.Fatalf("expected dedup to keep 1 event, got %d", got)
+	}
+}
+
+func TestCheckHumanCodePushIgnoresAgentPushAndAdvancesBaseline(t *testing.T) {
+	srv := mockGitHubHeadServer(t, "agent-sha-2", map[string]string{"login": "myclaw[bot]", "type": "Bot"})
+	s, db, runID, pr := newHumanPushTestRun(t, srv.URL, "claw-push-agent", "agent-sha-1")
+
+	s.checkHumanCodePush(pr, "test-token")
+
+	if got := humanPushEventCount(t, db, runID); got != 0 {
+		t.Fatalf("expected no human_manual_code_push event, got %d", got)
+	}
+	if got := lastAgentHeadSHA(t, db, runID); got != "agent-sha-2" {
+		t.Fatalf("expected baseline advanced to agent-sha-2, got %q", got)
+	}
+}
+
+func TestCheckHumanCodePushAdoptsHeadWhenBaselineMissing(t *testing.T) {
+	srv := mockGitHubHeadServer(t, "some-sha", map[string]string{"login": "alice", "type": "User"})
+	s, db, runID, pr := newHumanPushTestRun(t, srv.URL, "claw-push-nobaseline", "")
+
+	s.checkHumanCodePush(pr, "test-token")
+
+	// Without a baseline the head is adopted as the agent's SHA — no event,
+	// even though the head commit is human-authored (pre-feature rows).
+	if got := humanPushEventCount(t, db, runID); got != 0 {
+		t.Fatalf("expected no human_manual_code_push event, got %d", got)
+	}
+	if got := lastAgentHeadSHA(t, db, runID); got != "some-sha" {
+		t.Fatalf("expected baseline adopted as some-sha, got %q", got)
+	}
+}
+
+func TestCheckHumanCodePushTreatsUnlinkedCommitAsAgent(t *testing.T) {
+	srv := mockGitHubHeadServer(t, "unlinked-sha", nil)
+	s, db, runID, pr := newHumanPushTestRun(t, srv.URL, "claw-push-unlinked", "agent-sha-1")
+
+	s.checkHumanCodePush(pr, "test-token")
+
+	if got := humanPushEventCount(t, db, runID); got != 0 {
+		t.Fatalf("expected no human_manual_code_push event, got %d", got)
+	}
+	if got := lastAgentHeadSHA(t, db, runID); got != "unlinked-sha" {
+		t.Fatalf("expected baseline advanced to unlinked-sha, got %q", got)
+	}
+}

--- a/pkg/hub/pr_watcher_human_push_test.go
+++ b/pkg/hub/pr_watcher_human_push_test.go
@@ -91,7 +91,7 @@ func TestCheckHumanCodePushRecordsHumanCommit(t *testing.T) {
 	srv := mockGitHubHeadServer(t, "human-sha-2", map[string]string{"login": "alice", "type": "User"})
 	s, db, runID, pr := newHumanPushTestRun(t, srv.URL, "claw-push-human", "agent-sha-1")
 
-	s.checkHumanCodePush(pr, "test-token")
+	s.checkPRMerged(pr, "test-token")
 
 	if got := humanPushEventCount(t, db, runID); got != 1 {
 		t.Fatalf("expected 1 human_manual_code_push event, got %d", got)
@@ -110,7 +110,7 @@ func TestCheckHumanCodePushRecordsHumanCommit(t *testing.T) {
 	}
 
 	// A second poll of the same head SHA must not duplicate the event.
-	s.checkHumanCodePush(pr, "test-token")
+	s.checkPRMerged(pr, "test-token")
 	if got := humanPushEventCount(t, db, runID); got != 1 {
 		t.Fatalf("expected dedup to keep 1 event, got %d", got)
 	}
@@ -120,7 +120,7 @@ func TestCheckHumanCodePushIgnoresAgentPushAndAdvancesBaseline(t *testing.T) {
 	srv := mockGitHubHeadServer(t, "agent-sha-2", map[string]string{"login": "myclaw[bot]", "type": "Bot"})
 	s, db, runID, pr := newHumanPushTestRun(t, srv.URL, "claw-push-agent", "agent-sha-1")
 
-	s.checkHumanCodePush(pr, "test-token")
+	s.checkPRMerged(pr, "test-token")
 
 	if got := humanPushEventCount(t, db, runID); got != 0 {
 		t.Fatalf("expected no human_manual_code_push event, got %d", got)
@@ -134,7 +134,7 @@ func TestCheckHumanCodePushAdoptsHeadWhenBaselineMissing(t *testing.T) {
 	srv := mockGitHubHeadServer(t, "some-sha", map[string]string{"login": "alice", "type": "User"})
 	s, db, runID, pr := newHumanPushTestRun(t, srv.URL, "claw-push-nobaseline", "")
 
-	s.checkHumanCodePush(pr, "test-token")
+	s.checkPRMerged(pr, "test-token")
 
 	// Without a baseline the head is adopted as the agent's SHA — no event,
 	// even though the head commit is human-authored (pre-feature rows).
@@ -150,7 +150,7 @@ func TestCheckHumanCodePushTreatsUnlinkedCommitAsAgent(t *testing.T) {
 	srv := mockGitHubHeadServer(t, "unlinked-sha", nil)
 	s, db, runID, pr := newHumanPushTestRun(t, srv.URL, "claw-push-unlinked", "agent-sha-1")
 
-	s.checkHumanCodePush(pr, "test-token")
+	s.checkPRMerged(pr, "test-token")
 
 	if got := humanPushEventCount(t, db, runID); got != 0 {
 		t.Fatalf("expected no human_manual_code_push event, got %d", got)

--- a/pkg/hub/task_run_analytics.go
+++ b/pkg/hub/task_run_analytics.go
@@ -909,9 +909,12 @@ func materializeTaskRunTx(tx *sql.Tx, runID string) error {
 	definitiveFailure, definitiveFailureAt := definitiveFailure(events)
 	completedAt := taskCompletedAt(events)
 	prePRFailure, prePRFailureAt := prePRFailure(events)
-	status, phase, failureType, finishedAt := computeTaskRunStatus(
-		meta, counts, humanInteractions, warnings, phaseTimes, definitiveFailure, definitiveFailureAt, completedAt, prePRFailure, prePRFailureAt,
+	status, phase, failureType, extraWarning, finishedAt := computeTaskRunStatus(
+		meta, counts, humanInteractions, phaseTimes, definitiveFailure, definitiveFailureAt, completedAt, prePRFailure, prePRFailureAt,
 	)
+	if extraWarning != "" {
+		warnings[extraWarning] = true
+	}
 	if finishedAt == 0 && phase == taskRunPhaseTerminal {
 		finishedAt = epochMillis(now())
 	}
@@ -1039,18 +1042,17 @@ func computeTaskRunStatus(
 	meta taskRunMeta,
 	counts prCountSummary,
 	humanInteractions int,
-	warnings map[string]bool,
 	phaseTimes taskRunPhaseTimeSummary,
 	definitiveFailure string,
 	definitiveFailureAt int64,
 	taskCompletedAt int64,
 	prePRFailure string,
 	prePRFailureAt int64,
-) (status, phase, failureType string, finishedAt int64) {
+) (status, phase, failureType, extraWarning string, finishedAt int64) {
 	status, phase = taskRunStatusRunning, initialTaskRunPhase(meta, phaseTimes)
 	if meta.analyticsEnabled == 0 {
 		// Excluded runs are not part of PR-scoped analytics; failed/unknown is a sentinel summary state.
-		return taskRunStatusFailed, taskRunPhaseTerminal, taskRunFailureUnknown, meta.updatedAt
+		return taskRunStatusFailed, taskRunPhaseTerminal, taskRunFailureUnknown, "", meta.updatedAt
 	} else if meta.requiresPR == 0 && taskCompletedAt != 0 {
 		if humanInteractions > 0 {
 			status = taskRunStatusWarningSuccess
@@ -1072,14 +1074,14 @@ func computeTaskRunStatus(
 	} else if counts.open > 0 {
 		status, phase = taskRunStatusRunning, taskRunPhaseWaitingForMerge
 	} else if counts.total > 0 {
-		warnings[taskRunWarningPRClosedUnmerged] = true
+		extraWarning = taskRunWarningPRClosedUnmerged
 		status, phase, finishedAt = taskRunStatusWarningSuccess, taskRunPhaseTerminal, counts.latestTerminalAt
 	} else if definitiveFailure != "" {
 		status, phase, failureType, finishedAt = taskRunStatusFailed, taskRunPhaseTerminal, definitiveFailure, definitiveFailureAt
 	} else if prePRFailure != "" {
 		status, phase, failureType, finishedAt = taskRunStatusFailed, taskRunPhaseTerminal, prePRFailure, prePRFailureAt
 	}
-	return status, phase, failureType, finishedAt
+	return status, phase, failureType, extraWarning, finishedAt
 }
 
 func initialTaskRunPhase(meta taskRunMeta, phaseTimes taskRunPhaseTimeSummary) string {

--- a/pkg/hub/task_run_analytics.go
+++ b/pkg/hub/task_run_analytics.go
@@ -45,6 +45,7 @@ const (
 	taskRunWarningHumanSettingsChange   = "human_settings_or_status_change"
 	taskRunWarningUnknownHuman          = "unknown_human_interaction"
 	taskRunWarningPRReplaced            = "pr_replaced"
+	taskRunWarningPRClosedUnmerged      = "pr_closed_unmerged"
 
 	taskRunFailureDoneWithoutPR      = "done_without_pr"
 	taskRunFailureNoPR               = "no_pr"
@@ -174,7 +175,10 @@ type TaskRunPR struct {
 	State         string
 	Merged        bool
 	MergedByLogin string
-	OccurredAt    time.Time
+	// AgentHeadSHA marks HeadSHA as written by the agent, rather than observed
+	// from a GitHub update made by somebody else.
+	AgentHeadSHA bool
+	OccurredAt   time.Time
 }
 
 func epochMillis(t time.Time) int64 {
@@ -409,14 +413,19 @@ func (s *Server) associateTaskRunPR(input TaskRunPR) error {
 		mergedAt = at
 		closedAt = at
 	}
+	agentHeadSHA := ""
+	if input.AgentHeadSHA {
+		agentHeadSHA = input.HeadSHA
+	}
 	if _, err := tx.Exec(`
 		INSERT INTO task_run_prs(
-			id, tenant_id, run_id, repo, pr_number, pr_url, head_sha, head_branch, base_branch,
+			id, tenant_id, run_id, repo, pr_number, pr_url, head_sha, head_branch, last_agent_head_sha, base_branch,
 			state, merged, opened_at, closed_at, merged_at, merged_by_login, created_at, updated_at
-		) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+		) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
 		ON CONFLICT(tenant_id, run_id, repo, pr_number) DO UPDATE SET
 			pr_url=excluded.pr_url,
 			head_sha=excluded.head_sha,
+			last_agent_head_sha=CASE WHEN excluded.last_agent_head_sha != '' THEN excluded.last_agent_head_sha ELSE task_run_prs.last_agent_head_sha END,
 			head_branch=excluded.head_branch,
 			base_branch=excluded.base_branch,
 			state=CASE WHEN task_run_prs.merged = 1 OR task_run_prs.state = 'closed' THEN task_run_prs.state ELSE excluded.state END,
@@ -427,7 +436,7 @@ func (s *Server) associateTaskRunPR(input TaskRunPR) error {
 			merged_by_login=CASE WHEN excluded.merged_by_login != '' THEN excluded.merged_by_login ELSE task_run_prs.merged_by_login END,
 			updated_at=excluded.updated_at`,
 		uuid.New().String(), input.TenantID, input.RunID, input.Repo, input.PRNumber, input.URL,
-		input.HeadSHA, input.HeadBranch, input.BaseBranch, input.State, boolInt(input.Merged),
+		input.HeadSHA, input.HeadBranch, agentHeadSHA, input.BaseBranch, input.State, boolInt(input.Merged),
 		openedAt, closedAt, mergedAt, input.MergedByLogin, at, at,
 		boolInt(authoritativeOpen),
 	); err != nil {
@@ -877,7 +886,7 @@ func materializeTaskRunTx(tx *sql.Tx, runID string) error {
 		if warning := normalizeTaskRunWarningType(event.warningType); warning != "" {
 			warnings[warning] = true
 		}
-		if warning := warningTypeForEvent(event); warning != "" {
+		if warning := warningTypeForEvent(event); warning != "" && isHumanTaskRunEvent(event) {
 			humanInteractions++
 			warnings[warning] = true
 		}
@@ -901,7 +910,7 @@ func materializeTaskRunTx(tx *sql.Tx, runID string) error {
 	completedAt := taskCompletedAt(events)
 	prePRFailure, prePRFailureAt := prePRFailure(events)
 	status, phase, failureType, finishedAt := computeTaskRunStatus(
-		meta, counts, warnings, phaseTimes, definitiveFailure, definitiveFailureAt, completedAt, prePRFailure, prePRFailureAt,
+		meta, counts, humanInteractions, warnings, phaseTimes, definitiveFailure, definitiveFailureAt, completedAt, prePRFailure, prePRFailureAt,
 	)
 	if finishedAt == 0 && phase == taskRunPhaseTerminal {
 		finishedAt = epochMillis(now())
@@ -1013,9 +1022,23 @@ func materializeTaskRunTx(tx *sql.Tx, runID string) error {
 	return err
 }
 
+func isHumanTaskRunEvent(event taskRunEventProjection) bool {
+	if event.actorType == taskRunActorHuman {
+		return true
+	}
+	switch event.eventType {
+	case taskRunEventHumanPRComment, taskRunEventHumanReviewComment, taskRunEventHumanRequestedChanges,
+		taskRunWarningHumanManualCodePush, taskRunWarningHumanTrackerUpdate, taskRunEventHumanDashboardMessage,
+		taskRunEventManualStopBeforeDelivery, taskRunEventManualResume, taskRunEventSettingsChanged, taskRunWarningUnknownHuman:
+		return true
+	}
+	return false
+}
+
 func computeTaskRunStatus(
 	meta taskRunMeta,
 	counts prCountSummary,
+	humanInteractions int,
 	warnings map[string]bool,
 	phaseTimes taskRunPhaseTimeSummary,
 	definitiveFailure string,
@@ -1028,10 +1051,8 @@ func computeTaskRunStatus(
 	if meta.analyticsEnabled == 0 {
 		// Excluded runs are not part of PR-scoped analytics; failed/unknown is a sentinel summary state.
 		return taskRunStatusFailed, taskRunPhaseTerminal, taskRunFailureUnknown, meta.updatedAt
-	} else if definitiveFailure != "" {
-		status, phase, failureType, finishedAt = taskRunStatusFailed, taskRunPhaseTerminal, definitiveFailure, definitiveFailureAt
 	} else if meta.requiresPR == 0 && taskCompletedAt != 0 {
-		if len(warnings) > 0 {
+		if humanInteractions > 0 {
 			status = taskRunStatusWarningSuccess
 		} else {
 			status = taskRunStatusCleanSuccess
@@ -1039,7 +1060,7 @@ func computeTaskRunStatus(
 		phase = taskRunPhaseTerminal
 		finishedAt = taskCompletedAt
 	} else if counts.merged > 0 && counts.open == 0 {
-		if len(warnings) > 0 {
+		if humanInteractions > 0 {
 			status = taskRunStatusWarningSuccess
 		} else {
 			status = taskRunStatusCleanSuccess
@@ -1048,15 +1069,15 @@ func computeTaskRunStatus(
 		finishedAt = counts.latestTerminalAt
 	} else if counts.merged > 0 && counts.open > 0 {
 		status, phase = taskRunStatusRunning, taskRunPhaseWaitingForMerge
+	} else if counts.open > 0 {
+		status, phase = taskRunStatusRunning, taskRunPhaseWaitingForMerge
+	} else if counts.total > 0 {
+		warnings[taskRunWarningPRClosedUnmerged] = true
+		status, phase, finishedAt = taskRunStatusWarningSuccess, taskRunPhaseTerminal, counts.latestTerminalAt
+	} else if definitiveFailure != "" {
+		status, phase, failureType, finishedAt = taskRunStatusFailed, taskRunPhaseTerminal, definitiveFailure, definitiveFailureAt
 	} else if prePRFailure != "" {
 		status, phase, failureType, finishedAt = taskRunStatusFailed, taskRunPhaseTerminal, prePRFailure, prePRFailureAt
-	} else if counts.total > 0 {
-		status = taskRunStatusRunning
-		if counts.open > 0 {
-			phase = taskRunPhaseWaitingForMerge
-		} else {
-			status, phase, failureType, finishedAt = taskRunStatusFailed, taskRunPhaseTerminal, taskRunFailurePRClosedUnmerged, counts.latestTerminalAt
-		}
 	}
 	return status, phase, failureType, finishedAt
 }

--- a/pkg/hub/task_run_analytics.go
+++ b/pkg/hub/task_run_analytics.go
@@ -1558,7 +1558,8 @@ func normalizeTaskRunWarningType(value string) string {
 		taskRunWarningHumanManualStopResume,
 		taskRunWarningHumanSettingsChange,
 		taskRunWarningUnknownHuman,
-		taskRunWarningPRReplaced:
+		taskRunWarningPRReplaced,
+		taskRunWarningPRClosedUnmerged:
 		return value
 	default:
 		return ""

--- a/pkg/hub/task_run_analytics_test.go
+++ b/pkg/hub/task_run_analytics_test.go
@@ -213,6 +213,75 @@ func TestTaskRunMaterializationClassifiesWarningSuccess(t *testing.T) {
 	assertTaskRunSummary(t, db, runID, taskRunStatusWarningSuccess, taskRunPhaseTerminal, "", `["human_pr_comment"]`, 1, 1, 0, 1, 0)
 }
 
+func TestTaskRunMaterializationKeepsNonHumanWarningsClean(t *testing.T) {
+	s, db := newTaskRunAnalyticsTestServer(t, "claw-non-human-warning")
+	runID, attemptID := startTaskRunForTest(t, s, "claw-non-human-warning", "non-human-warning")
+	associatePRForTest(t, s, runID, "elastic/claw", 13, taskRunPRStateOpen)
+	recordTaskRunEventForTest(t, s, TaskRunEvent{TenantID: "test-tenant-id", RunID: runID, AttemptID: attemptID, EventKey: "non-human-warning:replaced", EventType: "pr_replaced", ActorType: taskRunActorSystem, Source: taskRunSourceHub, WarningType: taskRunWarningPRReplaced})
+	recordTaskRunEventForTest(t, s, TaskRunEvent{TenantID: "test-tenant-id", RunID: runID, AttemptID: attemptID, EventKey: "non-human-warning:merged", EventType: taskRunEventPRMerged, ActorType: taskRunActorSystem, Source: taskRunSourceGitHub, Detail: map[string]any{"repo": "elastic/claw", "prNumber": 13}})
+	assertTaskRunSummary(t, db, runID, taskRunStatusCleanSuccess, taskRunPhaseTerminal, "", `["pr_replaced"]`, 0, 1, 0, 1, 0)
+}
+
+func TestTaskRunHumanManualCodePushCountsAsHumanInteraction(t *testing.T) {
+	s, db := newTaskRunAnalyticsTestServer(t, "claw-human-push")
+	runID, attemptID := startTaskRunForTest(t, s, "claw-human-push", "human-push")
+	associatePRForTest(t, s, runID, "elastic/claw", 15, taskRunPRStateOpen)
+	recordTaskRunEventForTest(t, s, TaskRunEvent{TenantID: "test-tenant-id", RunID: runID, AttemptID: attemptID, EventKey: "human-push:sha", EventType: taskRunWarningHumanManualCodePush, ActorType: taskRunActorHuman, Source: taskRunSourceGitHub, WarningType: taskRunWarningHumanManualCodePush})
+	recordTaskRunEventForTest(t, s, TaskRunEvent{TenantID: "test-tenant-id", RunID: runID, AttemptID: attemptID, EventKey: "human-push:merged", EventType: taskRunEventPRMerged, ActorType: taskRunActorSystem, Source: taskRunSourceGitHub, Detail: map[string]any{"repo": "elastic/claw", "prNumber": 15}})
+	assertTaskRunSummary(t, db, runID, taskRunStatusWarningSuccess, taskRunPhaseTerminal, "", `["human_manual_code_push"]`, 1, 1, 0, 1, 0)
+}
+
+func TestTaskRunMaterializationNonPRCompletionUsesHumanInteractions(t *testing.T) {
+	for _, tc := range []struct {
+		name, eventType, warning, want string
+	}{
+		{"clean", taskRunEventTaskCompleted, "", taskRunStatusCleanSuccess},
+		{"human", taskRunEventHumanPRComment, taskRunWarningHumanPRComment, taskRunStatusWarningSuccess},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s, db := newTaskRunAnalyticsTestServer(t, "claw-non-pr-"+tc.name)
+			runID, attemptID := startTaskRunForTest(t, s, "claw-non-pr-"+tc.name, "non-pr-"+tc.name)
+			if _, err := db.Exec(`UPDATE task_runs SET requires_pr=0 WHERE id=?`, runID); err != nil {
+				t.Fatal(err)
+			}
+			recordTaskRunEventForTest(t, s, TaskRunEvent{TenantID: "test-tenant-id", RunID: runID, AttemptID: attemptID, EventKey: "non-pr:" + tc.name + ":completed", EventType: taskRunEventTaskCompleted, ActorType: taskRunActorAgent, Source: taskRunSourceHub})
+			if tc.warning != "" {
+				recordTaskRunEventForTest(t, s, TaskRunEvent{TenantID: "test-tenant-id", RunID: runID, AttemptID: attemptID, EventKey: "non-pr:" + tc.name + ":human", EventType: tc.eventType, ActorType: taskRunActorHuman, Source: taskRunSourceGitHub, WarningType: tc.warning})
+			}
+			assertTaskRunSummary(t, db, runID, tc.want, taskRunPhaseTerminal, "", func() string {
+				if tc.warning != "" {
+					return `["human_pr_comment"]`
+				}
+				return "[]"
+			}(), boolInt(tc.warning != ""), 0, 0, 0, 0)
+		})
+	}
+}
+
+func TestTaskRunAnalyticsStatusBackfillReclassifiesClosedUnmerged(t *testing.T) {
+	s, db := newTaskRunAnalyticsTestServer(t, "claw-status-backfill")
+	runID, _ := startTaskRunForTest(t, s, "claw-status-backfill", "status-backfill")
+	associatePRForTest(t, s, runID, "elastic/claw", 14, taskRunPRStateClosed)
+	if _, err := db.Exec(`UPDATE task_run_summaries SET status='failed', failure_type='pr_closed_unmerged', warning_types='[]' WHERE run_id=?`, runID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`DELETE FROM hub_migrations WHERE name='task_run_analytics_status_v2'`); err != nil {
+		t.Fatal(err)
+	}
+	if err := backfillTaskRunAnalyticsStatusV2(db); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	assertTaskRunSummary(t, db, runID, taskRunStatusWarningSuccess, taskRunPhaseTerminal, "", `["pr_closed_unmerged"]`, 0, 1, 0, 0, 1)
+}
+
+func TestTaskRunClosedUnmergedTakesPrecedenceOverTimeout(t *testing.T) {
+	s, db := newTaskRunAnalyticsTestServer(t, "claw-closed-timeout")
+	runID, attemptID := startTaskRunForTest(t, s, "claw-closed-timeout", "closed-timeout")
+	associatePRForTest(t, s, runID, "elastic/claw", 16, taskRunPRStateClosed)
+	recordTaskRunEventForTest(t, s, TaskRunEvent{TenantID: "test-tenant-id", RunID: runID, AttemptID: attemptID, EventKey: "closed-timeout:timeout", EventType: "timeout", ActorType: taskRunActorSystem, Source: taskRunSourceHub, FailureType: taskRunFailureTimeout})
+	assertTaskRunSummary(t, db, runID, taskRunStatusWarningSuccess, taskRunPhaseTerminal, "", `["pr_closed_unmerged"]`, 0, 1, 0, 0, 1)
+}
+
 func TestTaskRunClassificationFailsDoneWithoutPR(t *testing.T) {
 	s, db := newTaskRunAnalyticsTestServer(t, "claw-failed")
 	runID, attemptID := startTaskRunForTest(t, s, "claw-failed", "failed")
@@ -261,7 +330,7 @@ func TestTaskRunMaterializationClassifiesReplacedPRAsWarningSuccess(t *testing.T
 		Detail:    map[string]any{"repo": "elastic/claw", "prNumber": 22},
 	})
 
-	assertTaskRunSummary(t, db, runID, taskRunStatusWarningSuccess, taskRunPhaseTerminal, "", `["pr_replaced"]`, 0, 2, 0, 1, 1)
+	assertTaskRunSummary(t, db, runID, taskRunStatusCleanSuccess, taskRunPhaseTerminal, "", `["pr_replaced"]`, 0, 2, 0, 1, 1)
 }
 
 func TestTaskRunIdempotencyDoesNotDuplicateEventRows(t *testing.T) {
@@ -375,7 +444,7 @@ func TestTaskRunMaterializationTerminalStopDoesNotRegressToRunning(t *testing.T)
 	assertTaskRunSummary(t, db, runID, taskRunStatusFailed, taskRunPhaseTerminal, taskRunFailureManualStopDelivery, `["unknown_human_interaction"]`, 1, 0, 0, 0, 0)
 
 	associatePRForTest(t, s, runID, "elastic/claw", 51, taskRunPRStateOpen)
-	assertTaskRunSummary(t, db, runID, taskRunStatusFailed, taskRunPhaseTerminal, taskRunFailureManualStopDelivery, `["unknown_human_interaction"]`, 1, 1, 1, 0, 0)
+	assertTaskRunSummary(t, db, runID, taskRunStatusRunning, taskRunPhaseWaitingForMerge, "", `["unknown_human_interaction"]`, 1, 1, 1, 0, 0)
 }
 
 func TestTaskRunMaterializationIgnoresUnknownWarningTypes(t *testing.T) {
@@ -474,7 +543,7 @@ func TestTaskRunPRLifecycleDoesNotRegressClosedPRToOpen(t *testing.T) {
 	})
 	associatePRForTest(t, s, runID, "elastic/claw", 62, taskRunPRStateOpen)
 
-	assertTaskRunSummary(t, db, runID, taskRunStatusFailed, taskRunPhaseTerminal, taskRunFailurePRClosedUnmerged, "[]", 0, 1, 0, 0, 1)
+	assertTaskRunSummary(t, db, runID, taskRunStatusWarningSuccess, taskRunPhaseTerminal, "", `["pr_closed_unmerged"]`, 0, 1, 0, 0, 1)
 }
 
 func TestTaskRunDetailSanitizationRedactsNestedText(t *testing.T) {
@@ -1030,7 +1099,7 @@ func TestTaskRunPRMergeAndCloseInstrumentationMaterializesStatus(t *testing.T) {
 
 	assertTaskRunEventExists(t, db2, closedRunID, taskRunEventPRClosedUnmerged, taskRunInteractionTerminal)
 	assertTaskRunPR(t, db2, closedRunID, "elastic/claw", 73, taskRunPRStateClosed, false)
-	assertTaskRunSummary(t, db2, closedRunID, taskRunStatusFailed, taskRunPhaseTerminal, taskRunFailurePRClosedUnmerged, "[]", 0, 1, 0, 0, 1)
+	assertTaskRunSummary(t, db2, closedRunID, taskRunStatusWarningSuccess, taskRunPhaseTerminal, "", `["pr_closed_unmerged"]`, 0, 1, 0, 0, 1)
 }
 
 func TestTaskRunPRClosedFailureSurvivesOperationalStop(t *testing.T) {
@@ -1041,7 +1110,7 @@ func TestTaskRunPRClosedFailureSurvivesOperationalStop(t *testing.T) {
 	s.trackPRClosed("factory-pr-closed-stop", "ISSUE-pr-closed-stop", "claw-pr-closed-stop", "elastic/claw", 74)
 	s.stopAgentWithReason("claw-pr-closed-stop", "PR closed without merge", false)
 
-	assertTaskRunSummary(t, db, runID, taskRunStatusFailed, taskRunPhaseTerminal, taskRunFailurePRClosedUnmerged, "[]", 0, 1, 0, 0, 1)
+	assertTaskRunSummary(t, db, runID, taskRunStatusWarningSuccess, taskRunPhaseTerminal, "", `["pr_closed_unmerged"]`, 0, 1, 0, 0, 1)
 }
 
 func TestTaskRunStopAgentWithReasonInstrumentationRecordsTerminalFailure(t *testing.T) {

--- a/web/components/task-run-analytics-view.tsx
+++ b/web/components/task-run-analytics-view.tsx
@@ -387,9 +387,9 @@ export function TaskRunAnalyticsView({ workspaceScope }: { workspaceScope?: stri
           )}
           <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-6">
             <Metric label="Runs" value={kpiSummary?.totalRuns ?? 0} active={activeKpi === "runs"} onClick={() => applyKpiFilter("runs")} />
-            <Metric label="Clean" value={kpiSummary?.byStatus.clean_success ?? 0} tone="success" active={activeKpi === "clean"} onClick={() => applyKpiFilter("clean")} />
-            <Metric label="Warning" value={kpiSummary?.byStatus.warning_success ?? 0} tone="warning" active={activeKpi === "warning"} onClick={() => applyKpiFilter("warning")} />
-            <Metric label="Failed" value={kpiSummary?.byStatus.failed ?? 0} tone="danger" active={activeKpi === "failed"} onClick={() => applyKpiFilter("failed")} />
+            <Metric label="Clean" title="Merged with no human interaction" value={kpiSummary?.byStatus.clean_success ?? 0} tone="success" active={activeKpi === "clean"} onClick={() => applyKpiFilter("clean")} />
+            <Metric label="Warning" title="Merged with human touch or PR closed without merge" value={kpiSummary?.byStatus.warning_success ?? 0} tone="warning" active={activeKpi === "warning"} onClick={() => applyKpiFilter("warning")} />
+            <Metric label="Failed" title="No PR was ever opened" value={kpiSummary?.byStatus.failed ?? 0} tone="danger" active={activeKpi === "failed"} onClick={() => applyKpiFilter("failed")} />
             <Metric label="Human touches" value={kpiSummary?.humanInteractions ?? 0} active={activeKpi === "humanTouches"} onClick={() => applyKpiFilter("humanTouches")} />
             <Metric label="Merged PRs" value={kpiSummary?.prCounts.merged ?? 0} active={activeKpi === "mergedPrs"} onClick={() => applyKpiFilter("mergedPrs")} />
           </div>
@@ -502,10 +502,11 @@ export function TaskRunAnalyticsView({ workspaceScope }: { workspaceScope?: stri
   )
 }
 
-function Metric({ label, value, tone, active, onClick }: { label: string; value: number; tone?: "success" | "warning" | "danger"; active?: boolean; onClick: () => void }) {
+function Metric({ label, title, value, tone, active, onClick }: { label: string; title?: string; value: number; tone?: "success" | "warning" | "danger"; active?: boolean; onClick: () => void }) {
   return (
     <button
       type="button"
+      title={title}
       aria-pressed={active}
       onClick={onClick}
       className={cn(
@@ -725,6 +726,7 @@ function StatusBadge({ status }: { status: string }) {
   const icon = statusIcons[status] ?? <CircleDot className="size-3" />
   return (
     <Badge
+      title={status === "clean_success" ? "Merged with no human interaction" : status === "warning_success" ? "Merged with human touch or PR closed without merge" : status === "failed" ? "No PR was ever opened" : undefined}
       variant={status === "failed" ? "destructive" : status === "running" ? "secondary" : "outline"}
       className={cn(status === "clean_success" && "border-emerald-500/40 text-emerald-700 dark:text-emerald-300", status === "warning_success" && "border-amber-500/50 text-amber-700 dark:text-amber-300")}
     >


### PR DESCRIPTION
## Summary

Reworks how run status is computed in analytics (`computeTaskRunStatus`), keeping the same four status values but with new semantics:

- **clean_success** — at least one PR merged, none still open, and **zero human-interaction events**. Non-human warnings (e.g. `pr_replaced`) no longer downgrade the status; the merge click itself does not count as human touch.
- **warning_success** — merged with some human touch (PR comments, reviews, requested changes, dashboard messages, manual code pushes), **or** all PRs closed without merge (`pr_closed_unmerged` is now a warning, not a failure — reprioritization is not a factory failure).
- **failed** — the run ended and a PR was never opened (`done_without_pr`, pre-PR failures, timeout/stop before delivery). Definitive failures no longer force `failed` once a PR exists; PR outcome wins.

## Changes

- **Status rules** (`pkg/hub/task_run_analytics.go`): decision driven by human-interaction events instead of the generic warnings list; `pr_closed_unmerged` reclassified as warning with no `failure_type`.
- **Human manual code push detection** (previously unimplemented): `task_run_prs.last_agent_head_sha` now tracks the agent's last pushed SHA (with an `ALTER TABLE` migration for existing databases). Shared detection logic (`detectHumanCodePush`) runs in both the `pr_watcher` poll loop (covers all trigger types) and the GitHub webhook `synchronize` path, with cross-path dedup. Base-merge commits ("Update branch" button) and agent/bot pushes advance the baseline instead of counting as human touch.
- **Historical backfill**: one-time startup re-materialization of all existing `task_run_summaries` under the new rules (`backfillTaskRunAnalyticsStatusV2`, guarded by a `hub_migrations` marker row), recomputed from the raw `task_run_events` / `task_run_prs` data.
- **Frontend**: KPI tile and `StatusBadge` copy/tooltips updated to the new semantics (copy-only change, no layout changes — no screenshots).

## Test plan

- `go build ./...` and `go test ./pkg/hub/...` green.
- New/updated tests cover: merged without human events → clean; merged + human comment → warning; non-human warning only → clean; no PR ever → failed; all PRs closed unmerged → warning with `pr_closed_unmerged` and no failure type; timeout after PR opened → PR outcome wins; human push detection via poller and webhook (including "Update branch" false-positive guard, agent-push baseline advancement, cross-path dedup); backfill reclassification of old summaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)