### PR TITLE
[AIEDEV-17] feat: complete AWS Lambda MicroVM sandbox runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,5 @@ bootopt
 
 # Docker dev environment (contains secrets — never commit)
 docker/hub.dev.yaml
+aws/lambda-microvm/.env
 tmp/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-bridge build-bridge-linux test test-bootstrap test-container e2e e2e-github e2e-linear e2e-jira e2e-replicated-github e2e-replicated-linear e2e-replicated-jira e2e-exedev-github e2e-docker e2e-run clean install lint tidy clawpatch-init clawpatch-review clawpatch-report clawpatch-show clawpatch-triage clawpatch-pr dev dev-up dev-up-d dev-down dev-reset dev-logs dev-restart dev-sh-hub dev-sh-web dev-agent-build dev-claw _dev-config-check
+.PHONY: build build-bridge build-bridge-linux build-bridge-linux-arm64 build-lambda-microvm-artifact publish-lambda-microvm-image setup-lambda-microvm setup-lambda-microvm-apply test test-bootstrap test-container e2e e2e-github e2e-linear e2e-jira e2e-replicated-github e2e-replicated-linear e2e-replicated-jira e2e-exedev-github e2e-docker e2e-run clean install lint tidy clawpatch-init clawpatch-review clawpatch-report clawpatch-show clawpatch-triage clawpatch-pr dev dev-up dev-up-d dev-down dev-reset dev-logs dev-restart dev-sh-hub dev-sh-web dev-agent-build dev-claw _dev-config-check
 
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
@@ -39,6 +39,27 @@ build-bridge:
 build-bridge-linux:
 	mkdir -p bin
 	GONOSUMDB=* CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-X main.Version=$(VERSION) -X main.Commit=$(COMMIT) -X main.BuildDate=$(BUILD_DATE)" -o bin/claw-bridge-linux-amd64 ./cmd/claw-bridge/
+
+build-bridge-linux-arm64:
+	mkdir -p bin
+	GONOSUMDB=* CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "-X main.Version=$(VERSION) -X main.Commit=$(COMMIT) -X main.BuildDate=$(BUILD_DATE)" -o bin/claw-bridge-linux-arm64 ./cmd/claw-bridge/
+
+build-lambda-microvm-artifact: build-bridge-linux-arm64
+	@command -v zip >/dev/null 2>&1 || (echo "zip is required" && exit 1)
+	mkdir -p bin/lambda-microvm-artifact
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o bin/lambda-microvm-artifact/lambda-microvm-bridge ./cmd/lambda-microvm-bridge/
+	cp bin/claw-bridge-linux-arm64 bin/lambda-microvm-artifact/claw-bridge
+	cp aws/lambda-microvm/Dockerfile bin/lambda-microvm-artifact/Dockerfile
+	cd bin/lambda-microvm-artifact && zip -q -FS ../elasticclaw-lambda-microvm.zip Dockerfile claw-bridge lambda-microvm-bridge
+
+publish-lambda-microvm-image: build-lambda-microvm-artifact
+	bash scripts/publish-lambda-microvm-image.sh
+
+setup-lambda-microvm: build-lambda-microvm-artifact
+	bash scripts/setup-lambda-microvm.sh
+
+setup-lambda-microvm-apply: build-lambda-microvm-artifact
+	bash scripts/setup-lambda-microvm.sh --apply
 
 
 install:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Instead of manually launching agents one at a time, you define **workspaces** an
 - **Workflows** define the automation: trigger rules, stages, issue movement, lifecycle policy, and cleanup.
 - **Scoped GitHub App credentials** give each agent temporary repo access instead of broad personal tokens.
 - **Issue tracker integrations** turn Linear, GitHub Issues, Shortcut, and webhook events into structured work.
