### PR TITLE
fix(hub): stop 12-min watchdog nag flood; deliver nudge mid-turn; auto-resume after gateway restart

### DIFF
--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -1802,6 +1802,33 @@ func setActiveGatewaySession(gs *gatewaySession) {
 	gatewayProcessState.Unlock()
 }
 
+func activeGatewaySession() *gatewaySession {
+	gatewayProcessState.RLock()
+	defer gatewayProcessState.RUnlock()
+	return gatewayProcessState.session
+}
+func (gs *gatewaySession) turnInFlight() bool {
+	gs.infMu.RLock()
+	defer gs.infMu.RUnlock()
+	return gs.inFlight != nil
+}
+func injectGatewayNudge(ctx context.Context, text string) {
+	gs := activeGatewaySession()
+	if gs == nil || !gs.IsReady() {
+		log.Printf("[status] dropping nudge: gateway session not ready")
+		return
+	}
+	if !gs.turnInFlight() {
+		log.Printf("[status] dropping nudge: no turn in flight")
+		return
+	}
+	reqCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	if _, err := gs.sendReq(reqCtx, "sessions.send", map[string]string{"key": gs.getSessionKey(), "message": text}); err != nil {
+		log.Printf("[status] nudge injection failed: %v", err)
+	}
+}
+
 func (gs *gatewaySession) setReady() {
 	gs.readyMu.Lock()
 	gs.ready = true
@@ -3961,6 +3988,14 @@ func runStatusChannel(ctx context.Context, wsURL, clawID, clawName, templateName
 			}
 			if msg.Type == "status_ping" {
 				_ = wsjson.Write(ctx, conn, hubMsg{Type: "status_pong"})
+			}
+			if msg.Type == "nudge" {
+				var p struct {
+					Content string `json:"content"`
+				}
+				if err := json.Unmarshal(msg.Payload, &p); err == nil && p.Content != "" {
+					go injectGatewayNudge(ctx, p.Content)
+				}
 			}
 		}
 		pingCancel() // stop the ping goroutine before closing the connection

--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -1807,25 +1807,76 @@ func activeGatewaySession() *gatewaySession {
 	defer gatewayProcessState.RUnlock()
 	return gatewayProcessState.session
 }
