### PR TITLE
feat(hub): add exclude_paths to dependency_updates

### DIFF
--- a/pkg/hub/dependency_updates.go
+++ b/pkg/hub/dependency_updates.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -21,6 +22,7 @@ const (
 type dependencyUpdatesConfig struct {
 	Ecosystems       []string `json:"ecosystems"`
 	Paths            []string `json:"paths"`
+	ExcludePaths     []string `json:"exclude_paths"`
 	Grouping         string   `json:"grouping"`
 	IncludeMajor     bool     `json:"include_major"`
 	SeparateMajor    bool     `json:"separate_major"`
@@ -40,6 +42,7 @@ func normalizeDependencyUpdatesConfig(action pipeline.DependencyUpdatesAction) d
 	cfg := dependencyUpdatesConfig{
 		Ecosystems:       cleanStringList(action.Ecosystems),
 		Paths:            cleanStringList(action.Paths),
+		ExcludePaths:     cleanStringList(action.ExcludePaths),
 		Grouping:         strings.TrimSpace(action.Grouping),
 		IncludeMajor:     action.IncludeMajor,
 		SeparateMajor:    boolDefault(action.SeparateMajor, true),
@@ -107,6 +110,7 @@ func dependencyUpdatesConfigured(action pipeline.DependencyUpdatesAction) bool {
 	return action.Enabled ||
 		len(action.Ecosystems) > 0 ||
 		len(action.Paths) > 0 ||
+		len(action.ExcludePaths) > 0 ||
 		strings.TrimSpace(action.Grouping) != "" ||
 		action.IncludeMajor ||
 		action.SeparateMajor != nil ||
@@ -116,6 +120,24 @@ func dependencyUpdatesConfigured(action pipeline.DependencyUpdatesAction) bool {
 		len(action.Ignore) > 0 ||
 		strings.TrimSpace(action.Output) != "" ||
 		strings.TrimSpace(action.Timeout) != ""
+}
+
+func isExcludedPath(relPath string, patterns []string) bool {
+	for _, p := range patterns {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		if matched, _ := path.Match(p, relPath); matched {
+			return true
+		}
+		if !strings.ContainsAny(p, "*?") {
+			if relPath == p || strings.HasPrefix(relPath, p+"/") {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func discoverDependencyUpdateManifests(root string, cfg dependencyUpdatesConfig) ([]dependencyUpdateManifest, error) {
@@ -146,22 +168,28 @@ func discoverDependencyUpdateManifests(root string, cfg dependencyUpdatesConfig)
 			if err != nil {
 				return err
 			}
-			if d.IsDir() && shouldSkipDependencyUpdateDir(d.Name()) {
-				if path == base {
-					return nil
-				}
-				return filepath.SkipDir
-			}
-			if d.IsDir() {
-				return nil
-			}
-			name := d.Name()
-			dir := filepath.Dir(path)
 			relPath, err := filepath.Rel(root, path)
 			if err != nil {
 				return err
 			}
 			relPath = filepath.ToSlash(relPath)
+			if d.IsDir() {
+				if shouldSkipDependencyUpdateDir(d.Name()) {
+					if path == base {
+						return nil
+					}
+					return filepath.SkipDir
+				}
+				if isExcludedPath(relPath, cfg.ExcludePaths) {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if isExcludedPath(relPath, cfg.ExcludePaths) {
+				return nil
+			}
+			name := d.Name()
+			dir := filepath.Dir(path)
 			switch {
 			case ecosystems["go"] && name == "go.mod":
 				lock := filepath.Join(dir, "go.sum")
@@ -377,6 +405,20 @@ def rel(path):
 def should_skip(path):
     return any(part in SKIP_DIRS for part in path.parts)
 
+def is_excluded_path(path):
+    rel = str(path)
+    patterns = CONFIG.get("exclude_paths") or []
+    for p in patterns:
+        p = str(p).strip()
+        if not p:
+            continue
+        if fnmatch.fnmatch(rel, p):
+            return True
+        if "*" not in p and "?" not in p:
+            if rel == p or rel.startswith(p + "/"):
+                return True
+    return False
+
 def allowed(name):
     allow = CONFIG.get("allow") or ["*"]
     ignore = CONFIG.get("ignore") or []
@@ -452,23 +494,33 @@ def discover():
             continue
         if base.is_file():
             base = base.parent
+        if is_excluded_path(rel(base)):
+            continue
         for current, dirs, files in os.walk(base):
             current_path = pathlib.Path(current)
-            dirs[:] = [d for d in dirs if d not in SKIP_DIRS]
+            rel_current = rel(current_path)
+            if is_excluded_path(rel_current):
+                dirs[:] = []
+                continue
+            dirs[:] = [d for d in dirs if d not in SKIP_DIRS and not is_excluded_path(rel_current + "/" + d)]
             if should_skip(current_path.relative_to(ROOT)):
                 continue
             file_set = set(files)
             if "go" in ECOSYSTEMS and "go.mod" in file_set:
-                locks = []
-                if "go.sum" in file_set:
-                    locks.append(rel(current_path / "go.sum"))
-                manifests.append({"ecosystem": "go", "path": rel(current_path / "go.mod"), "lockfiles": locks})
+                mod_path = rel(current_path / "go.mod")
+                if not is_excluded_path(mod_path):
+                    locks = []
+                    if "go.sum" in file_set:
+                        locks.append(rel(current_path / "go.sum"))
+                    manifests.append({"ecosystem": "go", "path": mod_path, "lockfiles": locks})
             if "npm" in ECOSYSTEMS and "package.json" in file_set:
-                locks = []
-                for lock in ("package-lock.json", "npm-shrinkwrap.json"):
-                    if lock in file_set:
-                        locks.append(rel(current_path / lock))
-                manifests.append({"ecosystem": "npm", "path": rel(current_path / "package.json"), "lockfiles": locks})
+                pkg_path = rel(current_path / "package.json")
+                if not is_excluded_path(pkg_path):
+                    locks = []
+                    for lock in ("package-lock.json", "npm-shrinkwrap.json"):
+                        if lock in file_set:
+                            locks.append(rel(current_path / lock))
+                    manifests.append({"ecosystem": "npm", "path": pkg_path, "lockfiles": locks})
     manifests.sort(key=lambda item: (item["ecosystem"], item["path"]))
     return manifests
 

--- a/pkg/hub/dependency_updates_test.go
+++ b/pkg/hub/dependency_updates_test.go
@@ -73,6 +73,38 @@ func TestDiscoverDependencyUpdateManifestsRejectsEscapingPath(t *testing.T) {
 	}
 }
 
+func TestDiscoverDependencyUpdateManifestsExcludesPaths(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "go.mod", "module example.com/root\n")
+	writeFile(t, root, "go.sum", "")
+	writeFile(t, root, "dagger/go.mod", "module example.com/dagger\n")
+	writeFile(t, root, "dagger/go.sum", "")
+	writeFile(t, root, "web/package.json", `{"name":"web"}`)
+	writeFile(t, root, "web/package-lock.json", `{"lockfileVersion":3}`)
+	writeFile(t, root, "legacy/package.json", `{"name":"legacy"}`)
+	writeFile(t, root, "legacy/package-lock.json", `{"lockfileVersion":3}`)
+
+	manifests, err := discoverDependencyUpdateManifests(root, dependencyUpdatesConfig{
+		Ecosystems:   []string{"go", "npm"},
+		Paths:        []string{"."},
+		ExcludePaths: []string{"dagger", "legacy/package.json"},
+	})
+	if err != nil {
+		t.Fatalf("discover manifests: %v", err)
+	}
+	got := make([]string, 0, len(manifests))
+	for _, manifest := range manifests {
+		got = append(got, manifest.Ecosystem+":"+manifest.Path+":"+strings.Join(manifest.Lockfiles, ","))
+	}
+	want := []string{
+		"go:go.mod:go.sum",
+		"npm:web/package.json:web/package-lock.json",
+	}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("manifests:\n%s\nwant:\n%s", strings.Join(got, "\n"), strings.Join(want, "\n"))
+	}
+}
+
 func TestDependencyUpdatesCommandReturnsPythonScriptDirectly(t *testing.T) {
 	command, err := buildDependencyUpdatesCommand(pipeline.DependencyUpdatesAction{Enabled: true})
 	if err != nil {
@@ -469,6 +501,92 @@ exit 0
 	assertUpdateStatus(t, parsed, "go", "example.com/major", false, "major updates disabled")
 	assertUpdateStatus(t, parsed, "npm", "risky-lib", false, "filtered by allow/ignore")
 	assertUpdateStatus(t, parsed, "npm", "major-lib", false, "major updates disabled")
+}
+
+func TestDependencyUpdatesGeneratedCommandHonorsExcludePaths(t *testing.T) {
+	root := t.TempDir()
+	bin := filepath.Join(root, "bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeExecutable(t, bin, "go", `#!/usr/bin/env bash
+set -e
+if [ "$*" = "list -m -u -json all" ]; then
+  printf '%s\n' '{"Path":"example.com/root","Version":"v1.0.0","Update":{"Version":"v1.1.0"}}'
+  exit 0
+fi
+if [ "$1" = "get" ]; then
+  if [ "$2" = "example.com/dagger@v1.1.0" ]; then
+    echo "go get included excluded dependency: $2" >&2
+    exit 1
+  fi
+  if [ "$2" = "example.com/root@v1.1.0" ]; then
+    echo changed >> go.sum
+    exit 0
+  fi
+  echo "unexpected go get target: $2" >&2
+  exit 1
+fi
+if [ "$1 $2" = "mod tidy" ]; then
+  exit 0
+fi
+exit 0
+`)
+	writeExecutable(t, bin, "npm", `#!/usr/bin/env bash
+if [ "$1 $2" = "outdated --json" ]; then
+  printf '%s\n' '{}'
+  exit 1
+fi
+if [ "$1 $2" = "update --package-lock-only" ]; then
+  exit 0
+fi
+exit 0
+`)
+	writeFile(t, root, "go.mod", "module example.com/root\n")
+	writeFile(t, root, "go.sum", "")
+	writeFile(t, root, "dagger/go.mod", "module example.com/dagger\n")
+	writeFile(t, root, "dagger/go.sum", "")
+
+	command, err := buildDependencyUpdatesCommand(pipeline.DependencyUpdatesAction{
+		Enabled:      true,
+		Ecosystems:   []string{"go"},
+		ExcludePaths: []string{"dagger"},
+	})
+	if err != nil {
+		t.Fatalf("build command: %v", err)
+	}
+	cmd := osexec.Command("bash", "-c", command)
+	cmd.Dir = root
+	cmd.Env = testEnvWithPath(bin)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("dependency update command failed: %v\n%s", err, out)
+	}
+
+	parsed, ok := parsePipelineOutputJSON(string(out))
+	if !ok {
+		t.Fatalf("command did not emit JSON:\n%s", out)
+	}
+	manifests, ok := parsed["manifests"].([]interface{})
+	if !ok || len(manifests) != 1 {
+		t.Fatalf("manifests = %#v, want exactly one go.mod", parsed["manifests"])
+	}
+	commands, ok := parsed["commands"].([]interface{})
+	if !ok {
+		t.Fatalf("commands = %#v, want list", parsed["commands"])
+	}
+	for _, raw := range commands {
+		c, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		cmdStr, _ := c["command"].(string)
+		cwd, _ := c["cwd"].(string)
+		if strings.Contains(cmdStr, "dagger") || cwd == "dagger" {
+			t.Fatalf("command touched excluded dagger path: %s (cwd=%s)", cmdStr, cwd)
+		}
+	}
+	assertUpdateStatus(t, parsed, "go", "example.com/root", true, "")
 }
 
 func assertUpdateStatus(t *testing.T, parsed map[string]interface{}, ecosystem, name string, applied bool, skippedReason string) {

--- a/pkg/hub/pipeline/pipeline.go
+++ b/pkg/hub/pipeline/pipeline.go
@@ -217,6 +217,7 @@ type DependencyUpdatesAction struct {
 	Enabled          bool     `yaml:"-" json:"-"`
 	Ecosystems       []string `yaml:"ecosystems,omitempty"`
 	Paths            []string `yaml:"paths,omitempty"`
+	ExcludePaths     []string `yaml:"exclude_paths,omitempty"`
 	Grouping         string   `yaml:"grouping,omitempty"`
 	IncludeMajor     bool     `yaml:"include_major,omitempty"`
 	SeparateMajor    *bool    `yaml:"separate_major,omitempty"`

--- a/pkg/hub/pipeline/pipeline_test.go
+++ b/pkg/hub/pipeline/pipeline_test.go
@@ -236,6 +236,7 @@ stages:
       dependency_updates:
         ecosystems: [go, npm]
         paths: ["."]
+        exclude_paths: [dagger]
         grouping: all
         include_major: false
         output: deps
@@ -257,6 +258,9 @@ stages:
 	}
 	if !action.ContinueOnError {
 		t.Fatal("expected continue_on_error")
+	}
+	if strings.Join(action.ExcludePaths, ",") != "dagger" {
+		t.Fatalf("exclude_paths = %v, want [dagger]", action.ExcludePaths)
 	}
 }
 


### PR DESCRIPTION
## Problem

The `dependency_updates` workflow action only supports `paths` for inclusion. There is no way to exclude a specific subdirectory of that path.  E.g. I want to update `repo/go.mod` but not `repo/dagger/go.mod` which should be updated with `dagger develop` rather than standard Go tools.

## Solution

Add an `exclude_paths` option to the `dependency_updates` action. Excluded paths are skipped during manifest discovery and are never processed by the updater.

`exclude_paths` supports:
- simple directory names (e.g. `dagger` excludes everything under `dagger/`)
- exact paths (e.g. `dagger/go.mod`)
- glob patterns with `*` or `?`

## Usage

```yaml
on_enter:
  dependency_updates:
    exclude_paths: [dagger]
```

Note: `ignore` is for filtering individual dependency names, not paths.

## Changes

- `pkg/hub/pipeline/pipeline.go`: adds `ExcludePaths` to `DependencyUpdatesAction`.
- `pkg/hub/dependency_updates.go`: adds `exclude_paths` to the internal config, applies it in Go-side discovery, and adds matching logic to the embedded Python script.
- `pkg/hub/dependency_updates_test.go`: adds tests for Go discovery and the generated command honoring `exclude_paths`.
- `pkg/hub/pipeline/pipeline_test.go`: adds a test for YAML parsing of `exclude_paths`.

## Verification

`go test ./pkg/hub/... -count=1` passes.
