### PR TITLE
Centralize Grok OAuth token refresh

### DIFF
--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -41,6 +41,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -2632,44 +2633,7 @@ type managedModelAuthCredential struct {
 
 const managedGrokAuthSyncInterval = 5 * time.Minute
 
-func syncManagedGrokOAuthCredential() error {
-	if strings.TrimSpace(os.Getenv("ELASTICCLAW_MODEL_AUTH_PROVIDER")) != "grok" {
-		return nil
-	}
-	hubURL := strings.TrimRight(strings.TrimSpace(os.Getenv("ELASTICCLAW_HUB_URL")), "/")
-	clawID := strings.TrimSpace(os.Getenv("ELASTICCLAW_CLAW_ID"))
-	clawToken := strings.TrimSpace(os.Getenv("ELASTICCLAW_CLAW_TOKEN"))
-	if hubURL == "" || clawID == "" || clawToken == "" {
-		return fmt.Errorf("managed Grok auth requires hub URL, claw ID, and claw token")
-	}
-	if strings.HasPrefix(hubURL, "ws://") {
-		hubURL = "http://" + strings.TrimPrefix(hubURL, "ws://")
-	} else if strings.HasPrefix(hubURL, "wss://") {
-		hubURL = "https://" + strings.TrimPrefix(hubURL, "wss://")
-	}
-	req, err := http.NewRequest(http.MethodPost, hubURL+"/api/internal/model-auth/credential", nil)
-	if err != nil {
-		return err
-	}
-	req.Header.Set("X-Claw-Token", clawToken)
-	req.Header.Set("X-ElasticClaw-Claw-ID", clawID)
-	client := &http.Client{Timeout: 30 * time.Second}
-	resp, err := client.Do(req)
-	if err != nil {
-		return fmt.Errorf("request managed Grok credential: %w", err)
-	}
-	defer resp.Body.Close()
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
-	if err != nil {
-		return fmt.Errorf("read managed Grok credential: %w", err)
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("managed Grok credential returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
-	}
-	var credential managedModelAuthCredential
-	if err := json.Unmarshal(body, &credential); err != nil {
-		return fmt.Errorf("parse managed Grok credential: %w", err)
-	}
+func applyManagedGrokOAuthCredential(credential managedModelAuthCredential) error {
 	if credential.Provider != "xai" || credential.Access == "" || credential.Expires <= 0 {
 		return fmt.Errorf("managed Grok credential response is incomplete")
 	}
@@ -2747,18 +2711,14 @@ func writeManagedGrokCredentialToCLI(home string, credential managedModelAuthCre
 	if err := json.Unmarshal(data, &document); err != nil {
 		return err
 	}
-	for _, raw := range document {
-		entry, ok := raw.(map[string]any)
-		if !ok {
-			continue
-		}
-		if refresh, _ := entry["refresh_token"].(string); refresh == "" {
-			continue
-		}
-		entry["key"] = credential.Access
-		entry["refresh_token"] = "elasticclaw-managed"
-		entry["expires_at"] = time.UnixMilli(credential.Expires).UTC().Format(time.RFC3339Nano)
+	const canonicalCredential = "https://auth.x.ai::b1a00492-073a-47ea-816f-4c329264a828"
+	entry, ok := document[canonicalCredential].(map[string]any)
+	if !ok {
+		return fmt.Errorf("Grok auth file has no canonical xAI OAuth credential")
 	}
+	entry["key"] = credential.Access
+	entry["refresh_token"] = "elasticclaw-managed"
+	entry["expires_at"] = time.UnixMilli(credential.Expires).UTC().Format(time.RFC3339Nano)
 	updated, err := json.MarshalIndent(document, "", "  ")
 	if err != nil {
 		return err
@@ -2769,28 +2729,6 @@ func writeManagedGrokCredentialToCLI(home string, credential managedModelAuthCre
 		return err
 	}
 	return os.Rename(tempPath, authPath)
-}
-
-func runManagedGrokAuthSync(ctx context.Context) {
-	if strings.TrimSpace(os.Getenv("ELASTICCLAW_MODEL_AUTH_PROVIDER")) != "grok" {
-		return
-	}
-	syncOnce := func() {
-		if err := syncManagedGrokOAuthCredential(); err != nil {
-			log.Printf("[model-auth] Grok credential sync failed: %v", err)
-		}
-	}
-	syncOnce()
-	ticker := time.NewTicker(managedGrokAuthSyncInterval)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-			syncOnce()
-		}
-	}
 }
 
 var openClawWorkspaceManagedFiles = map[string]bool{
@@ -3484,10 +3422,6 @@ func runBootstrap() error {
 	if err := syncOpenClawOAuthAuth(); err != nil {
 		return err
 	}
-	if err := syncManagedGrokOAuthCredential(); err != nil {
-		log.Printf("[bootstrap] managed Grok auth sync warning: %v (will retry in bridge loop)", err)
-	}
-
 	if err := syncStagedWorkspaceToOpenClawWorkspace(); err != nil {
 		return fmt.Errorf("syncStagedWorkspaceToOpenClawWorkspace: %w", err)
 	}
@@ -3730,6 +3664,7 @@ func main() {
 	hubURL := mustEnv("ELASTICCLAW_HUB_URL")
 	clawID := mustEnv("ELASTICCLAW_CLAW_ID")
 	token := mustEnv("ELASTICCLAW_CLAW_TOKEN")
+	modelAuthToken := strings.TrimSpace(os.Getenv("ELASTICCLAW_MODEL_AUTH_TOKEN"))
 	gatewayAddr := envOr("ELASTICCLAW_GATEWAY", "localhost:18789")
 	clawName := envOr("ELASTICCLAW_CLAW_NAME", clawID)
 	templateName := envOr("ELASTICCLAW_TEMPLATE", "")
@@ -3776,7 +3711,6 @@ func main() {
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
-	go runManagedGrokAuthSync(ctx)
 
 	// Establish the persistent gateway session before entering the hub loop.
 	// Retry until we succeed (gateway may not be ready yet).
@@ -3813,7 +3747,7 @@ func main() {
 	go runStatusChannel(ctx, wsURL, clawID, clawName, templateName, token)
 
 	for {
-		if err := runHubLoop(ctx, wsURL, clawID, clawName, templateName, token, gwClient, gwSession, proxy, queue, deduper); err != nil {
+		if err := runHubLoop(ctx, wsURL, clawID, clawName, templateName, token, modelAuthToken, gwClient, gwSession, proxy, queue, deduper); err != nil {
 			if ctx.Err() != nil {
 				log.Printf("shutting down")
 				return
@@ -3942,7 +3876,7 @@ func runStatusChannel(ctx context.Context, wsURL, clawID, clawName, templateName
 	}
 }
 
-func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, token string, gwClient *gatewayClient, gwSession *gatewaySession, proxy *httpProxy, queue *msgQueue, deduper *messageDeduper) error {
+func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, token, modelAuthToken string, gwClient *gatewayClient, gwSession *gatewaySession, proxy *httpProxy, queue *msgQueue, deduper *messageDeduper) error {
 	conn, _, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{
 		HTTPHeader: http.Header{
 			"User-Agent":                 {"claw-bridge/1.0"},
@@ -3964,11 +3898,12 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 	reg := hubMsg{
 		Type: "register",
 		Payload: mustJSON(map[string]interface{}{
-			"claw_id":       clawID,
-			"name":          clawName,
-			"template":      templateName,
-			"token":         token,
-			"gateway_ready": gwSession.IsReady(),
+			"claw_id":          clawID,
+			"name":             clawName,
+			"template":         templateName,
+			"token":            token,
+			"model_auth_token": modelAuthToken,
+			"gateway_ready":    gwSession.IsReady(),
 		}),
 	}
 	if err := writeHub(reg); err != nil {
@@ -3982,6 +3917,24 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 	}
 	if ack.Type != "registered" {
 		return fmt.Errorf("expected registered, got %s", ack.Type)
+	}
+	var registered struct {
+		ModelAuthCredential *managedModelAuthCredential `json:"model_auth_credential"`
+		ModelAuthError      string                      `json:"model_auth_error"`
+	}
+	if len(ack.Payload) > 0 && string(ack.Payload) != "null" {
+		if err := json.Unmarshal(ack.Payload, &registered); err != nil {
+			return fmt.Errorf("parse registered payload: %w", err)
+		}
+	}
+	var lastModelAuthSync atomic.Int64
+	if registered.ModelAuthCredential != nil {
+		if err := applyManagedGrokOAuthCredential(*registered.ModelAuthCredential); err != nil {
+			return fmt.Errorf("apply registered model credential: %w", err)
+		}
+		lastModelAuthSync.Store(time.Now().UnixNano())
+	} else if registered.ModelAuthError != "" {
+		log.Printf("[model-auth] %s", registered.ModelAuthError)
 	}
 	log.Printf("registered with hub as %s", clawID)
 
@@ -4044,6 +3997,13 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 		connCancel()
 		conn.CloseNow()
 	}, func() {
+		lastSyncUnixNano := lastModelAuthSync.Load()
+		if strings.TrimSpace(os.Getenv("ELASTICCLAW_MODEL_AUTH_PROVIDER")) == "grok" &&
+			(lastSyncUnixNano == 0 || time.Since(time.Unix(0, lastSyncUnixNano)) >= managedGrokAuthSyncInterval) {
+			if err := writeHub(hubMsg{Type: "model_auth_sync"}); err == nil {
+				lastModelAuthSync.Store(time.Now().UnixNano())
+			}
+		}
 		go gwSession.refreshContextUsage(connCtx)
 		health := !gatewayProcessExited() && checkGateway(gwClient.addr)
 		cu := gwSession.ContextUsage()
@@ -4139,6 +4099,16 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 					queue.pushReply(reply)
 				}
 			}(msg.Payload)
+
+		case "model_auth_credential":
+			var credential managedModelAuthCredential
+			if err := json.Unmarshal(msg.Payload, &credential); err != nil {
+				log.Printf("[model-auth] invalid managed credential: %v", err)
+			} else if err := applyManagedGrokOAuthCredential(credential); err != nil {
+				log.Printf("[model-auth] apply managed credential: %v", err)
+			} else {
+				lastModelAuthSync.Store(time.Now().UnixNano())
+			}
 
 		case "http_proxy_res":
 			var res httpProxyRes

--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
+	"database/sql"
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
@@ -47,6 +48,7 @@ import (
 	"nhooyr.io/websocket/wsjson"
 
 	"github.com/elasticclaw/elasticclaw/pkg/cliversion"
+	_ "modernc.org/sqlite"
 )
 
 var (
@@ -2514,7 +2516,7 @@ func migrateGrokOAuthToOpenClaw(home string) error {
 		"type":          "oauth",
 		"provider":      "xai",
 		"access":        selected.Key,
-		"refresh":       selected.RefreshToken,
+		"refresh":       "elasticclaw-managed",
 		"expires":       expires,
 		"issuer":        issuer,
 		"tokenEndpoint": issuer + "/oauth2/token",
@@ -2620,6 +2622,175 @@ func syncOpenClawOAuthAuth() error {
 		return fmt.Errorf("sync OpenClaw OAuth auth: %w", err)
 	}
 	return nil
+}
+
+type managedModelAuthCredential struct {
+	Provider string `json:"provider"`
+	Access   string `json:"access"`
+	Expires  int64  `json:"expires"`
+}
+
+const managedGrokAuthSyncInterval = 5 * time.Minute
+
+func syncManagedGrokOAuthCredential() error {
+	if strings.TrimSpace(os.Getenv("ELASTICCLAW_MODEL_AUTH_PROVIDER")) != "grok" {
+		return nil
+	}
+	hubURL := strings.TrimRight(strings.TrimSpace(os.Getenv("ELASTICCLAW_HUB_URL")), "/")
+	clawID := strings.TrimSpace(os.Getenv("ELASTICCLAW_CLAW_ID"))
+	clawToken := strings.TrimSpace(os.Getenv("ELASTICCLAW_CLAW_TOKEN"))
+	if hubURL == "" || clawID == "" || clawToken == "" {
+		return fmt.Errorf("managed Grok auth requires hub URL, claw ID, and claw token")
+	}
+	if strings.HasPrefix(hubURL, "ws://") {
+		hubURL = "http://" + strings.TrimPrefix(hubURL, "ws://")
+	} else if strings.HasPrefix(hubURL, "wss://") {
+		hubURL = "https://" + strings.TrimPrefix(hubURL, "wss://")
+	}
+	req, err := http.NewRequest(http.MethodPost, hubURL+"/api/internal/model-auth/credential", nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("X-Claw-Token", clawToken)
+	req.Header.Set("X-ElasticClaw-Claw-ID", clawID)
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("request managed Grok credential: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return fmt.Errorf("read managed Grok credential: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("managed Grok credential returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var credential managedModelAuthCredential
+	if err := json.Unmarshal(body, &credential); err != nil {
+		return fmt.Errorf("parse managed Grok credential: %w", err)
+	}
+	if credential.Provider != "xai" || credential.Access == "" || credential.Expires <= 0 {
+		return fmt.Errorf("managed Grok credential response is incomplete")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("home dir: %w", err)
+	}
+	if err := writeManagedGrokCredentialToOpenClaw(home, credential); err != nil {
+		return err
+	}
+	if err := writeManagedGrokCredentialToCLI(home, credential); err != nil {
+		return fmt.Errorf("update local Grok credential: %w", err)
+	}
+	return nil
+}
+
+func writeManagedGrokCredentialToOpenClaw(home string, credential managedModelAuthCredential) error {
+	dbPath := filepath.Join(home, ".openclaw", "agents", "main", "agent", "openclaw-agent.sqlite")
+	db, err := sql.Open("sqlite", dbPath+"?_txlock=immediate&_pragma=busy_timeout(5000)")
+	if err != nil {
+		return fmt.Errorf("open OpenClaw auth database: %w", err)
+	}
+	defer db.Close()
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin OpenClaw auth update: %w", err)
+	}
+	defer tx.Rollback()
+	var storeJSON string
+	if err := tx.QueryRow(`SELECT store_json FROM auth_profile_store WHERE store_key='primary'`).Scan(&storeJSON); err != nil {
+		return fmt.Errorf("read OpenClaw auth store: %w", err)
+	}
+	var store map[string]any
+	if err := json.Unmarshal([]byte(storeJSON), &store); err != nil {
+		return fmt.Errorf("parse OpenClaw auth store: %w", err)
+	}
+	profiles, _ := store["profiles"].(map[string]any)
+	if profiles == nil {
+		profiles = map[string]any{}
+		store["profiles"] = profiles
+	}
+	profile, _ := profiles["xai:default"].(map[string]any)
+	if profile == nil {
+		profile = map[string]any{}
+	}
+	profile["type"] = "oauth"
+	profile["provider"] = "xai"
+	profile["access"] = credential.Access
+	profile["refresh"] = "elasticclaw-managed"
+	profile["expires"] = credential.Expires
+	profiles["xai:default"] = profile
+	updated, err := json.Marshal(store)
+	if err != nil {
+		return fmt.Errorf("encode OpenClaw auth store: %w", err)
+	}
+	if _, err := tx.Exec(`UPDATE auth_profile_store SET store_json=?, updated_at=? WHERE store_key='primary'`, string(updated), time.Now().UnixMilli()); err != nil {
+		return fmt.Errorf("write OpenClaw auth store: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit OpenClaw auth update: %w", err)
+	}
+	return nil
+}
+
+func writeManagedGrokCredentialToCLI(home string, credential managedModelAuthCredential) error {
+	authPath := filepath.Join(home, ".grok", "auth.json")
+	data, err := os.ReadFile(authPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	var document map[string]any
+	if err := json.Unmarshal(data, &document); err != nil {
+		return err
+	}
+	for _, raw := range document {
+		entry, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if refresh, _ := entry["refresh_token"].(string); refresh == "" {
+			continue
+		}
+		entry["key"] = credential.Access
+		entry["refresh_token"] = "elasticclaw-managed"
+		entry["expires_at"] = time.UnixMilli(credential.Expires).UTC().Format(time.RFC3339Nano)
+	}
+	updated, err := json.MarshalIndent(document, "", "  ")
+	if err != nil {
+		return err
+	}
+	updated = append(updated, '\n')
+	tempPath := authPath + ".tmp"
+	if err := os.WriteFile(tempPath, updated, 0600); err != nil {
+		return err
+	}
+	return os.Rename(tempPath, authPath)
+}
+
+func runManagedGrokAuthSync(ctx context.Context) {
+	if strings.TrimSpace(os.Getenv("ELASTICCLAW_MODEL_AUTH_PROVIDER")) != "grok" {
+		return
+	}
+	syncOnce := func() {
+		if err := syncManagedGrokOAuthCredential(); err != nil {
+			log.Printf("[model-auth] Grok credential sync failed: %v", err)
+		}
+	}
+	syncOnce()
+	ticker := time.NewTicker(managedGrokAuthSyncInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			syncOnce()
+		}
+	}
 }
 
 var openClawWorkspaceManagedFiles = map[string]bool{
@@ -3313,6 +3484,9 @@ func runBootstrap() error {
 	if err := syncOpenClawOAuthAuth(); err != nil {
 		return err
 	}
+	if err := syncManagedGrokOAuthCredential(); err != nil {
+		log.Printf("[bootstrap] managed Grok auth sync warning: %v (will retry in bridge loop)", err)
+	}
 
 	if err := syncStagedWorkspaceToOpenClawWorkspace(); err != nil {
 		return fmt.Errorf("syncStagedWorkspaceToOpenClawWorkspace: %w", err)
@@ -3602,6 +3776,7 @@ func main() {
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
+	go runManagedGrokAuthSync(ctx)
 
 	// Establish the persistent gateway session before entering the hub loop.
 	// Retry until we succeed (gateway may not be ready yet).

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -89,7 +89,16 @@ func TestWriteManagedGrokCredentialToCLI(t *testing.T) {
 		t.Fatal(err)
 	}
 	authPath := filepath.Join(authDir, "auth.json")
-	if err := os.WriteFile(authPath, []byte(`{"profile":{"key":"access","refresh_token":"rotating-secret","metadata":"keep"}}`), 0600); err != nil {
+	const canonical = "https://auth.x.ai::b1a00492-073a-47ea-816f-4c329264a828"
+	document := map[string]any{
+		canonical:   map[string]any{"key": "access", "refresh_token": "rotating-secret", "metadata": "keep"},
+		"unrelated": map[string]any{"key": "other-access", "refresh_token": "other-refresh"},
+	}
+	initial, err := json.Marshal(document)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(authPath, initial, 0600); err != nil {
 		t.Fatal(err)
 	}
 	credential := managedModelAuthCredential{Provider: "xai", Access: "current-access", Expires: 1893553445000}
@@ -102,6 +111,28 @@ func TestWriteManagedGrokCredentialToCLI(t *testing.T) {
 	}
 	if strings.Contains(string(data), "rotating-secret") || !strings.Contains(string(data), "elasticclaw-managed") || !strings.Contains(string(data), "current-access") || !strings.Contains(string(data), "2030-01-02T03:04:05Z") || !strings.Contains(string(data), `"metadata": "keep"`) {
 		t.Fatalf("unexpected managed Grok auth: %s", data)
+	}
+	var got map[string]map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got["unrelated"]["key"] != "other-access" || got["unrelated"]["refresh_token"] != "other-refresh" {
+		t.Fatalf("unrelated Grok credential was changed: %#v", got["unrelated"])
+	}
+}
+
+func TestWriteManagedGrokCredentialToCLIRequiresCanonicalEntry(t *testing.T) {
+	home := t.TempDir()
+	authDir := filepath.Join(home, ".grok")
+	if err := os.MkdirAll(authDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(authDir, "auth.json"), []byte(`{"unrelated":{"refresh_token":"keep"}}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	err := writeManagedGrokCredentialToCLI(home, managedModelAuthCredential{Provider: "xai", Access: "access", Expires: 1893553445000})
+	if err == nil || !strings.Contains(err.Error(), "canonical xAI") {
+		t.Fatalf("error = %v, want missing canonical credential", err)
 	}
 }
 
@@ -1252,7 +1283,7 @@ func TestRunHubLoopDoesNotLeakKeepaliveGoroutinesAcrossReconnects(t *testing.T) 
 	before := stableGoroutineCount(t)
 	const cycles = 5
 	for range cycles {
-		err := runHubLoop(ctx, wsURL, "claw-test", "test-claw", "test-template", "tok", gwClient, gwSession, proxy, queue, newMessageDeduper())
+		err := runHubLoop(ctx, wsURL, "claw-test", "test-claw", "test-template", "tok", "", gwClient, gwSession, proxy, queue, newMessageDeduper())
 		if err == nil {
 			t.Fatal("runHubLoop returned nil error, want read error after hub-side close")
 		}

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
@@ -21,6 +22,88 @@ import (
 	"nhooyr.io/websocket"
 	"nhooyr.io/websocket/wsjson"
 )
+
+func TestWriteManagedGrokCredentialToOpenClaw(t *testing.T) {
+	home := t.TempDir()
+	agentDir := filepath.Join(home, ".openclaw", "agents", "main", "agent")
+	if err := os.MkdirAll(agentDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	dbPath := filepath.Join(agentDir, "openclaw-agent.sqlite")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	existing := `{"version":1,"profiles":{"anthropic:default":{"type":"api_key","provider":"anthropic","key":"keep-me"},"xai:default":{"type":"oauth","provider":"xai","access":"old","refresh":"real-refresh","expires":1,"email":"dev@example.com"}}}`
+	if _, err := db.Exec(`CREATE TABLE auth_profile_store (store_key TEXT NOT NULL PRIMARY KEY, store_json TEXT NOT NULL, updated_at INTEGER NOT NULL)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO auth_profile_store(store_key,store_json,updated_at) VALUES('primary',?,1)`, existing); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	credential := managedModelAuthCredential{Provider: "xai", Access: "current-access", Expires: 1893553445000}
+	if err := writeManagedGrokCredentialToOpenClaw(home, credential); err != nil {
+		t.Fatal(err)
+	}
+	db, err = sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	var storeJSON string
+	if err := db.QueryRow(`SELECT store_json FROM auth_profile_store WHERE store_key='primary'`).Scan(&storeJSON); err != nil {
+		t.Fatal(err)
+	}
+	var store struct {
+		Profiles map[string]struct {
+			Access  string `json:"access"`
+			Refresh string `json:"refresh"`
+			Expires int64  `json:"expires"`
+			Email   string `json:"email"`
+			Key     string `json:"key"`
+		} `json:"profiles"`
+	}
+	if err := json.Unmarshal([]byte(storeJSON), &store); err != nil {
+		t.Fatal(err)
+	}
+	xai := store.Profiles["xai:default"]
+	if xai.Access != "current-access" || xai.Refresh != "elasticclaw-managed" || xai.Expires != credential.Expires {
+		t.Fatalf("unexpected managed xAI profile: %#v", xai)
+	}
+	if xai.Email != "dev@example.com" {
+		t.Fatalf("existing xAI metadata was not preserved: %#v", xai)
+	}
+	if got := store.Profiles["anthropic:default"].Key; got != "keep-me" {
+		t.Fatalf("unrelated auth profile was not preserved: %q", got)
+	}
+}
+
+func TestWriteManagedGrokCredentialToCLI(t *testing.T) {
+	home := t.TempDir()
+	authDir := filepath.Join(home, ".grok")
+	if err := os.MkdirAll(authDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	authPath := filepath.Join(authDir, "auth.json")
+	if err := os.WriteFile(authPath, []byte(`{"profile":{"key":"access","refresh_token":"rotating-secret","metadata":"keep"}}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	credential := managedModelAuthCredential{Provider: "xai", Access: "current-access", Expires: 1893553445000}
+	if err := writeManagedGrokCredentialToCLI(home, credential); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(authPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "rotating-secret") || !strings.Contains(string(data), "elasticclaw-managed") || !strings.Contains(string(data), "current-access") || !strings.Contains(string(data), "2030-01-02T03:04:05Z") || !strings.Contains(string(data), `"metadata": "keep"`) {
+		t.Fatalf("unexpected managed Grok auth: %s", data)
+	}
+}
 
 func resetGatewayProcessState(t *testing.T) {
 	t.Helper()
@@ -866,7 +949,7 @@ func TestRestoreCLIModelAuthMigratesGrokOAuthToOpenClaw(t *testing.T) {
 	if auth.Version != 1 || credential.Type != "oauth" || credential.Provider != "xai" {
 		t.Fatalf("unexpected OpenClaw auth profile: %#v", auth)
 	}
-	if credential.Access != "access-token" || credential.Refresh != "refresh-token" || credential.Expires != 1893553445000 {
+	if credential.Access != "access-token" || credential.Refresh != "elasticclaw-managed" || credential.Expires != 1893553445000 {
 		t.Fatalf("OAuth tokens were not migrated: %#v", credential)
 	}
 	if credential.Email != "dev@example.com" || credential.AccountID != "user-123" {

--- a/pkg/hub/bootstrap.go
+++ b/pkg/hub/bootstrap.go
@@ -11,10 +11,11 @@ import (
 // It is intentionally a pure value type — no DB, no server, no side effects.
 type BootstrapParams struct {
 	// Claw identity
-	ClawID       string
-	ClawName     string
-	ClawToken    string
-	TemplateName string
+	ClawID         string
+	ClawName       string
+	ClawToken      string
+	ModelAuthToken string
+	TemplateName   string
 
 	// Hub connectivity
 	HubURL string
@@ -435,6 +436,7 @@ set -euo pipefail
 export ELASTICCLAW_HUB_URL=%s
 export ELASTICCLAW_CLAW_ID=%s
 export ELASTICCLAW_CLAW_TOKEN=%s
+export ELASTICCLAW_MODEL_AUTH_TOKEN=%s
 export ELASTICCLAW_CLAW_NAME=%s
 export ELASTICCLAW_TEMPLATE=%s
 export ELASTICCLAW_GATEWAY_PASSWORD=%s
@@ -505,6 +507,7 @@ echo "ElasticClaw connector installed"
   printf 'export ELASTICCLAW_HUB_URL=%%q\n' "$ELASTICCLAW_HUB_URL"
   printf 'export ELASTICCLAW_CLAW_ID=%%q\n' "$ELASTICCLAW_CLAW_ID"
   printf 'export ELASTICCLAW_CLAW_TOKEN=%%q\n' "$ELASTICCLAW_CLAW_TOKEN"
+  printf 'export ELASTICCLAW_MODEL_AUTH_TOKEN=%%q\n' "$ELASTICCLAW_MODEL_AUTH_TOKEN"
   printf 'export ELASTICCLAW_CLAW_NAME=%%q\n' "$ELASTICCLAW_CLAW_NAME"
   printf 'export ELASTICCLAW_TEMPLATE=%%q\n' "$ELASTICCLAW_TEMPLATE"
   printf 'export ELASTICCLAW_GATEWAY_PASSWORD=%%q\n' "$ELASTICCLAW_GATEWAY_PASSWORD"
@@ -573,7 +576,7 @@ done
 echo "ERROR: timed out waiting for claw-bridge bootstrap to complete"
 exit 1
 `,
-		shellQuote(p.HubURL), shellQuote(p.ClawID), shellQuote(p.ClawToken), shellQuote(p.ClawName), shellQuote(p.TemplateName), shellQuote(p.GatewayPassword),
+		shellQuote(p.HubURL), shellQuote(p.ClawID), shellQuote(p.ClawToken), shellQuote(p.ModelAuthToken), shellQuote(p.ClawName), shellQuote(p.TemplateName), shellQuote(p.GatewayPassword),
 		shellQuote(p.DefaultModel), shellQuote(p.LLMProvider), shellQuote(nixFlag), shellQuote(dockerFlag),
 		p.LLMKeyEnv, p.ModelAuthEnv, linearEnvLine, apiKeyAuthSyncLine, oauthAuthSyncLine, shellQuote(p.OnboardFlags), providerConfigLine,
 		shellQuote(p.BridgeURL),

--- a/pkg/hub/bootstrap.go
+++ b/pkg/hub/bootstrap.go
@@ -313,7 +313,9 @@ store.profiles['xai:default'] = {
   type: 'oauth',
   provider: 'xai',
   access: source.key,
-  refresh: source.refresh_token,
+  // The hub owns xAI's rotating refresh token. Giving the same token to
+  // multiple claws lets the first local refresh revoke every other copy.
+  refresh: 'elasticclaw-managed',
   expires: parsedExpires,
 };
 

--- a/pkg/hub/bootstrap_test.go
+++ b/pkg/hub/bootstrap_test.go
@@ -19,6 +19,7 @@ func baseParams() BootstrapParams {
 		ClawID:          "test-claw-id-1234",
 		ClawName:        "test-claw",
 		ClawToken:       "test-token",
+		ModelAuthToken:  "test-model-auth-token",
 		TemplateName:    "adversarylabs",
 		HubURL:          "https://hub.example.com",
 		DefaultModel:    "anthropic/claude-sonnet-4-6",
@@ -69,7 +70,7 @@ func TestBootstrapScript_ContainsBridgeURL(t *testing.T) {
 
 func TestDaytonaBridgeCommands_AreAsyncAndIdempotent(t *testing.T) {
 	prep := daytonaPrepareBridgeCommand()
-	cmd := daytonaAsyncBridgeCommand("https://hub.example.com", "claw-123", "token-123", "NEXT-156", "adversarylabs")
+	cmd := daytonaAsyncBridgeCommand("https://hub.example.com", "claw-123", "token-123", "model-auth-123", "NEXT-156", "adversarylabs")
 	running := daytonaBridgeRunningCommand()
 
 	assertContains(t, prep, "pgrep -x claw-bridge", "detects already running bridge from previous start behavior")
@@ -88,6 +89,7 @@ func TestDaytonaBridgeCommands_AreAsyncAndIdempotent(t *testing.T) {
 	assertContains(t, cmd, "kill \"$child\"", "supervisor forwards termination to its bridge child")
 	assertContains(t, cmd, "restart budget exhausted after 3 attempts", "caps rapid restart flapping")
 	assertContains(t, cmd, `ELASTICCLAW_CLAW_ID='claw-123'`, "passes claw id to bridge")
+	assertContains(t, cmd, `ELASTICCLAW_MODEL_AUTH_TOKEN='model-auth-123'`, "passes per-claw model auth proof")
 	assertContains(t, cmd, `ELASTICCLAW_TEMPLATE='adversarylabs'`, "passes workspace identity to bridge")
 	assertNotContains(t, cmd, "nohup /tmp/claw-bridge", "does not execute bridge directly from tmp")
 	assertNotContains(t, cmd, "setsid", "does not rely on shell detach when Daytona async sessions are available")
@@ -100,7 +102,7 @@ func TestDaytonaBridgeCommands_AreAsyncAndIdempotent(t *testing.T) {
 func TestDaytonaAsyncBridgeCommandShellQuotesClawName(t *testing.T) {
 	clawName := `$(touch /tmp/elasticclaw-pwned)' "quoted"`
 	templateName := `$(touch /tmp/elasticclaw-template-pwned)' "quoted"`
-	cmd := daytonaAsyncBridgeCommand("https://hub.example.com", "claw-123", "token-123", clawName, templateName)
+	cmd := daytonaAsyncBridgeCommand("https://hub.example.com", "claw-123", "token-123", "model-auth-123", clawName, templateName)
 
 	assertContains(t, cmd, "ELASTICCLAW_CLAW_NAME="+shellQuote(clawName), "shell-quotes command-substitution payload")
 	assertNotContains(t, cmd, `ELASTICCLAW_CLAW_NAME="$(touch`, "must not place claw name in shell double quotes")
@@ -174,6 +176,7 @@ func TestBootstrapScript_BridgeEnvVars(t *testing.T) {
 	assertContains(t, script, `ELASTICCLAW_HUB_URL='https://hub.example.com'`, "hub URL env var")
 	assertContains(t, script, `ELASTICCLAW_CLAW_ID='test-claw-id-1234'`, "claw ID env var")
 	assertContains(t, script, `ELASTICCLAW_CLAW_TOKEN='test-token'`, "claw token env var")
+	assertContains(t, script, `ELASTICCLAW_MODEL_AUTH_TOKEN='test-model-auth-token'`, "per-claw model auth proof")
 	assertContains(t, script, `ELASTICCLAW_CLAW_NAME='test-claw'`, "claw name env var")
 	assertContains(t, script, `ELASTICCLAW_TEMPLATE='adversarylabs'`, "workspace identity env var")
 	assertContains(t, script, `ELASTICCLAW_GATEWAY_PASSWORD='test-gw-password'`, "gateway password env var")

--- a/pkg/hub/bootstrap_test.go
+++ b/pkg/hub/bootstrap_test.go
@@ -577,7 +577,7 @@ db.close();
 		t.Fatalf("parse SQLite auth store: %v\n%s", err, out)
 	}
 	xai := store.Profiles["xai:default"]
-	if xai.Type != "oauth" || xai.Provider != "xai" || xai.Access != "access-token" || xai.Refresh != "refresh-token" || xai.Expires != 1893553445000 {
+	if xai.Type != "oauth" || xai.Provider != "xai" || xai.Access != "access-token" || xai.Refresh != "elasticclaw-managed" || xai.Expires != 1893553445000 {
 		t.Fatalf("unexpected migrated xAI auth: %#v", xai)
 	}
 	if got := store.Profiles["anthropic:default"].Key; got != "keep-me" {

--- a/pkg/hub/model_auth.go
+++ b/pkg/hub/model_auth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -209,24 +210,7 @@ type managedModelAuthCredential struct {
 
 const managedGrokRefreshSkew = 30 * time.Minute
 
-func (s *Server) handleManagedModelAuthCredential(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
-	clawID := strings.TrimSpace(r.Header.Get("X-ElasticClaw-Claw-ID"))
-	if clawID == "" {
-		http.Error(w, "missing claw identity", http.StatusBadRequest)
-		return
-	}
-	credential, err := s.managedGrokCredential(r.Context(), clawID)
-	if err != nil {
-		logModelAuthRefreshError(clawID, err)
-		http.Error(w, "managed model authentication is unavailable", http.StatusBadGateway)
-		return
-	}
-	jsonOK(w, credential)
-}
+var errManagedGrokNotConfigured = errors.New("managed Grok authentication is not configured")
 
 func logModelAuthRefreshError(clawID string, err error) {
 	shortID := clawID
@@ -247,26 +231,36 @@ func (s *Server) managedGrokCredential(ctx context.Context, clawID string) (*man
 
 	// xAI refresh tokens rotate on every use. Serialize the complete read,
 	// refresh, and persistence sequence so concurrent claws never reuse one.
+	// A hub owns its SQLite database, config file, and listener as one process;
+	// sharing those paths between multiple hub processes is unsupported.
 	s.modelAuthRefreshMu.Lock()
 	defer s.modelAuthRefreshMu.Unlock()
 
 	s.mu.RLock()
 	activeKey := resolveActiveKey(s.hubCfg.LLMKeys, selectedKeyName)
 	var profile types.ModelAuthProfileConfig
+	var pendingAuthState string
 	if activeKey != nil && activeKey.Provider == "grok" && activeKey.AuthProfile != "" {
 		for _, candidate := range s.hubCfg.ModelAuthProfiles {
 			if candidate != nil && candidate.Name == activeKey.AuthProfile && candidate.Provider == "grok" {
 				profile = *candidate
+				pendingAuthState = s.modelAuthPending[candidate.Name]
 				break
 			}
 		}
 	}
 	s.mu.RUnlock()
 	if activeKey == nil || activeKey.Provider != "grok" || activeKey.AuthProfile == "" {
-		return nil, fmt.Errorf("claw does not use a managed Grok auth profile")
+		return nil, errManagedGrokNotConfigured
 	}
 	if profile.Name == "" || profile.AuthState == "" {
 		return nil, fmt.Errorf("Grok auth profile %q has no stored credential", activeKey.AuthProfile)
+	}
+	if pendingAuthState != "" {
+		profile.AuthState = pendingAuthState
+		if err := s.saveModelAuthProfile("grok", profile.Name, profile.Mode, pendingAuthState); err != nil {
+			log.Printf("[model-auth] retry persistence for Grok profile %q: %v", profile.Name, err)
+		}
 	}
 
 	bundle, authFile, authDocument, authEntry, expiresAt, err := decodeManagedGrokAuth(profile.AuthState)
@@ -314,7 +308,11 @@ func (s *Server) managedGrokCredential(ctx context.Context, clawID string) (*man
 			return nil, err
 		}
 		if err := s.saveModelAuthProfile("grok", profile.Name, profile.Mode, updatedState); err != nil {
-			return nil, fmt.Errorf("persist refreshed Grok OAuth: %w", err)
+			// The old refresh token has already been consumed. Retain the rotated
+			// state in memory and keep serving its access token while later claw
+			// syncs retry durable persistence.
+			s.rememberPendingModelAuthProfile("grok", profile.Name, profile.Mode, updatedState)
+			log.Printf("[model-auth] persist refreshed Grok OAuth profile %q: %v (retained in memory for retry)", profile.Name, err)
 		}
 		accessToken = token.AccessToken
 	}
@@ -359,15 +357,7 @@ func decodeManagedGrokAuth(authState string) (cliAuthBundle, string, map[string]
 		entry = candidate
 	}
 	if entry == nil {
-		for _, candidate := range document {
-			if value, ok := candidate.(map[string]any); ok && stringFromMap(value, "key") != "" {
-				entry = value
-				break
-			}
-		}
-	}
-	if entry == nil {
-		return bundle, "", nil, nil, time.Time{}, fmt.Errorf("Grok auth file has no OAuth credential")
+		return bundle, "", nil, nil, time.Time{}, fmt.Errorf("Grok auth file has no canonical xAI OAuth credential")
 	}
 	expiresAt, err := time.Parse(time.RFC3339Nano, stringFromMap(entry, "expires_at"))
 	if err != nil {
@@ -954,7 +944,40 @@ func (s *Server) saveModelAuthProfile(provider, name, mode, authState string) er
 		return err
 	}
 	s.hubCfg = &updatedCfg
+	delete(s.modelAuthPending, name)
 	return nil
+}
+
+func (s *Server) rememberPendingModelAuthProfile(provider, name, mode, authState string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	updatedCfg := *s.hubCfg
+	profiles := make([]*types.ModelAuthProfileConfig, len(updatedCfg.ModelAuthProfiles))
+	var found *types.ModelAuthProfileConfig
+	for i, profile := range updatedCfg.ModelAuthProfiles {
+		if profile == nil {
+			continue
+		}
+		copy := *profile
+		profiles[i] = &copy
+		if copy.Name == name {
+			found = &copy
+		}
+	}
+	if found == nil {
+		found = &types.ModelAuthProfileConfig{Name: name}
+		profiles = append(profiles, found)
+	}
+	found.Provider = provider
+	found.Mode = mode
+	found.AuthState = authState
+	found.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	updatedCfg.ModelAuthProfiles = profiles
+	s.hubCfg = &updatedCfg
+	if s.modelAuthPending == nil {
+		s.modelAuthPending = map[string]string{}
+	}
+	s.modelAuthPending[name] = authState
 }
 
 func buildModelAuthEnv(cfg *types.HubConfig, selectedKeyName string) string {

--- a/pkg/hub/model_auth.go
+++ b/pkg/hub/model_auth.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -198,6 +199,195 @@ type oauthTokenResponse struct {
 	ExpiresIn    int64  `json:"expires_in"`
 	Error        string `json:"error"`
 	Description  string `json:"error_description"`
+}
+
+type managedModelAuthCredential struct {
+	Provider string `json:"provider"`
+	Access   string `json:"access"`
+	Expires  int64  `json:"expires"`
+}
+
+const managedGrokRefreshSkew = 30 * time.Minute
+
+func (s *Server) handleManagedModelAuthCredential(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	clawID := strings.TrimSpace(r.Header.Get("X-ElasticClaw-Claw-ID"))
+	if clawID == "" {
+		http.Error(w, "missing claw identity", http.StatusBadRequest)
+		return
+	}
+	credential, err := s.managedGrokCredential(r.Context(), clawID)
+	if err != nil {
+		logModelAuthRefreshError(clawID, err)
+		http.Error(w, "managed model authentication is unavailable", http.StatusBadGateway)
+		return
+	}
+	jsonOK(w, credential)
+}
+
+func logModelAuthRefreshError(clawID string, err error) {
+	shortID := clawID
+	if len(shortID) > 8 {
+		shortID = shortID[:8]
+	}
+	log.Printf("[model-auth] managed Grok credential for claw %s: %v", shortID, err)
+}
+
+func (s *Server) managedGrokCredential(ctx context.Context, clawID string) (*managedModelAuthCredential, error) {
+	var selectedKeyName, tenantID string
+	if err := s.db.QueryRowContext(ctx, `SELECT COALESCE(llm_key,''), tenant_id FROM claws WHERE id=?`, clawID).Scan(&selectedKeyName, &tenantID); err != nil {
+		return nil, fmt.Errorf("resolve claw LLM key: %w", err)
+	}
+	if authenticatedTenant, _ := ctx.Value(ctxTenantKey{}).(string); authenticatedTenant != "" && tenantID != authenticatedTenant {
+		return nil, fmt.Errorf("claw does not belong to authenticated tenant")
+	}
+
+	// xAI refresh tokens rotate on every use. Serialize the complete read,
+	// refresh, and persistence sequence so concurrent claws never reuse one.
+	s.modelAuthRefreshMu.Lock()
+	defer s.modelAuthRefreshMu.Unlock()
+
+	s.mu.RLock()
+	activeKey := resolveActiveKey(s.hubCfg.LLMKeys, selectedKeyName)
+	var profile types.ModelAuthProfileConfig
+	if activeKey != nil && activeKey.Provider == "grok" && activeKey.AuthProfile != "" {
+		for _, candidate := range s.hubCfg.ModelAuthProfiles {
+			if candidate != nil && candidate.Name == activeKey.AuthProfile && candidate.Provider == "grok" {
+				profile = *candidate
+				break
+			}
+		}
+	}
+	s.mu.RUnlock()
+	if activeKey == nil || activeKey.Provider != "grok" || activeKey.AuthProfile == "" {
+		return nil, fmt.Errorf("claw does not use a managed Grok auth profile")
+	}
+	if profile.Name == "" || profile.AuthState == "" {
+		return nil, fmt.Errorf("Grok auth profile %q has no stored credential", activeKey.AuthProfile)
+	}
+
+	bundle, authFile, authDocument, authEntry, expiresAt, err := decodeManagedGrokAuth(profile.AuthState)
+	if err != nil {
+		return nil, err
+	}
+	accessToken := stringFromMap(authEntry, "key")
+	if accessToken == "" {
+		return nil, fmt.Errorf("stored Grok credential has no access token")
+	}
+
+	if !expiresAt.After(time.Now().Add(managedGrokRefreshSkew)) {
+		refreshToken := stringFromMap(authEntry, "refresh_token")
+		if refreshToken == "" {
+			return nil, fmt.Errorf("stored Grok credential has no refresh token")
+		}
+		endpoint := strings.TrimSpace(s.grokTokenEndpoint)
+		if endpoint == "" {
+			endpoint = grokAuthIssuer + "/oauth2/token"
+		}
+		form := url.Values{}
+		form.Set("grant_type", "refresh_token")
+		form.Set("client_id", grokAuthClientID)
+		form.Set("refresh_token", refreshToken)
+		var token oauthTokenResponse
+		if err := postForm(ctx, http.DefaultClient, endpoint, form, &token); err != nil {
+			return nil, fmt.Errorf("refresh Grok OAuth: %w", err)
+		}
+		if token.AccessToken == "" {
+			return nil, fmt.Errorf("Grok refresh response missing access token")
+		}
+		if token.RefreshToken == "" {
+			token.RefreshToken = refreshToken
+		}
+		expiresIn := token.ExpiresIn
+		if expiresIn <= 0 {
+			expiresIn = int64((6 * time.Hour) / time.Second)
+		}
+		expiresAt = time.Now().UTC().Add(time.Duration(expiresIn) * time.Second)
+		authEntry["key"] = token.AccessToken
+		authEntry["refresh_token"] = token.RefreshToken
+		authEntry["expires_at"] = expiresAt.Format(time.RFC3339Nano)
+		updatedState, err := encodeManagedGrokAuth(bundle, authFile, authDocument)
+		if err != nil {
+			return nil, err
+		}
+		if err := s.saveModelAuthProfile("grok", profile.Name, profile.Mode, updatedState); err != nil {
+			return nil, fmt.Errorf("persist refreshed Grok OAuth: %w", err)
+		}
+		accessToken = token.AccessToken
+	}
+
+	return &managedModelAuthCredential{
+		Provider: "xai",
+		Access:   accessToken,
+		Expires:  expiresAt.UnixMilli(),
+	}, nil
+}
+
+func decodeManagedGrokAuth(authState string) (cliAuthBundle, string, map[string]any, map[string]any, time.Time, error) {
+	var bundle cliAuthBundle
+	bundleData, err := base64.StdEncoding.DecodeString(authState)
+	if err != nil {
+		return bundle, "", nil, nil, time.Time{}, fmt.Errorf("decode Grok auth bundle: %w", err)
+	}
+	if err := json.Unmarshal(bundleData, &bundle); err != nil {
+		return bundle, "", nil, nil, time.Time{}, fmt.Errorf("parse Grok auth bundle: %w", err)
+	}
+	var authFile string
+	for name := range bundle.Files {
+		if filepath.ToSlash(name) == ".grok/auth.json" {
+			authFile = name
+			break
+		}
+	}
+	if authFile == "" {
+		return bundle, "", nil, nil, time.Time{}, fmt.Errorf("Grok auth bundle has no .grok/auth.json")
+	}
+	authData, err := base64.StdEncoding.DecodeString(bundle.Files[authFile])
+	if err != nil {
+		return bundle, "", nil, nil, time.Time{}, fmt.Errorf("decode Grok auth file: %w", err)
+	}
+	var document map[string]any
+	if err := json.Unmarshal(authData, &document); err != nil {
+		return bundle, "", nil, nil, time.Time{}, fmt.Errorf("parse Grok auth file: %w", err)
+	}
+	var entry map[string]any
+	preferredKey := grokAuthIssuer + "::" + grokAuthClientID
+	if candidate, ok := document[preferredKey].(map[string]any); ok {
+		entry = candidate
+	}
+	if entry == nil {
+		for _, candidate := range document {
+			if value, ok := candidate.(map[string]any); ok && stringFromMap(value, "key") != "" {
+				entry = value
+				break
+			}
+		}
+	}
+	if entry == nil {
+		return bundle, "", nil, nil, time.Time{}, fmt.Errorf("Grok auth file has no OAuth credential")
+	}
+	expiresAt, err := time.Parse(time.RFC3339Nano, stringFromMap(entry, "expires_at"))
+	if err != nil {
+		return bundle, "", nil, nil, time.Time{}, fmt.Errorf("parse Grok credential expiry: %w", err)
+	}
+	return bundle, authFile, document, entry, expiresAt, nil
+}
+
+func encodeManagedGrokAuth(bundle cliAuthBundle, authFile string, document map[string]any) (string, error) {
+	authData, err := json.MarshalIndent(document, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("encode Grok auth file: %w", err)
+	}
+	authData = append(authData, '\n')
+	bundle.Files[authFile] = base64.StdEncoding.EncodeToString(authData)
+	bundleData, err := json.Marshal(bundle)
+	if err != nil {
+		return "", fmt.Errorf("encode Grok auth bundle: %w", err)
+	}
+	return base64.StdEncoding.EncodeToString(bundleData), nil
 }
 
 func (s *Server) runCodexDeviceLogin(ctx context.Context, job *modelAuthLoginJob, authDir string) error {

--- a/pkg/hub/model_auth_test.go
+++ b/pkg/hub/model_auth_test.go
@@ -111,20 +111,99 @@ func TestManagedGrokCredentialSerializesRefreshAndPersistsRotation(t *testing.T)
 	}
 }
 
-func TestManagedModelAuthCredentialRequiresClawAuth(t *testing.T) {
+func TestManagedModelAuthCredentialHasNoHTTPRoute(t *testing.T) {
 	s, _ := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
 	req := httptest.NewRequest(http.MethodPost, "/api/internal/model-auth/credential", nil)
 	rec := httptest.NewRecorder()
 	s.Handler().ServeHTTP(rec, req)
-	if rec.Code != http.StatusUnauthorized {
-		t.Fatalf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNotFound)
 	}
-	req = httptest.NewRequest(http.MethodPost, "/api/internal/model-auth/credential", nil)
-	req.Header.Set("X-Claw-Token", "claw-token")
-	rec = httptest.NewRecorder()
-	s.Handler().ServeHTTP(rec, req)
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("authenticated status = %d, want %d for missing claw identity", rec.Code, http.StatusBadRequest)
+}
+
+func TestModelAuthTokenIsBoundToClawIdentity(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Token: "private-hub-token"}, "", "", "")
+	token := s.modelAuthTokenForClaw("claw-a")
+	if token == "" || !s.validModelAuthToken("claw-a", token) {
+		t.Fatal("derived token did not authenticate its claw")
+	}
+	if s.validModelAuthToken("claw-b", token) {
+		t.Fatal("one claw's model auth token authenticated another claw")
+	}
+}
+
+func TestDecodeManagedGrokAuthRequiresCanonicalCredential(t *testing.T) {
+	authData, err := json.Marshal(map[string]any{
+		"unrelated-a": map[string]any{"refresh_token": "one", "expires_at": time.Now().UTC().Format(time.RFC3339Nano)},
+		"unrelated-b": map[string]any{"refresh_token": "two", "expires_at": time.Now().UTC().Format(time.RFC3339Nano)},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundleData, err := json.Marshal(cliAuthBundle{Files: map[string]string{
+		".grok/auth.json": base64.StdEncoding.EncodeToString(authData),
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, _, _, _, err = decodeManagedGrokAuth(base64.StdEncoding.EncodeToString(bundleData))
+	if err == nil || !strings.Contains(err.Error(), "canonical xAI") {
+		t.Fatalf("error = %v, want missing canonical credential", err)
+	}
+}
+
+func TestManagedGrokCredentialRetainsRotationWhenConfigSaveFails(t *testing.T) {
+	failingPath := t.TempDir()
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", failingPath)
+	profileName := "grok-oauth"
+	cfg := &types.HubConfig{
+		LLMKeys: types.LLMKeysList{
+			{Name: "grok", Provider: "grok", AuthProfile: profileName, Default: true},
+		},
+		ModelAuthProfiles: []*types.ModelAuthProfileConfig{
+			{Name: profileName, Provider: "grok", Mode: "device", AuthState: testGrokAuthState(t, "old-access", "refresh-1", time.Now().Add(-time.Minute))},
+		},
+	}
+	s, db := NewTestServerWithConfig(t, cfg, "", "", "")
+	if _, err := db.Exec(`INSERT INTO claws(id,tenant_id,name,llm_key,status,created_at) VALUES(?,?,?,?,?,datetime('now'))`,
+		"claw-grok", "test-tenant-id", "grok claw", "grok", "connected"); err != nil {
+		t.Fatal(err)
+	}
+
+	var refreshes int
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		refreshes++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"new-access","refresh_token":"refresh-2","expires_in":3600}`))
+	}))
+	defer tokenServer.Close()
+	s.grokTokenEndpoint = tokenServer.URL
+	ctx := context.WithValue(context.Background(), ctxTenantKey{}, "test-tenant-id")
+
+	credential, err := s.managedGrokCredential(ctx, "claw-grok")
+	if err != nil {
+		t.Fatalf("managed credential after save failure: %v", err)
+	}
+	if credential.Access != "new-access" || refreshes != 1 || s.modelAuthPending[profileName] == "" {
+		t.Fatalf("credential=%#v refreshes=%d pending=%t", credential, refreshes, s.modelAuthPending[profileName] != "")
+	}
+
+	validPath := filepath.Join(t.TempDir(), "hub.yaml")
+	if err := os.Setenv("ELASTICCLAW_HUB_CONFIG", validPath); err != nil {
+		t.Fatal(err)
+	}
+	credential, err = s.managedGrokCredential(ctx, "claw-grok")
+	if err != nil {
+		t.Fatalf("managed credential after persistence recovery: %v", err)
+	}
+	if credential.Access != "new-access" || refreshes != 1 {
+		t.Fatalf("credential=%#v refreshes=%d, want retained credential without another refresh", credential, refreshes)
+	}
+	if s.modelAuthPending[profileName] != "" {
+		t.Fatal("pending rotated credential was not cleared after persistence recovered")
+	}
+	if _, err := os.Stat(validPath); err != nil {
+		t.Fatalf("persisted config: %v", err)
 	}
 }
 

--- a/pkg/hub/model_auth_test.go
+++ b/pkg/hub/model_auth_test.go
@@ -1,14 +1,132 @@
 package hub
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
+
+func testGrokAuthState(t *testing.T, access, refresh string, expires time.Time) string {
+	t.Helper()
+	authData, err := json.Marshal(map[string]any{
+		grokAuthIssuer + "::" + grokAuthClientID: map[string]any{
+			"key":           access,
+			"refresh_token": refresh,
+			"expires_at":    expires.UTC().Format(time.RFC3339Nano),
+			"preserved":     "metadata",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundleData, err := json.Marshal(cliAuthBundle{Files: map[string]string{
+		".grok/auth.json": base64.StdEncoding.EncodeToString(authData),
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return base64.StdEncoding.EncodeToString(bundleData)
+}
+
+func TestManagedGrokCredentialSerializesRefreshAndPersistsRotation(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", filepath.Join(t.TempDir(), "hub.yaml"))
+	profileName := "grok-oauth"
+	cfg := &types.HubConfig{
+		ClawToken: "claw-token",
+		LLMKeys: types.LLMKeysList{
+			{Name: "grok", Provider: "grok", AuthProfile: profileName, Default: true},
+		},
+		ModelAuthProfiles: []*types.ModelAuthProfileConfig{
+			{Name: profileName, Provider: "grok", Mode: "device", AuthState: testGrokAuthState(t, "old-access", "refresh-1", time.Now().Add(-time.Minute))},
+		},
+	}
+	s, db := NewTestServerWithConfig(t, cfg, "", "", "")
+	if _, err := db.Exec(`INSERT INTO claws(id,tenant_id,name,llm_key,status,created_at) VALUES(?,?,?,?,?,datetime('now'))`,
+		"claw-grok", "test-tenant-id", "grok claw", "grok", "connected"); err != nil {
+		t.Fatal(err)
+	}
+
+	var mu sync.Mutex
+	var refreshes []string
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("parse refresh form: %v", err)
+		}
+		mu.Lock()
+		refreshes = append(refreshes, r.Form.Get("refresh_token"))
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"new-access","refresh_token":"refresh-2","expires_in":3600}`))
+	}))
+	defer tokenServer.Close()
+	s.grokTokenEndpoint = tokenServer.URL
+
+	ctx := context.WithValue(context.Background(), ctxTenantKey{}, "test-tenant-id")
+	results := make(chan *managedModelAuthCredential, 2)
+	errs := make(chan error, 2)
+	start := make(chan struct{})
+	for range 2 {
+		go func() {
+			<-start
+			credential, err := s.managedGrokCredential(ctx, "claw-grok")
+			results <- credential
+			errs <- err
+		}()
+	}
+	close(start)
+	for range 2 {
+		if err := <-errs; err != nil {
+			t.Fatalf("managed credential: %v", err)
+		}
+		credential := <-results
+		if credential.Access != "new-access" || credential.Provider != "xai" || credential.Expires <= time.Now().UnixMilli() {
+			t.Fatalf("unexpected credential: %#v", credential)
+		}
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(refreshes) != 1 || refreshes[0] != "refresh-1" {
+		t.Fatalf("refresh calls = %#v, want one call with the original token", refreshes)
+	}
+
+	_, _, _, entry, _, err := decodeManagedGrokAuth(s.hubCfg.ModelAuthProfiles[0].AuthState)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := stringFromMap(entry, "refresh_token"); got != "refresh-2" {
+		t.Fatalf("persisted refresh token = %q, want refresh-2", got)
+	}
+	if got := stringFromMap(entry, "preserved"); got != "metadata" {
+		t.Fatalf("unrelated Grok auth metadata was lost: %q", got)
+	}
+}
+
+func TestManagedModelAuthCredentialRequiresClawAuth(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	req := httptest.NewRequest(http.MethodPost, "/api/internal/model-auth/credential", nil)
+	rec := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+	req = httptest.NewRequest(http.MethodPost, "/api/internal/model-auth/credential", nil)
+	req.Header.Set("X-Claw-Token", "claw-token")
+	rec = httptest.NewRecorder()
+	s.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("authenticated status = %d, want %d for missing claw identity", rec.Code, http.StatusBadRequest)
+	}
+}
 
 func TestCaptureModelAuthOutputStripsANSIFromURL(t *testing.T) {
 	s := &Server{}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -88,6 +88,8 @@ type Server struct {
 	fireworksModelsCacheUntil time.Time
 	modelAuthJobsMu           sync.Mutex
 	modelAuthJobs             map[string]*modelAuthLoginJob
+	modelAuthRefreshMu        sync.Mutex
+	grokTokenEndpoint         string // test seam; defaults to the xAI OAuth token endpoint
 	pollWarningMu             sync.Mutex
 	pollWarnings              map[string]struct{}
 
@@ -368,6 +370,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/settings/github/test", s.withWebAdminAuth(s.handleGitHubAppTest))
 	mux.HandleFunc("/api/settings/model-auth/login", s.withWebAdminAuth(s.handleModelAuthLogin))
 	mux.HandleFunc("/api/settings/model-auth/login/{id}", s.withWebAdminAuth(s.handleModelAuthLoginStatus))
+	mux.HandleFunc("/api/internal/model-auth/credential", s.withClawAuth(s.handleManagedModelAuthCredential))
 
 	// Template store
 	mux.HandleFunc("/api/templates", s.withWebAuth(s.handleTemplates))
@@ -509,6 +512,23 @@ func (s *Server) withAuth(next http.HandlerFunc) http.HandlerFunc {
 		}
 		r = r.WithContext(ctx)
 		next(w, r)
+	}
+}
+
+func (s *Server) withClawAuth(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		token := strings.TrimSpace(r.Header.Get("X-Claw-Token"))
+		if token == "" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		tenantID, err := s.tenantByClawToken(token)
+		if err != nil {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		ctx := context.WithValue(r.Context(), ctxTenantKey{}, tenantID)
+		next(w, r.WithContext(ctx))
 	}
 }
 
@@ -2666,7 +2686,8 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 					for k, v := range req.Header {
 						httpReq.Header.Set(k, v)
 					}
-					// Inject claw_token auth so withAuth middleware passes
+					httpReq.Header.Set("X-ElasticClaw-Claw-ID", clawID)
+					// Inject claw-token auth for internal endpoints used by the bridge.
 					s.mu.RLock()
 					clawToken := s.hubCfg.ClawToken
 					s.mu.RUnlock()

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -3,7 +3,9 @@ package hub
 import (
 	"bytes"
 	"context"
+	"crypto/hmac"
 	"crypto/rand"
+	"crypto/sha256"
 	"database/sql"
 	"encoding/base64"
 	"encoding/json"
@@ -89,7 +91,8 @@ type Server struct {
 	modelAuthJobsMu           sync.Mutex
 	modelAuthJobs             map[string]*modelAuthLoginJob
 	modelAuthRefreshMu        sync.Mutex
-	grokTokenEndpoint         string // test seam; defaults to the xAI OAuth token endpoint
+	modelAuthPending          map[string]string // rotated auth state awaiting durable config persistence
+	grokTokenEndpoint         string            // test seam; defaults to the xAI OAuth token endpoint
 	pollWarningMu             sync.Mutex
 	pollWarnings              map[string]struct{}
 
@@ -111,6 +114,23 @@ type Server struct {
 	reaperFirstSeen     map[string]time.Time
 	nowFunc             func() time.Time
 	terminateVMOverride func(provider, id string) error // test seam for terminal cleanup
+}
+
+func (s *Server) modelAuthTokenForClaw(clawID string) string {
+	s.mu.RLock()
+	secret := strings.TrimSpace(s.hubCfg.Token)
+	s.mu.RUnlock()
+	if secret == "" || clawID == "" {
+		return ""
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte("elasticclaw:model-auth:" + clawID))
+	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+}
+
+func (s *Server) validModelAuthToken(clawID, token string) bool {
+	want := s.modelAuthTokenForClaw(clawID)
+	return want != "" && hmac.Equal([]byte(want), []byte(strings.TrimSpace(token)))
 }
 
 type clawConn struct {
@@ -370,7 +390,6 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/settings/github/test", s.withWebAdminAuth(s.handleGitHubAppTest))
 	mux.HandleFunc("/api/settings/model-auth/login", s.withWebAdminAuth(s.handleModelAuthLogin))
 	mux.HandleFunc("/api/settings/model-auth/login/{id}", s.withWebAdminAuth(s.handleModelAuthLoginStatus))
-	mux.HandleFunc("/api/internal/model-auth/credential", s.withClawAuth(s.handleManagedModelAuthCredential))
 
 	// Template store
 	mux.HandleFunc("/api/templates", s.withWebAuth(s.handleTemplates))
@@ -512,23 +531,6 @@ func (s *Server) withAuth(next http.HandlerFunc) http.HandlerFunc {
 		}
 		r = r.WithContext(ctx)
 		next(w, r)
-	}
-}
-
-func (s *Server) withClawAuth(next http.HandlerFunc) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		token := strings.TrimSpace(r.Header.Get("X-Claw-Token"))
-		if token == "" {
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
-			return
-		}
-		tenantID, err := s.tenantByClawToken(token)
-		if err != nil {
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
-			return
-		}
-		ctx := context.WithValue(r.Context(), ctxTenantKey{}, tenantID)
-		next(w, r.WithContext(ctx))
 	}
 }
 
@@ -1157,7 +1159,8 @@ func (s *Server) handleCreateClaw(w http.ResponseWriter, r *http.Request, tenant
 	for k, v := range req.Env {
 		env[k] = v
 	}
-	// Workspace identity is hub-managed and must not be overridden by request env.
+	env["ELASTICCLAW_MODEL_AUTH_TOKEN"] = s.modelAuthTokenForClaw(clawID)
+	// Sensitive identity is hub-managed and must not be overridden by request env.
 	env["ELASTICCLAW_TEMPLATE"] = req.TemplateName
 	for envName, secretRef := range req.SecretRefs {
 		if val, ok := hubSecrets[secretRef]; ok {
@@ -2205,8 +2208,20 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 
 	log.Printf("[bridge] ✓ connected: %s (%s) gateway_ready=%v", rp.Name, clawID[:8], cc.gatewayReady)
 
-	// Ack
-	_ = wsjson.Write(ctx, conn, types.WSMessage{Type: "registered", Payload: map[string]string{"claw_id": clawID}})
+	// Bind managed model credentials to this authenticated WebSocket instead of
+	// accepting a caller-supplied claw ID on a tenant-token HTTP endpoint.
+	ackPayload := map[string]any{"claw_id": clawID}
+	modelAuthAuthorized := s.validModelAuthToken(clawID, rp.ModelAuthToken)
+	if modelAuthAuthorized {
+		credential, credentialErr := s.managedGrokCredential(context.WithValue(ctx, ctxTenantKey{}, tenantID), clawID)
+		if credentialErr == nil {
+			ackPayload["model_auth_credential"] = credential
+		} else if !errors.Is(credentialErr, errManagedGrokNotConfigured) {
+			logModelAuthRefreshError(clawID, credentialErr)
+			ackPayload["model_auth_error"] = "managed model authentication is unavailable"
+		}
+	}
+	_ = wsjson.Write(ctx, conn, types.WSMessage{Type: "registered", Payload: ackPayload})
 
 	// Broadcast initial status to user sessions
 	s.broadcastToUsers(tenantID, types.WSMessage{Type: "claw_status", Payload: map[string]string{"claw_id": clawID, "status": currentStatus}})
@@ -2655,6 +2670,20 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 						}
 					}
 				}
+			} else if msg.Type == "model_auth_sync" {
+				if !modelAuthAuthorized {
+					continue
+				}
+				go func() {
+					credential, err := s.managedGrokCredential(context.WithValue(ctx, ctxTenantKey{}, tenantID), clawID)
+					if err != nil {
+						if !errors.Is(err, errManagedGrokNotConfigured) {
+							logModelAuthRefreshError(clawID, err)
+						}
+						return
+					}
+					_ = wsjson.Write(ctx, conn, types.WSMessage{Type: "model_auth_credential", Payload: credential})
+				}()
 			} else if msg.Type == "http_proxy_req" {
 				// Proxy an HTTP request from the bridge to the hub's internal API.
 				// This allows tools in the sandbox to reach hub APIs without a public URL.
@@ -2686,7 +2715,6 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 					for k, v := range req.Header {
 						httpReq.Header.Set(k, v)
 					}
-					httpReq.Header.Set("X-ElasticClaw-Claw-ID", clawID)
 					// Inject claw-token auth for internal endpoints used by the bridge.
 					s.mu.RLock()
 					clawToken := s.hubCfg.ClawToken
@@ -3654,7 +3682,7 @@ gh auth status`
 	if err := s.db.QueryRow(`SELECT COALESCE(template,'') FROM claws WHERE id=?`, clawID).Scan(&templateName); err != nil {
 		return fmt.Errorf("load claw template: %w", err)
 	}
-	if err := s.startDaytonaBridge(ctx, instanceID, p, s.clawHubURL(), clawID, clawToken, clawName, templateName); err != nil {
+	if err := s.startDaytonaBridge(ctx, instanceID, p, s.clawHubURL(), clawID, clawToken, s.modelAuthTokenForClaw(clawID), clawName, templateName); err != nil {
 		return err
 	}
 
@@ -3692,7 +3720,7 @@ func recordE2EProviderID(label, envName, id string) {
 	}
 }
 
-func (s *Server) startDaytonaBridge(ctx context.Context, instanceID string, p *daytona.Provider, hubURL, clawID, clawToken, clawName, templateName string) error {
+func (s *Server) startDaytonaBridge(ctx context.Context, instanceID string, p *daytona.Provider, hubURL, clawID, clawToken, modelAuthToken, clawName, templateName string) error {
 	prepCmd := daytonaPrepareBridgeCommand()
 	result, err := p.ExecWithTimeout(ctx, instanceID, []string{prepCmd}, 15*time.Second)
 	if err != nil {
@@ -3710,7 +3738,7 @@ func (s *Server) startDaytonaBridge(ctx context.Context, instanceID string, p *d
 	if err := p.EnsureSession(ctx, instanceID, sessionID); err != nil {
 		return fmt.Errorf("start claw-bridge session: %w", err)
 	}
-	cmdID, err := p.ExecSessionAsync(ctx, instanceID, sessionID, daytonaAsyncBridgeCommand(hubURL, clawID, clawToken, clawName, templateName))
+	cmdID, err := p.ExecSessionAsync(ctx, instanceID, sessionID, daytonaAsyncBridgeCommand(hubURL, clawID, clawToken, modelAuthToken, clawName, templateName))
 	if err != nil {
 		return fmt.Errorf("start claw-bridge async: %w", err)
 	}
@@ -3886,7 +3914,7 @@ test -x /usr/local/bin/claw-bridge || { echo "claw-bridge installed at /usr/loca
 rm -f "$PIDFILE"`
 }
 
-func daytonaAsyncBridgeCommand(hubURL, clawID, clawToken, clawName, templateName string) string {
+func daytonaAsyncBridgeCommand(hubURL, clawID, clawToken, modelAuthToken, clawName, templateName string) string {
 	return fmt.Sprintf(`export HOME=/home/daytona
 mkdir -p /home/daytona/.openclaw/workspace /home/daytona/.openclaw/run
 cd /home/daytona/.openclaw/workspace
@@ -3901,7 +3929,7 @@ if pgrep -x claw-bridge >/dev/null 2>&1; then
   exit 0
 fi
 rm -f "$PIDFILE"
-ELASTICCLAW_HUB_URL=%s ELASTICCLAW_CLAW_ID=%s ELASTICCLAW_CLAW_TOKEN=%s ELASTICCLAW_CLAW_NAME=%s ELASTICCLAW_TEMPLATE=%s \
+ELASTICCLAW_HUB_URL=%s ELASTICCLAW_CLAW_ID=%s ELASTICCLAW_CLAW_TOKEN=%s ELASTICCLAW_MODEL_AUTH_TOKEN=%s ELASTICCLAW_CLAW_NAME=%s ELASTICCLAW_TEMPLATE=%s \
 sh -c '
 PIDFILE="$1"
 LOG="$2"
@@ -3943,6 +3971,7 @@ done
 		shellQuote(hubURL),
 		shellQuote(clawID),
 		shellQuote(clawToken),
+		shellQuote(modelAuthToken),
 		shellQuote(clawName),
 		shellQuote(templateName),
 	)
@@ -4445,6 +4474,7 @@ func (s *Server) bootstrapExedev(ctx context.Context, clawID, vmName string, p *
 		ClawID:          clawID,
 		ClawName:        clawName,
 		ClawToken:       clawToken,
+		ModelAuthToken:  s.modelAuthTokenForClaw(clawID),
 		TemplateName:    templateName,
 		HubURL:          s.clawHubURL(),
 		DefaultModel:    defaultModel,
@@ -4556,6 +4586,7 @@ func (s *Server) provisionDocker(ctx context.Context, clawID string, req types.C
 		"ELASTICCLAW_HUB_URL":            dockerClawHubURL(hubCfg),
 		"ELASTICCLAW_CLAW_ID":            clawID,
 		"ELASTICCLAW_CLAW_TOKEN":         clawToken,
+		"ELASTICCLAW_MODEL_AUTH_TOKEN":   s.modelAuthTokenForClaw(clawID),
 		"ELASTICCLAW_CLAW_NAME":          clawName,
 		"ELASTICCLAW_TEMPLATE":           templateName,
 		"ELASTICCLAW_GITHUB_REPOS":       githubReposJSON,
@@ -4794,6 +4825,7 @@ func (s *Server) provisionLambdaMicroVMs(ctx context.Context, clawID string, req
 		"ELASTICCLAW_HUB_URL":            s.clawHubURL(),
 		"ELASTICCLAW_CLAW_ID":            clawID,
 		"ELASTICCLAW_CLAW_TOKEN":         clawToken,
+		"ELASTICCLAW_MODEL_AUTH_TOKEN":   s.modelAuthTokenForClaw(clawID),
 		"ELASTICCLAW_CLAW_NAME":          clawName,
 		"ELASTICCLAW_TEMPLATE":           templateName,
 		"ELASTICCLAW_GITHUB_REPOS":       githubReposJSON,
@@ -5600,6 +5632,7 @@ func (s *Server) bootstrapReplicated(clawID, clawName, vmID string, cfg types.Pr
 		ClawID:          clawID,
 		ClawName:        clawName,
 		ClawToken:       clawToken,
+		ModelAuthToken:  s.modelAuthTokenForClaw(clawID),
 		TemplateName:    templateName,
 		HubURL:          s.clawHubURL(),
 		DefaultModel:    defaultModel,

--- a/pkg/types/hub.go
+++ b/pkg/types/hub.go
@@ -67,12 +67,13 @@ type FileReadResp struct {
 
 // RegisterPayload is sent by a claw on connect.
 type RegisterPayload struct {
-	ClawID       string `json:"claw_id"`
-	Name         string `json:"name"`
-	Template     string `json:"template"`
-	Token        string `json:"token"`                   // hub claw token for auth
-	GatewayReady *bool  `json:"gateway_ready,omitempty"` // true once openclaw gateway session is established; nil means unknown (old bridge, assume ready)
-	Channel      string `json:"channel,omitempty"`       // "status" for status channel, empty for main
+	ClawID         string `json:"claw_id"`
+	Name           string `json:"name"`
+	Template       string `json:"template"`
+	Token          string `json:"token"`                      // hub claw token for auth
+	ModelAuthToken string `json:"model_auth_token,omitempty"` // per-claw proof for managed model credentials
+	GatewayReady   *bool  `json:"gateway_ready,omitempty"`    // true once openclaw gateway session is established; nil means unknown (old bridge, assume ready)
+	Channel        string `json:"channel,omitempty"`          // "status" for status channel, empty for main
 }
 
 // CheckpointCreatePayload asks a connected bridge to prepare a checkpoint.


### PR DESCRIPTION
## Summary

- make the hub the sole owner of xAI's rotating OAuth refresh token
- refresh managed Grok credentials centrally under a mutex before access-token expiry
- synchronize current access tokens into active claws every five minutes
- replace claw-local refresh tokens with an ElasticClaw-managed placeholder
- preserve unrelated OpenClaw and Grok credential metadata during synchronization

## Root cause

xAI rotates its refresh token whenever OpenClaw refreshes an access token. ElasticClaw restored the same saved refresh token into every claw, but local rotations were never written back to the hub. The first refresh therefore revoked the hub snapshot and every other claw's copy, producing `invalid_grant (Refresh token has been revoked)` after the access token expired.

## Implementation

The authenticated internal credential endpoint resolves the claw's configured Grok profile and serializes refresh plus persistence. Claw bridges fetch that managed access token during bootstrap and every five minutes, then update OpenClaw's SQLite auth store transactionally. OpenClaw retains its normal OAuth profile shape, but cannot independently rotate the shared token.

Existing credentials that are already revoked still require one reauthorization after rollout. Subsequent rotation remains hub-managed.

## Verification

- `nix develop -c go test ./...`
- `nix develop -c go vet ./...`
- `nix develop -c go build ./...`
- `nix develop -c make test-bootstrap`
