### PR TITLE
fix(web): keep durable messages stable during stream and refresh

### DIFF
--- a/web/components/conversation-view.tsx
+++ b/web/components/conversation-view.tsx
@@ -37,7 +37,7 @@ import dynamic from "next/dynamic"
 import { useBranding } from "@/hooks/use-branding"
 import { BootstrapProgress } from "@/components/bootstrap-progress"
 import { ClawTitle } from "@/components/claw-title"
-import { isTerminalAssistantMessage } from "@/lib/messages"
+import { isTerminalAssistantMessage, windowMessagesByDurableCount } from "@/lib/messages"
 import { DependencyDowntimeBanner } from "@/components/dependency-downtime-banner"
 import type { TypewriterState } from "@/hooks/use-typewriter"
 
@@ -65,7 +65,8 @@ interface ConversationViewProps {
 }
 
 const FOLLOW_LATEST_THRESHOLD_PX = 24
-const BOARD_CARD_MESSAGE_WINDOW = 50
+/** Last N durable conversation turns on board cards (activities do not count). */
+const BOARD_CARD_DURABLE_MESSAGE_WINDOW = 50
 const EMPTY_MESSAGES: Message[] = []
 const noopClawAction = (_clawId: string) => {}
 const noopClawMessageAction = (_clawId: string, _content: string) => {}
