### PR TITLE
fix(hub): clarify missing-workspace workflow push errors

### DIFF
--- a/pkg/hub/external_storage.go
+++ b/pkg/hub/external_storage.go
@@ -449,6 +449,11 @@ func loadExternalWorkspaceConfig(name string) (types.WorkspaceConfig, error) {
 	configPath := filepath.Join(dir, "elasticclaw-config.yaml")
 	data, err := os.ReadFile(configPath)
 	if err != nil {
+		// Only fall back to legacy workspace.yaml when the canonical file is
+		// actually missing. Permissions / other I/O errors must surface as-is.
+		if !os.IsNotExist(err) {
+			return types.WorkspaceConfig{}, fmt.Errorf("read workspace %q config: %w", name, err)
+		}
 		legacyPath := filepath.Join(dir, "workspace.yaml")
 		data, err = os.ReadFile(legacyPath)
 		if err != nil {

--- a/pkg/hub/external_storage.go
+++ b/pkg/hub/external_storage.go
@@ -2,6 +2,7 @@ package hub
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -416,21 +417,54 @@ func loadExternalWorkspace(name string) (*types.WorkspaceConfig, error) {
 	return &workspace, nil
 }
 
+// errWorkspaceNotFound is returned when a workspace name does not exist on the hub.
+// Callers should map this to HTTP 404 rather than 500.
+type errWorkspaceNotFound struct {
+	Name string
+}
+
+func (e *errWorkspaceNotFound) Error() string {
+	return fmt.Sprintf(
+		"workspace %q not found on the hub; push it first with `elasticclaw workspace push --path <dir> %s`, then retry with `--workspace %s`",
+		e.Name, e.Name, e.Name,
+	)
+}
+
+func isWorkspaceNotFound(err error) bool {
+	var target *errWorkspaceNotFound
+	return errors.As(err, &target)
+}
+
 func loadExternalWorkspaceConfig(name string) (types.WorkspaceConfig, error) {
 	dir := filepath.Join(workspacesDir(), name)
+	if st, err := os.Stat(dir); err != nil {
+		if os.IsNotExist(err) {
+			return types.WorkspaceConfig{}, &errWorkspaceNotFound{Name: name}
+		}
+		return types.WorkspaceConfig{}, fmt.Errorf("stat workspace %q: %w", name, err)
+	} else if !st.IsDir() {
+		return types.WorkspaceConfig{}, fmt.Errorf("workspace %q path exists but is not a directory", name)
+	}
+
 	configPath := filepath.Join(dir, "elasticclaw-config.yaml")
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		legacyPath := filepath.Join(dir, "workspace.yaml")
 		data, err = os.ReadFile(legacyPath)
 		if err != nil {
-			return types.WorkspaceConfig{}, fmt.Errorf("read elasticclaw-config.yaml: %w", err)
+			if os.IsNotExist(err) {
+				return types.WorkspaceConfig{}, fmt.Errorf(
+					"workspace %q exists but is missing elasticclaw-config.yaml (looked for elasticclaw-config.yaml and workspace.yaml)",
+					name,
+				)
+			}
+			return types.WorkspaceConfig{}, fmt.Errorf("read workspace %q config: %w", name, err)
 		}
 		configPath = legacyPath
 	}
 	var workspace types.WorkspaceConfig
 	if err := yaml.Unmarshal(data, &workspace); err != nil {
-		return types.WorkspaceConfig{}, fmt.Errorf("parse %s: %w", filepath.Base(configPath), err)
+		return types.WorkspaceConfig{}, fmt.Errorf("parse workspace %q %s: %w", name, filepath.Base(configPath), err)
 	}
 	return workspace, nil
 }
@@ -541,7 +575,11 @@ func saveExternalWorkflows(workspaceName string, workflows []*types.WorkflowConf
 		return err
 	}
 	if _, err := loadExternalWorkspaceConfig(workspaceName); err != nil {
-		return err
+		// Preserve workspace-not-found for HTTP 404 mapping; wrap other load failures.
+		if isWorkspaceNotFound(err) {
+			return err
+		}
+		return fmt.Errorf("load workspace %q: %w", workspaceName, err)
 	}
 	workflowDir := filepath.Join(workspacesDir(), workspaceName, "workflows")
 	if err := os.MkdirAll(workflowDir, 0750); err != nil {

--- a/pkg/hub/workspace_api.go
+++ b/pkg/hub/workspace_api.go
@@ -567,7 +567,9 @@ func workflowToView(workspaceName string, workflow *types.WorkflowConfig) Workfl
 func (s *Server) resolveWorkflowConfig(workspaceName, workflowName string) (*types.WorkspaceConfig, *types.WorkflowConfig, bool, error) {
 	workspace, err := loadExternalWorkspace(workspaceName)
 	if err != nil {
-		if os.IsNotExist(err) {
+		// Typed workspace-not-found (and legacy os.IsNotExist) must map to 404,
+		// not 500 — loadExternalWorkspaceConfig no longer returns bare IsNotExist.
+		if isWorkspaceNotFound(err) || os.IsNotExist(err) {
 			return nil, nil, false, nil
 		}
 		return nil, nil, false, err

--- a/pkg/hub/workspace_api.go
+++ b/pkg/hub/workspace_api.go
@@ -209,6 +209,11 @@ func (s *Server) handleWorkspaceWorkflowsPush(w http.ResponseWriter, r *http.Req
 		}
 	}
 	if err := saveExternalWorkflows(name, req.Workflows); err != nil {
+		if isWorkspaceNotFound(err) {
+			// Missing workspace is a client mistake (wrong --workspace name), not a server fault.
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
 		http.Error(w, "save workflows: "+err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/pkg/hub/workspace_api_test.go
+++ b/pkg/hub/workspace_api_test.go
@@ -39,6 +39,47 @@ func TestWorkspacesEndpointReturnsPersistedWorkspacesOnly(t *testing.T) {
 	}
 }
 
+func TestWorkflowPushMissingWorkspaceReturnsClearNotFound(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", configDir+"/hub.yaml")
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+
+	// Push a workspace under a different name so the hub has something, but not "amazecrm".
+	body := `{"workspaces":[{"name":"amazecrm-dev","repositories":["elasticclaw/elasticclaw"]}]}`
+	req := httptest.NewRequest(http.MethodPost, "/api/workspaces", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("workspace push status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+
+	body = `{"workflows":[{"name":"linear","integration":"linear","enable_manual_trigger":true}]}`
+	req = httptest.NewRequest(http.MethodPost, "/api/workspaces/amazecrm/workflows", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	rr = httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("workflow push status = %d, want 404, body = %s", rr.Code, rr.Body.String())
+	}
+	got := rr.Body.String()
+	if !strings.Contains(got, `workspace "amazecrm" not found`) {
+		t.Fatalf("body = %q, want clear workspace not found message", got)
+	}
+	if strings.Contains(got, "elasticclaw-config.yaml") || strings.Contains(got, "workspace.yaml") {
+		t.Fatalf("body = %q, should not leak internal config file paths", got)
+	}
+	if strings.Contains(got, "save workflows:") {
+		t.Fatalf("body = %q, should not wrap not-found as save workflows 500", got)
+	}
+	if !strings.Contains(got, "workspace push") || !strings.Contains(got, "--workspace amazecrm") {
+		t.Fatalf("body = %q, want actionable push hint with the same workspace name", got)
+	}
+}
+
 func TestWorkflowPushPersistsWorkspaceWorkflows(t *testing.T) {
 	configDir := t.TempDir()
 	t.Setenv("ELASTICCLAW_HUB_CONFIG", configDir+"/hub.yaml")

--- a/pkg/hub/workspace_api_test.go
+++ b/pkg/hub/workspace_api_test.go
@@ -39,6 +39,35 @@ func TestWorkspacesEndpointReturnsPersistedWorkspacesOnly(t *testing.T) {
 	}
 }
 
+func TestResolveWorkflowConfigMissingWorkspaceIsNotFound(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", configDir+"/hub.yaml")
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+
+	// Create a different workspace so the hub is not empty.
+	body := `{"workspaces":[{"name":"amazecrm-dev","repositories":["elasticclaw/elasticclaw"]}]}`
+	req := httptest.NewRequest(http.MethodPost, "/api/workspaces", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("workspace push status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+
+	// Detail / patch / trigger all go through resolveWorkflowConfig.
+	req = httptest.NewRequest(http.MethodGet, "/api/workspaces/amazecrm/workflows/linear", nil)
+	req.Header.Set("Authorization", "Bearer test-token")
+	rr = httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("workflow detail status = %d, want 404, body = %s", rr.Code, rr.Body.String())
+	}
+	if strings.Contains(rr.Body.String(), "failed to load workflow") {
+		t.Fatalf("body = %q, missing workspace must not surface as 500 load failure", rr.Body.String())
+	}
+}
+
 func TestWorkflowPushMissingWorkspaceReturnsClearNotFound(t *testing.T) {
 	configDir := t.TempDir()
 	t.Setenv("ELASTICCLAW_HUB_CONFIG", configDir+"/hub.yaml")


### PR DESCRIPTION
## Summary
- Detect a missing workspace directory before attempting to read `elasticclaw-config.yaml` / legacy `workspace.yaml`.
- Return **HTTP 404** with a clear, actionable message naming the workspace and how to push it.
- Avoid wrapping not-found as `save workflows: … 500` with internal file paths.

### Before
```
hub returned 500: save workflows: read elasticclaw-config.yaml: open /root/.elasticclaw/workspaces/amazecrm/workspace.yaml: no such file or directory
```

### After
```
hub returned 404: workspace "amazecrm" not found on the hub; push it first with `elasticclaw workspace push --path <dir> amazecrm`, then retry with `--workspace amazecrm`
```

## Test plan
- [x] `go test ./pkg/hub/ -run 'TestWorkflowPushMissingWorkspace|TestWorkflowPushPersistsWorkspace'`
- [ ] Push a workspace as `amazecrm-dev`, then `workflow push --workspace amazecrm` and confirm the 404 wording
- [ ] `workflow push --workspace amazecrm-dev` still succeeds