### PR TITLE
feat(bridge,hub,cli): reduce agent activity log noise

### DIFF
--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -4151,11 +4151,13 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 			if bytes.Equal(payload, lastPayload) {
 				return
 			}
-			lastPayload = payload
-			_ = writeHub(hubMsg{
+			if err := writeHub(hubMsg{
 				Type:    "agent_activity",
 				Payload: payload,
-			})
+			}); err != nil {
+				return
+			}
+			lastPayload = payload
 		}
 	}()
 

--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -20,6 +20,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
@@ -929,8 +930,9 @@ func sanitizeActivityText(value string) string {
 	for _, r := range replacers {
 		value = redactActivityPrefix(value, r.prefix, r.value)
 	}
-	if len(value) > 240 {
-		value = value[:237] + "..."
+	const maxActivityTextLen = 2000
+	if len(value) > maxActivityTextLen {
+		value = value[:maxActivityTextLen-3] + "..."
 	}
 	return value
 }
@@ -4136,12 +4138,26 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 	}
 	log.Printf("registered with hub as %s", clawID)
 
-	writeActivity := func(activity agentActivity) {
-		_ = writeHub(hubMsg{
-			Type:    "agent_activity",
-			Payload: mustJSON(cleanAgentActivity(activity)),
-		})
-	}
+	writeActivity := func() func(agentActivity) {
+		var (
+			lastPayload []byte
+			mu          sync.Mutex
+		)
+		return func(activity agentActivity) {
+			cleaned := cleanAgentActivity(activity)
+			payload := mustJSON(cleaned)
+			mu.Lock()
+			defer mu.Unlock()
+			if bytes.Equal(payload, lastPayload) {
+				return
+			}
+			lastPayload = payload
+			_ = writeHub(hubMsg{
+				Type:    "agent_activity",
+				Payload: payload,
+			})
+		}
+	}()
 
 	// Replay any queued entries that accumulated while we were disconnected.
 	// Completed replies/notices are delivered directly; only unprocessed inputs

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -1060,6 +1060,22 @@ func TestSanitizeActivityTextRedactsRepeatedSecretPrefixes(t *testing.T) {
 	}
 }
 
