### PR TITLE
fix(hub): deflake inter-turn cooldown delivery test

### DIFF
--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -98,6 +98,13 @@ type Server struct {
 	replicatedBootstrapEnvMu sync.Mutex
 	replicatedBootstrapEnv   map[string]map[string]string // temporary handoff while a Replicated VM becomes reachable
 
+	// deliverySettled, when non-nil, fires after a sendNextQueuedMessage call
+	// that claimed the in-flight guard has released it again. The frame reaches
+	// the bridge before that call returns, so receiving a message is not enough
+	// to know the hub is ready to admit the next one; tests use this seam to
+	// sequence against the registration drain. Guarded by s.mu, nil in production.
+	deliverySettled func(clawID string)
+
 	// githubBaseURL overrides the GitHub API base for testing (default: https://api.github.com)
 	githubBaseURL string
 	// linearBaseURL overrides the Linear API base for testing (default: https://api.linear.app)
@@ -7601,6 +7608,12 @@ func (s *Server) sendNextQueuedMessage(cc *clawConn) {
 		cc.mu.Lock()
 		cc.deliveryInFlight = false
 		cc.mu.Unlock()
+		s.mu.RLock()
+		settled := s.deliverySettled
+		s.mu.RUnlock()
+		if settled != nil {
+			settled(clawID)
+		}
 	}()
 
 	var msg types.HubMessage

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -2264,12 +2264,33 @@ func TestSendNextQueuedMessageWaitsInterTurnCooldown(t *testing.T) {
 	insertPendingMessage(t, db, clawID, "first", now().Add(-time.Second))
 	insertPendingMessage(t, db, clawID, "second", now())
 
+	// Registration drains the queue on the handler goroutine, and that call only
+	// releases cc.deliveryInFlight after its frame is already on the wire.
+	// Reading "first" therefore does not mean the hub is idle again: driving
+	// sendNextQueuedMessage before the drain settles hits the in-flight guard,
+	// which returns without delivering "second". Wait for the drain to settle.
+	drained := make(chan struct{}, 1)
+	s.SetDeliverySettledHookForTest(func(id string) {
+		if id != clawID {
+			return
+		}
+		select {
+		case drained <- struct{}{}:
+		default:
+		}
+	})
+
 	ts := httptest.NewServer(s.Handler())
 	t.Cleanup(ts.Close)
 	clawWS := connectTestClaw(t, ts, clawID)
 	t.Cleanup(func() { _ = clawWS.Close(websocket.StatusNormalClosure, "done") })
 	if got := readTestHubMessage(t, clawWS).Content; got != "first" {
 		t.Fatalf("first delivered content = %q, want first", got)
+	}
+	select {
+	case <-drained:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the registration drain to settle")
 	}
 
 	// Speed up the cooldown so the test remains fast, but still measurable.

--- a/pkg/hub/testhelpers.go
+++ b/pkg/hub/testhelpers.go
@@ -150,6 +150,19 @@ func (s *Server) PollIntegrationsForTest() {
 	s.pollTick()
 }
 
+// SetDeliverySettledHookForTest registers fn to run after every queued-message
+// delivery attempt releases its in-flight guard. Tests that drive
+// sendNextQueuedMessage themselves need this to sequence against the
+// registration drain: the drain's frame is on the wire before the drain call
+// returns, so a delivery started on the strength of having read that frame
+// would hit the in-flight guard and silently deliver nothing.
+// fn must not block; it runs on the delivering goroutine.
+func (s *Server) SetDeliverySettledHookForTest(fn func(clawID string)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.deliverySettled = fn
+}
+
 // ClearWebhookDedupForTest empties the in-memory webhook dedup cache so tests can
 // exercise the durable factory_triggers claim rather than the short-lived 5s window.
 func (s *Server) ClearWebhookDedupForTest() {


### PR DESCRIPTION
## Problem

`TestSendNextQueuedMessageWaitsInterTurnCooldown` is flaky — measured **4 failures in 25 runs** on `main` (7d944ae7). It failed `Test / Unit tests` on #580 while the identical `E2E / Unit tests` job passed on the same commit.

```
server_test.go:2291: read delivered message: failed to read JSON message: failed to get reader: use of closed network connection
```

Failing runs take ~5.0s — the `readTestHubMessage` context deadline.

## Root cause

The registration handler drains the pending queue synchronously ([server.go:2382](pkg/hub/server.go:2382)). `sendNextQueuedMessage` claims `cc.deliveryInFlight`, writes the frame, and only releases the guard in its deferred cleanup — after the DB `delivered_at` update and the user broadcast.

The test read the `"first"` frame and took that as "the hub is idle again", then called `finishTurnLocked` + `sendNextQueuedMessage` itself. Whenever the test won that race, its call hit the `cc.deliveryInFlight` guard and returned **without delivering** — `"second"` was never written, and the subsequent read blocked until its 5s deadline. Verbose logs of a failing run show only one `[hub] delivered pending message`, versus two in a passing run.

## Fix

Add a delivery-settled seam on `Server`, fired after the in-flight guard is released, exposed to tests via `SetDeliverySettledHookForTest` (in the existing `!production` `testhelpers.go`). The test now waits for the registration drain to settle before finishing the turn, so its own delivery can never be swallowed by the guard.

No sleep, no retry loop, and the assertion is unchanged: the queued message must still be delivered and `sendNextQueuedMessage` must not return before the cooldown elapses.

## Verification

- `go test ./pkg/hub/ -run TestSendNextQueuedMessageWaitsInterTurnCooldown -count=50` — clean
- `go test ./pkg/hub/ -race -run ... -count=50` — clean
- `go test ./pkg/hub/` (full package) and `go vet ./pkg/hub/` — clean
- `go build -tags production ./pkg/hub/` — clean (the `-tags production ./...` break in `pkg/hub/factorytest` is pre-existing and untouched here)

No UI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)