### PR TITLE
feat(workflow): add rm command and delete API endpoint

### DIFF
--- a/cmd/workflow.go
+++ b/cmd/workflow.go
@@ -300,9 +300,10 @@ func runWorkflowPush(workspace string, paths []string) error {
 func workflowRmCmd() *cobra.Command {
 	var workspace string
 	cmd := &cobra.Command{
-		Use:   "rm <name>",
-		Short: "Remove a workflow from a workspace",
-		Args:  cobra.ExactArgs(1),
+		Use:     "rm <name>",
+		Aliases: []string{"delete", "remove"},
+		Short:   "Remove a workflow from a workspace",
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runWorkflowRm(workspace, args[0])
 		},

--- a/cmd/workflow.go
+++ b/cmd/workflow.go
@@ -27,6 +27,7 @@ func WorkflowCmd() *cobra.Command {
 	cmd.AddCommand(workflowListCmd())
 	cmd.AddCommand(workflowShowCmd())
 	cmd.AddCommand(workflowPushCmd())
+	cmd.AddCommand(workflowRmCmd())
 	cmd.AddCommand(workflowTriggerCmd())
 	cmd.AddCommand(workflowRunsCmd())
 	cmd.AddCommand(workflowInspectCmd())
@@ -293,6 +294,44 @@ func runWorkflowPush(workspace string, paths []string) error {
 	for _, workflow := range result.Workflows {
 		fmt.Printf("  ✓ %s\n", workflow.Name)
 	}
+	return nil
+}
+
+func workflowRmCmd() *cobra.Command {
+	var workspace string
+	cmd := &cobra.Command{
+		Use:   "rm <name>",
+		Short: "Remove a workflow from a workspace",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runWorkflowRm(workspace, args[0])
+		},
+	}
+	cmd.Flags().StringVar(&workspace, "workspace", "default", "workspace name")
+	return cmd
+}
+
+func runWorkflowRm(workspace, name string) error {
+	hubURL, clawToken, err := resolveHubConn()
+	if err != nil {
+		return err
+	}
+	path := fmt.Sprintf("/api/workspaces/%s/workflows/%s", url.PathEscape(workspace), url.PathEscape(name))
+	req, _ := http.NewRequest(http.MethodDelete, hubURL+path, nil)
+	req.Header.Set("Authorization", "Bearer "+clawToken)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("remove workflow failed: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("workflow %q not found in workspace %q", name, workspace)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("hub returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	fmt.Printf("Removed workflow %q from workspace %q.\n", name, workspace)
 	return nil
 }
 

--- a/cmd/workflow_test.go
+++ b/cmd/workflow_test.go
@@ -319,6 +319,36 @@ func TestRunWorkflowRmDeletesWorkflow(t *testing.T) {
 	}
 }
 
+func TestWorkflowRmCommandWiring(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if r.URL.Path == "/api/workspaces/prod/workflows/bugfix" {
+			_ = json.NewEncoder(w).Encode(map[string]string{"deleted": "bugfix"})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	t.Setenv("ELASTICCLAW_HUB_URL", server.URL)
+	t.Setenv("ELASTICCLAW_CLAW_TOKEN", "test-token")
+
+	out, err := captureStdout(func() error {
+		cmd := WorkflowCmd()
+		cmd.SetArgs([]string{"rm", "bugfix", "--workspace", "prod"})
+		return cmd.Execute()
+	})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if !strings.Contains(out, "Removed workflow \"bugfix\" from workspace \"prod\"") {
+		t.Fatalf("output missing removal confirmation:\n%s", out)
+	}
+}
+
 func TestRunWorkflowRunsListsRunsAndShortAgentID(t *testing.T) {
 	started := time.Date(2026, 7, 24, 9, 0, 0, 0, time.UTC)
 	finished := started.Add(5 * time.Minute)

--- a/cmd/workflow_test.go
+++ b/cmd/workflow_test.go
@@ -279,6 +279,46 @@ func mustJSON(t *testing.T, v interface{}) string {
 	return string(b)
 }
 
+func TestRunWorkflowRmDeletesWorkflow(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if r.URL.Path == "/api/workspaces/default/workflows/bugfix" {
+			_ = json.NewEncoder(w).Encode(map[string]string{"deleted": "bugfix"})
+			return
+		}
+		if r.URL.Path == "/api/workspaces/default/workflows/missing" {
+			http.Error(w, "workflow not found", http.StatusNotFound)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	t.Setenv("ELASTICCLAW_HUB_URL", server.URL)
+	t.Setenv("ELASTICCLAW_CLAW_TOKEN", "test-token")
+
+	out, err := captureStdout(func() error {
+		return runWorkflowRm("default", "bugfix")
+	})
+	if err != nil {
+		t.Fatalf("runWorkflowRm returned error: %v", err)
+	}
+	if !strings.Contains(out, "Removed workflow \"bugfix\" from workspace \"default\"") {
+		t.Fatalf("output missing removal confirmation:\n%s", out)
+	}
+
+	err = runWorkflowRm("default", "missing")
+	if err == nil {
+		t.Fatalf("expected error for missing workflow, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected not found error, got %v", err)
+	}
+}
+
 func TestRunWorkflowRunsListsRunsAndShortAgentID(t *testing.T) {
 	started := time.Date(2026, 7, 24, 9, 0, 0, 0, time.UTC)
 	finished := started.Add(5 * time.Minute)

--- a/pkg/hub/cron_scheduler.go
+++ b/pkg/hub/cron_scheduler.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"strings"
 	"sync"
 	"time"
 
@@ -189,11 +190,18 @@ func (cs *cronScheduler) removeWorkflow(workspaceName, workflowName string) {
 		return
 	}
 	key := workspaceName + "/" + workflowName
-	if entryID, ok := cs.entries[key]; ok {
-		cs.cron.Remove(entryID)
-		delete(cs.entries, key)
-		delete(cs.workflows, key)
-		log.Printf("[cron] removed schedule for %s", key)
+
+	// Storage deletes workflows by lowercased filename, so the deletion URL may
+	// use a different casing than the workflow name stored in the scheduler.
+	// Find and remove the matching entry case-insensitively.
+	for entryKey, entryID := range cs.entries {
+		if strings.EqualFold(entryKey, key) {
+			cs.cron.Remove(entryID)
+			delete(cs.entries, entryKey)
+			delete(cs.workflows, entryKey)
+			log.Printf("[cron] removed schedule for %s", entryKey)
+			return
+		}
 	}
 }
 

--- a/pkg/hub/cron_scheduler.go
+++ b/pkg/hub/cron_scheduler.go
@@ -178,6 +178,25 @@ func (cs *cronScheduler) reload() error {
 	return cs.reloadWorkflows()
 }
 
+// removeWorkflow stops the schedule for a single workflow without reloading the
+// full scheduler. This is used during deletion so the job is removed even if a
+// subsequent reload fails to load all workspaces.
+func (cs *cronScheduler) removeWorkflow(workspaceName, workflowName string) {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+
+	if cs.cron == nil {
+		return
+	}
+	key := workspaceName + "/" + workflowName
+	if entryID, ok := cs.entries[key]; ok {
+		cs.cron.Remove(entryID)
+		delete(cs.entries, key)
+		delete(cs.workflows, key)
+		log.Printf("[cron] removed schedule for %s", key)
+	}
+}
+
 // parseCronSchedule parses a cron schedule with timezone support.
 // It delegates expression parsing to types.ParseCronSchedule so that the
 // scheduler and save-time validation always accept the same expressions.

--- a/pkg/hub/external_storage.go
+++ b/pkg/hub/external_storage.go
@@ -882,6 +882,23 @@ func deleteExternalWorkspace(name string) error {
 	return os.RemoveAll(filepath.Join(workspacesDir(), name))
 }
 
+func deleteExternalWorkflow(workspaceName, workflowName string) error {
+	if err := validateName(workspaceName); err != nil {
+		return err
+	}
+	if err := validateName(workflowName); err != nil {
+		return err
+	}
+	path := filepath.Join(workspacesDir(), workspaceName, "workflows", strings.ToLower(workflowName)+".yaml")
+	if err := os.Remove(path); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("workflow not found")
+		}
+		return err
+	}
+	return nil
+}
+
 // ── Migration ────────────────────────────────────────────────────────────────
 
 // migrationMarkerPath returns the path to the migration marker file.

--- a/pkg/hub/external_storage.go
+++ b/pkg/hub/external_storage.go
@@ -882,6 +882,8 @@ func deleteExternalWorkspace(name string) error {
 	return os.RemoveAll(filepath.Join(workspacesDir(), name))
 }
 
+var errWorkflowNotFound = errors.New("workflow not found")
+
 func deleteExternalWorkflow(workspaceName, workflowName string) error {
 	if err := validateName(workspaceName); err != nil {
 		return err
@@ -892,7 +894,7 @@ func deleteExternalWorkflow(workspaceName, workflowName string) error {
 	path := filepath.Join(workspacesDir(), workspaceName, "workflows", strings.ToLower(workflowName)+".yaml")
 	if err := os.Remove(path); err != nil {
 		if os.IsNotExist(err) {
-			return fmt.Errorf("workflow not found")
+			return errWorkflowNotFound
 		}
 		return err
 	}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -585,7 +585,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/v2/workflow-runs/{runId}", s.withAuth(s.handleWorkflowV2Run))
 	mux.HandleFunc("/api/workspaces", s.withAdminForMethods(s.handleWorkspacesCRUD, http.MethodPost, http.MethodDelete)) // workspace CRUD
 	mux.HandleFunc("/api/workspaces/{name}/workflows", s.withAdminForMethods(s.handleWorkspaceWorkflowsList, http.MethodPost))
-	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}", s.withAdminForMethods(s.handleWorkspaceWorkflowDetail, http.MethodPatch))
+	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}", s.withAdminForMethods(s.handleWorkspaceWorkflowDetail, http.MethodPatch, http.MethodDelete))
 	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}/trigger", s.withAuth(s.handleWorkspaceWorkflowTrigger))
 	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}/cron/trigger", s.withAuth(s.handleCronWorkflowTrigger))  // POST manual trigger
 	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}/cron/runs", s.withAuth(s.handleCronWorkflowRuns))        // GET run history

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -2078,6 +2078,7 @@ func TestConfigMutationRoutesRequireWebAdminForGitHubSessions(t *testing.T) {
 		{name: "workspace delete", method: http.MethodDelete, path: "/api/workspaces?name=demo"},
 		{name: "workflow push", method: http.MethodPost, path: "/api/workspaces/demo/workflows", body: `{"workflows":[]}`},
 		{name: "workflow patch", method: http.MethodPatch, path: "/api/workspaces/demo/workflows/build", body: `{"enabled":true}`},
+		{name: "workflow delete", method: http.MethodDelete, path: "/api/workspaces/demo/workflows/build"},
 		{name: "workspace secret upsert", method: http.MethodPut, path: "/api/workspaces/demo/secrets", body: `{"name":"TOKEN","value":"secret"}`},
 		{name: "workspace secret delete", method: http.MethodDelete, path: "/api/workspaces/demo/secrets?name=TOKEN"},
 		{name: "workspace github app upsert", method: http.MethodPost, path: "/api/workspaces/demo/github-apps", body: `{"name":"app","appId":1}`},

--- a/pkg/hub/workspace_api.go
+++ b/pkg/hub/workspace_api.go
@@ -366,8 +366,8 @@ func (s *Server) handleWorkspaceWorkflowPatch(w http.ResponseWriter, r *http.Req
 }
 
 func (s *Server) handleWorkspaceWorkflowDelete(w http.ResponseWriter, r *http.Request) {
-	workspaceName := strings.TrimSpace(r.PathValue("workspace"))
-	workflowName := strings.TrimSpace(r.PathValue("workflow"))
+	workspaceName := r.PathValue("workspace")
+	workflowName := r.PathValue("workflow")
 	if workspaceName == "" || workflowName == "" {
 		http.Error(w, "workspace and workflow names required", http.StatusBadRequest)
 		return
@@ -381,6 +381,7 @@ func (s *Server) handleWorkspaceWorkflowDelete(w http.ResponseWriter, r *http.Re
 		return
 	}
 	if s.cronScheduler != nil {
+		s.cronScheduler.removeWorkflow(workspaceName, workflowName)
 		if err := s.cronScheduler.reload(); err != nil {
 			log.Printf("[cron] failed to reload workflows after workflow delete for workspace %s workflow %s: %v", workspaceName, workflowName, err)
 		}

--- a/pkg/hub/workspace_api.go
+++ b/pkg/hub/workspace_api.go
@@ -374,21 +374,37 @@ func (s *Server) handleWorkspaceWorkflowDelete(w http.ResponseWriter, r *http.Re
 		http.Error(w, "workspace and workflow names required", http.StatusBadRequest)
 		return
 	}
+
+	// Track the names used for the actual deletion so the cron scheduler key
+	// is removed correctly. Fall back to raw (untrimmed) path values to handle
+	// workflows persisted before push-time trimming was introduced.
+	deletedWorkspaceName := workspaceName
+	deletedWorkflowName := workflowName
 	if err := deleteExternalWorkflow(workspaceName, workflowName); err != nil {
-		if errors.Is(err, errWorkflowNotFound) {
-			http.Error(w, err.Error(), http.StatusNotFound)
+		if !errors.Is(err, errWorkflowNotFound) {
+			http.Error(w, "delete workflow: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
-		http.Error(w, "delete workflow: "+err.Error(), http.StatusInternalServerError)
-		return
+		rawWorkspaceName := r.PathValue("workspace")
+		rawWorkflowName := r.PathValue("workflow")
+		if err := deleteExternalWorkflow(rawWorkspaceName, rawWorkflowName); err != nil {
+			if errors.Is(err, errWorkflowNotFound) {
+				http.Error(w, err.Error(), http.StatusNotFound)
+				return
+			}
+			http.Error(w, "delete workflow: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		deletedWorkspaceName = rawWorkspaceName
+		deletedWorkflowName = rawWorkflowName
 	}
 	if s.cronScheduler != nil {
-		s.cronScheduler.removeWorkflow(workspaceName, workflowName)
+		s.cronScheduler.removeWorkflow(deletedWorkspaceName, deletedWorkflowName)
 		if err := s.cronScheduler.reload(); err != nil {
-			log.Printf("[cron] failed to reload workflows after workflow delete for workspace %s workflow %s: %v", workspaceName, workflowName, err)
+			log.Printf("[cron] failed to reload workflows after workflow delete for workspace %s workflow %s: %v", deletedWorkspaceName, deletedWorkflowName, err)
 		}
 	}
-	jsonOK(w, map[string]string{"deleted": workflowName})
+	jsonOK(w, map[string]string{"deleted": deletedWorkflowName})
 }
 
 func (s *Server) handleWorkspaceWorkflowTrigger(w http.ResponseWriter, r *http.Request) {

--- a/pkg/hub/workspace_api.go
+++ b/pkg/hub/workspace_api.go
@@ -3,6 +3,7 @@ package hub
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -222,6 +223,7 @@ func (s *Server) handleWorkspaceWorkflowsPush(w http.ResponseWriter, r *http.Req
 			http.Error(w, "workflow cannot be nil", http.StatusBadRequest)
 			return
 		}
+		workflow.Name = strings.TrimSpace(workflow.Name)
 		// V2 workflows use a separate schema; do not run v1 normalize/validate on them.
 		if isWorkflowV2(workflow) {
 			continue
@@ -366,14 +368,14 @@ func (s *Server) handleWorkspaceWorkflowPatch(w http.ResponseWriter, r *http.Req
 }
 
 func (s *Server) handleWorkspaceWorkflowDelete(w http.ResponseWriter, r *http.Request) {
-	workspaceName := r.PathValue("workspace")
-	workflowName := r.PathValue("workflow")
+	workspaceName := strings.TrimSpace(r.PathValue("workspace"))
+	workflowName := strings.TrimSpace(r.PathValue("workflow"))
 	if workspaceName == "" || workflowName == "" {
 		http.Error(w, "workspace and workflow names required", http.StatusBadRequest)
 		return
 	}
 	if err := deleteExternalWorkflow(workspaceName, workflowName); err != nil {
-		if err.Error() == "workflow not found" {
+		if errors.Is(err, errWorkflowNotFound) {
 			http.Error(w, err.Error(), http.StatusNotFound)
 			return
 		}

--- a/pkg/hub/workspace_api.go
+++ b/pkg/hub/workspace_api.go
@@ -270,6 +270,10 @@ func (s *Server) handleWorkspaceWorkflowDetail(w http.ResponseWriter, r *http.Re
 		s.handleWorkspaceWorkflowPatch(w, r)
 		return
 	}
+	if r.Method == http.MethodDelete {
+		s.handleWorkspaceWorkflowDelete(w, r)
+		return
+	}
 	if r.Method != http.MethodGet {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
@@ -359,6 +363,29 @@ func (s *Server) handleWorkspaceWorkflowPatch(w http.ResponseWriter, r *http.Req
 		}
 	}
 	jsonOK(w, workflowToView(workspace.Name, workflow))
+}
+
+func (s *Server) handleWorkspaceWorkflowDelete(w http.ResponseWriter, r *http.Request) {
+	workspaceName := strings.TrimSpace(r.PathValue("workspace"))
+	workflowName := strings.TrimSpace(r.PathValue("workflow"))
+	if workspaceName == "" || workflowName == "" {
+		http.Error(w, "workspace and workflow names required", http.StatusBadRequest)
+		return
+	}
+	if err := deleteExternalWorkflow(workspaceName, workflowName); err != nil {
+		if err.Error() == "workflow not found" {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		http.Error(w, "delete workflow: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if s.cronScheduler != nil {
+		if err := s.cronScheduler.reload(); err != nil {
+			log.Printf("[cron] failed to reload workflows after workflow delete for workspace %s workflow %s: %v", workspaceName, workflowName, err)
+		}
+	}
+	jsonOK(w, map[string]string{"deleted": workflowName})
 }
 
 func (s *Server) handleWorkspaceWorkflowTrigger(w http.ResponseWriter, r *http.Request) {

--- a/pkg/hub/workspace_api_test.go
+++ b/pkg/hub/workspace_api_test.go
@@ -280,6 +280,89 @@ func TestWorkflowDeleteRemovesWorkflow(t *testing.T) {
 	}
 }
 
+func TestWorkflowDeleteWithWhitespaceName(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", configDir+"/hub.yaml")
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+
+	body := `{"workspaces":[{"name":"engineering","repositories":[]}]}`
+	req := httptest.NewRequest(http.MethodPost, "/api/workspaces", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("workspace push status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+
+	body = `{"workflows":[{"name":" bugfix ","integration":"github","enable_manual_trigger":true}]}`
+	req = httptest.NewRequest(http.MethodPost, "/api/workspaces/engineering/workflows", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	rr = httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("workflow push status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+
+	req = httptest.NewRequest(http.MethodDelete, "/api/workspaces/engineering/workflows/%20bugfix%20", nil)
+	req.Header.Set("Authorization", "Bearer test-token")
+	rr = httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("workflow delete status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+
+	workflowPath := filepath.Join(configDir, "workspaces", "engineering", "workflows", " bugfix .yaml")
+	if _, err := os.Stat(workflowPath); !os.IsNotExist(err) {
+		t.Fatalf("workflow file with whitespace still exists after delete: %s", workflowPath)
+	}
+}
+
+func TestWorkflowDeleteRemovesCronSchedule(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", configDir+"/hub.yaml")
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+	s.cronScheduler = newCronScheduler(s)
+	s.cronScheduler.cron = cron.New(cron.WithSeconds())
+
+	body := `{"workspaces":[{"name":"engineering"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/api/workspaces", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("workspace push status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+
+	body = `{"workflows":[{"schemaVersion":"v1","name":"dependency-update-go","trigger":{"cron":{"schedule":"*/1 * * * *","timezone":"America/Chicago","overlap_policy":"skip","timeout":"2h"}},"stages":[{"id":"working","entry":true}]}]}`
+	req = httptest.NewRequest(http.MethodPost, "/api/workspaces/engineering/workflows", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	rr = httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("workflow push status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+
+	if _, ok := s.cronScheduler.entries["engineering/dependency-update-go"]; !ok {
+		t.Fatalf("cron workflow was not registered: %#v", s.cronScheduler.entries)
+	}
+
+	req = httptest.NewRequest(http.MethodDelete, "/api/workspaces/engineering/workflows/dependency-update-go", nil)
+	req.Header.Set("Authorization", "Bearer test-token")
+	rr = httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("workflow delete status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+
+	if _, ok := s.cronScheduler.entries["engineering/dependency-update-go"]; ok {
+		t.Fatalf("cron entry for deleted workflow still exists: %#v", s.cronScheduler.entries)
+	}
+}
+
 func TestWorkflowPushAcceptsNestedGitHubIssuesTrigger(t *testing.T) {
 	configDir := t.TempDir()
 	t.Setenv("ELASTICCLAW_HUB_CONFIG", configDir+"/hub.yaml")

--- a/pkg/hub/workspace_api_test.go
+++ b/pkg/hub/workspace_api_test.go
@@ -305,6 +305,13 @@ func TestWorkflowDeleteWithWhitespaceName(t *testing.T) {
 		t.Fatalf("workflow push status = %d, body = %s", rr.Code, rr.Body.String())
 	}
 
+	// Workflow names are normalized on push, so the persisted file has no
+	// surrounding whitespace even though the request body did.
+	workflowPath := filepath.Join(configDir, "workspaces", "engineering", "workflows", "bugfix.yaml")
+	if _, err := os.Stat(workflowPath); err != nil {
+		t.Fatalf("normalized workflow file not found: %v", err)
+	}
+
 	req = httptest.NewRequest(http.MethodDelete, "/api/workspaces/engineering/workflows/%20bugfix%20", nil)
 	req.Header.Set("Authorization", "Bearer test-token")
 	rr = httptest.NewRecorder()
@@ -313,9 +320,8 @@ func TestWorkflowDeleteWithWhitespaceName(t *testing.T) {
 		t.Fatalf("workflow delete status = %d, body = %s", rr.Code, rr.Body.String())
 	}
 
-	workflowPath := filepath.Join(configDir, "workspaces", "engineering", "workflows", " bugfix .yaml")
 	if _, err := os.Stat(workflowPath); !os.IsNotExist(err) {
-		t.Fatalf("workflow file with whitespace still exists after delete: %s", workflowPath)
+		t.Fatalf("workflow file still exists after delete: %s", workflowPath)
 	}
 }
 

--- a/pkg/hub/workspace_api_test.go
+++ b/pkg/hub/workspace_api_test.go
@@ -218,6 +218,68 @@ func TestWorkflowPushPersistsWorkspaceWorkflows(t *testing.T) {
 	}
 }
 
+func TestWorkflowDeleteRemovesWorkflow(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", configDir+"/hub.yaml")
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+
+	body := `{"workspaces":[{"name":"engineering","repositories":[]}]}`
+	req := httptest.NewRequest(http.MethodPost, "/api/workspaces", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("workspace push status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+
+	body = `{"workflows":[{"name":"bugfix","integration":"github","enable_manual_trigger":true}]}`
+	req = httptest.NewRequest(http.MethodPost, "/api/workspaces/engineering/workflows", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	rr = httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("workflow push status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+
+	req = httptest.NewRequest(http.MethodDelete, "/api/workspaces/engineering/workflows/bugfix", nil)
+	req.Header.Set("Authorization", "Bearer test-token")
+	rr = httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("workflow delete status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	var result map[string]string
+	if err := json.Unmarshal(rr.Body.Bytes(), &result); err != nil {
+		t.Fatalf("decode delete response: %v", err)
+	}
+	if result["deleted"] != "bugfix" {
+		t.Fatalf("deleted = %q, want bugfix", result["deleted"])
+	}
+
+	workflowPath := filepath.Join(configDir, "workspaces", "engineering", "workflows", "bugfix.yaml")
+	if _, err := os.Stat(workflowPath); !os.IsNotExist(err) {
+		t.Fatalf("workflow file still exists after delete: %s", workflowPath)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/workspaces/engineering/workflows/bugfix", nil)
+	req.Header.Set("Authorization", "Bearer test-token")
+	rr = httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("get deleted workflow status = %d, want 404, body = %s", rr.Code, rr.Body.String())
+	}
+
+	req = httptest.NewRequest(http.MethodDelete, "/api/workspaces/engineering/workflows/bugfix", nil)
+	req.Header.Set("Authorization", "Bearer test-token")
+	rr = httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("delete missing workflow status = %d, want 404, body = %s", rr.Code, rr.Body.String())
+	}
+}
+
 func TestWorkflowPushAcceptsNestedGitHubIssuesTrigger(t *testing.T) {
 	configDir := t.TempDir()
 	t.Setenv("ELASTICCLAW_HUB_CONFIG", configDir+"/hub.yaml")

--- a/pkg/hub/workspace_api_test.go
+++ b/pkg/hub/workspace_api_test.go
@@ -369,6 +369,51 @@ func TestWorkflowDeleteRemovesCronSchedule(t *testing.T) {
 	}
 }
 
+func TestWorkflowDeleteRemovesCronScheduleWithCaseMismatch(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", configDir+"/hub.yaml")
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+	s.cronScheduler = newCronScheduler(s)
+	s.cronScheduler.cron = cron.New(cron.WithSeconds())
+
+	body := `{"workspaces":[{"name":"engineering"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/api/workspaces", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("workspace push status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+
+	body = `{"workflows":[{"schemaVersion":"v1","name":"Dependency-Update-Go","trigger":{"cron":{"schedule":"*/1 * * * *","timezone":"America/Chicago","overlap_policy":"skip","timeout":"2h"}},"stages":[{"id":"working","entry":true}]}]}`
+	req = httptest.NewRequest(http.MethodPost, "/api/workspaces/engineering/workflows", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	rr = httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("workflow push status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+
+	if _, ok := s.cronScheduler.entries["engineering/Dependency-Update-Go"]; !ok {
+		t.Fatalf("cron workflow was not registered: %#v", s.cronScheduler.entries)
+	}
+
+	// Delete using a different casing than the stored workflow name.
+	req = httptest.NewRequest(http.MethodDelete, "/api/workspaces/engineering/workflows/dependency-update-go", nil)
+	req.Header.Set("Authorization", "Bearer test-token")
+	rr = httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("workflow delete status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+
+	if _, ok := s.cronScheduler.entries["engineering/Dependency-Update-Go"]; ok {
+		t.Fatalf("cron entry for deleted workflow still exists: %#v", s.cronScheduler.entries)
+	}
+}
+
 func TestWorkflowPushAcceptsNestedGitHubIssuesTrigger(t *testing.T) {
 	configDir := t.TempDir()
 	t.Setenv("ELASTICCLAW_HUB_CONFIG", configDir+"/hub.yaml")

--- a/pkg/hub/workspace_api_test.go
+++ b/pkg/hub/workspace_api_test.go
@@ -414,6 +414,60 @@ func TestWorkflowDeleteRemovesCronScheduleWithCaseMismatch(t *testing.T) {
 	}
 }
 
+func TestWorkflowDeleteRemovesLegacyWhitespaceWorkflow(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", configDir+"/hub.yaml")
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+	s.cronScheduler = newCronScheduler(s)
+	s.cronScheduler.cron = cron.New(cron.WithSeconds())
+
+	body := `{"workspaces":[{"name":"engineering"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/api/workspaces", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("workspace push status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+
+	// Simulate a legacy workflow persisted before push-time trimming: the file
+	// on disk has surrounding whitespace, and the cron scheduler uses the same
+	// unnormalized key.
+	workflowPath := filepath.Join(configDir, "workspaces", "engineering", "workflows", " bugfix .yaml")
+	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+		t.Fatalf("create workflows dir: %v", err)
+	}
+	if err := os.WriteFile(workflowPath, []byte("legacy workflow"), 0o644); err != nil {
+		t.Fatalf("write legacy workflow file: %v", err)
+	}
+	key := "engineering/ bugfix"
+	entryID, err := s.cronScheduler.cron.AddFunc("* * * * * *", func() {})
+	if err != nil {
+		t.Fatalf("add cron func: %v", err)
+	}
+	s.cronScheduler.entries[key] = entryID
+	s.cronScheduler.workflows[key] = &scheduledWorkflow{key: key}
+
+	// Delete using the trimmed URL. The handler should fall back to the raw
+	// path value and remove the legacy file and cron entry.
+	req = httptest.NewRequest(http.MethodDelete, "/api/workspaces/engineering/workflows/%20bugfix%20", nil)
+	req.Header.Set("Authorization", "Bearer test-token")
+	rr = httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("workflow delete status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+
+	if _, err := os.Stat(workflowPath); !os.IsNotExist(err) {
+		t.Fatalf("legacy workflow file still exists after delete: %s", workflowPath)
+	}
+
+	if _, ok := s.cronScheduler.entries[key]; ok {
+		t.Fatalf("cron entry for legacy workflow still exists: %#v", s.cronScheduler.entries)
+	}
+}
+
 func TestWorkflowPushAcceptsNestedGitHubIssuesTrigger(t *testing.T) {
 	configDir := t.TempDir()
 	t.Setenv("ELASTICCLAW_HUB_CONFIG", configDir+"/hub.yaml")


### PR DESCRIPTION
Adds `elasticclaw workflow rm <name> --workspace <workspace>` and the corresponding hub API endpoint `DELETE /api/workspaces/{workspace}/workflows/{workflow}`.

- CLI calls the hub API, matching the existing pattern used by `workspace rm` and other workflow commands.
- Handler deletes the workflow YAML from external storage and reloads the cron scheduler.
- Returns 404 if the workflow does not exist.
- Includes tests for the API endpoint, CLI command, and admin-auth route check.

All tests pass: `go test ./cmd ./pkg/hub -count=1`