### PR TITLE
fix(hub): charge errored claws at any age, and give humans their override back

### DIFF
--- a/pkg/hub/factory_triggers.go
+++ b/pkg/hub/factory_triggers.go
@@ -29,6 +29,11 @@ func activeTriggerStatus(status string) bool {
 	}
 }
 
+// manualWorkflowTriggerSource is the trigger source a human's "run it now"
+// button produces. Named so the exemption in triggerSourceSkipsBackoff and the
+// call sites cannot drift apart on a string literal.
+const manualWorkflowTriggerSource = "manual workflow trigger"
+
 func triggerPayloadJSON(payload any) string {
 	if payload == nil {
 		return "{}"
@@ -68,8 +73,14 @@ func factoryTriggerBackoff(retryCount int) time.Duration {
 // exemption: integration webhooks label themselves "<integration> webhook" and
 // do back off, because their events can repeat on their own (label churn,
 // comment edits).
+//
+// The manual trigger is exempt for the opposite reason: a human pressing the
+// button is the override, and making them wait up to 30 minutes — behind
+// "already has an active trigger claim", which does not describe a backoff —
+// is the worst possible reading of a deliberate retry. It cannot spin either;
+// it fires once per press.
 func triggerSourceSkipsBackoff(source string) bool {
-	return source == "webhook"
+	return source == "webhook" || source == manualWorkflowTriggerSource
 }
 
 func (s *Server) claimFactoryTrigger(factoryName, integration, triggerKey, source string, payload any) (bool, error) {
@@ -150,17 +161,21 @@ func (s *Server) claimFactoryTrigger(factoryName, integration, triggerKey, sourc
 		}
 	}
 
-	// bornDeadClawMax separates a claw that never got going from one that did its
-	// job and was cleaned up. Both end up 'deleted', so status alone cannot tell
-	// them apart, and charging the long-lived one a retry would make every
-	// SUCCESSFUL ticket pay a backoff the next time its trigger fires — with the
-	// counter ratcheting, because nothing ever resets it. The measured churn is
-	// claws dying within ~3 minutes of bootstrap, so the cutoff sits well above
-	// that and well below any real run.
+	// The age cutoff exists only to disambiguate 'deleted', which is written
+	// both by a claw that never got going and by one that did its job and was
+	// cleaned up. Charging the long-lived one would make every SUCCESSFUL ticket
+	// pay a backoff on its next trigger, and the counter would ratchet.
+	//
+	// 'error' needs no such cutoff: a claw is never marked errored on the way
+	// out of a successful run, so an errored claw is a failed attempt at any
+	// age. Gating it by age left the original burn loop intact one notch slower
+	// — a bootstrap that dies at minute 11, or a failure on the first long turn,
+	// fell through uncharged and got an immediate replacement, forever.
 	const bornDeadClawMax = 10 * 60 // seconds
 
-	clawDiedYoung := clawAgeSeconds.Valid && clawAgeSeconds.Int64 <= bornDeadClawMax
-	if clawID != "" && (clawStatus == "error" || clawStatus == "deleted") && clawDiedYoung {
+	clawFailed := clawStatus == "error" ||
+		(clawStatus == "deleted" && clawAgeSeconds.Valid && clawAgeSeconds.Int64 <= bornDeadClawMax)
+	if clawID != "" && clawFailed {
 		// The claw this trigger already paid for died young. Charge it as a failed
 		// attempt instead of dropping into the reclaim below, which reclaims with
 		// no wait and no retry_count bump. The failed-trigger guard above cannot
@@ -185,6 +200,21 @@ func (s *Server) claimFactoryTrigger(factoryName, integration, triggerKey, sourc
 		}
 		// Exempt sources still get charged the retry, but reclaim immediately —
 		// see triggerSourceSkipsBackoff.
+	}
+
+	// A claw that outlived the cutoff is evidence the failure healed, so the
+	// charges that led here are stale: clear them instead of letting a ticket
+	// carry a lifetime count that sends its next transient death straight to the
+	// 30m cap. Only this branch resets — completeFactoryTrigger must not, since
+	// it fires when a claw is CREATED, not when the work succeeds.
+	if clawID != "" && clawStatus == "deleted" && !clawFailed && retryCount > 0 {
+		if _, err = tx.Exec(`
+			UPDATE factory_triggers SET retry_count=0
+			 WHERE factory_name=? AND integration=? AND trigger_key=?`,
+			factoryName, integration, triggerKey,
+		); err != nil {
+			return false, err
+		}
 	}
 
 	// Reclaim path: reached when the trigger has no claw and is not actively

--- a/pkg/hub/factory_triggers_test.go
+++ b/pkg/hub/factory_triggers_test.go
@@ -522,3 +522,89 @@ func TestClaimFactoryTriggerDoesNotChargeLongLivedClaw(t *testing.T) {
 		t.Fatalf("a successful run must not leave a retry charge behind, got retry_count=%d", retryCount)
 	}
 }
+
+// An errored claw is a failed attempt at any age: nothing marks a claw errored
+// on the way out of a successful run. Gating it by age left the original burn
+// loop intact for anything that dies past the cutoff — a slow bootstrap, or a
+// failure on the first long turn.
+func TestClaimFactoryTriggerChargesErroredClawRegardlessOfAge(t *testing.T) {
+	s := newFactoryTriggerTestServer(t)
+	triggerKey := factoryTriggerKey("shortcut", "sc-old-error")
+	if _, err := s.db.Exec(`INSERT INTO claws(id, tenant_id, name, template, status, created_at) VALUES(?,?,?,?,?,?)`,
+		"claw-old-error", "tenant", "claw", "template", "error", now().Add(-2*time.Hour)); err != nil {
+		t.Fatalf("seed claw: %v", err)
+	}
+	if claimed, err := s.claimFactoryTrigger("qa", "shortcut", triggerKey, "poll", nil); err != nil || !claimed {
+		t.Fatalf("initial claim = %v, %v", claimed, err)
+	}
+	if err := s.completeFactoryTrigger("qa", "shortcut", triggerKey, "claw-old-error"); err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+
+	claimed, err := s.claimFactoryTrigger("qa", "shortcut", triggerKey, "poll", nil)
+	if err != nil {
+		t.Fatalf("second claim: %v", err)
+	}
+	if claimed {
+		t.Fatal("an errored claw must be charged a retry whatever its age")
+	}
+	var retryCount int
+	if err := s.db.QueryRow(`SELECT retry_count FROM factory_triggers WHERE trigger_key=?`, triggerKey).Scan(&retryCount); err != nil {
+		t.Fatalf("read retry_count: %v", err)
+	}
+	if retryCount != 1 {
+		t.Fatalf("retry_count = %d, want 1", retryCount)
+	}
+}
+
+// Surviving the cutoff is evidence the failure healed, so the stale charges go.
+// Otherwise a ticket that once churned carries the count for life and its next
+// transient death starts at the 30m cap instead of 30s.
+func TestClaimFactoryTriggerClearsStaleChargesAfterAHealthyRun(t *testing.T) {
+	s := newFactoryTriggerTestServer(t)
+	triggerKey := factoryTriggerKey("shortcut", "sc-healed")
+	if _, err := s.db.Exec(`INSERT INTO claws(id, tenant_id, name, template, status, created_at) VALUES(?,?,?,?,?,?)`,
+		"claw-healed", "tenant", "claw", "template", "deleted", now().Add(-2*time.Hour)); err != nil {
+		t.Fatalf("seed claw: %v", err)
+	}
+	if claimed, err := s.claimFactoryTrigger("qa", "shortcut", triggerKey, "poll", nil); err != nil || !claimed {
+		t.Fatalf("initial claim = %v, %v", claimed, err)
+	}
+	if err := s.completeFactoryTrigger("qa", "shortcut", triggerKey, "claw-healed"); err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+	// A history of churn from earlier attempts.
+	if _, err := s.db.Exec(`UPDATE factory_triggers SET retry_count=7 WHERE trigger_key=?`, triggerKey); err != nil {
+		t.Fatalf("seed retry_count: %v", err)
+	}
+
+	claimed, err := s.claimFactoryTrigger("qa", "shortcut", triggerKey, "poll", nil)
+	if err != nil {
+		t.Fatalf("reclaim: %v", err)
+	}
+	if !claimed {
+		t.Fatal("a long-lived claw must be reclaimed immediately")
+	}
+	var retryCount int
+	if err := s.db.QueryRow(`SELECT retry_count FROM factory_triggers WHERE trigger_key=?`, triggerKey).Scan(&retryCount); err != nil {
+		t.Fatalf("read retry_count: %v", err)
+	}
+	if retryCount != 0 {
+		t.Fatalf("stale charges survived a healthy run: retry_count=%d", retryCount)
+	}
+}
+
+// The human override the code's comment promised did not exist: the manual
+// trigger sat on the non-exempt side and was refused for up to 30 minutes
+// behind a message about an "active trigger claim".
+func TestManualWorkflowTriggerSkipsBackoff(t *testing.T) {
+	if !triggerSourceSkipsBackoff(manualWorkflowTriggerSource) {
+		t.Fatal("the manual trigger is the human override and must not wait out a backoff")
+	}
+	if triggerSourceSkipsBackoff("poll") {
+		t.Fatal("the poller must keep backing off — it is the only source that can spin")
+	}
+	if triggerSourceSkipsBackoff("linear webhook") {
+		t.Fatal("integration webhooks repeat on their own and must keep backing off")
+	}
+}

--- a/pkg/hub/workspace_api.go
+++ b/pkg/hub/workspace_api.go
@@ -487,7 +487,7 @@ func (s *Server) triggerWorkflowConfig(w http.ResponseWriter, r *http.Request, w
 		return
 	}
 
-	clawID, _, err := s.createClawFromWorkflowContext(r.Context(), workspace, workflow, validatedInputs, "manual workflow trigger")
+	clawID, _, err := s.createClawFromWorkflowContext(r.Context(), workspace, workflow, validatedInputs, manualWorkflowTriggerSource)
 	if err != nil {
 		jsonError(w, http.StatusInternalServerError, "failed to create claw: "+err.Error())
 		return
@@ -552,7 +552,7 @@ func (s *Server) createClawForManualGitHubIssueWorkflow(ctx context.Context, wor
 	}
 
 	payload := buildGitHubIssuesPollPayloadForAction(issue, repo, "manual")
-	return s.createClawForGitHubIssueWorkflowContext(ctx, workspace, workflow, payload, "manual workflow trigger")
+	return s.createClawForGitHubIssueWorkflowContext(ctx, workspace, workflow, payload, manualWorkflowTriggerSource)
 }
 
 func (s *Server) queryGitHubIssue(repo, token, base string, issueNumber int) (githubIssuesPollItem, error) {


### PR DESCRIPTION
Post-merge audit of [#638](https://github.com/elasticclaw/elasticclaw/pull/638), which never received an independent review — the reviewing agent died on a session limit. Three defects, all live in `2026.8.18.1-beta.2`. None warranted a rollback; the audit confirmed the core mechanism, the transaction isolation (`_txlock=immediate` serializes the poller/webhook race) and the SQL age computation are correct.

## 1. The burn loop survived, one notch slower

The ten-minute cutoff was applied to both terminal statuses. It only ever needed to disambiguate `deleted`, which is written both by a claw that never got going and by one that finished and was cleaned up.

Nothing marks a claw `error` on the way out of a successful run, so **an errored claw is a failed attempt at any age**. Gating it by age meant a bootstrap dying at minute 11, or a failure on the first long turn, fell through uncharged and got an immediate replacement — forever. Same shape as the bug #638 set out to fix.

```go
clawFailed := clawStatus == "error" ||
    (clawStatus == "deleted" && clawAgeSeconds.Valid && clawAgeSeconds.Int64 <= bornDeadClawMax)
```

## 2. The counter was a lifetime ratchet

Nothing reset `retry_count` and `factory_triggers` rows are never deleted (`INSERT OR IGNORE`). A ticket that once churned to 7 and then worked fine carried the 7 forever, so its next transient death started at the **30-minute cap instead of 30 seconds**.

A claw that outlives the cutoff is evidence the failure healed, so that reclaim now clears the stale charges. `completeFactoryTrigger` still must not reset — it fires when a claw is *created*, not when the work succeeds, and resetting there pins the ladder at its first rung.

## 3. The human override did not exist

The comment claimed *"a human who wants an immediate retry has the exempt-source path"*. False. Enumerating the sources actually passed in production:

| source | exempt before | |
| --- | --- | --- |
| `poll` | no | correct — the only one that can spin |
| `linear webhook`, `jira webhook`, `github-pr webhook`, … | no | correct — they repeat on their own |
| `manual workflow trigger` | **no** | wrong |
| `webhook` | yes | the generic external webhook |

Pressing the manual trigger during a backoff was refused for up to 30 minutes behind `already has an active trigger claim` — a message that does not describe a backoff — and a human re-adding a Linear label was swallowed silently.

The manual trigger is now exempt: it *is* the override, and it fires once per press so it cannot spin. The string became a named constant so the exemption and the two call sites in `workspace_api.go` cannot drift apart.

## Verification

```
gofmt -l  ->  clean
go build ./...  ->  OK
go test ./pkg/hub/ -run 'FactoryTrigger|Trigger|ExcludeLabel|GitHubPRPoll|Manual'  ->  ok
```

Falsified: restoring the old age gate on both statuses makes `TestClaimFactoryTriggerChargesErroredClawRegardlessOfAge` fail. Three new tests cover the errored-claw charge, the stale-charge clear, and the exemption set (asserting `poll` and `linear webhook` stay non-exempt, so the fix cannot silently widen).

The usual three live-GitHub tests fail here and on clean `origin/main`.

## Audit findings not acted on

The auditor flagged that a `claws.created_at` written without the `_time_format=sqlite` DSN would make `strftime` return NULL and silently disable the guard. It verified empirically that no such writer exists and that the DSN predates August, so every live row parses. A defensive log on `!clawAgeSeconds.Valid` would make the tripwire visible if that ever changes; left out as speculative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)