### PR TITLE
fix(hub): back off before replacing a claw that died young

### DIFF
--- a/pkg/hub/factory_triggers.go
+++ b/pkg/hub/factory_triggers.go
@@ -44,6 +44,34 @@ func triggerPayloadJSON(payload any) string {
 	return string(b)
 }
 
+// factoryTriggerBackoff is the wait a trigger owes after n failed attempts:
+// min(30s * 2^n, 30m). Both the creation-failure path and the dead-claw path
+// climb this same ladder, so a trigger that keeps failing keeps backing off
+// whether it dies before or after its claw exists.
+func factoryTriggerBackoff(retryCount int) time.Duration {
+	backoff := 30 * time.Second
+	for i := 0; i < retryCount && backoff < 30*time.Minute; i++ {
+		backoff *= 2
+	}
+	if backoff > 30*time.Minute {
+		backoff = 30 * time.Minute
+	}
+	return backoff
+}
+
+// triggerSourceSkipsBackoff reports whether a source may retry without waiting.
+// The backoff exists to break a tight loop, and only the poller can loop: it
+// re-sees the same trigger every tick and would recreate the claw forever. A
+// plain "webhook" source (the external integration) is edge-triggered — one
+// delivery per external event — so it cannot spin on its own, and delaying it
+// would only make a deliberate re-fire look ignored. Note this is a narrow
+// exemption: integration webhooks label themselves "<integration> webhook" and
+// do back off, because their events can repeat on their own (label churn,
+// comment edits).
+func triggerSourceSkipsBackoff(source string) bool {
+	return source == "webhook"
+}
+
 func (s *Server) claimFactoryTrigger(factoryName, integration, triggerKey, source string, payload any) (bool, error) {
 	if factoryName == "" || integration == "" || triggerKey == "" {
 		return false, fmt.Errorf("invalid factory trigger claim")
@@ -72,13 +100,15 @@ func (s *Server) claimFactoryTrigger(factoryName, integration, triggerKey, sourc
 	var clawID, triggerStatus, clawStatus string
 	var retryCount int
 	var updatedAt time.Time
+	var clawAgeSeconds sql.NullInt64
 	err = tx.QueryRow(`
-		SELECT COALESCE(ft.claw_id,''), ft.status, COALESCE(c.status,''), ft.retry_count, ft.updated_at
+		SELECT COALESCE(ft.claw_id,''), ft.status, COALESCE(c.status,''), ft.retry_count, ft.updated_at,
+		       CAST(strftime('%s','now') AS INTEGER) - CAST(strftime('%s', c.created_at) AS INTEGER)
 		  FROM factory_triggers ft
 		  LEFT JOIN claws c ON c.id = ft.claw_id
 		 WHERE ft.factory_name=? AND ft.integration=? AND ft.trigger_key=?`,
 		factoryName, integration, triggerKey,
-	).Scan(&clawID, &triggerStatus, &clawStatus, &retryCount, &updatedAt)
+	).Scan(&clawID, &triggerStatus, &clawStatus, &retryCount, &updatedAt, &clawAgeSeconds)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return false, fmt.Errorf("factory trigger disappeared while claiming")
@@ -110,16 +140,8 @@ func (s *Server) claimFactoryTrigger(factoryName, integration, triggerKey, sourc
 		}
 		return false, tx.Commit()
 	}
-	if clawID == "" && triggerStatus == "failed" && source != "webhook" {
-		// A failed attempt with count n waits min(30s * 2^n, 30m) before reclaiming.
-		backoff := 30 * time.Second
-		for i := 0; i < retryCount && backoff < 30*time.Minute; i++ {
-			backoff *= 2
-		}
-		if backoff > 30*time.Minute {
-			backoff = 30 * time.Minute
-		}
-		if now.Before(updatedAt.Add(backoff)) {
+	if clawID == "" && triggerStatus == "failed" && !triggerSourceSkipsBackoff(source) {
+		if now.Before(updatedAt.Add(factoryTriggerBackoff(retryCount))) {
 			_, err = tx.Exec(`UPDATE factory_triggers SET last_seen_at=? WHERE factory_name=? AND integration=? AND trigger_key=?`, now, factoryName, integration, triggerKey)
 			if err != nil {
 				return false, err
@@ -128,13 +150,51 @@ func (s *Server) claimFactoryTrigger(factoryName, integration, triggerKey, sourc
 		}
 	}
 
-	// Reclaim path: reached only when the linked claw is missing or already in a
-	// terminal state ('deleted'/'error'), or the trigger has no claw and is not
-	// actively being processed. No cleanup of the old claw is needed here — a
-	// claw reaches 'error' via stopAgentTerminalWithReason, which already calls
-	// finishRunByClawID, and the boot reaper sweeps any still-'running' run whose
-	// claw is 'error'/'deleted'/missing. (A prior cleanup block here was dead code:
-	// its guard duplicated the "already claimed" block above, which returns first.)
+	// bornDeadClawMax separates a claw that never got going from one that did its
+	// job and was cleaned up. Both end up 'deleted', so status alone cannot tell
+	// them apart, and charging the long-lived one a retry would make every
+	// SUCCESSFUL ticket pay a backoff the next time its trigger fires — with the
+	// counter ratcheting, because nothing ever resets it. The measured churn is
+	// claws dying within ~3 minutes of bootstrap, so the cutoff sits well above
+	// that and well below any real run.
+	const bornDeadClawMax = 10 * 60 // seconds
+
+	clawDiedYoung := clawAgeSeconds.Valid && clawAgeSeconds.Int64 <= bornDeadClawMax
+	if clawID != "" && (clawStatus == "error" || clawStatus == "deleted") && clawDiedYoung {
+		// The claw this trigger already paid for died young. Charge it as a failed
+		// attempt instead of dropping into the reclaim below, which reclaims with
+		// no wait and no retry_count bump. The failed-trigger guard above cannot
+		// cover this case: a claw that dies *after* creation still has its id on
+		// the trigger, so the guard's clawID=="" never holds, and every poll tick
+		// re-created an identical claw the moment the previous one errored. A
+		// deterministic failure (a build gate that always fails, a bootstrap that
+		// always crashes) then burns several claws per ticket instead of one.
+		// Recording the failure here routes the next tick through the backoff
+		// above, so the retry ladder is the same one a creation failure climbs.
+		_, err = tx.Exec(`
+			UPDATE factory_triggers
+			   SET claw_id='', status='failed', retry_count=retry_count+1, last_seen_at=?, updated_at=?
+			 WHERE factory_name=? AND integration=? AND trigger_key=?`,
+			now, now, factoryName, integration, triggerKey,
+		)
+		if err != nil {
+			return false, err
+		}
+		if !triggerSourceSkipsBackoff(source) {
+			return false, tx.Commit()
+		}
+		// Exempt sources still get charged the retry, but reclaim immediately —
+		// see triggerSourceSkipsBackoff.
+	}
+
+	// Reclaim path: reached when the trigger has no claw and is not actively
+	// being processed, when its claw row is simply gone from the database, or
+	// when an exempt source is retrying a dead claw. No cleanup of the old claw is
+	// needed here — a claw reaches 'error' via stopAgentTerminalWithReason, which
+	// already calls finishRunByClawID, and the boot reaper sweeps any still-'running'
+	// run whose claw is 'error'/'deleted'/missing. (A prior cleanup block here was
+	// dead code: its guard duplicated the "already claimed" block above, which
+	// returns first.)
 	_, err = tx.Exec(`
 		UPDATE factory_triggers
 		   SET trigger_source=?, trigger_payload=?, claw_id='', status='claimed', last_seen_at=?, updated_at=?
@@ -151,9 +211,16 @@ func (s *Server) completeFactoryTrigger(factoryName, integration, triggerKey, cl
 	if clawID == "" {
 		return fmt.Errorf("complete factory trigger: missing claw id")
 	}
+	// retry_count is deliberately not reset here. Completing a claim only means a
+	// claw was created, not that the work succeeded, and the dead-claw path in
+	// claimFactoryTrigger runs after this: zeroing here would pin every retry at
+	// the first rung (create → die → 30s → create → die → 30s …) and give back
+	// the tight loop the backoff is meant to break. The counter is per trigger
+	// key, so it stays bounded to one ticket, capped at 30m; a human who wants an
+	// immediate retry has the exempt-source path, not a counter reset.
 	res, err := s.db.Exec(`
 		UPDATE factory_triggers
-		   SET claw_id=?, status='active', retry_count=0, updated_at=?
+		   SET claw_id=?, status='active', updated_at=?
 		 WHERE factory_name=? AND integration=? AND trigger_key=?`,
 		clawID, now(), factoryName, integration, triggerKey,
 	)

--- a/pkg/hub/factory_triggers_test.go
+++ b/pkg/hub/factory_triggers_test.go
@@ -2,6 +2,7 @@ package hub
 
 import (
 	"encoding/json"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -115,7 +116,7 @@ func TestClaimFactoryTriggerSkipsActiveSameFactory(t *testing.T) {
 	}
 }
 
-func TestClaimFactoryTriggerReclaimsErroredClaw(t *testing.T) {
+func TestClaimFactoryTriggerReclaimsErroredClawAfterBackoff(t *testing.T) {
 	s := newFactoryTriggerTestServer(t)
 	triggerKey := factoryTriggerKey("shortcut", "sc-123")
 	_, _ = s.db.Exec(`INSERT INTO claws(id, tenant_id, name, template, status, created_at) VALUES(?,?,?,?,?,?)`,
@@ -136,12 +137,21 @@ func TestClaimFactoryTriggerReclaimsErroredClaw(t *testing.T) {
 	if err != nil {
 		t.Fatalf("second claim: %v", err)
 	}
+	if claimed {
+		t.Fatal("expected the dead claw to be charged a retry, not reclaimed on the spot")
+	}
+
+	ageTrigger(t, s, triggerKey, 61*time.Second)
+	claimed, err = s.claimFactoryTrigger("qa", "shortcut", triggerKey, "poll", nil)
+	if err != nil {
+		t.Fatalf("claim after backoff: %v", err)
+	}
 	if !claimed {
-		t.Fatal("expected errored claw to be reclaimable")
+		t.Fatal("expected errored claw to be reclaimable once the backoff elapsed")
 	}
 }
 
-func TestClaimFactoryTriggerReclaimsDeletedClaw(t *testing.T) {
+func TestClaimFactoryTriggerReclaimsDeletedClawAfterBackoff(t *testing.T) {
 	s := newFactoryTriggerTestServer(t)
 	triggerKey := factoryTriggerKey("shortcut", "sc-123")
 	_, _ = s.db.Exec(`INSERT INTO claws(id, tenant_id, name, template, status, created_at) VALUES(?,?,?,?,?,?)`,
@@ -162,8 +172,17 @@ func TestClaimFactoryTriggerReclaimsDeletedClaw(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reclaim: %v", err)
 	}
+	if claimed {
+		t.Fatal("expected the dead claw to be charged a retry, not reclaimed on the spot")
+	}
+
+	ageTrigger(t, s, triggerKey, 61*time.Second)
+	claimed, err = s.claimFactoryTrigger("qa", "shortcut", triggerKey, "poll", nil)
+	if err != nil {
+		t.Fatalf("claim after backoff: %v", err)
+	}
 	if !claimed {
-		t.Fatal("expected deleted claw to be reclaimable")
+		t.Fatal("expected deleted claw to be reclaimable once the backoff elapsed")
 	}
 }
 
@@ -228,7 +247,10 @@ func TestFailedFactoryTriggerBackoffAndWebhookBypass(t *testing.T) {
 	}
 }
 
-func TestCompleteFactoryTriggerResetsRetryCount(t *testing.T) {
+// Completing a claim means a claw exists, not that the ticket succeeded, so the
+// retry ladder must survive it — otherwise a claw that keeps dying after
+// creation retries at a flat 30s forever.
+func TestCompleteFactoryTriggerKeepsRetryCount(t *testing.T) {
 	s := newFactoryTriggerTestServer(t)
 	key := factoryTriggerKey("linear", "ELA-789")
 	claimed, err := s.claimFactoryTrigger("code", "linear", key, "poll", nil)
@@ -243,7 +265,260 @@ func TestCompleteFactoryTriggerResetsRetryCount(t *testing.T) {
 	if err := s.db.QueryRow(`SELECT retry_count FROM factory_triggers WHERE trigger_key=?`, key).Scan(&retryCount); err != nil {
 		t.Fatal(err)
 	}
+	if retryCount != 1 {
+		t.Fatalf("retry_count = %d, want 1", retryCount)
+	}
+}
+
+// seedTriggerWithClaw creates a claw row in the given status and links it to a
+// freshly claimed trigger, i.e. the state the hub is in right after a claw was
+// provisioned for a ticket.
+func seedTriggerWithClaw(t *testing.T, s *Server, factory, integration, key, clawID, clawStatus, source string) {
+	t.Helper()
+	claimed, err := s.claimFactoryTrigger(factory, integration, key, source, nil)
+	if err != nil {
+		t.Fatalf("seed claim: %v", err)
+	}
+	if !claimed {
+		t.Fatal("seed claim: expected trigger to be claimable")
+	}
+	linkClawToTrigger(t, s, factory, integration, key, clawID, clawStatus)
+}
+
+// linkClawToTrigger creates a claw row in the given status and completes an
+// open claim with it, i.e. what a provisioning path does after claiming.
+func linkClawToTrigger(t *testing.T, s *Server, factory, integration, key, clawID, clawStatus string) {
+	t.Helper()
+	if _, err := s.db.Exec(`INSERT INTO claws(id, tenant_id, name, template, status, created_at) VALUES(?,?,?,?,?,?)`,
+		clawID, "tenant", clawID, "template", clawStatus, now()); err != nil {
+		t.Fatalf("insert claw %s: %v", clawID, err)
+	}
+	if err := s.completeFactoryTrigger(factory, integration, key, clawID); err != nil {
+		t.Fatalf("complete claim with %s: %v", clawID, err)
+	}
+}
+
+func triggerRetryCount(t *testing.T, s *Server, key string) int {
+	t.Helper()
+	var retryCount int
+	if err := s.db.QueryRow(`SELECT retry_count FROM factory_triggers WHERE trigger_key=?`, key).Scan(&retryCount); err != nil {
+		t.Fatalf("read retry_count: %v", err)
+	}
+	return retryCount
+}
+
+func ageTrigger(t *testing.T, s *Server, key string, d time.Duration) {
+	t.Helper()
+	if _, err := s.db.Exec(`UPDATE factory_triggers SET updated_at=? WHERE trigger_key=?`, now().Add(-d), key); err != nil {
+		t.Fatalf("age trigger: %v", err)
+	}
+}
+
+// A claw that dies after creation must be charged a retry instead of being
+// reclaimed on the next tick, which is what produced several identical claws
+// per ticket for a deterministic failure.
+func TestClaimFactoryTriggerChargesDeadClawAsFailedAttempt(t *testing.T) {
+	cases := []struct {
+		name        string
+		clawStatus  string
+		source      string
+		wantClaimed bool
+	}{
+		{name: "errored claw polled", clawStatus: "error", source: "poll", wantClaimed: false},
+		{name: "deleted claw polled", clawStatus: "deleted", source: "poll", wantClaimed: false},
+		{name: "errored claw integration webhook", clawStatus: "error", source: "linear webhook", wantClaimed: false},
+		{name: "errored claw exempt webhook", clawStatus: "error", source: "webhook", wantClaimed: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newFactoryTriggerTestServer(t)
+			key := factoryTriggerKey("linear", "ELA-dead")
+			seedTriggerWithClaw(t, s, "code", "linear", key, "claw-dead", tc.clawStatus, "poll")
+
+			claimed, err := s.claimFactoryTrigger("code", "linear", key, tc.source, nil)
+			if err != nil {
+				t.Fatalf("claim after claw death: %v", err)
+			}
+			if claimed != tc.wantClaimed {
+				t.Fatalf("claim after claw death = %v, want %v", claimed, tc.wantClaimed)
+			}
+			if got := triggerRetryCount(t, s, key); got != 1 {
+				t.Fatalf("retry_count = %d, want 1", got)
+			}
+		})
+	}
+}
+
+// The dead-claw path must climb the same ladder a creation failure climbs, and
+// completing a claim must not knock it back down to the first rung.
+func TestClaimFactoryTriggerDeadClawBackoffLadder(t *testing.T) {
+	s := newFactoryTriggerTestServer(t)
+	key := factoryTriggerKey("linear", "ELA-ladder")
+	claimed, err := s.claimFactoryTrigger("code", "linear", key, "poll", nil)
+	if err != nil || !claimed {
+		t.Fatalf("initial claim = %v, %v", claimed, err)
+	}
+
+	// The wait is computed from the post-increment retry_count, so the first
+	// rung after a claw dies is 60s, the same rung a creation failure lands on.
+	for attempt, wait := range []time.Duration{60 * time.Second, 120 * time.Second, 240 * time.Second} {
+		linkClawToTrigger(t, s, "code", "linear", key, fmt.Sprintf("claw-ladder-%d", attempt), "error")
+
+		claimed, err = s.claimFactoryTrigger("code", "linear", key, "poll", nil)
+		if err != nil {
+			t.Fatalf("attempt %d: detect death: %v", attempt, err)
+		}
+		if claimed {
+			t.Fatalf("attempt %d: dead claw reclaimed with no wait", attempt)
+		}
+		if got, want := triggerRetryCount(t, s, key), attempt+1; got != want {
+			t.Fatalf("attempt %d: retry_count = %d, want %d", attempt, got, want)
+		}
+
+		ageTrigger(t, s, key, wait-time.Second)
+		claimed, err = s.claimFactoryTrigger("code", "linear", key, "poll", nil)
+		if err != nil {
+			t.Fatalf("attempt %d: claim inside backoff: %v", attempt, err)
+		}
+		if claimed {
+			t.Fatalf("attempt %d: reclaimed %s after death, want wait of %s", attempt, wait-time.Second, wait)
+		}
+
+		ageTrigger(t, s, key, wait+time.Second)
+		claimed, err = s.claimFactoryTrigger("code", "linear", key, "poll", nil)
+		if err != nil {
+			t.Fatalf("attempt %d: claim after backoff: %v", attempt, err)
+		}
+		if !claimed {
+			t.Fatalf("attempt %d: not reclaimed %s after death, want reclaim after %s", attempt, wait+time.Second, wait)
+		}
+	}
+}
+
+func TestFactoryTriggerBackoffCap(t *testing.T) {
+	cases := []struct {
+		retryCount int
+		want       time.Duration
+	}{
+		{retryCount: 0, want: 30 * time.Second},
+		{retryCount: 1, want: time.Minute},
+		{retryCount: 5, want: 16 * time.Minute},
+		{retryCount: 6, want: 30 * time.Minute},
+		{retryCount: 40, want: 30 * time.Minute},
+	}
+	for _, tc := range cases {
+		if got := factoryTriggerBackoff(tc.retryCount); got != tc.want {
+			t.Fatalf("factoryTriggerBackoff(%d) = %s, want %s", tc.retryCount, got, tc.want)
+		}
+	}
+}
+
+func TestClaimFactoryTriggerDeadClawBackoffIsCapped(t *testing.T) {
+	s := newFactoryTriggerTestServer(t)
+	key := factoryTriggerKey("linear", "ELA-cap")
+	seedTriggerWithClaw(t, s, "code", "linear", key, "claw-cap", "error", "poll")
+	if _, err := s.db.Exec(`UPDATE factory_triggers SET retry_count=20 WHERE trigger_key=?`, key); err != nil {
+		t.Fatalf("seed retry_count: %v", err)
+	}
+
+	claimed, err := s.claimFactoryTrigger("code", "linear", key, "poll", nil)
+	if err != nil {
+		t.Fatalf("detect death: %v", err)
+	}
+	if claimed {
+		t.Fatal("dead claw reclaimed with no wait")
+	}
+
+	ageTrigger(t, s, key, 29*time.Minute)
+	claimed, err = s.claimFactoryTrigger("code", "linear", key, "poll", nil)
+	if err != nil {
+		t.Fatalf("claim inside cap: %v", err)
+	}
+	if claimed {
+		t.Fatal("reclaimed after 29m, want 30m cap")
+	}
+
+	ageTrigger(t, s, key, 31*time.Minute)
+	claimed, err = s.claimFactoryTrigger("code", "linear", key, "poll", nil)
+	if err != nil {
+		t.Fatalf("claim past cap: %v", err)
+	}
+	if !claimed {
+		t.Fatal("not reclaimed after 31m, want backoff capped at 30m")
+	}
+}
+
+// A ticket nobody has attempted yet must never inherit a wait.
+func TestClaimFactoryTriggerFreshTriggerDoesNotWait(t *testing.T) {
+	s := newFactoryTriggerTestServer(t)
+	failedKey := factoryTriggerKey("linear", "ELA-failed")
+	seedTriggerWithClaw(t, s, "code", "linear", failedKey, "claw-failed", "error", "poll")
+	if claimed, err := s.claimFactoryTrigger("code", "linear", failedKey, "poll", nil); err != nil || claimed {
+		t.Fatalf("dead claw claim = %v, %v; want false, nil", claimed, err)
+	}
+
+	freshKey := factoryTriggerKey("linear", "ELA-fresh")
+	claimed, err := s.claimFactoryTrigger("code", "linear", freshKey, "poll", nil)
+	if err != nil || !claimed {
+		t.Fatalf("fresh trigger claim = %v, %v; want true, nil", claimed, err)
+	}
+}
+
+// A trigger whose claw row is gone from the database never recorded a failure,
+// so it is reclaimed straight away.
+func TestClaimFactoryTriggerMissingClawRowReclaimsImmediately(t *testing.T) {
+	s := newFactoryTriggerTestServer(t)
+	key := factoryTriggerKey("linear", "ELA-gone")
+	seedTriggerWithClaw(t, s, "code", "linear", key, "claw-gone", "running", "poll")
+	if _, err := s.db.Exec(`DELETE FROM claws WHERE id=?`, "claw-gone"); err != nil {
+		t.Fatalf("delete claw row: %v", err)
+	}
+
+	claimed, err := s.claimFactoryTrigger("code", "linear", key, "poll", nil)
+	if err != nil || !claimed {
+		t.Fatalf("claim with missing claw row = %v, %v; want true, nil", claimed, err)
+	}
+	if got := triggerRetryCount(t, s, key); got != 0 {
+		t.Fatalf("retry_count = %d, want 0", got)
+	}
+}
+
+// A claw that ran for a while and was then cleaned up is not churn. Charging it
+// a retry would make every successful ticket pay a backoff the next time its
+// trigger fires, and — since nothing ever resets retry_count — the wait would
+// ratchet up for the rest of that trigger's life.
+func TestClaimFactoryTriggerDoesNotChargeLongLivedClaw(t *testing.T) {
+	s := newFactoryTriggerTestServer(t)
+	triggerKey := factoryTriggerKey("shortcut", "sc-long-lived")
+	// Created two hours ago: this claw did its job before being deleted.
+	if _, err := s.db.Exec(`INSERT INTO claws(id, tenant_id, name, template, status, created_at) VALUES(?,?,?,?,?,?)`,
+		"claw-old", "tenant", "claw", "template", "deleted", now().Add(-2*time.Hour)); err != nil {
+		t.Fatalf("seed claw: %v", err)
+	}
+
+	claimed, err := s.claimFactoryTrigger("qa", "shortcut", triggerKey, "poll", nil)
+	if err != nil {
+		t.Fatalf("initial claim: %v", err)
+	}
+	if !claimed {
+		t.Fatal("expected initial claim")
+	}
+	if err := s.completeFactoryTrigger("qa", "shortcut", triggerKey, "claw-old"); err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+
+	claimed, err = s.claimFactoryTrigger("qa", "shortcut", triggerKey, "poll", nil)
+	if err != nil {
+		t.Fatalf("second claim: %v", err)
+	}
+	if !claimed {
+		t.Fatal("a long-lived claw must be reclaimed immediately, not charged a retry")
+	}
+	var retryCount int
+	if err := s.db.QueryRow(`SELECT retry_count FROM factory_triggers WHERE trigger_key=?`, triggerKey).Scan(&retryCount); err != nil {
+		t.Fatalf("read retry_count: %v", err)
+	}
 	if retryCount != 0 {
-		t.Fatalf("retry_count = %d, want 0", retryCount)
+		t.Fatalf("a successful run must not leave a retry charge behind, got retry_count=%d", retryCount)
 	}
 }

--- a/pkg/hub/github_webhook_exclude_labels_test.go
+++ b/pkg/hub/github_webhook_exclude_labels_test.go
@@ -63,7 +63,10 @@ func TestGitHubPRFactoryLabelsAndExcludeLabelsMatchBackingIssueLabels(t *testing
 	waitForGitHubPRClaw(t, db, "https://github.com/elastic/claw/pull/43")
 }
 
-func TestGitHubPRPollRecreatesClawAfterError(t *testing.T) {
+// A PR whose claw errored gets a replacement, but only after the trigger has
+// served its backoff — otherwise every poll tick recreates the claw the moment
+// the previous one dies.
+func TestGitHubPRPollRecreatesClawAfterErrorBackoff(t *testing.T) {
 	factory := &types.FactoryConfig{
 		Name:        "generic-pr",
 		Integration: "github",
@@ -93,7 +96,7 @@ func TestGitHubPRPollRecreatesClawAfterError(t *testing.T) {
 		t.Fatalf("mark claw errored: %v", err)
 	}
 
-	s.processGitHubPRPollItem(githubPRPollItem{
+	pollItem := githubPRPollItem{
 		Number:  46,
 		Title:   "Test PR",
 		HTMLURL: payload.PullRequest.HTMLURL,
@@ -107,14 +110,28 @@ func TestGitHubPRPollRecreatesClawAfterError(t *testing.T) {
 		Base: struct {
 			Ref string `json:"ref"`
 		}{Ref: "main"},
-	}, []*types.FactoryConfig{factory}, "elastic/claw", "")
+	}
 
+	s.processGitHubPRPollItem(pollItem, []*types.FactoryConfig{factory}, "elastic/claw", "")
 	var count int
 	if err := db.QueryRow(`SELECT COUNT(*) FROM claw_prs WHERE pr_url=?`, payload.PullRequest.HTMLURL).Scan(&count); err != nil {
 		t.Fatalf("count PR claws: %v", err)
 	}
+	if count != 1 {
+		t.Fatalf("expected the errored claw to cost a backoff, got %d claws", count)
+	}
+
+	triggerKey := factoryTriggerKey("github-pr", payload.PullRequest.HTMLURL)
+	if _, err := db.Exec(`UPDATE factory_triggers SET updated_at=? WHERE trigger_key=?`, now().Add(-61*time.Second), triggerKey); err != nil {
+		t.Fatalf("age trigger past backoff: %v", err)
+	}
+
+	s.processGitHubPRPollItem(pollItem, []*types.FactoryConfig{factory}, "elastic/claw", "")
+	if err := db.QueryRow(`SELECT COUNT(*) FROM claw_prs WHERE pr_url=?`, payload.PullRequest.HTMLURL).Scan(&count); err != nil {
+		t.Fatalf("count PR claws: %v", err)
+	}
 	if count != 2 {
-		t.Fatalf("expected a replacement PR claw after error, got %d claws", count)
+		t.Fatalf("expected a replacement PR claw after the backoff, got %d claws", count)
 	}
 }
 


### PR DESCRIPTION
## The problem, measured

**42% of August's claws (10 of 24) died within three minutes** of bootstrap. These were not distinct attempts at distinct problems:

| ticket | claws burned |
| --- | --- |
| NEXT-656 | 4 |
| NEXT-655 | 4 |
| NEXT-652 | 3 |

Each one a fresh sandbox for the same deterministic failure.

## The cause

`claimFactoryTrigger` **already has** an exponential backoff for exactly this — and it could never fire:

```go
if clawID == "" && triggerStatus == "failed" && source != "webhook" {
```

The guard requires `clawID == ""`. But a claw that dies *after* creation still has its id on the trigger, so the condition never held. Execution fell through to the reclaim path below — whose own comment says it is reached when "the linked claw is missing or already in a terminal state" — and that path re-claims **with no wait and no `retry_count` bump**. The next poll tick then built an identical claw, immediately, forever.

## The fix

Charge that case as a failed attempt so the next tick climbs the same ladder a creation failure already climbs. The backoff calculation is extracted rather than duplicated.

Two things this must not break, both of which cost more than the original bug:

**A claw that ran for two hours and was cleaned up also ends `deleted`.** Status alone cannot tell churn from success. Only claws that died within ten minutes of creation are charged — comfortably above the observed three-minute deaths and below any real run. Without that cutoff, **every successful ticket would pay a backoff on its next trigger**, with the counter ratcheting up, because nothing ever resets `retry_count` and `factory_triggers` rows are never deleted.

**`completeFactoryTrigger` no longer zeroes `retry_count`.** It fires when a claw is *created*, not when the work succeeds — zeroing there pins the ladder at its first rung: create, die, wait 30s, create, die, wait 30s. The counter is per trigger key and capped at 30 minutes.

The webhook exemption stays, now with its reasoning written down: only the poller can spin on its own, since it re-sees the same trigger every tick; a plain `webhook` source is edge-triggered. Integration webhooks label themselves `<integration> webhook` and **do** back off, since their events can repeat on their own.

## Verification

```
gofmt -l  ->  clean
go build ./...  ->  OK
go test ./pkg/hub/ -run 'FactoryTrigger|Trigger|ExcludeLabel|GitHubPRPoll'  ->  ok
```

The regression test for the ten-minute cutoff was falsified: forcing `clawDiedYoung := true` makes it fail with

```
factory_triggers_test.go:515: a long-lived claw must be reclaimed immediately, not charged a retry
```

`TestGitHubPRPollRecreatesClawAfterError` asserted the old immediate-recreate behaviour. It is renamed and now asserts both halves: no replacement before the backoff, a replacement after it. The test was not weakened to go green — what it asserts changed because the intended behaviour changed.

Three tests in the package fail on this branch (`TestDoneSignalRejectedWhenPRPersistenceFails`, `TestHandleClawDoneSignal_IssueLessWorkflowWatchesPR`, `TestCompleteIssueLessDoneClawKeepsRunningOnStoreFailure`). They hit the live GitHub API and fail identically in a clean worktree at `origin/main`. Verified there, not assumed.

## Process note

The agent that implemented this died on a session limit, and the adversarial review never ran. I reviewed it by hand and found two defects in what it left — the lifetime `retry_count` ratchet, and charging successful claws. Both are fixed above, but **this PR did not go through independent review**, unlike the others in this series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)