### PR TITLE
[AIEDEV-15] Add scheduled agent routines

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,15 @@ Create and inspect agents, manage workspaces and workflows, configure providers,
 
 Use webhooks and the ElasticClaw Server API to connect private queues, release events, internal systems, or scheduled work.
 
+### Scheduled routines
+
+Cron-triggered workflows are shown as **Routines** in the dashboard. The Hub
+owns the schedule, starts an isolated agent for each run, and records the run
+history. Configure a cron expression, IANA timezone, overlap policy, and
+optional timeout under `trigger.cron`.
+
+See the [scheduled routine example](examples/workflows/scheduled-routine.yaml).
+
 ## Architecture
 
 ElasticClaw has four main moving parts:

--- a/examples/workflows/scheduled-routine.yaml
+++ b/examples/workflows/scheduled-routine.yaml
@@ -1,0 +1,25 @@
+schema_version: v1
+name: dependency-health
+
+trigger:
+  cron:
+    schedule: "0 9 * * 1-5"
+    timezone: America/Argentina/Buenos_Aires
+    overlap_policy: skip
+    timeout: 2h
+
+stages:
+  - id: working
+    label: Working
+    entry: true
+    on_enter:
+      inject: |
+        Inspect dependency health in the configured repositories.
+        Apply safe updates, run the relevant tests, and open a pull request
+        when changes are required. When the routine is complete, say [DONE].
+
+  - id: completed
+    label: Completed
+    terminal: true
+    triggers:
+      - message_contains: "[DONE]"

--- a/pkg/hub/cron_scheduler.go
+++ b/pkg/hub/cron_scheduler.go
@@ -259,29 +259,53 @@ func (cs *cronScheduler) runWorkflow(sw *scheduledWorkflow) (workflowRunStartSta
 	// Record run start
 	cs.recordRun(runID, sw, "running", "", string(contextJSON))
 
-	// Build inputs (empty for cron, but could be extended)
-	inputs := make(map[string]string)
+	// Scheduled workflows cannot prompt an operator for inputs, so resolve
+	// declared defaults and fail the run if a required input has no default.
+	rawInputs := make(map[string]interface{})
+	for _, input := range sw.workflow.Inputs {
+		if input.Default != "" {
+			rawInputs[input.Name] = input.Default
+		}
+	}
+	inputs, err := validateFactoryInputs(sw.workflow.Inputs, rawInputs)
+	if err != nil {
+		result := fmt.Sprintf("invalid scheduled inputs: %v", err)
+		log.Printf("[cron] failed to resolve inputs for %s: %v", key, err)
+		cs.failRun(runID, result)
+		cs.releaseWorkflowSlot(key)
+		return workflowRunFailed, err
+	}
+
+	timeoutAt := time.Time{}
+	if sw.trigger.Timeout != "" {
+		timeout, err := time.ParseDuration(sw.trigger.Timeout)
+		if err != nil {
+			result := fmt.Sprintf("invalid timeout: %v", err)
+			log.Printf("[cron] failed to resolve timeout for %s: %v", key, err)
+			cs.failRun(runID, result)
+			cs.releaseWorkflowSlot(key)
+			return workflowRunFailed, err
+		}
+		timeoutAt = now.Add(timeout)
+	}
 
 	// Create claw
 	clawID, _, err := cs.srv.createClawFromWorkflowWithOptions(
 		sw.workspace,
 		sw.workflow,
 		workflowCreateOptions{
-			inputs:   inputs,
-			reason:   fmt.Sprintf("cron run %s at %s", runID, now.Format(time.RFC3339)),
-			clawName: fmt.Sprintf("%s-%s", sw.workflow.Name, now.Format("20060102-150405")),
+			inputs:      inputs,
+			triggerKind: "routine",
+			reason:      fmt.Sprintf("cron run %s at %s", runID, now.Format(time.RFC3339)),
+			clawName:    fmt.Sprintf("%s-%s", sw.workflow.Name, now.Format("20060102-150405")),
+			timeoutAt:   timeoutAt,
 		},
 	)
 	if err != nil {
 		log.Printf("[cron] failed to create claw for %s: %v", key, err)
 		cs.failRun(runID, fmt.Sprintf("failed to create claw: %v", err))
 		// No claw was created, so decrement the running counter immediately
-		cs.runningMu.Lock()
-		cs.running[key]--
-		if cs.running[key] < 0 {
-			cs.running[key] = 0
-		}
-		cs.runningMu.Unlock()
+		cs.releaseWorkflowSlot(key)
 		return workflowRunFailed, err
 	}
 
@@ -295,6 +319,15 @@ func (cs *cronScheduler) runWorkflow(sw *scheduledWorkflow) (workflowRunStartSta
 
 	log.Printf("[cron] started run %s for %s (claw %s)", runID, key, clawID)
 	return workflowRunStarted, nil
+}
+
+func (cs *cronScheduler) releaseWorkflowSlot(key string) {
+	cs.runningMu.Lock()
+	cs.running[key]--
+	if cs.running[key] < 0 {
+		cs.running[key] = 0
+	}
+	cs.runningMu.Unlock()
 }
 
 // recordRun inserts a workflow run record for a scheduled workflow.
@@ -394,12 +427,7 @@ func (cs *cronScheduler) releaseClawWorkflowSlot(clawID string) {
 	cs.clawWorkflowMu.Unlock()
 
 	if ok {
-		cs.runningMu.Lock()
-		cs.running[key]--
-		if cs.running[key] < 0 {
-			cs.running[key] = 0
-		}
-		cs.runningMu.Unlock()
+		cs.releaseWorkflowSlot(key)
 	}
 }
 

--- a/pkg/hub/cron_scheduler_test.go
+++ b/pkg/hub/cron_scheduler_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -246,6 +247,124 @@ func TestCronWorkflowTriggerValidation(t *testing.T) {
 				t.Errorf("WorkflowConfig.Validate() unexpected error: %v", err)
 			}
 		})
