### PR TITLE
fix(hub): survive gateway death — restore, escalation and post-mortem

### DIFF
--- a/pkg/hub/checkpoints.go
+++ b/pkg/hub/checkpoints.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"database/sql"
-	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -1021,24 +1020,12 @@ func (s *Server) restoreCheckpointToDaytona(ctx context.Context, clawID, instanc
 			return fmt.Errorf("read checkpoint blob %s: %w", f.SHA256, err)
 		}
 		remote := restoreRemotePath(f.Path, "/home/daytona", "/home/daytona/.openclaw/workspace")
-		cmd := checkpointDaytonaRestoreCommand(remote, data)
-		result, err := p.ExecWithTimeout(ctx, instanceID, []string{"bash", "-c", cmd}, 30*time.Second)
-		if err != nil {
+		if err := p.WriteFile(ctx, instanceID, remote, data); err != nil {
 			return fmt.Errorf("restore %s: %w", f.Path, err)
-		}
-		if result.ExitCode != 0 {
-			return fmt.Errorf("restore %s failed: %s", f.Path, result.Stdout)
 		}
 	}
 	s.markRestoreApplied(clawID, checkpointID)
 	return nil
-}
-
-func checkpointDaytonaRestoreCommand(remote string, data []byte) string {
-	encoded := base64.StdEncoding.EncodeToString(data)
-	return fmt.Sprintf(`export HOME=/home/daytona; mkdir -p %s; base64 -d > %s <<'ELASTICCLAW_CHECKPOINT_EOF'
-%s
-ELASTICCLAW_CHECKPOINT_EOF`, checkpointShellQuote(filepath.Dir(remote)), checkpointShellQuote(remote), encoded)
 }
 
 func (s *Server) restoreCheckpointToExedev(ctx context.Context, clawID, vmName string, p *exedevProvider.Provider) error {

--- a/pkg/hub/checkpoints_test.go
+++ b/pkg/hub/checkpoints_test.go
@@ -127,21 +127,6 @@ func TestDispatchCheckpointWriteFailureRemovesWaiter(t *testing.T) {
 	}
 }
 
