### PR TITLE
feat(hub): silent progress probes (status channel only)

### DIFF
--- a/examples/workflows/linear-issue-plan-gate.yaml
+++ b/examples/workflows/linear-issue-plan-gate.yaml
@@ -76,7 +76,14 @@ stages:
                   "reason": "steps must be a non-empty list of strings",
               }))
           else:
-              print(json.dumps({"status": "ok"}))
+              # Echo plan fields so the hub can publish an approved-plan summary.
+              print(json.dumps({
+                  "status": "ok",
+                  "understanding": data["understanding"].strip(),
+                  "area": data["area"].strip(),
+                  "steps": [s.strip() for s in steps],
+                  "verification": data["verification"].strip(),
+              }))
           PY
         output: plan
         timeout: 2m

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -1135,14 +1135,18 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 				_ = s.insertSystemMarker(clawID, tenantID, planGateAcceptedMarker(stage.ID))
 			}
 			// Surface the approved plan in chat even when the agent only said
-			// [PLAN_READY] — validators should echo understanding/area/steps.
+			// [PLAN_READY]. Prefer gate JSON fields; fall back to a short notice
+			// when the validator only printed {"status":"ok"}.
+			var summary string
 			if stage.Gate != nil && stage.Gate.Output != "" {
 				if outs := s.loadPipelineOutputs(clawID); outs != nil {
-					if summary := formatPlanGateSummary(outs[stage.Gate.Output]); summary != "" {
-						s.publishHubNotice(clawID, summary)
-					}
+					summary = formatPlanGateSummary(outs[stage.Gate.Output])
 				}
 			}
+			if summary == "" {
+				summary = formatPlanGateSummary(nil)
+			}
+			s.publishHubNotice(clawID, summary)
 			// When a gate_result route will inject the destination stage prompt,
 			// do not also inject proceed — that queues a duplicate agent turn
 			// before the implement instructions arrive (Greptile).

--- a/pkg/hub/pipeline_runner_test.go
+++ b/pkg/hub/pipeline_runner_test.go
@@ -595,8 +595,21 @@ func TestFormatPlanGateSummary(t *testing.T) {
 			t.Fatalf("summary missing %q:\n%s", want, got)
 		}
 	}
