### PR TITLE
fix(hub): use go list -e and skip modules with errors

### DIFF
--- a/pkg/hub/dependency_updates.go
+++ b/pkg/hub/dependency_updates.go
@@ -576,18 +576,22 @@ for manifest in manifests:
             result["commands"].append({"command": "go", "cwd": rel(cwd), "exit_code": 127, "stderr": "go executable not found"})
             had_failure = True
             continue
-        listed = run_command(cwd, "go list -m -u -json all")
-        # Even if go list exits non-zero (e.g. because of invalid placeholder versions
-        # behind replace directives), stdout may still contain valid JSON for usable
-        # modules. Try to parse it and apply whatever we can.
+        listed = run_command(cwd, "go list -e -m -u -json all")
+        # Use -e so go list keeps going when a module behind a replace directive or an
+        # unreplaceable placeholder version cannot be resolved. Modules with errors are
+        # emitted as JSON objects with an Error field; we skip them below. Even if go
+        # list exits non-zero, stdout may still contain valid JSON for usable modules,
+        # so we try to parse it and apply whatever we can.
         try:
             apply_updates = []
             for module in parse_go_modules(listed.stdout):
                 name = module.get("Path", "")
-                # Skip the main module, modules pinned by replace directives, and
-                # transitive-only dependencies. Only direct dependencies can be safely
-                # updated by go get; replaced modules would conflict with the directive.
-                if module.get("Main") or module.get("Replace") or module.get("Indirect"):
+                # Skip the main module, modules pinned by replace directives, modules
+                # that carry a resolution error, and transitive-only dependencies. Only
+                # direct dependencies can be safely updated by go get; replaced modules
+                # would conflict with the directive and error-carrying modules cannot be
+                # trusted to provide a valid update target.
+                if module.get("Main") or module.get("Replace") or module.get("Error") or module.get("Indirect"):
                     continue
                 update = module.get("Update") or {}
                 if not update:

--- a/pkg/hub/dependency_updates_test.go
+++ b/pkg/hub/dependency_updates_test.go
@@ -126,7 +126,7 @@ func TestDependencyUpdatesGeneratedCommandOutputsStructuredJSON(t *testing.T) {
 	}
 	writeExecutable(t, bin, "go", `#!/usr/bin/env bash
 set -e
-if [ "$*" = "list -m -u -json all" ]; then
+if [ "$*" = "list -e -m -u -json all" ]; then
   printf '%s\n' '{"Path":"example.com/root","Version":"v1.0.0","Update":{"Version":"v1.1.0"}}'
   exit 0
 fi
@@ -199,7 +199,7 @@ func TestDependencyUpdatesGoGetOneAtATime(t *testing.T) {
 	writeExecutable(t, bin, "go", `#!/usr/bin/env bash
 set -e
 ROOT=$(dirname "$0")/..
-if [ "$*" = "list -m -u -json all" ]; then
+if [ "$*" = "list -e -m -u -json all" ]; then
   printf '%s\n' '{"Path":"example.com/root","Version":"v1.0.0","Update":{"Version":"v1.1.0"}}'
   printf '%s\n' '{"Path":"example.com/other","Version":"v1.0.0","Update":{"Version":"v1.1.0"}}'
   exit 0
@@ -280,7 +280,7 @@ func TestDependencyUpdatesSkipsReplacedIndirectAndInvalidVersions(t *testing.T) 
 	}
 	writeExecutable(t, bin, "go", `#!/usr/bin/env bash
 set -e
-if [ "$*" = "list -m -u -json all" ]; then
+if [ "$*" = "list -e -m -u -json all" ]; then
   printf '%s\n' '{"Path":"example.com/root","Version":"v1.0.0","Update":{"Version":"v1.1.0"}}'
   printf '%s\n' '{"Path":"example.com/replaced","Version":"v0.0.0","Update":{"Version":"v1.0.0"},"Replace":{"Path":"example.com/replaced","Version":"v0.0.0"}}'
   printf '%s\n' '{"Path":"example.com/indirect","Version":"v1.0.0","Update":{"Version":"v1.1.0"},"Indirect":true}'
@@ -335,6 +335,66 @@ exit 0
 	// in the update records at all, to avoid noisy reports for unpinned deps.
 }
 
+func TestDependencyUpdatesSkipsModulesWithErrors(t *testing.T) {
+	root := t.TempDir()
+	bin := filepath.Join(root, "bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeExecutable(t, bin, "go", `#!/usr/bin/env bash
+set -e
+if [ "$*" = "list -e -m -u -json all" ]; then
+  printf '%s\n' '{"Path":"example.com/root","Version":"v1.0.0","Update":{"Version":"v1.1.0"}}'
+  printf '%s\n' '{"Path":"example.com/broken","Version":"v0.0.0","Update":{"Version":"v1.0.0"},"Error":{"Err":"example.com/broken@v0.0.0: invalid version"}}'
+  exit 0
+fi
+if [ "$1" = "get" ]; then
+  if [ "$2" != "example.com/root@v1.1.0" ]; then
+    echo "unexpected go get target: $2" >&2
+    exit 1
+  fi
+  echo changed >> go.sum
+  exit 0
+fi
+if [ "$1 $2" = "mod tidy" ]; then
+  exit 0
+fi
+exit 0
+`)
+	writeExecutable(t, bin, "npm", `#!/usr/bin/env bash
+if [ "$1 $2" = "outdated --json" ]; then
+  printf '%s\n' '{}'
+  exit 1
+fi
+if [ "$1 $2" = "update --package-lock-only" ]; then
+  exit 0
+fi
+exit 0
+`)
+	writeFile(t, root, "go.mod", "module example.com/root\n")
+	writeFile(t, root, "go.sum", "")
+
+	command, err := buildDependencyUpdatesCommand(pipeline.DependencyUpdatesAction{Enabled: true})
+	if err != nil {
+		t.Fatalf("build command: %v", err)
+	}
+	cmd := osexec.Command("bash", "-c", command)
+	cmd.Dir = root
+	cmd.Env = testEnvWithPath(bin)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("dependency update command failed: %v\n%s", err, out)
+	}
+
+	parsed, ok := parsePipelineOutputJSON(string(out))
+	if !ok {
+		t.Fatalf("command did not emit JSON:\n%s", out)
+	}
+	assertUpdateStatus(t, parsed, "go", "example.com/root", true, "")
+	// Modules carrying an Error field should be silently skipped; they are not
+	// safe update targets because their current version is already broken.
+}
+
 func TestDependencyUpdatesRetriesGoGetFailure(t *testing.T) {
 	root := t.TempDir()
 	bin := filepath.Join(root, "bin")
@@ -349,7 +409,7 @@ count=0
 if [ -f "$COUNT_FILE" ]; then
   count=$(cat "$COUNT_FILE")
 fi
-if [ "$*" = "list -m -u -json all" ]; then
+if [ "$*" = "list -e -m -u -json all" ]; then
   printf '%s\n' '{"Path":"example.com/root","Version":"v1.0.0","Update":{"Version":"v1.1.0"}}'
   exit 0
 fi
@@ -430,7 +490,7 @@ func TestDependencyUpdatesGeneratedCommandHonorsFiltersAndMajorPolicy(t *testing
 	}
 	writeExecutable(t, bin, "go", `#!/usr/bin/env bash
 set -e
-if [ "$*" = "list -m -u -json all" ]; then
+if [ "$*" = "list -e -m -u -json all" ]; then
   printf '%s\n' '{"Path":"example.com/root","Version":"v1.0.0","Update":{"Version":"v1.1.0"}}'
   printf '%s\n' '{"Path":"ignored.com/risky","Version":"v1.0.0","Update":{"Version":"v1.1.0"}}'
   printf '%s\n' '{"Path":"example.com/major","Version":"v0.9.0","Update":{"Version":"v1.0.0"}}'
@@ -511,7 +571,7 @@ func TestDependencyUpdatesGeneratedCommandHonorsExcludePaths(t *testing.T) {
 	}
 	writeExecutable(t, bin, "go", `#!/usr/bin/env bash
 set -e
-if [ "$*" = "list -m -u -json all" ]; then
+if [ "$*" = "list -e -m -u -json all" ]; then
   printf '%s\n' '{"Path":"example.com/root","Version":"v1.0.0","Update":{"Version":"v1.1.0"}}'
   exit 0
 fi
@@ -647,7 +707,7 @@ func writeExecutable(t *testing.T, root, name, content string) {
 }
 
 func TestFormatDependencyUpdateFailureExtractsFailedCommand(t *testing.T) {
-	stdout := `{"commands":[{"command":"go list -m -u -json all","cwd":"ec/e2e","exit_code":0,"stderr":""},{"command":"go get example.com/foo@v1.1.0","cwd":"ec/e2e","exit_code":1,"stderr":"go: example.com/foo@v1.1.0: not found"}],"updates":[]}`
+	stdout := `{"commands":[{"command":"go list -e -m -u -json all","cwd":"ec/e2e","exit_code":0,"stderr":""},{"command":"go get example.com/foo@v1.1.0","cwd":"ec/e2e","exit_code":1,"stderr":"go: example.com/foo@v1.1.0: not found"}],"updates":[]}`
 	result := &pipelineRunResult{ExitCode: 1, Stdout: stdout}
 	got := formatDependencyUpdateFailure(result)
 	want := "Dependency update step failed: go get example.com/foo@v1.1.0 (cwd=ec/e2e): go: example.com/foo@v1.1.0: not found"


### PR DESCRIPTION
The previous resilience fix only helped when go list exited non-zero but still emitted usable JSON. With placeholder versions like k8s.io/cri-streaming@v0.0.0, go list can fail before producing any JSON, so the fallback never ran.

Use go list -e so broken modules are emitted as JSON objects with an Error field instead of aborting the whole listing, and skip any module that carries an Error field.

Tests updated and passing.