### PR TITLE
feat(web): adopt the Modernist design system across the web UI

### DIFF
--- a/docs/design/modernist/README.md
+++ b/docs/design/modernist/README.md
@@ -1,0 +1,18 @@
+# Modernist design system — reference specs
+
+Imported from the Claude Design project "Modernist" (`templates/elasticclaw/`).
+These files are the source of truth for the web UI restyle. They are static
+mockups — the relative `<link>` paths inside the HTML files are not meant to
+resolve here.
+
+- `styles.css` — design-system tokens + component classes (the whole system).
+- `theme.json` — the compact seed the tokens were generated from. To replicate
+  a future design system: regenerate/replace `styles.css` from a new theme and
+  re-tune only the "Modernist tokens" layer in `web/app/globals.css`.
+- `app.css` — ElasticClaw layout scaffolding (layout only; colors/type/radius
+  all come from the tokens). Adds the 3 status colors (`--status-ok/warn/bad`).
+- `login.html`, `setup.html`, `board.html`, `conversation.html`,
+  `analytics.html`, `settings.html` — the six target screens.
+
+The app shell stays dark-only (`data-theme="dark"` equivalent), matching the
+mockups; the light palette ships in the tokens but is not user-switchable.

--- a/docs/design/modernist/analytics.html
+++ b/docs/design/modernist/analytics.html
@@ -1,0 +1,314 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>ElasticClaw — Analytics</title>
+<link rel="stylesheet" href="../../styles.css" />
+<link rel="stylesheet" href="app.css" />
+<style>
+.ic{width:16px;height:16px;display:block;fill:none;stroke:currentColor;stroke-width:2;stroke-linecap:round;stroke-linejoin:round}
+.ic-sm{width:14px;height:14px}
+/* One semantic scale for every chart: outcome series keep their meaning,
+   money series read as one accent ramp so cost never looks like an outcome. */
+.wrap{--c-clean:var(--status-ok);--c-human:var(--color-neutral-500);--c-warn:var(--status-warn);--c-fail:var(--color-accent);--c-data:oklch(0.66 0.12 250);--c-1:var(--c-data);--c-2:oklch(0.77 0.085 245);--c-3:oklch(0.52 0.11 258);--c-4:var(--color-neutral-600)}
+.wrap{max-width:1400px;margin:0 auto;padding:var(--space-6) var(--space-6) var(--space-8);display:grid;grid-template-columns:minmax(0,1fr);gap:var(--space-6);container-type:inline-size}
+.wrap > *{min-width:0}
+
+/* — sticky header: title and the filters that scope everything below — */
+.page-head{position:sticky;top:0;z-index:5;background:var(--color-bg);border-bottom:2px solid var(--color-divider);padding:var(--space-4) var(--space-6) var(--space-3)}
+.head-inner{max-width:1400px;margin:0 auto;display:grid;gap:var(--space-3)}
+.head-top{display:flex;align-items:baseline;gap:var(--space-3);flex-wrap:wrap}
+.head-top h2{margin:0}
+.period{margin-left:auto}
+.filters{display:flex;flex-wrap:wrap;align-items:center;gap:var(--space-2)}
+.filters .sep{width:1px;align-self:stretch;background:var(--color-divider);margin:0 var(--space-1)}
+.sel{min-height:32px;padding:4px 10px;font:inherit;font-size:13px;color:var(--color-text);background:var(--color-surface);border:1px solid var(--color-divider);border-radius:var(--radius-md)}
+.sel:hover{border-color:color-mix(in srgb,var(--color-text) 45%,transparent)}
+.applied{display:inline-flex;align-items:center;gap:6px;padding:3px 10px;border-radius:var(--radius-pill);background:color-mix(in srgb,var(--color-accent) 18%,transparent);color:var(--color-accent);font-size:12px}
+
+/* KPIs — one container query scale so the tile count snaps to sane numbers
+   at every width (the sidebar makes viewport breakpoints lie). Tiles use a
+   3-row grid so labels, values and deltas align across every tile. */
+.kpis{display:grid;grid-template-columns:minmax(0,1fr);gap:var(--space-6)}
+.kpis > section{min-width:0;display:grid;gap:var(--space-2);align-content:start}
+.kpi-grid{display:grid;gap:var(--space-2);grid-template-columns:repeat(2,minmax(0,1fr))}
+@container (min-width:520px){.kpi-grid{grid-template-columns:repeat(3,minmax(0,1fr))}}
+@container (min-width:820px){.kpi-grid[data-cols="6"]{grid-template-columns:repeat(6,minmax(0,1fr))}}
+@container (min-width:1120px){.kpis{grid-template-columns:2fr 1fr}}
+.kpi{display:grid;grid-template-rows:auto 1fr auto;gap:6px;min-width:0;padding:var(--space-3);border:1px solid var(--color-divider);border-radius:var(--radius-lg);background:var(--color-surface)}
+.kpi .lbl{margin:0;font-size:11px;line-height:1.35;text-wrap:pretty;color:color-mix(in srgb,var(--color-text) 62%,transparent)}
+.kpi .val{margin:auto 0 0;font-family:var(--font-heading);font-weight:var(--font-heading-weight);font-size:23px;line-height:1;letter-spacing:-0.02em}
+.kpi .delta{margin:0;font-size:11px;font-weight:600;min-height:15px;display:flex;align-items:center;gap:4px;white-space:nowrap}
+.kpi .delta em{font-style:normal;font-weight:400;color:color-mix(in srgb,var(--color-text) 55%,transparent)}
+.up{color:var(--status-ok)}.down{color:var(--color-accent)}
+
+/* — panels — */
+.grid2{display:grid;grid-template-columns:repeat(auto-fit,minmax(380px,1fr));gap:var(--space-6)}
+.grid2 > .panel{min-width:0}
+.panel{padding:var(--space-4) var(--space-4) var(--space-3)}
+.panel > header{display:grid;gap:2px;margin-bottom:var(--space-3)}
+.panel > header h3{margin:0;font-size:15px}
+.panel > header p{margin:0;font-size:12px;color:color-mix(in srgb,var(--color-text) 58%,transparent)}
+
+/* — charts — */
+.plot{position:relative;padding-left:34px}
+.plot .ymax,.plot .ymid,.plot .yzero{position:absolute;left:0;font-family:var(--font-mono);font-size:10px;color:color-mix(in srgb,var(--color-text) 45%,transparent)}
+.plot .ymax{top:-5px}.plot .ymid{top:calc(50% - 5px)}.plot .yzero{bottom:-5px}
+.plot::before,.plot::after{content:"";position:absolute;left:34px;right:0;height:1px;background:color-mix(in srgb,var(--color-text) 10%,transparent)}
+.plot::before{top:50%}.plot::after{bottom:0}
+.chart{display:flex;align-items:flex-end;gap:3px;height:180px}
+.chart .col{flex:1;display:flex;flex-direction:column;justify-content:flex-end;gap:1px;min-width:0}
+.chart .col i{display:block;border-radius:1px}
+.axis{display:flex;justify-content:space-between;margin:8px 0 0 34px;font-family:var(--font-mono);font-size:10px;color:color-mix(in srgb,var(--color-text) 45%,transparent)}
+.legend{display:flex;flex-wrap:wrap;gap:var(--space-3);margin-top:var(--space-3);padding-top:var(--space-2);border-top:1px solid var(--color-divider);font-size:11px;color:color-mix(in srgb,var(--color-text) 62%,transparent)}
+.legend span{display:inline-flex;align-items:center;gap:6px}
+.legend i{width:9px;height:9px;border-radius:2px;display:block}
+.funnel{display:grid;gap:var(--space-4);padding-top:var(--space-2)}
+.funnel .lab{display:flex;justify-content:space-between;align-items:baseline;font-size:13px;margin-bottom:6px}
+.funnel .lab b{font-family:var(--font-heading);font-weight:var(--font-heading-weight);font-size:16px}
+.funnel .bar{height:18px;border-radius:var(--radius-sm);background:color-mix(in srgb,var(--color-text) 9%,transparent);overflow:hidden}
+.funnel .bar i{display:block;height:100%;background:var(--c-1)}
+.funnel .drop{font-size:11px;color:color-mix(in srgb,var(--color-text) 55%,transparent)}
+.hbars{display:grid;gap:10px;padding-top:var(--space-2)}
+.hbar{display:grid;grid-template-columns:88px minmax(0,1fr) 56px;align-items:center;gap:var(--space-2);font-size:12px}
+.hbar .track{height:16px;border-radius:var(--radius-sm);background:color-mix(in srgb,var(--color-text) 8%,transparent);overflow:hidden}
+.hbar .track i{display:block;height:100%;background:var(--c-1)}
+.hbar .num{text-align:right;font-variant-numeric:tabular-nums}
+.heat{display:grid;grid-auto-flow:column;grid-auto-columns:minmax(0,1fr);grid-template-rows:repeat(7,11px);gap:3px}
+.heat i{width:auto;height:11px;border-radius:2px;display:block}
+.heat-legend{display:flex;align-items:center;justify-content:flex-end;gap:4px;margin-top:var(--space-3);font-size:11px;color:color-mix(in srgb,var(--color-text) 55%,transparent)}
+.heat-legend i{width:11px;height:11px;border-radius:2px;display:block}
+.tscroll{overflow-x:auto}
+.tscroll .table{min-width:660px}
+.tabular{font-variant-numeric:tabular-nums}
+/* Run status reads as its outcome color — the same scale the charts use. */
+.st{display:inline-flex;align-items:center;gap:6px;padding:2px 10px 2px 8px;border-radius:var(--radius-pill);border:1px solid currentColor;font-size:11px;letter-spacing:0.02em}
+.st i{width:7px;height:7px;border-radius:var(--radius-pill);background:currentColor;flex:none}
+.st span{color:var(--color-text)}
+.st-clean{color:var(--c-clean)}
+.st-human{color:var(--c-human)}
+.st-warn{color:var(--c-warn)}
+.st-fail{color:var(--c-fail);background:color-mix(in srgb,var(--color-accent) 14%,transparent)}
+.table td,.table th{white-space:nowrap}
+</style>
+</head>
+<body>
+<svg style="display:none" aria-hidden="true">
+<symbol id="i-grid" viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7" rx="1"></rect><rect x="14" y="3" width="7" height="7" rx="1"></rect><rect x="14" y="14" width="7" height="7" rx="1"></rect><rect x="3" y="14" width="7" height="7" rx="1"></rect></symbol>
+<symbol id="i-settings" viewBox="0 0 24 24"><path d="M20 7h-9"></path><path d="M14 17H5"></path><circle cx="17" cy="17" r="3"></circle><circle cx="7" cy="7" r="3"></circle></symbol>
+<symbol id="i-logout" viewBox="0 0 24 24"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"></path><path d="m16 17 5-5-5-5"></path><path d="M21 12H9"></path></symbol>
+<symbol id="i-pr" viewBox="0 0 24 24"><circle cx="6" cy="6" r="3"></circle><circle cx="6" cy="18" r="3"></circle><path d="M6 9v6"></path><circle cx="18" cy="18" r="3"></circle><path d="M18 15V9a3 3 0 0 0-3-3h-2"></path><path d="m15 4-2 2 2 2"></path></symbol>
+</svg>
+
+<div class="app">
+  <aside class="side">
+    <div class="side-head"><span class="side-brand">ElasticClaw</span></div>
+    <div class="side-list">
+      <div class="side-group" style="color:var(--color-accent)">Needs you<span style="margin-left:auto">2</span></div>
+      <div style="padding:0 var(--space-2) var(--space-2)">
+        <a class="agent-row" href="board.html" style="border-left-color:var(--color-accent)"><span class="agent-row-top"><span class="dot warn"></span><span class="agent-row-name">claw-4817</span></span><span class="agent-row-sub" style="color:var(--color-accent)">Waiting on you · force push?</span></a>
+        <a class="agent-row" href="board.html" style="border-left-color:var(--color-accent)"><span class="agent-row-top"><span class="dot bad"></span><span class="agent-row-name">claw-4805</span></span><span class="agent-row-sub" style="color:var(--color-accent)">Provisioning failed</span></a>
+      </div>
+      <hr class="rule" />
+      <div class="side-group">Working<span style="margin-left:auto">2</span></div>
+      <div style="padding:0 var(--space-2)">
+        <a class="agent-row" href="conversation.html"><span class="agent-row-top"><span class="dot ok"></span><span class="agent-row-name">claw-4821</span></span><span class="agent-row-sub">Edit · pkg/hub/db.go</span></a>
+        <a class="agent-row" href="conversation.html"><span class="agent-row-top"><span class="dot ok"></span><span class="agent-row-name">claw-4822</span></span><span class="agent-row-sub">Bash · go test ./pkg/hub</span></a>
+      </div>
+    </div>
+    <div class="side-foot">
+      <a class="side-item" href="board.html"><svg class="ic"><use href="#i-grid"></use></svg>Agents</a>
+      <a class="side-item" href="settings.html"><svg class="ic"><use href="#i-settings"></use></svg>Settings</a>
+      <hr class="rule" style="margin:var(--space-1) 0" />
+      <a class="side-item" href="login.html"><svg class="ic"><use href="#i-logout"></use></svg>Sign out</a>
+    </div>
+  </aside>
+
+  <main class="main">
+    <div class="scroll">
+      <header class="page-head">
+        <div class="head-inner">
+          <div class="head-top">
+            <h2>Analytics</h2>
+            <span class="text-muted" style="font-size:13px">Jul 17 – Aug 16, 2026 · compared with the previous 30 days</span>
+            <div class="seg period">
+              <label class="seg-opt"><input type="radio" name="period" /><span>7d</span></label>
+              <label class="seg-opt"><input type="radio" name="period" checked /><span>30d</span></label>
+              <label class="seg-opt"><input type="radio" name="period" /><span>90d</span></label>
+              <label class="seg-opt"><input type="radio" name="period" /><span>MTD</span></label>
+            </div>
+          </div>
+          <div class="filters">
+            <select class="sel" style="min-width:190px"><option>Workspace: All workspaces</option><option>elasticclaw</option></select>
+            <span class="sep"></span>
+            <select class="sel"><option>Factory: All</option></select>
+            <select class="sel"><option>Workflow: linear-story</option><option>All</option></select>
+            <select class="sel"><option>Repo: All</option></select>
+            <select class="sel"><option>Model: All</option></select>
+            <span class="applied">Workflow: linear-story ×</span>
+            <button class="btn btn-ghost" style="font-size:12px">Clear filters</button>
+          </div>
+        </div>
+      </header>
+
+      <div class="wrap">
+
+        <div class="kpis">
+          <section>
+            <p class="kicker" style="margin:0">Effectiveness</p>
+            <div class="kpi-grid" data-cols="6">
+              <div class="kpi"><p class="lbl">Runs started</p><p class="val tabular">412</p><p class="delta up">↑ 12.4% <em>vs prior</em></p></div>
+              <div class="kpi"><p class="lbl">Tickets worked on</p><p class="val tabular">188</p><p class="delta up">↑ 6.1% <em>vs prior</em></p></div>
+              <div class="kpi"><p class="lbl">Runs that delivered</p><p class="val tabular">68.4%</p><p class="delta up">↑ 3.2% <em>vs prior</em></p></div>
+              <div class="kpi"><p class="lbl">Tickets delivered</p><p class="val tabular">81.9%</p><p class="delta down">↓ 1.8% <em>vs prior</em></p></div>
+              <div class="kpi"><p class="lbl">Avg ticket → PR opened</p><p class="val tabular">3.4h</p><p class="delta up">↓ 9.0% <em>vs prior</em></p></div>
+              <div class="kpi"><p class="lbl">Avg ready for review → merge</p><p class="val tabular">5.1h</p><p class="delta down">↑ 4.4% <em>vs prior</em></p></div>
+            </div>
+          </section>
+          <section>
+            <p class="kicker" style="margin:0">Cost</p>
+            <div class="kpi-grid" data-cols="3">
+              <div class="kpi"><p class="lbl">Total AI spend</p><p class="val tabular">$2,884</p><p class="delta down">↑ 18.2% <em>vs prior</em></p></div>
+              <div class="kpi"><p class="lbl">Spend per run</p><p class="val tabular">$7.00</p><p class="delta">&nbsp;</p></div>
+              <div class="kpi"><p class="lbl">Spend per ticket</p><p class="val tabular">$15.34</p><p class="delta up">↓ 4.1% <em>vs prior</em></p></div>
+            </div>
+          </section>
+        </div>
+
+        <div class="grid2">
+          <section class="panel">
+            <header><h3>Run outcomes over time</h3><p>Each bar is a day. Clean = delivered with no human help.</p></header>
+            <div class="plot"><span class="ymax">32</span><span class="ymid">16</span><span class="yzero">0</span><div class="chart" id="outcomes"></div></div>
+            <div class="axis"><span>Jul 17</span><span>Aug 1</span><span>Aug 16</span></div>
+            <div class="legend"><span><i style="background:var(--c-clean)"></i>Clean</span><span><i style="background:var(--c-human)"></i>Human on the loop</span><span><i style="background:var(--c-warn)"></i>Warning</span><span><i style="background:var(--c-fail)"></i>Failed</span></div>
+          </section>
+          <section class="panel">
+            <header><h3>Delivery funnel</h3><p>From the agent starting to the pull request being finished.</p></header>
+            <div class="funnel">
+              <div><div class="lab"><span>Agent started</span><b class="tabular">412</b></div><div class="bar"><i style="width:100%"></i></div></div>
+              <div><div class="lab"><span>PR opened <span class="drop">· 80.3% of started</span></span><b class="tabular">331</b></div><div class="bar"><i style="width:80.3%"></i></div></div>
+              <div><div class="lab"><span>PR finished <span class="drop">· 85.2% of opened</span></span><b class="tabular">282</b></div><div class="bar"><i style="width:68.4%"></i></div></div>
+            </div>
+          </section>
+        </div>
+
+        <div class="grid2">
+          <section class="panel">
+            <header><h3>Ticket throughput</h3><p>Distinct tickets by the day of their first run, by outcome.</p></header>
+            <div class="plot"><span class="ymax">24</span><span class="ymid">12</span><span class="yzero">0</span><div class="chart" id="tickets"></div></div>
+            <div class="axis"><span>Jul 17</span><span>Aug 1</span><span>Aug 16</span></div>
+            <div class="legend"><span><i style="background:var(--c-clean)"></i>Delivered</span><span><i style="background:var(--c-human)"></i>In progress</span><span><i style="background:var(--c-fail)"></i>Failed</span></div>
+          </section>
+          <section class="panel">
+            <header><h3>Runs per ticket</h3><p>A long tail of 3+ means repeated retries on the same tickets.</p></header>
+            <div class="hbars">
+              <div class="hbar"><span>1 run</span><span class="track"><i style="width:100%"></i></span><span class="num">112</span></div>
+              <div class="hbar"><span>2 runs</span><span class="track"><i style="width:46%"></i></span><span class="num">52</span></div>
+              <div class="hbar"><span>3 runs</span><span class="track"><i style="width:16%"></i></span><span class="num">18</span></div>
+              <div class="hbar"><span>4+ runs</span><span class="track"><i style="width:5%"></i></span><span class="num">6</span></div>
+            </div>
+          </section>
+        </div>
+
+        <section class="panel">
+          <header><h3>Cost by day</h3><p>Darker means more spend. Click a day to focus the whole page on it.</p></header>
+          <div class="heat" id="heat"></div>
+          <div class="heat-legend">Less <i style="background:color-mix(in srgb,var(--c-data) 22%,transparent)"></i><i style="background:color-mix(in srgb,var(--c-data) 42%,transparent)"></i><i style="background:color-mix(in srgb,var(--c-data) 62%,transparent)"></i><i style="background:color-mix(in srgb,var(--c-data) 82%,transparent)"></i><i style="background:var(--c-data)"></i> More</div>
+        </section>
+
+        <div class="grid2">
+          <section class="panel">
+            <header><h3>Daily cost by model</h3><p>Spend per day, split by AI model.</p></header>
+            <div class="plot"><span class="ymax">$180</span><span class="ymid">$90</span><span class="yzero">$0</span><div class="chart" id="models"></div></div>
+            <div class="axis"><span>Jul 17</span><span>Aug 1</span><span>Aug 16</span></div>
+            <div class="legend"><span><i style="background:var(--c-1)"></i>claude-sonnet-4.5</span><span><i style="background:var(--c-2)"></i>gpt-5</span><span><i style="background:var(--c-3)"></i>grok-build</span><span><i style="background:var(--c-4)"></i>Other</span></div>
+          </section>
+          <section class="panel">
+            <header><h3>Cost per merged PR</h3><p>Weekly average; the dashed line is the period average ($9.80).</p></header>
+            <div class="plot" style="padding-left:34px"><span class="ymax">$16</span><span class="ymid">$8</span><span class="yzero">$0</span>
+              <svg viewBox="0 0 320 180" style="width:100%;height:180px;display:block" preserveAspectRatio="none">
+                <line x1="0" y1="106" x2="320" y2="106" stroke="var(--color-neutral-500)" stroke-dasharray="4 4" />
+                <polyline points="0,135 53,119 106,126 160,99 213,86 266,94 320,76" fill="none" stroke="var(--c-1)" stroke-width="2" vector-effect="non-scaling-stroke" />
+              </svg>
+            </div>
+            <div class="axis"><span>Jul 6</span><span>Jul 27</span><span>Aug 10</span></div>
+            <div class="legend"><span><i style="background:var(--c-1)"></i>Cost per merged PR</span><span><i style="background:var(--color-neutral-500)"></i>Period average</span></div>
+          </section>
+        </div>
+
+        <div class="grid2">
+          <section class="panel">
+            <header><h3>Workflow cost comparison</h3><p>Daily spend of the most expensive workflows, side by side.</p></header>
+            <div class="plot"><span class="ymax">$120</span><span class="ymid">$60</span><span class="yzero">$0</span>
+              <svg viewBox="0 0 320 180" style="width:100%;height:180px;display:block" preserveAspectRatio="none">
+                <polyline points="0,144 45,126 91,135 137,108 183,101 229,86 275,94 320,70" fill="none" stroke="var(--c-1)" stroke-width="2" vector-effect="non-scaling-stroke" />
+                <polyline points="0,162 45,158 91,151 137,155 183,135 229,142 275,126 320,119" fill="none" stroke="var(--c-2)" stroke-width="2" vector-effect="non-scaling-stroke" />
+                <polyline points="0,173 45,169 91,171 137,164 183,167 229,160 275,162 320,153" fill="none" stroke="var(--c-4)" stroke-width="2" vector-effect="non-scaling-stroke" />
+              </svg>
+            </div>
+            <div class="axis"><span>Jul 17</span><span>Aug 1</span><span>Aug 16</span></div>
+            <div class="legend"><span><i style="background:var(--c-1)"></i>linear-story</span><span><i style="background:var(--c-2)"></i>github-issue</span><span><i style="background:var(--c-4)"></i>Other</span></div>
+          </section>
+          <section class="panel">
+            <header><h3>Most expensive tickets</h3><p>Where the money concentrates in the selected period.</p></header>
+            <div class="hbars">
+              <div class="hbar"><span class="mono">ELA-288</span><span class="track"><i style="width:100%"></i></span><span class="num">$184</span></div>
+              <div class="hbar"><span class="mono">ELA-309</span><span class="track"><i style="width:77%"></i></span><span class="num">$142</span></div>
+              <div class="hbar"><span class="mono">ELA-274</span><span class="track"><i style="width:59%"></i></span><span class="num">$108</span></div>
+              <div class="hbar"><span class="mono">ELA-311</span><span class="track"><i style="width:41%"></i></span><span class="num">$76</span></div>
+              <div class="hbar"><span class="mono">ELA-298</span><span class="track"><i style="width:26%"></i></span><span class="num">$48</span></div>
+            </div>
+          </section>
+        </div>
+
+        <section class="panel">
+          <header><h3>Runs</h3><p>Every run in the selected period. Click a row for attempts, events and PRs.</p></header>
+          <div class="tscroll">
+          <table class="table">
+            <thead><tr><th>Status</th><th>Ticket</th><th>Model</th><th>Factory/Workflow</th><th style="text-align:right">Cost</th><th style="text-align:right">Duration</th><th style="text-align:right">Start date</th></tr></thead>
+            <tbody>
+              <tr><td><span class="st st-clean"><i></i><span>clean</span></span></td><td class="mono">ELA-311</td><td>claude-sonnet-4.5</td><td>linear-story</td><td class="tabular" style="text-align:right">$6.12</td><td class="tabular" style="text-align:right">42m</td><td class="tabular" style="text-align:right">8/16/2026</td></tr>
+              <tr><td><span class="st st-human"><i></i><span>human</span></span></td><td class="mono">ELA-309</td><td>claude-sonnet-4.5</td><td>github-issue</td><td class="tabular" style="text-align:right">$11.40</td><td class="tabular" style="text-align:right">1.8h</td><td class="tabular" style="text-align:right">8/16/2026</td></tr>
+              <tr><td><span class="st st-fail"><i></i><span>failed</span></span></td><td class="mono">ELA-306</td><td>gpt-5</td><td>linear-story</td><td class="tabular" style="text-align:right">$3.88</td><td class="tabular" style="text-align:right">21m</td><td class="tabular" style="text-align:right">8/15/2026</td></tr>
+              <tr><td><span class="st st-clean"><i></i><span>clean</span></span></td><td class="mono">ELA-304</td><td>claude-sonnet-4.5</td><td>linear-story</td><td class="tabular" style="text-align:right">$5.02</td><td class="tabular" style="text-align:right">36m</td><td class="tabular" style="text-align:right">8/15/2026</td></tr>
+              <tr><td><span class="st st-warn"><i></i><span>warning</span></span></td><td class="mono">ELA-298</td><td>grok-build</td><td>github-issue</td><td class="tabular" style="text-align:right">$9.77</td><td class="tabular" style="text-align:right">2.4h</td><td class="tabular" style="text-align:right">8/14/2026</td></tr>
+            </tbody>
+          </table>
+          </div>
+          <div class="row" style="justify-content:center;gap:var(--space-3);margin-top:var(--space-3)">
+            <button class="btn btn-secondary" disabled>Previous</button>
+            <span class="text-muted" style="font-size:13px">Page 1</span>
+            <button class="btn btn-secondary">Next</button>
+          </div>
+        </section>
+
+        <section class="panel">
+          <header><h3>Top cost drivers</h3><p>By workflow — total spend and efficiency in the selected period.</p></header>
+          <div class="tscroll">
+          <table class="table">
+            <thead><tr><th>Workflow</th><th style="text-align:right">Runs</th><th style="text-align:right">Success</th><th style="text-align:right">Cost</th><th style="text-align:right">Cost / merged PR</th></tr></thead>
+            <tbody>
+              <tr><td>linear-story</td><td class="tabular" style="text-align:right">241</td><td class="tabular" style="text-align:right">71.4%</td><td class="tabular" style="text-align:right">$1,702.44</td><td class="tabular" style="text-align:right">$9.88</td></tr>
+              <tr><td>github-issue</td><td class="tabular" style="text-align:right">128</td><td class="tabular" style="text-align:right">64.8%</td><td class="tabular" style="text-align:right">$894.10</td><td class="tabular" style="text-align:right">$10.77</td></tr>
+              <tr><td>linear-issue-plan-gate</td><td class="tabular" style="text-align:right">43</td><td class="tabular" style="text-align:right">58.1%</td><td class="tabular" style="text-align:right">$287.92</td><td class="tabular" style="text-align:right">$11.52</td></tr>
+            </tbody>
+          </table>
+          </div>
+        </section>
+      </div>
+    </div>
+  </main>
+</div>
+
+<script>
+const rnd=(s=>()=>(s=s*16807%2147483647)/2147483647)(42);
+function stack(el,series,n){const host=document.getElementById(el);if(!host)return;let html='';for(let d=0;d<n;d++){let col='<div class="col">';for(const s of series){const h=Math.round(s.base*(0.35+rnd()*0.65));if(h>0)col+='<i style="height:'+h+'px;background:'+s.color+'"></i>'}html+=col+'</div>'}host.innerHTML=html}
+stack('outcomes',[{base:22,color:'var(--c-fail)'},{base:12,color:'var(--c-warn)'},{base:30,color:'var(--c-human)'},{base:62,color:'var(--c-clean)'}],30);
+stack('tickets',[{base:18,color:'var(--c-fail)'},{base:32,color:'var(--c-human)'},{base:70,color:'var(--c-clean)'}],30);
+stack('models',[{base:18,color:'var(--c-4)'},{base:26,color:'var(--c-3)'},{base:34,color:'var(--c-2)'},{base:66,color:'var(--c-1)'}],30);
+const heat=document.getElementById('heat');
+if(heat){let h='';for(let i=0;i<364;i++){const v=rnd();const lv=v<0.28?0:Math.ceil(v*5);const bg=lv===0?'color-mix(in srgb, var(--color-text) 9%, transparent)':'color-mix(in srgb, var(--c-data) '+[0,22,42,62,82,100][lv]+'%, transparent)';h+='<i style="background:'+bg+'"></i>'}heat.innerHTML=h}
+</script>
+</body>
+</html>

--- a/docs/design/modernist/app.css
+++ b/docs/design/modernist/app.css
@@ -1,0 +1,73 @@
+/* ElasticClaw screens — layout scaffolding only. Every color, font, radius,
+   space and shadow comes from ../../styles.css (Modernist). The three status
+   colors below are the one addition: the product carries running / warning /
+   failed semantics the mono palette has no role for, so they are defined in
+   OKLCH at the accent's lightness and chroma, varying only hue. */
+@import url('https://fonts.googleapis.com/css2?family=Archivo:wght@400;600;800&display=swap');
+:root{--font-mono:ui-monospace,"SF Mono",Menlo,monospace;--status-ok:oklch(0.62 0.16 152);--status-warn:oklch(0.62 0.16 75);--status-bad:var(--color-accent)}
+html,body{height:100%}
+body{margin:0;overflow:hidden}
+.app{display:flex;height:100vh;background:var(--color-bg);color:var(--color-text)}
+.mono{font-family:var(--font-mono)}
+.rule{height:2px;background:var(--color-divider);border:0;margin:0}
+
+/* — sidebar — */
+.side{width:260px;flex:none;display:flex;flex-direction:column;border-right:2px solid var(--color-divider);background:var(--color-surface)}
+.side-head{display:flex;align-items:center;gap:var(--space-2);padding:var(--space-4);border-bottom:2px solid var(--color-divider)}
+.side-brand{font-family:var(--font-heading);font-weight:var(--font-heading-weight);font-size:18px;margin-right:auto;letter-spacing:-0.015em}
+.side-filters{padding:var(--space-3);border-bottom:2px solid var(--color-divider);display:grid;gap:var(--space-2)}
+.side-list{flex:1;min-height:0;overflow-y:auto}
+.side-group{display:flex;align-items:center;gap:6px;padding:var(--space-2) var(--space-4);font-size:10px;letter-spacing:0.1em;text-transform:uppercase;color:color-mix(in srgb,var(--color-text) 55%,transparent)}
+.side-foot{padding:var(--space-2);border-top:2px solid var(--color-divider);display:grid;gap:2px}
+.side-item{display:flex;align-items:center;gap:9px;width:100%;min-height:36px;padding:0 10px;border:0;border-radius:var(--radius-md);background:transparent;color:color-mix(in srgb,var(--color-text) 70%,transparent);font:inherit;font-size:13px;cursor:pointer;text-align:left;text-decoration:none}
+.side-item:hover{background:color-mix(in srgb,var(--color-text) 7%,transparent);color:var(--color-text)}
+.side-item[aria-current]{background:color-mix(in srgb,var(--color-text) 10%,transparent);color:var(--color-text)}
+
+/* — agent row in the sidebar — */
+.agent-row{display:block;width:100%;text-align:left;padding:var(--space-3);border:0;border-left:2px solid var(--color-divider);border-radius:0 var(--radius-md) var(--radius-md) 0;background:transparent;color:inherit;font:inherit;text-decoration:none;cursor:pointer}
+.agent-row:hover{background:color-mix(in srgb,var(--color-text) 6%,transparent)}
+.agent-row[aria-current]{background:color-mix(in srgb,var(--color-text) 10%,transparent)}
+.agent-row-top{display:flex;align-items:center;gap:8px}
+.agent-row-name{flex:1;min-width:0;font-family:var(--font-mono);font-size:13px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.agent-row-sub{display:block;padding-left:20px;margin-top:2px;font-family:var(--font-mono);font-size:10px;line-height:1.4;color:color-mix(in srgb,var(--color-text) 55%,transparent);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+
+/* — status marks — */
+.dot{width:8px;height:8px;border-radius:var(--radius-pill);flex:none;background:var(--color-neutral-500)}
+.dot.ok{background:var(--status-ok)}
+.dot.warn{background:var(--status-warn)}
+.dot.bad{background:var(--status-bad)}
+.badge-count{display:inline-flex;align-items:center;justify-content:center;min-width:20px;height:20px;padding:0 6px;border-radius:var(--radius-pill);background:var(--color-accent);color:var(--color-bg);font-size:11px;font-weight:600}
+
+/* — main region — */
+.main{flex:1;min-width:0;display:flex;flex-direction:column;overflow:hidden}
+.topbar{display:flex;align-items:center;gap:var(--space-3);padding:var(--space-3) var(--space-4);border-bottom:2px solid var(--color-divider)}
+.icon-btn{display:inline-flex;align-items:center;justify-content:center;width:32px;height:32px;border:0;border-radius:var(--radius-md);background:transparent;color:color-mix(in srgb,var(--color-text) 65%,transparent);cursor:pointer}
+.icon-btn:hover{background:color-mix(in srgb,var(--color-text) 8%,transparent);color:var(--color-text)}
+.spacer{margin-left:auto}
+.scroll{flex:1;min-height:0;overflow:auto}
+
+/* — the board — */
+.board{display:flex;gap:var(--space-4);padding:var(--space-4);height:100%;align-items:stretch}
+.board-card{width:500px;flex:none;display:flex;flex-direction:column;border:1px solid var(--color-divider);border-radius:var(--radius-lg);background:var(--color-surface);overflow:hidden}
+.card-head{padding:var(--space-3);border-bottom:2px solid var(--color-divider)}
+.meter{height:4px;border-radius:var(--radius-pill);background:color-mix(in srgb,var(--color-text) 12%,transparent);overflow:hidden}
+.meter > i{display:block;height:100%;background:var(--status-ok)}
+.now{display:flex;align-items:center;gap:8px;padding:6px var(--space-3);border-bottom:1px solid var(--color-divider);font-family:var(--font-mono);font-size:11px;color:color-mix(in srgb,var(--color-text) 70%,transparent)}
+.msgs{flex:1;min-height:0;overflow-y:auto;padding:var(--space-3);display:grid;gap:var(--space-2);align-content:start}
+.msg{padding:var(--space-2);border-radius:var(--radius-md);font-size:12px}
+.msg-you{background:color-mix(in srgb,var(--color-text) 8%,transparent);margin-left:32px}
+.msg-agent{background:color-mix(in srgb,var(--color-text) 4%,transparent);border:1px solid var(--color-divider);margin-right:32px}
+.msg-head{display:flex;align-items:center;gap:6px;margin-bottom:2px;font-size:11px;color:color-mix(in srgb,var(--color-text) 55%,transparent)}
+.msg-head b{color:var(--color-text);font-weight:600}
+.step{display:grid;grid-template-columns:auto 1fr auto;align-items:baseline;gap:8px;font-family:var(--font-mono);font-size:11px;color:color-mix(in srgb,var(--color-text) 65%,transparent)}
+.card-stats{display:flex;gap:var(--space-3);padding:4px var(--space-3);border-top:1px solid var(--color-divider);font-family:var(--font-mono);font-size:10px;color:color-mix(in srgb,var(--color-text) 55%,transparent)}
+.composer{display:flex;gap:6px;padding:var(--space-2);border-top:2px solid var(--color-divider)}
+
+/* — generic bits — */
+.stack{display:grid;gap:var(--space-3)}
+.row{display:flex;align-items:center;gap:var(--space-2)}
+.kicker{font-size:10px;letter-spacing:0.1em;text-transform:uppercase;color:color-mix(in srgb,var(--color-text) 55%,transparent)}
+.panel{border:1px solid var(--color-divider);border-radius:var(--radius-lg);background:var(--color-surface);padding:var(--space-4)}
+.panel > h2{font-size:15px;margin-bottom:var(--space-3)}
+a{color:var(--color-accent)}
+a:hover{color:var(--color-accent-hover)}

--- a/docs/design/modernist/board.html
+++ b/docs/design/modernist/board.html
@@ -1,0 +1,279 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>ElasticClaw — Agents</title>
+<link rel="stylesheet" href="../../styles.css" />
+<link rel="stylesheet" href="app.css" />
+<style>
+.ic{width:16px;height:16px;display:block;fill:none;stroke:currentColor;stroke-width:2;stroke-linecap:round;stroke-linejoin:round}
+.ic-sm{width:14px;height:14px}
+.search-wrap{position:relative}
+.search-wrap .ic{position:absolute;left:10px;top:50%;transform:translateY(-50%);color:color-mix(in srgb,var(--color-text) 55%,transparent)}
+.search-wrap .input{padding-left:32px;min-height:32px}
+.lanes{padding:var(--space-4);display:grid;gap:var(--space-6)}
+.lane-head{display:flex;align-items:center;gap:var(--space-2);padding-bottom:var(--space-2);border-bottom:2px solid var(--color-divider);margin-bottom:var(--space-3)}
+.lane-title{font-family:var(--font-heading);font-weight:var(--font-heading-weight);font-size:13px;letter-spacing:0.08em;text-transform:uppercase}
+.lane-count{display:inline-flex;align-items:center;justify-content:center;min-width:20px;height:20px;padding:0 6px;border-radius:var(--radius-pill);background:color-mix(in srgb,var(--color-text) 12%,transparent);font-size:11px;font-weight:600}
+.lane[data-tone="act"] .lane-title{color:var(--color-accent)}
+.lane[data-tone="act"] .lane-count{background:var(--color-accent);color:var(--color-bg)}
+.lane[data-tone="run"] .lane-title{color:var(--status-ok)}
+.lane-note{font-size:12px;color:color-mix(in srgb,var(--color-text) 55%,transparent);margin-left:auto}
+.cards{display:grid;grid-template-columns:repeat(auto-fill,minmax(360px,1fr));gap:var(--space-4);align-items:start}
+.cards > *{min-width:0}
+.board-card{width:auto}
+.state{display:flex;align-items:center;gap:8px;padding:8px var(--space-3);font-family:var(--font-heading);font-weight:var(--font-heading-weight);font-size:11px;letter-spacing:0.1em;text-transform:uppercase}
+.state-act{background:var(--color-accent);color:var(--color-bg)}
+.state-err{background:var(--color-accent-800);color:var(--color-accent-100)}
+.state-run{background:color-mix(in srgb,var(--status-ok) 20%,transparent);color:var(--status-ok)}
+.state-idle{background:color-mix(in srgb,var(--color-text) 8%,transparent);color:color-mix(in srgb,var(--color-text) 60%,transparent)}
+.state .why{margin-left:auto;font-family:var(--font-mono);font-weight:400;font-size:11px;letter-spacing:0;text-transform:none;opacity:0.85;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:55%}
+.card-off{opacity:0.55}
+.msgs{max-height:190px}
+.ask{padding:var(--space-3);border-bottom:1px solid var(--color-divider);display:grid;gap:var(--space-2)}
+.ask p{margin:0;font-size:13px}
+.ask .row{gap:6px}
+.state-run,.state-idle{font-family:var(--font-mono);font-weight:400;font-size:11px;letter-spacing:0;text-transform:none;background:transparent;border-bottom:1px solid var(--color-divider)}
+.state-run{color:var(--status-ok)}
+.state-idle{color:color-mix(in srgb,var(--color-text) 55%,transparent)}
+.state-run .why,.state-idle .why{color:color-mix(in srgb,var(--color-text) 55%,transparent)}
+.pr{display:inline-flex;align-items:center;gap:5px;padding:2px 8px;border:1px solid var(--color-divider);border-radius:var(--radius-pill);font-family:var(--font-mono);font-size:11px;color:inherit;text-decoration:none}
+.pr:hover{border-color:var(--color-accent);color:var(--color-accent)}
+.pr .ic{width:12px;height:12px}
+.side-group[data-tone="act"]{color:var(--color-accent)}
+.side-group .n{margin-left:auto;font-variant-numeric:tabular-nums}
+.agent-row[data-act]{border-left-color:var(--color-accent);background:color-mix(in srgb,var(--color-accent) 10%,transparent)}
+.agent-row[data-act]:hover{background:color-mix(in srgb,var(--color-accent) 16%,transparent)}
+.agent-row[data-off]{opacity:0.6}
+.mark{display:inline-flex;align-items:center;gap:3px;flex:none;font-family:var(--font-mono);font-size:10px;color:color-mix(in srgb,var(--color-text) 55%,transparent)}
+.mark .ic{width:11px;height:11px}
+.agent-row[data-act] .agent-row-sub{color:var(--color-accent)}
+</style>
+</head>
+<body>
+<svg style="display:none" aria-hidden="true">
+<symbol id="i-search" viewBox="0 0 24 24"><circle cx="11" cy="11" r="8"></circle><path d="m21 21-4.3-4.3"></path></symbol>
+<symbol id="i-plus" viewBox="0 0 24 24"><path d="M5 12h14"></path><path d="M12 5v14"></path></symbol>
+<symbol id="i-panel" viewBox="0 0 24 24"><rect x="3" y="3" width="18" height="18" rx="2"></rect><path d="M9 3v18"></path><path d="m16 15-3-3 3-3"></path></symbol>
+<symbol id="i-chevron-down" viewBox="0 0 24 24"><path d="m6 9 6 6 6-6"></path></symbol>
+<symbol id="i-chart" viewBox="0 0 24 24"><path d="M3 3v18h18"></path><path d="M18 17V9"></path><path d="M13 17V5"></path><path d="M8 17v-3"></path></symbol>
+<symbol id="i-settings" viewBox="0 0 24 24"><path d="M20 7h-9"></path><path d="M14 17H5"></path><circle cx="17" cy="17" r="3"></circle><circle cx="7" cy="7" r="3"></circle></symbol>
+<symbol id="i-logout" viewBox="0 0 24 24"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"></path><path d="m16 17 5-5-5-5"></path><path d="M21 12H9"></path></symbol>
+<symbol id="i-send" viewBox="0 0 24 24"><path d="m22 2-7 20-4-9-9-4Z"></path><path d="M22 2 11 13"></path></symbol>
+<symbol id="i-clip" viewBox="0 0 24 24"><path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"></path></symbol>
+<symbol id="i-info" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"></circle><path d="M12 16v-4"></path><path d="M12 8h.01"></path></symbol>
+<symbol id="i-msg" viewBox="0 0 24 24"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path></symbol>
+<symbol id="i-pin" viewBox="0 0 24 24"><path d="M12 17v5"></path><path d="M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V7a1 1 0 0 1 1-1 2 2 0 0 0 0-4H8a2 2 0 0 0 0 4 1 1 0 0 1 1 1z"></path></symbol>
+<symbol id="i-pr" viewBox="0 0 24 24"><circle cx="6" cy="6" r="3"></circle><circle cx="6" cy="18" r="3"></circle><path d="M6 9v6"></path><circle cx="18" cy="18" r="3"></circle><path d="M18 15V9a3 3 0 0 0-3-3h-2"></path><path d="m15 4-2 2 2 2"></path></symbol>
+<symbol id="i-copy" viewBox="0 0 24 24"><rect x="8" y="8" width="13" height="13" rx="2"></rect><path d="M5 16V5a2 2 0 0 1 2-2h11"></path></symbol>
+</svg>
+
+<div class="app">
+  <aside class="side">
+    <div class="side-head">
+      <span class="side-brand">ElasticClaw</span>
+      <button class="icon-btn" title="Create Agent"><svg class="ic"><use href="#i-plus"></use></svg></button>
+      <button class="icon-btn" title="Collapse sidebar"><svg class="ic"><use href="#i-panel"></use></svg></button>
+    </div>
+    <div class="side-filters">
+      <div class="search-wrap"><svg class="ic"><use href="#i-search"></use></svg><input class="input" placeholder="Filter by name or workflow..." /></div>
+      <div class="row" style="flex-wrap:wrap;gap:6px">
+        <button class="btn btn-secondary" style="font-size:12px;padding:4px 10px">Tags <svg class="ic ic-sm"><use href="#i-chevron-down"></use></svg></button>
+      </div>
+    </div>
+    <div class="side-list">
+      <div class="side-group" data-tone="act">Needs you<span class="n">2</span></div>
+      <div style="padding:0 var(--space-2) var(--space-2)">
+        <button class="agent-row" data-act aria-current="true"><span class="agent-row-top"><span class="dot warn"></span><span class="agent-row-name">claw-4817</span><span class="mark"><svg class="ic"><use href="#i-pr"></use></svg>#221</span></span><span class="agent-row-sub">Waiting on you · force push?</span></button>
+        <button class="agent-row" data-act><span class="agent-row-top"><span class="dot bad"></span><span class="agent-row-name">claw-4805</span></span><span class="agent-row-sub">Provisioning failed</span></button>
+      </div>
+      <hr class="rule" />
+      <div class="side-group">Working<span class="n">2</span></div>
+      <div style="padding:0 var(--space-2) var(--space-2)">
+        <button class="agent-row"><span class="agent-row-top"><span class="dot ok"></span><span class="agent-row-name">claw-4821</span><span class="badge-count">3</span></span><span class="agent-row-sub">Edit · pkg/hub/db.go</span></button>
+        <button class="agent-row"><span class="agent-row-top"><span class="dot ok"></span><span class="agent-row-name">claw-4822</span></span><span class="agent-row-sub">Bash · go test ./pkg/hub</span></button>
+      </div>
+      <hr class="rule" />
+      <div class="side-group">Idle &amp; offline<span class="n">1</span></div>
+      <div style="padding:0 var(--space-2) var(--space-2)">
+        <button class="agent-row" data-off><span class="agent-row-top"><span class="dot"></span><span class="agent-row-name">claw-4790</span><span class="mark"><svg class="ic"><use href="#i-pr"></use></svg>#218</span></span><span class="agent-row-sub">Offline · last seen 2h ago</span></button>
+      </div>
+    </div>
+    <div class="side-foot">
+      <a class="side-item" href="analytics.html"><svg class="ic"><use href="#i-chart"></use></svg>Analytics</a>
+      <a class="side-item" href="settings.html"><svg class="ic"><use href="#i-settings"></use></svg>Settings</a>
+      <hr class="rule" style="margin:var(--space-1) 0" />
+      <a class="side-item" href="login.html"><svg class="ic"><use href="#i-logout"></use></svg>Sign out</a>
+    </div>
+  </aside>
+
+  <main class="main">
+    <div class="scroll">
+      <div class="lanes">
+
+        <section class="lane" data-tone="act">
+          <div class="lane-head"><span class="lane-title">Needs you</span><span class="lane-count">2</span><span class="lane-note">Blocked until you answer or restart</span></div>
+          <div class="cards">
+
+            <article class="board-card">
+              <div class="state state-act"><span>Waiting on you</span><span class="why">asked 22m ago</span></div>
+              <div class="card-head">
+                <div class="row" style="margin-bottom:4px">
+                  <span class="dot warn"></span>
+                  <a class="mono" href="conversation.html" style="flex:1;font-size:14px;font-weight:600;color:var(--color-text);text-decoration:none">claw-4817</a>
+                  <button class="icon-btn" title="Open conversation"><svg class="ic ic-sm"><use href="#i-msg"></use></svg></button>
+                  <button class="icon-btn" title="View bot info"><svg class="ic ic-sm"><use href="#i-info"></use></svg></button>
+                </div>
+                <div class="row" style="justify-content:space-between">
+                  <span class="text-muted" style="font-size:12px">github-issue · elasticclaw</span>
+                  <span class="mono text-muted" style="font-size:12px">3h 04m · ctx 71%</span>
+                </div>
+                <div class="row" style="gap:6px;margin-top:var(--space-2)"><a class="pr" href="#"><svg class="ic"><use href="#i-pr"></use></svg>PR #221 · draft</a><span class="tag tag-neutral">web</span><span class="tag tag-neutral">ui</span></div>
+              </div>
+              <div class="ask">
+                <p>“O push foi rejeitado porque a branch remota mudou. Posso forçar push?”</p>
+                <div class="row"><button class="btn btn-primary" style="font-size:13px">Reply</button><button class="btn btn-secondary" style="font-size:13px">Open conversation</button></div>
+              </div>
+              <div class="msgs">
+                <div class="step"><span>Bash</span><span>pnpm build</span><span>1m 08s</span></div>
+                <div class="step" style="color:var(--color-accent)"><span>Bash</span><span>git push --force-with-lease</span><span>failed</span></div>
+              </div>
+              <div class="card-stats"><span>14 steps</span><span style="color:var(--status-bad)">1 failed</span><span style="margin-left:auto">ctx 71%</span></div>
+              <form class="composer" onsubmit="return false">
+                <button class="btn btn-secondary btn-icon" type="button" title="Attach files"><svg class="ic ic-sm"><use href="#i-clip"></use></svg></button>
+                <input class="input" placeholder="Send message..." />
+                <button class="btn btn-primary btn-icon" type="submit"><svg class="ic ic-sm"><use href="#i-send"></use></svg></button>
+              </form>
+            </article>
+
+            <article class="board-card">
+              <div class="state state-err"><span>Provisioning failed</span><span class="why">07:12 · replicated CMX</span></div>
+              <div class="card-head">
+                <div class="row" style="margin-bottom:4px">
+                  <span class="dot bad"></span>
+                  <span class="mono" style="flex:1;font-size:14px;font-weight:600">claw-4805</span>
+                  <button class="icon-btn" title="View bot info"><svg class="ic ic-sm"><use href="#i-info"></use></svg></button>
+                </div>
+                <div class="row" style="justify-content:space-between">
+                  <span class="text-muted" style="font-size:12px">linear-story · elasticclaw</span>
+                  <span class="mono" style="font-size:12px;color:var(--status-bad)">error</span>
+                </div>
+              </div>
+              <div class="ask">
+                <p class="text-muted" style="font-size:13px">Sandbox did not return a VM within 300s. Nothing ran; the ticket is untouched.</p>
+                <div class="row"><button class="btn btn-primary" style="font-size:13px">Retry run</button><button class="btn btn-secondary" style="font-size:13px">Kill</button></div>
+              </div>
+              <div class="msgs">
+                <div class="msg msg-agent"><div class="msg-head"><b>hub</b> 07:12</div>Provisioning failed: replicated CMX did not return a VM within 300s.</div>
+              </div>
+              <div class="card-stats"><span>0 steps</span><span style="margin-left:auto">ctx 12%</span></div>
+              <form class="composer" onsubmit="return false">
+                <button class="btn btn-secondary btn-icon" type="button" disabled title="Attach files"><svg class="ic ic-sm"><use href="#i-clip"></use></svg></button>
+                <input class="input" placeholder="Provisioning failed" disabled />
+                <button class="btn btn-primary btn-icon" type="submit" disabled><svg class="ic ic-sm"><use href="#i-send"></use></svg></button>
+              </form>
+            </article>
+
+          </div>
+        </section>
+
+        <section class="lane" data-tone="run">
+          <div class="lane-head"><span class="lane-title">Working</span><span class="lane-count">2</span><span class="lane-note">Live — no action needed</span></div>
+          <div class="cards">
+
+            <article class="board-card">
+              <div class="state state-run"><span>Working</span><span class="why">Edit pkg/hub/db.go · 0:42</span></div>
+              <div class="card-head">
+                <div class="row" style="margin-bottom:4px">
+                  <span class="dot ok"></span>
+                  <a class="mono" href="conversation.html" style="flex:1;font-size:14px;font-weight:600;color:var(--color-text);text-decoration:none">claw-4821</a>
+                  <span class="badge-count">3</span>
+                  <button class="icon-btn" title="Copy transcript"><svg class="ic ic-sm"><use href="#i-copy"></use></svg></button>
+                  <button class="icon-btn" title="View bot info"><svg class="ic ic-sm"><use href="#i-info"></use></svg></button>
+                </div>
+                <div class="row" style="justify-content:space-between">
+                  <span class="text-muted" style="font-size:12px">linear-story · elasticclaw</span>
+                  <span class="mono text-muted" style="font-size:12px">1h 12m · ctx 38%</span>
+                </div>
+                <div class="row" style="gap:6px;margin-top:var(--space-2)"><a class="pr" href="#"><svg class="ic"><use href="#i-pr"></use></svg>PR #220 · open</a><span class="tag tag-neutral">backend</span><span class="tag tag-neutral">hub</span><span class="tag tag-neutral">p1</span></div>
+              </div>
+              <div class="msgs">
+                <div class="msg msg-you"><div class="msg-head"><b>You</b> 09:14</div>Adiciona o índice em task_runs e roda os testes do hub.</div>
+                <div class="step"><span>Edit</span><span>pkg/hub/db.go · +18 −2</span><span>0.9s</span></div>
+                <div class="step"><span>Bash</span><span>go test ./pkg/hub -run Migration</span><span>34s</span></div>
+                <div class="msg msg-agent"><div class="msg-head"><b>claw-4821</b> 09:31</div>Migração criada e testes do pacote hub passando.</div>
+              </div>
+              <div class="card-stats"><span>27 steps</span><span style="margin-left:auto">ctx 38%</span></div>
+              <form class="composer" onsubmit="return false">
+                <button class="btn btn-secondary btn-icon" type="button" title="Attach files"><svg class="ic ic-sm"><use href="#i-clip"></use></svg></button>
+                <input class="input" placeholder="Send message..." />
+                <button class="btn btn-primary btn-icon" type="submit"><svg class="ic ic-sm"><use href="#i-send"></use></svg></button>
+              </form>
+            </article>
+
+            <article class="board-card">
+              <div class="state state-run"><span>Working</span><span class="why">Bash go test ./pkg/hub · 1:18</span></div>
+              <div class="card-head">
+                <div class="row" style="margin-bottom:4px">
+                  <span class="dot ok"></span>
+                  <a class="mono" href="conversation.html" style="flex:1;font-size:14px;font-weight:600;color:var(--color-text);text-decoration:none">claw-4822</a>
+                  <button class="icon-btn" title="View bot info"><svg class="ic ic-sm"><use href="#i-info"></use></svg></button>
+                </div>
+                <div class="row" style="justify-content:space-between">
+                  <span class="text-muted" style="font-size:12px">linear-story · elasticclaw</span>
+                  <span class="mono text-muted" style="font-size:12px">26m · ctx 21%</span>
+                </div>
+                <div class="row" style="gap:6px;margin-top:var(--space-2)"><span class="tag tag-neutral">backend</span></div>
+              </div>
+              <div class="msgs">
+                <div class="step"><span>Read</span><span>pkg/hub/checkpoints.go</span><span>0.7s</span></div>
+                <div class="step"><span>Bash</span><span>go test ./pkg/hub</span><span>running</span></div>
+              </div>
+              <div class="card-stats"><span>9 steps</span><span style="margin-left:auto">ctx 21%</span></div>
+              <form class="composer" onsubmit="return false">
+                <button class="btn btn-secondary btn-icon" type="button" title="Attach files"><svg class="ic ic-sm"><use href="#i-clip"></use></svg></button>
+                <input class="input" placeholder="Send message..." />
+                <button class="btn btn-primary btn-icon" type="submit"><svg class="ic ic-sm"><use href="#i-send"></use></svg></button>
+              </form>
+            </article>
+
+          </div>
+        </section>
+
+        <section class="lane">
+          <div class="lane-head"><span class="lane-title">Idle &amp; offline</span><span class="lane-count">1</span><span class="lane-note">Finished or disconnected</span></div>
+          <div class="cards">
+            <article class="board-card card-off">
+              <div class="state state-idle"><span>Offline</span><span class="why">last seen 2h ago</span></div>
+              <div class="card-head">
+                <div class="row" style="margin-bottom:4px">
+                  <span class="dot"></span>
+                  <span class="mono" style="flex:1;font-size:14px;font-weight:600">claw-4790</span>
+                  <button class="icon-btn" title="View bot info"><svg class="ic ic-sm"><use href="#i-info"></use></svg></button>
+                </div>
+                <div class="row" style="justify-content:space-between">
+                  <span class="text-muted" style="font-size:12px">github-issue · elasticclaw</span>
+                  <span class="mono text-muted" style="font-size:12px">4h 41m · ctx 64%</span>
+                </div>
+                <div class="row" style="gap:6px;margin-top:var(--space-2)"><a class="pr" href="#"><svg class="ic"><use href="#i-pr"></use></svg>PR #218 · awaiting review</a></div>
+              </div>
+              <div class="msgs">
+                <div class="msg msg-agent"><div class="msg-head"><b>claw-4790</b> 06:02</div>PR #218 aberto e aguardando review.</div>
+              </div>
+              <div class="card-stats"><span>31 steps</span><span style="margin-left:auto">ctx 64%</span></div>
+              <form class="composer" onsubmit="return false">
+                <button class="btn btn-secondary btn-icon" type="button" disabled title="Attach files"><svg class="ic ic-sm"><use href="#i-clip"></use></svg></button>
+                <input class="input" placeholder="Agent offline" disabled />
+                <button class="btn btn-primary btn-icon" type="submit" disabled><svg class="ic ic-sm"><use href="#i-send"></use></svg></button>
+              </form>
+            </article>
+          </div>
+        </section>
+
+      </div>
+    </div>
+  </main>
+</div>
+</body>
+</html>

--- a/docs/design/modernist/conversation.html
+++ b/docs/design/modernist/conversation.html
@@ -1,0 +1,102 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>ElasticClaw — claw-4821</title>
+<link rel="stylesheet" href="../../styles.css" />
+<link rel="stylesheet" href="app.css" />
+<style>
+.ic{width:16px;height:16px;display:block;fill:none;stroke:currentColor;stroke-width:2;stroke-linecap:round;stroke-linejoin:round}
+.ic-sm{width:14px;height:14px}
+.thread{max-width:820px;margin:0 auto;padding:var(--space-6) var(--space-4);display:grid;gap:var(--space-4)}
+.bubble{max-width:70%;padding:var(--space-3) var(--space-4);border-radius:var(--radius-lg);font-size:14px}
+.b-user{margin-left:auto;background:color-mix(in srgb,var(--color-text) 10%,transparent)}
+.b-agent{background:var(--color-surface);border:1px solid var(--color-divider)}
+.b-head{display:flex;align-items:center;gap:8px;margin-bottom:4px;font-size:12px;color:color-mix(in srgb,var(--color-text) 55%,transparent)}
+.b-head b{color:var(--color-text)}
+.turn{border:1px solid var(--color-divider);border-radius:var(--radius-lg);background:color-mix(in srgb,var(--color-text) 3%,transparent);padding:var(--space-3);display:grid;gap:6px}
+.sys{display:flex;align-items:center;gap:var(--space-3);font-size:10px;letter-spacing:0.1em;text-transform:uppercase;color:color-mix(in srgb,var(--color-text) 45%,transparent)}
+.sys::before,.sys::after{content:"";flex:1;height:1px;background:var(--color-divider)}
+.toolbar{display:flex;align-items:center;gap:var(--space-2);padding:var(--space-2) var(--space-4);border-bottom:1px solid var(--color-divider);font-size:12px}
+.composer-bar{border-top:2px solid var(--color-divider);padding:var(--space-3) var(--space-4)}
+.composer-inner{max-width:820px;margin:0 auto;display:flex;gap:var(--space-2)}
+</style>
+</head>
+<body>
+<svg style="display:none" aria-hidden="true">
+<symbol id="i-back" viewBox="0 0 24 24"><path d="m15 18-6-6 6-6"></path></symbol>
+<symbol id="i-term" viewBox="0 0 24 24"><rect x="3" y="3" width="18" height="18" rx="2"></rect><path d="m7 11 2-2-2-2"></path><path d="M11 13h4"></path></symbol>
+<symbol id="i-info" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"></circle><path d="M12 16v-4"></path><path d="M12 8h.01"></path></symbol>
+<symbol id="i-trash" viewBox="0 0 24 24"><path d="M3 6h18"></path><path d="M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2"></path><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"></path></symbol>
+<symbol id="i-send" viewBox="0 0 24 24"><path d="m22 2-7 20-4-9-9-4Z"></path><path d="M22 2 11 13"></path></symbol>
+<symbol id="i-clip" viewBox="0 0 24 24"><path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"></path></symbol>
+<symbol id="i-copy" viewBox="0 0 24 24"><rect x="8" y="8" width="13" height="13" rx="2"></rect><path d="M5 16V5a2 2 0 0 1 2-2h11"></path></symbol>
+</svg>
+
+<div class="app">
+  <main class="main">
+    <div class="topbar">
+      <a class="icon-btn" href="board.html" title="Back to board"><svg class="ic"><use href="#i-back"></use></svg></a>
+      <span class="dot ok"></span>
+      <h4 class="mono" style="margin:0;font-size:17px">claw-4821</h4>
+      <span class="tag tag-outline">connected</span>
+      <span class="text-muted" style="font-size:12px">linear-story · elasticclaw · 1h 12m</span>
+      <div class="spacer"></div>
+      <div class="row" style="gap:8px"><span class="kicker">ctx</span><div class="meter" style="width:96px"><i style="width:38%"></i></div><span class="mono" style="font-size:12px">38%</span></div>
+      <button class="icon-btn" title="Copy transcript"><svg class="ic"><use href="#i-copy"></use></svg></button>
+      <button class="icon-btn" title="Toggle terminal"><svg class="ic"><use href="#i-term"></use></svg></button>
+      <button class="icon-btn" title="View bot info"><svg class="ic"><use href="#i-info"></use></svg></button>
+      <button class="btn btn-secondary" style="font-size:13px"><svg class="ic ic-sm"><use href="#i-trash"></use></svg>Kill</button>
+    </div>
+
+    <div class="toolbar">
+      <span class="kicker">Timeline</span>
+      <div class="seg">
+        <label class="seg-opt"><input type="radio" name="density" /><span>Compact</span></label>
+        <label class="seg-opt"><input type="radio" name="density" checked /><span>Comfortable</span></label>
+        <label class="seg-opt"><input type="radio" name="density" /><span>Full</span></label>
+      </div>
+      <div class="spacer"></div>
+      <span class="text-muted" style="font-size:12px">27 steps · 1 failed · 4 turns</span>
+    </div>
+
+    <div class="scroll">
+      <div class="thread">
+        <div class="sys">Session started</div>
+
+        <div class="bubble b-user"><div class="b-head"><b>You</b><span>09:14</span></div>Adiciona o índice em <code class="mono">task_runs</code> e roda os testes do hub.</div>
+
+        <div class="turn">
+          <div class="row" style="justify-content:space-between"><span class="kicker">Activity · 6 steps</span><span class="mono text-muted" style="font-size:11px">2m 41s</span></div>
+          <div class="step"><span>Read</span><span>pkg/hub/db.go</span><span>1.2s</span></div>
+          <div class="step"><span>Grep</span><span>CREATE INDEX · pkg/hub</span><span>0.4s</span></div>
+          <div class="step"><span>Edit</span><span>pkg/hub/db.go · +18 −2</span><span>0.9s</span></div>
+          <div class="step"><span>Write</span><span>pkg/hub/db_task_runs_index_migration_test.go</span><span>0.6s</span></div>
+          <div class="step"><span>Bash</span><span>go test ./pkg/hub -run Migration</span><span>34s</span></div>
+          <div class="step"><span>Bash</span><span>go vet ./...</span><span>1m 24s</span></div>
+        </div>
+
+        <div class="bubble b-agent"><div class="b-head"><b>claw-4821</b><span>09:31</span></div>Migração criada e testes do pacote hub passando. Posso abrir o PR?</div>
+
+        <div class="bubble b-user"><div class="b-head"><b>You</b><span>09:33</span></div>Pode abrir, marca como draft.</div>
+
+        <div class="turn">
+          <div class="row" style="justify-content:space-between"><span class="kicker">Activity · running</span><span class="mono text-muted" style="font-size:11px">0:42</span></div>
+          <div class="step"><span>Bash</span><span>git commit -m "hub: index task_runs"</span><span>0.8s</span></div>
+          <div class="step"><span>Bash</span><span>gh pr create --draft</span><span>running</span></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="composer-bar">
+      <form class="composer-inner" onsubmit="return false">
+        <button class="btn btn-secondary btn-icon" type="button" title="Attach files"><svg class="ic ic-sm"><use href="#i-clip"></use></svg></button>
+        <input class="input" placeholder="Message agent, /stop, or attach files" />
+        <button class="btn btn-primary" type="submit"><svg class="ic ic-sm"><use href="#i-send"></use></svg>Send</button>
+      </form>
+    </div>
+  </main>
+</div>
+</body>
+</html>

--- a/docs/design/modernist/login.html
+++ b/docs/design/modernist/login.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>ElasticClaw — Sign in</title>
+<link rel="stylesheet" href="../../styles.css" />
+<link rel="stylesheet" href="app.css" />
+<style>
+.center{display:grid;place-items:center;height:100vh;padding:var(--space-4)}
+.auth{width:100%;max-width:360px;display:grid;gap:var(--space-4);padding:var(--space-8);border:1px solid var(--color-divider);border-radius:var(--radius-lg);background:var(--color-surface)}
+.or{display:flex;align-items:center;gap:var(--space-3);font-size:11px;letter-spacing:0.1em;text-transform:uppercase;color:color-mix(in srgb,var(--color-text) 50%,transparent)}
+.or::before,.or::after{content:"";flex:1;height:2px;background:var(--color-divider)}
+.gh{width:100%;justify-content:flex-start}
+</style>
+</head>
+<body>
+<main class="center">
+  <div class="auth">
+    <div>
+      <h2 style="font-size:26px;margin:0 0 4px">ElasticClaw</h2>
+      <p class="text-muted" style="margin:0;font-size:14px">Sign in to continue</p>
+    </div>
+    <button type="button" class="btn btn-secondary gh">
+      <svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z" /></svg>
+      Sign in with GitHub
+    </button>
+    <div class="or">or</div>
+    <form class="stack" onsubmit="return false">
+      <div class="field"><input class="input" type="password" placeholder="Access token" /></div>
+      <button type="submit" class="btn btn-primary btn-block">Sign in</button>
+    </form>
+  </div>
+</main>
+</body>
+</html>

--- a/docs/design/modernist/settings.html
+++ b/docs/design/modernist/settings.html
@@ -1,0 +1,100 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>ElasticClaw — Settings</title>
+<link rel="stylesheet" href="../../styles.css" />
+<link rel="stylesheet" href="app.css" />
+<style>
+.ic{width:16px;height:16px;display:block;fill:none;stroke:currentColor;stroke-width:2;stroke-linecap:round;stroke-linejoin:round}
+.ic-sm{width:14px;height:14px}
+.ws{display:flex;align-items:center;gap:var(--space-2);padding:var(--space-3) var(--space-4);border-bottom:2px solid var(--color-divider)}
+.ws-mark{width:28px;height:28px;flex:none;display:grid;place-items:center;border-radius:var(--radius-md);background:var(--color-accent);color:var(--color-bg);font-family:var(--font-heading);font-weight:var(--font-heading-weight);font-size:14px}
+.content{max-width:680px;padding:var(--space-8) var(--space-6);display:grid;gap:var(--space-6)}
+.provider{display:flex;align-items:flex-start;gap:var(--space-3);padding:var(--space-3);border:1px solid var(--color-divider);border-radius:var(--radius-lg);background:var(--color-surface);cursor:pointer}
+.provider:hover{background:color-mix(in srgb,var(--color-text) 7%,transparent)}
+.provider input{position:absolute;opacity:0;width:0;height:0}
+.provider .dot{width:16px;height:16px;margin-top:2px;border-radius:var(--radius-pill);border:1.5px solid var(--color-divider);background:transparent}
+.provider:has(input:checked){border-color:var(--color-accent)}
+.provider:has(input:checked) .dot{border-color:var(--color-accent);background:var(--color-accent);box-shadow:inset 0 0 0 4px var(--color-bg)}
+.provider b{display:block;font-size:14px}
+.provider small{color:color-mix(in srgb,var(--color-text) 60%,transparent);font-size:12px}
+</style>
+</head>
+<body>
+<svg style="display:none" aria-hidden="true">
+<symbol id="i-back" viewBox="0 0 24 24"><path d="m15 18-6-6 6-6"></path></symbol>
+<symbol id="i-layout" viewBox="0 0 24 24"><rect x="3" y="3" width="18" height="7" rx="1"></rect><rect x="3" y="14" width="7" height="7" rx="1"></rect><rect x="14" y="14" width="7" height="7" rx="1"></rect></symbol>
+<symbol id="i-branch" viewBox="0 0 24 24"><circle cx="6" cy="6" r="3"></circle><circle cx="6" cy="18" r="3"></circle><path d="M6 9v6"></path><path d="M21 9a9 9 0 0 1-9 9"></path><circle cx="18" cy="6" r="3"></circle></symbol>
+<symbol id="i-github" viewBox="0 0 24 24"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.4 5.4 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"></path><path d="M9 18c-4.51 2-5-2-7-2"></path></symbol>
+<symbol id="i-zap" viewBox="0 0 24 24"><path d="M4 14h7l-1 8 10-12h-7l1-8z"></path></symbol>
+<symbol id="i-lock" viewBox="0 0 24 24"><rect x="3" y="11" width="18" height="11" rx="2"></rect><path d="M7 11V7a5 5 0 0 1 10 0v4"></path></symbol>
+<symbol id="i-cpu" viewBox="0 0 24 24"><rect x="4" y="4" width="16" height="16" rx="2"></rect><rect x="9" y="9" width="6" height="6"></rect><path d="M9 2v2"></path><path d="M15 2v2"></path><path d="M9 20v2"></path><path d="M15 20v2"></path><path d="M2 9h2"></path><path d="M2 15h2"></path><path d="M20 9h2"></path><path d="M20 15h2"></path></symbol>
+<symbol id="i-key" viewBox="0 0 24 24"><circle cx="7.5" cy="15.5" r="4.5"></circle><path d="m21 2-9.6 9.6"></path><path d="m15.5 7.5 3 3L22 7l-3-3"></path></symbol>
+<symbol id="i-shield" viewBox="0 0 24 24"><path d="M20 13c0 5-3.5 7.5-8 9-4.5-1.5-8-4-8-9V6l8-3 8 3z"></path></symbol>
+<symbol id="i-sparkles" viewBox="0 0 24 24"><path d="m12 3 1.9 5.1L19 10l-5.1 1.9L12 17l-1.9-5.1L5 10l5.1-1.9z"></path><path d="M18 17.5 18.7 19.3 20.5 20 18.7 20.7 18 22.5 17.3 20.7 15.5 20 17.3 19.3z"></path></symbol>
+<symbol id="i-stetho" viewBox="0 0 24 24"><path d="M4 2v6a5 5 0 0 0 10 0V2"></path><path d="M9 13v3a5 5 0 0 0 10 0v-2"></path><circle cx="20" cy="10" r="2"></circle></symbol>
+<symbol id="i-wrench" viewBox="0 0 24 24"><path d="M14.7 6.3a4 4 0 0 0 5 5l-8.4 8.4a2.8 2.8 0 0 1-4-4z"></path></symbol>
+</svg>
+
+<div class="app">
+  <aside class="side">
+    <div class="side-head">
+      <a class="icon-btn" href="board.html" title="Back to agents"><svg class="ic"><use href="#i-back"></use></svg></a>
+      <span class="side-brand">Settings</span>
+    </div>
+    <div class="ws">
+      <span class="ws-mark">E</span>
+      <div style="min-width:0"><div class="mono" style="font-size:13px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">elasticclaw</div><div class="kicker">Workspace</div></div>
+    </div>
+    <div class="side-list" style="padding:var(--space-2)">
+      <div class="side-group" style="padding-left:10px">Workspace</div>
+      <a class="side-item" href="#"><svg class="ic"><use href="#i-layout"></use></svg>Overview</a>
+      <a class="side-item" href="#"><svg class="ic"><use href="#i-branch"></use></svg>Workflows</a>
+      <a class="side-item" href="#"><svg class="ic"><use href="#i-github"></use></svg>GitHub Apps</a>
+      <a class="side-item" href="#"><svg class="ic"><use href="#i-zap"></use></svg>Issue Trackers</a>
+      <a class="side-item" href="#"><svg class="ic"><use href="#i-lock"></use></svg>Secrets</a>
+      <a class="side-item" href="#"><svg class="ic"><use href="#i-zap"></use></svg>MCP Servers</a>
+      <div class="side-group" style="padding-left:10px">System</div>
+      <a class="side-item" href="#" aria-current="page"><svg class="ic"><use href="#i-cpu"></use></svg>Sandboxes</a>
+      <a class="side-item" href="#"><svg class="ic"><use href="#i-key"></use></svg>Models</a>
+      <a class="side-item" href="#"><svg class="ic"><use href="#i-shield"></use></svg>Authentication</a>
+      <a class="side-item" href="#"><svg class="ic"><use href="#i-sparkles"></use></svg>Configure with AI</a>
+      <div class="side-group" style="padding-left:10px">Diagnostics</div>
+      <a class="side-item" href="#"><svg class="ic"><use href="#i-stetho"></use></svg>Doctor</a>
+      <a class="side-item" href="#"><svg class="ic"><use href="#i-wrench"></use></svg>Troubleshoot</a>
+    </div>
+  </aside>
+
+  <main class="main">
+    <div class="scroll">
+      <div class="content">
+        <div>
+          <h3 style="margin:0 0 4px">Sandbox Runtimes</h3>
+          <p class="text-muted" style="font-size:14px;margin:0">Where agents run. One provider is active at a time; its credentials are stored as server secrets.</p>
+        </div>
+
+        <div class="stack">
+          <label class="provider"><input type="radio" name="provider" checked /><span class="dot"></span><span><b>Replicated CMX</b><small>Kubernetes-based VM provider</small></span></label>
+          <label class="provider"><input type="radio" name="provider" /><span class="dot"></span><span><b>Daytona</b><small>Development environment provider</small></span></label>
+          <label class="provider"><input type="radio" name="provider" /><span class="dot"></span><span><b>exe.dev</b><small>Persistent VM provider with SSH access</small></span></label>
+          <label class="provider"><input type="radio" name="provider" /><span class="dot"></span><span><b>Local Docker</b><small>Local Docker daemon provider for development and testing</small></span></label>
+          <label class="provider"><input type="radio" name="provider" /><span class="dot"></span><span><b>AWS Lambda MicroVMs <span class="tag tag-outline" style="margin-left:4px">alpha</span></b><small>Serverless Firecracker MicroVM provider</small></span></label>
+        </div>
+
+        <hr class="hr" />
+
+        <div class="stack">
+          <div class="field"><label for="api-token">Replicated API token</label><input id="api-token" class="input" type="password" placeholder="••••••••••••" /></div>
+          <div class="field"><label for="cluster">Cluster distribution</label><input id="cluster" class="input" value="k3s" /></div>
+          <div class="field"><label for="ttl">Instance TTL</label><input id="ttl" class="input" value="4h" /></div>
+        </div>
+
+        <div class="row"><button class="btn btn-primary">Save</button><button class="btn btn-ghost">Test connection</button></div>
+      </div>
+    </div>
+  </main>
+</div>
+</body>
+</html>

--- a/docs/design/modernist/setup.html
+++ b/docs/design/modernist/setup.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>ElasticClaw — Connect</title>
+<link rel="stylesheet" href="../../styles.css" />
+<link rel="stylesheet" href="app.css" />
+<style>
+.center{display:grid;place-items:center;height:100vh;padding:var(--space-4)}
+.setup{width:100%;max-width:440px;display:grid;gap:var(--space-6)}
+code{font-family:var(--font-mono);font-size:0.92em;background:color-mix(in srgb,var(--color-text) 10%,transparent);padding:1px 5px;border-radius:var(--radius-sm)}
+</style>
+</head>
+<body>
+<main class="center">
+  <div class="setup">
+    <div>
+      <h2 style="font-size:26px;margin:0 0 var(--space-2)">Connect to ElasticClaw Server</h2>
+      <p class="text-muted" style="margin:0;font-size:14px">Enter your ElasticClaw Server URL and authentication token to get started.</p>
+    </div>
+    <div class="stack">
+      <div class="field"><label for="hub-url">ElasticClaw Server URL</label><input id="hub-url" class="input" placeholder="http://your-server-host:8080" /></div>
+      <div class="field"><label for="hub-token">Token</label><input id="hub-token" class="input" type="password" placeholder="your-auth-token" /></div>
+    </div>
+    <button class="btn btn-primary btn-block">Connect</button>
+    <p class="text-muted" style="font-size:12px;margin:0">You can also set <code>NEXT_PUBLIC_HUB_URL</code> and <code>NEXT_PUBLIC_HUB_TOKEN</code> environment variables.</p>
+  </div>
+</main>
+</body>
+</html>

--- a/docs/design/modernist/styles.css
+++ b/docs/design/modernist/styles.css
@@ -1,0 +1,341 @@
+/* Modernist — design-system tokens and component classes. This file is the source of truth for the system's look; retune it here and see readme.md. */
+@import url('https://fonts.googleapis.com/css2?family=Archivo:wght@400;600;800&display=swap');
+
+:root {
+  --color-bg: #f4f4f5;
+  --color-surface: #e8e8ea;
+  --color-text: #1b1b1d;
+  --color-accent: #ec3013;
+  --color-accent-2: #e15b47;
+  --color-divider: color-mix(in srgb, #1b1b1d 40%, transparent);
+
+  /* Tonal ramps — generated in OKLCH on one shared lightness scale, so the
+     same step of any role matches the others in visual value. */
+  --color-neutral-100: #f7f7f8;
+  --color-neutral-200: #e9e9eb;
+  --color-neutral-300: #d5d5d8;
+  --color-neutral-400: #b8b8bc;
+  --color-neutral-500: #99999e;
+  --color-neutral-600: #7b7b80;
+  --color-neutral-700: #5e5e63;
+  --color-neutral-800: #424247;
+  --color-neutral-900: #2b2b30;
+
+  --color-accent-100: #fff2ef;
+  --color-accent-200: #ffe0d9;
+  --color-accent-300: #ffc4b8;
+  --color-accent-400: #ff9783;
+  --color-accent-500: #ff563c;
+  --color-accent-600: #dd2b0f;
+  --color-accent-700: #ae1800;
+  --color-accent-800: #7c1405;
+  --color-accent-900: #4d170e;
+
+  --color-accent-2-100: #fff2ef;
+  --color-accent-2-200: #ffe0da;
+  --color-accent-2-300: #ffc4b9;
+  --color-accent-2-400: #ff9784;
+  --color-accent-2-500: #ef6853;
+  --color-accent-2-600: #c94b39;
+  --color-accent-2-700: #9e3526;
+  --color-accent-2-800: #71261b;
+  --color-accent-2-900: #471d16;
+
+  --font-heading: "Archivo", system-ui, sans-serif;
+  --font-heading-weight: 800;
+  --font-body: "Archivo", system-ui, sans-serif;
+
+  --space-1: 4.0px;
+  --space-2: 8.0px;
+  --space-3: 12.0px;
+  --space-4: 16.0px;
+  --space-6: 24.0px;
+  --space-8: 32.0px;
+
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-pill: 999px;
+
+  /* Elevation — derived from the ground: soft ink-tinted shadows on a
+     light theme, a hairline edge + ambient darkness on a dark one. */
+  --shadow-sm: 0 1px 2px color-mix(in srgb, #2b2b30 14%, transparent);
+  --shadow-md: 0 3px 10px color-mix(in srgb, #2b2b30 16%, transparent);
+  --shadow-lg: 0 12px 32px color-mix(in srgb, #2b2b30 22%, transparent);
+
+  /* Tinted fills — the pair a chip or callout uses. Both members flip
+     together in dark mode so contrast holds either way. */
+  --tint-accent-bg: var(--color-accent-100);
+  --tint-accent-fg: var(--color-accent-800);
+  --tint-accent-2-bg: var(--color-accent-2-100);
+  --tint-accent-2-fg: var(--color-accent-2-800);
+  --tint-neutral-bg: var(--color-neutral-100);
+  --tint-neutral-fg: var(--color-neutral-800);
+
+  /* Pressed state — one ramp step past the accent, in the direction that
+     reads as "deeper" against the current ground. */
+  --color-accent-hover: var(--color-accent-600);
+  --color-accent-active: var(--color-accent-700);
+  --scrim: color-mix(in srgb, var(--color-neutral-900) 50%, transparent);
+}
+
+/* ── Dark mode ──────────────────────────────────────────────────────────
+   Follows the OS by default; force either theme with data-theme="dark" /
+   data-theme="light" on <html> (or any subtree). Only the role tokens
+   flip — the 100–900 ramps stay fixed, so a ramp step always means the
+   same color, and the tint pairs above pick the right end of it. */
+@media (prefers-color-scheme: dark) {
+  :root {
+    color-scheme: dark;
+    --color-bg: #141416;
+    --color-surface: #1e1e21;
+    --color-text: #f2f2f4;
+    --color-accent: #ff563c;
+    --color-accent-2: #ef6853;
+    --color-divider: color-mix(in srgb, #f2f2f4 34%, transparent);
+    --tint-accent-bg: color-mix(in srgb, var(--color-accent-700) 45%, transparent);
+    --tint-accent-fg: var(--color-accent-200);
+    --tint-accent-2-bg: color-mix(in srgb, var(--color-accent-2-700) 45%, transparent);
+    --tint-accent-2-fg: var(--color-accent-2-200);
+    --tint-neutral-bg: color-mix(in srgb, var(--color-neutral-100) 12%, transparent);
+    --tint-neutral-fg: var(--color-neutral-200);
+    --color-accent-hover: var(--color-accent-400);
+    --color-accent-active: var(--color-accent-300);
+    --shadow-sm: 0 1px 2px rgb(0 0 0 / 0.5);
+    --shadow-md: 0 3px 10px rgb(0 0 0 / 0.55);
+    --shadow-lg: 0 12px 32px rgb(0 0 0 / 0.6);
+    --scrim: color-mix(in srgb, #000 62%, transparent);
+  }
+}
+
+/* Forcing light back on, anywhere (whole page or one subtree). */
+[data-theme="light"] {
+  color-scheme: light;
+  --color-bg: #f4f4f5;
+  --color-surface: #e8e8ea;
+  --color-text: #1b1b1d;
+  --color-accent: #ec3013;
+  --color-accent-2: #e15b47;
+  --color-divider: color-mix(in srgb, #1b1b1d 40%, transparent);
+  --tint-accent-bg: var(--color-accent-100);
+  --tint-accent-fg: var(--color-accent-800);
+  --tint-accent-2-bg: var(--color-accent-2-100);
+  --tint-accent-2-fg: var(--color-accent-2-800);
+  --tint-neutral-bg: var(--color-neutral-100);
+  --tint-neutral-fg: var(--color-neutral-800);
+  --color-accent-hover: var(--color-accent-600);
+  --color-accent-active: var(--color-accent-700);
+  --shadow-sm: 0 1px 2px color-mix(in srgb, #2b2b30 14%, transparent);
+  --shadow-md: 0 3px 10px color-mix(in srgb, #2b2b30 16%, transparent);
+  --shadow-lg: 0 12px 32px color-mix(in srgb, #2b2b30 22%, transparent);
+  --scrim: color-mix(in srgb, var(--color-neutral-900) 50%, transparent);
+}
+
+[data-theme="dark"] {
+  color-scheme: dark;
+  --color-bg: #141416;
+  --color-surface: #1e1e21;
+  --color-text: #f2f2f4;
+  --color-accent: #ff563c;
+  --color-accent-2: #ef6853;
+  --color-divider: color-mix(in srgb, #f2f2f4 34%, transparent);
+  --tint-accent-bg: color-mix(in srgb, var(--color-accent-700) 45%, transparent);
+  --tint-accent-fg: var(--color-accent-200);
+  --tint-accent-2-bg: color-mix(in srgb, var(--color-accent-2-700) 45%, transparent);
+  --tint-accent-2-fg: var(--color-accent-2-200);
+  --tint-neutral-bg: color-mix(in srgb, var(--color-neutral-100) 12%, transparent);
+  --tint-neutral-fg: var(--color-neutral-200);
+  --color-accent-hover: var(--color-accent-400);
+  --color-accent-active: var(--color-accent-300);
+  --shadow-sm: 0 1px 2px rgb(0 0 0 / 0.5);
+  --shadow-md: 0 3px 10px rgb(0 0 0 / 0.55);
+  --shadow-lg: 0 12px 32px rgb(0 0 0 / 0.6);
+  --scrim: color-mix(in srgb, #000 62%, transparent);
+}
+
+body {
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-family: var(--font-body);
+}
+h1, h2, h3, h4 { font-family: var(--font-heading); font-weight: var(--font-heading-weight); }
+
+.grayscale{filter:grayscale(1) contrast(1.08)}
+
+/* ══════════════════════════════════════════════════════════════════════════
+   Components — built with the tokens above. Plain CSS
+   on plain HTML: no JavaScript, no build step. Each class is documented in
+   readme.md and demonstrated in foundations/ and components/.
+   ══════════════════════════════════════════════════════════════════════ */
+
+*, *::before, *::after { box-sizing: border-box; }
+body { margin: 0; font-size: 15px; line-height: 1.55; font-weight: 400; }
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-heading); font-weight: var(--font-heading-weight);
+  line-height: 1.12; letter-spacing: -0.015em; margin: 0 0 var(--space-2);
+}
+h1 { font-size: 42px; }
+h2 { font-size: 32px; }
+h3 { font-size: 25px; }
+h4 { font-size: 20px; }
+h5 { font-size: 16px; }
+h6 { font-size: 13px; }
+h6 { letter-spacing: 0.08em; text-transform: uppercase; }
+p { margin: 0 0 var(--space-3); }
+a { color: var(--color-accent); text-underline-offset: 3px; }
+img { display: block; max-width: 100%; }
+figure { margin: 0; }
+figcaption {
+  font-size: 11px; margin-top: var(--space-1);
+  color: color-mix(in srgb, var(--color-text) 55%, transparent);
+}
+.text-muted { color: color-mix(in srgb, var(--color-text) 55%, transparent); }
+:focus { outline: none; }
+:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 2px; }
+::selection { background: color-mix(in srgb, var(--color-accent) 30%, transparent); }
+
+/* — rules — */
+.hr {
+  height: 2px; border: 0; margin: var(--space-4) 0;
+  background: var(--color-divider);
+}
+
+/* — buttons — */
+.btn {
+  display: inline-flex; align-items: center; justify-content: center; gap: 6px;
+  cursor: pointer; text-decoration: none;
+  font-family: var(--font-heading); font-weight: var(--font-heading-weight);
+  font-size: 14px; line-height: 1.2; color: var(--color-text); /* matches the .input's 14px —
+     the pair sits side by side in sign-up rows */
+  background: transparent; border: 1px solid transparent;
+  padding: var(--space-2) calc(var(--space-3) * 1.2);
+  border-radius: var(--radius-md);
+}
+.btn svg { display: block; }
+.btn:disabled { opacity: 0.45; cursor: not-allowed; }
+.btn-primary { background: var(--color-accent); color: var(--color-bg); }
+.btn-primary:hover { background: var(--color-accent-hover); }
+.btn-primary:active { background: var(--color-accent-active); }
+.btn-secondary { border-color: var(--color-divider); }
+.btn-secondary:hover { background: color-mix(in srgb, var(--color-text) 7%, transparent); }
+.btn-secondary:active { background: color-mix(in srgb, var(--color-text) 14%, transparent); }
+.btn-ghost { color: var(--color-accent); padding-inline: var(--space-1); }
+.btn-ghost:hover { background: color-mix(in srgb, var(--color-accent) 10%, transparent); }
+.btn-ghost:active { background: color-mix(in srgb, var(--color-accent) 18%, transparent); }
+.btn-icon { width: 36px; height: 36px; padding: 0; border-radius: var(--radius-pill); }
+.btn-block { width: 100%; margin-top: var(--space-2); justify-content: flex-start; text-align: left; }
+
+/* — forms — */
+.field > label {
+  display: block; font-size: 12px; margin-bottom: 5px;
+  color: color-mix(in srgb, var(--color-text) 70%, transparent);
+}
+.input {
+  width: 100%; min-height: 36px; padding: 6px 10px; font: inherit;
+  font-size: 14px; color: var(--color-text); caret-color: var(--color-accent);
+  background: var(--color-surface);
+  border: 1px solid var(--color-divider); border-radius: var(--radius-md);
+}
+.input:hover { border-color: color-mix(in srgb, var(--color-text) 45%, transparent); }
+.input:focus-visible { border-color: var(--color-accent); outline-offset: 0; }
+textarea.input { min-height: 90px; resize: vertical; }
+.radio { display: inline-flex; align-items: center; gap: 8px; cursor: pointer; font-size: 14px; }
+.radio input, .seg-opt input {
+  position: absolute; opacity: 0; width: 0; height: 0; pointer-events: none;
+}
+.radio .dot {
+  width: 16px; height: 16px; flex: none; border-radius: 50%;
+  border: 1.5px solid var(--color-divider);
+}
+.radio:hover .dot { border-color: var(--color-accent); }
+.radio input:checked + .dot {
+  border-color: var(--color-accent); background: var(--color-accent);
+  box-shadow: inset 0 0 0 4px var(--color-bg);
+}
+.radio input:focus-visible + .dot { outline: 2px solid var(--color-accent); outline-offset: 2px; }
+.seg {
+  display: inline-flex; overflow: hidden;
+  border: 1px solid var(--color-divider); border-radius: var(--radius-md);
+}
+.seg-opt {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 7px 12px; font-size: 13px; cursor: pointer;
+}
+.seg-opt + .seg-opt { border-left: 1px solid var(--color-divider); }
+.seg-opt:has(input:checked) { background: var(--color-accent); color: var(--color-bg); }
+.seg-opt:not(:has(input:checked)):hover { background: color-mix(in srgb, var(--color-text) 7%, transparent); }
+.seg-opt:has(input:focus-visible) { outline: 2px solid var(--color-accent); outline-offset: -2px; }
+
+/* — cards — */
+.card {
+  display: flex; flex-direction: column; gap: var(--space-2);
+  padding: var(--space-3); border-radius: var(--radius-lg); background: var(--color-surface);
+}
+.card-kicker { font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--color-accent); }
+.card-title {
+  font-family: var(--font-heading); font-weight: var(--font-heading-weight);
+  font-size: 17px; line-height: 1.2;
+}
+.card-body { margin: 0; font-size: 13px; opacity: 0.8; flex: 1; }
+.card-meta {
+  display: flex; align-items: center; gap: 6px; font-size: 11px;
+  color: color-mix(in srgb, var(--color-text) 50%, transparent);
+}
+.elev-sm { box-shadow: var(--shadow-sm); }
+.elev-md { box-shadow: var(--shadow-md); }
+.elev-lg { box-shadow: var(--shadow-lg); }
+
+/* — tags — */
+.tag {
+  display: inline-flex; align-items: center; font-size: 11px;
+  letter-spacing: 0.02em; padding: 3px 10px;
+  border-radius: var(--radius-pill);
+}
+.tag-accent { background: var(--tint-accent-bg); color: var(--tint-accent-fg); }
+.tag-accent-2 { background: var(--tint-accent-2-bg); color: var(--tint-accent-2-fg); }
+.tag-neutral { background: var(--tint-neutral-bg); color: var(--tint-neutral-fg); }
+.tag-outline { border: 1px solid var(--color-accent); color: var(--color-accent); }
+
+/* — navigation — */
+.nav {
+  display: flex; align-items: center; gap: var(--space-4);
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 2px solid var(--color-divider);
+}
+.nav-brand {
+  font-family: var(--font-heading); font-weight: var(--font-heading-weight);
+  font-size: 18px; margin-right: auto;
+}
+.nav a { color: inherit; text-decoration: none; font-size: 14px; }
+.nav a:hover, .nav a[aria-current='page'] { color: var(--color-accent); }
+
+/* — tables — */
+.table { width: 100%; border-collapse: collapse; font-size: 14px; }
+.table th {
+  text-align: left; font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase;
+  color: color-mix(in srgb, var(--color-text) 60%, transparent);
+  padding: var(--space-2); border-bottom: 2px solid var(--color-divider);
+}
+.table td {
+  padding: var(--space-2);
+  border-bottom: 1px solid var(--color-divider);
+}
+.table tbody tr:hover { background: color-mix(in srgb, var(--color-text) 4%, transparent); }
+
+/* — dialog — */
+.dialog-backdrop {
+  position: fixed; inset: 0; display: grid; place-items: center;
+  padding: var(--space-4);
+  background: var(--scrim);
+}
+.dialog {
+  width: min(440px, 100%); display: flex; flex-direction: column; gap: var(--space-3);
+  padding: var(--space-4); border-radius: var(--radius-lg);
+  background: var(--color-surface); box-shadow: var(--shadow-lg);
+}
+.dialog-title {
+  font-family: var(--font-heading); font-weight: var(--font-heading-weight);
+  font-size: 20px;
+}
+.dialog-body { font-size: 14px; opacity: 0.85; }
+.dialog-actions { display: flex; justify-content: flex-end; gap: var(--space-2); margin-top: var(--space-2); }

--- a/docs/design/modernist/theme.json
+++ b/docs/design/modernist/theme.json
@@ -1,0 +1,49 @@
+{
+  "name": "Modernist",
+  "palette": {
+    "hue": 8,
+    "band": "light",
+    "scheme": "mono",
+    "sat": 0.85,
+    "bg": "#f4f4f5",
+    "surface": "#e8e8ea",
+    "text": "#1b1b1d",
+    "accent": "#ec3013",
+    "accent2": "#e15b47"
+  },
+  "fonts": {
+    "heading": {
+      "family": "Archivo",
+      "class": "grotesque",
+      "weights": [
+        400,
+        600,
+        800
+      ]
+    },
+    "body": {
+      "family": "Archivo",
+      "class": "grotesque",
+      "weights": [
+        400,
+        600,
+        800
+      ]
+    }
+  },
+  "density": 1,
+  "radius": 8,
+  "layoutStyle": "grid",
+  "dividers": "strong",
+  "buttonAlign": "left",
+  "imageTreatment": "grayscale",
+  "photo": "modernist",
+  "colorScheme": "system",
+  "paletteDark": {
+    "bg": "#141416",
+    "surface": "#1e1e21",
+    "text": "#f2f2f4",
+    "accent": "#ff563c",
+    "accent2": "#ef6853"
+  }
+}

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -11,90 +11,203 @@
   height: 100dvh;
 }
 
+/* ══════════════════════════════════════════════════════════════════════════
+   LAYER A — Modernist design system
+   ──────────────────────────────────────────────────────────────────────────
+   This block IS the design system: raw role colors, tonal ramps, tints,
+   shadows, radii and status hues, ported from docs/design/modernist/styles.css
+   (plus the three product status colors from that folder's app.css). It is the
+   replaceable layer — swapping the design system means re-tuning only the
+   values here; nothing below (layer B, the shadcn mapping) needs to change.
+   The app shell renders dark-only via <html className="dark">, so the .dark
+   block carries the values users actually see; :root keeps the light set so
+   the ramp stays legible and any future light mode is a one-line switch.
+   ══════════════════════════════════════════════════════════════════════════ */
+
 :root {
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --destructive-foreground: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --heatmap-1: oklch(0.86 0.08 250);
-  --heatmap-2: oklch(0.72 0.13 250);
-  --heatmap-3: oklch(0.59 0.17 250);
-  --heatmap-4: oklch(0.46 0.16 250);
-  --heatmap-5: oklch(0.32 0.12 250);
-  --radius: 0.625rem;
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  /* — role colors (light) — */
+  --ds-bg: #f4f4f5;
+  --ds-surface: #e8e8ea;
+  --ds-text: #1b1b1d;
+  --ds-accent: #ec3013;
+  --ds-accent-2: #e15b47;
+  --ds-divider: color-mix(in srgb, #1b1b1d 40%, transparent);
+
+  /* — tonal ramps — generated in OKLCH on one shared lightness scale, so the
+       same step of any role matches the others in visual value. The ramps do
+       NOT flip in dark mode: a step always means the same color. */
+  --ds-neutral-100: #f7f7f8;
+  --ds-neutral-200: #e9e9eb;
+  --ds-neutral-300: #d5d5d8;
+  --ds-neutral-400: #b8b8bc;
+  --ds-neutral-500: #99999e;
+  --ds-neutral-600: #7b7b80;
+  --ds-neutral-700: #5e5e63;
+  --ds-neutral-800: #424247;
+  --ds-neutral-900: #2b2b30;
+
+  --ds-accent-100: #fff2ef;
+  --ds-accent-200: #ffe0d9;
+  --ds-accent-300: #ffc4b8;
+  --ds-accent-400: #ff9783;
+  --ds-accent-500: #ff563c;
+  --ds-accent-600: #dd2b0f;
+  --ds-accent-700: #ae1800;
+  --ds-accent-800: #7c1405;
+  --ds-accent-900: #4d170e;
+
+  --ds-accent-2-100: #fff2ef;
+  --ds-accent-2-200: #ffe0da;
+  --ds-accent-2-300: #ffc4b9;
+  --ds-accent-2-400: #ff9784;
+  --ds-accent-2-500: #ef6853;
+  --ds-accent-2-600: #c94b39;
+  --ds-accent-2-700: #9e3526;
+  --ds-accent-2-800: #71261b;
+  --ds-accent-2-900: #471d16;
+
+  /* — tinted fills — the pair a chip or callout uses; both members flip
+       together in dark mode so contrast holds either way. */
+  --ds-tint-accent-bg: var(--ds-accent-100);
+  --ds-tint-accent-fg: var(--ds-accent-800);
+  --ds-tint-accent-2-bg: var(--ds-accent-2-100);
+  --ds-tint-accent-2-fg: var(--ds-accent-2-800);
+  --ds-tint-neutral-bg: var(--ds-neutral-100);
+  --ds-tint-neutral-fg: var(--ds-neutral-800);
+
+  /* — pressed / hover accents — one ramp step past the accent, in the
+       direction that reads as "deeper" against the current ground. */
+  --ds-accent-hover: var(--ds-accent-600);
+  --ds-accent-active: var(--ds-accent-700);
+
+  /* — elevation — soft ink-tinted shadows on a light ground. */
+  --ds-shadow-sm: 0 1px 2px color-mix(in srgb, #2b2b30 14%, transparent);
+  --ds-shadow-md: 0 3px 10px color-mix(in srgb, #2b2b30 16%, transparent);
+  --ds-shadow-lg: 0 12px 32px color-mix(in srgb, #2b2b30 22%, transparent);
+  --ds-scrim: color-mix(in srgb, var(--ds-neutral-900) 50%, transparent);
+
+  /* — radii — */
+  --ds-radius-sm: 4px;
+  --ds-radius-md: 8px;
+  --ds-radius-lg: 12px;
+  --ds-radius-pill: 999px;
+
+  /* — product status colors — the mono palette has no role for
+       running / warning / failed, so these are defined in OKLCH at the
+       accent's lightness and chroma, varying only hue. */
+  --ds-status-ok: oklch(0.62 0.16 152);
+  --ds-status-warn: oklch(0.62 0.16 75);
+  --ds-status-bad: var(--ds-accent);
+
+  /* — data hue — the one non-status, non-accent color, used by charts and
+       heatmaps so quantitative marks never read as "alert". */
+  --ds-data: oklch(0.66 0.12 250);
+  --ds-data-light: oklch(0.77 0.085 245);
+  --ds-data-dark: oklch(0.52 0.11 258);
 }
 
 .dark {
-  --background: #0a0a0a;
-  --foreground: #fafafa;
-  --card: #0f0f0f;
-  --card-foreground: #fafafa;
-  --popover: #0f0f0f;
-  --popover-foreground: #fafafa;
-  --primary: #fafafa;
-  --primary-foreground: #0a0a0a;
-  --secondary: #1a1a1a;
-  --secondary-foreground: #fafafa;
-  --muted: #1a1a1a;
-  --muted-foreground: #737373;
-  --accent: #1a1a1a;
-  --accent-foreground: #fafafa;
-  --destructive: #dc2626;
-  --destructive-foreground: #fafafa;
-  --border: #262626;
-  --input: #262626;
-  --ring: #404040;
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --heatmap-1: oklch(0.35 0.09 250);
-  --heatmap-2: oklch(0.45 0.13 250);
-  --heatmap-3: oklch(0.56 0.16 250);
-  --heatmap-4: oklch(0.67 0.15 250);
-  --heatmap-5: oklch(0.78 0.12 250);
-  --sidebar: #0f0f0f;
-  --sidebar-foreground: #fafafa;
-  --sidebar-primary: #fafafa;
-  --sidebar-primary-foreground: #0a0a0a;
-  --sidebar-accent: #1a1a1a;
-  --sidebar-accent-foreground: #fafafa;
-  --sidebar-border: #262626;
-  --sidebar-ring: #404040;
+  /* — role colors (dark) — the values the app actually ships. */
+  --ds-bg: #141416;
+  --ds-surface: #1e1e21;
+  --ds-text: #f2f2f4;
+  --ds-accent: #ff563c;
+  --ds-accent-2: #ef6853;
+  --ds-divider: color-mix(in srgb, #f2f2f4 34%, transparent);
+
+  --ds-tint-accent-bg: color-mix(in srgb, var(--ds-accent-700) 45%, transparent);
+  --ds-tint-accent-fg: var(--ds-accent-200);
+  --ds-tint-accent-2-bg: color-mix(in srgb, var(--ds-accent-2-700) 45%, transparent);
+  --ds-tint-accent-2-fg: var(--ds-accent-2-200);
+  --ds-tint-neutral-bg: color-mix(in srgb, var(--ds-neutral-100) 12%, transparent);
+  --ds-tint-neutral-fg: var(--ds-neutral-200);
+
+  --ds-accent-hover: var(--ds-accent-400);
+  --ds-accent-active: var(--ds-accent-300);
+
+  --ds-shadow-sm: 0 1px 2px rgb(0 0 0 / 0.5);
+  --ds-shadow-md: 0 3px 10px rgb(0 0 0 / 0.55);
+  --ds-shadow-lg: 0 12px 32px rgb(0 0 0 / 0.6);
+  --ds-scrim: color-mix(in srgb, #000 62%, transparent);
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+   LAYER B — shadcn mapping
+   ──────────────────────────────────────────────────────────────────────────
+   The component tokens shadcn/ui and the app screens consume, expressed
+   entirely in terms of layer A. Nothing here holds a literal color.
+   ══════════════════════════════════════════════════════════════════════════ */
+
+:root {
+  --background: var(--ds-bg);
+  --foreground: var(--ds-text);
+  --card: var(--ds-surface);
+  --card-foreground: var(--ds-text);
+  --popover: var(--ds-surface);
+  --popover-foreground: var(--ds-text);
+
+  --primary: var(--ds-accent);
+  --primary-foreground: var(--ds-bg);
+
+  /* Secondary / muted surfaces sit one notch off the ground: a soft ink wash
+     rather than a second opaque gray, so they layer on cards and on the bg. */
+  --secondary: color-mix(in srgb, var(--ds-text) 8%, transparent);
+  --secondary-foreground: var(--ds-text);
+  --muted: color-mix(in srgb, var(--ds-text) 6%, transparent);
+  --muted-foreground: color-mix(in srgb, var(--ds-text) 58%, transparent);
+  --accent: color-mix(in srgb, var(--ds-text) 10%, transparent);
+  --accent-foreground: var(--ds-text);
+
+  --destructive: var(--ds-accent);
+  --destructive-foreground: var(--ds-bg);
+
+  /* Divider at full strength is right for the 2px structural rules; every
+     input and card edge in the mockups uses the same color, so --border keeps
+     it and components choose the weight. */
+  --border: var(--ds-divider);
+  --input: var(--ds-divider);
+  --ring: var(--ds-accent);
+
+  /* Charts: the analytics mockup's scale — data blue, its light and dark
+     variants, a neutral, and the status hues for pass/fail series. */
+  --chart-1: var(--ds-data);
+  --chart-2: var(--ds-data-light);
+  --chart-3: var(--ds-data-dark);
+  --chart-4: var(--ds-neutral-600);
+  --chart-5: var(--ds-status-warn);
+
+  /* Heatmap, re-based on the data hue. */
+  --heatmap-1: oklch(0.86 0.05 250);
+  --heatmap-2: oklch(0.75 0.09 250);
+  --heatmap-3: oklch(0.66 0.12 250);
+  --heatmap-4: oklch(0.55 0.11 254);
+  --heatmap-5: oklch(0.42 0.09 258);
+
+  --radius: 0.5rem;
+
+  --sidebar: var(--ds-surface);
+  --sidebar-foreground: var(--ds-text);
+  --sidebar-primary: var(--ds-accent);
+  --sidebar-primary-foreground: var(--ds-bg);
+  --sidebar-accent: color-mix(in srgb, var(--ds-text) 10%, transparent);
+  --sidebar-accent-foreground: var(--ds-text);
+  --sidebar-border: var(--ds-divider);
+  --sidebar-ring: var(--ds-accent);
+}
+
+.dark {
+  /* Dark inherits the whole mapping above through layer A; only the chart and
+     heatmap ends need re-ordering so the ramp climbs out of the dark ground. */
+  --heatmap-1: oklch(0.34 0.07 258);
+  --heatmap-2: oklch(0.46 0.1 254);
+  --heatmap-3: oklch(0.58 0.12 250);
+  --heatmap-4: oklch(0.69 0.11 248);
+  --heatmap-5: oklch(0.8 0.08 245);
 }
 
 @theme inline {
-  --font-sans: 'Geist', 'Geist Fallback';
-  --font-mono: 'Geist Mono', 'Geist Mono Fallback';
+  --font-sans: 'Archivo', 'Archivo Fallback', system-ui, sans-serif;
+  --font-mono: 'Geist Mono', 'Geist Mono Fallback', ui-monospace, 'SF Mono', Menlo, monospace;
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-card: var(--card);
@@ -119,10 +232,36 @@
   --color-chart-3: var(--chart-3);
   --color-chart-4: var(--chart-4);
   --color-chart-5: var(--chart-5);
-  --radius-sm: calc(var(--radius) - 4px);
-  --radius-md: calc(var(--radius) - 2px);
-  --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) + 4px);
+
+  /* First-class product tokens — these generate real utilities
+     (bg-status-ok, text-status-warn, border-data, bg-accent-2, …) so screens
+     never need a raw palette class or an inline style. */
+  --color-status-ok: var(--ds-status-ok);
+  --color-status-warn: var(--ds-status-warn);
+  --color-status-bad: var(--ds-status-bad);
+  --color-data: var(--ds-data);
+  --color-data-light: var(--ds-data-light);
+  --color-data-dark: var(--ds-data-dark);
+  --color-accent-2: var(--ds-accent-2);
+  --color-tint-accent: var(--ds-tint-accent-bg);
+  --color-tint-accent-foreground: var(--ds-tint-accent-fg);
+  --color-tint-accent-2: var(--ds-tint-accent-2-bg);
+  --color-tint-accent-2-foreground: var(--ds-tint-accent-2-fg);
+  --color-tint-neutral: var(--ds-tint-neutral-bg);
+  --color-tint-neutral-foreground: var(--ds-tint-neutral-fg);
+  --color-heatmap-1: var(--heatmap-1);
+  --color-heatmap-2: var(--heatmap-2);
+  --color-heatmap-3: var(--heatmap-3);
+  --color-heatmap-4: var(--heatmap-4);
+  --color-heatmap-5: var(--heatmap-5);
+
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+  --shadow-ds-sm: var(--ds-shadow-sm);
+  --shadow-ds-md: var(--ds-shadow-md);
+  --shadow-ds-lg: var(--ds-shadow-lg);
   --color-sidebar: var(--sidebar);
   --color-sidebar-foreground: var(--sidebar-foreground);
   --color-sidebar-primary: var(--sidebar-primary);
@@ -139,7 +278,34 @@
   }
   body {
     @apply bg-background text-foreground;
+    font-size: 15px;
+    line-height: 1.55;
   }
+  /* Modernist headings: Archivo 800, tight tracking. Set on the elements
+     themselves so Tailwind utilities (text-sm, font-normal, …) still win. */
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-family: var(--font-sans);
+    font-weight: 800;
+    letter-spacing: -0.015em;
+    line-height: 1.12;
+  }
+  ::selection {
+    background: color-mix(in srgb, var(--ds-accent) 30%, transparent);
+  }
+}
+
+/* Uppercase letter-spaced kicker — the small label above a section title or
+   in a card header. Used across the board, analytics and settings screens. */
+@utility kicker {
+  font-size: 10px;
+  line-height: 1.4;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
 }
 
 /* Hide scrollbars while keeping scroll functionality */

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,9 +1,13 @@
 import type { Metadata, Viewport } from 'next'
-import { Geist, Geist_Mono } from 'next/font/google'
+import { Archivo, Geist_Mono } from 'next/font/google'
 import { BrandingPageTitle } from '@/components/branding-page-title'
 import './globals.css'
 
-const _geist = Geist({ subsets: ["latin"] });
+// Modernist type: Archivo for everything (400 body, 600 emphasis, 800
+// headings), Geist Mono for agent names, steps and metrics. Loading them here
+// registers the 'Archivo' / 'Geist Mono' families that globals.css names in
+// its @theme block.
+const _archivo = Archivo({ subsets: ['latin'], weight: ['400', '600', '800'] });
 const _geistMono = Geist_Mono({ subsets: ["latin"] });
 
 // viewportFit: 'cover' makes env(safe-area-inset-*) non-zero on notched

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -6,6 +6,38 @@ import { getHubUrl } from "@/lib/hub-url"
 import { clearConfig } from "@/lib/api"
 import { setGitHubToken, setHubToken, getOAuthState, setOAuthState, removeOAuthState, getOAuthNext, setOAuthNext, removeOAuthNext } from "@/lib/auth-storage"
 import { useBranding } from "@/hooks/use-branding"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Field } from "@/components/ui/field"
+
+function GitHubMark() {
+  return (
+    <svg viewBox="0 0 16 16" className="size-4 fill-current" aria-hidden="true">
+      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
+    </svg>
+  )
+}
+
+// The auth card is shared by the loaded form and the Suspense fallback so both
+// states present the same 360px surface instead of one reflowing into the other.
+function AuthCard({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="grid h-screen place-items-center bg-background p-4">
+      <div className="w-full max-w-[360px] space-y-4 rounded-lg border border-border bg-card p-8">
+        {children}
+      </div>
+    </div>
+  )
+}
+
+function AuthHeading({ appName, caption }: { appName: string; caption: string }) {
+  return (
+    <div>
+      <h1 className="text-[26px]">{appName}</h1>
+      <p className="mt-1 text-sm text-muted-foreground">{caption}</p>
+    </div>
+  )
+}
 
 interface AuthConfig {
   github_oauth_enabled: boolean
@@ -179,70 +211,54 @@ function LoginForm() {
   const isCallback = !!searchParams.get("code")
 
   return (
-    <div className="flex h-screen bg-background items-center justify-center">
-      <div className="w-full max-w-sm space-y-6 p-8 border border-border rounded-xl bg-card">
-        <div className="space-y-1 text-center">
-          <h1 className="text-2xl font-semibold tracking-tight">{appName}</h1>
-          <p className="text-sm text-muted-foreground">
-            {isCallback ? "Completing sign-in…" : "Sign in to continue"}
-          </p>
-        </div>
+    <AuthCard>
+      <AuthHeading appName={appName} caption={isCallback ? "Completing sign-in…" : "Sign in to continue"} />
 
-        {isCallback && !error && (
-          <p className="text-center text-sm text-muted-foreground animate-pulse">Signing you in with GitHub…</p>
-        )}
+      {isCallback && !error && (
+        <p className="animate-pulse text-sm text-muted-foreground">Signing you in with GitHub…</p>
+      )}
 
-        {error && <p className="text-sm text-red-500 text-center">{error}</p>}
+      {error && <p className="text-sm text-destructive">{error}</p>}
 
-        {!isCallback && (
-          <>
-            {showGitHub && (
-              <button
-                type="button"
-                onClick={handleGitHubSignIn}
-                className="w-full flex items-center justify-center gap-2 rounded-md border border-border bg-background px-3 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground"
-              >
-                <svg viewBox="0 0 16 16" className="h-4 w-4 fill-current" aria-hidden="true">
-                  <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
-                </svg>
-                Sign in with GitHub
-              </button>
-            )}
+      {!isCallback && (
+        <>
+          {showGitHub && (
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleGitHubSignIn}
+              className="w-full justify-start"
+            >
+              <GitHubMark />
+              Sign in with GitHub
+            </Button>
+          )}
 
-            {showGitHub && showPassword && (
-              <div className="relative">
-                <div className="absolute inset-0 flex items-center">
-                  <span className="w-full border-t border-border" />
-                </div>
-                <div className="relative flex justify-center text-xs uppercase">
-                  <span className="bg-card px-2 text-muted-foreground">or</span>
-                </div>
-              </div>
-            )}
+          {showGitHub && showPassword && (
+            <div className="flex items-center gap-3 kicker text-muted-foreground before:h-0.5 before:flex-1 before:bg-border before:content-[''] after:h-0.5 after:flex-1 after:bg-border after:content-['']">
+              or
+            </div>
+          )}
 
-            {showPassword && (
-              <form onSubmit={handleSubmit} className="space-y-4">
-                <input
+          {showPassword && (
+            <form onSubmit={handleSubmit} className="space-y-3">
+              <Field>
+                <Input
                   type="password"
                   placeholder="Access token"
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
                   autoFocus={!showGitHub}
-                  className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
                 />
-                <button
-                  type="submit"
-                  disabled={loading || !password}
-                  className="w-full rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
-                >
-                  {loading ? "Signing in…" : "Sign in"}
-                </button>
-              </form>
-            )}
-          </>
-        )}
-      </div>
-    </div>
+              </Field>
+              <Button type="submit" disabled={loading || !password} className="w-full justify-start">
+                {loading ? "Signing in…" : "Sign in"}
+              </Button>
+            </form>
+          )}
+        </>
+      )}
+    </AuthCard>
   )
 }
 
@@ -250,14 +266,9 @@ function LoginFallback() {
   const { appName } = useBranding()
 
   return (
-    <div className="flex h-screen bg-background items-center justify-center">
-      <div className="w-full max-w-sm space-y-6 p-8 border border-border rounded-xl bg-card">
-        <div className="space-y-1 text-center">
-          <h1 className="text-2xl font-semibold tracking-tight">{appName}</h1>
-          <p className="text-sm text-muted-foreground">Loading…</p>
-        </div>
-      </div>
-    </div>
+    <AuthCard>
+      <AuthHeading appName={appName} caption="Loading…" />
+    </AuthCard>
   )
 }
 

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -382,19 +382,19 @@ export default function SettingsSectionPage() {
   return (
     <div className="h-screen bg-background flex flex-col overflow-hidden">
       {/* Header */}
-      <header className="border-b border-border px-6 py-4 flex items-center gap-4">
+      <header className="border-b-2 border-border px-6 py-4 flex items-center gap-4">
         <Button variant="ghost" size="icon" onClick={() => window.location.href = "/"}>
           <ChevronLeft className="size-4" />
         </Button>
-        <h1 className="text-lg font-semibold">Configure</h1>
+        <h1 className="text-lg">Configure</h1>
         {version && <span className="ml-auto text-xs text-muted-foreground font-mono">{version}</span>}
       </header>
 
       <div className="flex flex-1 min-h-0 overflow-hidden">
         {/* Left nav */}
-        <aside className="w-56 border-r border-border p-4 flex flex-col overflow-y-auto">
+        <aside className="w-56 border-r-2 border-sidebar-border bg-sidebar text-sidebar-foreground p-4 flex flex-col overflow-y-auto">
           <div className="relative mb-1">
-            <div className="pointer-events-none absolute left-3 top-1/2 z-10 flex size-5 -translate-y-1/2 items-center justify-center rounded bg-blue-600 text-[11px] font-semibold text-white shadow-sm">
+            <div className="pointer-events-none absolute left-3 top-1/2 z-10 flex size-5 -translate-y-1/2 items-center justify-center rounded-md bg-sidebar-primary text-[11px] font-extrabold text-sidebar-primary-foreground shadow-ds-sm">
               {selectedWorkspaceInitial}
             </div>
             <select
@@ -418,11 +418,9 @@ export default function SettingsSectionPage() {
             {navGroups.map((group, groupIdx) => (
               <div key={group.label}>
                 {groupIdx > 0 && <div className="h-5" />}
-                {groupIdx > 0 && (
-                  <p className="px-3 pb-1 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground/70">
+                <p className="px-3 pb-1 kicker">
                     {group.label}
-                  </p>
-                )}
+                </p>
                 {group.items.map(({ id, label, icon: Icon }) => (
                   <Link
                     key={id}
@@ -430,7 +428,7 @@ export default function SettingsSectionPage() {
                     className={cn(
                       "w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm transition-colors text-left",
                       section === id
-                        ? "bg-primary/10 text-primary font-medium"
+                        ? "bg-sidebar-accent text-sidebar-accent-foreground font-medium"
                         : "text-muted-foreground hover:bg-secondary hover:text-foreground"
                     )}
                   >
@@ -450,8 +448,8 @@ export default function SettingsSectionPage() {
 
         {/* Content */}
         <main className={(section === "ai-config" || section === "troubleshoot") ? "flex-1 min-h-0 flex flex-col overflow-hidden" : "flex-1 overflow-y-auto p-8 max-w-2xl"}>
-          {error && <p className="mb-4 text-sm text-red-500">{error}</p>}
-          {success && <p className="mb-4 text-sm text-green-500">{success}</p>}
+          {error && <p className="mb-4 text-sm text-destructive">{error}</p>}
+          {success && <p className="mb-4 text-sm text-status-ok">{success}</p>}
 
           {settings && section === "runtimes" && (
             <RuntimesSection settings={settings} onSave={save} saving={saving} />
@@ -729,7 +727,7 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
   return (
     <div className="space-y-6">
       <div>
-        <h2 className="text-base font-semibold mb-1">Sandbox Runtimes</h2>
+        <h2 className="text-base mb-1">Sandbox Runtimes</h2>
         <p className="text-sm text-muted-foreground mb-4">Configure VM providers for spawning agents.</p>
 
         <div className="flex items-center gap-2 mb-6">
@@ -756,12 +754,12 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
                   <div className="flex items-center gap-2">
                     <span className="text-sm font-medium">{p.label}</span>
                     {p.alpha && (
-                      <span className="text-xs bg-amber-500/20 text-amber-300 px-1.5 py-0.5 rounded">
+                      <span className="text-xs bg-status-warn/20 text-status-warn px-1.5 py-0.5 rounded">
                         Alpha
                       </span>
                     )}
                     {p.configured && (
-                      <span className="text-xs bg-green-500/20 text-green-400 px-1.5 py-0.5 rounded flex items-center gap-1">
+                      <span className="text-xs bg-status-ok/20 text-status-ok px-1.5 py-0.5 rounded flex items-center gap-1">
                         <CheckCircle2 className="size-3" /> Configured
                       </span>
                     )}
@@ -829,7 +827,7 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
         <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto p-0 gap-0">
           <DialogTitle className="sr-only">{modalTitle}</DialogTitle>
           <div className="flex items-center justify-between px-5 py-4 border-b border-border">
-            <h3 className="font-medium">{modalTitle}</h3>
+            <h3>{modalTitle}</h3>
           </div>
 
           <div className="p-5 space-y-4">
@@ -918,7 +916,7 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
                           setTimeout(() => setCopiedKey(false), 2000)
                         }}
                       >
-                        {copiedKey ? <Check className="size-3 text-green-500" /> : <Copy className="size-3" />}
+                        {copiedKey ? <Check className="size-3 text-status-ok" /> : <Copy className="size-3" />}
                       </Button>
                     </div>
                   ) : (
@@ -1003,9 +1001,9 @@ function RuntimesSection({ settings, onSave, saving }: { settings: SettingsData;
 
             {formProvider === "lambda-microvms" && (
               <>
-                <div className="bg-amber-500/10 border border-amber-500/20 rounded-lg p-3">
+                <div className="bg-status-warn/10 border border-status-warn/20 rounded-lg p-3">
                   <div className="flex items-center gap-2 mb-1">
-                    <span className="text-xs bg-amber-500/20 text-amber-300 px-1.5 py-0.5 rounded">Alpha</span>
+                    <span className="text-xs bg-status-warn/20 text-status-warn px-1.5 py-0.5 rounded">Alpha</span>
                     <p className="text-xs font-medium">AWS Lambda MicroVMs</p>
                   </div>
                   <p className="text-xs text-muted-foreground">
@@ -1280,8 +1278,8 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
 
   function renderLoginWindow(win: Window, text: string) {
     win.document.body.style.margin = "0"
-    win.document.body.style.background = "#0a0a0a"
-    win.document.body.style.color = "#f5f5f5"
+    win.document.body.style.background = "#141416"
+    win.document.body.style.color = "#f2f2f4"
     win.document.body.style.fontFamily = "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace"
     win.document.body.style.whiteSpace = "pre-wrap"
     win.document.body.style.padding = "24px"
@@ -1352,7 +1350,7 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
   return (
     <div className="space-y-6">
       <div>
-        <h2 className="text-base font-semibold mb-1">Models</h2>
+        <h2 className="text-base mb-1">Models</h2>
         <p className="text-sm text-muted-foreground mb-4">
           API keys for LLM providers. The default key is used unless overridden by a workflow.
         </p>
@@ -1362,7 +1360,7 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
             {llmKeys.length} key{llmKeys.length !== 1 ? "s" : ""} configured
           </span>
           {needsAttention > 0 && (
-            <span className="text-xs bg-red-500/10 text-red-400 border border-red-500/20 px-2 py-1 rounded font-medium flex items-center gap-1">
+            <span className="text-xs bg-destructive/10 text-destructive border border-destructive/20 px-2 py-1 rounded font-medium flex items-center gap-1">
               <AlertTriangle className="size-3" /> {needsAttention} need{needsAttention !== 1 ? "" : "s"} attention
             </span>
           )}
@@ -1372,7 +1370,7 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
       {/* Needs Attention */}
       {needsAttention > 0 && (
         <div>
-          <p className="text-sm font-medium text-yellow-400 mb-2 flex items-center gap-1.5">
+          <p className="text-sm font-medium text-status-warn mb-2 flex items-center gap-1.5">
             <AlertTriangle className="size-4" /> Needs Attention
           </p>
           <div className="space-y-2">
@@ -1380,7 +1378,7 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
               <div
                 key={k.name}
                 onClick={() => openEdit(llmKeys.indexOf(k))}
-                className="border border-red-500/20 rounded-lg p-3 flex items-center justify-between cursor-pointer hover:bg-red-500/5 transition-colors"
+                className="border border-destructive/20 rounded-lg p-3 flex items-center justify-between cursor-pointer hover:bg-destructive/5 transition-colors"
               >
                 <div className="flex items-center gap-3">
                   <div className="w-8 h-8 rounded-lg bg-muted flex items-center justify-center">
@@ -1397,7 +1395,7 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
                       ) : (
                         <span className="text-xs text-muted-foreground">using provider default</span>
                       )}
-                      <span className="text-xs text-red-400 flex items-center gap-1">✕ Invalid</span>
+                      <span className="text-xs text-destructive flex items-center gap-1">✕ Invalid</span>
                     </div>
                   </div>
                 </div>
@@ -1443,7 +1441,7 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
                       ) : (
                         <span className="text-xs text-muted-foreground">using provider default</span>
                       )}
-                      <span className="text-xs text-green-400 flex items-center gap-1">✓ Valid</span>
+                      <span className="text-xs text-status-ok flex items-center gap-1">✓ Valid</span>
                     </div>
                   </div>
                 </div>
@@ -1476,7 +1474,7 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
         <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto p-0 gap-0">
           <DialogTitle className="sr-only">{modalMode === "add" ? "Add Model Key" : `Edit ${formName}`}</DialogTitle>
           <div className="flex items-center justify-between px-5 py-4 border-b border-border">
-            <h3 className="font-medium">{modalMode === "add" ? "Add Model Key" : `Edit ${formName}`}</h3>
+            <h3>{modalMode === "add" ? "Add Model Key" : `Edit ${formName}`}</h3>
           </div>
 
           <div className="p-5 space-y-4">
@@ -1552,7 +1550,7 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
                               <div className="font-mono text-lg font-semibold tracking-wide text-foreground">{loginJob.code}</div>
                             </div>
                             <Button type="button" size="sm" variant="outline" className="h-8 shrink-0 gap-1.5" onClick={() => copyLoginCode(loginJob.code || "")}>
-                              {copiedLoginCode ? <Check className="size-3.5 text-green-500" /> : <Copy className="size-3.5" />}
+                              {copiedLoginCode ? <Check className="size-3.5 text-status-ok" /> : <Copy className="size-3.5" />}
                               {copiedLoginCode ? "Copied" : "Copy"}
                             </Button>
                           </div>
@@ -1561,11 +1559,11 @@ function LLMSection({ settings, onSave, saving }: { settings: SettingsData; onSa
                       {!loginJob.code && loginJob.output && (
                         <pre className="max-h-24 overflow-auto whitespace-pre-wrap break-words rounded border border-border bg-background/60 p-2 text-[11px] text-muted-foreground">{loginJob.output}</pre>
                       )}
-                      {loginJob.error && <div className="text-red-400">{loginJob.error}</div>}
-                      {loginJob.status === "complete" && <div className="text-green-400">Profile saved. Save this model key to use it.</div>}
+                      {loginJob.error && <div className="text-destructive">{loginJob.error}</div>}
+                      {loginJob.status === "complete" && <div className="text-status-ok">Profile saved. Save this model key to use it.</div>}
                     </div>
                   )}
-                  {loginError && <div className="text-xs text-red-400">{loginError}</div>}
+                  {loginError && <div className="text-xs text-destructive">{loginError}</div>}
                 </div>
               )}
               <div>
@@ -1765,7 +1763,7 @@ function GitHubSection({ settings, onSave, saving, workspace }: { settings: Sett
 
   return (
     <div>
-      <h2 className="text-base font-semibold mb-1">GitHub Apps</h2>
+      <h2 className="text-base mb-1">GitHub Apps</h2>
       <div className="text-sm text-muted-foreground mb-6 space-y-1.5">
         <p>
           Register a GitHub App so your {brandName} workflows can access repositories.
@@ -1802,7 +1800,7 @@ function GitHubSection({ settings, onSave, saving, workspace }: { settings: Sett
                     {app.installation && <p className="text-xs text-muted-foreground">Installation: {app.installation}</p>}
                   </div>
                   <div className="flex items-center gap-2">
-                    <span className={cn("text-xs px-2 py-1 rounded", (app.privateKeySet || app.private_key_set) ? "bg-green-500/20 text-green-400" : "bg-yellow-500/20 text-yellow-400")}>
+                    <span className={cn("text-xs px-2 py-1 rounded", (app.privateKeySet || app.private_key_set) ? "bg-status-ok/20 text-status-ok" : "bg-status-warn/20 text-status-warn")}>
                       {(app.privateKeySet || app.private_key_set) ? "Key set" : "No key"}
                     </span>
                     <Button size="sm" variant="ghost" className="text-destructive hover:text-destructive h-7 px-2" disabled={saving}
@@ -1829,7 +1827,7 @@ function GitHubSection({ settings, onSave, saving, workspace }: { settings: Sett
                   )}
                 </div>
                 <div className="flex items-center gap-2">
-                  <span className={cn("text-xs px-2 py-1 rounded", app.keySet ? "bg-green-500/20 text-green-400" : "bg-yellow-500/20 text-yellow-400")}>
+                  <span className={cn("text-xs px-2 py-1 rounded", app.keySet ? "bg-status-ok/20 text-status-ok" : "bg-status-warn/20 text-status-warn")}>
                     {app.keySet ? "Key set" : "No key"}
                   </span>
                   <Button size="sm" variant="ghost" className="text-destructive hover:text-destructive h-7 px-2" disabled={saving}
@@ -1848,25 +1846,25 @@ function GitHubSection({ settings, onSave, saving, workspace }: { settings: Sett
 
               {/* Permission check results */}
               {app.permCheckError && (
-                <div className="mt-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20 px-3 py-2.5 flex items-start gap-2">
-                  <AlertTriangle className="size-4 text-yellow-400 shrink-0 mt-0.5" />
+                <div className="mt-3 rounded-lg bg-status-warn/10 border border-status-warn/20 px-3 py-2.5 flex items-start gap-2">
+                  <AlertTriangle className="size-4 text-status-warn shrink-0 mt-0.5" />
                   <div>
-                    <p className="text-xs font-medium text-yellow-400">Permission check failed</p>
-                    <p className="text-xs text-yellow-400/80">{app.permCheckError}</p>
+                    <p className="text-xs font-medium text-status-warn">Permission check failed</p>
+                    <p className="text-xs text-status-warn/80">{app.permCheckError}</p>
                   </div>
                 </div>
               )}
               {app.permissions && app.permissions.length > 0 && (
                 <div className="mt-3">
                   {app.permCheckOk === false && (
-                    <div className="rounded-lg bg-yellow-500/10 border border-yellow-500/20 px-3 py-2.5 mb-2 flex items-center justify-between">
+                    <div className="rounded-lg bg-status-warn/10 border border-status-warn/20 px-3 py-2.5 mb-2 flex items-center justify-between">
                       <div className="flex items-center gap-2">
-                        <Shield className="size-4 text-yellow-400" />
+                        <Shield className="size-4 text-status-warn" />
                         <div>
-                          <p className="text-xs font-medium text-yellow-400">
+                          <p className="text-xs font-medium text-status-warn">
                             {app.permissions.filter(p => !p.ok).length} permission{app.permissions.filter(p => !p.ok).length !== 1 ? "s" : ""} need attention
                           </p>
-                          <p className="text-xs text-yellow-400/70">
+                          <p className="text-xs text-status-warn/70">
                             {app.permissions.filter(p => p.ok).length} of {app.permissions.length} required permissions granted
                           </p>
                         </div>
@@ -1892,15 +1890,15 @@ function GitHubSection({ settings, onSave, saving, workspace }: { settings: Sett
                       <div className="mt-2 space-y-1">
                         <p className="text-[10px] uppercase tracking-wider text-muted-foreground/60 font-medium">Needs Attention</p>
                         {app.permissions.filter(p => !p.ok).map(p => (
-                          <div key={p.name} className="flex items-center justify-between rounded-lg bg-yellow-500/10 border border-yellow-500/20 px-3 py-2">
+                          <div key={p.name} className="flex items-center justify-between rounded-lg bg-status-warn/10 border border-status-warn/20 px-3 py-2">
                             <div className="flex items-center gap-2">
-                              <AlertTriangle className="size-3.5 text-yellow-400" />
-                              <span className="text-sm font-mono text-yellow-400">{p.name}</span>
+                              <AlertTriangle className="size-3.5 text-status-warn" />
+                              <span className="text-sm font-mono text-status-warn">{p.name}</span>
                             </div>
                             <div className="flex items-center gap-1.5 text-xs">
-                              <span className="px-1.5 py-0.5 rounded bg-yellow-500/20 text-yellow-400">{p.granted || "not set"}</span>
+                              <span className="px-1.5 py-0.5 rounded bg-status-warn/20 text-status-warn">{p.granted || "not set"}</span>
                               <span className="text-muted-foreground">→</span>
-                              <span className="px-1.5 py-0.5 rounded border border-yellow-500/30 text-yellow-400">needs {p.needed}</span>
+                              <span className="px-1.5 py-0.5 rounded border border-status-warn/30 text-status-warn">needs {p.needed}</span>
                             </div>
                           </div>
                         ))}
@@ -1911,12 +1909,12 @@ function GitHubSection({ settings, onSave, saving, workspace }: { settings: Sett
                       <div className="mt-2 space-y-1">
                         <p className="text-[10px] uppercase tracking-wider text-muted-foreground/60 font-medium">Configured</p>
                         {app.permissions.filter(p => p.ok).map(p => (
-                          <div key={p.name} className="flex items-center justify-between rounded-lg bg-green-500/10 border border-green-500/20 px-3 py-2">
+                          <div key={p.name} className="flex items-center justify-between rounded-lg bg-status-ok/10 border border-status-ok/20 px-3 py-2">
                             <div className="flex items-center gap-2">
-                              <CheckCircle2 className="size-3.5 text-green-400" />
-                              <span className="text-sm font-mono text-green-400">{p.name}</span>
+                              <CheckCircle2 className="size-3.5 text-status-ok" />
+                              <span className="text-sm font-mono text-status-ok">{p.name}</span>
                             </div>
-                            <span className="text-xs px-1.5 py-0.5 rounded bg-green-500/20 text-green-400">{p.granted}</span>
+                            <span className="text-xs px-1.5 py-0.5 rounded bg-status-ok/20 text-status-ok">{p.granted}</span>
                           </div>
                         ))}
                       </div>
@@ -1938,7 +1936,7 @@ function GitHubSection({ settings, onSave, saving, workspace }: { settings: Sett
         <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto p-0 gap-0">
           <DialogTitle className="sr-only">Add GitHub App</DialogTitle>
           <div className="flex items-center justify-between px-5 py-4 border-b border-border">
-            <h3 className="font-medium">Add GitHub App</h3>
+            <h3>Add GitHub App</h3>
           </div>
 
           <div className="p-5 space-y-4">
@@ -1982,9 +1980,9 @@ function GitHubSection({ settings, onSave, saving, workspace }: { settings: Sett
               </div>
 
               {testError && (
-                <div className="rounded-lg bg-red-500/10 border border-red-500/20 px-3 py-2.5 flex items-start gap-2">
-                  <AlertTriangle className="size-4 text-red-400 shrink-0 mt-0.5" />
-                  <p className="text-xs text-red-400">{testError}</p>
+                <div className="rounded-lg bg-destructive/10 border border-destructive/20 px-3 py-2.5 flex items-start gap-2">
+                  <AlertTriangle className="size-4 text-destructive shrink-0 mt-0.5" />
+                  <p className="text-xs text-destructive">{testError}</p>
                 </div>
               )}
 
@@ -1993,11 +1991,11 @@ function GitHubSection({ settings, onSave, saving, workspace }: { settings: Sett
                 <div className="space-y-3">
                   {/* permCheckOk is true — all good */}
                   {testResult.permCheckOk === true && (
-                    <div className="rounded-lg bg-green-500/10 border border-green-500/20 px-3 py-2.5 flex items-center gap-2">
-                      <CheckCircle2 className="size-4 text-green-400" />
+                    <div className="rounded-lg bg-status-ok/10 border border-status-ok/20 px-3 py-2.5 flex items-center gap-2">
+                      <CheckCircle2 className="size-4 text-status-ok" />
                       <div>
-                        <p className="text-xs font-medium text-green-400">All {totalCount} required permissions granted</p>
-                        <p className="text-xs text-green-400/70">This GitHub App is ready to use.</p>
+                        <p className="text-xs font-medium text-status-ok">All {totalCount} required permissions granted</p>
+                        <p className="text-xs text-status-ok/70">This GitHub App is ready to use.</p>
                       </div>
                     </div>
                   )}
@@ -2006,19 +2004,19 @@ function GitHubSection({ settings, onSave, saving, workspace }: { settings: Sett
                   {(testResult.permCheckOk === false || testResult.permCheckOk == null) && (
                     <>
                       {testResult.permCheckError ? (
-                        <div className="rounded-lg bg-yellow-500/10 border border-yellow-500/20 px-3 py-2.5 flex items-start gap-2">
-                          <AlertTriangle className="size-4 text-yellow-400 shrink-0 mt-0.5" />
-                          <p className="text-xs text-yellow-400">{testResult.permCheckError}</p>
+                        <div className="rounded-lg bg-status-warn/10 border border-status-warn/20 px-3 py-2.5 flex items-start gap-2">
+                          <AlertTriangle className="size-4 text-status-warn shrink-0 mt-0.5" />
+                          <p className="text-xs text-status-warn">{testResult.permCheckError}</p>
                         </div>
                       ) : (
-                        <div className="rounded-lg bg-yellow-500/10 border border-yellow-500/20 px-3 py-2.5 flex items-center justify-between">
+                        <div className="rounded-lg bg-status-warn/10 border border-status-warn/20 px-3 py-2.5 flex items-center justify-between">
                           <div className="flex items-center gap-2">
-                            <Shield className="size-4 text-yellow-400" />
+                            <Shield className="size-4 text-status-warn" />
                             <div>
-                              <p className="text-xs font-medium text-yellow-400">
+                              <p className="text-xs font-medium text-status-warn">
                                 {needsAttention} permission{needsAttention !== 1 ? "s" : ""} need attention
                               </p>
-                              <p className="text-xs text-yellow-400/70">
+                              <p className="text-xs text-status-warn/70">
                                 {configuredCount} of {totalCount} required permissions granted
                               </p>
                             </div>
@@ -2042,15 +2040,15 @@ function GitHubSection({ settings, onSave, saving, workspace }: { settings: Sett
                         <>
                           <p className="text-[10px] uppercase tracking-wider text-muted-foreground/60 font-medium">Needs Attention</p>
                           {testResult.permissions.filter(p => !p.ok).map(p => (
-                            <div key={p.name} className="flex items-center justify-between rounded-lg bg-yellow-500/10 border border-yellow-500/20 px-3 py-2">
+                            <div key={p.name} className="flex items-center justify-between rounded-lg bg-status-warn/10 border border-status-warn/20 px-3 py-2">
                               <div className="flex items-center gap-2">
-                                <AlertTriangle className="size-3.5 text-yellow-400" />
-                                <span className="text-sm font-mono text-yellow-400">{p.name}</span>
+                                <AlertTriangle className="size-3.5 text-status-warn" />
+                                <span className="text-sm font-mono text-status-warn">{p.name}</span>
                               </div>
                               <div className="flex items-center gap-1.5 text-xs">
-                                <span className="px-1.5 py-0.5 rounded bg-yellow-500/20 text-yellow-400">{p.granted || "not set"}</span>
+                                <span className="px-1.5 py-0.5 rounded bg-status-warn/20 text-status-warn">{p.granted || "not set"}</span>
                                 <span className="text-muted-foreground">→</span>
-                                <span className="px-1.5 py-0.5 rounded border border-yellow-500/30 text-yellow-400">needs {p.needed}</span>
+                                <span className="px-1.5 py-0.5 rounded border border-status-warn/30 text-status-warn">needs {p.needed}</span>
                               </div>
                             </div>
                           ))}
@@ -2060,12 +2058,12 @@ function GitHubSection({ settings, onSave, saving, workspace }: { settings: Sett
                         <>
                           <p className="text-[10px] uppercase tracking-wider text-muted-foreground/60 font-medium mt-2">Configured</p>
                           {testResult.permissions.filter(p => p.ok).map(p => (
-                            <div key={p.name} className="flex items-center justify-between rounded-lg bg-green-500/10 border border-green-500/20 px-3 py-2">
+                            <div key={p.name} className="flex items-center justify-between rounded-lg bg-status-ok/10 border border-status-ok/20 px-3 py-2">
                               <div className="flex items-center gap-2">
-                                <CheckCircle2 className="size-3.5 text-green-400" />
-                                <span className="text-sm font-mono text-green-400">{p.name}</span>
+                                <CheckCircle2 className="size-3.5 text-status-ok" />
+                                <span className="text-sm font-mono text-status-ok">{p.name}</span>
                               </div>
-                              <span className="text-xs px-1.5 py-0.5 rounded bg-green-500/20 text-green-400">{p.granted}</span>
+                              <span className="text-xs px-1.5 py-0.5 rounded bg-status-ok/20 text-status-ok">{p.granted}</span>
                             </div>
                           ))}
                         </>
@@ -2093,8 +2091,8 @@ function GitHubSection({ settings, onSave, saving, workspace }: { settings: Sett
             {testResult === null ? (
               <>
                 <div className="flex items-center gap-2">
-                  <AlertTriangle className="size-5 text-yellow-400" />
-                  <h3 className="font-medium">Test Recommended</h3>
+                  <AlertTriangle className="size-5 text-status-warn" />
+                  <h3>Test Recommended</h3>
                 </div>
                 <p className="text-sm text-muted-foreground">
                   You haven&apos;t tested this GitHub App yet. We recommend clicking <strong>Test Permissions</strong> first to verify it works.
@@ -2103,14 +2101,14 @@ function GitHubSection({ settings, onSave, saving, workspace }: { settings: Sett
             ) : (
               <>
                 <div className="flex items-center gap-2">
-                  <AlertTriangle className="size-5 text-yellow-400" />
-                  <h3 className="font-medium">Permissions Missing</h3>
+                  <AlertTriangle className="size-5 text-status-warn" />
+                  <h3>Permissions Missing</h3>
                 </div>
                 <p className="text-sm text-muted-foreground">
                   This GitHub App is missing required permissions. It <strong>will not work</strong> for agents until fixed.
                 </p>
                 {testResult.permCheckError && (
-                  <p className="text-xs text-yellow-400 bg-yellow-500/10 rounded px-2 py-1.5">{testResult.permCheckError}</p>
+                  <p className="text-xs text-status-warn bg-status-warn/10 rounded px-2 py-1.5">{testResult.permCheckError}</p>
                 )}
               </>
             )}
@@ -2214,7 +2212,7 @@ function AuthenticationSection({ settings, onSave, saving }: { settings: Setting
   return (
     <div className="space-y-6">
       <div>
-        <h2 className="text-base font-semibold mb-0.5">Authentication</h2>
+        <h2 className="text-base mb-0.5">Authentication</h2>
         <p className="text-sm text-muted-foreground">Both methods can be active simultaneously. GitHub OAuth users and password users both have full access unless tag-based restrictions are configured.</p>
       </div>
 
@@ -2222,14 +2220,14 @@ function AuthenticationSection({ settings, onSave, saving }: { settings: Setting
       <div className="border border-border rounded-lg p-5 space-y-3 max-w-lg">
         <div className="flex items-center justify-between">
           <div>
-            <h3 className="text-sm font-medium">Password Login</h3>
+            <h3 className="text-sm ">Password Login</h3>
             <p className="text-xs text-muted-foreground mt-0.5">
               {settings.auth?.disablePasswordAuth ? 'Disabled — GitHub OAuth only.' : 'Enabled. Used by the hub token and UI password.'}
             </p>
           </div>
           {settings.auth?.disablePasswordAuth
             ? <span className="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded font-medium">Disabled</span>
-            : <span className="text-xs bg-green-500/20 text-green-400 px-2 py-0.5 rounded font-medium">Active</span>
+            : <span className="text-xs bg-status-ok/20 text-status-ok px-2 py-0.5 rounded font-medium">Active</span>
           }
         </div>
 
@@ -2249,7 +2247,7 @@ function AuthenticationSection({ settings, onSave, saving }: { settings: Setting
               )}
             >
               <span className={cn(
-                'pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow-lg transform transition-transform',
+                'pointer-events-none inline-block h-4 w-4 rounded-full bg-background shadow-lg transform transition-transform',
                 settings.auth?.disablePasswordAuth ? 'translate-x-4' : 'translate-x-0'
               )} />
             </button>
@@ -2266,7 +2264,7 @@ function AuthenticationSection({ settings, onSave, saving }: { settings: Setting
               <label className="text-xs text-muted-foreground mb-1 block">Confirm Password</label>
               <Input type="password" value={pwConfirm} onChange={e => setPwConfirm(e.target.value)} className="h-8 text-sm" placeholder="Repeat password" />
             </div>
-            {pwErr && <p className="text-xs text-red-500">{pwErr}</p>}
+            {pwErr && <p className="text-xs text-destructive">{pwErr}</p>}
             <Button size="sm" disabled={saving || !newPw || !pwConfirm} onClick={handlePasswordSave}>
               Change Password
             </Button>
@@ -2278,11 +2276,11 @@ function AuthenticationSection({ settings, onSave, saving }: { settings: Setting
       <div className="border border-border rounded-lg p-5 space-y-3 max-w-lg">
         <div className="flex items-center justify-between">
           <div>
-            <h3 className="text-sm font-medium">GitHub OAuth</h3>
+            <h3 className="text-sm ">GitHub OAuth</h3>
             <p className="text-xs text-muted-foreground mt-0.5">Let users log in with their GitHub account.</p>
           </div>
           {ghOAuth
-            ? <span className="text-xs bg-green-500/20 text-green-400 px-2 py-0.5 rounded font-medium">Active</span>
+            ? <span className="text-xs bg-status-ok/20 text-status-ok px-2 py-0.5 rounded font-medium">Active</span>
             : <span className="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded font-medium">Inactive</span>
           }
         </div>
@@ -2314,14 +2312,14 @@ function AuthenticationSection({ settings, onSave, saving }: { settings: Setting
             )}
 
             <div className="space-y-3">
-              <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">App Credentials</h4>
+              <h4 className="text-xs text-muted-foreground uppercase tracking-wide">App Credentials</h4>
               <div>
                 <label className="text-xs text-muted-foreground mb-1 block">Client ID</label>
                 <Input value={clientId} onChange={e => setClientId(e.target.value)} className="h-8 text-sm font-mono" placeholder="Ov23li..." />
               </div>
               <div>
                 <label className="text-xs text-muted-foreground mb-1 block">
-                  Client Secret{ghOAuth?.clientSecretSet && <span className="ml-1 text-green-500">(set)</span>}
+                  Client Secret{ghOAuth?.clientSecretSet && <span className="ml-1 text-status-ok">(set)</span>}
                 </label>
                 <Input
                   type="password"
@@ -2334,7 +2332,7 @@ function AuthenticationSection({ settings, onSave, saving }: { settings: Setting
             </div>
 
             <div className="space-y-3">
-              <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Allowlist <span className="normal-case font-normal">(leave blank = any GitHub user)</span></h4>
+              <h4 className="text-xs text-muted-foreground uppercase tracking-wide">Allowlist <span className="normal-case font-normal">(leave blank = any GitHub user)</span></h4>
               <div>
                 <label className="text-xs text-muted-foreground mb-1 block">Usernames</label>
                 <Input value={allowedUsers} onChange={e => setAllowedUsers(e.target.value)} className="h-8 text-sm" placeholder="alice, bob" />
@@ -2350,7 +2348,7 @@ function AuthenticationSection({ settings, onSave, saving }: { settings: Setting
             </div>
 
             <div className="space-y-3">
-              <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Admins</h4>
+              <h4 className="text-xs text-muted-foreground uppercase tracking-wide">Admins</h4>
               <div>
                 <label className="text-xs text-muted-foreground mb-1 block">GitHub Usernames</label>
                 <Input value={admins} onChange={e => setAdmins(e.target.value)} className="h-8 text-sm" placeholder="alice, bob" />
@@ -2359,7 +2357,7 @@ function AuthenticationSection({ settings, onSave, saving }: { settings: Setting
             </div>
 
             <div className="space-y-3">
-              <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Tag-Based Access Control <span className="normal-case font-normal">(optional)</span></h4>
+              <h4 className="text-xs text-muted-foreground uppercase tracking-wide">Tag-Based Access Control <span className="normal-case font-normal">(optional)</span></h4>
               <div>
                 <label className="text-xs text-muted-foreground mb-1 block">View requires tag</label>
                 <Input value={viewTags} onChange={e => setViewTags(e.target.value)} className="h-8 text-sm font-mono" placeholder="user, team=frontend" />
@@ -2371,7 +2369,7 @@ function AuthenticationSection({ settings, onSave, saving }: { settings: Setting
               </div>
             </div>
 
-            {ghErr && <p className="text-xs text-red-500">{ghErr}</p>}
+            {ghErr && <p className="text-xs text-destructive">{ghErr}</p>}
 
             <div className="flex gap-2">
               <Button size="sm" disabled={saving} onClick={handleGitHubSave}>
@@ -2586,9 +2584,9 @@ function IntegrationsSection({ settings, onSave, saving, selectedWorkspace, hubP
   const modalIcon = (modalMode === "add" ? modalType : editType) === "linear"
     ? <Zap className="size-4" />
     : (modalMode === "add" ? modalType : editType) === "shortcut"
-    ? <span className="text-[#F4603C]">⚡</span>
+    ? <span className="text-primary">⚡</span>
     : (modalMode === "add" ? modalType : editType) === "jira"
-    ? <span className="text-[#0052CC] font-semibold text-sm">J</span>
+    ? <span className="text-data font-semibold text-sm">J</span>
     : <Github className="size-4" />
 
   const githubIssuesTokenParams = new URLSearchParams({
@@ -2634,7 +2632,7 @@ function IntegrationsSection({ settings, onSave, saving, selectedWorkspace, hubP
   return (
     <div className="space-y-6">
       <div>
-        <h2 className="text-base font-semibold mb-1">Issue Trackers</h2>
+        <h2 className="text-base mb-1">Issue Trackers</h2>
         <p className="text-sm text-muted-foreground mb-4">Connect issue trackers to sync and create issues from workflows.</p>
 
         {/* Summary badges */}
@@ -2674,9 +2672,9 @@ function IntegrationsSection({ settings, onSave, saving, selectedWorkspace, hubP
                 {tracker.type === "linear" ? (
                   <Zap className="size-4 text-muted-foreground" />
                 ) : tracker.type === "shortcut" ? (
-                  <span className="text-[#F4603C]">⚡</span>
+                  <span className="text-primary">⚡</span>
                 ) : tracker.type === "jira" ? (
-                  <span className="text-[#0052CC] font-semibold text-sm">J</span>
+                  <span className="text-data font-semibold text-sm">J</span>
                 ) : (
                   <Github className="size-4 text-muted-foreground" />
                 )}
@@ -2692,11 +2690,11 @@ function IntegrationsSection({ settings, onSave, saving, selectedWorkspace, hubP
                     ) : null}
                     <span className="text-xs text-muted-foreground">·</span>
                     {tracker.tokenSet ? (
-                      <span className="text-xs text-green-400 flex items-center gap-1">
+                      <span className="text-xs text-status-ok flex items-center gap-1">
                         <CheckCircle2 className="size-3" /> Connected
                       </span>
                     ) : (
-                      <span className="text-xs text-red-400 flex items-center gap-1">
+                      <span className="text-xs text-destructive flex items-center gap-1">
                         <AlertTriangle className="size-3" /> Token revoked
                       </span>
                     )}
@@ -2736,7 +2734,7 @@ function IntegrationsSection({ settings, onSave, saving, selectedWorkspace, hubP
               onClick={() => openAdd("shortcut")}
               className="w-full flex items-center gap-2 px-3 py-2 text-sm hover:bg-muted transition-colors text-left"
             >
-              <span className="text-[#F4603C]">⚡</span>
+              <span className="text-primary">⚡</span>
               <span>Shortcut</span>
             </button>
             <button
@@ -2750,7 +2748,7 @@ function IntegrationsSection({ settings, onSave, saving, selectedWorkspace, hubP
               onClick={() => openAdd("jira")}
               className="w-full flex items-center gap-2 px-3 py-2 text-sm hover:bg-muted transition-colors text-left"
             >
-              <span className="text-[#0052CC] font-semibold text-sm">J</span>
+              <span className="text-data font-semibold text-sm">J</span>
               <span>Jira</span>
             </button>
           </div>
@@ -2764,7 +2762,7 @@ function IntegrationsSection({ settings, onSave, saving, selectedWorkspace, hubP
           <div className="flex items-center justify-between px-5 py-4 border-b border-border">
             <div className="flex items-center gap-2">
               {modalIcon}
-              <h3 className="font-medium">{modalTitle}</h3>
+              <h3>{modalTitle}</h3>
             </div>
           </div>
           <div className="p-5 space-y-4">
@@ -2803,7 +2801,7 @@ function IntegrationsSection({ settings, onSave, saving, selectedWorkspace, hubP
                     {setupTab === "token" ? (
                     <div className="mt-4 space-y-4">
                       <div>
-                        <h4 className="text-sm font-medium">{activeTrackerType === "github-issues" ? "GitHub PAT" : "Linear API Token"}</h4>
+                        <h4 className="text-sm ">{activeTrackerType === "github-issues" ? "GitHub PAT" : "Linear API Token"}</h4>
                         <p className="text-xs text-muted-foreground mt-1">
                           {activeTrackerType === "github-issues"
                             ? `Used by ${appName} to read and update issues.`
@@ -2819,7 +2817,7 @@ function IntegrationsSection({ settings, onSave, saving, selectedWorkspace, hubP
                     ) : (
                     <div className="mt-4 space-y-4">
                       <div>
-                        <h4 className="text-sm font-medium">Webhook</h4>
+                        <h4 className="text-sm ">Webhook</h4>
                         <p className="text-xs text-muted-foreground mt-1">
                           {activeTrackerType === "github-issues"
                             ? "Create a repo or org webhook for Issues events."
@@ -2994,7 +2992,7 @@ function WebhooksSection({ hubUrl, selectedWorkspace }: { hubUrl: string; select
   return (
     <div className="space-y-6">
       <div>
-        <h2 className="text-base font-semibold mb-1">Webhooks</h2>
+        <h2 className="text-base mb-1">Webhooks</h2>
         <p className="text-sm text-muted-foreground mb-6">
           Use these URLs to send events into the selected workspace.
         </p>
@@ -3004,7 +3002,7 @@ function WebhooksSection({ hubUrl, selectedWorkspace }: { hubUrl: string; select
         {urls.map(({ name, url, hint }) => (
           <div key={name} className="border border-border rounded-lg p-4 space-y-3">
             <div>
-              <h4 className="text-sm font-medium">{name}</h4>
+              <h4 className="text-sm ">{name}</h4>
               <p className="text-xs text-muted-foreground mt-1">{hint}</p>
             </div>
             <div className="flex items-center gap-2">
@@ -3012,7 +3010,7 @@ function WebhooksSection({ hubUrl, selectedWorkspace }: { hubUrl: string; select
                 {url || "Loading…"}
               </code>
               <Button variant="outline" size="sm" className="shrink-0" onClick={() => doCopy(url, name)} disabled={!url}>
-                {copied === name ? <Check className="size-3.5 text-green-500" /> : <Copy className="size-3.5" />}
+                {copied === name ? <Check className="size-3.5 text-status-ok" /> : <Copy className="size-3.5" />}
                 <span className="ml-1.5">{copied === name ? "Copied" : "Copy"}</span>
               </Button>
             </div>
@@ -3045,7 +3043,7 @@ function WorkspacesSection({ selectedWorkspace }: { selectedWorkspace: string })
   return (
     <div className="space-y-6">
       {error && (
-        <div className="text-sm text-red-500 bg-red-500/10 border border-red-500/20 rounded-md px-3 py-2">
+        <div className="text-sm text-destructive bg-destructive/10 border border-destructive/20 rounded-md px-3 py-2">
           {error}
         </div>
       )}
@@ -3060,7 +3058,7 @@ function WorkspacesSection({ selectedWorkspace }: { selectedWorkspace: string })
         <div className="space-y-4">
           {visibleWorkspaces.map((workspace) => (
             <div key={workspace.name} className="space-y-4">
-              <h2 className="text-base font-semibold">{workspace.name}</h2>
+              <h2 className="text-base ">{workspace.name}</h2>
               <div className="overflow-hidden rounded-md border border-border bg-muted/40">
                 <YamlHighlight code={workspace.config || "No elasticclaw-config.yaml content available."} />
               </div>
@@ -3119,14 +3117,14 @@ function WorkflowsSection({ selectedWorkspace }: { selectedWorkspace: string }) 
   return (
     <div className="space-y-6">
       <div>
-        <h2 className="text-base font-semibold mb-1">Workflows</h2>
+        <h2 className="text-base mb-1">Workflows</h2>
         <p className="text-sm text-muted-foreground">
           Workflows define triggers and runtime behavior within this workspace.
         </p>
       </div>
 
       {error && (
-        <div className="text-sm text-red-500 bg-red-500/10 border border-red-500/20 rounded-md px-3 py-2">
+        <div className="text-sm text-destructive bg-destructive/10 border border-destructive/20 rounded-md px-3 py-2">
           {error}
         </div>
       )}
@@ -3193,7 +3191,7 @@ function WorkflowSummaryRow({
           <WorkflowRunsDialog workflow={workflow} />
           <span className={cn(
             "text-xs px-2 py-0.5 rounded",
-            workflow.enabled ? "bg-muted text-muted-foreground" : "bg-amber-500/10 text-amber-500"
+            workflow.enabled ? "bg-muted text-muted-foreground" : "bg-status-warn/10 text-status-warn"
           )}>
             {workflow.enabled ? "enabled" : "paused"}
           </span>
@@ -3206,7 +3204,7 @@ function WorkflowSummaryRow({
 function WorkspaceRepositoryList({ values }: { values: RepositoryAccess[] }) {
   return (
     <div className="space-y-1">
-      <h4 className="text-xs font-medium text-muted-foreground">Repositories</h4>
+      <h4 className="text-xs text-muted-foreground">Repositories</h4>
       {values.length === 0 ? (
         <p className="text-xs text-muted-foreground/70">None</p>
       ) : (
@@ -3229,7 +3227,7 @@ function WorkspaceRepositoryList({ values }: { values: RepositoryAccess[] }) {
 function WorkspaceAccessList({ title, values }: { title: string; values: string[] }) {
   return (
     <div className="space-y-1">
-      <h4 className="text-xs font-medium text-muted-foreground">{title}</h4>
+      <h4 className="text-xs text-muted-foreground">{title}</h4>
       {values.length === 0 ? (
         <p className="text-xs text-muted-foreground/70">None</p>
       ) : (
@@ -3308,7 +3306,7 @@ function SecretsSection({ settings, workspace }: { settings: SettingsData | null
   return (
     <div className="space-y-6">
       <div>
-        <h2 className="text-base font-semibold mb-1">Secrets</h2>
+        <h2 className="text-base mb-1">Secrets</h2>
         <p className="text-sm text-muted-foreground mb-6">
           Named secrets for workspace <code className="bg-muted px-1 rounded text-xs">{workspace || "default"}</code>. Values are stored on the hub and referenced from workspace env or workflow secret refs.
         </p>
@@ -3332,7 +3330,7 @@ function SecretsSection({ settings, workspace }: { settings: SettingsData | null
       </div>
 
       <div className="border border-border rounded-lg p-5 space-y-4">
-        <h3 className="text-sm font-medium">Add Secret</h3>
+        <h3 className="text-sm ">Add Secret</h3>
         <div className="flex gap-2">
           <Input placeholder="Name (e.g. linear_webhook_secret)" value={newName} onChange={e => setNewName(e.target.value)} className="font-mono text-sm" />
           <Input placeholder="Value" type="password" value={newValue} onChange={e => setNewValue(e.target.value)} className="font-mono text-sm" />
@@ -3826,7 +3824,7 @@ function AIConfigSection() {
       {/* Header */}
       <div className="px-8 pt-6 pb-3 flex-none flex items-start justify-between gap-4">
         <div>
-          <h2 className="text-base font-semibold mb-0.5">Configure with AI</h2>
+          <h2 className="text-base mb-0.5">Configure with AI</h2>
           <p className="text-sm text-muted-foreground">
             Describe changes in plain English. The AI will propose a hub.yaml update for you to review and apply.
           </p>
@@ -3866,7 +3864,7 @@ function AIConfigSection() {
           )}
           {applySuccess && (
             <div className="flex items-center gap-3">
-              <p className="text-sm text-green-600">&check; Config applied.</p>
+              <p className="text-sm text-status-ok">&check; Config applied.</p>
               {backupPath && (
                 <Button size="sm" variant="outline" onClick={revertConfig} disabled={reverting}>
                   <RotateCcw className="size-3.5 mr-1" />
@@ -3955,24 +3953,24 @@ function AIConfigSection() {
               <span className={cn(
                 "text-xs font-medium uppercase tracking-wide px-2 py-0.5 rounded",
                 yamlStreaming
-                  ? "bg-blue-500/15 text-blue-500 dark:text-blue-400"
+                  ? "bg-data/15 text-data dark:text-data"
                   : proposedYaml
-                    ? "bg-amber-500/15 text-amber-600 dark:text-amber-400"
+                    ? "bg-status-warn/15 text-status-warn dark:text-status-warn"
                     : "bg-muted text-muted-foreground"
               )}>
                 {yamlLabel}
               </span>
               {yamlStreaming && (
                 <span className="flex gap-0.5 items-center">
-                  <span className="size-1.5 rounded-full bg-blue-400 animate-bounce [animation-delay:0ms]" />
-                  <span className="size-1.5 rounded-full bg-blue-400 animate-bounce [animation-delay:150ms]" />
-                  <span className="size-1.5 rounded-full bg-blue-400 animate-bounce [animation-delay:300ms]" />
+                  <span className="size-1.5 rounded-full bg-data animate-bounce [animation-delay:0ms]" />
+                  <span className="size-1.5 rounded-full bg-data animate-bounce [animation-delay:150ms]" />
+                  <span className="size-1.5 rounded-full bg-data animate-bounce [animation-delay:300ms]" />
                 </span>
               )}
             </div>
             <div className="flex items-center gap-2">
               {revealSecrets && (
-                <span className="text-xs text-amber-500 font-medium">Secrets visible</span>
+                <span className="text-xs text-status-warn font-medium">Secrets visible</span>
               )}
               <Button
                 size="icon"
@@ -3988,11 +3986,11 @@ function AIConfigSection() {
 
           {/* YAML display — fills available height, scrollable */}
           <div className={cn(
-            "flex-1 min-h-0 border rounded-lg overflow-hidden bg-[#0d1117] relative transition-colors duration-300",
-            yamlStreaming ? "border-blue-500/50" : "border-border"
+            "flex-1 min-h-0 border rounded-lg overflow-hidden bg-card relative transition-colors duration-300",
+            yamlStreaming ? "border-data/50" : "border-border"
           )}>
             {yamlStreaming
-              ? <pre className="h-full overflow-auto p-3 text-xs font-mono leading-relaxed text-gray-300 whitespace-pre">{streamingYaml}<span className="animate-pulse text-amber-400">&#x258c;</span></pre>
+              ? <pre className="h-full overflow-auto p-3 text-xs font-mono leading-relaxed text-muted-foreground whitespace-pre">{streamingYaml}<span className="animate-pulse text-status-warn">&#x258c;</span></pre>
               : displayedYaml
                 ? <YamlHighlight code={displayedYaml} />
                 : <p className="p-3 text-xs text-muted-foreground">Loading…</p>
@@ -4153,7 +4151,7 @@ function MCPServersSection({ settings, onSave, saving }: { settings: SettingsDat
   return (
     <div className="space-y-6">
       <div>
-        <h2 className="text-base font-semibold mb-1">MCP Servers</h2>
+        <h2 className="text-base mb-1">MCP Servers</h2>
         <p className="text-sm text-muted-foreground mb-4">
           Model Context Protocol servers add tools to your agents. Configure them here and reference them in workflows.
         </p>
@@ -4162,7 +4160,7 @@ function MCPServersSection({ settings, onSave, saving }: { settings: SettingsDat
             {mcps.length} server{mcps.length !== 1 ? "s" : ""} configured
           </span>
           {enabledCount > 0 && (
-            <span className="text-xs bg-green-500/10 text-green-400 border border-green-500/20 px-2 py-1 rounded font-medium">
+            <span className="text-xs bg-status-ok/10 text-status-ok border border-status-ok/20 px-2 py-1 rounded font-medium">
               {enabledCount} enabled
             </span>
           )}
@@ -4187,13 +4185,13 @@ function MCPServersSection({ settings, onSave, saving }: { settings: SettingsDat
                   className={cn(
                     "relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full transition-colors duration-200",
                     mcp.enabled
-                      ? "bg-green-600 border-2 border-transparent"
+                      ? "bg-status-ok border-2 border-transparent"
                       : "bg-transparent border-2 border-muted-foreground/40"
                   )}
                 >
                   <span className={cn(
                     "pointer-events-none inline-block size-4 rounded-full shadow-sm transform transition-transform duration-200",
-                    mcp.enabled ? "bg-white translate-x-4" : "bg-muted-foreground/50 translate-x-0"
+                    mcp.enabled ? "bg-background translate-x-4" : "bg-muted-foreground/50 translate-x-0"
                   )} />
                 </button>
                 <div>
@@ -4226,7 +4224,7 @@ function MCPServersSection({ settings, onSave, saving }: { settings: SettingsDat
         <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto p-0 gap-0">
           <DialogTitle className="sr-only">{modalMode === "add" ? "Add MCP Server" : `Edit ${formName}`}</DialogTitle>
           <div className="flex items-center justify-between px-5 py-4 border-b border-border">
-            <h3 className="font-medium">{modalMode === "add" ? "Add MCP Server" : `Edit ${formName}`}</h3>
+            <h3>{modalMode === "add" ? "Add MCP Server" : `Edit ${formName}`}</h3>
           </div>
 
           <div className="p-5 space-y-4">
@@ -4517,7 +4515,7 @@ function TroubleshootSection() {
     <div className="flex flex-col" style={{ height: "calc(100vh - 8rem)" }}>
       <div className="px-8 pt-6 pb-3 flex-none flex items-start justify-between gap-4">
         <div>
-          <h2 className="text-base font-semibold mb-0.5">Troubleshoot</h2>
+          <h2 className="text-base mb-0.5">Troubleshoot</h2>
           <p className="text-sm text-muted-foreground">
             Describe what&apos;s not working. The AI will analyze your logs, config, and source code.
           </p>
@@ -4601,7 +4599,7 @@ function TroubleshootSection() {
           </div>
 
           {error && (
-            <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-3 text-sm text-red-500 flex-none">
+            <div className="rounded-lg border border-destructive/20 bg-destructive/5 p-3 text-sm text-destructive flex-none">
               {error}
             </div>
           )}
@@ -4664,17 +4662,17 @@ function DoctorSection() {
 
   const severityIcon = (s: string) => {
     switch (s) {
-      case "critical": return <AlertTriangle className="size-4 text-red-500" />
-      case "warning": return <AlertTriangle className="size-4 text-amber-500" />
-      default: return <CheckCircle2 className="size-4 text-blue-400" />
+      case "critical": return <AlertTriangle className="size-4 text-destructive" />
+      case "warning": return <AlertTriangle className="size-4 text-status-warn" />
+      default: return <CheckCircle2 className="size-4 text-data" />
     }
   }
 
   const severityBadge = (s: string) => {
     const classes: Record<string, string> = {
-      critical: "bg-red-500/10 text-red-500 border-red-500/20",
-      warning: "bg-amber-500/10 text-amber-500 border-amber-500/20",
-      info: "bg-blue-400/10 text-blue-400 border-blue-400/20",
+      critical: "bg-destructive/10 text-destructive border-destructive/20",
+      warning: "bg-status-warn/10 text-status-warn border-status-warn/20",
+      info: "bg-data/10 text-data border-data/20",
     }
     return (
       <span className={cn("text-[10px] uppercase tracking-wider font-semibold px-2 py-0.5 rounded border", classes[s] || classes.info)}>
@@ -4687,7 +4685,7 @@ function DoctorSection() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h2 className="text-base font-semibold mb-1">Doctor</h2>
+          <h2 className="text-base mb-1">Doctor</h2>
           <p className="text-sm text-muted-foreground">
             Diagnose hub configuration issues and get actionable fixes.
           </p>
@@ -4712,7 +4710,7 @@ function DoctorSection() {
       </div>
 
       {error && (
-        <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-4 text-sm text-red-500">
+        <div className="rounded-lg border border-destructive/20 bg-destructive/5 p-4 text-sm text-destructive">
           {error}
         </div>
       )}
@@ -4724,25 +4722,25 @@ function DoctorSection() {
               <p className="text-2xl font-bold">{report.summary.total}</p>
               <p className="text-xs text-muted-foreground mt-1">Checks</p>
             </div>
-            <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-3 text-center">
-              <p className="text-2xl font-bold text-red-500">{report.summary.critical}</p>
+            <div className="rounded-lg border border-destructive/20 bg-destructive/5 p-3 text-center">
+              <p className="text-2xl font-bold text-destructive">{report.summary.critical}</p>
               <p className="text-xs text-muted-foreground mt-1">Critical</p>
             </div>
-            <div className="rounded-lg border border-amber-500/20 bg-amber-500/5 p-3 text-center">
-              <p className="text-2xl font-bold text-amber-500">{report.summary.warning}</p>
+            <div className="rounded-lg border border-status-warn/20 bg-status-warn/5 p-3 text-center">
+              <p className="text-2xl font-bold text-status-warn">{report.summary.warning}</p>
               <p className="text-xs text-muted-foreground mt-1">Warnings</p>
             </div>
-            <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/5 p-3 text-center">
-              <p className="text-2xl font-bold text-emerald-500">{report.summary.passed}</p>
+            <div className="rounded-lg border border-status-ok/20 bg-status-ok/5 p-3 text-center">
+              <p className="text-2xl font-bold text-status-ok">{report.summary.passed}</p>
               <p className="text-xs text-muted-foreground mt-1">Passed</p>
             </div>
           </div>
 
           {visibleChecks.length === 0 ? (
             allPassing ? (
-              <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/5 p-6 text-center">
-                <CheckCircle2 className="size-8 text-emerald-500 mx-auto mb-2" />
-                <p className="text-sm font-medium text-emerald-500">All checks passing</p>
+              <div className="rounded-lg border border-status-ok/20 bg-status-ok/5 p-6 text-center">
+                <CheckCircle2 className="size-8 text-status-ok mx-auto mb-2" />
+                <p className="text-sm font-medium text-status-ok">All checks passing</p>
                 <p className="text-xs text-muted-foreground mt-1">
                   {report.summary.passed} check{report.summary.passed !== 1 ? "s" : ""} passed with no issues
                 </p>
@@ -4758,18 +4756,18 @@ function DoctorSection() {
                   className={cn(
                     "rounded-lg border p-4",
                     check.ok
-                      ? "border-emerald-500/20 bg-emerald-500/5"
+                      ? "border-status-ok/20 bg-status-ok/5"
                       : check.severity === "critical"
-                        ? "border-red-500/20 bg-red-500/5"
+                        ? "border-destructive/20 bg-destructive/5"
                         : check.severity === "warning"
-                          ? "border-amber-500/20 bg-amber-500/5"
+                          ? "border-status-warn/20 bg-status-warn/5"
                           : "border-border"
                   )}
                 >
                   <div className="flex items-start gap-3">
                     <div className="mt-0.5 shrink-0">
                       {check.ok ? (
-                        <CheckCircle2 className="size-4 text-emerald-500" />
+                        <CheckCircle2 className="size-4 text-status-ok" />
                       ) : (
                         severityIcon(check.severity)
                       )}
@@ -4784,7 +4782,7 @@ function DoctorSection() {
                       <p className="text-sm font-medium mt-1">{check.title}</p>
                       <p className="text-sm text-muted-foreground mt-0.5 whitespace-pre-wrap">{linkifyText(check.description)}</p>
                       {check.error && (
-                        <p className="text-xs text-red-400 mt-1 font-mono">{check.error}</p>
+                        <p className="text-xs text-destructive mt-1 font-mono">{check.error}</p>
                       )}
                       {check.fixAction && !check.ok && (
                         <div className="mt-3">

--- a/web/components/agent-timeline/activity-summary-block.tsx
+++ b/web/components/agent-timeline/activity-summary-block.tsx
@@ -110,7 +110,7 @@ export function ActivitySummaryBlock({
           <button
             type="button"
             onClick={(e) => handleToggle(e.currentTarget)}
-            className="w-full rounded border border-border/50 bg-muted/20 px-1.5 py-0.5 text-left text-[10px] text-muted-foreground hover:bg-muted/35"
+            className="w-full rounded-sm border border-border bg-foreground/4 px-1.5 py-0.5 text-left font-mono text-[10px] text-muted-foreground hover:bg-foreground/8"
           >
             {expanded ? "Hide" : "Show"} {summaryLabel(earlierCount)}
           </button>
@@ -137,15 +137,15 @@ export function ActivitySummaryBlock({
   return (
     <div className="space-y-1">
       <div className="flex items-center gap-2 py-1">
-        <div className="h-px flex-1 bg-border/50" />
+        <div className="h-px flex-1 bg-border" />
         <button
           type="button"
           onClick={(e) => handleToggle(e.currentTarget)}
-          className="rounded border border-border/60 bg-muted/25 px-2.5 py-1 text-xs text-muted-foreground hover:bg-muted/40 hover:text-foreground"
+          className="rounded-md border border-border bg-foreground/4 px-2.5 py-1 font-mono text-xs text-muted-foreground hover:bg-foreground/8 hover:text-foreground"
         >
           {expanded ? "Hide" : "Show"} {label}
         </button>
-        <div className="h-px flex-1 bg-border/50" />
+        <div className="h-px flex-1 bg-border" />
       </div>
       {expanded && loading && (
         <div className="text-center text-xs text-muted-foreground">Loading tool calls...</div>

--- a/web/components/agent-timeline/now-strip.tsx
+++ b/web/components/agent-timeline/now-strip.tsx
@@ -23,18 +23,27 @@ import { useLastOutputAt } from "@/hooks/use-last-output"
 export type NowStripState = "working" | "waiting" | "done" | "error" | "offline"
 
 const STATE_DOT: Record<Exclude<NowStripState, "working">, string> = {
-  waiting: "bg-amber-400",
-  done: "bg-muted-foreground/50",
-  error: "bg-red-500",
-  offline: "bg-muted-foreground/40",
+  waiting: "bg-status-warn",
+  done: "bg-muted-foreground",
+  error: "bg-destructive",
+  offline: "bg-muted-foreground/60",
 }
 
 const STATE_TEXT: Record<Exclude<NowStripState, "working">, string> = {
-  waiting: "text-amber-300/90",
+  waiting: "text-status-warn",
   done: "text-muted-foreground",
-  error: "text-red-400",
-  offline: "text-muted-foreground/70",
+  error: "text-destructive",
+  offline: "text-muted-foreground",
 }
+
+/** Geometry of the board card's state row — no type utilities here, so the
+ *  quiet (mono) and loud (Archivo 800) variants never fight over the cascade:
+ *  same-property Tailwind utilities win by source order in the sheet, not by
+ *  the order they appear in a className string. */
+const STATE_ROW =
+  "flex min-w-0 items-center gap-1.5 border-b border-border px-3 py-1 leading-4"
+const STATE_ROW_QUIET = "font-mono text-[10px]"
+const STATE_ROW_LOUD = "font-sans text-[11px] font-extrabold uppercase tracking-[0.1em]"
 
 export function NowStrip({
   clawId,
@@ -74,17 +83,40 @@ export function NowStrip({
           ? `last seen ${formatAge(statusAt, now)}`
           : "offline"
         : statusText || (state === "error" ? "Agent errored" : "Idle")
+    // The two loud states get the mockup's full-width state strip: a solid
+    // accent band for "needs you", the deep accent tint for a failure. The
+    // quiet states stay a plain mono line so the board reads at a glance.
+    const isBanner = state === "waiting" || state === "error"
     return (
-      <div className="flex min-w-0 items-center gap-1.5 border-b border-border bg-muted/20 px-3 py-1 text-[10px] leading-4">
-        <span className={cn("size-1.5 shrink-0 rounded-full", dotClass, state === "waiting" && "animate-pulse")} />
-        {state === "waiting" && (
-          <span className="shrink-0 font-medium text-amber-400">Needs you</span>
+      <div
+        className={cn(
+          STATE_ROW,
+          isBanner ? STATE_ROW_LOUD : STATE_ROW_QUIET,
+          state === "waiting" && "bg-primary text-primary-foreground",
+          state === "error" && "bg-[var(--ds-accent-800)] text-[var(--ds-accent-100)]"
         )}
-        <span className={cn("min-w-0 flex-1 truncate", textClass)} title={text} suppressHydrationWarning={state === "offline" || undefined}>
+      >
+        {!isBanner && <span className={cn("size-1.5 shrink-0 rounded-full", dotClass)} />}
+        {state === "waiting" && <span className="shrink-0">Waiting on you</span>}
+        <span
+          className={cn(
+            "min-w-0 flex-1 truncate",
+            state === "waiting" && "font-mono text-[10px] font-normal normal-case tracking-normal opacity-85",
+            !isBanner && textClass
+          )}
+          title={text}
+          suppressHydrationWarning={state === "offline" || undefined}
+        >
           {text}
         </span>
         {state !== "offline" && statusAt != null && statusAt > 0 && (
-          <span className="shrink-0 font-mono text-[9.5px] text-muted-foreground" suppressHydrationWarning>
+          <span
+            className={cn(
+              "shrink-0 font-mono text-[9.5px] font-normal normal-case tracking-normal",
+              isBanner ? "opacity-85" : "text-muted-foreground"
+            )}
+            suppressHydrationWarning
+          >
             {formatAge(statusAt, now)}
           </span>
         )}
@@ -110,17 +142,17 @@ export function NowStrip({
        truncating away. Card variant: one line, truncate hard. */
     <div
       className={cn(
-        "border-b border-border bg-muted/20",
+        "border-b border-border",
         isCard
-          ? "flex min-w-0 items-center gap-1.5 px-3 py-1 text-[10px] leading-4"
-          : "flex flex-wrap items-center gap-x-2 gap-y-0.5 px-4 md:px-6 py-1.5 text-xs"
+          ? cn(STATE_ROW, STATE_ROW_QUIET, "text-status-ok")
+          : "flex flex-wrap items-center gap-x-2 gap-y-0.5 bg-foreground/4 px-4 md:px-6 py-1.5 text-xs"
       )}
     >
       <span className={cn("relative flex shrink-0", isCard ? "size-1.5" : "size-2")}>
-        <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-400 opacity-75" />
-        <span className={cn("relative inline-flex rounded-full bg-green-500", isCard ? "size-1.5" : "size-2")} />
+        <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-status-ok opacity-75" />
+        <span className={cn("relative inline-flex rounded-full bg-status-ok", isCard ? "size-1.5" : "size-2")} />
       </span>
-      <span className="shrink-0 font-medium text-foreground">{what}</span>
+      <span className={cn("shrink-0", isCard ? "text-status-ok" : "font-medium text-foreground")}>{what}</span>
       {step?.detail && (
         <span
           className={cn(
@@ -141,7 +173,7 @@ export function NowStrip({
       >
         {elapsed !== null && <span suppressHydrationWarning>{formatDurationMs(elapsed)}</span>}
         {outputAge !== null && (
-          <span className={cn(stale && "text-amber-400")} suppressHydrationWarning>
+          <span className={cn(stale && "text-status-warn")} suppressHydrationWarning>
             last output {formatAge(lastOutputAt as number, now)}
           </span>
         )}

--- a/web/components/agent-timeline/step-row.tsx
+++ b/web/components/agent-timeline/step-row.tsx
@@ -44,15 +44,15 @@ function StepIcon({ step, className }: { step: Step; className: string }) {
 }
 
 function stepAccent(step: Step): string {
-  if (step.status === "running") return "border-l-blue-500"
-  if (step.status === "failed") return "border-l-red-500"
-  if (step.tone === "warning") return "border-l-amber-500/70"
+  if (step.status === "running") return "border-l-data"
+  if (step.status === "failed") return "border-l-destructive"
+  if (step.tone === "warning") return "border-l-status-warn/70"
   return "border-l-transparent"
 }
 
 function stepTextTone(step: Step): string {
-  if (step.status === "failed" || step.tone === "error") return "text-red-400"
-  if (step.tone === "warning") return "text-amber-400"
+  if (step.status === "failed" || step.tone === "error") return "text-destructive"
+  if (step.tone === "warning") return "text-status-warn"
   return "text-foreground/80"
 }
 
@@ -112,7 +112,7 @@ export function StepRow({
           "grid grid-cols-[auto_1fr_auto] items-baseline gap-x-2",
           isCard ? "py-0.5" : "py-1",
           // 44px tap target for expandable rows on touch screens
-          hasBody && "cursor-pointer rounded-sm hover:bg-muted/30 max-md:min-h-11 max-md:items-center"
+          hasBody && "cursor-pointer rounded-sm hover:bg-foreground/7 max-md:min-h-11 max-md:items-center"
         )}
       >
         <span className="self-center">
@@ -121,11 +121,13 @@ export function StepRow({
         <span className="flex min-w-0 items-baseline gap-1.5 max-md:flex-wrap max-md:gap-y-0">
           {running && (
             <span className="relative flex size-1.5 self-center">
-              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-blue-400 opacity-75" />
-              <span className="relative inline-flex size-1.5 rounded-full bg-blue-500" />
+              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-data opacity-75" />
+              <span className="relative inline-flex size-1.5 rounded-full bg-data" />
             </span>
           )}
-          <span className={cn("shrink-0 font-medium", isCard ? "text-[10px]" : "text-xs", stepTextTone(step))}>
+          {/* The mockup renders a step as one monospaced line: tool, target,
+              duration — so the tool name is mono here, not a sans label. */}
+          <span className={cn("shrink-0 font-mono", isCard ? "text-[10px]" : "text-xs", stepTextTone(step))}>
             {step.title}
           </span>
           {step.detail && (
@@ -143,10 +145,10 @@ export function StepRow({
             </span>
           )}
           {step.statusText && !isCard && (
-            <span className="min-w-0 truncate text-xs text-muted-foreground/50">{step.statusText}</span>
+            <span className="min-w-0 truncate text-xs text-muted-foreground">{step.statusText}</span>
           )}
           {showExit && (
-            <span className={cn("shrink-0 rounded bg-red-500/10 px-1 font-mono text-red-400", isCard ? "text-[9px]" : "text-[10px]")}>
+            <span className={cn("shrink-0 rounded-sm bg-destructive/12 px-1 font-mono text-destructive", isCard ? "text-[9px]" : "text-[10px]")}>
               exit {step.exitCode}
             </span>
           )}
@@ -158,7 +160,7 @@ export function StepRow({
             </span>
           )}
           {hasBody && (
-            <ChevronRight className={cn("size-3 text-muted-foreground/50 transition-transform", expanded && "rotate-90")} />
+            <ChevronRight className={cn("size-3 text-muted-foreground transition-transform", expanded && "rotate-90")} />
           )}
         </span>
       </div>
@@ -166,7 +168,7 @@ export function StepRow({
         <div className={cn("mb-1 space-y-1", isCard ? "pr-1" : "pr-2")}>
           {step.error && (
             <pre className={cn(
-              "overflow-y-auto whitespace-pre-wrap break-words rounded border border-red-500/20 bg-red-500/5 p-2 font-mono text-red-400",
+              "overflow-y-auto whitespace-pre-wrap break-words rounded-md border border-destructive/30 bg-destructive/8 p-2 font-mono text-destructive",
               isCard ? "max-h-32 text-[10px]" : "max-h-64 text-[11px]"
             )}>
               {step.error}
@@ -174,7 +176,7 @@ export function StepRow({
           )}
           {step.result && (
             <pre className={cn(
-              "overflow-y-auto whitespace-pre-wrap break-words rounded border border-border/50 bg-muted/40 p-2 font-mono text-muted-foreground",
+              "overflow-y-auto whitespace-pre-wrap break-words rounded-md border border-border bg-foreground/4 p-2 font-mono text-muted-foreground",
               isCard ? "max-h-32 text-[10px]" : "max-h-64 text-[11px]"
             )}>
               {step.result}
@@ -240,19 +242,19 @@ function StepGroupRow({
           setExpanded((v) => !v)
         }}
         className={cn(
-          "grid w-full grid-cols-[auto_1fr_auto] items-center gap-x-2 rounded-sm text-left hover:bg-muted/30 max-md:min-h-11",
+          "grid w-full grid-cols-[auto_1fr_auto] items-center gap-x-2 rounded-sm text-left hover:bg-foreground/7 max-md:min-h-11",
           isCard ? "py-0.5" : "py-1"
         )}
       >
         <Icon className={cn(isCard ? "size-2.5" : "size-3", "shrink-0 text-muted-foreground")} />
-        <span className={cn("min-w-0 truncate font-medium text-muted-foreground", isCard ? "text-[10px]" : "text-xs")}>
+        <span className={cn("min-w-0 truncate font-mono text-muted-foreground", isCard ? "text-[10px]" : "text-xs")}>
           {label}
         </span>
         <span className="flex items-center gap-1">
           {totalMs > 0 && (
             <span className="font-mono text-[10.5px] text-muted-foreground">{formatDurationMs(totalMs)}</span>
           )}
-          <ChevronRight className={cn("size-3 text-muted-foreground/50 transition-transform", expanded && "rotate-90")} />
+          <ChevronRight className={cn("size-3 text-muted-foreground transition-transform", expanded && "rotate-90")} />
         </span>
       </button>
       {expanded && (

--- a/web/components/agent-timeline/timeline-toolbar.tsx
+++ b/web/components/agent-timeline/timeline-toolbar.tsx
@@ -67,32 +67,35 @@ export function TimelineToolbar({
   stats: TimelineStats
 }) {
   return (
-    <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1 border-b border-border px-3 md:px-6 py-1.5">
-      <div className="flex items-center gap-0.5 rounded-md border border-border bg-muted/30 p-0.5">
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 border-b border-border px-3 md:px-6 py-1.5">
+      <span className="kicker shrink-0 text-muted-foreground">Timeline</span>
+      {/* Segmented control: one hairline-bordered strip, the active segment
+          filled with the accent — the mockup's .seg, not a pill group. */}
+      <div className="inline-flex overflow-hidden rounded-md border border-border">
         {DENSITY_OPTIONS.map((option) => (
           <button
             key={option.value}
             type="button"
             onClick={() => onDensityChange(option.value)}
             className={cn(
-              "rounded px-2 py-0.5 text-xs transition-colors",
+              "px-2.5 py-1 text-xs transition-colors border-l border-border first:border-l-0",
               density === option.value
-                ? "bg-secondary font-medium text-foreground"
-                : "text-muted-foreground hover:text-foreground"
+                ? "bg-primary text-primary-foreground"
+                : "text-muted-foreground hover:bg-foreground/7 hover:text-foreground"
             )}
           >
             {option.label}
           </button>
         ))}
       </div>
-      <span className="flex shrink-0 items-center gap-1.5 rounded-full border border-border bg-muted/20 px-2.5 py-0.5 text-[10.5px] text-muted-foreground">
+      <span className="ml-auto flex shrink-0 items-center gap-1.5 font-mono text-[10.5px] text-muted-foreground">
         <span>{stats.turns} turn{stats.turns === 1 ? "" : "s"}</span>
         <span className="text-border">·</span>
         <span>{stats.toolCalls} tool call{stats.toolCalls === 1 ? "" : "s"}</span>
         {stats.failures > 0 && (
           <>
             <span className="text-border">·</span>
-            <span className="font-medium text-red-400">{stats.failures} failed</span>
+            <span className="text-destructive">{stats.failures} failed</span>
           </>
         )}
       </span>

--- a/web/components/agent-timeline/timeline.tsx
+++ b/web/components/agent-timeline/timeline.tsx
@@ -35,7 +35,7 @@ function UnloadedActivityNotice({
         type="button"
         onClick={onLoad}
         disabled={loading}
-        className="rounded border border-border bg-muted/30 px-2.5 py-0.5 text-xs text-foreground hover:bg-muted/50 disabled:opacity-60"
+        className="rounded-md border border-border bg-foreground/4 px-2.5 py-0.5 text-xs text-foreground hover:bg-foreground/8 disabled:opacity-60"
       >
         {loading ? "Loading..." : "Load them"}
       </button>

--- a/web/components/agent-timeline/turn-card.tsx
+++ b/web/components/agent-timeline/turn-card.tsx
@@ -26,16 +26,16 @@ function StatusPill({ status }: { status: TurnStatus }) {
   return (
     <span
       className={cn(
-        "inline-flex items-center gap-1 rounded-full border px-1.5 py-px text-[10px] font-medium",
-        status === "running" && "border-blue-500/40 text-blue-400",
-        status === "failed" && "border-red-500/40 text-red-400",
+        "inline-flex items-center gap-1 rounded-full border px-1.5 py-px font-mono text-[10px]",
+        status === "running" && "border-data/50 text-data",
+        status === "failed" && "border-destructive/50 text-destructive",
         status === "ok" && "border-border text-muted-foreground"
       )}
     >
       {status === "running" && (
         <span className="relative flex size-1.5">
-          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-blue-400 opacity-75" />
-          <span className="relative inline-flex size-1.5 rounded-full bg-blue-500" />
+          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-data opacity-75" />
+          <span className="relative inline-flex size-1.5 rounded-full bg-data" />
         </span>
       )}
       {status === "running" ? "running" : status === "failed" ? "failed" : "done"}
@@ -114,27 +114,29 @@ export const TurnCard = memo(function TurnCard({
   )
 
   return (
-    <section className="overflow-hidden rounded-xl border border-border bg-card">
+    /* The mockup's activity group: a hairline-bordered block on a faint ink
+       wash, holding the monospaced step rows. */
+    <section className="overflow-hidden rounded-lg border border-border bg-foreground/4">
       <button
         type="button"
         onClick={(e) => {
           anchor(e.currentTarget)
           onToggle(toggleKey, expanded)
         }}
-        className="flex w-full items-center gap-2 bg-muted/30 px-3 py-2 text-left hover:bg-muted/50"
+        className="flex w-full items-center gap-2 px-3 py-2 text-left transition-colors hover:bg-foreground/7"
       >
         <ChevronRight
           className={cn("size-3.5 shrink-0 text-muted-foreground transition-transform", expanded && "rotate-90")}
         />
         <span className="min-w-0 truncate text-sm font-medium text-foreground">{label}</span>
         <StatusPill status={status} />
-        <span className="ml-auto flex shrink-0 items-center gap-2 text-[10.5px] text-muted-foreground">
+        <span className="ml-auto flex shrink-0 items-center gap-2 font-mono text-[10.5px] text-muted-foreground">
           {turn.failedCount > 0 && (
-            <span className="text-red-400">{turn.failedCount} failed</span>
+            <span className="text-destructive">{turn.failedCount} failed</span>
           )}
           <span>{stepNoun}</span>
-          {duration && <span className="font-mono">{duration}</span>}
-          <span className="font-mono" suppressHydrationWarning>{clock}</span>
+          {duration && <span>{duration}</span>}
+          <span suppressHydrationWarning>{clock}</span>
         </span>
       </button>
 

--- a/web/components/analytics-command-center.tsx
+++ b/web/components/analytics-command-center.tsx
@@ -6,9 +6,6 @@ import { Info } from "lucide-react"
 import {
   Bar,
   BarChart,
-  CartesianGrid,
-  LabelList,
-  Legend,
   Line,
   LineChart,
   ReferenceLine,
@@ -42,6 +39,7 @@ import {
   FilterSelect,
   RunDetailPanel,
   StatusBadge,
+  formatLabel,
   type DetailState,
   urlFilterKeys,
 } from "@/components/task-run-analytics-view"
@@ -54,6 +52,8 @@ import {
 } from "@/components/ui/select"
 import {
   ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
   ChartTooltip,
   ChartTooltipContent,
   type ChartConfig,
@@ -88,17 +88,48 @@ const chartConfig = {
   ticketFailed: { label: "Failed", color: "var(--color-primary)" },
   costPerMergedPr: { label: "Cost / merged PR", color: "var(--color-data)" },
 } satisfies ChartConfig
-// Legends: small square swatches over a 1px rule, muted 11px labels.
-const legendProps = {
-  iconType: "square",
-  iconSize: 9,
-  wrapperStyle: {
-    fontSize: 11,
-    paddingTop: 10,
-    marginTop: 4,
-    borderTop: "1px solid var(--color-border)",
-  },
-} as const
+// — plot language —
+// The mockup's charts are almost bare: no cartesian grid, no axis lines, no
+// tick marks. Only two hairlines (the mid rule and the baseline) hold the
+// vertical scale, and each axis is reduced to three mono labels. Everything
+// below expresses that in Recharts terms so every plot on the page reads the
+// same way.
+const hairline = { stroke: "var(--color-foreground)", strokeOpacity: 0.1, strokeWidth: 1 } as const
+const axisProps = { axisLine: false, tickLine: false, tickMargin: 8, interval: 0 } as const
+const plotMargin = { top: 6, right: 6, left: 0, bottom: 0 } as const
+
+// Round a max up to a value whose half is still a readable number, so the mid
+// hairline always lands on the middle label.
+function niceCeiling(value: number) {
+  if (!Number.isFinite(value) || value <= 0) return 1
+  const step = 10 ** Math.floor(Math.log10(value))
+  const normalized = value / step
+  const rounded = normalized <= 1 ? 1 : normalized <= 2 ? 2 : normalized <= 4 ? 4 : normalized <= 5 ? 5 : 10
+  return rounded * step
+}
+
+function yScale(maxValue: number) {
+  const max = niceCeiling(maxValue)
+  return { domain: [0, max] as [number, number], ticks: [0, max / 2, max], mid: max / 2 }
+}
+
+// Three x labels: the start, the middle and the end of the range.
+function edgeTicks<Row>(rows: Row[] | undefined, pick: (row: Row) => string) {
+  if (!rows?.length) return undefined
+  if (rows.length < 3) return rows.map(pick)
+  return [rows[0], rows[Math.floor((rows.length - 1) / 2)], rows[rows.length - 1]].map(pick)
+}
+
+function stackedMax(rows: readonly Record<string, unknown>[] | undefined, keys: readonly string[]) {
+  return Math.max(
+    0,
+    ...(rows ?? []).map((row) => keys.reduce((sum, key) => sum + (Number(row[key]) || 0), 0))
+  )
+}
+
+function seriesMax(rows: readonly Record<string, unknown>[] | undefined, keys: readonly string[]) {
+  return Math.max(0, ...(rows ?? []).flatMap((row) => keys.map((key) => Number(row[key]) || 0)))
+}
 // Money and volume series step down the single data-blue ramp and end on the
 // neutrals, so a cost series is never confused with an outcome color.
 const costSeriesColors = [
@@ -119,11 +150,34 @@ const usdWhole = new Intl.NumberFormat(undefined, {
   maximumFractionDigits: 0,
 })
 
-// Recharts colors legend item text with the series color by default. Our chart
-// rules keep the swatch colored but render the label text in the muted
-// foreground, so wrap it and let the Legend's own dot/line swatch carry the color.
-function legendTextFormatter(value: string) {
-  return <span className="text-muted-foreground">{value}</span>
+const periodOptions = [
+  ["7d", 7],
+  ["30d", 30],
+  ["90d", 90],
+  ["MTD", 0],
+] as const
+
+const monthDay = new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric" })
+const monthDayYear = new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric", year: "numeric" })
+
+// Caption under the page title: the range the whole screen is currently scoped
+// to. Derived from the range the loader actually applied, never from the clock.
+function formatPeriodRange(from?: string, to?: string) {
+  if (!from || !to) return undefined
+  return `${monthDay.format(new Date(from))} – ${monthDayYear.format(new Date(to))}`
+}
+
+// Which segment of the period control the applied range corresponds to, if any
+// (a heatmap day selection matches none of them).
+function activePeriodLabel(from?: string, to?: string) {
+  if (!from || !to) return undefined
+  const start = new Date(from)
+  const end = new Date(to)
+  const days = Math.round((end.getTime() - start.getTime()) / 86_400_000)
+  const exact = periodOptions.find(([, span]) => span > 0 && span === days)
+  if (exact) return exact[0]
+  const sameMonth = start.getDate() === 1 && start.getMonth() === end.getMonth() && start.getFullYear() === end.getFullYear()
+  return sameMonth ? "MTD" : undefined
 }
 
 function formatDate(value: string) {
@@ -196,6 +250,10 @@ export function AnalyticsCommandCenter() {
   const [detailLoading, setDetailLoading] = useState(false)
   const [detailError, setDetailError] = useState<string | null>(null)
   const [error, setError] = useState<string>()
+  // The range the loader actually used — the URL may carry none, in which case
+  // it defaults to the last 30 days. Kept in state so the header can caption
+  // the period without reading the clock during render.
+  const [appliedRange, setAppliedRange] = useState<{ from?: string; to?: string }>({})
   const loadAbortController = useRef<AbortController | null>(null)
   const loadRequestId = useRef(0)
   // Track the current page cursor in a ref so the polling effect below can read the
@@ -258,6 +316,7 @@ export function AnalyticsCommandCenter() {
           effectiveFilters.from = from.toISOString()
           effectiveFilters.to = to.toISOString()
         }
+        setAppliedRange({ from: effectiveFilters.from, to: effectiveFilters.to })
         const runFilters = { ...effectiveFilters, cursor }
         // The year heatmap always shows the trailing year, regardless of the
         // selected period. taskRunAnalyticsCostsUseRunFilters in
@@ -424,14 +483,26 @@ export function AnalyticsCommandCenter() {
     return range.from === filters.from && range.to === filters.to ? day : undefined
   })()
   const modelData = useModelData(costs)
+  const periodCaption = formatPeriodRange(appliedRange.from, appliedRange.to)
+  const activePeriod = activePeriodLabel(appliedRange.from, appliedRange.to)
 
   return (
     <main className="h-full overflow-auto bg-background">
+      {/* Sticky head: the title, the period it is scoped to, and the filters
+          that scope everything below — they stay reachable while scrolling. */}
+      <header className="sticky top-0 z-10 border-b-2 border-border bg-background px-5 pt-4 pb-3 lg:px-6">
+        <div className="mx-auto grid max-w-[1400px] gap-3">
+          <div className="flex flex-wrap items-baseline gap-3">
+            <h1 className="text-2xl tracking-tight">Analytics</h1>
+            {periodCaption && <span className="text-[13px] text-muted-foreground">{periodCaption}</span>}
+            <div className="ml-auto">
+              <PeriodControl active={activePeriod} onChange={setFilters} />
+            </div>
+          </div>
+          <FilterBar filters={filters} options={options} workspaces={workspaceNames} onChange={setFilters} />
+        </div>
+      </header>
       <div className="mx-auto max-w-[1400px] space-y-5 p-5 lg:p-6">
-        <header className="border-b-2 border-border pb-4">
-          <h1 className="text-2xl tracking-tight">Analytics</h1>
-        </header>
-        <FilterBar filters={filters} options={options} workspaces={workspaceNames} onChange={setFilters} />
         {error && <p className="text-sm text-destructive">{error}</p>}
 
         <div className="grid gap-5 xl:grid-cols-[6fr_3fr]">
@@ -501,20 +572,69 @@ export function AnalyticsCommandCenter() {
         </div>
 
         <div className="grid gap-5 lg:grid-cols-2">
-          <ChartCard title="Run outcomes over time" info="Each bar is a day. Clean = delivered with no human help; Human on the loop = a human helped via the pull request; Warning = a human had to step in from the dashboard; Failed = nothing was delivered.">
+          <ChartCard
+            title="Run outcomes over time"
+            description="Each bar is a day. Clean = delivered with no human help."
+            info="Each bar is a day. Clean = delivered with no human help; Human on the loop = a human helped via the pull request; Warning = a human had to step in from the dashboard; Failed = nothing was delivered."
+          >
             <OutcomesChart effect={effect} />
           </ChartCard>
-          <ChartCard title="Delivery funnel" info="How many runs made it from the agent starting, to opening a pull request, to that pull request being finished (merged or closed). Percentages show the conversion from the previous stage.">
+          <ChartCard
+            title="Delivery funnel"
+            description="From the agent starting to the pull request being finished."
+            info="How many runs made it from the agent starting, to opening a pull request, to that pull request being finished (merged or closed). Percentages show the conversion from the previous stage."
+          >
             <DeliveryFunnel effect={effect} />
           </ChartCard>
         </div>
 
         <div className="grid gap-5 lg:grid-cols-2">
-          <ChartCard title="Ticket throughput" info="Each bar is a day: how many distinct tickets had their first run that day, by how the ticket ended up. Delivered = at least one run delivered the work.">
+          <ChartCard
+            title="Ticket throughput"
+            description="Distinct tickets by the day of their first run, by outcome."
+            info="Each bar is a day: how many distinct tickets had their first run that day, by how the ticket ended up. Delivered = at least one run delivered the work."
+          >
             <TicketThroughputChart effect={effect} />
           </ChartCard>
-          <ChartCard title="Runs per ticket" info="How many runs each ticket needed. A long tail of 3+ means lots of retries on the same tickets.">
+          <ChartCard
+            title="Runs per ticket"
+            description="A long tail of 3+ means repeated retries on the same tickets."
+          >
             <RunsPerTicketChart effect={effect} />
+          </ChartCard>
+        </div>
+
+        <Heatmap
+          heatmap={heatmap}
+          maxCost={maxHeatCost}
+          selectedDay={selectedDay}
+          onSelectDay={(day) => setFilters(day === selectedDay ? { from: undefined, to: undefined } : isoDayRange(day))}
+          onClearSelectedDay={() => setFilters({ from: undefined, to: undefined })}
+        />
+
+        <div className="grid gap-5 lg:grid-cols-2">
+          <ChartCard title="Daily cost by model" description="Spend per day, split by AI model.">
+            <DailyCostChart costs={costs} modelData={modelData} />
+          </ChartCard>
+          <ChartCard
+            title="Cost per merged PR"
+            description="Weekly average; the dashed line is the period average."
+            info="Weekly average of what one merged pull request cost. The reference line is the period average."
+          >
+            <CostPerMergedPrChart effect={effect} />
+          </ChartCard>
+        </div>
+
+        <div className="grid gap-5 lg:grid-cols-2">
+          <ChartCard title="Workflow cost comparison" description="Daily spend of the most expensive workflows, side by side.">
+            <WorkflowCostComparisonChart drivers={drivers} />
+          </ChartCard>
+          <ChartCard
+            title="Most expensive tickets"
+            description="Where the money concentrates in the selected period."
+            info="Cost counts only the runs inside the selected period."
+          >
+            <TopTicketsByCostChart effect={effect} />
           </ChartCard>
         </div>
 
@@ -528,31 +648,6 @@ export function AnalyticsCommandCenter() {
           onNext={handleNextPage}
         />
 
-        <Heatmap
-          heatmap={heatmap}
-          maxCost={maxHeatCost}
-          selectedDay={selectedDay}
-          onSelectDay={(day) => setFilters(day === selectedDay ? { from: undefined, to: undefined } : isoDayRange(day))}
-          onClearSelectedDay={() => setFilters({ from: undefined, to: undefined })}
-        />
-
-        <div className="grid gap-5 lg:grid-cols-2">
-          <ChartCard title="Daily cost by model" info="How much was spent per day, split by AI model.">
-            <DailyCostChart costs={costs} modelData={modelData} />
-          </ChartCard>
-          <ChartCard title="Cost per merged PR" info="Weekly average of what one merged pull request cost. The reference line is the period average.">
-            <CostPerMergedPrChart effect={effect} />
-          </ChartCard>
-        </div>
-
-        <div className="grid gap-5 lg:grid-cols-2">
-          <ChartCard title="Workflow cost comparison" info="Daily spend of the most expensive workflows in the selected period, compared side by side.">
-            <WorkflowCostComparisonChart drivers={drivers} />
-          </ChartCard>
-          <ChartCard title="Most expensive tickets" info="Where the money concentrates: the costliest tickets in the selected period (cost counts only this period's runs).">
-            <TopTicketsByCostChart effect={effect} />
-          </ChartCard>
-        </div>
         <CostDrivers drivers={drivers} />
       </div>
       <RunDetailPanel
@@ -618,37 +713,26 @@ function FilterBar({
     ["Repo", "repo", options?.repos],
     ["Model", "model", options?.models],
   ] as const
+  // Chips restate what is currently scoping the page — the same values the
+  // selects hold, nothing more — and their × clears that one filter.
+  const applied = [
+    ["Workspace", "workspace", filters.workspace] as const,
+    ...selectFilters.map(([label, key]) => [label, key, filters[key]] as const),
+  ].filter(([, , value]) => Boolean(value))
 
   return (
-    <div className="flex flex-wrap items-center gap-2 rounded-lg border border-border bg-card p-2">
-      <div className="w-56">
+    <div className="flex flex-wrap items-center gap-2">
+      <div className="w-[190px]">
         <WorkspaceSelect
           value={filters.workspace}
           workspaces={workspaces}
           onChange={(value) => onChange({ workspace: value })}
         />
       </div>
-      <div className="flex h-8 divide-x divide-border overflow-hidden rounded-md border border-border">
-        {[["7d", 7], ["30d", 30], ["90d", 90], ["MTD", 0]].map(([label, days]) => (
-          <Button
-            key={label}
-            variant="ghost"
-            size="sm"
-            className="h-full rounded-none text-[13px] font-medium text-foreground"
-            onClick={() => {
-              const to = new Date()
-              const from = new Date()
-              if (days) from.setDate(to.getDate() - Number(days))
-              else from.setDate(1)
-              onChange({ from: from.toISOString(), to: to.toISOString() })
-            }}
-          >
-            {label}
-          </Button>
-        ))}
-      </div>
+      {/* Hairline that separates the workspace scope from the run filters. */}
+      <span aria-hidden className="mx-1 h-6 w-px bg-border" />
       {selectFilters.map(([label, key, values]) => (
-        <div key={key} className="w-48">
+        <div key={key} className="w-[168px]">
           <FilterSelect
             label={label}
             value={filters[key]}
@@ -656,6 +740,68 @@ function FilterBar({
             onChange={(value) => onChange({ [key]: value })}
           />
         </div>
+      ))}
+      {applied.map(([label, key, value]) => (
+        <span
+          key={key}
+          className="inline-flex items-center gap-1.5 rounded-full bg-tint-accent px-2.5 py-[3px] text-xs text-primary"
+        >
+          {label}: {formatLabel(String(value))}
+          <button
+            type="button"
+            aria-label={`Clear the ${label.toLowerCase()} filter`}
+            onClick={() => onChange({ [key]: undefined })}
+            className="-mr-1 rounded-full px-1 leading-none hover:bg-primary/15"
+          >
+            ×
+          </button>
+        </span>
+      ))}
+      {applied.length > 0 && (
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-8 px-2 text-xs text-primary hover:bg-primary/10 hover:text-primary"
+          onClick={() => onChange(Object.fromEntries(applied.map(([, key]) => [key, undefined])))}
+        >
+          Clear filters
+        </Button>
+      )}
+    </div>
+  )
+}
+
+// The period segmented control: one active segment on the accent, the rest
+// plain, hairline-divided — the mockup's .seg.
+function PeriodControl({
+  active,
+  onChange,
+}: {
+  active?: string
+  onChange: (updates: Record<string, string | undefined>) => void
+}) {
+  return (
+    <div className="flex h-8 shrink-0 overflow-hidden rounded-md border border-border">
+      {periodOptions.map(([label, days], index) => (
+        <button
+          key={label}
+          type="button"
+          aria-pressed={active === label}
+          className={`px-3 text-[13px] transition-colors ${index ? "border-l border-border" : ""} ${
+            active === label
+              ? "bg-primary text-primary-foreground"
+              : "text-foreground hover:bg-foreground/7"
+          }`}
+          onClick={() => {
+            const to = new Date()
+            const from = new Date()
+            if (days) from.setDate(to.getDate() - days)
+            else from.setDate(1)
+            onChange({ from: from.toISOString(), to: to.toISOString() })
+          }}
+        >
+          {label}
+        </button>
       ))}
     </div>
   )
@@ -692,9 +838,99 @@ function Heatmap({ heatmap, maxCost, selectedDay, onSelectDay, onClearSelectedDa
 
 function useModelData(costs?: CostOverview) { return useMemo(() => { const models = (costs?.seriesByModel ?? []).slice(0, 4); return (costs?.dailySeries ?? []).map((day, index) => ({ date: day.date, Other: Math.max(0, day.costUsd - models.reduce((sum, model) => sum + (model.dailySeries[index]?.costUsd ?? 0), 0)), ...Object.fromEntries(models.map((model) => [model.model, model.dailySeries[index]?.costUsd ?? 0])) })) }, [costs]) }
 function useWorkflowCostComparisonData(drivers: AnalyticsCostDriver[]) { return useMemo(() => { const topDrivers = [...drivers].sort((a, b) => b.costUsd - a.costUsd).slice(0, 5); const topNames = topDrivers.map((driver) => driver.name); const topNameSet = new Set(topNames); const dataByDate = new Map<string, Record<string, string | number>>(); for (const driver of drivers) for (const point of driver.dailyCost) { const row = dataByDate.get(point.date) ?? { date: point.date, Other: 0, ...Object.fromEntries(topNames.map((name) => [name, 0])) }; if (topNameSet.has(driver.name)) row[driver.name] = Number(row[driver.name]) + point.costUsd; else row.Other = Number(row.Other) + point.costUsd; dataByDate.set(point.date, row) } return { data: [...dataByDate.values()].sort((a, b) => String(a.date).localeCompare(String(b.date))), topNames } }, [drivers]) }
-function DailyCostChart({ costs, modelData }: { costs?: CostOverview; modelData: Record<string, string | number>[] }) { const labels = [...(costs?.seriesByModel ?? []).slice(0, 4).map((item) => item.model), "Other"]; return <ChartContainer config={chartConfig} className="h-64 w-full"><BarChart data={modelData}><CartesianGrid vertical={false} /><XAxis dataKey="date" tickFormatter={formatDate} /><YAxis /><ChartTooltip content={<ChartTooltipContent />} /><Legend {...legendProps} formatter={legendTextFormatter} />{labels.map((label, index) => <Bar key={label} dataKey={label} name={label} stackId="cost" fill={costSeriesColors[index % costSeriesColors.length]} />)}</BarChart></ChartContainer> }
-function WorkflowCostComparisonChart({ drivers }: { drivers: AnalyticsCostDriver[] }) { const { data, topNames } = useWorkflowCostComparisonData(drivers); if (drivers.length === 0) return <p className="py-8 text-center text-sm text-muted-foreground">No cost data for this period.</p>; return <ChartContainer config={chartConfig} className="h-64 w-full"><LineChart data={data}><CartesianGrid vertical={false} /><XAxis dataKey="date" tickFormatter={formatDate} /><YAxis /><ChartTooltip content={<ChartTooltipContent />} /><Legend {...legendProps} formatter={legendTextFormatter} />{topNames.map((name, index) => <Line key={name} type="monotone" dataKey={name} name={name} stroke={costSeriesColors[index % costSeriesColors.length]} dot={false} strokeWidth={2} />)}{drivers.length > 5 && <Line type="monotone" dataKey="Other" name="Other" stroke="var(--muted-foreground)" dot={false} strokeWidth={2} />}</LineChart></ChartContainer> }
-function OutcomesChart({ effect }: { effect?: AnalyticsEffectiveness }) { return <ChartContainer config={chartConfig} className="h-64 w-full"><BarChart data={effect?.outcomesByDay}><CartesianGrid vertical={false} /><XAxis dataKey="date" tickFormatter={formatDate} /><YAxis allowDecimals={false} /><ChartTooltip content={<ChartTooltipContent />} /><Legend {...legendProps} formatter={legendTextFormatter} /><Bar dataKey="clean" name="Clean" stackId="outcome" fill="var(--color-clean)" /><Bar dataKey="humanInTheLoop" name="Human on the loop" stackId="outcome" fill="var(--color-humanInTheLoop)" /><Bar dataKey="warning" name="Warning" stackId="outcome" fill="var(--color-warning)" /><Bar dataKey="failed" name="Failed" stackId="outcome" fill="var(--color-failed)" /></BarChart></ChartContainer> }
+// The two hairlines plus the three-label axes every plot on the page shares.
+// `max` sets the vertical scale; passing it explicitly keeps the mid rule and
+// the middle label on the same pixel. Returned as an array rather than a
+// component: Recharts looks its axes up among its own children, so a wrapper
+// component would hide them.
+function plotFrame({
+  max,
+  ticks,
+  dataKey = "date",
+  formatValue,
+}: {
+  max: number
+  ticks?: (string | number)[]
+  dataKey?: string
+  formatValue?: (value: number) => string
+}) {
+  const scale = yScale(max)
+  return [
+    <ReferenceLine key="mid" y={scale.mid} {...hairline} />,
+    <ReferenceLine key="base" y={0} {...hairline} />,
+    <XAxis key="x" dataKey={dataKey} ticks={ticks} tickFormatter={formatDate} {...axisProps} />,
+    <YAxis
+      key="y"
+      width={34}
+      domain={scale.domain}
+      ticks={scale.ticks}
+      tickFormatter={formatValue}
+      {...axisProps}
+    />,
+  ]
+}
+
+function DailyCostChart({ costs, modelData }: { costs?: CostOverview; modelData: Record<string, string | number>[] }) {
+  const labels = [...(costs?.seriesByModel ?? []).slice(0, 4).map((item) => item.model), "Other"]
+  return (
+    <ChartContainer config={chartConfig} className="h-64 w-full">
+      <BarChart data={modelData} margin={plotMargin} barCategoryGap={2}>
+        {plotFrame({
+          max: stackedMax(modelData, labels),
+          ticks: edgeTicks(modelData, (row) => String(row.date)),
+          formatValue: (value) => usdWhole.format(value),
+        })}
+        <ChartTooltip content={<ChartTooltipContent />} />
+        <ChartLegend content={<ChartLegendContent />} />
+        {labels.map((label, index) => (
+          <Bar key={label} dataKey={label} name={label} stackId="cost" fill={costSeriesColors[index % costSeriesColors.length]} />
+        ))}
+      </BarChart>
+    </ChartContainer>
+  )
+}
+
+function WorkflowCostComparisonChart({ drivers }: { drivers: AnalyticsCostDriver[] }) {
+  const { data, topNames } = useWorkflowCostComparisonData(drivers)
+  if (drivers.length === 0) return <EmptyPlot>No cost data for this period.</EmptyPlot>
+  const keys = drivers.length > 5 ? [...topNames, "Other"] : topNames
+  return (
+    <ChartContainer config={chartConfig} className="h-64 w-full">
+      <LineChart data={data} margin={plotMargin}>
+        {plotFrame({
+          max: seriesMax(data, keys),
+          ticks: edgeTicks(data, (row) => String(row.date)),
+          formatValue: (value) => usdWhole.format(value),
+        })}
+        <ChartTooltip content={<ChartTooltipContent />} />
+        <ChartLegend content={<ChartLegendContent />} />
+        {topNames.map((name, index) => (
+          <Line key={name} type="monotone" dataKey={name} name={name} stroke={costSeriesColors[index % costSeriesColors.length]} dot={false} strokeWidth={2} />
+        ))}
+        {drivers.length > 5 && <Line type="monotone" dataKey="Other" name="Other" stroke="var(--ds-neutral-600)" dot={false} strokeWidth={2} />}
+      </LineChart>
+    </ChartContainer>
+  )
+}
+
+const outcomeKeys = ["clean", "humanInTheLoop", "warning", "failed"] as const
+
+function OutcomesChart({ effect }: { effect?: AnalyticsEffectiveness }) {
+  const rows = effect?.outcomesByDay ?? []
+  return (
+    <ChartContainer config={chartConfig} className="h-64 w-full">
+      <BarChart data={rows} margin={plotMargin} barCategoryGap={2}>
+        {plotFrame({ max: stackedMax(rows, outcomeKeys), ticks: edgeTicks(rows, (row) => row.date) })}
+        <ChartTooltip content={<ChartTooltipContent />} />
+        <ChartLegend content={<ChartLegendContent />} />
+        <Bar dataKey="clean" name="Clean" stackId="outcome" fill="var(--color-clean)" />
+        <Bar dataKey="humanInTheLoop" name="Human on the loop" stackId="outcome" fill="var(--color-humanInTheLoop)" />
+        <Bar dataKey="warning" name="Warning" stackId="outcome" fill="var(--color-warning)" />
+        <Bar dataKey="failed" name="Failed" stackId="outcome" fill="var(--color-failed)" />
+      </BarChart>
+    </ChartContainer>
+  )
+}
 function DeliveryFunnel({ effect }: { effect?: AnalyticsEffectiveness }) {
   const stages = [
     ["agentStarted", "Agent started"],
@@ -702,22 +938,163 @@ function DeliveryFunnel({ effect }: { effect?: AnalyticsEffectiveness }) {
     ["prFinished", "PR finished"],
   ] as const
 
-  return <div className="space-y-4 pt-2">{stages.map(([name, label], index) => {
-    const value = effect?.funnel[name] ?? 0
-    const previous = index ? effect?.funnel[stages[index - 1][0]] ?? 0 : 0
-    return <div key={name}><div className="mb-1.5 flex items-baseline justify-between gap-2 text-[13px]"><span>{label}</span><span className="font-extrabold tabular-nums">{value} {index ? <span className="text-[11px] font-normal text-muted-foreground">({formatPercent(previous ? value / previous : undefined)})</span> : ""}</span></div><div className="h-[18px] overflow-hidden rounded-sm bg-foreground/9"><div className="h-full bg-data" style={{ width: `${Math.min(100, (value / (effect?.funnel.agentStarted || 1)) * 100)}%` }} /></div></div>
-  })}</div>
+  return (
+    <div className="grid gap-4 pt-2">
+      {stages.map(([name, label], index) => {
+        const value = effect?.funnel[name] ?? 0
+        const previousStage = index ? stages[index - 1] : undefined
+        const previousValue = previousStage ? effect?.funnel[previousStage[0]] ?? 0 : 0
+        const conversion = previousStage && previousValue ? value / previousValue : undefined
+        return (
+          <div key={name}>
+            <div className="mb-1.5 flex items-baseline justify-between gap-2 text-[13px]">
+              <span>
+                {label}
+                {previousStage && conversion != null && (
+                  <span className="text-[11px] text-muted-foreground">
+                    {" "}· {formatPercent(conversion)} of {previousStage[1].toLowerCase()}
+                  </span>
+                )}
+              </span>
+              <span className="text-[16px] font-extrabold tabular-nums">{value}</span>
+            </div>
+            <div className="h-[18px] overflow-hidden rounded-sm bg-foreground/9">
+              <div
+                className="h-full bg-data"
+                style={{ width: `${Math.min(100, (value / (effect?.funnel.agentStarted || 1)) * 100)}%` }}
+              />
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
 }
-function TicketThroughputChart({ effect }: { effect?: AnalyticsEffectiveness }) { if (!effect?.ticketsByDay?.length) return <p className="py-8 text-center text-sm text-muted-foreground">No ticket data for this period.</p>; return <ChartContainer config={chartConfig} className="h-64 w-full"><BarChart data={effect.ticketsByDay}><CartesianGrid vertical={false} /><XAxis dataKey="date" tickFormatter={formatDate} /><YAxis allowDecimals={false} /><ChartTooltip content={<ChartTooltipContent />} /><Legend {...legendProps} formatter={legendTextFormatter} /><Bar dataKey="delivered" name="Delivered" stackId="ticket" fill="var(--color-ticketDelivered)" /><Bar dataKey="inProgress" name="In progress" stackId="ticket" fill="var(--color-ticketInProgress)" /><Bar dataKey="failed" name="Failed" stackId="ticket" fill="var(--color-ticketFailed)" /></BarChart></ChartContainer> }
-function RunsPerTicketChart({ effect }: { effect?: AnalyticsEffectiveness }) { if (!effect?.runsPerTicket?.length) return <p className="py-8 text-center text-sm text-muted-foreground">No ticket data for this period.</p>; return <ChartContainer config={chartConfig} className="h-64 w-full"><BarChart data={effect.runsPerTicket} layout="vertical" margin={{ right: 36 }}><CartesianGrid horizontal={false} /><XAxis type="number" allowDecimals={false} /><YAxis type="category" dataKey="bucket" width={40} /><Bar dataKey="tickets" fill="var(--color-data)" radius={4}><LabelList dataKey="tickets" position="right" fill="var(--color-foreground)" fontSize={11} /></Bar></BarChart></ChartContainer> }
-function TopTicketTooltip({ active, payload }: { active?: boolean; payload?: { payload?: AnalyticsEffectiveness["topTicketsByCost"][number] }[] }) { const ticket = payload?.[0]?.payload; if (!active || !ticket) return null; const outcome = ticket.outcome === "in_progress" ? "In progress" : ticket.outcome ? ticket.outcome.charAt(0).toUpperCase() + ticket.outcome.slice(1) : "—"; return <div className={`${tooltipContentClassName} px-3 py-2 text-xs`}><div className="font-medium">{ticket.issueTitle}</div><div className="text-muted-foreground">{usd.format(ticket.costUsd)} · {ticket.runs} runs · {outcome}</div></div> }
-function TopTicketsByCostChart({ effect }: { effect?: AnalyticsEffectiveness }) { if (!effect?.topTicketsByCost?.length) return <p className="py-8 text-center text-sm text-muted-foreground">No ticket data for this period.</p>; return <ChartContainer config={chartConfig} className="h-64 w-full"><BarChart data={effect.topTicketsByCost} layout="vertical" margin={{ right: 36 }}><CartesianGrid horizontal={false} /><XAxis type="number" tickFormatter={(value) => usdWhole.format(value)} /><YAxis type="category" dataKey="issueId" width={90} interval={0} tickFormatter={(id) => (id.length > 14 ? id.slice(0, 13) + "…" : id)} /><ChartTooltip content={<TopTicketTooltip />} /><Bar dataKey="costUsd" fill="var(--color-data)" radius={4}><LabelList dataKey="costUsd" position="right" fill="var(--color-foreground)" fontSize={11} formatter={(value: number) => usd.format(value)} /></Bar></BarChart></ChartContainer> }
-function CostPerMergedPrChart({ effect }: { effect?: AnalyticsEffectiveness }) { return <ChartContainer config={chartConfig} className="h-64 w-full"><LineChart data={effect?.costPerMergedPr.weekly}><CartesianGrid vertical={false} /><XAxis dataKey="weekStart" tickFormatter={formatDate} /><YAxis /><ChartTooltip content={<ChartTooltipContent />} /><ReferenceLine y={effect?.costPerMergedPr.average} stroke="var(--ds-neutral-500)" strokeDasharray="4 4" /><Line type="monotone" dataKey="costPerMergedPr" name="Cost per merged PR" stroke="var(--color-costPerMergedPr)" dot={false} /></LineChart></ChartContainer> }
+
+function EmptyPlot({ children }: { children: ReactNode }) {
+  return <p className="py-8 text-center text-sm text-muted-foreground">{children}</p>
+}
+
+// The mockup's .hbars: a fixed label column, a track that carries the bar, and
+// a tabular number. Plain markup — a horizontal Recharts plot buys nothing here
+// and cannot align its rows with the label column.
+function HBars({
+  rows,
+  gridClassName,
+  labelClassName = "",
+}: {
+  rows: { key: string; label: string; value: number; formatted: string; title?: string }[]
+  // Full literal class strings: Tailwind only sees classes it can read verbatim.
+  gridClassName: string
+  labelClassName?: string
+}) {
+  const max = Math.max(...rows.map((row) => row.value), 0)
+  return (
+    <div className="grid gap-2.5 pt-2">
+      {rows.map((row) => (
+        <div
+          key={row.key}
+          title={row.title}
+          className={`grid items-center gap-2 text-xs ${gridClassName}`}
+        >
+          <span className={`truncate ${labelClassName}`}>{row.label}</span>
+          <span className="h-4 overflow-hidden rounded-sm bg-foreground/8">
+            <span className="block h-full bg-data" style={{ width: `${max ? (row.value / max) * 100 : 0}%` }} />
+          </span>
+          <span className="text-right tabular-nums">{row.formatted}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+const ticketKeys = ["delivered", "inProgress", "failed"] as const
+
+function TicketThroughputChart({ effect }: { effect?: AnalyticsEffectiveness }) {
+  const rows = effect?.ticketsByDay ?? []
+  if (!rows.length) return <EmptyPlot>No ticket data for this period.</EmptyPlot>
+  return (
+    <ChartContainer config={chartConfig} className="h-64 w-full">
+      <BarChart data={rows} margin={plotMargin} barCategoryGap={2}>
+        {plotFrame({ max: stackedMax(rows, ticketKeys), ticks: edgeTicks(rows, (row) => row.date) })}
+        <ChartTooltip content={<ChartTooltipContent />} />
+        <ChartLegend content={<ChartLegendContent />} />
+        <Bar dataKey="delivered" name="Delivered" stackId="ticket" fill="var(--color-ticketDelivered)" />
+        <Bar dataKey="inProgress" name="In progress" stackId="ticket" fill="var(--color-ticketInProgress)" />
+        <Bar dataKey="failed" name="Failed" stackId="ticket" fill="var(--color-ticketFailed)" />
+      </BarChart>
+    </ChartContainer>
+  )
+}
+
+function RunsPerTicketChart({ effect }: { effect?: AnalyticsEffectiveness }) {
+  const buckets = effect?.runsPerTicket ?? []
+  if (!buckets.length) return <EmptyPlot>No ticket data for this period.</EmptyPlot>
+  return (
+    <HBars
+      gridClassName="grid-cols-[88px_minmax(0,1fr)_56px]"
+      rows={buckets.map((bucket) => ({
+        key: bucket.bucket,
+        label: `${bucket.bucket} ${bucket.bucket === "1" ? "run" : "runs"}`,
+        value: bucket.tickets,
+        formatted: String(bucket.tickets),
+      }))}
+    />
+  )
+}
+
+function TopTicketsByCostChart({ effect }: { effect?: AnalyticsEffectiveness }) {
+  const tickets = effect?.topTicketsByCost ?? []
+  if (!tickets.length) return <EmptyPlot>No ticket data for this period.</EmptyPlot>
+  return (
+    <HBars
+      gridClassName="grid-cols-[110px_minmax(0,1fr)_64px]"
+      labelClassName="font-mono"
+      rows={tickets.map((ticket) => ({
+        key: ticket.issueId,
+        label: ticket.issueId,
+        value: ticket.costUsd,
+        formatted: usd.format(ticket.costUsd),
+        // The detail the old Recharts tooltip carried, kept on the row itself.
+        title: `${ticket.issueTitle} — ${usd.format(ticket.costUsd)} · ${ticket.runs} runs`,
+      }))}
+    />
+  )
+}
+function CostPerMergedPrChart({ effect }: { effect?: AnalyticsEffectiveness }) {
+  const rows = effect?.costPerMergedPr.weekly ?? []
+  const average = effect?.costPerMergedPr.average ?? 0
+  const scale = yScale(Math.max(seriesMax(rows, ["costPerMergedPr"]), average))
+  return (
+    <ChartContainer config={chartConfig} className="h-64 w-full">
+      <LineChart data={rows} margin={plotMargin}>
+        <ReferenceLine y={scale.mid} {...hairline} />
+        <ReferenceLine y={0} {...hairline} />
+        <XAxis
+          dataKey="weekStart"
+          ticks={edgeTicks(rows, (row) => row.weekStart)}
+          tickFormatter={formatDate}
+          {...axisProps}
+        />
+        <YAxis
+          width={34}
+          domain={scale.domain}
+          ticks={scale.ticks}
+          tickFormatter={(value) => usdWhole.format(value)}
+          {...axisProps}
+        />
+        <ChartTooltip content={<ChartTooltipContent />} />
+        <ChartLegend content={<ChartLegendContent />} />
+        <ReferenceLine y={average} stroke="var(--ds-neutral-500)" strokeDasharray="4 4" />
+        <Line type="monotone" dataKey="costPerMergedPr" name="Cost per merged PR" stroke="var(--color-costPerMergedPr)" dot={false} strokeWidth={2} />
+      </LineChart>
+    </ChartContainer>
+  )
+}
 function CostDrivers({ drivers }: { drivers: AnalyticsCostDriver[] }) {
-  return <section className="rounded-lg border border-border bg-card p-4"><div className="mb-3 flex items-center justify-between gap-3"><div><div className="flex items-center gap-1.5"><h2 className="text-[15px]">Top cost drivers</h2><InfoTooltip text="Where the money goes: total spend and efficiency per workflow in the selected period." /></div><p className="mt-0.5 text-xs text-muted-foreground">By workflow</p></div></div><Table><TableHeader><TableRow><TableHead>Workflow</TableHead><TableHead className="text-right">Runs</TableHead><TableHead className="text-right">Success</TableHead><TableHead className="text-right">Cost</TableHead><TableHead className="text-right">Cost / merged PR</TableHead></TableRow></TableHeader><TableBody>{drivers.slice(0, 10).map((driver) => <TableRow key={driver.name}><TableCell className="font-medium">{driver.name}</TableCell><TableCell className="text-right tabular-nums">{driver.runs}</TableCell><TableCell className="text-right tabular-nums">{formatPercent(driver.successRate)}</TableCell><TableCell className="text-right tabular-nums">{usd.format(driver.costUsd)}</TableCell><TableCell className="text-right tabular-nums">{usd.format(driver.costPerMergedPr)}</TableCell></TableRow>)}</TableBody></Table></section>
+  return <section className="rounded-lg border border-border bg-card p-4"><PanelHeader title="Top cost drivers" description="By workflow — total spend and efficiency in the selected period." /><Table><TableHeader><TableRow><TableHead>Workflow</TableHead><TableHead className="text-right">Runs</TableHead><TableHead className="text-right">Success</TableHead><TableHead className="text-right">Cost</TableHead><TableHead className="text-right">Cost / merged PR</TableHead></TableRow></TableHeader><TableBody>{drivers.slice(0, 10).map((driver) => <TableRow key={driver.name}><TableCell className="font-medium">{driver.name}</TableCell><TableCell className="text-right tabular-nums">{driver.runs}</TableCell><TableCell className="text-right tabular-nums">{formatPercent(driver.successRate)}</TableCell><TableCell className="text-right tabular-nums">{usd.format(driver.costUsd)}</TableCell><TableCell className="text-right tabular-nums">{usd.format(driver.costPerMergedPr)}</TableCell></TableRow>)}</TableBody></Table></section>
 }
 const runsTableRightAlignedHeaders = new Set(["Cost", "Duration", "Start date"])
-function RunsTable({ runs, page, canGoPrevious, canGoNext, onSelect, onPrevious, onNext }: { runs: TaskRunSummary[]; page: number; canGoPrevious: boolean; canGoNext: boolean; onSelect: (runId: string) => void; onPrevious: () => void; onNext: () => void }) { return <section className="rounded-lg border border-border bg-card p-4"><h2 className="mb-3 text-[15px]">Runs</h2><Table><TableHeader><TableRow>{["Status", "Ticket", "Model", "Factory/Workflow", "Cost", "Duration", "Start date"].map((label) => <TableHead key={label} className={runsTableRightAlignedHeaders.has(label) ? "text-right" : ""}>{label}</TableHead>)}</TableRow></TableHeader><TableBody>{runs.map((run) => <TableRow key={run.runId} className="cursor-pointer" onClick={() => onSelect(run.runId)}><TableCell><StatusBadge status={run.status} /></TableCell><TableCell className="font-mono">{run.issueId || "—"}</TableCell><TableCell>{run.model || "—"}</TableCell><TableCell>{run.factoryName || run.workflowName || "—"}</TableCell><TableCell className="text-right tabular-nums">{usd.format(run.estimatedCostUsd || 0)}</TableCell><TableCell className="text-right tabular-nums">{formatDuration(run.finishedAt ? run.finishedAt - run.startedAt : undefined)}</TableCell><TableCell className="text-right tabular-nums">{run.startedAt ? new Date(run.startedAt).toLocaleDateString() : "—"}</TableCell></TableRow>)}</TableBody></Table><div className="mt-3 flex items-center justify-center gap-3"><Button variant="outline" size="sm" disabled={!canGoPrevious} onClick={onPrevious}>Previous</Button><span className="text-sm text-muted-foreground">Page {page}</span><Button variant="outline" size="sm" disabled={!canGoNext} onClick={onNext}>Next</Button></div></section> }
+function RunsTable({ runs, page, canGoPrevious, canGoNext, onSelect, onPrevious, onNext }: { runs: TaskRunSummary[]; page: number; canGoPrevious: boolean; canGoNext: boolean; onSelect: (runId: string) => void; onPrevious: () => void; onNext: () => void }) { return <section className="rounded-lg border border-border bg-card p-4"><PanelHeader title="Runs" description="Every run in the selected period. Click a row for attempts, events and PRs." /><Table><TableHeader><TableRow>{["Status", "Ticket", "Model", "Factory/Workflow", "Cost", "Duration", "Start date"].map((label) => <TableHead key={label} className={runsTableRightAlignedHeaders.has(label) ? "text-right" : ""}>{label}</TableHead>)}</TableRow></TableHeader><TableBody>{runs.map((run) => <TableRow key={run.runId} className="cursor-pointer" onClick={() => onSelect(run.runId)}><TableCell><StatusBadge status={run.status} /></TableCell><TableCell className="font-mono">{run.issueId || "—"}</TableCell><TableCell>{run.model || "—"}</TableCell><TableCell>{run.factoryName || run.workflowName || "—"}</TableCell><TableCell className="text-right tabular-nums">{usd.format(run.estimatedCostUsd || 0)}</TableCell><TableCell className="text-right tabular-nums">{formatDuration(run.finishedAt ? run.finishedAt - run.startedAt : undefined)}</TableCell><TableCell className="text-right tabular-nums">{run.startedAt ? new Date(run.startedAt).toLocaleDateString() : "—"}</TableCell></TableRow>)}</TableBody></Table><div className="mt-3 flex items-center justify-center gap-3"><Button variant="outline" size="sm" disabled={!canGoPrevious} onClick={onPrevious}>Previous</Button><span className="text-sm text-muted-foreground">Page {page}</span><Button variant="outline" size="sm" disabled={!canGoNext} onClick={onNext}>Next</Button></div></section> }
 function calculateDelta(current?: number | null, prior?: number | null) { return current == null || prior == null || prior === 0 ? undefined : (current - prior) / prior }
 function KpiGroup({ title, columns = "sm:grid-cols-5", children }: { title: string; columns?: string; children: ReactNode }) { return <div><p className="kicker mb-2 font-semibold text-muted-foreground">{title}</p><div className={`grid grid-cols-2 gap-2 ${columns}`}>{children}</div></div> }
 function Kpi({ label, value, change, good, cost, onClick, title }: { label: string; value?: string | number; change?: number; good?: boolean; cost?: boolean; onClick?: () => void; title?: string }) {
@@ -728,31 +1105,31 @@ function Kpi({ label, value, change, good, cost, onClick, title }: { label: stri
       type="button"
       disabled={disabled}
       onClick={onClick}
-      className="flex h-full w-full min-w-0 flex-col rounded-lg border border-border bg-card p-3 text-left transition-colors enabled:hover:bg-foreground/4"
+      className="grid h-full w-full min-w-0 grid-rows-[auto_1fr_auto] gap-1.5 rounded-lg border border-border bg-card p-3 text-left transition-colors enabled:hover:bg-foreground/4"
     >
-      <p className="flex min-h-8 items-center gap-1 text-[11px] leading-[1.35] text-muted-foreground">
+      {/* Three rows — label, value, delta — so labels of different lengths
+          never push the values out of line across the grid. */}
+      <span className="flex items-start gap-1 text-pretty text-[11px] leading-[1.35] text-muted-foreground">
         {label}
-        {title && <Info aria-hidden className="size-3.5 shrink-0 text-muted-foreground" />}
-      </p>
-      <div className="mt-auto">
-      <p className="mt-2 text-[23px] font-extrabold leading-none tracking-[-0.02em] tabular-nums">{value ?? "—"}</p>
-      {/* Always render the delta row, even when there's no change, so every
-          tile reserves the same space and labels/values align across the grid. */}
-      <p
-        className={`mt-1.5 truncate text-[11px] font-semibold ${
+        {title && <Info aria-hidden className="mt-px size-3.5 shrink-0 text-muted-foreground" />}
+      </span>
+      <span className="self-end text-[23px] font-extrabold leading-none tracking-[-0.02em] tabular-nums">{value ?? "—"}</span>
+      {/* Always render the delta row, even when the API has no prior-period
+          value to compare against, so every tile reserves the same space. */}
+      <span
+        className={`flex min-h-[15px] items-center gap-1 truncate whitespace-nowrap text-[11px] font-semibold ${
           change == null ? "invisible" : bad ? "text-primary" : "text-status-ok"
         }`}
       >
         {change != null ? (
           <>
-            {change > 0 ? "+" : ""}
-            {(change * 100).toFixed(1)}% <span className="font-normal text-muted-foreground">vs prior</span>
+            {change > 0 ? "↑" : "↓"} {Math.abs(change * 100).toFixed(1)}%{" "}
+            <span className="font-normal text-muted-foreground">vs prior</span>
           </>
         ) : (
           " "
         )}
-      </p>
-      </div>
+      </span>
     </button>
   )
   if (!title) return button
@@ -787,4 +1164,26 @@ function InfoTooltip({ text }: { text: string }) {
     </Tooltip>
   )
 }
-function ChartCard({ title, info, children }: { title: string; info?: string; children: ReactNode }) { return <section className="rounded-lg border border-border bg-card p-4"><div className="mb-3 flex items-center gap-1.5"><h2 className="text-[15px]">{title}</h2>{info && <InfoTooltip text={info} />}</div>{children}</section> }
+// Panel header: a 15px Archivo-800 title and a 12px muted line saying what the
+// panel shows. The info tooltip stays only where it carries more than the
+// description does.
+function PanelHeader({ title, description, info }: { title: string; description?: string; info?: string }) {
+  return (
+    <header className="mb-3 grid gap-0.5">
+      <div className="flex items-center gap-1.5">
+        <h2 className="text-[15px]">{title}</h2>
+        {info && <InfoTooltip text={info} />}
+      </div>
+      {description && <p className="text-xs text-muted-foreground">{description}</p>}
+    </header>
+  )
+}
+
+function ChartCard({ title, description, info, children }: { title: string; description?: string; info?: string; children: ReactNode }) {
+  return (
+    <section className="rounded-lg border border-border bg-card p-4">
+      <PanelHeader title={title} description={description} info={info} />
+      {children}
+    </section>
+  )
+}

--- a/web/components/analytics-command-center.tsx
+++ b/web/components/analytics-command-center.tsx
@@ -71,18 +71,43 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 const commandCenterUrlFilterKeys = ["workspace", ...urlFilterKeys, "from", "to"] as const
 // Matches the heatmap's custom tooltip (bg-card/border/shadow-md) so every
 // explanatory tooltip in this file shares one look, in both themes.
-const tooltipContentClassName = "max-w-xs rounded-lg border bg-card text-foreground shadow-md"
+const tooltipContentClassName = "max-w-xs rounded-lg border border-border bg-card text-card-foreground shadow-ds-md"
 const tooltipArrowClassName = "bg-card fill-card"
+// One semantic scale for every chart on this screen. Outcome series always read
+// as outcome colors (clean = ok, human = neutral, warning = warn, failed =
+// accent); money and volume series read as the single data-blue ramp, so cost
+// can never be mistaken for an outcome. Everything points at a theme token so
+// the charts re-tint with the design system rather than at a frozen hex.
 const chartConfig = {
-  clean: { label: "Clean", color: "#0ca30c" },
-  humanInTheLoop: { label: "Human on the loop", color: "#2a78d6" },
-  warning: { label: "Warning", color: "#fab219" },
-  failed: { label: "Failed", color: "#d03b3b" },
-  ticketDelivered: { label: "Delivered", color: "#0ca30c" },
-  ticketInProgress: { label: "In progress", color: "#64748b" },
-  ticketFailed: { label: "Failed", color: "#d03b3b" },
-  costPerMergedPr: { label: "Cost / merged PR", color: "var(--chart-1)" },
+  clean: { label: "Clean", color: "var(--color-status-ok)" },
+  humanInTheLoop: { label: "Human on the loop", color: "var(--ds-neutral-500)" },
+  warning: { label: "Warning", color: "var(--color-status-warn)" },
+  failed: { label: "Failed", color: "var(--color-primary)" },
+  ticketDelivered: { label: "Delivered", color: "var(--color-status-ok)" },
+  ticketInProgress: { label: "In progress", color: "var(--ds-neutral-500)" },
+  ticketFailed: { label: "Failed", color: "var(--color-primary)" },
+  costPerMergedPr: { label: "Cost / merged PR", color: "var(--color-data)" },
 } satisfies ChartConfig
+// Legends: small square swatches over a 1px rule, muted 11px labels.
+const legendProps = {
+  iconType: "square",
+  iconSize: 9,
+  wrapperStyle: {
+    fontSize: 11,
+    paddingTop: 10,
+    marginTop: 4,
+    borderTop: "1px solid var(--color-border)",
+  },
+} as const
+// Money and volume series step down the single data-blue ramp and end on the
+// neutrals, so a cost series is never confused with an outcome color.
+const costSeriesColors = [
+  "var(--color-data)",
+  "var(--color-data-light)",
+  "var(--color-data-dark)",
+  "var(--ds-neutral-600)",
+  "var(--ds-neutral-400)",
+]
 const usd = new Intl.NumberFormat(undefined, {
   style: "currency",
   currency: "USD",
@@ -403,8 +428,8 @@ export function AnalyticsCommandCenter() {
   return (
     <main className="h-full overflow-auto bg-background">
       <div className="mx-auto max-w-[1400px] space-y-5 p-5 lg:p-6">
-        <header>
-          <h1 className="text-2xl font-semibold tracking-tight">Analytics</h1>
+        <header className="border-b-2 border-border pb-4">
+          <h1 className="text-2xl tracking-tight">Analytics</h1>
         </header>
         <FilterBar filters={filters} options={options} workspaces={workspaceNames} onChange={setFilters} />
         {error && <p className="text-sm text-destructive">{error}</p>}
@@ -561,7 +586,7 @@ function WorkspaceSelect({
       value={value ?? allWorkspacesValue}
       onValueChange={(next) => onChange(next === allWorkspacesValue ? undefined : next)}
     >
-      <SelectTrigger size="sm" className="w-full bg-background font-medium">
+      <SelectTrigger size="sm" className="w-full text-[13px] font-medium">
         <span className="truncate">
           <span className="text-muted-foreground font-normal">Workspace:</span> {value ?? "All workspaces"}
         </span>
@@ -595,7 +620,7 @@ function FilterBar({
   ] as const
 
   return (
-    <div className="flex flex-wrap gap-2 rounded-lg border bg-card p-2">
+    <div className="flex flex-wrap items-center gap-2 rounded-lg border border-border bg-card p-2">
       <div className="w-56">
         <WorkspaceSelect
           value={filters.workspace}
@@ -603,13 +628,13 @@ function FilterBar({
           onChange={(value) => onChange({ workspace: value })}
         />
       </div>
-      <div className="flex overflow-hidden rounded-md border">
+      <div className="flex h-8 divide-x divide-border overflow-hidden rounded-md border border-border">
         {[["7d", 7], ["30d", 30], ["90d", 90], ["MTD", 0]].map(([label, days]) => (
           <Button
             key={label}
             variant="ghost"
             size="sm"
-            className="rounded-none"
+            className="h-full rounded-none text-[13px] font-medium text-foreground"
             onClick={() => {
               const to = new Date()
               const from = new Date()
@@ -662,14 +687,14 @@ function Heatmap({ heatmap, maxCost, selectedDay, onSelectDay, onClearSelectedDa
   }
   const selectedDayLabel = selectedDay && new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric", year: "numeric" }).format(new Date(`${selectedDay}T00:00:00`))
 
-  return <section ref={containerRef} className="relative rounded-lg border bg-card p-4"><div className="mb-4 flex items-center gap-1"><h2 className="text-sm font-semibold">Cost by day</h2><InfoTooltip text="Each square is a day; darker means more spend. Click a day to focus the whole page on it." />{selectedDayLabel && <span className="ml-2 inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">{selectedDayLabel}<button type="button" aria-label={`Clear ${selectedDayLabel} filter`} onClick={onClearSelectedDay} className="rounded-full px-0.5 text-foreground hover:bg-accent">×</button></span>}</div><div className="flex gap-2"><div className="flex w-6 flex-col text-center text-[10px] text-muted-foreground"><div className="mb-1 h-4" aria-hidden="true" /><div className="grid flex-1 grid-rows-7 gap-1">{["M", "T", "W", "T", "F", "S", "S"].map((day, index) => <span key={`${day}-${index}`} className="flex items-center justify-center">{day}</span>)}</div></div><div className="min-w-0 flex-1"><div className="relative mb-1 h-4 text-[10px] text-muted-foreground">{heatmap.monthLabels.map(({ week, label }) => <span key={`${week}-${label}`} className="absolute" style={{ left: `${(week / 52) * 100}%` }}>{label}</span>)}</div><div className="grid grid-flow-col grid-cols-[repeat(52,minmax(0,1fr))] grid-rows-7 gap-1">{heatmap.days.map(({ iso, point }) => { const level = point?.costUsd ? Math.min(5, Math.ceil((point.costUsd / maxCost) * 5)) : 0; const selected = iso === selectedDay; return <button key={iso} onClick={() => onSelectDay(iso)} onMouseEnter={(event) => showTooltip(iso, point, event.clientX, event.clientY)} onMouseMove={(event) => showTooltip(iso, point, event.clientX, event.clientY)} onMouseLeave={() => setTooltip(null)} onFocus={(event) => { const rect = event.currentTarget.getBoundingClientRect(); showTooltip(iso, point, rect.left + rect.width / 2, rect.top + rect.height / 2) }} onBlur={() => setTooltip(null)} className={`aspect-square cursor-pointer rounded-sm border border-black/5 transition-shadow hover:ring-2 hover:ring-ring hover:ring-offset-1 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 ${selected ? "ring-2 ring-primary ring-offset-1" : ""}`} style={{ background: level ? `var(--heatmap-${level})` : "var(--muted)" }} /> })}</div></div></div>{tooltip && <div role="tooltip" className="pointer-events-none absolute z-10 rounded-lg border bg-card px-2 py-1.5 text-xs text-foreground shadow-md" style={{ left: tooltip.x, top: tooltip.y }}><div>{new Intl.DateTimeFormat(undefined, { weekday: "short", month: "short", day: "numeric", year: "numeric" }).format(new Date(`${tooltip.iso}T00:00:00`))}</div><div className="text-muted-foreground">{usdWhole.format(tooltip.point?.costUsd ?? 0)} · {tooltip.point?.runCount ?? 0} runs</div></div>}<div className="mt-3 flex justify-end gap-1 text-xs text-muted-foreground">Less {Array.from({ length: 5 }, (_, index) => <i key={index} className="size-3 rounded-sm" style={{ background: `var(--heatmap-${index + 1})` }} />)} More</div></section>
+  return <section ref={containerRef} className="relative rounded-lg border border-border bg-card p-4"><div className="mb-4 flex items-center gap-1.5"><h2 className="text-[15px]">Cost by day</h2><InfoTooltip text="Each square is a day; darker means more spend. Click a day to focus the whole page on it." />{selectedDayLabel && <span className="ml-2 inline-flex items-center gap-1 rounded-full border border-border px-2 py-0.5 font-mono text-[11px] text-muted-foreground">{selectedDayLabel}<button type="button" aria-label={`Clear ${selectedDayLabel} filter`} onClick={onClearSelectedDay} className="rounded-full px-0.5 text-foreground hover:bg-foreground/10">×</button></span>}</div><div className="flex gap-2"><div className="flex w-6 flex-col text-center font-mono text-[10px] text-muted-foreground"><div className="mb-1 h-4" aria-hidden="true" /><div className="grid flex-1 grid-rows-7 gap-1">{["M", "T", "W", "T", "F", "S", "S"].map((day, index) => <span key={`${day}-${index}`} className="flex items-center justify-center">{day}</span>)}</div></div><div className="min-w-0 flex-1"><div className="relative mb-1 h-4 font-mono text-[10px] text-muted-foreground">{heatmap.monthLabels.map(({ week, label }) => <span key={`${week}-${label}`} className="absolute" style={{ left: `${(week / 52) * 100}%` }}>{label}</span>)}</div><div className="grid grid-flow-col grid-cols-[repeat(52,minmax(0,1fr))] grid-rows-7 gap-1">{heatmap.days.map(({ iso, point }) => { const level = point?.costUsd ? Math.min(5, Math.ceil((point.costUsd / maxCost) * 5)) : 0; const selected = iso === selectedDay; return <button key={iso} onClick={() => onSelectDay(iso)} onMouseEnter={(event) => showTooltip(iso, point, event.clientX, event.clientY)} onMouseMove={(event) => showTooltip(iso, point, event.clientX, event.clientY)} onMouseLeave={() => setTooltip(null)} onFocus={(event) => { const rect = event.currentTarget.getBoundingClientRect(); showTooltip(iso, point, rect.left + rect.width / 2, rect.top + rect.height / 2) }} onBlur={() => setTooltip(null)} className={`aspect-square cursor-pointer rounded-sm border border-foreground/8 transition-shadow hover:ring-2 hover:ring-ring hover:ring-offset-1 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 ${selected ? "ring-2 ring-primary ring-offset-1" : ""}`} style={{ background: level ? `var(--heatmap-${level})` : "var(--muted)" }} /> })}</div></div></div>{tooltip && <div role="tooltip" className="pointer-events-none absolute z-10 rounded-lg border border-border bg-card px-2 py-1.5 text-xs text-foreground shadow-ds-md" style={{ left: tooltip.x, top: tooltip.y }}><div>{new Intl.DateTimeFormat(undefined, { weekday: "short", month: "short", day: "numeric", year: "numeric" }).format(new Date(`${tooltip.iso}T00:00:00`))}</div><div className="text-muted-foreground">{usdWhole.format(tooltip.point?.costUsd ?? 0)} · {tooltip.point?.runCount ?? 0} runs</div></div>}<div className="mt-3 flex items-center justify-end gap-1 text-[11px] text-muted-foreground">Less {Array.from({ length: 5 }, (_, index) => <i key={index} className="size-[11px] rounded-[2px]" style={{ background: `var(--heatmap-${index + 1})` }} />)} More</div></section>
 }
 
 function useModelData(costs?: CostOverview) { return useMemo(() => { const models = (costs?.seriesByModel ?? []).slice(0, 4); return (costs?.dailySeries ?? []).map((day, index) => ({ date: day.date, Other: Math.max(0, day.costUsd - models.reduce((sum, model) => sum + (model.dailySeries[index]?.costUsd ?? 0), 0)), ...Object.fromEntries(models.map((model) => [model.model, model.dailySeries[index]?.costUsd ?? 0])) })) }, [costs]) }
 function useWorkflowCostComparisonData(drivers: AnalyticsCostDriver[]) { return useMemo(() => { const topDrivers = [...drivers].sort((a, b) => b.costUsd - a.costUsd).slice(0, 5); const topNames = topDrivers.map((driver) => driver.name); const topNameSet = new Set(topNames); const dataByDate = new Map<string, Record<string, string | number>>(); for (const driver of drivers) for (const point of driver.dailyCost) { const row = dataByDate.get(point.date) ?? { date: point.date, Other: 0, ...Object.fromEntries(topNames.map((name) => [name, 0])) }; if (topNameSet.has(driver.name)) row[driver.name] = Number(row[driver.name]) + point.costUsd; else row.Other = Number(row.Other) + point.costUsd; dataByDate.set(point.date, row) } return { data: [...dataByDate.values()].sort((a, b) => String(a.date).localeCompare(String(b.date))), topNames } }, [drivers]) }
-function DailyCostChart({ costs, modelData }: { costs?: CostOverview; modelData: Record<string, string | number>[] }) { const labels = [...(costs?.seriesByModel ?? []).slice(0, 4).map((item) => item.model), "Other"]; return <ChartContainer config={chartConfig} className="h-64 w-full"><BarChart data={modelData}><CartesianGrid vertical={false} /><XAxis dataKey="date" tickFormatter={formatDate} /><YAxis /><ChartTooltip content={<ChartTooltipContent />} /><Legend formatter={legendTextFormatter} />{labels.map((label, index) => <Bar key={label} dataKey={label} name={label} stackId="cost" fill={`var(--chart-${index + 1})`} />)}</BarChart></ChartContainer> }
-function WorkflowCostComparisonChart({ drivers }: { drivers: AnalyticsCostDriver[] }) { const { data, topNames } = useWorkflowCostComparisonData(drivers); if (drivers.length === 0) return <p className="py-8 text-center text-sm text-muted-foreground">No cost data for this period.</p>; return <ChartContainer config={chartConfig} className="h-64 w-full"><LineChart data={data}><CartesianGrid vertical={false} /><XAxis dataKey="date" tickFormatter={formatDate} /><YAxis /><ChartTooltip content={<ChartTooltipContent />} /><Legend formatter={legendTextFormatter} />{topNames.map((name, index) => <Line key={name} type="monotone" dataKey={name} name={name} stroke={`var(--chart-${index + 1})`} dot={false} strokeWidth={2} />)}{drivers.length > 5 && <Line type="monotone" dataKey="Other" name="Other" stroke="var(--muted-foreground)" dot={false} strokeWidth={2} />}</LineChart></ChartContainer> }
-function OutcomesChart({ effect }: { effect?: AnalyticsEffectiveness }) { return <ChartContainer config={chartConfig} className="h-64 w-full"><BarChart data={effect?.outcomesByDay}><CartesianGrid vertical={false} /><XAxis dataKey="date" tickFormatter={formatDate} /><YAxis allowDecimals={false} /><ChartTooltip content={<ChartTooltipContent />} /><Legend formatter={legendTextFormatter} /><Bar dataKey="clean" name="Clean" stackId="outcome" fill="var(--color-clean)" /><Bar dataKey="humanInTheLoop" name="Human on the loop" stackId="outcome" fill="var(--color-humanInTheLoop)" /><Bar dataKey="warning" name="Warning" stackId="outcome" fill="var(--color-warning)" /><Bar dataKey="failed" name="Failed" stackId="outcome" fill="var(--color-failed)" /></BarChart></ChartContainer> }
+function DailyCostChart({ costs, modelData }: { costs?: CostOverview; modelData: Record<string, string | number>[] }) { const labels = [...(costs?.seriesByModel ?? []).slice(0, 4).map((item) => item.model), "Other"]; return <ChartContainer config={chartConfig} className="h-64 w-full"><BarChart data={modelData}><CartesianGrid vertical={false} /><XAxis dataKey="date" tickFormatter={formatDate} /><YAxis /><ChartTooltip content={<ChartTooltipContent />} /><Legend {...legendProps} formatter={legendTextFormatter} />{labels.map((label, index) => <Bar key={label} dataKey={label} name={label} stackId="cost" fill={costSeriesColors[index % costSeriesColors.length]} />)}</BarChart></ChartContainer> }
+function WorkflowCostComparisonChart({ drivers }: { drivers: AnalyticsCostDriver[] }) { const { data, topNames } = useWorkflowCostComparisonData(drivers); if (drivers.length === 0) return <p className="py-8 text-center text-sm text-muted-foreground">No cost data for this period.</p>; return <ChartContainer config={chartConfig} className="h-64 w-full"><LineChart data={data}><CartesianGrid vertical={false} /><XAxis dataKey="date" tickFormatter={formatDate} /><YAxis /><ChartTooltip content={<ChartTooltipContent />} /><Legend {...legendProps} formatter={legendTextFormatter} />{topNames.map((name, index) => <Line key={name} type="monotone" dataKey={name} name={name} stroke={costSeriesColors[index % costSeriesColors.length]} dot={false} strokeWidth={2} />)}{drivers.length > 5 && <Line type="monotone" dataKey="Other" name="Other" stroke="var(--muted-foreground)" dot={false} strokeWidth={2} />}</LineChart></ChartContainer> }
+function OutcomesChart({ effect }: { effect?: AnalyticsEffectiveness }) { return <ChartContainer config={chartConfig} className="h-64 w-full"><BarChart data={effect?.outcomesByDay}><CartesianGrid vertical={false} /><XAxis dataKey="date" tickFormatter={formatDate} /><YAxis allowDecimals={false} /><ChartTooltip content={<ChartTooltipContent />} /><Legend {...legendProps} formatter={legendTextFormatter} /><Bar dataKey="clean" name="Clean" stackId="outcome" fill="var(--color-clean)" /><Bar dataKey="humanInTheLoop" name="Human on the loop" stackId="outcome" fill="var(--color-humanInTheLoop)" /><Bar dataKey="warning" name="Warning" stackId="outcome" fill="var(--color-warning)" /><Bar dataKey="failed" name="Failed" stackId="outcome" fill="var(--color-failed)" /></BarChart></ChartContainer> }
 function DeliveryFunnel({ effect }: { effect?: AnalyticsEffectiveness }) {
   const stages = [
     ["agentStarted", "Agent started"],
@@ -677,24 +702,24 @@ function DeliveryFunnel({ effect }: { effect?: AnalyticsEffectiveness }) {
     ["prFinished", "PR finished"],
   ] as const
 
-  return <div className="space-y-3 pt-3">{stages.map(([name, label], index) => {
+  return <div className="space-y-4 pt-2">{stages.map(([name, label], index) => {
     const value = effect?.funnel[name] ?? 0
     const previous = index ? effect?.funnel[stages[index - 1][0]] ?? 0 : 0
-    return <div key={name}><div className="mb-1 flex justify-between text-sm"><span>{label}</span><span className="tabular-nums">{value} {index ? `(${formatPercent(previous ? value / previous : undefined)})` : ""}</span></div><div className="h-5 rounded bg-muted"><div className="h-full rounded bg-chart-1" style={{ width: `${Math.min(100, (value / (effect?.funnel.agentStarted || 1)) * 100)}%` }} /></div></div>
+    return <div key={name}><div className="mb-1.5 flex items-baseline justify-between gap-2 text-[13px]"><span>{label}</span><span className="font-extrabold tabular-nums">{value} {index ? <span className="text-[11px] font-normal text-muted-foreground">({formatPercent(previous ? value / previous : undefined)})</span> : ""}</span></div><div className="h-[18px] overflow-hidden rounded-sm bg-foreground/9"><div className="h-full bg-data" style={{ width: `${Math.min(100, (value / (effect?.funnel.agentStarted || 1)) * 100)}%` }} /></div></div>
   })}</div>
 }
-function TicketThroughputChart({ effect }: { effect?: AnalyticsEffectiveness }) { if (!effect?.ticketsByDay?.length) return <p className="py-8 text-center text-sm text-muted-foreground">No ticket data for this period.</p>; return <ChartContainer config={chartConfig} className="h-64 w-full"><BarChart data={effect.ticketsByDay}><CartesianGrid vertical={false} /><XAxis dataKey="date" tickFormatter={formatDate} /><YAxis allowDecimals={false} /><ChartTooltip content={<ChartTooltipContent />} /><Legend formatter={legendTextFormatter} /><Bar dataKey="delivered" name="Delivered" stackId="ticket" fill="var(--color-ticketDelivered)" /><Bar dataKey="inProgress" name="In progress" stackId="ticket" fill="var(--color-ticketInProgress)" /><Bar dataKey="failed" name="Failed" stackId="ticket" fill="var(--color-ticketFailed)" /></BarChart></ChartContainer> }
-function RunsPerTicketChart({ effect }: { effect?: AnalyticsEffectiveness }) { if (!effect?.runsPerTicket?.length) return <p className="py-8 text-center text-sm text-muted-foreground">No ticket data for this period.</p>; return <ChartContainer config={chartConfig} className="h-64 w-full"><BarChart data={effect.runsPerTicket} layout="vertical" margin={{ right: 36 }}><CartesianGrid horizontal={false} /><XAxis type="number" allowDecimals={false} /><YAxis type="category" dataKey="bucket" width={40} /><Bar dataKey="tickets" fill="var(--chart-1)" radius={4}><LabelList dataKey="tickets" position="right" /></Bar></BarChart></ChartContainer> }
+function TicketThroughputChart({ effect }: { effect?: AnalyticsEffectiveness }) { if (!effect?.ticketsByDay?.length) return <p className="py-8 text-center text-sm text-muted-foreground">No ticket data for this period.</p>; return <ChartContainer config={chartConfig} className="h-64 w-full"><BarChart data={effect.ticketsByDay}><CartesianGrid vertical={false} /><XAxis dataKey="date" tickFormatter={formatDate} /><YAxis allowDecimals={false} /><ChartTooltip content={<ChartTooltipContent />} /><Legend {...legendProps} formatter={legendTextFormatter} /><Bar dataKey="delivered" name="Delivered" stackId="ticket" fill="var(--color-ticketDelivered)" /><Bar dataKey="inProgress" name="In progress" stackId="ticket" fill="var(--color-ticketInProgress)" /><Bar dataKey="failed" name="Failed" stackId="ticket" fill="var(--color-ticketFailed)" /></BarChart></ChartContainer> }
+function RunsPerTicketChart({ effect }: { effect?: AnalyticsEffectiveness }) { if (!effect?.runsPerTicket?.length) return <p className="py-8 text-center text-sm text-muted-foreground">No ticket data for this period.</p>; return <ChartContainer config={chartConfig} className="h-64 w-full"><BarChart data={effect.runsPerTicket} layout="vertical" margin={{ right: 36 }}><CartesianGrid horizontal={false} /><XAxis type="number" allowDecimals={false} /><YAxis type="category" dataKey="bucket" width={40} /><Bar dataKey="tickets" fill="var(--color-data)" radius={4}><LabelList dataKey="tickets" position="right" fill="var(--color-foreground)" fontSize={11} /></Bar></BarChart></ChartContainer> }
 function TopTicketTooltip({ active, payload }: { active?: boolean; payload?: { payload?: AnalyticsEffectiveness["topTicketsByCost"][number] }[] }) { const ticket = payload?.[0]?.payload; if (!active || !ticket) return null; const outcome = ticket.outcome === "in_progress" ? "In progress" : ticket.outcome ? ticket.outcome.charAt(0).toUpperCase() + ticket.outcome.slice(1) : "—"; return <div className={`${tooltipContentClassName} px-3 py-2 text-xs`}><div className="font-medium">{ticket.issueTitle}</div><div className="text-muted-foreground">{usd.format(ticket.costUsd)} · {ticket.runs} runs · {outcome}</div></div> }
-function TopTicketsByCostChart({ effect }: { effect?: AnalyticsEffectiveness }) { if (!effect?.topTicketsByCost?.length) return <p className="py-8 text-center text-sm text-muted-foreground">No ticket data for this period.</p>; return <ChartContainer config={chartConfig} className="h-64 w-full"><BarChart data={effect.topTicketsByCost} layout="vertical" margin={{ right: 36 }}><CartesianGrid horizontal={false} /><XAxis type="number" tickFormatter={(value) => usdWhole.format(value)} /><YAxis type="category" dataKey="issueId" width={90} interval={0} tickFormatter={(id) => (id.length > 14 ? id.slice(0, 13) + "…" : id)} /><ChartTooltip content={<TopTicketTooltip />} /><Bar dataKey="costUsd" fill="var(--chart-1)" radius={4}><LabelList dataKey="costUsd" position="right" formatter={(value: number) => usd.format(value)} /></Bar></BarChart></ChartContainer> }
-function CostPerMergedPrChart({ effect }: { effect?: AnalyticsEffectiveness }) { return <ChartContainer config={chartConfig} className="h-64 w-full"><LineChart data={effect?.costPerMergedPr.weekly}><CartesianGrid vertical={false} /><XAxis dataKey="weekStart" tickFormatter={formatDate} /><YAxis /><ChartTooltip content={<ChartTooltipContent />} /><ReferenceLine y={effect?.costPerMergedPr.average} stroke="var(--muted-foreground)" /><Line type="monotone" dataKey="costPerMergedPr" name="Cost per merged PR" stroke="var(--color-costPerMergedPr)" dot={false} /></LineChart></ChartContainer> }
+function TopTicketsByCostChart({ effect }: { effect?: AnalyticsEffectiveness }) { if (!effect?.topTicketsByCost?.length) return <p className="py-8 text-center text-sm text-muted-foreground">No ticket data for this period.</p>; return <ChartContainer config={chartConfig} className="h-64 w-full"><BarChart data={effect.topTicketsByCost} layout="vertical" margin={{ right: 36 }}><CartesianGrid horizontal={false} /><XAxis type="number" tickFormatter={(value) => usdWhole.format(value)} /><YAxis type="category" dataKey="issueId" width={90} interval={0} tickFormatter={(id) => (id.length > 14 ? id.slice(0, 13) + "…" : id)} /><ChartTooltip content={<TopTicketTooltip />} /><Bar dataKey="costUsd" fill="var(--color-data)" radius={4}><LabelList dataKey="costUsd" position="right" fill="var(--color-foreground)" fontSize={11} formatter={(value: number) => usd.format(value)} /></Bar></BarChart></ChartContainer> }
+function CostPerMergedPrChart({ effect }: { effect?: AnalyticsEffectiveness }) { return <ChartContainer config={chartConfig} className="h-64 w-full"><LineChart data={effect?.costPerMergedPr.weekly}><CartesianGrid vertical={false} /><XAxis dataKey="weekStart" tickFormatter={formatDate} /><YAxis /><ChartTooltip content={<ChartTooltipContent />} /><ReferenceLine y={effect?.costPerMergedPr.average} stroke="var(--ds-neutral-500)" strokeDasharray="4 4" /><Line type="monotone" dataKey="costPerMergedPr" name="Cost per merged PR" stroke="var(--color-costPerMergedPr)" dot={false} /></LineChart></ChartContainer> }
 function CostDrivers({ drivers }: { drivers: AnalyticsCostDriver[] }) {
-  return <section className="rounded-lg border bg-card p-4"><div className="mb-3 flex items-center justify-between gap-3"><div><div className="flex items-center gap-1"><h2 className="text-sm font-semibold">Top cost drivers</h2><InfoTooltip text="Where the money goes: total spend and efficiency per workflow in the selected period." /></div><p className="text-xs text-muted-foreground">By workflow</p></div></div><Table><TableHeader><TableRow><TableHead>Workflow</TableHead><TableHead className="text-right">Runs</TableHead><TableHead className="text-right">Success</TableHead><TableHead className="text-right">Cost</TableHead><TableHead className="text-right">Cost / merged PR</TableHead></TableRow></TableHeader><TableBody>{drivers.slice(0, 10).map((driver) => <TableRow key={driver.name}><TableCell className="font-medium">{driver.name}</TableCell><TableCell className="text-right tabular-nums">{driver.runs}</TableCell><TableCell className="text-right tabular-nums">{formatPercent(driver.successRate)}</TableCell><TableCell className="text-right tabular-nums">{usd.format(driver.costUsd)}</TableCell><TableCell className="text-right tabular-nums">{usd.format(driver.costPerMergedPr)}</TableCell></TableRow>)}</TableBody></Table></section>
+  return <section className="rounded-lg border border-border bg-card p-4"><div className="mb-3 flex items-center justify-between gap-3"><div><div className="flex items-center gap-1.5"><h2 className="text-[15px]">Top cost drivers</h2><InfoTooltip text="Where the money goes: total spend and efficiency per workflow in the selected period." /></div><p className="mt-0.5 text-xs text-muted-foreground">By workflow</p></div></div><Table><TableHeader><TableRow><TableHead>Workflow</TableHead><TableHead className="text-right">Runs</TableHead><TableHead className="text-right">Success</TableHead><TableHead className="text-right">Cost</TableHead><TableHead className="text-right">Cost / merged PR</TableHead></TableRow></TableHeader><TableBody>{drivers.slice(0, 10).map((driver) => <TableRow key={driver.name}><TableCell className="font-medium">{driver.name}</TableCell><TableCell className="text-right tabular-nums">{driver.runs}</TableCell><TableCell className="text-right tabular-nums">{formatPercent(driver.successRate)}</TableCell><TableCell className="text-right tabular-nums">{usd.format(driver.costUsd)}</TableCell><TableCell className="text-right tabular-nums">{usd.format(driver.costPerMergedPr)}</TableCell></TableRow>)}</TableBody></Table></section>
 }
 const runsTableRightAlignedHeaders = new Set(["Cost", "Duration", "Start date"])
-function RunsTable({ runs, page, canGoPrevious, canGoNext, onSelect, onPrevious, onNext }: { runs: TaskRunSummary[]; page: number; canGoPrevious: boolean; canGoNext: boolean; onSelect: (runId: string) => void; onPrevious: () => void; onNext: () => void }) { return <section className="rounded-lg border bg-card p-4"><h2 className="mb-3 text-sm font-semibold">Runs</h2><Table><TableHeader><TableRow>{["Status", "Ticket", "Model", "Factory/Workflow", "Cost", "Duration", "Start date"].map((label) => <TableHead key={label} className={runsTableRightAlignedHeaders.has(label) ? "text-right" : ""}>{label}</TableHead>)}</TableRow></TableHeader><TableBody>{runs.map((run) => <TableRow key={run.runId} className="cursor-pointer" onClick={() => onSelect(run.runId)}><TableCell><StatusBadge status={run.status} /></TableCell><TableCell>{run.issueId || "—"}</TableCell><TableCell>{run.model || "—"}</TableCell><TableCell>{run.factoryName || run.workflowName || "—"}</TableCell><TableCell className="text-right tabular-nums">{usd.format(run.estimatedCostUsd || 0)}</TableCell><TableCell className="text-right tabular-nums">{formatDuration(run.finishedAt ? run.finishedAt - run.startedAt : undefined)}</TableCell><TableCell className="text-right tabular-nums">{run.startedAt ? new Date(run.startedAt).toLocaleDateString() : "—"}</TableCell></TableRow>)}</TableBody></Table><div className="mt-3 flex items-center justify-center gap-3"><Button variant="outline" size="sm" disabled={!canGoPrevious} onClick={onPrevious}>Previous</Button><span className="text-sm text-muted-foreground">Page {page}</span><Button variant="outline" size="sm" disabled={!canGoNext} onClick={onNext}>Next</Button></div></section> }
+function RunsTable({ runs, page, canGoPrevious, canGoNext, onSelect, onPrevious, onNext }: { runs: TaskRunSummary[]; page: number; canGoPrevious: boolean; canGoNext: boolean; onSelect: (runId: string) => void; onPrevious: () => void; onNext: () => void }) { return <section className="rounded-lg border border-border bg-card p-4"><h2 className="mb-3 text-[15px]">Runs</h2><Table><TableHeader><TableRow>{["Status", "Ticket", "Model", "Factory/Workflow", "Cost", "Duration", "Start date"].map((label) => <TableHead key={label} className={runsTableRightAlignedHeaders.has(label) ? "text-right" : ""}>{label}</TableHead>)}</TableRow></TableHeader><TableBody>{runs.map((run) => <TableRow key={run.runId} className="cursor-pointer" onClick={() => onSelect(run.runId)}><TableCell><StatusBadge status={run.status} /></TableCell><TableCell className="font-mono">{run.issueId || "—"}</TableCell><TableCell>{run.model || "—"}</TableCell><TableCell>{run.factoryName || run.workflowName || "—"}</TableCell><TableCell className="text-right tabular-nums">{usd.format(run.estimatedCostUsd || 0)}</TableCell><TableCell className="text-right tabular-nums">{formatDuration(run.finishedAt ? run.finishedAt - run.startedAt : undefined)}</TableCell><TableCell className="text-right tabular-nums">{run.startedAt ? new Date(run.startedAt).toLocaleDateString() : "—"}</TableCell></TableRow>)}</TableBody></Table><div className="mt-3 flex items-center justify-center gap-3"><Button variant="outline" size="sm" disabled={!canGoPrevious} onClick={onPrevious}>Previous</Button><span className="text-sm text-muted-foreground">Page {page}</span><Button variant="outline" size="sm" disabled={!canGoNext} onClick={onNext}>Next</Button></div></section> }
 function calculateDelta(current?: number | null, prior?: number | null) { return current == null || prior == null || prior === 0 ? undefined : (current - prior) / prior }
-function KpiGroup({ title, columns = "sm:grid-cols-5", children }: { title: string; columns?: string; children: ReactNode }) { return <div><p className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">{title}</p><div className={`grid grid-cols-2 gap-2 ${columns}`}>{children}</div></div> }
+function KpiGroup({ title, columns = "sm:grid-cols-5", children }: { title: string; columns?: string; children: ReactNode }) { return <div><p className="kicker mb-2 font-semibold text-muted-foreground">{title}</p><div className={`grid grid-cols-2 gap-2 ${columns}`}>{children}</div></div> }
 function Kpi({ label, value, change, good, cost, onClick, title }: { label: string; value?: string | number; change?: number; good?: boolean; cost?: boolean; onClick?: () => void; title?: string }) {
   const bad = cost ? (change ?? 0) > 0 : good ? (change ?? 0) < 0 : (change ?? 0) > 0
   const disabled = !onClick
@@ -703,19 +728,19 @@ function Kpi({ label, value, change, good, cost, onClick, title }: { label: stri
       type="button"
       disabled={disabled}
       onClick={onClick}
-      className="flex h-full w-full min-w-0 flex-col rounded-lg border bg-card p-3 text-left"
+      className="flex h-full w-full min-w-0 flex-col rounded-lg border border-border bg-card p-3 text-left transition-colors enabled:hover:bg-foreground/4"
     >
-      <p className="flex min-h-8 items-center gap-1 text-xs text-muted-foreground">
+      <p className="flex min-h-8 items-center gap-1 text-[11px] leading-[1.35] text-muted-foreground">
         {label}
         {title && <Info aria-hidden className="size-3.5 shrink-0 text-muted-foreground" />}
       </p>
       <div className="mt-auto">
-      <p className="mt-2 text-xl font-semibold tracking-tight">{value ?? "—"}</p>
+      <p className="mt-2 text-[23px] font-extrabold leading-none tracking-[-0.02em] tabular-nums">{value ?? "—"}</p>
       {/* Always render the delta row, even when there's no change, so every
           tile reserves the same space and labels/values align across the grid. */}
       <p
-        className={`truncate text-xs font-medium ${
-          change == null ? "invisible" : bad ? "text-red-600 dark:text-red-400" : "text-emerald-600 dark:text-emerald-400"
+        className={`mt-1.5 truncate text-[11px] font-semibold ${
+          change == null ? "invisible" : bad ? "text-primary" : "text-status-ok"
         }`}
       >
         {change != null ? (
@@ -762,4 +787,4 @@ function InfoTooltip({ text }: { text: string }) {
     </Tooltip>
   )
 }
-function ChartCard({ title, info, children }: { title: string; info?: string; children: ReactNode }) { return <section className="rounded-lg border bg-card p-4"><div className="flex items-center gap-1"><h2 className="text-sm font-semibold">{title}</h2>{info && <InfoTooltip text={info} />}</div>{children}</section> }
+function ChartCard({ title, info, children }: { title: string; info?: string; children: ReactNode }) { return <section className="rounded-lg border border-border bg-card p-4"><div className="mb-3 flex items-center gap-1.5"><h2 className="text-[15px]">{title}</h2>{info && <InfoTooltip text={info} />}</div>{children}</section> }

--- a/web/components/bootstrap-progress.tsx
+++ b/web/components/bootstrap-progress.tsx
@@ -58,8 +58,8 @@ export function BootstrapProgress({
     return (
       <div className="mt-1.5 w-full min-w-0 overflow-hidden space-y-1">
         <div className="flex min-w-0 items-center justify-between gap-2 text-[9px]">
-          <span className="min-w-0 truncate font-medium text-blue-400">{detail}</span>
-          <span className="shrink-0 text-muted-foreground/50">{currentIndex + 1}/{STEPS.length}</span>
+          <span className="min-w-0 truncate font-medium text-data">{detail}</span>
+          <span className="shrink-0 font-mono text-muted-foreground">{currentIndex + 1}/{STEPS.length}</span>
         </div>
         <div className="grid min-w-0 grid-cols-5 gap-0.5">
           {STEPS.map((step, index) => (
@@ -67,8 +67,8 @@ export function BootstrapProgress({
               key={step.key}
               className={cn(
                 "h-0.5 rounded-full bg-border",
-                index < currentIndex && "bg-blue-500/70",
-                index === currentIndex && "bg-blue-400 animate-pulse"
+                index < currentIndex && "bg-data/70",
+                index === currentIndex && "bg-data-light animate-pulse"
               )}
               title={step.label}
             />
@@ -82,8 +82,8 @@ export function BootstrapProgress({
     return (
       <div className="mt-2 space-y-1.5">
         <div className="flex items-center justify-between text-[10px]">
-          <span className="font-medium text-blue-400">{detail}</span>
-          <span className="text-muted-foreground/60">{currentIndex + 1}/{STEPS.length}</span>
+          <span className="font-medium text-data">{detail}</span>
+          <span className="font-mono text-muted-foreground">{currentIndex + 1}/{STEPS.length}</span>
         </div>
         <div className="grid grid-cols-5 gap-1">
           {STEPS.map((step, index) => (
@@ -91,8 +91,8 @@ export function BootstrapProgress({
               key={step.key}
               className={cn(
                 "h-1 rounded-full bg-border",
-                index < currentIndex && "bg-blue-500/70",
-                index === currentIndex && "bg-blue-400 animate-pulse"
+                index < currentIndex && "bg-data/70",
+                index === currentIndex && "bg-data-light animate-pulse"
               )}
               title={step.label}
             />
@@ -106,7 +106,7 @@ export function BootstrapProgress({
     <div className="border-t border-border/60 px-6 py-3">
       <div className="mb-2 flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <Loader2 className="size-3.5 animate-spin text-blue-400" />
+          <Loader2 className="size-3.5 animate-spin text-data" />
           <span className="text-sm font-medium text-foreground">Setting up agent</span>
         </div>
         <span className="text-xs text-muted-foreground">{detail}</span>
@@ -120,15 +120,15 @@ export function BootstrapProgress({
               <div
                 className={cn(
                   "mb-1 h-1 rounded-full bg-border",
-                  isDone && "bg-blue-500/70",
-                  isCurrent && "bg-blue-400 animate-pulse"
+                  isDone && "bg-data/70",
+                  isCurrent && "bg-data-light animate-pulse"
                 )}
               />
               <div className="flex min-w-0 items-center gap-1.5">
                 {isDone ? (
-                  <CheckCircle2 className="size-3 shrink-0 text-blue-400" />
+                  <CheckCircle2 className="size-3 shrink-0 text-data" />
                 ) : isCurrent ? (
-                  <Loader2 className="size-3 shrink-0 animate-spin text-blue-400" />
+                  <Loader2 className="size-3 shrink-0 animate-spin text-data" />
                 ) : (
                   <Circle className="size-3 shrink-0 text-muted-foreground/40" />
                 )}

--- a/web/components/claw-card.tsx
+++ b/web/components/claw-card.tsx
@@ -24,20 +24,20 @@ interface ClawCardProps {
 
 function StatusIndicator({ status, isStreaming }: { status: ClawStatus; isStreaming: boolean }) {
   if (isStreaming) {
-    return <Loader2 className="size-3.5 text-green-500 animate-spin shrink-0" />
+    return <Loader2 className="size-3.5 text-status-ok animate-spin shrink-0" />
   }
   if (status === "provisioning") {
-    return <Loader2 className="size-3.5 text-blue-400 animate-spin shrink-0" />
+    return <Loader2 className="size-3.5 text-data animate-spin shrink-0" />
   }
   if (status === "error") {
-    return <AlertCircle className="size-3.5 text-red-500 shrink-0" />
+    return <AlertCircle className="size-3.5 text-destructive shrink-0" />
   }
   return (
     <span
       className={cn(
         "size-2 rounded-full shrink-0",
-        status === "connected" && "bg-green-500",
-        status === "idle" && "bg-amber-500",
+        status === "connected" && "bg-status-ok",
+        status === "idle" && "bg-status-warn",
         status === "offline" && "bg-muted-foreground"
       )}
     />
@@ -46,9 +46,9 @@ function StatusIndicator({ status, isStreaming }: { status: ClawStatus; isStream
 
 function UnreadBadge({ count }: { count: number }) {
   if (count === 0) return null
-  
+
   return (
-    <span className="flex items-center justify-center min-w-5 h-5 px-1.5 text-xs font-medium bg-blue-600 text-white rounded-full">
+    <span className="flex items-center justify-center min-w-5 h-5 px-1.5 font-mono text-[11px] font-semibold bg-primary text-primary-foreground rounded-full">
       {count > 99 ? "99+" : count}
     </span>
   )
@@ -121,11 +121,11 @@ export function ClawCard({ claw, isSelected, onClick, onTogglePin, onTagsChange,
   const hasUnread = claw.unreadCount > 0
   const isPending = claw.status === "provisioning" || claw.status === "error"
   const railClass = claw.isStreaming
-    ? "border-l-green-500"
+    ? "border-l-status-ok"
     : claw.status === "provisioning"
-      ? "border-l-blue-400"
+      ? "border-l-data"
       : claw.status === "error"
-        ? "border-l-red-500"
+        ? "border-l-destructive"
         : COLOR_CLASSES[localColor]?.border ?? "border-l-border"
 
   return (
@@ -140,19 +140,23 @@ export function ClawCard({ claw, isSelected, onClick, onTogglePin, onTagsChange,
         }
       }}
       className={cn(
-        "w-full min-w-0 text-left p-3 rounded-md transition-colors relative group border-l-2",
+        // Sidebar agent row: 2px color rail on the left, square against it and
+        // rounded away from it, exactly like the mockup's .agent-row.
+        "w-full min-w-0 text-left p-3 rounded-l-none rounded-r-md transition-colors relative group border-l-2 cursor-pointer",
         railClass,
-        isPending ? "cursor-pointer opacity-70 hover:bg-accent" : "cursor-pointer hover:bg-accent",
-        isSelected && "bg-accent",
-        hasUnread && !isSelected && "bg-blue-950/30"
+        isPending && "opacity-70",
+        hasUnread && !isSelected
+          ? "bg-primary/10 hover:bg-primary/14"
+          : "hover:bg-foreground/7",
+        isSelected && "bg-foreground/10"
       )}
     >
       <div className="flex items-center gap-2 mb-1">
         <StatusIndicator status={claw.status} isStreaming={claw.isStreaming} />
         <span 
           className={cn(
-            "font-mono text-sm min-w-0 flex-1 group/name flex items-center gap-1",
-            hasUnread ? "text-foreground font-medium" : "text-foreground"
+            "font-mono text-[13px] min-w-0 flex-1 group/name flex items-center gap-1 text-foreground",
+            hasUnread && "font-medium"
           )}
         >
           {editingName ? (
@@ -163,7 +167,7 @@ export function ClawCard({ claw, isSelected, onClick, onTogglePin, onTagsChange,
               onKeyDown={handleNameKeyDown}
               onBlur={commitRename}
               onClick={(e) => e.stopPropagation()}
-              className="bg-transparent border-b border-ring outline-none text-sm font-mono w-full"
+              className="bg-transparent border-b border-ring outline-none text-[13px] font-mono w-full"
             />
           ) : (
             <>
@@ -188,7 +192,7 @@ export function ClawCard({ claw, isSelected, onClick, onTogglePin, onTagsChange,
           <button
             onClick={onTogglePin}
             className={cn(
-              "p-1 rounded hover:bg-background/50 transition-opacity",
+              "p-1 rounded-sm hover:bg-foreground/10 transition-opacity",
               claw.pinned ? "opacity-100" : "opacity-0 group-hover:opacity-100"
             )}
             title={claw.pinned ? "Unpin" : "Pin"}
@@ -240,7 +244,7 @@ export function ClawCard({ claw, isSelected, onClick, onTogglePin, onTagsChange,
             {showColorPicker && typeof document !== 'undefined' && createPortal(
               <div
                 data-color-picker
-                className="fixed bg-popover border border-border rounded-lg p-2 shadow-xl"
+                className="fixed bg-popover border border-border rounded-lg p-2 shadow-ds-lg"
                 style={{ top: pickerPos.top, left: pickerPos.left, zIndex: 99999 }}
               >
                 <div className="grid grid-cols-8 gap-1">

--- a/web/components/conversation-view.tsx
+++ b/web/components/conversation-view.tsx
@@ -154,7 +154,7 @@ function StreamingMessage({
       </div>
     ) : (
       <div className="flex justify-start">
-        <div className="bg-secondary rounded-lg px-4 py-3">
+        <div className="rounded-lg border border-border bg-card px-4 py-3">
           <div className="flex items-center gap-1.5">
             <span className="size-1.5 rounded-full bg-muted-foreground/60 animate-bounce [animation-delay:0ms]" />
             <span className="size-1.5 rounded-full bg-muted-foreground/60 animate-bounce [animation-delay:150ms]" />
@@ -169,9 +169,9 @@ function StreamingMessage({
 
   if (variant === "card") {
     return (
-      <div className="text-xs p-2 rounded bg-secondary mr-4">
+      <div className="text-xs p-2 rounded-md border border-border bg-foreground/4 mr-4">
         <div className="flex items-center gap-1 mb-0.5">
-          <span className="font-medium text-foreground/70">{clawName}</span>
+          <span className="font-mono text-foreground">{clawName}</span>
           <span className="text-muted-foreground" suppressHydrationWarning>
             {formatTimestamp(startedAt)}
           </span>
@@ -185,12 +185,12 @@ function StreamingMessage({
     <div className="flex w-full justify-start">
       <div
         className={cn(
-          "w-fit max-w-[88%] md:w-[70%] md:max-w-none min-w-0 rounded-lg px-4 py-3",
-          (clawColor && COLOR_CLASSES[clawColor]?.bubble) || "bg-secondary"
+          "w-fit max-w-[88%] md:w-[70%] md:max-w-none min-w-0 rounded-lg border border-border px-4 py-3",
+          (clawColor && COLOR_CLASSES[clawColor]?.bubble) || "bg-card"
         )}
       >
         <div className="flex items-center gap-2 mb-1">
-          <span className="text-xs font-medium text-foreground">{clawName}</span>
+          <span className="font-mono text-xs text-foreground">{clawName}</span>
           <span className="text-xs text-muted-foreground" suppressHydrationWarning>
             {formatTimestamp(startedAt)}
           </span>
@@ -313,10 +313,11 @@ function StatusBadge({ status, className }: { status: ClawStatus; className?: st
     <Badge
       variant="outline"
       className={cn(
-        "text-xs font-medium",
-        status === "connected" && "border-green-500/50 text-green-500",
-        status === "idle" && "border-amber-500/50 text-amber-500",
-        status === "offline" && "border-red-500/50 text-red-500",
+        // Outline tag from the mockup topbar: hairline border, status hue.
+        "rounded-full font-mono text-xs font-normal lowercase",
+        status === "connected" && "border-status-ok/60 text-status-ok",
+        status === "idle" && "border-status-warn/60 text-status-warn",
+        status === "offline" && "border-destructive/60 text-destructive",
         className
       )}
     >
@@ -326,15 +327,15 @@ function StatusBadge({ status, className }: { status: ClawStatus; className?: st
 }
 
 function StatusDot({ status, isStreaming }: { status: ClawStatus; isStreaming: boolean }) {
-  if (isStreaming) return <Loader2 className="size-3.5 text-green-500 animate-spin" />
-  if (status === "provisioning") return <Loader2 className="size-3.5 text-blue-400 animate-spin" />
-  if (status === "error") return <AlertCircle className="size-3.5 text-red-500" />
+  if (isStreaming) return <Loader2 className="size-3.5 text-status-ok animate-spin" />
+  if (status === "provisioning") return <Loader2 className="size-3.5 text-data animate-spin" />
+  if (status === "error") return <AlertCircle className="size-3.5 text-destructive" />
   return (
     <span
       className={cn(
         "size-2 rounded-full shrink-0",
-        status === "connected" && "bg-green-500",
-        status === "idle" && "bg-amber-500",
+        status === "connected" && "bg-status-ok",
+        status === "idle" && "bg-status-warn",
         status === "offline" && "bg-muted-foreground"
       )}
     />
@@ -343,16 +344,14 @@ function StatusDot({ status, isStreaming }: { status: ClawStatus; isStreaming: b
 
 function ContextProgressBar({ usage, size = "sm" }: { usage: number; size?: "sm" | "lg" }) {
   const getColor = (value: number) => {
-    if (value >= 90) return "bg-red-500"
-    if (value >= 70) return "bg-amber-500"
-    return "bg-green-500"
+    if (value >= 90) return "bg-destructive"
+    if (value >= 70) return "bg-status-warn"
+    return "bg-status-ok"
   }
 
-  const getBgColor = (value: number) => {
-    if (value >= 90) return "bg-red-500/20"
-    if (value >= 70) return "bg-amber-500/20"
-    return "bg-green-500/20"
-  }
+  // The mockup's meter track is one neutral ink wash at every level — only the
+  // fill carries the status hue.
+  const getBgColor = (_value: number) => "bg-foreground/14"
 
   if (size === "lg") {
     return (
@@ -434,7 +433,7 @@ function ClawCardBack({ claw }: { claw: Claw }) {
        content-sized, so the info panel scrolls inside its own bound. */
     <div className="flex-1 overflow-y-auto scrollbar-thin p-4 space-y-4 max-md:max-h-[40vh]">
       <div>
-        <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
+        <h3 className="kicker text-muted-foreground mb-2">
           Purpose
         </h3>
         <p className="text-sm text-foreground leading-relaxed">
@@ -443,7 +442,7 @@ function ClawCardBack({ claw }: { claw: Claw }) {
       </div>
 
       <div>
-        <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
+        <h3 className="kicker text-muted-foreground mb-2">
           Source
         </h3>
         <p className="text-sm font-mono text-foreground">
@@ -452,20 +451,20 @@ function ClawCardBack({ claw }: { claw: Claw }) {
       </div>
 
       <div>
-        <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
+        <h3 className="kicker text-muted-foreground mb-2">
           Status
         </h3>
         <div className="flex items-center gap-2">
           <StatusDot status={claw.status} isStreaming={claw.isStreaming} />
           <span className="text-sm text-foreground capitalize">{claw.status}</span>
           {claw.isStreaming && (
-            <span className="text-xs text-green-500">(streaming)</span>
+            <span className="text-xs text-status-ok">(streaming)</span>
           )}
         </div>
       </div>
 
       <div>
-        <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
+        <h3 className="kicker text-muted-foreground mb-2">
           Context Usage
         </h3>
         <div className="flex items-center gap-2">
@@ -477,7 +476,7 @@ function ClawCardBack({ claw }: { claw: Claw }) {
       </div>
 
       <div>
-        <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
+        <h3 className="kicker text-muted-foreground mb-2">
           Uptime
         </h3>
         <p className="text-sm font-mono text-foreground">
@@ -487,14 +486,14 @@ function ClawCardBack({ claw }: { claw: Claw }) {
 
       {claw.tags.length > 0 && (
         <div>
-          <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
+          <h3 className="kicker text-muted-foreground mb-2">
             Tags
           </h3>
           <div className="flex flex-wrap gap-1.5">
             {claw.tags.map((tag) => (
               <span
                 key={tag}
-                className="inline-flex items-center px-2 py-1 text-xs font-medium bg-secondary text-muted-foreground rounded"
+                className="inline-flex items-center rounded-full bg-tint-neutral px-2.5 py-0.5 text-[11px] text-tint-neutral-foreground"
               >
                 {tag}
               </span>
@@ -505,12 +504,14 @@ function ClawCardBack({ claw }: { claw: Claw }) {
 
       {prs.length > 0 && (
         <div>
-          <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">Pull Requests</h3>
-          <div className="space-y-1.5">
+          <h3 className="kicker text-muted-foreground mb-2">Pull Requests</h3>
+          {/* PR chips from the board mockup: mono on a divider-bordered pill
+              that picks up the accent on hover. */}
+          <div className="flex flex-wrap gap-1.5">
             {prs.map(pr => (
               <a key={pr.id} href={pr.url} target="_blank" rel="noopener noreferrer"
-                className="flex items-center gap-2 text-xs text-blue-400 hover:underline">
-                <span className="font-mono text-muted-foreground">#{pr.prNumber}</span>
+                className="inline-flex min-w-0 items-center gap-1.5 rounded-full border border-border px-2.5 py-0.5 font-mono text-[11px] text-foreground transition-colors hover:border-primary hover:text-primary">
+                <span className="shrink-0">#{pr.prNumber}</span>
                 <span className="truncate">{pr.repo}</span>
               </a>
             ))}
@@ -694,11 +695,13 @@ const ClawBoardCard = memo(function ClawBoardCard({
             instead of scrolling.) */}
         <div
           className={cn(
-            "flex flex-col rounded-lg border border-border bg-card",
+            // overflow-hidden so the state strip and composer sit flush inside
+            // the card's rounded edge, as in the board mockup.
+            "flex flex-col overflow-hidden rounded-lg border border-border bg-card",
             isMobile
               ? cn("relative", isFlipped && "hidden")
               : "absolute inset-0 [backface-visibility:hidden]",
-            hasUnread && "border-blue-500/30 bg-blue-950/10",
+            hasUnread && "border-data/50",
             isPending && "opacity-75"
           )}
           onDragEnter={isPending ? undefined : onDragEnter}
@@ -707,27 +710,42 @@ const ClawBoardCard = memo(function ClawBoardCard({
           onDrop={isPending ? undefined : onDrop}
         >
           {dragHover && !isPending && (
-            <div className="pointer-events-none absolute inset-0 z-30 flex items-center justify-center rounded-lg border-2 border-dashed border-ring bg-background/80">
+            <div className="pointer-events-none absolute inset-0 z-30 flex items-center justify-center rounded-lg border-2 border-dashed border-ring bg-[var(--ds-scrim)]">
               <div className="text-xs font-medium text-foreground">Drop files</div>
             </div>
           )}
           {isStreaming && (
-            <div className="absolute left-0 top-0 bottom-0 w-1 bg-green-500 rounded-l-lg z-10" />
+            <div className="absolute left-0 top-0 bottom-0 w-1 bg-status-ok z-10" />
           )}
           {claw.status === "provisioning" && (
-            <div className="absolute left-0 top-0 bottom-0 w-1 bg-blue-400 rounded-l-lg z-10 animate-pulse" />
+            <div className="absolute left-0 top-0 bottom-0 w-1 bg-data z-10 animate-pulse" />
           )}
           {claw.status === "error" && (
-            <div className="absolute left-0 top-0 bottom-0 w-1 bg-red-500 rounded-l-lg z-10" />
+            <div className="absolute left-0 top-0 bottom-0 w-1 bg-destructive z-10" />
           )}
-          
+
+          {/* State strip — the card's loudest signal, so it leads the card
+              exactly as in the board mockup, above the identity block. */}
+          {cardNow && (
+            <NowStrip
+              clawId={claw.id}
+              step={runningStep}
+              isStreaming={isStreaming}
+              lastMessageAt={lastMessageAt}
+              variant="card"
+              state={cardNow.state}
+              statusText={cardNow.text}
+              statusAt={cardNow.at}
+            />
+          )}
+
           {/* Context usage bar */}
           <div className="px-3 pt-2">
             <ContextProgressBar usage={claw.contextUsage} size="sm" />
           </div>
-          
+
           {/* Header - clickable to open full view */}
-          <div className="p-3 border-b border-border">
+          <div className="p-3 border-b-2 border-border">
             <div className="flex items-center gap-2 mb-1">
               {/* Drag handle — desktop board only; mobile has no reordering */}
               {dragHandleProps && (
@@ -752,7 +770,7 @@ const ClawBoardCard = memo(function ClawBoardCard({
                   {!isPending && (
                     <button
                       onClick={() => onClick(claw.id)}
-                      className="p-1 rounded hover:bg-accent transition-colors"
+                      className="p-1 rounded-md text-muted-foreground hover:bg-foreground/8 hover:text-foreground transition-colors"
                       title="Open conversation"
                     >
                       <MessageSquare className="size-3.5 text-muted-foreground" />
@@ -771,7 +789,7 @@ const ClawBoardCard = memo(function ClawBoardCard({
                 </button>
               )}
               {hasUnread && (
-                <span className="px-1.5 py-0.5 text-[10px] font-medium bg-blue-500 text-white rounded-full">
+                <span className="inline-flex min-w-5 items-center justify-center rounded-full bg-primary px-1.5 py-0.5 text-[10px] font-semibold text-primary-foreground">
                   {claw.unreadCount > 99 ? "99+" : claw.unreadCount}
                 </span>
               )}
@@ -784,7 +802,7 @@ const ClawBoardCard = memo(function ClawBoardCard({
               />
               <button
                 onClick={handleFlip}
-                className="p-1 rounded hover:bg-accent transition-colors"
+                className="p-1 rounded-md text-muted-foreground hover:bg-foreground/8 hover:text-foreground transition-colors"
                 title="View bot info"
               >
                 <Info className="size-3.5 text-muted-foreground" />
@@ -796,9 +814,9 @@ const ClawBoardCard = memo(function ClawBoardCard({
               </span>
               <span className="text-xs font-mono">
                 {claw.status === "provisioning" ? (
-                  <span className="text-blue-400">starting...</span>
+                  <span className="text-data">starting...</span>
                 ) : claw.status === "error" ? (
-                  <span className="text-red-500">error</span>
+                  <span className="text-destructive">error</span>
                 ) : (
                   <span className="text-muted-foreground">{formatUptime(claw.uptime)}</span>
                 )}
@@ -810,33 +828,19 @@ const ClawBoardCard = memo(function ClawBoardCard({
                 {claw.tags.slice(0, 3).map((tag) => (
                   <span
                     key={tag}
-                    className="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium bg-secondary text-muted-foreground rounded"
+                    className="inline-flex items-center rounded-full bg-tint-neutral px-2 py-0.5 text-[10px] text-tint-neutral-foreground"
                   >
                     {tag}
                   </span>
                 ))}
                 {claw.tags.length > 3 && (
-                  <span className="text-[10px] text-muted-foreground">
+                  <span className="font-mono text-[10px] text-muted-foreground">
                     +{claw.tags.length - 3}
                   </span>
                 )}
               </div>
             )}
           </div>
-
-          {/* Status line — what this agent is doing, with no clicks */}
-          {cardNow && (
-            <NowStrip
-              clawId={claw.id}
-              step={runningStep}
-              isStreaming={isStreaming}
-              lastMessageAt={lastMessageAt}
-              variant="card"
-              state={cardNow.state}
-              statusText={cardNow.text}
-              statusAt={cardNow.at}
-            />
-          )}
 
           {/* Messages area */}
           <div className="flex-1 relative min-h-0 overflow-hidden">
@@ -886,20 +890,20 @@ const ClawBoardCard = memo(function ClawBoardCard({
                 if (message.role === "system") {
                   return (
                     <div key={message.id} className="flex items-center gap-2 py-1">
-                      <div className="flex-1 h-px bg-border/50" />
-                      <span className="text-[9px] text-muted-foreground/50 uppercase tracking-wider">
+                      <div className="flex-1 h-px bg-border" />
+                      <span className="kicker text-muted-foreground">
                         {message.content === "__TOOL_GAP__" ? "tool" : message.content}
                       </span>
-                      <div className="flex-1 h-px bg-border/50" />
+                      <div className="flex-1 h-px bg-border" />
                     </div>
                   )
                 }
                 if (message.role === "hub") {
                   return (
                     <div key={message.id} className="flex items-start gap-1.5 py-0.5">
-                      <Settings2 className="size-2.5 shrink-0 text-muted-foreground/40 mt-0.5" />
+                      <Settings2 className="size-2.5 shrink-0 text-muted-foreground mt-0.5" />
                       <span className={cn(
-                        "text-[10px] italic text-muted-foreground/60 leading-tight",
+                        "font-mono text-[10px] text-muted-foreground leading-tight",
                         message.format === "pre" && "whitespace-pre-wrap"
                       )}>{message.content}</span>
                     </div>
@@ -916,14 +920,14 @@ const ClawBoardCard = memo(function ClawBoardCard({
                   <div
                     key={message.id}
                     className={cn(
-                      "text-xs p-2 rounded",
+                      "text-xs p-2 rounded-md",
                       message.role === "user"
-                        ? "bg-blue-600/20 border border-blue-500/20 ml-4"
-                        : "bg-secondary mr-4"
+                        ? "bg-foreground/8 ml-4"
+                        : "border border-border bg-foreground/4 mr-4"
                     )}
                   >
                     <div className="flex items-center gap-1 mb-0.5">
-                      <span className="font-medium text-foreground/70">
+                      <span className={cn(message.role === "user" ? "font-medium text-foreground" : "font-mono text-foreground")}>
                         {message.role === "user" ? "You" : claw.name}
                       </span>
                       <span className="text-muted-foreground" suppressHydrationWarning>
@@ -964,7 +968,7 @@ const ClawBoardCard = memo(function ClawBoardCard({
                 event.stopPropagation()
                 scrollCardToLatest()
               }}
-              className="absolute bottom-2 left-1/2 -translate-x-1/2 z-10 flex items-center gap-1 px-2.5 py-1 rounded-full bg-background/95 backdrop-blur-sm border border-border text-[10px] font-medium text-muted-foreground hover:text-foreground hover:bg-accent transition-colors shadow-md"
+              className="absolute bottom-2 left-1/2 -translate-x-1/2 z-10 flex items-center gap-1 px-2.5 py-1 rounded-full bg-card/95 backdrop-blur-sm border border-border font-mono text-[10px] text-muted-foreground hover:text-foreground hover:bg-foreground/8 transition-colors shadow-ds-md"
               aria-label="Follow latest claw activity"
             >
               <ChevronDown className="size-3" />
@@ -979,7 +983,7 @@ const ClawBoardCard = memo(function ClawBoardCard({
               {cardStats.toolCalls} step{cardStats.toolCalls === 1 ? "" : "s"}
             </span>
             {cardStats.failures > 0 && (
-              <span className="text-red-400">
+              <span className="text-destructive">
                 {cardStats.failures} failed
               </span>
             )}
@@ -987,7 +991,7 @@ const ClawBoardCard = memo(function ClawBoardCard({
           </div>
 
           {/* Input area */}
-          <form onSubmit={isPending ? (e) => e.preventDefault() : handleSubmit} className="p-2 border-t border-border flex flex-col gap-1.5">
+          <form onSubmit={isPending ? (e) => e.preventDefault() : handleSubmit} className="p-2 border-t-2 border-border flex flex-col gap-1.5">
             {attachments.length > 0 && (
               <div className="flex flex-wrap gap-1">
                 {attachments.map((a) => (
@@ -1053,7 +1057,7 @@ const ClawBoardCard = memo(function ClawBoardCard({
                 }}
                 onPaste={onPaste}
                 placeholder={isPending ? (claw.status === "error" ? "Provisioning failed" : claw.status === "offline" ? "Agent offline" : "Starting up...") : "Send message..."}
-                className="flex-1 resize-none overflow-hidden rounded-md border border-input bg-background px-2 py-1.5 text-xs ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 min-h-[32px]"
+                className="flex-1 resize-none overflow-hidden rounded-md border border-input bg-background px-2 py-1.5 text-xs placeholder:text-muted-foreground focus-visible:outline-none focus-visible:border-ring min-h-[32px]"
                 disabled={isPending}
                 ref={cardTextareaRef}
                 onClick={(e) => e.stopPropagation()}
@@ -1074,14 +1078,14 @@ const ClawBoardCard = memo(function ClawBoardCard({
         {/* Back - Bot info */}
         <div
           className={cn(
-            "flex flex-col rounded-lg border border-border bg-card",
+            "flex flex-col overflow-hidden rounded-lg border border-border bg-card",
             isMobile
               ? cn("relative", !isFlipped && "hidden")
               : "absolute inset-0 [backface-visibility:hidden] [transform:rotateY(180deg)]"
           )}
         >
           {/* Header */}
-          <div className="p-3 border-b border-border">
+          <div className="p-3 border-b-2 border-border">
             <div className="flex items-center gap-2">
               <StatusDot status={claw.status} isStreaming={claw.isStreaming} />
               <ClawTitle
@@ -1094,8 +1098,8 @@ const ClawBoardCard = memo(function ClawBoardCard({
                 <button
                   onClick={(e) => { e.stopPropagation(); setShowTerminal((v) => !v) }}
                   className={cn(
-                    "p-1 rounded hover:bg-accent transition-colors",
-                    showTerminal && "bg-accent text-foreground"
+                    "p-1 rounded-md text-muted-foreground hover:bg-foreground/8 hover:text-foreground transition-colors",
+                    showTerminal && "bg-foreground/10 text-foreground"
                   )}
                   title="Toggle terminal"
                 >
@@ -1104,7 +1108,7 @@ const ClawBoardCard = memo(function ClawBoardCard({
               )}
               <button
                 onClick={handleFlip}
-                className="p-1 rounded hover:bg-accent transition-colors"
+                className="p-1 rounded-md text-muted-foreground hover:bg-foreground/8 hover:text-foreground transition-colors"
                 title="View chat"
               >
                 <MessageSquare className="size-3.5 text-muted-foreground" />
@@ -1116,7 +1120,7 @@ const ClawBoardCard = memo(function ClawBoardCard({
           <ClawCardBack claw={claw} />
 
           {/* Footer */}
-          <div className="p-3 border-t border-border space-y-2">
+          <div className="p-3 border-t-2 border-border space-y-2">
             <Button 
               variant="outline" 
               size="sm" 
@@ -1148,7 +1152,7 @@ const ClawBoardCard = memo(function ClawBoardCard({
     {claw.ssh_host && (
       <Dialog open={showTerminal} onOpenChange={setShowTerminal}>
         <DialogContent className="!max-w-none w-[95vw] h-[90vh] flex flex-col p-0 gap-0">
-          <DialogHeader className="px-4 py-3 border-b border-border shrink-0">
+          <DialogHeader className="px-4 py-3 border-b-2 border-border shrink-0">
             <DialogTitle className="font-mono text-sm">{claw.name} — terminal</DialogTitle>
           </DialogHeader>
           <div className="flex-1 min-h-0">
@@ -1225,21 +1229,20 @@ const MessageBubble = memo(function MessageBubble({
     if (message.content === "__TOOL_GAP__") {
       return (
         <div className="flex items-center gap-2 py-2">
-          <div className="flex-1 h-px bg-border/50" />
-          <div className="flex items-center gap-1.5 text-muted-foreground/50">
+          <div className="flex-1 h-px bg-border" />
+          <div className="flex items-center gap-1.5 text-muted-foreground">
             <Wrench className="size-3" />
-            <span className="text-[10px] uppercase tracking-wider">tool call</span>
+            <span className="kicker">tool call</span>
           </div>
-          <div className="flex-1 h-px bg-border/50" />
+          <div className="flex-1 h-px bg-border" />
         </div>
       )
     }
+    /* System rule from the mockup: an uppercase kicker held between hairlines. */
     return (
       <div className="flex items-center gap-3 py-4">
         <div className="flex-1 h-px bg-border" />
-        <span className="text-xs text-muted-foreground uppercase tracking-wider font-medium">
-          {message.content}
-        </span>
+        <span className="kicker text-muted-foreground">{message.content}</span>
         <div className="flex-1 h-px bg-border" />
       </div>
     )
@@ -1256,7 +1259,7 @@ const MessageBubble = memo(function MessageBubble({
   if (message.content === "__THINKING__") {
     return (
       <div className="flex justify-start">
-        <div className="bg-secondary rounded-lg px-4 py-3">
+        <div className="rounded-lg border border-border bg-card px-4 py-3">
           <div className="flex items-center gap-1.5">
             <span className="size-1.5 rounded-full bg-muted-foreground/60 animate-bounce [animation-delay:0ms]" />
             <span className="size-1.5 rounded-full bg-muted-foreground/60 animate-bounce [animation-delay:150ms]" />
@@ -1274,11 +1277,11 @@ const MessageBubble = memo(function MessageBubble({
     return (
       <div className="flex items-start gap-2 py-1">
         <div className={cn(
-          "flex items-start gap-1.5 text-muted-foreground/60 text-xs italic bg-muted/40 border border-border/40 rounded px-3 py-1.5 max-w-[85%]",
+          "flex items-start gap-1.5 rounded-md border border-border bg-foreground/4 px-3 py-1.5 font-mono text-xs text-muted-foreground max-w-[85%]",
           message.format === "pre" && "whitespace-pre-wrap"
         )}>
-          <Settings2 className="size-3 shrink-0 text-muted-foreground/50 mt-0.5" />
-          <span className="text-muted-foreground/80">{message.content}</span>
+          <Settings2 className="size-3 shrink-0 text-muted-foreground mt-0.5" />
+          <span>{message.content}</span>
         </div>
       </div>
     )
@@ -1292,17 +1295,19 @@ const MessageBubble = memo(function MessageBubble({
     <div className={cn("flex w-full", isUser ? "justify-end" : "justify-start")}>
       <div
         className={cn(
+          // User: a right-aligned ink-wash bubble, no border. Agent: the
+          // mockup's surface bubble on a divider hairline.
           "w-fit max-w-[88%] md:w-[70%] md:max-w-none min-w-0 rounded-lg px-4 py-3",
           isUser
-            ? "bg-blue-600/20 border border-blue-500/20"
-            : (clawColor && COLOR_CLASSES[clawColor]?.bubble) || "bg-secondary"
+            ? "bg-foreground/10"
+            : cn("border border-border", (clawColor && COLOR_CLASSES[clawColor]?.bubble) || "bg-card")
         )}
       >
         <div className="flex items-center gap-2 mb-1">
           <span
             className={cn(
-              "text-xs font-medium",
-              isUser ? "text-muted-foreground" : "text-foreground"
+              "text-xs",
+              isUser ? "font-medium text-muted-foreground" : "font-mono text-foreground"
             )}
           >
             {isUser ? "You" : clawName}
@@ -1495,12 +1500,14 @@ function ClawChatView({
       onDrop={onDrop}
     >
       {dragHover && (
-        <div className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center bg-background/70 border-2 border-dashed border-ring rounded-sm">
+        <div className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center border-2 border-dashed border-ring bg-[var(--ds-scrim)]">
           <div className="text-sm text-foreground font-medium">Drop files to attach</div>
         </div>
       )}
-      <header className="border-b border-border">
-        <div className="px-4 md:px-6 pt-2">
+      <header className="border-b-2 border-border">
+        {/* Mockup topbar meter: a kicker-labelled pill track, status-ok fill. */}
+        <div className="flex items-center gap-2 px-4 md:px-6 pt-2">
+          <span className="kicker shrink-0 text-muted-foreground">ctx</span>
           <ContextProgressBar usage={claw.contextUsage} size="lg" />
         </div>
         {isMobile ? (
@@ -1636,7 +1643,7 @@ function ClawChatView({
         {showScrollBtn && (
           <button
             onClick={scrollToBottom}
-            className="absolute bottom-4 left-1/2 -translate-x-1/2 z-10 flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-secondary border border-border text-xs text-muted-foreground hover:text-foreground hover:bg-accent transition-colors shadow-md"
+            className="absolute bottom-4 left-1/2 -translate-x-1/2 z-10 flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-card border border-border text-xs text-muted-foreground hover:text-foreground hover:bg-foreground/8 transition-colors shadow-ds-md"
           >
             <ChevronDown className="size-3.5" />
             <span>Scroll to bottom</span>
@@ -1645,9 +1652,9 @@ function ClawChatView({
       </div>
 
       {/* Composer — padded above the home indicator on notched phones */}
-      <div className="p-4 border-t border-border pb-[calc(1rem+env(safe-area-inset-bottom))] md:pb-4">
+      <div className="p-4 border-t-2 border-border pb-[calc(1rem+env(safe-area-inset-bottom))] md:pb-4">
         {cmdToast && (
-          <div className="mb-2 max-w-3xl mx-auto text-xs text-amber-400 bg-amber-500/10 border border-amber-500/20 rounded-md px-3 py-2">
+          <div className="mb-2 max-w-3xl mx-auto rounded-md border border-status-warn/40 bg-status-warn/10 px-3 py-2 text-xs text-status-warn">
             {cmdToast}
           </div>
         )}
@@ -1720,7 +1727,7 @@ function ClawChatView({
               ref={panelTextareaRef}
               placeholder="Message agent, /stop, or attach files"
               rows={1}
-              className="flex-1 resize-none overflow-hidden rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 min-h-[40px]"
+              className="flex-1 resize-none overflow-hidden rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:border-ring min-h-[40px]"
             />
             <Button type="submit" size="icon" disabled={!canSubmit} className="shrink-0 max-md:size-11">
               <Send className="size-4" />
@@ -1736,7 +1743,7 @@ function ClawChatView({
       {claw.ssh_host && (
         <Dialog open={terminalOpen} onOpenChange={setTerminalOpen}>
           <DialogContent className="!max-w-none w-[95vw] h-[90vh] flex flex-col p-0 gap-0">
-            <DialogHeader className="px-4 py-3 border-b border-border shrink-0">
+            <DialogHeader className="px-4 py-3 border-b-2 border-border shrink-0">
               <DialogTitle className="font-mono text-sm">{claw.name} — terminal</DialogTitle>
             </DialogHeader>
             <div className="flex-1 min-h-0">
@@ -1825,13 +1832,13 @@ export function ConversationView({
     return (
       <main className="flex-1 flex flex-col bg-background min-w-0 overflow-hidden">
         <div className="flex flex-col items-center justify-center h-full gap-4 text-center px-8">
-          <div className="rounded-full bg-red-500/10 p-4">
-            <AlertCircle className="size-8 text-red-500" />
+          <div className="rounded-full bg-destructive/10 p-4">
+            <AlertCircle className="size-8 text-destructive" />
           </div>
           <div className="space-y-2">
             <p className="text-base font-medium text-foreground">Cannot reach the hub</p>
-            <p className="text-sm text-muted-foreground max-w-sm">Make sure <code className="bg-muted px-1 rounded text-xs">ELASTICCLAW_HUB_URL</code> and <code className="bg-muted px-1 rounded text-xs">ELASTICCLAW_HUB_TOKEN</code> are set correctly.</p>
-            <a href="/api/debug" target="_blank" rel="noopener" className="text-xs text-blue-400 hover:underline">
+            <p className="text-sm text-muted-foreground max-w-sm">Make sure <code className="rounded-sm bg-tint-neutral px-1 font-mono text-xs text-tint-neutral-foreground">ELASTICCLAW_HUB_URL</code> and <code className="rounded-sm bg-tint-neutral px-1 font-mono text-xs text-tint-neutral-foreground">ELASTICCLAW_HUB_TOKEN</code> are set correctly.</p>
+            <a href="/api/debug" target="_blank" rel="noopener" className="text-xs text-primary hover:underline">
               View debug info →
             </a>
           </div>
@@ -1847,7 +1854,7 @@ export function ConversationView({
     return (
       <main className="flex-1 flex flex-col bg-background min-w-0 overflow-hidden">
         {/* Header */}
-        <header className="flex items-center justify-between gap-2 px-3 md:px-6 py-2 md:py-4 border-b border-border shrink-0">
+        <header className="flex items-center justify-between gap-2 px-3 md:px-6 py-2 md:py-4 border-b-2 border-border shrink-0">
           <div className="flex min-w-0 items-center gap-1 md:gap-3">
             {isMobile && onOpenMenu ? (
               <Button variant="ghost" size="icon" className="size-11 shrink-0" onClick={onOpenMenu} title="Open agent list">
@@ -1864,15 +1871,15 @@ export function ConversationView({
             <DependencyDowntimeBanner dependencies={downtimeDependencies} />
             <div className="hidden md:flex items-center gap-4">
               <div className="flex items-center gap-1.5">
-                <span className="size-2 rounded-full bg-green-500" />
+                <span className="size-2 rounded-full bg-status-ok" />
                 <span>Connected</span>
               </div>
               <div className="flex items-center gap-1.5">
-                <span className="size-2 rounded-full bg-amber-500" />
+                <span className="size-2 rounded-full bg-status-warn" />
                 <span>Idle</span>
               </div>
               <div className="flex items-center gap-1.5">
-                <span className="size-2 rounded-full bg-red-500" />
+                <span className="size-2 rounded-full bg-destructive" />
                 <span>Offline</span>
               </div>
             </div>
@@ -1911,7 +1918,7 @@ export function ConversationView({
                   Start your first agent from the CLI to get started.
                 </p>
               </div>
-              <div className="bg-muted rounded-lg px-4 py-3 font-mono text-sm text-foreground/80 max-w-md w-full text-left">
+              <div className="rounded-lg border border-border bg-card px-4 py-3 font-mono text-sm text-foreground/80 max-w-md w-full text-left">
                 <span className="text-muted-foreground select-none">$ </span>
                 elasticclaw create --name my-agent
               </div>
@@ -1937,7 +1944,7 @@ export function ConversationView({
           <Button
             variant="ghost"
             size="icon"
-            className="absolute left-2 top-1/2 -translate-y-1/2 z-10 bg-background/80 backdrop-blur-sm border border-border shadow-sm"
+            className="absolute left-2 top-1/2 -translate-y-1/2 z-10 bg-card/90 backdrop-blur-sm border border-border shadow-ds-sm"
             onClick={() => scrollBoard("left")}
           >
             <ChevronLeft className="size-4" />
@@ -1992,7 +1999,7 @@ export function ConversationView({
           <Button
             variant="ghost"
             size="icon"
-            className="absolute right-2 top-1/2 -translate-y-1/2 z-10 bg-background/80 backdrop-blur-sm border border-border shadow-sm"
+            className="absolute right-2 top-1/2 -translate-y-1/2 z-10 bg-card/90 backdrop-blur-sm border border-border shadow-ds-sm"
             onClick={() => scrollBoard("right")}
           >
             <ChevronRight className="size-4" />

--- a/web/components/conversation-view.tsx
+++ b/web/components/conversation-view.tsx
@@ -18,7 +18,7 @@ import {
   CLAW_LANE_ORDER,
   allowsTrailingRunning,
   boardCardNow,
-  clawLane,
+  trailingLatestStep,
   type ClawLane,
 } from "@/lib/claw-lanes"
 import { AgentTimeline } from "@/components/agent-timeline/timeline"
@@ -477,13 +477,10 @@ const ClawBoardCard = memo(function ClawBoardCard({
   const allowTrailingRunning = allowsTrailingRunning(claw)
   // Latest step of the trailing activity run — drives the card's status line
   // (paired start/terminal, live elapsed while running).
-  const latestStep = useMemo(() => {
-    const steps = demoteStaleRunning(
-      pairActivitySteps(trailingActivityRun(visibleMessages)),
-      allowTrailingRunning
-    )
-    return steps.length > 0 ? steps[steps.length - 1] : null
-  }, [visibleMessages, allowTrailingRunning])
+  const latestStep = useMemo(
+    () => trailingLatestStep(claw, visibleMessages),
+    [claw, visibleMessages]
+  )
   const activityNowMs = useNowTick(Boolean(latestStep))
   const isStreaming = claw.isStreaming || Boolean(streamingBuffer?.hadChunks && streamingBuffer.text)
   const cardNow = useMemo(

--- a/web/components/conversation-view.tsx
+++ b/web/components/conversation-view.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState, useRef, useEffect, useCallback, useMemo, memo } from "react"
-import { Send, Terminal, TerminalSquare, ChevronLeft, ChevronRight, ChevronDown, Loader2, LayoutGrid, Info, MessageSquare, Trash2, AlertCircle, Wrench, GripVertical, Settings2, Paperclip, File as FileIcon, X, Menu, MoreVertical, LogOut, ClipboardCopy } from "lucide-react"
+import { Send, Terminal, TerminalSquare, ChevronLeft, ChevronDown, Loader2, LayoutGrid, Info, MessageSquare, Trash2, AlertCircle, Wrench, GripVertical, Settings2, Paperclip, File as FileIcon, X, Menu, MoreVertical, LogOut, ClipboardCopy } from "lucide-react"
 import {
   compactActivityRuns,
   demoteStaleRunning,
@@ -12,7 +12,15 @@ import {
   trailingActivityRun,
   type Step,
 } from "@/lib/turns"
-import type { NowStripState } from "@/components/agent-timeline/now-strip"
+import {
+  BOARD_CARD_DURABLE_MESSAGE_WINDOW,
+  CLAW_LANE_META,
+  CLAW_LANE_ORDER,
+  allowsTrailingRunning,
+  boardCardNow,
+  clawLane,
+  type ClawLane,
+} from "@/lib/claw-lanes"
 import { AgentTimeline } from "@/components/agent-timeline/timeline"
 import { TimelineToolbar, useTimelineDensity } from "@/components/agent-timeline/timeline-toolbar"
 import { NowStrip } from "@/components/agent-timeline/now-strip"
@@ -33,7 +41,7 @@ import {
 import {
   SortableContext,
   useSortable,
-  horizontalListSortingStrategy,
+  rectSortingStrategy,
   arrayMove,
 } from "@dnd-kit/sortable"
 import { CSS } from "@dnd-kit/utilities"
@@ -90,13 +98,13 @@ interface ConversationViewProps {
   onSelectClaw: (id: string) => void
   onDeselectClaw: () => void
   onReorderClaws: (ids: string[]) => void
+  /** Status lane per claw id — the board groups its cards by it. */
+  clawLanes: Record<string, ClawLane>
   /** Mobile only: opens the sidebar drawer from the board header hamburger. */
   onOpenMenu?: () => void
 }
 
 const FOLLOW_LATEST_THRESHOLD_PX = 24
-/** Last N durable conversation turns on board cards (activities do not count). */
-const BOARD_CARD_DURABLE_MESSAGE_WINDOW = 50
 const EMPTY_MESSAGES: Message[] = []
 const noopClawAction = (_clawId: string) => {}
 const noopClawMessageAction = (_clawId: string, _content: string) => {}
@@ -199,104 +207,6 @@ function StreamingMessage({
       </div>
     </div>
   )
-}
-
-function firstMeaningfulLine(text: string): string {
-  for (const line of text.split("\n")) {
-    const trimmed = line.replace(/^#+\s*/, "").trim()
-    if (trimmed) return trimmed
-  }
-  return text.trim()
-}
-
-/**
- * The last question sentence of a message, if it plausibly asks the user
- * something ("posso forçar push?"). The "?" must end the message or a
- * sentence; the question starts after the previous sentence/line break.
- */
-function extractQuestion(text: string): string | null {
-  const trimmed = text.trim()
-  const qIdx = trimmed.lastIndexOf("?")
-  if (qIdx === -1) return null
-  if (qIdx !== trimmed.length - 1 && !/\s/.test(trimmed[qIdx + 1])) return null
-  const before = trimmed.slice(0, qIdx)
-  const boundary = before.match(/[.!?\n][^.!?\n]*$/)
-  const start = boundary?.index !== undefined ? boundary.index + 1 : 0
-  const question = trimmed.slice(start, qIdx + 1).trim()
-  return question || null
-}
-
-function lastActivityError(messages: Message[]): string | null {
-  for (let i = messages.length - 1; i >= 0; i -= 1) {
-    const m = messages[i]
-    if (m.role === "activity" && m.activity?.error) return m.activity.error
-  }
-  return null
-}
-
-interface BoardCardNow {
-  state: NowStripState
-  text?: string
-  at?: number | null
-}
-
-/**
- * The card's status line: is the agent working, waiting on the user, finished,
- * broken, or gone — and the one-liner that proves it. Working defers to the
- * NowStrip's live content (tool + elapsed + last-output age).
- */
-function boardCardNow(
-  claw: Claw,
-  messages: Message[],
-  latestStep: Step | null,
-  isStreaming: boolean
-): BoardCardNow | null {
-  // BootstrapProgress owns the provisioning story.
-  if (claw.status === "provisioning") return null
-
-  let lastAt: number | null = null
-  for (let i = messages.length - 1; i >= 0; i -= 1) {
-    if (messages[i].role === "system") continue
-    lastAt = messages[i].timestamp.getTime()
-    break
-  }
-
-  if (claw.status === "error") {
-    return {
-      state: "error",
-      text: claw.reason || lastActivityError(messages) || "Agent errored",
-      at: lastAt,
-    }
-  }
-  if (claw.status === "offline") {
-    const seen = claw.last_seen ? new Date(claw.last_seen).getTime() : NaN
-    return { state: "offline", at: Number.isFinite(seen) ? seen : lastAt }
-  }
-  if (isStreaming || latestStep?.status === "running") return { state: "working" }
-
-  // Nothing live: surface what the agent ended with. Transcript tail decides —
-  // trailing tool activity beats older prose, a question flags "needs you".
-  if (latestStep) {
-    return {
-      state: "done",
-      text: latestStep.detail ? `${latestStep.title} · ${latestStep.detail}` : latestStep.title,
-      at: (latestStep.endedAt ?? latestStep.startedAt).getTime(),
-    }
-  }
-  for (let i = messages.length - 1; i >= 0; i -= 1) {
-    const m = messages[i]
-    if (m.role === "system" || m.role === "activity" || m.role === "activity_summary") continue
-    const at = m.timestamp.getTime()
-    if (m.role === "claw") {
-      const text = m.content.trim()
-      const question = extractQuestion(text)
-      if (question) return { state: "waiting", text: question, at }
-      return { state: "done", text: firstMeaningfulLine(text), at }
-    }
-    if (m.role === "hub") return { state: "done", text: m.content, at }
-    if (m.role === "user") return { state: "done", text: "Waiting to start", at }
-  }
-  return { state: "done", text: "Idle", at: lastAt }
 }
 
 function formatUptime(seconds: number): string {
@@ -545,9 +455,9 @@ const ClawBoardCard = memo(function ClawBoardCard({
   const cardTextareaRef = useRef<HTMLTextAreaElement>(null)
   const cardFileInputRef = useRef<HTMLInputElement>(null)
   const [isFlipped, setIsFlipped] = useState(false)
-  // The 3D flip (perspective/preserve-3d) is brittle on mobile Safari — on
-  // phones the card is full-width in a vertical list and front/back is a
-  // plain visibility swap instead of a rotateY transform.
+  // Front/back is a plain visibility swap. The old rotateY flip needed a
+  // fixed card height to position the back face; lane cards size to their
+  // content, and the 3D transform was brittle on mobile Safari anyway.
   const isMobile = useIsMobile()
   const [showTerminal, setShowTerminal] = useState(false)
   const [confirmKill, setConfirmKill] = useState(false)
@@ -564,7 +474,7 @@ const ClawBoardCard = memo(function ClawBoardCard({
   )
   const conversationItems = useMemo(() => compactActivityRuns(visibleMessages), [visibleMessages])
   // An offline/errored claw cannot still be running its dangling last step.
-  const allowTrailingRunning = claw.status !== "offline" && claw.status !== "error"
+  const allowTrailingRunning = allowsTrailingRunning(claw)
   // Latest step of the trailing activity run — drives the card's status line
   // (paired start/terminal, live elapsed while running).
   const latestStep = useMemo(() => {
@@ -671,36 +581,18 @@ const ClawBoardCard = memo(function ClawBoardCard({
   
   return (
     <>
-    <div
-      className={cn(
-        "shrink-0 relative",
-        // Mobile cards size to their content (capped below) instead of a
-        // fixed desktop-carryover height — several agents fit per screen.
-        isMobile ? "w-full" : "w-[500px] h-full [perspective:1000px]"
-      )}
-    >
-      <div
-        className={cn(
-          "relative w-full",
-          !isMobile && "h-full transition-transform duration-500 [transform-style:preserve-3d]",
-          !isMobile && isFlipped && "[transform:rotateY(180deg)]"
-        )}
-      >
-        {/* Front - Chat view. On mobile it is in normal flow and sizes to its
-            content; the message list below carries its own viewport cap and
-            scrolls inside, so the whole card stays around 60vh at most. (A
-            max-height on the card itself would not work: `h-full` inside a
-            max-height-clamped auto container resolves against an indefinite
-            height, so the inner scroller would overflow and get clipped
-            instead of scrolling.) */}
+    <div className="relative w-full min-w-0">
+      <div className="relative w-full">
+        {/* Front - Chat view. The card sits in normal flow and sizes to its
+            content on every breakpoint — lanes lay cards out in a grid, so a
+            fixed height would leave short cards padded with dead space. The
+            message list below carries its own cap and scrolls inside. */}
         <div
           className={cn(
             // overflow-hidden so the state strip and composer sit flush inside
             // the card's rounded edge, as in the board mockup.
-            "flex flex-col overflow-hidden rounded-lg border border-border bg-card",
-            isMobile
-              ? cn("relative", isFlipped && "hidden")
-              : "absolute inset-0 [backface-visibility:hidden]",
+            "relative flex flex-col overflow-hidden rounded-lg border border-border bg-card",
+            isFlipped && "hidden",
             hasUnread && "border-data/50",
             isPending && "opacity-75"
           )}
@@ -849,9 +741,10 @@ const ClawBoardCard = memo(function ClawBoardCard({
             onScroll={handleCardScroll}
             className={cn(
               "overflow-y-auto scrollbar-thin p-3",
-              // vh cap so mobile cards are content-sized with an internal
-              // scroll; desktop fills the fixed-height card as before.
-              isMobile ? "max-h-[40vh]" : "h-full"
+              // Content-sized with an internal scroll: the mockup caps the
+              // lane card's message area at ~190px; phones get more room
+              // because a single card owns the whole viewport width.
+              isMobile ? "max-h-[40vh]" : "max-h-[190px]"
             )}
           >
             {/* Content wrapper — the ResizeObserver in usePinnedAutoScroll watches it. */}
@@ -1078,10 +971,8 @@ const ClawBoardCard = memo(function ClawBoardCard({
         {/* Back - Bot info */}
         <div
           className={cn(
-            "flex flex-col overflow-hidden rounded-lg border border-border bg-card",
-            isMobile
-              ? cn("relative", !isFlipped && "hidden")
-              : "absolute inset-0 [backface-visibility:hidden] [transform:rotateY(180deg)]"
+            "relative flex flex-col overflow-hidden rounded-lg border border-border bg-card",
+            !isFlipped && "hidden"
           )}
         >
           {/* Header */}
@@ -1192,11 +1083,10 @@ const SortableClawBoardCard = memo(function SortableClawBoardCard({
     transform: CSS.Transform.toString(transform),
     transition,
     opacity: isDragging ? 0.35 : 1,
-    height: "100%",
   }
 
   return (
-    <div ref={setNodeRef} style={style} className="h-full">
+    <div ref={setNodeRef} style={style} className="min-w-0">
       <ClawBoardCard
         claw={claw}
         messages={messages}
@@ -1399,7 +1289,7 @@ function ClawChatView({
   })
   const [density, setDensity] = useTimelineDensity()
   // An offline/errored claw cannot still be running its dangling last step.
-  const allowTrailingRunning = claw.status !== "offline" && claw.status !== "error"
+  const allowTrailingRunning = allowsTrailingRunning(claw)
   const turns = useMemo(() => groupIntoTurns(messages, allowTrailingRunning), [messages, allowTrailingRunning])
   const stats = useMemo(() => timelineStats(turns), [turns])
   const runningStep = useMemo(() => latestRunningStep(turns), [turns])
@@ -1780,9 +1670,9 @@ export function ConversationView({
   onSelectClaw,
   onDeselectClaw,
   onReorderClaws,
+  clawLanes,
   onOpenMenu,
 }: ConversationViewProps) {
-  const boardRef = useRef<HTMLDivElement>(null)
   const [activeDragClaw, setActiveDragClaw] = useState<Claw | null>(null)
   const { logoUrl } = useBranding()
   const isMobile = useIsMobile()
@@ -1801,32 +1691,29 @@ export function ConversationView({
     setActiveDragClaw(found ?? null)
   }
 
+  // Manual order still applies, but only inside a lane: status decides which
+  // lane a card lives in, so a drop across lanes has nowhere to land and is
+  // ignored. The stored order stays global — moving a card past its lane
+  // neighbours in that list is exactly the within-lane move the user made.
   function handleBoardDragEnd(event: DragEndEvent) {
     setActiveDragClaw(null)
     const { active, over } = event
     if (!over || active.id === over.id) return
+    if (clawLanes[active.id as string] !== clawLanes[over.id as string]) return
     const ids = allClaws.map((c) => c.id)
     const oldIdx = ids.indexOf(active.id as string)
     const newIdx = ids.indexOf(over.id as string)
+    if (oldIdx === -1 || newIdx === -1) return
     onReorderClaws(arrayMove(ids, oldIdx, newIdx))
   }
 
-  // On initial load, scroll board to leftmost active card
-  useEffect(() => {
-    if (!boardRef.current) return
-    boardRef.current.scrollLeft = 0
-  }, [])
-
-  const scrollBoard = (direction: "left" | "right") => {
-    if (boardRef.current) {
-      // One card plus the flex gap, so the arrows page card-by-card.
-      const scrollAmount = 516
-      boardRef.current.scrollBy({
-        left: direction === "left" ? -scrollAmount : scrollAmount,
-        behavior: "smooth",
-      })
-    }
-  }
+  // Cards grouped into the three status lanes, keeping the stored order
+  // within each lane.
+  const laneGroups = useMemo(() => {
+    const groups: Record<ClawLane, Claw[]> = { attention: [], working: [], idle: [] }
+    for (const c of allClaws) groups[clawLanes[c.id] ?? "idle"].push(c)
+    return groups
+  }, [allClaws, clawLanes])
 
   if (hubError) {
     return (
@@ -1923,88 +1810,114 @@ export function ConversationView({
                 elasticclaw create --name my-agent
               </div>
             </div>
-          ) : isMobile ? (
-            /* Single-column vertical list: full-width cards, no reordering,
-               no scroll arrows — one-finger vertical scrolling only. */
-            <div className="h-full overflow-y-auto overflow-x-hidden p-3 flex flex-col gap-3">
-              {sortedClaws.map((c) => (
-                <ClawBoardCard
-                  key={c.id}
-                  claw={c}
-                  messages={allMessages[c.id] ?? EMPTY_MESSAGES}
-                  streamingBuffer={streamingBuffers[c.id]}
-                  onClick={handleCardClick}
-                  onSendMessage={handleCardSendMessage}
-                  onKill={handleCardKill}
-                />
-              ))}
-            </div>
           ) : (
-          <>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="absolute left-2 top-1/2 -translate-y-1/2 z-10 bg-card/90 backdrop-blur-sm border border-border shadow-ds-sm"
-            onClick={() => scrollBoard("left")}
-          >
-            <ChevronLeft className="size-4" />
-          </Button>
-
-          <DndContext
-            sensors={sensors}
-            collisionDetection={closestCenter}
-            onDragStart={handleBoardDragStart}
-            onDragEnd={handleBoardDragEnd}
-          >
-            <SortableContext
-              items={sortedClaws.map((c) => c.id)}
-              strategy={horizontalListSortingStrategy}
+            /* Status lanes stacked down a scrolling page. Cards inside a lane
+               flow into an auto-fill grid, so the board reads top-to-bottom by
+               urgency instead of sideways through a carousel. */
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragStart={handleBoardDragStart}
+              onDragEnd={handleBoardDragEnd}
             >
-              <div
-                ref={boardRef}
-                className="flex gap-4 h-full overflow-x-auto overflow-y-hidden py-6 px-12 items-stretch"
-                style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
-              >
-                {sortedClaws.map((c) => (
-                  <SortableClawBoardCard
-                    key={c.id}
-                    claw={c}
-                    messages={allMessages[c.id] ?? EMPTY_MESSAGES}
-                    streamingBuffer={streamingBuffers[c.id]}
-                    onClick={handleCardClick}
-                    onSendMessage={handleCardSendMessage}
-                    onKill={handleCardKill}
-                  />
-                ))}
+              <div className="grid h-full content-start gap-6 overflow-y-auto overflow-x-hidden p-3 md:p-4">
+                {CLAW_LANE_ORDER.map((lane) => {
+                  const laneClaws = laneGroups[lane]
+                  // Empty lanes are omitted — no headers over nothing.
+                  if (laneClaws.length === 0) return null
+                  const meta = CLAW_LANE_META[lane]
+                  return (
+                    <section key={lane}>
+                      <div className="mb-3 flex items-center gap-2 border-b-2 border-border pb-2">
+                        <h3
+                          className={cn(
+                            "text-[13px] font-extrabold uppercase tracking-[0.08em]",
+                            lane === "attention" && "text-primary",
+                            lane === "working" && "text-status-ok",
+                            lane === "idle" && "text-foreground"
+                          )}
+                        >
+                          {meta.title}
+                        </h3>
+                        <span
+                          className={cn(
+                            "inline-flex h-5 min-w-5 items-center justify-center rounded-full px-1.5 text-[11px] font-semibold tabular-nums",
+                            lane === "attention"
+                              ? "bg-primary text-primary-foreground"
+                              : "bg-foreground/12 text-foreground"
+                          )}
+                        >
+                          {laneClaws.length}
+                        </span>
+                        <span className="ml-auto hidden text-xs text-muted-foreground sm:block">
+                          {meta.note}
+                        </span>
+                      </div>
+                      <SortableContext
+                        items={laneClaws.map((c) => c.id)}
+                        strategy={rectSortingStrategy}
+                      >
+                        <div className="grid grid-cols-1 items-start gap-4 md:grid-cols-[repeat(auto-fill,minmax(360px,1fr))]">
+                          {laneClaws.map((c) => {
+                            const card = isMobile ? (
+                              /* No reordering on touch: a 6px activation would
+                                 steal one-finger scrolling. */
+                              <ClawBoardCard
+                                claw={c}
+                                messages={allMessages[c.id] ?? EMPTY_MESSAGES}
+                                streamingBuffer={streamingBuffers[c.id]}
+                                onClick={handleCardClick}
+                                onSendMessage={handleCardSendMessage}
+                                onKill={handleCardKill}
+                              />
+                            ) : (
+                              <SortableClawBoardCard
+                                claw={c}
+                                messages={allMessages[c.id] ?? EMPTY_MESSAGES}
+                                streamingBuffer={streamingBuffers[c.id]}
+                                onClick={handleCardClick}
+                                onSendMessage={handleCardSendMessage}
+                                onKill={handleCardKill}
+                              />
+                            )
+                            return lane === "idle" ? (
+                              // Dimmed until hovered: parked agents stay
+                              // readable without competing with the live ones.
+                              <div
+                                key={c.id}
+                                className="min-w-0 opacity-[0.55] transition-opacity hover:opacity-100 focus-within:opacity-100"
+                              >
+                                {card}
+                              </div>
+                            ) : (
+                              <div key={c.id} className="min-w-0">
+                                {card}
+                              </div>
+                            )
+                          })}
+                        </div>
+                      </SortableContext>
+                    </section>
+                  )
+                })}
               </div>
-            </SortableContext>
 
-            {/* Ghost card following cursor during drag */}
-            <DragOverlay>
-              {activeDragClaw ? (
-                <div className="opacity-90 shadow-2xl h-full" style={{ width: 320 }}>
-                  <ClawBoardCard
-                    claw={activeDragClaw}
-                    messages={allMessages[activeDragClaw.id] ?? EMPTY_MESSAGES}
-                    streamingBuffer={streamingBuffers[activeDragClaw.id]}
-                    onClick={noopClawAction}
-                    onSendMessage={noopClawMessageAction}
-                    onKill={noopClawAction}
-                  />
-                </div>
-              ) : null}
-            </DragOverlay>
-          </DndContext>
-
-          <Button
-            variant="ghost"
-            size="icon"
-            className="absolute right-2 top-1/2 -translate-y-1/2 z-10 bg-card/90 backdrop-blur-sm border border-border shadow-ds-sm"
-            onClick={() => scrollBoard("right")}
-          >
-            <ChevronRight className="size-4" />
-          </Button>
-          </>
+              {/* Ghost card following cursor during drag */}
+              <DragOverlay>
+                {activeDragClaw ? (
+                  <div className="opacity-90 shadow-ds-lg" style={{ width: 360 }}>
+                    <ClawBoardCard
+                      claw={activeDragClaw}
+                      messages={allMessages[activeDragClaw.id] ?? EMPTY_MESSAGES}
+                      streamingBuffer={streamingBuffers[activeDragClaw.id]}
+                      onClick={noopClawAction}
+                      onSendMessage={noopClawMessageAction}
+                      onKill={noopClawAction}
+                    />
+                  </div>
+                ) : null}
+              </DragOverlay>
+            </DndContext>
           )}
         </div>
       </main>

--- a/web/components/copy-transcript-button.tsx
+++ b/web/components/copy-transcript-button.tsx
@@ -71,12 +71,12 @@ export function CopyTranscriptButton({
         disabled={disabled}
         title={title}
         className={cn(
-          "p-1 rounded hover:bg-accent transition-colors disabled:opacity-40 disabled:pointer-events-none",
+          "p-1 rounded-md hover:bg-foreground/8 transition-colors disabled:opacity-40 disabled:pointer-events-none",
           className
         )}
       >
         {copied ? (
-          <Check className="size-3.5 text-green-500" />
+          <Check className="size-3.5 text-status-ok" />
         ) : (
           <ClipboardCopy className="size-3.5 text-muted-foreground" />
         )}
@@ -95,7 +95,7 @@ export function CopyTranscriptButton({
       className={className}
     >
       {copied ? (
-        <Check className="size-3.5 mr-1.5 text-green-500" />
+        <Check className="size-3.5 mr-1.5 text-status-ok" />
       ) : (
         <ClipboardCopy className="size-3.5 mr-1.5" />
       )}

--- a/web/components/dependency-downtime-banner.tsx
+++ b/web/components/dependency-downtime-banner.tsx
@@ -46,7 +46,7 @@ export function DependencyDowntimeBanner({ dependencies, className }: Dependency
           aria-label={`${text}: ${names}`}
           title={title}
           className={cn(
-            "inline-flex h-7 max-w-full items-center gap-1.5 whitespace-nowrap rounded-md border border-amber-500/40 bg-amber-500/10 px-2.5 text-xs font-medium text-amber-500 outline-none ring-offset-background transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+            "inline-flex h-7 max-w-full items-center gap-1.5 whitespace-nowrap rounded-md border border-status-warn/40 bg-status-warn/10 px-2.5 text-xs font-medium text-status-warn outline-none ring-offset-background transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
             className
           )}
         >

--- a/web/components/home-shell.tsx
+++ b/web/components/home-shell.tsx
@@ -13,6 +13,7 @@ import { useIsMobile } from "@/hooks/use-mobile"
 import { useHub } from "@/hooks/use-hub"
 import { useBoardActivityPrefetch } from "@/hooks/use-board-activity-prefetch"
 import { demoteStaleRunning, pairActivitySteps, trailingActivityRun } from "@/lib/turns"
+import { clawLanes as deriveClawLanes } from "@/lib/claw-lanes"
 import { type Workflow } from "@/lib/api"
 import {
   subscribeToShellStorage,
@@ -215,6 +216,18 @@ export function HomeShell() {
     return lines
   }, [claws, messages])
 
+  // Status lane per agent, shared by the board and the sidebar so both group
+  // the same way. Derived from the claw status and its loaded transcript tail
+  // — the exact signals the card's state strip already renders.
+  const lanes = useMemo(
+    () =>
+      deriveClawLanes(claws, messages, (claw) => {
+        const buffer = streamingBuffers[claw.id]
+        return claw.isStreaming || Boolean(buffer?.hadChunks && buffer.text)
+      }),
+    [claws, messages, streamingBuffers]
+  )
+
   // Mark messages as read when selecting a claw + lazy load history
   const handleSelectClaw = useCallback(
     (id: string) => {
@@ -324,6 +337,7 @@ export function HomeShell() {
       onToggleCollapse={() => setSidebarCollapsed(!sidebarCollapsed)}
       onReorderClaws={reorderClaws}
       activityLines={sidebarActivity}
+      clawLanes={lanes}
       isAdmin={isAdmin}
       onSelectWorkflow={setSelectedWorkflow}
       view={view}
@@ -370,6 +384,7 @@ export function HomeShell() {
             onSelectClaw={handleSelectClaw}
             onDeselectClaw={() => writeSelectedClawId(null)}
             onReorderClaws={reorderClaws}
+            clawLanes={lanes}
             loading={loading}
             hubError={hubError}
             onOpenMenu={isMobile ? () => setDrawerOpen(true) : undefined}

--- a/web/components/manual-trigger-modal.tsx
+++ b/web/components/manual-trigger-modal.tsx
@@ -102,7 +102,7 @@ export function ManualTriggerModal({ open, onOpenChange, workflow }: ManualTrigg
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            <Zap className="size-4 text-amber-500" />
+            <Zap className="size-4 text-status-warn" />
             Trigger {workflow.name}
           </DialogTitle>
           <DialogDescription>
@@ -126,7 +126,7 @@ export function ManualTriggerModal({ open, onOpenChange, workflow }: ManualTrigg
         )}
 
         {triggerError && (
-          <div className="flex items-center gap-1.5 text-sm text-red-500 bg-red-50 p-2 rounded">
+          <div className="flex items-center gap-1.5 rounded-md bg-destructive/10 p-2 text-sm text-destructive">
             <AlertCircle className="size-4" />
             <span>{triggerError}</span>
           </div>
@@ -166,9 +166,9 @@ function WorkflowInputField({
 }) {
   return (
     <div className="space-y-1.5">
-      <label className="text-sm font-medium flex items-center gap-1">
+      <label className="flex items-center gap-1.5 font-mono text-[13px]">
         {input.name}
-        {input.required && <span className="text-red-500">*</span>}
+        {input.required && <span className="text-destructive">*</span>}
         <Badge variant="secondary" className="text-[10px] font-normal">
           {input.type}
         </Badge>
@@ -178,7 +178,7 @@ function WorkflowInputField({
       )}
       {input.type === "enum" && input.options ? (
         <select
-          className="w-full text-sm border border-border rounded-md px-3 py-2 bg-background"
+          className="w-full rounded-md border border-input bg-card px-2.5 py-1.5 text-sm outline-none transition-colors hover:border-foreground/45 focus-visible:border-primary"
           value={value || input.default || ""}
           onChange={(e) => onChange(e.target.value)}
         >
@@ -188,7 +188,7 @@ function WorkflowInputField({
         </select>
       ) : input.type === "bool" ? (
         <select
-          className="w-full text-sm border border-border rounded-md px-3 py-2 bg-background"
+          className="w-full rounded-md border border-input bg-card px-2.5 py-1.5 text-sm outline-none transition-colors hover:border-foreground/45 focus-visible:border-primary"
           value={value || input.default || "false"}
           onChange={(e) => onChange(e.target.value)}
         >

--- a/web/components/markdown-content.tsx
+++ b/web/components/markdown-content.tsx
@@ -14,25 +14,36 @@ const remarkPlugins = [remarkGfm]
 
 const components: Components = {
   // Headings
-  h1: ({ children }) => <h1 className="text-base font-bold mt-3 mb-1 first:mt-0">{children}</h1>,
-  h2: ({ children }) => <h2 className="text-sm font-bold mt-3 mb-1 first:mt-0">{children}</h2>,
-  h3: ({ children }) => <h3 className="text-sm font-semibold mt-2 mb-1 first:mt-0">{children}</h3>,
+  h1: ({ children }) => <h1 className="text-base mt-3 mb-1 first:mt-0 text-foreground">{children}</h1>,
+  h2: ({ children }) => <h2 className="text-sm mt-3 mb-1 first:mt-0 text-foreground">{children}</h2>,
+  h3: ({ children }) => <h3 className="text-sm mt-2 mb-1 first:mt-0 text-foreground">{children}</h3>,
   p: ({ children }) => <p className="mb-2 last:mb-0 leading-relaxed">{children}</p>,
   code: ({ children, className }) => {
     const isBlock = className?.startsWith("language-")
-    if (isBlock) return <code className="block bg-black/40 rounded px-3 py-2 text-xs font-mono whitespace-pre my-2">{children}</code>
-    return <code className="bg-black/40 rounded px-1.5 py-0.5 text-xs font-mono break-words">{children}</code>
+    // Code sits on the neutral tint rather than a hardcoded ink wash so it
+    // stays legible on both the surface bubbles and the page ground.
+    if (isBlock)
+      return (
+        <code className="block rounded-md bg-tint-neutral text-tint-neutral-foreground px-3 py-2 text-xs font-mono whitespace-pre my-2">
+          {children}
+        </code>
+      )
+    return (
+      <code className="rounded-sm bg-tint-neutral text-tint-neutral-foreground px-1.5 py-0.5 text-xs font-mono break-words">
+        {children}
+      </code>
+    )
   },
   pre: ({ children }) => <pre className="not-prose my-2 overflow-x-auto">{children}</pre>,
   ul: ({ children }) => <ul className="list-disc list-outside ml-4 mb-2 last:mb-0 space-y-0.5">{children}</ul>,
   ol: ({ children }) => <ol className="list-decimal list-outside ml-4 mb-2 last:mb-0 space-y-0.5">{children}</ol>,
   li: ({ children }) => <li className="text-sm leading-relaxed">{children}</li>,
-  blockquote: ({ children }) => <blockquote className="border-l-2 border-muted-foreground/40 pl-3 my-2 text-muted-foreground italic">{children}</blockquote>,
+  blockquote: ({ children }) => <blockquote className="border-l-2 border-border pl-3 my-2 text-muted-foreground italic">{children}</blockquote>,
   table: ({ children }) => <div className="overflow-x-auto my-2"><table className="text-xs border-collapse w-full">{children}</table></div>,
-  th: ({ children }) => <th className="border border-border px-2 py-1 bg-muted text-left font-semibold">{children}</th>,
+  th: ({ children }) => <th className="border border-border px-2 py-1 bg-foreground/7 text-left font-semibold">{children}</th>,
   td: ({ children }) => <td className="border border-border px-2 py-1">{children}</td>,
-  a: ({ href, children }) => <a href={href} target="_blank" rel="noopener noreferrer" className="text-blue-400 hover:underline">{children}</a>,
-  hr: () => <hr className="border-border my-3" />,
+  a: ({ href, children }) => <a href={href} target="_blank" rel="noopener noreferrer" className="text-primary underline-offset-2 hover:underline">{children}</a>,
+  hr: () => <hr className="border-0 border-t border-border my-3" />,
   strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
   em: ({ children }) => <em className="italic">{children}</em>,
 }

--- a/web/components/mobile-tab-bar.tsx
+++ b/web/components/mobile-tab-bar.tsx
@@ -22,7 +22,7 @@ export function MobileTabBar({
   onSelectAnalytics: () => void
 }) {
   return (
-    <nav className="shrink-0 border-t border-border bg-card pb-[env(safe-area-inset-bottom)]">
+    <nav className="shrink-0 border-t-2 border-border bg-card pb-[env(safe-area-inset-bottom)]">
       <div className="flex">
         <TabItem
           label="Agents"
@@ -67,8 +67,10 @@ function TabItem({
       type="button"
       onClick={onClick}
       className={cn(
-        "flex min-h-12 flex-1 flex-col items-center justify-center gap-0.5 py-1.5 text-[10px] font-medium transition-colors",
-        active ? "text-foreground" : "text-muted-foreground hover:text-foreground"
+        // Matches the design system's nav: the current destination is the only
+        // thing wearing the accent, everything else is quiet.
+        "flex min-h-12 flex-1 flex-col items-center justify-center gap-0.5 py-1.5 kicker font-semibold transition-colors",
+        active ? "text-primary" : "text-muted-foreground hover:text-foreground"
       )}
       aria-current={active ? "page" : undefined}
     >

--- a/web/components/run-logs-dialog.tsx
+++ b/web/components/run-logs-dialog.tsx
@@ -107,9 +107,9 @@ function OutputTab({ open, runId }: { open: boolean; runId: string }) {
   return (
     <div className="space-y-4">
       {groups.map(([stage, stageOutputs]) => (
-        <section key={stage} className="rounded-md border">
-          <h3 className="border-b bg-muted/40 px-4 py-2 text-sm font-semibold">{stage}</h3>
-          <div className="divide-y">
+        <section key={stage} className="overflow-hidden rounded-lg border border-border">
+          <h3 className="border-b border-border bg-foreground/4 px-4 py-2 text-sm">{stage}</h3>
+          <div className="divide-y divide-border">
             {stageOutputs.map((output) => <OutputBlock key={`${output.clawId}-${output.outputName}`} output={output} />)}
           </div>
         </section>
@@ -124,9 +124,9 @@ function OutputBlock({ output }: { output: TaskRunOutput }) {
       <div className="flex flex-wrap items-center justify-between gap-2">
         <div>
           <div className="text-sm font-medium">{output.outputName}</div>
-          {output.attemptId && <div className="text-xs text-muted-foreground">{output.attemptId}</div>}
+          {output.attemptId && <div className="font-mono text-[11px] text-muted-foreground">{output.attemptId}</div>}
         </div>
-        <Badge className={cn("border", output.exitCode === 0 ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300" : "border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-300")}>Exit {output.exitCode}</Badge>
+        <Badge className={cn("border font-mono", output.exitCode === 0 ? "border-status-ok bg-status-ok/12 text-status-ok" : "border-primary bg-tint-accent text-primary")}>Exit {output.exitCode}</Badge>
       </div>
       {output.stdout && <LogStream label="stdout" value={output.stdout} />}
       {output.stderr && <LogStream label="stderr" value={output.stderr} error />}
@@ -136,5 +136,5 @@ function OutputBlock({ output }: { output: TaskRunOutput }) {
 }
 
 function LogStream({ label, value, error = false }: { label: string; value: string; error?: boolean }) {
-  return <div><div className={cn("mb-1 text-xs font-medium text-muted-foreground", error && "text-destructive")}>{label}</div><pre className="max-h-64 overflow-auto whitespace-pre-wrap break-words rounded-md bg-muted p-3 font-mono text-xs">{value}</pre></div>
+  return <div><div className={cn("kicker mb-1 font-semibold text-muted-foreground", error && "text-destructive")}>{label}</div><pre className="scrollbar-thin max-h-64 overflow-auto whitespace-pre-wrap break-words rounded-md border border-border bg-foreground/4 p-3 font-mono text-xs">{value}</pre></div>
 }

--- a/web/components/setup-screen.tsx
+++ b/web/components/setup-screen.tsx
@@ -24,17 +24,17 @@ export function SetupScreen({ onConnected }: { onConnected: () => void }) {
   }
 
   return (
-    <div className="flex h-screen bg-background items-center justify-center">
-      <div className="w-full max-w-md p-8 space-y-6">
-        <div className="space-y-2">
-          <h1 className="text-2xl font-bold">Connect to {appName} Server</h1>
-          <p className="text-sm text-muted-foreground">
+    <div className="grid h-screen place-items-center bg-background p-4">
+      <div className="w-full max-w-[440px] space-y-6">
+        <div>
+          <h1 className="text-[26px]">Connect to {appName} Server</h1>
+          <p className="mt-2 text-sm text-muted-foreground">
             Enter your {appName} Server URL and authentication token to get started.
           </p>
         </div>
 
         <div className="space-y-4">
-          <Field>
+          <Field className="gap-1.5">
             <FieldLabel htmlFor="hub-url">{appName} Server URL</FieldLabel>
             <Input
               id="hub-url"
@@ -44,7 +44,7 @@ export function SetupScreen({ onConnected }: { onConnected: () => void }) {
               onKeyDown={(e) => e.key === "Enter" && handleConnect()}
             />
           </Field>
-          <Field>
+          <Field className="gap-1.5">
             <FieldLabel htmlFor="hub-token">Token</FieldLabel>
             <Input
               id="hub-token"
@@ -59,16 +59,23 @@ export function SetupScreen({ onConnected }: { onConnected: () => void }) {
         </div>
 
         <Button
-          className="w-full"
+          className="w-full justify-start"
           onClick={handleConnect}
           disabled={!hubUrl.trim() || !hubToken.trim()}
         >
           Connect
         </Button>
 
-        <p className="text-xs text-muted-foreground text-center">
-          You can also set <code className="bg-muted px-1 rounded">NEXT_PUBLIC_HUB_URL</code> and{" "}
-          <code className="bg-muted px-1 rounded">NEXT_PUBLIC_HUB_TOKEN</code> environment variables.
+        <p className="text-xs text-muted-foreground">
+          You can also set{" "}
+          <code className="rounded-sm bg-foreground/10 px-1.5 py-px font-mono text-[0.92em] text-foreground">
+            NEXT_PUBLIC_HUB_URL
+          </code>{" "}
+          and{" "}
+          <code className="rounded-sm bg-foreground/10 px-1.5 py-px font-mono text-[0.92em] text-foreground">
+            NEXT_PUBLIC_HUB_TOKEN
+          </code>{" "}
+          environment variables.
         </p>
       </div>
     </div>

--- a/web/components/sidebar.tsx
+++ b/web/components/sidebar.tsx
@@ -487,7 +487,11 @@ export function Sidebar({
       >
         {/* Pinned section lives inside the scroll area — a long pinned list
             must scroll with the rest instead of squeezing "All Agents" out. */}
-        <ScrollArea className="flex-1 min-h-0">
+        {/* Radix sizes the viewport's content div as a table, so one long
+            activity line stretches every row past the sidebar and pushes the
+            right-aligned group counts out of view. Pin it to the viewport
+            width and the truncation inside the rows does its job. */}
+        <ScrollArea className="flex-1 min-h-0 [&>[data-slot=scroll-area-viewport]>div]:!block [&>[data-slot=scroll-area-viewport]>div]:!w-full">
           {pinnedClaws.length > 0 && !searchQuery && (
             <div className="border-b-2 border-border">
               <div className="flex items-center gap-1.5 px-4 py-2 text-muted-foreground">

--- a/web/components/sidebar.tsx
+++ b/web/components/sidebar.tsx
@@ -16,6 +16,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { cn } from "@/lib/utils"
+import { CLAW_LANE_META, CLAW_LANE_ORDER, type ClawLane } from "@/lib/claw-lanes"
 import type { Claw } from "@/lib/types"
 import {
   DndContext,
@@ -34,7 +35,7 @@ import {
   arrayMove,
 } from "@dnd-kit/sortable"
 import { CSS } from "@dnd-kit/utilities"
-import { useState, useEffect, useCallback } from "react"
+import { useState, useEffect, useCallback, useMemo } from "react"
 
 type TagFilter = string
 
@@ -57,6 +58,8 @@ interface SidebarProps {
   onToggleCollapse: () => void
   /** Per-claw "current tool" one-liners for the second row line. */
   activityLines?: Record<string, string>
+  /** Status lane per claw id — the list is grouped by it, board-style. */
+  clawLanes: Record<string, ClawLane>
   isAdmin?: boolean
   onSelectWorkflow?: (workflow: Workflow | null) => void
   view?: "agents" | "analytics"
@@ -124,6 +127,7 @@ export function Sidebar({
   isCollapsed,
   onToggleCollapse,
   activityLines,
+  clawLanes,
   isAdmin = true,
   onSelectWorkflow,
   view = "agents",
@@ -227,6 +231,8 @@ export function Sidebar({
     const targetInPinned = pinnedClaws.some((c) => c.id === over.id)
 
     if (inPinned !== targetInPinned) return // don't allow crossing sections
+    // Status decides the group, so reordering only makes sense inside a lane.
+    if (!inPinned && clawLanes[active.id as string] !== clawLanes[over.id as string]) return
 
     if (inPinned) {
       // Reorder within pinned — update full order accounting for the pinned move
@@ -248,6 +254,18 @@ export function Sidebar({
 
   // Merge pinned + unpinned for collapsed view (order already applied by parent)
   const allClaws = [...pinnedClaws, ...claws.filter(c => !pinnedClaws.find(p => p.id === c.id))]
+
+  // The filtered list, split into the same three status lanes the board uses.
+  // Filtering and search run before this, so a group only ever holds rows that
+  // survived them; empty groups are dropped.
+  const laneSections = useMemo(() => {
+    const groups: Record<ClawLane, Claw[]> = { attention: [], working: [], idle: [] }
+    for (const c of claws) groups[clawLanes[c.id] ?? "idle"].push(c)
+    return CLAW_LANE_ORDER.filter((lane) => groups[lane].length > 0).map((lane) => ({
+      lane,
+      claws: groups[lane],
+    }))
+  }, [claws, clawLanes])
 
   let sidebar: React.ReactElement
 
@@ -501,38 +519,57 @@ export function Sidebar({
               </div>
             </div>
           )}
-          <div className="p-2">
-            {!searchQuery && pinnedClaws.length > 0 && claws.length > 0 && (
-              <div className="flex items-center gap-1.5 px-2 py-2 text-muted-foreground">
-                <span className="kicker">All Agents</span>
-                <span className="ml-auto font-mono text-[10px] tabular-nums">
-                  {claws.length}
-                </span>
-              </div>
-            )}
+          <div className="pb-2">
             {claws.length === 0 && pinnedClaws.length === 0 ? (
               <p className="text-sm text-muted-foreground text-center py-8">
                 No agents found
               </p>
             ) : (
-              <SortableContext
-                items={claws.map((c) => c.id)}
-                strategy={verticalListSortingStrategy}
-              >
-                {claws.map((claw) => (
-                  <SortableClawCard
-                    key={claw.id}
-                    claw={claw}
-                    isSelected={claw.id === selectedClawId}
-                    onClick={() => onSelectClaw(claw.id)}
-                    onTogglePin={(e) => {
-                      e.stopPropagation()
-                      onTogglePin(claw.id)
-                    }}
-                    activityLine={activityLines?.[claw.id]}
-                  />
-                ))}
-              </SortableContext>
+              laneSections.map(({ lane, claws: laneClaws }, index) => (
+                <div
+                  key={lane}
+                  className={cn(index > 0 && "border-t-2 border-border")}
+                >
+                  <div className="flex items-center gap-1.5 px-4 py-2">
+                    <span
+                      className={cn(
+                        "kicker",
+                        lane === "attention" ? "text-primary" : "text-muted-foreground"
+                      )}
+                    >
+                      {CLAW_LANE_META[lane].title}
+                    </span>
+                    <span
+                      className={cn(
+                        "ml-auto font-mono text-[10px] tabular-nums",
+                        lane === "attention" ? "text-primary" : "text-muted-foreground"
+                      )}
+                    >
+                      {laneClaws.length}
+                    </span>
+                  </div>
+                  <div className="px-2 pb-2">
+                    <SortableContext
+                      items={laneClaws.map((c) => c.id)}
+                      strategy={verticalListSortingStrategy}
+                    >
+                      {laneClaws.map((claw) => (
+                        <SortableClawCard
+                          key={claw.id}
+                          claw={claw}
+                          isSelected={claw.id === selectedClawId}
+                          onClick={() => onSelectClaw(claw.id)}
+                          onTogglePin={(e) => {
+                            e.stopPropagation()
+                            onTogglePin(claw.id)
+                          }}
+                          activityLine={activityLines?.[claw.id]}
+                        />
+                      ))}
+                    </SortableContext>
+                  </div>
+                </div>
+              ))
             )}
           </div>
         </ScrollArea>

--- a/web/components/sidebar.tsx
+++ b/web/components/sidebar.tsx
@@ -253,8 +253,8 @@ export function Sidebar({
 
   if (isCollapsed && !inDrawer) {
     sidebar = (
-      <aside className="w-12 h-screen-safe flex flex-col border-r border-border bg-card">
-        <div className="p-2 border-b border-border flex flex-col items-center gap-1">
+      <aside className="w-12 h-screen-safe flex flex-col border-r-2 border-border bg-card">
+        <div className="p-2 border-b-2 border-border flex flex-col items-center gap-1">
           <Button
             variant="ghost"
             size="icon"
@@ -287,28 +287,28 @@ export function Sidebar({
                 onClick={() => onSelectClaw(claw.id)}
                 title={claw.name}
                 className={cn(
-                  "relative size-8 rounded-md flex items-center justify-center transition-colors hover:bg-accent",
-                  isSelected && "bg-accent"
+                  "relative size-8 rounded-md flex items-center justify-center transition-colors hover:bg-foreground/7",
+                  isSelected && "bg-foreground/10"
                 )}
               >
                 {/* Status dot */}
                 {claw.status === "provisioning" ? (
-                  <Loader2 className="size-3.5 text-blue-400 animate-spin" />
+                  <Loader2 className="size-3.5 text-data animate-spin" />
                 ) : claw.status === "error" ? (
-                  <AlertCircle className="size-3.5 text-red-500" />
+                  <AlertCircle className="size-3.5 text-destructive" />
                 ) : claw.isStreaming ? (
-                  <Loader2 className="size-3.5 text-green-500 animate-spin" />
+                  <Loader2 className="size-3.5 text-status-ok animate-spin" />
                 ) : (
                   <span className={cn(
                     "size-2.5 rounded-full",
-                    claw.status === "connected" && "bg-green-500",
-                    claw.status === "idle" && "bg-amber-500",
+                    claw.status === "connected" && "bg-status-ok",
+                    claw.status === "idle" && "bg-status-warn",
                     claw.status === "offline" && "bg-muted-foreground/50"
                   )} />
                 )}
                 {/* Unread badge */}
                 {hasUnread && (
-                  <span className="absolute -top-0.5 -right-0.5 size-3.5 flex items-center justify-center text-[8px] font-bold bg-blue-600 text-white rounded-full">
+                  <span className="absolute -top-0.5 -right-0.5 size-3.5 flex items-center justify-center font-mono text-[8px] font-bold bg-primary text-primary-foreground rounded-full">
                     {claw.unreadCount > 9 ? "9+" : claw.unreadCount}
                   </span>
                 )}
@@ -318,7 +318,7 @@ export function Sidebar({
         </div>
 
         {/* Footer: view toggle + settings (admin) and sign out */}
-        <div className="p-2 border-t border-border flex flex-col items-center gap-1">
+        <div className="p-2 border-t-2 border-border flex flex-col items-center gap-1">
           {isAdmin && (
             <>
               <Button
@@ -326,7 +326,7 @@ export function Sidebar({
                 size="icon"
                 className={cn(
                   "size-8 text-muted-foreground hover:text-foreground",
-                  inAnalytics && "bg-muted text-foreground"
+                  inAnalytics && "bg-foreground/10 text-foreground"
                 )}
                 title={viewToggleLabel}
                 onClick={onToggleView}
@@ -362,11 +362,11 @@ export function Sidebar({
       <aside
         className={cn(
           "flex flex-col bg-card",
-          inDrawer ? "w-full h-full" : "w-[260px] h-screen-safe border-r border-border"
+          inDrawer ? "w-full h-full" : "w-[260px] h-screen-safe border-r-2 border-border"
         )}
       >
-      <div className={cn("flex items-center justify-between p-4 border-b border-border", inDrawer && "pr-12")}>
-        <h1 className="text-lg font-semibold tracking-tight text-foreground">
+      <div className={cn("flex items-center justify-between p-4 border-b-2 border-border", inDrawer && "pr-12")}>
+        <h1 className="text-[18px] font-extrabold tracking-[-0.015em] text-foreground">
           {appName}
         </h1>
         <div className="flex items-center gap-1">
@@ -396,7 +396,7 @@ export function Sidebar({
         </div>
       </div>
 
-      <div className="p-3 border-b border-border space-y-2">
+      <div className="p-3 border-b-2 border-border space-y-2">
         <div className="relative">
           <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" />
           <Input
@@ -438,7 +438,7 @@ export function Sidebar({
             <span
               key={tag}
               title={tag}
-              className="inline-flex items-center gap-1 px-2 py-1 text-xs bg-secondary text-foreground rounded max-w-[120px]"
+              className="inline-flex items-center gap-1 px-2.5 py-1 text-[11px] tracking-[0.02em] bg-tint-neutral text-tint-neutral-foreground rounded-full max-w-[120px]"
             >
               <span className="truncate">{tag}</span>
               <button
@@ -471,11 +471,12 @@ export function Sidebar({
             must scroll with the rest instead of squeezing "All Agents" out. */}
         <ScrollArea className="flex-1 min-h-0">
           {pinnedClaws.length > 0 && !searchQuery && (
-            <div className="border-b border-border">
-              <div className="flex items-center gap-1.5 px-4 py-2">
-                <Pin className="size-3 text-muted-foreground" />
-                <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                  Pinned
+            <div className="border-b-2 border-border">
+              <div className="flex items-center gap-1.5 px-4 py-2 text-muted-foreground">
+                <Pin className="size-3" />
+                <span className="kicker">Pinned</span>
+                <span className="ml-auto font-mono text-[10px] tabular-nums">
+                  {pinnedClaws.length}
                 </span>
               </div>
               <div className="px-2 pb-2">
@@ -502,9 +503,10 @@ export function Sidebar({
           )}
           <div className="p-2">
             {!searchQuery && pinnedClaws.length > 0 && claws.length > 0 && (
-              <div className="flex items-center gap-1.5 px-2 py-2">
-                <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                  All Agents
+              <div className="flex items-center gap-1.5 px-2 py-2 text-muted-foreground">
+                <span className="kicker">All Agents</span>
+                <span className="ml-auto font-mono text-[10px] tabular-nums">
+                  {claws.length}
                 </span>
               </div>
             )}
@@ -538,7 +540,7 @@ export function Sidebar({
         {/* Drag overlay — ghost card that follows the cursor */}
         <DragOverlay>
           {activeDragClaw ? (
-            <div className="opacity-90 shadow-xl">
+            <div className="opacity-90 shadow-ds-lg">
               <ClawCard
                 claw={activeDragClaw}
                 isSelected={activeDragClaw.id === selectedClawId}
@@ -555,14 +557,14 @@ export function Sidebar({
           mobile drawer — the bottom tab bar and the board header menu own
           these destinations there. */}
       {!inDrawer && (
-      <div className="p-2 border-t border-border">
+      <div className="p-2 border-t-2 border-border">
         {isAdmin && (
           <>
             <button
               onClick={onToggleView}
               className={cn(
-                "flex w-full min-h-9 items-center gap-[9px] rounded-lg px-2.5 text-[12.5px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground",
-                inAnalytics && "bg-muted text-foreground"
+                "flex w-full min-h-9 items-center gap-[9px] rounded-md px-2.5 text-[13px] text-muted-foreground transition-colors hover:bg-foreground/7 hover:text-foreground",
+                inAnalytics && "bg-foreground/10 text-foreground"
               )}
             >
               <ViewToggleIcon className="size-4 flex-shrink-0" />
@@ -570,17 +572,17 @@ export function Sidebar({
             </button>
             <button
               onClick={() => { window.location.href = "/settings" }}
-              className="flex w-full min-h-9 items-center gap-[9px] rounded-lg px-2.5 text-[12.5px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              className="flex w-full min-h-9 items-center gap-[9px] rounded-md px-2.5 text-[13px] text-muted-foreground transition-colors hover:bg-foreground/7 hover:text-foreground"
             >
               <Settings className="size-4 flex-shrink-0" />
               Settings
             </button>
-            <div className="my-1 border-t border-border" />
+            <div className="my-1 border-t-2 border-border" />
           </>
         )}
         <button
           onClick={handleSignOut}
-          className="flex w-full min-h-9 items-center gap-[9px] rounded-lg px-2.5 text-[12.5px] text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
+          className="flex w-full min-h-9 items-center gap-[9px] rounded-md px-2.5 text-[13px] text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
         >
           <LogOut className="size-4 flex-shrink-0" />
           Sign out
@@ -633,14 +635,14 @@ function WorkflowPickerOverlay({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--ds-scrim)]"
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose()
       }}
     >
-      <div className="bg-card border border-border rounded-lg shadow-lg w-[320px] max-w-[90vw]">
+      <div className="bg-card border border-border rounded-lg shadow-ds-lg w-[320px] max-w-[90vw]">
         <div className="flex items-center justify-between p-3 border-b border-border">
-          <h3 className="text-sm font-medium">Select Workflow</h3>
+          <h3 className="text-sm font-extrabold tracking-[-0.015em]">Select Workflow</h3>
           <Button variant="ghost" size="icon" className="size-7" onClick={onClose}>
             <X className="size-4" />
           </Button>
@@ -653,7 +655,7 @@ function WorkflowPickerOverlay({
           ) : workflows.map((workflow) => (
             <button
               key={`${workflow.workspaceName}/${workflow.name}`}
-              className="w-full text-left px-3 py-2 text-sm rounded hover:bg-accent transition-colors"
+              className="w-full text-left px-3 py-2 text-sm rounded-md hover:bg-foreground/7 transition-colors"
               onClick={() => onSelect(workflow)}
             >
               <div className="font-medium">{workflow.name}</div>

--- a/web/components/task-run-analytics-view.tsx
+++ b/web/components/task-run-analytics-view.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore, type ReactNode } from "react"
 import { createPortal } from "react-dom"
 import { usePathname, useRouter, useSearchParams } from "next/navigation"
-import { AlertCircle, ArrowDown, ArrowUp, CheckCircle2, CircleDot, ExternalLink, GitPullRequest, Minus, RefreshCw, Search, Users, XCircle } from "lucide-react"
+import { AlertCircle, ArrowDown, ArrowUp, ExternalLink, GitPullRequest, Minus, RefreshCw, Search, XCircle } from "lucide-react"
 import { Bar, BarChart, XAxis } from "recharts"
 import {
   fetchCostOverview,
@@ -747,20 +747,16 @@ const statusPillClasses: Record<string, string> = {
 }
 
 export function StatusBadge({ status }: { status: string }) {
-  const statusIcons: Record<string, ReactNode> = {
-    clean: <CheckCircle2 className="size-3" />,
-    human_in_the_loop: <Users className="size-3" />,
-    failed: <XCircle className="size-3" />,
-  }
-  const icon = statusIcons[status] ?? <CircleDot className="size-3" />
   return (
     <Badge
       title={status === "clean" ? "PR merged or closed with zero human interaction." : status === "human_in_the_loop" ? "PR merged or closed; a human interacted via the PR (comment, review, or code push)." : status === "warning" ? "PR merged or closed; a human interacted via the factory dashboard." : status === "failed" ? "No PR was ever delivered or the run definitively failed before delivery." : status === "running" ? "In progress; no failure has occurred." : undefined}
       variant="outline"
-      className={cn("tracking-[0.02em]", statusPillClasses[status] ?? "border-border text-muted-foreground")}
+      className={cn("gap-1.5 pl-2 tracking-[0.02em]", statusPillClasses[status] ?? "border-border text-muted-foreground")}
     >
-      {icon}
-      {formatLabel(status)}
+      {/* The outcome reads from the dot and the ring; the label itself stays in
+          the normal text color so a row of pills isn't a row of colored words. */}
+      <span aria-hidden className="size-[7px] shrink-0 rounded-full bg-current" />
+      <span className="text-foreground">{formatLabel(status)}</span>
     </Badge>
   )
 }
@@ -776,7 +772,7 @@ function formatFilterList(labels: string[]) {
   return filterListFormatter.format(labels)
 }
 
-function formatLabel(value: string) {
+export function formatLabel(value: string) {
   return value.replace(/_/g, " ").replace(/\b\w/g, (match) => match.toUpperCase())
 }
 

--- a/web/components/task-run-analytics-view.tsx
+++ b/web/components/task-run-analytics-view.tsx
@@ -36,7 +36,8 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { cn } from "@/lib/utils"
 
 const costChartConfig = {
-  costUsd: { label: "Cost", color: "var(--chart-1)" },
+  // Spend is a money series, so it takes the data hue, never an outcome color.
+  costUsd: { label: "Cost", color: "var(--color-data)" },
 } satisfies ChartConfig
 
 export type DetailState = {
@@ -296,11 +297,11 @@ export function TaskRunAnalyticsView({ workspaceScope }: { workspaceScope?: stri
   return (
     <main className="flex h-full min-w-0 bg-background">
       <section className="flex min-w-0 flex-1 flex-col">
-        <header className="flex flex-col gap-3 border-b border-border px-4 py-3 lg:px-6">
+        <header className="flex flex-col gap-3 border-b-2 border-border px-4 py-3 lg:px-6">
           <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
             <div>
-              <h2 className="text-lg font-semibold tracking-tight">Task Run Analytics</h2>
-              <p className="text-sm text-muted-foreground">PR-scoped run outcomes, warnings, and delivery failures.</p>
+              <h2 className="text-lg tracking-tight">Task Run Analytics</h2>
+              <p className="mt-0.5 text-xs text-muted-foreground">PR-scoped run outcomes, warnings, and delivery failures.</p>
             </div>
             <div className="flex w-fit items-center gap-2">
               <Button variant="ghost" size="sm" onClick={clearFilters}>Reset</Button>
@@ -312,7 +313,7 @@ export function TaskRunAnalyticsView({ workspaceScope }: { workspaceScope?: stri
           </div>
           <div className="flex flex-col gap-2">
             <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
-              <h3 className="text-xs font-medium uppercase text-muted-foreground">AI Spend</h3>
+              <h3 className="kicker font-semibold text-muted-foreground">AI Spend</h3>
               {ignoredCostFilters.length > 0 && (
                 <span className="text-xs italic text-muted-foreground">Ignores {formatFilterList(ignoredCostFilters)} filters</span>
               )}
@@ -372,7 +373,7 @@ export function TaskRunAnalyticsView({ workspaceScope }: { workspaceScope?: stri
           </div>
           {generalStats && (
             <div className="flex flex-col gap-2">
-              <h3 className="text-xs font-medium uppercase text-muted-foreground">General Stats</h3>
+              <h3 className="kicker font-semibold text-muted-foreground">General Stats</h3>
               <div className="grid gap-2 sm:grid-cols-3">
                 <CostCard
                   label="Avg ticket to PR"
@@ -417,7 +418,7 @@ export function TaskRunAnalyticsView({ workspaceScope }: { workspaceScope?: stri
         )}
 
         <div className="min-h-0 flex-1 overflow-auto px-4 py-3 lg:px-6">
-          <div className="overflow-hidden rounded-md border border-border">
+          <div className="overflow-hidden rounded-lg border border-border bg-card">
             <Table>
               <TableHeader>
                 <TableRow>
@@ -453,20 +454,20 @@ export function TaskRunAnalyticsView({ workspaceScope }: { workspaceScope?: stri
                     <TableCell><StatusBadge status={run.status} /></TableCell>
                     <TableCell>
                       <div className="min-w-[180px]">
-                        <div className="font-medium">{run.ownerDisplayName || run.factoryName || run.ownerType}</div>
-                        <div className="text-xs text-muted-foreground">{ownerSecondaryLine(run)}</div>
+                        <div className="font-mono font-medium">{run.ownerDisplayName || run.factoryName || run.ownerType}</div>
+                        <div className="text-[11px] text-muted-foreground">{ownerSecondaryLine(run)}</div>
                       </div>
                     </TableCell>
                     <TableCell>
                       {run.issueId ? (
-                        <span className="block max-w-[200px] truncate">
+                        <span className="block max-w-[200px] truncate font-mono">
                           {run.issueTitle ? `${run.issueId}: ${run.issueTitle}` : run.issueId}
                         </span>
                       ) : (
                         <span className="text-muted-foreground">None</span>
                       )}
                     </TableCell>
-                    <TableCell>{run.repo || <span className="text-muted-foreground">None</span>}</TableCell>
+                    <TableCell className="font-mono">{run.repo || <span className="font-sans text-muted-foreground">None</span>}</TableCell>
                     <TableCell>{run.model || <span className="text-muted-foreground">Unknown</span>}</TableCell>
                     <TableCell>
                       <div className="flex max-w-[260px] flex-wrap gap-1">
@@ -516,16 +517,16 @@ function Metric({ label, title, value, tone, active, onClick }: { label: string;
       aria-pressed={active}
       onClick={onClick}
       className={cn(
-        "rounded-md border border-border bg-card px-3 py-2 text-left transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-        active && "border-primary/60 bg-accent"
+        "rounded-lg border border-border bg-card px-3 py-2 text-left transition-colors hover:bg-foreground/4 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring",
+        active && "border-primary bg-foreground/7"
       )}
     >
-      <div className="text-xs text-muted-foreground">{label}</div>
+      <div className="text-[11px] leading-[1.35] text-muted-foreground">{label}</div>
       <div className={cn(
-        "mt-1 text-xl font-semibold",
-        tone === "success" && "text-emerald-600 dark:text-emerald-400",
-        tone === "warning" && "text-amber-600 dark:text-amber-400",
-        tone === "danger" && "text-red-600 dark:text-red-400"
+        "mt-1 text-[23px] font-extrabold leading-none tracking-[-0.02em] tabular-nums",
+        tone === "success" && "text-status-ok",
+        tone === "warning" && "text-status-warn",
+        tone === "danger" && "text-destructive"
       )}>{value}</div>
     </button>
   )
@@ -533,10 +534,10 @@ function Metric({ label, title, value, tone, active, onClick }: { label: string;
 
 function CostCard({ label, value, sub, title }: { label: string; value: ReactNode; sub?: ReactNode; title?: string }) {
   return (
-    <div className="rounded-md border border-border bg-card px-3 py-2" title={title}>
-      <div className="text-xs text-muted-foreground">{label}</div>
-      <div className="mt-1 flex items-baseline gap-2 text-xl font-semibold">{value}</div>
-      {sub && <div className="mt-1 text-xs text-muted-foreground">{sub}</div>}
+    <div className="rounded-lg border border-border bg-card px-3 py-2" title={title}>
+      <div className="text-[11px] leading-[1.35] text-muted-foreground">{label}</div>
+      <div className="mt-1 flex items-baseline gap-2 text-[23px] font-extrabold leading-none tracking-[-0.02em] tabular-nums">{value}</div>
+      {sub && <div className="mt-1.5 text-[11px] text-muted-foreground">{sub}</div>}
     </div>
   )
 }
@@ -548,13 +549,9 @@ function DeltaIndicator({ pct }: { pct: number }) {
   return (
     <span
       className={cn(
-        "flex items-center gap-0.5 text-xs font-medium",
-        // A spend increase is worse (red); a decrease is better (emerald); flat is neutral.
-        flat
-          ? "text-muted-foreground"
-          : up
-            ? "text-red-600 dark:text-red-400"
-            : "text-emerald-600 dark:text-emerald-400"
+        "flex items-center gap-0.5 text-[11px] font-semibold",
+        // A spend increase is worse (accent); a decrease is better (status-ok); flat is neutral.
+        flat ? "text-muted-foreground" : up ? "text-primary" : "text-status-ok"
       )}
     >
       <Icon className="size-3" />
@@ -568,10 +565,10 @@ function ConfidenceBadge({ confidence }: { confidence: "high" | "medium" | "low"
     <Badge
       variant="outline"
       className={cn(
-        "text-xs font-normal",
-        confidence === "high" && "border-emerald-500/40 text-emerald-700 dark:text-emerald-300",
-        confidence === "medium" && "border-amber-500/50 text-amber-700 dark:text-amber-300",
-        confidence === "low" && "text-muted-foreground"
+        "font-normal",
+        confidence === "high" && "border-status-ok text-status-ok",
+        confidence === "medium" && "border-status-warn text-status-warn",
+        confidence === "low" && "border-border text-muted-foreground"
       )}
     >
       {formatLabel(confidence)}
@@ -587,7 +584,7 @@ export function FilterSelect({ label, value, values, onChange }: { label: string
 
   return (
     <Select value={value ?? anyValue} onValueChange={(next) => onChange(next === anyValue ? undefined : next)}>
-      <SelectTrigger size="sm" className="w-full bg-background">
+      <SelectTrigger size="sm" className="w-full text-[13px]">
         <span className="truncate">
           <span className="text-muted-foreground">{label}:</span> {displayValue}
         </span>
@@ -615,12 +612,12 @@ export function RunDetailPanel({ run, details, loading, error, onClose }: { run:
   if (!run || !mounted) return null
   return createPortal(
     <>
-    <div className="fixed inset-0 z-[55] bg-black/50" onClick={onClose} aria-hidden="true" />
-    <aside className="fixed inset-y-0 right-0 z-[60] flex w-full max-w-[66vw] flex-col border-l border-border bg-card shadow-xl">
-      <div className="flex items-start justify-between gap-3 border-b border-border p-4">
+    <div className="fixed inset-0 z-[55] bg-[var(--ds-scrim)]" onClick={onClose} aria-hidden="true" />
+    <aside className="fixed inset-y-0 right-0 z-[60] flex w-full max-w-[66vw] flex-col border-l-2 border-border bg-card shadow-ds-lg">
+      <div className="flex items-start justify-between gap-3 border-b-2 border-border p-4">
         <div className="min-w-0">
-          <div className="truncate text-sm font-semibold">{run.ownerDisplayName || run.runId}</div>
-          <div className="truncate text-xs text-muted-foreground">{run.runId}</div>
+          <div className="truncate text-[15px] font-extrabold tracking-[-0.015em]">{run.ownerDisplayName || run.runId}</div>
+          <div className="truncate font-mono text-xs text-muted-foreground">{run.runId}</div>
         </div>
         <Button variant="ghost" size="icon" className="size-8" onClick={onClose} aria-label="Close detail panel">
           <XCircle className="size-4" />
@@ -646,7 +643,7 @@ export function RunDetailPanel({ run, details, loading, error, onClose }: { run:
         </section>
         {hasUsageData(run) && (
           <section>
-            <h3 className="mb-2 text-xs font-medium uppercase text-muted-foreground">Usage</h3>
+            <h3 className="kicker mb-2 font-semibold text-muted-foreground">Usage</h3>
             <div className="grid grid-cols-2 gap-2 text-sm">
               <DetailItem label="Prompt tokens" value={formatCompactTokens(run.inputTokens)} />
               <DetailItem label="Completion tokens" value={formatCompactTokens(run.outputTokens)} />
@@ -658,10 +655,10 @@ export function RunDetailPanel({ run, details, loading, error, onClose }: { run:
         )}
         <TimingSection run={run} />
         <section>
-          <h3 className="mb-2 text-xs font-medium uppercase text-muted-foreground">Pull Requests</h3>
+          <h3 className="kicker mb-2 font-semibold text-muted-foreground">Pull Requests</h3>
           <div className="space-y-2">
             {(details?.prs ?? []).map((pr) => (
-              <a key={pr.id} href={pr.url} target="_blank" rel="noreferrer" className="flex items-center justify-between rounded-md border border-border px-3 py-2 text-sm hover:bg-accent">
+              <a key={pr.id} href={pr.url} target="_blank" rel="noreferrer" className="flex items-center justify-between rounded-md border border-border px-3 py-2 text-sm hover:bg-foreground/7">
                 <span className="flex min-w-0 items-center gap-2">
                   <GitPullRequest className="size-4 text-muted-foreground" />
                   <span className="truncate">{pr.repo}#{pr.prNumber}</span>
@@ -673,7 +670,7 @@ export function RunDetailPanel({ run, details, loading, error, onClose }: { run:
           </div>
         </section>
         <section>
-          <h3 className="mb-2 text-xs font-medium uppercase text-muted-foreground">Attempts</h3>
+          <h3 className="kicker mb-2 font-semibold text-muted-foreground">Attempts</h3>
           <div className="space-y-2">
             {(details?.attempts ?? []).map((attempt) => {
               const attemptDurationMs = durationBetween(attempt.startedAt, attempt.finishedAt)
@@ -693,7 +690,7 @@ export function RunDetailPanel({ run, details, loading, error, onClose }: { run:
           </div>
         </section>
         <section>
-          <h3 className="mb-2 text-xs font-medium uppercase text-muted-foreground">Events</h3>
+          <h3 className="kicker mb-2 font-semibold text-muted-foreground">Events</h3>
           <div className="space-y-2">
             {(details?.events ?? []).slice(-MAX_DISPLAYED_EVENTS).reverse().map((event) => (
               <div key={event.id} className="rounded-md border border-border px-3 py-2 text-sm">
@@ -718,7 +715,7 @@ function TimingSection({ run }: { run: TaskRunSummary }) {
   if (phases.length === 0) return null
   return (
     <section>
-      <h3 className="mb-2 text-xs font-medium uppercase text-muted-foreground">Timing</h3>
+      <h3 className="kicker mb-2 font-semibold text-muted-foreground">Timing</h3>
       <div className="grid grid-cols-2 gap-2 text-sm">
         {phases.map((phase) => (
           <DetailItem key={phase.label} label={phase.label} value={formatDurationMs(phase.ms)} title={phase.title} />
@@ -731,10 +728,22 @@ function TimingSection({ run }: { run: TaskRunSummary }) {
 function DetailItem({ label, value, title }: { label: string; value: ReactNode; title?: string }) {
   return (
     <div title={title} className="rounded-md border border-border px-3 py-2">
-      <div className="text-xs text-muted-foreground">{label}</div>
+      <div className="text-[11px] text-muted-foreground">{label}</div>
       <div className="mt-1 truncate">{value}</div>
     </div>
   )
+}
+
+// A run status reads as its outcome color — the same semantic scale the charts
+// use — drawn as an outlined pill. Failed is the one outcome that also takes a
+// soft accent fill, so a broken run is findable at a glance in a long table.
+// Full literal class strings: Tailwind only sees classes it can read verbatim.
+const statusPillClasses: Record<string, string> = {
+  clean: "border-status-ok text-status-ok",
+  human_in_the_loop: "border-[var(--ds-neutral-500)] text-[var(--ds-neutral-500)]",
+  warning: "border-status-warn text-status-warn",
+  failed: "border-primary bg-tint-accent text-primary",
+  running: "border-data text-data",
 }
 
 export function StatusBadge({ status }: { status: string }) {
@@ -747,8 +756,8 @@ export function StatusBadge({ status }: { status: string }) {
   return (
     <Badge
       title={status === "clean" ? "PR merged or closed with zero human interaction." : status === "human_in_the_loop" ? "PR merged or closed; a human interacted via the PR (comment, review, or code push)." : status === "warning" ? "PR merged or closed; a human interacted via the factory dashboard." : status === "failed" ? "No PR was ever delivered or the run definitively failed before delivery." : status === "running" ? "In progress; no failure has occurred." : undefined}
-      variant={status === "failed" ? "destructive" : status === "running" ? "secondary" : "outline"}
-      className={cn(status === "clean" && "border-emerald-500/40 text-emerald-700 dark:text-emerald-300", status === "human_in_the_loop" && "border-blue-500/50 text-blue-700 dark:text-blue-300", status === "warning" && "border-amber-500/50 text-amber-700 dark:text-amber-300")}
+      variant="outline"
+      className={cn("tracking-[0.02em]", statusPillClasses[status] ?? "border-border text-muted-foreground")}
     >
       {icon}
       {formatLabel(status)}

--- a/web/components/terminal.tsx
+++ b/web/components/terminal.tsx
@@ -10,6 +10,16 @@ interface TerminalProps {
 }
 
 /**
+ * xterm.js needs concrete color strings, so design tokens are resolved from the
+ * document at mount time instead of being handed over as `var(--…)`.
+ */
+function readToken(name: string, fallback: string): string {
+  if (typeof window === "undefined") return fallback
+  const value = getComputedStyle(document.documentElement).getPropertyValue(name).trim()
+  return value || fallback
+}
+
+/**
  * XTerminal — browser-only SSH terminal component.
  * Dynamically imports xterm.js to avoid SSR issues.
  */
@@ -32,31 +42,38 @@ export function XTerminal({ clawId, wsUrl, className }: TerminalProps) {
       const { FitAddon } = await import("@xterm/addon-fit")
       if (!mounted || !containerRef.current) return
 
+      const surface = readToken("--ds-surface", "#1e1e21")
+      const text = readToken("--ds-text", "#f2f2f4")
+
       const term = new Terminal({
         cursorBlink: true,
         fontFamily: '"JetBrains Mono", "Fira Code", "Cascadia Code", monospace',
         fontSize: 13,
         theme: {
-          background: "#1e1e1e",
-          foreground: "#d4d4d4",
-          cursor: "#d4d4d4",
-          selectionBackground: "#264f78",
-          black: "#1e1e1e",
-          red: "#f44747",
-          green: "#4ec9b0",
-          yellow: "#dcdcaa",
-          blue: "#569cd6",
-          magenta: "#c586c0",
-          cyan: "#9cdcfe",
-          white: "#d4d4d4",
-          brightBlack: "#808080",
-          brightRed: "#f44747",
-          brightGreen: "#4ec9b0",
-          brightYellow: "#dcdcaa",
-          brightBlue: "#569cd6",
-          brightMagenta: "#c586c0",
-          brightCyan: "#9cdcfe",
-          brightWhite: "#ffffff",
+          background: surface,
+          foreground: text,
+          cursor: "#ff563c",
+          cursorAccent: surface,
+          selectionBackground: "rgba(255, 86, 60, 0.32)",
+          selectionForeground: text,
+          // ANSI 16 tuned for the Modernist dark surface: the red family follows
+          // the accent, the other hues stay distinguishable as semantic ANSI slots.
+          black: "#2b2b30",
+          red: "#ff563c",
+          green: "#2fb37a",
+          yellow: "#d9a13a",
+          blue: "#6f9dea",
+          magenta: "#c98ad6",
+          cyan: "#4fbfc4",
+          white: "#d5d5d8",
+          brightBlack: "#7b7b80",
+          brightRed: "#ff8a76",
+          brightGreen: "#57d19c",
+          brightYellow: "#f0bf5f",
+          brightBlue: "#93b8f4",
+          brightMagenta: "#e0aeea",
+          brightCyan: "#7ad9dd",
+          brightWhite: "#f7f7f8",
         },
       })
 
@@ -127,7 +144,7 @@ export function XTerminal({ clawId, wsUrl, className }: TerminalProps) {
     <div
       ref={containerRef}
       className={className}
-      style={{ background: "#1e1e1e" }}
+      style={{ background: "var(--ds-surface)" }}
     />
   )
 }

--- a/web/components/ui/badge.tsx
+++ b/web/components/ui/badge.tsx
@@ -4,19 +4,21 @@ import { cva, type VariantProps } from 'class-variance-authority'
 
 import { cn } from '@/lib/utils'
 
+// Modernist tags: pill-shaped, 11px, and tinted rather than filled — the solid
+// accent stays reserved for buttons and live status marks.
 const badgeVariants = cva(
-  'inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden',
+  'inline-flex items-center justify-center rounded-full border border-transparent px-2.5 py-0.5 text-[11px] leading-4 font-medium tracking-[0.02em] w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring aria-invalid:border-destructive transition-colors overflow-hidden',
   {
     variants: {
       variant: {
         default:
-          'border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90',
+          'bg-tint-accent text-tint-accent-foreground [a&]:hover:bg-tint-accent-2',
         secondary:
-          'border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90',
+          'bg-tint-neutral text-tint-neutral-foreground [a&]:hover:bg-foreground/16',
         destructive:
-          'border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
+          'bg-destructive text-primary-foreground [a&]:hover:bg-[var(--ds-accent-hover)]',
         outline:
-          'text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground',
+          'border-primary text-primary [a&]:hover:bg-tint-accent [a&]:hover:text-tint-accent-foreground',
       },
     },
     defaultVariants: {

--- a/web/components/ui/button.tsx
+++ b/web/components/ui/button.tsx
@@ -4,21 +4,24 @@ import { cva, type VariantProps } from 'class-variance-authority'
 
 import { cn } from '@/lib/utils'
 
+// Modernist buttons: the heading face at weight 800, 14px, 8px radius. The
+// accent carries the primary action; everything else is a divider outline or a
+// bare ink wash, so a screen never shows two competing filled buttons.
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-extrabold leading-none tracking-normal transition-colors disabled:pointer-events-none disabled:opacity-45 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring aria-invalid:border-destructive",
   {
     variants: {
       variant: {
-        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        default:
+          'bg-primary text-primary-foreground hover:bg-[var(--ds-accent-hover)] active:bg-[var(--ds-accent-active)]',
         destructive:
-          'bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
+          'bg-destructive text-primary-foreground hover:bg-[var(--ds-accent-hover)] active:bg-[var(--ds-accent-active)]',
         outline:
-          'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50',
+          'border border-border bg-transparent text-foreground hover:bg-foreground/7 active:bg-foreground/14',
         secondary:
-          'bg-secondary text-secondary-foreground hover:bg-secondary/80',
-        ghost:
-          'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
-        link: 'text-primary underline-offset-4 hover:underline',
+          'bg-secondary text-secondary-foreground hover:bg-foreground/14 active:bg-foreground/18',
+        ghost: 'hover:bg-foreground/8 active:bg-foreground/14',
+        link: 'text-primary underline-offset-4 hover:underline hover:text-[var(--ds-accent-hover)]',
       },
       size: {
         default: 'h-9 px-4 py-2 has-[>svg]:px-3',
@@ -29,6 +32,14 @@ const buttonVariants = cva(
         'icon-lg': 'size-10',
       },
     },
+    compoundVariants: [
+      // A ghost button carrying a label reads as the system's tertiary action,
+      // so it takes the accent. Icon-only ghosts stay ink — the shell is full
+      // of them and an all-red toolbar would drown the real accents.
+      { variant: 'ghost', size: 'default', className: 'text-primary' },
+      { variant: 'ghost', size: 'sm', className: 'text-primary' },
+      { variant: 'ghost', size: 'lg', className: 'text-primary' },
+    ],
     defaultVariants: {
       variant: 'default',
       size: 'default',

--- a/web/components/ui/chart.tsx
+++ b/web/components/ui/chart.tsx
@@ -274,7 +274,7 @@ function ChartLegendContent({
   return (
     <div
       className={cn(
-        'text-muted-foreground flex flex-wrap items-center justify-center gap-x-4 gap-y-1.5 text-[11px]',
+        'text-muted-foreground flex flex-wrap items-center justify-start gap-x-3 gap-y-1.5 text-[11px]',
         verticalAlign === 'top'
           ? 'border-border mb-3 border-b pb-2'
           : 'border-border mt-3 border-t pt-2',
@@ -300,7 +300,10 @@ function ChartLegendContent({
                 }}
               />
             )}
-            {itemConfig?.label}
+            {/* Series that aren't in the chart config (model names, workflow
+                names — they only exist at runtime) fall back to the payload's
+                own label so the legend never renders an empty swatch. */}
+            {itemConfig?.label ?? item.value}
           </div>
         )
       })}

--- a/web/components/ui/chart.tsx
+++ b/web/components/ui/chart.tsx
@@ -49,13 +49,17 @@ function ChartContainer({
   const uniqueId = React.useId()
   const chartId = `chart-${id || uniqueId.replace(/:/g, '')}`
 
+  // The '#ccc' / '#fff' inside the selectors below are Recharts' own hardcoded
+  // stroke attributes — they are what we match on, never what we paint with.
+  // Every declaration resolves to a design-system token, so grid rules, tooltip
+  // cursors and the ring around dots follow the theme instead of staying grey.
   return (
     <ChartContext.Provider value={{ config }}>
       <div
         data-slot="chart"
         data-chart={chartId}
         className={cn(
-          "[&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border flex aspect-video justify-center text-xs [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-hidden [&_.recharts-sector]:outline-hidden [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-surface]:outline-hidden",
+          "[&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-axis-tick_text]:font-mono [&_.recharts-cartesian-axis-tick_text]:text-[10px] [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/40 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-foreground/8 [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-foreground/8 [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border flex aspect-video justify-center text-xs [&_.recharts-dot[stroke='#fff']]:stroke-background [&_.recharts-layer]:outline-hidden [&_.recharts-sector]:outline-hidden [&_.recharts-sector[stroke='#fff']]:stroke-background [&_.recharts-surface]:outline-hidden",
           className,
         )}
         {...props}
@@ -173,7 +177,7 @@ function ChartTooltipContent({
   return (
     <div
       className={cn(
-        'border-border/50 bg-background grid min-w-[8rem] items-start gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs shadow-xl',
+        'border-border bg-card text-card-foreground shadow-ds-lg grid min-w-[8rem] items-start gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs',
         className,
       )}
     >
@@ -270,8 +274,10 @@ function ChartLegendContent({
   return (
     <div
       className={cn(
-        'flex items-center justify-center gap-4',
-        verticalAlign === 'top' ? 'pb-3' : 'pt-3',
+        'text-muted-foreground flex flex-wrap items-center justify-center gap-x-4 gap-y-1.5 text-[11px]',
+        verticalAlign === 'top'
+          ? 'border-border mb-3 border-b pb-2'
+          : 'border-border mt-3 border-t pt-2',
         className,
       )}
     >
@@ -288,7 +294,7 @@ function ChartLegendContent({
               <itemConfig.icon />
             ) : (
               <div
-                className="h-2 w-2 shrink-0 rounded-[2px]"
+                className="size-[9px] shrink-0 rounded-[2px]"
                 style={{
                   backgroundColor: item.color,
                 }}

--- a/web/components/ui/dialog.tsx
+++ b/web/components/ui/dialog.tsx
@@ -38,7 +38,7 @@ function DialogOverlay({
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
       className={cn(
-        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-[var(--ds-scrim)]',
         className,
       )}
       {...props}
@@ -60,7 +60,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+          'bg-card text-card-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border border-border p-6 shadow-ds-lg duration-200 sm:max-w-lg',
           className,
         )}
         {...props}
@@ -69,7 +69,7 @@ function DialogContent({
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dialog-close"
-            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+            className="text-muted-foreground hover:text-foreground hover:bg-foreground/8 focus-visible:outline-ring absolute top-3 right-3 grid size-8 place-items-center rounded-md transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
           >
             <XIcon />
             <span className="sr-only">Close</span>
@@ -110,7 +110,7 @@ function DialogTitle({
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn('text-lg leading-none font-semibold', className)}
+      className={cn('text-xl leading-tight font-extrabold tracking-[-0.015em]', className)}
       {...props}
     />
   )

--- a/web/components/ui/dropdown-menu.tsx
+++ b/web/components/ui/dropdown-menu.tsx
@@ -42,7 +42,7 @@ function DropdownMenuContent({
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         className={cn(
-          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md',
+          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg border border-border p-1 shadow-ds-md',
           className,
         )}
         {...props}
@@ -155,7 +155,7 @@ function DropdownMenuLabel({
       data-slot="dropdown-menu-label"
       data-inset={inset}
       className={cn(
-        'px-2 py-1.5 text-sm font-medium data-[inset]:pl-8',
+        'text-muted-foreground px-2 py-1.5 text-[10px] tracking-[0.1em] uppercase data-[inset]:pl-8',
         className,
       )}
       {...props}
@@ -230,7 +230,7 @@ function DropdownMenuSubContent({
     <DropdownMenuPrimitive.SubContent
       data-slot="dropdown-menu-sub-content"
       className={cn(
-        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg',
+        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-lg border border-border p-1 shadow-ds-lg',
         className,
       )}
       {...props}

--- a/web/components/ui/field.tsx
+++ b/web/components/ui/field.tsx
@@ -31,7 +31,7 @@ function FieldLegend({
       data-slot="field-legend"
       data-variant={variant}
       className={cn(
-        'mb-3 font-medium',
+        'mb-3 font-extrabold tracking-[-0.015em]',
         'data-[variant=legend]:text-base',
         'data-[variant=label]:text-sm',
         className,
@@ -116,8 +116,8 @@ function FieldLabel({
       data-slot="field-label"
       className={cn(
         'group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50',
-        'has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col has-[>[data-slot=field]]:rounded-md has-[>[data-slot=field]]:border [&>*]:data-[slot=field]:p-4',
-        'has-data-[state=checked]:bg-primary/5 has-data-[state=checked]:border-primary dark:has-data-[state=checked]:bg-primary/10',
+        'has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col has-[>[data-slot=field]]:rounded-md has-[>[data-slot=field]]:border has-[>[data-slot=field]]:border-border [&>*]:data-[slot=field]:p-4',
+        'has-data-[state=checked]:bg-tint-accent has-data-[state=checked]:border-primary',
         className,
       )}
       {...props}
@@ -173,7 +173,7 @@ function FieldSeparator({
       <Separator className="absolute inset-0 top-1/2" />
       {children && (
         <span
-          className="bg-background text-muted-foreground relative mx-auto block w-fit px-2"
+          className="bg-background text-muted-foreground relative mx-auto block w-fit px-2 text-[10px] tracking-[0.1em] uppercase"
           data-slot="field-separator-content"
         >
           {children}

--- a/web/components/ui/input.tsx
+++ b/web/components/ui/input.tsx
@@ -8,9 +8,9 @@ function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
       type={type}
       data-slot="input"
       className={cn(
-        'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
-        'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
-        'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
+        'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground border-input bg-card caret-primary h-9 min-h-9 w-full min-w-0 rounded-md border px-2.5 py-1.5 text-base transition-colors outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-45 md:text-sm',
+        'hover:border-foreground/45 focus-visible:border-primary',
+        'aria-invalid:border-destructive',
         className,
       )}
       {...props}

--- a/web/components/ui/label.tsx
+++ b/web/components/ui/label.tsx
@@ -13,7 +13,7 @@ function Label({
     <LabelPrimitive.Root
       data-slot="label"
       className={cn(
-        'flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50',
+        'text-foreground/70 flex items-center gap-2 text-xs leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50',
         className,
       )}
       {...props}

--- a/web/components/ui/scroll-area.tsx
+++ b/web/components/ui/scroll-area.tsx
@@ -18,7 +18,7 @@ function ScrollArea({
     >
       <ScrollAreaPrimitive.Viewport
         data-slot="scroll-area-viewport"
-        className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
+        className="focus-visible:outline-ring size-full rounded-[inherit] outline-none focus-visible:outline-2 focus-visible:-outline-offset-2"
       >
         {children}
       </ScrollAreaPrimitive.Viewport>
@@ -49,7 +49,7 @@ function ScrollBar({
     >
       <ScrollAreaPrimitive.ScrollAreaThumb
         data-slot="scroll-area-thumb"
-        className="bg-border relative flex-1 rounded-full"
+        className="bg-foreground/25 hover:bg-foreground/40 relative flex-1 rounded-full transition-colors"
       />
     </ScrollAreaPrimitive.ScrollAreaScrollbar>
   )

--- a/web/components/ui/select.tsx
+++ b/web/components/ui/select.tsx
@@ -37,7 +37,7 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "border-input bg-card data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground hover:border-foreground/45 focus-visible:border-primary aria-invalid:border-destructive flex w-fit items-center justify-between gap-2 rounded-md border px-2.5 py-2 text-sm whitespace-nowrap transition-colors outline-none disabled:cursor-not-allowed disabled:opacity-45 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -61,7 +61,7 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(
-          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md',
+          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg border border-border shadow-ds-md',
           position === 'popper' &&
             'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
           className,
@@ -92,7 +92,10 @@ function SelectLabel({
   return (
     <SelectPrimitive.Label
       data-slot="select-label"
-      className={cn('text-muted-foreground px-2 py-1.5 text-xs', className)}
+      className={cn(
+        'text-muted-foreground px-2 py-1.5 text-[10px] tracking-[0.1em] uppercase',
+        className,
+      )}
       {...props}
     />
   )

--- a/web/components/ui/separator.tsx
+++ b/web/components/ui/separator.tsx
@@ -17,7 +17,7 @@ function Separator({
       decorative={decorative}
       orientation={orientation}
       className={cn(
-        'bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px',
+        'bg-border shrink-0 data-[orientation=horizontal]:h-0.5 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-0.5',
         className,
       )}
       {...props}

--- a/web/components/ui/sheet.tsx
+++ b/web/components/ui/sheet.tsx
@@ -36,7 +36,7 @@ function SheetOverlay({
     <SheetPrimitive.Overlay
       data-slot="sheet-overlay"
       className={cn(
-        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-[var(--ds-scrim)]',
         className,
       )}
       {...props}
@@ -58,21 +58,21 @@ function SheetContent({
       <SheetPrimitive.Content
         data-slot="sheet-content"
         className={cn(
-          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
+          'bg-card text-card-foreground data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-ds-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
           side === 'right' &&
-            'data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm',
+            'data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l-2 border-border sm:max-w-sm',
           side === 'left' &&
-            'data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm',
+            'data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r-2 border-border sm:max-w-sm',
           side === 'top' &&
-            'data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b',
+            'data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b-2 border-border',
           side === 'bottom' &&
-            'data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t',
+            'data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t-2 border-border',
           className,
         )}
         {...props}
       >
         {children}
-        <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+        <SheetPrimitive.Close className="text-muted-foreground hover:text-foreground hover:bg-foreground/8 focus-visible:outline-ring absolute top-3 right-3 grid size-8 place-items-center rounded-md transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus:outline-hidden disabled:pointer-events-none">
           <XIcon className="size-4" />
           <span className="sr-only">Close</span>
         </SheetPrimitive.Close>
@@ -108,7 +108,7 @@ function SheetTitle({
   return (
     <SheetPrimitive.Title
       data-slot="sheet-title"
-      className={cn('text-foreground font-semibold', className)}
+      className={cn('text-foreground text-base leading-tight font-extrabold tracking-[-0.015em]', className)}
       {...props}
     />
   )

--- a/web/components/ui/skeleton.tsx
+++ b/web/components/ui/skeleton.tsx
@@ -4,7 +4,7 @@ function Skeleton({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="skeleton"
-      className={cn('bg-accent animate-pulse rounded-md', className)}
+      className={cn('bg-foreground/10 animate-pulse rounded-md', className)}
       {...props}
     />
   )

--- a/web/components/ui/switch.tsx
+++ b/web/components/ui/switch.tsx
@@ -13,14 +13,14 @@ function Switch({
     <SwitchPrimitive.Root
       data-slot="switch"
       className={cn(
-        'peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+        'peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-foreground/25 focus-visible:outline-ring inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent transition-colors outline-none focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-45',
         className,
       )}
       {...props}
     >
       <SwitchPrimitive.Thumb
         data-slot="switch-thumb"
-        className="bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0"
+        className="data-[state=unchecked]:bg-foreground data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0"
       />
     </SwitchPrimitive.Root>
   )

--- a/web/components/ui/table.tsx
+++ b/web/components/ui/table.tsx
@@ -23,7 +23,7 @@ function TableHeader({ className, ...props }: React.ComponentProps<'thead'>) {
   return (
     <thead
       data-slot="table-header"
-      className={cn('[&_tr]:border-b', className)}
+      className={cn('[&_tr]:border-b-2 [&_tr]:border-border', className)}
       {...props}
     />
   )
@@ -44,7 +44,7 @@ function TableFooter({ className, ...props }: React.ComponentProps<'tfoot'>) {
     <tfoot
       data-slot="table-footer"
       className={cn(
-        'bg-muted/50 border-t font-medium [&>tr]:last:border-b-0',
+        'bg-foreground/5 border-t-2 border-border font-medium [&>tr]:last:border-b-0',
         className,
       )}
       {...props}
@@ -57,7 +57,7 @@ function TableRow({ className, ...props }: React.ComponentProps<'tr'>) {
     <tr
       data-slot="table-row"
       className={cn(
-        'hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors',
+        'hover:bg-foreground/4 data-[state=selected]:bg-foreground/8 border-b border-border transition-colors',
         className,
       )}
       {...props}
@@ -70,7 +70,7 @@ function TableHead({ className, ...props }: React.ComponentProps<'th'>) {
     <th
       data-slot="table-head"
       className={cn(
-        'text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+        'text-muted-foreground h-9 px-2 text-left align-middle text-[11px] font-medium tracking-[0.08em] whitespace-nowrap uppercase [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
         className,
       )}
       {...props}

--- a/web/components/ui/tabs.tsx
+++ b/web/components/ui/tabs.tsx
@@ -26,7 +26,7 @@ function TabsList({
     <TabsPrimitive.List
       data-slot="tabs-list"
       className={cn(
-        'bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]',
+        'text-muted-foreground border-border inline-flex h-9 w-fit items-center justify-center overflow-hidden rounded-md border [&>*+*]:border-l [&>*+*]:border-border',
         className,
       )}
       {...props}
@@ -42,7 +42,7 @@ function TabsTrigger({
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "data-[state=active]:bg-primary data-[state=active]:text-primary-foreground text-foreground hover:bg-foreground/7 data-[state=active]:hover:bg-primary inline-flex h-full flex-1 items-center justify-center gap-1.5 rounded-none px-3 py-1 text-[13px] font-medium whitespace-nowrap transition-colors outline-none focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-45 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}

--- a/web/components/ui/textarea.tsx
+++ b/web/components/ui/textarea.tsx
@@ -7,7 +7,7 @@ function Textarea({ className, ...props }: React.ComponentProps<'textarea'>) {
     <textarea
       data-slot="textarea"
       className={cn(
-        'border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'border-input bg-card caret-primary placeholder:text-muted-foreground hover:border-foreground/45 focus-visible:border-primary aria-invalid:border-destructive flex field-sizing-content min-h-16 w-full resize-y rounded-md border px-2.5 py-2 text-base transition-colors outline-none disabled:cursor-not-allowed disabled:opacity-45 md:text-sm',
         className,
       )}
       {...props}

--- a/web/components/ui/toast.tsx
+++ b/web/components/ui/toast.tsx
@@ -25,13 +25,13 @@ const ToastViewport = React.forwardRef<
 ToastViewport.displayName = ToastPrimitives.Viewport.displayName
 
 const toastVariants = cva(
-  'group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full',
+  'group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-lg border border-border p-4 pr-10 shadow-ds-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full',
   {
     variants: {
       variant: {
-        default: 'border bg-background text-foreground',
+        default: 'bg-card text-card-foreground',
         destructive:
-          'destructive group border-destructive bg-destructive text-destructive-foreground',
+          'destructive group border-destructive bg-destructive text-primary-foreground',
       },
     },
     defaultVariants: {
@@ -62,7 +62,7 @@ const ToastAction = React.forwardRef<
   <ToastPrimitives.Action
     ref={ref}
     className={cn(
-      'inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium ring-offset-background transition-colors hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive',
+      'inline-flex h-8 shrink-0 items-center justify-center rounded-md border border-border bg-transparent px-3 text-sm font-extrabold transition-colors hover:bg-foreground/8 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring focus:outline-none disabled:pointer-events-none disabled:opacity-45 group-[.destructive]:border-primary-foreground/40 group-[.destructive]:hover:bg-primary-foreground/15',
       className,
     )}
     {...props}
@@ -77,7 +77,7 @@ const ToastClose = React.forwardRef<
   <ToastPrimitives.Close
     ref={ref}
     className={cn(
-      'absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600',
+      'absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none group-hover:opacity-100 group-[.destructive]:text-primary-foreground/70 group-[.destructive]:hover:text-primary-foreground',
       className,
     )}
     toast-close=""
@@ -94,7 +94,7 @@ const ToastTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <ToastPrimitives.Title
     ref={ref}
-    className={cn('text-sm font-semibold', className)}
+    className={cn('text-sm leading-tight font-extrabold tracking-[-0.015em]', className)}
     {...props}
   />
 ))

--- a/web/components/ui/toggle.tsx
+++ b/web/components/ui/toggle.tsx
@@ -7,13 +7,13 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 
 const toggleVariants = cva(
-  "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium hover:bg-muted hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none transition-[color,box-shadow] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive whitespace-nowrap",
+  "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium hover:bg-foreground/7 disabled:pointer-events-none disabled:opacity-45 data-[state=on]:bg-primary data-[state=on]:text-primary-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring outline-none transition-colors aria-invalid:border-destructive whitespace-nowrap",
   {
     variants: {
       variant: {
         default: 'bg-transparent',
         outline:
-          'border border-input bg-transparent shadow-xs hover:bg-accent hover:text-accent-foreground',
+          'border border-border bg-transparent hover:bg-foreground/7',
       },
       size: {
         default: 'h-9 px-2 min-w-9',

--- a/web/components/ui/tooltip.tsx
+++ b/web/components/ui/tooltip.tsx
@@ -47,7 +47,7 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          'bg-foreground text-background animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance',
+          'bg-foreground text-background animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 shadow-ds-md z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-2.5 py-1.5 text-xs text-balance',
           className,
         )}
         {...props}

--- a/web/components/workflow-run-logs-dialog.tsx
+++ b/web/components/workflow-run-logs-dialog.tsx
@@ -30,7 +30,8 @@ export function WorkflowRunLogsDialog({ run }: { run: WorkflowRun }) {
           <DialogHeader className="shrink-0 border-b px-6 py-5 pr-12">
             <DialogTitle>Agent logs</DialogTitle>
             <DialogDescription>
-              Agent activity for run {shortId(run.id)} of {run.workflow_name} in {run.workspace_name}.
+              Agent activity for run <span className="font-mono">{shortId(run.id)}</span> of{" "}
+              <span className="font-mono">{run.workflow_name}</span> in {run.workspace_name}.
             </DialogDescription>
           </DialogHeader>
           <div className="min-h-0 flex-1 px-6 pb-6">

--- a/web/components/workflow-runs-dialog.tsx
+++ b/web/components/workflow-runs-dialog.tsx
@@ -69,7 +69,7 @@ export function WorkflowRunsDialog({ workflow }: { workflow: Workflow }) {
               <EmptyState>No runs have been recorded for this workflow yet.</EmptyState>
             )}
             {!loading && !error && runs.length > 0 && (
-              <div className="rounded-md border">
+              <div className="overflow-hidden rounded-lg border border-border">
                 <Table>
                   <TableHeader>
                     <TableRow>
@@ -139,27 +139,30 @@ export function WorkflowRunsDialog({ workflow }: { workflow: Workflow }) {
 function StatusBadge({ status }: { status: string }) {
   const variant = statusVariant(status)
   return (
-    <Badge className={cn("text-[10px]", variant)}>
+    <Badge className={cn("border text-[10px] tracking-[0.02em]", variant)}>
       {status}
     </Badge>
   )
 }
 
+// Outlined pills in the run's outcome color; a failed run additionally takes a
+// soft accent fill so it stands out in a long history. Full literal classes —
+// Tailwind only generates what it can read verbatim in the source.
 function statusVariant(status: string) {
   switch (status.toLowerCase()) {
     case "completed":
     case "success":
-      return "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
+      return "border-status-ok bg-status-ok/12 text-status-ok"
     case "failed":
     case "error":
-      return "border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-300"
+      return "border-primary bg-tint-accent text-primary"
     case "running":
-      return "border-blue-500/30 bg-blue-500/10 text-blue-700 dark:text-blue-300"
+      return "border-data bg-data/12 text-data"
     case "skipped":
-      return "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300"
+      return "border-status-warn bg-status-warn/12 text-status-warn"
     case "pending":
     default:
-      return "border-border bg-muted text-muted-foreground"
+      return "border-border bg-foreground/6 text-muted-foreground"
   }
 }
 
@@ -174,7 +177,7 @@ function LoadingState({ label }: { label: string }) {
 
 function EmptyState({ children }: { children: ReactNode }) {
   return (
-    <div className="flex h-40 items-center justify-center gap-2 rounded-md border border-dashed text-sm text-muted-foreground">
+    <div className="flex h-40 items-center justify-center gap-2 rounded-lg border border-dashed border-border text-sm text-muted-foreground">
       <Calendar className="size-4" />
       {children}
     </div>
@@ -184,7 +187,7 @@ function EmptyState({ children }: { children: ReactNode }) {
 function Notice({ children, destructive = false }: { children: ReactNode; destructive?: boolean }) {
   return (
     <div className={cn(
-      "flex items-center gap-2 rounded-md border px-4 py-3 text-sm",
+      "flex items-center gap-2 rounded-lg border border-border px-4 py-3 text-sm",
       destructive && "border-destructive/30 bg-destructive/10 text-destructive"
     )}>
       <AlertCircle className={cn("size-4 shrink-0", destructive && "text-destructive")} />

--- a/web/lib/claw-lanes.ts
+++ b/web/lib/claw-lanes.ts
@@ -1,0 +1,180 @@
+import type { Claw, Message } from "@/lib/types"
+import type { NowStripState } from "@/components/agent-timeline/now-strip"
+import { windowMessagesByDurableCount } from "@/lib/messages"
+import {
+  demoteStaleRunning,
+  pairActivitySteps,
+  trailingActivityRun,
+  type Step,
+} from "@/lib/turns"
+
+/** Board cards read a bounded tail of the transcript, not the whole history. */
+export const BOARD_CARD_DURABLE_MESSAGE_WINDOW = 50
+
+function firstMeaningfulLine(text: string): string {
+  for (const line of text.split("\n")) {
+    const trimmed = line.replace(/^#+\s*/, "").trim()
+    if (trimmed) return trimmed
+  }
+  return text.trim()
+}
+
+/**
+ * The last question sentence of a message, if it plausibly asks the user
+ * something ("posso forçar push?"). The "?" must end the message or a
+ * sentence; the question starts after the previous sentence/line break.
+ */
+export function extractQuestion(text: string): string | null {
+  const trimmed = text.trim()
+  const qIdx = trimmed.lastIndexOf("?")
+  if (qIdx === -1) return null
+  if (qIdx !== trimmed.length - 1 && !/\s/.test(trimmed[qIdx + 1])) return null
+  const before = trimmed.slice(0, qIdx)
+  const boundary = before.match(/[.!?\n][^.!?\n]*$/)
+  const start = boundary?.index !== undefined ? boundary.index + 1 : 0
+  const question = trimmed.slice(start, qIdx + 1).trim()
+  return question || null
+}
+
+function lastActivityError(messages: Message[]): string | null {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const m = messages[i]
+    if (m.role === "activity" && m.activity?.error) return m.activity.error
+  }
+  return null
+}
+
+export interface BoardCardNow {
+  state: NowStripState
+  text?: string
+  at?: number | null
+}
+
+/**
+ * The card's status line: is the agent working, waiting on the user, finished,
+ * broken, or gone — and the one-liner that proves it. Working defers to the
+ * NowStrip's live content (tool + elapsed + last-output age).
+ */
+export function boardCardNow(
+  claw: Claw,
+  messages: Message[],
+  latestStep: Step | null,
+  isStreaming: boolean
+): BoardCardNow | null {
+  // BootstrapProgress owns the provisioning story.
+  if (claw.status === "provisioning") return null
+
+  let lastAt: number | null = null
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    if (messages[i].role === "system") continue
+    lastAt = messages[i].timestamp.getTime()
+    break
+  }
+
+  if (claw.status === "error") {
+    return {
+      state: "error",
+      text: claw.reason || lastActivityError(messages) || "Agent errored",
+      at: lastAt,
+    }
+  }
+  if (claw.status === "offline") {
+    const seen = claw.last_seen ? new Date(claw.last_seen).getTime() : NaN
+    return { state: "offline", at: Number.isFinite(seen) ? seen : lastAt }
+  }
+  if (isStreaming || latestStep?.status === "running") return { state: "working" }
+
+  // Nothing live: surface what the agent ended with. Transcript tail decides —
+  // trailing tool activity beats older prose, a question flags "needs you".
+  if (latestStep) {
+    return {
+      state: "done",
+      text: latestStep.detail ? `${latestStep.title} · ${latestStep.detail}` : latestStep.title,
+      at: (latestStep.endedAt ?? latestStep.startedAt).getTime(),
+    }
+  }
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const m = messages[i]
+    if (m.role === "system" || m.role === "activity" || m.role === "activity_summary") continue
+    const at = m.timestamp.getTime()
+    if (m.role === "claw") {
+      const text = m.content.trim()
+      const question = extractQuestion(text)
+      if (question) return { state: "waiting", text: question, at }
+      return { state: "done", text: firstMeaningfulLine(text), at }
+    }
+    if (m.role === "hub") return { state: "done", text: m.content, at }
+    if (m.role === "user") return { state: "done", text: "Waiting to start", at }
+  }
+  return { state: "done", text: "Idle", at: lastAt }
+}
+
+/** An offline/errored claw cannot still be running its dangling last step. */
+export function allowsTrailingRunning(claw: Claw): boolean {
+  return claw.status !== "offline" && claw.status !== "error"
+}
+
+/** Latest step of the trailing activity run — the card's live status source. */
+export function trailingLatestStep(claw: Claw, visibleMessages: Message[]): Step | null {
+  const steps = demoteStaleRunning(
+    pairActivitySteps(trailingActivityRun(visibleMessages)),
+    allowsTrailingRunning(claw)
+  )
+  return steps.length > 0 ? steps[steps.length - 1] : null
+}
+
+/**
+ * The three status lanes the board and the sidebar are grouped by.
+ * "attention" is anything blocked on the user, "working" is live, "idle"
+ * is everything that finished or went away.
+ */
+export type ClawLane = "attention" | "working" | "idle"
+
+export const CLAW_LANE_ORDER: ClawLane[] = ["attention", "working", "idle"]
+
+export const CLAW_LANE_META: Record<ClawLane, { title: string; note: string }> = {
+  attention: { title: "Needs you", note: "Blocked until you answer or restart" },
+  working: { title: "Working", note: "Live — no action needed" },
+  idle: { title: "Idle & offline", note: "Finished or disconnected" },
+}
+
+/**
+ * Lane membership, derived from the same signals the board card already shows
+ * in its state strip — no extra data is fetched. Errors (which include a
+ * failed provisioning) and a trailing unanswered question mean the agent is
+ * stuck on the user; a live stream or a running tool step means it is working;
+ * everything else (finished turn, offline) is idle.
+ */
+export function clawLane(claw: Claw, messages: Message[], isStreaming: boolean): ClawLane {
+  if (claw.status === "error") return "attention"
+  // Still booting: nothing to answer yet, and it is on its way to running.
+  if (claw.status === "provisioning") return "working"
+  if (claw.status === "offline") return "idle"
+  if (isStreaming) return "working"
+
+  const visible = windowMessagesByDurableCount(messages, BOARD_CARD_DURABLE_MESSAGE_WINDOW)
+  const now = boardCardNow(claw, visible, trailingLatestStep(claw, visible), isStreaming)
+  if (!now) return "working"
+  switch (now.state) {
+    case "error":
+    case "waiting":
+      return "attention"
+    case "working":
+      return "working"
+    default:
+      return "idle"
+  }
+}
+
+/** Lane per claw id, ready to hand to the board and the sidebar. */
+export function clawLanes(
+  claws: Claw[],
+  messages: Record<string, Message[]>,
+  isStreaming: (claw: Claw) => boolean
+): Record<string, ClawLane> {
+  const lanes: Record<string, ClawLane> = {}
+  for (const claw of claws) {
+    lanes[claw.id] = clawLane(claw, messages[claw.id] ?? [], isStreaming(claw))
+  }
+  return lanes
+}

--- a/web/lib/claw-lanes.ts
+++ b/web/lib/claw-lanes.ts
@@ -139,11 +139,38 @@ export const CLAW_LANE_META: Record<ClawLane, { title: string; note: string }> =
 }
 
 /**
- * Lane membership, derived from the same signals the board card already shows
- * in its state strip — no extra data is fetched. Errors (which include a
- * failed provisioning) and a trailing unanswered question mean the agent is
- * stuck on the user; a live stream or a running tool step means it is working;
- * everything else (finished turn, offline) is idle.
+ * Does the transcript end on a question the user never answered? Only a
+ * trailing claw message counts: any tool activity after it — expanded rows or
+ * a still-collapsed summary — means the agent kept going on its own.
+ */
+export function hasUnansweredQuestion(messages: Message[]): boolean {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const m = messages[i]
+    if (m.role === "system") continue
+    // Empty summary remainders are invisible bookkeeping — look past them.
+    if (
+      m.role === "activity_summary" &&
+      (!m.activitySummary || m.activitySummary.count <= 0)
+    ) {
+      continue
+    }
+    if (m.role === "claw") return extractQuestion(m.content) !== null
+    return false
+  }
+  return false
+}
+
+/**
+ * Lane membership. Deliberately built on signals that do not depend on how
+ * much of the transcript a given page happens to have loaded: the claw status
+ * the hub reports, plus a trailing unanswered question.
+ *
+ * The status is the authority on "live": the hub keeps a claw `connected`
+ * only while its agent session is attached and parks a finished one as
+ * `idle`. Reading liveness off the transcript instead used to split the same
+ * claw across lanes — the board expands trailing activity summaries into
+ * steps, other pages leave them collapsed, so a running step was visible on
+ * one page and invisible on the next.
  */
 export function clawLane(claw: Claw, messages: Message[], isStreaming: boolean): ClawLane {
   if (claw.status === "error") return "attention"
@@ -151,19 +178,11 @@ export function clawLane(claw: Claw, messages: Message[], isStreaming: boolean):
   if (claw.status === "provisioning") return "working"
   if (claw.status === "offline") return "idle"
   if (isStreaming) return "working"
-
-  const visible = windowMessagesByDurableCount(messages, BOARD_CARD_DURABLE_MESSAGE_WINDOW)
-  const now = boardCardNow(claw, visible, trailingLatestStep(claw, visible), isStreaming)
-  if (!now) return "working"
-  switch (now.state) {
-    case "error":
-    case "waiting":
-      return "attention"
-    case "working":
-      return "working"
-    default:
-      return "idle"
-  }
+  // Blocked on the user outranks a live session. Costs nothing when the
+  // transcript is absent — an empty tail simply never matches.
+  if (hasUnansweredQuestion(windowMessagesByDurableCount(messages, BOARD_CARD_DURABLE_MESSAGE_WINDOW)))
+    return "attention"
+  return claw.status === "connected" ? "working" : "idle"
 }
 
 /** Lane per claw id, ready to hand to the board and the sidebar. */

--- a/web/lib/mappers.ts
+++ b/web/lib/mappers.ts
@@ -42,12 +42,15 @@ export const COLOR_CLASSES: Record<string, {
   lime:    { border: "border-[var(--ds-accent-2-400)]",  bubble: "bg-[var(--ds-accent-2-400)]/10",  dot: "bg-[var(--ds-accent-2-400)]",  badge: "bg-[var(--ds-accent-2-400)]/20 text-[var(--ds-accent-2-300)]" },
   green:   { border: "border-status-ok",                 bubble: "bg-status-ok/10",                 dot: "bg-status-ok",                 badge: "bg-status-ok/20 text-status-ok" },
   emerald: { border: "border-[var(--ds-accent-2-300)]",  bubble: "bg-[var(--ds-accent-2-300)]/10",  dot: "bg-[var(--ds-accent-2-300)]",  badge: "bg-[var(--ds-accent-2-300)]/20 text-[var(--ds-accent-2-200)]" },
-  teal:    { border: "border-heatmap-1",                 bubble: "bg-heatmap-1/10",                 dot: "bg-heatmap-1",                 badge: "bg-heatmap-1/20 text-heatmap-1" },
-  cyan:    { border: "border-heatmap-2",                 bubble: "bg-heatmap-2/10",                 dot: "bg-heatmap-2",                 badge: "bg-heatmap-2/20 text-heatmap-2" },
-  sky:     { border: "border-heatmap-4",                 bubble: "bg-heatmap-4/10",                 dot: "bg-heatmap-4",                 badge: "bg-heatmap-4/20 text-heatmap-4" },
+  // The heatmap ramp is reversed in dark mode, so its low steps sit at the
+  // card surface's luminance — identity colors must stay on the bright half
+  // (the shell ships dark-only).
+  teal:    { border: "border-data-light",                bubble: "bg-data-light/10",                dot: "bg-data-light",                badge: "bg-data-light/20 text-data-light" },
+  cyan:    { border: "border-heatmap-4",                 bubble: "bg-heatmap-4/10",                 dot: "bg-heatmap-4",                 badge: "bg-heatmap-4/20 text-heatmap-5" },
+  sky:     { border: "border-heatmap-5",                 bubble: "bg-heatmap-5/10",                 dot: "bg-heatmap-5",                 badge: "bg-heatmap-5/20 text-heatmap-5" },
   blue:    { border: "border-data",                      bubble: "bg-data/10",                      dot: "bg-data",                      badge: "bg-data/20 text-data-light" },
   indigo:  { border: "border-data-dark",                 bubble: "bg-data-dark/10",                 dot: "bg-data-dark",                 badge: "bg-data-dark/20 text-data-light" },
-  violet:  { border: "border-heatmap-5",                 bubble: "bg-heatmap-5/10",                 dot: "bg-heatmap-5",                 badge: "bg-heatmap-5/20 text-heatmap-5" },
+  violet:  { border: "border-[var(--ds-accent-2-200)]",  bubble: "bg-[var(--ds-accent-2-200)]/10",  dot: "bg-[var(--ds-accent-2-200)]",  badge: "bg-[var(--ds-accent-2-200)]/20 text-[var(--ds-accent-2-200)]" },
   purple:  { border: "border-[var(--ds-accent-2-600)]",  bubble: "bg-[var(--ds-accent-2-600)]/10",  dot: "bg-[var(--ds-accent-2-600)]",  badge: "bg-[var(--ds-accent-2-600)]/20 text-[var(--ds-accent-2-300)]" },
   pink:    { border: "border-[var(--ds-accent-2-500)]",  bubble: "bg-[var(--ds-accent-2-500)]/10",  dot: "bg-[var(--ds-accent-2-500)]",  badge: "bg-[var(--ds-accent-2-500)]/20 text-[var(--ds-accent-2-200)]" },
   rose:    { border: "border-[var(--ds-accent-400)]",    bubble: "bg-[var(--ds-accent-400)]/10",    dot: "bg-[var(--ds-accent-400)]",    badge: "bg-[var(--ds-accent-400)]/20 text-[var(--ds-accent-200)]" },

--- a/web/lib/mappers.ts
+++ b/web/lib/mappers.ts
@@ -16,30 +16,41 @@ function autoColor(name: string): string {
   return CLAW_COLORS[h % CLAW_COLORS.length]
 }
 
-// Tailwind color classes for each named color
-// All must be in the safelist so Tailwind includes them
+/**
+ * Per-claw accent classes, keyed by the legacy color names the API stores.
+ *
+ * The Modernist system has no 16-hue palette: it has one accent, a secondary
+ * accent, a data hue, three status hues and a neutral ramp. The 16 keys are
+ * therefore spread across those families at different ramp steps, which keeps
+ * every claw visually distinguishable while never introducing a color the
+ * design system does not own. Keys and the { border, bubble, dot, badge }
+ * shape are unchanged, so consumers keep working.
+ *
+ * Every class below must stay a full literal string — Tailwind v4 only emits
+ * classes it can find verbatim in the source.
+ */
 export const COLOR_CLASSES: Record<string, {
   border: string
   bubble: string
   dot: string
   badge: string
 }> = {
-  slate:   { border: "border-slate-500",   bubble: "bg-slate-500/10",   dot: "bg-slate-400",   badge: "bg-slate-500/20 text-slate-300" },
-  red:     { border: "border-red-500",     bubble: "bg-red-500/10",     dot: "bg-red-400",     badge: "bg-red-500/20 text-red-300" },
-  orange:  { border: "border-orange-500",  bubble: "bg-orange-500/10",  dot: "bg-orange-400",  badge: "bg-orange-500/20 text-orange-300" },
-  amber:   { border: "border-amber-500",   bubble: "bg-amber-500/10",   dot: "bg-amber-400",   badge: "bg-amber-500/20 text-amber-300" },
-  lime:    { border: "border-lime-500",    bubble: "bg-lime-500/10",    dot: "bg-lime-400",    badge: "bg-lime-500/20 text-lime-300" },
-  green:   { border: "border-green-500",   bubble: "bg-green-500/10",   dot: "bg-green-400",   badge: "bg-green-500/20 text-green-300" },
-  emerald: { border: "border-emerald-500", bubble: "bg-emerald-500/10", dot: "bg-emerald-400", badge: "bg-emerald-500/20 text-emerald-300" },
-  teal:    { border: "border-teal-500",    bubble: "bg-teal-500/10",    dot: "bg-teal-400",    badge: "bg-teal-500/20 text-teal-300" },
-  cyan:    { border: "border-cyan-500",    bubble: "bg-cyan-500/10",    dot: "bg-cyan-400",    badge: "bg-cyan-500/20 text-cyan-300" },
-  sky:     { border: "border-sky-500",     bubble: "bg-sky-500/10",     dot: "bg-sky-400",     badge: "bg-sky-500/20 text-sky-300" },
-  blue:    { border: "border-blue-500",    bubble: "bg-blue-500/10",    dot: "bg-blue-400",    badge: "bg-blue-500/20 text-blue-300" },
-  indigo:  { border: "border-indigo-500",  bubble: "bg-indigo-500/10",  dot: "bg-indigo-400",  badge: "bg-indigo-500/20 text-indigo-300" },
-  violet:  { border: "border-violet-500",  bubble: "bg-violet-500/10",  dot: "bg-violet-400",  badge: "bg-violet-500/20 text-violet-300" },
-  purple:  { border: "border-purple-500",  bubble: "bg-purple-500/10",  dot: "bg-purple-400",  badge: "bg-purple-500/20 text-purple-300" },
-  pink:    { border: "border-pink-500",    bubble: "bg-pink-500/10",    dot: "bg-pink-400",    badge: "bg-pink-500/20 text-pink-300" },
-  rose:    { border: "border-rose-500",    bubble: "bg-rose-500/10",    dot: "bg-rose-400",    badge: "bg-rose-500/20 text-rose-300" },
+  slate:   { border: "border-[var(--ds-neutral-500)]",   bubble: "bg-[var(--ds-neutral-500)]/10",   dot: "bg-[var(--ds-neutral-500)]",   badge: "bg-[var(--ds-neutral-500)]/20 text-[var(--ds-neutral-300)]" },
+  red:     { border: "border-[var(--ds-accent-600)]",    bubble: "bg-[var(--ds-accent-600)]/10",    dot: "bg-[var(--ds-accent-600)]",    badge: "bg-[var(--ds-accent-600)]/20 text-[var(--ds-accent-300)]" },
+  orange:  { border: "border-[var(--ds-accent-500)]",    bubble: "bg-[var(--ds-accent-500)]/10",    dot: "bg-[var(--ds-accent-500)]",    badge: "bg-[var(--ds-accent-500)]/20 text-[var(--ds-accent-300)]" },
+  amber:   { border: "border-status-warn",               bubble: "bg-status-warn/10",               dot: "bg-status-warn",               badge: "bg-status-warn/20 text-status-warn" },
+  lime:    { border: "border-[var(--ds-accent-2-400)]",  bubble: "bg-[var(--ds-accent-2-400)]/10",  dot: "bg-[var(--ds-accent-2-400)]",  badge: "bg-[var(--ds-accent-2-400)]/20 text-[var(--ds-accent-2-300)]" },
+  green:   { border: "border-status-ok",                 bubble: "bg-status-ok/10",                 dot: "bg-status-ok",                 badge: "bg-status-ok/20 text-status-ok" },
+  emerald: { border: "border-[var(--ds-accent-2-300)]",  bubble: "bg-[var(--ds-accent-2-300)]/10",  dot: "bg-[var(--ds-accent-2-300)]",  badge: "bg-[var(--ds-accent-2-300)]/20 text-[var(--ds-accent-2-200)]" },
+  teal:    { border: "border-heatmap-1",                 bubble: "bg-heatmap-1/10",                 dot: "bg-heatmap-1",                 badge: "bg-heatmap-1/20 text-heatmap-1" },
+  cyan:    { border: "border-heatmap-2",                 bubble: "bg-heatmap-2/10",                 dot: "bg-heatmap-2",                 badge: "bg-heatmap-2/20 text-heatmap-2" },
+  sky:     { border: "border-heatmap-4",                 bubble: "bg-heatmap-4/10",                 dot: "bg-heatmap-4",                 badge: "bg-heatmap-4/20 text-heatmap-4" },
+  blue:    { border: "border-data",                      bubble: "bg-data/10",                      dot: "bg-data",                      badge: "bg-data/20 text-data-light" },
+  indigo:  { border: "border-data-dark",                 bubble: "bg-data-dark/10",                 dot: "bg-data-dark",                 badge: "bg-data-dark/20 text-data-light" },
+  violet:  { border: "border-heatmap-5",                 bubble: "bg-heatmap-5/10",                 dot: "bg-heatmap-5",                 badge: "bg-heatmap-5/20 text-heatmap-5" },
+  purple:  { border: "border-[var(--ds-accent-2-600)]",  bubble: "bg-[var(--ds-accent-2-600)]/10",  dot: "bg-[var(--ds-accent-2-600)]",  badge: "bg-[var(--ds-accent-2-600)]/20 text-[var(--ds-accent-2-300)]" },
+  pink:    { border: "border-[var(--ds-accent-2-500)]",  bubble: "bg-[var(--ds-accent-2-500)]/10",  dot: "bg-[var(--ds-accent-2-500)]",  badge: "bg-[var(--ds-accent-2-500)]/20 text-[var(--ds-accent-2-200)]" },
+  rose:    { border: "border-[var(--ds-accent-400)]",    bubble: "bg-[var(--ds-accent-400)]/10",    dot: "bg-[var(--ds-accent-400)]",    badge: "bg-[var(--ds-accent-400)]/20 text-[var(--ds-accent-200)]" },
 }
 
 /**


### PR DESCRIPTION
## Summary

Full visual restyle of the web app onto the **Modernist** design system imported from the Claude Design project. Pure restyle: no behavior, route, aria, or data-flow changes (one deliberate exception noted below).

### Architecture — built for cheap replication
- `web/app/globals.css` is now two layers:
  - **Layer A — Modernist tokens** (`--ds-*` prefix): a near-verbatim port of the design system's `styles.css` (role colors, 100–900 ramps, tints, shadows, radius, status hues, data hue). This block is the *replaceable* design system — a future DS swap re-tunes only this block.
  - **Layer B — shadcn mapping**: the existing `@theme inline` names (`--background`, `--card`, `--primary`, …) remapped onto layer A, so no component learns new names.
- Reference specs committed under `docs/design/modernist/` (tokens, `theme.json` seed, the six screen mockups).
- Fonts: Geist → **Archivo** (400/600/800); Geist Mono retained.
- Shell stays dark-only (`className="dark"`), matching the mockups; the light palette ships in the tokens but is not switchable.

### Scope
- 19 used shadcn primitives restyled (`ui/`); `chart.tsx` retuned for token-driven Recharts colors.
- Screens: login, setup, agents board (sidebar + cards), conversation/timeline, analytics (semantic outcome scale vs. data-blue money scale), settings (~167 hardcoded palette classes → tokens).
- `lib/mappers.ts` claw identity colors ported to token-based literals (Tailwind v4-safe).
- xterm terminal palette tokenized (reads `--ds-*` at mount, harmonized ANSI 16).

### Notes for review
- **Deliberate structural change**: `NowStrip` moved above the board-card header (mockup's state-strip-on-top).
- Settings sidebar now labels the first nav group ("Workspace") — previously hidden; matches the mockup.
- Analytics delivery-funnel zeros in the screenshots are a seeding gap in the capture harness, not app code.

- **Board restructured into status lanes** (`7870ce82`) per the mockup: "Needs you" / "Working" / "Idle & offline" lanes with an auto-fill card grid, sidebar grouped identically (shared lane derivation in `web/lib/claw-lanes.ts`). Trade-offs: the desktop 3D card flip became a plain visibility swap (needed fixed heights), the horizontal-scroll arrows went away with the carousel, and drag-to-reorder is confined within a lane.

### Verification
- `npm run build` (static export, 33 pages) ✅ and `scripts/check-static-export.sh` (29 settings paths) ✅
- `tsc --noEmit` per screen ✅
- Reviews: Claude (behavior/token audit) + independent Codex review — its contrast finding on dark identity colors fixed in 5c6cfcd8.

### Screenshots
_All six screens captured against a seeded local hub — being attached by drag-and-drop (gh cannot upload images)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
