### PR TITLE
fix(hub): stop the PR watcher from exhausting the GitHub App quota

### DIFF
--- a/pkg/hub/github_client.go
+++ b/pkg/hub/github_client.go
@@ -1,0 +1,298 @@
+package hub
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// githubRateLimitReserve is the slice of the installation quota the background
+// pollers refuse to spend, so interactive and agent-initiated calls keep working
+// even when the watcher is busy. Override with ELASTICCLAW_GITHUB_RATE_RESERVE.
+var githubRateLimitReserve = githubEnvInt("ELASTICCLAW_GITHUB_RATE_RESERVE", 500)
+
+// githubETagCacheMax bounds the conditional-request cache so a long-lived hub
+// cannot grow it without limit.
+const githubETagCacheMax = 2048
+
+// githubRateLimitFallbackWait is used when GitHub reports a rate limit without
+// a usable reset hint.
+const githubRateLimitFallbackWait = time.Minute
+
+func githubEnvInt(key string, def int) int {
+	if v, err := strconv.Atoi(strings.TrimSpace(os.Getenv(key))); err == nil && v >= 0 {
+		return v
+	}
+	return def
+}
+
+type githubETagEntry struct {
+	etag     string
+	body     []byte
+	lastUsed time.Time
+}
+
+// githubClient is the shared HTTP client for GitHub REST calls. It tracks the
+// rate-limit headers GitHub returns on every response and caches ETags so
+// unchanged resources come back as 304s, which do not consume quota.
+type githubClient struct {
+	httpClient *http.Client
+
+	mu    sync.Mutex
+	etags map[string]*githubETagEntry
+
+	limit     int
+	remaining int
+	reset     time.Time
+	haveLimit bool
+	// blockedUntil is set when GitHub reports the quota exhausted (403/429 with
+	// no remaining budget, or a Retry-After). Requests short-circuit until it
+	// passes instead of hammering an exhausted quota every tick.
+	blockedUntil time.Time
+	lastBlockLog time.Time
+}
+
+func newGitHubClient() *githubClient {
+	return &githubClient{httpClient: http.DefaultClient, etags: map[string]*githubETagEntry{}}
+}
+
+// defaultGitHubClient backs the githubAPI* helpers, so every GitHub consumer in
+// the hub shares one rate-limit budget and one ETag cache.
+var defaultGitHubClient = newGitHubClient()
+
+type githubResponse struct {
+	StatusCode int
+	Body       []byte
+	Header     http.Header
+	// NotModified reports that GitHub answered 304 and Body came from the cache.
+	NotModified bool
+}
+
+// rateLimited mirrors the pre-existing semantics: GitHub says the quota is gone.
+func (r *githubResponse) rateLimited() bool {
+	return r.Header.Get("X-RateLimit-Remaining") == "0"
+}
+
+// get performs a conditional GET. A cached ETag is replayed as If-None-Match,
+// and a 304 returns the cached body without spending quota.
+func (c *githubClient) get(url, token string) (*githubResponse, error) {
+	return c.doGet(url, token, true)
+}
+
+func (c *githubClient) doGet(url, token string, conditional bool) (*githubResponse, error) {
+	if until, blocked := c.blockedUntilTime(); blocked {
+		return nil, &githubAPIError{
+			StatusCode:  http.StatusForbidden,
+			RateLimited: true,
+			Body: fmt.Sprintf("github rate limit exhausted; not retrying until %s",
+				until.UTC().Format(time.RFC3339)),
+		}
+	}
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	if conditional {
+		if etag := c.cachedETag(url); etag != "" {
+			req.Header.Set("If-None-Match", etag)
+		}
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("github API response read error: %w", err)
+	}
+	c.observe(resp.StatusCode, resp.Header, body)
+
+	if resp.StatusCode == http.StatusNotModified {
+		if cached, ok := c.cachedBody(url); ok {
+			return &githubResponse{StatusCode: http.StatusOK, Body: cached, Header: resp.Header, NotModified: true}, nil
+		}
+		// The entry was evicted after the validator was sent; ask again unconditionally.
+		c.forget(url)
+		return c.doGet(url, token, false)
+	}
+	if resp.StatusCode == http.StatusOK {
+		c.store(url, resp.Header.Get("ETag"), body)
+	}
+	return &githubResponse{StatusCode: resp.StatusCode, Body: body, Header: resp.Header}, nil
+}
+
+// observe records the rate-limit headers GitHub sends on every response and
+// arms the backoff when the quota is exhausted.
+func (c *githubClient) observe(status int, h http.Header, body []byte) {
+	limit, hasLimit := githubHeaderInt(h, "X-RateLimit-Limit")
+	remaining, hasRemaining := githubHeaderInt(h, "X-RateLimit-Remaining")
+	var reset time.Time
+	if secs, ok := githubHeaderInt(h, "X-RateLimit-Reset"); ok {
+		reset = time.Unix(int64(secs), 0)
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if hasLimit {
+		c.limit = limit
+	}
+	if hasRemaining {
+		c.remaining = remaining
+		c.haveLimit = true
+	}
+	if !reset.IsZero() {
+		c.reset = reset
+	}
+
+	if !githubIsRateLimited(status, h, body) {
+		return
+	}
+	until := time.Now().Add(githubRateLimitFallbackWait)
+	if retry, ok := githubHeaderInt(h, "Retry-After"); ok && retry > 0 {
+		until = time.Now().Add(time.Duration(retry) * time.Second)
+	} else if !reset.IsZero() && reset.After(time.Now()) {
+		until = reset
+	}
+	if until.After(c.blockedUntil) {
+		c.blockedUntil = until
+		if time.Since(c.lastBlockLog) >= time.Minute {
+			c.lastBlockLog = time.Now()
+			log.Printf("[github] rate limit exhausted (limit=%d remaining=%d); pausing GitHub calls until %s",
+				c.limit, c.remaining, until.UTC().Format(time.RFC3339))
+		}
+	}
+}
+
+func githubIsRateLimited(status int, h http.Header, body []byte) bool {
+	if status != http.StatusForbidden && status != http.StatusTooManyRequests {
+		return false
+	}
+	if h.Get("X-RateLimit-Remaining") == "0" || h.Get("Retry-After") != "" {
+		return true
+	}
+	return strings.Contains(strings.ToLower(string(body)), "rate limit")
+}
+
+func githubHeaderInt(h http.Header, key string) (int, bool) {
+	v := strings.TrimSpace(h.Get(key))
+	if v == "" {
+		return 0, false
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+// blockedUntilTime reports whether calls are currently paused, and until when.
+func (c *githubClient) blockedUntilTime() (time.Time, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.blockedUntil.IsZero() || !time.Now().Before(c.blockedUntil) {
+		return time.Time{}, false
+	}
+	return c.blockedUntil, true
+}
+
+// allowLowPriority reports whether background polling may still spend quota.
+// It goes false once the remaining budget drops into the reserve, so the
+// watcher degrades before it starves the rest of the hub.
+func (c *githubClient) allowLowPriority() bool {
+	if _, blocked := c.blockedUntilTime(); blocked {
+		return false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.haveLimit {
+		return true
+	}
+	if c.remaining >= githubRateLimitReserve {
+		return true
+	}
+	// Budget is inside the reserve: stay out until the window resets.
+	return !c.reset.IsZero() && !time.Now().Before(c.reset)
+}
+
+// budget reports the last observed quota state for logging.
+func (c *githubClient) budget() (limit, remaining int, reset time.Time, ok bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.limit, c.remaining, c.reset, c.haveLimit
+}
+
+func (c *githubClient) cachedETag(url string) string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if e, ok := c.etags[url]; ok {
+		return e.etag
+	}
+	return ""
+}
+
+func (c *githubClient) cachedBody(url string) ([]byte, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.etags[url]
+	if !ok {
+		return nil, false
+	}
+	e.lastUsed = time.Now()
+	return e.body, true
+}
+
+func (c *githubClient) store(url, etag string, body []byte) {
+	if etag == "" {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.etags) >= githubETagCacheMax {
+		if _, exists := c.etags[url]; !exists {
+			c.evictOldestLocked()
+		}
+	}
+	c.etags[url] = &githubETagEntry{etag: etag, body: body, lastUsed: time.Now()}
+}
+
+func (c *githubClient) evictOldestLocked() {
+	var oldestKey string
+	var oldest time.Time
+	for k, e := range c.etags {
+		if oldestKey == "" || e.lastUsed.Before(oldest) {
+			oldestKey, oldest = k, e.lastUsed
+		}
+	}
+	if oldestKey != "" {
+		delete(c.etags, oldestKey)
+	}
+}
+
+func (c *githubClient) forget(url string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.etags, url)
+}
+
+// reset clears cached state. Tests use it to isolate the package-level client.
+func (c *githubClient) resetState() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.etags = map[string]*githubETagEntry{}
+	c.limit, c.remaining, c.haveLimit = 0, 0, false
+	c.reset = time.Time{}
+	c.blockedUntil = time.Time{}
+	c.lastBlockLog = time.Time{}
+}

--- a/pkg/hub/github_client.go
+++ b/pkg/hub/github_client.go
@@ -25,6 +25,12 @@ const githubETagCacheMax = 2048
 // a usable reset hint.
 const githubRateLimitFallbackWait = time.Minute
 
+// githubRateLimitMaxWait clamps how long a single response may pause every
+// GitHub call in the hub. Legitimate values never exceed the hourly window, so
+// a malformed or hostile Retry-After/X-RateLimit-Reset cannot blind the hub
+// until the process restarts.
+const githubRateLimitMaxWait = time.Hour
+
 func githubEnvInt(key string, def int) int {
 	if v, err := strconv.Atoi(strings.TrimSpace(os.Getenv(key))); err == nil && v >= 0 {
 		return v
@@ -123,6 +129,11 @@ func (c *githubClient) doGet(url, token string, conditional bool) (*githubRespon
 		if cached, ok := c.cachedBody(url); ok {
 			return &githubResponse{StatusCode: http.StatusOK, Body: cached, Header: resp.Header, NotModified: true}, nil
 		}
+		if !conditional {
+			// We sent no validator, so a 304 is a protocol violation and there is
+			// nothing to replay. Surface it instead of retrying forever.
+			return nil, &githubAPIError{StatusCode: resp.StatusCode, Body: "github returned 304 without a conditional request"}
+		}
 		// The entry was evicted after the validator was sent; ask again unconditionally.
 		c.forget(url)
 		return c.doGet(url, token, false)
@@ -159,11 +170,15 @@ func (c *githubClient) observe(status int, h http.Header, body []byte) {
 	if !githubIsRateLimited(status, h, body) {
 		return
 	}
-	until := time.Now().Add(githubRateLimitFallbackWait)
+	now := time.Now()
+	until := now.Add(githubRateLimitFallbackWait)
 	if retry, ok := githubHeaderInt(h, "Retry-After"); ok && retry > 0 {
-		until = time.Now().Add(time.Duration(retry) * time.Second)
-	} else if !reset.IsZero() && reset.After(time.Now()) {
+		until = now.Add(time.Duration(retry) * time.Second)
+	} else if !reset.IsZero() && reset.After(now) {
 		until = reset
+	}
+	if max := now.Add(githubRateLimitMaxWait); until.After(max) {
+		until = max
 	}
 	if until.After(c.blockedUntil) {
 		c.blockedUntil = until
@@ -219,11 +234,23 @@ func (c *githubClient) allowLowPriority() bool {
 	if !c.haveLimit {
 		return true
 	}
-	if c.remaining >= githubRateLimitReserve {
+	if c.remaining >= c.effectiveReserveLocked() {
 		return true
 	}
 	// Budget is inside the reserve: stay out until the window resets.
 	return !c.reset.IsZero() && !time.Now().Before(c.reset)
+}
+
+// effectiveReserveLocked keeps the reserve proportional to the observed limit.
+// A token whose hourly limit is at or below githubRateLimitReserve (a classic
+// PAT scoped down, or an unauthenticated 60/hour budget) would otherwise sit
+// permanently inside the reserve and degrade the watcher to merge-only forever.
+func (c *githubClient) effectiveReserveLocked() int {
+	reserve := githubRateLimitReserve
+	if c.limit > 0 && reserve > c.limit/2 {
+		reserve = c.limit / 2
+	}
+	return reserve
 }
 
 // budget reports the last observed quota state for logging.

--- a/pkg/hub/github_client_test.go
+++ b/pkg/hub/github_client_test.go
@@ -129,6 +129,45 @@ func TestGitHubRetryAfterBlocksSubsequentCalls(t *testing.T) {
 	}
 }
 
+func TestGitHubRateLimitBlockIsClamped(t *testing.T) {
+	resetGitHubClientForTest(t)
+
+	gh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// A hostile or malformed hint that would otherwise blind the hub for years.
+		w.Header().Set("Retry-After", "99999999")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"message":"rate limit"}`))
+	}))
+	defer gh.Close()
+
+	if _, err := githubAPIWithBase(gh.URL, "repos/o/r/pulls/1", "tok"); err == nil {
+		t.Fatal("expected error")
+	}
+	until, blocked := defaultGitHubClient.blockedUntilTime()
+	if !blocked {
+		t.Fatal("client not blocked")
+	}
+	if wait := time.Until(until); wait > githubRateLimitMaxWait+time.Minute {
+		t.Fatalf("blocked for %s, want clamped to %s", wait, githubRateLimitMaxWait)
+	}
+}
+
+func TestGitHubReserveScalesWithSmallLimits(t *testing.T) {
+	resetGitHubClientForTest(t)
+
+	h := http.Header{}
+	h.Set("X-RateLimit-Limit", "60")
+	h.Set("X-RateLimit-Remaining", "40")
+	h.Set("X-RateLimit-Reset", strconv.FormatInt(time.Now().Add(30*time.Minute).Unix(), 10))
+	defaultGitHubClient.observe(http.StatusOK, h, nil)
+
+	// 40 remaining is below the 500 default reserve but well above half of a
+	// 60/hour limit, so background polling must stay enabled.
+	if !defaultGitHubClient.allowLowPriority() {
+		t.Fatal("low-priority polling disabled by a reserve larger than the limit")
+	}
+}
+
 func TestGitHubClientUsesETagSoUnchangedPollsAreFree(t *testing.T) {
 	resetGitHubClientForTest(t)
 

--- a/pkg/hub/github_client_test.go
+++ b/pkg/hub/github_client_test.go
@@ -1,0 +1,286 @@
+package hub
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+// resetGitHubClientForTest isolates the package-level client between tests.
+func resetGitHubClientForTest(t *testing.T) {
+	t.Helper()
+	defaultGitHubClient.resetState()
+	t.Cleanup(defaultGitHubClient.resetState)
+}
+
+func TestGitHubClientBacksOffWhenBudgetDepleted(t *testing.T) {
+	resetGitHubClientForTest(t)
+
+	var remaining int64 = 900
+	var calls int64
+	gh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&calls, 1)
+		w.Header().Set("X-RateLimit-Limit", "5000")
+		w.Header().Set("X-RateLimit-Remaining", strconv.FormatInt(atomic.LoadInt64(&remaining), 10))
+		w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(time.Now().Add(30*time.Minute).Unix(), 10))
+		_, _ = w.Write([]byte(`{"state":"open"}`))
+	}))
+	defer gh.Close()
+
+	if _, err := githubAPIWithBase(gh.URL, "repos/o/r/pulls/1", "tok"); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if !defaultGitHubClient.allowLowPriority() {
+		t.Fatalf("low-priority polling blocked while %d requests remain", remaining)
+	}
+
+	// Drop below the reserve: background polling must stand down while
+	// interactive calls keep working.
+	atomic.StoreInt64(&remaining, int64(githubRateLimitReserve-1))
+	if _, err := githubAPIWithBase(gh.URL, "repos/o/r/pulls/2", "tok"); err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if defaultGitHubClient.allowLowPriority() {
+		t.Fatalf("low-priority polling still allowed with remaining below reserve %d", githubRateLimitReserve)
+	}
+	if _, err := githubAPIWithBase(gh.URL, "repos/o/r/pulls/3", "tok"); err != nil {
+		t.Fatalf("high-priority call must still be served: %v", err)
+	}
+	if got := atomic.LoadInt64(&calls); got != 3 {
+		t.Fatalf("requests=%d, want 3", got)
+	}
+}
+
+func TestGitHubRateLimit403DoesNotRetryImmediately(t *testing.T) {
+	resetGitHubClientForTest(t)
+
+	var calls int64
+	gh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&calls, 1)
+		w.Header().Set("X-RateLimit-Limit", "5000")
+		w.Header().Set("X-RateLimit-Remaining", "0")
+		w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(time.Now().Add(20*time.Minute).Unix(), 10))
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"message":"API rate limit exceeded for installation ID 1."}`))
+	}))
+	defer gh.Close()
+
+	_, err := githubAPIWithBase(gh.URL, "repos/o/r/pulls/1", "tok")
+	if err == nil {
+		t.Fatal("expected rate limit error")
+	}
+	if isPermanentGitHubAPIError(err) {
+		t.Fatalf("rate limit must stay transient, got permanent: %v", err)
+	}
+
+	// Every later call short-circuits until the window resets, instead of
+	// re-issuing the request on the next tick.
+	for i := 0; i < 5; i++ {
+		if _, err := githubAPIWithBase(gh.URL, fmt.Sprintf("repos/o/r/pulls/%d", i+2), "tok"); err == nil {
+			t.Fatal("expected blocked error while rate limited")
+		}
+		if _, err := githubAPIListWithBase(gh.URL, "repos/o/r/issues/1/comments", "tok"); err == nil {
+			t.Fatal("expected blocked error while rate limited")
+		}
+	}
+	if got := atomic.LoadInt64(&calls); got != 1 {
+		t.Fatalf("requests=%d, want 1 (no retries while rate limited)", got)
+	}
+
+	until, blocked := defaultGitHubClient.blockedUntilTime()
+	if !blocked {
+		t.Fatal("client not blocked after 403 rate limit")
+	}
+	if time.Until(until) < 15*time.Minute {
+		t.Fatalf("blocked until %s, want the reported reset window", until)
+	}
+}
+
+func TestGitHubRetryAfterBlocksSubsequentCalls(t *testing.T) {
+	resetGitHubClientForTest(t)
+
+	var calls int64
+	gh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&calls, 1)
+		w.Header().Set("Retry-After", "120")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"message":"You have exceeded a secondary rate limit."}`))
+	}))
+	defer gh.Close()
+
+	if _, err := githubAPIWithBase(gh.URL, "repos/o/r/pulls/1", "tok"); err == nil {
+		t.Fatal("expected error")
+	}
+	if _, err := githubAPIWithBase(gh.URL, "repos/o/r/pulls/1", "tok"); err == nil {
+		t.Fatal("expected blocked error")
+	}
+	if got := atomic.LoadInt64(&calls); got != 1 {
+		t.Fatalf("requests=%d, want 1", got)
+	}
+	until, blocked := defaultGitHubClient.blockedUntilTime()
+	if !blocked || time.Until(until) < 60*time.Second {
+		t.Fatalf("Retry-After ignored: blocked=%v until=%s", blocked, until)
+	}
+}
+
+func TestGitHubClientUsesETagSoUnchangedPollsAreFree(t *testing.T) {
+	resetGitHubClientForTest(t)
+
+	var conditional int64
+	gh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("ETag", `W/"abc123"`)
+		if r.Header.Get("If-None-Match") == `W/"abc123"` {
+			atomic.AddInt64(&conditional, 1)
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		_, _ = w.Write([]byte(`{"state":"open","number":7}`))
+	}))
+	defer gh.Close()
+
+	first, err := githubAPIWithBase(gh.URL, "repos/o/r/pulls/7", "tok")
+	if err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	second, err := githubAPIWithBase(gh.URL, "repos/o/r/pulls/7", "tok")
+	if err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if atomic.LoadInt64(&conditional) != 1 {
+		t.Fatalf("second call did not send If-None-Match")
+	}
+	if second["state"] != first["state"] || second["number"] != first["number"] {
+		t.Fatalf("304 body = %v, want cached %v", second, first)
+	}
+}
+
+// githubAppAnyTokenTransport mints installation tokens for scoped and unscoped
+// requests alike, and counts how many tokens were minted.
+type githubAppAnyTokenTransport struct {
+	base  http.RoundTripper
+	mints *int64
+}
+
+func (t githubAppAnyTokenTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	if r.URL.Host != "api.github.com" {
+		return t.base.RoundTrip(r)
+	}
+	if r.Method == http.MethodGet && r.URL.Path == "/app/installations" {
+		return githubAppTokenResponse(http.StatusOK, `[{"id":1,"account":{"login":"owner"}}]`), nil
+	}
+	if r.Method == http.MethodPost && r.URL.Path == "/app/installations/1/access_tokens" {
+		atomic.AddInt64(t.mints, 1)
+		return githubAppTokenResponse(http.StatusCreated, `{"token":"tok","expires_at":"2030-01-01T00:00:00Z"}`), nil
+	}
+	return githubAppTokenResponse(http.StatusNotFound, `{"message":"not found"}`), nil
+}
+
+func TestPollAllPRsStopsCallingGitHubWhileRateLimited(t *testing.T) {
+	resetGitHubClientForTest(t)
+
+	var mints int64
+	oldTransport := http.DefaultTransport
+	http.DefaultTransport = githubAppAnyTokenTransport{base: oldTransport, mints: &mints}
+	t.Cleanup(func() { http.DefaultTransport = oldTransport })
+
+	var calls int64
+	gh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&calls, 1)
+		w.Header().Set("X-RateLimit-Limit", "5000")
+		w.Header().Set("X-RateLimit-Remaining", "0")
+		w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(time.Now().Add(30*time.Minute).Unix(), 10))
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"message":"API rate limit exceeded for installation ID 1."}`))
+	}))
+	defer gh.Close()
+
+	cfg := &types.HubConfig{GitHubApps: []*types.GitHubAppConfig{{AppID: 1, PrivateKeyPEM: testGitHubAppPEM(t)}}}
+	s, db := NewTestServerWithConfig(t, cfg, gh.URL, "", "")
+	insertWatcherTestPR(t, db, "claw-ratelimited", "pr-ratelimited")
+
+	s.pollAllPRs()
+	after := atomic.LoadInt64(&calls)
+	if after == 0 {
+		t.Fatal("first poll made no GitHub calls")
+	}
+	for i := 0; i < 3; i++ {
+		s.pollAllPRs()
+	}
+	if got := atomic.LoadInt64(&calls); got != after {
+		t.Fatalf("requests=%d after further polls, want %d (no calls while rate limited)", got, after)
+	}
+	// The next poll is deferred to the reported reset, not the base interval.
+	if delay := s.nextPollDelay(); delay <= prWatcherBaseInterval {
+		t.Fatalf("nextPollDelay=%s, want a backoff longer than %s", delay, prWatcherBaseInterval)
+	}
+
+	// One unscoped and one repo-scoped token for the whole run, not one per call.
+	if got := atomic.LoadInt64(&mints); got != 2 {
+		t.Fatalf("installation tokens minted=%d, want 2 (tokens must be cached)", got)
+	}
+}
+
+func TestInstallationTokensAreCachedAcrossCalls(t *testing.T) {
+	var mints int64
+	oldTransport := http.DefaultTransport
+	http.DefaultTransport = githubAppAnyTokenTransport{base: oldTransport, mints: &mints}
+	t.Cleanup(func() { http.DefaultTransport = oldTransport })
+
+	cfg := &types.HubConfig{GitHubApps: []*types.GitHubAppConfig{{AppID: 1, PrivateKeyPEM: testGitHubAppPEM(t)}}}
+	s, _ := NewTestServerWithConfig(t, cfg, "", "", "")
+
+	for i := 0; i < 10; i++ {
+		if got := s.resolveGitHubToken(); got != "tok" {
+			t.Fatalf("unscoped token = %q", got)
+		}
+		if got := s.resolveGitHubTokenForRepo("owner/repo"); got != "tok" {
+			t.Fatalf("repo token = %q", got)
+		}
+	}
+	if got := atomic.LoadInt64(&mints); got != 2 {
+		t.Fatalf("installation tokens minted=%d, want 2 (one per distinct scope)", got)
+	}
+}
+
+func TestPRWatcherIntervalScalesWithTrackedPRs(t *testing.T) {
+	if got := prWatcherInterval(0); got != prWatcherBaseInterval {
+		t.Fatalf("interval(0)=%s, want %s", got, prWatcherBaseInterval)
+	}
+	if got := prWatcherInterval(1); got != prWatcherBaseInterval {
+		t.Fatalf("interval(1)=%s, want the base interval floor %s", got, prWatcherBaseInterval)
+	}
+
+	prev := prWatcherInterval(4)
+	if prev <= prWatcherBaseInterval {
+		t.Fatalf("interval(4)=%s, want more than the base interval", prev)
+	}
+	for _, n := range []int{8, 16, 32} {
+		got := prWatcherInterval(n)
+		if got <= prev {
+			t.Fatalf("interval(%d)=%s, want more than %s", n, got, prev)
+		}
+		prev = got
+	}
+	if got := prWatcherInterval(10000); got != prWatcherMaxInterval {
+		t.Fatalf("interval(10000)=%s, want the cap %s", got, prWatcherMaxInterval)
+	}
+
+	// The whole point: hourly cost stays inside the watcher's budget until the
+	// interval hits its cap, past which the rate-limit reserve takes over.
+	for _, n := range []int{1, 2, 4, 8} {
+		interval := prWatcherInterval(n)
+		if interval >= prWatcherMaxInterval {
+			continue
+		}
+		perHour := float64(n*prWatcherCallsPerPR) * float64(time.Hour) / float64(interval)
+		if perHour > prWatcherHourlyBudget+1 {
+			t.Fatalf("%d PR(s) cost %.0f calls/hour, over budget %d", n, perHour, prWatcherHourlyBudget)
+		}
+	}
+}

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -183,18 +183,22 @@ const (
 	prWatcherBaseInterval = 30 * time.Second
 	// prWatcherMaxInterval caps the backoff so a big factory still reconciles.
 	prWatcherMaxInterval = 5 * time.Minute
-	// prWatcherCallsPerPR is the observed steady-state cost of one PR per poll
-	// (pull, check-runs, issue comments, review comments, reviews, plus the
-	// pipeline-driven extras).
-	prWatcherCallsPerPR = 7
+	// prWatcherCallsPerPR is the worst-case cost of one PR per poll: merge check
+	// (1) + CI failures (pull + check-runs = 2) + issue comments (1) + review
+	// comments (1) + reviews (1) + pr_conditions (pull + check-runs + reviews =
+	// 3). ETag 304s make the billed number lower in steady state.
+	prWatcherCallsPerPR = 9
 	// prWatcherHourlyBudget is the watcher's share of the 5,000/hour GitHub App
 	// installation quota. The rest is left for webhooks, pipelines and agents.
 	prWatcherHourlyBudget = 2000
 )
 
 // prWatcherInterval scales the poll interval with the number of tracked PRs so
