### PR TITLE
Connect GitHub lifecycle to workflow v2

### DIFF
--- a/pkg/hub/github_webhook.go
+++ b/pkg/hub/github_webhook.go
@@ -199,6 +199,7 @@ func (s *Server) validateGitHubSignature(body []byte, sig string) bool {
 
 // processGitHubPREvent finds matching factories and creates claws for a PR event.
 func (s *Server) processGitHubPREvent(payload githubPRPayload) {
+	s.processWorkflowV2GitHubPREvent(payload)
 	factories := s.resolveFactories()
 
 	repoFullName := payload.Repository.FullName
@@ -491,6 +492,7 @@ func (s *Server) processGitHubCheckEvent(event string, payload githubCheckPayloa
 	if payload.Action != "completed" {
 		return
 	}
+	s.processWorkflowV2GitHubCheckEvent(event, payload)
 
 	headSHA, prNumbers, _ := payload.checkEventSummary(event)
 	repo := payload.Repository.FullName
@@ -525,6 +527,7 @@ func (s *Server) processGitHubCheckEvent(event string, payload githubCheckPayloa
 }
 
 func (s *Server) processGitHubPRReviewCommentEvent(payload githubPRReviewCommentPayload) {
+	s.processWorkflowV2GitHubReviewCommentEvent(payload)
 	if payload.Action != "created" {
 		return
 	}
@@ -547,6 +550,7 @@ func (s *Server) processGitHubPRReviewCommentEvent(payload githubPRReviewComment
 }
 
 func (s *Server) processGitHubPRReviewEvent(payload githubPRReviewPayload) {
+	s.processWorkflowV2GitHubReviewEvent(payload)
 	if payload.Action != "submitted" || !strings.EqualFold(payload.Review.State, "changes_requested") {
 		return
 	}
@@ -580,6 +584,7 @@ type githubIssueCommentPayload struct {
 		} `json:"pull_request"`
 	} `json:"issue"`
 	Comment struct {
+		ID      int64  `json:"id"`
 		Body    string `json:"body"`
 		HTMLURL string `json:"html_url"`
 		User    struct {
@@ -626,6 +631,7 @@ func (s *Server) processGitHubIssueComment(payload githubIssueCommentPayload) {
 // If a claw exists for the PR, it injects the comment. If not, it tries to create a claw
 // (useful when a PR was opened before the webhook was configured or the opened event was missed).
 func (s *Server) processGitHubIssueCommentEvent(payload githubIssueCommentPayload) {
+	s.processWorkflowV2GitHubIssueCommentEvent(payload)
 	if payload.Action != "created" {
 		return // only care about new comments
 	}

--- a/pkg/hub/github_webhook.go
+++ b/pkg/hub/github_webhook.go
@@ -411,11 +411,13 @@ type githubPRReviewCommentPayload struct {
 type githubPRReviewPayload struct {
 	Action string `json:"action"` // "submitted", "edited", "dismissed"
 	Review struct {
-		ID      int64  `json:"id"`
-		State   string `json:"state"` // "changes_requested", "approved", "commented"
-		Body    string `json:"body"`
-		HTMLURL string `json:"html_url"`
-		User    struct {
+		ID          int64  `json:"id"`
+		State       string `json:"state"` // "changes_requested", "approved", "commented"
+		Body        string `json:"body"`
+		HTMLURL     string `json:"html_url"`
+		CommitID    string `json:"commit_id"`
+		SubmittedAt string `json:"submitted_at"`
+		User        struct {
 			Login string `json:"login"`
 			Type  string `json:"type"`
 		} `json:"user"`

--- a/pkg/hub/workflow_v2_github.go
+++ b/pkg/hub/workflow_v2_github.go
@@ -97,6 +97,67 @@ func githubAPIWithBaseContext(ctx context.Context, baseURL, path, token string) 
 	return result, nil
 }
 
+// githubAPICollectionWithBaseContext follows GitHub's Link pagination for a
+// named top-level collection. Every next URL must remain on the configured API
+// origin before the repository-scoped token is sent.
+func githubAPICollectionWithBaseContext(ctx context.Context, baseURL, requestPath, token, key string) ([]json.RawMessage, error) {
+	base, err := url.Parse(strings.TrimRight(baseURL, "/"))
+	if err != nil || base.Scheme == "" || base.Host == "" {
+		return nil, fmt.Errorf("invalid GitHub API base URL")
+	}
+	next := strings.TrimRight(baseURL, "/") + "/" + strings.TrimLeft(requestPath, "/")
+	visited := map[string]bool{}
+	var result []json.RawMessage
+	for page := 0; next != ""; page++ {
+		if page >= 100 || visited[next] {
+			return nil, fmt.Errorf("GitHub API pagination exceeded safe limit")
+		}
+		visited[next] = true
+		parsed, err := url.Parse(next)
+		if err != nil || !strings.EqualFold(parsed.Scheme, base.Scheme) || !strings.EqualFold(parsed.Host, base.Host) {
+			return nil, fmt.Errorf("GitHub API pagination left configured origin")
+		}
+		resp, err := defaultGitHubClient.getContext(ctx, next, token)
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode >= http.StatusBadRequest {
+			return nil, &githubAPIError{StatusCode: resp.StatusCode, Body: string(resp.Body), RateLimited: resp.rateLimited()}
+		}
+		var document map[string]json.RawMessage
+		if err := json.Unmarshal(resp.Body, &document); err != nil {
+			return nil, fmt.Errorf("github API parse error: %w", err)
+		}
+		var pageItems []json.RawMessage
+		if err := json.Unmarshal(document[key], &pageItems); err != nil {
+			return nil, fmt.Errorf("github API collection %q parse error: %w", key, err)
+		}
+		result = append(result, pageItems...)
+		next = githubNextPage(resp.Header.Get("Link"))
+	}
+	return result, nil
+}
+
+func githubNextPage(link string) string {
+	for _, entry := range strings.Split(link, ",") {
+		parts := strings.Split(entry, ";")
+		if len(parts) < 2 {
+			continue
+		}
+		relNext := false
+		for _, parameter := range parts[1:] {
+			if strings.TrimSpace(parameter) == `rel="next"` {
+				relNext = true
+				break
+			}
+		}
+		if relNext {
+			return strings.TrimSuffix(strings.TrimPrefix(strings.TrimSpace(parts[0]), "<"), ">")
+		}
+	}
+	return ""
+}
+
 func parseWorkflowV2GitHubPRURL(raw string) (string, int, error) {
 	parsed, err := url.Parse(strings.TrimSpace(raw))
 	if err != nil || parsed.Scheme != "https" || parsed.Host == "" || parsed.RawQuery != "" || parsed.Fragment != "" {

--- a/pkg/hub/workflow_v2_github_events.go
+++ b/pkg/hub/workflow_v2_github_events.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"path"
 	"sort"
 	"strconv"
 	"strings"
@@ -121,8 +122,15 @@ func (s *Server) processWorkflowV2GitHubCheckEvent(event string, payload githubC
 		Conclusion  string `json:"conclusion"`
 		DetailsURL  string `json:"details_url"`
 		CompletedAt string `json:"completed_at"`
+		App         struct {
+			Slug string `json:"slug"`
+		} `json:"app"`
+		CheckSuite struct {
+			ID int64 `json:"id"`
+		} `json:"check_suite"`
 	}
 	checksByRepository := map[string][]githubCheck{}
+	workflowRunsByRepository := map[string]map[int64]struct{ name, path string }{}
 	for _, target := range targets {
 		checks, loaded := checksByRepository[target.Repository]
 		if !loaded {
@@ -132,7 +140,7 @@ func (s *Server) processWorkflowV2GitHubCheckEvent(event string, payload githubC
 				continue
 			}
 			data, err := githubAPIWithBaseContext(context.Background(), s.ghBaseURL(),
-				fmt.Sprintf("repos/%s/commits/%s/check-runs?per_page=100", target.Repository, headSHA), token)
+				fmt.Sprintf("repos/%s/commits/%s/check-runs?filter=latest&per_page=100", target.Repository, headSHA), token)
 			if err != nil {
 				log.Printf("[workflow-v2 github] reconcile checks for %s@%s: %v", target.Repository, headSHA, err)
 				continue
@@ -143,12 +151,42 @@ func (s *Server) processWorkflowV2GitHubCheckEvent(event string, payload githubC
 				continue
 			}
 			checksByRepository[target.Repository] = checks
+			runsData, err := githubAPIWithBaseContext(context.Background(), s.ghBaseURL(),
+				fmt.Sprintf("repos/%s/actions/runs?head_sha=%s&per_page=100", target.Repository, headSHA), token)
+			if err != nil {
+				log.Printf("[workflow-v2 github] reconcile workflow runs for %s@%s: %v", target.Repository, headSHA, err)
+				delete(checksByRepository, target.Repository)
+				continue
+			}
+			rawRuns, _ = json.Marshal(runsData["workflow_runs"])
+			var workflowRuns []struct {
+				Name         string `json:"name"`
+				Path         string `json:"path"`
+				CheckSuiteID int64  `json:"check_suite_id"`
+			}
+			if err := json.Unmarshal(rawRuns, &workflowRuns); err != nil {
+				log.Printf("[workflow-v2 github] decode workflow runs for %s: %v", target.Repository, err)
+				delete(checksByRepository, target.Repository)
+				continue
+			}
+			bySuite := map[int64]struct{ name, path string }{}
+			for _, run := range workflowRuns {
+				if run.CheckSuiteID > 0 {
+					bySuite[run.CheckSuiteID] = struct{ name, path string }{name: run.Name, path: run.Path}
+				}
+			}
+			workflowRunsByRepository[target.Repository] = bySuite
+		}
+		workflowRuns, loaded := workflowRunsByRepository[target.Repository]
+		if !loaded {
+			continue
 		}
 		workspace, err := typesv2.ParseAndValidateWorkspace([]byte(target.WorkspaceYAML))
 		if err != nil || workspace.Workspace.CI == nil {
 			continue
 		}
 		evidenceInputs := make([]workflowv2.EvidenceInput, 0, len(checks))
+		evidenceScopes := make([]workflowv2.EvidenceScope, 0)
 		for pipelineName, pipeline := range workspace.Workspace.CI.Pipelines {
 			if pipeline.Repository != target.RepositoryName {
 				continue
@@ -157,7 +195,15 @@ func (s *Server) processWorkflowV2GitHubCheckEvent(event string, payload githubC
 			if !strings.EqualFold(connection.Provider, "github_actions") {
 				continue
 			}
+			evidenceScopes = append(evidenceScopes, workflowv2.EvidenceScope{RunID: target.RunID,
+				PRID: target.PRID, HeadSHA: headSHA, Domain: "ci", Connection: pipeline.Connection,
+				Pipeline: pipelineName})
 			for _, check := range checks {
+				workflowRun, ok := workflowRuns[check.CheckSuite.ID]
+				if !strings.EqualFold(check.App.Slug, "github-actions") || !ok ||
+					!workflowV2GitHubWorkflowMatches(pipeline.Workflow, workflowRun.name, workflowRun.path) {
+					continue
+				}
 				observed := parseGitHubTime(check.CompletedAt)
 				rawExternalID := strconv.FormatInt(check.ID, 10)
 				if check.ID == 0 {
@@ -175,12 +221,23 @@ func (s *Server) processWorkflowV2GitHubCheckEvent(event string, payload githubC
 				})
 			}
 		}
-		if len(evidenceInputs) > 0 {
-			if _, err := store.ReconcileEvidenceSet(context.Background(), evidenceInputs, workflowv2.ProducerCI); err != nil {
+		if len(evidenceScopes) > 0 {
+			if _, err := store.ReconcileEvidenceSnapshot(context.Background(), evidenceScopes, evidenceInputs,
+				workflowv2.ProducerCI); err != nil {
 				log.Printf("[workflow-v2 github] reconcile check snapshot for run %s: %v", target.RunID, err)
 			}
 		}
 	}
+}
+
+func workflowV2GitHubWorkflowMatches(configured, name, workflowPath string) bool {
+	configured = strings.TrimSpace(configured)
+	workflowPath = strings.TrimSpace(workflowPath)
+	if configured == "" || workflowPath == "" {
+		return false
+	}
+	return configured == workflowPath || configured == path.Base(workflowPath) ||
+		strings.EqualFold(configured, strings.TrimSpace(name))
 }
 
 func workflowV2GitHubCheckStatus(status, conclusion string) string {
@@ -201,9 +258,36 @@ func (s *Server) processWorkflowV2GitHubReviewEvent(payload githubPRReviewPayloa
 	if payload.Action != "submitted" && payload.Action != "edited" && payload.Action != "dismissed" {
 		return
 	}
-	if !s.isHumanGitHubActor(payload.Review.User.Login, payload.Review.User.Type) {
+	token := s.tokenForRepo(payload.Repository.FullName)
+	if token == "" {
+		log.Printf("[workflow-v2 github] no repository-scoped token for review %s", payload.Repository.FullName)
 		return
 	}
+	review, err := githubAPIWithBaseContext(context.Background(), s.ghBaseURL(), fmt.Sprintf(
+		"repos/%s/pulls/%d/reviews/%d", payload.Repository.FullName, payload.PullRequest.Number, payload.Review.ID), token)
+	if err != nil {
+		log.Printf("[workflow-v2 github] verify review %d on %s#%d: %v", payload.Review.ID,
+			payload.Repository.FullName, payload.PullRequest.Number, err)
+		return
+	}
+	user, _ := review["user"].(map[string]interface{})
+	login, _ := user["login"].(string)
+	userType, _ := user["type"].(string)
+	if !s.isHumanGitHubActor(login, userType) {
+		return
+	}
+	commitID, _ := review["commit_id"].(string)
+	status, _ := review["state"].(string)
+	status = strings.ToLower(strings.TrimSpace(status))
+	body, _ := review["body"].(string)
+	url, _ := review["html_url"].(string)
+	submittedAt, _ := review["submitted_at"].(string)
+	observed, observedErr := time.Parse(time.RFC3339Nano, strings.TrimSpace(submittedAt))
+	if commitID == "" || status == "" || observedErr != nil {
+		log.Printf("[workflow-v2 github] review %d is missing authoritative head, state, or timestamp", payload.Review.ID)
+		return
+	}
+	observed = observed.UTC()
 	targets, err := workflowv2.NewStore(s.db).ActiveDeliveryTargets(context.Background(),
 		payload.Repository.FullName, payload.PullRequest.Number)
 	if err != nil {
@@ -211,26 +295,25 @@ func (s *Server) processWorkflowV2GitHubReviewEvent(payload githubPRReviewPayloa
 		return
 	}
 	for _, target := range targets {
-		status := strings.ToLower(strings.TrimSpace(payload.Review.State))
-		if payload.Action == "dismissed" {
-			status = "dismissed"
+		if target.HeadSHA != commitID {
+			continue
 		}
-		observed := now().UTC()
 		if status == "changes_requested" {
 			// Persist the typed feedback fact before review evidence can take a
 			// policy transition that schedules an include_facts agent task.
-			s.applyWorkflowV2GitHubFeedback(target, "review", payload.Review.ID, payload.Review.User.Login,
-				payload.Review.Body, payload.Review.HTMLURL, "", 0)
+			feedbackID := fmt.Sprintf("%d:%s:%s", payload.Review.ID, payload.Action,
+				workflowV2GitHubEventID("", body))
+			s.applyWorkflowV2GitHubFeedback(target, "review", feedbackID, login, body, url, "", 0, observed)
 		}
 		connections := workflowV2GitHubReviewConnections(target)
 		for _, connection := range connections {
 			_, err := workflowv2.NewStore(s.db).RecordEvidence(context.Background(), workflowv2.EvidenceInput{
 				RunID: target.RunID, PRID: target.PRID, HeadSHA: target.HeadSHA, Domain: "review",
-				Connection: connection, ExternalID: payload.Review.User.Login, Kind: "approval", Status: status,
+				Connection: connection, ExternalID: login, Kind: "approval", Status: status,
 				ObservedAt: observed, Payload: map[string]interface{}{"review_id": payload.Review.ID,
-					"url": payload.Review.HTMLURL, "body": payload.Review.Body},
+					"url": url, "body": body, "commit_id": commitID},
 				Provenance: typesv2.EvidenceProvenance{Producer: string(workflowv2.ProducerReview),
-					Connection: connection, Principal: payload.Review.User.Login,
+					Connection: connection, Principal: login,
 					ExternalID: strconv.FormatInt(payload.Review.ID, 10), ObservedAt: observed},
 			}, workflowv2.ProducerReview)
 			if err != nil {
@@ -245,8 +328,8 @@ func (s *Server) processWorkflowV2GitHubReviewCommentEvent(payload githubPRRevie
 		return
 	}
 	s.processWorkflowV2GitHubFeedbackTargets(payload.Repository.FullName, payload.PullRequest.Number,
-		"inline_comment", payload.Comment.ID, payload.Comment.User.Login, payload.Comment.Body,
-		payload.Comment.HTMLURL, payload.Comment.Path, payload.Comment.Line)
+		"inline_comment", strconv.FormatInt(payload.Comment.ID, 10), payload.Comment.User.Login, payload.Comment.Body,
+		payload.Comment.HTMLURL, payload.Comment.Path, payload.Comment.Line, time.Time{})
 }
 
 func (s *Server) processWorkflowV2GitHubIssueCommentEvent(payload githubIssueCommentPayload) {
@@ -254,25 +337,27 @@ func (s *Server) processWorkflowV2GitHubIssueCommentEvent(payload githubIssueCom
 		return
 	}
 	s.processWorkflowV2GitHubFeedbackTargets(payload.Repository.FullName, payload.Issue.Number,
-		"pull_request_comment", payload.Comment.ID, payload.Comment.User.Login, payload.Comment.Body,
-		payload.Comment.HTMLURL, "", 0)
+		"pull_request_comment", strconv.FormatInt(payload.Comment.ID, 10), payload.Comment.User.Login, payload.Comment.Body,
+		payload.Comment.HTMLURL, "", 0, time.Time{})
 }
 
-func (s *Server) processWorkflowV2GitHubFeedbackTargets(repository string, number int, kind string, externalID int64,
-	author, body, url, path string, line int) {
+func (s *Server) processWorkflowV2GitHubFeedbackTargets(repository string, number int, kind, externalID string,
+	author, body, url, path string, line int, observed time.Time) {
 	targets, err := workflowv2.NewStore(s.db).ActiveDeliveryTargets(context.Background(), repository, number)
 	if err != nil {
 		log.Printf("[workflow-v2 github] find feedback targets: %v", err)
 		return
 	}
 	for _, target := range targets {
-		s.applyWorkflowV2GitHubFeedback(target, kind, externalID, author, body, url, path, line)
+		s.applyWorkflowV2GitHubFeedback(target, kind, externalID, author, body, url, path, line, observed)
 	}
 }
 
-func (s *Server) applyWorkflowV2GitHubFeedback(target workflowv2.DeliveryTarget, kind string, externalID int64,
-	author, body, url, path string, line int) {
-	observed := now().UTC()
+func (s *Server) applyWorkflowV2GitHubFeedback(target workflowv2.DeliveryTarget, kind, externalID string,
+	author, body, url, path string, line int, observed time.Time) {
+	if observed.IsZero() {
+		observed = now().UTC()
+	}
 	feedback := map[string]interface{}{"kind": kind, "author": author, "body": body, "url": url,
 		"repository": target.Repository, "number": target.Number, "pull_request_url": target.URL}
 	if path != "" {
@@ -282,10 +367,10 @@ func (s *Server) applyWorkflowV2GitHubFeedback(target workflowv2.DeliveryTarget,
 		feedback["line"] = line
 	}
 	eventID := workflowV2GitHubEventID(target.RunID, "review_feedback", kind,
-		strconv.FormatInt(externalID, 10), target.Repository, strconv.Itoa(target.Number))
+		externalID, target.Repository, strconv.Itoa(target.Number))
 	_, err := workflowv2.NewStore(s.db).ApplyReviewFeedback(context.Background(), target, eventID, feedback,
 		typesv2.EvidenceProvenance{Producer: string(workflowv2.ProducerReview), Principal: author,
-			ExternalID: strconv.FormatInt(externalID, 10), ObservedAt: observed})
+			ExternalID: externalID, ObservedAt: observed})
 	if err != nil {
 		log.Printf("[workflow-v2 github] apply feedback to run %s: %v", target.RunID, err)
 	}

--- a/pkg/hub/workflow_v2_github_events.go
+++ b/pkg/hub/workflow_v2_github_events.go
@@ -139,32 +139,34 @@ func (s *Server) processWorkflowV2GitHubCheckEvent(event string, payload githubC
 				log.Printf("[workflow-v2 github] no repository-scoped token for CI %s", target.Repository)
 				continue
 			}
-			data, err := githubAPIWithBaseContext(context.Background(), s.ghBaseURL(),
-				fmt.Sprintf("repos/%s/commits/%s/check-runs?filter=latest&per_page=100", target.Repository, headSHA), token)
+			rawRuns, err := githubAPICollectionWithBaseContext(context.Background(), s.ghBaseURL(),
+				fmt.Sprintf("repos/%s/commits/%s/check-runs?filter=latest&per_page=100", target.Repository, headSHA),
+				token, "check_runs")
 			if err != nil {
 				log.Printf("[workflow-v2 github] reconcile checks for %s@%s: %v", target.Repository, headSHA, err)
 				continue
 			}
-			rawRuns, _ := json.Marshal(data["check_runs"])
-			if err := json.Unmarshal(rawRuns, &checks); err != nil {
+			rawChecks, _ := json.Marshal(rawRuns)
+			if err := json.Unmarshal(rawChecks, &checks); err != nil {
 				log.Printf("[workflow-v2 github] decode check runs for %s: %v", target.Repository, err)
 				continue
 			}
 			checksByRepository[target.Repository] = checks
-			runsData, err := githubAPIWithBaseContext(context.Background(), s.ghBaseURL(),
-				fmt.Sprintf("repos/%s/actions/runs?head_sha=%s&per_page=100", target.Repository, headSHA), token)
+			rawRuns, err = githubAPICollectionWithBaseContext(context.Background(), s.ghBaseURL(),
+				fmt.Sprintf("repos/%s/actions/runs?head_sha=%s&per_page=100", target.Repository, headSHA),
+				token, "workflow_runs")
 			if err != nil {
 				log.Printf("[workflow-v2 github] reconcile workflow runs for %s@%s: %v", target.Repository, headSHA, err)
 				delete(checksByRepository, target.Repository)
 				continue
 			}
-			rawRuns, _ = json.Marshal(runsData["workflow_runs"])
+			rawWorkflowRuns, _ := json.Marshal(rawRuns)
 			var workflowRuns []struct {
 				Name         string `json:"name"`
 				Path         string `json:"path"`
 				CheckSuiteID int64  `json:"check_suite_id"`
 			}
-			if err := json.Unmarshal(rawRuns, &workflowRuns); err != nil {
+			if err := json.Unmarshal(rawWorkflowRuns, &workflowRuns); err != nil {
 				log.Printf("[workflow-v2 github] decode workflow runs for %s: %v", target.Repository, err)
 				delete(checksByRepository, target.Repository)
 				continue

--- a/pkg/hub/workflow_v2_github_events.go
+++ b/pkg/hub/workflow_v2_github_events.go
@@ -1,0 +1,326 @@
+package hub
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/hub/workflowv2"
+	typesv2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
+)
+
+func (s *Server) processWorkflowV2GitHubPREvent(payload githubPRPayload) {
+	targets, err := workflowv2.NewStore(s.db).ActiveDeliveryTargets(context.Background(),
+		payload.Repository.FullName, payload.Number)
+	if err != nil {
+		log.Printf("[workflow-v2 github] find PR targets: %v", err)
+		return
+	}
+	for _, target := range targets {
+		workspace, err := typesv2.ParseAndValidateWorkspace([]byte(target.WorkspaceYAML))
+		if err != nil {
+			log.Printf("[workflow-v2 github] parse workspace for run %s: %v", target.RunID, err)
+			continue
+		}
+		verified, err := s.verifyWorkflowV2PullRequest(context.Background(), workflowv2.Run{}, workspace.Workspace,
+			typesv2.PullRequestClaim{URL: target.URL})
+		if err != nil {
+			log.Printf("[workflow-v2 github] verify %s#%d for run %s: %v",
+				payload.Repository.FullName, payload.Number, target.RunID, err)
+			continue
+		}
+		verified.ID = target.PRID
+		verified.Provenance.Principal = payload.Sender.Login
+		kind := workflowV2PullRequestEventKind(payload.Action, verified.State, verified.HeadSHA != target.HeadSHA)
+		if kind == "" {
+			continue
+		}
+		eventID := workflowV2GitHubEventID(target.RunID, "pull_request", payload.Action,
+			verified.Repository, strconv.Itoa(verified.Number), verified.HeadSHA, verified.State,
+			payload.PullRequest.UpdatedAt)
+		if _, err := workflowv2.NewStore(s.db).ReconcilePullRequest(context.Background(), target, eventID, kind, verified); err != nil {
+			log.Printf("[workflow-v2 github] reconcile %s#%d for run %s: %v",
+				payload.Repository.FullName, payload.Number, target.RunID, err)
+		}
+	}
+}
+
+func workflowV2PullRequestEventKind(action, state string, headChanged bool) string {
+	if state == "merged" {
+		return "pull_request.merged"
+	}
+	if state == "closed" {
+		return "pull_request.closed"
+	}
+	switch action {
+	case "opened", "reopened", "ready_for_review":
+		return "pull_request.verified_open"
+	case "synchronize":
+		if headChanged {
+			return "pull_request.head_changed"
+		}
+		return "pull_request.updated"
+	case "edited", "converted_to_draft":
+		return "pull_request.updated"
+	default:
+		return ""
+	}
+}
+
+func (s *Server) processWorkflowV2GitHubCheckEvent(event string, payload githubCheckPayload) {
+	if payload.Action != "completed" {
+		return
+	}
+	headSHA, numbers, _ := payload.checkEventSummary(event)
+	if headSHA == "" {
+		return
+	}
+	targets := make([]workflowv2.DeliveryTarget, 0)
+	seen := map[string]bool{}
+	store := workflowv2.NewStore(s.db)
+	for _, number := range numbers {
+		matched, err := store.ActiveDeliveryTargets(context.Background(), payload.Repository.FullName, number)
+		if err != nil {
+			log.Printf("[workflow-v2 github] find CI targets: %v", err)
+			return
+		}
+		for _, target := range matched {
+			if target.HeadSHA == headSHA && !seen[target.RunID+"\x00"+target.PRID] {
+				seen[target.RunID+"\x00"+target.PRID] = true
+				targets = append(targets, target)
+			}
+		}
+	}
+	if len(targets) == 0 {
+		matched, err := store.ActiveDeliveryTargetsByHead(context.Background(), headSHA)
+		if err != nil {
+			log.Printf("[workflow-v2 github] find CI targets by head: %v", err)
+			return
+		}
+		for _, target := range matched {
+			if !seen[target.RunID+"\x00"+target.PRID] {
+				seen[target.RunID+"\x00"+target.PRID] = true
+				targets = append(targets, target)
+			}
+		}
+	}
+	if len(targets) == 0 {
+		return
+	}
+	type githubCheck struct {
+		ID          int64  `json:"id"`
+		Name        string `json:"name"`
+		Status      string `json:"status"`
+		Conclusion  string `json:"conclusion"`
+		DetailsURL  string `json:"details_url"`
+		CompletedAt string `json:"completed_at"`
+	}
+	checksByRepository := map[string][]githubCheck{}
+	for _, target := range targets {
+		checks, loaded := checksByRepository[target.Repository]
+		if !loaded {
+			token := s.tokenForRepo(target.Repository)
+			if token == "" {
+				log.Printf("[workflow-v2 github] no repository-scoped token for CI %s", target.Repository)
+				continue
+			}
+			data, err := githubAPIWithBaseContext(context.Background(), s.ghBaseURL(),
+				fmt.Sprintf("repos/%s/commits/%s/check-runs?per_page=100", target.Repository, headSHA), token)
+			if err != nil {
+				log.Printf("[workflow-v2 github] reconcile checks for %s@%s: %v", target.Repository, headSHA, err)
+				continue
+			}
+			rawRuns, _ := json.Marshal(data["check_runs"])
+			if err := json.Unmarshal(rawRuns, &checks); err != nil {
+				log.Printf("[workflow-v2 github] decode check runs for %s: %v", target.Repository, err)
+				continue
+			}
+			checksByRepository[target.Repository] = checks
+		}
+		workspace, err := typesv2.ParseAndValidateWorkspace([]byte(target.WorkspaceYAML))
+		if err != nil || workspace.Workspace.CI == nil {
+			continue
+		}
+		evidenceInputs := make([]workflowv2.EvidenceInput, 0, len(checks))
+		for pipelineName, pipeline := range workspace.Workspace.CI.Pipelines {
+			if pipeline.Repository != target.RepositoryName {
+				continue
+			}
+			connection := workspace.Workspace.CI.Connections[pipeline.Connection]
+			if !strings.EqualFold(connection.Provider, "github_actions") {
+				continue
+			}
+			for _, check := range checks {
+				observed := parseGitHubTime(check.CompletedAt)
+				rawExternalID := strconv.FormatInt(check.ID, 10)
+				if check.ID == 0 {
+					rawExternalID = check.Name
+				}
+				externalID := pipelineName + ":" + rawExternalID
+				evidenceInputs = append(evidenceInputs, workflowv2.EvidenceInput{
+					RunID: target.RunID, PRID: target.PRID, HeadSHA: headSHA, Domain: "ci",
+					Connection: pipeline.Connection, ExternalID: externalID, Kind: check.Name,
+					Status: workflowV2GitHubCheckStatus(check.Status, check.Conclusion), ObservedAt: observed,
+					Payload: map[string]interface{}{"pipeline": pipelineName, "details_url": check.DetailsURL,
+						"github_status": check.Status, "github_conclusion": check.Conclusion},
+					Provenance: typesv2.EvidenceProvenance{Producer: string(workflowv2.ProducerCI),
+						Connection: pipeline.Connection, ExternalID: rawExternalID, ObservedAt: observed, Reconciled: true},
+				})
+			}
+		}
+		if len(evidenceInputs) > 0 {
+			if _, err := store.ReconcileEvidenceSet(context.Background(), evidenceInputs, workflowv2.ProducerCI); err != nil {
+				log.Printf("[workflow-v2 github] reconcile check snapshot for run %s: %v", target.RunID, err)
+			}
+		}
+	}
+}
+
+func workflowV2GitHubCheckStatus(status, conclusion string) string {
+	if !strings.EqualFold(status, "completed") {
+		return "pending"
+	}
+	switch strings.ToLower(strings.TrimSpace(conclusion)) {
+	case "success", "neutral", "skipped":
+		return "success"
+	case "":
+		return "pending"
+	default:
+		return strings.ToLower(strings.TrimSpace(conclusion))
+	}
+}
+
+func (s *Server) processWorkflowV2GitHubReviewEvent(payload githubPRReviewPayload) {
+	if payload.Action != "submitted" && payload.Action != "edited" && payload.Action != "dismissed" {
+		return
+	}
+	if !s.isHumanGitHubActor(payload.Review.User.Login, payload.Review.User.Type) {
+		return
+	}
+	targets, err := workflowv2.NewStore(s.db).ActiveDeliveryTargets(context.Background(),
+		payload.Repository.FullName, payload.PullRequest.Number)
+	if err != nil {
+		log.Printf("[workflow-v2 github] find review targets: %v", err)
+		return
+	}
+	for _, target := range targets {
+		status := strings.ToLower(strings.TrimSpace(payload.Review.State))
+		if payload.Action == "dismissed" {
+			status = "dismissed"
+		}
+		observed := now().UTC()
+		if status == "changes_requested" {
+			// Persist the typed feedback fact before review evidence can take a
+			// policy transition that schedules an include_facts agent task.
+			s.applyWorkflowV2GitHubFeedback(target, "review", payload.Review.ID, payload.Review.User.Login,
+				payload.Review.Body, payload.Review.HTMLURL, "", 0)
+		}
+		connections := workflowV2GitHubReviewConnections(target)
+		for _, connection := range connections {
+			_, err := workflowv2.NewStore(s.db).RecordEvidence(context.Background(), workflowv2.EvidenceInput{
+				RunID: target.RunID, PRID: target.PRID, HeadSHA: target.HeadSHA, Domain: "review",
+				Connection: connection, ExternalID: payload.Review.User.Login, Kind: "approval", Status: status,
+				ObservedAt: observed, Payload: map[string]interface{}{"review_id": payload.Review.ID,
+					"url": payload.Review.HTMLURL, "body": payload.Review.Body},
+				Provenance: typesv2.EvidenceProvenance{Producer: string(workflowv2.ProducerReview),
+					Connection: connection, Principal: payload.Review.User.Login,
+					ExternalID: strconv.FormatInt(payload.Review.ID, 10), ObservedAt: observed},
+			}, workflowv2.ProducerReview)
+			if err != nil {
+				log.Printf("[workflow-v2 github] record review for run %s: %v", target.RunID, err)
+			}
+		}
+	}
+}
+
+func (s *Server) processWorkflowV2GitHubReviewCommentEvent(payload githubPRReviewCommentPayload) {
+	if payload.Action != "created" || !s.isHumanGitHubActor(payload.Comment.User.Login, payload.Comment.User.Type) {
+		return
+	}
+	s.processWorkflowV2GitHubFeedbackTargets(payload.Repository.FullName, payload.PullRequest.Number,
+		"inline_comment", payload.Comment.ID, payload.Comment.User.Login, payload.Comment.Body,
+		payload.Comment.HTMLURL, payload.Comment.Path, payload.Comment.Line)
+}
+
+func (s *Server) processWorkflowV2GitHubIssueCommentEvent(payload githubIssueCommentPayload) {
+	if payload.Action != "created" || !s.isHumanGitHubActor(payload.Comment.User.Login, payload.Comment.User.Type) {
+		return
+	}
+	s.processWorkflowV2GitHubFeedbackTargets(payload.Repository.FullName, payload.Issue.Number,
+		"pull_request_comment", payload.Comment.ID, payload.Comment.User.Login, payload.Comment.Body,
+		payload.Comment.HTMLURL, "", 0)
+}
+
+func (s *Server) processWorkflowV2GitHubFeedbackTargets(repository string, number int, kind string, externalID int64,
+	author, body, url, path string, line int) {
+	targets, err := workflowv2.NewStore(s.db).ActiveDeliveryTargets(context.Background(), repository, number)
+	if err != nil {
+		log.Printf("[workflow-v2 github] find feedback targets: %v", err)
+		return
+	}
+	for _, target := range targets {
+		s.applyWorkflowV2GitHubFeedback(target, kind, externalID, author, body, url, path, line)
+	}
+}
+
+func (s *Server) applyWorkflowV2GitHubFeedback(target workflowv2.DeliveryTarget, kind string, externalID int64,
+	author, body, url, path string, line int) {
+	observed := now().UTC()
+	feedback := map[string]interface{}{"kind": kind, "author": author, "body": body, "url": url,
+		"repository": target.Repository, "number": target.Number, "pull_request_url": target.URL}
+	if path != "" {
+		feedback["path"] = path
+	}
+	if line > 0 {
+		feedback["line"] = line
+	}
+	eventID := workflowV2GitHubEventID(target.RunID, "review_feedback", kind,
+		strconv.FormatInt(externalID, 10), target.Repository, strconv.Itoa(target.Number))
+	_, err := workflowv2.NewStore(s.db).ApplyReviewFeedback(context.Background(), target, eventID, feedback,
+		typesv2.EvidenceProvenance{Producer: string(workflowv2.ProducerReview), Principal: author,
+			ExternalID: strconv.FormatInt(externalID, 10), ObservedAt: observed})
+	if err != nil {
+		log.Printf("[workflow-v2 github] apply feedback to run %s: %v", target.RunID, err)
+	}
+}
+
+func workflowV2GitHubReviewConnections(target workflowv2.DeliveryTarget) []string {
+	workspace, err := typesv2.ParseAndValidateWorkspace([]byte(target.WorkspaceYAML))
+	if err != nil || workspace.Workspace.ReviewSystems == nil {
+		return nil
+	}
+	repository := workspace.Workspace.Repositories[target.RepositoryName]
+	var connections []string
+	for name, connection := range workspace.Workspace.ReviewSystems.Connections {
+		if strings.EqualFold(connection.Provider, "github") &&
+			(connection.SourceControl == "" || connection.SourceControl == repository.SourceControl) {
+			connections = append(connections, name)
+		}
+	}
+	sort.Strings(connections)
+	return connections
+}
+
+func workflowV2GitHubEventID(runID string, parts ...string) string {
+	hash := sha256.New()
+	_, _ = hash.Write([]byte(runID))
+	for _, part := range parts {
+		_, _ = hash.Write([]byte{0})
+		_, _ = hash.Write([]byte(part))
+	}
+	return "github:" + hex.EncodeToString(hash.Sum(nil))
+}
+
+func parseGitHubTime(value string) time.Time {
+	if parsed, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(value)); err == nil {
+		return parsed.UTC()
+	}
+	return now().UTC()
+}

--- a/pkg/hub/workflow_v2_github_events_test.go
+++ b/pkg/hub/workflow_v2_github_events_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -95,12 +96,37 @@ func TestWorkflowV2GitHubCIAndReviewUseTypedRuntimeOnly(t *testing.T) {
 	http.DefaultTransport = githubAppTokenTransport{base: oldTransport}
 	t.Cleanup(func() { http.DefaultTransport = oldTransport })
 
+	var emptyChecks atomic.Bool
+	var staleReview atomic.Bool
 	gh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.URL.Path, "/check-runs") {
+			if emptyChecks.Load() {
+				_, _ = w.Write([]byte(`{"check_runs":[]}`))
+				return
+			}
 			_, _ = w.Write([]byte(`{"check_runs":[
-                {"id":101,"name":"lint","status":"completed","conclusion":"success","completed_at":"2026-08-09T12:00:00Z"},
-                {"id":102,"name":"unit","status":"completed","conclusion":"success","completed_at":"2026-08-09T12:00:01Z"}
-            ]}`))
+				{"id":101,"name":"lint","status":"completed","conclusion":"success","completed_at":"2026-08-09T12:00:00Z","app":{"slug":"github-actions"},"check_suite":{"id":501}},
+				{"id":102,"name":"unit","status":"completed","conclusion":"success","completed_at":"2026-08-09T12:00:01Z","app":{"slug":"github-actions"},"check_suite":{"id":501}},
+				{"id":103,"name":"lint","status":"completed","conclusion":"success","completed_at":"2026-08-09T12:00:02Z","app":{"slug":"untrusted-ci"},"check_suite":{"id":999}}
+			]}`))
+			return
+		}
+		if strings.Contains(r.URL.Path, "/actions/runs") {
+			_, _ = w.Write([]byte(`{"workflow_runs":[
+				{"name":"CI","path":".github/workflows/ci.yml","check_suite_id":501}
+			]}`))
+			return
+		}
+		if strings.Contains(r.URL.Path, "/pulls/10/reviews/77") {
+			commitID := "head-1"
+			if staleReview.Load() {
+				commitID = "old-head"
+			}
+			_, _ = w.Write([]byte(`{"id":77,"state":"CHANGES_REQUESTED",
+				"body":"Handle the nil response before dereferencing it.",
+				"html_url":"https://github.com/org/api/pull/10#pullrequestreview-77",
+				"commit_id":"` + commitID + `","submitted_at":"2026-08-09T12:01:00Z",
+				"user":{"login":"alice","type":"User"}}`))
 			return
 		}
 		http.NotFound(w, r)
@@ -162,6 +188,15 @@ func TestWorkflowV2GitHubCIAndReviewUseTypedRuntimeOnly(t *testing.T) {
 	if !policy.CISatisfied || policy.ReviewSatisfied {
 		t.Fatalf("policy after CI = %#v", policy)
 	}
+	emptyChecks.Store(true)
+	s.processGitHubCheckEvent("check_run", checkPayload)
+	policy, err = store.EvaluateDeliveryPolicy(context.Background(), run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if policy.CISatisfied || policy.CIStatus != "pending" {
+		t.Fatalf("empty authoritative check snapshot retained stale evidence: %#v", policy)
+	}
 
 	var review githubPRReviewPayload
 	review.Action = "submitted"
@@ -171,9 +206,22 @@ func TestWorkflowV2GitHubCIAndReviewUseTypedRuntimeOnly(t *testing.T) {
 	review.Review.HTMLURL = prURL + "#pullrequestreview-77"
 	review.Review.User.Login = "alice"
 	review.Review.User.Type = "User"
+	review.Review.CommitID = "head-1"
+	review.Review.SubmittedAt = "2026-08-09T12:01:00Z"
 	review.PullRequest.Number = 10
 	review.PullRequest.HTMLURL = prURL
 	review.Repository.FullName = "org/api"
+	staleReview.Store(true)
+	s.processGitHubPRReviewEvent(review)
+	var reviewEvidence int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_evidence WHERE run_id=? AND domain='review'`,
+		run.ID).Scan(&reviewEvidence); err != nil {
+		t.Fatal(err)
+	}
+	if reviewEvidence != 0 {
+		t.Fatalf("delayed old-head review created %d evidence rows", reviewEvidence)
+	}
+	staleReview.Store(false)
 	s.processGitHubPRReviewEvent(review)
 	if err := s.drainWorkflowV2Effects(context.Background(), "test-v2-github-worker"); err != nil {
 		t.Fatal(err)

--- a/pkg/hub/workflow_v2_github_events_test.go
+++ b/pkg/hub/workflow_v2_github_events_test.go
@@ -1,0 +1,204 @@
+package hub
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/hub/workflowv2"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+	typesv2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
+)
+
+const workflowV2GitHubWorkspaceYAML = `
+schema_version: 2
+name: github-v2
+repositories:
+  api:
+    provider: github
+    repository: org/api
+    source_control: github
+source_control:
+  connections:
+    github:
+      provider: github
+ci:
+  connections:
+    github-actions:
+      provider: github_actions
+      source_control: github
+  pipelines:
+    github-pr:
+      connection: github-actions
+      repository: api
+      workflow: ci.yml
+review_systems:
+  connections:
+    github-reviews:
+      provider: github
+      source_control: github
+`
+
+const workflowV2GitHubWorkflowYAML = `
+schema_version: 2
+name: github-delivery
+enabled: true
+initial_state: reviewing
+states:
+  reviewing:
+    phase: review
+  fixing:
+    phase: build
+    on_enter:
+      effects:
+        - agent.task:
+            prompt: Address the trusted review feedback and update the pull request.
+            include_facts: [review.feedback]
+transitions:
+  review_failed:
+    from: reviewing
+    on: review.policy.evaluated
+    when:
+      review:
+        status:
+          equals: unsatisfied
+    to: fixing
+ci:
+  policies:
+    merge-ready:
+      all:
+        - pipeline: github-pr
+          checks: [lint, unit]
+      satisfied_for: current_pr_head
+review:
+  policies:
+    required-review:
+      all:
+        - connection: github-reviews
+          approvals:
+            minimum: 1
+      invalidate_on_new_head: true
+delivery:
+  pull_requests:
+    required: true
+    minimum: 1
+    ci_policy: merge-ready
+    review_policy: required-review
+    completion: all_merged
+`
+
+func TestWorkflowV2GitHubCIAndReviewUseTypedRuntimeOnly(t *testing.T) {
+	oldTransport := http.DefaultTransport
+	http.DefaultTransport = githubAppTokenTransport{base: oldTransport}
+	t.Cleanup(func() { http.DefaultTransport = oldTransport })
+
+	gh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/check-runs") {
+			_, _ = w.Write([]byte(`{"check_runs":[
+                {"id":101,"name":"lint","status":"completed","conclusion":"success","completed_at":"2026-08-09T12:00:00Z"},
+                {"id":102,"name":"unit","status":"completed","conclusion":"success","completed_at":"2026-08-09T12:00:01Z"}
+            ]}`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(gh.Close)
+
+	cfg := &types.HubConfig{
+		ClawToken:  "claw-token",
+		GitHubApps: []*types.GitHubAppConfig{{AppID: 1, PrivateKeyPEM: testGitHubAppPEM(t)}},
+		Factories: []*types.FactoryConfig{{Name: "token-scope", Integration: "github", Template: "elasticclaw",
+			Provider: "noop", Repos: []string{"org/api"}, WebhookSecret: "secret",
+			Trigger: &types.GitHubTrigger{On: "pull_request"}}},
+		Providers: map[string]types.ProviderConfig{"noop": {Type: "noop"}},
+	}
+	s, db := NewTestServerWithConfig(t, cfg, gh.URL, "", "")
+	if _, err := db.Exec(`INSERT INTO claws(id,tenant_id,name,template,provider,status,created_at)
+		VALUES('claw-v2-github','test-tenant-id','v2-github','github-v2','noop','connected',?)`, now()); err != nil {
+		t.Fatal(err)
+	}
+	store := workflowv2.NewStore(db)
+	run, err := store.CreateRun(context.Background(), workflowv2.CreateRunRequest{
+		ID: "run-v2-github", TenantID: "test-tenant-id", InitialClawID: "claw-v2-github",
+		WorkspaceYAML: []byte(workflowV2GitHubWorkspaceYAML), WorkflowYAML: []byte(workflowV2GitHubWorkflowYAML),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	prURL := "https://github.com/org/api/pull/10"
+	verified, err := store.SubmitDelivery(context.Background(), run.ID, run.CurrentAttemptID, typesv2.DeliveryManifest{
+		PullRequests: []typesv2.PullRequestClaim{{URL: prURL}},
+	}, workflowv2.PullRequestVerifierFunc(func(context.Context, workflowv2.Run, *typesv2.Workspace,
+		typesv2.PullRequestClaim) (typesv2.VerifiedPullRequest, error) {
+		observed := time.Date(2026, 8, 9, 11, 59, 0, 0, time.UTC)
+		return typesv2.VerifiedPullRequest{URL: prURL, RepositoryName: "api", Repository: "org/api", Number: 10,
+			SourceBranch: "feature", BaseBranch: "main", HeadSHA: "head-1", State: "open", VerifiedAt: observed,
+			Provenance: typesv2.EvidenceProvenance{Producer: string(workflowv2.ProducerSourceControl),
+				Connection: "github", ObservedAt: observed}}, nil
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(verified) != 1 {
+		t.Fatalf("verified delivery = %#v", verified)
+	}
+
+	var checkPayload githubCheckPayload
+	checkPayload.Action = "completed"
+	checkPayload.CheckRun.HeadSHA = "head-1"
+	// GitHub omits pull_requests for some fork checks. V2 has no transcript
+	// fallback or legacy PR poller, so resolve the independently verified head.
+	checkPayload.Repository.FullName = "org/api"
+	// Exercise the shared webhook entrypoint: V2 consumes typed evidence while
+	// the unchanged V1 path remains inert because there is no legacy claw_pr row.
+	s.processGitHubCheckEvent("check_run", checkPayload)
+	policy, err := store.EvaluateDeliveryPolicy(context.Background(), run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !policy.CISatisfied || policy.ReviewSatisfied {
+		t.Fatalf("policy after CI = %#v", policy)
+	}
+
+	var review githubPRReviewPayload
+	review.Action = "submitted"
+	review.Review.ID = 77
+	review.Review.State = "changes_requested"
+	review.Review.Body = "Handle the nil response before dereferencing it."
+	review.Review.HTMLURL = prURL + "#pullrequestreview-77"
+	review.Review.User.Login = "alice"
+	review.Review.User.Type = "User"
+	review.PullRequest.Number = 10
+	review.PullRequest.HTMLURL = prURL
+	review.Repository.FullName = "org/api"
+	s.processGitHubPRReviewEvent(review)
+	if err := s.drainWorkflowV2Effects(context.Background(), "test-v2-github-worker"); err != nil {
+		t.Fatal(err)
+	}
+	var state, phase, instructions string
+	if err := db.QueryRow(`SELECT state,display_phase FROM workflow_v2_runs WHERE id=?`, run.ID).Scan(&state, &phase); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT instructions FROM workflow_v2_agent_tasks WHERE run_id=?`, run.ID).Scan(&instructions); err != nil {
+		t.Fatal(err)
+	}
+	if state != "fixing" || phase != "build" || !strings.Contains(instructions, "Handle the nil response") {
+		t.Fatalf("state/phase/instructions = %q/%q/%s", state, phase, instructions)
+	}
+	var evidence, outbox, messages int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_evidence WHERE run_id=?`, run.ID).Scan(&evidence); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_control_outbox WHERE run_id=?`, run.ID).Scan(&outbox); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id='claw-v2-github'`).Scan(&messages); err != nil {
+		t.Fatal(err)
+	}
+	if evidence != 3 || outbox != 1 || messages != 0 {
+		t.Fatalf("evidence/outbox/messages = %d/%d/%d", evidence, outbox, messages)
+	}
+}

--- a/pkg/hub/workflow_v2_github_events_test.go
+++ b/pkg/hub/workflow_v2_github_events_test.go
@@ -104,14 +104,27 @@ func TestWorkflowV2GitHubCIAndReviewUseTypedRuntimeOnly(t *testing.T) {
 				_, _ = w.Write([]byte(`{"check_runs":[]}`))
 				return
 			}
+			if r.URL.Query().Get("page") == "2" {
+				_, _ = w.Write([]byte(`{"check_runs":[
+					{"id":102,"name":"unit","status":"completed","conclusion":"success","completed_at":"2026-08-09T12:00:01Z","app":{"slug":"github-actions"},"check_suite":{"id":502}}
+				]}`))
+				return
+			}
+			w.Header().Set("Link", workflowV2GitHubTestNextLink(r))
 			_, _ = w.Write([]byte(`{"check_runs":[
 				{"id":101,"name":"lint","status":"completed","conclusion":"success","completed_at":"2026-08-09T12:00:00Z","app":{"slug":"github-actions"},"check_suite":{"id":501}},
-				{"id":102,"name":"unit","status":"completed","conclusion":"success","completed_at":"2026-08-09T12:00:01Z","app":{"slug":"github-actions"},"check_suite":{"id":501}},
 				{"id":103,"name":"lint","status":"completed","conclusion":"success","completed_at":"2026-08-09T12:00:02Z","app":{"slug":"untrusted-ci"},"check_suite":{"id":999}}
 			]}`))
 			return
 		}
 		if strings.Contains(r.URL.Path, "/actions/runs") {
+			if r.URL.Query().Get("page") == "2" {
+				_, _ = w.Write([]byte(`{"workflow_runs":[
+					{"name":"CI","path":".github/workflows/ci.yml","check_suite_id":502}
+				]}`))
+				return
+			}
+			w.Header().Set("Link", workflowV2GitHubTestNextLink(r))
 			_, _ = w.Write([]byte(`{"workflow_runs":[
 				{"name":"CI","path":".github/workflows/ci.yml","check_suite_id":501}
 			]}`))
@@ -249,4 +262,14 @@ func TestWorkflowV2GitHubCIAndReviewUseTypedRuntimeOnly(t *testing.T) {
 	if evidence != 3 || outbox != 1 || messages != 0 {
 		t.Fatalf("evidence/outbox/messages = %d/%d/%d", evidence, outbox, messages)
 	}
+}
+
+func workflowV2GitHubTestNextLink(r *http.Request) string {
+	next := *r.URL
+	query := next.Query()
+	query.Set("page", "2")
+	next.RawQuery = query.Encode()
+	next.Scheme = "http"
+	next.Host = r.Host
+	return "<" + next.String() + `>; rel="next"`
 }

--- a/pkg/hub/workflowv2/evidence.go
+++ b/pkg/hub/workflowv2/evidence.go
@@ -46,45 +46,87 @@ type DeliveryPolicyResult struct {
 // RecordEvidence accepts only adapter-owned evidence for the current verified
 // PR head, then recomputes the workflow's aggregate delivery policy.
 func (s *Store) RecordEvidence(ctx context.Context, input EvidenceInput, producer Producer) (DeliveryPolicyResult, error) {
+	return s.recordEvidenceSet(ctx, []EvidenceInput{input}, producer, false)
+}
+
+// ReconcileEvidenceSet atomically replaces the current adapter-owned evidence
+// represented by one snapshot and publishes policy events only after every
+// sibling observation is durable. CI adapters use this to avoid evaluating a
+// transient mixture of old and new check results.
+func (s *Store) ReconcileEvidenceSet(ctx context.Context, inputs []EvidenceInput,
+	producer Producer) (DeliveryPolicyResult, error) {
+	return s.recordEvidenceSet(ctx, inputs, producer, true)
+}
+
+func (s *Store) recordEvidenceSet(ctx context.Context, inputs []EvidenceInput, producer Producer,
+	reconcile bool) (DeliveryPolicyResult, error) {
 	if s == nil || s.db == nil {
 		return DeliveryPolicyResult{}, fmt.Errorf("workflow v2 store is not configured")
 	}
-	input.Domain = strings.ToLower(strings.TrimSpace(input.Domain))
-	input.Connection = strings.TrimSpace(input.Connection)
-	input.ExternalID = strings.TrimSpace(input.ExternalID)
-	input.Kind = strings.TrimSpace(input.Kind)
-	input.Status = strings.ToLower(strings.TrimSpace(input.Status))
-	if err := validateEvidenceProducer(input.Domain, producer); err != nil {
-		return DeliveryPolicyResult{}, err
+	if len(inputs) == 0 {
+		return DeliveryPolicyResult{}, fmt.Errorf("evidence set must not be empty")
 	}
-	if input.RunID == "" || input.PRID == "" || input.HeadSHA == "" || input.ExternalID == "" || input.Kind == "" || input.Status == "" {
-		return DeliveryPolicyResult{}, fmt.Errorf("run, pull request, head, external id, kind, and status are required")
+	type preparedEvidence struct {
+		input          EvidenceInput
+		id             string
+		payloadJSON    []byte
+		provenanceJSON string
+		observed       time.Time
+		pipeline       string
 	}
-	if strings.TrimSpace(input.Provenance.Producer) != string(producer) {
-		return DeliveryPolicyResult{}, fmt.Errorf("evidence provenance producer %q does not match trusted adapter %q",
-			input.Provenance.Producer, producer)
-	}
-	observed := input.ObservedAt.UTC()
-	if observed.IsZero() {
-		observed = s.now().UTC()
-	}
-	if input.Provenance.ObservedAt.IsZero() {
-		input.Provenance.ObservedAt = observed
-	}
-	payloadJSON, err := json.Marshal(input.Payload)
-	if err != nil {
-		return DeliveryPolicyResult{}, err
-	}
-	if input.Payload == nil {
-		payloadJSON = []byte("{}")
-	}
-	provenanceJSON, err := marshalObject(input.Provenance)
-	if err != nil {
-		return DeliveryPolicyResult{}, err
-	}
-	id := strings.TrimSpace(input.ID)
-	if id == "" {
-		id = uuid.NewString()
+	prepared := make([]preparedEvidence, 0, len(inputs))
+	var runID, prID, headSHA, domain string
+	observed := time.Time{}
+	for index, raw := range inputs {
+		input := raw
+		input.Domain = strings.ToLower(strings.TrimSpace(input.Domain))
+		input.Connection = strings.TrimSpace(input.Connection)
+		input.ExternalID = strings.TrimSpace(input.ExternalID)
+		input.Kind = strings.TrimSpace(input.Kind)
+		input.Status = strings.ToLower(strings.TrimSpace(input.Status))
+		if err := validateEvidenceProducer(input.Domain, producer); err != nil {
+			return DeliveryPolicyResult{}, err
+		}
+		if input.RunID == "" || input.PRID == "" || input.HeadSHA == "" || input.ExternalID == "" || input.Kind == "" || input.Status == "" {
+			return DeliveryPolicyResult{}, fmt.Errorf("evidence[%d]: run, pull request, head, external id, kind, and status are required", index)
+		}
+		if index == 0 {
+			runID, prID, headSHA, domain = input.RunID, input.PRID, input.HeadSHA, input.Domain
+		} else if input.RunID != runID || input.PRID != prID || input.HeadSHA != headSHA || input.Domain != domain {
+			return DeliveryPolicyResult{}, fmt.Errorf("evidence set must share run, pull request, head, and domain")
+		}
+		if strings.TrimSpace(input.Provenance.Producer) != string(producer) {
+			return DeliveryPolicyResult{}, fmt.Errorf("evidence provenance producer %q does not match trusted adapter %q",
+				input.Provenance.Producer, producer)
+		}
+		itemObserved := input.ObservedAt.UTC()
+		if itemObserved.IsZero() {
+			itemObserved = s.now().UTC()
+		}
+		if observed.IsZero() || itemObserved.After(observed) {
+			observed = itemObserved
+		}
+		if input.Provenance.ObservedAt.IsZero() {
+			input.Provenance.ObservedAt = itemObserved
+		}
+		payloadJSON, err := json.Marshal(input.Payload)
+		if err != nil {
+			return DeliveryPolicyResult{}, err
+		}
+		if input.Payload == nil {
+			payloadJSON = []byte("{}")
+		}
+		provenanceJSON, err := marshalObject(input.Provenance)
+		if err != nil {
+			return DeliveryPolicyResult{}, err
+		}
+		id := strings.TrimSpace(input.ID)
+		if id == "" {
+			id = uuid.NewString()
+		}
+		pipeline, _ := input.Payload["pipeline"].(string)
+		prepared = append(prepared, preparedEvidence{input: input, id: id, payloadJSON: payloadJSON,
+			provenanceJSON: provenanceJSON, observed: itemObserved, pipeline: strings.TrimSpace(pipeline)})
 	}
 	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
 	if err != nil {
@@ -95,32 +137,60 @@ func (s *Store) RecordEvidence(ctx context.Context, input EvidenceInput, produce
 	var headGeneration int
 	if err := tx.QueryRowContext(ctx, `SELECT p.current_head_sha,COALESCE(MAX(h.generation),0)
 		FROM workflow_v2_delivery_prs p LEFT JOIN workflow_v2_delivery_heads h ON h.pr_id=p.id
-		WHERE p.id=? AND p.run_id=? AND p.active=1 GROUP BY p.id`, input.PRID, input.RunID).Scan(
+		WHERE p.id=? AND p.run_id=? AND p.active=1 GROUP BY p.id`, prID, runID).Scan(
 		&currentHead, &headGeneration); err != nil {
 		return DeliveryPolicyResult{}, fmt.Errorf("load active delivery: %w", err)
 	}
-	if currentHead != input.HeadSHA {
-		return DeliveryPolicyResult{}, fmt.Errorf("evidence head %s is stale; current head is %s", input.HeadSHA, currentHead)
+	if currentHead != headSHA {
+		return DeliveryPolicyResult{}, fmt.Errorf("evidence head %s is stale; current head is %s", headSHA, currentHead)
 	}
 	if headGeneration < 1 {
 		return DeliveryPolicyResult{}, fmt.Errorf("active delivery has no verified head generation")
 	}
-	_, err = tx.ExecContext(ctx, `INSERT INTO workflow_v2_evidence(
-		id,run_id,pr_id,head_sha,head_generation,domain,connection,external_id,kind,status,payload_json,provenance_json,observed_at)
-		VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?)
-		ON CONFLICT(run_id,pr_id,domain,connection,external_id,kind,head_generation) DO UPDATE SET
-		status=excluded.status,payload_json=excluded.payload_json,provenance_json=excluded.provenance_json,
-		observed_at=excluded.observed_at,superseded_at=0
-		WHERE excluded.observed_at>=workflow_v2_evidence.observed_at`, id, input.RunID, input.PRID, input.HeadSHA,
-		headGeneration, input.Domain, input.Connection, input.ExternalID, input.Kind, input.Status, string(payloadJSON),
-		provenanceJSON, observed.UnixMilli())
-	if err != nil {
-		return DeliveryPolicyResult{}, err
+	if reconcile {
+		seenSubjects := map[string]bool{}
+		reconciledAt := s.now().UTC().UnixMilli()
+		for _, item := range prepared {
+			subject := item.input.Connection + "\x00" + item.pipeline
+			if seenSubjects[subject] {
+				continue
+			}
+			seenSubjects[subject] = true
+			if item.pipeline != "" {
+				_, err = tx.ExecContext(ctx, `UPDATE workflow_v2_evidence SET superseded_at=?
+					WHERE run_id=? AND pr_id=? AND head_generation=? AND domain=? AND connection=?
+					AND json_extract(payload_json,'$.pipeline')=? AND superseded_at=0 AND observed_at<=?`, reconciledAt,
+					runID, prID, headGeneration, domain, item.input.Connection, item.pipeline, observed.UnixMilli())
+			} else {
+				_, err = tx.ExecContext(ctx, `UPDATE workflow_v2_evidence SET superseded_at=?
+					WHERE run_id=? AND pr_id=? AND head_generation=? AND domain=? AND connection=?
+					AND superseded_at=0 AND observed_at<=?`, reconciledAt, runID, prID, headGeneration, domain,
+					item.input.Connection, observed.UnixMilli())
+			}
+			if err != nil {
+				return DeliveryPolicyResult{}, err
+			}
+		}
+	}
+	for _, item := range prepared {
+		input := item.input
+		_, err = tx.ExecContext(ctx, `INSERT INTO workflow_v2_evidence(
+			id,run_id,pr_id,head_sha,head_generation,domain,connection,external_id,kind,status,payload_json,provenance_json,observed_at)
+			VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?)
+			ON CONFLICT(run_id,pr_id,domain,connection,external_id,kind,head_generation) DO UPDATE SET
+			status=excluded.status,payload_json=excluded.payload_json,provenance_json=excluded.provenance_json,
+			observed_at=excluded.observed_at,superseded_at=0
+			WHERE excluded.observed_at>=workflow_v2_evidence.observed_at`, item.id, runID, prID, headSHA,
+			headGeneration, domain, input.Connection, input.ExternalID, input.Kind, input.Status, string(item.payloadJSON),
+			item.provenanceJSON, item.observed.UnixMilli())
+		if err != nil {
+			return DeliveryPolicyResult{}, err
+		}
 	}
 	if err := tx.Commit(); err != nil {
 		return DeliveryPolicyResult{}, err
 	}
-	return s.evaluateAndPublishDeliveryPolicy(ctx, input.RunID, "", input.Domain, observed)
+	return s.evaluateAndPublishDeliveryPolicy(ctx, runID, "", domain, observed)
 }
 
 var errDeliveryPolicyChanged = errors.New("delivery policy inputs changed before publication")

--- a/pkg/hub/workflowv2/evidence.go
+++ b/pkg/hub/workflowv2/evidence.go
@@ -31,6 +31,17 @@ type EvidenceInput struct {
 	ObservedAt time.Time
 }
 
+// EvidenceScope identifies the authoritative subject set replaced by one
+// reconciliation snapshot. Pipeline is required for pipeline-scoped CI data.
+type EvidenceScope struct {
+	RunID      string
+	PRID       string
+	HeadSHA    string
+	Domain     string
+	Connection string
+	Pipeline   string
+}
+
 type DeliveryPolicyResult struct {
 	Revision         string `json:"revision"`
 	PullRequestCount int    `json:"pull_request_count"`
@@ -46,7 +57,7 @@ type DeliveryPolicyResult struct {
 // RecordEvidence accepts only adapter-owned evidence for the current verified
 // PR head, then recomputes the workflow's aggregate delivery policy.
 func (s *Store) RecordEvidence(ctx context.Context, input EvidenceInput, producer Producer) (DeliveryPolicyResult, error) {
-	return s.recordEvidenceSet(ctx, []EvidenceInput{input}, producer, false)
+	return s.recordEvidenceSet(ctx, nil, []EvidenceInput{input}, producer, false)
 }
 
 // ReconcileEvidenceSet atomically replaces the current adapter-owned evidence
@@ -55,15 +66,38 @@ func (s *Store) RecordEvidence(ctx context.Context, input EvidenceInput, produce
 // transient mixture of old and new check results.
 func (s *Store) ReconcileEvidenceSet(ctx context.Context, inputs []EvidenceInput,
 	producer Producer) (DeliveryPolicyResult, error) {
-	return s.recordEvidenceSet(ctx, inputs, producer, true)
+	if len(inputs) == 0 {
+		return DeliveryPolicyResult{}, fmt.Errorf("evidence set must not be empty without explicit scopes")
+	}
+	scopes := make([]EvidenceScope, 0, len(inputs))
+	seen := map[string]bool{}
+	for _, input := range inputs {
+		pipeline, _ := input.Payload["pipeline"].(string)
+		scope := EvidenceScope{RunID: input.RunID, PRID: input.PRID, HeadSHA: input.HeadSHA,
+			Domain: input.Domain, Connection: input.Connection, Pipeline: strings.TrimSpace(pipeline)}
+		key := scope.Connection + "\x00" + scope.Pipeline
+		if !seen[key] {
+			seen[key] = true
+			scopes = append(scopes, scope)
+		}
+	}
+	return s.recordEvidenceSet(ctx, scopes, inputs, producer, true)
 }
 
-func (s *Store) recordEvidenceSet(ctx context.Context, inputs []EvidenceInput, producer Producer,
+// ReconcileEvidenceSnapshot replaces explicit scopes even when a provider
+// returns no observations, ensuring an empty authoritative snapshot clears
+// stale success or failure evidence atomically.
+func (s *Store) ReconcileEvidenceSnapshot(ctx context.Context, scopes []EvidenceScope, inputs []EvidenceInput,
+	producer Producer) (DeliveryPolicyResult, error) {
+	return s.recordEvidenceSet(ctx, scopes, inputs, producer, true)
+}
+
+func (s *Store) recordEvidenceSet(ctx context.Context, scopes []EvidenceScope, inputs []EvidenceInput, producer Producer,
 	reconcile bool) (DeliveryPolicyResult, error) {
 	if s == nil || s.db == nil {
 		return DeliveryPolicyResult{}, fmt.Errorf("workflow v2 store is not configured")
 	}
-	if len(inputs) == 0 {
+	if len(inputs) == 0 && len(scopes) == 0 {
 		return DeliveryPolicyResult{}, fmt.Errorf("evidence set must not be empty")
 	}
 	type preparedEvidence struct {
@@ -76,6 +110,28 @@ func (s *Store) recordEvidenceSet(ctx context.Context, inputs []EvidenceInput, p
 	}
 	prepared := make([]preparedEvidence, 0, len(inputs))
 	var runID, prID, headSHA, domain string
+	if len(scopes) > 0 {
+		for index := range scopes {
+			scope := &scopes[index]
+			scope.RunID = strings.TrimSpace(scope.RunID)
+			scope.PRID = strings.TrimSpace(scope.PRID)
+			scope.HeadSHA = strings.TrimSpace(scope.HeadSHA)
+			scope.Domain = strings.ToLower(strings.TrimSpace(scope.Domain))
+			scope.Connection = strings.TrimSpace(scope.Connection)
+			scope.Pipeline = strings.TrimSpace(scope.Pipeline)
+			if scope.RunID == "" || scope.PRID == "" || scope.HeadSHA == "" || scope.Domain == "" || scope.Connection == "" {
+				return DeliveryPolicyResult{}, fmt.Errorf("evidence scope[%d]: run, pull request, head, domain, and connection are required", index)
+			}
+			if err := validateEvidenceProducer(scope.Domain, producer); err != nil {
+				return DeliveryPolicyResult{}, err
+			}
+			if index == 0 {
+				runID, prID, headSHA, domain = scope.RunID, scope.PRID, scope.HeadSHA, scope.Domain
+			} else if scope.RunID != runID || scope.PRID != prID || scope.HeadSHA != headSHA || scope.Domain != domain {
+				return DeliveryPolicyResult{}, fmt.Errorf("evidence scopes must share run, pull request, head, and domain")
+			}
+		}
+	}
 	observed := time.Time{}
 	for index, raw := range inputs {
 		input := raw
@@ -90,7 +146,7 @@ func (s *Store) recordEvidenceSet(ctx context.Context, inputs []EvidenceInput, p
 		if input.RunID == "" || input.PRID == "" || input.HeadSHA == "" || input.ExternalID == "" || input.Kind == "" || input.Status == "" {
 			return DeliveryPolicyResult{}, fmt.Errorf("evidence[%d]: run, pull request, head, external id, kind, and status are required", index)
 		}
-		if index == 0 {
+		if runID == "" {
 			runID, prID, headSHA, domain = input.RunID, input.PRID, input.HeadSHA, input.Domain
 		} else if input.RunID != runID || input.PRID != prID || input.HeadSHA != headSHA || input.Domain != domain {
 			return DeliveryPolicyResult{}, fmt.Errorf("evidence set must share run, pull request, head, and domain")
@@ -128,6 +184,20 @@ func (s *Store) recordEvidenceSet(ctx context.Context, inputs []EvidenceInput, p
 		prepared = append(prepared, preparedEvidence{input: input, id: id, payloadJSON: payloadJSON,
 			provenanceJSON: provenanceJSON, observed: itemObserved, pipeline: strings.TrimSpace(pipeline)})
 	}
+	if observed.IsZero() {
+		observed = s.now().UTC()
+	}
+	if reconcile {
+		allowedScopes := map[string]bool{}
+		for _, scope := range scopes {
+			allowedScopes[scope.Connection+"\x00"+scope.Pipeline] = true
+		}
+		for _, item := range prepared {
+			if !allowedScopes[item.input.Connection+"\x00"+item.pipeline] {
+				return DeliveryPolicyResult{}, fmt.Errorf("evidence input is outside its reconciliation scopes")
+			}
+		}
+	}
 	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
 	if err != nil {
 		return DeliveryPolicyResult{}, err
@@ -148,24 +218,18 @@ func (s *Store) recordEvidenceSet(ctx context.Context, inputs []EvidenceInput, p
 		return DeliveryPolicyResult{}, fmt.Errorf("active delivery has no verified head generation")
 	}
 	if reconcile {
-		seenSubjects := map[string]bool{}
 		reconciledAt := s.now().UTC().UnixMilli()
-		for _, item := range prepared {
-			subject := item.input.Connection + "\x00" + item.pipeline
-			if seenSubjects[subject] {
-				continue
-			}
-			seenSubjects[subject] = true
-			if item.pipeline != "" {
+		for _, scope := range scopes {
+			if scope.Pipeline != "" {
 				_, err = tx.ExecContext(ctx, `UPDATE workflow_v2_evidence SET superseded_at=?
 					WHERE run_id=? AND pr_id=? AND head_generation=? AND domain=? AND connection=?
 					AND json_extract(payload_json,'$.pipeline')=? AND superseded_at=0 AND observed_at<=?`, reconciledAt,
-					runID, prID, headGeneration, domain, item.input.Connection, item.pipeline, observed.UnixMilli())
+					runID, prID, headGeneration, domain, scope.Connection, scope.Pipeline, observed.UnixMilli())
 			} else {
 				_, err = tx.ExecContext(ctx, `UPDATE workflow_v2_evidence SET superseded_at=?
 					WHERE run_id=? AND pr_id=? AND head_generation=? AND domain=? AND connection=?
 					AND superseded_at=0 AND observed_at<=?`, reconciledAt, runID, prID, headGeneration, domain,
-					item.input.Connection, observed.UnixMilli())
+					scope.Connection, observed.UnixMilli())
 			}
 			if err != nil {
 				return DeliveryPolicyResult{}, err

--- a/pkg/hub/workflowv2/evidence_test.go
+++ b/pkg/hub/workflowv2/evidence_test.go
@@ -2,6 +2,7 @@ package workflowv2_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -47,7 +48,20 @@ states:
     phase: review
   fixing:
     phase: build
+    on_enter:
+      effects:
+        - agent.task:
+            prompt: Address the trusted review feedback.
+            include_facts: [review.feedback]
 transitions:
+  ci_failed:
+    from: reviewing
+    on: ci.policy.evaluated
+    when:
+      ci:
+        status:
+          equals: unsatisfied
+    to: fixing
   review_failed:
     from: reviewing
     on: review.policy.evaluated
@@ -166,6 +180,37 @@ func TestUnsatisfiedReviewLoopsBackToBuild(t *testing.T) {
 	}
 }
 
+func TestTypedReviewFeedbackIsIncludedInFixTask(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	attempt, pr := createPolicyDelivery(t, store, "run-review-feedback", "head-1", "open")
+	feedback := map[string]interface{}{"author": "alice", "body": "Handle the nil response before dereferencing it.",
+		"url": "https://github.example/org/api/pull/10#discussion_r1"}
+	if _, err := store.ApplyReviewFeedback(context.Background(), workflowv2.DeliveryTarget{
+		RunID: "run-review-feedback", AttemptID: attempt.ID, PRID: pr.ID, Repository: pr.Repository,
+		RepositoryName: pr.RepositoryName, Number: pr.Number, URL: pr.URL, HeadSHA: pr.HeadSHA,
+	}, "feedback-1", feedback, typesv2.EvidenceProvenance{
+		Producer: string(workflowv2.ProducerReview), Principal: "alice", ObservedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	recordPolicyEvidence(t, store, "run-review-feedback", pr, "review", "github-reviews", "alice", "approval",
+		"changes_requested", nil, workflowv2.ProducerReview)
+	claim, err := store.ClaimEffect(context.Background(), "feedback-worker", time.Minute)
+	if err != nil || claim == nil {
+		t.Fatalf("claim = %#v, %v", claim, err)
+	}
+	task, err := store.MaterializeAgentTask(context.Background(), claim.Effect.ID, claim.AttemptID,
+		"feedback-worker", time.Minute, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(task.Instructions, "Handle the nil response") ||
+		!strings.Contains(task.Instructions, `"review.feedback"`) {
+		t.Fatalf("task instructions = %s", task.Instructions)
+	}
+}
+
 func TestEvidenceForOldHeadIsRejectedAndInvalidated(t *testing.T) {
 	db := openRuntimeDB(t)
 	store := workflowv2.NewStore(db)
@@ -231,6 +276,99 @@ func TestEvidenceForOldHeadIsRejectedAndInvalidated(t *testing.T) {
 	}
 }
 
+func TestTrustedPullRequestReconciliationInvalidatesOldHeadEvidence(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	_, pr := createPolicyDelivery(t, store, "run-pr-reconcile", "head-1", "open")
+	recordPolicyEvidence(t, store, "run-pr-reconcile", pr, "ci", "github-actions", "lint-1", "lint", "success",
+		map[string]interface{}{"pipeline": "github-pr"}, workflowv2.ProducerCI)
+	targets, err := store.ActiveDeliveryTargets(context.Background(), "org/api", 10)
+	if err != nil || len(targets) != 1 {
+		t.Fatalf("targets = %#v, %v", targets, err)
+	}
+	observed := time.Date(2026, 8, 8, 12, 6, 0, 0, time.UTC)
+	reconciled := typesv2.VerifiedPullRequest{
+		ID: pr.ID, URL: pr.URL, RepositoryName: "api", Repository: "org/api", Number: 10,
+		SourceBranch: "feature", BaseBranch: "main", HeadSHA: "head-2", State: "open", VerifiedAt: observed,
+		Provenance: typesv2.EvidenceProvenance{Producer: string(workflowv2.ProducerSourceControl),
+			Connection: "github", ObservedAt: observed},
+	}
+	event, err := store.ReconcilePullRequest(context.Background(), targets[0], "github-sync-1",
+		"pull_request.head_changed", reconciled)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if event.Disposition != typesv2.DispositionAccepted {
+		t.Fatalf("event = %#v", event)
+	}
+	var head string
+	var generations, currentEvidence, supersededEvidence int
+	if err := db.QueryRow(`SELECT current_head_sha FROM workflow_v2_delivery_prs WHERE id=?`, pr.ID).Scan(&head); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_delivery_heads WHERE pr_id=?`, pr.ID).Scan(&generations); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_evidence WHERE pr_id=? AND superseded_at=0`, pr.ID).Scan(&currentEvidence); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_evidence WHERE pr_id=? AND superseded_at>0`, pr.ID).Scan(&supersededEvidence); err != nil {
+		t.Fatal(err)
+	}
+	if head != "head-2" || generations != 2 || currentEvidence != 0 || supersededEvidence != 1 {
+		t.Fatalf("head/generations/current/superseded = %q/%d/%d/%d", head, generations, currentEvidence, supersededEvidence)
+	}
+}
+
+func TestSuspendedRunsAreNotExternalDeliveryTargets(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	_, pr := createPolicyDelivery(t, store, "run-suspended-target", "head-1", "open")
+	if _, err := db.Exec(`UPDATE workflow_v2_runs SET status='suspended',waiting_reason='operator review'
+		WHERE id='run-suspended-target'`); err != nil {
+		t.Fatal(err)
+	}
+	byPR, err := store.ActiveDeliveryTargets(context.Background(), pr.Repository, pr.Number)
+	if err != nil {
+		t.Fatal(err)
+	}
+	byHead, err := store.ActiveDeliveryTargetsByHead(context.Background(), pr.HeadSHA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(byPR) != 0 || len(byHead) != 0 {
+		t.Fatalf("suspended targets by PR/head = %#v/%#v", byPR, byHead)
+	}
+}
+
+func TestReviewFeedbackRejectsStaleDeliveryHead(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	_, pr := createPolicyDelivery(t, store, "run-stale-feedback", "head-1", "open")
+	targets, err := store.ActiveDeliveryTargets(context.Background(), pr.Repository, pr.Number)
+	if err != nil || len(targets) != 1 {
+		t.Fatalf("targets = %#v, %v", targets, err)
+	}
+	if _, err := db.Exec(`UPDATE workflow_v2_delivery_prs SET current_head_sha='head-2' WHERE id=?`, pr.ID); err != nil {
+		t.Fatal(err)
+	}
+	_, err = store.ApplyReviewFeedback(context.Background(), targets[0], "stale-feedback",
+		map[string]interface{}{"body": "old head comment"}, typesv2.EvidenceProvenance{
+			Producer: string(workflowv2.ProducerReview), Principal: "alice", ObservedAt: time.Now().UTC(),
+		})
+	if err == nil || !strings.Contains(err.Error(), "stale") {
+		t.Fatalf("error = %v, want stale head rejection", err)
+	}
+	var events int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_events WHERE run_id=? AND id='stale-feedback'`,
+		"run-stale-feedback").Scan(&events); err != nil {
+		t.Fatal(err)
+	}
+	if events != 0 {
+		t.Fatalf("events = %d", events)
+	}
+}
+
 func TestCIPolicyUsesLatestCheckObservation(t *testing.T) {
 	db := openRuntimeDB(t)
 	store := workflowv2.NewStore(db)
@@ -261,6 +399,69 @@ func TestCIPolicyUsesLatestCheckObservation(t *testing.T) {
 	failed := record("lint-newest", "lint", "failure", base.Add(2*time.Minute))
 	if failed.CISatisfied || failed.CIStatus != "unsatisfied" {
 		t.Fatalf("newest failure did not fail policy: %#v", failed)
+	}
+}
+
+func TestReconciledCheckSetCannotTransitionOnMixedSnapshot(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	_, pr := createPolicyDelivery(t, store, "run-atomic-ci-snapshot", "head-1", "open")
+	old := time.Date(2026, 8, 8, 12, 1, 0, 0, time.UTC)
+	if _, err := db.Exec(`INSERT INTO workflow_v2_evidence(
+		id,run_id,pr_id,head_sha,head_generation,domain,connection,external_id,kind,status,
+		payload_json,provenance_json,observed_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		"old-unit", "run-atomic-ci-snapshot", pr.ID, pr.HeadSHA, 1, "ci", "github-actions",
+		"github-pr:old-unit", "unit", "failure", `{"pipeline":"github-pr"}`,
+		`{"producer":"ci","observed_at":"2026-08-08T12:01:00Z"}`, old.UnixMilli()); err != nil {
+		t.Fatal(err)
+	}
+	current := old.Add(time.Minute)
+	input := func(externalID, kind, status string) workflowv2.EvidenceInput {
+		return workflowv2.EvidenceInput{RunID: "run-atomic-ci-snapshot", PRID: pr.ID, HeadSHA: pr.HeadSHA,
+			Domain: "ci", Connection: "github-actions", ExternalID: "github-pr:" + externalID,
+			Kind: kind, Status: status, Payload: map[string]interface{}{"pipeline": "github-pr"},
+			ObservedAt: current, Provenance: typesv2.EvidenceProvenance{Producer: string(workflowv2.ProducerCI),
+				Connection: "github-actions", ExternalID: externalID, ObservedAt: current, Reconciled: true}}
+	}
+	result, err := store.ReconcileEvidenceSet(context.Background(), []workflowv2.EvidenceInput{
+		input("lint", "lint", "success"), input("unit", "unit", "pending"),
+	}, workflowv2.ProducerCI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := store.GetRun(context.Background(), "run-atomic-ci-snapshot")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.CIStatus != "pending" || run.State != "reviewing" || run.StateVersion != 1 {
+		t.Fatalf("policy/run = %#v/%#v", result, run)
+	}
+	var currentRows, supersededRows int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_evidence WHERE run_id=? AND superseded_at=0`,
+		run.ID).Scan(&currentRows); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_evidence WHERE run_id=? AND superseded_at>0`,
+		run.ID).Scan(&supersededRows); err != nil {
+		t.Fatal(err)
+	}
+	if currentRows != 2 || supersededRows != 1 {
+		t.Fatalf("current/superseded evidence = %d/%d", currentRows, supersededRows)
+	}
+	olderInput := func(externalID, kind string) workflowv2.EvidenceInput {
+		item := input(externalID, kind, "failure")
+		item.ObservedAt = old
+		item.Provenance.ObservedAt = old
+		return item
+	}
+	result, err = store.ReconcileEvidenceSet(context.Background(), []workflowv2.EvidenceInput{
+		olderInput("lint", "lint"), olderInput("unit", "unit"),
+	}, workflowv2.ProducerCI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.CIStatus != "pending" {
+		t.Fatalf("out-of-order snapshot regressed policy: %#v", result)
 	}
 }
 

--- a/pkg/hub/workflowv2/evidence_test.go
+++ b/pkg/hub/workflowv2/evidence_test.go
@@ -186,13 +186,21 @@ func TestTypedReviewFeedbackIsIncludedInFixTask(t *testing.T) {
 	attempt, pr := createPolicyDelivery(t, store, "run-review-feedback", "head-1", "open")
 	feedback := map[string]interface{}{"author": "alice", "body": "Handle the nil response before dereferencing it.",
 		"url": "https://github.example/org/api/pull/10#discussion_r1"}
-	if _, err := store.ApplyReviewFeedback(context.Background(), workflowv2.DeliveryTarget{
+	observed := time.Date(2026, 8, 8, 12, 10, 0, 0, time.UTC)
+	target := workflowv2.DeliveryTarget{
 		RunID: "run-review-feedback", AttemptID: attempt.ID, PRID: pr.ID, Repository: pr.Repository,
 		RepositoryName: pr.RepositoryName, Number: pr.Number, URL: pr.URL, HeadSHA: pr.HeadSHA,
-	}, "feedback-1", feedback, typesv2.EvidenceProvenance{
-		Producer: string(workflowv2.ProducerReview), Principal: "alice", ObservedAt: time.Now().UTC(),
+	}
+	if _, err := store.ApplyReviewFeedback(context.Background(), target, "feedback-1", feedback, typesv2.EvidenceProvenance{
+		Producer: string(workflowv2.ProducerReview), Principal: "alice", ObservedAt: observed,
 	}); err != nil {
 		t.Fatal(err)
+	}
+	if _, err := store.ApplyReviewFeedback(context.Background(), target, "feedback-older",
+		map[string]interface{}{"body": "obsolete feedback"}, typesv2.EvidenceProvenance{
+			Producer: string(workflowv2.ProducerReview), Principal: "alice", ObservedAt: observed.Add(-time.Minute),
+		}); err == nil || !strings.Contains(err.Error(), "older") {
+		t.Fatalf("out-of-order feedback error = %v", err)
 	}
 	recordPolicyEvidence(t, store, "run-review-feedback", pr, "review", "github-reviews", "alice", "approval",
 		"changes_requested", nil, workflowv2.ProducerReview)
@@ -462,6 +470,23 @@ func TestReconciledCheckSetCannotTransitionOnMixedSnapshot(t *testing.T) {
 	}
 	if result.CIStatus != "pending" {
 		t.Fatalf("out-of-order snapshot regressed policy: %#v", result)
+	}
+	result, err = store.ReconcileEvidenceSnapshot(context.Background(), []workflowv2.EvidenceScope{{
+		RunID: "run-atomic-ci-snapshot", PRID: pr.ID, HeadSHA: pr.HeadSHA, Domain: "ci",
+		Connection: "github-actions", Pipeline: "github-pr",
+	}}, nil, workflowv2.ProducerCI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.CIStatus != "pending" {
+		t.Fatalf("empty snapshot policy = %#v", result)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_evidence WHERE run_id=? AND superseded_at=0`,
+		"run-atomic-ci-snapshot").Scan(&currentRows); err != nil {
+		t.Fatal(err)
+	}
+	if currentRows != 0 {
+		t.Fatalf("empty snapshot retained %d current evidence rows", currentRows)
 	}
 }
 

--- a/pkg/hub/workflowv2/reconciliation.go
+++ b/pkg/hub/workflowv2/reconciliation.go
@@ -1,0 +1,232 @@
+package workflowv2
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	typesv2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
+	"github.com/google/uuid"
+)
+
+// DeliveryTarget is a currently owned, hub-verified delivery subject that an
+// external adapter may reconcile. Repository identity always originates from
+// the pinned workspace and the verified delivery row, never from chat text.
+type DeliveryTarget struct {
+	RunID          string
+	AttemptID      string
+	PRID           string
+	RepositoryName string
+	Repository     string
+	Number         int
+	URL            string
+	HeadSHA        string
+	State          string
+	WorkspaceYAML  string
+	WorkflowYAML   string
+}
+
+// ActiveDeliveryTargets finds every active V2 run that owns a verified PR. A PR
+// may intentionally belong to more than one run, so callers must reconcile
+// every returned target.
+func (s *Store) ActiveDeliveryTargets(ctx context.Context, repository string, number int) ([]DeliveryTarget, error) {
+	if s == nil || s.db == nil {
+		return nil, fmt.Errorf("workflow v2 store is not configured")
+	}
+	repository = strings.TrimSpace(repository)
+	if repository == "" || number <= 0 {
+		return nil, fmt.Errorf("repository and positive pull request number are required")
+	}
+	rows, err := s.db.QueryContext(ctx, `SELECT r.id,r.current_attempt_id,p.id,p.repository_name,p.repository,
+		p.pr_number,p.url,p.current_head_sha,p.state,r.workspace_yaml,r.workflow_yaml
+		FROM workflow_v2_delivery_prs p JOIN workflow_v2_runs r ON r.id=p.run_id
+		JOIN workflow_v2_attempts a ON a.id=r.current_attempt_id
+		WHERE p.repository=? AND p.pr_number=? AND p.active=1 AND r.status='active'
+		AND a.status='active' ORDER BY r.id`, repository, number)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var targets []DeliveryTarget
+	for rows.Next() {
+		var target DeliveryTarget
+		if err := rows.Scan(&target.RunID, &target.AttemptID, &target.PRID, &target.RepositoryName,
+			&target.Repository, &target.Number, &target.URL, &target.HeadSHA, &target.State,
+			&target.WorkspaceYAML, &target.WorkflowYAML); err != nil {
+			return nil, err
+		}
+		targets = append(targets, target)
+	}
+	return targets, rows.Err()
+}
+
+// ActiveDeliveryTargetsByHead resolves check webhooks that omit pull request
+// numbers (notably fork PRs). The SHA was independently verified when the
+// delivery manifest was accepted, so it remains a trusted subject lookup key.
+func (s *Store) ActiveDeliveryTargetsByHead(ctx context.Context, headSHA string) ([]DeliveryTarget, error) {
+	if s == nil || s.db == nil {
+		return nil, fmt.Errorf("workflow v2 store is not configured")
+	}
+	headSHA = strings.TrimSpace(headSHA)
+	if headSHA == "" {
+		return nil, fmt.Errorf("pull request head SHA is required")
+	}
+	rows, err := s.db.QueryContext(ctx, `SELECT r.id,r.current_attempt_id,p.id,p.repository_name,p.repository,
+		p.pr_number,p.url,p.current_head_sha,p.state,r.workspace_yaml,r.workflow_yaml
+		FROM workflow_v2_delivery_prs p JOIN workflow_v2_runs r ON r.id=p.run_id
+		JOIN workflow_v2_attempts a ON a.id=r.current_attempt_id
+		WHERE p.current_head_sha=? AND p.active=1 AND r.status='active' AND a.status='active'
+		ORDER BY r.id,p.repository,p.pr_number`, headSHA)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var targets []DeliveryTarget
+	for rows.Next() {
+		var target DeliveryTarget
+		if err := rows.Scan(&target.RunID, &target.AttemptID, &target.PRID, &target.RepositoryName,
+			&target.Repository, &target.Number, &target.URL, &target.HeadSHA, &target.State,
+			&target.WorkspaceYAML, &target.WorkflowYAML); err != nil {
+			return nil, err
+		}
+		targets = append(targets, target)
+	}
+	return targets, rows.Err()
+}
+
+// ReconcilePullRequest applies a trusted source-control observation to one
+// existing delivery subject, invalidates old-head evidence, emits a typed
+// workflow event, and then recomputes aggregate delivery policy.
+func (s *Store) ReconcilePullRequest(ctx context.Context, target DeliveryTarget, eventID, eventKind string,
+	verified typesv2.VerifiedPullRequest) (EventResult, error) {
+	if s == nil || s.db == nil {
+		return EventResult{}, fmt.Errorf("workflow v2 store is not configured")
+	}
+	if target.RunID == "" || target.AttemptID == "" || target.PRID == "" {
+		return EventResult{}, fmt.Errorf("delivery target run, attempt, and pull request are required")
+	}
+	if !strings.HasPrefix(eventKind, "pull_request.") {
+		return EventResult{}, fmt.Errorf("source-control reconciliation event %q must use pull_request namespace", eventKind)
+	}
+	workspace, err := typesv2.ParseAndValidateWorkspace([]byte(target.WorkspaceYAML))
+	if err != nil {
+		return EventResult{}, fmt.Errorf("load pinned workspace: %w", err)
+	}
+	if err := validateVerifiedPullRequest(workspace.Workspace, typesv2.PullRequestClaim{URL: target.URL}, verified); err != nil {
+		return EventResult{}, err
+	}
+	if verified.Repository != target.Repository || verified.Number != target.Number || verified.RepositoryName != target.RepositoryName {
+		return EventResult{}, fmt.Errorf("reconciled pull request does not match owned delivery target")
+	}
+	if strings.TrimSpace(eventID) == "" {
+		eventID = uuid.NewString()
+	}
+	observed := verified.Provenance.ObservedAt.UTC()
+	if observed.IsZero() {
+		observed = s.now().UTC()
+	}
+	event, err := s.applyEventWithMutation(ctx, target.RunID, EventInput{
+		ID: eventID, MessageID: eventID, Kind: eventKind, AttemptID: target.AttemptID,
+		Producer: ProducerSourceControl, Provenance: verified.Provenance,
+	}, func(ctx context.Context, tx *sql.Tx, input *EventInput) error {
+		var currentHead string
+		var currentState string
+		if err := tx.QueryRowContext(ctx, `SELECT current_head_sha,state FROM workflow_v2_delivery_prs
+			WHERE id=? AND run_id=? AND repository=? AND pr_number=? AND active=1`, target.PRID,
+			target.RunID, target.Repository, target.Number).Scan(&currentHead, &currentState); err != nil {
+			return err
+		}
+		provenanceJSON, err := marshalObject(verified.Provenance)
+		if err != nil {
+			return err
+		}
+		result, err := tx.ExecContext(ctx, `UPDATE workflow_v2_delivery_prs SET url=?,source_branch=?,base_branch=?,
+			current_head_sha=?,state=?,provenance_json=?,verified_at=?,updated_at=?
+			WHERE id=? AND run_id=? AND active=1`, verified.URL, verified.SourceBranch, verified.BaseBranch,
+			verified.HeadSHA, verified.State, provenanceJSON, verified.VerifiedAt.UnixMilli(), observed.UnixMilli(),
+			target.PRID, target.RunID)
+		if err != nil {
+			return err
+		}
+		if changed, err := result.RowsAffected(); err != nil || changed != 1 {
+			return fmt.Errorf("verified delivery changed while reconciling")
+		}
+		if currentHead != verified.HeadSHA {
+			var generation int
+			if err := tx.QueryRowContext(ctx, `SELECT COALESCE(MAX(generation),0)+1 FROM workflow_v2_delivery_heads
+				WHERE pr_id=?`, target.PRID).Scan(&generation); err != nil {
+				return err
+			}
+			if _, err := tx.ExecContext(ctx, `INSERT INTO workflow_v2_delivery_heads(id,pr_id,head_sha,generation,observed_at)
+				VALUES(?,?,?,?,?)`, uuid.NewString(), target.PRID, verified.HeadSHA, generation, observed.UnixMilli()); err != nil {
+				return err
+			}
+			if _, err := tx.ExecContext(ctx, `UPDATE workflow_v2_evidence SET superseded_at=?
+				WHERE run_id=? AND pr_id=? AND superseded_at=0`, observed.UnixMilli(), target.RunID, target.PRID); err != nil {
+				return err
+			}
+		}
+		summary, err := deliveryFactsFrom(ctx, tx, target.RunID)
+		if err != nil {
+			return err
+		}
+		pullRequest := map[string]interface{}{
+			"id": target.PRID, "repository": verified.Repository, "number": verified.Number,
+			"url": verified.URL, "head_sha": verified.HeadSHA, "state": verified.State,
+			"previous_head_sha": currentHead, "previous_state": currentState,
+			"head_changed": currentHead != verified.HeadSHA,
+		}
+		input.Payload = map[string]interface{}{"pull_request": pullRequest, "delivery": summary}
+		input.Facts = map[string]interface{}{
+			"pull_request.id": target.PRID, "pull_request.repository": verified.Repository,
+			"pull_request.number": verified.Number, "pull_request.url": verified.URL,
+			"pull_request.head_sha": verified.HeadSHA, "pull_request.state": verified.State,
+			"pull_request.head_changed": currentHead != verified.HeadSHA,
+			"delivery.count":            summary["count"], "delivery.open": summary["open"],
+			"delivery.merged": summary["merged"], "delivery.all_merged": summary["all_merged"],
+		}
+		return nil
+	})
+	if err != nil {
+		return EventResult{}, err
+	}
+	if event.Disposition == typesv2.DispositionAccepted {
+		if _, err := s.evaluateAndPublishDeliveryPolicy(ctx, target.RunID, target.AttemptID, "", observed); err != nil {
+			return EventResult{}, err
+		}
+	}
+	return event, nil
+}
+
+// ApplyReviewFeedback records a typed, trusted review event and current fact.
+// Workflows may use this event to transition back to build and include the fact
+// in the resulting agent task; no conversation row participates.
+func (s *Store) ApplyReviewFeedback(ctx context.Context, target DeliveryTarget, eventID string,
+	feedback map[string]interface{}, provenance typesv2.EvidenceProvenance) (EventResult, error) {
+	if target.RunID == "" || target.AttemptID == "" || target.PRID == "" || target.HeadSHA == "" {
+		return EventResult{}, fmt.Errorf("review feedback requires an owned delivery target")
+	}
+	if strings.TrimSpace(eventID) == "" {
+		eventID = uuid.NewString()
+	}
+	return s.applyEventWithMutation(ctx, target.RunID, EventInput{
+		ID: eventID, MessageID: eventID, Kind: "review.feedback.received", AttemptID: target.AttemptID,
+		Producer: ProducerReview, Provenance: provenance,
+	}, func(ctx context.Context, tx *sql.Tx, input *EventInput) error {
+		var headSHA string
+		if err := tx.QueryRowContext(ctx, `SELECT current_head_sha FROM workflow_v2_delivery_prs
+			WHERE id=? AND run_id=? AND repository=? AND pr_number=? AND active=1`, target.PRID,
+			target.RunID, target.Repository, target.Number).Scan(&headSHA); err != nil {
+			return fmt.Errorf("load review delivery target: %w", err)
+		}
+		if headSHA != target.HeadSHA {
+			return fmt.Errorf("review feedback head %s is stale; current head is %s", target.HeadSHA, headSHA)
+		}
+		input.Payload = map[string]interface{}{"review": map[string]interface{}{
+			"feedback": feedback, "pull_request_id": target.PRID, "head_sha": headSHA,
+		}}
+		input.Facts = map[string]interface{}{"review.feedback": feedback}
+		return nil
+	})
+}

--- a/pkg/hub/workflowv2/reconciliation.go
+++ b/pkg/hub/workflowv2/reconciliation.go
@@ -3,6 +3,7 @@ package workflowv2
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -214,6 +215,21 @@ func (s *Store) ApplyReviewFeedback(ctx context.Context, target DeliveryTarget, 
 		ID: eventID, MessageID: eventID, Kind: "review.feedback.received", AttemptID: target.AttemptID,
 		Producer: ProducerReview, Provenance: provenance,
 	}, func(ctx context.Context, tx *sql.Tx, input *EventInput) error {
+		var currentProvenance string
+		err := tx.QueryRowContext(ctx, `SELECT provenance_json FROM workflow_v2_facts
+			WHERE run_id=? AND fact_key='review.feedback'`, target.RunID).Scan(&currentProvenance)
+		if err != nil && err != sql.ErrNoRows {
+			return err
+		}
+		if err == nil {
+			var current typesv2.EvidenceProvenance
+			if err := json.Unmarshal([]byte(currentProvenance), &current); err != nil {
+				return fmt.Errorf("decode current review feedback provenance: %w", err)
+			}
+			if current.ObservedAt.After(provenance.ObservedAt) {
+				return fmt.Errorf("review feedback observation is older than the current fact")
+			}
+		}
 		var headSHA string
 		if err := tx.QueryRowContext(ctx, `SELECT current_head_sha FROM workflow_v2_delivery_prs
 			WHERE id=? AND run_id=? AND repository=? AND pr_number=? AND active=1`, target.PRID,

--- a/pkg/hub/workflowv2/tasks.go
+++ b/pkg/hub/workflowv2/tasks.go
@@ -67,6 +67,7 @@ func (s *Store) MaterializeAgentTask(ctx context.Context, effectID, effectAttemp
 		Instructions      string   `json:"instructions"`
 		AllowedActions    []string `json:"allowed_actions"`
 		RequiredArtifacts []string `json:"required_artifacts"`
+		IncludeFacts      []string `json:"include_facts"`
 	}
 	if err := json.Unmarshal([]byte(payloadJSON), &payload); err != nil {
 		return typesv2.AgentTask{}, fmt.Errorf("decode agent task effect: %w", err)
@@ -77,6 +78,38 @@ func (s *Store) MaterializeAgentTask(ctx context.Context, effectID, effectAttemp
 	}
 	if instructions == "" {
 		return typesv2.AgentTask{}, fmt.Errorf("agent task effect instructions are required")
+	}
+	if len(payload.IncludeFacts) > 20 {
+		return typesv2.AgentTask{}, fmt.Errorf("agent task effect includes more than 20 facts")
+	}
+	if len(payload.IncludeFacts) > 0 {
+		factValues := map[string]interface{}{}
+		seenFacts := map[string]bool{}
+		for _, key := range payload.IncludeFacts {
+			key = strings.TrimSpace(key)
+			if key == "" || seenFacts[key] {
+				return typesv2.AgentTask{}, fmt.Errorf("agent task effect include_facts must contain unique non-empty keys")
+			}
+			seenFacts[key] = true
+			var raw []byte
+			if err := tx.QueryRowContext(ctx, `SELECT value_json FROM workflow_v2_facts WHERE run_id=? AND fact_key=?`,
+				runID, key).Scan(&raw); err != nil {
+				if errors.Is(err, sql.ErrNoRows) {
+					return typesv2.AgentTask{}, fmt.Errorf("agent task required fact %q is unavailable", key)
+				}
+				return typesv2.AgentTask{}, err
+			}
+			var value interface{}
+			if err := json.Unmarshal(raw, &value); err != nil {
+				return typesv2.AgentTask{}, fmt.Errorf("decode agent task fact %q: %w", key, err)
+			}
+			factValues[key] = value
+		}
+		factsJSON, err := json.Marshal(factValues)
+		if err != nil {
+			return typesv2.AgentTask{}, err
+		}
+		instructions += "\n\nTyped workflow facts:\n" + string(factsJSON)
 	}
 	if payload.AllowedActions == nil {
 		payload.AllowedActions = []string{}

--- a/pkg/types/v2/workflow_test.go
+++ b/pkg/types/v2/workflow_test.go
@@ -244,6 +244,30 @@ transitions:
 	}
 }
 
+func TestWorkflowV2RejectsTranscriptFactsInAgentTasks(t *testing.T) {
+	workflow := `
+schema_version: 2
+name: transcript-agent-task
+enabled: true
+initial_state: build
+states:
+  build:
+    phase: build
+    on_enter:
+      effects:
+        - agent.task:
+            prompt: Continue the work.
+            include_facts: [conversation.body]
+  done:
+    phase: done
+    terminal: true
+`
+	_, _, err := v2.ParseAndValidateWorkflowPair([]byte(workflow), []byte(validWorkspaceYAML))
+	if err == nil || !strings.Contains(err.Error(), "conversation/transcript") {
+		t.Fatalf("error = %v, want conversation/transcript rejection", err)
+	}
+}
+
 func TestWorkflowV2AllowsMarkersAsInertDescription(t *testing.T) {
 	yaml := `
 schema_version: 2

--- a/pkg/types/v2/workflow_validate.go
+++ b/pkg/types/v2/workflow_validate.go
@@ -636,7 +636,29 @@ func validateEffectsAgainstWorkspace(path string, effects []map[string]interface
 					return fmt.Errorf("%s: unknown issue_tracker connection %q", epath, conn)
 				}
 			case "agent.task":
-				// agent tasks do not require workspace pipeline refs
+				prompt, _ := cfg["prompt"].(string)
+				instructions, _ := cfg["instructions"].(string)
+				if strings.TrimSpace(prompt) == "" && strings.TrimSpace(instructions) == "" {
+					return fmt.Errorf("%s: prompt or instructions is required", epath)
+				}
+				if rawFacts, exists := cfg["include_facts"]; exists {
+					facts, ok := rawFacts.([]interface{})
+					if !ok || len(facts) == 0 || len(facts) > 20 {
+						return fmt.Errorf("%s.include_facts must be a list of 1 to 20 fact keys", epath)
+					}
+					seen := map[string]bool{}
+					for index, rawFact := range facts {
+						fact, ok := rawFact.(string)
+						fact = strings.TrimSpace(fact)
+						if !ok || fact == "" || seen[fact] {
+							return fmt.Errorf("%s.include_facts[%d] must be a unique non-empty fact key", epath, index)
+						}
+						if isTranscriptFact(fact) {
+							return fmt.Errorf("%s.include_facts[%d]: conversation/transcript fact %q cannot control workflow v2", epath, index, fact)
+						}
+						seen[fact] = true
+					}
+				}
 			default:
 				// Unknown effect ops: reject at pair validation so they fail closed.
 				return fmt.Errorf("%s: unsupported effect operation %q", epath, op)


### PR DESCRIPTION
## Summary

- reconcile verified dynamic PR subjects from authoritative GitHub state and invalidate evidence on HEAD changes
- adapt GitHub check, review, and PR comment webhooks into protected V2 evidence/facts without changing V1 handlers
- atomically reconcile full check snapshots so mixed old/new evidence cannot take a transition
- deliver human review feedback to fixing tasks through explicit typed facts, never conversation rows
- support multi-PR/multi-repo ownership and check webhooks that omit PR numbers
- keep suspended runs closed to unsolicited external transitions

This is the GitHub lifecycle portion of the end-to-end vertical slice in #544. Lost-webhook periodic reconciliation remains a separate follow-up before the beta tag.

## Compatibility

- V1 webhook handlers and transcript behavior are unchanged.
- V2 adapters target only active, independently verified V2 delivery rows.
- V2 task fact inclusion rejects conversation/transcript namespaces.

## Verification

- `go test ./...`
- `go vet ./...`
- focused `go test -race` for V2 GitHub, evidence reconciliation, head invalidation, typed feedback, and suspended targeting
