### PR TITLE
feat: add authenticated workflow v2 control transport

### DIFF
--- a/cmd/claw-bridge/control_v2.go
+++ b/cmd/claw-bridge/control_v2.go
@@ -265,6 +265,10 @@ type controlSocketWriter struct {
 	conn *websocket.Conn
 }
 
+type activeTaskCancellation struct {
+	cancel context.CancelFunc
+}
+
 func (w *controlSocketWriter) write(ctx context.Context, frame typesv2.ControlFrame) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -287,14 +291,14 @@ type controlSupervisor struct {
 	connected   bool
 	snapshot    *typesv2.WorkflowSnapshot
 	gateway     *gatewaySession
-	activeTasks map[string]context.CancelFunc
+	activeTasks map[string]*activeTaskCancellation
 	recovered   map[workflowControlBinding]bool
 }
 
 func newControlSupervisor(ctx context.Context, wsURL, clawID, token string,
 	bridge typesv2.BridgeRegistration, store *bridgeControlStore) *controlSupervisor {
 	return &controlSupervisor{ctx: ctx, wsURL: wsURL, clawID: clawID, token: token,
-		bridge: bridge, store: store, activeTasks: map[string]context.CancelFunc{},
+		bridge: bridge, store: store, activeTasks: map[string]*activeTaskCancellation{},
 		recovered: map[workflowControlBinding]bool{}}
 }
 
@@ -566,14 +570,10 @@ func (s *controlSupervisor) executeTask(ctx context.Context, binding workflowCon
 		deadline = time.Now().Add(2 * time.Hour)
 	}
 	taskCtx, cancel := context.WithDeadline(ctx, deadline)
