### PR TITLE
fix: stop a frozen gateway from wedging claw-bridge, and capture the bridge log

### DIFF
--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -643,6 +643,8 @@ const (
 	gwRole     = "operator"
 )
 
+const gatewayReconnectTimeout = 30 * time.Second
+
 var defaultScopes = []string{
 	"operator.admin",
 	"operator.read",
@@ -1304,6 +1306,13 @@ func (gs *gatewaySession) reconnectGateway(ctx context.Context, expectedOld *web
 	return true, nil
 }
 
+func (gs *gatewaySession) reconnectGatewayWithTimeout(ctx context.Context, expectedOld *websocket.Conn, timeout time.Duration) (bool, error) {
+	reconnectCtx, cancel := context.WithTimeout(ctx, timeout)
+	reconnected, err := gs.reconnectGateway(reconnectCtx, expectedOld)
+	cancel()
+	return reconnected, err
+}
+
 // readLoop reads frames from the gateway forever, dispatching responses to
 // pending channels and agent events to the in-flight handler.
 // When the connection drops it reconnects and re-subscribes.
@@ -1343,7 +1352,8 @@ func (gs *gatewaySession) readLoop(ctx context.Context) {
 				if !gs.isCurrentConn(conn) {
 					break
 				}
-				if _, err := gs.reconnectGateway(ctx, conn); err != nil {
+				_, err := gs.reconnectGatewayWithTimeout(ctx, conn, gatewayReconnectTimeout)
+				if err != nil {
 					if !gs.isCurrentConn(conn) {
 						break
 					}

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -2261,6 +2262,41 @@ func TestReconnectGatewayReportsStaleConnectionNoop(t *testing.T) {
 	}
 	if got := gs.currentConn(); got != current {
 		t.Fatalf("current connection changed on stale reconnect: got %p, want %p", got, current)
+	}
+}
+
+func TestReconnectGatewayWithTimeoutWhenChallengeNeverArrives(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Skipf("local listener unavailable: %v", err)
+	}
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.CloseNow()
+		// Simulate a gateway whose event loop is wedged after the upgrade: it
+		// accepts WebSocket connections but never emits connect.challenge.
+		<-r.Context().Done()
+	}))
+	srv.Listener = listener
+	srv.Start()
+	defer srv.Close()
+
+	current := &websocket.Conn{}
+	gs := &gatewaySession{
+		client:  &gatewayClient{addr: strings.TrimPrefix(srv.URL, "http://")},
+		conn:    current,
+		pending: make(map[string]chan gwFrame),
+	}
+	started := time.Now()
+	_, err = gs.reconnectGatewayWithTimeout(context.Background(), current, 100*time.Millisecond)
+	if err == nil {
+		t.Fatal("reconnectGatewayWithTimeout error = nil, want timeout")
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("reconnect returned after %s, want roughly the timeout", elapsed)
 	}
 }
 

--- a/pkg/hub/gateway_logs.go
+++ b/pkg/hub/gateway_logs.go
@@ -15,6 +15,7 @@ const (
 	gatewayLogCaptureLimit   = 256 * 1024
 	gatewayLogCaptureTimeout = 20 * time.Second
 	gatewayLogCaptureCommand = "tail -c 262144 /home/daytona/.openclaw/gateway.log 2>/dev/null"
+	bridgeLogCaptureCommand  = "tail -c 262144 /home/daytona/claw-bridge.log 2>/dev/null"
 )
 
 // gatewayLogExecutor is deliberately limited to the operation needed for
