### PR TITLE
fix(hub): deliver nested workspace files to the live Daytona workspace

### DIFF
--- a/pkg/hub/daytona_workspace_files_test.go
+++ b/pkg/hub/daytona_workspace_files_test.go
@@ -1,0 +1,84 @@
+package hub
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/elasticclaw/elasticclaw/pkg/config"
+)
+
+func TestDaytonaWorkspaceFilesReadinessCommandChecksNestedPaths(t *testing.T) {
+	cmd := daytonaWorkspaceFilesReadinessCommand(daytonaLiveWorkspaceDir, map[string]string{
+		"AGENTS.md":                             "a",
+		"scripts/detect_android_changes.py":     "b",
+		"scripts/review-loop/reviewers/arch.md": "c",
+	})
+
+	for _, want := range []string{
+		"/home/daytona/.openclaw/workspace/AGENTS.md",
+		"/home/daytona/.openclaw/workspace/scripts/detect_android_changes.py",
+		"/home/daytona/.openclaw/workspace/scripts/review-loop/reviewers/arch.md",
+	} {
+		if !strings.Contains(cmd, want) {
+			t.Errorf("readiness command missing check for %s:\n%s", want, cmd)
+		}
+	}
+	if strings.Contains(cmd, "/home/daytona/workspace/") {
+		t.Errorf("readiness command must verify the live workspace, not the staged one:\n%s", cmd)
+	}
+	if got := daytonaWorkspaceFilesReadinessCommand(daytonaLiveWorkspaceDir, nil); got != "true" {
+		t.Errorf("empty file set = %q, want \"true\"", got)
+	}
+}
+
+func TestDaytonaExecutableWorkspaceFile(t *testing.T) {
+	cases := map[string]bool{
+		"scripts/run.sh":                     true,
+		"scripts/detect_android_changes.py":  true,
+		"AGENTS.md":                          false,
+		"scripts/review-loop/REVIEW_LOOP.md": false,
+	}
+	for name, want := range cases {
+		if got := daytonaExecutableWorkspaceFile(name); got != want {
+			t.Errorf("daytonaExecutableWorkspaceFile(%q) = %v, want %v", name, got, want)
+		}
+	}
+}
+
+// A workspace with nested subdirectories must round-trip through template
+// storage with its subtree intact: before this, saveExternalTemplate dropped
+// every path containing a slash, silently losing scripts/ and memory/.
+func TestSaveExternalTemplatePreservesNestedFiles(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", filepath.Join(t.TempDir(), "hub.yaml"))
+
+	files := map[string]string{
+		"AGENTS.md":                             "agents",
+		"scripts/detect_android_changes.py":     "print('hi')",
+		"scripts/review-loop/reviewers/arch.md": "reviewer",
+		"memory/notes.md":                       "note",
+		"../escape.md":                          "nope",
+	}
+	if err := saveExternalTemplate("faster", files); err != nil {
+		t.Fatalf("saveExternalTemplate: %v", err)
+	}
+
+	dir := filepath.Join(templatesDir(), "faster")
+	got, err := config.ReadTemplateFiles(dir)
+	if err != nil {
+		t.Fatalf("ReadTemplateFiles: %v", err)
+	}
+	for _, name := range []string{
+		"AGENTS.md",
+		"scripts/detect_android_changes.py",
+		"scripts/review-loop/reviewers/arch.md",
+		"memory/notes.md",
+	} {
+		if _, ok := got[name]; !ok {
+			t.Errorf("template files missing %s (got %v)", name, sortedWorkspaceFileNames(got))
+		}
+	}
+	if _, ok := got["escape.md"]; ok {
+		t.Error("traversal path must not be written")
+	}
+}

--- a/pkg/hub/daytona_workspace_files_test.go
+++ b/pkg/hub/daytona_workspace_files_test.go
@@ -8,8 +8,24 @@ import (
 	"github.com/elasticclaw/elasticclaw/pkg/config"
 )
 