+	}
+}
+
+func TestCronRunUsesInputDefaultsAndEnforcesTimeout(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{
+		Token:     "test-token",
+		ClawToken: "test-claw-token",
+		Providers: map[string]types.ProviderConfig{"noop": {Type: "noop"}},
+	}, "", "", "")
+	cs := newCronScheduler(s)
+	startedAt := time.Now().UTC()
+	sw := &scheduledWorkflow{
+		key: "engineering/dependency-health",
+		workspace: &types.WorkspaceConfig{
+			Name: "engineering",
+			Files: map[string]string{
+				"elasticclaw-config.yaml": "schema_version: v1\nname: engineering\nprovider: noop\n",
+			},
+		},
+		workflow: &types.WorkflowConfig{
+			Name:     "dependency-health",
+			Provider: "noop",
+			Inputs: []types.FactoryInput{{
+				Name:     "repository",
+				Type:     "string",
+				Required: true,
+				Default:  "elasticclaw/elasticclaw",
+			}},
+		},
+		trigger: &types.CronWorkflowTrigger{
+			Schedule: "0 9 * * *",
+			Timeout:  "2h",
+		},
+	}
+
+	status, err := cs.runWorkflow(sw)
+	if err != nil {
+		t.Fatalf("run workflow: %v", err)
+	}
+	if status != workflowRunStarted {
+		t.Fatalf("status = %q, want %q", status, workflowRunStarted)
+	}
+
+	var clawID, templateFiles, tagsJSON string
+	if err := db.QueryRow(`SELECT id, template_files, tags FROM claws WHERE name LIKE 'dependency-health-%'`).Scan(&clawID, &templateFiles, &tagsJSON); err != nil {
+		t.Fatalf("read created claw: %v", err)
+	}
+	var tags []string
+	if err := json.Unmarshal([]byte(tagsJSON), &tags); err != nil {
+		t.Fatalf("decode claw tags: %v", err)
+	}
+	if len(tags) == 0 || tags[0] != "routine" {
+		t.Fatalf("claw tags = %#v, want routine origin first", tags)
+	}
+	for _, tag := range tags {
+		if tag == "manual-trigger" {
+			t.Fatalf("scheduled claw tags = %#v, must not include manual-trigger", tags)
+		}
+	}
+	var files map[string]string
+	if err := json.Unmarshal([]byte(templateFiles), &files); err != nil {
+		t.Fatalf("decode template files: %v", err)
+	}
+	var triggerInputs map[string]string
+	if err := json.Unmarshal([]byte(files["TRIGGER_INPUTS.json"]), &triggerInputs); err != nil {
+		t.Fatalf("decode scheduled trigger inputs: %v", err)
+	}
+	if triggerInputs["repository"] != "elasticclaw/elasticclaw" {
+		t.Fatalf("scheduled input default = %q, want elasticclaw/elasticclaw", triggerInputs["repository"])
+	}
+
+	var timeoutAt int64
+	if err := db.QueryRow(`SELECT timeout_at FROM task_runs WHERE claw_id=?`, clawID).Scan(&timeoutAt); err != nil {
+		t.Fatalf("read task timeout: %v", err)
+	}
+	wantTimeout := startedAt.Add(2 * time.Hour).UnixMilli()
+	if timeoutAt < wantTimeout-5_000 || timeoutAt > wantTimeout+5_000 {
+		t.Fatalf("timeout_at = %d, want approximately %d", timeoutAt, wantTimeout)
+	}
+}
+
+func TestCronRunRejectsRequiredInputWithoutDefault(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+	cs := newCronScheduler(s)
+	sw := &scheduledWorkflow{
+		key:       "engineering/report",
+		workspace: &types.WorkspaceConfig{Name: "engineering"},
+		workflow: &types.WorkflowConfig{
+			Name: "report",
+			Inputs: []types.FactoryInput{{
+				Name:     "project",
+				Type:     "string",
+				Required: true,
+			}},
+		},
+		trigger: &types.CronWorkflowTrigger{Schedule: "0 9 * * *"},
+	}
+
+	status, err := cs.runWorkflow(sw)
+	if err == nil {
+		t.Fatal("expected required scheduled input error")
+	}
+	if status != workflowRunFailed {
+		t.Fatalf("status = %q, want %q", status, workflowRunFailed)
+	}
+	if cs.running[sw.key] != 0 {
+		t.Fatalf("running slot count = %d, want 0", cs.running[sw.key])
+	}
+
+	var runStatus, result string
+	if err := db.QueryRow(`SELECT status, result FROM workflow_runs WHERE workspace_name=? AND workflow_name=?`, "engineering", "report").Scan(&runStatus, &result); err != nil {
+		t.Fatalf("read failed workflow run: %v", err)
+	}
+	if runStatus != "failed" || !strings.Contains(result, `missing required input "project"`) {
+		t.Fatalf("run status/result = %q/%q", runStatus, result)
 	}
 }
 

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -735,6 +735,9 @@ func migrate(db *sql.DB) error {
 	if err := backfillTaskRunReadyAtV1(db); err != nil {
 		return err
 	}
+	if err := migrateCompletedRoutineHistoryV1(db); err != nil {
+		return err
+	}
 	for _, p := range []struct {
 		model                          string
 		in, out, cacheRead, cacheWrite float64
@@ -754,6 +757,47 @@ func migrate(db *sql.DB) error {
 		}
 	}
 	return nil
+}
+
+// migrateCompletedRoutineHistoryV1 restores successful routine runs that older
+// versions marked deleted when terminating their sandbox. Their messages were
+// preserved, so changing only the claw status makes that history visible.
+// The routine tag keeps intentional user deletions and unrelated terminal
+// workflows hidden.
+func migrateCompletedRoutineHistoryV1(db *sql.DB) error {
+	const migration = "completed_routine_history_v1"
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS hub_migrations (name TEXT PRIMARY KEY, applied_at INTEGER NOT NULL)`); err != nil {
+		return fmt.Errorf("create hub migrations: %w", err)
+	}
+	var applied int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM hub_migrations WHERE name=?`, migration).Scan(&applied); err != nil {
+		return fmt.Errorf("check completed routine history migration: %w", err)
+	}
+	if applied > 0 {
+		return nil
+	}
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if _, err := tx.Exec(`
+		UPDATE claws
+		   SET status='completed'
+		 WHERE status='deleted'
+		   AND tags LIKE '%"routine"%'
+		   AND EXISTS (
+		       SELECT 1
+		         FROM workflow_runs
+		        WHERE workflow_runs.claw_id=claws.id
+		          AND workflow_runs.status='completed'
+		   )`); err != nil {
+		return fmt.Errorf("restore completed routine history: %w", err)
+	}
+	if _, err := tx.Exec(`INSERT INTO hub_migrations(name, applied_at) VALUES(?, ?)`, migration, now().UnixMilli()); err != nil {
+		return fmt.Errorf("record completed routine history migration: %w", err)
+	}
+	return tx.Commit()
 }
 
 func rebuildTaskRunSummariesStatusV3(db *sql.DB) error {

--- a/pkg/hub/doctor_runtime.go
+++ b/pkg/hub/doctor_runtime.go
@@ -39,7 +39,7 @@ func (s *Server) checkRuntimeState(ctx context.Context) []DoctorCheck {
 		current.Add(-2*cfg.offlineGrace), current.Add(-2*cfg.provisioningMaxAge))
 	appendTimestampCheck("Orphaned workflow runs", runtimeBootReconciliationHint, `
 		SELECT COUNT(*), MIN(CAST(strftime('%s', COALESCE(started_at, created_at)) AS INTEGER)) FROM workflow_runs
-		WHERE status='running' AND (claw_id='' OR NOT EXISTS (SELECT 1 FROM claws c WHERE c.id=workflow_runs.claw_id) OR EXISTS (SELECT 1 FROM claws c WHERE c.id=workflow_runs.claw_id AND c.status IN ('error','deleted')))`)
+		WHERE status='running' AND (claw_id='' OR NOT EXISTS (SELECT 1 FROM claws c WHERE c.id=workflow_runs.claw_id) OR EXISTS (SELECT 1 FROM claws c WHERE c.id=workflow_runs.claw_id AND c.status IN ('completed','error','deleted')))`)
 	appendTimestampCheck("Unassigned claimed factory triggers", runtimeReaperHint+runtimeAgeMarginHint, `
 		SELECT COUNT(*), MIN(CAST(strftime('%s', created_at) AS INTEGER)) FROM factory_triggers
 		WHERE status='claimed' AND claw_id='' AND created_at < ?`, current.Add(-2*cfg.claimTTL))

--- a/pkg/hub/done_signal_test.go
+++ b/pkg/hub/done_signal_test.go
@@ -380,7 +380,7 @@ func TestHandleClawDoneSignal_IssueLessWorkflowCompletesWithoutPR(t *testing.T) 
 	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
 	s.cronScheduler = newCronScheduler(s)
 	const clawID = "claw-issue-less-done"
-	_, err := db.Exec(`INSERT INTO claws(id, tenant_id, name, template, status, created_at) VALUES(?,?,?,?,?,datetime('now'))`, clawID, "test-tenant-id", "workflow claw", "base", "connected")
+	_, err := db.Exec(`INSERT INTO claws(id, tenant_id, name, template, status, tags, created_at) VALUES(?,?,?,?,?,?,datetime('now'))`, clawID, "test-tenant-id", "workflow claw", "base", "connected", `["routine"]`)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -396,8 +396,8 @@ func TestHandleClawDoneSignal_IssueLessWorkflowCompletesWithoutPR(t *testing.T) 
 	if err := db.QueryRow(`SELECT status FROM workflow_runs WHERE id=?`, "run-issue-less-done").Scan(&runStatus); err != nil {
 		t.Fatal(err)
 	}
-	if clawStatus != "deleted" || runStatus != "completed" {
-		t.Fatalf("statuses = claw %q, run %q; want deleted, completed", clawStatus, runStatus)
+	if clawStatus != "completed" || runStatus != "completed" {
+		t.Fatalf("statuses = claw %q, run %q; want completed, completed", clawStatus, runStatus)
 	}
 }
 

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -1589,7 +1589,8 @@ func (s *Server) completeNoPRDoneClaw(clawID, tenantID, issueID string) {
 	if err := s.db.QueryRow(`SELECT COALESCE(provider,''), COALESCE(provider_id,'') FROM claws WHERE id=? AND tenant_id=?`, clawID, tenantID).Scan(&provider, &providerID); err != nil {
 		return
 	}
-	applied, err := s.finishClawTerminalTx(clawID, "deleted", "", "completed", "success", terminalTxOpts{})
+	clawStatus := s.successfulClawTerminalStatus(clawID)
+	applied, err := s.finishClawTerminalTx(clawID, clawStatus, "", "completed", "success", terminalTxOpts{})
 	if err != nil || !applied {
 		return
 	}
@@ -1610,7 +1611,7 @@ func (s *Server) completeNoPRDoneClaw(clawID, tenantID, issueID string) {
 	}
 	s.broadcastToUsers(tenantID, types.WSMessage{
 		Type:    "claw_status",
-		Payload: map[string]string{"claw_id": clawID, "status": "deleted"},
+		Payload: map[string]string{"claw_id": clawID, "status": clawStatus},
 	})
 	s.mu.Lock()
 	if cc, ok := s.claws[clawID]; ok {

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -1558,7 +1558,11 @@ func (s *Server) transitionResolvedPipelineStageWithContext(clawID string, stage
 		s.syncWorkflowVolumes(clawID)
 
 		status, result := pipelineTerminalWorkflowRunResult(stage, stageActionsSucceeded)
-		applied, err := s.finishClawTerminalTx(clawID, "deleted", "", status, result, terminalTxOpts{})
+		clawStatus := s.successfulClawTerminalStatus(clawID)
+		if status == "failed" {
+			clawStatus = "error"
+		}
+		applied, err := s.finishClawTerminalTx(clawID, clawStatus, result, status, result, terminalTxOpts{})
 		if err != nil || !applied {
 			return transitioned, injectDelivered
 		}
@@ -1574,7 +1578,7 @@ func (s *Server) transitionResolvedPipelineStageWithContext(clawID string, stage
 
 		s.broadcastToUsers(tenantID, types.WSMessage{
 			Type:    "claw_status",
-			Payload: map[string]string{"claw_id": clawID, "status": "deleted"},
+			Payload: map[string]string{"claw_id": clawID, "status": clawStatus},
 		})
 
 		if providerID != "" {
@@ -2246,10 +2250,10 @@ func (s *Server) findPipelineContextForClaw(clawID string) (pipelineContext, boo
 func (s *Server) findPipelineContextForIssue(issueID string) (pipelineContext, bool) {
 	var clawID string
 	queries := []string{
-		`SELECT id FROM claws WHERE linear_issue_id=? AND status NOT IN ('error','deleted') ORDER BY created_at DESC LIMIT 1`,
-		`SELECT id FROM claws WHERE github_issue_id=? AND status NOT IN ('error','deleted') ORDER BY created_at DESC LIMIT 1`,
-		`SELECT id FROM claws WHERE shortcut_story_id=? AND status NOT IN ('error','deleted') ORDER BY created_at DESC LIMIT 1`,
-		`SELECT id FROM claws WHERE jira_issue_id=? AND status NOT IN ('error','deleted') ORDER BY created_at DESC LIMIT 1`,
+		`SELECT id FROM claws WHERE linear_issue_id=? AND status NOT IN ('completed','error','deleted') ORDER BY created_at DESC LIMIT 1`,
+		`SELECT id FROM claws WHERE github_issue_id=? AND status NOT IN ('completed','error','deleted') ORDER BY created_at DESC LIMIT 1`,
+		`SELECT id FROM claws WHERE shortcut_story_id=? AND status NOT IN ('completed','error','deleted') ORDER BY created_at DESC LIMIT 1`,
+		`SELECT id FROM claws WHERE jira_issue_id=? AND status NOT IN ('completed','error','deleted') ORDER BY created_at DESC LIMIT 1`,
 	}
 	for _, query := range queries {
 		if err := s.db.QueryRow(query, issueID).Scan(&clawID); err == nil && clawID != "" {

--- a/pkg/hub/reaper.go
+++ b/pkg/hub/reaper.go
@@ -115,7 +115,7 @@ func (s *Server) reconcileOnBoot() {
 		s.stopAgentWithReason(c.id, "hub restarted during provisioning", false)
 	}
 	n := s.reaperNow()
-	if res, err := s.db.Exec(`UPDATE workflow_runs SET status='failed', result='orphaned by hub restart', finished_at=? WHERE status='running' AND (claw_id='' OR NOT EXISTS (SELECT 1 FROM claws c WHERE c.id=workflow_runs.claw_id) OR EXISTS (SELECT 1 FROM claws c WHERE c.id=workflow_runs.claw_id AND c.status IN ('error','deleted')))`, n); err != nil {
+	if res, err := s.db.Exec(`UPDATE workflow_runs SET status='failed', result='orphaned by hub restart', finished_at=? WHERE status='running' AND (claw_id='' OR NOT EXISTS (SELECT 1 FROM claws c WHERE c.id=workflow_runs.claw_id) OR EXISTS (SELECT 1 FROM claws c WHERE c.id=workflow_runs.claw_id AND c.status IN ('completed','error','deleted')))`, n); err != nil {
 		log.Printf("[reaper] boot workflow repair: %v", err)
 	} else if count, _ := res.RowsAffected(); count > 0 {
 		log.Printf("[reaper] boot failed %d orphaned workflow runs", count)
@@ -212,7 +212,7 @@ func (s *Server) reapOnce() {
 		}
 	}
 	type vm struct{ id, provider, providerID string }
-	vmRows, err := s.db.Query(`SELECT id, COALESCE(provider,''), provider_id FROM claws WHERE status IN ('error','deleted') AND provider_id != ''`)
+	vmRows, err := s.db.Query(`SELECT id, COALESCE(provider,''), provider_id FROM claws WHERE status IN ('completed','error','deleted') AND provider_id != ''`)
 	if err == nil {
 		var vms []vm
 		for vmRows.Next() {
@@ -262,7 +262,7 @@ func (s *Server) reapOnce() {
 	// A terminal pipeline stage is claimed before its terminal transaction is
 	// committed. If that transaction exhausts its short retry budget, recover it
 	// here rather than leaving the claimed stage and workflow run running forever.
-	terminalRows, err := s.db.Query(`SELECT c.id, c.pipeline_stage FROM claws c WHERE c.status NOT IN ('error','deleted') AND c.pipeline_stage != '' AND EXISTS (SELECT 1 FROM workflow_runs wr WHERE wr.claw_id=c.id AND wr.status='running')`)
+	terminalRows, err := s.db.Query(`SELECT c.id, c.pipeline_stage FROM claws c WHERE c.status NOT IN ('completed','error','deleted') AND c.pipeline_stage != '' AND EXISTS (SELECT 1 FROM workflow_runs wr WHERE wr.claw_id=c.id AND wr.status='running')`)
 	if err == nil {
 		type terminalCandidate struct{ id, stageID string }
 		var candidates []terminalCandidate

--- a/pkg/hub/routine_draft.go
+++ b/pkg/hub/routine_draft.go
@@ -1,0 +1,396 @@
+package hub
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+const routineDraftSystemPrompt = `You draft scheduled ElasticClaw agent routines.
+Return exactly one JSON object and no markdown or commentary:
+{"name":"kebab-case-name","task":"clear agent instruction","schedule":"five-field cron","timezone":"IANA timezone","overlapPolicy":"skip or parallel","timeout":"Go duration"}
+
+Rules:
+- Infer a practical schedule from the request. If it is ambiguous, use 0 9 * * 1-5.
+- Use the requested timezone; otherwise use the supplied browser timezone.
+- The task must be self-contained, concrete, and mention verification or reporting when appropriate.
+- Use "skip" unless concurrent runs are explicitly useful.
+- Use a realistic timeout such as 30m, 1h, or 2h.
+- Never include secrets, credentials, markdown, or extra JSON fields.`
+
+var routineNamePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
+
+var routineDraftCommandContext = exec.CommandContext
+
+const (
+	routineDraftCodexTimeout = 2 * time.Minute
+	routineDraftMaxAuthFile  = 2 * 1024 * 1024
+	routineDraftMaxAuthTotal = 10 * 1024 * 1024
+	routineDraftMaxCLIOutput = 8 * 1024
+)
+
+type routineDraftRequest struct {
+	Description string `json:"description"`
+	Timezone    string `json:"timezone"`
+}
+
+type routineDraftResponse struct {
+	Name          string `json:"name"`
+	Task          string `json:"task"`
+	Schedule      string `json:"schedule"`
+	Timezone      string `json:"timezone"`
+	OverlapPolicy string `json:"overlapPolicy"`
+	Timeout       string `json:"timeout"`
+}
+
+func (s *Server) handleRoutineDraft(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	workspaceName := strings.TrimSpace(r.PathValue("workspace"))
+	if workspaceName == "" {
+		http.Error(w, "workspace name required", http.StatusBadRequest)
+		return
+	}
+	workspace, err := loadExternalWorkspace(workspaceName)
+	if err != nil {
+		http.Error(w, "workspace not found", http.StatusNotFound)
+		return
+	}
+
+	var req routineDraftRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 32*1024)).Decode(&req); err != nil {
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	req.Description = strings.TrimSpace(req.Description)
+	if req.Description == "" {
+		http.Error(w, "description required", http.StatusBadRequest)
+		return
+	}
+	if len(req.Description) > 4000 {
+		http.Error(w, "description must be 4000 characters or fewer", http.StatusBadRequest)
+		return
+	}
+	req.Timezone = strings.TrimSpace(req.Timezone)
+	if req.Timezone == "" {
+		req.Timezone = "UTC"
+	}
+	if _, err := time.LoadLocation(req.Timezone); err != nil {
+		req.Timezone = "UTC"
+	}
+
+	repositories := make([]string, 0, len(workspace.Repositories))
+	for _, repository := range workspace.Repositories {
+		if repository.Repo != "" {
+			repositories = append(repositories, repository.Repo)
+		}
+	}
+	userPrompt := fmt.Sprintf(
+		"Workspace: %s\nRepositories: %s\nBrowser timezone: %s\n\nRoutine request:\n%s",
+		workspace.Name,
+		strings.Join(repositories, ", "),
+		req.Timezone,
+		req.Description,
+	)
+
+	s.mu.RLock()
+	llmKeys := cloneLLMKeys(s.hubCfg.LLMKeys)
+	defaultModel := s.hubCfg.DefaultModel
+	modelAuthProfiles := cloneModelAuthProfiles(s.hubCfg.ModelAuthProfiles)
+	s.mu.RUnlock()
+
+	raw, err := callLLMForRoutineDraft(r.Context(), userPrompt, llmKeys, defaultModel, modelAuthProfiles)
+	if err != nil {
+		http.Error(w, "unable to draft routine: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+	draft, err := parseRoutineDraft(raw, req.Timezone)
+	if err != nil {
+		http.Error(w, "the configured model returned an invalid routine: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+	jsonOK(w, draft)
+}
+
+func callLLMForRoutineDraft(
+	ctx context.Context,
+	prompt string,
+	llmKeys types.LLMKeysList,
+	defaultModel string,
+	modelAuthProfiles []*types.ModelAuthProfileConfig,
+) (string, error) {
+	choice, err := selectAIConfigProvider(llmKeys, defaultModel)
+	if err != nil {
+		return "", err
+	}
+	messages := []aiChatMessage{{Role: "user", Content: prompt}}
+	if choice.Anthropic {
+		return callAnthropicModel(ctx, choice.Key.APIKey, "claude-sonnet-4-6", routineDraftSystemPrompt, messages, 1200)
+	}
+	if choice.Key.APIKey == "" && choice.Key.Provider == "codex" && choice.Key.AuthProfile != "" {
+		profile := findModelAuthProfile(modelAuthProfiles, choice.Key.Provider, choice.Key.AuthProfile)
+		if profile == nil || profile.AuthState == "" {
+			return "", fmt.Errorf("Codex auth profile %q is not configured", choice.Key.AuthProfile)
+		}
+		return callCodexCLIForRoutineDraft(ctx, prompt, choice.Model, profile.AuthState)
+	}
+	if choice.Key.APIKey == "" && choice.Key.Provider != "ollama" {
+		return "", fmt.Errorf("the selected %s model requires an API key or supported CLI auth profile", choice.Key.Provider)
+	}
+	return callOpenAICompatible(ctx, choice.Provider, choice.Key.APIKey, choice.Model, routineDraftSystemPrompt, messages)
+}
+
+func cloneModelAuthProfiles(profiles []*types.ModelAuthProfileConfig) []*types.ModelAuthProfileConfig {
+	cloned := make([]*types.ModelAuthProfileConfig, len(profiles))
+	for i, profile := range profiles {
+		if profile == nil {
+			continue
+		}
+		copy := *profile
+		cloned[i] = &copy
+	}
+	return cloned
+}
+
+func findModelAuthProfile(profiles []*types.ModelAuthProfileConfig, provider, name string) *types.ModelAuthProfileConfig {
+	for _, profile := range profiles {
+		if profile != nil && profile.Provider == provider && profile.Name == name {
+			return profile
+		}
+	}
+	return nil
+}
+
+func callCodexCLIForRoutineDraft(ctx context.Context, prompt, model, authState string) (string, error) {
+	authRoot, err := os.MkdirTemp("", "elasticclaw-routine-draft-*")
+	if err != nil {
+		return "", fmt.Errorf("create temporary Codex home: %w", err)
+	}
+	defer os.RemoveAll(authRoot)
+	if err := os.Chmod(authRoot, 0o700); err != nil {
+		return "", fmt.Errorf("secure temporary Codex home: %w", err)
+	}
+	if err := restoreCLIAuthBundle(authRoot, authState); err != nil {
+		return "", fmt.Errorf("restore Codex auth profile: %w", err)
+	}
+
+	schemaPath := filepath.Join(authRoot, "routine-draft.schema.json")
+	if err := os.WriteFile(schemaPath, []byte(routineDraftJSONSchema), 0o600); err != nil {
+		return "", fmt.Errorf("write routine draft schema: %w", err)
+	}
+	outputPath := filepath.Join(authRoot, "routine-draft.json")
+	workspacePath := filepath.Join(authRoot, "workspace")
+	if err := os.Mkdir(workspacePath, 0o700); err != nil {
+		return "", fmt.Errorf("create temporary Codex workspace: %w", err)
+	}
+
+	runCtx, cancel := context.WithTimeout(ctx, routineDraftCodexTimeout)
+	defer cancel()
+	args := []string{
+		"exec",
+		"--ephemeral",
+		"--ignore-user-config",
+		"--ignore-rules",
+		"--sandbox", "read-only",
+		"--skip-git-repo-check",
+		"--color", "never",
+		"--output-schema", schemaPath,
+		"--output-last-message", outputPath,
+		"--cd", workspacePath,
+	}
+	if strings.TrimSpace(model) != "" {
+		args = append(args, "--model", model)
+	}
+	args = append(args, "-")
+
+	cmd := routineDraftCommandContext(runCtx, "codex", args...)
+	cmd.Env = routineDraftCodexEnv(authRoot)
+	cmd.Stdin = strings.NewReader(routineDraftSystemPrompt + "\n\n" + prompt)
+	var diagnostic cappedBuffer
+	diagnostic.max = routineDraftMaxCLIOutput
+	cmd.Stdout = &diagnostic
+	cmd.Stderr = &diagnostic
+	if err := cmd.Run(); err != nil {
+		if runCtx.Err() != nil {
+			return "", fmt.Errorf("Codex routine draft timed out: %w", runCtx.Err())
+		}
+		detail := strings.TrimSpace(diagnostic.String())
+		if detail == "" {
+			return "", fmt.Errorf("run Codex routine draft: %w", err)
+		}
+		return "", fmt.Errorf("run Codex routine draft: %w: %s", err, detail)
+	}
+
+	raw, err := os.ReadFile(outputPath)
+	if err != nil {
+		return "", fmt.Errorf("read Codex routine draft: %w", err)
+	}
+	if strings.TrimSpace(string(raw)) == "" {
+		return "", fmt.Errorf("Codex returned an empty routine draft")
+	}
+	return string(raw), nil
+}
+
+const routineDraftJSONSchema = `{
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["name", "task", "schedule", "timezone", "overlapPolicy", "timeout"],
+  "properties": {
+    "name": {"type": "string"},
+    "task": {"type": "string"},
+    "schedule": {"type": "string"},
+    "timezone": {"type": "string"},
+    "overlapPolicy": {"type": "string", "enum": ["skip", "parallel"]},
+    "timeout": {"type": "string"}
+  }
+}`
+
+func restoreCLIAuthBundle(root, authState string) error {
+	outer, err := base64.StdEncoding.DecodeString(authState)
+	if err != nil {
+		return fmt.Errorf("decode auth state: %w", err)
+	}
+	if len(outer) > routineDraftMaxAuthTotal {
+		return fmt.Errorf("auth bundle exceeds 10MiB")
+	}
+	var bundle cliAuthBundle
+	if err := json.Unmarshal(outer, &bundle); err != nil {
+		return fmt.Errorf("decode auth bundle: %w", err)
+	}
+	var total int
+	for rel, encoded := range bundle.Files {
+		clean := filepath.Clean(filepath.FromSlash(rel))
+		if clean == "." || clean == ".." || filepath.IsAbs(clean) || strings.HasPrefix(clean, ".."+string(os.PathSeparator)) {
+			return fmt.Errorf("auth bundle contains unsafe path %q", rel)
+		}
+		data, err := base64.StdEncoding.DecodeString(encoded)
+		if err != nil {
+			return fmt.Errorf("decode auth file %q: %w", rel, err)
+		}
+		if len(data) > routineDraftMaxAuthFile {
+			return fmt.Errorf("auth file %q exceeds 2MiB", rel)
+		}
+		total += len(data)
+		if total > routineDraftMaxAuthTotal {
+			return fmt.Errorf("auth bundle exceeds 10MiB")
+		}
+		path := filepath.Join(root, clean)
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			return fmt.Errorf("create auth directory for %q: %w", rel, err)
+		}
+		if err := os.WriteFile(path, data, 0o600); err != nil {
+			return fmt.Errorf("restore auth file %q: %w", rel, err)
+		}
+	}
+	return nil
+}
+
+func routineDraftCodexEnv(authRoot string) []string {
+	env := make([]string, 0, len(os.Environ())+3)
+	for _, entry := range os.Environ() {
+		key, _, _ := strings.Cut(entry, "=")
+		switch key {
+		case "HOME", "CODEX_HOME", "OPENAI_API_KEY", "CODEX_API_KEY":
+			continue
+		default:
+			env = append(env, entry)
+		}
+	}
+	return append(env,
+		"HOME="+authRoot,
+		"CODEX_HOME="+filepath.Join(authRoot, ".codex"),
+		"NO_COLOR=1",
+	)
+}
+
+type cappedBuffer struct {
+	buf bytes.Buffer
+	max int
+}
+
+func (b *cappedBuffer) Write(p []byte) (int, error) {
+	originalLen := len(p)
+	if b.max <= 0 || b.buf.Len() >= b.max {
+		return originalLen, nil
+	}
+	remaining := b.max - b.buf.Len()
+	if len(p) > remaining {
+		p = p[:remaining]
+	}
+	_, _ = b.buf.Write(p)
+	return originalLen, nil
+}
+
+func (b *cappedBuffer) String() string {
+	return b.buf.String()
+}
+
+var _ io.Writer = (*cappedBuffer)(nil)
+
+func parseRoutineDraft(raw, fallbackTimezone string) (*routineDraftResponse, error) {
+	raw = strings.TrimSpace(raw)
+	if strings.HasPrefix(raw, "```") {
+		raw = strings.TrimPrefix(raw, "```json")
+		raw = strings.TrimPrefix(raw, "```")
+		raw = strings.TrimSuffix(strings.TrimSpace(raw), "```")
+	}
+	start, end := strings.Index(raw, "{"), strings.LastIndex(raw, "}")
+	if start < 0 || end < start {
+		return nil, fmt.Errorf("response did not contain JSON")
+	}
+
+	var draft routineDraftResponse
+	if err := json.Unmarshal([]byte(raw[start:end+1]), &draft); err != nil {
+		return nil, fmt.Errorf("invalid JSON: %w", err)
+	}
+	draft.Name = strings.TrimSpace(draft.Name)
+	draft.Task = strings.TrimSpace(draft.Task)
+	draft.Schedule = strings.TrimSpace(draft.Schedule)
+	draft.Timezone = strings.TrimSpace(draft.Timezone)
+	draft.OverlapPolicy = strings.TrimSpace(draft.OverlapPolicy)
+	draft.Timeout = strings.TrimSpace(draft.Timeout)
+
+	if !routineNamePattern.MatchString(draft.Name) {
+		return nil, fmt.Errorf("name must use lowercase letters, numbers, and hyphens")
+	}
+	if draft.Task == "" {
+		return nil, fmt.Errorf("task is required")
+	}
+	if _, err := types.ParseCronSchedule(draft.Schedule); err != nil {
+		return nil, fmt.Errorf("invalid cron schedule: %w", err)
+	}
+	if draft.Timezone == "" {
+		draft.Timezone = fallbackTimezone
+	}
+	if _, err := time.LoadLocation(draft.Timezone); err != nil {
+		return nil, fmt.Errorf("invalid timezone %q", draft.Timezone)
+	}
+	if draft.OverlapPolicy == "" {
+		draft.OverlapPolicy = "skip"
+	}
+	if draft.OverlapPolicy != "skip" && draft.OverlapPolicy != "parallel" {
+		return nil, fmt.Errorf("overlap policy must be skip or parallel")
+	}
+	if draft.Timeout == "" {
+		draft.Timeout = "2h"
+	}
+	if _, err := time.ParseDuration(draft.Timeout); err != nil {
+		return nil, fmt.Errorf("invalid timeout: %w", err)
+	}
+	return &draft, nil
+}

