### PR TITLE
feat: define workspace/workflow v2 contract (RFC #544)

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -1,0 +1,189 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types/convert"
+	"github.com/spf13/cobra"
+)
+
+// shared convert flags bound by workspace/workflow convert commands
+type convertFlags struct {
+	to         string
+	from       string
+	output     string
+	inPlace    bool
+	workspace  string // workflow convert only: path to workspace config for pair validation
+	noValidate bool
+}
+
+func newConvertFlags() *convertFlags {
+	return &convertFlags{to: "2"}
+}
+
+func bindConvertFlags(cmd *cobra.Command, f *convertFlags, includeWorkspace bool) {
+	cmd.Flags().StringVar(&f.to, "to", "2", "target schema version (e.g. 2; future: 3)")
+	cmd.Flags().StringVar(&f.from, "from", "", "source schema version (default: auto-detect from document)")
+	cmd.Flags().StringVarP(&f.output, "output", "o", "", "write converted YAML to this file (default: stdout)")
+	cmd.Flags().BoolVar(&f.inPlace, "in-place", false, "overwrite the input file (or elasticclaw-config.yaml for a workspace directory)")
+	cmd.Flags().BoolVar(&f.noValidate, "no-validate", false, "skip post-conversion schema validation")
+	if includeWorkspace {
+		cmd.Flags().StringVar(&f.workspace, "workspace", "", "path to a workspace v2 YAML or directory (pair-validate workflow refs)")
+	}
+}
+
+func workspaceConvertCmd() *cobra.Command {
+	f := newConvertFlags()
+	cmd := &cobra.Command{
+		Use:   "convert <path>",
+		Short: "Convert a workspace document between schema versions",
+		Long: `Convert a workspace YAML document to another schema version.
+
+PATH may be a workspace directory (uses elasticclaw-config.yaml) or a YAML file.
+
+By default converts to schema version 2. Output is written to stdout unless
+--output or --in-place is set. Conversion is intentionally lossy where v1
+concepts have no safe v2 equivalent; warnings are printed to stderr.
+
+Examples:
+  elasticclaw workspace convert .elasticclaw/workspaces/my-ws
+  elasticclaw workspace convert ./elasticclaw-config.yaml --to 2 -o v2.yaml
+  elasticclaw workspace convert ./ws --in-place
+`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runConvert(convert.KindWorkspace, args[0], f)
+		},
+	}
+	bindConvertFlags(cmd, f, false)
+	return cmd
+}
+
+func workflowConvertCmd() *cobra.Command {
+	f := newConvertFlags()
+	cmd := &cobra.Command{
+		Use:   "convert <path>",
+		Short: "Convert a workflow document between schema versions",
+		Long: `Convert a workflow YAML document to another schema version.
+
+PATH is a workflow YAML file (or a directory of *.yaml workflows — each file
+is converted independently when --in-place is set; otherwise a single file is required).
+
+By default converts to schema version 2. Subjective v1 controls such as
+message_contains, [DONE], and [READY_TO_COMMIT] are never rewritten as trusted
+v2 evidence; they are reported as warnings for manual migration.
+
+Examples:
+  elasticclaw workflow convert examples/workflows/github-issue.yaml
+  elasticclaw workflow convert ./wf.yaml --to 2 --workspace ./ws -o wf.v2.yaml
+  elasticclaw workflow convert ./github-issue.yaml --in-place
+`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runConvert(convert.KindWorkflow, args[0], f)
+		},
+	}
+	bindConvertFlags(cmd, f, true)
+	return cmd
+}
+
+func runConvert(kind convert.Kind, path string, f *convertFlags) error {
+	if f.inPlace && f.output != "" {
+		return fmt.Errorf("use only one of --in-place or --output")
+	}
+
+	inputPath, data, err := readConvertInput(kind, path)
+	if err != nil {
+		return err
+	}
+
+	opts := convert.Options{
+		From: f.from,
+		To:   f.to,
+	}
+	if f.noValidate {
+		v := false
+		opts.Validate = &v
+	}
+	if kind == convert.KindWorkflow && strings.TrimSpace(f.workspace) != "" {
+		wsPath, wsData, err := readConvertInput(convert.KindWorkspace, f.workspace)
+		if err != nil {
+			return fmt.Errorf("--workspace: %w", err)
+		}
+		_ = wsPath
+		opts.WorkspaceYAML = wsData
+	}
+
+	result, err := convert.Convert(kind, data, opts)
+	if err != nil {
+		return err
+	}
+
+	for _, w := range result.Warnings {
+		fmt.Fprintf(os.Stderr, "warning: %s\n", w)
+	}
+	if !quiet {
+		fmt.Fprintf(os.Stderr, "converted %s %s → %s (%d warning(s))\n",
+			kind, result.From, result.To, len(result.Warnings))
+	}
+
+	switch {
+	case f.inPlace:
+		if err := os.WriteFile(inputPath, result.Output, 0644); err != nil {
+			return fmt.Errorf("write %s: %w", inputPath, err)
+		}
+		if !quiet {
+			fmt.Fprintf(os.Stderr, "wrote %s\n", inputPath)
+		}
+	case f.output != "":
+		if dir := filepath.Dir(f.output); dir != "" && dir != "." {
+			if err := os.MkdirAll(dir, 0755); err != nil {
+				return fmt.Errorf("mkdir for %s: %w", f.output, err)
+			}
+		}
+		if err := os.WriteFile(f.output, result.Output, 0644); err != nil {
+			return fmt.Errorf("write %s: %w", f.output, err)
+		}
+		if !quiet {
+			fmt.Fprintf(os.Stderr, "wrote %s\n", f.output)
+		}
+	default:
+		if _, err := os.Stdout.Write(result.Output); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// readConvertInput resolves a path to the YAML file bytes to convert.
+// For workspaces, a directory resolves to elasticclaw-config.yaml (or workspace.yaml).
+func readConvertInput(kind convert.Kind, path string) (filePath string, data []byte, err error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", nil, err
+	}
+	if info.IsDir() {
+		if kind != convert.KindWorkspace {
+			return "", nil, fmt.Errorf("%s convert expects a YAML file, got directory %q", kind, path)
+		}
+		for _, name := range []string{"elasticclaw-config.yaml", "workspace.yaml"} {
+			candidate := filepath.Join(path, name)
+			if st, err := os.Stat(candidate); err == nil && !st.IsDir() {
+				data, err := os.ReadFile(candidate)
+				if err != nil {
+					return "", nil, err
+				}
+				return candidate, data, nil
+			}
+		}
+		return "", nil, fmt.Errorf("no elasticclaw-config.yaml (or workspace.yaml) in %s", path)
+	}
+	data, err = os.ReadFile(path)
+	if err != nil {
+		return "", nil, err
+	}
+	return path, data, nil
+}

--- a/cmd/convert_test.go
+++ b/cmd/convert_test.go
@@ -1,0 +1,98 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types/convert"
+	v2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
+)
+
+func TestRunConvertWorkspaceInPlace(t *testing.T) {
+	dir := t.TempDir()
+	wsDir := filepath.Join(dir, "my-ws")
+	if err := os.MkdirAll(wsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	v1 := []byte(`schema_version: v1
+name: my-ws
+provider: daytona
+repositories:
+  - repo: org/repo
+    permissions: write
+`)
+	cfgPath := filepath.Join(wsDir, "elasticclaw-config.yaml")
+	if err := os.WriteFile(cfgPath, v1, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	f := newConvertFlags()
+	f.to = "2"
+	f.inPlace = true
+	if err := runConvert(convert.KindWorkspace, wsDir, f); err != nil {
+		t.Fatalf("runConvert: %v", err)
+	}
+
+	out, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(out), "schema_version: 2") {
+		t.Fatalf("expected v2 output, got:\n%s", out)
+	}
+	if _, err := v2.ParseAndValidateWorkspace(out); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+}
+
+func TestRunConvertWorkflowToOutput(t *testing.T) {
+	dir := t.TempDir()
+	in := filepath.Join(dir, "wf.yaml")
+	out := filepath.Join(dir, "wf.v2.yaml")
+	v1 := []byte(`schema_version: v1
+name: demo
+stages:
+  - id: start
+    entry: true
+  - id: done
+    terminal: true
+    triggers:
+      - pr_merged: {}
+`)
+	if err := os.WriteFile(in, v1, 0644); err != nil {
+		t.Fatal(err)
+	}
+	f := newConvertFlags()
+	f.to = "2"
+	f.output = out
+	if err := runConvert(convert.KindWorkflow, in, f); err != nil {
+		t.Fatalf("runConvert: %v", err)
+	}
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := v2.ParseAndValidateWorkflow(data); err != nil {
+		t.Fatalf("validate: %v\n%s", err, data)
+	}
+}
+
+func TestReadConvertInputWorkspaceDir(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "elasticclaw-config.yaml")
+	if err := os.WriteFile(path, []byte("schema_version: v1\nname: x\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	gotPath, data, err := readConvertInput(convert.KindWorkspace, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotPath != path {
+		t.Fatalf("path = %q, want %q", gotPath, path)
+	}
+	if !strings.Contains(string(data), "name: x") {
+		t.Fatalf("data = %s", data)
+	}
+}

--- a/cmd/workflow.go
+++ b/cmd/workflow.go
@@ -28,6 +28,7 @@ func WorkflowCmd() *cobra.Command {
 	cmd.AddCommand(workflowTriggerCmd())
 	cmd.AddCommand(workflowRunsCmd())
 	cmd.AddCommand(workflowLogsCmd())
+	cmd.AddCommand(workflowConvertCmd())
 	return cmd
 }
 

--- a/cmd/workflow.go
+++ b/cmd/workflow.go
@@ -13,6 +13,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/elasticclaw/elasticclaw/pkg/types"
+	v2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
@@ -194,6 +195,9 @@ func runWorkflowPush(workspace string, paths []string) error {
 		return fmt.Errorf("no workflow YAML files found")
 	}
 	for _, workflow := range workflows {
+		if v2.IsV2(workflow.SchemaVersion) {
+			continue // strict v2 validation happened while reading the authored document
+		}
 		if err := workflow.Validate(); err != nil {
 			return fmt.Errorf("validation failed for workflow %q: %w", workflow.Name, err)
 		}
@@ -258,6 +262,25 @@ func readWorkflowFiles(paths []string) ([]*types.WorkflowConfig, error) {
 		if err != nil {
 			return nil, fmt.Errorf("read %s: %w", path, err)
 		}
+		version, err := v2.DetectSchemaVersion(data)
+		if err != nil {
+			return nil, fmt.Errorf("parse %s: %w", path, err)
+		}
+		if v2.IsV2(version) {
+			resolved, err := v2.ParseAndValidateWorkflow(data)
+			if err != nil {
+				return nil, fmt.Errorf("validate %s: %w", path, err)
+			}
+			enabled := resolved.Workflow.Enabled
+			workflows = append(workflows, &types.WorkflowConfig{
+				SchemaVersion: "2",
+				Name:          resolved.Workflow.Name,
+				Enabled:       &enabled,
+				RawConfig:     string(data),
+			})
+			continue
+		}
+
 		var workflow types.WorkflowConfig
 		if err := yaml.Unmarshal(data, &workflow); err != nil {
 			return nil, fmt.Errorf("parse %s: %w", path, err)

--- a/cmd/workflow_test.go
+++ b/cmd/workflow_test.go
@@ -13,6 +13,42 @@ import (
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
 
+func TestReadWorkflowFilesPreservesV2Document(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "delivery.yaml")
+	raw := `schema_version: 2
+name: delivery
+enabled: false
+initial_state: planning
+states:
+  planning:
+    phase: plan
+  done:
+    phase: done
+    terminal: true
+`
+	if err := os.WriteFile(path, []byte(raw), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	workflows, err := readWorkflowFiles([]string{path})
+	if err != nil {
+		t.Fatalf("read v2 workflow: %v", err)
+	}
+	if len(workflows) != 1 {
+		t.Fatalf("workflow count = %d, want 1", len(workflows))
+	}
+	wf := workflows[0]
+	if wf.SchemaVersion != "2" || wf.Name != "delivery" || wf.Enabled == nil || *wf.Enabled {
+		t.Fatalf("v2 projection = %#v", wf)
+	}
+	if wf.RawConfig != raw {
+		t.Fatalf("authored v2 YAML was not preserved:\n%s", wf.RawConfig)
+	}
+	if len(wf.Stages) != 0 || wf.PipelineYAML != "" {
+		t.Fatalf("v2 workflow entered v1 normalization: %#v", wf)
+	}
+}
+
 func TestSanitizeWorkflowResultForTable(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/cmd/workspace.go
+++ b/cmd/workspace.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/elasticclaw/elasticclaw/pkg/config"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
+	v2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
@@ -61,9 +62,16 @@ func workspaceCreateCmd() *cobra.Command {
 	return cmd
 }
 
+// localWorkspaceDirs are candidate repo-local roots for workspace definitions.
+// factory-workspaces is preferred; .elasticclaw/workspaces remains supported.
+var localWorkspaceDirs = []string{
+	"factory-workspaces",
+	filepath.Join(".elasticclaw", "workspaces"),
+}
+
 func runWorkspaceCreate(name string) error {
 	name = strings.ToLower(strings.ReplaceAll(name, " ", "-"))
-	dir := filepath.Join(".elasticclaw", "workspaces", name)
+	dir := filepath.Join(localWorkspaceDirs[0], name)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("create workspace directory: %w", err)
 	}
@@ -170,9 +178,10 @@ func workspacePushCmd() *cobra.Command {
 		Short: "Push workspace definitions to the hub",
 		Long: `Push workspace definitions to the hub.
 
-By default, searches .elasticclaw/workspaces/ and pushes all valid workspaces.
+By default, searches factory-workspaces/ (preferred) and .elasticclaw/workspaces/
+and pushes all valid workspaces.
 Pass a name to push only the matching workspace.
-Use --path to push a workspace from a specific directory instead of the default location.`,
+Use --path to push a workspace from a specific directory instead of the default locations.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := ""
 			if len(args) > 0 {
@@ -181,7 +190,7 @@ Use --path to push a workspace from a specific directory instead of the default 
 			return runWorkspacePush(name, path)
 		},
 	}
-	cmd.Flags().StringVar(&path, "path", "", "path to a specific workspace directory to push (instead of .elasticclaw/workspaces/)")
+	cmd.Flags().StringVar(&path, "path", "", "path to a specific workspace directory to push (instead of factory-workspaces/)")
 	return cmd
 }
 
@@ -229,8 +238,8 @@ func runWorkspacePush(filterName string, path string) error {
 
 // collectWorkspacesForPush resolves the workspace directories to push.
 // If path is set, it pushes only that directory. Otherwise it scans
-// .elasticclaw/workspaces/*. The filterName optionally restricts results
-// to a single workspace name.
+// factory-workspaces/* then .elasticclaw/workspaces/*. The filterName
+// optionally restricts results to a single workspace name.
 func collectWorkspacesForPush(filterName string, path string) ([]*types.WorkspaceConfig, error) {
 	var workspaces []*types.WorkspaceConfig
 
@@ -255,12 +264,20 @@ func collectWorkspacesForPush(filterName string, path string) ([]*types.Workspac
 		return []*types.WorkspaceConfig{workspace}, nil
 	}
 
-	pattern := filepath.Join(".elasticclaw", "workspaces", "*")
-	matches, err := filepath.Glob(pattern)
-	if err != nil || len(matches) == 0 {
-		return nil, fmt.Errorf("no workspaces found under .elasticclaw/workspaces/")
+	var matches []string
+	for _, root := range localWorkspaceDirs {
+		pattern := filepath.Join(root, "*")
+		found, err := filepath.Glob(pattern)
+		if err != nil {
+			continue
+		}
+		matches = append(matches, found...)
+	}
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("no workspaces found under factory-workspaces/ or .elasticclaw/workspaces/")
 	}
 
+	seen := map[string]struct{}{}
 	for _, match := range matches {
 		if info, err := os.Stat(match); err != nil || !info.IsDir() {
 			continue
@@ -272,9 +289,15 @@ func collectWorkspacesForPush(filterName string, path string) ([]*types.Workspac
 		if filterName != "" && !strings.EqualFold(workspace.Name, filterName) {
 			continue
 		}
+		// Prefer earlier roots (factory-workspaces) when the same name appears twice.
+		key := strings.ToLower(workspace.Name)
+		if _, dup := seen[key]; dup {
+			continue
+		}
 		if err := workspace.Validate(); err != nil {
 			return nil, fmt.Errorf("validation failed for %s: %w", match, err)
 		}
+		seen[key] = struct{}{}
 		workspaces = append(workspaces, workspace)
 	}
 	return workspaces, nil
@@ -326,6 +349,42 @@ func readWorkspaceDir(dir string) (*types.WorkspaceConfig, error) {
 		}
 		configPath = legacyPath
 	}
+
+	files, err := config.ReadTemplateFiles(dir)
+	if err != nil {
+		files = map[string]string{}
+	}
+	if files == nil {
+		files = map[string]string{}
+	}
+	// Always push the authored config bytes under the canonical name so the hub
+	// store path can validate v1/v2 without re-deriving from typed fields.
+	files["elasticclaw-config.yaml"] = string(data)
+
+	version, err := v2.DetectSchemaVersion(data)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s: %w", configPath, err)
+	}
+
+	// V2 documents use map-shaped repositories/connections that cannot unmarshal
+	// into the v1 WorkspaceConfig type. Carry the raw YAML in Files and validate
+	// with the v2 schema; the hub save path validates and stores that YAML.
+	if v2.IsV2(version) {
+		resolved, err := v2.ParseAndValidateWorkspace(data)
+		if err != nil {
+			return nil, fmt.Errorf("validate workspace v2 %s: %w", configPath, err)
+		}
+		name := resolved.Workspace.Name
+		if name == "" {
+			name = filepath.Base(dir)
+		}
+		return &types.WorkspaceConfig{
+			SchemaVersion: "2",
+			Name:          name,
+			Files:         files,
+		}, nil
+	}
+
 	var workspace types.WorkspaceConfig
 	if err := yaml.Unmarshal(data, &workspace); err != nil {
 		return nil, fmt.Errorf("parse %s: %w", configPath, err)
@@ -333,9 +392,7 @@ func readWorkspaceDir(dir string) (*types.WorkspaceConfig, error) {
 	if workspace.Name == "" {
 		workspace.Name = filepath.Base(dir)
 	}
-	if files, err := config.ReadTemplateFiles(dir); err == nil {
-		workspace.Files = files
-	}
+	workspace.Files = files
 	return &workspace, nil
 }
 

--- a/cmd/workspace.go
+++ b/cmd/workspace.go
@@ -27,6 +27,7 @@ func WorkspaceCmd() *cobra.Command {
 	cmd.AddCommand(workspaceListCmd())
 	cmd.AddCommand(workspaceShowCmd())
 	cmd.AddCommand(workspaceRmCmd())
+	cmd.AddCommand(workspaceConvertCmd())
 	return cmd
 }
 

--- a/cmd/workspace_test.go
+++ b/cmd/workspace_test.go
@@ -3,13 +3,14 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
 func TestCollectWorkspacesForPush_DefaultPath(t *testing.T) {
-	// Create a temporary repo structure with .elasticclaw/workspaces/<name>/
+	// Create a temporary repo structure with factory-workspaces/<name>/
 	root := t.TempDir()
-	workspacesDir := filepath.Join(root, ".elasticclaw", "workspaces")
+	workspacesDir := filepath.Join(root, "factory-workspaces")
 	if err := os.MkdirAll(workspacesDir, 0755); err != nil {
 		t.Fatalf("mkdir workspaces: %v", err)
 	}
@@ -34,9 +35,59 @@ func TestCollectWorkspacesForPush_DefaultPath(t *testing.T) {
 	}
 }
 
-func TestCollectWorkspacesForPush_DefaultPathWithFilter(t *testing.T) {
+func TestCollectWorkspacesForPush_LegacyPath(t *testing.T) {
+	// .elasticclaw/workspaces remains supported when factory-workspaces is absent.
 	root := t.TempDir()
 	workspacesDir := filepath.Join(root, ".elasticclaw", "workspaces")
+	if err := os.MkdirAll(workspacesDir, 0755); err != nil {
+		t.Fatalf("mkdir workspaces: %v", err)
+	}
+	writeMinimalWorkspace(t, filepath.Join(workspacesDir, "legacy-ws"), "legacy-ws")
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer os.Chdir(origDir)
+
+	workspaces, err := collectWorkspacesForPush("", "")
+	if err != nil {
+		t.Fatalf("collect workspaces: %v", err)
+	}
+	if len(workspaces) != 1 || workspaces[0].Name != "legacy-ws" {
+		t.Fatalf("want 1 workspace named legacy-ws, got %+v", workspaces)
+	}
+}
+
+func TestCollectWorkspacesForPush_PrefersFactoryWorkspaces(t *testing.T) {
+	root := t.TempDir()
+	writeMinimalWorkspace(t, filepath.Join(root, "factory-workspaces", "shared"), "shared")
+	writeMinimalWorkspace(t, filepath.Join(root, ".elasticclaw", "workspaces", "shared"), "shared")
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer os.Chdir(origDir)
+
+	workspaces, err := collectWorkspacesForPush("", "")
+	if err != nil {
+		t.Fatalf("collect workspaces: %v", err)
+	}
+	if len(workspaces) != 1 || workspaces[0].Name != "shared" {
+		t.Fatalf("want single preferred workspace shared, got %+v", workspaces)
+	}
+}
+
+func TestCollectWorkspacesForPush_DefaultPathWithFilter(t *testing.T) {
+	root := t.TempDir()
+	workspacesDir := filepath.Join(root, "factory-workspaces")
 	if err := os.MkdirAll(workspacesDir, 0755); err != nil {
 		t.Fatalf("mkdir workspaces: %v", err)
 	}
@@ -113,5 +164,89 @@ func writeMinimalWorkspace(t *testing.T, dir, name string) {
 	config := "schema_version: v1\nname: " + name + "\nprovider: replicated\n"
 	if err := os.WriteFile(filepath.Join(dir, "elasticclaw-config.yaml"), []byte(config), 0644); err != nil {
 		t.Fatalf("write config: %v", err)
+	}
+}
+
+func TestReadWorkspaceDirV2MapRepositories(t *testing.T) {
+	dir := t.TempDir()
+	// Shape matches amazecrm-dev: named map repositories (not v1 list).
+	config := `
+schema_version: 2
+name: amazecrm-dev
+
+repositories:
+  primary:
+    provider: github
+    repository: amazecrm/amazecrm
+    source_control: github-default
+
+credentials:
+  github_app:
+    secret: github_app
+
+source_control:
+  connections:
+    github-default:
+      provider: github
+      credentials: github_app
+`
+	if err := os.WriteFile(filepath.Join(dir, "elasticclaw-config.yaml"), []byte(config), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte("# agents\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ws, err := readWorkspaceDir(dir)
+	if err != nil {
+		t.Fatalf("readWorkspaceDir: %v", err)
+	}
+	if ws.Name != "amazecrm-dev" {
+		t.Fatalf("name = %q", ws.Name)
+	}
+	if ws.SchemaVersion != "2" {
+		t.Fatalf("schema = %q", ws.SchemaVersion)
+	}
+	raw := ws.Files["elasticclaw-config.yaml"]
+	if !strings.Contains(raw, "schema_version: 2") || !strings.Contains(raw, "primary:") {
+		t.Fatalf("Files missing authored v2 YAML:\n%s", raw)
+	}
+	if ws.Files["AGENTS.md"] == "" {
+		t.Fatal("expected AGENTS.md in Files")
+	}
+	if err := ws.Validate(); err != nil {
+		t.Fatalf("shell Validate: %v", err)
+	}
+
+	// collectWorkspacesForPush must accept --path to a v2 workspace dir.
+	got, err := collectWorkspacesForPush("", dir)
+	if err != nil {
+		t.Fatalf("collectWorkspacesForPush: %v", err)
+	}
+	if len(got) != 1 || got[0].Name != "amazecrm-dev" {
+		t.Fatalf("got %#v", got)
+	}
+}
+
+func TestReadWorkspaceDirV2InvalidRejected(t *testing.T) {
+	dir := t.TempDir()
+	config := `
+schema_version: 2
+name: broken
+ci:
+  connections:
+    c1:
+      provider: github_actions
+      credentials: missing
+`
+	if err := os.WriteFile(filepath.Join(dir, "elasticclaw-config.yaml"), []byte(config), 0644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := readWorkspaceDir(dir)
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if !strings.Contains(err.Error(), "unknown credential") && !strings.Contains(err.Error(), "validate workspace v2") {
+		t.Fatalf("error = %v", err)
 	}
 }

--- a/pkg/hub/external_storage.go
+++ b/pkg/hub/external_storage.go
@@ -448,15 +448,6 @@ func saveExternalWorkspace(workspace *types.WorkspaceConfig) error {
 		return err
 	}
 
-	dir := filepath.Join(workspacesDir(), workspace.Name)
-	workflowDir := filepath.Join(dir, "workflows")
-	if err := os.MkdirAll(workflowDir, 0750); err != nil {
-		return fmt.Errorf("mkdir %s: %w", workflowDir, err)
-	}
-	if err := removeWorkspaceAuthoredFiles(dir); err != nil {
-		return err
-	}
-
 	data := []byte(workspace.Files["elasticclaw-config.yaml"])
 	if len(strings.TrimSpace(string(data))) == 0 {
 		var err error
@@ -464,6 +455,21 @@ func saveExternalWorkspace(workspace *types.WorkspaceConfig) error {
 		if err != nil {
 			return fmt.Errorf("marshal elasticclaw-config.yaml: %w", err)
 		}
+	}
+	// Refuse invalid v2 workspace documents at the store boundary (RFC #544 inv. 28).
+	// V1 documents continue through the existing WorkspaceConfig.Validate path above.
+	// Validate before mutating the on-disk tree so a rejection cannot wipe existing files.
+	if err := validateWorkspaceDocumentAtStore(data); err != nil {
+		return err
+	}
+
+	dir := filepath.Join(workspacesDir(), workspace.Name)
+	workflowDir := filepath.Join(dir, "workflows")
+	if err := os.MkdirAll(workflowDir, 0750); err != nil {
+		return fmt.Errorf("mkdir %s: %w", workflowDir, err)
+	}
+	if err := removeWorkspaceAuthoredFiles(dir); err != nil {
+		return err
 	}
 	if err := os.WriteFile(filepath.Join(dir, "elasticclaw-config.yaml"), data, 0640); err != nil {
 		return fmt.Errorf("write elasticclaw-config.yaml: %w", err)
@@ -504,12 +510,20 @@ func saveExternalWorkflows(workspaceName string, workflows []*types.WorkflowConf
 	if err := validateName(workspaceName); err != nil {
 		return err
 	}
-	if _, err := loadExternalWorkspaceConfig(workspaceName); err != nil {
-		// Preserve workspace-not-found for HTTP 404 mapping; wrap other load failures.
-		if isWorkspaceNotFound(err) {
-			return err
+	// Prefer raw YAML for store-time validation. V2 workspace documents use map-shaped
+	// repositories/connections that cannot be unmarshaled into the v1 WorkspaceConfig type.
+	workspaceYAML, err := readExternalWorkspaceYAML(workspaceName)
+	if err != nil {
+		// Fall back to the legacy typed load only to preserve the established
+		// workspace-not-found error and HTTP 404 mapping. Other load failures keep
+		// their existing context rather than being reported as v2 validation errors.
+		if _, loadErr := loadExternalWorkspaceConfig(workspaceName); loadErr != nil {
+			if isWorkspaceNotFound(loadErr) {
+				return loadErr
+			}
+			return fmt.Errorf("load workspace %q: %w", workspaceName, loadErr)
 		}
-		return fmt.Errorf("load workspace %q: %w", workspaceName, err)
+		return err
 	}
 	workflowDir := filepath.Join(workspacesDir(), workspaceName, "workflows")
 	if err := os.MkdirAll(workflowDir, 0750); err != nil {
@@ -533,6 +547,11 @@ func saveExternalWorkflows(workspaceName string, workflows []*types.WorkflowConf
 			if err != nil {
 				return fmt.Errorf("marshal workflow %q: %w", workflow.Name, err)
 			}
+		}
+		// Refuse invalid v2 workflow documents (and invalid v2 workspace pairs).
+		// V1 workflows keep the Normalize+Validate path at the API boundary.
+		if err := validateWorkflowDocumentAtStore(data, workspaceYAML); err != nil {
+			return fmt.Errorf("workflow %q: %w", workflow.Name, err)
 		}
 		if err := os.WriteFile(targetPath, data, 0640); err != nil {
 			return fmt.Errorf("write workflow %q: %w", workflow.Name, err)

--- a/pkg/hub/external_storage.go
+++ b/pkg/hub/external_storage.go
@@ -373,8 +373,10 @@ func loadExternalWorkflowDocument(fileName string, data []byte) (*types.Workflow
 	if v2.IsV2(version) {
 		// Prefer name from validated v2 doc; do not force v1 stage/trigger normalize.
 		name := strings.TrimSuffix(fileName, ".yaml")
+		enabled := false // missing/invalid v2 documents are always fail-closed
 		if resolved, err := v2.ParseAndValidateWorkflow(data); err == nil && resolved.Workflow.Name != "" {
 			name = resolved.Workflow.Name
+			enabled = resolved.Workflow.Enabled
 		} else {
 			var probe struct {
 				Name string `yaml:"name"`
@@ -390,6 +392,7 @@ func loadExternalWorkflowDocument(fileName string, data []byte) (*types.Workflow
 		return &types.WorkflowConfig{
 			SchemaVersion: "2",
 			Name:          name,
+			Enabled:       &enabled,
 			RawConfig:     string(data),
 		}, nil
 	}

--- a/pkg/hub/external_storage.go
+++ b/pkg/hub/external_storage.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/elasticclaw/elasticclaw/pkg/config"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
+	v2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
 	"gopkg.in/yaml.v3"
 )
 
@@ -326,18 +327,20 @@ func loadExternalWorkspace(name string) (*types.WorkspaceConfig, error) {
 		if err != nil {
 			return nil, fmt.Errorf("read workflow %s: %w", e.Name(), err)
 		}
-		var workflow types.WorkflowConfig
-		if err := yaml.Unmarshal(data, &workflow); err != nil {
-			return nil, fmt.Errorf("parse workflow %s: %w", e.Name(), err)
+		workflow, err := loadExternalWorkflowDocument(e.Name(), data)
+		if err != nil {
+			return nil, err
 		}
-		workflow.RawConfig = string(data)
-		if workflow.Name == "" {
-			workflow.Name = strings.TrimSuffix(e.Name(), ".yaml")
+		workspace.Workflows = append(workspace.Workflows, workflow)
+	}
+	// Ensure raw config is present for settings UI even if ReadTemplateFiles missed it.
+	if workspace.Files == nil {
+		workspace.Files = map[string]string{}
+	}
+	if _, ok := workspace.Files["elasticclaw-config.yaml"]; !ok {
+		if raw, err := readExternalWorkspaceYAML(name); err == nil {
+			workspace.Files["elasticclaw-config.yaml"] = string(raw)
 		}
-		if err := types.NormalizeWorkflowConfig(&workflow); err != nil {
-			return nil, fmt.Errorf("normalize workflow %s: %w", e.Name(), err)
-		}
-		workspace.Workflows = append(workspace.Workflows, &workflow)
 	}
 	return &workspace, nil
 }
@@ -358,6 +361,51 @@ func (e *errWorkspaceNotFound) Error() string {
 func isWorkspaceNotFound(err error) bool {
 	var target *errWorkspaceNotFound
 	return errors.As(err, &target)
+}
+
+// loadExternalWorkflowDocument loads a v1 or v2 workflow file for hub APIs.
+// V2 documents keep RawConfig as the source of truth and skip v1 normalize semantics.
+func loadExternalWorkflowDocument(fileName string, data []byte) (*types.WorkflowConfig, error) {
+	version, err := v2.DetectSchemaVersion(data)
+	if err != nil {
+		return nil, fmt.Errorf("parse workflow %s: %w", fileName, err)
+	}
+	if v2.IsV2(version) {
+		// Prefer name from validated v2 doc; do not force v1 stage/trigger normalize.
+		name := strings.TrimSuffix(fileName, ".yaml")
+		if resolved, err := v2.ParseAndValidateWorkflow(data); err == nil && resolved.Workflow.Name != "" {
+			name = resolved.Workflow.Name
+		} else {
+			var probe struct {
+				Name string `yaml:"name"`
+			}
+			_ = yaml.Unmarshal(data, &probe)
+			if strings.TrimSpace(probe.Name) != "" {
+				name = probe.Name
+			}
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "[hub] workflow %q v2 validation warning: %v\n", fileName, err)
+			}
+		}
+		return &types.WorkflowConfig{
+			SchemaVersion: "2",
+			Name:          name,
+			RawConfig:     string(data),
+		}, nil
+	}
+
+	var workflow types.WorkflowConfig
+	if err := yaml.Unmarshal(data, &workflow); err != nil {
+		return nil, fmt.Errorf("parse workflow %s: %w", fileName, err)
+	}
+	workflow.RawConfig = string(data)
+	if workflow.Name == "" {
+		workflow.Name = strings.TrimSuffix(fileName, ".yaml")
+	}
+	if err := types.NormalizeWorkflowConfig(&workflow); err != nil {
+		return nil, fmt.Errorf("normalize workflow %s: %w", fileName, err)
+	}
+	return &workflow, nil
 }
 
 func loadExternalWorkspaceConfig(name string) (types.WorkspaceConfig, error) {
@@ -392,11 +440,100 @@ func loadExternalWorkspaceConfig(name string) (types.WorkspaceConfig, error) {
 		}
 		configPath = legacyPath
 	}
+
+	version, err := v2.DetectSchemaVersion(data)
+	if err != nil {
+		return types.WorkspaceConfig{}, fmt.Errorf("parse %s: %w", filepath.Base(configPath), err)
+	}
+
+	// V2 configs use map-shaped repositories/connections that cannot unmarshal into
+	// the v1 WorkspaceConfig type. Load a shell config + projected access fields so
+	// list/settings APIs include the workspace instead of silently skipping it.
+	if v2.IsV2(version) {
+		return loadExternalWorkspaceConfigV2(name, data, configPath)
+	}
+
 	var workspace types.WorkspaceConfig
 	if err := yaml.Unmarshal(data, &workspace); err != nil {
 		return types.WorkspaceConfig{}, fmt.Errorf("parse workspace %q %s: %w", name, filepath.Base(configPath), err)
 	}
 	return workspace, nil
+}
+
+// loadExternalWorkspaceConfigV2 builds a WorkspaceConfig shell for hub APIs from
+// authored v2 YAML without requiring the v1 repositories list shape.
+func loadExternalWorkspaceConfigV2(name string, data []byte, configPath string) (types.WorkspaceConfig, error) {
+	var probe struct {
+		Name string `yaml:"name"`
+	}
+	if err := yaml.Unmarshal(data, &probe); err != nil {
+		return types.WorkspaceConfig{}, fmt.Errorf("parse %s: %w", filepath.Base(configPath), err)
+	}
+	ws := types.WorkspaceConfig{
+		SchemaVersion: "2",
+		Name:          strings.TrimSpace(probe.Name),
+	}
+	if ws.Name == "" {
+		ws.Name = name
+	}
+
+	resolved, err := v2.ParseAndValidateWorkspace(data)
+	if err != nil {
+		// Still return a listable shell so settings UI can surface the workspace
+		// name; full config is available via Files after ReadTemplateFiles.
+		fmt.Fprintf(os.Stderr, "[hub] workspace %q v2 validation warning: %v\n", name, err)
+		return ws, nil
+	}
+	if resolved.Workspace.Name != "" {
+		ws.Name = resolved.Workspace.Name
+	}
+	ws.Repositories = projectV2RepositoriesForAccess(resolved.Workspace)
+	ws.Secrets = projectV2CredentialSecrets(resolved.Workspace)
+	return ws, nil
+}
+
+// projectV2RepositoriesForAccess maps named v2 repositories into the legacy
+// access list used by WorkspaceView / settings UI.
+func projectV2RepositoriesForAccess(ws *v2.Workspace) types.RepositoryAccessList {
+	if ws == nil || len(ws.Repositories) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(ws.Repositories))
+	for name := range ws.Repositories {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	out := make(types.RepositoryAccessList, 0, len(names))
+	for _, name := range names {
+		repo := ws.Repositories[name]
+		out = append(out, types.GitHubRepoAccess{
+			Repo:        strings.TrimSpace(repo.Repository),
+			Permissions: "read", // v2 does not model per-repo permissions on the resource
+		})
+	}
+	return out
+}
+
+// projectV2CredentialSecrets exposes hub secret *names* referenced by v2 credentials.
+func projectV2CredentialSecrets(ws *v2.Workspace) []string {
+	if ws == nil || len(ws.Credentials) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(ws.Credentials))
+	seen := map[string]struct{}{}
+	for _, cred := range ws.Credentials {
+		secret := strings.TrimSpace(cred.Secret)
+		if secret == "" {
+			continue
+		}
+		if _, ok := seen[secret]; ok {
+			continue
+		}
+		seen[secret] = struct{}{}
+		names = append(names, secret)
+	}
+	sort.Strings(names)
+	return names
 }
 
 func loadExternalWorkflowsByIntegration(integration string) ([]*types.WorkspaceConfig, error) {

--- a/pkg/hub/external_storage.go
+++ b/pkg/hub/external_storage.go
@@ -665,20 +665,19 @@ func saveExternalWorkflows(workspaceName string, workflows []*types.WorkflowConf
 		}
 		return err
 	}
-	workflowDir := filepath.Join(workspacesDir(), workspaceName, "workflows")
-	if err := os.MkdirAll(workflowDir, 0750); err != nil {
-		return fmt.Errorf("mkdir %s: %w", workflowDir, err)
+	type workflowWrite struct {
+		workflow *types.WorkflowConfig
+		data     []byte
 	}
+	// Validate and marshal the complete batch before touching the filesystem.
+	// A client error in one document must not partially persist earlier items.
+	writes := make([]workflowWrite, 0, len(workflows))
 	for _, workflow := range workflows {
 		if workflow == nil {
 			continue
 		}
 		if err := validateName(workflow.Name); err != nil {
 			return fmt.Errorf("workflow %q: %w", workflow.Name, err)
-		}
-		targetPath := filepath.Join(workflowDir, strings.ToLower(workflow.Name)+".yaml")
-		if err := removeCaseVariantWorkflowFiles(workflowDir, workflow.Name, targetPath); err != nil {
-			return err
 		}
 		data := []byte(workflow.RawConfig)
 		if len(strings.TrimSpace(string(data))) == 0 {
@@ -693,7 +692,20 @@ func saveExternalWorkflows(workspaceName string, workflows []*types.WorkflowConf
 		if err := validateWorkflowDocumentAtStore(data, workspaceYAML); err != nil {
 			return fmt.Errorf("workflow %q: %w", workflow.Name, err)
 		}
-		if err := os.WriteFile(targetPath, data, 0640); err != nil {
+		writes = append(writes, workflowWrite{workflow: workflow, data: data})
+	}
+
+	workflowDir := filepath.Join(workspacesDir(), workspaceName, "workflows")
+	if err := os.MkdirAll(workflowDir, 0750); err != nil {
+		return fmt.Errorf("mkdir %s: %w", workflowDir, err)
+	}
+	for _, write := range writes {
+		workflow := write.workflow
+		targetPath := filepath.Join(workflowDir, strings.ToLower(workflow.Name)+".yaml")
+		if err := removeCaseVariantWorkflowFiles(workflowDir, workflow.Name, targetPath); err != nil {
+			return err
+		}
+		if err := os.WriteFile(targetPath, write.data, 0640); err != nil {
 			return fmt.Errorf("write workflow %q: %w", workflow.Name, err)
 		}
 	}

--- a/pkg/hub/schema_v2_validate.go
+++ b/pkg/hub/schema_v2_validate.go
@@ -1,0 +1,76 @@
+package hub
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	v2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
+)
+
+// validateWorkspaceDocumentAtStore rejects invalid workspace v2 YAML at the
+// persistence boundary. Non-v2 documents are left to WorkspaceConfig.Validate.
+func validateWorkspaceDocumentAtStore(data []byte) error {
+	version, err := v2.DetectSchemaVersion(data)
+	if err != nil {
+		return fmt.Errorf("workspace schema: %w", err)
+	}
+	if !v2.IsV2(version) {
+		return nil
+	}
+	if _, err := v2.ParseAndValidateWorkspace(data); err != nil {
+		return fmt.Errorf("invalid workspace v2: %w", err)
+	}
+	return nil
+}
+
+// validateWorkflowDocumentAtStore rejects invalid workflow v2 YAML (and invalid
+// v2 workspace pairs) at the persistence boundary. Non-v2 documents are left to
+// the existing NormalizeWorkflowConfig + WorkflowConfig.Validate path.
+func validateWorkflowDocumentAtStore(workflowData, workspaceYAML []byte) error {
+	version, err := v2.DetectSchemaVersion(workflowData)
+	if err != nil {
+		return fmt.Errorf("workflow schema: %w", err)
+	}
+	if !v2.IsV2(version) {
+		return nil
+	}
+
+	// Prefer authored workspace YAML when it is v2 for full pair validation.
+	if len(strings.TrimSpace(string(workspaceYAML))) > 0 && workspaceYAMLIsV2(workspaceYAML) {
+		if _, _, err := v2.ParseAndValidateWorkflowPair(workflowData, workspaceYAML); err != nil {
+			return fmt.Errorf("invalid workflow v2 pair: %w", err)
+		}
+		return nil
+	}
+
+	// Workflow is v2 but workspace is not v2: require structural workflow validity,
+	// then refuse the incomplete pair (v2 workflow requires v2 workspace).
+	if _, err := v2.ParseAndValidateWorkflow(workflowData); err != nil {
+		return fmt.Errorf("invalid workflow v2: %w", err)
+	}
+	return fmt.Errorf("invalid workflow v2 pair: workflow schema v2 requires a workspace schema v2")
+}
+
+func workspaceYAMLIsV2(data []byte) bool {
+	version, err := v2.DetectSchemaVersion(data)
+	return err == nil && v2.IsV2(version)
+}
+
+// readExternalWorkspaceYAML returns the authored elasticclaw-config.yaml bytes.
+func readExternalWorkspaceYAML(name string) ([]byte, error) {
+	if err := validateName(name); err != nil {
+		return nil, err
+	}
+	path := filepath.Join(workspacesDir(), name, "elasticclaw-config.yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		legacy := filepath.Join(workspacesDir(), name, "workspace.yaml")
+		data, err = os.ReadFile(legacy)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return data, nil
+}

--- a/pkg/hub/schema_v2_validate_test.go
+++ b/pkg/hub/schema_v2_validate_test.go
@@ -176,6 +176,79 @@ func TestSaveExternalWorkflowsAcceptsValidV2Pair(t *testing.T) {
 	}
 }
 
+func TestLoadExternalWorkspacesIncludesV2(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+
+	const yamlDoc = `
+schema_version: 2
+name: amazecrm-dev
+repositories:
+  primary:
+    provider: github
+    repository: amazecrm/amazecrm
+    source_control: sc
+credentials:
+  github_app:
+    secret: github_app
+source_control:
+  connections:
+    sc:
+      provider: github
+      credentials: github_app
+`
+	if err := saveExternalWorkspace(&types.WorkspaceConfig{
+		Name:  "amazecrm-dev",
+		Files: map[string]string{"elasticclaw-config.yaml": yamlDoc, "AGENTS.md": "# a\n"},
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// The bug: load used to fail with "repositories: expected a list" and skip the dir.
+	list, err := loadExternalWorkspaces()
+	if err != nil {
+		t.Fatalf("loadExternalWorkspaces: %v", err)
+	}
+	var found *types.WorkspaceConfig
+	for _, ws := range list {
+		if ws != nil && ws.Name == "amazecrm-dev" {
+			found = ws
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("v2 workspace not listed; got %d workspaces", len(list))
+	}
+	if found.SchemaVersion != "2" {
+		t.Fatalf("schema = %q", found.SchemaVersion)
+	}
+	if found.Files["elasticclaw-config.yaml"] == "" {
+		t.Fatal("expected raw config in Files for settings UI")
+	}
+	if len(found.Repositories) != 1 || found.Repositories[0].Repo != "amazecrm/amazecrm" {
+		t.Fatalf("projected repos = %#v", found.Repositories)
+	}
+
+	// workspaceViews (settings API source) must include it with config text.
+	// Use a minimal Server method via package-level helper path.
+	views := (&Server{}).workspaceViews()
+	var view *WorkspaceView
+	for i := range views {
+		if views[i].Name == "amazecrm-dev" {
+			view = &views[i]
+			break
+		}
+	}
+	if view == nil {
+		t.Fatal("workspaceViews missing amazecrm-dev")
+	}
+	if !strings.Contains(view.Config, "schema_version: 2") {
+		t.Fatalf("view.Config missing v2 yaml:\n%s", view.Config)
+	}
+	if len(view.Access.Repositories) != 1 {
+		t.Fatalf("access repos = %#v", view.Access.Repositories)
+	}
+}
+
 func TestSaveExternalWorkflowsStillAcceptsV1(t *testing.T) {
 	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
 

--- a/pkg/hub/schema_v2_validate_test.go
+++ b/pkg/hub/schema_v2_validate_test.go
@@ -45,6 +45,7 @@ ci:
 const testWorkflowV2YAML = `
 schema_version: 2
 name: delivery
+enabled: true
 initial_state: implementing
 states:
   implementing: {}
@@ -290,5 +291,29 @@ stages:
 	}})
 	if err != nil {
 		t.Fatalf("save v1 workflow: %v", err)
+	}
+}
+
+func TestV2WorkflowProjectionDefaultsMissingEnabledToFalse(t *testing.T) {
+	workflow, err := loadExternalWorkflowDocument("draft.yaml", []byte(`
+schema_version: 2
+name: draft
+initial_state: planning
+states:
+  planning:
+    phase: plan
+  done:
+    phase: done
+    terminal: true
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if workflow.Enabled == nil || *workflow.Enabled {
+		t.Fatalf("v2 enabled = %v, want explicit false", workflow.Enabled)
+	}
+	view := workflowToView("engineering", workflow)
+	if view.RuntimeAvailable || view.SchemaVersion != "2" {
+		t.Fatalf("v2 view = %#v, want schema 2 and unavailable runtime", view)
 	}
 }

--- a/pkg/hub/schema_v2_validate_test.go
+++ b/pkg/hub/schema_v2_validate_test.go
@@ -1,6 +1,8 @@
 package hub
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -177,6 +179,57 @@ func TestSaveExternalWorkflowsAcceptsValidV2Pair(t *testing.T) {
 	}})
 	if err != nil {
 		t.Fatalf("save valid v2 workflow pair: %v", err)
+	}
+}
+
+func TestSaveExternalWorkflowsValidatesBatchBeforeMutation(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	if err := saveExternalWorkspace(&types.WorkspaceConfig{
+		Name:  "engineering",
+		Files: map[string]string{"elasticclaw-config.yaml": testWorkspaceV2YAML},
+	}); err != nil {
+		t.Fatalf("seed workspace: %v", err)
+	}
+	oldWorkflow := `
+schema_version: 2
+name: first
+initial_state: planning
+states:
+  planning:
+    description: old-content
+  done:
+    terminal: true
+`
+	if err := saveExternalWorkflows("engineering", []*types.WorkflowConfig{{Name: "first", RawConfig: oldWorkflow}}); err != nil {
+		t.Fatalf("seed workflow: %v", err)
+	}
+	newWorkflow := strings.Replace(oldWorkflow, "old-content", "new-content", 1)
+	invalidWorkflow := `
+schema_version: 2
+name: invalid
+initial_state: planning
+states:
+  planning:
+    phase: unsupported
+  done:
+    terminal: true
+`
+	err := saveExternalWorkflows("engineering", []*types.WorkflowConfig{
+		{Name: "first", RawConfig: newWorkflow},
+		{Name: "invalid", RawConfig: invalidWorkflow},
+	})
+	if err == nil {
+		t.Fatal("expected invalid batch to fail")
+	}
+	persisted, readErr := os.ReadFile(filepath.Join(workspacesDir(), "engineering", "workflows", "first.yaml"))
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if !strings.Contains(string(persisted), "old-content") || strings.Contains(string(persisted), "new-content") {
+		t.Fatalf("valid item was partially persisted before later validation failure:\n%s", persisted)
+	}
+	if _, statErr := os.Stat(filepath.Join(workspacesDir(), "engineering", "workflows", "invalid.yaml")); !os.IsNotExist(statErr) {
+		t.Fatalf("invalid workflow should not be persisted, stat error=%v", statErr)
 	}
 }
 

--- a/pkg/hub/schema_v2_validate_test.go
+++ b/pkg/hub/schema_v2_validate_test.go
@@ -48,9 +48,12 @@ name: delivery
 enabled: true
 initial_state: implementing
 states:
-  implementing: {}
-  awaiting_ci: {}
+  implementing:
+    phase: build
+  awaiting_ci:
+    phase: pr
   completed:
+    phase: done
     terminal: true
 transitions:
   open:

--- a/pkg/hub/schema_v2_validate_test.go
+++ b/pkg/hub/schema_v2_validate_test.go
@@ -1,0 +1,221 @@
+package hub
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+const testWorkspaceV2YAML = `
+schema_version: 2
+name: engineering
+
+repositories:
+  primary:
+    provider: github
+    repository: org/repo
+    source_control: sc
+
+credentials:
+  github_app:
+    secret: GITHUB_APP_PRIVATE_KEY
+
+source_control:
+  connections:
+    sc:
+      provider: github
+      credentials: github_app
+
+ci:
+  connections:
+    gha:
+      provider: github_actions
+      source_control: sc
+      credentials: github_app
+      capability_restrictions:
+        trigger_run: false
+  pipelines:
+    github-pr:
+      connection: gha
+      repository: primary
+      workflow: ci.yml
+`
+
+const testWorkflowV2YAML = `
+schema_version: 2
+name: delivery
+initial_state: implementing
+states:
+  implementing: {}
+  awaiting_ci: {}
+  completed:
+    terminal: true
+transitions:
+  open:
+    from: implementing
+    on: pull_request.verified_open
+    to: awaiting_ci
+  done:
+    from: awaiting_ci
+    on: pull_request.merged
+    to: completed
+events:
+  ci.run.completed:
+    clauses:
+      - from: awaiting_ci
+        when:
+          conclusion:
+            equals: failure
+        assert:
+          work.needs_fix: true
+`
+
+func TestSaveExternalWorkspaceRejectsInvalidV2(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+
+	invalid := `
+schema_version: 2
+name: broken
+ci:
+  connections:
+    c1:
+      provider: github_actions
+      credentials: missing
+`
+	err := saveExternalWorkspace(&types.WorkspaceConfig{
+		Name:  "broken",
+		Files: map[string]string{"elasticclaw-config.yaml": invalid},
+	})
+	if err == nil {
+		t.Fatal("expected saveExternalWorkspace to refuse invalid v2")
+	}
+	if !strings.Contains(err.Error(), "invalid workspace v2") && !strings.Contains(err.Error(), "unknown credential") {
+		t.Fatalf("error = %v, want invalid workspace v2 / credential", err)
+	}
+}
+
+func TestSaveExternalWorkspaceAcceptsValidV2(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+
+	err := saveExternalWorkspace(&types.WorkspaceConfig{
+		Name:  "engineering",
+		Files: map[string]string{"elasticclaw-config.yaml": testWorkspaceV2YAML},
+	})
+	if err != nil {
+		t.Fatalf("save valid v2 workspace: %v", err)
+	}
+}
+
+func TestSaveExternalWorkspaceStillAcceptsV1(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+
+	err := saveExternalWorkspace(&types.WorkspaceConfig{
+		Name: "engineering",
+		Files: map[string]string{
+			"elasticclaw-config.yaml": "schema_version: v1\nname: engineering\nprovider: noop\n",
+		},
+	})
+	if err != nil {
+		t.Fatalf("save v1 workspace: %v", err)
+	}
+}
+
+func TestSaveExternalWorkflowsRejectsInvalidV2Pair(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+
+	if err := saveExternalWorkspace(&types.WorkspaceConfig{
+		Name:  "engineering",
+		Files: map[string]string{"elasticclaw-config.yaml": testWorkspaceV2YAML},
+	}); err != nil {
+		t.Fatalf("seed workspace: %v", err)
+	}
+
+	// Overlapping event clauses + protected namespace would also fail; use unknown pipeline effect.
+	badWorkflow := `
+schema_version: 2
+name: bad
+initial_state: s
+states:
+  s:
+    on_enter:
+      effects:
+        - ci.trigger:
+            pipeline: missing-pipeline
+  done:
+    terminal: true
+`
+	err := saveExternalWorkflows("engineering", []*types.WorkflowConfig{{
+		Name:      "bad",
+		RawConfig: badWorkflow,
+	}})
+	if err == nil {
+		t.Fatal("expected refuse invalid v2 pair")
+	}
+	if !strings.Contains(err.Error(), "unknown pipeline") && !strings.Contains(err.Error(), "invalid workflow v2") {
+		t.Fatalf("error = %v, want unknown pipeline / invalid workflow v2", err)
+	}
+}
+
+func TestSaveExternalWorkflowsAcceptsValidV2Pair(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+
+	if err := saveExternalWorkspace(&types.WorkspaceConfig{
+		Name:  "engineering",
+		Files: map[string]string{"elasticclaw-config.yaml": testWorkspaceV2YAML},
+	}); err != nil {
+		t.Fatalf("seed workspace: %v", err)
+	}
+
+	err := saveExternalWorkflows("engineering", []*types.WorkflowConfig{{
+		Name:      "delivery",
+		RawConfig: testWorkflowV2YAML,
+	}})
+	if err != nil {
+		t.Fatalf("save valid v2 workflow pair: %v", err)
+	}
+}
+
+func TestSaveExternalWorkflowsStillAcceptsV1(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+
+	if err := saveExternalWorkspace(&types.WorkspaceConfig{
+		Name: "engineering",
+		Files: map[string]string{
+			"elasticclaw-config.yaml": "schema_version: v1\nname: engineering\nprovider: noop\n",
+		},
+	}); err != nil {
+		t.Fatalf("seed v1 workspace: %v", err)
+	}
+
+	v1Workflow := `
+schema_version: v1
+name: bugfix
+trigger:
+  github_issues:
+    event: issue_labeled
+    repositories:
+      - org/repo
+    labels:
+      - todo
+stages:
+  - id: working
+    entry: true
+    on_enter:
+      inject: start
+`
+	wf := &types.WorkflowConfig{Name: "bugfix", RawConfig: v1Workflow}
+	if err := types.NormalizeWorkflowConfig(wf); err != nil {
+		// Normalize on unmarshaled struct — parse raw first for integration realism.
+		_ = err
+	}
+	// Simulate API path: unmarshal raw into struct then normalize/validate.
+	// Store path only needs RawConfig for v1 write-through.
+	err := saveExternalWorkflows("engineering", []*types.WorkflowConfig{{
+		Name:      "bugfix",
+		RawConfig: v1Workflow,
+	}})
+	if err != nil {
+		t.Fatalf("save v1 workflow: %v", err)
+	}
+}

--- a/pkg/hub/workspace_api.go
+++ b/pkg/hub/workspace_api.go
@@ -53,6 +53,7 @@ type WorkspaceAccess struct {
 // WorkflowView is a workflow-shaped projection of a legacy factory.
 type WorkflowView struct {
 	Name                 string                 `json:"name"`
+	SchemaVersion        string                 `json:"schemaVersion,omitempty"`
 	WorkspaceName        string                 `json:"workspaceName"`
 	Source               string                 `json:"source"`
 	Integration          string                 `json:"integration"`
@@ -64,6 +65,7 @@ type WorkflowView struct {
 	ExcludeLabels        []string               `json:"exclude_labels,omitempty"`
 	AssignedTo           string                 `json:"assignedTo,omitempty"`
 	Enabled              bool                   `json:"enabled"`
+	RuntimeAvailable     bool                   `json:"runtimeAvailable"`
 	HasWebhookSecret     bool                   `json:"hasWebhookSecret"`
 	WebhookSecretRef     string                 `json:"webhookSecretRef,omitempty"`
 	PipelineYAML         string                 `json:"pipelineYAML,omitempty"`
@@ -328,6 +330,10 @@ func (s *Server) handleWorkspaceWorkflowPatch(w http.ResponseWriter, r *http.Req
 		http.Error(w, "workflow not found", http.StatusNotFound)
 		return
 	}
+	if isWorkflowV2(workflow) {
+		http.Error(w, "workflow v2 activation is managed by the v2 runtime and cannot be changed through the v1 workflow patch API", http.StatusConflict)
+		return
+	}
 	if req.Enabled != nil {
 		workflow.Enabled = req.Enabled
 	}
@@ -381,6 +387,12 @@ func (s *Server) handleWorkspaceWorkflowTrigger(w http.ResponseWriter, r *http.R
 }
 
 func (s *Server) triggerWorkflowConfig(w http.ResponseWriter, r *http.Request, workspace *types.WorkspaceConfig, workflow *types.WorkflowConfig) {
+	// Until the deterministic runtime is installed, v2 is authorable but never
+	// normalized or executed through the legacy transcript-driven engine.
+	if isWorkflowV2(workflow) {
+		jsonError(w, http.StatusConflict, "workflow v2 runtime is not active; this workflow cannot execute through the v1 engine")
+		return
+	}
 	if !workflow.EnableManualTrigger {
 		jsonError(w, http.StatusForbidden, "workflow does not support manual triggers")
 		return
@@ -581,6 +593,7 @@ func workflowToView(workspaceName string, workflow *types.WorkflowConfig) Workfl
 	}
 	return WorkflowView{
 		Name:                 workflow.Name,
+		SchemaVersion:        workflow.SchemaVersion,
 		WorkspaceName:        workspaceName,
 		Source:               "workflow",
 		Integration:          workflow.Integration,
@@ -591,6 +604,7 @@ func workflowToView(workspaceName string, workflow *types.WorkflowConfig) Workfl
 		ExcludeLabels:        append([]string(nil), workflow.ExcludeLabels...),
 		AssignedTo:           workflow.AssignedTo,
 		Enabled:              workflow.Enabled == nil || *workflow.Enabled,
+		RuntimeAvailable:     !isWorkflowV2(workflow),
 		EnableManualTrigger:  workflow.EnableManualTrigger,
 		SecretRefs:           cloneStringMap(workflow.SecretRefs),
 		Volumes:              append([]types.WorkflowVolume(nil), workflow.Volumes...),

--- a/pkg/hub/workspace_api.go
+++ b/pkg/hub/workspace_api.go
@@ -13,8 +13,24 @@ import (
 	"time"
 
 	"github.com/elasticclaw/elasticclaw/pkg/types"
+	v2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
 	"github.com/google/uuid"
 )
+
+// isWorkflowV2 reports whether a workflow push payload is schema v2.
+// Prefers RawConfig when present so integer schema_version: 2 is detected.
+func isWorkflowV2(workflow *types.WorkflowConfig) bool {
+	if workflow == nil {
+		return false
+	}
+	if raw := strings.TrimSpace(workflow.RawConfig); raw != "" {
+		version, err := v2.DetectSchemaVersion([]byte(raw))
+		if err == nil && v2.IsV2(version) {
+			return true
+		}
+	}
+	return v2.IsV2(workflow.SchemaVersion)
+}
 
 // WorkspaceView is the API view of a persisted workspace.
 type WorkspaceView struct {
@@ -116,17 +132,26 @@ func (s *Server) handleWorkspacesPush(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var saveErrs []string
+	clientErr := false
 	for _, workspace := range req.Workspaces {
 		if workspace == nil {
 			saveErrs = append(saveErrs, "workspace cannot be nil")
+			clientErr = true
 			continue
 		}
 		if err := saveExternalWorkspace(workspace); err != nil {
 			saveErrs = append(saveErrs, fmt.Sprintf("save workspace %q: %v", workspace.Name, err))
+			if strings.Contains(err.Error(), "invalid workspace v2") || strings.Contains(err.Error(), "workspace name") {
+				clientErr = true
+			}
 		}
 	}
 	if len(saveErrs) > 0 {
-		http.Error(w, strings.Join(saveErrs, "; "), http.StatusInternalServerError)
+		status := http.StatusInternalServerError
+		if clientErr {
+			status = http.StatusBadRequest
+		}
+		http.Error(w, strings.Join(saveErrs, "; "), status)
 		return
 	}
 
@@ -195,6 +220,10 @@ func (s *Server) handleWorkspaceWorkflowsPush(w http.ResponseWriter, r *http.Req
 			http.Error(w, "workflow cannot be nil", http.StatusBadRequest)
 			return
 		}
+		// V2 workflows use a separate schema; do not run v1 normalize/validate on them.
+		if isWorkflowV2(workflow) {
+			continue
+		}
 		if err := types.NormalizeWorkflowConfig(workflow); err != nil {
 			http.Error(w, "invalid workflow: "+err.Error(), http.StatusBadRequest)
 			return
@@ -214,7 +243,12 @@ func (s *Server) handleWorkspaceWorkflowsPush(w http.ResponseWriter, r *http.Req
 			http.Error(w, err.Error(), http.StatusNotFound)
 			return
 		}
-		http.Error(w, "save workflows: "+err.Error(), http.StatusInternalServerError)
+		// Validation failures at the store boundary are client errors.
+		status := http.StatusInternalServerError
+		if strings.Contains(err.Error(), "invalid workflow v2") || strings.Contains(err.Error(), "invalid workspace v2") {
+			status = http.StatusBadRequest
+		}
+		http.Error(w, "save workflows: "+err.Error(), status)
 		return
 	}
 	if s.cronScheduler != nil {

--- a/pkg/hub/workspace_api_test.go
+++ b/pkg/hub/workspace_api_test.go
@@ -456,6 +456,56 @@ func TestWorkspaceWorkflowPatchUpdatesTriggerControls(t *testing.T) {
 	}
 }
 
+func TestV2WorkflowCannotEnterLegacyPatchOrTriggerPaths(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+
+	if err := saveExternalWorkspace(&types.WorkspaceConfig{
+		Name:  "engineering",
+		Files: map[string]string{"elasticclaw-config.yaml": testWorkspaceV2YAML},
+	}); err != nil {
+		t.Fatalf("seed workspace: %v", err)
+	}
+	if err := saveExternalWorkflows("engineering", []*types.WorkflowConfig{{
+		Name:      "delivery",
+		RawConfig: testWorkflowV2YAML,
+	}}); err != nil {
+		t.Fatalf("seed workflow: %v", err)
+	}
+
+	for _, tc := range []struct {
+		method string
+		body   string
+	}{
+		{http.MethodPatch, `{"enabled":false}`},
+		{http.MethodPost, `{"inputs":{}}`},
+	} {
+		path := "/api/workspaces/engineering/workflows/delivery"
+		if tc.method == http.MethodPost {
+			path += "/trigger"
+		}
+		req := httptest.NewRequest(tc.method, path, strings.NewReader(tc.body))
+		req.Header.Set("Authorization", "Bearer test-token")
+		req.Header.Set("Content-Type", "application/json")
+		rr := httptest.NewRecorder()
+		s.Handler().ServeHTTP(rr, req)
+		if rr.Code != http.StatusConflict {
+			t.Fatalf("%s status = %d, want %d, body = %s", tc.method, rr.Code, http.StatusConflict, rr.Body.String())
+		}
+		if !strings.Contains(rr.Body.String(), "v2") {
+			t.Fatalf("%s response does not explain v2 boundary: %s", tc.method, rr.Body.String())
+		}
+	}
+
+	loaded, err := loadExternalWorkspace("engineering")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded.Workflows) != 1 || !strings.Contains(loaded.Workflows[0].RawConfig, "enabled: true") {
+		t.Fatalf("v2 document was mutated by legacy path: %#v", loaded.Workflows)
+	}
+}
+
 func TestWorkspaceWorkflowPatchReloadsCronScheduler(t *testing.T) {
 	configDir := t.TempDir()
 	t.Setenv("ELASTICCLAW_HUB_CONFIG", configDir+"/hub.yaml")

--- a/pkg/types/convert/convert.go
+++ b/pkg/types/convert/convert.go
@@ -1,0 +1,179 @@
+// Package convert migrates authored workspace and workflow documents between
+// schema versions. Converters are registered as (kind, from, to) so v3 and
+// later paths can be added without changing the CLI surface.
+package convert
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	v2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
+)
+
+// Kind identifies which document family is being converted.
+type Kind string
+
+const (
+	KindWorkspace Kind = "workspace"
+	KindWorkflow  Kind = "workflow"
+)
+
+// Result is the output of a successful conversion.
+type Result struct {
+	// Output is the converted document as YAML bytes (trailing newline).
+	Output []byte
+	// From is the detected or requested source schema version (normalized).
+	From string
+	// To is the target schema version (normalized).
+	To string
+	// Warnings are human-readable notes about lossy or incomplete mappings.
+	// Callers should surface these; conversion can succeed with warnings.
+	Warnings []string
+}
+
+// Options control conversion behavior.
+type Options struct {
+	// From is the source schema version. Empty means auto-detect from document.
+	From string
+	// To is the target schema version. Required (CLI defaults to "2").
+	To string
+	// WorkspaceYAML is optional workspace v2 YAML used when converting a
+	// workflow so policy/resource refs can be pair-validated when present.
+	WorkspaceYAML []byte
+	// Validate runs post-conversion schema validation (default true).
+	Validate *bool
+}
+
+func shouldValidate(opts Options) bool {
+	if opts.Validate == nil {
+		return true
+	}
+	return *opts.Validate
+}
+
+type converterFunc func(data []byte, opts Options) (Result, error)
+
+type route struct {
+	kind Kind
+	from string
+	to   string
+	fn   converterFunc
+}
+
+var routes []route
+
+func register(kind Kind, from, to string, fn converterFunc) {
+	routes = append(routes, route{kind: kind, from: normalizeVersion(from), to: normalizeVersion(to), fn: fn})
+}
+
+func init() {
+	register(KindWorkspace, "v1", "2", convertWorkspaceV1ToV2)
+	register(KindWorkflow, "v1", "2", convertWorkflowV1ToV2)
+}
+
+// SupportedTargets lists target versions available for a kind from a source.
+func SupportedTargets(kind Kind, from string) []string {
+	from = normalizeVersion(from)
+	var out []string
+	for _, r := range routes {
+		if r.kind == kind && r.from == from {
+			out = append(out, r.to)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// NormalizeVersion maps authored forms to a canonical conversion key.
+// "v1"/"1" → "v1"; "2"/"v2" → "2".
+func NormalizeVersion(v string) string { return normalizeVersion(v) }
+
+func normalizeVersion(v string) string {
+	v = strings.TrimSpace(strings.ToLower(v))
+	switch v {
+	case "", "v1", "1":
+		if v == "" {
+			return ""
+		}
+		return "v1"
+	case "2", "v2":
+		return "2"
+	case "3", "v3":
+		return "3"
+	default:
+		// Keep "v1"-style and bare numbers as-is when already canonical-ish.
+		if strings.HasPrefix(v, "v") {
+			return v
+		}
+		return v
+	}
+}
+
+// DetectVersion reads schema_version from YAML.
+func DetectVersion(data []byte) (string, error) {
+	raw, err := v2.DetectSchemaVersion(data)
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(raw) == "" {
+		// Historical docs omit schema_version; treat as v1.
+		return "v1", nil
+	}
+	return normalizeVersion(raw), nil
+}
+
+// Convert migrates a document of the given kind from opts.From (or auto) to opts.To.
+func Convert(kind Kind, data []byte, opts Options) (Result, error) {
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return Result{}, fmt.Errorf("%s: empty document", kind)
+	}
+	to := normalizeVersion(opts.To)
+	if to == "" {
+		return Result{}, fmt.Errorf("--to is required (supported targets depend on source version)")
+	}
+
+	from := normalizeVersion(opts.From)
+	if from == "" {
+		detected, err := DetectVersion(data)
+		if err != nil {
+			return Result{}, err
+		}
+		from = detected
+	}
+
+	if from == to {
+		return Result{}, fmt.Errorf("%s is already schema version %s", kind, displayVersion(from))
+	}
+
+	// Direct route.
+	if fn := findRoute(kind, from, to); fn != nil {
+		opts.From = from
+		opts.To = to
+		return fn(data, opts)
+	}
+
+	// Future: multi-hop (v1→v2→v3). For now only direct edges are registered.
+	return Result{}, fmt.Errorf("no converter for %s %s → %s (supported from %s: %v)",
+		kind, displayVersion(from), displayVersion(to), displayVersion(from), SupportedTargets(kind, from))
+}
+
+func findRoute(kind Kind, from, to string) converterFunc {
+	for _, r := range routes {
+		if r.kind == kind && r.from == from && r.to == to {
+			return r.fn
+		}
+	}
+	return nil
+}
+
+func displayVersion(v string) string {
+	if v == "v1" {
+		return "v1"
+	}
+	return v
+}
+
+func appendWarning(warnings *[]string, format string, args ...interface{}) {
+	*warnings = append(*warnings, fmt.Sprintf(format, args...))
+}

--- a/pkg/types/convert/convert_test.go
+++ b/pkg/types/convert/convert_test.go
@@ -124,6 +124,9 @@ func TestConvertWorkflowV1ToV2(t *testing.T) {
 	if !resolved.Workflow.States["merged"].Terminal {
 		t.Fatal("merged should be terminal")
 	}
+	if resolved.Workflow.Enabled || !strings.Contains(string(res.Output), "enabled: false") {
+		t.Fatalf("converted workflow must be an explicitly inactive draft:\n%s", res.Output)
+	}
 
 	// Deterministic PR edges present; message_contains not turned into trusted transitions.
 	hasMerged := false

--- a/pkg/types/convert/convert_test.go
+++ b/pkg/types/convert/convert_test.go
@@ -1,0 +1,207 @@
+package convert_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types/convert"
+	v2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
+)
+
+const sampleWorkspaceV1 = `
+schema_version: v1
+name: elasticclaw
+
+provider: daytona
+nix: true
+docker: true
+
+repositories:
+  - repo: elasticclaw/elasticclaw
+    permissions: write
+  - repo: elasticclaw/elasticclaw.ai
+    permissions: write
+
+env:
+  LINEAR_API_KEY:
+    secret: LINEAR_API_KEY
+  ENVIRONMENT: dev
+`
+
+const sampleWorkflowV1 = `
+schema_version: v1
+name: github-issue
+
+trigger:
+  github_issues:
+    event: issue_labeled
+    repositories:
+      - elasticclaw/elasticclaw
+    states:
+      - open
+    labels:
+      - agent-ready
+
+stages:
+  - id: working
+    label: Working
+    entry: true
+    on_enter:
+      inject: |
+        Start work. Say [READY_TO_COMMIT] when done.
+  - id: pre_commit
+    label: Pre-Commit Checks
+    triggers:
+      - message_contains: "[READY_TO_COMMIT]"
+    on_enter:
+      run:
+        command: make test
+  - id: pr_opened
+    label: PR Opened
+    triggers:
+      - message_contains: "[DONE]"
+  - id: merged
+    label: Merged
+    terminal: true
+    triggers:
+      - pr_merged: {}
+  - id: closed_no_merge
+    label: Closed Without Merge
+    terminal: true
+    triggers:
+      - pr_closed: {}
+`
+
+func TestConvertWorkspaceV1ToV2(t *testing.T) {
+	res, err := convert.Convert(convert.KindWorkspace, []byte(sampleWorkspaceV1), convert.Options{To: "2"})
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	if res.From != "v1" || res.To != "2" {
+		t.Fatalf("from/to = %s/%s", res.From, res.To)
+	}
+	if len(res.Warnings) == 0 {
+		t.Fatal("expected migration warnings")
+	}
+
+	resolved, err := v2.ParseAndValidateWorkspace(res.Output)
+	if err != nil {
+		t.Fatalf("validate converted: %v\n%s", err, res.Output)
+	}
+	if resolved.Workspace.Name != "elasticclaw" {
+		t.Fatalf("name = %q", resolved.Workspace.Name)
+	}
+	if resolved.Workspace.Execution == nil || resolved.Workspace.Execution.Provider != "daytona" {
+		t.Fatalf("execution = %#v", resolved.Workspace.Execution)
+	}
+	if !resolved.Workspace.HasRepository("elasticclaw-elasticclaw") {
+		t.Fatalf("missing repo key, repos=%v\n%s", resolved.Workspace.Repositories, res.Output)
+	}
+	if !resolved.Workspace.HasCredential("linear_api_key") {
+		t.Fatalf("expected linear_api_key credential\n%s", res.Output)
+	}
+	// Inline env dropped with warning
+	joined := strings.Join(res.Warnings, "\n")
+	if !strings.Contains(joined, "env.ENVIRONMENT") {
+		t.Fatalf("expected warning about inline env, got:\n%s", joined)
+	}
+}
+
+func TestConvertWorkflowV1ToV2(t *testing.T) {
+	res, err := convert.Convert(convert.KindWorkflow, []byte(sampleWorkflowV1), convert.Options{To: "2"})
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	resolved, err := v2.ParseAndValidateWorkflow(res.Output)
+	if err != nil {
+		t.Fatalf("validate converted: %v\n%s", err, res.Output)
+	}
+	if resolved.Workflow.InitialState != "working" {
+		t.Fatalf("initial_state = %q", resolved.Workflow.InitialState)
+	}
+	if !resolved.Workflow.States["merged"].Terminal {
+		t.Fatal("merged should be terminal")
+	}
+
+	// Deterministic PR edges present; message_contains not turned into trusted transitions.
+	hasMerged := false
+	hasClosed := false
+	for _, tr := range resolved.Workflow.Transitions {
+		if tr.On == "pull_request.merged" && tr.To == "merged" {
+			hasMerged = true
+		}
+		if tr.On == "pull_request.closed" && tr.To == "closed_no_merge" {
+			hasClosed = true
+		}
+		if strings.Contains(tr.On, "message") || strings.Contains(tr.On, "DONE") {
+			t.Fatalf("must not create trusted transition from message control: %#v", tr)
+		}
+	}
+	if !hasMerged || !hasClosed {
+		t.Fatalf("expected pr_merged/pr_closed transitions, got %#v\n%s", resolved.Workflow.Transitions, res.Output)
+	}
+
+	joined := strings.Join(res.Warnings, "\n")
+	for _, want := range []string{"message_contains", "[DONE]", "[READY_TO_COMMIT]"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("expected warning mentioning %q, got:\n%s", want, joined)
+		}
+	}
+}
+
+func TestConvertWorkflowPairWithConvertedWorkspace(t *testing.T) {
+	ws, err := convert.Convert(convert.KindWorkspace, []byte(sampleWorkspaceV1), convert.Options{To: "2"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wf, err := convert.Convert(convert.KindWorkflow, []byte(sampleWorkflowV1), convert.Options{
+		To:            "2",
+		WorkspaceYAML: ws.Output,
+	})
+	if err != nil {
+		t.Fatalf("pair convert: %v", err)
+	}
+	if _, _, err := v2.ParseAndValidateWorkflowPair(wf.Output, ws.Output); err != nil {
+		t.Fatalf("pair validate: %v", err)
+	}
+}
+
+func TestConvertRejectsUnknownTarget(t *testing.T) {
+	_, err := convert.Convert(convert.KindWorkspace, []byte(sampleWorkspaceV1), convert.Options{To: "3"})
+	if err == nil || !strings.Contains(err.Error(), "no converter") {
+		t.Fatalf("error = %v, want no converter", err)
+	}
+}
+
+func TestConvertRejectsAlreadyTarget(t *testing.T) {
+	ws, err := convert.Convert(convert.KindWorkspace, []byte(sampleWorkspaceV1), convert.Options{To: "2"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = convert.Convert(convert.KindWorkspace, ws.Output, convert.Options{To: "2"})
+	if err == nil || !strings.Contains(err.Error(), "already schema version") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestExampleGitHubIssueWorkflowConverts(t *testing.T) {
+	path := filepath.Join("..", "..", "..", "examples", "workflows", "github-issue.yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		// try from module root relative to this package: pkg/types/convert -> ../../../examples
+		path = filepath.Join("..", "..", "..", "examples", "workflows", "github-issue.yaml")
+		data, err = os.ReadFile(path)
+		if err != nil {
+			t.Skipf("example workflow not found: %v", err)
+		}
+	}
+	res, err := convert.Convert(convert.KindWorkflow, data, convert.Options{To: "2"})
+	if err != nil {
+		t.Fatalf("convert example: %v", err)
+	}
+	if _, err := v2.ParseAndValidateWorkflow(res.Output); err != nil {
+		t.Fatalf("validate example conversion: %v\n%s", err, res.Output)
+	}
+}

--- a/pkg/types/convert/workflow_v1_v2.go
+++ b/pkg/types/convert/workflow_v1_v2.go
@@ -1,0 +1,334 @@
+package convert
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+	v2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
+	"gopkg.in/yaml.v3"
+)
+
+func convertWorkflowV1ToV2(data []byte, opts Options) (Result, error) {
+	var warnings []string
+
+	var wf types.WorkflowConfig
+	if err := yaml.Unmarshal(data, &wf); err != nil {
+		return Result{}, fmt.Errorf("parse workflow: %w", err)
+	}
+	if err := types.NormalizeWorkflowConfig(&wf); err != nil {
+		return Result{}, fmt.Errorf("normalize workflow: %w", err)
+	}
+	name := strings.TrimSpace(wf.Name)
+	if name == "" {
+		return Result{}, fmt.Errorf("workflow name is required")
+	}
+	if len(wf.Stages) == 0 {
+		return Result{}, fmt.Errorf("workflow %q: v1 stages are required to convert (no stages found)", name)
+	}
+
+	// Detect entry / build state list.
+	initial := ""
+	states := map[string]v2.State{}
+	stageOrder := make([]string, 0, len(wf.Stages))
+	nonTerminal := []string{}
+
+	for i, st := range wf.Stages {
+		id := strings.TrimSpace(st.ID)
+		if id == "" {
+			return Result{}, fmt.Errorf("workflow %q: stages[%d].id is required", name, i)
+		}
+		stageOrder = append(stageOrder, id)
+		desc := strings.TrimSpace(st.Label)
+		state := v2.State{
+			Description: desc,
+			Terminal:    st.Terminal,
+		}
+		// Convert on_enter inject → agent.task effect; label mutations → warnings.
+		actions, onEnterWarns := convertStageOnEnter(id, st.OnEnter)
+		if actions != nil {
+			state.OnEnter = actions
+		}
+		warnings = append(warnings, onEnterWarns...)
+		states[id] = state
+		if st.Entry && initial == "" {
+			initial = id
+		}
+		if !st.Terminal {
+			nonTerminal = append(nonTerminal, id)
+		}
+	}
+	if initial == "" {
+		// Fall back to first non-terminal stage, else first stage.
+		if len(nonTerminal) > 0 {
+			initial = nonTerminal[0]
+			appendWarning(&warnings, "initial_state: no stage marked entry: true; using first non-terminal stage %q", initial)
+		} else {
+			initial = stageOrder[0]
+			appendWarning(&warnings, "initial_state: no entry stage found; using %q", initial)
+		}
+	}
+
+	transitions := map[string]v2.Transition{}
+	usedTransitionNames := map[string]int{}
+
+	for _, st := range wf.Stages {
+		id := strings.TrimSpace(st.ID)
+		// Preceding non-terminal stages are the conservative `from` set for
+		// "enter this stage when trigger fires" v1 semantics.
+		fromStates := precedingNonTerminal(stageOrder, states, id)
+		if len(fromStates) == 0 {
+			// If nothing precedes, allow from other non-terminals except self.
+			for _, nt := range nonTerminal {
+				if nt != id {
+					fromStates = append(fromStates, nt)
+				}
+			}
+		}
+
+		for ti, trig := range st.Triggers {
+			path := fmt.Sprintf("stages.%s.triggers[%d]", id, ti)
+			mapped, warn := mapV1Trigger(path, trig)
+			warnings = append(warnings, warn...)
+			if mapped == nil {
+				continue
+			}
+			if len(fromStates) == 0 {
+				appendWarning(&warnings, "%s: no source states available for transition to %q; skipped", path, id)
+				continue
+			}
+			tname := uniqueName(fmt.Sprintf("to_%s_via_%s", id, mapped.slug), usedTransitionNames)
+			tr := v2.Transition{
+				From: stringOrList(fromStates),
+				On:   mapped.on,
+				To:   id,
+			}
+			if len(mapped.when) > 0 {
+				tr.When = mapped.when
+			}
+			transitions[tname] = tr
+		}
+	}
+
+	// Warn about v1 text-control markers that must not become trusted evidence.
+	rawStr := string(data)
+	for _, marker := range []string{"[DONE]", "[READY_TO_COMMIT]", "message_contains"} {
+		if strings.Contains(rawStr, marker) {
+			appendWarning(&warnings, "v1 text control %q detected: never reinterpreting as trusted v2 evidence — replace with explicit transitions/event clauses after review", marker)
+		}
+	}
+
+	// Integration/trigger metadata does not map 1:1; surface for operators.
+	if wf.Integration != "" {
+		appendWarning(&warnings, "integration %q: v2 workflows are event/state driven; re-bind trigger sources via workspace connections and runtime adapters (not embedded as v1 integration)", wf.Integration)
+	}
+	if wf.Trigger != nil {
+		appendWarning(&warnings, "trigger: v1 trigger block not copied into v2 — configure run creation / issue association outside the v2 state machine (hub trigger adapters)")
+	}
+	if len(wf.Inputs) > 0 {
+		appendWarning(&warnings, "inputs: %d v1 input(s) not represented in workflow v2 schema yet; preserve separately if still needed for manual trigger UX", len(wf.Inputs))
+	}
+	if len(wf.Volumes) > 0 {
+		appendWarning(&warnings, "volumes: %d v1 volume(s) not represented in workflow v2 schema yet", len(wf.Volumes))
+	}
+	if wf.ConcurrencyGroup != "" {
+		appendWarning(&warnings, "concurrency_group %q: not represented in workflow v2 schema yet", wf.ConcurrencyGroup)
+	}
+
+	out := v2.Workflow{
+		SchemaVersion: 2,
+		Name:          name,
+		InitialState:  initial,
+		States:        states,
+	}
+	if len(transitions) > 0 {
+		out.Transitions = transitions
+	}
+
+	// Validate structurally; pair-validate when workspace YAML provided.
+	if shouldValidate(opts) {
+		tmp, err := yaml.Marshal(out)
+		if err != nil {
+			return Result{}, err
+		}
+		if len(opts.WorkspaceYAML) > 0 {
+			wsVer, err := DetectVersion(opts.WorkspaceYAML)
+			if err == nil && wsVer == "2" {
+				if _, _, err := v2.ParseAndValidateWorkflowPair(tmp, opts.WorkspaceYAML); err != nil {
+					return Result{}, fmt.Errorf("converted workflow failed v2 pair validation: %w", err)
+				}
+			} else {
+				if _, err := v2.ParseAndValidateWorkflow(tmp); err != nil {
+					return Result{}, fmt.Errorf("converted workflow failed v2 validation: %w", err)
+				}
+				if wsVer == "v1" {
+					appendWarning(&warnings, "workspace document is still v1; convert the workspace first for pair validation of pipelines/connections")
+				}
+			}
+		} else if _, err := v2.ParseAndValidateWorkflow(tmp); err != nil {
+			return Result{}, fmt.Errorf("converted workflow failed v2 validation: %w", err)
+		}
+	}
+
+	encoded, err := yaml.Marshal(out)
+	if err != nil {
+		return Result{}, fmt.Errorf("marshal workflow v2: %w", err)
+	}
+	if len(encoded) == 0 || encoded[len(encoded)-1] != '\n' {
+		encoded = append(encoded, '\n')
+	}
+	sort.Strings(warnings)
+
+	return Result{
+		Output:   encoded,
+		From:     "v1",
+		To:       "2",
+		Warnings: warnings,
+	}, nil
+}
+
+type mappedTrigger struct {
+	on   string
+	slug string
+	when map[string]interface{}
+}
+
+func mapV1Trigger(path string, trig map[string]interface{}) (*mappedTrigger, []string) {
+	var warnings []string
+	if len(trig) == 0 {
+		return nil, warnings
+	}
+
+	// Deterministic, hub-owned triggers we can map.
+	if _, ok := trig["pr_merged"]; ok {
+		return &mappedTrigger{
+			on:   "pull_request.merged",
+			slug: "pr_merged",
+			when: map[string]interface{}{
+				"pull_request": map[string]interface{}{"state": "merged"},
+			},
+		}, warnings
+	}
+	if _, ok := trig["pr_closed"]; ok {
+		return &mappedTrigger{
+			on:   "pull_request.closed",
+			slug: "pr_closed",
+			when: map[string]interface{}{
+				"pull_request": map[string]interface{}{"state": "closed"},
+			},
+		}, warnings
+	}
+	if _, ok := trig["pr_opened"]; ok {
+		return &mappedTrigger{
+			on:   "pull_request.verified_open",
+			slug: "pr_opened",
+			when: map[string]interface{}{
+				"pull_request": map[string]interface{}{"state": "open"},
+			},
+		}, warnings
+	}
+
+	// Explicitly reject subjective text controls (RFC migration rules).
+	if v, ok := trig["message_contains"]; ok {
+		appendWarning(&warnings, "%s: message_contains %v cannot be auto-converted to trusted v2 evidence; add an explicit transition or event clause after choosing the authoritative fact", path, v)
+		return nil, warnings
+	}
+	if v, ok := trig["message_matches"]; ok {
+		appendWarning(&warnings, "%s: message_matches %v cannot be auto-converted to trusted v2 evidence", path, v)
+		return nil, warnings
+	}
+
+	// Unknown trigger keys — warn and skip.
+	keys := make([]string, 0, len(trig))
+	for k := range trig {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	appendWarning(&warnings, "%s: trigger %v not auto-converted; define a v2 transition/event clause manually", path, keys)
+	return nil, warnings
+}
+
+func convertStageOnEnter(stageID string, onEnter map[string]interface{}) (*v2.StateActions, []string) {
+	if len(onEnter) == 0 {
+		return nil, nil
+	}
+	var warnings []string
+	actions := &v2.StateActions{}
+	has := false
+
+	if inject, ok := onEnter["inject"].(string); ok && strings.TrimSpace(inject) != "" {
+		// Agent prompt as an effect — not trusted evidence.
+		actions.Effects = append(actions.Effects, map[string]interface{}{
+			"agent.task": map[string]interface{}{
+				"prompt": inject,
+			},
+		})
+		has = true
+		appendWarning(&warnings, "states.%s.on_enter.inject: mapped to agent.task effect (agent prose is never trusted workflow evidence)", stageID)
+	}
+
+	if _, ok := onEnter["add_labels"]; ok {
+		appendWarning(&warnings, "states.%s.on_enter.add_labels: not auto-converted — express as an issue-tracker effect with an explicit connection after review", stageID)
+	}
+	if _, ok := onEnter["remove_labels"]; ok {
+		appendWarning(&warnings, "states.%s.on_enter.remove_labels: not auto-converted — express as an issue-tracker effect with an explicit connection after review", stageID)
+	}
+	if _, ok := onEnter["run"]; ok {
+		appendWarning(&warnings, "states.%s.on_enter.run: shell/CI run hooks are not auto-converted — model as CI pipeline effects or agent.task after review", stageID)
+	}
+
+	// Surface other keys.
+	for k := range onEnter {
+		switch k {
+		case "inject", "add_labels", "remove_labels", "run":
+			continue
+		default:
+			appendWarning(&warnings, "states.%s.on_enter.%s: not auto-converted", stageID, k)
+		}
+	}
+
+	if !has {
+		return nil, warnings
+	}
+	return actions, warnings
+}
+
+func precedingNonTerminal(order []string, states map[string]v2.State, target string) []string {
+	var out []string
+	for _, id := range order {
+		if id == target {
+			break
+		}
+		if st, ok := states[id]; ok && !st.Terminal {
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
+func stringOrList(states []string) interface{} {
+	if len(states) == 1 {
+		return states[0]
+	}
+	// yaml.v3 marshals []string fine; v2.FromStates accepts []interface{} after unmarshal.
+	out := make([]interface{}, len(states))
+	for i, s := range states {
+		out[i] = s
+	}
+	return out
+}
+
+func uniqueName(base string, used map[string]int) string {
+	base = nonResourceChars.ReplaceAllString(strings.ToLower(base), "_")
+	base = strings.Trim(base, "_")
+	if base == "" {
+		base = "transition"
+	}
+	n := used[base]
+	used[base] = n + 1
+	if n == 0 {
+		return base
+	}
+	return fmt.Sprintf("%s_%d", base, n+1)
+}

--- a/pkg/types/convert/workflow_v1_v2.go
+++ b/pkg/types/convert/workflow_v1_v2.go
@@ -139,6 +139,7 @@ func convertWorkflowV1ToV2(data []byte, opts Options) (Result, error) {
 	out := v2.Workflow{
 		SchemaVersion: 2,
 		Name:          name,
+		Enabled:       false, // conversion is always an inactive draft
 		InitialState:  initial,
 		States:        states,
 	}

--- a/pkg/types/convert/workspace_v1_v2.go
+++ b/pkg/types/convert/workspace_v1_v2.go
@@ -1,0 +1,312 @@
+package convert
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	v2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
+	"gopkg.in/yaml.v3"
+)
+
+// v1WorkspaceRaw captures authored v1 workspace fields, including keys that
+// are not all present on types.WorkspaceConfig (provider/nix/docker).
+type v1WorkspaceRaw struct {
+	SchemaVersion  interface{}           `yaml:"schema_version"`
+	Name           string                `yaml:"name"`
+	Provider       string                `yaml:"provider"`
+	Nix            *bool                 `yaml:"nix"`
+	Docker         *bool                 `yaml:"docker"`
+	Repositories   []v1RepoEntry         `yaml:"repositories"`
+	Env            map[string]v1EnvEntry `yaml:"env"`
+	Secrets        []string              `yaml:"secrets"`
+	WebhookSecrets []string              `yaml:"webhook_secrets"`
+	SecretRefs     map[string]string     `yaml:"secret_refs"`
+}
+
+// v1RepoEntry accepts list form {repo, permissions} or will be filled from scalars.
+type v1RepoEntry struct {
+	Repo        string `yaml:"repo"`
+	Permissions string `yaml:"permissions"`
+	// When unmarshaling shorthand list items, Repo is set via custom logic below.
+	raw string
+}
+
+type v1EnvEntry struct {
+	Value  string `yaml:"value"`
+	Secret string `yaml:"secret"`
+	// Inline scalar form is handled by UnmarshalYAML.
+	inline string
+}
+
+func (e *v1EnvEntry) UnmarshalYAML(value *yaml.Node) error {
+	if value == nil {
+		return nil
+	}
+	if value.Kind == yaml.ScalarNode {
+		e.inline = value.Value
+		e.Value = value.Value
+		return nil
+	}
+	type plain v1EnvEntry
+	var p plain
+	if err := value.Decode(&p); err != nil {
+		return err
+	}
+	*e = v1EnvEntry(p)
+	return nil
+}
+
+func convertWorkspaceV1ToV2(data []byte, opts Options) (Result, error) {
+	var warnings []string
+
+	// Parse repositories with flexible list items (string or object).
+	var probe map[string]interface{}
+	if err := yaml.Unmarshal(data, &probe); err != nil {
+		return Result{}, fmt.Errorf("parse workspace: %w", err)
+	}
+
+	var raw v1WorkspaceRaw
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return Result{}, fmt.Errorf("parse workspace: %w", err)
+	}
+	// Re-parse repositories from probe for shorthand strings.
+	repos, repoWarns := parseV1Repositories(probe["repositories"])
+	warnings = append(warnings, repoWarns...)
+
+	name := strings.TrimSpace(raw.Name)
+	if name == "" {
+		return Result{}, fmt.Errorf("workspace name is required")
+	}
+
+	out := v2.Workspace{
+		SchemaVersion: 2,
+		Name:          name,
+		Repositories:  map[string]v2.Repository{},
+		Credentials:   map[string]v2.Credential{},
+	}
+
+	// Source-control connection: one default github connection when any repo present.
+	const defaultSC = "github-default"
+	if len(repos) > 0 {
+		out.SourceControl = &v2.SourceControlBlock{
+			Connections: map[string]v2.Connection{
+				defaultSC: {
+					Provider: "github",
+				},
+			},
+		}
+		appendWarning(&warnings, "source_control.connections.%s: created as a placeholder; set credentials to a GitHub app/token secret ref", defaultSC)
+	}
+
+	// Repositories → named map entries.
+	usedNames := map[string]int{}
+	for _, r := range repos {
+		repo := strings.TrimSpace(r.Repo)
+		if repo == "" {
+			continue
+		}
+		if strings.Contains(repo, "*") {
+			appendWarning(&warnings, "repositories %q: glob patterns are not expressible as a v2 named repository; skipped — configure repositories explicitly", repo)
+			continue
+		}
+		key := repoResourceName(repo, usedNames)
+		out.Repositories[key] = v2.Repository{
+			Provider:      "github",
+			Repository:    repo,
+			SourceControl: defaultSC,
+		}
+		if perms := strings.TrimSpace(r.Permissions); perms != "" && perms != "read" {
+			appendWarning(&warnings, "repositories.%s: v1 permissions %q are not modeled on workspace v2 repositories (access is connection/credential scoped)", key, perms)
+		}
+	}
+
+	// Execution from provider/nix/docker.
+	if raw.Provider != "" || raw.Nix != nil || raw.Docker != nil {
+		exec := &v2.Execution{Provider: strings.TrimSpace(raw.Provider)}
+		if raw.Nix != nil {
+			exec.Nix = *raw.Nix
+		}
+		if raw.Docker != nil {
+			exec.Docker = *raw.Docker
+		}
+		out.Execution = exec
+	}
+
+	// Env secret refs → credentials; inline values cannot live in v2 workspace schema.
+	for envName, entry := range raw.Env {
+		secret := strings.TrimSpace(entry.Secret)
+		if secret != "" {
+			credName := credentialName(secret, envName)
+			if _, exists := out.Credentials[credName]; !exists {
+				out.Credentials[credName] = v2.Credential{Secret: secret}
+			}
+			appendWarning(&warnings, "env.%s: secret ref mapped to credentials.%s (secret: %s); runtime env wiring is not part of workspace v2 schema and must be configured separately if still required", envName, credName, secret)
+			continue
+		}
+		if strings.TrimSpace(entry.Value) != "" || strings.TrimSpace(entry.inline) != "" {
+			appendWarning(&warnings, "env.%s: inline value dropped — workspace v2 does not embed environment values; configure via execution/runtime outside the workspace document if needed", envName)
+		}
+	}
+
+	// Top-level secrets / secret_refs / webhook_secrets.
+	for _, s := range raw.Secrets {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		credName := credentialName(s, s)
+		if _, exists := out.Credentials[credName]; !exists {
+			out.Credentials[credName] = v2.Credential{Secret: s}
+		}
+	}
+	for envName, secretName := range raw.SecretRefs {
+		secretName = strings.TrimSpace(secretName)
+		if secretName == "" {
+			continue
+		}
+		credName := credentialName(secretName, envName)
+		if _, exists := out.Credentials[credName]; !exists {
+			out.Credentials[credName] = v2.Credential{Secret: secretName}
+		}
+		appendWarning(&warnings, "secret_refs.%s: mapped to credentials.%s", envName, credName)
+	}
+	if len(raw.WebhookSecrets) > 0 {
+		appendWarning(&warnings, "webhook_secrets: not represented in workspace v2 schema yet; configure webhook authentication on the hub separately (%d ref(s) dropped)", len(raw.WebhookSecrets))
+	}
+
+	// Empty CI / issue trackers / review blocks are omitted; warn that CI must be added manually.
+	appendWarning(&warnings, "ci.connections/pipelines: not inferred from v1 — add named CI connections and pipelines manually (GitHub Actions, Depot, Jenkins, …)")
+	appendWarning(&warnings, "issue_trackers/review_systems: not inferred from v1 — add connections when you need Linear/GitHub review evidence")
+
+	// Attach credentials to default source_control if we have an obvious github cred.
+	if out.SourceControl != nil {
+		if cred := pickGitHubCredential(out.Credentials); cred != "" {
+			c := out.SourceControl.Connections[defaultSC]
+			c.Credentials = cred
+			out.SourceControl.Connections[defaultSC] = c
+		} else {
+			appendWarning(&warnings, "source_control.connections.%s.credentials: unset — add a credentials.* entry and reference it", defaultSC)
+		}
+	}
+
+	// Drop empty maps for cleaner YAML.
+	if len(out.Credentials) == 0 {
+		out.Credentials = nil
+	}
+	if len(out.Repositories) == 0 {
+		out.Repositories = nil
+		out.SourceControl = nil
+	}
+
+	if shouldValidate(opts) {
+		// Re-marshal then parse+validate through the real v2 path.
+		tmp, err := yaml.Marshal(out)
+		if err != nil {
+			return Result{}, err
+		}
+		if _, err := v2.ParseAndValidateWorkspace(tmp); err != nil {
+			return Result{}, fmt.Errorf("converted workspace failed v2 validation: %w", err)
+		}
+	}
+
+	encoded, err := yaml.Marshal(out)
+	if err != nil {
+		return Result{}, fmt.Errorf("marshal workspace v2: %w", err)
+	}
+	if len(encoded) == 0 || encoded[len(encoded)-1] != '\n' {
+		encoded = append(encoded, '\n')
+	}
+
+	// Stable warning order for tests.
+	sort.Strings(warnings)
+
+	return Result{
+		Output:   encoded,
+		From:     "v1",
+		To:       "2",
+		Warnings: warnings,
+	}, nil
+}
+
+func parseV1Repositories(raw interface{}) ([]v1RepoEntry, []string) {
+	var warnings []string
+	list, ok := raw.([]interface{})
+	if !ok || len(list) == 0 {
+		return nil, nil
+	}
+	var out []v1RepoEntry
+	for i, item := range list {
+		switch v := item.(type) {
+		case string:
+			out = append(out, v1RepoEntry{Repo: strings.TrimSpace(v), Permissions: "read"})
+		case map[string]interface{}:
+			repo, _ := v["repo"].(string)
+			perms, _ := v["permissions"].(string)
+			if perms == "" {
+				perms = "read"
+			}
+			out = append(out, v1RepoEntry{Repo: strings.TrimSpace(repo), Permissions: perms})
+		default:
+			warnings = append(warnings, fmt.Sprintf("repositories[%d]: unrecognized entry, skipped", i))
+		}
+	}
+	return out, warnings
+}
+
+var nonResourceChars = regexp.MustCompile(`[^a-zA-Z0-9_.-]+`)
+
+func repoResourceName(repo string, used map[string]int) string {
+	base := strings.ToLower(repo)
+	base = strings.ReplaceAll(base, "/", "-")
+	base = nonResourceChars.ReplaceAllString(base, "-")
+	base = strings.Trim(base, "-.")
+	if base == "" {
+		base = "repo"
+	}
+	if !regexp.MustCompile(`^[A-Za-z0-9]`).MatchString(base) {
+		base = "r-" + base
+	}
+	n := used[base]
+	used[base] = n + 1
+	if n == 0 {
+		return base
+	}
+	return fmt.Sprintf("%s-%d", base, n+1)
+}
+
+func credentialName(secret, fallback string) string {
+	s := strings.TrimSpace(secret)
+	if s == "" {
+		s = fallback
+	}
+	s = strings.ToLower(s)
+	s = nonResourceChars.ReplaceAllString(s, "_")
+	s = strings.Trim(s, "_")
+	if s == "" {
+		return "credential"
+	}
+	// resource names allow [A-Za-z0-9][A-Za-z0-9_.-]*
+	if !regexp.MustCompile(`^[A-Za-z0-9]`).MatchString(s) {
+		s = "c_" + s
+	}
+	return s
+}
+
+func pickGitHubCredential(creds map[string]v2.Credential) string {
+	// Prefer names that look like GitHub app keys.
+	preferred := []string{"github_app", "github_app_private_key", "github_token", "gh_token"}
+	for _, p := range preferred {
+		if _, ok := creds[p]; ok {
+			return p
+		}
+	}
+	for name, c := range creds {
+		sec := strings.ToUpper(c.Secret)
+		if strings.Contains(sec, "GITHUB") || strings.Contains(strings.ToUpper(name), "GITHUB") || strings.Contains(strings.ToUpper(name), "GH_") {
+			return name
+		}
+	}
+	return ""
+}

--- a/pkg/types/v2/capabilities.go
+++ b/pkg/types/v2/capabilities.go
@@ -1,0 +1,96 @@
+package v2
+
+// ConnectionCapability names operational capabilities a connection may expose.
+// Workspace YAML may only restrict (set false); it cannot invent or enable
+// capabilities beyond the provider capability model.
+type ConnectionCapability string
+
+const (
+	CapObserveRuns   ConnectionCapability = "observe_runs"
+	CapObserveChecks ConnectionCapability = "observe_checks"
+	CapTriggerRun    ConnectionCapability = "trigger_run"
+	CapRetryRun      ConnectionCapability = "retry_run"
+	CapCancelRun     ConnectionCapability = "cancel_run"
+	CapFetchLogs     ConnectionCapability = "fetch_logs"
+	CapReconcile     ConnectionCapability = "reconcile"
+)
+
+// AllConnectionCapabilities is the full set used by CI-style connections.
+var AllConnectionCapabilities = []ConnectionCapability{
+	CapObserveRuns,
+	CapObserveChecks,
+	CapTriggerRun,
+	CapRetryRun,
+	CapCancelRun,
+	CapFetchLogs,
+	CapReconcile,
+}
+
+// Effect operations that require a resolved connection capability.
+const (
+	EffectCITrigger = "ci.trigger"
+	EffectCIRetry   = "ci.retry"
+	EffectCICancel  = "ci.cancel"
+)
+
+// ProviderCapabilities returns the default capability set for a provider type.
+// Unknown providers get no capabilities (effects that need them will fail validation).
+func ProviderCapabilities(provider string) map[ConnectionCapability]bool {
+	out := map[ConnectionCapability]bool{}
+	switch provider {
+	case "github_actions", "depot", "jenkins":
+		for _, c := range AllConnectionCapabilities {
+			out[c] = true
+		}
+	case "github":
+		// Source-control / review providers: observe-oriented defaults only.
+		out[CapObserveRuns] = true
+		out[CapObserveChecks] = true
+		out[CapFetchLogs] = true
+		out[CapReconcile] = true
+	case "linear", "greptile":
+		out[CapObserveRuns] = true
+		out[CapReconcile] = true
+	default:
+		// Unknown: empty; server may grant later; workspace cannot invent.
+	}
+	return out
+}
+
+// ResolveCapabilities intersects provider defaults with workspace restrictions.
+// Restrictions may only set a capability to false; setting true when the
+// provider lacks it is rejected by validation before this is used.
+func ResolveCapabilities(provider string, restrictions map[string]bool) map[ConnectionCapability]bool {
+	base := ProviderCapabilities(provider)
+	resolved := make(map[ConnectionCapability]bool, len(base))
+	for c, allowed := range base {
+		resolved[c] = allowed
+	}
+	for name, enabled := range restrictions {
+		cap := ConnectionCapability(name)
+		if !enabled {
+			// Narrow: always allowed to set false.
+			resolved[cap] = false
+			continue
+		}
+		// Enabling is only valid if provider already supports it.
+		if base[cap] {
+			resolved[cap] = true
+		}
+	}
+	return resolved
+}
+
+// CapabilityForEffect maps a structured effect operation to the capability it needs.
+func CapabilityForEffect(op string) (ConnectionCapability, bool) {
+	switch op {
+	case EffectCITrigger:
+		return CapTriggerRun, true
+	case EffectCIRetry:
+		return CapRetryRun, true
+	case EffectCICancel:
+		return CapCancelRun, true
+	default:
+		return "", false
+	}
+}

--- a/pkg/types/v2/control.go
+++ b/pkg/types/v2/control.go
@@ -1,0 +1,302 @@
+package v2
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	ControlProtocolVersion = 2
+	ProtocolConversationV1 = "conversation.v1"
+	ProtocolControlV2      = "control.v2"
+)
+
+// ControlMessageKind identifies a typed control-plane operation. Conversation
+// messages are deliberately absent: freeform text is never a v2 control input.
+type ControlMessageKind string
+
+const (
+	MessageWorkflowSync       ControlMessageKind = "workflow.sync"
+	MessageAgentTaskAssign    ControlMessageKind = "agent.task.assign"
+	MessageAgentTaskCancel    ControlMessageKind = "agent.task.cancel"
+	MessageArtifactRequest    ControlMessageKind = "artifact.request"
+	MessageCheckpointRequest  ControlMessageKind = "checkpoint.request"
+	MessageRunSuspend         ControlMessageKind = "run.suspend"
+	MessageRunResume          ControlMessageKind = "run.resume"
+	MessageRunTerminate       ControlMessageKind = "run.terminate"
+	MessageAgentTaskStarted   ControlMessageKind = "agent.task.started"
+	MessageAgentTaskHeartbeat ControlMessageKind = "agent.task.heartbeat"
+	MessageAgentTaskCompleted ControlMessageKind = "agent.task.completed"
+	MessageAgentTaskFailed    ControlMessageKind = "agent.task.failed"
+	MessagePlanSubmitted      ControlMessageKind = "plan.submitted"
+	MessageDeliverySubmitted  ControlMessageKind = "delivery.submitted"
+	MessagePullRequestClaimed ControlMessageKind = "pull_request.claimed"
+	MessageHelpRequested      ControlMessageKind = "help.requested"
+)
+
+type ControlDirection string
+
+const (
+	DirectionHubToClaw ControlDirection = "hub_to_claw"
+	DirectionClawToHub ControlDirection = "claw_to_hub"
+)
+
+// ControlEnvelope carries the durable identity required for authentication,
+// deduplication, causality, and compare-and-swap state changes. Payload is
+// decoded only after the kind and direction have been accepted.
+type ControlEnvelope struct {
+	ProtocolVersion      int                `json:"protocol_version"`
+	MessageID            string             `json:"message_id"`
+	Kind                 ControlMessageKind `json:"kind"`
+	RunID                string             `json:"run_id"`
+	AttemptID            string             `json:"attempt_id,omitempty"`
+	TaskID               string             `json:"task_id,omitempty"`
+	ExpectedStateVersion *uint64            `json:"expected_state_version,omitempty"`
+	CausationID          string             `json:"causation_id,omitempty"`
+	SentAt               time.Time          `json:"sent_at,omitempty"`
+	Payload              json.RawMessage    `json:"payload,omitempty"`
+}
+
+// ControlDisposition is durably recorded for every received control message.
+type ControlDisposition string
+
+const (
+	DispositionAccepted     ControlDisposition = "accepted"
+	DispositionDuplicate    ControlDisposition = "duplicate"
+	DispositionStaleState   ControlDisposition = "stale_state"
+	DispositionRejected     ControlDisposition = "rejected"
+	DispositionUnauthorized ControlDisposition = "unauthorized"
+)
+
+type ControlReceipt struct {
+	MessageID    string             `json:"message_id"`
+	Disposition  ControlDisposition `json:"disposition"`
+	StateVersion uint64             `json:"state_version"`
+	Reason       string             `json:"reason,omitempty"`
+}
+
+// WorkflowEvent is the durable input record consumed by the v2 engine. Its
+// payload is typed by Kind; freeform conversation messages have no producer in
+// this event model.
+type WorkflowEvent struct {
+	ID                   string                 `json:"id"`
+	RunID                string                 `json:"run_id"`
+	Kind                 string                 `json:"kind"`
+	ExpectedStateVersion *uint64                `json:"expected_state_version,omitempty"`
+	CausationID          string                 `json:"causation_id,omitempty"`
+	Provenance           EvidenceProvenance     `json:"provenance"`
+	Payload              map[string]interface{} `json:"payload,omitempty"`
+	Disposition          ControlDisposition     `json:"disposition,omitempty"`
+	ReceivedAt           time.Time              `json:"received_at"`
+}
+
+var hubToClawKinds = map[ControlMessageKind]bool{
+	MessageWorkflowSync: true, MessageAgentTaskAssign: true,
+	MessageAgentTaskCancel: true, MessageArtifactRequest: true,
+	MessageCheckpointRequest: true, MessageRunSuspend: true,
+	MessageRunResume: true, MessageRunTerminate: true,
+}
+
+var clawToHubKinds = map[ControlMessageKind]bool{
+	MessageAgentTaskStarted: true, MessageAgentTaskHeartbeat: true,
+	MessageAgentTaskCompleted: true, MessageAgentTaskFailed: true,
+	MessagePlanSubmitted: true, MessageDeliverySubmitted: true,
+	MessagePullRequestClaimed: true, MessageHelpRequested: true,
+}
+
+var stateChangingKinds = map[ControlMessageKind]bool{
+	MessageRunSuspend: true, MessageRunResume: true, MessageRunTerminate: true,
+	MessageAgentTaskStarted: true, MessageAgentTaskCompleted: true,
+	MessageAgentTaskFailed: true, MessagePlanSubmitted: true,
+	MessageDeliverySubmitted: true, MessagePullRequestClaimed: true,
+}
+
+var taskKinds = map[ControlMessageKind]bool{
+	MessageAgentTaskAssign: true, MessageAgentTaskCancel: true,
+	MessageAgentTaskStarted: true, MessageAgentTaskHeartbeat: true,
+	MessageAgentTaskCompleted: true, MessageAgentTaskFailed: true,
+}
+
+// ValidateControlEnvelope rejects unknown protocol versions, missing durable
+// identities, and messages sent in the wrong direction.
+func ValidateControlEnvelope(envelope ControlEnvelope, direction ControlDirection) error {
+	if envelope.ProtocolVersion != ControlProtocolVersion {
+		return fmt.Errorf("unsupported control protocol version %d", envelope.ProtocolVersion)
+	}
+	if strings.TrimSpace(envelope.MessageID) == "" {
+		return fmt.Errorf("message_id is required")
+	}
+	if strings.TrimSpace(envelope.RunID) == "" {
+		return fmt.Errorf("run_id is required")
+	}
+	var allowed bool
+	switch direction {
+	case DirectionHubToClaw:
+		allowed = hubToClawKinds[envelope.Kind]
+	case DirectionClawToHub:
+		allowed = clawToHubKinds[envelope.Kind]
+	default:
+		return fmt.Errorf("unsupported control direction %q", direction)
+	}
+	if !allowed {
+		return fmt.Errorf("message kind %q is not allowed for direction %s", envelope.Kind, direction)
+	}
+	if direction == DirectionClawToHub && strings.TrimSpace(envelope.AttemptID) == "" {
+		return fmt.Errorf("attempt_id is required for claw-to-hub messages")
+	}
+	if taskKinds[envelope.Kind] && strings.TrimSpace(envelope.TaskID) == "" {
+		return fmt.Errorf("task_id is required for message kind %q", envelope.Kind)
+	}
+	if stateChangingKinds[envelope.Kind] && envelope.ExpectedStateVersion == nil {
+		return fmt.Errorf("expected_state_version is required for state-changing message kind %q", envelope.Kind)
+	}
+	return nil
+}
+
+// BridgeRegistration advertises protocols separately from optional feature
+// capabilities so a hub can reject a v2 run before provisioning an old bridge.
+type BridgeRegistration struct {
+	BridgeVersion string   `json:"bridge_version"`
+	Protocols     []string `json:"protocols"`
+	Capabilities  []string `json:"capabilities,omitempty"`
+}
+
+func (r BridgeRegistration) SupportsProtocol(protocol string) bool {
+	for _, candidate := range r.Protocols {
+		if candidate == protocol {
+			return true
+		}
+	}
+	return false
+}
+
+// ValidateBridgeForWorkflow enforces the rolling-upgrade compatibility
+// matrix. V1 remains compatible with old and new bridges; v2 requires the
+// dedicated typed control protocol.
+func ValidateBridgeForWorkflow(schemaVersion string, registration BridgeRegistration) error {
+	if !IsV2(schemaVersion) {
+		return nil
+	}
+	if !registration.SupportsProtocol(ProtocolControlV2) {
+		return fmt.Errorf("workflow schema v2 requires bridge protocol %s", ProtocolControlV2)
+	}
+	return nil
+}
+
+type AgentTaskStatus string
+
+const (
+	AgentTaskAssigned  AgentTaskStatus = "assigned"
+	AgentTaskRunning   AgentTaskStatus = "running"
+	AgentTaskCompleted AgentTaskStatus = "completed"
+	AgentTaskFailed    AgentTaskStatus = "failed"
+	AgentTaskCancelled AgentTaskStatus = "cancelled"
+	AgentTaskTimedOut  AgentTaskStatus = "timed_out"
+)
+
+// AgentTask is a durable long-running effect attached to a run attempt.
+type AgentTask struct {
+	ID                string          `json:"id"`
+	RunID             string          `json:"run_id"`
+	AttemptID         string          `json:"attempt_id"`
+	State             string          `json:"state"`
+	StateVersion      uint64          `json:"state_version"`
+	Status            AgentTaskStatus `json:"status"`
+	Instructions      string          `json:"instructions"`
+	AllowedActions    []string        `json:"allowed_actions,omitempty"`
+	RequiredArtifacts []string        `json:"required_artifacts,omitempty"`
+	HeartbeatDeadline time.Time       `json:"heartbeat_deadline"`
+	Deadline          time.Time       `json:"deadline"`
+}
+
+func (s AgentTaskStatus) Terminal() bool {
+	switch s {
+	case AgentTaskCompleted, AgentTaskFailed, AgentTaskCancelled, AgentTaskTimedOut:
+		return true
+	default:
+		return false
+	}
+}
+
+// WorkflowSnapshot is sent on registration/reconnect. The hub owns these
+// values; a claw may request actions but cannot assign its own workflow state.
+type WorkflowSnapshot struct {
+	RunID             string                `json:"run_id"`
+	AttemptID         string                `json:"attempt_id,omitempty"`
+	State             string                `json:"state"`
+	DisplayPhase      DisplayPhase          `json:"display_phase"`
+	StateVersion      uint64                `json:"state_version"`
+	CurrentTask       *AgentTask            `json:"current_task,omitempty"`
+	AllowedActions    []string              `json:"allowed_actions,omitempty"`
+	RequiredArtifacts []string              `json:"required_artifacts,omitempty"`
+	ContextBundle     *ContextBundleRef     `json:"context_bundle,omitempty"`
+	Delivery          []VerifiedPullRequest `json:"delivery,omitempty"`
+}
+
+// EvidenceProvenance identifies who observed a fact and through which trusted
+// adapter. Agent observations can be recorded but cannot populate protected
+// fact namespaces.
+type EvidenceProvenance struct {
+	Producer   string    `json:"producer"`
+	Connection string    `json:"connection,omitempty"`
+	Principal  string    `json:"principal,omitempty"`
+	ObservedAt time.Time `json:"observed_at"`
+	ExternalID string    `json:"external_id,omitempty"`
+	Reconciled bool      `json:"reconciled,omitempty"`
+}
+
+type ContextBundleRef struct {
+	ID       string `json:"id"`
+	Revision string `json:"revision"`
+}
+
+// ContextBundle records the exact source revisions/results supplied to a run.
+type ContextBundle struct {
+	ID        string                `json:"id"`
+	RunID     string                `json:"run_id"`
+	Revision  string                `json:"revision"`
+	CreatedAt time.Time             `json:"created_at"`
+	Sources   []ContextBundleSource `json:"sources"`
+}
+
+type ContextBundleSource struct {
+	Name           string   `json:"name"`
+	Type           string   `json:"type"`
+	Scope          string   `json:"scope"`
+	Required       bool     `json:"required"`
+	Status         string   `json:"status"`
+	SourceRevision string   `json:"source_revision,omitempty"`
+	ContentDigest  string   `json:"content_digest,omitempty"`
+	Documents      []string `json:"documents,omitempty"`
+	Error          string   `json:"error,omitempty"`
+}
+
+// DeliveryManifest is the untrusted claw submission. URLs are claims until the
+// hub resolves and verifies them through workspace source-control connections.
+type DeliveryManifest struct {
+	PullRequests []PullRequestClaim `json:"pull_requests,omitempty"`
+}
+
+type PullRequestClaim struct {
+	URL        string `json:"url"`
+	Supersedes string `json:"supersedes,omitempty"`
+}
+
+// VerifiedPullRequest is the authoritative, append-only delivery subject
+// derived by the hub. Evidence is always tied to HeadSHA.
+type VerifiedPullRequest struct {
+	ID             string             `json:"id"`
+	URL            string             `json:"url"`
+	Repository     string             `json:"repository"`
+	RepositoryName string             `json:"repository_name"`
+	Number         int                `json:"number"`
+	SourceBranch   string             `json:"source_branch"`
+	BaseBranch     string             `json:"base_branch"`
+	HeadSHA        string             `json:"head_sha"`
+	State          string             `json:"state"`
+	Supersedes     string             `json:"supersedes,omitempty"`
+	VerifiedAt     time.Time          `json:"verified_at"`
+	Provenance     EvidenceProvenance `json:"provenance"`
+}

--- a/pkg/types/v2/control_test.go
+++ b/pkg/types/v2/control_test.go
@@ -1,0 +1,68 @@
+package v2_test
+
+import (
+	"strings"
+	"testing"
+
+	v2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
+)
+
+func stateVersion(version uint64) *uint64 { return &version }
+
+func TestControlEnvelopeRequiresTypedDirectionAndStateVersion(t *testing.T) {
+	valid := v2.ControlEnvelope{
+		ProtocolVersion:      v2.ControlProtocolVersion,
+		MessageID:            "message-1",
+		Kind:                 v2.MessageAgentTaskCompleted,
+		RunID:                "run-1",
+		AttemptID:            "attempt-1",
+		TaskID:               "task-1",
+		ExpectedStateVersion: stateVersion(7),
+	}
+	if err := v2.ValidateControlEnvelope(valid, v2.DirectionClawToHub); err != nil {
+		t.Fatalf("valid envelope: %v", err)
+	}
+
+	wrongDirection := valid
+	if err := v2.ValidateControlEnvelope(wrongDirection, v2.DirectionHubToClaw); err == nil || !strings.Contains(err.Error(), "not allowed") {
+		t.Fatalf("wrong direction error = %v", err)
+	}
+
+	staleUnsafe := valid
+	staleUnsafe.ExpectedStateVersion = nil
+	if err := v2.ValidateControlEnvelope(staleUnsafe, v2.DirectionClawToHub); err == nil || !strings.Contains(err.Error(), "expected_state_version") {
+		t.Fatalf("missing state version error = %v", err)
+	}
+}
+
+func TestControlCatalogContainsNoConversationMessages(t *testing.T) {
+	kinds := []v2.ControlMessageKind{
+		v2.MessageWorkflowSync,
+		v2.MessageAgentTaskAssign,
+		v2.MessageAgentTaskCompleted,
+		v2.MessageDeliverySubmitted,
+	}
+	for _, kind := range kinds {
+		if strings.Contains(string(kind), "message") || strings.Contains(string(kind), "conversation") {
+			t.Fatalf("control kind %q crosses conversation boundary", kind)
+		}
+	}
+}
+
+func TestBridgeCompatibilityMatrix(t *testing.T) {
+	oldBridge := v2.BridgeRegistration{Protocols: []string{v2.ProtocolConversationV1}}
+	newBridge := v2.BridgeRegistration{Protocols: []string{v2.ProtocolConversationV1, v2.ProtocolControlV2}}
+
+	if err := v2.ValidateBridgeForWorkflow("v1", oldBridge); err != nil {
+		t.Fatalf("old bridge + v1: %v", err)
+	}
+	if err := v2.ValidateBridgeForWorkflow("v1", newBridge); err != nil {
+		t.Fatalf("new bridge + v1: %v", err)
+	}
+	if err := v2.ValidateBridgeForWorkflow("2", newBridge); err != nil {
+		t.Fatalf("new bridge + v2: %v", err)
+	}
+	if err := v2.ValidateBridgeForWorkflow("2", oldBridge); err == nil || !strings.Contains(err.Error(), v2.ProtocolControlV2) {
+		t.Fatalf("old bridge + v2 error = %v", err)
+	}
+}

--- a/pkg/types/v2/predicates.go
+++ b/pkg/types/v2/predicates.go
@@ -1,0 +1,529 @@
+package v2
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Restricted predicate operators allowed in event-clause `when` trees.
+var allowedPredicateOps = map[string]bool{
+	"equals":     true,
+	"not_equals": true,
+	"in":         true,
+	"not_in":     true,
+	"exists":     true,
+	"all":        true,
+	"any":        true,
+}
+
+// ValidatePredicateTree walks a when/assert-style map and ensures only the
+// restricted predicate language is used at operator positions.
+// Field maps like {conclusion: {equals: success}} are allowed.
+func ValidatePredicateTree(path string, tree map[string]interface{}) error {
+	if tree == nil {
+		return nil
+	}
+	return validatePredicateNode(path, tree)
+}
+
+func validatePredicateNode(path string, node interface{}) error {
+	switch n := node.(type) {
+	case map[string]interface{}:
+		// Either a logical combinator (all/any) or a field -> constraint map,
+		// or a single operator map (equals/in/…).
+		if len(n) == 1 {
+			for k, v := range n {
+				if allowedPredicateOps[k] {
+					return validateOperator(path+"."+k, k, v)
+				}
+				// field name -> nested constraint
+				return validatePredicateNode(path+"."+k, v)
+			}
+		}
+		// Multiple keys: treat as all-of field constraints unless they are all/any only.
+		hasAll := false
+		hasAny := false
+		for k, v := range n {
+			if k == "all" {
+				hasAll = true
+				if err := validateOperator(path+".all", "all", v); err != nil {
+					return err
+				}
+				continue
+			}
+			if k == "any" {
+				hasAny = true
+				if err := validateOperator(path+".any", "any", v); err != nil {
+					return err
+				}
+				continue
+			}
+			if allowedPredicateOps[k] && k != "all" && k != "any" {
+				// Multiple top-level ops without field context — allow equals-style only alone.
+				return fmt.Errorf("%s: multiple top-level predicate operators without field context", path)
+			}
+			if err := validatePredicateNode(path+"."+k, v); err != nil {
+				return err
+			}
+		}
+		_ = hasAll
+		_ = hasAny
+		return nil
+	case []interface{}:
+		for i, item := range n {
+			if err := validatePredicateNode(fmt.Sprintf("%s[%d]", path, i), item); err != nil {
+				return err
+			}
+		}
+		return nil
+	default:
+		// Scalar leaf (used as equals value) — ok at leaves.
+		return nil
+	}
+}
+
+func validateOperator(path, op string, value interface{}) error {
+	if !allowedPredicateOps[op] {
+		return fmt.Errorf("%s: unsupported predicate operator %q (allowed: equals, not_equals, in, not_in, exists, all, any)", path, op)
+	}
+	switch op {
+	case "equals", "not_equals":
+		// any scalar
+		return nil
+	case "in", "not_in":
+		list, ok := value.([]interface{})
+		if !ok {
+			return fmt.Errorf("%s: %s requires a list", path, op)
+		}
+		if len(list) == 0 {
+			return fmt.Errorf("%s: %s list cannot be empty", path, op)
+		}
+		return nil
+	case "exists":
+		switch value.(type) {
+		case bool, nil:
+			return nil
+		default:
+			return fmt.Errorf("%s: exists requires a boolean", path)
+		}
+	case "all", "any":
+		list, ok := value.([]interface{})
+		if !ok {
+			return fmt.Errorf("%s: %s requires a list of predicates", path, op)
+		}
+		for i, item := range list {
+			if err := validatePredicateNode(fmt.Sprintf("%s[%d]", path, i), item); err != nil {
+				return err
+			}
+		}
+		return nil
+	default:
+		return fmt.Errorf("%s: unsupported predicate operator %q", path, op)
+	}
+}
+
+// fieldConstraint is a simplified constraint on one field for overlap analysis.
+type fieldConstraint struct {
+	// kind: equals | not_equals | in | not_in | exists | unknown
+	kind   string
+	equals interface{}
+	set    map[string]struct{} // for in/not_in; stringified values
+	exists *bool
+}
+
+// OverlapWitness describes a concrete value that satisfies two clauses.
+type OverlapWitness struct {
+	Field string
+	Value string
+}
+
+// ClausesOverlap reports whether two when-predicate trees may both match the
+// same payload. If analysis cannot prove disjointness, they are treated as
+// overlapping (conservative).
+func ClausesOverlap(a, b map[string]interface{}) (bool, *OverlapWitness) {
+	if len(a) == 0 && len(b) == 0 {
+		return true, &OverlapWitness{Field: "*", Value: "<empty>"}
+	}
+	// Flatten field constraints from both trees.
+	fa := collectFieldConstraints(a)
+	fb := collectFieldConstraints(b)
+
+	// If either tree uses unknown structure (combinators we cannot flatten),
+	// treat as overlapping.
+	if fa == nil || fb == nil {
+		return true, &OverlapWitness{Field: "*", Value: "<unanalyzable>"}
+	}
+
+	// Fields only in one side do not prevent overlap.
+	// For each field present in both, constraints must be pairwise satisfiable.
+	// Also synthesize a witness value for one shared field when possible.
+	var witness *OverlapWitness
+	for field, ca := range fa {
+		cb, ok := fb[field]
+		if !ok {
+			continue
+		}
+		okOverlap, w := constraintsOverlap(field, ca, cb)
+		if !okOverlap {
+			return false, nil
+		}
+		if witness == nil && w != nil {
+			witness = w
+		}
+	}
+	if witness == nil {
+		// No conflicting fields; pick any constraint value as witness.
+		for field, ca := range fa {
+			if s := witnessFromConstraint(field, ca); s != nil {
+				witness = s
+				break
+			}
+		}
+		if witness == nil {
+			for field, cb := range fb {
+				if s := witnessFromConstraint(field, cb); s != nil {
+					witness = s
+					break
+				}
+			}
+		}
+		if witness == nil {
+			witness = &OverlapWitness{Field: "*", Value: "<any>"}
+		}
+	}
+	return true, witness
+}
+
+func collectFieldConstraints(tree map[string]interface{}) map[string]fieldConstraint {
+	out := map[string]fieldConstraint{}
+	if !flattenPredicates("", tree, out) {
+		return nil
+	}
+	return out
+}
+
+// flattenPredicates extracts field-level constraints. Returns false if unanalyzable.
+func flattenPredicates(prefix string, node interface{}, out map[string]fieldConstraint) bool {
+	m, ok := node.(map[string]interface{})
+	if !ok {
+		return true
+	}
+	// Logical all: conjunction — merge all children.
+	if all, ok := m["all"]; ok && len(m) == 1 {
+		list, ok := all.([]interface{})
+		if !ok {
+			return false
+		}
+		for _, item := range list {
+			if !flattenPredicates(prefix, item, out) {
+				return false
+			}
+		}
+		return true
+	}
+	// any: disjunction — unanalyzable for precise overlap without DNF expansion.
+	// Conservative: mark unanalyzable so ClausesOverlap treats as overlapping.
+	if _, ok := m["any"]; ok {
+		return false
+	}
+
+	// Single operator at this level without field: unanalyzable here.
+	if len(m) == 1 {
+		for k, v := range m {
+			if allowedPredicateOps[k] {
+				// bare op without field
+				return false
+			}
+			// field -> constraint
+			field := k
+			if prefix != "" {
+				field = prefix + "." + k
+			}
+			return absorbConstraint(field, v, out)
+		}
+	}
+
+	// Multiple field keys: conjunction.
+	for k, v := range m {
+		if allowedPredicateOps[k] {
+			return false
+		}
+		field := k
+		if prefix != "" {
+			field = prefix + "." + k
+		}
+		if !absorbConstraint(field, v, out) {
+			return false
+		}
+	}
+	return true
+}
+
+func absorbConstraint(field string, node interface{}, out map[string]fieldConstraint) bool {
+	m, ok := node.(map[string]interface{})
+	if !ok {
+		// Nested object field path
+		if nested, ok := node.(map[string]interface{}); ok {
+			return flattenPredicates(field, nested, out)
+		}
+		// Treat bare scalar as equals
+		out[field] = fieldConstraint{kind: "equals", equals: node}
+		return true
+	}
+	// Nested field map without ops
+	if len(m) == 1 {
+		for k, v := range m {
+			if allowedPredicateOps[k] {
+				c, ok := parseConstraint(k, v)
+				if !ok {
+					return false
+				}
+				// Merge with existing via conjunction
+				if prev, exists := out[field]; exists {
+					merged, ok := conjoinConstraints(prev, c)
+					if !ok {
+						// Unsatisfiable self-conjunction — still store impossible? mark unanalyzable
+						return false
+					}
+					out[field] = merged
+				} else {
+					out[field] = c
+				}
+				return true
+			}
+			// deeper nesting
+			return flattenPredicates(field, m, out)
+		}
+	}
+	// Multiple keys under field: either multiple ops or nested fields.
+	onlyOps := true
+	for k := range m {
+		if !allowedPredicateOps[k] {
+			onlyOps = false
+			break
+		}
+	}
+	if onlyOps {
+		var acc *fieldConstraint
+		for k, v := range m {
+			c, ok := parseConstraint(k, v)
+			if !ok {
+				return false
+			}
+			if acc == nil {
+				acc = &c
+			} else {
+				merged, ok := conjoinConstraints(*acc, c)
+				if !ok {
+					return false
+				}
+				acc = &merged
+			}
+		}
+		if acc != nil {
+			out[field] = *acc
+		}
+		return true
+	}
+	return flattenPredicates(field, m, out)
+}
+
+func parseConstraint(op string, value interface{}) (fieldConstraint, bool) {
+	switch op {
+	case "equals":
+		return fieldConstraint{kind: "equals", equals: value}, true
+	case "not_equals":
+		return fieldConstraint{kind: "not_equals", equals: value}, true
+	case "in":
+		list, ok := value.([]interface{})
+		if !ok {
+			return fieldConstraint{}, false
+		}
+		set := map[string]struct{}{}
+		for _, item := range list {
+			set[stringifyValue(item)] = struct{}{}
+		}
+		return fieldConstraint{kind: "in", set: set}, true
+	case "not_in":
+		list, ok := value.([]interface{})
+		if !ok {
+			return fieldConstraint{}, false
+		}
+		set := map[string]struct{}{}
+		for _, item := range list {
+			set[stringifyValue(item)] = struct{}{}
+		}
+		return fieldConstraint{kind: "not_in", set: set}, true
+	case "exists":
+		b, ok := value.(bool)
+		if !ok {
+			return fieldConstraint{}, false
+		}
+		return fieldConstraint{kind: "exists", exists: &b}, true
+	default:
+		return fieldConstraint{}, false
+	}
+}
+
+func conjoinConstraints(a, b fieldConstraint) (fieldConstraint, bool) {
+	// Conservative: only handle simple equals ∩ equals/in.
+	if a.kind == "equals" && b.kind == "equals" {
+		if stringifyValue(a.equals) == stringifyValue(b.equals) {
+			return a, true
+		}
+		return fieldConstraint{}, false
+	}
+	if a.kind == "equals" && b.kind == "in" {
+		if _, ok := b.set[stringifyValue(a.equals)]; ok {
+			return a, true
+		}
+		return fieldConstraint{}, false
+	}
+	if b.kind == "equals" && a.kind == "in" {
+		if _, ok := a.set[stringifyValue(b.equals)]; ok {
+			return b, true
+		}
+		return fieldConstraint{}, false
+	}
+	// Otherwise treat as unanalyzable merge.
+	return fieldConstraint{kind: "unknown"}, true
+}
+
+func constraintsOverlap(field string, a, b fieldConstraint) (bool, *OverlapWitness) {
+	// unknown is always potentially overlapping
+	if a.kind == "unknown" || b.kind == "unknown" {
+		return true, &OverlapWitness{Field: field, Value: "<unknown>"}
+	}
+	// equals vs equals
+	if a.kind == "equals" && b.kind == "equals" {
+		if stringifyValue(a.equals) == stringifyValue(b.equals) {
+			return true, &OverlapWitness{Field: field, Value: stringifyValue(a.equals)}
+		}
+		return false, nil
+	}
+	// equals vs in
+	if a.kind == "equals" && b.kind == "in" {
+		if _, ok := b.set[stringifyValue(a.equals)]; ok {
+			return true, &OverlapWitness{Field: field, Value: stringifyValue(a.equals)}
+		}
+		return false, nil
+	}
+	if b.kind == "equals" && a.kind == "in" {
+		if _, ok := a.set[stringifyValue(b.equals)]; ok {
+			return true, &OverlapWitness{Field: field, Value: stringifyValue(b.equals)}
+		}
+		return false, nil
+	}
+	// equals vs not_in
+	if a.kind == "equals" && b.kind == "not_in" {
+		if _, ok := b.set[stringifyValue(a.equals)]; ok {
+			return false, nil
+		}
+		return true, &OverlapWitness{Field: field, Value: stringifyValue(a.equals)}
+	}
+	if b.kind == "equals" && a.kind == "not_in" {
+		if _, ok := a.set[stringifyValue(b.equals)]; ok {
+			return false, nil
+		}
+		return true, &OverlapWitness{Field: field, Value: stringifyValue(b.equals)}
+	}
+	// equals vs not_equals
+	if a.kind == "equals" && b.kind == "not_equals" {
+		if stringifyValue(a.equals) == stringifyValue(b.equals) {
+			return false, nil
+		}
+		return true, &OverlapWitness{Field: field, Value: stringifyValue(a.equals)}
+	}
+	if b.kind == "equals" && a.kind == "not_equals" {
+		if stringifyValue(b.equals) == stringifyValue(a.equals) {
+			return false, nil
+		}
+		return true, &OverlapWitness{Field: field, Value: stringifyValue(b.equals)}
+	}
+	// in vs in: intersection
+	if a.kind == "in" && b.kind == "in" {
+		for v := range a.set {
+			if _, ok := b.set[v]; ok {
+				return true, &OverlapWitness{Field: field, Value: v}
+			}
+		}
+		return false, nil
+	}
+	// in vs not_in
+	if a.kind == "in" && b.kind == "not_in" {
+		for v := range a.set {
+			if _, ok := b.set[v]; !ok {
+				return true, &OverlapWitness{Field: field, Value: v}
+			}
+		}
+		return false, nil
+	}
+	if b.kind == "in" && a.kind == "not_in" {
+		for v := range b.set {
+			if _, ok := a.set[v]; !ok {
+				return true, &OverlapWitness{Field: field, Value: v}
+			}
+		}
+		return false, nil
+	}
+	// not_equals / not_in / exists combinations: usually overlapping
+	return true, &OverlapWitness{Field: field, Value: "<possible>"}
+}
+
+func witnessFromConstraint(field string, c fieldConstraint) *OverlapWitness {
+	switch c.kind {
+	case "equals":
+		return &OverlapWitness{Field: field, Value: stringifyValue(c.equals)}
+	case "in":
+		vals := make([]string, 0, len(c.set))
+		for v := range c.set {
+			vals = append(vals, v)
+		}
+		sort.Strings(vals)
+		if len(vals) > 0 {
+			return &OverlapWitness{Field: field, Value: vals[0]}
+		}
+	}
+	return nil
+}
+
+func stringifyValue(v interface{}) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	case bool:
+		if t {
+			return "true"
+		}
+		return "false"
+	case int:
+		return fmt.Sprintf("%d", t)
+	case int64:
+		return fmt.Sprintf("%d", t)
+	case float64:
+		if t == float64(int64(t)) {
+			return fmt.Sprintf("%d", int64(t))
+		}
+		return fmt.Sprintf("%v", t)
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}
+
+// FormatOverlapError builds the multi-clause error text expected by the RFC.
+func FormatOverlapError(eventOrContext, state string, clausePaths []string, witness *OverlapWitness) string {
+	var b strings.Builder
+	if state != "" {
+		fmt.Fprintf(&b, "%s has overlapping clauses for state %q\n", eventOrContext, state)
+	} else {
+		fmt.Fprintf(&b, "%s has overlapping clauses\n", eventOrContext)
+	}
+	for i, p := range clausePaths {
+		fmt.Fprintf(&b, "\nclause %d path: %s", i+1, p)
+	}
+	if witness != nil {
+		fmt.Fprintf(&b, "\n\nboth clauses may match %s = %s", witness.Field, witness.Value)
+	}
+	return b.String()
+}

--- a/pkg/types/v2/predicates.go
+++ b/pkg/types/v2/predicates.go
@@ -17,6 +17,16 @@ var allowedPredicateOps = map[string]bool{
 	"any":        true,
 }
 
+// unsupportedPredicateOps are common executable or non-analyzable operators
+// that must fail loudly rather than being mistaken for nested fact names.
+var unsupportedPredicateOps = map[string]bool{
+	"regex": true, "matches": true, "match": true,
+	"contains": true, "starts_with": true, "ends_with": true,
+	"gt": true, "gte": true, "lt": true, "lte": true,
+	"script": true, "javascript": true, "js": true,
+	"shell": true, "expression": true, "expr": true,
+}
+
 // ValidatePredicateTree walks a when/assert-style map and ensures only the
 // restricted predicate language is used at operator positions.
 // Field maps like {conclusion: {equals: success}} are allowed.
@@ -30,6 +40,11 @@ func ValidatePredicateTree(path string, tree map[string]interface{}) error {
 func validatePredicateNode(path string, node interface{}) error {
 	switch n := node.(type) {
 	case map[string]interface{}:
+		for key := range n {
+			if unsupportedPredicateOps[strings.ToLower(strings.TrimSpace(key))] {
+				return fmt.Errorf("%s.%s: unsupported predicate operator %q (allowed: equals, not_equals, in, not_in, exists, all, any)", path, key, key)
+			}
+		}
 		// Either a logical combinator (all/any) or a field -> constraint map,
 		// or a single operator map (equals/in/…).
 		if len(n) == 1 {

--- a/pkg/types/v2/predicates_test.go
+++ b/pkg/types/v2/predicates_test.go
@@ -1,0 +1,53 @@
+package v2
+
+import "testing"
+
+func TestClausesOverlapEqualsVsIn(t *testing.T) {
+	a := map[string]interface{}{
+		"conclusion": map[string]interface{}{"equals": "success"},
+	}
+	b := map[string]interface{}{
+		"conclusion": map[string]interface{}{"in": []interface{}{"success", "failure"}},
+	}
+	ok, w := ClausesOverlap(a, b)
+	if !ok {
+		t.Fatal("expected overlap")
+	}
+	if w == nil || w.Value != "success" {
+		t.Fatalf("witness = %#v, want success", w)
+	}
+}
+
+func TestClausesOverlapDisjointEquals(t *testing.T) {
+	a := map[string]interface{}{
+		"conclusion": map[string]interface{}{"equals": "success"},
+	}
+	b := map[string]interface{}{
+		"conclusion": map[string]interface{}{"equals": "failure"},
+	}
+	ok, _ := ClausesOverlap(a, b)
+	if ok {
+		t.Fatal("expected no overlap")
+	}
+}
+
+func TestValidatePredicateTreeAllowsRestrictedOps(t *testing.T) {
+	tree := map[string]interface{}{
+		"all": []interface{}{
+			map[string]interface{}{"pipeline": map[string]interface{}{"equals": "depot-container"}},
+			map[string]interface{}{"conclusion": map[string]interface{}{"in": []interface{}{"failure", "cancelled"}}},
+		},
+	}
+	if err := ValidatePredicateTree("when", tree); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValidatePredicateTreeRejectsEmptyIn(t *testing.T) {
+	tree := map[string]interface{}{
+		"x": map[string]interface{}{"in": []interface{}{}},
+	}
+	if err := ValidatePredicateTree("when", tree); err == nil {
+		t.Fatal("expected error for empty in list")
+	}
+}

--- a/pkg/types/v2/revision.go
+++ b/pkg/types/v2/revision.go
@@ -1,0 +1,41 @@
+package v2
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ContentDigest is an immutable content-addressed revision of a v2 document.
+type ContentDigest string
+
+// RevisionFromCanonicalYAML returns a stable SHA-256 digest of the given
+// canonical YAML bytes. Callers should pass CanonicalYAML output so equivalent
+// documents share a revision.
+func RevisionFromCanonicalYAML(canonical []byte) ContentDigest {
+	sum := sha256.Sum256(canonical)
+	return ContentDigest(hex.EncodeToString(sum[:]))
+}
+
+// CanonicalYAML re-marshals a validated document to YAML for hashing.
+// yaml.v3 map key order is insertion order for map[string]T in recent Go;
+// we marshal through a round-trip of the already-parsed typed structs so
+// two Parse→Validate paths of the same authored document share a digest.
+func CanonicalYAML(doc interface{}) ([]byte, error) {
+	data, err := yaml.Marshal(doc)
+	if err != nil {
+		return nil, fmt.Errorf("canonical yaml: %w", err)
+	}
+	return data, nil
+}
+
+// RevisionOf returns the content digest for a validated v2 document value.
+func RevisionOf(doc interface{}) (ContentDigest, error) {
+	canonical, err := CanonicalYAML(doc)
+	if err != nil {
+		return "", err
+	}
+	return RevisionFromCanonicalYAML(canonical), nil
+}

--- a/pkg/types/v2/schema.go
+++ b/pkg/types/v2/schema.go
@@ -1,0 +1,74 @@
+// Package v2 implements workspace and workflow schema version 2 foundations
+// from RFC issue #544 (Phase 1): parse, structural validation, pair validation,
+// and immutable content revisions. V1 schemas remain in package types.
+package v2
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// SchemaVersionV2 is the canonical authored form used in issue #544 examples.
+const SchemaVersionV2 = "2"
+
+// IsV2 reports whether a schema_version value identifies workspace/workflow v2.
+// Accepts "2", 2, "v2" (case-insensitive). Does not treat "v1" or empty as v2.
+func IsV2(version string) bool {
+	v := strings.TrimSpace(strings.ToLower(version))
+	return v == "2" || v == "v2"
+}
+
+// DetectSchemaVersion reads schema_version from raw YAML without full decode.
+// Returns the normalized string form ("v1", "2", …) or empty if absent.
+func DetectSchemaVersion(data []byte) (string, error) {
+	var probe struct {
+		SchemaVersion yaml.Node `yaml:"schema_version"`
+	}
+	if err := yaml.Unmarshal(data, &probe); err != nil {
+		return "", fmt.Errorf("parse schema_version: %w", err)
+	}
+	return normalizeSchemaVersionNode(&probe.SchemaVersion), nil
+}
+
+func normalizeSchemaVersionNode(n *yaml.Node) string {
+	if n == nil || n.Kind == 0 {
+		return ""
+	}
+	switch n.Kind {
+	case yaml.ScalarNode:
+		if n.Tag == "!!int" || n.Tag == "!!float" {
+			// Keep integer form as decimal string without "v" prefix.
+			if i, err := strconv.ParseInt(n.Value, 10, 64); err == nil {
+				return strconv.FormatInt(i, 10)
+			}
+		}
+		return strings.TrimSpace(n.Value)
+	default:
+		return strings.TrimSpace(n.Value)
+	}
+}
+
+// SchemaVersionString normalizes a decoded schema_version field that may arrive
+// as string or numeric YAML into a comparable string.
+func SchemaVersionString(raw interface{}) string {
+	switch v := raw.(type) {
+	case nil:
+		return ""
+	case string:
+		return strings.TrimSpace(v)
+	case int:
+		return strconv.Itoa(v)
+	case int64:
+		return strconv.FormatInt(v, 10)
+	case float64:
+		if v == float64(int64(v)) {
+			return strconv.FormatInt(int64(v), 10)
+		}
+		return strings.TrimSpace(fmt.Sprint(v))
+	default:
+		return strings.TrimSpace(fmt.Sprint(v))
+	}
+}

--- a/pkg/types/v2/schema.go
+++ b/pkg/types/v2/schema.go
@@ -1,6 +1,7 @@
-// Package v2 implements workspace and workflow schema version 2 foundations
-// from RFC issue #544 (Phase 1): parse, structural validation, pair validation,
-// and immutable content revisions. V1 schemas remain in package types.
+// Package v2 defines the deterministic workspace, workflow, and typed control
+// contracts from RFC issue #544: strict parsing, validation, immutable content
+// revisions, dynamic delivery, context assembly, and protocol negotiation.
+// V1 schemas and transcript-driven execution remain isolated in package types.
 package v2
 
 import (

--- a/pkg/types/v2/workflow.go
+++ b/pkg/types/v2/workflow.go
@@ -1,0 +1,122 @@
+package v2
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Workflow is the authored workflow v2 document (issue #544).
+type Workflow struct {
+	SchemaVersion interface{}                `yaml:"schema_version" json:"schema_version"`
+	Name          string                     `yaml:"name" json:"name"`
+	InitialState  string                     `yaml:"initial_state" json:"initial_state"`
+	States        map[string]State           `yaml:"states" json:"states"`
+	Transitions   map[string]Transition      `yaml:"transitions,omitempty" json:"transitions,omitempty"`
+	Commands      map[string]Command         `yaml:"commands,omitempty" json:"commands,omitempty"`
+	CI            *WorkflowCI                `yaml:"ci,omitempty" json:"ci,omitempty"`
+	Review        *WorkflowReview            `yaml:"review,omitempty" json:"review,omitempty"`
+	Events        map[string]EventDefinition `yaml:"events,omitempty" json:"events,omitempty"`
+	Raw           map[string]interface{}     `yaml:"-" json:"-"`
+}
+
+// State is an explicit workflow state.
+type State struct {
+	Description string                 `yaml:"description,omitempty" json:"description,omitempty"`
+	Terminal    bool                   `yaml:"terminal,omitempty" json:"terminal,omitempty"`
+	Invariant   map[string]interface{} `yaml:"invariant,omitempty" json:"invariant,omitempty"`
+	OnEnter     *StateActions          `yaml:"on_enter,omitempty" json:"on_enter,omitempty"`
+}
+
+// StateActions are effects/asserts run on state entry.
+type StateActions struct {
+	Assert  map[string]interface{}   `yaml:"assert,omitempty" json:"assert,omitempty"`
+	Effects []map[string]interface{} `yaml:"effects,omitempty" json:"effects,omitempty"`
+	Set     map[string]interface{}   `yaml:"set,omitempty" json:"set,omitempty"`
+}
+
+// Transition is a named legal edge in the state graph.
+type Transition struct {
+	From    interface{}              `yaml:"from" json:"from"` // string or []string
+	On      string                   `yaml:"on,omitempty" json:"on,omitempty"`
+	When    map[string]interface{}   `yaml:"when,omitempty" json:"when,omitempty"`
+	To      string                   `yaml:"to" json:"to"`
+	Assert  map[string]interface{}   `yaml:"assert,omitempty" json:"assert,omitempty"`
+	Set     map[string]interface{}   `yaml:"set,omitempty" json:"set,omitempty"`
+	Effects []map[string]interface{} `yaml:"effects,omitempty" json:"effects,omitempty"`
+}
+
+// Command is an authenticated operator/request edge.
+type Command struct {
+	From          interface{} `yaml:"from" json:"from"` // string or []string
+	To            string      `yaml:"to" json:"to"`
+	RequireReason bool        `yaml:"require_reason,omitempty" json:"require_reason,omitempty"`
+}
+
+// WorkflowCI holds CI policies that reference workspace pipelines by name.
+type WorkflowCI struct {
+	Policies map[string]Policy `yaml:"policies,omitempty" json:"policies,omitempty"`
+}
+
+// WorkflowReview holds review policies that reference workspace review connections.
+type WorkflowReview struct {
+	Policies map[string]Policy `yaml:"policies,omitempty" json:"policies,omitempty"`
+}
+
+// Policy is a composable all/any/not policy tree. Leaf nodes reference
+// pipeline/connection names; structure is intentionally loose at parse time
+// and validated for known resource refs.
+type Policy map[string]interface{}
+
+// EventDefinition holds custom event clauses for one event type.
+type EventDefinition struct {
+	Clauses []EventClause `yaml:"clauses,omitempty" json:"clauses,omitempty"`
+}
+
+// EventClause is a state-scoped custom reaction with restricted predicates.
+type EventClause struct {
+	From    interface{}              `yaml:"from,omitempty" json:"from,omitempty"` // string or []string; required (conservative)
+	When    map[string]interface{}   `yaml:"when,omitempty" json:"when,omitempty"`
+	Assert  map[string]interface{}   `yaml:"assert,omitempty" json:"assert,omitempty"`
+	Set     map[string]interface{}   `yaml:"set,omitempty" json:"set,omitempty"`
+	Effects []map[string]interface{} `yaml:"effects,omitempty" json:"effects,omitempty"`
+	Ignore  bool                     `yaml:"ignore,omitempty" json:"ignore,omitempty"`
+}
+
+// ResolvedWorkflow is a validated workflow plus its content revision.
+type ResolvedWorkflow struct {
+	Workflow *Workflow
+	Revision ContentDigest
+}
+
+// FromStates expands a from field (string or []string) into state names.
+func FromStates(from interface{}) ([]string, error) {
+	switch v := from.(type) {
+	case nil:
+		return nil, fmt.Errorf("from is required")
+	case string:
+		if strings.TrimSpace(v) == "" {
+			return nil, fmt.Errorf("from cannot be empty")
+		}
+		return []string{v}, nil
+	case []interface{}:
+		out := make([]string, 0, len(v))
+		for i, item := range v {
+			s, ok := item.(string)
+			if !ok || strings.TrimSpace(s) == "" {
+				return nil, fmt.Errorf("from[%d] must be a non-empty string", i)
+			}
+			out = append(out, s)
+		}
+		if len(out) == 0 {
+			return nil, fmt.Errorf("from cannot be empty")
+		}
+		return out, nil
+	case []string:
+		if len(v) == 0 {
+			return nil, fmt.Errorf("from cannot be empty")
+		}
+		return v, nil
+	default:
+		return nil, fmt.Errorf("from must be a string or list of strings")
+	}
+}

--- a/pkg/types/v2/workflow.go
+++ b/pkg/types/v2/workflow.go
@@ -9,12 +9,14 @@ import (
 type Workflow struct {
 	SchemaVersion interface{}                `yaml:"schema_version" json:"schema_version"`
 	Name          string                     `yaml:"name" json:"name"`
+	Enabled       bool                       `yaml:"enabled" json:"enabled"`
 	InitialState  string                     `yaml:"initial_state" json:"initial_state"`
 	States        map[string]State           `yaml:"states" json:"states"`
 	Transitions   map[string]Transition      `yaml:"transitions,omitempty" json:"transitions,omitempty"`
 	Commands      map[string]Command         `yaml:"commands,omitempty" json:"commands,omitempty"`
 	CI            *WorkflowCI                `yaml:"ci,omitempty" json:"ci,omitempty"`
 	Review        *WorkflowReview            `yaml:"review,omitempty" json:"review,omitempty"`
+	Delivery      *WorkflowDelivery          `yaml:"delivery,omitempty" json:"delivery,omitempty"`
 	Events        map[string]EventDefinition `yaml:"events,omitempty" json:"events,omitempty"`
 	Raw           map[string]interface{}     `yaml:"-" json:"-"`
 }
@@ -22,9 +24,35 @@ type Workflow struct {
 // State is an explicit workflow state.
 type State struct {
 	Description string                 `yaml:"description,omitempty" json:"description,omitempty"`
+	Phase       DisplayPhase           `yaml:"phase,omitempty" json:"phase,omitempty"`
 	Terminal    bool                   `yaml:"terminal,omitempty" json:"terminal,omitempty"`
 	Invariant   map[string]interface{} `yaml:"invariant,omitempty" json:"invariant,omitempty"`
 	OnEnter     *StateActions          `yaml:"on_enter,omitempty" json:"on_enter,omitempty"`
+}
+
+// DisplayPhase is the stable product-level lifecycle shown to operators. The
+// authored state graph may be arbitrarily detailed and may loop between phases.
+type DisplayPhase string
+
+const (
+	PhaseSetup   DisplayPhase = "setup"
+	PhaseContext DisplayPhase = "context"
+	PhasePlan    DisplayPhase = "plan"
+	PhaseBuild   DisplayPhase = "build"
+	PhaseTest    DisplayPhase = "test"
+	PhasePR      DisplayPhase = "pr"
+	PhaseReview  DisplayPhase = "review"
+	PhaseDone    DisplayPhase = "done"
+)
+
+// IsDisplayPhase reports whether phase belongs to the stable product lifecycle.
+func IsDisplayPhase(phase DisplayPhase) bool {
+	switch phase {
+	case PhaseSetup, PhaseContext, PhasePlan, PhaseBuild, PhaseTest, PhasePR, PhaseReview, PhaseDone:
+		return true
+	default:
+		return false
+	}
 }
 
 // StateActions are effects/asserts run on state entry.
@@ -61,6 +89,25 @@ type WorkflowCI struct {
 type WorkflowReview struct {
 	Policies map[string]Policy `yaml:"policies,omitempty" json:"policies,omitempty"`
 }
+
+// WorkflowDelivery declares aggregate constraints over the run-owned,
+// dynamically submitted delivery collection. It intentionally contains no
+// repository list; repository authority comes exclusively from the workspace.
+type WorkflowDelivery struct {
+	PullRequests *PullRequestDelivery `yaml:"pull_requests,omitempty" json:"pull_requests,omitempty"`
+}
+
+// PullRequestDelivery applies named CI/review policies to every active,
+// hub-verified PR and defines when that aggregate can complete.
+type PullRequestDelivery struct {
+	Required     bool   `yaml:"required,omitempty" json:"required,omitempty"`
+	Minimum      int    `yaml:"minimum,omitempty" json:"minimum,omitempty"`
+	CIPolicy     string `yaml:"ci_policy,omitempty" json:"ci_policy,omitempty"`
+	ReviewPolicy string `yaml:"review_policy,omitempty" json:"review_policy,omitempty"`
+	Completion   string `yaml:"completion,omitempty" json:"completion,omitempty"`
+}
+
+const DeliveryCompletionAllMerged = "all_merged"
 
 // Policy is a composable all/any/not policy tree. Leaf nodes reference
 // pipeline/connection names; structure is intentionally loose at parse time

--- a/pkg/types/v2/workflow_test.go
+++ b/pkg/types/v2/workflow_test.go
@@ -10,25 +10,33 @@ import (
 const validWorkflowYAML = `
 schema_version: 2
 name: pull-request-delivery
+enabled: true
 initial_state: implementing
 
 states:
   implementing:
     description: Work is in progress.
+    phase: build
   awaiting_ci:
     description: A verified pull request exists and CI is unresolved.
+    phase: pr
     invariant:
       pull_request:
         state: open
   fixing:
     description: Verified evidence indicates more work is required.
+    phase: build
   awaiting_review:
     description: CI policy is satisfied.
+    phase: review
   ready_to_merge:
     description: Ready.
+    phase: review
   completed:
+    phase: done
     terminal: true
   cancelled:
+    phase: done
     terminal: true
 
 transitions:
@@ -111,6 +119,14 @@ review:
             minimum: 1
       invalidate_on_new_head: true
 
+delivery:
+  pull_requests:
+    required: true
+    minimum: 1
+    ci_policy: merge_ready
+    review_policy: required_review
+    completion: all_merged
+
 events:
   ci.run.completed:
     clauses:
@@ -141,6 +157,128 @@ func TestParseAndValidateWorkflowValidRFCShape(t *testing.T) {
 	}
 	if resolved.Revision == "" {
 		t.Fatal("expected non-empty revision")
+	}
+	if resolved.Workflow.States["implementing"].Phase != v2.PhaseBuild {
+		t.Fatalf("phase = %q, want build", resolved.Workflow.States["implementing"].Phase)
+	}
+	if resolved.Workflow.Delivery.PullRequests.Minimum != 1 {
+		t.Fatalf("delivery minimum = %d, want 1", resolved.Workflow.Delivery.PullRequests.Minimum)
+	}
+}
+
+func TestWorkflowRejectsUnknownDisplayPhase(t *testing.T) {
+	yaml := `
+schema_version: 2
+name: invalid-phase
+initial_state: s
+states:
+  s:
+    phase: deploy
+  done:
+    terminal: true
+`
+	_, err := v2.ParseAndValidateWorkflow([]byte(yaml))
+	if err == nil || !strings.Contains(err.Error(), "unsupported") {
+		t.Fatalf("error = %v, want unsupported phase", err)
+	}
+}
+
+func TestWorkflowV2RejectsTranscriptControl(t *testing.T) {
+	for name, yaml := range map[string]string{
+		"event": `
+schema_version: 2
+name: transcript-event
+initial_state: s
+states:
+  s: {}
+  done: {terminal: true}
+transitions:
+  bad:
+    from: s
+    on: message.received
+    to: done
+`,
+		"fact": `
+schema_version: 2
+name: transcript-fact
+initial_state: s
+states:
+  s: {}
+  done: {terminal: true}
+transitions:
+  bad:
+    from: s
+    on: custom.signal
+    when:
+      conversation:
+        text:
+          equals: "[DONE]"
+    to: done
+`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := v2.ParseAndValidateWorkflow([]byte(yaml))
+			if err == nil || !strings.Contains(err.Error(), "conversation/transcript") {
+				t.Fatalf("error = %v, want conversation/transcript rejection", err)
+			}
+		})
+	}
+}
+
+func TestWorkflowV2AllowsMarkersAsInertDescription(t *testing.T) {
+	yaml := `
+schema_version: 2
+name: inert-prose
+initial_state: s
+states:
+  s:
+    description: The agent may literally explain [DONE] here without changing state.
+  done: {terminal: true}
+`
+	if _, err := v2.ParseAndValidateWorkflow([]byte(yaml)); err != nil {
+		t.Fatalf("inert prose should remain valid: %v", err)
+	}
+}
+
+func TestWorkflowDeliveryCannotDeclareRepositories(t *testing.T) {
+	yaml := `
+schema_version: 2
+name: fixed-repositories
+initial_state: s
+states:
+  s: {}
+  done:
+    terminal: true
+delivery:
+  pull_requests:
+    required: true
+    minimum: 1
+    repositories: [primary]
+`
+	_, err := v2.ParseAndValidateWorkflow([]byte(yaml))
+	if err == nil || !strings.Contains(err.Error(), "field repositories not found") {
+		t.Fatalf("error = %v, want strict unknown delivery repository field", err)
+	}
+}
+
+func TestWorkflowRejectsUnknownDeliveryPolicy(t *testing.T) {
+	yaml := `
+schema_version: 2
+name: bad-delivery-policy
+initial_state: s
+states:
+  s: {}
+  done:
+    terminal: true
+delivery:
+  pull_requests:
+    required: true
+    minimum: 1
+    ci_policy: missing
+`
+	_, err := v2.ParseAndValidateWorkflow([]byte(yaml))
+	if err == nil || !strings.Contains(err.Error(), "no ci policies") {
+		t.Fatalf("error = %v, want no ci policies", err)
 	}
 }
 

--- a/pkg/types/v2/workflow_test.go
+++ b/pkg/types/v2/workflow_test.go
@@ -183,6 +183,24 @@ states:
 	}
 }
 
+func TestEnabledWorkflowRequiresDisplayPhaseForEveryState(t *testing.T) {
+	yaml := `
+schema_version: 2
+name: missing-phase
+enabled: true
+initial_state: s
+states:
+  s:
+    phase: build
+  done:
+    terminal: true
+`
+	_, err := v2.ParseAndValidateWorkflow([]byte(yaml))
+	if err == nil || !strings.Contains(err.Error(), "phase is required") {
+		t.Fatalf("error = %v, want required phase", err)
+	}
+}
+
 func TestWorkflowV2RejectsTranscriptControl(t *testing.T) {
 	for name, yaml := range map[string]string{
 		"event": `

--- a/pkg/types/v2/workflow_test.go
+++ b/pkg/types/v2/workflow_test.go
@@ -1,0 +1,456 @@
+package v2_test
+
+import (
+	"strings"
+	"testing"
+
+	v2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
+)
+
+const validWorkflowYAML = `
+schema_version: 2
+name: pull-request-delivery
+initial_state: implementing
+
+states:
+  implementing:
+    description: Work is in progress.
+  awaiting_ci:
+    description: A verified pull request exists and CI is unresolved.
+    invariant:
+      pull_request:
+        state: open
+  fixing:
+    description: Verified evidence indicates more work is required.
+  awaiting_review:
+    description: CI policy is satisfied.
+  ready_to_merge:
+    description: Ready.
+  completed:
+    terminal: true
+  cancelled:
+    terminal: true
+
+transitions:
+  pr_opened:
+    from: implementing
+    on: pull_request.verified_open
+    when:
+      pull_request:
+        state: open
+    to: awaiting_ci
+
+  ci_satisfied:
+    from: awaiting_ci
+    on: ci.policy.evaluated
+    when:
+      ci:
+        policy: merge_ready
+        status: satisfied
+    to: awaiting_review
+
+  ci_failed:
+    from: awaiting_ci
+    on: ci.policy.evaluated
+    when:
+      ci:
+        policy: merge_ready
+        status: unsatisfied
+    to: fixing
+
+  fixes_pushed:
+    from: fixing
+    on: pull_request.head_changed
+    to: awaiting_ci
+
+  review_satisfied:
+    from: awaiting_review
+    on: review.policy.evaluated
+    when:
+      review:
+        policy: required_review
+        status: satisfied
+    to: ready_to_merge
+
+  review_unsatisfied:
+    from: awaiting_review
+    on: review.policy.evaluated
+    when:
+      review:
+        policy: required_review
+        status: unsatisfied
+    to: fixing
+
+  pull_request_merged:
+    from: ready_to_merge
+    on: pull_request.merged
+    to: completed
+
+commands:
+  cancel:
+    from: [implementing, awaiting_ci, fixing, awaiting_review, ready_to_merge]
+    to: cancelled
+    require_reason: true
+
+ci:
+  policies:
+    merge_ready:
+      all:
+        - pipeline: github-pr
+          checks: [lint, unit-tests]
+        - pipeline: depot-container
+          checks: [container-build]
+      satisfied_for: current_pr_head
+
+review:
+  policies:
+    required_review:
+      all:
+        - connection: github-reviews
+          approvals:
+            minimum: 1
+      invalidate_on_new_head: true
+
+events:
+  ci.run.completed:
+    clauses:
+      - from: awaiting_ci
+        when:
+          all:
+            - pipeline:
+                equals: depot-container
+            - conclusion:
+                equals: failure
+        assert:
+          work.ci_failure_investigation_requested: true
+        effects:
+          - agent.task:
+              prompt: Investigate the Depot CI failure.
+`
+
+func TestParseAndValidateWorkflowValidRFCShape(t *testing.T) {
+	// Structural-only first (no workspace pair) — policies not pair-checked.
+	// Use workflow without policy pipeline refs for pure validate... actually
+	// ValidateWorkflow does not check pipeline refs; pair does.
+	resolved, err := v2.ParseAndValidateWorkflow([]byte(validWorkflowYAML))
+	if err != nil {
+		t.Fatalf("ParseAndValidateWorkflow: %v", err)
+	}
+	if resolved.Workflow.Name != "pull-request-delivery" {
+		t.Fatalf("name = %q", resolved.Workflow.Name)
+	}
+	if resolved.Revision == "" {
+		t.Fatal("expected non-empty revision")
+	}
+}
+
+func TestWorkflowRevisionStableAcrossCalls(t *testing.T) {
+	a, err := v2.ParseAndValidateWorkflow([]byte(validWorkflowYAML))
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := v2.ParseAndValidateWorkflow([]byte(validWorkflowYAML))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a.Revision == "" || a.Revision != b.Revision {
+		t.Fatalf("revisions not stable: %q vs %q", a.Revision, b.Revision)
+	}
+}
+
+func TestWorkflowPairValidWithWorkspace(t *testing.T) {
+	rwf, rws, err := v2.ParseAndValidateWorkflowPair([]byte(validWorkflowYAML), []byte(validWorkspaceYAML))
+	if err != nil {
+		t.Fatalf("pair: %v", err)
+	}
+	if rwf.Revision == "" || rws.Revision == "" {
+		t.Fatal("expected revisions for both")
+	}
+}
+
+func TestWorkflowRejectsOverlappingEventClauses(t *testing.T) {
+	yaml := `
+schema_version: 2
+name: overlap-clauses
+initial_state: awaiting_ci
+states:
+  awaiting_ci: {}
+  done:
+    terminal: true
+events:
+  ci.run.completed:
+    clauses:
+      - from: awaiting_ci
+        when:
+          conclusion:
+            equals: success
+      - from: awaiting_ci
+        when:
+          conclusion:
+            in: [success, failure]
+`
+	_, err := v2.ParseAndValidateWorkflow([]byte(yaml))
+	if err == nil {
+		t.Fatal("expected overlap error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "overlapping clauses") {
+		t.Fatalf("error missing overlapping clauses: %v", err)
+	}
+	if !strings.Contains(msg, "awaiting_ci") {
+		t.Fatalf("error missing state path: %v", err)
+	}
+	if !strings.Contains(msg, "events.ci.run.completed.clauses") {
+		t.Fatalf("error missing clause paths: %v", err)
+	}
+	if !strings.Contains(msg, "success") {
+		t.Fatalf("error missing witness value: %v", err)
+	}
+}
+
+func TestWorkflowRejectsOverlappingOutgoingTransitions(t *testing.T) {
+	yaml := `
+schema_version: 2
+name: overlap-transitions
+initial_state: awaiting_ci
+states:
+  awaiting_ci: {}
+  good: {}
+  bad: {}
+  done:
+    terminal: true
+transitions:
+  t1:
+    from: awaiting_ci
+    on: ci.policy.evaluated
+    when:
+      status:
+        equals: satisfied
+    to: good
+  t2:
+    from: awaiting_ci
+    on: ci.policy.evaluated
+    when:
+      status:
+        in: [satisfied, unsatisfied]
+    to: bad
+`
+	_, err := v2.ParseAndValidateWorkflow([]byte(yaml))
+	if err == nil {
+		t.Fatal("expected transition overlap error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "overlapping") {
+		t.Fatalf("error = %v", err)
+	}
+	if !strings.Contains(msg, "transitions.t1") || !strings.Contains(msg, "transitions.t2") {
+		t.Fatalf("error missing transition paths: %v", err)
+	}
+}
+
+func TestWorkflowRejectsProtectedNamespaceWrite(t *testing.T) {
+	yaml := `
+schema_version: 2
+name: protected-write
+initial_state: s
+states:
+  s: {}
+  done:
+    terminal: true
+events:
+  custom.event:
+    clauses:
+      - from: s
+        when:
+          x:
+            equals: 1
+        assert:
+          ci.conclusion: success
+`
+	_, err := v2.ParseAndValidateWorkflow([]byte(yaml))
+	if err == nil || !strings.Contains(err.Error(), "protected namespace") {
+		t.Fatalf("error = %v, want protected namespace", err)
+	}
+	if !strings.Contains(err.Error(), "ci.conclusion") {
+		t.Fatalf("error should name fact key: %v", err)
+	}
+}
+
+func TestWorkflowRejectsUnknownPipelineRef(t *testing.T) {
+	yaml := `
+schema_version: 2
+name: unknown-pipe
+initial_state: s
+states:
+  s: {}
+  done:
+    terminal: true
+ci:
+  policies:
+    merge_ready:
+      all:
+        - pipeline: does-not-exist
+          checks: [lint]
+`
+	_, _, err := v2.ParseAndValidateWorkflowPair([]byte(yaml), []byte(validWorkspaceYAML))
+	if err == nil || !strings.Contains(err.Error(), "unknown pipeline") {
+		t.Fatalf("error = %v, want unknown pipeline", err)
+	}
+	if !strings.Contains(err.Error(), "does-not-exist") {
+		t.Fatalf("error should name pipeline: %v", err)
+	}
+}
+
+func TestWorkflowRejectsEffectWithoutCapability(t *testing.T) {
+	// github-production has trigger_run restricted to false in validWorkspaceYAML
+	yaml := `
+schema_version: 2
+name: no-cap
+initial_state: s
+states:
+  s:
+    on_enter:
+      effects:
+        - ci.trigger:
+            pipeline: github-pr
+            subject: current_pr_head
+  done:
+    terminal: true
+`
+	_, _, err := v2.ParseAndValidateWorkflowPair([]byte(yaml), []byte(validWorkspaceYAML))
+	if err == nil {
+		t.Fatal("expected capability error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "unsupported") && !strings.Contains(msg, "lacks capability") {
+		t.Fatalf("error = %v, want unsupported/capability", err)
+	}
+	if !strings.Contains(msg, "github-pr") {
+		t.Fatalf("error should name pipeline: %v", err)
+	}
+}
+
+func TestWorkflowRejectsTerminalOutgoingTransition(t *testing.T) {
+	yaml := `
+schema_version: 2
+name: terminal-out
+initial_state: s
+states:
+  s: {}
+  done:
+    terminal: true
+transitions:
+  bad:
+    from: done
+    on: x
+    to: s
+`
+	_, err := v2.ParseAndValidateWorkflow([]byte(yaml))
+	if err == nil || !strings.Contains(err.Error(), "terminal states cannot have outgoing") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestWorkflowRejectsUnsupportedPredicate(t *testing.T) {
+	yaml := `
+schema_version: 2
+name: bad-pred
+initial_state: s
+states:
+  s: {}
+  done:
+    terminal: true
+events:
+  e:
+    clauses:
+      - from: s
+        when:
+          x:
+            regex: ".*"
+`
+	_, err := v2.ParseAndValidateWorkflow([]byte(yaml))
+	// regex is treated as nested field not operator - actually absorbConstraint
+	// will try flatten as field "regex". Bare scalar ".*" under regex field is ok as equals-like.
+	// Need a clear unsupported op at operator position.
+	// Use when: {js: "return true"} which is field js with scalar - also allowed as domain.
+	// Better: when with all containing unsupported op map.
+	_ = err
+	yaml2 := `
+schema_version: 2
+name: bad-pred
+initial_state: s
+states:
+  s: {}
+  done:
+    terminal: true
+events:
+  e:
+    clauses:
+      - from: s
+        when:
+          x:
+            matches: ".*"
+`
+	// "matches" is not a known operator; treated as nested field path x.matches with scalar.
+	// The RFC restricted language is for operators. Nested unknown field names under
+	// a field constraint map that aren't ops get flattened as deeper fields.
+	// Force operator position via:
+	yaml3 := `
+schema_version: 2
+name: bad-pred
+initial_state: s
+states:
+  s: {}
+  done:
+    terminal: true
+events:
+  e:
+    clauses:
+      - from: s
+        when:
+          all:
+            - conclusion:
+                regex: fail
+`
+	_, err = v2.ParseAndValidateWorkflow([]byte(yaml3))
+	// conclusion -> map{regex: fail}: regex is not an allowed op and not nested further meaningfully.
+	// absorbConstraint sees map with key regex - not allowedPredicateOps, so flattenPredicates(conclusion, map)
+	// which treats regex as field under conclusion - scalar leaf - allowed.
+	// To reject unsupported operators we need validatePredicateNode to reject unknown ops
+	// when they appear as sole keys that look like ops... Currently only known ops are validated
+	// as operators; unknown keys are field names. That's acceptable for Phase 1: only
+	// equals/not_equals/in/not_in/exists/all/any are *interpreted* as ops; other keys are fields.
+	// Reject clear case: bare top-level op that's not allowed - hard with current design.
+	// Instead assert valid restricted ops work and overlap analysis uses them.
+	_ = yaml2
+	if err != nil {
+		// if we do get an error, fine
+		t.Logf("got error (ok): %v", err)
+	}
+}
+
+func TestWorkflowDisjointClausesAccepted(t *testing.T) {
+	yaml := `
+schema_version: 2
+name: disjoint
+initial_state: awaiting_ci
+states:
+  awaiting_ci: {}
+  done:
+    terminal: true
+events:
+  ci.run.completed:
+    clauses:
+      - from: awaiting_ci
+        when:
+          conclusion:
+            equals: success
+      - from: awaiting_ci
+        when:
+          conclusion:
+            equals: failure
+`
+	if _, err := v2.ParseAndValidateWorkflow([]byte(yaml)); err != nil {
+		t.Fatalf("disjoint clauses should validate: %v", err)
+	}
+}

--- a/pkg/types/v2/workflow_test.go
+++ b/pkg/types/v2/workflow_test.go
@@ -1,6 +1,7 @@
 package v2_test
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -508,7 +509,8 @@ transitions:
 }
 
 func TestWorkflowRejectsUnsupportedPredicate(t *testing.T) {
-	yaml := `
+	for _, operator := range []string{"regex", "matches", "javascript", "shell", "gte"} {
+		yaml := fmt.Sprintf(`
 schema_version: 2
 name: bad-pred
 initial_state: s
@@ -521,67 +523,13 @@ events:
     clauses:
       - from: s
         when:
-          x:
-            regex: ".*"
-`
-	_, err := v2.ParseAndValidateWorkflow([]byte(yaml))
-	// regex is treated as nested field not operator - actually absorbConstraint
-	// will try flatten as field "regex". Bare scalar ".*" under regex field is ok as equals-like.
-	// Need a clear unsupported op at operator position.
-	// Use when: {js: "return true"} which is field js with scalar - also allowed as domain.
-	// Better: when with all containing unsupported op map.
-	_ = err
-	yaml2 := `
-schema_version: 2
-name: bad-pred
-initial_state: s
-states:
-  s: {}
-  done:
-    terminal: true
-events:
-  e:
-    clauses:
-      - from: s
-        when:
-          x:
-            matches: ".*"
-`
-	// "matches" is not a known operator; treated as nested field path x.matches with scalar.
-	// The RFC restricted language is for operators. Nested unknown field names under
-	// a field constraint map that aren't ops get flattened as deeper fields.
-	// Force operator position via:
-	yaml3 := `
-schema_version: 2
-name: bad-pred
-initial_state: s
-states:
-  s: {}
-  done:
-    terminal: true
-events:
-  e:
-    clauses:
-      - from: s
-        when:
-          all:
-            - conclusion:
-                regex: fail
-`
-	_, err = v2.ParseAndValidateWorkflow([]byte(yaml3))
-	// conclusion -> map{regex: fail}: regex is not an allowed op and not nested further meaningfully.
-	// absorbConstraint sees map with key regex - not allowedPredicateOps, so flattenPredicates(conclusion, map)
-	// which treats regex as field under conclusion - scalar leaf - allowed.
-	// To reject unsupported operators we need validatePredicateNode to reject unknown ops
-	// when they appear as sole keys that look like ops... Currently only known ops are validated
-	// as operators; unknown keys are field names. That's acceptable for Phase 1: only
-	// equals/not_equals/in/not_in/exists/all/any are *interpreted* as ops; other keys are fields.
-	// Reject clear case: bare top-level op that's not allowed - hard with current design.
-	// Instead assert valid restricted ops work and overlap analysis uses them.
-	_ = yaml2
-	if err != nil {
-		// if we do get an error, fine
-		t.Logf("got error (ok): %v", err)
+          conclusion:
+            %s: failure
+`, operator)
+		_, err := v2.ParseAndValidateWorkflow([]byte(yaml))
+		if err == nil || !strings.Contains(err.Error(), "unsupported predicate operator") {
+			t.Fatalf("operator %q error = %v", operator, err)
+		}
 	}
 }
 

--- a/pkg/types/v2/workflow_validate.go
+++ b/pkg/types/v2/workflow_validate.go
@@ -1,6 +1,7 @@
 package v2
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 
@@ -26,12 +27,14 @@ var writableNamespaces = []string{
 var knownWorkflowKeys = map[string]bool{
 	"schema_version": true,
 	"name":           true,
+	"enabled":        true,
 	"initial_state":  true,
 	"states":         true,
 	"transitions":    true,
 	"commands":       true,
 	"ci":             true,
 	"review":         true,
+	"delivery":       true,
 	"events":         true,
 }
 
@@ -56,7 +59,9 @@ func ParseWorkflow(data []byte) (*Workflow, error) {
 	}
 
 	var wf Workflow
-	if err := yaml.Unmarshal(data, &wf); err != nil {
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&wf); err != nil {
 		return nil, fmt.Errorf("parse workflow: %w", err)
 	}
 	wf.Raw = raw
@@ -97,6 +102,12 @@ func ValidateWorkflow(wf *Workflow) (*ResolvedWorkflow, error) {
 				return nil, fmt.Errorf("workflow %q: %w", wf.Name, err)
 			}
 		}
+		if st.Phase != "" && !IsDisplayPhase(st.Phase) {
+			return nil, fmt.Errorf("workflow %q: states.%s.phase %q is unsupported", wf.Name, name, st.Phase)
+		}
+		if err := validateNoTranscriptFacts(fmt.Sprintf("states.%s.invariant", name), st.Invariant); err != nil {
+			return nil, fmt.Errorf("workflow %q: %w", wf.Name, err)
+		}
 	}
 
 	// Transitions form legal graph edges.
@@ -122,6 +133,12 @@ func ValidateWorkflow(wf *Workflow) (*ResolvedWorkflow, error) {
 		}
 		if _, ok := wf.States[tr.To]; !ok {
 			return nil, fmt.Errorf("workflow %q: transitions.%s.to %q: unknown state", wf.Name, name, tr.To)
+		}
+		if isTranscriptEvent(tr.On) {
+			return nil, fmt.Errorf("workflow %q: transitions.%s.on %q: conversation/transcript events cannot control workflow v2", wf.Name, name, tr.On)
+		}
+		if err := validateNoTranscriptFacts(fmt.Sprintf("transitions.%s.when", name), tr.When); err != nil {
+			return nil, fmt.Errorf("workflow %q: %w", wf.Name, err)
 		}
 		if err := ValidatePredicateTree(fmt.Sprintf("transitions.%s.when", name), tr.When); err != nil {
 			return nil, fmt.Errorf("workflow %q: %w", wf.Name, err)
@@ -169,9 +186,12 @@ func ValidateWorkflow(wf *Workflow) (*ResolvedWorkflow, error) {
 
 	// Event clauses.
 	for eventName, def := range wf.Events {
+		if isTranscriptEvent(eventName) {
+			return nil, fmt.Errorf("workflow %q: event %q: conversation/transcript events cannot control workflow v2", wf.Name, eventName)
+		}
 		for i, clause := range def.Clauses {
 			path := fmt.Sprintf("events.%s.clauses[%d]", eventName, i)
-			// Conservative: require from (open design question in RFC).
+			// Require state scope so event handling remains deterministic.
 			fromStates, err := FromStates(clause.From)
 			if err != nil {
 				return nil, fmt.Errorf("workflow %q: %s.from: %w (from is required)", wf.Name, path, err)
@@ -182,6 +202,9 @@ func ValidateWorkflow(wf *Workflow) (*ResolvedWorkflow, error) {
 				}
 			}
 			if err := ValidatePredicateTree(path+".when", clause.When); err != nil {
+				return nil, fmt.Errorf("workflow %q: %w", wf.Name, err)
+			}
+			if err := validateNoTranscriptFacts(path+".when", clause.When); err != nil {
 				return nil, fmt.Errorf("workflow %q: %w", wf.Name, err)
 			}
 			if err := validateFactWrites(path, clause.Assert, clause.Set); err != nil {
@@ -211,12 +234,97 @@ func ValidateWorkflow(wf *Workflow) (*ResolvedWorkflow, error) {
 			}
 		}
 	}
+	if err := validateDelivery(wf); err != nil {
+		return nil, fmt.Errorf("workflow %q: %w", wf.Name, err)
+	}
 
 	rev, err := RevisionOf(wf)
 	if err != nil {
 		return nil, err
 	}
 	return &ResolvedWorkflow{Workflow: wf, Revision: rev}, nil
+}
+
+func isTranscriptEvent(event string) bool {
+	event = strings.ToLower(strings.TrimSpace(event))
+	for _, prefix := range []string{"message.", "conversation.", "transcript.", "chat.", "agent.message", "claw.message"} {
+		if strings.HasPrefix(event, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func validateNoTranscriptFacts(path string, node interface{}) error {
+	return walkNoTranscriptFacts(path, "", node)
+}
+
+func walkNoTranscriptFacts(path, prefix string, node interface{}) error {
+	switch value := node.(type) {
+	case map[string]interface{}:
+		for key, child := range value {
+			fact := key
+			if prefix != "" {
+				fact = prefix + "." + key
+			}
+			if isTranscriptFact(key) || isTranscriptFact(fact) {
+				return fmt.Errorf("%s: conversation/transcript fact %q cannot control workflow v2", path, fact)
+			}
+			if err := walkNoTranscriptFacts(path, fact, child); err != nil {
+				return err
+			}
+		}
+	case []interface{}:
+		for _, child := range value {
+			if err := walkNoTranscriptFacts(path, prefix, child); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func isTranscriptFact(fact string) bool {
+	fact = strings.ToLower(strings.TrimSpace(fact))
+	for _, prefix := range []string{"message", "conversation", "transcript", "chat", "agent.message", "claw.message"} {
+		if fact == prefix || strings.HasPrefix(fact, prefix+".") {
+			return true
+		}
+	}
+	return false
+}
+
+func validateDelivery(wf *Workflow) error {
+	if wf.Delivery == nil || wf.Delivery.PullRequests == nil {
+		return nil
+	}
+	pr := wf.Delivery.PullRequests
+	if pr.Minimum < 0 {
+		return fmt.Errorf("delivery.pull_requests.minimum cannot be negative")
+	}
+	if pr.Required && pr.Minimum == 0 {
+		return fmt.Errorf("delivery.pull_requests.minimum must be at least 1 when required")
+	}
+	if pr.Completion != "" && pr.Completion != DeliveryCompletionAllMerged {
+		return fmt.Errorf("delivery.pull_requests.completion %q is unsupported", pr.Completion)
+	}
+	if pr.CIPolicy != "" {
+		if wf.CI == nil {
+			return fmt.Errorf("delivery.pull_requests.ci_policy %q: workflow has no ci policies", pr.CIPolicy)
+		}
+		if _, ok := wf.CI.Policies[pr.CIPolicy]; !ok {
+			return fmt.Errorf("delivery.pull_requests.ci_policy %q: unknown ci policy", pr.CIPolicy)
+		}
+	}
+	if pr.ReviewPolicy != "" {
+		if wf.Review == nil {
+			return fmt.Errorf("delivery.pull_requests.review_policy %q: workflow has no review policies", pr.ReviewPolicy)
+		}
+		if _, ok := wf.Review.Policies[pr.ReviewPolicy]; !ok {
+			return fmt.Errorf("delivery.pull_requests.review_policy %q: unknown review policy", pr.ReviewPolicy)
+		}
+	}
+	return nil
 }
 
 // ValidateWorkflowAgainstWorkspace pair-validates a workflow against a resolved workspace.

--- a/pkg/types/v2/workflow_validate.go
+++ b/pkg/types/v2/workflow_validate.go
@@ -1,0 +1,509 @@
+package v2
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Protected fact namespaces that workflow-authored assert/set cannot write.
+var protectedNamespaces = []string{
+	"ci.",
+	"pull_request.",
+	"review.",
+	"effects.",
+	"workflow.",
+	"operator.",
+}
+
+// Writable namespaces for workflow-authored facts.
+var writableNamespaces = []string{
+	"work.",
+	"custom.",
+}
+
+var knownWorkflowKeys = map[string]bool{
+	"schema_version": true,
+	"name":           true,
+	"initial_state":  true,
+	"states":         true,
+	"transitions":    true,
+	"commands":       true,
+	"ci":             true,
+	"review":         true,
+	"events":         true,
+}
+
+// ParseWorkflow unmarshals workflow v2 YAML. It does not validate.
+func ParseWorkflow(data []byte) (*Workflow, error) {
+	version, err := DetectSchemaVersion(data)
+	if err != nil {
+		return nil, err
+	}
+	if !IsV2(version) {
+		return nil, fmt.Errorf("workflow schema_version %q is not v2 (want 2 or v2)", version)
+	}
+
+	var raw map[string]interface{}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parse workflow yaml: %w", err)
+	}
+	for key := range raw {
+		if !knownWorkflowKeys[key] {
+			return nil, fmt.Errorf("workflow: unknown field %q", key)
+		}
+	}
+
+	var wf Workflow
+	if err := yaml.Unmarshal(data, &wf); err != nil {
+		return nil, fmt.Errorf("parse workflow: %w", err)
+	}
+	wf.Raw = raw
+	return &wf, nil
+}
+
+// ValidateWorkflow structurally validates a workflow v2 document (without
+// workspace pairing). Pair validation is ValidateWorkflowAgainstWorkspace.
+func ValidateWorkflow(wf *Workflow) (*ResolvedWorkflow, error) {
+	if wf == nil {
+		return nil, fmt.Errorf("workflow is nil")
+	}
+	if !IsV2(SchemaVersionString(wf.SchemaVersion)) {
+		return nil, fmt.Errorf("workflow schema_version %q is not v2", SchemaVersionString(wf.SchemaVersion))
+	}
+	if strings.TrimSpace(wf.Name) == "" {
+		return nil, fmt.Errorf("workflow name is required")
+	}
+	if strings.TrimSpace(wf.InitialState) == "" {
+		return nil, fmt.Errorf("workflow %q: initial_state is required", wf.Name)
+	}
+	if len(wf.States) == 0 {
+		return nil, fmt.Errorf("workflow %q: states is required", wf.Name)
+	}
+	if _, ok := wf.States[wf.InitialState]; !ok {
+		return nil, fmt.Errorf("workflow %q: initial_state %q is not defined in states", wf.Name, wf.InitialState)
+	}
+
+	for name, st := range wf.States {
+		if err := validateResourceName("states", name); err != nil {
+			return nil, fmt.Errorf("workflow %q: %w", wf.Name, err)
+		}
+		if st.OnEnter != nil {
+			if err := validateFactWrites(fmt.Sprintf("states.%s.on_enter", name), st.OnEnter.Assert, st.OnEnter.Set); err != nil {
+				return nil, fmt.Errorf("workflow %q: %w", wf.Name, err)
+			}
+			if err := validateEffectsShape(fmt.Sprintf("states.%s.on_enter.effects", name), st.OnEnter.Effects); err != nil {
+				return nil, fmt.Errorf("workflow %q: %w", wf.Name, err)
+			}
+		}
+	}
+
+	// Transitions form legal graph edges.
+	for name, tr := range wf.Transitions {
+		if err := validateResourceName("transitions", name); err != nil {
+			return nil, fmt.Errorf("workflow %q: %w", wf.Name, err)
+		}
+		fromStates, err := FromStates(tr.From)
+		if err != nil {
+			return nil, fmt.Errorf("workflow %q: transitions.%s.from: %w", wf.Name, name, err)
+		}
+		for _, fs := range fromStates {
+			st, ok := wf.States[fs]
+			if !ok {
+				return nil, fmt.Errorf("workflow %q: transitions.%s.from %q: unknown state", wf.Name, name, fs)
+			}
+			if st.Terminal {
+				return nil, fmt.Errorf("workflow %q: transitions.%s.from %q: terminal states cannot have outgoing transitions", wf.Name, name, fs)
+			}
+		}
+		if strings.TrimSpace(tr.To) == "" {
+			return nil, fmt.Errorf("workflow %q: transitions.%s.to is required", wf.Name, name)
+		}
+		if _, ok := wf.States[tr.To]; !ok {
+			return nil, fmt.Errorf("workflow %q: transitions.%s.to %q: unknown state", wf.Name, name, tr.To)
+		}
+		if err := ValidatePredicateTree(fmt.Sprintf("transitions.%s.when", name), tr.When); err != nil {
+			return nil, fmt.Errorf("workflow %q: %w", wf.Name, err)
+		}
+		if err := validateFactWrites(fmt.Sprintf("transitions.%s", name), tr.Assert, tr.Set); err != nil {
+			return nil, fmt.Errorf("workflow %q: %w", wf.Name, err)
+		}
+		if err := validateEffectsShape(fmt.Sprintf("transitions.%s.effects", name), tr.Effects); err != nil {
+			return nil, fmt.Errorf("workflow %q: %w", wf.Name, err)
+		}
+	}
+
+	// Outgoing transition uniqueness: for same from+on, when clauses must not overlap.
+	if err := validateTransitionOverlaps(wf); err != nil {
+		return nil, fmt.Errorf("workflow %q: %w", wf.Name, err)
+	}
+
+	// Commands are also legal graph edges.
+	for name, cmd := range wf.Commands {
+		if err := validateResourceName("commands", name); err != nil {
+			return nil, fmt.Errorf("workflow %q: %w", wf.Name, err)
+		}
+		fromStates, err := FromStates(cmd.From)
+		if err != nil {
+			return nil, fmt.Errorf("workflow %q: commands.%s.from: %w", wf.Name, name, err)
+		}
+		for _, fs := range fromStates {
+			if _, ok := wf.States[fs]; !ok {
+				return nil, fmt.Errorf("workflow %q: commands.%s.from %q: unknown state", wf.Name, name, fs)
+			}
+			// Commands may leave non-terminal states; terminal→anything is odd but
+			// cancel-from-terminal is not needed. Still allow from terminal? RFC
+			// says legal graph includes command edges; forbid terminal from for consistency.
+			if wf.States[fs].Terminal {
+				return nil, fmt.Errorf("workflow %q: commands.%s.from %q: terminal states cannot have outgoing transitions", wf.Name, name, fs)
+			}
+		}
+		if strings.TrimSpace(cmd.To) == "" {
+			return nil, fmt.Errorf("workflow %q: commands.%s.to is required", wf.Name, name)
+		}
+		if _, ok := wf.States[cmd.To]; !ok {
+			return nil, fmt.Errorf("workflow %q: commands.%s.to %q: unknown state", wf.Name, name, cmd.To)
+		}
+	}
+
+	// Event clauses.
+	for eventName, def := range wf.Events {
+		for i, clause := range def.Clauses {
+			path := fmt.Sprintf("events.%s.clauses[%d]", eventName, i)
+			// Conservative: require from (open design question in RFC).
+			fromStates, err := FromStates(clause.From)
+			if err != nil {
+				return nil, fmt.Errorf("workflow %q: %s.from: %w (from is required)", wf.Name, path, err)
+			}
+			for _, fs := range fromStates {
+				if _, ok := wf.States[fs]; !ok {
+					return nil, fmt.Errorf("workflow %q: %s.from %q: unknown state", wf.Name, path, fs)
+				}
+			}
+			if err := ValidatePredicateTree(path+".when", clause.When); err != nil {
+				return nil, fmt.Errorf("workflow %q: %w", wf.Name, err)
+			}
+			if err := validateFactWrites(path, clause.Assert, clause.Set); err != nil {
+				return nil, fmt.Errorf("workflow %q: %w", wf.Name, err)
+			}
+			if err := validateEffectsShape(path+".effects", clause.Effects); err != nil {
+				return nil, fmt.Errorf("workflow %q: %w", wf.Name, err)
+			}
+		}
+		if err := validateEventClauseOverlaps(wf.Name, eventName, def.Clauses); err != nil {
+			return nil, err
+		}
+	}
+
+	// Policy structure: minimal name checks; resource refs checked in pair validation.
+	if wf.CI != nil {
+		for name := range wf.CI.Policies {
+			if err := validateResourceName("ci.policies", name); err != nil {
+				return nil, fmt.Errorf("workflow %q: %w", wf.Name, err)
+			}
+		}
+	}
+	if wf.Review != nil {
+		for name := range wf.Review.Policies {
+			if err := validateResourceName("review.policies", name); err != nil {
+				return nil, fmt.Errorf("workflow %q: %w", wf.Name, err)
+			}
+		}
+	}
+
+	rev, err := RevisionOf(wf)
+	if err != nil {
+		return nil, err
+	}
+	return &ResolvedWorkflow{Workflow: wf, Revision: rev}, nil
+}
+
+// ValidateWorkflowAgainstWorkspace pair-validates a workflow against a resolved workspace.
+func ValidateWorkflowAgainstWorkspace(wf *Workflow, rws *ResolvedWorkspace) (*ResolvedWorkflow, error) {
+	resolved, err := ValidateWorkflow(wf)
+	if err != nil {
+		return nil, err
+	}
+	if rws == nil || rws.Workspace == nil {
+		return nil, fmt.Errorf("workflow %q: workspace is required for pair validation", wf.Name)
+	}
+	ws := rws.Workspace
+
+	// CI policies must reference known pipelines.
+	if wf.CI != nil {
+		for name, policy := range wf.CI.Policies {
+			if err := walkPolicyRefs(fmt.Sprintf("ci.policies.%s", name), policy, ws, "pipeline"); err != nil {
+				return nil, fmt.Errorf("workflow %q: %w", wf.Name, err)
+			}
+		}
+	}
+	// Review policies must reference known review connections.
+	if wf.Review != nil {
+		for name, policy := range wf.Review.Policies {
+			if err := walkPolicyRefs(fmt.Sprintf("review.policies.%s", name), policy, ws, "connection"); err != nil {
+				return nil, fmt.Errorf("workflow %q: %w", wf.Name, err)
+			}
+		}
+	}
+
+	// Effects on transitions, clauses, on_enter: pipeline/connection + capability.
+	checkEffects := func(path string, effects []map[string]interface{}) error {
+		return validateEffectsAgainstWorkspace(path, effects, rws)
+	}
+	for name, tr := range wf.Transitions {
+		if err := checkEffects(fmt.Sprintf("transitions.%s.effects", name), tr.Effects); err != nil {
+			return nil, fmt.Errorf("workflow %q: %w", wf.Name, err)
+		}
+	}
+	for sname, st := range wf.States {
+		if st.OnEnter != nil {
+			if err := checkEffects(fmt.Sprintf("states.%s.on_enter.effects", sname), st.OnEnter.Effects); err != nil {
+				return nil, fmt.Errorf("workflow %q: %w", wf.Name, err)
+			}
+		}
+	}
+	for eventName, def := range wf.Events {
+		for i, clause := range def.Clauses {
+			path := fmt.Sprintf("events.%s.clauses[%d].effects", eventName, i)
+			if err := checkEffects(path, clause.Effects); err != nil {
+				return nil, fmt.Errorf("workflow %q: %w", wf.Name, err)
+			}
+		}
+	}
+
+	return resolved, nil
+}
+
+// ParseAndValidateWorkflow is the shipped entry point for workflow-only validation.
+func ParseAndValidateWorkflow(data []byte) (*ResolvedWorkflow, error) {
+	wf, err := ParseWorkflow(data)
+	if err != nil {
+		return nil, err
+	}
+	return ValidateWorkflow(wf)
+}
+
+// ParseAndValidateWorkflowPair validates workflow YAML against workspace YAML.
+func ParseAndValidateWorkflowPair(workflowData, workspaceData []byte) (*ResolvedWorkflow, *ResolvedWorkspace, error) {
+	rws, err := ParseAndValidateWorkspace(workspaceData)
+	if err != nil {
+		return nil, nil, fmt.Errorf("workspace: %w", err)
+	}
+	wf, err := ParseWorkflow(workflowData)
+	if err != nil {
+		return nil, rws, err
+	}
+	rwf, err := ValidateWorkflowAgainstWorkspace(wf, rws)
+	if err != nil {
+		return nil, rws, err
+	}
+	return rwf, rws, nil
+}
+
+func validateFactWrites(path string, assert, set map[string]interface{}) error {
+	for _, facts := range []map[string]interface{}{assert, set} {
+		if facts == nil {
+			continue
+		}
+		for key := range facts {
+			if err := checkFactKeyWritable(path, key); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func checkFactKeyWritable(path, key string) error {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return fmt.Errorf("%s: empty fact key", path)
+	}
+	for _, p := range protectedNamespaces {
+		if key == strings.TrimSuffix(p, ".") || strings.HasPrefix(key, p) {
+			return fmt.Errorf("%s: cannot write protected namespace %q (workflow may only write work.* or custom.*)", path, key)
+		}
+	}
+	writable := false
+	for _, p := range writableNamespaces {
+		if key == strings.TrimSuffix(p, ".") || strings.HasPrefix(key, p) {
+			writable = true
+			break
+		}
+	}
+	if !writable {
+		// Bare keys without namespace are not allowed for assert/set in v2.
+		return fmt.Errorf("%s: fact key %q must be under work.* or custom.*", path, key)
+	}
+	return nil
+}
+
+func validateEffectsShape(path string, effects []map[string]interface{}) error {
+	for i, eff := range effects {
+		if len(eff) == 0 {
+			return fmt.Errorf("%s[%d]: empty effect", path, i)
+		}
+		// Each effect is a single-key map: { "ci.trigger": { ... } }
+		if len(eff) != 1 {
+			return fmt.Errorf("%s[%d]: effect must have exactly one operation key", path, i)
+		}
+	}
+	return nil
+}
+
+func validateEffectsAgainstWorkspace(path string, effects []map[string]interface{}, rws *ResolvedWorkspace) error {
+	ws := rws.Workspace
+	for i, eff := range effects {
+		for op, raw := range eff {
+			epath := fmt.Sprintf("%s[%d].%s", path, i, op)
+			cfg, _ := raw.(map[string]interface{})
+			switch op {
+			case EffectCITrigger, EffectCIRetry, EffectCICancel:
+				pipelineName, _ := cfg["pipeline"].(string)
+				if strings.TrimSpace(pipelineName) == "" {
+					return fmt.Errorf("%s: pipeline is required", epath)
+				}
+				pipe, ok := ws.CIPipeline(pipelineName)
+				if !ok {
+					return fmt.Errorf("%s: unknown pipeline %q", epath, pipelineName)
+				}
+				capNeeded, ok := CapabilityForEffect(op)
+				if !ok {
+					continue
+				}
+				caps := rws.ResolvedCICaps[pipe.Connection]
+				if caps == nil || !caps[capNeeded] {
+					return fmt.Errorf("%s: effect %q is unsupported by pipeline %q (connection %q lacks capability %s)",
+						epath, op, pipelineName, pipe.Connection, capNeeded)
+				}
+			case "issue.comment":
+				conn, _ := cfg["connection"].(string)
+				if strings.TrimSpace(conn) == "" {
+					return fmt.Errorf("%s: connection is required", epath)
+				}
+				if !ws.HasIssueTrackerConnection(conn) {
+					return fmt.Errorf("%s: unknown issue_tracker connection %q", epath, conn)
+				}
+			case "agent.task":
+				// agent tasks do not require workspace pipeline refs
+			default:
+				// Unknown effect ops: reject at pair validation so they fail closed.
+				return fmt.Errorf("%s: unsupported effect operation %q", epath, op)
+			}
+		}
+	}
+	return nil
+}
+
+func walkPolicyRefs(path string, node interface{}, ws *Workspace, mode string) error {
+	switch n := node.(type) {
+	case map[string]interface{}:
+		if pipe, ok := n["pipeline"].(string); ok && mode == "pipeline" {
+			if !ws.HasCIPipeline(pipe) {
+				return fmt.Errorf("%s: unknown pipeline %q", path, pipe)
+			}
+		}
+		if conn, ok := n["connection"].(string); ok && mode == "connection" {
+			if !ws.HasReviewSystemConnection(conn) && !ws.HasSourceControlConnection(conn) {
+				return fmt.Errorf("%s: unknown review/source_control connection %q", path, conn)
+			}
+		}
+		for k, v := range n {
+			if err := walkPolicyRefs(path+"."+k, v, ws, mode); err != nil {
+				return err
+			}
+		}
+	case []interface{}:
+		for i, item := range n {
+			if err := walkPolicyRefs(fmt.Sprintf("%s[%d]", path, i), item, ws, mode); err != nil {
+				return err
+			}
+		}
+	case Policy:
+		return walkPolicyRefs(path, map[string]interface{}(n), ws, mode)
+	}
+	return nil
+}
+
+func validateTransitionOverlaps(wf *Workflow) error {
+	// Group transitions by from-state + on event.
+	type key struct {
+		from string
+		on   string
+	}
+	type item struct {
+		name string
+		when map[string]interface{}
+	}
+	groups := map[key][]item{}
+	for name, tr := range wf.Transitions {
+		fromStates, err := FromStates(tr.From)
+		if err != nil {
+			return err
+		}
+		on := strings.TrimSpace(tr.On)
+		for _, fs := range fromStates {
+			k := key{from: fs, on: on}
+			groups[k] = append(groups[k], item{name: name, when: tr.When})
+		}
+	}
+	for k, items := range groups {
+		if len(items) < 2 {
+			continue
+		}
+		// Same from+on with empty on is still ambiguous if both match.
+		for i := 0; i < len(items); i++ {
+			for j := i + 1; j < len(items); j++ {
+				overlap, witness := ClausesOverlap(items[i].when, items[j].when)
+				if overlap {
+					ctx := fmt.Sprintf("transitions from state %q on %q", k.from, k.on)
+					if k.on == "" {
+						ctx = fmt.Sprintf("transitions from state %q", k.from)
+					}
+					return fmt.Errorf("%s", FormatOverlapError(ctx, k.from,
+						[]string{"transitions." + items[i].name, "transitions." + items[j].name},
+						witness))
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func validateEventClauseOverlaps(workflowName, eventName string, clauses []EventClause) error {
+	// Group by from state.
+	type item struct {
+		index int
+		when  map[string]interface{}
+	}
+	byState := map[string][]item{}
+	for i, clause := range clauses {
+		fromStates, err := FromStates(clause.From)
+		if err != nil {
+			return err
+		}
+		for _, fs := range fromStates {
+			byState[fs] = append(byState[fs], item{index: i, when: clause.When})
+		}
+	}
+	for state, items := range byState {
+		if len(items) < 2 {
+			continue
+		}
+		for i := 0; i < len(items); i++ {
+			for j := i + 1; j < len(items); j++ {
+				overlap, witness := ClausesOverlap(items[i].when, items[j].when)
+				if overlap {
+					ctx := fmt.Sprintf("event %q", eventName)
+					paths := []string{
+						fmt.Sprintf("events.%s.clauses[%d]", eventName, items[i].index),
+						fmt.Sprintf("events.%s.clauses[%d]", eventName, items[j].index),
+					}
+					return fmt.Errorf("workflow %q: %s", workflowName, FormatOverlapError(ctx, state, paths, witness))
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/types/v2/workflow_validate.go
+++ b/pkg/types/v2/workflow_validate.go
@@ -105,6 +105,9 @@ func ValidateWorkflow(wf *Workflow) (*ResolvedWorkflow, error) {
 		if st.Phase != "" && !IsDisplayPhase(st.Phase) {
 			return nil, fmt.Errorf("workflow %q: states.%s.phase %q is unsupported", wf.Name, name, st.Phase)
 		}
+		if wf.Enabled && st.Phase == "" {
+			return nil, fmt.Errorf("workflow %q: states.%s.phase is required when the workflow is enabled", wf.Name, name)
+		}
 		if err := validateNoTranscriptFacts(fmt.Sprintf("states.%s.invariant", name), st.Invariant); err != nil {
 			return nil, fmt.Errorf("workflow %q: %w", wf.Name, err)
 		}

--- a/pkg/types/v2/workspace.go
+++ b/pkg/types/v2/workspace.go
@@ -11,6 +11,7 @@ type Workspace struct {
 	CI            *CIBlock               `yaml:"ci,omitempty" json:"ci,omitempty"`
 	IssueTrackers *ConnectionsOnlyBlock  `yaml:"issue_trackers,omitempty" json:"issue_trackers,omitempty"`
 	ReviewSystems *ConnectionsOnlyBlock  `yaml:"review_systems,omitempty" json:"review_systems,omitempty"`
+	Knowledge     *KnowledgeBlock        `yaml:"knowledge,omitempty" json:"knowledge,omitempty"`
 	Raw           map[string]interface{} `yaml:"-" json:"-"`
 }
 
@@ -56,6 +57,38 @@ type CIBlock struct {
 type ConnectionsOnlyBlock struct {
 	Connections map[string]Connection `yaml:"connections,omitempty" json:"connections,omitempty"`
 }
+
+// KnowledgeBlock declares the organizational and repository context that the
+// hub may assemble for a run. Workflows consume the resulting context bundle;
+// they do not choose repositories or credentials themselves.
+type KnowledgeBlock struct {
+	Connections map[string]Connection      `yaml:"connections,omitempty" json:"connections,omitempty"`
+	Sources     map[string]KnowledgeSource `yaml:"sources,omitempty" json:"sources,omitempty"`
+}
+
+// KnowledgeSource is one versionable input to run context assembly.
+// Repository names, when present, refer to the workspace repository map. An
+// empty repository list on repository_files means all dynamically relevant
+// workspace repositories, not an unrestricted checkout.
+type KnowledgeSource struct {
+	Type         string                 `yaml:"type" json:"type"`
+	Scope        string                 `yaml:"scope" json:"scope"`
+	Required     bool                   `yaml:"required,omitempty" json:"required,omitempty"`
+	Connection   string                 `yaml:"connection,omitempty" json:"connection,omitempty"`
+	Repositories []string               `yaml:"repositories,omitempty" json:"repositories,omitempty"`
+	Paths        []string               `yaml:"paths,omitempty" json:"paths,omitempty"`
+	Query        string                 `yaml:"query,omitempty" json:"query,omitempty"`
+	Parameters   map[string]interface{} `yaml:"parameters,omitempty" json:"parameters,omitempty"`
+}
+
+const (
+	KnowledgeTypeWorkspaceFiles  = "workspace_files"
+	KnowledgeTypeRepositoryFiles = "repository_files"
+	KnowledgeTypeRetrieval       = "retrieval"
+
+	KnowledgeScopeOrganization = "organization"
+	KnowledgeScopeRepository   = "repository"
+)
 
 // Connection is a named provider endpoint + auth + optional capability narrows.
 type Connection struct {
@@ -146,6 +179,15 @@ func (w *Workspace) HasReviewSystemConnection(name string) bool {
 		return false
 	}
 	_, ok := w.ReviewSystems.Connections[name]
+	return ok
+}
+
+// HasKnowledgeConnection reports whether a knowledge connection exists.
+func (w *Workspace) HasKnowledgeConnection(name string) bool {
+	if w == nil || w.Knowledge == nil || w.Knowledge.Connections == nil {
+		return false
+	}
+	_, ok := w.Knowledge.Connections[name]
 	return ok
 }
 

--- a/pkg/types/v2/workspace.go
+++ b/pkg/types/v2/workspace.go
@@ -1,0 +1,168 @@
+package v2
+
+// Workspace is the authored workspace v2 document (issue #544).
+type Workspace struct {
+	SchemaVersion interface{}            `yaml:"schema_version" json:"schema_version"`
+	Name          string                 `yaml:"name" json:"name"`
+	Repositories  map[string]Repository  `yaml:"repositories,omitempty" json:"repositories,omitempty"`
+	Execution     *Execution             `yaml:"execution,omitempty" json:"execution,omitempty"`
+	Credentials   map[string]Credential  `yaml:"credentials,omitempty" json:"credentials,omitempty"`
+	SourceControl *SourceControlBlock    `yaml:"source_control,omitempty" json:"source_control,omitempty"`
+	CI            *CIBlock               `yaml:"ci,omitempty" json:"ci,omitempty"`
+	IssueTrackers *ConnectionsOnlyBlock  `yaml:"issue_trackers,omitempty" json:"issue_trackers,omitempty"`
+	ReviewSystems *ConnectionsOnlyBlock  `yaml:"review_systems,omitempty" json:"review_systems,omitempty"`
+	Raw           map[string]interface{} `yaml:"-" json:"-"`
+}
+
+// Repository is a named checkout target.
+type Repository struct {
+	Provider      string    `yaml:"provider" json:"provider"`
+	Repository    string    `yaml:"repository" json:"repository"`
+	SourceControl string    `yaml:"source_control,omitempty" json:"source_control,omitempty"`
+	Checkout      *Checkout `yaml:"checkout,omitempty" json:"checkout,omitempty"`
+}
+
+// Checkout configures clone depth/ref.
+type Checkout struct {
+	Ref   string `yaml:"ref,omitempty" json:"ref,omitempty"`
+	Depth string `yaml:"depth,omitempty" json:"depth,omitempty"`
+}
+
+// Execution describes the agent execution environment.
+type Execution struct {
+	Provider string   `yaml:"provider,omitempty" json:"provider,omitempty"`
+	Nix      bool     `yaml:"nix,omitempty" json:"nix,omitempty"`
+	Docker   bool     `yaml:"docker,omitempty" json:"docker,omitempty"`
+	Tools    []string `yaml:"tools,omitempty" json:"tools,omitempty"`
+}
+
+// Credential is a named secret reference (name only; never a secret value).
+type Credential struct {
+	Secret string `yaml:"secret" json:"secret"`
+}
+
+// SourceControlBlock holds source-control connections.
+type SourceControlBlock struct {
+	Connections map[string]Connection `yaml:"connections,omitempty" json:"connections,omitempty"`
+}
+
+// CIBlock holds CI connections and repository-specific pipelines.
+type CIBlock struct {
+	Connections map[string]Connection `yaml:"connections,omitempty" json:"connections,omitempty"`
+	Pipelines   map[string]Pipeline   `yaml:"pipelines,omitempty" json:"pipelines,omitempty"`
+}
+
+// ConnectionsOnlyBlock is used by issue_trackers and review_systems.
+type ConnectionsOnlyBlock struct {
+	Connections map[string]Connection `yaml:"connections,omitempty" json:"connections,omitempty"`
+}
+
+// Connection is a named provider endpoint + auth + optional capability narrows.
+type Connection struct {
+	Provider               string          `yaml:"provider" json:"provider"`
+	BaseURL                string          `yaml:"base_url,omitempty" json:"base_url,omitempty"`
+	Credentials            string          `yaml:"credentials,omitempty" json:"credentials,omitempty"`
+	SourceControl          string          `yaml:"source_control,omitempty" json:"source_control,omitempty"`
+	CapabilityRestrictions map[string]bool `yaml:"capability_restrictions,omitempty" json:"capability_restrictions,omitempty"`
+}
+
+// Pipeline is a repository-specific CI workload bound to a connection.
+type Pipeline struct {
+	Connection string `yaml:"connection" json:"connection"`
+	Repository string `yaml:"repository" json:"repository"`
+	Workflow   string `yaml:"workflow,omitempty" json:"workflow,omitempty"`
+	Project    string `yaml:"project,omitempty" json:"project,omitempty"`
+	Pipeline   string `yaml:"pipeline,omitempty" json:"pipeline,omitempty"`
+	Job        string `yaml:"job,omitempty" json:"job,omitempty"`
+}
+
+// ResolvedWorkspace is a validated workspace plus resolved connection capabilities.
+type ResolvedWorkspace struct {
+	Workspace             *Workspace
+	Revision              ContentDigest
+	ResolvedCICaps        map[string]map[ConnectionCapability]bool // connection name -> caps
+	ResolvedSourceControl map[string]map[ConnectionCapability]bool
+	ResolvedIssueTrackers map[string]map[ConnectionCapability]bool
+	ResolvedReviewSystems map[string]map[ConnectionCapability]bool
+}
+
+// HasCIConnection reports whether a CI connection name exists.
+func (w *Workspace) HasCIConnection(name string) bool {
+	if w == nil || w.CI == nil || w.CI.Connections == nil {
+		return false
+	}
+	_, ok := w.CI.Connections[name]
+	return ok
+}
+
+// HasCIPipeline reports whether a CI pipeline name exists.
+func (w *Workspace) HasCIPipeline(name string) bool {
+	if w == nil || w.CI == nil || w.CI.Pipelines == nil {
+		return false
+	}
+	_, ok := w.CI.Pipelines[name]
+	return ok
+}
+
+// HasRepository reports whether a named repository exists.
+func (w *Workspace) HasRepository(name string) bool {
+	if w == nil || w.Repositories == nil {
+		return false
+	}
+	_, ok := w.Repositories[name]
+	return ok
+}
+
+// HasCredential reports whether a named credential exists.
+func (w *Workspace) HasCredential(name string) bool {
+	if w == nil || w.Credentials == nil {
+		return false
+	}
+	_, ok := w.Credentials[name]
+	return ok
+}
+
+// HasSourceControlConnection reports whether a source-control connection exists.
+func (w *Workspace) HasSourceControlConnection(name string) bool {
+	if w == nil || w.SourceControl == nil || w.SourceControl.Connections == nil {
+		return false
+	}
+	_, ok := w.SourceControl.Connections[name]
+	return ok
+}
+
+// HasIssueTrackerConnection reports whether an issue-tracker connection exists.
+func (w *Workspace) HasIssueTrackerConnection(name string) bool {
+	if w == nil || w.IssueTrackers == nil || w.IssueTrackers.Connections == nil {
+		return false
+	}
+	_, ok := w.IssueTrackers.Connections[name]
+	return ok
+}
+
+// HasReviewSystemConnection reports whether a review-system connection exists.
+func (w *Workspace) HasReviewSystemConnection(name string) bool {
+	if w == nil || w.ReviewSystems == nil || w.ReviewSystems.Connections == nil {
+		return false
+	}
+	_, ok := w.ReviewSystems.Connections[name]
+	return ok
+}
+
+// CIConnection returns a CI connection by name.
+func (w *Workspace) CIConnection(name string) (Connection, bool) {
+	if w == nil || w.CI == nil || w.CI.Connections == nil {
+		return Connection{}, false
+	}
+	c, ok := w.CI.Connections[name]
+	return c, ok
+}
+
+// CIPipeline returns a CI pipeline by name.
+func (w *Workspace) CIPipeline(name string) (Pipeline, bool) {
+	if w == nil || w.CI == nil || w.CI.Pipelines == nil {
+		return Pipeline{}, false
+	}
+	p, ok := w.CI.Pipelines[name]
+	return p, ok
+}

--- a/pkg/types/v2/workspace_test.go
+++ b/pkg/types/v2/workspace_test.go
@@ -1,0 +1,238 @@
+package v2_test
+
+import (
+	"strings"
+	"testing"
+
+	v2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
+)
+
+const validWorkspaceYAML = `
+schema_version: 2
+name: elasticclaw
+
+repositories:
+  primary:
+    provider: github
+    repository: elasticclaw/elasticclaw
+    source_control: github-production
+    checkout:
+      ref: default
+      depth: full
+
+execution:
+  provider: daytona-production
+  nix: true
+  docker: true
+  tools:
+    - git
+    - gh
+    - depot
+
+credentials:
+  github_app:
+    secret: GITHUB_APP_PRIVATE_KEY
+  depot_token:
+    secret: DEPOT_TOKEN
+  jenkins_token:
+    secret: JENKINS_TOKEN
+  linear_api_key:
+    secret: LINEAR_API_KEY
+
+source_control:
+  connections:
+    github-production:
+      provider: github
+      credentials: github_app
+
+ci:
+  connections:
+    github-production:
+      provider: github_actions
+      source_control: github-production
+      credentials: github_app
+      capability_restrictions:
+        trigger_run: false
+        cancel_run: false
+
+    depot-production:
+      provider: depot
+      credentials: depot_token
+
+    corporate-jenkins:
+      provider: jenkins
+      base_url: https://jenkins.example.com
+      credentials: jenkins_token
+
+  pipelines:
+    github-pr:
+      connection: github-production
+      repository: primary
+      workflow: ci.yml
+
+    depot-container:
+      connection: depot-production
+      repository: primary
+      project: elasticclaw
+      pipeline: container-build
+
+    jenkins-release:
+      connection: corporate-jenkins
+      repository: primary
+      job: release-validation
+
+issue_trackers:
+  connections:
+    product-linear:
+      provider: linear
+      credentials: linear_api_key
+
+review_systems:
+  connections:
+    github-reviews:
+      provider: github
+      source_control: github-production
+    greptile:
+      provider: greptile
+      source_control: github-production
+`
+
+func TestParseAndValidateWorkspaceValidRFCShape(t *testing.T) {
+	resolved, err := v2.ParseAndValidateWorkspace([]byte(validWorkspaceYAML))
+	if err != nil {
+		t.Fatalf("ParseAndValidateWorkspace: %v", err)
+	}
+	if resolved.Workspace.Name != "elasticclaw" {
+		t.Fatalf("name = %q", resolved.Workspace.Name)
+	}
+	if resolved.Revision == "" {
+		t.Fatal("expected non-empty revision digest")
+	}
+	// capability restrictions narrow trigger_run
+	caps := resolved.ResolvedCICaps["github-production"]
+	if caps[v2.CapTriggerRun] {
+		t.Fatal("expected trigger_run to be restricted false")
+	}
+	if !caps[v2.CapObserveRuns] {
+		t.Fatal("expected observe_runs to remain true")
+	}
+	if !resolved.Workspace.HasCIPipeline("github-pr") {
+		t.Fatal("expected github-pr pipeline")
+	}
+}
+
+func TestWorkspaceRevisionStableAcrossCalls(t *testing.T) {
+	a, err := v2.ParseAndValidateWorkspace([]byte(validWorkspaceYAML))
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := v2.ParseAndValidateWorkspace([]byte(validWorkspaceYAML))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a.Revision == "" || a.Revision != b.Revision {
+		t.Fatalf("revisions not stable: %q vs %q", a.Revision, b.Revision)
+	}
+}
+
+func TestWorkspaceRejectsUnknownField(t *testing.T) {
+	yaml := `
+schema_version: 2
+name: x
+unknown_top_level: true
+`
+	_, err := v2.ParseAndValidateWorkspace([]byte(yaml))
+	if err == nil || !strings.Contains(err.Error(), "unknown field") {
+		t.Fatalf("error = %v, want unknown field", err)
+	}
+}
+
+func TestWorkspaceRejectsUnknownPipelineConnection(t *testing.T) {
+	yaml := `
+schema_version: 2
+name: x
+repositories:
+  primary:
+    provider: github
+    repository: org/repo
+credentials:
+  tok:
+    secret: TOKEN
+ci:
+  connections:
+    c1:
+      provider: github_actions
+      credentials: tok
+  pipelines:
+    p1:
+      connection: missing-conn
+      repository: primary
+`
+	_, err := v2.ParseAndValidateWorkspace([]byte(yaml))
+	if err == nil || !strings.Contains(err.Error(), "unknown ci connection") {
+		t.Fatalf("error = %v, want unknown ci connection", err)
+	}
+}
+
+func TestWorkspaceRejectsMissingCredential(t *testing.T) {
+	yaml := `
+schema_version: 2
+name: x
+ci:
+  connections:
+    c1:
+      provider: github_actions
+      credentials: missing_cred
+`
+	_, err := v2.ParseAndValidateWorkspace([]byte(yaml))
+	if err == nil || !strings.Contains(err.Error(), "unknown credential") {
+		t.Fatalf("error = %v, want unknown credential", err)
+	}
+}
+
+func TestWorkspaceRejectsCapabilityGrantBeyondProvider(t *testing.T) {
+	// greptile provider only has observe_runs + reconcile; granting trigger_run invents a capability.
+	yaml := `
+schema_version: 2
+name: x
+source_control:
+  connections:
+    sc:
+      provider: github
+review_systems:
+  connections:
+    greptile:
+      provider: greptile
+      source_control: sc
+      capability_restrictions:
+        trigger_run: true
+`
+	_, err := v2.ParseAndValidateWorkspace([]byte(yaml))
+	if err == nil || !strings.Contains(err.Error(), "cannot grant capability") {
+		t.Fatalf("error = %v, want cannot grant capability", err)
+	}
+}
+
+func TestWorkspaceRejectsNonV2(t *testing.T) {
+	yaml := `
+schema_version: v1
+name: x
+`
+	_, err := v2.ParseAndValidateWorkspace([]byte(yaml))
+	if err == nil || !strings.Contains(err.Error(), "not v2") {
+		t.Fatalf("error = %v, want not v2", err)
+	}
+}
+
+func TestIsV2AcceptsIntegerAndV2Forms(t *testing.T) {
+	if !v2.IsV2("2") || !v2.IsV2("v2") || !v2.IsV2("V2") {
+		t.Fatal("expected 2/v2 accepted")
+	}
+	if v2.IsV2("v1") || v2.IsV2("") || v2.IsV2("1") {
+		t.Fatal("expected v1/empty/1 rejected as v2")
+	}
+	ver, err := v2.DetectSchemaVersion([]byte("schema_version: 2\nname: x\n"))
+	if err != nil || ver != "2" {
+		t.Fatalf("DetectSchemaVersion = %q, %v", ver, err)
+	}
+}

--- a/pkg/types/v2/workspace_test.go
+++ b/pkg/types/v2/workspace_test.go
@@ -95,6 +95,29 @@ review_systems:
     greptile:
       provider: greptile
       source_control: github-production
+
+knowledge:
+  connections:
+    handbook-search:
+      provider: rag
+      base_url: https://knowledge.example.com
+      credentials: linear_api_key
+  sources:
+    engineering-principles:
+      type: workspace_files
+      scope: organization
+      required: true
+      paths: [ENGINEERING.md, PRODUCT.md]
+    repository-instructions:
+      type: repository_files
+      scope: repository
+      required: true
+      paths: [AGENTS.md]
+    architecture-search:
+      type: retrieval
+      scope: organization
+      connection: handbook-search
+      query: architecture decisions relevant to the task
 `
 
 func TestParseAndValidateWorkspaceValidRFCShape(t *testing.T) {
@@ -118,6 +141,48 @@ func TestParseAndValidateWorkspaceValidRFCShape(t *testing.T) {
 	}
 	if !resolved.Workspace.HasCIPipeline("github-pr") {
 		t.Fatal("expected github-pr pipeline")
+	}
+	if !resolved.Workspace.HasKnowledgeConnection("handbook-search") {
+		t.Fatal("expected handbook-search knowledge connection")
+	}
+}
+
+func TestWorkspaceKnowledgeCannotEscapeRepositoryAuthority(t *testing.T) {
+	yaml := `
+schema_version: 2
+name: x
+repositories:
+  primary:
+    provider: github
+    repository: org/repo
+knowledge:
+  sources:
+    instructions:
+      type: repository_files
+      scope: repository
+      repositories: [not-allowed]
+      paths: [AGENTS.md]
+`
+	_, err := v2.ParseAndValidateWorkspace([]byte(yaml))
+	if err == nil || !strings.Contains(err.Error(), "unknown repository") {
+		t.Fatalf("error = %v, want unknown repository", err)
+	}
+}
+
+func TestWorkspaceKnowledgeRejectsUnsafePath(t *testing.T) {
+	yaml := `
+schema_version: 2
+name: x
+knowledge:
+  sources:
+    principles:
+      type: workspace_files
+      scope: organization
+      paths: [../secret]
+`
+	_, err := v2.ParseAndValidateWorkspace([]byte(yaml))
+	if err == nil || !strings.Contains(err.Error(), "relative path") {
+		t.Fatalf("error = %v, want relative path", err)
 	}
 }
 

--- a/pkg/types/v2/workspace_validate.go
+++ b/pkg/types/v2/workspace_validate.go
@@ -1,7 +1,9 @@
 package v2
 
 import (
+	"bytes"
 	"fmt"
+	pathpkg "path"
 	"regexp"
 	"strings"
 
@@ -22,6 +24,7 @@ var knownWorkspaceKeys = map[string]bool{
 	"ci":             true,
 	"issue_trackers": true,
 	"review_systems": true,
+	"knowledge":      true,
 }
 
 // ParseWorkspace unmarshals workspace v2 YAML. It does not validate.
@@ -45,7 +48,9 @@ func ParseWorkspace(data []byte) (*Workspace, error) {
 	}
 
 	var ws Workspace
-	if err := yaml.Unmarshal(data, &ws); err != nil {
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&ws); err != nil {
 		return nil, fmt.Errorf("parse workspace: %w", err)
 	}
 	ws.Raw = raw
@@ -175,6 +180,21 @@ func ValidateWorkspace(ws *Workspace) (*ResolvedWorkspace, error) {
 		}
 	}
 
+	// Knowledge connections and sources. Sources are workspace-owned so a
+	// workflow can never expand repository or credential authority.
+	if ws.Knowledge != nil {
+		for name, conn := range ws.Knowledge.Connections {
+			if err := validateConnection("knowledge.connections", name, conn, ws); err != nil {
+				return nil, err
+			}
+		}
+		for name, source := range ws.Knowledge.Sources {
+			if err := validateKnowledgeSource(name, source, ws); err != nil {
+				return nil, err
+			}
+		}
+	}
+
 	resolvedSC := map[string]map[ConnectionCapability]bool{}
 	if ws.SourceControl != nil {
 		for name, conn := range ws.SourceControl.Connections {
@@ -197,6 +217,66 @@ func ValidateWorkspace(ws *Workspace) (*ResolvedWorkspace, error) {
 		ResolvedIssueTrackers: resolvedIT,
 		ResolvedReviewSystems: resolvedRS,
 	}, nil
+}
+
+func validateKnowledgeSource(name string, source KnowledgeSource, ws *Workspace) error {
+	if err := validateResourceName("knowledge.sources", name); err != nil {
+		return err
+	}
+	path := "knowledge.sources." + name
+	kind := strings.TrimSpace(source.Type)
+	switch kind {
+	case KnowledgeTypeWorkspaceFiles, KnowledgeTypeRepositoryFiles, KnowledgeTypeRetrieval:
+	case "":
+		return fmt.Errorf("%s.type is required", path)
+	default:
+		return fmt.Errorf("%s.type %q is unsupported", path, kind)
+	}
+	scope := strings.TrimSpace(source.Scope)
+	if scope != KnowledgeScopeOrganization && scope != KnowledgeScopeRepository {
+		return fmt.Errorf("%s.scope %q must be %q or %q", path, scope, KnowledgeScopeOrganization, KnowledgeScopeRepository)
+	}
+
+	if kind == KnowledgeTypeRetrieval {
+		if strings.TrimSpace(source.Connection) == "" {
+			return fmt.Errorf("%s.connection is required for retrieval", path)
+		}
+		if !ws.HasKnowledgeConnection(source.Connection) {
+			return fmt.Errorf("%s.connection %q: unknown knowledge connection", path, source.Connection)
+		}
+	} else if strings.TrimSpace(source.Connection) != "" {
+		return fmt.Errorf("%s.connection is only valid for retrieval", path)
+	}
+
+	if kind == KnowledgeTypeWorkspaceFiles || kind == KnowledgeTypeRepositoryFiles {
+		if len(source.Paths) == 0 {
+			return fmt.Errorf("%s.paths is required for %s", path, kind)
+		}
+		for i, p := range source.Paths {
+			p = strings.TrimSpace(p)
+			if p == "" || strings.HasPrefix(p, "/") || pathpkg.Clean(p) != p || hasParentPathSegment(p) {
+				return fmt.Errorf("%s.paths[%d] %q must be a non-empty relative path without '..'", path, i, p)
+			}
+		}
+	}
+	if kind != KnowledgeTypeRepositoryFiles && len(source.Repositories) > 0 {
+		return fmt.Errorf("%s.repositories is only valid for repository_files", path)
+	}
+	for i, repo := range source.Repositories {
+		if !ws.HasRepository(repo) {
+			return fmt.Errorf("%s.repositories[%d] %q: unknown repository", path, i, repo)
+		}
+	}
+	return nil
+}
+
+func hasParentPathSegment(value string) bool {
+	for _, segment := range strings.Split(value, "/") {
+		if segment == ".." {
+			return true
+		}
+	}
+	return false
 }
 
 // ParseAndValidateWorkspace is the shipped entry point for workspace v2 YAML.

--- a/pkg/types/v2/workspace_validate.go
+++ b/pkg/types/v2/workspace_validate.go
@@ -1,0 +1,268 @@
+package v2
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+var secretNameRegex = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+var resourceNameRegex = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_.-]*$`)
+
+// known workspace top-level keys for v2 (unknown keys are rejected).
+var knownWorkspaceKeys = map[string]bool{
+	"schema_version": true,
+	"name":           true,
+	"repositories":   true,
+	"execution":      true,
+	"credentials":    true,
+	"source_control": true,
+	"ci":             true,
+	"issue_trackers": true,
+	"review_systems": true,
+}
+
+// ParseWorkspace unmarshals workspace v2 YAML. It does not validate.
+func ParseWorkspace(data []byte) (*Workspace, error) {
+	version, err := DetectSchemaVersion(data)
+	if err != nil {
+		return nil, err
+	}
+	if !IsV2(version) {
+		return nil, fmt.Errorf("workspace schema_version %q is not v2 (want 2 or v2)", version)
+	}
+
+	var raw map[string]interface{}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parse workspace yaml: %w", err)
+	}
+	for key := range raw {
+		if !knownWorkspaceKeys[key] {
+			return nil, fmt.Errorf("workspace: unknown field %q", key)
+		}
+	}
+
+	var ws Workspace
+	if err := yaml.Unmarshal(data, &ws); err != nil {
+		return nil, fmt.Errorf("parse workspace: %w", err)
+	}
+	ws.Raw = raw
+	return &ws, nil
+}
+
+// ValidateWorkspace structurally validates a parsed workspace v2 document and
+// returns a resolved view with capability intersections and content revision.
+func ValidateWorkspace(ws *Workspace) (*ResolvedWorkspace, error) {
+	if ws == nil {
+		return nil, fmt.Errorf("workspace is nil")
+	}
+	if !IsV2(SchemaVersionString(ws.SchemaVersion)) {
+		return nil, fmt.Errorf("workspace schema_version %q is not v2", SchemaVersionString(ws.SchemaVersion))
+	}
+	if strings.TrimSpace(ws.Name) == "" {
+		return nil, fmt.Errorf("workspace name is required")
+	}
+
+	// Credentials: secret name refs only.
+	for name, cred := range ws.Credentials {
+		if err := validateResourceName("credentials", name); err != nil {
+			return nil, err
+		}
+		secret := strings.TrimSpace(cred.Secret)
+		if secret == "" {
+			return nil, fmt.Errorf("credentials.%s.secret is required", name)
+		}
+		if !secretNameRegex.MatchString(secret) {
+			return nil, fmt.Errorf("credentials.%s.secret %q must be a secret name reference (not a secret value)", name, secret)
+		}
+		// Reject obvious embedded material (multiline / PEM / whitespace).
+		if strings.Contains(secret, "\n") || strings.Contains(secret, "BEGIN ") {
+			return nil, fmt.Errorf("credentials.%s.secret must be a secret name reference, not embedded material", name)
+		}
+	}
+
+	// Source-control connections.
+	if ws.SourceControl != nil {
+		for name, conn := range ws.SourceControl.Connections {
+			if err := validateConnection("source_control.connections", name, conn, ws); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	// Repositories.
+	for name, repo := range ws.Repositories {
+		if err := validateResourceName("repositories", name); err != nil {
+			return nil, err
+		}
+		if strings.TrimSpace(repo.Provider) == "" {
+			return nil, fmt.Errorf("repositories.%s.provider is required", name)
+		}
+		if strings.TrimSpace(repo.Repository) == "" {
+			return nil, fmt.Errorf("repositories.%s.repository is required", name)
+		}
+		if sc := strings.TrimSpace(repo.SourceControl); sc != "" {
+			if !ws.HasSourceControlConnection(sc) {
+				return nil, fmt.Errorf("repositories.%s.source_control %q: unknown source_control connection", name, sc)
+			}
+		}
+	}
+
+	// CI connections and pipelines.
+	resolvedCI := map[string]map[ConnectionCapability]bool{}
+	if ws.CI != nil {
+		for name, conn := range ws.CI.Connections {
+			if err := validateConnection("ci.connections", name, conn, ws); err != nil {
+				return nil, err
+			}
+			if sc := strings.TrimSpace(conn.SourceControl); sc != "" && !ws.HasSourceControlConnection(sc) {
+				return nil, fmt.Errorf("ci.connections.%s.source_control %q: unknown source_control connection", name, sc)
+			}
+			if err := validateCapabilityRestrictions("ci.connections."+name, conn); err != nil {
+				return nil, err
+			}
+			resolvedCI[name] = ResolveCapabilities(conn.Provider, conn.CapabilityRestrictions)
+		}
+		for name, pipe := range ws.CI.Pipelines {
+			if err := validateResourceName("ci.pipelines", name); err != nil {
+				return nil, err
+			}
+			if strings.TrimSpace(pipe.Connection) == "" {
+				return nil, fmt.Errorf("ci.pipelines.%s.connection is required", name)
+			}
+			if !ws.HasCIConnection(pipe.Connection) {
+				return nil, fmt.Errorf("ci.pipelines.%s.connection %q: unknown ci connection", name, pipe.Connection)
+			}
+			if strings.TrimSpace(pipe.Repository) == "" {
+				return nil, fmt.Errorf("ci.pipelines.%s.repository is required", name)
+			}
+			if !ws.HasRepository(pipe.Repository) {
+				return nil, fmt.Errorf("ci.pipelines.%s.repository %q: unknown repository", name, pipe.Repository)
+			}
+		}
+	}
+
+	// Issue trackers.
+	resolvedIT := map[string]map[ConnectionCapability]bool{}
+	if ws.IssueTrackers != nil {
+		for name, conn := range ws.IssueTrackers.Connections {
+			if err := validateConnection("issue_trackers.connections", name, conn, ws); err != nil {
+				return nil, err
+			}
+			if err := validateCapabilityRestrictions("issue_trackers.connections."+name, conn); err != nil {
+				return nil, err
+			}
+			resolvedIT[name] = ResolveCapabilities(conn.Provider, conn.CapabilityRestrictions)
+		}
+	}
+
+	// Review systems.
+	resolvedRS := map[string]map[ConnectionCapability]bool{}
+	if ws.ReviewSystems != nil {
+		for name, conn := range ws.ReviewSystems.Connections {
+			if err := validateConnection("review_systems.connections", name, conn, ws); err != nil {
+				return nil, err
+			}
+			if sc := strings.TrimSpace(conn.SourceControl); sc != "" && !ws.HasSourceControlConnection(sc) {
+				return nil, fmt.Errorf("review_systems.connections.%s.source_control %q: unknown source_control connection", name, sc)
+			}
+			if err := validateCapabilityRestrictions("review_systems.connections."+name, conn); err != nil {
+				return nil, err
+			}
+			resolvedRS[name] = ResolveCapabilities(conn.Provider, conn.CapabilityRestrictions)
+		}
+	}
+
+	resolvedSC := map[string]map[ConnectionCapability]bool{}
+	if ws.SourceControl != nil {
+		for name, conn := range ws.SourceControl.Connections {
+			if err := validateCapabilityRestrictions("source_control.connections."+name, conn); err != nil {
+				return nil, err
+			}
+			resolvedSC[name] = ResolveCapabilities(conn.Provider, conn.CapabilityRestrictions)
+		}
+	}
+
+	rev, err := RevisionOf(ws)
+	if err != nil {
+		return nil, err
+	}
+	return &ResolvedWorkspace{
+		Workspace:             ws,
+		Revision:              rev,
+		ResolvedCICaps:        resolvedCI,
+		ResolvedSourceControl: resolvedSC,
+		ResolvedIssueTrackers: resolvedIT,
+		ResolvedReviewSystems: resolvedRS,
+	}, nil
+}
+
+// ParseAndValidateWorkspace is the shipped entry point for workspace v2 YAML.
+func ParseAndValidateWorkspace(data []byte) (*ResolvedWorkspace, error) {
+	ws, err := ParseWorkspace(data)
+	if err != nil {
+		return nil, err
+	}
+	return ValidateWorkspace(ws)
+}
+
+func validateResourceName(section, name string) error {
+	if strings.TrimSpace(name) == "" {
+		return fmt.Errorf("%s: empty resource name", section)
+	}
+	if !resourceNameRegex.MatchString(name) {
+		return fmt.Errorf("%s.%s: invalid resource name", section, name)
+	}
+	return nil
+}
+
+func validateConnection(path, name string, conn Connection, ws *Workspace) error {
+	if err := validateResourceName(path, name); err != nil {
+		return err
+	}
+	if strings.TrimSpace(conn.Provider) == "" {
+		return fmt.Errorf("%s.%s.provider is required", path, name)
+	}
+	if cred := strings.TrimSpace(conn.Credentials); cred != "" {
+		if !ws.HasCredential(cred) {
+			return fmt.Errorf("%s.%s.credentials %q: unknown credential (missing credentials.%s)", path, name, cred, cred)
+		}
+	}
+	return nil
+}
+
+func validateCapabilityRestrictions(path string, conn Connection) error {
+	if len(conn.CapabilityRestrictions) == 0 {
+		return nil
+	}
+	providerCaps := ProviderCapabilities(conn.Provider)
+	for capName, enabled := range conn.CapabilityRestrictions {
+		if strings.TrimSpace(capName) == "" {
+			return fmt.Errorf("%s.capability_restrictions: empty capability name", path)
+		}
+		// Workspace may only narrow: setting true when provider lacks the cap invents a grant.
+		if enabled {
+			if !providerCaps[ConnectionCapability(capName)] {
+				return fmt.Errorf("%s.capability_restrictions.%s: cannot grant capability unsupported by provider %q", path, capName, conn.Provider)
+			}
+		}
+		// false is always a legal narrow (even for unknown names we still reject unknown?).
+		// Unknown capability names that are set false are harmless narrows; reject unknown names
+		// that are not in the global catalog to catch typos.
+		if !isKnownCapability(capName) {
+			return fmt.Errorf("%s.capability_restrictions.%s: unknown capability", path, capName)
+		}
+	}
+	return nil
+}
+
+func isKnownCapability(name string) bool {
+	for _, c := range AllConnectionCapabilities {
+		if string(c) == name {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Reshapes the schema foundation from RFC #544 around the normative v2 addendum:

- defines strict workspace/workflow v2 parsing, validation, immutable revisions, deterministic states/transitions, protected facts, policies, effects, and ambiguity rejection;
- adds the fixed display phases `SETUP → CONTEXT → PLAN → BUILD → TEST → PR → REVIEW → DONE`, while allowing authored states and feedback loops to map onto those phases;
- adds workspace-owned organizational/repository knowledge sources for versioned context assembly;
- adds dynamic delivery constraints with no workflow repository list: a claw submits zero or more PR URL claims, and the hub contract records independently verified, amendable, HEAD-specific PR subjects;
- defines the dedicated bidirectional `control.v2` envelope, message directions, durable dispositions, CAS state versions, bridge protocol negotiation, snapshots, task heartbeat/deadline/status, evidence provenance, context bundles, and delivery manifests;
- rejects conversation/transcript event namespaces and facts as workflow v2 control inputs;
- makes v1→v2 conversion explicit and conservative; transcript markers remain warnings and converted workflows are emitted as disabled drafts;
- validates v2 documents at the storage boundary without normalizing them into v1;
- keeps v2 out of legacy PATCH/manual-trigger execution paths until the deterministic runtime lands, and exposes runtime availability in the additive API projection;
- removes the unrelated web commits previously present on this branch.

Workflow v1 remains supported through its existing parser, storage, trigger, transcript-marker, and bridge behavior. This PR does not activate the v2 runtime.

Implements the contract/schema foundation for #544. Durable runtime and control transport will follow in separate vertical-slice PRs.

## Compatibility guarantees

- Existing v1 YAML is neither converted nor reinterpreted.
- Existing v1 tests and execution paths remain unchanged.
- V2 cannot declare transcript-driven control and cannot fall back to the v1 engine.
- Missing `enabled` on v2 is fail-closed; conversion writes `enabled: false` explicitly.
- Old bridge + v1 and new bridge + v1 are valid; v2 requires advertised `control.v2` support before provisioning.
- Workspace repository authority is never expanded by a workflow or delivery claim.

## Test plan

- [x] `go test ./pkg/types/... ./pkg/hub/... ./cmd/...`
- [x] Valid v2 workspace/workflow pair, revision stability, strict unknown-field rejection, protected namespace and ambiguous transition failures
- [x] Context-source path, credential, connection, and repository authority validation
- [x] Dynamic delivery policies reject fixed workflow repository declarations
- [x] Control direction, required identity/state-version, and bridge compatibility matrix
- [x] V2 transcript events/facts rejected; marker text remains inert prose
- [x] Converted v2 workflows are disabled drafts and do not convert v1 transcript markers
- [x] V2 legacy PATCH/trigger paths fail closed without mutating the authored document
- [x] Existing v1 type, hub, pipeline, CLI, and bridge suites pass
