### PR TITLE
fix(hub): auto-resume agents that go idle mid-pipeline

### DIFF
--- a/pkg/hub/agent_idle.go
+++ b/pkg/hub/agent_idle.go
@@ -103,6 +103,80 @@ func (s *Server) agentIdleBaseline(nowAt time.Time, enabled bool) (baseline time
 	return s.agentIdleBaselineAt, true
 }
 
+// agentIdleSnapshot is one consistent read of the connection state both the
+// alert (checkAgentIdle) and the recovery (checkAgentIdleResume) reason about.
+// The stretch-start rule is subtle enough that a second copy of it would drift:
+// the two paths must agree on when a stretch began or the resume could fire for
+// a stretch the alert never considered started.
+type agentIdleSnapshot struct {
+	busy             bool
+	noProgressPaused bool
+	lastTurn         time.Time
+	notifiedAt       time.Time
+	// stretchStartAt is zero when the connection carries no usable clock at
+	// all (registration always stamps connectedAt, so this is unreachable in
+	// production and simply means "do not judge this claw").
+	stretchStartAt time.Time
+}
+
+// agentIdleSnapshotOf computes the idle stretch start under a single read lock.
+//
+// The stretch starts at the end of the last real turn, or — for a claw that
+// never ran one — the moment this connection registered. A claw that came up
+// connected and was never prompted at all (workflow start failed, pipeline
+// entry stage never injected, trigger dropped the issue) is the most common
+// real stall, so "no turn ever" must count too.
+//
+// The stretch cannot extend into time the claw was not connected:
+// lastTurnFinishedAt is re-seeded from message history on registration with no
+// time bound, so without this floor a bridge that was offline overnight — or a
+// claw restored from a checkpoint — would be judged on its first tick for
+// idleness that predates the connection.
+func agentIdleSnapshotOf(cc *clawConn) agentIdleSnapshot {
+	cc.mu.RLock()
+	defer cc.mu.RUnlock()
+	snap := agentIdleSnapshot{
+		busy:             cc.isBusyLocked(),
+		noProgressPaused: cc.noProgressPaused,
+		lastTurn:         cc.lastTurnFinishedAt,
+		notifiedAt:       cc.idleNotifiedAt,
+	}
+	start := cc.lastTurnFinishedAt
+	if start.IsZero() {
+		start = cc.connectedAt
+	}
+	if start.IsZero() {
+		return snap
+	}
+	if start.Before(cc.connectedAt) {
+		start = cc.connectedAt
+	}
+	snap.stretchStartAt = start
+	return snap
+}
+
+// agentIdleStretchAnchor names a stretch across hub restarts and bridge
+// reconnects. lastTurnFinishedAt is re-seeded (roughly) to its old value on
+// registration, so it survives; a claw that never ran a turn anchors on
+// claws.created_at instead, because connectedAt is re-stamped on every
+// registration and would make an unchanged stall look like a brand-new one.
+func agentIdleStretchAnchor(lastTurn time.Time, createdAtSec int64) time.Time {
+	if !lastTurn.IsZero() {
+		return lastTurn
+	}
+	return time.Unix(createdAtSec, 0)
+}
+
+// agentIdleAutoDriven reports whether something automatic drives an ad-hoc
+// claw (a pipeline stage or a live workflow run). Run-backed claws are driven
+// by their run and never ask.
+func (s *Server) agentIdleAutoDriven(clawID, taskRunID, pipelineStage string) bool {
+	if taskRunID != "" {
+		return false
+	}
+	return pipelineStage != "" || s.agentIdleHasActiveWorkflow(clawID)
+}
+
 // checkAgentIdle runs once per claw per watchdog tick. It decides whether the
 // claw's current idle stretch deserves an agent_idle notification and, if so,
 // persists the durable signal for the notifier passes to deliver.
@@ -118,39 +192,17 @@ func (s *Server) checkAgentIdle(nowAt time.Time, clawID string, cc *clawConn) {
 		return
 	}
 
-	cc.mu.RLock()
-	busy := cc.isBusyLocked()
-	lastTurn := cc.lastTurnFinishedAt
-	connectedAt := cc.connectedAt
-	noProgressPaused := cc.noProgressPaused
-	notifiedAt := cc.idleNotifiedAt
-	cc.mu.RUnlock()
+	snap := agentIdleSnapshotOf(cc)
+	lastTurn, noProgressPaused, notifiedAt := snap.lastTurn, snap.noProgressPaused, snap.notifiedAt
 
