### PR TITLE
Activate deterministic workflow v2 runs

### DIFF
--- a/pkg/hub/external_storage.go
+++ b/pkg/hub/external_storage.go
@@ -313,6 +313,11 @@ func loadExternalWorkspace(name string) (*types.WorkspaceConfig, error) {
 	if files, err := config.ReadTemplateFiles(dir); err == nil {
 		workspace.Files = files
 	}
+	if workspace.SchemaVersion == "2" {
+		if err := loadDeclaredWorkspaceKnowledgeFiles(dir, &workspace); err != nil {
+			return nil, err
+		}
+	}
 
 	workflowDir := filepath.Join(dir, "workflows")
 	entries, err := os.ReadDir(workflowDir)
@@ -343,6 +348,66 @@ func loadExternalWorkspace(name string) (*types.WorkspaceConfig, error) {
 		}
 	}
 	return &workspace, nil
+}
+
+// loadDeclaredWorkspaceKnowledgeFiles supplements the legacy OpenClaw file
+// allow-list with only the workspace_files paths explicitly authorized by a
+// validated V2 workspace document. V1 loading remains byte-for-byte unchanged.
+func loadDeclaredWorkspaceKnowledgeFiles(dir string, workspace *types.WorkspaceConfig) error {
+	if workspace == nil || workspace.Files == nil {
+		return nil
+	}
+	resolved, err := v2.ParseAndValidateWorkspace([]byte(workspace.Files["elasticclaw-config.yaml"]))
+	if err != nil || resolved.Workspace.Knowledge == nil {
+		return nil
+	}
+	for _, source := range resolved.Workspace.Knowledge.Sources {
+		if source.Type != v2.KnowledgeTypeWorkspaceFiles {
+			continue
+		}
+		for _, name := range source.Paths {
+			if _, loaded := workspace.Files[name]; loaded {
+				continue
+			}
+			content, err := readWorkspaceKnowledgeFile(dir, name)
+			if os.IsNotExist(err) {
+				// Missing required/optional files are represented by the context
+				// resolver, where source policy and provenance are available.
+				continue
+			}
+			if err != nil {
+				return fmt.Errorf("read workspace knowledge file %q: %w", name, err)
+			}
+			workspace.Files[name] = string(content)
+		}
+	}
+	return nil
+}
+
+func readWorkspaceKnowledgeFile(dir, name string) ([]byte, error) {
+	safeName, err := cleanWorkspaceFilePath(name)
+	if err != nil {
+		return nil, err
+	}
+	current := dir
+	parts := strings.Split(filepath.FromSlash(safeName), string(filepath.Separator))
+	for i, part := range parts {
+		current = filepath.Join(current, part)
+		info, err := os.Lstat(current)
+		if err != nil {
+			return nil, err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return nil, fmt.Errorf("symbolic links are not allowed")
+		}
+		if i < len(parts)-1 && !info.IsDir() {
+			return nil, fmt.Errorf("path component is not a directory")
+		}
+		if i == len(parts)-1 && !info.Mode().IsRegular() {
+			return nil, fmt.Errorf("path is not a regular file")
+		}
+	}
+	return os.ReadFile(current)
 }
 
 // errWorkspaceNotFound is returned when a workspace name does not exist on the hub.

--- a/pkg/hub/schema_v2_validate_test.go
+++ b/pkg/hub/schema_v2_validate_test.go
@@ -369,7 +369,7 @@ states:
 		t.Fatalf("v2 enabled = %v, want explicit false", workflow.Enabled)
 	}
 	view := workflowToView("engineering", workflow)
-	if view.RuntimeAvailable || view.SchemaVersion != "2" {
-		t.Fatalf("v2 view = %#v, want schema 2 and unavailable runtime", view)
+	if !view.RuntimeAvailable || view.SchemaVersion != "2" {
+		t.Fatalf("v2 view = %#v, want schema 2 and available runtime", view)
 	}
 }

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -458,6 +458,7 @@ func (s *Server) Run(opts ...RunOptions) error {
 }
 
 func (s *Server) run(ctx context.Context, opts ...RunOptions) error {
+	go s.runWorkflowV2Worker(ctx)
 	noWebUI := len(opts) > 0 && opts[0].NoWebUI
 	mux := http.NewServeMux()
 	s.mux = mux

--- a/pkg/hub/workflow_creator.go
+++ b/pkg/hub/workflow_creator.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/elasticclaw/elasticclaw/pkg/config"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
+	typesv2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
 	"github.com/google/uuid"
 )
 
@@ -28,6 +29,10 @@ type workflowCreateOptions struct {
 	issueCreatedAt       time.Time
 	reason               string
 	triggerActor         *triggerActor
+	// beforeProvision runs after the claw and analytics row exist but before
+	// provider work begins. Workflow v2 uses it to atomically create the run and
+	// initial attempt, closing the bridge-registration race.
+	beforeProvision func(context.Context, string, string) error
 }
 
 const hubInternalTemplateFilePrefix = "__hub__/"
@@ -58,7 +63,14 @@ func (s *Server) createClawFromWorkflowWithOptions(workspace *types.WorkspaceCon
 	}
 
 	var tmplCfg *types.TemplateConfig
