### PR TITLE
Fix flaky TestSendNextQueuedMessageKeepsPendingAfterWriteFailure

### DIFF
--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -2105,7 +2105,6 @@ func TestSendNextQueuedMessageKeepsPendingAfterWriteFailure(t *testing.T) {
 	s.mu.RLock()
 	cc := s.claws[clawID]
 	s.mu.RUnlock()
-	insertPendingMessage(t, db, clawID, "retry me", now())
 	// Sever the client side abruptly (no close handshake) so the server's
 	// next write to this connection fails, without touching cc.conn directly
 	// (which would race the server's own read/close goroutines).
@@ -2113,7 +2112,19 @@ func TestSendNextQueuedMessageKeepsPendingAfterWriteFailure(t *testing.T) {
 		t.Fatalf("close client websocket: %v", err)
 	}
 	waitForTestClawDisconnect(t, s, clawID)
-	// The closed peer makes the write fail; the row must remain eligible.
+	// Close the server side too: even after the claw is deregistered, a TCP
+	// write into the severed loopback socket can still succeed before the
+	// peer's RST is processed, which would count as a delivery. CloseNow is
+	// idempotent and concurrency safe, so racing the handler's own close is
+	// fine.
+	_ = cc.conn.CloseNow()
+	// Insert the pending row only after the disconnect is observed: the
+	// handler calls sendNextQueuedMessage right after acking registration,
+	// so an earlier insert could race that drain and be delivered over the
+	// still-live socket. The disconnect cleanup happens-after that call on
+	// the handler goroutine, so the drain can no longer see this row.
+	insertPendingMessage(t, db, clawID, "retry me", now())
+	// The closed connection makes the write fail; the row must remain eligible.
 	s.sendNextQueuedMessage(cc)
 	assertMessagesDelivered(t, db, clawID, 0)
 


### PR DESCRIPTION
## Problem

`TestSendNextQueuedMessageKeepsPendingAfterWriteFailure` failed intermittently (~1 in 8 runs locally, reproduced at `origin/main`) with:

```
server_test.go:2118: delivered messages = 1, want 0
```

It broke CI gating for PR #525's E2E suites.

## Diagnosis

The race is entirely in the **test** — the production queue logic is correct (a message is only marked delivered after a successful WS write).

Two layers:

1. **Registration-drain race.** The claw WS handler sends the `registered` ack and *then* calls `sendNextQueuedMessage` (`server.go:2240`). The test synchronized only on the ack before inserting the pending row, so the registration-time drain could run after the insert and legitimately deliver the message over the still-live connection. Failure logs confirm this: `[hub] delivered pending message` appears immediately after `[bridge] ✓ connected`, with no write error.
2. **Half-closed TCP write race.** Even after reordering, a residual ~1-2/50 flake remained: `waitForTestClawDisconnect` only observes the `s.claws` map deletion, and a TCP write into the client-severed loopback socket can still succeed before the peer's RST is processed, counting as a real delivery.

## Fix

- Sever the connection and wait for the disconnect **before** inserting the pending row. The disconnect cleanup happens-after the registration drain on the handler goroutine, so the drain can no longer see the row.
- Also close the server side (`cc.conn.CloseNow()`, idempotent and concurrency-safe) so the delivery write fails deterministically.

## Verification

- `go test ./pkg/hub/ -run TestSendNextQueuedMessageKeepsPendingAfterWriteFailure -count=50` — run 4 times, 200/200 pass (previously ~1 in 8 failed).
- `-race -count=20` — clean (the test now closes the conn concurrently with the handler).
- Full `go test ./pkg/hub/` — pass.
- `go vet ./pkg/hub/` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)