### PR TITLE
fix(hub): render Jira issue context in pipeline inject templates

### DIFF
--- a/pkg/hub/jira.go
+++ b/pkg/hub/jira.go
@@ -710,6 +710,25 @@ func (s *Server) fetchJiraIssue(tracker workspaceIssueTracker, key string) (jira
 	return issue, nil
 }
 
+// fetchJiraIssueDetails looks up a Jira issue by key (e.g. "KAN-2547") and
+// returns the fields needed for pipeline template rendering ({{.Issue.*}}).
+func (s *Server) fetchJiraIssueDetails(tracker workspaceIssueTracker, key string) (*linearIssueDetails, error) {
+	issue, err := s.fetchJiraIssue(tracker, key)
+	if err != nil {
+		return nil, err
+	}
+	browseURL := ""
+	if base := s.jiraBaseForTracker(tracker); base != "" && issue.Key != "" {
+		browseURL = base + "/browse/" + issue.Key
+	}
+	return &linearIssueDetails{
+		Identifier:  issue.Key,
+		Title:       issue.Fields.Summary,
+		URL:         browseURL,
+		Description: jiraDescriptionText(issue.Fields.Description),
+	}, nil
+}
+
 func (s *Server) queryJiraIssues(tracker workspaceIssueTracker, since time.Time, projects []string) ([]jiraPollIssue, error) {
 	base := s.jiraBaseForTracker(tracker)
 	if base == "" {

--- a/pkg/hub/jira_pipeline_inject_test.go
+++ b/pkg/hub/jira_pipeline_inject_test.go
@@ -1,0 +1,244 @@
+package hub
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/elasticclaw/elasticclaw/pkg/hub/pipeline"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func TestRunOnEnterInjectRendersJiraIssueDetails(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+
+	var hitJira bool
+	jira := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rest/api/2/issue/KAN-2547" {
+			http.NotFound(w, r)
+			return
+		}
+		hitJira = true
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"key": "KAN-2547",
+			"fields": map[string]interface{}{
+				"summary":     "Break down epic",
+				"description": "Plan the child issues",
+				"status":      map[string]string{"name": "Ready for Agent"},
+			},
+		})
+	}))
+	defer jira.Close()
+
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+	SaveWorkspaceForTest(t,
+		&types.WorkspaceConfig{
+			SchemaVersion: "v1",
+			Name:          "engineering",
+			Files: map[string]string{
+				"elasticclaw-config.yaml": "schema_version: v1\nname: engineering\n",
+			},
+		},
+		[]*types.WorkflowConfig{{
+			SchemaVersion: "v1",
+			Name:          "jira-epic-plan",
+			Integration:  "jira",
+			Workspace:    "default",
+			Trigger: &types.WorkflowTrigger{
+				Jira: &types.JiraWorkflowTrigger{
+					Workspace: "default",
+					Event:     "status_changed",
+					Projects:  []string{"KAN"},
+					States:    []string{"Ready for Agent"},
+				},
+			},
+			Stages: []types.WorkflowStage{{
+				ID:    "working",
+				Label: "Working",
+				Entry: true,
+			}},
+		}},
+	)
+	SaveWorkspaceIssueTrackerWithBaseForTest(t, "engineering", "jira", "default", jira.URL, "jira-user", "jira-token", "")
+
+	const clawID = "claw-jira-inject-render"
+	if _, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, template, status, jira_issue_id, tags, created_at) VALUES(?,?,?,?,?,?,?,datetime('now'))`,
+		clawID, "test-tenant-id", "KAN-2547", "base", "connected", "KAN-2547", `["workspace:engineering","workflow:jira-epic-plan"]`,
+	); err != nil {
+		t.Fatalf("insert claw: %v", err)
+	}
+
+	workspace, workflow, ok := loadWorkflowPipelineContext("engineering", "jira-epic-plan")
+	if !ok {
+		t.Fatal("expected jira workflow context")
+	}
+	stage := pipeline.Stage{
+		ID:    "working",
+		Label: "Working",
+		OnEnter: pipeline.OnEnter{
+			Inject: "Work on {{.Issue.Identifier}}: {{.Issue.Title}}\n{{.Issue.URL}}\n{{.Issue.Description}}",
+		},
+	}
+	ctx := pipelineContext{
+		Workspace: workspace,
+		Workflow:  workflow,
+		IssueID:   "KAN-2547",
+	}
+	if _, err := s.runOnEnter(clawID, stage, ctx); err != nil {
+		t.Fatalf("runOnEnter: %v", err)
+	}
+	if !hitJira {
+		t.Fatal("expected Jira issue fetch for inject template rendering")
+	}
+
+	var content string
+	if err := db.QueryRow(
+		`SELECT COALESCE(group_concat(content, '\n'),'') FROM messages WHERE claw_id=?`,
+		clawID,
+	).Scan(&content); err != nil {
+		t.Fatalf("load inject message: %v", err)
+	}
+	if !strings.Contains(content, "Work on KAN-2547: Break down epic") {
+		t.Fatalf("inject missing rendered title: %q", content)
+	}
+	if !strings.Contains(content, jira.URL+"/browse/KAN-2547") {
+		t.Fatalf("inject missing browse URL: %q", content)
+	}
+	if !strings.Contains(content, "Plan the child issues") {
+		t.Fatalf("inject missing description: %q", content)
+	}
+	if strings.Contains(content, "no Linear issue tracker") {
+		t.Fatalf("inject path incorrectly warned about Linear: %q", content)
+	}
+}
+
+func TestRunOnEnterInjectJiraFallbackWarnsAboutJiraNotLinear(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+	SaveWorkspaceForTest(t,
+		&types.WorkspaceConfig{
+			SchemaVersion: "v1",
+			Name:          "engineering",
+			Files: map[string]string{
+				"elasticclaw-config.yaml": "schema_version: v1\nname: engineering\n",
+			},
+		},
+		[]*types.WorkflowConfig{{
+			SchemaVersion: "v1",
+			Name:          "jira-backend",
+			Integration:  "jira",
+			Workspace:    "default",
+			Trigger: &types.WorkflowTrigger{
+				Jira: &types.JiraWorkflowTrigger{
+					Workspace: "default",
+					Event:     "status_changed",
+					Projects:  []string{"KAN"},
+					States:    []string{"Ready for Agent"},
+				},
+			},
+			Stages: []types.WorkflowStage{{
+				ID:    "working",
+				Label: "Working",
+				Entry: true,
+			}},
+		}},
+	)
+
+	const clawID = "claw-jira-inject-fallback"
+	if _, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, template, status, jira_issue_id, tags, created_at) VALUES(?,?,?,?,?,?,?,datetime('now'))`,
+		clawID, "test-tenant-id", "KAN-1", "base", "connected", "KAN-1", `["workspace:engineering","workflow:jira-backend"]`,
+	); err != nil {
+		t.Fatalf("insert claw: %v", err)
+	}
+
+	workspace, workflow, ok := loadWorkflowPipelineContext("engineering", "jira-backend")
+	if !ok {
+		t.Fatal("expected jira workflow context")
+	}
+	stage := pipeline.Stage{
+		ID: "working",
+		OnEnter: pipeline.OnEnter{
+			Inject: "Issue {{.Issue.Identifier}}",
+		},
+	}
+	if _, err := s.runOnEnter(clawID, stage, pipelineContext{
+		Workspace: workspace,
+		Workflow:  workflow,
+		IssueID:   "KAN-1",
+	}); err != nil {
+		t.Fatalf("runOnEnter: %v", err)
+	}
+
+	rows, err := db.Query(`SELECT content FROM messages WHERE claw_id=? ORDER BY id`, clawID)
+	if err != nil {
+		t.Fatalf("query messages: %v", err)
+	}
+	defer rows.Close()
+	var messages []string
+	for rows.Next() {
+		var content string
+		if err := rows.Scan(&content); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		messages = append(messages, content)
+	}
+	joined := strings.Join(messages, "\n")
+	if !strings.Contains(joined, "no Jira tracker configured") {
+		t.Fatalf("expected Jira tracker warning, got: %q", joined)
+	}
+	if strings.Contains(joined, "no Linear issue tracker") {
+		t.Fatalf("should not warn about Linear for jira workflows: %q", joined)
+	}
+	if !strings.Contains(joined, "Issue KAN-1") {
+		t.Fatalf("expected fallback inject with issue identifier: %q", joined)
+	}
+}
+
+func TestLoadIssueTextForJudgeUsesJira(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+
+	jira := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"key": "KAN-99",
+			"fields": map[string]interface{}{
+				"summary":     "Judge me",
+				"description": "Acceptance criteria",
+			},
+		})
+	}))
+	defer jira.Close()
+
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+	SaveWorkspaceForTest(t,
+		&types.WorkspaceConfig{Name: "engineering", Files: map[string]string{"elasticclaw-config.yaml": "schema_version: v1\nname: engineering\n"}},
+		[]*types.WorkflowConfig{{
+			Name:         "jira-backend",
+			Integration:  "jira",
+			Workspace:    "default",
+			PipelineYAML: "stages:\n  - id: working\n    entry: true\n",
+			Trigger:      &types.WorkflowTrigger{Jira: &types.JiraWorkflowTrigger{Workspace: "default"}},
+		}},
+	)
+	SaveWorkspaceIssueTrackerWithBaseForTest(t, "engineering", "jira", "default", jira.URL, "user", "token", "")
+
+	workspace, workflow, ok := loadWorkflowPipelineContext("engineering", "jira-backend")
+	if !ok {
+		t.Fatal("expected workflow")
+	}
+	got := s.loadIssueTextForJudge("unused", pipelineContext{
+		Workspace: workspace,
+		Workflow:  workflow,
+		IssueID:   "KAN-99",
+	})
+	if !strings.Contains(got, "KAN-99: Judge me") || !strings.Contains(got, "Acceptance criteria") {
+		t.Fatalf("judge issue text = %q", got)
+	}
+	if strings.HasPrefix(got, "Linear issue:") {
+		t.Fatalf("expected Jira issue text, got Linear fallback: %q", got)
+	}
+}