--- a/pkg/hub/routine_draft_test.go
+++ b/pkg/hub/routine_draft_test.go
@@ -1,0 +1,256 @@
+package hub
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func TestCallLLMForRoutineDraftUsesCodexAuthProfile(t *testing.T) {
+	installRoutineDraftCodexHelper(t)
+
+	raw, err := callLLMForRoutineDraft(
+		context.Background(),
+		"Draft a weekday dependency review.",
+		types.LLMKeysList{{
+			Name:         "codex-chatgpt",
+			Provider:     "codex",
+			Default:      true,
+			DefaultModel: "codex/gpt-5.5",
+			AuthProfile:  "codex-default",
+		}},
+		"",
+		[]*types.ModelAuthProfileConfig{{
+			Name:      "codex-default",
+			Provider:  "codex",
+			Mode:      "device",
+			AuthState: testCodexAuthState(t),
+		}},
+	)
+	if err != nil {
+		t.Fatalf("draft with Codex auth profile: %v", err)
+	}
+	draft, err := parseRoutineDraft(raw, "UTC")
+	if err != nil {
+		t.Fatalf("parse Codex routine draft: %v", err)
+	}
+	if draft.Name != "dependency-health" {
+		t.Fatalf("draft name = %q, want dependency-health", draft.Name)
+	}
+}
+
+func TestCallLLMForRoutineDraftRejectsMissingCodexAuthProfile(t *testing.T) {
+	_, err := callLLMForRoutineDraft(
+		context.Background(),
+		"Draft a routine.",
+		types.LLMKeysList{{
+			Name:         "codex-chatgpt",
+			Provider:     "codex",
+			DefaultModel: "codex/gpt-5.5",
+			AuthProfile:  "missing",
+		}},
+		"",
+		nil,
+	)
+	if err == nil || !strings.Contains(err.Error(), `Codex auth profile "missing" is not configured`) {
+		t.Fatalf("error = %v, want missing Codex auth profile", err)
+	}
+}
+
+func TestCallCodexCLIForRoutineDraftCleansTemporaryAuth(t *testing.T) {
+	marker := installRoutineDraftCodexHelper(t)
+
+	raw, err := callCodexCLIForRoutineDraft(
+		context.Background(),
+		"Draft a weekday dependency review.",
+		"gpt-5.5",
+		testCodexAuthState(t),
+	)
+	if err != nil {
+		t.Fatalf("call Codex CLI: %v", err)
+	}
+	if !strings.Contains(raw, `"dependency-health"`) {
+		t.Fatalf("unexpected Codex output: %s", raw)
+	}
+	authRootBytes, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatalf("read helper marker: %v", err)
+	}
+	authRoot := strings.TrimSpace(string(authRootBytes))
+	if authRoot == "" {
+		t.Fatal("helper did not record temporary auth root")
+	}
+	if _, err := os.Stat(authRoot); !os.IsNotExist(err) {
+		t.Fatalf("temporary auth root still exists: %s", authRoot)
+	}
+}
+
+func TestRestoreCLIAuthBundleRejectsUnsafePath(t *testing.T) {
+	bundle := cliAuthBundle{
+		Files: map[string]string{
+			"../auth.json": base64.StdEncoding.EncodeToString([]byte("not-secret")),
+		},
+	}
+	data, err := json.Marshal(bundle)
+	if err != nil {
+		t.Fatalf("marshal auth bundle: %v", err)
+	}
+	state := base64.StdEncoding.EncodeToString(data)
+	if err := restoreCLIAuthBundle(t.TempDir(), state); err == nil || !strings.Contains(err.Error(), "unsafe path") {
+		t.Fatalf("error = %v, want unsafe path rejection", err)
+	}
+}
+
+func installRoutineDraftCodexHelper(t *testing.T) string {
+	t.Helper()
+	original := routineDraftCommandContext
+	routineDraftCommandContext = func(ctx context.Context, _ string, args ...string) *exec.Cmd {
+		helperArgs := append([]string{"-test.run=TestRoutineDraftCodexHelperProcess", "--"}, args...)
+		return exec.CommandContext(ctx, os.Args[0], helperArgs...)
+	}
+	t.Cleanup(func() {
+		routineDraftCommandContext = original
+	})
+	marker := filepath.Join(t.TempDir(), "auth-root")
+	t.Setenv("ELASTICCLAW_ROUTINE_DRAFT_HELPER", "1")
+	t.Setenv("ELASTICCLAW_ROUTINE_DRAFT_MARKER", marker)
+	return marker
+}
+
+func testCodexAuthState(t *testing.T) string {
+	t.Helper()
+	bundle := cliAuthBundle{
+		Files: map[string]string{
+			".codex/auth.json": base64.StdEncoding.EncodeToString([]byte(`{"test":"credential"}`)),
+		},
+	}
+	data, err := json.Marshal(bundle)
+	if err != nil {
+		t.Fatalf("marshal auth bundle: %v", err)
+	}
+	return base64.StdEncoding.EncodeToString(data)
+}
+
+func TestRoutineDraftCodexHelperProcess(t *testing.T) {
+	if os.Getenv("ELASTICCLAW_ROUTINE_DRAFT_HELPER") != "1" {
+		return
+	}
+	fail := func(format string, args ...any) {
+		_, _ = fmt.Fprintf(os.Stderr, format+"\n", args...)
+		os.Exit(2)
+	}
+
+	authPath := filepath.Join(os.Getenv("CODEX_HOME"), "auth.json")
+	info, err := os.Stat(authPath)
+	if err != nil {
+		fail("stat restored auth: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		fail("restored auth mode = %o, want 600", info.Mode().Perm())
+	}
+	auth, err := os.ReadFile(authPath)
+	if err != nil || string(auth) != `{"test":"credential"}` {
+		fail("restored auth content is invalid")
+	}
+	if os.Getenv("OPENAI_API_KEY") != "" || os.Getenv("CODEX_API_KEY") != "" {
+		fail("host API key leaked into Codex draft environment")
+	}
+
+	prompt, err := io.ReadAll(os.Stdin)
+	if err != nil || !strings.Contains(string(prompt), routineDraftSystemPrompt) {
+		fail("routine draft prompt was not provided")
+	}
+
+	var outputPath, schemaPath, model string
+	args := os.Args
+	for i, arg := range args {
+		switch arg {
+		case "--output-last-message":
+			if i+1 < len(args) {
+				outputPath = args[i+1]
+			}
+		case "--output-schema":
+			if i+1 < len(args) {
+				schemaPath = args[i+1]
+			}
+		case "--model":
+			if i+1 < len(args) {
+				model = args[i+1]
+			}
+		}
+	}
+	if outputPath == "" || schemaPath == "" || model == "" {
+		fail("missing required Codex arguments")
+	}
+	if _, err := os.Stat(schemaPath); err != nil {
+		fail("routine draft schema is unavailable: %v", err)
+	}
+	if err := os.WriteFile(
+		outputPath,
+		[]byte(`{"name":"dependency-health","task":"Inspect dependencies and report results.","schedule":"0 9 * * 1-5","timezone":"UTC","overlapPolicy":"skip","timeout":"2h"}`),
+		0o600,
+	); err != nil {
+		fail("write Codex output: %v", err)
+	}
+	if marker := os.Getenv("ELASTICCLAW_ROUTINE_DRAFT_MARKER"); marker != "" {
+		if err := os.WriteFile(marker, []byte(os.Getenv("HOME")), 0o600); err != nil {
+			fail("write helper marker: %v", err)
+		}
+	}
+	os.Exit(0)
+}
+
+func TestParseRoutineDraft(t *testing.T) {
+	draft, err := parseRoutineDraft(`{
+		"name": "dependency-health",
+		"task": "Inspect dependencies, apply safe updates, run tests, and report the result.",
+		"schedule": "0 9 * * 1-5",
+		"timezone": "America/Argentina/Buenos_Aires",
+		"overlapPolicy": "skip",
+		"timeout": "2h"
+	}`, "UTC")
+	if err != nil {
+		t.Fatalf("parse routine draft: %v", err)
+	}
+	if draft.Name != "dependency-health" || draft.Schedule != "0 9 * * 1-5" {
+		t.Fatalf("unexpected draft: %#v", draft)
+	}
+}
+
+func TestParseRoutineDraftAcceptsFencedJSONAndDefaults(t *testing.T) {
+	draft, err := parseRoutineDraft("```json\n"+
+		`{"name":"daily-review","task":"Review open work and report blockers.","schedule":"0 9 * * *","timezone":"","overlapPolicy":"","timeout":""}`+
+		"\n```", "America/Argentina/Buenos_Aires")
+	if err != nil {
+		t.Fatalf("parse routine draft: %v", err)
+	}
+	if draft.Timezone != "America/Argentina/Buenos_Aires" || draft.OverlapPolicy != "skip" || draft.Timeout != "2h" {
+		t.Fatalf("defaults not applied: %#v", draft)
+	}
+}
+
+func TestParseRoutineDraftRejectsInvalidFields(t *testing.T) {
+	tests := map[string]string{
+		"name":     `{"name":"Bad Name","task":"Do work.","schedule":"0 9 * * *","timezone":"UTC","overlapPolicy":"skip","timeout":"1h"}`,
+		"schedule": `{"name":"good-name","task":"Do work.","schedule":"not cron","timezone":"UTC","overlapPolicy":"skip","timeout":"1h"}`,
+		"timezone": `{"name":"good-name","task":"Do work.","schedule":"0 9 * * *","timezone":"Moon/Base","overlapPolicy":"skip","timeout":"1h"}`,
+		"overlap":  `{"name":"good-name","task":"Do work.","schedule":"0 9 * * *","timezone":"UTC","overlapPolicy":"queue","timeout":"1h"}`,
+		"timeout":  `{"name":"good-name","task":"Do work.","schedule":"0 9 * * *","timezone":"UTC","overlapPolicy":"skip","timeout":"later"}`,
+	}
+	for name, raw := range tests {
+		t.Run(name, func(t *testing.T) {
+			if _, err := parseRoutineDraft(raw, "UTC"); err == nil {
+				t.Fatal("expected invalid draft to fail")
+			}
+		})
+	}
+}

--- a/pkg/hub/routine_preflight.go
+++ b/pkg/hub/routine_preflight.go
@@ -1,0 +1,337 @@
+package hub
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/elasticclaw/elasticclaw/pkg/config"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+type RoutinePreflightCheck struct {
+	ID          string     `json:"id"`
+	Category    string     `json:"category"`
+	Status      string     `json:"status"` // pass, warning, error
+	Title       string     `json:"title"`
+	Description string     `json:"description"`
+	FixAction   *FixAction `json:"fixAction,omitempty"`
+}
+
+type RoutinePreflightResponse struct {
+	Ready  bool                    `json:"ready"`
+	Status string                  `json:"status"` // ready, needs_setup
+	Checks []RoutinePreflightCheck `json:"checks"`
+}
+
+type routinePreflightRequest struct {
+	Workflow *types.WorkflowConfig `json:"workflow"`
+}
+
+func (s *Server) handleRoutinePreflight(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	workspaceName := strings.TrimSpace(r.PathValue("workspace"))
+	workspace, err := loadExternalWorkspace(workspaceName)
+	if err != nil {
+		http.Error(w, "workspace not found", http.StatusNotFound)
+		return
+	}
+	var req routinePreflightRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 256*1024)).Decode(&req); err != nil {
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	if req.Workflow == nil {
+		http.Error(w, "workflow required", http.StatusBadRequest)
+		return
+	}
+	jsonOK(w, s.preflightRoutine(workspace, req.Workflow))
+}
+
+func (s *Server) handleSavedRoutinePreflight(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	workspaceName := strings.TrimSpace(r.PathValue("workspace"))
+	workflowName := strings.TrimSpace(r.PathValue("workflow"))
+	workspace, workflow, ok, err := s.resolveWorkflowConfig(workspaceName, workflowName)
+	if err != nil {
+		http.Error(w, "failed to load workflow: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if !ok {
+		http.Error(w, "workflow not found", http.StatusNotFound)
+		return
+	}
+	jsonOK(w, s.preflightRoutine(workspace, workflow))
+}
+
+func (s *Server) preflightRoutine(workspace *types.WorkspaceConfig, workflow *types.WorkflowConfig) RoutinePreflightResponse {
+	checks := make([]RoutinePreflightCheck, 0, 8)
+	add := func(id, category, status, title, description, target, label string) {
+		var action *FixAction
+		if target != "" {
+			action = &FixAction{Type: "navigate", Target: target, Label: label}
+		}
+		checks = append(checks, RoutinePreflightCheck{
+			ID: id, Category: category, Status: status, Title: title,
+			Description: description, FixAction: action,
+		})
+	}
+
+	workflowCopy := *workflow
+	workflow = &workflowCopy
+	if err := types.NormalizeWorkflowConfig(workflow); err != nil {
+		add("workflow-schema", "workflow", "error", "Invalid routine configuration", err.Error(), "", "")
+	} else if err := workflow.Validate(); err != nil {
+		add("workflow-schema", "workflow", "error", "Invalid routine configuration", err.Error(), "", "")
+	} else if workflow.Trigger == nil || workflow.Trigger.Cron == nil {
+		add("workflow-schema", "workflow", "error", "Routine schedule missing", "A routine must use a cron trigger.", "", "")
+	} else {
+		add("workflow-schema", "workflow", "pass", "Routine configuration is valid", "The workflow, cron schedule, timezone, and timeout are valid.", "", "")
+	}
+
+	var tmplCfg *types.TemplateConfig
+	if raw := workspace.Files["elasticclaw-config.yaml"]; raw != "" {
+		parsed, err := config.ParseTemplateConfig([]byte(raw))
+		if err != nil {
+			add("workspace-config", "workspace", "error", "Workspace configuration is invalid", err.Error(), "", "")
+		} else {
+			tmplCfg = parsed
+			add("workspace-config", "workspace", "pass", "Workspace configuration loaded", "The workspace agent configuration can be parsed.", "", "")
+		}
+	} else {
+		add("workspace-config", "workspace", "warning", "Workspace agent configuration not found", "No elasticclaw-config.yaml was found; Hub defaults will be used.", "", "")
+	}
+
+	s.mu.RLock()
+	hubCfg := *s.hubCfg
+	hubCfg.Providers = cloneProviderConfigs(s.hubCfg.Providers)
+	hubCfg.LLMKeys = append(types.LLMKeysList(nil), s.hubCfg.LLMKeys...)
+	hubCfg.ModelAuthProfiles = append([]*types.ModelAuthProfileConfig(nil), s.hubCfg.ModelAuthProfiles...)
+	hubCfg.GitHubApps = append([]*types.GitHubAppConfig(nil), s.hubCfg.GitHubApps...)
+	hubCfg.Secrets = cloneStringMap(s.hubCfg.Secrets)
+	hubCfg.MCPServers = append([]*types.MCPServerHubConfig(nil), s.hubCfg.MCPServers...)
+	s.mu.RUnlock()
+
+	provider := strings.TrimSpace(workflow.Provider)
+	if provider == "" && tmplCfg != nil {
+		provider = strings.TrimSpace(tmplCfg.Provider)
+	}
+	if provider == "" {
+		provider = defaultProviderFromConfig(&hubCfg)
+	}
+	if provider == "" {
+		add("sandbox-provider", "sandbox", "error", "No sandbox provider selected", "Configure one sandbox provider or select one in the workspace.", "/settings/runtimes", "Configure sandbox")
+	} else if providerErr := validateRoutineProvider(provider, hubCfg.Providers[provider], hubCfg.Providers); providerErr != "" {
+		add("sandbox-provider", "sandbox", "error", "Sandbox provider is not ready", providerErr, "/settings/runtimes", "Configure sandbox")
+	} else {
+		add("sandbox-provider", "sandbox", "pass", "Sandbox provider is configured", fmt.Sprintf("The routine will use the %q provider.", provider), "", "")
+	}
+
+	selectedKey, model := "", hubCfg.DefaultModel
+	if tmplCfg != nil {
+		selectedKey, model = tmplCfg.LLMKey, firstNonEmpty(tmplCfg.DefaultModel, model)
+	}
+	model, selectedKey = resolveModelAndLLMKey(&hubCfg, selectedKey, model)
+	activeKey := resolveActiveKey(hubCfg.LLMKeys, selectedKey)
+	switch {
+	case activeKey == nil:
+		add("model", "model", "error", "No model credential is available", "Configure an LLM key or supported authentication profile for agent runs.", "/settings/models", "Configure model")
+	case !llmKeyHasRequiredAPIKey(activeKey):
+		add("model", "model", "error", "Model credential is incomplete", fmt.Sprintf("Model key %q has no API key or authentication profile.", activeKey.Name), "/settings/models", "Configure model")
+	case activeKey.AuthProfile != "" && !routineAuthProfileReady(hubCfg.ModelAuthProfiles, activeKey):
+		add("model", "model", "error", "Model authentication profile is unavailable", fmt.Sprintf("Authentication profile %q for %s has no stored credential.", activeKey.AuthProfile, activeKey.Provider), "/settings/models", "Reconnect model")
+	case strings.TrimSpace(model) == "":
+		add("model", "model", "error", "No model selected", fmt.Sprintf("Model key %q does not resolve to a model.", activeKey.Name), "/settings/models", "Select model")
+	default:
+		add("model", "model", "pass", "Model authentication is configured", fmt.Sprintf("Agent runs will use %s with key %q.", model, activeKey.Name), "", "")
+	}
+
+	workspaceSecrets, secretErr := loadWorkspaceSecrets(workspace.Name)
+	if secretErr != nil {
+		add("secrets", "secrets", "error", "Workspace secrets could not be read", secretErr.Error(), "/settings/secrets", "Manage secrets")
+	} else {
+		missing := missingRoutineSecrets(workflow, tmplCfg, workspaceSecrets, hubCfg.Secrets)
+		if len(missing) > 0 {
+			add("secrets", "secrets", "error", "Required secrets are missing", "Configure these secret names: "+strings.Join(missing, ", ")+". Never paste secret values into agent chat.", "/settings/secrets", "Configure secrets")
+		} else {
+			add("secrets", "secrets", "pass", "Required secrets are available", "Every explicitly referenced workspace and workflow secret exists.", "", "")
+		}
+	}
+
+	repositories := workspace.Repositories
+	if len(repositories) == 0 {
+		add("github", "github", "warning", "No repositories are assigned", "The routine can run, but the agent will not receive a repository checkout.", "", "")
+	} else {
+		workspaceApps, _ := loadWorkspaceGitHubAppConfigs(workspace.Name)
+		apps := append(workspaceApps, hubCfg.GitHubApps...)
+		validApps := 0
+		for _, app := range apps {
+			if app != nil && app.AppID != 0 && strings.TrimSpace(app.PrivateKeyPEM) != "" {
+				validApps++
+			}
+		}
+		if validApps == 0 {
+			add("github", "github", "error", "GitHub App credentials are missing", "This workspace declares repositories, but no usable workspace or Hub GitHub App is configured.", "/settings/github", "Configure GitHub App")
+		} else {
+			add("github", "github", "pass", "GitHub App credentials are configured", fmt.Sprintf("%d repository selector(s) will be requested. Installation scope is confirmed when a short-lived token is minted.", len(repositories)), "", "")
+		}
+	}
+
+	if tmplCfg != nil {
+		missingMCP := missingRoutineMCPs(tmplCfg, hubCfg.MCPServers, workspaceSecrets, hubCfg.Secrets)
+		if len(missingMCP) > 0 {
+			add("mcp", "mcp", "error", "MCP configuration is incomplete", strings.Join(missingMCP, "; "), "/settings/mcp", "Configure MCP servers")
+		} else if len(tmplCfg.MCPs) > 0 {
+			add("mcp", "mcp", "pass", "MCP servers are configured", fmt.Sprintf("%d workspace MCP server(s) are available.", len(tmplCfg.MCPs)), "", "")
+		}
+	}
+
+	if workflow.Integration != "" {
+		trackerType := workflow.Integration
+		if trackerType == "github" {
+			trackerType = "github-issues"
+		}
+		switch trackerType {
+		case "linear", "shortcut", "github-issues", "jira":
+			tracker, ok := findWorkspaceIssueTracker(workspace.Name, trackerType, workflow.Workspace)
+			if !ok || strings.TrimSpace(tracker.Token) == "" {
+				add("integration", "integration", "error", "Issue tracker credential is missing", fmt.Sprintf("The %s integration used by this workflow has no workspace token.", trackerType), "/settings/issue-trackers", "Configure issue tracker")
+			} else {
+				add("integration", "integration", "pass", "Issue tracker credential is configured", fmt.Sprintf("The %s workspace token is available.", trackerType), "", "")
+			}
+		}
+	}
+
+	ready := true
+	for _, check := range checks {
+		if check.Status == "error" {
+			ready = false
+			break
+		}
+	}
+	status := "ready"
+	if !ready {
+		status = "needs_setup"
+	}
+	return RoutinePreflightResponse{Ready: ready, Status: status, Checks: checks}
+}
+
+func cloneProviderConfigs(in map[string]types.ProviderConfig) map[string]types.ProviderConfig {
+	out := make(map[string]types.ProviderConfig, len(in))
+	for name, provider := range in {
+		out[name] = provider
+	}
+	return out
+}
+
+func defaultProviderFromConfig(cfg *types.HubConfig) string {
+	var only string
+	for name, provider := range cfg.Providers {
+		if provider.Token != "" || provider.APIKey != "" || provider.AccessToken != "" {
+			return name
+		}
+		if name != "noop" && provider.Type != "noop" {
+			if only != "" {
+				return ""
+			}
+			only = name
+		}
+	}
+	return only
+}
+
+func validateRoutineProvider(name string, provider types.ProviderConfig, configured map[string]types.ProviderConfig) string {
+	if _, ok := configured[name]; !ok {
+		return fmt.Sprintf("Provider %q is not configured on this Hub.", name)
+	}
+	switch name {
+	case "daytona":
+		if provider.APIKey == "" {
+			return "Daytona is missing its API key."
+		}
+	case "replicated":
+		if provider.Token == "" {
+			return "Replicated is missing its token."
+		}
+	case "lambda-microvms":
+		if provider.ImageIdentifier == "" {
+			return "Lambda MicroVMs is missing its image identifier."
+		}
+	case "docker", "exedev":
+		return ""
+	default:
+		return fmt.Sprintf("Provider %q is not supported for routine agents.", name)
+	}
+	return ""
+}
+
+func routineAuthProfileReady(profiles []*types.ModelAuthProfileConfig, key *types.LLMKeyConfig) bool {
+	for _, profile := range profiles {
+		if profile != nil && profile.Name == key.AuthProfile && profile.Provider == key.Provider {
+			return strings.TrimSpace(profile.AuthState) != ""
+		}
+	}
+	return false
+}
+
+func missingRoutineSecrets(workflow *types.WorkflowConfig, tmplCfg *types.TemplateConfig, workspaceSecrets, hubSecrets map[string]string) []string {
+	required := map[string]bool{}
+	for _, ref := range workflow.SecretRefs {
+		required[ref] = true
+	}
+	if tmplCfg != nil {
+		for _, env := range tmplCfg.Env {
+			if env.Secret != "" {
+				required[env.Secret] = true
+			}
+		}
+		for _, ref := range tmplCfg.SecretRefs {
+			required[ref] = true
+		}
+		for _, ref := range tmplCfg.Secrets {
+			if ref.Type == "custom" && ref.Name != "" {
+				required[ref.Name] = true
+			}
+		}
+	}
+	missing := make([]string, 0)
+	for name := range required {
+		if strings.TrimSpace(workspaceSecrets[name]) == "" && strings.TrimSpace(hubSecrets[name]) == "" {
+			missing = append(missing, name)
+		}
+	}
+	sort.Strings(missing)
+	return missing
+}
+
+func missingRoutineMCPs(tmplCfg *types.TemplateConfig, configured []*types.MCPServerHubConfig, workspaceSecrets, hubSecrets map[string]string) []string {
+	servers := map[string]*types.MCPServerHubConfig{}
+	for _, server := range configured {
+		if server != nil {
+			servers[server.Name] = server
+		}
+	}
+	var missing []string
+	for _, ref := range tmplCfg.MCPs {
+		server := servers[ref.Name]
+		if server == nil || !server.Enabled {
+			missing = append(missing, fmt.Sprintf("MCP server %q is not enabled", ref.Name))
+			continue
+		}
+		for envName, secretRef := range server.Secrets {
+			if strings.TrimSpace(workspaceSecrets[secretRef]) == "" && strings.TrimSpace(hubSecrets[secretRef]) == "" {
+				missing = append(missing, fmt.Sprintf("MCP server %q requires secret %q for %s", ref.Name, secretRef, envName))
+			}
+		}
+	}
+	sort.Strings(missing)
+	return missing
+}

--- a/pkg/hub/routine_preflight_test.go
+++ b/pkg/hub/routine_preflight_test.go
@@ -1,0 +1,142 @@
+package hub
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func TestRoutinePreflightReportsReadyConfiguration(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	s, _ := NewTestServerWithConfig(t, readyRoutineHubConfig(), "", "", "")
+	workspace, workflow := readyRoutineFixture()
+	SaveWorkspaceForTest(t, workspace, []*types.WorkflowConfig{workflow})
+
+	result := s.preflightRoutine(workspace, workflow)
+	if !result.Ready || result.Status != "ready" {
+		t.Fatalf("preflight = %#v, want ready", result)
+	}
+	for _, check := range result.Checks {
+		if check.Status == "error" {
+			t.Fatalf("unexpected blocker: %#v", check)
+		}
+	}
+}
+
+func TestRoutinePreflightReportsConfigurationBlockers(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{}, "", "", "")
+	workspace := &types.WorkspaceConfig{
+		Name:         "engineering",
+		Repositories: types.RepositoryAccessList{{Repo: "elasticclaw/elasticclaw", Permissions: "write"}},
+		Files: map[string]string{
+			"elasticclaw-config.yaml": "provider: daytona\nllm_key: missing\nsecret_refs:\n  DEPLOY_TOKEN: deploy-token\n",
+		},
+	}
+	workflow := routineWorkflowForTest("dependency-report", false)
+
+	result := s.preflightRoutine(workspace, workflow)
+	if result.Ready || result.Status != "needs_setup" {
+		t.Fatalf("preflight = %#v, want needs_setup", result)
+	}
+	for _, id := range []string{"sandbox-provider", "model", "secrets", "github"} {
+		if !hasRoutinePreflightError(result.Checks, id) {
+			t.Fatalf("missing %q blocker in %#v", id, result.Checks)
+		}
+	}
+}
+
+func TestRoutinePreflightEndpointAndEnableGuard(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+	workspace := &types.WorkspaceConfig{Name: "engineering"}
+	workflow := routineWorkflowForTest("dependency-report", false)
+	SaveWorkspaceForTest(t, workspace, []*types.WorkflowConfig{workflow})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/workspaces/engineering/workflows/dependency-report/preflight", nil)
+	req.Header.Set("Authorization", "Bearer test-token")
+	rr := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("preflight status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	var result RoutinePreflightResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &result); err != nil {
+		t.Fatalf("decode preflight: %v", err)
+	}
+	if result.Ready {
+		t.Fatalf("preflight unexpectedly ready: %#v", result)
+	}
+
+	req = httptest.NewRequest(http.MethodPatch, "/api/workspaces/engineering/workflows/dependency-report", strings.NewReader(`{"enabled":true}`))
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	rr = httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("enable status = %d, want 409, body = %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "routine is not ready") {
+		t.Fatalf("enable response does not explain blocker: %s", rr.Body.String())
+	}
+}
+
+func readyRoutineHubConfig() *types.HubConfig {
+	return &types.HubConfig{
+		Token:        "test-token",
+		DefaultModel: "codex/gpt-5.5",
+		Providers: map[string]types.ProviderConfig{
+			"docker": {Type: "docker"},
+		},
+		LLMKeys: types.LLMKeysList{{
+			Name:        "codex-chatgpt",
+			Provider:    "codex",
+			Default:     true,
+			AuthProfile: "codex-user",
+		}},
+		ModelAuthProfiles: []*types.ModelAuthProfileConfig{{
+			Name: "codex-user", Provider: "codex", AuthState: `{"auth":"configured"}`,
+		}},
+		GitHubApps: []*types.GitHubAppConfig{{
+			AppID: 42, PrivateKeyPEM: "configured-for-preflight",
+		}},
+	}
+}
+
+func readyRoutineFixture() (*types.WorkspaceConfig, *types.WorkflowConfig) {
+	workspace := &types.WorkspaceConfig{
+		Name:         "engineering",
+		Repositories: types.RepositoryAccessList{{Repo: "elasticclaw/elasticclaw", Permissions: "read"}},
+		Files: map[string]string{
+			"elasticclaw-config.yaml": "provider: docker\nllm_key: codex-chatgpt\n",
+		},
+	}
+	return workspace, routineWorkflowForTest("dependency-report", false)
+}
+
+func routineWorkflowForTest(name string, enabled bool) *types.WorkflowConfig {
+	return &types.WorkflowConfig{
+		SchemaVersion: "v1",
+		Name:          name,
+		Enabled:       &enabled,
+		Trigger: &types.WorkflowTrigger{Cron: &types.CronWorkflowTrigger{
+			Schedule: "*/15 * * * *", Timezone: "UTC", OverlapPolicy: "skip", Timeout: "10m",
+		}},
+		Stages: []types.WorkflowStage{{
+			ID: "working", Entry: true, OnEnter: map[string]interface{}{"inject": "List the latest commits."},
+		}},
+	}
+}
+
+func hasRoutinePreflightError(checks []RoutinePreflightCheck, id string) bool {
+	for _, check := range checks {
+		if check.ID == id && check.Status == "error" {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -458,10 +458,13 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/workspaces/{name}/workflows", s.withAdminForMethods(s.handleWorkspaceWorkflowsList, http.MethodPost))
 	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}", s.withAdminForMethods(s.handleWorkspaceWorkflowDetail, http.MethodPatch))
 	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}/trigger", s.withAuth(s.handleWorkspaceWorkflowTrigger))
-	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}/cron/trigger", s.withAuth(s.handleCronWorkflowTrigger)) // POST manual trigger
-	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}/cron/runs", s.withAuth(s.handleCronWorkflowRuns))       // GET run history
+	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}/cron/trigger", s.withAuth(s.handleCronWorkflowTrigger))  // POST manual trigger
+	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}/cron/runs", s.withAuth(s.handleCronWorkflowRuns))        // GET run history
 	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}/cron/runs/{runId}", s.withAuth(s.handleCronWorkflowRun)) // GET single run
