### PR TITLE
fix(hub): stop reading a dead transport as the agent talking

### DIFF
--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -51,6 +51,7 @@ import (
 	"nhooyr.io/websocket/wsjson"
 
 	"github.com/elasticclaw/elasticclaw/pkg/cliversion"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
 	_ "modernc.org/sqlite"
 )
 
@@ -4568,7 +4569,7 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 					// Notify the hub so it can inject a resume prompt with context.
 					_ = writeHub(hubMsg{Type: "session_rotated"})
 				} else {
-					reply = fmt.Sprintf("⚠️ error: %v", agentErr)
+					reply = fmt.Sprintf("%s %v", types.BridgeReplayErrorPrefix, agentErr)
 				}
 			}
 			if writeErr := deliver("claw", reply); writeErr != nil {
@@ -4695,7 +4696,7 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 						// Notify the hub so it can inject a resume prompt with context.
 						_ = writeHub(hubMsg{Type: "session_rotated"})
 					} else {
-						reply = fmt.Sprintf("⚠️ claw-bridge error: %v", agentErr)
+						reply = fmt.Sprintf("%s %v", types.BridgeErrorPrefix, agentErr)
 					}
 				} else {
 					log.Printf("[bridge] ← openclaw: %q", reply[:min(len(reply), 120)])

--- a/pkg/hub/bridge_error.go
+++ b/pkg/hub/bridge_error.go
@@ -1,0 +1,181 @@
+package hub
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+
+	"github.com/elasticclaw/elasticclaw/pkg/hub/pipeline"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+// Bridge transport errors (NEXT-725).
+//
+// claw-bridge answers a failed turn with the error text as the turn body (see
+// types.BridgeTransportError). The hub read that as the agent talking, and the
+// initial-plan gate — which only asks "is this message long enough to be a
+// real attempt?" — answered every one of them with another correction. On claw
+// 1572c4e4 the sandbox disk filled up: the ENOSPC reply was 158 characters,
+// comfortably over the gate's 120-character floor, so the hub re-sent the
+// correction, the bridge burned its full 60-minute turn cap failing again, and
+// the pair looped with the agent never producing a single word of its own.
+//
+// No existing recovery path could break it. claw_retry waits for an unhealthy
+// gateway (the gateway was fine — the DISK was full), the busy-turn watchdog
+// fires at 70 minutes but the bridge closes the turn at 60, idle auto-resume
+// requires no turn in flight, and the no-progress watchdog needed three
+// look-alike turns at an hour each. Worse, the word ENOSPC never reached the
+// hub's journal at all, so nobody could have known without opening the claw's
+// chat.
+//
+// bridgeErrorPauseThreshold is deliberately low. Every cycle costs up to an
+// hour, and the pause is cheap and reversible: a human sends any message and
+// resumeNoProgressAfterUserInput lifts it. A single error is genuinely
+// transient sometimes ("LLM request failed: network connection error", after
+// which the agent carried on), so 1 would stop healthy claws; 2 costs at most
+// one wasted cycle and still catches a stuck sandbox on its second try. The
+// streak resets on any real turn, so an occasional error never accumulates.
+const bridgeErrorPauseThreshold = 2
+
+// bridgeErrorNoticeLimit caps how much of the error we repeat into the
+// dashboard notice and the operator notification. The useful part ("no space
+// left on device") is at the front; a gateway stack trace is not.
+const bridgeErrorNoticeLimit = 400
+
+// observeBridgeErrorTurn records one bridge-error turn for a claw and reports
+// whether automatic continuation is paused as a result. The caller must route
+// bridge-error turns here INSTEAD of observeCompletedTurn: this is not an
+// agent outcome, and letting it into claw_turn_observations would let a single
+// transport blip reset the repeated-outcome chain the no-progress watchdog is
+// counting.
+func (s *Server) observeBridgeErrorTurn(cc *clawConn, clawID, errText string, definite bool) bool {
+	streak := 0
+	alreadyPaused := false
+	if cc != nil {
+		cc.mu.Lock()
+		// Only the bridge's own label counts toward stopping the claw; the
+		// generic replay label still silences the plan gate. See
+		// types.BridgeTransportErrorIsDefinite.
+		if definite {
+			cc.bridgeErrorStreak++
+		}
+		streak = cc.bridgeErrorStreak
+		alreadyPaused = cc.noProgressPaused
+		cc.mu.Unlock()
+	}
+	// Logged on EVERY bridge-error turn, not just at the threshold, and with
+	// the error verbatim: the incident's root cause was one grep away
+	// (`journalctl | grep ENOSPC` returned 0 matches) and nobody could reach it.
+	log.Printf("[bridge-error] claw %s: turn failed in the bridge transport (%d in a row), agent never ran: %s",
+		shortID(clawID), streak, errText)
+	if alreadyPaused {
+		return true
+	}
+	short := truncateRunes(errText, bridgeErrorNoticeLimit)
+	// The WARNING is deliberately not gated on the pause threshold. Reaching the
+	// threshold needs a SECOND turn, and nothing here guarantees one: with the
+	// plan gate no longer answering, the next turn only exists if the idle
+	// auto-resume fires — which is off when liveness.idle_resume is disabled,
+	// when the claw is ineligible, or once its lifetime resume cap is spent. Tie
+	// the alarm to that and a claw whose transport is dead can sit silent
+	// forever, which is the failure this whole change exists to end. So: tell
+	// the operator on the first one, stop the loop on the second.
+	if streak == 1 {
+		s.notifyBridgeError(clawID, short)
+	}
+	if streak < bridgeErrorPauseThreshold {
+		return false
+	}
+	notice := fmt.Sprintf("[hub] Automatic continuation paused: the last %d turns never reached the agent — claw-bridge returned a transport error instead. Last error: %s. This is the sandbox or the gateway failing, not the agent's output; fix it and send a message to resume.", streak, short)
+	if !s.pauseAutomaticContinuation(clawID, notice) {
+		// Someone else (or an earlier tick) already latched this claw. Still
+		// paused — just not by us, so no second notification.
+		return true
+	}
+	log.Printf("[bridge-error] claw %s: paused automatic continuation after %d consecutive bridge transport errors: %s",
+		shortID(clawID), streak, errText)
+	s.notifyBridgeErrorPause(clawID, streak, short)
+	return true
+}
+
+// notifyBridgeErrorPause delivers the pause to the operator over the existing
+// agent_idle lifecycle event.
+//
+// Reusing agent_idle rather than minting an event type is deliberate: the
+// operator-visible fact is identical ("this agent is not moving and nobody
+// told you"), the response is identical (go look), and agent_idle already has
+// the toggle, the severity, the run-backed notifier pass and the claw pass
+// wired up. A new type would mean a new toggle, a settings migration and a new
+// row in every notification-config test to express a distinction the message
+// body already carries — the same trade already argued for noProgressPaused,
+// which is folded into this event for exactly these reasons.
+//
+// Ad-hoc (non run-backed) claws get no event here: their delivery pass keys on
+// the claws.idle_since latch, which means "no turn finished for N minutes" and
+// is untrue for a claw that is finishing a failed turn every hour. Faking it
+// would misreport the duration in the message. Those claws are covered by the
+// dashboard notice and the log line above.
+func (s *Server) notifyBridgeErrorPause(clawID string, streak int, errText string) {
+	s.recordBridgeErrorEvent(clawID, streak, errText, true)
+}
+
+// notifyBridgeError is the same alarm without a pause: the transport failed,
+// and the operator hears about it before we know whether it will repeat.
+func (s *Server) notifyBridgeError(clawID, errText string) {
+	s.recordBridgeErrorEvent(clawID, 1, errText, false)
+}
+
+func (s *Server) recordBridgeErrorEvent(clawID string, streak int, errText string, paused bool) {
+	if err := s.recordTaskRunEventForClaw(clawID, TaskRunEvent{
+		// Keyed on the pause instant, so a second episode after a human
+		// resumes is a second notification instead of dedupe-swallowed.
+		EventKey:        taskRunEventAgentIdle + ":bridge-error:" + strconv.Itoa(streak) + ":" + strconv.FormatInt(epochMillis(now()), 10),
+		Source:          taskRunSourceHub,
+		EventType:       taskRunEventAgentIdle,
+		ActorType:       taskRunActorSystem,
+		InteractionRole: taskRunInteractionNeutral,
+		Detail: map[string]any{
+			"bridgeError":      errText,
+			"bridgeErrorTurns": streak,
+			"noProgressPaused": paused,
+		},
+		OccurredAt: now(),
+	}); err != nil {
+		log.Printf("[bridge-error] record notification event for claw %s: %v", shortID(clawID), err)
+	}
+}
+
+// observeTurnOutcome routes one completed turn to the consumer that owns it
+// and reports whether automatic continuation is now paused, plus whether the
+// turn was a bridge transport error.
+//
+// The split is the whole fix. A bridge-error turn deliberately never reaches
+// observeCompletedTurn: it is not an agent outcome, and letting it into
+// claw_turn_observations would let one transport blip reset the
+// repeated-outcome chain the no-progress watchdog is counting — the watchdog
+// would then need three MORE look-alike turns, at up to an hour each.
+// Conversely, any turn the agent actually authored proves the transport works,
+// so it clears the bridge-error streak.
+func (s *Server) observeTurnOutcome(cc *clawConn, clawID, messageID, content string) (paused bool, bridgeErrTurn bool) {
+	errText, definite, bridgeErrTurn := types.BridgeTransportErrorIsDefinite(content)
+	if bridgeErrTurn {
+		return s.observeBridgeErrorTurn(cc, clawID, errText, definite), true
+	}
+	if cc != nil {
+		cc.mu.Lock()
+		cc.bridgeErrorStreak = 0
+		cc.mu.Unlock()
+	}
+	return s.observeCompletedTurn(clawID, messageID, content), false
+}
+
+// turnMaySignal is pipeline.MessageSignals with the transport check in front.
+// A bridge-error body is written by claw-bridge, not by the agent, so a
+// gateway that folds agent output into its error text must not be able to
+// complete ([DONE]) or tear down ([TERMINATE]) a claw whose turn never ran.
+func turnMaySignal(content, token string, bridgeErrTurn bool) bool {
+	if bridgeErrTurn {
+		return false
+	}
+	return pipeline.MessageSignals(content, token)
+}

--- a/pkg/hub/bridge_error_test.go
+++ b/pkg/hub/bridge_error_test.go
@@ -1,0 +1,486 @@
+package hub
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+// The two turn bodies claw 1572c4e4 produced during NEXT-725, verbatim. Both
+// clear the initial-plan gate's 120-character floor, which is why the hub kept
+// answering them with another correction.
+const (
+	incidentENOSPCTurn   = "⚠️ claw-bridge error: ENOSPC: no space left on device, open '/home/daytona/.openclaw/agents/main/sessions/....jsonl.lock'"
+	incidentRecoveryTurn = "⚠️ claw-bridge error: context deadline exceeded; session recovery failed: sessions.create failed: ENOSPC: no space left on device, open '/home/daytona/.openclaw/agents/main/sessions/....jsonl.lock'"
+)
+
+func TestBridgeTransportErrorRecognisesDeployedBridgeReplies(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		wantErr string
+		want    bool
+	}{
+		{
+			name:    "live turn prefix from the incident",
+			content: incidentENOSPCTurn,
+			wantErr: "ENOSPC: no space left on device, open '/home/daytona/.openclaw/agents/main/sessions/....jsonl.lock'",
+			want:    true,
+		},
+		{
+			name:    "session recovery turn from the incident",
+			content: incidentRecoveryTurn,
+			wantErr: "context deadline exceeded; session recovery failed: sessions.create failed: ENOSPC: no space left on device, open '/home/daytona/.openclaw/agents/main/sessions/....jsonl.lock'",
+			want:    true,
+		},
+		{
+			name:    "replay path prefix",
+			content: "⚠️ error: LLM request failed: network connection error",
+			wantErr: "LLM request failed: network connection error",
+			want:    true,
+		},
+		{
+			name:    "leading whitespace still opens the message",
+			content: "\n  " + incidentENOSPCTurn,
+			wantErr: "ENOSPC: no space left on device, open '/home/daytona/.openclaw/agents/main/sessions/....jsonl.lock'",
+			want:    true,
+		},
+		{
+			name:    "agent quoting the error mid-sentence is the agent talking",
+			content: "The build log ends with ⚠️ claw-bridge error: ENOSPC: no space left on device, so I will clean the cache and retry.",
+		},
+		{
+			name:    "ordinary agent turn",
+			content: "I read the failing test and I am about to change the matcher.",
+		},
+		{name: "empty"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotErr, got := types.BridgeTransportError(tt.content)
+			if got != tt.want {
+				t.Fatalf("BridgeTransportError() ok = %v, want %v", got, tt.want)
+			}
+			if gotErr != tt.wantErr {
+				t.Fatalf("BridgeTransportError() err = %q, want %q", gotErr, tt.wantErr)
+			}
+		})
+	}
+}
+
+// The incident bodies must stay above the plan gate's length floor, otherwise
+// the regression tests below would pass for the wrong reason.
+func TestIncidentTurnsClearInitialPlanLengthFloor(t *testing.T) {
+	for _, content := range []string{incidentENOSPCTurn, incidentRecoveryTurn} {
+		if len(strings.TrimSpace(content)) < 120 {
+			t.Fatalf("incident turn is only %d bytes; it no longer exercises the gate", len(content))
+		}
+	}
+}
+
+func planGateClaw(t *testing.T, s *Server, clawID string, correctionSent bool) {
+	t.Helper()
+	if _, err := s.db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, tags, created_at) VALUES(?,?,?,?,datetime('now'))`,
+		clawID, "test-tenant-id", clawID, `[]`); err != nil {
+		t.Fatalf("insert claw %s: %v", clawID, err)
+	}
+	s.insertSystemMarker(clawID, "test-tenant-id", initialPlanRequiredMarker)
+	if correctionSent {
+		s.insertSystemMarker(clawID, "test-tenant-id", initialPlanCorrectionSentMarker)
+	}
+}
+
+func correctionCount(t *testing.T, s *Server, clawID string) int {
+	t.Helper()
+	var n int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND role='hub' AND content=?`,
+		clawID, initialPlanCorrectionContent).Scan(&n); err != nil {
+		t.Fatalf("count corrections for %s: %v", clawID, err)
+	}
+	return n
+}
+
+// The loop itself: a bridge error must never be answered with the plan
+// correction, while a genuine (incomplete) response still is.
+func TestHandleInitialPlanResponseIgnoresBridgeErrors(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, nil, "", "", "")
+
+	tests := []struct {
+		name            string
+		clawID          string
+		correctionSent  bool
+		content         string
+		wantCorrections int
+		wantAccepted    bool
+	}{
+		{
+			name:            "bridge error before any correction stays silent",
+			clawID:          "claw-bridge-error-first",
+			content:         incidentENOSPCTurn,
+			wantCorrections: 0,
+		},
+		{
+			name:            "bridge error after a correction does not re-send it",
+			clawID:          "claw-bridge-error-repeat",
+			correctionSent:  true,
+			content:         incidentRecoveryTurn,
+			wantCorrections: 0,
+		},
+		{
+			name:            "real incomplete response still gets the correction",
+			clawID:          "claw-real-incomplete",
+			content:         "Good, build passes. Now let me read the existing test files.",
+			wantCorrections: 1,
+		},
+		{
+			name:           "real incomplete response is re-nudged after a correction",
+			clawID:         "claw-real-renudge",
+			correctionSent: true,
+			content: "I looked at the repository and the CI configuration for a while and I am still deciding " +
+				"how to approach this, so here is a long update that carries no plan whatsoever yet.",
+			wantCorrections: 1,
+		},
+		{
+			name:           "substantial second attempt is still soft-accepted",
+			clawID:         "claw-soft-accept",
+			correctionSent: true,
+			content: strings.Repeat("Rough plan: add the lint workflow, wire pnpm cache, and run typecheck. ", 8) +
+				"Verification: run lint and typecheck in CI and confirm the PR checks go green.",
+			wantAccepted: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			planGateClaw(t, s, tt.clawID, tt.correctionSent)
+			s.handleInitialPlanResponse(tt.clawID, "test-tenant-id", tt.content)
+			if got := correctionCount(t, s, tt.clawID); got != tt.wantCorrections {
+				t.Fatalf("corrections sent = %d, want %d", got, tt.wantCorrections)
+			}
+			if got := s.hasSystemMarker(tt.clawID, initialPlanAcceptedMarker); got != tt.wantAccepted {
+				t.Fatalf("plan accepted = %v, want %v", got, tt.wantAccepted)
+			}
+			// A bridge error must also leave the gate armed, so the next real
+			// turn is judged exactly as it would have been.
+			if _, isBridgeError := types.BridgeTransportError(tt.content); isBridgeError {
+				if s.hasSystemMarker(tt.clawID, initialPlanCorrectionSentMarker) != tt.correctionSent {
+					t.Fatalf("bridge error changed the correction-sent marker")
+				}
+			}
+		})
+	}
+}
+
+func bridgeErrorClaw(t *testing.T, s *Server, clawID string) *clawConn {
+	t.Helper()
+	if _, err := s.db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, status, pipeline_stage, created_at) VALUES(?,?,?,?,?,datetime('now'))`,
+		clawID, "test-tenant-id", clawID, "connected", "ci_passed"); err != nil {
+		t.Fatalf("insert claw %s: %v", clawID, err)
+	}
+	cc := &clawConn{id: clawID, tenantID: "test-tenant-id"}
+	s.mu.Lock()
+	s.claws[clawID] = cc
+	s.mu.Unlock()
+	return cc
+}
+
+func pauseNotices(t *testing.T, s *Server, clawID string) []string {
+	t.Helper()
+	rows, err := s.db.Query(`SELECT content FROM messages WHERE claw_id=? AND role='hub' AND content LIKE '%Automatic continuation paused:%' ORDER BY rowid`, clawID)
+	if err != nil {
+		t.Fatalf("read notices: %v", err)
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var c string
+		if err := rows.Scan(&c); err != nil {
+			t.Fatal(err)
+		}
+		out = append(out, c)
+	}
+	return out
+}
+
+func clawPaused(t *testing.T, s *Server, clawID string) bool {
+	t.Helper()
+	var paused bool
+	if err := s.db.QueryRow(`SELECT COALESCE(no_progress_paused,0) != 0 FROM claws WHERE id=?`, clawID).Scan(&paused); err != nil {
+		t.Fatalf("read pause latch: %v", err)
+	}
+	return paused
+}
+
+// Two consecutive bridge errors pause automatic continuation exactly once, and
+// the notice carries the real error — "no space left on device" is what turns
+// an hour-long mystery into a one-minute fix.
+func TestConsecutiveBridgeErrorsPauseOnceAndSurfaceTheError(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+	const clawID = "claw-bridge-streak"
+	cc := bridgeErrorClaw(t, s, clawID)
+
+	errText, _ := types.BridgeTransportError(incidentENOSPCTurn)
+	if s.observeBridgeErrorTurn(cc, clawID, errText, true) {
+		t.Fatal("a single bridge error paused the claw; one error is transient")
+	}
+	if clawPaused(t, s, clawID) {
+		t.Fatal("a single bridge error latched the pause")
+	}
+	if got := len(pauseNotices(t, s, clawID)); got != 0 {
+		t.Fatalf("notices after one error = %d, want 0", got)
+	}
+
+	recoveryErr, _ := types.BridgeTransportError(incidentRecoveryTurn)
+	if !s.observeBridgeErrorTurn(cc, clawID, recoveryErr, true) {
+		t.Fatalf("%d consecutive bridge errors did not pause the claw", bridgeErrorPauseThreshold)
+	}
+	if !clawPaused(t, s, clawID) {
+		t.Fatal("pause was not persisted on the shared no_progress latch")
+	}
+	notices := pauseNotices(t, s, clawID)
+	if len(notices) != 1 {
+		t.Fatalf("notices after the pause = %d, want 1", len(notices))
+	}
+	if !strings.Contains(notices[0], "no space left on device") {
+		t.Fatalf("notice does not carry the real error: %q", notices[0])
+	}
+
+	// A third error must not notify again: the claw is already stopped.
+	if !s.observeBridgeErrorTurn(cc, clawID, recoveryErr, true) {
+		t.Fatal("a further bridge error unpaused the claw")
+	}
+	if got := len(pauseNotices(t, s, clawID)); got != 1 {
+		t.Fatalf("notices after a third error = %d, want 1", got)
+	}
+
+	// A human resuming clears both the latch and the streak, so the next
+	// pause costs the full threshold again.
+	s.resumeNoProgressAfterUserInput(clawID)
+	if clawPaused(t, s, clawID) {
+		t.Fatal("resume did not lift the bridge-error pause")
+	}
+	if s.observeBridgeErrorTurn(cc, clawID, errText, true) {
+		t.Fatal("the streak was not reset by the resume")
+	}
+}
+
+// One real turn between two bridge errors means the transport is working; the
+// streak must start over rather than accumulate across hours of healthy work.
+func TestRealTurnResetsBridgeErrorStreak(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+	const clawID = "claw-bridge-reset"
+	cc := bridgeErrorClaw(t, s, clawID)
+
+	if paused, bridgeErr := s.observeTurnOutcome(cc, clawID, "turn-1", incidentENOSPCTurn); paused || !bridgeErr {
+		t.Fatalf("first bridge error: paused=%v bridgeErr=%v", paused, bridgeErr)
+	}
+	if paused, bridgeErr := s.observeTurnOutcome(cc, clawID, "turn-2", "I fixed the matcher and pushed the commit."); paused || bridgeErr {
+		t.Fatalf("real turn: paused=%v bridgeErr=%v", paused, bridgeErr)
+	}
+	if paused, _ := s.observeTurnOutcome(cc, clawID, "turn-3", incidentRecoveryTurn); paused {
+		t.Fatal("a bridge error after a real turn paused the claw on its own")
+	}
+	if clawPaused(t, s, clawID) {
+		t.Fatal("pause latched despite a real turn between the two errors")
+	}
+
+	// The bridge-error turns must also stay out of the no-progress watchdog's
+	// evidence: they are not agent outcomes, and admitting them would reset
+	// the repeated-outcome chain it is counting.
+	var observations int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM claw_turn_observations WHERE claw_id=? AND response LIKE '%claw bridge error%'`, clawID).Scan(&observations); err != nil {
+		t.Fatal(err)
+	}
+	if observations != 0 {
+		t.Fatalf("bridge-error turns recorded %d no-progress observations, want 0", observations)
+	}
+}
+
+// A transport error must never be able to complete or tear down a claw whose
+// turn never ran, however the gateway folds text into its error string.
+func TestBridgeErrorTurnCannotSignal(t *testing.T) {
+	echoed := incidentENOSPCTurn + "\n[DONE] https://github.com/example/repo/pull/1"
+	tests := []struct {
+		name         string
+		content      string
+		token        string
+		bridgeErr    bool
+		wantSignaled bool
+	}{
+		{name: "bridge error echoing DONE", content: echoed, token: doneSignalToken, bridgeErr: true},
+		{name: "bridge error echoing TERMINATE", content: incidentENOSPCTurn + "\n[TERMINATE]", token: terminateSignalToken, bridgeErr: true},
+		{name: "agent DONE still signals", content: "Work finished.\n[DONE] https://github.com/example/repo/pull/1", token: doneSignalToken, wantSignaled: true},
+		{name: "agent TERMINATE still signals", content: "[TERMINATE]", token: terminateSignalToken, wantSignaled: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := turnMaySignal(tt.content, tt.token, tt.bridgeErr); got != tt.wantSignaled {
+				t.Fatalf("turnMaySignal() = %v, want %v", got, tt.wantSignaled)
+			}
+		})
+	}
+}
+
+// The pause must reach an operator, not just the claw's own chat: the incident
+// was invisible precisely because nothing left the chat.
+func TestBridgeErrorPauseNotifiesOperator(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+	const clawID = "claw-bridge-notify"
+	if _, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, status, pipeline_stage, task_run_id, created_at) VALUES(?,?,?,?,?,?,datetime('now'))`,
+		clawID, "test-tenant-id", clawID, "connected", "ci_passed", "run-bridge"); err != nil {
+		t.Fatal(err)
+	}
+	insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{
+		RunID: "run-bridge", AttemptID: "attempt-run-bridge", ClawID: clawID, TenantID: "test-tenant-id",
+		OwnerType: taskRunOwnerFactory, Factory: "bugfix", Phase: taskRunPhaseAgentRunning, StartedAt: int64(1760000000000),
+	})
+	cc := &clawConn{id: clawID, tenantID: "test-tenant-id"}
+	s.mu.Lock()
+	s.claws[clawID] = cc
+	s.mu.Unlock()
+
+	errText, _ := types.BridgeTransportError(incidentENOSPCTurn)
+	for i := 0; i < bridgeErrorPauseThreshold; i++ {
+		s.observeBridgeErrorTurn(cc, clawID, errText, true)
+	}
+
+	var detail string
+	if err := db.QueryRow(`SELECT detail FROM task_run_events WHERE run_id='run-bridge' AND event_type=?`, taskRunEventAgentIdle).Scan(&detail); err != nil {
+		t.Fatalf("no operator notification event was recorded: %v", err)
+	}
+	if !strings.Contains(detail, "no space left on device") {
+		t.Fatalf("notification detail does not carry the real error: %q", detail)
+	}
+}
+
+// The rendered notification must lead with the error, not with "agent stalled".
+func TestBridgeErrorNotificationRendersTheRealError(t *testing.T) {
+	ev := lifecycleEventRow{
+		EventType: taskRunEventAgentIdle,
+		Detail: map[string]any{
+			"bridgeError":      "ENOSPC: no space left on device, open '/home/daytona/.openclaw/agents/main/sessions/....jsonl.lock'",
+			"bridgeErrorTurns": 2,
+			"noProgressPaused": true,
+		},
+	}
+	msg := buildLifecycleMessage(ev, lifecycleRunContext{Repo: "example/repo", IssueID: "NEXT-725", ClawID: "1572c4e4"})
+	if !strings.Contains(msg.Body, "no space left on device") {
+		t.Fatalf("body does not carry the real error: %q", msg.Body)
+	}
+	if !strings.Contains(msg.Body, "2 consecutive turns") {
+		t.Fatalf("body does not say how many turns failed: %q", msg.Body)
+	}
+	if !strings.Contains(strings.Join(msg.Summary, " "), "no space left on device") {
+		t.Fatalf("push summary does not carry the real error: %q", msg.Summary)
+	}
+	// A real idle event must keep its own wording.
+	idle := buildLifecycleMessage(lifecycleEventRow{EventType: taskRunEventAgentIdle, Detail: map[string]any{"idleMinutes": 9}}, lifecycleRunContext{})
+	if !strings.Contains(idle.Body, "No agent activity") {
+		t.Fatalf("plain idle message changed: %q", idle.Body)
+	}
+}
+
+// The shared latch must be a latch: a second caller (the no-progress observer,
+// a racing tick) finds it already set, reports that it did not pause, and does
+// not publish a second notice into the claw's chat.
+func TestPauseAutomaticContinuationLatchesOnce(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+	const clawID = "claw-pause-latch"
+	cc := bridgeErrorClaw(t, s, clawID)
+
+	if !s.pauseAutomaticContinuation(clawID, "[hub] Automatic continuation paused: first.") {
+		t.Fatal("first pause did not latch")
+	}
+	if s.pauseAutomaticContinuation(clawID, "[hub] Automatic continuation paused: second.") {
+		t.Fatal("second pause claimed to latch an already-paused claw")
+	}
+	notices := pauseNotices(t, s, clawID)
+	if len(notices) != 1 {
+		t.Fatalf("notices = %d, want 1", len(notices))
+	}
+	cc.mu.RLock()
+	inMemory := cc.noProgressPaused
+	cc.mu.RUnlock()
+	if !inMemory || !clawPaused(t, s, clawID) {
+		t.Fatalf("pause not visible: memory=%v db=%v", inMemory, clawPaused(t, s, clawID))
+	}
+	// The no-progress observer must agree the claw is held rather than start
+	// its own count — the two stops share one latch, they do not compete.
+	if !s.observeCompletedTurn(clawID, "turn-1", "still waiting for CI") {
+		t.Fatal("observeCompletedTurn did not report the claw as already paused")
+	}
+}
+
+// The alarm must not wait for the pause threshold. Reaching it needs a SECOND
+// turn, and nothing guarantees one once the plan gate stops answering: the next
+// turn only exists if the idle auto-resume fires, which is off when
+// liveness.idle_resume is disabled, when the claw is ineligible, or once its
+// lifetime resume cap is spent. Tied to that, a dead transport could sit silent
+// forever — the exact failure this change exists to end.
+func TestFirstBridgeErrorNotifiesWithoutPausing(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+	const clawID = "claw-bridge-first"
+	if _, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, status, pipeline_stage, task_run_id, created_at) VALUES(?,?,?,?,?,?,datetime('now'))`,
+		clawID, "test-tenant-id", clawID, "connected", "working", "run-bridge-first"); err != nil {
+		t.Fatal(err)
+	}
+	insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{
+		RunID: "run-bridge-first", AttemptID: "attempt-first", ClawID: clawID, TenantID: "test-tenant-id",
+		OwnerType: taskRunOwnerFactory, Factory: "bugfix", Phase: taskRunPhaseAgentRunning, StartedAt: int64(1760000000000),
+	})
+	cc := &clawConn{id: clawID, tenantID: "test-tenant-id"}
+	s.mu.Lock()
+	s.claws[clawID] = cc
+	s.mu.Unlock()
+
+	errText, _ := types.BridgeTransportError(incidentENOSPCTurn)
+	if s.observeBridgeErrorTurn(cc, clawID, errText, true) {
+		t.Fatal("the first error paused the claw; one error is transient")
+	}
+	if clawPaused(t, s, clawID) {
+		t.Fatal("the first error latched the pause")
+	}
+
+	var detail string
+	if err := db.QueryRow(`SELECT detail FROM task_run_events WHERE run_id='run-bridge-first' AND event_type=?`,
+		taskRunEventAgentIdle).Scan(&detail); err != nil {
+		t.Fatalf("the first bridge error produced no operator notification: %v", err)
+	}
+	if !strings.Contains(detail, "no space left on device") {
+		t.Fatalf("first-error notification does not carry the real error: %q", detail)
+	}
+	if strings.Contains(detail, `"noProgressPaused":true`) {
+		t.Fatalf("first-error notification claims the claw is paused: %q", detail)
+	}
+}
+
+// The generic replay label is short enough for an agent to open a turn with it
+// while reporting a build failure. It still silences the plan gate — a turn
+// opening with an error is not a plan — but it must not count toward stopping
+// the claw, or a working agent gets paused and its operator gets told a lie
+// about the cause.
+func TestGenericErrorPrefixDoesNotCountTowardThePause(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+	const clawID = "claw-bridge-generic"
+	cc := bridgeErrorClaw(t, s, clawID)
+
+	errText, definite, ok := types.BridgeTransportErrorIsDefinite("⚠️ error: the build failed on step 3")
+	if !ok {
+		t.Fatal("the generic prefix must still be recognised so the plan gate stays quiet")
+	}
+	if definite {
+		t.Fatal("the generic prefix must not be treated as the bridge's own label")
+	}
+	for i := 0; i < bridgeErrorPauseThreshold+2; i++ {
+		if s.observeBridgeErrorTurn(cc, clawID, errText, definite) {
+			t.Fatalf("generic-prefix turn %d paused the claw", i+1)
+		}
+	}
+	if clawPaused(t, s, clawID) {
+		t.Fatal("generic-prefix turns latched the pause")
+	}
+}