-- **Sandbox providers** run each agent in an isolated workspace using Daytona, Replicated CMX, or exe.dev.
+- **Sandbox providers** run each agent in an isolated workspace using Daytona, Replicated CMX, exe.dev, local Docker, or AWS Lambda MicroVMs (alpha).
 - **Single-binary ElasticClaw Server** gives you the API, web UI, state, settings, and workflow automation in one self-hosted Go service.
 
 Each running agent runs [OpenClaw](https://github.com/openclaw/openclaw), connects back to ElasticClaw Server through the connector, clones the allowed repos, receives the issue context, and works inside an ephemeral VM.
@@ -78,7 +78,7 @@ elasticclaw install \
 
 Then configure the pieces your first workflow needs:
 
-1. A sandbox provider such as Daytona, Replicated CMX, or exe.dev.
+1. A sandbox provider such as Daytona, Replicated CMX, exe.dev, local Docker, or AWS Lambda MicroVMs.
 2. A GitHub App so ElasticClaw can mint scoped installation tokens.
 3. A workspace that defines repos, instructions, tools, and model defaults.
 4. An issue source such as Linear, GitHub Issues, Shortcut, or a webhook.

--- a/aws/lambda-microvm/Dockerfile
+++ b/aws/lambda-microvm/Dockerfile
@@ -1,0 +1,32 @@
+# ElasticClaw agent image for AWS Lambda MicroVMs. The release artifact built
+# by `make build-lambda-microvm-artifact` places both Linux binaries next to
+# this Dockerfile before uploading the zip to S3.
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates curl git gnupg python3 sudo \
+    && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && npm install -g openclaw@2026.7.1-2 --ignore-scripts \
+    && useradd -m -s /bin/bash claw \
+    && echo 'claw ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers \
+    && rm -rf /var/lib/apt/lists/* /root/.npm
+
+COPY claw-bridge /usr/local/bin/claw-bridge
+COPY lambda-microvm-bridge /usr/local/bin/lambda-microvm-bridge
+RUN chmod 0755 /usr/local/bin/claw-bridge /usr/local/bin/lambda-microvm-bridge \
+    && mkdir -p /home/claw/workspace \
+    && chown -R claw:claw /home/claw
+
+ENV HOME=/home/claw
+ENV ELASTICCLAW_GATEWAY=localhost:18789
+ENV OPENCLAW_NO_RESPAWN=1
+ENV OPENCLAW_DISABLE_BONJOUR=1
+
+USER claw
+WORKDIR /home/claw
+EXPOSE 8080
+
+ENTRYPOINT ["/usr/local/bin/lambda-microvm-bridge"]

--- a/aws/lambda-microvm/README.md
+++ b/aws/lambda-microvm/README.md
@@ -1,0 +1,98 @@
+# AWS Lambda MicroVM provider
+
+This provider runs each ElasticClaw agent in a stateful, Firecracker-isolated AWS Lambda MicroVM. The image contains two processes:
+
+- `lambda-microvm-bridge` is snapshotted into the image, handles AWS lifecycle hooks and exposes the authenticated HTTPS control API on port 8080.
+- `claw-bridge` starts only after the Hub sends per-claw environment and workspace files through that control API. Secrets are not baked into the shared image or the AWS run-hook payload.
+
+The provider is alpha. Lambda MicroVMs currently supports sessions up to eight hours, and using the commands below creates billable AWS resources.
+
+## Prerequisites
+
+- AWS CLI v2 with the `lambda-microvms` command (v2.36 or newer).
+- AWS access to deploy CloudFormation/IAM/S3 resources, pass the generated build role to Lambda, and create or update a MicroVM image. The examples use `us-east-1`.
+- Hub credentials from the standard AWS credential chain. Prefer an IAM role. For local development, use a named profile or short-lived `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and optional `AWS_SESSION_TOKEN` values.
+
+The Hub operator needs these actions for runtime operation:
+
+```json
+[
+  "lambda:RunMicrovm",
+  "lambda:GetMicrovm",
+  "lambda:ListMicrovms",
+  "lambda:SuspendMicrovm",
+  "lambda:ResumeMicrovm",
+  "lambda:TerminateMicrovm",
+  "lambda:CreateMicrovmAuthToken"
+]
+```
+
+If an execution role is configured for agents, also allow the Hub identity to pass only that role with `iam:PassRole`.
+
+## One-time AWS setup
+
+Use AWS IAM Identity Center (SSO) for developers instead of distributing access keys:
+
+```bash
+aws configure sso --profile elasticclaw-dev
+aws sso login --profile elasticclaw-dev
+export AWS_PROFILE=elasticclaw-dev
+export AWS_REGION=us-east-1
+```
+
+Copy the environment template and inspect the read-only plan. The plan resolves your AWS account and prints deterministic resource names but does not create anything:
+
+```bash
+cp aws/lambda-microvm/aws.env.example aws/lambda-microvm/.env
+set -a
+. aws/lambda-microvm/.env
+set +a
+make setup-lambda-microvm
+```
+
+An AWS platform administrator or deployment role runs the apply target once:
+
+```bash
+make setup-lambda-microvm-apply
+```
+
+This deploys `bootstrap.yaml`, uploads the content-addressed image artifact, creates or updates the MicroVM image, waits for it to become `CREATED`, and writes an untracked provider fragment to `bin/lambda-microvm-provider.yaml`. The CloudFormation stack owns:
+
+- an encrypted, versioned, private S3 artifact bucket;
+- the Lambda-assumable image build role;
+- a least-privilege managed policy for Hub runtime operations.
+
+Set `AWS_LAMBDA_MICROVM_HUB_ROLE_NAME` before applying to attach that managed policy to an existing Hub role automatically. If the Hub runs outside AWS, leave it blank and arrange workload federation or an AWS profile separately. The script never writes AWS credentials to repository files.
+
+## Build and publish the image
+
+The one-time setup above also publishes the initial image. For later image-only releases, fill in the artifact S3 URI and build-role ARN in the ignored `.env`, then run:
+
+```bash
+cp aws/lambda-microvm/aws.env.example aws/lambda-microvm/.env
+set -a
+. aws/lambda-microvm/.env
+set +a
+
+make publish-lambda-microvm-image
+```
+
+The publish command uploads `bin/elasticclaw-lambda-microvm.zip` and starts the asynchronous image build with the lifecycle hooks required by ElasticClaw. It does not wait for completion. Check it with:
+
+```bash
+aws lambda-microvms get-microvm-image \
+  --region "$AWS_REGION" \
+  --image-identifier "$AWS_LAMBDA_MICROVM_IMAGE_NAME"
+```
+
+When the state becomes `CREATED`, copy the returned `imageArn` and `imageVersion` into the Hub settings UI or merge [hub.yaml.example](hub.yaml.example) into `~/.elasticclaw/hub.yaml`. The Hub process must be able to execute the same AWS CLI and access the same credential chain.
+
+## Credentials
+
+No new ElasticClaw-specific secret is required. Do not put AWS access keys in `hub.yaml`. Use one of:
+
+- an IAM role attached to the Hub workload (recommended);
+- `AWS_PROFILE` plus the normal AWS shared config files;
+- short-lived AWS environment credentials.
+
+The `.env` file in this directory is ignored by Git.

--- a/aws/lambda-microvm/aws.env.example
+++ b/aws/lambda-microvm/aws.env.example
@@ -1,0 +1,21 @@
+# The Hub uses the standard AWS credential chain. Prefer an IAM role when the
+# Hub runs on AWS. For local development, either set AWS_PROFILE or fill in the
+# short-lived credential variables below in an untracked .env file.
+AWS_REGION=us-east-1
+AWS_PROFILE=
+# Optional: when set, the setup command attaches its generated runtime policy
+# to this existing Hub IAM role.
+AWS_LAMBDA_MICROVM_HUB_ROLE_NAME=
+AWS_LAMBDA_MICROVM_STACK_NAME=elasticclaw-lambda-microvms
+AWS_LAMBDA_MICROVM_BUCKET=
+AWS_LAMBDA_MICROVM_IMAGE_NAME=elasticclaw-agent
+
+# Usually unnecessary with SSO or a workload role. If used, these must be
+# short-lived credentials in the ignored aws/lambda-microvm/.env file.
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_SESSION_TOKEN=
+
+# Required only by `make publish-lambda-microvm-image`.
+AWS_LAMBDA_MICROVM_ARTIFACT_URI=s3://replace-me/elasticclaw-lambda-microvm.zip
+AWS_LAMBDA_MICROVM_BUILD_ROLE_ARN=arn:aws:iam::123456789012:role/ElasticClawMicroVMBuildRole

--- a/aws/lambda-microvm/bootstrap.yaml
+++ b/aws/lambda-microvm/bootstrap.yaml
@@ -1,0 +1,124 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Shared AWS infrastructure for the ElasticClaw Lambda MicroVM provider
+
+Parameters:
+  ArtifactBucketName:
+    Type: String
+    Description: Globally unique S3 bucket used for versioned MicroVM image artifacts
+  ImageName:
+    Type: String
+    Default: elasticclaw-agent
+    AllowedPattern: "^[a-zA-Z0-9-_]+$"
+    MaxLength: 64
+
+Resources:
+  ArtifactBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      BucketName: !Ref ArtifactBucketName
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      VersioningConfiguration:
+        Status: Enabled
+      Tags:
+        - Key: elasticclaw
+          Value: lambda-microvms
+
+  ArtifactBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref ArtifactBucket
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: DenyInsecureTransport
+            Effect: Deny
+            Principal: "*"
+            Action: s3:*
+            Resource:
+              - !GetAtt ArtifactBucket.Arn
+              - !Sub "${ArtifactBucket.Arn}/*"
+            Condition:
+              Bool:
+                aws:SecureTransport: false
+
+  MicroVMBuildRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Description: Lambda-assumed role for building ElasticClaw MicroVM images
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+              - sts:TagSession
+      Policies:
+        - PolicyName: MicroVMImageBuild
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Sid: ReadArtifact
+                Effect: Allow
+                Action: s3:GetObject
+                Resource: !Sub "${ArtifactBucket.Arn}/artifacts/*"
+              - Sid: WriteBuildLogs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*"
+      Tags:
+        - Key: elasticclaw
+          Value: lambda-microvms
+
+  HubRuntimePolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: Least-privilege runtime access for an ElasticClaw Hub using one MicroVM image
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: OperateElasticClawMicroVMs
+            Effect: Allow
+            Action:
+              - lambda:RunMicrovm
+              - lambda:GetMicrovm
+              - lambda:SuspendMicrovm
+              - lambda:ResumeMicrovm
+              - lambda:TerminateMicrovm
+              - lambda:CreateMicrovmAuthToken
+              - lambda:GetMicrovmImage
+            Resource: !Sub "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:microvm-image:${ImageName}"
+          - Sid: ListMicroVMResources
+            Effect: Allow
+            Action:
+              - lambda:ListMicrovms
+              - lambda:ListMicrovmImages
+            Resource: "*"
+          - Sid: UseAWSManagedNetworkConnectors
+            Effect: Allow
+            Action: lambda:PassNetworkConnector
+            Resource: "*"
+
+Outputs:
+  ArtifactBucketName:
+    Value: !Ref ArtifactBucket
+  BuildRoleArn:
+    Value: !GetAtt MicroVMBuildRole.Arn
+  HubRuntimePolicyArn:
+    Value: !Ref HubRuntimePolicy
+  ImageArn:
+    Value: !Sub "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:microvm-image:${ImageName}"

--- a/aws/lambda-microvm/hub.yaml.example
+++ b/aws/lambda-microvm/hub.yaml.example
@@ -1,0 +1,19 @@
+providers:
+  lambda-microvms:
+    type: lambda-microvms
+    aws_region: us-east-1
+    # Omit aws_profile when the Hub uses environment credentials or an IAM role.
+    # aws_profile: elasticclaw-dev
+    image_identifier: arn:aws:lambda:us-east-1:123456789012:microvm-image:elasticclaw-agent
+    # Pin a version in production. Omit to use the latest active image version.
+    # image_version: "1.0"
+    ingress_network_connectors:
+      - arn:aws:lambda:us-east-1:aws:network-connector:aws-network-connector:ALL_INGRESS
+    egress_network_connectors:
+      - arn:aws:lambda:us-east-1:aws:network-connector:aws-network-connector:INTERNET_EGRESS
+    idle_max_duration_seconds: 900
+    suspended_duration_seconds: 300
+    auto_resume: true
+    maximum_duration_seconds: 28800
+    bridge_port: 8080
+    auth_token_expiration_minutes: 30

--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -3096,6 +3096,16 @@ func syncStagedWorkspaceToOpenClawWorkspace() error {
 	if err != nil {
 		return err
 	}
+	// OpenClaw attests the workspace created by `openclaw onboard`. ElasticClaw
+	// intentionally replaces the managed files in that workspace immediately
+	// afterwards, so the attestation no longer describes the on-disk contents.
+	// Leaving it behind makes OpenClaw treat the intentional sync as workspace
+	// loss and refuse the first agent turn. Removing the per-container
+	// attestation lets OpenClaw attest the staged workspace on first use.
+	attestationsDir := filepath.Join(home, ".openclaw", "workspace-attestations")
+	if err := os.RemoveAll(attestationsDir); err != nil {
+		return fmt.Errorf("remove stale OpenClaw workspace attestations: %w", err)
+	}
 	log.Printf("[bootstrap] synced %d staged workspace files into %s", copied, activeDir)
 
 	// Nix flakes require flake.nix/flake.lock to be tracked by git when the

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -503,6 +503,11 @@ func TestSyncStagedWorkspaceToOpenClawWorkspace(t *testing.T) {
 	write(filepath.Join(stagedDir, ".elasticclaw-workspace-ready"), "ready\n")
 	write(filepath.Join(activeDir, "BOOTSTRAP.md"), "Who am I? Who are you?\n")
 	write(filepath.Join(activeDir, "MEMORY.md"), "blank slate\n")
+	attestationPath := filepath.Join(home, ".openclaw", "workspace-attestations", "workspace.attested")
+	if err := os.MkdirAll(filepath.Dir(attestationPath), 0700); err != nil {
+		t.Fatalf("mkdir attestations: %v", err)
+	}
+	write(attestationPath, "stale\n")
 	if err := os.Symlink("/etc/passwd", filepath.Join(stagedDir, "passwd-link")); err != nil {
 		t.Fatalf("create symlink: %v", err)
 	}
@@ -537,6 +542,9 @@ func TestSyncStagedWorkspaceToOpenClawWorkspace(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(activeDir, "passwd-link")); !os.IsNotExist(err) {
 		t.Fatalf("symlink should not be copied, got err=%v", err)
+	}
+	if _, err := os.Stat(attestationPath); !os.IsNotExist(err) {
+		t.Fatalf("stale workspace attestation should be removed, got err=%v", err)
 	}
 }
 

--- a/cmd/lambda-microvm-bridge/main.go
+++ b/cmd/lambda-microvm-bridge/main.go
@@ -1,0 +1,394 @@
+// lambda-microvm-bridge adapts the AWS Lambda MicroVM HTTPS and lifecycle-hook
+// APIs to the ElasticClaw claw-bridge process. It is baked into the MicroVM
+// image and snapshotted before any per-claw credentials are supplied.
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+const (
+	defaultAddress   = ":8080"
+	defaultBridgeBin = "/usr/local/bin/claw-bridge"
+	defaultWorkspace = "/home/claw/workspace"
+	maxRequestBytes  = 16 << 20
+)
+
+type server struct {
+	bridgeBinary string
+	workspaceDir string
+
+	mu           sync.Mutex
+	bridge       *exec.Cmd
+	started      bool
+	bridgeExited bool
+	runtimeEnv   []string
+	microVMID    string
+}
+
+type lifecycleRequest struct {
+	MicroVMID      string `json:"microvmId"`
+	RunHookPayload string `json:"runHookPayload"`
+}
+
+type runPayload struct {
+	Version       int               `json:"version"`
+	Name          string            `json:"name"`
+	Env           map[string]string `json:"env"`
+	TemplateFiles map[string]string `json:"templateFiles"`
+	StateMount    string            `json:"stateMount"`
+}
+
+type execRequest struct {
+	Command []string `json:"command"`
+}
+
+type execResponse struct {
+	ExitCode int    `json:"ExitCode"`
+	Stdout   string `json:"Stdout"`
+	Stderr   string `json:"Stderr"`
+}
+
+type writeFileRequest struct {
+	Path    string `json:"path"`
+	Content string `json:"content"`
+}
+
+func main() {
+	s := &server{
+		bridgeBinary: envOrDefault("ELASTICCLAW_BRIDGE_BINARY", defaultBridgeBin),
+		workspaceDir: envOrDefault("ELASTICCLAW_WORKSPACE_DIR", defaultWorkspace),
+	}
+	address := envOrDefault("ELASTICCLAW_LAMBDA_BRIDGE_ADDR", defaultAddress)
+	log.Printf("lambda microvm bridge listening on %s", address)
+	if err := http.ListenAndServe(address, s.routes()); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func envOrDefault(name, fallback string) string {
+	if value := strings.TrimSpace(os.Getenv(name)); value != "" {
+		return value
+	}
+	return fallback
+}
+
+func (s *server) routes() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/aws/lambda-microvms/runtime/v1/ready", okHook)
+	mux.HandleFunc("/aws/lambda-microvms/runtime/v1/validate", okHook)
+	mux.HandleFunc("/aws/lambda-microvms/runtime/v1/resume", okHook)
+	mux.HandleFunc("/aws/lambda-microvms/runtime/v1/suspend", okHook)
+	mux.HandleFunc("/aws/lambda-microvms/runtime/v1/terminate", okHook)
+	mux.HandleFunc("/aws/lambda-microvms/runtime/v1/run", s.runHook)
+	mux.HandleFunc("/elasticclaw/v1/init", s.initialize)
+	mux.HandleFunc("/elasticclaw/v1/exec", s.exec)
+	mux.HandleFunc("/elasticclaw/v1/write-file", s.writeFile)
+	mux.HandleFunc("/healthz", s.health)
+	return http.MaxBytesHandler(mux, maxRequestBytes)
+}
+
+func okHook(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *server) runHook(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var lifecycle lifecycleRequest
+	if err := decodeJSON(r.Body, &lifecycle); err != nil {
+		http.Error(w, "invalid lifecycle payload: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	var payload runPayload
+	if err := json.Unmarshal([]byte(lifecycle.RunHookPayload), &payload); err != nil {
+		http.Error(w, "invalid run hook payload: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if payload.Version != 1 {
+		http.Error(w, fmt.Sprintf("unsupported run hook payload version %d", payload.Version), http.StatusBadRequest)
+		return
+	}
+	if payload.Env == nil {
+		payload.Env = map[string]string{}
+	}
+	s.mu.Lock()
+	s.microVMID = lifecycle.MicroVMID
+	s.mu.Unlock()
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *server) initialize(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var payload runPayload
+	if err := decodeJSON(r.Body, &payload); err != nil {
+		http.Error(w, "invalid initialization payload: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if payload.Version != 1 {
+		http.Error(w, fmt.Sprintf("unsupported initialization payload version %d", payload.Version), http.StatusBadRequest)
+		return
+	}
+	if payload.Env == nil {
+		payload.Env = map[string]string{}
+	}
+	s.mu.Lock()
+	microVMID := s.microVMID
+	s.mu.Unlock()
+	if microVMID != "" {
+		payload.Env["ELASTICCLAW_MICROVM_ID"] = microVMID
+	}
+	if err := s.startBridge(payload); err != nil {
+		log.Printf("initialization failed: %v", err)
+		http.Error(w, "failed to initialize ElasticClaw", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *server) startBridge(payload runPayload) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.started {
+		return nil
+	}
+	for name := range payload.Env {
+		if !validEnvName(name) {
+			return fmt.Errorf("invalid environment variable name %q", name)
+		}
+	}
+	if err := writeTemplateFiles(s.workspaceDir, payload.TemplateFiles); err != nil {
+		return err
+	}
+	cmd := exec.Command(s.bridgeBinary, "--bootstrap")
+	s.runtimeEnv = mergeEnv(os.Environ(), payload.Env)
+	cmd.Env = s.runtimeEnv
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = nil
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start claw-bridge: %w", err)
+	}
+	s.bridge = cmd
+	s.started = true
+	go func() {
+		if err := cmd.Wait(); err != nil {
+			log.Printf("claw-bridge exited: %v", err)
+		}
+		s.mu.Lock()
+		s.bridgeExited = true
+		s.mu.Unlock()
+	}()
+	return nil
+}
+
+func writeTemplateFiles(workspace string, files map[string]string) error {
+	if err := os.MkdirAll(workspace, 0755); err != nil {
+		return fmt.Errorf("create workspace: %w", err)
+	}
+	for _, name := range sortedKeys(files) {
+		rel, err := cleanRelativePath(name)
+		if err != nil {
+			return err
+		}
+		content, err := base64.StdEncoding.DecodeString(files[name])
+		if err != nil {
+			return fmt.Errorf("decode template file %q: %w", name, err)
+		}
+		destination := filepath.Join(workspace, rel)
+		if err := os.MkdirAll(filepath.Dir(destination), 0755); err != nil {
+			return fmt.Errorf("create template directory for %q: %w", name, err)
+		}
+		mode := os.FileMode(0644)
+		if strings.HasPrefix(rel, "scripts"+string(filepath.Separator)) {
+			mode = 0755
+		}
+		if err := os.WriteFile(destination, content, mode); err != nil {
+			return fmt.Errorf("write template file %q: %w", name, err)
+		}
+	}
+	readyPath := filepath.Join(workspace, ".elasticclaw-workspace-ready")
+	if err := os.WriteFile(readyPath, []byte("ready\n"), 0644); err != nil {
+		return fmt.Errorf("write workspace readiness marker: %w", err)
+	}
+	return nil
+}
+
+func cleanRelativePath(name string) (string, error) {
+	if name == "" || filepath.IsAbs(name) || strings.ContainsRune(name, '\x00') {
+		return "", fmt.Errorf("invalid template file path %q", name)
+	}
+	clean := filepath.Clean(name)
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("template file path escapes workspace: %q", name)
+	}
+	return clean, nil
+}
+
+func sortedKeys(values map[string]string) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func mergeEnv(base []string, overlay map[string]string) []string {
+	values := make(map[string]string, len(base)+len(overlay))
+	for _, item := range base {
+		if index := strings.IndexByte(item, '='); index > 0 {
+			values[item[:index]] = item[index+1:]
+		}
+	}
+	for key, value := range overlay {
+		if validEnvName(key) {
+			values[key] = value
+		}
+	}
+	keys := sortedKeys(values)
+	result := make([]string, 0, len(keys))
+	for _, key := range keys {
+		result = append(result, key+"="+values[key])
+	}
+	return result
+}
+
+func validEnvName(name string) bool {
+	if name == "" || !isEnvFirst(name[0]) {
+		return false
+	}
+	for i := 1; i < len(name); i++ {
+		if !isEnvFirst(name[i]) && (name[i] < '0' || name[i] > '9') {
+			return false
+		}
+	}
+	return true
+}
+
+func isEnvFirst(char byte) bool {
+	return char == '_' || char >= 'A' && char <= 'Z' || char >= 'a' && char <= 'z'
+}
+
+func (s *server) exec(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var request execRequest
+	if err := decodeJSON(r.Body, &request); err != nil || len(request.Command) == 0 {
+		http.Error(w, "command is required", http.StatusBadRequest)
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Minute)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, request.Command[0], request.Command[1:]...)
+	s.mu.Lock()
+	if s.runtimeEnv != nil {
+		cmd.Env = append([]string(nil), s.runtimeEnv...)
+	}
+	s.mu.Unlock()
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	response := execResponse{Stdout: stdout.String(), Stderr: stderr.String()}
+	if err != nil {
+		var exitError *exec.ExitError
+		if errors.As(err, &exitError) {
+			response.ExitCode = exitError.ExitCode()
+		} else {
+			response.ExitCode = 1
+			response.Stderr += err.Error()
+		}
+	}
+	writeJSON(w, response)
+}
+
+func (s *server) writeFile(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var request writeFileRequest
+	if err := decodeJSON(r.Body, &request); err != nil {
+		http.Error(w, "invalid request: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if !filepath.IsAbs(request.Path) || strings.ContainsRune(request.Path, '\x00') {
+		http.Error(w, "path must be absolute", http.StatusBadRequest)
+		return
+	}
+	content, err := base64.StdEncoding.DecodeString(request.Content)
+	if err != nil {
+		http.Error(w, "content must be base64 encoded", http.StatusBadRequest)
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(request.Path), 0755); err != nil {
+		http.Error(w, "create parent directory failed", http.StatusInternalServerError)
+		return
+	}
+	if err := os.WriteFile(request.Path, content, 0644); err != nil {
+		http.Error(w, "write failed", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *server) health(w http.ResponseWriter, _ *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	status := "ready"
+	if s.started {
+		status = "running"
+		if s.bridgeExited {
+			status = "bridge-exited"
+		}
+	}
+	writeJSON(w, map[string]string{"status": status})
+}
+
+func decodeJSON(reader io.Reader, target interface{}) error {
+	decoder := json.NewDecoder(reader)
+	decoder.DisallowUnknownFields()
+	return decoder.Decode(target)
+}
+
+func writeJSON(w http.ResponseWriter, value interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(value); err != nil {
+		log.Printf("encode response: %v", err)
+	}
+}
+
+func (s *server) shutdownBridge() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.bridge != nil && s.bridge.Process != nil && s.bridge.ProcessState == nil {
+		_ = s.bridge.Process.Signal(syscall.SIGTERM)
+	}
+}

--- a/cmd/lambda-microvm-bridge/main.go
+++ b/cmd/lambda-microvm-bridge/main.go
@@ -27,6 +27,7 @@ const (
 	defaultBridgeBin = "/usr/local/bin/claw-bridge"
 	defaultWorkspace = "/home/claw/workspace"
 	maxRequestBytes  = 16 << 20
+	bridgeStartGrace = 2 * time.Second
 )
 
 type server struct {
@@ -37,6 +38,7 @@ type server struct {
 	bridge       *exec.Cmd
 	started      bool
 	bridgeExited bool
+	startGrace   time.Duration
 	runtimeEnv   []string
 	microVMID    string
 }
@@ -194,15 +196,52 @@ func (s *server) startBridge(payload runPayload) error {
 		return fmt.Errorf("start claw-bridge: %w", err)
 	}
 	s.bridge = cmd
-	s.started = true
+	s.bridgeExited = false
+	exited := make(chan error, 1)
 	go func() {
-		if err := cmd.Wait(); err != nil {
+		err := cmd.Wait()
+		exited <- err
+		if err != nil {
 			log.Printf("claw-bridge exited: %v", err)
 		}
 		s.mu.Lock()
-		s.bridgeExited = true
+		if s.bridge == cmd {
+			s.started = false
+			s.bridgeExited = true
+		}
 		s.mu.Unlock()
 	}()
+	grace := s.startGrace
+	if grace <= 0 {
+		grace = bridgeStartGrace
+	}
+	timer := time.NewTimer(grace)
+	defer timer.Stop()
+	select {
+	case err := <-exited:
+		s.bridge = nil
+		s.started = false
+		s.bridgeExited = true
+		if err != nil {
+			return fmt.Errorf("claw-bridge exited during startup: %w", err)
+		}
+		return errors.New("claw-bridge exited during startup")
+	case <-timer.C:
+		// Prefer an exit that raced with the timer over reporting a dead bridge
+		// as initialized successfully.
+		select {
+		case err := <-exited:
+			s.bridge = nil
+			s.started = false
+			s.bridgeExited = true
+			if err != nil {
+				return fmt.Errorf("claw-bridge exited during startup: %w", err)
+			}
+			return errors.New("claw-bridge exited during startup")
+		default:
+		}
+	}
+	s.started = true
 	return nil
 }
 
@@ -365,9 +404,8 @@ func (s *server) health(w http.ResponseWriter, _ *http.Request) {
 	status := "ready"
 	if s.started {
 		status = "running"
-		if s.bridgeExited {
-			status = "bridge-exited"
-		}
+	} else if s.bridgeExited {
+		status = "bridge-exited"
 	}
 	writeJSON(w, map[string]string{"status": status})
 }

--- a/cmd/lambda-microvm-bridge/main_test.go
+++ b/cmd/lambda-microvm-bridge/main_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunHookStagesFilesAndStartsBridgeWithRuntimeEnv(t *testing.T) {
+	temp := t.TempDir()
+	bridge := filepath.Join(temp, "fake-claw-bridge")
+	started := filepath.Join(temp, "started")
+	script := "#!/bin/sh\nprintf '%s|%s|%s' \"$1\" \"$ELASTICCLAW_CLAW_ID\" \"$ELASTICCLAW_MICROVM_ID\" > \"$STARTED_FILE\"\n"
+	if err := os.WriteFile(bridge, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+	s := &server{bridgeBinary: bridge, workspaceDir: filepath.Join(temp, "workspace")}
+	payload, err := json.Marshal(runPayload{
+		Version: 1,
+		Env: map[string]string{
+			"ELASTICCLAW_CLAW_ID": "claw-123",
+			"STARTED_FILE":        started,
+		},
+		TemplateFiles: map[string]string{
+			"AGENTS.md": base64.StdEncoding.EncodeToString([]byte("instructions")),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	runPayload, err := json.Marshal(runPayload{Version: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := json.Marshal(lifecycleRequest{MicroVMID: "mvm-123", RunHookPayload: string(runPayload)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := httptest.NewRequest(http.MethodPost, "/aws/lambda-microvms/runtime/v1/run", bytes.NewReader(body))
+	response := httptest.NewRecorder()
+	s.routes().ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+	}
+	request = httptest.NewRequest(http.MethodPost, "/elasticclaw/v1/init", bytes.NewReader(payload))
+	response = httptest.NewRecorder()
+	s.routes().ServeHTTP(response, request)
+	if response.Code != http.StatusNoContent {
+		t.Fatalf("init status = %d, body = %s", response.Code, response.Body.String())
+	}
+	t.Cleanup(s.shutdownBridge)
+
+	file, err := os.ReadFile(filepath.Join(s.workspaceDir, "AGENTS.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(file) != "instructions" {
+		t.Fatalf("workspace file = %q", file)
+	}
+	if _, err := os.Stat(filepath.Join(s.workspaceDir, ".elasticclaw-workspace-ready")); err != nil {
+		t.Fatalf("workspace readiness marker: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		contents, readErr := os.ReadFile(started)
+		if got, want := string(contents), "--bootstrap|claw-123|mvm-123"; readErr == nil && got == want {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("bridge invocation = %q, error = %v, want %q", contents, readErr, "--bootstrap|claw-123|mvm-123")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestRunHookRejectsEscapingTemplatePath(t *testing.T) {
+	s := &server{bridgeBinary: "/does/not/matter", workspaceDir: t.TempDir()}
+	payload, err := json.Marshal(runPayload{
+		Version: 1,
+		TemplateFiles: map[string]string{
+			"../secret": base64.StdEncoding.EncodeToString([]byte("nope")),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := httptest.NewRequest(http.MethodPost, "/elasticclaw/v1/init", bytes.NewReader(payload))
+	response := httptest.NewRecorder()
+	s.routes().ServeHTTP(response, request)
+	if response.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+	}
+	if _, err := os.Stat(filepath.Join(s.workspaceDir, "..", "secret")); !os.IsNotExist(err) {
+		t.Fatalf("escaping file was created")
+	}
+}
+
+func TestExecUsesRuntimeEnvironment(t *testing.T) {
+	s := &server{runtimeEnv: mergeEnv(os.Environ(), map[string]string{"ELASTICCLAW_TEST_VALUE": "available"})}
+	body := `{"command":["sh","-c","printf %s \"$ELASTICCLAW_TEST_VALUE\""]}`
+	request := httptest.NewRequest(http.MethodPost, "/elasticclaw/v1/exec", strings.NewReader(body))
+	response := httptest.NewRecorder()
+	s.routes().ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+	}
+	var result execResponse
+	if err := json.Unmarshal(response.Body.Bytes(), &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.ExitCode != 0 || result.Stdout != "available" {
+		t.Fatalf("exec result = %+v", result)
+	}
+}
+
+func TestCleanRelativePath(t *testing.T) {
+	for _, path := range []string{"", "/etc/passwd", "../secret", "nested/../../secret"} {
+		if _, err := cleanRelativePath(path); err == nil {
+			t.Errorf("cleanRelativePath(%q) unexpectedly succeeded", path)
+		}
+	}
+	if got, err := cleanRelativePath("scripts/check.sh"); err != nil || got != filepath.Join("scripts", "check.sh") {
+		t.Fatalf("cleanRelativePath valid = %q, %v", got, err)
+	}
+}

--- a/cmd/lambda-microvm-bridge/main_test.go
+++ b/cmd/lambda-microvm-bridge/main_test.go
@@ -17,11 +17,11 @@ func TestRunHookStagesFilesAndStartsBridgeWithRuntimeEnv(t *testing.T) {
 	temp := t.TempDir()
 	bridge := filepath.Join(temp, "fake-claw-bridge")
 	started := filepath.Join(temp, "started")
-	script := "#!/bin/sh\nprintf '%s|%s|%s' \"$1\" \"$ELASTICCLAW_CLAW_ID\" \"$ELASTICCLAW_MICROVM_ID\" > \"$STARTED_FILE\"\n"
+	script := "#!/bin/sh\ntrap 'exit 0' TERM INT\nprintf '%s|%s|%s' \"$1\" \"$ELASTICCLAW_CLAW_ID\" \"$ELASTICCLAW_MICROVM_ID\" > \"$STARTED_FILE\"\nwhile :; do sleep 1; done\n"
 	if err := os.WriteFile(bridge, []byte(script), 0755); err != nil {
 		t.Fatal(err)
 	}
-	s := &server{bridgeBinary: bridge, workspaceDir: filepath.Join(temp, "workspace")}
+	s := &server{bridgeBinary: bridge, workspaceDir: filepath.Join(temp, "workspace"), startGrace: 50 * time.Millisecond}
 	payload, err := json.Marshal(runPayload{
 		Version: 1,
 		Env: map[string]string{
@@ -78,6 +78,54 @@ func TestRunHookStagesFilesAndStartsBridgeWithRuntimeEnv(t *testing.T) {
 			t.Fatalf("bridge invocation = %q, error = %v, want %q", contents, readErr, "--bootstrap|claw-123|mvm-123")
 		}
 		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestInitializeRejectsDeadBridgeAndAllowsRetry(t *testing.T) {
+	temp := t.TempDir()
+	bridge := filepath.Join(temp, "fake-claw-bridge")
+	attempts := filepath.Join(temp, "attempts")
+	script := "#!/bin/sh\nprintf 'attempt\\n' >> \"$ATTEMPTS_FILE\"\nexit 42\n"
+	if err := os.WriteFile(bridge, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+	s := &server{
+		bridgeBinary: bridge,
+		workspaceDir: filepath.Join(temp, "workspace"),
+		startGrace:   500 * time.Millisecond,
+	}
+	payload, err := json.Marshal(runPayload{
+		Version: 1,
+		Env: map[string]string{
+			"ATTEMPTS_FILE": attempts,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for attempt := 1; attempt <= 2; attempt++ {
+		request := httptest.NewRequest(http.MethodPost, "/elasticclaw/v1/init", bytes.NewReader(payload))
+		response := httptest.NewRecorder()
+		s.routes().ServeHTTP(response, request)
+		if response.Code != http.StatusInternalServerError {
+			t.Fatalf("attempt %d status = %d, body = %s", attempt, response.Code, response.Body.String())
+		}
+	}
+
+	contents, err := os.ReadFile(attempts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Count(string(contents), "attempt\n"); got != 2 {
+		t.Fatalf("bridge starts = %d, want 2", got)
+	}
+
+	s.mu.Lock()
+	started, exited := s.started, s.bridgeExited
+	s.mu.Unlock()
+	if started || !exited {
+		t.Fatalf("bridge state after failed retry = started %v, exited %v", started, exited)
 	}
 }
 

--- a/cmd/provider.go
+++ b/cmd/provider.go
@@ -45,6 +45,11 @@ func runProviderList(cmd *cobra.Command, args []string) error {
 			Type:         types.ProviderTypeStateful,
 			Capabilities: []string{"exec", "ssh"},
 		},
+		{
+			Name:         "lambda-microvms",
+			Type:         types.ProviderTypeStateful,
+			Capabilities: []string{"alpha", "stateful", "https-bridge"},
+		},
 	}
 
 	if jsonOut {

--- a/pkg/hub/bootstrap.go
+++ b/pkg/hub/bootstrap.go
@@ -383,11 +383,10 @@ process.stdin.on("end", () => {
 '`
 }
 