+func TestSanitizeActivityTextTruncatesAtReasonableLength(t *testing.T) {
+	input := strings.Repeat("a", 5000)
+	got := sanitizeActivityText(input)
+	if len(got) > 2005 {
+		t.Fatalf("sanitizeActivityText produced %d chars, want <= 2005: %q", len(got), got)
+	}
+	if !strings.HasSuffix(got, "...") {
+		t.Fatalf("sanitizeActivityText should suffix with ...: %q", got)
+	}
+	// Content under the limit should be preserved unchanged.
+	short := strings.Repeat("b", 1500)
+	if got := sanitizeActivityText(short); got != short {
+		t.Fatalf("sanitizeActivityText truncated short input: %q", got)
+	}
+}
+
 func TestPromoteInsufficientGatewayPairingPromotesReadOnlyDevice(t *testing.T) {
 	home := t.TempDir()
 	devicesDir := filepath.Join(home, ".openclaw", "devices")

--- a/cmd/workflow.go
+++ b/cmd/workflow.go
@@ -475,10 +475,84 @@ func runWorkflowLogs(workspace, name, runID string) error {
 	}
 
 	fmt.Printf("Agent logs for run %s (agent %s, status %s):\n\n", runID, shortID(run.ClawID), run.Status)
-	for _, msg := range messages {
-		printActivityMessage(msg)
-	}
+	printCollapsedActivityMessages(messages)
 	return nil
+}
+
+// printCollapsedActivityMessages prints activity messages, collapsing bursts of
+// identical or prefix-extended reasoning messages so repeated model activity
+// does not drown out tool events and errors.
+func printCollapsedActivityMessages(messages []types.HubMessage) {
+	var pending *types.HubMessage
+	var pendingActivity *agentActivity
+	pendingCount := 0
+
+	flush := func() {
+		if pending == nil {
+			return
+		}
+		printActivityMessage(*pending, pendingCount-1)
+		pending = nil
+		pendingActivity = nil
+		pendingCount = 0
+	}
+
+	for i := range messages {
+		msg := &messages[i]
+		activity, ok := parseAgentActivity(*msg)
+		if !ok {
+			flush()
+			printActivityMessage(*msg, 0)
+			continue
+		}
+		if pending == nil {
+			pending = msg
+			pendingActivity = &activity
+			pendingCount = 1
+			continue
+		}
+		if canCollapseActivity(*pendingActivity, activity) {
+			if len(activity.Message) > len(pendingActivity.Message) {
+				pending = msg
+				pendingActivity = &activity
+			}
+			pendingCount++
+			continue
+		}
+		flush()
+		pending = msg
+		pendingActivity = &activity
+		pendingCount = 1
+	}
+	flush()
+}
+
+func parseAgentActivity(msg types.HubMessage) (agentActivity, bool) {
+	if !strings.HasPrefix(msg.Format, "activity:") {
+		return agentActivity{}, false
+	}
+	var activity agentActivity
+	if err := json.Unmarshal([]byte(strings.TrimPrefix(msg.Format, "activity:")), &activity); err != nil {
+		return agentActivity{}, false
+	}
+	return activity, true
+}
+
+// canCollapseActivity returns true when two activities are the same kind of
+// event and one message is a prefix of the other. This catches the common case
+// where a model streams its reasoning as a series of ever-longer messages.
+func canCollapseActivity(a, b agentActivity) bool {
+	return a.Kind == b.Kind &&
+		a.Tool == b.Tool &&
+		a.Phase == b.Phase &&
+		a.Command == b.Command &&
+		a.Path == b.Path &&
+		a.URL == b.URL &&
+		a.Error == b.Error &&
+		a.Detail == b.Detail &&
+		(a.Message == b.Message ||
+			strings.HasPrefix(a.Message, b.Message) ||
+			strings.HasPrefix(b.Message, a.Message))
 }
 
 type agentActivity struct {
@@ -493,7 +567,7 @@ type agentActivity struct {
 	Error   string `json:"error"`
 }
 
-func printActivityMessage(msg types.HubMessage) {
+func printActivityMessage(msg types.HubMessage, collapsedSimilar int) {
 	ts := msg.CreatedAt.Format("2006-01-02 15:04:05")
 	if !strings.HasPrefix(msg.Format, "activity:") {
 		fmt.Printf("%s  %s\n", ts, msg.Content)
@@ -533,6 +607,9 @@ func printActivityMessage(msg types.HubMessage) {
 	}
 	if activity.Error != "" {
 		parts = append(parts, fmt.Sprintf("error: %s", activity.Error))
+	}
+	if collapsedSimilar > 0 {
+		parts = append(parts, fmt.Sprintf("(+ %d similar)", collapsedSimilar))
 	}
 	if len(parts) == 0 {
 		fmt.Println(" " + msg.Content)

--- a/cmd/workflow_test.go
+++ b/cmd/workflow_test.go
@@ -172,6 +172,77 @@ func TestRunWorkflowLogsFetchesRunAndActivityMessages(t *testing.T) {
 	}
 }
 
+func TestPrintCollapsedActivityMessages(t *testing.T) {
+	started := time.Date(2026, 7, 24, 9, 0, 0, 0, time.UTC)
+	mk := func(kind, message string) types.HubMessage {
+		return types.HubMessage{
+			Format:    "activity:" + mustJSON(t, agentActivity{Kind: kind, Message: message}),
+			CreatedAt: started,
+		}
+	}
+	mkTool := func(phase, command string) types.HubMessage {
+		return types.HubMessage{
+			Format:    "activity:" + mustJSON(t, agentActivity{Kind: "tool", Tool: "bash", Phase: phase, Command: command}),
+			CreatedAt: started,
+		}
+	}
+	mkPlain := func(content string) types.HubMessage {
+		return types.HubMessage{Content: content, CreatedAt: started}
+	}
+
+	messages := []types.HubMessage{
+		mk("activity", "The"),
+		mk("activity", "The user wants"),
+		mk("activity", "The user wants to run updates"),
+		mkTool("running", "git status"),
+		mkTool("running", "git status"),
+		mkTool("completed", "git status"),
+		mkPlain("plain hub message"),
+		mk("activity", "Now thinking about tests"),
+		mk("activity", "Now thinking about tests and validation"),
+	}
+
+	out, err := captureStdout(func() error {
+		printCollapsedActivityMessages(messages)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("captureStdout failed: %v", err)
+	}
+
+	// The three prefix-extended reasoning messages should collapse to one.
+	if !strings.Contains(out, "The user wants to run updates") {
+		t.Fatalf("output missing final collapsed reasoning message:\n%s", out)
+	}
+	if !strings.Contains(out, "(+ 2 similar)") {
+		t.Fatalf("output missing collapse count for first reasoning burst:\n%s", out)
+	}
+	// The duplicate running tool messages should be collapsed.
+	if strings.Count(out, "[bash]") != 2 {
+		t.Fatalf("want 2 bash lines (running + completed), got %d:\n%s", strings.Count(out, "[bash]"), out)
+	}
+	if !strings.Contains(out, "(+ 1 similar)") {
+		t.Fatalf("output missing collapse count for duplicate tool start:\n%s", out)
+	}
+	// Non-activity content should appear as-is.
+	if !strings.Contains(out, "plain hub message") {
+		t.Fatalf("output missing plain message:\n%s", out)
+	}
+	// The final reasoning burst should be present.
+	if !strings.Contains(out, "Now thinking about tests and validation") {
+		t.Fatalf("output missing final reasoning message:\n%s", out)
+	}
+}
+
+func mustJSON(t *testing.T, v interface{}) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(b)
+}
+
 func TestRunWorkflowRunsListsRunsAndShortAgentID(t *testing.T) {
 	started := time.Date(2026, 7, 24, 9, 0, 0, 0, time.UTC)
 	finished := started.Add(5 * time.Minute)

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -458,10 +458,10 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/workspaces/{name}/workflows", s.withAdminForMethods(s.handleWorkspaceWorkflowsList, http.MethodPost))
 	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}", s.withAdminForMethods(s.handleWorkspaceWorkflowDetail, http.MethodPatch))
 	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}/trigger", s.withAuth(s.handleWorkspaceWorkflowTrigger))
-	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}/cron/trigger", s.withAuth(s.handleCronWorkflowTrigger)) // POST manual trigger
-	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}/cron/runs", s.withAuth(s.handleCronWorkflowRuns))       // GET run history
+	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}/cron/trigger", s.withAuth(s.handleCronWorkflowTrigger))  // POST manual trigger
+	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}/cron/runs", s.withAuth(s.handleCronWorkflowRuns))        // GET run history
 	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}/cron/runs/{runId}", s.withAuth(s.handleCronWorkflowRun)) // GET single run
