### PR TITLE
feat: add workflow run history to UI and CLI

### DIFF
--- a/cmd/workflow.go
+++ b/cmd/workflow.go
@@ -26,6 +26,7 @@ func WorkflowCmd() *cobra.Command {
 	cmd.AddCommand(workflowShowCmd())
 	cmd.AddCommand(workflowPushCmd())
 	cmd.AddCommand(workflowTriggerCmd())
+	cmd.AddCommand(workflowRunsCmd())
 	return cmd
 }
 
@@ -155,6 +156,23 @@ func workflowPushCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&workspace, "workspace", "", "workspace name [required]")
+	return cmd
+}
+
+func workflowRunsCmd() *cobra.Command {
+	var workspace string
+	var limit int
+	cmd := &cobra.Command{
+		Use:   "runs <name>",
+		Short: "Show recent runs for a workflow",
+		Long:  "List recent execution history for a workflow, including cron and manual triggers.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runWorkflowRuns(workspace, args[0], limit)
+		},
+	}
+	cmd.Flags().StringVar(&workspace, "workspace", "default", "workspace name")
+	cmd.Flags().IntVar(&limit, "limit", 50, "maximum number of runs to show")
 	return cmd
 }
 
@@ -289,6 +307,85 @@ func runWorkflowTrigger(workspace, name string, inputs []string) error {
 	}
 
 	fmt.Printf("Triggered workflow %q in workspace %q -> agent %s (%s)\n", name, workspace, shortID(result.ClawID), result.Status)
