### PR TITLE
chore(hub): stop loading factories/ directory

### DIFF
--- a/cmd/factory.go
+++ b/cmd/factory.go
@@ -8,13 +8,11 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"text/tabwriter"
 
 	"github.com/elasticclaw/elasticclaw/pkg/config"
-	"github.com/elasticclaw/elasticclaw/pkg/types"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
@@ -36,7 +34,7 @@ func FactoryCmd() *cobra.Command {
 func init() {
 	cmd := FactoryCmd()
 	cmd.Hidden = true
-	cmd.Deprecated = "factories are deprecated; use workflows instead"
+	cmd.Deprecated = "factories are retired; use workspace workflows (elasticclaw workflow push --workspace <name>)"
 	rootCmd.AddCommand(cmd)
 }
 
@@ -71,129 +69,7 @@ func factoryCreateCmd() *cobra.Command {
 }
 
 func runFactoryCreate(name, integration, workspace, triggerStatus, doneStatus, tmpl string) error {
-	name = strings.ToLower(strings.ReplaceAll(name, " ", "-"))
-	if workspace == "" {
-		workspace = name
-	}
-
-	var factoryYAML, pipelineYAML string
-
-	if integration == "github" {
-		// GitHub issue factory — uses repos and trigger instead of workspace/trigger_status
-		factoryYAML = fmt.Sprintf(`name: %s
-integration: github-issues
-workspace: %s
-trigger_status: "agent-ready"  # label name or issue state ("open")
-# labels: [bug]                # ALL labels must be present (AND)
-# assigned_to: "@username"      # or !@username, any, none
-# allowed_labelers:             # restrict who can trigger by labeling
-#   - marc-campbell
-#   - root-bot
-webhook_secret_ref: %s_webhook_secret
-
-template: %s
-`, name, workspace, name, tmpl)
-
-		pipelineYAML = fmt.Sprintf(`# Pipeline for %s (GitHub Issues)
-stages:
-  - id: working
-    label: "Working"
-    entry: true
-    on_enter:
-      inject: |
-        Read the GitHub issue in CONTEXT.md and start working.
-        Create a branch, implement the fix, and open a PR.
-        Narrate your progress. Send [DONE] when the PR is ready.
-
-  - id: pr_opened
-    label: "PR Opened"
-    triggers:
-      - message_contains: "[DONE]"
-    on_enter:
-      inject: |
-        PR created. Watch for CI results and review comments.
-
-  - id: done
-    label: "Done"
-    triggers:
-      - message_contains: "[DONE]"
-    on_enter:
-      close_issue: true
-      inject: |
-        Issue resolved. Closing the GitHub issue.
-    terminal: true
-`, name)
-	} else {
-		// Linear/Shortcut factory
-		factoryYAML = fmt.Sprintf(`name: %s
-integration: %s
-workspace: %s
-trigger_status: %q
-# labels: [bug, agent-ready]
-# assigned_to: "@username"  # or !@username, any, none
-webhook_secret_ref: %s_webhook_secret
-
-template: %s
-`, name, integration, workspace, triggerStatus, name, tmpl)
-
-		pipelineYAML = fmt.Sprintf(`# Pipeline for %s
-# Stages define the lifecycle of a factory-created agent.
-# ElasticClaw Server is the state machine — it injects instructions into the agent at each stage.
-
-stages:
-  - id: working
-    label: "Working"
-    entry: true
-    on_enter:
-      inject: |
-        Read your BOOTSTRAP.md and start working on the issue.
-        Narrate your progress as you go. Keep me updated.
-
-  - id: pr_opened
-    label: "PR Opened"
-    triggers:
-      - message_contains: "[DONE]"
-    on_enter:
-      move_issue: %q
-      inject: |
-        PR created. Watch for CI results and review comments.
-
-  - id: merged
-    label: "Merged"
-    triggers:
-      - pr_merged:
-    terminal: true
-
-  - id: closed_no_merge
-    label: "Closed Without Merge"
-    triggers:
-      - pr_closed:
-    on_enter:
-      inject: |
-        PR was closed without merging. Decide: reopen, new PR, or ask the user.
-`, name, doneStatus)
-	}
-
-	dir := filepath.Join(".elasticclaw", "factories", name)
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		return fmt.Errorf("failed to create directory: %w", err)
-	}
-
-	if err := os.WriteFile(filepath.Join(dir, "factory.yaml"), []byte(factoryYAML), 0644); err != nil {
-		return fmt.Errorf("failed to write factory.yaml: %w", err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "pipeline.yaml"), []byte(pipelineYAML), 0644); err != nil {
-		return fmt.Errorf("failed to write pipeline.yaml: %w", err)
-	}
-
-	fmt.Printf("\nCreated %s/\n", dir)
-	fmt.Printf("  factory.yaml\n")
-	fmt.Printf("  pipeline.yaml\n\n")
-	fmt.Printf("Next steps:\n")
-	fmt.Printf("  1. Edit %s/factory.yaml to review settings\n", dir)
-	fmt.Printf("  2. Add your webhook secret to the hub: elasticclaw hub settings\n")
-	fmt.Printf("  3. Push to hub: elasticclaw factory push\n")
-	return nil
+	return fmt.Errorf("factories are retired; use workspace workflows instead:\n  elasticclaw workspace push --path <workspace-dir> <name>\n  elasticclaw workflow push --workspace <name> <workflow.yaml>")
 }
 
 // ── factory push ──────────────────────────────────────────────────────────────