-// the watcher's hourly cost stays inside prWatcherHourlyBudget no matter how
-// many claws are live.
+// the watcher's hourly cost stays inside prWatcherHourlyBudget. The guarantee
+// holds until the interval hits prWatcherMaxInterval (around 18 tracked PRs);
+// past that the cost grows linearly again and the backstop is the rate-limit
+// reserve in githubClient, which degrades polling to merge-only rather than
+// letting the watcher exhaust the installation quota.
 func prWatcherInterval(trackedPRs int) time.Duration {
 	if trackedPRs <= 0 {
 		return prWatcherBaseInterval

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -5,10 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log"
 	"net/http"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -176,17 +176,71 @@ func (s *Server) scanMessageForPRs(clawID, content string) {
 	}
 }
 
+const (
+	// prWatcherBaseInterval is the fastest the poller ever runs. Comments,
+	// reviews and merges are already delivered by webhooks, so a tighter loop
+	// buys latency nobody consumes while it burns installation quota.
+	prWatcherBaseInterval = 30 * time.Second
+	// prWatcherMaxInterval caps the backoff so a big factory still reconciles.
+	prWatcherMaxInterval = 5 * time.Minute
+	// prWatcherCallsPerPR is the observed steady-state cost of one PR per poll
+	// (pull, check-runs, issue comments, review comments, reviews, plus the
+	// pipeline-driven extras).
+	prWatcherCallsPerPR = 7
+	// prWatcherHourlyBudget is the watcher's share of the 5,000/hour GitHub App
+	// installation quota. The rest is left for webhooks, pipelines and agents.
+	prWatcherHourlyBudget = 2000
+)
+
+// prWatcherInterval scales the poll interval with the number of tracked PRs so
+// the watcher's hourly cost stays inside prWatcherHourlyBudget no matter how
+// many claws are live.
+func prWatcherInterval(trackedPRs int) time.Duration {
+	if trackedPRs <= 0 {
+		return prWatcherBaseInterval
+	}
+	callsPerPoll := float64(trackedPRs * prWatcherCallsPerPR)
+	seconds := callsPerPoll * 3600 / float64(prWatcherHourlyBudget)
+	interval := time.Duration(seconds * float64(time.Second))
+	if interval < prWatcherBaseInterval {
+		return prWatcherBaseInterval
+	}
+	if interval > prWatcherMaxInterval {
+		return prWatcherMaxInterval
+	}
+	return interval
+}
+
+// nextPollDelay is the wait before the next poll: the quota reset when GitHub
+// has cut us off, otherwise the PR-count-scaled interval.
+func (s *Server) nextPollDelay() time.Duration {
+	if until, blocked := defaultGitHubClient.blockedUntilTime(); blocked {
+		wait := time.Until(until) + time.Second
+		if wait > prWatcherMaxInterval {
+			wait = prWatcherMaxInterval
+		}
+		if wait > 0 {
+			return wait
+		}
+	}
+	s.mu.RLock()
+	tracked := s.trackedPRCount
+	s.mu.RUnlock()
+	return prWatcherInterval(tracked)
+}
+
 // startPRWatcher launches the background poller.
 func (s *Server) startPRWatcher() {
 	go func() {
-		ticker := time.NewTicker(10 * time.Second)
-		defer ticker.Stop()
+		timer := time.NewTimer(prWatcherBaseInterval)
+		defer timer.Stop()
 		reconcileTicker := time.NewTicker(5 * time.Minute)
 		defer reconcileTicker.Stop()
 		for {
 			select {
-			case <-ticker.C:
+			case <-timer.C:
 				s.pollAllPRs()
+				timer.Reset(s.nextPollDelay())
 			case <-reconcileTicker.C:
 				s.reconcileDeadClawPRs()
 			}
@@ -331,6 +385,31 @@ func (s *Server) pollAllPRs() {
 	}
 	rows.Close()
 
+	s.mu.Lock()
+	s.trackedPRCount = len(prs)
+	s.mu.Unlock()
+
+	// GitHub already told us the quota is gone: retrying now only adds error
+	// lines to the log and delays the recovery for everyone else.
+	if until, blocked := defaultGitHubClient.blockedUntilTime(); blocked {
+		s.mu.Lock()
+		shouldLog := time.Since(s.lastRateLimitSkipLog) >= time.Minute
+		if shouldLog {
+			s.lastRateLimitSkipLog = time.Now()
+		}
+		s.mu.Unlock()
+		if shouldLog && len(prs) > 0 {
+			log.Printf("[pr-watcher] GitHub rate limit exhausted; skipping poll of %d PR(s) until %s",
+				len(prs), until.UTC().Format(time.RFC3339))
+		}
+		return
+	}
+
+	// Below the reserve the watcher drops everything except merge detection, so
+	// interactive and agent-initiated calls keep their headroom.
+	lowPriorityOK := defaultGitHubClient.allowLowPriority()
+	s.logGitHubBudget(lowPriorityOK)
+
 	token := s.resolveGitHubToken()
 	if token == "" {
 		if len(prs) > 0 {
@@ -366,6 +445,10 @@ func (s *Server) pollAllPRs() {
 		if s.checkPRMerged(r.pr, token) {
 			terminatedClaws[r.pr.clawID] = true
 			continue // claw is being terminated, skip other checks
+		}
+		if !lowPriorityOK {
+			// Merge detection above is the only call worth the remaining budget.
+			continue
 		}
 		// Always check CI failures
 		s.checkCIFailures(r.pr, token)
@@ -428,6 +511,28 @@ func (s *Server) pollAllPRs() {
 	}
 }
 
+// logGitHubBudget periodically records the remaining installation quota so a
+// depletion is visible before it turns into a wall of 403s.
+func (s *Server) logGitHubBudget(lowPriorityOK bool) {
+	limit, remaining, reset, ok := defaultGitHubClient.budget()
+	if !ok {
+		return
+	}
+	interval := 5 * time.Minute
+	if !lowPriorityOK {
+		interval = time.Minute
+	}
+	s.mu.Lock()
+	if time.Since(s.lastQuotaLog) < interval {
+		s.mu.Unlock()
+		return
+	}
+	s.lastQuotaLog = time.Now()
+	s.mu.Unlock()
+	log.Printf("[pr-watcher] github quota: remaining=%d/%d reset=%s reserve=%d lowPriority=%v",
+		remaining, limit, reset.UTC().Format(time.RFC3339), githubRateLimitReserve, lowPriorityOK)
+}
+
 // firePRConditions consumes the one-shot trigger only after its transition
 // claims the stage. A failed claim remains eligible for the next poll.
 func (s *Server) firePRConditions(pr clawPR, stage pipeline.Stage, ctx pipelineContext) {
@@ -448,20 +553,54 @@ func (s *Server) resolveGitHubTokenWithRepos(repoAccess []RepoAccess) string {
 	if len(cfg.GitHubApps) == 0 {
 		return ""
 	}
+	// Installation tokens live an hour. Minting one per call cost two extra
+	// GitHub App requests on every poll of every PR, which was its own
+	// rate-limit exhaustion path.
+	cacheKey := githubTokenCacheKey(repoAccess)
+	s.ghTokenMu.Lock()
+	defer s.ghTokenMu.Unlock()
+	if cached, ok := s.ghTokenCache[cacheKey]; ok && time.Now().Before(cached.expiresAt) {
+		return cached.token
+	}
 	for _, appCfg := range cfg.GitHubApps {
 		provider, err := NewGitHubTokenProvider(appCfg)
 		if err != nil {
 			log.Printf("[pr-watcher] CRITICAL: GitHub token provider setup failed: %v", err)
 			continue
 		}
-		token, _, err := provider.InstallationToken(context.Background(), 0, repoAccess)
+		token, expiresAt, err := provider.InstallationToken(context.Background(), 0, repoAccess)
 		if err != nil {
 			log.Printf("[pr-watcher] CRITICAL: GitHub token provider failed: %v", err)
 			continue
 		}
+		if s.ghTokenCache == nil {
+			s.ghTokenCache = map[string]cachedGitHubToken{}
+		}
+		// Renew a few minutes early so no in-flight call uses an expiring token.
+		if expiry := expiresAt.Add(-5 * time.Minute); expiry.After(time.Now()) {
+			s.ghTokenCache[cacheKey] = cachedGitHubToken{token: token, expiresAt: expiry}
+		}
 		return token
 	}
 	return ""
+}
+
+// cachedGitHubToken is an installation token held until shortly before expiry.
+type cachedGitHubToken struct {
+	token     string
+	expiresAt time.Time
+}
+
+func githubTokenCacheKey(repoAccess []RepoAccess) string {
+	if len(repoAccess) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(repoAccess))
+	for _, r := range repoAccess {
+		parts = append(parts, r.Repo+":"+r.Permissions)
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, ",")
 }
 
 // resolveGitHubTokenForRepo returns a GitHub App installation token scoped to the given repo.
@@ -1174,21 +1313,15 @@ func githubAPI(path, token string) (map[string]interface{}, error) {
 
 // githubAPIWithBase is like githubAPI but against a custom base URL (for testing).
 func githubAPIWithBase(baseURL, path, token string) (map[string]interface{}, error) {
-	req, _ := http.NewRequest("GET", baseURL+"/"+path, nil)
-	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("Accept", "application/vnd.github+json")
-	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := defaultGitHubClient.get(baseURL+"/"+path, token)
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
-	body, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode >= 400 {
-		return nil, &githubAPIError{StatusCode: resp.StatusCode, Body: string(body), RateLimited: resp.Header.Get("X-RateLimit-Remaining") == "0"}
+		return nil, &githubAPIError{StatusCode: resp.StatusCode, Body: string(resp.Body), RateLimited: resp.rateLimited()}
 	}
 	var result map[string]interface{}
-	if err := json.Unmarshal(body, &result); err != nil {
+	if err := json.Unmarshal(resp.Body, &result); err != nil {
 		return nil, fmt.Errorf("github API parse error: %w", err)
 	}
 	return result, nil
@@ -1681,33 +1814,21 @@ func githubAPIListWithBase(baseURL, path, token string) ([]interface{}, error) {
 	if strings.Contains(path, "?") {
 		separator = "&"
 	}
-	req, err := http.NewRequest("GET", baseURL+"/"+path+separator+"per_page=100", nil)
+	resp, err := defaultGitHubClient.get(baseURL+"/"+path+separator+"per_page=100", token)
 	if err != nil {
 		return nil, err
-	}
-	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("Accept", "application/vnd.github+json")
-	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("github API response read error: %w", err)
 	}
 	if resp.StatusCode >= 400 {
 		// GitHub returns 404 for auth failures to avoid leaking repo existence.
 		// Surface a clearer error when the token is likely the problem.
-		msg := string(body)
+		msg := string(resp.Body)
 		if resp.StatusCode == http.StatusNotFound && strings.Contains(msg, "Not Found") {
-			return nil, &githubAPIError{StatusCode: resp.StatusCode, Body: fmt.Sprintf("404 for %s/%s (token may be invalid or repo may not exist): %s", baseURL, path, msg), RateLimited: resp.Header.Get("X-RateLimit-Remaining") == "0"}
+			return nil, &githubAPIError{StatusCode: resp.StatusCode, Body: fmt.Sprintf("404 for %s/%s (token may be invalid or repo may not exist): %s", baseURL, path, msg), RateLimited: resp.rateLimited()}
 		}
-		return nil, &githubAPIError{StatusCode: resp.StatusCode, Body: msg, RateLimited: resp.Header.Get("X-RateLimit-Remaining") == "0"}
+		return nil, &githubAPIError{StatusCode: resp.StatusCode, Body: msg, RateLimited: resp.rateLimited()}
 	}
 	var result []interface{}
-	if err := json.Unmarshal(body, &result); err != nil {
+	if err := json.Unmarshal(resp.Body, &result); err != nil {
 		return nil, fmt.Errorf("github API list parse error: %w", err)
 	}
 	return result, nil

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -63,6 +63,18 @@ type Server struct {
 	// autoResumeRestartCounts records restart counts already handled per claw. Guarded by s.mu.
 	autoResumeRestartCounts map[string]int
 	lastTokenFailureLog     time.Time
+	// trackedPRCount is the PR count observed by the last poll; it drives the
+	// PR watcher's adaptive interval. Guarded by s.mu.
+	trackedPRCount int
+	// lastQuotaLog throttles the GitHub rate-limit budget log line. Guarded by s.mu.
+	lastQuotaLog time.Time
+	// lastRateLimitSkipLog throttles the "poll skipped, quota exhausted" log. Guarded by s.mu.
+	lastRateLimitSkipLog time.Time
+
+	// ghTokenCache holds GitHub App installation tokens until shortly before
+	// they expire, keyed by requested repo access.
+	ghTokenMu    sync.Mutex
+	ghTokenCache map[string]cachedGitHubToken
 	// one-time oauth_code -> signed GitHub session token
 
 	dependencyStatus *dependencyStatusService


### PR DESCRIPTION
## Incident

On 2026-07-27 the hub's GitHub App installation quota was exhausted for roughly four hours. The logs carry **628 `403 rate limit exceeded` lines** from `pr-watcher`. While the quota was gone the hub could not read PR state at all: merges, CI results, review comments and `pr_conditions` all went dark, so live agents sat waiting on pipeline transitions that could never fire. The watcher had starved every other GitHub consumer in the process — webhook backfills, pipelines and agent-initiated calls — and then hot-retried the exhausted quota every 10 seconds, which is where the 628 lines came from.

## The arithmetic

The watcher polled on a fixed 10s ticker, and each tracked PR cost up to 9 REST calls per poll (merge check 1, CI failures 2, issue comments 1, review comments 1, reviews 1, `pr_conditions` 3):

```
360 polls/hour x 4 PRs x 9 calls = 12,960 calls/hour
```

against a **5,000/hour** installation limit. Four PRs — a small factory — already overran the limit by 2.6x. Cost grew linearly with live claws, so the failure was structural, not a spike.

A second, larger consumer sat behind it: `resolveGitHubTokenWithRepos` minted a fresh installation token on every resolution (`GET /app/installations` + `POST access_tokens`), and ran ~4x per PR per tick — roughly **24,000 App-JWT calls/hour** against a 15,000/hour limit.

Once the quota was gone, nothing backed off: a 403 produced a transient error, the tick fired again 10s later, and the loop reissued every call.

## The fix

1. **Rate-limit headers are read on every response.** A shared `githubClient` parses `X-RateLimit-Limit/Remaining/Reset` and `Retry-After` on all responses, not just errors, and logs the budget periodically (every 5m normally, every 1m while degraded).
2. **403/429 stops the retry loop.** The client arms a block from `Retry-After`, else the reset, else +1m, and short-circuits every subsequent call without issuing a request. `nextPollDelay` defers the next poll to the reset instead of 10s. The incident's 628 error lines become ~4.
3. **The poll interval scales with load.** The 10s ticker became a timer driven by `prWatcherInterval(trackedPRs)`: floor 30s, cap 5m, sized so `trackedPRs x 9` calls/poll stays inside the watcher's 2,000/hour share of the installation limit.
4. **Conditional requests.** ETag + body are cached per URL (bounded at 2048 entries, LRU); `If-None-Match` is sent and a 304 replays the cached body. GitHub does not bill 304s, so unchanged polls are free — which is most polls, since comments and reviews rarely change between ticks.
5. **Installation tokens are cached** per scope until 5 minutes before expiry, removing the ~24k/hour App-JWT path entirely.

All four `githubAPI*` helpers route through the one client, so `integration_poller`, `github_webhook`, `linear`, `workspace_api` and `github_issues` inherit the ETag cache and the backoff without signature changes.

## New bound under load

| tracked PRs | interval | worst-case calls/hour | notes |
| --- | --- | --- | --- |
| 4 | 50s | ~2,590 | was 12,960; 304s cut the billed figure well below this |
| 8 | 130s | ~2,000 | at budget |
| 18 | 292s | ~2,000 | last point where the interval guarantee holds |
| 50 | 300s (cap) | ~5,400 | past the cap; reserve gating degrades polling instead |

Beyond ~18 tracked PRs the interval pins at its 5-minute cap and cost grows linearly again. That case **fails soft**: once remaining budget drops into the reserve (500 by default, `ELASTICCLAW_GITHUB_RATE_RESERVE`), background polling degrades to merge-detection only — check-runs, comments, reviews and `pr_conditions` pause until the window resets — so the watcher starves before the rest of the hub does, and no hot-retry loop is possible.

Latency cost: merge/comment/review reconciliation now takes up to ~50s for a 4-PR factory instead of 10s.

## Review findings applied

- **Clamped the block window to 1 hour.** `blockedUntil` took `Retry-After`/`X-RateLimit-Reset` verbatim; a malformed or hostile value (`Retry-After: 99999999`, or a garbage reset epoch) would have paused every GitHub call hub-wide until process restart. Legitimate values never exceed the hourly window. Test: `TestGitHubRateLimitBlockIsClamped`.
- **Corrected `prWatcherCallsPerPR` from 7 to 9** and rewrote the comment that claimed the budget holds "no matter how many claws are live" — it holds up to ~18 tracked PRs; past that the reserve is the backstop, as the table above states.
- **Scaled the reserve to the observed limit** (capped at `limit/2`), so a token whose hourly limit is at or below the 500 reserve is not degraded to merge-only polling permanently. Test: `TestGitHubReserveScalesWithSmallLimits`.
- **Made a 304 answered to a non-conditional request an error** rather than retrying, removing the theoretical unbounded recursion in `doGet`.

Not changed, and why:

- *Multiple installations share one client's quota state.* Correct observation, but out of scope for this incident (single-installation deployment) and a partition would need a per-installation client registry. Worth a follow-up if the hub ever serves several apps.
- *`ghTokenMu` held across the network mint serializes token resolution.* Intentional — it is also what prevents a thundering herd of mints on cold start.
- *Tests mutate the package-global `defaultGitHubClient`.* Correct for Go's sequential per-package execution; no `pkg/hub` test uses `t.Parallel`, and injecting the client everywhere would balloon the diff.

## Follow-up with the most leverage

`check_run`/`check_suite` are still not handled in `github_webhook.go`, so CI results remain poller-only. With the base interval at 30s that matters more than it did at 10s.

## Tests

New in `pkg/hub/github_client_test.go`: budget depletion gating, 403 no-immediate-retry, `Retry-After` honoured, block clamped to 1h, reserve scaled to small limits, ETag/304 replay, end-to-end "no calls while rate limited", token caching, and interval scaling with the hourly-cost assertion.

```
$ go build ./... && go vet ./pkg/hub/   # clean
$ go test ./... -count=1                # all packages ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
