### PR TITLE
feat: make agent activity useful, visible, and concise

### DIFF
--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -4151,11 +4151,13 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 			if bytes.Equal(payload, lastPayload) {
 				return
 			}
-			lastPayload = payload
-			_ = writeHub(hubMsg{
+			if err := writeHub(hubMsg{
 				Type:    "agent_activity",
 				Payload: payload,
-			})
+			}); err != nil {
+				return
+			}
+			lastPayload = payload
 		}
 	}()
 

--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -20,6 +20,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
@@ -929,8 +930,9 @@ func sanitizeActivityText(value string) string {
 	for _, r := range replacers {
 		value = redactActivityPrefix(value, r.prefix, r.value)
 	}
-	if len(value) > 240 {
-		value = value[:237] + "..."
+	const maxActivityTextLen = 2000
+	if len(value) > maxActivityTextLen {
+		value = value[:maxActivityTextLen-3] + "..."
 	}
 	return value
 }
@@ -4136,12 +4138,26 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 	}
 	log.Printf("registered with hub as %s", clawID)
 
-	writeActivity := func(activity agentActivity) {
-		_ = writeHub(hubMsg{
-			Type:    "agent_activity",
-			Payload: mustJSON(cleanAgentActivity(activity)),
-		})
-	}
+	writeActivity := func() func(agentActivity) {
+		var (
+			lastPayload []byte
+			mu          sync.Mutex
+		)
+		return func(activity agentActivity) {
+			cleaned := cleanAgentActivity(activity)
+			payload := mustJSON(cleaned)
+			mu.Lock()
+			defer mu.Unlock()
+			if bytes.Equal(payload, lastPayload) {
+				return
+			}
+			lastPayload = payload
+			_ = writeHub(hubMsg{
+				Type:    "agent_activity",
+				Payload: payload,
+			})
+		}
+	}()
 
 	// Replay any queued entries that accumulated while we were disconnected.
 	// Completed replies/notices are delivered directly; only unprocessed inputs

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -1060,6 +1060,22 @@ func TestSanitizeActivityTextRedactsRepeatedSecretPrefixes(t *testing.T) {
 	}
 }
 
