### PR TITLE
Isolate Workflow V2 from transcript controls

### DIFF
--- a/cmd/claw-bridge/control_v2.go
+++ b/cmd/claw-bridge/control_v2.go
@@ -590,9 +590,8 @@ func (s *controlSupervisor) executeTask(taskCtx context.Context, binding workflo
 		s.finishTask(binding, assignmentMessageID, task, typesv2.MessageAgentTaskFailed, "gateway is not ready")
 		return
 	}
-	if err := s.enqueueTaskEvent(binding, task, typesv2.MessageAgentTaskStarted, map[string]interface{}{
-		"execution": map[string]interface{}{"bridge_started_at": time.Now().UTC()},
-	}); err != nil {
+	if err := s.enqueueTaskEvent(binding, task, typesv2.MessageAgentTaskStarted,
+		taskLifecyclePayload(map[string]interface{}{"bridge_started_at": time.Now().UTC()})); err != nil {
 		s.finishTask(binding, assignmentMessageID, task, typesv2.MessageAgentTaskFailed, err.Error())
 		return
 	}
@@ -608,7 +607,7 @@ func (s *controlSupervisor) executeTask(taskCtx context.Context, binding workflo
 				return
 			case <-ticker.C:
 				_ = s.enqueueTaskEvent(binding, task, typesv2.MessageAgentTaskHeartbeat,
-					map[string]interface{}{"execution": map[string]interface{}{"heartbeat_at": time.Now().UTC()}})
+					taskLifecyclePayload(map[string]interface{}{"heartbeat_at": time.Now().UTC()}))
 			}
 		}
 	}()
@@ -620,9 +619,9 @@ func (s *controlSupervisor) executeTask(taskCtx context.Context, binding workflo
 		return
 	}
 	digest := sha256.Sum256([]byte(response))
