### PR TITLE
fix(hub): arm PR monitoring from pipeline [DONE] and run outputs

### DIFF
--- a/pkg/hub/done_signal_test.go
+++ b/pkg/hub/done_signal_test.go
@@ -86,9 +86,17 @@ func TestExtractDonePRURLs(t *testing.T) {
 			wantURLs: []string{"https://github.com/org/repo/pull/42"},
 		},
 		{
-			name:     "DONE on its own line, URL on next line — not picked up",
+			name:     "DONE on its own line, URL on next line",
 			message:  "[DONE]\nhttps://github.com/org/repo/pull/99",
-			wantURLs: nil,
+			wantURLs: []string{"https://github.com/org/repo/pull/99"},
+		},
+		{
+			name:    "DONE then multiple PR URLs on following lines",
+			message: "[DONE]\nhttps://github.com/org/repo/pull/1\nhttps://github.com/org/other/pull/2",
+			wantURLs: []string{
+				"https://github.com/org/repo/pull/1",
+				"https://github.com/org/other/pull/2",
+			},
 		},
 		{
 			name:     "no DONE token at all",
@@ -306,6 +314,58 @@ stages:
 	}
 	if !strings.Contains(injected, "Android validation started") {
 		t.Fatalf("injected message = %q, want validation inject", injected)
+	}
+}
+
+func TestHandleClawDoneSignal_PipelineDoneStillRegistersPRURLs(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+	s.hubCfg.Factories = []*types.FactoryConfig{
+		{
+			Name:     "github_todo",
+			Template: "elasticclaw",
+			PipelineYAML: `
+stages:
+  - id: working
+    entry: true
+  - id: pr_opened
+    triggers:
+      - message_contains: "[DONE]"
+    on_enter:
+      inject: "verify prs"
+  - id: merged
+    triggers:
+      - pr_merged: {}
+    terminal: true
+`,
+		},
+	}
+
+	const clawID = "claw-done-pipeline-prs"
+	_, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, template, status, tags, github_issue_id, pipeline_stage, created_at) VALUES(?,?,?,?,?,?,?,?,datetime('now'))`,
+		clawID, "test-tenant-id", "issue-1", "elasticclaw", "connected", `["factory:github_todo"]`, "org/repo/1", "working",
+	)
+	if err != nil {
+		t.Fatalf("insert claw: %v", err)
+	}
+
+	// Pipeline owns [DONE] — previously this path returned before registering PRs.
+	s.handleClawDoneSignal(clawID, "[DONE]\nhttps://github.com/org/repo/pull/42\nhttps://github.com/org/other/pull/7")
+
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM claw_prs WHERE claw_id=?`, clawID).Scan(&count); err != nil {
+		t.Fatalf("count claw_prs: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("claw_prs count = %d, want 2 (pipeline [DONE] must still arm PR monitoring)", count)
+	}
+
+	var stage string
+	if err := db.QueryRow(`SELECT pipeline_stage FROM claws WHERE id=?`, clawID).Scan(&stage); err != nil {
+		t.Fatalf("select pipeline_stage: %v", err)
+	}
+	if stage != "pr_opened" {
+		t.Fatalf("pipeline_stage = %q, want pr_opened", stage)
 	}
 }
 

--- a/pkg/hub/done_signal_test.go
+++ b/pkg/hub/done_signal_test.go
@@ -369,6 +369,59 @@ stages:
 	}
 }
 
+func TestHandleClawDoneSignal_PipelineDoneBlockedByFailedRequiredGate(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+	s.hubCfg.Factories = []*types.FactoryConfig{
+		{
+			Name:     "gated_todo",
+			Template: "elasticclaw",
+			PipelineYAML: `
+stages:
+  - id: working
+    entry: true
+  - id: pr_opened
+    triggers:
+      - message_contains: "[DONE]"
+    on_enter:
+      inject: "should not reach"
+`,
+		},
+	}
+
+	const clawID = "claw-done-pipeline-gate"
+	_, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, template, status, tags, github_issue_id, pipeline_stage, created_at) VALUES(?,?,?,?,?,?,?,?,datetime('now'))`,
+		clawID, "test-tenant-id", "issue-2", "elasticclaw", "connected", `["factory:gated_todo"]`, "org/repo/2", "working",
+	)
+	if err != nil {
+		t.Fatalf("insert claw: %v", err)
+	}
+	_, err = db.Exec(`
+		INSERT INTO pipeline_gate_results(claw_id, stage_id, output_name, verdict, matched_path, matched_value, required, created_at)
+		VALUES(?, ?, ?, ?, ?, ?, ?, datetime('now'))`,
+		clawID, "pr_opened", "pr_links", "fail", "status", "failed", 1)
+	if err != nil {
+		t.Fatalf("insert gate result: %v", err)
+	}
+
+	s.handleClawDoneSignal(clawID, "[DONE] https://github.com/org/repo/pull/99")
+
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM claw_prs WHERE claw_id=?`, clawID).Scan(&count); err != nil {
+		t.Fatalf("count claw_prs: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("claw_prs count = %d, want 0 when required gate failed", count)
+	}
+	var stage string
+	if err := db.QueryRow(`SELECT pipeline_stage FROM claws WHERE id=?`, clawID).Scan(&stage); err != nil {
+		t.Fatalf("select pipeline_stage: %v", err)
+	}
+	if stage != "working" {
+		t.Fatalf("pipeline_stage = %q, want working (blocked)", stage)
+	}
+}
+
 func TestHandleClawDoneSignal_BlockedByErrorRequiredGate(t *testing.T) {
 	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
 

--- a/pkg/hub/done_signal_test.go
+++ b/pkg/hub/done_signal_test.go
@@ -317,6 +317,33 @@ stages:
 	}
 }
 
