### PR TITLE
feat(hub): deterministic plan_gate with freeform fallback

### DIFF
--- a/pkg/hub/pipeline/pipeline.go
+++ b/pkg/hub/pipeline/pipeline.go
@@ -27,6 +27,11 @@ type Stage struct {
 	// prior run action) and produces a pass/fail verdict that can drive
 	// automatic stage transitions via gate_result triggers.
 	Gate *Gate `yaml:"gate,omitempty"`
+	// PlanGate marks this stage's gate as the workflow's plan-approval gate.
+	// When any stage has plan_gate: true with a configured gate, the hub skips
+	// freeform initial-plan keyword approval for claws on this pipeline so
+	// plan acceptance is deterministic and not double-enforced.
+	PlanGate bool `yaml:"plan_gate,omitempty"`
 }
 
 // StageSkip defines a pre-enter stage skip rule. When the condition evaluates
@@ -514,6 +519,22 @@ func (p *Pipeline) EntryStage() *Stage {
 		}
 	}
 	return nil
+}
+
+// HasPlanGate reports whether this pipeline opts into deterministic plan
+// approval: at least one stage with plan_gate: true and a configured gate.
+// Ordinary validation gates do not count — freeform hub plan approval remains
+// the default for existing workflows.
+func (p *Pipeline) HasPlanGate() bool {
+	if p == nil {
+		return false
+	}
+	for i := range p.Stages {
+		if p.Stages[i].PlanGate && p.Stages[i].Gate != nil {
+			return true
+		}
+	}
+	return false
 }
 
 // StageByID returns the stage with the given ID, or nil if none exists.

--- a/pkg/hub/pipeline/pipeline_test.go
+++ b/pkg/hub/pipeline/pipeline_test.go
@@ -513,6 +513,63 @@ stages:
 	}
 }
 
