### PR TITLE
feat: add Grok 4.5 model and pricing

### DIFF
--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -687,7 +687,7 @@ func migrate(db *sql.DB) error {
 		{"gpt-5", 1.25, 10, .125, 0}, {"gpt-5-mini", .25, 2, .025, 0}, {"gpt-5-nano", .05, .40, .005, 0},
 		{"gpt-5.1", 1.25, 10, .125, 0}, {"gpt-5.6", 1.25, 10, .125, 0},
 		{"kimi-k2p7-code", 0.95, 4, .19, 0},
-		{"grok/grok-build-0.1", 1, 2, 0, 0},
+		{"grok/grok-build-0.1", 1, 2, .2, .2},
 		{"grok/grok-4.5", 2, 6, .3, .3},
 	} {
 		// Upsert so price corrections in the static seed reach existing

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -687,6 +687,7 @@ func migrate(db *sql.DB) error {
 		{"gpt-5", 1.25, 10, .125, 0}, {"gpt-5-mini", .25, 2, .025, 0}, {"gpt-5-nano", .05, .40, .005, 0},
 		{"gpt-5.1", 1.25, 10, .125, 0}, {"gpt-5.6", 1.25, 10, .125, 0},
 		{"kimi-k2p7-code", 0.95, 4, .19, 0},
+		{"grok/grok-4.5", 2, 6, 0, 0},
 	} {
 		// Upsert so price corrections in the static seed reach existing
 		// databases; rows from other sources are left untouched.

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -687,6 +687,7 @@ func migrate(db *sql.DB) error {
 		{"gpt-5", 1.25, 10, .125, 0}, {"gpt-5-mini", .25, 2, .025, 0}, {"gpt-5-nano", .05, .40, .005, 0},
 		{"gpt-5.1", 1.25, 10, .125, 0}, {"gpt-5.6", 1.25, 10, .125, 0},
 		{"kimi-k2p7-code", 0.95, 4, .19, 0},
+		{"grok/grok-build-0.1", 1, 2, 0, 0},
 		{"grok/grok-4.5", 2, 6, .3, .3},
 	} {
 		// Upsert so price corrections in the static seed reach existing

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -687,7 +687,7 @@ func migrate(db *sql.DB) error {
 		{"gpt-5", 1.25, 10, .125, 0}, {"gpt-5-mini", .25, 2, .025, 0}, {"gpt-5-nano", .05, .40, .005, 0},
 		{"gpt-5.1", 1.25, 10, .125, 0}, {"gpt-5.6", 1.25, 10, .125, 0},
 		{"kimi-k2p7-code", 0.95, 4, .19, 0},
-		{"grok/grok-4.5", 2, 6, 0, 0},
+		{"grok/grok-4.5", 2, 6, .3, .3},
 	} {
 		// Upsert so price corrections in the static seed reach existing
 		// databases; rows from other sources are left untouched.

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -1184,6 +1184,7 @@ const PROVIDER_MODELS: Record<string, LLMModelOption[]> = {
   ],
   grok: [
     { id: "grok/grok-build-0.1", name: "Grok Build" },
+    { id: "grok/grok-4.5",       name: "Grok 4.5" },
     { id: "grok/grok-4.3",       name: "Grok 4.3" },
     { id: "__custom",            name: "Custom Grok model" },
   ],


### PR DESCRIPTION
Adds Grok 4.5 to the settings model list and seeds the static analytics pricing for it at $2/m input and $6/m output.