### PR TITLE
feat(hub): drive CI wake-up from check_run/check_suite webhooks

### DIFF
--- a/pkg/hub/github_check_webhook_test.go
+++ b/pkg/hub/github_check_webhook_test.go
@@ -1,0 +1,306 @@
+package hub
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+// checkWebhookFixture wires a server that (a) accepts signed GitHub webhooks
+// with the shared test secret, (b) can resolve a GitHub App installation token
+// without reaching api.github.com, and (c) answers PR/check-run reads from a
+// stub whose call count is observable.
+func checkWebhookFixture(t *testing.T, clawID, headSHA, checkRunsJSON string) (*Server, *sql.DB, clawPR, *atomic.Int32) {
+	t.Helper()
+
+	oldTransport := http.DefaultTransport
+	http.DefaultTransport = githubAppTokenTransport{base: oldTransport}
+	t.Cleanup(func() { http.DefaultTransport = oldTransport })
+
+	var calls atomic.Int32
+	gh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		if strings.Contains(r.URL.Path, "/check-runs") {
+			_, _ = w.Write([]byte(`{"check_runs":` + checkRunsJSON + `}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"head":{"sha":"` + headSHA + `"},"state":"open"}`))
+	}))
+	t.Cleanup(gh.Close)
+
+	cfg := &types.HubConfig{
+		ClawToken:  "test-claw-token",
+		GitHubApps: []*types.GitHubAppConfig{{AppID: 1, PrivateKeyPEM: testGitHubAppPEM(t)}},
+		Factories: []*types.FactoryConfig{{
+			Name:          "github-prs",
+			Integration:   "github",
+			Template:      "elasticclaw",
+			Provider:      "noop",
+			Repos:         []string{"owner/repo"},
+			WebhookSecret: "test-webhook-secret",
+			Trigger:       &types.GitHubTrigger{On: "pull_request"},
+		}},
+		Providers: map[string]types.ProviderConfig{"noop": {Type: "noop"}},
+	}
+	s, db := NewTestServerWithConfig(t, cfg, gh.URL, "", "")
+
+	if _, err := db.Exec(`INSERT INTO claws(id,tenant_id,name,template,provider,status,created_at) VALUES(?,?,?,?,?,?,?)`,
+		clawID, "test-tenant-id", clawID, "elasticclaw", "noop", "connected", now()); err != nil {
+		t.Fatal(err)
+	}
+	pr := clawPR{id: "pr-" + clawID, clawID: clawID, repo: "owner/repo", prNumber: 42, prURL: "https://github.com/owner/repo/pull/42"}
+	if _, err := db.Exec(`INSERT INTO claw_prs(id,claw_id,repo,pr_number,pr_url,created_at) VALUES(?,?,?,?,?,?)`,
+		pr.id, pr.clawID, pr.repo, pr.prNumber, pr.prURL, now()); err != nil {
+		t.Fatal(err)
+	}
+	return s, db, pr, &calls
+}
+
+func checkWebhookBody(event, action, headSHA string, prNumbers ...int) map[string]interface{} {
+	prs := []interface{}{}
+	for _, n := range prNumbers {
+		prs = append(prs, map[string]interface{}{"number": n})
+	}
+	sub := map[string]interface{}{
+		"name":          "verify",
+		"status":        "completed",
+		"conclusion":    "success",
+		"head_sha":      headSHA,
+		"pull_requests": prs,
+	}
+	key := "check_run"
+	if event == "check_suite" {
+		key = "check_suite"
+		delete(sub, "name")
+	}
+	return map[string]interface{}{
+		"action":     action,
+		key:          sub,
+		"repository": map[string]interface{}{"full_name": "owner/repo"},
+	}
+}
+
+// waitForGHCalls waits until the stub GitHub has served at least want requests.
+// The webhook handler runs under safeGo, so HTTP 200 returns before the work.
+func waitForGHCalls(t *testing.T, calls *atomic.Int32, want int32) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for calls.Load() < want {
+		if time.Now().After(deadline) {
+			t.Fatalf("GitHub calls = %d, want >= %d", calls.Load(), want)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+func greenMessageCount(t *testing.T, db *sql.DB, clawID string) int {
+	t.Helper()
+	n := 0
+	for _, m := range ciMessages(t, db, clawID) {
+		if strings.Contains(m, "All CI checks passed on PR #42") {
+			n++
+		}
+	}
+	return n
+}
+
+const allGreenCheckRuns = `[{"name":"verify","status":"completed","conclusion":"success"},
+                            {"name":"gitleaks","status":"completed","conclusion":"success"}]`
+
+// T1: a completed check_run for a fully green head SHA wakes the idle claw.
+func TestCheckWebhookGreenWakesIdleClawOnce(t *testing.T) {
+	const clawID = "claw-check-webhook-green"
+	const headSHA = "04cc3f49aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	s, db, pr, _ := checkWebhookFixture(t, clawID, headSHA, allGreenCheckRuns)
+
+	postSignedGitHubWebhook(t, s, "check_run", checkWebhookBody("check_run", "completed", headSHA, 42))
+
+	waitForMessageContains(t, db, clawID, "hub", []string{"All CI checks passed on PR #42", "04cc3f4"})
+	if got := greenMessageCount(t, db, clawID); got != 1 {
+		t.Fatalf("green messages = %d, want 1", got)
+	}
+	sha, conclusion := ciWatermark(t, db, pr.id)
+	if sha != headSHA || conclusion != ciConclusionSuccess {
+		t.Fatalf("watermark = (%q,%q), want (%q,success)", sha, conclusion, headSHA)
+	}
+}
+
+// T8: check_suite takes the same path as check_run.
+func TestCheckSuiteWebhookGreenWakesIdleClaw(t *testing.T) {
+	const clawID = "claw-check-suite-green"
+	const headSHA = "5ee5ee5ee5ee5ee5ee5ee5ee5ee5ee5ee5ee5ee5"
+	s, db, pr, _ := checkWebhookFixture(t, clawID, headSHA, allGreenCheckRuns)
+
+	postSignedGitHubWebhook(t, s, "check_suite", checkWebhookBody("check_suite", "completed", headSHA, 42))
+
+	waitForMessageContains(t, db, clawID, "hub", []string{"All CI checks passed on PR #42"})
+	if got := greenMessageCount(t, db, clawID); got != 1 {
+		t.Fatalf("green messages = %d, want 1", got)
+	}
+	if sha, conclusion := ciWatermark(t, db, pr.id); sha != headSHA || conclusion != ciConclusionSuccess {
+		t.Fatalf("watermark = (%q,%q), want (%q,success)", sha, conclusion, headSHA)
+	}
+}
+
+// T2: a redelivered event must not produce a second wake-up.
+func TestCheckWebhookDuplicateDeliveryNotifiesOnce(t *testing.T) {
+	const clawID = "claw-check-webhook-dup"
+	const headSHA = "abcdef0123456789abcdef0123456789abcdef01"
+	s, db, _, calls := checkWebhookFixture(t, clawID, headSHA, allGreenCheckRuns)
+
+	body := checkWebhookBody("check_run", "completed", headSHA, 42)
+	postSignedGitHubWebhook(t, s, "check_run", body)
+	waitForMessageContains(t, db, clawID, "hub", []string{"All CI checks passed on PR #42"})
+	postSignedGitHubWebhook(t, s, "check_run", body)
+	// 2 calls for the first delivery; the second stops after the head-SHA read
+	// because the stored watermark already records the success verdict.
+	waitForGHCalls(t, calls, 3)
+
+	if got := greenMessageCount(t, db, clawID); got != 1 {
+		t.Fatalf("green messages = %d, want 1 (claim must hold across deliveries)", got)
+	}
+}
+
+// T3: the anti-double-notify regression test. The webhook claims the verdict;
+// a poller tick that still holds the pre-claim clawPR value must stay silent.
+func TestCheckWebhookThenPollerDoesNotDoubleNotify(t *testing.T) {
+	const clawID = "claw-check-webhook-poller"
+	const headSHA = "beefbeefbeefbeefbeefbeefbeefbeefbeefbeef"
+	s, db, stalePR, _ := checkWebhookFixture(t, clawID, headSHA, allGreenCheckRuns)
+
+	postSignedGitHubWebhook(t, s, "check_run", checkWebhookBody("check_run", "completed", headSHA, 42))
+	waitForMessageContains(t, db, clawID, "hub", []string{"All CI checks passed on PR #42"})
+
+	// stalePR carries the empty watermark the poller loaded before the webhook
+	// landed: only the conditional UPDATE can stop it.
+	s.checkCIStatus(stalePR, "token")
+
+	if got := greenMessageCount(t, db, clawID); got != 1 {
+		t.Fatalf("green messages = %d, want 1 (poller re-notified after webhook claim)", got)
+	}
+}
+
+// T4: one check completing green while a sibling still runs is not a verdict.
+func TestCheckWebhookSinglePassingCheckDoesNotAnnounceGreen(t *testing.T) {
+	const clawID = "claw-check-webhook-partial"
+	const headSHA = "1111111111111111111111111111111111111111"
+	partial := `[{"name":"verify","status":"completed","conclusion":"success"},
+	             {"name":"e2e","status":"in_progress","conclusion":""}]`
+	s, db, pr, calls := checkWebhookFixture(t, clawID, headSHA, partial)
+
+	postSignedGitHubWebhook(t, s, "check_run", checkWebhookBody("check_run", "completed", headSHA, 42))
+	waitForGHCalls(t, calls, 2)
+
+	if msgs := ciMessages(t, db, clawID); len(msgs) != 0 {
+		t.Fatalf("messages = %v, want none while CI is still running", msgs)
+	}
+	if sha, conclusion := ciWatermark(t, db, pr.id); sha != "" || conclusion != "" {
+		t.Fatalf("watermark = (%q,%q), want empty — advancing it hides the real verdict", sha, conclusion)
+	}
+}
+
+// A non-green conclusion in the set must never be reported as passing.
+func TestCheckWebhookNonGreenConclusionDoesNotAnnounceGreen(t *testing.T) {
+	const clawID = "claw-check-webhook-red"
+	const headSHA = "2222222222222222222222222222222222222222"
+	red := `[{"name":"verify","status":"completed","conclusion":"success"},
+	         {"name":"e2e","status":"completed","conclusion":"cancelled","details_url":"https://ci/e2e"}]`
+	s, db, pr, calls := checkWebhookFixture(t, clawID, headSHA, red)
+
+	postSignedGitHubWebhook(t, s, "check_run", checkWebhookBody("check_run", "completed", headSHA, 42))
+	waitForGHCalls(t, calls, 2)
+	waitForMessageContains(t, db, clawID, "user", []string{"CI failed on PR #42"})
+
+	if got := greenMessageCount(t, db, clawID); got != 0 {
+		t.Fatalf("green messages = %d, want 0 for a cancelled check", got)
+	}
+	if _, conclusion := ciWatermark(t, db, pr.id); conclusion != ciConclusionFailure {
+		t.Fatalf("conclusion = %q, want failure", conclusion)
+	}
+}
+
+// T5: non-terminal actions must not spend GitHub API quota.
+func TestCheckWebhookNonCompletedActionMakesNoAPICalls(t *testing.T) {
+	const clawID = "claw-check-webhook-created"
+	const headSHA = "3333333333333333333333333333333333333333"
+	s, db, _, calls := checkWebhookFixture(t, clawID, headSHA, allGreenCheckRuns)
+
+	postSignedGitHubWebhook(t, s, "check_run", checkWebhookBody("check_run", "created", headSHA, 42))
+	time.Sleep(200 * time.Millisecond)
+
+	if got := calls.Load(); got != 0 {
+		t.Fatalf("GitHub calls = %d, want 0 for action=created", got)
+	}
+	if msgs := ciMessages(t, db, clawID); len(msgs) != 0 {
+		t.Fatalf("messages = %v, want none", msgs)
+	}
+}
+
+// T6: fork PRs arrive with an empty pull_requests array.
+func TestCheckWebhookEmptyPullRequestsIsInert(t *testing.T) {
+	const clawID = "claw-check-webhook-nopr"
+	const headSHA = "4444444444444444444444444444444444444444"
+	s, db, _, calls := checkWebhookFixture(t, clawID, headSHA, allGreenCheckRuns)
+
+	postSignedGitHubWebhook(t, s, "check_run", checkWebhookBody("check_run", "completed", headSHA))
+	time.Sleep(200 * time.Millisecond)
+
+	if got := calls.Load(); got != 0 {
+		t.Fatalf("GitHub calls = %d, want 0 without pull_requests", got)
+	}
+	if msgs := ciMessages(t, db, clawID); len(msgs) != 0 {
+		t.Fatalf("messages = %v, want none", msgs)
+	}
+}
+
+// T7: a PR nobody tracks must resolve to nothing, quietly.
+func TestCheckWebhookUntrackedPRIsIgnored(t *testing.T) {
+	const clawID = "claw-check-webhook-untracked"
+	const headSHA = "5555555555555555555555555555555555555555"
+	s, db, _, calls := checkWebhookFixture(t, clawID, headSHA, allGreenCheckRuns)
+
+	postSignedGitHubWebhook(t, s, "check_run", checkWebhookBody("check_run", "completed", headSHA, 999))
+	time.Sleep(200 * time.Millisecond)
+
+	if got := calls.Load(); got != 0 {
+		t.Fatalf("GitHub calls = %d, want 0 for an untracked PR", got)
+	}
+	if msgs := ciMessages(t, db, clawID); len(msgs) != 0 {
+		t.Fatalf("messages = %v, want none", msgs)
+	}
+}
+
+// An unauthenticated path that can wake agents would be a security hole.
+func TestCheckWebhookInvalidSignatureRejected(t *testing.T) {
+	const clawID = "claw-check-webhook-badsig"
+	const headSHA = "6666666666666666666666666666666666666666"
+	s, db, _, calls := checkWebhookFixture(t, clawID, headSHA, allGreenCheckRuns)
+
+	payload, err := json.Marshal(checkWebhookBody("check_run", "completed", headSHA, 42))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/integrations/github/webhook", strings.NewReader(string(payload)))
+	req.Header.Set("X-GitHub-Event", "check_run")
+	req.Header.Set("X-Hub-Signature-256", signGitHubWebhookForReviewFeedback(payload, "wrong-secret"))
+	rr := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rr.Code)
+	}
+	time.Sleep(200 * time.Millisecond)
+	if got := calls.Load(); got != 0 {
+		t.Fatalf("GitHub calls = %d, want 0 for an unsigned delivery", got)
+	}
+	if msgs := ciMessages(t, db, clawID); len(msgs) != 0 {
+		t.Fatalf("messages = %v, want none", msgs)
+	}
+}

