### PR TITLE
Reconcile workflow v2 GitHub state

### DIFF
--- a/pkg/hub/github_webhook.go
+++ b/pkg/hub/github_webhook.go
@@ -388,12 +388,14 @@ func (s *Server) findOpenTaskRunPR(repo string, prNumber int) (runID string, ok 
 type githubPRReviewCommentPayload struct {
 	Action  string `json:"action"` // "created", "edited", "deleted"
 	Comment struct {
-		ID      int64  `json:"id"`
-		Body    string `json:"body"`
-		HTMLURL string `json:"html_url"`
-		Path    string `json:"path"`
-		Line    int    `json:"line"`
-		User    struct {
+		ID        int64  `json:"id"`
+		Body      string `json:"body"`
+		HTMLURL   string `json:"html_url"`
+		Path      string `json:"path"`
+		Line      int    `json:"line"`
+		CommitID  string `json:"commit_id"`
+		UpdatedAt string `json:"updated_at"`
+		User      struct {
 			Login string `json:"login"`
 			Type  string `json:"type"`
 		} `json:"user"`
@@ -586,10 +588,11 @@ type githubIssueCommentPayload struct {
 		} `json:"pull_request"`
 	} `json:"issue"`
 	Comment struct {
-		ID      int64  `json:"id"`
-		Body    string `json:"body"`
-		HTMLURL string `json:"html_url"`
-		User    struct {
+		ID        int64  `json:"id"`
+		Body      string `json:"body"`
+		HTMLURL   string `json:"html_url"`
+		UpdatedAt string `json:"updated_at"`
+		User      struct {
 			Login string `json:"login"`
 			Type  string `json:"type"`
 		} `json:"user"`

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -459,6 +459,7 @@ func (s *Server) Run(opts ...RunOptions) error {
 
 func (s *Server) run(ctx context.Context, opts ...RunOptions) error {
 	go s.runWorkflowV2Worker(ctx)
+	go s.runWorkflowV2GitHubReconciler(ctx)
 	noWebUI := len(opts) > 0 && opts[0].NoWebUI
 	mux := http.NewServeMux()
 	s.mux = mux

--- a/pkg/hub/workflow_v2_github.go
+++ b/pkg/hub/workflow_v2_github.go
@@ -124,13 +124,19 @@ func githubAPICollectionWithBaseContext(ctx context.Context, baseURL, requestPat
 		if resp.StatusCode >= http.StatusBadRequest {
 			return nil, &githubAPIError{StatusCode: resp.StatusCode, Body: string(resp.Body), RateLimited: resp.rateLimited()}
 		}
-		var document map[string]json.RawMessage
-		if err := json.Unmarshal(resp.Body, &document); err != nil {
-			return nil, fmt.Errorf("github API parse error: %w", err)
-		}
 		var pageItems []json.RawMessage
-		if err := json.Unmarshal(document[key], &pageItems); err != nil {
-			return nil, fmt.Errorf("github API collection %q parse error: %w", key, err)
+		if key == "" {
+			if err := json.Unmarshal(resp.Body, &pageItems); err != nil {
+				return nil, fmt.Errorf("github API array parse error: %w", err)
+			}
+		} else {
+			var document map[string]json.RawMessage
+			if err := json.Unmarshal(resp.Body, &document); err != nil {
+				return nil, fmt.Errorf("github API parse error: %w", err)
+			}
+			if err := json.Unmarshal(document[key], &pageItems); err != nil {
+				return nil, fmt.Errorf("github API collection %q parse error: %w", key, err)
+			}
 		}
 		result = append(result, pageItems...)
 		next = githubNextPage(resp.Header.Get("Link"))

--- a/pkg/hub/workflow_v2_github_events.go
+++ b/pkg/hub/workflow_v2_github_events.go
@@ -115,6 +115,13 @@ func (s *Server) processWorkflowV2GitHubCheckEvent(event string, payload githubC
 	if len(targets) == 0 {
 		return
 	}
+	if err := s.reconcileWorkflowV2GitHubChecks(context.Background(), store, targets, headSHA); err != nil {
+		log.Printf("[workflow-v2 github] reconcile check snapshot: %v", err)
+	}
+}
+
+func (s *Server) reconcileWorkflowV2GitHubChecks(ctx context.Context, store *workflowv2.Store,
+	targets []workflowv2.DeliveryTarget, headSHA string) error {
 	type githubCheck struct {
 		ID          int64  `json:"id"`
 		Name        string `json:"name"`
@@ -132,6 +139,9 @@ func (s *Server) processWorkflowV2GitHubCheckEvent(event string, payload githubC
 	checksByRepository := map[string][]githubCheck{}
 	workflowRunsByRepository := map[string]map[int64]struct{ name, path string }{}
 	for _, target := range targets {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		checks, loaded := checksByRepository[target.Repository]
 		if !loaded {
 			token := s.tokenForRepo(target.Repository)
@@ -139,7 +149,7 @@ func (s *Server) processWorkflowV2GitHubCheckEvent(event string, payload githubC
 				log.Printf("[workflow-v2 github] no repository-scoped token for CI %s", target.Repository)
 				continue
 			}
-			rawRuns, err := githubAPICollectionWithBaseContext(context.Background(), s.ghBaseURL(),
+			rawRuns, err := githubAPICollectionWithBaseContext(ctx, s.ghBaseURL(),
 				fmt.Sprintf("repos/%s/commits/%s/check-runs?filter=latest&per_page=100", target.Repository, headSHA),
 				token, "check_runs")
 			if err != nil {
@@ -152,7 +162,7 @@ func (s *Server) processWorkflowV2GitHubCheckEvent(event string, payload githubC
 				continue
 			}
 			checksByRepository[target.Repository] = checks
-			rawRuns, err = githubAPICollectionWithBaseContext(context.Background(), s.ghBaseURL(),
+			rawRuns, err = githubAPICollectionWithBaseContext(ctx, s.ghBaseURL(),
 				fmt.Sprintf("repos/%s/actions/runs?head_sha=%s&per_page=100", target.Repository, headSHA),
 				token, "workflow_runs")
 			if err != nil {
@@ -224,12 +234,13 @@ func (s *Server) processWorkflowV2GitHubCheckEvent(event string, payload githubC
 			}
 		}
 		if len(evidenceScopes) > 0 {
-			if _, err := store.ReconcileEvidenceSnapshot(context.Background(), evidenceScopes, evidenceInputs,
+			if _, err := store.ReconcileEvidenceSnapshot(ctx, evidenceScopes, evidenceInputs,
 				workflowv2.ProducerCI); err != nil {
 				log.Printf("[workflow-v2 github] reconcile check snapshot for run %s: %v", target.RunID, err)
 			}
 		}
 	}
+	return nil
 }
 
 func workflowV2GitHubWorkflowMatches(configured, name, workflowPath string) bool {

--- a/pkg/hub/workflow_v2_github_events.go
+++ b/pkg/hub/workflow_v2_github_events.go
@@ -383,19 +383,18 @@ func (s *Server) applyWorkflowV2GitHubFeedback(target workflowv2.DeliveryTarget,
 	if line > 0 {
 		feedback["line"] = line
 	}
-	eventID := workflowV2GitHubFeedbackEventID(target, kind, externalID, body, path, line)
-	_, err := workflowv2.NewStore(s.db).ApplyReviewFeedback(context.Background(), target, eventID, feedback,
+	eventID := workflowV2GitHubFeedbackEventID(target, kind, externalID)
+	_, err := workflowv2.NewStore(s.db).ReconcileReviewFeedback(context.Background(), target, eventID, feedback,
 		typesv2.EvidenceProvenance{Producer: string(workflowv2.ProducerReview), Principal: author,
-			ExternalID: externalID, ObservedAt: observed})
+			ExternalID: kind + ":" + externalID, ObservedAt: observed})
 	if err != nil {
 		log.Printf("[workflow-v2 github] apply feedback to run %s: %v", target.RunID, err)
 	}
 }
 
-func workflowV2GitHubFeedbackEventID(target workflowv2.DeliveryTarget, kind, externalID, body, filePath string,
-	line int) string {
+func workflowV2GitHubFeedbackEventID(target workflowv2.DeliveryTarget, kind, externalID string) string {
 	return workflowV2GitHubEventID(target.RunID, "review_feedback", kind, externalID,
-		target.Repository, strconv.Itoa(target.Number), body, filePath, strconv.Itoa(line))
+		target.Repository, strconv.Itoa(target.Number))
 }
 
 func workflowV2GitHubReviewConnections(target workflowv2.DeliveryTarget) []string {

--- a/pkg/hub/workflow_v2_github_events.go
+++ b/pkg/hub/workflow_v2_github_events.go
@@ -314,8 +314,7 @@ func (s *Server) processWorkflowV2GitHubReviewEvent(payload githubPRReviewPayloa
 		if status == "changes_requested" {
 			// Persist the typed feedback fact before review evidence can take a
 			// policy transition that schedules an include_facts agent task.
-			feedbackID := fmt.Sprintf("%d:%s:%s", payload.Review.ID, payload.Action,
-				workflowV2GitHubEventID("", body))
+			feedbackID := strconv.FormatInt(payload.Review.ID, 10)
 			s.applyWorkflowV2GitHubFeedback(target, "review", feedbackID, login, body, url, "", 0, observed)
 		}
 		connections := workflowV2GitHubReviewConnections(target)
@@ -337,12 +336,14 @@ func (s *Server) processWorkflowV2GitHubReviewEvent(payload githubPRReviewPayloa
 }
 
 func (s *Server) processWorkflowV2GitHubReviewCommentEvent(payload githubPRReviewCommentPayload) {
-	if payload.Action != "created" || !s.isHumanGitHubActor(payload.Comment.User.Login, payload.Comment.User.Type) {
+	if payload.Action != "created" || strings.TrimSpace(payload.Comment.CommitID) == "" ||
+		!s.isHumanGitHubActor(payload.Comment.User.Login, payload.Comment.User.Type) {
 		return
 	}
 	s.processWorkflowV2GitHubFeedbackTargets(payload.Repository.FullName, payload.PullRequest.Number,
 		"inline_comment", strconv.FormatInt(payload.Comment.ID, 10), payload.Comment.User.Login, payload.Comment.Body,
-		payload.Comment.HTMLURL, payload.Comment.Path, payload.Comment.Line, time.Time{})
+		payload.Comment.HTMLURL, payload.Comment.Path, payload.Comment.Line, payload.Comment.CommitID,
+		parseGitHubTime(payload.Comment.UpdatedAt))
 }
 
 func (s *Server) processWorkflowV2GitHubIssueCommentEvent(payload githubIssueCommentPayload) {
@@ -351,17 +352,20 @@ func (s *Server) processWorkflowV2GitHubIssueCommentEvent(payload githubIssueCom
 	}
 	s.processWorkflowV2GitHubFeedbackTargets(payload.Repository.FullName, payload.Issue.Number,
 		"pull_request_comment", strconv.FormatInt(payload.Comment.ID, 10), payload.Comment.User.Login, payload.Comment.Body,
-		payload.Comment.HTMLURL, "", 0, time.Time{})
+		payload.Comment.HTMLURL, "", 0, "", parseGitHubTime(payload.Comment.UpdatedAt))
 }
 
 func (s *Server) processWorkflowV2GitHubFeedbackTargets(repository string, number int, kind, externalID string,
-	author, body, url, path string, line int, observed time.Time) {
+	author, body, url, path string, line int, headSHA string, observed time.Time) {
 	targets, err := workflowv2.NewStore(s.db).ActiveDeliveryTargets(context.Background(), repository, number)
 	if err != nil {
 		log.Printf("[workflow-v2 github] find feedback targets: %v", err)
 		return
 	}
 	for _, target := range targets {
+		if headSHA != "" && target.HeadSHA != headSHA {
+			continue
+		}
 		s.applyWorkflowV2GitHubFeedback(target, kind, externalID, author, body, url, path, line, observed)
 	}
 }
@@ -379,14 +383,19 @@ func (s *Server) applyWorkflowV2GitHubFeedback(target workflowv2.DeliveryTarget,
 	if line > 0 {
 		feedback["line"] = line
 	}
-	eventID := workflowV2GitHubEventID(target.RunID, "review_feedback", kind,
-		externalID, target.Repository, strconv.Itoa(target.Number))
+	eventID := workflowV2GitHubFeedbackEventID(target, kind, externalID, body, path, line)
 	_, err := workflowv2.NewStore(s.db).ApplyReviewFeedback(context.Background(), target, eventID, feedback,
 		typesv2.EvidenceProvenance{Producer: string(workflowv2.ProducerReview), Principal: author,
 			ExternalID: externalID, ObservedAt: observed})
 	if err != nil {
 		log.Printf("[workflow-v2 github] apply feedback to run %s: %v", target.RunID, err)
 	}
+}
+
+func workflowV2GitHubFeedbackEventID(target workflowv2.DeliveryTarget, kind, externalID, body, filePath string,
+	line int) string {
+	return workflowV2GitHubEventID(target.RunID, "review_feedback", kind, externalID,
+		target.Repository, strconv.Itoa(target.Number), body, filePath, strconv.Itoa(line))
 }
 
 func workflowV2GitHubReviewConnections(target workflowv2.DeliveryTarget) []string {

--- a/pkg/hub/workflow_v2_github_reconciler.go
+++ b/pkg/hub/workflow_v2_github_reconciler.go
@@ -1,0 +1,384 @@
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/hub/workflowv2"
+	typesv2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
+)
+
+const (
+	workflowV2GitHubReconcileInterval = 2 * time.Minute
+	workflowV2GitHubReconcileTimeout  = 30 * time.Second
+)
+
+// runWorkflowV2GitHubReconciler makes webhook delivery an optimization rather
+// than a correctness dependency. It runs once on startup for restart recovery,
+// then periodically while respecting the shared GitHub low-priority reserve.
+func (s *Server) runWorkflowV2GitHubReconciler(ctx context.Context) {
+	reconcile := func() {
+		if !defaultGitHubClient.allowLowPriority() {
+			return
+		}
+		if err := s.reconcileWorkflowV2GitHub(ctx); err != nil && ctx.Err() == nil {
+			log.Printf("[workflow-v2 github] periodic reconciliation: %v", err)
+		}
+	}
+	reconcile()
+	ticker := time.NewTicker(workflowV2GitHubReconcileInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			reconcile()
+		}
+	}
+}
+
+func (s *Server) reconcileWorkflowV2GitHub(ctx context.Context) error {
+	store := workflowv2.NewStore(s.db)
+	targets, err := store.ActiveDeliveryTargetsAll(ctx)
+	if err != nil {
+		return fmt.Errorf("list active deliveries: %w", err)
+	}
+	current := make([]workflowv2.DeliveryTarget, 0, len(targets))
+	for _, target := range targets {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if !defaultGitHubClient.allowLowPriority() {
+			break
+		}
+		targetCtx, cancel := context.WithTimeout(ctx, workflowV2GitHubReconcileTimeout)
+		workspace, parseErr := typesv2.ParseAndValidateWorkspace([]byte(target.WorkspaceYAML))
+		if parseErr != nil {
+			cancel()
+			log.Printf("[workflow-v2 github] parse workspace for run %s: %v", target.RunID, parseErr)
+			continue
+		}
+		verified, verifyErr := s.verifyWorkflowV2PullRequest(targetCtx, workflowv2.Run{}, workspace.Workspace,
+			typesv2.PullRequestClaim{URL: target.URL})
+		cancel()
+		if verifyErr != nil {
+			log.Printf("[workflow-v2 github] verify %s#%d for run %s: %v",
+				target.Repository, target.Number, target.RunID, verifyErr)
+			continue
+		}
+		verified.ID = target.PRID
+		verified.Provenance.Principal = "github-reconciler"
+		if kind := workflowV2ReconciledPREventKind(target, verified); kind != "" {
+			eventID := workflowV2GitHubEventID(target.RunID, "reconcile", target.Repository,
+				strconv.Itoa(target.Number), verified.HeadSHA, verified.State,
+				verified.Provenance.ObservedAt.UTC().Format(time.RFC3339Nano))
+			targetCtx, cancel = context.WithTimeout(ctx, workflowV2GitHubReconcileTimeout)
+			_, reconcileErr := store.ReconcilePullRequest(targetCtx, target, eventID, kind, verified)
+			cancel()
+			if reconcileErr != nil {
+				log.Printf("[workflow-v2 github] reconcile %s#%d for run %s: %v",
+					target.Repository, target.Number, target.RunID, reconcileErr)
+				continue
+			}
+		}
+		if target.HeadSHA != verified.HeadSHA {
+			target.HeadObservedAt = verified.Provenance.ObservedAt.UTC()
+		}
+		target.HeadSHA = verified.HeadSHA
+		target.State = verified.State
+		if verified.State == "open" {
+			current = append(current, target)
+		}
+	}
+
+	for _, group := range groupWorkflowV2DeliveryTargets(current, func(target workflowv2.DeliveryTarget) string {
+		return target.Repository + "\x00" + target.HeadSHA
+	}) {
+		if !defaultGitHubClient.allowLowPriority() {
+			break
+		}
+		targetCtx, cancel := context.WithTimeout(ctx, workflowV2GitHubReconcileTimeout)
+		err := s.reconcileWorkflowV2GitHubChecks(targetCtx, store, group, group[0].HeadSHA)
+		cancel()
+		if err != nil && ctx.Err() == nil {
+			log.Printf("[workflow-v2 github] reconcile CI for %s@%s: %v",
+				group[0].Repository, group[0].HeadSHA, err)
+		}
+	}
+
+	for _, group := range groupWorkflowV2DeliveryTargets(current, func(target workflowv2.DeliveryTarget) string {
+		return target.Repository + "\x00" + strconv.Itoa(target.Number)
+	}) {
+		if !defaultGitHubClient.allowLowPriority() {
+			break
+		}
+		targetCtx, cancel := context.WithTimeout(ctx, workflowV2GitHubReconcileTimeout)
+		err := s.reconcileWorkflowV2GitHubReviews(targetCtx, store, group)
+		cancel()
+		if err != nil && ctx.Err() == nil {
+			log.Printf("[workflow-v2 github] reconcile reviews for %s#%d: %v",
+				group[0].Repository, group[0].Number, err)
+		}
+		if !defaultGitHubClient.allowLowPriority() {
+			break
+		}
+		targetCtx, cancel = context.WithTimeout(ctx, workflowV2GitHubReconcileTimeout)
+		err = s.reconcileWorkflowV2GitHubComments(targetCtx, store, group)
+		cancel()
+		if err != nil && ctx.Err() == nil {
+			log.Printf("[workflow-v2 github] reconcile comments for %s#%d: %v",
+				group[0].Repository, group[0].Number, err)
+		}
+	}
+	return ctx.Err()
+}
+
+func workflowV2ReconciledPREventKind(target workflowv2.DeliveryTarget,
+	verified typesv2.VerifiedPullRequest) string {
+	switch verified.State {
+	case "merged":
+		if target.State != verified.State || target.HeadSHA != verified.HeadSHA {
+			return "pull_request.merged"
+		}
+	case "closed":
+		if target.State != verified.State || target.HeadSHA != verified.HeadSHA {
+			return "pull_request.closed"
+		}
+	case "open":
+		if target.State != verified.State {
+			return "pull_request.verified_open"
+		}
+		if target.HeadSHA != verified.HeadSHA {
+			return "pull_request.head_changed"
+		}
+	default:
+	}
+	return ""
+}
+
+func groupWorkflowV2DeliveryTargets(targets []workflowv2.DeliveryTarget,
+	key func(workflowv2.DeliveryTarget) string) [][]workflowv2.DeliveryTarget {
+	groups := map[string][]workflowv2.DeliveryTarget{}
+	var keys []string
+	for _, target := range targets {
+		value := key(target)
+		if _, ok := groups[value]; !ok {
+			keys = append(keys, value)
+		}
+		groups[value] = append(groups[value], target)
+	}
+	sort.Strings(keys)
+	result := make([][]workflowv2.DeliveryTarget, 0, len(keys))
+	for _, value := range keys {
+		result = append(result, groups[value])
+	}
+	return result
+}
+
+type workflowV2GitHubReview struct {
+	ID          int64  `json:"id"`
+	State       string `json:"state"`
+	Body        string `json:"body"`
+	HTMLURL     string `json:"html_url"`
+	CommitID    string `json:"commit_id"`
+	SubmittedAt string `json:"submitted_at"`
+	User        struct {
+		Login string `json:"login"`
+		Type  string `json:"type"`
+	} `json:"user"`
+}
+
+func (s *Server) reconcileWorkflowV2GitHubReviews(ctx context.Context, store *workflowv2.Store,
+	targets []workflowv2.DeliveryTarget) error {
+	if len(targets) == 0 {
+		return nil
+	}
+	token := s.tokenForRepo(targets[0].Repository)
+	if token == "" {
+		return fmt.Errorf("no repository-scoped token")
+	}
+	rawReviews, err := githubAPICollectionWithBaseContext(ctx, s.ghBaseURL(), fmt.Sprintf(
+		"repos/%s/pulls/%d/reviews?per_page=100", targets[0].Repository, targets[0].Number), token, "")
+	if err != nil {
+		return err
+	}
+	reviewsJSON, _ := json.Marshal(rawReviews)
+	var reviews []workflowV2GitHubReview
+	if err := json.Unmarshal(reviewsJSON, &reviews); err != nil {
+		return fmt.Errorf("decode reviews: %w", err)
+	}
+	for _, target := range targets {
+		connections := workflowV2GitHubReviewConnections(target)
+		if len(connections) == 0 {
+			continue
+		}
+		type observedReview struct {
+			review   workflowV2GitHubReview
+			observed time.Time
+		}
+		latest := map[string]observedReview{}
+		for _, review := range reviews {
+			observed, parseErr := time.Parse(time.RFC3339Nano, strings.TrimSpace(review.SubmittedAt))
+			status := strings.ToLower(strings.TrimSpace(review.State))
+			if parseErr != nil || review.CommitID != target.HeadSHA || status == "" ||
+				!s.isHumanGitHubActor(review.User.Login, review.User.Type) {
+				continue
+			}
+			login := strings.TrimSpace(review.User.Login)
+			if current, ok := latest[login]; !ok || observed.After(current.observed) {
+				latest[login] = observedReview{review: review, observed: observed.UTC()}
+			}
+		}
+		ordered := make([]observedReview, 0, len(latest))
+		for _, review := range latest {
+			ordered = append(ordered, review)
+		}
+		sort.Slice(ordered, func(i, j int) bool { return ordered[i].observed.Before(ordered[j].observed) })
+		scopes := make([]workflowv2.EvidenceScope, 0, len(connections))
+		inputs := make([]workflowv2.EvidenceInput, 0, len(connections)*len(ordered))
+		for _, connection := range connections {
+			scopes = append(scopes, workflowv2.EvidenceScope{RunID: target.RunID, PRID: target.PRID,
+				HeadSHA: target.HeadSHA, Domain: "review", Connection: connection})
+			for _, item := range ordered {
+				review := item.review
+				status := strings.ToLower(strings.TrimSpace(review.State))
+				inputs = append(inputs, workflowv2.EvidenceInput{RunID: target.RunID, PRID: target.PRID,
+					HeadSHA: target.HeadSHA, Domain: "review", Connection: connection,
+					ExternalID: review.User.Login, Kind: "approval", Status: status, ObservedAt: item.observed,
+					Payload: map[string]interface{}{"review_id": review.ID, "url": review.HTMLURL,
+						"body": review.Body, "commit_id": review.CommitID},
+					Provenance: typesv2.EvidenceProvenance{Producer: string(workflowv2.ProducerReview),
+						Connection: connection, Principal: review.User.Login,
+						ExternalID: strconv.FormatInt(review.ID, 10), ObservedAt: item.observed, Reconciled: true}})
+			}
+		}
+		// Apply feedback oldest-to-newest so the current typed fact is stable
+		// even when GitHub returns reviews in an unexpected order.
+		for _, item := range ordered {
+			if !strings.EqualFold(item.review.State, "changes_requested") {
+				continue
+			}
+			feedback := map[string]interface{}{"kind": "review", "author": item.review.User.Login,
+				"body": item.review.Body, "url": item.review.HTMLURL, "repository": target.Repository,
+				"number": target.Number, "pull_request_url": target.URL}
+			eventID := workflowV2GitHubEventID(target.RunID, "review_feedback", "reconciled",
+				strconv.FormatInt(item.review.ID, 10), item.review.SubmittedAt,
+				workflowV2GitHubEventID("", item.review.State, item.review.Body))
+			if _, err := store.ApplyReviewFeedback(ctx, target, eventID, feedback, typesv2.EvidenceProvenance{
+				Producer: string(workflowv2.ProducerReview), Principal: item.review.User.Login,
+				ExternalID: strconv.FormatInt(item.review.ID, 10), ObservedAt: item.observed, Reconciled: true,
+			}); err != nil && ctx.Err() == nil {
+				log.Printf("[workflow-v2 github] reconcile feedback for run %s: %v", target.RunID, err)
+			}
+		}
+		if _, err := store.ReconcileEvidenceSnapshot(ctx, scopes, inputs, workflowv2.ProducerReview); err != nil {
+			return fmt.Errorf("run %s: %w", target.RunID, err)
+		}
+	}
+	return nil
+}
+
+type workflowV2GitHubComment struct {
+	ID        int64  `json:"id"`
+	Body      string `json:"body"`
+	HTMLURL   string `json:"html_url"`
+	Path      string `json:"path"`
+	Line      int    `json:"line"`
+	CommitID  string `json:"commit_id"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+	User      struct {
+		Login string `json:"login"`
+		Type  string `json:"type"`
+	} `json:"user"`
+}
+
+func (s *Server) reconcileWorkflowV2GitHubComments(ctx context.Context, store *workflowv2.Store,
+	targets []workflowv2.DeliveryTarget) error {
+	if len(targets) == 0 {
+		return nil
+	}
+	token := s.tokenForRepo(targets[0].Repository)
+	if token == "" {
+		return fmt.Errorf("no repository-scoped token")
+	}
+	load := func(requestPath string) ([]workflowV2GitHubComment, error) {
+		raw, err := githubAPICollectionWithBaseContext(ctx, s.ghBaseURL(), requestPath, token, "")
+		if err != nil {
+			return nil, err
+		}
+		encoded, _ := json.Marshal(raw)
+		var comments []workflowV2GitHubComment
+		if err := json.Unmarshal(encoded, &comments); err != nil {
+			return nil, err
+		}
+		return comments, nil
+	}
+	inline, err := load(fmt.Sprintf("repos/%s/pulls/%d/comments?per_page=100",
+		targets[0].Repository, targets[0].Number))
+	if err != nil {
+		return fmt.Errorf("list review comments: %w", err)
+	}
+	discussion, err := load(fmt.Sprintf("repos/%s/issues/%d/comments?per_page=100",
+		targets[0].Repository, targets[0].Number))
+	if err != nil {
+		return fmt.Errorf("list pull request comments: %w", err)
+	}
+	for _, target := range targets {
+		for _, comment := range inline {
+			if comment.CommitID != target.HeadSHA {
+				continue
+			}
+			s.reconcileWorkflowV2GitHubComment(ctx, store, target, comment, "inline_comment")
+		}
+		for _, comment := range discussion {
+			created, parseErr := time.Parse(time.RFC3339Nano, strings.TrimSpace(comment.CreatedAt))
+			if parseErr != nil {
+				continue
+			}
+			created = created.UTC()
+			if target.HeadObservedAt.IsZero() || created.Before(target.HeadObservedAt) {
+				continue
+			}
+			s.reconcileWorkflowV2GitHubComment(ctx, store, target, comment, "pull_request_comment")
+		}
+	}
+	return nil
+}
+
+func (s *Server) reconcileWorkflowV2GitHubComment(ctx context.Context, store *workflowv2.Store,
+	target workflowv2.DeliveryTarget, comment workflowV2GitHubComment, kind string) {
+	if strings.TrimSpace(comment.Body) == "" ||
+		!s.isHumanGitHubActor(comment.User.Login, comment.User.Type) {
+		return
+	}
+	observed, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(comment.UpdatedAt))
+	if err != nil {
+		return
+	}
+	observed = observed.UTC()
+	feedback := map[string]interface{}{"kind": kind, "author": comment.User.Login, "body": comment.Body,
+		"url": comment.HTMLURL, "repository": target.Repository, "number": target.Number,
+		"pull_request_url": target.URL}
+	if comment.Path != "" {
+		feedback["path"] = comment.Path
+	}
+	if comment.Line > 0 {
+		feedback["line"] = comment.Line
+	}
+	eventID := workflowV2GitHubEventID(target.RunID, "review_feedback", kind,
+		strconv.FormatInt(comment.ID, 10), comment.UpdatedAt)
+	if _, err := store.ApplyReviewFeedback(ctx, target, eventID, feedback, typesv2.EvidenceProvenance{
+		Producer: string(workflowv2.ProducerReview), Principal: comment.User.Login,
+		ExternalID: strconv.FormatInt(comment.ID, 10), ObservedAt: observed, Reconciled: true,
+	}); err != nil && ctx.Err() == nil {
+		log.Printf("[workflow-v2 github] reconcile %s for run %s: %v", kind, target.RunID, err)
+	}
+}

--- a/pkg/hub/workflow_v2_github_reconciler.go
+++ b/pkg/hub/workflow_v2_github_reconciler.go
@@ -268,11 +268,11 @@ func (s *Server) reconcileWorkflowV2GitHubReviews(ctx context.Context, store *wo
 			feedback := map[string]interface{}{"kind": "review", "author": item.review.User.Login,
 				"body": item.review.Body, "url": item.review.HTMLURL, "repository": target.Repository,
 				"number": target.Number, "pull_request_url": target.URL}
-			eventID := workflowV2GitHubFeedbackEventID(target, "review",
-				strconv.FormatInt(item.review.ID, 10), item.review.Body, "", 0)
-			if _, err := store.ApplyReviewFeedback(ctx, target, eventID, feedback, typesv2.EvidenceProvenance{
+			rawID := strconv.FormatInt(item.review.ID, 10)
+			eventID := workflowV2GitHubFeedbackEventID(target, "review", rawID)
+			if _, err := store.ReconcileReviewFeedback(ctx, target, eventID, feedback, typesv2.EvidenceProvenance{
 				Producer: string(workflowv2.ProducerReview), Principal: item.review.User.Login,
-				ExternalID: strconv.FormatInt(item.review.ID, 10), ObservedAt: item.observed, Reconciled: true,
+				ExternalID: "review:" + rawID, ObservedAt: item.observed, Reconciled: true,
 			}); err != nil && ctx.Err() == nil {
 				log.Printf("[workflow-v2 github] reconcile feedback for run %s: %v", target.RunID, err)
 			}
@@ -372,11 +372,11 @@ func (s *Server) reconcileWorkflowV2GitHubComment(ctx context.Context, store *wo
 	if comment.Line > 0 {
 		feedback["line"] = comment.Line
 	}
-	eventID := workflowV2GitHubFeedbackEventID(target, kind, strconv.FormatInt(comment.ID, 10),
-		comment.Body, comment.Path, comment.Line)
-	if _, err := store.ApplyReviewFeedback(ctx, target, eventID, feedback, typesv2.EvidenceProvenance{
+	rawID := strconv.FormatInt(comment.ID, 10)
+	eventID := workflowV2GitHubFeedbackEventID(target, kind, rawID)
+	if _, err := store.ReconcileReviewFeedback(ctx, target, eventID, feedback, typesv2.EvidenceProvenance{
 		Producer: string(workflowv2.ProducerReview), Principal: comment.User.Login,
-		ExternalID: strconv.FormatInt(comment.ID, 10), ObservedAt: observed, Reconciled: true,
+		ExternalID: kind + ":" + rawID, ObservedAt: observed, Reconciled: true,
 	}); err != nil && ctx.Err() == nil {
 		log.Printf("[workflow-v2 github] reconcile %s for run %s: %v", kind, target.RunID, err)
 	}

--- a/pkg/hub/workflow_v2_github_reconciler.go
+++ b/pkg/hub/workflow_v2_github_reconciler.go
@@ -268,9 +268,8 @@ func (s *Server) reconcileWorkflowV2GitHubReviews(ctx context.Context, store *wo
 			feedback := map[string]interface{}{"kind": "review", "author": item.review.User.Login,
 				"body": item.review.Body, "url": item.review.HTMLURL, "repository": target.Repository,
 				"number": target.Number, "pull_request_url": target.URL}
-			eventID := workflowV2GitHubEventID(target.RunID, "review_feedback", "reconciled",
-				strconv.FormatInt(item.review.ID, 10), item.review.SubmittedAt,
-				workflowV2GitHubEventID("", item.review.State, item.review.Body))
+			eventID := workflowV2GitHubFeedbackEventID(target, "review",
+				strconv.FormatInt(item.review.ID, 10), item.review.Body, "", 0)
 			if _, err := store.ApplyReviewFeedback(ctx, target, eventID, feedback, typesv2.EvidenceProvenance{
 				Producer: string(workflowv2.ProducerReview), Principal: item.review.User.Login,
 				ExternalID: strconv.FormatInt(item.review.ID, 10), ObservedAt: item.observed, Reconciled: true,
@@ -373,8 +372,8 @@ func (s *Server) reconcileWorkflowV2GitHubComment(ctx context.Context, store *wo
 	if comment.Line > 0 {
 		feedback["line"] = comment.Line
 	}
-	eventID := workflowV2GitHubEventID(target.RunID, "review_feedback", kind,
-		strconv.FormatInt(comment.ID, 10), comment.UpdatedAt)
+	eventID := workflowV2GitHubFeedbackEventID(target, kind, strconv.FormatInt(comment.ID, 10),
+		comment.Body, comment.Path, comment.Line)
 	if _, err := store.ApplyReviewFeedback(ctx, target, eventID, feedback, typesv2.EvidenceProvenance{
 		Producer: string(workflowv2.ProducerReview), Principal: comment.User.Login,
 		ExternalID: strconv.FormatInt(comment.ID, 10), ObservedAt: observed, Reconciled: true,

--- a/pkg/hub/workflow_v2_github_reconciler_test.go
+++ b/pkg/hub/workflow_v2_github_reconciler_test.go
@@ -1,0 +1,191 @@
+package hub
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/hub/workflowv2"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+	typesv2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
+)
+
+func TestWorkflowV2PeriodicReconciliationRecoversLostGitHubWebhooks(t *testing.T) {
+	oldTransport := http.DefaultTransport
+	oldClient := defaultGitHubClient
+	http.DefaultTransport = githubAppTokenTransport{base: oldTransport}
+	defaultGitHubClient = newGitHubClient()
+	t.Cleanup(func() {
+		http.DefaultTransport = oldTransport
+		defaultGitHubClient = oldClient
+	})
+
+	var pullRequests, checks, workflows, reviews, inlineComments, discussionComments atomic.Int64
+	gh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/repos/org/api/pulls/10"):
+			pullRequests.Add(1)
+			_, _ = w.Write([]byte(`{"id":410,"html_url":"https://github.com/org/api/pull/10","state":"open","merged":false,
+				"head":{"sha":"head-2","ref":"feature"},"base":{"ref":"main"}}`))
+		case strings.Contains(r.URL.Path, "/check-runs"):
+			checks.Add(1)
+			_, _ = w.Write([]byte(`{"check_runs":[
+				{"id":101,"name":"lint","status":"completed","conclusion":"success","completed_at":"2026-08-09T12:00:00Z","app":{"slug":"github-actions"},"check_suite":{"id":501}},
+				{"id":102,"name":"unit","status":"completed","conclusion":"success","completed_at":"2026-08-09T12:00:01Z","app":{"slug":"github-actions"},"check_suite":{"id":502}}
+			]}`))
+		case strings.Contains(r.URL.Path, "/actions/runs"):
+			workflows.Add(1)
+			_, _ = w.Write([]byte(`{"workflow_runs":[
+				{"name":"CI","path":".github/workflows/ci.yml","check_suite_id":501},
+				{"name":"CI","path":".github/workflows/ci.yml","check_suite_id":502}
+			]}`))
+		case strings.HasSuffix(r.URL.Path, "/repos/org/api/pulls/10/reviews"):
+			reviews.Add(1)
+			_, _ = w.Write([]byte(`[
+				{"id":77,"state":"CHANGES_REQUESTED","body":"Recover this missed review.",
+				 "html_url":"https://github.com/org/api/pull/10#pullrequestreview-77","commit_id":"head-2",
+				 "submitted_at":"2026-08-09T12:01:00Z","user":{"login":"alice","type":"User"}},
+				{"id":76,"state":"APPROVED","body":"stale","commit_id":"head-1",
+				 "submitted_at":"2026-08-09T11:00:00Z","user":{"login":"bob","type":"User"}}
+			]`))
+		case strings.HasSuffix(r.URL.Path, "/repos/org/api/pulls/10/comments"):
+			inlineComments.Add(1)
+			_, _ = w.Write([]byte(`[
+				{"id":88,"body":"Recover this missed inline comment.",
+				 "html_url":"https://github.com/org/api/pull/10#discussion_r88","path":"api.go","line":42,
+				 "commit_id":"head-2","created_at":"2026-08-09T12:02:00Z","updated_at":"2026-08-09T12:02:00Z",
+				 "user":{"login":"carol","type":"User"}},
+				{"id":87,"body":"old head","commit_id":"head-1","created_at":"2026-08-09T11:02:00Z",
+				 "updated_at":"2026-08-09T11:02:00Z","user":{"login":"dave","type":"User"}}
+			]`))
+		case strings.HasSuffix(r.URL.Path, "/repos/org/api/issues/10/comments"):
+			discussionComments.Add(1)
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(gh.Close)
+
+	cfg := &types.HubConfig{
+		ClawToken:  "claw-token",
+		GitHubApps: []*types.GitHubAppConfig{{AppID: 1, PrivateKeyPEM: testGitHubAppPEM(t)}},
+		Factories: []*types.FactoryConfig{{Name: "token-scope", Integration: "github", Template: "elasticclaw",
+			Provider: "noop", Repos: []string{"org/api"}, WebhookSecret: "secret",
+			Trigger: &types.GitHubTrigger{On: "pull_request"}}},
+		Providers: map[string]types.ProviderConfig{"noop": {Type: "noop"}},
+	}
+	s, db := NewTestServerWithConfig(t, cfg, gh.URL, "", "")
+	if _, err := db.Exec(`INSERT INTO claws(id,tenant_id,name,template,provider,status,created_at)
+		VALUES('claw-v2-reconcile','test-tenant-id','v2-reconcile','github-v2','noop','connected',?)`, now()); err != nil {
+		t.Fatal(err)
+	}
+	store := workflowv2.NewStore(db)
+	run, err := store.CreateRun(context.Background(), workflowv2.CreateRunRequest{
+		ID: "run-v2-reconcile", TenantID: "test-tenant-id", InitialClawID: "claw-v2-reconcile",
+		WorkspaceYAML: []byte(workflowV2GitHubWorkspaceYAML), WorkflowYAML: []byte(workflowV2GitHubWorkflowYAML),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	prURL := "https://github.com/org/api/pull/10"
+	observed := time.Date(2026, 8, 9, 11, 0, 0, 0, time.UTC)
+	if _, err := store.SubmitDelivery(context.Background(), run.ID, run.CurrentAttemptID, typesv2.DeliveryManifest{
+		PullRequests: []typesv2.PullRequestClaim{{URL: prURL}},
+	}, workflowv2.PullRequestVerifierFunc(func(context.Context, workflowv2.Run, *typesv2.Workspace,
+		typesv2.PullRequestClaim) (typesv2.VerifiedPullRequest, error) {
+		return typesv2.VerifiedPullRequest{URL: prURL, RepositoryName: "api", Repository: "org/api", Number: 10,
+			SourceBranch: "feature", BaseBranch: "main", HeadSHA: "head-1", State: "open", VerifiedAt: observed,
+			Provenance: typesv2.EvidenceProvenance{Producer: string(workflowv2.ProducerSourceControl),
+				Connection: "github", ObservedAt: observed}}, nil
+	})); err != nil {
+		t.Fatal(err)
+	}
+
+	// No webhook entrypoint is called: the periodic pass must recover every
+	// authoritative domain observation from GitHub.
+	if err := s.reconcileWorkflowV2GitHub(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.drainWorkflowV2Effects(context.Background(), "test-v2-reconcile-worker"); err != nil {
+		t.Fatal(err)
+	}
+	var head, prState, runState, phase, instructions string
+	if err := db.QueryRow(`SELECT current_head_sha,state FROM workflow_v2_delivery_prs WHERE run_id=?`,
+		run.ID).Scan(&head, &prState); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT state,display_phase FROM workflow_v2_runs WHERE id=?`, run.ID).
+		Scan(&runState, &phase); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT instructions FROM workflow_v2_agent_tasks WHERE run_id=?`, run.ID).
+		Scan(&instructions); err != nil {
+		t.Fatal(err)
+	}
+	if head != "head-2" || prState != "open" || runState != "fixing" || phase != "build" ||
+		!strings.Contains(instructions, "Recover this missed inline comment") {
+		t.Fatalf("head/pr/run/phase/instructions = %q/%q/%q/%q/%q", head, prState, runState, phase, instructions)
+	}
+	var currentEvidence, messages, eventCount, taskCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_evidence WHERE run_id=? AND superseded_at=0`,
+		run.ID).Scan(&currentEvidence); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id='claw-v2-reconcile'`).Scan(&messages); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_events WHERE run_id=?`, run.ID).Scan(&eventCount); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_agent_tasks WHERE run_id=?`, run.ID).Scan(&taskCount); err != nil {
+		t.Fatal(err)
+	}
+	if currentEvidence != 3 || messages != 0 || pullRequests.Load() != 1 || checks.Load() != 1 ||
+		workflows.Load() != 1 || reviews.Load() != 1 || inlineComments.Load() != 1 || discussionComments.Load() != 1 {
+		t.Fatalf("evidence/messages/API calls = %d/%d/%d/%d/%d/%d/%d/%d", currentEvidence, messages,
+			pullRequests.Load(), checks.Load(), workflows.Load(), reviews.Load(), inlineComments.Load(), discussionComments.Load())
+	}
+
+	// A second pass converges the CI policy fact to the aggregate revision that
+	// includes the review snapshot written later in the first pass.
+	if err := s.reconcileWorkflowV2GitHub(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	var convergedEvents, convergedTasks int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_events WHERE run_id=?`, run.ID).Scan(&convergedEvents); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_agent_tasks WHERE run_id=?`, run.ID).Scan(&convergedTasks); err != nil {
+		t.Fatal(err)
+	}
+	if convergedTasks != taskCount {
+		t.Fatalf("reconciliation convergence changed task count from %d to %d", taskCount, convergedTasks)
+	}
+	if err := s.reconcileWorkflowV2GitHub(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	var replayEvents, replayTasks int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_events WHERE run_id=?`, run.ID).Scan(&replayEvents); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_agent_tasks WHERE run_id=?`, run.ID).Scan(&replayTasks); err != nil {
+		t.Fatal(err)
+	}
+	if replayEvents != convergedEvents || replayTasks != convergedTasks {
+		t.Fatalf("reconciliation replay changed events/tasks from %d/%d to %d/%d",
+			convergedEvents, convergedTasks, replayEvents, replayTasks)
+	}
+}
+
+func TestWorkflowV2ReconciledMergeWinsOverSimultaneousHeadChange(t *testing.T) {
+	target := workflowv2.DeliveryTarget{HeadSHA: "head-1", State: "open"}
+	verified := typesv2.VerifiedPullRequest{HeadSHA: "head-2", State: "merged"}
+	if got := workflowV2ReconciledPREventKind(target, verified); got != "pull_request.merged" {
+		t.Fatalf("event kind = %q, want pull_request.merged", got)
+	}
+}

--- a/pkg/hub/workflow_v2_github_reconciler_test.go
+++ b/pkg/hub/workflow_v2_github_reconciler_test.go
@@ -26,6 +26,7 @@ func TestWorkflowV2PeriodicReconciliationRecoversLostGitHubWebhooks(t *testing.T
 
 	var pullRequests, checks, workflows, reviews, inlineComments, discussionComments atomic.Int64
 	var exposeWebhookComment atomic.Bool
+	var editWebhookComment atomic.Bool
 	gh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case strings.HasSuffix(r.URL.Path, "/repos/org/api/pulls/10"):
@@ -64,9 +65,15 @@ func TestWorkflowV2PeriodicReconciliationRecoversLostGitHubWebhooks(t *testing.T
 				 "updated_at":"2026-08-09T11:02:00Z","user":{"login":"dave","type":"User"}}
 			`
 			if exposeWebhookComment.Load() {
-				body += `,{"id":89,"body":"Webhook and poll see the same feedback.",
+				commentBody := "Webhook and poll see the same feedback."
+				updatedAt := "2026-08-09T12:03:00Z"
+				if editWebhookComment.Load() {
+					commentBody = "Edited feedback converges without another fix task."
+					updatedAt = "2026-08-09T12:04:00Z"
+				}
+				body += `,{"id":89,"body":"` + commentBody + `",
 				 "html_url":"https://github.com/org/api/pull/10#discussion_r89","path":"api.go","line":43,
-				 "commit_id":"head-2","created_at":"2026-08-09T12:03:00Z","updated_at":"2026-08-09T12:03:00Z",
+				 "commit_id":"head-2","created_at":"2026-08-09T12:03:00Z","updated_at":"` + updatedAt + `",
 				 "user":{"login":"erin","type":"User"}}`
 			}
 			_, _ = w.Write([]byte(body + `]`))
@@ -204,6 +211,36 @@ func TestWorkflowV2PeriodicReconciliationRecoversLostGitHubWebhooks(t *testing.T
 	if convergedTasks != taskCount {
 		t.Fatalf("reconciliation convergence changed task count from %d to %d", taskCount, convergedTasks)
 	}
+	editWebhookComment.Store(true)
+	if err := s.reconcileWorkflowV2GitHub(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	var receivedAfterEdit, reconciledAfterEdit, tasksAfterEdit int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_events
+		WHERE run_id=? AND kind='review.feedback.received'`, run.ID).Scan(&receivedAfterEdit); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_events
+		WHERE run_id=? AND kind='review.feedback.reconciled'`, run.ID).Scan(&reconciledAfterEdit); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_agent_tasks WHERE run_id=?`, run.ID).Scan(&tasksAfterEdit); err != nil {
+		t.Fatal(err)
+	}
+	var feedbackJSON string
+	if err := db.QueryRow(`SELECT value_json FROM workflow_v2_facts
+		WHERE run_id=? AND fact_key='review.feedback'`, run.ID).Scan(&feedbackJSON); err != nil {
+		t.Fatal(err)
+	}
+	if receivedAfterEdit != feedbackAfterWebhook || reconciledAfterEdit != 1 || tasksAfterEdit != convergedTasks ||
+		!strings.Contains(feedbackJSON, "Edited feedback converges") {
+		t.Fatalf("edited feedback received/reconciled/tasks/fact = %d/%d/%d/%s",
+			receivedAfterEdit, reconciledAfterEdit, tasksAfterEdit, feedbackJSON)
+	}
+	var revisedEvents int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_events WHERE run_id=?`, run.ID).Scan(&revisedEvents); err != nil {
+		t.Fatal(err)
+	}
 	if err := s.reconcileWorkflowV2GitHub(context.Background()); err != nil {
 		t.Fatal(err)
 	}
@@ -214,9 +251,9 @@ func TestWorkflowV2PeriodicReconciliationRecoversLostGitHubWebhooks(t *testing.T
 	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_agent_tasks WHERE run_id=?`, run.ID).Scan(&replayTasks); err != nil {
 		t.Fatal(err)
 	}
-	if replayEvents != convergedEvents || replayTasks != convergedTasks {
+	if replayEvents != revisedEvents || replayTasks != convergedTasks {
 		t.Fatalf("reconciliation replay changed events/tasks from %d/%d to %d/%d",
-			convergedEvents, convergedTasks, replayEvents, replayTasks)
+			revisedEvents, convergedTasks, replayEvents, replayTasks)
 	}
 }
 

--- a/pkg/hub/workflow_v2_github_reconciler_test.go
+++ b/pkg/hub/workflow_v2_github_reconciler_test.go
@@ -25,6 +25,7 @@ func TestWorkflowV2PeriodicReconciliationRecoversLostGitHubWebhooks(t *testing.T
 	})
 
 	var pullRequests, checks, workflows, reviews, inlineComments, discussionComments atomic.Int64
+	var exposeWebhookComment atomic.Bool
 	gh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case strings.HasSuffix(r.URL.Path, "/repos/org/api/pulls/10"):
@@ -54,14 +55,21 @@ func TestWorkflowV2PeriodicReconciliationRecoversLostGitHubWebhooks(t *testing.T
 			]`))
 		case strings.HasSuffix(r.URL.Path, "/repos/org/api/pulls/10/comments"):
 			inlineComments.Add(1)
-			_, _ = w.Write([]byte(`[
+			body := `[
 				{"id":88,"body":"Recover this missed inline comment.",
 				 "html_url":"https://github.com/org/api/pull/10#discussion_r88","path":"api.go","line":42,
 				 "commit_id":"head-2","created_at":"2026-08-09T12:02:00Z","updated_at":"2026-08-09T12:02:00Z",
 				 "user":{"login":"carol","type":"User"}},
 				{"id":87,"body":"old head","commit_id":"head-1","created_at":"2026-08-09T11:02:00Z",
 				 "updated_at":"2026-08-09T11:02:00Z","user":{"login":"dave","type":"User"}}
-			]`))
+			`
+			if exposeWebhookComment.Load() {
+				body += `,{"id":89,"body":"Webhook and poll see the same feedback.",
+				 "html_url":"https://github.com/org/api/pull/10#discussion_r89","path":"api.go","line":43,
+				 "commit_id":"head-2","created_at":"2026-08-09T12:03:00Z","updated_at":"2026-08-09T12:03:00Z",
+				 "user":{"login":"erin","type":"User"}}`
+			}
+			_, _ = w.Write([]byte(body + `]`))
 		case strings.HasSuffix(r.URL.Path, "/repos/org/api/issues/10/comments"):
 			discussionComments.Add(1)
 			_, _ = w.Write([]byte(`[]`))
@@ -150,6 +158,27 @@ func TestWorkflowV2PeriodicReconciliationRecoversLostGitHubWebhooks(t *testing.T
 		t.Fatalf("evidence/messages/API calls = %d/%d/%d/%d/%d/%d/%d/%d", currentEvidence, messages,
 			pullRequests.Load(), checks.Load(), workflows.Load(), reviews.Load(), inlineComments.Load(), discussionComments.Load())
 	}
+	var webhookComment githubPRReviewCommentPayload
+	webhookComment.Action = "created"
+	webhookComment.Comment.ID = 89
+	webhookComment.Comment.Body = "Webhook and poll see the same feedback."
+	webhookComment.Comment.HTMLURL = "https://github.com/org/api/pull/10#discussion_r89"
+	webhookComment.Comment.Path = "api.go"
+	webhookComment.Comment.Line = 43
+	webhookComment.Comment.CommitID = "head-2"
+	webhookComment.Comment.UpdatedAt = "2026-08-09T12:03:00Z"
+	webhookComment.Comment.User.Login = "erin"
+	webhookComment.Comment.User.Type = "User"
+	webhookComment.PullRequest.Number = 10
+	webhookComment.PullRequest.HTMLURL = prURL
+	webhookComment.Repository.FullName = "org/api"
+	s.processGitHubPRReviewCommentEvent(webhookComment)
+	var feedbackAfterWebhook int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_events
+		WHERE run_id=? AND kind='review.feedback.received'`, run.ID).Scan(&feedbackAfterWebhook); err != nil {
+		t.Fatal(err)
+	}
+	exposeWebhookComment.Store(true)
 
 	// A second pass converges the CI policy fact to the aggregate revision that
 	// includes the review snapshot written later in the first pass.
@@ -162,6 +191,15 @@ func TestWorkflowV2PeriodicReconciliationRecoversLostGitHubWebhooks(t *testing.T
 	}
 	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_agent_tasks WHERE run_id=?`, run.ID).Scan(&convergedTasks); err != nil {
 		t.Fatal(err)
+	}
+	var feedbackAfterPoll int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_events
+		WHERE run_id=? AND kind='review.feedback.received'`, run.ID).Scan(&feedbackAfterPoll); err != nil {
+		t.Fatal(err)
+	}
+	if feedbackAfterPoll != feedbackAfterWebhook {
+		t.Fatalf("webhook feedback count changed from %d to %d after polling the same provider comment",
+			feedbackAfterWebhook, feedbackAfterPoll)
 	}
 	if convergedTasks != taskCount {
 		t.Fatalf("reconciliation convergence changed task count from %d to %d", taskCount, convergedTasks)

--- a/pkg/hub/workflowv2/evidence.go
+++ b/pkg/hub/workflowv2/evidence.go
@@ -290,44 +290,63 @@ func (s *Store) publishEvidencePolicyEvents(ctx context.Context, runID, attemptI
 	if workflow.Workflow.Delivery != nil && workflow.Workflow.Delivery.PullRequests != nil {
 		requirements := workflow.Workflow.Delivery.PullRequests
 		if domain == "ci" && requirements.CIPolicy != "" {
-			status := result.CIStatus
-			event, err := s.applyDeliveryPolicyEvent(ctx, runID, result, EventInput{
-				ID: uuid.NewString(), Kind: "ci.policy.evaluated", AttemptID: attemptID, Producer: ProducerCI,
-				Payload: map[string]interface{}{"ci": map[string]interface{}{
-					"policy": requirements.CIPolicy, "status": status, "revision": result.Revision,
-				}},
-				Facts: map[string]interface{}{
-					"ci.policy": requirements.CIPolicy, "ci.status": status, "ci.policy_revision": result.Revision,
-				},
-				Provenance: typesv2.EvidenceProvenance{Producer: string(ProducerCI), ObservedAt: observed},
-			})
+			unchanged, err := s.policyRevisionMatches(ctx, runID, "ci.policy_revision", result.Revision)
 			if err != nil {
 				return err
 			}
-			if event.Disposition != typesv2.DispositionAccepted {
-				return fmt.Errorf("CI policy event was %s: %s", event.Disposition, event.Reason)
+			if !unchanged {
+				status := result.CIStatus
+				event, err := s.applyDeliveryPolicyEvent(ctx, runID, result, EventInput{
+					ID: uuid.NewString(), Kind: "ci.policy.evaluated", AttemptID: attemptID, Producer: ProducerCI,
+					Payload: map[string]interface{}{"ci": map[string]interface{}{
+						"policy": requirements.CIPolicy, "status": status, "revision": result.Revision,
+					}},
+					Facts: map[string]interface{}{
+						"ci.policy": requirements.CIPolicy, "ci.status": status, "ci.policy_revision": result.Revision,
+					},
+					Provenance: typesv2.EvidenceProvenance{Producer: string(ProducerCI), ObservedAt: observed},
+				})
+				if err != nil {
+					return err
+				}
+				if event.Disposition != typesv2.DispositionAccepted {
+					return fmt.Errorf("CI policy event was %s: %s", event.Disposition, event.Reason)
+				}
 			}
 		}
 		if domain == "review" && requirements.ReviewPolicy != "" {
-			status := result.ReviewStatus
-			event, err := s.applyDeliveryPolicyEvent(ctx, runID, result, EventInput{
-				ID: uuid.NewString(), Kind: "review.policy.evaluated", AttemptID: attemptID, Producer: ProducerReview,
-				Payload: map[string]interface{}{"review": map[string]interface{}{
-					"policy": requirements.ReviewPolicy, "status": status, "revision": result.Revision,
-				}},
-				Facts: map[string]interface{}{
-					"review.policy": requirements.ReviewPolicy, "review.status": status,
-					"review.policy_revision": result.Revision,
-				},
-				Provenance: typesv2.EvidenceProvenance{Producer: string(ProducerReview), ObservedAt: observed},
-			})
+			unchanged, err := s.policyRevisionMatches(ctx, runID, "review.policy_revision", result.Revision)
 			if err != nil {
 				return err
 			}
-			if event.Disposition != typesv2.DispositionAccepted {
-				return fmt.Errorf("review policy event was %s: %s", event.Disposition, event.Reason)
+			if !unchanged {
+				status := result.ReviewStatus
+				event, err := s.applyDeliveryPolicyEvent(ctx, runID, result, EventInput{
+					ID: uuid.NewString(), Kind: "review.policy.evaluated", AttemptID: attemptID, Producer: ProducerReview,
+					Payload: map[string]interface{}{"review": map[string]interface{}{
+						"policy": requirements.ReviewPolicy, "status": status, "revision": result.Revision,
+					}},
+					Facts: map[string]interface{}{
+						"review.policy": requirements.ReviewPolicy, "review.status": status,
+						"review.policy_revision": result.Revision,
+					},
+					Provenance: typesv2.EvidenceProvenance{Producer: string(ProducerReview), ObservedAt: observed},
+				})
+				if err != nil {
+					return err
+				}
+				if event.Disposition != typesv2.DispositionAccepted {
+					return fmt.Errorf("review policy event was %s: %s", event.Disposition, event.Reason)
+				}
 			}
 		}
+	}
+	unchanged, err := s.policyRevisionMatches(ctx, runID, "delivery.policy_revision", result.Revision)
+	if err != nil {
+		return err
+	}
+	if unchanged {
+		return nil
 	}
 	deliveryEvent, err := s.applyDeliveryPolicyEvent(ctx, runID, result, EventInput{
 		ID: uuid.NewString(), Kind: "workflow.delivery.evaluated", AttemptID: attemptID, Producer: ProducerEngine,
@@ -346,6 +365,23 @@ func (s *Store) publishEvidencePolicyEvents(ctx context.Context, runID, attemptI
 		return fmt.Errorf("delivery policy event was %s: %s", deliveryEvent.Disposition, deliveryEvent.Reason)
 	}
 	return nil
+}
+
+func (s *Store) policyRevisionMatches(ctx context.Context, runID, factKey, revision string) (bool, error) {
+	var valueJSON string
+	err := s.db.QueryRowContext(ctx, `SELECT value_json FROM workflow_v2_facts WHERE run_id=? AND fact_key=?`,
+		runID, factKey).Scan(&valueJSON)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	var current string
+	if err := json.Unmarshal([]byte(valueJSON), &current); err != nil {
+		return false, fmt.Errorf("decode %s: %w", factKey, err)
+	}
+	return current == revision, nil
 }
 
 func (s *Store) applyDeliveryPolicyEvent(ctx context.Context, runID string, expected DeliveryPolicyResult,

--- a/pkg/hub/workflowv2/evidence_test.go
+++ b/pkg/hub/workflowv2/evidence_test.go
@@ -344,8 +344,12 @@ func TestSuspendedRunsAreNotExternalDeliveryTargets(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(byPR) != 0 || len(byHead) != 0 {
-		t.Fatalf("suspended targets by PR/head = %#v/%#v", byPR, byHead)
+	all, err := store.ActiveDeliveryTargetsAll(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(byPR) != 0 || len(byHead) != 0 || len(all) != 0 {
+		t.Fatalf("suspended targets by PR/head/all = %#v/%#v/%#v", byPR, byHead, all)
 	}
 }
 
@@ -487,6 +491,51 @@ func TestReconciledCheckSetCannotTransitionOnMixedSnapshot(t *testing.T) {
 	}
 	if currentRows != 0 {
 		t.Fatalf("empty snapshot retained %d current evidence rows", currentRows)
+	}
+}
+
+func TestPolicyPublicationSuppressesIdenticalSnapshotsButAllowsRevisionCycles(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	_, pr := createPolicyDelivery(t, store, "run-policy-revisions", "head-1", "open")
+	observed := time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+	scopes := []workflowv2.EvidenceScope{{RunID: "run-policy-revisions", PRID: pr.ID,
+		HeadSHA: pr.HeadSHA, Domain: "ci", Connection: "github-actions", Pipeline: "github-pr"}}
+	inputs := []workflowv2.EvidenceInput{
+		{RunID: "run-policy-revisions", PRID: pr.ID, HeadSHA: pr.HeadSHA, Domain: "ci",
+			Connection: "github-actions", ExternalID: "github-pr:lint", Kind: "lint", Status: "success",
+			Payload: map[string]interface{}{"pipeline": "github-pr"}, ObservedAt: observed,
+			Provenance: typesv2.EvidenceProvenance{Producer: string(workflowv2.ProducerCI), ObservedAt: observed}},
+		{RunID: "run-policy-revisions", PRID: pr.ID, HeadSHA: pr.HeadSHA, Domain: "ci",
+			Connection: "github-actions", ExternalID: "github-pr:unit", Kind: "unit", Status: "success",
+			Payload: map[string]interface{}{"pipeline": "github-pr"}, ObservedAt: observed.Add(time.Second),
+			Provenance: typesv2.EvidenceProvenance{Producer: string(workflowv2.ProducerCI), ObservedAt: observed.Add(time.Second)}},
+	}
+	reconcile := func(snapshot []workflowv2.EvidenceInput) {
+		t.Helper()
+		if _, err := store.ReconcileEvidenceSnapshot(context.Background(), scopes, snapshot, workflowv2.ProducerCI); err != nil {
+			t.Fatal(err)
+		}
+	}
+	countPolicyEvents := func() int {
+		t.Helper()
+		var count int
+		if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_events
+			WHERE run_id='run-policy-revisions' AND kind='ci.policy.evaluated'`).Scan(&count); err != nil {
+			t.Fatal(err)
+		}
+		return count
+	}
+
+	reconcile(inputs)
+	reconcile(inputs)
+	if got := countPolicyEvents(); got != 1 {
+		t.Fatalf("identical success snapshots published %d CI policy events, want 1", got)
+	}
+	reconcile(nil)
+	reconcile(inputs)
+	if got := countPolicyEvents(); got != 3 {
+		t.Fatalf("success -> pending -> success published %d CI policy events, want 3", got)
 	}
 }
 

--- a/pkg/hub/workflowv2/reconciliation.go
+++ b/pkg/hub/workflowv2/reconciliation.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	typesv2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
 	"github.com/google/uuid"
@@ -23,6 +24,7 @@ type DeliveryTarget struct {
 	Number         int
 	URL            string
 	HeadSHA        string
+	HeadObservedAt time.Time
 	State          string
 	WorkspaceYAML  string
 	WorkflowYAML   string
@@ -40,7 +42,9 @@ func (s *Store) ActiveDeliveryTargets(ctx context.Context, repository string, nu
 		return nil, fmt.Errorf("repository and positive pull request number are required")
 	}
 	rows, err := s.db.QueryContext(ctx, `SELECT r.id,r.current_attempt_id,p.id,p.repository_name,p.repository,
-		p.pr_number,p.url,p.current_head_sha,p.state,r.workspace_yaml,r.workflow_yaml
+		p.pr_number,p.url,p.current_head_sha,p.state,r.workspace_yaml,r.workflow_yaml,
+		COALESCE((SELECT h.observed_at FROM workflow_v2_delivery_heads h WHERE h.pr_id=p.id
+			ORDER BY h.generation DESC LIMIT 1),p.verified_at)
 		FROM workflow_v2_delivery_prs p JOIN workflow_v2_runs r ON r.id=p.run_id
 		JOIN workflow_v2_attempts a ON a.id=r.current_attempt_id
 		WHERE p.repository=? AND p.pr_number=? AND p.active=1 AND r.status='active'
@@ -49,17 +53,7 @@ func (s *Store) ActiveDeliveryTargets(ctx context.Context, repository string, nu
 		return nil, err
 	}
 	defer rows.Close()
-	var targets []DeliveryTarget
-	for rows.Next() {
-		var target DeliveryTarget
-		if err := rows.Scan(&target.RunID, &target.AttemptID, &target.PRID, &target.RepositoryName,
-			&target.Repository, &target.Number, &target.URL, &target.HeadSHA, &target.State,
-			&target.WorkspaceYAML, &target.WorkflowYAML); err != nil {
-			return nil, err
-		}
-		targets = append(targets, target)
-	}
-	return targets, rows.Err()
+	return scanDeliveryTargets(rows)
 }
 
 // ActiveDeliveryTargetsByHead resolves check webhooks that omit pull request
@@ -74,7 +68,9 @@ func (s *Store) ActiveDeliveryTargetsByHead(ctx context.Context, headSHA string)
 		return nil, fmt.Errorf("pull request head SHA is required")
 	}
 	rows, err := s.db.QueryContext(ctx, `SELECT r.id,r.current_attempt_id,p.id,p.repository_name,p.repository,
-		p.pr_number,p.url,p.current_head_sha,p.state,r.workspace_yaml,r.workflow_yaml
+		p.pr_number,p.url,p.current_head_sha,p.state,r.workspace_yaml,r.workflow_yaml,
+		COALESCE((SELECT h.observed_at FROM workflow_v2_delivery_heads h WHERE h.pr_id=p.id
+			ORDER BY h.generation DESC LIMIT 1),p.verified_at)
 		FROM workflow_v2_delivery_prs p JOIN workflow_v2_runs r ON r.id=p.run_id
 		JOIN workflow_v2_attempts a ON a.id=r.current_attempt_id
 		WHERE p.current_head_sha=? AND p.active=1 AND r.status='active' AND a.status='active'
@@ -83,14 +79,42 @@ func (s *Store) ActiveDeliveryTargetsByHead(ctx context.Context, headSHA string)
 		return nil, err
 	}
 	defer rows.Close()
+	return scanDeliveryTargets(rows)
+}
+
+// ActiveDeliveryTargetsAll returns every currently owned V2 delivery subject
+// for periodic provider reconciliation. V1 rows and suspended runs are never
+// selected.
+func (s *Store) ActiveDeliveryTargetsAll(ctx context.Context) ([]DeliveryTarget, error) {
+	if s == nil || s.db == nil {
+		return nil, fmt.Errorf("workflow v2 store is not configured")
+	}
+	rows, err := s.db.QueryContext(ctx, `SELECT r.id,r.current_attempt_id,p.id,p.repository_name,p.repository,
+		p.pr_number,p.url,p.current_head_sha,p.state,r.workspace_yaml,r.workflow_yaml,
+		COALESCE((SELECT h.observed_at FROM workflow_v2_delivery_heads h WHERE h.pr_id=p.id
+			ORDER BY h.generation DESC LIMIT 1),p.verified_at)
+		FROM workflow_v2_delivery_prs p JOIN workflow_v2_runs r ON r.id=p.run_id
+		JOIN workflow_v2_attempts a ON a.id=r.current_attempt_id
+		WHERE p.active=1 AND r.status='active' AND a.status='active'
+		ORDER BY r.updated_at,p.repository,p.pr_number,r.id`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanDeliveryTargets(rows)
+}
+
+func scanDeliveryTargets(rows *sql.Rows) ([]DeliveryTarget, error) {
 	var targets []DeliveryTarget
 	for rows.Next() {
 		var target DeliveryTarget
+		var headObservedAt int64
 		if err := rows.Scan(&target.RunID, &target.AttemptID, &target.PRID, &target.RepositoryName,
 			&target.Repository, &target.Number, &target.URL, &target.HeadSHA, &target.State,
-			&target.WorkspaceYAML, &target.WorkflowYAML); err != nil {
+			&target.WorkspaceYAML, &target.WorkflowYAML, &headObservedAt); err != nil {
 			return nil, err
 		}
+		target.HeadObservedAt = time.UnixMilli(headObservedAt).UTC()
 		targets = append(targets, target)
 	}
 	return targets, rows.Err()
@@ -137,6 +161,9 @@ func (s *Store) ReconcilePullRequest(ctx context.Context, target DeliveryTarget,
 			WHERE id=? AND run_id=? AND repository=? AND pr_number=? AND active=1`, target.PRID,
 			target.RunID, target.Repository, target.Number).Scan(&currentHead, &currentState); err != nil {
 			return err
+		}
+		if currentHead != target.HeadSHA || currentState != target.State {
+			return fmt.Errorf("verified delivery changed while reconciling")
 		}
 		provenanceJSON, err := marshalObject(verified.Provenance)
 		if err != nil {

--- a/pkg/hub/workflowv2/reconciliation.go
+++ b/pkg/hub/workflowv2/reconciliation.go
@@ -1,8 +1,11 @@
 package workflowv2
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -232,6 +235,66 @@ func (s *Store) ReconcilePullRequest(ctx context.Context, target DeliveryTarget,
 // in the resulting agent task; no conversation row participates.
 func (s *Store) ApplyReviewFeedback(ctx context.Context, target DeliveryTarget, eventID string,
 	feedback map[string]interface{}, provenance typesv2.EvidenceProvenance) (EventResult, error) {
+	return s.applyReviewFeedbackEvent(ctx, target, eventID, "review.feedback.received", feedback, provenance)
+}
+
+// ReconcileReviewFeedback converges edits to an existing provider feedback
+// object without emitting review.feedback.received twice. The stable received
+// event controls workflow execution; a content revision is an auditable but
+// distinct reconciliation event that only refreshes the protected typed fact.
+func (s *Store) ReconcileReviewFeedback(ctx context.Context, target DeliveryTarget, eventID string,
+	feedback map[string]interface{}, provenance typesv2.EvidenceProvenance) (EventResult, error) {
+	received, err := s.ApplyReviewFeedback(ctx, target, eventID, feedback, provenance)
+	if err != nil || received.Disposition != typesv2.DispositionDuplicate {
+		return received, err
+	}
+	current, sameObject, sameContent, err := s.currentReviewFeedback(ctx, target.RunID, feedback, provenance)
+	if err != nil || !sameObject || sameContent || current.ObservedAt.After(provenance.ObservedAt) {
+		return received, err
+	}
+	encoded, err := json.Marshal(feedback)
+	if err != nil {
+		return EventResult{}, err
+	}
+	digest := sha256.Sum256(encoded)
+	revisionID := eventID + ":revision:" + hex.EncodeToString(digest[:])
+	return s.applyReviewFeedbackEvent(ctx, target, revisionID, "review.feedback.reconciled", feedback, provenance)
+}
+
+func (s *Store) currentReviewFeedback(ctx context.Context, runID string, feedback map[string]interface{},
+	provenance typesv2.EvidenceProvenance) (typesv2.EvidenceProvenance, bool, bool, error) {
+	var valueJSON, provenanceJSON string
+	err := s.db.QueryRowContext(ctx, `SELECT value_json,provenance_json FROM workflow_v2_facts
+		WHERE run_id=? AND fact_key='review.feedback'`, runID).Scan(&valueJSON, &provenanceJSON)
+	if err == sql.ErrNoRows {
+		return typesv2.EvidenceProvenance{}, false, false, nil
+	}
+	if err != nil {
+		return typesv2.EvidenceProvenance{}, false, false, err
+	}
+	var current typesv2.EvidenceProvenance
+	if err := json.Unmarshal([]byte(provenanceJSON), &current); err != nil {
+		return typesv2.EvidenceProvenance{}, false, false, err
+	}
+	encoded, err := json.Marshal(feedback)
+	if err != nil {
+		return typesv2.EvidenceProvenance{}, false, false, err
+	}
+	var currentFeedback map[string]interface{}
+	if err := json.Unmarshal([]byte(valueJSON), &currentFeedback); err != nil {
+		return typesv2.EvidenceProvenance{}, false, false, err
+	}
+	return current, currentFeedback["kind"] == feedback["kind"] &&
+			reviewFeedbackExternalIDsMatch(current.ExternalID, provenance.ExternalID),
+		bytes.Equal([]byte(valueJSON), encoded), nil
+}
+
+func reviewFeedbackExternalIDsMatch(current, incoming string) bool {
+	return current == incoming || (current != "" && strings.HasSuffix(incoming, ":"+current))
+}
+
+func (s *Store) applyReviewFeedbackEvent(ctx context.Context, target DeliveryTarget, eventID, eventKind string,
+	feedback map[string]interface{}, provenance typesv2.EvidenceProvenance) (EventResult, error) {
 	if target.RunID == "" || target.AttemptID == "" || target.PRID == "" || target.HeadSHA == "" {
 		return EventResult{}, fmt.Errorf("review feedback requires an owned delivery target")
 	}
@@ -239,12 +302,12 @@ func (s *Store) ApplyReviewFeedback(ctx context.Context, target DeliveryTarget, 
 		eventID = uuid.NewString()
 	}
 	return s.applyEventWithMutation(ctx, target.RunID, EventInput{
-		ID: eventID, MessageID: eventID, Kind: "review.feedback.received", AttemptID: target.AttemptID,
+		ID: eventID, MessageID: eventID, Kind: eventKind, AttemptID: target.AttemptID,
 		Producer: ProducerReview, Provenance: provenance,
 	}, func(ctx context.Context, tx *sql.Tx, input *EventInput) error {
-		var currentProvenance string
-		err := tx.QueryRowContext(ctx, `SELECT provenance_json FROM workflow_v2_facts
-			WHERE run_id=? AND fact_key='review.feedback'`, target.RunID).Scan(&currentProvenance)
+		var currentValue, currentProvenance string
+		err := tx.QueryRowContext(ctx, `SELECT value_json,provenance_json FROM workflow_v2_facts
+			WHERE run_id=? AND fact_key='review.feedback'`, target.RunID).Scan(&currentValue, &currentProvenance)
 		if err != nil && err != sql.ErrNoRows {
 			return err
 		}
@@ -255,6 +318,16 @@ func (s *Store) ApplyReviewFeedback(ctx context.Context, target DeliveryTarget, 
 			}
 			if current.ObservedAt.After(provenance.ObservedAt) {
 				return fmt.Errorf("review feedback observation is older than the current fact")
+			}
+			if eventKind == "review.feedback.reconciled" {
+				var currentFeedback map[string]interface{}
+				if err := json.Unmarshal([]byte(currentValue), &currentFeedback); err != nil {
+					return fmt.Errorf("decode current review feedback: %w", err)
+				}
+				if currentFeedback["kind"] != feedback["kind"] ||
+					!reviewFeedbackExternalIDsMatch(current.ExternalID, provenance.ExternalID) {
+					return fmt.Errorf("review feedback object changed while reconciling")
+				}
 			}
 		}
 		var headSHA string


### PR DESCRIPTION
Closes part of #544.

## Summary
- reconcile active V2 pull requests immediately on hub startup and every two minutes
- recover lost PR, current-head GitHub Actions, review, and safely attributable comment webhooks from authoritative paginated snapshots
- respect the shared low-priority GitHub rate-limit reserve and per-target deadlines
- keep V1 and suspended runs outside the reconciler
- suppress unchanged policy publications while preserving real revision cycles

## Verification
- `go test ./... -count=1`
- `go vet ./...`
- focused `go test -race` for V2 GitHub/runtime paths
- regression proves no webhook invocation and no chat rows are needed to reach a typed review-fix task