+	return nil
+}
+
+func runWorkflowRuns(workspace, name string, limit int) error {
+	hubURL, clawToken, err := resolveHubConn()
+	if err != nil {
+		return err
+	}
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 200 {
+		limit = 200
+	}
+
+	path := fmt.Sprintf("/api/workspaces/%s/workflows/%s/cron/runs?limit=%d", url.PathEscape(workspace), url.PathEscape(name), limit)
+	req, _ := http.NewRequest(http.MethodGet, hubURL+path, nil)
+	req.Header.Set("Authorization", "Bearer "+clawToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("fetch workflow runs failed: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("hub returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var result struct {
+		Runs  []types.WorkflowRun `json:"runs"`
+		Count int                 `json:"count"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+
+	if jsonOut {
+		return json.NewEncoder(os.Stdout).Encode(result.Runs)
+	}
+	if len(result.Runs) == 0 {
+		fmt.Printf("No runs found for workflow %q in workspace %q.\n", name, workspace)
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "STATUS\tTRIGGER\tSTARTED\tFINISHED\tRESULT\tAGENT")
+	for _, run := range result.Runs {
+		started := "—"
+		if run.StartedAt != nil && !run.StartedAt.IsZero() {
+			started = run.StartedAt.Format("2006-01-02 15:04:05")
+		}
+		finished := "—"
+		if run.FinishedAt != nil && !run.FinishedAt.IsZero() {
+			finished = run.FinishedAt.Format("2006-01-02 15:04:05")
+		}
+		clawID := "—"
+		if run.ClawID != "" {
+			clawID = shortID(run.ClawID)
+		}
+		resultText := run.Result
+		if resultText == "" {
+			resultText = "—"
+		}
+		// Truncate long result text so tabwriter stays readable.
+		if len(resultText) > 80 {
+			resultText = resultText[:77] + "..."
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			run.Status,
+			run.TriggerType,
+			started,
+			finished,
+			resultText,
+			clawID,
+		)
+	}
+	w.Flush()
+	fmt.Printf("\nShowing %d run(s).\n", result.Count)
 	return nil
 }
 

--- a/cmd/workflow.go
+++ b/cmd/workflow.go
@@ -367,14 +367,7 @@ func runWorkflowRuns(workspace, name string, limit int) error {
 		if run.ClawID != "" {
 			clawID = shortID(run.ClawID)
 		}
-		resultText := run.Result
-		if resultText == "" {
-			resultText = "—"
-		}
-		// Truncate long result text so tabwriter stays readable.
-		if len(resultText) > 80 {
-			resultText = resultText[:77] + "..."
-		}
+		resultText := sanitizeWorkflowResultForTable(run.Result, 80)
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
 			run.Status,
 			run.TriggerType,
@@ -387,6 +380,26 @@ func runWorkflowRuns(workspace, name string, limit int) error {
 	w.Flush()
 	fmt.Printf("\nShowing %d run(s).\n", result.Count)
 	return nil
+}
+
+// sanitizeWorkflowResultForTable makes a workflow result safe for tabwriter output.
+// It strips control characters (tabs, newlines, carriage returns), collapses whitespace,
+// and truncates by rune length so multibyte characters are not sliced in half.
+func sanitizeWorkflowResultForTable(result string, maxRunes int) string {
+	if result == "" {
+		return "—"
+	}
+	replacer := strings.NewReplacer("\t", " ", "\n", " ", "\r", " ")
+	s := replacer.Replace(result)
+	for strings.Contains(s, "  ") {
+		s = strings.ReplaceAll(s, "  ", " ")
+	}
+	s = strings.TrimSpace(s)
+	runes := []rune(s)
+	if len(runes) > maxRunes {
+		return string(runes[:maxRunes-3]) + "..."
+	}
+	return s
 }
 
 func fetchWorkflowViews(workspace string) ([]workflowCLIView, error) {

--- a/cmd/workflow_test.go
+++ b/cmd/workflow_test.go
@@ -2,10 +2,15 @@ package cmd
 
 import (
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
 
 func TestExampleGitHubIssueWorkflowPublishesNestedTrigger(t *testing.T) {
@@ -84,5 +89,53 @@ stages:
 	}
 	if workflow.Trigger == nil || workflow.Trigger.Cron == nil {
 		t.Fatalf("cron trigger missing: %#v", workflow.Trigger)
+	}
+}
+
+func TestRunWorkflowRunsListsRunsAndShortAgentID(t *testing.T) {
+	started := time.Date(2026, 7, 24, 9, 0, 0, 0, time.UTC)
+	finished := started.Add(5 * time.Minute)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		expectedPath := "/api/workspaces/default/workflows/dependency-update/cron/runs"
+		if r.URL.Path != expectedPath {
+			http.NotFound(w, r)
+			return
+		}
+		if r.URL.Query().Get("limit") != "10" {
+			http.Error(w, "unexpected limit", http.StatusBadRequest)
+			return
+		}
+		runs := map[string]interface{}{
+			"runs": []types.WorkflowRun{{
+				ID:            "run-1",
+				WorkflowName:  "dependency-update",
+				WorkspaceName: "default",
+				TriggerType:   "cron",
+				Status:        "failed",
+				Result:        "provisioning timed out",
+				ClawID:        "claw-1234567890",
+				StartedAt:     &started,
+				FinishedAt:    &finished,
+				CreatedAt:     started,
+			}},
+			"count": 1,
+		}
+		_ = json.NewEncoder(w).Encode(runs)
+	}))
+	defer server.Close()
+
+	t.Setenv("ELASTICCLAW_HUB_URL", server.URL)
+	t.Setenv("ELASTICCLAW_CLAW_TOKEN", "test-token")
+
+	out, err := captureStdout(func() error {
+		return runWorkflowRuns("default", "dependency-update", 10)
+	})
+	if err != nil {
+		t.Fatalf("runWorkflowRuns returned error: %v", err)
+	}
+	for _, want := range []string{"failed", "cron", "claw-123", "provisioning timed out", "Showing 1 run"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q:\n%s", want, out)
+		}
 	}
 }

--- a/cmd/workflow_test.go
+++ b/cmd/workflow_test.go
@@ -13,6 +13,31 @@ import (
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
 
+func TestSanitizeWorkflowResultForTable(t *testing.T) {
+	tests := []struct {
+		name     string
+		result   string
+		maxRunes int
+		want     string
+	}{
+		{"empty", "", 80, "—"},
+		{"simple", "provisioning failed", 80, "provisioning failed"},
+		{"newlines", "line1\nline2\r\nline3", 80, "line1 line2 line3"},
+		{"tabs", "a\tb\tc", 80, "a b c"},
+		{"multispace", "a  b   c", 80, "a b c"},
+		{"multibyte truncate", "🚀" + strings.Repeat("a", 80), 80, "🚀" + strings.Repeat("a", 76) + "..."},
+		{"ascii truncate", strings.Repeat("a", 100), 80, strings.Repeat("a", 77) + "..."},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitizeWorkflowResultForTable(tc.result, tc.maxRunes)
+			if got != tc.want {
+				t.Fatalf("sanitizeWorkflowResultForTable(%q, %d) = %q, want %q", tc.result, tc.maxRunes, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestExampleGitHubIssueWorkflowPublishesNestedTrigger(t *testing.T) {
 	path := filepath.Join("..", "examples", "workflows", "github-issue.yaml")
 

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -15,6 +15,7 @@ import { VALID_SECTIONS, type Section } from "./sections"
 import { fetchWorkspaces, updateWorkflowControls, type RepositoryAccess, type Workspace, type Workflow } from "@/lib/api"
 import { useBranding } from "@/hooks/use-branding"
 import { AnalyticsCommandCenter } from "@/components/analytics-command-center"
+import { WorkflowRunsDialog } from "@/components/workflow-runs-dialog"
 
 function isValidSection(s: string): s is Section {
   return VALID_SECTIONS.includes(s as Section)
@@ -3161,6 +3162,7 @@ function WorkflowSummaryRow({
             />
             <span>Manual trigger</span>
           </label>
+          <WorkflowRunsDialog workflow={workflow} />
           <span className={cn(
             "text-xs px-2 py-0.5 rounded",
             workflow.enabled ? "bg-muted text-muted-foreground" : "bg-amber-500/10 text-amber-500"

--- a/web/components/workflow-runs-dialog.tsx
+++ b/web/components/workflow-runs-dialog.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useEffect, useState, type ReactNode } from "react"
+import { useRouter } from "next/navigation"
 import { AlertCircle, BarChart3, Calendar, ExternalLink, History, Loader2 } from "lucide-react"
 import { ApiError, fetchCronWorkflowRuns, type Workflow } from "@/lib/api"
 import type { WorkflowRun } from "@/lib/types"
@@ -11,6 +12,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { cn } from "@/lib/utils"
 
 export function WorkflowRunsDialog({ workflow }: { workflow: Workflow }) {
+  const router = useRouter()
   const [open, setOpen] = useState(false)
   const [runs, setRuns] = useState<WorkflowRun[]>([])
   const [loading, setLoading] = useState(false)
@@ -59,7 +61,7 @@ export function WorkflowRunsDialog({ workflow }: { workflow: Workflow }) {
               <span className="font-medium">{workflow.workspaceName}</span>.
             </DialogDescription>
           </DialogHeader>
-          <div className="min-h-0 flex-1 px-6 pb-6">
+          <div className="min-h-0 flex-1 overflow-y-auto px-6 pb-6">
             {loading && <LoadingState label="Loading run history…" />}
             {!loading && error && <Notice destructive>{error}</Notice>}
             {!loading && !error && runs.length === 0 && (
@@ -91,8 +93,8 @@ export function WorkflowRunsDialog({ workflow }: { workflow: Workflow }) {
                         <TableCell className="text-xs text-muted-foreground">
                           {run.finished_at ? formatTimestamp(run.finished_at) : "—"}
                         </TableCell>
-                        <TableCell className="max-w-xs">
-                          <div className="text-xs text-muted-foreground break-words">
+                        <TableCell className="max-w-xs align-top">
+                          <div className="max-w-full overflow-hidden text-xs text-muted-foreground break-words leading-relaxed">
                             {run.result || "—"}
                           </div>
                         </TableCell>
@@ -106,15 +108,22 @@ export function WorkflowRunsDialog({ workflow }: { workflow: Workflow }) {
               </div>
             )}
           </div>
-          <div className="shrink-0 border-t px-6 py-3">
-            <a
-              href={`/settings/workspace-analytics?workspace=${encodeURIComponent(workflow.workspaceName)}&workflow=${encodeURIComponent(workflow.name)}`}
-              className="inline-flex items-center gap-1.5 text-xs text-primary hover:underline"
+          <div className="shrink-0 border-t bg-background px-6 py-3">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-auto px-0 py-0 text-xs text-primary hover:text-primary hover:underline"
+              onClick={() => {
+                setOpen(false)
+                router.push(
+                  `/settings/workspace-analytics?workspace=${encodeURIComponent(workflow.workspaceName)}&workflow=${encodeURIComponent(workflow.name)}`
+                )
+              }}
             >
               <BarChart3 className="size-3.5" />
               Open full analytics for this workflow
               <ExternalLink className="size-3" />
-            </a>
+            </Button>
           </div>
         </DialogContent>
       </Dialog>

--- a/web/components/workflow-runs-dialog.tsx
+++ b/web/components/workflow-runs-dialog.tsx
@@ -93,8 +93,8 @@ export function WorkflowRunsDialog({ workflow }: { workflow: Workflow }) {
                         <TableCell className="text-xs text-muted-foreground">
                           {run.finished_at ? formatTimestamp(run.finished_at) : "—"}
                         </TableCell>
-                        <TableCell className="max-w-xs align-top">
-                          <div className="max-w-full overflow-hidden text-xs text-muted-foreground break-words leading-relaxed">
+                        <TableCell className="min-w-[20rem] max-w-lg align-top">
+                          <div className="max-w-full text-xs text-muted-foreground whitespace-pre-wrap break-words leading-relaxed">
                             {run.result || "—"}
                           </div>
                         </TableCell>

--- a/web/components/workflow-runs-dialog.tsx
+++ b/web/components/workflow-runs-dialog.tsx
@@ -1,0 +1,193 @@
+"use client"
+
+import { useEffect, useState, type ReactNode } from "react"
+import { AlertCircle, BarChart3, Calendar, ExternalLink, History, Loader2 } from "lucide-react"
+import { ApiError, fetchCronWorkflowRuns, type Workflow } from "@/lib/api"
+import type { WorkflowRun } from "@/lib/types"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { cn } from "@/lib/utils"
+
+export function WorkflowRunsDialog({ workflow }: { workflow: Workflow }) {
+  const [open, setOpen] = useState(false)
+  const [runs, setRuns] = useState<WorkflowRun[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!open) return
+    let cancelled = false
+    queueMicrotask(() => {
+      if (cancelled) return
+      setLoading(true)
+      setError(null)
+      setRuns([])
+      fetchCronWorkflowRuns(workflow.workspaceName, workflow.name)
+        .then((response) => {
+          if (cancelled) return
+          setRuns(response.runs || [])
+        })
+        .catch((err) => {
+          if (cancelled) return
+          if (err instanceof ApiError && err.status === 404) {
+            setError("This workflow is not configured for scheduled or manual runs.")
+            return
+          }
+          setError(err instanceof Error ? err.message : "Unable to load run history")
+        })
+        .finally(() => {
+          if (!cancelled) setLoading(false)
+        })
+    })
+    return () => { cancelled = true }
+  }, [open, workflow])
+
+  return (
+    <>
+      <Button variant="outline" size="sm" onClick={() => setOpen(true)}>
+        <History className="size-4" />
+        Run history
+      </Button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="flex h-[min(85vh,700px)] flex-col gap-3 overflow-hidden p-0 sm:max-w-4xl">
+          <DialogHeader className="shrink-0 border-b px-6 py-5 pr-12">
+            <DialogTitle>Run history</DialogTitle>
+            <DialogDescription>
+              Recent executions of <span className="font-medium">{workflow.name}</span> in{" "}
+              <span className="font-medium">{workflow.workspaceName}</span>.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="min-h-0 flex-1 px-6 pb-6">
+            {loading && <LoadingState label="Loading run history…" />}
+            {!loading && error && <Notice destructive>{error}</Notice>}
+            {!loading && !error && runs.length === 0 && (
+              <EmptyState>No runs have been recorded for this workflow yet.</EmptyState>
+            )}
+            {!loading && !error && runs.length > 0 && (
+              <div className="rounded-md border">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead className="w-28">Status</TableHead>
+                      <TableHead className="w-24">Trigger</TableHead>
+                      <TableHead>Started</TableHead>
+                      <TableHead>Finished</TableHead>
+                      <TableHead>Result</TableHead>
+                      <TableHead>Agent</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {runs.map((run) => (
+                      <TableRow key={run.id}>
+                        <TableCell>
+                          <StatusBadge status={run.status} />
+                        </TableCell>
+                        <TableCell className="text-xs capitalize">{run.trigger_type}</TableCell>
+                        <TableCell className="text-xs text-muted-foreground">
+                          {run.started_at ? formatTimestamp(run.started_at) : "—"}
+                        </TableCell>
+                        <TableCell className="text-xs text-muted-foreground">
+                          {run.finished_at ? formatTimestamp(run.finished_at) : "—"}
+                        </TableCell>
+                        <TableCell className="max-w-xs">
+                          <div className="text-xs text-muted-foreground break-words">
+                            {run.result || "—"}
+                          </div>
+                        </TableCell>
+                        <TableCell className="text-xs font-mono text-muted-foreground">
+                          {run.claw_id ? shortId(run.claw_id) : "—"}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            )}
+          </div>
+          <div className="shrink-0 border-t px-6 py-3">
+            <a
+              href={`/settings/workspace-analytics?workspace=${encodeURIComponent(workflow.workspaceName)}&workflow=${encodeURIComponent(workflow.name)}`}
+              className="inline-flex items-center gap-1.5 text-xs text-primary hover:underline"
+            >
+              <BarChart3 className="size-3.5" />
+              Open full analytics for this workflow
+              <ExternalLink className="size-3" />
+            </a>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const variant = statusVariant(status)
+  return (
+    <Badge className={cn("text-[10px]", variant)}>
+      {status}
+    </Badge>
+  )
+}
+
+function statusVariant(status: string) {
+  switch (status.toLowerCase()) {
+    case "completed":
+    case "success":
+      return "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
+    case "failed":
+    case "error":
+      return "border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-300"
+    case "running":
+      return "border-blue-500/30 bg-blue-500/10 text-blue-700 dark:text-blue-300"
+    case "skipped":
+      return "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300"
+    case "pending":
+    default:
+      return "border-border bg-muted text-muted-foreground"
+  }
+}
+
+function LoadingState({ label }: { label: string }) {
+  return (
+    <div className="flex h-40 items-center justify-center gap-2 text-sm text-muted-foreground">
+      <Loader2 className="size-4 animate-spin" />
+      {label}
+    </div>
+  )
+}
+
+function EmptyState({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex h-40 items-center justify-center gap-2 rounded-md border border-dashed text-sm text-muted-foreground">
+      <Calendar className="size-4" />
+      {children}
+    </div>
+  )
+}
+
+function Notice({ children, destructive = false }: { children: ReactNode; destructive?: boolean }) {
+  return (
+    <div className={cn(
+      "flex items-center gap-2 rounded-md border px-4 py-3 text-sm",
+      destructive && "border-destructive/30 bg-destructive/10 text-destructive"
+    )}>
+      <AlertCircle className={cn("size-4 shrink-0", destructive && "text-destructive")} />
+      {children}
+    </div>
+  )
+}
+
+function shortId(id: string) {
+  return id.length > 8 ? id.slice(0, 8) : id
+}
+
+function formatTimestamp(value: string) {
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(new Date(value))
+}

--- a/web/components/workflow-runs-dialog.tsx
+++ b/web/components/workflow-runs-dialog.tsx
@@ -44,7 +44,7 @@ export function WorkflowRunsDialog({ workflow }: { workflow: Workflow }) {
         })
     })
     return () => { cancelled = true }
-  }, [open, workflow])
+  }, [open, workflow.workspaceName, workflow.name])
 
   return (
     <>

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -16,6 +16,7 @@ import type {
   TaskRunPR,
   TaskRunsResponse,
   TaskRunSummary,
+  WorkflowRunsResponse,
 } from "./types"
 import { getHubUrl, setHubUrl } from "./hub-url"
 import { getAuthToken, requestAuthToken, clearAuthTokens } from "./auth-storage"
@@ -360,6 +361,12 @@ export async function triggerWorkflow(workflow: Workflow, inputs?: Record<string
       method: "POST",
       body: JSON.stringify({ inputs: inputs || {} }),
     }
+  )
+}
+
+export async function fetchCronWorkflowRuns(workspaceName: string, workflowName: string, limit = 50): Promise<WorkflowRunsResponse> {
+  return apiFetch<WorkflowRunsResponse>(
+    `/api/workspaces/${encodeURIComponent(workspaceName)}/workflows/${encodeURIComponent(workflowName)}/cron/runs?limit=${limit}`
   )
 }
 

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -370,3 +370,23 @@ export interface DependencyStatusResponse {
   downtimeCount: number
   checkedAt: string
 }
+
+export interface WorkflowRun {
+  id: string
+  tenant_id?: string
+  workflow_name: string
+  workspace_name: string
+  trigger_type: string
+  status: string
+  result?: string
+  claw_id?: string
+  run_context?: Record<string, unknown>
+  started_at?: string
+  finished_at?: string
+  created_at: string
+}
+
+export interface WorkflowRunsResponse {
+  runs: WorkflowRun[]
+  count: number
+}


### PR DESCRIPTION
Adds visibility into cron/manual workflow execution history.

### Changes
- **Web UI:** New "Run history" button on Settings → Workflows rows. Opens a dialog listing recent runs with status, trigger type, start/finish times, full result text, and agent ID. Includes a link to full task-run analytics for the workflow.
- **CLI:** New `elasticclaw workflow runs <name> --workspace <workspace> --limit <n>` command with JSON output support.
- **Backend:** Uses the existing `/api/workspaces/{ws}/workflows/{wf}/cron/runs` endpoint.

### UI polish
- Content area scrolls vertically.
- Result text wraps and preserves line breaks instead of overflowing into adjacent columns.
- Analytics link uses the router and closes the dialog before navigating.

### Commits
- `3f4b5aaf` feat(web): add workflow run history dialog to workflows settings page
- `7d636205` feat(cli): add workflow runs command to list execution history
- `1112bab0` fix(web): scroll run history dialog and wrap result text legibly
- `f376a95a` fix(web): preserve line breaks and show full result text in run history

Tested and deployed on a remote VM; the UI and CLI both surface the failed cron run results correctly.


<img width="907" height="704" alt="image" src="https://github.com/user-attachments/assets/0103121a-46a3-40c1-9c6f-fefa7a1f03d9" />