-	if cfgContent, ok := templateFiles["elasticclaw-config.yaml"]; ok {
+	var workspaceV2 *typesv2.Workspace
+	if isWorkflowV2(workflow) {
+		resolved, err := typesv2.ParseAndValidateWorkspace([]byte(templateFiles["elasticclaw-config.yaml"]))
+		if err != nil {
+			return "", false, fmt.Errorf("parse workspace v2 execution config: %w", err)
+		}
+		workspaceV2 = resolved.Workspace
+	} else if cfgContent, ok := templateFiles["elasticclaw-config.yaml"]; ok {
 		var err error
 		tmplCfg, err = config.ParseTemplateConfig([]byte(cfgContent))
 		if err != nil {
@@ -94,6 +106,9 @@ func (s *Server) createClawFromWorkflowWithOptions(workspace *types.WorkspaceCon
 	}
 
 	provider := workflow.Provider
+	if workspaceV2 != nil && workspaceV2.Execution != nil {
+		provider = strings.TrimSpace(workspaceV2.Execution.Provider)
+	}
 	if provider == "" && tmplCfg != nil {
 		provider = tmplCfg.Provider
 	}
@@ -222,6 +237,14 @@ func (s *Server) createClawFromWorkflowWithOptions(workspace *types.WorkspaceCon
 			linearWorkspace = tmplCfg.Linear.Workspace
 		}
 	}
+	if workspaceV2 != nil && workspaceV2.Execution != nil {
+		if workspaceV2.Execution.Nix {
+			nixEnabled = 1
+		}
+		if workspaceV2.Execution.Docker {
+			dockerEnabled = 1
+		}
+	}
 	s.mu.RLock()
 	defaultModel, llmKey = resolveModelAndLLMKey(s.hubCfg, llmKey, defaultModel)
 	s.mu.RUnlock()
@@ -312,6 +335,18 @@ func (s *Server) createClawFromWorkflowWithOptions(workspace *types.WorkspaceCon
 		}
 		go s.promotePendingClaws()
 		return "", false, fmt.Errorf("task run analytics: %w", err)
+	}
+	if opts.beforeProvision != nil {
+		callbackCtx := opts.ctx
+		if callbackCtx == nil {
+			callbackCtx = context.Background()
+		}
+		if err := opts.beforeProvision(callbackCtx, clawID, tenantID); err != nil {
+			_, _ = s.finishClawTerminalTx(clawID, "deleted", "", "failed",
+				"workflow v2 activation failed: "+err.Error(), terminalTxOpts{})
+			go s.promotePendingClaws()
+			return "", false, fmt.Errorf("activate workflow v2 run: %w", err)
+		}
 	}
 
 	log.Printf("[workflow] created claw %s (%s) for workflow %s/%s (status=%s, reason=%s)", clawName, clawID[:8], workspace.Name, workflow.Name, initialStatus, opts.reason)

--- a/pkg/hub/workflow_v2_activation.go
+++ b/pkg/hub/workflow_v2_activation.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/elasticclaw/elasticclaw/pkg/hub/workflowv2"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
@@ -60,12 +61,23 @@ func (s *Server) triggerWorkflowV2Config(w http.ResponseWriter, r *http.Request,
 			store := workflowv2.NewStore(s.db)
 			run, err := store.CreateRun(ctx, workflowv2.CreateRunRequest{
 				ID: runID, TenantID: tenantID, InitialClawID: clawID,
-				WorkspaceYAML: workspaceYAML, WorkflowYAML: workflowYAML,
+				WorkspaceYAML: workspaceYAML, WorkflowYAML: workflowYAML, ActivationPending: true,
 			})
-			if err != nil || run.DisplayPhase != typesv2.PhaseContext {
+			if err != nil {
 				return err
 			}
 			_, err = store.AssembleOrganizationContext(ctx, run.ID, workspaceFileKnowledgeResolver(workspace.Files))
+			if err == nil {
+				err = store.CompleteActivation(ctx, run.ID)
+			}
+			if err == nil {
+				return nil
+			}
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if cleanupErr := store.CancelActivation(cleanupCtx, run.ID, err.Error()); cleanupErr != nil {
+				return errors.Join(err, fmt.Errorf("cancel failed workflow v2 activation: %w", cleanupErr))
+			}
 			return err
 		},
 	})

--- a/pkg/hub/workflow_v2_activation.go
+++ b/pkg/hub/workflow_v2_activation.go
@@ -1,0 +1,106 @@
+package hub
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/elasticclaw/elasticclaw/pkg/hub/workflowv2"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+	typesv2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
+	"github.com/google/uuid"
+)
+
+// triggerWorkflowV2Config is an authenticated operator run-creation adapter.
+// It deliberately does not translate the request or any conversation text
+// into workflow transitions. Trigger inputs are only staged as claw context;
+// the durable state machine still advances exclusively through typed events.
+func (s *Server) triggerWorkflowV2Config(w http.ResponseWriter, r *http.Request,
+	workspace *types.WorkspaceConfig, workflow *types.WorkflowConfig) {
+	if workflow.Enabled == nil || !*workflow.Enabled {
+		jsonError(w, http.StatusForbidden, "workflow is disabled")
+		return
+	}
+	var req FactoryTriggerRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+		jsonError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		return
+	}
+	inputs := make(map[string]string, len(req.Inputs))
+	for name, value := range req.Inputs {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			jsonError(w, http.StatusBadRequest, "input names cannot be empty")
+			return
+		}
+		raw, err := json.Marshal(value)
+		if err != nil {
+			jsonError(w, http.StatusBadRequest, "invalid input "+name+": "+err.Error())
+			return
+		}
+		if text, ok := value.(string); ok {
+			inputs[name] = text
+		} else {
+			inputs[name] = string(raw)
+		}
+	}
+
+	workspaceYAML := []byte(workspace.Files["elasticclaw-config.yaml"])
+	workflowYAML := []byte(workflow.RawConfig)
+	runID := uuid.NewString()
+	clawID, _, err := s.createClawFromWorkflowWithOptions(workspace, workflow, workflowCreateOptions{
+		ctx: r.Context(), inputs: inputs, reason: "manual workflow v2 trigger",
+		beforeProvision: func(ctx context.Context, clawID, tenantID string) error {
+			store := workflowv2.NewStore(s.db)
+			run, err := store.CreateRun(ctx, workflowv2.CreateRunRequest{
+				ID: runID, TenantID: tenantID, InitialClawID: clawID,
+				WorkspaceYAML: workspaceYAML, WorkflowYAML: workflowYAML,
+			})
+			if err != nil || run.DisplayPhase != typesv2.PhaseContext {
+				return err
+			}
+			_, err = store.AssembleOrganizationContext(ctx, run.ID, workspaceFileKnowledgeResolver(workspace.Files))
+			return err
+		},
+	})
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "failed to create workflow v2 run: "+err.Error())
+		return
+	}
+	jsonOK(w, map[string]string{"run_id": runID, "claw_id": clawID, "status": "created"})
+}
+
+func workspaceFileKnowledgeResolver(files map[string]string) workflowv2.KnowledgeResolver {
+	return workflowv2.KnowledgeResolverFunc(func(_ context.Context, run workflowv2.Run, name string,
+		source typesv2.KnowledgeSource) (typesv2.ContextBundleSource, error) {
+		if source.Type != typesv2.KnowledgeTypeWorkspaceFiles {
+			return typesv2.ContextBundleSource{}, fmt.Errorf(
+				"organization knowledge source %q uses unsupported runtime type %q", name, source.Type)
+		}
+		paths := append([]string(nil), source.Paths...)
+		sort.Strings(paths)
+		documents := make([]string, 0, len(paths))
+		hash := sha256.New()
+		for _, path := range paths {
+			path = strings.TrimSpace(path)
+			content, found := files[path]
+			if !found {
+				return typesv2.ContextBundleSource{}, fmt.Errorf("workspace knowledge file %q is missing", path)
+			}
+			document := path + "\n" + content
+			documents = append(documents, document)
+			_, _ = hash.Write([]byte(document))
+			_, _ = hash.Write([]byte{0})
+		}
+		return typesv2.ContextBundleSource{
+			Status: "ready", SourceRevision: "workspace:" + run.WorkspaceRevision,
+			ContentDigest: fmt.Sprintf("sha256:%x", hash.Sum(nil)), Documents: documents,
+		}, nil
+	})
+}

--- a/pkg/hub/workflow_v2_activation_test.go
+++ b/pkg/hub/workflow_v2_activation_test.go
@@ -142,3 +142,86 @@ func TestWorkspaceFileKnowledgeResolverRejectsMissingRequiredDocument(t *testing
 		t.Fatalf("error = %v", err)
 	}
 }
