### PR TITLE
fix(hub): only treat a signal token as a signal when it opens a line

### DIFF
--- a/.elasticclaw/workflows/github-issue.yaml
+++ b/.elasticclaw/workflows/github-issue.yaml
@@ -39,7 +39,9 @@ stages:
 
         Read the issue and CONTEXT.md and start working on the issue.
         Narrate your progress as you go. Keep me updated.
-        When implementation is complete and before committing, say [READY_TO_COMMIT].
+        When implementation is complete and before committing, reply with `[READY_TO_COMMIT]`
+        alone on the first line of your message. The hub only reads the signal when the
+        token opens a line; written inside a sentence it is ignored and the run stalls.
 
   - id: pre_commit
     label: Pre-Commit Checks
@@ -54,7 +56,8 @@ stages:
         Review the clawpatch report at .elasticclaw/clawpatch/report.json.
         Fix issues you agree with.
         Do not commit .elasticclaw/clawpatch files.
-        When fixes are complete, create the final commit and PR, then say [DONE].
+        When fixes are complete, create the final commit and PR, then reply with `[DONE]` on
+        the first line and list the PR URL after it. `[DONE]` must open that line.
 
   - id: pr_opened
     label: PR Opened

--- a/.elasticclaw/workflows/linear-story.yaml
+++ b/.elasticclaw/workflows/linear-story.yaml
@@ -21,6 +21,9 @@ stages:
 
         Read the issue and CONTEXT.md and start working on the issue.
         Narrate your progress as you go. Keep me updated.
+        When the PR is open, reply with `[DONE]` on the first line and list the PR URL after
+        it. The hub reads the signal only when `[DONE]` opens a line; mentioned inside a
+        sentence it is ignored.
 
   - id: pr_opened
     label: PR Opened

--- a/examples/workflows/github-issue.yaml
+++ b/examples/workflows/github-issue.yaml
@@ -30,7 +30,8 @@ stages:
 
         Read the issue and README.md, then start working on the issue.
         Narrate your progress as you go. Keep me updated.
-        When implementation is complete and before committing, say [READY_TO_COMMIT].
+        When implementation is complete and before committing, reply with `[READY_TO_COMMIT]`
+        on the first line. The hub reads the signal only when the token opens a line.
 
   - id: pre_commit
     label: Pre-Commit Checks
@@ -44,7 +45,8 @@ stages:
       inject: |
         Review the pre-commit check output.
         Fix issues you agree with.
-        When fixes are complete, create the final commit and PR, then say [DONE].
+        When fixes are complete, create the final commit and PR, then reply with `[DONE]` on
+        the first line and list the PR URL after it.
 
   - id: pr_opened
     label: PR Opened

--- a/examples/workflows/linear-issue-plan-gate.yaml
+++ b/examples/workflows/linear-issue-plan-gate.yaml
@@ -35,7 +35,8 @@ stages:
           steps          (array of strings)
           verification   (string)
 
-        Then say exactly: [PLAN_READY]
+        Then reply with `[PLAN_READY]` on the first line, that exact token and nothing before
+        it on that line. The hub reads the signal only when the token opens a line.
         Do not edit product code until the next stage injects proceed.
 
   - id: plan_validate
@@ -111,7 +112,8 @@ stages:
 
         Plan accepted (status {{ .Outputs.plan.status }}) — coding begins now.
         Do not wait for another proceed message. Do not emit [PLAN_READY] again.
-        Implement the issue. Narrate progress. When the PR is ready, say [DONE] with the PR URL.
+        Implement the issue. Narrate progress. When the PR is ready, reply with `[DONE]` on the
+        first line and put the PR URL after it.
 
   - id: fix_plan
     label: Fix plan
@@ -122,7 +124,7 @@ stages:
     on_enter:
       inject: |
         Plan incomplete: {{ .Outputs.plan.reason }}
-        Update .elasticclaw/plan.json, then say [PLAN_READY] again.
+        Update .elasticclaw/plan.json, then reply with `[PLAN_READY]` on the first line again.
 
   - id: pr_opened
     label: PR opened

--- a/pkg/hub/done_signal_test.go
+++ b/pkg/hub/done_signal_test.go
@@ -108,6 +108,15 @@ func TestExtractDonePRURLs(t *testing.T) {
 			message:  "Here is a summary.\n\n[DONE] https://github.com/org/repo/pull/55\n\nThanks!",
 			wantURLs: []string{"https://github.com/org/repo/pull/55"},
 		},
