### PR TITLE
fix(hub): hide plan_gate system markers from chat

### DIFF
--- a/examples/workflows/linear-issue-plan-gate.yaml
+++ b/examples/workflows/linear-issue-plan-gate.yaml
@@ -107,7 +107,10 @@ stages:
           verdict: pass
     on_enter:
       inject: |
-        Plan accepted (status {{ .Outputs.plan.status }}).
+        ## Starting implementation for {{.Issue.Identifier}}
+
+        Plan accepted (status {{ .Outputs.plan.status }}) — coding begins now.
+        Do not wait for another proceed message. Do not emit [PLAN_READY] again.
         Implement the issue. Narrate progress. When the PR is ready, say [DONE] with the PR URL.
 
   - id: fix_plan

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1937,16 +1937,28 @@ func hiddenSystemMessagesArgs() []interface{} {
 		initialPlanAcceptedMarker,
 		initialPlanCorrectionSentMarker,
 		// planGateAcceptedMarker is per-stage: __PLAN_GATE_ACCEPTED__:<stageID>
-		planGateAcceptedMarkerPrefix + "%",
+		// Escape LIKE metacharacters so underscores in the prefix are literal
+		// (SQL LIKE treats _ as a single-char wildcard without ESCAPE).
+		sqlLikeLiteralPrefix(planGateAcceptedMarkerPrefix) + "%",
 	}
 }
 
 func hiddenSystemMessagesSQL() string {
 	// Exact markers (wake / freeform plan) plus per-stage plan_gate accepted markers.
+	// ESCAPE '\' makes \_ and \% literal in the prefix pattern.
 	return `AND NOT (role = 'system' AND (
 		content IN (?, ?, ?, ?, ?, ?)
-		OR content LIKE ?
+		OR content LIKE ? ESCAPE '\'
 	))`
+}
+
+// sqlLikeLiteralPrefix escapes \, %, and _ so a marker prefix can be used with
+// LIKE ? ESCAPE '\' without treating underscores as wildcards.
+func sqlLikeLiteralPrefix(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `%`, `\%`)
+	s = strings.ReplaceAll(s, `_`, `\_`)
+	return s
 }
 
 func (s *Server) handleMessageTimeline(w http.ResponseWriter, r *http.Request, tenantID, clawID string) {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1862,31 +1862,39 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 
 	var rows *sql.Rows
 	var err error
+	hideSQL := hiddenSystemMessagesSQL()
+	hideArgs := hiddenSystemMessagesArgs()
 	if before != "" {
 		// Fetch older messages — return in ASC order after fetching DESC
+		args := append([]interface{}{clawID, tenantID, before}, hideArgs...)
+		args = append(args, limit)
 		rows, err = s.db.Query(
 			`SELECT id, claw_id, tenant_id, role, content, COALESCE(format,''), created_at FROM messages
 			 WHERE claw_id = ? AND tenant_id = ? AND created_at < ?
-			 AND NOT (role = 'system' AND content IN (?, ?, ?, ?, ?, ?))
+			 `+hideSQL+`
 			 ORDER BY created_at DESC LIMIT ?`,
-			clawID, tenantID, before, wakeMessageMarker, defaultWakeContent, initialPlanWakeContent, initialPlanRequiredMarker, initialPlanAcceptedMarker, initialPlanCorrectionSentMarker, limit,
+			args...,
 		)
 	} else if after != "" {
+		args := append([]interface{}{clawID, tenantID, after}, hideArgs...)
+		args = append(args, limit)
 		rows, err = s.db.Query(
 			`SELECT id, claw_id, tenant_id, role, content, COALESCE(format,''), created_at FROM messages
 			 WHERE claw_id = ? AND tenant_id = ? AND created_at > ?
-			 AND NOT (role = 'system' AND content IN (?, ?, ?, ?, ?, ?))
+			 `+hideSQL+`
 			 ORDER BY created_at ASC LIMIT ?`,
-			clawID, tenantID, after, wakeMessageMarker, defaultWakeContent, initialPlanWakeContent, initialPlanRequiredMarker, initialPlanAcceptedMarker, initialPlanCorrectionSentMarker, limit,
+			args...,
 		)
 	} else {
 		// Default: last N messages
+		args := append([]interface{}{clawID, tenantID}, hideArgs...)
+		args = append(args, limit)
 		rows, err = s.db.Query(
 			`SELECT id, claw_id, tenant_id, role, content, COALESCE(format,''), created_at FROM messages
 			 WHERE claw_id = ? AND tenant_id = ?
-			 AND NOT (role = 'system' AND content IN (?, ?, ?, ?, ?, ?))
+			 `+hideSQL+`
 			 ORDER BY created_at DESC LIMIT ?`,
-			clawID, tenantID, wakeMessageMarker, defaultWakeContent, initialPlanWakeContent, initialPlanRequiredMarker, initialPlanAcceptedMarker, initialPlanCorrectionSentMarker, limit,
+			args...,
 		)
 	}
 	if err != nil {
@@ -1928,11 +1936,17 @@ func hiddenSystemMessagesArgs() []interface{} {
 		initialPlanRequiredMarker,
 		initialPlanAcceptedMarker,
 		initialPlanCorrectionSentMarker,
+		// planGateAcceptedMarker is per-stage: __PLAN_GATE_ACCEPTED__:<stageID>
+		planGateAcceptedMarkerPrefix + "%",
 	}
 }
 
 func hiddenSystemMessagesSQL() string {
-	return `AND NOT (role = 'system' AND content IN (?, ?, ?, ?, ?, ?))`
+	// Exact markers (wake / freeform plan) plus per-stage plan_gate accepted markers.
+	return `AND NOT (role = 'system' AND (
+		content IN (?, ?, ?, ?, ?, ?)
+		OR content LIKE ?
+	))`
 }
 
 func (s *Server) handleMessageTimeline(w http.ResponseWriter, r *http.Request, tenantID, clawID string) {
@@ -5984,7 +5998,10 @@ const (
 	initialPlanRequiredMarker       = "__INITIAL_PLAN_REQUIRED__"
 	initialPlanAcceptedMarker       = "__INITIAL_PLAN_ACCEPTED__"
 	initialPlanCorrectionSentMarker = "__INITIAL_PLAN_CORRECTION_SENT__"
-	defaultWakeContent              = "Introduce yourself briefly and let the user know you're ready to help."
+	// planGateAcceptedMarkerPrefix is the shared prefix for per-stage markers
+	// written on plan_gate pass. Hidden from chat/timeline/transcript APIs.
+	planGateAcceptedMarkerPrefix = "__PLAN_GATE_ACCEPTED__:"
+	defaultWakeContent           = "Introduce yourself briefly and let the user know you're ready to help."
 	initialPlanWakeContent          = `Initial plan required before implementation.
 
 Before editing files, running builds, or doing broad tool exploration, send one visible assistant message that contains:
@@ -6105,7 +6122,7 @@ func formatPlanGateSummary(output map[string]interface{}) string {
 // planGateAcceptedMarker is per-stage so a second plan_gate later in the
 // workflow still evaluates its own output instead of inheriting a global pass.
 func planGateAcceptedMarker(stageID string) string {
-	return "__PLAN_GATE_ACCEPTED__:" + stageID
+	return planGateAcceptedMarkerPrefix + stageID
 }
 
 // sendWakeMessage sends a silent system message to wake the agent.

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -954,6 +954,8 @@ func TestHandleMessagesFiltersWakeMarkers(t *testing.T) {
 		{ID: "plan-required-1", ClawID: "claw-1", TenantID: "test-tenant-id", Role: "system", Content: initialPlanRequiredMarker, CreatedAt: now()},
 		{ID: "plan-accepted-1", ClawID: "claw-1", TenantID: "test-tenant-id", Role: "system", Content: initialPlanAcceptedMarker, CreatedAt: now()},
 		{ID: "plan-correction-1", ClawID: "claw-1", TenantID: "test-tenant-id", Role: "system", Content: initialPlanCorrectionSentMarker, CreatedAt: now()},
+		// Per-stage plan_gate marker must not leak into the chat UI/transcript.
+		{ID: "plan-gate-1", ClawID: "claw-1", TenantID: "test-tenant-id", Role: "system", Content: planGateAcceptedMarker("plan_validate"), CreatedAt: now()},
 		{ID: "user-1", ClawID: "claw-1", TenantID: "test-tenant-id", Role: "user", Content: "hello", CreatedAt: now()},
 	} {
 		_, err := db.Exec(

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -985,6 +985,71 @@ func TestHandleMessagesFiltersWakeMarkers(t *testing.T) {
 	}
 }
 
+func TestSQLLikeLiteralPrefixEscapesWildcards(t *testing.T) {
+	// Underscores must be escaped so LIKE does not treat them as single-char wildcards.
+	got := sqlLikeLiteralPrefix("__PLAN_GATE_ACCEPTED__:")
+	want := `\_\_PLAN\_GATE\_ACCEPTED\_\_:`
+	if got != want {
+		t.Fatalf("sqlLikeLiteralPrefix = %q, want %q", got, want)
+	}
+	if got := sqlLikeLiteralPrefix(`a%b_c\d`); got != `a\%b\_c\\d` {
+		t.Fatalf("escape order wrong: %q", got)
+	}
+}
+
+func TestHandleMessagesDoesNotHideUnrelatedUnderscoreMarkers(t *testing.T) {
+	// Without ESCAPE, LIKE '__PLAN_GATE_ACCEPTED__:%' would also match any string
+	// of the same shape with different letters (each _ is a wildcard).
+	s, db := NewTestServerWithConfig(t, nil, "", "", "")
+	_, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, tags, created_at) VALUES(?,?,?,?,datetime('now'))`,
+		"claw-like", "test-tenant-id", "claw", `[]`,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Same length/shape as __PLAN_GATE_ACCEPTED__:x but different content.
+	lookalike := "XXPLANXGATEDACCEPTEDXX:not-a-real-marker"
+	if len(lookalike) != len(planGateAcceptedMarker("not-a-real-marker")) {
+		// Keep the test meaningful if the prefix length changes.
+		lookalike = strings.Repeat("X", len(planGateAcceptedMarkerPrefix)) + "not-a-real-marker"
+	}
+	for _, msg := range []types.HubMessage{
+		{ID: "lookalike", ClawID: "claw-like", TenantID: "test-tenant-id", Role: "system", Content: lookalike, CreatedAt: now()},
+		{ID: "real-gate", ClawID: "claw-like", TenantID: "test-tenant-id", Role: "system", Content: planGateAcceptedMarker("plan_validate"), CreatedAt: now()},
+		{ID: "user-1", ClawID: "claw-like", TenantID: "test-tenant-id", Role: "user", Content: "hello", CreatedAt: now()},
+	} {
+		if _, err := db.Exec(
+			`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at) VALUES(?,?,?,?,?,?)`,
+			msg.ID, msg.ClawID, msg.TenantID, msg.Role, msg.Content, msg.CreatedAt,
+		); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/messages/claw-like", nil)
+	req = req.WithContext(context.WithValue(req.Context(), ctxTenantKey{}, "test-tenant-id"))
+	rec := httptest.NewRecorder()
+	s.handleMessages(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d", rec.Code)
+	}
+	var msgs []types.HubMessage
+	if err := json.NewDecoder(rec.Body).Decode(&msgs); err != nil {
+		t.Fatal(err)
+	}
+	ids := map[string]bool{}
+	for _, m := range msgs {
+		ids[m.ID] = true
+	}
+	if !ids["user-1"] || !ids["lookalike"] {
+		t.Fatalf("expected user + lookalike system message visible, got %#v", msgs)
+	}
+	if ids["real-gate"] {
+		t.Fatalf("real plan_gate marker must stay hidden, got %#v", msgs)
+	}
+}
+
 func TestMessageTimelineSummarizesActivityWithoutCrowdingConversation(t *testing.T) {
 	s, db := NewTestServerWithConfig(t, nil, "", "", "")
 	_, err := db.Exec(


### PR DESCRIPTION
## Summary
- Hide `__PLAN_GATE_ACCEPTED__:<stage>` system markers from message list + timeline APIs (they leaked into UI and copy-transcript, e.g. AMA-111)
- Route `/api/messages` through the shared `hiddenSystemMessages*` helper so filters stay consistent
- Example plan-gate workflow implement inject leads with **Starting implementation** for clearer stage UX

## Test plan
- [x] `go test ./pkg/hub/ -run TestHandleMessagesFiltersWakeMarkers`
- [ ] Run a plan_gate workflow; confirm system marker does not appear in chat or copied transcript
- [ ] Confirm wake / freeform plan markers still hidden
- [ ] Confirm implement inject still queues the agent turn