-func (gs *gatewaySession) turnInFlight() bool {
-	gs.infMu.RLock()
-	defer gs.infMu.RUnlock()
-	return gs.inFlight != nil
-}
 func injectGatewayNudge(ctx context.Context, text string) {
 	gs := activeGatewaySession()
 	if gs == nil || !gs.IsReady() {
 		log.Printf("[status] dropping nudge: gateway session not ready")
 		return
 	}
-	if !gs.turnInFlight() {
+	reqCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	sent, err := gs.sendTurnScopedReq(reqCtx, "sessions.send", map[string]string{"key": gs.getSessionKey(), "message": text})
+	if !sent {
 		log.Printf("[status] dropping nudge: no turn in flight")
 		return
 	}
-	reqCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
-	defer cancel()
-	if _, err := gs.sendReq(reqCtx, "sessions.send", map[string]string{"key": gs.getSessionKey(), "message": text}); err != nil {
+	if err != nil {
 		log.Printf("[status] nudge injection failed: %v", err)
+	}
+}
+
+// sendTurnScopedReq dispatches a request only while a turn is in flight,
+// holding infMu across the check AND the WebSocket write so the readLoop
+// cannot mark the turn finished in between (closing the turnInFlight/send
+// TOCTOU). The response is awaited without the lock — the readLoop needs
+// infMu.Lock to clear inFlight, so holding it across the await would
+// deadlock. Returns sent=false when no turn was in flight at write time.
+func (gs *gatewaySession) sendTurnScopedReq(ctx context.Context, method string, params interface{}) (bool, error) {
+	paramsJSON, _ := json.Marshal(params)
+	reqID := randomID()
+	ch := make(chan gwFrame, 1)
+
+	gs.pendMu.Lock()
+	gs.pending[reqID] = ch
+	gs.pendMu.Unlock()
+	cleanup := func() {
+		gs.pendMu.Lock()
+		delete(gs.pending, reqID)
+		gs.pendMu.Unlock()
+	}
+
+	gs.infMu.RLock()
+	if gs.inFlight == nil {
+		gs.infMu.RUnlock()
+		cleanup()
+		return false, nil
+	}
+	conn := gs.currentConn()
+	// Short write deadline: the RLock stalls readLoop writers (turn-end
+	// bookkeeping) until the write returns, so don't hold it for the full
+	// request timeout against a wedged socket.
+	writeCtx, writeCancel := context.WithTimeout(ctx, 5*time.Second)
+	err := wsjson.Write(writeCtx, conn, gwFrame{Type: "req", ID: reqID, Method: method, Params: paramsJSON})
+	writeCancel()
+	gs.infMu.RUnlock()
+	if err != nil {
+		cleanup()
+		return true, fmt.Errorf("%s write: %w", method, err)
+	}
+
+	select {
+	case resp := <-ch:
+		if !resp.OK {
+			msg := "unknown"
+			if resp.Error != nil {
+				msg = resp.Error.Message
+			}
+			return true, fmt.Errorf("%s failed: %s", method, msg)
+		}
+		return true, nil
+	case <-ctx.Done():
+		cleanup()
+		return true, ctx.Err()
 	}
 }
 

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -82,6 +82,64 @@ func TestWriteManagedGrokCredentialToOpenClaw(t *testing.T) {
 	}
 }
 
+func TestInjectGatewayNudgeSendsOnActiveSessionMidTurn(t *testing.T) {
+	received := make(chan gwFrame, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		defer conn.CloseNow()
+		var req gwFrame
+		if err := wsjson.Read(r.Context(), conn, &req); err != nil {
+			t.Error(err)
+			return
+		}
+		received <- req
+		_ = wsjson.Write(r.Context(), conn, gwFrame{Type: "res", ID: req.ID, OK: true})
+	}))
+	defer srv.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	conn, _, err := websocket.Dial(ctx, "ws"+strings.TrimPrefix(srv.URL, "http"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.CloseNow()
+	gs := &gatewaySession{conn: conn, pending: make(map[string]chan gwFrame), sessionKey: "session-1", ready: true, inFlight: &inFlightState{done: make(chan agentResult, 1)}}
+	go gs.readLoop(ctx)
+	old := activeGatewaySession()
+	setActiveGatewaySession(gs)
+	t.Cleanup(func() { setActiveGatewaySession(old) })
+	injectGatewayNudge(ctx, "nudge text")
+	select {
+	case req := <-received:
+		if req.Method != "sessions.send" {
+			t.Fatalf("method=%q", req.Method)
+		}
+		var params map[string]string
+		if err := json.Unmarshal(req.Params, &params); err != nil {
+			t.Fatal(err)
+		}
+		if params["key"] != "session-1" || params["message"] != "nudge text" {
+			t.Fatalf("params=%v", params)
+		}
+	case <-ctx.Done():
+		t.Fatal("did not receive nudge request")
+	}
+}
+
+func TestInjectGatewayNudgeDroppedWhenNoTurnInFlight(t *testing.T) {
+	old := activeGatewaySession()
+	setActiveGatewaySession(nil)
+	t.Cleanup(func() { setActiveGatewaySession(old) })
+	injectGatewayNudge(context.Background(), "nudge text") // nil session must not panic
+	gs := &gatewaySession{ready: true, pending: make(map[string]chan gwFrame)}
+	setActiveGatewaySession(gs)
+	injectGatewayNudge(context.Background(), "nudge text") // no in-flight turn must not send
+}
+
 func TestWriteManagedGrokCredentialToCLI(t *testing.T) {
 	home := t.TempDir()
 	authDir := filepath.Join(home, ".grok")

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -1050,7 +1050,12 @@ func (s *Server) injectMessage(clawID, content, role string) {
 		return
 	}
 	var pendingDupes int
-	_ = s.db.QueryRow(`SELECT COUNT(1) FROM messages WHERE claw_id=? AND role=? AND content=? AND delivered_at IS NULL`, clawID, role, content).Scan(&pendingDupes)
+	// Fail closed: injecting on a failed dedup check is the outcome this
+	// guard exists to prevent.
+	if err := s.db.QueryRow(`SELECT COUNT(1) FROM messages WHERE claw_id=? AND role=? AND content=? AND delivered_at IS NULL`, clawID, role, content).Scan(&pendingDupes); err != nil {
+		log.Printf("[pr-watcher] dedup check for claw %s failed: %v", shortID(clawID), err)
+		return
+	}
 	if pendingDupes > 0 {
 		log.Printf("[pr-watcher] skipping duplicate pending %s message for claw %s", role, shortID(clawID))
 		return

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -1049,6 +1049,12 @@ func (s *Server) injectMessage(clawID, content, role string) {
 	if err := s.db.QueryRow(`SELECT tenant_id FROM claws WHERE id=?`, clawID).Scan(&tenantID); err != nil {
 		return
 	}
+	var pendingDupes int
+	_ = s.db.QueryRow(`SELECT COUNT(1) FROM messages WHERE claw_id=? AND role=? AND content=? AND delivered_at IS NULL`, clawID, role, content).Scan(&pendingDupes)
+	if pendingDupes > 0 {
+		log.Printf("[pr-watcher] skipping duplicate pending %s message for claw %s", role, shortID(clawID))
+		return
+	}
 
 	format := ""
 	if role == "hub" {

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -1047,14 +1047,16 @@ func (s *Server) injectMessage(clawID, content, role string) {
 	// Resolve tenant
 	var tenantID string
 	if err := s.db.QueryRow(`SELECT tenant_id FROM claws WHERE id=?`, clawID).Scan(&tenantID); err != nil {
+		log.Printf("[pr-watcher] dropping %s message for claw %s: tenant lookup failed: %v", role, shortID(clawID), err)
 		return
 	}
 	var pendingDupes int
-	// Fail closed: injecting on a failed dedup check is the outcome this
-	// guard exists to prevent.
+	// Fail open on a dedup-check error: dropping the injection can strand
+	// the agent (a lost watchdog nudge or restart-resume prompt), while
+	// injecting blind at worst duplicates one pending message.
 	if err := s.db.QueryRow(`SELECT COUNT(1) FROM messages WHERE claw_id=? AND role=? AND content=? AND delivered_at IS NULL`, clawID, role, content).Scan(&pendingDupes); err != nil {
-		log.Printf("[pr-watcher] dedup check for claw %s failed: %v", shortID(clawID), err)
-		return
+		log.Printf("[pr-watcher] dedup check for claw %s failed, injecting anyway: %v", shortID(clawID), err)
+		pendingDupes = 0
 	}
 	if pendingDupes > 0 {
 		log.Printf("[pr-watcher] skipping duplicate pending %s message for claw %s", role, shortID(clawID))

--- a/pkg/hub/pr_watcher_test.go
+++ b/pkg/hub/pr_watcher_test.go
@@ -413,3 +413,29 @@ func TestStorePRMentionConcurrentDuplicate(t *testing.T) {
 		t.Fatalf("claw_prs rows = %d, want 1", count)
 	}
 }
+
+func TestInjectMessageSkipsIdenticalPendingRow(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	const clawID = "inject-message-dedupe"
+	if _, err := db.Exec(`INSERT INTO claws(id,tenant_id,name,template,status,created_at) VALUES(?,?,?,?,?,?)`, clawID, "test-tenant-id", clawID, "elasticclaw", "connected", now()); err != nil {
+		t.Fatal(err)
+	}
+	cc := &clawConn{id: clawID, tenantID: "test-tenant-id", awaitingResponse: true}
+	s.mu.Lock()
+	s.claws[clawID] = cc
+	s.mu.Unlock()
+	s.injectHubMessageByID(clawID, "same text")
+	s.injectHubMessageByID(clawID, "same text")
+	s.injectHubMessageByID(clawID, "different text")
+	var pending int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND delivered_at IS NULL`, clawID).Scan(&pending); err != nil || pending != 2 {
+		t.Fatalf("pending rows=%d err=%v, want 2", pending, err)
+	}
+	if _, err := db.Exec(`UPDATE messages SET delivered_at=? WHERE claw_id=? AND content='same text'`, now(), clawID); err != nil {
+		t.Fatal(err)
+	}
+	s.injectHubMessageByID(clawID, "same text")
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND content='same text'`, clawID).Scan(&pending); err != nil || pending != 2 {
+		t.Fatalf("same text rows=%d err=%v, want 2", pending, err)
+	}
+}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -60,7 +60,9 @@ type Server struct {
 	users map[string]*userConn // tenant_id -> []conn (broadcast)
 	// gatewayRestartCounts retains the heartbeat counter across WebSocket reconnects.
 	gatewayRestartCounts map[string]int
-	lastTokenFailureLog  time.Time
+	// autoResumeRestartCounts records restart counts already handled per claw. Guarded by s.mu.
+	autoResumeRestartCounts map[string]int
+	lastTokenFailureLog     time.Time
 	// one-time oauth_code -> signed GitHub session token
 
 	dependencyStatus *dependencyStatusService
@@ -160,6 +162,7 @@ type clawConn struct {
 	contextWarningSent    bool            // true once the context-nearly-full warning has been injected this turn
 	awaitingResponse      bool            // true as soon as a prompt is delivered, before the first chunk/activity
 	noProgressPaused      bool            // automatic delivery is paused after repeated turns with unchanged progress
+	lastTurnFinishedAt    time.Time       // when the last streaming turn ended (for post-restart resume window)
 
 	deliveryInFlight bool // serializes DB-backed delivery writes
 
@@ -180,6 +183,13 @@ const (
 	defaultGatewayUnhealthyMax = 12
 	defaultBusyTurnMax         = 45 * time.Minute
 	defaultSilentDeathMax      = 10 * time.Minute
+)
+
+const (
+	streamingTimeoutNudge  = "[hub] Your current response has been running for over 12 minutes. Please wrap up and send your response."
+	contextNearlyFullNudge = "[hub] Context window is nearly full. Summarize your progress briefly and send [DONE] with any PR URL, or ask the user what to do next."
+	// autoResumeRecentTurnWindow includes races between a crash and turn completion.
+	autoResumeRecentTurnWindow = 5 * time.Minute
 )
 
 // initialStatus returns the claw status string to use on bridge registration.
@@ -207,6 +217,7 @@ func (cc *clawConn) finishTurnLocked() {
 	cc.streamingStartedAt = time.Time{}
 	cc.streamingTimeoutSent = false
 	cc.contextWarningSent = false
+	cc.lastTurnFinishedAt = time.Now()
 }
 
 func (s *Server) flushStreamingSegment(clawID, tenantID string, cc *clawConn) error {
@@ -262,21 +273,22 @@ func NewServer(addr, dbPath, identityDir string, hubCfg *types.HubConfig) (*Serv
 	}
 	log.Printf("Hub SSH public key:\n%s", id.PublicKey)
 	srv := &Server{
-		db:                   db,
-		addr:                 addr,
-		hubCfg:               hubCfg,
-		identity:             id,
-		artifacts:            artifacts,
-		claws:                make(map[string]*clawConn),
-		users:                make(map[string]*userConn),
-		gatewayRestartCounts: make(map[string]int),
-		dependencyStatus:     newDependencyStatusService(hubCfg),
-		fileAckWaiters:       make(map[string]chan types.FileAck),
-		fileReadWaiters:      make(map[string]chan types.FileReadResp),
-		checkpointWaiters:    make(map[string]chan error),
-		webhookDedup:         make(map[string]time.Time),
-		reaperFirstSeen:      make(map[string]time.Time),
-		nowFunc:              now,
+		db:                      db,
+		addr:                    addr,
+		hubCfg:                  hubCfg,
+		identity:                id,
+		artifacts:               artifacts,
+		claws:                   make(map[string]*clawConn),
+		users:                   make(map[string]*userConn),
+		gatewayRestartCounts:    make(map[string]int),
+		autoResumeRestartCounts: make(map[string]int),
+		dependencyStatus:        newDependencyStatusService(hubCfg),
+		fileAckWaiters:          make(map[string]chan types.FileAck),
+		fileReadWaiters:         make(map[string]chan types.FileReadResp),
+		checkpointWaiters:       make(map[string]chan error),
+		webhookDedup:            make(map[string]time.Time),
+		reaperFirstSeen:         make(map[string]time.Time),
+		nowFunc:                 now,
 	}
 	if srv.livenessEnabled() {
 		srv.reconcileOnBoot()
@@ -2348,6 +2360,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 					var shouldWake bool
 					var shouldWarnContext bool
 					var shouldEscalateGateway bool
+					var shouldAutoResume bool
 					var prevUsage int
 					s.mu.Lock()
 					if cc, ok := s.claws[clawID]; ok {
@@ -2365,6 +2378,15 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 						if hb.RestartCount != lastRestartCount {
 							log.Printf("[heartbeat] %s (%s): agent process restarted (restart_count=%d)", rp.Name, clawID[:8], hb.RestartCount)
 							s.gatewayRestartCounts[clawID] = hb.RestartCount
+							if s.autoResumeRestartCounts == nil {
+								s.autoResumeRestartCounts = make(map[string]int)
+							}
+							turnOpenOrRecent := !cc.streamingStartedAt.IsZero() || cc.awaitingResponse ||
+								(!cc.lastTurnFinishedAt.IsZero() && time.Since(cc.lastTurnFinishedAt) < autoResumeRecentTurnWindow)
+							if turnOpenOrRecent && s.autoResumeRestartCounts[clawID] != hb.RestartCount {
+								s.autoResumeRestartCounts[clawID] = hb.RestartCount
+								shouldAutoResume = true
+							}
 						}
 						cc.gatewayRestartCount = s.gatewayRestartCounts[clawID]
 						// Promote from 'starting' to 'connected' once gateway is ready.
@@ -2422,6 +2444,9 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 					}
 					s.mu.Unlock()
 					s.heartbeatWorkflowVolumeLeases(clawID)
+					if shouldAutoResume {
+						go s.enqueueRestartResume(clawID, hb.RestartCount)
+					}
 					if shouldEscalateGateway {
 						// Re-read the claw state before escalating: idle/completed claws
 						// remain connected intentionally, and bootstrapping claws are
@@ -2433,7 +2458,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 						warnCC := s.claws[clawID]
 						s.mu.RUnlock()
 						if warnCC != nil {
-							go s.injectHubMessage(ctx, warnCC, "[hub] Context window is nearly full. Summarize your progress briefly and send [DONE] with any PR URL, or ask the user what to do next.")
+							go s.sendStreamingNudge(warnCC, contextNearlyFullNudge)
 						}
 					}
 					if shouldWake {
@@ -2450,7 +2475,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 							time.Since(cc.streamingStartedAt) > 12*time.Minute {
 							cc.streamingTimeoutSent = true
 							cc.mu.Unlock()
-							go s.injectHubMessage(ctx, cc, "[hub] Your current response has been running for over 12 minutes. Please wrap up and send your response.")
+							go s.sendStreamingNudge(cc, streamingTimeoutNudge)
 						} else {
 							cc.mu.Unlock()
 						}
@@ -2506,8 +2531,6 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 						cc.mu.Lock()
 						if cc.streamingMsgID == "" {
 							cc.streamingMsgID = uuid.New().String()
-							cc.streamingTimeoutSent = false
-							cc.contextWarningSent = false
 						}
 						if cc.streamingStartedAt.IsZero() {
 							cc.streamingStartedAt = time.Now()
@@ -2553,6 +2576,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				cc.finishTurnLocked()
 				cc.forcedFinishCount = 0
 				cc.mu.Unlock()
+				s.deleteStaleWatchdogNags(clawID)
 				// Drop empty messages — never store or broadcast
 				if strings.TrimSpace(hm.Content) == "" {
 					// Clear typing indicator first — always clear even if no queued messages
@@ -5256,6 +5280,7 @@ func (s *Server) checkClawStatus() {
 		if !streamingStartedAt.IsZero() && now.Sub(streamingStartedAt) > cfg.busyTurnMax {
 			var content, messageID string
 			var escalate bool
+			finished := false
 			cc.mu.Lock()
 			if !cc.streamingStartedAt.IsZero() && now.Sub(cc.streamingStartedAt) > cfg.busyTurnMax {
 				if cc.streamingBuf.Len() > 0 {
@@ -5266,10 +5291,14 @@ func (s *Server) checkClawStatus() {
 					}
 				}
 				cc.finishTurnLocked()
+				finished = true
 				cc.forcedFinishCount++
 				escalate = cc.forcedFinishCount >= 2
 			}
 			cc.mu.Unlock()
+			if finished {
+				s.deleteStaleWatchdogNags(id)
+			}
 			if content != "" {
 				_, _ = s.db.Exec(`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at,delivered_at) VALUES(?,?,?,?,?,?,?) ON CONFLICT(id) DO UPDATE SET content=excluded.content, delivered_at=excluded.delivered_at`, messageID, id, tenantID, "claw", content, now, now)
 				s.broadcastToUsers(tenantID, types.WSMessage{Type: "message", Payload: types.HubMessage{ID: messageID, ClawID: id, TenantID: tenantID, Role: "claw", Content: content, CreatedAt: now}})
@@ -7218,6 +7247,91 @@ func (s *Server) injectHubMessage(_ context.Context, cc *clawConn, text string) 
 	// input. Writing directly to the socket can start a second bridge turn in
 	// the gap before the first response emits a chunk or activity.
 	s.injectHubMessageByID(cc.id, text)
+}
+
+// deleteStaleWatchdogNags removes nudges that targeted the just-ended turn.
+func (s *Server) deleteStaleWatchdogNags(clawID string) {
+	res, err := s.db.Exec(`DELETE FROM messages WHERE claw_id=? AND role='hub' AND delivered_at IS NULL AND content IN (?,?)`, clawID, streamingTimeoutNudge, contextNearlyFullNudge)
+	if err != nil {
+		log.Printf("[watchdog] delete stale nags for %s: %v", shortID(clawID), err)
+		return
+	}
+	if n, _ := res.RowsAffected(); n > 0 {
+		log.Printf("[watchdog] dropped %d stale watchdog nag(s) for %s at turn end", n, shortID(clawID))
+	}
+}
+
+const restartResumePrefix = "[hub] Agent process restart detected."
+
+func (s *Server) enqueueRestartResume(clawID string, restartCount int) {
+	var status, issueTitle, linearID, githubID, shortcutID, jiraID string
+	var bootstrapOK int
+	err := s.db.QueryRow(`SELECT status, COALESCE(bootstrap_ok,0), COALESCE(issue_title,''), COALESCE(linear_issue_id,''), COALESCE(github_issue_id,''), COALESCE(shortcut_story_id,''), COALESCE(jira_issue_id,'') FROM claws WHERE id=?`, clawID).Scan(&status, &bootstrapOK, &issueTitle, &linearID, &githubID, &shortcutID, &jiraID)
+	if err != nil {
+		return
+	}
+	if status != "connected" || bootstrapOK == 0 {
+		log.Printf("[watchdog] skipping auto-resume for %s: status=%s bootstrap_ok=%d", shortID(clawID), status, bootstrapOK)
+		return
+	}
+	var issueRef string
+	switch {
+	case linearID != "":
+		issueRef = "Linear issue " + linearID
+	case githubID != "":
+		issueRef = "GitHub issue " + githubID
+	case shortcutID != "":
+		issueRef = "Shortcut story " + shortcutID
+	case jiraID != "":
+		issueRef = "Jira issue " + jiraID
+	}
+	var b strings.Builder
+	b.WriteString(restartResumePrefix)
+	b.WriteString(" Your previous session was lost, so you have no memory of the earlier conversation. The workspace on disk is intact, including your repositories under ~/workspace.")
+	if issueTitle != "" || issueRef != "" {
+		b.WriteString("\n\nAssigned task: ")
+		if issueTitle != "" {
+			b.WriteString(issueTitle)
+		}
+		if issueRef != "" {
+			if issueTitle != "" {
+				b.WriteString(" (")
+				b.WriteString(issueRef)
+				b.WriteString(")")
+			} else {
+				b.WriteString(issueRef)
+			}
+		}
+		b.WriteString(".")
+	}
+	b.WriteString("\n\nBefore anything else, recover your state from the workspace: run git status and git log --oneline -15, check which branch you are on and whether there are uncommitted changes or an open PR for it. Then resume the task from where the workspace shows it stopped. Do not start over and do not discard existing work.")
+	// Append a zero-width marker carrying the restart_count so that two resume
+	// prompts for two different restarts are never treated as the identical
+	// pending message by injectMessage's dedup (change 2) — each restart is a
+	// distinct incident even when the rest of the wording is unchanged.
+	b.WriteString(fmt.Sprintf("\n\n<!-- restart:%d -->", restartCount))
+	log.Printf("[watchdog] enqueueing post-restart resume for %s", shortID(clawID))
+	s.injectHubMessageByID(clawID, b.String())
+}
+
+func (s *Server) sendStreamingNudge(cc *clawConn, text string) {
+	cc.mu.RLock()
+	sc, clawID, tenantID := cc.statusConn, cc.id, cc.tenantID
+	cc.mu.RUnlock()
+	if sc == nil {
+		s.injectHubMessageByID(clawID, text)
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := wsjson.Write(ctx, sc, types.WSMessage{Type: "nudge", Payload: mustJSONRaw(map[string]string{"claw_id": clawID, "content": text})}); err != nil {
+		log.Printf("[watchdog] nudge over status channel for %s failed, queueing: %v", shortID(clawID), err)
+		s.injectHubMessageByID(clawID, text)
+		return
+	}
+	msg := types.HubMessage{ID: uuid.New().String(), ClawID: clawID, TenantID: tenantID, Role: "hub", Content: text, Format: "pre", CreatedAt: now()}
+	_, _ = s.db.Exec(`INSERT INTO messages(id,claw_id,tenant_id,role,content,format,created_at,delivered_at) VALUES(?,?,?,?,?,?,?,?)`, msg.ID, msg.ClawID, msg.TenantID, msg.Role, msg.Content, msg.Format, msg.CreatedAt, msg.CreatedAt)
+	s.broadcastToUsers(tenantID, types.WSMessage{Type: "message", Payload: msg})
 }
 
 // sendNextQueuedMessage delivers the oldest pending message if the claw is idle.

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2226,6 +2226,14 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 
 	var noProgressPaused bool
 	_ = s.db.QueryRow(`SELECT COALESCE(no_progress_paused, 0) != 0 FROM claws WHERE id=?`, clawID).Scan(&noProgressPaused)
+	// A bridge-process restart tears down the main channel, so the old clawConn
+	// (and its lastTurnFinishedAt) is usually gone by the time the new bridge
+	// registers. Seed the post-restart resume window from the last claw
+	// response — a turn interrupted by the crash was flushed as an
+	// "[interrupted]" claw message at disconnect, so its created_at marks the
+	// turn end closely enough for autoResumeRecentTurnWindow.
+	var lastClawMsgAt time.Time
+	_ = s.db.QueryRow(`SELECT created_at FROM messages WHERE claw_id=? AND role='claw' ORDER BY created_at DESC LIMIT 1`, clawID).Scan(&lastClawMsgAt)
 	cc := &clawConn{id: clawID, tenantID: tenantID, conn: conn, gatewayReady: gatewayReadyBool(rp.GatewayReady), tags: registrationTags, lastUserMessageAt: time.Now(), lastStatusAt: time.Now(), noProgressPaused: noProgressPaused}
 	s.mu.Lock()
 	if s.gatewayRestartCounts != nil {
@@ -2235,7 +2243,11 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 		old.mu.RLock()
 		cc.statusConn = old.statusConn
 		cc.lastStatusAt = old.lastStatusAt
+		cc.lastTurnFinishedAt = old.lastTurnFinishedAt
 		old.mu.RUnlock()
+	}
+	if cc.lastTurnFinishedAt.IsZero() {
+		cc.lastTurnFinishedAt = lastClawMsgAt
 	}
 	s.claws[clawID] = cc
 	s.mu.Unlock()
@@ -2371,11 +2383,18 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 						if s.gatewayRestartCounts == nil {
 							s.gatewayRestartCounts = make(map[string]int)
 						}
-						lastRestartCount := s.gatewayRestartCounts[clawID]
-						// Any change signals a restart: an increase is an in-process
-						// gateway restart; a decrease means the bridge process itself
-						// was relaunched and its counter reset.
-						if hb.RestartCount != lastRestartCount {
+						lastRestartCount, restartCountSeen := s.gatewayRestartCounts[clawID]
+						// The map is in-memory only: the first heartbeat after a hub
+						// restart carries a historical restart_count, not a fresh
+						// restart. Record it as a baseline instead of treating it as
+						// a restart, or every busy claw would get a spurious
+						// "session was lost" resume after each hub deploy.
+						if !restartCountSeen {
+							s.gatewayRestartCounts[clawID] = hb.RestartCount
+						} else if hb.RestartCount != lastRestartCount {
+							// Any change signals a restart: an increase is an in-process
+							// gateway restart; a decrease means the bridge process itself
+							// was relaunched and its counter reset.
 							log.Printf("[heartbeat] %s (%s): agent process restarted (restart_count=%d)", rp.Name, clawID[:8], hb.RestartCount)
 							s.gatewayRestartCounts[clawID] = hb.RestartCount
 							if s.autoResumeRestartCounts == nil {
@@ -7317,7 +7336,16 @@ func (s *Server) enqueueRestartResume(clawID string, restartCount int) {
 func (s *Server) sendStreamingNudge(cc *clawConn, text string) {
 	cc.mu.RLock()
 	sc, clawID, tenantID := cc.statusConn, cc.id, cc.tenantID
+	turnOpen := cc.isBusyLocked()
 	cc.mu.RUnlock()
+	// The nudge targets the in-flight turn. This runs on a goroutine, so the
+	// turn may have ended (and deleteStaleWatchdogNags already run) before we
+	// get here — queueing now would deliver the stale nudge as the next
+	// turn's prompt. Drop it instead.
+	if !turnOpen {
+		log.Printf("[watchdog] dropping nudge for %s: turn already ended", shortID(clawID))
+		return
+	}
 	if sc == nil {
 		s.injectHubMessageByID(clawID, text)
 		return
@@ -7325,6 +7353,14 @@ func (s *Server) sendStreamingNudge(cc *clawConn, text string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	if err := wsjson.Write(ctx, sc, types.WSMessage{Type: "nudge", Payload: mustJSONRaw(map[string]string{"claw_id": clawID, "content": text})}); err != nil {
+		// Up to 5s may have elapsed; re-check before falling back to the queue.
+		cc.mu.RLock()
+		turnOpen = cc.isBusyLocked()
+		cc.mu.RUnlock()
+		if !turnOpen {
+			log.Printf("[watchdog] dropping nudge for %s: turn ended during status-channel send", shortID(clawID))
+			return
+		}
 		log.Printf("[watchdog] nudge over status channel for %s failed, queueing: %v", shortID(clawID), err)
 		s.injectHubMessageByID(clawID, text)
 		return

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2402,7 +2402,11 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 							}
 							turnOpenOrRecent := !cc.streamingStartedAt.IsZero() || cc.awaitingResponse ||
 								(!cc.lastTurnFinishedAt.IsZero() && time.Since(cc.lastTurnFinishedAt) < autoResumeRecentTurnWindow)
-							if turnOpenOrRecent && s.autoResumeRestartCounts[clawID] != hb.RestartCount {
+							// Existence-aware lookup: a bridge relaunch resets its counter
+							// to 0, which equals the zero value of an absent map entry — a
+							// plain read would skip the resume for that first relaunch.
+							lastResumedCount, resumeRecorded := s.autoResumeRestartCounts[clawID]
+							if turnOpenOrRecent && (!resumeRecorded || lastResumedCount != hb.RestartCount) {
 								s.autoResumeRestartCounts[clawID] = hb.RestartCount
 								shouldAutoResume = true
 							}

--- a/pkg/hub/watchdog_enforcement_test.go
+++ b/pkg/hub/watchdog_enforcement_test.go
@@ -306,6 +306,8 @@ func TestRestartMidTurnEnqueuesExactlyOneResume(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
+	// First observation after hub boot is a baseline, not a restart.
+	beat(0)
 	beat(1)
 	beat(1)
 	beat(1)
@@ -327,6 +329,17 @@ func TestRestartWhileIdleDoesNotEnqueueResume(t *testing.T) {
 	if _, err := db.Exec(`UPDATE claws SET status='connected', bootstrap_ok=1 WHERE id=?`, clawID); err != nil {
 		t.Fatal(err)
 	}
+	// Baseline observation first: the initial restart_count after (re)boot is
+	// recorded, not treated as a restart.
+	if err := wsjson.Write(context.Background(), conn, types.WSMessage{Type: "heartbeat", Payload: map[string]any{"gateway_healthy": true, "restart_count": 0}}); err != nil {
+		t.Fatal(err)
+	}
+	eventuallyWatchdog(t, func() bool {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+		_, seen := s.gatewayRestartCounts[clawID]
+		return seen
+	}, "restart count baseline")
 	// watchdogClaw already seeded a delivered message to suppress the async
 	// post-registration wake-turn reservation. Also force the claw back to a
 	// deterministic idle state in case that reservation raced ahead of it.
@@ -342,6 +355,162 @@ func TestRestartWhileIdleDoesNotEnqueueResume(t *testing.T) {
 	var n int
 	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND content LIKE ?`, clawID, restartResumePrefix+"%").Scan(&n); err != nil || n != 0 {
 		t.Fatalf("resume rows=%d err=%v", n, err)
+	}
+}
+
+func TestFirstHeartbeatAfterHubBootDoesNotAutoResume(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	const clawID = "watchdog-hub-boot-baseline"
+	conn := watchdogClaw(t, s, clawID)
+	cc := watchdogClawConn(t, s, clawID)
+	if _, err := db.Exec(`UPDATE claws SET status='connected', bootstrap_ok=1 WHERE id=?`, clawID); err != nil {
+		t.Fatal(err)
+	}
+	cc.mu.Lock()
+	cc.streamingStartedAt = time.Now()
+	cc.mu.Unlock()
+	beat := func(n int) {
+		if err := wsjson.Write(context.Background(), conn, types.WSMessage{Type: "heartbeat", Payload: map[string]any{"gateway_healthy": true, "restart_count": n}}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	count := func() int {
+		var n int
+		_ = db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND role='hub' AND content LIKE ?`, clawID, restartResumePrefix+"%").Scan(&n)
+		return n
+	}
+	// A fresh Server has an empty gatewayRestartCounts map — exactly the state
+	// after a hub restart. A historical nonzero restart_count on the first
+	// heartbeat must be recorded as a baseline, not treated as a restart.
+	beat(3)
+	eventuallyWatchdog(t, func() bool {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+		return s.gatewayRestartCounts[clawID] == 3
+	}, "baseline recorded")
+	if got := count(); got != 0 {
+		t.Fatalf("resume rows after baseline heartbeat=%d, want 0", got)
+	}
+	// A genuine restart after the baseline still triggers auto-resume.
+	beat(4)
+	eventuallyWatchdog(t, func() bool { return count() == 1 }, "resume after genuine restart")
+}
+
+func TestRestartDuringBootstrapDoesNotEnqueueResume(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	const clawID = "watchdog-bootstrap-restart"
+	conn := watchdogClaw(t, s, clawID)
+	cc := watchdogClawConn(t, s, clawID)
+	if _, err := db.Exec(`UPDATE claws SET status='connected', bootstrap_ok=0 WHERE id=?`, clawID); err != nil {
+		t.Fatal(err)
+	}
+	cc.mu.Lock()
+	cc.streamingStartedAt = time.Now()
+	cc.mu.Unlock()
+	beat := func(n int) {
+		if err := wsjson.Write(context.Background(), conn, types.WSMessage{Type: "heartbeat", Payload: map[string]any{"gateway_healthy": true, "restart_count": n}}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	beat(0)
+	beat(1)
+	time.Sleep(100 * time.Millisecond)
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND content LIKE ?`, clawID, restartResumePrefix+"%").Scan(&n); err != nil || n != 0 {
+		t.Fatalf("resume rows=%d err=%v, want 0", n, err)
+	}
+}
+
+func TestStreamingNudgeGoesOverStatusChannel(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	const clawID = "watchdog-nudge-status-channel"
+	_ = watchdogClaw(t, s, clawID)
+	cc := watchdogClawConn(t, s, clawID)
+
+	// Connect the status channel like the bridge does.
+	ts := httptest.NewServer(s.Handler())
+	t.Cleanup(ts.Close)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	statusConn, _, err := websocket.Dial(ctx, "ws"+strings.TrimPrefix(ts.URL, "http")+"/claw/ws", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = statusConn.Close(websocket.StatusNormalClosure, "done") })
+	if err := wsjson.Write(ctx, statusConn, types.WSMessage{Type: "register", Payload: types.RegisterPayload{
+		ClawID: clawID, Name: "watchdog claw", Template: "elasticclaw", Token: "claw-token", Channel: "status",
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	var ack types.WSMessage
+	if err := wsjson.Read(ctx, statusConn, &ack); err != nil || ack.Type != "registered" {
+		t.Fatalf("status channel ack: type=%q err=%v", ack.Type, err)
+	}
+	eventuallyWatchdog(t, func() bool {
+		cc.mu.RLock()
+		defer cc.mu.RUnlock()
+		return cc.statusConn != nil
+	}, "status channel attach")
+
+	cc.mu.Lock()
+	cc.streamingStartedAt = time.Now()
+	cc.streamingMsgID = "stream"
+	cc.mu.Unlock()
+	s.sendStreamingNudge(cc, streamingTimeoutNudge)
+
+	// The nudge must arrive over the status channel, not the message queue.
+	var got types.WSMessage
+	if err := wsjson.Read(ctx, statusConn, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Type != "nudge" {
+		t.Fatalf("status channel message type=%q, want nudge", got.Type)
+	}
+	payload, _ := got.Payload.(map[string]interface{})
+	if payload["claw_id"] != clawID || payload["content"] != streamingTimeoutNudge {
+		t.Fatalf("nudge payload=%#v", payload)
+	}
+	// The UI row is recorded as already delivered — never queued for the agent.
+	var delivered, pending int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND content=? AND delivered_at IS NOT NULL`, clawID, streamingTimeoutNudge).Scan(&delivered); err != nil || delivered != 1 {
+		t.Fatalf("delivered rows=%d err=%v, want 1", delivered, err)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND content=? AND delivered_at IS NULL`, clawID, streamingTimeoutNudge).Scan(&pending); err != nil || pending != 0 {
+		t.Fatalf("pending rows=%d err=%v, want 0", pending, err)
+	}
+}
+
+func TestStreamingNudgeFallsBackToQueueWithoutStatusChannel(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	const clawID = "watchdog-nudge-fallback"
+	_ = watchdogClaw(t, s, clawID)
+	cc := watchdogClawConn(t, s, clawID)
+	cc.mu.Lock()
+	cc.streamingStartedAt = time.Now()
+	cc.streamingMsgID = "stream"
+	cc.statusConn = nil
+	cc.mu.Unlock()
+	s.sendStreamingNudge(cc, streamingTimeoutNudge)
+	var pending int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND content=? AND delivered_at IS NULL`, clawID, streamingTimeoutNudge).Scan(&pending); err != nil || pending != 1 {
+		t.Fatalf("pending rows=%d err=%v, want 1", pending, err)
+	}
+}
+
+func TestStreamingNudgeDroppedWhenTurnAlreadyEnded(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	const clawID = "watchdog-nudge-stale-drop"
+	_ = watchdogClaw(t, s, clawID)
+	cc := watchdogClawConn(t, s, clawID)
+	// The nudge goroutine may run after the turn it targeted already finished;
+	// it must be dropped entirely, not queued as the next turn's prompt.
+	cc.mu.Lock()
+	cc.finishTurnLocked()
+	cc.mu.Unlock()
+	s.sendStreamingNudge(cc, streamingTimeoutNudge)
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND content=?`, clawID, streamingTimeoutNudge).Scan(&n); err != nil || n != 0 {
+		t.Fatalf("nudge rows=%d err=%v, want 0", n, err)
 	}
 }
 
@@ -377,5 +546,14 @@ func TestLongTurnInterleavedSegmentsNagsExactlyOnce(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 	if got := count(); got != 1 {
 		t.Fatalf("timeout nudge rows=%d, want 1", got)
+	}
+	// The flag must survive segment flushes: if the chunk handler re-armed it
+	// per segment (the original bug), interleaved chunks would reset it to
+	// false and the row-count check alone could still pass via dedup.
+	cc.mu.RLock()
+	timeoutSent := cc.streamingTimeoutSent
+	cc.mu.RUnlock()
+	if !timeoutSent {
+		t.Fatal("streamingTimeoutSent was re-armed by an interleaved segment; it must stay true for the whole turn")
 	}
 }

--- a/pkg/hub/watchdog_enforcement_test.go
+++ b/pkg/hub/watchdog_enforcement_test.go
@@ -333,6 +333,42 @@ func TestRestartMidTurnEnqueuesExactlyOneResume(t *testing.T) {
 	eventuallyWatchdog(t, func() bool { return count() == 2 }, "second restart resume")
 }
 
+// A bridge-process relaunch resets restart_count to 0 — equal to the zero
+// value of an absent autoResumeRestartCounts entry, which a plain map read
+// cannot distinguish from "never resumed".
+func TestRestartCountResetMidTurnEnqueuesResume(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	const clawID = "watchdog-restart-reset"
+	conn := watchdogClaw(t, s, clawID)
+	cc := watchdogClawConn(t, s, clawID)
+	if _, err := db.Exec(`UPDATE claws SET status='connected', bootstrap_ok=1, issue_title='Fix watchdog', github_issue_id='owner/repo#42' WHERE id=?`, clawID); err != nil {
+		t.Fatal(err)
+	}
+	cc.mu.Lock()
+	cc.streamingStartedAt = time.Now()
+	cc.mu.Unlock()
+	beat := func(n int) {
+		if err := wsjson.Write(context.Background(), conn, types.WSMessage{Type: "heartbeat", Payload: map[string]any{"gateway_healthy": true, "restart_count": n}}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	count := func() int {
+		var n int
+		_ = db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND role='hub' AND content LIKE ?`, clawID, restartResumePrefix+"%").Scan(&n)
+		return n
+	}
+	// Historical baseline from before the relaunch, then the relaunched
+	// bridge reports a reset counter mid-turn.
+	beat(5)
+	beat(0)
+	eventuallyWatchdog(t, func() bool { return count() == 1 }, "resume after restart_count reset")
+	beat(0)
+	beat(0)
+	if got := count(); got != 1 {
+		t.Fatalf("resume count after duplicate reset beats = %d, want 1", got)
+	}
+}
+
 func TestRestartWhileIdleDoesNotEnqueueResume(t *testing.T) {
 	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
 	const clawID = "watchdog-idle-restart"

--- a/pkg/hub/watchdog_enforcement_test.go
+++ b/pkg/hub/watchdog_enforcement_test.go
@@ -30,12 +30,22 @@ func watchdogClaw(t *testing.T, s *Server, clawID string) *websocket.Conn {
 	// claw has no messages yet (clawHasMessages), so seed an already-delivered
 	// row BEFORE registering — inserting after the ack races the async check
 	// and lets the wake reserve the turn and write a stray message frame.
-	// delivered_at is set so the row can never be drained as a pending
+	// messages.claw_id has a foreign key on claws(id), so the claws row must
+	// exist first; registration upserts it, so pre-creating is safe.
+	// delivered_at is set so the seed can never be drained as a pending
 	// message and interfere with queue-draining tests.
-	_, _ = s.db.Exec(
+	if _, err := s.db.Exec(
+		`INSERT INTO claws(id,tenant_id,name,template,status,created_at) VALUES(?,?,?,?,?,?)`,
+		clawID, "test-tenant-id", "watchdog claw", "elasticclaw", "offline", time.Now(),
+	); err != nil {
+		t.Fatalf("pre-create claws row: %v", err)
+	}
+	if _, err := s.db.Exec(
 		`INSERT INTO messages(id,claw_id,tenant_id,role,content,format,created_at,delivered_at) VALUES(?,?,?,?,?,?,?,?)`,
 		"seed-"+clawID, clawID, "test-tenant-id", "system", "seed", "pre", time.Now(), time.Now(),
-	)
+	); err != nil {
+		t.Fatalf("seed wake-suppression message: %v", err)
+	}
 	ready := true
 	if err := wsjson.Write(ctx, conn, types.WSMessage{Type: "register", Payload: types.RegisterPayload{
 		ClawID: clawID, Name: "watchdog claw", Template: "elasticclaw", Token: "claw-token", GatewayReady: &ready,

--- a/pkg/hub/watchdog_enforcement_test.go
+++ b/pkg/hub/watchdog_enforcement_test.go
@@ -24,6 +24,18 @@ func watchdogClaw(t *testing.T, s *Server, clawID string) *websocket.Conn {
 		t.Fatalf("dial claw websocket: %v", err)
 	}
 	t.Cleanup(func() { _ = conn.Close(websocket.StatusNormalClosure, "done") })
+	// Registration with gateway_ready triggers an async post-registration
+	// sendWakeMessage/sendInitialPlanInstruction turn reservation (real hub
+	// behavior, unrelated to most watchdog tests). It only fires when the
+	// claw has no messages yet (clawHasMessages), so seed an already-delivered
+	// row BEFORE registering — inserting after the ack races the async check
+	// and lets the wake reserve the turn and write a stray message frame.
+	// delivered_at is set so the row can never be drained as a pending
+	// message and interfere with queue-draining tests.
+	_, _ = s.db.Exec(
+		`INSERT INTO messages(id,claw_id,tenant_id,role,content,format,created_at,delivered_at) VALUES(?,?,?,?,?,?,?,?)`,
+		"seed-"+clawID, clawID, "test-tenant-id", "system", "seed", "pre", time.Now(), time.Now(),
+	)
 	ready := true
 	if err := wsjson.Write(ctx, conn, types.WSMessage{Type: "register", Payload: types.RegisterPayload{
 		ClawID: clawID, Name: "watchdog claw", Template: "elasticclaw", Token: "claw-token", GatewayReady: &ready,
@@ -34,16 +46,6 @@ func watchdogClaw(t *testing.T, s *Server, clawID string) *websocket.Conn {
 	if err := wsjson.Read(ctx, conn, &ack); err != nil || ack.Type != "registered" {
 		t.Fatalf("read registration ack: type=%q err=%v", ack.Type, err)
 	}
-	// Registration with gateway_ready races an async post-registration
-	// sendWakeMessage/sendInitialPlanInstruction turn reservation (real hub
-	// behavior, unrelated to most watchdog tests). It only fires when the
-	// claw has no messages yet (clawHasMessages), so seed an already-delivered
-	// row immediately to suppress it — delivered_at is set so it can never be
-	// drained as a pending message and interfere with queue-draining tests.
-	_, _ = s.db.Exec(
-		`INSERT INTO messages(id,claw_id,tenant_id,role,content,format,created_at,delivered_at) VALUES(?,?,?,?,?,?,?,?)`,
-		"seed-"+clawID, clawID, "test-tenant-id", "system", "seed", "pre", time.Now(), time.Now(),
-	)
 	return conn
 }
 

--- a/pkg/hub/watchdog_enforcement_test.go
+++ b/pkg/hub/watchdog_enforcement_test.go
@@ -34,6 +34,16 @@ func watchdogClaw(t *testing.T, s *Server, clawID string) *websocket.Conn {
 	if err := wsjson.Read(ctx, conn, &ack); err != nil || ack.Type != "registered" {
 		t.Fatalf("read registration ack: type=%q err=%v", ack.Type, err)
 	}
+	// Registration with gateway_ready races an async post-registration
+	// sendWakeMessage/sendInitialPlanInstruction turn reservation (real hub
+	// behavior, unrelated to most watchdog tests). It only fires when the
+	// claw has no messages yet (clawHasMessages), so seed an already-delivered
+	// row immediately to suppress it — delivered_at is set so it can never be
+	// drained as a pending message and interfere with queue-draining tests.
+	_, _ = s.db.Exec(
+		`INSERT INTO messages(id,claw_id,tenant_id,role,content,format,created_at,delivered_at) VALUES(?,?,?,?,?,?,?,?)`,
+		"seed-"+clawID, clawID, "test-tenant-id", "system", "seed", "pre", time.Now(), time.Now(),
+	)
 	return conn
 }
 
@@ -220,4 +230,152 @@ func TestWatchdogSilentDeathStopsClaw(t *testing.T) {
 		_ = db.QueryRow(`SELECT status FROM claws WHERE id=?`, clawID).Scan(&status)
 		return status == "error"
 	}, fmt.Sprintf("silent claw %s error", clawID))
+}
+
+func TestTurnFinishDeletesPendingWatchdogNags(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	const clawID = "watchdog-delete-on-finish"
+	conn := watchdogClaw(t, s, clawID)
+	cc := watchdogClawConn(t, s, clawID)
+	cc.mu.Lock()
+	cc.streamingStartedAt = time.Now()
+	cc.streamingMsgID = "stream"
+	cc.mu.Unlock()
+	for _, row := range []struct{ id, role, content string }{{"nag", "hub", streamingTimeoutNudge}, {"user", "user", "next request"}} {
+		if _, err := db.Exec(`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at,delivered_at) VALUES(?,?,?,?,?,?,NULL)`, row.id, clawID, "test-tenant-id", row.role, row.content, time.Now()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := wsjson.Write(context.Background(), conn, types.WSMessage{Type: "message", Payload: types.HubMessage{Content: "done"}}); err != nil {
+		t.Fatal(err)
+	}
+	eventuallyWatchdog(t, func() bool {
+		var n int
+		_ = db.QueryRow(`SELECT COUNT(*) FROM messages WHERE id='nag'`).Scan(&n)
+		return n == 0
+	}, "stale nag deletion")
+	readCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	for {
+		var got types.WSMessage
+		if err := wsjson.Read(readCtx, conn, &got); err != nil {
+			t.Fatal(err)
+		}
+		if got.Type == "message" {
+			b, _ := got.Payload.(map[string]interface{})
+			if b["content"] != "next request" {
+				t.Fatalf("delivered content = %#v", b["content"])
+			}
+			break
+		}
+	}
+}
+
+func TestForcedFinishDeletesPendingWatchdogNags(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	const clawID = "watchdog-delete-forced"
+	_ = watchdogClaw(t, s, clawID)
+	cc := watchdogClawConn(t, s, clawID)
+	cc.mu.Lock()
+	cc.streamingStartedAt = time.Now().Add(-defaultBusyTurnMax - time.Minute)
+	cc.mu.Unlock()
+	if _, err := db.Exec(`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at,delivered_at) VALUES(?,?,?,?,?,?,NULL)`, "nag", clawID, "test-tenant-id", "hub", streamingTimeoutNudge, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	s.checkClawStatus()
+	eventuallyWatchdog(t, func() bool {
+		var n int
+		_ = db.QueryRow(`SELECT COUNT(*) FROM messages WHERE id='nag'`).Scan(&n)
+		return n == 0
+	}, "forced finish nag deletion")
+}
+
+func TestRestartMidTurnEnqueuesExactlyOneResume(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	const clawID = "watchdog-restart-resume"
+	conn := watchdogClaw(t, s, clawID)
+	cc := watchdogClawConn(t, s, clawID)
+	if _, err := db.Exec(`UPDATE claws SET status='connected', bootstrap_ok=1, issue_title='Fix watchdog', github_issue_id='owner/repo#42' WHERE id=?`, clawID); err != nil {
+		t.Fatal(err)
+	}
+	cc.mu.Lock()
+	cc.streamingStartedAt = time.Now()
+	cc.mu.Unlock()
+	beat := func(n int) {
+		if err := wsjson.Write(context.Background(), conn, types.WSMessage{Type: "heartbeat", Payload: map[string]any{"gateway_healthy": true, "restart_count": n}}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	beat(1)
+	beat(1)
+	beat(1)
+	count := func() int {
+		var n int
+		_ = db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND role='hub' AND content LIKE ?`, clawID, restartResumePrefix+"%").Scan(&n)
+		return n
+	}
+	eventuallyWatchdog(t, func() bool { return count() == 1 }, "one restart resume")
+	beat(2)
+	eventuallyWatchdog(t, func() bool { return count() == 2 }, "second restart resume")
+}
+
+func TestRestartWhileIdleDoesNotEnqueueResume(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	const clawID = "watchdog-idle-restart"
+	conn := watchdogClaw(t, s, clawID)
+	cc := watchdogClawConn(t, s, clawID)
+	if _, err := db.Exec(`UPDATE claws SET status='connected', bootstrap_ok=1 WHERE id=?`, clawID); err != nil {
+		t.Fatal(err)
+	}
+	// watchdogClaw already seeded a delivered message to suppress the async
+	// post-registration wake-turn reservation. Also force the claw back to a
+	// deterministic idle state in case that reservation raced ahead of it.
+	cc.mu.Lock()
+	cc.streamingStartedAt = time.Time{}
+	cc.awaitingResponse = false
+	cc.lastTurnFinishedAt = time.Time{}
+	cc.mu.Unlock()
+	if err := wsjson.Write(context.Background(), conn, types.WSMessage{Type: "heartbeat", Payload: map[string]any{"gateway_healthy": true, "restart_count": 1}}); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(100 * time.Millisecond)
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND content LIKE ?`, clawID, restartResumePrefix+"%").Scan(&n); err != nil || n != 0 {
+		t.Fatalf("resume rows=%d err=%v", n, err)
+	}
+}
+
+func TestLongTurnInterleavedSegmentsNagsExactlyOnce(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	const clawID = "watchdog-interleaved-segments"
+	conn := watchdogClaw(t, s, clawID)
+	cc := watchdogClawConn(t, s, clawID)
+	write := func(m types.WSMessage) {
+		if err := wsjson.Write(context.Background(), conn, m); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(types.WSMessage{Type: "chunk", Payload: map[string]string{"content": "first"}})
+	eventuallyWatchdog(t, func() bool { cc.mu.RLock(); defer cc.mu.RUnlock(); return !cc.streamingStartedAt.IsZero() }, "first chunk")
+	cc.mu.Lock()
+	cc.streamingStartedAt = time.Now().Add(-13 * time.Minute)
+	cc.mu.Unlock()
+	write(types.WSMessage{Type: "agent_activity", Payload: map[string]any{"kind": "tool", "phase": "started"}})
+	write(types.WSMessage{Type: "chunk", Payload: map[string]string{"content": "second"}})
+	write(types.WSMessage{Type: "heartbeat", Payload: map[string]any{"gateway_healthy": true}})
+	count := func() int {
+		var n int
+		_ = db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND content=?`, clawID, streamingTimeoutNudge).Scan(&n)
+		return n
+	}
+	eventuallyWatchdog(t, func() bool { return count() == 1 }, "one timeout nudge")
+	for i := 0; i < 2; i++ {
+		write(types.WSMessage{Type: "agent_activity", Payload: map[string]any{"kind": "tool", "phase": "started"}})
+		write(types.WSMessage{Type: "chunk", Payload: map[string]string{"content": "more"}})
+		write(types.WSMessage{Type: "heartbeat", Payload: map[string]any{"gateway_healthy": true}})
+	}
+	time.Sleep(100 * time.Millisecond)
+	if got := count(); got != 1 {
+		t.Fatalf("timeout nudge rows=%d, want 1", got)
+	}
 }

--- a/pkg/types/hub.go
+++ b/pkg/types/hub.go
@@ -43,6 +43,7 @@ type HubMessage struct {
 //   - "file_ack"      claw → hub     FileAck
 //   - "file_read"     hub → claw     {request_id, path}
 //   - "file_read_resp" claw → hub    FileReadResp
+//   - "nudge"         hub → claw     {claw_id, content} — mid-turn watchdog nudge
 type WSMessage struct {
 	Type    string      `json:"type"`
 	Payload interface{} `json:"payload,omitempty"`


### PR DESCRIPTION
## Incident (NEXT-490)

On 2026-07-24, a long-running agent turn triggered the 12-minute watchdog repeatedly: **35 duplicate "still working?" nags were queued between 12:01 and 12:18 UTC**. When the gateway restarted mid-incident, the entire queue drained into a freshly reset session, and the claw then sat **stale for ~50 minutes** until it was manually resumed.

## Changes

1. **Turn-scoped watchdog flags** — `streamingTimeoutSent` is scoped to the current turn and no longer re-arms while the same turn is still streaming, so the watchdog fires at most once per turn instead of flooding.
2. **Stale-nag drop** — pending watchdog nags addressed to a turn that has already ended are dropped instead of being delivered into the next turn or a reset session. `sendStreamingNudge` re-checks busy state at entry and again after a failed status-channel write before falling back to the queue.
3. **Mid-turn nudge delivery over the status channel** — the bridge injects watchdog nudges into the in-flight OpenClaw turn via the WS status channel (`Channel:"status"`), so the agent sees the nudge while it is still working; if no status channel is connected, it falls back to the regular queue.
4. **Pending-queue dedup** — byte-identical pending queued messages are deduplicated (per role), so repeated watchdog/resume enqueues collapse to a single delivery.
5. **Auto-resume after gateway restart** — the hub detects a genuine gateway restart via the heartbeat restart counter and enqueues a resume automatically. The first heartbeat observation per claw is recorded as a baseline (no restart path), so a hub reboot cannot cause a spurious resume; `lastTurnFinishedAt` survives main-channel reconnects (copied from the old conn, or seeded from the newest `role='claw'` message when the bridge process itself restarted); restarts during bootstrap do not enqueue a resume.

## Test coverage

New/updated tests in `pkg/hub/watchdog_enforcement_test.go`, `pkg/hub/pr_watcher_test.go`, `cmd/claw-bridge/main_test.go`:

- `TestStreamingNudgeGoesOverStatusChannel` — nudge frame delivered over the WS status channel, UI row recorded, zero pending rows
- `TestStreamingNudgeFallsBackToQueueWithoutStatusChannel`
- `TestStreamingNudgeDroppedWhenTurnAlreadyEnded` — late fallback nudge does not leak into the next turn
- `TestRestartDuringBootstrapDoesNotEnqueueResume`
- `TestFirstHeartbeatAfterHubBootDoesNotAutoResume` — baseline observation, then genuine restart auto-resumes
- Interleaved-segments test asserts `streamingTimeoutSent` stays set across segment flushes (guards against re-arm regression)
- Dedup and mid-turn injection tests for the queue and bridge paths

## Verification

- `go build ./...` and `go vet ./...` clean
- `go test ./...` all packages ok (`pkg/hub` 24s)
- New/watchdog tests pass under `-race -count=3`
- `go test -tags integration ./pkg/hub/`: 6 `TestWorkflowHarness_*` failures are **pre-existing on main** — verified byte-identical failure set at merge-base 8256c62 in a clean worktree; this branch introduces no new integration failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