-	s.mu.Lock()
-	s.activeTasks[task.ID] = cancel
-	s.mu.Unlock()
+	activeCancellation := s.registerTaskCancellation(task.ID, cancel)
 	defer func() {
 		cancel()
-		s.mu.Lock()
-		delete(s.activeTasks, task.ID)
-		s.mu.Unlock()
+		s.unregisterTaskCancellation(task.ID, activeCancellation)
 	}()
 
 	if err := s.enqueueTaskEvent(binding, task, typesv2.MessageAgentTaskStarted, map[string]interface{}{
@@ -758,21 +758,39 @@ func (s *controlSupervisor) stateVersion(binding workflowControlBinding) uint64 
 }
 
 func (s *controlSupervisor) cancelTask(taskID string) {
-	s.mu.Lock()
-	cancel := s.activeTasks[taskID]
-	s.mu.Unlock()
-	if cancel != nil {
-		cancel()
+	s.mu.RLock()
+	activeCancellation := s.activeTasks[taskID]
+	s.mu.RUnlock()
+	if activeCancellation != nil {
+		activeCancellation.cancel()
 	}
 }
 
-func (s *controlSupervisor) cancelAllTasks() {
+func (s *controlSupervisor) registerTaskCancellation(taskID string,
+	cancel context.CancelFunc) *activeTaskCancellation {
+	activeCancellation := &activeTaskCancellation{cancel: cancel}
 	s.mu.Lock()
-	cancels := make([]context.CancelFunc, 0, len(s.activeTasks))
-	for _, cancel := range s.activeTasks {
-		cancels = append(cancels, cancel)
+	s.activeTasks[taskID] = activeCancellation
+	s.mu.Unlock()
+	return activeCancellation
+}
+
+func (s *controlSupervisor) unregisterTaskCancellation(taskID string,
+	activeCancellation *activeTaskCancellation) {
+	s.mu.Lock()
+	if s.activeTasks[taskID] == activeCancellation {
+		delete(s.activeTasks, taskID)
 	}
 	s.mu.Unlock()
+}
+
+func (s *controlSupervisor) cancelAllTasks() {
+	s.mu.RLock()
+	cancels := make([]context.CancelFunc, 0, len(s.activeTasks))
+	for _, activeCancellation := range s.activeTasks {
+		cancels = append(cancels, activeCancellation.cancel)
+	}
+	s.mu.RUnlock()
 	for _, cancel := range cancels {
 		cancel()
 	}

--- a/cmd/claw-bridge/control_v2.go
+++ b/cmd/claw-bridge/control_v2.go
@@ -438,7 +438,7 @@ func (s *controlSupervisor) runConnection(ctx context.Context, binding workflowC
 				return err
 			}
 			if startTask != nil && receipt.Disposition == typesv2.DispositionAccepted {
-				go s.executeTask(ctx, binding, frame.Envelope.MessageID, *startTask)
+				s.startTask(ctx, binding, frame.Envelope.MessageID, *startTask)
 			}
 		default:
 			return fmt.Errorf("unsupported control frame %q", frame.Type)
@@ -549,8 +549,33 @@ func (s *controlSupervisor) acceptHubEnvelope(binding workflowControlBinding,
 		Disposition: typesv2.DispositionAccepted, StateVersion: s.stateVersion(binding)}, task, nil
 }
 
-func (s *controlSupervisor) executeTask(ctx context.Context, binding workflowControlBinding,
+// startTask registers cancellation synchronously on the WebSocket reader path
+// before it launches agent work. A cancellation frame read immediately after
+// the assignment can therefore always find and stop this task.
+func (s *controlSupervisor) startTask(ctx context.Context, binding workflowControlBinding,
 	assignmentMessageID string, task typesv2.AgentTask) {
+	taskCtx, cancel, activeCancellation := s.prepareTaskExecution(ctx, task)
+	go s.executeTask(taskCtx, binding, assignmentMessageID, task, cancel, activeCancellation)
+}
+
+func (s *controlSupervisor) prepareTaskExecution(ctx context.Context,
+	task typesv2.AgentTask) (context.Context, context.CancelFunc, *activeTaskCancellation) {
+	deadline := task.Deadline
+	if deadline.IsZero() {
+		deadline = time.Now().Add(2 * time.Hour)
+	}
+	taskCtx, cancel := context.WithDeadline(ctx, deadline)
+	activeCancellation := s.registerTaskCancellation(task.ID, cancel)
+	return taskCtx, cancel, activeCancellation
+}
+
+func (s *controlSupervisor) executeTask(taskCtx context.Context, binding workflowControlBinding,
+	assignmentMessageID string, task typesv2.AgentTask, cancel context.CancelFunc,
+	activeCancellation *activeTaskCancellation) {
+	defer func() {
+		cancel()
+		s.unregisterTaskCancellation(task.ID, activeCancellation)
+	}()
 	claimed, err := s.store.setIncomingStatus(assignmentMessageID, "accepted", "running")
 	if err != nil || !claimed {
 		if err != nil {
@@ -565,17 +590,6 @@ func (s *controlSupervisor) executeTask(ctx context.Context, binding workflowCon
 		s.finishTask(binding, assignmentMessageID, task, typesv2.MessageAgentTaskFailed, "gateway is not ready")
 		return
 	}
-	deadline := task.Deadline
-	if deadline.IsZero() {
-		deadline = time.Now().Add(2 * time.Hour)
-	}
-	taskCtx, cancel := context.WithDeadline(ctx, deadline)
-	activeCancellation := s.registerTaskCancellation(task.ID, cancel)
-	defer func() {
-		cancel()
-		s.unregisterTaskCancellation(task.ID, activeCancellation)
-	}()
-
 	if err := s.enqueueTaskEvent(binding, task, typesv2.MessageAgentTaskStarted, map[string]interface{}{
 		"execution": map[string]interface{}{"bridge_started_at": time.Now().UTC()},
 	}); err != nil {
@@ -672,7 +686,7 @@ func (s *controlSupervisor) recoverInterrupted(ctx context.Context, binding work
 		}
 		var task typesv2.AgentTask
 		if json.Unmarshal(envelope.Payload, &task) == nil {
-			go s.executeTask(ctx, binding, envelope.MessageID, task)
+			s.startTask(ctx, binding, envelope.MessageID, task)
 		}
 	}
 }

--- a/cmd/claw-bridge/control_v2.go
+++ b/cmd/claw-bridge/control_v2.go
@@ -1,0 +1,1012 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	typesv2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
+	"github.com/google/uuid"
+	"nhooyr.io/websocket"
+	"nhooyr.io/websocket/wsjson"
+)
+
+const (
+	localControlPath   = "/v2/control"
+	controlTokenHeader = "X-Claw-Token"
+)
+
+type bridgeProtocolRegistration = typesv2.BridgeRegistration
+
+type workflowControlBinding struct {
+	RunID     string `json:"run_id"`
+	AttemptID string `json:"attempt_id"`
+}
+
+func (b workflowControlBinding) equal(other workflowControlBinding) bool {
+	return b.RunID == other.RunID && b.AttemptID == other.AttemptID
+}
+
+type bridgeControlStore struct {
+	db *sql.DB
+}
+
+func openBridgeControlStore(path string) (*bridgeControlStore, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return nil, err
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return nil, err
+	}
+	if err := file.Close(); err != nil {
+		return nil, err
+	}
+	if err := os.Chmod(path, 0600); err != nil {
+		return nil, err
+	}
+	db, err := sql.Open("sqlite", path+"?_txlock=immediate&_pragma=busy_timeout(5000)")
+	if err != nil {
+		return nil, err
+	}
+	db.SetMaxOpenConns(1)
+	statements := []string{
+		`CREATE TABLE IF NOT EXISTS bridge_control_inbox (
+			message_id TEXT PRIMARY KEY, run_id TEXT NOT NULL, attempt_id TEXT NOT NULL,
+			kind TEXT NOT NULL, envelope_json TEXT NOT NULL, status TEXT NOT NULL,
+			created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_bridge_control_inbox_task
+			ON bridge_control_inbox(run_id,attempt_id,status,created_at)`,
+		`CREATE TABLE IF NOT EXISTS bridge_control_outbox (
+			message_id TEXT PRIMARY KEY, run_id TEXT NOT NULL, attempt_id TEXT NOT NULL,
+			kind TEXT NOT NULL, envelope_json TEXT NOT NULL, status TEXT NOT NULL,
+			next_attempt_at INTEGER NOT NULL DEFAULT 0, receipt_json TEXT NOT NULL DEFAULT '',
+			created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_bridge_control_outbox_ready
+			ON bridge_control_outbox(run_id,attempt_id,status,next_attempt_at,created_at)`,
+		`CREATE TABLE IF NOT EXISTS bridge_control_snapshots (
+			run_id TEXT NOT NULL, attempt_id TEXT NOT NULL, snapshot_json TEXT NOT NULL,
+			updated_at INTEGER NOT NULL, PRIMARY KEY(run_id,attempt_id)
+		)`,
+	}
+	for _, statement := range statements {
+		if _, err := db.Exec(statement); err != nil {
+			db.Close()
+			return nil, err
+		}
+	}
+	return &bridgeControlStore{db: db}, nil
+}
+
+func (s *bridgeControlStore) close() error { return s.db.Close() }
+
+func (s *bridgeControlStore) saveSnapshot(snapshot typesv2.WorkflowSnapshot) error {
+	raw, err := json.Marshal(snapshot)
+	if err != nil {
+		return err
+	}
+	now := time.Now().UTC().UnixMilli()
+	_, err = s.db.Exec(`INSERT INTO bridge_control_snapshots(run_id,attempt_id,snapshot_json,updated_at)
+		VALUES(?,?,?,?) ON CONFLICT(run_id,attempt_id) DO UPDATE SET
+		snapshot_json=excluded.snapshot_json,updated_at=excluded.updated_at`,
+		snapshot.RunID, snapshot.AttemptID, string(raw), now)
+	return err
+}
+
+func (s *bridgeControlStore) snapshot(binding workflowControlBinding) (typesv2.WorkflowSnapshot, bool, error) {
+	var raw string
+	err := s.db.QueryRow(`SELECT snapshot_json FROM bridge_control_snapshots WHERE run_id=? AND attempt_id=?`,
+		binding.RunID, binding.AttemptID).Scan(&raw)
+	if errors.Is(err, sql.ErrNoRows) {
+		return typesv2.WorkflowSnapshot{}, false, nil
+	}
+	if err != nil {
+		return typesv2.WorkflowSnapshot{}, false, err
+	}
+	var snapshot typesv2.WorkflowSnapshot
+	if err := json.Unmarshal([]byte(raw), &snapshot); err != nil {
+		return typesv2.WorkflowSnapshot{}, false, err
+	}
+	return snapshot, true, nil
+}
+
+func (s *bridgeControlStore) recordIncoming(envelope typesv2.ControlEnvelope) (bool, error) {
+	raw, err := json.Marshal(envelope)
+	if err != nil {
+		return false, err
+	}
+	now := time.Now().UTC().UnixMilli()
+	result, err := s.db.Exec(`INSERT INTO bridge_control_inbox(
+		message_id,run_id,attempt_id,kind,envelope_json,status,created_at,updated_at)
+		VALUES(?,?,?,?,?,'accepted',?,?) ON CONFLICT(message_id) DO NOTHING`, envelope.MessageID,
+		envelope.RunID, envelope.AttemptID, string(envelope.Kind), string(raw), now, now)
+	if err != nil {
+		return false, err
+	}
+	changed, err := result.RowsAffected()
+	return changed == 0, err
+}
+
+func (s *bridgeControlStore) setIncomingStatus(messageID, from, to string) (bool, error) {
+	now := time.Now().UTC().UnixMilli()
+	result, err := s.db.Exec(`UPDATE bridge_control_inbox SET status=?,updated_at=? WHERE message_id=? AND status=?`,
+		to, now, messageID, from)
+	if err != nil {
+		return false, err
+	}
+	changed, err := result.RowsAffected()
+	return changed == 1, err
+}
+
+func (s *bridgeControlStore) incomingByStatus(binding workflowControlBinding, status string) ([]typesv2.ControlEnvelope, error) {
+	rows, err := s.db.Query(`SELECT envelope_json FROM bridge_control_inbox
+		WHERE run_id=? AND attempt_id=? AND status=? ORDER BY created_at,message_id`,
+		binding.RunID, binding.AttemptID, status)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var envelopes []typesv2.ControlEnvelope
+	for rows.Next() {
+		var raw string
+		if err := rows.Scan(&raw); err != nil {
+			return nil, err
+		}
+		var envelope typesv2.ControlEnvelope
+		if err := json.Unmarshal([]byte(raw), &envelope); err != nil {
+			return nil, err
+		}
+		envelopes = append(envelopes, envelope)
+	}
+	return envelopes, rows.Err()
+}
+
+func (s *bridgeControlStore) enqueue(envelope typesv2.ControlEnvelope) error {
+	raw, err := json.Marshal(envelope)
+	if err != nil {
+		return err
+	}
+	now := time.Now().UTC().UnixMilli()
+	_, err = s.db.Exec(`INSERT INTO bridge_control_outbox(
+		message_id,run_id,attempt_id,kind,envelope_json,status,next_attempt_at,created_at,updated_at)
+		VALUES(?,?,?,?,?,'pending',0,?,?) ON CONFLICT(message_id) DO NOTHING`, envelope.MessageID,
+		envelope.RunID, envelope.AttemptID, string(envelope.Kind), string(raw), now, now)
+	return err
+}
+
+func (s *bridgeControlStore) ready(binding workflowControlBinding, limit int) ([]typesv2.ControlEnvelope, error) {
+	if limit <= 0 || limit > 100 {
+		limit = 100
+	}
+	rows, err := s.db.Query(`SELECT envelope_json FROM bridge_control_outbox
+		WHERE run_id=? AND attempt_id=? AND status IN ('pending','sent') AND next_attempt_at<=?
+		ORDER BY created_at,message_id LIMIT ?`, binding.RunID, binding.AttemptID, time.Now().UTC().UnixMilli(), limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var envelopes []typesv2.ControlEnvelope
+	for rows.Next() {
+		var raw string
+		if err := rows.Scan(&raw); err != nil {
+			return nil, err
+		}
+		var envelope typesv2.ControlEnvelope
+		if err := json.Unmarshal([]byte(raw), &envelope); err != nil {
+			return nil, err
+		}
+		envelopes = append(envelopes, envelope)
+	}
+	return envelopes, rows.Err()
+}
+
+func (s *bridgeControlStore) markSent(messageID string) error {
+	now := time.Now().UTC()
+	_, err := s.db.Exec(`UPDATE bridge_control_outbox SET status='sent',next_attempt_at=?,updated_at=?
+		WHERE message_id=? AND status IN ('pending','sent')`, now.Add(5*time.Second).UnixMilli(), now.UnixMilli(), messageID)
+	return err
+}
+
+func (s *bridgeControlStore) acknowledge(receipt typesv2.ControlReceipt) error {
+	raw, err := json.Marshal(receipt)
+	if err != nil {
+		return err
+	}
+	now := time.Now().UTC().UnixMilli()
+	result, err := s.db.Exec(`UPDATE bridge_control_outbox SET status='acknowledged',receipt_json=?,updated_at=?
+		WHERE message_id=? AND status IN ('pending','sent')`, string(raw), now, receipt.MessageID)
+	if err != nil {
+		return err
+	}
+	changed, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if changed != 1 {
+		return fmt.Errorf("control receipt does not match a pending bridge message")
+	}
+	return nil
+}
+
+func (s *bridgeControlStore) receipt(messageID string) (typesv2.ControlReceipt, bool, error) {
+	var raw string
+	err := s.db.QueryRow(`SELECT receipt_json FROM bridge_control_outbox
+		WHERE message_id=? AND status='acknowledged'`, messageID).Scan(&raw)
+	if errors.Is(err, sql.ErrNoRows) {
+		return typesv2.ControlReceipt{}, false, nil
+	}
+	if err != nil {
+		return typesv2.ControlReceipt{}, false, err
+	}
+	var receipt typesv2.ControlReceipt
+	if err := json.Unmarshal([]byte(raw), &receipt); err != nil {
+		return typesv2.ControlReceipt{}, false, err
+	}
+	return receipt, true, nil
+}
+
+type controlSocketWriter struct {
+	mu   sync.Mutex
+	conn *websocket.Conn
+}
+
+func (w *controlSocketWriter) write(ctx context.Context, frame typesv2.ControlFrame) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	writeCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	return wsjson.Write(writeCtx, w.conn, frame)
+}
+
+type controlSupervisor struct {
+	ctx    context.Context
+	wsURL  string
+	clawID string
+	token  string
+	bridge typesv2.BridgeRegistration
+	store  *bridgeControlStore
+
+	mu          sync.RWMutex
+	binding     *workflowControlBinding
+	bindingStop context.CancelFunc
+	connected   bool
+	snapshot    *typesv2.WorkflowSnapshot
+	gateway     *gatewaySession
+	activeTasks map[string]context.CancelFunc
+	recovered   map[workflowControlBinding]bool
+}
+
+func newControlSupervisor(ctx context.Context, wsURL, clawID, token string,
+	bridge typesv2.BridgeRegistration, store *bridgeControlStore) *controlSupervisor {
+	return &controlSupervisor{ctx: ctx, wsURL: wsURL, clawID: clawID, token: token,
+		bridge: bridge, store: store, activeTasks: map[string]context.CancelFunc{},
+		recovered: map[workflowControlBinding]bool{}}
+}
+
+func (s *controlSupervisor) setGatewaySession(session *gatewaySession) {
+	s.mu.Lock()
+	s.gateway = session
+	s.mu.Unlock()
+}
+
+func (s *controlSupervisor) updateBinding(binding *workflowControlBinding) {
+	s.mu.Lock()
+	if binding == nil {
+		if s.bindingStop != nil {
+			s.bindingStop()
+		}
+		s.binding, s.bindingStop, s.connected, s.snapshot = nil, nil, false, nil
+		s.mu.Unlock()
+		return
+	}
+	if s.binding != nil && s.binding.equal(*binding) {
+		s.mu.Unlock()
+		return
+	}
+	if s.bindingStop != nil {
+		s.bindingStop()
+	}
+	bindingCtx, cancel := context.WithCancel(s.ctx)
+	copyBinding := *binding
+	s.binding, s.bindingStop, s.connected = &copyBinding, cancel, false
+	if snapshot, found, err := s.store.snapshot(copyBinding); err == nil && found {
+		s.snapshot = &snapshot
+	} else {
+		s.snapshot = nil
+	}
+	s.mu.Unlock()
+	go s.runBinding(bindingCtx, copyBinding)
+}
+
+func (s *controlSupervisor) runBinding(ctx context.Context, binding workflowControlBinding) {
+	backoff := time.Second
+	for ctx.Err() == nil {
+		if err := s.runConnection(ctx, binding); err != nil && ctx.Err() == nil {
+			log.Printf("[control-v2] disconnected: %v — retry in %v", err, backoff)
+		}
+		s.setConnected(binding, false)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+			if backoff < 30*time.Second {
+				backoff *= 2
+			}
+		}
+	}
+}
+
+func (s *controlSupervisor) runConnection(ctx context.Context, binding workflowControlBinding) error {
+	conn, _, err := websocket.Dial(ctx, s.wsURL, &websocket.DialOptions{HTTPHeader: http.Header{
+		controlTokenHeader: {s.token}, "User-Agent": {"claw-bridge/" + Version},
+		"ngrok-skip-browser-warning": {"true"},
+	}})
+	if err != nil {
+		return fmt.Errorf("dial: %w", err)
+	}
+	defer conn.CloseNow()
+	conn.SetReadLimit(2 << 20)
+	writer := &controlSocketWriter{conn: conn}
+	registration := typesv2.ControlRegistration{Token: s.token, ClawID: s.clawID,
+		RunID: binding.RunID, AttemptID: binding.AttemptID, Bridge: s.bridge}
+	if err := writer.write(ctx, typesv2.ControlFrame{Type: typesv2.ControlFrameRegister, Registration: &registration}); err != nil {
+		return fmt.Errorf("register: %w", err)
+	}
+	var ack typesv2.ControlFrame
+	if err := wsjson.Read(ctx, conn, &ack); err != nil {
+		return fmt.Errorf("read registration: %w", err)
+	}
+	if ack.Type != typesv2.ControlFrameRegistered || ack.Snapshot == nil ||
+		ack.Snapshot.RunID != binding.RunID || ack.Snapshot.AttemptID != binding.AttemptID {
+		return fmt.Errorf("invalid registration snapshot")
+	}
+	if err := s.store.saveSnapshot(*ack.Snapshot); err != nil {
+		return fmt.Errorf("persist snapshot: %w", err)
+	}
+	s.setSnapshot(binding, *ack.Snapshot)
+	s.setConnected(binding, true)
+	if s.claimRecovery(binding) {
+		s.recoverInterrupted(ctx, binding)
+	}
+	log.Printf("[control-v2] connected run=%s attempt=%s", binding.RunID, binding.AttemptID)
+
+	connectionCtx, connectionCancel := context.WithCancel(ctx)
+	defer connectionCancel()
+	go func() {
+		ticker := time.NewTicker(30 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-connectionCtx.Done():
+				return
+			case <-ticker.C:
+				pingCtx, pingCancel := context.WithTimeout(connectionCtx, 10*time.Second)
+				err := conn.Ping(pingCtx)
+				pingCancel()
+				if err != nil {
+					conn.CloseNow()
+					return
+				}
+			}
+		}
+	}()
+	writeErr := make(chan error, 1)
+	go s.sendOutbox(connectionCtx, binding, writer, writeErr)
+	for {
+		var frame typesv2.ControlFrame
+		if err := wsjson.Read(connectionCtx, conn, &frame); err != nil {
+			return err
+		}
+		switch frame.Type {
+		case typesv2.ControlFrameReceipt:
+			if frame.Receipt == nil {
+				return fmt.Errorf("missing control receipt")
+			}
+			if err := s.store.acknowledge(*frame.Receipt); err != nil {
+				return err
+			}
+			s.updateReceiptVersion(binding, *frame.Receipt)
+		case typesv2.ControlFrameEnvelope:
+			if frame.Envelope == nil {
+				return fmt.Errorf("missing control envelope")
+			}
+			receipt, startTask, err := s.acceptHubEnvelope(binding, *frame.Envelope)
+			if err != nil {
+				receipt = typesv2.ControlReceipt{MessageID: frame.Envelope.MessageID,
+					Disposition: typesv2.DispositionRejected, Reason: err.Error()}
+			}
+			if err := writer.write(connectionCtx, typesv2.ControlFrame{Type: typesv2.ControlFrameReceipt, Receipt: &receipt}); err != nil {
+				return err
+			}
+			if startTask != nil && receipt.Disposition == typesv2.DispositionAccepted {
+				go s.executeTask(ctx, binding, frame.Envelope.MessageID, *startTask)
+			}
+		default:
+			return fmt.Errorf("unsupported control frame %q", frame.Type)
+		}
+		select {
+		case err := <-writeErr:
+			return err
+		default:
+		}
+	}
+}
+
+func (s *controlSupervisor) sendOutbox(ctx context.Context, binding workflowControlBinding,
+	writer *controlSocketWriter, result chan<- error) {
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		envelopes, err := s.store.ready(binding, 100)
+		if err != nil {
+			result <- err
+			writer.conn.CloseNow()
+			return
+		}
+		for i := range envelopes {
+			envelope := envelopes[i]
+			if err := writer.write(ctx, typesv2.ControlFrame{Type: typesv2.ControlFrameEnvelope, Envelope: &envelope}); err != nil {
+				result <- err
+				writer.conn.CloseNow()
+				return
+			}
+			if err := s.store.markSent(envelope.MessageID); err != nil {
+				result <- err
+				writer.conn.CloseNow()
+				return
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+func (s *controlSupervisor) acceptHubEnvelope(binding workflowControlBinding,
+	envelope typesv2.ControlEnvelope) (typesv2.ControlReceipt, *typesv2.AgentTask, error) {
+	if envelope.RunID != binding.RunID || envelope.AttemptID != binding.AttemptID {
+		return typesv2.ControlReceipt{}, nil, fmt.Errorf("control envelope identity mismatch")
+	}
+	if err := typesv2.ValidateControlEnvelope(envelope, typesv2.DirectionHubToClaw); err != nil {
+		return typesv2.ControlReceipt{}, nil, err
+	}
+	var task *typesv2.AgentTask
+	switch envelope.Kind {
+	case typesv2.MessageAgentTaskAssign:
+		var decoded typesv2.AgentTask
+		if err := json.Unmarshal(envelope.Payload, &decoded); err != nil {
+			return typesv2.ControlReceipt{}, nil, fmt.Errorf("decode agent task: %w", err)
+		}
+		if decoded.ID != envelope.TaskID || decoded.RunID != binding.RunID || decoded.AttemptID != binding.AttemptID {
+			return typesv2.ControlReceipt{}, nil, fmt.Errorf("agent task identity mismatch")
+		}
+		currentVersion := s.stateVersion(binding)
+		if decoded.StateVersion < currentVersion {
+			return typesv2.ControlReceipt{}, nil, fmt.Errorf("agent task state version %d is older than snapshot version %d",
+				decoded.StateVersion, currentVersion)
+		}
+		if envelope.ExpectedStateVersion != nil && *envelope.ExpectedStateVersion != decoded.StateVersion {
+			return typesv2.ControlReceipt{}, nil, fmt.Errorf("agent task envelope and payload state versions differ")
+		}
+		task = &decoded
+	case typesv2.MessageAgentTaskCancel, typesv2.MessageRunSuspend, typesv2.MessageRunTerminate:
+		// These controls cancel local task execution below after durable receipt.
+	case typesv2.MessageWorkflowSync:
+		var snapshot typesv2.WorkflowSnapshot
+		if err := json.Unmarshal(envelope.Payload, &snapshot); err != nil {
+			return typesv2.ControlReceipt{}, nil, fmt.Errorf("decode workflow snapshot: %w", err)
+		}
+		if snapshot.RunID != binding.RunID || snapshot.AttemptID != binding.AttemptID {
+			return typesv2.ControlReceipt{}, nil, fmt.Errorf("workflow snapshot identity mismatch")
+		}
+		if err := s.store.saveSnapshot(snapshot); err != nil {
+			return typesv2.ControlReceipt{}, nil, err
+		}
+		s.setSnapshot(binding, snapshot)
+	case typesv2.MessageRunResume:
+	default:
+		return typesv2.ControlReceipt{}, nil, fmt.Errorf("bridge does not support control kind %q", envelope.Kind)
+	}
+	duplicate, err := s.store.recordIncoming(envelope)
+	if err != nil {
+		return typesv2.ControlReceipt{}, nil, err
+	}
+	if duplicate {
+		return typesv2.ControlReceipt{MessageID: envelope.MessageID,
+			Disposition: typesv2.DispositionDuplicate, StateVersion: s.stateVersion(binding)}, nil, nil
+	}
+	if task != nil {
+		s.updateTaskSnapshot(binding, task)
+	}
+	if envelope.Kind == typesv2.MessageAgentTaskCancel {
+		s.cancelTask(envelope.TaskID)
+	}
+	if envelope.Kind == typesv2.MessageRunSuspend || envelope.Kind == typesv2.MessageRunTerminate {
+		s.cancelAllTasks()
+	}
+	return typesv2.ControlReceipt{MessageID: envelope.MessageID,
+		Disposition: typesv2.DispositionAccepted, StateVersion: s.stateVersion(binding)}, task, nil
+}
+
+func (s *controlSupervisor) executeTask(ctx context.Context, binding workflowControlBinding,
+	assignmentMessageID string, task typesv2.AgentTask) {
+	claimed, err := s.store.setIncomingStatus(assignmentMessageID, "accepted", "running")
+	if err != nil || !claimed {
+		if err != nil {
+			log.Printf("[control-v2] claim task %s: %v", task.ID, err)
+		}
+		return
+	}
+	s.mu.RLock()
+	gateway := s.gateway
+	s.mu.RUnlock()
+	if gateway == nil || !gateway.IsReady() {
+		s.finishTask(binding, assignmentMessageID, task, typesv2.MessageAgentTaskFailed, "gateway is not ready")
+		return
+	}
+	deadline := task.Deadline
+	if deadline.IsZero() {
+		deadline = time.Now().Add(2 * time.Hour)
+	}
+	taskCtx, cancel := context.WithDeadline(ctx, deadline)
+	s.mu.Lock()
+	s.activeTasks[task.ID] = cancel
+	s.mu.Unlock()
+	defer func() {
+		cancel()
+		s.mu.Lock()
+		delete(s.activeTasks, task.ID)
+		s.mu.Unlock()
+	}()
+
+	if err := s.enqueueTaskEvent(binding, task, typesv2.MessageAgentTaskStarted, map[string]interface{}{
+		"execution": map[string]interface{}{"bridge_started_at": time.Now().UTC()},
+	}); err != nil {
+		s.finishTask(binding, assignmentMessageID, task, typesv2.MessageAgentTaskFailed, err.Error())
+		return
+	}
+	heartbeatDone := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(30 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-heartbeatDone:
+				return
+			case <-taskCtx.Done():
+				return
+			case <-ticker.C:
+				_ = s.enqueueTaskEvent(binding, task, typesv2.MessageAgentTaskHeartbeat,
+					map[string]interface{}{"execution": map[string]interface{}{"heartbeat_at": time.Now().UTC()}})
+			}
+		}
+	}()
+	prompt := workflowV2TaskPrompt(task)
+	response, sendErr := gateway.SendMessage(taskCtx, prompt, func(string) {}, func(agentActivity) {})
+	close(heartbeatDone)
+	if sendErr != nil {
+		s.finishTask(binding, assignmentMessageID, task, typesv2.MessageAgentTaskFailed, sendErr.Error())
+		return
+	}
+	digest := sha256.Sum256([]byte(response))
+	payload := map[string]interface{}{"execution": map[string]interface{}{
+		"gateway_turn_completed": true, "response_bytes": len(response), "response_sha256": hex.EncodeToString(digest[:]),
+	}}
+	if err := s.enqueueTaskEvent(binding, task, typesv2.MessageAgentTaskCompleted, payload); err != nil {
+		log.Printf("[control-v2] queue completion for task %s: %v", task.ID, err)
+		return
+	}
+	_, _ = s.store.setIncomingStatus(assignmentMessageID, "running", "completed")
+}
+
+func (s *controlSupervisor) finishTask(binding workflowControlBinding, assignmentMessageID string,
+	task typesv2.AgentTask, kind typesv2.ControlMessageKind, reason string) {
+	if err := s.enqueueTaskEvent(binding, task, kind,
+		map[string]interface{}{"execution": map[string]interface{}{"error": reason}}); err != nil {
+		log.Printf("[control-v2] queue terminal event for task %s: %v", task.ID, err)
+		return
+	}
+	_, _ = s.store.setIncomingStatus(assignmentMessageID, "running", "failed")
+}
+
+func (s *controlSupervisor) enqueueTaskEvent(binding workflowControlBinding, task typesv2.AgentTask,
+	kind typesv2.ControlMessageKind, payload interface{}) error {
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	version := task.StateVersion
+	envelope := typesv2.ControlEnvelope{ProtocolVersion: typesv2.ControlProtocolVersion,
+		MessageID: uuid.NewString(), Kind: kind, RunID: binding.RunID, AttemptID: binding.AttemptID,
+		TaskID: task.ID, ExpectedStateVersion: &version, SentAt: time.Now().UTC(), Payload: raw}
+	if kind == typesv2.MessageAgentTaskHeartbeat {
+		envelope.ExpectedStateVersion = nil
+	}
+	if err := typesv2.ValidateControlEnvelope(envelope, typesv2.DirectionClawToHub); err != nil {
+		return err
+	}
+	return s.store.enqueue(envelope)
+}
+
+func (s *controlSupervisor) recoverInterrupted(ctx context.Context, binding workflowControlBinding) {
+	envelopes, err := s.store.incomingByStatus(binding, "running")
+	if err != nil {
+		log.Printf("[control-v2] load interrupted tasks: %v", err)
+		return
+	}
+	for _, envelope := range envelopes {
+		if envelope.Kind != typesv2.MessageAgentTaskAssign {
+			continue
+		}
+		var task typesv2.AgentTask
+		if err := json.Unmarshal(envelope.Payload, &task); err != nil {
+			continue
+		}
+		s.finishTask(binding, envelope.MessageID, task, typesv2.MessageAgentTaskFailed,
+			"bridge restarted while task execution outcome was unknown")
+	}
+	accepted, err := s.store.incomingByStatus(binding, "accepted")
+	if err != nil {
+		return
+	}
+	for _, envelope := range accepted {
+		if envelope.Kind != typesv2.MessageAgentTaskAssign {
+			continue
+		}
+		var task typesv2.AgentTask
+		if json.Unmarshal(envelope.Payload, &task) == nil {
+			go s.executeTask(ctx, binding, envelope.MessageID, task)
+		}
+	}
+}
+
+func (s *controlSupervisor) claimRecovery(binding workflowControlBinding) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.recovered[binding] {
+		return false
+	}
+	s.recovered[binding] = true
+	return true
+}
+
+func workflowV2TaskPrompt(task typesv2.AgentTask) string {
+	return fmt.Sprintf(`You are executing ElasticClaw workflow v2 task %s in state %s.
+
+%s
+
+Workflow execution is controlled only through typed messages, never through phrases in your response. Use:
+  claw-bridge control status
+  claw-bridge control plan --payload '<json>'
+  claw-bridge control delivery <pull-request-url> [more URLs...]
+  claw-bridge control help --payload '<json>'
+
+The bridge reports task start, heartbeat, and terminal execution status automatically.`, task.ID, task.State, task.Instructions)
+}
+
+func (s *controlSupervisor) setConnected(binding workflowControlBinding, connected bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.binding != nil && s.binding.equal(binding) {
+		s.connected = connected
+	}
+}
+
+func (s *controlSupervisor) setSnapshot(binding workflowControlBinding, snapshot typesv2.WorkflowSnapshot) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.binding != nil && s.binding.equal(binding) {
+		copySnapshot := snapshot
+		s.snapshot = &copySnapshot
+	}
+}
+
+func (s *controlSupervisor) updateTaskSnapshot(binding workflowControlBinding, task *typesv2.AgentTask) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.binding == nil || !s.binding.equal(binding) {
+		return
+	}
+	if s.snapshot == nil {
+		s.snapshot = &typesv2.WorkflowSnapshot{RunID: binding.RunID, AttemptID: binding.AttemptID}
+	}
+	copyTask := *task
+	s.snapshot.CurrentTask = &copyTask
+	s.snapshot.State = task.State
+	s.snapshot.StateVersion = task.StateVersion
+	snapshot := *s.snapshot
+	_ = s.store.saveSnapshot(snapshot)
+}
+
+func (s *controlSupervisor) updateReceiptVersion(binding workflowControlBinding, receipt typesv2.ControlReceipt) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.binding == nil || !s.binding.equal(binding) || s.snapshot == nil {
+		return
+	}
+	if receipt.StateVersion > s.snapshot.StateVersion {
+		s.snapshot.StateVersion = receipt.StateVersion
+		snapshot := *s.snapshot
+		_ = s.store.saveSnapshot(snapshot)
+	}
+}
+
+func (s *controlSupervisor) stateVersion(binding workflowControlBinding) uint64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.binding != nil && s.binding.equal(binding) && s.snapshot != nil {
+		return s.snapshot.StateVersion
+	}
+	return 0
+}
+
+func (s *controlSupervisor) cancelTask(taskID string) {
+	s.mu.Lock()
+	cancel := s.activeTasks[taskID]
+	s.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+}
+
+func (s *controlSupervisor) cancelAllTasks() {
+	s.mu.Lock()
+	cancels := make([]context.CancelFunc, 0, len(s.activeTasks))
+	for _, cancel := range s.activeTasks {
+		cancels = append(cancels, cancel)
+	}
+	s.mu.Unlock()
+	for _, cancel := range cancels {
+		cancel()
+	}
+}
+
+type localControlRequest struct {
+	Kind                 typesv2.ControlMessageKind `json:"kind"`
+	TaskID               string                     `json:"task_id,omitempty"`
+	ExpectedStateVersion *uint64                    `json:"expected_state_version,omitempty"`
+	Payload              json.RawMessage            `json:"payload,omitempty"`
+}
+
+func (s *controlSupervisor) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	s.mu.RLock()
+	binding, connected := s.binding, s.connected
+	var snapshot *typesv2.WorkflowSnapshot
+	if s.snapshot != nil {
+		copySnapshot := *s.snapshot
+		snapshot = &copySnapshot
+	}
+	s.mu.RUnlock()
+	if r.Method == http.MethodGet {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"connected": connected, "binding": binding, "snapshot": snapshot,
+		})
+		return
+	}
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	if binding == nil {
+		http.Error(w, `{"error":"no active workflow v2 binding"}`, http.StatusConflict)
+		return
+	}
+	decoder := json.NewDecoder(io.LimitReader(r.Body, 1<<20))
+	decoder.DisallowUnknownFields()
+	var request localControlRequest
+	if err := decoder.Decode(&request); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusBadRequest)
+		return
+	}
+	if request.TaskID == "" && snapshot != nil && snapshot.CurrentTask != nil {
+		request.TaskID = snapshot.CurrentTask.ID
+	}
+	if request.ExpectedStateVersion == nil && snapshot != nil {
+		version := snapshot.StateVersion
+		request.ExpectedStateVersion = &version
+	}
+	envelope := typesv2.ControlEnvelope{ProtocolVersion: typesv2.ControlProtocolVersion,
+		MessageID: uuid.NewString(), Kind: request.Kind, RunID: binding.RunID, AttemptID: binding.AttemptID,
+		TaskID: request.TaskID, ExpectedStateVersion: request.ExpectedStateVersion,
+		SentAt: time.Now().UTC(), Payload: request.Payload}
+	if request.Kind == typesv2.MessageAgentTaskHeartbeat || request.Kind == typesv2.MessageHelpRequested {
+		envelope.ExpectedStateVersion = nil
+	}
+	if err := typesv2.ValidateControlEnvelope(envelope, typesv2.DirectionClawToHub); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusBadRequest)
+		return
+	}
+	if err := s.store.enqueue(envelope); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	if connected {
+		waitCtx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+		defer cancel()
+		if receipt, found, err := s.waitForReceipt(waitCtx, envelope.MessageID); err != nil {
+			http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+			return
+		} else if found {
+			status := http.StatusOK
+			if receipt.Disposition != typesv2.DispositionAccepted && receipt.Disposition != typesv2.DispositionDuplicate {
+				status = http.StatusConflict
+			}
+			w.WriteHeader(status)
+			_ = json.NewEncoder(w).Encode(receipt)
+			return
+		}
+	}
+	w.WriteHeader(http.StatusAccepted)
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{"message_id": envelope.MessageID, "status": "pending"})
+}
+
+func (s *controlSupervisor) waitForReceipt(ctx context.Context, messageID string) (typesv2.ControlReceipt, bool, error) {
+	ticker := time.NewTicker(25 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		receipt, found, err := s.store.receipt(messageID)
+		if err != nil || found {
+			return receipt, found, err
+		}
+		select {
+		case <-ctx.Done():
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				return typesv2.ControlReceipt{}, false, nil
+			}
+			return typesv2.ControlReceipt{}, false, ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+type unavailableControlHandler struct{ reason string }
+
+func (h unavailableControlHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+	http.Error(w, h.reason, http.StatusServiceUnavailable)
+}
+
+func defaultBridgeControlStorePath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".elasticclaw", "control-v2.sqlite"), nil
+}
+
+func bridgeRegistration(controlAvailable bool) typesv2.BridgeRegistration {
+	protocols := []string{typesv2.ProtocolConversationV1}
+	capabilities := []string(nil)
+	if controlAvailable {
+		protocols = append(protocols, typesv2.ProtocolControlV2)
+		capabilities = []string{"workflow.snapshot", "agent.task", "delivery.manifest", "local.control"}
+	}
+	return typesv2.BridgeRegistration{BridgeVersion: Version, Protocols: protocols, Capabilities: capabilities}
+}
+
+func runControlCLI(args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "usage: claw-bridge control <status|send|plan|delivery|help> ...")
+		return 2
+	}
+	if args[0] == "status" {
+		return controlCLIRequest(http.MethodGet, nil)
+	}
+	request := localControlRequest{}
+	switch args[0] {
+	case "send":
+		if len(args) < 2 {
+			fmt.Fprintln(os.Stderr, "usage: claw-bridge control send <kind> [--task-id=ID] [--state-version=N] [--payload=JSON]")
+			return 2
+		}
+		request.Kind = typesv2.ControlMessageKind(args[1])
+		args = args[2:]
+	case "plan":
+		request.Kind = typesv2.MessagePlanSubmitted
+		args = args[1:]
+	case "help":
+		request.Kind = typesv2.MessageHelpRequested
+		args = args[1:]
+	case "delivery":
+		request.Kind = typesv2.MessageDeliverySubmitted
+		urls := args[1:]
+		if len(urls) == 0 {
+			fmt.Fprintln(os.Stderr, "usage: claw-bridge control delivery <pull-request-url> [more URLs...]")
+			return 2
+		}
+		manifest := typesv2.DeliveryManifest{PullRequests: make([]typesv2.PullRequestClaim, len(urls))}
+		for i, value := range urls {
+			manifest.PullRequests[i] = typesv2.PullRequestClaim{URL: value}
+		}
+		request.Payload, _ = json.Marshal(manifest)
+		args = nil
+	default:
+		fmt.Fprintf(os.Stderr, "unknown control command %q\n", args[0])
+		return 2
+	}
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case strings.HasPrefix(arg, "--task-id="):
+			request.TaskID = strings.TrimPrefix(arg, "--task-id=")
+		case arg == "--task-id" && i+1 < len(args):
+			i++
+			request.TaskID = args[i]
+		case strings.HasPrefix(arg, "--state-version="):
+			value, err := strconv.ParseUint(strings.TrimPrefix(arg, "--state-version="), 10, 64)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				return 2
+			}
+			request.ExpectedStateVersion = &value
+		case arg == "--state-version" && i+1 < len(args):
+			i++
+			value, err := strconv.ParseUint(args[i], 10, 64)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				return 2
+			}
+			request.ExpectedStateVersion = &value
+		case strings.HasPrefix(arg, "--payload="):
+			request.Payload = json.RawMessage(strings.TrimPrefix(arg, "--payload="))
+		case arg == "--payload" && i+1 < len(args):
+			i++
+			request.Payload = json.RawMessage(args[i])
+		default:
+			fmt.Fprintf(os.Stderr, "unknown option %q\n", arg)
+			return 2
+		}
+	}
+	raw, err := json.Marshal(request)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	return controlCLIRequest(http.MethodPost, raw)
+}
+
+func controlCLIRequest(method string, body []byte) int {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	var reader io.Reader
+	if body != nil {
+		reader = strings.NewReader(string(body))
+	}
+	req, err := http.NewRequestWithContext(ctx, method, "http://127.0.0.1:18790"+localControlPath, reader)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	defer resp.Body.Close()
+	response, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	_, _ = os.Stdout.Write(response)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return 1
+	}
+	return 0
+}

