### PR TITLE
feat: add durable workflow v2 runtime

### DIFF
--- a/cmd/workflow.go
+++ b/cmd/workflow.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	workflowv2 "github.com/elasticclaw/elasticclaw/pkg/hub/workflowv2"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 	v2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
 	"github.com/spf13/cobra"
@@ -28,9 +29,73 @@ func WorkflowCmd() *cobra.Command {
 	cmd.AddCommand(workflowPushCmd())
 	cmd.AddCommand(workflowTriggerCmd())
 	cmd.AddCommand(workflowRunsCmd())
+	cmd.AddCommand(workflowInspectCmd())
 	cmd.AddCommand(workflowLogsCmd())
 	cmd.AddCommand(workflowConvertCmd())
 	return cmd
+}
+
+func workflowInspectCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "inspect <run-id>",
+		Short: "Explain the durable state of a workflow v2 run",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runWorkflowInspect(args[0])
+		},
+	}
+}
+
+func runWorkflowInspect(runID string) error {
+	hubURL, clawToken, err := resolveHubConn()
+	if err != nil {
+		return err
+	}
+	path := "/api/v2/workflow-runs/" + url.PathEscape(runID)
+	req, _ := http.NewRequest(http.MethodGet, hubURL+path, nil)
+	req.Header.Set("Authorization", "Bearer "+clawToken)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("inspect workflow run failed: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("workflow v2 run %s not found", runID)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("hub returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var inspection workflowv2.Inspection
+	if err := json.Unmarshal(body, &inspection); err != nil {
+		return fmt.Errorf("decode workflow run: %w", err)
+	}
+	if jsonOut {
+		return json.NewEncoder(os.Stdout).Encode(inspection)
+	}
+	printWorkflowInspection(inspection)
+	return nil
+}
+
+func printWorkflowInspection(inspection workflowv2.Inspection) {
+	run := inspection.Run
+	fmt.Printf("Run: %s\nWorkflow: %s/%s\nState: %s (phase %s, version %d)\nStatus: %s\n",
+		run.ID, run.WorkspaceName, run.WorkflowName, run.State, run.DisplayPhase, run.StateVersion, run.Status)
+	if len(inspection.Waiting) > 0 {
+		fmt.Println("Waiting:")
+		for _, reason := range inspection.Waiting {
+			fmt.Printf("  - %s: %s\n", reason.Kind, reason.Detail)
+		}
+	}
+	if len(inspection.ExpectedTransitions) > 0 {
+		fmt.Println("Expected transitions:")
+		for _, transition := range inspection.ExpectedTransitions {
+			fmt.Printf("  - %s --[%s]--> %s\n", run.State, transition.EventKind, transition.ToState)
+		}
+	}
+	fmt.Printf("Delivery: %d active PR(s), %d open, %d merged, %d closed\n",
+		inspection.Delivery.ActivePullRequests, inspection.Delivery.OpenPullRequests,
+		inspection.Delivery.MergedPullRequests, inspection.Delivery.ClosedPullRequests)
 }
 
 type workflowCLIView struct {

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	workflowv2 "github.com/elasticclaw/elasticclaw/pkg/hub/workflowv2"
+
 	_ "modernc.org/sqlite" // pure-Go SQLite, no CGO required
 )
 
@@ -751,6 +753,9 @@ func migrate(db *sql.DB) error {
 	);
 	`)
 	if err != nil {
+		return err
+	}
+	if err := workflowv2.Migrate(db); err != nil {
 		return err
 	}
 	if err := rebuildTaskRunSummariesStatusV3(db); err != nil {

--- a/pkg/hub/db_test.go
+++ b/pkg/hub/db_test.go
@@ -24,6 +24,42 @@ func TestOpenDBSetsBusyTimeout(t *testing.T) {
 	}
 }
 
+func TestWorkflowV2MigrationIsAdditiveToExistingHubData(t *testing.T) {
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "hub.db")+"?_time_format=sqlite&_pragma=foreign_keys(on)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if _, err := db.Exec(`CREATE TABLE tenants (
+		id TEXT PRIMARY KEY, name TEXT NOT NULL, token TEXT NOT NULL UNIQUE,
+		claw_token TEXT NOT NULL UNIQUE, created_at DATETIME NOT NULL
+	)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO tenants(id,name,token,claw_token,created_at) VALUES(?,?,?,?,?)`,
+		"legacy-tenant", "Legacy", "legacy-token", "legacy-claw-token", time.Now()); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := migrate(db); err != nil {
+		t.Fatalf("migrate legacy database: %v", err)
+	}
+	var name string
+	if err := db.QueryRow(`SELECT name FROM tenants WHERE id='legacy-tenant'`).Scan(&name); err != nil {
+		t.Fatalf("legacy row was not preserved: %v", err)
+	}
+	if name != "Legacy" {
+		t.Fatalf("legacy tenant name = %q", name)
+	}
+	var v2Tables int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name LIKE 'workflow_v2_%'`).Scan(&v2Tables); err != nil {
+		t.Fatal(err)
+	}
+	if v2Tables == 0 {
+		t.Fatal("workflow v2 tables were not added")
+	}
+}
+
 func TestClawsTriggerActorJSONDefaultIsValidJSON(t *testing.T) {
 	t.Run("fresh schema", func(t *testing.T) {
 		db, err := openDB(filepath.Join(t.TempDir(), "hub.db"))

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -568,6 +568,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/analytics/runs", s.withAuth(s.handleTaskRunAnalyticsRuns))
 	mux.HandleFunc("/api/analytics/runs/", s.withAuth(s.handleTaskRunAnalyticsRuns))
 	mux.HandleFunc("/api/dependencies/status", s.withAuth(s.handleDependencyStatus))
+	mux.HandleFunc("/api/v2/workflow-runs/{runId}", s.withAuth(s.handleWorkflowV2Run))
 	mux.HandleFunc("/api/workspaces", s.withAdminForMethods(s.handleWorkspacesCRUD, http.MethodPost, http.MethodDelete)) // workspace CRUD
 	mux.HandleFunc("/api/workspaces/{name}/workflows", s.withAdminForMethods(s.handleWorkspaceWorkflowsList, http.MethodPost))
 	mux.HandleFunc("/api/workspaces/{workspace}/workflows/{workflow}", s.withAdminForMethods(s.handleWorkspaceWorkflowDetail, http.MethodPatch))

--- a/pkg/hub/workflow_v2_api.go
+++ b/pkg/hub/workflow_v2_api.go
@@ -1,0 +1,48 @@
+package hub
+
+import (
+	"database/sql"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/elasticclaw/elasticclaw/pkg/hub/workflowv2"
+)
+
+// handleWorkflowV2Run exposes the durable state-machine record used for
+// operator inspection. It never reads conversation messages or transcripts.
+func (s *Server) handleWorkflowV2Run(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		jsonError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	runID := strings.TrimSpace(r.PathValue("runId"))
+	if runID == "" {
+		jsonError(w, http.StatusBadRequest, "run id is required")
+		return
+	}
+
+	var exists int
+	err := s.db.QueryRowContext(r.Context(),
+		`SELECT 1 FROM workflow_v2_runs WHERE id=? AND tenant_id=?`, runID, tenantFromCtx(r)).Scan(&exists)
+	if errors.Is(err, sql.ErrNoRows) {
+		jsonError(w, http.StatusNotFound, "workflow run not found")
+		return
+	}
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "inspect workflow run")
+		return
+	}
+
+	inspection, err := workflowv2.NewStore(s.db).InspectRun(r.Context(), runID)
+	if errors.Is(err, sql.ErrNoRows) {
+		jsonError(w, http.StatusNotFound, "workflow run not found")
+		return
+	}
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "inspect workflow run")
+		return
+	}
+	jsonOK(w, inspection)
+}

