### PR TITLE
feat: surface pipeline step output and preserve chat scrollback

### DIFF
--- a/pkg/hub/dependency_updates.go
+++ b/pkg/hub/dependency_updates.go
@@ -350,6 +350,60 @@ func formatDependencyUpdateFailure(result *pipelineRunResult) string {
 	return "Dependency update step failed: " + combined
 }
 
+// formatDependencyUpdateSummary returns a concise, human-readable summary of a
+// successful dependency update run based on the JSON result document emitted by
+// the dependency update script. It is surfaced in the web UI so users can see
+// what the step did without reading the full structured output.
+func formatDependencyUpdateSummary(result *pipelineRunResult) string {
+	if result == nil {
+		return "Dependency updates completed"
+	}
+	combined := strings.TrimSpace(result.Stdout)
+	if combined == "" {
+		return "Dependency updates completed"
+	}
+
+	var output struct {
+		Ecosystems []string `json:"ecosystems"`
+		Manifests  []struct {
+			Ecosystem string `json:"ecosystem"`
+			Path      string `json:"path"`
+		} `json:"manifests"`
+		Updates []struct {
+			Applied bool `json:"applied"`
+		} `json:"updates"`
+		FilesChanged []string `json:"files_changed"`
+	}
+	if doc := lastJSONObject(combined); doc != nil {
+		_ = json.Unmarshal(doc, &output)
+	}
+
+	applied := 0
+	skipped := 0
+	for _, update := range output.Updates {
+		if update.Applied {
+			applied++
+		} else {
+			skipped++
+		}
+	}
+
+	parts := []string{"Dependency updates completed"}
+	if len(output.Ecosystems) > 0 {
+		parts = append(parts, fmt.Sprintf("%d ecosystem(s)", len(output.Ecosystems)))
+	}
+	if len(output.Manifests) > 0 {
+		parts = append(parts, fmt.Sprintf("%d manifest(s)", len(output.Manifests)))
+	}
+	if applied > 0 || skipped > 0 {
+		parts = append(parts, fmt.Sprintf("%d applied, %d skipped", applied, skipped))
+	}
+	if len(output.FilesChanged) > 0 {
+		parts = append(parts, fmt.Sprintf("%d file(s) changed", len(output.FilesChanged)))
+	}
+	return strings.Join(parts, ": ")
+}
+
 // lastJSONObject returns the last valid JSON object in s, or nil if none is found.
 // It is used to extract the dependency update result document from output that may
 // contain non-JSON banners or log lines before or after the JSON.
@@ -398,6 +452,7 @@ def enabled_ecosystems():
 
 ECOSYSTEMS = enabled_ecosystems()
 result["ecosystems"] = sorted(ECOSYSTEMS)
+print(f"Starting dependency updates for ecosystem(s): {', '.join(result['ecosystems'])}", file=sys.stderr)
 
 def rel(path):
     return path.relative_to(ROOT).as_posix()