@@ -53,27 +54,53 @@ func (s *Server) captureGatewayLog(clawID, provider, providerID string) {
 }
 
 func captureGatewayLogWithExecutor(ctx context.Context, executor gatewayLogExecutor, clawID, providerID, dataDir string) error {
-	ctx, cancel := context.WithTimeout(ctx, gatewayLogCaptureTimeout)
-	defer cancel()
-
-	// Pass the script as a single element: ExecWithTimeout joins cmdArgs and wraps
-	// the result in `bash -c '...'` itself, so a "bash -c" prefix here would nest a
-	// second shell that swallows the arguments. Use an absolute path rather than ~,
-	// which is unreliable in Daytona exec sessions.
-	result, err := executor.ExecWithTimeout(ctx, providerID, []string{gatewayLogCaptureCommand}, gatewayLogCaptureTimeout)
-	if err != nil {
-		return err
-	}
-	if result == nil {
-		return fmt.Errorf("empty exec result")
-	}
-	// A missing log or a dead sandbox is the normal case, not something to record:
-	// writing an empty file would make a failed capture look like a successful one.
-	if result.ExitCode != 0 || len(result.Stdout) == 0 {
-		return nil
+	var firstErr error
+	keepErr := func(err error) {
+		if firstErr == nil {
+			firstErr = err
+		}
 	}
 
-	contents := []byte(result.Stdout)
+	for _, capture := range []struct {
+		name    string
+		command string
+	}{
+		{name: "gateway", command: gatewayLogCaptureCommand},
+		{name: "bridge", command: bridgeLogCaptureCommand},
+	} {
+		if ctx.Err() != nil {
+			keepErr(ctx.Err())
+			break
+		}
+		// Each capture gets its own time box. Sharing one would let a hung tail
+		// against a half-dead sandbox starve the second file — and the bridge log
+		// is the one the NEXT-655 post-mortem proved we need most.
+		execCtx, cancel := context.WithTimeout(ctx, gatewayLogCaptureTimeout)
+		// ExecWithTimeout wraps this single script argument in `bash -c`; do not
+		// add a second shell here.
+		result, err := executor.ExecWithTimeout(execCtx, providerID, []string{capture.command}, gatewayLogCaptureTimeout)
+		cancel()
+		if err != nil {
+			// A transport failure means the hub could not reach the sandbox at all
+			// — bad credentials, a network error, a rate limit. That is worth
+			// surfacing, unlike a missing log file.
+			keepErr(fmt.Errorf("%s log: %w", capture.name, err))
+			continue
+		}
+		// A missing log or an already-dead sandbox is the normal case on teardown:
+		// stay quiet, and write nothing rather than an empty file that would read
+		// as a successful but blank post-mortem.
+		if result == nil || result.ExitCode != 0 || len(result.Stdout) == 0 {
+			continue
+		}
+		if err := writeGatewayLogCapture(dataDir, clawID, capture.name, []byte(result.Stdout)); err != nil {
+			keepErr(err)
+		}
+	}
+	return firstErr
+}
+
+func writeGatewayLogCapture(dataDir, clawID, source string, contents []byte) error {
 	if len(contents) > gatewayLogCaptureLimit {
 		contents = contents[len(contents)-gatewayLogCaptureLimit:]
 	}
@@ -82,7 +109,7 @@ func captureGatewayLogWithExecutor(ctx context.Context, executor gatewayLogExecu
 	if err := os.MkdirAll(diagnosticsDir, 0o700); err != nil {
 		return fmt.Errorf("create diagnostics directory: %w", err)
 	}
-	filename := fmt.Sprintf("%s-%s.log", filepath.Base(clawID), time.Now().UTC().Format(time.RFC3339Nano))
+	filename := fmt.Sprintf("%s-%s-%s.log", filepath.Base(clawID), time.Now().UTC().Format(time.RFC3339Nano), source)
 	path := filepath.Join(diagnosticsDir, filename)
 	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
 	if err != nil {
@@ -100,6 +127,6 @@ func captureGatewayLogWithExecutor(ctx context.Context, executor gatewayLogExecu
 	if err := os.Chmod(path, 0o600); err != nil {
 		return fmt.Errorf("secure capture file: %w", err)
 	}
-	log.Printf("[gateway-log] captured %d bytes for %s at %s", len(contents), shortID(clawID), path)
+	log.Printf("[gateway-log] captured %s log: %d bytes for %s at %s", source, len(contents), shortID(clawID), path)
 	return nil
 }

--- a/pkg/hub/gateway_logs_test.go
+++ b/pkg/hub/gateway_logs_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -13,20 +14,26 @@ import (
 
 type gatewayLogExecutorStub struct {
 	result  *types.ExecResult
+	results []*types.ExecResult
 	err     error
-	args    []string
+	args    [][]string
 	timeout time.Duration
 }
 
 func (s *gatewayLogExecutorStub) ExecWithTimeout(_ context.Context, _ string, args []string, timeout time.Duration) (*types.ExecResult, error) {
-	s.args = args
+	s.args = append(s.args, args)
 	s.timeout = timeout
+	if len(s.results) > 0 {
+		result := s.results[0]
+		s.results = s.results[1:]
+		return result, s.err
+	}
 	return s.result, s.err
 }
 
 func TestCaptureGatewayLogWritesSecureTail(t *testing.T) {
 	dataDir := t.TempDir()
-	executor := &gatewayLogExecutorStub{result: &types.ExecResult{Stdout: "gateway stopped: out of memory\n"}}
+	executor := &gatewayLogExecutorStub{results: []*types.ExecResult{{Stdout: "gateway stopped: out of memory\n"}, {Stdout: "bridge reconnect timed out\n"}}}
 	if err := captureGatewayLogWithExecutor(context.Background(), executor, "claw-123", "sandbox-123", dataDir); err != nil {
 		t.Fatalf("captureGatewayLogWithExecutor: %v", err)
 	}
@@ -34,7 +41,7 @@ func TestCaptureGatewayLogWritesSecureTail(t *testing.T) {
 	// them in `bash -c '...'`, so a prefix here nests a second shell that eats the
 	// arguments and silently tails nothing. The stub cannot catch that, so assert the
 	// shape.
-	if got, want := executor.args, []string{gatewayLogCaptureCommand}; len(got) != len(want) || got[0] != want[0] {
+	if got, want := executor.args, [][]string{{gatewayLogCaptureCommand}, {bridgeLogCaptureCommand}}; len(got) != len(want) || got[0][0] != want[0][0] || got[1][0] != want[1][0] {
 		t.Fatalf("exec args = %q, want %q", got, want)
 	}
 	if executor.timeout != gatewayLogCaptureTimeout {
@@ -42,28 +49,45 @@ func TestCaptureGatewayLogWritesSecureTail(t *testing.T) {
 	}
 
 	files, err := filepath.Glob(filepath.Join(dataDir, "diagnostics", "claw-123-*.log"))
-	if err != nil || len(files) != 1 {
-		t.Fatalf("capture files = %q, %v; want one", files, err)
+	if err != nil || len(files) != 2 {
+		t.Fatalf("capture files = %q, %v; want two", files, err)
 	}
-	contents, err := os.ReadFile(files[0])
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got, want := string(contents), "gateway stopped: out of memory\n"; got != want {
-		t.Fatalf("capture contents = %q, want %q", got, want)
-	}
-	info, err := os.Stat(files[0])
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got, want := info.Mode().Perm(), os.FileMode(0o600); got != want {
-		t.Fatalf("capture mode = %o, want %o", got, want)
+
+	// Each file must carry the content of its OWN source. Asserting only that
+	// some file contains some expected line would stay green if the two captures
+	// were swapped, and an on-call reader would blame the bridge for a gateway
+	// stall.
+	for suffix, want := range map[string]string{
+		"-gateway.log": "gateway stopped: out of memory",
+		"-bridge.log":  "bridge reconnect timed out",
+	} {
+		matches, err := filepath.Glob(filepath.Join(dataDir, "diagnostics", "claw-123-*"+suffix))
+		if err != nil || len(matches) != 1 {
+			t.Fatalf("%s files = %q, %v; want one", suffix, matches, err)
+		}
+		contents, err := os.ReadFile(matches[0])
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(contents), want) {
+			t.Fatalf("%s contents = %q, want it to contain %q", suffix, contents, want)
+		}
+		info, err := os.Stat(matches[0])
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := info.Mode().Perm(), os.FileMode(0o600); got != want {
+			t.Fatalf("%s mode = %o, want %o", suffix, got, want)
+		}
 	}
 }
 
 func TestCaptureGatewayLogExecErrorLeavesNoFile(t *testing.T) {
 	dataDir := t.TempDir()
 	executor := &gatewayLogExecutorStub{err: errors.New("sandbox not found")}
+	// A transport error must still surface: silently returning nil would make a
+	// rotated API key indistinguishable from "the sandbox had no logs", and the
+	// caller's one-line failure log would never fire.
 	if err := captureGatewayLogWithExecutor(context.Background(), executor, "claw-123", "sandbox-123", dataDir); err == nil {
 		t.Fatal("captureGatewayLogWithExecutor error = nil, want error")
 	}
@@ -73,6 +97,21 @@ func TestCaptureGatewayLogExecErrorLeavesNoFile(t *testing.T) {
 	}
 	if len(files) != 0 {
 		t.Fatalf("capture files = %q, want none", files)
+	}
+}
+
+func TestCaptureGatewayLogCapturesOtherFileWhenOneTailIsEmpty(t *testing.T) {
+	dataDir := t.TempDir()
+	executor := &gatewayLogExecutorStub{results: []*types.ExecResult{{ExitCode: 1}, {Stdout: "bridge was stuck\n"}}}
+	if err := captureGatewayLogWithExecutor(context.Background(), executor, "claw-123", "sandbox-123", dataDir); err != nil {
+		t.Fatalf("captureGatewayLogWithExecutor: %v", err)
+	}
+	files, err := filepath.Glob(filepath.Join(dataDir, "diagnostics", "*-bridge.log"))
+	if err != nil || len(files) != 1 {
+		t.Fatalf("bridge capture files = %q, %v; want one", files, err)
+	}
+	if _, err := os.Stat(strings.Replace(files[0], "-bridge.log", "-gateway.log", 1)); !os.IsNotExist(err) {
+		t.Fatalf("gateway capture exists or stat failed: %v", err)
 	}
 }
 

--- a/pkg/hub/gateway_logs_test.go
+++ b/pkg/hub/gateway_logs_test.go
@@ -110,8 +110,12 @@ func TestCaptureGatewayLogCapturesOtherFileWhenOneTailIsEmpty(t *testing.T) {
 	if err != nil || len(files) != 1 {
 		t.Fatalf("bridge capture files = %q, %v; want one", files, err)
 	}
-	if _, err := os.Stat(strings.Replace(files[0], "-bridge.log", "-gateway.log", 1)); !os.IsNotExist(err) {
-		t.Fatalf("gateway capture exists or stat failed: %v", err)
+	// Glob rather than deriving the gateway name from the bridge one: each capture
+	// stamps its own timestamp, so a derived path never exists and the assertion
+	// would pass even if a gateway file had been written.
+	gatewayFiles, err := filepath.Glob(filepath.Join(dataDir, "diagnostics", "*-gateway.log"))
+	if err != nil || len(gatewayFiles) != 0 {
+		t.Fatalf("gateway capture files = %q, %v; want none", gatewayFiles, err)
 	}
 }
 


### PR DESCRIPTION
Follow-up to #620, from the post-mortem that #620's log capture made possible. Claw NEXT-655 died three times; this fixes the mechanism that actually killed it.

## What the captured log proved

The OpenClaw gateway inside the sandbox stalls right after a tool process ends: event loop blocked **412s** with `eventLoopUtilization=1` but `cpuCoreRatio=0.071` — 7% CPU, so it is waiting, not computing — while holding the session write lock for **507798ms** against a 300000ms max. Not OOM, not CPU exhaustion, not a crash: the process never died and never restarted, and OpenClaw's own recovery aborted the stuck run at ~8.5 min.

That stall is an upstream bug (see below). What killed the claw was our side's reaction to it.

## 1. The bridge wedged itself on the frozen gateway

`readLoop` passed the long-lived bridge context to `reconnectGateway`, so an attempt had no deadline of its own. `connectToGateway` dials and then waits for the gateway's `connect.challenge` frame — which a frozen gateway never sends, though it happily accepts the WebSocket upgrade. The read blocked forever, so the `retrying in 5s` loop never reached a second iteration.

Gateway-side proof: two `ua=claw-bridge/1.0` connections sat in `phase=ws_upgrade_started` and `phase=auth_validated` from ~03:25 until the gateway unfroze at 03:32:01 and closed them.

This was an oversight, not a design choice — the other `reconnectGateway` call site already wraps it in a 30s timeout. This change gives the `readLoop` path the same budget.

Consequence in the incident: the bridge stayed alive but stuck, so the supervisor (which only reacts to process *exit*) saw nothing wrong, and the reaper killed the claw at the 10-minute offline grace — **3m50s after the gateway had already recovered**. With this fix the bridge retries within ~35s and the claw survives the stall.

## 2. The bridge log died with the sandbox

The bridge writes to `/home/daytona/claw-bridge.log`, separate from the gateway log, and it is destroyed with the sandbox. That is why the last minutes of bridge behaviour in this incident remain unproven.

Both logs are now tailed into separate `-gateway.log` / `-bridge.log` files, each with its own 256 KB cap and its own 20s budget. Separate time boxes matter: a shared one would let a hung tail against a half-dead sandbox starve the bridge capture — the one this incident proved we need most. Transport errors now surface (a rotated API key should not look identical to "no logs existed"), while a missing file or dead sandbox stays quiet, since that is normal on teardown.

## Dropped from this PR: supervisor wedge detection

A third change — a sentinel file plus a supervisor watchdog to restart a wedged-but-alive bridge — was implemented and **pulled after review found it strictly worse than the bug it targets**:

- The watchdog killed with `SIGTERM`, but the bridge installs `signal.NotifyContext(SIGINT, SIGTERM)` and shuts down *gracefully* with exit 0. The supervisor's `rc == 0` branch prints "exited cleanly" and exits. The result is no bridge **and** no supervisor, permanently.
- The sentinel was only touched on a completed hub heartbeat, so a healthy bridge that simply cannot reach the hub (a hub redeploy, a network partition) looks wedged and gets killed.
- Nothing touched the sentinel during bootstrap, so any bootstrap slower than 5 minutes was killed mid-install — and the restart path drops bootstrap mode, so the claw never recovers. The outer script explicitly tolerates 1800s.
- The wedge kill could never consume the restart budget: the watchdog only fires at >= 300s of sentinel age, which is exactly the pre-existing budget-reset condition, so a permanently wedging bridge would restart forever.

The idea is sound but the liveness signal needs to prove the bridge's *own* progress rather than hub reachability, and the kill needs `SIGKILL` escalation with an explicit wedge marker so the budget applies. That deserves its own PR rather than being rushed in behind this one.

## Upstream

The stall itself is not in this repo. Our pin is `2026.7.1-2` ([cliversion.go](pkg/cliversion/cliversion.go)), which is the current `latest` upstream — there is nothing newer to upgrade to. The failure family is known and **entirely open**: openclaw/openclaw#122233 (which reports it on our exact version), #119454, #118625, #108384. So these mitigations are the fix for as long as those stay open.

## Verification

- `go build ./...` and `go vet ./pkg/hub/... ./cmd/...` clean.
- `go test ./pkg/hub/... ./cmd/...` — only the three known failures that reproduce identically on main (they hit the live GitHub API from a sandbox).
- New test: a gateway that accepts the upgrade and then goes silent makes a reconnect attempt return an error within the timeout instead of blocking forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)