### PR TITLE
feat(hub,cli,web): workflow run history, agent logs, and message preservation

### DIFF
--- a/cmd/workflow.go
+++ b/cmd/workflow.go
@@ -27,6 +27,7 @@ func WorkflowCmd() *cobra.Command {
 	cmd.AddCommand(workflowPushCmd())
 	cmd.AddCommand(workflowTriggerCmd())
 	cmd.AddCommand(workflowRunsCmd())
+	cmd.AddCommand(workflowLogsCmd())
 	return cmd
 }
 
@@ -353,7 +354,7 @@ func runWorkflowRuns(workspace, name string, limit int) error {
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "STATUS\tTRIGGER\tSTARTED\tFINISHED\tRESULT\tAGENT")
+	fmt.Fprintln(w, "RUN ID\tSTATUS\tTRIGGER\tSTARTED\tFINISHED\tRESULT\tAGENT")
 	for _, run := range result.Runs {
 		started := "—"
 		if run.StartedAt != nil && !run.StartedAt.IsZero() {
@@ -368,7 +369,8 @@ func runWorkflowRuns(workspace, name string, limit int) error {
 			clawID = shortID(run.ClawID)
 		}
 		resultText := sanitizeWorkflowResultForTable(run.Result, 80)
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			run.ID,
 			run.Status,
 			run.TriggerType,
 			started,
@@ -400,6 +402,143 @@ func sanitizeWorkflowResultForTable(result string, maxRunes int) string {
 		return string(runes[:maxRunes-3]) + "..."
 	}
 	return s
+}
+
+func workflowLogsCmd() *cobra.Command {
+	var workspace string
+	cmd := &cobra.Command{
+		Use:   "logs <workflow> <run-id>",
+		Short: "Show detailed agent logs for a workflow run",
+		Long:  "Show detailed agent activity logs for a workflow run by run ID.",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runWorkflowLogs(workspace, args[0], args[1])
+		},
+	}
+	cmd.Flags().StringVar(&workspace, "workspace", "default", "workspace name")
+	return cmd
+}
+
+func runWorkflowLogs(workspace, name, runID string) error {
+	hubURL, clawToken, err := resolveHubConn()
+	if err != nil {
+		return err
+	}
+
+	runPath := fmt.Sprintf("/api/workspaces/%s/workflows/%s/cron/runs/%s", url.PathEscape(workspace), url.PathEscape(name), url.PathEscape(runID))
+	runReq, _ := http.NewRequest(http.MethodGet, hubURL+runPath, nil)
+	runReq.Header.Set("Authorization", "Bearer "+clawToken)
+	runResp, err := http.DefaultClient.Do(runReq)
+	if err != nil {
+		return fmt.Errorf("fetch workflow run failed: %w", err)
+	}
+	defer runResp.Body.Close()
+	runBody, _ := io.ReadAll(runResp.Body)
+	if runResp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("workflow run %s not found", runID)
+	}
+	if runResp.StatusCode != http.StatusOK {
+		return fmt.Errorf("hub returned %d: %s", runResp.StatusCode, strings.TrimSpace(string(runBody)))
+	}
+	var run types.WorkflowRun
+	if err := json.Unmarshal(runBody, &run); err != nil {
+		return fmt.Errorf("decode run: %w", err)
+	}
+	if run.ClawID == "" {
+		return fmt.Errorf("workflow run %s is not linked to an agent", runID)
+	}
+
+	msgPath := fmt.Sprintf("/api/messages/%s/activity?limit=500", url.PathEscape(run.ClawID))
+	msgReq, _ := http.NewRequest(http.MethodGet, hubURL+msgPath, nil)
+	msgReq.Header.Set("Authorization", "Bearer "+clawToken)
+	msgResp, err := http.DefaultClient.Do(msgReq)
+	if err != nil {
+		return fmt.Errorf("fetch agent logs failed: %w", err)
+	}
+	defer msgResp.Body.Close()
+	msgBody, _ := io.ReadAll(msgResp.Body)
+	if msgResp.StatusCode != http.StatusOK {
+		return fmt.Errorf("hub returned %d: %s", msgResp.StatusCode, strings.TrimSpace(string(msgBody)))
+	}
+	var messages []types.HubMessage
+	if err := json.Unmarshal(msgBody, &messages); err != nil {
+		return fmt.Errorf("decode logs: %w", err)
+	}
+
+	if jsonOut {
+		return json.NewEncoder(os.Stdout).Encode(messages)
+	}
+
+	if len(messages) == 0 {
+		fmt.Printf("No agent logs found for run %s (agent %s).\n", runID, shortID(run.ClawID))
+		return nil
+	}
+
+	fmt.Printf("Agent logs for run %s (agent %s, status %s):\n\n", runID, shortID(run.ClawID), run.Status)
+	for _, msg := range messages {
+		printActivityMessage(msg)
+	}
+	return nil
+}
+
+type agentActivity struct {
+	Kind    string `json:"kind"`
+	Tool    string `json:"tool"`
+	Phase   string `json:"phase"`
+	Detail  string `json:"detail"`
+	Command string `json:"command"`
+	Path    string `json:"path"`
+	URL     string `json:"url"`
+	Message string `json:"message"`
+	Error   string `json:"error"`
+}
+
+func printActivityMessage(msg types.HubMessage) {
+	ts := msg.CreatedAt.Format("2006-01-02 15:04:05")
+	if !strings.HasPrefix(msg.Format, "activity:") {
+		fmt.Printf("%s  %s\n", ts, msg.Content)
+		return
+	}
+	var activity agentActivity
+	if err := json.Unmarshal([]byte(strings.TrimPrefix(msg.Format, "activity:")), &activity); err != nil {
+		fmt.Printf("%s  %s\n", ts, msg.Content)
+		return
+	}
+	label := activity.Tool
+	if label == "" {
+		label = activity.Kind
+	}
+	if label == "" {
+		label = "activity"
+	}
+	fmt.Printf("%s  [%s]", ts, label)
+	if activity.Phase != "" {
+		fmt.Printf(" (%s)", activity.Phase)
+	}
+	var parts []string
+	if activity.Command != "" {
+		parts = append(parts, fmt.Sprintf("cmd: %s", activity.Command))
+	}
+	if activity.Path != "" {
+		parts = append(parts, fmt.Sprintf("path: %s", activity.Path))
+	}
+	if activity.URL != "" {
+		parts = append(parts, fmt.Sprintf("url: %s", activity.URL))
+	}
+	if activity.Detail != "" {
+		parts = append(parts, activity.Detail)
+	}
+	if activity.Message != "" {
+		parts = append(parts, activity.Message)
+	}
+	if activity.Error != "" {
+		parts = append(parts, fmt.Sprintf("error: %s", activity.Error))
+	}
+	if len(parts) == 0 {
+		fmt.Println(" " + msg.Content)
+	} else {
+		fmt.Println(" " + strings.Join(parts, " | "))
+	}
 }
 
 func fetchWorkflowViews(workspace string) ([]workflowCLIView, error) {

--- a/cmd/workflow_test.go
+++ b/cmd/workflow_test.go
@@ -117,6 +117,61 @@ stages:
 	}
 }
 
