### PR TITLE
fix(hub): make dependency updates reliable with workspace flake contract

### DIFF
--- a/pkg/hub/dependency_updates.go
+++ b/pkg/hub/dependency_updates.go
@@ -525,40 +525,50 @@ for manifest in manifests:
             had_failure = True
             continue
         listed = run_command(cwd, "go list -m -u -json all")
-        if listed.returncode == 0:
-            try:
-                apply_updates = []
-                for module in parse_go_modules(listed.stdout):
-                    update = module.get("Update") or {}
-                    name = module.get("Path", "")
-                    if not update:
-                        continue
-                    from_version = module.get("Version", "")
-                    to_version = update.get("Version", "")
-                    kind = update_type(from_version, to_version)
-                    if not allowed(name):
-                        update_record("go", name, from_version, to_version, kind, False, skipped_reason="filtered by allow/ignore")
-                        continue
-                    if kind == "major" and not CONFIG.get("include_major"):
-                        update_record("go", name, from_version, to_version, kind, False, skipped_reason="major updates disabled")
-                        continue
-                    update_record("go", name, from_version, to_version, kind, True)
-                    apply_updates.append(f"{name}@{to_version}")
-                # Apply Go updates in a single command. Go can occasionally hit an internal
-                # race where its cached view of go.mod diverges from disk before the final
-                # write, causing "existing contents have changed since last read". A single
-                # retry re-reads go.mod fresh and lets the update recover without failing
-                # the whole step.
-                if apply_updates:
-                    update_args = " ".join(shlex.quote(u) for u in apply_updates)
-                    run_command_with_retry(cwd, "go get " + update_args)
-                # Always tidy after applying updates so that failures still leave
-                # go.mod/go.sum in a consistent state.
-                if apply_updates:
-                    run_command(cwd, "go mod tidy")
-            except Exception as exc:
-                result["commands"].append({"command": "parse go list output", "cwd": rel(cwd), "exit_code": 1, "stderr": str(exc)})
-                had_failure = True
+        # Even if go list exits non-zero (e.g. because of invalid placeholder versions
+        # behind replace directives), stdout may still contain valid JSON for usable
+        # modules. Try to parse it and apply whatever we can.
+        try:
+            apply_updates = []
+            for module in parse_go_modules(listed.stdout):
+                name = module.get("Path", "")
+                # Skip the main module, modules pinned by replace directives, and
+                # transitive-only dependencies. Only direct dependencies can be safely
+                # updated by go get; replaced modules would conflict with the directive.
+                if module.get("Main") or module.get("Replace") or module.get("Indirect"):
+                    continue
+                update = module.get("Update") or {}
+                if not update:
+                    continue
+                from_version = module.get("Version", "")
+                to_version = update.get("Version", "")
+                # Skip placeholder/invalid versions that appear behind replace directives
+                # or in broken module graphs (e.g. v0.0.0).
+                if to_version.startswith("v0.0.0"):
+                    update_record("go", name, from_version, to_version, "unknown", False, skipped_reason="invalid/placeholder version")
+                    continue
+                kind = update_type(from_version, to_version)
+                if not allowed(name):
+                    update_record("go", name, from_version, to_version, kind, False, skipped_reason="filtered by allow/ignore")
+                    continue
+                if kind == "major" and not CONFIG.get("include_major"):
+                    update_record("go", name, from_version, to_version, kind, False, skipped_reason="major updates disabled")
+                    continue
+                update_record("go", name, from_version, to_version, kind, True)
+                apply_updates.append(f"{name}@{to_version}")
+            # Apply each Go update individually. Large batched commands can hit
+            # Go-internal go.mod races and version conflicts between unrelated
+            # modules. Smaller commands isolate failures and let successful updates
+            # remain applied; a single retry handles transient write-conflicts.
+            for update in apply_updates:
+                run_command_with_retry(cwd, "go get " + shlex.quote(update))
+            # Always tidy after applying updates so that partial failures still leave
+            # go.mod/go.sum in a consistent state.
+            if apply_updates:
+                run_command(cwd, "go mod tidy")
+        except Exception as exc:
+            result["commands"].append({"command": "parse go list output", "cwd": rel(cwd), "exit_code": 1, "stderr": str(exc)})
+            had_failure = True
     elif manifest["ecosystem"] == "npm":
         if shutil.which("npm") is None:
             result["commands"].append({"command": "npm", "cwd": rel(cwd), "exit_code": 127, "stderr": "npm executable not found"})

--- a/pkg/hub/dependency_updates.go
+++ b/pkg/hub/dependency_updates.go
@@ -99,6 +99,10 @@ func cleanStringList(values []string) []string {
 	return result
 }
 
