### PR TITLE
fix(bridge,hub): stage flake.nix and flake.lock after workspace sync

### DIFF
--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -2899,6 +2899,20 @@ func syncStagedWorkspaceToOpenClawWorkspace() error {
 		return err
 	}
 	log.Printf("[bootstrap] synced %d staged workspace files into %s", copied, activeDir)
+
+	// Nix flakes require flake.nix/flake.lock to be tracked by git when the
+	// workspace directory is a git repo. Ensure they are staged so subsequent
+	// nix develop / flake-run invocations can evaluate the flake.
+	if _, err := os.Stat(filepath.Join(activeDir, ".git")); err == nil {
+		for _, name := range []string{"flake.nix", "flake.lock"} {
+			p := filepath.Join(activeDir, name)
+			if _, err := os.Stat(p); err == nil {
+				if err := runShell(fmt.Sprintf("cd %q && git add %q", activeDir, name)); err != nil {
+					log.Printf("[bootstrap] warning: git add %s: %v", name, err)
+				}
+			}
+		}
+	}
 	return nil
 }
 

--- a/pkg/hub/dependency_updates.go
+++ b/pkg/hub/dependency_updates.go
@@ -361,12 +361,12 @@ def update_type(old, new):
         return "patch"
     return "unknown"
 
-def run_command(cwd, command, allowed_exit_codes=(0,)):
+def run_command(cwd, command, allowed_exit_codes=(0,), reported_cwd=None):
     global had_failure
     proc = subprocess.run(command, cwd=str(cwd), shell=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     result["commands"].append({
         "command": command,
-        "cwd": rel(cwd),
+        "cwd": rel(reported_cwd if reported_cwd is not None else cwd),
         "exit_code": proc.returncode,
         "stdout": proc.stdout[-4000:],
         "stderr": proc.stderr[-4000:],
@@ -374,6 +374,29 @@ def run_command(cwd, command, allowed_exit_codes=(0,)):
     if proc.returncode not in allowed_exit_codes:
         had_failure = True
     return proc
+
+def prefix_command(base, prefix, subcmd):
+    if prefix:
+        return f"{base} {prefix} {subcmd}"
+    return f"{base} {subcmd}"
+
+def find_repo_root(path):
+    path = pathlib.Path(path).resolve()
+    root = pathlib.Path(ROOT).resolve()
+    while True:
+        if (path / "flake.nix").exists():
+            return path
+        if path == root:
+            return None
+        parent = path.parent
+        if parent == path:
+            return None
+        path = parent
+
+def nix_wrap(command, flake_dir):
+    if flake_dir is None or not shutil.which("nix"):
+        return command
+    return f"nix develop --accept-flake-config {shlex.quote(str(flake_dir))} -c bash -lc {shlex.quote(command)}"
 
 def discover():
     manifests = []
@@ -454,12 +477,26 @@ before = file_snapshot(collect_files(manifests))
 for manifest in manifests:
     manifest_path = ROOT / manifest["path"]
     cwd = manifest_path.parent
+    repo_root = find_repo_root(cwd)
+    if repo_root is not None and repo_root != cwd:
+        # Run commands from the directory that contains flake.nix (which may be
+        # the workspace root or a parent repo directory). This keeps the nix
+        # dev shell's cwd in a directory with a flake and avoids nix treating a
+        # missing flake.nix in the manifest's subdirectory as a fatal error.
+        run_cwd = repo_root
+        rel_dir = cwd.relative_to(repo_root).as_posix()
+    else:
+        run_cwd = cwd
+        rel_dir = "."
+    use_root = rel_dir != "."
+
     if manifest["ecosystem"] == "go":
         if shutil.which("go") is None:
             result["commands"].append({"command": "go", "cwd": rel(cwd), "exit_code": 127, "stderr": "go executable not found"})
             had_failure = True
             continue
-        listed = run_command(cwd, "go list -m -u -json all")
+        go_dir = f"-C {shlex.quote(rel_dir)}" if use_root else ""
+        listed = run_command(run_cwd, nix_wrap(prefix_command("go", go_dir, "list -m -u -json all"), repo_root), reported_cwd=cwd)
         if listed.returncode == 0:
             try:
                 apply_updates = []
@@ -480,8 +517,8 @@ for manifest in manifests:
                     update_record("go", name, from_version, to_version, kind, True)
                     apply_updates.append(f"{name}@{to_version}")
                 if apply_updates:
-                    run_command(cwd, "go get " + " ".join(shlex.quote(value) for value in apply_updates))
-                    run_command(cwd, "go mod tidy")
+                    run_command(run_cwd, nix_wrap(prefix_command("go", go_dir, "get " + " ".join(shlex.quote(value) for value in apply_updates)), repo_root), reported_cwd=cwd)
+                    run_command(run_cwd, nix_wrap(prefix_command("go", go_dir, "mod tidy"), repo_root), reported_cwd=cwd)
             except Exception as exc:
                 result["commands"].append({"command": "parse go list output", "cwd": rel(cwd), "exit_code": 1, "stderr": str(exc)})
                 had_failure = True
@@ -490,7 +527,8 @@ for manifest in manifests:
             result["commands"].append({"command": "npm", "cwd": rel(cwd), "exit_code": 127, "stderr": "npm executable not found"})
             had_failure = True
             continue
-        outdated = run_command(cwd, "npm outdated --json", allowed_exit_codes=(0, 1))
+        npm_dir = f"--prefix {shlex.quote(rel_dir)}" if use_root else ""
+        outdated = run_command(run_cwd, nix_wrap(prefix_command("npm", npm_dir, "outdated --json"), repo_root), allowed_exit_codes=(0, 1), reported_cwd=cwd)
         if outdated.stdout.strip():
             try:
                 apply_updates = []
@@ -511,7 +549,7 @@ for manifest in manifests:
                     if latest and latest != wanted and update_type(current, latest) == "major" and not CONFIG.get("include_major"):
                         update_record("npm", name, current, latest, "major", False, group="major", skipped_reason="major updates disabled")
                 if apply_updates:
-                    run_command(cwd, "npm update --package-lock-only " + " ".join(shlex.quote(value) for value in apply_updates))
+                    run_command(run_cwd, nix_wrap(prefix_command("npm", npm_dir, "update --package-lock-only " + " ".join(shlex.quote(value) for value in apply_updates)), repo_root), reported_cwd=cwd)
             except Exception as exc:
                 result["commands"].append({"command": "parse npm outdated output", "cwd": rel(cwd), "exit_code": 1, "stderr": str(exc)})
                 had_failure = True

--- a/pkg/hub/dependency_updates_test.go
+++ b/pkg/hub/dependency_updates_test.go
@@ -319,3 +319,212 @@ func writeExecutable(t *testing.T, root, name, content string) {
 		t.Fatal(err)
 	}
 }
+
+func TestDependencyUpdatesGeneratedCommandUsesWorkspaceRootForSubdirectories(t *testing.T) {
+	root := t.TempDir()
+	bin := filepath.Join(root, "bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeExecutable(t, bin, "go", `#!/usr/bin/env bash
+set -e
+if [[ "$1" == "-C" && "$2" == "web" && "$3 $4 $5 $6" == "list -m -u -json" && "$7" == "all" ]]; then
+  printf '%s\n' '{"Path":"example.com/web","Version":"v1.0.0","Update":{"Version":"v1.1.0"}}'
+  exit 0
+fi
+if [[ "$1" == "-C" && "$2" == "web" && "$3" == "get" && "$*" == *"example.com/web@v1.1.0"* ]]; then
+  echo changed >> web/go.sum
+  exit 0
+fi
+if [[ "$1" == "-C" && "$2" == "web" && "$3 $4" == "mod tidy" ]]; then
+  exit 0
+fi
+echo "unexpected go invocation: $*" >&2
+exit 1
+`)
+	writeExecutable(t, bin, "npm", `#!/usr/bin/env bash
+set -e
+if [[ "$1" == "--prefix" && "$2" == "web" && "$3 $4" == "outdated --json" ]]; then
+  printf '%s\n' '{"left-pad":{"current":"1.0.0","wanted":"1.1.0","latest":"2.0.0"}}'
+  exit 1
+fi
+if [[ "$1" == "--prefix" && "$2" == "web" && "$3 $4" == "update --package-lock-only" ]]; then
+  printf '%s\n' '{"lockfileVersion":3,"updated":true}' > web/package-lock.json
+  exit 0
+fi
+echo "unexpected npm invocation: $*" >&2
+exit 1
+`)
+	writeExecutable(t, bin, "nix", `#!/usr/bin/env bash
+set -e
+if [[ "$1" == "develop" && "$2" == "--accept-flake-config" ]]; then
+    flake_dir="$3"
+    shift 3
+    if [[ "$1" == "-c" && "$2" == "bash" && "$3" == "-lc" ]]; then
+        command="$4"
+        cd "$flake_dir" && PATH="$PATH" bash -c "$command"
+        exit $?
+    fi
+fi
+echo "unexpected nix invocation: $*" >&2
+exit 1
+`)
+	writeFile(t, root, "flake.nix", "{ description = \"test\"; }\n")
+	writeFile(t, root, "web/go.mod", "module example.com/web\n")
+	writeFile(t, root, "web/go.sum", "")
+	writeFile(t, root, "web/package.json", `{"name":"web","dependencies":{"left-pad":"^1.0.0"}}`)
+	writeFile(t, root, "web/package-lock.json", `{"lockfileVersion":3}`)
+
+	command, err := buildDependencyUpdatesCommand(pipeline.DependencyUpdatesAction{
+		Enabled: true,
+		Paths:   []string{"web"},
+	})
+	if err != nil {
+		t.Fatalf("build command: %v", err)
+	}
+	cmd := osexec.Command("bash", "-c", command)
+	cmd.Dir = root
+	cmd.Env = testEnvWithPath(bin)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("dependency update command failed: %v\n%s", err, out)
+	}
+
+	parsed, ok := parsePipelineOutputJSON(string(out))
+	if !ok {
+		t.Fatalf("command did not emit JSON:\n%s", out)
+	}
+	assertUpdateStatus(t, parsed, "go", "example.com/web", true, "")
+	assertUpdateStatus(t, parsed, "npm", "left-pad", true, "")
+	filesChanged, ok := parsed["files_changed"].([]interface{})
+	if !ok || len(filesChanged) == 0 {
+		t.Fatalf("files_changed = %#v, want at least one changed file", parsed["files_changed"])
+	}
+	commands, ok := parsed["commands"].([]interface{})
+	if !ok {
+		t.Fatalf("commands = %#v, want list", parsed["commands"])
+	}
+	for _, raw := range commands {
+		command, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if command["cwd"] != "web" {
+			continue
+		}
+		cmdStr, _ := command["command"].(string)
+		if strings.Contains(cmdStr, "go") && !strings.Contains(cmdStr, "-C web") {
+			t.Fatalf("go command for subdirectory missing -C: %q", cmdStr)
+		}
+		if strings.Contains(cmdStr, "npm") && !strings.Contains(cmdStr, "--prefix web") {
+			t.Fatalf("npm command for subdirectory missing --prefix: %q", cmdStr)
+		}
+	}
+}
+
+func TestDependencyUpdatesGeneratedCommandUsesRepoRootForSubdirectories(t *testing.T) {
+	root := t.TempDir()
+	bin := filepath.Join(root, "bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeExecutable(t, bin, "go", `#!/usr/bin/env bash
+set -e
+if [[ "$1" == "-C" && "$2" == "web" && "$3 $4 $5 $6" == "list -m -u -json" && "$7" == "all" ]]; then
+  printf '%s\n' '{"Path":"example.com/web","Version":"v1.0.0","Update":{"Version":"v1.1.0"}}'
+  exit 0
+fi
+if [[ "$1" == "-C" && "$2" == "web" && "$3" == "get" && "$*" == *"example.com/web@v1.1.0"* ]]; then
+  echo changed >> web/go.sum
+  exit 0
+fi
+if [[ "$1" == "-C" && "$2" == "web" && "$3 $4" == "mod tidy" ]]; then
+  exit 0
+fi
+echo "unexpected go invocation: $*" >&2
+exit 1
+`)
+	writeExecutable(t, bin, "npm", `#!/usr/bin/env bash
+set -e
+if [[ "$1" == "--prefix" && "$2" == "web" && "$3 $4" == "outdated --json" ]]; then
+  printf '%s\n' '{"left-pad":{"current":"1.0.0","wanted":"1.1.0","latest":"2.0.0"}}'
+  exit 1
+fi
+if [[ "$1" == "--prefix" && "$2" == "web" && "$3 $4" == "update --package-lock-only" ]]; then
+  printf '%s\n' '{"lockfileVersion":3,"updated":true}' > web/package-lock.json
+  exit 0
+fi
+echo "unexpected npm invocation: $*" >&2
+exit 1
+`)
+	writeExecutable(t, bin, "nix", `#!/usr/bin/env bash
+set -e
+if [[ "$1" == "develop" && "$2" == "--accept-flake-config" ]]; then
+    flake_dir="$3"
+    shift 3
+    if [[ "$1" == "-c" && "$2" == "bash" && "$3" == "-lc" ]]; then
+        command="$4"
+        cd "$flake_dir" && PATH="$PATH" bash -c "$command"
+        exit $?
+    fi
+fi
+echo "unexpected nix invocation: $*" >&2
+exit 1
+`)
+	writeFile(t, root, "vandoor/flake.nix", "{ description = \"test\"; }\n")
+	writeFile(t, root, "vandoor/web/go.mod", "module example.com/web\n")
+	writeFile(t, root, "vandoor/web/go.sum", "")
+	writeFile(t, root, "vandoor/web/package.json", `{"name":"web","dependencies":{"left-pad":"^1.0.0"}}`)
+	writeFile(t, root, "vandoor/web/package-lock.json", `{"lockfileVersion":3}`)
+
+	command, err := buildDependencyUpdatesCommand(pipeline.DependencyUpdatesAction{
+		Enabled: true,
+		Paths:   []string{"vandoor/web"},
+	})
+	if err != nil {
+		t.Fatalf("build command: %v", err)
+	}
+	cmd := osexec.Command("bash", "-c", command)
+	cmd.Dir = root
+	cmd.Env = testEnvWithPath(bin)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("dependency update command failed: %v\n%s", err, out)
+	}
+
+	parsed, ok := parsePipelineOutputJSON(string(out))
+	if !ok {
+		t.Fatalf("command did not emit JSON:\n%s", out)
+	}
+	assertUpdateStatus(t, parsed, "go", "example.com/web", true, "")
+	assertUpdateStatus(t, parsed, "npm", "left-pad", true, "")
+	filesChanged, ok := parsed["files_changed"].([]interface{})
+	if !ok || len(filesChanged) == 0 {
+		t.Fatalf("files_changed = %#v, want at least one changed file", parsed["files_changed"])
+	}
+	commands, ok := parsed["commands"].([]interface{})
+	if !ok {
+		t.Fatalf("commands = %#v, want list", parsed["commands"])
+	}
+	foundRepoRoot := false
+	for _, raw := range commands {
+		command, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if command["cwd"] != "vandoor/web" {
+			continue
+		}
+		cmdStr, _ := command["command"].(string)
+		if strings.Contains(cmdStr, "go") && !strings.Contains(cmdStr, "-C web") {
+			t.Fatalf("go command for subdirectory missing -C: %q", cmdStr)
+		}
+		if strings.Contains(cmdStr, "npm") && !strings.Contains(cmdStr, "--prefix web") {
+			t.Fatalf("npm command for subdirectory missing --prefix: %q", cmdStr)
+		}
+		foundRepoRoot = true
+	}
+	if !foundRepoRoot {
+		t.Fatalf("no commands recorded with cwd vandoor/web")
+	}
+}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -6655,6 +6655,30 @@ func (s *Server) sshWriteFiles(user, host, dir string, files map[string]string) 
 			return fmt.Errorf("write %s: %w\n%s", name, err, string(out))
 		}
 	}
+
+	// If the target directory is a git repo, stage the written files so Nix can
+	// evaluate a workspace flake (nix requires flake.nix/flake.lock to be tracked).
+	if len(files) > 0 {
+		names := make([]string, 0, len(files))
+		for name := range files {
+			if safeName, err := cleanWorkspaceFilePath(name); err == nil {
+				names = append(names, safeName)
+			}
+		}
+		if len(names) > 0 {
+			quotedNames := make([]string, len(names))
+			for i, n := range names {
+				quotedNames[i] = shellDoubleQuote(n)
+			}
+			gitCmd := fmt.Sprintf("cd %s && if [ -d .git ]; then git add %s; fi",
+				shellDoubleQuote(dir), strings.Join(quotedNames, " "))
+			sess, err := client.NewSession()
+			if err == nil {
+				_, _ = sess.CombinedOutput(gitCmd)
+				sess.Close()
+			}
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
Nix flakes require `flake.nix` and `flake.lock` to be tracked by git when the workspace directory is a git repo. After syncing or writing workspace files, automatically stage them so the gateway can evaluate the flake and bootstrap successfully.