+func TestSanitizeActivityTextTruncatesAtReasonableLength(t *testing.T) {
+	input := strings.Repeat("a", 5000)
+	got := sanitizeActivityText(input)
+	if len(got) > 2005 {
+		t.Fatalf("sanitizeActivityText produced %d chars, want <= 2005: %q", len(got), got)
+	}
+	if !strings.HasSuffix(got, "...") {
+		t.Fatalf("sanitizeActivityText should suffix with ...: %q", got)
+	}
+	// Content under the limit should be preserved unchanged.
+	short := strings.Repeat("b", 1500)
+	if got := sanitizeActivityText(short); got != short {
+		t.Fatalf("sanitizeActivityText truncated short input: %q", got)
+	}
+}
+
 func TestPromoteInsufficientGatewayPairingPromotesReadOnlyDevice(t *testing.T) {
 	home := t.TempDir()
 	devicesDir := filepath.Join(home, ".openclaw", "devices")

--- a/cmd/workflow.go
+++ b/cmd/workflow.go
@@ -475,10 +475,84 @@ func runWorkflowLogs(workspace, name, runID string) error {
 	}
 
 	fmt.Printf("Agent logs for run %s (agent %s, status %s):\n\n", runID, shortID(run.ClawID), run.Status)
-	for _, msg := range messages {
-		printActivityMessage(msg)
-	}
+	printCollapsedActivityMessages(messages)
 	return nil
+}
+
+// printCollapsedActivityMessages prints activity messages, collapsing bursts of
+// identical or prefix-extended reasoning messages so repeated model activity
+// does not drown out tool events and errors.
+func printCollapsedActivityMessages(messages []types.HubMessage) {
+	var pending *types.HubMessage
+	var pendingActivity *agentActivity
+	pendingCount := 0
+
+	flush := func() {
+		if pending == nil {
+			return
+		}
+		printActivityMessage(*pending, pendingCount-1)
+		pending = nil
+		pendingActivity = nil
+		pendingCount = 0
+	}
+
+	for i := range messages {
+		msg := &messages[i]
+		activity, ok := parseAgentActivity(*msg)
+		if !ok {
+			flush()
+			printActivityMessage(*msg, 0)
+			continue
+		}
+		if pending == nil {
+			pending = msg
+			pendingActivity = &activity
+			pendingCount = 1
+			continue
+		}
+		if canCollapseActivity(*pendingActivity, activity) {
+			if len(activity.Message) > len(pendingActivity.Message) {
+				pending = msg
+				pendingActivity = &activity
+			}
+			pendingCount++
+			continue
+		}
+		flush()
+		pending = msg
+		pendingActivity = &activity
+		pendingCount = 1
+	}
+	flush()
+}
+
+func parseAgentActivity(msg types.HubMessage) (agentActivity, bool) {
+	if !strings.HasPrefix(msg.Format, "activity:") {
+		return agentActivity{}, false
+	}
+	var activity agentActivity
+	if err := json.Unmarshal([]byte(strings.TrimPrefix(msg.Format, "activity:")), &activity); err != nil {
+		return agentActivity{}, false
+	}
+	return activity, true
+}
+
+// canCollapseActivity returns true when two activities are the same kind of
+// event and one message is a prefix of the other. This catches the common case
+// where a model streams its reasoning as a series of ever-longer messages.
+func canCollapseActivity(a, b agentActivity) bool {
+	return a.Kind == b.Kind &&
+		a.Tool == b.Tool &&
+		a.Phase == b.Phase &&
+		a.Command == b.Command &&
+		a.Path == b.Path &&
+		a.URL == b.URL &&
+		a.Error == b.Error &&
+		a.Detail == b.Detail &&
+		(a.Message == b.Message ||
+			strings.HasPrefix(a.Message, b.Message) ||
+			strings.HasPrefix(b.Message, a.Message))
 }
 
 type agentActivity struct {
@@ -493,7 +567,7 @@ type agentActivity struct {
 	Error   string `json:"error"`
 }
 
-func printActivityMessage(msg types.HubMessage) {
+func printActivityMessage(msg types.HubMessage, collapsedSimilar int) {
 	ts := msg.CreatedAt.Format("2006-01-02 15:04:05")
 	if !strings.HasPrefix(msg.Format, "activity:") {
 		fmt.Printf("%s  %s\n", ts, msg.Content)
@@ -533,6 +607,9 @@ func printActivityMessage(msg types.HubMessage) {
 	}
 	if activity.Error != "" {
 		parts = append(parts, fmt.Sprintf("error: %s", activity.Error))
+	}
+	if collapsedSimilar > 0 {
+		parts = append(parts, fmt.Sprintf("(+ %d similar)", collapsedSimilar))
 	}
 	if len(parts) == 0 {
 		fmt.Println(" " + msg.Content)

--- a/cmd/workflow_test.go
+++ b/cmd/workflow_test.go
@@ -172,6 +172,77 @@ func TestRunWorkflowLogsFetchesRunAndActivityMessages(t *testing.T) {
 	}
 }
 
+func TestPrintCollapsedActivityMessages(t *testing.T) {
+	started := time.Date(2026, 7, 24, 9, 0, 0, 0, time.UTC)
+	mk := func(kind, message string) types.HubMessage {
+		return types.HubMessage{
+			Format:    "activity:" + mustJSON(t, agentActivity{Kind: kind, Message: message}),
+			CreatedAt: started,
+		}
+	}
+	mkTool := func(phase, command string) types.HubMessage {
+		return types.HubMessage{
+			Format:    "activity:" + mustJSON(t, agentActivity{Kind: "tool", Tool: "bash", Phase: phase, Command: command}),
+			CreatedAt: started,
+		}
+	}
+	mkPlain := func(content string) types.HubMessage {
+		return types.HubMessage{Content: content, CreatedAt: started}
+	}
+
+	messages := []types.HubMessage{
+		mk("activity", "The"),
+		mk("activity", "The user wants"),
+		mk("activity", "The user wants to run updates"),
+		mkTool("running", "git status"),
+		mkTool("running", "git status"),
+		mkTool("completed", "git status"),
+		mkPlain("plain hub message"),
+		mk("activity", "Now thinking about tests"),
+		mk("activity", "Now thinking about tests and validation"),
+	}
+
+	out, err := captureStdout(func() error {
+		printCollapsedActivityMessages(messages)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("captureStdout failed: %v", err)
+	}
+
+	// The three prefix-extended reasoning messages should collapse to one.
+	if !strings.Contains(out, "The user wants to run updates") {
+		t.Fatalf("output missing final collapsed reasoning message:\n%s", out)
+	}
+	if !strings.Contains(out, "(+ 2 similar)") {
+		t.Fatalf("output missing collapse count for first reasoning burst:\n%s", out)
+	}
+	// The duplicate running tool messages should be collapsed.
+	if strings.Count(out, "[bash]") != 2 {
+		t.Fatalf("want 2 bash lines (running + completed), got %d:\n%s", strings.Count(out, "[bash]"), out)
+	}
+	if !strings.Contains(out, "(+ 1 similar)") {
+		t.Fatalf("output missing collapse count for duplicate tool start:\n%s", out)
+	}
+	// Non-activity content should appear as-is.
+	if !strings.Contains(out, "plain hub message") {
+		t.Fatalf("output missing plain message:\n%s", out)
+	}
+	// The final reasoning burst should be present.
+	if !strings.Contains(out, "Now thinking about tests and validation") {
+		t.Fatalf("output missing final reasoning message:\n%s", out)
+	}
+}
+
+func mustJSON(t *testing.T, v interface{}) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(b)
+}
+
 func TestRunWorkflowRunsListsRunsAndShortAgentID(t *testing.T) {
 	started := time.Date(2026, 7, 24, 9, 0, 0, 0, time.UTC)
 	finished := started.Add(5 * time.Minute)

--- a/pkg/hub/dependency_updates.go
+++ b/pkg/hub/dependency_updates.go
@@ -350,6 +350,60 @@ func formatDependencyUpdateFailure(result *pipelineRunResult) string {
 	return "Dependency update step failed: " + combined
 }
 
+// formatDependencyUpdateSummary returns a concise, human-readable summary of a
+// successful dependency update run based on the JSON result document emitted by
+// the dependency update script. It is surfaced in the web UI so users can see
+// what the step did without reading the full structured output.
+func formatDependencyUpdateSummary(result *pipelineRunResult) string {
+	if result == nil {
+		return "Dependency updates completed"
+	}
+	combined := strings.TrimSpace(result.Stdout)
+	if combined == "" {
+		return "Dependency updates completed"
+	}
+
+	var output struct {
+		Ecosystems []string `json:"ecosystems"`
+		Manifests  []struct {
+			Ecosystem string `json:"ecosystem"`
+			Path      string `json:"path"`
+		} `json:"manifests"`
+		Updates []struct {
+			Applied bool `json:"applied"`
+		} `json:"updates"`
+		FilesChanged []string `json:"files_changed"`
+	}
+	if doc := lastJSONObject(combined); doc != nil {
+		_ = json.Unmarshal(doc, &output)
+	}
+
+	applied := 0
+	skipped := 0
+	for _, update := range output.Updates {
+		if update.Applied {
+			applied++
+		} else {
+			skipped++
+		}
+	}
+
+	parts := []string{"Dependency updates completed"}
+	if len(output.Ecosystems) > 0 {
+		parts = append(parts, fmt.Sprintf("%d ecosystem(s)", len(output.Ecosystems)))
+	}
+	if len(output.Manifests) > 0 {
+		parts = append(parts, fmt.Sprintf("%d manifest(s)", len(output.Manifests)))
+	}
+	if applied > 0 || skipped > 0 {
+		parts = append(parts, fmt.Sprintf("%d applied, %d skipped", applied, skipped))
+	}
+	if len(output.FilesChanged) > 0 {
+		parts = append(parts, fmt.Sprintf("%d file(s) changed", len(output.FilesChanged)))
+	}
+	return strings.Join(parts, ": ")
+}
+
 // lastJSONObject returns the last valid JSON object in s, or nil if none is found.
 // It is used to extract the dependency update result document from output that may
 // contain non-JSON banners or log lines before or after the JSON.
@@ -398,6 +452,7 @@ def enabled_ecosystems():
 
 ECOSYSTEMS = enabled_ecosystems()
 result["ecosystems"] = sorted(ECOSYSTEMS)
+print(f"Starting dependency updates for ecosystem(s): {', '.join(result['ecosystems'])}", file=sys.stderr)
 
 def rel(path):
     return path.relative_to(ROOT).as_posix()
@@ -437,6 +492,10 @@ def update_record(ecosystem, name, from_version, to_version, kind, applied, grou
     if skipped_reason:
         record["skipped_reason"] = skipped_reason
     result["updates"].append(record)
+    if applied:
+        print(f"Applying {ecosystem} update: {name} {from_version} -> {to_version}", file=sys.stderr)
+    else:
+        print(f"Skipping {ecosystem} update: {name} ({skipped_reason})", file=sys.stderr)
 
 def version_parts(version):
     version = str(version or "").strip().lstrip("v")
@@ -565,9 +624,11 @@ def collect_files(manifests):
 
 manifests = discover()
 result["manifests"] = manifests
+print(f"Discovered {len(manifests)} manifest(s)", file=sys.stderr)
 before = file_snapshot(collect_files(manifests))
 
 for manifest in manifests:
+    print(f"Processing {manifest['ecosystem']} manifest {manifest['path']}", file=sys.stderr)
     manifest_path = ROOT / manifest["path"]
     cwd = manifest_path.parent
 
@@ -653,6 +714,7 @@ for manifest in manifests:
                 had_failure = True
 
 result["files_changed"] = changed_files(before)
+print(f"Dependency update complete: {len(result['updates'])} update(s), {len(result['files_changed'])} file(s) changed", file=sys.stderr)
 print(json.dumps(result, sort_keys=True))
 sys.exit(1 if had_failure else 0)
 `

--- a/pkg/hub/dependency_updates_test.go
+++ b/pkg/hub/dependency_updates_test.go
@@ -705,3 +705,21 @@ func TestFormatDependencyUpdateFailureSkipsRetriedAttempts(t *testing.T) {
 		t.Fatalf("formatDependencyUpdateFailure = %q, want %q", got, want)
 	}
 }
+
+func TestFormatDependencyUpdateSummary(t *testing.T) {
+	stdout := `{"ecosystems":["go","npm"],"manifests":[{"ecosystem":"go","path":"go.mod"},{"ecosystem":"npm","path":"web/package.json"}],"updates":[{"applied":true,"name":"example.com/foo"},{"applied":true,"name":"left-pad"},{"applied":false,"name":"example.com/bar"}],"files_changed":["go.mod","go.sum","web/package-lock.json"]}`
+	result := &pipelineRunResult{ExitCode: 0, Stdout: stdout}
+	got := formatDependencyUpdateSummary(result)
+	want := "Dependency updates completed: 2 ecosystem(s): 2 manifest(s): 2 applied, 1 skipped: 3 file(s) changed"
+	if got != want {
+		t.Fatalf("formatDependencyUpdateSummary = %q, want %q", got, want)
+	}
+
+	if got := formatDependencyUpdateSummary(nil); got != "Dependency updates completed" {
+		t.Fatalf("nil result summary = %q, want %q", got, "Dependency updates completed")
+	}
+
+	if got := formatDependencyUpdateSummary(&pipelineRunResult{ExitCode: 0, Stdout: "not-json"}); got != "Dependency updates completed" {
+		t.Fatalf("non-JSON result summary = %q, want %q", got, "Dependency updates completed")
+	}
+}

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -941,6 +941,15 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 			}
 		} else {
 			log.Printf("[pipeline] workflow command completed for claw %s stage %q", clawID[:8], stage.ID)
+			if result != nil {
+				if result.Stdout != "" {
+					log.Printf("[pipeline] workflow command stdout for claw %s:\n%s", clawID[:8], result.Stdout)
+				}
+				if result.Stderr != "" {
+					log.Printf("[pipeline] workflow command stderr for claw %s:\n%s", clawID[:8], result.Stderr)
+				}
+				s.injectHubMessageByID(clawID, fmt.Sprintf("[hub] Workflow command completed for stage %q (exit %d)", stage.ID, result.ExitCode))
+			}
 		}
 	}
 
@@ -969,6 +978,17 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 				log.Printf("[pipeline] %s", msg)
 				s.injectHubMessageByID(clawID, "[hub] Error: "+msg)
 				return false, errors.New(msg)
+			}
+		} else {
+			log.Printf("[pipeline] dependency updates completed for claw %s stage %q", clawID[:8], stage.ID)
+			if result != nil {
+				if result.Stdout != "" {
+					log.Printf("[pipeline] dependency update stdout for claw %s:\n%s", clawID[:8], result.Stdout)
+				}
+				if result.Stderr != "" {
+					log.Printf("[pipeline] dependency update stderr for claw %s:\n%s", clawID[:8], result.Stderr)
+				}
+				s.injectHubMessageByID(clawID, "[hub] "+formatDependencyUpdateSummary(result))
 			}
 		}
 	}

--- a/pkg/hub/pipeline_runner_test.go
+++ b/pkg/hub/pipeline_runner_test.go
@@ -1078,6 +1078,49 @@ func TestRunOnEnterJudgeContinueOnError(t *testing.T) {
 	}
 }
 
+func TestRunOnEnterRunCommandLogsAndInjectsOnSuccess(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{
+		Token:     "test-token",
+		ClawToken: "test-claw-token",
+		Providers: map[string]types.ProviderConfig{
+			"noop": {Type: "noop"},
+		},
+	}, "", "", "")
+
+	const clawID = "claw-run-success"
+	_, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, template, status, provider, provider_id, created_at) VALUES(?,?,?,?,?,?,?,datetime('now'))`,
+		clawID, "test-tenant-id", "test-claw", "elasticclaw", "connected", "noop", "noop-id",
+	)
+	if err != nil {
+		t.Fatalf("insert claw: %v", err)
+	}
+
+	stage := pipeline.Stage{
+		ID:    "build",
+		Label: "Build",
+		OnEnter: pipeline.OnEnter{
+			Run: pipeline.RunAction{
+				Command: "echo hello",
+			},
+			Inject: "Continue after build",
+		},
+	}
+
+	_, err = s.runOnEnter(clawID, stage, pipelineContext{})
+	if err != nil {
+		t.Fatalf("expected runOnEnter to succeed, got error: %v", err)
+	}
+
+	var messageCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=?`, clawID).Scan(&messageCount); err != nil {
+		t.Fatalf("count messages: %v", err)
+	}
+	if messageCount != 2 {
+		t.Fatalf("expected 2 messages (run completion + inject), got %d", messageCount)
+	}
+}
+
 func TestRunOnEnterDependencyUpdatesStopsOnError(t *testing.T) {
 	s, db := NewTestServerWithConfig(t, &types.HubConfig{
 		Token:     "test-token",
@@ -1164,6 +1207,49 @@ func TestRunOnEnterDependencyUpdatesContinueOnError(t *testing.T) {
 	// Should have 2 messages: deps warning + inject message (because continue_on_error=true).
 	if messageCount != 2 {
 		t.Fatalf("expected 2 messages (deps warning + inject), got %d", messageCount)
+	}
+}
+
+func TestRunOnEnterDependencyUpdatesLogsAndInjectsOnSuccess(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{
+		Token:     "test-token",
+		ClawToken: "test-claw-token",
+		Providers: map[string]types.ProviderConfig{
+			"noop": {Type: "noop"},
+		},
+	}, "", "", "")
+
+	const clawID = "claw-deps-success"
+	_, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, template, status, provider, provider_id, created_at) VALUES(?,?,?,?,?,?,?,datetime('now'))`,
+		clawID, "test-tenant-id", "test-claw", "elasticclaw", "connected", "noop", "noop-id",
+	)
+	if err != nil {
+		t.Fatalf("insert claw: %v", err)
+	}
+
+	stage := pipeline.Stage{
+		ID:    "deps",
+		Label: "Dependency Updates",
+		OnEnter: pipeline.OnEnter{
+			DependencyUpdates: pipeline.DependencyUpdatesAction{
+				Enabled: true,
+			},
+			Inject: "Continue after deps",
+		},
+	}
+
+	_, err = s.runOnEnter(clawID, stage, pipelineContext{})
+	if err != nil {
+		t.Fatalf("expected runOnEnter to succeed, got error: %v", err)
+	}
+
+	var messageCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=?`, clawID).Scan(&messageCount); err != nil {
+		t.Fatalf("count messages: %v", err)
+	}
+	if messageCount != 2 {
+		t.Fatalf("expected 2 messages (deps summary + inject), got %d", messageCount)
 	}
 }
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -458,10 +458,10 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/workspaces/{name}/workflows", s.withAdminForMethods(s.handleWorkspaceWorkflowsList, http.MethodPost))
 	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}", s.withAdminForMethods(s.handleWorkspaceWorkflowDetail, http.MethodPatch))
 	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}/trigger", s.withAuth(s.handleWorkspaceWorkflowTrigger))
-	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}/cron/trigger", s.withAuth(s.handleCronWorkflowTrigger)) // POST manual trigger
-	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}/cron/runs", s.withAuth(s.handleCronWorkflowRuns))       // GET run history
+	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}/cron/trigger", s.withAuth(s.handleCronWorkflowTrigger))  // POST manual trigger
+	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}/cron/runs", s.withAuth(s.handleCronWorkflowRuns))        // GET run history
 	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}/cron/runs/{runId}", s.withAuth(s.handleCronWorkflowRun)) // GET single run
-	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}/cron/next", s.withAuth(s.handleCronWorkflowNextRun))    // GET next scheduled run
+	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}/cron/next", s.withAuth(s.handleCronWorkflowNextRun))     // GET next scheduled run
 	mux.HandleFunc("/api/workspaces/{workspace}/secrets", s.withAdminForMethods(s.handleWorkspaceSecretsCRUD, http.MethodPut, http.MethodPost, http.MethodDelete))
 	mux.HandleFunc("/api/workspaces/{workspace}/github-apps", s.withAdminForMethods(s.handleWorkspaceGitHubAppsCRUD, http.MethodPut, http.MethodPost, http.MethodDelete))
 	mux.HandleFunc("/api/workspaces/{workspace}/issue-trackers", s.withAdminForMethods(s.handleWorkspaceIssueTrackersCRUD, http.MethodPut, http.MethodPost, http.MethodDelete))
@@ -2537,10 +2537,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 					content := activityContent(activity)
 					if content != "" && !isUnhelpfulActivityContent(activity, content) {
 						format := "activity:" + string(payload)
-						_, _ = s.db.Exec(
-							`INSERT INTO messages(id,claw_id,tenant_id,role,content,format,created_at,delivered_at) VALUES(?,?,?,?,?,?,?,?)`,
-							uuid.New().String(), clawID, tenantID, "activity", content, format, createdAt, createdAt,
-						)
+						s.storeAgentActivity(clawID, tenantID, content, format, activity, createdAt)
 					}
 					s.broadcastToUsers(tenantID, types.WSMessage{
 						Type:    "agent_activity",
@@ -4579,6 +4576,29 @@ func isUnhelpfulActivityContent(activity map[string]interface{}, content string)
 		return true
 	}
 	return strings.HasPrefix(content, "No streamed output")
+}
+
+// storeAgentActivity persists an activity message. Generic reasoning activity
+// (kind == "activity") is upserted into a single row per claw so the model's
+// streaming internal monologue does not flood the messages table. Tool,
+// diagnostic, error, and lifecycle activity messages are inserted as distinct
+// rows because they are useful audit events.
+func (s *Server) storeAgentActivity(clawID, tenantID, content, format string, activity map[string]interface{}, createdAt time.Time) {
+	kind, _ := activity["kind"].(string)
+	if strings.ToLower(strings.TrimSpace(kind)) == "activity" {
+		// Use a deterministic ID so repeated reasoning updates collapse to one row.
+		msgID := "activity-stream:" + clawID
+		_, _ = s.db.Exec(
+			`INSERT INTO messages(id,claw_id,tenant_id,role,content,format,created_at,delivered_at) VALUES(?,?,?,?,?,?,?,?)
+			 ON CONFLICT(id) DO UPDATE SET content=excluded.content, format=excluded.format, created_at=excluded.created_at, delivered_at=excluded.delivered_at`,
+			msgID, clawID, tenantID, "activity", content, format, createdAt, createdAt,
+		)
+		return
+	}
+	_, _ = s.db.Exec(
+		`INSERT INTO messages(id,claw_id,tenant_id,role,content,format,created_at,delivered_at) VALUES(?,?,?,?,?,?,?,?)`,
+		uuid.New().String(), clawID, tenantID, "activity", content, format, createdAt, createdAt,
+	)
 }
 
 func daytonaBootstrapStatusForStep(label string) string {

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -125,8 +125,8 @@ func TestWorkspaceFlakeStageCommand(t *testing.T) {
 			name: "ignores invalid paths",
 			dir:  "/workspace",
 			files: map[string]string{
-				"flake.nix": "{}",
-				"../secret": "secret",
+				"flake.nix":   "{}",
+				"../secret":   "secret",
 				"/etc/passwd": "pw",
 			},
 			wantNames:   []string{"flake.nix"},
@@ -2463,5 +2463,55 @@ func TestMergeDockerContainerEnvPreservesWorkflowSecrets(t *testing.T) {
 	}
 	if got["ELASTICCLAW_CLAW_ID"] != "claw-123" {
 		t.Fatalf("ELASTICCLAW_CLAW_ID = %q, want managed claw ID", got["ELASTICCLAW_CLAW_ID"])
+	}
+}
+
+func TestAgentActivityGenericReasoningUpsertsButToolEventsInsert(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	const clawID = "activity-storage-test"
+	conn := watchdogClaw(t, s, clawID)
+	_ = watchdogClawConn(t, s, clawID)
+
+	write := func(m types.WSMessage) {
+		if err := wsjson.Write(context.Background(), conn, m); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Send a burst of generic reasoning activity frames.
+	for i := 0; i < 5; i++ {
+		write(types.WSMessage{Type: "agent_activity", Payload: map[string]any{
+			"kind":    "activity",
+			"message": fmt.Sprintf("The user wants%s", strings.Repeat(".", i+1)),
+		}})
+	}
+	// Send two distinct tool events.
+	write(types.WSMessage{Type: "agent_activity", Payload: map[string]any{
+		"kind": "tool", "tool": "bash", "phase": "running", "command": "git status",
+	}})
+	write(types.WSMessage{Type: "agent_activity", Payload: map[string]any{
+		"kind": "tool", "tool": "bash", "phase": "completed", "command": "git status",
+	}})
+
+	eventuallyWatchdog(t, func() bool {
+		var n int
+		_ = db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND role='activity'`, clawID).Scan(&n)
+		return n >= 3
+	}, "activity rows persisted")
+
+	var total int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND role='activity'`, clawID).Scan(&total); err != nil {
+		t.Fatalf("count activity rows: %v", err)
+	}
+	if total != 3 {
+		t.Fatalf("activity rows = %d, want 3 (1 upserted reasoning + 2 tool events)", total)
+	}
+
+	var latestReasoning string
+	if err := db.QueryRow(`SELECT content FROM messages WHERE claw_id=? AND id=?`, clawID, "activity-stream:"+clawID).Scan(&latestReasoning); err != nil {
+		t.Fatalf("read upserted reasoning row: %v", err)
+	}
+	if !strings.Contains(latestReasoning, "The user wants") {
+		t.Fatalf("upserted reasoning content unexpected: %q", latestReasoning)
 	}
 }

--- a/web/components/conversation-view.tsx
+++ b/web/components/conversation-view.tsx
@@ -1076,10 +1076,6 @@ function isHiddenActivity(message: Message): boolean {
   return message.activity?.kind === "still_working" || message.content.startsWith("No streamed output")
 }
 
-function isStaleModelWait(message: Message, latestActivity: Message | null): boolean {
-  return message.activity?.kind === "model_started" && latestActivity?.id !== message.id
-}
-
 function hasEarlierTerminalAssistant(messages: Message[], index: number): boolean {
   for (let i = index - 1; i >= 0; i -= 1) {
     if (isTerminalAssistantMessage(messages[i])) return true
@@ -1120,24 +1116,16 @@ type ConversationItem =
 function compactActivityRuns(messages: Message[]): ConversationItem[] {
   const items: ConversationItem[] = []
   let run: Message[] = []
-  const latestActivity = latestActivityMessage(messages)
 
   const flush = () => {
-    const visible = run.filter((message) => !isHiddenActivity(message) && !isStaleModelWait(message, latestActivity))
+    const visible = run.filter((message) => !isHiddenActivity(message))
     run = []
     if (visible.length === 0) return
-    if (visible.length === 1) {
-      items.push({ type: "message", message: visible[0] })
-      return
-    }
-    const collapsed = visible.slice(0, -1)
-    const latest = visible[visible.length - 1]
     items.push({
       type: "activity-summary",
-      id: `activity-summary-${collapsed[0].id}-${collapsed[collapsed.length - 1].id}`,
-      messages: collapsed,
+      id: `activity-summary-${visible[0].id}-${visible[visible.length - 1].id}`,
+      messages: visible,
     })
-    items.push({ type: "message", message: latest })
   }
 
   for (const message of messages) {

--- a/web/hooks/use-windowed-messages.ts
+++ b/web/hooks/use-windowed-messages.ts
@@ -6,7 +6,6 @@ import { mapApiMessage } from "@/lib/mappers"
 import type { Message } from "@/lib/types"
 
 const PAGE_SIZE = 50    // messages per page
-const MAX_WINDOW = 50   // max messages kept in DOM
 const ROLE_ORDER: Record<Message["role"], number> = {
   user: 0,
   hub: 1,
@@ -92,11 +91,7 @@ export function useWindowedMessages({ clawId, liveMessages }: UseWindowedMessage
       setHasOlder(hasOlderConversationPage(older, PAGE_SIZE))
       oldestTimestamp.current = oldestConversationCursor(older)
 
-      setHistoricalMsgs((prev) => {
-        const combined = [...older, ...prev]
-        // Cap window — drop from bottom if too large
-        return combined.length > MAX_WINDOW ? combined.slice(0, MAX_WINDOW) : combined
-      })
+      setHistoricalMsgs((prev) => [...older, ...prev])
 
       // Restore scroll position so prepend doesn't jump
       requestAnimationFrame(() => {
@@ -134,7 +129,7 @@ export function useWindowedMessages({ clawId, liveMessages }: UseWindowedMessage
       all.push(m)
     }
     all.sort(compareMessages)
-    return all.length > MAX_WINDOW ? all.slice(all.length - MAX_WINDOW) : all
+    return all
   })()
 
   return { messages, hasOlder, loadingOlder, loadOlder, scrollRef, onScroll }


### PR DESCRIPTION
## Goal

Agent runs currently generate a lot of low-signal activity chatter while hiding the useful work they actually do. This PR combines the two related changes so that:

1. **Important work is visible** — pipeline steps like run commands and dependency updates now emit completion messages, log their stdout/stderr on success, and appear in the web UI **Actions** tab.
2. **Noise is reduced** — duplicate activity messages are deduplicated, generic reasoning is upserted instead of flooding the DB, and the CLI/web UI collapse long tool-call runs.

## Backend / CLI

- `dependency_updates` and `on_enter.run.command` log stdout/stderr on success, emit a completion log, and inject a summary message into the claw chat so the step appears in the web UI **Actions** tab.
- The dependency update Python script prints progress lines to stderr (discovered manifests, processing each manifest, applying/skipping updates, completion summary).
- Bridge deduplicates exact duplicate activity messages before sending to the hub, and only updates its dedup cache after a successful send.
- Hub upserts generic "reasoning" activity messages so the model's streaming internal monologue does not flood the `messages` table; tool/error/diagnostic events are still inserted as distinct audit rows.
- Activity text truncation limit raised from 240 to 2000 characters.
- `elasticclaw workflow logs` collapses prefix-extended and duplicate activity messages.

## Web UI

- Removed the 50-message DOM cap in `useWindowedMessages` so streaming chat scrollback no longer drops older messages as new ones arrive.
- `compactActivityRuns` folds an entire run of tool/activity messages into a single expandable summary line, reducing chatter while keeping the full history available.

## Where to see it

- **Actions tab**: completion messages for run commands and dependency updates.
- **Output tab**: dependency update stderr progress lines; run command stdout/stderr when `output:` is set.
- **Hub logs**: full stdout/stderr for both step types on success, not just failure.
- **Workflow logs**: collapsed duplicate/prefix-extended activity lines and fewer generic reasoning spam rows.

## Tests

- `go test ./pkg/hub/... ./cmd/...` passes.
- `npm run typecheck` passes in `web/`.
- `npm run lint` has no new errors (only pre-existing image warnings).

## Replaces

- Closes #564
- Closes #572
