### PR TITLE
Add workspace repository glob patterns

### DIFF
--- a/cmd/workspace.go
+++ b/cmd/workspace.go
@@ -91,6 +91,12 @@ provider: replicated
 # repositories:
 #   - repo: owner/repo
 #     permissions: write
+#   # Patterns without an owner match repository names. Use "*" for all repos.
+#   - repo: "*-infra-*"
+#     permissions: read
+#   # Patterns with an owner match the full owner/repository name.
+#   - repo: "owner/*"
+#     permissions: read
 #
 # Optional workspace environment:
 # env:

--- a/pkg/hub/github.go
+++ b/pkg/hub/github.go
@@ -192,12 +192,15 @@ func (p *GitHubTokenProvider) ListInstallationRepositories(ctx context.Context, 
 		if err != nil {
 			return nil, fmt.Errorf("github list installation repositories: %w", err)
 		}
+		if resp.StatusCode != http.StatusOK {
+			var errBody map[string]interface{}
+			_ = json.NewDecoder(resp.Body).Decode(&errBody)
+			resp.Body.Close()
+			return nil, fmt.Errorf("github list installation repositories: status %d: %v", resp.StatusCode, errBody["message"])
+		}
 		var result githubInstallationRepositoriesResponse
 		decodeErr := json.NewDecoder(resp.Body).Decode(&result)
 		resp.Body.Close()
-		if resp.StatusCode != http.StatusOK {
-			return nil, fmt.Errorf("github list installation repositories: status %d", resp.StatusCode)
-		}
 		if decodeErr != nil {
 			return nil, fmt.Errorf("decode installation repositories: %w", decodeErr)
 		}

--- a/pkg/hub/github.go
+++ b/pkg/hub/github.go
@@ -34,10 +34,24 @@ type githubTokenResponse struct {
 	ExpiresAt time.Time `json:"expires_at"`
 }
 
+// githubRepository is the subset of repository metadata needed when expanding
+// workspace repository patterns.
+type githubRepository struct {
+	Name     string `json:"name"`
+	FullName string `json:"full_name"`
+}
+
+type githubInstallationRepositoriesResponse struct {
+	TotalCount   int                `json:"total_count"`
+	Repositories []githubRepository `json:"repositories"`
+}
+
 // GitHubTokenProvider generates installation tokens for a GitHub App.
 type GitHubTokenProvider struct {
 	cfg        *types.GitHubAppConfig
 	privateKey *rsa.PrivateKey
+	apiBaseURL string
+	httpClient *http.Client
 }
 
 // NewGitHubTokenProvider creates a provider from hub config.
@@ -46,7 +60,16 @@ func NewGitHubTokenProvider(cfg *types.GitHubAppConfig) (*GitHubTokenProvider, e
 	if err != nil {
 		return nil, fmt.Errorf("github app private key: %w", err)
 	}
-	return &GitHubTokenProvider{cfg: cfg, privateKey: key}, nil
+	return &GitHubTokenProvider{
+		cfg:        cfg,
+		privateKey: key,
+		apiBaseURL: "https://api.github.com",
+		httpClient: http.DefaultClient,
+	}, nil
+}
+
+func (p *GitHubTokenProvider) apiURL(path string) string {
+	return strings.TrimRight(p.apiBaseURL, "/") + path
 }
 
 func parseRSAPrivateKey(pemStr string) (*rsa.PrivateKey, error) {
@@ -122,12 +145,12 @@ func (p *GitHubTokenProvider) ListInstallations(ctx context.Context) ([]githubIn
 		return nil, fmt.Errorf("sign app jwt: %w", err)
 	}
 
-	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.github.com/app/installations?per_page=100", nil)
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, p.apiURL("/app/installations?per_page=100"), nil)
 	req.Header.Set("Authorization", "Bearer "+appJWT)
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := p.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("github list installations: %w", err)
 	}
@@ -142,6 +165,48 @@ func (p *GitHubTokenProvider) ListInstallations(ctx context.Context) ([]githubIn
 		return nil, fmt.Errorf("decode installations: %w", err)
 	}
 	return installations, nil