-	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}/cron/next", s.withAuth(s.handleCronWorkflowNextRun))    // GET next scheduled run
+	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}/cron/next", s.withAuth(s.handleCronWorkflowNextRun))     // GET next scheduled run
+	mux.HandleFunc("/api/workspaces/{workspace}/routines/draft", s.withWebAdminAuth(s.handleRoutineDraft))
+	mux.HandleFunc("/api/workspaces/{workspace}/routines/preflight", s.withWebAdminAuth(s.handleRoutinePreflight))
+	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}/preflight", s.withWebAdminAuth(s.handleSavedRoutinePreflight))
 	mux.HandleFunc("/api/workspaces/{workspace}/secrets", s.withAdminForMethods(s.handleWorkspaceSecretsCRUD, http.MethodPut, http.MethodPost, http.MethodDelete))
 	mux.HandleFunc("/api/workspaces/{workspace}/github-apps", s.withAdminForMethods(s.handleWorkspaceGitHubAppsCRUD, http.MethodPut, http.MethodPost, http.MethodDelete))
 	mux.HandleFunc("/api/workspaces/{workspace}/issue-trackers", s.withAdminForMethods(s.handleWorkspaceIssueTrackersCRUD, http.MethodPut, http.MethodPost, http.MethodDelete))
@@ -1128,7 +1131,7 @@ func (s *Server) handleClaws(w http.ResponseWriter, r *http.Request) {
 				c.Status = "starting"
 			}
 			c.ContextUsage = cc.contextUsage