+		{
+			// pipeline.MessageSignals accepts the token in any case, so this
+			// turn DOES advance the stage. If the URL scan stayed
+			// case-sensitive the stage would advance with nothing registered
+			// and merge tracking would never arm.
+			name:     "lowercase done token still yields its PR URLs",
+			message:  "[done] https://github.com/org/repo/pull/56",
+			wantURLs: []string{"https://github.com/org/repo/pull/56"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/hub/jira_workflow_test.go
+++ b/pkg/hub/jira_workflow_test.go
@@ -340,7 +340,7 @@ func TestJiraTerminateSignalCommentsIssue(t *testing.T) {
 		t.Fatalf("find claw: %v", err)
 	}
 	bridge := factorytest.ConnectFakeBridge(t, httpSrv.URL, clawID, "EC-123", "test-claw-token")
-	bridge.SendMessage("Stopping now. [TERMINATE]")
+	bridge.SendMessage("Stopping now.\n\n[TERMINATE]")
 
 	comment := jira.waitForComment(t, "EC-123")
 	if !strings.Contains(comment, "Agent stopped: claw requested self-termination") {

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/elasticclaw/elasticclaw/pkg/config"
+	"github.com/elasticclaw/elasticclaw/pkg/hub/pipeline"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 	"github.com/google/uuid"
 	"nhooyr.io/websocket"
@@ -1312,6 +1313,13 @@ func buildLinearContext(payload linearWebhookPayload, requiresPR bool) string {
 // If no valid open PRs are found (and a GH App is configured), it injects an
 // error message back so the claw can retry.
 func (s *Server) handleClawDoneSignal(clawID, rawMessage string) {
+	// Re-decide the signal here instead of trusting the caller. This function
+	// terminates claws and moves tracker issues, and it used to run on whatever
+	// its caller thought was a [DONE] — which is how the same message could be
+	// refused by the pipeline and accepted here. One text, one verdict.
+	if !pipeline.MessageSignals(rawMessage, doneSignalToken) {
+		return
+	}
 	// Get the issue ID and tenant for this claw. Workflow claws may not have an
 	// issue, but [DONE] must still give those runs a terminal path.
 	var issueID, tenantID string
@@ -1644,6 +1652,11 @@ func (s *Server) completeNoPRDoneClaw(clawID, tenantID, issueID string) {
 // Unlike [DONE] which moves issues and keeps the claw in idle mode, [TERMINATE] immediately
 // soft-deletes the claw and terminates its associated VM while preserving run logs.
 func (s *Server) handleClawTerminateSignal(clawID, rawMessage string) {
+	// Same rule as handleClawDoneSignal: the teardown decision is re-made from
+	// the message here, not inherited from the caller's substring test.
+	if !pipeline.MessageSignals(rawMessage, terminateSignalToken) {
+		return
+	}
 	// Get the tenant ID and issue ID for this claw
 	var issueID, tenantID, factoryName string
 	if err := s.db.QueryRow(`SELECT COALESCE(NULLIF(linear_issue_id,''),NULLIF(github_issue_id,''),NULLIF(shortcut_story_id,''),NULLIF(jira_issue_id,'')), tenant_id, factory_name FROM claws WHERE id = ?`, clawID).Scan(&issueID, &tenantID, &factoryName); err != nil {
@@ -1755,10 +1768,27 @@ func (s *Server) handleClawTerminateSignal(clawID, rawMessage string) {
 //	https://github.com/org/repo/pull/1
 //
 // and those URLs must still register for merge/close monitoring.
+// indexFold is strings.Index with case-insensitive matching. The offset stays
+// byte-exact so it can slice the original line, which strings.ToUpper would not
+// guarantee for non-ASCII input.
+func indexFold(s, substr string) int {
+	n := len(substr)
+	for i := 0; i+n <= len(s); i++ {
+		if strings.EqualFold(s[i:i+n], substr) {
+			return i
+		}
+	}
+	return -1
+}
+
 func extractDonePRURLs(message string) []string {
 	lines := strings.Split(message, "\n")
 	for i, line := range lines {
-		idx := strings.Index(line, "[DONE]")
+		// Case-insensitive, matching pipeline.MessageSignals. The two must agree:
+		// if the signal is recognised but the URL scan is not, the stage advances
+		// with zero PRs registered and merge/close tracking is never armed — the
+		// same one-text-two-verdicts split the anchoring exists to remove.
+		idx := indexFold(line, doneSignalToken)
 		if idx < 0 {
 			continue
 		}
@@ -1773,7 +1803,7 @@ func extractDonePRURLs(message string) []string {
 				urls = append(urls, pr.url)
 			}
 		}
-		add(line[idx+len("[DONE]"):])
+		add(line[idx+len(doneSignalToken):])
 		for _, later := range lines[i+1:] {
 			add(later)
 		}

--- a/pkg/hub/no_progress.go
+++ b/pkg/hub/no_progress.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/elasticclaw/elasticclaw/pkg/hub/pipeline"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
 
@@ -25,7 +26,11 @@ var commitMarkerPattern = regexp.MustCompile(`(?i)\b[0-9a-f]{7,40}\b`)
 // latest outcomes are substantially the same and that state has not changed.
 // This is deliberately progress-based rather than a lifetime or turn limit.
 func (s *Server) observeCompletedTurn(clawID, messageID, content string) bool {
-	if strings.Contains(content, "[DONE]") || strings.Contains(content, "[TERMINATE]") {
+	// Anchored, like every other signal test in the hub. A turn that merely
+	// mentions a token has not signalled anything and must not buy itself
+	// immunity from the no-progress check — an agent repeating "I can't send
+	// [DONE] yet" every turn is the exact shape this watchdog exists to catch.
+	if pipeline.MessageSignals(content, doneSignalToken) || pipeline.MessageSignals(content, terminateSignalToken) {
 		return false
 	}
 	s.noProgressMu.Lock()

--- a/pkg/hub/pipeline/pipeline.go
+++ b/pkg/hub/pipeline/pipeline.go
@@ -49,7 +49,10 @@ type IssueLabelsSkip struct {
 // Trigger defines a condition that causes a transition into the parent stage.
 // Exactly one field should be set.
 type Trigger struct {
-	// MessageContains matches when a claw message contains this substring.
+	// MessageContains matches when this token opens a line of a claw message,
+	// ignoring leading whitespace and markdown decoration. The name is kept for
+	// YAML compatibility, but the match is anchored, not a substring scan: see
+	// MessageSignals for why. A token quoted mid-sentence does not match.
 	MessageContains string `yaml:"message_contains"`
 	// PRMerged is true when the pr_merged key is present in the YAML (even with null value).
 	PRMerged bool
@@ -547,18 +550,129 @@ func (p *Pipeline) StageByID(id string) *Stage {
 	return nil
 }
 
-// StageForMessageContains returns the first stage that has a message_contains
-// trigger matching the given message text. Returns nil if none match.
+// StageForMessageContains returns the first stage whose message_contains
+// trigger token opens a line of the given message. Returns nil if none match.
+// The matching rule is MessageSignals; read it before changing this.
 func (p *Pipeline) StageForMessageContains(message string) *Stage {
 	for i := range p.Stages {
 		for _, t := range p.Stages[i].Triggers {
-			if t.MessageContains != "" && containsFold(message, t.MessageContains) {
+			if t.MessageContains != "" && MessageSignals(message, t.MessageContains) {
 				return &p.Stages[i]
 			}
 		}
 	}
 	return nil
 }
+
+// MessageContainsTokens returns the distinct message_contains tokens declared by
+// this pipeline, in stage order. It exists so the hub can tell which tokens are
+// meaningful to a given run without re-parsing triggers, which is what the
+// unanchored-signal nudge needs.
+// StageIDForMessageContainsToken returns the id of the first stage triggered by
+// this token, or "" if none declares it. The caller needs it to tell a token
+// whose stage is still ahead from one whose stage is already behind.
+func (p *Pipeline) StageIDForMessageContainsToken(token string) string {
+	for i := range p.Stages {
+		for _, t := range p.Stages[i].Triggers {
+			if t.MessageContains != "" && strings.EqualFold(t.MessageContains, token) {
+				return p.Stages[i].ID
+			}
+		}
+	}
+	return ""
+}
+
+func (p *Pipeline) MessageContainsTokens() []string {
+	var tokens []string
+	seen := map[string]bool{}
+	for i := range p.Stages {
+		for _, t := range p.Stages[i].Triggers {
+			if t.MessageContains == "" {
+				continue
+			}
+			key := strings.ToUpper(t.MessageContains)
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			tokens = append(tokens, t.MessageContains)
+		}
+	}
+	return tokens
+}
+
+// MessageSignals reports whether message emits token as a signal: the token must
+// ANCHOR at the start of some line of the message, ignoring leading whitespace
+// and markdown decoration. It is the single definition of "the agent sent this
+// signal", and every caller in the hub must use it — the pipeline trigger path,
+// the legacy [DONE] and [TERMINATE] gates in server.go, and handleClawDoneSignal
+// itself. One message getting two different verdicts on two code paths is how
+// NEXT-707 turned a partial fix into a worse bug than the original.
+//
+// A bare substring match burned us twice in two days. NEXT-724: a claw that had
+// no ticket yet described the process it would follow — "5. Commit locally and
+// signal `[IMPLEMENTATION_DONE]` per the lifecycle table" — and the hub jumped
+// straight to review_loop; the run died 4h20 later at $6.64 with zero PRs.
+// NEXT-707: an agent reported a legitimate blocker with "sending `[DONE]` now
+// would be a false signal", and the hub opened a PR stage, stamped Agent
+// Finished on Linear and pinged Slack for human review — the agent was declared
+// done because it said it was NOT declaring itself done.
+//
+// Anchoring is unconditional, not a per-pipeline opt-in: the hub is shared by
+// factories we do not own, and a flag defaulting either way is wrong. Defaulting
+// off leaves every factory carrying the bug that cost these two runs; defaulting
+// on makes the flag dead weight nobody would ever set.
+//
+// This tightens the contract rather than restating it. The injects in this repo
+// were NOT uniform — .elasticclaw/workflows/github-issue.yaml only said "say
+// [DONE]" — so anchoring is what makes them uniform, and they have been reworded
+// to match. Injects we do not own (other repos' workflows) may still ask for the
+// token loosely; MessageMentionsUnanchored plus the hub's nudge is the safety net
+// for those, converting a silent freeze into a recoverable one.
+func MessageSignals(message, token string) bool {
+	if token == "" {
+		return false
+	}
+	for _, line := range strings.Split(message, "\n") {
+		line = strings.TrimLeft(line, signalDecoration)
+		if len(line) >= len(token) && equalFold(line[:len(token)], token) {
+			return true
+		}
+	}
+	return false
+}
+
+// MessageMentionsUnanchored reports whether token appears somewhere in message
+// but never opens a line — precisely the shape that used to transition the
+// pipeline and now does not. The hub uses it to nudge the agent to resend, so
+// that a mis-formatted signal fails loudly instead of hanging the run forever.
+func MessageMentionsUnanchored(message, token string) bool {
+	if token == "" {
+		return false
+	}
+	return containsFold(message, token) && !MessageSignals(message, token)
+}
+
+// signalDecoration is what may sit between the start of a line and the signal
+// token. A missed signal is worse than a spurious one — a spurious transition
+// wastes a run, a missed one freezes the pipeline forever — so this has to
+// tolerate how agents actually decorate the token. Observed in this hub:
+// **[REVIEW_LOOP_PASSED]** (bold), `[DONE]` (backticked), and the bare token.
+// Underscore joins asterisk because it is the same markdown emphasis marker, and
+// '#' because a heading marker only ever exists at the start of a line.
+//
+// Blockquote '>' is deliberately excluded: quoting the inject back is exactly the
+// NEXT-707 shape, and no agent has ever been seen signalling from inside a quote.
+// List markers ('-', '1.') are excluded for the same reason — NEXT-724 was a
+// numbered list item.
+//
+// '\r' is deliberately absent. It looks like it belongs next to '\t', but the
+// split below is on '\n', so a CRLF message always leaves '\r' at the END of the
+// preceding line and never at the start of one: it would pin nothing and protect
+// nothing. Every character here is covered by exactly one case in
+// TestStageForMessageContainsAnchoring; add a case with the character, or do not
+// add the character.
+const signalDecoration = " \t*_`#"
 
 // StageForPRMerged returns the first stage with a pr_merged trigger, or nil.
 func (p *Pipeline) StageForPRMerged() *Stage {
@@ -686,7 +800,9 @@ func GetJSONPath(m map[string]interface{}, path string) interface{} {
 	return current
 }
 
-// containsFold reports whether s contains substr, case-insensitively.
+// containsFold reports whether s contains substr, case-insensitively. Only
+// MessageMentionsUnanchored may use it: an unanchored mention is grounds for a
+// nudge, never for a stage transition.
 func containsFold(s, substr string) bool {
 	if len(substr) == 0 {
 		return true

--- a/pkg/hub/pipeline/pipeline_test.go
+++ b/pkg/hub/pipeline/pipeline_test.go
@@ -292,12 +292,288 @@ func TestEntryStage(t *testing.T) {
 
 func TestStageForMessageContains(t *testing.T) {
 	p, _ := pipeline.Parse([]byte(sampleYAML))
-	s := p.StageForMessageContains("Great work! [DONE] https://github.com/org/repo/pull/1")
+	s := p.StageForMessageContains("[DONE] https://github.com/org/repo/pull/1")
 	if s == nil {
 		t.Fatal("expected to match message_contains trigger")
 	}
 	if s.ID != "pr_opened" {
 		t.Errorf("expected 'pr_opened', got %q", s.ID)
+	}
+}
+
+// TestStageForMessageContainsAnchoring pins the line-start anchoring that
+// NEXT-724 and NEXT-707 paid for. The "does not match" cases are the verbatim
+// text from those two incidents; the "matches" cases are decorated forms this
+// hub has actually seen agents send. A regression on either side is expensive:
+// a spurious match burns a run, a missed match freezes the pipeline forever.
+func TestStageForMessageContainsAnchoring(t *testing.T) {
+	// Mirrors the real workflow tokens so the incident messages below can be
+	// quoted verbatim, token included.
+	const signalYAML = `
+stages:
+  - id: working
+    label: "Working"
+    entry: true
+
+  - id: review_loop
+    label: "Review Loop"
+    triggers:
+      - message_contains: "[IMPLEMENTATION_DONE]"
+
+  # Every token the decoration cases below use MUST have a trigger here. Without
+  # this stage, a "**[REVIEW_LOOP_PASSED]**" case matched nothing and was
+  # satisfied by an unrelated "[DONE]" line further down the same message — the
+  # decoration set had no real coverage at all and mutating it stayed green.
+  - id: android_validation
+    label: "Android Validation"
+    triggers:
+      - message_contains: "[REVIEW_LOOP_PASSED]"
+
+  - id: pr_opened
+    label: "PR Opened"
+    triggers:
+      - message_contains: "[DONE]"
+`
+	p, err := pipeline.Parse([]byte(signalYAML))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		message string
+		want    string // stage ID, empty means no transition
+	}{
+		{
+			name:    "bare token opening the message",
+			message: "[DONE] https://github.com/org/repo/pull/1",
+			want:    "pr_opened",
+		},
+		// Every character of signalDecoration is pinned by at least one case:
+		// removing it from the set makes this test fail. The mapping is not
+		// one-to-one — dropping ' ' fails both the indented and the heading case
+		// (the heading needs the space after the hashes), and dropping '`' fails
+		// both backticked cases.
+		{
+			// pins '*'
+			name:    "bold token",
+			message: "**[REVIEW_LOOP_PASSED]**",
+			want:    "android_validation",
+		},
+		{
+			// pins '_'
+			name:    "italic token",
+			message: "_[REVIEW_LOOP_PASSED]_",
+			want:    "android_validation",
+		},
+		{
+			// pins '#'
+			name:    "token as a heading",
+			message: "### [REVIEW_LOOP_PASSED]\n\nAll lenses converged.",
+			want:    "android_validation",
+		},
+		{
+			// pins '`'
+			name:    "backticked token",
+			message: "`[DONE]` https://github.com/org/repo/pull/1",
+			want:    "pr_opened",
+		},
+		{
+			// The suffixed form REVIEW_LOOP.md documents. The suffix must not
+			// change gating — it exists so downstream cannot mistake a degraded
+			// pass for a clean one.
+			name:    "token with documented suffix",
+			message: "[REVIEW_LOOP_PASSED] degraded=security",
+			want:    "android_validation",
+		},
+		{
+			name:    "token with unresolved suffix, backticked",
+			message: "`[REVIEW_LOOP_PASSED]` unresolved=3\n\nThree findings carried forward.",
+			want:    "android_validation",
+		},
+		{
+			name:    "token opening a later line",
+			message: "Implementation is committed locally and the tests pass.\n\n[IMPLEMENTATION_DONE]",
+			want:    "review_loop",
+		},
+		{
+			// pins ' '
+			name:    "space-indented token",
+			message: "  [DONE] https://github.com/org/repo/pull/1",
+			want:    "pr_opened",
+		},
+		{
+			// pins '\t'
+			name:    "tab-indented token",
+			message: "Summary of the run:\n\n\t[DONE] https://github.com/org/repo/pull/1",
+			want:    "pr_opened",
+		},
+		{
+			name:    "lowercase token",
+			message: "[done] https://github.com/org/repo/pull/1",
+			want:    "pr_opened",
+		},
+		{
+			// NEXT-724, verbatim: the claw had no ticket and was listing the
+			// process it would follow once it got one. Substring matching read
+			// this as the signal itself and jumped to review_loop.
+			name:    "NEXT-724 numbered list describing the future process",
+			message: "5. Commit locally and signal `[IMPLEMENTATION_DONE]` per the lifecycle table.",
+			want:    "",
+		},
+		{
+			// NEXT-707, verbatim: the agent explained why it was NOT signalling,
+			// and was declared finished for saying so.
+			name:    "NEXT-707 refusal to signal",
+			message: "No implementation exists yet, so there is nothing to commit/push/PR —\nsending `[DONE]` now would be a false signal.",
+			want:    "",
+		},
+		{
+			name:    "token quoted mid-sentence",
+			message: "The workflow ends when I reply with [DONE] and the PR URLs.",
+			want:    "",
+		},
+		{
+			name:    "token inside a blockquoted instruction",
+			message: "> Then reply with `[DONE]` on the first line.",
+			want:    "",
+		},
+		{
+			// Decoration is allowed BEFORE the token, never prose. Bolding a
+			// whole sentence must not smuggle a mid-sentence token in.
+			name:    "bolded sentence containing the token",
+			message: "**I am not sending [REVIEW_LOOP_PASSED] until the security lens returns.**",
+			want:    "",
+		},
+		{
+			name:    "token in a heading sentence",
+			message: "### Why [REVIEW_LOOP_PASSED] is premature",
+			want:    "",
+		},
+		{
+			name:    "empty message",
+			message: "",
+			want:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ""
+			if stage := p.StageForMessageContains(tt.message); stage != nil {
+				got = stage.ID
+			}
+			if got != tt.want {
+				t.Errorf("StageForMessageContains(%q) = %q, want %q", tt.message, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestMessageMentionsUnanchored pins the predicate the hub's nudge is built on.
+// It must be exactly the complement of MessageSignals within "the token appears
+// at all": if these two ever both return false for a message containing the
+// token, the run freezes with nobody told, which is the failure anchoring
+// introduces and the nudge exists to undo.
+func TestMessageMentionsUnanchored(t *testing.T) {
+	tests := []struct {
+		name           string
+		message        string
+		token          string
+		wantSignals    bool
+		wantUnanchored bool
+	}{
+		{
+			name:           "anchored signal is not a stray mention",
+			message:        "[DONE] https://github.com/org/repo/pull/1",
+			token:          "[DONE]",
+			wantSignals:    true,
+			wantUnanchored: false,
+		},
+		{
+			// The dominant risk case: an inject that only said "say [DONE]" and
+			// an agent that obliged mid-sentence.
+			name:           "mid-sentence token is a stray mention",
+			message:        "Implementation complete, so [READY_TO_COMMIT].",
+			token:          "[READY_TO_COMMIT]",
+			wantSignals:    false,
+			wantUnanchored: true,
+		},
+		{
+			// Anchored once and quoted again: the agent signalled correctly, so
+			// nudging would be noise.
+			name:           "anchored plus a later stray mention",
+			message:        "[DONE] https://x/pull/1\n\nI sent [DONE] as instructed.",
+			token:          "[DONE]",
+			wantSignals:    true,
+			wantUnanchored: false,
+		},
+		{
+			name:           "token absent entirely",
+			message:        "Still working on the migration.",
+			token:          "[DONE]",
+			wantSignals:    false,
+			wantUnanchored: false,
+		},
+		{
+			name:           "case-insensitive stray mention",
+			message:        "I will not say [terminate] yet.",
+			token:          "[TERMINATE]",
+			wantSignals:    false,
+			wantUnanchored: true,
+		},
+		{
+			name:           "empty token never matches either way",
+			message:        "anything",
+			token:          "",
+			wantSignals:    false,
+			wantUnanchored: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := pipeline.MessageSignals(tt.message, tt.token); got != tt.wantSignals {
+				t.Errorf("MessageSignals(%q, %q) = %v, want %v", tt.message, tt.token, got, tt.wantSignals)
+			}
+			if got := pipeline.MessageMentionsUnanchored(tt.message, tt.token); got != tt.wantUnanchored {
+				t.Errorf("MessageMentionsUnanchored(%q, %q) = %v, want %v", tt.message, tt.token, got, tt.wantUnanchored)
+			}
+		})
+	}
+}
+
+func TestMessageContainsTokens(t *testing.T) {
+	const yamlSrc = `
+stages:
+  - id: a
+    entry: true
+    triggers:
+      - message_contains: "[IMPLEMENTATION_DONE]"
+  - id: b
+    triggers:
+      - message_contains: "[DONE]"
+      - pr_merged: {}
+  - id: c
+    triggers:
+      - message_contains: "[DONE]"
+  - id: d
+    triggers:
+      - pr_closed: {}
+`
+	p, err := pipeline.Parse([]byte(yamlSrc))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	got := p.MessageContainsTokens()
+	want := []string{"[IMPLEMENTATION_DONE]", "[DONE]"}
+	if len(got) != len(want) {
+		t.Fatalf("MessageContainsTokens() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("MessageContainsTokens() = %v, want %v", got, want)
+		}
 	}
 }
 

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -21,6 +21,110 @@ import (
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
 
+// The two lifecycle tokens the hub understands on its own, independent of any
+// pipeline's message_contains triggers. Both are matched with
+// pipeline.MessageSignals — never strings.Contains.
+const (
+	doneSignalToken      = "[DONE]"
+	terminateSignalToken = "[TERMINATE]"
+)
+
+// signalTokensForClaw lists the tokens that mean something to this claw: the two
+// built-in lifecycle tokens plus whatever its pipeline declares. Used only to
+// decide what an unanchored mention should be nudged about.
+func (s *Server) signalTokensForClaw(clawID string) []string {
+	tokens := []string{doneSignalToken, terminateSignalToken}
+	seen := map[string]bool{doneSignalToken: true, terminateSignalToken: true}
+	ctx, ok := s.findPipelineContextForClaw(clawID)
+	if !ok {
+		return tokens
+	}
+	pl := parsePipelineForContext(ctx)
+	if pl == nil {
+		return tokens
+	}
+	for _, t := range pl.MessageContainsTokens() {
+		key := strings.ToUpper(t)
+		if seen[key] {
+			continue
+		}
+		// Never nudge about a token whose stage is already behind us. The inject
+		// that leaves such a stage often tells the agent NOT to emit it again,
+		// so "resend it at the start of a line" would be talking it into a
+		// backwards transition — message_contains triggers have no visited-stage
+		// guard of their own.
+		if stageID := pl.StageIDForMessageContainsToken(t); stageID != "" && s.hasVisitedPipelineStage(clawID, stageID) {
+			continue
+		}
+		seen[key] = true
+		tokens = append(tokens, t)
+	}
+	return tokens
+}
+
+// unanchoredSignalNudgeText is a pure function of the token on purpose: an
+// identical string is what lets both dedup layers below recognise a repeat.
+func unanchoredSignalNudgeText(token string) string {
+	return fmt.Sprintf(
+		"[hub] I saw %s in your last message, but not at the start of a line, so it was not read as a signal and nothing advanced. "+
+			"A signal only counts when the token opens its own line (a leading backtick, *, _ or # is fine; prose before it is not). "+
+			"If you meant to send it, resend it now with %s opening the first line. "+
+			"If you were only referring to the token, ignore this — you will not be told about %s again.",
+		token, token, token)
+}
+
+// nudgeUnanchoredSignal tells an agent that wrote a known signal token
+// mid-sentence to resend it anchored.
+//
+// Anchoring trades a spurious transition for a missed one, and a missed signal
+// is a run that hangs until a human notices — the worst failure mode the hub
+// has. This is what keeps it recoverable: the agent is told, in the same
+// channel, that the hub saw the token and did not act on it.
+//
+// Three things keep it from becoming spam:
+//
+//  1. If ANY known token is properly anchored in this message, we say nothing.
+//     The agent signalled correctly; a stray mention alongside it is commentary.
+//  2. At most one nudge per turn, even if several tokens were quoted loosely.
+//  3. At most one nudge per token per claw, ever. The text is a constant per
+//     token, so the check below is an exact-match lookup over this claw's
+//     messages — an agent that quotes [DONE] in twenty consecutive turns gets
+//     exactly one nudge. injectMessage's pending-duplicate check is a second
+//     layer underneath, covering races between concurrent turns.
+//
+// No new queue: this rides the existing hub message injection.
+func (s *Server) nudgeUnanchoredSignal(clawID, message string) {
+	tokens := s.signalTokensForClaw(clawID)
+	var stray []string
+	for _, token := range tokens {
+		if pipeline.MessageSignals(message, token) {
+			return // rule 1
+		}
+		if pipeline.MessageMentionsUnanchored(message, token) {
+			stray = append(stray, token)
+		}
+	}
+	for _, token := range stray {
+		text := unanchoredSignalNudgeText(token)
+		var alreadyNudged bool
+		if err := s.db.QueryRow(
+			`SELECT EXISTS(SELECT 1 FROM messages WHERE claw_id=? AND role='hub' AND content=?)`,
+			clawID, text,
+		).Scan(&alreadyNudged); err != nil {
+			// Fail closed. Unlike a watchdog nudge, a duplicate here is pure
+			// noise in the agent's context, and the next turn retries anyway.
+			log.Printf("[pipeline] unanchored-signal nudge dedup check for claw %s failed, skipping: %v", shortID(clawID), err)
+			return
+		}
+		if alreadyNudged {
+			continue
+		}
+		log.Printf("[pipeline] claw %s wrote %s unanchored; nudging to resend on its own line", shortID(clawID), token)
+		s.injectHubMessageByID(clawID, text)
+		return // rule 2
+	}
+}
+
 // githubIssueDetails holds the fields we fetch for pipeline template rendering.
 type githubIssueDetails struct {
 	Identifier  string `json:"identifier"`

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2866,13 +2866,20 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				if !automaticContinuationPaused {
 					s.handleInitialPlanResponse(clawID, tenantID, turnContent)
 				}
+				// Every [DONE]/[TERMINATE] gate below asks pipeline.MessageSignals,
+				// never strings.Contains. They used to disagree: the pipeline
+				// refused an unanchored [DONE] while the legacy gates accepted it,
+				// so pipelineHandledDone stayed false and the legacy handler ran on
+				// exactly the text the pipeline had just rejected — the NEXT-707
+				// outcome, reached by the code that was supposed to prevent it.
+				doneSignalled := pipeline.MessageSignals(turnContent, doneSignalToken)
 				// Evaluate pipeline triggers. If a pipeline explicitly owns a
 				// [DONE] trigger, let it handle that signal instead of the
 				// legacy factory PR-URL completion path below.
 				pipelineHandledDone := false
 				var pipelineDoneCtx pipelineContext
 				var pipelineDoneStage *pipeline.Stage
-				if strings.Contains(turnContent, "[DONE]") {
+				if doneSignalled {
 					pipelineDoneCtx, pipelineDoneStage, pipelineHandledDone = s.pipelineStageForMessageContains(clawID, turnContent)
 				}
 				if automaticContinuationPaused {
@@ -2898,8 +2905,15 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 							})
 						}
 					}
-				} else if !strings.Contains(turnContent, "[DONE]") {
+				} else if !doneSignalled {
 					s.safeGo("pipeline message triggers", func() { s.checkPipelineMessageTriggers(clawID, turnContent) })
+				}
+				// A known token written mid-sentence no longer transitions
+				// anything. Tell the agent so, or the run freezes with nobody
+				// aware the signal was dropped. Skipped while continuation is
+				// paused: that claw is already being held, not waiting on us.
+				if !automaticContinuationPaused {
+					s.safeGo("unanchored signal nudge", func() { s.nudgeUnanchoredSignal(clawID, turnContent) })
 				}
 				// Clear typing indicator now that response is complete
 				s.broadcastToUsers(tenantID, types.WSMessage{
@@ -2910,7 +2924,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 					},
 				})
 				// Check for [DONE] signal from a factory-created claw
-				if strings.Contains(turnContent, "[DONE]") {
+				if doneSignalled {
 					s.safeGo("done checkpoint", func() {
 						if _, err := s.requestCheckpoint(context.Background(), clawID, "done", "hub", false, checkpointRequestTimeout); err != nil {
 							log.Printf("[checkpoint] done request for %s failed: %v", shortID(clawID), err)
@@ -2920,8 +2934,11 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 						s.safeGo("done signal", func() { s.handleClawDoneSignal(clawID, turnContent) })
 					}
 				}
-				// Check for [TERMINATE] signal - allows claw to manage its own lifecycle
-				if strings.Contains(turnContent, "[TERMINATE]") {
+				// Check for [TERMINATE] signal - allows claw to manage its own
+				// lifecycle. Anchored for the same reason as [DONE], with a worse
+				// blast radius: under substring matching an agent writing "I will
+				// not send [TERMINATE] yet" tore down its own claw.
+				if pipeline.MessageSignals(turnContent, terminateSignalToken) {
 					go s.handleClawTerminateSignal(clawID, turnContent)
 				}
 				// Detect and store PR URLs mentioned mid-work. [DONE] turns are
@@ -2930,7 +2947,11 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				// stay atomic. A fallback scan here would call storePRMention
 				// per-URL and could partially arm the watcher after an aborted
 				// atomic register or a gate-blocked [DONE].
-				if strings.Contains(turnContent, "[DONE]") {
+				//
+				// Gated on doneSignalled, not on the token appearing: a turn that
+				// merely mentions [DONE] registers nothing, so skipping the scan
+				// there would silently drop PR URLs the agent did post.
+				if doneSignalled {
 					log.Printf("[pr-watcher] skipping PR scan for claw %s: [DONE] registration is handled explicitly", shortID(clawID))
 				} else {
 					go s.scanMessageForPRs(clawID, turnContent)

--- a/pkg/hub/unanchored_signal_nudge_test.go
+++ b/pkg/hub/unanchored_signal_nudge_test.go
@@ -1,0 +1,186 @@
+package hub
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+// newNudgeTestServer builds a server with one claw, optionally attached to a
+// factory whose pipeline declares its own message_contains tokens.
+func newNudgeTestServer(t *testing.T, clawID string, factories []*types.FactoryConfig) *Server {
+	t.Helper()
+	cfg := &types.HubConfig{Token: "test-token", Factories: factories}
+	s, db := NewTestServerWithConfig(t, cfg, "", "", "")
+	tags := "[]"
+	if len(factories) > 0 {
+		tags = `["factory:` + factories[0].Name + `"]`
+	}
+	if _, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, template, status, tags, linear_issue_id, pipeline_stage, created_at)
+		 VALUES(?,?,?,?,?,?,?,?,datetime('now'))`,
+		clawID, "test-tenant-id", "nudge-claw", "elasticclaw", "connected", tags, "ELA-1", "working",
+	); err != nil {
+		t.Fatalf("insert claw: %v", err)
+	}
+	return s
+}
+
+// nudgeMessages returns the unanchored-signal nudges injected for a claw.
+func nudgeMessages(t *testing.T, s *Server, clawID string) []string {
+	t.Helper()
+	rows, err := s.db.Query(`SELECT content FROM messages WHERE claw_id=? AND role='hub' ORDER BY rowid`, clawID)
+	if err != nil {
+		t.Fatalf("query messages: %v", err)
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var c string
+		if err := rows.Scan(&c); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		if strings.Contains(c, "not at the start of a line") {
+			out = append(out, c)
+		}
+	}
+	if err := rows.Err(); err != nil && err != sql.ErrNoRows {
+		t.Fatalf("rows: %v", err)
+	}
+	return out
+}
+
+// TestNudgeUnanchoredSignal is the recoverability half of the anchoring change.
+// Anchoring trades a spurious transition for a missed one, and a missed signal
+// is a run that hangs until a human notices. Without this nudge the agent has
+// no way to learn its signal was dropped, so these cases matter as much as the
+// matcher's.
+func TestNudgeUnanchoredSignal(t *testing.T) {
+	t.Run("stray mention produces exactly one nudge, ever", func(t *testing.T) {
+		const clawID = "claw-nudge-once"
+		s := newNudgeTestServer(t, clawID, nil)
+
+		s.nudgeUnanchoredSignal(clawID, "Implementation complete, so [DONE].")
+		got := nudgeMessages(t, s, clawID)
+		if len(got) != 1 {
+			t.Fatalf("first turn produced %d nudges, want 1: %v", len(got), got)
+		}
+		if !strings.Contains(got[0], "[DONE]") {
+			t.Fatalf("nudge does not name the token: %q", got[0])
+		}
+
+		// Same token quoted again on later turns must not re-nudge: an agent
+		// that mentions [DONE] every turn would otherwise be nudged every turn,
+		// which is the spam this is designed to avoid.
+		s.nudgeUnanchoredSignal(clawID, "As I said, [DONE] is premature.")
+		s.nudgeUnanchoredSignal(clawID, "Still not sending [DONE].")
+		if got := nudgeMessages(t, s, clawID); len(got) != 1 {
+			t.Fatalf("repeat mentions produced %d nudges, want 1: %v", len(got), got)
+		}
+	})
+
+	t.Run("anchored signal suppresses the nudge", func(t *testing.T) {
+		const clawID = "claw-nudge-anchored"
+		s := newNudgeTestServer(t, clawID, nil)
+
+		// The agent signalled correctly; the second mention is commentary.
+		s.nudgeUnanchoredSignal(clawID, "[DONE] https://github.com/org/repo/pull/1\n\nI sent [DONE] as instructed.")
+		if got := nudgeMessages(t, s, clawID); len(got) != 0 {
+			t.Fatalf("nudged despite a correct signal: %v", got)
+		}
+	})
+
+	t.Run("a different anchored token also suppresses the nudge", func(t *testing.T) {
+		const clawID = "claw-nudge-other-anchored"
+		s := newNudgeTestServer(t, clawID, nil)
+
+		s.nudgeUnanchoredSignal(clawID, "[TERMINATE]\n\nI never reached [DONE].")
+		if got := nudgeMessages(t, s, clawID); len(got) != 0 {
+			t.Fatalf("nudged despite an anchored [TERMINATE]: %v", got)
+		}
+	})
+
+	t.Run("at most one nudge per turn", func(t *testing.T) {
+		const clawID = "claw-nudge-one-per-turn"
+		s := newNudgeTestServer(t, clawID, nil)
+
+		s.nudgeUnanchoredSignal(clawID, "Neither [DONE] nor [TERMINATE] applies yet.")
+		if got := nudgeMessages(t, s, clawID); len(got) != 1 {
+			t.Fatalf("two stray tokens produced %d nudges, want 1: %v", len(got), got)
+		}
+	})
+
+	t.Run("no token means no nudge", func(t *testing.T) {
+		const clawID = "claw-nudge-none"
+		s := newNudgeTestServer(t, clawID, nil)
+
+		s.nudgeUnanchoredSignal(clawID, "Still working through the migration.")
+		if got := nudgeMessages(t, s, clawID); len(got) != 0 {
+			t.Fatalf("nudged a message with no signal token: %v", got)
+		}
+	})
+
+	t.Run("pipeline tokens are nudged too", func(t *testing.T) {
+		// The dominant real case: an inject that only said "say
+		// [READY_TO_COMMIT]" and an agent that obliged mid-sentence. Without the
+		// pipeline's own tokens in the set, that message would freeze the run in
+		// silence.
+		const clawID = "claw-nudge-pipeline"
+		s := newNudgeTestServer(t, clawID, []*types.FactoryConfig{{
+			Name:        "nudge-factory",
+			Integration: "linear",
+			Workspace:   "test-workspace",
+			PipelineYAML: `
+stages:
+  - id: working
+    entry: true
+  - id: pre_commit
+    triggers:
+      - message_contains: "[READY_TO_COMMIT]"
+`,
+		}})
+
+		s.nudgeUnanchoredSignal(clawID, "Implementation complete, so [READY_TO_COMMIT].")
+		got := nudgeMessages(t, s, clawID)
+		if len(got) != 1 {
+			t.Fatalf("pipeline token produced %d nudges, want 1: %v", len(got), got)
+		}
+		if !strings.Contains(got[0], "[READY_TO_COMMIT]") {
+			t.Fatalf("nudge does not name the pipeline token: %q", got[0])
+		}
+	})
+
+	t.Run("a token whose stage is already behind us is not nudged", func(t *testing.T) {
+		// The inject that leaves such a stage usually tells the agent not to
+		// emit the token again. Nudging "resend it at the start of a line"
+		// would be talking it into a backwards transition, because
+		// message_contains triggers have no visited-stage guard of their own.
+		const clawID = "claw-nudge-visited"
+		s := newNudgeTestServer(t, clawID, []*types.FactoryConfig{{
+			Name:        "nudge-factory",
+			Integration: "linear",
+			Workspace:   "test-workspace",
+			PipelineYAML: `
+stages:
+  - id: working
+    entry: true
+  - id: pre_commit
+    triggers:
+      - message_contains: "[READY_TO_COMMIT]"
+`,
+		}})
+		if _, err := s.db.Exec(
+			`INSERT INTO pipeline_stage_history(claw_id, stage_id, created_at) VALUES(?,?,datetime('now'))`,
+			clawID, "pre_commit",
+		); err != nil {
+			t.Fatalf("mark stage visited: %v", err)
+		}
+
+		s.nudgeUnanchoredSignal(clawID, "I will not emit [READY_TO_COMMIT] again.")
+		if got := nudgeMessages(t, s, clawID); len(got) != 0 {
+			t.Fatalf("nudged a token whose stage already passed: %v", got)
+		}
+	})
+}

--- a/pkg/hub/workflow_harness_integration_test.go
+++ b/pkg/hub/workflow_harness_integration_test.go
@@ -186,7 +186,7 @@ func TestWorkflowHarness_GitHubIssuePrecommit(t *testing.T) {
 	bridge.WaitForMessage(t, "[READY_TO_COMMIT]", 5*time.Second)
 
 	// Fake agent: ready to commit
-	bridge.SendMessage("I've implemented the feature. [READY_TO_COMMIT]")
+	bridge.SendMessage("I've implemented the feature.\n\n[READY_TO_COMMIT]")
 
 	// Wait for pre-commit stage inject (after run command)
 	bridge.WaitForMessage(t, "Pre-commit checks passed", 5*time.Second)
@@ -224,7 +224,7 @@ func TestWorkflowHarness_RunFailsStop(t *testing.T) {
 	bridge.WaitForMessage(t, "Starting workflow", 5*time.Second)
 
 	// Fake agent: proceed to run-fail stage
-	bridge.SendMessage("Proceeding. [PROCEED]")
+	bridge.SendMessage("Proceeding.\n\n[PROCEED]")
 
 	// The run action fails (failing provider), so the inject message should NOT appear.
 	// Wait briefly to ensure the inject is NOT sent.
@@ -257,7 +257,7 @@ func TestWorkflowHarness_DeterministicGatePass(t *testing.T) {
 	bridge.WaitForMessage(t, "Initial plan required", 5*time.Second)
 	bridge.WaitForMessage(t, "Starting deterministic validation", 5*time.Second)
 
-	bridge.SendMessage("Ready for validation. [DONE]")
+	bridge.SendMessage("Ready for validation.\n\n[DONE]")
 
 	bridge.WaitForMessage(t, "Gate passed: Validation", 5*time.Second)
 	bridge.WaitForMessage(t, "No issues found. Workflow complete.", 5*time.Second)
@@ -279,14 +279,14 @@ func TestWorkflowHarness_DeterministicGateRetryLoop(t *testing.T) {
 	bridge.WaitForMessage(t, "Initial plan required", 5*time.Second)
 	bridge.WaitForMessage(t, "Starting deterministic validation", 5*time.Second)
 
-	bridge.SendMessage("Ready for validation. [DONE]")
+	bridge.SendMessage("Ready for validation.\n\n[DONE]")
 
 	bridge.WaitForMessage(t, "Gate failed: Validation", 5*time.Second)
 	bridge.WaitForMessage(t, "1 issue found. Apply the deterministic fix and say [RETRY].", 5*time.Second)
 	assertGateVerdict(t, ts, clawID, "validation", "fail")
 	assertPipelineStage(t, ts, clawID, "fix")
 
-	bridge.SendMessage("Retrying after deterministic fix. [RETRY]")
+	bridge.SendMessage("Retrying after deterministic fix.\n\n[RETRY]")
 
 	bridge.WaitForMessage(t, "Gate passed: Validation", 5*time.Second)
 	bridge.WaitForMessage(t, "No issues found. Workflow complete.", 5*time.Second)
@@ -311,7 +311,7 @@ func TestWorkflowHarness_RunFailsContinue(t *testing.T) {
 	bridge.WaitForMessage(t, "Starting workflow", 5*time.Second)
 
 	// Fake agent: proceed to run-fail-continue stage
-	bridge.SendMessage("Proceeding. [PROCEED]")
+	bridge.SendMessage("Proceeding.\n\n[PROCEED]")
 
 	// Wait for the warning message about the failed run
 	bridge.WaitForMessage(t, "Workflow command failed", 5*time.Second)
@@ -348,7 +348,7 @@ func TestWorkflowHarness_LinearMoveIssue(t *testing.T) {
 	bridge.WaitForMessage(t, "[READY_FOR_REVIEW]", 5*time.Second)
 
 	// Fake agent: ready for review
-	bridge.SendMessage("Ready for review. [READY_FOR_REVIEW]")
+	bridge.SendMessage("Ready for review.\n\n[READY_FOR_REVIEW]")
 
 	// Wait for terminal inject
 	bridge.WaitForMessage(t, "Issue moved to In Review", 5*time.Second)


### PR DESCRIPTION
## Two runs, two days, one substring

**NEXT-724** — a claw came up with no ticket, said it could not start, and listed the process it would follow once it had one:

```
5. Commit locally and signal `[IMPLEMENTATION_DONE]` per the lifecycle table.
```

The hub entered `review_loop` in the same millisecond. The agent then invented scope, the gateway stalled, and the run died 4h20m later. **$6.64, zero PRs.**

**NEXT-707** — the agent found a real blocker and wrote:

```
No implementation exists yet, so there's nothing to commit/push/PR —
sending `[DONE]` now would be a false signal.
```

The hub stamped **Agent Finished** on the Linear issue, told Slack the story was ready for human review, and instructed the agent to stop. Zero PRs, zero code. It was declared finished for saying it would not declare itself finished.

`StageForMessageContains` matched the token anywhere in the message. Every inject asks for the signal on the first line; the matcher never checked.

## One definition of "the agent signalled"

`pipeline.MessageSignals` requires the token to **open a line**, after leading whitespace and a small set of markdown decoration that agents demonstrably use — bold, italic, backticks, headings. Every character of that set is pinned by a test that fails when the character is removed.

Everything else that judged agent text now calls it:

| site | before |
| --- | --- |
| `server.go` `[DONE]` gates (×4) | `strings.Contains` |
| `server.go` `[TERMINATE]` | `strings.Contains` |
| `handleClawDoneSignal`, `handleClawTerminateSignal` | trusted the caller |
| `no_progress.go` | `strings.Contains` |
| `extractDonePRURLs` | case-sensitive `strings.Index` |

The `[TERMINATE]` one had the worst blast radius: *"I will not send [TERMINATE] yet"* tore the claw down.

The no-progress one is subtler — substring matching let an agent repeating *"I can't send [DONE] yet"* buy permanent immunity from the watchdog built to catch exactly that shape.

And `extractDonePRURLs` had to move too: `MessageSignals` is case-insensitive, so `[done] <url>` advances the stage — if the URL scan stayed case-sensitive the stage would advance with **zero PRs registered and merge tracking never armed**, the same one-text-two-verdicts split this change exists to remove.

## A missed signal must not freeze the run

Anchoring alone trades a loud bug for a silent one. A signal the hub stops recognising freezes the run forever, which is worse than the wrong transition.

So when a known token appears but never opens a line and nothing matched, the hub says so — **once per token per claw**, never when a signal did land, and never for a token whose stage is already behind, since resending that one would walk the pipeline backwards (`message_contains` triggers have no visited-stage guard of their own).

The injects in this repo were reworded to ask for the first line. `linear-story.yaml` gained the `[DONE]` instruction it never had, despite carrying the trigger.

## Not done, deliberately

**Refusing transitions to an earlier stage.** The original analysis proposed it; I checked and it would disable both retry routes — `[RETRY_ANDROID_DETECTION]` and `[RETRY_ANDROID_VALIDATION]` target stages *ahead of* the `fix_*` stage that emits them, so jumping backwards is by design. It also would not have caught either incident: both jumps were forward.

**next_tooling injects.** Separate repo, separate PR. The retry injects say "say exactly `[RETRY_ANDROID_DETECTION]`" without a line requirement, and `REVIEW_LOOP.md` still documents the token as matching "as a substring".

## Verification

```
gofmt -l <changed>   -> clean        go vet ./pkg/hub/...  -> clean
go build ./...       -> OK           go test ./pkg/hub/pipeline/ -race -> ok
```

Mutation-tested per character of the decoration set, and per fix: reverting `indexFold` fails `TestExtractDonePRURLs`; reverting the visited-stage filter fails `TestNudgeUnanchoredSignal`; reverting the anchoring itself fails six cases including both incident texts, quoted verbatim rather than paraphrased.

Two existing fixtures encoded the old contract and were corrected: `TestJiraTerminateSignalCommentsIssue` sent `"Stopping now. [TERMINATE]"`, and seven harness fixtures signalled mid-line. The harness tests fail identically with and without this change (they stall on "Initial plan required" on the base commit too), so those edits are correct-by-contract but **unverified by execution** — worth knowing.

The three live-GitHub tests fail here and on the base commit with byte-identical messages.

## Review

Two adversarial rounds. The first found that anchoring only the pipeline path *activated* the legacy one — the pipeline correctly declining meant `pipelineHandledDone` was false, so `handleClawDoneSignal` ran where it previously had not. That is why the diff reaches into `server.go`. The second round found the case-sensitivity split above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)