### PR TITLE
fix(hub): request workflows write on GitHub installation tokens

### DIFF
--- a/pkg/hub/github.go
+++ b/pkg/hub/github.go
@@ -21,6 +21,9 @@ type githubInstallation struct {
 	Account struct {
 		Login string `json:"login"`
 	} `json:"account"`
+	// Permissions are the scopes granted to this installation (may lag the
+	// App's configured permissions until the owner accepts an update).
+	Permissions map[string]string `json:"permissions"`
 }
 
 // githubAppMeta is the response from GET /app (authenticated as the App).
@@ -259,9 +262,12 @@ func (p *GitHubTokenProvider) InstallationToken(ctx context.Context, installatio
 	}
 
 	// Build request body with correct permissions.
-	// Installation tokens only receive the permissions listed here (capped by the
-	// App's granted permissions). contents=write alone is not enough to create or
-	// update files under .github/workflows/ — GitHub requires the workflows scope.
+	// Installation tokens only receive the permissions listed here (capped by
+	// what this installation was granted). Requesting a scope the installation
+	// lacks makes POST /access_tokens fail — so optional scopes like workflows
+	// are included only after GET /app/installations/{id} confirms write/admin.
+	// contents=write alone is not enough to create or update files under
+	// .github/workflows/; GitHub requires the workflows scope when available.
 	var bodyStr string
 	if len(repos) > 0 {
 		needsWrite := false
@@ -282,9 +288,7 @@ func (p *GitHubTokenProvider) InstallationToken(ctx context.Context, installatio
 			"checks":        "read", // needed for gh pr checks / CI status
 			"statuses":      "read", // needed for commit status checks
 		}
-		// Match contents: agents that can push code must also be able to open PRs
-		// that touch workflow files when the App has workflows permission.
-		if needsWrite {
+		if needsWrite && p.installationHasWorkflowsWrite(ctx, installationID) {
 			perms["workflows"] = "write"
 		}
 		body := map[string]interface{}{
@@ -372,4 +376,56 @@ func (p *GitHubTokenProvider) CheckAppPermissions(ctx context.Context) (map[stri
 		return nil, fmt.Errorf("decode app meta: %w", err)
 	}
 	return meta.Permissions, nil
+}
+
+// installationHasWorkflowsWrite reports whether this installation was granted
+// workflows write (or admin). App-level config is not enough: an org may still
+// be on an older permission set until they accept the App update. On lookup
+// failure, returns false so we omit the scope and still mint a working token.
+func (p *GitHubTokenProvider) installationHasWorkflowsWrite(ctx context.Context, installationID int64) bool {
+	if installationID == 0 {
+		return false
+	}
+	perms, err := p.installationPermissions(ctx, installationID)
+	if err != nil || perms == nil {
+		return false
+	}
+	level := strings.ToLower(strings.TrimSpace(perms["workflows"]))
+	return level == "write" || level == "admin"
+}
+
+// installationPermissions returns the scopes granted to a specific installation
+// via GET /app/installations/{id}.
+func (p *GitHubTokenProvider) installationPermissions(ctx context.Context, installationID int64) (map[string]string, error) {
+	appJWT, err := p.appJWT()
+	if err != nil {
+		return nil, fmt.Errorf("sign app jwt: %w", err)
+	}
+
+	url := p.apiURL(fmt.Sprintf("/app/installations/%d", installationID))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+appJWT)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("github get installation: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		var errBody map[string]interface{}
+		json.NewDecoder(resp.Body).Decode(&errBody)
+		return nil, fmt.Errorf("github get installation %d: %v", resp.StatusCode, errBody["message"])
+	}
+
+	var inst githubInstallation
+	if err := json.NewDecoder(resp.Body).Decode(&inst); err != nil {
+		return nil, fmt.Errorf("decode installation: %w", err)
+	}
+	return inst.Permissions, nil
 }

--- a/pkg/hub/github.go
+++ b/pkg/hub/github.go
@@ -259,7 +259,9 @@ func (p *GitHubTokenProvider) InstallationToken(ctx context.Context, installatio
 	}
 
 	// Build request body with correct permissions.
-	// GitHub token permissions: contents=read means read-only, contents=write means read+write.
+	// Installation tokens only receive the permissions listed here (capped by the
+	// App's granted permissions). contents=write alone is not enough to create or
+	// update files under .github/workflows/ — GitHub requires the workflows scope.
 	var bodyStr string
 	if len(repos) > 0 {
 		needsWrite := false
@@ -273,14 +275,20 @@ func (p *GitHubTokenProvider) InstallationToken(ctx context.Context, installatio
 		if needsWrite {
 			contentsPermission = "write"
 		}
+		perms := map[string]string{
+			"contents":      contentsPermission,
+			"pull_requests": contentsPermission,
+			"metadata":      "read",
+			"checks":        "read", // needed for gh pr checks / CI status
+			"statuses":      "read", // needed for commit status checks
+		}
+		// Match contents: agents that can push code must also be able to open PRs
+		// that touch workflow files when the App has workflows permission.
+		if needsWrite {
+			perms["workflows"] = "write"
+		}
 		body := map[string]interface{}{
-			"permissions": map[string]string{
-				"contents":      contentsPermission,
-				"pull_requests": contentsPermission,
-				"metadata":      "read",
-				"checks":        "read", // needed for gh pr checks / CI status
-				"statuses":      "read", // needed for commit status checks
-			},
+			"permissions": perms,
 		}
 		if len(repos) <= maxScopedInstallationRepos {
 			repoNames := make([]string, 0, len(repos))

--- a/pkg/hub/github_token_refresh_test.go
+++ b/pkg/hub/github_token_refresh_test.go
@@ -109,19 +109,23 @@ func TestGitHubBootstrapCloneTimeoutScalesWithRepoCount(t *testing.T) {
 	}
 }
 
-func TestInstallationTokenOmitsNameListAboveGitHubCap(t *testing.T) {
-	// GitHub rejects repositories arrays longer than 50. We still mint a
-	// permission-restricted installation token so 50+ workspaces work; git
-	// clones should use ?repo= for least privilege.
-	var sawBody string
+// githubInstallationTokenTestServer mocks token mint + installation permission lookup.
+// installPermissionsJSON is the permissions object returned by GET /app/installations/{id}.
+func githubInstallationTokenTestServer(t *testing.T, installPermissionsJSON string, onAccessToken func(body string)) *httptest.Server {
+	t.Helper()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/app/installations"):
+		case r.Method == http.MethodGet && r.URL.Path == "/app/installations/99":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":99,"account":{"login":"org"},"permissions":` + installPermissionsJSON + `}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/app/installations":
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`[{"id":99,"account":{"login":"org"}}]`))
 		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/access_tokens"):
 			body, _ := io.ReadAll(r.Body)
-			sawBody = string(body)
+			if onAccessToken != nil {
+				onAccessToken(string(body))
+			}
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
 			_, _ = w.Write([]byte(`{"token":"tok","expires_at":"2099-01-01T00:00:00Z"}`))
@@ -130,6 +134,17 @@ func TestInstallationTokenOmitsNameListAboveGitHubCap(t *testing.T) {
 		}
 	}))
 	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestInstallationTokenOmitsNameListAboveGitHubCap(t *testing.T) {
+	// GitHub rejects repositories arrays longer than 50. We still mint a
+	// permission-restricted installation token so 50+ workspaces work; git
+	// clones should use ?repo= for least privilege.
+	var sawBody string
+	srv := githubInstallationTokenTestServer(t, `{"contents":"write","workflows":"write"}`, func(body string) {
+		sawBody = body
+	})
 
 	provider, err := NewGitHubTokenProvider(&types.GitHubAppConfig{AppID: 1, PrivateKeyPEM: testGitHubAppPEM(t)})
 	if err != nil {
@@ -152,28 +167,15 @@ func TestInstallationTokenOmitsNameListAboveGitHubCap(t *testing.T) {
 		t.Fatalf("expected write permissions, body=%s", sawBody)
 	}
 	if !strings.Contains(sawBody, `"workflows":"write"`) {
-		t.Fatalf("expected workflows write permission for write-scoped tokens, body=%s", sawBody)
+		t.Fatalf("expected workflows write when installation grants it, body=%s", sawBody)
 	}
 }
 
 func TestInstallationTokenScopesRepositoryAllowlist(t *testing.T) {
 	var sawBody string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/app/installations"):
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`[{"id":99,"account":{"login":"org"}}]`))
-		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/access_tokens"):
-			body, _ := io.ReadAll(r.Body)
-			sawBody = string(body)
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusCreated)
-			_, _ = w.Write([]byte(`{"token":"tok","expires_at":"2099-01-01T00:00:00Z"}`))
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	t.Cleanup(srv.Close)
+	srv := githubInstallationTokenTestServer(t, `{"contents":"write","workflows":"write"}`, func(body string) {
+		sawBody = body
+	})
 
 	provider, err := NewGitHubTokenProvider(&types.GitHubAppConfig{AppID: 1, PrivateKeyPEM: testGitHubAppPEM(t)})
 	if err != nil {
@@ -193,7 +195,65 @@ func TestInstallationTokenScopesRepositoryAllowlist(t *testing.T) {
 		t.Fatalf("expected write permissions, body=%s", sawBody)
 	}
 	if !strings.Contains(sawBody, `"workflows":"write"`) {
-		t.Fatalf("expected workflows write permission for write-scoped tokens, body=%s", sawBody)
+		t.Fatalf("expected workflows write when installation grants it, body=%s", sawBody)
+	}
+}
+
+func TestInstallationTokenOmitsWorkflowsWhenInstallLacksPermission(t *testing.T) {
+	var sawBody string
+	// Installation has contents write but no workflows — requesting workflows would fail mint.
+	srv := githubInstallationTokenTestServer(t, `{"contents":"write","pull_requests":"write"}`, func(body string) {
+		sawBody = body
+	})
+
+	provider, err := NewGitHubTokenProvider(&types.GitHubAppConfig{AppID: 1, PrivateKeyPEM: testGitHubAppPEM(t)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	provider.apiBaseURL = srv.URL
+	provider.httpClient = srv.Client()
+
+	if _, _, err := provider.InstallationToken(context.Background(), 99, []RepoAccess{{Repo: "org/a", Permissions: "write"}}); err != nil {
+		t.Fatalf("InstallationToken: %v", err)
+	}
+	if !strings.Contains(sawBody, `"contents":"write"`) {
+		t.Fatalf("expected write permissions, body=%s", sawBody)
+	}
+	if strings.Contains(sawBody, `"workflows"`) {
+		t.Fatalf("must not request workflows when installation lacks it, body=%s", sawBody)
+	}
+}
+
+func TestInstallationTokenOmitsWorkflowsWhenInstallLookupFails(t *testing.T) {
+	var sawBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/app/installations/99":
+			http.Error(w, `{"message":"boom"}`, http.StatusInternalServerError)
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/access_tokens"):
+			body, _ := io.ReadAll(r.Body)
+			sawBody = string(body)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"token":"tok","expires_at":"2099-01-01T00:00:00Z"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	provider, err := NewGitHubTokenProvider(&types.GitHubAppConfig{AppID: 1, PrivateKeyPEM: testGitHubAppPEM(t)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	provider.apiBaseURL = srv.URL
+	provider.httpClient = srv.Client()
+
+	if _, _, err := provider.InstallationToken(context.Background(), 99, []RepoAccess{{Repo: "org/a", Permissions: "write"}}); err != nil {
+		t.Fatalf("InstallationToken: %v", err)
+	}
+	if strings.Contains(sawBody, `"workflows"`) {
+		t.Fatalf("must omit workflows when installation permission lookup fails, body=%s", sawBody)
 	}
 }
 

--- a/pkg/hub/github_token_refresh_test.go
+++ b/pkg/hub/github_token_refresh_test.go
@@ -151,6 +151,9 @@ func TestInstallationTokenOmitsNameListAboveGitHubCap(t *testing.T) {
 	if !strings.Contains(sawBody, `"contents":"write"`) {
 		t.Fatalf("expected write permissions, body=%s", sawBody)
 	}
+	if !strings.Contains(sawBody, `"workflows":"write"`) {
+		t.Fatalf("expected workflows write permission for write-scoped tokens, body=%s", sawBody)
+	}
 }
 
 func TestInstallationTokenScopesRepositoryAllowlist(t *testing.T) {
@@ -188,6 +191,9 @@ func TestInstallationTokenScopesRepositoryAllowlist(t *testing.T) {
 	}
 	if !strings.Contains(sawBody, `"contents":"write"`) {
 		t.Fatalf("expected write permissions, body=%s", sawBody)
+	}
+	if !strings.Contains(sawBody, `"workflows":"write"`) {
+		t.Fatalf("expected workflows write permission for write-scoped tokens, body=%s", sawBody)
 	}
 }
 


### PR DESCRIPTION
## Summary
Agents with write access could not open PRs that touch `.github/workflows/*` files, even when the GitHub App was granted **Read and write access to workflows**.

GitHub installation tokens only get the permissions **requested at mint time** (subset of the App's grants). ElasticClaw requested:

- `contents`
- `pull_requests`
- `metadata` / `checks` / `statuses` (read)

…but **not** `workflows`. GitHub then rejects commits/PRs that modify workflow files.

### Fix
For write-scoped installation tokens, also request `workflows: write`.

## Not a workspace misconfig
Your App permissions were fine. The hub token mint path was incomplete.

## Test plan
- [x] `go test ./pkg/hub/ -run TestInstallationToken`
- [ ] Deploy hub, start a new claw (token is minted at bootstrap / credential helper refresh)
- [ ] Agent PR that edits a workflow file should succeed with the same App permissions