### PR TITLE
fix(web): stop the analytics page issuing its initial load twice

### DIFF
--- a/web/components/analytics-command-center.tsx
+++ b/web/components/analytics-command-center.tsx
@@ -258,7 +258,6 @@ export function AnalyticsCommandCenter({ workspaceScope }: { workspaceScope?: st
           statsData,
           driversData,
           runsData,
-          optionsData,
         ] = await Promise.all([
           fetchTaskRunAnalyticsSummary(effectiveFilters, { signal: controller.signal }),
           canViewCosts
@@ -281,7 +280,6 @@ export function AnalyticsCommandCenter({ workspaceScope }: { workspaceScope?: st
               )
             : Promise.resolve([]),
           fetchTaskRuns(runFilters, { signal: controller.signal }),
-          options ? Promise.resolve(options) : fetchTaskRunFilterOptions({ signal: controller.signal }),
         ])
         if (controller.signal.aborted || requestId !== loadRequestId.current) return
 
@@ -293,7 +291,6 @@ export function AnalyticsCommandCenter({ workspaceScope }: { workspaceScope?: st
         setDrivers(driversData)
         setRuns((currentRuns) => (append ? [...currentRuns, ...runsData.runs] : runsData.runs))
         setNextCursor(runsData.nextCursor)
-        setOptions(optionsData)
         if (!append && !silent) {
           setSelectedRunId(null)
         }
@@ -305,8 +302,25 @@ export function AnalyticsCommandCenter({ workspaceScope }: { workspaceScope?: st
         }
       }
     },
-    [canViewCosts, filters, options]
+    [canViewCosts, filters]
   )
+
+  // The filter dropdown contents are static for the session, so they are
+  // fetched once here rather than inside load(). Keeping them out of load's
+  // dependencies is what stops the initial load from running twice: load()
+  // used to set this state, which changed load's own identity and re-fired
+  // the effect below, issuing a second full round of requests one
+  // round-trip after the first.
+  useEffect(() => {
+    const controller = new AbortController()
+    fetchTaskRunFilterOptions({ signal: controller.signal })
+      .then(setOptions)
+      .catch(() => {
+        // A missing filter list only empties the dropdowns; the page itself
+        // stays usable, and load() surfaces real data errors.
+      })
+    return () => controller.abort()
+  }, [])
 
   useEffect(() => {
     // Wait for /api/auth/me so the first load already knows whether cost


### PR DESCRIPTION
## What

The analytics command center ran a full round of requests **twice** when the page opened, one request round-trip apart, each measured over a slightly different period.

`load()` fetched the run filter options inside its `Promise.all` and wrote them to state. Because `options` was also in `load`'s `useCallback` dependency array, that write changed `load`'s own identity, re-firing the effect that calls it and issuing a second full round.

The filter options are static for the session, so they are now fetched once in their own mount effect, and `load()` no longer depends on them.

## Correcting the original report

This was reported as a self-perpetuating refetch loop polling roughly every 6s. Measurement shows it is **bounded, not infinite**: the second round reuses the cached options object, `setOptions` hits React's bailout, and the sequence stops. The reported "12 requests in a 12-second window" is consistent with the duplicated startup round at a ~6s hub round-trip, observed within the first 12s after load.

The `from`/`to` drift in the report is real and explained: the default period is clock-derived inside `load()`, so each round reports a range shifted by exactly one round-trip.

## Root cause, measured not inferred

An instrumented build logged identity changes for every captured value per render, plus a mount counter:

```
mounts: 1          // not remounting
renders: 6         // then quiescent
t=156    <first render>      // capabilitiesLoading true, no load
t=4215   capabilitiesLoading // capabilities resolve -> load #1
t=8416   options, load       // load #1 completes -> setOptions -> load identity flips -> load #2
t=8781   (nothing)           // load #2 reuses options -> bailout -> quiescent
```

`params`, `paramsKey` and `filters` **never** changed identity. An earlier hypothesis blamed `useSearchParams()` instability; that was wrong. Next 16 memoizes the `ReadonlyURLSearchParams` on its context value (`next/dist/client/components/navigation.js:96`), and a local `setState` does not re-render the router provider. The `filters` memo is left untouched as a result.

## Verification

Against the **production static export** (`npx next build`, served with SPA fallback and `/api` proxied to a seeded hub), not the dev server. Idle page, untouched, with 4s of emulated hub latency so the round-trip-period effect is visible at all — a millisecond-latency local hub hides it.

| | before | after |
|---|---|---|
| startup rounds | 2, at t=4.4s and t=8.7s (ranges 4.35s apart) | 1, at t=4.3s |
| steady state | — | 1 refresh at t=61.2s (the 60s interval) |
| `filter-options` | 1 | 1 |

Session **with** `costs:read`: one startup round of all 8 requests, Cost tab visible.
Session **without** `costs:read`: one startup round of 4 requests, Cost tab hidden, **zero** requests to `/api/analytics/costs` or `/api/analytics/cost-drivers`.

## Constraints honoured

- No debounce, no widened interval — the dependency cycle itself is gone.
- The clock read stays inside `load()`, so no clock-derived value is produced during render and the prerender does not suspend under `cacheComponents`.
- `costs:read` gating untouched.

No screenshots: the rendered UI is unchanged, the fix is purely in request behaviour.

## Base

Stacked on `feature/phase1-runs-analytics-cost-gate` (#580), which is where this code lives — it is not on `main`. Retarget to `main` after #580 merges if preferred.

## Note

`web/` has no frontend test framework, so this is not locked in by a regression test; the guarantee rests on the before/after measurement above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)