### PR TITLE
Pause repeated no-progress workflow turns

### DIFF
--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -59,6 +59,7 @@ func migrate(db *sql.DB) error {
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN workflow_volumes TEXT NOT NULL DEFAULT '[]'`)
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN trigger_actor_json TEXT NOT NULL DEFAULT '{}'`)
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN stop_comment_pending INTEGER NOT NULL DEFAULT 0`)
+	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN no_progress_paused INTEGER NOT NULL DEFAULT 0`)
 	_, _ = db.Exec(`ALTER TABLE claw_prs ADD COLUMN last_comment_at TEXT NOT NULL DEFAULT ''`)
 	_, _ = db.Exec(`ALTER TABLE claw_prs ADD COLUMN pr_conditions_fired INTEGER NOT NULL DEFAULT 0`)
 	_, _ = db.Exec(`ALTER TABLE claw_prs ADD COLUMN permanent_failure_count INTEGER NOT NULL DEFAULT 0`)
@@ -114,6 +115,14 @@ func migrate(db *sql.DB) error {
 	)`)
 	_, _ = db.Exec(`CREATE INDEX IF NOT EXISTS idx_claw_checkpoints_claw ON claw_checkpoints(claw_id, created_at)`)
 	_, _ = db.Exec(`CREATE INDEX IF NOT EXISTS idx_claw_checkpoints_status ON claw_checkpoints(status, created_at)`)
+	_, _ = db.Exec(`CREATE TABLE IF NOT EXISTS claw_turn_observations (
+		id                   TEXT PRIMARY KEY,
+		claw_id              TEXT NOT NULL REFERENCES claws(id) ON DELETE CASCADE,
+		response             TEXT NOT NULL,
+		progress_fingerprint TEXT NOT NULL,
+		created_at           DATETIME NOT NULL
+	)`)
+	_, _ = db.Exec(`CREATE INDEX IF NOT EXISTS idx_claw_turn_observations_claw ON claw_turn_observations(claw_id, created_at)`)
 
 	_, _ = db.Exec(`CREATE TABLE IF NOT EXISTS ssh_known_hosts (
 		host          TEXT PRIMARY KEY,
@@ -248,7 +257,8 @@ func migrate(db *sql.DB) error {
 		task_run_id TEXT NOT NULL DEFAULT '',
 		workflow_volumes TEXT NOT NULL DEFAULT '[]',
 		trigger_actor_json TEXT NOT NULL DEFAULT '{}',
-		stop_comment_pending INTEGER NOT NULL DEFAULT 0
+		stop_comment_pending INTEGER NOT NULL DEFAULT 0,
+		no_progress_paused INTEGER NOT NULL DEFAULT 0
 	);
 
 
@@ -263,6 +273,15 @@ func migrate(db *sql.DB) error {
 		created_at DATETIME NOT NULL,
 		delivered_at DATETIME
 	);
+
+	CREATE TABLE IF NOT EXISTS claw_turn_observations (
+		id                   TEXT PRIMARY KEY,
+		claw_id              TEXT NOT NULL REFERENCES claws(id) ON DELETE CASCADE,
+		response             TEXT NOT NULL,
+		progress_fingerprint TEXT NOT NULL,
+		created_at           DATETIME NOT NULL
+	);
+	CREATE INDEX IF NOT EXISTS idx_claw_turn_observations_claw ON claw_turn_observations(claw_id, created_at);
 
 	CREATE TABLE IF NOT EXISTS factory_triggers (
 		id             TEXT PRIMARY KEY,

--- a/pkg/hub/github_webhook.go
+++ b/pkg/hub/github_webhook.go
@@ -282,7 +282,7 @@ func (s *Server) processGitHubPREvent(payload githubPRPayload) {
 						msg = fmt.Sprintf("PR #%d was reopened.", payload.Number)
 					}
 					log.Printf("[factory:%s] github PR #%d action=%s — injecting into claw %s", factory.Name, payload.Number, payload.Action, existingClawID[:8])
-					s.injectHubMessageByID(existingClawID, msg)
+					s.injectExternalHubMessageByID(existingClawID, msg)
 				}
 			default:
 				log.Printf("[factory:%s] github PR #%d action=%s — claw exists, no action taken", factory.Name, payload.Number, payload.Action)
@@ -471,7 +471,7 @@ func (s *Server) processGitHubIssueComment(payload githubIssueCommentPayload) {
 	existingClawID := s.findClawForGitHubIssue(issueURL)
 	if existingClawID != "" {
 		log.Printf("[github-webhook] issue_comment on issue #%d — injecting into existing claw %s", payload.Issue.Number, existingClawID[:8])
-		s.injectHubMessageByID(existingClawID, commentMsg)
+		s.injectExternalHubMessageByID(existingClawID, commentMsg)
 		return
 	}
 
@@ -505,7 +505,7 @@ func (s *Server) processGitHubIssueCommentEvent(payload githubIssueCommentPayloa
 	if existingClawID != "" {
 		// Inject the comment into the existing claw
 		log.Printf("[github-webhook] issue_comment on PR #%d — injecting into existing claw %s", prNumber, existingClawID[:8])
-		s.injectHubMessageByID(existingClawID, commentMsg)
+		s.injectExternalHubMessageByID(existingClawID, commentMsg)
 		return
 	}
 

--- a/pkg/hub/no_progress.go
+++ b/pkg/hub/no_progress.go
@@ -1,0 +1,243 @@
+package hub
+
+import (
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"log"
+	"regexp"
+	"sort"
+	"strings"
+	"unicode"
+
+	"github.com/google/uuid"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+const repeatedNoProgressTurnThreshold = 3
+
+var commitMarkerPattern = regexp.MustCompile(`(?i)\b[0-9a-f]{7,40}\b`)
+
+// observeCompletedTurn records the outcome and the external state visible at
+// the end of a workflow turn. It pauses automatic continuation only when the
+// latest outcomes are substantially the same and that state has not changed.
+// This is deliberately progress-based rather than a lifetime or turn limit.
+func (s *Server) observeCompletedTurn(clawID, messageID, content string) bool {
+	if strings.Contains(content, "[DONE]") || strings.Contains(content, "[TERMINATE]") {
+		return false
+	}
+	var stage string
+	var alreadyPaused bool
+	if err := s.db.QueryRow(`SELECT pipeline_stage, no_progress_paused != 0 FROM claws WHERE id=?`, clawID).Scan(&stage, &alreadyPaused); err != nil || stage == "" {
+		return false
+	}
+	if alreadyPaused {
+		return true
+	}
+
+	response := normalizeTurnOutcome(content)
+	if response == "" {
+		return false
+	}
+	progress := s.turnProgressFingerprint(clawID, content)
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		log.Printf("[no-progress] begin observation for claw %s: %v", shortID(clawID), err)
+		return false
+	}
+	defer tx.Rollback()
+
+	var previousResponse, previousProgress string
+	err = tx.QueryRow(`SELECT response, progress_fingerprint FROM claw_turn_observations WHERE claw_id=? ORDER BY rowid DESC LIMIT 1`, clawID).Scan(&previousResponse, &previousProgress)
+	if err != nil && err != sql.ErrNoRows {
+		log.Printf("[no-progress] load observation for claw %s: %v", shortID(clawID), err)
+		return false
+	}
+	if err == sql.ErrNoRows || previousProgress != progress || !similarTurnOutcomes(previousResponse, response) {
+		if _, err := tx.Exec(`DELETE FROM claw_turn_observations WHERE claw_id=?`, clawID); err != nil {
+			log.Printf("[no-progress] reset observations for claw %s: %v", shortID(clawID), err)
+			return false
+		}
+	}
+
+	if _, err := tx.Exec(`INSERT OR REPLACE INTO claw_turn_observations(id, claw_id, response, progress_fingerprint, created_at) VALUES(?,?,?,?,?)`, messageID, clawID, response, progress, now()); err != nil {
+		log.Printf("[no-progress] store observation for claw %s: %v", shortID(clawID), err)
+		return false
+	}
+	if _, err := tx.Exec(`DELETE FROM claw_turn_observations WHERE claw_id=? AND rowid NOT IN (SELECT rowid FROM claw_turn_observations WHERE claw_id=? ORDER BY rowid DESC LIMIT ?)`, clawID, clawID, repeatedNoProgressTurnThreshold); err != nil {
+		log.Printf("[no-progress] prune observations for claw %s: %v", shortID(clawID), err)
+		return false
+	}
+	var repeats int
+	if err := tx.QueryRow(`SELECT COUNT(*) FROM claw_turn_observations WHERE claw_id=?`, clawID).Scan(&repeats); err != nil {
+		return false
+	}
+	paused := repeats >= repeatedNoProgressTurnThreshold
+	if paused {
+		if _, err := tx.Exec(`UPDATE claws SET no_progress_paused=1 WHERE id=?`, clawID); err != nil {
+			return false
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		log.Printf("[no-progress] commit observation for claw %s: %v", shortID(clawID), err)
+		return false
+	}
+	if !paused {
+		return false
+	}
+
+	s.mu.RLock()
+	cc := s.claws[clawID]
+	s.mu.RUnlock()
+	if cc != nil {
+		cc.mu.Lock()
+		cc.noProgressPaused = true
+		cc.mu.Unlock()
+	}
+	log.Printf("[no-progress] paused automatic continuation for claw %s after %d repeated outcomes", shortID(clawID), repeats)
+	s.publishHubNotice(clawID, "[hub] Automatic continuation paused: the last three agent turns reported nearly the same outcome while workflow, CI, review, and pull-request state did not change. Send a message to resume after reviewing the activity.")
+	return true
+}
+
+func (s *Server) resumeNoProgressAfterUserInput(clawID string) {
+	res, err := s.db.Exec(`UPDATE claws SET no_progress_paused=0 WHERE id=? AND no_progress_paused!=0`, clawID)
+	if err != nil {
+		log.Printf("[no-progress] resume claw %s: %v", shortID(clawID), err)
+		return
+	}
+	_, _ = s.db.Exec(`DELETE FROM claw_turn_observations WHERE claw_id=?`, clawID)
+	s.mu.RLock()
+	cc := s.claws[clawID]
+	s.mu.RUnlock()
+	if cc != nil {
+		cc.mu.Lock()
+		cc.noProgressPaused = false
+		cc.mu.Unlock()
+	}
+	if changed, _ := res.RowsAffected(); changed > 0 {
+		log.Printf("[no-progress] resumed claw %s after new user or external input", shortID(clawID))
+	}
+}
+
+// publishHubNotice persists a dashboard-visible hub message without turning it
+// into another model prompt. It is used for bookkeeping and intervention
+// notices whose contents should not consume an agent turn.
+func (s *Server) publishHubNotice(clawID, content string) {
+	var tenantID string
+	if err := s.db.QueryRow(`SELECT tenant_id FROM claws WHERE id=?`, clawID).Scan(&tenantID); err != nil {
+		return
+	}
+	createdAt := now()
+	msg := types.HubMessage{
+		ID: uuid.New().String(), ClawID: clawID, TenantID: tenantID,
+		Role: "hub", Content: content, Format: "pre", CreatedAt: createdAt,
+	}
+	if _, err := s.db.Exec(`INSERT INTO messages(id,claw_id,tenant_id,role,content,format,created_at,delivered_at) VALUES(?,?,?,?,?,?,?,?)`, msg.ID, clawID, tenantID, msg.Role, msg.Content, msg.Format, createdAt, createdAt); err != nil {
+		log.Printf("[hub] persist notice for claw %s: %v", shortID(clawID), err)
+		return
+	}
+	s.broadcastToUsers(tenantID, types.WSMessage{Type: "message", Payload: msg})
+}
+
+func normalizeTurnOutcome(content string) string {
+	var b strings.Builder
+	space := true
+	for _, r := range strings.ToLower(strings.TrimSpace(content)) {
+		if unicode.IsLetter(r) || unicode.IsNumber(r) {
+			b.WriteRune(r)
+			space = false
+		} else if !space {
+			b.WriteByte(' ')
+			space = true
+		}
+	}
+	return strings.TrimSpace(b.String())
+}
+
+func similarTurnOutcomes(a, b string) bool {
+	if a == b {
+		return true
+	}
+	aWords := strings.Fields(a)
+	bWords := strings.Fields(b)
+	if len(aWords) < 12 || len(bWords) < 12 {
+		return false
+	}
+	aSet := make(map[string]struct{}, len(aWords))
+	bSet := make(map[string]struct{}, len(bWords))
+	for _, word := range aWords {
+		aSet[word] = struct{}{}
+	}
+	for _, word := range bWords {
+		bSet[word] = struct{}{}
+	}
+	intersection := 0
+	for word := range aSet {
+		if _, ok := bSet[word]; ok {
+			intersection++
+		}
+	}
+	union := len(aSet) + len(bSet) - intersection
+	return union > 0 && float64(intersection)/float64(union) >= 0.8
+}
+
+func (s *Server) turnProgressFingerprint(clawID, response string) string {
+	var parts []string
+	var stage, taskRunID string
+	_ = s.db.QueryRow(`SELECT pipeline_stage, task_run_id FROM claws WHERE id=?`, clawID).Scan(&stage, &taskRunID)
+	parts = append(parts, "stage="+stage)
+
+	if rows, err := s.db.Query(`SELECT repo, pr_number, last_ci_sha, last_comment_id, last_comment_at, last_review_comment_id, last_review_id, pr_conditions_fired FROM claw_prs WHERE claw_id=? ORDER BY repo, pr_number`, clawID); err == nil {
+		defer rows.Close()
+		for rows.Next() {
+			var repo, ciSHA, commentAt string
+			var number, commentID, reviewCommentID, reviewID, conditions int
+			if rows.Scan(&repo, &number, &ciSHA, &commentID, &commentAt, &reviewCommentID, &reviewID, &conditions) == nil {
+				parts = append(parts, fmt.Sprintf("pr=%s#%d:%s:%d:%s:%d:%d:%d", repo, number, ciSHA, commentID, commentAt, reviewCommentID, reviewID, conditions))
+			}
+		}
+	}
+	if taskRunID != "" {
+		if rows, err := s.db.Query(`SELECT repo, pr_number, head_sha, last_agent_head_sha, state, merged FROM task_run_prs WHERE run_id=? ORDER BY repo, pr_number`, taskRunID); err == nil {
+			defer rows.Close()
+			for rows.Next() {
+				var repo, headSHA, agentSHA, state string
+				var number, merged int
+				if rows.Scan(&repo, &number, &headSHA, &agentSHA, &state, &merged) == nil {
+					parts = append(parts, fmt.Sprintf("task-pr=%s#%d:%s:%s:%s:%d", repo, number, headSHA, agentSHA, state, merged))
+				}
+			}
+		}
+	}
+	if rows, err := s.db.Query(`SELECT output_name, exit_code, stdout, stderr, parsed_json FROM pipeline_outputs WHERE claw_id=? ORDER BY output_name`, clawID); err == nil {
+		defer rows.Close()
+		for rows.Next() {
+			var name, stdout, stderr, parsed string
+			var exitCode int
+			if rows.Scan(&name, &exitCode, &stdout, &stderr, &parsed) == nil {
+				parts = append(parts, fmt.Sprintf("output=%s:%d:%s:%s:%s", name, exitCode, stdout, stderr, parsed))
+			}
+		}
+	}
+	parts = append(parts, responseProgressMarkers(response)...)
+	sort.Strings(parts)
+	sum := sha256.Sum256([]byte(strings.Join(parts, "\x00")))
+	return hex.EncodeToString(sum[:])
+}
+
+func responseProgressMarkers(content string) []string {
+	markers := make([]string, 0)
+	for _, pr := range extractPRs(content) {
+		markers = append(markers, "mentioned-pr="+pr.url)
+	}
+	for _, sha := range commitMarkerPattern.FindAllString(strings.ToLower(content), -1) {
+		if strings.ContainsAny(sha, "abcdef") && strings.ContainsAny(sha, "0123456789") {
+			markers = append(markers, "mentioned-sha="+sha)
+		}
+	}
+	sort.Strings(markers)
+	return markers
+}

--- a/pkg/hub/no_progress.go
+++ b/pkg/hub/no_progress.go
@@ -28,6 +28,9 @@ func (s *Server) observeCompletedTurn(clawID, messageID, content string) bool {
 	if strings.Contains(content, "[DONE]") || strings.Contains(content, "[TERMINATE]") {
 		return false
 	}
+	s.noProgressMu.Lock()
+	defer s.noProgressMu.Unlock()
+
 	var stage string
 	var alreadyPaused bool
 	if err := s.db.QueryRow(`SELECT pipeline_stage, no_progress_paused != 0 FROM claws WHERE id=?`, clawID).Scan(&stage, &alreadyPaused); err != nil || stage == "" {
@@ -41,7 +44,11 @@ func (s *Server) observeCompletedTurn(clawID, messageID, content string) bool {
 	if response == "" {
 		return false
 	}
-	progress := s.turnProgressFingerprint(clawID, content)
+	progress, err := s.turnProgressFingerprint(clawID, content)
+	if err != nil {
+		log.Printf("[no-progress] fingerprint claw %s: %v", shortID(clawID), err)
+		return false
+	}
 
 	tx, err := s.db.Begin()
 	if err != nil {
@@ -103,6 +110,9 @@ func (s *Server) observeCompletedTurn(clawID, messageID, content string) bool {
 }
 
 func (s *Server) resumeNoProgressAfterUserInput(clawID string) {
+	s.noProgressMu.Lock()
+	defer s.noProgressMu.Unlock()
+
 	res, err := s.db.Exec(`UPDATE claws SET no_progress_paused=0 WHERE id=? AND no_progress_paused!=0`, clawID)
 	if err != nil {
 		log.Printf("[no-progress] resume claw %s: %v", shortID(clawID), err)
@@ -184,48 +194,76 @@ func similarTurnOutcomes(a, b string) bool {
 	return union > 0 && float64(intersection)/float64(union) >= 0.8
 }
 
-func (s *Server) turnProgressFingerprint(clawID, response string) string {
+func (s *Server) turnProgressFingerprint(clawID, response string) (string, error) {
 	var parts []string
 	var stage, taskRunID string
-	_ = s.db.QueryRow(`SELECT pipeline_stage, task_run_id FROM claws WHERE id=?`, clawID).Scan(&stage, &taskRunID)
+	if err := s.db.QueryRow(`SELECT pipeline_stage, task_run_id FROM claws WHERE id=?`, clawID).Scan(&stage, &taskRunID); err != nil {
+		return "", fmt.Errorf("load claw state: %w", err)
+	}
 	parts = append(parts, "stage="+stage)
 
-	if rows, err := s.db.Query(`SELECT repo, pr_number, last_ci_sha, last_comment_id, last_comment_at, last_review_comment_id, last_review_id, pr_conditions_fired FROM claw_prs WHERE claw_id=? ORDER BY repo, pr_number`, clawID); err == nil {
-		defer rows.Close()
-		for rows.Next() {
-			var repo, ciSHA, commentAt string
-			var number, commentID, reviewCommentID, reviewID, conditions int
-			if rows.Scan(&repo, &number, &ciSHA, &commentID, &commentAt, &reviewCommentID, &reviewID, &conditions) == nil {
-				parts = append(parts, fmt.Sprintf("pr=%s#%d:%s:%d:%s:%d:%d:%d", repo, number, ciSHA, commentID, commentAt, reviewCommentID, reviewID, conditions))
-			}
-		}
+	rows, err := s.db.Query(`SELECT repo, pr_number, last_ci_sha, last_comment_id, last_comment_at, last_review_comment_id, last_review_id, pr_conditions_fired FROM claw_prs WHERE claw_id=? ORDER BY repo, pr_number`, clawID)
+	if err != nil {
+		return "", fmt.Errorf("query tracked pull requests: %w", err)
 	}
+	for rows.Next() {
+		var repo, ciSHA, commentAt string
+		var number, commentID, reviewCommentID, reviewID, conditions int
+		if err := rows.Scan(&repo, &number, &ciSHA, &commentID, &commentAt, &reviewCommentID, &reviewID, &conditions); err != nil {
+			rows.Close()
+			return "", fmt.Errorf("scan tracked pull request: %w", err)
+		}
+		parts = append(parts, fmt.Sprintf("pr=%s#%d:%s:%d:%s:%d:%d:%d", repo, number, ciSHA, commentID, commentAt, reviewCommentID, reviewID, conditions))
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return "", fmt.Errorf("iterate tracked pull requests: %w", err)
+	}
+	rows.Close()
+
 	if taskRunID != "" {
-		if rows, err := s.db.Query(`SELECT repo, pr_number, head_sha, last_agent_head_sha, state, merged FROM task_run_prs WHERE run_id=? ORDER BY repo, pr_number`, taskRunID); err == nil {
-			defer rows.Close()
-			for rows.Next() {
-				var repo, headSHA, agentSHA, state string
-				var number, merged int
-				if rows.Scan(&repo, &number, &headSHA, &agentSHA, &state, &merged) == nil {
-					parts = append(parts, fmt.Sprintf("task-pr=%s#%d:%s:%s:%s:%d", repo, number, headSHA, agentSHA, state, merged))
-				}
-			}
+		rows, err = s.db.Query(`SELECT repo, pr_number, head_sha, last_agent_head_sha, state, merged FROM task_run_prs WHERE run_id=? ORDER BY repo, pr_number`, taskRunID)
+		if err != nil {
+			return "", fmt.Errorf("query task pull requests: %w", err)
 		}
-	}
-	if rows, err := s.db.Query(`SELECT output_name, exit_code, stdout, stderr, parsed_json FROM pipeline_outputs WHERE claw_id=? ORDER BY output_name`, clawID); err == nil {
-		defer rows.Close()
 		for rows.Next() {
-			var name, stdout, stderr, parsed string
-			var exitCode int
-			if rows.Scan(&name, &exitCode, &stdout, &stderr, &parsed) == nil {
-				parts = append(parts, fmt.Sprintf("output=%s:%d:%s:%s:%s", name, exitCode, stdout, stderr, parsed))
+			var repo, headSHA, agentSHA, state string
+			var number, merged int
+			if err := rows.Scan(&repo, &number, &headSHA, &agentSHA, &state, &merged); err != nil {
+				rows.Close()
+				return "", fmt.Errorf("scan task pull request: %w", err)
 			}
+			parts = append(parts, fmt.Sprintf("task-pr=%s#%d:%s:%s:%s:%d", repo, number, headSHA, agentSHA, state, merged))
 		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return "", fmt.Errorf("iterate task pull requests: %w", err)
+		}
+		rows.Close()
 	}
+	rows, err = s.db.Query(`SELECT output_name, exit_code, stdout, stderr, parsed_json FROM pipeline_outputs WHERE claw_id=? ORDER BY output_name`, clawID)
+	if err != nil {
+		return "", fmt.Errorf("query pipeline outputs: %w", err)
+	}
+	for rows.Next() {
+		var name, stdout, stderr, parsed string
+		var exitCode int
+		if err := rows.Scan(&name, &exitCode, &stdout, &stderr, &parsed); err != nil {
+			rows.Close()
+			return "", fmt.Errorf("scan pipeline output: %w", err)
+		}
+		parts = append(parts, fmt.Sprintf("output=%s:%d:%s:%s:%s", name, exitCode, stdout, stderr, parsed))
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return "", fmt.Errorf("iterate pipeline outputs: %w", err)
+	}
+	rows.Close()
+
 	parts = append(parts, responseProgressMarkers(response)...)
 	sort.Strings(parts)
 	sum := sha256.Sum256([]byte(strings.Join(parts, "\x00")))
-	return hex.EncodeToString(sum[:])
+	return hex.EncodeToString(sum[:]), nil
 }
 
 func responseProgressMarkers(content string) []string {

--- a/pkg/hub/no_progress_test.go
+++ b/pkg/hub/no_progress_test.go
@@ -1,0 +1,103 @@
+package hub
+
+import (
+	"testing"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func TestSimilarTurnOutcomes(t *testing.T) {
+	tests := []struct {
+		name string
+		a    string
+		b    string
+		want bool
+	}{
+		{name: "exact short trigger", a: "[CI RETRY]", b: "[CI RETRY]", want: true},
+		{
+			name: "minor wording change",
+			a:    "Depot passed and the pull request is ready. I checked every Greptile conversation, review, and inline thread and found no actionable feedback remaining.",
+			b:    "Depot passed; the pull request is ready. I checked all Greptile conversation, review, and inline threads and found no actionable feedback remaining.",
+			want: true,
+		},
+		{
+			name: "new outcome",
+			a:    "Depot passed and the pull request is ready. I checked every Greptile conversation, review, and inline thread and found no actionable feedback remaining.",
+			b:    "Greptile found a race in message delivery. I changed the queue implementation, added a regression test, pushed a new commit, and requested CI again.",
+			want: false,
+		},
+		{name: "different short messages", a: "waiting for review", b: "review completed", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := similarTurnOutcomes(normalizeTurnOutcome(tt.a), normalizeTurnOutcome(tt.b)); got != tt.want {
+				t.Fatalf("similarTurnOutcomes() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestObserveCompletedTurnPausesOnlyUnchangedRepeatedOutcomes(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+	const clawID = "claw-no-progress"
+	if _, err := db.Exec(`INSERT INTO claws(id, tenant_id, name, status, pipeline_stage, created_at) VALUES(?,?,?,?,?,datetime('now'))`, clawID, "test-tenant-id", "AMB-12", "connected", "ci_passed"); err != nil {
+		t.Fatal(err)
+	}
+	s.claws[clawID] = &clawConn{id: clawID, tenantID: "test-tenant-id"}
+
+	if s.observeCompletedTurn(clawID, "turn-1", "[CI RETRY]") {
+		t.Fatal("first repeated outcome paused the claw")
+	}
+	if s.observeCompletedTurn(clawID, "turn-2", "[CI RETRY]") {
+		t.Fatal("second repeated outcome paused the claw")
+	}
+	// A changed workflow output is material progress and starts a new epoch,
+	// even though the model emitted the same control signal.
+	if _, err := db.Exec(`INSERT INTO pipeline_outputs(claw_id, stage_id, output_name, exit_code, stdout, stderr, parsed_json, created_at) VALUES(?,?,?,?,?,?,?,datetime('now'))`, clawID, "depot_ci", "depot_ci", 0, `{"status":"passed","head":"abc1234"}`, "", `{"status":"passed","head":"abc1234"}`); err != nil {
+		t.Fatal(err)
+	}
+	if s.observeCompletedTurn(clawID, "turn-3", "[CI RETRY]") {
+		t.Fatal("changed pipeline output did not reset repeated outcomes")
+	}
+	if s.observeCompletedTurn(clawID, "turn-4", "[CI RETRY]") {
+		t.Fatal("second outcome in the new epoch paused the claw")
+	}
+	if !s.observeCompletedTurn(clawID, "turn-5", "[CI RETRY]") {
+		t.Fatal("third unchanged repeated outcome did not pause the claw")
+	}
+
+	var paused bool
+	if err := db.QueryRow(`SELECT no_progress_paused != 0 FROM claws WHERE id=?`, clawID).Scan(&paused); err != nil {
+		t.Fatal(err)
+	}
+	if !paused {
+		t.Fatal("pause was not persisted")
+	}
+	var notices int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND role='hub' AND content LIKE '%Automatic continuation paused:%' AND delivered_at IS NOT NULL`, clawID).Scan(&notices); err != nil {
+		t.Fatal(err)
+	}
+	if notices != 1 {
+		t.Fatalf("pause notices = %d, want 1", notices)
+	}
+
+	s.resumeNoProgressAfterUserInput(clawID)
+	var observations int
+	if err := db.QueryRow(`SELECT no_progress_paused != 0, (SELECT COUNT(*) FROM claw_turn_observations WHERE claw_id=?) FROM claws WHERE id=?`, clawID, clawID).Scan(&paused, &observations); err != nil {
+		t.Fatal(err)
+	}
+	if paused || observations != 0 {
+		t.Fatalf("resume left paused=%v observations=%d", paused, observations)
+	}
+}
+
+func TestResponseProgressMarkersTrackNewCommitsAndPRs(t *testing.T) {
+	first := responseProgressMarkers("Pushed 1a2b3c4 to https://github.com/elasticclaw/elasticclaw/pull/100")
+	second := responseProgressMarkers("Pushed 9d8e7f6 to https://github.com/elasticclaw/elasticclaw/pull/100")
+	if len(first) != 2 || len(second) != 2 {
+		t.Fatalf("markers = %v and %v, want PR and commit markers", first, second)
+	}
+	if first[0] == second[0] && first[1] == second[1] {
+		t.Fatal("new commit did not change progress markers")
+	}
+}

--- a/pkg/hub/no_progress_test.go
+++ b/pkg/hub/no_progress_test.go
@@ -1,6 +1,8 @@
 package hub
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/elasticclaw/elasticclaw/pkg/types"
@@ -88,6 +90,71 @@ func TestObserveCompletedTurnPausesOnlyUnchangedRepeatedOutcomes(t *testing.T) {
 	}
 	if paused || observations != 0 {
 		t.Fatalf("resume left paused=%v observations=%d", paused, observations)
+	}
+}
+
+func TestConcurrentResumeWinsOverNoProgressPause(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+	const clawID = "claw-no-progress-race"
+	if _, err := db.Exec(`INSERT INTO claws(id, tenant_id, name, status, pipeline_stage, created_at) VALUES(?,?,?,?,?,datetime('now'))`, clawID, "test-tenant-id", "AMB-12", "connected", "ci_passed"); err != nil {
+		t.Fatal(err)
+	}
+	cc := &clawConn{id: clawID, tenantID: "test-tenant-id"}
+	s.claws[clawID] = cc
+
+	for i := 0; i < 25; i++ {
+		s.resumeNoProgressAfterUserInput(clawID)
+		if s.observeCompletedTurn(clawID, fmt.Sprintf("turn-%d-1", i), "[CI RETRY]") {
+			t.Fatal("first repeated outcome paused the claw")
+		}
+		if s.observeCompletedTurn(clawID, fmt.Sprintf("turn-%d-2", i), "[CI RETRY]") {
+			t.Fatal("second repeated outcome paused the claw")
+		}
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			s.observeCompletedTurn(clawID, fmt.Sprintf("turn-%d-3", i), "[CI RETRY]")
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			s.resumeNoProgressAfterUserInput(clawID)
+		}()
+		close(start)
+		wg.Wait()
+
+		var persistedPaused bool
+		if err := db.QueryRow(`SELECT no_progress_paused != 0 FROM claws WHERE id=?`, clawID).Scan(&persistedPaused); err != nil {
+			t.Fatal(err)
+		}
+		cc.mu.RLock()
+		memoryPaused := cc.noProgressPaused
+		cc.mu.RUnlock()
+		if persistedPaused || memoryPaused {
+			t.Fatalf("iteration %d: concurrent resume left persisted=%v memory=%v", i, persistedPaused, memoryPaused)
+		}
+	}
+}
+
+func TestTurnProgressFingerprintRejectsPartialState(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+	const clawID = "claw-partial-fingerprint"
+	if _, err := db.Exec(`INSERT INTO claws(id, tenant_id, name, status, pipeline_stage, created_at) VALUES(?,?,?,?,?,datetime('now'))`, clawID, "test-tenant-id", "AMB-12", "connected", "ci_passed"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`ALTER TABLE pipeline_outputs RENAME TO pipeline_outputs_valid`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE VIEW pipeline_outputs AS SELECT 'claw-partial-fingerprint' AS claw_id, NULL AS output_name, 0 AS exit_code, '' AS stdout, '' AS stderr, '' AS parsed_json`); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := s.turnProgressFingerprint(clawID, "still waiting"); err == nil {
+		t.Fatal("turnProgressFingerprint accepted a partial row after a scan error")
 	}
 }
 

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -930,7 +930,7 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 			// failure so the gate can still evaluate the captured JSON output.
 			if stage.Gate != nil && stage.OnEnter.Run.Output != "" && result != nil {
 				log.Printf("[pipeline] %s; continuing because stage has a gate configured", msg)
-				s.injectHubMessageByID(clawID, "[hub] Warning: "+msg)
+				s.publishHubNotice(clawID, "[hub] Warning: "+msg)
 			} else if stage.OnEnter.Run.ContinueOnError {
 				log.Printf("[pipeline] %s; continuing because continue_on_error=true", msg)
 				s.injectHubMessageByID(clawID, "[hub] Warning: "+msg)
@@ -1023,28 +1023,42 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 	if stage.Gate != nil {
 		gateResult := s.evaluateGate(clawID, stage.ID, stage.Gate)
 		log.Printf("[pipeline] gate evaluated for claw %s stage %q: verdict=%s", clawID[:8], stage.ID, gateResult.Verdict)
-		// Inject gate result into claw chat
-		if gateResult.Verdict == "pass" {
-			s.injectHubMessageByID(clawID, fmt.Sprintf("[hub] Gate passed: %s", stage.Label))
-		} else if gateResult.Verdict == "skipped" && stage.Gate.TreatSkippedAsPass {
-			s.injectHubMessageByID(clawID, fmt.Sprintf("[hub] Gate skipped (treated as pass): %s", stage.Label))
-		} else if gateResult.Verdict == "error" {
-			msg := fmt.Sprintf("[hub] Gate error (no condition matched): %s", stage.Label)
-			s.injectHubMessageByID(clawID, msg)
-		} else {
-			msg := fmt.Sprintf("[hub] Gate failed: %s", stage.Label)
-			if gateResult.MatchedPath != "" {
-				msg += fmt.Sprintf("\n- path: %s\n- value: %s", gateResult.MatchedPath, gateResult.MatchedValue)
-			}
-			s.injectHubMessageByID(clawID, msg)
-		}
-		// Auto-transition to next stage if a gate_result trigger matches.
 		// Normalise "skipped" → "pass" when TreatSkippedAsPass is set so that
 		// gate_result: { verdict: pass } stages are correctly reached.
 		autoTransitionVerdict := gateResult.Verdict
 		if autoTransitionVerdict == "skipped" && stage.Gate.TreatSkippedAsPass {
 			autoTransitionVerdict = "pass"
 		}
+		gateResultHasRoute := false
+		if pl := parsePipelineForContext(ctx); pl != nil {
+			gateResultHasRoute = pl.StageForGateResult(stage.ID, autoTransitionVerdict) != nil
+		}
+		notifyGateResult := func(message string) {
+			if gateResultHasRoute {
+				// The destination stage owns the next model prompt. Keep mechanical
+				// gate bookkeeping visible in the dashboard without consuming an
+				// extra turn before that stage's on_enter instructions.
+				s.publishHubNotice(clawID, message)
+				return
+			}
+			s.injectHubMessageByID(clawID, message)
+		}
+		// Report the gate result in chat.
+		if gateResult.Verdict == "pass" {
+			notifyGateResult(fmt.Sprintf("[hub] Gate passed: %s", stage.Label))
+		} else if gateResult.Verdict == "skipped" && stage.Gate.TreatSkippedAsPass {
+			notifyGateResult(fmt.Sprintf("[hub] Gate skipped (treated as pass): %s", stage.Label))
+		} else if gateResult.Verdict == "error" {
+			msg := fmt.Sprintf("[hub] Gate error (no condition matched): %s", stage.Label)
+			notifyGateResult(msg)
+		} else {
+			msg := fmt.Sprintf("[hub] Gate failed: %s", stage.Label)
+			if gateResult.MatchedPath != "" {
+				msg += fmt.Sprintf("\n- path: %s\n- value: %s", gateResult.MatchedPath, gateResult.MatchedValue)
+			}
+			notifyGateResult(msg)
+		}
+		// Auto-transition to next stage if a gate_result trigger matches.
 		s.safeGo("pipeline gate auto-transition", func() {
 			s.autoTransitionAfterGate(clawID, stage.ID, autoTransitionVerdict, ctx, gateResult.Reason)
 		})
@@ -1052,7 +1066,11 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 		if stage.Gate.Required && (gateResult.Verdict == "fail" || gateResult.Verdict == "error") {
 			msg := fmt.Sprintf("Required gate %q %s — blocking further pipeline actions", stage.ID, gateResult.Verdict)
 			log.Printf("[pipeline] %s", msg)
-			s.injectHubMessageByID(clawID, "[hub] Error: "+msg)
+			if gateResultHasRoute {
+				s.publishHubNotice(clawID, "[hub] Error: "+msg)
+			} else {
+				s.injectHubMessageByID(clawID, "[hub] Error: "+msg)
+			}
 			if pl := parsePipelineForContext(ctx); pl != nil && pl.StageForGateResult(stage.ID, gateResult.Verdict) != nil {
 				return false, &routedRequiredGateError{stageID: stage.ID, verdict: gateResult.Verdict}
 			}

--- a/pkg/hub/pipeline_runner_test.go
+++ b/pkg/hub/pipeline_runner_test.go
@@ -1596,6 +1596,67 @@ stages:
 	}
 }
 
+func TestRoutedGateResultDoesNotStartItsOwnAgentTurn(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+	const clawID = "claw-routed-gate-notice"
+	if _, err := db.Exec(`INSERT INTO claws(id, tenant_id, name, template, status, pipeline_stage, created_at) VALUES(?,?,?,?,?,?,datetime('now'))`, clawID, "test-tenant-id", "AMB-12", "base", "connected", "depot_ci"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO pipeline_outputs(claw_id, stage_id, output_name, exit_code, stdout, stderr, parsed_json, created_at) VALUES(?,?,?,?,?,?,?,datetime('now'))`, clawID, "depot_ci", "depot_ci", 0, `{"status":"passed"}`, "", `{"status":"passed"}`); err != nil {
+		t.Fatal(err)
+	}
+	factory := &types.FactoryConfig{Name: "linear-todo", PipelineYAML: `
+stages:
+  - id: depot_ci
+    label: Monitor Depot CI
+    gate:
+      output: depot_ci
+      pass:
+        path: status
+        values: [passed]
+  - id: ci_passed
+    label: Review Pull Requests
+    triggers:
+      - gate_result:
+          stage: depot_ci
+          verdict: pass
+    on_enter:
+      inject: Inspect every review thread.
+`}
+	stage := pipeline.Stage{
+		ID:    "depot_ci",
+		Label: "Monitor Depot CI",
+		Gate: &pipeline.Gate{
+			Output: "depot_ci",
+			Pass:   pipeline.GateCondition{Path: "status", Values: []string{"passed"}},
+		},
+	}
+	if _, err := s.runOnEnter(clawID, stage, pipelineContext{Factory: factory}); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for s.getPipelineStage(clawID) != "ci_passed" && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := s.getPipelineStage(clawID); got != "ci_passed" {
+		t.Fatalf("pipeline stage = %q, want ci_passed", got)
+	}
+	var gateDelivered, stageDelivered interface{}
+	if err := db.QueryRow(`SELECT delivered_at FROM messages WHERE claw_id=? AND content='[hub] Gate passed: Monitor Depot CI'`, clawID).Scan(&gateDelivered); err != nil {
+		t.Fatal(err)
+	}
+	if gateDelivered == nil {
+		t.Fatal("routed gate bookkeeping was left pending for agent delivery")
+	}
+	if err := db.QueryRow(`SELECT delivered_at FROM messages WHERE claw_id=? AND content='Inspect every review thread.'`, clawID).Scan(&stageDelivered); err != nil {
+		t.Fatal(err)
+	}
+	if stageDelivered != nil {
+		t.Fatal("destination stage prompt should remain pending until the claw is connected")
+	}
+}
+
 func TestBuildWorkspaceRunCommand(t *testing.T) {
 	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
 

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -581,7 +581,7 @@ func (s *Server) checkPRComments(pr clawPR, commentsData []interface{}, opts prC
 	}
 
 	log.Printf("[pr-watcher] forwarding %d new comment(s) to claw %s", len(newComments), pr.clawID[:8])
-	s.injectHubMessageByID(pr.clawID, strings.Join(newComments, "\n\n"))
+	s.injectExternalHubMessageByID(pr.clawID, strings.Join(newComments, "\n\n"))
 }
 
 // checkBugbotComments polls PR review comments for new bugbot entries.
@@ -788,7 +788,7 @@ func (s *Server) forwardHumanReviewComment(pr clawPR, id int64, login, body, htm
 		"comment_id": id,
 		"path":       path,
 	})
-	s.injectHubMessageByID(pr.clawID, formatHumanReviewCommentMessage(login, pr.prNumber, body, htmlURL, path, line))
+	s.injectExternalHubMessageByID(pr.clawID, formatHumanReviewCommentMessage(login, pr.prNumber, body, htmlURL, path, line))
 }
 
 func (s *Server) forwardHumanRequestedChangesReview(pr clawPR, id int64, login, body, htmlURL string) {
@@ -800,7 +800,7 @@ func (s *Server) forwardHumanRequestedChangesReview(pr clawPR, id int64, login, 
 		"pr_number": pr.prNumber,
 		"review_id": id,
 	})
-	s.injectHubMessageByID(pr.clawID, formatHumanRequestedChangesMessage(login, pr.prNumber, body, htmlURL))
+	s.injectExternalHubMessageByID(pr.clawID, formatHumanRequestedChangesMessage(login, pr.prNumber, body, htmlURL))
 }
 
 // detectHumanCodePush compares a tracked PR's head SHA against the last
@@ -1032,7 +1032,18 @@ func (s *Server) injectHubMessageByID(clawID, content string) {
 	s.injectMessage(clawID, content, "hub")
 }
 
+// injectExternalHubMessageByID delivers an external event that is rendered as
+// a hub message. Unlike workflow bookkeeping, new review or tracker activity
+// is material progress and resumes a no-progress pause.
+func (s *Server) injectExternalHubMessageByID(clawID, content string) {
+	s.resumeNoProgressAfterUserInput(clawID)
+	s.injectMessage(clawID, content, "hub")
+}
+
 func (s *Server) injectMessage(clawID, content, role string) {
+	if role == "user" {
+		s.resumeNoProgressAfterUserInput(clawID)
+	}
 	// Resolve tenant
 	var tenantID string
 	if err := s.db.QueryRow(`SELECT tenant_id FROM claws WHERE id=?`, clawID).Scan(&tenantID); err != nil {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -154,6 +154,8 @@ type clawConn struct {
 	streamingStartedAt    time.Time       // when the current streaming turn started (zero if not streaming)
 	streamingTimeoutSent  bool            // true once the 12-min timeout message has been injected this turn
 	contextWarningSent    bool            // true once the context-nearly-full warning has been injected this turn
+	awaitingResponse      bool            // true as soon as a prompt is delivered, before the first chunk/activity
+	noProgressPaused      bool            // automatic delivery is paused after repeated turns with unchanged progress
 
 	deliveryInFlight bool // serializes DB-backed delivery writes
 
@@ -190,10 +192,11 @@ func gatewayReadyBool(v *bool) bool {
 }
 
 func (cc *clawConn) isBusyLocked() bool {
-	return !cc.streamingStartedAt.IsZero() || cc.streamingMsgID != ""
+	return cc.awaitingResponse || !cc.streamingStartedAt.IsZero() || cc.streamingMsgID != ""
 }
 
 func (cc *clawConn) finishTurnLocked() {
+	cc.awaitingResponse = false
 	cc.streamingMsgID = ""
 	cc.streamingBuf.Reset()
 	cc.streamingSplit = false
@@ -1660,6 +1663,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 			ID: uuid.New().String(), ClawID: clawID, TenantID: tenantID,
 			Role: "user", Content: body.Content, CreatedAt: now(),
 		}
+		s.resumeNoProgressAfterUserInput(clawID)
 		if _, err := s.db.Exec(
 			`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at,delivered_at) VALUES(?,?,?,?,?,?,NULL)`,
 			msg.ID, msg.ClawID, msg.TenantID, msg.Role, msg.Content, msg.CreatedAt,
@@ -2202,7 +2206,9 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cc := &clawConn{id: clawID, tenantID: tenantID, conn: conn, gatewayReady: gatewayReadyBool(rp.GatewayReady), tags: registrationTags, lastUserMessageAt: time.Now(), lastStatusAt: time.Now()}
+	var noProgressPaused bool
+	_ = s.db.QueryRow(`SELECT COALESCE(no_progress_paused, 0) != 0 FROM claws WHERE id=?`, clawID).Scan(&noProgressPaused)
+	cc := &clawConn{id: clawID, tenantID: tenantID, conn: conn, gatewayReady: gatewayReadyBool(rp.GatewayReady), tags: registrationTags, lastUserMessageAt: time.Now(), lastStatusAt: time.Now(), noProgressPaused: noProgressPaused}
 	s.mu.Lock()
 	if s.gatewayRestartCounts != nil {
 		cc.gatewayRestartCount = s.gatewayRestartCounts[clawID]
@@ -2564,7 +2570,10 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 					)
 					s.broadcastToUsers(tenantID, types.WSMessage{Type: "message", Payload: hm})
 				}
-				s.handleInitialPlanResponse(clawID, tenantID, hm.Content)
+				automaticContinuationPaused := s.observeCompletedTurn(clawID, hm.ID, hm.Content)
+				if !automaticContinuationPaused {
+					s.handleInitialPlanResponse(clawID, tenantID, hm.Content)
+				}
 				// Evaluate pipeline triggers. If a pipeline explicitly owns a
 				// [DONE] trigger, let it handle that signal instead of the
 				// legacy factory PR-URL completion path below.
@@ -2574,7 +2583,9 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				if strings.Contains(hm.Content, "[DONE]") {
 					pipelineDoneCtx, pipelineDoneStage, pipelineHandledDone = s.pipelineStageForMessageContains(clawID, hm.Content)
 				}
-				if pipelineHandledDone {
+				if automaticContinuationPaused {
+					pipelineHandledDone = false
+				} else if pipelineHandledDone {
 					prURLs := extractDonePRURLs(hm.Content)
 					s.trackDoneSignal(pipelineDoneCtx.Name(), pipelineDoneCtx.IssueID, clawID, len(prURLs))
 					s.safeGo("pipeline done transition", func() { s.transitionPipelineStageWithContext(clawID, *pipelineDoneStage, pipelineDoneCtx) })
@@ -2607,7 +2618,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				// Detect and store any PR URLs mentioned by the agent
 				go s.scanMessageForPRs(clawID, hm.Content)
 				// Detect tool error loops and inject a corrective message
-				if detectToolLoop(hm.Content) {
+				if !automaticContinuationPaused && detectToolLoop(hm.Content) {
 					s.mu.RLock()
 					loopCC := s.claws[clawID]
 					s.mu.RUnlock()
@@ -2618,7 +2629,9 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				// Check for queued messages and send the next one.
 				// Use this goroutine's cc (the outer cc from line 1449).
 				// If the claw reconnected, a new handleClawWS goroutine handles the new cc.
-				s.sendNextQueuedMessage(cc)
+				if !automaticContinuationPaused {
+					s.sendNextQueuedMessage(cc)
+				}
 				s.drainPendingCheckpoint(clawID)
 			} else if msg.Type == "file_ack" {
 				raw, _ := json.Marshal(msg.Payload)
@@ -2906,6 +2919,7 @@ func (s *Server) handleUserWS(w http.ResponseWriter, r *http.Request) {
 			hm.TenantID = tenantID
 			hm.Role = "user"
 			hm.CreatedAt = now()
+			s.resumeNoProgressAfterUserInput(hm.ClawID)
 			_, _ = s.db.Exec(
 				`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at,delivered_at) VALUES(?,?,?,?,?,?,NULL)`,
 				hm.ID, hm.ClawID, hm.TenantID, hm.Role, hm.Content, hm.CreatedAt,
@@ -5469,6 +5483,17 @@ This first message must be a normal assistant message visible to the user. Tool 
 // For factory claws, it sends a task-specific prompt.
 // A marker is stored in DB so reconnects after hub restart don't re-introduce.
 func (s *Server) sendWakeMessage(cc *clawConn, clawID string) {
+	cc.mu.Lock()
+	if cc.isBusyLocked() || cc.noProgressPaused {
+		cc.mu.Unlock()
+		return
+	}
+	cc.awaitingResponse = true
+	cc.streamingStartedAt = time.Now()
+	cc.streamingTimeoutSent = false
+	cc.contextWarningSent = false
+	cc.mu.Unlock()
+
 	wakeContent := defaultWakeContent
 	if s.clawNeedsInitialPlan(clawID) {
 		wakeContent = initialPlanWakeContent
@@ -5487,7 +5512,11 @@ func (s *Server) sendWakeMessage(cc *clawConn, clawID string) {
 		wakeMsg.ID, wakeMsg.ClawID, wakeMsg.TenantID, wakeMsg.Role, wakeMsg.Content, wakeMsg.CreatedAt, wakeMsg.CreatedAt,
 	)
 	wakeMsg.Content = wakeContent
-	_ = wsjson.Write(context.Background(), cc.conn, types.WSMessage{Type: "message", Payload: wakeMsg})
+	if err := wsjson.Write(context.Background(), cc.conn, types.WSMessage{Type: "message", Payload: wakeMsg}); err != nil {
+		cc.mu.Lock()
+		cc.finishTurnLocked()
+		cc.mu.Unlock()
+	}
 
 	// Note: We don't call sendNextQueuedMessage here because sendWakeMessage is launched
 	// with 'go' (asynchronously). The normal end-of-turn path in handleClawWS read loop
@@ -5499,7 +5528,20 @@ func (s *Server) sendInitialPlanInstruction(cc *clawConn, clawID string) {
 	if cc == nil || !s.clawNeedsInitialPlan(clawID) || s.hasSystemMarker(clawID, initialPlanAcceptedMarker) {
 		return
 	}
+	cc.mu.Lock()
+	if cc.isBusyLocked() || cc.noProgressPaused {
+		cc.mu.Unlock()
+		return
+	}
+	cc.awaitingResponse = true
+	cc.streamingStartedAt = time.Now()
+	cc.streamingTimeoutSent = false
+	cc.contextWarningSent = false
+	cc.mu.Unlock()
 	if !s.insertSystemMarker(clawID, cc.tenantID, initialPlanRequiredMarker) {
+		cc.mu.Lock()
+		cc.finishTurnLocked()
+		cc.mu.Unlock()
 		return
 	}
 	msg := types.HubMessage{
@@ -5510,7 +5552,11 @@ func (s *Server) sendInitialPlanInstruction(cc *clawConn, clawID string) {
 		Content:   initialPlanWakeContent,
 		CreatedAt: now(),
 	}
-	_ = wsjson.Write(context.Background(), cc.conn, types.WSMessage{Type: "message", Payload: msg})
+	if err := wsjson.Write(context.Background(), cc.conn, types.WSMessage{Type: "message", Payload: msg}); err != nil {
+		cc.mu.Lock()
+		cc.finishTurnLocked()
+		cc.mu.Unlock()
+	}
 }
 
 func (s *Server) clawNeedsInitialPlan(clawID string) bool {
@@ -7080,28 +7126,17 @@ func detectToolLoop(content string) bool {
 // injectHubMessage sends a hub-role message to the claw over its WebSocket
 // connection and persists it to the DB so it appears in the message history.
 // Hub messages are visually distinct from user messages in the UI.
-func (s *Server) injectHubMessage(ctx context.Context, cc *clawConn, text string) {
-	msg := types.HubMessage{
-		ID:        uuid.New().String(),
-		ClawID:    cc.id,
-		TenantID:  cc.tenantID,
-		Role:      "hub",
-		Content:   text,
-		Format:    "pre",
-		CreatedAt: now(),
-	}
-	_, _ = s.db.Exec(
-		`INSERT INTO messages(id,claw_id,tenant_id,role,content,format,created_at,delivered_at) VALUES(?,?,?,?,?,?,?,?)`,
-		msg.ID, msg.ClawID, msg.TenantID, msg.Role, msg.Content, msg.Format, msg.CreatedAt, msg.CreatedAt,
-	)
-	_ = wsjson.Write(ctx, cc.conn, types.WSMessage{Type: "message", Payload: msg})
-	s.broadcastToUsers(cc.tenantID, types.WSMessage{Type: "message", Payload: msg})
+func (s *Server) injectHubMessage(_ context.Context, cc *clawConn, text string) {
+	// Route watchdog prompts through the same durable queue as every other
+	// input. Writing directly to the socket can start a second bridge turn in
+	// the gap before the first response emits a chunk or activity.
+	s.injectHubMessageByID(cc.id, text)
 }
 
 // sendNextQueuedMessage delivers the oldest pending message if the claw is idle.
 func (s *Server) sendNextQueuedMessage(cc *clawConn) {
 	cc.mu.Lock()
-	if cc.isBusyLocked() || cc.deliveryInFlight {
+	if cc.isBusyLocked() || cc.deliveryInFlight || cc.noProgressPaused {
 		cc.mu.Unlock()
 		return
 	}
@@ -7135,16 +7170,27 @@ func (s *Server) sendNextQueuedMessage(cc *clawConn) {
 	// allocates a fresh clawConn, so cc.conn cannot change under us; a write
 	// to a dead socket fails and leaves the row pending for the new connection.
 	cc.mu.Lock()
-	if cc.isBusyLocked() {
+	if cc.isBusyLocked() || cc.noProgressPaused {
 		cc.mu.Unlock()
 		return
 	}
+	// Reserve the turn before the WebSocket write. The bridge starts work as
+	// soon as it receives this frame, while chunks and activity can arrive
+	// later. Without this reservation, concurrent workflow injections can both
+	// observe an idle claw and start back-to-back model turns.
+	cc.awaitingResponse = true
+	cc.streamingStartedAt = time.Now()
+	cc.streamingTimeoutSent = false
+	cc.contextWarningSent = false
 	cc.mu.Unlock()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	err = wsjson.Write(ctx, conn, types.WSMessage{Type: "message", Payload: msg})
 	if err != nil {
+		cc.mu.Lock()
+		cc.finishTurnLocked()
+		cc.mu.Unlock()
 		log.Printf("[hub] failed to deliver pending message to %s: %v", shortID(clawID), err)
 		return
 	}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -96,6 +96,7 @@ type Server struct {
 	grokTokenEndpoint         string            // test seam; defaults to the xAI OAuth token endpoint
 	pollWarningMu             sync.Mutex
 	pollWarnings              map[string]struct{}
+	noProgressMu              sync.Mutex // serializes pause/resume state across the DB and active connection
 
 	// webhookDedup prevents duplicate Linear webhook deliveries from creating
 	// duplicate claws. Keyed by issue transition fingerprint; entries expire after 30s.

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -2064,6 +2064,33 @@ func TestReconnectDeliversQueuedMessagesInOrder(t *testing.T) {
 	waitForMessagesDelivered(t, db, clawID, 2)
 }
 
+func TestDeliveredPromptReservesTurnBeforeFirstActivity(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	const clawID = "claw-reserved-turn"
+	insertPendingMessage(t, db, clawID, "first", now().Add(-time.Second))
+	insertPendingMessage(t, db, clawID, "second", now())
+
+	ts := httptest.NewServer(s.Handler())
+	t.Cleanup(ts.Close)
+	clawWS := connectTestClaw(t, ts, clawID)
+	t.Cleanup(func() { _ = clawWS.Close(websocket.StatusNormalClosure, "done") })
+	if got := readTestHubMessage(t, clawWS).Content; got != "first" {
+		t.Fatalf("first delivered content = %q, want first", got)
+	}
+
+	s.mu.RLock()
+	cc := s.claws[clawID]
+	s.mu.RUnlock()
+	s.sendNextQueuedMessage(cc)
+	assertMessagesDelivered(t, db, clawID, 1)
+	cc.mu.RLock()
+	reserved := cc.awaitingResponse
+	cc.mu.RUnlock()
+	if !reserved {
+		t.Fatal("delivered prompt did not reserve the turn")
+	}
+}
+
 func TestReconnectRedeliversMessageUnmarkedAfterSuccessfulWrite(t *testing.T) {
 	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
 	const clawID = "claw-redeliver-pending"

--- a/pkg/hub/watchdog_enforcement_test.go
+++ b/pkg/hub/watchdog_enforcement_test.go
@@ -174,8 +174,8 @@ func TestWatchdogForceFinishesStaleTurnAndDeliversQueue(t *testing.T) {
 	}
 	cc.mu.RLock()
 	defer cc.mu.RUnlock()
-	if cc.isBusyLocked() || cc.forcedFinishCount != 1 {
-		t.Fatalf("turn not force-finished cleanly: busy=%v forced=%d", cc.isBusyLocked(), cc.forcedFinishCount)
+	if !cc.awaitingResponse || cc.streamingStartedAt.IsZero() || cc.streamingMsgID != "" || cc.forcedFinishCount != 1 {
+		t.Fatalf("stale turn not replaced cleanly: awaiting=%v streaming=%v message=%q forced=%d", cc.awaitingResponse, !cc.streamingStartedAt.IsZero(), cc.streamingMsgID, cc.forcedFinishCount)
 	}
 	var deliveredAt interface{}
 	if err := db.QueryRow(`SELECT delivered_at FROM messages WHERE id=?`, "queued-message").Scan(&deliveredAt); err != nil || deliveredAt == nil {


### PR DESCRIPTION
## Summary

- reserve a claw turn as soon as its prompt is delivered so concurrent workflow injections cannot start overlapping turns
- keep routed gate bookkeeping visible without spending a separate model turn before the destination stage prompt
- pause automatic continuation after three similar outcomes only when pipeline, CI, review, PR, and commit progress is unchanged
- resume automatically on human, Greptile, or other external review input

## Why

A routed gate could deliver its status message and next-stage instructions before the first response emitted activity. The bridge serialized both requests eventually, but each became a separate model turn. In retry workflows, the response to the mechanical gate message could repeat the same control signal and cycle indefinitely.

The circuit breaker is based on unchanged progress, not elapsed time or a total-turn limit, so long-running factories remain supported.

## Verification

- go test ./...
- go build ./...