--- a/pkg/hub/workflow_v2_api_test.go
+++ b/pkg/hub/workflow_v2_api_test.go
@@ -1,0 +1,95 @@
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/elasticclaw/elasticclaw/pkg/hub/workflowv2"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func TestWorkflowV2RunInspectionAPIIsTenantScoped(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+	store := workflowv2.NewStore(db)
+	_, err := store.CreateRun(context.Background(), workflowv2.CreateRunRequest{
+		ID:            "run-inspect-api",
+		TenantID:      "test-tenant-id",
+		WorkspaceYAML: []byte(workflowV2APIWorkspace),
+		WorkflowYAML:  []byte(workflowV2APIWorkflow),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/workflow-runs/run-inspect-api", nil)
+	req.Header.Set("Authorization", "Bearer test-token")
+	rr := httptest.NewRecorder()
+	s.mux.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	var inspection workflowv2.Inspection
+	if err := json.NewDecoder(rr.Body).Decode(&inspection); err != nil {
+		t.Fatal(err)
+	}
+	if inspection.Run.ID != "run-inspect-api" || len(inspection.Waiting) != 1 || inspection.Waiting[0].Kind != "effect" {
+		t.Fatalf("inspection = %#v", inspection)
+	}
+
+	if _, err := db.Exec(`INSERT INTO tenants(id,name,token,claw_token,created_at) VALUES(?,?,?,?,datetime('now'))`,
+		"other-tenant", "other", "other-token", "other-claw-token"); err != nil {
+		t.Fatal(err)
+	}
+	req = httptest.NewRequest(http.MethodGet, "/api/v2/workflow-runs/run-inspect-api", nil)
+	req.Header.Set("Authorization", "Bearer other-token")
+	rr = httptest.NewRecorder()
+	s.mux.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("cross-tenant status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestWorkflowV2RunInspectionAPIRejectsOtherMethods(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/workflow-runs/run-id", nil)
+	req.Header.Set("Authorization", "Bearer test-token")
+	rr := httptest.NewRecorder()
+	s.mux.ServeHTTP(rr, req)
+	if rr.Code != http.StatusMethodNotAllowed || rr.Header().Get("Allow") != http.MethodGet {
+		t.Fatalf("status/allow = %d/%q", rr.Code, rr.Header().Get("Allow"))
+	}
+}
+
+const workflowV2APIWorkspace = `
+schema_version: 2
+name: engineering
+repositories:
+  primary:
+    provider: github
+    repository: org/repo
+`
+
+const workflowV2APIWorkflow = `
+schema_version: 2
+name: delivery
+enabled: true
+initial_state: planning
+states:
+  planning:
+    phase: plan
+    on_enter:
+      effects:
+        - agent.task:
+            prompt: Make a plan.
+  done:
+    phase: done
+    terminal: true
+transitions:
+  planned:
+    from: planning
+    on: agent.task.completed
+    to: done
+`

--- a/pkg/hub/workflowv2/effects.go
+++ b/pkg/hub/workflowv2/effects.go
@@ -1,0 +1,260 @@
+package workflowv2
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type EffectStatus string
+
+const (
+	EffectPlanned         EffectStatus = "planned"
+	EffectRunning         EffectStatus = "running"
+	EffectSucceeded       EffectStatus = "succeeded"
+	EffectRetryableFailed EffectStatus = "retryable_failed"
+	EffectPermanentFailed EffectStatus = "permanent_failed"
+	EffectUnknown         EffectStatus = "unknown"
+	EffectCancelled       EffectStatus = "cancelled"
+)
+
+type Effect struct {
+	ID             string                 `json:"id"`
+	RunID          string                 `json:"run_id"`
+	EffectKey      string                 `json:"effect_key"`
+	Kind           string                 `json:"kind"`
+	Payload        map[string]interface{} `json:"payload"`
+	Status         EffectStatus           `json:"status"`
+	AttemptCount   int                    `json:"attempt_count"`
+	LeaseOwner     string                 `json:"lease_owner,omitempty"`
+	LeaseExpiresAt time.Time              `json:"lease_expires_at,omitempty"`
+	NextAttemptAt  time.Time              `json:"next_attempt_at,omitempty"`
+	LastError      string                 `json:"last_error,omitempty"`
+}
+
+type EffectClaim struct {
+	Effect    Effect `json:"effect"`
+	AttemptID string `json:"attempt_id"`
+}
+
+// ClaimEffect leases one ready effect. Expired running effects are first moved
+// to unknown and are deliberately not retried: a reconciler must determine
+// whether the external side effect happened before it is safe to continue.
+func (s *Store) ClaimEffect(ctx context.Context, worker string, lease time.Duration) (*EffectClaim, error) {
+	if s == nil || s.db == nil {
+		return nil, fmt.Errorf("workflow v2 store is not configured")
+	}
+	worker = strings.TrimSpace(worker)
+	if worker == "" {
+		return nil, fmt.Errorf("worker is required")
+	}
+	if lease <= 0 {
+		return nil, fmt.Errorf("lease duration must be positive")
+	}
+	now := s.now().UTC()
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	if err := expireEffectLeases(ctx, tx, now); err != nil {
+		return nil, err
+	}
+	row := tx.QueryRowContext(ctx, `SELECT id,run_id,effect_key,kind,payload_json,status,attempt_count,next_attempt_at,last_error
+		FROM workflow_v2_effects
+		WHERE status IN ('planned','retryable_failed') AND next_attempt_at<=?
+		ORDER BY next_attempt_at,created_at,id LIMIT 1`, now.UnixMilli())
+	var effect Effect
+	var payloadJSON string
+	var status string
+	var nextAttempt int64
+	if err := row.Scan(&effect.ID, &effect.RunID, &effect.EffectKey, &effect.Kind, &payloadJSON,
+		&status, &effect.AttemptCount, &nextAttempt, &effect.LastError); errors.Is(err, sql.ErrNoRows) {
+		if err := tx.Commit(); err != nil {
+			return nil, err
+		}
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal([]byte(payloadJSON), &effect.Payload); err != nil {
+		return nil, fmt.Errorf("decode effect %s payload: %w", effect.ID, err)
+	}
+
+	expires := now.Add(lease)
+	result, err := tx.ExecContext(ctx, `UPDATE workflow_v2_effects SET status='running',attempt_count=attempt_count+1,
+		lease_owner=?,lease_expires_at=?,updated_at=?
+		WHERE id=? AND status=? AND attempt_count=? AND next_attempt_at<=?`,
+		worker, expires.UnixMilli(), now.UnixMilli(), effect.ID, status, effect.AttemptCount, now.UnixMilli())
+	if err != nil {
+		return nil, err
+	}
+	changed, err := result.RowsAffected()
+	if err != nil {
+		return nil, err
+	}
+	if changed != 1 {
+		return nil, nil
+	}
+	effect.Status = EffectRunning
+	effect.AttemptCount++
+	effect.LeaseOwner = worker
+	effect.LeaseExpiresAt = expires
+	if nextAttempt > 0 {
+		effect.NextAttemptAt = time.UnixMilli(nextAttempt).UTC()
+	}
+	attemptID := uuid.NewString()
+	if _, err := tx.ExecContext(ctx, `INSERT INTO workflow_v2_effect_attempts(
+		id,effect_id,number,status,request_json,started_at) VALUES(?,?,?,?,?,?)`,
+		attemptID, effect.ID, effect.AttemptCount, string(EffectRunning), payloadJSON, now.UnixMilli()); err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return &EffectClaim{Effect: effect, AttemptID: attemptID}, nil
+}
+
+type CompleteEffectRequest struct {
+	EffectID   string
+	AttemptID  string
+	Worker     string
+	Status     EffectStatus
+	Receipt    map[string]interface{}
+	Error      string
+	RetryAfter time.Duration
+}
+
+type ResolveUnknownEffectRequest struct {
+	EffectID   string
+	Status     EffectStatus
+	Receipt    map[string]interface{}
+	Error      string
+	RetryAfter time.Duration
+}
+
+// CompleteEffect records the durable outcome of the currently leased attempt.
+func (s *Store) CompleteEffect(ctx context.Context, req CompleteEffectRequest) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("workflow v2 store is not configured")
+	}
+	switch req.Status {
+	case EffectSucceeded, EffectRetryableFailed, EffectPermanentFailed, EffectUnknown, EffectCancelled:
+	default:
+		return fmt.Errorf("invalid effect completion status %q", req.Status)
+	}
+	if strings.TrimSpace(req.EffectID) == "" || strings.TrimSpace(req.AttemptID) == "" || strings.TrimSpace(req.Worker) == "" {
+		return fmt.Errorf("effect id, attempt id, and worker are required")
+	}
+	receiptJSON, err := marshalObject(req.Receipt)
+	if err != nil {
+		return err
+	}
+	now := s.now().UTC()
+	nextAttempt := int64(0)
+	if req.Status == EffectRetryableFailed {
+		if req.RetryAfter < 0 {
+			return fmt.Errorf("retry delay cannot be negative")
+		}
+		nextAttempt = now.Add(req.RetryAfter).UnixMilli()
+	}
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	var attemptNumber int
+	err = tx.QueryRowContext(ctx, `SELECT a.number FROM workflow_v2_effect_attempts a
+		JOIN workflow_v2_effects e ON e.id=a.effect_id
+		WHERE a.id=? AND a.effect_id=? AND a.status='running' AND e.status='running' AND e.lease_owner=? AND e.lease_expires_at>=?`,
+		req.AttemptID, req.EffectID, req.Worker, now.UnixMilli()).Scan(&attemptNumber)
+	if errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("effect attempt is not actively leased by worker")
+	}
+	if err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE workflow_v2_effect_attempts SET status=?,receipt_json=?,error=?,finished_at=?
+		WHERE id=? AND effect_id=? AND number=?`, string(req.Status), receiptJSON, req.Error, now.UnixMilli(),
+		req.AttemptID, req.EffectID, attemptNumber); err != nil {
+		return err
+	}
+	result, err := tx.ExecContext(ctx, `UPDATE workflow_v2_effects SET status=?,lease_owner='',lease_expires_at=0,
+		next_attempt_at=?,receipt_json=?,last_error=?,updated_at=? WHERE id=? AND status='running' AND lease_owner=?`,
+		string(req.Status), nextAttempt, receiptJSON, req.Error, now.UnixMilli(), req.EffectID, req.Worker)
+	if err != nil {
+		return err
+	}
+	changed, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if changed != 1 {
+		return fmt.Errorf("effect lease changed while completing attempt")
+	}
+	return tx.Commit()
+}
+
+// ResolveUnknownEffect records the result of authoritative reconciliation
+// after a worker lease expired. Retrying is opt-in so an uncertain external
+// write can never be replayed merely because time passed.
+func (s *Store) ResolveUnknownEffect(ctx context.Context, req ResolveUnknownEffectRequest) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("workflow v2 store is not configured")
+	}
+	switch req.Status {
+	case EffectSucceeded, EffectRetryableFailed, EffectPermanentFailed, EffectCancelled:
+	default:
+		return fmt.Errorf("invalid reconciled effect status %q", req.Status)
+	}
+	if strings.TrimSpace(req.EffectID) == "" {
+		return fmt.Errorf("effect id is required")
+	}
+	if req.RetryAfter < 0 {
+		return fmt.Errorf("retry delay cannot be negative")
+	}
+	receiptJSON, err := marshalObject(req.Receipt)
+	if err != nil {
+		return err
+	}
+	now := s.now().UTC()
+	nextAttempt := int64(0)
+	if req.Status == EffectRetryableFailed {
+		nextAttempt = now.Add(req.RetryAfter).UnixMilli()
+	}
+	result, err := s.db.ExecContext(ctx, `UPDATE workflow_v2_effects SET status=?,next_attempt_at=?,
+		receipt_json=?,last_error=?,updated_at=? WHERE id=? AND status='unknown'`,
+		string(req.Status), nextAttempt, receiptJSON, req.Error, now.UnixMilli(), req.EffectID)
+	if err != nil {
+		return err
+	}
+	changed, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if changed != 1 {
+		return fmt.Errorf("effect is not awaiting reconciliation")
+	}
+	return nil
+}
+
+func expireEffectLeases(ctx context.Context, tx *sql.Tx, now time.Time) error {
+	if _, err := tx.ExecContext(ctx, `UPDATE workflow_v2_effect_attempts SET status='unknown',
+		error='worker lease expired; outcome requires reconciliation',finished_at=?
+		WHERE status='running' AND effect_id IN (
+			SELECT id FROM workflow_v2_effects WHERE status='running' AND lease_expires_at<?
+		)`, now.UnixMilli(), now.UnixMilli()); err != nil {
+		return err
+	}
+	_, err := tx.ExecContext(ctx, `UPDATE workflow_v2_effects SET status='unknown',lease_owner='',lease_expires_at=0,
+		last_error='worker lease expired; outcome requires reconciliation',updated_at=?
+		WHERE status='running' AND lease_expires_at<?`, now.UnixMilli(), now.UnixMilli())
+	return err
+}

--- a/pkg/hub/workflowv2/inspect.go
+++ b/pkg/hub/workflowv2/inspect.go
@@ -1,0 +1,285 @@
+package workflowv2
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	typesv2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
+)
+
+type Inspection struct {
+	Run                 Run                    `json:"run"`
+	Waiting             []WaitingReason        `json:"waiting"`
+	ExpectedTransitions []ExpectedTransition   `json:"expected_transitions"`
+	Facts               map[string]interface{} `json:"facts"`
+	RecentEvents        []EventRecord          `json:"recent_events"`
+	Transitions         []Transition           `json:"transitions"`
+	Effects             []EffectSummary        `json:"effects"`
+	AgentTasks          []AgentTaskSummary     `json:"agent_tasks"`
+	Delivery            DeliverySummary        `json:"delivery"`
+	Context             ContextSummary         `json:"context"`
+}
+
+type WaitingReason struct {
+	Kind   string `json:"kind"`
+	Detail string `json:"detail"`
+}
+
+type ExpectedTransition struct {
+	Name      string                 `json:"name"`
+	EventKind string                 `json:"event_kind"`
+	ToState   string                 `json:"to_state"`
+	When      map[string]interface{} `json:"when,omitempty"`
+}
+
+type EventRecord struct {
+	ID                   string                     `json:"id"`
+	Kind                 string                     `json:"kind"`
+	Producer             Producer                   `json:"producer"`
+	Disposition          typesv2.ControlDisposition `json:"disposition"`
+	ExpectedStateVersion *uint64                    `json:"expected_state_version,omitempty"`
+	ObservedStateVersion uint64                     `json:"observed_state_version"`
+	Reason               string                     `json:"reason,omitempty"`
+	ReceivedAt           time.Time                  `json:"received_at"`
+}
+
+type EffectSummary struct {
+	ID             string    `json:"id"`
+	Kind           string    `json:"kind"`
+	Status         string    `json:"status"`
+	DefinitionPath string    `json:"definition_path"`
+	AttemptCount   int       `json:"attempt_count"`
+	LastError      string    `json:"last_error,omitempty"`
+	UpdatedAt      time.Time `json:"updated_at"`
+}
+
+type AgentTaskSummary struct {
+	ID                string    `json:"id"`
+	Status            string    `json:"status"`
+	State             string    `json:"state"`
+	StateVersion      uint64    `json:"state_version"`
+	AttemptID         string    `json:"attempt_id,omitempty"`
+	HeartbeatDeadline time.Time `json:"heartbeat_deadline"`
+	Deadline          time.Time `json:"deadline"`
+	TerminalReason    string    `json:"terminal_reason,omitempty"`
+}
+
+type DeliverySummary struct {
+	ActivePullRequests int `json:"active_pull_requests"`
+	OpenPullRequests   int `json:"open_pull_requests"`
+	MergedPullRequests int `json:"merged_pull_requests"`
+	ClosedPullRequests int `json:"closed_pull_requests"`
+}
+
+type ContextSummary struct {
+	BundleID string `json:"bundle_id,omitempty"`
+	Revision string `json:"revision,omitempty"`
+	Status   string `json:"status,omitempty"`
+}
+
+func (s *Store) InspectRun(ctx context.Context, runID string) (Inspection, error) {
+	run, err := s.GetRun(ctx, runID)
+	if err != nil {
+		return Inspection{}, err
+	}
+	inspection := Inspection{Run: run, Facts: map[string]interface{}{}}
+
+	var workflowYAML string
+	if err := s.db.QueryRowContext(ctx, `SELECT workflow_yaml FROM workflow_v2_runs WHERE id=?`, runID).Scan(&workflowYAML); err != nil {
+		return Inspection{}, err
+	}
+	workflow, err := typesv2.ParseAndValidateWorkflow([]byte(workflowYAML))
+	if err != nil {
+		return Inspection{}, fmt.Errorf("inspect pinned workflow: %w", err)
+	}
+	for _, name := range sortedKeys(workflow.Workflow.Transitions) {
+		definition := workflow.Workflow.Transitions[name]
+		from, err := typesv2.FromStates(definition.From)
+		if err != nil {
+			return Inspection{}, err
+		}
+		if contains(from, run.State) {
+			inspection.ExpectedTransitions = append(inspection.ExpectedTransitions, ExpectedTransition{
+				Name: name, EventKind: definition.On, ToState: definition.To, When: definition.When,
+			})
+		}
+	}
+
+	if err := s.inspectFacts(ctx, runID, inspection.Facts); err != nil {
+		return Inspection{}, err
+	}
+	if inspection.RecentEvents, err = s.inspectEvents(ctx, runID); err != nil {
+		return Inspection{}, err
+	}
+	if inspection.Transitions, err = s.inspectTransitions(ctx, runID); err != nil {
+		return Inspection{}, err
+	}
+	if inspection.Effects, err = s.inspectEffects(ctx, runID); err != nil {
+		return Inspection{}, err
+	}
+	if inspection.AgentTasks, err = s.inspectAgentTasks(ctx, runID); err != nil {
+		return Inspection{}, err
+	}
+	if err := s.db.QueryRowContext(ctx, `SELECT
+		COALESCE(SUM(CASE WHEN active=1 THEN 1 ELSE 0 END),0),
+		COALESCE(SUM(CASE WHEN active=1 AND state='open' THEN 1 ELSE 0 END),0),
+		COALESCE(SUM(CASE WHEN active=1 AND state='merged' THEN 1 ELSE 0 END),0),
+		COALESCE(SUM(CASE WHEN active=1 AND state='closed' THEN 1 ELSE 0 END),0)
+		FROM workflow_v2_delivery_prs WHERE run_id=?`, runID).Scan(
+		&inspection.Delivery.ActivePullRequests, &inspection.Delivery.OpenPullRequests,
+		&inspection.Delivery.MergedPullRequests, &inspection.Delivery.ClosedPullRequests); err != nil {
+		return Inspection{}, err
+	}
+	if run.ContextBundleID != "" {
+		if err := s.db.QueryRowContext(ctx, `SELECT id,revision,status FROM workflow_v2_context_bundles WHERE id=? AND run_id=?`,
+			run.ContextBundleID, runID).Scan(&inspection.Context.BundleID, &inspection.Context.Revision, &inspection.Context.Status); err != nil && err != sql.ErrNoRows {
+			return Inspection{}, err
+		}
+	}
+
+	inspection.Waiting = deriveWaitingReasons(inspection)
+	return inspection, nil
+}
+
+func deriveWaitingReasons(inspection Inspection) []WaitingReason {
+	if inspection.Run.Status == RunSuspended {
+		return []WaitingReason{{Kind: "suspended", Detail: inspection.Run.WaitingReason}}
+	}
+	if inspection.Run.Status == RunCompleted || inspection.Run.Status == RunCancelled {
+		return nil
+	}
+	for _, task := range inspection.AgentTasks {
+		if task.Status == "assigned" || task.Status == "running" {
+			return []WaitingReason{{Kind: "agent_task", Detail: fmt.Sprintf("task %s is %s", task.ID, task.Status)}}
+		}
+	}
+	for _, effect := range inspection.Effects {
+		if effect.Status == "planned" || effect.Status == "running" || effect.Status == "retryable_failed" || effect.Status == "unknown" {
+			return []WaitingReason{{Kind: "effect", Detail: fmt.Sprintf("effect %s (%s) is %s", effect.ID, effect.Kind, effect.Status)}}
+		}
+	}
+	if len(inspection.ExpectedTransitions) == 0 {
+		return []WaitingReason{{Kind: "definition", Detail: "no outgoing transition is defined for the current state"}}
+	}
+	reasons := make([]WaitingReason, 0, len(inspection.ExpectedTransitions))
+	for _, transition := range inspection.ExpectedTransitions {
+		reasons = append(reasons, WaitingReason{
+			Kind: "event", Detail: fmt.Sprintf("waiting for %s to enter %s via %s", transition.EventKind, transition.ToState, transition.Name),
+		})
+	}
+	return reasons
+}
+
+func (s *Store) inspectFacts(ctx context.Context, runID string, target map[string]interface{}) error {
+	rows, err := s.db.QueryContext(ctx, `SELECT fact_key,value_json FROM workflow_v2_facts WHERE run_id=? ORDER BY fact_key`, runID)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var key, raw string
+		if err := rows.Scan(&key, &raw); err != nil {
+			return err
+		}
+		var value interface{}
+		if err := json.Unmarshal([]byte(raw), &value); err != nil {
+			return err
+		}
+		setDotted(target, key, value)
+	}
+	return rows.Err()
+}
+
+func (s *Store) inspectEvents(ctx context.Context, runID string) ([]EventRecord, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT id,kind,producer,disposition,expected_state_version,observed_state_version,reason,received_at
+		FROM workflow_v2_events WHERE run_id=? ORDER BY received_at DESC,id DESC LIMIT 50`, runID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var result []EventRecord
+	for rows.Next() {
+		var item EventRecord
+		var disposition string
+		var expected sql.NullInt64
+		var received int64
+		if err := rows.Scan(&item.ID, &item.Kind, &item.Producer, &disposition, &expected,
+			&item.ObservedStateVersion, &item.Reason, &received); err != nil {
+			return nil, err
+		}
+		item.Disposition = typesv2.ControlDisposition(disposition)
+		if expected.Valid {
+			value := uint64(expected.Int64)
+			item.ExpectedStateVersion = &value
+		}
+		item.ReceivedAt = time.UnixMilli(received).UTC()
+		result = append(result, item)
+	}
+	return result, rows.Err()
+}
+
+func (s *Store) inspectTransitions(ctx context.Context, runID string) ([]Transition, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT id,event_id,definition_name,from_state,to_state,from_version,to_version,created_at
+		FROM workflow_v2_transitions WHERE run_id=? ORDER BY to_version,id`, runID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var result []Transition
+	for rows.Next() {
+		var item Transition
+		var created int64
+		if err := rows.Scan(&item.ID, &item.EventID, &item.DefinitionName, &item.FromState, &item.ToState,
+			&item.FromVersion, &item.ToVersion, &created); err != nil {
+			return nil, err
+		}
+		item.CreatedAt = time.UnixMilli(created).UTC()
+		result = append(result, item)
+	}
+	return result, rows.Err()
+}
+
+func (s *Store) inspectEffects(ctx context.Context, runID string) ([]EffectSummary, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT id,kind,status,definition_path,attempt_count,last_error,updated_at
+		FROM workflow_v2_effects WHERE run_id=? ORDER BY created_at DESC,id DESC LIMIT 50`, runID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var result []EffectSummary
+	for rows.Next() {
+		var item EffectSummary
+		var updated int64
+		if err := rows.Scan(&item.ID, &item.Kind, &item.Status, &item.DefinitionPath, &item.AttemptCount, &item.LastError, &updated); err != nil {
+			return nil, err
+		}
+		item.UpdatedAt = time.UnixMilli(updated).UTC()
+		result = append(result, item)
+	}
+	return result, rows.Err()
+}
+
+func (s *Store) inspectAgentTasks(ctx context.Context, runID string) ([]AgentTaskSummary, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT id,status,state,state_version,attempt_id,heartbeat_deadline,deadline,terminal_reason
+		FROM workflow_v2_agent_tasks WHERE run_id=? ORDER BY created_at DESC,id DESC LIMIT 50`, runID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var result []AgentTaskSummary
+	for rows.Next() {
+		var item AgentTaskSummary
+		var heartbeat, deadline int64
+		if err := rows.Scan(&item.ID, &item.Status, &item.State, &item.StateVersion, &item.AttemptID,
+			&heartbeat, &deadline, &item.TerminalReason); err != nil {
+			return nil, err
+		}
+		item.HeartbeatDeadline = time.UnixMilli(heartbeat).UTC()
+		item.Deadline = time.UnixMilli(deadline).UTC()
+		result = append(result, item)
+	}
+	return result, rows.Err()
+}

--- a/pkg/hub/workflowv2/runtime.go
+++ b/pkg/hub/workflowv2/runtime.go
@@ -1,0 +1,877 @@
+package workflowv2
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	typesv2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
+	"github.com/google/uuid"
+)
+
+type RunStatus string
+
+const (
+	RunActive    RunStatus = "active"
+	RunSuspended RunStatus = "suspended"
+	RunCompleted RunStatus = "completed"
+	RunCancelled RunStatus = "cancelled"
+)
+
+type Producer string
+
+const (
+	ProducerHub           Producer = "hub"
+	ProducerEngine        Producer = "engine"
+	ProducerAgent         Producer = "agent"
+	ProducerCI            Producer = "ci"
+	ProducerSourceControl Producer = "source_control"
+	ProducerReview        Producer = "review"
+	ProducerOperator      Producer = "operator"
+	ProducerEffect        Producer = "effect"
+	ProducerContext       Producer = "context"
+	ProducerCustom        Producer = "custom"
+)
+
+type Run struct {
+	ID                string               `json:"id"`
+	TenantID          string               `json:"tenant_id"`
+	WorkspaceName     string               `json:"workspace_name"`
+	WorkflowName      string               `json:"workflow_name"`
+	WorkspaceRevision string               `json:"workspace_revision"`
+	WorkflowRevision  string               `json:"workflow_revision"`
+	State             string               `json:"state"`
+	DisplayPhase      typesv2.DisplayPhase `json:"display_phase"`
+	StateVersion      uint64               `json:"state_version"`
+	Status            RunStatus            `json:"status"`
+	WaitingReason     string               `json:"waiting_reason,omitempty"`
+	CurrentAttemptID  string               `json:"current_attempt_id,omitempty"`
+	CurrentTaskID     string               `json:"current_task_id,omitempty"`
+	ContextBundleID   string               `json:"context_bundle_id,omitempty"`
+	CreatedAt         time.Time            `json:"created_at"`
+	UpdatedAt         time.Time            `json:"updated_at"`
+	FinishedAt        *time.Time           `json:"finished_at,omitempty"`
+}
+
+type CreateRunRequest struct {
+	ID            string
+	TenantID      string
+	WorkspaceYAML []byte
+	WorkflowYAML  []byte
+}
+
+type EventInput struct {
+	ID                   string
+	MessageID            string
+	Kind                 string
+	ExpectedStateVersion *uint64
+	Producer             Producer
+	Provenance           typesv2.EvidenceProvenance
+	Payload              map[string]interface{}
+	Facts                map[string]interface{}
+}
+
+type EventResult struct {
+	EventID     string                     `json:"event_id"`
+	Disposition typesv2.ControlDisposition `json:"disposition"`
+	Reason      string                     `json:"reason,omitempty"`
+	Run         Run                        `json:"run"`
+	Transition  *Transition                `json:"transition,omitempty"`
+}
+
+type Transition struct {
+	ID             string    `json:"id"`
+	EventID        string    `json:"event_id"`
+	DefinitionName string    `json:"definition_name"`
+	FromState      string    `json:"from_state"`
+	ToState        string    `json:"to_state"`
+	FromVersion    uint64    `json:"from_version"`
+	ToVersion      uint64    `json:"to_version"`
+	CreatedAt      time.Time `json:"created_at"`
+}
+
+type Store struct {
+	db  *sql.DB
+	now func() time.Time
+}
+
+func NewStore(db *sql.DB) *Store {
+	return &Store{db: db, now: func() time.Time { return time.Now().UTC() }}
+}
+
+func (s *Store) SetClock(now func() time.Time) {
+	if now != nil {
+		s.now = now
+	}
+}
+
+func (s *Store) CreateRun(ctx context.Context, req CreateRunRequest) (Run, error) {
+	if s == nil || s.db == nil {
+		return Run{}, fmt.Errorf("workflow v2 store is not configured")
+	}
+	if strings.TrimSpace(req.TenantID) == "" {
+		return Run{}, fmt.Errorf("tenant_id is required")
+	}
+	rwf, rws, err := typesv2.ParseAndValidateWorkflowPair(req.WorkflowYAML, req.WorkspaceYAML)
+	if err != nil {
+		return Run{}, err
+	}
+	if !rwf.Workflow.Enabled {
+		return Run{}, fmt.Errorf("workflow %q is disabled", rwf.Workflow.Name)
+	}
+	initial := rwf.Workflow.States[rwf.Workflow.InitialState]
+	if initial.Phase == "" {
+		return Run{}, fmt.Errorf("workflow %q initial state %q has no display phase", rwf.Workflow.Name, rwf.Workflow.InitialState)
+	}
+
+	runID := strings.TrimSpace(req.ID)
+	if runID == "" {
+		runID = uuid.NewString()
+	}
+	now := s.now().UTC()
+	status := RunActive
+	finishedAt := int64(0)
+	if initial.Terminal {
+		status = terminalRunStatus(rwf.Workflow.InitialState)
+		finishedAt = now.UnixMilli()
+	}
+
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return Run{}, err
+	}
+	defer tx.Rollback()
+	_, err = tx.ExecContext(ctx, `INSERT INTO workflow_v2_runs(
+		id,tenant_id,workspace_name,workflow_name,workspace_revision,workflow_revision,
+		workspace_yaml,workflow_yaml,state,display_phase,state_version,status,created_at,updated_at,finished_at
+	) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		runID, req.TenantID, rws.Workspace.Name, rwf.Workflow.Name, string(rws.Revision), string(rwf.Revision),
+		string(req.WorkspaceYAML), string(req.WorkflowYAML), rwf.Workflow.InitialState, string(initial.Phase), 1, string(status),
+		now.UnixMilli(), now.UnixMilli(), finishedAt)
+	if err != nil {
+		return Run{}, fmt.Errorf("create workflow v2 run: %w", err)
+	}
+
+	eventID := uuid.NewString()
+	provenance := typesv2.EvidenceProvenance{Producer: string(ProducerEngine), ObservedAt: now}
+	if err := insertEvent(ctx, tx, eventID, runID, "", "workflow.run.created", nil, 0,
+		typesv2.DispositionAccepted, "", ProducerEngine, provenance, nil, nil, now); err != nil {
+		return Run{}, err
+	}
+	transitionID := uuid.NewString()
+	_, err = tx.ExecContext(ctx, `INSERT INTO workflow_v2_transitions(
+		id,run_id,event_id,definition_name,from_state,to_state,from_version,to_version,
+		workspace_revision,workflow_revision,fact_delta_json,created_at
+	) VALUES(?,?,?,?,?,?,?,?,?,?,?,?)`, transitionID, runID, eventID, "initial", "", rwf.Workflow.InitialState,
+		0, 1, string(rws.Revision), string(rwf.Revision), `{}`, now.UnixMilli())
+	if err != nil {
+		return Run{}, fmt.Errorf("record initial transition: %w", err)
+	}
+	if initial.OnEnter != nil {
+		writes := mergeWrites(initial.OnEnter.Assert, initial.OnEnter.Set)
+		if err := writeFacts(ctx, tx, runID, eventID, ProducerEngine, provenance, writes, now); err != nil {
+			return Run{}, err
+		}
+		if err := scheduleEffects(ctx, tx, runID, "initial", transitionID, "states."+rwf.Workflow.InitialState+".on_enter.effects", initial.OnEnter.Effects, now); err != nil {
+			return Run{}, err
+		}
+	}
+	if err := insertEventReceipt(ctx, tx, runID, eventID, "", typesv2.DispositionAccepted, 1, "", now); err != nil {
+		return Run{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return Run{}, err
+	}
+	return s.GetRun(ctx, runID)
+}
+
+func (s *Store) GetRun(ctx context.Context, runID string) (Run, error) {
+	if s == nil || s.db == nil {
+		return Run{}, fmt.Errorf("workflow v2 store is not configured")
+	}
+	return scanRun(s.db.QueryRowContext(ctx, `SELECT id,tenant_id,workspace_name,workflow_name,
+		workspace_revision,workflow_revision,state,display_phase,state_version,status,waiting_reason,
+		current_attempt_id,current_task_id,context_bundle_id,created_at,updated_at,finished_at
+		FROM workflow_v2_runs WHERE id=?`, runID))
+}
+
+func (s *Store) ApplyEvent(ctx context.Context, runID string, input EventInput) (EventResult, error) {
+	if s == nil || s.db == nil {
+		return EventResult{}, fmt.Errorf("workflow v2 store is not configured")
+	}
+	if strings.TrimSpace(input.ID) == "" {
+		return EventResult{}, fmt.Errorf("event id is required")
+	}
+	if strings.TrimSpace(input.Kind) == "" {
+		return EventResult{}, fmt.Errorf("event kind is required")
+	}
+	now := s.now().UTC()
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return EventResult{}, err
+	}
+	defer tx.Rollback()
+
+	stored, workflowYAML, err := getRunForUpdate(ctx, tx, runID)
+	if err != nil {
+		return EventResult{}, err
+	}
+	if existing, found, err := findDuplicateEvent(ctx, tx, runID, input.ID, input.MessageID); err != nil {
+		return EventResult{}, err
+	} else if found {
+		reason := "event already received"
+		if err := insertEventReceipt(ctx, tx, runID, existing, input.MessageID, typesv2.DispositionDuplicate, stored.StateVersion, reason, now); err != nil {
+			return EventResult{}, err
+		}
+		if err := tx.Commit(); err != nil {
+			return EventResult{}, err
+		}
+		return EventResult{EventID: existing, Disposition: typesv2.DispositionDuplicate, Reason: reason, Run: stored}, nil
+	}
+
+	workflow, err := typesv2.ParseAndValidateWorkflow([]byte(workflowYAML))
+	if err != nil {
+		return EventResult{}, fmt.Errorf("load pinned workflow: %w", err)
+	}
+	if string(workflow.Revision) != stored.WorkflowRevision {
+		return EventResult{}, fmt.Errorf("pinned workflow revision mismatch: stored %s decoded %s", stored.WorkflowRevision, workflow.Revision)
+	}
+
+	disposition, reason := authorizeEvent(input)
+	if disposition == "" && input.ExpectedStateVersion != nil && *input.ExpectedStateVersion != stored.StateVersion {
+		disposition = typesv2.DispositionStaleState
+		reason = fmt.Sprintf("expected state version %d, current version is %d", *input.ExpectedStateVersion, stored.StateVersion)
+	}
+	if disposition != "" {
+		if err := insertEvent(ctx, tx, input.ID, runID, input.MessageID, input.Kind, input.ExpectedStateVersion,
+			stored.StateVersion, disposition, reason, input.Producer, input.Provenance, input.Payload, input.Facts, now); err != nil {
+			return EventResult{}, err
+		}
+		if err := insertEventReceipt(ctx, tx, runID, input.ID, input.MessageID, disposition, stored.StateVersion, reason, now); err != nil {
+			return EventResult{}, err
+		}
+		if err := tx.Commit(); err != nil {
+			return EventResult{}, err
+		}
+		return EventResult{EventID: input.ID, Disposition: disposition, Reason: reason, Run: stored}, nil
+	}
+
+	if err := insertEvent(ctx, tx, input.ID, runID, input.MessageID, input.Kind, input.ExpectedStateVersion,
+		stored.StateVersion, typesv2.DispositionAccepted, "", input.Producer, input.Provenance, input.Payload, input.Facts, now); err != nil {
+		return EventResult{}, err
+	}
+	if err := writeFacts(ctx, tx, runID, input.ID, input.Producer, input.Provenance, input.Facts, now); err != nil {
+		return EventResult{}, err
+	}
+
+	facts, err := loadFacts(ctx, tx, runID)
+	if err != nil {
+		return EventResult{}, err
+	}
+	matchFacts := deepMerge(cloneMap(facts), input.Payload)
+	state := workflow.Workflow.States[stored.State]
+
+	clauseName, clause, clauseCount, err := matchingEventClause(workflow.Workflow, input.Kind, stored.State, matchFacts)
+	if err != nil {
+		return EventResult{}, err
+	}
+	if clauseCount > 1 {
+		reason = fmt.Sprintf("runtime ambiguity: %d event clauses matched %s in state %s", clauseCount, input.Kind, stored.State)
+		return s.rejectAndSuspend(ctx, tx, stored, input, reason, now)
+	}
+	clauseWrites := map[string]interface{}{}
+	if clause != nil && !clause.Ignore {
+		clauseWrites = mergeWrites(clause.Assert, clause.Set)
+		facts = applyWritesToMap(facts, clauseWrites)
+		matchFacts = deepMerge(cloneMap(facts), input.Payload)
+	}
+
+	name, transitionDef, matchCount, err := matchingTransition(workflow.Workflow, input.Kind, stored.State, matchFacts)
+	if err != nil {
+		return EventResult{}, err
+	}
+	if matchCount > 1 {
+		reason = fmt.Sprintf("runtime ambiguity: %d transitions matched %s in state %s", matchCount, input.Kind, stored.State)
+		return s.rejectAndSuspend(ctx, tx, stored, input, reason, now)
+	}
+	if transitionDef == nil {
+		valid, err := typesv2.MatchPredicate(state.Invariant, facts)
+		if err != nil {
+			return EventResult{}, err
+		}
+		if !valid {
+			reason = fmt.Sprintf("state invariant no longer holds for %s and no transition matched %s", stored.State, input.Kind)
+			return s.rejectAndSuspend(ctx, tx, stored, input, reason, now)
+		}
+		if err := writeFacts(ctx, tx, runID, input.ID, ProducerEngine, input.Provenance, clauseWrites, now); err != nil {
+			return EventResult{}, err
+		}
+		if clause != nil && !clause.Ignore {
+			if err := scheduleEffects(ctx, tx, runID, "event_clause", input.ID,
+				"events."+input.Kind+".clauses["+clauseName+"].effects", clause.Effects, now); err != nil {
+				return EventResult{}, err
+			}
+		}
+		if err := insertEventReceipt(ctx, tx, runID, input.ID, input.MessageID, typesv2.DispositionAccepted, stored.StateVersion, "", now); err != nil {
+			return EventResult{}, err
+		}
+		if err := tx.Commit(); err != nil {
+			return EventResult{}, err
+		}
+		updated, err := s.GetRun(ctx, runID)
+		return EventResult{EventID: input.ID, Disposition: typesv2.DispositionAccepted, Run: updated}, err
+	}
+
+	destination := workflow.Workflow.States[transitionDef.To]
+	writes := mergeWrites(clauseWrites, transitionDef.Assert, transitionDef.Set)
+	if destination.OnEnter != nil {
+		writes = mergeWrites(writes, mergeWrites(destination.OnEnter.Assert, destination.OnEnter.Set))
+	}
+	prospectiveFacts := applyWritesToMap(cloneMap(facts), writes)
+	valid, err := typesv2.MatchPredicate(destination.Invariant, prospectiveFacts)
+	if err != nil {
+		return EventResult{}, err
+	}
+	if !valid {
+		reason = fmt.Sprintf("destination invariant does not hold for state %s", transitionDef.To)
+		return s.rejectAndSuspend(ctx, tx, stored, input, reason, now)
+	}
+
+	transitionID := uuid.NewString()
+	toVersion := stored.StateVersion + 1
+	status := RunActive
+	finishedAt := int64(0)
+	if destination.Terminal {
+		status = terminalRunStatus(transitionDef.To)
+		finishedAt = now.UnixMilli()
+	}
+	result, err := tx.ExecContext(ctx, `UPDATE workflow_v2_runs SET state=?,display_phase=?,state_version=?,status=?,waiting_reason='',updated_at=?,finished_at=?
+		WHERE id=? AND state=? AND state_version=? AND workspace_revision=? AND workflow_revision=?`,
+		transitionDef.To, string(destination.Phase), toVersion, string(status), now.UnixMilli(), finishedAt,
+		runID, stored.State, stored.StateVersion, stored.WorkspaceRevision, stored.WorkflowRevision)
+	if err != nil {
+		return EventResult{}, err
+	}
+	changed, err := result.RowsAffected()
+	if err != nil {
+		return EventResult{}, err
+	}
+	if changed != 1 {
+		return EventResult{}, fmt.Errorf("state compare-and-swap failed for run %s version %d", runID, stored.StateVersion)
+	}
+
+	deltaJSON, err := marshalObject(writes)
+	if err != nil {
+		return EventResult{}, err
+	}
+	_, err = tx.ExecContext(ctx, `INSERT INTO workflow_v2_transitions(
+		id,run_id,event_id,definition_name,from_state,to_state,from_version,to_version,
+		workspace_revision,workflow_revision,fact_delta_json,created_at
+	) VALUES(?,?,?,?,?,?,?,?,?,?,?,?)`, transitionID, runID, input.ID, name, stored.State, transitionDef.To,
+		stored.StateVersion, toVersion, stored.WorkspaceRevision, stored.WorkflowRevision, deltaJSON, now.UnixMilli())
+	if err != nil {
+		return EventResult{}, fmt.Errorf("record transition: %w", err)
+	}
+	if err := writeFacts(ctx, tx, runID, input.ID, ProducerEngine, input.Provenance, writes, now); err != nil {
+		return EventResult{}, err
+	}
+	if clause != nil && !clause.Ignore {
+		if err := scheduleEffects(ctx, tx, runID, "event_clause", input.ID,
+			"events."+input.Kind+".clauses["+clauseName+"].effects", clause.Effects, now); err != nil {
+			return EventResult{}, err
+		}
+	}
+	if err := scheduleEffects(ctx, tx, runID, "transition", transitionID, "transitions."+name+".effects", transitionDef.Effects, now); err != nil {
+		return EventResult{}, err
+	}
+	if destination.OnEnter != nil {
+		if err := scheduleEffects(ctx, tx, runID, "transition", transitionID,
+			"states."+transitionDef.To+".on_enter.effects", destination.OnEnter.Effects, now); err != nil {
+			return EventResult{}, err
+		}
+	}
+	if err := insertEventReceipt(ctx, tx, runID, input.ID, input.MessageID, typesv2.DispositionAccepted, toVersion, "", now); err != nil {
+		return EventResult{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return EventResult{}, err
+	}
+	updated, err := s.GetRun(ctx, runID)
+	if err != nil {
+		return EventResult{}, err
+	}
+	return EventResult{
+		EventID: input.ID, Disposition: typesv2.DispositionAccepted, Run: updated,
+		Transition: &Transition{ID: transitionID, EventID: input.ID, DefinitionName: name,
+			FromState: stored.State, ToState: transitionDef.To, FromVersion: stored.StateVersion,
+			ToVersion: toVersion, CreatedAt: now},
+	}, nil
+}
+
+func (s *Store) rejectAndSuspend(ctx context.Context, tx *sql.Tx, run Run, input EventInput, reason string, now time.Time) (EventResult, error) {
+	if _, err := tx.ExecContext(ctx, `UPDATE workflow_v2_events SET disposition=?,reason=? WHERE id=?`,
+		string(typesv2.DispositionRejected), reason, input.ID); err != nil {
+		return EventResult{}, err
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE workflow_v2_runs SET status='suspended',waiting_reason=?,updated_at=? WHERE id=? AND state_version=?`,
+		reason, now.UnixMilli(), run.ID, run.StateVersion); err != nil {
+		return EventResult{}, err
+	}
+	if err := insertEventReceipt(ctx, tx, run.ID, input.ID, input.MessageID, typesv2.DispositionRejected, run.StateVersion, reason, now); err != nil {
+		return EventResult{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return EventResult{}, err
+	}
+	updated, err := s.GetRun(ctx, run.ID)
+	return EventResult{EventID: input.ID, Disposition: typesv2.DispositionRejected, Reason: reason, Run: updated}, err
+}
+
+func authorizeEvent(input EventInput) (typesv2.ControlDisposition, string) {
+	if !producerMayEmit(input.Producer, input.Kind) {
+		return typesv2.DispositionUnauthorized, fmt.Sprintf("producer %q cannot emit event %q", input.Producer, input.Kind)
+	}
+	for key := range input.Payload {
+		if !producerMaySupplyPayload(input.Producer, key) {
+			return typesv2.DispositionUnauthorized, fmt.Sprintf("producer %q cannot supply payload namespace %q", input.Producer, key)
+		}
+	}
+	for key := range input.Facts {
+		if !producerOwnsFact(input.Producer, key) {
+			return typesv2.DispositionUnauthorized, fmt.Sprintf("producer %q cannot write fact %q", input.Producer, key)
+		}
+	}
+	return "", ""
+}
+
+func producerMaySupplyPayload(producer Producer, namespace string) bool {
+	namespace = strings.SplitN(strings.TrimSpace(namespace), ".", 2)[0]
+	switch producer {
+	case ProducerAgent:
+		return namespace == "agent" || namespace == "task" || namespace == "plan" || namespace == "delivery" ||
+			namespace == "help" || namespace == "artifact" || namespace == "checkpoint"
+	case ProducerCI:
+		return namespace == "ci"
+	case ProducerSourceControl:
+		return namespace == "pull_request" || namespace == "delivery"
+	case ProducerReview:
+		return namespace == "review"
+	case ProducerOperator:
+		return namespace == "operator" || namespace == "command"
+	case ProducerEffect:
+		return namespace == "effect" || namespace == "effects"
+	case ProducerContext:
+		return namespace == "context"
+	case ProducerCustom:
+		return namespace == "custom"
+	case ProducerHub, ProducerEngine:
+		return namespace == "workflow" || namespace == "run" || namespace == "setup" || namespace == "task"
+	default:
+		return false
+	}
+}
+
+func producerMayEmit(producer Producer, kind string) bool {
+	prefix := strings.SplitN(strings.TrimSpace(kind), ".", 2)[0]
+	switch producer {
+	case ProducerAgent:
+		return prefix == "agent" || prefix == "plan" || prefix == "delivery" || prefix == "help" || prefix == "artifact" || prefix == "checkpoint"
+	case ProducerCI:
+		return prefix == "ci"
+	case ProducerSourceControl:
+		return prefix == "pull_request" || prefix == "delivery"
+	case ProducerReview:
+		return prefix == "review"
+	case ProducerOperator:
+		return prefix == "operator" || prefix == "command"
+	case ProducerEffect:
+		return prefix == "effect" || prefix == "effects"
+	case ProducerContext:
+		return prefix == "context"
+	case ProducerCustom:
+		return prefix == "custom"
+	case ProducerHub, ProducerEngine:
+		return prefix == "workflow" || prefix == "run" || prefix == "setup" || prefix == "task"
+	default:
+		return false
+	}
+}
+
+func producerOwnsFact(producer Producer, key string) bool {
+	namespace := strings.SplitN(strings.TrimSpace(key), ".", 2)[0]
+	switch namespace {
+	case "ci":
+		return producer == ProducerCI
+	case "pull_request":
+		return producer == ProducerSourceControl
+	case "review":
+		return producer == ProducerReview
+	case "operator":
+		return producer == ProducerOperator
+	case "effects":
+		return producer == ProducerEffect
+	case "workflow":
+		return producer == ProducerEngine
+	case "context":
+		return producer == ProducerContext
+	case "work", "custom":
+		return producer == ProducerEngine || producer == ProducerCustom
+	default:
+		return false
+	}
+}
+
+func matchingTransition(workflow *typesv2.Workflow, kind, state string, facts map[string]interface{}) (string, *typesv2.Transition, int, error) {
+	names := sortedKeys(workflow.Transitions)
+	var matchedName string
+	var matched *typesv2.Transition
+	count := 0
+	for _, name := range names {
+		definition := workflow.Transitions[name]
+		from, err := typesv2.FromStates(definition.From)
+		if err != nil {
+			return "", nil, 0, err
+		}
+		if !contains(from, state) || definition.On != kind {
+			continue
+		}
+		ok, err := typesv2.MatchPredicate(definition.When, facts)
+		if err != nil {
+			return "", nil, 0, fmt.Errorf("evaluate transition %s: %w", name, err)
+		}
+		if ok {
+			copy := definition
+			matchedName, matched = name, &copy
+			count++
+		}
+	}
+	return matchedName, matched, count, nil
+}
+
+func matchingEventClause(workflow *typesv2.Workflow, kind, state string, facts map[string]interface{}) (string, *typesv2.EventClause, int, error) {
+	definition, ok := workflow.Events[kind]
+	if !ok {
+		return "", nil, 0, nil
+	}
+	var matched *typesv2.EventClause
+	matchedIndex := ""
+	count := 0
+	for i, clause := range definition.Clauses {
+		from, err := typesv2.FromStates(clause.From)
+		if err != nil {
+			return "", nil, 0, err
+		}
+		if !contains(from, state) {
+			continue
+		}
+		ok, err := typesv2.MatchPredicate(clause.When, facts)
+		if err != nil {
+			return "", nil, 0, fmt.Errorf("evaluate event clause %d: %w", i, err)
+		}
+		if ok {
+			copy := clause
+			matched, matchedIndex = &copy, fmt.Sprintf("%d", i)
+			count++
+		}
+	}
+	return matchedIndex, matched, count, nil
+}
+
+func scheduleEffects(ctx context.Context, tx *sql.Tx, runID, originType, originID, basePath string, effects []map[string]interface{}, now time.Time) error {
+	for index, effect := range effects {
+		for kind, payload := range effect {
+			definitionPath := fmt.Sprintf("%s[%d]", basePath, index)
+			key := effectKey(runID, originID, definitionPath)
+			payloadJSON, err := json.Marshal(payload)
+			if err != nil {
+				return err
+			}
+			_, err = tx.ExecContext(ctx, `INSERT INTO workflow_v2_effects(
+				id,run_id,origin_type,origin_id,definition_path,effect_key,kind,payload_json,status,created_at,updated_at
+			) VALUES(?,?,?,?,?,?,?,?,?,?,?) ON CONFLICT(effect_key) DO NOTHING`,
+				uuid.NewString(), runID, originType, originID, definitionPath, key, kind, string(payloadJSON), "planned", now.UnixMilli(), now.UnixMilli())
+			if err != nil {
+				return fmt.Errorf("schedule effect %s: %w", definitionPath, err)
+			}
+		}
+	}
+	return nil
+}
+
+func effectKey(runID, originID, path string) string {
+	sum := sha256.Sum256([]byte(runID + "\x00" + originID + "\x00" + path))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func writeFacts(ctx context.Context, tx *sql.Tx, runID, eventID string, producer Producer, provenance typesv2.EvidenceProvenance, writes map[string]interface{}, now time.Time) error {
+	provenanceJSON, err := marshalObject(provenance)
+	if err != nil {
+		return err
+	}
+	keys := make([]string, 0, len(writes))
+	for key := range writes {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		value := writes[key]
+		if value == nil {
+			if _, err := tx.ExecContext(ctx, `DELETE FROM workflow_v2_facts WHERE run_id=? AND fact_key=?`, runID, key); err != nil {
+				return err
+			}
+			continue
+		}
+		valueJSON, err := json.Marshal(value)
+		if err != nil {
+			return err
+		}
+		_, err = tx.ExecContext(ctx, `INSERT INTO workflow_v2_facts(run_id,fact_key,value_json,producer,provenance_json,event_id,updated_at)
+			VALUES(?,?,?,?,?,?,?) ON CONFLICT(run_id,fact_key) DO UPDATE SET
+			value_json=excluded.value_json,producer=excluded.producer,provenance_json=excluded.provenance_json,event_id=excluded.event_id,updated_at=excluded.updated_at`,
+			runID, key, string(valueJSON), string(producer), provenanceJSON, eventID, now.UnixMilli())
+		if err != nil {
+			return fmt.Errorf("write fact %s: %w", key, err)
+		}
+	}
+	return nil
+}
+
+func loadFacts(ctx context.Context, tx *sql.Tx, runID string) (map[string]interface{}, error) {
+	rows, err := tx.QueryContext(ctx, `SELECT fact_key,value_json FROM workflow_v2_facts WHERE run_id=? ORDER BY fact_key`, runID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	facts := map[string]interface{}{}
+	for rows.Next() {
+		var key string
+		var raw []byte
+		if err := rows.Scan(&key, &raw); err != nil {
+			return nil, err
+		}
+		var value interface{}
+		if err := json.Unmarshal(raw, &value); err != nil {
+			return nil, err
+		}
+		setDotted(facts, key, value)
+	}
+	return facts, rows.Err()
+}
+
+func setDotted(target map[string]interface{}, key string, value interface{}) {
+	parts := strings.Split(key, ".")
+	current := target
+	for _, part := range parts[:len(parts)-1] {
+		next, ok := current[part].(map[string]interface{})
+		if !ok {
+			next = map[string]interface{}{}
+			current[part] = next
+		}
+		current = next
+	}
+	current[parts[len(parts)-1]] = value
+}
+
+func applyWritesToMap(facts map[string]interface{}, writes map[string]interface{}) map[string]interface{} {
+	for key, value := range writes {
+		if value == nil {
+			deleteDotted(facts, key)
+		} else {
+			setDotted(facts, key, value)
+		}
+	}
+	return facts
+}
+
+func deleteDotted(target map[string]interface{}, key string) {
+	parts := strings.Split(key, ".")
+	current := target
+	for _, part := range parts[:len(parts)-1] {
+		next, ok := current[part].(map[string]interface{})
+		if !ok {
+			return
+		}
+		current = next
+	}
+	delete(current, parts[len(parts)-1])
+}
+
+func mergeWrites(maps ...map[string]interface{}) map[string]interface{} {
+	result := map[string]interface{}{}
+	for _, values := range maps {
+		for key, value := range values {
+			result[key] = value
+		}
+	}
+	return result
+}
+
+func cloneMap(source map[string]interface{}) map[string]interface{} {
+	result := map[string]interface{}{}
+	for key, value := range source {
+		if nested, ok := value.(map[string]interface{}); ok {
+			result[key] = cloneMap(nested)
+		} else {
+			result[key] = value
+		}
+	}
+	return result
+}
+
+func deepMerge(target, overlay map[string]interface{}) map[string]interface{} {
+	for key, value := range overlay {
+		if nested, ok := value.(map[string]interface{}); ok {
+			base, _ := target[key].(map[string]interface{})
+			if base == nil {
+				base = map[string]interface{}{}
+			}
+			target[key] = deepMerge(base, nested)
+		} else {
+			target[key] = value
+		}
+	}
+	return target
+}
+
+func insertEvent(ctx context.Context, tx *sql.Tx, id, runID, messageID, kind string, expected *uint64, observed uint64,
+	disposition typesv2.ControlDisposition, reason string, producer Producer, provenance typesv2.EvidenceProvenance,
+	payload, facts map[string]interface{}, now time.Time) error {
+	payloadJSON, err := marshalObject(payload)
+	if err != nil {
+		return err
+	}
+	factsJSON, err := marshalObject(facts)
+	if err != nil {
+		return err
+	}
+	provenanceJSON, err := marshalObject(provenance)
+	if err != nil {
+		return err
+	}
+	var expectedValue interface{}
+	if expected != nil {
+		expectedValue = *expected
+	}
+	_, err = tx.ExecContext(ctx, `INSERT INTO workflow_v2_events(
+		id,run_id,message_id,kind,expected_state_version,observed_state_version,disposition,reason,
+		producer,provenance_json,payload_json,facts_json,received_at
+	) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?)`, id, runID, messageID, kind, expectedValue, observed, string(disposition), reason,
+		string(producer), provenanceJSON, payloadJSON, factsJSON, now.UnixMilli())
+	if err != nil {
+		return fmt.Errorf("record event: %w", err)
+	}
+	return nil
+}
+
+func insertEventReceipt(ctx context.Context, tx *sql.Tx, runID, eventID, messageID string,
+	disposition typesv2.ControlDisposition, version uint64, reason string, now time.Time) error {
+	_, err := tx.ExecContext(ctx, `INSERT INTO workflow_v2_event_receipts(
+		id,run_id,event_id,message_id,disposition,observed_state_version,reason,received_at
+	) VALUES(?,?,?,?,?,?,?,?)`, uuid.NewString(), runID, eventID, messageID, string(disposition), version, reason, now.UnixMilli())
+	return err
+}
+
+func findDuplicateEvent(ctx context.Context, tx *sql.Tx, runID, eventID, messageID string) (string, bool, error) {
+	var id string
+	err := tx.QueryRowContext(ctx, `SELECT id FROM workflow_v2_events WHERE run_id=? AND (id=? OR (? != '' AND message_id=?)) LIMIT 1`,
+		runID, eventID, messageID, messageID).Scan(&id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", false, nil
+	}
+	return id, err == nil, err
+}
+
+func getRunForUpdate(ctx context.Context, tx *sql.Tx, runID string) (Run, string, error) {
+	var workflowYAML string
+	row := tx.QueryRowContext(ctx, `SELECT id,tenant_id,workspace_name,workflow_name,
+		workspace_revision,workflow_revision,state,display_phase,state_version,status,waiting_reason,
+		current_attempt_id,current_task_id,context_bundle_id,created_at,updated_at,finished_at,workflow_yaml
+		FROM workflow_v2_runs WHERE id=?`, runID)
+	run, err := scanRunWithWorkflow(row, &workflowYAML)
+	return run, workflowYAML, err
+}
+
+type scanner interface{ Scan(...interface{}) error }
+
+func scanRun(row scanner) (Run, error) {
+	var run Run
+	var phase, status string
+	var created, updated, finished int64
+	err := row.Scan(&run.ID, &run.TenantID, &run.WorkspaceName, &run.WorkflowName,
+		&run.WorkspaceRevision, &run.WorkflowRevision, &run.State, &phase, &run.StateVersion, &status, &run.WaitingReason,
+		&run.CurrentAttemptID, &run.CurrentTaskID, &run.ContextBundleID, &created, &updated, &finished)
+	if err != nil {
+		return Run{}, err
+	}
+	finishRunScan(&run, phase, status, created, updated, finished)
+	return run, nil
+}
+
+func scanRunWithWorkflow(row scanner, workflowYAML *string) (Run, error) {
+	var run Run
+	var phase, status string
+	var created, updated, finished int64
+	err := row.Scan(&run.ID, &run.TenantID, &run.WorkspaceName, &run.WorkflowName,
+		&run.WorkspaceRevision, &run.WorkflowRevision, &run.State, &phase, &run.StateVersion, &status, &run.WaitingReason,
+		&run.CurrentAttemptID, &run.CurrentTaskID, &run.ContextBundleID, &created, &updated, &finished, workflowYAML)
+	if err != nil {
+		return Run{}, err
+	}
+	finishRunScan(&run, phase, status, created, updated, finished)
+	return run, nil
+}
+
+func finishRunScan(run *Run, phase, status string, created, updated, finished int64) {
+	run.DisplayPhase = typesv2.DisplayPhase(phase)
+	run.Status = RunStatus(status)
+	run.CreatedAt = time.UnixMilli(created).UTC()
+	run.UpdatedAt = time.UnixMilli(updated).UTC()
+	if finished > 0 {
+		value := time.UnixMilli(finished).UTC()
+		run.FinishedAt = &value
+	}
+}
+
+func terminalRunStatus(state string) RunStatus {
+	lower := strings.ToLower(state)
+	if strings.Contains(lower, "cancel") {
+		return RunCancelled
+	}
+	return RunCompleted
+}
+
+func sortedKeys[V any](values map[string]V) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func contains(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
+func marshalObject(value interface{}) (string, error) {
+	if value == nil {
+		return `{}`, nil
+	}
+	if object, ok := value.(map[string]interface{}); ok && object == nil {
+		return `{}`, nil
+	}
+	encoded, err := json.Marshal(value)
+	return string(encoded), err
+}

--- a/pkg/hub/workflowv2/runtime_test.go
+++ b/pkg/hub/workflowv2/runtime_test.go
@@ -1,0 +1,488 @@
+package workflowv2_test
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	workflowv2 "github.com/elasticclaw/elasticclaw/pkg/hub/workflowv2"
+	typesv2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
+	_ "modernc.org/sqlite"
+)
+
+const runtimeWorkspaceYAML = `
+schema_version: 2
+name: engineering
+repositories:
+  primary:
+    provider: github
+    repository: org/repo
+`
+
+const runtimeWorkflowYAML = `
+schema_version: 2
+name: delivery
+enabled: true
+initial_state: building
+states:
+  building:
+    phase: build
+    on_enter:
+      effects:
+        - agent.task:
+            prompt: Implement the change.
+  testing:
+    phase: test
+    invariant:
+      work:
+        build_complete:
+          equals: true
+  fixing:
+    phase: build
+    invariant:
+      ci:
+        status:
+          equals: failure
+    on_enter:
+      effects:
+        - agent.task:
+            prompt: Fix the verified test failure.
+  completed:
+    phase: done
+    terminal: true
+transitions:
+  build_completed:
+    from: [building, fixing]
+    on: agent.task.completed
+    when:
+      task:
+        result:
+          equals: success
+    to: testing
+    set:
+      work.build_complete: true
+  tests_failed:
+    from: testing
+    on: ci.policy.evaluated
+    when:
+      ci:
+        status:
+          equals: failure
+    to: fixing
+  tests_passed:
+    from: testing
+    on: ci.policy.evaluated
+    when:
+      ci:
+        status:
+          equals: success
+    to: completed
+`
+
+func openRuntimeDB(t *testing.T) *sql.DB {
+	t.Helper()
+	dsn := filepath.Join(t.TempDir(), "runtime.db") + "?_txlock=immediate&_pragma=foreign_keys(on)&_pragma=busy_timeout(5000)"
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := workflowv2.Migrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return db
+}
+
+func TestSQLiteJSONObjectConstraintBinding(t *testing.T) {
+	db := openRuntimeDB(t)
+	var valid int
+	var kind string
+	if err := db.QueryRow(`SELECT json_valid(?), json_type(?)`, `{}`, `{}`).Scan(&valid, &kind); err != nil {
+		t.Fatal(err)
+	}
+	if valid != 1 || kind != "object" {
+		t.Fatalf("json binding valid/type = %d/%q", valid, kind)
+	}
+}
+
+func createRuntimeRun(t *testing.T, store *workflowv2.Store, id string) workflowv2.Run {
+	t.Helper()
+	run, err := store.CreateRun(context.Background(), workflowv2.CreateRunRequest{
+		ID: id, TenantID: "tenant-1",
+		WorkspaceYAML: []byte(runtimeWorkspaceYAML),
+		WorkflowYAML:  []byte(runtimeWorkflowYAML),
+	})
+	if err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	return run
+}
+
+func version(value uint64) *uint64 { return &value }
+
+func TestCreateRunPinsRevisionsAndInitialEntry(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	fixed := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+	store.SetClock(func() time.Time { return fixed })
+
+	run := createRuntimeRun(t, store, "run-create")
+	if run.State != "building" || run.DisplayPhase != typesv2.PhaseBuild || run.StateVersion != 1 || run.Status != workflowv2.RunActive {
+		t.Fatalf("run = %#v", run)
+	}
+	if len(run.WorkspaceRevision) != 64 || len(run.WorkflowRevision) != 64 {
+		t.Fatalf("revisions not pinned: %#v", run)
+	}
+	var transitions, effects int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_transitions WHERE run_id=?`, run.ID).Scan(&transitions); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_effects WHERE run_id=?`, run.ID).Scan(&effects); err != nil {
+		t.Fatal(err)
+	}
+	if transitions != 1 || effects != 1 {
+		t.Fatalf("initial transitions/effects = %d/%d, want 1/1", transitions, effects)
+	}
+}
+
+func TestInspectRunExplainsDurableWaitingState(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	createRuntimeRun(t, store, "run-inspect")
+
+	inspection, err := store.InspectRun(context.Background(), "run-inspect")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inspection.Run.State != "building" || inspection.Run.StateVersion != 1 {
+		t.Fatalf("run = %#v", inspection.Run)
+	}
+	if len(inspection.Waiting) != 1 || inspection.Waiting[0].Kind != "effect" {
+		t.Fatalf("waiting = %#v", inspection.Waiting)
+	}
+	if len(inspection.ExpectedTransitions) != 1 || inspection.ExpectedTransitions[0].EventKind != "agent.task.completed" {
+		t.Fatalf("expected transitions = %#v", inspection.ExpectedTransitions)
+	}
+	if len(inspection.Transitions) != 1 || len(inspection.Effects) != 1 || len(inspection.RecentEvents) != 1 {
+		t.Fatalf("history sizes = transitions:%d effects:%d events:%d",
+			len(inspection.Transitions), len(inspection.Effects), len(inspection.RecentEvents))
+	}
+}
+
+func TestEffectLeaseRetryAndCompletion(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	current := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+	store.SetClock(func() time.Time { return current })
+	createRuntimeRun(t, store, "run-effect")
+
+	claim, err := store.ClaimEffect(context.Background(), "worker-1", time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claim == nil || claim.Effect.Status != workflowv2.EffectRunning || claim.Effect.AttemptCount != 1 {
+		t.Fatalf("first claim = %#v", claim)
+	}
+	if err := store.CompleteEffect(context.Background(), workflowv2.CompleteEffectRequest{
+		EffectID: claim.Effect.ID, AttemptID: claim.AttemptID, Worker: "worker-1",
+		Status: workflowv2.EffectRetryableFailed, Error: "temporary", RetryAfter: 30 * time.Second,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if early, err := store.ClaimEffect(context.Background(), "worker-2", time.Minute); err != nil || early != nil {
+		t.Fatalf("early claim = %#v, %v", early, err)
+	}
+
+	current = current.Add(30 * time.Second)
+	retry, err := store.ClaimEffect(context.Background(), "worker-2", time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if retry == nil || retry.Effect.ID != claim.Effect.ID || retry.Effect.AttemptCount != 2 {
+		t.Fatalf("retry claim = %#v", retry)
+	}
+	if err := store.CompleteEffect(context.Background(), workflowv2.CompleteEffectRequest{
+		EffectID: retry.Effect.ID, AttemptID: retry.AttemptID, Worker: "worker-2",
+		Status: workflowv2.EffectSucceeded, Receipt: map[string]interface{}{"external_id": "task-123"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if again, err := store.ClaimEffect(context.Background(), "worker-3", time.Minute); err != nil || again != nil {
+		t.Fatalf("claim after success = %#v, %v", again, err)
+	}
+}
+
+func TestExpiredEffectLeaseBecomesUnknownWithoutAutomaticReplay(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	current := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+	store.SetClock(func() time.Time { return current })
+	createRuntimeRun(t, store, "run-effect-unknown")
+
+	claim, err := store.ClaimEffect(context.Background(), "worker-1", time.Minute)
+	if err != nil || claim == nil {
+		t.Fatalf("claim = %#v, %v", claim, err)
+	}
+	current = current.Add(time.Minute + time.Millisecond)
+	next, err := store.ClaimEffect(context.Background(), "worker-2", time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if next != nil {
+		t.Fatalf("expired effect was automatically replayed: %#v", next)
+	}
+	var effectStatus, attemptStatus string
+	if err := db.QueryRow(`SELECT status FROM workflow_v2_effects WHERE id=?`, claim.Effect.ID).Scan(&effectStatus); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT status FROM workflow_v2_effect_attempts WHERE id=?`, claim.AttemptID).Scan(&attemptStatus); err != nil {
+		t.Fatal(err)
+	}
+	if effectStatus != string(workflowv2.EffectUnknown) || attemptStatus != string(workflowv2.EffectUnknown) {
+		t.Fatalf("statuses = effect:%s attempt:%s", effectStatus, attemptStatus)
+	}
+	if err := store.ResolveUnknownEffect(context.Background(), workflowv2.ResolveUnknownEffectRequest{
+		EffectID: claim.Effect.ID, Status: workflowv2.EffectRetryableFailed,
+		Error: "provider confirms no write", RetryAfter: time.Minute,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if early, err := store.ClaimEffect(context.Background(), "worker-2", time.Minute); err != nil || early != nil {
+		t.Fatalf("reconciled retry ran too early: %#v, %v", early, err)
+	}
+	current = current.Add(time.Minute)
+	retry, err := store.ClaimEffect(context.Background(), "worker-2", time.Minute)
+	if err != nil || retry == nil || retry.Effect.ID != claim.Effect.ID {
+		t.Fatalf("reconciled retry = %#v, %v", retry, err)
+	}
+}
+
+func TestApplyEventTransitionsCASAndDeduplicates(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	createRuntimeRun(t, store, "run-transition")
+
+	input := workflowv2.EventInput{
+		ID: "event-build-done", MessageID: "message-build-done",
+		Kind: "agent.task.completed", ExpectedStateVersion: version(1), Producer: workflowv2.ProducerAgent,
+		Payload: map[string]interface{}{"task": map[string]interface{}{"result": "success"}},
+	}
+	result, err := store.ApplyEvent(context.Background(), "run-transition", input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Disposition != typesv2.DispositionAccepted || result.Transition == nil || result.Run.State != "testing" || result.Run.StateVersion != 2 {
+		t.Fatalf("result = %#v", result)
+	}
+
+	duplicate, err := store.ApplyEvent(context.Background(), "run-transition", input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if duplicate.Disposition != typesv2.DispositionDuplicate || duplicate.Run.StateVersion != 2 {
+		t.Fatalf("duplicate = %#v", duplicate)
+	}
+	var transitions, effects, receipts int
+	_ = db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_transitions WHERE run_id='run-transition'`).Scan(&transitions)
+	_ = db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_effects WHERE run_id='run-transition'`).Scan(&effects)
+	_ = db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_event_receipts WHERE run_id='run-transition'`).Scan(&receipts)
+	if transitions != 2 || effects != 1 || receipts != 3 {
+		t.Fatalf("transitions/effects/receipts = %d/%d/%d, want 2/1/3", transitions, effects, receipts)
+	}
+}
+
+func TestStaleAndUnauthorizedEventsCannotMutateRun(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	createRuntimeRun(t, store, "run-guards")
+
+	stale, err := store.ApplyEvent(context.Background(), "run-guards", workflowv2.EventInput{
+		ID: "stale", Kind: "agent.task.completed", ExpectedStateVersion: version(9), Producer: workflowv2.ProducerAgent,
+		Payload: map[string]interface{}{"task": map[string]interface{}{"result": "success"}},
+	})
+	if err != nil || stale.Disposition != typesv2.DispositionStaleState {
+		t.Fatalf("stale = %#v, err=%v", stale, err)
+	}
+	unauthorized, err := store.ApplyEvent(context.Background(), "run-guards", workflowv2.EventInput{
+		ID: "forged-ci", Kind: "ci.policy.evaluated", ExpectedStateVersion: version(1), Producer: workflowv2.ProducerAgent,
+		Facts: map[string]interface{}{"ci.status": "success"},
+	})
+	if err != nil || unauthorized.Disposition != typesv2.DispositionUnauthorized {
+		t.Fatalf("unauthorized = %#v, err=%v", unauthorized, err)
+	}
+	run, err := store.GetRun(context.Background(), "run-guards")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.State != "building" || run.StateVersion != 1 {
+		t.Fatalf("guarded run mutated: %#v", run)
+	}
+	var factCount int
+	_ = db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_facts WHERE run_id='run-guards'`).Scan(&factCount)
+	if factCount != 0 {
+		t.Fatalf("forged protected facts persisted: %d", factCount)
+	}
+}
+
+func TestAgentPayloadCannotSpoofProtectedEvidence(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	createRuntimeRun(t, store, "run-payload-auth")
+
+	result, err := store.ApplyEvent(context.Background(), "run-payload-auth", workflowv2.EventInput{
+		ID: "event-spoof-ci", Kind: "agent.task.completed", ExpectedStateVersion: version(1),
+		Producer: workflowv2.ProducerAgent,
+		Payload: map[string]interface{}{
+			"task": map[string]interface{}{"result": "success"},
+			"ci":   map[string]interface{}{"status": "success"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Disposition != typesv2.DispositionUnauthorized || result.Run.StateVersion != 1 {
+		t.Fatalf("result = %#v", result)
+	}
+	inspection, err := store.InspectRun(context.Background(), "run-payload-auth")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, exists := inspection.Facts["ci"]; exists {
+		t.Fatalf("agent-created CI facts = %#v", inspection.Facts["ci"])
+	}
+}
+
+func TestFeedbackLoopCreatesEffectsPerLegitimateReentry(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	createRuntimeRun(t, store, "run-loop")
+
+	events := []workflowv2.EventInput{
+		{ID: "build-1", Kind: "agent.task.completed", ExpectedStateVersion: version(1), Producer: workflowv2.ProducerAgent,
+			Payload: map[string]interface{}{"task": map[string]interface{}{"result": "success"}}},
+		{ID: "ci-fail", Kind: "ci.policy.evaluated", ExpectedStateVersion: version(2), Producer: workflowv2.ProducerCI,
+			Facts: map[string]interface{}{"ci.status": "failure"}, Payload: map[string]interface{}{"ci": map[string]interface{}{"status": "failure"}}},
+		{ID: "build-2", Kind: "agent.task.completed", ExpectedStateVersion: version(3), Producer: workflowv2.ProducerAgent,
+			Payload: map[string]interface{}{"task": map[string]interface{}{"result": "success"}}},
+		{ID: "ci-pass", Kind: "ci.policy.evaluated", ExpectedStateVersion: version(4), Producer: workflowv2.ProducerCI,
+			Facts: map[string]interface{}{"ci.status": "success"}, Payload: map[string]interface{}{"ci": map[string]interface{}{"status": "success"}}},
+	}
+	for _, event := range events {
+		result, err := store.ApplyEvent(context.Background(), "run-loop", event)
+		if err != nil || result.Disposition != typesv2.DispositionAccepted {
+			t.Fatalf("event %s result=%#v err=%v", event.ID, result, err)
+		}
+	}
+	run, _ := store.GetRun(context.Background(), "run-loop")
+	if run.State != "completed" || run.StateVersion != 5 || run.Status != workflowv2.RunCompleted {
+		t.Fatalf("completed run = %#v", run)
+	}
+	var effects, distinctKeys int
+	_ = db.QueryRow(`SELECT COUNT(*),COUNT(DISTINCT effect_key) FROM workflow_v2_effects WHERE run_id='run-loop'`).Scan(&effects, &distinctKeys)
+	// Initial BUILD task + the task created by legitimate entry into fixing.
+	if effects != 2 || distinctKeys != 2 {
+		t.Fatalf("effects/distinct = %d/%d, want 2/2", effects, distinctKeys)
+	}
+}
+
+func TestInvariantViolationSuspendsAndPersistsEvidence(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	createRuntimeRun(t, store, "run-invariant")
+	_, err := store.ApplyEvent(context.Background(), "run-invariant", workflowv2.EventInput{
+		ID: "build", Kind: "agent.task.completed", ExpectedStateVersion: version(1), Producer: workflowv2.ProducerAgent,
+		Payload: map[string]interface{}{"task": map[string]interface{}{"result": "success"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := store.ApplyEvent(context.Background(), "run-invariant", workflowv2.EventInput{
+		ID: "ci-unknown", Kind: "ci.policy.evaluated", ExpectedStateVersion: version(2), Producer: workflowv2.ProducerCI,
+		Facts:   map[string]interface{}{"work.build_complete": nil},
+		Payload: map[string]interface{}{"ci": map[string]interface{}{"status": "pending"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// CI cannot write work.*; use an authenticated engine event to invalidate it.
+	if result.Disposition != typesv2.DispositionUnauthorized {
+		t.Fatalf("cross-namespace mutation = %#v", result)
+	}
+	result, err = store.ApplyEvent(context.Background(), "run-invariant", workflowv2.EventInput{
+		ID: "engine-invalidates", Kind: "workflow.fact.changed", ExpectedStateVersion: version(2), Producer: workflowv2.ProducerEngine,
+		Facts: map[string]interface{}{"work.build_complete": nil},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Disposition != typesv2.DispositionRejected || result.Run.Status != workflowv2.RunSuspended || !strings.Contains(result.Reason, "invariant") {
+		t.Fatalf("invariant result = %#v", result)
+	}
+}
+
+func TestConcurrentExpectedVersionAllowsOneTransition(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	createRuntimeRun(t, store, "run-concurrent")
+
+	start := make(chan struct{})
+	results := make(chan workflowv2.EventResult, 2)
+	errs := make(chan error, 2)
+	var wg sync.WaitGroup
+	for _, id := range []string{"event-a", "event-b"} {
+		wg.Add(1)
+		go func(id string) {
+			defer wg.Done()
+			<-start
+			result, err := store.ApplyEvent(context.Background(), "run-concurrent", workflowv2.EventInput{
+				ID: id, Kind: "agent.task.completed", ExpectedStateVersion: version(1), Producer: workflowv2.ProducerAgent,
+				Payload: map[string]interface{}{"task": map[string]interface{}{"result": "success"}},
+			})
+			results <- result
+			errs <- err
+		}(id)
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	accepted, stale := 0, 0
+	for result := range results {
+		switch result.Disposition {
+		case typesv2.DispositionAccepted:
+			accepted++
+		case typesv2.DispositionStaleState:
+			stale++
+		}
+	}
+	if accepted != 1 || stale != 1 {
+		t.Fatalf("accepted/stale = %d/%d, want 1/1", accepted, stale)
+	}
+}
+
+func TestRuntimeRecoveryDoesNotReadConversationRows(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	createRuntimeRun(t, store, "run-recovery")
+	// Deliberately create and destroy an unrelated transcript-shaped table.
+	if _, err := db.Exec(`CREATE TABLE messages(id TEXT PRIMARY KEY, content TEXT); INSERT INTO messages VALUES('m','[DONE]'); DELETE FROM messages`); err != nil {
+		t.Fatal(err)
+	}
+	restarted := workflowv2.NewStore(db)
+	run, err := restarted.GetRun(context.Background(), "run-recovery")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.State != "building" || run.StateVersion != 1 {
+		t.Fatalf("conversation deletion changed recovery: %#v", run)
+	}
+}

--- a/pkg/hub/workflowv2/schema.go
+++ b/pkg/hub/workflowv2/schema.go
@@ -1,0 +1,270 @@
+// Package workflowv2 implements the deterministic durable workflow runtime.
+// It intentionally has no dependency on hub conversation/message types.
+package workflowv2
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+// Migrate adds v2 runtime storage without changing or reinterpreting any v1
+// workflow, claw, transcript, or analytics table.
+func Migrate(db *sql.DB) error {
+	if db == nil {
+		return fmt.Errorf("workflow v2 migrate: database is nil")
+	}
+	_, err := db.Exec(`
+	CREATE TABLE IF NOT EXISTS workflow_v2_runs (
+		id                 TEXT PRIMARY KEY,
+		tenant_id          TEXT NOT NULL,
+		workspace_name     TEXT NOT NULL,
+		workflow_name      TEXT NOT NULL,
+		workspace_revision TEXT NOT NULL,
+		workflow_revision  TEXT NOT NULL,
+		workspace_yaml     TEXT NOT NULL,
+		workflow_yaml      TEXT NOT NULL,
+		state              TEXT NOT NULL,
+		display_phase      TEXT NOT NULL,
+		state_version      INTEGER NOT NULL CHECK(state_version >= 1),
+		status             TEXT NOT NULL CHECK(status IN ('active','suspended','completed','cancelled')),
+		waiting_reason     TEXT NOT NULL DEFAULT '',
+		current_attempt_id TEXT NOT NULL DEFAULT '',
+		current_task_id    TEXT NOT NULL DEFAULT '',
+		context_bundle_id  TEXT NOT NULL DEFAULT '',
+		created_at         INTEGER NOT NULL,
+		updated_at         INTEGER NOT NULL,
+		finished_at        INTEGER NOT NULL DEFAULT 0
+	);
+	CREATE INDEX IF NOT EXISTS idx_workflow_v2_runs_tenant_updated ON workflow_v2_runs(tenant_id, updated_at DESC, id);
+	CREATE INDEX IF NOT EXISTS idx_workflow_v2_runs_workflow ON workflow_v2_runs(tenant_id, workspace_name, workflow_name, updated_at DESC);
+	CREATE INDEX IF NOT EXISTS idx_workflow_v2_runs_status ON workflow_v2_runs(tenant_id, status, updated_at DESC);
+
+	CREATE TABLE IF NOT EXISTS workflow_v2_attempts (
+		id          TEXT PRIMARY KEY,
+		run_id      TEXT NOT NULL REFERENCES workflow_v2_runs(id) ON DELETE CASCADE,
+		claw_id     TEXT NOT NULL DEFAULT '',
+		number      INTEGER NOT NULL CHECK(number > 0),
+		status      TEXT NOT NULL CHECK(status IN ('provisioning','active','succeeded','failed','lost','cancelled')),
+		started_at  INTEGER NOT NULL,
+		heartbeat_at INTEGER NOT NULL DEFAULT 0,
+		finished_at INTEGER NOT NULL DEFAULT 0,
+		reason      TEXT NOT NULL DEFAULT '',
+		UNIQUE(run_id, number)
+	);
+	CREATE INDEX IF NOT EXISTS idx_workflow_v2_attempts_run ON workflow_v2_attempts(run_id, number);
+	CREATE INDEX IF NOT EXISTS idx_workflow_v2_attempts_claw ON workflow_v2_attempts(claw_id);
+
+	CREATE TABLE IF NOT EXISTS workflow_v2_events (
+		id                     TEXT PRIMARY KEY,
+		run_id                 TEXT NOT NULL REFERENCES workflow_v2_runs(id) ON DELETE CASCADE,
+		message_id             TEXT NOT NULL DEFAULT '',
+		kind                   TEXT NOT NULL,
+		expected_state_version INTEGER,
+		observed_state_version INTEGER NOT NULL,
+		disposition            TEXT NOT NULL CHECK(disposition IN ('accepted','duplicate','stale_state','rejected','unauthorized')),
+		reason                 TEXT NOT NULL DEFAULT '',
+		producer               TEXT NOT NULL,
+		provenance_json        TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(provenance_json) AND json_type(provenance_json)='object'),
+		payload_json           TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(payload_json) AND json_type(payload_json)='object'),
+		facts_json             TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(facts_json) AND json_type(facts_json)='object'),
+		received_at            INTEGER NOT NULL
+	);
+	CREATE UNIQUE INDEX IF NOT EXISTS idx_workflow_v2_events_message ON workflow_v2_events(run_id, message_id) WHERE message_id != '';
+	CREATE INDEX IF NOT EXISTS idx_workflow_v2_events_run ON workflow_v2_events(run_id, received_at, id);
+	CREATE INDEX IF NOT EXISTS idx_workflow_v2_events_disposition ON workflow_v2_events(run_id, disposition, received_at);
+
+	CREATE TABLE IF NOT EXISTS workflow_v2_event_receipts (
+		id                     TEXT PRIMARY KEY,
+		run_id                 TEXT NOT NULL REFERENCES workflow_v2_runs(id) ON DELETE CASCADE,
+		event_id               TEXT NOT NULL,
+		message_id             TEXT NOT NULL DEFAULT '',
+		disposition            TEXT NOT NULL CHECK(disposition IN ('accepted','duplicate','stale_state','rejected','unauthorized')),
+		observed_state_version INTEGER NOT NULL,
+		reason                 TEXT NOT NULL DEFAULT '',
+		received_at            INTEGER NOT NULL
+	);
+	CREATE INDEX IF NOT EXISTS idx_workflow_v2_event_receipts_run ON workflow_v2_event_receipts(run_id, received_at, id);
+
+	CREATE TABLE IF NOT EXISTS workflow_v2_facts (
+		run_id          TEXT NOT NULL REFERENCES workflow_v2_runs(id) ON DELETE CASCADE,
+		fact_key        TEXT NOT NULL,
+		value_json      TEXT NOT NULL CHECK(json_valid(value_json)),
+		producer        TEXT NOT NULL,
+		provenance_json TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(provenance_json) AND json_type(provenance_json)='object'),
+		event_id        TEXT NOT NULL REFERENCES workflow_v2_events(id),
+		updated_at      INTEGER NOT NULL,
+		PRIMARY KEY(run_id, fact_key)
+	);
+
+	CREATE TABLE IF NOT EXISTS workflow_v2_transitions (
+		id                 TEXT PRIMARY KEY,
+		run_id             TEXT NOT NULL REFERENCES workflow_v2_runs(id) ON DELETE CASCADE,
+		event_id           TEXT NOT NULL REFERENCES workflow_v2_events(id),
+		definition_name    TEXT NOT NULL,
+		from_state         TEXT NOT NULL,
+		to_state           TEXT NOT NULL,
+		from_version       INTEGER NOT NULL,
+		to_version         INTEGER NOT NULL,
+		workspace_revision TEXT NOT NULL,
+		workflow_revision  TEXT NOT NULL,
+		fact_delta_json    TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(fact_delta_json) AND json_type(fact_delta_json)='object'),
+		created_at         INTEGER NOT NULL,
+		UNIQUE(event_id),
+		UNIQUE(run_id, to_version)
+	);
+	CREATE INDEX IF NOT EXISTS idx_workflow_v2_transitions_run ON workflow_v2_transitions(run_id, to_version);
+
+	CREATE TABLE IF NOT EXISTS workflow_v2_effects (
+		id                 TEXT PRIMARY KEY,
+		run_id             TEXT NOT NULL REFERENCES workflow_v2_runs(id) ON DELETE CASCADE,
+		origin_type        TEXT NOT NULL CHECK(origin_type IN ('initial','transition','event_clause','command')),
+		origin_id          TEXT NOT NULL,
+		definition_path    TEXT NOT NULL,
+		effect_key         TEXT NOT NULL UNIQUE,
+		kind               TEXT NOT NULL,
+		payload_json       TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(payload_json)),
+		status             TEXT NOT NULL CHECK(status IN ('planned','running','succeeded','retryable_failed','permanent_failed','unknown','cancelled')),
+		attempt_count      INTEGER NOT NULL DEFAULT 0 CHECK(attempt_count >= 0),
+		lease_owner        TEXT NOT NULL DEFAULT '',
+		lease_expires_at   INTEGER NOT NULL DEFAULT 0,
+		next_attempt_at    INTEGER NOT NULL DEFAULT 0,
+		receipt_json       TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(receipt_json) AND json_type(receipt_json)='object'),
+		last_error         TEXT NOT NULL DEFAULT '',
+		created_at         INTEGER NOT NULL,
+		updated_at         INTEGER NOT NULL
+	);
+	CREATE INDEX IF NOT EXISTS idx_workflow_v2_effects_ready ON workflow_v2_effects(status, next_attempt_at, lease_expires_at);
+	CREATE INDEX IF NOT EXISTS idx_workflow_v2_effects_run ON workflow_v2_effects(run_id, created_at, id);
+
+	CREATE TABLE IF NOT EXISTS workflow_v2_effect_attempts (
+		id            TEXT PRIMARY KEY,
+		effect_id     TEXT NOT NULL REFERENCES workflow_v2_effects(id) ON DELETE CASCADE,
+		number        INTEGER NOT NULL CHECK(number > 0),
+		status        TEXT NOT NULL CHECK(status IN ('running','succeeded','retryable_failed','permanent_failed','unknown','cancelled')),
+		request_json  TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(request_json)),
+		receipt_json  TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(receipt_json)),
+		error         TEXT NOT NULL DEFAULT '',
+		started_at    INTEGER NOT NULL,
+		finished_at   INTEGER NOT NULL DEFAULT 0,
+		UNIQUE(effect_id, number)
+	);
+
+	CREATE TABLE IF NOT EXISTS workflow_v2_agent_tasks (
+		id                  TEXT PRIMARY KEY,
+		run_id              TEXT NOT NULL REFERENCES workflow_v2_runs(id) ON DELETE CASCADE,
+		effect_id           TEXT NOT NULL DEFAULT '',
+		attempt_id          TEXT NOT NULL DEFAULT '',
+		state               TEXT NOT NULL,
+		state_version       INTEGER NOT NULL,
+		status              TEXT NOT NULL CHECK(status IN ('assigned','running','completed','failed','cancelled','timed_out')),
+		instructions        TEXT NOT NULL,
+		allowed_actions     TEXT NOT NULL DEFAULT '[]' CHECK(json_valid(allowed_actions) AND json_type(allowed_actions)='array'),
+		required_artifacts  TEXT NOT NULL DEFAULT '[]' CHECK(json_valid(required_artifacts) AND json_type(required_artifacts)='array'),
+		heartbeat_deadline  INTEGER NOT NULL,
+		deadline            INTEGER NOT NULL,
+		last_heartbeat_at   INTEGER NOT NULL DEFAULT 0,
+		terminal_reason     TEXT NOT NULL DEFAULT '',
+		created_at          INTEGER NOT NULL,
+		updated_at          INTEGER NOT NULL,
+		finished_at         INTEGER NOT NULL DEFAULT 0
+	);
+	CREATE INDEX IF NOT EXISTS idx_workflow_v2_agent_tasks_run ON workflow_v2_agent_tasks(run_id, created_at, id);
+	CREATE INDEX IF NOT EXISTS idx_workflow_v2_agent_tasks_liveness ON workflow_v2_agent_tasks(status, heartbeat_deadline, deadline);
+
+	CREATE TABLE IF NOT EXISTS workflow_v2_artifacts (
+		id            TEXT PRIMARY KEY,
+		run_id        TEXT NOT NULL REFERENCES workflow_v2_runs(id) ON DELETE CASCADE,
+		task_id       TEXT NOT NULL DEFAULT '',
+		kind          TEXT NOT NULL,
+		name          TEXT NOT NULL,
+		revision      INTEGER NOT NULL CHECK(revision > 0),
+		content_type  TEXT NOT NULL DEFAULT 'application/json',
+		content_json  TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(content_json)),
+		content_digest TEXT NOT NULL,
+		status        TEXT NOT NULL CHECK(status IN ('submitted','accepted','rejected','superseded')),
+		created_at    INTEGER NOT NULL,
+		UNIQUE(run_id, kind, name, revision)
+	);
+
+	CREATE TABLE IF NOT EXISTS workflow_v2_context_bundles (
+		id           TEXT PRIMARY KEY,
+		run_id       TEXT NOT NULL REFERENCES workflow_v2_runs(id) ON DELETE CASCADE,
+		revision     TEXT NOT NULL,
+		status       TEXT NOT NULL CHECK(status IN ('assembling','ready','failed')),
+		sources_json TEXT NOT NULL DEFAULT '[]' CHECK(json_valid(sources_json) AND json_type(sources_json)='array'),
+		created_at   INTEGER NOT NULL,
+		updated_at   INTEGER NOT NULL,
+		UNIQUE(run_id, revision)
+	);
+
+	CREATE TABLE IF NOT EXISTS workflow_v2_delivery_prs (
+		id                  TEXT PRIMARY KEY,
+		run_id              TEXT NOT NULL REFERENCES workflow_v2_runs(id) ON DELETE CASCADE,
+		url                 TEXT NOT NULL,
+		repository_name     TEXT NOT NULL,
+		repository          TEXT NOT NULL,
+		pr_number           INTEGER NOT NULL CHECK(pr_number > 0),
+		source_branch       TEXT NOT NULL,
+		base_branch         TEXT NOT NULL,
+		current_head_sha    TEXT NOT NULL,
+		state               TEXT NOT NULL CHECK(state IN ('open','closed','merged')),
+		active              INTEGER NOT NULL DEFAULT 1 CHECK(active IN (0,1)),
+		supersedes_id       TEXT NOT NULL DEFAULT '',
+		provenance_json     TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(provenance_json) AND json_type(provenance_json)='object'),
+		verified_at         INTEGER NOT NULL,
+		updated_at          INTEGER NOT NULL,
+		UNIQUE(run_id, url),
+		UNIQUE(run_id, repository, pr_number)
+	);
+	CREATE INDEX IF NOT EXISTS idx_workflow_v2_delivery_run ON workflow_v2_delivery_prs(run_id, active, state);
+
+	CREATE TABLE IF NOT EXISTS workflow_v2_delivery_heads (
+		id          TEXT PRIMARY KEY,
+		pr_id       TEXT NOT NULL REFERENCES workflow_v2_delivery_prs(id) ON DELETE CASCADE,
+		head_sha    TEXT NOT NULL,
+		generation  INTEGER NOT NULL CHECK(generation > 0),
+		observed_at INTEGER NOT NULL,
+		UNIQUE(pr_id, head_sha),
+		UNIQUE(pr_id, generation)
+	);
+
+	CREATE TABLE IF NOT EXISTS workflow_v2_evidence (
+		id              TEXT PRIMARY KEY,
+		run_id          TEXT NOT NULL REFERENCES workflow_v2_runs(id) ON DELETE CASCADE,
+		pr_id           TEXT NOT NULL DEFAULT '',
+		head_sha         TEXT NOT NULL DEFAULT '',
+		domain           TEXT NOT NULL CHECK(domain IN ('ci','review','pull_request','operator','effect','context')),
+		connection       TEXT NOT NULL DEFAULT '',
+		external_id      TEXT NOT NULL DEFAULT '',
+		kind             TEXT NOT NULL,
+		status           TEXT NOT NULL,
+		payload_json     TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(payload_json)),
+		provenance_json  TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(provenance_json) AND json_type(provenance_json)='object'),
+		observed_at      INTEGER NOT NULL,
+		superseded_at    INTEGER NOT NULL DEFAULT 0,
+		UNIQUE(run_id, domain, connection, external_id, kind, head_sha)
+	);
+	CREATE INDEX IF NOT EXISTS idx_workflow_v2_evidence_subject ON workflow_v2_evidence(run_id, pr_id, head_sha, domain, superseded_at);
+
+	CREATE TABLE IF NOT EXISTS workflow_v2_control_outbox (
+		message_id       TEXT PRIMARY KEY,
+		run_id           TEXT NOT NULL REFERENCES workflow_v2_runs(id) ON DELETE CASCADE,
+		attempt_id       TEXT NOT NULL DEFAULT '',
+		task_id          TEXT NOT NULL DEFAULT '',
+		kind             TEXT NOT NULL,
+		envelope_json    TEXT NOT NULL CHECK(json_valid(envelope_json) AND json_type(envelope_json)='object'),
+		status           TEXT NOT NULL CHECK(status IN ('pending','sent','acknowledged','cancelled')),
+		attempt_count    INTEGER NOT NULL DEFAULT 0,
+		next_attempt_at  INTEGER NOT NULL DEFAULT 0,
+		last_error       TEXT NOT NULL DEFAULT '',
+		created_at       INTEGER NOT NULL,
+		updated_at       INTEGER NOT NULL,
+		acknowledged_at  INTEGER NOT NULL DEFAULT 0
+	);
+	CREATE INDEX IF NOT EXISTS idx_workflow_v2_control_ready ON workflow_v2_control_outbox(status, next_attempt_at);
+	`)
+	if err != nil {
+		return fmt.Errorf("workflow v2 migrate: %w", err)
+	}
+	return nil
+}

--- a/pkg/types/v2/predicate_eval.go
+++ b/pkg/types/v2/predicate_eval.go
@@ -1,0 +1,183 @@
+package v2
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+)
+
+// MatchPredicate evaluates the restricted predicate language against facts.
+// It is intentionally data-only: callers provide durable facts/event payloads,
+// never conversation text or executable expressions.
+func MatchPredicate(predicate map[string]interface{}, facts map[string]interface{}) (bool, error) {
+	if len(predicate) == 0 {
+		return true, nil
+	}
+	return matchPredicateMap(predicate, facts)
+}
+
+func matchPredicateMap(predicate, facts map[string]interface{}) (bool, error) {
+	for key, expected := range predicate {
+		switch key {
+		case "all":
+			items, ok := expected.([]interface{})
+			if !ok {
+				return false, fmt.Errorf("all requires a list")
+			}
+			for _, item := range items {
+				child, ok := item.(map[string]interface{})
+				if !ok {
+					return false, fmt.Errorf("all item must be a predicate map")
+				}
+				matched, err := matchPredicateMap(child, facts)
+				if err != nil || !matched {
+					return matched, err
+				}
+			}
+		case "any":
+			items, ok := expected.([]interface{})
+			if !ok {
+				return false, fmt.Errorf("any requires a list")
+			}
+			matchedAny := false
+			for _, item := range items {
+				child, ok := item.(map[string]interface{})
+				if !ok {
+					return false, fmt.Errorf("any item must be a predicate map")
+				}
+				matched, err := matchPredicateMap(child, facts)
+				if err != nil {
+					return false, err
+				}
+				matchedAny = matchedAny || matched
+			}
+			if !matchedAny {
+				return false, nil
+			}
+		default:
+			actual, exists := facts[key]
+			matched, err := matchConstraint(expected, actual, exists)
+			if err != nil || !matched {
+				return matched, err
+			}
+		}
+	}
+	return true, nil
+}
+
+func matchConstraint(expected, actual interface{}, exists bool) (bool, error) {
+	constraint, isMap := expected.(map[string]interface{})
+	if !isMap {
+		return exists && valuesEqual(actual, expected), nil
+	}
+
+	hasOperator := false
+	for op, value := range constraint {
+		switch op {
+		case "equals":
+			hasOperator = true
+			if !exists || !valuesEqual(actual, value) {
+				return false, nil
+			}
+		case "not_equals":
+			hasOperator = true
+			if exists && valuesEqual(actual, value) {
+				return false, nil
+			}
+		case "in", "not_in":
+			hasOperator = true
+			items, ok := value.([]interface{})
+			if !ok {
+				return false, fmt.Errorf("%s requires a list", op)
+			}
+			found := false
+			for _, item := range items {
+				found = found || (exists && valuesEqual(actual, item))
+			}
+			if (op == "in" && !found) || (op == "not_in" && found) {
+				return false, nil
+			}
+		case "exists":
+			hasOperator = true
+			want, ok := value.(bool)
+			if !ok {
+				return false, fmt.Errorf("exists requires a boolean")
+			}
+			if exists != want {
+				return false, nil
+			}
+		}
+	}
+	if hasOperator {
+		for key := range constraint {
+			if !isConstraintOperator(key) {
+				return false, fmt.Errorf("unsupported predicate operator %q", key)
+			}
+		}
+		return true, nil
+	}
+	if !exists {
+		return false, nil
+	}
+	actualMap, ok := actual.(map[string]interface{})
+	if !ok {
+		return false, nil
+	}
+	return matchPredicateMap(constraint, actualMap)
+}
+
+func isConstraintOperator(value string) bool {
+	switch value {
+	case "equals", "not_equals", "in", "not_in", "exists":
+		return true
+	default:
+		return false
+	}
+}
+
+func valuesEqual(a, b interface{}) bool {
+	if reflect.DeepEqual(a, b) {
+		return true
+	}
+	if left, ok := numericValue(a); ok {
+		if right, ok := numericValue(b); ok {
+			return left == right
+		}
+	}
+	// YAML and JSON decoders use different concrete numeric types. Canonical
+	// JSON makes semantically equal scalar/collection values comparable.
+	left, leftErr := json.Marshal(a)
+	right, rightErr := json.Marshal(b)
+	return leftErr == nil && rightErr == nil && string(left) == string(right)
+}
+
+func numericValue(value interface{}) (float64, bool) {
+	switch number := value.(type) {
+	case int:
+		return float64(number), true
+	case int8:
+		return float64(number), true
+	case int16:
+		return float64(number), true
+	case int32:
+		return float64(number), true
+	case int64:
+		return float64(number), true
+	case uint:
+		return float64(number), true
+	case uint8:
+		return float64(number), true
+	case uint16:
+		return float64(number), true
+	case uint32:
+		return float64(number), true
+	case uint64:
+		return float64(number), true
+	case float32:
+		return float64(number), true
+	case float64:
+		return number, true
+	default:
+		return 0, false
+	}
+}

--- a/pkg/types/v2/predicate_eval_test.go
+++ b/pkg/types/v2/predicate_eval_test.go
@@ -1,0 +1,47 @@
+package v2_test
+
+import (
+	"testing"
+
+	v2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
+)
+
+func TestMatchPredicateRestrictedLanguage(t *testing.T) {
+	facts := map[string]interface{}{
+		"ci": map[string]interface{}{
+			"status":   "satisfied",
+			"attempt":  float64(2),
+			"optional": false,
+		},
+	}
+	tests := []struct {
+		name      string
+		predicate map[string]interface{}
+		want      bool
+	}{
+		{"nested equals", map[string]interface{}{"ci": map[string]interface{}{"status": map[string]interface{}{"equals": "satisfied"}}}, true},
+		{"numeric json yaml equality", map[string]interface{}{"ci": map[string]interface{}{"attempt": map[string]interface{}{"equals": float64(2)}}}, true},
+		{"in", map[string]interface{}{"ci": map[string]interface{}{"status": map[string]interface{}{"in": []interface{}{"pending", "satisfied"}}}}, true},
+		{"not in", map[string]interface{}{"ci": map[string]interface{}{"status": map[string]interface{}{"not_in": []interface{}{"failed"}}}}, true},
+		{"exists false", map[string]interface{}{"ci": map[string]interface{}{"missing": map[string]interface{}{"exists": false}}}, true},
+		{"all", map[string]interface{}{"all": []interface{}{
+			map[string]interface{}{"ci": map[string]interface{}{"status": "satisfied"}},
+			map[string]interface{}{"ci": map[string]interface{}{"optional": false}},
+		}}, true},
+		{"any false", map[string]interface{}{"any": []interface{}{
+			map[string]interface{}{"ci": map[string]interface{}{"status": "failed"}},
+			map[string]interface{}{"ci": map[string]interface{}{"status": "pending"}},
+		}}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := v2.MatchPredicate(tc.predicate, facts)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.want {
+				t.Fatalf("matched = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Builds on #557 and implements the durable workflow v2 execution foundation from #544.

- pins immutable workspace/workflow revisions per run
- applies typed events with producer authorization, deduplication, CAS state versions, invariant enforcement, and transition history
- schedules durable idempotent effects with leases, retry policy, and explicit unknown-outcome reconciliation
- stores attempts, tasks, artifacts, context bundles, dynamic multi-PR delivery, head-bound evidence, and control outbox state in additive v2 tables
- adds tenant-scoped GET /api/v2/workflow-runs/{runId} and elasticclaw workflow inspect
- never reads conversation messages or transcripts for v2 control
- leaves all v1 tables and runtime paths intact

Verification: go test ./...; go vet on changed runtime/hub/CLI packages.