-	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}/cron/next", s.withAuth(s.handleCronWorkflowNextRun))    // GET next scheduled run
+	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}/cron/next", s.withAuth(s.handleCronWorkflowNextRun))     // GET next scheduled run
 	mux.HandleFunc("/api/workspaces/{workspace}/secrets", s.withAdminForMethods(s.handleWorkspaceSecretsCRUD, http.MethodPut, http.MethodPost, http.MethodDelete))
 	mux.HandleFunc("/api/workspaces/{workspace}/github-apps", s.withAdminForMethods(s.handleWorkspaceGitHubAppsCRUD, http.MethodPut, http.MethodPost, http.MethodDelete))
 	mux.HandleFunc("/api/workspaces/{workspace}/issue-trackers", s.withAdminForMethods(s.handleWorkspaceIssueTrackersCRUD, http.MethodPut, http.MethodPost, http.MethodDelete))
@@ -2537,10 +2537,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 					content := activityContent(activity)
 					if content != "" && !isUnhelpfulActivityContent(activity, content) {
 						format := "activity:" + string(payload)
-						_, _ = s.db.Exec(
-							`INSERT INTO messages(id,claw_id,tenant_id,role,content,format,created_at,delivered_at) VALUES(?,?,?,?,?,?,?,?)`,
-							uuid.New().String(), clawID, tenantID, "activity", content, format, createdAt, createdAt,
-						)
+						s.storeAgentActivity(clawID, tenantID, content, format, activity, createdAt)
 					}
 					s.broadcastToUsers(tenantID, types.WSMessage{
 						Type:    "agent_activity",
@@ -4579,6 +4576,29 @@ func isUnhelpfulActivityContent(activity map[string]interface{}, content string)
 		return true
 	}
 	return strings.HasPrefix(content, "No streamed output")
+}
+
+// storeAgentActivity persists an activity message. Generic reasoning activity
+// (kind == "activity") is upserted into a single row per claw so the model's
+// streaming internal monologue does not flood the messages table. Tool,
+// diagnostic, error, and lifecycle activity messages are inserted as distinct
+// rows because they are useful audit events.
+func (s *Server) storeAgentActivity(clawID, tenantID, content, format string, activity map[string]interface{}, createdAt time.Time) {
+	kind, _ := activity["kind"].(string)
+	if strings.ToLower(strings.TrimSpace(kind)) == "activity" {
+		// Use a deterministic ID so repeated reasoning updates collapse to one row.
+		msgID := "activity-stream:" + clawID
+		_, _ = s.db.Exec(
+			`INSERT INTO messages(id,claw_id,tenant_id,role,content,format,created_at,delivered_at) VALUES(?,?,?,?,?,?,?,?)
+			 ON CONFLICT(id) DO UPDATE SET content=excluded.content, format=excluded.format, created_at=excluded.created_at, delivered_at=excluded.delivered_at`,
+			msgID, clawID, tenantID, "activity", content, format, createdAt, createdAt,
+		)
+		return
+	}
+	_, _ = s.db.Exec(
+		`INSERT INTO messages(id,claw_id,tenant_id,role,content,format,created_at,delivered_at) VALUES(?,?,?,?,?,?,?,?)`,
+		uuid.New().String(), clawID, tenantID, "activity", content, format, createdAt, createdAt,
+	)
 }
 
 func daytonaBootstrapStatusForStep(label string) string {

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -125,8 +125,8 @@ func TestWorkspaceFlakeStageCommand(t *testing.T) {
 			name: "ignores invalid paths",
 			dir:  "/workspace",
 			files: map[string]string{
-				"flake.nix": "{}",
-				"../secret": "secret",
+				"flake.nix":   "{}",
+				"../secret":   "secret",
 				"/etc/passwd": "pw",
 			},
 			wantNames:   []string{"flake.nix"},
@@ -2463,5 +2463,55 @@ func TestMergeDockerContainerEnvPreservesWorkflowSecrets(t *testing.T) {
 	}
 	if got["ELASTICCLAW_CLAW_ID"] != "claw-123" {
 		t.Fatalf("ELASTICCLAW_CLAW_ID = %q, want managed claw ID", got["ELASTICCLAW_CLAW_ID"])
+	}
+}
+
+func TestAgentActivityGenericReasoningUpsertsButToolEventsInsert(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	const clawID = "activity-storage-test"
+	conn := watchdogClaw(t, s, clawID)
+	_ = watchdogClawConn(t, s, clawID)
+
+	write := func(m types.WSMessage) {
+		if err := wsjson.Write(context.Background(), conn, m); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Send a burst of generic reasoning activity frames.
+	for i := 0; i < 5; i++ {
+		write(types.WSMessage{Type: "agent_activity", Payload: map[string]any{
+			"kind":    "activity",
+			"message": fmt.Sprintf("The user wants%s", strings.Repeat(".", i+1)),
+		}})
+	}
+	// Send two distinct tool events.
+	write(types.WSMessage{Type: "agent_activity", Payload: map[string]any{
+		"kind": "tool", "tool": "bash", "phase": "running", "command": "git status",
+	}})
+	write(types.WSMessage{Type: "agent_activity", Payload: map[string]any{
+		"kind": "tool", "tool": "bash", "phase": "completed", "command": "git status",
+	}})
+
+	eventuallyWatchdog(t, func() bool {
+		var n int
+		_ = db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND role='activity'`, clawID).Scan(&n)
+		return n >= 3
+	}, "activity rows persisted")
+
+	var total int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND role='activity'`, clawID).Scan(&total); err != nil {
+		t.Fatalf("count activity rows: %v", err)
+	}
+	if total != 3 {
+		t.Fatalf("activity rows = %d, want 3 (1 upserted reasoning + 2 tool events)", total)
+	}
+
+	var latestReasoning string
+	if err := db.QueryRow(`SELECT content FROM messages WHERE claw_id=? AND id=?`, clawID, "activity-stream:"+clawID).Scan(&latestReasoning); err != nil {
+		t.Fatalf("read upserted reasoning row: %v", err)
+	}
+	if !strings.Contains(latestReasoning, "The user wants") {
+		t.Fatalf("upserted reasoning content unexpected: %q", latestReasoning)
 	}
 }


### PR DESCRIPTION
Reduces the volume and improves the usefulness of agent activity logs.

Changes:
- Increase activity text truncation limit from 240 to 2000 chars.
- Deduplicate exact duplicate activity messages in the bridge before sending to the hub.
- Collapse prefix-extended and duplicate activity messages in `elasticclaw workflow logs` output.
- Upsert generic reasoning activity messages in the hub so the model's streaming internal monologue does not flood the `messages` table; tool/error/diagnostic events are still inserted as distinct audit rows.

Tests added for the new truncation limit, CLI collapsing, and hub upsert behavior.