### PR TITLE
feat: add workflow v2 control and delivery primitives

### DIFF
--- a/pkg/hub/github_client.go
+++ b/pkg/hub/github_client.go
@@ -1,6 +1,7 @@
 package hub
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"log"
@@ -91,7 +92,15 @@ func (c *githubClient) get(url, token string) (*githubResponse, error) {
 	return c.doGet(url, token, true)
 }
 
+func (c *githubClient) getContext(ctx context.Context, url, token string) (*githubResponse, error) {
+	return c.doGetContext(ctx, url, token, true)
+}
+
 func (c *githubClient) doGet(url, token string, conditional bool) (*githubResponse, error) {
+	return c.doGetContext(context.Background(), url, token, conditional)
+}
+
+func (c *githubClient) doGetContext(ctx context.Context, url, token string, conditional bool) (*githubResponse, error) {
 	if until, blocked := c.blockedUntilTime(); blocked {
 		return nil, &githubAPIError{
 			StatusCode:  http.StatusForbidden,
@@ -101,7 +110,7 @@ func (c *githubClient) doGet(url, token string, conditional bool) (*githubRespon
 		}
 	}
 
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -136,7 +145,7 @@ func (c *githubClient) doGet(url, token string, conditional bool) (*githubRespon
 		}
 		// The entry was evicted after the validator was sent; ask again unconditionally.
 		c.forget(url)
-		return c.doGet(url, token, false)
+		return c.doGetContext(ctx, url, token, false)
 	}
 	if resp.StatusCode == http.StatusOK {
 		c.store(url, resp.Header.Get("ETag"), body)

--- a/pkg/hub/workflow_v2_github.go
+++ b/pkg/hub/workflow_v2_github.go
@@ -1,0 +1,114 @@
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/elasticclaw/elasticclaw/pkg/hub/workflowv2"
+	typesv2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
+)
+
+func (s *Server) workflowV2PullRequestVerifier() workflowv2.PullRequestVerifier {
+	return workflowv2.PullRequestVerifierFunc(s.verifyWorkflowV2PullRequest)
+}
+
+// verifyWorkflowV2PullRequest treats the claw URL only as a claim. Repository,
+// number, branches, state, and head are resolved through the hub's trusted
+// GitHub API connection before the runtime can use them.
+func (s *Server) verifyWorkflowV2PullRequest(ctx context.Context, run workflowv2.Run, workspace *typesv2.Workspace,
+	claim typesv2.PullRequestClaim) (typesv2.VerifiedPullRequest, error) {
+	if err := ctx.Err(); err != nil {
+		return typesv2.VerifiedPullRequest{}, err
+	}
+	_ = run // run identity is bound by SubmitDelivery before this verifier is invoked.
+	repository, number, err := parseWorkflowV2GitHubPRURL(claim.URL)
+	if err != nil {
+		return typesv2.VerifiedPullRequest{}, err
+	}
+	repositoryName := ""
+	repositoryConfig := typesv2.Repository{}
+	for name, candidate := range workspace.Repositories {
+		if candidate.Repository == repository {
+			repositoryName, repositoryConfig = name, candidate
+			break
+		}
+	}
+	if repositoryName == "" {
+		return typesv2.VerifiedPullRequest{}, fmt.Errorf("repository %q is not in workspace %q", repository, workspace.Name)
+	}
+	if !strings.EqualFold(strings.TrimSpace(repositoryConfig.Provider), "github") {
+		return typesv2.VerifiedPullRequest{}, fmt.Errorf("repository %q uses unsupported provider %q", repositoryName, repositoryConfig.Provider)
+	}
+	data, err := githubAPIWithBaseContext(ctx, s.ghBaseURL(), fmt.Sprintf("repos/%s/pulls/%d", repository, number), s.tokenForRepo(repository))
+	if err != nil {
+		return typesv2.VerifiedPullRequest{}, err
+	}
+	canonicalURL, _ := data["html_url"].(string)
+	if canonicalURL != strings.TrimSpace(claim.URL) {
+		return typesv2.VerifiedPullRequest{}, fmt.Errorf("GitHub returned canonical URL %q for claim %q", canonicalURL, claim.URL)
+	}
+	head, _ := data["head"].(map[string]interface{})
+	base, _ := data["base"].(map[string]interface{})
+	headSHA, _ := head["sha"].(string)
+	headRef, _ := head["ref"].(string)
+	baseRef, _ := base["ref"].(string)
+	state, _ := data["state"].(string)
+	merged, _ := data["merged"].(bool)
+	if merged {
+		state = "merged"
+	}
+	if state != "open" && state != "closed" && state != "merged" {
+		return typesv2.VerifiedPullRequest{}, fmt.Errorf("GitHub returned unsupported PR state %q", state)
+	}
+	externalID := fmt.Sprint(data["id"])
+	if externalID == "<nil>" {
+		externalID = repository + "#" + strconv.Itoa(number)
+	}
+	observed := now().UTC()
+	connection := strings.TrimSpace(repositoryConfig.SourceControl)
+	if connection == "" {
+		connection = "github"
+	}
+	return typesv2.VerifiedPullRequest{
+		URL: canonicalURL, Repository: repository, RepositoryName: repositoryName, Number: number,
+		SourceBranch: headRef, BaseBranch: baseRef, HeadSHA: headSHA, State: state, VerifiedAt: observed,
+		Provenance: typesv2.EvidenceProvenance{Producer: string(workflowv2.ProducerSourceControl),
+			Connection: connection, ExternalID: externalID, ObservedAt: observed, Reconciled: true},
+	}, nil
+}
+
+func githubAPIWithBaseContext(ctx context.Context, baseURL, path, token string) (map[string]interface{}, error) {
+	resp, err := defaultGitHubClient.getContext(ctx, strings.TrimRight(baseURL, "/")+"/"+strings.TrimLeft(path, "/"), token)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode >= http.StatusBadRequest {
+		return nil, &githubAPIError{StatusCode: resp.StatusCode, Body: string(resp.Body), RateLimited: resp.rateLimited()}
+	}
+	var result map[string]interface{}
+	if err := json.Unmarshal(resp.Body, &result); err != nil {
+		return nil, fmt.Errorf("github API parse error: %w", err)
+	}
+	return result, nil
+}
+
+func parseWorkflowV2GitHubPRURL(raw string) (string, int, error) {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || parsed.Scheme != "https" || parsed.Host == "" || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", 0, fmt.Errorf("pull request URL must be an absolute HTTPS GitHub URL without query or fragment")
+	}
+	parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	if len(parts) != 4 || parts[2] != "pull" || parts[0] == "" || parts[1] == "" {
+		return "", 0, fmt.Errorf("pull request URL path must be /owner/repository/pull/number")
+	}
+	number, err := strconv.Atoi(parts[3])
+	if err != nil || number <= 0 {
+		return "", 0, fmt.Errorf("pull request URL has invalid number %q", parts[3])
+	}
+	return parts[0] + "/" + parts[1], number, nil
+}

--- a/pkg/hub/workflow_v2_github_test.go
+++ b/pkg/hub/workflow_v2_github_test.go
@@ -1,0 +1,97 @@
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/hub/workflowv2"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+	typesv2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
+)
+
+func TestWorkflowV2GitHubVerifierResolvesClaimThroughAPI(t *testing.T) {
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/org/api/pulls/42" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"id": 1234, "html_url": "https://github.com/org/api/pull/42", "state": "open", "merged": false,
+			"head": map[string]interface{}{"sha": "abc123", "ref": "feature"},
+			"base": map[string]interface{}{"ref": "main"},
+		})
+	}))
+	defer api.Close()
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{}, api.URL, "", "")
+	workspace := &typesv2.Workspace{Name: "engineering", Repositories: map[string]typesv2.Repository{
+		"api": {Provider: "github", Repository: "org/api", SourceControl: "github-prod"},
+	}}
+	verified, err := s.verifyWorkflowV2PullRequest(context.Background(), workflowv2.Run{ID: "run-1"}, workspace,
+		typesv2.PullRequestClaim{URL: "https://github.com/org/api/pull/42"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if verified.RepositoryName != "api" || verified.Repository != "org/api" || verified.Number != 42 ||
+		verified.HeadSHA != "abc123" || verified.SourceBranch != "feature" || verified.BaseBranch != "main" ||
+		verified.Provenance.Connection != "github-prod" || !verified.Provenance.Reconciled {
+		t.Fatalf("verified = %#v", verified)
+	}
+}
+
+func TestWorkflowV2GitHubVerifierRejectsClaimOutsideWorkspaceWithoutAPICall(t *testing.T) {
+	calls := 0
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		http.Error(w, "unexpected", http.StatusInternalServerError)
+	}))
+	defer api.Close()
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{}, api.URL, "", "")
+	workspace := &typesv2.Workspace{Name: "engineering", Repositories: map[string]typesv2.Repository{
+		"api": {Provider: "github", Repository: "org/api"},
+	}}
+	_, err := s.verifyWorkflowV2PullRequest(context.Background(), workflowv2.Run{}, workspace,
+		typesv2.PullRequestClaim{URL: "https://github.com/other/repo/pull/1"})
+	if err == nil {
+		t.Fatal("outside repository was accepted")
+	}
+	if calls != 0 {
+		t.Fatalf("made %d API calls for unauthorized repository", calls)
+	}
+}
+
+func TestParseWorkflowV2GitHubPRURLRejectsAmbiguousURLs(t *testing.T) {
+	for _, raw := range []string{
+		"http://github.com/org/repo/pull/1",
+		"https://github.com/org/repo/pull/1/files",
+		"https://github.com/org/repo/pull/1?diff=split",
+		"https://github.com/org/repo/issues/1",
+	} {
+		if _, _, err := parseWorkflowV2GitHubPRURL(raw); err == nil {
+			t.Fatalf("accepted %q", raw)
+		}
+	}
+}
+
+func TestWorkflowV2GitHubRequestHonorsContextCancellation(t *testing.T) {
+	requestCancelled := make(chan struct{})
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+		close(requestCancelled)
+	}))
+	defer api.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	_, err := githubAPIWithBaseContext(ctx, api.URL, "repos/org/cancel/pulls/98765", "")
+	if err == nil {
+		t.Fatal("cancelled verification returned no error")
+	}
+	select {
+	case <-requestCancelled:
+	case <-time.After(time.Second):
+		t.Fatal("GitHub request did not observe context cancellation")
+	}
+}