+
+func TestWorkflowV2ActivationFailureCancelsBoundRun(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token", ClawToken: "claw-token",
+		Providers: map[string]types.ProviderConfig{"noop": {Type: "noop"}}}, "", "", "")
+	workspaceYAML := `
+schema_version: 2
+name: failing-context
+execution:
+  provider: noop
+repositories:
+  primary:
+    provider: github
+    repository: org/repo
+knowledge:
+  sources:
+    principles:
+      type: workspace_files
+      scope: organization
+      required: true
+      paths: [MISSING.md]
+`
+	workflowYAML := `
+schema_version: 2
+name: guarded-context
+enabled: true
+initial_state: gathering
+states:
+  gathering:
+    phase: context
+    invariant:
+      context:
+        status:
+          equals: ready
+    on_enter:
+      effects:
+        - agent.task:
+            prompt: This must never execute without context.
+  completed:
+    phase: done
+    terminal: true
+transitions:
+  ready:
+    from: gathering
+    on: context.bundle.ready
+    to: completed
+`
+	if err := saveExternalWorkspace(&types.WorkspaceConfig{Name: "failing-context", Files: map[string]string{
+		"elasticclaw-config.yaml": workspaceYAML,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := saveExternalWorkflows("failing-context", []*types.WorkflowConfig{{
+		Name: "guarded-context", RawConfig: workflowYAML,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/workspaces/failing-context/workflows/guarded-context/trigger", strings.NewReader(`{"inputs":{}}`))
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	var runStatus, attemptStatus, effectStatus, clawStatus string
+	if err := db.QueryRow(`SELECT r.status,a.status,e.status,c.status FROM workflow_v2_runs r
+		JOIN workflow_v2_attempts a ON a.id=r.current_attempt_id
+		JOIN workflow_v2_effects e ON e.run_id=r.id
+		JOIN claws c ON c.id=a.claw_id
+		WHERE r.workspace_name='failing-context'`).Scan(&runStatus, &attemptStatus, &effectStatus, &clawStatus); err != nil {
+		t.Fatal(err)
+	}
+	if runStatus != "cancelled" || attemptStatus != "cancelled" || effectStatus != "cancelled" || clawStatus != "deleted" {
+		t.Fatalf("run/attempt/effect/claw = %q/%q/%q/%q", runStatus, attemptStatus, effectStatus, clawStatus)
+	}
+	if err := s.drainWorkflowV2Effects(t.Context(), "test-cancelled-worker"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/hub/workflow_v2_activation_test.go
+++ b/pkg/hub/workflow_v2_activation_test.go
@@ -1,0 +1,144 @@
+package hub
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/hub/workflowv2"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+	typesv2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
+)
+
+func TestWorkflowV2TriggerAssemblesOrganizationContextBeforeProvisioning(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token", ClawToken: "claw-token",
+		Providers: map[string]types.ProviderConfig{"noop": {Type: "noop"}}}, "", "", "")
+	workspaceYAML := `
+schema_version: 2
+name: context-workspace
+execution:
+  provider: noop
+repositories:
+  primary:
+    provider: github
+    repository: org/repo
+knowledge:
+  sources:
+    principles:
+      type: workspace_files
+      scope: organization
+      required: true
+      paths: [ENGINEERING.md]
+    repository-guidance:
+      type: repository_files
+      scope: repository
+      paths: [AGENTS.md]
+`
+	workflowYAML := `
+schema_version: 2
+name: context-delivery
+enabled: true
+initial_state: gathering
+states:
+  gathering:
+    phase: context
+  planning:
+    phase: plan
+    on_enter:
+      effects:
+        - agent.task:
+            prompt: Create a plan using the context bundle.
+transitions:
+  context_ready:
+    from: gathering
+    on: context.bundle.ready
+    when:
+      context:
+        status:
+          equals: ready
+    to: planning
+`
+	if err := saveExternalWorkspace(&types.WorkspaceConfig{Name: "context-workspace", Files: map[string]string{
+		"elasticclaw-config.yaml": workspaceYAML,
+		"ENGINEERING.md":          "# Engineering principles\n\nPrefer deterministic protocols.\n",
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := saveExternalWorkflows("context-workspace", []*types.WorkflowConfig{{
+		Name: "context-delivery", RawConfig: workflowYAML,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/workspaces/context-workspace/workflows/context-delivery/trigger", strings.NewReader(`{"inputs":{}}`))
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	var created map[string]string
+	if err := json.Unmarshal(rr.Body.Bytes(), &created); err != nil {
+		t.Fatal(err)
+	}
+	waitForWorkflowV2TestClaw(t, db, created["claw_id"])
+	var state, phase, sourcesJSON string
+	var version uint64
+	if err := db.QueryRow(`SELECT r.state,r.display_phase,r.state_version,b.sources_json
+		FROM workflow_v2_runs r JOIN workflow_v2_context_bundles b ON b.id=r.context_bundle_id
+		WHERE r.id=?`, created["run_id"]).Scan(&state, &phase, &version, &sourcesJSON); err != nil {
+		t.Fatal(err)
+	}
+	if state != "planning" || phase != "plan" || version != 2 {
+		t.Fatalf("state/phase/version = %q/%q/%d", state, phase, version)
+	}
+	if !strings.Contains(sourcesJSON, "ENGINEERING.md") ||
+		!strings.Contains(sourcesJSON, "Prefer deterministic protocols") ||
+		strings.Contains(sourcesJSON, "repository-guidance") {
+		t.Fatalf("organization context sources = %s", sourcesJSON)
+	}
+	var effects int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_effects WHERE run_id=? AND kind='agent.task'`,
+		created["run_id"]).Scan(&effects); err != nil {
+		t.Fatal(err)
+	}
+	if effects != 1 {
+		t.Fatalf("planning agent effects = %d", effects)
+	}
+}
+
+func waitForWorkflowV2TestClaw(t *testing.T, db *sql.DB, clawID string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		var status string
+		if err := db.QueryRow(`SELECT status FROM claws WHERE id=?`, clawID).Scan(&status); err != nil {
+			t.Fatal(err)
+		}
+		if status == "connected" {
+			return
+		}
+		if status == "error" || status == "deleted" {
+			t.Fatalf("claw %s reached unexpected status %q", clawID, status)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("claw %s did not finish noop provisioning", clawID)
+}
+
+func TestWorkspaceFileKnowledgeResolverRejectsMissingRequiredDocument(t *testing.T) {
+	resolver := workspaceFileKnowledgeResolver(map[string]string{})
+	_, err := resolver.ResolveKnowledge(t.Context(), workflowv2.Run{WorkspaceRevision: "revision"}, "principles",
+		typesv2.KnowledgeSource{Type: typesv2.KnowledgeTypeWorkspaceFiles, Paths: []string{"MISSING.md"}})
+	if err == nil || !strings.Contains(err.Error(), "MISSING.md") {
+		t.Fatalf("error = %v", err)
+	}
+}

--- a/pkg/hub/workflow_v2_worker.go
+++ b/pkg/hub/workflow_v2_worker.go
@@ -1,0 +1,81 @@
+package hub
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/hub/workflowv2"
+	"github.com/google/uuid"
+)
+
+const (
+	workflowV2EffectLease        = time.Minute
+	workflowV2EffectRetry        = 5 * time.Second
+	workflowV2TaskHeartbeat      = 2 * time.Minute
+	workflowV2TaskDeadline       = 2 * time.Hour
+	workflowV2EffectPoll         = 250 * time.Millisecond
+	workflowV2TaskExpirationPoll = 30 * time.Second
+)
+
+func (s *Server) runWorkflowV2Worker(ctx context.Context) {
+	worker := "hub-workflow-v2-" + uuid.NewString()
+	effectTicker := time.NewTicker(workflowV2EffectPoll)
+	expirationTicker := time.NewTicker(workflowV2TaskExpirationPoll)
+	defer effectTicker.Stop()
+	defer expirationTicker.Stop()
+	for {
+		if err := s.drainWorkflowV2Effects(ctx, worker); err != nil && ctx.Err() == nil {
+			log.Printf("[workflow-v2] effect worker: %v", err)
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-expirationTicker.C:
+			if _, err := workflowv2.NewStore(s.db).ExpireAgentTasks(ctx); err != nil && ctx.Err() == nil {
+				log.Printf("[workflow-v2] expire agent tasks: %v", err)
+			}
+		case <-effectTicker.C:
+		}
+	}
+}
+
+func (s *Server) drainWorkflowV2Effects(ctx context.Context, worker string) error {
+	store := workflowv2.NewStore(s.db)
+	for i := 0; i < 100 && ctx.Err() == nil; i++ {
+		claim, err := store.ClaimEffect(ctx, worker, workflowV2EffectLease)
+		if err != nil {
+			return err
+		}
+		if claim == nil {
+			return nil
+		}
+		if err := s.executeWorkflowV2Effect(ctx, store, worker, *claim); err != nil {
+			return err
+		}
+	}
+	return ctx.Err()
+}
+
+func (s *Server) executeWorkflowV2Effect(ctx context.Context, store *workflowv2.Store,
+	worker string, claim workflowv2.EffectClaim) error {
+	switch claim.Effect.Kind {
+	case "agent.task":
+		if _, err := store.MaterializeAgentTask(ctx, claim.Effect.ID, claim.AttemptID, worker,
+			workflowV2TaskHeartbeat, workflowV2TaskDeadline); err == nil {
+			return nil
+		} else {
+			return store.CompleteEffect(ctx, workflowv2.CompleteEffectRequest{
+				EffectID: claim.Effect.ID, AttemptID: claim.AttemptID, Worker: worker,
+				Status: workflowv2.EffectRetryableFailed, Error: err.Error(), RetryAfter: workflowV2EffectRetry,
+			})
+		}
+	default:
+		err := fmt.Errorf("hub has no workflow v2 executor for effect kind %q", claim.Effect.Kind)
+		return store.CompleteEffect(ctx, workflowv2.CompleteEffectRequest{
+			EffectID: claim.Effect.ID, AttemptID: claim.AttemptID, Worker: worker,
+			Status: workflowv2.EffectPermanentFailed, Error: err.Error(),
+		})
+	}
+}

--- a/pkg/hub/workflowv2/context.go
+++ b/pkg/hub/workflowv2/context.go
@@ -31,6 +31,19 @@ func (f KnowledgeResolverFunc) ResolveKnowledge(ctx context.Context, run Run, na
 // caller may only narrow repository_files sources to named workspace repos.
 func (s *Store) AssembleContext(ctx context.Context, runID string, relevantRepositories []string,
 	resolver KnowledgeResolver) (typesv2.ContextBundle, error) {
+	return s.assembleContext(ctx, runID, relevantRepositories, "", resolver)
+}
+
+// AssembleOrganizationContext builds the mandatory pre-plan layer without
+// prematurely resolving repository-scoped sources. Repository context is
+// expanded later, after planning has selected names from the pinned workspace.
+func (s *Store) AssembleOrganizationContext(ctx context.Context, runID string,
+	resolver KnowledgeResolver) (typesv2.ContextBundle, error) {
+	return s.assembleContext(ctx, runID, nil, typesv2.KnowledgeScopeOrganization, resolver)
+}
+
+func (s *Store) assembleContext(ctx context.Context, runID string, relevantRepositories []string,
+	scope string, resolver KnowledgeResolver) (typesv2.ContextBundle, error) {
 	if s == nil || s.db == nil {
 		return typesv2.ContextBundle{}, fmt.Errorf("workflow v2 store is not configured")
 	}
@@ -84,6 +97,9 @@ func (s *Store) AssembleContext(ctx context.Context, runID string, relevantRepos
 		sort.Strings(names)
 		for _, name := range names {
 			source := workspace.Workspace.Knowledge.Sources[name]
+			if scope != "" && source.Scope != scope {
+				continue
+			}
 			if source.Type == typesv2.KnowledgeTypeRepositoryFiles && len(source.Repositories) == 0 {
 				source.Repositories = append([]string(nil), relevant...)
 			}

--- a/pkg/hub/workflowv2/context.go
+++ b/pkg/hub/workflowv2/context.go
@@ -77,7 +77,7 @@ func (s *Store) assembleContext(ctx context.Context, runID string, relevantRepos
 	}
 	sort.Strings(relevant)
 
-	bundle := typesv2.ContextBundle{ID: uuid.NewString(), RunID: runID, CreatedAt: s.now().UTC()}
+	bundle := typesv2.ContextBundle{ID: uuid.NewString(), RunID: runID, Sources: []typesv2.ContextBundleSource{}, CreatedAt: s.now().UTC()}
 	nowMillis := bundle.CreatedAt.UnixMilli()
 	if _, err := s.db.ExecContext(ctx, `INSERT INTO workflow_v2_context_bundles(id,run_id,revision,status,sources_json,created_at,updated_at)
 		VALUES(?,?,?,'assembling','[]',?,?)`, bundle.ID, runID, "assembling:"+bundle.ID, nowMillis, nowMillis); err != nil {

--- a/pkg/hub/workflowv2/context.go
+++ b/pkg/hub/workflowv2/context.go
@@ -195,10 +195,11 @@ func (s *Store) assembleContext(ctx context.Context, runID string, relevantRepos
 	if eventResult.Disposition != typesv2.DispositionAccepted {
 		return typesv2.ContextBundle{}, fmt.Errorf("context event was %s: %s", eventResult.Disposition, eventResult.Reason)
 	}
-	if status == "failed" && eventResult.Transition == nil && eventResult.Run.Status == RunActive {
+	if status == "failed" && eventResult.Transition == nil &&
+		(eventResult.Run.Status == RunActive || eventResult.Run.Status == RunSuspended) {
 		reason := "one or more required knowledge sources failed"
 		if _, err := s.db.ExecContext(ctx, `UPDATE workflow_v2_runs SET status='suspended',waiting_reason=?,updated_at=?
-			WHERE id=? AND state_version=? AND status='active'`, reason, s.now().UTC().UnixMilli(), runID, eventResult.Run.StateVersion); err != nil {
+			WHERE id=? AND state_version=? AND status IN ('active','suspended')`, reason, s.now().UTC().UnixMilli(), runID, eventResult.Run.StateVersion); err != nil {
 			return typesv2.ContextBundle{}, err
 		}
 	}

--- a/pkg/hub/workflowv2/context_test.go
+++ b/pkg/hub/workflowv2/context_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"strings"
 	"testing"
+	"time"
 
 	workflowv2 "github.com/elasticclaw/elasticclaw/pkg/hub/workflowv2"
 	typesv2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
@@ -208,6 +210,40 @@ func TestRequiredKnowledgeFailedStatusSuspendsRun(t *testing.T) {
 	}
 	if run.Status != workflowv2.RunSuspended {
 		t.Fatalf("run = %#v", run)
+	}
+}
+
+func TestActivationPendingRequiredKnowledgeFailureRemainsSuspended(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	run, err := store.CreateRun(context.Background(), workflowv2.CreateRunRequest{
+		ID: "run-context-activation-failure", TenantID: "tenant-1", InitialClawID: "claw-context-failure",
+		WorkspaceYAML: []byte(contextWorkspaceYAML), WorkflowYAML: []byte(runtimeWorkflowYAML),
+		ActivationPending: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = store.AssembleOrganizationContext(context.Background(), run.ID,
+		workflowv2.KnowledgeResolverFunc(func(context.Context, workflowv2.Run, string,
+			typesv2.KnowledgeSource) (typesv2.ContextBundleSource, error) {
+			return typesv2.ContextBundleSource{}, errors.New("required handbook unavailable")
+		}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.CompleteActivation(context.Background(), run.ID); err != nil {
+		t.Fatal(err)
+	}
+	run, err = store.GetRun(context.Background(), run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.Status != workflowv2.RunSuspended || !strings.Contains(run.WaitingReason, "required knowledge") {
+		t.Fatalf("failed-context activation = %#v", run)
+	}
+	if claim, err := store.ClaimEffect(context.Background(), "worker-without-required-context", time.Minute); err != nil || claim != nil {
+		t.Fatalf("failed-context effect claim = %#v, %v", claim, err)
 	}
 }
 

--- a/pkg/hub/workflowv2/context_test.go
+++ b/pkg/hub/workflowv2/context_test.go
@@ -118,6 +118,28 @@ func TestAssembleContextUsesPinnedWorkspaceAndRelevantRepositories(t *testing.T)
 	}
 }
 
+func TestAssembleOrganizationContextDefersRepositorySources(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	createContextRun(t, store, "run-org-context")
+	var resolved []string
+	bundle, err := store.AssembleOrganizationContext(context.Background(), "run-org-context",
+		workflowv2.KnowledgeResolverFunc(func(_ context.Context, _ workflowv2.Run, name string,
+			source typesv2.KnowledgeSource) (typesv2.ContextBundleSource, error) {
+			resolved = append(resolved, name)
+			return typesv2.ContextBundleSource{Status: "ready", ContentDigest: "sha256:" + name}, nil
+		}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(resolved, []string{"principles"}) || len(bundle.Sources) != 1 {
+		t.Fatalf("resolved=%#v bundle=%#v", resolved, bundle)
+	}
+	if bundle.Sources[0].Scope != typesv2.KnowledgeScopeOrganization {
+		t.Fatalf("source = %#v", bundle.Sources[0])
+	}
+}
+
 func TestAssembleContextRejectsRepositoryOutsideWorkspace(t *testing.T) {
 	db := openRuntimeDB(t)
 	store := workflowv2.NewStore(db)

--- a/pkg/hub/workflowv2/effects.go
+++ b/pkg/hub/workflowv2/effects.go
@@ -67,10 +67,10 @@ func (s *Store) ClaimEffect(ctx context.Context, worker string, lease time.Durat
 	if err := expireEffectLeases(ctx, tx, now); err != nil {
 		return nil, err
 	}
-	row := tx.QueryRowContext(ctx, `SELECT id,run_id,effect_key,kind,payload_json,status,attempt_count,next_attempt_at,last_error
-		FROM workflow_v2_effects
-		WHERE status IN ('planned','retryable_failed') AND next_attempt_at<=?
-		ORDER BY next_attempt_at,created_at,id LIMIT 1`, now.UnixMilli())
+	row := tx.QueryRowContext(ctx, `SELECT e.id,e.run_id,e.effect_key,e.kind,e.payload_json,e.status,e.attempt_count,e.next_attempt_at,e.last_error
+		FROM workflow_v2_effects e JOIN workflow_v2_runs r ON r.id=e.run_id
+		WHERE e.status IN ('planned','retryable_failed') AND e.next_attempt_at<=? AND r.status='active'
+		ORDER BY e.next_attempt_at,e.created_at,e.id LIMIT 1`, now.UnixMilli())
 	var effect Effect
 	var payloadJSON string
 	var status string

--- a/pkg/hub/workflowv2/runtime.go
+++ b/pkg/hub/workflowv2/runtime.go
@@ -69,6 +69,9 @@ type CreateRunRequest struct {
 	// is created. Production activation uses this so a newly provisioned bridge
 	// cannot connect before its control-plane binding exists.
 	InitialClawID string
+	// ActivationPending keeps effects unclaimable until organization context
+	// has been assembled and CompleteActivation has released the run.
+	ActivationPending bool
 }
 
 type EventInput struct {
@@ -146,10 +149,14 @@ func (s *Store) CreateRun(ctx context.Context, req CreateRunRequest) (Run, error
 	}
 	now := s.now().UTC()
 	status := RunActive
+	waitingReason := ""
 	finishedAt := int64(0)
 	if initial.Terminal {
 		status = terminalRunStatus(rwf.Workflow.InitialState)
 		finishedAt = now.UnixMilli()
+	} else if req.ActivationPending {
+		status = RunSuspended
+		waitingReason = activationPendingReason
 	}
 
 	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
@@ -159,17 +166,17 @@ func (s *Store) CreateRun(ctx context.Context, req CreateRunRequest) (Run, error
 	defer tx.Rollback()
 	currentAttemptID := ""
 	if strings.TrimSpace(req.InitialClawID) != "" {
-		if status != RunActive {
+		if initial.Terminal {
 			return Run{}, fmt.Errorf("terminal workflow cannot start an execution attempt")
 		}
 		currentAttemptID = uuid.NewString()
 	}
 	_, err = tx.ExecContext(ctx, `INSERT INTO workflow_v2_runs(
 		id,tenant_id,workspace_name,workflow_name,workspace_revision,workflow_revision,
-		workspace_yaml,workflow_yaml,state,display_phase,state_version,status,current_attempt_id,created_at,updated_at,finished_at
-	) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		workspace_yaml,workflow_yaml,state,display_phase,state_version,status,waiting_reason,current_attempt_id,created_at,updated_at,finished_at
+	) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
 		runID, req.TenantID, rws.Workspace.Name, rwf.Workflow.Name, string(rws.Revision), string(rwf.Revision),
-		string(req.WorkspaceYAML), string(req.WorkflowYAML), rwf.Workflow.InitialState, string(initial.Phase), 1, string(status), currentAttemptID,
+		string(req.WorkspaceYAML), string(req.WorkflowYAML), rwf.Workflow.InitialState, string(initial.Phase), 1, string(status), waitingReason, currentAttemptID,
 		now.UnixMilli(), now.UnixMilli(), finishedAt)
 	if err != nil {
 		return Run{}, fmt.Errorf("create workflow v2 run: %w", err)
@@ -213,6 +220,91 @@ func (s *Store) CreateRun(ctx context.Context, req CreateRunRequest) (Run, error
 		return Run{}, err
 	}
 	return s.GetRun(ctx, runID)
+}
+
+const activationPendingReason = "workflow activation pending organization context"
+
+// CompleteActivation releases a context-pinned run for effect execution. It is
+// idempotent when context assembly already advanced the run or deliberately
+// suspended it on a domain-level context failure.
+func (s *Store) CompleteActivation(ctx context.Context, runID string) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("workflow v2 store is not configured")
+	}
+	now := s.now().UTC().UnixMilli()
+	result, err := s.db.ExecContext(ctx, `UPDATE workflow_v2_runs SET status='active',waiting_reason='',updated_at=?
+		WHERE id=? AND status='suspended' AND waiting_reason=? AND context_bundle_id!=''`,
+		now, runID, activationPendingReason)
+	if err != nil {
+		return err
+	}
+	if changed, err := result.RowsAffected(); err != nil {
+		return err
+	} else if changed == 1 {
+		return nil
+	}
+	var status, waitingReason, contextBundleID string
+	if err := s.db.QueryRowContext(ctx, `SELECT status,waiting_reason,context_bundle_id FROM workflow_v2_runs WHERE id=?`,
+		runID).Scan(&status, &waitingReason, &contextBundleID); err != nil {
+		return err
+	}
+	if contextBundleID == "" {
+		return fmt.Errorf("workflow v2 run has no organization context bundle")
+	}
+	if status == string(RunActive) || (status == string(RunSuspended) && waitingReason != activationPendingReason) {
+		return nil
+	}
+	return fmt.Errorf("workflow v2 run cannot complete activation from status %q", status)
+}
+
+// CancelActivation terminally closes a run whose pre-provision activation
+// failed, including every attempt and queued effect that could otherwise be
+// left bound to the claw being deleted by the caller.
+func (s *Store) CancelActivation(ctx context.Context, runID, reason string) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("workflow v2 store is not configured")
+	}
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		reason = "workflow activation failed"
+	}
+	now := s.now().UTC().UnixMilli()
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if _, err := tx.ExecContext(ctx, `UPDATE workflow_v2_effect_attempts SET status='cancelled',error=?,finished_at=?
+		WHERE status='running' AND effect_id IN (SELECT id FROM workflow_v2_effects WHERE run_id=?)`, reason, now, runID); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE workflow_v2_effects SET status='cancelled',lease_owner='',lease_expires_at=0,
+		last_error=?,updated_at=? WHERE run_id=? AND status IN ('planned','running','retryable_failed','unknown')`, reason, now, runID); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE workflow_v2_control_outbox SET status='cancelled',last_error=?,updated_at=?
+		WHERE run_id=? AND status IN ('pending','sent')`, reason, now, runID); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE workflow_v2_agent_tasks SET status='cancelled',terminal_reason=?,updated_at=?,finished_at=?
+		WHERE run_id=? AND status IN ('assigned','running')`, reason, now, now, runID); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE workflow_v2_attempts SET status='cancelled',reason=?,finished_at=?
+		WHERE run_id=? AND status IN ('provisioning','active')`, reason, now, runID); err != nil {
+		return err
+	}
+	result, err := tx.ExecContext(ctx, `UPDATE workflow_v2_runs SET status='cancelled',waiting_reason=?,current_task_id='',
+		updated_at=?,finished_at=? WHERE id=? AND status IN ('active','suspended')`, reason, now, now, runID)
+	if err != nil {
+		return err
+	}
+	if changed, err := result.RowsAffected(); err != nil {
+		return err
+	} else if changed != 1 {
+		return fmt.Errorf("workflow v2 run is not cancellable during activation")
+	}
+	return tx.Commit()
 }
 
 func (s *Store) GetRun(ctx context.Context, runID string) (Run, error) {

--- a/pkg/hub/workflowv2/runtime.go
+++ b/pkg/hub/workflowv2/runtime.go
@@ -65,6 +65,10 @@ type CreateRunRequest struct {
 	TenantID      string
 	WorkspaceYAML []byte
 	WorkflowYAML  []byte
+	// InitialClawID atomically binds the first execution attempt while the run
+	// is created. Production activation uses this so a newly provisioned bridge
+	// cannot connect before its control-plane binding exists.
+	InitialClawID string
 }
 
 type EventInput struct {
@@ -153,15 +157,29 @@ func (s *Store) CreateRun(ctx context.Context, req CreateRunRequest) (Run, error
 		return Run{}, err
 	}
 	defer tx.Rollback()
+	currentAttemptID := ""
+	if strings.TrimSpace(req.InitialClawID) != "" {
+		if status != RunActive {
+			return Run{}, fmt.Errorf("terminal workflow cannot start an execution attempt")
+		}
+		currentAttemptID = uuid.NewString()
+	}
 	_, err = tx.ExecContext(ctx, `INSERT INTO workflow_v2_runs(
 		id,tenant_id,workspace_name,workflow_name,workspace_revision,workflow_revision,
-		workspace_yaml,workflow_yaml,state,display_phase,state_version,status,created_at,updated_at,finished_at
-	) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		workspace_yaml,workflow_yaml,state,display_phase,state_version,status,current_attempt_id,created_at,updated_at,finished_at
+	) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
 		runID, req.TenantID, rws.Workspace.Name, rwf.Workflow.Name, string(rws.Revision), string(rwf.Revision),
-		string(req.WorkspaceYAML), string(req.WorkflowYAML), rwf.Workflow.InitialState, string(initial.Phase), 1, string(status),
+		string(req.WorkspaceYAML), string(req.WorkflowYAML), rwf.Workflow.InitialState, string(initial.Phase), 1, string(status), currentAttemptID,
 		now.UnixMilli(), now.UnixMilli(), finishedAt)
 	if err != nil {
 		return Run{}, fmt.Errorf("create workflow v2 run: %w", err)
+	}
+	if currentAttemptID != "" {
+		if _, err := tx.ExecContext(ctx, `INSERT INTO workflow_v2_attempts(
+			id,run_id,claw_id,number,status,started_at,heartbeat_at) VALUES(?,?,?,?,?,?,?)`,
+			currentAttemptID, runID, strings.TrimSpace(req.InitialClawID), 1, "active", now.UnixMilli(), now.UnixMilli()); err != nil {
+			return Run{}, fmt.Errorf("create initial workflow v2 attempt: %w", err)
+		}
 	}
 
 	eventID := uuid.NewString()

--- a/pkg/hub/workflowv2/runtime_test.go
+++ b/pkg/hub/workflowv2/runtime_test.go
@@ -149,6 +149,37 @@ func TestCreateRunPinsRevisionsAndInitialEntry(t *testing.T) {
 	}
 }
 
+func TestCreateRunAtomicallyBindsInitialAttempt(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	run, err := store.CreateRun(context.Background(), workflowv2.CreateRunRequest{
+		ID: "run-bound", TenantID: "tenant-1", InitialClawID: "claw-bound",
+		WorkspaceYAML: []byte(runtimeWorkspaceYAML), WorkflowYAML: []byte(runtimeWorkflowYAML),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.CurrentAttemptID == "" {
+		t.Fatal("run has no initial attempt")
+	}
+	binding, found, err := store.ActiveControlBinding(context.Background(), "tenant-1", "claw-bound")
+	if err != nil || !found {
+		t.Fatalf("binding found=%v err=%v", found, err)
+	}
+	if binding.RunID != run.ID || binding.AttemptID != run.CurrentAttemptID {
+		t.Fatalf("binding = %#v, run = %#v", binding, run)
+	}
+	var attemptNumber int
+	var status string
+	if err := db.QueryRow(`SELECT number,status FROM workflow_v2_attempts WHERE id=?`, run.CurrentAttemptID).
+		Scan(&attemptNumber, &status); err != nil {
+		t.Fatal(err)
+	}
+	if attemptNumber != 1 || status != "active" {
+		t.Fatalf("attempt number/status = %d/%q", attemptNumber, status)
+	}
+}
+
 func TestInspectRunExplainsDurableWaitingState(t *testing.T) {
 	db := openRuntimeDB(t)
 	store := workflowv2.NewStore(db)

--- a/pkg/hub/workflowv2/runtime_test.go
+++ b/pkg/hub/workflowv2/runtime_test.go
@@ -180,6 +180,80 @@ func TestCreateRunAtomicallyBindsInitialAttempt(t *testing.T) {
 	}
 }
 
+func TestActivationPendingBlocksEffectsUntilContextIsPinned(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	run, err := store.CreateRun(context.Background(), workflowv2.CreateRunRequest{
+		ID: "run-activation-pending", TenantID: "tenant-1", InitialClawID: "claw-pending",
+		WorkspaceYAML: []byte(runtimeWorkspaceYAML), WorkflowYAML: []byte(runtimeWorkflowYAML),
+		ActivationPending: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.Status != workflowv2.RunSuspended || run.WaitingReason == "" {
+		t.Fatalf("pending run = %#v", run)
+	}
+	if claim, err := store.ClaimEffect(context.Background(), "worker-before-context", time.Minute); err != nil || claim != nil {
+		t.Fatalf("pre-context effect claim = %#v, %v", claim, err)
+	}
+	bundle, err := store.AssembleOrganizationContext(context.Background(), run.ID,
+		workflowv2.KnowledgeResolverFunc(func(context.Context, workflowv2.Run, string,
+			typesv2.KnowledgeSource) (typesv2.ContextBundleSource, error) {
+			t.Fatal("workspace without knowledge sources invoked resolver")
+			return typesv2.ContextBundleSource{}, nil
+		}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bundle.ID == "" {
+		t.Fatal("organization context bundle was not pinned")
+	}
+	if err := store.CompleteActivation(context.Background(), run.ID); err != nil {
+		t.Fatal(err)
+	}
+	claim, err := store.ClaimEffect(context.Background(), "worker-after-context", time.Minute)
+	if err != nil || claim == nil {
+		t.Fatalf("post-context effect claim = %#v, %v", claim, err)
+	}
+}
+
+func TestCancelActivationClosesAttemptAndEffects(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	run, err := store.CreateRun(context.Background(), workflowv2.CreateRunRequest{
+		ID: "run-activation-cancel", TenantID: "tenant-1", InitialClawID: "claw-cancel",
+		WorkspaceYAML: []byte(runtimeWorkspaceYAML), WorkflowYAML: []byte(runtimeWorkflowYAML),
+		ActivationPending: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.CancelActivation(context.Background(), run.ID, "knowledge resolver unavailable"); err != nil {
+		t.Fatal(err)
+	}
+	run, err = store.GetRun(context.Background(), run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.Status != workflowv2.RunCancelled || !strings.Contains(run.WaitingReason, "knowledge resolver") {
+		t.Fatalf("cancelled run = %#v", run)
+	}
+	var attemptStatus, effectStatus string
+	if err := db.QueryRow(`SELECT status FROM workflow_v2_attempts WHERE id=?`, run.CurrentAttemptID).Scan(&attemptStatus); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT status FROM workflow_v2_effects WHERE run_id=?`, run.ID).Scan(&effectStatus); err != nil {
+		t.Fatal(err)
+	}
+	if attemptStatus != "cancelled" || effectStatus != string(workflowv2.EffectCancelled) {
+		t.Fatalf("attempt/effect status = %q/%q", attemptStatus, effectStatus)
+	}
+	if claim, err := store.ClaimEffect(context.Background(), "worker-after-cancel", time.Minute); err != nil || claim != nil {
+		t.Fatalf("cancelled effect claim = %#v, %v", claim, err)
+	}
+}
+
 func TestInspectRunExplainsDurableWaitingState(t *testing.T) {
 	db := openRuntimeDB(t)
 	store := workflowv2.NewStore(db)

--- a/pkg/hub/workspace_api.go
+++ b/pkg/hub/workspace_api.go
@@ -387,10 +387,8 @@ func (s *Server) handleWorkspaceWorkflowTrigger(w http.ResponseWriter, r *http.R
 }
 
 func (s *Server) triggerWorkflowConfig(w http.ResponseWriter, r *http.Request, workspace *types.WorkspaceConfig, workflow *types.WorkflowConfig) {
-	// Until the deterministic runtime is installed, v2 is authorable but never
-	// normalized or executed through the legacy transcript-driven engine.
 	if isWorkflowV2(workflow) {
-		jsonError(w, http.StatusConflict, "workflow v2 runtime is not active; this workflow cannot execute through the v1 engine")
+		s.triggerWorkflowV2Config(w, r, workspace, workflow)
 		return
 	}
 	if !workflow.EnableManualTrigger {
@@ -604,7 +602,7 @@ func workflowToView(workspaceName string, workflow *types.WorkflowConfig) Workfl
 		ExcludeLabels:        append([]string(nil), workflow.ExcludeLabels...),
 		AssignedTo:           workflow.AssignedTo,
 		Enabled:              workflow.Enabled == nil || *workflow.Enabled,
-		RuntimeAvailable:     !isWorkflowV2(workflow),
+		RuntimeAvailable:     true,
 		EnableManualTrigger:  workflow.EnableManualTrigger,
 		SecretRefs:           cloneStringMap(workflow.SecretRefs),
 		Volumes:              append([]types.WorkflowVolume(nil), workflow.Volumes...),

--- a/pkg/hub/workspace_api_test.go
+++ b/pkg/hub/workspace_api_test.go
@@ -456,45 +456,82 @@ func TestWorkspaceWorkflowPatchUpdatesTriggerControls(t *testing.T) {
 	}
 }
 
-func TestV2WorkflowCannotEnterLegacyPatchOrTriggerPaths(t *testing.T) {
+func TestV2WorkflowRejectsLegacyPatchAndTriggersDeterministicRun(t *testing.T) {
 	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
-	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token", ClawToken: "claw-token",
+		Providers: map[string]types.ProviderConfig{"noop": {Type: "noop"}}}, "", "", "")
+	workspaceYAML := testWorkspaceV2YAML + "\nexecution:\n  provider: noop\n"
 
 	if err := saveExternalWorkspace(&types.WorkspaceConfig{
 		Name:  "engineering",
-		Files: map[string]string{"elasticclaw-config.yaml": testWorkspaceV2YAML},
+		Files: map[string]string{"elasticclaw-config.yaml": workspaceYAML},
 	}); err != nil {
 		t.Fatalf("seed workspace: %v", err)
 	}
 	if err := saveExternalWorkflows("engineering", []*types.WorkflowConfig{{
-		Name:      "delivery",
-		RawConfig: testWorkflowV2YAML,
+		Name: "delivery",
+		RawConfig: strings.Replace(testWorkflowV2YAML, "  implementing:\n    phase: build", `  implementing:
+    phase: build
+    on_enter:
+      effects:
+        - agent.task:
+            prompt: Implement the requested change.`, 1),
 	}}); err != nil {
 		t.Fatalf("seed workflow: %v", err)
 	}
 
-	for _, tc := range []struct {
-		method string
-		body   string
-	}{
-		{http.MethodPatch, `{"enabled":false}`},
-		{http.MethodPost, `{"inputs":{}}`},
-	} {
-		path := "/api/workspaces/engineering/workflows/delivery"
-		if tc.method == http.MethodPost {
-			path += "/trigger"
-		}
-		req := httptest.NewRequest(tc.method, path, strings.NewReader(tc.body))
-		req.Header.Set("Authorization", "Bearer test-token")
-		req.Header.Set("Content-Type", "application/json")
-		rr := httptest.NewRecorder()
-		s.Handler().ServeHTTP(rr, req)
-		if rr.Code != http.StatusConflict {
-			t.Fatalf("%s status = %d, want %d, body = %s", tc.method, rr.Code, http.StatusConflict, rr.Body.String())
-		}
-		if !strings.Contains(rr.Body.String(), "v2") {
-			t.Fatalf("%s response does not explain v2 boundary: %s", tc.method, rr.Body.String())
-		}
+	req := httptest.NewRequest(http.MethodPatch, "/api/workspaces/engineering/workflows/delivery",
+		strings.NewReader(`{"enabled":false}`))
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusConflict || !strings.Contains(rr.Body.String(), "v2") {
+		t.Fatalf("patch status/body = %d/%s", rr.Code, rr.Body.String())
+	}
+
+	req = httptest.NewRequest(http.MethodPost, "/api/workspaces/engineering/workflows/delivery/trigger",
+		strings.NewReader(`{"inputs":{"issue":"org/repo#42"}}`))
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	rr = httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("trigger status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	var created map[string]string
+	if err := json.Unmarshal(rr.Body.Bytes(), &created); err != nil {
+		t.Fatal(err)
+	}
+	if created["run_id"] == "" || created["claw_id"] == "" {
+		t.Fatalf("trigger response = %#v", created)
+	}
+	waitForWorkflowV2TestClaw(t, db, created["claw_id"])
+	var currentAttemptID, boundClawID string
+	if err := db.QueryRow(`SELECT r.current_attempt_id,a.claw_id FROM workflow_v2_runs r
+		JOIN workflow_v2_attempts a ON a.id=r.current_attempt_id WHERE r.id=?`, created["run_id"]).
+		Scan(&currentAttemptID, &boundClawID); err != nil {
+		t.Fatal(err)
+	}
+	if currentAttemptID == "" || boundClawID != created["claw_id"] {
+		t.Fatalf("attempt/claw = %q/%q", currentAttemptID, boundClawID)
+	}
+	if err := s.drainWorkflowV2Effects(t.Context(), "test-v2-worker"); err != nil {
+		t.Fatal(err)
+	}
+	var taskCount, outboxCount, conversationCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_agent_tasks WHERE run_id=?`, created["run_id"]).Scan(&taskCount); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_control_outbox WHERE run_id=?`, created["run_id"]).Scan(&outboxCount); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=?`, created["claw_id"]).Scan(&conversationCount); err != nil {
+		t.Fatal(err)
+	}
+	if taskCount != 1 || outboxCount != 1 || conversationCount != 0 {
+		t.Fatalf("task/outbox/conversation = %d/%d/%d", taskCount, outboxCount, conversationCount)
 	}
 
 	loaded, err := loadExternalWorkspace("engineering")

--- a/pkg/hub/workspace_api_test.go
+++ b/pkg/hub/workspace_api_test.go
@@ -461,11 +461,24 @@ func TestV2WorkflowRejectsLegacyPatchAndTriggersDeterministicRun(t *testing.T) {
 	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
 	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token", ClawToken: "claw-token",
 		Providers: map[string]types.ProviderConfig{"noop": {Type: "noop"}}}, "", "", "")
-	workspaceYAML := testWorkspaceV2YAML + "\nexecution:\n  provider: noop\n"
+	workspaceYAML := testWorkspaceV2YAML + `
+execution:
+  provider: noop
+knowledge:
+  sources:
+    principles:
+      type: workspace_files
+      scope: organization
+      required: true
+      paths: [ENGINEERING.md]
+`
 
 	if err := saveExternalWorkspace(&types.WorkspaceConfig{
-		Name:  "engineering",
-		Files: map[string]string{"elasticclaw-config.yaml": workspaceYAML},
+		Name: "engineering",
+		Files: map[string]string{
+			"elasticclaw-config.yaml": workspaceYAML,
+			"ENGINEERING.md":          "# Engineering\n\nUse typed control protocols.\n",
+		},
 	}); err != nil {
 		t.Fatalf("seed workspace: %v", err)
 	}
@@ -508,14 +521,16 @@ func TestV2WorkflowRejectsLegacyPatchAndTriggersDeterministicRun(t *testing.T) {
 		t.Fatalf("trigger response = %#v", created)
 	}
 	waitForWorkflowV2TestClaw(t, db, created["claw_id"])
-	var currentAttemptID, boundClawID string
-	if err := db.QueryRow(`SELECT r.current_attempt_id,a.claw_id FROM workflow_v2_runs r
-		JOIN workflow_v2_attempts a ON a.id=r.current_attempt_id WHERE r.id=?`, created["run_id"]).
-		Scan(&currentAttemptID, &boundClawID); err != nil {
+	var currentAttemptID, boundClawID, contextBundleID, sourcesJSON string
+	if err := db.QueryRow(`SELECT r.current_attempt_id,a.claw_id,r.context_bundle_id,b.sources_json FROM workflow_v2_runs r
+		JOIN workflow_v2_attempts a ON a.id=r.current_attempt_id
+		JOIN workflow_v2_context_bundles b ON b.id=r.context_bundle_id WHERE r.id=?`, created["run_id"]).
+		Scan(&currentAttemptID, &boundClawID, &contextBundleID, &sourcesJSON); err != nil {
 		t.Fatal(err)
 	}
-	if currentAttemptID == "" || boundClawID != created["claw_id"] {
-		t.Fatalf("attempt/claw = %q/%q", currentAttemptID, boundClawID)
+	if currentAttemptID == "" || boundClawID != created["claw_id"] || contextBundleID == "" ||
+		!strings.Contains(sourcesJSON, "Use typed control protocols") {
+		t.Fatalf("attempt/claw/context/sources = %q/%q/%q/%s", currentAttemptID, boundClawID, contextBundleID, sourcesJSON)
 	}
 	if err := s.drainWorkflowV2Effects(t.Context(), "test-v2-worker"); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Refs #544.\n\nThis activates manually triggered Workflow V2 definitions without routing them through the V1 transcript-driven engine. It atomically binds the initial claw attempt before provisioning, assembles declared organization-scoped workspace knowledge before planning, and runs a durable hub worker that materializes agent.task effects onto the authenticated control WebSocket outbox.\n\nBackward compatibility: V1 parsing, triggering, and workspace file loading remain unchanged; the expanded knowledge-file loader applies only to explicitly declared V2 workspace_files paths. Trigger inputs are staged only as claw context and never interpreted as control events.\n\nVerification:\n- env GOCACHE=/private/tmp/elasticclaw-go-build go test ./...\n- env GOCACHE=/private/tmp/elasticclaw-go-build go vet ./...\n- focused go test -race for activation, context, initial-attempt, and worker paths