### PR TITLE
fix(hub): recover from stale go.mod in multi-module dependency updates

### DIFF
--- a/pkg/hub/dependency_updates.go
+++ b/pkg/hub/dependency_updates.go
@@ -577,25 +577,29 @@ for manifest in manifests:
             had_failure = True
             continue
         failure_before = had_failure
-        listed = run_command(cwd, "go list -m -u -json all")
-        # If an earlier module update left this module's go.mod stale, go list will
-        # refuse to run until it is tidied. That is a recoverable failure.
+        listed = run_command(cwd, "go list -e -m -u -json all")
+        # Use -e so go list keeps going when a module behind a replace directive or an
+        # unreplaceable placeholder version cannot be resolved. Modules with errors are
+        # emitted as JSON objects with an Error field; we skip them below. If an earlier
+        # module update left this module's go.mod stale, go list will refuse to run until
+        # it is tidied; that is a recoverable failure. Even if go list exits non-zero,
+        # stdout may still contain valid JSON for usable modules, so we try to parse it
+        # and apply whatever we can.
         if listed.returncode != 0 and "updates to go.mod needed" in listed.stderr:
             if not failure_before:
                 had_failure = False
             run_command(cwd, "go mod tidy", record_failure=False)
-            listed = run_command(cwd, "go list -m -u -json all")
-        # Even if go list exits non-zero (e.g. because of invalid placeholder versions
-        # behind replace directives), stdout may still contain valid JSON for usable
-        # modules. Try to parse it and apply whatever we can.
+            listed = run_command(cwd, "go list -e -m -u -json all")
         try:
             apply_updates = []
             for module in parse_go_modules(listed.stdout):
                 name = module.get("Path", "")
-                # Skip the main module, modules pinned by replace directives, and
-                # transitive-only dependencies. Only direct dependencies can be safely
-                # updated by go get; replaced modules would conflict with the directive.
-                if module.get("Main") or module.get("Replace") or module.get("Indirect"):
+                # Skip the main module, modules pinned by replace directives, modules
+                # that carry a resolution error, and transitive-only dependencies. Only
+                # direct dependencies can be safely updated by go get; replaced modules
+                # would conflict with the directive and error-carrying modules cannot be
+                # trusted to provide a valid update target.
+                if module.get("Main") or module.get("Replace") or module.get("Error") or module.get("Indirect"):
                     continue
                 update = module.get("Update") or {}
                 if not update:

--- a/pkg/hub/dependency_updates.go
+++ b/pkg/hub/dependency_updates.go
@@ -576,7 +576,15 @@ for manifest in manifests:
             result["commands"].append({"command": "go", "cwd": rel(cwd), "exit_code": 127, "stderr": "go executable not found"})
             had_failure = True
             continue
+        failure_before = had_failure
         listed = run_command(cwd, "go list -m -u -json all")
+        # If an earlier module update left this module's go.mod stale, go list will
+        # refuse to run until it is tidied. That is a recoverable failure.
+        if listed.returncode != 0 and "updates to go.mod needed" in listed.stderr:
+            if not failure_before:
+                had_failure = False
+            run_command(cwd, "go mod tidy", record_failure=False)
+            listed = run_command(cwd, "go list -m -u -json all")
         # Even if go list exits non-zero (e.g. because of invalid placeholder versions
         # behind replace directives), stdout may still contain valid JSON for usable
         # modules. Try to parse it and apply whatever we can.