+func TestHasPlanGateRequiresPlanGateFlagAndGate(t *testing.T) {
+	// Ordinary validation gate must NOT opt out of freeform plan approval.
+	validationOnly, err := pipeline.Parse([]byte(`
+stages:
+  - id: validation
+    gate:
+      output: validation
+      pass:
+        path: status
+        values: [clean]
+`))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if validationOnly.HasPlanGate() {
+		t.Fatal("validation gate without plan_gate should not count as plan gate")
+	}
+
+	// plan_gate without gate block is incomplete.
+	flagOnly, err := pipeline.Parse([]byte(`
+stages:
+  - id: plan
+    plan_gate: true
+`))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if flagOnly.HasPlanGate() {
+		t.Fatal("plan_gate without gate block should not count")
+	}
+
+	// Full deterministic plan gate.
+	plan, err := pipeline.Parse([]byte(`
+stages:
+  - id: plan_validate
+    plan_gate: true
+    gate:
+      output: plan
+      pass:
+        path: status
+        values: [ok]
+      fail:
+        path: status
+        values: [incomplete]
+      required: true
+`))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if !plan.HasPlanGate() {
+		t.Fatal("expected HasPlanGate true for plan_gate + gate")
+	}
+	if !plan.Stages[0].PlanGate {
+		t.Fatal("expected PlanGate flag parsed")
+	}
+}
+
 func TestParseGateAction(t *testing.T) {
 	p, err := pipeline.Parse([]byte(`
 stages:

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -1093,6 +1093,13 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 			}
 			notifyGateResult(msg)
 		}
+		// Deterministic plan gates mark plan accepted so freeform never re-fires
+		// if something races; freeform is already skipped when HasPlanGate().
+		if stage.PlanGate && autoTransitionVerdict == "pass" {
+			if tenantID := s.tenantIDForClaw(clawID); tenantID != "" {
+				_ = s.insertSystemMarker(clawID, tenantID, initialPlanAcceptedMarker)
+			}
+		}
 		// Auto-transition to next stage if a gate_result trigger matches.
 		s.safeGo("pipeline gate auto-transition", func() {
 			s.autoTransitionAfterGate(clawID, stage.ID, autoTransitionVerdict, ctx, gateResult.Reason)

--- a/pkg/hub/pipeline_runner_test.go
+++ b/pkg/hub/pipeline_runner_test.go
@@ -357,6 +357,189 @@ func TestPipelineEntryInjectIncludesInitialPlanInstruction(t *testing.T) {
 	}
 }
 
+func TestPipelineEntrySkipsFreeformPlanWhenPlanGatePresent(t *testing.T) {
+	// Deterministic plan_gate owns approval — freeform wake must not be prepended
+	// (would double-approve / freeze on keywords).
+	factory := &types.FactoryConfig{
+		Name: "plan-gate-factory",
+		PipelineYAML: `
+stages:
+  - id: plan
+    entry: true
+    on_enter:
+      inject: Write plan.json then say [PLAN_READY]
+  - id: plan_validate
+    plan_gate: true
+    triggers:
+      - message_contains: "[PLAN_READY]"
+    on_enter:
+      run:
+        command: "echo '{\"status\":\"ok\"}'"
+        output: plan
+    gate:
+      output: plan
+      pass:
+        path: status
+        values: [ok]
+      fail:
+        path: status
+        values: [incomplete]
+      required: true
+  - id: implement
+    triggers:
+      - gate_result:
+          stage: plan_validate
+          verdict: pass
+    on_enter:
+      inject: Proceed with implementation
+`,
+	}
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{
+		Token:     "test-token",
+		Factories: []*types.FactoryConfig{factory},
+	}, "", "", "")
+
+	const clawID = "claw-plan-gate-pipeline"
+	_, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, template, status, tags, linear_issue_id, pipeline_stage, created_at) VALUES(?,?,?,?,?,?,?,?,datetime('now'))`,
+		clawID, "test-tenant-id", "plan gate claw", "elasticclaw", "connected",
+		`["factory:plan-gate-factory"]`, "AMA-109", "",
+	)
+	if err != nil {
+		t.Fatalf("insert claw: %v", err)
+	}
+
+	if !s.clawEligibleForInitialPlan(clawID) {
+		t.Fatal("expected issue-backed claw to be plan-eligible")
+	}
+	if !s.clawPipelineHasPlanGate(clawID) {
+		t.Fatal("expected pipeline HasPlanGate via factory YAML")
+	}
+	if s.clawNeedsInitialPlan(clawID) {
+		t.Fatal("freeform initial plan must be skipped when plan_gate is present")
+	}
+
+	stage := pipeline.Stage{
+		ID:    "plan",
+		Label: "Plan",
+		OnEnter: pipeline.OnEnter{
+			Inject: "Write plan.json then say [PLAN_READY]",
+		},
+	}
+	if !s.transitionPipelineStageWithContext(clawID, stage, pipelineContext{Factory: factory, IssueID: "AMA-109"}) {
+		t.Fatalf("stage transition returned false")
+	}
+
+	rows, err := db.Query(`SELECT content FROM messages WHERE claw_id=? AND role='hub'`, clawID)
+	if err != nil {
+		t.Fatalf("select hub messages: %v", err)
+	}
+	defer rows.Close()
+	var all []string
+	foundInject := false
+	for rows.Next() {
+		var content string
+		if err := rows.Scan(&content); err != nil {
+			t.Fatal(err)
+		}
+		all = append(all, content)
+		if strings.Contains(content, initialPlanWakeContent) {
+			t.Fatalf("must not prepend freeform plan wake when plan_gate present:\n%s", content)
+		}
+		if strings.Contains(content, "Write plan.json then say [PLAN_READY]") {
+			foundInject = true
+		}
+	}
+	if !foundInject {
+		t.Fatalf("expected workflow inject among hub messages, got:\n%s", strings.Join(all, "\n---\n"))
+	}
+	if s.hasSystemMarker(clawID, initialPlanRequiredMarker) {
+		t.Fatal("must not insert freeform plan-required marker when plan_gate present")
+	}
+}
+
+func TestPlanGatePassMarksInitialPlanAccepted(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+
+	const clawID = "claw-plan-gate-accept"
+	_, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, template, status, pipeline_stage, created_at) VALUES(?,?,?,?,?,?,datetime('now'))`,
+		clawID, "test-tenant-id", "test-claw", "base", "connected", "",
+	)
+	if err != nil {
+		t.Fatalf("insert claw: %v", err)
+	}
+	s.persistPipelineOutput(clawID, "plan_validate", "plan", &pipelineRunResult{
+		ExitCode: 0,
+		Stdout:   `{"status":"ok"}`,
+	})
+
+	stage := pipeline.Stage{
+		ID:       "plan_validate",
+		Label:    "Plan validation",
+		PlanGate: true,
+		Gate: &pipeline.Gate{
+			Output: "plan",
+			Pass:   pipeline.GateCondition{Path: "status", Values: []string{"ok"}},
+			Fail:   pipeline.GateCondition{Path: "status", Values: []string{"incomplete"}},
+		},
+	}
+	if _, err := s.runOnEnter(clawID, stage, pipelineContext{}); err != nil {
+		t.Fatalf("runOnEnter: %v", err)
+	}
+	if !s.hasSystemMarker(clawID, initialPlanAcceptedMarker) {
+		t.Fatal("plan_gate pass should mark initial plan accepted (no freeform re-fire)")
+	}
+}
+
+func TestOrdinaryGateDoesNotSkipFreeformPlan(t *testing.T) {
+	// Existing installs with validation gates (not plan_gate) keep freeform.
+	factory := &types.FactoryConfig{
+		Name: "validation-factory",
+		PipelineYAML: `
+stages:
+  - id: entry
+    entry: true
+    on_enter:
+      inject: Start work
+  - id: validation
+    triggers:
+      - message_contains: "[DONE]"
+    on_enter:
+      run:
+        command: "echo '{\"status\":\"clean\"}'"
+        output: validation
+    gate:
+      output: validation
+      pass:
+        path: status
+        values: [clean]
+      required: true
+`,
+	}
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{
+		Token:     "test-token",
+		Factories: []*types.FactoryConfig{factory},
+	}, "", "", "")
+
+	const clawID = "claw-validation-gate-only"
+	_, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, template, status, tags, linear_issue_id, pipeline_stage, created_at) VALUES(?,?,?,?,?,?,?,?,datetime('now'))`,
+		clawID, "test-tenant-id", "validation claw", "elasticclaw", "connected",
+		`["factory:validation-factory"]`, "AMA-110", "",
+	)
+	if err != nil {
+		t.Fatalf("insert claw: %v", err)
+	}
+
+	if s.clawPipelineHasPlanGate(clawID) {
+		t.Fatal("validation gate must not count as plan_gate")
+	}
+	if !s.clawNeedsInitialPlan(clawID) {
+		t.Fatal("freeform plan must remain for existing pipelines without plan_gate")
+	}
+}
+
 func TestPipelineInjectIncludesExactManualTriggerInputs(t *testing.T) {
 	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -5993,6 +5993,20 @@ func (s *Server) sendInitialPlanInstruction(cc *clawConn, clawID string) {
 }
 
 func (s *Server) clawNeedsInitialPlan(clawID string) bool {
+	if !s.clawEligibleForInitialPlan(clawID) {
+		return false
+	}
+	// Workflows that declare a deterministic plan_gate own plan approval.
+	// Skip freeform keyword checks so we do not double-approve or freeze.
+	if s.clawPipelineHasPlanGate(clawID) {
+		return false
+	}
+	return true
+}
+
+// clawEligibleForInitialPlan is true for issue-backed or factory/workflow claws
+// that historically received the freeform initial-plan wake.
+func (s *Server) clawEligibleForInitialPlan(clawID string) bool {
 	issueID, tags := s.clawIssueAndTags(clawID)
 	if issueID != "" {
 		return true
@@ -6003,6 +6017,17 @@ func (s *Server) clawNeedsInitialPlan(clawID string) bool {
 		}
 	}
 	return false
+}
+
+// clawPipelineHasPlanGate reports whether this claw's factory/workflow YAML
+// declares plan_gate: true on a stage that also has a gate block.
+func (s *Server) clawPipelineHasPlanGate(clawID string) bool {
+	ctx, ok := s.findPipelineContextForClaw(clawID)
+	if !ok {
+		return false
+	}
+	pl := parsePipelineForContext(ctx)
+	return pl != nil && pl.HasPlanGate()
 }
 
 func (s *Server) tenantIDForClaw(clawID string) string {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -6041,15 +6041,30 @@ func (s *Server) handleInitialPlanResponse(clawID, tenantID, content string) {
 	if !s.hasSystemMarker(clawID, initialPlanRequiredMarker) || s.hasSystemMarker(clawID, initialPlanAcceptedMarker) {
 		return
 	}
-	if isValidInitialPlan(content) {
+	// Strict keyword match, or a substantial second attempt after we already
+	// asked for a correction. Without the soft path, a real plan that misses
+	// one keyword (e.g. "issue") leaves the agent waiting forever for proceed.
+	correctionSent := s.hasSystemMarker(clawID, initialPlanCorrectionSentMarker)
+	if isValidInitialPlan(content) || (correctionSent && isSubstantialInitialPlan(content)) {
 		_ = s.insertSystemMarker(clawID, tenantID, initialPlanAcceptedMarker)
 		s.injectHubMessageByID(clawID, initialPlanProceedContent)
 		return
 	}
-	if !s.hasSystemMarker(clawID, initialPlanCorrectionSentMarker) {
+	if !correctionSent {
 		_ = s.insertSystemMarker(clawID, tenantID, initialPlanCorrectionSentMarker)
 		s.injectHubMessageByID(clawID, initialPlanCorrectionContent)
+		return
 	}
+	// Correction already sent and this turn still failed both gates. Re-nudge
+	// only when the agent produced a real attempt (not a short ack), so it is
+	// not frozen waiting for a proceed that never arrives.
+	trimmed := strings.TrimSpace(content)
+	if len(trimmed) < 120 {
+		return
+	}
+	log.Printf("[hub] initial plan still incomplete for claw %s (len=%d words=%d); re-sending correction",
+		shortID(clawID), len(trimmed), len(strings.Fields(trimmed)))
+	s.injectHubMessageByID(clawID, initialPlanCorrectionContent)
 }
 
 func (s *Server) handleInitialPlanActivity(clawID, tenantID string, activity map[string]interface{}) {
@@ -6072,24 +6087,32 @@ func isValidInitialPlan(content string) bool {
 		return false
 	}
 	lower := strings.ToLower(content)
-	hasUnderstanding := strings.Contains(lower, "understand") ||
-		strings.Contains(lower, "issue") ||
-		strings.Contains(lower, "task") ||
-		strings.Contains(lower, "problem")
-	hasPlan := strings.Contains(lower, "plan") ||
-		strings.Contains(lower, "step") ||
-		strings.Contains(lower, "approach")
-	hasVerification := strings.Contains(lower, "test") ||
-		strings.Contains(lower, "verify") ||
-		strings.Contains(lower, "check") ||
-		strings.Contains(lower, "build")
-	hasCodeArea := strings.Contains(lower, "file") ||
-		strings.Contains(lower, "code") ||
-		strings.Contains(lower, "package") ||
-		strings.Contains(lower, "component") ||
-		strings.Contains(lower, "backend") ||
-		strings.Contains(lower, "frontend")
+	hasUnderstanding := containsAny(lower, []string{
+		"understand", "issue", "task", "problem", "requirement", "requirements",
+		"will add", "will implement", "need to", "goal", "ticket",
+	})
+	hasPlan := containsAny(lower, []string{"plan", "step", "approach", "implement", "implementation"})
+	hasVerification := containsAny(lower, []string{"test", "verify", "verification", "check", "build", "ci"})
+	hasCodeArea := containsAny(lower, []string{
+		"file", "code", "package", "component", "backend", "frontend",
+		"workflow", "repo", "repository", "directory", "config", "script",
+		".github", "package.json",
+	})
 	return hasUnderstanding && hasPlan && hasVerification && hasCodeArea
+}
+
+// isSubstantialInitialPlan is a softer gate used after we already sent a
+// correction. Agents often write a real plan without the exact keyword set
+// (e.g. naming a ticket id instead of "issue"); accepting those unblocks work.
+func isSubstantialInitialPlan(content string) bool {
+	content = strings.TrimSpace(content)
+	if len(content) < 200 || len(strings.Fields(content)) < 40 {
+		return false
+	}
+	lower := strings.ToLower(content)
+	hasPlan := containsAny(lower, []string{"plan", "step", "approach", "implement", "implementation"})
+	hasVerification := containsAny(lower, []string{"test", "verify", "verification", "check", "build", "ci"})
+	return hasPlan && hasVerification
 }
 
 // clawHasMessages returns true if the claw already has message history.

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -1677,6 +1677,28 @@ func TestIsValidInitialPlanRequiresUnderstandingPlanAreaAndVerification(t *testi
 	if isValidInitialPlan(invalid) {
 		t.Fatalf("invalid initial plan was accepted")
 	}
+	// Real agent plan from AMA-109: no "issue"/"task"/"understand" keywords, but
+	// clearly a complete plan — must not be rejected (that freezes the claw).
+	ticketStyle := `AMA-109 will add pull-request CI for linting and TypeScript type-checking in the amazecrm/amazecrm repository. I'll confirm the full requirements from Linear before changing anything.
+
+Likely code areas:
+.github/workflows/ for the new GitHub Actions workflow
+package.json only if a dedicated type-check script is required and missing
+Existing pnpm/Node configuration to ensure CI matches the project
+Rough implementation plan:
+Read AMA-109 and repository instructions.
+Inspect existing workflows and package scripts.
+Create a focused feature branch.
+Add minimal PR-triggered lint and type-check jobs with pnpm caching and frozen-lockfile installation.
+Run the equivalent checks locally.
+Review, commit, push, open a PR, and inspect its checks.
+Verification will cover workflow syntax and triggers, dependency caching/setup, pnpm lint, standalone TypeScript checking, and the opened PR's CI result. I'll wait for the hub's proceed message before using tools or editing files.`
+	if !isValidInitialPlan(ticketStyle) {
+		t.Fatalf("ticket-style initial plan was rejected")
+	}
+	if !isSubstantialInitialPlan(ticketStyle) {
+		t.Fatalf("ticket-style plan should pass soft substantial gate")
+	}
 }
 
 func TestHandleInitialPlanResponseMarksAcceptedOrCorrection(t *testing.T) {
@@ -1712,6 +1734,38 @@ func TestHandleInitialPlanResponseMarksAcceptedOrCorrection(t *testing.T) {
 	}
 	if s.hasSystemMarker("claw-valid-plan", initialPlanCorrectionSentMarker) {
 		t.Fatalf("valid initial plan marked correction sent")
+	}
+}
+
+func TestHandleInitialPlanResponseSoftAcceptsAfterCorrection(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, nil, "", "", "")
+	_, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, tags, created_at) VALUES(?,?,?,?,datetime('now'))`,
+		"claw-soft-plan", "test-tenant-id", "claw soft plan", `[]`,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.insertSystemMarker("claw-soft-plan", "test-tenant-id", initialPlanRequiredMarker)
+	s.insertSystemMarker("claw-soft-plan", "test-tenant-id", initialPlanCorrectionSentMarker)
+
+	// Substantial plan with plan+verification but intentionally avoids some
+	// strict understanding keywords; after a correction this must proceed.
+	soft := strings.Repeat("Rough plan: add the lint workflow, wire pnpm cache, and run typecheck. ", 8) +
+		"Verification: run lint and typecheck in CI and confirm the PR checks go green."
+	s.handleInitialPlanResponse("claw-soft-plan", "test-tenant-id", soft)
+	if !s.hasSystemMarker("claw-soft-plan", initialPlanAcceptedMarker) {
+		t.Fatalf("substantial plan after correction was not soft-accepted")
+	}
+	var proceedCount int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM messages WHERE claw_id=? AND role='hub' AND content=?`,
+		"claw-soft-plan", initialPlanProceedContent,
+	).Scan(&proceedCount); err != nil {
+		t.Fatal(err)
+	}
+	if proceedCount != 1 {
+		t.Fatalf("expected proceed message after soft accept, got %d", proceedCount)
 	}
 }
 


### PR DESCRIPTION
## Summary
- **Default (existing installs):** freeform initial-plan approval stays as today (with looser keyword matching + soft-accept after correction so claws stop freezing).
- **Opt-in deterministic path:** workflows that set `plan_gate: true` on a stage that also has a `gate:` block **skip freeform entirely** — no double approval, no keyword freeze.
- On `plan_gate` pass, hub marks plan accepted so freeform cannot re-fire.

## Workflow usage
```yaml
stages:
  - id: plan
    entry: true
    on_enter:
      inject: |
        Write .elasticclaw/plan.json then say [PLAN_READY]

  - id: plan_validate
    plan_gate: true          # opts out of freeform plan approval
    triggers:
      - message_contains: "[PLAN_READY]"
    on_enter:
      run:
        command: 'python3 -c "..."'   # schema check → {"status":"ok"|"incomplete"}
        output: plan
    gate:
      output: plan
      pass:  { path: status, values: [ok] }
      fail:  { path: status, values: [incomplete] }
      required: true

  - id: implement
    triggers:
      - gate_result: { stage: plan_validate, verdict: pass }
    on_enter:
      inject: Plan accepted. Proceed with implementation.
```

Ordinary validation gates **without** `plan_gate: true` do not disable freeform.

## Test plan
- [x] `go test ./pkg/hub/pipeline/ -run TestHasPlanGate`
- [x] `go test ./pkg/hub/ -run 'TestPipelineEntry|TestPlanGate|TestOrdinaryGate|TestIsValidInitialPlan|TestHandleInitialPlan'`
- [ ] Deploy + point a demo workflow at `plan_gate` stages