### PR TITLE
fix(bridge): exclude session/runtime files from checkpoints and recover session file lock errors

### DIFF
--- a/cmd/claw-bridge/checkpoint.go
+++ b/cmd/claw-bridge/checkpoint.go
@@ -183,7 +183,7 @@ func checkpointExclude(path string, d os.DirEntry) bool {
 		return true
 	}
 	switch name {
-	case "node_modules", ".cache", "tmp", "dist", "build", ".next", "auth-profiles.json":
+	case "node_modules", ".cache", "tmp", "dist", "build", ".next", "auth-profiles.json", "openclaw-agent.sqlite", "sessions":
 		return true
 	}
 	if strings.HasSuffix(name, ".log") && !strings.Contains(path, "workspace") {

--- a/cmd/claw-bridge/checkpoint.go
+++ b/cmd/claw-bridge/checkpoint.go
@@ -183,7 +183,11 @@ func checkpointExclude(path string, d os.DirEntry) bool {
 		return true
 	}
 	switch name {
-	case "node_modules", ".cache", "tmp", "dist", "build", ".next", "auth-profiles.json", "openclaw-agent.sqlite", "sessions":
+	case "node_modules", ".cache", "tmp", "dist", "build", ".next", "auth-profiles.json", "openclaw-agent.sqlite":
+		return true
+	}
+	// Only exclude the agent sessions directory, not arbitrary "sessions" folders in the workspace.
+	if name == "sessions" && strings.Contains(filepath.ToSlash(path), ".openclaw/agents/") {
 		return true
 	}
 	if strings.HasSuffix(name, ".log") && !strings.Contains(path, "workspace") {

--- a/cmd/claw-bridge/checkpoint_test.go
+++ b/cmd/claw-bridge/checkpoint_test.go
@@ -12,6 +12,7 @@ func TestCollectCheckpointFilesExcludesSessionsAndAuthProfiles(t *testing.T) {
 
 	files := map[string]string{
 		".openclaw/workspace/src/main.go":          "package main",
+		".openclaw/workspace/sessions/data.json":   "[]",
 		".openclaw/openclaw.json":                  "{}",
 		".openclaw/agents/main/agent/openclaw-agent.sqlite": "sqlite",
 		".openclaw/agents/main/agent/auth-profiles.json":    "auth",
@@ -39,6 +40,9 @@ func TestCollectCheckpointFilesExcludesSessionsAndAuthProfiles(t *testing.T) {
 
 	if !byPath["workspace/src/main.go"] {
 		t.Errorf("expected workspace file to be checkpointed, got paths: %v", byPath)
+	}
+	if !byPath["workspace/sessions/data.json"] {
+		t.Errorf("expected workspace sessions folder to be checkpointed, got paths: %v", byPath)
 	}
 	if !byPath[".openclaw/openclaw.json"] {
 		t.Errorf("expected openclaw.json to be checkpointed, got paths: %v", byPath)

--- a/cmd/claw-bridge/checkpoint_test.go
+++ b/cmd/claw-bridge/checkpoint_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCollectCheckpointFilesExcludesSessionsAndAuthProfiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	files := map[string]string{
+		".openclaw/workspace/src/main.go":          "package main",
+		".openclaw/openclaw.json":                  "{}",
+		".openclaw/agents/main/agent/openclaw-agent.sqlite": "sqlite",
+		".openclaw/agents/main/agent/auth-profiles.json":    "auth",
+		".openclaw/agents/main/sessions/session.jsonl":      "{}",
+	}
+	for rel, content := range files {
+		abs := filepath.Join(tmpDir, rel)
+		if err := os.MkdirAll(filepath.Dir(abs), 0o700); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(abs), err)
+		}
+		if err := os.WriteFile(abs, []byte(content), 0o600); err != nil {
+			t.Fatalf("write %s: %v", abs, err)
+		}
+	}
+
+	got, err := collectCheckpointFiles()
+	if err != nil {
+		t.Fatalf("collectCheckpointFiles: %v", err)
+	}
+
+	byPath := map[string]bool{}
+	for _, f := range got {
+		byPath[f.entry.Path] = true
+	}
+
+	if !byPath["workspace/src/main.go"] {
+		t.Errorf("expected workspace file to be checkpointed, got paths: %v", byPath)
+	}
+	if !byPath[".openclaw/openclaw.json"] {
+		t.Errorf("expected openclaw.json to be checkpointed, got paths: %v", byPath)
+	}
+	if byPath[".openclaw/agents/main/agent/openclaw-agent.sqlite"] {
+		t.Errorf("openclaw-agent.sqlite should be excluded from checkpoints")
+	}
+	if byPath[".openclaw/agents/main/agent/auth-profiles.json"] {
+		t.Errorf("auth-profiles.json should be excluded from checkpoints")
+	}
+	if byPath[".openclaw/agents/main/sessions/session.jsonl"] {
+		t.Errorf("session files should be excluded from checkpoints")
+	}
+}

--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -1962,7 +1962,19 @@ func isRecoverableSessionLifecycleError(err error) bool {
 	if errors.As(err, &sendErr) {
 		return false
 	}
-	return errors.Is(err, context.DeadlineExceeded) || isProviderRequestFormatError(err)
+	return errors.Is(err, context.DeadlineExceeded) || isProviderRequestFormatError(err) || isSessionFileLockConflictError(err)
+}
+
+// isSessionFileLockConflictError detects OpenClaw's "session file changed while
+// embedded prompt lock was released" error. That error indicates the on-disk
+// session transcript was modified unexpectedly, leaving the persistent session
+// in an inconsistent state. Rotating to a fresh session is the only recovery.
+func isSessionFileLockConflictError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "session file changed") && strings.Contains(msg, "embedded prompt lock")
 }
 
 // SendMessage sends a user message to the persistent session, streams chunks

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -1392,6 +1392,9 @@ func TestIsRecoverableSessionLifecycleError(t *testing.T) {
 		{name: "send request deadline", err: &sessionSendRequestError{err: context.DeadlineExceeded}, want: false},
 		{name: "caller cancellation", err: context.Canceled, want: false},
 		{name: "ordinary lifecycle error", err: errString("tool-policy: exec is not allowed"), want: false},
+		{name: "session file lock conflict", err: errString("error: session file changed while embedded prompt lock was released: /home/elasticclaw/.openclaw/agents/main/sessions/4fb88b9b-8233-4f78-819f-516fbe605e32.jsonl"), want: true},
+		{name: "session file changed without lock mention", err: errString("session file changed"), want: false},
+		{name: "embedded prompt lock without file changed", err: errString("embedded prompt lock released"), want: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1520,6 +1523,133 @@ func TestGatewaySessionResetsAfterProviderFormatLifecycleError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), providerErr) || !strings.Contains(err.Error(), "session reset") {
 		t.Fatalf("SendMessage error = %q, want provider error and recovery notice", err)
+	}
+	if got := gs.getSessionKey(); got != "session-2" {
+		t.Fatalf("session key = %q, want session-2", got)
+	}
+	if got := loadBridgeSession(); got != "session-2" {
+		t.Fatalf("persisted session key = %q, want session-2", got)
+	}
+}
+
+func TestGatewaySessionResetsAfterSessionFileLockConflict(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const sessionErr = "error: session file changed while embedded prompt lock was released: /home/elasticclaw/.openclaw/agents/main/sessions/4fb88b9b-8233-4f78-819f-516fbe605e32.jsonl"
+	testDone := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Errorf("accept websocket: %v", err)
+			return
+		}
+		defer conn.CloseNow()
+
+		readRequest := func(wantMethod string) (gwFrame, bool) {
+			var req gwFrame
+			if err := wsjson.Read(r.Context(), conn, &req); err != nil {
+				t.Errorf("read %s request: %v", wantMethod, err)
+				return gwFrame{}, false
+			}
+			if req.Method != wantMethod {
+				t.Errorf("request method = %q, want %q", req.Method, wantMethod)
+				return gwFrame{}, false
+			}
+			return req, true
+		}
+
+		sendReq, ok := readRequest("sessions.send")
+		if !ok {
+			return
+		}
+		if err := wsjson.Write(r.Context(), conn, gwFrame{Type: "res", ID: sendReq.ID, OK: true}); err != nil {
+			t.Errorf("accept sessions.send: %v", err)
+			return
+		}
+		if err := wsjson.Write(r.Context(), conn, gwFrame{
+			Type:  "event",
+			Event: "agent",
+			Payload: mustJSON(map[string]interface{}{
+				"stream":     "lifecycle",
+				"sessionKey": "session-1",
+				"data": map[string]string{
+					"phase": "error",
+					"error": sessionErr,
+				},
+			}),
+		}); err != nil {
+			t.Errorf("write lifecycle error: %v", err)
+			return
+		}
+
+		abortReq, ok := readRequest("sessions.abort")
+		if !ok {
+			return
+		}
+		var abortParams map[string]string
+		if err := json.Unmarshal(abortReq.Params, &abortParams); err != nil {
+			t.Errorf("decode sessions.abort params: %v", err)
+			return
+		}
+		if abortParams["key"] != "session-1" {
+			t.Errorf("sessions.abort key = %q, want session-1", abortParams["key"])
+			return
+		}
+		if err := wsjson.Write(r.Context(), conn, gwFrame{Type: "res", ID: abortReq.ID, OK: true}); err != nil {
+			t.Errorf("abort poisoned session: %v", err)
+			return
+		}
+
+		createReq, ok := readRequest("sessions.create")
+		if !ok {
+			return
+		}
+		if err := wsjson.Write(r.Context(), conn, gwFrame{
+			Type:    "res",
+			ID:      createReq.ID,
+			OK:      true,
+			Payload: mustJSON(map[string]string{"key": "session-2"}),
+		}); err != nil {
+			t.Errorf("create replacement session: %v", err)
+			return
+		}
+
+		subscribeReq, ok := readRequest("sessions.subscribe")
+		if !ok {
+			return
+		}
+		if err := wsjson.Write(r.Context(), conn, gwFrame{Type: "res", ID: subscribeReq.ID, OK: true}); err != nil {
+			t.Errorf("subscribe replacement session: %v", err)
+			return
+		}
+
+		<-testDone
+	}))
+	defer srv.Close()
+	defer close(testDone)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer conn.CloseNow()
+
+	gs := &gatewaySession{
+		sessionKey: "session-1",
+		conn:       conn,
+		pending:    make(map[string]chan gwFrame),
+	}
+	go gs.readLoop(ctx)
+
+	_, err = gs.SendMessage(ctx, "continue the task", nil, nil)
+	if err == nil {
+		t.Fatal("SendMessage returned nil error")
+	}
+	if !strings.Contains(err.Error(), sessionErr) || !strings.Contains(err.Error(), "session reset") {
+		t.Fatalf("SendMessage error = %q, want session error and recovery notice", err)
 	}
 	if got := gs.getSessionKey(); got != "session-2" {
 		t.Fatalf("session key = %q, want session-2", got)


### PR DESCRIPTION
On Replicated, checkpoint restore happens after the bridge has started, so restoring `.openclaw/agents/main/sessions/*.jsonl` can overwrite a live OpenClaw session file and trigger `session file changed while embedded prompt lock was released`. Also exclude `openclaw-agent.sqlite`, which is runtime auth state.

As a safety net, treat that specific lifecycle error as recoverable so the bridge aborts the poisoned session and creates a fresh one.

Changes:
- `cmd/claw-bridge/checkpoint.go`: exclude `sessions` and `openclaw-agent.sqlite` from checkpoints
- `cmd/claw-bridge/main.go`: treat session file lock conflict as a recoverable lifecycle error
- `cmd/claw-bridge/main_test.go`: add unit and integration tests for the recovery path
- `cmd/claw-bridge/checkpoint_test.go` (new): test checkpoint file exclusion

Tested with `go test ./cmd/claw-bridge`.