+// The write loop and the readiness gate both go through daytonaWorkspaceFilePath,
+// so pinning it here is what stops a regression back to the staged
+// /home/daytona/workspace dir that nothing syncs on Daytona.
+func TestDaytonaWorkspaceFilePathTargetsLiveWorkspace(t *testing.T) {
+	cases := map[string]string{
+		"AGENTS.md":                             "/home/daytona/.openclaw/workspace/AGENTS.md",
+		"scripts/detect_android_changes.py":     "/home/daytona/.openclaw/workspace/scripts/detect_android_changes.py",
+		"scripts/review-loop/reviewers/arch.md": "/home/daytona/.openclaw/workspace/scripts/review-loop/reviewers/arch.md",
+	}
+	for name, want := range cases {
+		if got := daytonaWorkspaceFilePath(name); got != want {
+			t.Errorf("daytonaWorkspaceFilePath(%q) = %q, want %q", name, got, want)
+		}
+	}
+}
+
 func TestDaytonaWorkspaceFilesReadinessCommandChecksNestedPaths(t *testing.T) {
-	cmd := daytonaWorkspaceFilesReadinessCommand(daytonaLiveWorkspaceDir, map[string]string{
+	cmd := daytonaWorkspaceFilesReadinessCommand(map[string]string{
 		"AGENTS.md":                             "a",
 		"scripts/detect_android_changes.py":     "b",
 		"scripts/review-loop/reviewers/arch.md": "c",
@@ -27,7 +43,7 @@ func TestDaytonaWorkspaceFilesReadinessCommandChecksNestedPaths(t *testing.T) {
 	if strings.Contains(cmd, "/home/daytona/workspace/") {
 		t.Errorf("readiness command must verify the live workspace, not the staged one:\n%s", cmd)
 	}
-	if got := daytonaWorkspaceFilesReadinessCommand(daytonaLiveWorkspaceDir, nil); got != "true" {
+	if got := daytonaWorkspaceFilesReadinessCommand(nil); got != "true" {
 		t.Errorf("empty file set = %q, want \"true\"", got)
 	}
 }

--- a/pkg/hub/external_storage.go
+++ b/pkg/hub/external_storage.go
@@ -143,10 +143,16 @@ func saveExternalTemplate(name string, files map[string]string) error {
 		return fmt.Errorf("mkdir %s: %w", dir, err)
 	}
 	for fname, content := range files {
-		if strings.Contains(fname, "..") || strings.ContainsAny(fname, `/\`) {
-			continue // skip paths with directory traversal
+		// Nested files (memory/**, scripts/**) must survive a template push, so
+		// only reject paths that would escape the template dir.
+		safeName, err := cleanWorkspaceFilePath(fname)
+		if err != nil {
+			continue
 		}
-		path := filepath.Join(dir, fname)
+		path := filepath.Join(dir, filepath.FromSlash(safeName))
+		if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil {
+			return fmt.Errorf("mkdir for template file %s: %w", safeName, err)
+		}
 		if err := os.WriteFile(path, []byte(content), 0640); err != nil {
 			return fmt.Errorf("write %s: %w", path, err)
 		}

--- a/pkg/hub/external_storage.go
+++ b/pkg/hub/external_storage.go
@@ -3,6 +3,7 @@ package hub
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -145,8 +146,13 @@ func saveExternalTemplate(name string, files map[string]string) error {
 	for fname, content := range files {
 		// Nested files (memory/**, scripts/**) must survive a template push, so
 		// only reject paths that would escape the template dir.
+		// Note the asymmetry with bootstrapDaytona, which hard-fails on an invalid
+		// path: here a bad key is a client input we can safely drop at push time,
+		// while at bootstrap the same key means the claw would start with a file
+		// its workflows expect missing.
 		safeName, err := cleanWorkspaceFilePath(fname)
 		if err != nil {
+			log.Printf("[templates] skipping invalid template file path %q for %s: %v", fname, name, err)
 			continue
 		}
 		path := filepath.Join(dir, filepath.FromSlash(safeName))

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -3401,10 +3401,14 @@ docker --version`); err != nil {
 					log.Printf("[daytona] warning: skipping invalid flake path %q: %v", name, err)
 					continue
 				}
-				// Write to the *staged* workspace dir (~ /workspace) that the bridge's
-				// hasWorkspaceFlake() and setupFlakeEnvironmentSync() inspect.
-				// This ensures early flake staging is visible for devShell wrapper creation
-				// before bridge starts. (syncStaged... later copies it into ~/.openclaw/workspace)
+				// Write to the *staged* workspace dir (~/workspace) where flake
+				// tooling looks for the devShell definition.
+				// NOTE: on Daytona the bridge runs WITHOUT ELASTICCLAW_BOOTSTRAP (see
+				// daytonaAsyncBridgeCommand), so runBootstrap -- and therefore
+				// hasWorkspaceFlake(), setupFlakeEnvironmentSync() and
+				// syncStagedWorkspaceToOpenClawWorkspace() -- never runs here. Nothing
+				// copies this staged file into ~/.openclaw/workspace; flake setup for
+				// Daytona is hub-driven. Do not assume bridge-side consumption.
 				targetPath := "/home/daytona/workspace/" + safeName
 				targetDir := path.Dir(targetPath)
 				// Base64-encode the user-controlled flake content, then use heredoc *only* for the
@@ -3614,11 +3618,11 @@ cp "$BIN" /tmp/claw-bridge.download && chmod +x /tmp/claw-bridge.download && mv 
 	if err := json.Unmarshal([]byte(filesJSON), &templateFiles); err != nil {
 		return fmt.Errorf("parse template_files for final write %s: %w", clawID, err)
 	}
+	writtenWorkspaceFiles := map[string]string{}
 	if len(templateFiles) > 0 {
 		templateFiles = workspaceTemplateFiles(templateFiles)
-		for name, content := range templateFiles {
-			name := name
-			content := content
+		for _, name := range sortedWorkspaceFileNames(templateFiles) {
+			content := templateFiles[name]
 			// Skip flake files here: they were staged early (with collision-resistant
 			// delimiter) specifically for the devShell contract. Rewriting them with
 			// a fixed delimiter would re-introduce the heredoc injection risk.
@@ -3627,20 +3631,22 @@ cp "$BIN" /tmp/claw-bridge.download && chmod +x /tmp/claw-bridge.download && mv 
 			}
 			safeName, err := cleanWorkspaceFilePath(name)
 			if err != nil {
-				log.Printf("[daytona] warning: skipping invalid template file path %q: %v", name, err)
-				continue
+				// Fail closed: a workspace missing files it declares (e.g. scripts/
+				// referenced by workflow commands) fails every stage at runtime.
+				return fmt.Errorf("invalid workspace file path %q: %w", name, err)
 			}
-			// Write to the *staged* workspace dir (~/workspace) so that syncStagedWorkspaceToOpenClawWorkspace
-			// (run inside bridge) will copy the injected files (e.g. CONTEXT.md for GitHub Issues/Linear factories)
-			// into ~/.openclaw/workspace. Direct writes to ~/.openclaw/workspace get stripped by the managed-files removal in sync.
-			targetPath := "/home/daytona/workspace/" + safeName
+			// Write straight into the LIVE workspace. The Daytona bridge is started
+			// WITHOUT ELASTICCLAW_BOOTSTRAP (see daytonaAsyncBridgeCommand), so
+			// runBootstrap -- and with it syncStagedWorkspaceToOpenClawWorkspace --
+			// never runs on this provider: nothing would ever copy staged files over.
+			// Mirrors Replicated, which also writes final files after bootstrap.
+			targetPath := daytonaLiveWorkspaceDir + "/" + safeName
 			targetDir := path.Dir(targetPath)
 			// Use collision-resistant delimiter (same strategy as early flake staging)
 			// to protect against content containing a fixed token.
 			raw := make([]byte, 8)
 			if _, err := rand.Read(raw); err != nil {
-				log.Printf("[daytona] warning: rand for write delim %s: %v", name, err)
-				continue
+				return fmt.Errorf("random delimiter for workspace file %s: %w", name, err)
 			}
 			delim := "ELASTICCLAW_FILE_" + hex.EncodeToString(raw)
 			writeCmd := fmt.Sprintf(
@@ -3648,11 +3654,15 @@ cp "$BIN" /tmp/claw-bridge.download && chmod +x /tmp/claw-bridge.download && mv 
 %s
 %s`,
 				shellQuote(targetDir), shellQuote(targetPath), delim, content, delim)
-			if err := exec("write "+name, 15*time.Second, writeCmd); err != nil {
-				log.Printf("[daytona] warning: failed to write %s: %v", name, err)
+			if daytonaExecutableWorkspaceFile(safeName) {
+				writeCmd += fmt.Sprintf("\nchmod +x %s", shellQuote(targetPath))
 			}
+			if err := exec("write "+name, 15*time.Second, writeCmd); err != nil {
+				return fmt.Errorf("write workspace file %s: %w", name, err)
+			}
+			writtenWorkspaceFiles[safeName] = content
 		}
-		log.Printf("[daytona] template files written for claw %s", clawID)
+		log.Printf("[daytona] %d workspace files written for claw %s", len(writtenWorkspaceFiles), clawID)
 	}
 
 	// Step 5: GitHub credential helper (if GitHub Apps configured)
@@ -3809,6 +3819,26 @@ gh auth status`
 
 	if err := s.restoreCheckpointToDaytona(ctx, clawID, instanceID, p); err != nil {
 		return fmt.Errorf("restore checkpoint: %w", err)
+	}
+
+	// Workspace file gate: every file the workspace declares (including nested
+	// scripts/**) must exist before the agent's first turn, otherwise workflow
+	// commands fail with "can't open file" on every stage.
+	if len(writtenWorkspaceFiles) > 0 {
+		s.setBootstrapStatus(clawID, "Verifying workspace files")
+		filesScript := daytonaWorkspaceFilesReadinessCommand(daytonaLiveWorkspaceDir, writtenWorkspaceFiles)
+		filesResult, filesErr := p.ExecWithTimeout(ctx, instanceID, []string{"bash", "-c", filesScript}, 30*time.Second)
+		if filesErr != nil {
+			diag := fmt.Sprintf("Workspace files verification failed: %v", filesErr)
+			s.setBootstrapStatusWithDiagnostic(clawID, "Workspace incomplete", diag)
+			return fmt.Errorf("workspace files readiness: %w", filesErr)
+		}
+		if filesResult.ExitCode != 0 {
+			diag := fmt.Sprintf("Workspace files incomplete. %s", sanitizeBootstrapOutput(filesResult.Stdout))
+			s.setBootstrapStatusWithDiagnostic(clawID, "Workspace incomplete", diag)
+			return fmt.Errorf("workspace files incomplete (exit %d): %s", filesResult.ExitCode, sanitizeBootstrapOutput(filesResult.Stdout))
+		}
+		log.Printf("[daytona] workspace files verified for claw %s", clawID)
 	}
 
 	// Final workspace readiness gate: verify every configured repository is
@@ -4054,6 +4084,45 @@ if pgrep -af %s >/dev/null 2>&1; then
 fi
 echo "openclaw-install-status=missing"
 tail -n 120 "$LOG" 2>/dev/null || true`, shellQuote("openclaw@"+version))
+}
+
+// daytonaLiveWorkspaceDir is the workspace the OpenClaw agent actually runs in.
+const daytonaLiveWorkspaceDir = "/home/daytona/.openclaw/workspace"
+
+func sortedWorkspaceFileNames(files map[string]string) []string {
+	names := make([]string, 0, len(files))
+	for name := range files {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// daytonaExecutableWorkspaceFile reports whether a workspace file should be
+// written with the executable bit (scripts are frequently invoked directly).
+func daytonaExecutableWorkspaceFile(name string) bool {
+	ext := strings.ToLower(path.Ext(name))
+	return ext == ".sh" || ext == ".py"
+}
+
+// daytonaWorkspaceFilesReadinessCommand verifies every workspace file landed in
+// the live workspace, including nested paths such as scripts/review-loop/x.md.
+func daytonaWorkspaceFilesReadinessCommand(dir string, files map[string]string) string {
+	if len(files) == 0 {
+		return "true"
+	}
+	var b strings.Builder
+	b.WriteString("set -e\n")
+	for _, name := range sortedWorkspaceFileNames(files) {
+		remotePath := strings.TrimRight(dir, "/") + "/" + name
+		b.WriteString("test -f ")
+		b.WriteString(shellQuote(remotePath))
+		b.WriteString(" || { echo ")
+		b.WriteString(shellQuote("missing workspace file: " + name))
+		b.WriteString("; exit 1; }\n")
+	}
+	b.WriteString("echo 'workspace files verified'\n")
+	return b.String()
 }
 
 func daytonaPrepareBridgeCommand() string {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -3640,7 +3640,7 @@ cp "$BIN" /tmp/claw-bridge.download && chmod +x /tmp/claw-bridge.download && mv 
 			// runBootstrap -- and with it syncStagedWorkspaceToOpenClawWorkspace --
 			// never runs on this provider: nothing would ever copy staged files over.
 			// Mirrors Replicated, which also writes final files after bootstrap.
-			targetPath := daytonaLiveWorkspaceDir + "/" + safeName
+			targetPath := daytonaWorkspaceFilePath(safeName)
 			targetDir := path.Dir(targetPath)
 			// Use collision-resistant delimiter (same strategy as early flake staging)
 			// to protect against content containing a fixed token.
@@ -3826,7 +3826,7 @@ gh auth status`
 	// commands fail with "can't open file" on every stage.
 	if len(writtenWorkspaceFiles) > 0 {
 		s.setBootstrapStatus(clawID, "Verifying workspace files")
-		filesScript := daytonaWorkspaceFilesReadinessCommand(daytonaLiveWorkspaceDir, writtenWorkspaceFiles)
+		filesScript := daytonaWorkspaceFilesReadinessCommand(writtenWorkspaceFiles)
 		filesResult, filesErr := p.ExecWithTimeout(ctx, instanceID, []string{"bash", "-c", filesScript}, 30*time.Second)
 		if filesErr != nil {
 			diag := fmt.Sprintf("Workspace files verification failed: %v", filesErr)
@@ -4105,18 +4105,25 @@ func daytonaExecutableWorkspaceFile(name string) bool {
 	return ext == ".sh" || ext == ".py"
 }
 
+// daytonaWorkspaceFilePath returns the sandbox path a workspace file must be
+// written to. The write loop and the readiness gate share it so they can never
+// disagree about the target, and a regression back to the staged
+// /home/daytona/workspace dir is caught by unit tests instead of at runtime.
+func daytonaWorkspaceFilePath(name string) string {
+	return daytonaLiveWorkspaceDir + "/" + strings.TrimPrefix(name, "/")
+}
+
 // daytonaWorkspaceFilesReadinessCommand verifies every workspace file landed in
 // the live workspace, including nested paths such as scripts/review-loop/x.md.
-func daytonaWorkspaceFilesReadinessCommand(dir string, files map[string]string) string {
+func daytonaWorkspaceFilesReadinessCommand(files map[string]string) string {
 	if len(files) == 0 {
 		return "true"
 	}
 	var b strings.Builder
 	b.WriteString("set -e\n")
 	for _, name := range sortedWorkspaceFileNames(files) {
-		remotePath := strings.TrimRight(dir, "/") + "/" + name
 		b.WriteString("test -f ")
-		b.WriteString(shellQuote(remotePath))
+		b.WriteString(shellQuote(daytonaWorkspaceFilePath(name)))
 		b.WriteString(" || { echo ")
 		b.WriteString(shellQuote("missing workspace file: " + name))
 		b.WriteString("; exit 1; }\n")


### PR DESCRIPTION
## Incident

Claws NEXT-505, NEXT-508 and NEXT-520 hard-stopped on their first turn. Every workflow stage that shelled out to a workspace script failed with "can't open file", because `~/.openclaw/workspace/scripts/` did not exist in the sandbox at all. Top-level files (AGENTS.md, SOUL.md, ...) were present, which made it look like template delivery had worked — those are OpenClaw agent-generated defaults, not template deliveries, so the whole `scripts/` and `memory/` subtree was silently missing.

## Root cause

Two independent bugs on the path from push to a running Daytona claw. **Only bug 2 caused this incident** — see the note under bug 1.

1. **Nested files were dropped at push time.** `saveExternalTemplate` (`pkg/hub/external_storage.go`) skipped any filename containing a slash:

   ```go
   if strings.Contains(fname, "..") || strings.ContainsAny(fname, `/\`) {
       continue // skip paths with directory traversal
   }
   ```

   `saveExternalWorkspace` already handled nested paths correctly; the **template** path had diverged.

   **This was not the cause of the NEXT-505/508/520 incident.** Corrected after an operator checked the live hub DB: `claws.template_files` for the affected claws contains all 17 nested paths, including `scripts/detect_android_changes.py`, and the hub log shows the writes happening (`[daytona] write scripts/review-loop/reviewers/performance-reviewer.md done`). The `faster` workspace is published as a *workspace*, so it goes through `saveExternalWorkspace`, which was never broken. Bug 1 is a real defect on the *template* flow and the fix stands — `TestSaveExternalTemplatePreservesNestedFiles` fails on main — but it starved nothing here.

   Bug 2 alone is what emptied `~/.openclaw/workspace/scripts/`. **Do not drop the staged-to-live change on the assumption that the path filter was the real fix** — that would restore the outage with the tests still green.

2. **The final write targeted a directory nothing syncs.** `bootstrapDaytona` wrote `template_files` into the *staged* `/home/daytona/workspace/`, with a comment claiming `syncStagedWorkspaceToOpenClawWorkspace` would copy them into the live workspace. That sync only runs inside `runBootstrap()`, which is gated on `ELASTICCLAW_BOOTSTRAP=1` — and `daytonaAsyncBridgeCommand` starts the Daytona bridge **without** that variable. On Daytona nothing ever ran the sync, so staged files were dead on arrival. Exedev and Replicated use the bootstrap-script path with `ELASTICCLAW_BOOTSTRAP=1` and were never affected, which is why this only ever showed up on Daytona.

## Fix

**`pkg/hub/external_storage.go`** — `saveExternalTemplate` now validates via `cleanWorkspaceFilePath` + `os.MkdirAll`, matching `saveExternalWorkspace`. Nested `memory/**` and `scripts/**` survive a push; traversal paths (`../escape.md`, absolute paths, NUL) are still rejected, now with a log line instead of a silent skip.

**`pkg/hub/server.go`**
- The `template_files` write loop writes to the live workspace via the new shared `daytonaWorkspaceFilePath` helper (`/home/daytona/.openclaw/workspace/...`), preserving the nested `safeName` verbatim. The false comment about bridge-side sync is replaced with the real contract.
- Fail-closed: invalid path, write failure and rand failure now return an error instead of `log.Printf` + `continue`. A claw missing a script its workflow invokes fails every stage anyway — better to fail loudly at bootstrap.
- Deterministic iteration (`sortedWorkspaceFileNames`).
- `chmod +x` for `.sh`/`.py`. `template_files` is `map[string]string` and carries no mode, so this is an extension-based rule, not a copy of the source mode.
- **New readiness gate** before the repo-readiness gate: `daytonaWorkspaceFilesReadinessCommand` emits a `test -f` per delivered file; on failure the bootstrap status becomes "Workspace incomplete" with the missing path.
- Corrected the early-flake block comments to state that the flake helpers never run on Daytona. Behaviour unchanged.

Not touched, per non-goals: `config.ReadTemplateFiles`, `cmd/claw-bridge/main.go` sync, `daytonaAsyncBridgeCommand` env.

## Review feedback applied

- **Write target now directly unit-tested.** The review noted the write loop's target path was only enforced at runtime by the gate. Write loop and readiness gate now share `daytonaWorkspaceFilePath`, and `TestDaytonaWorkspaceFilePathTargetsLiveWorkspace` pins it — a regression back to the staged dir fails the unit suite.
- **Push-time skip is now logged** and the asymmetry with the fail-closed bootstrap is documented in the code.
- Not changed: the review flagged that fail-closed on an invalid path could hard-fail a legacy claw carrying a malformed `template_files` key. That is intentional — a claw that boots without the files its workflows declare is exactly the incident being fixed, and a loud bootstrap error is easier to triage than a stopped agent. The error string names the offending key.
- Not changed: extension-based `chmod +x` on `.py`/`.sh`. Agreed it is slightly beyond the bug fix, but `template_files` carries no mode and scripts are invoked directly.

## Testing

```
go build ./...                                  # clean
go vet ./pkg/hub/                               # clean
go test ./pkg/hub/ ./pkg/config/ ./cmd/... -count=1
go test ./... -count=1                          # full suite, no failures
```

New `pkg/hub/daytona_workspace_files_test.go` covers: the live write target for nested paths, the readiness command's nested-path assertions (and that it never references the staged dir), the executable-bit rule, and `TestSaveExternalTemplatePreservesNestedFiles`, which round-trips a template through `saveExternalTemplate` → `config.ReadTemplateFiles`. That last test **fails on main** (`template files missing scripts/detect_android_changes.py ... (got [AGENTS.md])`), which pins bug 1.

## Residual risk

Verification is unit-level only. End-to-end proof still requires an ops check on a fresh Daytona claw for workspace `faster`: `ls ~/.openclaw/workspace/scripts/` must list the four script entries plus `review-loop/` and `tests/`, and `elasticclaw-config.yaml` + `CONTEXT.md` must sit at the workspace root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