+// dependencyUpdatesConfigured reports whether the dependency update stage is
+// actually configured to do work. ContinueOnError is intentionally excluded:
+// the parser already sets Enabled when the dependency_updates block is present,
+// and ContinueOnError only controls whether the pipeline continues after a failure.
 func dependencyUpdatesConfigured(action pipeline.DependencyUpdatesAction) bool {
 	return action.Enabled ||
 		len(action.Ecosystems) > 0 ||
@@ -111,8 +115,7 @@ func dependencyUpdatesConfigured(action pipeline.DependencyUpdatesAction) bool {
 		len(action.Allow) > 0 ||
 		len(action.Ignore) > 0 ||
 		strings.TrimSpace(action.Output) != "" ||
-		strings.TrimSpace(action.Timeout) != "" ||
-		action.ContinueOnError
+		strings.TrimSpace(action.Timeout) != ""
 }
 
 func discoverDependencyUpdateManifests(root string, cfg dependencyUpdatesConfig) ([]dependencyUpdateManifest, error) {
@@ -241,7 +244,7 @@ func buildDependencyUpdatesCommand(action pipeline.DependencyUpdatesAction) (str
 }
 
 func (s *Server) executeDependencyUpdatesAction(clawID, stageID string, action pipeline.DependencyUpdatesAction) (*pipelineRunResult, error) {
-	command, err := s.dependencyUpdatesCommandForClaw(clawID, action)
+	command, err := buildDependencyUpdatesCommand(action)
 	if err != nil {
 		return nil, err
 	}
@@ -256,31 +259,83 @@ func (s *Server) executeDependencyUpdatesAction(clawID, stageID string, action p
 	return result, err
 }
 
-func (s *Server) dependencyUpdatesCommandForClaw(clawID string, action pipeline.DependencyUpdatesAction) (string, error) {
-	command, err := buildDependencyUpdatesCommand(action)
-	if err != nil {
-		return "", err
+// formatDependencyUpdateFailure extracts a concise, actionable failure reason
+// from the dependency update command output. The dependency update script emits
+// JSON; when it fails, surfacing the specific command(s) that failed is far more
+// useful than a raw blob of stdout/stderr that may be dominated by nix shellHook
+// banners or toolchain download noise.
+func formatDependencyUpdateFailure(result *pipelineRunResult) string {
+	if result == nil {
+		return "Dependency update step failed"
 	}
-	useNix, err := s.clawUsesNix(clawID)
-	if err != nil {
-		return "", err
+	combined := strings.TrimSpace(result.Stdout + "\n" + result.Stderr)
+	if combined == "" {
+		return "Dependency update step failed (no output)"
 	}
-	return wrapDependencyUpdatesCommand(command, useNix), nil
+
+	var output struct {
+		Commands []struct {
+			Command  string `json:"command"`
+			Cwd      string `json:"cwd"`
+			ExitCode int    `json:"exit_code"`
+			Stderr   string `json:"stderr"`
+			Stdout   string `json:"stdout"`
+			Failed   *bool  `json:"failed,omitempty"`
+		} `json:"commands"`
+	}
+	// The script may print non-JSON (e.g. shellHook banners) before the JSON.
+	// Try to parse the last JSON object in the output, which is the result document.
+	// The object is not guaranteed to be on a single line, so scan by matching
+	// braces rather than splitting on newlines.
+	if doc := lastJSONObject(combined); doc != nil {
+		_ = json.Unmarshal(doc, &output)
+	}
+
+	var parts []string
+	for _, cmd := range output.Commands {
+		isFailed := cmd.ExitCode != 0
+		if cmd.Failed != nil {
+			isFailed = *cmd.Failed
+		}
+		if !isFailed {
+			continue
+		}
+		detail := cmd.Stderr
+		if detail == "" {
+			detail = cmd.Stdout
+		}
+		detail = strings.TrimSpace(detail)
+		if detail == "" {
+			detail = "exit code " + fmt.Sprintf("%d", cmd.ExitCode)
+		} else if len(detail) > 500 {
+			detail = detail[:500] + "..."
+		}
+		parts = append(parts, fmt.Sprintf("%s (cwd=%s): %s", cmd.Command, cmd.Cwd, detail))
+	}
+	if len(parts) > 0 {
+		return "Dependency update step failed: " + strings.Join(parts, "; ")
+	}
+	// Fallback to raw output if we couldn't parse a structured reason.
+	if len(combined) > 2000 {
+		return "Dependency update step failed: " + combined[:2000] + "..."
+	}
+	return "Dependency update step failed: " + combined
 }
 
-func (s *Server) clawUsesNix(clawID string) (bool, error) {
-	var nixEnabled int
-	if err := s.db.QueryRow(`SELECT nix FROM claws WHERE id=?`, clawID).Scan(&nixEnabled); err != nil {
-		return false, fmt.Errorf("load agent nix setting: %w", err)
+// lastJSONObject returns the last valid JSON object in s, or nil if none is found.
+// It is used to extract the dependency update result document from output that may
+// contain non-JSON banners or log lines before or after the JSON.
+func lastJSONObject(s string) []byte {
+	for close := strings.LastIndex(s, "}"); close >= 0; close = strings.LastIndex(s[:close], "}") {
+		for open := strings.LastIndex(s[:close], "{"); open >= 0; open = strings.LastIndex(s[:open], "{") {
+			candidate := s[open : close+1]
+			var v any
+			if json.Unmarshal([]byte(candidate), &v) == nil {
+				return []byte(candidate)
+			}
+		}
 	}
-	return nixEnabled != 0, nil
-}
-
-func wrapDependencyUpdatesCommand(command string, useNix bool) string {
-	if !useNix {
-		return command
-	}
-	return "nix develop --accept-flake-config -c bash -lc " + shellQuote(command)
+	return nil
 }
 
 const dependencyUpdatesPythonScript = `import base64
@@ -361,18 +416,27 @@ def update_type(old, new):
         return "patch"
     return "unknown"
 
-def run_command(cwd, command, allowed_exit_codes=(0,)):
+def run_command(cwd, command, allowed_exit_codes=(0,), record_failure=True):
     global had_failure
     proc = subprocess.run(command, cwd=str(cwd), shell=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    failed = proc.returncode not in allowed_exit_codes and record_failure
+    if failed:
+        had_failure = True
     result["commands"].append({
         "command": command,
         "cwd": rel(cwd),
         "exit_code": proc.returncode,
-        "stdout": proc.stdout[-4000:],
-        "stderr": proc.stderr[-4000:],
+        "stdout": proc.stdout[-8000:],
+        "stderr": proc.stderr[-8000:],
+        "failed": failed,
     })
-    if proc.returncode not in allowed_exit_codes:
-        had_failure = True
+    return proc
+
+def run_command_with_retry(cwd, command, allowed_exit_codes=(0,), max_attempts=2):
+    for attempt in range(1, max_attempts + 1):
+        proc = run_command(cwd, command, allowed_exit_codes, record_failure=(attempt == max_attempts))
+        if proc.returncode in allowed_exit_codes:
+            return proc
     return proc
 
 def discover():
@@ -454,6 +518,7 @@ before = file_snapshot(collect_files(manifests))
 for manifest in manifests:
     manifest_path = ROOT / manifest["path"]
     cwd = manifest_path.parent
+
     if manifest["ecosystem"] == "go":
         if shutil.which("go") is None:
             result["commands"].append({"command": "go", "cwd": rel(cwd), "exit_code": 127, "stderr": "go executable not found"})
@@ -479,8 +544,17 @@ for manifest in manifests:
                         continue
                     update_record("go", name, from_version, to_version, kind, True)
                     apply_updates.append(f"{name}@{to_version}")
+                # Apply Go updates in a single command. Go can occasionally hit an internal
+                # race where its cached view of go.mod diverges from disk before the final
+                # write, causing "existing contents have changed since last read". A single
+                # retry re-reads go.mod fresh and lets the update recover without failing
+                # the whole step.
                 if apply_updates:
-                    run_command(cwd, "go get " + " ".join(shlex.quote(value) for value in apply_updates))
+                    update_args = " ".join(shlex.quote(u) for u in apply_updates)
+                    run_command_with_retry(cwd, "go get " + update_args)
+                # Always tidy after applying updates so that failures still leave
+                # go.mod/go.sum in a consistent state.
+                if apply_updates:
                     run_command(cwd, "go mod tidy")
             except Exception as exc:
                 result["commands"].append({"command": "parse go list output", "cwd": rel(cwd), "exit_code": 1, "stderr": str(exc)})

--- a/pkg/hub/dependency_updates_test.go
+++ b/pkg/hub/dependency_updates_test.go
@@ -158,7 +158,7 @@ exit 0
 	}
 }
 
-func TestDependencyUpdatesBatchesGoGet(t *testing.T) {
+func TestDependencyUpdatesGoGetOneAtATime(t *testing.T) {
 	root := t.TempDir()
 	bin := filepath.Join(root, "bin")
 	if err := os.MkdirAll(bin, 0o755); err != nil {
@@ -166,18 +166,23 @@ func TestDependencyUpdatesBatchesGoGet(t *testing.T) {
 	}
 	writeExecutable(t, bin, "go", `#!/usr/bin/env bash
 set -e
+ROOT=$(dirname "$0")/..
 if [ "$*" = "list -m -u -json all" ]; then
   printf '%s\n' '{"Path":"example.com/root","Version":"v1.0.0","Update":{"Version":"v1.1.0"}}'
   printf '%s\n' '{"Path":"example.com/other","Version":"v1.0.0","Update":{"Version":"v1.1.0"}}'
   exit 0
 fi
 if [ "$1" = "get" ]; then
-  if [[ "$*" != *"example.com/root@v1.1.0"* || "$*" != *"example.com/other@v1.1.0"* ]]; then
-    echo "expected batched go get with both modules, got: $*" >&2
-    exit 1
-  fi
-  echo changed >> go.sum
-  exit 0
+  case "$2" in
+    example.com/root@v1.1.0|example.com/other@v1.1.0)
+      echo changed >> go.sum
+      exit 0
+      ;;
+    *)
+      echo "unexpected go get target: $2" >&2
+      exit 1
+      ;;
+  esac
 fi
 if [ "$1 $2" = "mod tidy" ]; then
   exit 0
@@ -228,11 +233,74 @@ exit 0
 			getAttempts++
 		}
 	}
-	if getAttempts != 1 {
-		t.Fatalf("go get commands = %d, want 1 batched command", getAttempts)
+	if getAttempts != 2 {
+		t.Fatalf("go get commands = %d, want 2 one-at-a-time commands", getAttempts)
 	}
 	assertUpdateStatus(t, parsed, "go", "example.com/root", true, "")
 	assertUpdateStatus(t, parsed, "go", "example.com/other", true, "")
+}
+
+func TestDependencyUpdatesSkipsReplacedIndirectAndInvalidVersions(t *testing.T) {
+	root := t.TempDir()
+	bin := filepath.Join(root, "bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeExecutable(t, bin, "go", `#!/usr/bin/env bash
+set -e
+if [ "$*" = "list -m -u -json all" ]; then
+  printf '%s\n' '{"Path":"example.com/root","Version":"v1.0.0","Update":{"Version":"v1.1.0"}}'
+  printf '%s\n' '{"Path":"example.com/replaced","Version":"v0.0.0","Update":{"Version":"v1.0.0"},"Replace":{"Path":"example.com/replaced","Version":"v0.0.0"}}'
+  printf '%s\n' '{"Path":"example.com/indirect","Version":"v1.0.0","Update":{"Version":"v1.1.0"},"Indirect":true}'
+  printf '%s\n' '{"Path":"example.com/invalid","Version":"v0.0.0","Update":{"Version":"v0.0.0"}}'
+  exit 0
+fi
+if [ "$1" = "get" ]; then
+  if [ "$2" != "example.com/root@v1.1.0" ]; then
+    echo "unexpected go get target: $2" >&2
+    exit 1
+  fi
+  echo changed >> go.sum
+  exit 0
+fi
+if [ "$1 $2" = "mod tidy" ]; then
+  exit 0
+fi
+exit 0
+`)
+	writeExecutable(t, bin, "npm", `#!/usr/bin/env bash
+if [ "$1 $2" = "outdated --json" ]; then
+  printf '%s\n' '{}'
+  exit 1
+fi
+if [ "$1 $2" = "update --package-lock-only" ]; then
+  exit 0
+fi
+exit 0
+`)
+	writeFile(t, root, "go.mod", "module example.com/root\n")
+	writeFile(t, root, "go.sum", "")
+
+	command, err := buildDependencyUpdatesCommand(pipeline.DependencyUpdatesAction{Enabled: true})
+	if err != nil {
+		t.Fatalf("build command: %v", err)
+	}
+	cmd := osexec.Command("bash", "-c", command)
+	cmd.Dir = root
+	cmd.Env = testEnvWithPath(bin)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("dependency update command failed: %v\n%s", err, out)
+	}
+
+	parsed, ok := parsePipelineOutputJSON(string(out))
+	if !ok {
+		t.Fatalf("command did not emit JSON:\n%s", out)
+	}
+	assertUpdateStatus(t, parsed, "go", "example.com/root", true, "")
+	assertUpdateStatus(t, parsed, "go", "example.com/invalid", false, "invalid/placeholder version")
+	// Replaced and indirect modules are silently skipped and should not appear
+	// in the update records at all, to avoid noisy reports for unpinned deps.
 }
 
 func TestDependencyUpdatesRetriesGoGetFailure(t *testing.T) {

--- a/pkg/hub/dependency_updates_test.go
+++ b/pkg/hub/dependency_updates_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/elasticclaw/elasticclaw/pkg/hub/pipeline"
-	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
 
 func TestNormalizeDependencyUpdatesConfigDefaults(t *testing.T) {
@@ -74,39 +73,16 @@ func TestDiscoverDependencyUpdateManifestsRejectsEscapingPath(t *testing.T) {
 	}
 }
 
-func TestWrapDependencyUpdatesCommandUsesNixDevShellWhenEnabled(t *testing.T) {
-	command := "python3 - <<'PY'\nprint('dependency update')\nPY"
-
-	wrapped := wrapDependencyUpdatesCommand(command, true)
-
-	want := "nix develop --accept-flake-config -c bash -lc " + shellQuote(command)
-	if wrapped != want {
-		t.Fatalf("wrapped command = %q, want %q", wrapped, want)
-	}
-	if got := wrapDependencyUpdatesCommand(command, false); got != command {
-		t.Fatalf("non-nix command = %q, want original command", got)
-	}
-}
-
-func TestDependencyUpdatesCommandForClawWrapsNixEnabledAgents(t *testing.T) {
-	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
-	_, err := db.Exec(
-		`INSERT INTO claws(id, tenant_id, name, template, status, nix, created_at) VALUES(?,?,?,?,?,?,datetime('now'))`,
-		"nix-claw", "test-tenant-id", "nix claw", "workspace", "connected", 1,
-	)
-	if err != nil {
-		t.Fatalf("insert claw: %v", err)
-	}
-
-	command, err := s.dependencyUpdatesCommandForClaw("nix-claw", pipeline.DependencyUpdatesAction{Enabled: true})
+func TestDependencyUpdatesCommandReturnsPythonScriptDirectly(t *testing.T) {
+	command, err := buildDependencyUpdatesCommand(pipeline.DependencyUpdatesAction{Enabled: true})
 	if err != nil {
 		t.Fatalf("build command: %v", err)
 	}
-	if !strings.HasPrefix(command, "nix develop --accept-flake-config -c bash -lc ") {
-		t.Fatalf("command was not wrapped with nix develop:\n%s", command)
+	if strings.HasPrefix(command, "nix develop --accept-flake-config -c bash -lc ") {
+		t.Fatalf("dependency update command should not add its own nix develop wrapper; the workspace run wrapper handles nix:\n%s", command)
 	}
-	if !strings.Contains(command, "python3 - <<") {
-		t.Fatalf("wrapped command missing dependency update script:\n%s", command)
+	if !strings.HasPrefix(command, "python3 - <<") {
+		t.Fatalf("command missing dependency update script:\n%s", command)
 	}
 }
 
@@ -123,8 +99,8 @@ if [ "$*" = "list -m -u -json all" ]; then
   exit 0
 fi
 if [ "$1" = "get" ]; then
-  if [[ "$*" != *"example.com/root@v1.1.0"* ]]; then
-    echo "missing selected module in go get: $*" >&2
+  if [ "$2" != "example.com/root@v1.1.0" ]; then
+    echo "unexpected go get target: $2" >&2
     exit 1
   fi
   echo changed >> go.sum
@@ -182,6 +158,170 @@ exit 0
 	}
 }
 
+func TestDependencyUpdatesBatchesGoGet(t *testing.T) {
+	root := t.TempDir()
+	bin := filepath.Join(root, "bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeExecutable(t, bin, "go", `#!/usr/bin/env bash
+set -e
+if [ "$*" = "list -m -u -json all" ]; then
+  printf '%s\n' '{"Path":"example.com/root","Version":"v1.0.0","Update":{"Version":"v1.1.0"}}'
+  printf '%s\n' '{"Path":"example.com/other","Version":"v1.0.0","Update":{"Version":"v1.1.0"}}'
+  exit 0
+fi
+if [ "$1" = "get" ]; then
+  if [[ "$*" != *"example.com/root@v1.1.0"* || "$*" != *"example.com/other@v1.1.0"* ]]; then
+    echo "expected batched go get with both modules, got: $*" >&2
+    exit 1
+  fi
+  echo changed >> go.sum
+  exit 0
+fi
+if [ "$1 $2" = "mod tidy" ]; then
+  exit 0
+fi
+exit 0
+`)
+	writeExecutable(t, bin, "npm", `#!/usr/bin/env bash
+if [ "$1 $2" = "outdated --json" ]; then
+  printf '%s\n' '{}'
+  exit 1
+fi
+if [ "$1 $2" = "update --package-lock-only" ]; then
+  exit 0
+fi
+exit 0
+`)
+	writeFile(t, root, "go.mod", "module example.com/root\n")
+	writeFile(t, root, "go.sum", "")
+
+	command, err := buildDependencyUpdatesCommand(pipeline.DependencyUpdatesAction{Enabled: true})
+	if err != nil {
+		t.Fatalf("build command: %v", err)
+	}
+	cmd := osexec.Command("bash", "-c", command)
+	cmd.Dir = root
+	cmd.Env = testEnvWithPath(bin)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("dependency update command failed: %v\n%s", err, out)
+	}
+
+	parsed, ok := parsePipelineOutputJSON(string(out))
+	if !ok {
+		t.Fatalf("command did not emit JSON:\n%s", out)
+	}
+	commands, ok := parsed["commands"].([]interface{})
+	if !ok {
+		t.Fatalf("commands = %#v, want list", parsed["commands"])
+	}
+	var getAttempts int
+	for _, raw := range commands {
+		c, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		cmdStr, _ := c["command"].(string)
+		if strings.HasPrefix(cmdStr, "go get") {
+			getAttempts++
+		}
+	}
+	if getAttempts != 1 {
+		t.Fatalf("go get commands = %d, want 1 batched command", getAttempts)
+	}
+	assertUpdateStatus(t, parsed, "go", "example.com/root", true, "")
+	assertUpdateStatus(t, parsed, "go", "example.com/other", true, "")
+}
+
+func TestDependencyUpdatesRetriesGoGetFailure(t *testing.T) {
+	root := t.TempDir()
+	bin := filepath.Join(root, "bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeExecutable(t, bin, "go", `#!/usr/bin/env bash
+set -e
+ROOT=$(dirname "$0")/..
+COUNT_FILE="$ROOT/get-count"
+count=0
+if [ -f "$COUNT_FILE" ]; then
+  count=$(cat "$COUNT_FILE")
+fi
+if [ "$*" = "list -m -u -json all" ]; then
+  printf '%s\n' '{"Path":"example.com/root","Version":"v1.0.0","Update":{"Version":"v1.1.0"}}'
+  exit 0
+fi
+if [ "$1" = "get" ]; then
+  count=$((count + 1))
+  echo "$count" > "$COUNT_FILE"
+  if [ "$count" -eq 1 ]; then
+    echo "go: updating go.mod: existing contents have changed since last read" >&2
+    exit 1
+  fi
+  if [ "$2" != "example.com/root@v1.1.0" ]; then
+    echo "unexpected go get target: $2" >&2
+    exit 1
+  fi
+  echo changed >> go.sum
+  exit 0
+fi
+if [ "$1 $2" = "mod tidy" ]; then
+  exit 0
+fi
+exit 0
+`)
+	writeExecutable(t, bin, "npm", `#!/usr/bin/env bash
+if [ "$1 $2" = "outdated --json" ]; then
+  printf '%s\n' '{}'
+  exit 1
+fi
+if [ "$1 $2" = "update --package-lock-only" ]; then
+  exit 0
+fi
+exit 0
+`)
+	writeFile(t, root, "go.mod", "module example.com/root\n")
+	writeFile(t, root, "go.sum", "")
+
+	command, err := buildDependencyUpdatesCommand(pipeline.DependencyUpdatesAction{Enabled: true})
+	if err != nil {
+		t.Fatalf("build command: %v", err)
+	}
+	cmd := osexec.Command("bash", "-c", command)
+	cmd.Dir = root
+	cmd.Env = testEnvWithPath(bin)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("dependency update command failed: %v\n%s", err, out)
+	}
+
+	parsed, ok := parsePipelineOutputJSON(string(out))
+	if !ok {
+		t.Fatalf("command did not emit JSON:\n%s", out)
+	}
+	commands, ok := parsed["commands"].([]interface{})
+	if !ok {
+		t.Fatalf("commands = %#v, want list", parsed["commands"])
+	}
+	var getAttempts int
+	for _, raw := range commands {
+		c, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		cmdStr, _ := c["command"].(string)
+		if strings.HasPrefix(cmdStr, "go get") {
+			getAttempts++
+		}
+	}
+	if getAttempts != 2 {
+		t.Fatalf("go get attempts = %d, want 2 (initial failure + retry)", getAttempts)
+	}
+	assertUpdateStatus(t, parsed, "go", "example.com/root", true, "")
+}
+
 func TestDependencyUpdatesGeneratedCommandHonorsFiltersAndMajorPolicy(t *testing.T) {
 	root := t.TempDir()
 	bin := filepath.Join(root, "bin")
@@ -197,12 +337,12 @@ if [ "$*" = "list -m -u -json all" ]; then
   exit 0
 fi
 if [ "$1" = "get" ]; then
-  if [[ "$*" == *"ignored.com/risky"* || "$*" == *"example.com/major"* ]]; then
-    echo "go get included skipped dependency: $*" >&2
+  if [ "$2" = "ignored.com/risky@v1.1.0" ] || [ "$2" = "example.com/major@v1.0.0" ]; then
+    echo "go get included skipped dependency: $2" >&2
     exit 1
   fi
-  if [[ "$*" != *"example.com/root@v1.1.0"* ]]; then
-    echo "go get omitted selected dependency: $*" >&2
+  if [ "$2" != "example.com/root@v1.1.0" ]; then
+    echo "go get omitted or unexpected selected dependency: $2" >&2
     exit 1
   fi
   echo changed >> go.sum
@@ -317,5 +457,65 @@ func writeExecutable(t *testing.T, root, name, content string) {
 	path := filepath.Join(root, name)
 	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestFormatDependencyUpdateFailureExtractsFailedCommand(t *testing.T) {
+	stdout := `{"commands":[{"command":"go list -m -u -json all","cwd":"ec/e2e","exit_code":0,"stderr":""},{"command":"go get example.com/foo@v1.1.0","cwd":"ec/e2e","exit_code":1,"stderr":"go: example.com/foo@v1.1.0: not found"}],"updates":[]}`
+	result := &pipelineRunResult{ExitCode: 1, Stdout: stdout}
+	got := formatDependencyUpdateFailure(result)
+	want := "Dependency update step failed: go get example.com/foo@v1.1.0 (cwd=ec/e2e): go: example.com/foo@v1.1.0: not found"
+	if got != want {
+		t.Fatalf("formatDependencyUpdateFailure = %q, want %q", got, want)
+	}
+}
+
+func TestFormatDependencyUpdateFailureFallsBackToRawOutput(t *testing.T) {
+	result := &pipelineRunResult{ExitCode: 1, Stderr: "some shellHook banner\n" + strings.Repeat("x", 3000)}
+	got := formatDependencyUpdateFailure(result)
+	if !strings.HasPrefix(got, "Dependency update step failed: ") {
+		t.Fatalf("unexpected prefix: %q", got)
+	}
+	if len(got) > 2100 {
+		t.Fatalf("fallback message not truncated: length %d", len(got))
+	}
+}
+
+func TestFormatDependencyUpdateFailureHandlesMultiLineJSON(t *testing.T) {
+	stdout := "some shellHook banner\n" + `{
+  "commands": [
+    {
+      "command": "go get example.com/foo@v1.1.0",
+      "cwd": "ec/e2e",
+      "exit_code": 1,
+      "stderr": "go: example.com/foo@v1.1.0: not found"
+    }
+  ]
+}`
+	result := &pipelineRunResult{ExitCode: 1, Stdout: stdout}
+	got := formatDependencyUpdateFailure(result)
+	want := "Dependency update step failed: go get example.com/foo@v1.1.0 (cwd=ec/e2e): go: example.com/foo@v1.1.0: not found"
+	if got != want {
+		t.Fatalf("formatDependencyUpdateFailure = %q, want %q", got, want)
+	}
+}
+
+func TestFormatDependencyUpdateFailureSkipsAllowedExitCodes(t *testing.T) {
+	stdout := `{"commands":[{"command":"npm outdated --json","cwd":"ec/e2e","exit_code":1,"failed":false},{"command":"npm update --package-lock-only foo","cwd":"ec/e2e","exit_code":1,"stderr":"npm ERR! code E404","failed":true}],"updates":[]}`
+	result := &pipelineRunResult{ExitCode: 1, Stdout: stdout}
+	got := formatDependencyUpdateFailure(result)
+	want := "Dependency update step failed: npm update --package-lock-only foo (cwd=ec/e2e): npm ERR! code E404"
+	if got != want {
+		t.Fatalf("formatDependencyUpdateFailure = %q, want %q", got, want)
+	}
+}
+
+func TestFormatDependencyUpdateFailureSkipsRetriedAttempts(t *testing.T) {
+	stdout := `{"commands":[{"command":"go get example.com/foo@v1.1.0","cwd":"ec/e2e","exit_code":1,"stderr":"existing contents have changed since last read","failed":false},{"command":"go get example.com/foo@v1.1.0","cwd":"ec/e2e","exit_code":0,"failed":false},{"command":"go mod tidy","cwd":"ec/e2e","exit_code":1,"stderr":"go: errors","failed":true}],"updates":[]}`
+	result := &pipelineRunResult{ExitCode: 1, Stdout: stdout}
+	got := formatDependencyUpdateFailure(result)
+	want := "Dependency update step failed: go mod tidy (cwd=ec/e2e): go: errors"
+	if got != want {
+		t.Fatalf("formatDependencyUpdateFailure = %q, want %q", got, want)
 	}
 }

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -949,19 +949,26 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 		log.Printf("[pipeline] running dependency updates for claw %s stage %q output %q", clawID[:8], stage.ID, outputName)
 		result, err := s.executeDependencyUpdatesAction(clawID, stage.ID, stage.OnEnter.DependencyUpdates)
 		if err != nil || (result != nil && result.ExitCode != 0) {
-			msg := "Dependency update step failed"
-			if result != nil {
-				details := strings.TrimSpace(result.Stdout + "\n" + result.Stderr)
-				if details != "" {
-					msg += ": " + truncateString(details, 2000)
-				}
-			} else if err != nil {
+			msg := formatDependencyUpdateFailure(result)
+			if err != nil && !strings.Contains(msg, err.Error()) {
 				msg += ": " + err.Error()
 			}
-			log.Printf("[pipeline] %s", msg)
-			s.injectHubMessageByID(clawID, "[hub] Error: "+msg)
-			if !stage.OnEnter.DependencyUpdates.ContinueOnError {
-				return false, fmt.Errorf("dependency update step failed: %s", msg)
+			// Log the full output so operators can debug even when the chat message is truncated.
+			if result != nil {
+				if result.Stdout != "" {
+					log.Printf("[pipeline] dependency update stdout for claw %s:\n%s", clawID[:8], result.Stdout)
+				}
+				if result.Stderr != "" {
+					log.Printf("[pipeline] dependency update stderr for claw %s:\n%s", clawID[:8], result.Stderr)
+				}
+			}
+			if stage.OnEnter.DependencyUpdates.ContinueOnError {
+				log.Printf("[pipeline] %s; continuing because continue_on_error=true", msg)
+				s.injectHubMessageByID(clawID, "[hub] Warning: "+msg)
+			} else {
+				log.Printf("[pipeline] %s", msg)
+				s.injectHubMessageByID(clawID, "[hub] Error: "+msg)
+				return false, errors.New(msg)
 			}
 		}
 	}

--- a/pkg/hub/pipeline_runner_test.go
+++ b/pkg/hub/pipeline_runner_test.go
@@ -1078,6 +1078,95 @@ func TestRunOnEnterJudgeContinueOnError(t *testing.T) {
 	}
 }
 
+func TestRunOnEnterDependencyUpdatesStopsOnError(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{
+		Token:     "test-token",
+		ClawToken: "test-claw-token",
+		Providers: map[string]types.ProviderConfig{
+			"failing": {Type: "failing"},
+		},
+	}, "", "", "")
+
+	const clawID = "claw-deps-stop"
+	_, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, template, status, provider, provider_id, created_at) VALUES(?,?,?,?,?,?,?,datetime('now'))`,
+		clawID, "test-tenant-id", "test-claw", "elasticclaw", "connected", "failing", "failing-id",
+	)
+	if err != nil {
+		t.Fatalf("insert claw: %v", err)
+	}
+
+	stage := pipeline.Stage{
+		ID:    "deps",
+		Label: "Dependency Updates",
+		OnEnter: pipeline.OnEnter{
+			DependencyUpdates: pipeline.DependencyUpdatesAction{
+				Enabled: true,
+			},
+			Inject: "Continue after deps",
+		},
+	}
+
+	_, err = s.runOnEnter(clawID, stage, pipelineContext{})
+	if err == nil {
+		t.Fatal("expected runOnEnter to return error when dependency updates fail and continue_on_error=false")
+	}
+
+	var messageCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=?`, clawID).Scan(&messageCount); err != nil {
+		t.Fatalf("count messages: %v", err)
+	}
+	// Should have 1 error message; inject message should NOT appear because the stage aborted.
+	if messageCount != 1 {
+		t.Fatalf("expected 1 message (deps error), got %d", messageCount)
+	}
+}
+
+func TestRunOnEnterDependencyUpdatesContinueOnError(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{
+		Token:     "test-token",
+		ClawToken: "test-claw-token",
+		Providers: map[string]types.ProviderConfig{
+			"failing": {Type: "failing"},
+		},
+	}, "", "", "")
+
+	const clawID = "claw-deps-continue"
+	_, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, template, status, provider, provider_id, created_at) VALUES(?,?,?,?,?,?,?,datetime('now'))`,
+		clawID, "test-tenant-id", "test-claw", "elasticclaw", "connected", "failing", "failing-id",
+	)
+	if err != nil {
+		t.Fatalf("insert claw: %v", err)
+	}
+
+	stage := pipeline.Stage{
+		ID:    "deps",
+		Label: "Dependency Updates",
+		OnEnter: pipeline.OnEnter{
+			DependencyUpdates: pipeline.DependencyUpdatesAction{
+				Enabled:         true,
+				ContinueOnError: true,
+			},
+			Inject: "Continue after deps",
+		},
+	}
+
+	_, err = s.runOnEnter(clawID, stage, pipelineContext{})
+	if err != nil {
+		t.Fatalf("expected runOnEnter to continue when continue_on_error=true, got error: %v", err)
+	}
+
+	var messageCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=?`, clawID).Scan(&messageCount); err != nil {
+		t.Fatalf("count messages: %v", err)
+	}
+	// Should have 2 messages: deps warning + inject message (because continue_on_error=true).
+	if messageCount != 2 {
+		t.Fatalf("expected 2 messages (deps warning + inject), got %d", messageCount)
+	}
+}
+
 func TestAutoTransitionAfterJudge(t *testing.T) {
 	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
 

--- a/web/components/conversation-view.tsx
+++ b/web/components/conversation-view.tsx
@@ -1786,7 +1786,7 @@ export function ConversationView({
           {sortedClaws.length === 0 && !loading ? (
             <div className="flex flex-col items-center justify-center h-full gap-6 px-8 text-center">
               <img
-                src={logoUrl || "/mascot.png"}
+                src={logoUrl || "/mascot.png?v=2"}
                 alt="mascot"
                 className="w-72 h-72 object-contain select-none pointer-events-none opacity-90"
                 draggable={false}


### PR DESCRIPTION
This PR aligns dependency update nix handling with the workspace flake contract (#526): the workspace root flake is the single source of truth for workspace tools, and repo-local flakes are kept separate. It also makes Go dependency updates resilient to replace directives, indirect-dependency conflicts, and transient go.mod races.

## Problems fixed

### 1. Double nix develop wrapping
When a workspace has a flake, the workflow command is already wrapped by flake-run (which enters the workspace devShell). The dependency update action added another `nix develop --accept-flake-config -c bash -lc ...` wrapper, causing the devShell shellHook banner to be printed twice and increasing the chance of flake lock/evaluation failures.

### 2. Go updates failed on repos with replace directives and complex dependency graphs
`go list -m -u -json all` reports updates for every module, including:
- the main module,
- modules pinned by `replace` directives,
- indirect dependencies, and
- placeholder versions like `v0.0.0`.

Applying all of these in one batched `go get` caused failures such as:
- `invalid version: unknown revision v0.0.0` for replaced k8s.io modules,
- version conflicts between indirect dependencies (e.g. `google.golang.org/protobuf` versions required by different direct deps),
- Go's transient `existing contents have changed since last read` go.mod race.

A single failed command rolled back the entire batch, leaving no useful updates applied.

## Changes

- Remove the per-action `nix develop` wrapper from dependency updates. The dependency update script is returned directly and relies on `buildWorkspaceRunCommand` / `flake-run` to provide the workspace nix environment.
- Run `go` and `npm` commands from the manifest directory directly; the workspace flake supplies the correct tools via `flake-run`.
- Filter Go modules before updating:
  - skip the main module,
  - skip modules with `replace` directives,
  - skip indirect dependencies (let Go's MVS resolve those),
  - skip placeholder/invalid versions like `v0.0.0`.
- Parse `go list` output even when it exits non-zero, so valid direct-dependency updates still apply when the module graph has replace/placeholder issues.
- Apply Go updates one module at a time with a single retry per module. This isolates failures so one conflicting or transient failure cannot roll back the whole batch.
- Run `go mod tidy` after the updates to keep `go.mod`/`go.sum` consistent even when some updates fail.
- Dependency update failures respect `continue_on_error` (default `false`). When `false`, the failure is reported as `[hub] Error:` and the stage aborts. When `true`, the failure is reported as `[hub] Warning:` and the agent continues.
- Add `formatDependencyUpdateFailure` which parses the structured JSON output from the Python script and reports the specific command(s) that failed, rather than dumping raw stdout/stderr. Full output is still logged to the hub logs for debugging.
- Increase per-command output capture from 4000 to 8000 characters.
- Fix the embedded web UI mascot image URL to include a cache-busting query string (`/mascot.png?v=2`) so browsers/CDNs fetch it fresh after the web UI is deployed.

## Tests

- No double-wrap when the workspace has a flake.
- Go updates are applied one module at a time.
- Replaced, indirect, and invalid/placeholder Go modules are skipped.
- Retry on transient `go get` failure.
- Structured failure message formatting.
- Continue-on-error behavior for dependency updates.
- Filter and major-policy handling for Go and npm.
- Multi-line JSON parsing for failure messages.

Partially implements #526
