### PR TITLE
fix: clarify GitHub auth helper for agents

### DIFF
--- a/.elasticclaw/workspaces/elasticclaw/AGENTS.md
+++ b/.elasticclaw/workspaces/elasticclaw/AGENTS.md
@@ -48,7 +48,13 @@ How it works: `/usr/local/bin/gh` is a wrapper that calls the credential helper 
 
 Do not use `gh auth status` to check authentication — it looks at the persisted `hosts.yml` file and can report "not authenticated" even when the wrapper is working. To verify gh is ready, run a real command such as `gh api rate_limit` or `gh repo view <owner>/<repo>`.
 
-If you see an auth prompt or error, the correct response is to verify the credential helper is being invoked (e.g. `git credential fill` returns `username=x-access-token` and a password), not to try logging in again. The helper is the source of truth.
+If you see an auth prompt or error, verify the credential helper is being invoked by running:
+
+```bash
+printf 'protocol=https\nhost=github.com\n' | git credential fill
+```
+
+This should return `username=x-access-token` and a password. Do not try logging in again. The helper is the source of truth.
 
 NEVER force push and rebase unless you are resolving conflicts. When addressing standard feedback, it's preferable to push a new commit.
 

--- a/.elasticclaw/workspaces/elasticclaw/AGENTS.md
+++ b/.elasticclaw/workspaces/elasticclaw/AGENTS.md
@@ -40,9 +40,16 @@ go version && node --version && npm --version && oras version
 docker version   # Docker is on the VM; use for container tests
 ```
 
-## Git
+## Git & GitHub Auth
 
-You have a git credential helper installed. Use that to interaction with git and gh.
+You are already authenticated to GitHub via the ElasticClaw credential helper. Do not run `gh auth login`, `gh auth setup-git`, or set `GITHUB_TOKEN`/`GH_TOKEN` yourself. Just use `git` and `gh` directly — the helper mints a fresh, scoped GitHub App token for every operation.
+
+How it works: `/usr/local/bin/gh` is a wrapper that calls the credential helper (`/usr/local/bin/elasticclaw-git-credentials`) to fetch a token from the hub before delegating to the real `gh` binary. The credential helper hits `$ELASTICCLAW_HUB_URL/api/github/token/$ELASTICCLAW_CLAW_ID` and returns a short-lived GitHub App installation token. Because the token is refreshed per invocation, nothing is persisted in `~/.config/gh/hosts.yml`.
+
+Do not use `gh auth status` to check authentication — it looks at the persisted `hosts.yml` file and can report "not authenticated" even when the wrapper is working. To verify gh is ready, run a real command such as `gh api rate_limit` or `gh repo view <owner>/<repo>`.
+
+If you see an auth prompt or error, the correct response is to verify the credential helper is being invoked (e.g. `git credential fill` returns `username=x-access-token` and a password), not to try logging in again. The helper is the source of truth.
+
 NEVER force push and rebase unless you are resolving conflicts. When addressing standard feedback, it's preferable to push a new commit.
 
 ## Memory

--- a/pkg/hub/github_webhook.go
+++ b/pkg/hub/github_webhook.go
@@ -1281,8 +1281,10 @@ func buildGitHubPRContext(pr githubPRPayload) string {
 	b.WriteString(`
 ## Git & GitHub Auth
 
-A git credential helper is pre-configured. You do NOT need to run gh auth login or set GH_TOKEN.
+A git credential helper is pre-configured. /usr/local/bin/gh is a wrapper that calls the credential helper to fetch a fresh GitHub App token before each invocation. You do NOT need to run gh auth login or set GH_TOKEN.
 Just use git and gh commands directly — authentication is handled automatically.
