### PR TITLE
fix(hub): plan_gate freeform skip + clearer workflow chat UX

### DIFF
--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -1056,6 +1056,16 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 
 	// Evaluate gate if configured
 	if stage.Gate != nil {
+		// Re-emitting [PLAN_READY] after a successful plan gate must not loop
+		// the agent through validation forever — short-circuit with a clear nudge.
+		if stage.PlanGate && s.hasSystemMarker(clawID, initialPlanAcceptedMarker) {
+			s.injectHubMessageByID(clawID, planGateAlreadyAcceptedContent)
+			s.safeGo("pipeline plan-gate already accepted", func() {
+				s.autoTransitionAfterGate(clawID, stage.ID, "pass", ctx)
+			})
+			return true, nil
+		}
+
 		gateResult := s.evaluateGate(clawID, stage.ID, stage.Gate)
 		log.Printf("[pipeline] gate evaluated for claw %s stage %q: verdict=%s", clawID[:8], stage.ID, gateResult.Verdict)
 		// Normalise "skipped" → "pass" when TreatSkippedAsPass is set so that
@@ -1069,27 +1079,38 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 			gateResultHasRoute = pl.StageForGateResult(stage.ID, autoTransitionVerdict) != nil
 		}
 		notifyGateResult := func(message string) {
+			// Always surface gate outcomes in the transcript for human observers.
+			// When a gate_result route will inject the next stage prompt, use a
+			// notice (no extra model turn); otherwise inject so the agent sees it.
 			if gateResultHasRoute {
-				// The destination stage owns the next model prompt. Keep mechanical
-				// gate bookkeeping visible in the dashboard without consuming an
-				// extra turn before that stage's on_enter instructions.
 				s.publishHubNotice(clawID, message)
 				return
 			}
 			s.injectHubMessageByID(clawID, message)
 		}
-		// Report the gate result in chat.
+		// Report the gate result in chat with friendlier plan-gate wording.
+		stageLabel := strings.TrimSpace(stage.Label)
+		if stageLabel == "" {
+			stageLabel = stage.ID
+		}
 		if gateResult.Verdict == "pass" {
-			notifyGateResult(fmt.Sprintf("[hub] Gate passed: %s", stage.Label))
+			if stage.PlanGate {
+				notifyGateResult(fmt.Sprintf("[hub] ✓ Plan approved (%s). Moving to implementation.", stageLabel))
+			} else {
+				notifyGateResult(fmt.Sprintf("[hub] ✓ Gate passed: %s", stageLabel))
+			}
 		} else if gateResult.Verdict == "skipped" && stage.Gate.TreatSkippedAsPass {
-			notifyGateResult(fmt.Sprintf("[hub] Gate skipped (treated as pass): %s", stage.Label))
+			notifyGateResult(fmt.Sprintf("[hub] Gate skipped (treated as pass): %s", stageLabel))
 		} else if gateResult.Verdict == "error" {
-			msg := fmt.Sprintf("[hub] Gate error (no condition matched): %s", stage.Label)
+			msg := fmt.Sprintf("[hub] Gate error (no condition matched): %s", stageLabel)
 			notifyGateResult(msg)
 		} else {
-			msg := fmt.Sprintf("[hub] Gate failed: %s", stage.Label)
+			msg := fmt.Sprintf("[hub] ✗ Gate failed: %s", stageLabel)
 			if gateResult.MatchedPath != "" {
 				msg += fmt.Sprintf("\n- path: %s\n- value: %s", gateResult.MatchedPath, gateResult.MatchedValue)
+			}
+			if gateResult.Reason != "" {
+				msg += "\n- reason: " + gateResult.Reason
 			}
 			notifyGateResult(msg)
 		}
@@ -1099,6 +1120,9 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 			if tenantID := s.tenantIDForClaw(clawID); tenantID != "" {
 				_ = s.insertSystemMarker(clawID, tenantID, initialPlanAcceptedMarker)
 			}