-	if busy {
+	if snap.busy {
 		// A running turn ends the idle stretch.
 		s.clearAgentIdleLatch(clawID, cc)
 		return
 	}
-	// The stretch starts at the end of the last real turn, or — for a claw
-	// that never ran one — the moment this connection registered. A claw that
-	// came up connected and was never prompted at all (workflow start failed,
-	// pipeline entry stage never injected, trigger dropped the issue) is the
-	// most common real stall, so "no turn ever" must alert too.
-	//
-	// The stretch cannot extend into time the claw was not connected:
-	// lastTurnFinishedAt is re-seeded from message history on registration
-	// with no time bound, so without this floor a bridge that was offline
-	// overnight — or a claw restored from a checkpoint — would be alerted on
-	// its first tick for idleness that predates the connection.
-	stretchStartAt := lastTurn
-	if stretchStartAt.IsZero() {
-		stretchStartAt = connectedAt
-	}
+	stretchStartAt := snap.stretchStartAt
 	if stretchStartAt.IsZero() {
 		return // no usable clock at all (registration always stamps connectedAt)
-	}
-	if stretchStartAt.Before(connectedAt) {
-		stretchStartAt = connectedAt
 	}
 	idleFor := nowAt.Sub(stretchStartAt)
 	if idleFor < lifecycleIdleAfter(cfg.Lifecycle) {
@@ -187,10 +239,7 @@ func (s *Server) checkAgentIdle(nowAt time.Time, clawID string, cc *clawConn) {
 	// Accepted consequence: a never-turn stall that began before the
 	// notification baseline is parked once and stays parked across reconnects
 	// — the "first enable never replays history" rule applied consistently.
-	anchor := lastTurn
-	if anchor.IsZero() {
-		anchor = time.Unix(createdAtSec, 0)
-	}
+	anchor := agentIdleStretchAnchor(lastTurn, createdAtSec)
 	slackMs := agentIdleStretchSlack.Milliseconds()
 	if idleSince != 0 && anchor.UnixMilli() <= idleSince+slackMs {
 		cc.mu.Lock()
@@ -198,10 +247,7 @@ func (s *Server) checkAgentIdle(nowAt time.Time, clawID string, cc *clawConn) {
 		cc.mu.Unlock()
 		return
 	}
-	autoDriven := false
-	if taskRunID == "" {
-		autoDriven = pipelineStage != "" || s.agentIdleHasActiveWorkflow(clawID)
-	}
+	autoDriven := s.agentIdleAutoDriven(clawID, taskRunID, pipelineStage)
 	if !agentIdleEligible(status, taskRunID, s.agentIdleRunPhase(taskRunID), s.agentIdleHasClawPRs(clawID), autoDriven) {
 		return
 	}
@@ -256,6 +302,225 @@ func (s *Server) checkAgentIdle(nowAt time.Time, clawID string, cc *clawConn) {
 	cc.mu.Lock()
 	cc.idleNotifiedAt = nowAt
 	cc.mu.Unlock()
+}
+
+// Idle auto-resume (NEXT-713). The alert above tells a human; this recovers.
+//
+// The incident: the agent called a tool that waits for spawned work
+// (sessions_yield in the pinned OpenClaw) and that call never returned a
+// result. The call ENDS THE TURN, so to the hub the claw looked idle and
+// perfectly healthy — status pongs fine, no turn in flight, nothing queued —
+// and every existing recovery path missed it: the busy-turn watchdog needs an
+// open turn, sendStreamingNudge drops when no turn is open, and the
+// restart/session-rotation resumes need a restart or a rotation (a clean
+// bridge reconnect is neither). The claw sat for 1h44m and the only thing that
+// ever moved it was a human typing "continue". This injects that "continue".
+//
+// It is deliberately NOT part of checkAgentIdle: that function returns early
+// when lifecycle notifications are disabled or muted, and recovery must not
+// depend on whether anyone is listening to Slack.
+const (
+	defaultIdleResumeAfter = 10 * time.Minute
+	// minIdleResumeAfter is the floor for idle_resume_after. It is NOT what
+	// keeps a stalled claw from being poked repeatedly — the once-per-stretch
+	// idle_resume_at latch is, and it works at any threshold, including ones
+	// below the 2-minute watchdog tick. The floor exists because below a
+	// minute the threshold stops describing a stall at all: a claw that pauses
+	// for seconds between turns is simply working, and resuming it interrupts
+	// the very progress the recovery is meant to restore.
+	minIdleResumeAfter = time.Minute
+
+	// agentIdleResumeBaselineKey persists (in slack_notifier_state, epoch
+	// millis) the moment from which idle stretches may be auto-resumed.
+	// Stretches that BEGAN before it are parked (latched, never injected).
+	// Without it the first watchdog tick after this feature reaches an
+	// existing hub would poke every connected, eligible, long-idle claw at
+	// once — including claws a human deliberately walked away from hours ago,
+	// which is a thundering herd of prompts, not a recovery.
+	//
+	// This mirrors agentIdleBaselineKey but is deliberately independent state:
+	// the two features must not be able to move each other's baseline, and
+	// this one is cleared only while the RESUME itself is disabled. Lifecycle
+	// notifications being off must never touch it — the resume does not read
+	// the notification config at all, by design.
+	agentIdleResumeBaselineKey = "agent_idle_resume_baseline"
+
+	// agentIdleResumeMaxAttempts bounds the resumes a single claw can ever
+	// receive. The PRIMARY backstop is the existing no-progress watchdog: a
+	// resume that produces the same empty outcome three times sets
+	// no_progress_paused, which this check honours (see below). The cap covers
+	// the pathological case that watchdog cannot see — turns whose outcomes
+	// keep differing just enough to reset its observation window — so a
+	// wake-do-nothing-idle loop cannot poke forever.
+	agentIdleResumeMaxAttempts = 10
+
+	agentIdleResumePrefix = "[hub] No turn has been running for"
+)
+
+// agentIdleResumeBaseline returns the moment from which idle stretches may be
+// auto-resumed, managing the persisted key (see agentIdleResumeBaselineKey).
+// While the resume is disabled it clears the key (once per disabled window)
+// and returns zero, so a re-enable stamps a fresh baseline and the disabled
+// window is never replayed. ok is false only on a state read failure, in which
+// case the caller must skip the resume for this tick rather than guess — the
+// guess would be a poke.
+//
+// Deliberately takes the resume's OWN enabled flag: unlike agentIdleBaseline
+// this must never be driven by the notification config.
+func (s *Server) agentIdleResumeBaseline(nowAt time.Time, enabled bool) (baseline time.Time, ok bool) {
+	s.agentIdleResumeBaselineMu.Lock()
+	defer s.agentIdleResumeBaselineMu.Unlock()
+	if !enabled {
+		if !s.agentIdleResumeBaselineCleared {
+			s.clearNotifierState(agentIdleResumeBaselineKey)
+			s.agentIdleResumeBaselineCleared = true
+			s.agentIdleResumeBaselineAt = time.Time{}
+		}
+		return time.Time{}, true
+	}
+	s.agentIdleResumeBaselineCleared = false
+	if !s.agentIdleResumeBaselineAt.IsZero() {
+		return s.agentIdleResumeBaselineAt, true
+	}
+	v, found, err := s.notifierStateInt64(agentIdleResumeBaselineKey)
+	switch {
+	case err != nil:
+		log.Printf("[agent-idle] read resume baseline: %v", err)
+		return time.Time{}, false
+	case found && v > 0:
+		s.agentIdleResumeBaselineAt = time.UnixMilli(v)
+	default:
+		s.agentIdleResumeBaselineAt = nowAt
+		s.setNotifierStateInt64(agentIdleResumeBaselineKey, nowAt.UnixMilli())
+	}
+	return s.agentIdleResumeBaselineAt, true
+}
+
+// checkAgentIdleResume runs on the same watchdog tick as checkAgentIdle and
+// injects a resume prompt into a claw that has been idle past
+// liveness.idle_resume_after. It shares the eligibility rule and the
+// stretch-start computation with the alert; only the threshold, the latch and
+// the delivery differ.
+func (s *Server) checkAgentIdleResume(nowAt time.Time, clawID string, cc *clawConn) {
+	cfg := s.livenessSettings()
+	baseline, ok := s.agentIdleResumeBaseline(nowAt, cfg.idleResumeEnabled)
+	if !cfg.idleResumeEnabled || !ok {
+		return
+	}
+	snap := agentIdleSnapshotOf(cc)
+	if snap.busy {
+		// A turn is running: nothing to resume.
+		//
+		// The latch is deliberately NOT cleared here. A turn RESERVATION in
+		// flight is not a turn that finished: abortTurnLocked (WS write
+		// failure) releases the reservation without moving
+		// lastTurnFinishedAt, so a tick that lands inside a delivery which
+		// then aborts would clear the latch while the stretch anchor is
+		// unchanged — and the same stretch would be resumed twice. Re-arming
+		// is driven by lastTurnFinishedAt actually moving past the latched
+		// stretch instead (see below).
+		return
+	}
+	if snap.noProgressPaused {
+		// The no-progress watchdog has deliberately stopped automatic
+		// continuation for this claw and told its human so. Poking it here
+		// would fight that backstop and restart the exact loop it stopped.
+		return
+	}
+	if snap.stretchStartAt.IsZero() {
+		return
+	}
+	idleFor := nowAt.Sub(snap.stretchStartAt)
+	if idleFor < cfg.idleResumeAfter {
+		return
+	}
+
+	var status, taskRunID, pipelineStage string
+	var resumeAt, resumeCount, createdAtSec int64
+	err := s.db.QueryRow(`SELECT status, COALESCE(task_run_id,''), COALESCE(pipeline_stage,''), idle_resume_at, idle_resume_count, CAST(strftime('%s', created_at) AS INTEGER) FROM claws WHERE id=?`, clawID).
+		Scan(&status, &taskRunID, &pipelineStage, &resumeAt, &resumeCount, &createdAtSec)
+	if err != nil {
+		if err != sql.ErrNoRows {
+			log.Printf("[agent-idle] read claw %s for resume: %v", shortID(clawID), err)
+		}
+		return
+	}
+	// Same stretch identity rule as the alert's latch: the anchor, not the
+	// floored start, so a hub restart or bridge reconnect cannot re-poke a
+	// stretch that was already resumed or parked.
+	anchor := agentIdleStretchAnchor(snap.lastTurn, createdAtSec)
+	if resumeAt != 0 {
+		if anchor.UnixMilli() <= resumeAt+agentIdleStretchSlack.Milliseconds() {
+			return // this stretch was already handled
+		}
+		// lastTurnFinishedAt has moved past the latched stretch, so a turn
+		// genuinely ran and finished (an aborted reservation cannot produce
+		// this — it never stamps lastTurnFinishedAt). This is a new stretch:
+		// re-arm the durable latch. The comparison above would already let
+		// this tick through, but clearing keeps the stored state honest for
+		// the paths below that return without re-latching (cap reached,
+		// no longer eligible, parked).
+		s.clearAgentIdleResumeLatch(clawID)
+	}
+	if resumeCount >= agentIdleResumeMaxAttempts {
+		return // cap already reached and already logged (see below)
+	}
+	if !agentIdleEligible(status, taskRunID, s.agentIdleRunPhase(taskRunID), s.agentIdleHasClawPRs(clawID), s.agentIdleAutoDriven(clawID, taskRunID, pipelineStage)) {
+		return
+	}
+
+	stretchStart := snap.stretchStartAt.UnixMilli()
+	if snap.stretchStartAt.Before(baseline) {
+		// The stretch began before the resume could have observed it (first
+		// deploy or first enable, or during a disabled window): park it —
+		// latch without injecting, without consuming the lifetime cap — so
+		// turning the feature on never replays history. This is what keeps
+		// the first tick against an existing database from poking every
+		// long-idle claw on it at once. A real turn re-arms the claw
+		// normally, so parking costs a stalled claw at most one stretch.
+		s.parkAgentIdleResumeStretch(clawID, stretchStart)
+		return
+	}
+
+	// Latch before injecting: if the UPDATE fails we send nothing and retry on
+	// the next tick, whereas injecting first would risk a second poke for the
+	// same stretch on every tick until the write finally succeeded.
+	if _, err := s.db.Exec(`UPDATE claws SET idle_resume_at=?, idle_resume_count=idle_resume_count+1 WHERE id=?`, stretchStart, clawID); err != nil {
+		log.Printf("[agent-idle] latch resume for claw %s: %v", shortID(clawID), err)
+		return
+	}
+	log.Printf("[agent-idle] auto-resuming claw %s after %d minutes idle (attempt %d/%d)", shortID(clawID), int(idleFor.Minutes()), resumeCount+1, agentIdleResumeMaxAttempts)
+	if resumeCount+1 >= agentIdleResumeMaxAttempts {
+		log.Printf("[agent-idle] claw %s reached the lifetime auto-resume cap of %d; no further resumes will be sent", shortID(clawID), agentIdleResumeMaxAttempts)
+	}
+	// What makes the resume once-per-stretch is the idle_resume_at latch
+	// written just above, NOT injectMessage's dedupe: the message embeds the
+	// idle minute count, so two injections are only "identical" when their
+	// minute counts happen to match. The dedupe is still worth having for the
+	// case it does cover — successive stretches whose prompts are byte-equal
+	// while an earlier one sits undelivered on a wedged socket — so no
+	// uniqueness marker is appended to defeat it.
+	s.injectHubMessageByID(clawID, agentIdleResumeMessage(idleFor))
+}
+
+// parkAgentIdleResumeStretch latches a stretch as handled WITHOUT injecting a
+// prompt and without consuming an attempt from the lifetime cap: nothing is
+// delivered, so nothing was spent. The latch alone dedupes every future
+// re-detection of the stretch, including across hub restarts.
+func (s *Server) parkAgentIdleResumeStretch(clawID string, stretchStart int64) {
+	if _, err := s.db.Exec(`UPDATE claws SET idle_resume_at=? WHERE id=?`, stretchStart, clawID); err != nil {
+		log.Printf("[agent-idle] park resume latch for claw %s: %v", shortID(clawID), err)
+	}
+}
+
+// agentIdleResumeMessage is deliberately hub-generic: the hub serves other
+// factories, so it must not name this workspace's stages or tools. It states
+// the observation, gives the blocked-on-background case its own instruction
+// (the incident's actual shape: waiting on spawned work that never reported),
+// and otherwise repeats the workspace-recovery wording of
+// enqueueSessionLostResume so a resumed agent never starts over.
+func agentIdleResumeMessage(idleFor time.Duration) string {
+	return fmt.Sprintf("%s %d minutes. If you are blocked waiting on background or spawned work that has not reported back, stop waiting for it and follow your task's degradation path instead of waiting longer. Otherwise, recover your state from the workspace: run git status and git log --oneline -15, check which branch you are on and whether there are uncommitted changes. Then resume the current stage from where the workspace shows it stopped. Do not start over and do not discard existing work.", agentIdleResumePrefix, int(idleFor.Minutes()))
 }
 
 // agentIdleEligible is the exclusion rule: an idle agent only alerts when it
@@ -361,14 +626,36 @@ func (s *Server) agentIdleHasClawPRs(clawID string) bool {
 	return n > 0
 }
 
-// clearAgentIdleLatch drops the durable latch when the claw is busy again,
-// re-arming the alert for the next idle stretch.
+// clearAgentIdleLatch drops the alert's durable latch when the claw is busy
+// again, re-arming the alert for the next idle stretch.
+//
+// It deliberately does NOT touch the resume latch. This runs on observing a
+// turn in flight, and a reservation that aborts (abortTurnLocked, on a WS
+// write failure) never becomes a finished turn; clearing the resume latch here
+// would re-arm a stretch that never ended and poke it a second time. The
+// resume re-arms itself in checkAgentIdleResume, from lastTurnFinishedAt
+// actually moving.
 func (s *Server) clearAgentIdleLatch(clawID string, cc *clawConn) {
 	cc.mu.Lock()
 	cc.idleNotifiedAt = time.Time{}
 	cc.mu.Unlock()
 	if _, err := s.db.Exec(`UPDATE claws SET idle_since=0 WHERE id=? AND idle_since != 0`, clawID); err != nil {
 		log.Printf("[agent-idle] clear latch for claw %s: %v", shortID(clawID), err)
+	}
+}
+
+// clearAgentIdleResumeLatch re-arms the auto-resume for the next idle stretch.
+// The single caller is the "a turn actually finished" branch of
+// checkAgentIdleResume; see clearAgentIdleLatch for why observing busy is not
+// good enough.
+//
+// idle_resume_count is deliberately NOT reset. A resume that produces an empty
+// turn still ends the stretch, so resetting the counter on every turn would
+// make the lifetime cap unreachable in precisely the runaway case it exists to
+// bound (wake, do nothing, idle, repeat).
+func (s *Server) clearAgentIdleResumeLatch(clawID string) {
+	if _, err := s.db.Exec(`UPDATE claws SET idle_resume_at=0 WHERE id=? AND idle_resume_at != 0`, clawID); err != nil {
+		log.Printf("[agent-idle] clear resume latch for claw %s: %v", shortID(clawID), err)
 	}
 }
 

--- a/pkg/hub/agent_idle_resume_test.go
+++ b/pkg/hub/agent_idle_resume_test.go
@@ -1,0 +1,365 @@
+package hub
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+// newIdleResumeTestServer builds a hub with NO notifications configured at
+// all. That is the point: auto-resume is recovery, not an alert, and every
+// test in this file must pass on a hub where nobody is listening to Slack.
+//
+// The resume baseline is backdated, i.e. these servers model a hub where the
+// feature has been on for a long time. Baseline behaviour itself is covered by
+// TestAgentIdleResumeParksStretchesOlderThanBaseline, which deliberately does
+// not backdate.
+func newIdleResumeTestServer(t *testing.T, liveness *types.LivenessConfig) (*Server, *sql.DB) {
+	t.Helper()
+	s, db := newIdleResumeTestServerAtEnable(t, liveness)
+	backdateAgentIdleResumeBaseline(t, s)
+	return s, db
+}
+
+// newIdleResumeTestServerAtEnable is the same hub with no baseline stamped
+// yet: the next resume tick is the first one the feature ever ran.
+func newIdleResumeTestServerAtEnable(t *testing.T, liveness *types.LivenessConfig) (*Server, *sql.DB) {
+	t.Helper()
+	return NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token", Liveness: liveness}, "", "", "")
+}
+
+// backdateAgentIdleResumeBaseline moves the auto-resume baseline a day into
+// the past and drops the in-memory cache, so stretches the test provokes count
+// as post-enable and are actually resumed instead of parked.
+func backdateAgentIdleResumeBaseline(t *testing.T, s *Server) {
+	t.Helper()
+	s.setNotifierStateInt64(agentIdleResumeBaselineKey, time.Now().Add(-24*time.Hour).UnixMilli())
+	s.agentIdleResumeBaselineMu.Lock()
+	s.agentIdleResumeBaselineAt = time.Time{}
+	s.agentIdleResumeBaselineCleared = false
+	s.agentIdleResumeBaselineMu.Unlock()
+}
+
+// idleResumeMessages counts the resume prompts injected into a claw's
+// conversation.
+func idleResumeMessages(t *testing.T, db *sql.DB, clawID string) int {
+	t.Helper()
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND role='hub' AND content LIKE ?`, clawID, agentIdleResumePrefix+"%").Scan(&n); err != nil {
+		t.Fatalf("count resume messages for %s: %v", clawID, err)
+	}
+	return n
+}
+
+func clawIdleResumeState(t *testing.T, db *sql.DB, clawID string) (at, count int64) {
+	t.Helper()
+	if err := db.QueryRow(`SELECT idle_resume_at, idle_resume_count FROM claws WHERE id=?`, clawID).Scan(&at, &count); err != nil {
+		t.Fatalf("read idle_resume state for %s: %v", clawID, err)
+	}
+	return at, count
+}
+
+// The regression that matters most (NEXT-713): the hub notified about the
+// stall and did nothing else. Auto-resume must fire on a hub with lifecycle
+// notifications entirely absent — muting the alert channel must never disable
+// recovery — exactly once per idle stretch, and re-arm once a turn has run.
+func TestAgentIdleResumeFiresWithoutNotificationsOncePerStretchAndRearms(t *testing.T) {
+	s, db := newIdleResumeTestServer(t, nil)
+	const clawID = "resume-adhoc"
+	insertSlackTestClaw(t, db, clawID, "connected", 0, "", oldEnough)
+	setClawPipelineStage(t, db, clawID, "implement")
+	if cfg := s.notificationsConfig(); cfg != nil {
+		t.Fatal("test server unexpectedly has notifications configured")
+	}
+
+	cc := idleTestConn(clawID, 15*time.Minute)
+	s.checkAgentIdleResume(time.Now(), clawID, cc)
+	at, count := clawIdleResumeState(t, db, clawID)
+	if at == 0 || count != 1 {
+		t.Fatalf("first resume: idle_resume_at=%d count=%d, want a latch and count 1", at, count)
+	}
+	if got := idleResumeMessages(t, db, clawID); got != 1 {
+		t.Fatalf("injected %d resume messages, want 1", got)
+	}
+
+	// Same stretch, later tick: latched, so nothing more is sent.
+	s.checkAgentIdleResume(time.Now(), clawID, cc)
+	if got := idleResumeMessages(t, db, clawID); got != 1 {
+		t.Fatalf("same stretch resumed twice: %d messages", got)
+	}
+	if _, count := clawIdleResumeState(t, db, clawID); count != 1 {
+		t.Fatalf("same stretch bumped the attempt counter to %d", count)
+	}
+
+	// A hub restart must not re-poke the stretch: the fresh clawConn loses all
+	// in-memory state and lastTurnFinishedAt is re-seeded with a little drift.
+	restarted := &clawConn{id: clawID, tenantID: "test-tenant-id",
+		connectedAt:        time.Now().Add(-12 * time.Minute),
+		lastTurnFinishedAt: cc.lastTurnFinishedAt.Add(2 * time.Second)}
+	s.checkAgentIdleResume(time.Now(), clawID, restarted)
+	if got := idleResumeMessages(t, db, clawID); got != 1 {
+		t.Fatalf("restart re-resumed the same stretch: %d messages", got)
+	}
+
+	// A tick landing while a turn RESERVATION is in flight must not re-arm the
+	// resume: abortTurnLocked (a failed WS delivery) releases the reservation
+	// without ever moving lastTurnFinishedAt, so the stretch is unchanged and
+	// clearing the latch here would resume it a second time. The embedded
+	// minute count differs between the two prompts, so injectMessage's
+	// identical-pending dedupe would not catch that.
+	latchedAt, _ := clawIdleResumeState(t, db, clawID)
+	cc.mu.Lock()
+	cc.awaitingResponse = true
+	cc.mu.Unlock()
+	s.checkAgentIdleResume(time.Now(), clawID, cc)
+	cc.mu.Lock()
+	cc.abortTurnLocked()
+	cc.mu.Unlock()
+	s.checkAgentIdleResume(time.Now().Add(time.Minute), clawID, cc)
+	if got := idleResumeMessages(t, db, clawID); got != 1 {
+		t.Fatalf("an aborted delivery re-resumed the same stretch: %d messages", got)
+	}
+	if at, _ := clawIdleResumeState(t, db, clawID); at != latchedAt {
+		t.Fatalf("busy tick moved the resume latch to %d, want it unchanged at %d", at, latchedAt)
+	}
+
+	// A turn actually runs and finishes, and the claw stalls again: a
+	// genuinely new stretch earns a second resume — and the latch re-arms even
+	// though checkAgentIdle never runs on this notification-less hub.
+	cc.mu.Lock()
+	cc.finishTurnLocked()
+	cc.lastTurnFinishedAt = time.Now().Add(-11 * time.Minute)
+	cc.mu.Unlock()
+	s.checkAgentIdleResume(time.Now(), clawID, cc)
+	if got := idleResumeMessages(t, db, clawID); got != 2 {
+		t.Fatalf("new stretch injected %d resume messages in total, want 2", got)
+	}
+	if _, count := clawIdleResumeState(t, db, clawID); count != 2 {
+		t.Fatalf("attempt counter = %d after two resumes", count)
+	}
+}
+
+// The resume inherits the alert's eligibility rule and adds the two states in
+// which poking is actively wrong: a turn already in flight, and a claw the
+// no-progress watchdog has deliberately stopped.
+func TestAgentIdleResumeExclusions(t *testing.T) {
+	base := int64(1760000000000)
+	cases := []struct {
+		name             string
+		status           string
+		runID            string // "" = ad-hoc
+		phase            string
+		withPR           bool
+		pipeline         bool
+		busy             bool
+		noProgressPaused bool
+		idleFor          time.Duration // zero = well past the threshold
+		disabled         bool
+		want             bool
+	}{
+		{name: "adhoc-pipeline-stalled", status: "connected", pipeline: true, want: true},
+		{name: "run-agent-running-stalled", status: "connected", runID: "run-working", phase: taskRunPhaseAgentRunning, want: true},
+		// Still inside the threshold: the alert may already have fired at 5m,
+		// the resume waits for its own, longer escalation window.
+		{name: "below-threshold", status: "connected", pipeline: true, idleFor: 6 * time.Minute},
+		{name: "busy-turn", status: "connected", pipeline: true, busy: true},
+		// The no-progress watchdog stopped automatic continuation on purpose;
+		// resuming here would restart the loop it just broke.
+		{name: "no-progress-paused", status: "connected", pipeline: true, noProgressPaused: true},
+		// Delivered work waiting on a human is idle by definition.
+		{name: "adhoc-with-open-pr", status: "connected", pipeline: true, withPR: true},
+		{name: "run-pr-opened", status: "connected", runID: "run-propen", phase: taskRunPhasePROpened},
+		{name: "run-waiting-for-merge", status: "connected", runID: "run-merge", phase: taskRunPhaseWaitingForMerge},
+		{name: "run-terminal", status: "connected", runID: "run-done", phase: taskRunPhaseTerminal},
+		// Nothing automatic drives an interactive claw, so a long pause is its
+		// human thinking, not a stall.
+		{name: "adhoc-interactive-human-paced", status: "connected"},
+		{name: "not-connected", status: "error", pipeline: true},
+		{name: "feature-disabled", status: "connected", pipeline: true, disabled: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var liveness *types.LivenessConfig
+			if tc.disabled {
+				off := false
+				liveness = &types.LivenessConfig{IdleResume: &off}
+			}
+			s, db := newIdleResumeTestServer(t, liveness)
+			clawID := "claw-" + tc.name
+			insertSlackTestClaw(t, db, clawID, tc.status, 0, tc.runID, oldEnough)
+			if tc.runID != "" {
+				insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{
+					RunID: tc.runID, AttemptID: "attempt-" + tc.runID, ClawID: clawID, TenantID: "test-tenant-id",
+					OwnerType: taskRunOwnerFactory, Factory: "bugfix", Phase: tc.phase, StartedAt: base,
+				})
+			}
+			if tc.withPR {
+				insertSlackTestClawPR(t, db, "pr-"+clawID, clawID, "acme/app", 7, "https://github.com/acme/app/pull/7")
+			}
+			if tc.pipeline {
+				setClawPipelineStage(t, db, clawID, "implement")
+			}
+			idleFor := tc.idleFor
+			if idleFor == 0 {
+				idleFor = 15 * time.Minute
+			}
+			cc := idleTestConn(clawID, idleFor)
+			cc.awaitingResponse = tc.busy
+			cc.noProgressPaused = tc.noProgressPaused
+			s.checkAgentIdleResume(time.Now(), clawID, cc)
+
+			resumed := idleResumeMessages(t, db, clawID) > 0
+			if resumed != tc.want {
+				t.Fatalf("resumed=%v, want %v", resumed, tc.want)
+			}
+			if _, count := clawIdleResumeState(t, db, clawID); (count > 0) != tc.want {
+				t.Fatalf("attempt counter = %d, want fired=%v", count, tc.want)
+			}
+		})
+	}
+}
+
+// The runaway backstop: a claw that keeps waking, doing nothing, and idling
+// again clears the per-stretch latch every time, so only the lifetime cap
+// stops the poking. (The primary backstop is the no-progress watchdog, which
+// pauses such a claw after three identical outcomes — see the exclusion test.)
+func TestAgentIdleResumeStopsAtLifetimeCap(t *testing.T) {
+	s, db := newIdleResumeTestServer(t, nil)
+	const clawID = "resume-cap"
+	insertSlackTestClaw(t, db, clawID, "connected", 0, "", oldEnough)
+	setClawPipelineStage(t, db, clawID, "implement")
+
+	for i := 0; i < agentIdleResumeMaxAttempts+3; i++ {
+		// Each iteration is a genuinely distinct stretch: the claw woke, ran
+		// an empty turn and stalled again, so lastTurnFinishedAt moves forward
+		// every time and re-arms the per-stretch latch on its own. Only the
+		// lifetime cap can stop the poking. The steps are wider than
+		// agentIdleStretchSlack so no two stretches are mistaken for one.
+		cc := idleTestConn(clawID, time.Hour-time.Duration(i)*2*time.Minute)
+		s.checkAgentIdleResume(time.Now(), clawID, cc)
+	}
+	_, count := clawIdleResumeState(t, db, clawID)
+	if count != agentIdleResumeMaxAttempts {
+		t.Fatalf("attempt counter = %d, want the cap %d", count, agentIdleResumeMaxAttempts)
+	}
+	if got := idleResumeMessages(t, db, clawID); got != agentIdleResumeMaxAttempts {
+		t.Fatalf("injected %d resume messages, want the cap %d", got, agentIdleResumeMaxAttempts)
+	}
+}
+
+// The first tick after this feature reaches an existing hub must not poke
+// every long-idle claw in the database at once — including pipeline claws a
+// human deliberately walked away from hours ago. A stretch that began before
+// the resume baseline is parked: latched so it is never re-examined, never
+// injected, and never charged against the lifetime cap.
+func TestAgentIdleResumeParksStretchesOlderThanBaseline(t *testing.T) {
+	s, db := newIdleResumeTestServerAtEnable(t, nil)
+	const clawID = "resume-pre-existing"
+	insertSlackTestClaw(t, db, clawID, "connected", 0, "", oldEnough)
+	setClawPipelineStage(t, db, clawID, "implement")
+
+	// A claw that has been stalled for three hours, on the very first tick the
+	// feature ever runs: it is eligible in every other respect.
+	cc := idleTestConn(clawID, 3*time.Hour)
+	enabledAt := time.Now()
+	s.checkAgentIdleResume(enabledAt, clawID, cc)
+	if got := idleResumeMessages(t, db, clawID); got != 0 {
+		t.Fatalf("a stretch that predates the feature injected %d resume prompts, want 0", got)
+	}
+	at, count := clawIdleResumeState(t, db, clawID)
+	if at == 0 {
+		t.Fatal("pre-baseline stretch was not parked: it will be reconsidered on every future tick")
+	}
+	if count != 0 {
+		t.Fatalf("parking consumed %d of the lifetime cap, want 0", count)
+	}
+
+	// Still parked on later ticks, and across a hub restart (fresh clawConn,
+	// re-seeded lastTurnFinishedAt with a little drift).
+	s.checkAgentIdleResume(enabledAt.Add(5*time.Minute), clawID, cc)
+	restarted := &clawConn{id: clawID, tenantID: "test-tenant-id",
+		connectedAt:        time.Now().Add(-30 * time.Minute),
+		lastTurnFinishedAt: cc.lastTurnFinishedAt.Add(2 * time.Second)}
+	s.checkAgentIdleResume(enabledAt.Add(10*time.Minute), clawID, restarted)
+	if got := idleResumeMessages(t, db, clawID); got != 0 {
+		t.Fatalf("parked stretch was resumed later anyway: %d messages", got)
+	}
+
+	// A turn runs after the baseline and the claw stalls again. That stretch
+	// began where the feature could see it, so it is recovered normally —
+	// parking costs a genuinely stuck claw at most one stretch.
+	cc.mu.Lock()
+	cc.finishTurnLocked()
+	cc.mu.Unlock()
+	s.checkAgentIdleResume(enabledAt.Add(20*time.Minute), clawID, cc)
+	if got := idleResumeMessages(t, db, clawID); got != 1 {
+		t.Fatalf("post-baseline stretch injected %d resume prompts, want 1", got)
+	}
+}
+
+// The wiring, not the logic. checkClawStatus is the only production caller of
+// checkAgentIdleResume, and every other test here calls the check directly —
+// so without this one, deleting that call site leaves the suite green and
+// ships a recovery path that never fires, which is precisely the incident this
+// feature exists to prevent. This test drives the real watchdog pass against a
+// registered, stalled, eligible claw.
+func TestCheckClawStatusAutoResumesStalledClaw(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	const clawID = "watchdog-idle-resume"
+	_ = watchdogClaw(t, s, clawID)
+	if _, err := db.Exec(`UPDATE claws SET status='connected', pipeline_stage='implement' WHERE id=?`, clawID); err != nil {
+		t.Fatalf("make claw eligible: %v", err)
+	}
+	backdateAgentIdleResumeBaseline(t, s)
+	cc := watchdogClawConn(t, s, clawID)
+	cc.mu.Lock()
+	cc.connectedAt = time.Now().Add(-2 * time.Hour)
+	cc.lastTurnFinishedAt = time.Now().Add(-30 * time.Minute)
+	cc.mu.Unlock()
+
+	s.checkClawStatus()
+
+	if got := idleResumeMessages(t, db, clawID); got != 1 {
+		t.Fatalf("the watchdog pass injected %d resume prompts into a stalled claw, want 1 — is checkAgentIdleResume still called from checkClawStatus?", got)
+	}
+}
+
+// The message must stay hub-generic (the hub serves other factories) while
+// carrying both instructions the incident needed: stop waiting on background
+// work that never reported, and recover from the workspace instead of
+// starting over.
+func TestAgentIdleResumeMessageContent(t *testing.T) {
+	msg := agentIdleResumeMessage(12 * time.Minute)
+	for _, want := range []string{"12 minutes", "background or spawned work", "degradation path", "git log --oneline -15", "Do not start over"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("resume message missing %q: %s", want, msg)
+		}
+	}
+}
+
+func TestLivenessIdleResumeSettings(t *testing.T) {
+	settings := func(l *types.LivenessConfig) livenessSettings {
+		s, _ := newIdleResumeTestServer(t, l)
+		return s.livenessSettings()
+	}
+	if got := settings(nil); !got.idleResumeEnabled || got.idleResumeAfter != defaultIdleResumeAfter {
+		t.Fatalf("defaults: enabled=%v after=%v, want true/%v", got.idleResumeEnabled, got.idleResumeAfter, defaultIdleResumeAfter)
+	}
+	if got := settings(&types.LivenessConfig{IdleResumeAfter: "20m"}); got.idleResumeAfter != 20*time.Minute {
+		t.Fatalf("idle_resume_after 20m = %v", got.idleResumeAfter)
+	}
+	// Below the floor or unparsable: clamped/ignored, never honoured.
+	if got := settings(&types.LivenessConfig{IdleResumeAfter: "5s"}); got.idleResumeAfter != minIdleResumeAfter {
+		t.Fatalf("sub-minute idle_resume_after honoured: %v", got.idleResumeAfter)
+	}
+	if got := settings(&types.LivenessConfig{IdleResumeAfter: "bogus"}); got.idleResumeAfter != defaultIdleResumeAfter {
+		t.Fatalf("unparsable idle_resume_after = %v, want the default", got.idleResumeAfter)
+	}
+	off := false
+	if got := settings(&types.LivenessConfig{IdleResume: &off}); got.idleResumeEnabled {
+		t.Fatal("idle_resume: false did not disable auto-resume")
+	}
+}

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -117,6 +117,22 @@ func migrate(db *sql.DB) error {
 	if err := addColumn(db, "claws", "idle_since", `INTEGER NOT NULL DEFAULT 0`); err != nil {
 		return err
 	}
+	// idle_resume_at (epoch millis, 0 = not resumed) is the durable
+	// once-per-idle-stretch latch for the idle AUTO-RESUME recovery, kept
+	// separate from idle_since because the two fire at different thresholds
+	// and must not silence each other. Without it a hub restart would forget
+	// that a stretch was already poked and prompt the same stalled agent again
+	// on the first tick after boot.
+	if err := addColumn(db, "claws", "idle_resume_at", `INTEGER NOT NULL DEFAULT 0`); err != nil {
+		return err
+	}
+	// idle_resume_count is the lifetime attempt counter behind the runaway cap
+	// (agentIdleResumeMaxAttempts): a claw that wakes, replies nothing, and
+	// idles again would otherwise be poked forever, since each wake clears the
+	// per-stretch latch.
+	if err := addColumn(db, "claws", "idle_resume_count", `INTEGER NOT NULL DEFAULT 0`); err != nil {
+		return err
+	}
 	_, _ = db.Exec(`ALTER TABLE claw_prs ADD COLUMN last_comment_at TEXT NOT NULL DEFAULT ''`)
 	_, _ = db.Exec(`ALTER TABLE claw_prs ADD COLUMN pr_conditions_fired INTEGER NOT NULL DEFAULT 0`)
 	_, _ = db.Exec(`ALTER TABLE claw_prs ADD COLUMN permanent_failure_count INTEGER NOT NULL DEFAULT 0`)
@@ -321,7 +337,9 @@ func migrate(db *sql.DB) error {
 		trigger_actor_json TEXT NOT NULL DEFAULT '{}',
 		stop_comment_pending INTEGER NOT NULL DEFAULT 0,
 		no_progress_paused INTEGER NOT NULL DEFAULT 0,
-		idle_since INTEGER NOT NULL DEFAULT 0
+		idle_since INTEGER NOT NULL DEFAULT 0,
+		idle_resume_at INTEGER NOT NULL DEFAULT 0,
+		idle_resume_count INTEGER NOT NULL DEFAULT 0
 	);
 
 

--- a/pkg/hub/reaper.go
+++ b/pkg/hub/reaper.go
@@ -20,6 +20,8 @@ type livenessSettings struct {
 	gatewayUnhealthyMax                                  int
 	busyTurnMax, silentDeathMax                          time.Duration
 	prConditionsMaxWait                                  time.Duration
+	idleResumeEnabled                                    bool
+	idleResumeAfter                                      time.Duration
 }
 
 func (s *Server) livenessEnabled() bool {
@@ -42,6 +44,8 @@ func (s *Server) livenessSettings() livenessSettings {
 		busyTurnMax:         defaultBusyTurnMax,
 		silentDeathMax:      defaultSilentDeathMax,
 		prConditionsMaxWait: 2 * time.Hour,
+		idleResumeEnabled:   true,
+		idleResumeAfter:     defaultIdleResumeAfter,
 	}
 	s.mu.RLock()
 	l := livenessConfig(s.hubCfg)
@@ -71,6 +75,16 @@ func (s *Server) livenessSettings() livenessSettings {
 	}
 	cfg.silentDeathMax = parse(l.SilentDeathMax, cfg.silentDeathMax, "silent_death_max")
 	cfg.prConditionsMaxWait = parse(l.PRConditionsMaxWait, cfg.prConditionsMaxWait, "pr_conditions_max_wait")
+	if l.IdleResume != nil {
+		cfg.idleResumeEnabled = *l.IdleResume
+	}
+	cfg.idleResumeAfter = parse(l.IdleResumeAfter, cfg.idleResumeAfter, "idle_resume_after")
+	if cfg.idleResumeAfter < minIdleResumeAfter {
+		// Below a minute the threshold no longer describes a stall: a claw
+		// pausing for seconds between turns would be "resumed" mid-progress.
+		log.Printf("[reaper] idle_resume_after %s is below the minimum %s; using %s", cfg.idleResumeAfter, minIdleResumeAfter, minIdleResumeAfter)
+		cfg.idleResumeAfter = minIdleResumeAfter
+	}
 	if l.GatewayUnhealthyChecks != nil {
 		if *l.GatewayUnhealthyChecks <= 0 {
 			log.Printf("[reaper] invalid gateway_unhealthy_checks %d; using %d", *l.GatewayUnhealthyChecks, cfg.gatewayUnhealthyMax)

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -99,6 +99,14 @@ type Server struct {
 	agentIdleBaselineAt      time.Time
 	agentIdleBaselineCleared bool
 
+	// agentIdleResumeBaselineAt caches the persisted idle AUTO-RESUME baseline
+	// (see agentIdleResumeBaseline in agent_idle.go). Deliberately separate
+	// state from the alert baseline above: the resume never reads the
+	// notification config, so disabling Slack must not move its baseline.
+	agentIdleResumeBaselineMu      sync.Mutex
+	agentIdleResumeBaselineAt      time.Time
+	agentIdleResumeBaselineCleared bool
+
 	replicatedBootstrapEnvMu sync.Mutex
 	replicatedBootstrapEnv   map[string]map[string]string // temporary handoff while a Replicated VM becomes reachable
 
@@ -5789,6 +5797,10 @@ func (s *Server) checkClawStatus() {
 		// broadcasts, not idleness. Riding this 2-minute tick means a
 		// threshold of T fires between T and T+2m — deliberately not tightened.
 		s.checkAgentIdle(now, id, cc)
+		// Recovery for the same signal, at a longer threshold and independent
+		// of whether anyone is being notified (NEXT-713: an agent parked in a
+		// tool call that never returns is only unstuck by a prompt).
+		s.checkAgentIdleResume(now, id, cc)
 
 		// If user sent a message in the last 2 minutes, skip status broadcast
 		if now.Sub(lastUserMessageAt) < 2*time.Minute {

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -615,6 +615,29 @@ type LivenessConfig struct {
 	SilentDeathMax         string `yaml:"silent_death_max,omitempty" json:"silentDeathMax,omitempty"`
 	// PRConditionsMaxWait is the maximum time a PR may wait for pr_conditions before the run errors.
 	PRConditionsMaxWait string `yaml:"pr_conditions_max_wait,omitempty" json:"prConditionsMaxWait,omitempty"`
+	// IdleResume controls the idle auto-resume recovery (default on). It lives
+	// here and not under notifications because muting an alert channel must
+	// never disable recovery: an agent parked in a tool call that never
+	// returns is only unstuck by a prompt, and before this the only thing that
+	// ever delivered one was a human typing "continue".
+	IdleResume *bool `yaml:"idle_resume,omitempty" json:"idleResume,omitempty"`
+	// IdleResumeAfter is how long an eligible claw must sit with no turn
+	// running before the hub injects the resume prompt. Deliberately longer
+	// than the agent_idle alert threshold so the alert stays the early signal
+	// and the resume is the escalation.
+	//
+	// Set it ABOVE the longest legitimate wait between turns for the factory
+	// it applies to. The hub cannot distinguish "stalled in a tool call that
+	// will never return" from "correctly waiting longer than this for
+	// something real": a claw that legitimately waits longer is poked and told
+	// to stop waiting, which is at best a wasted turn and at worst pushes the
+	// agent off a wait it should have kept. Because the attempt counter behind
+	// the runaway cap is a LIFETIME counter (it is not reset by a turn, or the
+	// cap could never be reached in the wake-do-nothing-idle loop it exists to
+	// bound), every premature poke permanently consumes part of that claw's
+	// recovery budget — a threshold set too low can exhaust the budget on
+	// healthy waits and leave nothing for the stall it was added for.
+	IdleResumeAfter string `yaml:"idle_resume_after,omitempty" json:"idleResumeAfter,omitempty"`
 }
 
 // IntegrationsConfig holds configs for external integrations.


### PR DESCRIPTION
## The gap

An agent that calls a tool which never returns is invisible to every recovery path the hub has.

`sessions_yield` **ends the turn**, so to the hub the claw looks idle-and-healthy: pongs answer, no turn is in flight, nothing is queued. So the busy-turn watchdog (needs an open turn) misses it, `sendStreamingNudge` drops it (`turnOpen` false), and the restart/session-rotation resume never fires (a plain WS reconnect is neither).

On NEXT-713 that left claw `545693d2` blocked for **1h44min**:

```
13:40:02  sessions_yield "Waiting for correctness, spec-runtime, simplicity, and the security retry"
13:46:32  hub records agent_idle (6 min)   <- last automatic action
14:06:10  bridge reconnects cleanly        <- neither restart nor rotation, no resume
13:40:03 -> 15:24:44   ZERO activity
15:24:44  human types "skip to the next step"
```

The hub *knew* at 13:46. `agent_idle` is notification-only and latched once per stretch, so the detection died in a Slack alert nobody was watching.

## The change

`checkAgentIdleResume` runs on the same watchdog tick and, after `liveness.idle_resume_after` (default 10m), injects the prompt a human would have typed.

**Not part of the notification path.** Muting a channel must never disable recovery, so it reads liveness config only, with its own baseline and latch. There is a regression test that runs it on a hub with no `notifications` block at all.

**Eligibility is shared with the alert, unchanged.** `agentIdleEligible` already excludes a claw with a PR out, one past the working phase, and one driven by nothing but a human — none of those get poked.

**Bounded three ways:**

| bound | mechanism |
| --- | --- |
| one per idle stretch | durable `idle_resume_at` latch on the same stretch anchor the alert uses, so restarts and reconnects cannot re-poke |
| lifetime cap | `idle_resume_count`, 10 attempts, logged when reached |
| no-progress backstop | hard skip while `no_progress_paused` |

The latch re-arms only when `lastTurnFinishedAt` actually moves. Observing a turn *reservation* is not enough — `abortTurnLocked` releases one without finishing a turn, which would otherwise let the same stretch be resumed twice.

Stretches that began before the feature was enabled are **parked** (latched, not injected, no cap spent), so the first tick against the production database does not poke every long-idle claw at once.

## Config

```yaml
liveness:
  idle_resume: true          # default
  idle_resume_after: 10m     # default, floor 1m
```

Set `idle_resume_after` above the longest legitimate inter-turn wait for the factory — the hub cannot tell a dead wait from a slow one, and because the cap is a lifetime counter, premature pokes permanently consume a claw's recovery budget. That tradeoff is documented on the field.

## Companion

[next_tooling#24](https://github.com/FasterWayToFatLoss/next_tooling/pull/24) adds the review-loop rule for what to do when this message arrives. The two only work together: this PR supplies the external clock, that one says what to do with it.

## Verification

```
gofmt -l <changed files>                                          -> clean
go build ./...                                                    -> OK
go test ./pkg/hub/ -run 'Idle|Resume|Liveness|Watchdog|Reaper|SilentDeath|Turn'  -> ok (70 tests)
go test ./pkg/types/                                              -> ok
```

The wiring test was verified to actually catch a missing call site: deleting `s.checkAgentIdleResume(now, id, cc)` from `checkClawStatus` fails `TestCheckClawStatusAutoResumesStalledClaw` and nothing else. Run independently, call site restored.

Three tests in `pkg/hub` fail on this branch — `TestDoneSignalRejectedWhenPRPersistenceFails`, `TestHandleClawDoneSignal_IssueLessWorkflowWatchesPR`, `TestCompleteIssueLessDoneClawKeepsRunningOnStoreFailure`. Pre-existing: they hit the live GitHub API (422/404) and fail identically in a clean worktree at `origin/main`. Verified there, not assumed.

## Not done

No UI/API exposure of the new columns, no notification when a resume fires (logged under `[agent-idle]`), no change to `agentIdleEligible` or to the alert's behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)