+func TestRegisterDonePRURLsAtomicMulti(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+	const clawID = "claw-register-atomic"
+	_, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, template, status, created_at) VALUES(?,?,?,?,?,datetime('now'))`,
+		clawID, "test-tenant-id", "claw", "elasticclaw", "connected",
+	)
+	if err != nil {
+		t.Fatalf("insert claw: %v", err)
+	}
+
+	failURL := s.registerDonePRURLs(clawID, []string{
+		"https://github.com/org/repo/pull/1",
+		"https://github.com/org/other/pull/2",
+	})
+	if failURL != "" {
+		t.Fatalf("registerDonePRURLs failed on %q", failURL)
+	}
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM claw_prs WHERE claw_id=?`, clawID).Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("claw_prs count = %d, want 2", count)
+	}
+}
+
 func TestHandleClawDoneSignal_PipelineDoneStillRegistersPRURLs(t *testing.T) {
 	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
 	s.hubCfg.Factories = []*types.FactoryConfig{

--- a/pkg/hub/github_webhook.go
+++ b/pkg/hub/github_webhook.go
@@ -1151,7 +1151,7 @@ func (s *Server) createClawForGitHubPR(factory *types.FactoryConfig, pr githubPR
 	// the trigger claim active — permanently blocking re-creation for this PR. If
 	// the association fails, tear the claw down and release the claim so poll/webhook
 	// can retry.
-	if err := s.storePRMention(clawID, repoFullName, prNumber, prURL); err != nil {
+	if _, err := s.storePRMention(clawID, repoFullName, prNumber, prURL); err != nil {
 		_, _ = s.db.Exec(`UPDATE claws SET status='deleted' WHERE id=?`, clawID)
 		if s.cronScheduler != nil {
 			s.cronScheduler.finishRunByClawID(clawID, "failed", err.Error())

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -1324,6 +1324,10 @@ func (s *Server) handleClawDoneSignal(clawID, rawMessage string) {
 	prURLs := extractDonePRURLs(rawMessage)
 
 	if pipelineCtx, stage, ok := s.pipelineStageForMessageContains(clawID, rawMessage); ok {
+		// Pipeline stages that match [DONE] return before the legacy store path
+		// below. Register PRs here so merge/close monitoring and review injects
+		// still arm; without this, claws can live forever after a PR merges.
+		s.registerDonePRURLs(clawID, prURLs)
 		if issueID != "" {
 			s.trackDoneSignal(pipelineCtx.Name(), issueID, clawID, len(prURLs))
 		}
@@ -1384,15 +1388,12 @@ func (s *Server) handleClawDoneSignal(clawID, rawMessage string) {
 	}
 
 	// Store all validated PRs (idempotent).
-	for _, pr := range extractPRs(strings.Join(prURLs, " ")) {
-		if err := s.storePRMention(clawID, pr.repo, pr.number, pr.url); err != nil {
-			log.Printf("[factory] failed to register PR %s: %v", pr.url, err)
-			// Resend with ALL original URLs: earlier PRs in the list are already
-			// stored (idempotent), and the retried [DONE] must carry the full set
-			// so pipeline transitions and analytics see the complete PR list.
-			s.injectUserMessage(clawID, fmt.Sprintf("[factory] Failed to register PR %s: internal error. Please resend: [DONE] %s", pr.url, strings.Join(prURLs, " ")))
-			return
-		}
+	if errURL := s.registerDonePRURLs(clawID, prURLs); errURL != "" {
+		// Resend with ALL original URLs: earlier PRs in the list are already
+		// stored (idempotent), and the retried [DONE] must carry the full set
+		// so pipeline transitions and analytics see the complete PR list.
+		s.injectUserMessage(clawID, fmt.Sprintf("[factory] Failed to register PR %s: internal error. Please resend: [DONE] %s", errURL, strings.Join(prURLs, " ")))
+		return
 	}
 
 	pipelineHandledDone := false
@@ -1737,19 +1738,54 @@ func (s *Server) handleClawTerminateSignal(clawID, rawMessage string) {
 }
 
 // extractDonePRURLs parses PR URLs from a [DONE] message.
-// It finds the [DONE] token and returns all github.com PR URLs that follow it on the same line.
+// It finds the [DONE] token and returns github.com PR URLs that follow it on the
+// same line, plus any PR URLs on subsequent lines of the same message. Agents
+// commonly emit:
+//
+//	[DONE]
+//	https://github.com/org/repo/pull/1
+//
+// and those URLs must still register for merge/close monitoring.
 func extractDonePRURLs(message string) []string {
-	for _, line := range strings.Split(message, "\n") {
-		if idx := strings.Index(line, "[DONE]"); idx >= 0 {
-			rest := line[idx+len("[DONE]"):]
-			var urls []string
-			for _, pr := range extractPRs(rest) {
+	lines := strings.Split(message, "\n")
+	for i, line := range lines {
+		idx := strings.Index(line, "[DONE]")
+		if idx < 0 {
+			continue
+		}
+		var urls []string
+		seen := map[string]bool{}
+		add := func(content string) {
+			for _, pr := range extractPRs(content) {
+				if seen[pr.url] {
+					continue
+				}
+				seen[pr.url] = true
 				urls = append(urls, pr.url)
 			}
-			return urls
 		}
+		add(line[idx+len("[DONE]"):])
+		for _, later := range lines[i+1:] {
+			add(later)
+		}
+		return urls
 	}
 	return nil
+}
+
+// registerDonePRURLs persists every PR URL into claw_prs (idempotent).
+// Returns the first URL that failed to store, or "" on full success.
+func (s *Server) registerDonePRURLs(clawID string, prURLs []string) string {
+	if len(prURLs) == 0 {
+		return ""
+	}
+	for _, pr := range extractPRs(strings.Join(prURLs, " ")) {
+		if err := s.storePRMention(clawID, pr.repo, pr.number, pr.url); err != nil {
+			log.Printf("[factory] failed to register PR %s for claw %s: %v", pr.url, shortID(clawID), err)
+			return pr.url
+		}
+	}
+	return ""
 }
 
 // validateDonePRs checks that every PR URL in the [DONE] signal refers to an open PR.

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -1785,9 +1785,10 @@ func extractDonePRURLs(message string) []string {
 // registerDonePRURLs persists every PR URL into claw_prs (idempotent).
 // Returns the first URL that failed to store, or "" on full success.
 //
-// Registration is all-or-nothing for URLs newly introduced by this call: if a
-// later store fails, rows inserted earlier in the same call are rolled back so
-// the PR watcher is not left partially armed while the stage transition aborts.
+// Multi-URL registration is atomic: either every new claw_prs row is
+// committed, or none are. Compensating DELETEs are intentionally avoided —
+// a failed cleanup after a partial write could still leave the watcher armed
+// on a blocked [DONE] path.
 func (s *Server) registerDonePRURLs(clawID string, prURLs []string) string {
 	if len(prURLs) == 0 {
 		return ""
@@ -1797,21 +1798,30 @@ func (s *Server) registerDonePRURLs(clawID string, prURLs []string) string {
 		return ""
 	}
 
-	var newlyInserted []string
+	// Single URL: reuse the normal path (no multi-row partial-write risk).
+	if len(prs) == 1 {
+		if _, err := s.storePRMention(clawID, prs[0].repo, prs[0].number, prs[0].url); err != nil {
+			log.Printf("[factory] failed to register PR %s for claw %s: %v", prs[0].url, shortID(clawID), err)
+			return prs[0].url
+		}
+		return ""
+	}
+
+	var toInsert []prMentionCandidate
 	for _, pr := range prs {
-		inserted, err := s.storePRMention(clawID, pr.repo, pr.number, pr.url)
+		already, row, err := s.preparePRMention(clawID, pr.repo, pr.number, pr.url)
 		if err != nil {
-			log.Printf("[factory] failed to register PR %s for claw %s: %v", pr.url, shortID(clawID), err)
-			for _, url := range newlyInserted {
-				if _, delErr := s.db.Exec(`DELETE FROM claw_prs WHERE claw_id=? AND pr_url=?`, clawID, url); delErr != nil {
-					log.Printf("[factory] failed to roll back PR %s for claw %s after partial register: %v", url, shortID(clawID), delErr)
-				}
-			}
+			log.Printf("[factory] failed to prepare PR %s for claw %s: %v", pr.url, shortID(clawID), err)
 			return pr.url
 		}
-		if inserted {
-			newlyInserted = append(newlyInserted, pr.url)
+		if already {
+			continue
 		}
+		toInsert = append(toInsert, row)
+	}
+	if failURL := s.insertClawPRsAtomic(clawID, toInsert); failURL != "" {
+		log.Printf("[factory] failed to register PR set for claw %s (first failure %s)", shortID(clawID), failURL)
+		return failURL
 	}
 	return ""
 }

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -1567,18 +1567,15 @@ func (s *Server) completeIssueLessDoneClaw(clawID, tenantID string, prURLs []str
 		s.injectUserMessage(clawID, "[factory] `[DONE]` blocked: a required tool gate has failed. Please fix the issues and retry.")
 		return
 	}
-	for _, pr := range extractPRs(strings.Join(prURLs, " ")) {
-		if err := s.storePRMention(clawID, pr.repo, pr.number, pr.url); err != nil {
-			// A failed INSERT leaves the PR untracked, so the watcher would never
-			// detect its merge/close and the claw would stall in 'idle' forever.
-			// Nudge the claw to resend [DONE] instead of idling it.
-			log.Printf("[factory] failed to register PR %s: %v", pr.url, err)
-			// Resend with ALL original URLs: earlier PRs in the list are already
-			// stored (idempotent), and the retried [DONE] must carry the full set
-			// so pipeline transitions and analytics see the complete PR list.
-			s.injectUserMessage(clawID, fmt.Sprintf("[factory] Failed to register PR %s: internal error. Please resend: [DONE] %s", pr.url, strings.Join(prURLs, " ")))
-			return
-		}
+	if errURL := s.registerDonePRURLs(clawID, prURLs); errURL != "" {
+		// A failed INSERT leaves the PR untracked (and any partial inserts
+		// from this call are rolled back), so the watcher would never
+		// detect its merge/close and the claw would stall in 'idle' forever.
+		// Nudge the claw to resend [DONE] instead of idling it.
+		// Resend with ALL original URLs so the retried [DONE] carries the
+		// full set for pipeline transitions and analytics.
+		s.injectUserMessage(clawID, fmt.Sprintf("[factory] Failed to register PR %s: internal error. Please resend: [DONE] %s", errURL, strings.Join(prURLs, " ")))
+		return
 	}
 	if len(prURLs) == 0 {
 		s.completeNoPRDoneClaw(clawID, tenantID, "")
@@ -1787,14 +1784,33 @@ func extractDonePRURLs(message string) []string {
 
 // registerDonePRURLs persists every PR URL into claw_prs (idempotent).
 // Returns the first URL that failed to store, or "" on full success.
+//
+// Registration is all-or-nothing for URLs newly introduced by this call: if a
+// later store fails, rows inserted earlier in the same call are rolled back so
+// the PR watcher is not left partially armed while the stage transition aborts.
 func (s *Server) registerDonePRURLs(clawID string, prURLs []string) string {
 	if len(prURLs) == 0 {
 		return ""
 	}
-	for _, pr := range extractPRs(strings.Join(prURLs, " ")) {
-		if err := s.storePRMention(clawID, pr.repo, pr.number, pr.url); err != nil {
+	prs := extractPRs(strings.Join(prURLs, " "))
+	if len(prs) == 0 {
+		return ""
+	}
+
+	var newlyInserted []string
+	for _, pr := range prs {
+		inserted, err := s.storePRMention(clawID, pr.repo, pr.number, pr.url)
+		if err != nil {
 			log.Printf("[factory] failed to register PR %s for claw %s: %v", pr.url, shortID(clawID), err)
+			for _, url := range newlyInserted {
+				if _, delErr := s.db.Exec(`DELETE FROM claw_prs WHERE claw_id=? AND pr_url=?`, clawID, url); delErr != nil {
+					log.Printf("[factory] failed to roll back PR %s for claw %s after partial register: %v", url, shortID(clawID), delErr)
+				}
+			}
 			return pr.url
+		}
+		if inserted {
+			newlyInserted = append(newlyInserted, pr.url)
 		}
 	}
 	return ""

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -1324,10 +1324,22 @@ func (s *Server) handleClawDoneSignal(clawID, rawMessage string) {
 	prURLs := extractDonePRURLs(rawMessage)
 
 	if pipelineCtx, stage, ok := s.pipelineStageForMessageContains(clawID, rawMessage); ok {
+		// Match the legacy [DONE] path: a failed required gate must block both
+		// stage advance and PR registration so a blocked workflow cannot later
+		// terminate on merge/close of an improperly registered PR.
+		if s.hasFailedRequiredGate(clawID) {
+			msg := "[factory] `[DONE]` blocked: a required tool gate has failed. Please fix the issues and retry."
+			log.Printf("[factory] claw %s pipeline [DONE] blocked by failed required gate", shortID(clawID))
+			s.injectUserMessage(clawID, msg)
+			return
+		}
 		// Pipeline stages that match [DONE] return before the legacy store path
 		// below. Register PRs here so merge/close monitoring and review injects
 		// still arm; without this, claws can live forever after a PR merges.
-		s.registerDonePRURLs(clawID, prURLs)
+		if errURL := s.registerDonePRURLs(clawID, prURLs); errURL != "" {
+			s.injectUserMessage(clawID, fmt.Sprintf("[factory] Failed to register PR %s: internal error. Please resend: [DONE] %s", errURL, strings.Join(prURLs, " ")))
+			return
+		}
 		if issueID != "" {
 			s.trackDoneSignal(pipelineCtx.Name(), issueID, clawID, len(prURLs))
 		}

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -917,6 +917,11 @@ func (e *routedRequiredGateError) Error() string {
 // MoveIssue.IssueID (including template references like {{.Inputs.xxx}}).
 func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineContext) (injectDelivered bool, err error) {
 	issueID := ctx.IssueID
+	// Captured for PR registration after any required gate has been evaluated.
+	// Scanning immediately after the run would arm claw_prs before a failing
+	// required gate could block the stage (and leave the watcher able to kill
+	// the claw on merge/close while the workflow is still blocked).
+	var runStdoutForPRScan string
 	if strings.TrimSpace(stage.OnEnter.Run.Command) != "" {
 		log.Printf("[pipeline] running workflow command for claw %s stage %q: %s", clawID[:8], stage.ID, stage.OnEnter.Run.Command)
 		result, err := s.executePipelineRunAction(clawID, stage.OnEnter.Run)
@@ -924,11 +929,8 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 		if stage.OnEnter.Run.Output != "" && result != nil {
 			s.persistPipelineOutput(clawID, stage.ID, stage.OnEnter.Run.Output, result)
 		}
-		// Scripts like verify-github-pr-links emit PR URLs in JSON. Register them
-		// so the PR watcher can monitor merge/close even when the agent never
-		// pasted bare github.com/…/pull/N links into chat.
-		if result != nil && strings.TrimSpace(result.Stdout) != "" {
-			s.scanMessageForPRs(clawID, result.Stdout)
+		if result != nil {
+			runStdoutForPRScan = result.Stdout
 		}
 		if err != nil || (result != nil && result.ExitCode != 0) {
 			msg := formatPipelineRunFailure(stage.OnEnter.Run, result, err)
@@ -1109,6 +1111,13 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 			}
 			return false, fmt.Errorf("required gate %q %s", stage.ID, gateResult.Verdict)
 		}
+	}
+
+	// Scripts like verify-github-pr-links emit PR URLs in JSON. Register them
+	// only after a required gate (if any) has allowed the stage to continue, so
+	// a failed gate cannot leave the PR watcher armed on a blocked claw.
+	if strings.TrimSpace(runStdoutForPRScan) != "" {
+		s.scanMessageForPRs(clawID, runStdoutForPRScan)
 	}
 
 	if stage.OnEnter.Inject != "" {

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -924,6 +924,12 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 		if stage.OnEnter.Run.Output != "" && result != nil {
 			s.persistPipelineOutput(clawID, stage.ID, stage.OnEnter.Run.Output, result)
 		}
+		// Scripts like verify-github-pr-links emit PR URLs in JSON. Register them
+		// so the PR watcher can monitor merge/close even when the agent never
+		// pasted bare github.com/…/pull/N links into chat.
+		if result != nil && strings.TrimSpace(result.Stdout) != "" {
+			s.scanMessageForPRs(clawID, result.Stdout)
+		}
 		if err != nil || (result != nil && result.ExitCode != 0) {
 			msg := formatPipelineRunFailure(stage.OnEnter.Run, result, err)
 			// If this stage has a gate, treat nonzero exit as a normal validation

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -177,6 +177,146 @@ func (s *Server) scanMessageForPRs(clawID, content string) {
 	}
 }
 
+// prMentionCandidate is a PR URL pending claw_prs registration.
+type prMentionCandidate struct {
+	repo     string
+	number   int
+	url      string
+	comment  int64
+	review   int64
+	commentAt string
+	headSHA  string
+}
+
+// preparePRMention loads GitHub watermarks for a PR insert. alreadyTracked is
+// true when claw_prs already has this URL (no write needed).
+func (s *Server) preparePRMention(clawID, repo string, prNumber int, prURL string) (alreadyTracked bool, row prMentionCandidate, err error) {
+	var existing string
+	_ = s.db.QueryRow(`SELECT id FROM claw_prs WHERE claw_id=? AND pr_url=?`, clawID, prURL).Scan(&existing)
+	if existing != "" {
+		return true, prMentionCandidate{}, nil
+	}
+
+	row = prMentionCandidate{repo: repo, number: prNumber, url: prURL}
+	token := s.resolveGitHubToken()
+	if token == "" {
+		return false, row, nil
+	}
+	var lastCommentTime time.Time
+	commentsData, err := githubAPIList(fmt.Sprintf("repos/%s/issues/%d/comments", repo, prNumber), token)
+	if err == nil {
+		for _, c := range commentsData {
+			comment, _ := c.(map[string]interface{})
+			idF, _ := comment["id"].(float64)
+			id := int64(idF)
+			if id > row.comment {
+				row.comment = id
+			}
+			createdAt, _ := comment["created_at"].(string)
+			if createdAt == "" {
+				continue
+			}
+			createdAtTime, err := time.Parse(time.RFC3339, createdAt)
+			if err != nil {
+				continue
+			}
+			if row.commentAt == "" || createdAtTime.After(lastCommentTime) {
+				row.commentAt = createdAt
+				lastCommentTime = createdAtTime
+			}
+		}
+	}
+	prData, err := githubAPI(fmt.Sprintf("repos/%s/pulls/%d", repo, prNumber), token)
+	if err == nil {
+		if headObj, ok := prData["head"].(map[string]interface{}); ok {
+			row.headSHA, _ = headObj["sha"].(string)
+		}
+	}
+	reviewsData, err := githubAPIList(fmt.Sprintf("repos/%s/pulls/%d/reviews", repo, prNumber), token)
+	if err == nil {
+		row.review = maxPRReviewID(reviewsData, 0)
+	}
+	return false, row, nil
+}
+
+// insertClawPRsAtomic inserts zero or more new claw_prs rows in a single
+// transaction. Either every new row is committed, or none are — so callers
+// never leave the PR watcher partially armed when one URL fails.
+// Returns the URL that failed, or "" on full success.
+func (s *Server) insertClawPRsAtomic(clawID string, rows []prMentionCandidate) string {
+	if len(rows) == 0 {
+		return ""
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		log.Printf("[pr-watcher] begin claw_prs tx for claw %s: %v", shortID(clawID), err)
+		return rows[0].url
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	var inserted []prMentionCandidate
+	for _, row := range rows {
+		// Re-check inside the transaction so a concurrent writer is handled
+		// via INSERT OR IGNORE rather than a hard failure.
+		var existing string
+		_ = tx.QueryRow(`SELECT id FROM claw_prs WHERE claw_id=? AND pr_url=?`, clawID, row.url).Scan(&existing)
+		if existing != "" {
+			continue
+		}
+		prID := uuid.New().String()
+		res, err := tx.Exec(
+			`INSERT OR IGNORE INTO claw_prs(id,claw_id,repo,pr_number,pr_url,last_comment_id,last_comment_at,last_review_id,last_ci_sha,created_at) VALUES(?,?,?,?,?,?,?,?,?,?)`,
+			prID, clawID, row.repo, row.number, row.url, row.comment, row.commentAt, row.review, row.headSHA, now(),
+		)
+		if err != nil {
+			log.Printf("[pr-watcher] failed to persist PR %s#%d for claw %s: %v", row.repo, row.number, shortID(clawID), err)
+			return row.url
+		}
+		if affected, err := res.RowsAffected(); err == nil && affected == 0 {
+			continue // concurrent insert won the race
+		}
+		inserted = append(inserted, row)
+	}
+	if err := tx.Commit(); err != nil {
+		log.Printf("[pr-watcher] commit claw_prs tx for claw %s: %v", shortID(clawID), err)
+		if len(inserted) > 0 {
+			return inserted[0].url
+		}
+		return rows[0].url
+	}
+	committed = true
+
+	// Side effects only after the rows are durably present.
+	factory, issueID := s.findFactoryForClaw(clawID)
+	for _, row := range inserted {
+		if factory != nil {
+			s.trackPROpened(factory.Name, issueID, clawID, row.repo, row.number)
+		}
+		if _, runID, _, ok, err := s.taskRunContextForClaw(clawID); err != nil {
+			log.Printf("[task-run-analytics] failed to resolve task run for PR mention claw %s: %v", clawID, err)
+		} else if ok {
+			if err := s.associateTaskRunPR(TaskRunPR{
+				RunID:        runID,
+				Repo:         row.repo,
+				PRNumber:     row.number,
+				URL:          row.url,
+				HeadSHA:      row.headSHA,
+				AgentHeadSHA: true,
+				State:        taskRunPRStateOpen,
+			}); err != nil {
+				log.Printf("[task-run-analytics] failed to associate PR %s#%d for claw %s: %v", row.repo, row.number, clawID, err)
+			}
+		}
+		log.Printf("[pr-watcher] detected PR %s#%d for claw %s", row.repo, row.number, shortID(clawID))
+	}
+	return ""
+}
+
 const (
 	// prWatcherBaseInterval is the fastest the poller ever runs. Comments,
 	// reviews and merges are already delivered by webhooks, so a tighter loop

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -72,11 +72,12 @@ func extractPRs(content string) []struct {
 
 // storePRMention persists a detected PR reference for a claw (idempotent by URL).
 // Also tracks analytics for the first detection of a PR open.
-func (s *Server) storePRMention(clawID, repo string, prNumber int, prURL string) error {
+// inserted is true only when this call created the claw_prs row.
+func (s *Server) storePRMention(clawID, repo string, prNumber int, prURL string) (inserted bool, err error) {
 	var existing string
 	_ = s.db.QueryRow(`SELECT id FROM claw_prs WHERE claw_id=? AND pr_url=?`, clawID, prURL).Scan(&existing)
 	if existing != "" {
-		return nil
+		return false, nil
 	}
 
 	// Track analytics: PR was opened (detected for the first time)
@@ -140,10 +141,10 @@ func (s *Server) storePRMention(clawID, repo string, prNumber int, prURL string)
 	)
 	if err != nil {
 		log.Printf("[pr-watcher] failed to persist PR %s#%d for claw %s: %v", repo, prNumber, clawID[:8], err)
-		return err
+		return false, err
 	}
 	if affected, err := res.RowsAffected(); err == nil && affected == 0 {
-		return nil // concurrent writer already registered this PR
+		return false, nil // concurrent writer already registered this PR
 	}
 	if _, runID, _, ok, err := s.taskRunContextForClaw(clawID); err != nil {
 		log.Printf("[task-run-analytics] failed to resolve task run for PR mention claw %s: %v", clawID, err)
@@ -164,13 +165,13 @@ func (s *Server) storePRMention(clawID, repo string, prNumber int, prURL string)
 		}
 	}
 	log.Printf("[pr-watcher] detected PR %s#%d for claw %s", repo, prNumber, clawID[:8])
-	return nil
+	return true, nil
 }
 
 // scanMessageForPRs extracts and stores any PR URLs found in a message.
 func (s *Server) scanMessageForPRs(clawID, content string) {
 	for _, pr := range extractPRs(content) {
-		if err := s.storePRMention(clawID, pr.repo, pr.number, pr.url); err != nil {
+		if _, err := s.storePRMention(clawID, pr.repo, pr.number, pr.url); err != nil {
 			log.Printf("[pr-watcher] failed to store PR mention: %v", err)
 		}
 	}

--- a/pkg/hub/pr_watcher_test.go
+++ b/pkg/hub/pr_watcher_test.go
@@ -429,7 +429,7 @@ func TestStorePRMentionConcurrentDuplicate(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			errs[i] = s.storePRMention("claw-dup", "owner/repo", 7, "https://github.com/owner/repo/pull/7")
+			_, errs[i] = s.storePRMention("claw-dup", "owner/repo", 7, "https://github.com/owner/repo/pull/7")
 		}(i)
 	}
 	wg.Wait()

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2744,13 +2744,26 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				if automaticContinuationPaused {
 					pipelineHandledDone = false
 				} else if pipelineHandledDone {
-					prURLs := extractDonePRURLs(turnContent)
-					// Register before the stage transition so pr_merged/pr_closed
-					// monitoring is armed even if the agent only listed URLs next
-					// to [DONE] and never elsewhere in chat.
-					s.registerDonePRURLs(clawID, prURLs)
-					s.trackDoneSignal(pipelineDoneCtx.Name(), pipelineDoneCtx.IssueID, clawID, len(prURLs))
-					s.safeGo("pipeline done transition", func() { s.transitionPipelineStageWithContext(clawID, *pipelineDoneStage, pipelineDoneCtx) })
+					// Same gates as handleClawDoneSignal: do not advance or arm
+					// PR monitoring while a required gate is failed. Keep
+					// pipelineHandledDone true so we do not also run the
+					// legacy done handler (which would double-nudge).
+					if s.hasFailedRequiredGate(clawID) {
+						s.injectUserMessage(clawID, "[factory] `[DONE]` blocked: a required tool gate has failed. Please fix the issues and retry.")
+					} else {
+						prURLs := extractDonePRURLs(turnContent)
+						// Register before the stage transition so pr_merged/pr_closed
+						// monitoring is armed even if the agent only listed URLs next
+						// to [DONE] and never elsewhere in chat.
+						if errURL := s.registerDonePRURLs(clawID, prURLs); errURL != "" {
+							s.injectUserMessage(clawID, fmt.Sprintf("[factory] Failed to register PR %s: internal error. Please resend: [DONE] %s", errURL, strings.Join(prURLs, " ")))
+						} else {
+							s.trackDoneSignal(pipelineDoneCtx.Name(), pipelineDoneCtx.IssueID, clawID, len(prURLs))
+							s.safeGo("pipeline done transition", func() {
+								s.transitionPipelineStageWithContext(clawID, *pipelineDoneStage, pipelineDoneCtx)
+							})
+						}
+					}
 				} else if !strings.Contains(turnContent, "[DONE]") {
 					s.safeGo("pipeline message triggers", func() { s.checkPipelineMessageTriggers(clawID, turnContent) })
 				}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2790,12 +2790,14 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				if strings.Contains(turnContent, "[TERMINATE]") {
 					go s.handleClawTerminateSignal(clawID, turnContent)
 				}
-				// Detect and store any PR URLs mentioned by the agent. Skip when
-				// this turn is a blocked [DONE]: hasFailedRequiredGate already
-				// refused explicit registration, and scanning here would still
-				// arm claw_prs so merge/close could terminate a blocked claw.
-				if strings.Contains(turnContent, "[DONE]") && s.hasFailedRequiredGate(clawID) {
-					log.Printf("[pr-watcher] skipping PR scan for claw %s: [DONE] blocked by failed required gate", shortID(clawID))
+				// Detect and store PR URLs mentioned mid-work. [DONE] turns are
+				// intentionally excluded: registerDonePRURLs (pipeline path or
+				// handleClawDoneSignal) owns that registration so multi-URL sets
+				// stay atomic. A fallback scan here would call storePRMention
+				// per-URL and could partially arm the watcher after an aborted
+				// atomic register or a gate-blocked [DONE].
+				if strings.Contains(turnContent, "[DONE]") {
+					log.Printf("[pr-watcher] skipping PR scan for claw %s: [DONE] registration is handled explicitly", shortID(clawID))
 				} else {
 					go s.scanMessageForPRs(clawID, turnContent)
 				}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2790,8 +2790,15 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				if strings.Contains(turnContent, "[TERMINATE]") {
 					go s.handleClawTerminateSignal(clawID, turnContent)
 				}
-				// Detect and store any PR URLs mentioned by the agent
-				go s.scanMessageForPRs(clawID, turnContent)
+				// Detect and store any PR URLs mentioned by the agent. Skip when
+				// this turn is a blocked [DONE]: hasFailedRequiredGate already
+				// refused explicit registration, and scanning here would still
+				// arm claw_prs so merge/close could terminate a blocked claw.
+				if strings.Contains(turnContent, "[DONE]") && s.hasFailedRequiredGate(clawID) {
+					log.Printf("[pr-watcher] skipping PR scan for claw %s: [DONE] blocked by failed required gate", shortID(clawID))
+				} else {
+					go s.scanMessageForPRs(clawID, turnContent)
+				}
 				// Detect tool error loops and inject a corrective message
 				if !automaticContinuationPaused && detectToolLoop(hm.Content) {
 					s.mu.RLock()

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2696,8 +2696,15 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				cc.forcedFinishCount = 0
 				cc.mu.Unlock()
 				s.deleteStaleWatchdogNags(clawID)
+				// Prefer the streamed buffer for the turn body: the final message
+				// event sometimes arrives empty while persistContent holds the
+				// full streamed response (including [DONE] and PR URLs).
+				turnContent := persistContent
+				if strings.TrimSpace(turnContent) == "" {
+					turnContent = hm.Content
+				}
 				// Drop empty messages — never store or broadcast
-				if strings.TrimSpace(hm.Content) == "" {
+				if strings.TrimSpace(turnContent) == "" {
 					// Clear typing indicator first — always clear even if no queued messages
 					s.broadcastToUsers(tenantID, types.WSMessage{
 						Type: "agent_typing",
@@ -2712,17 +2719,18 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 					s.drainPendingCheckpoint(clawID)
 					continue
 				}
-				if !skipPersist && strings.TrimSpace(persistContent) != "" {
+				if !skipPersist {
+					hm.Content = turnContent
 					_, _ = s.db.Exec(
 						`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at,delivered_at) VALUES(?,?,?,?,?,?,?)
 						 ON CONFLICT(id) DO UPDATE SET content=excluded.content, delivered_at=excluded.delivered_at`,
-						hm.ID, hm.ClawID, hm.TenantID, hm.Role, persistContent, hm.CreatedAt, hm.CreatedAt,
+						hm.ID, hm.ClawID, hm.TenantID, hm.Role, turnContent, hm.CreatedAt, hm.CreatedAt,
 					)
 					s.broadcastToUsers(tenantID, types.WSMessage{Type: "message", Payload: hm})
 				}
-				automaticContinuationPaused := s.observeCompletedTurn(clawID, hm.ID, hm.Content)
+				automaticContinuationPaused := s.observeCompletedTurn(clawID, hm.ID, turnContent)
 				if !automaticContinuationPaused {
-					s.handleInitialPlanResponse(clawID, tenantID, hm.Content)
+					s.handleInitialPlanResponse(clawID, tenantID, turnContent)
 				}
 				// Evaluate pipeline triggers. If a pipeline explicitly owns a
 				// [DONE] trigger, let it handle that signal instead of the
@@ -2730,17 +2738,21 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				pipelineHandledDone := false
 				var pipelineDoneCtx pipelineContext
 				var pipelineDoneStage *pipeline.Stage
-				if strings.Contains(hm.Content, "[DONE]") {
-					pipelineDoneCtx, pipelineDoneStage, pipelineHandledDone = s.pipelineStageForMessageContains(clawID, hm.Content)
+				if strings.Contains(turnContent, "[DONE]") {
+					pipelineDoneCtx, pipelineDoneStage, pipelineHandledDone = s.pipelineStageForMessageContains(clawID, turnContent)
 				}
 				if automaticContinuationPaused {
 					pipelineHandledDone = false
 				} else if pipelineHandledDone {
-					prURLs := extractDonePRURLs(hm.Content)
+					prURLs := extractDonePRURLs(turnContent)
+					// Register before the stage transition so pr_merged/pr_closed
+					// monitoring is armed even if the agent only listed URLs next
+					// to [DONE] and never elsewhere in chat.
+					s.registerDonePRURLs(clawID, prURLs)
 					s.trackDoneSignal(pipelineDoneCtx.Name(), pipelineDoneCtx.IssueID, clawID, len(prURLs))
 					s.safeGo("pipeline done transition", func() { s.transitionPipelineStageWithContext(clawID, *pipelineDoneStage, pipelineDoneCtx) })
-				} else if !strings.Contains(hm.Content, "[DONE]") {
-					s.safeGo("pipeline message triggers", func() { s.checkPipelineMessageTriggers(clawID, hm.Content) })
+				} else if !strings.Contains(turnContent, "[DONE]") {
+					s.safeGo("pipeline message triggers", func() { s.checkPipelineMessageTriggers(clawID, turnContent) })
 				}
 				// Clear typing indicator now that response is complete
 				s.broadcastToUsers(tenantID, types.WSMessage{
@@ -2751,22 +2763,22 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 					},
 				})
 				// Check for [DONE] signal from a factory-created claw
-				if strings.Contains(hm.Content, "[DONE]") {
+				if strings.Contains(turnContent, "[DONE]") {
 					s.safeGo("done checkpoint", func() {
 						if _, err := s.requestCheckpoint(context.Background(), clawID, "done", "hub", false, checkpointRequestTimeout); err != nil {
 							log.Printf("[checkpoint] done request for %s failed: %v", shortID(clawID), err)
 						}
 					})
 					if !pipelineHandledDone {
-						s.safeGo("done signal", func() { s.handleClawDoneSignal(clawID, hm.Content) })
+						s.safeGo("done signal", func() { s.handleClawDoneSignal(clawID, turnContent) })
 					}
 				}
 				// Check for [TERMINATE] signal - allows claw to manage its own lifecycle
-				if strings.Contains(hm.Content, "[TERMINATE]") {
-					go s.handleClawTerminateSignal(clawID, hm.Content)
+				if strings.Contains(turnContent, "[TERMINATE]") {
+					go s.handleClawTerminateSignal(clawID, turnContent)
 				}
 				// Detect and store any PR URLs mentioned by the agent
-				go s.scanMessageForPRs(clawID, hm.Content)
+				go s.scanMessageForPRs(clawID, turnContent)
 				// Detect tool error loops and inject a corrective message
 				if !automaticContinuationPaused && detectToolLoop(hm.Content) {
 					s.mu.RLock()


### PR DESCRIPTION
## Summary
- Register PR URLs when a pipeline stage matches `[DONE]`, so `claw_prs` is populated and the PR watcher can fire `pr_merged` / `pr_closed` terminal stages (claws no longer stay alive forever after merge).
- Extract PR URLs from lines after `[DONE]`, not only the same line.
- Prefer streamed turn content for `[DONE]` / PR scanning when the final message event body is empty or incomplete.
- Scan pipeline `run` stdout for PR URLs so scripts like `verify-github-pr-links` also arm monitoring.

## Test plan
- [x] `go test ./pkg/hub/ -run 'TestExtractDonePRURLs|TestHandleClawDoneSignal'`
- [ ] Deploy hub and run a github-issues workflow that emits `[DONE]` with PR URLs (same line or following lines)
- [ ] Confirm hub logs show `[pr-watcher] detected PR ...` and `claw_prs` rows exist
- [ ] Merge or close the PR and confirm claw reaches terminal stage and is deleted
- [ ] Confirm a required-gate blocked `[DONE]` still does **not** register PRs