### PR TITLE
fix(daytona): create empty files through the shell on restore

### DIFF
--- a/pkg/provider/daytona/daytona.go
+++ b/pkg/provider/daytona/daytona.go
@@ -163,6 +163,14 @@ func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
 }
 
+// truncateFileCommand creates or empties a file. It is returned as a single
+// script string because ExecWithTimeout joins cmdArgs and wraps the result in
+// `bash -c` itself — adding a "bash -c" prefix here would nest a second shell
+// that swallows the arguments.
+func truncateFileCommand(absPath string) string {
+	return ": > " + shellQuote(absPath)
+}
+
 // Status checks current sandbox state
 func (p *Provider) Status(ctx context.Context, instanceID string) (types.InstanceStatus, error) {
 	sandbox, err := p.client.Get(ctx, instanceID)
@@ -224,6 +232,22 @@ func (p *Provider) WriteFile(ctx context.Context, instanceID, remotePath string,
 		if err := sandbox.FileSystem.CreateFolder(ctx, dir); err != nil {
 			return fmt.Errorf("daytona writefile %s: %w", remotePath, err)
 		}
+	}
+
+	// Daytona's upload rejects empty content with "bad request: http: no such
+	// file", so an empty file has to be created through the shell instead. The
+	// payload is fixed-size, so this cannot hit the argv limit that made the
+	// old base64 upload path fail. Create() sidesteps the same API limitation by
+	// skipping empty template files outright.
+	if len(content) == 0 {
+		result, err := p.ExecWithTimeout(ctx, instanceID, []string{truncateFileCommand(absPath)}, 30*time.Second)
+		if err != nil {
+			return fmt.Errorf("daytona writefile %s (empty): %w", remotePath, err)
+		}
+		if result.ExitCode != 0 {
+			return fmt.Errorf("daytona writefile %s (empty) failed: %s", remotePath, result.Stdout)
+		}
+		return nil
 	}
 
 	if err := sandbox.FileSystem.UploadFile(ctx, content, absPath); err != nil {

--- a/pkg/provider/daytona/daytona_test.go
+++ b/pkg/provider/daytona/daytona_test.go
@@ -124,3 +124,19 @@ func TestIsDaytonaNotFound(t *testing.T) {
 		t.Fatal("non-404 Daytona error should not be recognized as not found")
 	}
 }
+
+func TestTruncateFileCommandQuotesPath(t *testing.T) {
+	// Empty content cannot go through the upload API, which rejects it with
+	// "bad request: http: no such file" — a 0-byte .gitkeep or SQLite -wal in a
+	// checkpoint used to fail the entire restore because of it.
+	got := truncateFileCommand("/home/daytona/.openclaw/workspace/$SECRET/`touch /tmp/pwn`/it's.txt")
+	want := `: > '/home/daytona/.openclaw/workspace/$SECRET/` + "`touch /tmp/pwn`" + `/it'"'"'s.txt'`
+	if got != want {
+		t.Fatalf("truncateFileCommand = %q, want %q", got, want)
+	}
+	// A "bash -c" prefix here would nest a second shell inside the one
+	// ExecWithTimeout adds, and the path would never reach tail/truncate.
+	if strings.HasPrefix(got, "bash ") || strings.Contains(got, `> "`) {
+		t.Fatalf("expected a bare single-quoted redirect, got %q", got)
+	}
+}


### PR DESCRIPTION
Regression from #620, hit in production on claw NEXT-656 about an hour after that release was deployed.

## What broke

`Provider.WriteFile` sends every file through Daytona's upload API, which rejects empty content:

```
restore checkpoint: restore .openclaw/agents/main/agent/openclaw-agent.sqlite-wal:
daytona writefile /home/daytona/.openclaw/agents/main/agent/openclaw-agent.sqlite-wal:
Validation error: bad request: http: no such file
```

Checkpoint restore aborts on the first 0-byte file it meets, and 0-byte files are routine — `.gitkeep` markers and SQLite `-wal` files. The manifest that broke NEXT-656 contains **ten** of them.

So #620 removed a deterministic restore failure on files larger than ~96 KB (the `MAX_ARG_STRLEN` case) and introduced a deterministic one on files of zero bytes. Both abort the whole restore, so bootstrap retries cannot recover from either.

The clue was already in the file: `Create()` skips empty template files with the comment *"Skip empty files (like .gitkeep)"* — it sidesteps the same API limitation. `WriteFile` did not replicate that guard, and neither the review nor I noticed.

## The fix

Create empty files with a shell redirect (`: > path`) instead of the upload API. The payload is fixed-size, so this cannot reach the argv limit that made the old base64 path fail — the property that motivated #620 is preserved.

The command is passed as a **single** element, because `ExecWithTimeout` joins `cmdArgs` and wraps the result in `bash -c` itself; a `bash -c` prefix here would nest a second shell and swallow the path.

Skipping empty files, as `Create` does, was the other option. Creating them keeps the restore faithful: an empty file the agent deliberately made still exists afterwards.

## Production impact

Claw NEXT-656 (`10959190`) was correctly escalated by the gateway-health fix from #620 — the unhealthy counter survived a bridge reconnect, reached 12 consecutive checks, and triggered `claw-retry` with a checkpoint, which is exactly the recovery path that never fired for NEXT-655. The replacement then failed to restore that checkpoint on all three attempts because of this bug, burning the retry budget.

## Verification

- `go build ./...`, `go vet ./pkg/provider/...`, `go test ./pkg/provider/daytona/` clean.
- New test covers the command shape and shell quoting, including a path containing `$SECRET`, backticks and a quote, and asserts there is no nested `bash -c`.

The package has no fake-client harness, so the API call itself is not covered by a test — only the part with logic. Worth noting rather than papering over: the empty-content case is exactly the kind of thing a unit test here would not have caught either way, since the rejection comes from the remote API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)