-		} else if c.Status != "provisioning" && c.Status != "starting" && c.Status != "error" && c.Status != "pending" {
+		} else if c.Status != "provisioning" && c.Status != "starting" && c.Status != "error" && c.Status != "pending" && c.Status != "completed" {
 			// Not currently connected and not in an active provisioning state —
 			// DB status is stale (e.g. 'connected' from before hub restart)
 			c.Status = "offline"
@@ -2177,7 +2180,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 			`INSERT INTO claws(id,tenant_id,name,template,status,last_seen,created_at) VALUES(?,?,?,?,?,?,?)
 			 ON CONFLICT(id) DO UPDATE SET name=excluded.name,
 			 template=COALESCE(NULLIF(excluded.template,''), claws.template),
-			 status=CASE WHEN claws.status IN ('idle','deleted') THEN claws.status ELSE excluded.status END,
+			 status=CASE WHEN claws.status IN ('completed','idle','deleted') THEN claws.status ELSE excluded.status END,
 			 last_seen=excluded.last_seen
 			 RETURNING status`,
 			clawID, tenantID, rp.Name, rp.Template, desiredStatus, now(), now(),

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -125,8 +125,8 @@ func TestWorkspaceFlakeStageCommand(t *testing.T) {
 			name: "ignores invalid paths",
 			dir:  "/workspace",
 			files: map[string]string{
-				"flake.nix": "{}",
-				"../secret": "secret",
+				"flake.nix":   "{}",
+				"../secret":   "secret",
 				"/etc/passwd": "pw",
 			},
 			wantNames:   []string{"flake.nix"},
@@ -762,6 +762,92 @@ func TestDeleteClawKeepsMessages(t *testing.T) {
 	}
 	if count != 2 {
 		t.Fatalf("expected 2 messages to be preserved, got %d", count)
+	}
+}
+
+func TestCompletedClawRemainsVisibleWithMessages(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, nil, "", "", "")
+	_, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, tags, created_at, status) VALUES(?,?,?,?,datetime('now'),?)`,
+		"claw-completed", "test-tenant-id", "completed routine", `["routine"]`, "completed",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = db.Exec(
+		`INSERT INTO messages(id, claw_id, tenant_id, role, content, created_at) VALUES(?,?,?,?,?,datetime('now'))`,
+		"msg-completed", "claw-completed", "test-tenant-id", "claw", "routine report",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	listReq := httptest.NewRequest(http.MethodGet, "/api/claws", nil)
+	listReq = listReq.WithContext(context.WithValue(listReq.Context(), ctxTenantKey{}, "test-tenant-id"))
+	listRec := httptest.NewRecorder()
+	s.handleClaws(listRec, listReq)
+	if listRec.Code != http.StatusOK {
+		t.Fatalf("expected list status %d, got %d", http.StatusOK, listRec.Code)
+	}
+	var claws []types.Claw
+	if err := json.NewDecoder(listRec.Body).Decode(&claws); err != nil {
+		t.Fatal(err)
+	}
+	if len(claws) != 1 || claws[0].Status != "completed" {
+		t.Fatalf("expected completed claw in list, got %#v", claws)
+	}
+
+	var messageCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=?`, "claw-completed").Scan(&messageCount); err != nil {
+		t.Fatal(err)
+	}
+	if messageCount != 1 {
+		t.Fatalf("expected completed claw messages to remain available, got %d", messageCount)
+	}
+}
+
+func TestMigrateCompletedRoutineHistoryRestoresOnlySuccessfulRoutines(t *testing.T) {
+	_, db := NewTestServerWithConfig(t, nil, "", "", "")
+	if _, err := db.Exec(`DELETE FROM hub_migrations WHERE name='completed_routine_history_v1'`); err != nil {
+		t.Fatal(err)
+	}
+	for _, row := range []struct {
+		id, tags, runStatus string
+	}{
+		{"successful-routine", `["routine"]`, "completed"},
+		{"failed-routine", `["routine"]`, "failed"},
+		{"manual-deletion", `[]`, "completed"},
+	} {
+		if _, err := db.Exec(
+			`INSERT INTO claws(id, tenant_id, name, tags, created_at, status) VALUES(?,?,?,?,datetime('now'),'deleted')`,
+			row.id, "test-tenant-id", row.id, row.tags,
+		); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := db.Exec(
+			`INSERT INTO workflow_runs(id, tenant_id, workflow_name, workspace_name, status, claw_id, created_at) VALUES(?,?,?,?,?,?,datetime('now'))`,
+			"run-"+row.id, "test-tenant-id", "routine", "workspace", row.runStatus, row.id,
+		); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := migrateCompletedRoutineHistoryV1(db); err != nil {
+		t.Fatal(err)
+	}
+
+	var restoredStatus, failedStatus, deletedStatus string
+	if err := db.QueryRow(`SELECT status FROM claws WHERE id='successful-routine'`).Scan(&restoredStatus); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT status FROM claws WHERE id='failed-routine'`).Scan(&failedStatus); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT status FROM claws WHERE id='manual-deletion'`).Scan(&deletedStatus); err != nil {
+		t.Fatal(err)
+	}
+	if restoredStatus != "completed" || failedStatus != "deleted" || deletedStatus != "deleted" {
+		t.Fatalf("statuses = successful:%q failed:%q manual:%q", restoredStatus, failedStatus, deletedStatus)
 	}
 }
 