-	payload := map[string]interface{}{"execution": map[string]interface{}{
+	payload := taskLifecyclePayload(map[string]interface{}{
 		"gateway_turn_completed": true, "response_bytes": len(response), "response_sha256": hex.EncodeToString(digest[:]),
-	}}
+	})
 	if err := s.enqueueTaskEvent(binding, task, typesv2.MessageAgentTaskCompleted, payload); err != nil {
 		log.Printf("[control-v2] queue completion for task %s: %v", task.ID, err)
 		return
@@ -632,12 +631,15 @@ func (s *controlSupervisor) executeTask(taskCtx context.Context, binding workflo
 
 func (s *controlSupervisor) finishTask(binding workflowControlBinding, assignmentMessageID string,
 	task typesv2.AgentTask, kind typesv2.ControlMessageKind, reason string) {
-	if err := s.enqueueTaskEvent(binding, task, kind,
-		map[string]interface{}{"execution": map[string]interface{}{"error": reason}}); err != nil {
+	if err := s.enqueueTaskEvent(binding, task, kind, taskLifecyclePayload(map[string]interface{}{"error": reason})); err != nil {
 		log.Printf("[control-v2] queue terminal event for task %s: %v", task.ID, err)
 		return
 	}
 	_, _ = s.store.setIncomingStatus(assignmentMessageID, "running", "failed")
+}
+
+func taskLifecyclePayload(values map[string]interface{}) map[string]interface{} {
+	return map[string]interface{}{"task": values}
 }
 
 func (s *controlSupervisor) enqueueTaskEvent(binding workflowControlBinding, task typesv2.AgentTask,

--- a/cmd/claw-bridge/control_v2_test.go
+++ b/cmd/claw-bridge/control_v2_test.go
@@ -160,6 +160,13 @@ func TestBridgeRegistrationOnlyAdvertisesControlWhenDurableStoreIsAvailable(t *t
 	}
 }
 
+func TestTaskLifecyclePayloadUsesAgentOwnedNamespace(t *testing.T) {
+	payload := taskLifecyclePayload(map[string]interface{}{"gateway_turn_completed": true})
+	if payload["task"] == nil || payload["execution"] != nil || len(payload) != 1 {
+		t.Fatalf("task lifecycle payload = %#v", payload)
+	}
+}
+
 func TestOldTaskCleanupCannotRemoveReplacementCancellation(t *testing.T) {
 	supervisor := newControlSupervisor(context.Background(), "ws://invalid", "claw", "token",
 		bridgeRegistration(true), openTestBridgeControlStore(t))

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -1942,9 +1942,11 @@ func (s *Server) injectMessage(clawID, content, role string) {
 		cc.mu.Lock()
 		cc.lastUserMessageAt = time.Now()
 		busy := cc.isBusyLocked()
+		workflowV2Controlled := cc.workflowV2Controlled
 		cc.mu.Unlock()
-		acceptedForAgent = true
+		acceptedForAgent = !workflowV2Controlled
 		if !busy {
+			// V1 delivers the row; V2 settles it as display-only.
 			s.sendNextQueuedMessage(cc)
 		}
 	}

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -1942,8 +1942,8 @@ func (s *Server) injectMessage(clawID, content, role string) {
 		cc.mu.Lock()
 		cc.lastUserMessageAt = time.Now()
 		busy := cc.isBusyLocked()
-		workflowV2Controlled := cc.workflowV2Controlled
 		cc.mu.Unlock()
+		workflowV2Controlled := s.workflowV2OwnsExecution(cc)
 		acceptedForAgent = !workflowV2Controlled
 		if !busy {
 			// V1 delivers the row; V2 settles it as display-only.

--- a/pkg/hub/schema_v2_validate_test.go
+++ b/pkg/hub/schema_v2_validate_test.go
@@ -60,7 +60,11 @@ states:
 transitions:
   open:
     from: implementing
-    on: pull_request.verified_open
+    on: delivery.verified
+    when:
+      delivery:
+        open:
+          not_equals: 0
     to: awaiting_ci
   done:
     from: awaiting_ci

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -299,6 +299,38 @@ type clawConn struct {
 	unresponsiveWarnedAt  time.Time       // when the silent-death warning was first broadcast
 }
 
+// workflowV2OwnsExecution refreshes the durable ownership boundary instead of
+// relying only on the registration-time snapshot. A claw may be connected
+// before a V2 attempt is assigned to it; once that happens, conversation text
+// must immediately become display-only for the lifetime of the claw.
+//
+// Ownership lookup failures fail closed. Running an untyped legacy turn while
+// durable ownership is temporarily unavailable is more dangerous than leaving
+// a conversation row pending until the next delivery attempt.
+func (s *Server) workflowV2OwnsExecution(cc *clawConn) bool {
+	if cc == nil {
+		return false
+	}
+	cc.mu.RLock()
+	owned := cc.workflowV2Controlled
+	clawID, tenantID := cc.id, cc.tenantID
+	cc.mu.RUnlock()
+	if owned {
+		return true
+	}
+	owned, err := workflowv2.NewStore(s.db).OwnsClawExecution(context.Background(), tenantID, clawID)
+	if err != nil {
+		log.Printf("[workflow-v2] ownership lookup for %s failed; blocking legacy execution: %v", shortID(clawID), err)
+		return true
+	}
+	if owned {
+		cc.mu.Lock()
+		cc.workflowV2Controlled = true
+		cc.mu.Unlock()
+	}
+	return owned
+}
+
 const (
 	// defaultGatewayUnhealthyMax counts consecutive bridge heartbeats reporting
 	// gateway_healthy=false before the hub escalates and replaces the claw. The
@@ -2756,10 +2788,11 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 
 	// Initialize entry pipeline stage only after bridge connects so on_enter inject
 	// can be delivered over WS.
-	if !cc.workflowV2Controlled && allowWake && cc.gatewayReady && currentStatus == "connected" {
+	workflowV2Controlled = s.workflowV2OwnsExecution(cc)
+	if !workflowV2Controlled && allowWake && cc.gatewayReady && currentStatus == "connected" {
 		s.startWorkflowAfterVolumes(ctx, cc, clawID)
 	}
-	if !cc.workflowV2Controlled && allowWake && cc.gatewayReady && currentStatus == "connected" && !s.hasRecentCheckpoint(clawID, time.Hour) {
+	if !workflowV2Controlled && allowWake && cc.gatewayReady && currentStatus == "connected" && !s.hasRecentCheckpoint(clawID, time.Hour) {
 		go s.requestBootstrapCheckpoint(clawID)
 	}
 
@@ -3200,9 +3233,10 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				)
 				s.broadcastToUsers(tenantID, types.WSMessage{Type: "message", Payload: hm})
 			}
+			workflowV2Controlled := s.workflowV2OwnsExecution(cc)
 			automaticContinuationPaused := false
 			bridgeErrTurn := false
-			if !cc.workflowV2Controlled {
+			if !workflowV2Controlled {
 				automaticContinuationPaused, bridgeErrTurn = s.observeTurnOutcome(cc, clawID, hm.ID, turnContent)
 				if !automaticContinuationPaused {
 					s.handleInitialPlanResponse(clawID, tenantID, turnContent)
@@ -3221,7 +3255,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 			pipelineHandledDone := false
 			var pipelineDoneCtx pipelineContext
 			var pipelineDoneStage *pipeline.Stage
-			if !cc.workflowV2Controlled && !bridgeErrTurn {
+			if !workflowV2Controlled && !bridgeErrTurn {
 				doneSignalled = turnMaySignal(turnContent, doneSignalToken, bridgeErrTurn)
 				if doneSignalled {
 					pipelineDoneCtx, pipelineDoneStage, pipelineHandledDone = s.pipelineStageForMessageContains(clawID, turnContent)
@@ -3250,14 +3284,14 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 						})
 					}
 				}
-			} else if !cc.workflowV2Controlled && !doneSignalled && !bridgeErrTurn {
+			} else if !workflowV2Controlled && !doneSignalled && !bridgeErrTurn {
 				s.safeGo("pipeline message triggers", func() { s.checkPipelineMessageTriggers(clawID, turnContent) })
 			}
 			// A known token written mid-sentence no longer transitions
 			// anything. Tell the agent so, or the run freezes with nobody
 			// aware the signal was dropped. Skipped while continuation is
 			// paused: that claw is already being held, not waiting on us.
-			if !cc.workflowV2Controlled && !automaticContinuationPaused && !bridgeErrTurn {
+			if !workflowV2Controlled && !automaticContinuationPaused && !bridgeErrTurn {
 				s.safeGo("unanchored signal nudge", func() { s.nudgeUnanchoredSignal(clawID, turnContent) })
 			}
 			// Clear typing indicator now that response is complete
@@ -3269,7 +3303,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				},
 			})
 			// Check for [DONE] signal from a factory-created claw
-			if !cc.workflowV2Controlled && doneSignalled {
+			if !workflowV2Controlled && doneSignalled {
 				s.safeGo("done checkpoint", func() {
 					if _, err := s.requestCheckpoint(context.Background(), clawID, "done", "hub", false, checkpointRequestTimeout); err != nil {
 						log.Printf("[checkpoint] done request for %s failed: %v", shortID(clawID), err)
@@ -3283,7 +3317,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 			// lifecycle. Anchored for the same reason as [DONE], with a worse
 			// blast radius: under substring matching an agent writing "I will
 			// not send [TERMINATE] yet" tore down its own claw.
-			if !cc.workflowV2Controlled && turnMaySignal(turnContent, terminateSignalToken, bridgeErrTurn) {
+			if !workflowV2Controlled && turnMaySignal(turnContent, terminateSignalToken, bridgeErrTurn) {
 				go s.handleClawTerminateSignal(clawID, turnContent)
 			}
 			// Detect and store PR URLs mentioned mid-work. [DONE] turns are
@@ -3296,7 +3330,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 			// Gated on doneSignalled, not on the token appearing: a turn that
 			// merely mentions [DONE] registers nothing, so skipping the scan
 			// there would silently drop PR URLs the agent did post.
-			if !cc.workflowV2Controlled {
+			if !workflowV2Controlled {
 				if doneSignalled {
 					log.Printf("[pr-watcher] skipping PR scan for claw %s: [DONE] registration is handled explicitly", shortID(clawID))
 				} else if !bridgeErrTurn {
@@ -3307,7 +3341,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 			// Detect tool error loops and inject a corrective message
-			if !cc.workflowV2Controlled && !automaticContinuationPaused && detectToolLoop(hm.Content) {
+			if !workflowV2Controlled && !automaticContinuationPaused && detectToolLoop(hm.Content) {
 				s.mu.RLock()
 				loopCC := s.claws[clawID]
 				s.mu.RUnlock()
@@ -8874,15 +8908,19 @@ func (s *Server) enqueueSessionLostResume(clawID, prefix, marker string) {
 // (cliversion.OpenClawVersion) treats it as session takeover and aborts the
 // in-flight turn with EmbeddedAttemptSessionTakeoverError without upstream
 // support.
+// Queue streaming watchdog nudges for delivery after the active turn. Do not
+// reintroduce mid-turn status-channel injection: pinned OpenClaw
+// (cliversion.OpenClawVersion) treats it as session takeover and aborts the
+// in-flight turn with EmbeddedAttemptSessionTakeoverError without upstream
+// support.
 func (s *Server) sendStreamingNudge(cc *clawConn, text string) {
-	cc.mu.RLock()
-	clawID := cc.id
-	workflowV2Controlled := cc.workflowV2Controlled
-	turnOpen := cc.isBusyLocked()
-	cc.mu.RUnlock()
-	if workflowV2Controlled {
+	if s.workflowV2OwnsExecution(cc) {
 		return
 	}
+	cc.mu.RLock()
+	clawID := cc.id
+	turnOpen := cc.isBusyLocked()
+	cc.mu.RUnlock()
 	// The nudge targets the in-flight turn. This runs on a goroutine, so the
 	// turn may have ended (and deleteStaleWatchdogNags already run) before we
 	// get here — queueing now would deliver the stale nudge as the next
@@ -8899,10 +8937,10 @@ func (s *Server) sendStreamingNudge(cc *clawConn, text string) {
 
 // sendNextQueuedMessage delivers the oldest pending message if the claw is idle.
 func (s *Server) sendNextQueuedMessage(cc *clawConn) {
-	cc.mu.Lock()
-	if cc.workflowV2Controlled {
+	if s.workflowV2OwnsExecution(cc) {
+		cc.mu.RLock()
 		clawID, tenantID := cc.id, cc.tenantID
-		cc.mu.Unlock()
+		cc.mu.RUnlock()
 		// Conversation rows remain visible in the transcript, but they are
 		// never inputs to a V2-owned execution. Settle any old or newly queued
 		// rows so reconnects cannot repeatedly reconsider them for delivery.
@@ -8913,6 +8951,7 @@ func (s *Server) sendNextQueuedMessage(cc *clawConn) {
 		}
 		return
 	}
+	cc.mu.Lock()
 	if cc.isBusyLocked() || cc.deliveryInFlight || cc.noProgressPaused {
 		cc.mu.Unlock()
 		return
@@ -8945,6 +8984,16 @@ func (s *Server) sendNextQueuedMessage(cc *clawConn) {
 	}
 	if err != nil {
 		log.Printf("[hub] find pending message for %s: %v", shortID(clawID), err)
+		return
+	}
+	// Ownership may have changed after this delivery attempt began. Refresh it
+	// again at the final execution boundary before reserving a legacy turn.
+	if s.workflowV2OwnsExecution(cc) {
+		if _, err := s.db.Exec(`UPDATE messages SET delivered_at=created_at,
+			format=CASE WHEN format='' THEN 'workflow_v2_display_only' ELSE format END
+			WHERE claw_id=? AND tenant_id=? AND delivered_at IS NULL`, clawID, tenantID); err != nil {
+			log.Printf("[workflow-v2] settle display-only messages for %s: %v", shortID(clawID), err)
+		}
 		return
 	}
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -8877,8 +8877,12 @@ func (s *Server) enqueueSessionLostResume(clawID, prefix, marker string) {
 func (s *Server) sendStreamingNudge(cc *clawConn, text string) {
 	cc.mu.RLock()
 	clawID := cc.id
+	workflowV2Controlled := cc.workflowV2Controlled
 	turnOpen := cc.isBusyLocked()
 	cc.mu.RUnlock()
+	if workflowV2Controlled {
+		return
+	}
 	// The nudge targets the in-flight turn. This runs on a goroutine, so the
 	// turn may have ended (and deleteStaleWatchdogNags already run) before we
 	// get here — queueing now would deliver the stale nudge as the next
@@ -8896,6 +8900,19 @@ func (s *Server) sendStreamingNudge(cc *clawConn, text string) {
 // sendNextQueuedMessage delivers the oldest pending message if the claw is idle.
 func (s *Server) sendNextQueuedMessage(cc *clawConn) {
 	cc.mu.Lock()
+	if cc.workflowV2Controlled {
+		clawID, tenantID := cc.id, cc.tenantID
+		cc.mu.Unlock()
+		// Conversation rows remain visible in the transcript, but they are
+		// never inputs to a V2-owned execution. Settle any old or newly queued
+		// rows so reconnects cannot repeatedly reconsider them for delivery.
+		if _, err := s.db.Exec(`UPDATE messages SET delivered_at=created_at,
+			format=CASE WHEN format='' THEN 'workflow_v2_display_only' ELSE format END
+			WHERE claw_id=? AND tenant_id=? AND delivered_at IS NULL`, clawID, tenantID); err != nil {
+			log.Printf("[workflow-v2] settle display-only messages for %s: %v", shortID(clawID), err)
+		}
+		return
+	}
 	if cc.isBusyLocked() || cc.deliveryInFlight || cc.noProgressPaused {
 		cc.mu.Unlock()
 		return

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -267,6 +267,7 @@ type clawConn struct {
 	forcedFinishCount       int             // consecutive watchdog-forced streaming turn finishes
 	workflowStartPending    bool            // true while initial volume attach / wake is in flight
 	workflowStartDone       bool            // true once initial volume attach / wake has completed
+	workflowV2Controlled    bool            // typed control owns execution; conversation text is display-only
 	streamingBuf            strings.Builder // accumulates chunks for current in-flight response
 	streamingMsgID          string          // pre-assigned message ID for the current stream
 	streamingSplit          bool            // true once activity has split this turn into multiple persisted segments
@@ -2579,8 +2580,16 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 	// so initialStatus would incorrectly overwrite 'starting'/'bootstrap_needed').
 	isStatusChannel := rp.Channel == "status"
 	var workflowControl *workflowV2ControlBinding
+	workflowV2Controlled := false
 	if !isStatusChannel {
-		binding, found, bindingErr := workflowv2.NewStore(s.db).ActiveControlBinding(ctx, tenantID, clawID)
+		workflowStore := workflowv2.NewStore(s.db)
+		var ownershipErr error
+		workflowV2Controlled, ownershipErr = workflowStore.OwnsClawExecution(ctx, tenantID, clawID)
+		if ownershipErr != nil {
+			conn.Close(websocket.StatusInternalError, "workflow control ownership unavailable")
+			return
+		}
+		binding, found, bindingErr := workflowStore.ActiveControlBinding(ctx, tenantID, clawID)
 		if bindingErr != nil {
 			conn.Close(websocket.StatusInternalError, "workflow control binding unavailable")
 			return
@@ -2688,7 +2697,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 	// turn end closely enough for autoResumeRecentTurnWindow.
 	var lastClawMsgAt time.Time
 	_ = s.db.QueryRow(`SELECT created_at FROM messages WHERE claw_id=? AND role='claw' ORDER BY created_at DESC LIMIT 1`, clawID).Scan(&lastClawMsgAt)
-	cc := &clawConn{id: clawID, tenantID: tenantID, conn: conn, gatewayReady: gatewayReadyBool(rp.GatewayReady), tags: registrationTags, lastUserMessageAt: time.Now(), lastStatusAt: time.Now(), connectedAt: time.Now(), noProgressPaused: noProgressPaused}
+	cc := &clawConn{id: clawID, tenantID: tenantID, conn: conn, gatewayReady: gatewayReadyBool(rp.GatewayReady), tags: registrationTags, lastUserMessageAt: time.Now(), lastStatusAt: time.Now(), connectedAt: time.Now(), noProgressPaused: noProgressPaused, workflowV2Controlled: workflowV2Controlled}
 	var old *clawConn
 	s.mu.Lock()
 	if s.gatewayRestartCounts != nil {
@@ -2747,10 +2756,10 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 
 	// Initialize entry pipeline stage only after bridge connects so on_enter inject
 	// can be delivered over WS.
-	if allowWake && cc.gatewayReady && currentStatus == "connected" {
+	if !cc.workflowV2Controlled && allowWake && cc.gatewayReady && currentStatus == "connected" {
 		s.startWorkflowAfterVolumes(ctx, cc, clawID)
 	}
-	if allowWake && cc.gatewayReady && currentStatus == "connected" && !s.hasRecentCheckpoint(clawID, time.Hour) {
+	if !cc.workflowV2Controlled && allowWake && cc.gatewayReady && currentStatus == "connected" && !s.hasRecentCheckpoint(clawID, time.Hour) {
 		go s.requestBootstrapCheckpoint(clawID)
 	}
 
@@ -3191,9 +3200,13 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				)
 				s.broadcastToUsers(tenantID, types.WSMessage{Type: "message", Payload: hm})
 			}
-			automaticContinuationPaused, bridgeErrTurn := s.observeTurnOutcome(cc, clawID, hm.ID, turnContent)
-			if !automaticContinuationPaused {
-				s.handleInitialPlanResponse(clawID, tenantID, turnContent)
+			automaticContinuationPaused := false
+			bridgeErrTurn := false
+			if !cc.workflowV2Controlled {
+				automaticContinuationPaused, bridgeErrTurn = s.observeTurnOutcome(cc, clawID, hm.ID, turnContent)
+				if !automaticContinuationPaused {
+					s.handleInitialPlanResponse(clawID, tenantID, turnContent)
+				}
 			}
 			// Every [DONE]/[TERMINATE] gate below asks pipeline.MessageSignals,
 			// never strings.Contains. They used to disagree: the pipeline
@@ -3201,15 +3214,18 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 			// so pipelineHandledDone stayed false and the legacy handler ran on
 			// exactly the text the pipeline had just rejected — the NEXT-707
 			// outcome, reached by the code that was supposed to prevent it.
-			doneSignalled := turnMaySignal(turnContent, doneSignalToken, bridgeErrTurn)
+			doneSignalled := false
 			// Evaluate pipeline triggers. If a pipeline explicitly owns a
 			// [DONE] trigger, let it handle that signal instead of the
 			// legacy factory PR-URL completion path below.
 			pipelineHandledDone := false
 			var pipelineDoneCtx pipelineContext
 			var pipelineDoneStage *pipeline.Stage
-			if doneSignalled {
-				pipelineDoneCtx, pipelineDoneStage, pipelineHandledDone = s.pipelineStageForMessageContains(clawID, turnContent)
+			if !cc.workflowV2Controlled && !bridgeErrTurn {
+				doneSignalled = turnMaySignal(turnContent, doneSignalToken, bridgeErrTurn)
+				if doneSignalled {
+					pipelineDoneCtx, pipelineDoneStage, pipelineHandledDone = s.pipelineStageForMessageContains(clawID, turnContent)
+				}
 			}
 			if automaticContinuationPaused {
 				pipelineHandledDone = false
@@ -3234,14 +3250,14 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 						})
 					}
 				}
-			} else if !doneSignalled && !bridgeErrTurn {
+			} else if !cc.workflowV2Controlled && !doneSignalled && !bridgeErrTurn {
 				s.safeGo("pipeline message triggers", func() { s.checkPipelineMessageTriggers(clawID, turnContent) })
 			}
 			// A known token written mid-sentence no longer transitions
 			// anything. Tell the agent so, or the run freezes with nobody
 			// aware the signal was dropped. Skipped while continuation is
 			// paused: that claw is already being held, not waiting on us.
-			if !automaticContinuationPaused && !bridgeErrTurn {
+			if !cc.workflowV2Controlled && !automaticContinuationPaused && !bridgeErrTurn {
 				s.safeGo("unanchored signal nudge", func() { s.nudgeUnanchoredSignal(clawID, turnContent) })
 			}
 			// Clear typing indicator now that response is complete
@@ -3253,7 +3269,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				},
 			})
 			// Check for [DONE] signal from a factory-created claw
-			if doneSignalled {
+			if !cc.workflowV2Controlled && doneSignalled {
 				s.safeGo("done checkpoint", func() {
 					if _, err := s.requestCheckpoint(context.Background(), clawID, "done", "hub", false, checkpointRequestTimeout); err != nil {
 						log.Printf("[checkpoint] done request for %s failed: %v", shortID(clawID), err)
@@ -3267,7 +3283,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 			// lifecycle. Anchored for the same reason as [DONE], with a worse
 			// blast radius: under substring matching an agent writing "I will
 			// not send [TERMINATE] yet" tore down its own claw.
-			if turnMaySignal(turnContent, terminateSignalToken, bridgeErrTurn) {
+			if !cc.workflowV2Controlled && turnMaySignal(turnContent, terminateSignalToken, bridgeErrTurn) {
 				go s.handleClawTerminateSignal(clawID, turnContent)
 			}
 			// Detect and store PR URLs mentioned mid-work. [DONE] turns are
@@ -3280,16 +3296,18 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 			// Gated on doneSignalled, not on the token appearing: a turn that
 			// merely mentions [DONE] registers nothing, so skipping the scan
 			// there would silently drop PR URLs the agent did post.
-			if doneSignalled {
-				log.Printf("[pr-watcher] skipping PR scan for claw %s: [DONE] registration is handled explicitly", shortID(clawID))
-			} else if !bridgeErrTurn {
-				// A transport error can quote a repository URL (git and CI
-				// failures routinely do). Arming the PR watcher on text the
-				// agent never wrote would watch a PR nobody opened.
-				go s.scanMessageForPRs(clawID, turnContent, true)
+			if !cc.workflowV2Controlled {
+				if doneSignalled {
+					log.Printf("[pr-watcher] skipping PR scan for claw %s: [DONE] registration is handled explicitly", shortID(clawID))
+				} else if !bridgeErrTurn {
+					// A transport error can quote a repository URL (git and CI
+					// failures routinely do). Arming the PR watcher on text the
+					// agent never wrote would watch a PR nobody opened.
+					go s.scanMessageForPRs(clawID, turnContent, true)
+				}
 			}
 			// Detect tool error loops and inject a corrective message
-			if !automaticContinuationPaused && detectToolLoop(hm.Content) {
+			if !cc.workflowV2Controlled && !automaticContinuationPaused && detectToolLoop(hm.Content) {
 				s.mu.RLock()
 				loopCC := s.claws[clawID]
 				s.mu.RUnlock()

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -3067,7 +3067,6 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 						go s.recordClawAgentStarted(clawID)
 						shouldWake = true
 						wakeConn = cc
-						go s.requestBootstrapCheckpoint(clawID)
 					}
 				}
 				s.heartbeatWorkflowVolumeLeases(clawID)
@@ -3089,7 +3088,10 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 					}
 				}
 				if shouldWake {
-					s.startWorkflowAfterVolumes(ctx, wakeConn, clawID)
+					if !s.workflowV2OwnsExecution(wakeConn) {
+						go s.requestBootstrapCheckpoint(clawID)
+						s.startWorkflowAfterVolumes(ctx, wakeConn, clawID)
+					}
 				}
 				// Check for streaming turn timeout (12 minutes)
 				s.mu.RLock()
@@ -5179,13 +5181,15 @@ func (s *Server) promoteBootstrapReadyClaw(clawID string) bool {
 	})
 	go s.recordClawAgentStarted(clawID)
 	log.Printf("[bridge] ✓ ready after bootstrap: %s", clawID[:8])
-	go s.requestBootstrapCheckpoint(clawID)
-	s.startWorkflowAfterVolumes(context.Background(), cc, clawID)
+	if !s.workflowV2OwnsExecution(cc) {
+		go s.requestBootstrapCheckpoint(clawID)
+		s.startWorkflowAfterVolumes(context.Background(), cc, clawID)
+	}
 	return true
 }
 
 func (s *Server) startWorkflowAfterVolumes(ctx context.Context, cc *clawConn, clawID string) {
-	if cc == nil {
+	if cc == nil || s.workflowV2OwnsExecution(cc) {
 		return
 	}
 	cc.mu.Lock()
@@ -5212,6 +5216,11 @@ func (s *Server) startWorkflowAfterVolumes(ctx context.Context, cc *clawConn, cl
 		cc.workflowStartDone = true
 		cc.mu.Unlock()
 
+		// Ownership can change while volume attachment is in flight. Crossing
+		// this boundary would start an untyped legacy turn for a V2 claw.
+		if s.workflowV2OwnsExecution(cc) {
+			return
+		}
 		if s.initializePipelineEntryIfNeeded(clawID) {
 			// The entry inject just briefed this session with full task
 			// context (a retried claw can land here when it died before its
@@ -6622,6 +6631,9 @@ func planGateAcceptedMarker(stageID string) string {
 // For factory claws, it sends a task-specific prompt.
 // A marker is stored in DB so reconnects after hub restart don't re-introduce.
 func (s *Server) sendWakeMessage(cc *clawConn, clawID string) {
+	if s.workflowV2OwnsExecution(cc) {
+		return
+	}
 	cc.mu.Lock()
 	if cc.isBusyLocked() || cc.noProgressPaused {
 		cc.mu.Unlock()
@@ -6632,6 +6644,12 @@ func (s *Server) sendWakeMessage(cc *clawConn, clawID string) {
 	cc.streamingTimeoutSent = false
 	cc.contextWarningSent = false
 	cc.mu.Unlock()
+	if s.workflowV2OwnsExecution(cc) {
+		cc.mu.Lock()
+		cc.abortTurnLocked()
+		cc.mu.Unlock()
+		return
+	}
 
 	wakeContent := defaultWakeContent
 	if s.clawNeedsInitialPlan(clawID) {
@@ -6664,7 +6682,7 @@ func (s *Server) sendWakeMessage(cc *clawConn, clawID string) {
 }
 
 func (s *Server) sendInitialPlanInstruction(cc *clawConn, clawID string) {
-	if cc == nil || !s.clawNeedsInitialPlan(clawID) || s.hasSystemMarker(clawID, initialPlanAcceptedMarker) {
+	if cc == nil || s.workflowV2OwnsExecution(cc) || !s.clawNeedsInitialPlan(clawID) || s.hasSystemMarker(clawID, initialPlanAcceptedMarker) {
 		return
 	}
 	cc.mu.Lock()
@@ -6677,6 +6695,12 @@ func (s *Server) sendInitialPlanInstruction(cc *clawConn, clawID string) {
 	cc.streamingTimeoutSent = false
 	cc.contextWarningSent = false
 	cc.mu.Unlock()
+	if s.workflowV2OwnsExecution(cc) {
+		cc.mu.Lock()
+		cc.abortTurnLocked()
+		cc.mu.Unlock()
+		return
+	}
 	if !s.insertSystemMarker(clawID, cc.tenantID, initialPlanRequiredMarker) {
 		cc.mu.Lock()
 		cc.abortTurnLocked()

--- a/pkg/hub/workflow_v2_control_ws_test.go
+++ b/pkg/hub/workflow_v2_control_ws_test.go
@@ -253,6 +253,11 @@ stages:
 			t.Fatal(err)
 		}
 	}
+	if _, err := db.Exec(`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at,delivered_at)
+		VALUES('v2-queued-before-reconnect',?,?,'user','proceed [DONE] https://github.com/org/repo/pull/99',datetime('now'),NULL)`,
+		v2ClawID, "test-tenant-id"); err != nil {
+		t.Fatal(err)
+	}
 	store := workflowv2.NewStore(db)
 	run, err := store.CreateRun(context.Background(), workflowv2.CreateRunRequest{
 		ID: "run-concurrent-v2", TenantID: "test-tenant-id", InitialClawID: v2ClawID,
@@ -398,7 +403,7 @@ stages:
 	}
 	var v2State string
 	var v2Version uint64
-	var v2Events, v2LegacyPRs, v2InjectedMessages int
+	var v2Events, v2LegacyPRs, v2DisplayOnlyMessages, v2PendingMessages int
 	if err := db.QueryRow(`SELECT state,state_version FROM workflow_v2_runs WHERE id=?`, run.ID).
 		Scan(&v2State, &v2Version); err != nil {
 		t.Fatal(err)
@@ -409,12 +414,18 @@ stages:
 	if err := db.QueryRow(`SELECT COUNT(*) FROM claw_prs WHERE claw_id=?`, v2ClawID).Scan(&v2LegacyPRs); err != nil {
 		t.Fatal(err)
 	}
-	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND role!='claw'`, v2ClawID).
-		Scan(&v2InjectedMessages); err != nil {
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND role!='claw'
+		AND delivered_at IS NOT NULL AND format='workflow_v2_display_only'`, v2ClawID).
+		Scan(&v2DisplayOnlyMessages); err != nil {
 		t.Fatal(err)
 	}
-	if v2State != "done" || v2Version != 2 || v2Events != 3 || v2LegacyPRs != 0 || v2InjectedMessages != 0 {
-		t.Fatalf("V2 state/version/events/legacy_prs/injected = %q/%d/%d/%d/%d",
-			v2State, v2Version, v2Events, v2LegacyPRs, v2InjectedMessages)
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND delivered_at IS NULL`, v2ClawID).
+		Scan(&v2PendingMessages); err != nil {
+		t.Fatal(err)
+	}
+	if v2State != "done" || v2Version != 2 || v2Events != 3 || v2LegacyPRs != 0 ||
+		v2DisplayOnlyMessages != 1 || v2PendingMessages != 0 {
+		t.Fatalf("V2 state/version/events/legacy_prs/display_only/pending = %q/%d/%d/%d/%d/%d",
+			v2State, v2Version, v2Events, v2LegacyPRs, v2DisplayOnlyMessages, v2PendingMessages)
 	}
 }

--- a/pkg/hub/workflow_v2_control_ws_test.go
+++ b/pkg/hub/workflow_v2_control_ws_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -225,5 +226,195 @@ func TestNewBridgeStillUsesConversationPathForV1(t *testing.T) {
 	}
 	if ack.Type != "registered" || ack.Payload.ClawID != "claw-v1-new-bridge" || ack.Payload.WorkflowControl != nil {
 		t.Fatalf("v1 registration ack = %#v", ack)
+	}
+}
+
+func TestV1AndV2ConversationMessagesRunConcurrentlyWithoutCrossingControlPlanes(t *testing.T) {
+	const (
+		v1ClawID = "claw-concurrent-v1"
+		v2ClawID = "claw-concurrent-v2"
+	)
+	cfg := &types.HubConfig{Token: "test-token", ClawToken: "claw-token",
+		Factories: []*types.FactoryConfig{{Name: "compat", Template: "elasticclaw", PipelineYAML: `
+stages:
+  - id: working
+    entry: true
+  - id: legacy_done
+    terminal: true
+    triggers:
+      - message_contains: "[DONE]"
+`}},
+	}
+	s, db := NewTestServerWithConfig(t, cfg, "", "", "")
+	for _, clawID := range []string{v1ClawID, v2ClawID} {
+		if _, err := db.Exec(`INSERT INTO claws(id,tenant_id,name,template,status,tags,pipeline_stage,created_at)
+			VALUES(?,?,?,?,?,?,?,datetime('now'))`, clawID, "test-tenant-id", clawID, "elasticclaw",
+			"connected", `["factory:compat"]`, "working"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	store := workflowv2.NewStore(db)
+	run, err := store.CreateRun(context.Background(), workflowv2.CreateRunRequest{
+		ID: "run-concurrent-v2", TenantID: "test-tenant-id", InitialClawID: v2ClawID,
+		WorkspaceYAML: []byte(workflowV2APIWorkspace), WorkflowYAML: []byte(workflowV2APIWorkflow),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.drainWorkflowV2Effects(context.Background(), "concurrent-v2-worker"); err != nil {
+		t.Fatal(err)
+	}
+
+	server := httptest.NewServer(s.Handler())
+	t.Cleanup(server.Close)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	connect := func(clawID string) *websocket.Conn {
+		t.Helper()
+		conn, _, err := websocket.Dial(ctx, "ws"+strings.TrimPrefix(server.URL, "http")+"/claw/ws", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := wsjson.Write(ctx, conn, types.WSMessage{Type: "register", Payload: map[string]interface{}{
+			"claw_id": clawID, "token": "claw-token", "gateway_ready": true,
+			"bridge_version": "test", "protocols": []string{typesv2.ProtocolConversationV1, typesv2.ProtocolControlV2},
+		}}); err != nil {
+			conn.CloseNow()
+			t.Fatal(err)
+		}
+		var ack types.WSMessage
+		if err := wsjson.Read(ctx, conn, &ack); err != nil || ack.Type != "registered" {
+			conn.CloseNow()
+			t.Fatalf("register %s: ack=%#v err=%v", clawID, ack, err)
+		}
+		return conn
+	}
+	v1Conn := connect(v1ClawID)
+	defer v1Conn.CloseNow()
+	v2Conn := connect(v2ClawID)
+	defer v2Conn.CloseNow()
+	controlConn, _, err := websocket.Dial(ctx,
+		"ws"+strings.TrimPrefix(server.URL, "http")+"/claw/control/ws", &websocket.DialOptions{HTTPHeader: http.Header{
+			clawControlTokenHeader: {"claw-token"},
+		}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer controlConn.CloseNow()
+	registration := typesv2.ControlRegistration{Token: "claw-token", ClawID: v2ClawID,
+		RunID: run.ID, AttemptID: run.CurrentAttemptID,
+		Bridge: typesv2.BridgeRegistration{BridgeVersion: "test", Protocols: []string{typesv2.ProtocolControlV2}}}
+	if err := wsjson.Write(ctx, controlConn,
+		typesv2.ControlFrame{Type: typesv2.ControlFrameRegister, Registration: &registration}); err != nil {
+		t.Fatal(err)
+	}
+	var registered, assignment typesv2.ControlFrame
+	if err := wsjson.Read(ctx, controlConn, &registered); err != nil || registered.Type != typesv2.ControlFrameRegistered {
+		t.Fatalf("control registration = %#v, err=%v", registered, err)
+	}
+	if err := wsjson.Read(ctx, controlConn, &assignment); err != nil || assignment.Envelope == nil ||
+		assignment.Envelope.Kind != typesv2.MessageAgentTaskAssign {
+		t.Fatalf("task assignment = %#v, err=%v", assignment, err)
+	}
+	if err := wsjson.Write(ctx, controlConn, typesv2.ControlFrame{Type: typesv2.ControlFrameReceipt,
+		Receipt: &typesv2.ControlReceipt{MessageID: assignment.Envelope.MessageID,
+			Disposition: typesv2.DispositionAccepted, StateVersion: 1}}); err != nil {
+		t.Fatal(err)
+	}
+	stateVersion := uint64(1)
+	started := typesv2.ControlEnvelope{ProtocolVersion: typesv2.ControlProtocolVersion,
+		MessageID: "concurrent-v2-started", Kind: typesv2.MessageAgentTaskStarted,
+		RunID: run.ID, AttemptID: run.CurrentAttemptID, TaskID: assignment.Envelope.TaskID,
+		ExpectedStateVersion: &stateVersion, Payload: []byte(`{"task":{"started":true}}`)}
+	if err := wsjson.Write(ctx, controlConn,
+		typesv2.ControlFrame{Type: typesv2.ControlFrameEnvelope, Envelope: &started}); err != nil {
+		t.Fatal(err)
+	}
+	var startedReceipt typesv2.ControlFrame
+	if err := wsjson.Read(ctx, controlConn, &startedReceipt); err != nil || startedReceipt.Receipt == nil ||
+		startedReceipt.Receipt.Disposition != typesv2.DispositionAccepted {
+		if startedReceipt.Receipt != nil {
+			t.Fatalf("task-start receipt = %+v, err=%v", *startedReceipt.Receipt, err)
+		}
+		t.Fatalf("task-start frame = %#v, err=%v", startedReceipt, err)
+	}
+
+	turn := types.WSMessage{Type: "message", Payload: types.HubMessage{
+		Content: "[DONE] https://github.com/org/repo/pull/42",
+	}}
+	completed := typesv2.ControlEnvelope{ProtocolVersion: typesv2.ControlProtocolVersion,
+		MessageID: "concurrent-v2-completed", Kind: typesv2.MessageAgentTaskCompleted,
+		RunID: run.ID, AttemptID: run.CurrentAttemptID, TaskID: assignment.Envelope.TaskID,
+		ExpectedStateVersion: &stateVersion, Payload: []byte(`{"task":{"result":"success"}}`)}
+	var wg sync.WaitGroup
+	errs := make(chan error, 3)
+	for _, conn := range []*websocket.Conn{v1Conn, v2Conn} {
+		wg.Add(1)
+		go func(conn *websocket.Conn) {
+			defer wg.Done()
+			errs <- wsjson.Write(ctx, conn, turn)
+		}(conn)
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		errs <- wsjson.Write(ctx, controlConn,
+			typesv2.ControlFrame{Type: typesv2.ControlFrameEnvelope, Envelope: &completed})
+	}()
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	var completedReceipt typesv2.ControlFrame
+	if err := wsjson.Read(ctx, controlConn, &completedReceipt); err != nil || completedReceipt.Receipt == nil ||
+		completedReceipt.Receipt.Disposition != typesv2.DispositionAccepted || completedReceipt.Receipt.StateVersion != 2 {
+		t.Fatalf("task-completion receipt = %#v, err=%v", completedReceipt, err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	var v1Stage, v2Stage string
+	var persisted int
+	for time.Now().Before(deadline) {
+		_ = db.QueryRow(`SELECT pipeline_stage FROM claws WHERE id=?`, v1ClawID).Scan(&v1Stage)
+		_ = db.QueryRow(`SELECT pipeline_stage FROM claws WHERE id=?`, v2ClawID).Scan(&v2Stage)
+		_ = db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id IN (?,?) AND role='claw'`,
+			v1ClawID, v2ClawID).Scan(&persisted)
+		if v1Stage == "legacy_done" && persisted == 2 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if v1Stage != "legacy_done" {
+		t.Fatalf("V1 transcript trigger did not advance: stage=%q", v1Stage)
+	}
+	if v2Stage != "working" {
+		t.Fatalf("V2 transcript crossed into the legacy pipeline: stage=%q", v2Stage)
+	}
+	if persisted != 2 {
+		t.Fatalf("persisted conversation rows = %d, want 2", persisted)
+	}
+	var v2State string
+	var v2Version uint64
+	var v2Events, v2LegacyPRs, v2InjectedMessages int
+	if err := db.QueryRow(`SELECT state,state_version FROM workflow_v2_runs WHERE id=?`, run.ID).
+		Scan(&v2State, &v2Version); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_events WHERE run_id=?`, run.ID).Scan(&v2Events); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM claw_prs WHERE claw_id=?`, v2ClawID).Scan(&v2LegacyPRs); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND role!='claw'`, v2ClawID).
+		Scan(&v2InjectedMessages); err != nil {
+		t.Fatal(err)
+	}
+	if v2State != "done" || v2Version != 2 || v2Events != 3 || v2LegacyPRs != 0 || v2InjectedMessages != 0 {
+		t.Fatalf("V2 state/version/events/legacy_prs/injected = %q/%d/%d/%d/%d",
+			v2State, v2Version, v2Events, v2LegacyPRs, v2InjectedMessages)
 	}
 }

--- a/pkg/hub/workflow_v2_control_ws_test.go
+++ b/pkg/hub/workflow_v2_control_ws_test.go
@@ -229,6 +229,41 @@ func TestNewBridgeStillUsesConversationPathForV1(t *testing.T) {
 	}
 }
 
+func TestBootstrapPromotionDoesNotStartLegacyWorkflowForV2(t *testing.T) {
+	const clawID = "claw-v2-bootstrap-ready"
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token", ClawToken: "claw-token"}, "", "", "")
+	if _, err := db.Exec(`INSERT INTO claws(id,tenant_id,name,template,provider,status,bootstrap_ok,created_at)
+		VALUES(?,?,?,?,?,'starting',1,datetime('now'))`, clawID, "test-tenant-id", clawID, "elasticclaw", "daytona"); err != nil {
+		t.Fatal(err)
+	}
+	store := workflowv2.NewStore(db)
+	if _, err := store.CreateRun(context.Background(), workflowv2.CreateRunRequest{
+		ID: "run-v2-bootstrap-ready", TenantID: "test-tenant-id", InitialClawID: clawID,
+		WorkspaceYAML: []byte(workflowV2APIWorkspace), WorkflowYAML: []byte(workflowV2APIWorkflow),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cc := &clawConn{id: clawID, tenantID: "test-tenant-id", gatewayReady: true}
+	s.claws[clawID] = cc
+	if !s.promoteBootstrapReadyClaw(clawID) {
+		t.Fatal("bootstrap-ready V2 claw was not promoted")
+	}
+	cc.mu.RLock()
+	controlled := cc.workflowV2Controlled
+	startPending, startDone := cc.workflowStartPending, cc.workflowStartDone
+	cc.mu.RUnlock()
+	if !controlled || startPending || startDone {
+		t.Fatalf("V2 bootstrap promotion control/pending/done = %v/%v/%v", controlled, startPending, startDone)
+	}
+	var legacyMessages int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=?`, clawID).Scan(&legacyMessages); err != nil {
+		t.Fatal(err)
+	}
+	if legacyMessages != 0 {
+		t.Fatalf("legacy bootstrap messages = %d, want 0", legacyMessages)
+	}
+}
+
 func TestV1AndV2ConversationMessagesRunConcurrentlyWithoutCrossingControlPlanes(t *testing.T) {
 	const (
 		v1ClawID = "claw-concurrent-v1"

--- a/pkg/hub/workflow_v2_control_ws_test.go
+++ b/pkg/hub/workflow_v2_control_ws_test.go
@@ -253,22 +253,7 @@ stages:
 			t.Fatal(err)
 		}
 	}
-	if _, err := db.Exec(`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at,delivered_at)
-		VALUES('v2-queued-before-reconnect',?,?,'user','proceed [DONE] https://github.com/org/repo/pull/99',datetime('now'),NULL)`,
-		v2ClawID, "test-tenant-id"); err != nil {
-		t.Fatal(err)
-	}
 	store := workflowv2.NewStore(db)
-	run, err := store.CreateRun(context.Background(), workflowv2.CreateRunRequest{
-		ID: "run-concurrent-v2", TenantID: "test-tenant-id", InitialClawID: v2ClawID,
-		WorkspaceYAML: []byte(workflowV2APIWorkspace), WorkflowYAML: []byte(workflowV2APIWorkflow),
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := s.drainWorkflowV2Effects(context.Background(), "concurrent-v2-worker"); err != nil {
-		t.Fatal(err)
-	}
 
 	server := httptest.NewServer(s.Handler())
 	t.Cleanup(server.Close)
@@ -281,7 +266,7 @@ stages:
 			t.Fatal(err)
 		}
 		if err := wsjson.Write(ctx, conn, types.WSMessage{Type: "register", Payload: map[string]interface{}{
-			"claw_id": clawID, "token": "claw-token", "gateway_ready": true,
+			"claw_id": clawID, "token": "claw-token", "gateway_ready": false,
 			"bridge_version": "test", "protocols": []string{typesv2.ProtocolConversationV1, typesv2.ProtocolControlV2},
 		}}); err != nil {
 			conn.CloseNow()
@@ -298,6 +283,32 @@ stages:
 	defer v1Conn.CloseNow()
 	v2Conn := connect(v2ClawID)
 	defer v2Conn.CloseNow()
+
+	// Activate V2 only after its normal conversation socket is connected. This
+	// exercises the ownership refresh path instead of the registration snapshot.
+	run, err := store.CreateRun(context.Background(), workflowv2.CreateRunRequest{
+		ID: "run-concurrent-v2", TenantID: "test-tenant-id", InitialClawID: v2ClawID,
+		WorkspaceYAML: []byte(workflowV2APIWorkspace), WorkflowYAML: []byte(workflowV2APIWorkflow),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.drainWorkflowV2Effects(context.Background(), "concurrent-v2-worker"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at,delivered_at)
+		VALUES('v2-queued-after-activation',?,?,'user','proceed [DONE] https://github.com/org/repo/pull/99',datetime('now'),NULL)`,
+		v2ClawID, "test-tenant-id"); err != nil {
+		t.Fatal(err)
+	}
+	s.mu.RLock()
+	v2CC := s.claws[v2ClawID]
+	s.mu.RUnlock()
+	if v2CC == nil {
+		t.Fatal("connected V2 claw is missing")
+	}
+	s.sendNextQueuedMessage(v2CC)
+
 	controlConn, _, err := websocket.Dial(ctx,
 		"ws"+strings.TrimPrefix(server.URL, "http")+"/claw/control/ws", &websocket.DialOptions{HTTPHeader: http.Header{
 			clawControlTokenHeader: {"claw-token"},

--- a/pkg/hub/workflowv2/control.go
+++ b/pkg/hub/workflowv2/control.go
@@ -27,6 +27,26 @@ type ControlBinding struct {
 	AttemptID string `json:"attempt_id"`
 }
 
+// OwnsClawExecution reports whether a claw has ever been assigned to a
+// workflow v2 attempt. Claw IDs are unique execution identities, so a
+// historical assignment permanently reserves execution control for the typed
+// v2 channel even after the run becomes terminal. This prevents a late
+// conversation message from falling through to legacy transcript controls.
+func (s *Store) OwnsClawExecution(ctx context.Context, tenantID, clawID string) (bool, error) {
+	if s == nil || s.db == nil {
+		return false, fmt.Errorf("workflow v2 store is not configured")
+	}
+	if strings.TrimSpace(tenantID) == "" || strings.TrimSpace(clawID) == "" {
+		return false, fmt.Errorf("tenant id and claw id are required")
+	}
+	var owned bool
+	err := s.db.QueryRowContext(ctx, `SELECT EXISTS(
+		SELECT 1 FROM workflow_v2_attempts a
+		JOIN workflow_v2_runs r ON r.id=a.run_id
+		WHERE r.tenant_id=? AND a.claw_id=?)`, tenantID, clawID).Scan(&owned)
+	return owned, err
+}
+
 // ActiveControlBinding returns the single active workflow v2 attempt assigned
 // to a claw. Multiple bindings are rejected rather than choosing one and
 // risking cross-run control delivery.

--- a/pkg/hub/workflowv2/control_test.go
+++ b/pkg/hub/workflowv2/control_test.go
@@ -72,6 +72,30 @@ func TestAttemptSnapshotAndControlOutbox(t *testing.T) {
 	}
 }
 
+func TestWorkflowV2ClawOwnershipSurvivesTerminalRun(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	createRuntimeRun(t, store, "run-owned-claw")
+	if _, err := store.StartAttempt(context.Background(), "run-owned-claw", "claw-owned-v2"); err != nil {
+		t.Fatal(err)
+	}
+	owned, err := store.OwnsClawExecution(context.Background(), "tenant-1", "claw-owned-v2")
+	if err != nil || !owned {
+		t.Fatalf("active ownership = %v, %v", owned, err)
+	}
+	if _, err := db.Exec(`UPDATE workflow_v2_runs SET status='completed' WHERE id='run-owned-claw'`); err != nil {
+		t.Fatal(err)
+	}
+	owned, err = store.OwnsClawExecution(context.Background(), "tenant-1", "claw-owned-v2")
+	if err != nil || !owned {
+		t.Fatalf("terminal ownership = %v, %v", owned, err)
+	}
+	owned, err = store.OwnsClawExecution(context.Background(), "tenant-1", "ordinary-v1-claw")
+	if err != nil || owned {
+		t.Fatalf("ordinary claw ownership = %v, %v", owned, err)
+	}
+}
+
 func TestRejectedHubControlSuspendsRunInsteadOfDroppingCommand(t *testing.T) {
 	db := openRuntimeDB(t)
 	store := workflowv2.NewStore(db)

--- a/pkg/hub/workflowv2/delivery_test.go
+++ b/pkg/hub/workflowv2/delivery_test.go
@@ -24,6 +24,27 @@ repositories:
     repository: org/web
 `
 
+const deliveryTransitionWorkflowYAML = `
+schema_version: 2
+name: delivery-transition
+enabled: true
+initial_state: awaiting_delivery
+states:
+  awaiting_delivery:
+    phase: build
+  reviewing:
+    phase: review
+transitions:
+  submitted:
+    from: awaiting_delivery
+    on: delivery.verified
+    when:
+      delivery:
+        open:
+          not_equals: 0
+    to: reviewing
+`
+
 func createDeliveryRun(t *testing.T, store *workflowv2.Store, id string) workflowv2.Attempt {
 	t.Helper()
 	if _, err := store.CreateRun(context.Background(), workflowv2.CreateRunRequest{
@@ -85,6 +106,39 @@ func TestSubmitDeliveryVerifiesMultipleWorkspaceRepositories(t *testing.T) {
 	deliveryFacts, ok := inspection.Facts["delivery"].(map[string]interface{})
 	if !ok || deliveryFacts["count"] != float64(2) || deliveryFacts["all_merged"] != false {
 		t.Fatalf("delivery facts = %#v", inspection.Facts["delivery"])
+	}
+}
+
+func TestVerifiedDeliveryAdvancesToPRLifecycleWithoutOpenedWebhook(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	run, err := store.CreateRun(context.Background(), workflowv2.CreateRunRequest{
+		ID: "run-delivery-transition", TenantID: "tenant-1", InitialClawID: "claw-delivery-transition",
+		WorkspaceYAML: []byte(deliveryWorkspaceYAML), WorkflowYAML: []byte(deliveryTransitionWorkflowYAML),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	apiURL := "https://github.example/org/api/pull/10"
+	if _, err := store.SubmitDelivery(context.Background(), run.ID, run.CurrentAttemptID,
+		typesv2.DeliveryManifest{PullRequests: []typesv2.PullRequestClaim{{URL: apiURL}}},
+		deliveryVerifier(map[string]string{apiURL: "api-head"})); err != nil {
+		t.Fatal(err)
+	}
+	updated, err := store.GetRun(context.Background(), run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.State != "reviewing" || updated.DisplayPhase != typesv2.PhaseReview || updated.StateVersion != 2 {
+		t.Fatalf("run after verified delivery = %#v", updated)
+	}
+	var openedEvents int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_events
+		WHERE run_id=? AND kind='pull_request.verified_open'`, run.ID).Scan(&openedEvents); err != nil {
+		t.Fatal(err)
+	}
+	if openedEvents != 0 {
+		t.Fatalf("transition unexpectedly depended on %d opened webhook events", openedEvents)
 	}
 }
 

--- a/pkg/types/convert/convert_test.go
+++ b/pkg/types/convert/convert_test.go
@@ -154,6 +154,48 @@ func TestConvertWorkflowV1ToV2(t *testing.T) {
 	}
 }
 
+func TestConvertWorkflowPRStartedUsesVerifiedDeliveryEdge(t *testing.T) {
+	input := []byte(`
+schema_version: v1
+name: pr-lifecycle
+stages:
+  - id: build
+    entry: true
+  - id: review
+    triggers:
+      - pr_opened: {}
+`)
+	res, err := convert.Convert(convert.KindWorkflow, input, convert.Options{To: "2"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolved, err := v2.ParseAndValidateWorkflow(res.Output)
+	if err != nil {
+		t.Fatalf("validate converted workflow: %v\n%s", err, res.Output)
+	}
+	found := false
+	for _, transition := range resolved.Workflow.Transitions {
+		if transition.To != "review" {
+			continue
+		}
+		found = true
+		if transition.On != "delivery.verified" {
+			t.Fatalf("PR-start transition event = %q, want delivery.verified", transition.On)
+		}
+		delivery, ok := transition.When["delivery"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("PR-start transition predicate = %#v", transition.When)
+		}
+		open, ok := delivery["open"].(map[string]interface{})
+		if !ok || open["not_equals"] == nil {
+			t.Fatalf("PR-start transition predicate = %#v", transition.When)
+		}
+	}
+	if !found {
+		t.Fatalf("converted workflow has no transition to review:\n%s", res.Output)
+	}
+}
+
 func TestConvertWorkflowPairWithConvertedWorkspace(t *testing.T) {
 	ws, err := convert.Convert(convert.KindWorkspace, []byte(sampleWorkspaceV1), convert.Options{To: "2"})
 	if err != nil {

--- a/pkg/types/convert/workflow_v1_v2.go
+++ b/pkg/types/convert/workflow_v1_v2.go
@@ -222,10 +222,13 @@ func mapV1Trigger(path string, trig map[string]interface{}) (*mappedTrigger, []s
 	}
 	if _, ok := trig["pr_opened"]; ok {
 		return &mappedTrigger{
-			on:   "pull_request.verified_open",
+			// V2 learns the claw's dynamic PR set when the authenticated
+			// delivery manifest is verified. The GitHub opened webhook normally
+			// predates that registration and is therefore not a reliable edge.
+			on:   "delivery.verified",
 			slug: "pr_opened",
 			when: map[string]interface{}{
-				"pull_request": map[string]interface{}{"state": "open"},
+				"delivery": map[string]interface{}{"open": map[string]interface{}{"not_equals": 0}},
 			},
 		}, warnings
 	}


### PR DESCRIPTION
## Summary

Completes the Workflow V2 compatibility boundary from #544:

- permanently routes claws assigned to a V2 attempt through typed control, including after a run becomes terminal;
- keeps V2 conversation messages visible and durable while bypassing legacy initial-plan, message-trigger, `[DONE]`, `[TERMINATE]`, PR scanning, no-progress, tool-loop, bootstrap-wake, and pipeline execution paths;
- preserves the existing conversation-driven behavior for V1 claws;
- changes converted `pr_opened` edges to the authoritative `delivery.verified` event, because PR-open webhooks normally predate dynamic delivery registration;
- fixes bridge task lifecycle payloads to use the agent-owned `task` namespace rather than the unauthorized `execution` namespace;
- adds concurrent V1/V2 WebSocket coverage: V1 advances on `[DONE]` while V2 completes a real assigned task through authenticated `/claw/control/ws`, and identical V2 transcript text remains display-only.

This is additive for V1: no V1 schema, bridge negotiation, transcript trigger, or pipeline behavior changes.

## Verification

- [x] `go test ./... -count=1`
- [x] `go vet ./...`
- [x] focused concurrent V1/V2 race-detector coverage
- [x] verified delivery advances without relying on an earlier PR-open webhook
- [x] terminal V2 ownership cannot fall back into legacy transcript controls

Part of #544.