### PR TITLE
fix(hub): reconcile dead-claw PRs on terminal runs

### DIFF
--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -197,13 +197,14 @@ func (s *Server) startPRWatcher() {
 // reconcileDeadClawPRs closes out task_run_prs rows left open because their
 // backing claw died before the PR's merge/close was observed. It only queries
 // and updates task-run state; it never touches claws or injects into agents.
+// Terminal runs that do not require a PR can still have an open PR whose merge
+// must be recorded, so this intentionally does not filter by run status.
 func (s *Server) reconcileDeadClawPRs() {
 	rows, err := s.db.Query(`
 		SELECT trp.run_id, trp.repo, trp.pr_number, trp.pr_url
 		FROM task_run_prs trp
 		JOIN task_run_summaries trs ON trs.run_id = trp.run_id
 		WHERE trp.state = 'open'
-		  AND trs.status = 'running'
 		  AND trs.analytics_enabled = 1
 		  AND (trp.opened_at = 0 OR trp.opened_at > ?)
 		  AND NOT EXISTS (

--- a/pkg/hub/pr_watcher_test.go
+++ b/pkg/hub/pr_watcher_test.go
@@ -138,6 +138,39 @@ func TestReconcileDeadClawPRsClosesUnmergedPRSetsSuccessStatus(t *testing.T) {
 	}
 }
 
+func TestReconcileDeadClawPRsClosesMergedPRForTerminalNonPRRun(t *testing.T) {
+	oldTransport := http.DefaultTransport
+	http.DefaultTransport = githubAppTokenTransport{base: oldTransport}
+	t.Cleanup(func() { http.DefaultTransport = oldTransport })
+
+	gh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer repo-token" {
+			t.Fatalf("authorization = %q, want repo token", r.Header.Get("Authorization"))
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"state": "closed", "merged": true, "merged_at": "2026-01-01T00:00:00Z"})
+	}))
+	defer gh.Close()
+
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{GitHubApps: []*types.GitHubAppConfig{{AppID: 1, PrivateKeyPEM: testGitHubAppPEM(t)}}}, gh.URL, "", "")
+	if _, err := db.Exec(`INSERT INTO claws(id, tenant_id, name, template, status, created_at) VALUES(?,?,?,?,?,?)`, "dead-terminal", "test-tenant-id", "dead-terminal", "elasticclaw", "running", now()); err != nil {
+		t.Fatal(err)
+	}
+	runID, attemptID := startTaskRunWithRequiresPRForTest(t, s, "dead-terminal", "terminal", false)
+	recordTaskRunEventForTest(t, s, TaskRunEvent{TenantID: "test-tenant-id", RunID: runID, AttemptID: attemptID, EventKey: "terminal:completed", EventType: taskRunEventTaskCompleted, ActorType: taskRunActorAgent, Source: taskRunSourceHub})
+	associatePRForTest(t, s, runID, "owner/repo", 5, taskRunPRStateOpen)
+	assertTaskRunSummary(t, db, runID, taskRunStatusClean, taskRunPhaseTerminal, "", "[]", 0, 1, 1, 0, 0)
+
+	s.reconcileDeadClawPRs()
+	assertTaskRunPR(t, db, runID, "owner/repo", 5, taskRunPRStateClosed, true)
+	var mergedAt int64
+	if err := db.QueryRow(`SELECT merged_at FROM task_run_summaries WHERE run_id=?`, runID).Scan(&mergedAt); err != nil {
+		t.Fatal(err)
+	}
+	if mergedAt == 0 {
+		t.Fatal("expected merged_at to be populated")
+	}
+}
+
 func TestReconcileDeadClawPRsSkipsAgeCappedRows(t *testing.T) {
 	oldTransport := http.DefaultTransport
 	http.DefaultTransport = githubAppTokenTransport{base: oldTransport}

--- a/pkg/hub/task_run_analytics_test.go
+++ b/pkg/hub/task_run_analytics_test.go
@@ -737,6 +737,10 @@ func newTaskRunAnalyticsTestServer(t *testing.T, clawID string) (*Server, *sql.D
 }
 
 func startTaskRunForTest(t *testing.T, s *Server, clawID, keyPrefix string) (string, string) {
+	return startTaskRunWithRequiresPRForTest(t, s, clawID, keyPrefix, true)
+}
+
+func startTaskRunWithRequiresPRForTest(t *testing.T, s *Server, clawID, keyPrefix string, requiresPR bool) (string, string) {
 	t.Helper()
 	runID, attemptID, err := s.ensureTaskRunForClaw(clawID, TaskRunStart{
 		TenantID:         "test-tenant-id",
@@ -751,7 +755,7 @@ func startTaskRunForTest(t *testing.T, s *Server, clawID, keyPrefix string) (str
 		Source:           taskRunSourceFactory,
 		IssueID:          "ISSUE-" + keyPrefix,
 		AnalyticsEnabled: true,
-		RequiresPR:       true,
+		RequiresPR:       requiresPR,
 		EventKey:         keyPrefix + ":task-start",
 		Tags:             []string{"test:" + keyPrefix},
 	})


### PR DESCRIPTION
Closes [AIEDEV-13](https://linear.app/nimble-la/issue/AIEDEV-13).

## Problem

`reconcileDeadClawPRs` — the only recovery path for PR merge/close timestamps when the backing claw is dead — required `trs.status = 'running'`. Once a run materialized into a terminal status it was excluded permanently, so a merge landing afterwards was never recorded and `merged_at` stayed zero forever.

## Which runs actually hit this

Narrower than the ticket assumed. `computeTaskRunStatus` evaluates in this order:

1. `analytics_enabled == 0` → failed/terminal
2. `requires_pr == 0 && taskCompletedAt != 0` → success/terminal
3. `counts.open > 0` → **running**/waiting_for_merge

So a run with an open `task_run_prs` row can only be terminal when `analytics_enabled = 0` (already excluded by the reconciler's own `analytics_enabled = 1` predicate) or when `requires_pr = 0` and the task completed. Only that second case leaks — those runs still record `pr_opened_at`/`merged_at` and surface whenever the dashboard filters `requiresPr=0` explicitly.

Runs with `requires_pr = 1` and an open PR are always `running`, so the default analytics scope (`requires_pr=1 AND analytics_enabled=1`) was already covered.

## Fix

Drop the `trs.status = 'running'` predicate. The 90-day `opened_at` window and `trp.state = 'open'` already bound the scan.

Late merges on terminal runs are safe: `merged_at` in `task_run_summaries` comes from `counts.latestMergedAt` and is written regardless of which status branch is taken (see `TestTaskRunMaterializationLateMergeOverridesPrePRFailure`).

## Test

`TestReconcileDeadClawPRsClosesMergedPRForTerminalNonPRRun` seeds a dead claw + a `requires_pr = 0` run that materializes terminal via `task_completed` + an open PR merged on the GitHub side, asserts the run is terminal *before* reconciling, then asserts the PR row closes and `merged_at` is populated. Verified to fail with the old predicate restored.

`startTaskRunForTest` hardcoded `RequiresPR: true`, so it was split into `startTaskRunWithRequiresPRForTest` with the old helper delegating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)