--- a/pkg/hub/task_run_analytics_test.go
+++ b/pkg/hub/task_run_analytics_test.go
@@ -1505,7 +1505,7 @@ func TestTaskRunDoneWithoutPRAllowsNonPRRuns(t *testing.T) {
 		t.Fatalf("read claw status: %v", err)
 	}
 	if status != "deleted" {
-		t.Fatalf("expected non-pr claw to be deleted after completion, got %q", status)
+		t.Fatalf("expected non-routine claw to be deleted after completion, got %q", status)
 	}
 	var injected int
 	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND role='user' AND content LIKE '%received with no PR URLs%'`, "claw-done-non-pr").Scan(&injected); err != nil {

--- a/pkg/hub/terminal_transitions.go
+++ b/pkg/hub/terminal_transitions.go
@@ -2,10 +2,28 @@ package hub
 
 import (
 	"database/sql"
+	"encoding/json"
 	"log"
 	"strings"
 	"time"
 )
+
+func (s *Server) successfulClawTerminalStatus(clawID string) string {
+	var tagsJSON string
+	if err := s.db.QueryRow(`SELECT COALESCE(tags, '[]') FROM claws WHERE id=?`, clawID).Scan(&tagsJSON); err != nil {
+		return "deleted"
+	}
+	var tags []string
+	if json.Unmarshal([]byte(tagsJSON), &tags) != nil {
+		return "deleted"
+	}
+	for _, tag := range tags {
+		if tag == "routine" {
+			return "completed"
+		}
+	}
+	return "deleted"
+}
 
 func (s *Server) execStatusLogged(opCtx, query string, args ...any) (sql.Result, error) {
 	res, err := s.db.Exec(query, args...)
@@ -50,19 +68,19 @@ func (s *Server) finishClawTerminalTx(clawID, clawStatus, diagnostic, runStatus,
 			var res sql.Result
 			switch clawStatus {
 			case "deleted":
-				res, err = tx.Exec(`UPDATE claws SET status=?, bootstrap_status='' WHERE id=? AND status NOT IN ('deleted','error')`, clawStatus, clawID)
+				res, err = tx.Exec(`UPDATE claws SET status=?, bootstrap_status='' WHERE id=? AND status NOT IN ('completed','deleted','error')`, clawStatus, clawID)
 			case "idle":
-				res, err = tx.Exec(`UPDATE claws SET status=? WHERE id=? AND status NOT IN ('deleted','error')`, clawStatus, clawID)
+				res, err = tx.Exec(`UPDATE claws SET status=? WHERE id=? AND status NOT IN ('completed','deleted','error')`, clawStatus, clawID)
 			default:
 				pending := 0
 				if opts.setStopCommentPending {
 					pending = 1
 				}
-				res, err = tx.Exec(`UPDATE claws SET status=?, bootstrap_status='', bootstrap_diagnostic=?, stop_comment_pending=? WHERE id=? AND status NOT IN ('deleted','error')`, clawStatus, diagnostic, pending, clawID)
+				res, err = tx.Exec(`UPDATE claws SET status=?, bootstrap_status='', bootstrap_diagnostic=?, stop_comment_pending=? WHERE id=? AND status NOT IN ('completed','deleted','error')`, clawStatus, diagnostic, pending, clawID)
 				// Some test/legacy schemas predate the marker migration. The
 				// migration runs in production; retain terminal atomicity there too.
 				if err != nil && strings.Contains(strings.ToLower(err.Error()), "no such column: stop_comment_pending") {
-					res, err = tx.Exec(`UPDATE claws SET status=?, bootstrap_status='', bootstrap_diagnostic=? WHERE id=? AND status NOT IN ('deleted','error')`, clawStatus, diagnostic, clawID)
+					res, err = tx.Exec(`UPDATE claws SET status=?, bootstrap_status='', bootstrap_diagnostic=? WHERE id=? AND status NOT IN ('completed','deleted','error')`, clawStatus, diagnostic, clawID)
 				}
 			}
 			if err == nil {

--- a/pkg/hub/workflow_creator.go
+++ b/pkg/hub/workflow_creator.go
@@ -17,6 +17,7 @@ import (
 type workflowCreateOptions struct {
 	ctx                  context.Context
 	inputs               map[string]string
+	triggerKind          string
 	workspaceFiles       map[string]string
 	clawName             string
 	githubIssueID        string
@@ -28,6 +29,7 @@ type workflowCreateOptions struct {
 	issueCreatedAt       time.Time
 	reason               string
 	triggerActor         *triggerActor
+	timeoutAt            time.Time
 }
 
 const hubInternalTemplateFilePrefix = "__hub__/"
@@ -228,7 +230,9 @@ func (s *Server) createClawFromWorkflowWithOptions(workspace *types.WorkspaceCon
 
 	tags := mergeTags(workspace.Name, workflow.Tags, nil)
 	tags = append(tags, "workspace:"+workspace.Name, "workflow:"+workflow.Name)
-	if opts.inputs != nil {
+	if opts.triggerKind == "routine" {
+		tags = append([]string{"routine"}, tags...)
+	} else if opts.inputs != nil {
 		tags = append(tags, "manual-trigger")
 	}
 	tagsJSON, _ := json.Marshal(tags)
@@ -304,6 +308,7 @@ func (s *Server) createClawFromWorkflowWithOptions(workspace *types.WorkspaceCon
 		AnalyticsEnabled: analyticsEnabled,
 		RequiresPR:       requiresPR,
 		ExcludedReason:   excludedReason,
+		TimeoutAt:        opts.timeoutAt,
 		StartedAt:        now,
 		EventKey:         "task_start:claw:" + clawID,
 	}); err != nil {

--- a/pkg/hub/workflow_harness_integration_test.go
+++ b/pkg/hub/workflow_harness_integration_test.go
@@ -381,7 +381,7 @@ func TestWorkflowHarness_TerminalStage(t *testing.T) {
 	// Wait for terminal inject
 	bridge.WaitForMessage(t, "Workflow complete", 5*time.Second)
 
-	// Verify claw is deleted (terminal stage)
+	// Verify the claw is deleted (terminal stage).
 	// Give the async goroutine time to update the DB
 	time.Sleep(200 * time.Millisecond)
 	ts.WaitForClawStatus(t, clawID, "deleted", 5*time.Second)

--- a/pkg/hub/workspace_api.go
+++ b/pkg/hub/workspace_api.go
@@ -56,6 +56,11 @@ type WorkflowView struct {
 	Volumes              []types.WorkflowVolume `json:"volumes,omitempty"`
 	Inputs               []types.FactoryInput   `json:"inputs,omitempty"`
 	RawConfig            string                 `json:"rawConfig,omitempty"`
+	Task                 string                 `json:"task,omitempty"`
+	Schedule             string                 `json:"schedule,omitempty"`
+	Timezone             string                 `json:"timezone,omitempty"`
+	OverlapPolicy        string                 `json:"overlapPolicy,omitempty"`
+	Timeout              string                 `json:"timeout,omitempty"`
 }
 
 func (s *Server) handleWorkspacesList(w http.ResponseWriter, _ *http.Request) {
@@ -230,9 +235,14 @@ func (s *Server) handleWorkspaceWorkflowDetail(w http.ResponseWriter, r *http.Re
 }
 
 type WorkflowPatchRequest struct {
-	Enabled                  *bool `json:"enabled"`
-	EnableManualTrigger      *bool `json:"enableManualTrigger"`
-	EnableManualTriggerSnake *bool `json:"enable_manual_trigger"`
+	Enabled                  *bool   `json:"enabled"`
+	EnableManualTrigger      *bool   `json:"enableManualTrigger"`
+	EnableManualTriggerSnake *bool   `json:"enable_manual_trigger"`
+	Task                     *string `json:"task"`
+	Schedule                 *string `json:"schedule"`
+	Timezone                 *string `json:"timezone"`
+	OverlapPolicy            *string `json:"overlapPolicy"`
+	Timeout                  *string `json:"timeout"`
 }
 
 func (s *Server) handleWorkspaceWorkflowPatch(w http.ResponseWriter, r *http.Request) {
@@ -247,7 +257,8 @@ func (s *Server) handleWorkspaceWorkflowPatch(w http.ResponseWriter, r *http.Req
 		http.Error(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
 		return
 	}
-	if req.Enabled == nil && req.EnableManualTrigger == nil && req.EnableManualTriggerSnake == nil {
+	hasCronPatch := req.Schedule != nil || req.Timezone != nil || req.OverlapPolicy != nil || req.Timeout != nil
+	if req.Enabled == nil && req.EnableManualTrigger == nil && req.EnableManualTriggerSnake == nil && req.Task == nil && !hasCronPatch {
 		http.Error(w, "no workflow fields provided", http.StatusBadRequest)
 		return
 	}
@@ -266,6 +277,19 @@ func (s *Server) handleWorkspaceWorkflowPatch(w http.ResponseWriter, r *http.Req
 		return
 	}
 	if req.Enabled != nil {
+		if *req.Enabled && (workflow.Enabled == nil || !*workflow.Enabled) {
+			preflight := s.preflightRoutine(workspace, workflow)
+			if !preflight.Ready {
+				var blockers []string
+				for _, check := range preflight.Checks {
+					if check.Status == "error" {
+						blockers = append(blockers, check.Title)
+					}
+				}
+				http.Error(w, "routine is not ready: "+strings.Join(blockers, "; "), http.StatusConflict)
+				return
+			}
+		}
 		workflow.Enabled = req.Enabled
 	}
 	if req.EnableManualTrigger != nil {
@@ -273,6 +297,53 @@ func (s *Server) handleWorkspaceWorkflowPatch(w http.ResponseWriter, r *http.Req
 	}
 	if req.EnableManualTriggerSnake != nil {
 		workflow.EnableManualTrigger = *req.EnableManualTriggerSnake
+	}
+	if hasCronPatch {
+		if workflow.Trigger == nil || workflow.Trigger.Cron == nil {
+			http.Error(w, "schedule fields can only be updated for cron-triggered workflows", http.StatusBadRequest)
+			return
+		}
+		if req.Schedule != nil {
+			workflow.Trigger.Cron.Schedule = strings.TrimSpace(*req.Schedule)
+		}
+		if req.Timezone != nil {
+			workflow.Trigger.Cron.Timezone = strings.TrimSpace(*req.Timezone)
+		}
+		if req.OverlapPolicy != nil {
+			workflow.Trigger.Cron.OverlapPolicy = strings.TrimSpace(*req.OverlapPolicy)
+		}
+		if req.Timeout != nil {
+			workflow.Trigger.Cron.Timeout = strings.TrimSpace(*req.Timeout)
+		}
+	}
+	if req.Task != nil {
+		task := strings.TrimSpace(*req.Task)
+		if task == "" {
+			http.Error(w, "routine task cannot be empty", http.StatusBadRequest)
+			return
+		}
+		stageIndex := -1
+		for i := range workflow.Stages {
+			if workflow.Stages[i].Entry {
+				stageIndex = i
+				break
+			}
+		}
+		if stageIndex < 0 && len(workflow.Stages) > 0 {
+			stageIndex = 0
+		}
+		if stageIndex < 0 {
+			http.Error(w, "routine has no stage to receive the task", http.StatusBadRequest)
+			return
+		}
+		if workflow.Stages[stageIndex].OnEnter == nil {
+			workflow.Stages[stageIndex].OnEnter = map[string]interface{}{}
+		}
+		workflow.Stages[stageIndex].OnEnter["inject"] = routineTaskInject(task)
+	}
+	if err := workflow.Validate(); err != nil {
+		http.Error(w, "invalid workflow update: "+err.Error(), http.StatusBadRequest)
+		return
 	}
 	workflow.RawConfig = ""
 	if err := saveExternalWorkflows(workspace.Name, []*types.WorkflowConfig{workflow}); err != nil {
@@ -511,7 +582,7 @@ func workflowToView(workspaceName string, workflow *types.WorkflowConfig) Workfl
 	if workflow.Integration == "linear" || (workflow.Trigger != nil && workflow.Trigger.Linear != nil) {
 		projects = append([]string(nil), linearWorkflowProjects(workflow)...)
 	}
-	return WorkflowView{
+	view := WorkflowView{
 		Name:                 workflow.Name,
 		WorkspaceName:        workspaceName,
 		Source:               "workflow",
@@ -528,6 +599,37 @@ func workflowToView(workspaceName string, workflow *types.WorkflowConfig) Workfl
 		Volumes:              append([]types.WorkflowVolume(nil), workflow.Volumes...),
 		Inputs:               append([]types.FactoryInput(nil), workflow.Inputs...),
 	}
+	if workflow.Trigger != nil && workflow.Trigger.Cron != nil {
+		view.Task = routineTaskFromWorkflow(workflow)
+		view.Schedule = workflow.Trigger.Cron.Schedule
+		view.Timezone = workflow.Trigger.Cron.Timezone
+		view.OverlapPolicy = workflow.Trigger.Cron.OverlapPolicy
+		view.Timeout = workflow.Trigger.Cron.Timeout
+	}
+	return view
+}
+
+const routineTaskDoneInstruction = "When the routine is complete, say [DONE]."
+
+func routineTaskInject(task string) string {
+	return strings.TrimSpace(task) + "\n\n" + routineTaskDoneInstruction
+}
+
+func routineTaskFromWorkflow(workflow *types.WorkflowConfig) string {
+	for _, stage := range workflow.Stages {
+		if !stage.Entry || stage.OnEnter == nil {
+			continue
+		}
+		if inject, ok := stage.OnEnter["inject"].(string); ok {
+			return strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(inject), routineTaskDoneInstruction))
+		}
+	}
+	if len(workflow.Stages) > 0 && workflow.Stages[0].OnEnter != nil {
+		if inject, ok := workflow.Stages[0].OnEnter["inject"].(string); ok {
+			return strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(inject), routineTaskDoneInstruction))
+		}
+	}
+	return ""
 }
 
 func (s *Server) resolveWorkflowConfig(workspaceName, workflowName string) (*types.WorkspaceConfig, *types.WorkflowConfig, bool, error) {

--- a/pkg/hub/workspace_api_test.go
+++ b/pkg/hub/workspace_api_test.go
@@ -265,6 +265,47 @@ func TestWorkflowPushReloadsCronScheduler(t *testing.T) {
 	}
 }
 
+func TestCronWorkflowViewExposesRoutineSchedule(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", configDir+"/hub.yaml")
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+
+	body := `{"workspaces":[{"name":"engineering"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/api/workspaces", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("workspace push status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+
+	body = `{"workflows":[{"schemaVersion":"v1","name":"dependency-update","trigger":{"cron":{"schedule":"0 9 * * 1","timezone":"America/Chicago","overlap_policy":"parallel","timeout":"2h"}},"stages":[{"id":"working","entry":true,"onEnter":{"inject":"Update dependencies"}}]}]}`
+	req = httptest.NewRequest(http.MethodPost, "/api/workspaces/engineering/workflows", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	rr = httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("workflow push status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+
+	var response struct {
+		Workflows []WorkflowView `json:"workflows"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode workflow response: %v", err)
+	}
+	if len(response.Workflows) != 1 {
+		t.Fatalf("workflow count = %d, want 1", len(response.Workflows))
+	}
+	view := response.Workflows[0]
+	if view.Schedule != "0 9 * * 1" || view.Timezone != "America/Chicago" ||
+		view.OverlapPolicy != "parallel" || view.Timeout != "2h" {
+		t.Fatalf("unexpected routine schedule view: %#v", view)
+	}
+}
+
 func TestWorkflowPushWithUnstartedCronSchedulerStillSucceeds(t *testing.T) {
 	configDir := t.TempDir()
 	t.Setenv("ELASTICCLAW_HUB_CONFIG", configDir+"/hub.yaml")
@@ -427,6 +468,78 @@ func TestWorkspaceWorkflowPatchReloadsCronScheduler(t *testing.T) {
 
 	if _, ok := s.cronScheduler.entries["engineering/dependency-update-go"]; ok {
 		t.Fatalf("disabled cron workflow remained registered: %#v", s.cronScheduler.entries)
+	}
+}
+
+func TestWorkspaceWorkflowPatchUpdatesRoutineSchedule(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", configDir+"/hub.yaml")
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+	s.cronScheduler = newCronScheduler(s)
+	s.cronScheduler.cron = cron.New(cron.WithSeconds())
+
+	workspaceBody := `{"workspaces":[{"name":"engineering"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/api/workspaces", strings.NewReader(workspaceBody))
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("workspace push status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+
+	workflowBody := `{"workflows":[{"schemaVersion":"v1","name":"dependency-update","trigger":{"cron":{"schedule":"0 9 * * 1","timezone":"UTC","overlap_policy":"skip","timeout":"1h"}},"stages":[{"id":"working","entry":true,"onEnter":{"inject":"Update dependencies\n\nWhen the routine is complete, say [DONE]."}}]}]}`
+	req = httptest.NewRequest(http.MethodPost, "/api/workspaces/engineering/workflows", strings.NewReader(workflowBody))
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	rr = httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("workflow push status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+
+	patchBody := `{"task":"Audit and update dependencies","schedule":"30 10 * * 1-5","timezone":"America/Argentina/Buenos_Aires","overlapPolicy":"parallel","timeout":"90m"}`
+	req = httptest.NewRequest(http.MethodPatch, "/api/workspaces/engineering/workflows/dependency-update", strings.NewReader(patchBody))
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	rr = httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("patch status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+
+	var view WorkflowView
+	if err := json.Unmarshal(rr.Body.Bytes(), &view); err != nil {
+		t.Fatalf("decode patched workflow: %v", err)
+	}
+	if view.Schedule != "30 10 * * 1-5" || view.Timezone != "America/Argentina/Buenos_Aires" ||
+		view.OverlapPolicy != "parallel" || view.Timeout != "90m" {
+		t.Fatalf("unexpected patched routine view: %#v", view)
+	}
+	if view.Task != "Audit and update dependencies" {
+		t.Fatalf("patched routine task = %q", view.Task)
+	}
+
+	loaded, err := loadExternalWorkspace("engineering")
+	if err != nil {
+		t.Fatalf("load workspace: %v", err)
+	}
+	cronTrigger := loaded.Workflows[0].Trigger.Cron
+	if cronTrigger.Schedule != "30 10 * * 1-5" || cronTrigger.Timezone != "America/Argentina/Buenos_Aires" ||
+		cronTrigger.OverlapPolicy != "parallel" || cronTrigger.Timeout != "90m" {
+		t.Fatalf("unexpected persisted cron trigger: %#v", cronTrigger)
+	}
+	if got := routineTaskFromWorkflow(loaded.Workflows[0]); got != "Audit and update dependencies" {
+		t.Fatalf("persisted routine task = %q", got)
+	}
+
+	req = httptest.NewRequest(http.MethodPatch, "/api/workspaces/engineering/workflows/dependency-update", strings.NewReader(`{"schedule":"not-a-cron"}`))
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	rr = httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("invalid patch status = %d, want 400, body = %s", rr.Code, rr.Body.String())
 	}
 }
 

--- a/web/app/settings/[[...parts]]/sections.ts
+++ b/web/app/settings/[[...parts]]/sections.ts
@@ -6,6 +6,7 @@ export const VALID_SECTIONS = [
   "issue-trackers",
   "workspaces",
   "workflows",
+  "routines",
   "workspace-analytics",
   "secrets",
   "ai-config",

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -4,7 +4,7 @@ import { useParams, usePathname, useRouter } from "next/navigation"
 import React, { Suspense, useEffect, useState, useCallback, useRef } from "react"
 import { getHubUrl } from "@/lib/hub-url"
 import { getAuthToken } from "@/lib/auth-storage"
-import { Cpu, Key, Github, ChevronLeft, Shield, Zap, Copy, Check, LayoutTemplate, Trash2, Lock, Sparkles, Send, RotateCcw, Eye, EyeOff, ExternalLink, AlertTriangle, X, CheckCircle2, Webhook, Stethoscope, ArrowRight, Wrench, GitBranch, ChevronDown, BarChart3 } from "lucide-react"
+import { Cpu, Key, Github, ChevronLeft, Shield, Zap, Copy, Check, LayoutTemplate, Trash2, Lock, Sparkles, Send, RotateCcw, Eye, EyeOff, ExternalLink, AlertTriangle, X, CheckCircle2, Webhook, Stethoscope, ArrowRight, Wrench, GitBranch, ChevronDown, BarChart3, CalendarClock } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Switch } from "@/components/ui/switch"
@@ -16,6 +16,7 @@ import { fetchWorkspaces, updateWorkflowControls, type RepositoryAccess, type Wo
 import { useBranding } from "@/hooks/use-branding"
 import { AnalyticsCommandCenter } from "@/components/analytics-command-center"
 import { WorkflowRunsDialog } from "@/components/workflow-runs-dialog"
+import { RoutinesSection } from "@/components/routines-section"
 
 function isValidSection(s: string): s is Section {
   return VALID_SECTIONS.includes(s as Section)
@@ -24,6 +25,7 @@ function isValidSection(s: string): s is Section {
 const WORKSPACE_SECTIONS = new Set<Section>([
   "workspaces",
   "workflows",
+  "routines",
   "workspace-analytics",
   "github",
   "issue-trackers",
@@ -344,6 +346,7 @@ export default function SettingsSectionPage() {
       items: [
         { id: "workspaces", label: "Overview", icon: LayoutTemplate },
         { id: "workflows", label: "Workflows", icon: GitBranch },
+        { id: "routines", label: "Routines", icon: CalendarClock },
         { id: "workspace-analytics", label: "Analytics", icon: BarChart3 },
         { id: "github", label: "GitHub Apps", icon: Github },
         { id: "issue-trackers", label: "Issue Trackers", icon: Zap },
@@ -479,6 +482,9 @@ export default function SettingsSectionPage() {
           )}
           {section === "workflows" && (
             <WorkflowsSection selectedWorkspace={selectedWorkspace} />
+          )}
+          {section === "routines" && (
+            <RoutinesSection selectedWorkspace={selectedWorkspace} />
           )}
           {section === "workspace-analytics" && (
             <Suspense fallback={null}>

--- a/web/components/claw-card.tsx
+++ b/web/components/claw-card.tsx
@@ -7,7 +7,7 @@ import type { Claw, ClawStatus } from "@/lib/types"
 import { COLOR_CLASSES, CLAW_COLORS } from "@/lib/mappers"
 import { TagEditor } from "@/components/tag-editor"
 import { patchClaw } from "@/lib/api"
-import { Loader2, Pin, AlertCircle, Pencil } from "lucide-react"
+import { Loader2, Pin, AlertCircle, Pencil, CircleCheck } from "lucide-react"
 import { BootstrapProgress } from "@/components/bootstrap-progress"
 import { ClawTitle } from "@/components/claw-title"
 
@@ -29,6 +29,9 @@ function StatusIndicator({ status, isStreaming }: { status: ClawStatus; isStream
   }
   if (status === "error") {
     return <AlertCircle className="size-3.5 text-red-500 shrink-0" />
+  }
+  if (status === "completed") {
+    return <CircleCheck className="size-3.5 text-violet-400 shrink-0" />
   }
   return (
     <span
@@ -117,7 +120,7 @@ export function ClawCard({ claw, isSelected, onClick, onTogglePin, onTagsChange,
     }
   }
   const hasUnread = claw.unreadCount > 0
-  const isPending = claw.status === "provisioning" || claw.status === "error"
+  const isPending = claw.status === "provisioning" || claw.status === "completed" || claw.status === "error"
   const railClass = claw.isStreaming
     ? "border-l-green-500"
     : claw.status === "provisioning"

--- a/web/components/conversation-view.tsx
+++ b/web/components/conversation-view.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState, useRef, useEffect, useCallback, useMemo, memo } from "react"
-import { Send, Terminal, TerminalSquare, ChevronLeft, ChevronRight, ChevronDown, Loader2, LayoutGrid, Info, MessageSquare, Trash2, AlertCircle, Wrench, GripVertical, Settings2, Paperclip, File as FileIcon, X } from "lucide-react"
+import { Send, Terminal, TerminalSquare, ChevronLeft, ChevronRight, ChevronDown, Loader2, LayoutGrid, Info, MessageSquare, Trash2, AlertCircle, CheckCircle2, Wrench, GripVertical, Settings2, Paperclip, File as FileIcon, X } from "lucide-react"
 import {
   DndContext,
   closestCenter,
@@ -38,6 +38,7 @@ import { useBranding } from "@/hooks/use-branding"
 import { BootstrapProgress } from "@/components/bootstrap-progress"
 import { ClawTitle } from "@/components/claw-title"
 import { isTerminalAssistantMessage } from "@/lib/messages"
+import { tagBadgeClass } from "@/lib/tag-styles"
 import { DependencyDowntimeBanner } from "@/components/dependency-downtime-banner"
 import type { TypewriterState } from "@/hooks/use-typewriter"
 
@@ -216,6 +217,7 @@ function StatusBadge({ status }: { status: ClawStatus }) {
         "text-xs font-medium",
         status === "connected" && "border-green-500/50 text-green-500",
         status === "idle" && "border-amber-500/50 text-amber-500",
+        status === "completed" && "border-violet-500/50 text-violet-400",
         status === "offline" && "border-red-500/50 text-red-500"
       )}
     >
@@ -228,6 +230,7 @@ function StatusDot({ status, isStreaming }: { status: ClawStatus; isStreaming: b
   if (isStreaming) return <Loader2 className="size-3.5 text-green-500 animate-spin" />
   if (status === "provisioning") return <Loader2 className="size-3.5 text-blue-400 animate-spin" />
   if (status === "error") return <AlertCircle className="size-3.5 text-red-500" />
+  if (status === "completed") return <CheckCircle2 className="size-3.5 text-violet-400" />
   return (
     <span
       className={cn(
@@ -391,7 +394,10 @@ function ClawCardBack({ claw }: { claw: Claw }) {
             {claw.tags.map((tag) => (
               <span
                 key={tag}
-                className="inline-flex items-center px-2 py-1 text-xs font-medium bg-secondary text-muted-foreground rounded"
+                className={cn(
+                  "inline-flex items-center px-2 py-1 text-xs font-medium rounded",
+                  tagBadgeClass(tag)
+                )}
               >
                 {tag}
               </span>
@@ -444,7 +450,7 @@ const ClawBoardCard = memo(function ClawBoardCard({
   const [showTerminal, setShowTerminal] = useState(false)
   const [confirmKill, setConfirmKill] = useState(false)
   const hasUnread = claw.unreadCount > 0
-  const isPending = claw.status === "provisioning" || claw.status === "error" || claw.status === "offline"
+  const isPending = claw.status === "provisioning" || claw.status === "completed" || claw.status === "error" || claw.status === "offline"
   const msgScrollRef = useRef<HTMLDivElement>(null)
   const cardFollowingLatest = useRef(true)
   const [isCardFollowingLatest, setIsCardFollowingLatest] = useState(true)
@@ -656,7 +662,10 @@ const ClawBoardCard = memo(function ClawBoardCard({
                 {claw.tags.slice(0, 3).map((tag) => (
                   <span
                     key={tag}
-                    className="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium bg-secondary text-muted-foreground rounded"
+                    className={cn(
+                      "inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium rounded",
+                      tagBadgeClass(tag)
+                    )}
                   >
                     {tag}
                   </span>
@@ -864,7 +873,7 @@ const ClawBoardCard = memo(function ClawBoardCard({
                   }
                 }}
                 onPaste={onPaste}
-                placeholder={isPending ? (claw.status === "error" ? "Provisioning failed" : claw.status === "offline" ? "Agent offline" : "Starting up...") : "Send message..."}
+                placeholder={isPending ? (claw.status === "completed" ? "Run completed" : claw.status === "error" ? "Provisioning failed" : claw.status === "offline" ? "Agent offline" : "Starting up...") : "Send message..."}
                 className="flex-1 resize-none overflow-hidden rounded-md border border-input bg-background px-2 py-1.5 text-xs ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 min-h-[32px]"
                 disabled={isPending}
                 ref={cardTextareaRef}
@@ -1596,7 +1605,8 @@ function ClawChatView({
 
   const stillUploading = attachments.some((a) => a.status === "uploading")
   const hasErrored = attachments.some((a) => a.status === "error")
-  const canSubmit = !stillUploading && !hasErrored && (input.trim().length > 0 || attachments.some((a) => a.status === "ready"))
+  const isReadOnly = claw.status === "completed"
+  const canSubmit = !isReadOnly && !stillUploading && !hasErrored && (input.trim().length > 0 || attachments.some((a) => a.status === "ready"))
 
   const toggleActivityGroup = useCallback((id: string) => {
     setExpandedActivityGroups((prev) => ({ ...prev, [id]: !prev[id] }))
@@ -1765,6 +1775,7 @@ function ClawChatView({
               type="button"
               size="icon"
               variant="ghost"
+              disabled={isReadOnly}
               onClick={() => fileInputRef.current?.click()}
               className="shrink-0"
               title="Attach files"
@@ -1795,7 +1806,8 @@ function ClawChatView({
               }}
               onPaste={onPaste}
               ref={panelTextareaRef}
-              placeholder="Message agent, /stop, or attach files"
+              disabled={isReadOnly}
+              placeholder={isReadOnly ? "Run completed — history is read-only" : "Message agent, /stop, or attach files"}
               rows={1}
               className="flex-1 resize-none overflow-hidden rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 min-h-[40px]"
             />
@@ -1925,7 +1937,9 @@ export function ConversationView({
           <div className="flex items-center gap-3">
             <Terminal className="size-5 text-muted-foreground" />
             <h2 className="text-lg font-medium text-foreground">
-              {loading ? "Agents" : `${allClaws.length} Active Agents`}
+              {loading
+                ? "Agents"
+                : `${allClaws.filter((item) => item.status !== "completed").length} Active Agents · ${allClaws.filter((item) => item.status === "completed").length} Completed`}
             </h2>
           </div>
           <div className="flex min-w-0 flex-wrap items-center justify-end gap-x-4 gap-y-2 text-xs text-muted-foreground">
@@ -1941,6 +1955,10 @@ export function ConversationView({
             <div className="flex items-center gap-1.5">
               <span className="size-2 rounded-full bg-red-500" />
               <span>Offline</span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <span className="size-2 rounded-full bg-violet-400" />
+              <span>Completed</span>
             </div>
           </div>
         </header>

--- a/web/components/routines-section.tsx
+++ b/web/components/routines-section.tsx
@@ -1,0 +1,604 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react"
+import { AlertTriangle, CalendarClock, CheckCircle2, Loader2, Pencil, Play, Plus, Sparkles } from "lucide-react"
+import {
+  createRoutine,
+  draftRoutineWithAI,
+  fetchCronWorkflowRuns,
+  fetchRoutineNextRun,
+  fetchRoutinePreflight,
+  fetchWorkspaces,
+  triggerRoutine,
+  updateWorkflowControls,
+  type CreateRoutineInput,
+  type RoutinePreflight,
+  type Workflow,
+} from "@/lib/api"
+import type { WorkflowRun } from "@/lib/types"
+import { WorkflowRunsDialog } from "@/components/workflow-runs-dialog"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Switch } from "@/components/ui/switch"
+import { Textarea } from "@/components/ui/textarea"
+
+type RoutineDraft = CreateRoutineInput
+
+const EMPTY_DRAFT: RoutineDraft = {
+  name: "",
+  task: "",
+  schedule: "0 9 * * 1-5",
+  timezone: "UTC",
+  overlapPolicy: "skip",
+  timeout: "2h",
+}
+
+export function RoutinesSection({ selectedWorkspace }: { selectedWorkspace: string }) {
+  const [workflows, setWorkflows] = useState<Workflow[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState("")
+  const [success, setSuccess] = useState("")
+  const [creating, setCreating] = useState(false)
+  const [createOpen, setCreateOpen] = useState(false)
+  const [busyRoutine, setBusyRoutine] = useState("")
+  const [refreshVersion, setRefreshVersion] = useState(0)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError("")
+    try {
+      const workspaces = await fetchWorkspaces()
+      const workspace = workspaces.find((item) => item.name === selectedWorkspace)
+      setWorkflows(workspace?.workflows || [])
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load routines")
+    } finally {
+      setLoading(false)
+    }
+  }, [selectedWorkspace])
+
+  useEffect(() => {
+    let cancelled = false
+    queueMicrotask(() => {
+      if (!cancelled) void load()
+    })
+    return () => { cancelled = true }
+  }, [load])
+
+  const routines = useMemo(
+    () => workflows.filter((workflow) => Boolean(workflow.schedule)),
+    [workflows],
+  )
+
+  const patchRoutine = useCallback(async (
+    workflow: Workflow,
+    patch: {
+      enabled?: boolean
+      task?: string
+      schedule?: string
+      timezone?: string
+      overlapPolicy?: string
+      timeout?: string
+    },
+  ) => {
+    const key = `${workflow.workspaceName}/${workflow.name}`
+    setBusyRoutine(key)
+    setError("")
+    setSuccess("")
+    try {
+      await updateWorkflowControls(workflow, patch)
+      await load()
+      setRefreshVersion((value) => value + 1)
+      setSuccess(`Updated ${workflow.name}`)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to update routine")
+      throw err
+    } finally {
+      setBusyRoutine("")
+    }
+  }, [load])
+
+  const runRoutine = useCallback(async (workflow: Workflow) => {
+    const key = `${workflow.workspaceName}/${workflow.name}`
+    setBusyRoutine(key)
+    setError("")
+    setSuccess("")
+    try {
+      await triggerRoutine(workflow.workspaceName, workflow.name)
+      setSuccess(`Started ${workflow.name}`)
+      setRefreshVersion((value) => value + 1)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to start routine")
+    } finally {
+      setBusyRoutine("")
+    }
+  }, [])
+
+  const addRoutine = useCallback(async (draft: RoutineDraft) => {
+    if (workflows.some((workflow) => workflow.name.toLowerCase() === draft.name.toLowerCase())) {
+      throw new Error(`A workflow named ${draft.name} already exists in this workspace`)
+    }
+    setCreating(true)
+    setError("")
+    setSuccess("")
+    try {
+      await createRoutine(selectedWorkspace, draft)
+      await load()
+      setCreateOpen(false)
+      setSuccess(`Created ${draft.name}`)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create routine")
+      throw err
+    } finally {
+      setCreating(false)
+    }
+  }, [load, selectedWorkspace, workflows])
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-base font-semibold mb-1">Routines</h2>
+          <p className="text-sm text-muted-foreground">
+            Schedule repeatable agent workflows. The Hub owns the schedule and starts an isolated agent for every run.
+          </p>
+        </div>
+        <Button onClick={() => setCreateOpen(true)} disabled={!selectedWorkspace}>
+          <Plus className="size-4" />
+          New routine
+        </Button>
+      </div>
+
+      {error && (
+        <div className="rounded-md border border-red-500/20 bg-red-500/10 px-3 py-2 text-sm text-red-500">
+          {error}
+        </div>
+      )}
+      {success && (
+        <div className="rounded-md border border-emerald-500/20 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-600 dark:text-emerald-400">
+          {success}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="flex items-center justify-center gap-2 px-4 py-12 text-sm text-muted-foreground">
+          <Loader2 className="size-4 animate-spin" />
+          Loading routines…
+        </div>
+      ) : routines.length === 0 ? (
+        <div className="rounded-lg border border-dashed px-6 py-12 text-center">
+          <CalendarClock className="mx-auto mb-3 size-8 text-muted-foreground" />
+          <p className="text-sm font-medium">No routines configured</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Create a scheduled workflow for recurring maintenance, triage, reporting, or repository checks.
+          </p>
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-lg border border-border">
+          <div className="hidden grid-cols-[minmax(0,1.2fr)_minmax(190px,1fr)_auto] gap-6 border-b border-border bg-muted/30 px-4 py-2.5 text-[11px] font-medium uppercase tracking-wider text-muted-foreground md:grid">
+            <span>Routine</span>
+            <span>Schedule &amp; runs</span>
+            <span className="min-w-[224px]">Controls</span>
+          </div>
+          <div className="divide-y divide-border">
+          {routines.map((routine) => (
+            <RoutineRow
+              key={`${routine.workspaceName}/${routine.name}`}
+              routine={routine}
+              busy={busyRoutine === `${routine.workspaceName}/${routine.name}`}
+              refreshVersion={refreshVersion}
+              onPatch={patchRoutine}
+              onRun={runRoutine}
+            />
+          ))}
+          </div>
+        </div>
+      )}
+
+      <RoutineEditorDialog
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        title="Create routine"
+        description="Create a cron-backed workflow with a task for the agent to execute."
+        initialValue={EMPTY_DRAFT}
+        saving={creating}
+        allowName
+        workspaceName={selectedWorkspace}
+        onSave={addRoutine}
+      />
+    </div>
+  )
+}
+
+function RoutineRow({
+  routine,
+  busy,
+  refreshVersion,
+  onPatch,
+  onRun,
+}: {
+  routine: Workflow
+  busy: boolean
+  refreshVersion: number
+  onPatch: (
+    workflow: Workflow,
+    patch: { enabled?: boolean; task?: string; schedule?: string; timezone?: string; overlapPolicy?: string; timeout?: string },
+  ) => Promise<void>
+  onRun: (workflow: Workflow) => Promise<void>
+}) {
+  const [editOpen, setEditOpen] = useState(false)
+  const [nextRun, setNextRun] = useState("")
+  const [lastRun, setLastRun] = useState<WorkflowRun | null>(null)
+  const [preflight, setPreflight] = useState<RoutinePreflight | null>(null)
+  const [checking, setChecking] = useState(false)
+
+  const loadStatus = useCallback(async () => {
+    setChecking(true)
+    const [nextResult, historyResult, preflightResult] = await Promise.allSettled([
+      fetchRoutineNextRun(routine.workspaceName, routine.name),
+      fetchCronWorkflowRuns(routine.workspaceName, routine.name, 1),
+      fetchRoutinePreflight(routine.workspaceName, routine.name),
+    ])
+    setNextRun(nextResult.status === "fulfilled" ? nextResult.value.next_run : "")
+    setLastRun(historyResult.status === "fulfilled" ? historyResult.value.runs?.[0] || null : null)
+    setPreflight(preflightResult.status === "fulfilled" ? preflightResult.value : null)
+    setChecking(false)
+  }, [routine.name, routine.workspaceName])
+
+  useEffect(() => {
+    let cancelled = false
+    const refresh = async () => {
+      await loadStatus()
+      if (cancelled) return
+    }
+    void refresh()
+    return () => { cancelled = true }
+  }, [loadStatus, refreshVersion, routine.enabled, routine.schedule])
+
+  const blocker = preflight?.checks.find((check) => check.status === "error")
+
+  const editValue: RoutineDraft = {
+    name: routine.name,
+    task: routine.task || "",
+    schedule: routine.schedule || "",
+    timezone: routine.timezone || "UTC",
+    overlapPolicy: routine.overlapPolicy === "parallel" ? "parallel" : "skip",
+    timeout: routine.timeout || "",
+  }
+
+  return (
+    <div className="px-4 py-4">
+      <div className="grid gap-4 md:grid-cols-[minmax(0,1.2fr)_minmax(190px,1fr)_auto] md:items-start md:gap-6">
+        <div className="min-w-0">
+          <p className="mb-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground md:hidden">
+            Routine
+          </p>
+          <div className="flex flex-wrap items-center gap-2">
+            <p className="min-w-0 truncate text-sm font-medium" title={routine.name}>{routine.name}</p>
+            <Badge variant="outline" className="text-[10px]">
+              {routine.enabled ? "active" : "paused"}
+            </Badge>
+            {checking && !preflight ? (
+              <Badge variant="outline" className="gap-1 text-[10px] text-muted-foreground">
+                <Loader2 className="size-3 animate-spin" />
+                checking
+              </Badge>
+            ) : preflight?.ready ? (
+              <Badge className="gap-1 border-emerald-500/30 bg-emerald-500/10 text-[10px] text-emerald-700 dark:text-emerald-300">
+                <CheckCircle2 className="size-3" />
+                ready
+              </Badge>
+            ) : preflight ? (
+              <Badge className="gap-1 border-amber-500/30 bg-amber-500/10 text-[10px] text-amber-700 dark:text-amber-300">
+                <AlertTriangle className="size-3" />
+                needs setup
+              </Badge>
+            ) : null}
+            {lastRun && <RunStatusBadge status={lastRun.status} />}
+          </div>
+          {blocker && (
+            <p className="mt-2 text-xs text-amber-700 dark:text-amber-300" title={blocker.description}>
+              {blocker.title}
+            </p>
+          )}
+        </div>
+
+        <div className="min-w-0">
+          <p className="mb-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground md:hidden">
+            Schedule &amp; runs
+          </p>
+          <p className="font-mono text-xs text-foreground/80">{routine.schedule}</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {routine.timezone || "UTC"} · {routine.overlapPolicy || "skip"} overlaps
+            {routine.timeout ? ` · timeout ${routine.timeout}` : ""}
+          </p>
+          <div className="mt-2 space-y-0.5 text-xs text-muted-foreground">
+            <p>
+              <span className="text-foreground/70">Next:</span>{" "}
+              {routine.enabled && nextRun ? formatTimestamp(nextRun) : routine.enabled ? "Unavailable" : "Paused"}
+            </p>
+            <p>
+              <span className="text-foreground/70">Last:</span>{" "}
+              {lastRun?.started_at ? formatTimestamp(lastRun.started_at) : "No runs yet"}
+            </p>
+          </div>
+        </div>
+
+        <div className="min-w-[224px]">
+          <p className="mb-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground md:hidden">
+            Controls
+          </p>
+          <div className="grid grid-cols-2 gap-2">
+          <label className="flex h-9 items-center gap-2 rounded-md border border-border px-2.5 text-xs text-muted-foreground">
+            <Switch
+              checked={routine.enabled}
+              disabled={busy || checking || (!routine.enabled && !preflight?.ready)}
+              onCheckedChange={(enabled) => { void onPatch(routine, { enabled }) }}
+              aria-label={`Toggle ${routine.name}`}
+            />
+            Enabled
+          </label>
+          <Button variant="outline" size="sm" onClick={() => setEditOpen(true)} disabled={busy}>
+            <Pencil className="size-3.5" />
+            Edit
+          </Button>
+          <WorkflowRunsDialog workflow={routine} />
+          <Button size="sm" onClick={() => { void onRun(routine) }} disabled={busy || checking || !routine.enabled || !preflight?.ready}>
+            {busy ? <Loader2 className="size-3.5 animate-spin" /> : <Play className="size-3.5" />}
+            Run now
+          </Button>
+          </div>
+        </div>
+      </div>
+
+      <RoutineEditorDialog
+        open={editOpen}
+        onOpenChange={setEditOpen}
+        title={`Edit ${routine.name}`}
+        description="Update the agent task and Hub-owned schedule for this routine."
+        initialValue={editValue}
+        saving={busy}
+        onSave={async (draft) => {
+          await onPatch(routine, {
+            task: draft.task,
+            schedule: draft.schedule,
+            timezone: draft.timezone,
+            overlapPolicy: draft.overlapPolicy,
+            timeout: draft.timeout,
+          })
+          setEditOpen(false)
+        }}
+      />
+    </div>
+  )
+}
+
+function RoutineEditorDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  initialValue,
+  saving,
+  allowName = false,
+  workspaceName,
+  onSave,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  title: string
+  description: string
+  initialValue: RoutineDraft
+  saving: boolean
+  allowName?: boolean
+  workspaceName?: string
+  onSave: (draft: RoutineDraft) => Promise<void>
+}) {
+  const [draft, setDraft] = useState<RoutineDraft>(initialValue)
+  const [aiPrompt, setAIPrompt] = useState("")
+  const [drafting, setDrafting] = useState(false)
+  const [formError, setFormError] = useState("")
+
+  useEffect(() => {
+    if (!open) return
+    let cancelled = false
+    queueMicrotask(() => {
+      if (cancelled) return
+      setDraft(initialValue)
+      setAIPrompt("")
+      setDrafting(false)
+      setFormError("")
+    })
+    return () => { cancelled = true }
+  }, [initialValue, open])
+
+  const draftWithAI = async () => {
+    const description = aiPrompt.trim()
+    if (!description) {
+      setFormError("Describe the routine you want AI to draft.")
+      return
+    }
+    if (!workspaceName) {
+      setFormError("Select a workspace before drafting a routine.")
+      return
+    }
+    setDrafting(true)
+    setFormError("")
+    try {
+      const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC"
+      const result = await draftRoutineWithAI(workspaceName, description, timezone)
+      setDraft({
+        name: result.name,
+        task: result.task,
+        schedule: result.schedule,
+        timezone: result.timezone || timezone,
+        overlapPolicy: result.overlapPolicy || "skip",
+        timeout: result.timeout || "2h",
+      })
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : "Unable to draft routine with AI")
+    } finally {
+      setDrafting(false)
+    }
+  }
+
+  const submit = async () => {
+    setFormError("")
+    if (allowName && !/^[a-z0-9][a-z0-9-]*$/.test(draft.name)) {
+      setFormError("Name must use lowercase letters, numbers, and hyphens.")
+      return
+    }
+    if (!draft.task.trim()) {
+      setFormError("Describe the task the agent should perform.")
+      return
+    }
+    if (!draft.schedule.trim()) {
+      setFormError("A cron schedule is required.")
+      return
+    }
+    try {
+      await onSave({
+        ...draft,
+        name: draft.name.trim(),
+        task: draft.task.trim(),
+        schedule: draft.schedule.trim(),
+        timezone: draft.timezone?.trim() || "UTC",
+        timeout: draft.timeout?.trim(),
+      })
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : "Unable to save routine")
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-xl">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4 py-2">
+          {allowName && (
+            <div className="space-y-2 rounded-lg border border-border bg-muted/20 p-3">
+              <div>
+                <p className="text-sm font-medium">Draft with AI</p>
+                <p className="text-xs text-muted-foreground">
+                  Describe the outcome and timing. AI fills the form for you to review; it does not save the routine.
+                </p>
+              </div>
+              <Textarea
+                value={aiPrompt}
+                onChange={(event) => setAIPrompt(event.target.value)}
+                placeholder="Every weekday at 9 AM, inspect dependency health, apply safe updates, run tests, and open a pull request."
+                className="min-h-20"
+                disabled={drafting || saving}
+              />
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                onClick={() => { void draftWithAI() }}
+                disabled={drafting || saving || !aiPrompt.trim()}
+              >
+                {drafting ? <Loader2 className="size-4 animate-spin" /> : <Sparkles className="size-4" />}
+                {drafting ? "Drafting…" : "Draft with AI"}
+              </Button>
+            </div>
+          )}
+          {allowName && (
+            <Field label="Name" hint="Lowercase letters, numbers, and hyphens.">
+              <Input
+                value={draft.name}
+                onChange={(event) => setDraft((value) => ({ ...value, name: event.target.value }))}
+                placeholder="dependency-health"
+              />
+            </Field>
+          )}
+          <Field label="Agent task" hint="The instruction injected when each run starts.">
+            <Textarea
+              value={draft.task}
+              onChange={(event) => setDraft((value) => ({ ...value, task: event.target.value }))}
+              placeholder="Inspect dependency health, apply safe updates, run tests, and open a pull request."
+              className="min-h-28"
+            />
+          </Field>
+          <Field label="Cron schedule" hint='Five-field cron, for example "0 9 * * 1-5".'>
+            <Input
+              value={draft.schedule}
+              onChange={(event) => setDraft((value) => ({ ...value, schedule: event.target.value }))}
+              className="font-mono"
+            />
+          </Field>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <Field label="Timezone" hint="IANA timezone name.">
+              <Input
+                value={draft.timezone}
+                onChange={(event) => setDraft((value) => ({ ...value, timezone: event.target.value }))}
+                placeholder="UTC"
+              />
+            </Field>
+            <Field label="Timeout" hint="Go duration, such as 30m or 2h.">
+              <Input
+                value={draft.timeout}
+                onChange={(event) => setDraft((value) => ({ ...value, timeout: event.target.value }))}
+                placeholder="2h"
+              />
+            </Field>
+          </div>
+          <Field label="When a previous run is active" hint="Queueing is not available in this version.">
+            <Select
+              value={draft.overlapPolicy}
+              onValueChange={(overlapPolicy: "skip" | "parallel") => setDraft((value) => ({ ...value, overlapPolicy }))}
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="skip">Skip the new run</SelectItem>
+                <SelectItem value="parallel">Start another run</SelectItem>
+              </SelectContent>
+            </Select>
+          </Field>
+          {formError && <p className="text-sm text-red-500">{formError}</p>}
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={saving || drafting}>Cancel</Button>
+          <Button onClick={() => { void submit() }} disabled={saving || drafting}>
+            {saving && <Loader2 className="size-4 animate-spin" />}
+            {allowName ? "Save paused" : "Save changes"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function Field({ label, hint, children }: { label: string; hint: string; children: ReactNode }) {
+  return (
+    <label className="block space-y-1.5">
+      <span className="text-sm font-medium">{label}</span>
+      {children}
+      <span className="block text-xs text-muted-foreground">{hint}</span>
+    </label>
+  )
+}
+
+function RunStatusBadge({ status }: { status: string }) {
+  const normalized = status.toLowerCase()
+  const className = normalized === "completed"
+    ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
+    : normalized === "failed"
+      ? "border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-300"
+      : normalized === "running"
+        ? "border-blue-500/30 bg-blue-500/10 text-blue-700 dark:text-blue-300"
+        : "border-border bg-muted text-muted-foreground"
+  return <Badge className={`text-[10px] ${className}`}>{status}</Badge>
+}
+
+function formatTimestamp(value: string) {
+  const parsed = new Date(value)
+  return Number.isNaN(parsed.getTime()) ? value : parsed.toLocaleString()
+}

--- a/web/components/tag-editor.tsx
+++ b/web/components/tag-editor.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useEffect } from "react"
 import { X, Plus } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { patchClaw } from "@/lib/api"
+import { tagBadgeClass } from "@/lib/tag-styles"
 
 interface TagEditorProps {
   clawId: string
@@ -74,7 +75,10 @@ export function TagEditor({ clawId, tags, onTagsChange, className }: TagEditorPr
         <span
           key={tag}
           title={tag}
-          className="inline-flex items-center gap-0.5 px-1.5 py-0.5 text-[10px] font-medium bg-secondary text-muted-foreground rounded group/tag max-w-[120px]"
+          className={cn(
+            "inline-flex items-center gap-0.5 px-1.5 py-0.5 text-[10px] font-medium rounded group/tag max-w-[120px]",
+            tagBadgeClass(tag)
+          )}
         >
           <span className="truncate">{tag}</span>
           <button

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -319,6 +319,11 @@ export interface Workflow {
   enableManualTrigger?: boolean
   secretRefs?: Record<string, string>
   inputs?: WorkflowInput[]
+  task?: string
+  schedule?: string
+  timezone?: string
+  overlapPolicy?: "skip" | "queue" | "parallel" | string
+  timeout?: string
 }
 
 export interface Workspace {
@@ -343,7 +348,15 @@ export async function fetchWorkflow(workspaceName: string, workflowName: string)
 
 export async function updateWorkflowControls(
   workflow: Workflow,
-  patch: { enabled?: boolean; enableManualTrigger?: boolean }
+  patch: {
+    enabled?: boolean
+    enableManualTrigger?: boolean
+    task?: string
+    schedule?: string
+    timezone?: string
+    overlapPolicy?: string
+    timeout?: string
+  }
 ): Promise<Workflow> {
   return apiFetch<Workflow>(
     `/api/workspaces/${encodeURIComponent(workflow.workspaceName)}/workflows/${encodeURIComponent(workflow.name)}`,
@@ -351,6 +364,124 @@ export async function updateWorkflowControls(
       method: "PATCH",
       body: JSON.stringify(patch),
     }
+  )
+}
+
+export interface CreateRoutineInput {
+  name: string
+  task: string
+  schedule: string
+  timezone?: string
+  overlapPolicy?: "skip" | "parallel"
+  timeout?: string
+}
+
+export interface RoutinePreflightCheck {
+  id: string
+  category: string
+  status: "pass" | "warning" | "error"
+  title: string
+  description: string
+  fixAction?: {
+    type: string
+    target: string
+    label: string
+  }
+}
+
+export interface RoutinePreflight {
+  ready: boolean
+  status: "ready" | "needs_setup"
+  checks: RoutinePreflightCheck[]
+}
+
+function routineWorkflowInput(routine: CreateRoutineInput) {
+  return {
+    schemaVersion: "v1",
+    name: routine.name,
+    enabled: false,
+    trigger: {
+      cron: {
+        schedule: routine.schedule,
+        timezone: routine.timezone || "UTC",
+        overlap_policy: routine.overlapPolicy || "skip",
+        timeout: routine.timeout || undefined,
+      },
+    },
+    stages: [
+      {
+        id: "working",
+        label: "Working",
+        entry: true,
+        onEnter: {
+          inject: `${routine.task.trim()}\n\nWhen the routine is complete, say [DONE].`,
+        },
+      },
+      {
+        id: "completed",
+        label: "Completed",
+        terminal: true,
+        triggers: [{ message_contains: "[DONE]" }],
+      },
+    ],
+  }
+}
+
+export async function draftRoutineWithAI(
+  workspaceName: string,
+  description: string,
+  timezone: string
+): Promise<CreateRoutineInput> {
+  return apiFetch<CreateRoutineInput>(
+    `/api/workspaces/${encodeURIComponent(workspaceName)}/routines/draft`,
+    {
+      method: "POST",
+      body: JSON.stringify({ description, timezone }),
+    }
+  )
+}
+
+export async function preflightRoutineDraft(workspaceName: string, routine: CreateRoutineInput): Promise<RoutinePreflight> {
+  return apiFetch<RoutinePreflight>(
+    `/api/workspaces/${encodeURIComponent(workspaceName)}/routines/preflight`,
+    {
+      method: "POST",
+      body: JSON.stringify({ workflow: routineWorkflowInput(routine) }),
+    }
+  )
+}
+
+export async function fetchRoutinePreflight(workspaceName: string, workflowName: string): Promise<RoutinePreflight> {
+  return apiFetch<RoutinePreflight>(
+    `/api/workspaces/${encodeURIComponent(workspaceName)}/workflows/${encodeURIComponent(workflowName)}/preflight`
+  )
+}
+
+export async function createRoutine(workspaceName: string, routine: CreateRoutineInput): Promise<Workflow> {
+  const response = await apiFetch<{ workflows: Workflow[] }>(
+    `/api/workspaces/${encodeURIComponent(workspaceName)}/workflows`,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        workflows: [routineWorkflowInput(routine)],
+      }),
+    }
+  )
+  const created = response.workflows?.find((workflow) => workflow.name === routine.name)
+  if (!created) throw new Error("The Hub did not return the created routine")
+  return created
+}
+
+export async function triggerRoutine(workspaceName: string, workflowName: string): Promise<{ status: string; workflow: string }> {
+  return apiFetch<{ status: string; workflow: string }>(
+    `/api/workspaces/${encodeURIComponent(workspaceName)}/workflows/${encodeURIComponent(workflowName)}/cron/trigger`,
+    { method: "POST" }
+  )
+}
+
+export async function fetchRoutineNextRun(workspaceName: string, workflowName: string): Promise<{ workflow: string; next_run: string }> {
+  return apiFetch<{ workflow: string; next_run: string }>(
+    `/api/workspaces/${encodeURIComponent(workspaceName)}/workflows/${encodeURIComponent(workflowName)}/cron/next`
   )
 }
 

--- a/web/lib/mappers.ts
+++ b/web/lib/mappers.ts
@@ -80,6 +80,8 @@ export function mapApiStatus(status: ApiClaw["status"]): ClawStatus {
       return "connected"
     case "idle":
       return "idle"
+    case "completed":
+      return "completed"
     case "provisioning":
     case "starting":
       return "provisioning"

--- a/web/lib/tag-styles.ts
+++ b/web/lib/tag-styles.ts
@@ -1,0 +1,6 @@
+export function tagBadgeClass(tag: string): string {
+  if (tag === "routine") {
+    return "border border-violet-400/40 bg-violet-500/20 text-violet-300"
+  }
+  return "bg-secondary text-muted-foreground"
+}

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -1,4 +1,4 @@
-export type ClawStatus = "connected" | "idle" | "offline" | "provisioning" | "error"
+export type ClawStatus = "connected" | "idle" | "offline" | "provisioning" | "completed" | "error"
 
 export interface Claw {
   id: string
@@ -64,7 +64,7 @@ export interface ApiClaw {
   id: string
   name: string
   template: string
-  status: "connected" | "offline" | "provisioning" | "starting" | "error" | "idle"
+  status: "connected" | "offline" | "provisioning" | "starting" | "completed" | "error" | "idle"
   last_seen: string
   created_at: string
   tenant_id: string


### PR DESCRIPTION
## Summary

- add Hub-managed cron routines with editable agent tasks, timezones, timeouts, overlap handling, manual runs, and run history
- add AI-assisted routine drafting using configured API-key, Ollama, or Codex auth-profile models
- add automatic readiness checks before enabling or running a routine
- identify routine agents in the dashboard and preserve completed routine logs after their sandbox terminates
- add routine APIs, UI, documentation, examples, migrations, and test coverage

## Why

ElasticClaw workflows can already be triggered manually or by external systems, but users need a first-class way to schedule repeatable agent work. Routines provide a Hub-owned schedule while keeping every execution isolated and observable.

Only `routine`-tagged successful agents use retained `completed` history. Existing non-routine workflow lifecycle behavior is unchanged. Codex-ready image and bundled bridge changes are intentionally excluded from this PR.

## User impact

Users can create a routine from a natural-language description or manually configure its task and schedule, keep it paused until ready, run it immediately, inspect prior executions, and reopen completed routine logs without keeping the sandbox alive.

## Validation

- `make build`
- `make test`
- `go build ./...`
- `npm run lint -- --quiet`
- `npm run build`
- `git diff --check`

Linear: [AIEDEV-15](https://linear.app/nimble-la/issue/AIEDEV-15)