--- a/pkg/hub/dependency_updates_test.go
+++ b/pkg/hub/dependency_updates_test.go
@@ -126,7 +126,7 @@ func TestDependencyUpdatesGeneratedCommandOutputsStructuredJSON(t *testing.T) {
 	}
 	writeExecutable(t, bin, "go", `#!/usr/bin/env bash
 set -e
-if [ "$*" = "list -m -u -json all" ]; then
+if [ "$*" = "list -e -m -u -json all" ]; then
   printf '%s\n' '{"Path":"example.com/root","Version":"v1.0.0","Update":{"Version":"v1.1.0"}}'
   exit 0
 fi
@@ -199,7 +199,7 @@ func TestDependencyUpdatesGoGetOneAtATime(t *testing.T) {
 	writeExecutable(t, bin, "go", `#!/usr/bin/env bash
 set -e
 ROOT=$(dirname "$0")/..
-if [ "$*" = "list -m -u -json all" ]; then
+if [ "$*" = "list -e -m -u -json all" ]; then
   printf '%s\n' '{"Path":"example.com/root","Version":"v1.0.0","Update":{"Version":"v1.1.0"}}'
   printf '%s\n' '{"Path":"example.com/other","Version":"v1.0.0","Update":{"Version":"v1.1.0"}}'
   exit 0
@@ -280,7 +280,7 @@ func TestDependencyUpdatesSkipsReplacedIndirectAndInvalidVersions(t *testing.T) 
 	}
 	writeExecutable(t, bin, "go", `#!/usr/bin/env bash
 set -e
-if [ "$*" = "list -m -u -json all" ]; then
+if [ "$*" = "list -e -m -u -json all" ]; then
   printf '%s\n' '{"Path":"example.com/root","Version":"v1.0.0","Update":{"Version":"v1.1.0"}}'
   printf '%s\n' '{"Path":"example.com/replaced","Version":"v0.0.0","Update":{"Version":"v1.0.0"},"Replace":{"Path":"example.com/replaced","Version":"v0.0.0"}}'
   printf '%s\n' '{"Path":"example.com/indirect","Version":"v1.0.0","Update":{"Version":"v1.1.0"},"Indirect":true}'
@@ -335,6 +335,66 @@ exit 0
 	// in the update records at all, to avoid noisy reports for unpinned deps.
 }
 
+func TestDependencyUpdatesSkipsModulesWithErrors(t *testing.T) {
+	root := t.TempDir()
+	bin := filepath.Join(root, "bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeExecutable(t, bin, "go", `#!/usr/bin/env bash
+set -e
+if [ "$*" = "list -e -m -u -json all" ]; then
+  printf '%s\n' '{"Path":"example.com/root","Version":"v1.0.0","Update":{"Version":"v1.1.0"}}'
+  printf '%s\n' '{"Path":"example.com/broken","Version":"v0.0.0","Update":{"Version":"v1.0.0"},"Error":{"Err":"example.com/broken@v0.0.0: invalid version"}}'
+  exit 0
+fi
+if [ "$1" = "get" ]; then
+  if [ "$2" != "example.com/root@v1.1.0" ]; then
+    echo "unexpected go get target: $2" >&2
+    exit 1
+  fi
+  echo changed >> go.sum
+  exit 0
+fi
+if [ "$1 $2" = "mod tidy" ]; then
+  exit 0
+fi
+exit 0
+`)
+	writeExecutable(t, bin, "npm", `#!/usr/bin/env bash
+if [ "$1 $2" = "outdated --json" ]; then
+  printf '%s\n' '{}'
+  exit 1
+fi
+if [ "$1 $2" = "update --package-lock-only" ]; then
+  exit 0
+fi
+exit 0
+`)
+	writeFile(t, root, "go.mod", "module example.com/root\n")
+	writeFile(t, root, "go.sum", "")
+
+	command, err := buildDependencyUpdatesCommand(pipeline.DependencyUpdatesAction{Enabled: true})
+	if err != nil {
+		t.Fatalf("build command: %v", err)
+	}
+	cmd := osexec.Command("bash", "-c", command)
+	cmd.Dir = root
+	cmd.Env = testEnvWithPath(bin)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("dependency update command failed: %v\n%s", err, out)
+	}
+
+	parsed, ok := parsePipelineOutputJSON(string(out))
+	if !ok {
+		t.Fatalf("command did not emit JSON:\n%s", out)
+	}
+	assertUpdateStatus(t, parsed, "go", "example.com/root", true, "")
+	// Modules carrying an Error field should be silently skipped; they are not
+	// safe update targets because their current version is already broken.
+}
+
 func TestDependencyUpdatesRetriesGoGetFailure(t *testing.T) {
 	root := t.TempDir()
 	bin := filepath.Join(root, "bin")
@@ -349,7 +409,7 @@ count=0
 if [ -f "$COUNT_FILE" ]; then
   count=$(cat "$COUNT_FILE")
 fi
-if [ "$*" = "list -m -u -json all" ]; then
+if [ "$*" = "list -e -m -u -json all" ]; then
   printf '%s\n' '{"Path":"example.com/root","Version":"v1.0.0","Update":{"Version":"v1.1.0"}}'
   exit 0
 fi
@@ -430,7 +490,7 @@ func TestDependencyUpdatesGeneratedCommandHonorsFiltersAndMajorPolicy(t *testing
 	}
 	writeExecutable(t, bin, "go", `#!/usr/bin/env bash
 set -e
-if [ "$*" = "list -m -u -json all" ]; then
+if [ "$*" = "list -e -m -u -json all" ]; then
   printf '%s\n' '{"Path":"example.com/root","Version":"v1.0.0","Update":{"Version":"v1.1.0"}}'
   printf '%s\n' '{"Path":"ignored.com/risky","Version":"v1.0.0","Update":{"Version":"v1.1.0"}}'
   printf '%s\n' '{"Path":"example.com/major","Version":"v0.9.0","Update":{"Version":"v1.0.0"}}'
@@ -511,7 +571,7 @@ func TestDependencyUpdatesGeneratedCommandHonorsExcludePaths(t *testing.T) {
 	}
 	writeExecutable(t, bin, "go", `#!/usr/bin/env bash
 set -e
-if [ "$*" = "list -m -u -json all" ]; then
+if [ "$*" = "list -e -m -u -json all" ]; then
   printf '%s\n' '{"Path":"example.com/root","Version":"v1.0.0","Update":{"Version":"v1.1.0"}}'
   exit 0
 fi
@@ -600,7 +660,7 @@ set -e
 ROOT=$(cd "$(dirname "$0")/.." && pwd)
 CWD=$(pwd)
 STATE_FILE="$ROOT/.go-state-$(echo "$CWD" | tr '/' '_')"
-if [ "$*" = "list -m -u -json all" ]; then
+if [ "$*" = "list -e -m -u -json all" ]; then
   if [ "$(basename "$CWD")" = "plugin" ]; then
     if [ ! -f "$STATE_FILE" ]; then
       echo "go: updates to go.mod needed; to update it:" >&2
@@ -747,7 +807,7 @@ func writeExecutable(t *testing.T, root, name, content string) {
 }
 
 func TestFormatDependencyUpdateFailureExtractsFailedCommand(t *testing.T) {
-	stdout := `{"commands":[{"command":"go list -m -u -json all","cwd":"ec/e2e","exit_code":0,"stderr":""},{"command":"go get example.com/foo@v1.1.0","cwd":"ec/e2e","exit_code":1,"stderr":"go: example.com/foo@v1.1.0: not found"}],"updates":[]}`
+	stdout := `{"commands":[{"command":"go list -e -m -u -json all","cwd":"ec/e2e","exit_code":0,"stderr":""},{"command":"go get example.com/foo@v1.1.0","cwd":"ec/e2e","exit_code":1,"stderr":"go: example.com/foo@v1.1.0: not found"}],"updates":[]}`
 	result := &pipelineRunResult{ExitCode: 1, Stdout: stdout}
 	got := formatDependencyUpdateFailure(result)
 	want := "Dependency update step failed: go get example.com/foo@v1.1.0 (cwd=ec/e2e): go: example.com/foo@v1.1.0: not found"

--- a/pkg/hub/dependency_updates_test.go
+++ b/pkg/hub/dependency_updates_test.go
@@ -589,6 +589,106 @@ exit 0
 	assertUpdateStatus(t, parsed, "go", "example.com/root", true, "")
 }
 
+func TestDependencyUpdatesRecoversStalePluginModules(t *testing.T) {
+	root := t.TempDir()
+	bin := filepath.Join(root, "bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeExecutable(t, bin, "go", `#!/usr/bin/env bash
+set -e
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+CWD=$(pwd)
+STATE_FILE="$ROOT/.go-state-$(echo "$CWD" | tr '/' '_')"
+if [ "$*" = "list -m -u -json all" ]; then
+  if [ "$(basename "$CWD")" = "plugin" ]; then
+    if [ ! -f "$STATE_FILE" ]; then
+      echo "go: updates to go.mod needed; to update it:" >&2
+      echo "\tgo mod tidy" >&2
+      touch "$STATE_FILE"
+      exit 1
+    fi
+    printf '%s\n' '{"Path":"plugin.com/dep","Version":"v1.0.0","Update":{"Version":"v1.1.0"}}'
+    exit 0
+  fi
+  printf '%s\n' '{"Path":"example.com/root","Version":"v1.0.0","Update":{"Version":"v1.1.0"}}'
+  exit 0
+fi
+if [ "$1" = "get" ]; then
+  case "$2" in
+    example.com/root@v1.1.0|plugin.com/dep@v1.1.0)
+      echo changed >> go.sum
+      exit 0
+      ;;
+    *)
+      echo "unexpected go get target: $2" >&2
+      exit 1
+      ;;
+  esac
+fi
+if [ "$1 $2" = "mod tidy" ]; then
+  exit 0
+fi
+exit 0
+`)
+	writeExecutable(t, bin, "npm", `#!/usr/bin/env bash
+if [ "$1 $2" = "outdated --json" ]; then
+  printf '%s\n' '{}'
+  exit 1
+fi
+if [ "$1 $2" = "update --package-lock-only" ]; then
+  exit 0
+fi
+exit 0
+`)
+	writeFile(t, root, "go.mod", "module example.com/root\n")
+	writeFile(t, root, "go.sum", "")
+	writeFile(t, root, "plugin/go.mod", "module example.com/plugin\n")
+	writeFile(t, root, "plugin/go.sum", "")
+
+	command, err := buildDependencyUpdatesCommand(pipeline.DependencyUpdatesAction{
+		Enabled:    true,
+		Ecosystems: []string{"go"},
+	})
+	if err != nil {
+		t.Fatalf("build command: %v", err)
+	}
+	cmd := osexec.Command("bash", "-c", command)
+	cmd.Dir = root
+	cmd.Env = testEnvWithPath(bin)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("dependency update command failed: %v\n%s", err, out)
+	}
+
+	parsed, ok := parsePipelineOutputJSON(string(out))
+	if !ok {
+		t.Fatalf("command did not emit JSON:\n%s", out)
+	}
+	assertUpdateStatus(t, parsed, "go", "example.com/root", true, "")
+	assertUpdateStatus(t, parsed, "go", "plugin.com/dep", true, "")
+
+	commands, ok := parsed["commands"].([]interface{})
+	if !ok {
+		t.Fatalf("commands = %#v, want list", parsed["commands"])
+	}
+	var tidyAttempts int
+	for _, raw := range commands {
+		c, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		cmdStr, _ := c["command"].(string)
+		cwd, _ := c["cwd"].(string)
+		if cmdStr == "go mod tidy" && cwd == "plugin" {
+			tidyAttempts++
+		}
+	}
+	if tidyAttempts < 1 {
+		t.Fatalf("go mod tidy in plugin = %d, want at least 1", tidyAttempts)
+	}
+}
+
 func assertUpdateStatus(t *testing.T, parsed map[string]interface{}, ecosystem, name string, applied bool, skippedReason string) {
 	t.Helper()
 	updates, ok := parsed["updates"].([]interface{})


### PR DESCRIPTION
This PR combines two related dependency-update resilience fixes:

1. **Stale `go.mod` recovery (#576 original)** — When the root module is updated before plugin modules in a multi-module repository, `go list` in the plugin directories can fail with `updates to go.mod needed`. We now run `go mod tidy` and retry `go list` in that case so dependency updates continue instead of failing the whole step.

2. **Tolerate broken modules in `go list` (#573, incorporated here)** — The previous resilience fix only helped when `go list` exited non-zero but still emitted usable JSON. With placeholder versions like `k8s.io/cri-streaming@v0.0.0`, `go list` can fail before producing any JSON, so the fallback never ran. We now use `go list -e` so broken modules are emitted as JSON objects with an `Error` field, and skip any module carrying an error.

Changes:
- `pkg/hub/dependency_updates.go` — uses `go list -e`, skips modules with `Error`, and recovers from stale `go.mod`
- `pkg/hub/dependency_updates_test.go` — updated existing tests for `-e`, added `TestDependencyUpdatesSkipsModulesWithErrors` and `TestDependencyUpdatesRecoversStalePluginModules`

Closes #573.
