### PR TITLE
Recover poisoned OpenClaw sessions

### DIFF
--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -1847,6 +1847,11 @@ func (gs *gatewaySession) abortActiveSession(ctx context.Context) error {
 	return nil
 }
 
+// providerRequestFormatErrorFragment is emitted by OpenClaw when a provider
+// rejects the assembled request schema or tool payload. Session recovery
+// depends on this upstream compatibility string, so keep the coupling explicit.
+const providerRequestFormatErrorFragment = "provider rejected the request schema or tool payload"
+
 func isRecoverableSessionSendError(err error) bool {
 	var sendErr *sessionSendRequestError
 	if !errors.As(err, &sendErr) {
@@ -1863,7 +1868,7 @@ func isProviderRequestFormatError(err error) bool {
 		return false
 	}
 	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "provider rejected the request schema or tool payload")
+	return strings.Contains(msg, providerRequestFormatErrorFragment)
 }
 
 // isRecoverableSessionLifecycleError identifies failures that can leave an

--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -1836,6 +1836,17 @@ func (gs *gatewaySession) createFreshSession(ctx context.Context, reason string)
 	return nil
 }
 
+func (gs *gatewaySession) abortActiveSession(ctx context.Context) error {
+	key := gs.getSessionKey()
+	if key == "" {
+		return nil
+	}
+	if _, err := gs.sendReq(ctx, "sessions.abort", map[string]string{"key": key}); err != nil {
+		return fmt.Errorf("sessions.abort: %w", err)
+	}
+	return nil
+}
+
 func isRecoverableSessionSendError(err error) bool {
 	var sendErr *sessionSendRequestError
 	if !errors.As(err, &sendErr) {
@@ -1843,7 +1854,32 @@ func isRecoverableSessionSendError(err error) bool {
 	}
 	msg := strings.ToLower(sendErr.err.Error())
 	return strings.Contains(msg, "context overflow") ||
-		strings.Contains(msg, "prompt too large")
+		strings.Contains(msg, "prompt too large") ||
+		isProviderRequestFormatError(sendErr.err)
+}
+
+func isProviderRequestFormatError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "provider rejected the request schema or tool payload")
+}
+
+// isRecoverableSessionLifecycleError identifies failures that can leave an
+// accepted OpenClaw turn stuck in the persistent session. Unlike a rejected
+// sessions.send request, these turns must not be replayed because they may
+// already have performed tool side effects. Rotating the session lets the next
+// hub message continue the story without inheriting the poisoned transcript.
+func isRecoverableSessionLifecycleError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var sendErr *sessionSendRequestError
+	if errors.As(err, &sendErr) {
+		return false
+	}
+	return errors.Is(err, context.DeadlineExceeded) || isProviderRequestFormatError(err)
 }
 
 // SendMessage sends a user message to the persistent session, streams chunks
@@ -1891,6 +1927,21 @@ func (gs *gatewaySession) SendMessage(ctx context.Context, message string, onChu
 				log.Printf("[gateway] retrying message after another goroutine reconnected gateway")
 			}
 			continue