--- a/pkg/hub/notify_action.go
+++ b/pkg/hub/notify_action.go
@@ -206,13 +206,24 @@ func (s *Server) notifyIssueTemplateData(clawID string, pipelineCtx pipelineCont
 	}
 
 	details := &linearIssueDetails{Identifier: issueID}
-	if !strings.HasPrefix(issueID, "sc-") {
-		if token := s.resolveLinearTokenForPipeline(pipelineCtx); token != "" {
-			if fetched, err := s.fetchLinearIssueDetails(token, issueID); err == nil && fetched != nil {
+	if strings.HasPrefix(issueID, "sc-") {
+		return details
+	}
+	if s.preferJiraForPipelineIssue(pipelineCtx) {
+		if tracker, ok := s.resolveJiraTrackerForPipeline(pipelineCtx); ok {
+			if fetched, err := s.fetchJiraIssueDetails(tracker, issueID); err == nil && fetched != nil {
 				return fetched
 			} else if err != nil {
 				log.Printf("[pipeline] notify issue template lookup failed for claw %s: %v", clawID, err)
 			}
+		}
+		return details
+	}
+	if token := s.resolveLinearTokenForPipeline(pipelineCtx); token != "" {
+		if fetched, err := s.fetchLinearIssueDetails(token, issueID); err == nil && fetched != nil {
+			return fetched
+		} else if err != nil {
+			log.Printf("[pipeline] notify issue template lookup failed for claw %s: %v", clawID, err)
 		}
 	}
 	return details

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -366,6 +366,22 @@ func (s *Server) resolveJiraTrackerForPipeline(ctx pipelineContext) (workspaceIs
 	return workspaceIssueTracker{}, false
 }
 
+// preferJiraForPipelineIssue reports whether KEY-style issue IDs (e.g. KAN-1)
+// should be resolved via Jira rather than Linear for pipeline templates.
+func (s *Server) preferJiraForPipelineIssue(ctx pipelineContext) bool {
+	switch strings.ToLower(strings.TrimSpace(ctx.Integration())) {
+	case "jira":
+		return true
+	case "linear", "shortcut", "github", "github-issues", "cron":
+		return false
+	default:
+		// No explicit integration: prefer Jira only when a Jira tracker is
+		// configured and Linear is not, so Linear factories keep working.
+		_, jiraOK := s.resolveJiraTrackerForPipeline(ctx)
+		return jiraOK && s.resolveLinearTokenForPipeline(ctx) == ""
+	}
+}
+
 const defaultPipelineRunTimeout = 10 * time.Minute
 
 type pipelineRunResult struct {
@@ -808,6 +824,15 @@ func (s *Server) loadIssueTextForJudge(clawID string, ctx pipelineContext) strin
 		}
 		return "GitHub issue: " + issueID
 	}
+	if s.preferJiraForPipelineIssue(ctx) {
+		if tracker, ok := s.resolveJiraTrackerForPipeline(ctx); ok {
+			details, err := s.fetchJiraIssueDetails(tracker, issueID)
+			if err == nil && details != nil {
+				return fmt.Sprintf("**%s: %s**\n%s\n\n%s", details.Identifier, details.Title, details.URL, details.Description)
+			}
+		}
+		return "Jira issue: " + issueID
+	}
 	// Linear issue
 	linearToken := s.resolveLinearTokenForPipeline(ctx)
 	if linearToken != "" {
@@ -1089,26 +1114,51 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 		injectMsg := stage.OnEnter.Inject
 		manualInputs := s.loadManualTriggerInputs(clawID)
 
-		// Render {{.Issue.Identifier}}, {{.Issue.Title}}, {{.Issue.URL}} if this is a Linear claw
-		// GitHub Issues IDs are owner/repo/number format (contain "/"), Shortcut IDs start with "sc-"
+		// Render {{.Issue.Identifier}}, {{.Issue.Title}}, {{.Issue.URL}} for tracker issues.
+		// GitHub Issues IDs are owner/repo/number format (contain "/"), Shortcut IDs start with "sc-".
+		// KEY-style IDs (e.g. KAN-1) are Jira when the workflow/factory integration is jira,
+		// otherwise Linear.
 		if issueID != "" && !strings.HasPrefix(issueID, "sc-") && !strings.Contains(issueID, "/") {
 			log.Printf("[pipeline] attempting to render template for claw %s issue %s", clawID[:8], issueID)
-			linearToken := s.resolveLinearTokenForPipeline(ctx)
-			if linearToken == "" {
-				s.warnPipelineRender(clawID, "%s: no Linear issue tracker token configured; rendering inject with fallback issue context", ctx.Name())
-				injectMsg = renderInjectWithData(clawID, injectMsg, s.injectTemplateData(clawID, map[string]interface{}{
-					"Issue": &linearIssueDetails{Identifier: issueID},
-				}))
-				goto injectMessage
-			}
-			details, err := s.fetchLinearIssueDetails(linearToken, issueID)
-			if err != nil {
-				s.warnPipelineRender(clawID, "%s: failed to fetch Linear issue details for %s: %v", ctx.Name(), issueID, err)
-				details = &linearIssueDetails{Identifier: issueID}
-			}
-			if details == nil {
-				s.warnPipelineRender(clawID, "%s: Linear issue %s returned no details", ctx.Name(), issueID)
-				details = &linearIssueDetails{Identifier: issueID}
+			var details *linearIssueDetails
+			if s.preferJiraForPipelineIssue(ctx) {
+				tracker, ok := s.resolveJiraTrackerForPipeline(ctx)
+				if !ok {
+					s.warnPipelineRender(clawID, "%s: no Jira tracker configured; rendering inject with fallback issue context", ctx.Name())
+					injectMsg = renderInjectWithData(clawID, injectMsg, s.injectTemplateData(clawID, map[string]interface{}{
+						"Issue": &linearIssueDetails{Identifier: issueID},
+					}))
+					goto injectMessage
+				}
+				fetched, err := s.fetchJiraIssueDetails(tracker, issueID)
+				if err != nil {
+					s.warnPipelineRender(clawID, "%s: failed to fetch Jira issue details for %s: %v", ctx.Name(), issueID, err)
+					details = &linearIssueDetails{Identifier: issueID}
+				} else if fetched == nil {
+					s.warnPipelineRender(clawID, "%s: Jira issue %s returned no details", ctx.Name(), issueID)
+					details = &linearIssueDetails{Identifier: issueID}
+				} else {
+					details = fetched
+				}
+			} else {
+				linearToken := s.resolveLinearTokenForPipeline(ctx)
+				if linearToken == "" {
+					s.warnPipelineRender(clawID, "%s: no Linear issue tracker token configured; rendering inject with fallback issue context", ctx.Name())
+					injectMsg = renderInjectWithData(clawID, injectMsg, s.injectTemplateData(clawID, map[string]interface{}{
+						"Issue": &linearIssueDetails{Identifier: issueID},
+					}))
+					goto injectMessage
+				}
+				fetched, err := s.fetchLinearIssueDetails(linearToken, issueID)
+				if err != nil {
+					s.warnPipelineRender(clawID, "%s: failed to fetch Linear issue details for %s: %v", ctx.Name(), issueID, err)
+					details = &linearIssueDetails{Identifier: issueID}
+				} else if fetched == nil {
+					s.warnPipelineRender(clawID, "%s: Linear issue %s returned no details", ctx.Name(), issueID)
+					details = &linearIssueDetails{Identifier: issueID}
+				} else {
+					details = fetched
+				}
 			}
 			tmpl, err := template.New("inject").Parse(injectMsg)
 			if err != nil {
@@ -1278,11 +1328,20 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 		if strings.Contains(resolvedIssueID, "{{.Issue.") {
 			var details *linearIssueDetails
 			if issueID != "" && !strings.HasPrefix(issueID, "sc-") && !strings.Contains(issueID, "/") {
-				linearToken := s.resolveLinearTokenForPipeline(ctx)
-				if linearToken != "" {
-					d, err := s.fetchLinearIssueDetails(linearToken, issueID)
-					if err == nil && d != nil {
-						details = d
+				if s.preferJiraForPipelineIssue(ctx) {
+					if tracker, ok := s.resolveJiraTrackerForPipeline(ctx); ok {
+						d, err := s.fetchJiraIssueDetails(tracker, issueID)
+						if err == nil && d != nil {
+							details = d
+						}
+					}
+				} else {
+					linearToken := s.resolveLinearTokenForPipeline(ctx)
+					if linearToken != "" {
+						d, err := s.fetchLinearIssueDetails(linearToken, issueID)
+						if err == nil && d != nil {
+							details = d
+						}
 					}
 				}
 			} else if strings.Contains(issueID, "/") {
@@ -1348,6 +1407,9 @@ issueResolved:
 	default:
 		isShortcut = strings.HasPrefix(resolvedIssueID, "sc-")
 		isGitHub = strings.Contains(resolvedIssueID, "/")
+		if !isShortcut && !isGitHub {
+			isJira = s.preferJiraForPipelineIssue(ctx)
+		}
 	}
 
 	if isJira {


### PR DESCRIPTION
## Summary
- KEY-style issue IDs (e.g. `KAN-2547`) were always treated as Linear when rendering `{{.Issue.*}}` inject/judge/notify templates, so Jira workflows logged `no Linear issue tracker token` and fell back to identifier-only context.
- Prefer Jira when the workflow/factory integration is `jira` (and when only a Jira tracker is configured), fetch real issue title/URL/description via the existing Jira API helper, and warn about a missing Jira tracker instead of Linear.
- Apply the same routing to judge issue text, notify templates, and `move_issue` `{{.Issue.*}}` resolution.

## Test plan
- [x] `go test ./pkg/hub/ -run 'TestRunOnEnterInjectRendersJiraIssueDetails|TestRunOnEnterInjectJiraFallbackWarnsAboutJiraNotLinear|TestLoadIssueTextForJudgeUsesJira'`
- [ ] Trigger a Jira workflow with an inject that uses `{{.Issue.Title}}` / `{{.Issue.URL}}` and confirm the agent prompt includes real Jira fields
- [ ] Confirm hub logs no longer warn about a missing Linear token for Jira claws
- [ ] Smoke a Linear workflow inject to confirm Linear path is unchanged