-	if formatPlanGateSummary(map[string]interface{}{"status": "ok"}) != "" {
-		t.Fatal("expected empty summary when no plan fields")
+	// Status-only validator output still produces a short approved notice.
+	statusOnly := formatPlanGateSummary(map[string]interface{}{"status": "ok"})
+	if !strings.Contains(statusOnly, "Plan approved") {
+		t.Fatalf("status-only output should still notice approval, got %q", statusOnly)
+	}
+	// Multiline field values must stay indented under their label.
+	multi := formatPlanGateSummary(map[string]interface{}{
+		"understanding": "Line one\nLine two\n- not a field",
+		"steps":         []interface{}{"step A\ncontinued A", "step B"},
+	})
+	if !strings.Contains(multi, "- understanding: \n    Line one\n    Line two\n    - not a field") {
+		t.Fatalf("multiline understanding not indented:\n%s", multi)
+	}
+	if !strings.Contains(multi, "  • step A\n    continued A\n  • step B") {
+		t.Fatalf("multiline step item not indented:\n%s", multi)
 	}
 }
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -6019,13 +6019,37 @@ When the PR is ready, say [DONE] with the PR URL(s).`
 
 // formatPlanGateSummary builds a human-readable plan dump from gate output JSON
 // so the transcript shows the plan even when the agent only said [PLAN_READY].
+// Multiline values are indented under their field. When the validator only
+// returned status (legacy), still emit a short approved notice so chat is not silent.
 func formatPlanGateSummary(output map[string]interface{}) string {
 	if output == nil {
-		return ""
+		return "[hub] Plan approved (schema gate)."
 	}
 	var b strings.Builder
 	b.WriteString("[hub] Approved plan summary:\n")
 	wrote := false
+	writeLabeled := func(label, value string) {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return
+		}
+		lines := strings.Split(value, "\n")
+		b.WriteString("- ")
+		b.WriteString(label)
+		b.WriteString(": ")
+		if len(lines) == 1 {
+			b.WriteString(lines[0])
+			b.WriteByte('\n')
+		} else {
+			b.WriteByte('\n')
+			for _, line := range lines {
+				b.WriteString("    ")
+				b.WriteString(strings.TrimRight(line, "\r"))
+				b.WriteByte('\n')
+			}
+		}
+		wrote = true
+	}
 	writeField := func(label, key string) {
 		v, ok := output[key]
 		if !ok || v == nil {
@@ -6033,15 +6057,7 @@ func formatPlanGateSummary(output map[string]interface{}) string {
 		}
 		switch t := v.(type) {
 		case string:
-			if strings.TrimSpace(t) == "" {
-				return
-			}
-			b.WriteString("- ")
-			b.WriteString(label)
-			b.WriteString(": ")
-			b.WriteString(strings.TrimSpace(t))
-			b.WriteByte('\n')
-			wrote = true
+			writeLabeled(label, t)
 		case []interface{}:
 			if len(t) == 0 {
 				return
@@ -6050,9 +6066,19 @@ func formatPlanGateSummary(output map[string]interface{}) string {
 			b.WriteString(label)
 			b.WriteString(":\n")
 			for _, item := range t {
+				itemLines := strings.Split(strings.TrimSpace(fmt.Sprint(item)), "\n")
 				b.WriteString("  • ")
-				b.WriteString(strings.TrimSpace(fmt.Sprint(item)))
+				if len(itemLines) == 0 {
+					b.WriteByte('\n')
+					continue
+				}
+				b.WriteString(itemLines[0])
 				b.WriteByte('\n')
+				for _, cont := range itemLines[1:] {
+					b.WriteString("    ")
+					b.WriteString(strings.TrimRight(cont, "\r"))
+					b.WriteByte('\n')
+				}
 			}
 			wrote = true
 		default:
@@ -6060,12 +6086,7 @@ func formatPlanGateSummary(output map[string]interface{}) string {
 			if s == "" || s == "[]" || s == "map[]" {
 				return
 			}
-			b.WriteString("- ")
-			b.WriteString(label)
-			b.WriteString(": ")
-			b.WriteString(s)
-			b.WriteByte('\n')
-			wrote = true
+			writeLabeled(label, s)
 		}
 	}
 	writeField("understanding", "understanding")
@@ -6073,7 +6094,8 @@ func formatPlanGateSummary(output map[string]interface{}) string {
 	writeField("steps", "steps")
 	writeField("verification", "verification")
 	if !wrote {
-		return ""
+		// Validator only returned status (or empty fields). Still surface a notice.
+		return "[hub] Plan approved (schema gate)."
 	}
 	return strings.TrimRight(b.String(), "\n")
 }

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -235,6 +235,7 @@ type clawConn struct {
 	lastUserMessageAt     time.Time       // when the user last sent a message (for idle detection)
 	lastStatusBroadcastAt time.Time       // when we last broadcast status to user
 	unresponsiveWarnedAt  time.Time       // when the silent-death warning was first broadcast
+	lastProgressProbeAt   time.Time       // when we last sent a silent mid-turn progress probe
 }
 
 const (
@@ -246,6 +247,14 @@ const (
 const (
 	streamingTimeoutNudge  = "[hub] Your current response has been running for over 12 minutes. Please wrap up and send your response."
 	contextNearlyFullNudge = "[hub] Context window is nearly full. Summarize your progress briefly and send [DONE] with any PR URL, or ask the user what to do next."
+	// progressProbeContent is injected mid-turn over the status channel only
+	// (never persisted to chat). It asks the agent to post a visible update
+	// so tool-only runs still feel proactive to humans watching the UI.
+	progressProbeContent = "Humans are watching this chat. Before more tool work, post a short plain assistant message (1–3 sentences) covering what you just did and what you will do next. Tool activity alone is not enough."
+	// progressProbeInterval is the minimum gap between silent progress probes.
+	progressProbeInterval = time.Minute
+	// progressProbeMinTurnAge waits for the turn to get going before the first probe.
+	progressProbeMinTurnAge = 45 * time.Second
 	// autoResumeRecentTurnWindow includes races between a crash and turn completion.
 	autoResumeRecentTurnWindow = 5 * time.Minute
 )
@@ -296,6 +305,7 @@ func (cc *clawConn) resetTurnStateLocked() {
 	cc.streamingStartedAt = time.Time{}
 	cc.streamingTimeoutSent = false
 	cc.contextWarningSent = false
+	cc.lastProgressProbeAt = time.Time{}
 }
 
 func (s *Server) flushStreamingSegment(clawID, tenantID string, cc *clawConn) error {
@@ -395,6 +405,7 @@ func NewServer(addr, dbPath, identityDir string, hubCfg *types.HubConfig) (*Serv
 	go srv.keepAliveDaytonaSandboxes()
 	go srv.pruneAnalytics()
 	go srv.statusWatchdog()
+	go srv.progressProbeWatchdog()
 	go srv.checkpointScheduler()
 	if srv.livenessEnabled() {
 		go srv.runReaper()
@@ -5611,6 +5622,63 @@ func (s *Server) statusWatchdog() {
 	}
 }
 
+// progressProbeWatchdog periodically asks busy agents (over the status channel
+// only) to post a visible chat update. Probes never appear in the transcript.
+func (s *Server) progressProbeWatchdog() {
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+	for range ticker.C {
+		s.probeBusyClawsForProgress()
+	}
+}
+
+// probeBusyClawsForProgress sends silent mid-turn status-channel nudges so
+// tool-heavy agents still produce human-readable chat updates.
+func (s *Server) probeBusyClawsForProgress() {
+	now := time.Now()
+	s.mu.RLock()
+	ids := make([]string, 0, len(s.claws))
+	for id := range s.claws {
+		ids = append(ids, id)
+	}
+	s.mu.RUnlock()
+	for _, id := range ids {
+		s.mu.RLock()
+		cc, ok := s.claws[id]
+		s.mu.RUnlock()
+		if !ok || cc == nil {
+			continue
+		}
+		s.maybeSendProgressProbe(cc, now)
+	}
+}
+
+// maybeSendProgressProbe rate-limits and dispatches one silent progress probe
+// for a claw that has been mid-turn long enough.
+func (s *Server) maybeSendProgressProbe(cc *clawConn, now time.Time) {
+	cc.mu.Lock()
+	if !cc.isBusyLocked() || cc.statusConn == nil {
+		cc.mu.Unlock()
+		return
+	}
+	turnStart := cc.streamingStartedAt
+	if turnStart.IsZero() {
+		// Prompt delivered but first chunk not yet seen — still a live turn.
+		turnStart = cc.lastUserMessageAt
+	}
+	if turnStart.IsZero() || now.Sub(turnStart) < progressProbeMinTurnAge {
+		cc.mu.Unlock()
+		return
+	}
+	if !cc.lastProgressProbeAt.IsZero() && now.Sub(cc.lastProgressProbeAt) < progressProbeInterval {
+		cc.mu.Unlock()
+		return
+	}
+	cc.lastProgressProbeAt = now
+	cc.mu.Unlock()
+	s.sendSilentStatusNudge(cc, progressProbeContent)
+}
+
 // checkClawStatus queries active claws, sends status requests via the status channel,
 // and detects claws that have gone silent (no status response, no user message recently).
 func (s *Server) checkClawStatus() {
@@ -8115,6 +8183,35 @@ func (s *Server) sendStreamingNudge(cc *clawConn, text string) {
 	msg := types.HubMessage{ID: uuid.New().String(), ClawID: clawID, TenantID: tenantID, Role: "hub", Content: text, Format: "pre", CreatedAt: now()}
 	_, _ = s.db.Exec(`INSERT INTO messages(id,claw_id,tenant_id,role,content,format,created_at,delivered_at) VALUES(?,?,?,?,?,?,?,?)`, msg.ID, msg.ClawID, msg.TenantID, msg.Role, msg.Content, msg.Format, msg.CreatedAt, msg.CreatedAt)
 	s.broadcastToUsers(tenantID, types.WSMessage{Type: "message", Payload: msg})
+}
+
+// sendSilentStatusNudge injects text into the in-flight agent turn over the
+// status channel only. Unlike sendStreamingNudge it never persists or
+// broadcasts a chat row — probes stay invisible in the transcript.
+// It never falls back to the main message queue (that would surface the probe).
+func (s *Server) sendSilentStatusNudge(cc *clawConn, text string) {
+	if cc == nil || strings.TrimSpace(text) == "" {
+		return
+	}
+	cc.mu.RLock()
+	sc, clawID := cc.statusConn, cc.id
+	turnOpen := cc.isBusyLocked()
+	cc.mu.RUnlock()
+	if !turnOpen {
+		log.Printf("[progress-probe] drop for %s: turn already ended", shortID(clawID))
+		return
+	}
+	if sc == nil {
+		log.Printf("[progress-probe] drop for %s: no status channel", shortID(clawID))
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := wsjson.Write(ctx, sc, types.WSMessage{Type: "nudge", Payload: mustJSONRaw(map[string]string{"claw_id": clawID, "content": text})}); err != nil {
+		log.Printf("[progress-probe] status send failed for %s: %v", shortID(clawID), err)
+		return
+	}
+	log.Printf("[progress-probe] silent nudge sent to %s", shortID(clawID))
 }
 
 // sendNextQueuedMessage delivers the oldest pending message if the claw is idle.

--- a/pkg/hub/watchdog_enforcement_test.go
+++ b/pkg/hub/watchdog_enforcement_test.go
@@ -556,6 +556,90 @@ func TestSessionRotatedNotConnectedDoesNotEnqueueResume(t *testing.T) {
 	}
 }
 
+func TestSilentProgressProbeGoesOverStatusChannelWithoutTranscript(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	const clawID = "progress-probe-silent"
+	_ = watchdogClaw(t, s, clawID)
+	cc := watchdogClawConn(t, s, clawID)
+
+	ts := httptest.NewServer(s.Handler())
+	t.Cleanup(ts.Close)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	statusConn, _, err := websocket.Dial(ctx, "ws"+strings.TrimPrefix(ts.URL, "http")+"/claw/ws", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = statusConn.Close(websocket.StatusNormalClosure, "done") })
+	if err := wsjson.Write(ctx, statusConn, types.WSMessage{Type: "register", Payload: types.RegisterPayload{
+		ClawID: clawID, Name: "probe claw", Template: "elasticclaw", Token: "claw-token", Channel: "status",
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	var ack types.WSMessage
+	if err := wsjson.Read(ctx, statusConn, &ack); err != nil || ack.Type != "registered" {
+		t.Fatalf("status channel ack: type=%q err=%v", ack.Type, err)
+	}
+	eventuallyWatchdog(t, func() bool {
+		cc.mu.RLock()
+		defer cc.mu.RUnlock()
+		return cc.statusConn != nil
+	}, "status channel attach")
+
+	// Turn already long enough for a probe.
+	cc.mu.Lock()
+	cc.streamingStartedAt = time.Now().Add(-2 * time.Minute)
+	cc.streamingMsgID = "stream"
+	cc.lastProgressProbeAt = time.Time{}
+	cc.mu.Unlock()
+
+	s.maybeSendProgressProbe(cc, time.Now())
+
+	var got types.WSMessage
+	if err := wsjson.Read(ctx, statusConn, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Type != "nudge" {
+		t.Fatalf("status channel message type=%q, want nudge", got.Type)
+	}
+	payload, _ := got.Payload.(map[string]interface{})
+	if payload["content"] != progressProbeContent {
+		t.Fatalf("nudge content=%#v, want progress probe", payload["content"])
+	}
+	// Must never appear in the chat transcript (no message rows).
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND content=?`, clawID, progressProbeContent).Scan(&n); err != nil || n != 0 {
+		t.Fatalf("transcript rows=%d err=%v, want 0 (silent probe)", n, err)
+	}
+	// Rate-limited: immediate second call must not send another nudge.
+	s.maybeSendProgressProbe(cc, time.Now())
+	// Non-blocking check: no second message within a short window.
+	readCtx, readCancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer readCancel()
+	var second types.WSMessage
+	if err := wsjson.Read(readCtx, statusConn, &second); err == nil {
+		t.Fatalf("unexpected second nudge: %#v", second)
+	}
+}
+
+func TestSilentProgressProbeSkippedWithoutStatusChannel(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	const clawID = "progress-probe-no-status"
+	_ = watchdogClaw(t, s, clawID)
+	cc := watchdogClawConn(t, s, clawID)
+	cc.mu.Lock()
+	cc.streamingStartedAt = time.Now().Add(-2 * time.Minute)
+	cc.streamingMsgID = "stream"
+	cc.statusConn = nil
+	cc.mu.Unlock()
+	s.maybeSendProgressProbe(cc, time.Now())
+	// Must not fall back to chat queue.
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND content=?`, clawID, progressProbeContent).Scan(&n); err != nil || n != 0 {
+		t.Fatalf("chat rows=%d err=%v, want 0 (no fallback)", n, err)
+	}
+}
+
 func TestStreamingNudgeGoesOverStatusChannel(t *testing.T) {
 	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
 	const clawID = "watchdog-nudge-status-channel"


### PR DESCRIPTION
## Summary
While an agent is mid-turn (tool-heavy work), the hub now sends a **silent** progress probe over the **status channel** (~every 60s after the first 45s of the turn):

> Humans are watching this chat. Before more tool work, post a short plain assistant message…

### Design
| Property | Behavior |
|---|---|
| Transport | Status WS `nudge` → bridge `sessions.send` (in-flight turn only) |
| Chat transcript | **Never** persisted or broadcast |
| Fallback | **None** — if no status channel / turn ended, drop (don’t inject hub chat) |
| Rate limit | First after 45s of turn; then ≥60s between probes |
| Watchdog tick | Every 30s checks eligibility |

Existing visible watchdog nudges (12m timeout, context full) are unchanged.

### Why
Plan-gate demos still looked silent: agents worked via tools with almost no plain chat. Probes nudge mid-turn without polluting the transcript with hub messages.

## Test plan
- [x] `TestSilentProgressProbeGoesOverStatusChannelWithoutTranscript`
- [x] `TestSilentProgressProbeSkippedWithoutStatusChannel`
- [ ] Live: long implement turn → agent posts periodic progress; transcript has no probe rows