+		}
+		if isRecoverableSessionLifecycleError(err) {
+			abortCtx, abortCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			abortErr := gs.abortActiveSession(abortCtx)
+			abortCancel()
+			if abortErr != nil {
+				log.Printf("[session] failed to abort poisoned session before recovery: %v", abortErr)
+			}
+			recoveryCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			resetErr := gs.createFreshSession(recoveryCtx, err.Error())
+			cancel()
+			if resetErr != nil {
+				return reply, fmt.Errorf("%w; session recovery failed: %v", err, resetErr)
+			}
+			return reply, fmt.Errorf("%w; OpenClaw session reset so the next message can continue", err)
 		}
 		if !isRecoverableSessionSendError(err) {
 			return reply, err

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -1310,6 +1310,7 @@ func TestIsRecoverableSessionSendError(t *testing.T) {
 		{name: "lifecycle prompt too large not retryable", err: errString("Context overflow: prompt too large for the model"), want: false},
 		{name: "send request context overflow", err: &sessionSendRequestError{err: errString("context overflow detected")}, want: true},
 		{name: "send request prompt too large", err: &sessionSendRequestError{err: errString("Context overflow: prompt too large for the model")}, want: true},
+		{name: "send request provider format rejection", err: &sessionSendRequestError{err: errString("LLM request failed: provider rejected the request schema or tool payload.")}, want: true},
 		{name: "send failure", err: errString("sessions.send failed: tool crashed"), want: false},
 	}
 	for _, tt := range tests {
@@ -1318,6 +1319,155 @@ func TestIsRecoverableSessionSendError(t *testing.T) {
 				t.Fatalf("isRecoverableSessionSendError(%v) = %v, want %v", tt.err, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestIsRecoverableSessionLifecycleError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "provider format rejection", err: errString("LLM request failed: provider rejected the request schema or tool payload."), want: true},
+		{name: "accepted turn deadline", err: context.DeadlineExceeded, want: true},
+		{name: "send request deadline", err: &sessionSendRequestError{err: context.DeadlineExceeded}, want: false},
+		{name: "caller cancellation", err: context.Canceled, want: false},
+		{name: "ordinary lifecycle error", err: errString("tool-policy: exec is not allowed"), want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isRecoverableSessionLifecycleError(tt.err); got != tt.want {
+				t.Fatalf("isRecoverableSessionLifecycleError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGatewaySessionResetsAfterProviderFormatLifecycleError(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const providerErr = "LLM request failed: provider rejected the request schema or tool payload."
+	testDone := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Errorf("accept websocket: %v", err)
+			return
+		}
+		defer conn.CloseNow()
+
+		readRequest := func(wantMethod string) (gwFrame, bool) {
+			var req gwFrame
+			if err := wsjson.Read(r.Context(), conn, &req); err != nil {
+				t.Errorf("read %s request: %v", wantMethod, err)
+				return gwFrame{}, false
+			}
+			if req.Method != wantMethod {
+				t.Errorf("request method = %q, want %q", req.Method, wantMethod)
+				return gwFrame{}, false
+			}
+			return req, true
+		}
+
+		sendReq, ok := readRequest("sessions.send")
+		if !ok {
+			return
+		}
+		if err := wsjson.Write(r.Context(), conn, gwFrame{Type: "res", ID: sendReq.ID, OK: true}); err != nil {
+			t.Errorf("accept sessions.send: %v", err)
+			return
+		}
+		if err := wsjson.Write(r.Context(), conn, gwFrame{
+			Type:  "event",
+			Event: "agent",
+			Payload: mustJSON(map[string]interface{}{
+				"stream":     "lifecycle",
+				"sessionKey": "session-1",
+				"data": map[string]string{
+					"phase": "error",
+					"error": providerErr,
+				},
+			}),
+		}); err != nil {
+			t.Errorf("write lifecycle error: %v", err)
+			return
+		}
+
+		abortReq, ok := readRequest("sessions.abort")
+		if !ok {
+			return
+		}
+		var abortParams map[string]string
+		if err := json.Unmarshal(abortReq.Params, &abortParams); err != nil {
+			t.Errorf("decode sessions.abort params: %v", err)
+			return
+		}
+		if abortParams["key"] != "session-1" {
+			t.Errorf("sessions.abort key = %q, want session-1", abortParams["key"])
+			return
+		}
+		if err := wsjson.Write(r.Context(), conn, gwFrame{Type: "res", ID: abortReq.ID, OK: true}); err != nil {
+			t.Errorf("abort poisoned session: %v", err)
+			return
+		}
+
+		createReq, ok := readRequest("sessions.create")
+		if !ok {
+			return
+		}
+		if err := wsjson.Write(r.Context(), conn, gwFrame{
+			Type:    "res",
+			ID:      createReq.ID,
+			OK:      true,
+			Payload: mustJSON(map[string]string{"key": "session-2"}),
+		}); err != nil {
+			t.Errorf("create replacement session: %v", err)
+			return
+		}
+
+		subscribeReq, ok := readRequest("sessions.subscribe")
+		if !ok {
+			return
+		}
+		if err := wsjson.Write(r.Context(), conn, gwFrame{Type: "res", ID: subscribeReq.ID, OK: true}); err != nil {
+			t.Errorf("subscribe replacement session: %v", err)
+			return
+		}
+
+		<-testDone
+	}))
+	defer srv.Close()
+	defer close(testDone)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer conn.CloseNow()
+
+	gs := &gatewaySession{
+		sessionKey: "session-1",
+		conn:       conn,
+		pending:    make(map[string]chan gwFrame),
+	}
+	go gs.readLoop(ctx)
+
+	_, err = gs.SendMessage(ctx, "continue the task", nil, nil)
+	if err == nil {
+		t.Fatal("SendMessage returned nil error")
+	}
+	if !strings.Contains(err.Error(), providerErr) || !strings.Contains(err.Error(), "session reset") {
+		t.Fatalf("SendMessage error = %q, want provider error and recovery notice", err)
+	}
+	if got := gs.getSessionKey(); got != "session-2" {
+		t.Fatalf("session key = %q, want session-2", got)
+	}
+	if got := loadBridgeSession(); got != "session-2" {
+		t.Fatalf("persisted session key = %q, want session-2", got)
 	}
 }
 

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -1310,7 +1310,7 @@ func TestIsRecoverableSessionSendError(t *testing.T) {
 		{name: "lifecycle prompt too large not retryable", err: errString("Context overflow: prompt too large for the model"), want: false},
 		{name: "send request context overflow", err: &sessionSendRequestError{err: errString("context overflow detected")}, want: true},
 		{name: "send request prompt too large", err: &sessionSendRequestError{err: errString("Context overflow: prompt too large for the model")}, want: true},
-		{name: "send request provider format rejection", err: &sessionSendRequestError{err: errString("LLM request failed: provider rejected the request schema or tool payload.")}, want: true},
+		{name: "send request provider format rejection", err: &sessionSendRequestError{err: errString("LLM request failed: " + providerRequestFormatErrorFragment + ".")}, want: true},
 		{name: "send failure", err: errString("sessions.send failed: tool crashed"), want: false},
 	}
 	for _, tt := range tests {
@@ -1329,7 +1329,7 @@ func TestIsRecoverableSessionLifecycleError(t *testing.T) {
 		want bool
 	}{
 		{name: "nil", err: nil, want: false},
-		{name: "provider format rejection", err: errString("LLM request failed: provider rejected the request schema or tool payload."), want: true},
+		{name: "provider format rejection", err: errString("LLM request failed: " + providerRequestFormatErrorFragment + "."), want: true},
 		{name: "accepted turn deadline", err: context.DeadlineExceeded, want: true},
 		{name: "send request deadline", err: &sessionSendRequestError{err: context.DeadlineExceeded}, want: false},
 		{name: "caller cancellation", err: context.Canceled, want: false},
@@ -1347,7 +1347,7 @@ func TestIsRecoverableSessionLifecycleError(t *testing.T) {
 func TestGatewaySessionResetsAfterProviderFormatLifecycleError(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
-	const providerErr = "LLM request failed: provider rejected the request schema or tool payload."
+	const providerErr = "LLM request failed: " + providerRequestFormatErrorFragment + "."
 	testDone := make(chan struct{})
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		conn, err := websocket.Accept(w, r, nil)
@@ -1462,6 +1462,124 @@ func TestGatewaySessionResetsAfterProviderFormatLifecycleError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), providerErr) || !strings.Contains(err.Error(), "session reset") {
 		t.Fatalf("SendMessage error = %q, want provider error and recovery notice", err)
+	}
+	if got := gs.getSessionKey(); got != "session-2" {
+		t.Fatalf("session key = %q, want session-2", got)
+	}
+	if got := loadBridgeSession(); got != "session-2" {
+		t.Fatalf("persisted session key = %q, want session-2", got)
+	}
+}
+
+func TestGatewaySessionResetsAfterAcceptedTurnDeadline(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	testDone := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Errorf("accept websocket: %v", err)
+			return
+		}
+		defer conn.CloseNow()
+
+		readRequest := func(wantMethod string) (gwFrame, bool) {
+			var req gwFrame
+			if err := wsjson.Read(r.Context(), conn, &req); err != nil {
+				t.Errorf("read %s request: %v", wantMethod, err)
+				return gwFrame{}, false
+			}
+			if req.Method != wantMethod {
+				t.Errorf("request method = %q, want %q", req.Method, wantMethod)
+				return gwFrame{}, false
+			}
+			return req, true
+		}
+
+		sendReq, ok := readRequest("sessions.send")
+		if !ok {
+			return
+		}
+		if err := wsjson.Write(r.Context(), conn, gwFrame{Type: "res", ID: sendReq.ID, OK: true}); err != nil {
+			t.Errorf("accept sessions.send: %v", err)
+			return
+		}
+		// Do not emit a lifecycle result. The accepted turn must time out in
+		// sendMessageOnce before recovery aborts and rotates the session.
+
+		abortReq, ok := readRequest("sessions.abort")
+		if !ok {
+			return
+		}
+		var abortParams map[string]string
+		if err := json.Unmarshal(abortReq.Params, &abortParams); err != nil {
+			t.Errorf("decode sessions.abort params: %v", err)
+			return
+		}
+		if abortParams["key"] != "session-1" {
+			t.Errorf("sessions.abort key = %q, want session-1", abortParams["key"])
+			return
+		}
+		if err := wsjson.Write(r.Context(), conn, gwFrame{Type: "res", ID: abortReq.ID, OK: true}); err != nil {
+			t.Errorf("abort timed-out session: %v", err)
+			return
+		}
+
+		createReq, ok := readRequest("sessions.create")
+		if !ok {
+			return
+		}
+		if err := wsjson.Write(r.Context(), conn, gwFrame{
+			Type:    "res",
+			ID:      createReq.ID,
+			OK:      true,
+			Payload: mustJSON(map[string]string{"key": "session-2"}),
+		}); err != nil {
+			t.Errorf("create replacement session: %v", err)
+			return
+		}
+
+		subscribeReq, ok := readRequest("sessions.subscribe")
+		if !ok {
+			return
+		}
+		if err := wsjson.Write(r.Context(), conn, gwFrame{Type: "res", ID: subscribeReq.ID, OK: true}); err != nil {
+			t.Errorf("subscribe replacement session: %v", err)
+			return
+		}
+
+		<-testDone
+	}))
+	defer srv.Close()
+	defer close(testDone)
+
+	readCtx, stopRead := context.WithTimeout(context.Background(), 5*time.Second)
+	defer stopRead()
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	conn, _, err := websocket.Dial(readCtx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer conn.CloseNow()
+
+	gs := &gatewaySession{
+		sessionKey: "session-1",
+		conn:       conn,
+		pending:    make(map[string]chan gwFrame),
+	}
+	go gs.readLoop(readCtx)
+
+	sendCtx, cancelSend := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancelSend()
+	_, err = gs.SendMessage(sendCtx, "continue the task", nil, nil)
+	if err == nil {
+		t.Fatal("SendMessage returned nil error")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("SendMessage error = %v, want wrapped context deadline exceeded", err)
+	}
+	if !strings.Contains(err.Error(), "session reset") {
+		t.Fatalf("SendMessage error = %q, want recovery notice", err)
 	}
 	if got := gs.getSessionKey(); got != "session-2" {
 		t.Fatalf("session key = %q, want session-2", got)


### PR DESCRIPTION
## Summary

- detect provider request-schema/tool-payload failures that poison a persistent OpenClaw session
- recover accepted lifecycle failures and turn deadlines by best-effort aborting the old run, creating a fresh session, subscribing to it, and persisting its key
- preserve side-effect safety by never replaying a turn after `sessions.send` was accepted
- retry provider-format failures returned directly by `sessions.send`, where the turn was not accepted

## Why

OpenClaw can persist incompatible multi-turn tool history after a provider rejects a continuation payload. ElasticClaw previously surfaced the lifecycle error but kept reusing the same session, so every later workflow message failed and the story could no longer progress. A timed-out accepted turn had the same problem and could continue running in the background.

The recovery path uses OpenClaw `sessions.abort` before rotating an accepted/stuck session, preventing the old run from racing future work. Abort is best-effort so a terminal format error or an older gateway cannot block session replacement.

Related upstream reports:
- https://github.com/openclaw/openclaw/issues/68735
- https://github.com/openclaw/openclaw/issues/71160

## Verification

- `go test -race ./cmd/claw-bridge`
- `go vet ./cmd/claw-bridge`
- `go test ./...`

The gateway integration test proves the accepted turn error, abort, replacement-session creation, subscription, persistence, and user-visible recovery notice.