@@ -437,6 +492,10 @@ def update_record(ecosystem, name, from_version, to_version, kind, applied, grou
     if skipped_reason:
         record["skipped_reason"] = skipped_reason
     result["updates"].append(record)
+    if applied:
+        print(f"Applying {ecosystem} update: {name} {from_version} -> {to_version}", file=sys.stderr)
+    else:
+        print(f"Skipping {ecosystem} update: {name} ({skipped_reason})", file=sys.stderr)
 
 def version_parts(version):
     version = str(version or "").strip().lstrip("v")
@@ -565,9 +624,11 @@ def collect_files(manifests):
 
 manifests = discover()
 result["manifests"] = manifests
+print(f"Discovered {len(manifests)} manifest(s)", file=sys.stderr)
 before = file_snapshot(collect_files(manifests))
 
 for manifest in manifests:
+    print(f"Processing {manifest['ecosystem']} manifest {manifest['path']}", file=sys.stderr)
     manifest_path = ROOT / manifest["path"]
     cwd = manifest_path.parent
 
@@ -653,6 +714,7 @@ for manifest in manifests:
                 had_failure = True
 
 result["files_changed"] = changed_files(before)
+print(f"Dependency update complete: {len(result['updates'])} update(s), {len(result['files_changed'])} file(s) changed", file=sys.stderr)
 print(json.dumps(result, sort_keys=True))
 sys.exit(1 if had_failure else 0)
 `

--- a/pkg/hub/dependency_updates_test.go
+++ b/pkg/hub/dependency_updates_test.go
@@ -705,3 +705,21 @@ func TestFormatDependencyUpdateFailureSkipsRetriedAttempts(t *testing.T) {
 		t.Fatalf("formatDependencyUpdateFailure = %q, want %q", got, want)
 	}
 }
+
+func TestFormatDependencyUpdateSummary(t *testing.T) {
+	stdout := `{"ecosystems":["go","npm"],"manifests":[{"ecosystem":"go","path":"go.mod"},{"ecosystem":"npm","path":"web/package.json"}],"updates":[{"applied":true,"name":"example.com/foo"},{"applied":true,"name":"left-pad"},{"applied":false,"name":"example.com/bar"}],"files_changed":["go.mod","go.sum","web/package-lock.json"]}`
+	result := &pipelineRunResult{ExitCode: 0, Stdout: stdout}
+	got := formatDependencyUpdateSummary(result)
+	want := "Dependency updates completed: 2 ecosystem(s): 2 manifest(s): 2 applied, 1 skipped: 3 file(s) changed"
+	if got != want {
+		t.Fatalf("formatDependencyUpdateSummary = %q, want %q", got, want)
+	}
+
+	if got := formatDependencyUpdateSummary(nil); got != "Dependency updates completed" {
+		t.Fatalf("nil result summary = %q, want %q", got, "Dependency updates completed")
+	}
+
+	if got := formatDependencyUpdateSummary(&pipelineRunResult{ExitCode: 0, Stdout: "not-json"}); got != "Dependency updates completed" {
+		t.Fatalf("non-JSON result summary = %q, want %q", got, "Dependency updates completed")
+	}
+}

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -941,6 +941,15 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 			}
 		} else {
 			log.Printf("[pipeline] workflow command completed for claw %s stage %q", clawID[:8], stage.ID)
+			if result != nil {
+				if result.Stdout != "" {
+					log.Printf("[pipeline] workflow command stdout for claw %s:\n%s", clawID[:8], result.Stdout)
+				}
+				if result.Stderr != "" {
+					log.Printf("[pipeline] workflow command stderr for claw %s:\n%s", clawID[:8], result.Stderr)
+				}
+				s.injectHubMessageByID(clawID, fmt.Sprintf("[hub] Workflow command completed for stage %q (exit %d)", stage.ID, result.ExitCode))
+			}
 		}
 	}
 
@@ -969,6 +978,17 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 				log.Printf("[pipeline] %s", msg)
 				s.injectHubMessageByID(clawID, "[hub] Error: "+msg)
 				return false, errors.New(msg)
+			}
+		} else {
+			log.Printf("[pipeline] dependency updates completed for claw %s stage %q", clawID[:8], stage.ID)
+			if result != nil {
+				if result.Stdout != "" {
+					log.Printf("[pipeline] dependency update stdout for claw %s:\n%s", clawID[:8], result.Stdout)
+				}
+				if result.Stderr != "" {
+					log.Printf("[pipeline] dependency update stderr for claw %s:\n%s", clawID[:8], result.Stderr)
+				}
+				s.injectHubMessageByID(clawID, "[hub] "+formatDependencyUpdateSummary(result))
 			}
 		}
 	}

--- a/pkg/hub/pipeline_runner_test.go
+++ b/pkg/hub/pipeline_runner_test.go
@@ -1078,6 +1078,49 @@ func TestRunOnEnterJudgeContinueOnError(t *testing.T) {
 	}
 }
 
+func TestRunOnEnterRunCommandLogsAndInjectsOnSuccess(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{
+		Token:     "test-token",
+		ClawToken: "test-claw-token",
+		Providers: map[string]types.ProviderConfig{
+			"noop": {Type: "noop"},
+		},
+	}, "", "", "")
+
+	const clawID = "claw-run-success"
+	_, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, template, status, provider, provider_id, created_at) VALUES(?,?,?,?,?,?,?,datetime('now'))`,
+		clawID, "test-tenant-id", "test-claw", "elasticclaw", "connected", "noop", "noop-id",
+	)
+	if err != nil {
+		t.Fatalf("insert claw: %v", err)
+	}
+
+	stage := pipeline.Stage{
+		ID:    "build",
+		Label: "Build",
+		OnEnter: pipeline.OnEnter{
+			Run: pipeline.RunAction{
+				Command: "echo hello",
+			},
+			Inject: "Continue after build",
+		},
+	}
+
+	_, err = s.runOnEnter(clawID, stage, pipelineContext{})
+	if err != nil {
+		t.Fatalf("expected runOnEnter to succeed, got error: %v", err)
+	}
+
+	var messageCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=?`, clawID).Scan(&messageCount); err != nil {
+		t.Fatalf("count messages: %v", err)
+	}
+	if messageCount != 2 {
+		t.Fatalf("expected 2 messages (run completion + inject), got %d", messageCount)
+	}
+}
+
 func TestRunOnEnterDependencyUpdatesStopsOnError(t *testing.T) {
 	s, db := NewTestServerWithConfig(t, &types.HubConfig{
 		Token:     "test-token",
@@ -1164,6 +1207,49 @@ func TestRunOnEnterDependencyUpdatesContinueOnError(t *testing.T) {
 	// Should have 2 messages: deps warning + inject message (because continue_on_error=true).
 	if messageCount != 2 {
 		t.Fatalf("expected 2 messages (deps warning + inject), got %d", messageCount)
+	}
+}
+
+func TestRunOnEnterDependencyUpdatesLogsAndInjectsOnSuccess(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{
+		Token:     "test-token",
+		ClawToken: "test-claw-token",
+		Providers: map[string]types.ProviderConfig{
+			"noop": {Type: "noop"},
+		},
+	}, "", "", "")
+
+	const clawID = "claw-deps-success"
+	_, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, template, status, provider, provider_id, created_at) VALUES(?,?,?,?,?,?,?,datetime('now'))`,
+		clawID, "test-tenant-id", "test-claw", "elasticclaw", "connected", "noop", "noop-id",
+	)
+	if err != nil {
+		t.Fatalf("insert claw: %v", err)
+	}
+
+	stage := pipeline.Stage{
+		ID:    "deps",
+		Label: "Dependency Updates",
+		OnEnter: pipeline.OnEnter{
+			DependencyUpdates: pipeline.DependencyUpdatesAction{
+				Enabled: true,
+			},
+			Inject: "Continue after deps",
+		},
+	}
+
+	_, err = s.runOnEnter(clawID, stage, pipelineContext{})
+	if err != nil {
+		t.Fatalf("expected runOnEnter to succeed, got error: %v", err)
+	}
+
+	var messageCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=?`, clawID).Scan(&messageCount); err != nil {
+		t.Fatalf("count messages: %v", err)
+	}
+	if messageCount != 2 {
+		t.Fatalf("expected 2 messages (deps summary + inject), got %d", messageCount)
 	}
 }
 

--- a/web/components/conversation-view.tsx
+++ b/web/components/conversation-view.tsx
@@ -1076,10 +1076,6 @@ function isHiddenActivity(message: Message): boolean {
   return message.activity?.kind === "still_working" || message.content.startsWith("No streamed output")
 }
 
-function isStaleModelWait(message: Message, latestActivity: Message | null): boolean {
-  return message.activity?.kind === "model_started" && latestActivity?.id !== message.id
-}
-
 function hasEarlierTerminalAssistant(messages: Message[], index: number): boolean {
   for (let i = index - 1; i >= 0; i -= 1) {
     if (isTerminalAssistantMessage(messages[i])) return true
@@ -1120,24 +1116,16 @@ type ConversationItem =
 function compactActivityRuns(messages: Message[]): ConversationItem[] {
   const items: ConversationItem[] = []
   let run: Message[] = []
-  const latestActivity = latestActivityMessage(messages)
 
   const flush = () => {
-    const visible = run.filter((message) => !isHiddenActivity(message) && !isStaleModelWait(message, latestActivity))
+    const visible = run.filter((message) => !isHiddenActivity(message))
     run = []
     if (visible.length === 0) return
-    if (visible.length === 1) {
-      items.push({ type: "message", message: visible[0] })
-      return
-    }
-    const collapsed = visible.slice(0, -1)
-    const latest = visible[visible.length - 1]
     items.push({
       type: "activity-summary",
-      id: `activity-summary-${collapsed[0].id}-${collapsed[collapsed.length - 1].id}`,
-      messages: collapsed,
+      id: `activity-summary-${visible[0].id}-${visible[visible.length - 1].id}`,
+      messages: visible,
     })
-    items.push({ type: "message", message: latest })
   }
 
   for (const message of messages) {

--- a/web/hooks/use-windowed-messages.ts
+++ b/web/hooks/use-windowed-messages.ts
@@ -6,7 +6,6 @@ import { mapApiMessage } from "@/lib/mappers"
 import type { Message } from "@/lib/types"
 
 const PAGE_SIZE = 50    // messages per page
-const MAX_WINDOW = 50   // max messages kept in DOM
 const ROLE_ORDER: Record<Message["role"], number> = {
   user: 0,
   hub: 1,
@@ -92,11 +91,7 @@ export function useWindowedMessages({ clawId, liveMessages }: UseWindowedMessage
       setHasOlder(hasOlderConversationPage(older, PAGE_SIZE))
       oldestTimestamp.current = oldestConversationCursor(older)
 
-      setHistoricalMsgs((prev) => {
-        const combined = [...older, ...prev]
-        // Cap window — drop from bottom if too large
-        return combined.length > MAX_WINDOW ? combined.slice(0, MAX_WINDOW) : combined
-      })
+      setHistoricalMsgs((prev) => [...older, ...prev])
 
       // Restore scroll position so prepend doesn't jump
       requestAnimationFrame(() => {
@@ -134,7 +129,7 @@ export function useWindowedMessages({ clawId, liveMessages }: UseWindowedMessage
       all.push(m)
     }
     all.sort(compareMessages)
-    return all.length > MAX_WINDOW ? all.slice(all.length - MAX_WINDOW) : all
+    return all
   })()
 
   return { messages, hasOlder, loadingOlder, loadOlder, scrollRef, onScroll }


### PR DESCRIPTION
## What changed

- **Backend visibility**: `dependency_updates` and `on_enter.run.command` now log their stdout/stderr on success, emit a completion log, and inject a summary message into the claw chat so the step appears in the web UI **Actions** tab.
- **Dependency update progress**: the Python script now prints progress lines to stderr (discovered manifests, processing each manifest, applying/skipping updates, completion summary).
- **Chat scrollback**: removed the 50-message DOM cap in `useWindowedMessages`, so the streaming chat no longer drops older messages as new ones arrive.
- **Activity collapsing**: `compactActivityRuns` now folds an entire run of tool/activity messages into a single expandable summary line, reducing chatter while keeping the full history available.

## Where to see it

- **Actions tab**: completion messages for run commands and dependency updates.
- **Output tab**: dependency update stderr progress lines; run command stdout/stderr when `output:` is set.
- **Hub logs**: full stdout/stderr for both step types on success, not just failure.

## Tests

- `go test ./pkg/hub/...` passes.
- `npm run typecheck` passes in `web/`.
- `npm run lint` has no new errors (only pre-existing image warnings).