### PR TITLE
Rework analytics run-status taxonomy and reconcile dead-claw PRs

### DIFF
--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	_ "modernc.org/sqlite" // pure-Go SQLite, no CGO required
@@ -441,7 +442,7 @@ func migrate(db *sql.DB) error {
 		run_id                  TEXT NOT NULL REFERENCES task_runs(id) ON DELETE CASCADE,
 		initial_attempt_id      TEXT NOT NULL DEFAULT '',
 		current_attempt_id      TEXT NOT NULL DEFAULT '',
-		status                  TEXT NOT NULL CHECK(status IN ('running','clean_success','warning_success','failed')),
+		status                  TEXT NOT NULL CHECK(status IN ('running','clean','human_in_the_loop','warning','failed')),
 		phase                   TEXT NOT NULL CHECK(phase IN ('claimed','queued','provisioning','agent_running','pr_opened','waiting_for_merge','terminal')),
 		attempt_count           INTEGER NOT NULL DEFAULT 0 CHECK(attempt_count >= 0),
 		owner_type              TEXT NOT NULL DEFAULT '',
@@ -641,12 +642,18 @@ func migrate(db *sql.DB) error {
 	if err != nil {
 		return err
 	}
+	if err := rebuildTaskRunSummariesStatusV3(db); err != nil {
+		return err
+	}
 	// Backfill rows that predate the usage_day column so cost corrections land
 	// on the day the run's usage was last applied, not on the correction's day.
 	if _, err := db.Exec(`UPDATE task_run_usage SET usage_day = strftime('%Y-%m-%d', updated_at/1000, 'unixepoch') WHERE usage_day = '' AND updated_at > 0`); err != nil {
 		return fmt.Errorf("backfill task_run_usage.usage_day: %w", err)
 	}
 	if err := backfillTaskRunAnalyticsStatusV2(db); err != nil {
+		return err
+	}
+	if err := backfillTaskRunAnalyticsStatusV3(db); err != nil {
 		return err
 	}
 	for _, p := range []struct {
@@ -667,6 +674,47 @@ func migrate(db *sql.DB) error {
 		}
 	}
 	return nil
+}
+
+func rebuildTaskRunSummariesStatusV3(db *sql.DB) error {
+	var schema string
+	if err := db.QueryRow(`SELECT sql FROM sqlite_master WHERE type='table' AND name='task_run_summaries'`).Scan(&schema); err != nil {
+		return fmt.Errorf("read task run summaries schema: %w", err)
+	}
+	if !strings.Contains(schema, "clean_success") {
+		return nil
+	}
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if _, err := tx.Exec(`CREATE TABLE task_run_summaries_new (
+		id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL, run_id TEXT NOT NULL REFERENCES task_runs(id) ON DELETE CASCADE,
+		initial_attempt_id TEXT NOT NULL DEFAULT '', current_attempt_id TEXT NOT NULL DEFAULT '',
+		status TEXT NOT NULL CHECK(status IN ('running','clean','human_in_the_loop','warning','failed')),
+		phase TEXT NOT NULL CHECK(phase IN ('claimed','queued','provisioning','agent_running','pr_opened','waiting_for_merge','terminal')),
+		attempt_count INTEGER NOT NULL DEFAULT 0 CHECK(attempt_count >= 0), owner_type TEXT NOT NULL DEFAULT '', workspace_name TEXT NOT NULL DEFAULT '', workflow_name TEXT NOT NULL DEFAULT '', factory_name TEXT NOT NULL DEFAULT '', owner_id TEXT NOT NULL DEFAULT '', owner_display_name TEXT NOT NULL DEFAULT '', run_kind TEXT NOT NULL DEFAULT 'pr_task' CHECK(run_kind IN ('code_task','pr_task')), integration TEXT NOT NULL DEFAULT '', integration_workspace TEXT NOT NULL DEFAULT '', issue_id TEXT NOT NULL DEFAULT '', issue_title TEXT NOT NULL DEFAULT '', issue_created_at INTEGER NOT NULL DEFAULT 0, claw_id TEXT NOT NULL DEFAULT '', model TEXT NOT NULL DEFAULT '', input_tokens INTEGER NOT NULL DEFAULT 0, output_tokens INTEGER NOT NULL DEFAULT 0, total_tokens INTEGER NOT NULL DEFAULT 0, estimated_cost_usd REAL NOT NULL DEFAULT 0, usage_updated_at INTEGER NOT NULL DEFAULT 0, llm_key TEXT NOT NULL DEFAULT '', repo TEXT NOT NULL DEFAULT '', primary_pr_url TEXT NOT NULL DEFAULT '', pr_count INTEGER NOT NULL DEFAULT 0 CHECK(pr_count >= 0), open_pr_count INTEGER NOT NULL DEFAULT 0 CHECK(open_pr_count >= 0), merged_pr_count INTEGER NOT NULL DEFAULT 0 CHECK(merged_pr_count >= 0), closed_pr_count INTEGER NOT NULL DEFAULT 0 CHECK(closed_pr_count >= 0), warning_types TEXT NOT NULL DEFAULT '[]' CHECK(json_valid(warning_types) AND json_type(warning_types) = 'array'), failure_type TEXT NOT NULL DEFAULT '' CHECK(failure_type IN ('','creation_failed','provision_failed','bootstrap_failed','agent_stopped','manual_stop_before_delivery','done_without_pr','no_pr','pr_closed_unmerged','timeout','provider_lost','permission_or_auth_failed','unknown')), human_interaction_count INTEGER NOT NULL DEFAULT 0 CHECK(human_interaction_count >= 0), started_at INTEGER NOT NULL, queued_at INTEGER NOT NULL DEFAULT 0, provision_started_at INTEGER NOT NULL DEFAULT 0, agent_started_at INTEGER NOT NULL DEFAULT 0, pr_opened_at INTEGER NOT NULL DEFAULT 0, merged_at INTEGER NOT NULL DEFAULT 0, finished_at INTEGER NOT NULL DEFAULT 0, timeout_at INTEGER NOT NULL DEFAULT 0, last_event_at INTEGER NOT NULL, materialized_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, analytics_enabled INTEGER NOT NULL DEFAULT 1 CHECK(analytics_enabled IN (0,1)), requires_pr INTEGER NOT NULL DEFAULT 1 CHECK(requires_pr IN (0,1)), excluded_reason TEXT NOT NULL DEFAULT '', UNIQUE(run_id), UNIQUE(tenant_id, run_id)
+	)`); err != nil {
+		return fmt.Errorf("create task run summaries v3: %w", err)
+	}
+	if _, err := tx.Exec(`INSERT INTO task_run_summaries_new SELECT id, tenant_id, run_id, initial_attempt_id, current_attempt_id, CASE status WHEN 'clean_success' THEN 'clean' WHEN 'warning_success' THEN 'warning' ELSE status END, phase, attempt_count, owner_type, workspace_name, workflow_name, factory_name, owner_id, owner_display_name, run_kind, integration, integration_workspace, issue_id, issue_title, issue_created_at, claw_id, model, input_tokens, output_tokens, total_tokens, estimated_cost_usd, usage_updated_at, llm_key, repo, primary_pr_url, pr_count, open_pr_count, merged_pr_count, closed_pr_count, warning_types, failure_type, human_interaction_count, started_at, queued_at, provision_started_at, agent_started_at, pr_opened_at, merged_at, finished_at, timeout_at, last_event_at, materialized_at, updated_at, analytics_enabled, requires_pr, excluded_reason FROM task_run_summaries`); err != nil {
+		return fmt.Errorf("copy task run summaries v3: %w", err)
+	}
+	if _, err := tx.Exec(`DROP TABLE task_run_summaries; ALTER TABLE task_run_summaries_new RENAME TO task_run_summaries;
+		CREATE INDEX idx_task_run_summaries_status ON task_run_summaries(tenant_id, status, started_at DESC);
+		CREATE INDEX idx_task_run_summaries_owner_started ON task_run_summaries(workspace_name, owner_type, owner_display_name, started_at DESC);
+		CREATE INDEX idx_task_run_summaries_run ON task_run_summaries(run_id);
+		CREATE INDEX idx_task_run_summaries_started_run ON task_run_summaries(tenant_id, started_at DESC, run_id DESC);
+		CREATE INDEX idx_task_run_summaries_workspace ON task_run_summaries(tenant_id, workspace_name, started_at DESC);
+		CREATE INDEX idx_task_run_summaries_workflow ON task_run_summaries(tenant_id, workspace_name, workflow_name, started_at DESC);
+		CREATE INDEX idx_task_run_summaries_factory ON task_run_summaries(tenant_id, factory_name, started_at DESC);
+		CREATE INDEX idx_task_run_summaries_model ON task_run_summaries(tenant_id, model, started_at DESC);
+		CREATE INDEX idx_task_run_summaries_repo ON task_run_summaries(tenant_id, repo, started_at DESC);
+		CREATE INDEX idx_task_run_summaries_timeout ON task_run_summaries(tenant_id, timeout_at)`); err != nil {
+		return fmt.Errorf("replace task run summaries v3: %w", err)
+	}
+	return tx.Commit()
 }
 
 // backfillTaskRunAnalyticsStatusV2 re-materializes existing summaries once so
@@ -718,6 +766,45 @@ func backfillTaskRunAnalyticsStatusV2(db *sql.DB) error {
 		return fmt.Errorf("mark task run analytics status backfill: %w", err)
 	}
 	return nil
+}
+
+func backfillTaskRunAnalyticsStatusV3(db *sql.DB) error {
+	const migration = "task_run_analytics_status_v3"
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS hub_migrations (name TEXT PRIMARY KEY, applied_at INTEGER NOT NULL)`); err != nil {
+		return fmt.Errorf("create hub migrations: %w", err)
+	}
+	var applied int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM hub_migrations WHERE name=?`, migration).Scan(&applied); err != nil {
+		return fmt.Errorf("check task run analytics status backfill: %w", err)
+	}
+	if applied > 0 {
+		return nil
+	}
+	rows, err := db.Query(`SELECT id FROM task_runs ORDER BY created_at, id`)
+	if err != nil {
+		return fmt.Errorf("list task runs for status backfill: %w", err)
+	}
+	var runIDs []string
+	for rows.Next() {
+		var runID string
+		if err := rows.Scan(&runID); err != nil {
+			rows.Close()
+			return err
+		}
+		runIDs = append(runIDs, runID)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return err
+	}
+	rows.Close()
+	for _, runID := range runIDs {
+		if err := backfillTaskRunStatus(db, runID); err != nil {
+			log.Printf("[task-run-analytics] status v3 backfill skipped run %s: %v", runID, err)
+		}
+	}
+	_, err = db.Exec(`INSERT INTO hub_migrations(name, applied_at) VALUES(?, ?) ON CONFLICT(name) DO NOTHING`, migration, now().UnixMilli())
+	return err
 }
 
 // backfillTaskRunStatus re-materializes a single run in its own transaction.

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -798,10 +798,15 @@ func backfillTaskRunAnalyticsStatusV3(db *sql.DB) error {
 		return err
 	}
 	rows.Close()
+	skipped := 0
 	for _, runID := range runIDs {
 		if err := backfillTaskRunStatus(db, runID); err != nil {
+			skipped++
 			log.Printf("[task-run-analytics] status v3 backfill skipped run %s: %v", runID, err)
 		}
+	}
+	if skipped > 0 {
+		log.Printf("[task-run-analytics] status v3 backfill skipped %d of %d run(s)", skipped, len(runIDs))
 	}
 	_, err = db.Exec(`INSERT INTO hub_migrations(name, applied_at) VALUES(?, ?) ON CONFLICT(name) DO NOTHING`, migration, now().UnixMilli())
 	return err