+}
+
+// ListInstallationRepositories returns every repository visible to one GitHub
+// App installation. GitHub requires an installation token for this endpoint,
+// so the provider first mints an unscoped token and then follows pagination.
+func (p *GitHubTokenProvider) ListInstallationRepositories(ctx context.Context, installationID int64) ([]githubRepository, error) {
+	token, _, err := p.InstallationToken(ctx, installationID, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create installation token: %w", err)
+	}
+
+	const perPage = 100
+	var repositories []githubRepository
+	for page := 1; ; page++ {
+		url := p.apiURL(fmt.Sprintf("/installation/repositories?per_page=%d&page=%d", perPage, page))
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return nil, fmt.Errorf("build repository list request: %w", err)
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("Accept", "application/vnd.github+json")
+		req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+		resp, err := p.httpClient.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("github list installation repositories: %w", err)
+		}
+		var result githubInstallationRepositoriesResponse
+		decodeErr := json.NewDecoder(resp.Body).Decode(&result)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("github list installation repositories: status %d", resp.StatusCode)
+		}
+		if decodeErr != nil {
+			return nil, fmt.Errorf("decode installation repositories: %w", decodeErr)
+		}
+
+		repositories = append(repositories, result.Repositories...)
+		if len(result.Repositories) < perPage || (result.TotalCount > 0 && len(repositories) >= result.TotalCount) {
+			return repositories, nil
+		}
+	}
 }
 
 // RepoAccess is a repo + permission level used when minting tokens.
@@ -206,7 +271,7 @@ func (p *GitHubTokenProvider) InstallationToken(ctx context.Context, installatio
 		bodyStr = string(b)
 	}
 
