### PR TITLE
fix(cli): show remote CalVer on hub upgrade

### DIFF
--- a/cmd/hub_upgrade.go
+++ b/cmd/hub_upgrade.go
@@ -76,9 +76,14 @@ func runHubUpgrade(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Check current version on server
+	// Check current version on server. Prefer PATH then the install default;
+	// sudo when needed (matches the post-upgrade version probe).
 	fmt.Println("Checking remote version...")
-	remoteVerOut, err := sshRunClient(client, "elasticclaw version 2>/dev/null || echo 'unknown'")
+	remoteVersionCmd := `elasticclaw version 2>/dev/null || /usr/local/bin/elasticclaw version 2>/dev/null || true`
+	if useSudo {
+		remoteVersionCmd = `sudo elasticclaw version 2>/dev/null || sudo /usr/local/bin/elasticclaw version 2>/dev/null || elasticclaw version 2>/dev/null || /usr/local/bin/elasticclaw version 2>/dev/null || true`
+	}
+	remoteVerOut, err := sshRunClient(client, remoteVersionCmd)
 	if err != nil {
 		return fmt.Errorf("failed to check remote version: %w", err)
 	}
@@ -184,15 +189,32 @@ func inferSSHFromProfile(profileName string) (string, string) {
 	return fmt.Sprintf("ssh://root@%s", host), hubProfile.SSHKey
 }
 
-// parseVersionFromOutput extracts the version tag from "elasticclaw vX.Y.Z ..." output.
+// parseVersionFromOutput extracts the version tag from elasticclaw version output.
+// Accepts CalVer with or without a leading "v", e.g.:
+//
+//	elasticclaw 2026.8.8-beta.2 (commit: abc, built: ...)
+//	elasticclaw v0.1.0 (commit: abc, built: ...)
 func parseVersionFromOutput(s string) string {
-	// Handle "Using config file: ..." prefix lines
 	for _, line := range strings.Split(s, "\n") {
 		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "elasticclaw v") {
+		if line == "" || strings.HasPrefix(line, "Using config file:") {
+			continue
+		}
+		// Plain: "elasticclaw <version> ..."
+		if strings.HasPrefix(line, "elasticclaw ") {
 			fields := strings.Fields(line)
 			if len(fields) >= 2 {
-				return fields[1]
+				return strings.TrimPrefix(fields[1], "v")
+			}
+		}
+		// JSON: {"version":"...","commit":"...","buildDate":"..."}
+		if strings.HasPrefix(line, "{") && strings.Contains(line, `"version"`) {
+			const key = `"version":"`
+			if i := strings.Index(line, key); i >= 0 {
+				rest := line[i+len(key):]
+				if j := strings.IndexByte(rest, '"'); j > 0 {
+					return strings.TrimPrefix(rest[:j], "v")
+				}
 			}
 		}
 	}

--- a/cmd/hub_upgrade.go
+++ b/cmd/hub_upgrade.go
@@ -110,7 +110,10 @@ func runHubUpgrade(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("Remote: %s  →  Target: %s\n", remoteVer, targetVer)
 
-	if remoteVer == targetVer {
+	// Compare normalized tags so remote "0.1.0" matches GitHub target "v0.1.0"
+	// (and CalVer with/without accidental v). Download still uses targetVer as
+	// the exact release tag on GitHub.
+	if sameReleaseVersion(remoteVer, targetVer) {
 		fmt.Println("Already up to date.")
 		return nil
 	}
@@ -189,11 +192,34 @@ func inferSSHFromProfile(profileName string) (string, string) {
 	return fmt.Sprintf("ssh://root@%s", host), hubProfile.SSHKey
 }
 
+// normalizeReleaseVersion strips a single leading "v" so GitHub tags like
+// v0.1.0 and binary output like "0.1.0" compare equal.
+func normalizeReleaseVersion(v string) string {
+	v = strings.TrimSpace(v)
+	if v == "" || v == "unknown" {
+		return v
+	}
+	return strings.TrimPrefix(v, "v")
+}
+
+// sameReleaseVersion reports whether two version strings refer to the same
+// release tag, ignoring an optional leading "v".
+func sameReleaseVersion(a, b string) bool {
+	na, nb := normalizeReleaseVersion(a), normalizeReleaseVersion(b)
+	if na == "" || nb == "" || na == "unknown" || nb == "unknown" {
+		return false
+	}
+	return na == nb
+}
+
 // parseVersionFromOutput extracts the version tag from elasticclaw version output.
 // Accepts CalVer with or without a leading "v", e.g.:
 //
 //	elasticclaw 2026.8.8-beta.2 (commit: abc, built: ...)
 //	elasticclaw v0.1.0 (commit: abc, built: ...)
+//
+// The returned value is normalized (no leading "v") for display; comparisons
+// with GitHub tags should use sameReleaseVersion so "v0.1.0" still matches.
 func parseVersionFromOutput(s string) string {
 	for _, line := range strings.Split(s, "\n") {
 		line = strings.TrimSpace(line)
@@ -204,7 +230,7 @@ func parseVersionFromOutput(s string) string {
 		if strings.HasPrefix(line, "elasticclaw ") {
 			fields := strings.Fields(line)
 			if len(fields) >= 2 {
-				return strings.TrimPrefix(fields[1], "v")
+				return normalizeReleaseVersion(fields[1])
 			}
 		}
 		// JSON: {"version":"...","commit":"...","buildDate":"..."}
@@ -213,7 +239,7 @@ func parseVersionFromOutput(s string) string {
 			if i := strings.Index(line, key); i >= 0 {
 				rest := line[i+len(key):]
 				if j := strings.IndexByte(rest, '"'); j > 0 {
-					return strings.TrimPrefix(rest[:j], "v")
+					return normalizeReleaseVersion(rest[:j])
 				}
 			}
 		}

--- a/cmd/hub_upgrade_test.go
+++ b/cmd/hub_upgrade_test.go
@@ -54,3 +54,29 @@ func TestParseVersionFromOutput(t *testing.T) {
 		})
 	}
 }
+
+func TestSameReleaseVersion(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		a, b string
+		want bool
+	}{
+		{"0.1.0", "v0.1.0", true},
+		{"v0.1.0", "v0.1.0", true},
+		{"2026.8.8-beta.2", "2026.8.8-beta.2", true},
+		{"v2026.8.8-beta.2", "2026.8.8-beta.2", true},
+		{"0.1.0", "0.1.1", false},
+		{"unknown", "v0.1.0", false},
+		{"", "v0.1.0", false},
+		{"0.1.0", "unknown", false},
+	}
+	for _, tc := range cases {
+		name := tc.a + " vs " + tc.b
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if got := sameReleaseVersion(tc.a, tc.b); got != tc.want {
+				t.Fatalf("sameReleaseVersion(%q, %q) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/hub_upgrade_test.go
+++ b/cmd/hub_upgrade_test.go
@@ -1,0 +1,56 @@
+package cmd
+
+import "testing"
+
+func TestParseVersionFromOutput(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "calver beta",
+			in:   "elasticclaw 2026.8.8-beta.2 (commit: 4125c5f, built: 2026-08-08T12:35:51Z)",
+			want: "2026.8.8-beta.2",
+		},
+		{
+			name: "calver stable",
+			in:   "elasticclaw 2026.8.4 (commit: abc1234, built: 2026-08-04T00:00:00Z)",
+			want: "2026.8.4",
+		},
+		{
+			name: "legacy v-prefix",
+			in:   "elasticclaw v0.1.0 (commit: abc, built: unknown)",
+			want: "0.1.0",
+		},
+		{
+			name: "config file noise on stderr-style lines",
+			in:   "Using config file: /root/.elasticclaw/config.yaml\nelasticclaw 2026.8.8-beta.2 (commit: x, built: y)\n",
+			want: "2026.8.8-beta.2",
+		},
+		{
+			name: "json",
+			in:   `{"version":"2026.8.8-beta.2","commit":"4125c5f","buildDate":"2026-08-08T12:35:51Z"}`,
+			want: "2026.8.8-beta.2",
+		},
+		{
+			name: "empty",
+			in:   "",
+			want: "unknown",
+		},
+		{
+			name: "unrelated",
+			in:   "command not found",
+			want: "unknown",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := parseVersionFromOutput(tc.in); got != tc.want {
+				t.Fatalf("parseVersionFromOutput(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`elasticclaw hub upgrade` printed:

```text
Remote: unknown  →  Target: 2026.8.8-beta.2
```

even when the remote hub was running a real build.

**Cause:** `parseVersionFromOutput` required a leading `v` (`elasticclaw v…`), but `elasticclaw version` prints CalVer without it:

```text
elasticclaw 2026.8.8-beta.2 (commit: …, built: …)
```

**Fix:** Parse CalVer and legacy `v`-prefixed lines (and JSON). Also probe `/usr/local/bin/elasticclaw` and `sudo` when checking the remote version.

## Test plan

- [x] `go test ./cmd/ -run TestParseVersionFromOutput`
- [ ] `elasticclaw-beta hub upgrade --profile …` shows the real remote version before upgrade