--- a/pkg/hub/db_status_v3_migration_test.go
+++ b/pkg/hub/db_status_v3_migration_test.go
@@ -1,0 +1,89 @@
+package hub
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+func TestRebuildTaskRunSummariesStatusV3MigratesOldSchema(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if _, err := db.Exec(`CREATE TABLE task_runs (id TEXT PRIMARY KEY)`); err != nil {
+		t.Fatal(err)
+	}
+	// This is the pre-v3 table definition: only the status CHECK differs from
+	// the current task_run_summaries schema.
+	if _, err := db.Exec(`CREATE TABLE task_run_summaries (
+		id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL, run_id TEXT NOT NULL REFERENCES task_runs(id) ON DELETE CASCADE,
+		initial_attempt_id TEXT NOT NULL DEFAULT '', current_attempt_id TEXT NOT NULL DEFAULT '',
+		status TEXT NOT NULL CHECK(status IN ('running','clean_success','human_in_the_loop','warning_success','failed')),
+		phase TEXT NOT NULL CHECK(phase IN ('claimed','queued','provisioning','agent_running','pr_opened','waiting_for_merge','terminal')),
+		attempt_count INTEGER NOT NULL DEFAULT 0 CHECK(attempt_count >= 0), owner_type TEXT NOT NULL DEFAULT '', workspace_name TEXT NOT NULL DEFAULT '', workflow_name TEXT NOT NULL DEFAULT '', factory_name TEXT NOT NULL DEFAULT '', owner_id TEXT NOT NULL DEFAULT '', owner_display_name TEXT NOT NULL DEFAULT '', run_kind TEXT NOT NULL DEFAULT 'pr_task' CHECK(run_kind IN ('code_task','pr_task')), integration TEXT NOT NULL DEFAULT '', integration_workspace TEXT NOT NULL DEFAULT '', issue_id TEXT NOT NULL DEFAULT '', issue_title TEXT NOT NULL DEFAULT '', issue_created_at INTEGER NOT NULL DEFAULT 0, claw_id TEXT NOT NULL DEFAULT '', model TEXT NOT NULL DEFAULT '', input_tokens INTEGER NOT NULL DEFAULT 0, output_tokens INTEGER NOT NULL DEFAULT 0, total_tokens INTEGER NOT NULL DEFAULT 0, estimated_cost_usd REAL NOT NULL DEFAULT 0, usage_updated_at INTEGER NOT NULL DEFAULT 0, llm_key TEXT NOT NULL DEFAULT '', repo TEXT NOT NULL DEFAULT '', primary_pr_url TEXT NOT NULL DEFAULT '', pr_count INTEGER NOT NULL DEFAULT 0 CHECK(pr_count >= 0), open_pr_count INTEGER NOT NULL DEFAULT 0 CHECK(open_pr_count >= 0), merged_pr_count INTEGER NOT NULL DEFAULT 0 CHECK(merged_pr_count >= 0), closed_pr_count INTEGER NOT NULL DEFAULT 0 CHECK(closed_pr_count >= 0), warning_types TEXT NOT NULL DEFAULT '[]' CHECK(json_valid(warning_types) AND json_type(warning_types) = 'array'), failure_type TEXT NOT NULL DEFAULT '' CHECK(failure_type IN ('','creation_failed','provision_failed','bootstrap_failed','agent_stopped','manual_stop_before_delivery','done_without_pr','no_pr','pr_closed_unmerged','timeout','provider_lost','permission_or_auth_failed','unknown')), human_interaction_count INTEGER NOT NULL DEFAULT 0 CHECK(human_interaction_count >= 0), started_at INTEGER NOT NULL, queued_at INTEGER NOT NULL DEFAULT 0, provision_started_at INTEGER NOT NULL DEFAULT 0, agent_started_at INTEGER NOT NULL DEFAULT 0, pr_opened_at INTEGER NOT NULL DEFAULT 0, merged_at INTEGER NOT NULL DEFAULT 0, finished_at INTEGER NOT NULL DEFAULT 0, timeout_at INTEGER NOT NULL DEFAULT 0, last_event_at INTEGER NOT NULL, materialized_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, analytics_enabled INTEGER NOT NULL DEFAULT 1 CHECK(analytics_enabled IN (0,1)), requires_pr INTEGER NOT NULL DEFAULT 1 CHECK(requires_pr IN (0,1)), excluded_reason TEXT NOT NULL DEFAULT '', UNIQUE(run_id), UNIQUE(tenant_id, run_id)
+	)`); err != nil {
+		t.Fatal(err)
+	}
+	for _, statement := range []string{
+		`CREATE INDEX idx_task_run_summaries_status ON task_run_summaries(tenant_id, status, started_at DESC)`,
+		`CREATE INDEX idx_task_run_summaries_owner_started ON task_run_summaries(workspace_name, owner_type, owner_display_name, started_at DESC)`,
+		`CREATE INDEX idx_task_run_summaries_run ON task_run_summaries(run_id)`,
+		`CREATE INDEX idx_task_run_summaries_started_run ON task_run_summaries(tenant_id, started_at DESC, run_id DESC)`,
+		`CREATE INDEX idx_task_run_summaries_workspace ON task_run_summaries(tenant_id, workspace_name, started_at DESC)`,
+		`CREATE INDEX idx_task_run_summaries_workflow ON task_run_summaries(tenant_id, workspace_name, workflow_name, started_at DESC)`,
+		`CREATE INDEX idx_task_run_summaries_factory ON task_run_summaries(tenant_id, factory_name, started_at DESC)`,
+		`CREATE INDEX idx_task_run_summaries_model ON task_run_summaries(tenant_id, model, started_at DESC)`,
+		`CREATE INDEX idx_task_run_summaries_repo ON task_run_summaries(tenant_id, repo, started_at DESC)`,
+		`CREATE INDEX idx_task_run_summaries_timeout ON task_run_summaries(tenant_id, timeout_at)`,
+	} {
+		if _, err := db.Exec(statement); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	statuses := []struct{ old, want string }{{"running", "running"}, {"clean_success", "clean"}, {"human_in_the_loop", "human_in_the_loop"}, {"warning_success", "warning"}, {"failed", "failed"}}
+	for i, tc := range statuses {
+		runID := "run-" + tc.old
+		if _, err := db.Exec(`INSERT INTO task_runs(id) VALUES(?)`, runID); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := db.Exec(`INSERT INTO task_run_summaries(id, tenant_id, run_id, status, phase, input_tokens, output_tokens, total_tokens, estimated_cost_usd, usage_updated_at, started_at, last_event_at, materialized_at, updated_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)`, "summary-"+tc.old, "tenant", runID, tc.old, "claimed", i+1, i+11, i+21, float64(i)+0.25, i+31, i+41, i+51, i+61, i+71); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := rebuildTaskRunSummariesStatusV3(db); err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+	var schema string
+	if err := db.QueryRow(`SELECT sql FROM sqlite_master WHERE type='table' AND name='task_run_summaries'`).Scan(&schema); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(schema, "'running','clean','human_in_the_loop','warning','failed'") || strings.Contains(schema, "clean_success") || strings.Contains(schema, "warning_success") {
+		t.Fatalf("unexpected rebuilt schema: %s", schema)
+	}
+	for i, tc := range statuses {
+		var status string
+		var input, output, total, usageUpdated int
+		var cost float64
+		if err := db.QueryRow(`SELECT status, input_tokens, output_tokens, total_tokens, estimated_cost_usd, usage_updated_at FROM task_run_summaries WHERE run_id=?`, "run-"+tc.old).Scan(&status, &input, &output, &total, &cost, &usageUpdated); err != nil {
+			t.Fatal(err)
+		}
+		if status != tc.want || input != i+1 || output != i+11 || total != i+21 || cost != float64(i)+0.25 || usageUpdated != i+31 {
+			t.Fatalf("row %s changed: status=%q input=%d output=%d total=%d cost=%v usage_updated_at=%d", tc.old, status, input, output, total, cost, usageUpdated)
+		}
+	}
+	for _, name := range []string{"idx_task_run_summaries_status", "idx_task_run_summaries_owner_started", "idx_task_run_summaries_run", "idx_task_run_summaries_started_run", "idx_task_run_summaries_workspace", "idx_task_run_summaries_workflow", "idx_task_run_summaries_factory", "idx_task_run_summaries_model", "idx_task_run_summaries_repo", "idx_task_run_summaries_timeout"} {
+		var count int
+		if err := db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND tbl_name='task_run_summaries' AND name=?`, name).Scan(&count); err != nil || count != 1 {
+			t.Fatalf("index %s count=%d err=%v", name, count, err)
+		}
+	}
+	if err := rebuildTaskRunSummariesStatusV3(db); err != nil {
+		t.Fatalf("idempotent rebuild: %v", err)
+	}
+}

--- a/pkg/hub/github_webhook.go
+++ b/pkg/hub/github_webhook.go
@@ -250,7 +250,7 @@ func (s *Server) processGitHubPREvent(payload githubPRPayload) {
 				if _, runID, _, ok, err := s.taskRunContextForClaw(existingClawID); err == nil && ok {
 					at := parseRFC3339Timestamp(payload.PullRequest.MergedAt)
 					if !payload.PullRequest.Merged {
-						at = time.Time{}
+						at = parseRFC3339Timestamp(payload.PullRequest.ClosedAt)
 					}
 					_ = s.associateTaskRunPR(TaskRunPR{RunID: runID, Repo: repoFullName, PRNumber: payload.Number, URL: payload.PullRequest.HTMLURL, State: taskRunPRStateClosed, Merged: payload.PullRequest.Merged, OccurredAt: at})
 				}
@@ -297,7 +297,7 @@ func (s *Server) processGitHubPREvent(payload githubPRPayload) {
 			if runID, ok := s.findOpenTaskRunPR(repoFullName, payload.Number); ok {
 				at := parseRFC3339Timestamp(payload.PullRequest.MergedAt)
 				if !payload.PullRequest.Merged {
-					at = time.Time{}
+					at = parseRFC3339Timestamp(payload.PullRequest.ClosedAt)
 				}
 				if err := s.associateTaskRunPR(TaskRunPR{RunID: runID, Repo: repoFullName, PRNumber: payload.Number, URL: payload.PullRequest.HTMLURL, State: taskRunPRStateClosed, Merged: payload.PullRequest.Merged, OccurredAt: at}); err != nil {
 					log.Printf("[github-webhook] failed to record dead-claw PR outcome for run %s, %s#%d: %v", runID, repoFullName, payload.Number, err)

--- a/pkg/hub/github_webhook.go
+++ b/pkg/hub/github_webhook.go
@@ -190,18 +190,6 @@ func (s *Server) processGitHubPREvent(payload githubPRPayload) {
 
 	repoFullName := payload.Repository.FullName
 	log.Printf("[github-webhook] processing PR event: repo=%q action=%q — checking %d factories", repoFullName, payload.Action, len(factories))
-	if payload.Action == "closed" {
-		if runID, ok := s.findOpenTaskRunPR(repoFullName, payload.Number); ok {
-			atValue := payload.PullRequest.ClosedAt
-			if payload.PullRequest.Merged {
-				atValue = payload.PullRequest.MergedAt
-			}
-			if err := s.associateTaskRunPR(TaskRunPR{RunID: runID, Repo: repoFullName, PRNumber: payload.Number, URL: payload.PullRequest.HTMLURL, State: taskRunPRStateClosed, Merged: payload.PullRequest.Merged, OccurredAt: parseRFC3339Timestamp(atValue)}); err != nil {
-				log.Printf("[github-webhook] failed to record closed PR outcome for run %s, %s#%d: %v", runID, repoFullName, payload.Number, err)
-			}
-			return
-		}
-	}
 
 	for _, factory := range factories {
 		if factory.Integration != "github" {
@@ -338,7 +326,7 @@ func (s *Server) processGitHubPREvent(payload githubPRPayload) {
 // task runs after the claw has been deleted, errored, or gone offline.
 func (s *Server) findOpenTaskRunPR(repo string, prNumber int) (runID string, ok bool) {
 	err := s.db.QueryRow(
-		`SELECT run_id FROM task_run_prs WHERE repo = ? AND pr_number = ? AND state = 'open' LIMIT 1`,
+		`SELECT run_id FROM task_run_prs WHERE repo = ? AND pr_number = ? AND state = 'open' ORDER BY opened_at DESC LIMIT 1`,
 		repo, prNumber,
 	).Scan(&runID)
 	if err != nil {

--- a/pkg/hub/github_webhook.go
+++ b/pkg/hub/github_webhook.go
@@ -33,6 +33,7 @@ type githubPRPayload struct {
 		Title     string `json:"title"`
 		CreatedAt string `json:"created_at"`
 		MergedAt  string `json:"merged_at"`
+		ClosedAt  string `json:"closed_at"`
 		Merged    bool   `json:"merged"`
 		User      struct {
 			Login string `json:"login"`
@@ -189,6 +190,18 @@ func (s *Server) processGitHubPREvent(payload githubPRPayload) {
 
 	repoFullName := payload.Repository.FullName
 	log.Printf("[github-webhook] processing PR event: repo=%q action=%q — checking %d factories", repoFullName, payload.Action, len(factories))
+	if payload.Action == "closed" {
+		if runID, ok := s.findOpenTaskRunPR(repoFullName, payload.Number); ok {
+			atValue := payload.PullRequest.ClosedAt
+			if payload.PullRequest.Merged {
+				atValue = payload.PullRequest.MergedAt
+			}
+			if err := s.associateTaskRunPR(TaskRunPR{RunID: runID, Repo: repoFullName, PRNumber: payload.Number, URL: payload.PullRequest.HTMLURL, State: taskRunPRStateClosed, Merged: payload.PullRequest.Merged, OccurredAt: parseRFC3339Timestamp(atValue)}); err != nil {
+				log.Printf("[github-webhook] failed to record closed PR outcome for run %s, %s#%d: %v", runID, repoFullName, payload.Number, err)
+			}
+			return
+		}
+	}
 
 	for _, factory := range factories {
 		if factory.Integration != "github" {

--- a/pkg/hub/github_webhook.go
+++ b/pkg/hub/github_webhook.go
@@ -289,6 +289,24 @@ func (s *Server) processGitHubPREvent(payload githubPRPayload) {
 			continue
 		}
 
+		// A closed PR may belong to a claw that has already been deleted,
+		// errored, or gone offline. Such claws are intentionally excluded by
+		// findClawForGitHubPR, but its task-run PR outcome still needs recording.
+		if payload.Action == "closed" {
+			if runID, ok := s.findOpenTaskRunPR(repoFullName, payload.Number); ok {
+				at := parseRFC3339Timestamp(payload.PullRequest.MergedAt)
+				if !payload.PullRequest.Merged {
+					at = time.Time{}
+				}
+				if err := s.associateTaskRunPR(TaskRunPR{RunID: runID, Repo: repoFullName, PRNumber: payload.Number, URL: payload.PullRequest.HTMLURL, State: taskRunPRStateClosed, Merged: payload.PullRequest.Merged, OccurredAt: at}); err != nil {
+					log.Printf("[github-webhook] failed to record dead-claw PR outcome for run %s, %s#%d: %v", runID, repoFullName, payload.Number, err)
+				} else {
+					log.Printf("[github-webhook] recorded closed PR outcome for dead-claw run %s, %s#%d (merged=%v)", runID, repoFullName, payload.Number, payload.PullRequest.Merged)
+				}
+				continue
+			}
+		}
+
 		// No existing claw — create one (regardless of action, first event wins)
 		log.Printf("[factory:%s] github PR #%d in %s (action=%s) — creating claw", factory.Name, payload.Number, repoFullName, payload.Action)
 		if err := s.createClawForGitHubPR(factory, payload, "github-pr webhook"); err != nil {
@@ -300,6 +318,20 @@ func (s *Server) processGitHubPREvent(payload githubPRPayload) {
 				payload.PullRequest.Title, "", payload.Action, "error", "", err.Error())
 		}
 	}
+}
+
+// findOpenTaskRunPR returns the run ID of an open task-run PR regardless of
+// whether its backing claw is still alive. This lets closed PR webhooks update
+// task runs after the claw has been deleted, errored, or gone offline.
+func (s *Server) findOpenTaskRunPR(repo string, prNumber int) (runID string, ok bool) {
+	err := s.db.QueryRow(
+		`SELECT run_id FROM task_run_prs WHERE repo = ? AND pr_number = ? AND state = 'open' LIMIT 1`,
+		repo, prNumber,
+	).Scan(&runID)
+	if err != nil {
+		return "", false
+	}
+	return runID, runID != ""
 }
 
 // githubPRReviewCommentPayload holds fields from a pull_request_review_comment webhook event.

--- a/pkg/hub/github_webhook_human_push_test.go
+++ b/pkg/hub/github_webhook_human_push_test.go
@@ -191,7 +191,10 @@ func closedPRPayload(merged bool) githubPRPayload {
 	payload.Repository.FullName = "elastic/claw"
 	payload.PullRequest.HTMLURL = "https://github.com/elastic/claw/pull/21"
 	payload.PullRequest.Merged = merged
-	payload.PullRequest.MergedAt = "2026-01-01T00:00:00Z"
+	if merged {
+		payload.PullRequest.MergedAt = "2026-01-01T00:00:00Z"
+	}
+	payload.PullRequest.ClosedAt = "2026-01-01T00:00:00Z"
 	return payload
 }
 
@@ -219,6 +222,34 @@ func TestGitHubWebhookClosedPRFallbackUpdatesDeadClawRunWithoutCreatingClaw(t *t
 	}
 	if claws != 0 {
 		t.Fatalf("created %d claws for closed dead-claw PR, want none", claws)
+	}
+}
+
+func TestGitHubWebhookClosedUnmergedPRRecordsPayloadClosedAt(t *testing.T) {
+	factory := taskRunLifecycleFactoryConfig("pr-factory", "github")
+	factory.Repos = []string{"elastic/claw"}
+	factory.Trigger = &types.GitHubTrigger{On: "pull_request"}
+	s, db := newTaskRunLifecycleTestServer(t, []*types.FactoryConfig{factory})
+	if _, err := db.Exec(`
+		INSERT INTO claws(id, tenant_id, name, template, status, created_at)
+		VALUES(?,?,?,?,?,?)`, "deleted-claw", "test-tenant-id", "deleted-claw", "elasticclaw", "running", now()); err != nil {
+		t.Fatalf("insert claw: %v", err)
+	}
+	runID, _ := startTaskRunForTest(t, s, "deleted-claw", "dead-webhook-unmerged")
+	associatePRForTest(t, s, runID, "elastic/claw", 21, taskRunPRStateOpen)
+	if _, err := db.Exec(`DELETE FROM claws WHERE id=?`, "deleted-claw"); err != nil {
+		t.Fatalf("delete claw: %v", err)
+	}
+
+	payload := closedPRPayload(false)
+	s.processGitHubPREvent(payload)
+	var closedAt int64
+	if err := db.QueryRow(`SELECT closed_at FROM task_run_prs WHERE run_id=? AND repo=? AND pr_number=?`, runID, "elastic/claw", 21).Scan(&closedAt); err != nil {
+		t.Fatal(err)
+	}
+	want := epochMillis(parseRFC3339Timestamp(payload.PullRequest.ClosedAt))
+	if closedAt != want {
+		t.Fatalf("closed_at=%d, want payload closed_at %d", closedAt, want)
 	}
 }
 

--- a/pkg/hub/github_webhook_human_push_test.go
+++ b/pkg/hub/github_webhook_human_push_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
@@ -182,5 +183,92 @@ func TestGitHubWebhookAndPollerDedupHumanPush(t *testing.T) {
 
 	if got := humanPushEventCount(t, db, runID); got != 1 {
 		t.Fatalf("expected 1 human_manual_code_push event across webhook and poller, got %d", got)
+	}
+}
+
+func closedPRPayload(merged bool) githubPRPayload {
+	payload := githubPRPayload{Action: "closed", Number: 21}
+	payload.Repository.FullName = "elastic/claw"
+	payload.PullRequest.HTMLURL = "https://github.com/elastic/claw/pull/21"
+	payload.PullRequest.Merged = merged
+	payload.PullRequest.MergedAt = "2026-01-01T00:00:00Z"
+	return payload
+}
+
+func TestGitHubWebhookClosedPRFallbackUpdatesDeadClawRunWithoutCreatingClaw(t *testing.T) {
+	factory := taskRunLifecycleFactoryConfig("pr-factory", "github")
+	factory.Repos = []string{"elastic/claw"}
+	factory.Trigger = &types.GitHubTrigger{On: "pull_request"}
+	s, db := newTaskRunLifecycleTestServer(t, []*types.FactoryConfig{factory})
+	if _, err := db.Exec(`
+		INSERT INTO claws(id, tenant_id, name, template, status, created_at)
+		VALUES(?,?,?,?,?,?)`, "deleted-claw", "test-tenant-id", "deleted-claw", "elasticclaw", "running", now()); err != nil {
+		t.Fatalf("insert claw: %v", err)
+	}
+	runID, _ := startTaskRunForTest(t, s, "deleted-claw", "dead-webhook")
+	associatePRForTest(t, s, runID, "elastic/claw", 21, taskRunPRStateOpen)
+	if _, err := db.Exec(`DELETE FROM claws WHERE id=?`, "deleted-claw"); err != nil {
+		t.Fatalf("delete claw: %v", err)
+	}
+
+	s.processGitHubPREvent(closedPRPayload(true))
+	assertTaskRunSummary(t, db, runID, taskRunStatusClean, taskRunPhaseTerminal, "", "[]", 0, 1, 0, 1, 0)
+	var claws int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM claws`).Scan(&claws); err != nil {
+		t.Fatal(err)
+	}
+	if claws != 0 {
+		t.Fatalf("created %d claws for closed dead-claw PR, want none", claws)
+	}
+}
+
+func TestGitHubWebhookClosedPRUsesLiveClawRunInsteadOfStaleRow(t *testing.T) {
+	s, db, liveRunID, _ := newWebhookHumanPushTestRun(t, "", "claw-live-closed", "agent-sha")
+	if _, err := db.Exec(`
+		INSERT INTO claws(id, tenant_id, name, template, status, created_at)
+		VALUES(?,?,?,?,?,?)`, "claw-stale-closed", "test-tenant-id", "claw-stale-closed", "elasticclaw", "running", now()); err != nil {
+		t.Fatalf("insert claw: %v", err)
+	}
+	staleRunID, _ := startTaskRunForTest(t, s, "claw-stale-closed", "stale-closed")
+	associatePRForTest(t, s, staleRunID, "elastic/claw", 21, taskRunPRStateOpen)
+	// Make the stale row the one the removed unordered early intercept could
+	// select. The live claw path must still close only its own task run.
+	if _, err := db.Exec(`UPDATE task_run_prs SET opened_at=? WHERE run_id=?`, epochMillis(now().Add(time.Hour)), staleRunID); err != nil {
+		t.Fatal(err)
+	}
+
+	s.processGitHubPREvent(closedPRPayload(true))
+	assertTaskRunSummary(t, db, liveRunID, taskRunStatusClean, taskRunPhaseTerminal, "", "[]", 0, 1, 0, 1, 0)
+	var staleStatus string
+	if err := db.QueryRow(`SELECT status FROM task_run_summaries WHERE run_id=?`, staleRunID).Scan(&staleStatus); err != nil {
+		t.Fatal(err)
+	}
+	if staleStatus != taskRunStatusRunning {
+		t.Fatalf("stale run status=%q, want running", staleStatus)
+	}
+}
+
+func TestFindOpenTaskRunPRPrefersMostRecentlyOpenedRow(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{}, "", "", "")
+	for _, clawID := range []string{"claw-old-pr", "claw-new-pr"} {
+		if _, err := db.Exec(`
+			INSERT INTO claws(id, tenant_id, name, template, status, created_at)
+			VALUES(?,?,?,?,?,?)`, clawID, "test-tenant-id", clawID, "elasticclaw", "running", now()); err != nil {
+			t.Fatalf("insert claw: %v", err)
+		}
+	}
+	olderRunID, _ := startTaskRunForTest(t, s, "claw-old-pr", "old-pr")
+	newerRunID, _ := startTaskRunForTest(t, s, "claw-new-pr", "new-pr")
+	associatePRForTest(t, s, olderRunID, "elastic/claw", 21, taskRunPRStateOpen)
+	associatePRForTest(t, s, newerRunID, "elastic/claw", 21, taskRunPRStateOpen)
+	if _, err := db.Exec(`UPDATE task_run_prs SET opened_at=? WHERE run_id=?`, epochMillis(now().Add(-time.Hour)), olderRunID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`UPDATE task_run_prs SET opened_at=? WHERE run_id=?`, epochMillis(now()), newerRunID); err != nil {
+		t.Fatal(err)
+	}
+	got, ok := s.findOpenTaskRunPR("elastic/claw", 21)
+	if !ok || got != newerRunID {
+		t.Fatalf("findOpenTaskRunPR = (%q, %v), want (%q, true)", got, ok, newerRunID)
 	}
 }

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -181,10 +181,92 @@ func (s *Server) startPRWatcher() {
 	go func() {
 		ticker := time.NewTicker(10 * time.Second)
 		defer ticker.Stop()
-		for range ticker.C {
-			s.pollAllPRs()
+		reconcileTicker := time.NewTicker(5 * time.Minute)
+		defer reconcileTicker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				s.pollAllPRs()
+			case <-reconcileTicker.C:
+				s.reconcileDeadClawPRs()
+			}
 		}
 	}()
+}
+
+// reconcileDeadClawPRs closes out task_run_prs rows left open because their
+// backing claw died before the PR's merge/close was observed. It only queries
+// and updates task-run state; it never touches claws or injects into agents.
+func (s *Server) reconcileDeadClawPRs() {
+	rows, err := s.db.Query(`
+		SELECT trp.run_id, trp.repo, trp.pr_number, trp.pr_url
+		FROM task_run_prs trp
+		JOIN task_runs tr ON tr.id = trp.run_id
+		LEFT JOIN claws cl ON cl.id = tr.claw_id
+		WHERE trp.state = 'open'
+		  AND (cl.id IS NULL OR cl.status IN ('deleted','error','offline'))
+	`)
+	if err != nil {
+		if strings.Contains(err.Error(), "database is closed") {
+			return
+		}
+		log.Printf("[pr-reconciler] query error: %v", err)
+		return
+	}
+	type openPR struct {
+		runID, repo, url string
+		prNumber         int
+	}
+	var prs []openPR
+	for rows.Next() {
+		var p openPR
+		if err := rows.Scan(&p.runID, &p.repo, &p.prNumber, &p.url); err != nil {
+			continue
+		}
+		prs = append(prs, p)
+	}
+	rows.Close()
+	if len(prs) == 0 {
+		return
+	}
+	token := s.resolveGitHubToken()
+	if token == "" {
+		return
+	}
+	for _, p := range prs {
+		repoToken := s.resolveGitHubTokenForRepo(p.repo)
+		if repoToken == "" {
+			repoToken = token
+		}
+		data, err := githubAPI(fmt.Sprintf("repos/%s/pulls/%d", p.repo, p.prNumber), repoToken)
+		if err != nil {
+			log.Printf("[pr-reconciler] fetch PR %s#%d failed: %v", p.repo, p.prNumber, err)
+			continue
+		}
+		state, _ := data["state"].(string)
+		merged, _ := data["merged"].(bool)
+		if state != "closed" && !merged {
+			continue
+		}
+		mergedAtValue, _ := data["merged_at"].(string)
+		at := parseRFC3339Timestamp(mergedAtValue)
+		if !merged {
+			at = time.Time{}
+		}
+		if err := s.associateTaskRunPR(TaskRunPR{
+			RunID:      p.runID,
+			Repo:       p.repo,
+			PRNumber:   p.prNumber,
+			URL:        p.url,
+			State:      taskRunPRStateClosed,
+			Merged:     merged,
+			OccurredAt: at,
+		}); err != nil {
+			log.Printf("[pr-reconciler] failed to reconcile run %s PR %s#%d: %v", p.runID, p.repo, p.prNumber, err)
+		} else {
+			log.Printf("[pr-reconciler] reconciled dead-claw PR %s#%d for run %s (merged=%v)", p.repo, p.prNumber, p.runID, merged)
+		}
+	}
 }
 
 type clawPR struct {

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -201,11 +201,16 @@ func (s *Server) reconcileDeadClawPRs() {
 	rows, err := s.db.Query(`
 		SELECT trp.run_id, trp.repo, trp.pr_number, trp.pr_url
 		FROM task_run_prs trp
-		JOIN task_runs tr ON tr.id = trp.run_id
-		LEFT JOIN claws cl ON cl.id = tr.claw_id
+		JOIN task_run_summaries trs ON trs.run_id = trp.run_id
 		WHERE trp.state = 'open'
-		  AND (cl.id IS NULL OR cl.status IN ('deleted','error','offline'))
-	`)
+		  AND trs.status = 'running'
+		  AND trs.analytics_enabled = 1
+		  AND trp.opened_at > ?
+		  AND NOT EXISTS (
+			SELECT 1 FROM claw_prs cp JOIN claws cl ON cl.id = cp.claw_id
+			WHERE cp.repo = trp.repo AND cp.pr_number = trp.pr_number
+			  AND cl.status NOT IN ('deleted','error','offline')
+		  )`, epochMillis(now().Add(-90*24*time.Hour)))
 	if err != nil {
 		if strings.Contains(err.Error(), "database is closed") {
 			return
@@ -238,7 +243,11 @@ func (s *Server) reconcileDeadClawPRs() {
 		if repoToken == "" {
 			repoToken = token
 		}
-		data, err := githubAPI(fmt.Sprintf("repos/%s/pulls/%d", p.repo, p.prNumber), repoToken)
+		ghBase := s.githubBaseURL
+		if ghBase == "" {
+			ghBase = "https://api.github.com"
+		}
+		data, err := githubAPIWithBase(ghBase, fmt.Sprintf("repos/%s/pulls/%d", p.repo, p.prNumber), repoToken)
 		if err != nil {
 			log.Printf("[pr-reconciler] fetch PR %s#%d failed: %v", p.repo, p.prNumber, err)
 			continue
@@ -248,11 +257,11 @@ func (s *Server) reconcileDeadClawPRs() {
 		if state != "closed" && !merged {
 			continue
 		}
-		mergedAtValue, _ := data["merged_at"].(string)
-		at := parseRFC3339Timestamp(mergedAtValue)
+		atValue, _ := data["merged_at"].(string)
 		if !merged {
-			at = time.Time{}
+			atValue, _ = data["closed_at"].(string)
 		}
+		at := parseRFC3339Timestamp(atValue)
 		if err := s.associateTaskRunPR(TaskRunPR{
 			RunID:      p.runID,
 			Repo:       p.repo,

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -205,7 +205,7 @@ func (s *Server) reconcileDeadClawPRs() {
 		WHERE trp.state = 'open'
 		  AND trs.status = 'running'
 		  AND trs.analytics_enabled = 1
-		  AND trp.opened_at > ?
+		  AND (trp.opened_at = 0 OR trp.opened_at > ?)
 		  AND NOT EXISTS (
 			SELECT 1 FROM claw_prs cp JOIN claws cl ON cl.id = cp.claw_id
 			WHERE cp.repo = trp.repo AND cp.pr_number = trp.pr_number
@@ -234,14 +234,15 @@ func (s *Server) reconcileDeadClawPRs() {
 	if len(prs) == 0 {
 		return
 	}
-	token := s.resolveGitHubToken()
-	if token == "" {
-		return
-	}
+	globalToken := s.resolveGitHubToken()
 	for _, p := range prs {
 		repoToken := s.resolveGitHubTokenForRepo(p.repo)
 		if repoToken == "" {
-			repoToken = token
+			repoToken = globalToken
+		}
+		if repoToken == "" {
+			log.Printf("[pr-reconciler] no token available for %s, skipping run %s", p.repo, p.runID)
+			continue
 		}
 		ghBase := s.githubBaseURL
 		if ghBase == "" {

--- a/pkg/hub/pr_watcher_test.go
+++ b/pkg/hub/pr_watcher_test.go
@@ -1,7 +1,14 @@
 package hub
 
 import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
 	"database/sql"
+	"encoding/json"
+	"encoding/pem"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -13,6 +20,92 @@ import (
 	"github.com/elasticclaw/elasticclaw/pkg/hub/pipeline"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
+
+// githubAppTokenTransport supplies GitHub App installation tokens without
+// reaching api.github.com. It deliberately rejects unscoped token requests so
+// reconciliation tests prove that the repo-scoped lookup is used.
+type githubAppTokenTransport struct{ base http.RoundTripper }
+
+func (t githubAppTokenTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	if r.URL.Host != "api.github.com" {
+		return t.base.RoundTrip(r)
+	}
+	var body []byte
+	if r.Body != nil {
+		body, _ = io.ReadAll(r.Body)
+	}
+	if r.Method == http.MethodGet && r.URL.Path == "/app/installations" {
+		return githubAppTokenResponse(http.StatusOK, `[{"id":1,"account":{"login":"owner"}}]`), nil
+	}
+	if r.Method == http.MethodPost && r.URL.Path == "/app/installations/1/access_tokens" {
+		if bytes.Contains(body, []byte(`"repositories"`)) {
+			return githubAppTokenResponse(http.StatusCreated, `{"token":"repo-token","expires_at":"2030-01-01T00:00:00Z"}`), nil
+		}
+		return githubAppTokenResponse(http.StatusForbidden, `{"message":"unscoped token unavailable"}`), nil
+	}
+	return githubAppTokenResponse(http.StatusNotFound, `{"message":"not found"}`), nil
+}
+
+func githubAppTokenResponse(status int, body string) *http.Response {
+	return &http.Response{StatusCode: status, Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header)}
+}
+
+func testGitHubAppPEM(t *testing.T) string {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}))
+}
+
+func TestReconcileDeadClawPRsClosesRunsWithRepoTokenAndZeroOpenedAt(t *testing.T) {
+	oldTransport := http.DefaultTransport
+	http.DefaultTransport = githubAppTokenTransport{base: oldTransport}
+	t.Cleanup(func() { http.DefaultTransport = oldTransport })
+
+	gh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer repo-token" {
+			t.Fatalf("authorization = %q, want repo token", r.Header.Get("Authorization"))
+		}
+		if strings.HasSuffix(r.URL.Path, "/pulls/1") {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"state": "closed", "merged": true, "merged_at": "2026-01-01T00:00:00Z"})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"state": "closed", "merged": false, "closed_at": "2026-01-01T00:00:00Z"})
+	}))
+	defer gh.Close()
+
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{GitHubApps: []*types.GitHubAppConfig{{AppID: 1, PrivateKeyPEM: testGitHubAppPEM(t)}}}, gh.URL, "", "")
+	for _, tc := range []struct {
+		claw, key string
+		number    int
+	}{{"dead-merged", "merged", 1}, {"dead-closed", "closed", 2}} {
+		if _, err := db.Exec(`
+			INSERT INTO claws(id, tenant_id, name, template, status, created_at)
+			VALUES(?,?,?,?,?,?)`, tc.claw, "test-tenant-id", tc.claw, "elasticclaw", "running", now()); err != nil {
+			t.Fatal(err)
+		}
+		runID, _ := startTaskRunForTest(t, s, tc.claw, tc.key)
+		associatePRForTest(t, s, runID, "owner/repo", tc.number, taskRunPRStateOpen)
+		if tc.number == 1 {
+			if _, err := db.Exec(`UPDATE task_run_prs SET opened_at=0 WHERE run_id=?`, runID); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	s.reconcileDeadClawPRs()
+	for _, tc := range []struct{ key, want string }{{"merged", taskRunStatusClean}, {"closed", taskRunStatusClean}} {
+		var status string
+		if err := db.QueryRow(`SELECT status FROM task_run_summaries WHERE factory_name=?`, "factory-"+tc.key).Scan(&status); err != nil {
+			t.Fatal(err)
+		}
+		if status != tc.want {
+			t.Fatalf("%s status=%q, want %q", tc.key, status, tc.want)
+		}
+	}
+}
 
 func insertWatcherTestPR(t *testing.T, db *sql.DB, clawID, prID string) {
 	t.Helper()

--- a/pkg/hub/pr_watcher_test.go
+++ b/pkg/hub/pr_watcher_test.go
@@ -107,6 +107,67 @@ func TestReconcileDeadClawPRsClosesRunsWithRepoTokenAndZeroOpenedAt(t *testing.T
 	}
 }
 
+func TestReconcileDeadClawPRsClosesUnmergedPRSetsSuccessStatus(t *testing.T) {
+	oldTransport := http.DefaultTransport
+	http.DefaultTransport = githubAppTokenTransport{base: oldTransport}
+	t.Cleanup(func() { http.DefaultTransport = oldTransport })
+
+	gh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer repo-token" {
+			t.Fatalf("authorization = %q, want repo token", r.Header.Get("Authorization"))
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"state": "closed", "merged": false, "closed_at": "2026-01-01T00:00:00Z"})
+	}))
+	defer gh.Close()
+
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{GitHubApps: []*types.GitHubAppConfig{{AppID: 1, PrivateKeyPEM: testGitHubAppPEM(t)}}}, gh.URL, "", "")
+	if _, err := db.Exec(`INSERT INTO claws(id, tenant_id, name, template, status, created_at) VALUES(?,?,?,?,?,?)`, "dead-unmerged", "test-tenant-id", "dead-unmerged", "elasticclaw", "running", now()); err != nil {
+		t.Fatal(err)
+	}
+	runID, _ := startTaskRunForTest(t, s, "dead-unmerged", "unmerged")
+	associatePRForTest(t, s, runID, "owner/repo", 3, taskRunPRStateOpen)
+
+	s.reconcileDeadClawPRs()
+	assertTaskRunSummary(t, db, runID, taskRunStatusClean, taskRunPhaseTerminal, "", `["pr_closed_unmerged"]`, 0, 1, 0, 0, 1)
+	var closedAt int64
+	if err := db.QueryRow(`SELECT closed_at FROM task_run_prs WHERE run_id=? AND repo=? AND pr_number=?`, runID, "owner/repo", 3).Scan(&closedAt); err != nil {
+		t.Fatal(err)
+	}
+	if closedAt == 0 {
+		t.Fatal("expected closed_at to be populated")
+	}
+}
+
+func TestReconcileDeadClawPRsSkipsAgeCappedRows(t *testing.T) {
+	oldTransport := http.DefaultTransport
+	http.DefaultTransport = githubAppTokenTransport{base: oldTransport}
+	t.Cleanup(func() { http.DefaultTransport = oldTransport })
+
+	var requests atomic.Int64
+	gh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"state": "closed", "merged": false, "closed_at": "2026-01-01T00:00:00Z"})
+	}))
+	defer gh.Close()
+
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{GitHubApps: []*types.GitHubAppConfig{{AppID: 1, PrivateKeyPEM: testGitHubAppPEM(t)}}}, gh.URL, "", "")
+	if _, err := db.Exec(`INSERT INTO claws(id, tenant_id, name, template, status, created_at) VALUES(?,?,?,?,?,?)`, "dead-old", "test-tenant-id", "dead-old", "elasticclaw", "running", now()); err != nil {
+		t.Fatal(err)
+	}
+	runID, _ := startTaskRunForTest(t, s, "dead-old", "old")
+	associatePRForTest(t, s, runID, "owner/repo", 4, taskRunPRStateOpen)
+	if _, err := db.Exec(`UPDATE task_run_prs SET opened_at=? WHERE run_id=?`, epochMillis(now().Add(-100*24*time.Hour)), runID); err != nil {
+		t.Fatal(err)
+	}
+
+	s.reconcileDeadClawPRs()
+	if got := requests.Load(); got != 0 {
+		t.Fatalf("GitHub requests = %d, want 0", got)
+	}
+	assertTaskRunPR(t, db, runID, "owner/repo", 4, taskRunPRStateOpen, false)
+	assertTaskRunSummary(t, db, runID, taskRunStatusRunning, taskRunPhaseWaitingForMerge, "", "[]", 0, 1, 1, 0, 0)
+}
+
 func insertWatcherTestPR(t *testing.T, db *sql.DB, clawID, prID string) {
 	t.Helper()
 	if _, err := db.Exec(`INSERT INTO claws(id,tenant_id,name,template,status,created_at) VALUES(?,?,?,?,?,?)`, clawID, "test-tenant-id", clawID, "elasticclaw", "connected", now()); err != nil {

--- a/pkg/hub/task_run_analytics.go
+++ b/pkg/hub/task_run_analytics.go
@@ -19,8 +19,9 @@ const (
 	taskRunKindPRTask   = "pr_task"
 
 	taskRunStatusRunning        = "running"
-	taskRunStatusCleanSuccess   = "clean_success"
-	taskRunStatusWarningSuccess = "warning_success"
+	taskRunStatusClean          = "clean"
+	taskRunStatusHumanInTheLoop = "human_in_the_loop"
+	taskRunStatusWarning        = "warning"
 	taskRunStatusFailed         = "failed"
 
 	taskRunPhaseClaimed         = "claimed"
@@ -882,6 +883,8 @@ func materializeTaskRunTx(tx *sql.Tx, runID string) error {
 
 	warnings := map[string]bool{}
 	humanInteractions := 0
+	dashboardInteractions := 0
+	externalInteractions := 0
 	for _, event := range events {
 		if warning := normalizeTaskRunWarningType(event.warningType); warning != "" {
 			warnings[warning] = true
@@ -889,6 +892,12 @@ func materializeTaskRunTx(tx *sql.Tx, runID string) error {
 		if warning := warningTypeForEvent(event); warning != "" && isHumanTaskRunEvent(event) {
 			humanInteractions++
 			warnings[warning] = true
+			switch taskRunWarningChannel(warning) {
+			case "dashboard":
+				dashboardInteractions++
+			case "external":
+				externalInteractions++
+			}
 		}
 	}
 
@@ -910,7 +919,7 @@ func materializeTaskRunTx(tx *sql.Tx, runID string) error {
 	completedAt := taskCompletedAt(events)
 	prePRFailure, prePRFailureAt := prePRFailure(events)
 	status, phase, failureType, extraWarning, finishedAt := computeTaskRunStatus(
-		meta, counts, humanInteractions, phaseTimes, definitiveFailure, definitiveFailureAt, completedAt, prePRFailure, prePRFailureAt,
+		meta, counts, dashboardInteractions, externalInteractions, phaseTimes, definitiveFailure, definitiveFailureAt, completedAt, prePRFailure, prePRFailureAt,
 	)
 	if extraWarning != "" {
 		warnings[extraWarning] = true
@@ -1038,10 +1047,24 @@ func isHumanTaskRunEvent(event taskRunEventProjection) bool {
 	return false
 }
 
+// taskRunWarningChannel identifies where a human interaction originated.
+func taskRunWarningChannel(warningType string) string {
+	switch warningType {
+	case taskRunWarningHumanDashboardMessage, taskRunWarningHumanManualStopResume, taskRunWarningHumanSettingsChange:
+		return "dashboard"
+	case taskRunWarningHumanPRComment, taskRunWarningHumanReviewComment, taskRunWarningHumanRequestedChanges,
+		taskRunWarningHumanManualCodePush, taskRunWarningHumanTrackerUpdate, taskRunWarningUnknownHuman:
+		return "external"
+	default:
+		return ""
+	}
+}
+
 func computeTaskRunStatus(
 	meta taskRunMeta,
 	counts prCountSummary,
-	humanInteractions int,
+	dashboardInteractions int,
+	externalInteractions int,
 	phaseTimes taskRunPhaseTimeSummary,
 	definitiveFailure string,
 	definitiveFailureAt int64,
@@ -1049,33 +1072,28 @@ func computeTaskRunStatus(
 	prePRFailure string,
 	prePRFailureAt int64,
 ) (status, phase, failureType, extraWarning string, finishedAt int64) {
+	successStatus := func() string {
+		if dashboardInteractions > 0 {
+			return taskRunStatusWarning
+		}
+		if externalInteractions > 0 {
+			return taskRunStatusHumanInTheLoop
+		}
+		return taskRunStatusClean
+	}
 	status, phase = taskRunStatusRunning, initialTaskRunPhase(meta, phaseTimes)
 	if meta.analyticsEnabled == 0 {
 		// Excluded runs are not part of PR-scoped analytics; failed/unknown is a sentinel summary state.
 		return taskRunStatusFailed, taskRunPhaseTerminal, taskRunFailureUnknown, "", meta.updatedAt
 	} else if meta.requiresPR == 0 && taskCompletedAt != 0 {
-		if humanInteractions > 0 {
-			status = taskRunStatusWarningSuccess
-		} else {
-			status = taskRunStatusCleanSuccess
-		}
-		phase = taskRunPhaseTerminal
-		finishedAt = taskCompletedAt
-	} else if counts.merged > 0 && counts.open == 0 {
-		if humanInteractions > 0 {
-			status = taskRunStatusWarningSuccess
-		} else {
-			status = taskRunStatusCleanSuccess
-		}
-		phase = taskRunPhaseTerminal
-		finishedAt = counts.latestTerminalAt
-	} else if counts.merged > 0 && counts.open > 0 {
-		status, phase = taskRunStatusRunning, taskRunPhaseWaitingForMerge
+		return successStatus(), taskRunPhaseTerminal, "", "", taskCompletedAt
 	} else if counts.open > 0 {
 		status, phase = taskRunStatusRunning, taskRunPhaseWaitingForMerge
+	} else if counts.merged > 0 {
+		return successStatus(), taskRunPhaseTerminal, "", "", counts.latestTerminalAt
 	} else if counts.total > 0 {
 		extraWarning = taskRunWarningPRClosedUnmerged
-		status, phase, finishedAt = taskRunStatusWarningSuccess, taskRunPhaseTerminal, counts.latestTerminalAt
+		return successStatus(), taskRunPhaseTerminal, "", extraWarning, counts.latestTerminalAt
 	} else if definitiveFailure != "" {
 		status, phase, failureType, finishedAt = taskRunStatusFailed, taskRunPhaseTerminal, definitiveFailure, definitiveFailureAt
 	} else if prePRFailure != "" {

--- a/pkg/hub/task_run_analytics_api_test.go
+++ b/pkg/hub/task_run_analytics_api_test.go
@@ -17,13 +17,13 @@ func TestTaskRunAnalyticsAPISummaryRunsFiltersAndPagination(t *testing.T) {
 	ts := int64(1760000000000)
 	insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{
 		RunID: "run-clean", AttemptID: "attempt-clean", ClawID: "claw-clean", TenantID: "test-tenant-id",
-		Status: taskRunStatusCleanSuccess, Phase: taskRunPhaseTerminal, OwnerType: taskRunOwnerFactory,
+		Status: taskRunStatusClean, Phase: taskRunPhaseTerminal, OwnerType: taskRunOwnerFactory,
 		Workspace: "eng", Factory: "bugfix", Integration: "github", Repo: "elastic/claw", Model: "gpt-5",
 		StartedAt: ts + 3000, MergedAt: ts + 5000, FinishedAt: ts + 5000, PRCount: 1, MergedPRCount: 1,
 	})
 	insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{
 		RunID: "run-warning", AttemptID: "attempt-warning", ClawID: "claw-warning", TenantID: "test-tenant-id",
-		Status: taskRunStatusWarningSuccess, Phase: taskRunPhaseTerminal, OwnerType: taskRunOwnerWorkflow,
+		Status: taskRunStatusHumanInTheLoop, Phase: taskRunPhaseTerminal, OwnerType: taskRunOwnerWorkflow,
 		Workspace: "platform", Workflow: "review", Integration: "linear", Repo: "elastic/api", Model: "gpt-4.1",
 		WarningTypes: []string{taskRunWarningHumanPRComment}, StartedAt: ts + 2000, MergedAt: ts + 4000,
 		FinishedAt: ts + 4000, HumanInteractions: 2, PRCount: 2, ClosedPRCount: 1, MergedPRCount: 1,
@@ -42,7 +42,7 @@ func TestTaskRunAnalyticsAPISummaryRunsFiltersAndPagination(t *testing.T) {
 	})
 	insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{
 		RunID: "run-non-pr", AttemptID: "attempt-non-pr", ClawID: "claw-non-pr", TenantID: "test-tenant-id",
-		Status: taskRunStatusCleanSuccess, Phase: taskRunPhaseTerminal, OwnerType: taskRunOwnerWorkflow,
+		Status: taskRunStatusClean, Phase: taskRunPhaseTerminal, OwnerType: taskRunOwnerWorkflow,
 		Workspace: "internal", Workflow: "note", Integration: "external", Repo: "elastic/internal", Model: "gpt-5",
 		StartedAt: ts + 8000, RequiresPR: boolPtr(false), ExcludedReason: "not_pr_task",
 	})
@@ -72,7 +72,7 @@ func TestTaskRunAnalyticsAPISummaryRunsFiltersAndPagination(t *testing.T) {
 	allSummaryRR := requestTaskRunAnalyticsAPI(t, s, http.MethodGet, "/api/analytics/summary", "test-token")
 	var allSummary taskRunAnalyticsSummaryResponse
 	decodeTaskRunAnalyticsAPI(t, allSummaryRR, &allSummary)
-	if allSummary.TotalRuns != 4 || allSummary.ByStatus[taskRunStatusCleanSuccess] != 1 || allSummary.ByStatus[taskRunStatusWarningSuccess] != 1 || allSummary.ByStatus[taskRunStatusRunning] != 1 || allSummary.ByStatus[taskRunStatusFailed] != 1 {
+	if allSummary.TotalRuns != 4 || allSummary.ByStatus[taskRunStatusClean] != 1 || allSummary.ByStatus[taskRunStatusHumanInTheLoop] != 1 || allSummary.ByStatus[taskRunStatusRunning] != 1 || allSummary.ByStatus[taskRunStatusFailed] != 1 {
 		t.Fatalf("summary should include only authenticated tenant runs, got %#v", allSummary)
 	}
 	if allSummary.WarningBreakdown[taskRunWarningHumanPRComment] != 1 || allSummary.HumanInteractions != 3 {
@@ -139,7 +139,7 @@ func TestTaskRunAnalyticsAPISummaryRunsFiltersAndPagination(t *testing.T) {
 	mergedPRsRR := requestTaskRunAnalyticsAPI(t, s, http.MethodGet, "/api/analytics/summary?mergedPrs=true", "test-token")
 	var mergedPRsSummary taskRunAnalyticsSummaryResponse
 	decodeTaskRunAnalyticsAPI(t, mergedPRsRR, &mergedPRsSummary)
-	if mergedPRsSummary.TotalRuns != 2 || mergedPRsSummary.PRCounts.Merged != 2 || mergedPRsSummary.ByStatus[taskRunStatusCleanSuccess] != 1 || mergedPRsSummary.ByStatus[taskRunStatusWarningSuccess] != 1 {
+	if mergedPRsSummary.TotalRuns != 2 || mergedPRsSummary.PRCounts.Merged != 2 || mergedPRsSummary.ByStatus[taskRunStatusClean] != 1 || mergedPRsSummary.ByStatus[taskRunStatusHumanInTheLoop] != 1 {
 		t.Fatalf("mergedPrs summary mismatch: %#v", mergedPRsSummary)
 	}
 	mergedPRsRunsRR := requestTaskRunAnalyticsAPI(t, s, http.MethodGet, "/api/analytics/runs?mergedPrs=true", "test-token")
@@ -256,14 +256,14 @@ func TestTaskRunAnalyticsAPIRunDetailsAttemptsEventsAndPRs(t *testing.T) {
 	ts := int64(1760000000000)
 	insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{
 		RunID: "run-detail", AttemptID: "attempt-detail", ClawID: "claw-detail", TenantID: "test-tenant-id",
-		Status: taskRunStatusWarningSuccess, Phase: taskRunPhaseTerminal, OwnerType: taskRunOwnerFactory,
+		Status: taskRunStatusHumanInTheLoop, Phase: taskRunPhaseTerminal, OwnerType: taskRunOwnerFactory,
 		Workspace: "eng", Factory: "bugfix", Integration: "github", Repo: "elastic/claw", Model: "gpt-5",
 		WarningTypes: []string{taskRunWarningHumanReviewComment}, StartedAt: ts, FinishedAt: ts + 1000,
 		HumanInteractions: 1, PRCount: 1, MergedPRCount: 1,
 	})
 	insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{
 		RunID: "run-other-tenant", AttemptID: "attempt-other", ClawID: "claw-other", TenantID: "other-tenant-id",
-		Status: taskRunStatusCleanSuccess, Phase: taskRunPhaseTerminal, OwnerType: taskRunOwnerFactory,
+		Status: taskRunStatusClean, Phase: taskRunPhaseTerminal, OwnerType: taskRunOwnerFactory,
 		Workspace: "secret", Factory: "hidden", Integration: "github", Repo: "secret/repo", Model: "hidden",
 		StartedAt: ts,
 	})
@@ -352,7 +352,7 @@ func TestTaskRunAnalyticsAPIOutputs(t *testing.T) {
 	ts := int64(1760000000000)
 	insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{
 		RunID: "run-outputs", AttemptID: "attempt-one", ClawID: "claw-one", TenantID: "test-tenant-id",
-		Status: taskRunStatusCleanSuccess, Phase: taskRunPhaseTerminal, OwnerType: taskRunOwnerFactory,
+		Status: taskRunStatusClean, Phase: taskRunPhaseTerminal, OwnerType: taskRunOwnerFactory,
 		Factory: "bugfix", StartedAt: ts,
 	})
 	if _, err := db.Exec(`
@@ -414,11 +414,11 @@ func TestTaskRunAnalyticsAPIAccessControl(t *testing.T) {
 	ts := int64(1760000000000)
 	insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{
 		RunID: "run-alice", AttemptID: "attempt-alice", ClawID: "claw-alice", TenantID: "test-tenant-id",
-		Status: taskRunStatusCleanSuccess, OwnerType: taskRunOwnerFactory, Factory: "bugfix", StartedAt: ts + 100,
+		Status: taskRunStatusClean, OwnerType: taskRunOwnerFactory, Factory: "bugfix", StartedAt: ts + 100,
 	})
 	insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{
 		RunID: "run-bob", AttemptID: "attempt-bob", ClawID: "claw-bob", TenantID: "test-tenant-id",
-		Status: taskRunStatusCleanSuccess, OwnerType: taskRunOwnerFactory, Factory: "bugfix", StartedAt: ts,
+		Status: taskRunStatusClean, OwnerType: taskRunOwnerFactory, Factory: "bugfix", StartedAt: ts,
 	})
 	for _, claw := range []struct{ id, tags string }{
 		{id: "claw-alice", tags: `["owner=alice"]`},
@@ -498,7 +498,7 @@ func TestTaskRunAnalyticsAPIAccessControlAggregates(t *testing.T) {
 	})
 	insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{
 		RunID: "run-bob", AttemptID: "attempt-bob", ClawID: "claw-bob", TenantID: "test-tenant-id",
-		Status: taskRunStatusWarningSuccess, Phase: taskRunPhaseTerminal, OwnerType: taskRunOwnerFactory,
+		Status: taskRunStatusHumanInTheLoop, Phase: taskRunPhaseTerminal, OwnerType: taskRunOwnerFactory,
 		Workspace: "bob-space", Factory: "bob-factory", Integration: "github", Repo: "bob/repo", Model: "bob-model",
 		WarningTypes: []string{taskRunWarningHumanPRComment}, StartedAt: ts, HumanInteractions: 1,
 		PRCount: 1, MergedPRCount: 1, MergedAt: ts + 500, FinishedAt: ts + 500,
@@ -522,7 +522,7 @@ func TestTaskRunAnalyticsAPIAccessControlAggregates(t *testing.T) {
 	if summary.TotalRuns != 1 || summary.HumanInteractions != 1 {
 		t.Fatalf("OAuth summary was not ACL-filtered: %#v", summary)
 	}
-	if summary.ByStatus[taskRunStatusWarningSuccess] != 1 || summary.ByStatus[taskRunStatusFailed] != 0 || len(summary.FailureBreakdown) != 0 {
+	if summary.ByStatus[taskRunStatusHumanInTheLoop] != 1 || summary.ByStatus[taskRunStatusFailed] != 0 || len(summary.FailureBreakdown) != 0 {
 		t.Fatalf("OAuth summary leaked hidden run breakdowns: %#v", summary)
 	}
 	if summary.WarningBreakdown[taskRunWarningHumanPRComment] != 1 {
@@ -540,7 +540,7 @@ func TestTaskRunAnalyticsAPIAccessControlAggregates(t *testing.T) {
 	assertStringSliceEqual(t, options.Integrations, []string{"github"})
 	assertStringSliceEqual(t, options.Repos, []string{"bob/repo"})
 	assertStringSliceEqual(t, options.Models, []string{"bob-model"})
-	assertStringSliceEqual(t, options.Statuses, []string{taskRunStatusWarningSuccess})
+	assertStringSliceEqual(t, options.Statuses, []string{taskRunStatusHumanInTheLoop})
 	assertStringSliceEqual(t, options.WarningTypes, []string{taskRunWarningHumanPRComment})
 	assertStringSliceEqual(t, options.FailureTypes, []string{})
 	if strings.Contains(optionsRR.Body.String(), "alice") {
@@ -581,7 +581,7 @@ func TestTaskRunAnalyticsAPIAllowsMissingClawsWithoutViewRestrictions(t *testing
 	}, "", "", "")
 	insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{
 		RunID: "run-deleted-claw", AttemptID: "attempt-deleted-claw", ClawID: "claw-deleted", TenantID: "test-tenant-id",
-		Status: taskRunStatusCleanSuccess, OwnerType: taskRunOwnerFactory, Factory: "bugfix", StartedAt: 1760000000000,
+		Status: taskRunStatusClean, OwnerType: taskRunOwnerFactory, Factory: "bugfix", StartedAt: 1760000000000,
 	})
 	session, err := signGitHubSession("analytics-session-secret", "alice", "", "")
 	if err != nil {
@@ -617,7 +617,7 @@ func TestTaskRunAnalyticsAPIFilterOptionsAreTenantScoped(t *testing.T) {
 	ts := int64(1760000000000)
 	insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{
 		RunID: "run-options-a", AttemptID: "attempt-options-a", ClawID: "claw-options-a", TenantID: "test-tenant-id",
-		Status: taskRunStatusWarningSuccess, Phase: taskRunPhaseTerminal, OwnerType: taskRunOwnerFactory,
+		Status: taskRunStatusHumanInTheLoop, Phase: taskRunPhaseTerminal, OwnerType: taskRunOwnerFactory,
 		Workspace: "eng", Factory: "bugfix", Integration: "github", Repo: "elastic/claw", Model: "gpt-5",
 		WarningTypes: []string{taskRunWarningHumanDashboardMessage}, StartedAt: ts,
 	})
@@ -635,7 +635,7 @@ func TestTaskRunAnalyticsAPIFilterOptionsAreTenantScoped(t *testing.T) {
 	})
 	insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{
 		RunID: "run-options-non-pr", AttemptID: "attempt-options-non-pr", ClawID: "claw-options-non-pr", TenantID: "test-tenant-id",
-		Status: taskRunStatusCleanSuccess, Phase: taskRunPhaseTerminal, OwnerType: taskRunOwnerWorkflow,
+		Status: taskRunStatusClean, Phase: taskRunPhaseTerminal, OwnerType: taskRunOwnerWorkflow,
 		Workspace: "ignored", Workflow: "ignored", Integration: "external", Repo: "ignored/repo", Model: "ignored-model",
 		StartedAt: ts + 2, AnalyticsEnabled: boolPtr(false), RequiresPR: boolPtr(false), ExcludedReason: "not_pr_task",
 	})
@@ -649,7 +649,7 @@ func TestTaskRunAnalyticsAPIFilterOptionsAreTenantScoped(t *testing.T) {
 	assertStringSliceEqual(t, options.Integrations, []string{"github", "linear"})
 	assertStringSliceEqual(t, options.Repos, []string{"elastic/api", "elastic/claw"})
 	assertStringSliceEqual(t, options.Models, []string{"gpt-4.1", "gpt-5"})
-	assertStringSliceEqual(t, options.Statuses, []string{taskRunStatusFailed, taskRunStatusWarningSuccess})
+	assertStringSliceEqual(t, options.Statuses, []string{taskRunStatusFailed, taskRunStatusHumanInTheLoop})
 	assertStringSliceEqual(t, options.WarningTypes, []string{taskRunWarningHumanDashboardMessage})
 	assertStringSliceEqual(t, options.FailureTypes, []string{taskRunFailureManualStopDelivery})
 }
@@ -744,7 +744,7 @@ func insertTaskRunAnalyticsAPIRun(t *testing.T, db *sql.DB, fixture apiRunFixtur
 	attemptStatus := "running"
 	if fixture.Status == taskRunStatusFailed {
 		attemptStatus = "failed"
-	} else if fixture.Status == taskRunStatusCleanSuccess || fixture.Status == taskRunStatusWarningSuccess {
+	} else if fixture.Status == taskRunStatusClean || fixture.Status == taskRunStatusHumanInTheLoop {
 		attemptStatus = "succeeded"
 	}
 	_, err = db.Exec(`

--- a/pkg/hub/task_run_analytics_test.go
+++ b/pkg/hub/task_run_analytics_test.go
@@ -178,11 +178,11 @@ func TestTaskRunMaterializationClassifiesCleanSuccess(t *testing.T) {
 		Detail:    map[string]any{"repo": "elastic/claw", "prNumber": 11},
 	})
 
-	assertTaskRunSummary(t, db, runID, taskRunStatusCleanSuccess, taskRunPhaseTerminal, "", "[]", 0, 1, 0, 1, 0)
+	assertTaskRunSummary(t, db, runID, taskRunStatusClean, taskRunPhaseTerminal, "", "[]", 0, 1, 0, 1, 0)
 	assertTaskRunAttempt(t, db, runID, "succeeded", "")
 }
 
-func TestTaskRunMaterializationClassifiesWarningSuccess(t *testing.T) {
+func TestTaskRunMaterializationClassifiesHumanInTheLoop(t *testing.T) {
 	s, db := newTaskRunAnalyticsTestServer(t, "claw-warning")
 	runID, attemptID := startTaskRunForTest(t, s, "claw-warning", "warning")
 
@@ -210,7 +210,17 @@ func TestTaskRunMaterializationClassifiesWarningSuccess(t *testing.T) {
 		Detail:    map[string]any{"repo": "elastic/claw", "prNumber": 12},
 	})
 
-	assertTaskRunSummary(t, db, runID, taskRunStatusWarningSuccess, taskRunPhaseTerminal, "", `["human_pr_comment"]`, 1, 1, 0, 1, 0)
+	assertTaskRunSummary(t, db, runID, taskRunStatusHumanInTheLoop, taskRunPhaseTerminal, "", `["human_pr_comment"]`, 1, 1, 0, 1, 0)
+}
+
+func TestTaskRunMaterializationClassifiesDashboardInteractionAsWarning(t *testing.T) {
+	s, db := newTaskRunAnalyticsTestServer(t, "claw-dashboard-warning")
+	runID, attemptID := startTaskRunForTest(t, s, "claw-dashboard-warning", "dashboard-warning")
+	associatePRForTest(t, s, runID, "elastic/claw", 121, taskRunPRStateOpen)
+	recordTaskRunEventForTest(t, s, TaskRunEvent{TenantID: "test-tenant-id", RunID: runID, AttemptID: attemptID, EventKey: "dashboard-warning:message", EventType: taskRunEventHumanDashboardMessage, ActorType: taskRunActorHuman, Source: taskRunSourceDashboard, WarningType: taskRunWarningHumanDashboardMessage})
+	recordTaskRunEventForTest(t, s, TaskRunEvent{TenantID: "test-tenant-id", RunID: runID, AttemptID: attemptID, EventKey: "dashboard-warning:comment", EventType: taskRunEventHumanPRComment, ActorType: taskRunActorHuman, Source: taskRunSourceGitHub, WarningType: taskRunWarningHumanPRComment})
+	recordTaskRunEventForTest(t, s, TaskRunEvent{TenantID: "test-tenant-id", RunID: runID, AttemptID: attemptID, EventKey: "dashboard-warning:merged", EventType: taskRunEventPRMerged, ActorType: taskRunActorSystem, Source: taskRunSourceGitHub, Detail: map[string]any{"repo": "elastic/claw", "prNumber": 121}})
+	assertTaskRunSummary(t, db, runID, taskRunStatusWarning, taskRunPhaseTerminal, "", `["human_dashboard_message","human_pr_comment"]`, 2, 1, 0, 1, 0)
 }
 
 func TestTaskRunMaterializationKeepsNonHumanWarningsClean(t *testing.T) {
@@ -219,7 +229,7 @@ func TestTaskRunMaterializationKeepsNonHumanWarningsClean(t *testing.T) {
 	associatePRForTest(t, s, runID, "elastic/claw", 13, taskRunPRStateOpen)
 	recordTaskRunEventForTest(t, s, TaskRunEvent{TenantID: "test-tenant-id", RunID: runID, AttemptID: attemptID, EventKey: "non-human-warning:replaced", EventType: "pr_replaced", ActorType: taskRunActorSystem, Source: taskRunSourceHub, WarningType: taskRunWarningPRReplaced})
 	recordTaskRunEventForTest(t, s, TaskRunEvent{TenantID: "test-tenant-id", RunID: runID, AttemptID: attemptID, EventKey: "non-human-warning:merged", EventType: taskRunEventPRMerged, ActorType: taskRunActorSystem, Source: taskRunSourceGitHub, Detail: map[string]any{"repo": "elastic/claw", "prNumber": 13}})
-	assertTaskRunSummary(t, db, runID, taskRunStatusCleanSuccess, taskRunPhaseTerminal, "", `["pr_replaced"]`, 0, 1, 0, 1, 0)
+	assertTaskRunSummary(t, db, runID, taskRunStatusClean, taskRunPhaseTerminal, "", `["pr_replaced"]`, 0, 1, 0, 1, 0)
 }
 
 func TestTaskRunHumanManualCodePushCountsAsHumanInteraction(t *testing.T) {
@@ -228,15 +238,15 @@ func TestTaskRunHumanManualCodePushCountsAsHumanInteraction(t *testing.T) {
 	associatePRForTest(t, s, runID, "elastic/claw", 15, taskRunPRStateOpen)
 	recordTaskRunEventForTest(t, s, TaskRunEvent{TenantID: "test-tenant-id", RunID: runID, AttemptID: attemptID, EventKey: "human-push:sha", EventType: taskRunWarningHumanManualCodePush, ActorType: taskRunActorHuman, Source: taskRunSourceGitHub, WarningType: taskRunWarningHumanManualCodePush})
 	recordTaskRunEventForTest(t, s, TaskRunEvent{TenantID: "test-tenant-id", RunID: runID, AttemptID: attemptID, EventKey: "human-push:merged", EventType: taskRunEventPRMerged, ActorType: taskRunActorSystem, Source: taskRunSourceGitHub, Detail: map[string]any{"repo": "elastic/claw", "prNumber": 15}})
-	assertTaskRunSummary(t, db, runID, taskRunStatusWarningSuccess, taskRunPhaseTerminal, "", `["human_manual_code_push"]`, 1, 1, 0, 1, 0)
+	assertTaskRunSummary(t, db, runID, taskRunStatusHumanInTheLoop, taskRunPhaseTerminal, "", `["human_manual_code_push"]`, 1, 1, 0, 1, 0)
 }
 
 func TestTaskRunMaterializationNonPRCompletionUsesHumanInteractions(t *testing.T) {
 	for _, tc := range []struct {
 		name, eventType, warning, want string
 	}{
-		{"clean", taskRunEventTaskCompleted, "", taskRunStatusCleanSuccess},
-		{"human", taskRunEventHumanPRComment, taskRunWarningHumanPRComment, taskRunStatusWarningSuccess},
+		{"clean", taskRunEventTaskCompleted, "", taskRunStatusClean},
+		{"human", taskRunEventHumanPRComment, taskRunWarningHumanPRComment, taskRunStatusHumanInTheLoop},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			s, db := newTaskRunAnalyticsTestServer(t, "claw-non-pr-"+tc.name)
@@ -265,13 +275,13 @@ func TestTaskRunAnalyticsStatusBackfillReclassifiesClosedUnmerged(t *testing.T) 
 	if _, err := db.Exec(`UPDATE task_run_summaries SET status='failed', failure_type='pr_closed_unmerged', warning_types='[]' WHERE run_id=?`, runID); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := db.Exec(`DELETE FROM hub_migrations WHERE name='task_run_analytics_status_v2'`); err != nil {
+	if _, err := db.Exec(`DELETE FROM hub_migrations WHERE name='task_run_analytics_status_v3'`); err != nil {
 		t.Fatal(err)
 	}
-	if err := backfillTaskRunAnalyticsStatusV2(db); err != nil {
+	if err := backfillTaskRunAnalyticsStatusV3(db); err != nil {
 		t.Fatalf("backfill: %v", err)
 	}
-	assertTaskRunSummary(t, db, runID, taskRunStatusWarningSuccess, taskRunPhaseTerminal, "", `["pr_closed_unmerged"]`, 0, 1, 0, 0, 1)
+	assertTaskRunSummary(t, db, runID, taskRunStatusClean, taskRunPhaseTerminal, "", `["pr_closed_unmerged"]`, 0, 1, 0, 0, 1)
 }
 
 func TestTaskRunClosedUnmergedTakesPrecedenceOverTimeout(t *testing.T) {
@@ -279,7 +289,7 @@ func TestTaskRunClosedUnmergedTakesPrecedenceOverTimeout(t *testing.T) {
 	runID, attemptID := startTaskRunForTest(t, s, "claw-closed-timeout", "closed-timeout")
 	associatePRForTest(t, s, runID, "elastic/claw", 16, taskRunPRStateClosed)
 	recordTaskRunEventForTest(t, s, TaskRunEvent{TenantID: "test-tenant-id", RunID: runID, AttemptID: attemptID, EventKey: "closed-timeout:timeout", EventType: "timeout", ActorType: taskRunActorSystem, Source: taskRunSourceHub, FailureType: taskRunFailureTimeout})
-	assertTaskRunSummary(t, db, runID, taskRunStatusWarningSuccess, taskRunPhaseTerminal, "", `["pr_closed_unmerged"]`, 0, 1, 0, 0, 1)
+	assertTaskRunSummary(t, db, runID, taskRunStatusClean, taskRunPhaseTerminal, "", `["pr_closed_unmerged"]`, 0, 1, 0, 0, 1)
 }
 
 func TestTaskRunClassificationFailsDoneWithoutPR(t *testing.T) {
@@ -330,7 +340,7 @@ func TestTaskRunMaterializationClassifiesReplacedPRAsWarningSuccess(t *testing.T
 		Detail:    map[string]any{"repo": "elastic/claw", "prNumber": 22},
 	})
 
-	assertTaskRunSummary(t, db, runID, taskRunStatusCleanSuccess, taskRunPhaseTerminal, "", `["pr_replaced"]`, 0, 2, 0, 1, 1)
+	assertTaskRunSummary(t, db, runID, taskRunStatusClean, taskRunPhaseTerminal, "", `["pr_replaced"]`, 0, 2, 0, 1, 1)
 }
 
 func TestTaskRunIdempotencyDoesNotDuplicateEventRows(t *testing.T) {
@@ -377,7 +387,7 @@ func TestTaskRunMaterializationLateWarningReclassifiesCleanSuccess(t *testing.T)
 		Source:    taskRunSourceGitHub,
 		Detail:    map[string]any{"repo": "elastic/claw", "prNumber": 31},
 	})
-	assertTaskRunSummary(t, db, runID, taskRunStatusCleanSuccess, taskRunPhaseTerminal, "", "[]", 0, 1, 0, 1, 0)
+	assertTaskRunSummary(t, db, runID, taskRunStatusClean, taskRunPhaseTerminal, "", "[]", 0, 1, 0, 1, 0)
 
 	recordTaskRunEventForTest(t, s, TaskRunEvent{
 		TenantID:        "test-tenant-id",
@@ -392,7 +402,7 @@ func TestTaskRunMaterializationLateWarningReclassifiesCleanSuccess(t *testing.T)
 		OccurredAt:      time.Now().UTC().Add(-time.Second),
 	})
 
-	assertTaskRunSummary(t, db, runID, taskRunStatusWarningSuccess, taskRunPhaseTerminal, "", `["human_pr_comment"]`, 1, 1, 0, 1, 0)
+	assertTaskRunSummary(t, db, runID, taskRunStatusHumanInTheLoop, taskRunPhaseTerminal, "", `["human_pr_comment"]`, 1, 1, 0, 1, 0)
 }
 
 func TestTaskRunMaterializationLateMergeOverridesPrePRFailure(t *testing.T) {
@@ -423,7 +433,7 @@ func TestTaskRunMaterializationLateMergeOverridesPrePRFailure(t *testing.T) {
 		Detail:    map[string]any{"repo": "elastic/claw", "prNumber": 41},
 	})
 
-	assertTaskRunSummary(t, db, runID, taskRunStatusCleanSuccess, taskRunPhaseTerminal, "", "[]", 0, 1, 0, 1, 0)
+	assertTaskRunSummary(t, db, runID, taskRunStatusClean, taskRunPhaseTerminal, "", "[]", 0, 1, 0, 1, 0)
 	assertTaskRunAttempt(t, db, runID, "succeeded", "")
 }
 
@@ -524,7 +534,7 @@ func TestTaskRunPRLifecycleDoesNotRegressMergedPRToOpen(t *testing.T) {
 	})
 	associatePRForTest(t, s, runID, "elastic/claw", 61, taskRunPRStateOpen)
 
-	assertTaskRunSummary(t, db, runID, taskRunStatusCleanSuccess, taskRunPhaseTerminal, "", "[]", 0, 1, 0, 1, 0)
+	assertTaskRunSummary(t, db, runID, taskRunStatusClean, taskRunPhaseTerminal, "", "[]", 0, 1, 0, 1, 0)
 }
 
 func TestTaskRunPRLifecycleDoesNotRegressClosedPRToOpen(t *testing.T) {
@@ -543,7 +553,7 @@ func TestTaskRunPRLifecycleDoesNotRegressClosedPRToOpen(t *testing.T) {
 	})
 	associatePRForTest(t, s, runID, "elastic/claw", 62, taskRunPRStateOpen)
 
-	assertTaskRunSummary(t, db, runID, taskRunStatusWarningSuccess, taskRunPhaseTerminal, "", `["pr_closed_unmerged"]`, 0, 1, 0, 0, 1)
+	assertTaskRunSummary(t, db, runID, taskRunStatusClean, taskRunPhaseTerminal, "", `["pr_closed_unmerged"]`, 0, 1, 0, 0, 1)
 }
 
 func TestTaskRunDetailSanitizationRedactsNestedText(t *testing.T) {
@@ -1089,7 +1099,7 @@ func TestTaskRunPRMergeAndCloseInstrumentationMaterializesStatus(t *testing.T) {
 
 	assertTaskRunEventExists(t, db, runID, taskRunEventPRMerged, taskRunInteractionTerminal)
 	assertTaskRunPR(t, db, runID, "elastic/claw", 72, taskRunPRStateClosed, true)
-	assertTaskRunSummary(t, db, runID, taskRunStatusCleanSuccess, taskRunPhaseTerminal, "", "[]", 0, 1, 0, 1, 0)
+	assertTaskRunSummary(t, db, runID, taskRunStatusClean, taskRunPhaseTerminal, "", "[]", 0, 1, 0, 1, 0)
 
 	s2, db2 := newTaskRunAnalyticsTestServer(t, "claw-pr-closed")
 	closedRunID, _ := startTaskRunForTest(t, s2, "claw-pr-closed", "pr-closed")
@@ -1099,7 +1109,7 @@ func TestTaskRunPRMergeAndCloseInstrumentationMaterializesStatus(t *testing.T) {
 
 	assertTaskRunEventExists(t, db2, closedRunID, taskRunEventPRClosedUnmerged, taskRunInteractionTerminal)
 	assertTaskRunPR(t, db2, closedRunID, "elastic/claw", 73, taskRunPRStateClosed, false)
-	assertTaskRunSummary(t, db2, closedRunID, taskRunStatusWarningSuccess, taskRunPhaseTerminal, "", `["pr_closed_unmerged"]`, 0, 1, 0, 0, 1)
+	assertTaskRunSummary(t, db2, closedRunID, taskRunStatusClean, taskRunPhaseTerminal, "", `["pr_closed_unmerged"]`, 0, 1, 0, 0, 1)
 }
 
 func TestTaskRunPRClosedFailureSurvivesOperationalStop(t *testing.T) {
@@ -1110,7 +1120,7 @@ func TestTaskRunPRClosedFailureSurvivesOperationalStop(t *testing.T) {
 	s.trackPRClosed("factory-pr-closed-stop", "ISSUE-pr-closed-stop", "claw-pr-closed-stop", "elastic/claw", 74)
 	s.stopAgentWithReason("claw-pr-closed-stop", "PR closed without merge", false)
 
-	assertTaskRunSummary(t, db, runID, taskRunStatusWarningSuccess, taskRunPhaseTerminal, "", `["pr_closed_unmerged"]`, 0, 1, 0, 0, 1)
+	assertTaskRunSummary(t, db, runID, taskRunStatusClean, taskRunPhaseTerminal, "", `["pr_closed_unmerged"]`, 0, 1, 0, 0, 1)
 }
 
 func TestTaskRunStopAgentWithReasonInstrumentationRecordsTerminalFailure(t *testing.T) {
@@ -1319,7 +1329,7 @@ func TestTaskRunDoneWithoutPRAllowsNonPRRuns(t *testing.T) {
 		t.Fatalf("expected no done_without_pr failure event for non-pr run, got %d", failures)
 	}
 	assertTaskRunEventExists(t, db, runID, taskRunEventTaskCompleted, taskRunInteractionTerminal)
-	assertTaskRunSummary(t, db, runID, taskRunStatusCleanSuccess, taskRunPhaseTerminal, "", "[]", 0, 0, 0, 0, 0)
+	assertTaskRunSummary(t, db, runID, taskRunStatusClean, taskRunPhaseTerminal, "", "[]", 0, 0, 0, 0, 0)
 
 	var status string
 	if err := db.QueryRow(`SELECT status FROM claws WHERE id=?`, "claw-done-non-pr").Scan(&status); err != nil {

--- a/pkg/hub/task_run_analytics_test.go
+++ b/pkg/hub/task_run_analytics_test.go
@@ -223,6 +223,27 @@ func TestTaskRunMaterializationClassifiesDashboardInteractionAsWarning(t *testin
 	assertTaskRunSummary(t, db, runID, taskRunStatusWarning, taskRunPhaseTerminal, "", `["human_dashboard_message","human_pr_comment"]`, 2, 1, 0, 1, 0)
 }
 
+func TestTaskRunMaterializationClosedUnmergedWithPRCommentIsHumanInTheLoop(t *testing.T) {
+	s, db := newTaskRunAnalyticsTestServer(t, "claw-closed-pr-comment")
+	runID, attemptID := startTaskRunForTest(t, s, "claw-closed-pr-comment", "closed-pr-comment")
+	associatePRForTest(t, s, runID, "elastic/claw", 122, taskRunPRStateOpen)
+	recordTaskRunEventForTest(t, s, TaskRunEvent{TenantID: "test-tenant-id", RunID: runID, AttemptID: attemptID, EventKey: "closed-pr-comment:comment", EventType: taskRunEventHumanPRComment, ActorType: taskRunActorHuman, Source: taskRunSourceGitHub, WarningType: taskRunWarningHumanPRComment, Detail: map[string]any{"repo": "elastic/claw", "prNumber": 122}})
+	recordTaskRunEventForTest(t, s, TaskRunEvent{TenantID: "test-tenant-id", RunID: runID, AttemptID: attemptID, EventKey: "closed-pr-comment:closed", EventType: taskRunEventPRClosedUnmerged, ActorType: taskRunActorSystem, Source: taskRunSourceGitHub, Detail: map[string]any{"repo": "elastic/claw", "prNumber": 122}})
+
+	assertTaskRunSummary(t, db, runID, taskRunStatusHumanInTheLoop, taskRunPhaseTerminal, "", `["human_pr_comment","pr_closed_unmerged"]`, 1, 1, 0, 0, 1)
+}
+
+func TestTaskRunMaterializationClosedUnmergedWithDashboardMessageIsWarning(t *testing.T) {
+	s, db := newTaskRunAnalyticsTestServer(t, "claw-closed-dashboard")
+	runID, attemptID := startTaskRunForTest(t, s, "claw-closed-dashboard", "closed-dashboard")
+	associatePRForTest(t, s, runID, "elastic/claw", 123, taskRunPRStateOpen)
+	recordTaskRunEventForTest(t, s, TaskRunEvent{TenantID: "test-tenant-id", RunID: runID, AttemptID: attemptID, EventKey: "closed-dashboard:message", EventType: taskRunEventHumanDashboardMessage, ActorType: taskRunActorHuman, Source: taskRunSourceDashboard, WarningType: taskRunWarningHumanDashboardMessage})
+	recordTaskRunEventForTest(t, s, TaskRunEvent{TenantID: "test-tenant-id", RunID: runID, AttemptID: attemptID, EventKey: "closed-dashboard:comment", EventType: taskRunEventHumanPRComment, ActorType: taskRunActorHuman, Source: taskRunSourceGitHub, WarningType: taskRunWarningHumanPRComment, Detail: map[string]any{"repo": "elastic/claw", "prNumber": 123}})
+	recordTaskRunEventForTest(t, s, TaskRunEvent{TenantID: "test-tenant-id", RunID: runID, AttemptID: attemptID, EventKey: "closed-dashboard:closed", EventType: taskRunEventPRClosedUnmerged, ActorType: taskRunActorSystem, Source: taskRunSourceGitHub, Detail: map[string]any{"repo": "elastic/claw", "prNumber": 123}})
+
+	assertTaskRunSummary(t, db, runID, taskRunStatusWarning, taskRunPhaseTerminal, "", `["human_dashboard_message","human_pr_comment","pr_closed_unmerged"]`, 2, 1, 0, 0, 1)
+}
+
 func TestTaskRunMaterializationKeepsNonHumanWarningsClean(t *testing.T) {
 	s, db := newTaskRunAnalyticsTestServer(t, "claw-non-human-warning")
 	runID, attemptID := startTaskRunForTest(t, s, "claw-non-human-warning", "non-human-warning")

--- a/web/components/task-run-analytics-view.tsx
+++ b/web/components/task-run-analytics-view.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react"
 import { usePathname, useRouter, useSearchParams } from "next/navigation"
-import { AlertCircle, ArrowDown, ArrowUp, CheckCircle2, CircleDot, ExternalLink, GitPullRequest, Minus, RefreshCw, Search, XCircle } from "lucide-react"
+import { AlertCircle, ArrowDown, ArrowUp, CheckCircle2, CircleDot, ExternalLink, GitPullRequest, Minus, RefreshCw, Search, Users, XCircle } from "lucide-react"
 import { Bar, BarChart, XAxis } from "recharts"
 import {
   fetchCostOverview,
@@ -74,7 +74,7 @@ const allUrlFilterKeys = [
 
 type UrlFilterKey = (typeof allUrlFilterKeys)[number]
 type UrlStringFilterKey = (typeof urlFilterKeys)[number]
-type KpiFilter = "runs" | "clean" | "warning" | "failed" | "humanTouches" | "mergedPrs"
+type KpiFilter = "runs" | "clean" | "humanInTheLoop" | "warning" | "failed" | "humanTouches" | "mergedPrs"
 
 function analyticsFiltersFromParams(params: URLSearchParams, workspaceScope?: string): TaskRunAnalyticsFilters {
   const filters: TaskRunAnalyticsFilters = {
@@ -254,8 +254,9 @@ export function TaskRunAnalyticsView({ workspaceScope }: { workspaceScope?: stri
       humanTouched: undefined,
       mergedPrs: undefined,
     }
-    if (kpi === "clean") updates.status = "clean_success"
-    if (kpi === "warning") updates.status = "warning_success"
+    if (kpi === "clean") updates.status = "clean"
+    if (kpi === "humanInTheLoop") updates.status = "human_in_the_loop"
+    if (kpi === "warning") updates.status = "warning"
     if (kpi === "failed") updates.status = "failed"
     if (kpi === "humanTouches") updates.humanTouched = true
     if (kpi === "mergedPrs") updates.mergedPrs = true
@@ -281,8 +282,9 @@ export function TaskRunAnalyticsView({ workspaceScope }: { workspaceScope?: stri
   const activeKpi = useMemo<KpiFilter | null>(() => {
     if (filters.humanTouched === true) return "humanTouches"
     if (filters.mergedPrs === true) return "mergedPrs"
-    if (filters.status === "clean_success") return "clean"
-    if (filters.status === "warning_success") return "warning"
+    if (filters.status === "clean") return "clean"
+    if (filters.status === "human_in_the_loop") return "humanInTheLoop"
+    if (filters.status === "warning") return "warning"
     if (filters.status === "failed") return "failed"
     if (!filters.status && filters.humanTouched === undefined && filters.mergedPrs === undefined) return "runs"
     return null
@@ -385,11 +387,12 @@ export function TaskRunAnalyticsView({ workspaceScope }: { workspaceScope?: stri
               </div>
             </div>
           )}
-          <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-6">
+          <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-7">
             <Metric label="Runs" value={kpiSummary?.totalRuns ?? 0} active={activeKpi === "runs"} onClick={() => applyKpiFilter("runs")} />
-            <Metric label="Clean" title="Merged with no human interaction" value={kpiSummary?.byStatus.clean_success ?? 0} tone="success" active={activeKpi === "clean"} onClick={() => applyKpiFilter("clean")} />
-            <Metric label="Warning" title="Merged with human touch or PR closed without merge" value={kpiSummary?.byStatus.warning_success ?? 0} tone="warning" active={activeKpi === "warning"} onClick={() => applyKpiFilter("warning")} />
-            <Metric label="Failed" title="No PR was ever opened" value={kpiSummary?.byStatus.failed ?? 0} tone="danger" active={activeKpi === "failed"} onClick={() => applyKpiFilter("failed")} />
+            <Metric label="Clean" title="PR merged or closed with zero human interaction." value={kpiSummary?.byStatus.clean ?? 0} tone="success" active={activeKpi === "clean"} onClick={() => applyKpiFilter("clean")} />
+            <Metric label="Human in the loop" title="PR merged or closed; a human interacted via the PR (comment, review, or code push)." value={kpiSummary?.byStatus.human_in_the_loop ?? 0} active={activeKpi === "humanInTheLoop"} onClick={() => applyKpiFilter("humanInTheLoop")} />
+            <Metric label="Warning" title="PR merged or closed; a human interacted via the factory dashboard." value={kpiSummary?.byStatus.warning ?? 0} tone="warning" active={activeKpi === "warning"} onClick={() => applyKpiFilter("warning")} />
+            <Metric label="Failed" title="No PR was ever delivered or the run definitively failed before delivery." value={kpiSummary?.byStatus.failed ?? 0} tone="danger" active={activeKpi === "failed"} onClick={() => applyKpiFilter("failed")} />
             <Metric label="Human touches" value={kpiSummary?.humanInteractions ?? 0} active={activeKpi === "humanTouches"} onClick={() => applyKpiFilter("humanTouches")} />
             <Metric label="Merged PRs" value={kpiSummary?.prCounts.merged ?? 0} active={activeKpi === "mergedPrs"} onClick={() => applyKpiFilter("mergedPrs")} />
           </div>
@@ -720,15 +723,16 @@ function DetailItem({ label, value }: { label: string; value: ReactNode }) {
 
 function StatusBadge({ status }: { status: string }) {
   const statusIcons: Record<string, ReactNode> = {
-    clean_success: <CheckCircle2 className="size-3" />,
+    clean: <CheckCircle2 className="size-3" />,
+    human_in_the_loop: <Users className="size-3" />,
     failed: <XCircle className="size-3" />,
   }
   const icon = statusIcons[status] ?? <CircleDot className="size-3" />
   return (
     <Badge
-      title={status === "clean_success" ? "Merged with no human interaction" : status === "warning_success" ? "Merged with human touch or PR closed without merge" : status === "failed" ? "No PR was ever opened" : undefined}
+      title={status === "clean" ? "PR merged or closed with zero human interaction." : status === "human_in_the_loop" ? "PR merged or closed; a human interacted via the PR (comment, review, or code push)." : status === "warning" ? "PR merged or closed; a human interacted via the factory dashboard." : status === "failed" ? "No PR was ever delivered or the run definitively failed before delivery." : status === "running" ? "In progress; no failure has occurred." : undefined}
       variant={status === "failed" ? "destructive" : status === "running" ? "secondary" : "outline"}
-      className={cn(status === "clean_success" && "border-emerald-500/40 text-emerald-700 dark:text-emerald-300", status === "warning_success" && "border-amber-500/50 text-amber-700 dark:text-amber-300")}
+      className={cn(status === "clean" && "border-emerald-500/40 text-emerald-700 dark:text-emerald-300", status === "human_in_the_loop" && "border-blue-500/50 text-blue-700 dark:text-blue-300", status === "warning" && "border-amber-500/50 text-amber-700 dark:text-amber-300")}
     >
       {icon}
       {formatLabel(status)}


### PR DESCRIPTION
## Summary

Replaces the analytics run-status taxonomy (`running` / `clean_success` / `warning_success` / `failed`) with five statuses driven by PR outcome and human-interaction channel:

| Status | Meaning |
|---|---|
| `clean` | PR merged or closed with zero human interaction |
| `human_in_the_loop` | PR merged/closed; human interacted via the PR (comment, review, requested changes, code push) |
| `warning` | PR merged/closed; human interacted via the factory dashboard (takes precedence over PR-channel interaction) |
| `failed` | No PR was ever delivered (or definitive pre-delivery failure) |
| `running` | In progress, no failure — pre-PR phases and open PRs |

`clean`, `human_in_the_loop`, and `warning` all count as success — success/failure is defined solely by the PR outcome, and closed-without-merge now counts as success (`pr_closed_unmerged` remains as informational data in `warning_types`).

## Changes

- **Status derivation** (`pkg/hub/task_run_analytics.go`): channel-aware interaction counting (dashboard vs PR/tracker) feeding a rewritten `computeTaskRunStatus` cascade; a late merge still overrides a pre-PR failure.
- **Migration** (`pkg/hub/db.go`): `task_run_summaries` table rebuild replacing the status CHECK constraint with the new values (CASE-mapping legacy rows), plus a `task_run_analytics_status_v3` backfill that re-materializes every run under the new rules.
- **Dead-claw PR reconciliation**: previously, a PR merged/closed after the agent session died was never observed (both the PR poller and the webhook lookup skip dead claws), leaving runs stuck as `running` forever. Now a 5-minute reconciliation tick polls open `task_run_prs` rows whose claw is dead or missing (90-day age cap), and the PR webhook records closed/merged outcomes for runs with no live claw instead of falling through to claw creation.
- **Frontend** (`web/components/task-run-analytics-view.tsx`): five status KPI tiles, filters, and `StatusBadge` variants with updated tooltips.
- **Tests**: retargeted existing derivation tests, plus new coverage for channel precedence, closed-unmerged variants, the migration rebuild (old-schema DB → mapped statuses, preserved usage columns, idempotency), and the reconciler (merged, closed-unmerged, age-cap, zero `opened_at`, repo-token fallback, webhook fallback).

## Verification

- `go build ./...` and `go test ./pkg/hub -count=1` pass.
- `npx tsc --noEmit` and `npm run build` pass in `web/`.
- No `clean_success`/`warning_success` literals remain outside the migration code.

No UI screenshots included: the analytics view needs a populated hub database to render meaningfully; the visual change is limited to the KPI tiles and status badges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)