--- a/pkg/hub/workflowv2/context.go
+++ b/pkg/hub/workflowv2/context.go
@@ -3,11 +3,13 @@ package workflowv2
 import (
 	"context"
 	"crypto/sha256"
+	"database/sql"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	typesv2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
 	"github.com/google/uuid"
@@ -106,14 +108,35 @@ func (s *Store) AssembleContext(ctx context.Context, runID string, relevantRepos
 	if err != nil {
 		return typesv2.ContextBundle{}, err
 	}
-	result, err := s.db.ExecContext(ctx, `UPDATE workflow_v2_context_bundles SET revision=?,status=?,sources_json=?,updated_at=?
-		WHERE id=? AND run_id=? AND status='assembling'`, bundle.Revision, status, string(sourcesJSON),
-		s.now().UTC().UnixMilli(), bundle.ID, runID)
-	if err != nil {
-		return typesv2.ContextBundle{}, err
+	var existingID, existingStatus, existingSources string
+	var existingCreated int64
+	existingErr := s.db.QueryRowContext(ctx, `SELECT id,status,sources_json,created_at FROM workflow_v2_context_bundles
+		WHERE run_id=? AND revision=? AND id!=?`, runID, bundle.Revision, bundle.ID).Scan(
+		&existingID, &existingStatus, &existingSources, &existingCreated)
+	if existingErr != nil && existingErr != sql.ErrNoRows {
+		return typesv2.ContextBundle{}, existingErr
 	}
-	if changed, err := result.RowsAffected(); err != nil || changed != 1 {
-		return typesv2.ContextBundle{}, fmt.Errorf("context bundle changed while assembling")
+	if existingID != "" {
+		if _, err := s.db.ExecContext(ctx, `DELETE FROM workflow_v2_context_bundles WHERE id=? AND run_id=? AND status='assembling'`,
+			bundle.ID, runID); err != nil {
+			return typesv2.ContextBundle{}, err
+		}
+		bundle.ID = existingID
+		bundle.CreatedAt = time.UnixMilli(existingCreated).UTC()
+		if err := json.Unmarshal([]byte(existingSources), &bundle.Sources); err != nil {
+			return typesv2.ContextBundle{}, err
+		}
+		status = existingStatus
+	} else {
+		result, err := s.db.ExecContext(ctx, `UPDATE workflow_v2_context_bundles SET revision=?,status=?,sources_json=?,updated_at=?
+			WHERE id=? AND run_id=? AND status='assembling'`, bundle.Revision, status, string(sourcesJSON),
+			s.now().UTC().UnixMilli(), bundle.ID, runID)
+		if err != nil {
+			return typesv2.ContextBundle{}, err
+		}
+		if changed, err := result.RowsAffected(); err != nil || changed != 1 {
+			return typesv2.ContextBundle{}, fmt.Errorf("context bundle changed while assembling")
+		}
 	}
 	if _, err := s.db.ExecContext(ctx, `UPDATE workflow_v2_runs SET context_bundle_id=?,updated_at=? WHERE id=?`,
 		bundle.ID, s.now().UTC().UnixMilli(), runID); err != nil {

--- a/pkg/hub/workflowv2/context.go
+++ b/pkg/hub/workflowv2/context.go
@@ -1,0 +1,160 @@
+package workflowv2
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	typesv2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
+	"github.com/google/uuid"
+)
+
+type KnowledgeResolver interface {
+	ResolveKnowledge(context.Context, Run, string, typesv2.KnowledgeSource) (typesv2.ContextBundleSource, error)
+}
+
+type KnowledgeResolverFunc func(context.Context, Run, string, typesv2.KnowledgeSource) (typesv2.ContextBundleSource, error)
+
+func (f KnowledgeResolverFunc) ResolveKnowledge(ctx context.Context, run Run, name string,
+	source typesv2.KnowledgeSource) (typesv2.ContextBundleSource, error) {
+	return f(ctx, run, name, source)
+}
+
+// AssembleContext resolves workspace-owned knowledge sources into a versioned
+// bundle. Repository authority remains bounded by the pinned workspace; the
+// caller may only narrow repository_files sources to named workspace repos.
+func (s *Store) AssembleContext(ctx context.Context, runID string, relevantRepositories []string,
+	resolver KnowledgeResolver) (typesv2.ContextBundle, error) {
+	if s == nil || s.db == nil {
+		return typesv2.ContextBundle{}, fmt.Errorf("workflow v2 store is not configured")
+	}
+	if resolver == nil {
+		return typesv2.ContextBundle{}, fmt.Errorf("knowledge resolver is required")
+	}
+	run, err := s.GetRun(ctx, runID)
+	if err != nil {
+		return typesv2.ContextBundle{}, err
+	}
+	var workspaceYAML string
+	if err := s.db.QueryRowContext(ctx, `SELECT workspace_yaml FROM workflow_v2_runs WHERE id=?`, runID).Scan(&workspaceYAML); err != nil {
+		return typesv2.ContextBundle{}, err
+	}
+	workspace, err := typesv2.ParseAndValidateWorkspace([]byte(workspaceYAML))
+	if err != nil {
+		return typesv2.ContextBundle{}, fmt.Errorf("load pinned workspace: %w", err)
+	}
+	relevant := make([]string, 0, len(relevantRepositories))
+	seen := map[string]bool{}
+	for _, name := range relevantRepositories {
+		name = strings.TrimSpace(name)
+		if name == "" || seen[name] {
+			continue
+		}
+		if !workspace.Workspace.HasRepository(name) {
+			return typesv2.ContextBundle{}, fmt.Errorf("relevant repository %q is not in pinned workspace", name)
+		}
+		seen[name] = true
+		relevant = append(relevant, name)
+	}
+	sort.Strings(relevant)
+
+	bundle := typesv2.ContextBundle{ID: uuid.NewString(), RunID: runID, CreatedAt: s.now().UTC()}
+	nowMillis := bundle.CreatedAt.UnixMilli()
+	if _, err := s.db.ExecContext(ctx, `INSERT INTO workflow_v2_context_bundles(id,run_id,revision,status,sources_json,created_at,updated_at)
+		VALUES(?,?,?,'assembling','[]',?,?)`, bundle.ID, runID, "assembling:"+bundle.ID, nowMillis, nowMillis); err != nil {
+		return typesv2.ContextBundle{}, err
+	}
+
+	status := "ready"
+	if workspace.Workspace.Knowledge != nil {
+		names := make([]string, 0, len(workspace.Workspace.Knowledge.Sources))
+		for name := range workspace.Workspace.Knowledge.Sources {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			source := workspace.Workspace.Knowledge.Sources[name]
+			if source.Type == typesv2.KnowledgeTypeRepositoryFiles && len(source.Repositories) == 0 {
+				source.Repositories = append([]string(nil), relevant...)
+			}
+			resolved, resolveErr := resolver.ResolveKnowledge(ctx, run, name, source)
+			resolved.Name = name
+			resolved.Type = source.Type
+			resolved.Scope = source.Scope
+			resolved.Required = source.Required
+			if resolveErr != nil {
+				resolved.Status = "failed"
+				resolved.Error = resolveErr.Error()
+				if source.Required {
+					status = "failed"
+				}
+			} else if strings.TrimSpace(resolved.Status) == "" {
+				resolved.Status = "ready"
+			}
+			bundle.Sources = append(bundle.Sources, resolved)
+		}
+	}
+	bundle.Revision, err = contextRevision(bundle.Sources)
+	if err != nil {
+		return typesv2.ContextBundle{}, err
+	}
+	sourcesJSON, err := json.Marshal(bundle.Sources)
+	if err != nil {
+		return typesv2.ContextBundle{}, err
+	}
+	result, err := s.db.ExecContext(ctx, `UPDATE workflow_v2_context_bundles SET revision=?,status=?,sources_json=?,updated_at=?
+		WHERE id=? AND run_id=? AND status='assembling'`, bundle.Revision, status, string(sourcesJSON),
+		s.now().UTC().UnixMilli(), bundle.ID, runID)
+	if err != nil {
+		return typesv2.ContextBundle{}, err
+	}
+	if changed, err := result.RowsAffected(); err != nil || changed != 1 {
+		return typesv2.ContextBundle{}, fmt.Errorf("context bundle changed while assembling")
+	}
+	if _, err := s.db.ExecContext(ctx, `UPDATE workflow_v2_runs SET context_bundle_id=?,updated_at=? WHERE id=?`,
+		bundle.ID, s.now().UTC().UnixMilli(), runID); err != nil {
+		return typesv2.ContextBundle{}, err
+	}
+
+	eventKind := "context.bundle.ready"
+	if status == "failed" {
+		eventKind = "context.bundle.failed"
+	}
+	eventResult, err := s.ApplyEvent(ctx, runID, EventInput{
+		ID: uuid.NewString(), Kind: eventKind, Producer: ProducerContext,
+		Payload: map[string]interface{}{"context": map[string]interface{}{
+			"status": status, "bundle_id": bundle.ID, "revision": bundle.Revision,
+		}},
+		Facts: map[string]interface{}{
+			"context.status": status, "context.bundle_id": bundle.ID, "context.revision": bundle.Revision,
+		},
+		Provenance: typesv2.EvidenceProvenance{Producer: string(ProducerContext), ObservedAt: s.now().UTC()},
+	})
+	if err != nil {
+		return typesv2.ContextBundle{}, err
+	}
+	if eventResult.Disposition != typesv2.DispositionAccepted {
+		return typesv2.ContextBundle{}, fmt.Errorf("context event was %s: %s", eventResult.Disposition, eventResult.Reason)
+	}
+	if status == "failed" && eventResult.Transition == nil && eventResult.Run.Status == RunActive {
+		reason := "one or more required knowledge sources failed"
+		if _, err := s.db.ExecContext(ctx, `UPDATE workflow_v2_runs SET status='suspended',waiting_reason=?,updated_at=?
+			WHERE id=? AND state_version=? AND status='active'`, reason, s.now().UTC().UnixMilli(), runID, eventResult.Run.StateVersion); err != nil {
+			return typesv2.ContextBundle{}, err
+		}
+	}
+	return bundle, nil
+}
+
+func contextRevision(sources []typesv2.ContextBundleSource) (string, error) {
+	raw, err := json.Marshal(sources)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(raw)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}

--- a/pkg/hub/workflowv2/context.go
+++ b/pkg/hub/workflowv2/context.go
@@ -70,6 +70,10 @@ func (s *Store) AssembleContext(ctx context.Context, runID string, relevantRepos
 		VALUES(?,?,?,'assembling','[]',?,?)`, bundle.ID, runID, "assembling:"+bundle.ID, nowMillis, nowMillis); err != nil {
 		return typesv2.ContextBundle{}, err
 	}
+	defer func() {
+		_, _ = s.db.ExecContext(context.Background(), `DELETE FROM workflow_v2_context_bundles WHERE id=? AND run_id=? AND status='assembling'`,
+			bundle.ID, runID)
+	}()
 
 	status := "ready"
 	if workspace.Workspace.Knowledge != nil {
@@ -88,14 +92,26 @@ func (s *Store) AssembleContext(ctx context.Context, runID string, relevantRepos
 			resolved.Type = source.Type
 			resolved.Scope = source.Scope
 			resolved.Required = source.Required
+			resolved.Repositories = append([]string(nil), source.Repositories...)
 			if resolveErr != nil {
 				resolved.Status = "failed"
 				resolved.Error = resolveErr.Error()
-				if source.Required {
-					status = "failed"
-				}
 			} else if strings.TrimSpace(resolved.Status) == "" {
 				resolved.Status = "ready"
+			}
+			if resolved.Status != "ready" && resolved.Status != "failed" {
+				return typesv2.ContextBundle{}, fmt.Errorf("knowledge resolver returned unsupported status %q for source %q",
+					resolved.Status, name)
+			}
+			if resolved.Status == "ready" && strings.TrimSpace(resolved.SourceRevision) == "" &&
+				strings.TrimSpace(resolved.ContentDigest) == "" {
+				return typesv2.ContextBundle{}, fmt.Errorf("knowledge source %q is ready without a revision or content digest", name)
+			}
+			if resolved.Status == "failed" && strings.TrimSpace(resolved.Error) == "" {
+				return typesv2.ContextBundle{}, fmt.Errorf("knowledge source %q failed without an error", name)
+			}
+			if source.Required && resolved.Status != "ready" {
+				status = "failed"
 			}
 			bundle.Sources = append(bundle.Sources, resolved)
 		}

--- a/pkg/hub/workflowv2/context_test.go
+++ b/pkg/hub/workflowv2/context_test.go
@@ -81,6 +81,9 @@ func TestAssembleContextUsesPinnedWorkspaceAndRelevantRepositories(t *testing.T)
 	if len(bundle.Sources) != 2 || bundle.Revision == "" {
 		t.Fatalf("bundle = %#v", bundle)
 	}
+	if got := bundle.Sources[1].Repositories; !reflect.DeepEqual(got, []string{"web"}) {
+		t.Fatalf("bundle repository scope = %#v", got)
+	}
 	if got := seen["repository-guidance"].Repositories; !reflect.DeepEqual(got, []string{"web"}) {
 		t.Fatalf("resolved repositories = %#v", got)
 	}
@@ -145,7 +148,7 @@ func TestRequiredKnowledgeFailureSuspendsWithoutExplicitRecoveryEdge(t *testing.
 			if name == "principles" {
 				return typesv2.ContextBundleSource{}, errors.New("knowledge service unavailable")
 			}
-			return typesv2.ContextBundleSource{Status: "ready"}, nil
+			return typesv2.ContextBundleSource{Status: "ready", ContentDigest: "sha256:repository"}, nil
 		}))
 	if err != nil {
 		t.Fatal(err)
@@ -159,5 +162,50 @@ func TestRequiredKnowledgeFailureSuspendsWithoutExplicitRecoveryEdge(t *testing.
 	}
 	if run.Status != workflowv2.RunSuspended || run.State != "gathering" || run.WaitingReason == "" {
 		t.Fatalf("run = %#v", run)
+	}
+}
+
+func TestRequiredKnowledgeFailedStatusSuspendsRun(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	createContextRun(t, store, "run-context-failed-status")
+	_, err := store.AssembleContext(context.Background(), "run-context-failed-status", []string{"api"},
+		workflowv2.KnowledgeResolverFunc(func(_ context.Context, _ workflowv2.Run, name string,
+			_ typesv2.KnowledgeSource) (typesv2.ContextBundleSource, error) {
+			if name == "principles" {
+				return typesv2.ContextBundleSource{Status: "failed", Error: "source unavailable"}, nil
+			}
+			return typesv2.ContextBundleSource{Status: "ready", ContentDigest: "sha256:repository"}, nil
+		}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := store.GetRun(context.Background(), "run-context-failed-status")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.Status != workflowv2.RunSuspended {
+		t.Fatalf("run = %#v", run)
+	}
+}
+
+func TestInvalidKnowledgeStatusCleansProvisionalBundle(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	createContextRun(t, store, "run-context-invalid-status")
+	_, err := store.AssembleContext(context.Background(), "run-context-invalid-status", []string{"api"},
+		workflowv2.KnowledgeResolverFunc(func(context.Context, workflowv2.Run, string,
+			typesv2.KnowledgeSource) (typesv2.ContextBundleSource, error) {
+			return typesv2.ContextBundleSource{Status: "partial"}, nil
+		}))
+	if err == nil {
+		t.Fatal("unsupported resolver status was accepted")
+	}
+	var bundles int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_context_bundles WHERE run_id='run-context-invalid-status'`).Scan(&bundles); err != nil {
+		t.Fatal(err)
+	}
+	if bundles != 0 {
+		t.Fatalf("provisional bundles = %d, want 0", bundles)
 	}
 }

--- a/pkg/hub/workflowv2/context_test.go
+++ b/pkg/hub/workflowv2/context_test.go
@@ -1,0 +1,149 @@
+package workflowv2_test
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	workflowv2 "github.com/elasticclaw/elasticclaw/pkg/hub/workflowv2"
+	typesv2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
+)
+
+const contextWorkspaceYAML = `
+schema_version: 2
+name: engineering
+repositories:
+  api:
+    provider: github
+    repository: org/api
+  web:
+    provider: github
+    repository: org/web
+knowledge:
+  sources:
+    principles:
+      type: workspace_files
+      scope: organization
+      required: true
+      paths: [ENGINEERING.md, PRODUCT.md]
+    repository-guidance:
+      type: repository_files
+      scope: repository
+      paths: [AGENTS.md, README.md]
+`
+
+const contextWorkflowYAML = `
+schema_version: 2
+name: context-first
+enabled: true
+initial_state: gathering
+states:
+  gathering:
+    phase: context
+  planning:
+    phase: plan
+transitions:
+  context_ready:
+    from: gathering
+    on: context.bundle.ready
+    when:
+      context:
+        status:
+          equals: ready
+    to: planning
+`
+
+func createContextRun(t *testing.T, store *workflowv2.Store, id string) {
+	t.Helper()
+	if _, err := store.CreateRun(context.Background(), workflowv2.CreateRunRequest{
+		ID: id, TenantID: "tenant-1", WorkspaceYAML: []byte(contextWorkspaceYAML), WorkflowYAML: []byte(contextWorkflowYAML),
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAssembleContextUsesPinnedWorkspaceAndRelevantRepositories(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	createContextRun(t, store, "run-context")
+	seen := map[string]typesv2.KnowledgeSource{}
+	resolver := workflowv2.KnowledgeResolverFunc(func(_ context.Context, _ workflowv2.Run, name string,
+		source typesv2.KnowledgeSource) (typesv2.ContextBundleSource, error) {
+		seen[name] = source
+		return typesv2.ContextBundleSource{Status: "ready", SourceRevision: "git:abc", ContentDigest: "sha256:123",
+			Documents: append([]string(nil), source.Paths...)}, nil
+	})
+	bundle, err := store.AssembleContext(context.Background(), "run-context", []string{"web"}, resolver)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bundle.Sources) != 2 || bundle.Revision == "" {
+		t.Fatalf("bundle = %#v", bundle)
+	}
+	if got := seen["repository-guidance"].Repositories; !reflect.DeepEqual(got, []string{"web"}) {
+		t.Fatalf("resolved repositories = %#v", got)
+	}
+	run, err := store.GetRun(context.Background(), "run-context")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.ContextBundleID != bundle.ID || run.State != "planning" || run.StateVersion != 2 {
+		t.Fatalf("run = %#v", run)
+	}
+	inspection, err := store.InspectRun(context.Background(), "run-context")
+	if err != nil {
+		t.Fatal(err)
+	}
+	contextFacts, ok := inspection.Facts["context"].(map[string]interface{})
+	if !ok || contextFacts["status"] != "ready" || contextFacts["revision"] != bundle.Revision {
+		t.Fatalf("context facts = %#v", inspection.Facts["context"])
+	}
+}
+
+func TestAssembleContextRejectsRepositoryOutsideWorkspace(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	createContextRun(t, store, "run-context-authority")
+	_, err := store.AssembleContext(context.Background(), "run-context-authority", []string{"unknown"},
+		workflowv2.KnowledgeResolverFunc(func(context.Context, workflowv2.Run, string, typesv2.KnowledgeSource) (typesv2.ContextBundleSource, error) {
+			return typesv2.ContextBundleSource{}, nil
+		}))
+	if err == nil {
+		t.Fatal("repository outside pinned workspace was accepted")
+	}
+	var bundles int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_context_bundles WHERE run_id='run-context-authority'`).Scan(&bundles); err != nil {
+		t.Fatal(err)
+	}
+	if bundles != 0 {
+		t.Fatalf("invalid assembly persisted %d bundles", bundles)
+	}
+}
+
+func TestRequiredKnowledgeFailureSuspendsWithoutExplicitRecoveryEdge(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	createContextRun(t, store, "run-context-failure")
+	bundle, err := store.AssembleContext(context.Background(), "run-context-failure", []string{"api"},
+		workflowv2.KnowledgeResolverFunc(func(_ context.Context, _ workflowv2.Run, name string,
+			source typesv2.KnowledgeSource) (typesv2.ContextBundleSource, error) {
+			if name == "principles" {
+				return typesv2.ContextBundleSource{}, errors.New("knowledge service unavailable")
+			}
+			return typesv2.ContextBundleSource{Status: "ready"}, nil
+		}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bundle.Sources) != 2 || bundle.Sources[0].Status != "failed" {
+		t.Fatalf("bundle = %#v", bundle)
+	}
+	run, err := store.GetRun(context.Background(), "run-context-failure")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.Status != workflowv2.RunSuspended || run.State != "gathering" || run.WaitingReason == "" {
+		t.Fatalf("run = %#v", run)
+	}
+}

--- a/pkg/hub/workflowv2/context_test.go
+++ b/pkg/hub/workflowv2/context_test.go
@@ -99,6 +99,20 @@ func TestAssembleContextUsesPinnedWorkspaceAndRelevantRepositories(t *testing.T)
 	if !ok || contextFacts["status"] != "ready" || contextFacts["revision"] != bundle.Revision {
 		t.Fatalf("context facts = %#v", inspection.Facts["context"])
 	}
+	repeated, err := store.AssembleContext(context.Background(), "run-context", []string{"web"}, resolver)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if repeated.ID != bundle.ID || repeated.Revision != bundle.Revision {
+		t.Fatalf("repeated bundle = %#v, want id/revision %s/%s", repeated, bundle.ID, bundle.Revision)
+	}
+	var bundleCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_context_bundles WHERE run_id='run-context'`).Scan(&bundleCount); err != nil {
+		t.Fatal(err)
+	}
+	if bundleCount != 1 {
+		t.Fatalf("context bundle count = %d, want 1", bundleCount)
+	}
 }
 
 func TestAssembleContextRejectsRepositoryOutsideWorkspace(t *testing.T) {

--- a/pkg/hub/workflowv2/control.go
+++ b/pkg/hub/workflowv2/control.go
@@ -35,8 +35,9 @@ func (s *Store) StartAttempt(ctx context.Context, runID, clawID string) (Attempt
 		return Attempt{}, err
 	}
 	defer tx.Rollback()
-	var status string
-	if err := tx.QueryRowContext(ctx, `SELECT status FROM workflow_v2_runs WHERE id=?`, runID).Scan(&status); err != nil {
+	var status, currentTaskID string
+	if err := tx.QueryRowContext(ctx, `SELECT status,current_task_id FROM workflow_v2_runs WHERE id=?`, runID).Scan(
+		&status, &currentTaskID); err != nil {
 		return Attempt{}, err
 	}
 	if status != string(RunActive) && status != string(RunSuspended) {
@@ -55,8 +56,67 @@ func (s *Store) StartAttempt(ctx context.Context, runID, clawID string) (Attempt
 		VALUES(?,?,?,?,?,?,?)`, attempt.ID, runID, clawID, number, attempt.Status, now.UnixMilli(), now.UnixMilli()); err != nil {
 		return Attempt{}, err
 	}
-	if _, err := tx.ExecContext(ctx, `UPDATE workflow_v2_runs SET current_attempt_id=?,updated_at=? WHERE id=?`,
-		attempt.ID, now.UnixMilli(), runID); err != nil {
+	if _, err := tx.ExecContext(ctx, `UPDATE workflow_v2_control_outbox SET status='cancelled',updated_at=?
+		WHERE run_id=? AND status IN ('pending','sent')`, now.UnixMilli(), runID); err != nil {
+		return Attempt{}, err
+	}
+	replacementTaskID := ""
+	if currentTaskID != "" {
+		var oldTask typesv2.AgentTask
+		var oldEffectID, oldStatus, allowedJSON, artifactsJSON string
+		var deadline int64
+		err := tx.QueryRowContext(ctx, `SELECT id,effect_id,attempt_id,state,state_version,status,instructions,
+			allowed_actions,required_artifacts,deadline FROM workflow_v2_agent_tasks WHERE id=? AND run_id=?`,
+			currentTaskID, runID).Scan(&oldTask.ID, &oldEffectID, &oldTask.AttemptID, &oldTask.State,
+			&oldTask.StateVersion, &oldStatus, &oldTask.Instructions, &allowedJSON, &artifactsJSON, &deadline)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return Attempt{}, err
+		}
+		if err == nil && (oldStatus == string(typesv2.AgentTaskAssigned) || oldStatus == string(typesv2.AgentTaskRunning)) {
+			if _, err := tx.ExecContext(ctx, `UPDATE workflow_v2_agent_tasks SET status='cancelled',terminal_reason=?,
+				updated_at=?,finished_at=? WHERE id=? AND run_id=? AND status IN ('assigned','running')`,
+				"superseded by a new attempt", now.UnixMilli(), now.UnixMilli(), currentTaskID, runID); err != nil {
+				return Attempt{}, err
+			}
+			_ = json.Unmarshal([]byte(allowedJSON), &oldTask.AllowedActions)
+			_ = json.Unmarshal([]byte(artifactsJSON), &oldTask.RequiredArtifacts)
+			oldTask.ID = uuid.NewString()
+			oldTask.AttemptID = attempt.ID
+			oldTask.Status = typesv2.AgentTaskAssigned
+			oldTask.HeartbeatDeadline = now.Add(2 * time.Minute)
+			oldTask.Deadline = time.UnixMilli(deadline).UTC()
+			if _, err := tx.ExecContext(ctx, `INSERT INTO workflow_v2_agent_tasks(
+				id,run_id,effect_id,attempt_id,state,state_version,status,instructions,allowed_actions,required_artifacts,
+				heartbeat_deadline,deadline,created_at,updated_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+				oldTask.ID, runID, oldEffectID, attempt.ID, oldTask.State, oldTask.StateVersion, string(oldTask.Status),
+				oldTask.Instructions, allowedJSON, artifactsJSON, oldTask.HeartbeatDeadline.UnixMilli(), deadline,
+				now.UnixMilli(), now.UnixMilli()); err != nil {
+				return Attempt{}, err
+			}
+			taskJSON, err := json.Marshal(oldTask)
+			if err != nil {
+				return Attempt{}, err
+			}
+			envelope := typesv2.ControlEnvelope{
+				ProtocolVersion: typesv2.ControlProtocolVersion, MessageID: uuid.NewString(), Kind: typesv2.MessageAgentTaskAssign,
+				RunID: runID, AttemptID: attempt.ID, TaskID: oldTask.ID, ExpectedStateVersion: &oldTask.StateVersion,
+				CausationID: currentTaskID, SentAt: now, Payload: taskJSON,
+			}
+			envelopeJSON, err := json.Marshal(envelope)
+			if err != nil {
+				return Attempt{}, err
+			}
+			if _, err := tx.ExecContext(ctx, `INSERT INTO workflow_v2_control_outbox(
+				message_id,run_id,attempt_id,task_id,kind,envelope_json,status,next_attempt_at,created_at,updated_at)
+				VALUES(?,?,?,?,?,?,'pending',0,?,?)`, envelope.MessageID, runID, attempt.ID, oldTask.ID,
+				string(envelope.Kind), string(envelopeJSON), now.UnixMilli(), now.UnixMilli()); err != nil {
+				return Attempt{}, err
+			}
+			replacementTaskID = oldTask.ID
+		}
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE workflow_v2_runs SET current_attempt_id=?,current_task_id=?,updated_at=? WHERE id=?`,
+		attempt.ID, replacementTaskID, now.UnixMilli(), runID); err != nil {
 		return Attempt{}, err
 	}
 	if err := tx.Commit(); err != nil {
@@ -80,6 +140,14 @@ func (s *Store) Snapshot(ctx context.Context, runID, attemptID string) (typesv2.
 	run, err := s.GetRun(ctx, runID)
 	if err != nil {
 		return typesv2.WorkflowSnapshot{}, err
+	}
+	if attemptID == "" || attemptID != run.CurrentAttemptID {
+		return typesv2.WorkflowSnapshot{}, fmt.Errorf("workflow snapshot attempt is no longer active")
+	}
+	var active int
+	if err := s.db.QueryRowContext(ctx, `SELECT 1 FROM workflow_v2_attempts WHERE id=? AND run_id=? AND status='active'`,
+		attemptID, runID).Scan(&active); err != nil {
+		return typesv2.WorkflowSnapshot{}, fmt.Errorf("workflow snapshot attempt is no longer active")
 	}
 	snapshot := typesv2.WorkflowSnapshot{RunID: run.ID, AttemptID: attemptID, State: run.State,
 		DisplayPhase: run.DisplayPhase, StateVersion: run.StateVersion}
@@ -185,9 +253,11 @@ func (s *Store) ReadyControl(ctx context.Context, runID, attemptID string, limit
 		limit = 100
 	}
 	now := s.now().UTC().UnixMilli()
-	rows, err := s.db.QueryContext(ctx, `SELECT envelope_json FROM workflow_v2_control_outbox
-		WHERE run_id=? AND attempt_id=? AND status IN ('pending','sent') AND next_attempt_at<=?
-		ORDER BY created_at,message_id LIMIT ?`, runID, attemptID, now, limit)
+	rows, err := s.db.QueryContext(ctx, `SELECT o.envelope_json FROM workflow_v2_control_outbox o
+		JOIN workflow_v2_runs r ON r.id=o.run_id JOIN workflow_v2_attempts a ON a.id=o.attempt_id
+		WHERE o.run_id=? AND o.attempt_id=? AND r.current_attempt_id=o.attempt_id AND a.status='active'
+		AND o.status IN ('pending','sent') AND o.next_attempt_at<=?
+		ORDER BY o.created_at,o.message_id LIMIT ?`, runID, attemptID, now, limit)
 	if err != nil {
 		return nil, err
 	}
@@ -350,6 +420,13 @@ func updateBoundTask(ctx context.Context, tx *sql.Tx, runID string, input EventI
 	}
 	if changed != 1 {
 		return fmt.Errorf("active task not found")
+	}
+	if typesv2.ControlMessageKind(input.Kind) == typesv2.MessageAgentTaskCompleted ||
+		typesv2.ControlMessageKind(input.Kind) == typesv2.MessageAgentTaskFailed {
+		if _, err := tx.ExecContext(ctx, `UPDATE workflow_v2_runs SET current_task_id='',updated_at=?
+			WHERE id=? AND current_task_id=? AND current_attempt_id=?`, now.UnixMilli(), runID, input.TaskID, input.AttemptID); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/hub/workflowv2/control.go
+++ b/pkg/hub/workflowv2/control.go
@@ -1,0 +1,284 @@
+package workflowv2
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	typesv2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
+	"github.com/google/uuid"
+)
+
+type Attempt struct {
+	ID        string    `json:"id"`
+	RunID     string    `json:"run_id"`
+	ClawID    string    `json:"claw_id"`
+	Number    int       `json:"number"`
+	Status    string    `json:"status"`
+	StartedAt time.Time `json:"started_at"`
+}
+
+func (s *Store) StartAttempt(ctx context.Context, runID, clawID string) (Attempt, error) {
+	if s == nil || s.db == nil {
+		return Attempt{}, fmt.Errorf("workflow v2 store is not configured")
+	}
+	if strings.TrimSpace(runID) == "" || strings.TrimSpace(clawID) == "" {
+		return Attempt{}, fmt.Errorf("run id and claw id are required")
+	}
+	now := s.now().UTC()
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return Attempt{}, err
+	}
+	defer tx.Rollback()
+	var status string
+	if err := tx.QueryRowContext(ctx, `SELECT status FROM workflow_v2_runs WHERE id=?`, runID).Scan(&status); err != nil {
+		return Attempt{}, err
+	}
+	if status != string(RunActive) && status != string(RunSuspended) {
+		return Attempt{}, fmt.Errorf("cannot start attempt for %s run", status)
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE workflow_v2_attempts SET status='lost',finished_at=?,reason='superseded by a new attempt'
+		WHERE run_id=? AND status IN ('provisioning','active')`, now.UnixMilli(), runID); err != nil {
+		return Attempt{}, err
+	}
+	var number int
+	if err := tx.QueryRowContext(ctx, `SELECT COALESCE(MAX(number),0)+1 FROM workflow_v2_attempts WHERE run_id=?`, runID).Scan(&number); err != nil {
+		return Attempt{}, err
+	}
+	attempt := Attempt{ID: uuid.NewString(), RunID: runID, ClawID: clawID, Number: number, Status: "active", StartedAt: now}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO workflow_v2_attempts(id,run_id,claw_id,number,status,started_at,heartbeat_at)
+		VALUES(?,?,?,?,?,?,?)`, attempt.ID, runID, clawID, number, attempt.Status, now.UnixMilli(), now.UnixMilli()); err != nil {
+		return Attempt{}, err
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE workflow_v2_runs SET current_attempt_id=?,updated_at=? WHERE id=?`,
+		attempt.ID, now.UnixMilli(), runID); err != nil {
+		return Attempt{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return Attempt{}, err
+	}
+	return attempt, nil
+}
+
+func (s *Store) AuthorizeControlAttempt(ctx context.Context, runID, attemptID, clawID, tenantID string) error {
+	var found int
+	err := s.db.QueryRowContext(ctx, `SELECT 1 FROM workflow_v2_attempts a JOIN workflow_v2_runs r ON r.id=a.run_id
+		WHERE r.id=? AND r.tenant_id=? AND r.current_attempt_id=? AND a.id=? AND a.claw_id=? AND a.status='active'`,
+		runID, tenantID, attemptID, attemptID, clawID).Scan(&found)
+	if errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("active workflow attempt not found")
+	}
+	return err
+}
+
+func (s *Store) Snapshot(ctx context.Context, runID, attemptID string) (typesv2.WorkflowSnapshot, error) {
+	run, err := s.GetRun(ctx, runID)
+	if err != nil {
+		return typesv2.WorkflowSnapshot{}, err
+	}
+	snapshot := typesv2.WorkflowSnapshot{RunID: run.ID, AttemptID: attemptID, State: run.State,
+		DisplayPhase: run.DisplayPhase, StateVersion: run.StateVersion}
+	if run.CurrentTaskID != "" {
+		var task typesv2.AgentTask
+		var status string
+		var allowedJSON, artifactsJSON string
+		var heartbeat, deadline int64
+		err := s.db.QueryRowContext(ctx, `SELECT id,run_id,attempt_id,state,state_version,status,instructions,
+			allowed_actions,required_artifacts,heartbeat_deadline,deadline FROM workflow_v2_agent_tasks
+			WHERE id=? AND run_id=?`, run.CurrentTaskID, runID).Scan(&task.ID, &task.RunID, &task.AttemptID,
+			&task.State, &task.StateVersion, &status, &task.Instructions, &allowedJSON, &artifactsJSON, &heartbeat, &deadline)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return typesv2.WorkflowSnapshot{}, err
+		}
+		if err == nil {
+			task.Status = typesv2.AgentTaskStatus(status)
+			_ = json.Unmarshal([]byte(allowedJSON), &task.AllowedActions)
+			_ = json.Unmarshal([]byte(artifactsJSON), &task.RequiredArtifacts)
+			task.HeartbeatDeadline = time.UnixMilli(heartbeat).UTC()
+			task.Deadline = time.UnixMilli(deadline).UTC()
+			snapshot.CurrentTask = &task
+			snapshot.AllowedActions = append([]string(nil), task.AllowedActions...)
+			snapshot.RequiredArtifacts = append([]string(nil), task.RequiredArtifacts...)
+		}
+	}
+	if run.ContextBundleID != "" {
+		var ref typesv2.ContextBundleRef
+		if err := s.db.QueryRowContext(ctx, `SELECT id,revision FROM workflow_v2_context_bundles WHERE id=? AND run_id=?`,
+			run.ContextBundleID, runID).Scan(&ref.ID, &ref.Revision); err == nil {
+			snapshot.ContextBundle = &ref
+		} else if !errors.Is(err, sql.ErrNoRows) {
+			return typesv2.WorkflowSnapshot{}, err
+		}
+	}
+	rows, err := s.db.QueryContext(ctx, `SELECT id,url,repository,repository_name,pr_number,source_branch,base_branch,
+		current_head_sha,state,supersedes_id,verified_at,provenance_json FROM workflow_v2_delivery_prs
+		WHERE run_id=? AND active=1 ORDER BY repository,pr_number`, runID)
+	if err != nil {
+		return typesv2.WorkflowSnapshot{}, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var pr typesv2.VerifiedPullRequest
+		var verified int64
+		var provenanceJSON string
+		if err := rows.Scan(&pr.ID, &pr.URL, &pr.Repository, &pr.RepositoryName, &pr.Number, &pr.SourceBranch,
+			&pr.BaseBranch, &pr.HeadSHA, &pr.State, &pr.Supersedes, &verified, &provenanceJSON); err != nil {
+			return typesv2.WorkflowSnapshot{}, err
+		}
+		pr.VerifiedAt = time.UnixMilli(verified).UTC()
+		_ = json.Unmarshal([]byte(provenanceJSON), &pr.Provenance)
+		snapshot.Delivery = append(snapshot.Delivery, pr)
+	}
+	return snapshot, rows.Err()
+}
+
+func (s *Store) EnqueueControl(ctx context.Context, envelope typesv2.ControlEnvelope) error {
+	if err := typesv2.ValidateControlEnvelope(envelope, typesv2.DirectionHubToClaw); err != nil {
+		return err
+	}
+	raw, err := json.Marshal(envelope)
+	if err != nil {
+		return err
+	}
+	now := s.now().UTC().UnixMilli()
+	_, err = s.db.ExecContext(ctx, `INSERT INTO workflow_v2_control_outbox(
+		message_id,run_id,attempt_id,task_id,kind,envelope_json,status,next_attempt_at,created_at,updated_at)
+		VALUES(?,?,?,?,?,?,'pending',0,?,?) ON CONFLICT(message_id) DO NOTHING`, envelope.MessageID,
+		envelope.RunID, envelope.AttemptID, envelope.TaskID, string(envelope.Kind), string(raw), now, now)
+	return err
+}
+
+func (s *Store) ReadyControl(ctx context.Context, runID, attemptID string, limit int) ([]typesv2.ControlEnvelope, error) {
+	if limit <= 0 || limit > 100 {
+		limit = 100
+	}
+	now := s.now().UTC().UnixMilli()
+	rows, err := s.db.QueryContext(ctx, `SELECT envelope_json FROM workflow_v2_control_outbox
+		WHERE run_id=? AND attempt_id=? AND status IN ('pending','sent') AND next_attempt_at<=?
+		ORDER BY created_at,message_id LIMIT ?`, runID, attemptID, now, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var result []typesv2.ControlEnvelope
+	for rows.Next() {
+		var raw string
+		if err := rows.Scan(&raw); err != nil {
+			return nil, err
+		}
+		var envelope typesv2.ControlEnvelope
+		if err := json.Unmarshal([]byte(raw), &envelope); err != nil {
+			return nil, err
+		}
+		result = append(result, envelope)
+	}
+	return result, rows.Err()
+}
+
+func (s *Store) MarkControlSent(ctx context.Context, messageID string) error {
+	now := s.now().UTC()
+	_, err := s.db.ExecContext(ctx, `UPDATE workflow_v2_control_outbox SET status='sent',attempt_count=attempt_count+1,
+		next_attempt_at=?,updated_at=? WHERE message_id=? AND status IN ('pending','sent')`,
+		now.Add(5*time.Second).UnixMilli(), now.UnixMilli(), messageID)
+	return err
+}
+
+func (s *Store) AcknowledgeControl(ctx context.Context, runID, attemptID string, receipt typesv2.ControlReceipt) error {
+	if strings.TrimSpace(receipt.MessageID) == "" {
+		return fmt.Errorf("message id is required")
+	}
+	now := s.now().UTC().UnixMilli()
+	result, err := s.db.ExecContext(ctx, `UPDATE workflow_v2_control_outbox SET status='acknowledged',acknowledged_at=?,updated_at=?
+		WHERE message_id=? AND run_id=? AND attempt_id=? AND status IN ('pending','sent')`,
+		now, now, receipt.MessageID, runID, attemptID)
+	if err != nil {
+		return err
+	}
+	changed, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if changed != 1 {
+		return fmt.Errorf("control message is not pending for this attempt")
+	}
+	return nil
+}
+
+func (s *Store) ApplyAgentControl(ctx context.Context, envelope typesv2.ControlEnvelope) (typesv2.ControlReceipt, error) {
+	if err := typesv2.ValidateControlEnvelope(envelope, typesv2.DirectionClawToHub); err != nil {
+		return typesv2.ControlReceipt{}, err
+	}
+	var active int
+	if err := s.db.QueryRowContext(ctx, `SELECT 1 FROM workflow_v2_attempts a JOIN workflow_v2_runs r ON r.id=a.run_id
+		WHERE r.id=? AND r.current_attempt_id=? AND a.id=? AND a.status='active'`, envelope.RunID,
+		envelope.AttemptID, envelope.AttemptID).Scan(&active); errors.Is(err, sql.ErrNoRows) {
+		return typesv2.ControlReceipt{}, fmt.Errorf("control envelope attempt is no longer active")
+	} else if err != nil {
+		return typesv2.ControlReceipt{}, err
+	}
+	var payload map[string]interface{}
+	if len(envelope.Payload) > 0 {
+		if err := json.Unmarshal(envelope.Payload, &payload); err != nil {
+			return typesv2.ControlReceipt{}, fmt.Errorf("decode control payload: %w", err)
+		}
+	}
+	result, err := s.ApplyEvent(ctx, envelope.RunID, EventInput{
+		ID: envelope.MessageID, MessageID: envelope.MessageID, Kind: string(envelope.Kind),
+		ExpectedStateVersion: envelope.ExpectedStateVersion, Producer: ProducerAgent, Payload: payload,
+		Provenance: typesv2.EvidenceProvenance{Producer: string(ProducerAgent), ObservedAt: s.now().UTC()},
+	})
+	if err != nil {
+		return typesv2.ControlReceipt{}, err
+	}
+	if (result.Disposition == typesv2.DispositionAccepted || result.Disposition == typesv2.DispositionDuplicate) && envelope.TaskID != "" {
+		if err := s.updateTaskFromControl(ctx, envelope); err != nil {
+			return typesv2.ControlReceipt{}, err
+		}
+	}
+	return typesv2.ControlReceipt{MessageID: envelope.MessageID, Disposition: result.Disposition,
+		StateVersion: result.Run.StateVersion, Reason: result.Reason}, nil
+}
+
+func (s *Store) updateTaskFromControl(ctx context.Context, envelope typesv2.ControlEnvelope) error {
+	now := s.now().UTC()
+	status := ""
+	finished := int64(0)
+	switch envelope.Kind {
+	case typesv2.MessageAgentTaskStarted:
+		status = string(typesv2.AgentTaskRunning)
+	case typesv2.MessageAgentTaskHeartbeat:
+		_, err := s.db.ExecContext(ctx, `UPDATE workflow_v2_agent_tasks SET last_heartbeat_at=?,heartbeat_deadline=?,updated_at=?
+			WHERE id=? AND run_id=? AND attempt_id=? AND status IN ('assigned','running')`, now.UnixMilli(),
+			now.Add(2*time.Minute).UnixMilli(), now.UnixMilli(), envelope.TaskID, envelope.RunID, envelope.AttemptID)
+		if err == nil {
+			_, err = s.db.ExecContext(ctx, `UPDATE workflow_v2_attempts SET heartbeat_at=? WHERE id=? AND run_id=? AND status='active'`,
+				now.UnixMilli(), envelope.AttemptID, envelope.RunID)
+		}
+		return err
+	case typesv2.MessageAgentTaskCompleted:
+		status, finished = string(typesv2.AgentTaskCompleted), now.UnixMilli()
+	case typesv2.MessageAgentTaskFailed:
+		status, finished = string(typesv2.AgentTaskFailed), now.UnixMilli()
+	default:
+		return nil
+	}
+	result, err := s.db.ExecContext(ctx, `UPDATE workflow_v2_agent_tasks SET status=?,last_heartbeat_at=?,updated_at=?,finished_at=?
+		WHERE id=? AND run_id=? AND attempt_id=? AND status IN ('assigned','running')`, status, now.UnixMilli(),
+		now.UnixMilli(), finished, envelope.TaskID, envelope.RunID, envelope.AttemptID)
+	if err != nil {
+		return err
+	}
+	changed, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if changed == 0 && envelope.Kind != typesv2.MessageAgentTaskCompleted && envelope.Kind != typesv2.MessageAgentTaskFailed {
+		return fmt.Errorf("active task not found")
+	}
+	return nil
+}

--- a/pkg/hub/workflowv2/control.go
+++ b/pkg/hub/workflowv2/control.go
@@ -336,7 +336,7 @@ func authorizeBoundAttempt(ctx context.Context, tx *sql.Tx, run Run, input Event
 	if input.AttemptID == "" {
 		return nil
 	}
-	if input.Producer != ProducerAgent || run.CurrentAttemptID != input.AttemptID {
+	if run.CurrentAttemptID != input.AttemptID {
 		return fmt.Errorf("control envelope attempt is no longer active")
 	}
 	var active int

--- a/pkg/hub/workflowv2/control.go
+++ b/pkg/hub/workflowv2/control.go
@@ -235,7 +235,9 @@ func (s *Store) ApplyAgentControl(ctx context.Context, envelope typesv2.ControlE
 	if err != nil {
 		return typesv2.ControlReceipt{}, err
 	}
-	if (result.Disposition == typesv2.DispositionAccepted || result.Disposition == typesv2.DispositionDuplicate) && envelope.TaskID != "" {
+	updateTask := result.Disposition == typesv2.DispositionAccepted ||
+		(result.Disposition == typesv2.DispositionDuplicate && envelope.Kind != typesv2.MessageAgentTaskHeartbeat)
+	if updateTask && envelope.TaskID != "" {
 		if err := s.updateTaskFromControl(ctx, envelope); err != nil {
 			return typesv2.ControlReceipt{}, err
 		}

--- a/pkg/hub/workflowv2/control.go
+++ b/pkg/hub/workflowv2/control.go
@@ -141,16 +141,43 @@ func (s *Store) EnqueueControl(ctx context.Context, envelope typesv2.ControlEnve
 	if err := typesv2.ValidateControlEnvelope(envelope, typesv2.DirectionHubToClaw); err != nil {
 		return err
 	}
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	var currentAttempt string
+	var currentVersion uint64
+	var runStatus string
+	if err := tx.QueryRowContext(ctx, `SELECT current_attempt_id,state_version,status FROM workflow_v2_runs WHERE id=?`,
+		envelope.RunID).Scan(&currentAttempt, &currentVersion, &runStatus); err != nil {
+		return err
+	}
+	if runStatus != string(RunActive) && runStatus != string(RunSuspended) {
+		return fmt.Errorf("cannot enqueue control for %s run", runStatus)
+	}
+	if envelope.AttemptID == "" {
+		envelope.AttemptID = currentAttempt
+	}
+	if envelope.AttemptID == "" || envelope.AttemptID != currentAttempt {
+		return fmt.Errorf("control envelope does not target the current attempt")
+	}
+	if envelope.ExpectedStateVersion != nil && *envelope.ExpectedStateVersion != currentVersion {
+		return fmt.Errorf("control envelope state version %d is stale; current version is %d",
+			*envelope.ExpectedStateVersion, currentVersion)
+	}
 	raw, err := json.Marshal(envelope)
 	if err != nil {
 		return err
 	}
 	now := s.now().UTC().UnixMilli()
-	_, err = s.db.ExecContext(ctx, `INSERT INTO workflow_v2_control_outbox(
+	if _, err := tx.ExecContext(ctx, `INSERT INTO workflow_v2_control_outbox(
 		message_id,run_id,attempt_id,task_id,kind,envelope_json,status,next_attempt_at,created_at,updated_at)
 		VALUES(?,?,?,?,?,?,'pending',0,?,?) ON CONFLICT(message_id) DO NOTHING`, envelope.MessageID,
-		envelope.RunID, envelope.AttemptID, envelope.TaskID, string(envelope.Kind), string(raw), now, now)
-	return err
+		envelope.RunID, envelope.AttemptID, envelope.TaskID, string(envelope.Kind), string(raw), now, now); err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 func (s *Store) ReadyControl(ctx context.Context, runID, attemptID string, limit int) ([]typesv2.ControlEnvelope, error) {
@@ -213,13 +240,8 @@ func (s *Store) ApplyAgentControl(ctx context.Context, envelope typesv2.ControlE
 	if err := typesv2.ValidateControlEnvelope(envelope, typesv2.DirectionClawToHub); err != nil {
 		return typesv2.ControlReceipt{}, err
 	}
-	var active int
-	if err := s.db.QueryRowContext(ctx, `SELECT 1 FROM workflow_v2_attempts a JOIN workflow_v2_runs r ON r.id=a.run_id
-		WHERE r.id=? AND r.current_attempt_id=? AND a.id=? AND a.status='active'`, envelope.RunID,
-		envelope.AttemptID, envelope.AttemptID).Scan(&active); errors.Is(err, sql.ErrNoRows) {
-		return typesv2.ControlReceipt{}, fmt.Errorf("control envelope attempt is no longer active")
-	} else if err != nil {
-		return typesv2.ControlReceipt{}, err
+	if envelope.Kind == typesv2.MessageDeliverySubmitted || envelope.Kind == typesv2.MessagePullRequestClaimed {
+		return typesv2.ControlReceipt{}, fmt.Errorf("delivery claims require trusted source-control verification")
 	}
 	var payload map[string]interface{}
 	if len(envelope.Payload) > 0 {
@@ -229,38 +251,85 @@ func (s *Store) ApplyAgentControl(ctx context.Context, envelope typesv2.ControlE
 	}
 	result, err := s.ApplyEvent(ctx, envelope.RunID, EventInput{
 		ID: envelope.MessageID, MessageID: envelope.MessageID, Kind: string(envelope.Kind),
+		AttemptID: envelope.AttemptID, TaskID: envelope.TaskID,
 		ExpectedStateVersion: envelope.ExpectedStateVersion, Producer: ProducerAgent, Payload: payload,
 		Provenance: typesv2.EvidenceProvenance{Producer: string(ProducerAgent), ObservedAt: s.now().UTC()},
 	})
 	if err != nil {
 		return typesv2.ControlReceipt{}, err
 	}
-	updateTask := result.Disposition == typesv2.DispositionAccepted ||
-		(result.Disposition == typesv2.DispositionDuplicate && envelope.Kind != typesv2.MessageAgentTaskHeartbeat)
-	if updateTask && envelope.TaskID != "" {
-		if err := s.updateTaskFromControl(ctx, envelope); err != nil {
-			return typesv2.ControlReceipt{}, err
-		}
-	}
 	return typesv2.ControlReceipt{MessageID: envelope.MessageID, Disposition: result.Disposition,
 		StateVersion: result.Run.StateVersion, Reason: result.Reason}, nil
 }
 
-func (s *Store) updateTaskFromControl(ctx context.Context, envelope typesv2.ControlEnvelope) error {
-	now := s.now().UTC()
+func authorizeBoundAttempt(ctx context.Context, tx *sql.Tx, run Run, input EventInput) error {
+	if input.AttemptID == "" {
+		return nil
+	}
+	if input.Producer != ProducerAgent || run.CurrentAttemptID != input.AttemptID {
+		return fmt.Errorf("control envelope attempt is no longer active")
+	}
+	var active int
+	if err := tx.QueryRowContext(ctx, `SELECT 1 FROM workflow_v2_attempts
+		WHERE id=? AND run_id=? AND status='active'`, input.AttemptID, run.ID).Scan(&active); errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("control envelope attempt is no longer active")
+	} else if err != nil {
+		return err
+	}
+	return nil
+}
+
+func authorizeBoundTask(ctx context.Context, tx *sql.Tx, run Run, input EventInput) error {
+	if input.TaskID == "" {
+		return nil
+	}
+	if input.Producer != ProducerAgent || run.CurrentTaskID != input.TaskID {
+		return fmt.Errorf("control envelope does not name the current task")
+	}
+	var taskVersion uint64
+	var taskStatus string
+	err := tx.QueryRowContext(ctx, `SELECT state_version,status FROM workflow_v2_agent_tasks
+		WHERE id=? AND run_id=? AND attempt_id=?`, input.TaskID, run.ID, input.AttemptID).Scan(&taskVersion, &taskStatus)
+	if errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("control envelope does not name the current task")
+	}
+	if err != nil {
+		return err
+	}
+	if input.ExpectedStateVersion != nil && *input.ExpectedStateVersion != taskVersion {
+		return fmt.Errorf("control envelope state version does not match assigned task")
+	}
+	if taskStatus != string(typesv2.AgentTaskAssigned) && taskStatus != string(typesv2.AgentTaskRunning) {
+		return fmt.Errorf("task status %q does not accept control messages", taskStatus)
+	}
+	return nil
+}
+
+func updateBoundTask(ctx context.Context, tx *sql.Tx, runID string, input EventInput, now time.Time) error {
+	if input.TaskID == "" {
+		return nil
+	}
 	status := ""
 	finished := int64(0)
-	switch envelope.Kind {
+	switch typesv2.ControlMessageKind(input.Kind) {
 	case typesv2.MessageAgentTaskStarted:
 		status = string(typesv2.AgentTaskRunning)
 	case typesv2.MessageAgentTaskHeartbeat:
-		_, err := s.db.ExecContext(ctx, `UPDATE workflow_v2_agent_tasks SET last_heartbeat_at=?,heartbeat_deadline=?,updated_at=?
+		result, err := tx.ExecContext(ctx, `UPDATE workflow_v2_agent_tasks SET last_heartbeat_at=?,heartbeat_deadline=?,updated_at=?
 			WHERE id=? AND run_id=? AND attempt_id=? AND status IN ('assigned','running')`, now.UnixMilli(),
-			now.Add(2*time.Minute).UnixMilli(), now.UnixMilli(), envelope.TaskID, envelope.RunID, envelope.AttemptID)
-		if err == nil {
-			_, err = s.db.ExecContext(ctx, `UPDATE workflow_v2_attempts SET heartbeat_at=? WHERE id=? AND run_id=? AND status='active'`,
-				now.UnixMilli(), envelope.AttemptID, envelope.RunID)
+			now.Add(2*time.Minute).UnixMilli(), now.UnixMilli(), input.TaskID, runID, input.AttemptID)
+		if err != nil {
+			return err
 		}
+		changed, err := result.RowsAffected()
+		if err != nil {
+			return err
+		}
+		if changed != 1 {
+			return fmt.Errorf("active task not found")
+		}
+		_, err = tx.ExecContext(ctx, `UPDATE workflow_v2_attempts SET heartbeat_at=? WHERE id=? AND run_id=? AND status='active'`,
+			now.UnixMilli(), input.AttemptID, runID)
 		return err
 	case typesv2.MessageAgentTaskCompleted:
 		status, finished = string(typesv2.AgentTaskCompleted), now.UnixMilli()
@@ -269,9 +338,9 @@ func (s *Store) updateTaskFromControl(ctx context.Context, envelope typesv2.Cont
 	default:
 		return nil
 	}
-	result, err := s.db.ExecContext(ctx, `UPDATE workflow_v2_agent_tasks SET status=?,last_heartbeat_at=?,updated_at=?,finished_at=?
-		WHERE id=? AND run_id=? AND attempt_id=? AND status IN ('assigned','running')`, status, now.UnixMilli(),
-		now.UnixMilli(), finished, envelope.TaskID, envelope.RunID, envelope.AttemptID)
+	result, err := tx.ExecContext(ctx, `UPDATE workflow_v2_agent_tasks SET status=?,last_heartbeat_at=?,updated_at=?,finished_at=?
+		WHERE id=? AND run_id=? AND attempt_id=? AND status IN ('assigned','running')`, status, now.UnixMilli(), now.UnixMilli(), finished,
+		input.TaskID, runID, input.AttemptID)
 	if err != nil {
 		return err
 	}
@@ -279,7 +348,7 @@ func (s *Store) updateTaskFromControl(ctx context.Context, envelope typesv2.Cont
 	if err != nil {
 		return err
 	}
-	if changed == 0 && envelope.Kind != typesv2.MessageAgentTaskCompleted && envelope.Kind != typesv2.MessageAgentTaskFailed {
+	if changed != 1 {
 		return fmt.Errorf("active task not found")
 	}
 	return nil

--- a/pkg/hub/workflowv2/control_test.go
+++ b/pkg/hub/workflowv2/control_test.go
@@ -123,6 +123,47 @@ func TestAgentControlIsTypedDeduplicatedAndAttemptBound(t *testing.T) {
 	}
 }
 
+func TestDuplicateHeartbeatDoesNotExtendTaskLiveness(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	current := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+	store.SetClock(func() time.Time { return current })
+	createRuntimeRun(t, store, "run-heartbeat-replay")
+	attempt, err := store.StartAttempt(context.Background(), "run-heartbeat-replay", "claw-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO workflow_v2_agent_tasks(
+		id,run_id,effect_id,attempt_id,state,state_version,status,instructions,heartbeat_deadline,deadline,created_at,updated_at)
+		VALUES(?,?,?,?,?,?,'running',?,?,?,?,?)`, "task-heartbeat", "run-heartbeat-replay", "", attempt.ID, "building", 1,
+		"implement", current.Add(time.Minute).UnixMilli(), current.Add(time.Hour).UnixMilli(), current.UnixMilli(), current.UnixMilli()); err != nil {
+		t.Fatal(err)
+	}
+	envelope := typesv2.ControlEnvelope{ProtocolVersion: typesv2.ControlProtocolVersion, MessageID: "heartbeat-1",
+		Kind: typesv2.MessageAgentTaskHeartbeat, RunID: "run-heartbeat-replay", AttemptID: attempt.ID,
+		TaskID: "task-heartbeat", Payload: json.RawMessage(`{"task":{"heartbeat":true}}`)}
+	first, err := store.ApplyAgentControl(context.Background(), envelope)
+	if err != nil || first.Disposition != typesv2.DispositionAccepted {
+		t.Fatalf("first heartbeat = %#v, %v", first, err)
+	}
+	var firstDeadline int64
+	if err := db.QueryRow(`SELECT heartbeat_deadline FROM workflow_v2_agent_tasks WHERE id='task-heartbeat'`).Scan(&firstDeadline); err != nil {
+		t.Fatal(err)
+	}
+	current = current.Add(30 * time.Second)
+	duplicate, err := store.ApplyAgentControl(context.Background(), envelope)
+	if err != nil || duplicate.Disposition != typesv2.DispositionDuplicate {
+		t.Fatalf("duplicate heartbeat = %#v, %v", duplicate, err)
+	}
+	var replayedDeadline int64
+	if err := db.QueryRow(`SELECT heartbeat_deadline FROM workflow_v2_agent_tasks WHERE id='task-heartbeat'`).Scan(&replayedDeadline); err != nil {
+		t.Fatal(err)
+	}
+	if replayedDeadline != firstDeadline {
+		t.Fatalf("duplicate heartbeat extended deadline from %d to %d", firstDeadline, replayedDeadline)
+	}
+}
+
 func TestStartingNewAttemptInvalidatesOldControlIdentity(t *testing.T) {
 	db := openRuntimeDB(t)
 	store := workflowv2.NewStore(db)

--- a/pkg/hub/workflowv2/control_test.go
+++ b/pkg/hub/workflowv2/control_test.go
@@ -139,6 +139,9 @@ func TestDuplicateHeartbeatDoesNotExtendTaskLiveness(t *testing.T) {
 		"implement", current.Add(time.Minute).UnixMilli(), current.Add(time.Hour).UnixMilli(), current.UnixMilli(), current.UnixMilli()); err != nil {
 		t.Fatal(err)
 	}
+	if _, err := db.Exec(`UPDATE workflow_v2_runs SET current_task_id=? WHERE id=?`, "task-heartbeat", "run-heartbeat-replay"); err != nil {
+		t.Fatal(err)
+	}
 	envelope := typesv2.ControlEnvelope{ProtocolVersion: typesv2.ControlProtocolVersion, MessageID: "heartbeat-1",
 		Kind: typesv2.MessageAgentTaskHeartbeat, RunID: "run-heartbeat-replay", AttemptID: attempt.ID,
 		TaskID: "task-heartbeat", Payload: json.RawMessage(`{"task":{"heartbeat":true}}`)}
@@ -191,6 +194,146 @@ func TestStartingNewAttemptInvalidatesOldControlIdentity(t *testing.T) {
 		TaskID: "old-task", Payload: json.RawMessage(`{"task":{"heartbeat":true}}`),
 	}); err == nil {
 		t.Fatal("superseded attempt was allowed to submit a control envelope")
+	}
+}
+
+func TestAgentControlMustNameCurrentTask(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	createRuntimeRun(t, store, "run-current-task")
+	attempt, err := store.StartAttempt(context.Background(), "run-current-task", "claw-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	if _, err := db.Exec(`INSERT INTO workflow_v2_agent_tasks(
+		id,run_id,effect_id,attempt_id,state,state_version,status,instructions,heartbeat_deadline,deadline,created_at,updated_at)
+		VALUES(?,?,?,?,?,?,'assigned',?,?,?,?,?)`, "task-current", "run-current-task", "", attempt.ID, "building", 1,
+		"implement", now.Add(2*time.Minute).UnixMilli(), now.Add(time.Hour).UnixMilli(), now.UnixMilli(), now.UnixMilli()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`UPDATE workflow_v2_runs SET current_task_id=? WHERE id=?`, "task-current", "run-current-task"); err != nil {
+		t.Fatal(err)
+	}
+	version := uint64(1)
+	_, err = store.ApplyAgentControl(context.Background(), typesv2.ControlEnvelope{
+		ProtocolVersion: typesv2.ControlProtocolVersion, MessageID: "wrong-task-complete",
+		Kind: typesv2.MessageAgentTaskCompleted, RunID: "run-current-task", AttemptID: attempt.ID,
+		TaskID: "task-invented", ExpectedStateVersion: &version,
+		Payload: json.RawMessage(`{"task":{"result":"success"}}`),
+	})
+	if err == nil {
+		t.Fatal("control message for an invented task was accepted")
+	}
+	run, err := store.GetRun(context.Background(), "run-current-task")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.StateVersion != 1 || run.State != "building" {
+		t.Fatalf("run changed after rejected control: %#v", run)
+	}
+}
+
+func TestAgentControlRollsBackEventWhenTaskUpdateFails(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	createRuntimeRun(t, store, "run-atomic-control")
+	attempt, err := store.StartAttempt(context.Background(), "run-atomic-control", "claw-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	if _, err := db.Exec(`INSERT INTO workflow_v2_agent_tasks(
+		id,run_id,effect_id,attempt_id,state,state_version,status,instructions,heartbeat_deadline,deadline,created_at,updated_at)
+		VALUES(?,?,?,?,?,?,'assigned',?,?,?,?,?)`, "task-atomic", "run-atomic-control", "", attempt.ID, "building", 1,
+		"implement", now.Add(2*time.Minute).UnixMilli(), now.Add(time.Hour).UnixMilli(), now.UnixMilli(), now.UnixMilli()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`UPDATE workflow_v2_runs SET current_task_id=? WHERE id=?`, "task-atomic", "run-atomic-control"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TRIGGER reject_task_completion BEFORE UPDATE OF status ON workflow_v2_agent_tasks
+		WHEN NEW.id='task-atomic' AND NEW.status='completed' BEGIN SELECT RAISE(ABORT, 'simulated task write failure'); END`); err != nil {
+		t.Fatal(err)
+	}
+	version := uint64(1)
+	_, err = store.ApplyAgentControl(context.Background(), typesv2.ControlEnvelope{
+		ProtocolVersion: typesv2.ControlProtocolVersion, MessageID: "atomic-complete",
+		Kind: typesv2.MessageAgentTaskCompleted, RunID: "run-atomic-control", AttemptID: attempt.ID,
+		TaskID: "task-atomic", ExpectedStateVersion: &version,
+		Payload: json.RawMessage(`{"task":{"result":"success"}}`),
+	})
+	if err == nil {
+		t.Fatal("simulated task write failure did not fail control application")
+	}
+	run, err := store.GetRun(context.Background(), "run-atomic-control")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.StateVersion != 1 || run.State != "building" {
+		t.Fatalf("run advanced despite failed task update: %#v", run)
+	}
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_events WHERE id='atomic-complete'`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatalf("event persisted despite failed task update: %d", count)
+	}
+}
+
+func TestDeliveryControlRequiresTrustedVerificationPath(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	createRuntimeRun(t, store, "run-unverified-delivery")
+	attempt, err := store.StartAttempt(context.Background(), "run-unverified-delivery", "claw-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	version := uint64(1)
+	_, err = store.ApplyAgentControl(context.Background(), typesv2.ControlEnvelope{
+		ProtocolVersion: typesv2.ControlProtocolVersion, MessageID: "unverified-delivery",
+		Kind: typesv2.MessageDeliverySubmitted, RunID: "run-unverified-delivery", AttemptID: attempt.ID,
+		ExpectedStateVersion: &version, Payload: json.RawMessage(`{"delivery":{"pull_requests":[]}}`),
+	})
+	if err == nil {
+		t.Fatal("unverified delivery entered through the generic control path")
+	}
+	run, err := store.GetRun(context.Background(), "run-unverified-delivery")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.StateVersion != 1 || run.State != "building" {
+		t.Fatalf("run changed after rejected delivery: %#v", run)
+	}
+}
+
+func TestControlOutboxRejectsSupersededAttempt(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	createRuntimeRun(t, store, "run-stale-assignment")
+	first, err := store.StartAttempt(context.Background(), "run-stale-assignment", "claw-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.StartAttempt(context.Background(), "run-stale-assignment", "claw-2"); err != nil {
+		t.Fatal(err)
+	}
+	version := uint64(1)
+	err = store.EnqueueControl(context.Background(), typesv2.ControlEnvelope{
+		ProtocolVersion: typesv2.ControlProtocolVersion, MessageID: "stale-assignment",
+		Kind: typesv2.MessageAgentTaskAssign, RunID: "run-stale-assignment", AttemptID: first.ID,
+		TaskID: "task-old", ExpectedStateVersion: &version, Payload: json.RawMessage(`{"instructions":"old"}`),
+	})
+	if err == nil {
+		t.Fatal("control assignment for a superseded attempt was queued")
+	}
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_control_outbox WHERE run_id='run-stale-assignment'`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatalf("stale outbox rows = %d", count)
 	}
 }
 

--- a/pkg/hub/workflowv2/control_test.go
+++ b/pkg/hub/workflowv2/control_test.go
@@ -121,6 +121,13 @@ func TestAgentControlIsTypedDeduplicatedAndAttemptBound(t *testing.T) {
 	if taskStatus != string(typesv2.AgentTaskCompleted) {
 		t.Fatalf("task status = %q", taskStatus)
 	}
+	var currentTaskID string
+	if err := db.QueryRow(`SELECT current_task_id FROM workflow_v2_runs WHERE id='run-agent-control'`).Scan(&currentTaskID); err != nil {
+		t.Fatal(err)
+	}
+	if currentTaskID != "" {
+		t.Fatalf("terminal task remained current: %q", currentTaskID)
+	}
 }
 
 func TestDuplicateHeartbeatDoesNotExtendTaskLiveness(t *testing.T) {
@@ -194,6 +201,76 @@ func TestStartingNewAttemptInvalidatesOldControlIdentity(t *testing.T) {
 		TaskID: "old-task", Payload: json.RawMessage(`{"task":{"heartbeat":true}}`),
 	}); err == nil {
 		t.Fatal("superseded attempt was allowed to submit a control envelope")
+	}
+}
+
+func TestStartingNewAttemptReassignsCurrentTask(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	current := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+	store.SetClock(func() time.Time { return current })
+	createRuntimeRun(t, store, "run-task-reassign")
+	first, err := store.StartAttempt(context.Background(), "run-task-reassign", "claw-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO workflow_v2_agent_tasks(
+		id,run_id,effect_id,attempt_id,state,state_version,status,instructions,allowed_actions,required_artifacts,
+		heartbeat_deadline,deadline,created_at,updated_at) VALUES(?,?,?,?,?,?,'running',?,?,?,?,?,?,?)`,
+		"task-original", "run-task-reassign", "effect-1", first.ID, "building", 1, "implement", `["commit"]`, `["tests"]`,
+		current.Add(time.Minute).UnixMilli(), current.Add(time.Hour).UnixMilli(), current.UnixMilli(), current.UnixMilli()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`UPDATE workflow_v2_runs SET current_task_id='task-original' WHERE id='run-task-reassign'`); err != nil {
+		t.Fatal(err)
+	}
+	version := uint64(1)
+	if err := store.EnqueueControl(context.Background(), typesv2.ControlEnvelope{
+		ProtocolVersion: typesv2.ControlProtocolVersion, MessageID: "old-assignment", Kind: typesv2.MessageAgentTaskAssign,
+		RunID: "run-task-reassign", AttemptID: first.ID, TaskID: "task-original", ExpectedStateVersion: &version,
+		Payload: json.RawMessage(`{"instructions":"implement"}`),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	second, err := store.StartAttempt(context.Background(), "run-task-reassign", "claw-2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := store.GetRun(context.Background(), "run-task-reassign")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.CurrentAttemptID != second.ID || run.CurrentTaskID == "" || run.CurrentTaskID == "task-original" {
+		t.Fatalf("run after reassignment = %#v", run)
+	}
+	var oldStatus, oldOutboxStatus, newAttempt, newStatus string
+	if err := db.QueryRow(`SELECT status FROM workflow_v2_agent_tasks WHERE id='task-original'`).Scan(&oldStatus); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT status FROM workflow_v2_control_outbox WHERE message_id='old-assignment'`).Scan(&oldOutboxStatus); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT attempt_id,status FROM workflow_v2_agent_tasks WHERE id=?`, run.CurrentTaskID).Scan(
+		&newAttempt, &newStatus); err != nil {
+		t.Fatal(err)
+	}
+	if oldStatus != string(typesv2.AgentTaskCancelled) || oldOutboxStatus != "cancelled" ||
+		newAttempt != second.ID || newStatus != string(typesv2.AgentTaskAssigned) {
+		t.Fatalf("old/new task state = %s/%s/%s/%s", oldStatus, oldOutboxStatus, newAttempt, newStatus)
+	}
+	if ready, err := store.ReadyControl(context.Background(), "run-task-reassign", first.ID, 10); err != nil || len(ready) != 0 {
+		t.Fatalf("old attempt ready control = %#v, %v", ready, err)
+	}
+	ready, err := store.ReadyControl(context.Background(), "run-task-reassign", second.ID, 10)
+	if err != nil || len(ready) != 1 || ready[0].TaskID != run.CurrentTaskID {
+		t.Fatalf("replacement assignment = %#v, %v", ready, err)
+	}
+	if _, err := store.Snapshot(context.Background(), "run-task-reassign", first.ID); err == nil {
+		t.Fatal("superseded attempt received a snapshot")
+	}
+	snapshot, err := store.Snapshot(context.Background(), "run-task-reassign", second.ID)
+	if err != nil || snapshot.CurrentTask == nil || snapshot.CurrentTask.ID != run.CurrentTaskID {
+		t.Fatalf("replacement snapshot = %#v, %v", snapshot, err)
 	}
 }
 

--- a/pkg/hub/workflowv2/control_test.go
+++ b/pkg/hub/workflowv2/control_test.go
@@ -1,0 +1,238 @@
+package workflowv2_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	workflowv2 "github.com/elasticclaw/elasticclaw/pkg/hub/workflowv2"
+	typesv2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
+)
+
+func TestAttemptSnapshotAndControlOutbox(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	createRuntimeRun(t, store, "run-control")
+	attempt, err := store.StartAttempt(context.Background(), "run-control", "claw-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attempt.Number != 1 || attempt.Status != "active" {
+		t.Fatalf("attempt = %#v", attempt)
+	}
+	if err := store.AuthorizeControlAttempt(context.Background(), "run-control", attempt.ID, "claw-1", "tenant-1"); err != nil {
+		t.Fatalf("authorize active attempt: %v", err)
+	}
+	if err := store.AuthorizeControlAttempt(context.Background(), "run-control", attempt.ID, "other-claw", "tenant-1"); err == nil {
+		t.Fatal("different claw authorized for attempt")
+	}
+
+	version := uint64(1)
+	envelope := typesv2.ControlEnvelope{
+		ProtocolVersion:      typesv2.ControlProtocolVersion,
+		MessageID:            "assign-1",
+		Kind:                 typesv2.MessageAgentTaskAssign,
+		RunID:                "run-control",
+		AttemptID:            attempt.ID,
+		TaskID:               "task-1",
+		ExpectedStateVersion: &version,
+		Payload:              json.RawMessage(`{"instructions":"implement"}`),
+	}
+	if err := store.EnqueueControl(context.Background(), envelope); err != nil {
+		t.Fatal(err)
+	}
+	ready, err := store.ReadyControl(context.Background(), "run-control", attempt.ID, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ready) != 1 || ready[0].MessageID != envelope.MessageID {
+		t.Fatalf("ready = %#v", ready)
+	}
+	if err := store.MarkControlSent(context.Background(), envelope.MessageID); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AcknowledgeControl(context.Background(), "run-control", attempt.ID, typesv2.ControlReceipt{
+		MessageID: envelope.MessageID, Disposition: typesv2.DispositionAccepted, StateVersion: 1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	ready, err = store.ReadyControl(context.Background(), "run-control", attempt.ID, 10)
+	if err != nil || len(ready) != 0 {
+		t.Fatalf("ready after ack = %#v, %v", ready, err)
+	}
+
+	snapshot, err := store.Snapshot(context.Background(), "run-control", attempt.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.RunID != "run-control" || snapshot.AttemptID != attempt.ID || snapshot.StateVersion != 1 || snapshot.State != "building" {
+		t.Fatalf("snapshot = %#v", snapshot)
+	}
+}
+
+func TestAgentControlIsTypedDeduplicatedAndAttemptBound(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	createRuntimeRun(t, store, "run-agent-control")
+	attempt, err := store.StartAttempt(context.Background(), "run-agent-control", "claw-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	if _, err := db.Exec(`INSERT INTO workflow_v2_agent_tasks(
+		id,run_id,effect_id,attempt_id,state,state_version,status,instructions,heartbeat_deadline,deadline,created_at,updated_at)
+		VALUES(?,?,?,?,?,?,'assigned',?,?,?,?,?)`, "task-1", "run-agent-control", "", attempt.ID, "building", 1,
+		"implement", now.Add(2*time.Minute).UnixMilli(), now.Add(time.Hour).UnixMilli(), now.UnixMilli(), now.UnixMilli()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`UPDATE workflow_v2_runs SET current_task_id=? WHERE id=?`, "task-1", "run-agent-control"); err != nil {
+		t.Fatal(err)
+	}
+	version := uint64(1)
+	envelope := typesv2.ControlEnvelope{
+		ProtocolVersion:      typesv2.ControlProtocolVersion,
+		MessageID:            "completed-1",
+		Kind:                 typesv2.MessageAgentTaskCompleted,
+		RunID:                "run-agent-control",
+		AttemptID:            attempt.ID,
+		TaskID:               "task-1",
+		ExpectedStateVersion: &version,
+		Payload:              json.RawMessage(`{"task":{"result":"success"}}`),
+	}
+	receipt, err := store.ApplyAgentControl(context.Background(), envelope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Disposition != typesv2.DispositionAccepted || receipt.StateVersion != 2 {
+		t.Fatalf("receipt = %#v", receipt)
+	}
+	duplicate, err := store.ApplyAgentControl(context.Background(), envelope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if duplicate.Disposition != typesv2.DispositionDuplicate || duplicate.StateVersion != 2 {
+		t.Fatalf("duplicate = %#v", duplicate)
+	}
+	var taskStatus string
+	if err := db.QueryRow(`SELECT status FROM workflow_v2_agent_tasks WHERE id='task-1'`).Scan(&taskStatus); err != nil {
+		t.Fatal(err)
+	}
+	if taskStatus != string(typesv2.AgentTaskCompleted) {
+		t.Fatalf("task status = %q", taskStatus)
+	}
+}
+
+func TestStartingNewAttemptInvalidatesOldControlIdentity(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	createRuntimeRun(t, store, "run-attempt-replace")
+	first, err := store.StartAttempt(context.Background(), "run-attempt-replace", "claw-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := store.StartAttempt(context.Background(), "run-attempt-replace", "claw-2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.Number != 2 {
+		t.Fatalf("second attempt = %#v", second)
+	}
+	if err := store.AuthorizeControlAttempt(context.Background(), "run-attempt-replace", first.ID, "claw-1", "tenant-1"); err == nil {
+		t.Fatal("superseded attempt remained authorized")
+	}
+	if err := store.AuthorizeControlAttempt(context.Background(), "run-attempt-replace", second.ID, "claw-2", "tenant-1"); err != nil {
+		t.Fatalf("new attempt not authorized: %v", err)
+	}
+	if _, err := store.ApplyAgentControl(context.Background(), typesv2.ControlEnvelope{
+		ProtocolVersion: typesv2.ControlProtocolVersion, MessageID: "old-heartbeat",
+		Kind: typesv2.MessageAgentTaskHeartbeat, RunID: "run-attempt-replace", AttemptID: first.ID,
+		TaskID: "old-task", Payload: json.RawMessage(`{"task":{"heartbeat":true}}`),
+	}); err == nil {
+		t.Fatal("superseded attempt was allowed to submit a control envelope")
+	}
+}
+
+func TestMaterializeAgentTaskIsAtomicWithAssignmentAndEffect(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	current := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+	store.SetClock(func() time.Time { return current })
+	createRuntimeRun(t, store, "run-materialize")
+	attempt, err := store.StartAttempt(context.Background(), "run-materialize", "claw-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim, err := store.ClaimEffect(context.Background(), "task-worker", time.Minute)
+	if err != nil || claim == nil {
+		t.Fatalf("effect claim = %#v, %v", claim, err)
+	}
+	task, err := store.MaterializeAgentTask(context.Background(), claim.Effect.ID, claim.AttemptID,
+		"task-worker", 90*time.Second, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if task.AttemptID != attempt.ID || task.State != "building" || task.StateVersion != 1 || task.Instructions != "Implement the change." {
+		t.Fatalf("task = %#v", task)
+	}
+	var effectStatus, attemptStatus, currentTask string
+	if err := db.QueryRow(`SELECT status FROM workflow_v2_effects WHERE id=?`, claim.Effect.ID).Scan(&effectStatus); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT status FROM workflow_v2_effect_attempts WHERE id=?`, claim.AttemptID).Scan(&attemptStatus); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT current_task_id FROM workflow_v2_runs WHERE id='run-materialize'`).Scan(&currentTask); err != nil {
+		t.Fatal(err)
+	}
+	if effectStatus != "succeeded" || attemptStatus != "succeeded" || currentTask != task.ID {
+		t.Fatalf("effect/attempt/current task = %s/%s/%s", effectStatus, attemptStatus, currentTask)
+	}
+	ready, err := store.ReadyControl(context.Background(), "run-materialize", attempt.ID, 10)
+	if err != nil || len(ready) != 1 || ready[0].Kind != typesv2.MessageAgentTaskAssign || ready[0].TaskID != task.ID {
+		t.Fatalf("assignment = %#v, %v", ready, err)
+	}
+	var assigned typesv2.AgentTask
+	if err := json.Unmarshal(ready[0].Payload, &assigned); err != nil {
+		t.Fatal(err)
+	}
+	if assigned.ID != task.ID || assigned.Instructions != task.Instructions {
+		t.Fatalf("assigned task = %#v", assigned)
+	}
+}
+
+func TestAgentTaskDeadlineSuspendsRunForExplicitRecovery(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	current := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+	store.SetClock(func() time.Time { return current })
+	createRuntimeRun(t, store, "run-timeout")
+	_, err := store.StartAttempt(context.Background(), "run-timeout", "claw-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim, err := store.ClaimEffect(context.Background(), "task-worker", time.Minute)
+	if err != nil || claim == nil {
+		t.Fatalf("effect claim = %#v, %v", claim, err)
+	}
+	task, err := store.MaterializeAgentTask(context.Background(), claim.Effect.ID, claim.AttemptID,
+		"task-worker", time.Minute, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	current = current.Add(time.Minute + time.Millisecond)
+	expired, err := store.ExpireAgentTasks(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(expired) != 1 || expired[0] != task.ID {
+		t.Fatalf("expired = %#v", expired)
+	}
+	run, err := store.GetRun(context.Background(), "run-timeout")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.Status != workflowv2.RunSuspended || run.WaitingReason == "" {
+		t.Fatalf("run = %#v", run)
+	}
+}

--- a/pkg/hub/workflowv2/control_test.go
+++ b/pkg/hub/workflowv2/control_test.go
@@ -204,6 +204,37 @@ func TestStartingNewAttemptInvalidatesOldControlIdentity(t *testing.T) {
 	}
 }
 
+func TestAttemptBoundTrustedEventRejectsRevokedAttempt(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	createRuntimeRun(t, store, "run-revoked-trusted-event")
+	first, err := store.StartAttempt(context.Background(), "run-revoked-trusted-event", "claw-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.StartAttempt(context.Background(), "run-revoked-trusted-event", "claw-2"); err != nil {
+		t.Fatal(err)
+	}
+	_, err = store.ApplyEvent(context.Background(), "run-revoked-trusted-event", workflowv2.EventInput{
+		ID: "late-delivery-event", Kind: "delivery.verified", AttemptID: first.ID,
+		Producer: workflowv2.ProducerSourceControl,
+		Payload:  map[string]interface{}{"delivery": map[string]interface{}{"count": 1}},
+		Provenance: typesv2.EvidenceProvenance{
+			Producer: string(workflowv2.ProducerSourceControl), ObservedAt: time.Now().UTC(),
+		},
+	})
+	if err == nil {
+		t.Fatal("trusted event from revoked attempt was accepted")
+	}
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_events WHERE id='late-delivery-event'`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatalf("revoked event rows = %d", count)
+	}
+}
+
 func TestStartingNewAttemptReassignsCurrentTask(t *testing.T) {
 	db := openRuntimeDB(t)
 	store := workflowv2.NewStore(db)

--- a/pkg/hub/workflowv2/delivery.go
+++ b/pkg/hub/workflowv2/delivery.go
@@ -57,6 +57,7 @@ func (s *Store) SubmitDelivery(ctx context.Context, runID, attemptID string, man
 	}
 
 	verified := make([]typesv2.VerifiedPullRequest, 0, len(manifest.PullRequests))
+	trustedSupersedes := make(map[string]string)
 	claimsByURL := map[string]bool{}
 	identities := map[string]bool{}
 	for i, claim := range manifest.PullRequests {
@@ -81,7 +82,30 @@ func (s *Store) SubmitDelivery(ctx context.Context, runID, attemptID string, man
 			return nil, fmt.Errorf("pull_requests[%d] duplicates verified PR %s", i, identity)
 		}
 		identities[identity] = true
-		pr.Supersedes = strings.TrimSpace(claim.Supersedes)
+		if supersedes := strings.TrimSpace(claim.Supersedes); supersedes != "" {
+			var targetID, targetURL, targetHead string
+			err := s.db.QueryRowContext(ctx, `SELECT id,url,current_head_sha FROM workflow_v2_delivery_prs
+				WHERE run_id=? AND active=1 AND (id=? OR url=?)`, runID, supersedes, supersedes).Scan(&targetID, &targetURL, &targetHead)
+			if err != nil {
+				return nil, fmt.Errorf("verify pull_requests[%d] supersedes %q: active target not found", i, supersedes)
+			}
+			resolvedTarget, err := verifier.VerifyPullRequest(ctx, run, resolvedWorkspace.Workspace,
+				typesv2.PullRequestClaim{URL: targetURL})
+			if err != nil {
+				return nil, fmt.Errorf("verify pull_requests[%d] superseded target %s: %w", i, targetURL, err)
+			}
+			if err := validateVerifiedPullRequest(resolvedWorkspace.Workspace, typesv2.PullRequestClaim{URL: targetURL}, resolvedTarget); err != nil {
+				return nil, fmt.Errorf("verify pull_requests[%d] superseded target %s: %w", i, targetURL, err)
+			}
+			if resolvedTarget.State != "closed" && resolvedTarget.State != "merged" {
+				return nil, fmt.Errorf("verify pull_requests[%d] supersedes %q: target is still %s", i, supersedes, resolvedTarget.State)
+			}
+			if resolvedTarget.HeadSHA != targetHead {
+				return nil, fmt.Errorf("verify pull_requests[%d] supersedes %q: target head changed; reconcile it first", i, supersedes)
+			}
+			pr.Supersedes = targetID
+			trustedSupersedes[pr.Repository+"#"+fmt.Sprint(pr.Number)] = targetID
+		}
 		verified = append(verified, pr)
 	}
 
@@ -91,6 +115,10 @@ func (s *Store) SubmitDelivery(ctx context.Context, runID, attemptID string, man
 		return nil, err
 	}
 	defer tx.Rollback()
+	if err := tx.QueryRowContext(ctx, `SELECT 1 FROM workflow_v2_attempts a JOIN workflow_v2_runs r ON r.id=a.run_id
+		WHERE r.id=? AND r.current_attempt_id=? AND a.id=? AND a.status='active'`, runID, attemptID, attemptID).Scan(&activeAttempt); err != nil {
+		return nil, fmt.Errorf("delivery attempt was superseded during verification")
+	}
 	for i := range verified {
 		pr := &verified[i]
 		var existingID, existingHead string
@@ -138,8 +166,13 @@ func (s *Store) SubmitDelivery(ctx context.Context, runID, attemptID string, man
 			}
 		}
 		if pr.Supersedes != "" {
+			identity := pr.Repository + "#" + fmt.Sprint(pr.Number)
+			if trustedSupersedes[identity] != pr.Supersedes {
+				return nil, fmt.Errorf("superseded pull request was not trusted by the verifier")
+			}
 			result, err := tx.ExecContext(ctx, `UPDATE workflow_v2_delivery_prs SET active=0,updated_at=?
-				WHERE run_id=? AND active=1 AND id!=? AND (id=? OR url=?)`, now.UnixMilli(), runID, pr.ID, pr.Supersedes, pr.Supersedes)
+				WHERE run_id=? AND active=1 AND id!=? AND id=? AND state IN ('closed','merged')`,
+				now.UnixMilli(), runID, pr.ID, pr.Supersedes)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/hub/workflowv2/delivery.go
+++ b/pkg/hub/workflowv2/delivery.go
@@ -1,0 +1,225 @@
+package workflowv2
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+
+	typesv2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
+	"github.com/google/uuid"
+)
+
+type PullRequestVerifier interface {
+	VerifyPullRequest(context.Context, Run, *typesv2.Workspace, typesv2.PullRequestClaim) (typesv2.VerifiedPullRequest, error)
+}
+
+type PullRequestVerifierFunc func(context.Context, Run, *typesv2.Workspace,
+	typesv2.PullRequestClaim) (typesv2.VerifiedPullRequest, error)
+
+func (f PullRequestVerifierFunc) VerifyPullRequest(ctx context.Context, run Run, workspace *typesv2.Workspace,
+	claim typesv2.PullRequestClaim) (typesv2.VerifiedPullRequest, error) {
+	return f(ctx, run, workspace, claim)
+}
+
+// SubmitDelivery verifies every untrusted PR claim before atomically amending
+// the run-owned delivery collection. Workflows never declare repository lists;
+// authority comes solely from the pinned workspace repository map.
+func (s *Store) SubmitDelivery(ctx context.Context, runID, attemptID string, manifest typesv2.DeliveryManifest,
+	verifier PullRequestVerifier) ([]typesv2.VerifiedPullRequest, error) {
+	if s == nil || s.db == nil {
+		return nil, fmt.Errorf("workflow v2 store is not configured")
+	}
+	if verifier == nil && len(manifest.PullRequests) > 0 {
+		return nil, fmt.Errorf("pull request verifier is required")
+	}
+	if len(manifest.PullRequests) > 100 {
+		return nil, fmt.Errorf("delivery manifest exceeds 100 pull requests")
+	}
+	run, err := s.GetRun(ctx, runID)
+	if err != nil {
+		return nil, err
+	}
+	var activeAttempt int
+	if err := s.db.QueryRowContext(ctx, `SELECT 1 FROM workflow_v2_attempts WHERE id=? AND run_id=? AND status='active'`,
+		attemptID, runID).Scan(&activeAttempt); err != nil || run.CurrentAttemptID != attemptID {
+		return nil, fmt.Errorf("delivery attempt is not active")
+	}
+	var workspaceYAML string
+	if err := s.db.QueryRowContext(ctx, `SELECT workspace_yaml FROM workflow_v2_runs WHERE id=?`, runID).Scan(&workspaceYAML); err != nil {
+		return nil, err
+	}
+	resolvedWorkspace, err := typesv2.ParseAndValidateWorkspace([]byte(workspaceYAML))
+	if err != nil {
+		return nil, fmt.Errorf("load pinned workspace: %w", err)
+	}
+
+	verified := make([]typesv2.VerifiedPullRequest, 0, len(manifest.PullRequests))
+	claimsByURL := map[string]bool{}
+	identities := map[string]bool{}
+	for i, claim := range manifest.PullRequests {
+		claim.URL = strings.TrimSpace(claim.URL)
+		parsed, err := url.Parse(claim.URL)
+		if err != nil || (parsed.Scheme != "https" && parsed.Scheme != "http") || parsed.Host == "" {
+			return nil, fmt.Errorf("pull_requests[%d].url is not an absolute HTTP(S) URL", i)
+		}
+		if claimsByURL[claim.URL] {
+			return nil, fmt.Errorf("pull_requests[%d].url is duplicated", i)
+		}
+		claimsByURL[claim.URL] = true
+		pr, err := verifier.VerifyPullRequest(ctx, run, resolvedWorkspace.Workspace, claim)
+		if err != nil {
+			return nil, fmt.Errorf("verify pull_requests[%d] %s: %w", i, claim.URL, err)
+		}
+		if err := validateVerifiedPullRequest(resolvedWorkspace.Workspace, claim, pr); err != nil {
+			return nil, fmt.Errorf("verify pull_requests[%d] %s: %w", i, claim.URL, err)
+		}
+		identity := pr.Repository + "#" + fmt.Sprint(pr.Number)
+		if identities[identity] {
+			return nil, fmt.Errorf("pull_requests[%d] duplicates verified PR %s", i, identity)
+		}
+		identities[identity] = true
+		pr.Supersedes = strings.TrimSpace(claim.Supersedes)
+		verified = append(verified, pr)
+	}
+
+	now := s.now().UTC()
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+	for i := range verified {
+		pr := &verified[i]
+		var existingID, existingHead string
+		err := tx.QueryRowContext(ctx, `SELECT id,current_head_sha FROM workflow_v2_delivery_prs
+			WHERE run_id=? AND repository=? AND pr_number=?`, runID, pr.Repository, pr.Number).Scan(&existingID, &existingHead)
+		if err != nil && err != sql.ErrNoRows {
+			return nil, err
+		}
+		if existingID == "" {
+			pr.ID = uuid.NewString()
+		} else {
+			pr.ID = existingID
+		}
+		provenanceJSON, err := marshalObject(pr.Provenance)
+		if err != nil {
+			return nil, err
+		}
+		_, err = tx.ExecContext(ctx, `INSERT INTO workflow_v2_delivery_prs(
+			id,run_id,url,repository_name,repository,pr_number,source_branch,base_branch,current_head_sha,state,
+			active,supersedes_id,provenance_json,verified_at,updated_at) VALUES(?,?,?,?,?,?,?,?,?,?,1,?,?,?,?)
+			ON CONFLICT(run_id,repository,pr_number) DO UPDATE SET url=excluded.url,repository_name=excluded.repository_name,
+			source_branch=excluded.source_branch,base_branch=excluded.base_branch,current_head_sha=excluded.current_head_sha,
+			state=excluded.state,active=1,supersedes_id=excluded.supersedes_id,provenance_json=excluded.provenance_json,
+			verified_at=excluded.verified_at,updated_at=excluded.updated_at`,
+			pr.ID, runID, pr.URL, pr.RepositoryName, pr.Repository, pr.Number, pr.SourceBranch, pr.BaseBranch,
+			pr.HeadSHA, pr.State, pr.Supersedes, provenanceJSON, pr.VerifiedAt.UnixMilli(), now.UnixMilli())
+		if err != nil {
+			return nil, err
+		}
+		if existingHead != pr.HeadSHA {
+			var generation int
+			if err := tx.QueryRowContext(ctx, `SELECT COALESCE(MAX(generation),0)+1 FROM workflow_v2_delivery_heads WHERE pr_id=?`,
+				pr.ID).Scan(&generation); err != nil {
+				return nil, err
+			}
+			if _, err := tx.ExecContext(ctx, `INSERT INTO workflow_v2_delivery_heads(id,pr_id,head_sha,generation,observed_at)
+				VALUES(?,?,?,?,?)`, uuid.NewString(), pr.ID, pr.HeadSHA, generation, now.UnixMilli()); err != nil {
+				return nil, err
+			}
+			if existingHead != "" {
+				if _, err := tx.ExecContext(ctx, `UPDATE workflow_v2_evidence SET superseded_at=?
+					WHERE run_id=? AND pr_id=? AND head_sha=? AND superseded_at=0`, now.UnixMilli(), runID, pr.ID, existingHead); err != nil {
+					return nil, err
+				}
+			}
+		}
+		if pr.Supersedes != "" {
+			result, err := tx.ExecContext(ctx, `UPDATE workflow_v2_delivery_prs SET active=0,updated_at=?
+				WHERE run_id=? AND active=1 AND id!=? AND (id=? OR url=?)`, now.UnixMilli(), runID, pr.ID, pr.Supersedes, pr.Supersedes)
+			if err != nil {
+				return nil, err
+			}
+			if changed, err := result.RowsAffected(); err != nil || changed != 1 {
+				return nil, fmt.Errorf("superseded pull request %q is not an active delivery", pr.Supersedes)
+			}
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+
+	summary, err := s.deliveryFacts(ctx, runID)
+	if err != nil {
+		return nil, err
+	}
+	eventResult, err := s.ApplyEvent(ctx, runID, EventInput{
+		ID: uuid.NewString(), Kind: "delivery.verified", Producer: ProducerSourceControl,
+		Payload: map[string]interface{}{"delivery": summary},
+		Facts: map[string]interface{}{
+			"delivery.count": summary["count"], "delivery.open": summary["open"],
+			"delivery.merged": summary["merged"], "delivery.all_merged": summary["all_merged"],
+		},
+		Provenance: typesv2.EvidenceProvenance{Producer: string(ProducerSourceControl), ObservedAt: now},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if eventResult.Disposition != typesv2.DispositionAccepted {
+		return nil, fmt.Errorf("delivery verification event was %s: %s", eventResult.Disposition, eventResult.Reason)
+	}
+	policyResult, err := s.EvaluateDeliveryPolicy(ctx, runID)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.publishEvidencePolicyEvents(ctx, runID, "", policyResult, now); err != nil {
+		return nil, err
+	}
+	sort.Slice(verified, func(i, j int) bool {
+		if verified[i].Repository == verified[j].Repository {
+			return verified[i].Number < verified[j].Number
+		}
+		return verified[i].Repository < verified[j].Repository
+	})
+	return verified, nil
+}
+
+func validateVerifiedPullRequest(workspace *typesv2.Workspace, claim typesv2.PullRequestClaim,
+	pr typesv2.VerifiedPullRequest) error {
+	repo, ok := workspace.Repositories[pr.RepositoryName]
+	if !ok {
+		return fmt.Errorf("repository name %q is not in pinned workspace", pr.RepositoryName)
+	}
+	if repo.Repository != pr.Repository {
+		return fmt.Errorf("repository %q does not match workspace repository %q", pr.Repository, repo.Repository)
+	}
+	if pr.Number <= 0 || strings.TrimSpace(pr.URL) == "" || strings.TrimSpace(pr.HeadSHA) == "" ||
+		strings.TrimSpace(pr.SourceBranch) == "" || strings.TrimSpace(pr.BaseBranch) == "" {
+		return fmt.Errorf("verified pull request identity, branches, and head SHA are required")
+	}
+	if pr.State != "open" && pr.State != "closed" && pr.State != "merged" {
+		return fmt.Errorf("verified pull request state %q is invalid", pr.State)
+	}
+	if strings.TrimSpace(pr.Provenance.Producer) != string(ProducerSourceControl) || pr.Provenance.ObservedAt.IsZero() || pr.VerifiedAt.IsZero() {
+		return fmt.Errorf("verified pull request requires trusted source-control provenance")
+	}
+	if claim.URL != pr.URL {
+		return fmt.Errorf("verified URL %q does not match claimed URL", pr.URL)
+	}
+	return nil
+}
+
+func (s *Store) deliveryFacts(ctx context.Context, runID string) (map[string]interface{}, error) {
+	var count, open, merged int
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*),
+		COALESCE(SUM(CASE WHEN state='open' THEN 1 ELSE 0 END),0),
+		COALESCE(SUM(CASE WHEN state='merged' THEN 1 ELSE 0 END),0)
+		FROM workflow_v2_delivery_prs WHERE run_id=? AND active=1`, runID).Scan(&count, &open, &merged); err != nil {
+		return nil, err
+	}
+	return map[string]interface{}{"count": count, "open": open, "merged": merged,
+		"all_merged": count > 0 && merged == count}, nil
+}

--- a/pkg/hub/workflowv2/delivery.go
+++ b/pkg/hub/workflowv2/delivery.go
@@ -118,94 +118,83 @@ func (s *Store) SubmitDelivery(ctx context.Context, runID, attemptID string, man
 	}
 
 	now := s.now().UTC()
-	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
-	if err != nil {
-		return nil, err
-	}
-	defer tx.Rollback()
-	if err := tx.QueryRowContext(ctx, `SELECT 1 FROM workflow_v2_attempts a JOIN workflow_v2_runs r ON r.id=a.run_id
-		WHERE r.id=? AND r.current_attempt_id=? AND a.id=? AND a.status='active'`, runID, attemptID, attemptID).Scan(&activeAttempt); err != nil {
-		return nil, fmt.Errorf("delivery attempt was superseded during verification")
-	}
-	for i := range verified {
-		pr := &verified[i]
-		var existingID, existingHead string
-		err := tx.QueryRowContext(ctx, `SELECT id,current_head_sha FROM workflow_v2_delivery_prs
-			WHERE run_id=? AND repository=? AND pr_number=?`, runID, pr.Repository, pr.Number).Scan(&existingID, &existingHead)
-		if err != nil && err != sql.ErrNoRows {
-			return nil, err
-		}
-		if existingID == "" {
-			pr.ID = uuid.NewString()
-		} else {
-			pr.ID = existingID
-		}
-		provenanceJSON, err := marshalObject(pr.Provenance)
-		if err != nil {
-			return nil, err
-		}
-		_, err = tx.ExecContext(ctx, `INSERT INTO workflow_v2_delivery_prs(
-			id,run_id,url,repository_name,repository,pr_number,source_branch,base_branch,current_head_sha,state,
-			active,supersedes_id,provenance_json,verified_at,updated_at) VALUES(?,?,?,?,?,?,?,?,?,?,1,?,?,?,?)
-			ON CONFLICT(run_id,repository,pr_number) DO UPDATE SET url=excluded.url,repository_name=excluded.repository_name,
-			source_branch=excluded.source_branch,base_branch=excluded.base_branch,current_head_sha=excluded.current_head_sha,
-			state=excluded.state,active=1,supersedes_id=excluded.supersedes_id,provenance_json=excluded.provenance_json,
-			verified_at=excluded.verified_at,updated_at=excluded.updated_at`,
-			pr.ID, runID, pr.URL, pr.RepositoryName, pr.Repository, pr.Number, pr.SourceBranch, pr.BaseBranch,
-			pr.HeadSHA, pr.State, pr.Supersedes, provenanceJSON, pr.VerifiedAt.UnixMilli(), now.UnixMilli())
-		if err != nil {
-			return nil, err
-		}
-		if existingHead != pr.HeadSHA {
-			var generation int
-			if err := tx.QueryRowContext(ctx, `SELECT COALESCE(MAX(generation),0)+1 FROM workflow_v2_delivery_heads WHERE pr_id=?`,
-				pr.ID).Scan(&generation); err != nil {
-				return nil, err
+	eventResult, err := s.applyEventWithMutation(ctx, runID, EventInput{
+		ID: uuid.NewString(), Kind: "delivery.verified", AttemptID: attemptID, Producer: ProducerSourceControl,
+		Provenance: typesv2.EvidenceProvenance{Producer: string(ProducerSourceControl), ObservedAt: now},
+	}, func(ctx context.Context, tx *sql.Tx, input *EventInput) error {
+		for i := range verified {
+			pr := &verified[i]
+			var existingID, existingHead string
+			err := tx.QueryRowContext(ctx, `SELECT id,current_head_sha FROM workflow_v2_delivery_prs
+				WHERE run_id=? AND repository=? AND pr_number=?`, runID, pr.Repository, pr.Number).Scan(&existingID, &existingHead)
+			if err != nil && err != sql.ErrNoRows {
+				return err
 			}
-			if _, err := tx.ExecContext(ctx, `INSERT INTO workflow_v2_delivery_heads(id,pr_id,head_sha,generation,observed_at)
-				VALUES(?,?,?,?,?)`, uuid.NewString(), pr.ID, pr.HeadSHA, generation, now.UnixMilli()); err != nil {
-				return nil, err
+			if existingID == "" {
+				pr.ID = uuid.NewString()
+			} else {
+				pr.ID = existingID
 			}
-			if existingHead != "" {
-				if _, err := tx.ExecContext(ctx, `UPDATE workflow_v2_evidence SET superseded_at=?
-					WHERE run_id=? AND pr_id=? AND superseded_at=0`, now.UnixMilli(), runID, pr.ID); err != nil {
-					return nil, err
+			provenanceJSON, err := marshalObject(pr.Provenance)
+			if err != nil {
+				return err
+			}
+			_, err = tx.ExecContext(ctx, `INSERT INTO workflow_v2_delivery_prs(
+				id,run_id,url,repository_name,repository,pr_number,source_branch,base_branch,current_head_sha,state,
+				active,supersedes_id,provenance_json,verified_at,updated_at) VALUES(?,?,?,?,?,?,?,?,?,?,1,?,?,?,?)
+				ON CONFLICT(run_id,repository,pr_number) DO UPDATE SET url=excluded.url,repository_name=excluded.repository_name,
+				source_branch=excluded.source_branch,base_branch=excluded.base_branch,current_head_sha=excluded.current_head_sha,
+				state=excluded.state,active=1,supersedes_id=excluded.supersedes_id,provenance_json=excluded.provenance_json,
+				verified_at=excluded.verified_at,updated_at=excluded.updated_at`,
+				pr.ID, runID, pr.URL, pr.RepositoryName, pr.Repository, pr.Number, pr.SourceBranch, pr.BaseBranch,
+				pr.HeadSHA, pr.State, pr.Supersedes, provenanceJSON, pr.VerifiedAt.UnixMilli(), now.UnixMilli())
+			if err != nil {
+				return err
+			}
+			if existingHead != pr.HeadSHA {
+				var generation int
+				if err := tx.QueryRowContext(ctx, `SELECT COALESCE(MAX(generation),0)+1 FROM workflow_v2_delivery_heads WHERE pr_id=?`,
+					pr.ID).Scan(&generation); err != nil {
+					return err
+				}
+				if _, err := tx.ExecContext(ctx, `INSERT INTO workflow_v2_delivery_heads(id,pr_id,head_sha,generation,observed_at)
+					VALUES(?,?,?,?,?)`, uuid.NewString(), pr.ID, pr.HeadSHA, generation, now.UnixMilli()); err != nil {
+					return err
+				}
+				if existingHead != "" {
+					if _, err := tx.ExecContext(ctx, `UPDATE workflow_v2_evidence SET superseded_at=?
+						WHERE run_id=? AND pr_id=? AND superseded_at=0`, now.UnixMilli(), runID, pr.ID); err != nil {
+						return err
+					}
+				}
+			}
+			if pr.Supersedes != "" {
+				identity := pr.Repository + "#" + fmt.Sprint(pr.Number)
+				trusted, ok := trustedSupersedes[identity]
+				if !ok || trusted.ID != pr.Supersedes {
+					return fmt.Errorf("superseded pull request was not trusted by the verifier")
+				}
+				result, err := tx.ExecContext(ctx, `UPDATE workflow_v2_delivery_prs SET active=0,updated_at=?
+					WHERE run_id=? AND active=1 AND id!=? AND id=? AND current_head_sha=? AND state=?`,
+					now.UnixMilli(), runID, pr.ID, trusted.ID, trusted.HeadSHA, trusted.State)
+				if err != nil {
+					return err
+				}
+				if changed, err := result.RowsAffected(); err != nil || changed != 1 {
+					return fmt.Errorf("superseded pull request %q is not an active delivery", pr.Supersedes)
 				}
 			}
 		}
-		if pr.Supersedes != "" {
-			identity := pr.Repository + "#" + fmt.Sprint(pr.Number)
-			trusted, ok := trustedSupersedes[identity]
-			if !ok || trusted.ID != pr.Supersedes {
-				return nil, fmt.Errorf("superseded pull request was not trusted by the verifier")
-			}
-			result, err := tx.ExecContext(ctx, `UPDATE workflow_v2_delivery_prs SET active=0,updated_at=?
-				WHERE run_id=? AND active=1 AND id!=? AND id=? AND current_head_sha=? AND state=?`,
-				now.UnixMilli(), runID, pr.ID, trusted.ID, trusted.HeadSHA, trusted.State)
-			if err != nil {
-				return nil, err
-			}
-			if changed, err := result.RowsAffected(); err != nil || changed != 1 {
-				return nil, fmt.Errorf("superseded pull request %q is not an active delivery", pr.Supersedes)
-			}
+		summary, err := deliveryFactsFrom(ctx, tx, runID)
+		if err != nil {
+			return err
 		}
-	}
-	if err := tx.Commit(); err != nil {
-		return nil, err
-	}
-
-	summary, err := s.deliveryFacts(ctx, runID)
-	if err != nil {
-		return nil, err
-	}
-	eventResult, err := s.ApplyEvent(ctx, runID, EventInput{
-		ID: uuid.NewString(), Kind: "delivery.verified", AttemptID: attemptID, Producer: ProducerSourceControl,
-		Payload: map[string]interface{}{"delivery": summary},
-		Facts: map[string]interface{}{
+		input.Payload = map[string]interface{}{"delivery": summary}
+		input.Facts = map[string]interface{}{
 			"delivery.count": summary["count"], "delivery.open": summary["open"],
 			"delivery.merged": summary["merged"], "delivery.all_merged": summary["all_merged"],
-		},
-		Provenance: typesv2.EvidenceProvenance{Producer: string(ProducerSourceControl), ObservedAt: now},
+		}
+		return nil
 	})
 	if err != nil {
 		return nil, err
@@ -217,7 +206,7 @@ func (s *Store) SubmitDelivery(ctx context.Context, runID, attemptID string, man
 	if err != nil {
 		return nil, err
 	}
-	if err := s.publishEvidencePolicyEvents(ctx, runID, attemptID, "", policyResult, now); err != nil {
+	if err := s.publishEvidencePolicyEvents(ctx, runID, "", "", policyResult, now); err != nil {
 		return nil, err
 	}
 	sort.Slice(verified, func(i, j int) bool {
@@ -254,9 +243,13 @@ func validateVerifiedPullRequest(workspace *typesv2.Workspace, claim typesv2.Pul
 	return nil
 }
 
-func (s *Store) deliveryFacts(ctx context.Context, runID string) (map[string]interface{}, error) {
+type rowQueryer interface {
+	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+}
+
+func deliveryFactsFrom(ctx context.Context, queryer rowQueryer, runID string) (map[string]interface{}, error) {
 	var count, open, merged int
-	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*),
+	if err := queryer.QueryRowContext(ctx, `SELECT COUNT(*),
 		COALESCE(SUM(CASE WHEN state='open' THEN 1 ELSE 0 END),0),
 		COALESCE(SUM(CASE WHEN state='merged' THEN 1 ELSE 0 END),0)
 		FROM workflow_v2_delivery_prs WHERE run_id=? AND active=1`, runID).Scan(&count, &open, &merged); err != nil {

--- a/pkg/hub/workflowv2/delivery.go
+++ b/pkg/hub/workflowv2/delivery.go
@@ -156,7 +156,7 @@ func (s *Store) SubmitDelivery(ctx context.Context, runID, attemptID string, man
 	if eventResult.Disposition != typesv2.DispositionAccepted {
 		return nil, fmt.Errorf("delivery verification event was %s: %s", eventResult.Disposition, eventResult.Reason)
 	}
-	if _, err := s.evaluateAndPublishDeliveryPolicy(ctx, runID, "", "", now); err != nil {
+	if _, err := s.evaluateAndPublishDeliveryPolicy(ctx, runID, attemptID, "", now); err != nil {
 		return nil, err
 	}
 	sort.Slice(verified, func(i, j int) bool {

--- a/pkg/hub/workflowv2/delivery.go
+++ b/pkg/hub/workflowv2/delivery.go
@@ -160,7 +160,7 @@ func (s *Store) SubmitDelivery(ctx context.Context, runID, attemptID string, man
 			}
 			if existingHead != "" {
 				if _, err := tx.ExecContext(ctx, `UPDATE workflow_v2_evidence SET superseded_at=?
-					WHERE run_id=? AND pr_id=? AND head_sha=? AND superseded_at=0`, now.UnixMilli(), runID, pr.ID, existingHead); err != nil {
+					WHERE run_id=? AND pr_id=? AND superseded_at=0`, now.UnixMilli(), runID, pr.ID); err != nil {
 					return nil, err
 				}
 			}
@@ -254,5 +254,5 @@ func (s *Store) deliveryFacts(ctx context.Context, runID string) (map[string]int
 		return nil, err
 	}
 	return map[string]interface{}{"count": count, "open": open, "merged": merged,
-		"all_merged": count > 0 && merged == count}, nil
+		"all_merged": merged == count}, nil
 }

--- a/pkg/hub/workflowv2/delivery.go
+++ b/pkg/hub/workflowv2/delivery.go
@@ -19,6 +19,12 @@ type PullRequestVerifier interface {
 type PullRequestVerifierFunc func(context.Context, Run, *typesv2.Workspace,
 	typesv2.PullRequestClaim) (typesv2.VerifiedPullRequest, error)
 
+type verifiedSupersession struct {
+	ID      string
+	HeadSHA string
+	State   string
+}
+
 func (f PullRequestVerifierFunc) VerifyPullRequest(ctx context.Context, run Run, workspace *typesv2.Workspace,
 	claim typesv2.PullRequestClaim) (typesv2.VerifiedPullRequest, error) {
 	return f(ctx, run, workspace, claim)
@@ -57,7 +63,7 @@ func (s *Store) SubmitDelivery(ctx context.Context, runID, attemptID string, man
 	}
 
 	verified := make([]typesv2.VerifiedPullRequest, 0, len(manifest.PullRequests))
-	trustedSupersedes := make(map[string]string)
+	trustedSupersedes := make(map[string]verifiedSupersession)
 	claimsByURL := map[string]bool{}
 	identities := map[string]bool{}
 	for i, claim := range manifest.PullRequests {
@@ -104,7 +110,9 @@ func (s *Store) SubmitDelivery(ctx context.Context, runID, attemptID string, man
 				return nil, fmt.Errorf("verify pull_requests[%d] supersedes %q: target head changed; reconcile it first", i, supersedes)
 			}
 			pr.Supersedes = targetID
-			trustedSupersedes[pr.Repository+"#"+fmt.Sprint(pr.Number)] = targetID
+			trustedSupersedes[pr.Repository+"#"+fmt.Sprint(pr.Number)] = verifiedSupersession{
+				ID: targetID, HeadSHA: resolvedTarget.HeadSHA, State: resolvedTarget.State,
+			}
 		}
 		verified = append(verified, pr)
 	}
@@ -167,12 +175,13 @@ func (s *Store) SubmitDelivery(ctx context.Context, runID, attemptID string, man
 		}
 		if pr.Supersedes != "" {
 			identity := pr.Repository + "#" + fmt.Sprint(pr.Number)
-			if trustedSupersedes[identity] != pr.Supersedes {
+			trusted, ok := trustedSupersedes[identity]
+			if !ok || trusted.ID != pr.Supersedes {
 				return nil, fmt.Errorf("superseded pull request was not trusted by the verifier")
 			}
 			result, err := tx.ExecContext(ctx, `UPDATE workflow_v2_delivery_prs SET active=0,updated_at=?
-				WHERE run_id=? AND active=1 AND id!=? AND id=? AND state IN ('closed','merged')`,
-				now.UnixMilli(), runID, pr.ID, pr.Supersedes)
+				WHERE run_id=? AND active=1 AND id!=? AND id=? AND current_head_sha=? AND state=?`,
+				now.UnixMilli(), runID, pr.ID, trusted.ID, trusted.HeadSHA, trusted.State)
 			if err != nil {
 				return nil, err
 			}
@@ -190,7 +199,7 @@ func (s *Store) SubmitDelivery(ctx context.Context, runID, attemptID string, man
 		return nil, err
 	}
 	eventResult, err := s.ApplyEvent(ctx, runID, EventInput{
-		ID: uuid.NewString(), Kind: "delivery.verified", Producer: ProducerSourceControl,
+		ID: uuid.NewString(), Kind: "delivery.verified", AttemptID: attemptID, Producer: ProducerSourceControl,
 		Payload: map[string]interface{}{"delivery": summary},
 		Facts: map[string]interface{}{
 			"delivery.count": summary["count"], "delivery.open": summary["open"],
@@ -208,7 +217,7 @@ func (s *Store) SubmitDelivery(ctx context.Context, runID, attemptID string, man
 	if err != nil {
 		return nil, err
 	}
-	if err := s.publishEvidencePolicyEvents(ctx, runID, "", policyResult, now); err != nil {
+	if err := s.publishEvidencePolicyEvents(ctx, runID, attemptID, "", policyResult, now); err != nil {
 		return nil, err
 	}
 	sort.Slice(verified, func(i, j int) bool {

--- a/pkg/hub/workflowv2/delivery.go
+++ b/pkg/hub/workflowv2/delivery.go
@@ -19,12 +19,6 @@ type PullRequestVerifier interface {
 type PullRequestVerifierFunc func(context.Context, Run, *typesv2.Workspace,
 	typesv2.PullRequestClaim) (typesv2.VerifiedPullRequest, error)
 
-type verifiedSupersession struct {
-	ID      string
-	HeadSHA string
-	State   string
-}
-
 func (f PullRequestVerifierFunc) VerifyPullRequest(ctx context.Context, run Run, workspace *typesv2.Workspace,
 	claim typesv2.PullRequestClaim) (typesv2.VerifiedPullRequest, error) {
 	return f(ctx, run, workspace, claim)
@@ -63,11 +57,13 @@ func (s *Store) SubmitDelivery(ctx context.Context, runID, attemptID string, man
 	}
 
 	verified := make([]typesv2.VerifiedPullRequest, 0, len(manifest.PullRequests))
-	trustedSupersedes := make(map[string]verifiedSupersession)
 	claimsByURL := map[string]bool{}
 	identities := map[string]bool{}
 	for i, claim := range manifest.PullRequests {
 		claim.URL = strings.TrimSpace(claim.URL)
+		if strings.TrimSpace(claim.Supersedes) != "" {
+			return nil, fmt.Errorf("pull_requests[%d].supersedes requires hub-owned source-control reconciliation", i)
+		}
 		parsed, err := url.Parse(claim.URL)
 		if err != nil || (parsed.Scheme != "https" && parsed.Scheme != "http") || parsed.Host == "" {
 			return nil, fmt.Errorf("pull_requests[%d].url is not an absolute HTTP(S) URL", i)
@@ -88,32 +84,6 @@ func (s *Store) SubmitDelivery(ctx context.Context, runID, attemptID string, man
 			return nil, fmt.Errorf("pull_requests[%d] duplicates verified PR %s", i, identity)
 		}
 		identities[identity] = true
-		if supersedes := strings.TrimSpace(claim.Supersedes); supersedes != "" {
-			var targetID, targetURL, targetHead string
-			err := s.db.QueryRowContext(ctx, `SELECT id,url,current_head_sha FROM workflow_v2_delivery_prs
-				WHERE run_id=? AND active=1 AND (id=? OR url=?)`, runID, supersedes, supersedes).Scan(&targetID, &targetURL, &targetHead)
-			if err != nil {
-				return nil, fmt.Errorf("verify pull_requests[%d] supersedes %q: active target not found", i, supersedes)
-			}
-			resolvedTarget, err := verifier.VerifyPullRequest(ctx, run, resolvedWorkspace.Workspace,
-				typesv2.PullRequestClaim{URL: targetURL})
-			if err != nil {
-				return nil, fmt.Errorf("verify pull_requests[%d] superseded target %s: %w", i, targetURL, err)
-			}
-			if err := validateVerifiedPullRequest(resolvedWorkspace.Workspace, typesv2.PullRequestClaim{URL: targetURL}, resolvedTarget); err != nil {
-				return nil, fmt.Errorf("verify pull_requests[%d] superseded target %s: %w", i, targetURL, err)
-			}
-			if resolvedTarget.State != "closed" && resolvedTarget.State != "merged" {
-				return nil, fmt.Errorf("verify pull_requests[%d] supersedes %q: target is still %s", i, supersedes, resolvedTarget.State)
-			}
-			if resolvedTarget.HeadSHA != targetHead {
-				return nil, fmt.Errorf("verify pull_requests[%d] supersedes %q: target head changed; reconcile it first", i, supersedes)
-			}
-			pr.Supersedes = targetID
-			trustedSupersedes[pr.Repository+"#"+fmt.Sprint(pr.Number)] = verifiedSupersession{
-				ID: targetID, HeadSHA: resolvedTarget.HeadSHA, State: resolvedTarget.State,
-			}
-		}
 		verified = append(verified, pr)
 	}
 
@@ -168,22 +138,6 @@ func (s *Store) SubmitDelivery(ctx context.Context, runID, attemptID string, man
 					}
 				}
 			}
-			if pr.Supersedes != "" {
-				identity := pr.Repository + "#" + fmt.Sprint(pr.Number)
-				trusted, ok := trustedSupersedes[identity]
-				if !ok || trusted.ID != pr.Supersedes {
-					return fmt.Errorf("superseded pull request was not trusted by the verifier")
-				}
-				result, err := tx.ExecContext(ctx, `UPDATE workflow_v2_delivery_prs SET active=0,updated_at=?
-					WHERE run_id=? AND active=1 AND id!=? AND id=? AND current_head_sha=? AND state=?`,
-					now.UnixMilli(), runID, pr.ID, trusted.ID, trusted.HeadSHA, trusted.State)
-				if err != nil {
-					return err
-				}
-				if changed, err := result.RowsAffected(); err != nil || changed != 1 {
-					return fmt.Errorf("superseded pull request %q is not an active delivery", pr.Supersedes)
-				}
-			}
 		}
 		summary, err := deliveryFactsFrom(ctx, tx, runID)
 		if err != nil {
@@ -202,11 +156,7 @@ func (s *Store) SubmitDelivery(ctx context.Context, runID, attemptID string, man
 	if eventResult.Disposition != typesv2.DispositionAccepted {
 		return nil, fmt.Errorf("delivery verification event was %s: %s", eventResult.Disposition, eventResult.Reason)
 	}
-	policyResult, err := s.EvaluateDeliveryPolicy(ctx, runID)
-	if err != nil {
-		return nil, err
-	}
-	if err := s.publishEvidencePolicyEvents(ctx, runID, "", "", policyResult, now); err != nil {
+	if _, err := s.evaluateAndPublishDeliveryPolicy(ctx, runID, "", "", now); err != nil {
 		return nil, err
 	}
 	sort.Slice(verified, func(i, j int) bool {

--- a/pkg/hub/workflowv2/delivery_test.go
+++ b/pkg/hub/workflowv2/delivery_test.go
@@ -109,6 +109,41 @@ func TestSubmitDeliveryRejectsAnyRepositoryOutsidePinnedWorkspaceAtomically(t *t
 	}
 }
 
+func TestSubmitDeliveryRollsBackWhenWorkflowEventFails(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	attempt := createDeliveryRun(t, store, "run-delivery-event-atomic")
+	if _, err := db.Exec(`CREATE TRIGGER reject_delivery_event BEFORE INSERT ON workflow_v2_events
+		WHEN NEW.kind='delivery.verified' BEGIN SELECT RAISE(ABORT, 'simulated event failure'); END`); err != nil {
+		t.Fatal(err)
+	}
+	apiURL := "https://github.example/org/api/pull/10"
+	_, err := store.SubmitDelivery(context.Background(), "run-delivery-event-atomic", attempt.ID,
+		typesv2.DeliveryManifest{PullRequests: []typesv2.PullRequestClaim{{URL: apiURL}}},
+		deliveryVerifier(map[string]string{apiURL: "api-head"}))
+	if err == nil {
+		t.Fatal("simulated workflow event failure did not fail delivery")
+	}
+	var deliveries, heads int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_delivery_prs WHERE run_id='run-delivery-event-atomic'`).Scan(&deliveries); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_delivery_heads`).Scan(&heads); err != nil {
+		t.Fatal(err)
+	}
+	if deliveries != 0 || heads != 0 {
+		t.Fatalf("delivery/head rows persisted after event failure: %d/%d", deliveries, heads)
+	}
+	var eventCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_events WHERE run_id='run-delivery-event-atomic' AND kind='delivery.verified'`).Scan(
+		&eventCount); err != nil {
+		t.Fatal(err)
+	}
+	if eventCount != 0 {
+		t.Fatalf("delivery events persisted = %d", eventCount)
+	}
+}
+
 func TestDeliveryHeadChangeSupersedesHeadBoundEvidence(t *testing.T) {
 	db := openRuntimeDB(t)
 	store := workflowv2.NewStore(db)
@@ -209,7 +244,7 @@ func TestAttemptRevokedDuringVerificationCannotWriteDelivery(t *testing.T) {
 	})
 	_, err := store.SubmitDelivery(context.Background(), "run-revoked-delivery", attempt.ID,
 		typesv2.DeliveryManifest{PullRequests: []typesv2.PullRequestClaim{{URL: prURL}}}, verifier)
-	if err == nil || !strings.Contains(err.Error(), "superseded during verification") {
+	if err == nil || !strings.Contains(err.Error(), "no longer active") {
 		t.Fatalf("error = %v", err)
 	}
 	var count int

--- a/pkg/hub/workflowv2/delivery_test.go
+++ b/pkg/hub/workflowv2/delivery_test.go
@@ -263,3 +263,49 @@ func TestSourceControlConfirmedClosedPRCanBeSuperseded(t *testing.T) {
 		t.Fatalf("old/new active = %d/%d", oldActive, newActive)
 	}
 }
+
+func TestSupersessionRejectsTargetChangedAfterVerification(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	attempt := createDeliveryRun(t, store, "run-supersede-head-race")
+	oldURL := "https://github.example/org/api/pull/10"
+	newURL := "https://github.example/org/api/pull/11"
+	verifiedPR := func(claim typesv2.PullRequestClaim, number int, head, state string) typesv2.VerifiedPullRequest {
+		now := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+		return typesv2.VerifiedPullRequest{URL: claim.URL, RepositoryName: "api", Repository: "org/api", Number: number,
+			SourceBranch: "feature", BaseBranch: "main", HeadSHA: head, State: state, VerifiedAt: now,
+			Provenance: typesv2.EvidenceProvenance{Producer: string(workflowv2.ProducerSourceControl), ObservedAt: now}}
+	}
+	if _, err := store.SubmitDelivery(context.Background(), "run-supersede-head-race", attempt.ID,
+		typesv2.DeliveryManifest{PullRequests: []typesv2.PullRequestClaim{{URL: oldURL}}},
+		workflowv2.PullRequestVerifierFunc(func(_ context.Context, _ workflowv2.Run, _ *typesv2.Workspace,
+			claim typesv2.PullRequestClaim) (typesv2.VerifiedPullRequest, error) {
+			return verifiedPR(claim, 10, "old-head", "closed"), nil
+		})); err != nil {
+		t.Fatal(err)
+	}
+	_, err := store.SubmitDelivery(context.Background(), "run-supersede-head-race", attempt.ID,
+		typesv2.DeliveryManifest{PullRequests: []typesv2.PullRequestClaim{{URL: newURL, Supersedes: oldURL}}},
+		workflowv2.PullRequestVerifierFunc(func(_ context.Context, _ workflowv2.Run, _ *typesv2.Workspace,
+			claim typesv2.PullRequestClaim) (typesv2.VerifiedPullRequest, error) {
+			if claim.URL == oldURL {
+				if _, updateErr := db.Exec(`UPDATE workflow_v2_delivery_prs SET current_head_sha='raced-head' WHERE run_id=? AND url=?`,
+					"run-supersede-head-race", oldURL); updateErr != nil {
+					return typesv2.VerifiedPullRequest{}, updateErr
+				}
+				return verifiedPR(claim, 10, "old-head", "closed"), nil
+			}
+			return verifiedPR(claim, 11, "new-head", "open"), nil
+		}))
+	if err == nil {
+		t.Fatal("supersession accepted a target that changed after verification")
+	}
+	var active, total int
+	if err := db.QueryRow(`SELECT COALESCE(SUM(active),0),COUNT(*) FROM workflow_v2_delivery_prs
+		WHERE run_id='run-supersede-head-race'`).Scan(&active, &total); err != nil {
+		t.Fatal(err)
+	}
+	if active != 1 || total != 1 {
+		t.Fatalf("delivery after rejected supersession = active %d total %d", active, total)
+	}
+}

--- a/pkg/hub/workflowv2/delivery_test.go
+++ b/pkg/hub/workflowv2/delivery_test.go
@@ -163,3 +163,99 @@ func TestEmptyDeliveryManifestSupportsNoPRWorkflow(t *testing.T) {
 		t.Fatalf("delivery = %#v", inspection.Delivery)
 	}
 }
+
+func TestUnverifiedOpenPRSupersessionCannotRemoveDelivery(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	attempt := createDeliveryRun(t, store, "run-supersede-open")
+	oldURL := "https://github.example/org/api/pull/10"
+	newURL := "https://github.example/org/api/pull/11"
+	if _, err := store.SubmitDelivery(context.Background(), "run-supersede-open", attempt.ID, typesv2.DeliveryManifest{
+		PullRequests: []typesv2.PullRequestClaim{{URL: oldURL}},
+	}, deliveryVerifier(map[string]string{oldURL: "old-head", newURL: "new-head"})); err != nil {
+		t.Fatal(err)
+	}
+	_, err := store.SubmitDelivery(context.Background(), "run-supersede-open", attempt.ID, typesv2.DeliveryManifest{
+		PullRequests: []typesv2.PullRequestClaim{{URL: newURL, Supersedes: oldURL}},
+	}, deliveryVerifier(map[string]string{oldURL: "old-head", newURL: "new-head"}))
+	if err == nil || !strings.Contains(err.Error(), "still open") {
+		t.Fatalf("supersession error = %v", err)
+	}
+	var active, total int
+	_ = db.QueryRow(`SELECT COALESCE(SUM(active),0),COUNT(*) FROM workflow_v2_delivery_prs WHERE run_id='run-supersede-open'`).Scan(&active, &total)
+	if active != 1 || total != 1 {
+		t.Fatalf("active/total deliveries = %d/%d", active, total)
+	}
+}
+
+func TestAttemptRevokedDuringVerificationCannotWriteDelivery(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	attempt := createDeliveryRun(t, store, "run-revoked-delivery")
+	prURL := "https://github.example/org/api/pull/10"
+	verifier := workflowv2.PullRequestVerifierFunc(func(_ context.Context, _ workflowv2.Run, _ *typesv2.Workspace,
+		claim typesv2.PullRequestClaim) (typesv2.VerifiedPullRequest, error) {
+		if _, err := store.StartAttempt(context.Background(), "run-revoked-delivery", "replacement-claw"); err != nil {
+			t.Fatal(err)
+		}
+		now := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+		return typesv2.VerifiedPullRequest{URL: claim.URL, RepositoryName: "api", Repository: "org/api", Number: 10,
+			SourceBranch: "feature", BaseBranch: "main", HeadSHA: "head", State: "open", VerifiedAt: now,
+			Provenance: typesv2.EvidenceProvenance{Producer: string(workflowv2.ProducerSourceControl), ObservedAt: now}}, nil
+	})
+	_, err := store.SubmitDelivery(context.Background(), "run-revoked-delivery", attempt.ID,
+		typesv2.DeliveryManifest{PullRequests: []typesv2.PullRequestClaim{{URL: prURL}}}, verifier)
+	if err == nil || !strings.Contains(err.Error(), "superseded during verification") {
+		t.Fatalf("error = %v", err)
+	}
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_delivery_prs WHERE run_id='run-revoked-delivery'`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatalf("revoked attempt wrote %d deliveries", count)
+	}
+}
+
+func TestSourceControlConfirmedClosedPRCanBeSuperseded(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	attempt := createDeliveryRun(t, store, "run-supersede-closed")
+	oldURL := "https://github.example/org/api/pull/10"
+	newURL := "https://github.example/org/api/pull/11"
+	states := map[string]string{oldURL: "open", newURL: "open"}
+	heads := map[string]string{oldURL: "old-head", newURL: "new-head"}
+	verifier := workflowv2.PullRequestVerifierFunc(func(_ context.Context, _ workflowv2.Run, _ *typesv2.Workspace,
+		claim typesv2.PullRequestClaim) (typesv2.VerifiedPullRequest, error) {
+		parts := strings.Split(strings.TrimPrefix(claim.URL, "https://github.example/org/api/pull/"), "/")
+		number := 0
+		_, _ = fmt.Sscanf(parts[0], "%d", &number)
+		now := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+		return typesv2.VerifiedPullRequest{URL: claim.URL, RepositoryName: "api", Repository: "org/api", Number: number,
+			SourceBranch: "feature", BaseBranch: "main", HeadSHA: heads[claim.URL], State: states[claim.URL], VerifiedAt: now,
+			Provenance: typesv2.EvidenceProvenance{Producer: string(workflowv2.ProducerSourceControl), ObservedAt: now}}, nil
+	})
+	if _, err := store.SubmitDelivery(context.Background(), "run-supersede-closed", attempt.ID,
+		typesv2.DeliveryManifest{PullRequests: []typesv2.PullRequestClaim{{URL: oldURL}}}, verifier); err != nil {
+		t.Fatal(err)
+	}
+	states[oldURL] = "closed"
+	if _, err := store.SubmitDelivery(context.Background(), "run-supersede-closed", attempt.ID,
+		typesv2.DeliveryManifest{PullRequests: []typesv2.PullRequestClaim{{URL: oldURL}}}, verifier); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.SubmitDelivery(context.Background(), "run-supersede-closed", attempt.ID,
+		typesv2.DeliveryManifest{PullRequests: []typesv2.PullRequestClaim{{URL: newURL, Supersedes: oldURL}}}, verifier); err != nil {
+		t.Fatal(err)
+	}
+	var oldActive, newActive int
+	if err := db.QueryRow(`SELECT active FROM workflow_v2_delivery_prs WHERE run_id='run-supersede-closed' AND url=?`, oldURL).Scan(&oldActive); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT active FROM workflow_v2_delivery_prs WHERE run_id='run-supersede-closed' AND url=?`, newURL).Scan(&newActive); err != nil {
+		t.Fatal(err)
+	}
+	if oldActive != 0 || newActive != 1 {
+		t.Fatalf("old/new active = %d/%d", oldActive, newActive)
+	}
+}

--- a/pkg/hub/workflowv2/delivery_test.go
+++ b/pkg/hub/workflowv2/delivery_test.go
@@ -1,0 +1,165 @@
+package workflowv2_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	workflowv2 "github.com/elasticclaw/elasticclaw/pkg/hub/workflowv2"
+	typesv2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
+	"github.com/google/uuid"
+)
+
+const deliveryWorkspaceYAML = `
+schema_version: 2
+name: engineering
+repositories:
+  api:
+    provider: github
+    repository: org/api
+  web:
+    provider: github
+    repository: org/web
+`
+
+func createDeliveryRun(t *testing.T, store *workflowv2.Store, id string) workflowv2.Attempt {
+	t.Helper()
+	if _, err := store.CreateRun(context.Background(), workflowv2.CreateRunRequest{
+		ID: id, TenantID: "tenant-1", WorkspaceYAML: []byte(deliveryWorkspaceYAML), WorkflowYAML: []byte(runtimeWorkflowYAML),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	attempt, err := store.StartAttempt(context.Background(), id, "claw-delivery")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return attempt
+}
+
+func deliveryVerifier(heads map[string]string) workflowv2.PullRequestVerifier {
+	return workflowv2.PullRequestVerifierFunc(func(_ context.Context, _ workflowv2.Run, _ *typesv2.Workspace,
+		claim typesv2.PullRequestClaim) (typesv2.VerifiedPullRequest, error) {
+		parts := strings.Split(strings.TrimPrefix(claim.URL, "https://github.example/org/"), "/pull/")
+		if len(parts) != 2 {
+			return typesv2.VerifiedPullRequest{}, fmt.Errorf("unrecognized URL")
+		}
+		number := 0
+		if _, err := fmt.Sscanf(parts[1], "%d", &number); err != nil {
+			return typesv2.VerifiedPullRequest{}, err
+		}
+		repositoryName := parts[0]
+		return typesv2.VerifiedPullRequest{
+			URL: claim.URL, RepositoryName: repositoryName, Repository: "org/" + repositoryName, Number: number,
+			SourceBranch: "feature", BaseBranch: "main", HeadSHA: heads[claim.URL], State: "open",
+			VerifiedAt: time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC),
+			Provenance: typesv2.EvidenceProvenance{Producer: string(workflowv2.ProducerSourceControl),
+				Connection: "github", ObservedAt: time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)},
+		}, nil
+	})
+}
+
+func TestSubmitDeliveryVerifiesMultipleWorkspaceRepositories(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	attempt := createDeliveryRun(t, store, "run-multi-pr")
+	apiURL := "https://github.example/org/api/pull/10"
+	webURL := "https://github.example/org/web/pull/20"
+	verified, err := store.SubmitDelivery(context.Background(), "run-multi-pr", attempt.ID, typesv2.DeliveryManifest{
+		PullRequests: []typesv2.PullRequestClaim{{URL: webURL}, {URL: apiURL}},
+	}, deliveryVerifier(map[string]string{apiURL: "api-head-1", webURL: "web-head-1"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(verified) != 2 || verified[0].Repository != "org/api" || verified[1].Repository != "org/web" {
+		t.Fatalf("verified = %#v", verified)
+	}
+	inspection, err := store.InspectRun(context.Background(), "run-multi-pr")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inspection.Delivery.ActivePullRequests != 2 || inspection.Delivery.OpenPullRequests != 2 {
+		t.Fatalf("delivery = %#v", inspection.Delivery)
+	}
+	deliveryFacts, ok := inspection.Facts["delivery"].(map[string]interface{})
+	if !ok || deliveryFacts["count"] != float64(2) || deliveryFacts["all_merged"] != false {
+		t.Fatalf("delivery facts = %#v", inspection.Facts["delivery"])
+	}
+}
+
+func TestSubmitDeliveryRejectsAnyRepositoryOutsidePinnedWorkspaceAtomically(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	attempt := createDeliveryRun(t, store, "run-delivery-authority")
+	apiURL := "https://github.example/org/api/pull/10"
+	evilURL := "https://github.example/org/evil/pull/99"
+	_, err := store.SubmitDelivery(context.Background(), "run-delivery-authority", attempt.ID, typesv2.DeliveryManifest{
+		PullRequests: []typesv2.PullRequestClaim{{URL: apiURL}, {URL: evilURL}},
+	}, deliveryVerifier(map[string]string{apiURL: "api-head", evilURL: "evil-head"}))
+	if err == nil || !strings.Contains(err.Error(), "pinned workspace") {
+		t.Fatalf("error = %v", err)
+	}
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_delivery_prs WHERE run_id='run-delivery-authority'`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatalf("partially persisted %d pull requests", count)
+	}
+}
+
+func TestDeliveryHeadChangeSupersedesHeadBoundEvidence(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	attempt := createDeliveryRun(t, store, "run-head-change")
+	apiURL := "https://github.example/org/api/pull/10"
+	verified, err := store.SubmitDelivery(context.Background(), "run-head-change", attempt.ID, typesv2.DeliveryManifest{
+		PullRequests: []typesv2.PullRequestClaim{{URL: apiURL}},
+	}, deliveryVerifier(map[string]string{apiURL: "head-1"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC().UnixMilli()
+	if _, err := db.Exec(`INSERT INTO workflow_v2_evidence(
+		id,run_id,pr_id,head_sha,domain,connection,external_id,kind,status,payload_json,provenance_json,observed_at)
+		VALUES(?,?,?,?,?,?,?,?,?,'{}','{}',?)`, uuid.NewString(), "run-head-change", verified[0].ID, "head-1",
+		"ci", "github", "check-1", "required-checks", "success", now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.SubmitDelivery(context.Background(), "run-head-change", attempt.ID, typesv2.DeliveryManifest{
+		PullRequests: []typesv2.PullRequestClaim{{URL: apiURL}},
+	}, deliveryVerifier(map[string]string{apiURL: "head-2"})); err != nil {
+		t.Fatal(err)
+	}
+	var currentHead string
+	var generations, superseded int
+	if err := db.QueryRow(`SELECT current_head_sha FROM workflow_v2_delivery_prs WHERE id=?`, verified[0].ID).Scan(&currentHead); err != nil {
+		t.Fatal(err)
+	}
+	_ = db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_delivery_heads WHERE pr_id=?`, verified[0].ID).Scan(&generations)
+	_ = db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_evidence WHERE pr_id=? AND superseded_at>0`, verified[0].ID).Scan(&superseded)
+	if currentHead != "head-2" || generations != 2 || superseded != 1 {
+		t.Fatalf("head/generations/superseded = %s/%d/%d", currentHead, generations, superseded)
+	}
+}
+
+func TestEmptyDeliveryManifestSupportsNoPRWorkflow(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	attempt := createDeliveryRun(t, store, "run-no-pr")
+	verified, err := store.SubmitDelivery(context.Background(), "run-no-pr", attempt.ID, typesv2.DeliveryManifest{}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(verified) != 0 {
+		t.Fatalf("verified = %#v", verified)
+	}
+	inspection, err := store.InspectRun(context.Background(), "run-no-pr")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inspection.Delivery.ActivePullRequests != 0 {
+		t.Fatalf("delivery = %#v", inspection.Delivery)
+	}
+}

--- a/pkg/hub/workflowv2/delivery_test.go
+++ b/pkg/hub/workflowv2/delivery_test.go
@@ -203,7 +203,7 @@ func TestEmptyDeliveryManifestSupportsNoPRWorkflow(t *testing.T) {
 	}
 }
 
-func TestUnverifiedOpenPRSupersessionCannotRemoveDelivery(t *testing.T) {
+func TestClawSupersessionCannotRemoveOpenDelivery(t *testing.T) {
 	db := openRuntimeDB(t)
 	store := workflowv2.NewStore(db)
 	attempt := createDeliveryRun(t, store, "run-supersede-open")
@@ -217,7 +217,7 @@ func TestUnverifiedOpenPRSupersessionCannotRemoveDelivery(t *testing.T) {
 	_, err := store.SubmitDelivery(context.Background(), "run-supersede-open", attempt.ID, typesv2.DeliveryManifest{
 		PullRequests: []typesv2.PullRequestClaim{{URL: newURL, Supersedes: oldURL}},
 	}, deliveryVerifier(map[string]string{oldURL: "old-head", newURL: "new-head"}))
-	if err == nil || !strings.Contains(err.Error(), "still open") {
+	if err == nil || !strings.Contains(err.Error(), "hub-owned") {
 		t.Fatalf("supersession error = %v", err)
 	}
 	var active, total int
@@ -256,7 +256,7 @@ func TestAttemptRevokedDuringVerificationCannotWriteDelivery(t *testing.T) {
 	}
 }
 
-func TestSourceControlConfirmedClosedPRCanBeSuperseded(t *testing.T) {
+func TestClawCannotSupersedeSourceControlConfirmedClosedPR(t *testing.T) {
 	db := openRuntimeDB(t)
 	store := workflowv2.NewStore(db)
 	attempt := createDeliveryRun(t, store, "run-supersede-closed")
@@ -284,63 +284,46 @@ func TestSourceControlConfirmedClosedPRCanBeSuperseded(t *testing.T) {
 		t.Fatal(err)
 	}
 	if _, err := store.SubmitDelivery(context.Background(), "run-supersede-closed", attempt.ID,
-		typesv2.DeliveryManifest{PullRequests: []typesv2.PullRequestClaim{{URL: newURL, Supersedes: oldURL}}}, verifier); err != nil {
-		t.Fatal(err)
+		typesv2.DeliveryManifest{PullRequests: []typesv2.PullRequestClaim{{URL: newURL, Supersedes: oldURL}}}, verifier); err == nil ||
+		!strings.Contains(err.Error(), "hub-owned") {
+		t.Fatalf("error = %v", err)
 	}
-	var oldActive, newActive int
+	var oldActive, newCount int
 	if err := db.QueryRow(`SELECT active FROM workflow_v2_delivery_prs WHERE run_id='run-supersede-closed' AND url=?`, oldURL).Scan(&oldActive); err != nil {
 		t.Fatal(err)
 	}
-	if err := db.QueryRow(`SELECT active FROM workflow_v2_delivery_prs WHERE run_id='run-supersede-closed' AND url=?`, newURL).Scan(&newActive); err != nil {
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_delivery_prs WHERE run_id='run-supersede-closed' AND url=?`, newURL).Scan(&newCount); err != nil {
 		t.Fatal(err)
 	}
-	if oldActive != 0 || newActive != 1 {
-		t.Fatalf("old/new active = %d/%d", oldActive, newActive)
+	if oldActive != 1 || newCount != 0 {
+		t.Fatalf("old active/new count = %d/%d", oldActive, newCount)
 	}
 }
 
-func TestSupersessionRejectsTargetChangedAfterVerification(t *testing.T) {
+func TestClawSupersessionIsRejectedBeforeSourceControlLookup(t *testing.T) {
 	db := openRuntimeDB(t)
 	store := workflowv2.NewStore(db)
-	attempt := createDeliveryRun(t, store, "run-supersede-head-race")
-	oldURL := "https://github.example/org/api/pull/10"
+	attempt := createDeliveryRun(t, store, "run-supersede-authority")
 	newURL := "https://github.example/org/api/pull/11"
-	verifiedPR := func(claim typesv2.PullRequestClaim, number int, head, state string) typesv2.VerifiedPullRequest {
-		now := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
-		return typesv2.VerifiedPullRequest{URL: claim.URL, RepositoryName: "api", Repository: "org/api", Number: number,
-			SourceBranch: "feature", BaseBranch: "main", HeadSHA: head, State: state, VerifiedAt: now,
-			Provenance: typesv2.EvidenceProvenance{Producer: string(workflowv2.ProducerSourceControl), ObservedAt: now}}
-	}
-	if _, err := store.SubmitDelivery(context.Background(), "run-supersede-head-race", attempt.ID,
-		typesv2.DeliveryManifest{PullRequests: []typesv2.PullRequestClaim{{URL: oldURL}}},
+	called := false
+	_, err := store.SubmitDelivery(context.Background(), "run-supersede-authority", attempt.ID,
+		typesv2.DeliveryManifest{PullRequests: []typesv2.PullRequestClaim{{URL: newURL, Supersedes: "old-pr"}}},
 		workflowv2.PullRequestVerifierFunc(func(_ context.Context, _ workflowv2.Run, _ *typesv2.Workspace,
-			claim typesv2.PullRequestClaim) (typesv2.VerifiedPullRequest, error) {
-			return verifiedPR(claim, 10, "old-head", "closed"), nil
-		})); err != nil {
-		t.Fatal(err)
-	}
-	_, err := store.SubmitDelivery(context.Background(), "run-supersede-head-race", attempt.ID,
-		typesv2.DeliveryManifest{PullRequests: []typesv2.PullRequestClaim{{URL: newURL, Supersedes: oldURL}}},
-		workflowv2.PullRequestVerifierFunc(func(_ context.Context, _ workflowv2.Run, _ *typesv2.Workspace,
-			claim typesv2.PullRequestClaim) (typesv2.VerifiedPullRequest, error) {
-			if claim.URL == oldURL {
-				if _, updateErr := db.Exec(`UPDATE workflow_v2_delivery_prs SET current_head_sha='raced-head' WHERE run_id=? AND url=?`,
-					"run-supersede-head-race", oldURL); updateErr != nil {
-					return typesv2.VerifiedPullRequest{}, updateErr
-				}
-				return verifiedPR(claim, 10, "old-head", "closed"), nil
-			}
-			return verifiedPR(claim, 11, "new-head", "open"), nil
+			_ typesv2.PullRequestClaim) (typesv2.VerifiedPullRequest, error) {
+			called = true
+			return typesv2.VerifiedPullRequest{}, nil
 		}))
-	if err == nil {
-		t.Fatal("supersession accepted a target that changed after verification")
+	if err == nil || !strings.Contains(err.Error(), "hub-owned") {
+		t.Fatalf("error = %v", err)
 	}
-	var active, total int
-	if err := db.QueryRow(`SELECT COALESCE(SUM(active),0),COUNT(*) FROM workflow_v2_delivery_prs
-		WHERE run_id='run-supersede-head-race'`).Scan(&active, &total); err != nil {
+	if called {
+		t.Fatal("untrusted supersession reached source-control verifier")
+	}
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_delivery_prs WHERE run_id='run-supersede-authority'`).Scan(&count); err != nil {
 		t.Fatal(err)
 	}
-	if active != 1 || total != 1 {
-		t.Fatalf("delivery after rejected supersession = active %d total %d", active, total)
+	if count != 0 {
+		t.Fatalf("supersession persisted %d deliveries", count)
 	}
 }

--- a/pkg/hub/workflowv2/delivery_test.go
+++ b/pkg/hub/workflowv2/delivery_test.go
@@ -162,6 +162,10 @@ func TestEmptyDeliveryManifestSupportsNoPRWorkflow(t *testing.T) {
 	if inspection.Delivery.ActivePullRequests != 0 {
 		t.Fatalf("delivery = %#v", inspection.Delivery)
 	}
+	deliveryFacts, ok := inspection.Facts["delivery"].(map[string]interface{})
+	if !ok || deliveryFacts["all_merged"] != true {
+		t.Fatalf("zero-PR delivery should be vacuously merged: %#v", inspection.Facts["delivery"])
+	}
 }
 
 func TestUnverifiedOpenPRSupersessionCannotRemoveDelivery(t *testing.T) {

--- a/pkg/hub/workflowv2/evidence.go
+++ b/pkg/hub/workflowv2/evidence.go
@@ -2,8 +2,11 @@ package workflowv2
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -29,6 +32,7 @@ type EvidenceInput struct {
 }
 
 type DeliveryPolicyResult struct {
+	Revision         string `json:"revision"`
 	PullRequestCount int    `json:"pull_request_count"`
 	MinimumMet       bool   `json:"minimum_met"`
 	CISatisfied      bool   `json:"ci_satisfied"`
@@ -116,14 +120,27 @@ func (s *Store) RecordEvidence(ctx context.Context, input EvidenceInput, produce
 	if err := tx.Commit(); err != nil {
 		return DeliveryPolicyResult{}, err
 	}
-	result, err := s.EvaluateDeliveryPolicy(ctx, input.RunID)
-	if err != nil {
-		return DeliveryPolicyResult{}, err
+	return s.evaluateAndPublishDeliveryPolicy(ctx, input.RunID, "", input.Domain, observed)
+}
+
+var errDeliveryPolicyChanged = errors.New("delivery policy inputs changed before publication")
+
+func (s *Store) evaluateAndPublishDeliveryPolicy(ctx context.Context, runID, attemptID, domain string,
+	observed time.Time) (DeliveryPolicyResult, error) {
+	for attempt := 0; attempt < 5; attempt++ {
+		result, err := s.EvaluateDeliveryPolicy(ctx, runID)
+		if err != nil {
+			return DeliveryPolicyResult{}, err
+		}
+		if err := s.publishEvidencePolicyEvents(ctx, runID, attemptID, domain, result, observed); err != nil {
+			if errors.Is(err, errDeliveryPolicyChanged) {
+				continue
+			}
+			return DeliveryPolicyResult{}, err
+		}
+		return result, nil
 	}
-	if err := s.publishEvidencePolicyEvents(ctx, input.RunID, "", input.Domain, result, observed); err != nil {
-		return DeliveryPolicyResult{}, err
-	}
-	return result, nil
+	return DeliveryPolicyResult{}, fmt.Errorf("delivery policy kept changing during publication")
 }
 
 func (s *Store) publishEvidencePolicyEvents(ctx context.Context, runID, attemptID, domain string,
@@ -140,10 +157,14 @@ func (s *Store) publishEvidencePolicyEvents(ctx context.Context, runID, attemptI
 		requirements := workflow.Workflow.Delivery.PullRequests
 		if domain == "ci" && requirements.CIPolicy != "" {
 			status := result.CIStatus
-			event, err := s.ApplyEvent(ctx, runID, EventInput{
+			event, err := s.applyDeliveryPolicyEvent(ctx, runID, result, EventInput{
 				ID: uuid.NewString(), Kind: "ci.policy.evaluated", AttemptID: attemptID, Producer: ProducerCI,
-				Payload:    map[string]interface{}{"ci": map[string]interface{}{"policy": requirements.CIPolicy, "status": status}},
-				Facts:      map[string]interface{}{"ci.policy": requirements.CIPolicy, "ci.status": status},
+				Payload: map[string]interface{}{"ci": map[string]interface{}{
+					"policy": requirements.CIPolicy, "status": status, "revision": result.Revision,
+				}},
+				Facts: map[string]interface{}{
+					"ci.policy": requirements.CIPolicy, "ci.status": status, "ci.policy_revision": result.Revision,
+				},
 				Provenance: typesv2.EvidenceProvenance{Producer: string(ProducerCI), ObservedAt: observed},
 			})
 			if err != nil {
@@ -155,10 +176,15 @@ func (s *Store) publishEvidencePolicyEvents(ctx context.Context, runID, attemptI
 		}
 		if domain == "review" && requirements.ReviewPolicy != "" {
 			status := result.ReviewStatus
-			event, err := s.ApplyEvent(ctx, runID, EventInput{
+			event, err := s.applyDeliveryPolicyEvent(ctx, runID, result, EventInput{
 				ID: uuid.NewString(), Kind: "review.policy.evaluated", AttemptID: attemptID, Producer: ProducerReview,
-				Payload:    map[string]interface{}{"review": map[string]interface{}{"policy": requirements.ReviewPolicy, "status": status}},
-				Facts:      map[string]interface{}{"review.policy": requirements.ReviewPolicy, "review.status": status},
+				Payload: map[string]interface{}{"review": map[string]interface{}{
+					"policy": requirements.ReviewPolicy, "status": status, "revision": result.Revision,
+				}},
+				Facts: map[string]interface{}{
+					"review.policy": requirements.ReviewPolicy, "review.status": status,
+					"review.policy_revision": result.Revision,
+				},
 				Provenance: typesv2.EvidenceProvenance{Producer: string(ProducerReview), ObservedAt: observed},
 			})
 			if err != nil {
@@ -169,13 +195,13 @@ func (s *Store) publishEvidencePolicyEvents(ctx context.Context, runID, attemptI
 			}
 		}
 	}
-	deliveryEvent, err := s.ApplyEvent(ctx, runID, EventInput{
+	deliveryEvent, err := s.applyDeliveryPolicyEvent(ctx, runID, result, EventInput{
 		ID: uuid.NewString(), Kind: "workflow.delivery.evaluated", AttemptID: attemptID, Producer: ProducerEngine,
 		Payload: map[string]interface{}{"workflow": map[string]interface{}{"delivery": result}},
 		Facts: map[string]interface{}{
 			"delivery.minimum_met": result.MinimumMet, "delivery.ci_satisfied": result.CISatisfied,
 			"delivery.review_satisfied": result.ReviewSatisfied, "delivery.all_merged": result.AllMerged,
-			"delivery.satisfied": result.Satisfied,
+			"delivery.satisfied": result.Satisfied, "delivery.policy_revision": result.Revision,
 		},
 		Provenance: typesv2.EvidenceProvenance{Producer: string(ProducerEngine), ObservedAt: observed},
 	})
@@ -186,6 +212,20 @@ func (s *Store) publishEvidencePolicyEvents(ctx context.Context, runID, attemptI
 		return fmt.Errorf("delivery policy event was %s: %s", deliveryEvent.Disposition, deliveryEvent.Reason)
 	}
 	return nil
+}
+
+func (s *Store) applyDeliveryPolicyEvent(ctx context.Context, runID string, expected DeliveryPolicyResult,
+	input EventInput) (EventResult, error) {
+	return s.applyEventWithMutation(ctx, runID, input, func(ctx context.Context, tx *sql.Tx, _ *EventInput) error {
+		current, err := evaluateDeliveryPolicy(ctx, tx, runID)
+		if err != nil {
+			return err
+		}
+		if current.Revision != expected.Revision {
+			return errDeliveryPolicyChanged
+		}
+		return nil
+	})
 }
 
 func validateEvidenceProducer(domain string, producer Producer) error {
@@ -223,23 +263,63 @@ type storedEvidence struct {
 }
 
 func (s *Store) EvaluateDeliveryPolicy(ctx context.Context, runID string) (DeliveryPolicyResult, error) {
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable, ReadOnly: true})
+	if err != nil {
+		return DeliveryPolicyResult{}, err
+	}
+	defer tx.Rollback()
+	result, err := evaluateDeliveryPolicy(ctx, tx, runID)
+	if err != nil {
+		return DeliveryPolicyResult{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return DeliveryPolicyResult{}, err
+	}
+	return result, nil
+}
+
+type policyQueryer interface {
+	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
+}
+
+type deliveryPolicySubject struct {
+	ID         string           `json:"id"`
+	Repository string           `json:"repository"`
+	Number     int              `json:"number"`
+	State      string           `json:"state"`
+	HeadSHA    string           `json:"head_sha"`
+	Generation int              `json:"generation"`
+	Evidence   []storedEvidence `json:"evidence"`
+}
+
+func evaluateDeliveryPolicy(ctx context.Context, queryer policyQueryer, runID string) (DeliveryPolicyResult, error) {
 	var workflowYAML string
-	if err := s.db.QueryRowContext(ctx, `SELECT workflow_yaml FROM workflow_v2_runs WHERE id=?`, runID).Scan(&workflowYAML); err != nil {
+	if err := queryer.QueryRowContext(ctx, `SELECT workflow_yaml FROM workflow_v2_runs WHERE id=?`, runID).Scan(&workflowYAML); err != nil {
 		return DeliveryPolicyResult{}, err
 	}
 	workflow, err := typesv2.ParseAndValidateWorkflow([]byte(workflowYAML))
 	if err != nil {
 		return DeliveryPolicyResult{}, err
 	}
-	var prs struct {
-		count, merged int
-	}
-	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*),COALESCE(SUM(CASE WHEN state='merged' THEN 1 ELSE 0 END),0)
-		FROM workflow_v2_delivery_prs WHERE run_id=? AND active=1`, runID).Scan(&prs.count, &prs.merged); err != nil {
+	subjects, err := loadDeliveryPolicySubjects(ctx, queryer, runID)
+	if err != nil {
 		return DeliveryPolicyResult{}, err
 	}
-	result := DeliveryPolicyResult{PullRequestCount: prs.count, CISatisfied: true, CIStatus: policySatisfied,
-		ReviewSatisfied: true, ReviewStatus: policySatisfied, AllMerged: prs.count == prs.merged}
+	revisionJSON, err := json.Marshal(subjects)
+	if err != nil {
+		return DeliveryPolicyResult{}, err
+	}
+	revisionHash := sha256.Sum256(revisionJSON)
+	merged := 0
+	for _, subject := range subjects {
+		if subject.State == "merged" {
+			merged++
+		}
+	}
+	result := DeliveryPolicyResult{Revision: "sha256:" + hex.EncodeToString(revisionHash[:]), PullRequestCount: len(subjects),
+		CISatisfied: true, CIStatus: policySatisfied, ReviewSatisfied: true, ReviewStatus: policySatisfied,
+		AllMerged: len(subjects) == merged}
 	policy := workflow.Workflow.Delivery
 	if policy == nil || policy.PullRequests == nil {
 		result.MinimumMet = true
@@ -247,30 +327,11 @@ func (s *Store) EvaluateDeliveryPolicy(ctx context.Context, runID string) (Deliv
 		return result, nil
 	}
 	requirements := policy.PullRequests
-	result.MinimumMet = prs.count >= requirements.Minimum && (!requirements.Required || prs.count > 0)
-	rows, err := s.db.QueryContext(ctx, `SELECT p.id,COALESCE(MAX(h.generation),0)
-		FROM workflow_v2_delivery_prs p LEFT JOIN workflow_v2_delivery_heads h ON h.pr_id=p.id
-		WHERE p.run_id=? AND p.active=1 GROUP BY p.id ORDER BY p.repository,p.pr_number`, runID)
-	if err != nil {
-		return DeliveryPolicyResult{}, err
-	}
-	defer rows.Close()
-	for rows.Next() {
-		var prID string
-		var generation int
-		if err := rows.Scan(&prID, &generation); err != nil {
-			return DeliveryPolicyResult{}, err
-		}
-		if generation < 1 {
-			return DeliveryPolicyResult{}, fmt.Errorf("active delivery %s has no verified head generation", prID)
-		}
-		evidence, err := loadCurrentEvidence(ctx, s.db, runID, prID, generation)
-		if err != nil {
-			return DeliveryPolicyResult{}, err
-		}
+	result.MinimumMet = len(subjects) >= requirements.Minimum && (!requirements.Required || len(subjects) > 0)
+	for _, subject := range subjects {
 		if requirements.CIPolicy != "" {
 			definition := workflow.Workflow.CI.Policies[requirements.CIPolicy]
-			status, err := evaluateEvidencePolicyStatus(definition, "ci", evidence)
+			status, err := evaluateEvidencePolicyStatus(definition, "ci", subject.Evidence)
 			if err != nil {
 				return DeliveryPolicyResult{}, fmt.Errorf("evaluate CI policy %s: %w", requirements.CIPolicy, err)
 			}
@@ -278,15 +339,12 @@ func (s *Store) EvaluateDeliveryPolicy(ctx context.Context, runID string) (Deliv
 		}
 		if requirements.ReviewPolicy != "" {
 			definition := workflow.Workflow.Review.Policies[requirements.ReviewPolicy]
-			status, err := evaluateEvidencePolicyStatus(definition, "review", evidence)
+			status, err := evaluateEvidencePolicyStatus(definition, "review", subject.Evidence)
 			if err != nil {
 				return DeliveryPolicyResult{}, fmt.Errorf("evaluate review policy %s: %w", requirements.ReviewPolicy, err)
 			}
 			result.ReviewStatus = combineAllPolicyStatus(result.ReviewStatus, status)
 		}
-	}
-	if err := rows.Err(); err != nil {
-		return DeliveryPolicyResult{}, err
 	}
 	result.CISatisfied = result.CIStatus == policySatisfied
 	result.ReviewSatisfied = result.ReviewStatus == policySatisfied
@@ -298,8 +356,44 @@ func (s *Store) EvaluateDeliveryPolicy(ctx context.Context, runID string) (Deliv
 	return result, nil
 }
 
-func loadCurrentEvidence(ctx context.Context, db *sql.DB, runID, prID string, generation int) ([]storedEvidence, error) {
-	rows, err := db.QueryContext(ctx, `SELECT domain,connection,external_id,kind,status,payload_json,observed_at
+func loadDeliveryPolicySubjects(ctx context.Context, queryer policyQueryer, runID string) ([]deliveryPolicySubject, error) {
+	rows, err := queryer.QueryContext(ctx, `SELECT p.id,p.repository,p.pr_number,p.state,p.current_head_sha,
+		COALESCE(MAX(h.generation),0) FROM workflow_v2_delivery_prs p
+		LEFT JOIN workflow_v2_delivery_heads h ON h.pr_id=p.id
+		WHERE p.run_id=? AND p.active=1 GROUP BY p.id ORDER BY p.repository,p.pr_number`, runID)
+	if err != nil {
+		return nil, err
+	}
+	var subjects []deliveryPolicySubject
+	for rows.Next() {
+		var subject deliveryPolicySubject
+		if err := rows.Scan(&subject.ID, &subject.Repository, &subject.Number, &subject.State, &subject.HeadSHA,
+			&subject.Generation); err != nil {
+			return nil, err
+		}
+		if subject.Generation < 1 {
+			return nil, fmt.Errorf("active delivery %s has no verified head generation", subject.ID)
+		}
+		subjects = append(subjects, subject)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	for i := range subjects {
+		evidence, err := loadCurrentEvidence(ctx, queryer, runID, subjects[i].ID, subjects[i].Generation)
+		if err != nil {
+			return nil, err
+		}
+		subjects[i].Evidence = evidence
+	}
+	return subjects, nil
+}
+
+func loadCurrentEvidence(ctx context.Context, queryer policyQueryer, runID, prID string, generation int) ([]storedEvidence, error) {
+	rows, err := queryer.QueryContext(ctx, `SELECT domain,connection,external_id,kind,status,payload_json,observed_at
 		FROM workflow_v2_evidence WHERE run_id=? AND pr_id=? AND head_generation=? AND superseded_at=0
 		ORDER BY domain,connection,external_id,kind,observed_at`, runID, prID, generation)
 	if err != nil {

--- a/pkg/hub/workflowv2/evidence.go
+++ b/pkg/hub/workflowv2/evidence.go
@@ -1,0 +1,500 @@
+package workflowv2
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	typesv2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
+	"github.com/google/uuid"
+)
+
+type EvidenceInput struct {
+	ID         string
+	RunID      string
+	PRID       string
+	HeadSHA    string
+	Domain     string
+	Connection string
+	ExternalID string
+	Kind       string
+	Status     string
+	Payload    map[string]interface{}
+	Provenance typesv2.EvidenceProvenance
+	ObservedAt time.Time
+}
+
+type DeliveryPolicyResult struct {
+	PullRequestCount int    `json:"pull_request_count"`
+	MinimumMet       bool   `json:"minimum_met"`
+	CISatisfied      bool   `json:"ci_satisfied"`
+	CIStatus         string `json:"ci_status"`
+	ReviewSatisfied  bool   `json:"review_satisfied"`
+	ReviewStatus     string `json:"review_status"`
+	AllMerged        bool   `json:"all_merged"`
+	Satisfied        bool   `json:"satisfied"`
+}
+
+// RecordEvidence accepts only adapter-owned evidence for the current verified
+// PR head, then recomputes the workflow's aggregate delivery policy.
+func (s *Store) RecordEvidence(ctx context.Context, input EvidenceInput, producer Producer) (DeliveryPolicyResult, error) {
+	if s == nil || s.db == nil {
+		return DeliveryPolicyResult{}, fmt.Errorf("workflow v2 store is not configured")
+	}
+	if err := validateEvidenceProducer(input.Domain, producer); err != nil {
+		return DeliveryPolicyResult{}, err
+	}
+	if input.RunID == "" || input.PRID == "" || input.HeadSHA == "" || input.ExternalID == "" || input.Kind == "" || input.Status == "" {
+		return DeliveryPolicyResult{}, fmt.Errorf("run, pull request, head, external id, kind, and status are required")
+	}
+	var currentHead string
+	if err := s.db.QueryRowContext(ctx, `SELECT current_head_sha FROM workflow_v2_delivery_prs
+		WHERE id=? AND run_id=? AND active=1`, input.PRID, input.RunID).Scan(&currentHead); err != nil {
+		return DeliveryPolicyResult{}, fmt.Errorf("load active delivery: %w", err)
+	}
+	if currentHead != input.HeadSHA {
+		return DeliveryPolicyResult{}, fmt.Errorf("evidence head %s is stale; current head is %s", input.HeadSHA, currentHead)
+	}
+	if strings.TrimSpace(input.Provenance.Producer) != string(producer) {
+		return DeliveryPolicyResult{}, fmt.Errorf("evidence provenance producer %q does not match trusted adapter %q",
+			input.Provenance.Producer, producer)
+	}
+	observed := input.ObservedAt.UTC()
+	if observed.IsZero() {
+		observed = s.now().UTC()
+	}
+	if input.Provenance.ObservedAt.IsZero() {
+		input.Provenance.ObservedAt = observed
+	}
+	payloadJSON, err := json.Marshal(input.Payload)
+	if err != nil {
+		return DeliveryPolicyResult{}, err
+	}
+	if input.Payload == nil {
+		payloadJSON = []byte("{}")
+	}
+	provenanceJSON, err := marshalObject(input.Provenance)
+	if err != nil {
+		return DeliveryPolicyResult{}, err
+	}
+	id := strings.TrimSpace(input.ID)
+	if id == "" {
+		id = uuid.NewString()
+	}
+	_, err = s.db.ExecContext(ctx, `INSERT INTO workflow_v2_evidence(
+		id,run_id,pr_id,head_sha,domain,connection,external_id,kind,status,payload_json,provenance_json,observed_at)
+		VALUES(?,?,?,?,?,?,?,?,?,?,?,?)
+		ON CONFLICT(run_id,domain,connection,external_id,kind,head_sha) DO UPDATE SET
+		status=excluded.status,payload_json=excluded.payload_json,provenance_json=excluded.provenance_json,
+		observed_at=excluded.observed_at,superseded_at=0`, id, input.RunID, input.PRID, input.HeadSHA,
+		input.Domain, input.Connection, input.ExternalID, input.Kind, input.Status, string(payloadJSON),
+		provenanceJSON, observed.UnixMilli())
+	if err != nil {
+		return DeliveryPolicyResult{}, err
+	}
+	result, err := s.EvaluateDeliveryPolicy(ctx, input.RunID)
+	if err != nil {
+		return DeliveryPolicyResult{}, err
+	}
+	if err := s.publishEvidencePolicyEvents(ctx, input.RunID, input.Domain, result, observed); err != nil {
+		return DeliveryPolicyResult{}, err
+	}
+	return result, nil
+}
+
+func (s *Store) publishEvidencePolicyEvents(ctx context.Context, runID, domain string, result DeliveryPolicyResult, observed time.Time) error {
+	var workflowYAML string
+	if err := s.db.QueryRowContext(ctx, `SELECT workflow_yaml FROM workflow_v2_runs WHERE id=?`, runID).Scan(&workflowYAML); err != nil {
+		return err
+	}
+	workflow, err := typesv2.ParseAndValidateWorkflow([]byte(workflowYAML))
+	if err != nil {
+		return err
+	}
+	if workflow.Workflow.Delivery != nil && workflow.Workflow.Delivery.PullRequests != nil {
+		requirements := workflow.Workflow.Delivery.PullRequests
+		if domain == "ci" && requirements.CIPolicy != "" {
+			status := result.CIStatus
+			event, err := s.ApplyEvent(ctx, runID, EventInput{
+				ID: uuid.NewString(), Kind: "ci.policy.evaluated", Producer: ProducerCI,
+				Payload:    map[string]interface{}{"ci": map[string]interface{}{"policy": requirements.CIPolicy, "status": status}},
+				Facts:      map[string]interface{}{"ci.policy": requirements.CIPolicy, "ci.status": status},
+				Provenance: typesv2.EvidenceProvenance{Producer: string(ProducerCI), ObservedAt: observed},
+			})
+			if err != nil {
+				return err
+			}
+			if event.Disposition != typesv2.DispositionAccepted {
+				return fmt.Errorf("CI policy event was %s: %s", event.Disposition, event.Reason)
+			}
+		}
+		if domain == "review" && requirements.ReviewPolicy != "" {
+			status := result.ReviewStatus
+			event, err := s.ApplyEvent(ctx, runID, EventInput{
+				ID: uuid.NewString(), Kind: "review.policy.evaluated", Producer: ProducerReview,
+				Payload:    map[string]interface{}{"review": map[string]interface{}{"policy": requirements.ReviewPolicy, "status": status}},
+				Facts:      map[string]interface{}{"review.policy": requirements.ReviewPolicy, "review.status": status},
+				Provenance: typesv2.EvidenceProvenance{Producer: string(ProducerReview), ObservedAt: observed},
+			})
+			if err != nil {
+				return err
+			}
+			if event.Disposition != typesv2.DispositionAccepted {
+				return fmt.Errorf("review policy event was %s: %s", event.Disposition, event.Reason)
+			}
+		}
+	}
+	deliveryEvent, err := s.ApplyEvent(ctx, runID, EventInput{
+		ID: uuid.NewString(), Kind: "workflow.delivery.evaluated", Producer: ProducerEngine,
+		Payload: map[string]interface{}{"workflow": map[string]interface{}{"delivery": result}},
+		Facts: map[string]interface{}{
+			"delivery.minimum_met": result.MinimumMet, "delivery.ci_satisfied": result.CISatisfied,
+			"delivery.review_satisfied": result.ReviewSatisfied, "delivery.all_merged": result.AllMerged,
+			"delivery.satisfied": result.Satisfied,
+		},
+		Provenance: typesv2.EvidenceProvenance{Producer: string(ProducerEngine), ObservedAt: observed},
+	})
+	if err != nil {
+		return err
+	}
+	if deliveryEvent.Disposition != typesv2.DispositionAccepted {
+		return fmt.Errorf("delivery policy event was %s: %s", deliveryEvent.Disposition, deliveryEvent.Reason)
+	}
+	return nil
+}
+
+func validateEvidenceProducer(domain string, producer Producer) error {
+	allowed := false
+	switch domain {
+	case "ci":
+		allowed = producer == ProducerCI
+	case "review":
+		allowed = producer == ProducerReview
+	case "pull_request":
+		allowed = producer == ProducerSourceControl
+	case "operator":
+		allowed = producer == ProducerOperator
+	case "effect":
+		allowed = producer == ProducerEffect
+	case "context":
+		allowed = producer == ProducerContext
+	default:
+		return fmt.Errorf("unsupported evidence domain %q", domain)
+	}
+	if !allowed {
+		return fmt.Errorf("producer %q cannot record %s evidence", producer, domain)
+	}
+	return nil
+}
+
+type storedEvidence struct {
+	Domain     string
+	Connection string
+	ExternalID string
+	Kind       string
+	Status     string
+	Payload    map[string]interface{}
+}
+
+func (s *Store) EvaluateDeliveryPolicy(ctx context.Context, runID string) (DeliveryPolicyResult, error) {
+	var workflowYAML string
+	if err := s.db.QueryRowContext(ctx, `SELECT workflow_yaml FROM workflow_v2_runs WHERE id=?`, runID).Scan(&workflowYAML); err != nil {
+		return DeliveryPolicyResult{}, err
+	}
+	workflow, err := typesv2.ParseAndValidateWorkflow([]byte(workflowYAML))
+	if err != nil {
+		return DeliveryPolicyResult{}, err
+	}
+	var prs struct {
+		count, merged int
+	}
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*),COALESCE(SUM(CASE WHEN state='merged' THEN 1 ELSE 0 END),0)
+		FROM workflow_v2_delivery_prs WHERE run_id=? AND active=1`, runID).Scan(&prs.count, &prs.merged); err != nil {
+		return DeliveryPolicyResult{}, err
+	}
+	result := DeliveryPolicyResult{PullRequestCount: prs.count, CISatisfied: true, CIStatus: policySatisfied,
+		ReviewSatisfied: true, ReviewStatus: policySatisfied, AllMerged: prs.count > 0 && prs.count == prs.merged}
+	policy := workflow.Workflow.Delivery
+	if policy == nil || policy.PullRequests == nil {
+		result.MinimumMet = true
+		result.Satisfied = true
+		return result, nil
+	}
+	requirements := policy.PullRequests
+	result.MinimumMet = prs.count >= requirements.Minimum && (!requirements.Required || prs.count > 0)
+	rows, err := s.db.QueryContext(ctx, `SELECT id,current_head_sha FROM workflow_v2_delivery_prs
+		WHERE run_id=? AND active=1 ORDER BY repository,pr_number`, runID)
+	if err != nil {
+		return DeliveryPolicyResult{}, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var prID, head string
+		if err := rows.Scan(&prID, &head); err != nil {
+			return DeliveryPolicyResult{}, err
+		}
+		evidence, err := loadCurrentEvidence(ctx, s.db, runID, prID, head)
+		if err != nil {
+			return DeliveryPolicyResult{}, err
+		}
+		if requirements.CIPolicy != "" {
+			definition := workflow.Workflow.CI.Policies[requirements.CIPolicy]
+			status, err := evaluateEvidencePolicyStatus(definition, "ci", evidence)
+			if err != nil {
+				return DeliveryPolicyResult{}, fmt.Errorf("evaluate CI policy %s: %w", requirements.CIPolicy, err)
+			}
+			result.CIStatus = combineAllPolicyStatus(result.CIStatus, status)
+		}
+		if requirements.ReviewPolicy != "" {
+			definition := workflow.Workflow.Review.Policies[requirements.ReviewPolicy]
+			status, err := evaluateEvidencePolicyStatus(definition, "review", evidence)
+			if err != nil {
+				return DeliveryPolicyResult{}, fmt.Errorf("evaluate review policy %s: %w", requirements.ReviewPolicy, err)
+			}
+			result.ReviewStatus = combineAllPolicyStatus(result.ReviewStatus, status)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return DeliveryPolicyResult{}, err
+	}
+	result.CISatisfied = result.CIStatus == policySatisfied
+	result.ReviewSatisfied = result.ReviewStatus == policySatisfied
+	completionMet := true
+	if requirements.Completion == typesv2.DeliveryCompletionAllMerged {
+		completionMet = result.AllMerged
+	}
+	result.Satisfied = result.MinimumMet && result.CISatisfied && result.ReviewSatisfied && completionMet
+	return result, nil
+}
+
+func loadCurrentEvidence(ctx context.Context, db *sql.DB, runID, prID, head string) ([]storedEvidence, error) {
+	rows, err := db.QueryContext(ctx, `SELECT domain,connection,external_id,kind,status,payload_json
+		FROM workflow_v2_evidence WHERE run_id=? AND pr_id=? AND head_sha=? AND superseded_at=0
+		ORDER BY domain,connection,external_id,kind`, runID, prID, head)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var result []storedEvidence
+	for rows.Next() {
+		var item storedEvidence
+		var payload string
+		if err := rows.Scan(&item.Domain, &item.Connection, &item.ExternalID, &item.Kind, &item.Status, &payload); err != nil {
+			return nil, err
+		}
+		if err := json.Unmarshal([]byte(payload), &item.Payload); err != nil {
+			return nil, err
+		}
+		result = append(result, item)
+	}
+	return result, rows.Err()
+}
+
+func evaluateEvidencePolicy(policy typesv2.Policy, domain string, evidence []storedEvidence) (bool, error) {
+	status, err := evaluateEvidencePolicyStatus(policy, domain, evidence)
+	return status == policySatisfied, err
+}
+
+const (
+	policyPending     = "pending"
+	policySatisfied   = "satisfied"
+	policyUnsatisfied = "unsatisfied"
+)
+
+func evaluateEvidencePolicyStatus(policy typesv2.Policy, domain string, evidence []storedEvidence) (string, error) {
+	return evaluateEvidenceNode(map[string]interface{}(policy), domain, evidence)
+}
+
+func combineAllPolicyStatus(left, right string) string {
+	if left == policyUnsatisfied || right == policyUnsatisfied {
+		return policyUnsatisfied
+	}
+	if left == policyPending || right == policyPending {
+		return policyPending
+	}
+	return policySatisfied
+}
+
+func evaluateEvidenceNode(node interface{}, domain string, evidence []storedEvidence) (string, error) {
+	switch value := node.(type) {
+	case map[string]interface{}:
+		if raw, ok := value["all"]; ok {
+			items, ok := raw.([]interface{})
+			if !ok || len(items) == 0 {
+				return "", fmt.Errorf("all requires a non-empty list")
+			}
+			status := policySatisfied
+			for _, item := range items {
+				itemStatus, err := evaluateEvidenceNode(item, domain, evidence)
+				if err != nil {
+					return "", err
+				}
+				status = combineAllPolicyStatus(status, itemStatus)
+			}
+			return status, nil
+		}
+		if raw, ok := value["any"]; ok {
+			items, ok := raw.([]interface{})
+			if !ok || len(items) == 0 {
+				return "", fmt.Errorf("any requires a non-empty list")
+			}
+			pending := false
+			for _, item := range items {
+				itemStatus, err := evaluateEvidenceNode(item, domain, evidence)
+				if err != nil {
+					return "", err
+				}
+				if itemStatus == policySatisfied {
+					return policySatisfied, nil
+				}
+				pending = pending || itemStatus == policyPending
+			}
+			if pending {
+				return policyPending, nil
+			}
+			return policyUnsatisfied, nil
+		}
+		if raw, ok := value["not"]; ok {
+			status, err := evaluateEvidenceNode(raw, domain, evidence)
+			if err != nil || status == policyPending {
+				return status, err
+			}
+			if status == policySatisfied {
+				return policyUnsatisfied, nil
+			}
+			return policySatisfied, nil
+		}
+		return evaluateEvidenceLeaf(value, domain, evidence)
+	case typesv2.Policy:
+		return evaluateEvidenceNode(map[string]interface{}(value), domain, evidence)
+	default:
+		return "", fmt.Errorf("policy node has unsupported type %T", node)
+	}
+}
+
+func evaluateEvidenceLeaf(leaf map[string]interface{}, domain string, evidence []storedEvidence) (string, error) {
+	if domain == "ci" {
+		pipeline, _ := leaf["pipeline"].(string)
+		if pipeline == "" {
+			return "", fmt.Errorf("CI policy leaf requires pipeline")
+		}
+		checks, err := stringList(leaf["checks"])
+		if err != nil {
+			return "", fmt.Errorf("CI policy leaf checks: %w", err)
+		}
+		if len(checks) == 0 {
+			return "", fmt.Errorf("CI policy leaf checks must not be empty")
+		}
+		for _, check := range checks {
+			found := false
+			for _, item := range evidence {
+				if item.Domain == "ci" && item.Kind == check && item.Payload["pipeline"] == pipeline {
+					if item.Status == "success" {
+						found = true
+						break
+					}
+					if isFailureEvidenceStatus(item.Status) {
+						return policyUnsatisfied, nil
+					}
+				}
+			}
+			if !found {
+				return policyPending, nil
+			}
+		}
+		return policySatisfied, nil
+	}
+	connection, _ := leaf["connection"].(string)
+	if connection == "" {
+		return "", fmt.Errorf("review policy leaf requires connection")
+	}
+	minimum := 1
+	if approvals, ok := storedPolicyMap(leaf["approvals"]); ok {
+		if raw, exists := approvals["minimum"]; exists {
+			parsed, err := integerValue(raw)
+			if err != nil || parsed < 0 {
+				return "", fmt.Errorf("review approvals.minimum is invalid")
+			}
+			minimum = parsed
+		}
+	}
+	seen := map[string]bool{}
+	changesRequested := false
+	for _, item := range evidence {
+		if item.Domain == "review" && item.Connection == connection && item.Kind == "approval" && item.Status == "approved" {
+			seen[item.ExternalID] = true
+		}
+		if item.Domain == "review" && item.Connection == connection && isFailureEvidenceStatus(item.Status) {
+			changesRequested = true
+		}
+	}
+	if len(seen) >= minimum && !changesRequested {
+		return policySatisfied, nil
+	}
+	if changesRequested {
+		return policyUnsatisfied, nil
+	}
+	return policyPending, nil
+}
+
+func storedPolicyMap(value interface{}) (map[string]interface{}, bool) {
+	switch typed := value.(type) {
+	case map[string]interface{}:
+		return typed, true
+	case typesv2.Policy:
+		return map[string]interface{}(typed), true
+	default:
+		return nil, false
+	}
+}
+
+func isFailureEvidenceStatus(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "failure", "failed", "error", "cancelled", "timed_out", "changes_requested", "rejected":
+		return true
+	default:
+		return false
+	}
+}
+
+func stringList(raw interface{}) ([]string, error) {
+	items, ok := raw.([]interface{})
+	if !ok {
+		if typed, ok := raw.([]string); ok {
+			return typed, nil
+		}
+		return nil, fmt.Errorf("must be a list")
+	}
+	result := make([]string, 0, len(items))
+	for _, item := range items {
+		value, ok := item.(string)
+		if !ok || strings.TrimSpace(value) == "" {
+			return nil, fmt.Errorf("must contain non-empty strings")
+		}
+		result = append(result, value)
+	}
+	return result, nil
+}
+
+func integerValue(raw interface{}) (int, error) {
+	switch value := raw.(type) {
+	case int:
+		return value, nil
+	case int64:
+		return int(value), nil
+	case float64:
+		if value != float64(int(value)) {
+			return 0, fmt.Errorf("must be an integer")
+		}
+		return int(value), nil
+	case json.Number:
+		parsed, err := strconv.Atoi(string(value))
+		return parsed, err
+	default:
+		return 0, fmt.Errorf("must be an integer")
+	}
+}

--- a/pkg/hub/workflowv2/evidence.go
+++ b/pkg/hub/workflowv2/evidence.go
@@ -45,19 +45,16 @@ func (s *Store) RecordEvidence(ctx context.Context, input EvidenceInput, produce
 	if s == nil || s.db == nil {
 		return DeliveryPolicyResult{}, fmt.Errorf("workflow v2 store is not configured")
 	}
+	input.Domain = strings.ToLower(strings.TrimSpace(input.Domain))
+	input.Connection = strings.TrimSpace(input.Connection)
+	input.ExternalID = strings.TrimSpace(input.ExternalID)
+	input.Kind = strings.TrimSpace(input.Kind)
+	input.Status = strings.ToLower(strings.TrimSpace(input.Status))
 	if err := validateEvidenceProducer(input.Domain, producer); err != nil {
 		return DeliveryPolicyResult{}, err
 	}
 	if input.RunID == "" || input.PRID == "" || input.HeadSHA == "" || input.ExternalID == "" || input.Kind == "" || input.Status == "" {
 		return DeliveryPolicyResult{}, fmt.Errorf("run, pull request, head, external id, kind, and status are required")
-	}
-	var currentHead string
-	if err := s.db.QueryRowContext(ctx, `SELECT current_head_sha FROM workflow_v2_delivery_prs
-		WHERE id=? AND run_id=? AND active=1`, input.PRID, input.RunID).Scan(&currentHead); err != nil {
-		return DeliveryPolicyResult{}, fmt.Errorf("load active delivery: %w", err)
-	}
-	if currentHead != input.HeadSHA {
-		return DeliveryPolicyResult{}, fmt.Errorf("evidence head %s is stale; current head is %s", input.HeadSHA, currentHead)
 	}
 	if strings.TrimSpace(input.Provenance.Producer) != string(producer) {
 		return DeliveryPolicyResult{}, fmt.Errorf("evidence provenance producer %q does not match trusted adapter %q",
@@ -85,15 +82,38 @@ func (s *Store) RecordEvidence(ctx context.Context, input EvidenceInput, produce
 	if id == "" {
 		id = uuid.NewString()
 	}
-	_, err = s.db.ExecContext(ctx, `INSERT INTO workflow_v2_evidence(
-		id,run_id,pr_id,head_sha,domain,connection,external_id,kind,status,payload_json,provenance_json,observed_at)
-		VALUES(?,?,?,?,?,?,?,?,?,?,?,?)
-		ON CONFLICT(run_id,domain,connection,external_id,kind,head_sha) DO UPDATE SET
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return DeliveryPolicyResult{}, err
+	}
+	defer tx.Rollback()
+	var currentHead string
+	var headGeneration int
+	if err := tx.QueryRowContext(ctx, `SELECT p.current_head_sha,COALESCE(MAX(h.generation),0)
+		FROM workflow_v2_delivery_prs p LEFT JOIN workflow_v2_delivery_heads h ON h.pr_id=p.id
+		WHERE p.id=? AND p.run_id=? AND p.active=1 GROUP BY p.id`, input.PRID, input.RunID).Scan(
+		&currentHead, &headGeneration); err != nil {
+		return DeliveryPolicyResult{}, fmt.Errorf("load active delivery: %w", err)
+	}
+	if currentHead != input.HeadSHA {
+		return DeliveryPolicyResult{}, fmt.Errorf("evidence head %s is stale; current head is %s", input.HeadSHA, currentHead)
+	}
+	if headGeneration < 1 {
+		return DeliveryPolicyResult{}, fmt.Errorf("active delivery has no verified head generation")
+	}
+	_, err = tx.ExecContext(ctx, `INSERT INTO workflow_v2_evidence(
+		id,run_id,pr_id,head_sha,head_generation,domain,connection,external_id,kind,status,payload_json,provenance_json,observed_at)
+		VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?)
+		ON CONFLICT(run_id,pr_id,domain,connection,external_id,kind,head_generation) DO UPDATE SET
 		status=excluded.status,payload_json=excluded.payload_json,provenance_json=excluded.provenance_json,
-		observed_at=excluded.observed_at,superseded_at=0`, id, input.RunID, input.PRID, input.HeadSHA,
-		input.Domain, input.Connection, input.ExternalID, input.Kind, input.Status, string(payloadJSON),
+		observed_at=excluded.observed_at,superseded_at=0
+		WHERE excluded.observed_at>=workflow_v2_evidence.observed_at`, id, input.RunID, input.PRID, input.HeadSHA,
+		headGeneration, input.Domain, input.Connection, input.ExternalID, input.Kind, input.Status, string(payloadJSON),
 		provenanceJSON, observed.UnixMilli())
 	if err != nil {
+		return DeliveryPolicyResult{}, err
+	}
+	if err := tx.Commit(); err != nil {
 		return DeliveryPolicyResult{}, err
 	}
 	result, err := s.EvaluateDeliveryPolicy(ctx, input.RunID)
@@ -198,6 +218,7 @@ type storedEvidence struct {
 	Kind       string
 	Status     string
 	Payload    map[string]interface{}
+	ObservedAt time.Time
 }
 
 func (s *Store) EvaluateDeliveryPolicy(ctx context.Context, runID string) (DeliveryPolicyResult, error) {
@@ -217,7 +238,7 @@ func (s *Store) EvaluateDeliveryPolicy(ctx context.Context, runID string) (Deliv
 		return DeliveryPolicyResult{}, err
 	}
 	result := DeliveryPolicyResult{PullRequestCount: prs.count, CISatisfied: true, CIStatus: policySatisfied,
-		ReviewSatisfied: true, ReviewStatus: policySatisfied, AllMerged: prs.count > 0 && prs.count == prs.merged}
+		ReviewSatisfied: true, ReviewStatus: policySatisfied, AllMerged: prs.count == prs.merged}
 	policy := workflow.Workflow.Delivery
 	if policy == nil || policy.PullRequests == nil {
 		result.MinimumMet = true
@@ -226,18 +247,23 @@ func (s *Store) EvaluateDeliveryPolicy(ctx context.Context, runID string) (Deliv
 	}
 	requirements := policy.PullRequests
 	result.MinimumMet = prs.count >= requirements.Minimum && (!requirements.Required || prs.count > 0)
-	rows, err := s.db.QueryContext(ctx, `SELECT id,current_head_sha FROM workflow_v2_delivery_prs
-		WHERE run_id=? AND active=1 ORDER BY repository,pr_number`, runID)
+	rows, err := s.db.QueryContext(ctx, `SELECT p.id,COALESCE(MAX(h.generation),0)
+		FROM workflow_v2_delivery_prs p LEFT JOIN workflow_v2_delivery_heads h ON h.pr_id=p.id
+		WHERE p.run_id=? AND p.active=1 GROUP BY p.id ORDER BY p.repository,p.pr_number`, runID)
 	if err != nil {
 		return DeliveryPolicyResult{}, err
 	}
 	defer rows.Close()
 	for rows.Next() {
-		var prID, head string
-		if err := rows.Scan(&prID, &head); err != nil {
+		var prID string
+		var generation int
+		if err := rows.Scan(&prID, &generation); err != nil {
 			return DeliveryPolicyResult{}, err
 		}
-		evidence, err := loadCurrentEvidence(ctx, s.db, runID, prID, head)
+		if generation < 1 {
+			return DeliveryPolicyResult{}, fmt.Errorf("active delivery %s has no verified head generation", prID)
+		}
+		evidence, err := loadCurrentEvidence(ctx, s.db, runID, prID, generation)
 		if err != nil {
 			return DeliveryPolicyResult{}, err
 		}
@@ -271,10 +297,10 @@ func (s *Store) EvaluateDeliveryPolicy(ctx context.Context, runID string) (Deliv
 	return result, nil
 }
 
-func loadCurrentEvidence(ctx context.Context, db *sql.DB, runID, prID, head string) ([]storedEvidence, error) {
-	rows, err := db.QueryContext(ctx, `SELECT domain,connection,external_id,kind,status,payload_json
-		FROM workflow_v2_evidence WHERE run_id=? AND pr_id=? AND head_sha=? AND superseded_at=0
-		ORDER BY domain,connection,external_id,kind`, runID, prID, head)
+func loadCurrentEvidence(ctx context.Context, db *sql.DB, runID, prID string, generation int) ([]storedEvidence, error) {
+	rows, err := db.QueryContext(ctx, `SELECT domain,connection,external_id,kind,status,payload_json,observed_at
+		FROM workflow_v2_evidence WHERE run_id=? AND pr_id=? AND head_generation=? AND superseded_at=0
+		ORDER BY domain,connection,external_id,kind,observed_at`, runID, prID, generation)
 	if err != nil {
 		return nil, err
 	}
@@ -283,12 +309,14 @@ func loadCurrentEvidence(ctx context.Context, db *sql.DB, runID, prID, head stri
 	for rows.Next() {
 		var item storedEvidence
 		var payload string
-		if err := rows.Scan(&item.Domain, &item.Connection, &item.ExternalID, &item.Kind, &item.Status, &payload); err != nil {
+		var observedAt int64
+		if err := rows.Scan(&item.Domain, &item.Connection, &item.ExternalID, &item.Kind, &item.Status, &payload, &observedAt); err != nil {
 			return nil, err
 		}
 		if err := json.Unmarshal([]byte(payload), &item.Payload); err != nil {
 			return nil, err
 		}
+		item.ObservedAt = time.UnixMilli(observedAt).UTC()
 		result = append(result, item)
 	}
 	return result, rows.Err()
@@ -390,19 +418,23 @@ func evaluateEvidenceLeaf(leaf map[string]interface{}, domain string, evidence [
 			return "", fmt.Errorf("CI policy leaf checks must not be empty")
 		}
 		for _, check := range checks {
-			found := false
+			var latest *storedEvidence
 			for _, item := range evidence {
 				if item.Domain == "ci" && item.Kind == check && item.Payload["pipeline"] == pipeline {
-					if item.Status == "success" {
-						found = true
-						break
-					}
-					if isFailureEvidenceStatus(item.Status) {
-						return policyUnsatisfied, nil
+					candidate := item
+					if latest == nil || candidate.ObservedAt.After(latest.ObservedAt) ||
+						(candidate.ObservedAt.Equal(latest.ObservedAt) && candidate.ExternalID > latest.ExternalID) {
+						latest = &candidate
 					}
 				}
 			}
-			if !found {
+			if latest == nil {
+				return policyPending, nil
+			}
+			if isFailureEvidenceStatus(latest.Status) {
+				return policyUnsatisfied, nil
+			}
+			if latest.Status != "success" {
 				return policyPending, nil
 			}
 		}
@@ -422,17 +454,26 @@ func evaluateEvidenceLeaf(leaf map[string]interface{}, domain string, evidence [
 			minimum = parsed
 		}
 	}
-	seen := map[string]bool{}
-	changesRequested := false
+	latestByPrincipal := map[string]storedEvidence{}
 	for _, item := range evidence {
-		if item.Domain == "review" && item.Connection == connection && item.Kind == "approval" && item.Status == "approved" {
-			seen[item.ExternalID] = true
+		if item.Domain != "review" || item.Connection != connection || item.Kind != "approval" {
+			continue
 		}
-		if item.Domain == "review" && item.Connection == connection && isFailureEvidenceStatus(item.Status) {
-			changesRequested = true
+		current, ok := latestByPrincipal[item.ExternalID]
+		if !ok || item.ObservedAt.After(current.ObservedAt) ||
+			(item.ObservedAt.Equal(current.ObservedAt) && item.Status > current.Status) {
+			latestByPrincipal[item.ExternalID] = item
 		}
 	}
-	if len(seen) >= minimum && !changesRequested {
+	approvals := 0
+	changesRequested := false
+	for _, item := range latestByPrincipal {
+		if item.Status == "approved" {
+			approvals++
+		}
+		changesRequested = changesRequested || isFailureEvidenceStatus(item.Status)
+	}
+	if approvals >= minimum && !changesRequested {
 		return policySatisfied, nil
 	}
 	if changesRequested {

--- a/pkg/hub/workflowv2/evidence.go
+++ b/pkg/hub/workflowv2/evidence.go
@@ -120,13 +120,14 @@ func (s *Store) RecordEvidence(ctx context.Context, input EvidenceInput, produce
 	if err != nil {
 		return DeliveryPolicyResult{}, err
 	}
-	if err := s.publishEvidencePolicyEvents(ctx, input.RunID, input.Domain, result, observed); err != nil {
+	if err := s.publishEvidencePolicyEvents(ctx, input.RunID, "", input.Domain, result, observed); err != nil {
 		return DeliveryPolicyResult{}, err
 	}
 	return result, nil
 }
 
-func (s *Store) publishEvidencePolicyEvents(ctx context.Context, runID, domain string, result DeliveryPolicyResult, observed time.Time) error {
+func (s *Store) publishEvidencePolicyEvents(ctx context.Context, runID, attemptID, domain string,
+	result DeliveryPolicyResult, observed time.Time) error {
 	var workflowYAML string
 	if err := s.db.QueryRowContext(ctx, `SELECT workflow_yaml FROM workflow_v2_runs WHERE id=?`, runID).Scan(&workflowYAML); err != nil {
 		return err
@@ -140,7 +141,7 @@ func (s *Store) publishEvidencePolicyEvents(ctx context.Context, runID, domain s
 		if domain == "ci" && requirements.CIPolicy != "" {
 			status := result.CIStatus
 			event, err := s.ApplyEvent(ctx, runID, EventInput{
-				ID: uuid.NewString(), Kind: "ci.policy.evaluated", Producer: ProducerCI,
+				ID: uuid.NewString(), Kind: "ci.policy.evaluated", AttemptID: attemptID, Producer: ProducerCI,
 				Payload:    map[string]interface{}{"ci": map[string]interface{}{"policy": requirements.CIPolicy, "status": status}},
 				Facts:      map[string]interface{}{"ci.policy": requirements.CIPolicy, "ci.status": status},
 				Provenance: typesv2.EvidenceProvenance{Producer: string(ProducerCI), ObservedAt: observed},
@@ -155,7 +156,7 @@ func (s *Store) publishEvidencePolicyEvents(ctx context.Context, runID, domain s
 		if domain == "review" && requirements.ReviewPolicy != "" {
 			status := result.ReviewStatus
 			event, err := s.ApplyEvent(ctx, runID, EventInput{
-				ID: uuid.NewString(), Kind: "review.policy.evaluated", Producer: ProducerReview,
+				ID: uuid.NewString(), Kind: "review.policy.evaluated", AttemptID: attemptID, Producer: ProducerReview,
 				Payload:    map[string]interface{}{"review": map[string]interface{}{"policy": requirements.ReviewPolicy, "status": status}},
 				Facts:      map[string]interface{}{"review.policy": requirements.ReviewPolicy, "review.status": status},
 				Provenance: typesv2.EvidenceProvenance{Producer: string(ProducerReview), ObservedAt: observed},
@@ -169,7 +170,7 @@ func (s *Store) publishEvidencePolicyEvents(ctx context.Context, runID, domain s
 		}
 	}
 	deliveryEvent, err := s.ApplyEvent(ctx, runID, EventInput{
-		ID: uuid.NewString(), Kind: "workflow.delivery.evaluated", Producer: ProducerEngine,
+		ID: uuid.NewString(), Kind: "workflow.delivery.evaluated", AttemptID: attemptID, Producer: ProducerEngine,
 		Payload: map[string]interface{}{"workflow": map[string]interface{}{"delivery": result}},
 		Facts: map[string]interface{}{
 			"delivery.minimum_met": result.MinimumMet, "delivery.ci_satisfied": result.CISatisfied,

--- a/pkg/hub/workflowv2/evidence_revision_internal_test.go
+++ b/pkg/hub/workflowv2/evidence_revision_internal_test.go
@@ -1,0 +1,138 @@
+package workflowv2
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	typesv2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
+	_ "modernc.org/sqlite"
+)
+
+const revisionTestWorkspace = `
+schema_version: 2
+name: revision-test
+repositories:
+  api:
+    provider: github
+    repository: org/api
+ci:
+  connections:
+    github-actions:
+      provider: github
+  pipelines:
+    github-pr:
+      connection: github-actions
+      repository: api
+      workflow: ci.yml
+`
+
+const revisionTestWorkflow = `
+schema_version: 2
+name: revision-test
+enabled: true
+initial_state: reviewing
+states:
+  reviewing:
+    phase: review
+  done:
+    phase: done
+    terminal: true
+transitions:
+  ci_satisfied:
+    from: reviewing
+    on: ci.policy.evaluated
+    when:
+      ci:
+        status:
+          equals: satisfied
+    to: done
+ci:
+  policies:
+    merge-ready:
+      all:
+        - pipeline: github-pr
+          checks: [lint]
+      satisfied_for: current_pr_head
+delivery:
+  pull_requests:
+    required: true
+    minimum: 1
+    ci_policy: merge-ready
+`
+
+func TestPolicyEventRejectsSupersededEvaluationRevision(t *testing.T) {
+	dsn := filepath.Join(t.TempDir(), "revision.db") + "?_txlock=immediate&_pragma=foreign_keys(on)&_pragma=busy_timeout(5000)"
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := Migrate(db); err != nil {
+		t.Fatal(err)
+	}
+	store := NewStore(db)
+	if _, err := store.CreateRun(context.Background(), CreateRunRequest{
+		ID: "run-policy-revision", TenantID: "tenant-1", WorkspaceYAML: []byte(revisionTestWorkspace),
+		WorkflowYAML: []byte(revisionTestWorkflow),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC).UnixMilli()
+	if _, err := db.Exec(`INSERT INTO workflow_v2_delivery_prs(
+		id,run_id,url,repository_name,repository,pr_number,source_branch,base_branch,current_head_sha,state,
+		active,provenance_json,verified_at,updated_at) VALUES(?,?,?,?,?,?,?,?,?,'open',1,'{}',?,?)`,
+		"pr-1", "run-policy-revision", "https://github.example/org/api/pull/1", "api", "org/api", 1,
+		"feature", "main", "head-1", now, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO workflow_v2_delivery_heads(id,pr_id,head_sha,generation,observed_at)
+		VALUES('head-generation-1','pr-1','head-1',1,?)`, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO workflow_v2_evidence(
+		id,run_id,pr_id,head_sha,head_generation,domain,connection,external_id,kind,status,payload_json,provenance_json,observed_at)
+		VALUES('evidence-1','run-policy-revision','pr-1','head-1',1,'ci','github-actions','lint-1','lint','success',
+		'{"pipeline":"github-pr"}','{}',?)`, now); err != nil {
+		t.Fatal(err)
+	}
+	evaluated, err := store.EvaluateDeliveryPolicy(context.Background(), "run-policy-revision")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !evaluated.CISatisfied || evaluated.Revision == "" {
+		t.Fatalf("evaluated policy = %#v", evaluated)
+	}
+	if _, err := db.Exec(`UPDATE workflow_v2_delivery_prs SET current_head_sha='head-2',updated_at=? WHERE id='pr-1'`, now+1); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO workflow_v2_delivery_heads(id,pr_id,head_sha,generation,observed_at)
+		VALUES('head-generation-2','pr-1','head-2',2,?)`, now+1); err != nil {
+		t.Fatal(err)
+	}
+	_, err = store.applyDeliveryPolicyEvent(context.Background(), "run-policy-revision", evaluated, EventInput{
+		ID: "stale-policy-event", Kind: "ci.policy.evaluated", Producer: ProducerCI,
+		Payload: map[string]interface{}{"ci": map[string]interface{}{"policy": "merge-ready", "status": "satisfied"}},
+		Facts:   map[string]interface{}{"ci.policy": "merge-ready", "ci.status": "satisfied"},
+		Provenance: typesv2.EvidenceProvenance{
+			Producer: string(ProducerCI), ObservedAt: time.UnixMilli(now).UTC(),
+		},
+	})
+	if !errors.Is(err, errDeliveryPolicyChanged) {
+		t.Fatalf("stale policy event error = %v", err)
+	}
+	var eventCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_events WHERE id='stale-policy-event'`).Scan(&eventCount); err != nil {
+		t.Fatal(err)
+	}
+	run, err := store.GetRun(context.Background(), "run-policy-revision")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if eventCount != 0 || run.State != "reviewing" {
+		t.Fatalf("stale event count/run = %d/%#v", eventCount, run)
+	}
+}

--- a/pkg/hub/workflowv2/evidence_revision_internal_test.go
+++ b/pkg/hub/workflowv2/evidence_revision_internal_test.go
@@ -81,6 +81,10 @@ func TestPolicyEventRejectsSupersededEvaluationRevision(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
+	firstAttempt, err := store.StartAttempt(context.Background(), "run-policy-revision", "claw-1")
+	if err != nil {
+		t.Fatal(err)
+	}
 	now := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC).UnixMilli()
 	if _, err := db.Exec(`INSERT INTO workflow_v2_delivery_prs(
 		id,run_id,url,repository_name,repository,pr_number,source_branch,base_branch,current_head_sha,state,
@@ -134,5 +138,30 @@ func TestPolicyEventRejectsSupersededEvaluationRevision(t *testing.T) {
 	}
 	if eventCount != 0 || run.State != "reviewing" {
 		t.Fatalf("stale event count/run = %d/%#v", eventCount, run)
+	}
+	current, err := store.EvaluateDeliveryPolicy(context.Background(), "run-policy-revision")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.StartAttempt(context.Background(), "run-policy-revision", "claw-2"); err != nil {
+		t.Fatal(err)
+	}
+	_, err = store.applyDeliveryPolicyEvent(context.Background(), "run-policy-revision", current, EventInput{
+		ID: "revoked-policy-event", Kind: "workflow.delivery.evaluated", AttemptID: firstAttempt.ID,
+		Producer: ProducerEngine,
+		Payload:  map[string]interface{}{"workflow": map[string]interface{}{"delivery": current}},
+		Facts:    map[string]interface{}{"delivery.satisfied": current.Satisfied},
+		Provenance: typesv2.EvidenceProvenance{
+			Producer: string(ProducerEngine), ObservedAt: time.UnixMilli(now + 1).UTC(),
+		},
+	})
+	if err == nil {
+		t.Fatal("policy event from revoked attempt was accepted")
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_events WHERE id='revoked-policy-event'`).Scan(&eventCount); err != nil {
+		t.Fatal(err)
+	}
+	if eventCount != 0 {
+		t.Fatalf("revoked policy event rows = %d", eventCount)
 	}
 }

--- a/pkg/hub/workflowv2/evidence_test.go
+++ b/pkg/hub/workflowv2/evidence_test.go
@@ -172,6 +172,11 @@ func TestEvidenceForOldHeadIsRejectedAndInvalidated(t *testing.T) {
 	attempt, pr := createPolicyDelivery(t, store, "run-stale-evidence", "head-1", "open")
 	recordPolicyEvidence(t, store, "run-stale-evidence", pr, "ci", "github-actions", "lint-run", "lint", "success",
 		map[string]interface{}{"pipeline": "github-pr"}, workflowv2.ProducerCI)
+	initial := recordPolicyEvidence(t, store, "run-stale-evidence", pr, "ci", "github-actions", "unit-run", "unit", "success",
+		map[string]interface{}{"pipeline": "github-pr"}, workflowv2.ProducerCI)
+	if !initial.CISatisfied {
+		t.Fatalf("initial head CI = %#v", initial)
+	}
 	prURL := pr.URL
 	now := time.Date(2026, 8, 8, 12, 5, 0, 0, time.UTC)
 	updated, err := store.SubmitDelivery(context.Background(), "run-stale-evidence", attempt.ID, typesv2.DeliveryManifest{
@@ -198,6 +203,96 @@ func TestEvidenceForOldHeadIsRejectedAndInvalidated(t *testing.T) {
 	}
 	if result.CISatisfied {
 		t.Fatalf("new head inherited old CI evidence: %#v; updated=%#v", result, updated)
+	}
+	returned, err := store.SubmitDelivery(context.Background(), "run-stale-evidence", attempt.ID, typesv2.DeliveryManifest{
+		PullRequests: []typesv2.PullRequestClaim{{URL: prURL}},
+	}, workflowv2.PullRequestVerifierFunc(func(context.Context, workflowv2.Run, *typesv2.Workspace,
+		typesv2.PullRequestClaim) (typesv2.VerifiedPullRequest, error) {
+		return typesv2.VerifiedPullRequest{URL: prURL, RepositoryName: "api", Repository: "org/api", Number: 10,
+			SourceBranch: "feature", BaseBranch: "main", HeadSHA: "head-1", State: "open", VerifiedAt: now.Add(time.Minute),
+			Provenance: typesv2.EvidenceProvenance{Producer: string(workflowv2.ProducerSourceControl), ObservedAt: now.Add(time.Minute)}}, nil
+	}))
+	if err != nil {
+		t.Fatalf("return to prior head: %v", err)
+	}
+	result, err = store.EvaluateDeliveryPolicy(context.Background(), "run-stale-evidence")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.CISatisfied {
+		t.Fatalf("returned head inherited evidence from its old generation: %#v; returned=%#v", result, returned)
+	}
+	var generations int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_delivery_heads WHERE pr_id=?`, pr.ID).Scan(&generations); err != nil {
+		t.Fatal(err)
+	}
+	if generations != 3 {
+		t.Fatalf("head generations = %d, want 3", generations)
+	}
+}
+
+func TestCIPolicyUsesLatestCheckObservation(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	_, pr := createPolicyDelivery(t, store, "run-latest-ci", "head-1", "open")
+	base := time.Date(2026, 8, 8, 12, 1, 0, 0, time.UTC)
+	record := func(externalID, kind, status string, observed time.Time) workflowv2.DeliveryPolicyResult {
+		result, err := store.RecordEvidence(context.Background(), workflowv2.EvidenceInput{
+			RunID: "run-latest-ci", PRID: pr.ID, HeadSHA: pr.HeadSHA, Domain: "ci", Connection: "github-actions",
+			ExternalID: externalID, Kind: kind, Status: status, Payload: map[string]interface{}{"pipeline": "github-pr"},
+			ObservedAt: observed, Provenance: typesv2.EvidenceProvenance{Producer: string(workflowv2.ProducerCI),
+				Connection: "github-actions", ObservedAt: observed},
+		}, workflowv2.ProducerCI)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return result
+	}
+	record("lint-old", "lint", "failure", base)
+	record("unit", "unit", "success", base)
+	latest := record("lint-new", "lint", "success", base.Add(time.Minute))
+	if !latest.CISatisfied || latest.CIStatus != "satisfied" {
+		t.Fatalf("newer successful rerun did not replace failure: %#v", latest)
+	}
+	regressed := record("lint-old", "lint", "failure", base.Add(-time.Minute))
+	if !regressed.CISatisfied || regressed.CIStatus != "satisfied" {
+		t.Fatalf("out-of-order evidence regressed policy: %#v", regressed)
+	}
+	failed := record("lint-newest", "lint", "failure", base.Add(2*time.Minute))
+	if failed.CISatisfied || failed.CIStatus != "unsatisfied" {
+		t.Fatalf("newest failure did not fail policy: %#v", failed)
+	}
+}
+
+func TestEvidenceIdentityIsScopedToPullRequest(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	attempt := createDeliveryRun(t, store, "run-evidence-pr-scope")
+	apiURL := "https://github.example/org/api/pull/10"
+	webURL := "https://github.example/org/web/pull/20"
+	verified, err := store.SubmitDelivery(context.Background(), "run-evidence-pr-scope", attempt.ID,
+		typesv2.DeliveryManifest{PullRequests: []typesv2.PullRequestClaim{{URL: apiURL}, {URL: webURL}}},
+		deliveryVerifier(map[string]string{apiURL: "shared-head", webURL: "shared-head"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	observed := time.Date(2026, 8, 8, 12, 1, 0, 0, time.UTC)
+	for _, pr := range verified {
+		if _, err := store.RecordEvidence(context.Background(), workflowv2.EvidenceInput{
+			RunID: "run-evidence-pr-scope", PRID: pr.ID, HeadSHA: pr.HeadSHA, Domain: "ci", Connection: "github",
+			ExternalID: "same-provider-id", Kind: "unit", Status: "success",
+			Payload: map[string]interface{}{"pipeline": "shared"}, ObservedAt: observed,
+			Provenance: typesv2.EvidenceProvenance{Producer: string(workflowv2.ProducerCI), ObservedAt: observed},
+		}, workflowv2.ProducerCI); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_evidence WHERE run_id='run-evidence-pr-scope'`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 2 {
+		t.Fatalf("cross-PR evidence rows = %d, want 2", count)
 	}
 }
 

--- a/pkg/hub/workflowv2/evidence_test.go
+++ b/pkg/hub/workflowv2/evidence_test.go
@@ -1,0 +1,216 @@
+package workflowv2_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	workflowv2 "github.com/elasticclaw/elasticclaw/pkg/hub/workflowv2"
+	typesv2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
+)
+
+const policyWorkspaceYAML = `
+schema_version: 2
+name: engineering
+repositories:
+  api:
+    provider: github
+    repository: org/api
+source_control:
+  connections:
+    github:
+      provider: github
+ci:
+  connections:
+    github-actions:
+      provider: github
+      source_control: github
+  pipelines:
+    github-pr:
+      connection: github-actions
+      repository: api
+      workflow: ci.yml
+review_systems:
+  connections:
+    github-reviews:
+      provider: github
+      source_control: github
+`
+
+const policyWorkflowYAML = `
+schema_version: 2
+name: delivery-policy
+enabled: true
+initial_state: reviewing
+states:
+  reviewing:
+    phase: review
+  fixing:
+    phase: build
+transitions:
+  review_failed:
+    from: reviewing
+    on: review.policy.evaluated
+    when:
+      review:
+        status:
+          equals: unsatisfied
+    to: fixing
+ci:
+  policies:
+    merge-ready:
+      all:
+        - pipeline: github-pr
+          checks: [lint, unit]
+      satisfied_for: current_pr_head
+review:
+  policies:
+    required-review:
+      all:
+        - connection: github-reviews
+          approvals:
+            minimum: 1
+      invalidate_on_new_head: true
+delivery:
+  pull_requests:
+    required: true
+    minimum: 1
+    ci_policy: merge-ready
+    review_policy: required-review
+    completion: all_merged
+`
+
+func createPolicyDelivery(t *testing.T, store *workflowv2.Store, runID, head, state string) (workflowv2.Attempt, typesv2.VerifiedPullRequest) {
+	t.Helper()
+	if _, err := store.CreateRun(context.Background(), workflowv2.CreateRunRequest{
+		ID: runID, TenantID: "tenant-1", WorkspaceYAML: []byte(policyWorkspaceYAML), WorkflowYAML: []byte(policyWorkflowYAML),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	attempt, err := store.StartAttempt(context.Background(), runID, "claw-policy")
+	if err != nil {
+		t.Fatal(err)
+	}
+	prURL := "https://github.example/org/api/pull/10"
+	verified, err := store.SubmitDelivery(context.Background(), runID, attempt.ID, typesv2.DeliveryManifest{
+		PullRequests: []typesv2.PullRequestClaim{{URL: prURL}},
+	}, workflowv2.PullRequestVerifierFunc(func(context.Context, workflowv2.Run, *typesv2.Workspace,
+		typesv2.PullRequestClaim) (typesv2.VerifiedPullRequest, error) {
+		now := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+		return typesv2.VerifiedPullRequest{URL: prURL, RepositoryName: "api", Repository: "org/api", Number: 10,
+			SourceBranch: "feature", BaseBranch: "main", HeadSHA: head, State: state, VerifiedAt: now,
+			Provenance: typesv2.EvidenceProvenance{Producer: string(workflowv2.ProducerSourceControl), ObservedAt: now}}, nil
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return attempt, verified[0]
+}
+
+func recordPolicyEvidence(t *testing.T, store *workflowv2.Store, runID string, pr typesv2.VerifiedPullRequest,
+	domain, connection, externalID, kind, status string, payload map[string]interface{}, producer workflowv2.Producer) workflowv2.DeliveryPolicyResult {
+	t.Helper()
+	now := time.Date(2026, 8, 8, 12, 1, 0, 0, time.UTC)
+	result, err := store.RecordEvidence(context.Background(), workflowv2.EvidenceInput{
+		RunID: runID, PRID: pr.ID, HeadSHA: pr.HeadSHA, Domain: domain, Connection: connection,
+		ExternalID: externalID, Kind: kind, Status: status, Payload: payload, ObservedAt: now,
+		Provenance: typesv2.EvidenceProvenance{Producer: string(producer), Connection: connection, ObservedAt: now},
+	}, producer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return result
+}
+
+func TestHeadBoundCIAndReviewPoliciesRequireAllEvidence(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	_, pr := createPolicyDelivery(t, store, "run-policy", "head-1", "open")
+
+	result := recordPolicyEvidence(t, store, "run-policy", pr, "ci", "github-actions", "lint-run", "lint", "success",
+		map[string]interface{}{"pipeline": "github-pr"}, workflowv2.ProducerCI)
+	if result.CISatisfied || result.CIStatus != "pending" || result.ReviewSatisfied || result.ReviewStatus != "pending" || result.Satisfied {
+		t.Fatalf("policy satisfied too early: %#v", result)
+	}
+	result = recordPolicyEvidence(t, store, "run-policy", pr, "ci", "github-actions", "unit-run", "unit", "success",
+		map[string]interface{}{"pipeline": "github-pr"}, workflowv2.ProducerCI)
+	if !result.CISatisfied || result.CIStatus != "satisfied" || result.ReviewSatisfied || result.ReviewStatus != "pending" || result.Satisfied {
+		t.Fatalf("CI result = %#v", result)
+	}
+	result = recordPolicyEvidence(t, store, "run-policy", pr, "review", "github-reviews", "alice", "approval", "approved",
+		nil, workflowv2.ProducerReview)
+	if !result.CISatisfied || !result.ReviewSatisfied || result.Satisfied || result.AllMerged {
+		t.Fatalf("review result = %#v", result)
+	}
+	inspection, err := store.InspectRun(context.Background(), "run-policy")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inspection.Run.State != "reviewing" {
+		t.Fatalf("satisfied review should not take failure edge: %#v", inspection.Run)
+	}
+}
+
+func TestUnsatisfiedReviewLoopsBackToBuild(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	_, pr := createPolicyDelivery(t, store, "run-review-loop", "head-1", "open")
+	recordPolicyEvidence(t, store, "run-review-loop", pr, "review", "github-reviews", "alice", "approval", "changes_requested",
+		nil, workflowv2.ProducerReview)
+	run, err := store.GetRun(context.Background(), "run-review-loop")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.State != "fixing" || run.DisplayPhase != typesv2.PhaseBuild || run.StateVersion != 2 {
+		t.Fatalf("run = %#v", run)
+	}
+}
+
+func TestEvidenceForOldHeadIsRejectedAndInvalidated(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	attempt, pr := createPolicyDelivery(t, store, "run-stale-evidence", "head-1", "open")
+	recordPolicyEvidence(t, store, "run-stale-evidence", pr, "ci", "github-actions", "lint-run", "lint", "success",
+		map[string]interface{}{"pipeline": "github-pr"}, workflowv2.ProducerCI)
+	prURL := pr.URL
+	now := time.Date(2026, 8, 8, 12, 5, 0, 0, time.UTC)
+	updated, err := store.SubmitDelivery(context.Background(), "run-stale-evidence", attempt.ID, typesv2.DeliveryManifest{
+		PullRequests: []typesv2.PullRequestClaim{{URL: prURL}},
+	}, workflowv2.PullRequestVerifierFunc(func(context.Context, workflowv2.Run, *typesv2.Workspace,
+		typesv2.PullRequestClaim) (typesv2.VerifiedPullRequest, error) {
+		return typesv2.VerifiedPullRequest{URL: prURL, RepositoryName: "api", Repository: "org/api", Number: 10,
+			SourceBranch: "feature", BaseBranch: "main", HeadSHA: "head-2", State: "open", VerifiedAt: now,
+			Provenance: typesv2.EvidenceProvenance{Producer: string(workflowv2.ProducerSourceControl), ObservedAt: now}}, nil
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.RecordEvidence(context.Background(), workflowv2.EvidenceInput{
+		RunID: "run-stale-evidence", PRID: pr.ID, HeadSHA: "head-1", Domain: "ci", Connection: "github-actions",
+		ExternalID: "late", Kind: "unit", Status: "success",
+		Provenance: typesv2.EvidenceProvenance{Producer: string(workflowv2.ProducerCI)},
+	}, workflowv2.ProducerCI); err == nil {
+		t.Fatal("stale-head evidence was accepted")
+	}
+	result, err := store.EvaluateDeliveryPolicy(context.Background(), "run-stale-evidence")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.CISatisfied {
+		t.Fatalf("new head inherited old CI evidence: %#v; updated=%#v", result, updated)
+	}
+}
+
+func TestEvidenceDomainCannotBeForgedByWrongAdapter(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	_, pr := createPolicyDelivery(t, store, "run-evidence-auth", "head-1", "open")
+	_, err := store.RecordEvidence(context.Background(), workflowv2.EvidenceInput{
+		RunID: "run-evidence-auth", PRID: pr.ID, HeadSHA: pr.HeadSHA, Domain: "ci", Connection: "github-actions",
+		ExternalID: "forged", Kind: "lint", Status: "success",
+		Provenance: typesv2.EvidenceProvenance{Producer: string(workflowv2.ProducerAgent)},
+	}, workflowv2.ProducerAgent)
+	if err == nil {
+		t.Fatal("agent forged CI evidence")
+	}
+}

--- a/pkg/hub/workflowv2/runtime.go
+++ b/pkg/hub/workflowv2/runtime.go
@@ -511,6 +511,8 @@ func producerOwnsFact(producer Producer, key string) bool {
 		return producer == ProducerCI
 	case "pull_request":
 		return producer == ProducerSourceControl
+	case "delivery":
+		return producer == ProducerSourceControl || producer == ProducerEngine
 	case "review":
 		return producer == ProducerReview
 	case "operator":

--- a/pkg/hub/workflowv2/runtime.go
+++ b/pkg/hub/workflowv2/runtime.go
@@ -78,7 +78,10 @@ type EventInput struct {
 	Provenance           typesv2.EvidenceProvenance
 	Payload              map[string]interface{}
 	Facts                map[string]interface{}
+	mutation             eventMutation
 }
+
+type eventMutation func(context.Context, *sql.Tx, *EventInput) error
 
 type EventResult struct {
 	EventID     string                     `json:"event_id"`
@@ -242,6 +245,11 @@ func (s *Store) ApplyEvent(ctx context.Context, runID string, input EventInput) 
 	}
 	if err := authorizeBoundTask(ctx, tx, stored, input); err != nil {
 		return EventResult{}, err
+	}
+	if input.mutation != nil {
+		if err := input.mutation(ctx, tx, &input); err != nil {
+			return EventResult{}, err
+		}
 	}
 
 	workflow, err := typesv2.ParseAndValidateWorkflow([]byte(workflowYAML))
@@ -427,6 +435,12 @@ func (s *Store) ApplyEvent(ctx context.Context, runID string, input EventInput) 
 			FromState: stored.State, ToState: transitionDef.To, FromVersion: stored.StateVersion,
 			ToVersion: toVersion, CreatedAt: now},
 	}, nil
+}
+
+func (s *Store) applyEventWithMutation(ctx context.Context, runID string, input EventInput,
+	mutation eventMutation) (EventResult, error) {
+	input.mutation = mutation
+	return s.ApplyEvent(ctx, runID, input)
 }
 
 func (s *Store) rejectAndSuspend(ctx context.Context, tx *sql.Tx, run Run, input EventInput, reason string, now time.Time) (EventResult, error) {

--- a/pkg/hub/workflowv2/runtime.go
+++ b/pkg/hub/workflowv2/runtime.go
@@ -71,6 +71,8 @@ type EventInput struct {
 	ID                   string
 	MessageID            string
 	Kind                 string
+	AttemptID            string
+	TaskID               string
 	ExpectedStateVersion *uint64
 	Producer             Producer
 	Provenance           typesv2.EvidenceProvenance
@@ -223,6 +225,9 @@ func (s *Store) ApplyEvent(ctx context.Context, runID string, input EventInput) 
 	if err != nil {
 		return EventResult{}, err
 	}
+	if err := authorizeBoundAttempt(ctx, tx, stored, input); err != nil {
+		return EventResult{}, err
+	}
 	if existing, found, err := findDuplicateEvent(ctx, tx, runID, input.ID, input.MessageID); err != nil {
 		return EventResult{}, err
 	} else if found {
@@ -234,6 +239,9 @@ func (s *Store) ApplyEvent(ctx context.Context, runID string, input EventInput) 
 			return EventResult{}, err
 		}
 		return EventResult{EventID: existing, Disposition: typesv2.DispositionDuplicate, Reason: reason, Run: stored}, nil
+	}
+	if err := authorizeBoundTask(ctx, tx, stored, input); err != nil {
+		return EventResult{}, err
 	}
 
 	workflow, err := typesv2.ParseAndValidateWorkflow([]byte(workflowYAML))
@@ -319,6 +327,9 @@ func (s *Store) ApplyEvent(ctx context.Context, runID string, input EventInput) 
 				return EventResult{}, err
 			}
 		}
+		if err := updateBoundTask(ctx, tx, runID, input, now); err != nil {
+			return EventResult{}, err
+		}
 		if err := insertEventReceipt(ctx, tx, runID, input.ID, input.MessageID, typesv2.DispositionAccepted, stored.StateVersion, "", now); err != nil {
 			return EventResult{}, err
 		}
@@ -396,6 +407,9 @@ func (s *Store) ApplyEvent(ctx context.Context, runID string, input EventInput) 
 			"states."+transitionDef.To+".on_enter.effects", destination.OnEnter.Effects, now); err != nil {
 			return EventResult{}, err
 		}
+	}
+	if err := updateBoundTask(ctx, tx, runID, input, now); err != nil {
+		return EventResult{}, err
 	}
 	if err := insertEventReceipt(ctx, tx, runID, input.ID, input.MessageID, typesv2.DispositionAccepted, toVersion, "", now); err != nil {
 		return EventResult{}, err

--- a/pkg/hub/workflowv2/schema.go
+++ b/pkg/hub/workflowv2/schema.go
@@ -224,7 +224,6 @@ func Migrate(db *sql.DB) error {
 		head_sha    TEXT NOT NULL,
 		generation  INTEGER NOT NULL CHECK(generation > 0),
 		observed_at INTEGER NOT NULL,
-		UNIQUE(pr_id, head_sha),
 		UNIQUE(pr_id, generation)
 	);
 
@@ -233,6 +232,7 @@ func Migrate(db *sql.DB) error {
 		run_id          TEXT NOT NULL REFERENCES workflow_v2_runs(id) ON DELETE CASCADE,
 		pr_id           TEXT NOT NULL DEFAULT '',
 		head_sha         TEXT NOT NULL DEFAULT '',
+		head_generation  INTEGER NOT NULL DEFAULT 0 CHECK(head_generation >= 0),
 		domain           TEXT NOT NULL CHECK(domain IN ('ci','review','pull_request','operator','effect','context')),
 		connection       TEXT NOT NULL DEFAULT '',
 		external_id      TEXT NOT NULL DEFAULT '',
@@ -242,9 +242,9 @@ func Migrate(db *sql.DB) error {
 		provenance_json  TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(provenance_json) AND json_type(provenance_json)='object'),
 		observed_at      INTEGER NOT NULL,
 		superseded_at    INTEGER NOT NULL DEFAULT 0,
-		UNIQUE(run_id, domain, connection, external_id, kind, head_sha)
+		UNIQUE(run_id, pr_id, domain, connection, external_id, kind, head_generation)
 	);
-	CREATE INDEX IF NOT EXISTS idx_workflow_v2_evidence_subject ON workflow_v2_evidence(run_id, pr_id, head_sha, domain, superseded_at);
+	CREATE INDEX IF NOT EXISTS idx_workflow_v2_evidence_subject ON workflow_v2_evidence(run_id, pr_id, head_generation, domain, superseded_at);
 
 	CREATE TABLE IF NOT EXISTS workflow_v2_control_outbox (
 		message_id       TEXT PRIMARY KEY,

--- a/pkg/hub/workflowv2/tasks.go
+++ b/pkg/hub/workflowv2/tasks.go
@@ -1,0 +1,200 @@
+package workflowv2
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	typesv2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
+	"github.com/google/uuid"
+)
+
+// MaterializeAgentTask atomically completes an agent.task effect, creates the
+// durable task, and queues its typed assignment for the run's active attempt.
+func (s *Store) MaterializeAgentTask(ctx context.Context, effectID, effectAttemptID, worker string,
+	heartbeatTimeout, taskTimeout time.Duration) (typesv2.AgentTask, error) {
+	if s == nil || s.db == nil {
+		return typesv2.AgentTask{}, fmt.Errorf("workflow v2 store is not configured")
+	}
+	if strings.TrimSpace(effectID) == "" || strings.TrimSpace(effectAttemptID) == "" || strings.TrimSpace(worker) == "" {
+		return typesv2.AgentTask{}, fmt.Errorf("effect id, effect attempt id, and worker are required")
+	}
+	if heartbeatTimeout <= 0 {
+		heartbeatTimeout = 2 * time.Minute
+	}
+	if taskTimeout <= 0 {
+		taskTimeout = 2 * time.Hour
+	}
+	now := s.now().UTC()
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return typesv2.AgentTask{}, err
+	}
+	defer tx.Rollback()
+
+	var runID, runAttemptID, state, kind, payloadJSON string
+	var stateVersion uint64
+	err = tx.QueryRowContext(ctx, `SELECT e.run_id,r.current_attempt_id,r.state,r.state_version,e.kind,e.payload_json
+		FROM workflow_v2_effects e JOIN workflow_v2_runs r ON r.id=e.run_id
+		JOIN workflow_v2_effect_attempts ea ON ea.effect_id=e.id
+		WHERE e.id=? AND ea.id=? AND ea.status='running' AND e.status='running' AND e.lease_owner=? AND e.lease_expires_at>=?
+		AND r.status='active'`, effectID, effectAttemptID, worker, now.UnixMilli()).Scan(
+		&runID, &runAttemptID, &state, &stateVersion, &kind, &payloadJSON)
+	if errors.Is(err, sql.ErrNoRows) {
+		return typesv2.AgentTask{}, fmt.Errorf("agent task effect is not actively leased")
+	}
+	if err != nil {
+		return typesv2.AgentTask{}, err
+	}
+	if kind != "agent.task" {
+		return typesv2.AgentTask{}, fmt.Errorf("effect %s has kind %q, want agent.task", effectID, kind)
+	}
+	if runAttemptID == "" {
+		return typesv2.AgentTask{}, fmt.Errorf("run %s has no active attempt", runID)
+	}
+	var activeAttempt int
+	if err := tx.QueryRowContext(ctx, `SELECT 1 FROM workflow_v2_attempts WHERE id=? AND run_id=? AND status='active'`,
+		runAttemptID, runID).Scan(&activeAttempt); err != nil {
+		return typesv2.AgentTask{}, fmt.Errorf("load active run attempt: %w", err)
+	}
+
+	var payload struct {
+		Prompt            string   `json:"prompt"`
+		Instructions      string   `json:"instructions"`
+		AllowedActions    []string `json:"allowed_actions"`
+		RequiredArtifacts []string `json:"required_artifacts"`
+	}
+	if err := json.Unmarshal([]byte(payloadJSON), &payload); err != nil {
+		return typesv2.AgentTask{}, fmt.Errorf("decode agent task effect: %w", err)
+	}
+	instructions := strings.TrimSpace(payload.Instructions)
+	if instructions == "" {
+		instructions = strings.TrimSpace(payload.Prompt)
+	}
+	if instructions == "" {
+		return typesv2.AgentTask{}, fmt.Errorf("agent task effect instructions are required")
+	}
+	if payload.AllowedActions == nil {
+		payload.AllowedActions = []string{}
+	}
+	if payload.RequiredArtifacts == nil {
+		payload.RequiredArtifacts = []string{}
+	}
+	allowedJSON, _ := json.Marshal(payload.AllowedActions)
+	artifactsJSON, _ := json.Marshal(payload.RequiredArtifacts)
+	task := typesv2.AgentTask{
+		ID: uuid.NewString(), RunID: runID, AttemptID: runAttemptID, State: state, StateVersion: stateVersion,
+		Status: typesv2.AgentTaskAssigned, Instructions: instructions, AllowedActions: payload.AllowedActions,
+		RequiredArtifacts: payload.RequiredArtifacts, HeartbeatDeadline: now.Add(heartbeatTimeout), Deadline: now.Add(taskTimeout),
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO workflow_v2_agent_tasks(
+		id,run_id,effect_id,attempt_id,state,state_version,status,instructions,allowed_actions,required_artifacts,
+		heartbeat_deadline,deadline,created_at,updated_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		task.ID, runID, effectID, runAttemptID, state, stateVersion, string(task.Status), instructions,
+		string(allowedJSON), string(artifactsJSON), task.HeartbeatDeadline.UnixMilli(), task.Deadline.UnixMilli(),
+		now.UnixMilli(), now.UnixMilli()); err != nil {
+		return typesv2.AgentTask{}, err
+	}
+	result, err := tx.ExecContext(ctx, `UPDATE workflow_v2_runs SET current_task_id=?,updated_at=?
+		WHERE id=? AND current_attempt_id=? AND state=? AND state_version=? AND status='active'`,
+		task.ID, now.UnixMilli(), runID, runAttemptID, state, stateVersion)
+	if err != nil {
+		return typesv2.AgentTask{}, err
+	}
+	if changed, err := result.RowsAffected(); err != nil || changed != 1 {
+		return typesv2.AgentTask{}, fmt.Errorf("run changed while materializing agent task")
+	}
+	taskJSON, err := json.Marshal(task)
+	if err != nil {
+		return typesv2.AgentTask{}, err
+	}
+	envelope := typesv2.ControlEnvelope{
+		ProtocolVersion: typesv2.ControlProtocolVersion, MessageID: uuid.NewString(), Kind: typesv2.MessageAgentTaskAssign,
+		RunID: runID, AttemptID: runAttemptID, TaskID: task.ID, ExpectedStateVersion: &stateVersion,
+		CausationID: effectID, SentAt: now, Payload: taskJSON,
+	}
+	if err := typesv2.ValidateControlEnvelope(envelope, typesv2.DirectionHubToClaw); err != nil {
+		return typesv2.AgentTask{}, err
+	}
+	envelopeJSON, _ := json.Marshal(envelope)
+	if _, err := tx.ExecContext(ctx, `INSERT INTO workflow_v2_control_outbox(
+		message_id,run_id,attempt_id,task_id,kind,envelope_json,status,next_attempt_at,created_at,updated_at)
+		VALUES(?,?,?,?,?,?,'pending',0,?,?)`, envelope.MessageID, runID, runAttemptID, task.ID,
+		string(envelope.Kind), string(envelopeJSON), now.UnixMilli(), now.UnixMilli()); err != nil {
+		return typesv2.AgentTask{}, err
+	}
+	receiptJSON, _ := json.Marshal(map[string]interface{}{"task_id": task.ID, "message_id": envelope.MessageID})
+	if _, err := tx.ExecContext(ctx, `UPDATE workflow_v2_effect_attempts SET status='succeeded',receipt_json=?,finished_at=?
+		WHERE id=? AND effect_id=? AND status='running'`, string(receiptJSON), now.UnixMilli(), effectAttemptID, effectID); err != nil {
+		return typesv2.AgentTask{}, err
+	}
+	result, err = tx.ExecContext(ctx, `UPDATE workflow_v2_effects SET status='succeeded',lease_owner='',lease_expires_at=0,
+		receipt_json=?,last_error='',updated_at=? WHERE id=? AND status='running' AND lease_owner=?`,
+		string(receiptJSON), now.UnixMilli(), effectID, worker)
+	if err != nil {
+		return typesv2.AgentTask{}, err
+	}
+	if changed, err := result.RowsAffected(); err != nil || changed != 1 {
+		return typesv2.AgentTask{}, fmt.Errorf("agent task effect lease changed while materializing")
+	}
+	if err := tx.Commit(); err != nil {
+		return typesv2.AgentTask{}, err
+	}
+	return task, nil
+}
+
+// ExpireAgentTasks moves timed-out tasks and their runs to an inspectable,
+// conservative suspended state. Retrying requires an explicit recovery action.
+func (s *Store) ExpireAgentTasks(ctx context.Context) ([]string, error) {
+	if s == nil || s.db == nil {
+		return nil, fmt.Errorf("workflow v2 store is not configured")
+	}
+	now := s.now().UTC()
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+	rows, err := tx.QueryContext(ctx, `SELECT id,run_id FROM workflow_v2_agent_tasks
+		WHERE status IN ('assigned','running') AND (deadline<? OR heartbeat_deadline<?) ORDER BY created_at,id`,
+		now.UnixMilli(), now.UnixMilli())
+	if err != nil {
+		return nil, err
+	}
+	type expiredTask struct{ id, runID string }
+	var expired []expiredTask
+	for rows.Next() {
+		var task expiredTask
+		if err := rows.Scan(&task.id, &task.runID); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		expired = append(expired, task)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	for _, task := range expired {
+		reason := "agent task " + task.id + " missed its heartbeat or execution deadline"
+		if _, err := tx.ExecContext(ctx, `UPDATE workflow_v2_agent_tasks SET status='timed_out',terminal_reason=?,
+			updated_at=?,finished_at=? WHERE id=? AND status IN ('assigned','running')`, reason, now.UnixMilli(), now.UnixMilli(), task.id); err != nil {
+			return nil, err
+		}
+		if _, err := tx.ExecContext(ctx, `UPDATE workflow_v2_runs SET status='suspended',waiting_reason=?,updated_at=?
+			WHERE id=? AND current_task_id=? AND status='active'`, reason, now.UnixMilli(), task.runID, task.id); err != nil {
+			return nil, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	ids := make([]string, len(expired))
+	for i := range expired {
+		ids[i] = expired[i].id
+	}
+	return ids, nil
+}

--- a/pkg/types/v2/control.go
+++ b/pkg/types/v2/control.go
@@ -293,6 +293,7 @@ type ContextBundleSource struct {
 	Type           string   `json:"type"`
 	Scope          string   `json:"scope"`
 	Required       bool     `json:"required"`
+	Repositories   []string `json:"repositories,omitempty"`
 	Status         string   `json:"status"`
 	SourceRevision string   `json:"source_revision,omitempty"`
 	ContentDigest  string   `json:"content_digest,omitempty"`

--- a/pkg/types/v2/control.go
+++ b/pkg/types/v2/control.go
@@ -308,7 +308,9 @@ type DeliveryManifest struct {
 }
 
 type PullRequestClaim struct {
-	URL        string `json:"url"`
+	URL string `json:"url"`
+	// Supersedes is reserved for a hub-owned source-control reconciler. Claw
+	// submissions that set it are rejected rather than trusted to remove PRs.
 	Supersedes string `json:"supersedes,omitempty"`
 }
 

--- a/pkg/types/v2/control.go
+++ b/pkg/types/v2/control.go
@@ -77,6 +77,33 @@ type ControlReceipt struct {
 	Reason       string             `json:"reason,omitempty"`
 }
 
+const (
+	ControlFrameRegister   = "register"
+	ControlFrameRegistered = "registered"
+	ControlFrameEnvelope   = "envelope"
+	ControlFrameReceipt    = "receipt"
+)
+
+// ControlRegistration authenticates the bridge's dedicated workflow channel.
+// It is intentionally separate from the conversation WebSocket registration.
+type ControlRegistration struct {
+	Token     string             `json:"token"`
+	ClawID    string             `json:"claw_id"`
+	RunID     string             `json:"run_id"`
+	AttemptID string             `json:"attempt_id"`
+	Bridge    BridgeRegistration `json:"bridge"`
+}
+
+// ControlFrame is the only wire frame accepted on /claw/control/ws.
+type ControlFrame struct {
+	Type         string               `json:"type"`
+	Registration *ControlRegistration `json:"registration,omitempty"`
+	Snapshot     *WorkflowSnapshot    `json:"snapshot,omitempty"`
+	Envelope     *ControlEnvelope     `json:"envelope,omitempty"`
+	Receipt      *ControlReceipt      `json:"receipt,omitempty"`
+	Error        string               `json:"error,omitempty"`
+}
+
 // WorkflowEvent is the durable input record consumed by the v2 engine. Its
 // payload is typed by Kind; freeform conversation messages have no producer in
 // this event model.

--- a/pkg/types/v2/control_test.go
+++ b/pkg/types/v2/control_test.go
@@ -1,6 +1,8 @@
 package v2_test
 
 import (
+	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -46,6 +48,23 @@ func TestControlCatalogContainsNoConversationMessages(t *testing.T) {
 		if strings.Contains(string(kind), "message") || strings.Contains(string(kind), "conversation") {
 			t.Fatalf("control kind %q crosses conversation boundary", kind)
 		}
+	}
+}
+
+func TestControlWireFrameIsSeparateFromConversationMessages(t *testing.T) {
+	frame := v2.ControlFrame{
+		Type: v2.ControlFrameRegister,
+		Registration: &v2.ControlRegistration{
+			Token: "token", ClawID: "claw-1", RunID: "run-1", AttemptID: "attempt-1",
+			Bridge: v2.BridgeRegistration{BridgeVersion: "test", Protocols: []string{v2.ProtocolControlV2}},
+		},
+	}
+	raw, err := json.Marshal(frame)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(raw, []byte(`"content"`)) || bytes.Contains(raw, []byte(`"role"`)) {
+		t.Fatalf("control registration contains conversation fields: %s", raw)
 	}
 }
 

--- a/pkg/types/v2/workflow_test.go
+++ b/pkg/types/v2/workflow_test.go
@@ -458,6 +458,47 @@ ci:
 	}
 }
 
+func TestWorkflowRejectsUnsupportedEvidencePolicyShape(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "operator", body: `ci:
+  policies:
+    bad:
+      quorum:
+        - pipeline: github-pr
+          checks: [lint]`, want: "unsupported CI policy field"},
+		{name: "empty checks", body: `ci:
+  policies:
+    bad:
+      pipeline: github-pr
+      checks: []`, want: "checks must be a non-empty list"},
+		{name: "review minimum", body: `review:
+  policies:
+    bad:
+      connection: github-reviews
+      approvals:
+        minimum: -1`, want: "non-negative integer"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			yaml := `schema_version: 2
+name: invalid-policy
+initial_state: start
+states:
+  start:
+    phase: plan
+` + tt.body
+			_, err := v2.ParseAndValidateWorkflow([]byte(yaml))
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
 func TestWorkflowRejectsEffectWithoutCapability(t *testing.T) {
 	// github-production has trigger_run restricted to false in validWorkspaceYAML
 	yaml := `

--- a/pkg/types/v2/workflow_validate.go
+++ b/pkg/types/v2/workflow_validate.go
@@ -224,15 +224,21 @@ func ValidateWorkflow(wf *Workflow) (*ResolvedWorkflow, error) {
 
 	// Policy structure: minimal name checks; resource refs checked in pair validation.
 	if wf.CI != nil {
-		for name := range wf.CI.Policies {
+		for name, policy := range wf.CI.Policies {
 			if err := validateResourceName("ci.policies", name); err != nil {
+				return nil, fmt.Errorf("workflow %q: %w", wf.Name, err)
+			}
+			if err := validateEvidencePolicy("ci.policies."+name, policy, "ci"); err != nil {
 				return nil, fmt.Errorf("workflow %q: %w", wf.Name, err)
 			}
 		}
 	}
 	if wf.Review != nil {
-		for name := range wf.Review.Policies {
+		for name, policy := range wf.Review.Policies {
 			if err := validateResourceName("review.policies", name); err != nil {
+				return nil, fmt.Errorf("workflow %q: %w", wf.Name, err)
+			}
+			if err := validateEvidencePolicy("review.policies."+name, policy, "review"); err != nil {
 				return nil, fmt.Errorf("workflow %q: %w", wf.Name, err)
 			}
 		}
@@ -246,6 +252,139 @@ func ValidateWorkflow(wf *Workflow) (*ResolvedWorkflow, error) {
 		return nil, err
 	}
 	return &ResolvedWorkflow{Workflow: wf, Revision: rev}, nil
+}
+
+func validateEvidencePolicy(path string, policy Policy, mode string) error {
+	return validateEvidencePolicyNode(path, map[string]interface{}(policy), mode, true)
+}
+
+func validateEvidencePolicyNode(path string, node interface{}, mode string, root bool) error {
+	value, ok := evidencePolicyMap(node)
+	if !ok || len(value) == 0 {
+		return fmt.Errorf("%s must be a non-empty policy object", path)
+	}
+	operator := ""
+	for _, candidate := range []string{"all", "any", "not"} {
+		if _, exists := value[candidate]; exists {
+			if operator != "" {
+				return fmt.Errorf("%s cannot combine policy operators %q and %q", path, operator, candidate)
+			}
+			operator = candidate
+		}
+	}
+	metadata := map[string]bool{}
+	if root && mode == "ci" {
+		metadata["satisfied_for"] = true
+	}
+	if root && mode == "review" {
+		metadata["invalidate_on_new_head"] = true
+	}
+	if raw, exists := value["satisfied_for"]; exists {
+		if mode != "ci" || raw != "current_pr_head" {
+			return fmt.Errorf("%s.satisfied_for must be %q", path, "current_pr_head")
+		}
+	}
+	if raw, exists := value["invalidate_on_new_head"]; exists {
+		invalidate, ok := raw.(bool)
+		if mode != "review" || !ok || !invalidate {
+			return fmt.Errorf("%s.invalidate_on_new_head must be true", path)
+		}
+	}
+	if operator != "" {
+		for key := range value {
+			if key != operator && !metadata[key] {
+				return fmt.Errorf("%s: unsupported field %q beside %s", path, key, operator)
+			}
+		}
+		switch operator {
+		case "all", "any":
+			items, ok := value[operator].([]interface{})
+			if !ok || len(items) == 0 {
+				return fmt.Errorf("%s.%s must be a non-empty list", path, operator)
+			}
+			for i, item := range items {
+				if err := validateEvidencePolicyNode(fmt.Sprintf("%s.%s[%d]", path, operator, i), item, mode, false); err != nil {
+					return err
+				}
+			}
+		case "not":
+			if err := validateEvidencePolicyNode(path+".not", value["not"], mode, false); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if mode == "ci" {
+		for key := range value {
+			if key != "pipeline" && key != "checks" && !metadata[key] {
+				return fmt.Errorf("%s: unsupported CI policy field %q", path, key)
+			}
+		}
+		pipeline, _ := value["pipeline"].(string)
+		if strings.TrimSpace(pipeline) == "" {
+			return fmt.Errorf("%s.pipeline is required", path)
+		}
+		checks, ok := value["checks"].([]interface{})
+		if !ok || len(checks) == 0 {
+			return fmt.Errorf("%s.checks must be a non-empty list", path)
+		}
+		for i, check := range checks {
+			if name, ok := check.(string); !ok || strings.TrimSpace(name) == "" {
+				return fmt.Errorf("%s.checks[%d] must be a non-empty string", path, i)
+			}
+		}
+		return nil
+	}
+	for key := range value {
+		if key != "connection" && key != "approvals" && !metadata[key] {
+			return fmt.Errorf("%s: unsupported review policy field %q", path, key)
+		}
+	}
+	connection, _ := value["connection"].(string)
+	if strings.TrimSpace(connection) == "" {
+		return fmt.Errorf("%s.connection is required", path)
+	}
+	approvals, ok := evidencePolicyMap(value["approvals"])
+	if !ok {
+		return fmt.Errorf("%s.approvals is required", path)
+	}
+	for key := range approvals {
+		if key != "minimum" {
+			return fmt.Errorf("%s.approvals: unsupported field %q", path, key)
+		}
+	}
+	minimum, ok := policyNonNegativeInteger(approvals["minimum"])
+	if !ok || minimum < 0 {
+		return fmt.Errorf("%s.approvals.minimum must be a non-negative integer", path)
+	}
+	return nil
+}
+
+func evidencePolicyMap(value interface{}) (map[string]interface{}, bool) {
+	switch typed := value.(type) {
+	case map[string]interface{}:
+		return typed, true
+	case Policy:
+		return map[string]interface{}(typed), true
+	default:
+		return nil, false
+	}
+}
+
+func policyNonNegativeInteger(value interface{}) (int, bool) {
+	switch number := value.(type) {
+	case int:
+		return number, number >= 0
+	case int64:
+		return int(number), number >= 0
+	case uint64:
+		return int(number), true
+	case float64:
+		integer := int(number)
+		return integer, number >= 0 && number == float64(integer)
+	default:
+		return 0, false
+	}
 }
 
 func isTranscriptEvent(event string) bool {


### PR DESCRIPTION
Builds on #607 and implements the durable, non-transcript control-domain primitives from #544.

- binds typed control identities to durable run attempts and invalidates superseded attempts
- stores reconnect snapshots and acknowledged control outbox messages separately from conversations
- atomically materializes agent.task effects with durable task assignments and conservative timeout suspension
- assembles idempotent, versioned workspace-owned context bundles with required-source gates
- verifies zero, one, or many dynamically submitted PRs against the pinned workspace repository authority
- tracks PR head generations and invalidates stale-head CI/review evidence
- evaluates restricted CI/review policies across every active PR and supports REVIEW to BUILD feedback loops
- rejects malformed policy operators and agent attempts to forge protected evidence

This PR intentionally does not expose the new WebSocket route yet; the production service-boundary change remains a separate reviewed step. Existing v1 workspaces, workflow tables, sockets, and transcript behavior are unchanged.

Verification: focused v2 runtime and schema suites pass; full repository suite will run in CI.