--- a/pkg/hub/github_check_webhook_test.go
+++ b/pkg/hub/github_check_webhook_test.go
@@ -304,3 +304,31 @@ func TestCheckWebhookInvalidSignatureRejected(t *testing.T) {
 		t.Fatalf("messages = %v, want none", msgs)
 	}
 }
+
+// T10: two live claws tracking the same PR are both woken by one delivery.
+// Each claw_prs row carries its own CI watermark, so taking only the newest row
+// would leave the other claw idle until the (possibly paused) poller caught up.
+func TestCheckWebhookWakesEveryClawTrackingThePR(t *testing.T) {
+	const clawID = "claw-check-webhook-multi-a"
+	const otherClawID = "claw-check-webhook-multi-b"
+	const headSHA = "77aa77aa77aa77aa77aa77aa77aa77aa77aa77aa"
+	s, db, _, _ := checkWebhookFixture(t, clawID, headSHA, allGreenCheckRuns)
+
+	if _, err := db.Exec(`INSERT INTO claws(id,tenant_id,name,template,provider,status,created_at) VALUES(?,?,?,?,?,?,?)`,
+		otherClawID, "test-tenant-id", otherClawID, "elasticclaw", "noop", "connected", now()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO claw_prs(id,claw_id,repo,pr_number,pr_url,created_at) VALUES(?,?,?,?,?,?)`,
+		"pr-"+otherClawID, otherClawID, "owner/repo", 42, "https://github.com/owner/repo/pull/42", now()); err != nil {
+		t.Fatal(err)
+	}
+
+	postSignedGitHubWebhook(t, s, "check_run", checkWebhookBody("check_run", "completed", headSHA, 42))
+
+	for _, id := range []string{clawID, otherClawID} {
+		waitForMessageContains(t, db, id, "hub", []string{"All CI checks passed on PR #42"})
+		if got := greenMessageCount(t, db, id); got != 1 {
+			t.Fatalf("green messages for %s = %d, want 1", id, got)
+		}
+	}
+}

--- a/pkg/hub/github_webhook.go
+++ b/pkg/hub/github_webhook.go
@@ -139,6 +139,17 @@ func (s *Server) handleGitHubWebhook(w http.ResponseWriter, r *http.Request) {
 				payload.Action, payload.Repository.FullName, payload.Issue.Number, payload.Comment.User.Login)
 			s.safeGo("github issue comment webhook", func() { s.processGitHubIssueComment(payload) })
 		}
+	case "check_run", "check_suite":
+		var payload githubCheckPayload
+		if err := json.Unmarshal(body, &payload); err != nil {
+			log.Printf("[github-webhook] failed to parse %s payload: %v", event, err)
+			http.Error(w, "invalid payload", http.StatusBadRequest)
+			return
+		}
+		headSHA, prNumbers, conclusion := payload.checkEventSummary(event)
+		log.Printf("[github-webhook] %s action=%q repo=%q sha=%q conclusion=%q prs=%d",
+			event, payload.Action, payload.Repository.FullName, headSHA, conclusion, len(prNumbers))
+		s.safeGo("github check webhook", func() { s.processGitHubCheckEvent(event, payload) })
 	case "ping":
 		log.Printf("[github-webhook] ping received — webhook configured correctly")
 	default:
@@ -415,6 +426,98 @@ type githubPRReviewPayload struct {
 	Repository struct {
 		FullName string `json:"full_name"`
 	} `json:"repository"`
+}
+
+// githubCheckPayload holds the fields we need from check_run and check_suite
+// webhook events. One struct serves both: the handler reads the sub-object that
+// matches the event name.
+type githubCheckPayload struct {
+	Action   string `json:"action"` // "completed", "created", "rerequested", "requested"
+	CheckRun struct {
+		Name         string `json:"name"`
+		Status       string `json:"status"`
+		Conclusion   string `json:"conclusion"`
+		HeadSHA      string `json:"head_sha"`
+		PullRequests []struct {
+			Number int `json:"number"`
+		} `json:"pull_requests"`
+	} `json:"check_run"`
+	CheckSuite struct {
+		Status       string `json:"status"`
+		Conclusion   string `json:"conclusion"`
+		HeadSHA      string `json:"head_sha"`
+		PullRequests []struct {
+			Number int `json:"number"`
+		} `json:"pull_requests"`
+	} `json:"check_suite"`
+	Repository struct {
+		FullName string `json:"full_name"`
+	} `json:"repository"`
+}
+
+// checkEventSummary extracts the head SHA, PR numbers and conclusion for the
+// sub-object matching the event name.
+func (p githubCheckPayload) checkEventSummary(event string) (headSHA string, prNumbers []int, conclusion string) {
+	if event == "check_suite" {
+		headSHA, conclusion = p.CheckSuite.HeadSHA, p.CheckSuite.Conclusion
+		for _, pr := range p.CheckSuite.PullRequests {
+			prNumbers = append(prNumbers, pr.Number)
+		}
+		return headSHA, prNumbers, conclusion
+	}
+	headSHA, conclusion = p.CheckRun.HeadSHA, p.CheckRun.Conclusion
+	for _, pr := range p.CheckRun.PullRequests {
+		prNumbers = append(prNumbers, pr.Number)
+	}
+	return headSHA, prNumbers, conclusion
+}
+
+// processGitHubCheckEvent turns a completed check_run/check_suite delivery into
+// an immediate CI re-evaluation for the tracked PR, so a claw waiting on CI is
+// woken in seconds instead of on the next poller tick (30s–5min).
+//
+// The event is only a *trigger*: the verdict itself always comes from
+// checkCIStatus, which re-reads the full check-run set for the head SHA. A
+// single green check_run says nothing about the sibling checks still running,
+// and the payload conclusion must never be used to announce green.
+//
+// Because both paths end in the same conditional UPDATE on claw_prs.id, the
+// webhook and the poller cannot double-notify the same (sha, conclusion): the
+// loser sees RowsAffected()==0 and returns silently. The poller therefore stays
+// as the fallback for missed or unsubscribed deliveries.
+func (s *Server) processGitHubCheckEvent(event string, payload githubCheckPayload) {
+	// Only terminal events can change the verdict; created/rerequested/requested
+	// would spend two GitHub API calls on a guaranteed no-op.
+	if payload.Action != "completed" {
+		return
+	}
+
+	headSHA, prNumbers, _ := payload.checkEventSummary(event)
+	repo := payload.Repository.FullName
+	// GitHub omits pull_requests when the head repository differs from the
+	// check's repository (notably fork PRs). Nothing to resolve then — the
+	// poller remains the fallback for those PRs.
+	if headSHA == "" || len(prNumbers) == 0 {
+		log.Printf("[github-webhook] %s completed repo=%q sha=%q — no pull_requests in payload, leaving it to the poller", event, repo, headSHA)
+		return
+	}
+
+	for _, number := range prNumbers {
+		pr, ok := s.loadClawPRByNumber(repo, number)
+		if !ok {
+			log.Printf("[github-webhook] %s completed on %s#%d — not an agent-tracked PR, ignored", event, repo, number)
+			continue
+		}
+		token := s.resolveGitHubTokenForRepo(pr.repo)
+		if token == "" {
+			token = s.resolveGitHubToken()
+		}
+		if token == "" {
+			log.Printf("[github-webhook] CRITICAL: GitHub token resolution failed; cannot check CI for %s#%d", repo, number)
+			return
+		}
+		s.checkCIStatus(pr, token)
+	}
 }
 
 func (s *Server) processGitHubPRReviewCommentEvent(payload githubPRReviewCommentPayload) {

--- a/pkg/hub/github_webhook.go
+++ b/pkg/hub/github_webhook.go
@@ -503,20 +503,25 @@ func (s *Server) processGitHubCheckEvent(event string, payload githubCheckPayloa
 	}
 
 	for _, number := range prNumbers {
-		pr, ok := s.loadClawPRByNumber(repo, number)
-		if !ok {
+		// A PR can be tracked by more than one live claw; the poller evaluates
+		// every row, so the webhook must too or the extra claws would only ever
+		// be woken by the (possibly paused) poller.
+		prs := s.loadClawPRsByNumber(repo, number)
+		if len(prs) == 0 {
 			log.Printf("[github-webhook] %s completed on %s#%d — not an agent-tracked PR, ignored", event, repo, number)
 			continue
 		}
-		token := s.resolveGitHubTokenForRepo(pr.repo)
-		if token == "" {
-			token = s.resolveGitHubToken()
+		for _, pr := range prs {
+			token := s.resolveGitHubTokenForRepo(pr.repo)
+			if token == "" {
+				token = s.resolveGitHubToken()
+			}
+			if token == "" {
+				log.Printf("[github-webhook] CRITICAL: GitHub token resolution failed; cannot check CI for %s#%d", repo, number)
+				continue
+			}
+			s.checkCIStatus(pr, token)
 		}
-		if token == "" {
-			log.Printf("[github-webhook] CRITICAL: GitHub token resolution failed; cannot check CI for %s#%d", repo, number)
-			return
-		}
-		s.checkCIStatus(pr, token)
 	}
 }
 

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -2,6 +2,7 @@ package hub
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -294,6 +295,36 @@ type clawPR struct {
 	lastReviewID        int64
 	prConditionsFired   bool
 	createdAt           string
+}
+
+// loadClawPRByNumber hydrates the tracked-PR row for a (repo, number) pair.
+//
+// checkCIStatus claims its verdict with a conditional UPDATE keyed on
+// claw_prs.id and skips work using the stored watermark, so the value-literal
+// clawPR built by the review-comment webhook handlers (which leaves id empty)
+// is not sufficient here — the row has to come from the database.
+func (s *Server) loadClawPRByNumber(repo string, prNumber int) (clawPR, bool) {
+	var pr clawPR
+	var prConditionsFiredInt int
+	err := s.db.QueryRow(`
+		SELECT cp.id, cp.claw_id, cp.repo, cp.pr_number, cp.pr_url, cp.last_ci_sha, cp.last_ci_conclusion, cp.last_comment_id,
+		       cp.last_comment_at, cp.last_review_comment_id, cp.last_review_id, cp.pr_conditions_fired, cp.created_at
+		FROM claw_prs cp
+		JOIN claws cl ON cl.id = cp.claw_id
+		WHERE cp.repo = ? AND cp.pr_number = ? AND cl.status NOT IN ('deleted','error','offline')
+		ORDER BY cp.created_at DESC
+		LIMIT 1
+	`, repo, prNumber).Scan(&pr.id, &pr.clawID, &pr.repo, &pr.prNumber, &pr.prURL,
+		&pr.lastCISHA, &pr.lastCIConclusion, &pr.lastCommentID, &pr.lastCommentAt,
+		&pr.lastReviewCommentID, &pr.lastReviewID, &prConditionsFiredInt, &pr.createdAt)
+	if err != nil {
+		if !errors.Is(err, sql.ErrNoRows) {
+			log.Printf("[pr-watcher] failed to load tracked PR %s#%d: %v", repo, prNumber, err)
+		}
+		return clawPR{}, false
+	}
+	pr.prConditionsFired = prConditionsFiredInt == 1
+	return pr, true
 }
 
 func (s *Server) pollAllPRs() {

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -2,7 +2,6 @@ package hub
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -297,34 +296,47 @@ type clawPR struct {
 	createdAt           string
 }
 
-// loadClawPRByNumber hydrates the tracked-PR row for a (repo, number) pair.
+// loadClawPRsByNumber hydrates every tracked-PR row for a (repo, number) pair
+// that belongs to a live claw — the same set pollAllPRs would visit, restricted
+// to one PR. More than one claw can track the same PR, and each row carries its
+// own CI watermark, so all of them have to be evaluated.
 //
 // checkCIStatus claims its verdict with a conditional UPDATE keyed on
 // claw_prs.id and skips work using the stored watermark, so the value-literal
 // clawPR built by the review-comment webhook handlers (which leaves id empty)
-// is not sufficient here — the row has to come from the database.
-func (s *Server) loadClawPRByNumber(repo string, prNumber int) (clawPR, bool) {
-	var pr clawPR
-	var prConditionsFiredInt int
-	err := s.db.QueryRow(`
+// is not sufficient here — the rows have to come from the database.
+func (s *Server) loadClawPRsByNumber(repo string, prNumber int) []clawPR {
+	rows, err := s.db.Query(`
 		SELECT cp.id, cp.claw_id, cp.repo, cp.pr_number, cp.pr_url, cp.last_ci_sha, cp.last_ci_conclusion, cp.last_comment_id,
 		       cp.last_comment_at, cp.last_review_comment_id, cp.last_review_id, cp.pr_conditions_fired, cp.created_at
 		FROM claw_prs cp
 		JOIN claws cl ON cl.id = cp.claw_id
 		WHERE cp.repo = ? AND cp.pr_number = ? AND cl.status NOT IN ('deleted','error','offline')
 		ORDER BY cp.created_at DESC
-		LIMIT 1
-	`, repo, prNumber).Scan(&pr.id, &pr.clawID, &pr.repo, &pr.prNumber, &pr.prURL,
-		&pr.lastCISHA, &pr.lastCIConclusion, &pr.lastCommentID, &pr.lastCommentAt,
-		&pr.lastReviewCommentID, &pr.lastReviewID, &prConditionsFiredInt, &pr.createdAt)
+	`, repo, prNumber)
 	if err != nil {
-		if !errors.Is(err, sql.ErrNoRows) {
-			log.Printf("[pr-watcher] failed to load tracked PR %s#%d: %v", repo, prNumber, err)
-		}
-		return clawPR{}, false
+		log.Printf("[pr-watcher] failed to load tracked PR %s#%d: %v", repo, prNumber, err)
+		return nil
 	}
-	pr.prConditionsFired = prConditionsFiredInt == 1
-	return pr, true
+	defer rows.Close()
+
+	var prs []clawPR
+	for rows.Next() {
+		var pr clawPR
+		var prConditionsFiredInt int
+		if err := rows.Scan(&pr.id, &pr.clawID, &pr.repo, &pr.prNumber, &pr.prURL,
+			&pr.lastCISHA, &pr.lastCIConclusion, &pr.lastCommentID, &pr.lastCommentAt,
+			&pr.lastReviewCommentID, &pr.lastReviewID, &prConditionsFiredInt, &pr.createdAt); err != nil {
+			log.Printf("[pr-watcher] failed to scan tracked PR %s#%d: %v", repo, prNumber, err)
+			return prs
+		}
+		pr.prConditionsFired = prConditionsFiredInt == 1
+		prs = append(prs, pr)
+	}
+	if err := rows.Err(); err != nil {
+		log.Printf("[pr-watcher] failed to iterate tracked PRs %s#%d: %v", repo, prNumber, err)
+	}
+	return prs
 }
 
 func (s *Server) pollAllPRs() {


### PR DESCRIPTION
> ### ⚠️ Stacked PR — merge order matters
>
> This PR is **stacked on #562** and targets `fix/ci-status-wakeup`, **not `main`**. It must merge **after** #562.
>
> Recommended landing order for the three related PRs:
>
> 1. **#561** — `fix(hub): stop the PR watcher from exhausting the GitHub App quota`
> 2. **#562** — `fix(hub): wake idle claws when CI turns green`
> 3. **this PR**
>
> #561 first, because it is what makes this PR necessary rather than merely nice.

> ### 🚨 Operator action required — without it this code is inert
>
> Nothing in this repository declares the webhook subscription, so **no code change enables delivery**. In the GitHub App settings an operator must:
>
> 1. Add the **Checks: Read-only** repository permission.
> 2. Subscribe to the **Check run** and **Check suite** events.
> 3. Have an org owner **approve the new permission on each installation** — GitHub does not apply added permissions retroactively; installations stay on the old permission set until approved.
>
> Until all three are done, zero check events arrive, `processGitHubCheckEvent` is never called, and the poller from #562 remains the only path. That is the safe failure mode: both paths converge on the same conditional claim, so the feature being switched off changes latency and nothing else.

---

## Why

After #561 the PR watcher no longer polls on a fixed fast cadence: the interval floats between **30s and 5min** under quota pressure, and in the degraded mode it drops to **merge-detection only**, pausing check-run polling entirely. That is the right call for quota, but it means CI results reach a waiting agent slowly — and in the degraded mode they can stop reaching it altogether.

That is not hypothetical. In the **NEXT-509** incident, claw `b1b53952` sat idle for **7 hours** on `next_mobile#238` with every check green. The work was done; nothing told the agent.

This PR makes CI results **push-based**. GitHub already knows the instant a check completes and will tell us for free, so we stop paying API quota to discover it by asking repeatedly. Latency goes from 30s–5min (or never, in degraded mode) to **seconds**, at **zero quota cost** on the delivery itself. Polling is unchanged and remains the fallback for missed deliveries, fork PRs, and any installation where the subscription above has not been approved.

## What changed

**`pkg/hub/github_webhook.go`**

- `githubCheckPayload` — one struct for both `check_run` and `check_suite`; `checkEventSummary(event)` returns `(headSHA, prNumbers, conclusion)` from whichever sub-object matches the event name.
- New `case "check_run", "check_suite":` in the dispatch switch, placed **after** the existing shared HMAC-SHA256 verification, so signature handling is untouched and shared. The handler runs under `s.safeGo`.
- `processGitHubCheckEvent(event, payload)` — returns on `action != "completed"`; returns with a log when `head_sha` or `pull_requests` is empty (GitHub omits `pull_requests` for fork PRs; the poller stays the fallback there); otherwise, per PR number, loads the tracked rows, resolves a repo-scoped token with the unscoped token as fallback, and calls `s.checkCIStatus(pr, token)`.

**`pkg/hub/pr_watcher.go`**

- `loadClawPRsByNumber(repo, prNumber) []clawPR` — the same column set, JOIN and `cl.status NOT IN ('deleted','error','offline')` filter as `pollAllPRs`, scoped to one PR. Needed because the claim keys on `claw_prs.id`, and the value-literal `clawPR` the review-comment handlers build leaves `id` empty.

No schema change. No change to `startPRWatcher`, to avoid conflicting with #561's file region.

### The key property: the event is a trigger, never a verdict

`processGitHubCheckEvent` **discards the payload's conclusion**. A single green `check_run` says nothing about the sibling checks still running, so the verdict always comes from `checkCIStatus` re-reading the full check-run set for the current head SHA — which bails if any run is non-completed or the set is empty.

Both the webhook and the poller then end in the *same* conditional claim:

```sql
UPDATE claw_prs SET last_ci_sha=?, last_ci_conclusion=? WHERE id=? AND NOT (last_ci_sha=? AND last_ci_conclusion=?)
```

SQLite serializes the writes; the loser sees `RowsAffected()==0` and injects nothing. **Double-notification is structurally impossible rather than defended against**, and there is no in-memory dedup that would break the guarantee across multiple hub processes.

## Tests

`pkg/hub/github_check_webhook_test.go` (new) — 10 tests. The fixture composes `githubAppTokenTransport` (token resolution without reaching api.github.com), a factory carrying a test webhook secret, and a call-counting GitHub stub wired through `githubBaseURL`.

- Green `check_run` wakes once and advances the watermark; green `check_suite` takes the same path.
- Duplicate delivery notifies exactly once.
- **Webhook-then-stale-poller does not double-notify** — the regression test that matters.
- A partial suite with a sibling `in_progress` produces zero messages and leaves the watermark at `('','')`.
- A `cancelled` sibling produces the failure message and never the green one.
- Two live claws tracking the same PR both get exactly one green message from one delivery.
- `action=created`, empty `pull_requests`, and an untracked PR number each make **zero** GitHub API calls.
- An invalid signature gets 401 with zero API calls and zero messages.

```
go build ./...                                                              clean
go vet ./pkg/hub/                                                           clean
go test ./pkg/hub/ -run 'CheckWebhook|CheckSuiteWebhook|CI' -race -count=1   ok
go test ./pkg/hub/... -count=1                                              ok (all 4 packages)
go test ./... -count=1                                                      no failures
```

## Review findings applied

- **Only the newest tracked row was woken.** `loadClawPRByNumber` used `ORDER BY created_at DESC LIMIT 1`, so when two live claws tracked the same PR only one was woken. The review called this benign because the poller covered the other claw — but under #561's degraded mode that fallback can be paused, so it is no longer benign. Replaced with `loadClawPRsByNumber`, matching `pollAllPRs`' semantics, plus a regression test.
- **Token-resolution failure abandoned the rest of the delivery.** `return` inside the per-PR loop is now `continue`.

## Known limitations (accepted, documented)

- **Premature green from a check-registration gap.** `checkCIStatus` correctly refuses to call green while any registered run is incomplete, but if a fast check completes before a slower CI app has *registered* its runs for the SHA, the list contains only completed runs. GitHub Actions registers at queue time so this is mostly closed intra-Actions; mixed providers (Actions + Depot + CodeRabbit) have a real gap. **Pre-existing in #562's poller** — the webhook raises the probability because it fires precisely at completion instants. It self-corrects with a follow-up failure message, but a false green wake can make an agent proceed. Not blocking; worth revisiting if observed.
- **A narrow ABA window on the claim.** The claim excludes only the exact `(sha, conclusion)` pair — it carries no freshness ordering. If a push lands between a webhook goroutine's head-SHA read and its `UPDATE`, and a concurrent poll fully processes the *new* SHA inside that sub-second window, the webhook can overwrite the newer verdict with the older one; the next poll then re-claims and re-notifies. The window is one API round-trip and the poller floor is 30s, so it is very unlikely to fire. A real fix means comparing against the live head at claim time, which is not cleanly expressible in the current schema — not worth holding this PR for.
- **No `repo#number@sha` coalescer.** A repo with N workflows fires N `check_run` events per SHA; the first N−1 spend 2 API calls each on an early return. Subscribing to **`check_suite` as the primary trigger** keeps this bounded, which is why the operator note above lists both. Cost per completed event on a tracked PR is 2 calls (1 once the success watermark is set). Worth measuring before adding a debounce primitive that does not exist in `pkg/hub` yet.
- **Test-hygiene nit, not fixed:** the fixture swaps `http.DefaultTransport` process-wide (restored via `t.Cleanup`). Safe today because none of these tests call `t.Parallel`; it would need rework if that changes.

## Note on the base branch

The green-classification fix `fd2f5f6` (`fix(hub): never report a non-green CI conclusion as passing` — a completed `cancelled`/`action_required`/`stale`/`startup_failure` run would previously have been announced as "all checks passed") was authored alongside this work but **already landed on `fix/ci-status-wakeup`**, so it is part of #562 and is *not* in this PR's diff. Flagging it because it is a genuine behavior change and should be reviewed as part of #562 rather than assumed pre-existing.

## Incident

- NEXT-509 — claw `b1b53952` idle 7h on `next_mobile#238` with all checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