@@ -214,81 +90,8 @@ func factoryPushCmd() *cobra.Command {
 }
 
 func runFactoryPush(filterName string) error {
-	hubURL, clawToken, err := resolveHubConn()
-	if err != nil {
-		return err
-	}
-
-	// Find all factory.yaml files
-	pattern := filepath.Join(".elasticclaw", "factories", "*", "factory.yaml")
-	matches, err := filepath.Glob(pattern)
-	if err != nil || len(matches) == 0 {
-		return fmt.Errorf("no factories found under .elasticclaw/factories/")
-	}
-
-	var factories []*types.FactoryConfig
-	for _, match := range matches {
-		data, err := os.ReadFile(match)
-		if err != nil {
-			return fmt.Errorf("read %s: %w", match, err)
-		}
-		var f types.FactoryConfig
-		if err := yaml.Unmarshal(data, &f); err != nil {
-			return fmt.Errorf("parse %s: %w", match, err)
-		}
-		if filterName != "" && !strings.EqualFold(f.Name, filterName) {
-			continue
-		}
-
-		// Read pipeline.yaml alongside if present
-		pipelinePath := filepath.Join(filepath.Dir(match), "pipeline.yaml")
-		if pdata, err := os.ReadFile(pipelinePath); err == nil {
-			f.PipelineYAML = string(pdata)
-		}
-
-		// Validate factory configuration before pushing
-		if err := f.Validate(); err != nil {
-			return fmt.Errorf("validation failed for %s: %w", match, err)
-		}
-
-		factories = append(factories, &f)
-	}
-
-	if len(factories) == 0 {
-		return fmt.Errorf("no factories matched")
-	}
-
-	body, _ := json.Marshal(map[string]interface{}{"factories": factories})
-	req, _ := http.NewRequest(http.MethodPost, hubURL+"/api/factories", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+clawToken)
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("push failed: %w", err)
-	}
-	defer resp.Body.Close()
-	respBody, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("hub returned %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
-	}
-
-	var result struct {
-		Pushed    int `json:"pushed"`
-		Factories []struct {
-			Name string `json:"name"`
-		} `json:"factories"`
-	}
-	_ = json.Unmarshal(respBody, &result)
-
-	fmt.Printf("Pushed %d factory/factories to hub:\n", result.Pushed)
-	for _, f := range result.Factories {
-		fmt.Printf("  ✓ %s\n", f.Name)
-	}
-	return nil
+	return fmt.Errorf("factories are retired; use workspace workflows instead:\n  elasticclaw workflow push --workspace <name> <workflow.yaml>")
 }
