### PR TITLE
fix(hub): wake idle claws when CI turns green

### DIFF
--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -21,9 +21,55 @@ func openDB(path string) (*sql.DB, error) {
 	return db, nil
 }
 
+// addColumn applies an additive `ALTER TABLE ... ADD COLUMN` migration.
+//
+// SQLite has no `IF NOT EXISTS` for ADD COLUMN, so the two benign outcomes are
+// absorbed here: the column already exists (the common case on every restart
+// after the first), and the table does not exist yet (fresh databases create it
+// with the column already in the CREATE TABLE below). Everything else is
+// wrapped and returned, so a migration that genuinely failed aborts startup
+// instead of leaving a missing column to break queries at runtime.
+//
+// The existence check is done up front against pragma_table_info rather than by
+// parsing the driver error: modernc.org/sqlite reports both "duplicate column
+// name" and "no such table" as the same generic SQLITE_ERROR code (1), so the
+// message text is the only discriminator and must not be the sole line of
+// defense. The message match remains as a fallback for the racy case where the
+// column appears between the check and the ALTER.
+func addColumn(db *sql.DB, table, column, columnDef string) error {
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info(?) WHERE name = ?`, table, column).Scan(&count); err != nil {
+		return fmt.Errorf("inspect column %s.%s: %w", table, column, err)
+	}
+	if count > 0 {
+		return nil
+	}
+	if _, err := db.Exec(fmt.Sprintf(`ALTER TABLE %q ADD COLUMN %q %s`, table, column, columnDef)); err != nil {
+		if isBenignAddColumnErr(err) {
+			return nil
+		}
+		return fmt.Errorf("add column %s.%s: %w", table, column, err)
+	}
+	return nil
+}
+
+// isBenignAddColumnErr reports whether an ADD COLUMN failure means the column
+// is already present or the table does not exist yet.
+func isBenignAddColumnErr(err error) bool {
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "duplicate column name") || strings.Contains(msg, "no such table")
+}
+
 func migrate(db *sql.DB) error {
 	// Add columns that may be missing from older databases.
 	// SQLite doesn't support IF NOT EXISTS on ALTER TABLE, so ignore errors.
+	//
+	// addColumn above is the intended idiom for new columns. The 61 legacy
+	// `_, _ = db.Exec(...)` lines below are deliberately left as-is: migrate()
+	// runs on the hub startup path against a live production database, and
+	// flipping all of them to a fatal-on-unexpected-error helper in one go risks
+	// the hub refusing to start over a legacy column. Converting them is a
+	// separate, dedicated follow-up.
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN provider TEXT NOT NULL DEFAULT ''`)
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN provider_id TEXT NOT NULL DEFAULT ''`)
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN default_model TEXT NOT NULL DEFAULT ''`)
@@ -65,7 +111,9 @@ func migrate(db *sql.DB) error {
 	_, _ = db.Exec(`ALTER TABLE claw_prs ADD COLUMN permanent_failure_count INTEGER NOT NULL DEFAULT 0`)
 	_, _ = db.Exec(`ALTER TABLE claw_prs ADD COLUMN last_review_comment_id INTEGER NOT NULL DEFAULT 0`)
 	_, _ = db.Exec(`ALTER TABLE claw_prs ADD COLUMN last_review_id INTEGER NOT NULL DEFAULT 0`)
-	_, _ = db.Exec(`ALTER TABLE claw_prs ADD COLUMN last_ci_conclusion TEXT NOT NULL DEFAULT ''`)
+	if err := addColumn(db, "claw_prs", "last_ci_conclusion", `TEXT NOT NULL DEFAULT ''`); err != nil {
+		return err
+	}
 	_, _ = db.Exec(`ALTER TABLE messages ADD COLUMN format TEXT NOT NULL DEFAULT ''`)
 	if _, err := db.Exec(`ALTER TABLE messages ADD COLUMN delivered_at DATETIME`); err == nil {
 		// A failed backfill must abort startup: the column now exists, so a

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -65,6 +65,7 @@ func migrate(db *sql.DB) error {
 	_, _ = db.Exec(`ALTER TABLE claw_prs ADD COLUMN permanent_failure_count INTEGER NOT NULL DEFAULT 0`)
 	_, _ = db.Exec(`ALTER TABLE claw_prs ADD COLUMN last_review_comment_id INTEGER NOT NULL DEFAULT 0`)
 	_, _ = db.Exec(`ALTER TABLE claw_prs ADD COLUMN last_review_id INTEGER NOT NULL DEFAULT 0`)
+	_, _ = db.Exec(`ALTER TABLE claw_prs ADD COLUMN last_ci_conclusion TEXT NOT NULL DEFAULT ''`)
 	_, _ = db.Exec(`ALTER TABLE messages ADD COLUMN format TEXT NOT NULL DEFAULT ''`)
 	if _, err := db.Exec(`ALTER TABLE messages ADD COLUMN delivered_at DATETIME`); err == nil {
 		// A failed backfill must abort startup: the column now exists, so a
@@ -539,6 +540,7 @@ func migrate(db *sql.DB) error {
 		pr_number   INTEGER NOT NULL,
 		pr_url      TEXT NOT NULL,
 		last_ci_sha TEXT NOT NULL DEFAULT '',   -- last SHA we checked CI on
+		last_ci_conclusion TEXT NOT NULL DEFAULT '', -- terminal CI verdict already delivered for last_ci_sha: '' | 'success' | 'failure'
 		last_comment_id INTEGER NOT NULL DEFAULT 0, -- last bugbot/pipeline comment ID seen
 		last_comment_at TEXT NOT NULL DEFAULT '', -- timestamp of last seen comment
 		last_review_comment_id INTEGER NOT NULL DEFAULT 0, -- last PR review comment ID seen

--- a/pkg/hub/db_claw_prs_ci_conclusion_migration_test.go
+++ b/pkg/hub/db_claw_prs_ci_conclusion_migration_test.go
@@ -2,6 +2,7 @@ package hub
 
 import (
 	"database/sql"
+	"strings"
 	"testing"
 
 	_ "modernc.org/sqlite"
@@ -44,5 +45,139 @@ func TestMigrateAddsLastCIConclusionToExistingClawPRs(t *testing.T) {
 	}
 	if sha != "04cc3f49" || conclusion != "" {
 		t.Fatalf("row = (%q,%q), want (04cc3f49, \"\")", sha, conclusion)
+	}
+
+	// Every hub restart re-runs migrate() against a database that already has the
+	// column. addColumn must absorb that, not abort startup.
+	if err := migrate(db); err != nil {
+		t.Fatalf("second migrate: %v", err)
+	}
+	if err := db.QueryRow(`SELECT last_ci_conclusion FROM claw_prs WHERE id='p'`).Scan(&conclusion); err != nil {
+		t.Fatalf("select after second migration: %v", err)
+	}
+	if conclusion != "" {
+		t.Fatalf("conclusion = %q after re-migrate, want \"\"", conclusion)
+	}
+}
+
+// A fresh database gets claw_prs from CREATE TABLE, already carrying the
+// column; the default must still be '' so a newly tracked PR is unevaluated.
+func TestMigrateFreshDBHasLastCIConclusionDefault(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	if err := migrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	// foreign_keys is off on this bare connection, so claw_prs can be inserted
+	// without a parent claws row.
+	if _, err := db.Exec(`INSERT INTO claw_prs(id,claw_id,repo,pr_number,pr_url,created_at) VALUES('p','c','o/r',1,'u',datetime('now'))`); err != nil {
+		t.Fatal(err)
+	}
+
+	var conclusion string
+	if err := db.QueryRow(`SELECT last_ci_conclusion FROM claw_prs WHERE id='p'`).Scan(&conclusion); err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if conclusion != "" {
+		t.Fatalf("conclusion = %q, want \"\"", conclusion)
+	}
+}
+
+func TestAddColumn(t *testing.T) {
+	newDB := func(t *testing.T) *sql.DB {
+		t.Helper()
+		db, err := sql.Open("sqlite", ":memory:")
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { db.Close() })
+		if _, err := db.Exec(`CREATE TABLE t (a TEXT NOT NULL DEFAULT '')`); err != nil {
+			t.Fatal(err)
+		}
+		return db
+	}
+
+	t.Run("adds missing column", func(t *testing.T) {
+		db := newDB(t)
+		if err := addColumn(db, "t", "b", `TEXT NOT NULL DEFAULT 'x'`); err != nil {
+			t.Fatalf("addColumn: %v", err)
+		}
+		if _, err := db.Exec(`INSERT INTO t(a) VALUES('1')`); err != nil {
+			t.Fatal(err)
+		}
+		var b string
+		if err := db.QueryRow(`SELECT b FROM t`).Scan(&b); err != nil {
+			t.Fatalf("select: %v", err)
+		}
+		if b != "x" {
+			t.Fatalf("b = %q, want x", b)
+		}
+	})
+
+	t.Run("existing column is a no-op", func(t *testing.T) {
+		db := newDB(t)
+		if err := addColumn(db, "t", "a", `TEXT NOT NULL DEFAULT ''`); err != nil {
+			t.Fatalf("addColumn on existing column: %v", err)
+		}
+	})
+
+	t.Run("missing table is a no-op", func(t *testing.T) {
+		db := newDB(t)
+		if err := addColumn(db, "not_a_table", "b", `TEXT NOT NULL DEFAULT ''`); err != nil {
+			t.Fatalf("addColumn on missing table: %v", err)
+		}
+	})
+
+	// The whole point of the helper: anything other than the two benign cases
+	// must surface instead of leaving migrate() to report success on a database
+	// that is missing the column.
+	t.Run("unexpected error propagates", func(t *testing.T) {
+		db := newDB(t)
+		err := addColumn(db, "t", "b", `TEXT NOT NULL DEFAULT`)
+		if err == nil {
+			t.Fatal("addColumn with a malformed column def returned nil")
+		}
+		if !strings.Contains(err.Error(), "t.b") {
+			t.Fatalf("error %q does not name the table and column", err)
+		}
+	})
+
+	t.Run("closed db propagates", func(t *testing.T) {
+		db := newDB(t)
+		db.Close()
+		if err := addColumn(db, "t", "b", `TEXT NOT NULL DEFAULT ''`); err == nil {
+			t.Fatal("addColumn on a closed db returned nil")
+		}
+	})
+}
+
+func TestIsBenignAddColumnErr(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if _, err := db.Exec(`CREATE TABLE t (a TEXT)`); err != nil {
+		t.Fatal(err)
+	}
+
+	// Guard the fallback string match against the real driver messages: if
+	// modernc.org/sqlite ever reworded these, the hub would start failing on
+	// every restart after the first.
+	_, dup := db.Exec(`ALTER TABLE t ADD COLUMN a TEXT NOT NULL DEFAULT ''`)
+	if dup == nil || !isBenignAddColumnErr(dup) {
+		t.Fatalf("duplicate column error not recognised: %v", dup)
+	}
+	_, missing := db.Exec(`ALTER TABLE nope ADD COLUMN a TEXT NOT NULL DEFAULT ''`)
+	if missing == nil || !isBenignAddColumnErr(missing) {
+		t.Fatalf("missing table error not recognised: %v", missing)
+	}
+	_, syntax := db.Exec(`ALTER TABLE t ADD COLUMN b TEXT NOT NULL DEFAULT`)
+	if syntax == nil || isBenignAddColumnErr(syntax) {
+		t.Fatalf("syntax error wrongly treated as benign: %v", syntax)
 	}
 }

--- a/pkg/hub/db_claw_prs_ci_conclusion_migration_test.go
+++ b/pkg/hub/db_claw_prs_ci_conclusion_migration_test.go
@@ -1,0 +1,48 @@
+package hub
+
+import (
+	"database/sql"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+// An existing hub database predates last_ci_conclusion. The additive migration
+// must backfill it as '' so previously observed SHAs are re-evaluated once and
+// the poller's SELECT keeps working.
+func TestMigrateAddsLastCIConclusionToExistingClawPRs(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	// Pre-migration shape of claw_prs.
+	if _, err := db.Exec(`CREATE TABLE claw_prs (
+		id TEXT PRIMARY KEY,
+		claw_id TEXT NOT NULL,
+		repo TEXT NOT NULL,
+		pr_number INTEGER NOT NULL,
+		pr_url TEXT NOT NULL,
+		last_ci_sha TEXT NOT NULL DEFAULT '',
+		last_comment_id INTEGER NOT NULL DEFAULT 0,
+		created_at DATETIME NOT NULL
+	)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO claw_prs(id,claw_id,repo,pr_number,pr_url,last_ci_sha,created_at) VALUES('p','c','o/r',1,'u','04cc3f49',datetime('now'))`); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := migrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	var sha, conclusion string
+	if err := db.QueryRow(`SELECT last_ci_sha, last_ci_conclusion FROM claw_prs WHERE id='p'`).Scan(&sha, &conclusion); err != nil {
+		t.Fatalf("select after migration: %v", err)
+	}
+	if sha != "04cc3f49" || conclusion != "" {
+		t.Fatalf("row = (%q,%q), want (04cc3f49, \"\")", sha, conclusion)
+	}
+}

--- a/pkg/hub/no_progress.go
+++ b/pkg/hub/no_progress.go
@@ -202,18 +202,18 @@ func (s *Server) turnProgressFingerprint(clawID, response string) (string, error
 	}
 	parts = append(parts, "stage="+stage)
 
-	rows, err := s.db.Query(`SELECT repo, pr_number, last_ci_sha, last_comment_id, last_comment_at, last_review_comment_id, last_review_id, pr_conditions_fired FROM claw_prs WHERE claw_id=? ORDER BY repo, pr_number`, clawID)
+	rows, err := s.db.Query(`SELECT repo, pr_number, last_ci_sha, last_ci_conclusion, last_comment_id, last_comment_at, last_review_comment_id, last_review_id, pr_conditions_fired FROM claw_prs WHERE claw_id=? ORDER BY repo, pr_number`, clawID)
 	if err != nil {
 		return "", fmt.Errorf("query tracked pull requests: %w", err)
 	}
 	for rows.Next() {
-		var repo, ciSHA, commentAt string
+		var repo, ciSHA, ciConclusion, commentAt string
 		var number, commentID, reviewCommentID, reviewID, conditions int
-		if err := rows.Scan(&repo, &number, &ciSHA, &commentID, &commentAt, &reviewCommentID, &reviewID, &conditions); err != nil {
+		if err := rows.Scan(&repo, &number, &ciSHA, &ciConclusion, &commentID, &commentAt, &reviewCommentID, &reviewID, &conditions); err != nil {
 			rows.Close()
 			return "", fmt.Errorf("scan tracked pull request: %w", err)
 		}
-		parts = append(parts, fmt.Sprintf("pr=%s#%d:%s:%d:%s:%d:%d:%d", repo, number, ciSHA, commentID, commentAt, reviewCommentID, reviewID, conditions))
+		parts = append(parts, fmt.Sprintf("pr=%s#%d:%s:%s:%d:%s:%d:%d:%d", repo, number, ciSHA, ciConclusion, commentID, commentAt, reviewCommentID, reviewID, conditions))
 	}
 	if err := rows.Err(); err != nil {
 		rows.Close()

--- a/pkg/hub/no_progress_test.go
+++ b/pkg/hub/no_progress_test.go
@@ -158,6 +158,35 @@ func TestTurnProgressFingerprintRejectsPartialState(t *testing.T) {
 	}
 }
 
+// A CI verdict flipping on an unchanged head SHA is real external progress and
+// must not be mistaken for a repeated turn by the no-progress detector.
+func TestTurnProgressFingerprintTracksCIConclusion(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+	const clawID = "claw-ci-fingerprint"
+	if _, err := db.Exec(`INSERT INTO claws(id, tenant_id, name, status, pipeline_stage, created_at) VALUES(?,?,?,?,?,datetime('now'))`, clawID, "test-tenant-id", "AMB-13", "connected", "review_loop"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO claw_prs(id, claw_id, repo, pr_number, pr_url, last_ci_sha, last_ci_conclusion, created_at) VALUES(?,?,?,?,?,?,?,datetime('now'))`,
+		"pr-fp", clawID, "o/r", 1, "https://github.com/o/r/pull/1", "abc1234", "failure"); err != nil {
+		t.Fatal(err)
+	}
+
+	before, err := s.turnProgressFingerprint(clawID, "waiting on CI")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`UPDATE claw_prs SET last_ci_conclusion='success' WHERE id='pr-fp'`); err != nil {
+		t.Fatal(err)
+	}
+	after, err := s.turnProgressFingerprint(clawID, "waiting on CI")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before == after {
+		t.Fatal("CI conclusion flip did not change the progress fingerprint")
+	}
+}
+
 func TestResponseProgressMarkersTrackNewCommitsAndPRs(t *testing.T) {
 	first := responseProgressMarkers("Pushed 1a2b3c4 to https://github.com/elasticclaw/elasticclaw/pull/100")
 	second := responseProgressMarkers("Pushed 9d8e7f6 to https://github.com/elasticclaw/elasticclaw/pull/100")

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -287,6 +287,7 @@ type clawPR struct {
 	prNumber            int
 	prURL               string
 	lastCISHA           string
+	lastCIConclusion    string
 	lastCommentID       int64
 	lastCommentAt       string
 	lastReviewCommentID int64
@@ -297,7 +298,7 @@ type clawPR struct {
 
 func (s *Server) pollAllPRs() {
 	rows, err := s.db.Query(`
-		SELECT cp.id, cp.claw_id, cp.repo, cp.pr_number, cp.pr_url, cp.last_ci_sha, cp.last_comment_id,
+		SELECT cp.id, cp.claw_id, cp.repo, cp.pr_number, cp.pr_url, cp.last_ci_sha, cp.last_ci_conclusion, cp.last_comment_id,
 		       cp.last_comment_at, cp.last_review_comment_id, cp.last_review_id, cp.pr_conditions_fired, cp.created_at,
 		       cl.status
 		FROM claw_prs cp
@@ -322,7 +323,7 @@ func (s *Server) pollAllPRs() {
 		var r row
 		var prConditionsFiredInt int
 		if err := rows.Scan(&r.pr.id, &r.pr.clawID, &r.pr.repo, &r.pr.prNumber, &r.pr.prURL,
-			&r.pr.lastCISHA, &r.pr.lastCommentID, &r.pr.lastCommentAt, &r.pr.lastReviewCommentID, &r.pr.lastReviewID, &prConditionsFiredInt, &r.pr.createdAt,
+			&r.pr.lastCISHA, &r.pr.lastCIConclusion, &r.pr.lastCommentID, &r.pr.lastCommentAt, &r.pr.lastReviewCommentID, &r.pr.lastReviewID, &prConditionsFiredInt, &r.pr.createdAt,
 			&r.clawStatus); err != nil {
 			continue
 		}
@@ -367,8 +368,8 @@ func (s *Server) pollAllPRs() {
 			terminatedClaws[r.pr.clawID] = true
 			continue // claw is being terminated, skip other checks
 		}
-		// Always check CI failures
-		s.checkCIFailures(r.pr, token)
+		// Always check CI status (failures and, just as importantly, green)
+		s.checkCIStatus(r.pr, token)
 
 		repoToken := s.resolveGitHubTokenForRepo(r.pr.repo)
 		if repoToken == "" {
@@ -475,10 +476,20 @@ func (s *Server) resolveGitHubToken() string {
 	return s.resolveGitHubTokenWithRepos(nil)
 }
 
-// checkCIFailures polls PR check runs and injects a message on new failures.
-func (s *Server) checkCIFailures(pr clawPR, token string) {
+// checkCIStatus polls PR check runs and injects a message when CI reaches a
+// terminal verdict for the head SHA — failure *or* success.
+//
+// The success branch exists because a green CI run is otherwise not an event:
+// an agent that pushed a fix and ended its turn waiting on CI would never be
+// woken, and the run deadlocks with both sides waiting on each other.
+func (s *Server) checkCIStatus(pr clawPR, token string) {
+	ghBase := s.githubBaseURL
+	if ghBase == "" {
+		ghBase = "https://api.github.com"
+	}
+
 	// Get PR head SHA
-	prData, err := githubAPI(fmt.Sprintf("repos/%s/pulls/%d", pr.repo, pr.prNumber), token)
+	prData, err := githubAPIWithBase(ghBase, fmt.Sprintf("repos/%s/pulls/%d", pr.repo, pr.prNumber), token)
 	if err != nil {
 		return
 	}
@@ -487,12 +498,17 @@ func (s *Server) checkCIFailures(pr clawPR, token string) {
 		return
 	}
 	headSHA, ok := headObj["sha"].(string)
-	if !ok || headSHA == "" || headSHA == pr.lastCISHA {
-		return // no new commits
+	if !ok || headSHA == "" {
+		return
+	}
+	// Already delivered a terminal verdict for this SHA. A failure verdict stays
+	// re-checkable so a re-run of the same commit can still report green.
+	if headSHA == pr.lastCISHA && pr.lastCIConclusion == ciConclusionSuccess {
+		return
 	}
 
 	// Get check runs for head SHA
-	checksData, err := githubAPI(fmt.Sprintf("repos/%s/commits/%s/check-runs", pr.repo, headSHA), token)
+	checksData, err := githubAPIWithBase(ghBase, fmt.Sprintf("repos/%s/commits/%s/check-runs", pr.repo, headSHA), token)
 	if err != nil {
 		return
 	}
@@ -516,19 +532,62 @@ func (s *Server) checkCIFailures(pr clawPR, token string) {
 		}
 	}
 
-	// Only update SHA if all checks have completed or if we found failures
-	if len(failures) > 0 || allCompleted {
-		_, _ = s.db.Exec(`UPDATE claw_prs SET last_ci_sha=? WHERE id=?`, headSHA, pr.id)
+	// No check runs at all: CI has not reported yet. Reporting "0 checks passed"
+	// would be a spurious wake-up, and advancing the watermark would hide the
+	// real verdict when it lands.
+	if len(checkRuns) == 0 {
+		return
 	}
-
-	if len(failures) == 0 {
+	// CI still running: nothing terminal to report, and the watermark must not
+	// advance or the eventual verdict becomes unobservable.
+	if len(failures) == 0 && !allCompleted {
 		return
 	}
 
-	msg := fmt.Sprintf("CI failed on PR #%d ([%s](%s)):\n\n%s\n\nPlease fix these failures on the same branch.",
-		pr.prNumber, pr.repo, pr.prURL, strings.Join(failures, "\n"))
+	conclusion := ciConclusionSuccess
+	if len(failures) > 0 {
+		conclusion = ciConclusionFailure
+	}
 
-	s.injectUserMessage(pr.clawID, msg)
+	// Conditional UPDATE = claim, same idiom as claimPipelineStageTransition.
+	// Exactly one poll (and exactly one hub process) observes a given
+	// (sha, conclusion) pair, so the injection below cannot double-fire.
+	res, err := s.db.Exec(
+		`UPDATE claw_prs SET last_ci_sha=?, last_ci_conclusion=? WHERE id=? AND NOT (last_ci_sha=? AND last_ci_conclusion=?)`,
+		headSHA, conclusion, pr.id, headSHA, conclusion)
+	if err != nil {
+		log.Printf("[pr-watcher] failed to claim CI status for %s: %v", pr.prURL, err)
+		return
+	}
+	if claimed, err := res.RowsAffected(); err != nil || claimed == 0 {
+		return
+	}
+
+	if conclusion == ciConclusionFailure {
+		msg := fmt.Sprintf("CI failed on PR #%d ([%s](%s)):\n\n%s\n\nPlease fix these failures on the same branch.",
+			pr.prNumber, pr.repo, pr.prURL, strings.Join(failures, "\n"))
+		s.injectUserMessage(pr.clawID, msg)
+		return
+	}
+
+	log.Printf("[pr-watcher] CI passed on %s@%s — notifying claw %s", pr.prURL, shortSHA(headSHA), shortID(pr.clawID))
+	s.injectExternalHubMessageByID(pr.clawID, fmt.Sprintf(
+		"[hub] All CI checks passed on PR #%d ([%s](%s)) at commit `%s` (%d check(s)).\n\n"+
+			"If your workflow is waiting on CI, this is the signal to proceed: emit the stage's signal token, or explain what is still blocking you.",
+		pr.prNumber, pr.repo, pr.prURL, shortSHA(headSHA), len(checkRuns)))
+}
+
+// Terminal CI verdicts recorded in claw_prs.last_ci_conclusion.
+const (
+	ciConclusionSuccess = "success"
+	ciConclusionFailure = "failure"
+)
+
+func shortSHA(sha string) string {
+	if len(sha) > 7 {
+		return sha[:7]
+	}
+	return sha
 }
 
 type prCommentOptions struct {

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -526,9 +526,16 @@ func (s *Server) checkCIStatus(pr clawPR, token string) {
 			allCompleted = false
 		}
 
-		if conclusion == "failure" || conclusion == "timed_out" {
+		// Anything terminal that is not green blocks: cancelled, action_required,
+		// stale and startup_failure are "completed" too, and announcing them as
+		// "all checks passed" would be an affirmative false claim.
+		if conclusion != "" && !isGreenCheckConclusion(conclusion) {
 			detailsURL, _ := run["details_url"].(string)
-			failures = append(failures, fmt.Sprintf("**%s** — [view logs](%s)", name, detailsURL))
+			label := name
+			if conclusion != "failure" && conclusion != "timed_out" {
+				label = fmt.Sprintf("%s (%s)", name, conclusion)
+			}
+			failures = append(failures, fmt.Sprintf("**%s** — [view logs](%s)", label, detailsURL))
 		}
 	}
 
@@ -582,6 +589,18 @@ const (
 	ciConclusionSuccess = "success"
 	ciConclusionFailure = "failure"
 )
+
+// isGreenCheckConclusion reports whether a completed check run counts as green.
+// GitHub's non-green terminal conclusions (failure, timed_out, cancelled,
+// action_required, stale, startup_failure) and any conclusion we do not know
+// are treated as blocking, so an unknown value can never be reported as green.
+func isGreenCheckConclusion(conclusion string) bool {
+	switch conclusion {
+	case "success", "neutral", "skipped":
+		return true
+	}
+	return false
+}
 
 func shortSHA(sha string) string {
 	if len(sha) > 7 {

--- a/pkg/hub/pr_watcher_test.go
+++ b/pkg/hub/pr_watcher_test.go
@@ -638,6 +638,57 @@ func TestCheckCIStatusFailureMessageUnchangedAndRerunCanTurnGreen(t *testing.T) 
 	}
 }
 
+// A completed-but-not-green conclusion (cancelled, action_required, stale,
+// startup_failure, or anything unknown) must never be announced as green: the
+// claw would emit its stage signal token on a PR that is not actually passing.
+func TestCheckCIStatusNonGreenTerminalConclusionsAreNotGreen(t *testing.T) {
+	for _, conclusion := range []string{"cancelled", "action_required", "stale", "startup_failure", "some_future_value"} {
+		t.Run(conclusion, func(t *testing.T) {
+			clawID := "claw-ci-" + conclusion
+			const headSHA = "abcdef1234567890"
+			s, db, pr := ciStatusFixture(t, clawID, headSHA,
+				`[{"name":"verify","status":"completed","conclusion":"success"},
+				  {"name":"deploy","status":"completed","conclusion":"`+conclusion+`","details_url":"https://ci/2"}]`)
+
+			s.checkCIStatus(pr, "token")
+
+			msgs := ciMessages(t, db, clawID)
+			if len(msgs) != 1 {
+				t.Fatalf("messages = %v, want exactly 1", msgs)
+			}
+			if strings.Contains(msgs[0], "All CI checks passed") {
+				t.Fatalf("%q reported as green: %q", conclusion, msgs[0])
+			}
+			if !strings.Contains(msgs[0], "**deploy ("+conclusion+")**") {
+				t.Fatalf("message does not name the non-green check: %q", msgs[0])
+			}
+			if _, got := ciWatermark(t, db, pr.id); got != ciConclusionFailure {
+				t.Fatalf("watermark conclusion = %q, want failure", got)
+			}
+		})
+	}
+}
+
+// neutral and skipped are green: a skipped optional job must not block the PR.
+func TestCheckCIStatusNeutralAndSkippedAreGreen(t *testing.T) {
+	const clawID = "claw-ci-neutral"
+	const headSHA = "fedcba0987654321"
+	s, db, pr := ciStatusFixture(t, clawID, headSHA,
+		`[{"name":"verify","status":"completed","conclusion":"success"},
+		  {"name":"optional","status":"completed","conclusion":"skipped"},
+		  {"name":"advisory","status":"completed","conclusion":"neutral"}]`)
+
+	s.checkCIStatus(pr, "token")
+
+	msgs := ciMessages(t, db, clawID)
+	if len(msgs) != 1 || !strings.Contains(msgs[0], "All CI checks passed") {
+		t.Fatalf("messages = %v, want one green notification", msgs)
+	}
+	if _, got := ciWatermark(t, db, pr.id); got != ciConclusionSuccess {
+		t.Fatalf("watermark conclusion = %q, want success", got)
+	}
+}
+
 func TestInjectMessageSkipsIdenticalPendingRow(t *testing.T) {
 	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
 	const clawID = "inject-message-dedupe"

--- a/pkg/hub/pr_watcher_test.go
+++ b/pkg/hub/pr_watcher_test.go
@@ -447,6 +447,197 @@ func TestStorePRMentionConcurrentDuplicate(t *testing.T) {
 	}
 }
 
+// ciStatusFixture wires a server against a stub GitHub that reports a fixed
+// head SHA and a fixed set of check runs for it.
+func ciStatusFixture(t *testing.T, clawID, headSHA, checkRunsJSON string) (*Server, *sql.DB, clawPR) {
+	t.Helper()
+	gh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/check-runs") {
+			_, _ = w.Write([]byte(`{"check_runs":` + checkRunsJSON + `}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"head":{"sha":"` + headSHA + `"},"state":"open"}`))
+	}))
+	t.Cleanup(gh.Close)
+
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, gh.URL, "", "")
+	if _, err := db.Exec(`INSERT INTO claws(id,tenant_id,name,template,status,created_at) VALUES(?,?,?,?,?,?)`,
+		clawID, "test-tenant-id", clawID, "elasticclaw", "connected", now()); err != nil {
+		t.Fatal(err)
+	}
+	pr := clawPR{id: "pr-" + clawID, clawID: clawID, repo: "owner/repo", prNumber: 42, prURL: "https://github.com/owner/repo/pull/42"}
+	if _, err := db.Exec(`INSERT INTO claw_prs(id,claw_id,repo,pr_number,pr_url,created_at) VALUES(?,?,?,?,?,?)`,
+		pr.id, pr.clawID, pr.repo, pr.prNumber, pr.prURL, now()); err != nil {
+		t.Fatal(err)
+	}
+	return s, db, pr
+}
+
+func ciMessages(t *testing.T, db *sql.DB, clawID string) []string {
+	t.Helper()
+	rows, err := db.Query(`SELECT content FROM messages WHERE claw_id=? ORDER BY created_at, rowid`, clawID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var c string
+		if err := rows.Scan(&c); err != nil {
+			t.Fatal(err)
+		}
+		out = append(out, c)
+	}
+	return out
+}
+
+func ciWatermark(t *testing.T, db *sql.DB, prID string) (string, string) {
+	t.Helper()
+	var sha, conclusion string
+	if err := db.QueryRow(`SELECT last_ci_sha, last_ci_conclusion FROM claw_prs WHERE id=?`, prID).Scan(&sha, &conclusion); err != nil {
+		t.Fatal(err)
+	}
+	return sha, conclusion
+}
+
+// TestCheckCIStatusGreenWakesIdleClawOnce is the regression test for the CI-green
+// deadlock: an agent that pushed a fix and ended its turn waiting on CI got no
+// event at all, because only failures were reported.
+func TestCheckCIStatusGreenWakesIdleClawOnce(t *testing.T) {
+	const clawID = "claw-ci-green"
+	const headSHA = "04cc3f49aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	allGreen := `[{"name":"verify","status":"completed","conclusion":"success"},
+	              {"name":"gitleaks","status":"completed","conclusion":"success"}]`
+	s, db, pr := ciStatusFixture(t, clawID, headSHA, allGreen)
+
+	s.checkCIStatus(pr, "token")
+
+	msgs := ciMessages(t, db, clawID)
+	if len(msgs) != 1 {
+		t.Fatalf("messages = %d (%v), want 1", len(msgs), msgs)
+	}
+	if !strings.Contains(msgs[0], "All CI checks passed on PR #42") || !strings.Contains(msgs[0], "04cc3f4") {
+		t.Fatalf("unexpected CI-green message: %q", msgs[0])
+	}
+	var role string
+	if err := db.QueryRow(`SELECT role FROM messages WHERE claw_id=?`, clawID).Scan(&role); err != nil {
+		t.Fatal(err)
+	}
+	if role != "hub" {
+		t.Fatalf("role = %q, want hub (same channel as review-comment wake-ups)", role)
+	}
+	sha, conclusion := ciWatermark(t, db, pr.id)
+	if sha != headSHA || conclusion != ciConclusionSuccess {
+		t.Fatalf("watermark = (%q,%q), want (%q,success)", sha, conclusion, headSHA)
+	}
+
+	// Re-poll with the watermark the previous poll wrote: no second wake-up.
+	pr.lastCISHA, pr.lastCIConclusion = sha, conclusion
+	s.checkCIStatus(pr, "token")
+	if msgs := ciMessages(t, db, clawID); len(msgs) != 1 {
+		t.Fatalf("re-poll injected again: messages = %d (%v), want 1", len(msgs), msgs)
+	}
+}
+
+// A stale in-memory clawPR (e.g. two overlapping polls) must not re-notify:
+// the conditional UPDATE is the authority, not the cached watermark.
+func TestCheckCIStatusGreenClaimBlocksConcurrentRepoll(t *testing.T) {
+	const clawID = "claw-ci-green-claim"
+	s, db, pr := ciStatusFixture(t, clawID, "abcdef0123456789", `[{"name":"verify","status":"completed","conclusion":"success"}]`)
+
+	s.checkCIStatus(pr, "token")
+	s.checkCIStatus(pr, "token") // same stale pr value, watermark already claimed
+
+	if msgs := ciMessages(t, db, clawID); len(msgs) != 1 {
+		t.Fatalf("messages = %d (%v), want 1", len(msgs), msgs)
+	}
+}
+
+func TestCheckCIStatusGreenDoesNotInterruptBusyClaw(t *testing.T) {
+	const clawID = "claw-ci-green-busy"
+	s, db, pr := ciStatusFixture(t, clawID, "beefbeefbeefbeef", `[{"name":"verify","status":"completed","conclusion":"success"}]`)
+	cc := &clawConn{id: clawID, tenantID: "test-tenant-id", awaitingResponse: true}
+	s.mu.Lock()
+	s.claws[clawID] = cc
+	s.mu.Unlock()
+
+	s.checkCIStatus(pr, "token")
+
+	var pending int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND delivered_at IS NULL`, clawID).Scan(&pending); err != nil {
+		t.Fatal(err)
+	}
+	if pending != 1 {
+		t.Fatalf("pending messages = %d, want 1 (queued, not delivered mid-turn)", pending)
+	}
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+	if !cc.awaitingResponse || !cc.streamingStartedAt.IsZero() {
+		t.Fatal("CI-green injection started a turn on a busy claw")
+	}
+}
+
+func TestCheckCIStatusRunningNeitherNotifiesNorAdvances(t *testing.T) {
+	const clawID = "claw-ci-running"
+	s, db, pr := ciStatusFixture(t, clawID, "0011223344556677",
+		`[{"name":"verify","status":"in_progress","conclusion":null}]`)
+
+	s.checkCIStatus(pr, "token")
+
+	if msgs := ciMessages(t, db, clawID); len(msgs) != 0 {
+		t.Fatalf("messages = %v, want none while CI is running", msgs)
+	}
+	if sha, conclusion := ciWatermark(t, db, pr.id); sha != "" || conclusion != "" {
+		t.Fatalf("watermark = (%q,%q), want empty while CI is running", sha, conclusion)
+	}
+}
+
+func TestCheckCIStatusNoCheckRunsIsNotGreen(t *testing.T) {
+	const clawID = "claw-ci-none"
+	s, db, pr := ciStatusFixture(t, clawID, "7766554433221100", `[]`)
+
+	s.checkCIStatus(pr, "token")
+
+	if msgs := ciMessages(t, db, clawID); len(msgs) != 0 {
+		t.Fatalf("messages = %v, want none when CI has not reported", msgs)
+	}
+	if sha, _ := ciWatermark(t, db, pr.id); sha != "" {
+		t.Fatalf("watermark = %q, want empty when CI has not reported", sha)
+	}
+}
+
+func TestCheckCIStatusFailureMessageUnchangedAndRerunCanTurnGreen(t *testing.T) {
+	const clawID = "claw-ci-flip"
+	const headSHA = "1234567890abcdef"
+	s, db, pr := ciStatusFixture(t, clawID, headSHA,
+		`[{"name":"verify","status":"completed","conclusion":"failure","details_url":"https://ci/1"}]`)
+
+	s.checkCIStatus(pr, "token")
+
+	msgs := ciMessages(t, db, clawID)
+	want := "CI failed on PR #42 ([owner/repo](https://github.com/owner/repo/pull/42)):\n\n" +
+		"**verify** — [view logs](https://ci/1)\n\nPlease fix these failures on the same branch."
+	if len(msgs) != 1 || msgs[0] != want {
+		t.Fatalf("failure message = %v, want %q", msgs, want)
+	}
+	sha, conclusion := ciWatermark(t, db, pr.id)
+	if sha != headSHA || conclusion != ciConclusionFailure {
+		t.Fatalf("watermark = (%q,%q), want (%q,failure)", sha, conclusion, headSHA)
+	}
+
+	// A re-run of the *same* SHA that turns green must still wake the agent.
+	green, _, prGreen := ciStatusFixture(t, clawID+"-2", headSHA, `[{"name":"verify","status":"completed","conclusion":"success"}]`)
+	if _, err := green.db.Exec(`UPDATE claw_prs SET last_ci_sha=?, last_ci_conclusion=? WHERE id=?`, headSHA, ciConclusionFailure, prGreen.id); err != nil {
+		t.Fatal(err)
+	}
+	prGreen.lastCISHA, prGreen.lastCIConclusion = headSHA, ciConclusionFailure
+	green.checkCIStatus(prGreen, "token")
+	greenMsgs := ciMessages(t, green.db, prGreen.clawID)
+	if len(greenMsgs) != 1 || !strings.Contains(greenMsgs[0], "All CI checks passed") {
+		t.Fatalf("failure->success on same SHA did not notify: %v", greenMsgs)
+	}
+}
+
 func TestInjectMessageSkipsIdenticalPendingRow(t *testing.T) {
 	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
 	const clawID = "inject-message-dedupe"


### PR DESCRIPTION
## The incident

On 2026-07-27 claw `b1b53952` (NEXT-509) sat idle for **7 hours** on a PR whose CI was fully green.

The agent pushed a CI fix at ~17:53 and ended its turn saying it was waiting on CI. All checks went green a few minutes later. Nothing happened — no comment, no review, no push — and the hub only wakes an idle claw on comment/review events. `checkCIFailures` *did* compute the green verdict on the very next poll, then wrote `last_ci_sha` and returned without injecting anything. Writing the watermark made that success permanently unobservable, so the deadlock was self-sealing: the agent waited for the hub, the hub had already decided there was nothing left to say. It took an operator message to unstick it.

## The fix

`checkCIFailures` → `checkCIStatus` in `pkg/hub/pr_watcher.go`. Same call site, same 10s ticker, same already-fetched `check-runs` response — no new goroutine, webhook, GitHub App permission, or per-tick API call for a PR that is progressing normally.

- **Green is now an event.** The success branch injects via `injectExternalHubMessageByID` (role `hub`), the same primitive `forwardHumanReviewComment` and `checkPRComments` already use. It resumes a no-progress pause. The failure branch and its message text are unchanged.
- **The watermark no longer self-silences.** CI still running, or zero check runs at all, returns *without* advancing `last_ci_sha`. The old code advanced on `allCompleted`, which is what made the eventual verdict unobservable.
- **New `claw_prs.last_ci_conclusion` column** (`''` | `'success'` | `'failure'`), additive migration beside the other `claw_prs` ones. The early return now requires a SHA already observed as `success`, so a re-run that flips `failure → success` on an unchanged SHA still notifies.
- **Only green-ish conclusions count as green.** `success`, `neutral`, `skipped` pass; `failure`, `timed_out`, `cancelled`, `action_required`, `stale`, `startup_failure` and any future/unknown value block. (Second commit — review finding, see below.)
- `turnProgressFingerprint` hashes the conclusion, so a verdict flip counts as real progress.
- Both fetches moved to `githubAPIWithBase(s.githubBaseURL, …)`, consistent with `checkPRConditions`. In production `githubBaseURL` is empty ⇒ identical behaviour; without it the function was untestable.

### Would it have woken NEXT-509? Yes, both ways

- **Prospectively:** push → in-progress → return without touching the watermark → green → claim succeeds → inject → claw is idle → delivered. Deadlock broken within ~10s of green.
- **Retroactively:** the actual stuck row (`last_ci_sha=04cc3f49`, migration backfills conclusion `''`) fires on the first poll after deploy, because the early return requires conclusion `success`, not just a SHA match. Deploying this would have unstuck `b1b53952` with no operator message.

## Why this is not a nag flood

The failure mode to avoid here is the PR #551 shape: a periodic poller that re-injects the same message forever.

- **Claim, not write.** The watermark update is `UPDATE claw_prs SET last_ci_sha=?, last_ci_conclusion=? WHERE id=? AND NOT (last_ci_sha=? AND last_ci_conclusion=?)`, `RowsAffected()==0` ⇒ bail — the same idiom as `claimPipelineStageTransition`. Exactly one poll, and exactly one hub process, ever observes a given `(sha, conclusion)` pair.
- **Re-poll safe.** `pollAllPRs` snapshots rows at tick start, but the claim runs against live DB state, so a stale in-memory `clawPR` cannot double-fire.
- **Restart safe.** State is in the DB; a restarted hub reads `(sha, success)` and early-returns.
- **Bounded per SHA.** After `success` is recorded the SHA is never re-examined. Worst case is 2 notifications per SHA: one failure, then one success after a re-run.
- **Never interrupts.** `injectMessage` only calls `sendNextQueuedMessage` when the claw is not busy; a busy claw gets the row queued and delivered at end of turn. Asserted by `TestCheckCIStatusGreenDoesNotInterruptBusyClaw`.
- **Message-level backstop.** `injectMessage` dedups identical undelivered content.

## Review findings

Applied in commit 2 (`fix(hub): never report a non-green CI conclusion as passing`):

- **Non-green terminal conclusions were announced as "All CI checks passed".** `cancelled` / `action_required` / `stale` / `startup_failure` are completed-with-conclusion, so the verdict became `success` and the claw was told to emit its stage signal token on a PR that was not green. The classification was inherited from the old code, but the old code stayed *silent*; the new success branch turned it into an affirmative false claim. Now only `success`/`neutral`/`skipped` are green; anything else, including unknown future values, is blocking and is listed with its conclusion name. Table-driven tests cover all five, plus `neutral`/`skipped`.

Acknowledged, **not** applied — follow-ups rather than blockers:

- **Sustained polling for PRs with zero check runs.** A repo without CI re-fetches `check-runs` every 10s for the life of the PR, because the watermark never advances. Real cost, but any fix needs new per-SHA first-seen state, and recording a "no CI" verdict prematurely would permanently silence a check suite that registers a few seconds late — strictly worse than the current cost. Wants its own change, alongside the rate-limit work.
- **Re-fetching check runs while a PR is red.** Same shape, but this one is the point: it is what lets a re-run of an unchanged SHA report green. Keeping it.
- **One-time notification wave on deploy.** The `''` backfill means red PRs get one fresh "CI failed … please fix" on the first poll after deploy. Bounded at one per PR, never interrupts a turn — and it is inseparable from the retroactive unstick that resolves the incident. Expect a small burst on deploy day; it is not a loop.
- **Claim-then-inject is at-most-once.** A hub crash in the millisecond gap between the claim and the injection consumes the `(sha, success)` pair and silences it. Inverting the order trades this for duplicates, which is the worse failure here. The real net is spec §4.6 (`firePRConditions` warn-log) and re-arming the 2h `prConditionsMaxWait` via `pr_conditions: {ci: passing}` in the next_tooling workflow YAML — both outside this repo's Go code.
- **A failure re-run after a recorded success on the same SHA is silent.** Accepted trade: it is exactly what makes a storm structurally impossible.

Also deliberately out of scope, per "keep it minimal": spec §4.5 (`check_run`/`check_suite`/`status` webhook arm — latency only; the 10s poll already breaks the deadlock).

## Tests

```
go build ./...            clean
go vet ./pkg/hub/         clean
go test ./...             all packages ok
```

New in `pkg/hub/pr_watcher_test.go` (stub GitHub via `httptest`): green wakes an idle claw exactly once with role `hub` and re-polling injects nothing; a stale in-memory `clawPR` cannot double-fire past the claim; a busy claw only queues; `in_progress` neither notifies nor advances; zero check runs is not green; the failure message is unchanged and `failure → success` on the same SHA notifies; non-green terminal conclusions are never reported as green; `neutral`/`skipped` are. Plus `TestTurnProgressFingerprintTracksCIConclusion` and `TestMigrateAddsLastCIConclusionToExistingClawPRs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
