### PR TITLE
fix(bridge): bound the startup gateway handshake

### DIFF
--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -968,6 +968,12 @@ type gatewaySession struct {
 
 	connMu sync.Mutex
 	conn   *websocket.Conn
+	// sessionCancel stops the permanent read loop, and is called only when
+	// startup abandons this session. A healthy session never cancels it: its
+	// read loop is meant to live as long as the parent context. Holding the
+	// func here rather than in a local also keeps go vet's lostcancel check
+	// satisfied, since the success path deliberately does not call it.
+	sessionCancel context.CancelFunc
 
 	reconnectMu sync.Mutex
 
@@ -1001,25 +1007,40 @@ type gatewayUsage struct {
 // newGatewaySession creates a gatewaySession, establishes the gateway
 // connection, resolves (or creates) the persistent session, subscribes,
 // and starts the background read loop.
-func newGatewaySession(ctx context.Context, client *gatewayClient) (*gatewaySession, error) {
+func newGatewaySession(ctx context.Context, client *gatewayClient, attemptTimeout time.Duration) (*gatewaySession, error) {
 	gs := &gatewaySession{
 		client:  client,
 		pending: make(map[string]chan gwFrame),
 	}
 
-	if err := gs.connect(ctx); err != nil {
+	// The startup handshake must be bounded, but the read loop is permanent.
+	// Keep their contexts separate: readLoop exits permanently when its context
+	// is cancelled, while connect and initSession must time out so startup can
+	// retry a wedged gateway.
+	attemptCtx, cancelAttempt := context.WithTimeout(ctx, attemptTimeout)
+	defer cancelAttempt()
+	sessionCtx, cancelSession := context.WithCancel(ctx)
+	gs.sessionCancel = cancelSession
+
+	if err := gs.connect(attemptCtx); err != nil {
+		gs.sessionCancel()
 		return nil, err
 	}
 
 	// Start read loop BEFORE initSession — sendReq depends on the read loop
 	// to dispatch responses; without it sendReq blocks forever.
-	go gs.readLoop(ctx)
+	go gs.readLoop(sessionCtx)
 
-	if err := gs.initSession(ctx); err != nil {
+	if err := gs.initSession(attemptCtx); err != nil {
+		// Stop the discarded session before closing its connection. Otherwise its
+		// read loop can treat the close as a gateway outage and reconnect itself.
+		gs.sessionCancel()
 		gs.conn.CloseNow()
 		return nil, err
 	}
 
+	// Do not cancel sessionCtx here: it intentionally lives with the parent
+	// context for the lifetime of a healthy gateway session.
 	return gs, nil
 }
 
@@ -4052,7 +4073,7 @@ func main() {
 				continue
 			}
 		}
-		gwSession, err = newGatewaySession(ctx, gwClient)
+		gwSession, err = newGatewaySession(ctx, gwClient, gatewayReconnectTimeout)
 		if err != nil {
 			log.Printf("[bridge] failed to init gateway session: %v — retrying in 5s", err)
 			select {

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -2300,6 +2300,135 @@ func TestReconnectGatewayWithTimeoutWhenChallengeNeverArrives(t *testing.T) {
 	}
 }
 
+func TestNewGatewaySessionTimesOutWhenChallengeNeverArrives(t *testing.T) {
+	connectionClosed := make(chan struct{})
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Skipf("local listener unavailable: %v", err)
+	}
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.CloseNow()
+		// Accept the upgrade but never emit connect.challenge, as a frozen
+		// gateway can after validating the WebSocket connection.
+		//
+		// Once Accept hijacks the connection, net/http no longer owns it, so
+		// r.Context() never observes the peer closing the socket. Block on a
+		// read instead: it only returns once the client tears down its side.
+		_, _, _ = conn.Read(context.Background())
+		close(connectionClosed)
+	}))
+	srv.Listener = listener
+	srv.Start()
+	defer srv.Close()
+
+	const attemptTimeout = 100 * time.Millisecond
+	started := time.Now()
+	_, err = newGatewaySession(context.Background(), &gatewayClient{
+		addr: strings.TrimPrefix(srv.URL, "http://"),
+	}, attemptTimeout)
+	if err == nil {
+		t.Fatal("newGatewaySession error = nil, want timeout")
+	}
+	if elapsed := time.Since(started); elapsed < attemptTimeout/2 || elapsed > time.Second {
+		t.Fatalf("newGatewaySession returned after %s, want roughly %s", elapsed, attemptTimeout)
+	}
+	select {
+	case <-connectionClosed:
+		// The attempt closed its connection; no read loop remains against it.
+	case <-time.After(time.Second):
+		t.Fatal("frozen gateway connection remained open after failed startup attempt")
+	}
+}
+
+func TestNewGatewaySessionReadLoopOutlivesAttemptTimeout(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	requestReceived := make(chan struct{})
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Skipf("local listener unavailable: %v", err)
+	}
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Errorf("accept websocket: %v", err)
+			return
+		}
+		defer conn.CloseNow()
+		ctx := r.Context()
+
+		challengePayload, _ := json.Marshal(map[string]string{"nonce": "nonce"})
+		if err := wsjson.Write(ctx, conn, gwFrame{Type: "event", Event: "connect.challenge", Payload: challengePayload}); err != nil {
+			t.Errorf("write challenge: %v", err)
+			return
+		}
+		for {
+			var req gwFrame
+			if err := wsjson.Read(ctx, conn, &req); err != nil {
+				return
+			}
+			switch req.Method {
+			case "connect", "sessions.subscribe", "sessions.get":
+				if err := wsjson.Write(ctx, conn, gwFrame{Type: "res", ID: req.ID, OK: true}); err != nil {
+					t.Errorf("write %s response: %v", req.Method, err)
+					return
+				}
+				if req.Method == "sessions.get" {
+					close(requestReceived)
+				}
+			case "sessions.create":
+				payload, _ := json.Marshal(map[string]string{"key": "session-1"})
+				if err := wsjson.Write(ctx, conn, gwFrame{Type: "res", ID: req.ID, OK: true, Payload: payload}); err != nil {
+					t.Errorf("write sessions.create response: %v", err)
+					return
+				}
+			case "sessions.describe":
+				// setReady() kicks off an async context-usage poll; answer it so
+				// it doesn't trip the "unexpected request method" default below.
+				if err := wsjson.Write(ctx, conn, gwFrame{Type: "res", ID: req.ID, OK: true}); err != nil {
+					t.Errorf("write sessions.describe response: %v", err)
+					return
+				}
+			default:
+				t.Errorf("unexpected request method %q", req.Method)
+				return
+			}
+		}
+	}))
+	srv.Listener = listener
+	srv.Start()
+	defer srv.Close()
+
+	const attemptTimeout = 100 * time.Millisecond
+	parentCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	client := &gatewayClient{
+		addr:   strings.TrimPrefix(srv.URL, "http://"),
+		token:  "token",
+		device: &deviceIdentity{DeviceID: "device-1", PublicKeyPem: testPEM("PUBLIC KEY"), PrivateKeyPem: testPEM("PRIVATE KEY")},
+	}
+	gs, err := newGatewaySession(parentCtx, client, attemptTimeout)
+	if err != nil {
+		t.Fatalf("newGatewaySession: %v", err)
+	}
+	defer gs.currentConn().CloseNow()
+
+	time.Sleep(2 * attemptTimeout)
+	requestCtx, requestCancel := context.WithTimeout(parentCtx, time.Second)
+	defer requestCancel()
+	if _, err := gs.sendReq(requestCtx, "sessions.get", map[string]string{"key": "session-1"}); err != nil {
+		t.Fatalf("request after attempt timeout: %v", err)
+	}
+	select {
+	case <-requestReceived:
+	case <-time.After(time.Second):
+		t.Fatal("read loop did not dispatch response after attempt timeout")
+	}
+}
+
 func TestGatewaySessionRetriesSendAfterClosedGatewayWrite(t *testing.T) {
 	var connections atomic.Int32
 	var acceptedSends atomic.Int32


### PR DESCRIPTION
Follow-up to #620 and #623, closing the last unbounded call in the path that killed claw NEXT-655.

## The gap

`newGatewaySession` ran `connect` and `initSession` on the process-lifetime context, so the startup handshake had no deadline. `connectToGateway` dials and then waits for the gateway's `connect.challenge` frame. A frozen OpenClaw gateway accepts the WebSocket upgrade and can even validate auth while never sending that frame, so the read blocked forever — and the caller's retry-in-5s loop never got to iterate. The bridge then never registered with the hub at all.

NEXT-655's captured gateway log showed exactly this shape: claw-bridge connections sitting in `phase=ws_upgrade_started` and `phase=auth_validated` for seven minutes, closed only when the gateway thawed. #623 bounded the `readLoop` reconnect path; this startup path was missed.

## Why the one-line fix would have been worse than the bug

Wrapping the call in `context.WithTimeout(ctx, 30*time.Second)` looks right and is a fleet-wide outage. The same context is handed to the session's **permanent** read loop, which exits for good when it errors. Every healthy session would go deaf 30 seconds after startup: the read loop returns, `sendReq` responses are never dispatched, and every later turn hangs until its own deadline.

The change splits the two lifetimes instead:

- an **attempt** context — `WithTimeout`, scoping only `connect` and `initSession`;
- a **session** context — `WithCancel` off the parent, no timeout, which is what `readLoop` receives and which is never cancelled on the success path.

Cancelling the session context on the failure paths also fixes a pre-existing leak: an abandoned read loop used to treat its closed connection as an outage, fall into its reconnect loop, and revive a session the caller had already discarded — potentially calling `setReady` on an object nobody references.

`gs.sessionCancel` holds the cancel func rather than a local. That is load-bearing rather than dead code: `go vet`'s `lostcancel` check fails otherwise, because the success path deliberately never calls it.

## Verification

- `go build ./...`, `go vet ./cmd/...`, `go test ./cmd/... -race` all clean.
- Two new tests: a gateway that completes the upgrade then goes silent makes startup fail at the timeout instead of blocking; and a **successfully** established session still serves a request after the attempt timeout has elapsed.
- The second test was mutation-checked: replacing `readLoop(sessionCtx)` with `readLoop(attemptCtx)` makes it fail with `use of closed network connection` on the post-timeout request — the exact regression it exists to catch. It is not vacuous.

## Scope

`cmd/claw-bridge` only. No hub, supervisor, or reaper changes.

This is the surviving half of a larger plan. The other half — registering with the hub before the gateway is ready, so a claw stays visible during a gateway outage — was rejected in review for reasons worth recording: the `starting` → `connected` promotion it relied on is gated on `bootstrap_ok=1`, which docker and local claws never set (they would die at the 30-minute provisioning timeout), and the bridge-side message queue is the wrong place to hold pre-readiness turns since it only replays on hub reconnect. It is being redesigned around hub-side queueing gated on `cc.gatewayReady`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)