### PR TITLE
fix(hub): exedev exec quoting + workspace GitHub App tokens

### DIFF
--- a/pkg/hub/github_client_test.go
+++ b/pkg/hub/github_client_test.go
@@ -261,11 +261,13 @@ func TestPollAllPRsStopsCallingGitHubWhileRateLimited(t *testing.T) {
 		t.Fatalf("nextPollDelay=%s, want a backoff longer than %s", delay, prWatcherBaseInterval)
 	}
 
-	// One unscoped and one repo-scoped token for the whole run, not one per call.
-	if got := atomic.LoadInt64(&mints); got != 2 {
-		t.Fatalf("installation tokens minted=%d, want 2 (tokens must be cached)", got)
+	// Repo-scoped only (pollAllPRs uses tokenForRepo so multi-org workspace apps
+	// are not collapsed onto a single unscoped installation token).
+	if got := atomic.LoadInt64(&mints); got != 1 {
+		t.Fatalf("installation tokens minted=%d, want 1 (repo-scoped token cached across polls)", got)
 	}
 }
+
 
 func TestInstallationTokensAreCachedAcrossCalls(t *testing.T) {
 	var mints int64

--- a/pkg/hub/github_client_test.go
+++ b/pkg/hub/github_client_test.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -284,6 +286,50 @@ func TestInstallationTokensAreCachedAcrossCalls(t *testing.T) {
 	}
 	if got := atomic.LoadInt64(&mints); got != 2 {
 		t.Fatalf("installation tokens minted=%d, want 2 (one per distinct scope)", got)
+	}
+}
+
+// Factories often configure GitHub Apps only on the workspace (no hub-global
+// github_apps). PR watcher / poller / reconciler must still mint tokens.
+func TestResolveGitHubTokenUsesWorkspaceAppsWhenHubHasNone(t *testing.T) {
+	var mints int64
+	oldTransport := http.DefaultTransport
+	http.DefaultTransport = githubAppAnyTokenTransport{base: oldTransport, mints: &mints}
+	t.Cleanup(func() { http.DefaultTransport = oldTransport })
+
+	// Point hub config dir at a temp tree with one workspace app only.
+	tmp := t.TempDir()
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", tmp+"/hub.yaml")
+	wsDir := tmp + "/workspaces/adversaries/.elasticclaw-managed"
+	if err := os.MkdirAll(wsDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	// Minimal workspace marker so the dir is a real workspace.
+	if err := os.WriteFile(tmp+"/workspaces/adversaries/elasticclaw-config.yaml", []byte("schema_version: v1\nname: adversaries\n"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	pem := testGitHubAppPEM(t)
+	appsYAML := "github_apps:\n  AdversaryLabs:\n    app_id: 1\n    url: https://github.com/apps/factory-marecampbell-com\n    private_key_pem: |\n"
+	for _, line := range strings.Split(pem, "\n") {
+		appsYAML += "      " + line + "\n"
+	}
+	if err := os.WriteFile(wsDir+"/github_apps.yaml", []byte(appsYAML), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// No hub-global apps.
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{}, "", "", "")
+	if got := s.resolveGitHubToken(); got != "tok" {
+		t.Fatalf("unscoped token from workspace app = %q, want tok", got)
+	}
+	if got := s.resolveGitHubTokenForRepo("adversarylabs/engineering-review-adversary"); got != "tok" {
+		t.Fatalf("repo token from workspace app = %q, want tok", got)
+	}
+	if got := atomic.LoadInt64(&mints); got != 2 {
+		t.Fatalf("installation tokens minted=%d, want 2", got)
+	}
+	if !s.isOwnAppBot("factory-marecampbell-com[bot]") {
+		t.Fatal("expected workspace app bot login to be recognized as own app bot")
 	}
 }
 

--- a/pkg/hub/github_client_test.go
+++ b/pkg/hub/github_client_test.go
@@ -335,6 +335,41 @@ func TestResolveGitHubTokenUsesWorkspaceAppsWhenHubHasNone(t *testing.T) {
 	}
 }
 
+// Same AppID on workspace (bad PEM) and hub (good PEM) must not drop the hub
+// entry via AppID dedupe — resolution should fall through to the hub key.
+func TestResolveGitHubTokenFallsThroughBadWorkspaceKeySameAppID(t *testing.T) {
+	var mints int64
+	oldTransport := http.DefaultTransport
+	http.DefaultTransport = githubAppAnyTokenTransport{base: oldTransport, mints: &mints}
+	t.Cleanup(func() { http.DefaultTransport = oldTransport })
+
+	tmp := t.TempDir()
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", tmp+"/hub.yaml")
+	wsDir := tmp + "/workspaces/adversaries/.elasticclaw-managed"
+	if err := os.MkdirAll(wsDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(tmp+"/workspaces/adversaries/elasticclaw-config.yaml", []byte("schema_version: v1\nname: adversaries\n"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	// Non-empty but unusable PEM (provider setup fails); hub has a valid key for AppID 1.
+	badYAML := "github_apps:\n  Broken:\n    app_id: 1\n    private_key_pem: |\n      -----BEGIN RSA PRIVATE KEY-----\n      not-a-real-key\n      -----END RSA PRIVATE KEY-----\n"
+	if err := os.WriteFile(wsDir+"/github_apps.yaml", []byte(badYAML), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	goodPEM := testGitHubAppPEM(t)
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{
+		GitHubApps: []*types.GitHubAppConfig{{AppID: 1, PrivateKeyPEM: goodPEM}},
+	}, "", "", "")
+	if got := s.tokenForRepo("owner/repo"); got != "tok" {
+		t.Fatalf("tokenForRepo with bad workspace + good hub same AppID = %q, want tok", got)
+	}
+	if got := atomic.LoadInt64(&mints); got != 1 {
+		t.Fatalf("mints=%d, want 1 (hub key after workspace setup failure)", got)
+	}
+}
+
 func TestPRWatcherIntervalScalesWithTrackedPRs(t *testing.T) {
 	if got := prWatcherInterval(0); got != prWatcherBaseInterval {
 		t.Fatalf("interval(0)=%s, want %s", got, prWatcherBaseInterval)

--- a/pkg/hub/github_webhook.go
+++ b/pkg/hub/github_webhook.go
@@ -512,10 +512,9 @@ func (s *Server) processGitHubCheckEvent(event string, payload githubCheckPayloa
 			continue
 		}
 		for _, pr := range prs {
-			token := s.resolveGitHubTokenForRepo(pr.repo)
-			if token == "" {
-				token = s.resolveGitHubToken()
-			}
+			// Repo-scoped only — do not fall back to an unscoped token from a
+			// different workspace app (wrong-org 404s look like deleted PRs).
+			token := s.tokenForRepo(pr.repo)
 			if token == "" {
 				log.Printf("[github-webhook] CRITICAL: GitHub token resolution failed; cannot check CI for %s#%d", repo, number)
 				continue

--- a/pkg/hub/github_webhook.go
+++ b/pkg/hub/github_webhook.go
@@ -855,20 +855,19 @@ func githubRepoMatches(fullName string, repos []string) bool {
 
 // createClawForGitHubPR provisions a new claw for a GitHub PR event.
 // isOwnAppBot returns true if the given GitHub login is the bot account for one of
-// the hub's configured GitHub Apps. App bots have the login "<app-slug>[bot]".
-// The app slug is derived from the App URL field (e.g. "https://github.com/apps/my-app" → "my-app").
+// the configured GitHub Apps (hub-global or workspace-scoped). App bots have the
+// login "<app-slug>[bot]". The app slug is derived from the App URL field
+// (e.g. "https://github.com/apps/my-app" → "my-app").
 func (s *Server) isOwnAppBot(login string) bool {
 	if !strings.HasSuffix(login, "[bot]") {
 		return false
 	}
-	s.mu.RLock()
-	apps := s.hubCfg.GitHubApps
-	s.mu.RUnlock()
-	for _, app := range apps {
+	for _, app := range s.githubAppConfigsForTokens() {
 		if app.URL == "" {
 			continue
 		}
 		// Extract slug from URL: https://github.com/apps/<slug> or https://github.com/settings/apps/<slug>
+		// Also accept org settings URLs: .../organizations/.../settings/apps/<slug>
 		u := strings.TrimSuffix(app.URL, "/")
 		slug := u[strings.LastIndex(u, "/")+1:]
 		if strings.EqualFold(login, slug+"[bot]") {

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -755,19 +755,16 @@ func (s *Server) firePRConditions(pr clawPR, stage pipeline.Stage, ctx pipelineC
 // resolution matches agent credential helpers.
 //
 // Order: workspace apps first (primary for factory deploys), then hub apps.
-// Duplicate AppIDs are skipped after the first occurrence.
+// Same AppID may appear more than once (e.g. workspace key unusable, hub key
+// valid). resolveGitHubTokenWithRepos tries each entry in order and skips
+// setup/mint failures, so we must not drop later credentials by AppID.
 func (s *Server) githubAppConfigsForTokens() []*types.GitHubAppConfig {
 	var apps []*types.GitHubAppConfig
-	seen := map[int64]bool{}
 	add := func(list []*types.GitHubAppConfig) {
 		for _, app := range list {
 			if app == nil || app.AppID == 0 || app.PrivateKeyPEM == "" {
 				continue
 			}
-			if seen[app.AppID] {
-				continue
-			}
-			seen[app.AppID] = true
 			apps = append(apps, app)
 		}
 	}

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -871,19 +871,17 @@ func (s *Server) resolveGitHubTokenForRepo(repo string) string {
 	return s.resolveGitHubTokenWithRepos([]RepoAccess{{Repo: repo, Permissions: "read"}})
 }
 
-// tokenForRepo prefers a repo-scoped installation token so multi-org workspace
-// GitHub Apps are not collapsed onto the first unscoped installation. Falls
-// back to an unscoped mint only when scoped minting fails (legacy single-app).
+// tokenForRepo returns a repo-scoped installation token for owner/repo.
+// It does not fall back to an unscoped mint: the first configured app's
+// unscoped token can 404/403 for repos only another workspace app can see,
+// and repeated "permanent" 404s can wrongly terminate the claw.
 func (s *Server) tokenForRepo(repo string) string {
-	if tok := s.resolveGitHubTokenForRepo(repo); tok != "" {
-		return tok
-	}
-	return s.resolveGitHubToken()
+	return s.resolveGitHubTokenForRepo(repo)
 }
 
 // resolveGitHubToken returns an unscoped GitHub App installation token.
-// Prefer tokenForRepo / resolveGitHubTokenForRepo when a repository is known —
-// unscoped tokens from the first configured app may not reach other orgs.
+// Prefer tokenForRepo when a repository is known — unscoped tokens from the
+// first configured app may not reach other orgs.
 func (s *Server) resolveGitHubToken() string {
 	return s.resolveGitHubTokenWithRepos(nil)
 }

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -87,8 +87,9 @@ func (s *Server) storePRMention(clawID, repo string, prNumber int, prURL string)
 		s.trackPROpened(factory.Name, issueID, clawID, repo, prNumber)
 	}
 
-	// Get the current max comment ID and head SHA to avoid flooding with historical data
-	token := s.resolveGitHubToken()
+	// Get the current max comment ID and head SHA to avoid flooding with historical data.
+	// Prefer a repo-scoped installation token so multi-org workspace apps work.
+	token := s.tokenForRepo(repo)
 	var maxCommentID int64
 	var maxReviewID int64
 	var lastCommentAt string
@@ -199,7 +200,7 @@ func (s *Server) preparePRMention(clawID, repo string, prNumber int, prURL strin
 	}
 
 	row = prMentionCandidate{repo: repo, number: prNumber, url: prURL}
-	token := s.resolveGitHubToken()
+	token := s.tokenForRepo(repo)
 	if token == "" {
 		return false, row, nil
 	}
@@ -435,12 +436,8 @@ func (s *Server) reconcileDeadClawPRs() {
 	if len(prs) == 0 {
 		return
 	}
-	globalToken := s.resolveGitHubToken()
 	for _, p := range prs {
-		repoToken := s.resolveGitHubTokenForRepo(p.repo)
-		if repoToken == "" {
-			repoToken = globalToken
-		}
+		repoToken := s.tokenForRepo(p.repo)
 		if repoToken == "" {
 			log.Printf("[pr-reconciler] no token available for %s, skipping run %s", p.repo, p.runID)
 			continue
@@ -600,12 +597,14 @@ func (s *Server) pollAllPRs() {
 	lowPriorityOK := defaultGitHubClient.allowLowPriority()
 	s.logGitHubBudget(lowPriorityOK)
 
-	token := s.resolveGitHubToken()
-	if token == "" {
+	// Prefer per-repo installation tokens. An unscoped mint from the first app
+	// cannot be reused across orgs when multiple workspace GitHub Apps exist
+	// (Greptile P1): merge/CI checks for later apps would 404/403 silently.
+	if len(s.githubAppConfigsForTokens()) == 0 {
 		if len(prs) > 0 {
 			s.mu.Lock()
 			if time.Since(s.lastTokenFailureLog) >= time.Minute {
-				log.Printf("[pr-watcher] CRITICAL: GitHub token resolution failed; PR watcher is effectively disabled for %d tracked PR(s)", len(prs))
+				log.Printf("[pr-watcher] CRITICAL: no GitHub Apps configured (hub or workspace); PR watcher disabled for %d tracked PR(s)", len(prs))
 				s.lastTokenFailureLog = time.Now()
 			}
 			s.mu.Unlock()
@@ -618,10 +617,18 @@ func (s *Server) pollAllPRs() {
 	}
 
 	terminatedClaws := map[string]bool{}
+	tokenMisses := 0
 	for _, r := range prs {
 		log.Printf("[pr-watcher] poll: claw=%s status=%s pr=%s", r.pr.clawID[:8], r.clawStatus, r.pr.prURL)
 		// Skip PRs for claws that were already terminated in this poll
 		if terminatedClaws[r.pr.clawID] {
+			continue
+		}
+
+		token := s.tokenForRepo(r.pr.repo)
+		if token == "" {
+			tokenMisses++
+			log.Printf("[pr-watcher] no token for %s (claw %s); skipping this PR", r.pr.repo, shortID(r.pr.clawID))
 			continue
 		}
 
@@ -647,11 +654,7 @@ func (s *Server) pollAllPRs() {
 		// Always check CI status (failures and, just as importantly, green)
 		s.checkCIStatus(r.pr, token)
 
-		repoToken := s.resolveGitHubTokenForRepo(r.pr.repo)
-		if repoToken == "" {
-			repoToken = token
-		}
-		commentsData, err := githubAPIList(fmt.Sprintf("repos/%s/issues/%d/comments", r.pr.repo, r.pr.prNumber), repoToken)
+		commentsData, err := githubAPIList(fmt.Sprintf("repos/%s/issues/%d/comments", r.pr.repo, r.pr.prNumber), token)
 		if err != nil {
 			log.Printf("[pr-watcher] error fetching comments for %s: %v", r.pr.prURL, err)
 			continue
@@ -669,7 +672,7 @@ func (s *Server) pollAllPRs() {
 
 		// Greptile posts inline review comments via the pulls/{n}/comments API.
 		// Fetch and track them separately from issue comments.
-		reviewCommentsData, err := githubAPIList(fmt.Sprintf("repos/%s/pulls/%d/comments", r.pr.repo, r.pr.prNumber), repoToken)
+		reviewCommentsData, err := githubAPIList(fmt.Sprintf("repos/%s/pulls/%d/comments", r.pr.repo, r.pr.prNumber), token)
 		if err != nil {
 			log.Printf("[pr-watcher] error fetching review comments for %s: %v", r.pr.prURL, err)
 		} else {
@@ -677,7 +680,7 @@ func (s *Server) pollAllPRs() {
 			s.updateReviewCommentWatermark(r.pr, reviewCommentsData)
 		}
 
-		reviewsData, err := githubAPIList(fmt.Sprintf("repos/%s/pulls/%d/reviews", r.pr.repo, r.pr.prNumber), repoToken)
+		reviewsData, err := githubAPIList(fmt.Sprintf("repos/%s/pulls/%d/reviews", r.pr.repo, r.pr.prNumber), token)
 		if err != nil {
 			log.Printf("[pr-watcher] error fetching reviews for %s: %v", r.pr.prURL, err)
 		} else {
@@ -702,6 +705,14 @@ func (s *Server) pollAllPRs() {
 				}
 			}
 		}
+	}
+	if tokenMisses > 0 && tokenMisses == len(prs) {
+		s.mu.Lock()
+		if time.Since(s.lastTokenFailureLog) >= time.Minute {
+			log.Printf("[pr-watcher] CRITICAL: GitHub token resolution failed for all %d tracked PR(s)", len(prs))
+			s.lastTokenFailureLog = time.Now()
+		}
+		s.mu.Unlock()
 	}
 }
 
@@ -850,11 +861,29 @@ func githubTokenCacheKey(repoAccess []RepoAccess) string {
 
 // resolveGitHubTokenForRepo returns a GitHub App installation token scoped to the given repo.
 // Use this for private repos — an unscoped token won't have read access.
+// When multiple workspace apps cover different orgs, this tries each app until
+// one can mint for owner/repo (cached per repo).
 func (s *Server) resolveGitHubTokenForRepo(repo string) string {
+	repo = strings.TrimSpace(repo)
+	if repo == "" {
+		return ""
+	}
 	return s.resolveGitHubTokenWithRepos([]RepoAccess{{Repo: repo, Permissions: "read"}})
 }
 
-// resolveGitHubToken returns a GitHub App installation token for PR polling.
+// tokenForRepo prefers a repo-scoped installation token so multi-org workspace
+// GitHub Apps are not collapsed onto the first unscoped installation. Falls
+// back to an unscoped mint only when scoped minting fails (legacy single-app).
+func (s *Server) tokenForRepo(repo string) string {
+	if tok := s.resolveGitHubTokenForRepo(repo); tok != "" {
+		return tok
+	}
+	return s.resolveGitHubToken()
+}
+
+// resolveGitHubToken returns an unscoped GitHub App installation token.
+// Prefer tokenForRepo / resolveGitHubTokenForRepo when a repository is known —
+// unscoped tokens from the first configured app may not reach other orgs.
 func (s *Server) resolveGitHubToken() string {
 	return s.resolveGitHubTokenWithRepos(nil)
 }

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"regexp"
 	"sort"
 	"strconv"
@@ -737,13 +738,58 @@ func (s *Server) firePRConditions(pr clawPR, stage pipeline.Stage, ctx pipelineC
 	}
 }
 
+// githubAppConfigsForTokens returns GitHub Apps for hub-side API minting
+// (PR watcher, reconciler, issue poller). Factories often configure apps only
+// on the workspace (no hub-global github_apps); include those so token
+// resolution matches agent credential helpers.
+//
+// Order: workspace apps first (primary for factory deploys), then hub apps.
+// Duplicate AppIDs are skipped after the first occurrence.
+func (s *Server) githubAppConfigsForTokens() []*types.GitHubAppConfig {
+	var apps []*types.GitHubAppConfig
+	seen := map[int64]bool{}
+	add := func(list []*types.GitHubAppConfig) {
+		for _, app := range list {
+			if app == nil || app.AppID == 0 || app.PrivateKeyPEM == "" {
+				continue
+			}
+			if seen[app.AppID] {
+				continue
+			}
+			seen[app.AppID] = true
+			apps = append(apps, app)
+		}
+	}
+	// Workspace-scoped apps (adversaries, etc.)
+	if entries, err := os.ReadDir(workspacesDir()); err == nil {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			if e.IsDir() && !strings.HasPrefix(e.Name(), ".") {
+				names = append(names, e.Name())
+			}
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			wsApps, err := loadWorkspaceGitHubAppConfigs(name)
+			if err != nil {
+				log.Printf("[github] load workspace %q github apps: %v", name, err)
+				continue
+			}
+			add(wsApps)
+		}
+	}
+	s.mu.RLock()
+	hubApps := append([]*types.GitHubAppConfig(nil), s.hubCfg.GitHubApps...)
+	s.mu.RUnlock()
+	add(hubApps)
+	return apps
+}
+
 // resolveGitHubTokenWithRepos is a shared helper that resolves a GitHub App installation token
 // with optional repo-scoped access.
 func (s *Server) resolveGitHubTokenWithRepos(repoAccess []RepoAccess) string {
-	s.mu.RLock()
-	cfg := s.hubCfg
-	s.mu.RUnlock()
-	if len(cfg.GitHubApps) == 0 {
+	appCfgs := s.githubAppConfigsForTokens()
+	if len(appCfgs) == 0 {
 		return ""
 	}
 	// Installation tokens live an hour. Minting one per call cost two extra
@@ -755,15 +801,18 @@ func (s *Server) resolveGitHubTokenWithRepos(repoAccess []RepoAccess) string {
 	if cached, ok := s.ghTokenCache[cacheKey]; ok && time.Now().Before(cached.expiresAt) {
 		return cached.token
 	}
-	for _, appCfg := range cfg.GitHubApps {
+	var lastErr error
+	for _, appCfg := range appCfgs {
 		provider, err := NewGitHubTokenProvider(appCfg)
 		if err != nil {
-			log.Printf("[pr-watcher] CRITICAL: GitHub token provider setup failed: %v", err)
+			log.Printf("[pr-watcher] CRITICAL: GitHub token provider setup failed (app_id=%d): %v", appCfg.AppID, err)
+			lastErr = err
 			continue
 		}
 		token, expiresAt, err := provider.InstallationToken(context.Background(), 0, repoAccess)
 		if err != nil {
-			log.Printf("[pr-watcher] CRITICAL: GitHub token provider failed: %v", err)
+			log.Printf("[pr-watcher] GitHub token provider failed (app_id=%d): %v", appCfg.AppID, err)
+			lastErr = err
 			continue
 		}
 		if s.ghTokenCache == nil {
@@ -774,6 +823,9 @@ func (s *Server) resolveGitHubTokenWithRepos(repoAccess []RepoAccess) string {
 			s.ghTokenCache[cacheKey] = cachedGitHubToken{token: token, expiresAt: expiry}
 		}
 		return token
+	}
+	if lastErr != nil {
+		log.Printf("[pr-watcher] CRITICAL: GitHub token resolution failed after trying %d app(s): %v", len(appCfgs), lastErr)
 	}
 	return ""
 }

--- a/pkg/hub/pr_watcher_token_test.go
+++ b/pkg/hub/pr_watcher_token_test.go
@@ -3,6 +3,8 @@ package hub
 import (
 	"bytes"
 	"log"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -10,6 +12,11 @@ import (
 )
 
 func TestPollAllPRsLogsWhenTokenResolutionFails(t *testing.T) {
+	// Isolate from any developer workspace GitHub Apps under ~/.elasticclaw.
+	tmp := t.TempDir()
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", filepath.Join(tmp, "hub.yaml"))
+	_ = os.MkdirAll(filepath.Join(tmp, "workspaces"), 0o750)
+
 	s, db := NewTestServerWithConfig(t, &types.HubConfig{}, "", "", "")
 	insertWatcherTestPR(t, db, "claw-token", "pr-token")
 	var buf bytes.Buffer
@@ -17,7 +24,10 @@ func TestPollAllPRsLogsWhenTokenResolutionFails(t *testing.T) {
 	log.SetOutput(&buf)
 	defer log.SetOutput(previous)
 	s.pollAllPRs()
-	if !strings.Contains(buf.String(), "CRITICAL: GitHub token resolution failed") {
-		t.Fatalf("missing critical log: %s", buf.String())
+	// Empty hub + empty workspaces: pollAllPRs logs that no apps are configured
+	// (not the per-PR "token resolution failed for all" path).
+	got := buf.String()
+	if !strings.Contains(got, "CRITICAL:") || !strings.Contains(got, "no GitHub Apps configured") {
+		t.Fatalf("missing critical no-apps log: %s", got)
 	}
 }

--- a/pkg/provider/exedev/exedev.go
+++ b/pkg/provider/exedev/exedev.go
@@ -189,14 +189,28 @@ func (p *Provider) Status(ctx context.Context, instanceID string) (types.Instanc
 }
 
 // Exec runs a command inside the VM via SSH.
+//
+// The remote command is always a single shell-quoted string. OpenSSH (and
+// exe.dev's remote command repl) concatenate multi-arg remote commands with
+// spaces and without re-quoting, so:
+//
+//	ssh host bash -lc 'cd "$HOME/..." && script.sh'
+//
+// becomes a broken remote line where bash -lc only sees the first word. That
+// made workflow gates (verify-github-pr-links, depot CI) exit 0 with empty
+// stdout. Quote-join every argv so the remote shell receives one intact command.
 func (p *Provider) Exec(ctx context.Context, instanceID string, cmdArgs []string) (*types.ExecResult, error) {
 	host := p.vmHost(instanceID)
 	if host == "" {
 		return nil, fmt.Errorf("exedev exec: cannot determine host for %s", instanceID)
 	}
+	if len(cmdArgs) == 0 {
+		return nil, fmt.Errorf("exedev exec: empty command")
+	}
 
 	args := p.sshVMArgs(host)
-	args = append(args, cmdArgs...)
+	// One remote argv only — see comment above.
+	args = append(args, shellQuote(cmdArgs))
 	cmd := exec.CommandContext(ctx, "ssh", args...)
 	var stdoutBuf, stderrBuf bytes.Buffer
 	cmd.Stdout = &stdoutBuf

--- a/pkg/provider/exedev/exedev_test.go
+++ b/pkg/provider/exedev/exedev_test.go
@@ -2,8 +2,41 @@ package exedev
 
 import (
 	"path"
+	"strings"
 	"testing"
 )
+
+func TestShellQuoteJoinsArgsAsSingleRemoteCommand(t *testing.T) {
+	t.Parallel()
+	// Matches how pipeline_runner invokes Exec for workflow run actions.
+	workspaceCmd := `~/.elasticclaw/flake-run bash -lc 'cd "$HOME/.openclaw/workspace" && bash scripts/verify-github-pr-links.sh'`
+	got := shellQuote([]string{"bash", "-lc", workspaceCmd})
+	// Must be one shell word-stream that re-expands to bash -lc <full script>.
+	if !strings.HasPrefix(got, "'bash' '-lc' '") {
+		t.Fatalf("shellQuote prefix = %q, want 'bash' '-lc' '…'", got)
+	}
+	if !strings.Contains(got, "verify-github-pr-links.sh") {
+		t.Fatalf("shellQuote missing script path: %q", got)
+	}
+	// Inner single quotes must be escaped so the remote shell keeps the full -lc payload.
+	if strings.Count(got, "bash") < 2 {
+		t.Fatalf("shellQuote should embed nested bash -lc: %q", got)
+	}
+	// Regression: multi-arg ssh used to drop everything after the first word of
+	// the -lc payload; a single remote argv is what Exec must pass to ssh.
+	if strings.Contains(got, "\x00") {
+		t.Fatal("shellQuote must not embed NULs")
+	}
+}
+
+func TestShellQuoteEscapesEmbeddedSingleQuotes(t *testing.T) {
+	t.Parallel()
+	got := shellQuote([]string{"echo", "it's"})
+	want := `'echo' 'it'"'"'s'`
+	if got != want {
+		t.Fatalf("shellQuote = %q, want %q", got, want)
+	}
+}
 
 func TestExpandRemotePathLocalRules(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

Factory concurrent agents were stuck on `pr_opened` with:

```text
gate: no conditions matched, verdict=error
Result: <no value>
```

while `pipeline_outputs.pr_links` stored `exit=0`, empty stdout/stderr, `parsed_json={}`.

### 1. exedev `Exec` remote command packaging

Hub invoked:

```text
ssh host bash -lc '~/.elasticclaw/flake-run bash -lc '\''cd … && script.sh'\'''
```

as **multiple** SSH remote argv. OpenSSH / exe.dev’s remote command repl
re-tokenizes without re-quoting, so `bash -lc` only received the first word
(`~/.elasticclaw/flake-run`) with no args → empty success.

**Fix:** always pass a **single** shell-quoted remote command string from
`exedev.Exec` (reuse existing `shellQuote`).

Reproduced on factory: multi-arg empty vs single-arg full JSON from
`verify-github-pr-links.sh`.

### 2. Workspace GitHub Apps for hub-side tokens

Factory has **no** hub-global `github_apps` (only
`workspaces/adversaries/.elasticclaw-managed/github_apps.yaml`). PR watcher
and reconciler only read `hubCfg.GitHubApps` →

```text
CRITICAL: GitHub token resolution failed
pr-reconciler: no token available for adversarylabs/…
```

Agent mint already merged workspace apps; hub watch paths did not.

**Fix:** `githubAppConfigsForTokens()` loads workspace apps first, then hub
apps (dedupe by AppID). Used by `resolveGitHubToken*` and `isOwnAppBot`.

`torvalds-adversary` 404 noise was a side effect of resolving against the
wrong/empty app set — not removed from the workflow.

## Test plan

- [x] `go test ./pkg/provider/exedev/ ./pkg/hub/`
- [x] `TestShellQuoteJoinsArgsAsSingleRemoteCommand`
- [x] `TestResolveGitHubTokenUsesWorkspaceAppsWhenHubHasNone`
- [ ] Deploy hub to factory-marcecampbell
- [ ] Re-run / re-`[DONE]` an adversaries claw; confirm `pipeline_outputs.pr_links` has non-empty stdout and gate `pass`/`fail` (not empty `error`)
- [ ] Confirm PR watcher no longer logs token resolution failed for adversarylabs repos
- [ ] Concurrent trains on same repo should no longer thrash solely due to false gate errors