--- a/cmd/claw-bridge/control_v2_test.go
+++ b/cmd/claw-bridge/control_v2_test.go
@@ -1,0 +1,238 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	typesv2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
+)
+
+func openTestBridgeControlStore(t *testing.T) *bridgeControlStore {
+	t.Helper()
+	store, err := openBridgeControlStore(filepath.Join(t.TempDir(), "control.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.close() })
+	return store
+}
+
+func TestBridgeControlStoreDurablyDeduplicatesInboxAndReplaysOutbox(t *testing.T) {
+	store := openTestBridgeControlStore(t)
+	binding := workflowControlBinding{RunID: "run-1", AttemptID: "attempt-1"}
+	version := uint64(3)
+	incoming := typesv2.ControlEnvelope{ProtocolVersion: typesv2.ControlProtocolVersion,
+		MessageID: "assign-1", Kind: typesv2.MessageAgentTaskAssign, RunID: binding.RunID,
+		AttemptID: binding.AttemptID, TaskID: "task-1", ExpectedStateVersion: &version}
+	duplicate, err := store.recordIncoming(incoming)
+	if err != nil || duplicate {
+		t.Fatalf("first incoming duplicate=%v err=%v", duplicate, err)
+	}
+	duplicate, err = store.recordIncoming(incoming)
+	if err != nil || !duplicate {
+		t.Fatalf("second incoming duplicate=%v err=%v", duplicate, err)
+	}
+
+	outgoing := typesv2.ControlEnvelope{ProtocolVersion: typesv2.ControlProtocolVersion,
+		MessageID: "plan-1", Kind: typesv2.MessagePlanSubmitted, RunID: binding.RunID,
+		AttemptID: binding.AttemptID, ExpectedStateVersion: &version, Payload: []byte(`{"plan":{"summary":"safe"}}`)}
+	if err := store.enqueue(outgoing); err != nil {
+		t.Fatal(err)
+	}
+	ready, err := store.ready(binding, 10)
+	if err != nil || len(ready) != 1 || ready[0].MessageID != outgoing.MessageID {
+		t.Fatalf("ready = %#v, err=%v", ready, err)
+	}
+	if err := store.markSent(outgoing.MessageID); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.acknowledge(typesv2.ControlReceipt{MessageID: outgoing.MessageID,
+		Disposition: typesv2.DispositionAccepted, StateVersion: version}); err != nil {
+		t.Fatal(err)
+	}
+	ready, err = store.ready(binding, 10)
+	if err != nil || len(ready) != 0 {
+		t.Fatalf("ready after receipt = %#v, err=%v", ready, err)
+	}
+}
+
+func TestLocalControlEndpointBuildsBoundTypedEnvelope(t *testing.T) {
+	store := openTestBridgeControlStore(t)
+	binding := workflowControlBinding{RunID: "run-local", AttemptID: "attempt-local"}
+	supervisor := newControlSupervisor(context.Background(), "ws://invalid", "claw-local", "token",
+		bridgeRegistration(true), store)
+	supervisor.binding = &binding
+	// A disconnected control socket still journals commands and returns pending
+	// immediately; connected commands are covered by TestLocalControlEndpointWaitsForReceipt.
+	supervisor.connected = false
+	supervisor.snapshot = &typesv2.WorkflowSnapshot{RunID: binding.RunID, AttemptID: binding.AttemptID,
+		State: "planning", StateVersion: 7, CurrentTask: &typesv2.AgentTask{ID: "task-local"}}
+
+	req := httptest.NewRequest(http.MethodPost, localControlPath,
+		bytes.NewBufferString(`{"kind":"plan.submitted","payload":{"plan":{"summary":"ready"}}}`))
+	recorder := httptest.NewRecorder()
+	supervisor.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	ready, err := store.ready(binding, 10)
+	if err != nil || len(ready) != 1 {
+		t.Fatalf("ready = %#v, err=%v", ready, err)
+	}
+	if ready[0].RunID != binding.RunID || ready[0].AttemptID != binding.AttemptID ||
+		ready[0].TaskID != "task-local" || ready[0].ExpectedStateVersion == nil || *ready[0].ExpectedStateVersion != 7 {
+		t.Fatalf("envelope = %#v", ready[0])
+	}
+	var payload map[string]interface{}
+	if err := json.Unmarshal(ready[0].Payload, &payload); err != nil || payload["plan"] == nil {
+		t.Fatalf("payload = %#v, err=%v", payload, err)
+	}
+
+	bad := httptest.NewRequest(http.MethodPost, localControlPath,
+		bytes.NewBufferString(`{"kind":"conversation.message","payload":{}}`))
+	badRecorder := httptest.NewRecorder()
+	supervisor.ServeHTTP(badRecorder, bad)
+	if badRecorder.Code != http.StatusBadRequest {
+		t.Fatalf("conversation control status = %d, body = %s", badRecorder.Code, badRecorder.Body.String())
+	}
+}
+
+func TestLocalControlEndpointWaitsForReceipt(t *testing.T) {
+	store := openTestBridgeControlStore(t)
+	binding := workflowControlBinding{RunID: "run-receipt", AttemptID: "attempt-receipt"}
+	supervisor := newControlSupervisor(context.Background(), "ws://invalid", "claw", "token", bridgeRegistration(true), store)
+	supervisor.binding = &binding
+	supervisor.connected = true
+	supervisor.snapshot = &typesv2.WorkflowSnapshot{RunID: binding.RunID, AttemptID: binding.AttemptID, StateVersion: 2}
+
+	done := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		recorder := httptest.NewRecorder()
+		supervisor.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, localControlPath,
+			bytes.NewBufferString(`{"kind":"plan.submitted","payload":{"plan":{"summary":"ready"}}}`)))
+		done <- recorder
+	}()
+	deadline := time.Now().Add(time.Second)
+	var messageID string
+	for messageID == "" && time.Now().Before(deadline) {
+		ready, err := store.ready(binding, 10)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(ready) > 0 {
+			messageID = ready[0].MessageID
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if messageID == "" {
+		t.Fatal("local command was not queued")
+	}
+	if err := store.acknowledge(typesv2.ControlReceipt{MessageID: messageID,
+		Disposition: typesv2.DispositionAccepted, StateVersion: 3}); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case recorder := <-done:
+		if recorder.Code != http.StatusOK || !strings.Contains(recorder.Body.String(), string(typesv2.DispositionAccepted)) {
+			t.Fatalf("status/body = %d/%s", recorder.Code, recorder.Body.String())
+		}
+	case <-time.After(time.Second):
+		t.Fatal("local control request did not return after receipt")
+	}
+}
+
+func TestBridgeRegistrationOnlyAdvertisesControlWhenDurableStoreIsAvailable(t *testing.T) {
+	legacy := bridgeRegistration(false)
+	if !legacy.SupportsProtocol(typesv2.ProtocolConversationV1) || legacy.SupportsProtocol(typesv2.ProtocolControlV2) {
+		t.Fatalf("legacy registration = %#v", legacy)
+	}
+	control := bridgeRegistration(true)
+	if !control.SupportsProtocol(typesv2.ProtocolConversationV1) || !control.SupportsProtocol(typesv2.ProtocolControlV2) {
+		t.Fatalf("control registration = %#v", control)
+	}
+}
+
+func TestBridgeRejectsTaskAssignmentOlderThanAuthoritativeSnapshot(t *testing.T) {
+	store := openTestBridgeControlStore(t)
+	binding := workflowControlBinding{RunID: "run-stale-task", AttemptID: "attempt-stale-task"}
+	supervisor := newControlSupervisor(context.Background(), "ws://invalid", "claw", "token", bridgeRegistration(true), store)
+	supervisor.binding = &binding
+	supervisor.snapshot = &typesv2.WorkflowSnapshot{RunID: binding.RunID, AttemptID: binding.AttemptID, StateVersion: 7}
+	task := typesv2.AgentTask{ID: "task-stale", RunID: binding.RunID, AttemptID: binding.AttemptID,
+		State: "building", StateVersion: 6, Status: typesv2.AgentTaskAssigned, Instructions: "obsolete work"}
+	payload, _ := json.Marshal(task)
+	version := uint64(6)
+	envelope := typesv2.ControlEnvelope{ProtocolVersion: typesv2.ControlProtocolVersion,
+		MessageID: "assign-stale", Kind: typesv2.MessageAgentTaskAssign, RunID: binding.RunID,
+		AttemptID: binding.AttemptID, TaskID: task.ID, ExpectedStateVersion: &version, Payload: payload}
+	if _, _, err := supervisor.acceptHubEnvelope(binding, envelope); err == nil || !strings.Contains(err.Error(), "older") {
+		t.Fatalf("stale assignment error = %v", err)
+	}
+	accepted, err := store.incomingByStatus(binding, "accepted")
+	if err != nil || len(accepted) != 0 {
+		t.Fatalf("stale assignment was journaled: %#v, err=%v", accepted, err)
+	}
+}
+
+func TestWorkflowV2TaskPromptUsesTypedToolAndNotTranscriptMarkers(t *testing.T) {
+	prompt := workflowV2TaskPrompt(typesv2.AgentTask{ID: "task-1", State: "building", Instructions: "Implement it."})
+	if !strings.Contains(prompt, "claw-bridge control") || !strings.Contains(prompt, "never through phrases") {
+		t.Fatalf("prompt = %q", prompt)
+	}
+	for _, marker := range []string{"[DONE]", "[READY_TO_COMMIT]"} {
+		if strings.Contains(prompt, marker) {
+			t.Fatalf("prompt contains transcript marker %q", marker)
+		}
+	}
+}
+
+func TestBridgeControlSnapshotPersistsAcrossProcessRestart(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "control.sqlite")
+	first, err := openBridgeControlStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot := typesv2.WorkflowSnapshot{RunID: "run-restart", AttemptID: "attempt-restart",
+		State: "building", StateVersion: 11}
+	if err := first.saveSnapshot(snapshot); err != nil {
+		t.Fatal(err)
+	}
+	if err := first.close(); err != nil {
+		t.Fatal(err)
+	}
+	second, err := openBridgeControlStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer second.close()
+	loaded, found, err := second.snapshot(workflowControlBinding{RunID: snapshot.RunID, AttemptID: snapshot.AttemptID})
+	if err != nil || !found || loaded.StateVersion != snapshot.StateVersion || loaded.State != snapshot.State {
+		t.Fatalf("loaded = %#v, found=%v, err=%v", loaded, found, err)
+	}
+}
+
+func TestBridgeControlOutboxRetryUsesStableMessageIdentity(t *testing.T) {
+	store := openTestBridgeControlStore(t)
+	binding := workflowControlBinding{RunID: "run-retry", AttemptID: "attempt-retry"}
+	envelope := typesv2.ControlEnvelope{ProtocolVersion: typesv2.ControlProtocolVersion,
+		MessageID: "stable-message", Kind: typesv2.MessageHelpRequested,
+		RunID: binding.RunID, AttemptID: binding.AttemptID, SentAt: time.Now().UTC()}
+	if err := store.enqueue(envelope); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.enqueue(envelope); err != nil {
+		t.Fatal(err)
+	}
+	ready, err := store.ready(binding, 10)
+	if err != nil || len(ready) != 1 || ready[0].MessageID != envelope.MessageID {
+		t.Fatalf("ready = %#v, err=%v", ready, err)
+	}
+}