@@ -449,7 +450,12 @@ const ClawBoardCard = memo(function ClawBoardCard({
   const cardFollowingLatest = useRef(true)
   const [isCardFollowingLatest, setIsCardFollowingLatest] = useState(true)
   const [expandedActivityGroups, setExpandedActivityGroups] = useState<Record<string, boolean>>({})
-  const visibleMessages = useMemo(() => messages.slice(-BOARD_CARD_MESSAGE_WINDOW), [messages])
+  // Window by durable turns only — a tool-activity flood must not age out
+  // earlier user/claw messages from the card (refresh would still show them).
+  const visibleMessages = useMemo(
+    () => windowMessagesByDurableCount(messages, BOARD_CARD_DURABLE_MESSAGE_WINDOW),
+    [messages]
+  )
   const conversationItems = useMemo(() => compactActivityRuns(visibleMessages), [visibleMessages])
   const latestActivity = useMemo(() => latestActivityMessage(visibleMessages), [visibleMessages])
   const activityNow = useActivityNow(Boolean(latestActivity))

--- a/web/hooks/use-hub.ts
+++ b/web/hooks/use-hub.ts
@@ -342,18 +342,29 @@ export function useHub(selectedClawId: string | null): HubState {
         const inflight = existing.filter((m) => m.id.startsWith('opt-') &&
           !msgs.some((r) => r.content === m.content && r.role === m.role))
         // Keep in-flight tool activity + stream fragments so selecting a claw
-        // mid-turn does not blank the UI. Drop live-segments once the durable
-        // final reply is already present in the timeline (refresh parity).
-        const liveTransient = existing.filter((m) => {
-          if (!isTransientMessage(m)) return false
-          if (!m.id.startsWith("live-segment-") && !m.id.startsWith("live-")) return true
-          const segTime = m.timestamp.getTime()
-          const durableFinalPresent = msgs.some(
+        // mid-turn does not blank the UI. Drop live text fragments only when the
+        // timeline already has a durable assistant/hub reply strictly newer than
+        // the latest fragment (the completed final). A nearby *previous* turn's
+        // message must not count — that used to drop in-flight text incorrectly.
+        let latestLiveTextAt = 0
+        for (const m of existing) {
+          if (!m.id.startsWith("live-segment-") && !m.id.startsWith("live-")) continue
+          const t = m.timestamp.getTime()
+          if (t > latestLiveTextAt) latestLiveTextAt = t
+        }
+        const durableFinalAfterLiveText =
+          latestLiveTextAt > 0 &&
+          msgs.some(
             (api) =>
               (api.role === "claw" || api.role === "hub") &&
-              api.timestamp.getTime() >= segTime - 2_000
+              api.timestamp.getTime() > latestLiveTextAt
           )
-          return !durableFinalPresent
+        const liveTransient = existing.filter((m) => {
+          if (!isTransientMessage(m)) return false
+          if (m.id.startsWith("live-segment-") || m.id.startsWith("live-")) {
+            return !durableFinalAfterLiveText
+          }
+          return true
         })
         const merged = pruneOldestLiveActivities(
           [...msgs, ...cachedOnly, ...inflight, ...liveTransient],

--- a/web/hooks/use-hub.ts
+++ b/web/hooks/use-hub.ts
@@ -341,29 +341,16 @@ export function useHub(selectedClawId: string | null): HubState {
         const cachedOnly = existingNonOpt.filter((m) => !apiIds.has(m.id))
         const inflight = existing.filter((m) => m.id.startsWith('opt-') &&
           !msgs.some((r) => r.content === m.content && r.role === m.role))
-        // Keep in-flight tool activity + stream fragments so selecting a claw
-        // mid-turn does not blank the UI. Drop live text fragments only when the
-        // timeline already has a durable assistant/hub reply strictly newer than
-        // the latest fragment (the completed final). A nearby *previous* turn's
-        // message must not count — that used to drop in-flight text incorrectly.
-        let latestLiveTextAt = 0
-        for (const m of existing) {
-          if (!m.id.startsWith("live-segment-") && !m.id.startsWith("live-")) continue
-          const t = m.timestamp.getTime()
-          if (t > latestLiveTextAt) latestLiveTextAt = t
-        }
-        const durableFinalAfterLiveText =
-          latestLiveTextAt > 0 &&
-          msgs.some(
-            (api) =>
-              (api.role === "claw" || api.role === "hub") &&
-              api.timestamp.getTime() > latestLiveTextAt
-          )
+        // Keep in-flight tool activity so selecting a claw mid-turn does not blank
+        // the UI. Live text fragments are only valid while a segmented stream is
+        // open (segmentedStreamRef); once the durable final lands the ref is
+        // cleared and fragments must go so we never double-render beside the
+        // timeline reply. Avoid timestamp heuristics — equal ms and nearby
+        // previous-turn replies both mis-classify "is this the current final?".
+        const streamInProgress = Boolean(segmentedStreamRef.current[clawId])
         const liveTransient = existing.filter((m) => {
           if (!isTransientMessage(m)) return false
-          if (m.id.startsWith("live-segment-") || m.id.startsWith("live-")) {
-            return !durableFinalAfterLiveText
-          }
+          if (m.id.startsWith("live-")) return streamInProgress
           return true
         })
         const merged = pruneOldestLiveActivities(

--- a/web/hooks/use-hub.ts
+++ b/web/hooks/use-hub.ts
@@ -14,7 +14,11 @@ import {
   isConfigured,
 } from "@/lib/api"
 import { mapApiClaw, mapApiMessage, mapApiStatus, computeUptime } from "@/lib/mappers"
-import { isTerminalAssistantMessage } from "@/lib/messages"
+import {
+  isTerminalAssistantMessage,
+  isTransientMessage,
+  pruneOldestLiveActivities,
+} from "@/lib/messages"
 import { useTypewriter, type TypewriterState } from "@/hooks/use-typewriter"
 
 export interface HubState {
@@ -42,6 +46,8 @@ const ORDER_KEY = "elasticclaw_claw_order"
 // ── localStorage message cache ──────────────────────────────────────────────
 const MESSAGES_KEY = "elasticclaw_messages"
 const MAX_CACHED_PER_CLAW = 200
+/** Cap live tool/activity rows in memory so floods don't bloat the client. */
+const MAX_LIVE_ACTIVITIES_PER_CLAW = 200
 
 function readCachedMessages(): Record<string, Message[]> {
   if (typeof window === "undefined") return {}
@@ -84,10 +90,6 @@ function describeWsUrl(rawUrl: string): string {
   } catch {
     return rawUrl.replace(/token=[^&]+/, "token=[redacted]")
   }
-}
-
-function isTransientMessage(message: Message): boolean {
-  return message.id.startsWith("activity-") || message.id.startsWith("live-") || message.id.startsWith("thinking-")
 }
 
 function formatActivityContent(activity: AgentActivity): string {
@@ -330,14 +332,33 @@ export function useHub(selectedClawId: string | null): HubState {
       setMessages((prev) => {
         const existing = prev[clawId] || []
         // Merge API result with cached state:
-        // 1. Keep non-optimistic existing messages not in API result (preserves cache beyond API limit)
+        // 1. Keep non-optimistic existing durable messages not in API result (cache beyond API limit)
         // 2. Re-append any in-flight opt- messages so send() can still swap them with real UUIDs
+        // 3. Preserve live activity / stream segments so opening a claw mid-turn does not
+        //    wipe the in-progress transcript (stream and refresh stay content-aligned)
         const existingNonOpt = existing.filter((m) => !m.id.startsWith('opt-') && !isTransientMessage(m))
         const apiIds = new Set(msgs.map((m) => m.id))
         const cachedOnly = existingNonOpt.filter((m) => !apiIds.has(m.id))
         const inflight = existing.filter((m) => m.id.startsWith('opt-') &&
           !msgs.some((r) => r.content === m.content && r.role === m.role))
-        const merged = [...msgs, ...cachedOnly, ...inflight]
+        // Keep in-flight tool activity + stream fragments so selecting a claw
+        // mid-turn does not blank the UI. Drop live-segments once the durable
+        // final reply is already present in the timeline (refresh parity).
+        const liveTransient = existing.filter((m) => {
+          if (!isTransientMessage(m)) return false
+          if (!m.id.startsWith("live-segment-") && !m.id.startsWith("live-")) return true
+          const segTime = m.timestamp.getTime()
+          const durableFinalPresent = msgs.some(
+            (api) =>
+              (api.role === "claw" || api.role === "hub") &&
+              api.timestamp.getTime() >= segTime - 2_000
+          )
+          return !durableFinalPresent
+        })
+        const merged = pruneOldestLiveActivities(
+          [...msgs, ...cachedOnly, ...inflight, ...liveTransient],
+          MAX_LIVE_ACTIVITIES_PER_CLAW
+        )
         merged.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime())
         const next = { ...prev, [clawId]: merged }
         persistMessages(next)
@@ -459,7 +480,8 @@ export function useHub(selectedClawId: string | null): HubState {
               activity,
               timestamp: createdAt,
             })
-            const next = { ...prev, [clawId]: nextMessages }
+            const pruned = pruneOldestLiveActivities(nextMessages, MAX_LIVE_ACTIVITIES_PER_CLAW)
+            const next = { ...prev, [clawId]: pruned }
             persistMessages(next)
             return next
           })
@@ -473,9 +495,10 @@ export function useHub(selectedClawId: string | null): HubState {
           const msg = mapApiMessage(payload)
           const clawId = payload.claw_id
           if (segmentedStreamRef.current[clawId]) {
-            const tail = clearTypewriter(clawId)
+            // Drop any remaining typewriter tail — the durable final message is
+            // the canonical full reply (same content a refresh would load).
+            clearTypewriter(clawId)
             delete segmentedStreamRef.current[clawId]
-            const tailId = tail.trim() ? nextClientMessageId("live-segment", clawId) : null
             // Called once typewriter is fully drained — safe to add final message
             setClaws((prev) =>
               prev.map((c) =>
@@ -492,19 +515,17 @@ export function useHub(selectedClawId: string | null): HubState {
               )
             )
             setMessages((prev) => {
-              const nextMessages = withoutModelWaitActivities(prev[clawId] || [])
-              const hasLiveSegment = nextMessages.some((m) => m.id.startsWith(`live-segment-${clawId}-`))
-              if (tailId) {
-                nextMessages.push({
-                  id: tailId,
-                  role: "claw",
-                  content: tail,
-                  timestamp: msg.timestamp,
-                })
-              } else if (!hasLiveSegment && msg.content.trim()) {
+              // Replace live text fragments with the durable server message so
+              // end-of-stream matches timeline/refresh. Keep live activity rows
+              // for the current turn (refresh shows activity_summary instead).
+              const nextMessages = withoutModelWaitActivities(prev[clawId] || []).filter(
+                (m) => !m.id.startsWith(`live-segment-${clawId}-`)
+              )
+              if (!nextMessages.some((m) => m.id === msg.id)) {
                 nextMessages.push(msg)
               }
-              const next = { ...prev, [clawId]: nextMessages }
+              const pruned = pruneOldestLiveActivities(nextMessages, MAX_LIVE_ACTIVITIES_PER_CLAW)
+              const next = { ...prev, [clawId]: pruned }
               persistMessages(next)
               return next
             })

--- a/web/hooks/use-windowed-messages.ts
+++ b/web/hooks/use-windowed-messages.ts
@@ -5,7 +5,8 @@ import { fetchMessageTimeline } from "@/lib/api"
 import { mapApiMessage } from "@/lib/mappers"
 import type { Message } from "@/lib/types"
 
-const PAGE_SIZE = 50    // messages per page
+// Timeline page size — durable turns + activity_summary rows (not live tool floods).
+const PAGE_SIZE = 100
 const ROLE_ORDER: Record<Message["role"], number> = {
   user: 0,
   hub: 1,
@@ -16,6 +17,7 @@ const ROLE_ORDER: Record<Message["role"], number> = {
 }
 
 function conversationMessages(messages: Message[]): Message[] {
+  // Cursor pagination is keyed off real conversation rows, not activity chrome.
   return messages.filter((message) => message.role !== "activity" && message.role !== "activity_summary")
 }
 

--- a/web/lib/messages.ts
+++ b/web/lib/messages.ts
@@ -3,3 +3,73 @@ import type { Message } from "@/lib/types"
 export function isTerminalAssistantMessage(message: Message): boolean {
   return message.role === "claw" && /\[(DONE|READY_TO_COMMIT)\]/.test(message.content)
 }
+
+/** Client-only rows that never come from the timeline API. */
+export function isTransientMessage(message: Message): boolean {
+  return (
+    message.id.startsWith("activity-") ||
+    message.id.startsWith("live-") ||
+    message.id.startsWith("thinking-")
+  )
+}
+
+/**
+ * Durable conversation rows that must not be aged out by a flood of live
+ * tool/activity events. Includes timeline activity_summary placeholders.
+ */
+export function isDurableConversationMessage(message: Message): boolean {
+  if (isTransientMessage(message)) return false
+  if (message.role === "activity") return false
+  return true
+}
+
+/**
+ * Window a transcript for compact surfaces (board cards) by durable turns,
+ * not by raw row count. Activities and live segments never push durable
+ * user/claw messages out of the window.
+ *
+ * Keeps the last `durableLimit` durable messages and every row from the
+ * first kept durable message onward (so in-window tool activity stays).
+ */
+export function windowMessagesByDurableCount(
+  messages: Message[],
+  durableLimit: number
+): Message[] {
+  if (durableLimit <= 0 || messages.length === 0) return messages
+
+  let durableCount = 0
+  let startIdx = 0
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    if (!isDurableConversationMessage(messages[i])) continue
+    durableCount += 1
+    if (durableCount >= durableLimit) {
+      startIdx = i
+      break
+    }
+  }
+  return messages.slice(startIdx)
+}
+
+/**
+ * Drop the oldest live activity rows once they exceed `maxActivities`,
+ * without touching durable conversation messages or live text segments.
+ */
+export function pruneOldestLiveActivities(
+  messages: Message[],
+  maxActivities: number
+): Message[] {
+  if (maxActivities < 0 || messages.length === 0) return messages
+
+  let activityCount = 0
+  for (const message of messages) {
+    if (message.role === "activity") activityCount += 1
+  }
+  if (activityCount <= maxActivities) return messages
+
+  let toDrop = activityCount - maxActivities
+  return messages.filter((message) => {
+    if (message.role !== "activity" || toDrop <= 0) return true
+    toDrop -= 1
+    return false
+  })
+}


### PR DESCRIPTION
## Summary
- **Board cards** window by durable conversation turns (user/claw/hub/summary), not raw row count — tool-activity floods no longer push earlier messages out of the card.
- **Segmented streams** always commit the durable final server message and drop live text fragments, so end-of-stream matches what a refresh/timeline load shows.
- **`loadMessages`** preserves in-flight activity/stream rows mid-turn (no blanking when opening a claw), and drops live-segments once the durable reply is already in the timeline.
- Cap live activity rows in memory; bump full-chat timeline page size to 100.

## Problem
During heavy tool use, messages appeared to vanish from the UI even though they were still in the DB. Users had to refresh to get them back (or lost stream-only fragments that never became durable in the client).

Root causes:
1. Board used `messages.slice(-50)`, counting every activity as a slot.
2. Segmented final-message handling skipped the durable append when live-segments existed.
3. Reloading/selecting a claw dropped all transient rows mid-stream.

## Test plan
- [ ] Open a claw, send a prompt that triggers many tool calls; earlier user/claw messages stay visible on the **board card** throughout.
- [ ] Same turn in **full chat**: scroll up still loads older history; messages do not disappear as tools stream.
- [ ] After the turn completes (no refresh), the final assistant reply matches what you get after a hard refresh.
- [ ] Select the claw mid-stream: live tool activity does not blank out; after completion, durable reply is present without needing refresh.
- [ ] `cd web && npm run typecheck`