### PR TITLE
fix(claw-bridge): skip non-regular files instead of aborting checkpoints

### DIFF
--- a/cmd/claw-bridge/checkpoint.go
+++ b/cmd/claw-bridge/checkpoint.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -125,6 +126,14 @@ func collectCheckpointFiles() ([]checkpointLocalFile, error) {
 		{filepath.Join(home, ".openclaw", "agents"), ".openclaw/agents"},
 	}
 	var out []checkpointLocalFile
+	skipped := 0
+	firstSkipped := ""
+	noteSkipped := func(path string) {
+		skipped++
+		if firstSkipped == "" {
+			firstSkipped = path
+		}
+	}
 	for _, root := range roots {
 		info, err := os.Lstat(root.base)
 		if os.IsNotExist(err) {
@@ -135,6 +144,10 @@ func collectCheckpointFiles() ([]checkpointLocalFile, error) {
 		}
 		if !info.IsDir() {
 			f, err := checkpointFile(root.base, root.label, info)
+			if errors.Is(err, errNotRegularFile) {
+				noteSkipped(root.base)
+				continue
+			}
 			if err != nil {
 				return nil, err
 			}
@@ -164,6 +177,10 @@ func collectCheckpointFiles() ([]checkpointLocalFile, error) {
 			}
 			rel = filepath.ToSlash(filepath.Join(root.label, rel))
 			f, err := checkpointFile(path, rel, info)
+			if errors.Is(err, errNotRegularFile) {
+				noteSkipped(path)
+				return nil
+			}
 			if err != nil {
 				return err
 			}
@@ -173,6 +190,9 @@ func collectCheckpointFiles() ([]checkpointLocalFile, error) {
 		if err != nil {
 			return nil, err
 		}
+	}
+	if skipped > 0 {
+		log.Printf("[checkpoint] skipped %d non-regular file(s) (symlink/socket/fifo/device), first: %s", skipped, firstSkipped)
 	}
 	return out, nil
 }
@@ -196,9 +216,13 @@ func checkpointExclude(path string, d os.DirEntry) bool {
 	return false
 }
 
+// errNotRegularFile marks entries a checkpoint cannot capture (symlinks, sockets,
+// fifos, devices). Callers skip them instead of aborting the whole snapshot.
+var errNotRegularFile = errors.New("not a regular file")
+
 func checkpointFile(abs, rel string, info os.FileInfo) (checkpointLocalFile, error) {
 	if !info.Mode().IsRegular() {
-		return checkpointLocalFile{}, fmt.Errorf("not a regular file: %s", abs)
+		return checkpointLocalFile{}, fmt.Errorf("%w: %s", errNotRegularFile, abs)
 	}
 	f, err := os.Open(abs)
 	if err != nil {

--- a/cmd/claw-bridge/checkpoint_test.go
+++ b/cmd/claw-bridge/checkpoint_test.go
@@ -57,3 +57,70 @@ func TestCollectCheckpointFilesExcludesSessionsAndAuthProfiles(t *testing.T) {
 		t.Errorf("session files should be excluded from checkpoints")
 	}
 }
+
+func TestCollectCheckpointFilesSkipsSymlinks(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	workspace := filepath.Join(tmpDir, ".openclaw", "workspace", "next_mobile")
+	if err := os.MkdirAll(workspace, 0o700); err != nil {
+		t.Fatalf("mkdir %s: %v", workspace, err)
+	}
+	target := filepath.Join(workspace, "AGENTS.md")
+	if err := os.WriteFile(target, []byte("# agents"), 0o600); err != nil {
+		t.Fatalf("write %s: %v", target, err)
+	}
+	if err := os.Symlink(target, filepath.Join(workspace, "CLAUDE.md")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	got, err := collectCheckpointFiles()
+	if err != nil {
+		t.Fatalf("collectCheckpointFiles: %v", err)
+	}
+
+	byPath := map[string]bool{}
+	for _, f := range got {
+		byPath[f.entry.Path] = true
+	}
+
+	if !byPath["workspace/next_mobile/AGENTS.md"] {
+		t.Errorf("expected regular file to be checkpointed, got paths: %v", byPath)
+	}
+	if byPath["workspace/next_mobile/CLAUDE.md"] {
+		t.Errorf("symlink should be skipped, got paths: %v", byPath)
+	}
+}
+
+func TestCollectCheckpointFilesSkipsDanglingSymlink(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	workspace := filepath.Join(tmpDir, ".openclaw", "workspace")
+	if err := os.MkdirAll(workspace, 0o700); err != nil {
+		t.Fatalf("mkdir %s: %v", workspace, err)
+	}
+	if err := os.WriteFile(filepath.Join(workspace, "main.go"), []byte("package main"), 0o600); err != nil {
+		t.Fatalf("write main.go: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(tmpDir, "gone.md"), filepath.Join(workspace, "broken.md")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	got, err := collectCheckpointFiles()
+	if err != nil {
+		t.Fatalf("collectCheckpointFiles: %v", err)
+	}
+
+	byPath := map[string]bool{}
+	for _, f := range got {
+		byPath[f.entry.Path] = true
+	}
+
+	if !byPath["workspace/main.go"] {
+		t.Errorf("expected regular file to be checkpointed, got paths: %v", byPath)
+	}
+	if byPath["workspace/broken.md"] {
+		t.Errorf("dangling symlink should be skipped, got paths: %v", byPath)
+	}
+}


### PR DESCRIPTION
## The numbers

**27,092 failed checkpoints vs 63 ready — a 99.8% failure rate.**

The cause is a single line. `collectCheckpointFiles` walks the checkpointed roots with `filepath.WalkDir`, and `checkpointFile` returned a hard error for anything that is not a regular file:

```go
if !info.Mode().IsRegular() {
    return checkpointLocalFile{}, fmt.Errorf("not a regular file: %s", abs)
}
```

`WalkDir` propagates that error, so **one symlink anywhere under the tree aborts the entire walk** and the whole snapshot fails. The production `claw_checkpoints.error` rows show exactly this, e.g. a `CLAUDE.md` symlinked next to the real file:

```
not a regular file: /home/openclaw/.openclaw/workspace/next_mobile/CLAUDE.md
```

This is why **dead sandboxes are unrecoverable**: there is no usable checkpoint to restore from. It is also why **`[claw-retry]` logs show an empty checkpoint** — the retry path finds nothing to restore because nothing was ever successfully captured.

**#559 is already deployed and did not fix this.** It addressed a different failure mode; the walk still aborts on the first non-regular entry.

## The fix

`checkpointFile` now returns a wrapped sentinel:

```go
// errNotRegularFile marks entries a checkpoint cannot capture (symlinks, sockets,
// fifos, devices). Callers skip them instead of aborting the whole snapshot.
var errNotRegularFile = errors.New("not a regular file")
```

Both call sites in `collectCheckpointFiles` test it with `errors.Is`, count the entry as skipped, and continue:

- the **non-directory root case** (a symlinked `.openclaw/openclaw.json`), which `checkpointExclude` never sees at all;
- the **`WalkDir` callback**.

A single `log.Printf` after all roots reports the total plus the first offending path, so a skip is never silent.

### Why the sentinel, and not `checkpointExclude`

`checkpointExclude(path, d)` answers a policy question — "is this path one we deliberately do not capture?" Non-regular-ness is a property of the entry's *mode*, not its name; folding it in would make the exclusion list return true for things it was never asked about, and it would not cover the non-directory root case. The sentinel keeps the single source of truth for "can this be captured" inside `checkpointFile`, where the mode is already inspected, and lets each caller decide the policy.

### Symlinks are skipped, never followed

Following them is unsafe and cannot be made safe cheaply. Capturing a target means resolving it and *proving* the result is inside the workspace root: `EvalSymlinks` on the target, `EvalSymlinks` on the root (the sandbox home may itself sit behind a symlink, so a raw prefix compare gives both false accepts and false rejects), then a boundary-safe compare that a `/workspace-old` sibling cannot fool. Every mistake in that chain writes host files — `/etc/*`, `~/.ssh/*`, another claw's directory — into a blob that is uploaded to the hub and restored into a *different* sandbox. That is a data-exfiltration bug with a far worse blast radius than the thing it buys.

What it buys is small: the workspace is a git checkout, an in-workspace symlink points at a file that is already captured on its own, and following it would duplicate content and silently turn a link into a regular file on restore. **Residual cost, stated honestly:** a restored tree comes back without its symlinks. For the incident at hand that is trivial against a run that currently dies outright. If symlink topology ever needs to survive restore, the right fix is a first-class entry type in `types.CheckpointFile` recreated via `os.Symlink` — never reading through the link.

### Scope

Only the walk is hardened. Genuine I/O failures (`walkErr`, `d.Info()`, `os.Open`, `io.Copy`) still abort the checkpoint, which is deliberate — a mid-walk disappearance or an unreadable file is a different failure mode and left alone to keep the diff minimal.

## Evidence: the tests fail without the fix

`cmd/claw-bridge/checkpoint.go` was reverted to `origin/main` while keeping the new test file, then the tests were run:

```
=== RUN   TestCollectCheckpointFilesSkipsSymlinks
    checkpoint_test.go:79: collectCheckpointFiles: not a regular file: .../.openclaw/workspace/next_mobile/CLAUDE.md
--- FAIL: TestCollectCheckpointFilesSkipsSymlinks (0.01s)
=== RUN   TestCollectCheckpointFilesSkipsDanglingSymlink
    checkpoint_test.go:112: collectCheckpointFiles: not a regular file: .../.openclaw/workspace/broken.md
--- FAIL: TestCollectCheckpointFilesSkipsDanglingSymlink (0.00s)
FAIL
```

The failure message reproduces the production error verbatim, including the `next_mobile/CLAUDE.md` shape from `claw_checkpoints.error`. With the fix restored:

```
=== RUN   TestCollectCheckpointFilesExcludesSessionsAndAuthProfiles
--- PASS: TestCollectCheckpointFilesExcludesSessionsAndAuthProfiles (0.01s)
=== RUN   TestCollectCheckpointFilesSkipsSymlinks
[checkpoint] skipped 1 non-regular file(s) (symlink/socket/fifo/device), first: .../workspace/next_mobile/CLAUDE.md
--- PASS: TestCollectCheckpointFilesSkipsSymlinks (0.00s)
=== RUN   TestCollectCheckpointFilesSkipsDanglingSymlink
[checkpoint] skipped 1 non-regular file(s) (symlink/socket/fifo/device), first: .../workspace/broken.md
--- PASS: TestCollectCheckpointFilesSkipsDanglingSymlink (0.00s)
PASS
ok  	github.com/elasticclaw/elasticclaw/cmd/claw-bridge	0.893s
```

The tests assert *content*, not merely absence of error: the sibling regular file must be present and the symlink absent. The dangling case matters because `d.Info()` succeeds via lstat while any `os.Open` of the target would not.

`go build ./...`, `go vet ./cmd/claw-bridge/` and `go test ./cmd/claw-bridge/ -count=1` all pass.

## Review

**CodeRabbit ran clean** — a real review completed, with **0 findings**. It was not rate-limited and did not report "no changes detected".

- Command: `coderabbit review --agent --base main`
- Completion line: `{"type":"complete","status":"review_completed","findings":0,"reviewedFiles":["cmd/claw-bridge/checkpoint.go","cmd/claw-bridge/checkpoint_test.go"]}`
- Reviewed files match `git diff --name-only` 1:1, so there are **no out-of-scope findings** in files this change does not touch.
- Caveat (not a failure): the run used the free CLI allowance — CodeRabbit reported the repo is not connected to an accessible CodeRabbit organization, so depth may be lower than an org-plan review.

An independent review verified the failure-on-main claim by the same file-swap method and requested no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
