### PR TITLE
fix(hub,bridge): recover OpenClaw session lock conflicts with same-session retry and resume prompt

### DIFF
--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -1978,6 +1978,16 @@ func isSessionFileLockConflictError(err error) bool {
 	return strings.Contains(msg, "session file changed") && strings.Contains(msg, "embedded prompt lock")
 }
 
+// sessionLockConflictRetryDelays backs off between same-session retries when
+// sessions.send is rejected with the "session file changed while embedded
+// prompt lock was released" error. A rejected send means the turn was never
+// accepted (no tool side effects), and the conflict is usually the previous
+// turn still flushing its session file after the lifecycle end event — the
+// window is routinely longer than any hub-side inter-turn pause on slow
+// sandbox disks. Retrying preserves the transcript that a session rotation
+// would discard. A variable so tests can shorten it.
+var sessionLockConflictRetryDelays = []time.Duration{500 * time.Millisecond, time.Second, 2 * time.Second, 4 * time.Second}
+
 // isSessionRotatedError reports whether SendMessage recovered from a session
 // lock conflict by rotating to a fresh session. In that case the original turn
 // cannot be completed, but the next hub message can continue. The bridge should
@@ -2000,6 +2010,7 @@ func (gs *gatewaySession) SendMessage(ctx context.Context, message string, onChu
 
 	delays := []time.Duration{2 * time.Second, 5 * time.Second}
 	gatewayRetried := false
+	lockConflictRetries := 0
 	for attempt := 0; ; attempt++ {
 		conn := gs.currentConn()
 		reply, err := gs.sendMessageOnce(ctx, message, onChunk, onActivity)
@@ -2037,6 +2048,24 @@ func (gs *gatewaySession) SendMessage(ctx context.Context, message string, onChu
 			}
 			continue
 		}
+		// A lock conflict rejected at the sessions.send request means the turn
+		// was never accepted, so replaying the same message on the same session
+		// is safe. The previous turn is likely still flushing its session file;
+		// back off and retry before considering rotation, which would discard
+		// the transcript. Mid-turn lifecycle lock conflicts are excluded above:
+		// those turns may already have side effects and must not be retried.
+		var sendReqErr *sessionSendRequestError
+		if errors.As(err, &sendReqErr) && isSessionFileLockConflictError(err) && lockConflictRetries < len(sessionLockConflictRetryDelays) {
+			delay := sessionLockConflictRetryDelays[lockConflictRetries]
+			lockConflictRetries++
+			log.Printf("[gateway] session file lock conflict on sessions.send (attempt %d/%d) — retrying same session in %s: %v", lockConflictRetries, len(sessionLockConflictRetryDelays), delay, err)
+			select {
+			case <-time.After(delay):
+			case <-ctx.Done():
+				return "", ctx.Err()
+			}
+			continue
+		}
 		if isRecoverableSessionLifecycleError(err) {
 			abortCtx, abortCancel := context.WithTimeout(context.Background(), 5*time.Second)
 			abortErr := gs.abortActiveSession(abortCtx)
@@ -2051,6 +2080,18 @@ func (gs *gatewaySession) SendMessage(ctx context.Context, message string, onChu
 				return reply, fmt.Errorf("%w; session recovery failed: %v", err, resetErr)
 			}
 			return reply, fmt.Errorf("%w; OpenClaw session reset so the next message can continue", err)
+		}
+		// Same-session retries exhausted: rotate as a last resort and surface
+		// the reset error instead of silently replaying, so the hub injects a
+		// resume prompt with task context into the fresh session.
+		if errors.As(err, &sendReqErr) && isSessionFileLockConflictError(err) {
+			recoveryCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			resetErr := gs.createFreshSession(recoveryCtx, err.Error())
+			cancel()
+			if resetErr != nil {
+				return "", fmt.Errorf("%w; session recovery failed: %v", err, resetErr)
+			}
+			return "", fmt.Errorf("%w; OpenClaw session reset so the next message can continue", err)
 		}
 		if !isRecoverableSessionSendError(err) {
 			return reply, err

--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -4182,6 +4182,8 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 				if isSessionRotatedError(agentErr) {
 					writeActivity(agentActivity{Kind: "session_rotated", Message: fmt.Sprintf("OpenClaw session rotated to recover from lock conflict; waiting for next message (%v)", agentErr)})
 					reply = ""
+					// Notify the hub so it can inject a resume prompt with context.
+					_ = writeHub(hubMsg{Type: "session_rotated"})
 				} else {
 					reply = fmt.Sprintf("⚠️ error: %v", agentErr)
 				}
@@ -4307,6 +4309,8 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 					if isSessionRotatedError(agentErr) {
 						writeActivity(agentActivity{Kind: "session_rotated", Message: fmt.Sprintf("OpenClaw session rotated to recover from lock conflict; waiting for next message (%v)", agentErr)})
 						reply = ""
+						// Notify the hub so it can inject a resume prompt with context.
+						_ = writeHub(hubMsg{Type: "session_rotated"})
 					} else {
 						reply = fmt.Sprintf("⚠️ claw-bridge error: %v", agentErr)
 					}

--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -1935,11 +1935,12 @@ func isRecoverableSessionSendError(err error) bool {
 	if !errors.As(err, &sendErr) {
 		return false
 	}
+	// Note: session file lock conflicts are deliberately absent here — they
+	// are handled earlier in SendMessage with same-session retries.
 	msg := strings.ToLower(sendErr.err.Error())
 	return strings.Contains(msg, "context overflow") ||
 		strings.Contains(msg, "prompt too large") ||
-		isProviderRequestFormatError(sendErr.err) ||
-		isSessionFileLockConflictError(sendErr.err)
+		isProviderRequestFormatError(sendErr.err)
 }
 
 func isProviderRequestFormatError(err error) bool {

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -1369,7 +1369,7 @@ func TestIsRecoverableSessionSendError(t *testing.T) {
 		{name: "send request context overflow", err: &sessionSendRequestError{err: errString("context overflow detected")}, want: true},
 		{name: "send request prompt too large", err: &sessionSendRequestError{err: errString("Context overflow: prompt too large for the model")}, want: true},
 		{name: "send request provider format rejection", err: &sessionSendRequestError{err: errString("LLM request failed: " + providerRequestFormatErrorFragment + ".")}, want: true},
-		{name: "send request session file lock conflict", err: &sessionSendRequestError{err: errString("error: session file changed while embedded prompt lock was released: /home/elasticclaw/.openclaw/agents/main/sessions/4fb88b9b-8233-4f78-819f-516fbe605e32.jsonl")}, want: true},
+		{name: "send request session file lock conflict handled by same-session retry", err: &sessionSendRequestError{err: errString("error: session file changed while embedded prompt lock was released: /home/elasticclaw/.openclaw/agents/main/sessions/4fb88b9b-8233-4f78-819f-516fbe605e32.jsonl")}, want: false},
 		{name: "send failure", err: errString("sessions.send failed: tool crashed"), want: false},
 	}
 	for _, tt := range tests {

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -1680,8 +1680,12 @@ func TestGatewaySessionResetsAfterSessionFileLockConflict(t *testing.T) {
 	}
 }
 
-func TestGatewaySessionRetriesAfterSessionFileLockSendError(t *testing.T) {
+func TestGatewaySessionRetriesSameSessionAfterLockConflictSendError(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
+
+	oldDelays := sessionLockConflictRetryDelays
+	sessionLockConflictRetryDelays = []time.Duration{time.Millisecond, time.Millisecond}
+	t.Cleanup(func() { sessionLockConflictRetryDelays = oldDelays })
 
 	const sessionErr = "error: session file changed while embedded prompt lock was released: /home/elasticclaw/.openclaw/agents/main/sessions/4fb88b9b-8233-4f78-819f-516fbe605e32.jsonl"
 	testDone := make(chan struct{})
@@ -1706,18 +1710,9 @@ func TestGatewaySessionRetriesAfterSessionFileLockSendError(t *testing.T) {
 			return req, true
 		}
 
-		// First send fails with the lock-conflict error.
+		// First send is rejected with the lock-conflict error.
 		sendReq, ok := readRequest("sessions.send")
 		if !ok {
-			return
-		}
-		var sendParams map[string]string
-		if err := json.Unmarshal(sendReq.Params, &sendParams); err != nil {
-			t.Errorf("decode first sessions.send params: %v", err)
-			return
-		}
-		if sendParams["key"] != "session-1" {
-			t.Errorf("first sessions.send key = %q, want session-1", sendParams["key"])
 			return
 		}
 		if err := wsjson.Write(r.Context(), conn, gwFrame{
@@ -1733,31 +1728,7 @@ func TestGatewaySessionRetriesAfterSessionFileLockSendError(t *testing.T) {
 			return
 		}
 
-		// Bridge should create and subscribe to a fresh session.
-		createReq, ok := readRequest("sessions.create")
-		if !ok {
-			return
-		}
-		if err := wsjson.Write(r.Context(), conn, gwFrame{
-			Type:    "res",
-			ID:      createReq.ID,
-			OK:      true,
-			Payload: mustJSON(map[string]string{"key": "session-2"}),
-		}); err != nil {
-			t.Errorf("create replacement session: %v", err)
-			return
-		}
-
-		subscribeReq, ok := readRequest("sessions.subscribe")
-		if !ok {
-			return
-		}
-		if err := wsjson.Write(r.Context(), conn, gwFrame{Type: "res", ID: subscribeReq.ID, OK: true}); err != nil {
-			t.Errorf("subscribe replacement session: %v", err)
-			return
-		}
-
-		// Retry in the fresh session should succeed.
+		// The retry must go to the SAME session — no rotation, no transcript loss.
 		retrySendReq, ok := readRequest("sessions.send")
 		if !ok {
 			return
@@ -1767,8 +1738,8 @@ func TestGatewaySessionRetriesAfterSessionFileLockSendError(t *testing.T) {
 			t.Errorf("decode retry sessions.send params: %v", err)
 			return
 		}
-		if retrySendParams["key"] != "session-2" {
-			t.Errorf("retry sessions.send key = %q, want session-2", retrySendParams["key"])
+		if retrySendParams["key"] != "session-1" {
+			t.Errorf("retry sessions.send key = %q, want same session session-1", retrySendParams["key"])
 			return
 		}
 		if err := wsjson.Write(r.Context(), conn, gwFrame{Type: "res", ID: retrySendReq.ID, OK: true}); err != nil {
@@ -1780,7 +1751,7 @@ func TestGatewaySessionRetriesAfterSessionFileLockSendError(t *testing.T) {
 			Event: "agent",
 			Payload: mustJSON(map[string]interface{}{
 				"stream":     "assistant",
-				"sessionKey": "session-2",
+				"sessionKey": "session-1",
 				"data":       map[string]string{"delta": "hello"},
 			}),
 		}); err != nil {
@@ -1792,7 +1763,7 @@ func TestGatewaySessionRetriesAfterSessionFileLockSendError(t *testing.T) {
 			Event: "agent",
 			Payload: mustJSON(map[string]interface{}{
 				"stream":     "lifecycle",
-				"sessionKey": "session-2",
+				"sessionKey": "session-1",
 				"data":       map[string]string{"phase": "end"},
 			}),
 		}); err != nil {
@@ -1827,6 +1798,128 @@ func TestGatewaySessionRetriesAfterSessionFileLockSendError(t *testing.T) {
 	}
 	if reply != "hello" {
 		t.Fatalf("SendMessage reply = %q, want hello", reply)
+	}
+	if got := gs.getSessionKey(); got != "session-1" {
+		t.Fatalf("session key = %q, want unchanged session-1", got)
+	}
+	if got := loadBridgeSession(); got != "" {
+		t.Fatalf("persisted session key = %q, want empty (no rotation)", got)
+	}
+}
+
+func TestGatewaySessionRotatesAfterLockConflictRetriesExhausted(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	oldDelays := sessionLockConflictRetryDelays
+	sessionLockConflictRetryDelays = []time.Duration{time.Millisecond, time.Millisecond}
+	t.Cleanup(func() { sessionLockConflictRetryDelays = oldDelays })
+
+	const sessionErr = "error: session file changed while embedded prompt lock was released: /home/elasticclaw/.openclaw/agents/main/sessions/4fb88b9b-8233-4f78-819f-516fbe605e32.jsonl"
+	testDone := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Errorf("accept websocket: %v", err)
+			return
+		}
+		defer conn.CloseNow()
+
+		readRequest := func(wantMethod string) (gwFrame, bool) {
+			var req gwFrame
+			if err := wsjson.Read(r.Context(), conn, &req); err != nil {
+				t.Errorf("read %s request: %v", wantMethod, err)
+				return gwFrame{}, false
+			}
+			if req.Method != wantMethod {
+				t.Errorf("request method = %q, want %q", req.Method, wantMethod)
+				return gwFrame{}, false
+			}
+			return req, true
+		}
+
+		// Every same-session attempt (initial + all retries) is rejected.
+		for i := 0; i <= len(sessionLockConflictRetryDelays); i++ {
+			sendReq, ok := readRequest("sessions.send")
+			if !ok {
+				return
+			}
+			var sendParams map[string]string
+			if err := json.Unmarshal(sendReq.Params, &sendParams); err != nil {
+				t.Errorf("decode sessions.send params: %v", err)
+				return
+			}
+			if sendParams["key"] != "session-1" {
+				t.Errorf("sessions.send attempt %d key = %q, want session-1", i+1, sendParams["key"])
+				return
+			}
+			if err := wsjson.Write(r.Context(), conn, gwFrame{
+				Type: "res",
+				ID:   sendReq.ID,
+				OK:   false,
+				Error: &gwError{
+					Code:    "session_file_lock_conflict",
+					Message: sessionErr,
+				},
+			}); err != nil {
+				t.Errorf("reject sessions.send attempt %d: %v", i+1, err)
+				return
+			}
+		}
+
+		// Retries exhausted: bridge rotates to a fresh session as a last resort.
+		createReq, ok := readRequest("sessions.create")
+		if !ok {
+			return
+		}
+		if err := wsjson.Write(r.Context(), conn, gwFrame{
+			Type:    "res",
+			ID:      createReq.ID,
+			OK:      true,
+			Payload: mustJSON(map[string]string{"key": "session-2"}),
+		}); err != nil {
+			t.Errorf("create replacement session: %v", err)
+			return
+		}
+
+		subscribeReq, ok := readRequest("sessions.subscribe")
+		if !ok {
+			return
+		}
+		if err := wsjson.Write(r.Context(), conn, gwFrame{Type: "res", ID: subscribeReq.ID, OK: true}); err != nil {
+			t.Errorf("subscribe replacement session: %v", err)
+			return
+		}
+
+		<-testDone
+	}))
+	defer srv.Close()
+	defer close(testDone)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer conn.CloseNow()
+
+	gs := &gatewaySession{
+		sessionKey: "session-1",
+		conn:       conn,
+		pending:    make(map[string]chan gwFrame),
+	}
+	go gs.readLoop(ctx)
+
+	_, err = gs.SendMessage(ctx, "continue the task", nil, nil)
+	if err == nil {
+		t.Fatal("SendMessage returned nil error")
+	}
+	if !strings.Contains(err.Error(), sessionErr) || !strings.Contains(err.Error(), "session reset") {
+		t.Fatalf("SendMessage error = %q, want session error and recovery notice", err)
+	}
+	if !isSessionRotatedError(err) {
+		t.Fatalf("SendMessage error must be recognized as session rotation, got: %v", err)
 	}
 	if got := gs.getSessionKey(); got != "session-2" {
 		t.Fatalf("session key = %q, want session-2", got)

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -7384,7 +7384,21 @@ func (s *Server) enqueueRestartResume(clawID string, restartCount int) {
 	s.enqueueSessionLostResume(clawID, restartResumePrefix, fmt.Sprintf("restart:%d", restartCount))
 }
 
+// sessionRotatedResumeThrottle bounds the rotation → resume → rotation loop:
+// if lock conflicts persist across fresh sessions (e.g. another process keeps
+// touching the session files), each rotation would otherwise enqueue another
+// resume prompt indefinitely — rotation turns complete with an empty reply,
+// so the no-progress watchdog never observes them.
+const sessionRotatedResumeThrottle = 10 * time.Minute
+
 func (s *Server) enqueueSessionRotatedResume(clawID string) {
+	var recent int
+	err := s.db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND role='hub' AND content LIKE ? AND created_at > ?`,
+		clawID, sessionRotatedResumePrefix+"%", now().Add(-sessionRotatedResumeThrottle)).Scan(&recent)
+	if err == nil && recent > 0 {
+		log.Printf("[watchdog] skipping session-rotated resume for %s: already resumed within %s", shortID(clawID), sessionRotatedResumeThrottle)
+		return
+	}
 	s.enqueueSessionLostResume(clawID, sessionRotatedResumePrefix, fmt.Sprintf("session_rotated:%s", uuid.NewString()))
 }
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -465,10 +465,10 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/workspaces/{name}/workflows", s.withAdminForMethods(s.handleWorkspaceWorkflowsList, http.MethodPost))
 	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}", s.withAdminForMethods(s.handleWorkspaceWorkflowDetail, http.MethodPatch))
 	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}/trigger", s.withAuth(s.handleWorkspaceWorkflowTrigger))
-	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}/cron/trigger", s.withAuth(s.handleCronWorkflowTrigger)) // POST manual trigger
-	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}/cron/runs", s.withAuth(s.handleCronWorkflowRuns))       // GET run history
+	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}/cron/trigger", s.withAuth(s.handleCronWorkflowTrigger))  // POST manual trigger
+	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}/cron/runs", s.withAuth(s.handleCronWorkflowRuns))        // GET run history
 	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}/cron/runs/{runId}", s.withAuth(s.handleCronWorkflowRun)) // GET single run
-	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}/cron/next", s.withAuth(s.handleCronWorkflowNextRun))    // GET next scheduled run
+	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}/cron/next", s.withAuth(s.handleCronWorkflowNextRun))     // GET next scheduled run
 	mux.HandleFunc("/api/workspaces/{workspace}/secrets", s.withAdminForMethods(s.handleWorkspaceSecretsCRUD, http.MethodPut, http.MethodPost, http.MethodDelete))
 	mux.HandleFunc("/api/workspaces/{workspace}/github-apps", s.withAdminForMethods(s.handleWorkspaceGitHubAppsCRUD, http.MethodPut, http.MethodPost, http.MethodDelete))
 	mux.HandleFunc("/api/workspaces/{workspace}/issue-trackers", s.withAdminForMethods(s.handleWorkspaceIssueTrackersCRUD, http.MethodPut, http.MethodPost, http.MethodDelete))
@@ -2767,6 +2767,8 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 						}
 					}
 				}
+			} else if msg.Type == "session_rotated" {
+				go s.enqueueSessionRotatedResume(clawID)
 			} else if msg.Type == "model_auth_sync" {
 				if !modelAuthAuthorized {
 					continue
@@ -7380,9 +7382,20 @@ func (s *Server) deleteStaleWatchdogNags(clawID string) {
 	}
 }
 
-const restartResumePrefix = "[hub] Agent process restart detected."
+const (
+	restartResumePrefix        = "[hub] Agent process restart detected."
+	sessionRotatedResumePrefix = "[hub] OpenClaw session reset detected."
+)
 
 func (s *Server) enqueueRestartResume(clawID string, restartCount int) {
+	s.enqueueSessionLostResume(clawID, restartResumePrefix, fmt.Sprintf("restart:%d", restartCount))
+}
+
+func (s *Server) enqueueSessionRotatedResume(clawID string) {
+	s.enqueueSessionLostResume(clawID, sessionRotatedResumePrefix, fmt.Sprintf("session_rotated:%s", uuid.NewString()))
+}
+
+func (s *Server) enqueueSessionLostResume(clawID, prefix, marker string) {
 	var status, issueTitle, linearID, githubID, shortcutID, jiraID string
 	var bootstrapOK int
 	err := s.db.QueryRow(`SELECT status, COALESCE(bootstrap_ok,0), COALESCE(issue_title,''), COALESCE(linear_issue_id,''), COALESCE(github_issue_id,''), COALESCE(shortcut_story_id,''), COALESCE(jira_issue_id,'') FROM claws WHERE id=?`, clawID).Scan(&status, &bootstrapOK, &issueTitle, &linearID, &githubID, &shortcutID, &jiraID)
@@ -7405,7 +7418,7 @@ func (s *Server) enqueueRestartResume(clawID string, restartCount int) {
 		issueRef = "Jira issue " + jiraID
 	}
 	var b strings.Builder
-	b.WriteString(restartResumePrefix)
+	b.WriteString(prefix)
 	b.WriteString(" Your previous session was lost, so you have no memory of the earlier conversation. The workspace on disk is intact, including your repositories under ~/workspace.")
 	if issueTitle != "" || issueRef != "" {
 		b.WriteString("\n\nAssigned task: ")
@@ -7424,12 +7437,12 @@ func (s *Server) enqueueRestartResume(clawID string, restartCount int) {
 		b.WriteString(".")
 	}
 	b.WriteString("\n\nBefore anything else, recover your state from the workspace: run git status and git log --oneline -15, check which branch you are on and whether there are uncommitted changes or an open PR for it. Then resume the task from where the workspace shows it stopped. Do not start over and do not discard existing work.")
-	// Append a zero-width marker carrying the restart_count so that two resume
-	// prompts for two different restarts are never treated as the identical
-	// pending message by injectMessage's dedup (change 2) — each restart is a
-	// distinct incident even when the rest of the wording is unchanged.
-	b.WriteString(fmt.Sprintf("\n\n<!-- restart:%d -->", restartCount))
-	log.Printf("[watchdog] enqueueing post-restart resume for %s", shortID(clawID))
+	// Append a zero-width marker so that two resume prompts for two different
+	// incidents are never treated as the identical pending message by
+	// injectMessage's dedup — each restart/session rotation is a distinct
+	// incident even when the rest of the wording is unchanged.
+	b.WriteString(fmt.Sprintf("\n\n<!-- %s -->", marker))
+	log.Printf("[watchdog] enqueueing %s resume for %s", marker, shortID(clawID))
 	s.injectHubMessageByID(clawID, b.String())
 }
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -204,13 +204,6 @@ const (
 	autoResumeRecentTurnWindow = 5 * time.Minute
 )
 
-// interTurnCooldown gives the OpenClaw gateway a short window to finish
-// releasing the prompt lock and writing the final session state before the
-// next message is admitted. This mitigates the upstream "session file changed
-// while embedded prompt lock was released" race when a second message reaches
-// the session during the previous turn's cleanup window.
-var interTurnCooldown = 100 * time.Millisecond
-
 // initialStatus returns the claw status string to use on bridge registration.
 // A nil pointer means the field was absent (old bridge) — treat as ready for backward compat.
 func initialStatus(gatewayReady *bool) string {
@@ -7490,23 +7483,11 @@ func (s *Server) sendNextQueuedMessage(cc *clawConn) {
 		cc.mu.Unlock()
 		return
 	}
-	// If the previous turn finished very recently, pause briefly before
-	// admitting the next message. This avoids the OpenClaw prompt-lock release
-	// race where a second message sent too soon after a turn ends corrupts the
-	// session file. See openclaw/openclaw#113194.
-	if !cc.lastTurnFinishedAt.IsZero() {
-		if elapsed := time.Since(cc.lastTurnFinishedAt); elapsed < interTurnCooldown {
-			cc.mu.Unlock()
-			time.Sleep(interTurnCooldown - elapsed)
-			cc.mu.Lock()
-			// Re-check the guard after waking up; the claw may have become busy
-			// or another delivery may have started while we slept.
-			if cc.isBusyLocked() || cc.deliveryInFlight || cc.noProgressPaused {
-				cc.mu.Unlock()
-				return
-			}
-		}
-	}
+	// No inter-turn cooldown here: if the next message reaches OpenClaw while
+	// the previous turn is still releasing its prompt lock, the bridge retries
+	// the rejected sessions.send on the same session with backoff (see
+	// sessionLockConflictRetryDelays in cmd/claw-bridge), which preserves the
+	// transcript instead of forcing a session rotation.
 	// Claim the in-flight guard before querying so a concurrent caller cannot
 	// read the same pending row and re-deliver it after we mark it delivered.
 	cc.deliveryInFlight = true

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -2258,9 +2258,9 @@ func TestDeliveredPromptReservesTurnBeforeFirstActivity(t *testing.T) {
 	}
 }
 
-func TestSendNextQueuedMessageWaitsInterTurnCooldown(t *testing.T) {
+func TestSendNextQueuedMessageDeliversImmediatelyAfterTurnEnd(t *testing.T) {
 	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
-	const clawID = "claw-inter-turn-cooldown"
+	const clawID = "claw-inter-turn-no-cooldown"
 	insertPendingMessage(t, db, clawID, "first", now().Add(-time.Second))
 	insertPendingMessage(t, db, clawID, "second", now())
 
@@ -2272,11 +2272,6 @@ func TestSendNextQueuedMessageWaitsInterTurnCooldown(t *testing.T) {
 		t.Fatalf("first delivered content = %q, want first", got)
 	}
 
-	// Speed up the cooldown so the test remains fast, but still measurable.
-	oldCooldown := interTurnCooldown
-	interTurnCooldown = 50 * time.Millisecond
-	t.Cleanup(func() { interTurnCooldown = oldCooldown })
-
 	s.mu.RLock()
 	cc := s.claws[clawID]
 	s.mu.RUnlock()
@@ -2284,6 +2279,9 @@ func TestSendNextQueuedMessageWaitsInterTurnCooldown(t *testing.T) {
 	cc.finishTurnLocked()
 	cc.mu.Unlock()
 
+	// The hub no longer pauses between turns: lock-conflict recovery lives in
+	// the bridge (same-session sessions.send retry with backoff), so the next
+	// queued message must be admitted without delay.
 	start := time.Now()
 	s.sendNextQueuedMessage(cc)
 	elapsed := time.Since(start)
@@ -2291,8 +2289,8 @@ func TestSendNextQueuedMessageWaitsInterTurnCooldown(t *testing.T) {
 	if got := readTestHubMessage(t, clawWS).Content; got != "second" {
 		t.Fatalf("second delivered content = %q, want second", got)
 	}
-	if elapsed < interTurnCooldown {
-		t.Fatalf("sendNextQueuedMessage returned too fast: %s, want at least %s", elapsed, interTurnCooldown)
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("sendNextQueuedMessage took too long: %s, want prompt delivery", elapsed)
 	}
 }
 

--- a/pkg/hub/watchdog_enforcement_test.go
+++ b/pkg/hub/watchdog_enforcement_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/elasticclaw/elasticclaw/pkg/types"
+	"github.com/google/uuid"
 	"nhooyr.io/websocket"
 	"nhooyr.io/websocket/wsjson"
 )
@@ -486,6 +487,55 @@ func TestSessionRotatedEnqueuesResume(t *testing.T) {
 		return n
 	}
 	eventuallyWatchdog(t, func() bool { return count() == 1 }, "session rotated resume")
+}
+
+func TestSessionRotatedResumeThrottled(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	const clawID = "watchdog-session-rotated-throttled"
+	conn := watchdogClaw(t, s, clawID)
+	_ = watchdogClawConn(t, s, clawID)
+	if _, err := db.Exec(`UPDATE claws SET status='connected', bootstrap_ok=1, issue_title='Fix session' WHERE id=?`, clawID); err != nil {
+		t.Fatal(err)
+	}
+	// A resume prompt already went out moments ago — a second rotation inside
+	// the throttle window must not enqueue another one.
+	if _, err := db.Exec(`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at) VALUES(?,?,?,?,?,?)`,
+		uuid.NewString(), clawID, "test-tenant-id", "hub", sessionRotatedResumePrefix+" earlier resume", now().Add(-time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if err := wsjson.Write(context.Background(), conn, types.WSMessage{Type: "session_rotated"}); err != nil {
+		t.Fatalf("write session_rotated: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND role='hub' AND content LIKE ?`, clawID, sessionRotatedResumePrefix+"%").Scan(&n); err != nil || n != 1 {
+		t.Fatalf("resume rows=%d err=%v, want 1 (throttled)", n, err)
+	}
+}
+
+func TestSessionRotatedResumeThrottleWindowExpires(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	const clawID = "watchdog-session-rotated-throttle-expired"
+	conn := watchdogClaw(t, s, clawID)
+	_ = watchdogClawConn(t, s, clawID)
+	if _, err := db.Exec(`UPDATE claws SET status='connected', bootstrap_ok=1, issue_title='Fix session' WHERE id=?`, clawID); err != nil {
+		t.Fatal(err)
+	}
+	// The previous resume is older than the throttle window, so a new
+	// rotation must enqueue a fresh resume prompt.
+	if _, err := db.Exec(`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at) VALUES(?,?,?,?,?,?)`,
+		uuid.NewString(), clawID, "test-tenant-id", "hub", sessionRotatedResumePrefix+" earlier resume", now().Add(-sessionRotatedResumeThrottle-time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if err := wsjson.Write(context.Background(), conn, types.WSMessage{Type: "session_rotated"}); err != nil {
+		t.Fatalf("write session_rotated: %v", err)
+	}
+	count := func() int {
+		var n int
+		_ = db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND role='hub' AND content LIKE ?`, clawID, sessionRotatedResumePrefix+"%").Scan(&n)
+		return n
+	}
+	eventuallyWatchdog(t, func() bool { return count() == 2 }, "session rotated resume after throttle window")
 }
 
 func TestSessionRotatedNotConnectedDoesNotEnqueueResume(t *testing.T) {

--- a/pkg/hub/watchdog_enforcement_test.go
+++ b/pkg/hub/watchdog_enforcement_test.go
@@ -469,6 +469,43 @@ func TestRestartDuringBootstrapDoesNotEnqueueResume(t *testing.T) {
 	}
 }
 
+func TestSessionRotatedEnqueuesResume(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	const clawID = "watchdog-session-rotated"
+	conn := watchdogClaw(t, s, clawID)
+	_ = watchdogClawConn(t, s, clawID)
+	if _, err := db.Exec(`UPDATE claws SET status='connected', bootstrap_ok=1, issue_title='Fix session', github_issue_id='owner/repo#42' WHERE id=?`, clawID); err != nil {
+		t.Fatal(err)
+	}
+	if err := wsjson.Write(context.Background(), conn, types.WSMessage{Type: "session_rotated"}); err != nil {
+		t.Fatalf("write session_rotated: %v", err)
+	}
+	count := func() int {
+		var n int
+		_ = db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND role='hub' AND content LIKE ?`, clawID, sessionRotatedResumePrefix+"%").Scan(&n)
+		return n
+	}
+	eventuallyWatchdog(t, func() bool { return count() == 1 }, "session rotated resume")
+}
+
+func TestSessionRotatedNotConnectedDoesNotEnqueueResume(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	const clawID = "watchdog-session-rotated-not-connected"
+	conn := watchdogClaw(t, s, clawID)
+	_ = watchdogClawConn(t, s, clawID)
+	if _, err := db.Exec(`UPDATE claws SET status='starting', bootstrap_ok=1, issue_title='Fix session', github_issue_id='owner/repo#42' WHERE id=?`, clawID); err != nil {
+		t.Fatal(err)
+	}
+	if err := wsjson.Write(context.Background(), conn, types.WSMessage{Type: "session_rotated"}); err != nil {
+		t.Fatalf("write session_rotated: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND content LIKE ?`, clawID, sessionRotatedResumePrefix+"%").Scan(&n); err != nil || n != 0 {
+		t.Fatalf("resume rows=%d err=%v, want 0", n, err)
+	}
+}
+
 func TestStreamingNudgeGoesOverStatusChannel(t *testing.T) {
 	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
 	const clawID = "watchdog-nudge-status-channel"


### PR DESCRIPTION
OpenClaw frequently reported "session file changed while embedded prompt lock was released" — especially on the Replicated provider, where slower disk I/O stretches the session-flush window past the previous turn's lifecycle end event. The hub's 100ms inter-turn cooldown was not enough to cover that window, and when the race fired the bridge immediately rotated the session: the transcript was lost and the fresh session had no task context, so it sat idle waiting for instructions.

## Changes

- **Bridge: same-session retry first.** When `sessions.send` is *rejected* with the lock-conflict error, the turn was never accepted (no side effects), so the bridge now backs off (500ms / 1s / 2s / 4s, `sessionLockConflictRetryDelays`) and retries on the **same** session, preserving the transcript. Mid-turn lifecycle lock conflicts are excluded from retry since those turns may have side effects.
- **Bridge: rotation is the last resort.** Only after retries are exhausted does the bridge rotate via `createFreshSession`, and it surfaces the reset error instead of silently replaying, so recovery becomes visible. The now-unreachable lock-conflict fragment was removed from `isRecoverableSessionSendError`.
- **Bridge → hub: `session_rotated` notification.** When rotation does happen, the bridge notifies the hub.
- **Hub: resume prompt with context.** The hub handles `session_rotated` by enqueueing a resume prompt that repeats the assigned task and tells the agent to recover state from the workspace. The restart-resume builder was refactored so restart and session-rotation resumes share the same logic with distinct dedup markers.
- **Hub: resume throttle.** A session-rotated resume is skipped if one was already enqueued in the last 10 minutes — bounds the rotation → resume → rotation loop if lock conflicts persist across fresh sessions (rotation turns complete with an empty reply, so the no-progress watchdog would never break the cycle).
- **Hub: inter-turn cooldown removed.** `sendNextQueuedMessage` no longer sleeps between turns — lock-conflict recovery now lives where the lock state lives (the bridge).

## Verification

- `go build ./...`
- `go vet ./cmd/claw-bridge ./pkg/hub`
- `go test ./cmd/claw-bridge ./pkg/hub -count=1`
- New tests: same-session retry succeeds without rotation; rotation only after retries exhausted (error recognized by `isSessionRotatedError`); immediate queued-message delivery after turn end; resume prompt throttled inside the 10-minute window and re-allowed after it; watchdog tests for the resume prompt.