### PR TITLE
fix(ui,hub): keep stream text visible across tool calls

### DIFF
--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -314,12 +314,30 @@ func (s *Server) flushStreamingSegment(clawID, tenantID string, cc *clawConn) er
 	cc.streamingSplit = true
 	cc.mu.Unlock()
 
+	createdAt := now()
 	_, err := s.db.Exec(
 		`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at,delivered_at) VALUES(?,?,?,?,?,?,?)
 		 ON CONFLICT(id) DO UPDATE SET content=excluded.content, delivered_at=excluded.delivered_at`,
-		msgID, clawID, tenantID, "claw", content, now(), now(),
+		msgID, clawID, tenantID, "claw", content, createdAt, createdAt,
 	)
-	return err
+	if err != nil {
+		return err
+	}
+	// Broadcast the flushed segment so the UI keeps prior turn text when a tool
+	// call interrupts streaming. Without this, only the client typewriter
+	// snapshot holds the text — and the final message handler used to wipe it.
+	s.broadcastToUsers(tenantID, types.WSMessage{
+		Type: "message",
+		Payload: types.HubMessage{
+			ID:        msgID,
+			ClawID:    clawID,
+			TenantID:  tenantID,
+			Role:      "claw",
+			Content:   content,
+			CreatedAt: createdAt,
+		},
+	})
+	return nil
 }
 
 type userConn struct {

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -1471,6 +1471,7 @@ func TestSplitStreamingTurnDoesNotBroadcastGhostFinalMessage(t *testing.T) {
 
 	seenIdle := false
 	seenGhostMessage := false
+	seenSegmentMessage := false
 	readUntil := time.Now().Add(2 * time.Second)
 	for time.Now().Before(readUntil) && !seenIdle {
 		readCtx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
@@ -1484,8 +1485,13 @@ func TestSplitStreamingTurnDoesNotBroadcastGhostFinalMessage(t *testing.T) {
 		case "message":
 			payload, _ := json.Marshal(msg.Payload)
 			var hm types.HubMessage
-			if err := json.Unmarshal(payload, &hm); err == nil && hm.Content == finalContent {
-				seenGhostMessage = true
+			if err := json.Unmarshal(payload, &hm); err == nil {
+				if hm.Content == finalContent {
+					seenGhostMessage = true
+				}
+				if hm.Content == "Assistant segment 1" {
+					seenSegmentMessage = true
+				}
 			}
 		case "agent_typing":
 			payload, _ := json.Marshal(msg.Payload)
@@ -1503,6 +1509,9 @@ func TestSplitStreamingTurnDoesNotBroadcastGhostFinalMessage(t *testing.T) {
 	}
 	if seenGhostMessage {
 		t.Fatal("observed unpersisted final full-response message over user websocket")
+	}
+	if !seenSegmentMessage {
+		t.Fatal("did not observe flushed segment broadcast over user websocket")
 	}
 
 	var finalRows int

--- a/web/hooks/use-hub.ts
+++ b/web/hooks/use-hub.ts
@@ -341,16 +341,18 @@ export function useHub(selectedClawId: string | null): HubState {
         const cachedOnly = existingNonOpt.filter((m) => !apiIds.has(m.id))
         const inflight = existing.filter((m) => m.id.startsWith('opt-') &&
           !msgs.some((r) => r.content === m.content && r.role === m.role))
-        // Keep in-flight tool activity so selecting a claw mid-turn does not blank
-        // the UI. Live text fragments are only valid while a segmented stream is
-        // open (segmentedStreamRef); once the durable final lands the ref is
-        // cleared and fragments must go so we never double-render beside the
-        // timeline reply. Avoid timestamp heuristics — equal ms and nearby
-        // previous-turn replies both mis-classify "is this the current final?".
-        const streamInProgress = Boolean(segmentedStreamRef.current[clawId])
+        // Keep in-flight tool activity and live text segments that the API has
+        // not yet returned. Live segments must survive tool boundaries and
+        // timeline reloads — otherwise the transcript blanks until a full
+        // page refresh reloads durable rows from the server.
         const liveTransient = existing.filter((m) => {
           if (!isTransientMessage(m)) return false
-          if (m.id.startsWith("live-")) return streamInProgress
+          if (m.id.startsWith("live-")) {
+            // Drop only when a durable API row already carries the same text.
+            return !msgs.some(
+              (api) => api.role === m.role && api.content === m.content
+            )
+          }
           return true
         })
         const merged = pruneOldestLiveActivities(
@@ -492,12 +494,7 @@ export function useHub(selectedClawId: string | null): HubState {
           // Final message — hold until typewriter drains, then commit
           const msg = mapApiMessage(payload)
           const clawId = payload.claw_id
-          if (segmentedStreamRef.current[clawId]) {
-            // Drop any remaining typewriter tail — the durable final message is
-            // the canonical full reply (same content a refresh would load).
-            clearTypewriter(clawId)
-            delete segmentedStreamRef.current[clawId]
-            // Called once typewriter is fully drained — safe to add final message
+          const commitFinalMessage = () => {
             setClaws((prev) =>
               prev.map((c) =>
                 c.id === clawId
@@ -513,43 +510,54 @@ export function useHub(selectedClawId: string | null): HubState {
               )
             )
             setMessages((prev) => {
-              // Replace live text fragments with the durable server message so
-              // end-of-stream matches timeline/refresh. Keep live activity rows
-              // for the current turn (refresh shows activity_summary instead).
-              const nextMessages = withoutModelWaitActivities(prev[clawId] || []).filter(
-                (m) => !m.id.startsWith(`live-segment-${clawId}-`)
-              )
+              // Keep prior live-segment rows on tool-interrupted turns. The final
+              // message is often only the post-tool tail; wiping live-segments
+              // blanked the transcript until a full page refresh.
+              const nextMessages = withoutModelWaitActivities(prev[clawId] || [])
               if (!nextMessages.some((m) => m.id === msg.id)) {
-                nextMessages.push(msg)
+                const lastLiveIdx = (() => {
+                  for (let i = nextMessages.length - 1; i >= 0; i -= 1) {
+                    if (
+                      nextMessages[i].id.startsWith("live-") &&
+                      nextMessages[i].role === msg.role
+                    ) {
+                      return i
+                    }
+                  }
+                  return -1
+                })()
+                if (
+                  lastLiveIdx >= 0 &&
+                  nextMessages[lastLiveIdx].content === msg.content
+                ) {
+                  // Promote live row to durable id to avoid double-render.
+                  nextMessages[lastLiveIdx] = {
+                    ...nextMessages[lastLiveIdx],
+                    id: msg.id,
+                    timestamp: msg.timestamp,
+                  }
+                } else {
+                  nextMessages.push(msg)
+                }
               }
-              const pruned = pruneOldestLiveActivities(nextMessages, MAX_LIVE_ACTIVITIES_PER_CLAW)
+              const pruned = pruneOldestLiveActivities(
+                nextMessages,
+                MAX_LIVE_ACTIVITIES_PER_CLAW
+              )
               const next = { ...prev, [clawId]: pruned }
               persistMessages(next)
               return next
             })
+          }
+
+          if (segmentedStreamRef.current[clawId]) {
+            // Segments already committed as live-*/hub messages; drop typewriter tail.
+            clearTypewriter(clawId)
+            delete segmentedStreamRef.current[clawId]
+            commitFinalMessage()
           } else {
-            finalizeTypewriter(clawId, () => {
-              // Called once typewriter is fully drained — safe to add final message
-              setClaws((prev) =>
-                prev.map((c) =>
-                  c.id === clawId
-                    ? {
-                        ...c,
-                        isStreaming: false,
-                        unreadCount:
-                          selectedClawIdRef.current !== clawId && msg.role === "claw"
-                            ? c.unreadCount + 1
-                            : c.unreadCount,
-                      }
-                    : c
-                )
-              )
-              setMessages((prev) => {
-                const next = { ...prev, [clawId]: [...withoutModelWaitActivities(prev[clawId] || []), msg] }
-                persistMessages(next)
-                return next
-              })
-            })
+            // Uninterrupted turn: let the typewriter finish revealing, then commit.
+            finalizeTypewriter(clawId, commitFinalMessage)
           }
         } else if (type === "claw_status") {
           const { claw_id, status } = payload

--- a/web/hooks/use-hub.ts
+++ b/web/hooks/use-hub.ts
@@ -15,6 +15,7 @@ import {
 } from "@/lib/api"
 import { mapApiClaw, mapApiMessage, mapApiStatus, computeUptime } from "@/lib/mappers"
 import {
+  isLiveSegmentCoveredByDurable,
   isTerminalAssistantMessage,
   isTransientMessage,
   pruneOldestLiveActivities,
@@ -345,13 +346,13 @@ export function useHub(selectedClawId: string | null): HubState {
         // not yet returned. Live segments must survive tool boundaries and
         // timeline reloads — otherwise the transcript blanks until a full
         // page refresh reloads durable rows from the server.
+        // Drop a live segment only when a nearby durable API row is its flush
+        // (role+content+time), not when any older turn reused the same prose.
+        const claimedDurableIds = new Set<string>()
         const liveTransient = existing.filter((m) => {
           if (!isTransientMessage(m)) return false
           if (m.id.startsWith("live-")) {
-            // Drop only when a durable API row already carries the same text.
-            return !msgs.some(
-              (api) => api.role === m.role && api.content === m.content
-            )
+            return !isLiveSegmentCoveredByDurable(m, msgs, claimedDurableIds)
           }
           return true
         })

--- a/web/hooks/use-windowed-messages.ts
+++ b/web/hooks/use-windowed-messages.ts
@@ -3,6 +3,7 @@
 import { useState, useRef, useCallback, useEffect } from "react"
 import { fetchMessageTimeline } from "@/lib/api"
 import { mapApiMessage } from "@/lib/mappers"
+import { isLiveSegmentCoveredByDurable } from "@/lib/messages"
 import type { Message } from "@/lib/types"
 
 // Timeline page size — durable turns + activity_summary rows (not live tool floods).
@@ -124,17 +125,15 @@ export function useWindowedMessages({ clawId, liveMessages }: UseWindowedMessage
     for (const m of historicalMsgs) {
       if (!seen.has(m.id)) { seen.add(m.id); all.push(m) }
     }
+    // Claim durable ids so repeated assistant text across turns does not
+    // hide a new live segment that happens to match older prose.
+    const claimedDurableIds = new Set<string>()
     for (const m of liveMessages) {
       if (seen.has(m.id)) continue
       if (all.some((existing) => isDuplicateLiveActivity(existing, m))) continue
-      // Prefer durable API rows over client live-segment clones of the same text
-      // so tool-interrupted turns do not double-render after the hub flushes a segment.
-      if (
-        m.id.startsWith("live-") &&
-        all.some((existing) => existing.role === m.role && existing.content === m.content)
-      ) {
-        continue
-      }
+      // Drop live only when a nearby durable row is this segment's flush —
+      // not every historical message with identical content.
+      if (isLiveSegmentCoveredByDurable(m, all, claimedDurableIds)) continue
       seen.add(m.id)
       all.push(m)
     }

--- a/web/hooks/use-windowed-messages.ts
+++ b/web/hooks/use-windowed-messages.ts
@@ -127,6 +127,14 @@ export function useWindowedMessages({ clawId, liveMessages }: UseWindowedMessage
     for (const m of liveMessages) {
       if (seen.has(m.id)) continue
       if (all.some((existing) => isDuplicateLiveActivity(existing, m))) continue
+      // Prefer durable API rows over client live-segment clones of the same text
+      // so tool-interrupted turns do not double-render after the hub flushes a segment.
+      if (
+        m.id.startsWith("live-") &&
+        all.some((existing) => existing.role === m.role && existing.content === m.content)
+      ) {
+        continue
+      }
       seen.add(m.id)
       all.push(m)
     }

--- a/web/lib/messages.ts
+++ b/web/lib/messages.ts
@@ -13,8 +13,10 @@ export function isTransientMessage(message: Message): boolean {
   )
 }
 
-/** How close a durable row must be to a live segment to count as its flush. */
+/** How long after a live segment a durable flush may still count as its twin. */
 export const LIVE_SEGMENT_DURABLE_MATCH_MS = 60_000
+/** Allow durable timestamps slightly before live (client/server clock skew). */
+export const LIVE_SEGMENT_CLOCK_SKEW_MS = 5_000
 
 function messageTimeMs(message: Message): number {
   return message.timestamp instanceof Date
@@ -24,19 +26,25 @@ function messageTimeMs(message: Message): number {
 
 /**
  * True when a client live-* segment is already represented by a durable
- * timeline/API message (hub flush or promoted final). Matches only durable
- * rows with the same role+content near the live timestamp. When
- * `claimedDurableIds` is provided, each durable id is claimed at most once so
- * repeated assistant phrasing across turns does not hide the current stream.
+ * timeline/API message (hub flush or promoted final).
+ *
+ * A durable row covers a live segment only when:
+ * - same role + content
+ * - durable time is in [live − skew, live + match window] so an *earlier*
+ *   durable with the same prose (even within 60s) cannot hide a new stream
+ * - each durable id is claimed at most once when `claimedDurableIds` is set
  */
 export function isLiveSegmentCoveredByDurable(
   live: Message,
   durableCandidates: Message[],
   claimedDurableIds?: Set<string>,
-  maxDeltaMs: number = LIVE_SEGMENT_DURABLE_MATCH_MS
+  maxDeltaMs: number = LIVE_SEGMENT_DURABLE_MATCH_MS,
+  clockSkewMs: number = LIVE_SEGMENT_CLOCK_SKEW_MS
 ): boolean {
   if (!live.id.startsWith("live-") || !live.content.trim()) return false
   const liveTime = messageTimeMs(live)
+  const earliest = liveTime - clockSkewMs
+  const latest = liveTime + maxDeltaMs
   let bestId: string | null = null
   let bestDelta = Infinity
   for (const durable of durableCandidates) {
@@ -44,8 +52,11 @@ export function isLiveSegmentCoveredByDurable(
     if (durable.role === "activity" || durable.role === "activity_summary") continue
     if (claimedDurableIds?.has(durable.id)) continue
     if (durable.role !== live.role || durable.content !== live.content) continue
-    const delta = Math.abs(messageTimeMs(durable) - liveTime)
-    if (delta <= maxDeltaMs && delta < bestDelta) {
+    const durableTime = messageTimeMs(durable)
+    // Earlier durable with the same text is a previous turn — not this flush.
+    if (durableTime < earliest || durableTime > latest) continue
+    const delta = Math.abs(durableTime - liveTime)
+    if (delta < bestDelta) {
       bestDelta = delta
       bestId = durable.id
     }

--- a/web/lib/messages.ts
+++ b/web/lib/messages.ts
@@ -15,8 +15,6 @@ export function isTransientMessage(message: Message): boolean {
 
 /** How long after a live segment a durable flush may still count as its twin. */
 export const LIVE_SEGMENT_DURABLE_MATCH_MS = 60_000
-/** Allow durable timestamps slightly before live (client/server clock skew). */
-export const LIVE_SEGMENT_CLOCK_SKEW_MS = 5_000
 
 function messageTimeMs(message: Message): number {
   return message.timestamp instanceof Date
@@ -30,20 +28,18 @@ function messageTimeMs(message: Message): number {
  *
  * A durable row covers a live segment only when:
  * - same role + content
- * - durable time is in [live − skew, live + match window] so an *earlier*
- *   durable with the same prose (even within 60s) cannot hide a new stream
+ * - durable time is in [live, live + match window] — never *before* live, so
+ *   a preceding durable with the same prose cannot hide a new segment
  * - each durable id is claimed at most once when `claimedDurableIds` is set
  */
 export function isLiveSegmentCoveredByDurable(
   live: Message,
   durableCandidates: Message[],
   claimedDurableIds?: Set<string>,
-  maxDeltaMs: number = LIVE_SEGMENT_DURABLE_MATCH_MS,
-  clockSkewMs: number = LIVE_SEGMENT_CLOCK_SKEW_MS
+  maxDeltaMs: number = LIVE_SEGMENT_DURABLE_MATCH_MS
 ): boolean {
   if (!live.id.startsWith("live-") || !live.content.trim()) return false
   const liveTime = messageTimeMs(live)
-  const earliest = liveTime - clockSkewMs
   const latest = liveTime + maxDeltaMs
   let bestId: string | null = null
   let bestDelta = Infinity
@@ -53,9 +49,10 @@ export function isLiveSegmentCoveredByDurable(
     if (claimedDurableIds?.has(durable.id)) continue
     if (durable.role !== live.role || durable.content !== live.content) continue
     const durableTime = messageTimeMs(durable)
-    // Earlier durable with the same text is a previous turn — not this flush.
-    if (durableTime < earliest || durableTime > latest) continue
-    const delta = Math.abs(durableTime - liveTime)
+    // Strictly no earlier durable: preceding same-text rows are prior turns.
+    // Equal timestamps OK (same flush event / rounded ms).
+    if (durableTime < liveTime || durableTime > latest) continue
+    const delta = durableTime - liveTime
     if (delta < bestDelta) {
       bestDelta = delta
       bestId = durable.id

--- a/web/lib/messages.ts
+++ b/web/lib/messages.ts
@@ -13,6 +13,48 @@ export function isTransientMessage(message: Message): boolean {
   )
 }
 
+/** How close a durable row must be to a live segment to count as its flush. */
+export const LIVE_SEGMENT_DURABLE_MATCH_MS = 60_000
+
+function messageTimeMs(message: Message): number {
+  return message.timestamp instanceof Date
+    ? message.timestamp.getTime()
+    : new Date(message.timestamp).getTime()
+}
+
+/**
+ * True when a client live-* segment is already represented by a durable
+ * timeline/API message (hub flush or promoted final). Matches only durable
+ * rows with the same role+content near the live timestamp. When
+ * `claimedDurableIds` is provided, each durable id is claimed at most once so
+ * repeated assistant phrasing across turns does not hide the current stream.
+ */
+export function isLiveSegmentCoveredByDurable(
+  live: Message,
+  durableCandidates: Message[],
+  claimedDurableIds?: Set<string>,
+  maxDeltaMs: number = LIVE_SEGMENT_DURABLE_MATCH_MS
+): boolean {
+  if (!live.id.startsWith("live-") || !live.content.trim()) return false
+  const liveTime = messageTimeMs(live)
+  let bestId: string | null = null
+  let bestDelta = Infinity
+  for (const durable of durableCandidates) {
+    if (isTransientMessage(durable)) continue
+    if (durable.role === "activity" || durable.role === "activity_summary") continue
+    if (claimedDurableIds?.has(durable.id)) continue
+    if (durable.role !== live.role || durable.content !== live.content) continue
+    const delta = Math.abs(messageTimeMs(durable) - liveTime)
+    if (delta <= maxDeltaMs && delta < bestDelta) {
+      bestDelta = delta
+      bestId = durable.id
+    }
+  }
+  if (!bestId) return false
+  claimedDurableIds?.add(bestId)
+  return true
+}
+
 /**
  * Durable conversation rows that must not be aged out by a flood of live
  * tool/activity events. Includes timeline activity_summary placeholders.


### PR DESCRIPTION
## Summary
Fixes the demo-breaking UI bug where assistant messages disappeared when tool calls started, until a full page refresh.

### Cause
1. On tool activity, the hub flushed the current stream segment to the DB but **did not broadcast** it as a `message`.
2. The UI kept that text only as a client `live-segment-*` row.
3. When the final turn message arrived (often just the **post-tool** tail), the UI **deleted all live-segments**, wiping earlier text until refresh reloaded durable DB rows.

### Fix
- **Hub:** `flushStreamingSegment` broadcasts the segment as a normal `message` (same content already in DB).
- **UI:** Never wipe live-segments on final message; promote a matching last live row to the durable id, otherwise append.
- **UI:** Timeline reload keeps live-segments until an API row with the same content exists.
- **UI:** Windowed merge prefers durable API rows over live clones of the same text.

Tool calls remain collapsed via existing activity summary groups. Chat view still loads older pages on scroll-up.

## Test plan
- [x] `go test ./pkg/hub/ -run TestSplitStreamingTurnDoesNotBroadcastGhostFinalMessage`
- [ ] Open a claw mid-tool-use: streamed text before a tool call stays on screen without refresh
- [ ] Multiple tool calls: each text segment remains; tools stay collapsed
- [ ] Scroll-up in full chat still loads older history
- [ ] Hard refresh still shows full durable transcript