-// buildOpenClawCodexOAuthAuthSyncShell verifies that OpenClaw discovers the
-// restored Codex CLI credential as its canonical OpenAI auth profile. The
-// current OpenClaw runtime reads openai:default from ~/.codex/auth.json, so this
-// deliberately uses the supported CLI path instead of writing the SQLite store
-// directly.
+// buildOpenClawCodexOAuthAuthSyncShell imports the restored Codex CLI credential
+// through OpenClaw's Codex migration provider. OpenClaw assigns an
+// account-scoped profile ID during this import, so callers must not assume the
+// legacy openai:default profile name.
 func buildOpenClawCodexOAuthAuthSyncShell() string {
 	return `set -euo pipefail
 node <<'NODE'
@@ -402,6 +401,13 @@ if (!tokens || typeof tokens.access_token !== 'string' || !tokens.access_token |
   throw new Error('restored Codex OAuth credential is missing access or refresh token');
 }
 NODE
+openclaw migrate apply codex \
+  --from "$HOME/.codex" \
+  --include-secrets \
+  --yes \
+  --no-backup \
+  --force \
+  --json >/dev/null
 openclaw models auth list --provider openai --json | node -e '
 let input = "";
 process.stdin.setEncoding("utf8");
@@ -409,13 +415,13 @@ process.stdin.on("data", (chunk) => { input += chunk; });
 process.stdin.on("end", () => {
   const result = JSON.parse(input);
   if (!Array.isArray(result.profiles) || !result.profiles.some((profile) =>
-    profile.id === "openai:default" && profile.type === "oauth"
+    typeof profile.id === "string" && profile.id.startsWith("openai:") &&
+    profile.type === "oauth" && (!profile.provider || profile.provider === "openai")
   )) {
-    throw new Error("OpenClaw did not discover the restored Codex OAuth profile");
+    throw new Error("OpenClaw did not import the restored Codex OAuth profile");
   }
 });
-'
-openclaw config set 'auth.profiles["openai:default"]' '{"provider":"openai","mode":"oauth"}' --strict-json >/dev/null`
+'`
 }
 
 // GenerateReplicatedBootstrapScript returns a minimal bash script that downloads

