### PR TITLE
fix(hub): validate template file paths before wiping the template dir

### DIFF
--- a/pkg/hub/daytona_workspace_files_test.go
+++ b/pkg/hub/daytona_workspace_files_test.go
@@ -73,7 +73,6 @@ func TestSaveExternalTemplatePreservesNestedFiles(t *testing.T) {
 		"scripts/detect_android_changes.py":     "print('hi')",
 		"scripts/review-loop/reviewers/arch.md": "reviewer",
 		"memory/notes.md":                       "note",
-		"../escape.md":                          "nope",
 	}
 	if err := saveExternalTemplate("faster", files); err != nil {
 		t.Fatalf("saveExternalTemplate: %v", err)
@@ -93,8 +92,5 @@ func TestSaveExternalTemplatePreservesNestedFiles(t *testing.T) {
 		if _, ok := got[name]; !ok {
 			t.Errorf("template files missing %s (got %v)", name, sortedWorkspaceFileNames(got))
 		}
-	}
-	if _, ok := got["escape.md"]; ok {
-		t.Error("traversal path must not be written")
 	}
 }

--- a/pkg/hub/external_storage.go
+++ b/pkg/hub/external_storage.go
@@ -3,7 +3,6 @@ package hub
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -134,6 +133,27 @@ func saveExternalTemplate(name string, files map[string]string) error {
 	if err := validateName(name); err != nil {
 		return err
 	}
+	// Validate every key before touching the filesystem. The save below wipes the
+	// existing template directory, so a bad key cannot be skipped: dropping it
+	// after the wipe would destroy the previously stored template and persist a
+	// silently truncated one while still reporting success. Nested files
+	// (memory/**, scripts/**) must survive a push, so cleanWorkspaceFilePath
+	// keeps them and rejects only unusable keys: paths that escape the template
+	// dir, and empty or otherwise invalid names.
+	safeNames := make(map[string]string, len(files))
+	fnames := make([]string, 0, len(files))
+	for fname := range files {
+		fnames = append(fnames, fname)
+	}
+	sort.Strings(fnames)
+	for _, fname := range fnames {
+		safeName, err := cleanWorkspaceFilePath(fname)
+		if err != nil {
+			return fmt.Errorf("invalid template file path %q for %s: %w", fname, name, err)
+		}
+		safeNames[fname] = safeName
+	}
+
 	dir := filepath.Join(templatesDir(), name)
 	// Remove and recreate the directory so stale files from previous pushes
 	// are not re-read by ReadTemplateFiles (which walks the memory/ subtree).
@@ -144,17 +164,7 @@ func saveExternalTemplate(name string, files map[string]string) error {
 		return fmt.Errorf("mkdir %s: %w", dir, err)
 	}
 	for fname, content := range files {
-		// Nested files (memory/**, scripts/**) must survive a template push, so
-		// only reject paths that would escape the template dir.
-		// Note the asymmetry with bootstrapDaytona, which hard-fails on an invalid
-		// path: here a bad key is a client input we can safely drop at push time,
-		// while at bootstrap the same key means the claw would start with a file
-		// its workflows expect missing.
-		safeName, err := cleanWorkspaceFilePath(fname)
-		if err != nil {
-			log.Printf("[templates] skipping invalid template file path %q for %s: %v", fname, name, err)
-			continue
-		}
+		safeName := safeNames[fname]
 		path := filepath.Join(dir, filepath.FromSlash(safeName))
 		if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil {
 			return fmt.Errorf("mkdir for template file %s: %w", safeName, err)

--- a/pkg/hub/external_storage_template_test.go
+++ b/pkg/hub/external_storage_template_test.go
@@ -1,0 +1,51 @@
+package hub
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/elasticclaw/elasticclaw/pkg/config"
+)
+
+// A push carrying one unsafe key must be rejected outright. Before this, the
+// template directory was wiped before any key was validated, so a single bad
+// key destroyed the stored template and left a silently truncated one behind
+// while saveExternalTemplate still returned nil.
+func TestSaveExternalTemplateRejectsInvalidPathBeforeWipe(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", filepath.Join(t.TempDir(), "hub.yaml"))
+
+	good := map[string]string{
+		"AGENTS.md":       "agents",
+		"memory/notes.md": "note",
+	}
+	if err := saveExternalTemplate("faster", good); err != nil {
+		t.Fatalf("saveExternalTemplate (initial): %v", err)
+	}
+
+	bad := map[string]string{
+		"AGENTS.md":    "replaced",
+		"../escape.md": "nope",
+	}
+	err := saveExternalTemplate("faster", bad)
+	if err == nil {
+		t.Fatal("saveExternalTemplate succeeded, want invalid path error")
+	}
+	if !strings.Contains(err.Error(), "../escape.md") {
+		t.Errorf("error = %v, want it to name the offending key %q", err, "../escape.md")
+	}
+
+	dir := filepath.Join(templatesDir(), "faster")
+	got, err := config.ReadTemplateFiles(dir)
+	if err != nil {
+		t.Fatalf("ReadTemplateFiles: %v", err)
+	}
+	for name, want := range good {
+		if got[name] != want {
+			t.Errorf("template file %s = %q, want %q (previous template must survive a rejected push)", name, got[name], want)
+		}
+	}
+	if _, ok := got["escape.md"]; ok {
+		t.Error("traversal path must not be written")
+	}
+}


### PR DESCRIPTION
## The bug

`saveExternalTemplate` wiped the stored template **before** validating a single filename.

The order was: `validateName(name)` → `os.RemoveAll(dir)` → `os.MkdirAll(dir)` → loop over `files`, calling `cleanWorkspaceFilePath` on each key and `log.Printf` + `continue` on a bad one.

So a push whose `files` map carried one unsafe key (`"../escape.md"`) had already destroyed the previously stored template by the time that key was checked. The bad key was skipped, the remaining keys were written into the now-empty directory, and the function **returned `nil`**. Net effect: the old template was gone, a silently truncated template was persisted in its place, and the caller was told the push succeeded.

The comment sitting on the skip claimed a bad key "is a client input we can safely drop at push time" — that was only true before the directory wipe was introduced.

## The fix

Validate every key with `cleanWorkspaceFilePath` before the first filesystem mutation:

- Keys are collected and `sort.Strings`-ed so that, with several invalid keys, the one named in the error is deterministic rather than whatever Go's randomized map iteration reached first.
- The first invalid key returns `fmt.Errorf("invalid template file path %q for %s: %w", ...)`. Nothing has been removed or created at that point, so the stored template is byte-for-byte intact.
- The write loop reuses the pre-computed `safeNames` map — no second validation, no `continue`, no silent drop.
- Nested files (`memory/**`, `scripts/**`) still round-trip; only keys that escape the template dir or are otherwise unusable are rejected.
- `log` dropped from the imports (that `log.Printf` was its only use in the file).

### Caller-visible behaviour change

Two callers, one worth flagging for operators:

- `pkg/hub/templates.go` (HTTP template push): a push with a bad key now fails with an error instead of silently truncating the template. Intended.
- `MigrateLegacyTemplates` → `cmd/hub.go`: a legacy DB row with a bad file key now **aborts hub startup** with a named error instead of migrating as a silently truncated template. The legacy table is preserved, so no data is lost and the migration can be retried after the row is fixed. This trades availability for integrity deliberately, but it is a real operational change.

## Tests

New `pkg/hub/external_storage_template_test.go` — `TestSaveExternalTemplateRejectsInvalidPathBeforeWipe` saves a good template, pushes one carrying `"../escape.md"`, and asserts (a) an error is returned, (b) the error names the offending key, (c) the previously stored template survives unchanged, (d) the traversal file was not written. Verified to **fail** against unmodified `external_storage.go` on `main` (e5ab554) and pass with the fix.

`TestSaveExternalTemplatePreservesNestedFiles` had to change: it passed `"../escape.md"` in an otherwise-valid map and asserted `saveExternalTemplate` returned `nil` while dropping that key — i.e. it asserted exactly the behaviour being fixed. The traversal key and its assertion were removed; that case is now covered properly by the new regression test.

`go build ./...`, `go vet ./pkg/hub/` and `go test ./pkg/hub/ -count=1` all pass.

## `saveExternalWorkspace` assessment (reported, not changed here)

`pkg/hub/external_storage.go` — it shares the destructive-before-validate ordering, but the blast radius is smaller.

Sequence: `validateWorkspaceName` → `workspace.Validate()` → `MkdirAll` → `removeWorkspaceAuthoredFiles(dir)` → write config → loop over `workspace.Files` with an inline `strings.Contains(name, "..")` skip. So the per-key check again happens after the delete, and a bad key is silently `continue`d.

Two things blunt it:

1. `removeWorkspaceAuthoredFiles` is selective — it preserves `workflows/` and the workspace-managed dir rather than `RemoveAll`-ing everything. But every other top-level authored file is still removed and not rewritten, so a workspace whose map carries one `..` key ends up with a silent partial write returning nil. Same class, narrower.
2. The `..` substring check both over-rejects harmless names (`a..b.md`) and misses cases `cleanWorkspaceFilePath` catches (NUL bytes, whitespace-only names, leading `/`).

Follow-up PR, not this one: hoist path validation above `removeWorkspaceAuthoredFiles`, swap the inline `strings.Contains` for `cleanWorkspaceFilePath`, and keep the `workflows/` / `workspace.yaml` / `elasticclaw-config.yaml` skips as a separate filter in the write loop — they are intentional filtering, not validation, so a straight port of this fix would conflate the two concerns.

## Reviews

**CodeRabbit ran clean — it was not rate-limited.** Exit 0, no `rate_limit` in the stream. It reported **0 findings**: the review ran in a sibling worktree whose HEAD was identical to `origin/main` with no working-tree changes, so it reported "No changes detected" and skipped. No out-of-scope findings were produced, so there is nothing parked here.

An independent review of the diff verified all claims empirically and approved. Its two non-blocking nits were applied: the duplicated nested-files round-trip test was dropped (the pre-existing one already covers it), and the new comment no longer implies path escape is the only rejection reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