-	url := fmt.Sprintf("https://api.github.com/app/installations/%d/access_tokens", installationID)
+	url := p.apiURL(fmt.Sprintf("/app/installations/%d/access_tokens", installationID))
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(bodyStr))
 	if err != nil {
 		return "", time.Time{}, err
@@ -218,7 +283,7 @@ func (p *GitHubTokenProvider) InstallationToken(ctx context.Context, installatio
 		req.Header.Set("Content-Type", "application/json")
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := p.httpClient.Do(req)
 	if err != nil {
 		return "", time.Time{}, fmt.Errorf("github api: %w", err)
 	}
@@ -246,7 +311,7 @@ func (p *GitHubTokenProvider) CheckAppPermissions(ctx context.Context) (map[stri
 		return nil, fmt.Errorf("sign app jwt: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.github.com/app", nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.apiURL("/app"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("build request: %w", err)
 	}
@@ -254,7 +319,7 @@ func (p *GitHubTokenProvider) CheckAppPermissions(ctx context.Context) (map[stri
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := p.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("github get app: %w", err)
 	}

--- a/pkg/hub/github_issues.go
+++ b/pkg/hub/github_issues.go
@@ -506,6 +506,10 @@ func assignedToMatches(filter, assignee string) bool {
 }
 
 func (s *Server) createClawForGitHubIssueWorkflow(workspace *types.WorkspaceConfig, workflow *types.WorkflowConfig, payload githubIssuesWebhookPayload, reason string) (string, bool, error) {
+	return s.createClawForGitHubIssueWorkflowContext(context.Background(), workspace, workflow, payload, reason)
+}
+
+func (s *Server) createClawForGitHubIssueWorkflowContext(ctx context.Context, workspace *types.WorkspaceConfig, workflow *types.WorkflowConfig, payload githubIssuesWebhookPayload, reason string) (string, bool, error) {
 	issueID := fmt.Sprintf("%s/%d", payload.Repository.FullName, payload.Issue.Number)
 	issueCreatedAt := parseRFC3339Timestamp(payload.Issue.CreatedAt)
 	var existing string
@@ -549,6 +553,7 @@ func (s *Server) createClawForGitHubIssueWorkflow(workspace *types.WorkspaceConf
 	}
 
 	clawID, _, err := s.createClawFromWorkflowWithOptions(workspace, workflow, workflowCreateOptions{
+		ctx:                  ctx,
 		workspaceFiles:       templateFiles,
 		clawName:             clawName,
 		githubIssueID:        issueID,

--- a/pkg/hub/repository_globs.go
+++ b/pkg/hub/repository_globs.go
@@ -1,0 +1,152 @@
+package hub
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func hasRepositoryGlob(repositories []types.GitHubRepoAccess) bool {
+	for _, repository := range repositories {
+		if strings.ContainsAny(repository.Repo, "*?[") {
+			return true
+		}
+	}
+	return false
+}
+
+// expandRepositoryAccess resolves repository selectors against one GitHub App
+// installation. Patterns without a slash match repository names; patterns with
+// a slash match the canonical owner/repository name.
+func expandRepositoryAccess(selectors []types.GitHubRepoAccess, available []githubRepository) ([]types.GitHubRepoAccess, error) {
+	type selectedRepository struct {
+		name       string
+		permission string
+	}
+	selected := make(map[string]selectedRepository)
+
+	for _, selector := range selectors {
+		pattern := strings.ToLower(selector.Repo)
+		isGlob := strings.ContainsAny(pattern, "*?[")
+		matchFullName := strings.Contains(pattern, "/")
+		matched := false
+
+		for _, repository := range available {
+			if repository.FullName == "" || repository.Name == "" {
+				continue
+			}
+			target := strings.ToLower(repository.Name)
+			if matchFullName || !isGlob {
+				target = strings.ToLower(repository.FullName)
+			}
+
+			var matches bool
+			if isGlob {
+				var err error
+				matches, err = path.Match(pattern, target)
+				if err != nil {
+					return nil, fmt.Errorf("invalid repository pattern %q: %w", selector.Repo, err)
+				}
+			} else {
+				matches = pattern == target
+			}
+			if !matches {
+				continue
+			}
+
+			matched = true
+			key := strings.ToLower(repository.FullName)
+			permission := selector.Permissions
+			if permission == "" {
+				permission = "read"
+			}
+			_, exists := selected[key]
+			if !exists || permission == "write" {
+				selected[key] = selectedRepository{name: repository.FullName, permission: permission}
+			}
+		}
+		if !matched {
+			kind := "repository"
+			if isGlob {
+				kind = "repository pattern"
+			}
+			return nil, fmt.Errorf("%s %q matched no repositories accessible to this GitHub App installation", kind, selector.Repo)
+		}
+	}
+
+	keys := make([]string, 0, len(selected))
+	for key := range selected {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	expanded := make([]types.GitHubRepoAccess, 0, len(keys))
+	for _, key := range keys {
+		repository := selected[key]
+		expanded = append(expanded, types.GitHubRepoAccess{
+			Repo:        repository.name,
+			Permissions: repository.permission,
+		})
+	}
+	return expanded, nil
+}
+
+// expandWorkspaceRepositories selects the first configured GitHub App
+// installation that can satisfy every selector. Keeping the expansion within
+// one installation is required because each claw currently uses one GitHub
+// installation token for all repository operations.
+func (s *Server) expandWorkspaceRepositories(ctx context.Context, workspaceName string, selectors []types.GitHubRepoAccess) ([]types.GitHubRepoAccess, error) {
+	if !hasRepositoryGlob(selectors) {
+		return append([]types.GitHubRepoAccess(nil), selectors...), nil
+	}
+
+	workspaceApps, err := loadWorkspaceGitHubAppConfigs(workspaceName)
+	if err != nil {
+		return nil, fmt.Errorf("load workspace GitHub Apps: %w", err)
+	}
+	s.mu.RLock()
+	hubApps := append([]*types.GitHubAppConfig(nil), s.hubCfg.GitHubApps...)
+	s.mu.RUnlock()
+	githubApps := append(workspaceApps, hubApps...)
+	if len(githubApps) == 0 {
+		return nil, fmt.Errorf("repository patterns require a GitHub App configured for workspace %q", workspaceName)
+	}
+
+	var failures []string
+	for _, appConfig := range githubApps {
+		provider, err := NewGitHubTokenProvider(appConfig)
+		if err != nil {
+			failures = append(failures, fmt.Sprintf("app %d: %v", appConfig.AppID, err))
+			continue
+		}
+		if s.githubBaseURL != "" {
+			provider.apiBaseURL = s.githubBaseURL
+		}
+
+		installations, err := provider.ListInstallations(ctx)
+		if err != nil {
+			failures = append(failures, fmt.Sprintf("app %d: %v", appConfig.AppID, err))
+			continue
+		}
+		for _, installation := range installations {
+			available, err := provider.ListInstallationRepositories(ctx, installation.ID)
+			if err != nil {
+				failures = append(failures, fmt.Sprintf("app %d installation %d: %v", appConfig.AppID, installation.ID, err))
+				continue
+			}
+			expanded, err := expandRepositoryAccess(selectors, available)
+			if err == nil {
+				return expanded, nil
+			}
+			failures = append(failures, fmt.Sprintf("app %d installation %d: %v", appConfig.AppID, installation.ID, err))
+		}
+	}
+
+	if len(failures) == 0 {
+		return nil, fmt.Errorf("no installations found for the GitHub Apps configured for workspace %q", workspaceName)
+	}
+	return nil, fmt.Errorf("no single GitHub App installation can satisfy workspace repository selectors: %s", strings.Join(failures, "; "))
+}

--- a/pkg/hub/repository_globs.go
+++ b/pkg/hub/repository_globs.go
@@ -128,12 +128,18 @@ func (s *Server) expandWorkspaceRepositories(ctx context.Context, workspaceName 
 
 		installations, err := provider.ListInstallations(ctx)
 		if err != nil {
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
 			failures = append(failures, fmt.Sprintf("app %d: %v", appConfig.AppID, err))
 			continue
 		}
 		for _, installation := range installations {
 			available, err := provider.ListInstallationRepositories(ctx, installation.ID)
 			if err != nil {
+				if ctx.Err() != nil {
+					return nil, ctx.Err()
+				}
 				failures = append(failures, fmt.Sprintf("app %d installation %d: %v", appConfig.AppID, installation.ID, err))
 				continue
 			}

--- a/pkg/hub/repository_globs_test.go
+++ b/pkg/hub/repository_globs_test.go
@@ -1,0 +1,211 @@
+package hub
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func TestExpandRepositoryAccess(t *testing.T) {
+	available := []githubRepository{
+		{Name: "api-infra-prod", FullName: "Acme/api-infra-prod"},
+		{Name: "web-infra-dev", FullName: "Acme/web-infra-dev"},
+		{Name: "website", FullName: "Acme/website"},
+		{Name: "api-infra-prod", FullName: "Other/api-infra-prod"},
+	}
+	selectors := []types.GitHubRepoAccess{
+		{Repo: "*-infra-*", Permissions: "read"},
+		{Repo: "acme/api-*", Permissions: "write"},
+		{Repo: "Acme/website", Permissions: "read"},
+	}
+
+	got, err := expandRepositoryAccess(selectors, available)
+	if err != nil {
+		t.Fatalf("expandRepositoryAccess: %v", err)
+	}
+	want := []types.GitHubRepoAccess{
+		{Repo: "Acme/api-infra-prod", Permissions: "write"},
+		{Repo: "Acme/web-infra-dev", Permissions: "read"},
+		{Repo: "Acme/website", Permissions: "read"},
+		{Repo: "Other/api-infra-prod", Permissions: "read"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expanded repositories = %#v, want %#v", got, want)
+	}
+}
+
+func TestExpandRepositoryAccessAllRepositories(t *testing.T) {
+	available := []githubRepository{
+		{Name: "zeta", FullName: "acme/zeta"},
+		{Name: "alpha", FullName: "acme/alpha"},
+	}
+	got, err := expandRepositoryAccess([]types.GitHubRepoAccess{{Repo: "*", Permissions: "write"}}, available)
+	if err != nil {
+		t.Fatalf("expandRepositoryAccess: %v", err)
+	}
+	want := []types.GitHubRepoAccess{
+		{Repo: "acme/alpha", Permissions: "write"},
+		{Repo: "acme/zeta", Permissions: "write"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expanded repositories = %#v, want %#v", got, want)
+	}
+}
+
+func TestExpandRepositoryAccessRejectsUnmatchedPattern(t *testing.T) {
+	_, err := expandRepositoryAccess(
+		[]types.GitHubRepoAccess{{Repo: "*-infra-*", Permissions: "read"}},
+		[]githubRepository{{Name: "website", FullName: "acme/website"}},
+	)
+	if err == nil || !strings.Contains(err.Error(), `repository pattern "*-infra-*" matched no repositories`) {
+		t.Fatalf("error = %v, want unmatched pattern error", err)
+	}
+}
+
+func TestHasRepositoryGlob(t *testing.T) {
+	if hasRepositoryGlob([]types.GitHubRepoAccess{{Repo: "acme/api"}}) {
+		t.Fatal("exact repository unexpectedly detected as a glob")
+	}
+	if !hasRepositoryGlob([]types.GitHubRepoAccess{{Repo: "acme/api-?"}}) {
+		t.Fatal("repository pattern was not detected")
+	}
+}
+
+func TestListInstallationRepositoriesPaginates(t *testing.T) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		t.Fatalf("generate private key: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/app/installations/42/access_tokens":
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"token":"installation-token","expires_at":"2030-01-01T00:00:00Z"}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/installation/repositories":
+			if r.Header.Get("Authorization") != "Bearer installation-token" {
+				http.Error(w, "missing installation token", http.StatusUnauthorized)
+				return
+			}
+			page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+			repositories := make([]githubRepository, 0, 100)
+			start, count := 0, 100
+			if page == 2 {
+				start, count = 100, 1
+			}
+			for i := start; i < start+count; i++ {
+				repositories = append(repositories, githubRepository{
+					Name:     fmt.Sprintf("repo-%03d", i),
+					FullName: fmt.Sprintf("acme/repo-%03d", i),
+				})
+			}
+			_ = json.NewEncoder(w).Encode(githubInstallationRepositoriesResponse{
+				TotalCount:   101,
+				Repositories: repositories,
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	provider := &GitHubTokenProvider{
+		cfg:        &types.GitHubAppConfig{AppID: 123},
+		privateKey: privateKey,
+		apiBaseURL: server.URL,
+		httpClient: server.Client(),
+	}
+	repositories, err := provider.ListInstallationRepositories(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("ListInstallationRepositories: %v", err)
+	}
+	if len(repositories) != 101 {
+		t.Fatalf("repository count = %d, want 101", len(repositories))
+	}
+	if repositories[100].FullName != "acme/repo-100" {
+		t.Fatalf("last repository = %q, want acme/repo-100", repositories[100].FullName)
+	}
+}
+
+func TestWorkflowCreationStoresExpandedRepositories(t *testing.T) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		t.Fatalf("generate private key: %v", err)
+	}
+	privateKeyPEM := string(pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
+	}))
+
+	github := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/app/installations":
+			_, _ = w.Write([]byte(`[{"id":42,"account":{"login":"acme"}}]`))
+		case r.Method == http.MethodPost && r.URL.Path == "/app/installations/42/access_tokens":
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"token":"installation-token","expires_at":"2030-01-01T00:00:00Z"}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/installation/repositories":
+			_ = json.NewEncoder(w).Encode(githubInstallationRepositoriesResponse{
+				TotalCount: 2,
+				Repositories: []githubRepository{
+					{Name: "api-infra-prod", FullName: "acme/api-infra-prod"},
+					{Name: "website", FullName: "acme/website"},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer github.Close()
+
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{
+		Token:     "test-token",
+		ClawToken: "test-claw-token",
+		Providers: map[string]types.ProviderConfig{"noop": {Type: "noop"}},
+		GitHubApps: []*types.GitHubAppConfig{{
+			AppID:         123,
+			PrivateKeyPEM: privateKeyPEM,
+		}},
+	}, github.URL, "", "")
+	workspace := &types.WorkspaceConfig{
+		Name: "engineering",
+		Repositories: []types.GitHubRepoAccess{
+			{Repo: "*-infra-*", Permissions: "write"},
+		},
+		Files: map[string]string{
+			"elasticclaw-config.yaml": "schema_version: v1\nname: engineering\nprovider: noop\n",
+		},
+	}
+	workflow := &types.WorkflowConfig{Name: "infra-update", Provider: "noop"}
+
+	clawID, _, err := s.createClawFromWorkflow(workspace, workflow, nil, "test")
+	if err != nil {
+		t.Fatalf("createClawFromWorkflow: %v", err)
+	}
+	var repositoriesJSON string
+	if err := db.QueryRow(`SELECT github_repos FROM claws WHERE id=?`, clawID).Scan(&repositoriesJSON); err != nil {
+		t.Fatalf("read claw repositories: %v", err)
+	}
+	var repositories []types.GitHubRepoAccess
+	if err := json.Unmarshal([]byte(repositoriesJSON), &repositories); err != nil {
+		t.Fatalf("decode claw repositories: %v", err)
+	}
+	want := []types.GitHubRepoAccess{{Repo: "acme/api-infra-prod", Permissions: "write"}}
+	if !reflect.DeepEqual(repositories, want) {
+		t.Fatalf("stored repositories = %#v, want %#v", repositories, want)
+	}
+}

--- a/pkg/hub/repository_globs_test.go
+++ b/pkg/hub/repository_globs_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -84,11 +85,6 @@ func TestHasRepositoryGlob(t *testing.T) {
 }
 
 func TestListInstallationRepositoriesPaginates(t *testing.T) {
-	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
-	if err != nil {
-		t.Fatalf("generate private key: %v", err)
-	}
-
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodPost && r.URL.Path == "/app/installations/42/access_tokens":
@@ -121,12 +117,7 @@ func TestListInstallationRepositoriesPaginates(t *testing.T) {
 	}))
 	defer server.Close()
 
-	provider := &GitHubTokenProvider{
-		cfg:        &types.GitHubAppConfig{AppID: 123},
-		privateKey: privateKey,
-		apiBaseURL: server.URL,
-		httpClient: server.Client(),
-	}
+	provider := newTestGitHubTokenProvider(t, server)
 	repositories, err := provider.ListInstallationRepositories(context.Background(), 42)
 	if err != nil {
 		t.Fatalf("ListInstallationRepositories: %v", err)
@@ -136,6 +127,42 @@ func TestListInstallationRepositoriesPaginates(t *testing.T) {
 	}
 	if repositories[100].FullName != "acme/repo-100" {
 		t.Fatalf("last repository = %q, want acme/repo-100", repositories[100].FullName)
+	}
+}
+
+func TestListInstallationRepositoriesIncludesGitHubErrorMessage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/app/installations/42/access_tokens":
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"token":"installation-token","expires_at":"2030-01-01T00:00:00Z"}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/installation/repositories":
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"message":"Resource not accessible by integration"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	provider := newTestGitHubTokenProvider(t, server)
+	_, err := provider.ListInstallationRepositories(context.Background(), 42)
+	if err == nil || !strings.Contains(err.Error(), "status 403: Resource not accessible by integration") {
+		t.Fatalf("error = %v, want GitHub status and message", err)
+	}
+}
+
+func newTestGitHubTokenProvider(t *testing.T, server *httptest.Server) *GitHubTokenProvider {
+	t.Helper()
+	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		t.Fatalf("generate private key: %v", err)
+	}
+	return &GitHubTokenProvider{
+		cfg:        &types.GitHubAppConfig{AppID: 123},
+		privateKey: privateKey,
+		apiBaseURL: server.URL,
+		httpClient: server.Client(),
 	}
 }
 
@@ -192,7 +219,7 @@ func TestWorkflowCreationStoresExpandedRepositories(t *testing.T) {
 	}
 	workflow := &types.WorkflowConfig{Name: "infra-update", Provider: "noop"}
 
-	clawID, _, err := s.createClawFromWorkflow(workspace, workflow, nil, "test")
+	clawID, _, err := s.createClawFromWorkflowContext(context.Background(), workspace, workflow, nil, "test")
 	if err != nil {
 		t.Fatalf("createClawFromWorkflow: %v", err)
 	}
@@ -207,5 +234,19 @@ func TestWorkflowCreationStoresExpandedRepositories(t *testing.T) {
 	want := []types.GitHubRepoAccess{{Repo: "acme/api-infra-prod", Permissions: "write"}}
 	if !reflect.DeepEqual(repositories, want) {
 		t.Fatalf("stored repositories = %#v, want %#v", repositories, want)
+	}
+
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, _, err = s.createClawFromWorkflowContext(canceledCtx, workspace, workflow, nil, "canceled test")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled workflow creation error = %v, want context.Canceled", err)
+	}
+	var clawCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM claws`).Scan(&clawCount); err != nil {
+		t.Fatalf("count claws: %v", err)
+	}
+	if clawCount != 1 {
+		t.Fatalf("claw count after canceled expansion = %d, want 1", clawCount)
 	}
 }

--- a/pkg/hub/workflow_creator.go
+++ b/pkg/hub/workflow_creator.go
@@ -15,6 +15,7 @@ import (
 )
 
 type workflowCreateOptions struct {
+	ctx                  context.Context
 	inputs               map[string]string
 	workspaceFiles       map[string]string
 	clawName             string
@@ -43,7 +44,11 @@ func workspaceTemplateFiles(files map[string]string) map[string]string {
 }
 
 func (s *Server) createClawFromWorkflow(workspace *types.WorkspaceConfig, workflow *types.WorkflowConfig, inputs map[string]string, reason string) (string, bool, error) {
-	return s.createClawFromWorkflowWithOptions(workspace, workflow, workflowCreateOptions{inputs: inputs, reason: reason})
+	return s.createClawFromWorkflowContext(context.Background(), workspace, workflow, inputs, reason)
+}
+
+func (s *Server) createClawFromWorkflowContext(ctx context.Context, workspace *types.WorkspaceConfig, workflow *types.WorkflowConfig, inputs map[string]string, reason string) (string, bool, error) {
+	return s.createClawFromWorkflowWithOptions(workspace, workflow, workflowCreateOptions{ctx: ctx, inputs: inputs, reason: reason})
 }
 
 func (s *Server) createClawFromWorkflowWithOptions(workspace *types.WorkspaceConfig, workflow *types.WorkflowConfig, opts workflowCreateOptions) (string, bool, error) {
@@ -190,7 +195,11 @@ func (s *Server) createClawFromWorkflowWithOptions(workspace *types.WorkspaceCon
 		repositories = append([]types.GitHubRepoAccess(nil), workspace.Repositories...)
 	}
 	if hasRepositoryGlob(repositories) {
-		expandCtx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+		parentCtx := opts.ctx
+		if parentCtx == nil {
+			parentCtx = context.Background()
+		}
+		expandCtx, cancel := context.WithTimeout(parentCtx, 45*time.Second)
 		defer cancel()
 		repositories, err = s.expandWorkspaceRepositories(expandCtx, workspace.Name, repositories)
 		if err != nil {

--- a/pkg/hub/workflow_creator.go
+++ b/pkg/hub/workflow_creator.go
@@ -189,6 +189,14 @@ func (s *Server) createClawFromWorkflowWithOptions(workspace *types.WorkspaceCon
 	if len(workspace.Repositories) > 0 {
 		repositories = append([]types.GitHubRepoAccess(nil), workspace.Repositories...)
 	}
+	if hasRepositoryGlob(repositories) {
+		expandCtx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+		defer cancel()
+		repositories, err = s.expandWorkspaceRepositories(expandCtx, workspace.Name, repositories)
+		if err != nil {
+			return "", false, fmt.Errorf("expand workspace repositories: %w", err)
+		}
+	}
 	if tmplCfg != nil {
 		instanceType = tmplCfg.InstanceType
 		llmKey = tmplCfg.LLMKey

--- a/pkg/hub/workspace_api.go
+++ b/pkg/hub/workspace_api.go
@@ -1,6 +1,7 @@
 package hub
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -327,7 +328,7 @@ func (s *Server) triggerWorkflowConfig(w http.ResponseWriter, r *http.Request, w
 	}
 
 	if workflow.Integration == "github-issues" || (workflow.Trigger != nil && workflow.Trigger.GitHubIssues != nil) {
-		clawID, created, err := s.createClawForManualGitHubIssueWorkflow(workspace, workflow, validatedInputs)
+		clawID, created, err := s.createClawForManualGitHubIssueWorkflow(r.Context(), workspace, workflow, validatedInputs)
 		if err != nil {
 			if isFactoryTriggerAlreadyClaimed(err) {
 				jsonError(w, http.StatusConflict, "workflow trigger already in progress for this GitHub issue")
@@ -347,7 +348,7 @@ func (s *Server) triggerWorkflowConfig(w http.ResponseWriter, r *http.Request, w
 		return
 	}
 
-	clawID, _, err := s.createClawFromWorkflow(workspace, workflow, validatedInputs, "manual workflow trigger")
+	clawID, _, err := s.createClawFromWorkflowContext(r.Context(), workspace, workflow, validatedInputs, "manual workflow trigger")
 	if err != nil {
 		jsonError(w, http.StatusInternalServerError, "failed to create claw: "+err.Error())
 		return
@@ -358,7 +359,7 @@ func (s *Server) triggerWorkflowConfig(w http.ResponseWriter, r *http.Request, w
 	})
 }
 
-func (s *Server) createClawForManualGitHubIssueWorkflow(workspace *types.WorkspaceConfig, workflow *types.WorkflowConfig, inputs map[string]string) (string, bool, error) {
+func (s *Server) createClawForManualGitHubIssueWorkflow(ctx context.Context, workspace *types.WorkspaceConfig, workflow *types.WorkflowConfig, inputs map[string]string) (string, bool, error) {
 	rawIssueNumber := strings.TrimSpace(inputs["issue_number"])
 	if rawIssueNumber == "" {
 		return "", false, fmt.Errorf(`missing required input "issue_number"`)
@@ -401,7 +402,7 @@ func (s *Server) createClawForManualGitHubIssueWorkflow(workspace *types.Workspa
 	}
 
 	payload := buildGitHubIssuesPollPayloadForAction(issue, repo, "manual")
-	return s.createClawForGitHubIssueWorkflow(workspace, workflow, payload, "manual workflow trigger")
+	return s.createClawForGitHubIssueWorkflowContext(ctx, workspace, workflow, payload, "manual workflow trigger")
 }
 
 func (s *Server) queryGitHubIssue(repo, token, base string, issueNumber int) (githubIssuesPollItem, error) {

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -281,9 +281,10 @@ type GitHubAppConfig struct {
 	PrivateKeyPEM string `yaml:"private_key_pem"` // PEM-encoded RSA private key (paste directly in yaml)
 }
 
-// GitHubRepoAccess specifies a repo and the permissions needed.
+// GitHubRepoAccess specifies a repo and the permissions needed. Workspace
+// repository lists may also use glob patterns.
 type GitHubRepoAccess struct {
-	Repo        string `yaml:"repo"        json:"repo"`        // e.g. "owner/repo"
+	Repo        string `yaml:"repo"        json:"repo"`        // e.g. "owner/repo", "*-infra-*", or "owner/*"
 	Permissions string `yaml:"permissions" json:"permissions"` // "read" or "write" (default: "read")
 }
 
@@ -292,6 +293,8 @@ type GitHubRepoAccess struct {
 //	repositories:
 //	  - repo: owner/repo
 //	    permissions: write
+//	  - repo: "*-infra-*"
+//	    permissions: read
 //
 // and the earlier shorthand form:
 //

--- a/pkg/types/validation.go
+++ b/pkg/types/validation.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"fmt"
+	"path"
 	"regexp"
 	"strings"
 	"time"
@@ -582,19 +583,50 @@ func validateExternalTrigger(factoryName string, trigger *ExternalTrigger) error
 	return nil
 }
 
-func validateRepositoryAccessList(field string, repos []GitHubRepoAccess) error {
+func validateRepositoryAccessList(field string, repos []GitHubRepoAccess, allowPatterns bool) error {
 	for i, repo := range repos {
 		if repo.Repo == "" {
 			return fmt.Errorf("%s[%d]: repo is required", field, i)
 		}
-		if !repoRegex.MatchString(repo.Repo) {
+		if !allowPatterns && !repoRegex.MatchString(repo.Repo) {
 			return fmt.Errorf("%s[%d]: invalid repo format %q (expected owner/repo)", field, i, repo.Repo)
+		}
+		if allowPatterns && !validRepositoryAccessSelector(repo.Repo) {
+			return fmt.Errorf("%s[%d]: invalid repo format or pattern %q (expected owner/repo or a glob such as *, *-infra-*, or owner/*)", field, i, repo.Repo)
 		}
 		if repo.Permissions != "" && repo.Permissions != "read" && repo.Permissions != "write" {
 			return fmt.Errorf("%s[%d]: invalid permissions %q (must be read or write)", field, i, repo.Permissions)
 		}
 	}
 	return nil
+}
+
+func validRepositoryAccessSelector(selector string) bool {
+	if selector == "" || strings.TrimSpace(selector) != selector || strings.Count(selector, "/") > 1 {
+		return false
+	}
+
+	hasGlob := strings.ContainsAny(selector, "*?[")
+	if !hasGlob {
+		return repoRegex.MatchString(selector)
+	}
+	if _, err := path.Match(selector, ""); err != nil {
+		return false
+	}
+
+	parts := strings.Split(selector, "/")
+	if len(parts) == 2 && (parts[0] == "" || parts[1] == "") {
+		return false
+	}
+	for _, r := range selector {
+		if r == '/' || r == '*' || r == '?' || r == '[' || r == ']' ||
+			r == '-' || r == '_' || r == '.' ||
+			(r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 // Validate validates a TemplateConfig and returns an error if invalid.
@@ -616,13 +648,13 @@ func (t *TemplateConfig) Validate() error {
 		return fmt.Errorf("invalid color %q", t.Color)
 	}
 
-	if err := validateRepositoryAccessList("repositories", t.Repositories); err != nil {
+	if err := validateRepositoryAccessList("repositories", t.Repositories, false); err != nil {
 		return err
 	}
 
 	// Validate GitHub repos if provided
 	if t.GitHub != nil {
-		if err := validateRepositoryAccessList("github.repos", t.GitHub.Repos); err != nil {
+		if err := validateRepositoryAccessList("github.repos", t.GitHub.Repos, false); err != nil {
 			return err
 		}
 	}

--- a/pkg/types/validation_test.go
+++ b/pkg/types/validation_test.go
@@ -7,6 +7,43 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+func TestValidateRepositoryAccessPatterns(t *testing.T) {
+	tests := []struct {
+		selector string
+		valid    bool
+	}{
+		{selector: "owner/repo", valid: true},
+		{selector: "*", valid: true},
+		{selector: "*-infra-*", valid: true},
+		{selector: "owner/*", valid: true},
+		{selector: "owner/repo-?", valid: true},
+		{selector: "owner/[ab]pi", valid: true},
+		{selector: "repo", valid: false},
+		{selector: "owner/", valid: false},
+		{selector: "owner/[", valid: false},
+		{selector: "owner/repo/extra", valid: false},
+		{selector: "owner name/*", valid: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.selector, func(t *testing.T) {
+			workspace := &WorkspaceConfig{
+				Name: "test",
+				Repositories: []GitHubRepoAccess{{
+					Repo:        tt.selector,
+					Permissions: "read",
+				}},
+			}
+			err := workspace.Validate()
+			if tt.valid && err != nil {
+				t.Fatalf("Validate() error = %v", err)
+			}
+			if !tt.valid && err == nil {
+				t.Fatal("Validate() succeeded for invalid repository selector")
+			}
+		})
+	}
+}
+
 func TestFactoryConfigValidate(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/pkg/types/workspace.go
+++ b/pkg/types/workspace.go
@@ -182,7 +182,7 @@ func (w *WorkspaceConfig) Validate() error {
 	if w.Name == "" {
 		return fmt.Errorf("workspace name is required")
 	}
-	if err := validateRepositoryAccessList("repositories", w.Repositories); err != nil {
+	if err := validateRepositoryAccessList("repositories", w.Repositories, true); err != nil {
 		return fmt.Errorf("workspace %q: %w", w.Name, err)
 	}
 	for _, workflow := range w.Workflows {


### PR DESCRIPTION
## Summary

- allow workspace `repositories` entries to use globs such as `*`, `*-infra-*`, and `owner/*`
- expand patterns against repositories visible to the workspace or hub GitHub Apps before creating a claw
- keep expansion within one GitHub App installation so the resulting repository list can use one installation token
- deduplicate matches deterministically and preserve the strongest requested permission
- document repository glob examples in newly generated workspace configuration

## Matching behavior

- patterns without `/` match repository names across the selected installation
- patterns with `/` match the full `owner/repository` name
- exact `owner/repository` entries continue to work unchanged
- a pattern that matches nothing fails claw creation with a clear error

## Verification

- `go test ./...`
- integration coverage verifies paginated GitHub repository discovery and that claws store expanded concrete repository names