-
-// ── factory list ──────────────────────────────────────────────────────────────
 
 func factoryListCmd() *cobra.Command {
 	return &cobra.Command{

--- a/cmd/hub.go
+++ b/cmd/hub.go
@@ -108,7 +108,7 @@ func runHub(cmd *cobra.Command, args []string) error {
 	hub.Version = Version
 	hub.Commit = Commit
 
-	// Ensure external storage directories exist (factories/, templates/)
+	// Ensure external storage directories exist (templates/, workspaces/)
 	if err := hub.EnsureExternalDirs(); err != nil {
 		return fmt.Errorf("failed to create external storage dirs: %w", err)
 	}
@@ -118,34 +118,31 @@ func runHub(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to start hub: %w", err)
 	}
 
-	// Migrate legacy templates from SQLite and factories from hub.yaml.
-	// Migration is mandatory — if it fails, the hub refuses to start to prevent
-	// split-brain where some data lives in external storage and some in legacy locations.
-	// Also re-runs if hub.yaml still has inline factories (e.g. prior migration didn't
-	// clean up, or user manually edited hub.yaml after migration).
+	// Migrate legacy templates from SQLite; strip any leftover factories from hub.yaml.
+	// On-disk factories/ is no longer loaded — automations use workspace workflows only.
 	needsMigrate := !hub.HasMigratedV2()
 	needsCleanup := len(hubCfg.Factories) > 0
 	if needsMigrate || needsCleanup {
-		fmt.Println("[hub] migrating legacy templates and factories to external storage...")
 		if needsMigrate {
+			fmt.Println("[hub] migrating legacy templates to external storage...")
 			if err := s.MigrateLegacyTemplates(); err != nil {
 				return fmt.Errorf("template migration failed: %w", err)
 			}
 		}
-		migrated, err := hub.MigrateLegacyFactories(hubCfg)
-		if err != nil {
-			return fmt.Errorf("factory migration failed: %w", err)
-		}
-		if len(migrated) > 0 {
-			fmt.Printf("[hub] migrated factories: %s\n", strings.Join(migrated, ", "))
+		if needsCleanup {
+			removed, err := hub.MigrateLegacyFactories(hubCfg)
+			if err != nil {
+				return fmt.Errorf("factory cleanup failed: %w", err)
+			}
+			if len(removed) > 0 {
+				fmt.Printf("[hub] removed factories from hub.yaml (use workspace workflows): %s\n", strings.Join(removed, ", "))
+			}
 		}
 		if needsMigrate {
 			if err := hub.MarkMigratedV2(); err != nil {
 				return fmt.Errorf("migration marker write failed: %w", err)
 			}
 			fmt.Println("[hub] migration complete — future runs will skip this step")
-		} else {
-			fmt.Println("[hub] cleaned up lingering factories from hub.yaml")
 		}
 	}
 

--- a/pkg/hub/external_storage.go
+++ b/pkg/hub/external_storage.go
@@ -42,11 +42,6 @@ func hubConfigDir() string {
 	return filepath.Join(home, ".elasticclaw")
 }
 
-// factoriesDir returns the path to the external factories directory.
-func factoriesDir() string {
-	return filepath.Join(hubConfigDir(), "factories")
-}
-
 // templatesDir returns the path to the external templates directory.
 func templatesDir() string {
 	return filepath.Join(hubConfigDir(), "templates")
@@ -57,16 +52,27 @@ func workspacesDir() string {
 	return filepath.Join(hubConfigDir(), "workspaces")
 }
 
-// EnsureExternalDirs creates the factories/ and templates/ directories
+// legacyFactoriesDir is the retired on-disk factories/ tree. It is no longer
+// created or loaded; deleteExternalFactory may still remove leftover entries
+// so operators can clean a pre-migration hub.
+func legacyFactoriesDir() string {
+	return filepath.Join(hubConfigDir(), "factories")
+}
+
+// EnsureExternalDirs creates the templates/ and workspaces/ directories
 // alongside hub.yaml if they don't exist.
 func EnsureExternalDirs() error {
-	for _, dir := range []string{factoriesDir(), templatesDir(), workspacesDir()} {
+	for _, dir := range []string{templatesDir(), workspacesDir()} {
 		if err := os.MkdirAll(dir, 0750); err != nil {
 			return fmt.Errorf("mkdir %s: %w", dir, err)
 		}
 	}
 	return nil
 }
+
+// errFactoriesRetired is returned by factory save/load paths that used to
+// target ~/.elasticclaw/factories. Automations must use workspace workflows.
+var errFactoriesRetired = fmt.Errorf("factories are retired; use workspace workflows (elasticclaw workflow push --workspace <name>) instead of the factories/ directory")
 
 // ── Templates ────────────────────────────────────────────────────────────────
 
@@ -203,99 +209,44 @@ func listExternalTemplates() ([]string, error) {
 	return names, nil
 }
 
-// ── Factories ────────────────────────────────────────────────────────────────
+// ── Factories (retired on-disk storage) ──────────────────────────────────────
+//
+// Automations live under workspaces/*/workflows/. The factories/ directory is
+// no longer loaded or written. resolveFactories only returns in-memory
+// hubCfg.Factories (used by unit tests); production hubs keep that empty.
 
-// loadExternalFactories scans the factories directory and returns all
-// FactoryConfigs with PipelineYAML loaded from disk.
+// loadExternalFactories used to scan factories/. It always returns an empty
+// list so leftover on-disk factories cannot dual-fire with workflows.
 func loadExternalFactories() ([]*types.FactoryConfig, error) {
-	dir := factoriesDir()
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("read factories dir: %w", err)
-	}
-
-	var factories []*types.FactoryConfig
-	for _, e := range entries {
-		if !e.IsDir() || strings.HasPrefix(e.Name(), ".") {
-			continue
-		}
-		f, err := loadExternalFactory(e.Name())
-		if err != nil {
-			// Log but don't fail — one bad factory shouldn't break the rest
-			fmt.Fprintf(os.Stderr, "[hub] skip factory %q: %v\n", e.Name(), err)
-			continue
-		}
-		factories = append(factories, f)
-	}
-	return factories, nil
+	return nil, nil
 }
 
-// resolveFactories returns the merged view of in-memory and external-storage
-// factories. External takes precedence. Used by polling and webhook handlers
-// so they always see the latest factories regardless of whether they were
-// loaded from hub.yaml or pushed via CLI/API.
+// resolveFactories returns in-memory factories only (tests). Production hubs
+// do not load factories from disk or hub.yaml after migration cleanup.
 func (s *Server) resolveFactories() []*types.FactoryConfig {
-	external, err := loadExternalFactories()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "[hub] loadExternalFactories: %v\n", err)
-	}
-
 	s.mu.RLock()
 	mem := s.hubCfg.Factories
 	s.mu.RUnlock()
 
-	merged := make(map[string]*types.FactoryConfig, len(mem)+len(external))
+	result := make([]*types.FactoryConfig, 0, len(mem))
 	for _, f := range mem {
 		if f == nil {
 			continue
 		}
-		merged[f.Name] = f
-	}
-	for _, f := range external {
-		if f == nil {
-			continue
-		}
-		merged[f.Name] = f
-	}
-
-	result := make([]*types.FactoryConfig, 0, len(merged))
-	for _, f := range merged {
 		result = append(result, f)
 	}
 	return result
 }
 
-// loadExternalFactory reads a single factory from disk.
+// loadExternalFactory always fails: on-disk factories are retired.
 func loadExternalFactory(name string) (*types.FactoryConfig, error) {
 	if err := validateName(name); err != nil {
 		return nil, err
 	}
-	dir := filepath.Join(factoriesDir(), name)
-
-	factoryPath := filepath.Join(dir, "factory.yaml")
-	data, err := os.ReadFile(factoryPath)
-	if err != nil {
-		return nil, fmt.Errorf("read factory.yaml: %w", err)
-	}
-
-	var f types.FactoryConfig
-	if err := yaml.Unmarshal(data, &f); err != nil {
-		return nil, fmt.Errorf("parse factory.yaml: %w", err)
-	}
-
-	// Load pipeline.yaml alongside if present
-	pipelinePath := filepath.Join(dir, "pipeline.yaml")
-	if pdata, err := os.ReadFile(pipelinePath); err == nil {
-		f.PipelineYAML = string(pdata)
-	}
-
-	return &f, nil
+	return nil, errFactoriesRetired
 }
 
-// saveExternalFactory writes a factory to the external directory.
+// saveExternalFactory rejects writes: use workspace workflows instead.
 func saveExternalFactory(f *types.FactoryConfig) error {
 	if f == nil || f.Name == "" {
 		return fmt.Errorf("factory name required")
@@ -303,46 +254,20 @@ func saveExternalFactory(f *types.FactoryConfig) error {
 	if err := f.Validate(); err != nil {
 		return err
 	}
-	if err := validateName(f.Name); err != nil {
-		return err
-	}
-
-	dir := filepath.Join(factoriesDir(), f.Name)
-	if err := os.MkdirAll(dir, 0750); err != nil {
-		return fmt.Errorf("mkdir %s: %w", dir, err)
-	}
-
-	// Write factory.yaml (without PipelineYAML — that goes in pipeline.yaml)
-	factoryCopy := *f
-	factoryCopy.PipelineYAML = ""
-	fdata, err := yaml.Marshal(&factoryCopy)
-	if err != nil {
-		return fmt.Errorf("marshal factory.yaml: %w", err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "factory.yaml"), fdata, 0640); err != nil {
-		return fmt.Errorf("write factory.yaml: %w", err)
-	}
-
-	// Write or remove pipeline.yaml based on whether PipelineYAML is set
-	pipelinePath := filepath.Join(dir, "pipeline.yaml")
-	if f.PipelineYAML != "" {
-		if err := os.WriteFile(pipelinePath, []byte(f.PipelineYAML), 0640); err != nil {
-			return fmt.Errorf("write pipeline.yaml: %w", err)
-		}
-	} else {
-		_ = os.Remove(pipelinePath)
-	}
-
-	return nil
+	return errFactoriesRetired
 }
 
-// deleteExternalFactory removes a factory directory.
+// deleteExternalFactory removes a leftover factories/<name> directory if
+// present (best-effort cleanup). Missing dirs are not an error.
 func deleteExternalFactory(name string) error {
 	if err := validateName(name); err != nil {
 		return err
 	}
-	dir := filepath.Join(factoriesDir(), name)
-	return os.RemoveAll(dir)
+	dir := filepath.Join(legacyFactoriesDir(), name)
+	if err := os.RemoveAll(dir); err != nil {
+		return err
+	}
+	return nil
 }
 
 // ── Workspaces ───────────────────────────────────────────────────────────────
@@ -742,33 +667,25 @@ func (s *Server) MigrateLegacyTemplates() error {
 	return nil
 }
 
-// MigrateLegacyFactories migrates factories from hub.yaml to the external
-// factories/ directory, then strips them from hub.yaml. Returns the list of
-// migrated factory names.
+// MigrateLegacyFactories strips factories from hub.yaml. On-disk factories/
+// is no longer populated or loaded; automations must use workspace workflows.
+// Returns names that were present in hub.yaml before clearing (for logging).
 func MigrateLegacyFactories(cfg *types.HubConfig) ([]string, error) {
-	var migrated []string
+	var removed []string
 	for _, f := range cfg.Factories {
-		if f == nil {
+		if f == nil || f.Name == "" {
 			continue
 		}
-		if err := saveExternalFactory(f); err != nil {
-			fmt.Fprintf(os.Stderr, "[hub] migrate factory %q: %v\n", f.Name, err)
-			continue
-		}
-		migrated = append(migrated, f.Name)
+		removed = append(removed, f.Name)
 	}
 
-	// Strip factories from hub.yaml so they are never loaded from legacy location again.
-	// This runs even if len(migrated)==0 (all factories already on disk) to prevent
-	// split-brain where hub.yaml and external storage both claim ownership.
 	cfg.Factories = nil
 	if err := config.SaveHubConfig(cfg); err != nil {
-		return migrated, fmt.Errorf("strip factories from hub.yaml: %w", err)
+		return removed, fmt.Errorf("strip factories from hub.yaml: %w", err)
 	}
-	if len(migrated) > 0 {
-		fmt.Println("[hub] stripped migrated factories from hub.yaml")
-	} else {
-		fmt.Println("[hub] no inline factories to migrate — cleared factories from hub.yaml")
+	if len(removed) > 0 {
+		fmt.Printf("[hub] removed %d factory config(s) from hub.yaml (factories/ is retired; use workspace workflows): %s\n",
+			len(removed), strings.Join(removed, ", "))
 	}
-	return migrated, nil
+	return removed, nil
 }

--- a/pkg/hub/external_storage_validation_test.go
+++ b/pkg/hub/external_storage_validation_test.go
@@ -1,27 +1,47 @@
 package hub
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
 
-func TestSaveExternalFactoryRejectsInvalidExcludeLabels(t *testing.T) {
+func TestSaveExternalFactoryIsRetired(t *testing.T) {
 	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
 
 	err := saveExternalFactory(&types.FactoryConfig{
-		Name:          "invalid-label-filter",
+		Name:          "retired-factory",
 		Integration:   "linear",
 		TriggerStatus: "Ready",
 		Template:      "elasticclaw",
-		ExcludeLabels: []string{" "},
 	})
 	if err == nil {
-		t.Fatal("saveExternalFactory succeeded, want validation error")
+		t.Fatal("saveExternalFactory succeeded, want retired error")
 	}
-	if !strings.Contains(err.Error(), "exclude_labels[0] cannot be blank") {
-		t.Fatalf("error = %v, want exclude_labels validation", err)
+	if !strings.Contains(err.Error(), "factories are retired") {
+		t.Fatalf("error = %v, want factories are retired", err)
+	}
+}
+
+func TestLoadExternalFactoriesIgnoresDisk(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	// Even if a leftover factories/ tree exists, load must return empty.
+	dir := filepath.Join(legacyFactoriesDir(), "ghost")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "factory.yaml"), []byte("name: ghost\nintegration: linear\ntrigger_status: Todo\ntemplate: elasticclaw\n"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	factories, err := loadExternalFactories()
+	if err != nil {
+		t.Fatalf("loadExternalFactories: %v", err)
+	}
+	if len(factories) != 0 {
+		t.Fatalf("loadExternalFactories returned %d factories, want 0", len(factories))
 	}
 }
 

--- a/pkg/hub/factory_api.go
+++ b/pkg/hub/factory_api.go
@@ -2,9 +2,7 @@ package hub
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
@@ -74,25 +72,10 @@ func factoryToPushView(f *types.FactoryConfig) FactoryPushView {
 }
 
 func (s *Server) handleFactoriesList(w http.ResponseWriter, r *http.Request) {
-	nameFilter := strings.TrimSpace(r.URL.Query().Get("name"))
-
-	factories, err := loadExternalFactories()
-	if err != nil {
-		http.Error(w, "fs error: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	views := make([]FactoryPushView, 0, len(factories))
-	for _, f := range factories {
-		if f == nil {
-			continue
-		}
-		if nameFilter != "" && !strings.EqualFold(f.Name, nameFilter) {
-			continue
-		}
-		views = append(views, factoryToPushView(f))
-	}
-	jsonOK(w, views)
+	// On-disk factories/ is retired. Always return an empty list so the UI
+	// does not surface ghost automations that no longer run.
+	_ = r
+	jsonOK(w, []FactoryPushView{})
 }
 
 // FactoryPushRequest is the payload for POST /api/factories.
@@ -101,77 +84,14 @@ type FactoryPushRequest struct {
 }
 
 func (s *Server) handleFactoriesPush(w http.ResponseWriter, r *http.Request) {
+	// Drain body so clients don't hang, then reject.
 	var req FactoryPushRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
-		return
-	}
-	if len(req.Factories) == 0 {
-		http.Error(w, "no factories provided", http.StatusBadRequest)
-		return
-	}
-
-	// Validate all factories before saving, so a bad one fails the whole
-	// batch as a 400 instead of a partial save. Notify "via" references get
-	// the same author-time check as workflow saves (see validateNotifyVias).
-	for _, f := range req.Factories {
-		if f == nil {
-			http.Error(w, "factory cannot be nil", http.StatusBadRequest)
-			return
-		}
-		if err := f.Validate(); err != nil {
-			http.Error(w, "validation error: "+err.Error(), http.StatusBadRequest)
-			return
-		}
-		if err := s.validateFactoryNotifyVias(f); err != nil {
-			http.Error(w, "validation error: "+err.Error(), http.StatusBadRequest)
-			return
-		}
-	}
-
-	// Preserve webhook secrets from external storage before overwriting.
-	for _, incoming := range req.Factories {
-		if incoming == nil || incoming.Name == "" {
-			continue
-		}
-		if disk, err := loadExternalFactory(incoming.Name); err == nil {
-			if incoming.WebhookSecret == "" && incoming.WebhookSecretRef == "" && disk.WebhookSecret != "" {
-				incoming.WebhookSecret = disk.WebhookSecret
-			}
-		}
-	}
-
-	// Write each factory to external storage — attempt all writes before
-	// returning so that a failure mid-batch doesn't leave a partial update.
-	var saveErrs []string
-	for _, f := range req.Factories {
-		if f == nil || f.Name == "" {
-			saveErrs = append(saveErrs, "factory name required")
-			continue
-		}
-		if err := saveExternalFactory(f); err != nil {
-			saveErrs = append(saveErrs, fmt.Sprintf("save factory %q: %v", f.Name, err))
-		}
-	}
-	if len(saveErrs) > 0 {
-		http.Error(w, strings.Join(saveErrs, "; "), http.StatusInternalServerError)
-		return
-	}
-
-	// Keep hubCfg.Factories empty — external storage is the only source of truth.
-	// This prevents stale in-memory configs from shadowing disk state.
-
-	views := make([]FactoryPushView, 0, len(req.Factories))
-	for _, f := range req.Factories {
-		views = append(views, factoryToPushView(f))
-	}
-	jsonOK(w, map[string]interface{}{
-		"pushed":    len(req.Factories),
-		"factories": views,
-	})
+	_ = json.NewDecoder(r.Body).Decode(&req)
+	http.Error(w, errFactoriesRetired.Error(), http.StatusGone)
 }
 
 func (s *Server) handleFactoryDelete(w http.ResponseWriter, _ *http.Request, name string) {
+	// Best-effort remove leftover factories/<name> on disk.
 	if err := deleteExternalFactory(name); err != nil {
 		http.Error(w, "delete error: "+err.Error(), http.StatusInternalServerError)
 		return

--- a/pkg/hub/notify_validate_test.go
+++ b/pkg/hub/notify_validate_test.go
@@ -264,44 +264,9 @@ func savedFactoryCount(t *testing.T, s *Server, name string) int {
 	return len(views)
 }
 
-// Factories are a notify surface of their own (the runtime executes their
-// pipeline_yaml notify actions and the doctor judges it as a first-class
-// source), so POST /api/factories must apply the same author-time via check
-// as workflow saves — and fail the whole batch before anything is written.
-func TestFactoriesPushRejectsBadNotifyViaBeforeSavingBatch(t *testing.T) {
-	s := newNotifyValidateTestServer(t, notifyValidateTestNotifiers())
-	body, err := json.Marshal(FactoryPushRequest{Factories: []*types.FactoryConfig{
-		notifyTestFactory("fine", "eng-agents"),
-		notifyTestFactory("probe", "ghost"),
-	}})
-	if err != nil {
-		t.Fatalf("marshal factories push: %v", err)
-	}
-	req := httptest.NewRequest(http.MethodPost, "/api/factories", bytes.NewReader(body))
-	req.Header.Set("Authorization", "Bearer test-token")
-	req.Header.Set("Content-Type", "application/json")
-	rr := httptest.NewRecorder()
-	s.Handler().ServeHTTP(rr, req)
-	if rr.Code != http.StatusBadRequest {
-		t.Fatalf("status = %d, want 400; body = %s", rr.Code, rr.Body.String())
-	}
-	respBody := rr.Body.String()
-	if !strings.Contains(respBody, `factory "probe"`) || !strings.Contains(respBody, `stage "announce"`) || !strings.Contains(respBody, `"ghost"`) {
-		t.Fatalf("error does not locate the offending action: %s", respBody)
-	}
-	if !strings.Contains(respBody, "defined notifiers: eng-agents, ops") {
-		t.Fatalf("error does not list the defined notifiers: %s", respBody)
-	}
-	// The bad factory fails the whole batch: the valid sibling is not saved either.
-	if n := savedFactoryCount(t, s, "probe"); n != 0 {
-		t.Fatalf("rejected factory was saved anyway (%d found)", n)
-	}
-	if n := savedFactoryCount(t, s, "fine"); n != 0 {
-		t.Fatalf("batch with a bad factory saved the valid sibling (%d found)", n)
-	}
-}
-
-func TestFactoriesPushAcceptsValidNotifyVia(t *testing.T) {
+// POST /api/factories is retired with on-disk factories/. Push is rejected
+// with 410 Gone and must not write anything.
+func TestFactoriesPushIsRetired(t *testing.T) {
 	s := newNotifyValidateTestServer(t, notifyValidateTestNotifiers())
 	body, err := json.Marshal(FactoryPushRequest{Factories: []*types.FactoryConfig{
 		notifyTestFactory("probe", "eng-agents"),
@@ -314,58 +279,40 @@ func TestFactoriesPushAcceptsValidNotifyVia(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 	s.Handler().ServeHTTP(rr, req)
-	if rr.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	if rr.Code != http.StatusGone {
+		t.Fatalf("status = %d, want 410; body = %s", rr.Code, rr.Body.String())
 	}
-	if n := savedFactoryCount(t, s, "probe"); n != 1 {
-		t.Fatalf("valid factory not saved (%d found)", n)
+	if !strings.Contains(rr.Body.String(), "factories are retired") {
+		t.Fatalf("body = %q, want retired message", rr.Body.String())
+	}
+	if n := savedFactoryCount(t, s, "probe"); n != 0 {
+		t.Fatalf("retired factory push still saved %d factories", n)
 	}
 }
 
-// The web UI saves factories through PATCH /api/settings; the merged factory
-// about to be persisted must get the same author-time via check. This test
-// also guards the locking shape: patchSettings holds s.mu exclusively, so the
-// check there must not re-enter the lock (a regression deadlocks and times
-// the test out).
-func TestSettingsPatchRejectsFactoryBadNotifyVia(t *testing.T) {
+// Settings factory patches are rejected the same way.
+func TestSettingsPatchRejectsFactories(t *testing.T) {
 	s := newNotifyValidateTestServer(t, notifyValidateTestNotifiers())
-	patchFactories := func(via string) *httptest.ResponseRecorder {
-		body, err := json.Marshal(SettingsPatch{Factories: []FactoryPatch{{
-			Name:                "probe",
-			Integration:         "github",
-			Template:            "default",
-			EnableManualTrigger: true,
-			PipelineYAML:        strings.Replace(factoryPipelineYAMLTemplate, "%s", via, 1),
-		}}})
-		if err != nil {
-			t.Fatalf("marshal settings patch: %v", err)
-		}
-		req := httptest.NewRequest(http.MethodPatch, "/api/settings", bytes.NewReader(body))
-		req.Header.Set("Authorization", "Bearer test-token")
-		req.Header.Set("Content-Type", "application/json")
-		rr := httptest.NewRecorder()
-		s.Handler().ServeHTTP(rr, req)
-		return rr
+	body, err := json.Marshal(SettingsPatch{Factories: []FactoryPatch{{
+		Name:                "probe",
+		Integration:         "github",
+		Template:            "default",
+		EnableManualTrigger: true,
+		PipelineYAML:        strings.Replace(factoryPipelineYAMLTemplate, "%s", "ops", 1),
+	}}})
+	if err != nil {
+		t.Fatalf("marshal settings patch: %v", err)
 	}
-
-	rr := patchFactories("ghost")
-	if rr.Code != http.StatusBadRequest {
-		t.Fatalf("status = %d, want 400; body = %s", rr.Code, rr.Body.String())
-	}
-	respBody := rr.Body.String()
-	if !strings.Contains(respBody, `factory "probe"`) || !strings.Contains(respBody, `stage "announce"`) || !strings.Contains(respBody, `"ghost"`) {
-		t.Fatalf("error does not locate the offending action: %s", respBody)
+	req := httptest.NewRequest(http.MethodPatch, "/api/settings", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusGone {
+		t.Fatalf("status = %d, want 410; body = %s", rr.Code, rr.Body.String())
 	}
 	if n := savedFactoryCount(t, s, "probe"); n != 0 {
-		t.Fatalf("rejected factory was saved anyway (%d found)", n)
-	}
-
-	rr = patchFactories("ops")
-	if rr.Code != http.StatusOK {
-		t.Fatalf("valid via: status = %d, want 200; body = %s", rr.Code, rr.Body.String())
-	}
-	if n := savedFactoryCount(t, s, "probe"); n != 1 {
-		t.Fatalf("valid factory not saved (%d found)", n)
+		t.Fatalf("settings factory patch still saved %d factories", n)
 	}
 }
 

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"sort"
 
 	"github.com/elasticclaw/elasticclaw/pkg/cliversion"
 	"github.com/elasticclaw/elasticclaw/pkg/config"
@@ -582,54 +581,8 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	// Factories — load only from external storage (single source of truth)
+	// Factories are retired; keep an empty slice for API compatibility.
 	view.Factories = []FactoryView{}
-	factories, err := loadExternalFactories()
-	if err != nil {
-		http.Error(w, "failed to load factories: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-	// Sort by name for stable ordering
-	factoryNames := make([]string, 0, len(factories))
-	for _, f := range factories {
-		if f != nil {
-			factoryNames = append(factoryNames, f.Name)
-		}
-	}
-	sort.Strings(factoryNames)
-	factoryMap := make(map[string]*types.FactoryConfig, len(factories))
-	for _, f := range factories {
-		if f != nil {
-			factoryMap[f.Name] = f
-		}
-	}
-	for _, name := range factoryNames {
-		f := factoryMap[name]
-		view.Factories = append(view.Factories, FactoryView{
-			Name:                f.Name,
-			Integration:         f.Integration,
-			Workspace:           f.Workspace,
-			Team:                f.Team,
-			TriggerStatus:       f.TriggerStatus,
-			DoneStatus:          f.DoneStatus,
-			TerminateOnLeave:    f.TerminateOnLeave,
-			Template:            f.Template,
-			NamePattern:         f.NamePattern,
-			WebhookSecretSet:    f.WebhookSecret != "" || f.WebhookSecretRef != "",
-			WebhookSecretRef:    f.WebhookSecretRef,
-			PipelineYAML:        f.PipelineYAML,
-			Tags:                f.Tags,
-			Color:               f.Color,
-			Labels:              f.Labels,
-			ExcludeLabels:       f.ExcludeLabels,
-			AssignedTo:          f.AssignedTo,
-			Enabled:             isFactoryEnabled(f),
-			ConcurrencyGroup:    f.ConcurrencyGroup,
-			EnableManualTrigger: f.EnableManualTrigger,
-			SecretRefs:          f.SecretRefs,
-			ExternalTrigger:     f.ExternalTrigger,
-		})
-	}
 	// Auth config — copy under lock before RUnlock
 	var authView *AuthView
 	if s.hubCfg.Auth != nil {
@@ -1208,139 +1161,14 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 		updatedCfg.ConcurrencyGroups = groups
 	}
 
-	// Factories (full replace) — write directly to external storage, never hubCfg.Factories
+	// Factories are retired. Settings must not write factories/ or hubCfg.Factories.
+	// Non-empty patches are rejected so the UI cannot reintroduce dual-fire automations.
+	if patch.Factories != nil && len(patch.Factories) > 0 {
+		http.Error(w, errFactoriesRetired.Error(), http.StatusGone)
+		return
+	}
 	if patch.Factories != nil {
-		for _, fp := range patch.Factories {
-			// Preserve existing webhook secret if not being replaced
-			webhookSecret := fp.WebhookSecret
-			if webhookSecret == "" {
-				matchName := fp.Name
-				if fp.OriginalName != "" {
-					matchName = fp.OriginalName
-				}
-				if old, err := loadExternalFactory(matchName); err == nil && old.WebhookSecret != "" {
-					webhookSecret = old.WebhookSecret
-				}
-			}
-
-			// For renames, start from the original factory on disk so no fields are lost.
-			baseName := fp.Name
-			if fp.OriginalName != "" && fp.OriginalName != fp.Name {
-				baseName = fp.OriginalName
-			}
-			var disk *types.FactoryConfig
-			if d, err := loadExternalFactory(baseName); err == nil {
-				disk = d
-				if fp.OriginalName != "" && fp.OriginalName != fp.Name {
-					disk.Name = fp.Name // apply the new name
-				}
-			} else {
-				disk = &types.FactoryConfig{Name: fp.Name}
-			}
-
-			if fp.Integration != "" {
-				disk.Integration = fp.Integration
-			}
-			if fp.Workspace != "" {
-				disk.Workspace = fp.Workspace
-			}
-			if fp.Team != "" {
-				disk.Team = fp.Team
-			}
-			if fp.TriggerStatus != "" {
-				disk.TriggerStatus = fp.TriggerStatus
-			}
-			if fp.DoneStatus != "" {
-				disk.DoneStatus = fp.DoneStatus
-			}
-			disk.TerminateOnLeave = fp.TerminateOnLeave
-			if fp.Template != "" {
-				disk.Template = fp.Template
-			}
-			if fp.NamePattern != "" {
-				disk.NamePattern = fp.NamePattern
-			}
-			if webhookSecret != "" {
-				disk.WebhookSecret = webhookSecret
-			}
-			if fp.WebhookSecretRef != "" {
-				disk.WebhookSecretRef = fp.WebhookSecretRef
-			}
-			if fp.PipelineYAML != "" {
-				disk.PipelineYAML = fp.PipelineYAML
-			}
-			if fp.Tags != nil {
-				disk.Tags = fp.Tags
-			}
-			if fp.Color != "" {
-				disk.Color = fp.Color
-			}
-			if fp.Labels != nil {
-				disk.Labels = fp.Labels
-			}
-			if fp.ExcludeLabels != nil {
-				disk.ExcludeLabels = fp.ExcludeLabels
-			}
-			if fp.AssignedTo != "" {
-				disk.AssignedTo = fp.AssignedTo
-			}
-			if fp.Enabled != nil {
-				disk.Enabled = fp.Enabled
-			}
-			if fp.ConcurrencyGroup != "" {
-				disk.ConcurrencyGroup = fp.ConcurrencyGroup
-			}
-			disk.EnableManualTrigger = fp.EnableManualTrigger
-			if fp.SecretRefs != nil {
-				disk.SecretRefs = fp.SecretRefs
-			}
-			if fp.Inputs != nil {
-				disk.Inputs = fp.Inputs
-			}
-			// Integration-specific fields
-			if fp.Repos != nil {
-				disk.Repos = fp.Repos
-			}
-			if fp.Trigger != nil {
-				disk.Trigger = fp.Trigger
-			}
-			if fp.ExternalTrigger != nil {
-				disk.ExternalTrigger = fp.ExternalTrigger
-			}
-
-			if err := disk.Validate(); err != nil {
-				http.Error(w, "validation error: "+err.Error(), http.StatusBadRequest)
-				return
-			}
-			// Author-time notify check on the merged factory about to be
-			// persisted. validateNotifyVias is called directly with the
-			// notifier set instead of via s.validateFactoryNotifyVias: this
-			// handler holds s.mu exclusively, and the helper re-enters the
-			// lock through s.notificationsConfig(). Notifications cannot be
-			// modified by a SettingsPatch, so updatedCfg carries the live set.
-			var notifiers map[string]types.NotifierConfig
-			if updatedCfg.Notifications != nil {
-				notifiers = updatedCfg.Notifications.Notifiers
-			}
-			if err := validateNotifyVias(notifiers, fmt.Sprintf("factory %q", disk.Name), disk.PipelineYAML); err != nil {
-				http.Error(w, "validation error: "+err.Error(), http.StatusBadRequest)
-				return
-			}
-			if err := saveExternalFactory(disk); err != nil {
-				http.Error(w, "failed to save factory "+fp.Name+": "+err.Error(), http.StatusInternalServerError)
-				return
-			}
-
-			// If this was a rename, delete the old factory directory so it doesn't
-			// appear as a phantom duplicate in listings.
-			if fp.OriginalName != "" && fp.OriginalName != fp.Name {
-				if err := deleteExternalFactory(fp.OriginalName); err != nil {
-					http.Error(w, "failed to delete old factory "+fp.OriginalName+": "+err.Error(), http.StatusInternalServerError)
-					return
-				}
-			}
-		}
-		updatedCfg.Factories = nil // never store factories in hubCfg
+		updatedCfg.Factories = nil
 	}
 
 	// Auth config


### PR DESCRIPTION
## Summary
- **Do not load or write** `~/.elasticclaw/factories/` (or hub config dir `factories/`).
- `resolveFactories()` only returns in-memory test factories; production hubs see none from disk.
- Factory push API and settings factory patches return **410 Gone** with a clear migrate-to-workflows message.
- Factory list returns `[]`.
- Hub startup still strips leftover `factories:` from `hub.yaml` but no longer migrates them onto disk.
- CLI `factory create/push` fail with workflow migration instructions.

This stops leftover factory configs from dual-creating claws next to workspace workflows (e.g. Linear Todo → workflow + factory).

## Operator note
After deploy, leftover `factories/` on disk is ignored. You may delete it:

```bash
rm -rf ~/.elasticclaw/factories
# or /var/lib/elasticclaw/factories for system installs
```

Use:

```bash
elasticclaw workspace push --path <dir> <name>
elasticclaw workflow push --workspace <name> <workflow.yaml>
```

## Test plan
- [x] `go test ./pkg/hub/ ./cmd/`
- [ ] Deploy hub with a leftover `factories/foo` + workspace workflow on same Linear trigger → only workflow creates a claw
- [ ] `POST /api/factories` returns 410
- [ ] `GET /api/factories` returns `[]`