### PR TITLE
Add Claude Opus 5 and Sonnet 5 to Anthropic model dropdown

### DIFF
--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -1145,6 +1145,8 @@ const PROVIDER_OPTIONS = [
 
 const PROVIDER_MODELS: Record<string, LLMModelOption[]> = {
   anthropic: [
+    { id: "anthropic/claude-opus-5",     name: "Claude Opus 5" },
+    { id: "anthropic/claude-sonnet-5",   name: "Claude Sonnet 5" },
     { id: "anthropic/claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
     { id: "anthropic/claude-opus-4-5",   name: "Claude Opus 4.5" },
     { id: "anthropic/claude-sonnet-4-5", name: "Claude Sonnet 4.5" },


### PR DESCRIPTION
## Summary
- Adds `claude-opus-5` and `claude-sonnet-5` as native options in the Anthropic model dropdown (Settings > LLM Keys), so they no longer require the "Custom Anthropic model" fallback.

## Test plan
- [ ] Open Settings > LLM Keys, add/edit an Anthropic key, confirm both models appear in the dropdown and can be selected/saved.