--- a/cmd/claw-bridge/control_v2_test.go
+++ b/cmd/claw-bridge/control_v2_test.go
@@ -160,6 +160,30 @@ func TestBridgeRegistrationOnlyAdvertisesControlWhenDurableStoreIsAvailable(t *t
 	}
 }
 
+func TestOldTaskCleanupCannotRemoveReplacementCancellation(t *testing.T) {
+	supervisor := newControlSupervisor(context.Background(), "ws://invalid", "claw", "token",
+		bridgeRegistration(true), openTestBridgeControlStore(t))
+	oldCancelled := make(chan struct{})
+	oldCancellation := supervisor.registerTaskCancellation("task-reused", func() { close(oldCancelled) })
+	newCancelled := make(chan struct{})
+	newCancellation := supervisor.registerTaskCancellation("task-reused", func() { close(newCancelled) })
+
+	supervisor.unregisterTaskCancellation("task-reused", oldCancellation)
+	supervisor.cancelTask("task-reused")
+
+	select {
+	case <-newCancelled:
+	default:
+		t.Fatal("replacement task cancellation was removed by old task cleanup")
+	}
+	select {
+	case <-oldCancelled:
+		t.Fatal("cancelling the replacement task cancelled the old task")
+	default:
+	}
+	supervisor.unregisterTaskCancellation("task-reused", newCancellation)
+}
+
 func TestBridgeRejectsTaskAssignmentOlderThanAuthoritativeSnapshot(t *testing.T) {
 	store := openTestBridgeControlStore(t)
 	binding := workflowControlBinding{RunID: "run-stale-task", AttemptID: "attempt-stale-task"}

--- a/cmd/claw-bridge/control_v2_test.go
+++ b/cmd/claw-bridge/control_v2_test.go
@@ -184,6 +184,24 @@ func TestOldTaskCleanupCannotRemoveReplacementCancellation(t *testing.T) {
 	supervisor.unregisterTaskCancellation("task-reused", newCancellation)
 }
 
+func TestTaskCancellationIsRegisteredBeforeExecutionStarts(t *testing.T) {
+	supervisor := newControlSupervisor(context.Background(), "ws://invalid", "claw", "token",
+		bridgeRegistration(true), openTestBridgeControlStore(t))
+	task := typesv2.AgentTask{ID: "task-immediate-cancel", Deadline: time.Now().Add(time.Minute)}
+	taskCtx, cancel, activeCancellation := supervisor.prepareTaskExecution(context.Background(), task)
+	defer cancel()
+	defer supervisor.unregisterTaskCancellation("task-immediate-cancel", activeCancellation)
+
+	// This is the ordering used by startTask: registration occurs on the reader
+	// goroutine before execution is launched and before it can read a cancel.
+	supervisor.cancelTask("task-immediate-cancel")
+	select {
+	case <-taskCtx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("immediate cancellation did not reach the registered task")
+	}
+}
+
 func TestBridgeRejectsTaskAssignmentOlderThanAuthoritativeSnapshot(t *testing.T) {
 	store := openTestBridgeControlStore(t)
 	binding := workflowControlBinding{RunID: "run-stale-task", AttemptID: "attempt-stale-task"}

--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -3941,6 +3941,9 @@ func main() {
 	if len(os.Args) > 1 && os.Args[1] == "linear" {
 		os.Exit(runLinearCLI(os.Args[2:]))
 	}
+	if len(os.Args) > 1 && os.Args[1] == "control" {
+		os.Exit(runControlCLI(os.Args[2:]))
+	}
 
 	// Bootstrap mode: run all VM setup steps before entering the bridge loop.
 	// Activated by --bootstrap flag or ELASTICCLAW_BOOTSTRAP=1 env var.
@@ -3964,14 +3967,15 @@ func main() {
 	clawName := envOr("ELASTICCLAW_CLAW_NAME", clawID)
 	templateName := envOr("ELASTICCLAW_TEMPLATE", "")
 
-	// Build WebSocket URL from hub URL directly
-	wsURL := strings.TrimRight(hubURL, "/")
-	if strings.HasPrefix(wsURL, "http://") {
-		wsURL = "ws://" + wsURL[7:]
-	} else if strings.HasPrefix(wsURL, "https://") {
-		wsURL = "wss://" + wsURL[8:]
+	// Build independent conversation and workflow-control WebSocket URLs.
+	wsBaseURL := strings.TrimRight(hubURL, "/")
+	if strings.HasPrefix(wsBaseURL, "http://") {
+		wsBaseURL = "ws://" + wsBaseURL[7:]
+	} else if strings.HasPrefix(wsBaseURL, "https://") {
+		wsBaseURL = "wss://" + wsBaseURL[8:]
 	}
-	wsURL += "/claw/ws"
+	wsURL := wsBaseURL + "/claw/ws"
+	controlWSURL := wsBaseURL + "/claw/control/ws"
 	log.Printf("  Mode:    direct")
 
 	log.Printf("claw-bridge starting")
@@ -3992,20 +3996,35 @@ func main() {
 		log.Printf("  ⚠️  gateway not responding at %s (will retry)", gatewayAddr)
 	}
 
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
 	// Start local HTTP proxy so tools in the sandbox can reach hub APIs
 	// via http://localhost:18790 without needing a public hub URL.
 	proxy := newHTTPProxy(nil) // send func wired up in runHubLoop
 	queue := &msgQueue{}
 	deduper := newMessageDeduper()
+	var control *controlSupervisor
+	var controlHandler http.Handler = unavailableControlHandler{reason: "workflow v2 control is unavailable"}
+	if controlPath, pathErr := defaultBridgeControlStorePath(); pathErr != nil {
+		log.Printf("[control-v2] disabled: %v", pathErr)
+	} else if controlStore, storeErr := openBridgeControlStore(controlPath); storeErr != nil {
+		log.Printf("[control-v2] disabled: %v", storeErr)
+	} else {
+		defer controlStore.close()
+		control = newControlSupervisor(ctx, controlWSURL, clawID, token, bridgeRegistration(true), controlStore)
+		controlHandler = control
+	}
+	protocolRegistration := bridgeRegistration(control != nil)
+	localMux := http.NewServeMux()
+	localMux.Handle(localControlPath, controlHandler)
+	localMux.Handle("/", proxy)
 	go func() {
 		log.Printf("[bridge] local HTTP proxy on 127.0.0.1:18790")
-		if err := http.ListenAndServe("127.0.0.1:18790", proxy); err != nil {
+		if err := http.ListenAndServe("127.0.0.1:18790", localMux); err != nil {
 			log.Printf("[bridge] HTTP proxy error: %v", err)
 		}
 	}()
-
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-	defer stop()
 
 	// Establish the persistent gateway session before entering the hub loop.
 	// Retry until we succeed (gateway may not be ready yet).
@@ -4037,12 +4056,16 @@ func main() {
 	}
 	log.Printf("[bridge] gateway session ready: %s", gwSession.getSessionKey())
 	setActiveGatewaySession(gwSession)
+	if control != nil {
+		control.setGatewaySession(gwSession)
+	}
 
 	// Start status channel goroutine (lightweight second WS to hub)
 	go runStatusChannel(ctx, wsURL, clawID, clawName, templateName, token)
 
 	for {
-		if err := runHubLoop(ctx, wsURL, clawID, clawName, templateName, token, modelAuthToken, gwClient, gwSession, proxy, queue, deduper); err != nil {
+		if err := runHubLoop(ctx, wsURL, clawID, clawName, templateName, token, modelAuthToken,
+			protocolRegistration, control, gwClient, gwSession, proxy, queue, deduper); err != nil {
 			if ctx.Err() != nil {
 				log.Printf("shutting down")
 				return
@@ -4179,7 +4202,9 @@ func runStatusChannel(ctx context.Context, wsURL, clawID, clawName, templateName
 	}
 }
 
-func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, token, modelAuthToken string, gwClient *gatewayClient, gwSession *gatewaySession, proxy *httpProxy, queue *msgQueue, deduper *messageDeduper) error {
+func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, token, modelAuthToken string,
+	protocolRegistration bridgeProtocolRegistration, control *controlSupervisor, gwClient *gatewayClient,
+	gwSession *gatewaySession, proxy *httpProxy, queue *msgQueue, deduper *messageDeduper) error {
 	conn, _, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{
 		HTTPHeader: http.Header{
 			"User-Agent":                 {"claw-bridge/1.0"},
@@ -4207,6 +4232,9 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 			"token":            token,
 			"model_auth_token": modelAuthToken,
 			"gateway_ready":    gwSession.IsReady(),
+			"bridge_version":   protocolRegistration.BridgeVersion,
+			"protocols":        protocolRegistration.Protocols,
+			"capabilities":     protocolRegistration.Capabilities,
 		}),
 	}
 	if err := writeHub(reg); err != nil {
@@ -4224,6 +4252,7 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 	var registered struct {
 		ModelAuthCredential *managedModelAuthCredential `json:"model_auth_credential"`
 		ModelAuthError      string                      `json:"model_auth_error"`
+		WorkflowControl     *workflowControlBinding     `json:"workflow_control"`
 	}
 	if len(ack.Payload) > 0 && string(ack.Payload) != "null" {
 		if err := json.Unmarshal(ack.Payload, &registered); err != nil {
@@ -4238,6 +4267,9 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 		lastModelAuthSync.Store(time.Now().UnixNano())
 	} else if registered.ModelAuthError != "" {
 		log.Printf("[model-auth] %s", registered.ModelAuthError)
+	}
+	if control != nil {
+		control.updateBinding(registered.WorkflowControl)
 	}
 	log.Printf("registered with hub as %s", clawID)
 

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -1440,7 +1440,8 @@ func TestRunHubLoopDoesNotLeakKeepaliveGoroutinesAcrossReconnects(t *testing.T) 
 	before := stableGoroutineCount(t)
 	const cycles = 5
 	for range cycles {
-		err := runHubLoop(ctx, wsURL, "claw-test", "test-claw", "test-template", "tok", "", gwClient, gwSession, proxy, queue, newMessageDeduper())
+		err := runHubLoop(ctx, wsURL, "claw-test", "test-claw", "test-template", "tok", "",
+			bridgeRegistration(false), nil, gwClient, gwSession, proxy, queue, newMessageDeduper())
 		if err == nil {
 			t.Fatal("runHubLoop returned nil error, want read error after hub-side close")
 		}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -37,10 +37,12 @@ import (
 	"github.com/elasticclaw/elasticclaw/pkg/hub/artifact"
 	"github.com/elasticclaw/elasticclaw/pkg/hub/notify"
 	"github.com/elasticclaw/elasticclaw/pkg/hub/pipeline"
+	"github.com/elasticclaw/elasticclaw/pkg/hub/workflowv2"
 	daytona "github.com/elasticclaw/elasticclaw/pkg/provider/daytona"
 	exedevProvider "github.com/elasticclaw/elasticclaw/pkg/provider/exedev"
 	replicatedpkg "github.com/elasticclaw/elasticclaw/pkg/provider/replicated"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
+	typesv2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
 	"github.com/google/uuid"
 	gossh "golang.org/x/crypto/ssh"
 	"nhooyr.io/websocket"
@@ -512,6 +514,9 @@ func (s *Server) run(ctx context.Context, opts ...RunOptions) error {
 func (s *Server) registerRoutes(mux *http.ServeMux) {
 	// Claw WebSocket
 	mux.HandleFunc("/claw/ws", s.handleClawWS)
+	// Dedicated workflow v2 control WebSocket. Authentication and wire types
+	// are intentionally separate from the conversation channel above.
+	mux.HandleFunc("/claw/control/ws", s.handleWorkflowV2ControlWS)
 
 	// Browser WebSocket
 	mux.HandleFunc("/api/ws", s.withAuth(s.handleUserWS))
@@ -2302,6 +2307,23 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 	// Status channels must not mutate claw DB state (rp.GatewayReady is nil,
 	// so initialStatus would incorrectly overwrite 'starting'/'bootstrap_needed').
 	isStatusChannel := rp.Channel == "status"
+	var workflowControl *workflowV2ControlBinding
+	if !isStatusChannel {
+		binding, found, bindingErr := workflowv2.NewStore(s.db).ActiveControlBinding(ctx, tenantID, clawID)
+		if bindingErr != nil {
+			conn.Close(websocket.StatusInternalError, "workflow control binding unavailable")
+			return
+		}
+		if found {
+			bridge := typesv2.BridgeRegistration{BridgeVersion: rp.BridgeVersion,
+				Protocols: rp.Protocols, Capabilities: rp.Capabilities}
+			if err := typesv2.ValidateBridgeForWorkflow("2", bridge); err != nil {
+				conn.Close(websocket.StatusPolicyViolation, "active workflow requires control.v2")
+				return
+			}
+			workflowControl = &workflowV2ControlBinding{RunID: binding.RunID, AttemptID: binding.AttemptID}
+		}
+	}
 
 	var bootstrapOK int
 	var provider string
@@ -2412,6 +2434,9 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 	// Bind managed model credentials to this authenticated WebSocket instead of
 	// accepting a caller-supplied claw ID on a tenant-token HTTP endpoint.
 	ackPayload := map[string]any{"claw_id": clawID}
+	if workflowControl != nil {
+		ackPayload["workflow_control"] = workflowControl
+	}
 	modelAuthAuthorized := s.validModelAuthToken(clawID, rp.ModelAuthToken)
 	if modelAuthAuthorized {
 		credential, credentialErr := s.managedGrokCredential(context.WithValue(ctx, ctxTenantKey{}, tenantID), clawID)
@@ -6015,7 +6040,7 @@ const (
 	// written on plan_gate pass. Hidden from chat/timeline/transcript APIs.
 	planGateAcceptedMarkerPrefix = "__PLAN_GATE_ACCEPTED__:"
 	defaultWakeContent           = "Introduce yourself briefly and let the user know you're ready to help."
-	initialPlanWakeContent          = `Initial plan required before implementation.
+	initialPlanWakeContent       = `Initial plan required before implementation.
 
 Before editing files, running builds, or doing broad tool exploration, send one visible assistant message that contains:
 1. Your understanding of the issue or task.

--- a/pkg/hub/workflow_v2_control_ws.go
+++ b/pkg/hub/workflow_v2_control_ws.go
@@ -1,0 +1,191 @@
+package hub
+
+import (
+	"context"
+	"crypto/hmac"
+	"errors"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/hub/workflowv2"
+	typesv2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
+	"nhooyr.io/websocket"
+	"nhooyr.io/websocket/wsjson"
+)
+
+const clawControlTokenHeader = "X-Claw-Token"
+
+type workflowV2ControlBinding struct {
+	RunID     string `json:"run_id"`
+	AttemptID string `json:"attempt_id"`
+}
+
+type workflowV2ControlWriter struct {
+	mu   sync.Mutex
+	conn *websocket.Conn
+}
+
+func (w *workflowV2ControlWriter) write(ctx context.Context, frame typesv2.ControlFrame) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	writeCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	return wsjson.Write(writeCtx, w.conn, frame)
+}
+
+// handleWorkflowV2ControlWS owns only deterministic workflow control. It does
+// not accept or emit conversation messages, and it is independently
+// authenticated and bound to one durable run attempt.
+func (s *Server) handleWorkflowV2ControlWS(w http.ResponseWriter, r *http.Request) {
+	headerToken := strings.TrimSpace(r.Header.Get(clawControlTokenHeader))
+	tenantID, err := s.tenantByClawToken(headerToken)
+	if headerToken == "" || err != nil {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	conn, err := websocket.Accept(w, r, nil)
+	if err != nil {
+		return
+	}
+	defer conn.CloseNow()
+	conn.SetReadLimit(2 << 20)
+
+	ctx, cancel := context.WithCancel(r.Context())
+	defer cancel()
+	registrationCtx, registrationCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer registrationCancel()
+	var first typesv2.ControlFrame
+	if err := wsjson.Read(registrationCtx, conn, &first); err != nil || first.Type != typesv2.ControlFrameRegister || first.Registration == nil {
+		_ = conn.Close(websocket.StatusPolicyViolation, "expected control registration")
+		return
+	}
+	registration := *first.Registration
+	if err := typesv2.ValidateControlRegistration(registration); err != nil ||
+		!hmac.Equal([]byte(headerToken), []byte(strings.TrimSpace(registration.Token))) {
+		_ = conn.Close(websocket.StatusPolicyViolation, "invalid control registration")
+		return
+	}
+
+	store := workflowv2.NewStore(s.db)
+	if err := store.AuthorizeControlAttempt(ctx, registration.RunID, registration.AttemptID, registration.ClawID, tenantID); err != nil {
+		_ = conn.Close(websocket.StatusPolicyViolation, "workflow attempt is not authorized")
+		return
+	}
+	snapshot, err := store.Snapshot(ctx, registration.RunID, registration.AttemptID)
+	if err != nil {
+		_ = conn.Close(websocket.StatusInternalError, "workflow snapshot unavailable")
+		return
+	}
+
+	writer := &workflowV2ControlWriter{conn: conn}
+	if err := writer.write(ctx, typesv2.ControlFrame{Type: typesv2.ControlFrameRegistered, Snapshot: &snapshot}); err != nil {
+		return
+	}
+
+	outboxErr := make(chan error, 1)
+	go s.sendWorkflowV2ControlOutbox(ctx, store, writer, registration, tenantID, outboxErr)
+	for {
+		var frame typesv2.ControlFrame
+		if err := wsjson.Read(ctx, conn, &frame); err != nil {
+			return
+		}
+		if err := store.AuthorizeControlAttempt(ctx, registration.RunID, registration.AttemptID, registration.ClawID, tenantID); err != nil {
+			_ = conn.Close(websocket.StatusPolicyViolation, "workflow attempt is no longer active")
+			return
+		}
+		switch frame.Type {
+		case typesv2.ControlFrameReceipt:
+			if frame.Receipt == nil || strings.TrimSpace(frame.Receipt.MessageID) == "" {
+				_ = conn.Close(websocket.StatusPolicyViolation, "invalid control receipt")
+				return
+			}
+			if err := store.AcknowledgeControl(ctx, registration.RunID, registration.AttemptID, *frame.Receipt); err != nil {
+				_ = conn.Close(websocket.StatusPolicyViolation, "control receipt is not authorized")
+				return
+			}
+		case typesv2.ControlFrameEnvelope:
+			if frame.Envelope == nil {
+				_ = conn.Close(websocket.StatusPolicyViolation, "missing control envelope")
+				return
+			}
+			envelope := *frame.Envelope
+			if envelope.RunID != registration.RunID || envelope.AttemptID != registration.AttemptID {
+				_ = conn.Close(websocket.StatusPolicyViolation, "control envelope identity mismatch")
+				return
+			}
+			receipt, applyErr := s.applyWorkflowV2ClawControl(ctx, store, envelope)
+			if applyErr != nil {
+				if strings.TrimSpace(envelope.MessageID) == "" {
+					_ = conn.Close(websocket.StatusPolicyViolation, "control message id is required")
+					return
+				}
+				receipt, err = store.RejectAgentControl(ctx, envelope, applyErr.Error())
+				if err != nil {
+					_ = conn.Close(websocket.StatusInternalError, "control rejection could not be recorded")
+					return
+				}
+			}
+			if err := writer.write(ctx, typesv2.ControlFrame{Type: typesv2.ControlFrameReceipt, Receipt: &receipt}); err != nil {
+				return
+			}
+		default:
+			_ = conn.Close(websocket.StatusPolicyViolation, "unsupported control frame")
+			return
+		}
+		select {
+		case err := <-outboxErr:
+			if err != nil && !errors.Is(err, context.Canceled) {
+				log.Printf("[workflow-v2 control] outbox %s/%s: %v", registration.RunID, registration.AttemptID, err)
+			}
+			return
+		default:
+		}
+	}
+}
+
+func (s *Server) applyWorkflowV2ClawControl(ctx context.Context, store *workflowv2.Store,
+	envelope typesv2.ControlEnvelope) (typesv2.ControlReceipt, error) {
+	if envelope.Kind == typesv2.MessageDeliverySubmitted || envelope.Kind == typesv2.MessagePullRequestClaimed {
+		return store.ApplyDeliveryControl(ctx, envelope, s.workflowV2PullRequestVerifier())
+	}
+	return store.ApplyAgentControl(ctx, envelope)
+}
+
+func (s *Server) sendWorkflowV2ControlOutbox(ctx context.Context, store *workflowv2.Store,
+	writer *workflowV2ControlWriter, registration typesv2.ControlRegistration, tenantID string, result chan<- error) {
+	defer writer.conn.CloseNow()
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if err := store.AuthorizeControlAttempt(ctx, registration.RunID, registration.AttemptID, registration.ClawID, tenantID); err != nil {
+			result <- err
+			return
+		}
+		envelopes, err := store.ReadyControl(ctx, registration.RunID, registration.AttemptID, 100)
+		if err != nil {
+			result <- err
+			return
+		}
+		for i := range envelopes {
+			envelope := envelopes[i]
+			if err := writer.write(ctx, typesv2.ControlFrame{Type: typesv2.ControlFrameEnvelope, Envelope: &envelope}); err != nil {
+				result <- err
+				return
+			}
+			if err := store.MarkControlSent(ctx, envelope.MessageID); err != nil {
+				result <- err
+				return
+			}
+		}
+		select {
+		case <-ctx.Done():
+			result <- ctx.Err()
+			return
+		case <-ticker.C:
+		}
+	}
+}

--- a/pkg/hub/workflow_v2_control_ws_test.go
+++ b/pkg/hub/workflow_v2_control_ws_test.go
@@ -1,0 +1,229 @@
+package hub
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/hub/workflowv2"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+	typesv2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
+	"nhooyr.io/websocket"
+	"nhooyr.io/websocket/wsjson"
+)
+
+func createWorkflowV2ControlServer(t *testing.T) (*Server, *workflowv2.Store, workflowv2.Attempt, *httptest.Server) {
+	t.Helper()
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token", ClawToken: "claw-token"}, "", "", "")
+	store := workflowv2.NewStore(db)
+	if _, err := store.CreateRun(context.Background(), workflowv2.CreateRunRequest{
+		ID: "run-control-ws", TenantID: "test-tenant-id",
+		WorkspaceYAML: []byte(workflowV2APIWorkspace), WorkflowYAML: []byte(workflowV2APIWorkflow),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	attempt, err := store.StartAttempt(context.Background(), "run-control-ws", "claw-control-ws")
+	if err != nil {
+		t.Fatal(err)
+	}
+	httpServer := httptest.NewServer(s.Handler())
+	t.Cleanup(httpServer.Close)
+	return s, store, attempt, httpServer
+}
+
+func TestWorkflowV2ControlWebSocketAuthenticatesBindsSnapshotsAndDeduplicates(t *testing.T) {
+	_, store, attempt, server := createWorkflowV2ControlServer(t)
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/claw/control/ws"
+
+	unauthorized, response, err := websocket.Dial(context.Background(), wsURL, nil)
+	if unauthorized != nil {
+		unauthorized.CloseNow()
+	}
+	if err == nil || response == nil || response.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("unauthorized dial response/error = %#v/%v", response, err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, _, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{HTTPHeader: http.Header{
+		clawControlTokenHeader: {"claw-token"},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.CloseNow()
+	registration := typesv2.ControlRegistration{Token: "claw-token", ClawID: "claw-control-ws",
+		RunID: "run-control-ws", AttemptID: attempt.ID,
+		Bridge: typesv2.BridgeRegistration{BridgeVersion: "test", Protocols: []string{typesv2.ProtocolControlV2}}}
+	if err := wsjson.Write(ctx, conn, typesv2.ControlFrame{Type: typesv2.ControlFrameRegister, Registration: &registration}); err != nil {
+		t.Fatal(err)
+	}
+	var registered typesv2.ControlFrame
+	if err := wsjson.Read(ctx, conn, &registered); err != nil {
+		t.Fatal(err)
+	}
+	if registered.Type != typesv2.ControlFrameRegistered || registered.Snapshot == nil ||
+		registered.Snapshot.RunID != "run-control-ws" || registered.Snapshot.AttemptID != attempt.ID {
+		t.Fatalf("registered frame = %#v", registered)
+	}
+
+	syncEnvelope := typesv2.ControlEnvelope{ProtocolVersion: typesv2.ControlProtocolVersion,
+		MessageID: "sync-ws-1", Kind: typesv2.MessageWorkflowSync, RunID: "run-control-ws", AttemptID: attempt.ID}
+	if err := store.EnqueueControl(ctx, syncEnvelope); err != nil {
+		t.Fatal(err)
+	}
+	var delivered typesv2.ControlFrame
+	if err := wsjson.Read(ctx, conn, &delivered); err != nil {
+		t.Fatal(err)
+	}
+	if delivered.Type != typesv2.ControlFrameEnvelope || delivered.Envelope == nil || delivered.Envelope.MessageID != syncEnvelope.MessageID {
+		t.Fatalf("delivered frame = %#v", delivered)
+	}
+	receipt := typesv2.ControlReceipt{MessageID: syncEnvelope.MessageID,
+		Disposition: typesv2.DispositionAccepted, StateVersion: registered.Snapshot.StateVersion}
+	if err := wsjson.Write(ctx, conn, typesv2.ControlFrame{Type: typesv2.ControlFrameReceipt, Receipt: &receipt}); err != nil {
+		t.Fatal(err)
+	}
+
+	helpEnvelope := typesv2.ControlEnvelope{ProtocolVersion: typesv2.ControlProtocolVersion,
+		MessageID: "help-ws-1", Kind: typesv2.MessageHelpRequested, RunID: "run-control-ws", AttemptID: attempt.ID,
+		Payload: []byte(`{"help":{"reason":"blocked"}}`)}
+	for i, want := range []typesv2.ControlDisposition{typesv2.DispositionAccepted, typesv2.DispositionDuplicate} {
+		if err := wsjson.Write(ctx, conn, typesv2.ControlFrame{Type: typesv2.ControlFrameEnvelope, Envelope: &helpEnvelope}); err != nil {
+			t.Fatal(err)
+		}
+		var responseFrame typesv2.ControlFrame
+		if err := wsjson.Read(ctx, conn, &responseFrame); err != nil {
+			t.Fatal(err)
+		}
+		if responseFrame.Type != typesv2.ControlFrameReceipt || responseFrame.Receipt == nil || responseFrame.Receipt.Disposition != want {
+			t.Fatalf("receipt %d = %#v, want %s", i, responseFrame, want)
+		}
+	}
+
+	malformed := typesv2.ControlEnvelope{ProtocolVersion: typesv2.ControlProtocolVersion,
+		MessageID: "malformed-ws-1", Kind: typesv2.MessagePlanSubmitted,
+		RunID: "run-control-ws", AttemptID: attempt.ID, Payload: []byte(`{"plan":{"summary":"missing CAS"}}`)}
+	for i, want := range []typesv2.ControlDisposition{typesv2.DispositionRejected, typesv2.DispositionDuplicate} {
+		if err := wsjson.Write(ctx, conn, typesv2.ControlFrame{Type: typesv2.ControlFrameEnvelope, Envelope: &malformed}); err != nil {
+			t.Fatal(err)
+		}
+		var responseFrame typesv2.ControlFrame
+		if err := wsjson.Read(ctx, conn, &responseFrame); err != nil {
+			t.Fatal(err)
+		}
+		if responseFrame.Receipt == nil || responseFrame.Receipt.Disposition != want {
+			t.Fatalf("malformed receipt %d = %#v, want %s", i, responseFrame, want)
+		}
+	}
+	inspection, err := store.InspectRun(ctx, "run-control-ws")
+	if err != nil {
+		t.Fatal(err)
+	}
+	foundRejected := false
+	for _, event := range inspection.RecentEvents {
+		if event.ID == malformed.MessageID && event.Disposition == typesv2.DispositionRejected {
+			foundRejected = true
+		}
+	}
+	if !foundRejected {
+		t.Fatalf("durable rejected event missing: %#v", inspection.RecentEvents)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		ready, err := store.ReadyControl(ctx, "run-control-ws", attempt.ID, 10)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(ready) == 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("acknowledged outbox remained ready: %#v", ready)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestMainClawWebSocketNegotiatesWorkflowV2ControlWithoutChangingV1Registration(t *testing.T) {
+	_, _, attempt, server := createWorkflowV2ControlServer(t)
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/claw/ws"
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	oldConn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := wsjson.Write(ctx, oldConn, types.WSMessage{Type: "register", Payload: map[string]interface{}{
+		"claw_id": "claw-control-ws", "token": "claw-token", "gateway_ready": true,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	var oldAck types.WSMessage
+	if err := wsjson.Read(ctx, oldConn, &oldAck); err == nil {
+		t.Fatal("old bridge was accepted for an active workflow v2 attempt")
+	}
+	oldConn.CloseNow()
+
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.CloseNow()
+	if err := wsjson.Write(ctx, conn, types.WSMessage{Type: "register", Payload: map[string]interface{}{
+		"claw_id": "claw-control-ws", "token": "claw-token", "gateway_ready": true,
+		"bridge_version": "test", "protocols": []string{typesv2.ProtocolConversationV1, typesv2.ProtocolControlV2},
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	var ack struct {
+		Type    string `json:"type"`
+		Payload struct {
+			WorkflowControl *workflowV2ControlBinding `json:"workflow_control"`
+		} `json:"payload"`
+	}
+	if err := wsjson.Read(ctx, conn, &ack); err != nil {
+		t.Fatal(err)
+	}
+	if ack.Type != "registered" || ack.Payload.WorkflowControl == nil ||
+		ack.Payload.WorkflowControl.RunID != "run-control-ws" || ack.Payload.WorkflowControl.AttemptID != attempt.ID {
+		t.Fatalf("registration ack = %#v", ack)
+	}
+}
+
+func TestNewBridgeStillUsesConversationPathForV1(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token", ClawToken: "claw-token"}, "", "", "")
+	server := httptest.NewServer(s.Handler())
+	defer server.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, _, err := websocket.Dial(ctx, "ws"+strings.TrimPrefix(server.URL, "http")+"/claw/ws", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.CloseNow()
+	if err := wsjson.Write(ctx, conn, types.WSMessage{Type: "register", Payload: map[string]interface{}{
+		"claw_id": "claw-v1-new-bridge", "token": "claw-token", "gateway_ready": true,
+		"bridge_version": "test", "protocols": []string{typesv2.ProtocolConversationV1, typesv2.ProtocolControlV2},
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	var ack struct {
+		Type    string `json:"type"`
+		Payload struct {
+			ClawID          string                    `json:"claw_id"`
+			WorkflowControl *workflowV2ControlBinding `json:"workflow_control"`
+		} `json:"payload"`
+	}
+	if err := wsjson.Read(ctx, conn, &ack); err != nil {
+		t.Fatal(err)
+	}
+	if ack.Type != "registered" || ack.Payload.ClawID != "claw-v1-new-bridge" || ack.Payload.WorkflowControl != nil {
+		t.Fatalf("v1 registration ack = %#v", ack)
+	}
+}

--- a/pkg/hub/workflowv2/control.go
+++ b/pkg/hub/workflowv2/control.go
@@ -22,6 +22,49 @@ type Attempt struct {
 	StartedAt time.Time `json:"started_at"`
 }
 
+type ControlBinding struct {
+	RunID     string `json:"run_id"`
+	AttemptID string `json:"attempt_id"`
+}
+
+// ActiveControlBinding returns the single active workflow v2 attempt assigned
+// to a claw. Multiple bindings are rejected rather than choosing one and
+// risking cross-run control delivery.
+func (s *Store) ActiveControlBinding(ctx context.Context, tenantID, clawID string) (ControlBinding, bool, error) {
+	if s == nil || s.db == nil {
+		return ControlBinding{}, false, fmt.Errorf("workflow v2 store is not configured")
+	}
+	if strings.TrimSpace(tenantID) == "" || strings.TrimSpace(clawID) == "" {
+		return ControlBinding{}, false, fmt.Errorf("tenant id and claw id are required")
+	}
+	rows, err := s.db.QueryContext(ctx, `SELECT r.id,a.id FROM workflow_v2_runs r
+		JOIN workflow_v2_attempts a ON a.id=r.current_attempt_id
+		WHERE r.tenant_id=? AND a.claw_id=? AND a.status='active'
+		AND r.status IN ('active','suspended') ORDER BY r.updated_at DESC,r.id LIMIT 2`, tenantID, clawID)
+	if err != nil {
+		return ControlBinding{}, false, err
+	}
+	defer rows.Close()
+	var bindings []ControlBinding
+	for rows.Next() {
+		var binding ControlBinding
+		if err := rows.Scan(&binding.RunID, &binding.AttemptID); err != nil {
+			return ControlBinding{}, false, err
+		}
+		bindings = append(bindings, binding)
+	}
+	if err := rows.Err(); err != nil {
+		return ControlBinding{}, false, err
+	}
+	if len(bindings) == 0 {
+		return ControlBinding{}, false, nil
+	}
+	if len(bindings) > 1 {
+		return ControlBinding{}, false, fmt.Errorf("claw %s has multiple active workflow v2 attempts", clawID)
+	}
+	return bindings[0], true, nil
+}
+
 func (s *Store) StartAttempt(ctx context.Context, runID, clawID string) (Attempt, error) {
 	if s == nil || s.db == nil {
 		return Attempt{}, fmt.Errorf("workflow v2 store is not configured")
@@ -289,6 +332,13 @@ func (s *Store) AcknowledgeControl(ctx context.Context, runID, attemptID string,
 	if strings.TrimSpace(receipt.MessageID) == "" {
 		return fmt.Errorf("message id is required")
 	}
+	switch receipt.Disposition {
+	case typesv2.DispositionAccepted, typesv2.DispositionDuplicate:
+	case typesv2.DispositionRejected, typesv2.DispositionStaleState, typesv2.DispositionUnauthorized:
+		return s.rejectControl(ctx, runID, attemptID, receipt)
+	default:
+		return fmt.Errorf("unsupported control receipt disposition %q", receipt.Disposition)
+	}
 	now := s.now().UTC().UnixMilli()
 	result, err := s.db.ExecContext(ctx, `UPDATE workflow_v2_control_outbox SET status='acknowledged',acknowledged_at=?,updated_at=?
 		WHERE message_id=? AND run_id=? AND attempt_id=? AND status IN ('pending','sent')`,
@@ -304,6 +354,48 @@ func (s *Store) AcknowledgeControl(ctx context.Context, runID, attemptID string,
 		return fmt.Errorf("control message is not pending for this attempt")
 	}
 	return nil
+}
+
+func (s *Store) rejectControl(ctx context.Context, runID, attemptID string, receipt typesv2.ControlReceipt) error {
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	now := s.now().UTC().UnixMilli()
+	result, err := tx.ExecContext(ctx, `UPDATE workflow_v2_control_outbox SET status='cancelled',acknowledged_at=?,updated_at=?
+		WHERE message_id=? AND run_id=? AND attempt_id=? AND status IN ('pending','sent')`,
+		now, now, receipt.MessageID, runID, attemptID)
+	if err != nil {
+		return err
+	}
+	changed, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if changed != 1 {
+		return fmt.Errorf("control message is not pending for this attempt")
+	}
+	reason := fmt.Sprintf("control message %s was %s by the claw", receipt.MessageID, receipt.Disposition)
+	if detail := strings.TrimSpace(receipt.Reason); detail != "" {
+		if len(detail) > 500 {
+			detail = detail[:500]
+		}
+		reason += ": " + detail
+	}
+	result, err = tx.ExecContext(ctx, `UPDATE workflow_v2_runs SET status='suspended',waiting_reason=?,updated_at=?
+		WHERE id=? AND current_attempt_id=? AND status IN ('active','suspended')`, reason, now, runID, attemptID)
+	if err != nil {
+		return err
+	}
+	changed, err = result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if changed != 1 {
+		return fmt.Errorf("workflow attempt is no longer active")
+	}
+	return tx.Commit()
 }
 
 func (s *Store) ApplyAgentControl(ctx context.Context, envelope typesv2.ControlEnvelope) (typesv2.ControlReceipt, error) {
@@ -330,6 +422,70 @@ func (s *Store) ApplyAgentControl(ctx context.Context, envelope typesv2.ControlE
 	}
 	return typesv2.ControlReceipt{MessageID: envelope.MessageID, Disposition: result.Disposition,
 		StateVersion: result.Run.StateVersion, Reason: result.Reason}, nil
+}
+
+// RejectAgentControl durably records a validation/application failure for an
+// authenticated envelope that was already bound to the active run attempt by
+// the transport. This keeps malformed messages in the same audit and
+// deduplication model as accepted messages.
+func (s *Store) RejectAgentControl(ctx context.Context, envelope typesv2.ControlEnvelope, reason string) (typesv2.ControlReceipt, error) {
+	if s == nil || s.db == nil {
+		return typesv2.ControlReceipt{}, fmt.Errorf("workflow v2 store is not configured")
+	}
+	if strings.TrimSpace(envelope.MessageID) == "" || strings.TrimSpace(envelope.RunID) == "" ||
+		strings.TrimSpace(envelope.AttemptID) == "" {
+		return typesv2.ControlReceipt{}, fmt.Errorf("message id, run id, and attempt id are required")
+	}
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		reason = "control message was rejected"
+	}
+	if len(reason) > 1000 {
+		reason = reason[:1000]
+	}
+	now := s.now().UTC()
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return typesv2.ControlReceipt{}, err
+	}
+	defer tx.Rollback()
+	run, _, err := getRunForUpdate(ctx, tx, envelope.RunID)
+	if err != nil {
+		return typesv2.ControlReceipt{}, err
+	}
+	input := EventInput{ID: envelope.MessageID, MessageID: envelope.MessageID, Kind: string(envelope.Kind),
+		AttemptID: envelope.AttemptID, TaskID: envelope.TaskID, ExpectedStateVersion: envelope.ExpectedStateVersion,
+		Producer: ProducerAgent, Provenance: typesv2.EvidenceProvenance{Producer: string(ProducerAgent), ObservedAt: now}}
+	if err := authorizeBoundAttempt(ctx, tx, run, input); err != nil {
+		return typesv2.ControlReceipt{}, err
+	}
+	if existing, found, err := findDuplicateEvent(ctx, tx, run.ID, input.ID, input.MessageID); err != nil {
+		return typesv2.ControlReceipt{}, err
+	} else if found {
+		duplicateReason := "event already received"
+		if err := insertEventReceipt(ctx, tx, run.ID, existing, input.MessageID, typesv2.DispositionDuplicate,
+			run.StateVersion, duplicateReason, now); err != nil {
+			return typesv2.ControlReceipt{}, err
+		}
+		if err := tx.Commit(); err != nil {
+			return typesv2.ControlReceipt{}, err
+		}
+		return typesv2.ControlReceipt{MessageID: envelope.MessageID, Disposition: typesv2.DispositionDuplicate,
+			StateVersion: run.StateVersion, Reason: duplicateReason}, nil
+	}
+	if err := insertEvent(ctx, tx, input.ID, run.ID, input.MessageID, input.Kind, input.ExpectedStateVersion,
+		run.StateVersion, typesv2.DispositionRejected, reason, ProducerAgent, input.Provenance, nil, nil, now); err != nil {
+		return typesv2.ControlReceipt{}, err
+	}
+	if err := insertEventReceipt(ctx, tx, run.ID, input.ID, input.MessageID, typesv2.DispositionRejected,
+		run.StateVersion, reason, now); err != nil {
+		return typesv2.ControlReceipt{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return typesv2.ControlReceipt{}, err
+	}
+	return typesv2.ControlReceipt{MessageID: envelope.MessageID, Disposition: typesv2.DispositionRejected,
+		StateVersion: run.StateVersion, Reason: reason}, nil
 }
 
 func authorizeBoundAttempt(ctx context.Context, tx *sql.Tx, run Run, input EventInput) error {

--- a/pkg/hub/workflowv2/control_test.go
+++ b/pkg/hub/workflowv2/control_test.go
@@ -3,6 +3,7 @@ package workflowv2_test
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -68,6 +69,63 @@ func TestAttemptSnapshotAndControlOutbox(t *testing.T) {
 	}
 	if snapshot.RunID != "run-control" || snapshot.AttemptID != attempt.ID || snapshot.StateVersion != 1 || snapshot.State != "building" {
 		t.Fatalf("snapshot = %#v", snapshot)
+	}
+}
+
+func TestRejectedHubControlSuspendsRunInsteadOfDroppingCommand(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	createRuntimeRun(t, store, "run-control-rejected")
+	attempt, err := store.StartAttempt(context.Background(), "run-control-rejected", "claw-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	envelope := typesv2.ControlEnvelope{ProtocolVersion: typesv2.ControlProtocolVersion,
+		MessageID: "sync-rejected", Kind: typesv2.MessageWorkflowSync,
+		RunID: "run-control-rejected", AttemptID: attempt.ID}
+	if err := store.EnqueueControl(context.Background(), envelope); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AcknowledgeControl(context.Background(), envelope.RunID, attempt.ID, typesv2.ControlReceipt{
+		MessageID: envelope.MessageID, Disposition: typesv2.DispositionRejected, Reason: "unsupported snapshot",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	run, err := store.GetRun(context.Background(), envelope.RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.Status != workflowv2.RunSuspended || !strings.Contains(run.WaitingReason, "unsupported snapshot") {
+		t.Fatalf("run = %#v", run)
+	}
+	ready, err := store.ReadyControl(context.Background(), envelope.RunID, attempt.ID, 10)
+	if err != nil || len(ready) != 0 {
+		t.Fatalf("ready = %#v, err=%v", ready, err)
+	}
+}
+
+func TestActiveControlBindingRejectsAmbiguousClawAssignment(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	createRuntimeRun(t, store, "run-binding-1")
+	first, err := store.StartAttempt(context.Background(), "run-binding-1", "claw-shared")
+	if err != nil {
+		t.Fatal(err)
+	}
+	binding, found, err := store.ActiveControlBinding(context.Background(), "tenant-1", "claw-shared")
+	if err != nil || !found || binding.RunID != "run-binding-1" || binding.AttemptID != first.ID {
+		t.Fatalf("binding = %#v, found=%v, err=%v", binding, found, err)
+	}
+
+	createRuntimeRun(t, store, "run-binding-2")
+	if _, err := store.StartAttempt(context.Background(), "run-binding-2", "claw-shared"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.ActiveControlBinding(context.Background(), "tenant-1", "claw-shared"); err == nil {
+		t.Fatal("ambiguous active control bindings were accepted")
+	}
+	if _, found, err := store.ActiveControlBinding(context.Background(), "other-tenant", "claw-shared"); err != nil || found {
+		t.Fatalf("cross-tenant binding found=%v err=%v", found, err)
 	}
 }
 

--- a/pkg/hub/workflowv2/delivery.go
+++ b/pkg/hub/workflowv2/delivery.go
@@ -3,6 +3,7 @@ package workflowv2
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"sort"
@@ -29,31 +30,126 @@ func (f PullRequestVerifierFunc) VerifyPullRequest(ctx context.Context, run Run,
 // authority comes solely from the pinned workspace repository map.
 func (s *Store) SubmitDelivery(ctx context.Context, runID, attemptID string, manifest typesv2.DeliveryManifest,
 	verifier PullRequestVerifier) ([]typesv2.VerifiedPullRequest, error) {
+	verified, eventResult, err := s.submitDelivery(ctx, runID, attemptID, uuid.NewString(), "", nil, manifest, verifier)
+	if err != nil {
+		return nil, err
+	}
+	if eventResult.Disposition != typesv2.DispositionAccepted {
+		return nil, fmt.Errorf("delivery verification event was %s: %s", eventResult.Disposition, eventResult.Reason)
+	}
+	return verified, nil
+}
+
+// ApplyDeliveryControl verifies an untrusted delivery manifest through the
+// configured source-control connection and uses the incoming message identity
+// for durable deduplication and state-version guarding.
+func (s *Store) ApplyDeliveryControl(ctx context.Context, envelope typesv2.ControlEnvelope,
+	verifier PullRequestVerifier) (typesv2.ControlReceipt, error) {
+	if err := typesv2.ValidateControlEnvelope(envelope, typesv2.DirectionClawToHub); err != nil {
+		return typesv2.ControlReceipt{}, err
+	}
+	if envelope.Kind != typesv2.MessageDeliverySubmitted && envelope.Kind != typesv2.MessagePullRequestClaimed {
+		return typesv2.ControlReceipt{}, fmt.Errorf("message kind %q is not a delivery submission", envelope.Kind)
+	}
+	var manifest typesv2.DeliveryManifest
+	if err := json.Unmarshal(envelope.Payload, &manifest); err != nil {
+		return typesv2.ControlReceipt{}, fmt.Errorf("decode delivery manifest: %w", err)
+	}
+	if receipt, handled, err := s.preflightDeliveryControl(ctx, envelope); err != nil {
+		return typesv2.ControlReceipt{}, err
+	} else if handled {
+		return receipt, nil
+	}
+	_, eventResult, err := s.submitDelivery(ctx, envelope.RunID, envelope.AttemptID, envelope.MessageID,
+		envelope.MessageID, envelope.ExpectedStateVersion, manifest, verifier)
+	if err != nil {
+		return typesv2.ControlReceipt{}, err
+	}
+	return typesv2.ControlReceipt{MessageID: envelope.MessageID, Disposition: eventResult.Disposition,
+		StateVersion: eventResult.Run.StateVersion, Reason: eventResult.Reason}, nil
+}
+
+func (s *Store) preflightDeliveryControl(ctx context.Context,
+	envelope typesv2.ControlEnvelope) (typesv2.ControlReceipt, bool, error) {
+	now := s.now().UTC()
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return typesv2.ControlReceipt{}, false, err
+	}
+	defer tx.Rollback()
+	run, _, err := getRunForUpdate(ctx, tx, envelope.RunID)
+	if err != nil {
+		return typesv2.ControlReceipt{}, false, err
+	}
+	input := EventInput{ID: envelope.MessageID, MessageID: envelope.MessageID, Kind: "delivery.verified",
+		AttemptID: envelope.AttemptID, ExpectedStateVersion: envelope.ExpectedStateVersion,
+		Producer: ProducerSourceControl, Provenance: typesv2.EvidenceProvenance{
+			Producer: string(ProducerSourceControl), ObservedAt: now,
+		}}
+	if err := authorizeBoundAttempt(ctx, tx, run, input); err != nil {
+		return typesv2.ControlReceipt{}, false, err
+	}
+	if existing, found, err := findDuplicateEvent(ctx, tx, run.ID, input.ID, input.MessageID); err != nil {
+		return typesv2.ControlReceipt{}, false, err
+	} else if found {
+		reason := "event already received"
+		if err := insertEventReceipt(ctx, tx, run.ID, existing, input.MessageID, typesv2.DispositionDuplicate,
+			run.StateVersion, reason, now); err != nil {
+			return typesv2.ControlReceipt{}, false, err
+		}
+		if err := tx.Commit(); err != nil {
+			return typesv2.ControlReceipt{}, false, err
+		}
+		return typesv2.ControlReceipt{MessageID: envelope.MessageID, Disposition: typesv2.DispositionDuplicate,
+			StateVersion: run.StateVersion, Reason: reason}, true, nil
+	}
+	if envelope.ExpectedStateVersion == nil || *envelope.ExpectedStateVersion == run.StateVersion {
+		return typesv2.ControlReceipt{}, false, nil
+	}
+	reason := fmt.Sprintf("expected state version %d, current version is %d", *envelope.ExpectedStateVersion, run.StateVersion)
+	if err := insertEvent(ctx, tx, input.ID, run.ID, input.MessageID, input.Kind, input.ExpectedStateVersion,
+		run.StateVersion, typesv2.DispositionStaleState, reason, ProducerSourceControl, input.Provenance, nil, nil, now); err != nil {
+		return typesv2.ControlReceipt{}, false, err
+	}
+	if err := insertEventReceipt(ctx, tx, run.ID, input.ID, input.MessageID, typesv2.DispositionStaleState,
+		run.StateVersion, reason, now); err != nil {
+		return typesv2.ControlReceipt{}, false, err
+	}
+	if err := tx.Commit(); err != nil {
+		return typesv2.ControlReceipt{}, false, err
+	}
+	return typesv2.ControlReceipt{MessageID: envelope.MessageID, Disposition: typesv2.DispositionStaleState,
+		StateVersion: run.StateVersion, Reason: reason}, true, nil
+}
+
+func (s *Store) submitDelivery(ctx context.Context, runID, attemptID, eventID, messageID string,
+	expectedStateVersion *uint64, manifest typesv2.DeliveryManifest,
+	verifier PullRequestVerifier) ([]typesv2.VerifiedPullRequest, EventResult, error) {
 	if s == nil || s.db == nil {
-		return nil, fmt.Errorf("workflow v2 store is not configured")
+		return nil, EventResult{}, fmt.Errorf("workflow v2 store is not configured")
 	}
 	if verifier == nil && len(manifest.PullRequests) > 0 {
-		return nil, fmt.Errorf("pull request verifier is required")
+		return nil, EventResult{}, fmt.Errorf("pull request verifier is required")
 	}
 	if len(manifest.PullRequests) > 100 {
-		return nil, fmt.Errorf("delivery manifest exceeds 100 pull requests")
+		return nil, EventResult{}, fmt.Errorf("delivery manifest exceeds 100 pull requests")
 	}
 	run, err := s.GetRun(ctx, runID)
 	if err != nil {
-		return nil, err
+		return nil, EventResult{}, err
 	}
 	var activeAttempt int
 	if err := s.db.QueryRowContext(ctx, `SELECT 1 FROM workflow_v2_attempts WHERE id=? AND run_id=? AND status='active'`,
 		attemptID, runID).Scan(&activeAttempt); err != nil || run.CurrentAttemptID != attemptID {
-		return nil, fmt.Errorf("delivery attempt is not active")
+		return nil, EventResult{}, fmt.Errorf("delivery attempt is not active")
 	}
 	var workspaceYAML string
 	if err := s.db.QueryRowContext(ctx, `SELECT workspace_yaml FROM workflow_v2_runs WHERE id=?`, runID).Scan(&workspaceYAML); err != nil {
-		return nil, err
+		return nil, EventResult{}, err
 	}
 	resolvedWorkspace, err := typesv2.ParseAndValidateWorkspace([]byte(workspaceYAML))
 	if err != nil {
-		return nil, fmt.Errorf("load pinned workspace: %w", err)
+		return nil, EventResult{}, fmt.Errorf("load pinned workspace: %w", err)
 	}
 
 	verified := make([]typesv2.VerifiedPullRequest, 0, len(manifest.PullRequests))
@@ -62,26 +158,26 @@ func (s *Store) SubmitDelivery(ctx context.Context, runID, attemptID string, man
 	for i, claim := range manifest.PullRequests {
 		claim.URL = strings.TrimSpace(claim.URL)
 		if strings.TrimSpace(claim.Supersedes) != "" {
-			return nil, fmt.Errorf("pull_requests[%d].supersedes requires hub-owned source-control reconciliation", i)
+			return nil, EventResult{}, fmt.Errorf("pull_requests[%d].supersedes requires hub-owned source-control reconciliation", i)
 		}
 		parsed, err := url.Parse(claim.URL)
 		if err != nil || (parsed.Scheme != "https" && parsed.Scheme != "http") || parsed.Host == "" {
-			return nil, fmt.Errorf("pull_requests[%d].url is not an absolute HTTP(S) URL", i)
+			return nil, EventResult{}, fmt.Errorf("pull_requests[%d].url is not an absolute HTTP(S) URL", i)
 		}
 		if claimsByURL[claim.URL] {
-			return nil, fmt.Errorf("pull_requests[%d].url is duplicated", i)
+			return nil, EventResult{}, fmt.Errorf("pull_requests[%d].url is duplicated", i)
 		}
 		claimsByURL[claim.URL] = true
 		pr, err := verifier.VerifyPullRequest(ctx, run, resolvedWorkspace.Workspace, claim)
 		if err != nil {
-			return nil, fmt.Errorf("verify pull_requests[%d] %s: %w", i, claim.URL, err)
+			return nil, EventResult{}, fmt.Errorf("verify pull_requests[%d] %s: %w", i, claim.URL, err)
 		}
 		if err := validateVerifiedPullRequest(resolvedWorkspace.Workspace, claim, pr); err != nil {
-			return nil, fmt.Errorf("verify pull_requests[%d] %s: %w", i, claim.URL, err)
+			return nil, EventResult{}, fmt.Errorf("verify pull_requests[%d] %s: %w", i, claim.URL, err)
 		}
 		identity := pr.Repository + "#" + fmt.Sprint(pr.Number)
 		if identities[identity] {
-			return nil, fmt.Errorf("pull_requests[%d] duplicates verified PR %s", i, identity)
+			return nil, EventResult{}, fmt.Errorf("pull_requests[%d] duplicates verified PR %s", i, identity)
 		}
 		identities[identity] = true
 		verified = append(verified, pr)
@@ -89,7 +185,8 @@ func (s *Store) SubmitDelivery(ctx context.Context, runID, attemptID string, man
 
 	now := s.now().UTC()
 	eventResult, err := s.applyEventWithMutation(ctx, runID, EventInput{
-		ID: uuid.NewString(), Kind: "delivery.verified", AttemptID: attemptID, Producer: ProducerSourceControl,
+		ID: eventID, MessageID: messageID, Kind: "delivery.verified", AttemptID: attemptID,
+		ExpectedStateVersion: expectedStateVersion, Producer: ProducerSourceControl,
 		Provenance: typesv2.EvidenceProvenance{Producer: string(ProducerSourceControl), ObservedAt: now},
 	}, func(ctx context.Context, tx *sql.Tx, input *EventInput) error {
 		for i := range verified {
@@ -151,13 +248,12 @@ func (s *Store) SubmitDelivery(ctx context.Context, runID, attemptID string, man
 		return nil
 	})
 	if err != nil {
-		return nil, err
+		return nil, EventResult{}, err
 	}
-	if eventResult.Disposition != typesv2.DispositionAccepted {
-		return nil, fmt.Errorf("delivery verification event was %s: %s", eventResult.Disposition, eventResult.Reason)
-	}
-	if _, err := s.evaluateAndPublishDeliveryPolicy(ctx, runID, attemptID, "", now); err != nil {
-		return nil, err
+	if eventResult.Disposition == typesv2.DispositionAccepted {
+		if _, err := s.evaluateAndPublishDeliveryPolicy(ctx, runID, attemptID, "", now); err != nil {
+			return nil, EventResult{}, err
+		}
 	}
 	sort.Slice(verified, func(i, j int) bool {
 		if verified[i].Repository == verified[j].Repository {
@@ -165,7 +261,7 @@ func (s *Store) SubmitDelivery(ctx context.Context, runID, attemptID string, man
 		}
 		return verified[i].Repository < verified[j].Repository
 	})
-	return verified, nil
+	return verified, eventResult, nil
 }
 
 func validateVerifiedPullRequest(workspace *typesv2.Workspace, claim typesv2.PullRequestClaim,

--- a/pkg/hub/workflowv2/delivery_test.go
+++ b/pkg/hub/workflowv2/delivery_test.go
@@ -88,6 +88,77 @@ func TestSubmitDeliveryVerifiesMultipleWorkspaceRepositories(t *testing.T) {
 	}
 }
 
+func TestApplyDeliveryControlUsesMessageIdentityForDeduplication(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	attempt := createDeliveryRun(t, store, "run-delivery-control")
+	apiURL := "https://github.example/org/api/pull/10"
+	payload := []byte(`{"pull_requests":[{"url":"https://github.example/org/api/pull/10"}]}`)
+	stateVersion := uint64(1)
+	envelope := typesv2.ControlEnvelope{ProtocolVersion: typesv2.ControlProtocolVersion,
+		MessageID: "delivery-control-1", Kind: typesv2.MessageDeliverySubmitted,
+		RunID: "run-delivery-control", AttemptID: attempt.ID, ExpectedStateVersion: &stateVersion, Payload: payload}
+	verificationCalls := 0
+	baseVerifier := deliveryVerifier(map[string]string{apiURL: "api-head-1"})
+	verifier := workflowv2.PullRequestVerifierFunc(func(ctx context.Context, run workflowv2.Run,
+		workspace *typesv2.Workspace, claim typesv2.PullRequestClaim) (typesv2.VerifiedPullRequest, error) {
+		verificationCalls++
+		return baseVerifier.VerifyPullRequest(ctx, run, workspace, claim)
+	})
+	first, err := store.ApplyDeliveryControl(context.Background(), envelope, verifier)
+	if err != nil || first.Disposition != typesv2.DispositionAccepted {
+		t.Fatalf("first receipt = %#v, err=%v", first, err)
+	}
+	duplicate, err := store.ApplyDeliveryControl(context.Background(), envelope, verifier)
+	if err != nil || duplicate.Disposition != typesv2.DispositionDuplicate {
+		t.Fatalf("duplicate receipt = %#v, err=%v", duplicate, err)
+	}
+	var events, deliveries int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_events WHERE id=?`, envelope.MessageID).Scan(&events); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_delivery_prs WHERE run_id=?`, envelope.RunID).Scan(&deliveries); err != nil {
+		t.Fatal(err)
+	}
+	if events != 1 || deliveries != 1 {
+		t.Fatalf("events/deliveries = %d/%d", events, deliveries)
+	}
+	if verificationCalls != 1 {
+		t.Fatalf("duplicate control performed %d source-control verifications", verificationCalls)
+	}
+}
+
+func TestApplyDeliveryControlRejectsStaleStateBeforeMutation(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	attempt := createDeliveryRun(t, store, "run-delivery-control-stale")
+	staleVersion := uint64(0)
+	envelope := typesv2.ControlEnvelope{ProtocolVersion: typesv2.ControlProtocolVersion,
+		MessageID: "delivery-control-stale", Kind: typesv2.MessageDeliverySubmitted,
+		RunID: "run-delivery-control-stale", AttemptID: attempt.ID, ExpectedStateVersion: &staleVersion,
+		Payload: []byte(`{"pull_requests":[{"url":"https://github.example/org/api/pull/10"}]}`)}
+	verificationCalls := 0
+	verifier := workflowv2.PullRequestVerifierFunc(func(context.Context, workflowv2.Run, *typesv2.Workspace,
+		typesv2.PullRequestClaim) (typesv2.VerifiedPullRequest, error) {
+		verificationCalls++
+		return typesv2.VerifiedPullRequest{}, nil
+	})
+	receipt, err := store.ApplyDeliveryControl(context.Background(), envelope, verifier)
+	if err != nil || receipt.Disposition != typesv2.DispositionStaleState {
+		t.Fatalf("receipt = %#v, err=%v", receipt, err)
+	}
+	var deliveries int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_delivery_prs WHERE run_id=?`, envelope.RunID).Scan(&deliveries); err != nil {
+		t.Fatal(err)
+	}
+	if deliveries != 0 {
+		t.Fatalf("stale control mutated %d deliveries", deliveries)
+	}
+	if verificationCalls != 0 {
+		t.Fatalf("stale control performed %d source-control verifications", verificationCalls)
+	}
+}
+
 func TestSubmitDeliveryRejectsAnyRepositoryOutsidePinnedWorkspaceAtomically(t *testing.T) {
 	db := openRuntimeDB(t)
 	store := workflowv2.NewStore(db)

--- a/pkg/hub/workflowv2/runtime.go
+++ b/pkg/hub/workflowv2/runtime.go
@@ -246,6 +246,42 @@ func (s *Store) ApplyEvent(ctx context.Context, runID string, input EventInput) 
 	if err := authorizeBoundTask(ctx, tx, stored, input); err != nil {
 		return EventResult{}, err
 	}
+	// Preserve authorization precedence over compare-and-swap handling. The
+	// mutation callback may add trusted payload/facts and is authorized again
+	// below after it runs.
+	if disposition, reason := authorizeEvent(input); disposition != "" {
+		if err := insertEvent(ctx, tx, input.ID, runID, input.MessageID, input.Kind, input.ExpectedStateVersion,
+			stored.StateVersion, disposition, reason, input.Producer, input.Provenance, input.Payload, input.Facts, now); err != nil {
+			return EventResult{}, err
+		}
+		if err := insertEventReceipt(ctx, tx, runID, input.ID, input.MessageID, disposition, stored.StateVersion, reason, now); err != nil {
+			return EventResult{}, err
+		}
+		if err := tx.Commit(); err != nil {
+			return EventResult{}, err
+		}
+		return EventResult{EventID: input.ID, Disposition: disposition, Reason: reason, Run: stored}, nil
+	}
+	// A mutation callback may write authoritative domain state. Reject stale
+	// compare-and-swap inputs before invoking it so a stale control frame cannot
+	// alter delivery, evidence, or other domain rows while receiving a
+	// stale_state disposition.
+	if input.ExpectedStateVersion != nil && *input.ExpectedStateVersion != stored.StateVersion {
+		reason := fmt.Sprintf("expected state version %d, current version is %d", *input.ExpectedStateVersion, stored.StateVersion)
+		if err := insertEvent(ctx, tx, input.ID, runID, input.MessageID, input.Kind, input.ExpectedStateVersion,
+			stored.StateVersion, typesv2.DispositionStaleState, reason, input.Producer, input.Provenance,
+			input.Payload, input.Facts, now); err != nil {
+			return EventResult{}, err
+		}
+		if err := insertEventReceipt(ctx, tx, runID, input.ID, input.MessageID, typesv2.DispositionStaleState,
+			stored.StateVersion, reason, now); err != nil {
+			return EventResult{}, err
+		}
+		if err := tx.Commit(); err != nil {
+			return EventResult{}, err
+		}
+		return EventResult{EventID: input.ID, Disposition: typesv2.DispositionStaleState, Reason: reason, Run: stored}, nil
+	}
 	if input.mutation != nil {
 		if err := input.mutation(ctx, tx, &input); err != nil {
 			return EventResult{}, err
@@ -261,10 +297,6 @@ func (s *Store) ApplyEvent(ctx context.Context, runID string, input EventInput) 
 	}
 
 	disposition, reason := authorizeEvent(input)
-	if disposition == "" && input.ExpectedStateVersion != nil && *input.ExpectedStateVersion != stored.StateVersion {
-		disposition = typesv2.DispositionStaleState
-		reason = fmt.Sprintf("expected state version %d, current version is %d", *input.ExpectedStateVersion, stored.StateVersion)
-	}
 	if disposition != "" {
 		if err := insertEvent(ctx, tx, input.ID, runID, input.MessageID, input.Kind, input.ExpectedStateVersion,
 			stored.StateVersion, disposition, reason, input.Producer, input.Provenance, input.Payload, input.Facts, now); err != nil {

--- a/pkg/types/hub.go
+++ b/pkg/types/hub.go
@@ -68,13 +68,16 @@ type FileReadResp struct {
 
 // RegisterPayload is sent by a claw on connect.
 type RegisterPayload struct {
-	ClawID         string `json:"claw_id"`
-	Name           string `json:"name"`
-	Template       string `json:"template"`
-	Token          string `json:"token"`                      // hub claw token for auth
-	ModelAuthToken string `json:"model_auth_token,omitempty"` // per-claw proof for managed model credentials
-	GatewayReady   *bool  `json:"gateway_ready,omitempty"`    // true once openclaw gateway session is established; nil means unknown (old bridge, assume ready)
-	Channel        string `json:"channel,omitempty"`          // "status" for status channel, empty for main
+	ClawID         string   `json:"claw_id"`
+	Name           string   `json:"name"`
+	Template       string   `json:"template"`
+	Token          string   `json:"token"`                      // hub claw token for auth
+	ModelAuthToken string   `json:"model_auth_token,omitempty"` // per-claw proof for managed model credentials
+	GatewayReady   *bool    `json:"gateway_ready,omitempty"`    // true once openclaw gateway session is established; nil means unknown (old bridge, assume ready)
+	Channel        string   `json:"channel,omitempty"`          // "status" for status channel, empty for main
+	BridgeVersion  string   `json:"bridge_version,omitempty"`   // protocol negotiation; absent on old bridges
+	Protocols      []string `json:"protocols,omitempty"`        // conversation.v1 and, on new bridges, control.v2
+	Capabilities   []string `json:"capabilities,omitempty"`     // optional narrow bridge capabilities
 }
 
 // CheckpointCreatePayload asks a connected bridge to prepare a checkpoint.

--- a/pkg/types/v2/control.go
+++ b/pkg/types/v2/control.go
@@ -94,6 +94,30 @@ type ControlRegistration struct {
 	Bridge    BridgeRegistration `json:"bridge"`
 }
 
+// ValidateControlRegistration validates the durable identity presented by a
+// bridge before the hub accepts a dedicated workflow control connection.
+func ValidateControlRegistration(registration ControlRegistration) error {
+	if strings.TrimSpace(registration.Token) == "" {
+		return fmt.Errorf("token is required")
+	}
+	if strings.TrimSpace(registration.ClawID) == "" {
+		return fmt.Errorf("claw_id is required")
+	}
+	if strings.TrimSpace(registration.RunID) == "" {
+		return fmt.Errorf("run_id is required")
+	}
+	if strings.TrimSpace(registration.AttemptID) == "" {
+		return fmt.Errorf("attempt_id is required")
+	}
+	if strings.TrimSpace(registration.Bridge.BridgeVersion) == "" {
+		return fmt.Errorf("bridge_version is required")
+	}
+	if !registration.Bridge.SupportsProtocol(ProtocolControlV2) {
+		return fmt.Errorf("control registration requires bridge protocol %s", ProtocolControlV2)
+	}
+	return nil
+}
+
 // ControlFrame is the only wire frame accepted on /claw/control/ws.
 type ControlFrame struct {
 	Type         string               `json:"type"`

--- a/pkg/types/v2/control_test.go
+++ b/pkg/types/v2/control_test.go
@@ -37,6 +37,26 @@ func TestControlEnvelopeRequiresTypedDirectionAndStateVersion(t *testing.T) {
 	}
 }
 
+func TestControlRegistrationRequiresDurableIdentityAndProtocol(t *testing.T) {
+	valid := v2.ControlRegistration{
+		Token: "token", ClawID: "claw-1", RunID: "run-1", AttemptID: "attempt-1",
+		Bridge: v2.BridgeRegistration{BridgeVersion: "test", Protocols: []string{v2.ProtocolConversationV1, v2.ProtocolControlV2}},
+	}
+	if err := v2.ValidateControlRegistration(valid); err != nil {
+		t.Fatalf("valid registration: %v", err)
+	}
+	withoutAttempt := valid
+	withoutAttempt.AttemptID = ""
+	if err := v2.ValidateControlRegistration(withoutAttempt); err == nil || !strings.Contains(err.Error(), "attempt_id") {
+		t.Fatalf("missing attempt error = %v", err)
+	}
+	oldBridge := valid
+	oldBridge.Bridge.Protocols = []string{v2.ProtocolConversationV1}
+	if err := v2.ValidateControlRegistration(oldBridge); err == nil || !strings.Contains(err.Error(), v2.ProtocolControlV2) {
+		t.Fatalf("old bridge error = %v", err)
+	}
+}
+
 func TestControlCatalogContainsNoConversationMessages(t *testing.T) {
 	kinds := []v2.ControlMessageKind{
 		v2.MessageWorkflowSync,


### PR DESCRIPTION
Implements the dedicated workflow v2 transport and bridge-local typed control tool from #544.

- exposes header-authenticated /claw/control/ws, separately from /claw/ws
- binds every connection to tenant, claw, run, and active attempt before sending an authoritative reconnect snapshot
- pumps the durable hub control outbox with retry/acknowledgment and records all authenticated message dispositions
- verifies dynamic delivery manifests through the trusted source-control adapter with message-ID deduplication before external replay
- advertises bridge protocol support on the existing registration without changing V1 conversation behavior
- journals the bridge control inbox/outbox and snapshot in owner-only SQLite storage
- exposes localhost-only claw-bridge control status/plan/delivery/help commands
- drives agent tasks from typed assignments with heartbeat, terminal events, cancellation, and conservative unknown-outcome recovery

Compatibility matrix covered by tests:
- old bridge + V1 remains supported
- new bridge + V1 remains on conversation.v1
- new bridge + V2 negotiates control.v2
- old bridge + active V2 is rejected rather than falling back to transcript control

Verification:
- go test ./...
- go vet ./...
- focused go test -race for workflowv2 and claw-bridge control paths

This remains additive: no existing V1 route, table, workflow parser, transcript marker, or execution path is removed or reinterpreted.