--- a/pkg/hub/lifecycle_notifier.go
+++ b/pkg/hub/lifecycle_notifier.go
@@ -1041,6 +1041,27 @@ func buildAgentIdleMessage(ev lifecycleEventRow, runCtx lifecycleRunContext) not
 	if subject == "" {
 		subject = "task"
 	}
+	// A bridge-error pause is carried by this event (see notifyBridgeErrorPause)
+	// and renders from the real error text. "Agent stalled" would send an
+	// operator to read the agent's chat; "no space left on device" sends them to
+	// the disk, which is the whole point of NEXT-725 — the error existed only
+	// inside the claw's chat and never reached a human.
+	if bridgeError := detailString(ev.Detail, "bridgeError"); bridgeError != "" {
+		turns := "Consecutive turns"
+		if n := intFromDetail(ev.Detail, "bridgeErrorTurns", "bridge_error_turns"); n > 0 {
+			turns = fmt.Sprintf("%d consecutive turns", n)
+		}
+		body := fmt.Sprintf("%s never reached the agent: claw-bridge returned a transport error instead. Automatic continuation is paused until someone sends a message.\n\n%s", turns, bridgeError)
+		return notify.Message{
+			Title:    style.title,
+			Emoji:    style.emoji,
+			Severity: style.severity,
+			Subject:  subject,
+			Body:     body,
+			Fields:   lifecycleMetaFields(runCtx, true, false),
+			Summary:  []string{runCtx.Repo, subject, "bridge error: " + compressSummaryReason(bridgeError)},
+		}
+	}
 	idleLabel := agentIdleDurationLabel(ev.Detail)
 	body := "No agent activity"
 	if idleLabel != "" {

--- a/pkg/hub/no_progress.go
+++ b/pkg/hub/no_progress.go
@@ -130,6 +130,9 @@ func (s *Server) resumeNoProgressAfterUserInput(clawID string) {
 	if cc != nil {
 		cc.mu.Lock()
 		cc.noProgressPaused = false
+		// A human intervened, so the bridge-error streak starts over too: the
+		// next pause should again cost bridgeErrorPauseThreshold turns, not one.
+		cc.bridgeErrorStreak = 0
 		cc.mu.Unlock()
 	}
 	if changed, _ := res.RowsAffected(); changed > 0 {
@@ -283,4 +286,43 @@ func responseProgressMarkers(content string) []string {
 	}
 	sort.Strings(markers)
 	return markers
+}
+
+// pauseAutomaticContinuation latches the SAME no_progress_paused stop that
+// observeCompletedTurn uses, for a caller that already knows the claw must
+// stop. It exists so a second stop reason (bridge transport errors, NEXT-725)
+// reuses the existing latch — column, in-memory flag, every
+// `cc.noProgressPaused` delivery gate, and resumeNoProgressAfterUserInput —
+// instead of adding a second pause mechanism that those gates would have to
+// learn about one by one.
+//
+// It reports whether THIS call performed the pause: an already-paused claw
+// returns false so the caller does not notify a human twice about a claw that
+// is already stopped. Both writers take noProgressMu, so an observation tick
+// and a bridge error cannot both think they were the one to latch.
+func (s *Server) pauseAutomaticContinuation(clawID, notice string) bool {
+	s.noProgressMu.Lock()
+	defer s.noProgressMu.Unlock()
+
+	res, err := s.db.Exec(`UPDATE claws SET no_progress_paused=1 WHERE id=? AND COALESCE(no_progress_paused,0)=0`, clawID)
+	if err != nil {
+		log.Printf("[no-progress] pause claw %s: %v", shortID(clawID), err)
+		return false
+	}
+	changed, _ := res.RowsAffected()
+	if changed == 0 {
+		return false
+	}
+	s.mu.RLock()
+	cc := s.claws[clawID]
+	s.mu.RUnlock()
+	if cc != nil {
+		cc.mu.Lock()
+		cc.noProgressPaused = true
+		cc.mu.Unlock()
+	}
+	if notice != "" {
+		s.publishHubNotice(clawID, notice)
+	}
+	return true
 }

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -235,6 +235,7 @@ type clawConn struct {
 	contextWarningSent   bool            // true once the context-nearly-full warning has been injected this turn
 	awaitingResponse     bool            // true as soon as a prompt is delivered, before the first chunk/activity
 	noProgressPaused     bool            // automatic delivery is paused after repeated turns with unchanged progress
+	bridgeErrorStreak    int             // consecutive turns that came back as a claw-bridge transport error (NEXT-725)
 	lastTurnFinishedAt   time.Time       // when the last streaming turn ended (for post-restart resume window)
 	connectedAt          time.Time       // when this connection registered; immutable after registration
 	idleNotifiedAt       time.Time       // when the agent_idle notification fired for the current idle stretch (zero = armed)
@@ -2862,7 +2863,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 					)
 					s.broadcastToUsers(tenantID, types.WSMessage{Type: "message", Payload: hm})
 				}
-				automaticContinuationPaused := s.observeCompletedTurn(clawID, hm.ID, turnContent)
+				automaticContinuationPaused, bridgeErrTurn := s.observeTurnOutcome(cc, clawID, hm.ID, turnContent)
 				if !automaticContinuationPaused {
 					s.handleInitialPlanResponse(clawID, tenantID, turnContent)
 				}
@@ -2872,7 +2873,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				// so pipelineHandledDone stayed false and the legacy handler ran on
 				// exactly the text the pipeline had just rejected — the NEXT-707
 				// outcome, reached by the code that was supposed to prevent it.
-				doneSignalled := pipeline.MessageSignals(turnContent, doneSignalToken)
+				doneSignalled := turnMaySignal(turnContent, doneSignalToken, bridgeErrTurn)
 				// Evaluate pipeline triggers. If a pipeline explicitly owns a
 				// [DONE] trigger, let it handle that signal instead of the
 				// legacy factory PR-URL completion path below.
@@ -2905,14 +2906,14 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 							})
 						}
 					}
