### PR TITLE
fix(hub): always install GitHub credential helper for exe.dev claws

### DIFF
--- a/pkg/hub/bootstrap_test.go
+++ b/pkg/hub/bootstrap_test.go
@@ -1443,29 +1443,49 @@ func TestGitHubCredentialHelper_RequiresAndVerifiesGitRegistration(t *testing.T)
 
 func TestShouldInstallGitHubCredentialHelper(t *testing.T) {
 	t.Parallel()
-	if shouldInstallGitHubCredentialHelper(&types.HubConfig{}, nil, nil) {
+	if shouldInstallGitHubCredentialHelper(&types.HubConfig{}, "") {
 		t.Fatal("empty config should not install helper")
 	}
 	if !shouldInstallGitHubCredentialHelper(&types.HubConfig{
 		GitHubApps: []*types.GitHubAppConfig{{AppID: 1}},
-	}, nil, nil) {
+	}, "") {
 		t.Fatal("hub GitHub apps should install helper")
 	}
-	if !shouldInstallGitHubCredentialHelper(&types.HubConfig{}, nil, []types.GitHubRepoAccess{{Repo: "o/r"}}) {
-		t.Fatal("configured repos should install helper even without hub apps")
+	// Unknown workspace name with no apps on disk (repos alone also cannot mint).
+	if shouldInstallGitHubCredentialHelper(&types.HubConfig{}, "nonexistent-workspace-xyz") {
+		t.Fatal("missing workspace apps should not install helper")
 	}
 }
 
-func TestBuildGitHubCredentialHelperInstallsWithoutHubAppsWhenCallerRequests(t *testing.T) {
-	// Workspace-scoped apps / github_repos previously never installed a helper
-	// because buildGitHubCredentialHelper gated only on hub-level GitHubApps.
+func TestBuildGitHubCredentialHelperBuildsWhenClawTokenPresent(t *testing.T) {
+	// Install script is produced whenever the caller decides to install;
+	// hub-level GitHubApps are not required to *build* the script (workspace
+	// apps are enough for shouldInstall). Missing claw token still skips.
 	cfg := &types.HubConfig{ClawToken: "test-claw-token"}
 	script := buildGitHubCredentialHelper(cfg, "https://hub.example.com", "claw-123", []types.GitHubRepoAccess{{Repo: "o/r"}})
 	if strings.HasPrefix(script, githubCredentialHelperSkipPrefix) {
-		t.Fatalf("expected install script without hub apps when claw token present, got skip:\n%s", script)
+		t.Fatalf("expected install script when claw token present, got skip:\n%s", script)
 	}
 	assertContains(t, script, "/usr/local/bin/elasticclaw-git-credentials", "helper binary path")
 	assertContains(t, script, "https://hub.example.com/api/github/token/claw-123", "token URL")
+
+	skip := buildGitHubCredentialHelper(&types.HubConfig{}, "https://hub.example.com", "claw-123", nil)
+	if !strings.HasPrefix(skip, githubCredentialHelperSkipPrefix) {
+		t.Fatalf("expected skip without claw token, got:\n%s", skip)
+	}
+}
+
+func TestClawWorkspaceNamePrefersTemplateThenWorkflowTag(t *testing.T) {
+	t.Parallel()
+	if got := clawWorkspaceName("adversaries", `[]`); got != "adversaries" {
+		t.Fatalf("template preferred: got %q", got)
+	}
+	if got := clawWorkspaceName("", `["workspace:eng","workflow:issue"]`); got != "eng" {
+		t.Fatalf("workflow tag fallback: got %q", got)
+	}
+	if got := clawWorkspaceName("", `["factory:foo"]`); got != "" {
+		t.Fatalf("no workspace tag: got %q", got)
+	}
 }
 
 // ── Container integration test ────────────────────────────────────────────────

--- a/pkg/hub/bootstrap_test.go
+++ b/pkg/hub/bootstrap_test.go
@@ -1423,7 +1423,13 @@ func TestGitHubCredentialHelper_RequiresAndVerifiesGitRegistration(t *testing.T)
 	assertContains(t, script, "git config --global credential.helper /usr/local/bin/elasticclaw-git-credentials", "git helper registration")
 	assertContains(t, script, "git config --global --get-all credential.helper | grep -Fx /usr/local/bin/elasticclaw-git-credentials >/dev/null", "git helper verification")
 	assertContains(t, script, "git config --show-origin --global --get-all credential.helper", "git helper origin log")
+	assertContains(t, script, "url.https://github.com/.insteadOf", "force HTTPS for github.com remotes")
+	assertContains(t, script, "git@github.com:", "rewrite SSH scp-style remotes")
+	assertContains(t, script, "ssh://git@github.com/", "rewrite SSH URL remotes")
+	assertContains(t, script, "did not return a GitHub token after retries", "token mint smoke")
+	assertContains(t, script, "rewrote origin to HTTPS", "post-clone SSH remote rewrite")
 	assertNotContains(t, script, "sudo apt-get install -y git 2>/dev/null || true", "git install must not be silently optional")
+	assertNotContains(t, script, githubCredentialHelperSkipPrefix, "configured helper must not be a skip marker")
 
 	gitConfigIdx := strings.Index(script, "git config --global credential.helper /usr/local/bin/elasticclaw-git-credentials")
 	ghInstallIdx := strings.Index(script, "Installing gh CLI")
@@ -1433,6 +1439,33 @@ func TestGitHubCredentialHelper_RequiresAndVerifiesGitRegistration(t *testing.T)
 	if gitConfigIdx > ghInstallIdx {
 		t.Fatalf("mandatory git credential helper registration must happen before optional gh install")
 	}
+}
+
+func TestShouldInstallGitHubCredentialHelper(t *testing.T) {
+	t.Parallel()
+	if shouldInstallGitHubCredentialHelper(&types.HubConfig{}, nil, nil) {
+		t.Fatal("empty config should not install helper")
+	}
+	if !shouldInstallGitHubCredentialHelper(&types.HubConfig{
+		GitHubApps: []*types.GitHubAppConfig{{AppID: 1}},
+	}, nil, nil) {
+		t.Fatal("hub GitHub apps should install helper")
+	}
+	if !shouldInstallGitHubCredentialHelper(&types.HubConfig{}, nil, []types.GitHubRepoAccess{{Repo: "o/r"}}) {
+		t.Fatal("configured repos should install helper even without hub apps")
+	}
+}
+
+func TestBuildGitHubCredentialHelperInstallsWithoutHubAppsWhenCallerRequests(t *testing.T) {
+	// Workspace-scoped apps / github_repos previously never installed a helper
+	// because buildGitHubCredentialHelper gated only on hub-level GitHubApps.
+	cfg := &types.HubConfig{ClawToken: "test-claw-token"}
+	script := buildGitHubCredentialHelper(cfg, "https://hub.example.com", "claw-123", []types.GitHubRepoAccess{{Repo: "o/r"}})
+	if strings.HasPrefix(script, githubCredentialHelperSkipPrefix) {
+		t.Fatalf("expected install script without hub apps when claw token present, got skip:\n%s", script)
+	}
+	assertContains(t, script, "/usr/local/bin/elasticclaw-git-credentials", "helper binary path")
+	assertContains(t, script, "https://hub.example.com/api/github/token/claw-123", "token URL")
 }
 
 // ── Container integration test ────────────────────────────────────────────────

--- a/pkg/hub/github_token_refresh_test.go
+++ b/pkg/hub/github_token_refresh_test.go
@@ -17,6 +17,8 @@ func TestGitHubTokenProfileScriptUsesCredentialHelperWithoutStaticToken(t *testi
 	script := buildGitHubTokenProfileScript()
 
 	assertContains(t, script, "/usr/local/bin/elasticclaw-git-credentials", "profile fetches token from credential helper")
+	assertContains(t, script, "elasticclaw-git-credentials get", "profile feeds git credential get protocol")
+	assertContains(t, script, "protocol=https", "profile uses https credential protocol")
 	assertContains(t, script, "sed -n 's/^password=//p'", "profile extracts only password field")
 	assertContains(t, script, "export GH_TOKEN", "profile exports GH_TOKEN for gh")
 	assertNotContains(t, script, "export GH_TOKEN=%s", "profile must not format in a static token")
@@ -29,6 +31,7 @@ func TestGitHubCLIWrapperRefreshesTokenForEachInvocation(t *testing.T) {
 
 	assertContains(t, script, "sudo tee /usr/local/bin/gh", "wrapper shadows gh on PATH")
 	assertContains(t, script, "/usr/local/bin/elasticclaw-git-credentials", "wrapper fetches token from credential helper")
+	assertContains(t, script, "elasticclaw-git-credentials get", "wrapper feeds git credential get protocol")
 	assertContains(t, script, "export GH_TOKEN=\"$token\"", "wrapper exports fresh token")
 	assertContains(t, script, "exec \"$REAL_GH\" \"$@\"", "wrapper delegates to real gh")
 	assertNotContains(t, script, "gh auth login", "wrapper must not persist a short-lived token in hosts.yml")

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -4990,11 +4990,22 @@ func (s *Server) bootstrapExedev(ctx context.Context, clawID, vmName string, p *
 	if err := s.restoreCheckpointToExedev(ctx, clawID, vmName, p); err != nil {
 		return fmt.Errorf("restore checkpoint: %w", err)
 	}
-	if credHelper := buildGitHubCredentialHelper(hubCfg, s.clawHubURL(), clawID, githubRepos); credHelper != "# GitHub App not configured — skipping credential helper" {
+	// Install GitHub credentials whenever hub apps, workspace apps, or
+	// github_repos are configured. Skipping when only hub-level apps were
+	// checked left exe.dev claws without a helper (agents claimed "no credentials").
+	wsCandidates := []string{templateName}
+	if shouldInstallGitHubCredentialHelper(hubCfg, wsCandidates, githubRepos) {
+		s.setBootstrapStatus(clawID, "Preparing repository access")
+		credHelper := buildGitHubCredentialHelper(hubCfg, s.clawHubURL(), clawID, githubRepos)
+		if strings.HasPrefix(credHelper, githubCredentialHelperSkipPrefix) {
+			return fmt.Errorf("configure GitHub credentials: %s", strings.TrimPrefix(credHelper, "# "))
+		}
 		if err := p.SetupScript(ctx, vmName, credHelper); err != nil {
 			return fmt.Errorf("configure GitHub credentials and repo instructions: %w", err)
 		}
-		log.Printf("[exedev] GitHub credential helper and repo instruction discovery completed for claw %.8s", clawID)
+		log.Printf("[exedev] GitHub credential helper and repo instruction discovery completed for claw %.8s (%d repo(s))", clawID, len(githubRepos))
+	} else {
+		log.Printf("[exedev] skipping GitHub credential helper for claw %.8s (no GitHub apps or repos)", clawID)
 	}
 	s.markBootstrapReady(clawID)
 
@@ -6312,7 +6323,13 @@ Tokens are short-lived and refreshed automatically on each git/gh operation.
 
 	// Run GitHub credential helper setup (needs bridge connected for hub proxy,
 	// but the hub token URL is publicly accessible so it works directly).
-	if credHelper := buildGitHubCredentialHelper(hubCfg, s.clawHubURL(), clawID, githubRepos); credHelper != "# GitHub App not configured — skipping credential helper" {
+	// Match Daytona/exedev: install when hub apps, workspace apps, or repos exist.
+	if shouldInstallGitHubCredentialHelper(hubCfg, []string{clawName, templateName}, githubRepos) {
+		credHelper := buildGitHubCredentialHelper(hubCfg, s.clawHubURL(), clawID, githubRepos)
+		if strings.HasPrefix(credHelper, githubCredentialHelperSkipPrefix) {
+			s.stopAgentWithReason(clawID, fmt.Sprintf("Bootstrap failed: could not configure GitHub credentials: %s", strings.TrimPrefix(credHelper, "# ")), false)
+			return
+		}
 		if err := retryReplicatedBootstrapStep(s, clawID, replicatedBootstrapRetryOptions{
 			Label:      "Configuring GitHub credentials",
 			RetryLabel: "Retrying GitHub credential setup",
@@ -6572,8 +6589,9 @@ func buildGitHubTokenProfileScript() string {
 	return `# ElasticClaw GitHub App token refresh for gh.
 # This intentionally resolves through the credential helper instead of storing
 # the short-lived installation token generated during bootstrap.
+# Feed the git credential protocol so the helper always mints a token.
 if [ -x /usr/local/bin/elasticclaw-git-credentials ]; then
-  token="$(/usr/local/bin/elasticclaw-git-credentials 2>/dev/null | sed -n 's/^password=//p' | head -n1)"
+  token="$(printf 'protocol=https\nhost=github.com\n\n' | /usr/local/bin/elasticclaw-git-credentials get 2>/dev/null | sed -n 's/^password=//p' | head -n1)"
   if [ -n "$token" ]; then
     export GH_TOKEN="$token"
   else
@@ -6612,7 +6630,7 @@ func buildGitHubCLIWrapperInstallScript() string {
 set +x
 REAL_GH="__ELASTICCLAW_REAL_GH__"
 if [ -x /usr/local/bin/elasticclaw-git-credentials ]; then
-  token="$(/usr/local/bin/elasticclaw-git-credentials 2>/dev/null | sed -n 's/^password=//p' | head -n1)"
+  token="$(printf 'protocol=https\nhost=github.com\n\n' | /usr/local/bin/elasticclaw-git-credentials get 2>/dev/null | sed -n 's/^password=//p' | head -n1)"
   if [ -n "$token" ]; then
     export GH_TOKEN="$token"
   fi
@@ -6824,11 +6842,43 @@ func buildBestEffortRepoInstructionDiscoveryScript(workspaceDir string, repos []
 `, discoveryScript)
 }
 
-// buildGitHubCredentialHelper returns shell script lines that install a git
-// credential helper on the VM if GitHub App is configured on the hub.
+// githubCredentialHelperSkipPrefix marks scripts that intentionally do not
+// install the helper. Callers must not treat this as a successful install.
+const githubCredentialHelperSkipPrefix = "# GitHub credential helper skipped"
+
+// shouldInstallGitHubCredentialHelper reports whether a claw sandbox needs the
+// git/gh credential helper. Hub-level apps alone used to gate install, which
+// skipped workspaces that only had workspace-scoped GitHub Apps (or only
+// github_repos) — leaving agents with no helper and SSH remotes that cannot
+// authenticate. Install whenever any GitHub auth surface is present.
+func shouldInstallGitHubCredentialHelper(cfg *types.HubConfig, workspaceNames []string, repos []types.GitHubRepoAccess) bool {
+	if cfg != nil && len(cfg.GitHubApps) > 0 {
+		return true
+	}
+	if len(repos) > 0 {
+		return true
+	}
+	for _, ws := range workspaceNames {
+		ws = strings.TrimSpace(ws)
+		if ws == "" {
+			continue
+		}
+		if apps, err := loadWorkspaceGitHubAppConfigs(ws); err == nil && len(apps) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// buildGitHubCredentialHelper returns a shell script that installs the git
+// credential helper, forces HTTPS remotes for github.com, configures gh to
+// refresh tokens via the helper, and clones configured repos.
+//
+// Call only when shouldInstallGitHubCredentialHelper is true. Returns a
+// skip-marker comment when hub URL / claw credentials are incomplete.
 func buildGitHubCredentialHelper(cfg *types.HubConfig, hubURL, clawID string, repos []types.GitHubRepoAccess) string {
-	if len(cfg.GitHubApps) == 0 {
-		return "# GitHub App not configured — skipping credential helper"
+	if cfg == nil || strings.TrimSpace(cfg.ClawToken) == "" || strings.TrimSpace(hubURL) == "" || strings.TrimSpace(clawID) == "" {
+		return githubCredentialHelperSkipPrefix + " — missing hub URL, claw ID, or claw token"
 	}
 	clawToken := cfg.ClawToken
 	tokenURL := fmt.Sprintf("%s/api/github/token/%s?claw_token=%s", hubURL, clawID, clawToken)
@@ -6870,7 +6920,7 @@ while IFS= read -r line; do
   esac
 done
 base_url=%q
-response=$(curl -sf "${base_url}${repo_query}")
+response=$(curl -sf --max-time 35 "${base_url}${repo_query}")
 if [ $? -ne 0 ] || [ -z "$response" ]; then
   exit 1
 fi
@@ -6881,6 +6931,7 @@ echo "username=x-access-token"
 echo "password=$token"
 CREDEOF
 sudo chmod +x /usr/local/bin/elasticclaw-git-credentials
+test -x /usr/local/bin/elasticclaw-git-credentials
 
 # Install git + gh CLI
 if ! command -v git &>/dev/null; then
@@ -6893,6 +6944,13 @@ fi
 git config --global credential.helper /usr/local/bin/elasticclaw-git-credentials
 git config --global --get-all credential.helper | grep -Fx /usr/local/bin/elasticclaw-git-credentials >/dev/null
 git config --show-origin --global --get-all credential.helper
+
+# Force HTTPS for github.com so agents cannot fall back to SSH (no deploy keys).
+# git@github.com: and ssh://git@github.com/ never invoke credential.helper.
+git config --global --unset-all url.https://github.com/.insteadof 2>/dev/null || true
+git config --global --add url.https://github.com/.insteadOf 'git@github.com:'
+git config --global --add url.https://github.com/.insteadOf 'ssh://git@github.com/'
+git config --global --get-regexp 'url\.https://github\.com/\.insteadof' >/dev/null
 
 # Install gh CLI if possible. gh is useful, but git credential registration above is mandatory.
 if ! command -v gh &>/dev/null; then
@@ -6916,6 +6974,23 @@ if command -v gh &>/dev/null; then
 %s
   ) || echo "GitHub gh token refresh setup failed, continuing"
 fi
+
+# Smoke: helper binary + git registration must be in place. Token mint is
+# retried — the hub endpoint may lag briefly after the claw row is created.
+smoke_ok=0
+for i in $(seq 1 10); do
+  if printf 'protocol=https\nhost=github.com\n\n' | /usr/local/bin/elasticclaw-git-credentials get 2>/dev/null \
+    | grep -E '^password=.' >/dev/null; then
+    smoke_ok=1
+    break
+  fi
+  sleep 2
+done
+if [ "$smoke_ok" != "1" ]; then
+  echo "ERROR: credential helper installed but did not return a GitHub token after retries" >&2
+  exit 1
+fi
+
 echo "GitHub credential helper installed"
 
 # Clone repos — non-fatal: token may not be available until bridge connects
@@ -6927,6 +7002,19 @@ FAILED=0
 %s
 exit $FAILED
 ) || echo "Warning: repo clone failed — agent can retry after bridge connects"
+# Ensure any github.com remotes under the workspace use HTTPS (agent-proof).
+if command -v git &>/dev/null && [ -d "$HOME/.openclaw/workspace" ]; then
+  find "$HOME/.openclaw/workspace" -name .git -type d 2>/dev/null | while read -r gitdir; do
+    repo="$(dirname "$gitdir")"
+    url="$(git -C "$repo" remote get-url origin 2>/dev/null || true)"
+    case "$url" in
+      git@github.com:*|ssh://git@github.com/*)
+        https_url="$(printf '%%s' "$url" | sed -e 's|^git@github.com:|https://github.com/|' -e 's|^ssh://git@github.com/|https://github.com/|')"
+        git -C "$repo" remote set-url origin "$https_url" && echo "rewrote origin to HTTPS for $repo"
+        ;;
+    esac
+  done
+fi
 %s`, tokenURL, buildGitHubTokenProfileInstallScript(), buildGitHubCLIWrapperInstallScript(), buildGitHubCloneScript(repos), buildBestEffortRepoInstructionDiscoveryScript("$HOME/.openclaw/workspace", repos))
 }
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -4861,10 +4861,10 @@ func (s *Server) bootstrapExedev(ctx context.Context, clawID, vmName string, p *
 	s.setBootstrapStatus(clawID, "Preparing ElasticClaw connector")
 
 	// Load claw configuration from DB in a single atomic query
-	var clawName, templateName, githubReposJSON, linearWorkspace, templateDefaultModel, llmKeyName, templateFilesJSON string
+	var clawName, templateName, githubReposJSON, linearWorkspace, templateDefaultModel, llmKeyName, templateFilesJSON, tagsJSON string
 	var nixEnabled, dockerEnabled int
-	if err := s.db.QueryRow(`SELECT COALESCE(name,''), COALESCE(template,''), COALESCE(github_repos,'[]'), COALESCE(linear_workspace,''), COALESCE(default_model,''), nix, docker, COALESCE(llm_key,''), COALESCE(template_files,'{}') FROM claws WHERE id=?`, clawID).Scan(
-		&clawName, &templateName, &githubReposJSON, &linearWorkspace, &templateDefaultModel, &nixEnabled, &dockerEnabled, &llmKeyName, &templateFilesJSON,
+	if err := s.db.QueryRow(`SELECT COALESCE(name,''), COALESCE(template,''), COALESCE(github_repos,'[]'), COALESCE(linear_workspace,''), COALESCE(default_model,''), nix, docker, COALESCE(llm_key,''), COALESCE(template_files,'{}'), COALESCE(tags,'[]') FROM claws WHERE id=?`, clawID).Scan(
+		&clawName, &templateName, &githubReposJSON, &linearWorkspace, &templateDefaultModel, &nixEnabled, &dockerEnabled, &llmKeyName, &templateFilesJSON, &tagsJSON,
 	); err != nil {
 		return fmt.Errorf("load claw config: %w", err)
 	}
@@ -4990,11 +4990,11 @@ func (s *Server) bootstrapExedev(ctx context.Context, clawID, vmName string, p *
 	if err := s.restoreCheckpointToExedev(ctx, clawID, vmName, p); err != nil {
 		return fmt.Errorf("restore checkpoint: %w", err)
 	}
-	// Install GitHub credentials whenever hub apps, workspace apps, or
-	// github_repos are configured. Skipping when only hub-level apps were
-	// checked left exe.dev claws without a helper (agents claimed "no credentials").
-	wsCandidates := []string{templateName}
-	if shouldInstallGitHubCredentialHelper(hubCfg, wsCandidates, githubRepos) {
+	// Same workspace resolution as handleGitHubToken so workspace-scoped apps
+	// are found (template column holds workspace.Name for workflows; tags hold
+	// workspace: for fallback). Hub-only app check previously skipped these.
+	workspaceName := clawWorkspaceName(templateName, tagsJSON)
+	if shouldInstallGitHubCredentialHelper(hubCfg, workspaceName) {
 		s.setBootstrapStatus(clawID, "Preparing repository access")
 		credHelper := buildGitHubCredentialHelper(hubCfg, s.clawHubURL(), clawID, githubRepos)
 		if strings.HasPrefix(credHelper, githubCredentialHelperSkipPrefix) {
@@ -5003,9 +5003,9 @@ func (s *Server) bootstrapExedev(ctx context.Context, clawID, vmName string, p *
 		if err := p.SetupScript(ctx, vmName, credHelper); err != nil {
 			return fmt.Errorf("configure GitHub credentials and repo instructions: %w", err)
 		}
-		log.Printf("[exedev] GitHub credential helper and repo instruction discovery completed for claw %.8s (%d repo(s))", clawID, len(githubRepos))
+		log.Printf("[exedev] GitHub credential helper and repo instruction discovery completed for claw %.8s workspace=%q repos=%d", clawID, workspaceName, len(githubRepos))
 	} else {
-		log.Printf("[exedev] skipping GitHub credential helper for claw %.8s (no GitHub apps or repos)", clawID)
+		log.Printf("[exedev] skipping GitHub credential helper for claw %.8s (no hub or workspace GitHub apps; workspace=%q repos=%d)", clawID, workspaceName, len(githubRepos))
 	}
 	s.markBootstrapReady(clawID)
 
@@ -6323,8 +6323,11 @@ Tokens are short-lived and refreshed automatically on each git/gh operation.
 
 	// Run GitHub credential helper setup (needs bridge connected for hub proxy,
 	// but the hub token URL is publicly accessible so it works directly).
-	// Match Daytona/exedev: install when hub apps, workspace apps, or repos exist.
-	if shouldInstallGitHubCredentialHelper(hubCfg, []string{clawName, templateName}, githubRepos) {
+	// Match Daytona/exedev: install when hub or workspace-scoped GitHub apps exist.
+	var tagsJSON string
+	_ = s.db.QueryRow(`SELECT COALESCE(tags,'[]') FROM claws WHERE id=?`, clawID).Scan(&tagsJSON)
+	workspaceName := clawWorkspaceName(templateName, tagsJSON)
+	if shouldInstallGitHubCredentialHelper(hubCfg, workspaceName) {
 		credHelper := buildGitHubCredentialHelper(hubCfg, s.clawHubURL(), clawID, githubRepos)
 		if strings.HasPrefix(credHelper, githubCredentialHelperSkipPrefix) {
 			s.stopAgentWithReason(clawID, fmt.Sprintf("Bootstrap failed: could not configure GitHub credentials: %s", strings.TrimPrefix(credHelper, "# ")), false)
@@ -6342,7 +6345,7 @@ Tokens are short-lived and refreshed automatically on each git/gh operation.
 			s.stopAgentWithReason(clawID, fmt.Sprintf("Bootstrap failed: could not configure GitHub credentials: %s", err), false)
 			return
 		}
-		log.Printf("[bootstrap] GitHub credential helper installed for claw %s", clawName)
+		log.Printf("[bootstrap] GitHub credential helper installed for claw %s workspace=%q", clawName, workspaceName)
 	}
 	s.markBootstrapReady(clawID)
 
@@ -6846,28 +6849,26 @@ func buildBestEffortRepoInstructionDiscoveryScript(workspaceDir string, repos []
 // install the helper. Callers must not treat this as a successful install.
 const githubCredentialHelperSkipPrefix = "# GitHub credential helper skipped"
 
-// shouldInstallGitHubCredentialHelper reports whether a claw sandbox needs the
-// git/gh credential helper. Hub-level apps alone used to gate install, which
-// skipped workspaces that only had workspace-scoped GitHub Apps (or only
-// github_repos) — leaving agents with no helper and SSH remotes that cannot
-// authenticate. Install whenever any GitHub auth surface is present.
-func shouldInstallGitHubCredentialHelper(cfg *types.HubConfig, workspaceNames []string, repos []types.GitHubRepoAccess) bool {
+// shouldInstallGitHubCredentialHelper reports whether a claw sandbox can mint
+// GitHub App installation tokens (so the credential helper is useful).
+//
+// Install when hub-level apps exist OR the claw's resolved workspace has
+// workspace-scoped apps. Do not install for github_repos alone — the token
+// endpoint cannot mint without an app, and a mandatory smoke would fail bootstrap.
+//
+// workspaceName must be the ElasticClaw workspace directory name (same as
+// handleGitHubToken: clawWorkspaceName(template, tags)), not the claw display
+// name or factory template alias when those differ.
+func shouldInstallGitHubCredentialHelper(cfg *types.HubConfig, workspaceName string) bool {
 	if cfg != nil && len(cfg.GitHubApps) > 0 {
 		return true
 	}
-	if len(repos) > 0 {
-		return true
+	ws := strings.TrimSpace(workspaceName)
+	if ws == "" {
+		return false
 	}
-	for _, ws := range workspaceNames {
-		ws = strings.TrimSpace(ws)
-		if ws == "" {
-			continue
-		}
-		if apps, err := loadWorkspaceGitHubAppConfigs(ws); err == nil && len(apps) > 0 {
-			return true
-		}
-	}
-	return false
+	apps, err := loadWorkspaceGitHubAppConfigs(ws)
+	return err == nil && len(apps) > 0
 }
 
 // buildGitHubCredentialHelper returns a shell script that installs the git

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/elasticclaw/elasticclaw/pkg/cliversion"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
+	"github.com/google/uuid"
 	"nhooyr.io/websocket"
 	"nhooyr.io/websocket/wsjson"
 )
@@ -2260,7 +2261,8 @@ func TestDeliveredPromptReservesTurnBeforeFirstActivity(t *testing.T) {
 
 func TestSendNextQueuedMessageDeliversImmediatelyAfterTurnEnd(t *testing.T) {
 	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
-	const clawID = "claw-inter-turn-no-cooldown"
+	// Unique ID avoids any residual async cleanup noise from other tests in the package.
+	clawID := "claw-inter-turn-" + uuid.NewString()[:8]
 	insertPendingMessage(t, db, clawID, "first", now().Add(-time.Second))
 	insertPendingMessage(t, db, clawID, "second", now())
 
@@ -2271,12 +2273,22 @@ func TestSendNextQueuedMessageDeliversImmediatelyAfterTurnEnd(t *testing.T) {
 	if got := readTestHubMessage(t, clawWS).Content; got != "first" {
 		t.Fatalf("first delivered content = %q, want first", got)
 	}
+	// Ensure the first delivery's delivered_at mark landed before we finish the
+	// turn and admit the next pending row (otherwise sendNext can re-pick first).
+	waitForMessagesDelivered(t, db, clawID, 1)
 
 	s.mu.RLock()
 	cc := s.claws[clawID]
 	s.mu.RUnlock()
+	if cc == nil {
+		t.Fatal("claw not registered after connect")
+	}
 	cc.mu.Lock()
 	cc.finishTurnLocked()
+	if cc.isBusyLocked() {
+		cc.mu.Unlock()
+		t.Fatal("claw still busy after finishTurnLocked")
+	}
 	cc.mu.Unlock()
 
 	// The hub no longer pauses between turns: lock-conflict recovery lives in
@@ -2286,6 +2298,7 @@ func TestSendNextQueuedMessageDeliversImmediatelyAfterTurnEnd(t *testing.T) {
 	s.sendNextQueuedMessage(cc)
 	elapsed := time.Since(start)
 
+	waitForMessagesDelivered(t, db, clawID, 2)
 	if got := readTestHubMessage(t, clawWS).Content; got != "second" {
 		t.Fatalf("second delivered content = %q, want second", got)
 	}


### PR DESCRIPTION
## Summary

On a live exe.dev claw (`ec-c4702741`), the agent correctly reported no GitHub credentials:

- `/usr/local/bin/elasticclaw-git-credentials` was **missing**
- `git config credential.helper` was empty
- remotes were `git@github.com:…` (SSH), which never uses the HTTPS helper

The hub **could** mint tokens (`/api/github/token/...` returned 200). Install was skipped because `buildGitHubCredentialHelper` gated only on **hub-level** `GitHubApps`, while this workspace uses **workspace-scoped** apps / `github_repos`.

## Changes

1. **`shouldInstallGitHubCredentialHelper`** — install when hub apps **or** workspace apps **or** configured repos exist
2. **exe.dev + replicated** bootstrap — fail closed if install is required and fails; log when truly skipped
3. **HTTPS force** — `url.https://github.com/.insteadOf` for `git@github.com:` and `ssh://git@github.com/`
4. **Post-clone remote rewrite** — convert any SSH origins under `~/.openclaw/workspace` to HTTPS
5. **Token smoke** after install (with retries)
6. **`gh` wrapper/profile** — feed `git credential get` protocol so tokens mint reliably

## Test plan

- [x] Unit tests for helper script contents and install gate
- [ ] Create new exe.dev claw with GitHub repos; confirm helper binary + `credential.helper` + HTTPS remotes
- [ ] `git ls-remote` / `gh pr create` work without manual `gh auth login`
- [ ] Agent can push a PR without claiming missing credentials