--- a/pkg/hub/bootstrap_test.go
+++ b/pkg/hub/bootstrap_test.go
@@ -660,8 +660,10 @@ func TestBuildOpenClawOAuthAuthSyncShellDiscoversCodexOAuth(t *testing.T) {
 	shell := buildOpenClawOAuthAuthSyncShell(types.LLMKeysList{
 		{Name: "codex-main", Provider: "codex", AuthProfile: "codex-oauth", Default: true},
 	}, "codex-main")
+	assertContains(t, shell, "migrate apply codex", "imports Codex OAuth through the supported migration provider")
+	assertContains(t, shell, "--include-secrets", "selects the restored Codex credential for import")
 	assertContains(t, shell, "models auth list --provider openai --json", "discovers Codex OAuth through OpenClaw")
-	assertContains(t, shell, `auth.profiles["openai:default"]`, "sets canonical OpenAI profile metadata")
+	assertNotContains(t, shell, `auth.profiles["openai:default"]`, "does not assume a legacy fixed profile ID")
 	assertNotContains(t, shell, "auth_profile_store", "does not manipulate the OpenClaw auth database directly")
 
 	home := t.TempDir()
@@ -680,7 +682,7 @@ func TestBuildOpenClawOAuthAuthSyncShellDiscoversCodexOAuth(t *testing.T) {
 	fakeOpenClawScript := `#!/bin/sh
 printf '%s\n' "$*" >> "$OPENCLAW_INVOCATIONS"
 if [ "$*" = "models auth list --provider openai --json" ]; then
-  printf '%s\n' '{"profiles":[{"id":"openai:default","type":"oauth"}]}'
+  printf '%s\n' '{"profiles":[{"id":"openai:account-test","type":"oauth","provider":"openai"}]}'
 fi
 `
 	if err := os.WriteFile(fakeOpenClaw, []byte(fakeOpenClawScript), 0755); err != nil {
@@ -700,8 +702,8 @@ fi
 		t.Fatalf("read fake OpenClaw invocations: %v", err)
 	}
 	invocationLog := string(invocations)
+	assertContains(t, invocationLog, "migrate apply codex --from "+filepath.Join(home, ".codex")+" --include-secrets --yes --no-backup --force --json", "imports the restored Codex profile")
 	assertContains(t, invocationLog, "models auth list --provider openai --json", "verifies the discovered profile")
-	assertContains(t, invocationLog, `config set auth.profiles["openai:default"] {"provider":"openai","mode":"oauth"} --strict-json`, "configures profile metadata")
 }
 
 func TestBuildOpenClawOAuthAuthSyncShellRejectsIncompleteCodexOAuth(t *testing.T) {

--- a/pkg/provider/lambdamicrovms/lambdamicrovms.go
+++ b/pkg/provider/lambdamicrovms/lambdamicrovms.go
@@ -85,11 +85,25 @@ func New(cfg Config) (*Provider, error) {
 	if cfg.BridgePort == 0 {
 		cfg.BridgePort = DefaultBridgePort
 	}
+	if cfg.BridgePort < 1 || cfg.BridgePort > 65535 {
+		return nil, fmt.Errorf("lambda microvms bridge_port must be between 1 and 65535")
+	}
 	if cfg.TokenExpirationMinutes == 0 {
 		cfg.TokenExpirationMinutes = DefaultTokenExpirationMinutes
 	}
+	if cfg.TokenExpirationMinutes < 1 || cfg.TokenExpirationMinutes > 60 {
+		return nil, fmt.Errorf("lambda microvms auth_token_expiration_minutes must be between 1 and 60")
+	}
 	if cfg.MaximumDurationSeconds == 0 {
 		cfg.MaximumDurationSeconds = DefaultMaximumDurationSeconds
+	}
+	if cfg.MaximumDurationSeconds < 1 || cfg.MaximumDurationSeconds > DefaultMaximumDurationSeconds {
+		return nil, fmt.Errorf("lambda microvms maximum_duration_seconds must be between 1 and %d", DefaultMaximumDurationSeconds)
+	}
+	if cfg.IdleMaxDurationSeconds > 0 || cfg.SuspendedDurationSeconds > 0 || cfg.AutoResume != nil {
+		if cfg.IdleMaxDurationSeconds < 60 || cfg.AutoResume == nil {
+			return nil, fmt.Errorf("lambda microvms idle policy requires idle_max_duration_seconds >= 60 and auto_resume")
+		}
 	}
 	return &Provider{cfg: cfg, http: &http.Client{Timeout: 60 * time.Second}}, nil
 }
@@ -103,11 +117,15 @@ func (p *Provider) Info() types.ProviderInfo {
 }
 
 func (p *Provider) Create(ctx context.Context, req types.CreateRequest) (*types.Instance, error) {
-	payload, err := buildRunHookPayload(req)
+	initializationPayload, err := buildInitializationPayload(req)
 	if err != nil {
 		return nil, err
 	}
-	payloadArg, cleanup, err := writeRunHookPayloadFile(payload)
+	runPayload, err := json.Marshal(runHookPayload{Version: 1, Name: req.Name})
+	if err != nil {
+		return nil, fmt.Errorf("marshal run hook payload: %w", err)
+	}
+	payloadArg, cleanup, err := writeRunHookPayloadFile(string(runPayload))
 	if err != nil {
 		return nil, err
 	}
@@ -126,6 +144,10 @@ func (p *Provider) Create(ctx context.Context, req types.CreateRequest) (*types.
 	}
 	if resp.MicroVMID == "" {
 		return nil, fmt.Errorf("run microvm response missing microvmId")
+	}
+	if err := p.initialize(ctx, resp.MicroVMID, resp.Endpoint, initializationPayload); err != nil {
+		_, _ = p.aws(context.Background(), "lambda-microvms", "terminate-microvm", "--microvm-identifier", resp.MicroVMID)
+		return nil, fmt.Errorf("initialize microvm: %w", err)
 	}
 	return &types.Instance{
 		Name:      req.Name,
@@ -169,10 +191,15 @@ func (p *Provider) Connect(ctx context.Context, instanceID string) (*types.Conne
 		return nil, err
 	}
 	return &types.ConnectInfo{
-		Web: "https://" + vm.Endpoint,
+		Web: endpointURL(vm.Endpoint, "/"),
 		Shell: &types.ShellConnect{
 			Command: "aws",
-			Args:    append(p.awsBaseArgs(), "lambda-microvms", "create-microvm-auth-token", "--microvm-identifier", instanceID),
+			Args: append(p.awsBaseArgs(),
+				"lambda-microvms", "create-microvm-auth-token",
+				"--microvm-identifier", instanceID,
+				"--expiration-in-minutes", strconv.Itoa(p.cfg.TokenExpirationMinutes),
+				"--allowed-ports", fmt.Sprintf(`[{"port":%d}]`, p.cfg.BridgePort),
+			),
 		},
 	}, nil
 }
@@ -200,14 +227,18 @@ func (p *Provider) List(ctx context.Context) ([]*types.Instance, error) {
 	if err != nil {
 		return nil, err
 	}
+	return parseListMicroVMs(out)
+}
+
+func parseListMicroVMs(data []byte) ([]*types.Instance, error) {
 	var resp struct {
-		MicroVMs []getMicroVMResponse `json:"microvms"`
+		Items []getMicroVMResponse `json:"items"`
 	}
-	if err := json.Unmarshal(out, &resp); err != nil {
+	if err := json.Unmarshal(data, &resp); err != nil {
 		return nil, fmt.Errorf("parse list microvms response: %w", err)
 	}
-	instances := make([]*types.Instance, 0, len(resp.MicroVMs))
-	for _, vm := range resp.MicroVMs {
+	instances := make([]*types.Instance, 0, len(resp.Items))
+	for _, vm := range resp.Items {
 		instances = append(instances, &types.Instance{
 			ID:       vm.MicroVMID,
 			Name:     vm.MicroVMID,
@@ -221,7 +252,7 @@ func (p *Provider) List(ctx context.Context) ([]*types.Instance, error) {
 	return instances, nil
 }
 
-func buildRunHookPayload(req types.CreateRequest) (string, error) {
+func buildInitializationPayload(req types.CreateRequest) (string, error) {
 	files := make(map[string]string, len(req.TemplateFiles))
 	for path, content := range req.TemplateFiles {
 		files[path] = base64.StdEncoding.EncodeToString(content)
@@ -237,8 +268,8 @@ func buildRunHookPayload(req types.CreateRequest) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if len(data) > 16*1024 {
-		return "", fmt.Errorf("lambda microvms run hook payload exceeds 16KiB")
+	if len(data) > 16*1024*1024 {
+		return "", fmt.Errorf("lambda microvms initialization payload exceeds 16MiB")
 	}
 	return string(data), nil
 }
@@ -287,15 +318,10 @@ func (p *Provider) runMicroVMArgs(runHookPayloadArg string) ([]string, error) {
 		args = append(args, p.cfg.EgressNetworkConnectors...)
 	}
 	if p.cfg.IdleMaxDurationSeconds > 0 || p.cfg.SuspendedDurationSeconds > 0 || p.cfg.AutoResume != nil {
-		idle := map[string]interface{}{}
-		if p.cfg.IdleMaxDurationSeconds > 0 {
-			idle["maxIdleDurationSeconds"] = p.cfg.IdleMaxDurationSeconds
-		}
-		if p.cfg.SuspendedDurationSeconds > 0 {
-			idle["suspendedDurationSeconds"] = p.cfg.SuspendedDurationSeconds
-		}
-		if p.cfg.AutoResume != nil {
-			idle["autoResumeEnabled"] = *p.cfg.AutoResume
+		idle := map[string]interface{}{
+			"maxIdleDurationSeconds":   p.cfg.IdleMaxDurationSeconds,
+			"suspendedDurationSeconds": p.cfg.SuspendedDurationSeconds,
+			"autoResumeEnabled":        *p.cfg.AutoResume,
 		}
 		data, err := json.Marshal(idle)
 		if err != nil {
@@ -352,6 +378,37 @@ func (p *Provider) bridgeJSON(ctx context.Context, instanceID, method, path stri
 	if err != nil {
 		return err
 	}
+	return p.bridgeJSONAtEndpoint(ctx, instanceID, vm.Endpoint, method, path, body, out)
+}
+
+func (p *Provider) initialize(ctx context.Context, instanceID, endpoint, payload string) error {
+	initCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+	var lastErr error
+	for {
+		if strings.TrimSpace(endpoint) == "" {
+			vm, getErr := p.get(initCtx, instanceID)
+			if getErr != nil {
+				lastErr = getErr
+			} else {
+				endpoint = vm.Endpoint
+			}
+		}
+		if strings.TrimSpace(endpoint) != "" {
+			lastErr = p.bridgeJSONAtEndpoint(initCtx, instanceID, endpoint, http.MethodPost, "/elasticclaw/v1/init", json.RawMessage(payload), nil)
+			if lastErr == nil {
+				return nil
+			}
+		}
+		select {
+		case <-initCtx.Done():
+			return fmt.Errorf("bridge did not become ready: %w", lastErr)
+		case <-time.After(2 * time.Second):
+		}
+	}
+}
+
+func (p *Provider) bridgeJSONAtEndpoint(ctx context.Context, instanceID, endpoint, method, path string, body interface{}, out interface{}) error {
 	token, err := p.authToken(ctx, instanceID)
 	if err != nil {
 		return err
@@ -362,7 +419,7 @@ func (p *Provider) bridgeJSON(ctx context.Context, instanceID, method, path stri
 			return err
 		}
 	}
-	req, err := http.NewRequestWithContext(ctx, method, "https://"+vm.Endpoint+path, &buf)
+	req, err := http.NewRequestWithContext(ctx, method, endpointURL(endpoint, path), &buf)
 	if err != nil {
 		return err
 	}
@@ -390,6 +447,14 @@ func (p *Provider) bridgeJSON(ctx context.Context, instanceID, method, path stri
 		}
 	}
 	return nil
+}
+
+func endpointURL(endpoint, requestPath string) string {
+	base := strings.TrimRight(strings.TrimSpace(endpoint), "/")
+	if !strings.HasPrefix(base, "https://") && !strings.HasPrefix(base, "http://") {
+		base = "https://" + base
+	}
+	return base + "/" + strings.TrimLeft(requestPath, "/")
 }
 
 func (p *Provider) aws(ctx context.Context, args ...string) ([]byte, error) {

--- a/pkg/provider/lambdamicrovms/lambdamicrovms_test.go
+++ b/pkg/provider/lambdamicrovms/lambdamicrovms_test.go
@@ -84,8 +84,8 @@ func TestWriteRunHookPayloadFileKeepsPayloadOutOfArgs(t *testing.T) {
 	}
 }
 
-func TestBuildRunHookPayloadEncodesTemplateFiles(t *testing.T) {
-	payload, err := buildRunHookPayload(types.CreateRequest{
+func TestBuildInitializationPayloadEncodesTemplateFiles(t *testing.T) {
+	payload, err := buildInitializationPayload(types.CreateRequest{
 		Name: "ec-test",
 		Env:  map[string]string{"ELASTICCLAW_CLAW_ID": "claw-1"},
 		TemplateFiles: map[string][]byte{
@@ -104,14 +104,54 @@ func TestBuildRunHookPayloadEncodesTemplateFiles(t *testing.T) {
 	}
 }
 
-func TestBuildRunHookPayloadRejectsOversizedPayload(t *testing.T) {
-	_, err := buildRunHookPayload(types.CreateRequest{
+func TestBuildInitializationPayloadRejectsOversizedPayload(t *testing.T) {
+	_, err := buildInitializationPayload(types.CreateRequest{
 		Name: "ec-test",
 		TemplateFiles: map[string][]byte{
-			"large.txt": []byte(strings.Repeat("x", 17*1024)),
+			"large.txt": []byte(strings.Repeat("x", 17*1024*1024)),
 		},
 	})
-	if err == nil || !strings.Contains(err.Error(), "exceeds 16KiB") {
+	if err == nil || !strings.Contains(err.Error(), "exceeds 16MiB") {
 		t.Fatalf("err = %v, want payload size error", err)
+	}
+}
+
+func TestParseListMicroVMsUsesAWSItemsField(t *testing.T) {
+	instances, err := parseListMicroVMs([]byte(`{"items":[{"microvmId":"mvm-1","state":"RUNNING"}]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(instances) != 1 || instances[0].ID != "mvm-1" || instances[0].Status != types.StatusRunning {
+		t.Fatalf("instances = %#v", instances)
+	}
+}
+
+func TestEndpointURLAcceptsHostOrURL(t *testing.T) {
+	for _, test := range []struct{ endpoint, path, want string }{
+		{"mvm.example.aws", "/healthz", "https://mvm.example.aws/healthz"},
+		{"https://mvm.example.aws/", "elasticclaw/v1/init", "https://mvm.example.aws/elasticclaw/v1/init"},
+	} {
+		if got := endpointURL(test.endpoint, test.path); got != test.want {
+			t.Errorf("endpointURL(%q, %q) = %q, want %q", test.endpoint, test.path, got, test.want)
+		}
+	}
+}
+
+func TestNewValidatesAWSLimits(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		cfg  Config
+		want string
+	}{
+		{"bridge port", Config{ImageIdentifier: "image", BridgePort: 70000}, "bridge_port"},
+		{"token expiration", Config{ImageIdentifier: "image", TokenExpirationMinutes: 61}, "auth_token_expiration_minutes"},
+		{"maximum duration", Config{ImageIdentifier: "image", MaximumDurationSeconds: 28801}, "maximum_duration_seconds"},
+		{"partial idle policy", Config{ImageIdentifier: "image", IdleMaxDurationSeconds: 900}, "idle policy"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := New(test.cfg); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("New() error = %v, want %q", err, test.want)
+			}
+		})
 	}
 }

--- a/scripts/publish-lambda-microvm-image.sh
+++ b/scripts/publish-lambda-microvm-image.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+artifact="${ELASTICCLAW_LAMBDA_MICROVM_ARTIFACT:-bin/elasticclaw-lambda-microvm.zip}"
+region="${AWS_REGION:-${AWS_DEFAULT_REGION:-us-east-1}}"
+artifact_uri="${AWS_LAMBDA_MICROVM_ARTIFACT_URI:-}"
+build_role_arn="${AWS_LAMBDA_MICROVM_BUILD_ROLE_ARN:-}"
+image_name="${AWS_LAMBDA_MICROVM_IMAGE_NAME:-elasticclaw-agent}"
+base_image_arn="${AWS_LAMBDA_MICROVM_BASE_IMAGE_ARN:-arn:aws:lambda:${region}:aws:microvm-image:al2023-1}"
+wait_for_image="${AWS_LAMBDA_MICROVM_WAIT:-0}"
+
+command -v aws >/dev/null 2>&1 || { echo "aws is required" >&2; exit 1; }
+test -f "$artifact" || { echo "$artifact is missing; run make build-lambda-microvm-artifact" >&2; exit 1; }
+test -n "$artifact_uri" || { echo "AWS_LAMBDA_MICROVM_ARTIFACT_URI is required" >&2; exit 1; }
+test -n "$build_role_arn" || { echo "AWS_LAMBDA_MICROVM_BUILD_ROLE_ARN is required" >&2; exit 1; }
+
+export AWS_PAGER=""
+aws lambda-microvms help >/dev/null
+caller_arn="$(aws sts get-caller-identity --region "$region" --query Arn --output text)"
+account_id="$(aws sts get-caller-identity --region "$region" --query Account --output text)"
+partition="${caller_arn#arn:}"
+partition="${partition%%:*}"
+image_identifier="arn:${partition}:lambda:${region}:${account_id}:microvm-image:${image_name}"
+aws s3 cp "$artifact" "$artifact_uri" --region "$region"
+hooks='{"port":8080,"microvmHooks":{"run":"ENABLED","runTimeoutInSeconds":60,"resume":"ENABLED","resumeTimeoutInSeconds":30,"suspend":"ENABLED","suspendTimeoutInSeconds":30,"terminate":"ENABLED","terminateTimeoutInSeconds":30},"microvmImageHooks":{"ready":"ENABLED","readyTimeoutInSeconds":300,"validate":"ENABLED","validateTimeoutInSeconds":300}}'
+client_token="elasticclaw-$(sha256sum "$artifact" | awk '{print $1}')"
+
+common_args=(
+  --region "$region"
+  --code-artifact "uri=$artifact_uri"
+  --base-image-arn "$base_image_arn"
+  --build-role-arn "$build_role_arn"
+  --hooks "$hooks"
+  --client-token "$client_token"
+  --output json
+)
+
+get_error="$(mktemp)"
+trap 'rm -f "$get_error"' EXIT
+if aws lambda-microvms get-microvm-image --region "$region" --image-identifier "$image_identifier" >/dev/null 2>"$get_error"; then
+  echo "Updating Lambda MicroVM image $image_name"
+  aws lambda-microvms update-microvm-image \
+    --image-identifier "$image_identifier" \
+    "${common_args[@]}"
+elif grep -Eqi 'ResourceNotFound|not found|does not exist' "$get_error"; then
+  echo "Creating Lambda MicroVM image $image_name"
+  aws lambda-microvms create-microvm-image \
+    --name "$image_name" \
+    --tags 'elasticclaw=agent-provider' \
+    "${common_args[@]}"
+else
+  echo "Unable to check whether Lambda MicroVM image $image_name exists:" >&2
+  sed 's/^/  /' "$get_error" >&2
+  exit 1
+fi
+
+if [[ "$wait_for_image" == "1" ]]; then
+  echo "Waiting for Lambda MicroVM image build..."
+  for attempt in $(seq 1 120); do
+    state="$(aws lambda-microvms get-microvm-image --region "$region" --image-identifier "$image_identifier" --query state --output text)"
+    case "$state" in
+      CREATED|UPDATED)
+        aws lambda-microvms get-microvm-image --region "$region" --image-identifier "$image_identifier" --output json
+        exit 0
+        ;;
+      CREATE_FAILED|UPDATE_FAILED)
+        echo "Lambda MicroVM image build failed; inspect /aws/lambda/microvms/$image_name in CloudWatch Logs" >&2
+        exit 1
+        ;;
+    esac
+    sleep 10
+  done
+  echo "Timed out waiting for Lambda MicroVM image $image_name" >&2
+  exit 1
+fi

--- a/scripts/setup-lambda-microvm.sh
+++ b/scripts/setup-lambda-microvm.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+apply=false
+if [[ "${1:-}" == "--apply" ]]; then
+  apply=true
+elif [[ $# -gt 0 ]]; then
+  echo "usage: $0 [--apply]" >&2
+  exit 2
+fi
+
+region="${AWS_REGION:-${AWS_DEFAULT_REGION:-us-east-1}}"
+stack_name="${AWS_LAMBDA_MICROVM_STACK_NAME:-elasticclaw-lambda-microvms}"
+image_name="${AWS_LAMBDA_MICROVM_IMAGE_NAME:-elasticclaw-agent}"
+artifact="${ELASTICCLAW_LAMBDA_MICROVM_ARTIFACT:-bin/elasticclaw-lambda-microvm.zip}"
+template="aws/lambda-microvm/bootstrap.yaml"
+output_config="${ELASTICCLAW_LAMBDA_MICROVM_CONFIG_OUTPUT:-bin/lambda-microvm-provider.yaml}"
+hub_role_name="${AWS_LAMBDA_MICROVM_HUB_ROLE_NAME:-}"
+
+command -v aws >/dev/null 2>&1 || { echo "aws CLI v2 is required" >&2; exit 1; }
+test -f "$template" || { echo "$template is missing" >&2; exit 1; }
+test -f "$artifact" || { echo "$artifact is missing; run make build-lambda-microvm-artifact" >&2; exit 1; }
+
+export AWS_PAGER=""
+aws lambda-microvms help >/dev/null
+account_id="$(aws sts get-caller-identity --query Account --output text --region "$region")"
+bucket_name="${AWS_LAMBDA_MICROVM_BUCKET:-elasticclaw-microvms-${account_id}-${region}}"
+
+echo "AWS account: $account_id"
+echo "Region:      $region"
+echo "Stack:       $stack_name"
+echo "Bucket:      $bucket_name"
+echo "Image:       $image_name"
+
+if [[ "$apply" != true ]]; then
+  echo
+  echo "Plan only; no AWS resources were changed."
+  echo "Run 'make setup-lambda-microvm-apply' to deploy the stack, upload the artifact, and create or update the image."
+  exit 0
+fi
+
+aws cloudformation deploy \
+  --region "$region" \
+  --stack-name "$stack_name" \
+  --template-file "$template" \
+  --capabilities CAPABILITY_IAM \
+  --parameter-overrides \
+    "ArtifactBucketName=$bucket_name" \
+    "ImageName=$image_name" \
+  --tags elasticclaw=lambda-microvms
+
+stack_output() {
+  aws cloudformation describe-stacks \
+    --region "$region" \
+    --stack-name "$stack_name" \
+    --query "Stacks[0].Outputs[?OutputKey=='$1'].OutputValue | [0]" \
+    --output text
+}
+
+build_role_arn="$(stack_output BuildRoleArn)"
+runtime_policy_arn="$(stack_output HubRuntimePolicyArn)"
+image_arn="$(stack_output ImageArn)"
+artifact_hash="$(sha256sum "$artifact" | awk '{print $1}')"
+artifact_uri="s3://${bucket_name}/artifacts/elasticclaw-lambda-microvm-${artifact_hash}.zip"
+
+AWS_LAMBDA_MICROVM_ARTIFACT_URI="$artifact_uri" \
+AWS_LAMBDA_MICROVM_BUILD_ROLE_ARN="$build_role_arn" \
+AWS_LAMBDA_MICROVM_IMAGE_NAME="$image_name" \
+AWS_LAMBDA_MICROVM_WAIT=1 \
+AWS_REGION="$region" \
+  bash scripts/publish-lambda-microvm-image.sh
+
+if [[ -n "$hub_role_name" ]]; then
+  echo "Attaching the Hub runtime policy to IAM role $hub_role_name"
+  aws iam attach-role-policy \
+    --role-name "$hub_role_name" \
+    --policy-arn "$runtime_policy_arn"
+fi
+
+mkdir -p "$(dirname "$output_config")"
+umask 077
+{
+  echo "providers:"
+  echo "  lambda-microvms:"
+  echo "    type: lambda-microvms"
+  echo "    aws_region: $region"
+  echo "    image_identifier: $image_arn"
+  echo "    ingress_network_connectors:"
+  echo "      - arn:aws:lambda:${region}:aws:network-connector:aws-network-connector:ALL_INGRESS"
+  echo "    egress_network_connectors:"
+  echo "      - arn:aws:lambda:${region}:aws:network-connector:aws-network-connector:INTERNET_EGRESS"
+  echo "    idle_max_duration_seconds: 900"
+  echo "    suspended_duration_seconds: 300"
+  echo "    auto_resume: true"
+  echo "    maximum_duration_seconds: 28800"
+  echo "    bridge_port: 8080"
+  echo "    auth_token_expiration_minutes: 30"
+} > "$output_config"
+
+echo
+echo "AWS setup complete."
+echo "Hub runtime policy: $runtime_policy_arn"
+if [[ -z "$hub_role_name" ]]; then
+  echo "Attach that policy to the IAM role used by the ElasticClaw Hub, or set AWS_LAMBDA_MICROVM_HUB_ROLE_NAME and rerun apply."
+fi
+echo "Merge $output_config into the Hub's protected hub.yaml, then restart the Hub."

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -514,6 +514,23 @@ const SANDBOX_PROVIDER_OPTIONS = [
   { value: "lambda-microvms", label: "AWS Lambda MicroVMs", description: "Serverless Firecracker MicroVM provider", alpha: true },
 ]
 
+const LAMBDA_MICROVM_DEFAULT_REGION = "us-east-1"
+const LAMBDA_MICROVM_DEFAULTS = {
+  idleMaxDuration: "900",
+  suspendedDuration: "300",
+  maximumDuration: "28800",
+  bridgePort: "8080",
+  authTokenExpiration: "30",
+}
+
+function lambdaMicroVMConnectors(region: string) {
+  const resolvedRegion = region.trim() || LAMBDA_MICROVM_DEFAULT_REGION
+  return {
+    ingress: `arn:aws:lambda:${resolvedRegion}:aws:network-connector:aws-network-connector:ALL_INGRESS`,
+    egress: `arn:aws:lambda:${resolvedRegion}:aws:network-connector:aws-network-connector:INTERNET_EGRESS`,
+  }
+}
+
 interface SandboxProviderView {
   name: string
   type: string
@@ -594,6 +611,7 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
   const [formMaximumDuration, setFormMaximumDuration] = useState("")
   const [formBridgePort, setFormBridgePort] = useState("")
   const [formAuthTokenExpiration, setFormAuthTokenExpiration] = useState("")
+  const [showLambdaAdvanced, setShowLambdaAdvanced] = useState(false)
 
   const resetForm = () => {
     setFormProvider("replicated")
@@ -615,13 +633,53 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
     setFormExecutionRoleArn("")
     setFormIngressConnectors("")
     setFormEgressConnectors("")
-    setFormIdleMaxDuration("900")
-    setFormSuspendedDuration("300")
+    setFormIdleMaxDuration(LAMBDA_MICROVM_DEFAULTS.idleMaxDuration)
+    setFormSuspendedDuration(LAMBDA_MICROVM_DEFAULTS.suspendedDuration)
     setFormAutoResume(true)
-    setFormMaximumDuration("28800")
-    setFormBridgePort("8080")
-    setFormAuthTokenExpiration("30")
+    setFormMaximumDuration(LAMBDA_MICROVM_DEFAULTS.maximumDuration)
+    setFormBridgePort(LAMBDA_MICROVM_DEFAULTS.bridgePort)
+    setFormAuthTokenExpiration(LAMBDA_MICROVM_DEFAULTS.authTokenExpiration)
+    setShowLambdaAdvanced(false)
     setEditName(null)
+  }
+
+  const applySuggestedLambdaNetwork = (region = formAwsRegion) => {
+    const connectors = lambdaMicroVMConnectors(region)
+    setFormIngressConnectors(connectors.ingress)
+    setFormEgressConnectors(connectors.egress)
+  }
+
+  const applySuggestedLambdaLifecycle = () => {
+    setFormIdleMaxDuration(LAMBDA_MICROVM_DEFAULTS.idleMaxDuration)
+    setFormSuspendedDuration(LAMBDA_MICROVM_DEFAULTS.suspendedDuration)
+    setFormMaximumDuration(LAMBDA_MICROVM_DEFAULTS.maximumDuration)
+    setFormBridgePort(LAMBDA_MICROVM_DEFAULTS.bridgePort)
+    setFormAuthTokenExpiration(LAMBDA_MICROVM_DEFAULTS.authTokenExpiration)
+    setFormAutoResume(true)
+  }
+
+  const applySuggestedLambdaSetup = () => {
+    const region = formAwsRegion.trim() || LAMBDA_MICROVM_DEFAULT_REGION
+    setFormAwsRegion(region)
+    setFormAwsProfile("")
+    applySuggestedLambdaNetwork(region)
+    applySuggestedLambdaLifecycle()
+  }
+
+  const selectProvider = (provider: string) => {
+    setFormProvider(provider)
+    if (provider === "lambda-microvms" && modalMode === "add") {
+      applySuggestedLambdaSetup()
+    }
+  }
+
+  const updateLambdaImageIdentifier = (value: string) => {
+    setFormImageIdentifier(value)
+    const arnRegion = value.trim().match(/^arn:[^:]+:lambda:([^:]+):/)?.[1]
+    if (arnRegion && arnRegion !== formAwsRegion) {
+      setFormAwsRegion(arnRegion)
+      applySuggestedLambdaNetwork(arnRegion)
+    }
   }
 
   const openAdd = () => {
@@ -633,6 +691,11 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
         setFormDefaultCpu("2")
         setFormDefaultMemory("4")
         setFormDefaultDisk("10")
+      } else if (firstAvailable.value === "lambda-microvms") {
+        const connectors = lambdaMicroVMConnectors(LAMBDA_MICROVM_DEFAULT_REGION)
+        setFormAwsRegion(LAMBDA_MICROVM_DEFAULT_REGION)
+        setFormIngressConnectors(connectors.ingress)
+        setFormEgressConnectors(connectors.egress)
       }
     }
     setModalMode("add")
@@ -666,12 +729,22 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
     setFormMaximumDuration(p?.maximumDurationSeconds?.toString() || "28800")
     setFormBridgePort(p?.bridgePort?.toString() || "8080")
     setFormAuthTokenExpiration(p?.authTokenExpirationMinutes?.toString() || "30")
+    setShowLambdaAdvanced(false)
     setEditName(name)
     setModalMode("edit")
     setShowModal(true)
   }
 
   const availableProviders = SANDBOX_PROVIDER_OPTIONS.filter(o => !providers[o.value])
+  const suggestedLambdaConnectors = lambdaMicroVMConnectors(formAwsRegion)
+  const usingSuggestedLambdaNetwork = formIngressConnectors.trim() === suggestedLambdaConnectors.ingress
+    && formEgressConnectors.trim() === suggestedLambdaConnectors.egress
+  const usingSuggestedLambdaLifecycle = formIdleMaxDuration === LAMBDA_MICROVM_DEFAULTS.idleMaxDuration
+    && formSuspendedDuration === LAMBDA_MICROVM_DEFAULTS.suspendedDuration
+    && formMaximumDuration === LAMBDA_MICROVM_DEFAULTS.maximumDuration
+    && formBridgePort === LAMBDA_MICROVM_DEFAULTS.bridgePort
+    && formAuthTokenExpiration === LAMBDA_MICROVM_DEFAULTS.authTokenExpiration
+    && formAutoResume
 
   function splitConnectorList(value: string) {
     return value
@@ -849,7 +922,7 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
                 <label className="text-xs text-muted-foreground mb-1 block">Provider</label>
                 <select
                   value={formProvider}
-                  onChange={e => setFormProvider(e.target.value)}
+                  onChange={e => selectProvider(e.target.value)}
                   className="w-full h-8 rounded-md border border-border bg-background px-2 text-sm"
                 >
                   {availableProviders.map(o => <option key={o.value} value={o.value}>{o.label}{o.alpha ? " (alpha)" : ""}</option>)}
@@ -1014,98 +1087,143 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
 
             {formProvider === "lambda-microvms" && (
               <>
-                <div className="bg-amber-500/10 border border-amber-500/20 rounded-lg p-3">
-                  <div className="flex items-center gap-2 mb-1">
-                    <span className="text-xs bg-amber-500/20 text-amber-300 px-1.5 py-0.5 rounded">Alpha</span>
-                    <p className="text-xs font-medium">AWS Lambda MicroVMs</p>
-                  </div>
-                  <p className="text-xs text-muted-foreground">
-                    Requires an image that starts the Elastic Claw bridge from the MicroVM run hook payload.
-                  </p>
+                <div className="flex items-center justify-between rounded-lg border border-amber-500/20 bg-amber-500/10 px-3 py-2">
+                  <p className="text-xs font-medium">AWS Lambda MicroVMs</p>
+                  <span className="rounded bg-amber-500/20 px-1.5 py-0.5 text-[10px] text-amber-300">Alpha</span>
                 </div>
                 <div>
                   <label className="text-xs text-muted-foreground mb-1 block">Image identifier</label>
                   <Input
                     value={formImageIdentifier}
-                    onChange={e => setFormImageIdentifier(e.target.value)}
+                    onChange={e => updateLambdaImageIdentifier(e.target.value)}
                     className="h-8 text-sm font-mono"
-                    placeholder="arn:aws:lambda:us-east-1:123456789012:microvm-image/elasticclaw"
+                    placeholder="arn:aws:lambda:us-east-1:123456789012:microvm-image:elasticclaw-agent"
                   />
+                  <p className="mt-1 text-[11px] text-muted-foreground">Paste the ARN from the AWS setup command. Region is detected automatically.</p>
                 </div>
-                <div className="grid grid-cols-2 gap-3">
-                  <div>
-                    <label className="text-xs text-muted-foreground mb-1 block">AWS Region</label>
-                    <Input value={formAwsRegion} onChange={e => setFormAwsRegion(e.target.value)} className="h-8 text-sm" placeholder="us-east-1" />
+
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between rounded-lg border border-border px-3 py-2.5">
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2">
+                        <p className="text-xs font-medium">AWS access</p>
+                        {!formAwsProfile.trim() && <span className="rounded bg-primary/10 px-1.5 py-0.5 text-[10px] text-primary">Suggested</span>}
+                      </div>
+                      <p className="mt-0.5 truncate text-[11px] text-muted-foreground">
+                        {formAwsProfile.trim() ? `Named profile: ${formAwsProfile.trim()}` : "Use the Hub IAM role"}
+                      </p>
+                    </div>
+                    {formAwsProfile.trim() ? (
+                      <Button type="button" size="sm" variant="ghost" className="h-7 text-xs" onClick={() => setFormAwsProfile("")}>Use suggestion</Button>
+                    ) : (
+                      <div className="flex items-center gap-1">
+                        <span className="flex items-center gap-1 text-[10px] text-muted-foreground"><Check className="size-3" /> Using suggestion</span>
+                        <Button type="button" size="sm" variant="ghost" className="h-7 text-xs" onClick={() => setShowLambdaAdvanced(true)}>Modify</Button>
+                      </div>
+                    )}
                   </div>
-                  <div>
-                    <label className="text-xs text-muted-foreground mb-1 block">AWS Profile</label>
-                    <Input value={formAwsProfile} onChange={e => setFormAwsProfile(e.target.value)} className="h-8 text-sm" placeholder="default" />
+
+                  <div className="flex items-center justify-between rounded-lg border border-border px-3 py-2.5">
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2">
+                        <p className="text-xs font-medium">Network</p>
+                        {usingSuggestedLambdaNetwork && <span className="rounded bg-primary/10 px-1.5 py-0.5 text-[10px] text-primary">Suggested</span>}
+                      </div>
+                      <p className="mt-0.5 text-[11px] text-muted-foreground">Public HTTPS + internet egress</p>
+                    </div>
+                    {usingSuggestedLambdaNetwork ? (
+                      <Button type="button" size="sm" variant="ghost" className="h-7 text-xs" onClick={() => setShowLambdaAdvanced(true)}>Modify</Button>
+                    ) : (
+                      <Button type="button" size="sm" variant="ghost" className="h-7 text-xs" onClick={() => applySuggestedLambdaNetwork()}>Use suggestion</Button>
+                    )}
                   </div>
-                </div>
-                <div>
-                  <label className="text-xs text-muted-foreground mb-1 block">Image version</label>
-                  <Input value={formImageVersion} onChange={e => setFormImageVersion(e.target.value)} className="h-8 text-sm" placeholder="latest" />
-                </div>
-                <div>
-                  <label className="text-xs text-muted-foreground mb-1 block">Execution role ARN</label>
-                  <Input
-                    value={formExecutionRoleArn}
-                    onChange={e => setFormExecutionRoleArn(e.target.value)}
-                    className="h-8 text-sm font-mono"
-                    placeholder="arn:aws:iam::123456789012:role/elasticclaw-microvm"
-                  />
-                </div>
-                <div>
-                  <label className="text-xs text-muted-foreground mb-1 block">Ingress network connectors</label>
-                  <textarea
-                    value={formIngressConnectors}
-                    onChange={e => setFormIngressConnectors(e.target.value)}
-                    className="min-h-16 w-full rounded-md border border-border bg-background px-2 py-1.5 text-sm font-mono"
-                    placeholder="One ARN per line"
-                  />
-                </div>
-                <div>
-                  <label className="text-xs text-muted-foreground mb-1 block">Egress network connectors</label>
-                  <textarea
-                    value={formEgressConnectors}
-                    onChange={e => setFormEgressConnectors(e.target.value)}
-                    className="min-h-16 w-full rounded-md border border-border bg-background px-2 py-1.5 text-sm font-mono"
-                    placeholder="One ARN per line"
-                  />
-                </div>
-                <div className="grid grid-cols-2 gap-3">
-                  <div>
-                    <label className="text-xs text-muted-foreground mb-1 block">Idle max seconds</label>
-                    <Input type="number" min={1} value={formIdleMaxDuration} onChange={e => setFormIdleMaxDuration(e.target.value)} className="h-8 text-sm" placeholder="900" />
-                  </div>
-                  <div>
-                    <label className="text-xs text-muted-foreground mb-1 block">Suspended seconds</label>
-                    <Input type="number" min={1} value={formSuspendedDuration} onChange={e => setFormSuspendedDuration(e.target.value)} className="h-8 text-sm" placeholder="300" />
-                  </div>
-                </div>
-                <div className="grid grid-cols-3 gap-3">
-                  <div>
-                    <label className="text-xs text-muted-foreground mb-1 block">Max seconds</label>
-                    <Input type="number" min={1} value={formMaximumDuration} onChange={e => setFormMaximumDuration(e.target.value)} className="h-8 text-sm" placeholder="28800" />
-                  </div>
-                  <div>
-                    <label className="text-xs text-muted-foreground mb-1 block">Bridge port</label>
-                    <Input type="number" min={1} value={formBridgePort} onChange={e => setFormBridgePort(e.target.value)} className="h-8 text-sm" placeholder="8080" />
-                  </div>
-                  <div>
-                    <label className="text-xs text-muted-foreground mb-1 block">Token minutes</label>
-                    <Input type="number" min={1} value={formAuthTokenExpiration} onChange={e => setFormAuthTokenExpiration(e.target.value)} className="h-8 text-sm" placeholder="30" />
+
+                  <div className="flex items-center justify-between rounded-lg border border-border px-3 py-2.5">
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2">
+                        <p className="text-xs font-medium">Lifecycle</p>
+                        {usingSuggestedLambdaLifecycle && <span className="rounded bg-primary/10 px-1.5 py-0.5 text-[10px] text-primary">Suggested</span>}
+                      </div>
+                      <p className="mt-0.5 text-[11px] text-muted-foreground">Suspend after 15m · resume automatically · stop after 8h</p>
+                    </div>
+                    {usingSuggestedLambdaLifecycle ? (
+                      <Button type="button" size="sm" variant="ghost" className="h-7 text-xs" onClick={() => setShowLambdaAdvanced(true)}>Modify</Button>
+                    ) : (
+                      <Button type="button" size="sm" variant="ghost" className="h-7 text-xs" onClick={applySuggestedLambdaLifecycle}>Use suggestion</Button>
+                    )}
                   </div>
                 </div>
-                <label className="flex items-center gap-2 text-sm">
-                  <input
-                    type="checkbox"
-                    checked={formAutoResume}
-                    onChange={e => setFormAutoResume(e.target.checked)}
-                    className="size-4 rounded border-border"
-                  />
-                  Auto resume suspended MicroVMs
-                </label>
+
+                <button
+                  type="button"
+                  onClick={() => setShowLambdaAdvanced(value => !value)}
+                  className="flex w-full items-center justify-between rounded-md px-1 py-1 text-xs text-muted-foreground hover:text-foreground"
+                  aria-expanded={showLambdaAdvanced}
+                >
+                  <span>Advanced settings</span>
+                  <ChevronDown className={cn("size-3.5 transition-transform", showLambdaAdvanced && "rotate-180")} />
+                </button>
+
+                {showLambdaAdvanced && (
+                  <div className="space-y-3 rounded-lg border border-border bg-muted/20 p-3">
+                    <div className="grid grid-cols-2 gap-3">
+                      <div>
+                        <label className="text-xs text-muted-foreground mb-1 block">AWS region</label>
+                        <Input value={formAwsRegion} onChange={e => setFormAwsRegion(e.target.value)} className="h-8 text-sm" placeholder="us-east-1" />
+                      </div>
+                      <div>
+                        <label className="text-xs text-muted-foreground mb-1 block">Local AWS profile</label>
+                        <Input value={formAwsProfile} onChange={e => setFormAwsProfile(e.target.value)} className="h-8 text-sm" placeholder="Optional" />
+                      </div>
+                    </div>
+                    <div className="grid grid-cols-2 gap-3">
+                      <div>
+                        <label className="text-xs text-muted-foreground mb-1 block">Image version</label>
+                        <Input value={formImageVersion} onChange={e => setFormImageVersion(e.target.value)} className="h-8 text-sm" placeholder="Latest" />
+                      </div>
+                      <div>
+                        <label className="text-xs text-muted-foreground mb-1 block">Execution role ARN</label>
+                        <Input value={formExecutionRoleArn} onChange={e => setFormExecutionRoleArn(e.target.value)} className="h-8 text-sm font-mono" placeholder="Optional" />
+                      </div>
+                    </div>
+                    <div>
+                      <label className="text-xs text-muted-foreground mb-1 block">Ingress connectors</label>
+                      <textarea value={formIngressConnectors} onChange={e => setFormIngressConnectors(e.target.value)} className="min-h-14 w-full rounded-md border border-border bg-background px-2 py-1.5 text-xs font-mono" />
+                    </div>
+                    <div>
+                      <label className="text-xs text-muted-foreground mb-1 block">Egress connectors</label>
+                      <textarea value={formEgressConnectors} onChange={e => setFormEgressConnectors(e.target.value)} className="min-h-14 w-full rounded-md border border-border bg-background px-2 py-1.5 text-xs font-mono" />
+                    </div>
+                    <div className="grid grid-cols-3 gap-3">
+                      <div>
+                        <label className="text-xs text-muted-foreground mb-1 block">Idle (sec)</label>
+                        <Input type="number" min={1} value={formIdleMaxDuration} onChange={e => setFormIdleMaxDuration(e.target.value)} className="h-8 text-sm" />
+                      </div>
+                      <div>
+                        <label className="text-xs text-muted-foreground mb-1 block">Suspended (sec)</label>
+                        <Input type="number" min={1} value={formSuspendedDuration} onChange={e => setFormSuspendedDuration(e.target.value)} className="h-8 text-sm" />
+                      </div>
+                      <div>
+                        <label className="text-xs text-muted-foreground mb-1 block">Maximum (sec)</label>
+                        <Input type="number" min={1} value={formMaximumDuration} onChange={e => setFormMaximumDuration(e.target.value)} className="h-8 text-sm" />
+                      </div>
+                    </div>
+                    <div className="grid grid-cols-2 gap-3">
+                      <div>
+                        <label className="text-xs text-muted-foreground mb-1 block">Bridge port</label>
+                        <Input type="number" min={1} value={formBridgePort} onChange={e => setFormBridgePort(e.target.value)} className="h-8 text-sm" />
+                      </div>
+                      <div>
+                        <label className="text-xs text-muted-foreground mb-1 block">Token minutes</label>
+                        <Input type="number" min={1} value={formAuthTokenExpiration} onChange={e => setFormAuthTokenExpiration(e.target.value)} className="h-8 text-sm" />
+                      </div>
+                    </div>
+                    <label className="flex items-center gap-2 text-xs">
+                      <input type="checkbox" checked={formAutoResume} onChange={e => setFormAutoResume(e.target.checked)} className="size-4 rounded border-border" />
+                      Resume suspended MicroVMs automatically
+                    </label>
+                  </div>
+                )}
               </>
             )}
           </div>


### PR DESCRIPTION
## Relationship to #420

Builds on the alpha AWS Lambda MicroVM provider introduced in #420. That PR already registered the provider, connected Hub lifecycle paths to the AWS Lambda MicroVM APIs through the AWS CLI, and exposed its configuration in the admin UI. It intentionally expected operators to supply a compatible MicroVM image that started the ElasticClaw bridge from the run-hook payload.

This PR completes the deployable, end-to-end runtime path by supplying that image and bridge, provisioning infrastructure, moving scoped initialization behind the authenticated MicroVM endpoint, and validating the complete workflow against AWS.

## Summary

- add a dedicated HTTPS lifecycle/control bridge for the existing Lambda MicroVM provider
- build and publish an arm64 agent image without baking Hub, repository, or model credentials into it
- provision least-privilege S3, IAM, and MicroVM image resources through CloudFormation and reproducible setup scripts
- initialize each MicroVM with its scoped environment and workspace only after AWS returns the authenticated endpoint
- expand initialization beyond the run-hook payload's 16 KiB limit while keeping the run hook minimal
- improve the existing sandbox settings UI with safer suggested network and lifecycle defaults plus advanced overrides
- harden restored Codex OAuth migration and remove stale OpenClaw workspace attestations discovered during live MicroVM testing
- reject a bridge that exits during startup so provisioning can retry instead of accepting a dead sandbox

## Why

The original alpha provider established the Hub and AWS integration contract, but using it required an independently prepared compatible image and bridge. This change provides the missing runtime and deployment artifacts so teams can reproducibly run ElasticClaw agents in stateful, Firecracker-isolated AWS sandboxes.

Linear: [AIEDEV-17](https://linear.app/nimble-la/issue/AIEDEV-17)

## Security and operator impact

- the Hub uses the standard AWS credential chain; committed examples contain no credentials or account-specific identifiers
- the shared image contains only the runtime and bridges; per-agent secrets are sent through the AWS-authenticated endpoint after startup
- the generated artifact bucket is encrypted, versioned, private, and retained by default
- runtime IAM is scoped to the configured MicroVM image, with list and AWS-managed network-connector actions separated explicitly
- the provider remains labeled alpha and documents AWS CLI, IAM, cost, and eight-hour runtime constraints

## Validation

- `go test ./...`
- `go test -race ./cmd/lambda-microvm-bridge`
- `npm --prefix web run typecheck`
- `npm --prefix web run lint` (passes with two pre-existing `<img>` warnings)
- `npm --prefix web run build`
- `bash -n scripts/publish-lambda-microvm-image.sh scripts/setup-lambda-microvm.sh`
- `aws cloudformation validate-template --region us-east-1 --template-body file://aws/lambda-microvm/bootstrap.yaml`
- live AWS MicroVM E2E: provisioned an agent, cloned the scoped repository, changed and tested `page.tsx`, pushed a task branch, opened [agent-race PR #19](https://github.com/nicoprofe/agent-race/pull/19), and terminated the sandbox

## Notes

Codex ChatGPT OAuth profiles use rotating refresh tokens. The live test used a freshly synchronized Hub auth profile; operators should refresh an expired Hub profile before launching new sandboxes until managed Codex token rotation is implemented separately.