-				} else if !doneSignalled {
+				} else if !doneSignalled && !bridgeErrTurn {
 					s.safeGo("pipeline message triggers", func() { s.checkPipelineMessageTriggers(clawID, turnContent) })
 				}
 				// A known token written mid-sentence no longer transitions
 				// anything. Tell the agent so, or the run freezes with nobody
 				// aware the signal was dropped. Skipped while continuation is
 				// paused: that claw is already being held, not waiting on us.
-				if !automaticContinuationPaused {
+				if !automaticContinuationPaused && !bridgeErrTurn {
 					s.safeGo("unanchored signal nudge", func() { s.nudgeUnanchoredSignal(clawID, turnContent) })
 				}
 				// Clear typing indicator now that response is complete
@@ -2938,7 +2939,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				// lifecycle. Anchored for the same reason as [DONE], with a worse
 				// blast radius: under substring matching an agent writing "I will
 				// not send [TERMINATE] yet" tore down its own claw.
-				if pipeline.MessageSignals(turnContent, terminateSignalToken) {
+				if turnMaySignal(turnContent, terminateSignalToken, bridgeErrTurn) {
 					go s.handleClawTerminateSignal(clawID, turnContent)
 				}
 				// Detect and store PR URLs mentioned mid-work. [DONE] turns are
@@ -2953,7 +2954,10 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				// there would silently drop PR URLs the agent did post.
 				if doneSignalled {
 					log.Printf("[pr-watcher] skipping PR scan for claw %s: [DONE] registration is handled explicitly", shortID(clawID))
-				} else {
+				} else if !bridgeErrTurn {
+					// A transport error can quote a repository URL (git and CI
+					// failures routinely do). Arming the PR watcher on text the
+					// agent never wrote would watch a PR nobody opened.
 					go s.scanMessageForPRs(clawID, turnContent)
 				}
 				// Detect tool error loops and inject a corrective message
@@ -6336,6 +6340,15 @@ func (s *Server) insertSystemMarker(clawID, tenantID, marker string) bool {
 
 func (s *Server) handleInitialPlanResponse(clawID, tenantID, content string) {
 	if !s.hasSystemMarker(clawID, initialPlanRequiredMarker) || s.hasSystemMarker(clawID, initialPlanAcceptedMarker) {
+		return
+	}
+	// A claw-bridge transport error is not a plan attempt — the agent never
+	// saw the request. Re-sending the correction to it is what turned a full
+	// disk into an endless hourly loop on claw 1572c4e4 (NEXT-725): the ENOSPC
+	// reply cleared the length floor below, so the gate kept answering the
+	// transport. Stay silent and leave the gate armed; the next real turn is
+	// judged exactly as before.
+	if _, isBridgeError := types.BridgeTransportError(content); isBridgeError {
 		return
 	}
 	// Strict keyword match, or a substantial second attempt after we already

--- a/pkg/types/bridge_error.go
+++ b/pkg/types/bridge_error.go
@@ -1,0 +1,62 @@
+package types
+
+import "strings"
+
+// Bridge transport errors (NEXT-725).
+//
+// When a turn fails before or inside the gateway, claw-bridge has no reply to
+// send, so it sends the error text as the turn body. The hub used to read that
+// as the agent speaking: on claw 1572c4e4 the sandbox disk filled up, every
+// turn came back as "⚠️ claw-bridge error: ENOSPC: no space left on device",
+// and the initial-plan gate answered each one with another correction — one
+// hour per round trip, forever, with the word ENOSPC never once reaching the
+// hub's journal.
+//
+// The prefixes below are what bridges ALREADY deployed write, and they are the
+// only recognition signal that works today: a claw only gets a new bridge when
+// it is created after a release, so a new protocol field would leave every
+// live claw on the old path. The bridge builds its replies from these same
+// constants so the two halves cannot drift apart silently.
+const (
+	// BridgeErrorPrefix opens the reply written when a live turn fails.
+	BridgeErrorPrefix = "⚠️ claw-bridge error:"
+	// BridgeReplayErrorPrefix opens the same reply on the reconnect-replay
+	// path, which has always used a shorter label. Both are in the field.
+	BridgeReplayErrorPrefix = "⚠️ error:"
+)
+
+// BridgeTransportError reports whether a claw turn body is a bridge error
+// reply and returns the underlying error text.
+//
+// The prefix must OPEN the message, for the reason the [DONE]/[TERMINATE]
+// matchers are anchored: an agent that quotes or explains an error it saw
+// ("the build printed ⚠️ claw-bridge error: ...") is talking, and treating
+// that turn as a dead transport would silently stop a working claw.
+func BridgeTransportError(content string) (string, bool) {
+	errText, _, ok := bridgeTransportError(content)
+	return errText, ok
+}
+
+// BridgeTransportErrorIsDefinite additionally reports whether the reply carried
+// the bridge's OWN label rather than the generic replay one.
+//
+// Only the definite form should count toward stopping a claw. "⚠️ error:" is
+// short enough that an agent can plausibly open a turn with it while reporting
+// a build failure, and mistaking that for a dead transport would pause a
+// working claw and tell its operator a lie about the cause. Silencing the plan
+// gate on the generic form is safe either way — a turn opening with an error
+// is not a plan.
+func BridgeTransportErrorIsDefinite(content string) (string, bool, bool) {
+	return bridgeTransportError(content)
+}
+
+func bridgeTransportError(content string) (errText string, definite bool, ok bool) {
+	trimmed := strings.TrimSpace(content)
+	if rest, cut := strings.CutPrefix(trimmed, BridgeErrorPrefix); cut {
+		return strings.TrimSpace(rest), true, true
+	}
+	if rest, cut := strings.CutPrefix(trimmed, BridgeReplayErrorPrefix); cut {
+		return strings.TrimSpace(rest), false, true
+	}
+	return "", false, false
+}

--- a/pkg/types/bridge_error_test.go
+++ b/pkg/types/bridge_error_test.go
@@ -1,0 +1,17 @@
+package types
+
+import "testing"
+
+// The prefixes are a WIRE FORMAT, not a label: bridges already running in the
+// field emit these exact strings, and a claw only gets a newer bridge when it
+// is created after a release. Changing a byte here silently un-recognises
+// every live claw and brings back the NEXT-725 loop, so the literals are
+// pinned to what the deployed bridges write.
+func TestBridgeErrorPrefixesMatchDeployedBridges(t *testing.T) {
+	if BridgeErrorPrefix != "⚠️ claw-bridge error:" {
+		t.Fatalf("live-turn prefix changed: %q", BridgeErrorPrefix)
+	}
+	if BridgeReplayErrorPrefix != "⚠️ error:" {
+		t.Fatalf("replay prefix changed: %q", BridgeReplayErrorPrefix)
+	}
+}


### PR DESCRIPTION
## The incident

NEXT-725's sandbox ran out of disk. The agent never produced a word of its own — every turn came back as the transport's error text:

```
15:30:24  hub sends the plan correction
15:43:35  claw: "⚠️ claw-bridge error: ENOSPC: no space left on device, open '.../sessions/....jsonl.lock'"
16:43:35  claw: "⚠️ claw-bridge error: context deadline exceeded; session recovery failed: ... ENOSPC"
16:43:35  hub sends the plan correction again
```

```
[hub] initial plan still incomplete for claw 1572c4e4 (len=158 words=11); re-sending correction
[hub] initial plan still incomplete for claw 1572c4e4 (len=283 words=22); re-sending correction
```

Exactly one hour apart — the bridge's turn cap. The ENOSPC reply is 158 characters, comfortably over the gate's 120-character floor, so the gate read it as a real-but-incomplete attempt and answered. Forever.

**Nothing could break it.** I walked every recovery path:

| mechanism | why it never fired |
| --- | --- |
| `claw_retry` | needs 12 unhealthy gateway heartbeats — the gateway was fine, the **disk** was full |
| busy-turn watchdog | fires at 70 min; the bridge closes the turn at 60 |
| idle auto-resume | requires no turn in flight; there was always one |
| no-progress | needs three look-alike turns, at an hour each |

And `journalctl | grep ENOSPC` returned **zero**. The cause existed only inside the claw's chat.

## One idea

**A claw-bridge error reply is not the agent speaking.** It is the transport reporting that the turn never ran. The hub treated it as agent content everywhere, and that is where the loop came from.

Recognition matches what bridges **already deployed** write — a claw only gets a new bridge when it is created after a release, so a new protocol field would leave the whole live fleet on the old path. It is anchored at the start of the message for the same reason the signal matchers are: an agent quoting an error it saw is talking. The bridge now builds those replies from the shared constants, and a test pins the literals, so editing one breaks the build instead of silently un-recognising every live claw.

From there:

- the plan gate stops counting such a turn as an attempt, and stops answering
- two consecutive ones stop automatic continuation, reusing the no-progress latch rather than inventing a second pause
- the error is logged verbatim on **every** occurrence, and the operator is notified

## The warning does not wait for the pause

This is the part the review caught, and it matters more than the pause.

Reaching the threshold needs a **second turn** — and once the gate stops answering, nothing guarantees one. The next turn only exists if idle auto-resume fires, which is off when `liveness.idle_resume` is disabled, when the claw is ineligible, or once its lifetime resume cap is spent. Tied to that, a dead transport could sit silent forever: a loud loop traded for a silent freeze, which is worse and is exactly the failure this change exists to end.

So the operator hears on the **first** error. The loop stops on the second.

Only the bridge's own label counts toward stopping a claw. The shorter replay label (`⚠️ error:`) is something an agent can plausibly open a turn with while reporting a build failure — it still silences the plan gate, because a turn opening with an error is not a plan, but it must not pause a working claw and blame the transport.

## What else the turn is kept out of

Signal matching, pipeline message triggers, PR scan. That body is written by claw-bridge, so a gateway folding agent output into its error text must not be able to complete (`[DONE]`) or tear down (`[TERMINATE]`) a claw whose turn never ran — and git failures quote repository URLs routinely, which would arm the watcher on a PR nobody opened.

Kept: the transcript, the broadcast, and turn analytics. Hiding the cost of failure is how this stayed invisible.

## Verification

```
gofmt -l <changed>  -> clean      go vet ./pkg/hub/... ./pkg/types/...  -> clean
go build ./...      -> OK         go test ./pkg/types/ ./pkg/hub/pipeline/ ./cmd/claw-bridge/  -> ok
```

Ten mutations from the implementation round, plus two for the review fixes: removing the first-error notification fails `TestFirstBridgeErrorNotifiesWithoutPausing`; letting the generic prefix count fails `TestGenericErrorPrefixDoesNotCountTowardThePause`. Tests use the incident's messages verbatim, and one test asserts they clear the gate's 120-character floor — otherwise the others would pass for the wrong reason.

**A fourth test failure showed up in the full suite** beyond the three known live-GitHub ones: `TestPlanGatePassWithRouteDoesNotInjectProceedTurn`. Since this diff touches the plan gate, I treated it as mine until proven otherwise. It passes in isolation, and on a clean `origin/main` worktree it fails **2 of 6** full-suite runs — the same rate as this branch. It is a pre-existing flake: the test polls for a stage change with a 2-second deadline, which the full suite's load exceeds.

## Not done

- No auto-kill or re-provision — that is the operator's call.
- No fatal-vs-transient classifier on the error string; it would break silently when the upstream message changes. Repeats are treated uniformly and the human reads the actual error.
- No change to the bridge's turn cap.
- Ad-hoc (non run-backed) claws get the log and the dashboard notice but no operator event: that delivery pass keys on `idle_since`, which means "no turn finished for N minutes" and is untrue here.
- `⚠️ claw-bridge:` (the dropped-queue warning) is also transport speech still read as agent content. One-shot per reconnect, no loop — worth its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)