### PR TITLE
fix(bridge): append host binary dirs to PATH inside flake-run wrapper

### DIFF
--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -2385,12 +2385,15 @@ func setupFlakeEnvironmentSync(nixDone <-chan error) error {
 	// Workspace flakes supply claw-wide tools (e.g. depot). This is the
 	// contract used by both the agent gateway and deterministic run steps.
 	// We deliberately do not use "nix profile install ." (wrong for dev-shell-only flakes).
+	// After nix develop builds the flake's PATH, we append common host binary dirs
+	// so bootstrap-installed tools (e.g. gh) and host tools (e.g. Homebrew) are
+	// available as fallbacks, while flake packages remain preferred.
 	wrapperScript := fmt.Sprintf(`#!/bin/bash
 set -euo pipefail
 export PATH="/nix/var/nix/profiles/default/bin:$PATH"
 . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh 2>/dev/null || true
 cd %q
-exec nix develop --accept-flake-config -c "$@"
+exec nix develop --accept-flake-config -c bash -c 'export PATH="$PATH:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin"; exec "$@"' bash "$@"
 `, flakeDir)
 	wrapperPath := filepath.Join(home, ".elasticclaw", "flake-run")
 	if err := os.WriteFile(wrapperPath, []byte(wrapperScript), 0755); err != nil {


### PR DESCRIPTION
When a workspace has a flake.nix, the claw-bridge writes a `~/.elasticclaw/flake-run` wrapper that starts the OpenClaw gateway inside `nix develop`. The flake's dev shell only exposes packages listed in the flake's `buildInputs`, so tools installed by the VM bootstrap (e.g. the ElasticClaw `gh` token-refresh wrapper at `/usr/local/bin/gh`) or by the host OS (e.g. Homebrew) were not on PATH.

Change the wrapper to append common host binary directories to PATH after `nix develop` sets up the flake environment. This keeps Nix packages preferred while making bootstrap/host tools available as fallbacks.

Verified with `go build ./cmd/claw-bridge`.