### PR TITLE
feat(release): publish Linux binaries in the Homebrew formula

### DIFF
--- a/.depot/workflows/release.yaml
+++ b/.depot/workflows/release.yaml
@@ -128,8 +128,30 @@ jobs:
             COMMIT_MSG="elasticclaw ${VERSION}"
           fi
 
-          SHA_ARM64=$(curl -fsSL "https://github.com/elasticclaw/elasticclaw/releases/download/${VERSION}/elasticclaw-darwin-arm64" | sha256sum | awk '{print $1}')
-          SHA_AMD64=$(curl -fsSL "https://github.com/elasticclaw/elasticclaw/releases/download/${VERSION}/elasticclaw-darwin-amd64" | sha256sum | awk '{print $1}')
+          # Read the checksums from the release asset instead of re-hashing each
+          # binary. The binaries embed the web UI, so they are large. One small
+          # request replaces four big downloads. The release job writes this file
+          # with "sha256sum *", so field 2 is the bare asset name.
+          CHECKSUMS=$(curl -fsSL "https://github.com/elasticclaw/elasticclaw/releases/download/${VERSION}/checksums.txt")
+          sha_for() {
+            printf '%s\n' "$CHECKSUMS" | awk -v name="$1" '$2 == name { print $1 }'
+          }
+
+          SHA_DARWIN_ARM64=$(sha_for elasticclaw-darwin-arm64)
+          SHA_DARWIN_AMD64=$(sha_for elasticclaw-darwin-amd64)
+          SHA_LINUX_ARM64=$(sha_for elasticclaw-linux-arm64)
+          SHA_LINUX_AMD64=$(sha_for elasticclaw-linux-amd64)
+
+          # A renamed or absent asset makes sha_for print nothing, and
+          # "set -euo pipefail" does not fail on an empty awk result. The tap has
+          # no CI, so an empty sha256 would reach users and break every
+          # "brew install". Fail here instead.
+          for var in SHA_DARWIN_ARM64 SHA_DARWIN_AMD64 SHA_LINUX_ARM64 SHA_LINUX_AMD64; do
+            if [[ ! "${!var}" =~ ^[0-9a-f]{64}$ ]]; then
+              echo "Invalid checksum for ${var}: '${!var}'" >&2
+              exit 1
+            fi
+          done
 
           git clone "https://x-access-token:${TAP_TOKEN}@github.com/elasticclaw/homebrew-elasticclaw.git" tap
           cd tap
@@ -149,17 +171,29 @@ jobs:
             on_macos do
               on_arm do
                 url "https://github.com/elasticclaw/elasticclaw/releases/download/#{version}/elasticclaw-darwin-arm64"
-                sha256 "${SHA_ARM64}"
+                sha256 "${SHA_DARWIN_ARM64}"
               end
               on_intel do
                 url "https://github.com/elasticclaw/elasticclaw/releases/download/#{version}/elasticclaw-darwin-amd64"
-                sha256 "${SHA_AMD64}"
+                sha256 "${SHA_DARWIN_AMD64}"
+              end
+            end
+
+            on_linux do
+              on_arm do
+                url "https://github.com/elasticclaw/elasticclaw/releases/download/#{version}/elasticclaw-linux-arm64"
+                sha256 "${SHA_LINUX_ARM64}"
+              end
+              on_intel do
+                url "https://github.com/elasticclaw/elasticclaw/releases/download/#{version}/elasticclaw-linux-amd64"
+                sha256 "${SHA_LINUX_AMD64}"
               end
             end
 
             def install
-              bin_name = Hardware::CPU.arm? ? "elasticclaw-darwin-arm64" : "elasticclaw-darwin-amd64"
-              bin.install bin_name => "${INSTALLED_BINARY}"
+              os = OS.mac? ? "darwin" : "linux"
+              arch = Hardware::CPU.arm? ? "arm64" : "amd64"
+              bin.install "elasticclaw-#{os}-#{arch}" => "${INSTALLED_BINARY}"
             end
 
             test do


### PR DESCRIPTION
## Problem

The `release` job already cross-compiles and uploads `elasticclaw-linux-amd64` and
`elasticclaw-linux-arm64`. The `update-homebrew` job did not use them. It generated a
formula with an `on_macos` block only, and an `install` method that assumed `darwin`.

Linux users therefore had release assets but no `brew install` path.

## Changes

**Add an `on_linux` block** with `on_arm` and `on_intel`, which mirrors the existing
`on_macos` block.

**Select the asset from the platform.** The `install` method read
`Hardware::CPU.arm?` only and hardcoded `darwin`. It now reads `OS.mac?` too:

```ruby
os = OS.mac? ? "darwin" : "linux"
arch = Hardware::CPU.arm? ? "arm64" : "amd64"
bin.install "elasticclaw-#{os}-#{arch}" => "${INSTALLED_BINARY}"
```

**Read the checksums from `checksums.txt`.** The job downloaded two binaries and piped
each through `sha256sum`. Linux needs two more. The binaries embed the web UI, so each
download is large. One small request now replaces four big ones. The `release` job
writes this asset in the same workflow run, and `needs: release` makes it present.

**Add a checksum guard.** `sha_for` prints nothing if an asset is absent or renamed, and
`set -euo pipefail` does not fail on an empty `awk` result. The tap repo has no CI, so an
empty `sha256` would reach users and break every `brew install`. The job now checks all
four values against `^[0-9a-f]{64}$` and fails before it clones the tap.

The two existing variables gain platform names. `SHA_ARM64` becomes `SHA_DARWIN_ARM64`,
and `SHA_AMD64` becomes `SHA_DARWIN_AMD64`.

## Prerelease formula

The same template generates `elasticclaw-beta.rb` for prerelease tags, with class
`ElasticclawBeta` and installed binary `elasticclaw-beta`. The `install` and `test`
blocks keep the `${INSTALLED_BINARY}` variable, so both formulas stay correct.

## Verification

`test.yaml` does not exercise `release.yaml`, so CI cannot catch a fault here. I verified
by hand instead. The harness parses this YAML file, extracts the `run` script, and
executes it with the network call and the tap clone stubbed.

- Both formulas generate, for tag `2026.8.10` and tag `2026.8.10-rc1`.
- The only differences between the two outputs are the class name, the version, and the
  two binary names. `#{version}` survives the shell in both.
- `ruby -c` reports `Syntax OK` for both.
- All four checksums match the live `2026.8.10` `checksums.txt` byte for byte.
- Against a stub Homebrew DSL, all four platforms resolve to the matching url, `sha256`,
  and installed name. This ran for both the stable and the beta formula.
- With `elasticclaw-linux-arm64` removed from `checksums.txt`, the guard exits 1 with
  `Invalid checksum for SHA_LINUX_ARM64: ''`, before the tap clone.

`brew audit --strict` could not run. It fails at startup on this machine with a `json`
gem fault inside Homebrew, before it loads any formula.

## Effect on the tap

`Formula/elasticclaw.rb` in `elasticclaw/homebrew-elasticclaw` is a build artifact. This
job overwrites it in full on every release tag.

This change gives Linux support at the **next** stable tag. The tap keeps the macOS-only
formula for 2026.8.10 until then.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