+			// Explicit agent-facing proceed so the model does not keep waiting
+			// for freeform "hub proceed" language or re-emit [PLAN_READY].
+			s.injectHubMessageByID(clawID, planGateProceedContent)
 		}
 		// Auto-transition to next stage if a gate_result trigger matches.
 		s.safeGo("pipeline gate auto-transition", func() {
@@ -1566,6 +1590,13 @@ func (s *Server) transitionResolvedPipelineStageWithContext(clawID string, stage
 	// (like output_matches) don't re-fire on subsequent messages.
 	s.recordPipelineStageVisit(clawID, stage.ID)
 	log.Printf("[pipeline] claw %s → stage %q (%s)", clawID[:8], stage.ID, stage.Label)
+	// User-visible stage progress in the transcript (dashboard only — does not
+	// queue a model turn). Makes workflow progress less of a black box.
+	stageLabel := strings.TrimSpace(stage.Label)
+	if stageLabel == "" {
+		stageLabel = stage.ID
+	}
+	s.publishHubNotice(clawID, fmt.Sprintf("[hub] ▶ Stage: %s", stageLabel))
 	injectDelivered, onEnterErr := s.runOnEnter(clawID, stage, ctx)
 	stageActionsSucceeded := onEnterErr == nil
 	var routedGateErr *routedRequiredGateError

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -1056,9 +1056,10 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 
 	// Evaluate gate if configured
 	if stage.Gate != nil {
-		// Re-emitting [PLAN_READY] after a successful plan gate must not loop
-		// the agent through validation forever — short-circuit with a clear nudge.
-		if stage.PlanGate && s.hasSystemMarker(clawID, initialPlanAcceptedMarker) {
+		// Re-entering *this* plan_gate stage after it already passed must not
+		// re-run validation forever. Scoped per stageID so a later plan_gate
+		// in the same workflow still evaluates its own output (Greptile).
+		if stage.PlanGate && s.hasSystemMarker(clawID, planGateAcceptedMarker(stage.ID)) {
 			s.injectHubMessageByID(clawID, planGateAlreadyAcceptedContent)
 			s.safeGo("pipeline plan-gate already accepted", func() {
 				s.autoTransitionAfterGate(clawID, stage.ID, "pass", ctx)
@@ -1116,9 +1117,12 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 		}
 		// Deterministic plan gates mark plan accepted so freeform never re-fires
 		// if something races; freeform is already skipped when HasPlanGate().
+		// Per-stage marker powers re-entry short-circuit without skipping later
+		// plan_gate stages in the same workflow.
 		if stage.PlanGate && autoTransitionVerdict == "pass" {
 			if tenantID := s.tenantIDForClaw(clawID); tenantID != "" {
 				_ = s.insertSystemMarker(clawID, tenantID, initialPlanAcceptedMarker)
+				_ = s.insertSystemMarker(clawID, tenantID, planGateAcceptedMarker(stage.ID))
 			}
 			// Explicit agent-facing proceed so the model does not keep waiting
 			// for freeform "hub proceed" language or re-emit [PLAN_READY].

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -1060,11 +1060,21 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 		// re-run validation forever. Scoped per stageID so a later plan_gate
 		// in the same workflow still evaluates its own output (Greptile).
 		if stage.PlanGate && s.hasSystemMarker(clawID, planGateAcceptedMarker(stage.ID)) {
-			s.injectHubMessageByID(clawID, planGateAlreadyAcceptedContent)
+			alreadyRouted := false
+			if pl := parsePipelineForContext(ctx); pl != nil {
+				alreadyRouted = pl.StageForGateResult(stage.ID, "pass") != nil
+			}
+			// Destination stage inject owns the next agent turn when routed.
+			if alreadyRouted {
+				s.publishHubNotice(clawID, planGateAlreadyAcceptedContent)
+			} else {
+				s.injectHubMessageByID(clawID, planGateAlreadyAcceptedContent)
+			}
 			s.safeGo("pipeline plan-gate already accepted", func() {
 				s.autoTransitionAfterGate(clawID, stage.ID, "pass", ctx)
 			})
-			return true, nil
+			// injectDelivered only when we queued a model turn (no route).
+			return !alreadyRouted, nil
 		}
 
 		gateResult := s.evaluateGate(clawID, stage.ID, stage.Gate)
@@ -1124,9 +1134,14 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 				_ = s.insertSystemMarker(clawID, tenantID, initialPlanAcceptedMarker)
 				_ = s.insertSystemMarker(clawID, tenantID, planGateAcceptedMarker(stage.ID))
 			}
-			// Explicit agent-facing proceed so the model does not keep waiting
-			// for freeform "hub proceed" language or re-emit [PLAN_READY].
-			s.injectHubMessageByID(clawID, planGateProceedContent)
+			// When a gate_result route will inject the destination stage prompt,
+			// do not also inject proceed — that queues a duplicate agent turn
+			// before the implement instructions arrive (Greptile).
+			if gateResultHasRoute {
+				s.publishHubNotice(clawID, planGateProceedContent)
+			} else {
+				s.injectHubMessageByID(clawID, planGateProceedContent)
+			}
 		}
 		// Auto-transition to next stage if a gate_result trigger matches.
 		s.safeGo("pipeline gate auto-transition", func() {

--- a/pkg/hub/pipeline_runner_test.go
+++ b/pkg/hub/pipeline_runner_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/elasticclaw/elasticclaw/pkg/hub/pipeline"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
+	"gopkg.in/yaml.v3"
 )
 
 func TestTransitionPipelineStageSkipsDuplicateCurrentStage(t *testing.T) {
@@ -345,15 +346,76 @@ func TestPipelineEntryInjectIncludesInitialPlanInstruction(t *testing.T) {
 		t.Fatalf("stage transition returned false")
 	}
 
-	var content string
-	if err := db.QueryRow(`SELECT content FROM messages WHERE claw_id=? AND role='hub'`, clawID).Scan(&content); err != nil {
-		t.Fatalf("select injected message: %v", err)
+	rows, err := db.Query(`SELECT content FROM messages WHERE claw_id=? AND role='hub' ORDER BY created_at`, clawID)
+	if err != nil {
+		t.Fatalf("select hub messages: %v", err)
 	}
-	if !strings.Contains(content, initialPlanWakeContent) || !strings.Contains(content, "Task context:\nRead the GitHub issue and start work.") {
-		t.Fatalf("pipeline inject did not include initial plan and task context:\n%s", content)
+	defer rows.Close()
+	var all []string
+	foundPlan := false
+	foundStageBanner := false
+	for rows.Next() {
+		var content string
+		if err := rows.Scan(&content); err != nil {
+			t.Fatal(err)
+		}
+		all = append(all, content)
+		if strings.Contains(content, initialPlanWakeContent) && strings.Contains(content, "Task context:\nRead the GitHub issue and start work.") {
+			foundPlan = true
+		}
+		if strings.Contains(content, "[hub] ▶ Stage:") {
+			foundStageBanner = true
+		}
+	}
+	if !foundPlan {
+		t.Fatalf("pipeline inject did not include initial plan and task context:\n%s", strings.Join(all, "\n---\n"))
+	}
+	if !foundStageBanner {
+		t.Fatalf("expected stage progress banner in transcript:\n%s", strings.Join(all, "\n---\n"))
 	}
 	if !s.hasSystemMarker(clawID, initialPlanRequiredMarker) {
 		t.Fatalf("initial plan required marker was not inserted")
+	}
+}
+
+func TestNormalizedWorkflowPlanGateSkipsFreeformPlan(t *testing.T) {
+	// Regression: WorkflowStage used to drop plan_gate when re-marshaling into
+	// PipelineYAML, so HasPlanGate was false and freeform plan still fired.
+	raw := []byte(`
+schema_version: v1
+name: amazecrm-linear
+stages:
+  - id: plan
+    entry: true
+    on_enter:
+      inject: write plan
+  - id: plan_validate
+    plan_gate: true
+    triggers:
+      - message_contains: "[PLAN_READY]"
+    on_enter:
+      run:
+        command: echo ok
+        output: plan
+    gate:
+      output: plan
+      pass:
+        path: status
+        values: [ok]
+`)
+	var workflow types.WorkflowConfig
+	if err := yaml.Unmarshal(raw, &workflow); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if err := types.NormalizeWorkflowConfig(&workflow); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	pl, err := pipeline.Parse([]byte(workflow.PipelineYAML))
+	if err != nil {
+		t.Fatalf("parse pipeline: %v", err)
+	}
+	if !pl.HasPlanGate() {
+		t.Fatalf("expected HasPlanGate after normalize; pipeline yaml:\n%s", workflow.PipelineYAML)
 	}
 }
 

--- a/pkg/hub/pipeline_runner_test.go
+++ b/pkg/hub/pipeline_runner_test.go
@@ -552,6 +552,49 @@ func TestPlanGatePassMarksInitialPlanAccepted(t *testing.T) {
 	if !s.hasSystemMarker(clawID, initialPlanAcceptedMarker) {
 		t.Fatal("plan_gate pass should mark initial plan accepted (no freeform re-fire)")
 	}
+	if !s.hasSystemMarker(clawID, planGateAcceptedMarker(stage.ID)) {
+		t.Fatal("plan_gate pass should mark per-stage accepted marker")
+	}
+}
+
+func TestSecondPlanGateStillEvaluatesAfterFirstPass(t *testing.T) {
+	// Global freeform-accept must not short-circuit a later plan_gate stage.
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+	const clawID = "claw-second-plan-gate"
+	_, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, template, status, pipeline_stage, created_at) VALUES(?,?,?,?,?,?,datetime('now'))`,
+		clawID, "test-tenant-id", "test-claw", "base", "connected", "",
+	)
+	if err != nil {
+		t.Fatalf("insert claw: %v", err)
+	}
+	// First plan gate already accepted.
+	s.insertSystemMarker(clawID, "test-tenant-id", initialPlanAcceptedMarker)
+	s.insertSystemMarker(clawID, "test-tenant-id", planGateAcceptedMarker("plan_validate"))
+
+	// Second plan gate should still evaluate its output (fail path).
+	s.persistPipelineOutput(clawID, "plan_review", "plan_review", &pipelineRunResult{
+		ExitCode: 0,
+		Stdout:   `{"status":"incomplete","reason":"needs more detail"}`,
+	})
+	stage := pipeline.Stage{
+		ID:       "plan_review",
+		Label:    "Plan review",
+		PlanGate: true,
+		Gate: &pipeline.Gate{
+			Output:   "plan_review",
+			Pass:     pipeline.GateCondition{Path: "status", Values: []string{"ok"}},
+			Fail:     pipeline.GateCondition{Path: "status", Values: []string{"incomplete"}},
+			Required: true,
+		},
+	}
+	_, err = s.runOnEnter(clawID, stage, pipelineContext{})
+	if err == nil {
+		t.Fatal("expected required gate failure for second plan_gate, got nil")
+	}
+	if s.hasSystemMarker(clawID, planGateAcceptedMarker("plan_review")) {
+		t.Fatal("second plan_gate must not be marked accepted when it fails")
+	}
 }
 
 func TestOrdinaryGateDoesNotSkipFreeformPlan(t *testing.T) {
@@ -627,17 +670,28 @@ func TestPipelineInjectIncludesExactManualTriggerInputs(t *testing.T) {
 		t.Fatalf("stage transition returned false")
 	}
 
-	var content string
-	if err := db.QueryRow(`SELECT content FROM messages WHERE claw_id=? AND role='hub'`, clawID).Scan(&content); err != nil {
-		t.Fatalf("select injected message: %v", err)
+	rows, err := db.Query(`SELECT content FROM messages WHERE claw_id=? AND role='hub' ORDER BY created_at`, clawID)
+	if err != nil {
+		t.Fatalf("select hub messages: %v", err)
 	}
+	defer rows.Close()
+	var all []string
+	for rows.Next() {
+		var content string
+		if err := rows.Scan(&content); err != nil {
+			t.Fatal(err)
+		}
+		all = append(all, content)
+	}
+	joined := strings.Join(all, "\n")
 	for _, want := range []string{
 		"Manual trigger inputs (use these exact values):",
 		`"jira_ticket": "AWB-2420"`,
 		"Use the single manual input `jira_ticket` as the Jira issue to investigate.",
+		"[hub] ▶ Stage: Working",
 	} {
-		if !strings.Contains(content, want) {
-			t.Fatalf("pipeline inject missing %q:\n%s", want, content)
+		if !strings.Contains(joined, want) {
+			t.Fatalf("pipeline inject missing %q:\n%s", want, joined)
 		}
 	}
 }
@@ -964,12 +1018,20 @@ func TestTransitionPipelineStageConcurrentCallsRunOnEnterOnce(t *testing.T) {
 		t.Fatalf("concurrent stage transitions returned true %d times, want 1", transitionCount)
 	}
 
+	// Stage banner notice + on_enter inject (exactly once despite concurrent callers).
 	var messageCount int
 	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=?`, clawID).Scan(&messageCount); err != nil {
 		t.Fatalf("count messages: %v", err)
 	}
-	if messageCount != 1 {
-		t.Fatalf("concurrent stage transitions injected %d messages, want 1", messageCount)
+	if messageCount != 2 {
+		t.Fatalf("concurrent stage transitions wrote %d messages, want 2 (stage banner + inject)", messageCount)
+	}
+	var injectCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND content=?`, clawID, stage.OnEnter.Inject).Scan(&injectCount); err != nil {
+		t.Fatalf("count inject: %v", err)
+	}
+	if injectCount != 1 {
+		t.Fatalf("on_enter inject count = %d, want 1", injectCount)
 	}
 	if got := s.getPipelineStage(clawID); got != "pr_opened" {
 		t.Fatalf("pipeline stage = %q, want pr_opened", got)
@@ -2063,7 +2125,7 @@ stages:
 		t.Fatalf("pipeline stage = %q, want ci_passed", got)
 	}
 	var gateDelivered, stageDelivered interface{}
-	if err := db.QueryRow(`SELECT delivered_at FROM messages WHERE claw_id=? AND content='[hub] Gate passed: Monitor Depot CI'`, clawID).Scan(&gateDelivered); err != nil {
+	if err := db.QueryRow(`SELECT delivered_at FROM messages WHERE claw_id=? AND content='[hub] ✓ Gate passed: Monitor Depot CI'`, clawID).Scan(&gateDelivered); err != nil {
 		t.Fatal(err)
 	}
 	if gateDelivered == nil {

--- a/pkg/hub/pipeline_runner_test.go
+++ b/pkg/hub/pipeline_runner_test.go
@@ -555,6 +555,101 @@ func TestPlanGatePassMarksInitialPlanAccepted(t *testing.T) {
 	if !s.hasSystemMarker(clawID, planGateAcceptedMarker(stage.ID)) {
 		t.Fatal("plan_gate pass should mark per-stage accepted marker")
 	}
+	// No gate_result route in this test — proceed should be injected for the agent.
+	var proceedCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND content=?`, clawID, planGateProceedContent).Scan(&proceedCount); err != nil {
+		t.Fatal(err)
+	}
+	if proceedCount != 1 {
+		t.Fatalf("proceed inject count = %d, want 1 when unrouted", proceedCount)
+	}
+}
+
+func TestPlanGatePassWithRouteDoesNotInjectProceedTurn(t *testing.T) {
+	// When gate_result routes to an implement inject, do not also inject
+	// planGateProceedContent (that would queue a duplicate agent turn).
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+	const clawID = "claw-plan-gate-routed"
+	_, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, template, status, pipeline_stage, created_at) VALUES(?,?,?,?,?,?,datetime('now'))`,
+		clawID, "test-tenant-id", "test-claw", "base", "connected", "",
+	)
+	if err != nil {
+		t.Fatalf("insert claw: %v", err)
+	}
+	s.persistPipelineOutput(clawID, "plan_validate", "plan", &pipelineRunResult{
+		ExitCode: 0,
+		Stdout:   `{"status":"ok"}`,
+	})
+	factory := &types.FactoryConfig{Name: "plan-routed", PipelineYAML: `
+stages:
+  - id: plan_validate
+    plan_gate: true
+    gate:
+      output: plan
+      pass:
+        path: status
+        values: [ok]
+  - id: implement
+    triggers:
+      - gate_result:
+          stage: plan_validate
+          verdict: pass
+    on_enter:
+      inject: Implement the issue now.
+`}
+	stage := pipeline.Stage{
+		ID:       "plan_validate",
+		Label:    "Validate plan",
+		PlanGate: true,
+		Gate: &pipeline.Gate{
+			Output: "plan",
+			Pass:   pipeline.GateCondition{Path: "status", Values: []string{"ok"}},
+		},
+	}
+	if _, err := s.runOnEnter(clawID, stage, pipelineContext{Factory: factory}); err != nil {
+		t.Fatalf("runOnEnter: %v", err)
+	}
+	// Proceed text may appear as a delivered notice, not a pending agent inject.
+	var pendingProceed int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM messages WHERE claw_id=? AND content=? AND delivered_at IS NULL`,
+		clawID, planGateProceedContent,
+	).Scan(&pendingProceed); err != nil {
+		t.Fatal(err)
+	}
+	if pendingProceed != 0 {
+		t.Fatalf("routed plan_gate must not queue pending proceed inject, got %d", pendingProceed)
+	}
+	// Notice should be persisted (delivered immediately for dashboard).
+	var noticeCount int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM messages WHERE claw_id=? AND content=? AND delivered_at IS NOT NULL`,
+		clawID, planGateProceedContent,
+	).Scan(&noticeCount); err != nil {
+		t.Fatal(err)
+	}
+	if noticeCount != 1 {
+		t.Fatalf("expected delivered proceed notice, got %d", noticeCount)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for s.getPipelineStage(clawID) != "implement" && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := s.getPipelineStage(clawID); got != "implement" {
+		t.Fatalf("pipeline stage = %q, want implement", got)
+	}
+	var pendingImplement int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM messages WHERE claw_id=? AND content=? AND delivered_at IS NULL`,
+		clawID, "Implement the issue now.",
+	).Scan(&pendingImplement); err != nil {
+		t.Fatal(err)
+	}
+	if pendingImplement != 1 {
+		t.Fatalf("destination inject pending count = %d, want 1", pendingImplement)
+	}
 }
 
 func TestSecondPlanGateStillEvaluatesAfterFirstPass(t *testing.T) {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -5928,6 +5928,17 @@ Before editing files, running builds, or doing broad tool exploration, send one 
 This first message must be a normal assistant message visible to the user. Tool calls, activity rows, and update_plan do not count. After that visible plan, wait for the hub's proceed message, then start implementation and continue sending visible progress updates.`
 	initialPlanProceedContent    = `[hub] Initial plan received. Proceed with implementation. Keep sending visible progress updates before and after substantial work; tool calls and activity rows do not count as user communication.`
 	initialPlanCorrectionContent = `[hub] Initial plan is required before implementation. Pause tool work and send a visible assistant message with your understanding of the issue, likely code area, rough plan, and verification approach.`
+	// planGateProceedContent is injected when a workflow plan_gate passes.
+	// It must be unambiguous: agents previously waited for freeform "proceed"
+	// or re-emitted [PLAN_READY] after the gate already passed.
+	planGateProceedContent = `[hub] Plan gate passed — you are cleared to implement now.
+Do not wait for another proceed message.
+Do not emit [PLAN_READY] again.
+Keep sending short visible progress updates as you work.
+When the PR is ready, say [DONE] with the PR URL(s).`
+	planGateAlreadyAcceptedContent = `[hub] Plan was already approved earlier in this run.
+Continue implementation — do not emit [PLAN_READY] again.
+When the PR is ready, say [DONE] with the PR URL(s).`
 )
 
 // sendWakeMessage sends a silent system message to wake the agent.

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -5941,6 +5941,12 @@ Continue implementation — do not emit [PLAN_READY] again.
 When the PR is ready, say [DONE] with the PR URL(s).`
 )
 
+// planGateAcceptedMarker is per-stage so a second plan_gate later in the
+// workflow still evaluates its own output instead of inheriting a global pass.
+func planGateAcceptedMarker(stageID string) string {
+	return "__PLAN_GATE_ACCEPTED__:" + stageID
+}
+
 // sendWakeMessage sends a silent system message to wake the agent.
 // For factory claws, it sends a task-specific prompt.
 // A marker is stored in DB so reconnects after hub restart don't re-introduce.

--- a/pkg/types/workflow_normalize_test.go
+++ b/pkg/types/workflow_normalize_test.go
@@ -416,6 +416,72 @@ stages:
 	}
 }
 
+func TestWorkflowNormalizePreservesPlanGate(t *testing.T) {
+	data := []byte(`
+schema_version: v1
+name: plan-gate-story
+trigger:
+  linear:
+    event: status_changed
+    workspace: amazecrm
+    states:
+      - Todo
+stages:
+  - id: plan
+    entry: true
+    on_enter:
+      inject: write plan.json
+  - id: plan_validate
+    plan_gate: true
+    triggers:
+      - message_contains: "[PLAN_READY]"
+    on_enter:
+      run:
+        command: echo ok
+        output: plan
+    gate:
+      output: plan
+      pass:
+        path: status
+        values: [ok]
+      required: true
+`)
+	var workflow WorkflowConfig
+	if err := yaml.Unmarshal(data, &workflow); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(workflow.Stages) < 2 || !workflow.Stages[1].PlanGate {
+		t.Fatalf("expected plan_gate parsed on authored stage, stages=%+v", workflow.Stages)
+	}
+	if err := NormalizeWorkflowConfig(&workflow); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if !strings.Contains(workflow.PipelineYAML, "plan_gate: true") {
+		t.Fatalf("pipeline yaml lost plan_gate after normalize:\n%s", workflow.PipelineYAML)
+	}
+	// Round-trip through pipeline parse would live in hub; ensure re-unmarshal keeps it.
+	var again WorkflowConfig
+	if err := yaml.Unmarshal([]byte(workflow.PipelineYAML), &again); err != nil {
+		t.Fatalf("re-unmarshal pipeline yaml: %v", err)
+	}
+	// PipelineYAML is only stages wrapper — parse as stages blob
+	var stagesOnly struct {
+		Stages []WorkflowStage `yaml:"stages"`
+	}
+	if err := yaml.Unmarshal([]byte(workflow.PipelineYAML), &stagesOnly); err != nil {
+		t.Fatalf("unmarshal stages: %v", err)
+	}
+	found := false
+	for _, st := range stagesOnly.Stages {
+		if st.ID == "plan_validate" && st.PlanGate {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("plan_gate not preserved on plan_validate after normalize re-marshal: %+v", stagesOnly.Stages)
+	}
+}
+
 func TestWorkflowV1ShortcutTriggerValidates(t *testing.T) {
 	data := []byte(`
 schema_version: v1

--- a/pkg/types/workspace.go
+++ b/pkg/types/workspace.go
@@ -173,6 +173,10 @@ type WorkflowStage struct {
 	SkipIf     map[string]interface{}   `yaml:"skip_if,omitempty" json:"skipIf,omitempty"`
 	SkipUnless map[string]interface{}   `yaml:"skip_unless,omitempty" json:"skipUnless,omitempty"`
 	Gate       map[string]interface{}   `yaml:"gate,omitempty" json:"gate,omitempty"`
+	// PlanGate marks this stage as deterministic plan approval. Must survive
+	// NormalizeWorkflowConfig re-marshal into PipelineYAML or freeform plan
+	// approval incorrectly stays on for workflows that set plan_gate: true.
+	PlanGate bool `yaml:"plan_gate,omitempty" json:"planGate,omitempty"`
 }
 
 func (w *WorkspaceConfig) Validate() error {


### PR DESCRIPTION
## Summary
Root cause of AMA-116 looping on `[PLAN_READY]`:

**`plan_gate: true` was stripped** when the hub normalizes authored workflow stages into `PipelineYAML` (`WorkflowStage` lacked a `PlanGate` field). Freeform plan approval still ran, so the agent was told both “write plan.json / [PLAN_READY]” **and** “wait for the hub proceed message”. After the gate passed, it kept re-emitting `[PLAN_READY]`.

### Fixes
1. **Preserve `plan_gate`** on `types.WorkflowStage` through normalize → `PipelineYAML` → pipeline parse (regression test).
2. **Clearer transcript UX**
   - `[hub] ▶ Stage: …` notice when entering each stage (dashboard-visible)
   - Friendlier plan-gate pass/fail wording
   - Explicit inject after plan gate pass: cleared to implement, do not wait for another proceed, do not emit `[PLAN_READY]` again
   - Re-`[PLAN_READY]` after accept short-circuits with the same guidance instead of re-running validation forever

### Deploy
1. Merge + deploy hub to amaze-factory
2. Re-push amazecrm-linear workflow (no YAML change required for the strip fix, but restart hub to load new binary)
3. Re-test a Linear Todo issue — freeform “Initial plan required…” should **not** appear when `plan_gate` is set

## Test plan
- [x] `go test ./pkg/types/ -run TestWorkflowNormalizePreserves`
- [x] `go test ./pkg/hub/ -run 'TestNormalized|TestPipelineEntry|TestPlanGate'`
- [ ] Live: Todo issue with plan_gate workflow — no freeform wake, one `[PLAN_READY]`, clear stage banners, implement proceeds