### PR TITLE
feat(hub): emit start notices for workflow run/dependency_updates/judge actions

### DIFF
--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -923,6 +923,11 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 	// the claw on merge/close while the workflow is still blocked).
 	var runStdoutForPRScan string
 	if strings.TrimSpace(stage.OnEnter.Run.Command) != "" {
+		startMsg := fmt.Sprintf("[hub] ▶ Running workflow command for stage %q", stage.ID)
+		if stage.OnEnter.Run.Timeout != "" {
+			startMsg += fmt.Sprintf(" (timeout %s)", stage.OnEnter.Run.Timeout)
+		}
+		s.publishHubNotice(clawID, startMsg)
 		log.Printf("[pipeline] running workflow command for claw %s stage %q: %s", clawID[:8], stage.ID, stage.OnEnter.Run.Command)
 		result, err := s.executePipelineRunAction(clawID, stage.OnEnter.Run)
 		// Persist output so later stages can reference it via {{ .Outputs.<name>.<key> }}
@@ -963,6 +968,11 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 
 	if dependencyUpdatesConfigured(stage.OnEnter.DependencyUpdates) {
 		outputName := dependencyUpdatesOutputName(stage.OnEnter.DependencyUpdates)
+		startMsg := fmt.Sprintf("[hub] ▶ Running dependency updates for stage %q", stage.ID)
+		if len(stage.OnEnter.DependencyUpdates.Ecosystems) > 0 {
+			startMsg += fmt.Sprintf(" (ecosystems: %s)", strings.Join(stage.OnEnter.DependencyUpdates.Ecosystems, ", "))
+		}
+		s.publishHubNotice(clawID, startMsg)
 		log.Printf("[pipeline] running dependency updates for claw %s stage %q output %q", clawID[:8], stage.ID, outputName)
 		result, err := s.executeDependencyUpdatesAction(clawID, stage.ID, stage.OnEnter.DependencyUpdates)
 		if err != nil || (result != nil && result.ExitCode != 0) {
@@ -1003,6 +1013,7 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 
 	// Execute judge action if configured
 	if stage.OnEnter.Judge.Instructions != "" {
+		s.publishHubNotice(clawID, fmt.Sprintf("[hub] ▶ Running judge for stage %q", stage.ID))
 		log.Printf("[pipeline] running judge for claw %s stage %q", clawID[:8], stage.ID)
 		judgeResult, err := s.executeJudgeAction(clawID, stage.OnEnter.Judge, ctx)
 		if err != nil {

--- a/pkg/hub/pipeline_runner_test.go
+++ b/pkg/hub/pipeline_runner_test.go
@@ -1483,9 +1483,9 @@ func TestRunOnEnterJudgeBlocksOnFail(t *testing.T) {
 	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=?`, clawID).Scan(&messageCount); err != nil {
 		t.Fatalf("count messages: %v", err)
 	}
-	// Should have 1 error message from the judge failure, not the inject message
-	if messageCount != 1 {
-		t.Fatalf("expected 1 message (judge error), got %d", messageCount)
+	// Should have 2 messages: judge start notice + judge error. Inject should NOT appear.
+	if messageCount != 2 {
+		t.Fatalf("expected 2 messages (judge start notice + judge error), got %d", messageCount)
 	}
 }
 
@@ -1522,9 +1522,9 @@ func TestRunOnEnterJudgeContinueOnError(t *testing.T) {
 	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=?`, clawID).Scan(&messageCount); err != nil {
 		t.Fatalf("count messages: %v", err)
 	}
-	// Should have 2 messages: judge error + inject message (because continue_on_error=true)
-	if messageCount != 2 {
-		t.Fatalf("expected 2 messages (judge error + inject), got %d", messageCount)
+	// Should have 3 messages: judge start notice + judge error + inject message (because continue_on_error=true)
+	if messageCount != 3 {
+		t.Fatalf("expected 3 messages (judge start notice + judge error + inject), got %d", messageCount)
 	}
 }
 
@@ -1566,8 +1566,8 @@ func TestRunOnEnterRunCommandLogsAndInjectsOnSuccess(t *testing.T) {
 	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=?`, clawID).Scan(&messageCount); err != nil {
 		t.Fatalf("count messages: %v", err)
 	}
-	if messageCount != 2 {
-		t.Fatalf("expected 2 messages (run completion + inject), got %d", messageCount)
+	if messageCount != 3 {
+		t.Fatalf("expected 3 messages (run start notice + run completion + inject), got %d", messageCount)
 	}
 }
 
@@ -1609,9 +1609,9 @@ func TestRunOnEnterDependencyUpdatesStopsOnError(t *testing.T) {
 	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=?`, clawID).Scan(&messageCount); err != nil {
 		t.Fatalf("count messages: %v", err)
 	}
-	// Should have 1 error message; inject message should NOT appear because the stage aborted.
-	if messageCount != 1 {
-		t.Fatalf("expected 1 message (deps error), got %d", messageCount)
+	// Should have 2 messages: deps start notice + deps error. Inject message should NOT appear because the stage aborted.
+	if messageCount != 2 {
+		t.Fatalf("expected 2 messages (deps start notice + deps error), got %d", messageCount)
 	}
 }
 
@@ -1654,9 +1654,9 @@ func TestRunOnEnterDependencyUpdatesContinueOnError(t *testing.T) {
 	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=?`, clawID).Scan(&messageCount); err != nil {
 		t.Fatalf("count messages: %v", err)
 	}
-	// Should have 2 messages: deps warning + inject message (because continue_on_error=true).
-	if messageCount != 2 {
-		t.Fatalf("expected 2 messages (deps warning + inject), got %d", messageCount)
+	// Should have 3 messages: deps start notice + deps warning + inject message (because continue_on_error=true).
+	if messageCount != 3 {
+		t.Fatalf("expected 3 messages (deps start notice + deps warning + inject), got %d", messageCount)
 	}
 }
 
@@ -1698,8 +1698,8 @@ func TestRunOnEnterDependencyUpdatesLogsAndInjectsOnSuccess(t *testing.T) {
 	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=?`, clawID).Scan(&messageCount); err != nil {
 		t.Fatalf("count messages: %v", err)
 	}
-	if messageCount != 2 {
-		t.Fatalf("expected 2 messages (deps summary + inject), got %d", messageCount)
+	if messageCount != 3 {
+		t.Fatalf("expected 3 messages (deps start notice + deps summary + inject), got %d", messageCount)
 	}
 }
 


### PR DESCRIPTION
Closes #627

Adds dashboard-visible [hub] ▶ start notices before long-running on_enter actions so the chat UI shows a clear start → finish timeline for workflow steps.

Notices added for:
- run: '[hub] ▶ Running workflow command for stage "..." (timeout ...)'
- dependency_updates: '[hub] ▶ Running dependency updates for stage "..." (ecosystems: ...)'
- judge: '[hub] ▶ Running judge for stage "..."'

Uses publishHubNotice so the notices are visible in the transcript without queuing an agent turn. Updates the affected message-count assertions in pipeline_runner_test.go.

All tests pass: go test ./...