### PR TITLE
feat(ui): copy chat transcript button

### DIFF
--- a/web/components/conversation-view.tsx
+++ b/web/components/conversation-view.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect, useCallback, useMemo, memo } from "react"
 import { Send, Terminal, TerminalSquare, ChevronLeft, ChevronRight, ChevronDown, Loader2, LayoutGrid, Info, MessageSquare, Trash2, AlertCircle, Wrench, GripVertical, Settings2, Paperclip, File as FileIcon, X } from "lucide-react"
+import { CopyTranscriptButton } from "@/components/copy-transcript-button"
 import {
   DndContext,
   closestCenter,
@@ -634,6 +635,13 @@ const ClawBoardCard = memo(function ClawBoardCard({
                   {claw.unreadCount > 99 ? "99+" : claw.unreadCount}
                 </span>
               )}
+              <CopyTranscriptButton
+                claw={claw}
+                messages={messages}
+                streamingText={streamingBuffer?.text}
+                size="icon"
+                stopPropagation
+              />
               <button
                 onClick={handleFlip}
                 className="p-1 rounded hover:bg-accent transition-colors"
@@ -1654,6 +1662,12 @@ function ClawChatView({
             <span className="text-sm text-muted-foreground font-mono">{formatUptime(claw.uptime)}</span>
           </div>
           <div className="flex items-center gap-2">
+            <CopyTranscriptButton
+              claw={claw}
+              messages={messages}
+              streamingText={streamingBuffer?.text}
+              size="sm"
+            />
             {claw.ssh_host && (
               <Button variant="outline" size="sm" onClick={() => setTerminalOpen(true)}>
                 <TerminalSquare className="size-3.5 mr-1.5" />

--- a/web/components/copy-transcript-button.tsx
+++ b/web/components/copy-transcript-button.tsx
@@ -1,0 +1,105 @@
+"use client"
+
+import { useCallback, useState } from "react"
+import { Check, ClipboardCopy } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+import type { Message } from "@/lib/types"
+import {
+  copyTextToClipboard,
+  formatChatTranscript,
+  type TranscriptClawMeta,
+} from "@/lib/transcript"
+
+type Size = "icon" | "sm"
+
+interface CopyTranscriptButtonProps {
+  claw: TranscriptClawMeta
+  messages: Message[]
+  streamingText?: string
+  size?: Size
+  className?: string
+  /** When true, stop click from bubbling (board cards). */
+  stopPropagation?: boolean
+}
+
+export function CopyTranscriptButton({
+  claw,
+  messages,
+  streamingText,
+  size = "sm",
+  className,
+  stopPropagation = false,
+}: CopyTranscriptButtonProps) {
+  const [copied, setCopied] = useState(false)
+  const [busy, setBusy] = useState(false)
+
+  const handleCopy = useCallback(
+    async (e: React.MouseEvent) => {
+      if (stopPropagation) {
+        e.stopPropagation()
+        e.preventDefault()
+      }
+      if (busy) return
+      setBusy(true)
+      const text = formatChatTranscript({
+        claw,
+        messages,
+        streamingText,
+      })
+      const ok = await copyTextToClipboard(text)
+      setBusy(false)
+      if (!ok) return
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 2000)
+    },
+    [busy, claw, messages, streamingText, stopPropagation]
+  )
+
+  const disabled = busy || (messages.length === 0 && !streamingText?.trim())
+  const title = copied
+    ? "Copied"
+    : disabled
+      ? "No messages to copy"
+      : "Copy chat transcript"
+
+  if (size === "icon") {
+    return (
+      <button
+        type="button"
+        onClick={handleCopy}
+        disabled={disabled}
+        title={title}
+        className={cn(
+          "p-1 rounded hover:bg-accent transition-colors disabled:opacity-40 disabled:pointer-events-none",
+          className
+        )}
+      >
+        {copied ? (
+          <Check className="size-3.5 text-green-500" />
+        ) : (
+          <ClipboardCopy className="size-3.5 text-muted-foreground" />
+        )}
+      </button>
+    )
+  }
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      onClick={handleCopy}
+      disabled={disabled}
+      title={title}
+      className={className}
+    >
+      {copied ? (
+        <Check className="size-3.5 mr-1.5 text-green-500" />
+      ) : (
+        <ClipboardCopy className="size-3.5 mr-1.5" />
+      )}
+      {copied ? "Copied" : "Copy transcript"}
+    </Button>
+  )
+}

--- a/web/lib/transcript.ts
+++ b/web/lib/transcript.ts
@@ -1,0 +1,124 @@
+import type { Message } from "@/lib/types"
+
+export type TranscriptClawMeta = {
+  id: string
+  name: string
+  status?: string
+  template?: string
+  githubIssueId?: string
+  githubIssueUrl?: string
+}
+
+/** Human-readable role for debug transcripts. */
+export function transcriptRoleLabel(message: Message): string {
+  switch (message.role) {
+    case "user":
+      return "user"
+    case "claw":
+      return "agent"
+    case "hub":
+      return "hub (injected)"
+    case "system":
+      return "system"
+    case "activity": {
+      const a = message.activity
+      if (!a) return "activity"
+      const parts = [a.kind]
+      if (a.tool) parts.push(a.tool)
+      if (a.phase) parts.push(a.phase)
+      return `activity (${parts.filter(Boolean).join(": ")})`
+    }
+    case "activity_summary":
+      return "activity_summary"
+    default:
+      return String(message.role)
+  }
+}
+
+function toISO(ts: Date | string): string {
+  const d = ts instanceof Date ? ts : new Date(ts)
+  if (Number.isNaN(d.getTime())) return String(ts)
+  return d.toISOString()
+}
+
+/**
+ * Format a claw conversation for clipboard paste into debugging tools.
+ * Includes role labels (user / agent / hub injected / system / activity)
+ * and ISO timestamps per message.
+ */
+export function formatChatTranscript(opts: {
+  claw: TranscriptClawMeta
+  messages: Message[]
+  streamingText?: string
+}): string {
+  const { claw, messages, streamingText } = opts
+  const sorted = [...messages].sort((a, b) => {
+    const ta = a.timestamp instanceof Date ? a.timestamp.getTime() : new Date(a.timestamp).getTime()
+    const tb = b.timestamp instanceof Date ? b.timestamp.getTime() : new Date(b.timestamp).getTime()
+    return ta - tb
+  })
+
+  const lines: string[] = [
+    "# ElasticClaw chat transcript",
+    `claw: ${claw.name}`,
+    `id: ${claw.id}`,
+  ]
+  if (claw.template) lines.push(`template: ${claw.template}`)
+  if (claw.status) lines.push(`status: ${claw.status}`)
+  if (claw.githubIssueId) lines.push(`issue: ${claw.githubIssueId}`)
+  if (claw.githubIssueUrl) lines.push(`issue_url: ${claw.githubIssueUrl}`)
+  lines.push(`exported: ${new Date().toISOString()}`)
+  lines.push(
+    `message_count: ${sorted.length}${streamingText?.trim() ? " (+ streaming tail)" : ""}`
+  )
+  lines.push("")
+  lines.push("---")
+  lines.push("")
+
+  for (const message of sorted) {
+    const label = transcriptRoleLabel(message)
+    lines.push(`[${toISO(message.timestamp)}] ${label}`)
+    const body = (message.content ?? "").replace(/\s+$/u, "")
+    if (body) {
+      lines.push(body)
+    } else {
+      lines.push("(empty)")
+    }
+    lines.push("")
+  }
+
+  const stream = streamingText?.replace(/\s+$/u, "")
+  if (stream) {
+    lines.push(`[${new Date().toISOString()}] agent (streaming)`)
+    lines.push(stream)
+    lines.push("")
+  }
+
+  return lines.join("\n")
+}
+
+/** Copy text to the clipboard; returns true on success. */
+export async function copyTextToClipboard(text: string): Promise<boolean> {
+  try {
+    if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text)
+      return true
+    }
+  } catch {
+    // fall through to execCommand
+  }
+  try {
+    const el = document.createElement("textarea")
+    el.value = text
+    el.setAttribute("readonly", "")
+    el.style.position = "fixed"
+    el.style.left = "-9999px"
+    document.body.appendChild(el)
+    el.select()
+    const ok = document.execCommand("copy")
+    document.body.removeChild(el)
+    return ok
+  } catch {
+    return false
+  }
+}

--- a/web/lib/transcript.ts
+++ b/web/lib/transcript.ts
@@ -1,4 +1,4 @@
-import type { Message } from "@/lib/types"
+import type { AgentActivity, Message } from "@/lib/types"
 
 export type TranscriptClawMeta = {
   id: string
@@ -28,8 +28,10 @@ export function transcriptRoleLabel(message: Message): string {
       if (a.phase) parts.push(a.phase)
       return `activity (${parts.filter(Boolean).join(": ")})`
     }
-    case "activity_summary":
-      return "activity_summary"
+    case "activity_summary": {
+      const n = message.activitySummary?.count
+      return typeof n === "number" ? `activity_summary (count=${n})` : "activity_summary"
+    }
     default:
       return String(message.role)
   }
@@ -39,6 +41,67 @@ function toISO(ts: Date | string): string {
   const d = ts instanceof Date ? ts : new Date(ts)
   if (Number.isNaN(d.getTime())) return String(ts)
   return d.toISOString()
+}
+
+function trimBody(text: string): string {
+  return text.replace(/\s+$/u, "")
+}
+
+/** Serialize structured AgentActivity fields for debug paste. */
+export function formatActivityTranscriptBody(activity: AgentActivity): string {
+  const lines: string[] = []
+  const push = (key: string, value: string | undefined) => {
+    const v = value?.trim()
+    if (v) lines.push(`${key}: ${v}`)
+  }
+  push("kind", activity.kind)
+  push("tool", activity.tool)
+  push("phase", activity.phase)
+  push("stream", activity.stream)
+  push("command", activity.command)
+  push("path", activity.path)
+  push("url", activity.url)
+  push("detail", activity.detail)
+  push("message", activity.message)
+  push("error", activity.error)
+  return lines.join("\n")
+}
+
+/**
+ * Body text for one transcript row. Prefer structured activity / summary
+ * fields so copied logs match what the UI shows (commands, paths, errors).
+ */
+export function formatTranscriptMessageBody(message: Message): string {
+  if (message.role === "activity" && message.activity) {
+    const structured = formatActivityTranscriptBody(message.activity)
+    const content = trimBody(message.content ?? "")
+    // Prefer structured fields; append content only when it adds new info.
+    if (structured) {
+      if (content && !structured.includes(content)) {
+        return `${structured}\ncontent: ${content}`
+      }
+      return structured
+    }
+    if (content) return content
+    return "(empty activity)"
+  }
+
+  if (message.role === "activity_summary") {
+    const summary = message.activitySummary
+    const lines: string[] = []
+    if (summary) {
+      lines.push(`count: ${summary.count}`)
+      if (summary.from) lines.push(`from: ${summary.from}`)
+      if (summary.to) lines.push(`to: ${summary.to}`)
+    }
+    const content = trimBody(message.content ?? "")
+    if (content) lines.push(content)
+    if (lines.length === 0) return "(empty activity summary)"
+    return lines.join("\n")
+  }
+
+  const body = trimBody(message.content ?? "")
+  return body || "(empty)"
 }
 
 /**
@@ -78,12 +141,7 @@ export function formatChatTranscript(opts: {
   for (const message of sorted) {
     const label = transcriptRoleLabel(message)
     lines.push(`[${toISO(message.timestamp)}] ${label}`)
-    const body = (message.content ?? "").replace(/\s+$/u, "")
-    if (body) {
-      lines.push(body)
-    } else {
-      lines.push("(empty)")
-    }
+    lines.push(formatTranscriptMessageBody(message))
     lines.push("")
   }
 


### PR DESCRIPTION
## Summary
- **Copy transcript** on the board claw card (icon in header) and full conversation view (button next to Terminal/Kill).
- Clipboard text includes claw metadata, ISO timestamps, and role labels:
  - `user`
  - `agent`
  - `hub (injected)`
  - `system` / `activity` / `activity_summary`
- Includes in-progress streaming tail when present.
- Copies whatever is currently loaded in that view (board: full in-memory messages; full view: timeline window + live).

## Example format
```
# ElasticClaw chat transcript
claw: AMA-109
id: 5a521a5a-...
exported: 2026-08-06T16:40:00.000Z

---

[2026-08-06T15:19:55.000Z] hub (injected)
Initial plan required...

[2026-08-06T15:20:15.000Z] agent
AMA-109 will add...
```

## Test plan
- [ ] Open board view → click copy icon on a card → paste into editor
- [ ] Open full conversation → **Copy transcript** → paste
- [ ] Empty claw shows disabled control
- [ ] After copy, icon/button briefly shows checkmark