+
+Do not use gh auth status to verify authentication; it checks the persisted hosts.yml file and may report "not authenticated" even when the wrapper is working. Use a real command such as gh api rate_limit or gh repo view <owner>/<repo>.
 
 To check out this PR:
 `)

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -6572,7 +6572,12 @@ gh issue list
 `+"```\n"+`
 Do not use gh auth status to verify authentication. Instead, run a real command such as gh api rate_limit or gh repo view <owner>/<repo>.
 
-If you see an authentication prompt or error, do not try to fix it by logging in. Verify the credential helper is being invoked (e.g. "git credential fill" returns "username=x-access-token" and a password). The helper is the source of truth.
+If you see an authentication prompt or error, do not try to fix it by logging in. Verify the credential helper is being invoked by running:
+
+`+"```bash\n"+`printf 'protocol=https\nhost=github.com\n' | git credential fill
+`+"```\n"+`
+
+This should return "username=x-access-token" and a password. The helper is the source of truth.
 `, repoLines)
 		if existing, ok := files["TOOLS.md"]; ok {
 			files["TOOLS.md"] = existing + "\n" + githubSection

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -6558,7 +6558,9 @@ func (s *Server) bootstrapReplicated(clawID, clawName, vmID string, cfg types.Pr
 		githubSection := fmt.Sprintf(`
 ## GitHub Access
 
-This agent has authenticated access to the following repositories via a GitHub App installation token. The token is fetched automatically — you don't need to configure anything.
+This agent has already authenticated to GitHub via an ElasticClaw GitHub App. The credential helper is installed and will mint a fresh, scoped installation token for every git/gh operation. **Do not run gh auth login, gh auth setup-git, or set GITHUB_TOKEN/GH_TOKEN yourself.** Just use git and gh commands directly.
+
+How it works: /usr/local/bin/gh is a wrapper that calls /usr/local/bin/elasticclaw-git-credentials to fetch a token from the hub before delegating to the real gh binary. The credential helper hits the hub's /api/github/token endpoint and returns a short-lived GitHub App installation token. Nothing is persisted in ~/.config/gh/hosts.yml, so gh auth status may look empty even though gh is authenticated.
 
 %s
 **git** and **gh CLI** are pre-configured and will work without any additional auth setup:
@@ -6568,7 +6570,9 @@ git clone https://github.com/owner/repo
 gh pr create
 gh issue list
 `+"```\n"+`
-Tokens are short-lived and refreshed automatically on each git/gh operation.
+Do not use gh auth status to verify authentication. Instead, run a real command such as gh api rate_limit or gh repo view <owner>/<repo>.
+
+If you see an authentication prompt or error, do not try to fix it by logging in. Verify the credential helper is being invoked (e.g. "git credential fill" returns "username=x-access-token" and a password). The helper is the source of truth.
 `, repoLines)
 		if existing, ok := files["TOOLS.md"]; ok {
 			files["TOOLS.md"] = existing + "\n" + githubSection


### PR DESCRIPTION
Agents were reporting that 'gh' is not authenticated even though the ElasticClaw credential helper and wrapper are in place.

The root cause is that 'gh auth status' checks ~/.config/gh/hosts.yml, not the GH_TOKEN env var that our wrapper refreshes on every invocation. Because the installation token is short-lived and minted per call, nothing is persisted in hosts.yml, so gh auth status can misleadingly report "not authenticated".

This change updates the startup instructions that every agent reads:

- Explain that /usr/local/bin/gh is a wrapper that calls the credential helper before delegating to the real gh binary.
- Tell agents not to use gh auth status to verify authentication.
- Direct agents to use real commands like gh api rate_limit or gh repo view <owner>/<repo> instead.
- Repeat the existing rule: do not run gh auth login or set GH_TOKEN/GITHUB_TOKEN.

Files updated:
- .elasticclaw/workspaces/elasticclaw/AGENTS.md
- pkg/hub/server.go (injected TOOLS.md GitHub Access section)
- pkg/hub/github_webhook.go (PR-assignment BOOTSTRAP.md context)

Verification:
- go build ./...
- go test ./... -count:1