+func TestRunWorkflowLogsFetchesRunAndActivityMessages(t *testing.T) {
+	started := time.Date(2026, 7, 24, 9, 0, 0, 0, time.UTC)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/workspaces/default/workflows/dependency-update/cron/runs/run-1":
+			_ = json.NewEncoder(w).Encode(types.WorkflowRun{
+				ID:            "run-1",
+				WorkflowName:  "dependency-update",
+				WorkspaceName: "default",
+				TriggerType:   "cron",
+				Status:        "failed",
+				Result:        "provisioning timed out",
+				ClawID:        "claw-1234567890",
+				StartedAt:     &started,
+				CreatedAt:     started,
+			})
+		case "/api/messages/claw-1234567890/activity":
+			_ = json.NewEncoder(w).Encode([]types.HubMessage{
+				{
+					ID:        "msg-1",
+					ClawID:    "claw-1234567890",
+					Role:      "activity",
+					Format:    `activity:{"kind":"tool","tool":"bash","command":"ls -la"}`,
+					CreatedAt: started,
+				},
+				{
+					ID:        "msg-2",
+					ClawID:    "claw-1234567890",
+					Role:      "activity",
+					Format:    `activity:{"kind":"tool","tool":"bash","error":"command failed","detail":"exit status 1"}`,
+					CreatedAt: started.Add(time.Second),
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("ELASTICCLAW_HUB_URL", server.URL)
+	t.Setenv("ELASTICCLAW_CLAW_TOKEN", "test-token")
+
+	out, err := captureStdout(func() error {
+		return runWorkflowLogs("default", "dependency-update", "run-1")
+	})
+	if err != nil {
+		t.Fatalf("runWorkflowLogs returned error: %v", err)
+	}
+	for _, want := range []string{"Agent logs for run run-1", "claw-123", "failed", "[bash]", "cmd: ls -la", "error: command failed"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
 func TestRunWorkflowRunsListsRunsAndShortAgentID(t *testing.T) {
 	started := time.Date(2026, 7, 24, 9, 0, 0, 0, time.UTC)
 	finished := started.Add(5 * time.Minute)
@@ -158,7 +213,7 @@ func TestRunWorkflowRunsListsRunsAndShortAgentID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runWorkflowRuns returned error: %v", err)
 	}
-	for _, want := range []string{"failed", "cron", "claw-123", "provisioning timed out", "Showing 1 run"} {
+	for _, want := range []string{"RUN ID", "run-1", "failed", "cron", "claw-123", "provisioning timed out", "Showing 1 run"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("output missing %q:\n%s", want, out)
 		}

--- a/pkg/hub/cron_api.go
+++ b/pkg/hub/cron_api.go
@@ -82,6 +82,37 @@ func (s *Server) handleCronWorkflowRuns(w http.ResponseWriter, r *http.Request) 
 	})
 }
 
+// handleCronWorkflowRun handles GET /api/workspaces/{workspace}/workflows/{workflow}/cron/runs/{runId}
+// Returns a single workflow run by ID.
+func (s *Server) handleCronWorkflowRun(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	workspace := r.PathValue("workspace")
+	workflow := r.PathValue("workflow")
+	runID := r.PathValue("runId")
+
+	if s.cronScheduler == nil {
+		http.Error(w, "Cron scheduler not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	run, err := s.cronScheduler.getRunByID(workspace, workflow, runID)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to get run: %v", err), http.StatusInternalServerError)
+		return
+	}
+	if run == nil {
+		http.Error(w, "Run not found", http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(run)
+}
+
 // handleCronWorkflowNextRun handles GET /api/workspaces/{workspace}/workflows/{workflow}/cron/next
 // Returns the next scheduled run time for a cron workflow.
 func (s *Server) handleCronWorkflowNextRun(w http.ResponseWriter, r *http.Request) {

--- a/pkg/hub/cron_scheduler.go
+++ b/pkg/hub/cron_scheduler.go
@@ -297,21 +297,33 @@ func (cs *cronScheduler) runWorkflow(sw *scheduledWorkflow) (workflowRunStartSta
 	return workflowRunStarted, nil
 }
 
-// recordRun inserts a workflow run record.
+// recordRun inserts a workflow run record for a scheduled workflow.
 func (cs *cronScheduler) recordRun(runID string, sw *scheduledWorkflow, status, clawID, context string) {
-	now := time.Now().UTC()
+	cs.srv.recordWorkflowRun(runID, "", sw.workspace.Name, sw.workflow.Name, "cron", status, clawID, context, time.Time{})
+}
 
-	var tenantID string
-	_ = cs.srv.db.QueryRow(`SELECT id FROM tenants LIMIT 1`).Scan(&tenantID)
-
-	_, err := cs.srv.db.Exec(
+// recordWorkflowRun inserts a workflow run record. If runID is empty, a new
+// UUID is generated. If tenantID is empty, the first tenant is used. It is used
+// by both scheduled cron runs and manual workflow triggers.
+func (s *Server) recordWorkflowRun(runID, tenantID, workspaceName, workflowName, triggerType, status, clawID, context string, startedAt time.Time) string {
+	if runID == "" {
+		runID = uuid.New().String()
+	}
+	if tenantID == "" {
+		_ = s.db.QueryRow(`SELECT id FROM tenants LIMIT 1`).Scan(&tenantID)
+	}
+	if startedAt.IsZero() {
+		startedAt = time.Now().UTC()
+	}
+	_, err := s.db.Exec(
 		`INSERT INTO workflow_runs (id, tenant_id, workflow_name, workspace_name, trigger_type, status, claw_id, run_context, started_at, created_at)
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		runID, tenantID, sw.workflow.Name, sw.workspace.Name, "cron", status, clawID, context, now, now,
+		runID, tenantID, workflowName, workspaceName, triggerType, status, clawID, context, startedAt, time.Now().UTC(),
 	)
 	if err != nil {
-		log.Printf("[cron] failed to record run for %s: %v", sw.key, err)
+		log.Printf("[workflow-runs] failed to record run for %s/%s: %v", workspaceName, workflowName, err)
 	}
+	return runID
 }
 
 // updateRun updates an existing workflow run with claw ID and status.
@@ -527,6 +539,39 @@ func (cs *cronScheduler) getRunHistory(workspaceName, workflowName string, limit
 		runs = append(runs, r)
 	}
 	return runs, rows.Err()
+}
+
+// getRunByID returns a single workflow run by ID, or nil if not found.
+func (cs *cronScheduler) getRunByID(workspaceName, workflowName, runID string) (*types.WorkflowRun, error) {
+	var tenantID string
+	_ = cs.srv.db.QueryRow(`SELECT id FROM tenants LIMIT 1`).Scan(&tenantID)
+
+	var r types.WorkflowRun
+	var finishedAt sql.NullTime
+	var runContextJSON string
+	err := cs.srv.db.QueryRow(
+		`SELECT id, tenant_id, workflow_name, workspace_name, trigger_type, status, result, claw_id, run_context, started_at, finished_at, created_at
+		 FROM workflow_runs
+		 WHERE tenant_id = ? AND workspace_name = ? AND workflow_name = ? AND id = ?`,
+		tenantID, workspaceName, workflowName, runID,
+	).Scan(
+		&r.ID, &r.TenantID, &r.WorkflowName, &r.WorkspaceName, &r.TriggerType,
+		&r.Status, &r.Result, &r.ClawID, &runContextJSON,
+		&r.StartedAt, &finishedAt, &r.CreatedAt,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if finishedAt.Valid {
+		r.FinishedAt = &finishedAt.Time
+	}
+	if runContextJSON != "" && runContextJSON != "{}" {
+		_ = json.Unmarshal([]byte(runContextJSON), &r.RunContext)
+	}
+	return &r, nil
 }
 
 // loadAllWorkspaces loads all workspace configurations.

--- a/pkg/hub/cron_scheduler_test.go
+++ b/pkg/hub/cron_scheduler_test.go
@@ -1,6 +1,9 @@
 package hub
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -243,6 +246,73 @@ func TestCronWorkflowTriggerValidation(t *testing.T) {
 				t.Errorf("WorkflowConfig.Validate() unexpected error: %v", err)
 			}
 		})
+	}
+}
+
+func TestCronWorkflowRunAPI(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+	s.cronScheduler = newCronScheduler(s)
+
+	now := time.Now().UTC()
+	if _, err := db.Exec(`INSERT INTO workflow_runs(id,tenant_id,workflow_name,workspace_name,trigger_type,status,claw_id,run_context,started_at,created_at) VALUES(?,?,?,?,?,?,?,?,?,?)`,
+		"run-1", "test-tenant-id", "wf", "ws", "cron", "running", "claw-1", "{}", now, now); err != nil {
+		t.Fatalf("insert run: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/workspaces/ws/workflows/wf/cron/runs/run-1", nil)
+	req.Header.Set("Authorization", "Bearer test-token")
+	rr := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	var run types.WorkflowRun
+	if err := json.Unmarshal(rr.Body.Bytes(), &run); err != nil {
+		t.Fatalf("decode run: %v", err)
+	}
+	if run.ID != "run-1" || run.ClawID != "claw-1" {
+		t.Fatalf("unexpected run: %#v", run)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/workspaces/ws/workflows/wf/cron/runs/missing", nil)
+	req.Header.Set("Authorization", "Bearer test-token")
+	rr = httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("missing status = %d, want %d", rr.Code, http.StatusNotFound)
+	}
+}
+
+func TestCronSchedulerGetRunByID(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+	s.cronScheduler = newCronScheduler(s)
+
+	now := time.Now().UTC()
+	if _, err := db.Exec(`INSERT INTO workflow_runs(id,tenant_id,workflow_name,workspace_name,trigger_type,status,claw_id,run_context,started_at,created_at) VALUES(?,?,?,?,?,?,?,?,?,?)`,
+		"run-1", "test-tenant-id", "wf", "ws", "cron", "running", "claw-1", "{}", now, now); err != nil {
+		t.Fatalf("insert run: %v", err)
+	}
+
+	run, err := s.cronScheduler.getRunByID("ws", "wf", "run-1")
+	if err != nil {
+		t.Fatalf("getRunByID: %v", err)
+	}
+	if run == nil {
+		t.Fatalf("expected run, got nil")
+	}
+	if run.ID != "run-1" || run.WorkspaceName != "ws" || run.WorkflowName != "wf" || run.ClawID != "claw-1" {
+		t.Fatalf("unexpected run: %#v", run)
+	}
+
+	missing, err := s.cronScheduler.getRunByID("ws", "wf", "missing")
+	if err != nil {
+		t.Fatalf("getRunByID missing: %v", err)
+	}
+	if missing != nil {
+		t.Fatalf("expected nil for missing run, got %#v", missing)
 	}
 }
 

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -1705,9 +1705,12 @@ func (s *Server) handleClawTerminateSignal(clawID, rawMessage string) {
 	}
 	s.mu.Unlock()
 
-	// Soft-delete the claw and keep messages (including agent activity logs)
-	// for post-mortem diagnosis. claw_prs is still removed because it is tied to
-	// the issue lifecycle rather than the run log.
+	// Finalize any workflow run tied to this claw and release its slot, then
+	// soft-delete the claw while keeping messages for post-mortem diagnosis.
+	// claw_prs is still removed because it is tied to the issue lifecycle.
+	if s.cronScheduler != nil {
+		s.cronScheduler.finishRunByClawID(clawID, "failed", "agent self-terminated")
+	}
 	_, _ = s.db.Exec(`DELETE FROM claw_prs WHERE claw_id = ?`, clawID)
 	_, _ = s.db.Exec(`UPDATE claws SET status='deleted' WHERE id = ?`, clawID)
 

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -1623,7 +1623,7 @@ func (s *Server) completeNoPRDoneClaw(clawID, tenantID, issueID string) {
 		if providerID != "" {
 			s.terminateVMForClaw(clawID, provider, providerID)
 		}
-		_, _ = s.db.Exec(`DELETE FROM messages WHERE claw_id=?`, clawID)
+		// Keep messages (including agent activity logs) for post-mortem diagnosis.
 		_, _ = s.db.Exec(`DELETE FROM claw_prs WHERE claw_id=?`, clawID)
 		s.promotePendingClaws()
 	}()
@@ -1632,7 +1632,7 @@ func (s *Server) completeNoPRDoneClaw(clawID, tenantID, issueID string) {
 // handleClawTerminateSignal is called when a claw sends a message containing [TERMINATE].
 // It immediately terminates the claw, allowing the claw to manage its own lifecycle.
 // Unlike [DONE] which moves issues and keeps the claw in idle mode, [TERMINATE] immediately
-// deletes the claw and its associated VM.
+// soft-deletes the claw and terminates its associated VM while preserving run logs.
 func (s *Server) handleClawTerminateSignal(clawID, rawMessage string) {
 	// Get the tenant ID and issue ID for this claw
 	var issueID, tenantID, factoryName string
@@ -1705,10 +1705,11 @@ func (s *Server) handleClawTerminateSignal(clawID, rawMessage string) {
 	}
 	s.mu.Unlock()
 
-	// Delete messages first (FK constraint)
-	_, _ = s.db.Exec(`DELETE FROM messages WHERE claw_id = ?`, clawID)
+	// Soft-delete the claw and keep messages (including agent activity logs)
+	// for post-mortem diagnosis. claw_prs is still removed because it is tied to
+	// the issue lifecycle rather than the run log.
 	_, _ = s.db.Exec(`DELETE FROM claw_prs WHERE claw_id = ?`, clawID)
-	_, _ = s.db.Exec(`DELETE FROM claws WHERE id = ?`, clawID)
+	_, _ = s.db.Exec(`UPDATE claws SET status='deleted' WHERE id = ?`, clawID)
 
 	// Notify dashboards so the card disappears immediately
 	s.broadcastToUsers(tenantID, types.WSMessage{

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -448,6 +448,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}/trigger", s.withAuth(s.handleWorkspaceWorkflowTrigger))
 	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}/cron/trigger", s.withAuth(s.handleCronWorkflowTrigger)) // POST manual trigger
 	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}/cron/runs", s.withAuth(s.handleCronWorkflowRuns))       // GET run history
+	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}/cron/runs/{runId}", s.withAuth(s.handleCronWorkflowRun)) // GET single run
 	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}/cron/next", s.withAuth(s.handleCronWorkflowNextRun))    // GET next scheduled run
 	mux.HandleFunc("/api/workspaces/{workspace}/secrets", s.withAdminForMethods(s.handleWorkspaceSecretsCRUD, http.MethodPut, http.MethodPost, http.MethodDelete))
 	mux.HandleFunc("/api/workspaces/{workspace}/github-apps", s.withAdminForMethods(s.handleWorkspaceGitHubAppsCRUD, http.MethodPut, http.MethodPost, http.MethodDelete))
@@ -1568,7 +1569,7 @@ func (s *Server) handleClawDetail(w http.ResponseWriter, r *http.Request) {
 			if providerID != "" {
 				s.terminateVM(provider, providerID)
 			}
-			_, _ = s.db.Exec(`DELETE FROM messages WHERE claw_id = ?`, clawID)
+			// Keep messages (including agent activity logs) for post-mortem diagnosis.
 			_, _ = s.db.Exec(`DELETE FROM claw_prs WHERE claw_id = ?`, clawID)
 		}()
 		// Promote any pending claws now that a slot is free

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -710,6 +710,61 @@ func TestDeleteClawSoftDeletesAndHidesFromAPI(t *testing.T) {
 	}
 }
 
+func TestDeleteClawKeepsMessages(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, nil, "", "", "")
+	_, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, tags, created_at, status) VALUES(?,?,?,?,datetime('now'),?)`,
+		"claw-1", "test-tenant-id", "claw 1", `[]`, "connected",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = db.Exec(
+		`INSERT INTO messages(id, claw_id, tenant_id, role, content, created_at) VALUES(?,?,?,?,?,datetime('now'))`,
+		"msg-1", "claw-1", "test-tenant-id", "agent_activity", "activity 1",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = db.Exec(
+		`INSERT INTO messages(id, claw_id, tenant_id, role, content, created_at) VALUES(?,?,?,?,?,datetime('now'))`,
+		"msg-2", "claw-1", "test-tenant-id", "claw", "assistant message",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/claws/claw-1", nil)
+	req = req.WithContext(context.WithValue(req.Context(), ctxTenantKey{}, "test-tenant-id"))
+	req.SetPathValue("id", "claw-1")
+	rec := httptest.NewRecorder()
+
+	s.handleClawDetail(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected status %d, got %d", http.StatusNoContent, rec.Code)
+	}
+
+	var status string
+	if err := db.QueryRow(`SELECT status FROM claws WHERE id=?`, "claw-1").Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	if status != "deleted" {
+		t.Fatalf("expected claw status deleted, got %q", status)
+	}
+
+	// Wait for async cleanup goroutine.
+	time.Sleep(200 * time.Millisecond)
+
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=?`, "claw-1").Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 2 {
+		t.Fatalf("expected 2 messages to be preserved, got %d", count)
+	}
+}
+
 func TestClawAPIReturnsGitHubIssueLink(t *testing.T) {
 	s, db := NewTestServerWithConfig(t, nil, "", "", "")
 	_, err := db.Exec(

--- a/pkg/hub/workspace_api.go
+++ b/pkg/hub/workspace_api.go
@@ -10,8 +10,10 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/elasticclaw/elasticclaw/pkg/types"
+	"github.com/google/uuid"
 )
 
 // WorkspaceView is the API view of a persisted workspace.
@@ -337,6 +339,19 @@ func (s *Server) triggerWorkflowConfig(w http.ResponseWriter, r *http.Request, w
 			jsonError(w, http.StatusInternalServerError, "failed to create claw: "+err.Error())
 			return
 		}
+		if created {
+			now := time.Now().UTC()
+			runID := uuid.New().String()
+			contextData := map[string]interface{}{
+				"run_id":         runID,
+				"trigger_type":   "manual",
+				"workflow_name":  workflow.Name,
+				"workspace_name": workspace.Name,
+				"issue_number":   validatedInputs["issue_number"],
+			}
+			contextJSON, _ := json.Marshal(contextData)
+			s.recordWorkflowRun(runID, "", workspace.Name, workflow.Name, "manual", "running", clawID, string(contextJSON), now)
+		}
 		status := "existing"
 		if created {
 			status = "created"
@@ -353,6 +368,17 @@ func (s *Server) triggerWorkflowConfig(w http.ResponseWriter, r *http.Request, w
 		jsonError(w, http.StatusInternalServerError, "failed to create claw: "+err.Error())
 		return
 	}
+	now := time.Now().UTC()
+	runID := uuid.New().String()
+	contextData := map[string]interface{}{
+		"run_id":         runID,
+		"trigger_type":   "manual",
+		"workflow_name":  workflow.Name,
+		"workspace_name": workspace.Name,
+		"inputs":         validatedInputs,
+	}
+	contextJSON, _ := json.Marshal(contextData)
+	s.recordWorkflowRun(runID, "", workspace.Name, workflow.Name, "manual", "running", clawID, string(contextJSON), now)
 	jsonOK(w, map[string]string{
 		"claw_id": clawID,
 		"status":  "created",

--- a/pkg/hub/workspace_api_test.go
+++ b/pkg/hub/workspace_api_test.go
@@ -710,3 +710,58 @@ func TestWorkspaceWorkflowTriggerCreatesGitHubIssueWorkflowFromIssueNumber(t *te
 		t.Fatalf("duplicate response = %#v, want same claw id with existing status", duplicateResp)
 	}
 }
+
+func TestWorkspaceWorkflowTriggerRecordsManualRun(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{
+		Token:     "test-token",
+		ClawToken: "test-claw-token",
+		Providers: map[string]types.ProviderConfig{
+			"noop": {Type: "noop"},
+		},
+	}, "", "", "")
+	SaveWorkspaceForTest(t,
+		&types.WorkspaceConfig{
+			SchemaVersion: "v1",
+			Name:          "engineering",
+			Files: map[string]string{
+				"elasticclaw-config.yaml": "schema_version: v1\nname: engineering\nprovider: noop\n",
+			},
+		},
+		[]*types.WorkflowConfig{{
+			SchemaVersion:       "v1",
+			Name:                "manual-only",
+			EnableManualTrigger: true,
+		}},
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/workspaces/engineering/workflows/manual-only/trigger", strings.NewReader(`{"inputs":{}}`))
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body = %s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	clawID := resp["claw_id"]
+	if clawID == "" {
+		t.Fatalf("missing claw_id in response")
+	}
+
+	var triggerType, status string
+	if err := db.QueryRow(`SELECT trigger_type, status FROM workflow_runs WHERE claw_id=?`, clawID).Scan(&triggerType, &status); err != nil {
+		t.Fatalf("load workflow run: %v", err)
+	}
+	if triggerType != "manual" {
+		t.Fatalf("trigger_type = %q, want manual", triggerType)
+	}
+	if status != "running" {
+		t.Fatalf("status = %q, want running", status)
+	}
+}

--- a/web/components/claw-activity-log.tsx
+++ b/web/components/claw-activity-log.tsx
@@ -1,0 +1,150 @@
+"use client"
+
+import { useEffect, useState, type ReactNode } from "react"
+import { AlertCircle, Loader2 } from "lucide-react"
+import { ApiError, fetchActivityMessages } from "@/lib/api"
+import type { AgentActivity, ApiMessage } from "@/lib/types"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+const activityPageSize = 100
+
+export function ClawActivityLog({ clawId }: { clawId: string }) {
+  const [messages, setMessages] = useState<ApiMessage[]>([])
+  const [loading, setLoading] = useState(false)
+  const [loadingOlder, setLoadingOlder] = useState(false)
+  const [hasOlder, setHasOlder] = useState(false)
+  const [accessDenied, setAccessDenied] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!clawId) return
+    let cancelled = false
+    queueMicrotask(() => {
+      if (cancelled) return
+      setLoading(true)
+      setMessages([])
+      setAccessDenied(false)
+      setError(null)
+      fetchActivityMessages(clawId, { limit: activityPageSize, order: "desc" })
+        .then((page) => {
+          if (cancelled) return
+          setMessages(page.reverse())
+          setHasOlder(page.length === activityPageSize)
+        })
+        .catch((err) => {
+          if (cancelled) return
+          if (err instanceof ApiError && err.status === 403) setAccessDenied(true)
+          else setError(err instanceof Error ? err.message : "Unable to load agent activity")
+        })
+        .finally(() => { if (!cancelled) setLoading(false) })
+    })
+    return () => { cancelled = true }
+  }, [clawId])
+
+  const loadOlder = async () => {
+    const before = messages[0]?.created_at
+    if (!before || loadingOlder) return
+    setLoadingOlder(true)
+    setError(null)
+    try {
+      const page = await fetchActivityMessages(clawId, { before, limit: activityPageSize, order: "desc" })
+      setMessages((current) => [...page.reverse(), ...current])
+      setHasOlder(page.length === activityPageSize)
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 403) setAccessDenied(true)
+      else setError(err instanceof Error ? err.message : "Unable to load older activity")
+    } finally {
+      setLoadingOlder(false)
+    }
+  }
+
+  if (loading) return <LoadingState label="Loading agent activity..." />
+  if (accessDenied) return <Notice>You don&apos;t have access to this agent&apos;s logs.</Notice>
+  if (error && messages.length === 0) return <Notice destructive>{error}</Notice>
+  if (messages.length === 0) return <EmptyState>No agent actions were recorded for this attempt.</EmptyState>
+
+  return (
+    <div className="flex h-full min-h-0 flex-col rounded-md border">
+      <div className="shrink-0 border-b p-2 text-center">
+        {hasOlder ? (
+          <Button variant="ghost" size="sm" onClick={loadOlder} disabled={loadingOlder}>
+            {loadingOlder && <Loader2 className="size-4 animate-spin" />}
+            Load older
+          </Button>
+        ) : <span className="text-xs text-muted-foreground">Beginning of activity</span>}
+      </div>
+      {error && <div className="border-b px-3 py-2 text-sm text-destructive">{error}</div>}
+      <div className="min-h-0 flex-1 divide-y overflow-auto">
+        {messages.map((message) => <ActivityLine key={message.id} message={message} />)}
+      </div>
+    </div>
+  )
+}
+
+function ActivityLine({ message }: { message: ApiMessage }) {
+  const activity = parseActivity(message)
+  const label = activity?.tool || activity?.kind || "activity"
+  const detailItems = activity ? [
+    activity.command && { kind: "command", value: activity.command },
+    activity.path && { kind: "path", value: activity.path },
+    activity.url && { kind: "url", value: activity.url },
+    activity.detail && { kind: "detail", value: activity.detail },
+    activity.error && { kind: "error", value: activity.error },
+    !activity.detail && !activity.error && activity.message && { kind: "message", value: activity.message },
+  ].filter((item): item is { kind: string; value: string } => Boolean(item)) : []
+
+  return (
+    <div className="grid gap-2 px-3 py-3 text-sm sm:grid-cols-[8rem_10rem_minmax(0,1fr)]">
+      <time className="text-xs text-muted-foreground">{formatTimestamp(message.created_at)}</time>
+      <div className="flex min-w-0 items-start gap-2">
+        <span className="truncate font-medium">{label}</span>
+        {activity?.phase && <Badge variant="outline" className="shrink-0 text-[10px]">{activity.phase}</Badge>}
+      </div>
+      <div className="min-w-0 space-y-1">
+        {detailItems.length > 0 ? detailItems.map((item, index) => (
+          item.kind === "url" && isSafeHttpUrl(item.value) ? (
+            <a key={`${item.kind}-${index}`} href={item.value} target="_blank" rel="noreferrer" className="block truncate text-primary underline-offset-4 hover:underline">{item.value}</a>
+          ) : (
+            <div key={`${item.kind}-${index}`} className={cn("break-words text-muted-foreground", item.kind === "command" && "rounded bg-muted px-2 py-1 font-mono text-foreground", item.kind === "error" && "text-destructive")}>{item.value}</div>
+          )
+        )) : <span className="text-muted-foreground">{message.content || "No details"}</span>}
+      </div>
+    </div>
+  )
+}
+
+function isSafeHttpUrl(value: string) {
+  try {
+    const protocol = new URL(value).protocol
+    return protocol === "http:" || protocol === "https:"
+  } catch {
+    return false
+  }
+}
+
+function parseActivity(message: ApiMessage): AgentActivity | null {
+  if (!message.format?.startsWith("activity:")) return null
+  try {
+    return JSON.parse(message.format.slice("activity:".length)) as AgentActivity
+  } catch {
+    return null
+  }
+}
+
+export function LoadingState({ label }: { label: string }) {
+  return <div className="flex h-40 items-center justify-center gap-2 text-sm text-muted-foreground"><Loader2 className="size-4 animate-spin" />{label}</div>
+}
+
+export function EmptyState({ children }: { children: ReactNode }) {
+  return <div className="flex h-40 items-center justify-center rounded-md border border-dashed text-sm text-muted-foreground">{children}</div>
+}
+
+export function Notice({ children, destructive = false }: { children: ReactNode; destructive?: boolean }) {
+  return <div className={cn("flex items-center gap-2 rounded-md border px-4 py-3 text-sm", destructive && "border-destructive/30 bg-destructive/10 text-destructive")}><AlertCircle className={cn("size-4 shrink-0", destructive && "text-destructive")} />{children}</div>
+}
+
+function formatTimestamp(value: string) {
+  return new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit", second: "2-digit" }).format(new Date(value))
+}

--- a/web/components/run-logs-dialog.tsx
+++ b/web/components/run-logs-dialog.tsx
@@ -1,18 +1,17 @@
 "use client"
 
-import { useEffect, useMemo, useState, type ReactNode } from "react"
-import { AlertCircle, FileTerminal, Loader2 } from "lucide-react"
-import { ApiError, fetchActivityMessages, fetchTaskRunOutputs } from "@/lib/api"
-import type { AgentActivity, ApiMessage, TaskRunAttempt, TaskRunOutput, TaskRunSummary } from "@/lib/types"
+import { useEffect, useMemo, useState } from "react"
+import { FileTerminal } from "lucide-react"
+import { ApiError, fetchTaskRunOutputs } from "@/lib/api"
+import type { TaskRunAttempt, TaskRunOutput, TaskRunSummary } from "@/lib/types"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+import { ClawActivityLog, EmptyState, LoadingState, Notice } from "@/components/claw-activity-log"
 import { cn } from "@/lib/utils"
-
-const activityPageSize = 100
 
 export function RunLogsDialog({ run, attempts }: { run: TaskRunSummary; attempts: TaskRunAttempt[] }) {
   const [open, setOpen] = useState(false)
@@ -65,7 +64,7 @@ export function RunLogsDialog({ run, attempts }: { run: TaskRunSummary; attempts
               )}
             </div>
             <TabsContent value="actions" className="min-h-0 overflow-hidden">
-              <ActionsTab open={open} clawId={clawId} />
+              <ClawActivityLog clawId={clawId} />
             </TabsContent>
             <TabsContent value="output" className="min-h-0 overflow-auto">
               <OutputTab open={open} runId={run.runId} />
@@ -74,111 +73,6 @@ export function RunLogsDialog({ run, attempts }: { run: TaskRunSummary; attempts
         </DialogContent>
       </Dialog>
     </>
-  )
-}
-
-function ActionsTab({ open, clawId }: { open: boolean; clawId: string }) {
-  const [messages, setMessages] = useState<ApiMessage[]>([])
-  const [loading, setLoading] = useState(false)
-  const [loadingOlder, setLoadingOlder] = useState(false)
-  const [hasOlder, setHasOlder] = useState(false)
-  const [accessDenied, setAccessDenied] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-
-  useEffect(() => {
-    if (!open || !clawId) return
-    let cancelled = false
-    queueMicrotask(() => {
-      if (cancelled) return
-      setLoading(true)
-      setMessages([])
-      setAccessDenied(false)
-      setError(null)
-      fetchActivityMessages(clawId, { limit: activityPageSize, order: "desc" })
-        .then((page) => {
-          if (cancelled) return
-          setMessages(page.reverse())
-          setHasOlder(page.length === activityPageSize)
-        })
-        .catch((err) => {
-          if (cancelled) return
-          if (err instanceof ApiError && err.status === 403) setAccessDenied(true)
-          else setError(err instanceof Error ? err.message : "Unable to load agent activity")
-        })
-        .finally(() => { if (!cancelled) setLoading(false) })
-    })
-    return () => { cancelled = true }
-  }, [clawId, open])
-
-  const loadOlder = async () => {
-    const before = messages[0]?.created_at
-    if (!before || loadingOlder) return
-    setLoadingOlder(true)
-    setError(null)
-    try {
-      const page = await fetchActivityMessages(clawId, { before, limit: activityPageSize, order: "desc" })
-      setMessages((current) => [...page.reverse(), ...current])
-      setHasOlder(page.length === activityPageSize)
-    } catch (err) {
-      if (err instanceof ApiError && err.status === 403) setAccessDenied(true)
-      else setError(err instanceof Error ? err.message : "Unable to load older activity")
-    } finally {
-      setLoadingOlder(false)
-    }
-  }
-
-  if (loading) return <LoadingState label="Loading agent activity..." />
-  if (accessDenied) return <Notice>You don&apos;t have access to this agent&apos;s logs.</Notice>
-  if (error && messages.length === 0) return <Notice destructive>{error}</Notice>
-  if (messages.length === 0) return <EmptyState>No agent actions were recorded for this attempt.</EmptyState>
-
-  return (
-    <div className="flex h-full min-h-0 flex-col rounded-md border">
-      <div className="shrink-0 border-b p-2 text-center">
-        {hasOlder ? (
-          <Button variant="ghost" size="sm" onClick={loadOlder} disabled={loadingOlder}>
-            {loadingOlder && <Loader2 className="size-4 animate-spin" />}
-            Load older
-          </Button>
-        ) : <span className="text-xs text-muted-foreground">Beginning of activity</span>}
-      </div>
-      {error && <div className="border-b px-3 py-2 text-sm text-destructive">{error}</div>}
-      <div className="min-h-0 flex-1 divide-y overflow-auto">
-        {messages.map((message) => <ActivityLine key={message.id} message={message} />)}
-      </div>
-    </div>
-  )
-}
-
-function ActivityLine({ message }: { message: ApiMessage }) {
-  const activity = parseActivity(message)
-  const label = activity?.tool || activity?.kind || "activity"
-  const detailItems = activity ? [
-    activity.command && { kind: "command", value: activity.command },
-    activity.path && { kind: "path", value: activity.path },
-    activity.url && { kind: "url", value: activity.url },
-    activity.detail && { kind: "detail", value: activity.detail },
-    activity.error && { kind: "error", value: activity.error },
-    !activity.detail && !activity.error && activity.message && { kind: "message", value: activity.message },
-  ].filter((item): item is { kind: string; value: string } => Boolean(item)) : []
-
-  return (
-    <div className="grid gap-2 px-3 py-3 text-sm sm:grid-cols-[8rem_10rem_minmax(0,1fr)]">
-      <time className="text-xs text-muted-foreground">{formatTimestamp(message.created_at)}</time>
-      <div className="flex min-w-0 items-start gap-2">
-        <span className="truncate font-medium">{label}</span>
-        {activity?.phase && <Badge variant="outline" className="shrink-0 text-[10px]">{activity.phase}</Badge>}
-      </div>
-      <div className="min-w-0 space-y-1">
-        {detailItems.length > 0 ? detailItems.map((item, index) => (
-          item.kind === "url" && isSafeHttpUrl(item.value) ? (
-            <a key={`${item.kind}-${index}`} href={item.value} target="_blank" rel="noreferrer" className="block truncate text-primary underline-offset-4 hover:underline">{item.value}</a>
-          ) : (
-            <div key={`${item.kind}-${index}`} className={cn("break-words text-muted-foreground", item.kind === "command" && "rounded bg-muted px-2 py-1 font-mono text-foreground", item.kind === "error" && "text-destructive")}>{item.value}</div>
-          )
-        )) : <span className="text-muted-foreground">{message.content || "No details"}</span>}
-      </div>
-    </div>
   )
 }
 
@@ -243,38 +137,4 @@ function OutputBlock({ output }: { output: TaskRunOutput }) {
 
 function LogStream({ label, value, error = false }: { label: string; value: string; error?: boolean }) {
   return <div><div className={cn("mb-1 text-xs font-medium text-muted-foreground", error && "text-destructive")}>{label}</div><pre className="max-h-64 overflow-auto whitespace-pre-wrap break-words rounded-md bg-muted p-3 font-mono text-xs">{value}</pre></div>
-}
-
-function isSafeHttpUrl(value: string) {
-  try {
-    const protocol = new URL(value).protocol
-    return protocol === "http:" || protocol === "https:"
-  } catch {
-    return false
-  }
-}
-
-function parseActivity(message: ApiMessage): AgentActivity | null {
-  if (!message.format?.startsWith("activity:")) return null
-  try {
-    return JSON.parse(message.format.slice("activity:".length)) as AgentActivity
-  } catch {
-    return null
-  }
-}
-
-function LoadingState({ label }: { label: string }) {
-  return <div className="flex h-40 items-center justify-center gap-2 text-sm text-muted-foreground"><Loader2 className="size-4 animate-spin" />{label}</div>
-}
-
-function EmptyState({ children }: { children: ReactNode }) {
-  return <div className="flex h-40 items-center justify-center rounded-md border border-dashed text-sm text-muted-foreground">{children}</div>
-}
-
-function Notice({ children, destructive = false }: { children: ReactNode; destructive?: boolean }) {
-  return <div className={cn("flex items-center gap-2 rounded-md border px-4 py-3 text-sm", destructive && "border-destructive/30 bg-destructive/10 text-destructive")}><AlertCircle className="size-4 shrink-0" />{children}</div>
-}
-
-function formatTimestamp(value: string) {
-  return new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit", second: "2-digit" }).format(new Date(value))
 }

--- a/web/components/workflow-run-logs-dialog.tsx
+++ b/web/components/workflow-run-logs-dialog.tsx
@@ -1,0 +1,47 @@
+"use client"
+
+import { useState } from "react"
+import { FileTerminal } from "lucide-react"
+import { ClawActivityLog } from "@/components/claw-activity-log"
+import { Button } from "@/components/ui/button"
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+import type { WorkflowRun } from "@/lib/types"
+
+export function WorkflowRunLogsDialog({ run }: { run: WorkflowRun }) {
+  const [open, setOpen] = useState(false)
+  const disabled = !run.claw_id
+
+  return (
+    <>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="inline-flex" tabIndex={disabled ? 0 : undefined}>
+            <Button variant="outline" size="sm" disabled={disabled} onClick={() => setOpen(true)}>
+              <FileTerminal className="size-4" />
+              Agent logs
+            </Button>
+          </span>
+        </TooltipTrigger>
+        {disabled && <TooltipContent>This run is not linked to an agent, so logs are unavailable.</TooltipContent>}
+      </Tooltip>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="flex h-[min(85vh,800px)] flex-col gap-3 overflow-hidden p-0 sm:max-w-5xl">
+          <DialogHeader className="shrink-0 border-b px-6 py-5 pr-12">
+            <DialogTitle>Agent logs</DialogTitle>
+            <DialogDescription>
+              Agent activity for run {shortId(run.id)} of {run.workflow_name} in {run.workspace_name}.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="min-h-0 flex-1 px-6 pb-6">
+            {run.claw_id && <ClawActivityLog clawId={run.claw_id} />}
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}
+
+function shortId(id: string) {
+  return id.length > 8 ? id.slice(0, 8) : id
+}

--- a/web/components/workflow-runs-dialog.tsx
+++ b/web/components/workflow-runs-dialog.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, type ReactNode } from "react"
 import { useRouter } from "next/navigation"
 import { AlertCircle, BarChart3, Calendar, ExternalLink, History, Loader2 } from "lucide-react"
 import { ApiError, fetchCronWorkflowRuns, type Workflow } from "@/lib/api"
+import { WorkflowRunLogsDialog } from "@/components/workflow-run-logs-dialog"
 import type { WorkflowRun } from "@/lib/types"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -78,6 +79,7 @@ export function WorkflowRunsDialog({ workflow }: { workflow: Workflow }) {
                       <TableHead>Finished</TableHead>
                       <TableHead>Result</TableHead>
                       <TableHead>Agent</TableHead>
+                      <TableHead className="w-28">Logs</TableHead>
                     </TableRow>
                   </TableHeader>
                   <TableBody>
@@ -100,6 +102,9 @@ export function WorkflowRunsDialog({ workflow }: { workflow: Workflow }) {
                         </TableCell>
                         <TableCell className="text-xs font-mono text-muted-foreground">
                           {run.claw_id ? shortId(run.claw_id) : "—"}
+                        </TableCell>
+                        <TableCell>
+                          <WorkflowRunLogsDialog run={run} />
                         </TableCell>
                       </TableRow>
                     ))}


### PR DESCRIPTION
This PR adds workflow run history, CLI commands for listing runs and fetching logs, and UI components for viewing agent activity logs.

### Changes
- **Hub**: Add workflow run history endpoint; record manual workflow triggers in `workflow_runs`.
- **CLI**: Add `workflow runs` and `workflow logs` commands.
- **Web**: Add `ClawActivityLog` component and `WorkflowRunLogsDialog` for viewing run logs.
- **Hub**: Preserve agent messages when claws are killed, self-terminated, or completed without PRs.
- **Hub**: Finalize `workflow_runs` rows when an agent self-terminates via `[TERMINATE]` so they do not remain stuck in `running`.

### Testing
- `go test ./pkg/hub/... ./cmd/...` passes.
- Manual deployment to the test server confirmed the hub restarts and the new bridge image is reachable.

### Notes
- The bridge image is currently pushed to `ttl.sh/elasticclaw-claw-bridge:1w` for testing; it expires in 1 week.
- Old runs that were already deleted still will not have logs; the fix applies to future runs.