-func TestDaytonaRestoreCommandSingleQuotesPaths(t *testing.T) {
-	remote := "/home/daytona/.openclaw/workspace/src/$SECRET/`touch /tmp/pwn`/it's.txt"
-	cmd := checkpointDaytonaRestoreCommand(remote, []byte("hello"))
-
-	if !strings.Contains(cmd, "mkdir -p "+checkpointShellQuote("/home/daytona/.openclaw/workspace/src/$SECRET/`touch /tmp/pwn`")) {
-		t.Fatalf("expected single-quoted mkdir path, got %q", cmd)
-	}
-	if !strings.Contains(cmd, "> "+checkpointShellQuote(remote)) {
-		t.Fatalf("expected single-quoted output path, got %q", cmd)
-	}
-	if strings.Contains(cmd, `mkdir -p "`) || strings.Contains(cmd, `> "`) {
-		t.Fatalf("expected restore paths to avoid shell double quotes, got %q", cmd)
-	}
-}
-
 func assertPendingCheckpointDrained(t *testing.T, s *Server) {
 	t.Helper()
 	cc := s.claws["claw"]

--- a/pkg/hub/claw_retry.go
+++ b/pkg/hub/claw_retry.go
@@ -108,16 +108,7 @@ func (s *Server) escalateClawHealthFailure(clawID, reason string) {
 }
 
 func (s *Server) escalateGatewayHealthFailure(clawID string) {
-	s.mu.RLock()
-	cc := s.claws[clawID]
-	s.mu.RUnlock()
-	if cc == nil {
-		return
-	}
-	cc.mu.RLock()
-	unhealthyCount := cc.gatewayUnhealthyCount
-	cc.mu.RUnlock()
-	if unhealthyCount < 12 {
+	if s.gatewayUnhealthyCount(clawID) < s.livenessSettings().gatewayUnhealthyMax {
 		return
 	}
 	s.escalateClawHealthFailure(clawID, "workspace unresponsive: gateway unhealthy for ~3m")

--- a/pkg/hub/claw_retry.go
+++ b/pkg/hub/claw_retry.go
@@ -108,10 +108,15 @@ func (s *Server) escalateClawHealthFailure(clawID, reason string) {
 }
 
 func (s *Server) escalateGatewayHealthFailure(clawID string) {
-	if s.gatewayUnhealthyCount(clawID) < s.livenessSettings().gatewayUnhealthyMax {
+	unhealthyMax := s.livenessSettings().gatewayUnhealthyMax
+	if s.gatewayUnhealthyCount(clawID) < unhealthyMax {
 		return
 	}
-	s.escalateClawHealthFailure(clawID, "workspace unresponsive: gateway unhealthy for ~3m")
+	// Report the check count rather than a duration: the threshold is configurable
+	// via gateway_unhealthy_checks, and the heartbeat cadence that would turn it into
+	// a duration lives in the bridge, not here. Keep the "workspace unresponsive"
+	// prefix — classifyAgentFailure matches on it.
+	s.escalateClawHealthFailure(clawID, fmt.Sprintf("workspace unresponsive: gateway unhealthy for %d consecutive checks", unhealthyMax))
 }
 
 // prepareClawRetry atomically fails the current attempt and creates its

--- a/pkg/hub/gateway_logs.go
+++ b/pkg/hub/gateway_logs.go
@@ -1,0 +1,95 @@
+package hub
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+const (
+	gatewayLogCaptureLimit   = 256 * 1024
+	gatewayLogCaptureTimeout = 20 * time.Second
+)
+
+// gatewayLogExecutor is deliberately limited to the operation needed for
+// diagnostic capture so this path can be tested without contacting Daytona.
+type gatewayLogExecutor interface {
+	ExecWithTimeout(context.Context, string, []string, time.Duration) (*types.ExecResult, error)
+}
+
+// captureGatewayLog preserves a small tail of a Daytona gateway log before its
+// sandbox is destroyed. Capture is diagnostic-only: failures must never affect
+// termination.
+func (s *Server) captureGatewayLog(clawID, provider, providerID string) {
+	if provider != "daytona" {
+		return
+	}
+
+	s.mu.RLock()
+	var cfg types.ProviderConfig
+	var ok bool
+	if s.hubCfg != nil {
+		cfg, ok = s.hubCfg.Providers[provider]
+	}
+	s.mu.RUnlock()
+	if !ok {
+		log.Printf("[gateway-log] capture failed for %s: provider is not configured", shortID(clawID))
+		return
+	}
+
+	executor, err := newDaytonaProvider(cfg)
+	if err == nil {
+		err = captureGatewayLogWithExecutor(context.Background(), executor, clawID, providerID, hubDataDir())
+	}
+	if err != nil {
+		log.Printf("[gateway-log] capture failed for %s: %v", shortID(clawID), err)
+	}
+}
+
+func captureGatewayLogWithExecutor(ctx context.Context, executor gatewayLogExecutor, clawID, providerID, dataDir string) error {
+	ctx, cancel := context.WithTimeout(ctx, gatewayLogCaptureTimeout)
+	defer cancel()
+
+	result, err := executor.ExecWithTimeout(ctx, providerID, []string{"bash", "-lc", "tail -c 262144 ~/.openclaw/gateway.log"}, gatewayLogCaptureTimeout)
+	if err != nil {
+		return err
+	}
+	if result == nil {
+		return fmt.Errorf("empty exec result")
+	}
+
+	contents := []byte(result.Stdout)
+	if len(contents) > gatewayLogCaptureLimit {
+		contents = contents[len(contents)-gatewayLogCaptureLimit:]
+	}
+
+	diagnosticsDir := filepath.Join(dataDir, "diagnostics")
+	if err := os.MkdirAll(diagnosticsDir, 0o700); err != nil {
+		return fmt.Errorf("create diagnostics directory: %w", err)
+	}
+	filename := fmt.Sprintf("%s-%s.log", filepath.Base(clawID), time.Now().UTC().Format(time.RFC3339Nano))
+	path := filepath.Join(diagnosticsDir, filename)
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return fmt.Errorf("create capture file: %w", err)
+	}
+	if _, err := file.Write(contents); err != nil {
+		_ = file.Close()
+		_ = os.Remove(path)
+		return fmt.Errorf("write capture file: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(path)
+		return fmt.Errorf("close capture file: %w", err)
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		return fmt.Errorf("secure capture file: %w", err)
+	}
+	log.Printf("[gateway-log] captured %d bytes for %s at %s", len(contents), shortID(clawID), path)
+	return nil
+}

--- a/pkg/hub/gateway_logs.go
+++ b/pkg/hub/gateway_logs.go
@@ -14,6 +14,7 @@ import (
 const (
 	gatewayLogCaptureLimit   = 256 * 1024
 	gatewayLogCaptureTimeout = 20 * time.Second
+	gatewayLogCaptureCommand = "tail -c 262144 /home/daytona/.openclaw/gateway.log 2>/dev/null"
 )
 
 // gatewayLogExecutor is deliberately limited to the operation needed for
@@ -55,12 +56,21 @@ func captureGatewayLogWithExecutor(ctx context.Context, executor gatewayLogExecu
 	ctx, cancel := context.WithTimeout(ctx, gatewayLogCaptureTimeout)
 	defer cancel()
 
-	result, err := executor.ExecWithTimeout(ctx, providerID, []string{"bash", "-lc", "tail -c 262144 ~/.openclaw/gateway.log"}, gatewayLogCaptureTimeout)
+	// Pass the script as a single element: ExecWithTimeout joins cmdArgs and wraps
+	// the result in `bash -c '...'` itself, so a "bash -c" prefix here would nest a
+	// second shell that swallows the arguments. Use an absolute path rather than ~,
+	// which is unreliable in Daytona exec sessions.
+	result, err := executor.ExecWithTimeout(ctx, providerID, []string{gatewayLogCaptureCommand}, gatewayLogCaptureTimeout)
 	if err != nil {
 		return err
 	}
 	if result == nil {
 		return fmt.Errorf("empty exec result")
+	}
+	// A missing log or a dead sandbox is the normal case, not something to record:
+	// writing an empty file would make a failed capture look like a successful one.
+	if result.ExitCode != 0 || len(result.Stdout) == 0 {
+		return nil
 	}
 
 	contents := []byte(result.Stdout)

--- a/pkg/hub/gateway_logs_test.go
+++ b/pkg/hub/gateway_logs_test.go
@@ -30,7 +30,11 @@ func TestCaptureGatewayLogWritesSecureTail(t *testing.T) {
 	if err := captureGatewayLogWithExecutor(context.Background(), executor, "claw-123", "sandbox-123", dataDir); err != nil {
 		t.Fatalf("captureGatewayLogWithExecutor: %v", err)
 	}
-	if got, want := executor.args, []string{"bash", "-lc", "tail -c 262144 ~/.openclaw/gateway.log"}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] || got[2] != want[2] {
+	// One element, no "bash -c" prefix: the Daytona provider joins cmdArgs and wraps
+	// them in `bash -c '...'`, so a prefix here nests a second shell that eats the
+	// arguments and silently tails nothing. The stub cannot catch that, so assert the
+	// shape.
+	if got, want := executor.args, []string{gatewayLogCaptureCommand}; len(got) != len(want) || got[0] != want[0] {
 		t.Fatalf("exec args = %q, want %q", got, want)
 	}
 	if executor.timeout != gatewayLogCaptureTimeout {
@@ -69,6 +73,33 @@ func TestCaptureGatewayLogExecErrorLeavesNoFile(t *testing.T) {
 	}
 	if len(files) != 0 {
 		t.Fatalf("capture files = %q, want none", files)
+	}
+}
+
+func TestCaptureGatewayLogSkipsEmptyAndFailedTail(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		result *types.ExecResult
+	}{
+		{"missing log", &types.ExecResult{ExitCode: 1}},
+		{"empty log", &types.ExecResult{Stdout: ""}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dataDir := t.TempDir()
+			executor := &gatewayLogExecutorStub{result: tc.result}
+			if err := captureGatewayLogWithExecutor(context.Background(), executor, "claw-123", "sandbox-123", dataDir); err != nil {
+				t.Fatalf("captureGatewayLogWithExecutor: %v", err)
+			}
+			// An empty capture file would read as a successful post-mortem that
+			// happens to be blank, hiding the fact that nothing was preserved.
+			files, err := filepath.Glob(filepath.Join(dataDir, "diagnostics", "*.log"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(files) != 0 {
+				t.Fatalf("capture files = %q, want none", files)
+			}
+		})
 	}
 }
 

--- a/pkg/hub/gateway_logs_test.go
+++ b/pkg/hub/gateway_logs_test.go
@@ -1,0 +1,93 @@
+package hub
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+type gatewayLogExecutorStub struct {
+	result  *types.ExecResult
+	err     error
+	args    []string
+	timeout time.Duration
+}
+
+func (s *gatewayLogExecutorStub) ExecWithTimeout(_ context.Context, _ string, args []string, timeout time.Duration) (*types.ExecResult, error) {
+	s.args = args
+	s.timeout = timeout
+	return s.result, s.err
+}
+
+func TestCaptureGatewayLogWritesSecureTail(t *testing.T) {
+	dataDir := t.TempDir()
+	executor := &gatewayLogExecutorStub{result: &types.ExecResult{Stdout: "gateway stopped: out of memory\n"}}
+	if err := captureGatewayLogWithExecutor(context.Background(), executor, "claw-123", "sandbox-123", dataDir); err != nil {
+		t.Fatalf("captureGatewayLogWithExecutor: %v", err)
+	}
+	if got, want := executor.args, []string{"bash", "-lc", "tail -c 262144 ~/.openclaw/gateway.log"}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] || got[2] != want[2] {
+		t.Fatalf("exec args = %q, want %q", got, want)
+	}
+	if executor.timeout != gatewayLogCaptureTimeout {
+		t.Fatalf("exec timeout = %s, want %s", executor.timeout, gatewayLogCaptureTimeout)
+	}
+
+	files, err := filepath.Glob(filepath.Join(dataDir, "diagnostics", "claw-123-*.log"))
+	if err != nil || len(files) != 1 {
+		t.Fatalf("capture files = %q, %v; want one", files, err)
+	}
+	contents, err := os.ReadFile(files[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := string(contents), "gateway stopped: out of memory\n"; got != want {
+		t.Fatalf("capture contents = %q, want %q", got, want)
+	}
+	info, err := os.Stat(files[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := info.Mode().Perm(), os.FileMode(0o600); got != want {
+		t.Fatalf("capture mode = %o, want %o", got, want)
+	}
+}
+
+func TestCaptureGatewayLogExecErrorLeavesNoFile(t *testing.T) {
+	dataDir := t.TempDir()
+	executor := &gatewayLogExecutorStub{err: errors.New("sandbox not found")}
+	if err := captureGatewayLogWithExecutor(context.Background(), executor, "claw-123", "sandbox-123", dataDir); err == nil {
+		t.Fatal("captureGatewayLogWithExecutor error = nil, want error")
+	}
+	files, err := filepath.Glob(filepath.Join(dataDir, "diagnostics", "*.log"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 0 {
+		t.Fatalf("capture files = %q, want none", files)
+	}
+}
+
+func TestCaptureGatewayLogHonorsSizeCap(t *testing.T) {
+	dataDir := t.TempDir()
+	contents := make([]byte, gatewayLogCaptureLimit+100)
+	for i := range contents {
+		contents[i] = 'x'
+	}
+	executor := &gatewayLogExecutorStub{result: &types.ExecResult{Stdout: string(contents)}}
+	if err := captureGatewayLogWithExecutor(context.Background(), executor, "claw-123", "sandbox-123", dataDir); err != nil {
+		t.Fatalf("captureGatewayLogWithExecutor: %v", err)
+	}
+	files, _ := filepath.Glob(filepath.Join(dataDir, "diagnostics", "*.log"))
+	info, err := os.Stat(files[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := info.Size(), int64(gatewayLogCaptureLimit); got != want {
+		t.Fatalf("capture size = %d, want %d", got, want)
+	}
+}

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -2044,6 +2044,7 @@ func (s *Server) stopAgentTerminalWithReason(clawID, reason string, skipVMTermin
 		cc.conn.Close(1000, "Agent stopped: "+safeReason)
 		delete(s.claws, clawID)
 	}
+	delete(s.gatewayUnhealthyCounts, clawID)
 	s.mu.Unlock()
 
 	// 4. Write issue-tracker comment without delaying agent shutdown.

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -2057,7 +2057,10 @@ func (s *Server) stopAgentTerminalWithReason(clawID, reason string, skipVMTermin
 
 	// 5. Terminate VM if still running
 	if providerID != "" && !skipVMTerminate {
-		go s.terminateVMForClaw(clawID, provider, providerID)
+		go func() {
+			s.captureGatewayLog(clawID, provider, providerID)
+			s.terminateVMForClaw(clawID, provider, providerID)
+		}()
 	}
 
 	log.Printf("[stopAgent] claw %s stopped: %s", clawID[:8], reason)

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2627,7 +2627,12 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 							if unhealthyCount == 4 && !cc.streamingStartedAt.IsZero() {
 								go s.injectHubMessageByID(clawID, "[hub] The gateway has been unresponsive for about a minute. If you're stuck in a long operation, consider sending [DONE] and starting fresh.")
 							}
-							if unhealthyCount == gatewayUnhealthyMax {
+							// Retry the escalation every gatewayUnhealthyMax checks rather than
+							// only on the first crossing. escalateClawHealthFailure declines
+							// while the claw is not yet 'connected' or is protected, and now
+							// that reconnects no longer reset the counter, a single declined
+							// attempt would otherwise be the last one this claw ever gets.
+							if unhealthyCount >= gatewayUnhealthyMax && unhealthyCount%gatewayUnhealthyMax == 0 {
 								shouldEscalateGateway = true
 							}
 						}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -63,6 +63,8 @@ type Server struct {
 	users map[string]*userConn // tenant_id -> []conn (broadcast)
 	// gatewayRestartCounts retains the heartbeat counter across WebSocket reconnects.
 	gatewayRestartCounts map[string]int
+	// gatewayUnhealthyCounts survives WebSocket reconnects so flapping gateways still escalate.
+	gatewayUnhealthyCounts map[string]int
 	// autoResumeRestartCounts records restart counts already handled per claw. Guarded by s.mu.
 	autoResumeRestartCounts map[string]int
 	lastTokenFailureLog     time.Time
@@ -198,31 +200,36 @@ func (s *Server) validModelAuthToken(clawID, token string) bool {
 	return want != "" && hmac.Equal([]byte(want), []byte(strings.TrimSpace(token)))
 }
 
+func (s *Server) gatewayUnhealthyCount(clawID string) int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.gatewayUnhealthyCounts[clawID]
+}
+
 type clawConn struct {
 	mu sync.RWMutex // protects mutable fields below
 
-	id                    string
-	tenantID              string
-	conn                  *websocket.Conn
-	tags                  []string        // cached from DB at registration time for access-control checks
-	contextUsage          int             // 0-100, updated from heartbeats
-	gatewayReady          bool            // true once bridge reports gateway session established
-	gatewayUnhealthyCount int             // consecutive unhealthy heartbeats
-	gatewayRestartCount   int             // cumulative bridge restarts reported by heartbeats
-	forcedFinishCount     int             // consecutive watchdog-forced streaming turn finishes
-	workflowStartPending  bool            // true while initial volume attach / wake is in flight
-	workflowStartDone     bool            // true once initial volume attach / wake has completed
-	streamingBuf          strings.Builder // accumulates chunks for current in-flight response
-	streamingMsgID        string          // pre-assigned message ID for the current stream
-	streamingSplit        bool            // true once activity has split this turn into multiple persisted segments
-	streamingStartedAt    time.Time       // when the current streaming turn started (zero if not streaming)
-	streamingTimeoutSent  bool            // true once the 12-min timeout message has been injected this turn
-	contextWarningSent    bool            // true once the context-nearly-full warning has been injected this turn
-	awaitingResponse      bool            // true as soon as a prompt is delivered, before the first chunk/activity
-	noProgressPaused      bool            // automatic delivery is paused after repeated turns with unchanged progress
-	lastTurnFinishedAt    time.Time       // when the last streaming turn ended (for post-restart resume window)
-	connectedAt           time.Time       // when this connection registered; immutable after registration
-	idleNotifiedAt        time.Time       // when the agent_idle notification fired for the current idle stretch (zero = armed)
+	id                   string
+	tenantID             string
+	conn                 *websocket.Conn
+	tags                 []string        // cached from DB at registration time for access-control checks
+	contextUsage         int             // 0-100, updated from heartbeats
+	gatewayReady         bool            // true once bridge reports gateway session established
+	gatewayRestartCount  int             // cumulative bridge restarts reported by heartbeats
+	forcedFinishCount    int             // consecutive watchdog-forced streaming turn finishes
+	workflowStartPending bool            // true while initial volume attach / wake is in flight
+	workflowStartDone    bool            // true once initial volume attach / wake has completed
+	streamingBuf         strings.Builder // accumulates chunks for current in-flight response
+	streamingMsgID       string          // pre-assigned message ID for the current stream
+	streamingSplit       bool            // true once activity has split this turn into multiple persisted segments
+	streamingStartedAt   time.Time       // when the current streaming turn started (zero if not streaming)
+	streamingTimeoutSent bool            // true once the 12-min timeout message has been injected this turn
+	contextWarningSent   bool            // true once the context-nearly-full warning has been injected this turn
+	awaitingResponse     bool            // true as soon as a prompt is delivered, before the first chunk/activity
+	noProgressPaused     bool            // automatic delivery is paused after repeated turns with unchanged progress
+	lastTurnFinishedAt   time.Time       // when the last streaming turn ended (for post-restart resume window)
+	connectedAt          time.Time       // when this connection registered; immutable after registration
+	idleNotifiedAt       time.Time       // when the agent_idle notification fired for the current idle stretch (zero = armed)
 
 	deliveryInFlight bool // serializes DB-backed delivery writes
 
@@ -379,6 +386,7 @@ func NewServer(addr, dbPath, identityDir string, hubCfg *types.HubConfig) (*Serv
 		claws:                   make(map[string]*clawConn),
 		users:                   make(map[string]*userConn),
 		gatewayRestartCounts:    make(map[string]int),
+		gatewayUnhealthyCounts:  make(map[string]int),
 		autoResumeRestartCounts: make(map[string]int),
 		dependencyStatus:        newDependencyStatusService(hubCfg),
 		fileAckWaiters:          make(map[string]chan types.FileAck),
@@ -1686,6 +1694,7 @@ func (s *Server) handleClawDetail(w http.ResponseWriter, r *http.Request) {
 			cc.conn.Close(websocket.StatusNormalClosure, "killed")
 			delete(s.claws, clawID)
 		}
+		delete(s.gatewayUnhealthyCounts, clawID)
 		s.mu.Unlock()
 		go func() {
 			s.checkpointBeforeTermination(clawID, "manual-kill")
@@ -2605,16 +2614,20 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 							}
 						}
 						if !hb.GatewayHealthy {
-							cc.gatewayUnhealthyCount++
-							if cc.gatewayUnhealthyCount == 1 {
-								log.Printf("[heartbeat] %s (%s): gateway unhealthy", rp.Name, clawID[:8])
-							} else if cc.gatewayUnhealthyCount%4 == 0 {
-								log.Printf("[heartbeat] %s (%s): gateway unhealthy for %d consecutive checks", rp.Name, clawID[:8], cc.gatewayUnhealthyCount)
+							if s.gatewayUnhealthyCounts == nil {
+								s.gatewayUnhealthyCounts = make(map[string]int)
 							}
-							if cc.gatewayUnhealthyCount == 4 && !cc.streamingStartedAt.IsZero() {
+							s.gatewayUnhealthyCounts[clawID]++
+							unhealthyCount := s.gatewayUnhealthyCounts[clawID]
+							if unhealthyCount == 1 {
+								log.Printf("[heartbeat] %s (%s): gateway unhealthy", rp.Name, clawID[:8])
+							} else if unhealthyCount%4 == 0 {
+								log.Printf("[heartbeat] %s (%s): gateway unhealthy for %d consecutive checks", rp.Name, clawID[:8], unhealthyCount)
+							}
+							if unhealthyCount == 4 && !cc.streamingStartedAt.IsZero() {
 								go s.injectHubMessageByID(clawID, "[hub] The gateway has been unresponsive for about a minute. If you're stuck in a long operation, consider sending [DONE] and starting fresh.")
 							}
-							if cc.gatewayUnhealthyCount == gatewayUnhealthyMax {
+							if unhealthyCount == gatewayUnhealthyMax {
 								shouldEscalateGateway = true
 							}
 						}
@@ -2623,9 +2636,9 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 						if hb.ContextUsage != prevUsage && (hb.ContextUsage >= 80 || prevUsage >= 80) {
 							log.Printf("[heartbeat] %s (%s): context_usage=%d%%", rp.Name, clawID[:8], hb.ContextUsage)
 						}
-						if hb.GatewayHealthy && cc.gatewayUnhealthyCount > 0 {
-							log.Printf("[heartbeat] %s (%s): gateway recovered after %d unhealthy checks", rp.Name, clawID[:8], cc.gatewayUnhealthyCount)
-							cc.gatewayUnhealthyCount = 0
+						if hb.GatewayHealthy && s.gatewayUnhealthyCounts[clawID] > 0 {
+							log.Printf("[heartbeat] %s (%s): gateway recovered after %d unhealthy checks", rp.Name, clawID[:8], s.gatewayUnhealthyCounts[clawID])
+							s.gatewayUnhealthyCounts[clawID] = 0
 						}
 						// Inject context warning once per streaming turn when usage is >=95%
 						if !cc.streamingStartedAt.IsZero() &&

--- a/pkg/hub/watchdog_enforcement_test.go
+++ b/pkg/hub/watchdog_enforcement_test.go
@@ -36,13 +36,13 @@ func watchdogClaw(t *testing.T, s *Server, clawID string) *websocket.Conn {
 	// delivered_at is set so the seed can never be drained as a pending
 	// message and interfere with queue-draining tests.
 	if _, err := s.db.Exec(
-		`INSERT INTO claws(id,tenant_id,name,template,status,created_at) VALUES(?,?,?,?,?,?)`,
+		`INSERT OR IGNORE INTO claws(id,tenant_id,name,template,status,created_at) VALUES(?,?,?,?,?,?)`,
 		clawID, "test-tenant-id", "watchdog claw", "elasticclaw", "offline", time.Now(),
 	); err != nil {
 		t.Fatalf("pre-create claws row: %v", err)
 	}
 	if _, err := s.db.Exec(
-		`INSERT INTO messages(id,claw_id,tenant_id,role,content,format,created_at,delivered_at) VALUES(?,?,?,?,?,?,?,?)`,
+		`INSERT OR IGNORE INTO messages(id,claw_id,tenant_id,role,content,format,created_at,delivered_at) VALUES(?,?,?,?,?,?,?,?)`,
 		"seed-"+clawID, clawID, "test-tenant-id", "system", "seed", "pre", time.Now(), time.Now(),
 	); err != nil {
 		t.Fatalf("seed wake-suppression message: %v", err)
@@ -116,7 +116,6 @@ func TestWatchdogHealthyHeartbeatResetsUnhealthyCounter(t *testing.T) {
 	s, _ := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
 	const clawID = "watchdog-heartbeat-reset"
 	conn := watchdogClaw(t, s, clawID)
-	cc := watchdogClawConn(t, s, clawID)
 	writeHeartbeat := func(healthy bool) {
 		t.Helper()
 		if err := wsjson.Write(context.Background(), conn, types.WSMessage{Type: "heartbeat", Payload: map[string]any{"gateway_healthy": healthy}}); err != nil {
@@ -127,20 +126,59 @@ func TestWatchdogHealthyHeartbeatResetsUnhealthyCounter(t *testing.T) {
 		writeHeartbeat(false)
 	}
 	eventuallyWatchdog(t, func() bool {
-		cc.mu.RLock()
-		defer cc.mu.RUnlock()
-		return cc.gatewayUnhealthyCount == defaultGatewayUnhealthyMax-1
+		return s.gatewayUnhealthyCount(clawID) == defaultGatewayUnhealthyMax-1
 	}, "unhealthy heartbeat count")
 	writeHeartbeat(true)
-	eventuallyWatchdog(t, func() bool { cc.mu.RLock(); defer cc.mu.RUnlock(); return cc.gatewayUnhealthyCount == 0 }, "healthy reset")
+	eventuallyWatchdog(t, func() bool { return s.gatewayUnhealthyCount(clawID) == 0 }, "healthy reset")
 	for i := 0; i < defaultGatewayUnhealthyMax-1; i++ {
 		writeHeartbeat(false)
 	}
 	eventuallyWatchdog(t, func() bool {
-		cc.mu.RLock()
-		defer cc.mu.RUnlock()
-		return cc.gatewayUnhealthyCount == defaultGatewayUnhealthyMax-1
+		return s.gatewayUnhealthyCount(clawID) == defaultGatewayUnhealthyMax-1
 	}, "post-reset unhealthy count")
+}
+
+func TestWatchdogUnhealthyCounterSurvivesBridgeReconnect(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	s.cronScheduler = newCronScheduler(s)
+	const clawID = "watchdog-unhealthy-reconnect"
+	conn := watchdogClaw(t, s, clawID)
+	if _, err := db.Exec(`UPDATE claws SET provider='noop', status='connected', bootstrap_ok=1 WHERE id=?`, clawID); err != nil {
+		t.Fatal(err)
+	}
+	runID, _, err := s.ensureTaskRunForClaw(clawID, TaskRunStart{RunKind: taskRunKindPRTask, OwnerType: taskRunOwnerFactory, AnalyticsEnabled: true, Tags: []string{}})
+	if err != nil {
+		t.Fatalf("create task run: %v", err)
+	}
+	writeUnhealthy := func(conn *websocket.Conn) {
+		t.Helper()
+		if err := wsjson.Write(context.Background(), conn, types.WSMessage{Type: "heartbeat", Payload: map[string]any{"gateway_healthy": false}}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	first := defaultGatewayUnhealthyMax / 2
+	for i := 0; i < first; i++ {
+		writeUnhealthy(conn)
+	}
+	eventuallyWatchdog(t, func() bool { return s.gatewayUnhealthyCount(clawID) == first }, "unhealthy count before reconnect")
+	if err := conn.Close(websocket.StatusNormalClosure, "reconnect"); err != nil {
+		t.Fatal(err)
+	}
+	eventuallyWatchdog(t, func() bool {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+		return s.claws[clawID] == nil
+	}, "bridge disconnect")
+	conn = watchdogClaw(t, s, clawID)
+	for i := first; i < defaultGatewayUnhealthyMax; i++ {
+		writeUnhealthy(conn)
+	}
+	eventuallyWatchdog(t, func() bool {
+		var attempts, retryEvents int
+		_ = db.QueryRow(`SELECT attempt_count FROM task_runs WHERE id=?`, runID).Scan(&attempts)
+		_ = db.QueryRow(`SELECT COUNT(*) FROM task_run_events WHERE run_id=? AND event_key=?`, runID, "retry:"+clawID+":2").Scan(&retryEvents)
+		return attempts == 2 && retryEvents == 1
+	}, "replacement attempt scheduled after reconnect")
 }
 
 func TestHeartbeatRestartCountChangeDetectedInBothDirections(t *testing.T) {

--- a/pkg/provider/daytona/daytona.go
+++ b/pkg/provider/daytona/daytona.go
@@ -207,6 +207,31 @@ func (p *Provider) Exec(ctx context.Context, instanceID string, cmdArgs []string
 	return p.ExecWithTimeout(ctx, instanceID, cmdArgs, 60*time.Second)
 }
 
+// WriteFile writes content to a file in an existing sandbox.
+func (p *Provider) WriteFile(ctx context.Context, instanceID, remotePath string, content []byte) error {
+	sandbox, err := p.client.Get(ctx, instanceID)
+	if err != nil {
+		return fmt.Errorf("daytona writefile %s: %w", remotePath, err)
+	}
+
+	absPath := remotePath
+	if !strings.HasPrefix(remotePath, "/") {
+		absPath = "/home/daytona/" + remotePath
+	}
+
+	dir := getDir(absPath)
+	if dir != "" && dir != "." {
+		if err := sandbox.FileSystem.CreateFolder(ctx, dir); err != nil {
+			return fmt.Errorf("daytona writefile %s: %w", remotePath, err)
+		}
+	}
+
+	if err := sandbox.FileSystem.UploadFile(ctx, content, absPath); err != nil {
+		return fmt.Errorf("daytona writefile %s: %w", remotePath, err)
+	}
+	return nil
+}
+
 // ExecWithTimeout runs a command with an explicit timeout. Use for long-running
 // operations like package installs that exceed the default 60s SDK HTTP timeout.
 func (p *Provider) ExecWithTimeout(ctx context.Context, instanceID string, cmdArgs []string, timeout time.Duration) (*types.ExecResult, error) {


### PR DESCRIPTION
Three defects surfaced by claw NEXT-655, which died twice and left no usable evidence behind. Root cause of both deaths was the same: running the `next_mobile` Jest suite killed the OpenClaw gateway on a 2 vCPU / 4 GB Daytona sandbox. This PR does not fix that — it fixes the three ways the hub made a recoverable incident unrecoverable and undiagnosable.

## 1. Checkpoint restore could not restore

Restore base64-encoded each file into the *text* of a shell command and passed it as a single argv element to `bash -c`. Linux caps one argument at 128 KB (`MAX_ARG_STRLEN`), so any file over ~96 KB raw failed with `zsh: argument list too long: bash`. Deterministic, so bootstrap retries could never recover.

In production, all 6 bootstrap attempts aborted on the same 128 KB PNG. It was only the first offender: the manifest holds 2,454 files, at least 6 over the limit, largest a 2.1 MB `.mp4`.

Add `Provider.WriteFile` to the Daytona provider and use it — no shell, no base64, no argv limit. Mirrors the exedev restore path and the Daytona bootstrap path, which both already used the SDK filesystem API.

## 2. Escalation never fired when the bridge flapped

`gatewayUnhealthyCount` lived on `clawConn`, the per-WebSocket struct rebuilt on every registration, so each reconnect silently reset it. A gateway dying and restarting in a loop could never reach the consecutive unhealthy heartbeats that trigger `claw-retry`, so the claw was never replaced — it sat there until the reaper's 10-minute offline grace killed it. The logs show the signature: three "gateway unhealthy" first-occurrence lines with no "gateway recovered" between them.

Move the counter to a server-level map keyed by claw ID, mirroring `gatewayRestartCounts`, which already exists for exactly this. A genuine healthy heartbeat still resets it; only reconnects no longer do. Escalation now also honours the configurable `gateway_unhealthy_checks` instead of a hardcoded 12, and retries every N checks rather than only on the first crossing — `escalateClawHealthFailure` declines while a claw is not yet connected, and with a persistent counter one declined attempt would otherwise be the last one a claw ever gets.

## 3. The post-mortem evidence was destroyed with the sandbox

The gateway writes to `~/.openclaw/gateway.log` inside the sandbox, and the sandbox is destroyed as soon as a claw stops. That log is the only record of *why* the gateway died. Confirmed on the failed claw: the Daytona API returns 404 and the log is gone, so whether the process was OOM-killed or hung is now unanswerable.

Tail the log to the hub's diagnostics directory before terminating, best effort and time-boxed so a missing or unreachable sandbox never delays or fails shutdown. The file may contain tokens, so it is written `0600` and only its path and byte count are logged — never its contents.

## Verification

- `go build ./...` and `go vet ./pkg/hub/... ./pkg/provider/...` clean.
- `go test ./pkg/hub/... ./pkg/provider/...` — only three failures, all reproducing identically at merge-base `4b219d88` in a separate worktree (they hit the live GitHub API from a sandbox).
- New tests: the unhealthy counter survives a simulated bridge reconnect and still resets on a healthy heartbeat; log capture writes a `0600` tail, honours the size cap, leaves no file on exec error, and leaves no misleading empty file when the log is missing.

## Not in this PR

- The actual cause of death: the `next_mobile` Jest suite exhausting a 4 GB sandbox. Needs either a larger snapshot or `--maxWorkers` capped in the workflow.
- The Linear board has no "Agent Error" state, so `agent-failure-feedback` fails and agent deaths stay invisible there.
- Checkpoints capture 19.7 MB across 2,454 files, including git-tracked content that bootstrap clones anyway. Filtering that changes capture behaviour and deserves its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)