### PR TITLE
fix(hub): three Slack notification defects (start, threads, formatting)

### DIFF
--- a/pkg/hub/agent_idle.go
+++ b/pkg/hub/agent_idle.go
@@ -633,7 +633,7 @@ func (s *Server) parkAgentIdleStretch(nowAt time.Time, clawID string, cc *clawCo
 		if _, err := s.db.Exec(`
 			INSERT INTO slack_notification_deliveries(event_id, run_id, delivered_at, message_ts, status)
 			VALUES(?,?,?,?,?) ON CONFLICT(event_id) DO NOTHING`,
-			lifecycleClawIdleKey(clawID, stretchStart), lifecycleClawThreadKey(clawID),
+			lifecycleClawIdleKey(clawID, stretchStart), lifecycleClawRunKey(clawID),
 			epochMillis(nowAt), "", notificationDeliveryStatusSkipped); err != nil {
 			log.Printf("[agent-idle] park claw %s: %v", shortID(clawID), err)
 			return // retry next tick; nothing latched yet

--- a/pkg/hub/lifecycle_claw_notifier.go
+++ b/pkg/hub/lifecycle_claw_notifier.go
@@ -40,10 +40,7 @@ import (
 //
 // Dedupe reuses slack_notification_deliveries with namespaced synthetic keys
 // ("claw:<id>:agent_started", "claw:<id>:failure", "claw:<id>:pr:<url>") that
-// can never collide with task_run_events ids. Threading reuses
-// slack_run_threads with the namespaced key "claw:<id>" in the run_id column,
-// so all events for one ad-hoc claw share one thread and existing run threads
-// keep working unchanged.
+// can never collide with task_run_events ids.
 const (
 	// lifecycleStateClawBaselineKey marks that the claw pass has recorded the
 	// current claw/PR state as history. Set on the first enabled run so
@@ -79,6 +76,10 @@ func lifecycleClawPRKey(clawID, prURL string) string {
 	return "claw:" + clawID + ":pr:" + prURL
 }
 
+// lifecycleClawRunKey keeps synthetic claw delivery rows distinct from
+// task-run rows.
+func lifecycleClawRunKey(clawID string) string { return "claw:" + clawID }
+
 // lifecycleClawIdleKey keys one idle stretch of one ad-hoc claw. The latch
 // value (claws.idle_since, the stretch's start in millis) is part of the key
 // so a claw that goes idle, works, and goes idle again gets a fresh key — and
@@ -87,10 +88,6 @@ func lifecycleClawPRKey(clawID, prURL string) string {
 func lifecycleClawIdleKey(clawID string, idleSince int64) string {
 	return "claw:" + clawID + ":idle:" + strconv.FormatInt(idleSince, 10)
 }
-
-// lifecycleClawThreadKey namespaces the claw id for the slack_run_threads run_id
-// column so claw threads can never collide with task run ids.
-func lifecycleClawThreadKey(clawID string) string { return "claw:" + clawID }
 
 // lifecycleClawRow is the claws-table context the claw pass renders messages from.
 type lifecycleClawRow struct {
@@ -483,15 +480,15 @@ func (s *Server) deliverLifecycleClawEvent(d lifecycleDelivery, claw lifecycleCl
 		return true
 	}
 
-	threadKey := lifecycleClawThreadKey(claw.ID)
-	err := s.postLifecycleEvent(d, ev, runCtx, threadKey, deliveryKey, claw.TenantID)
+	runKey := lifecycleClawRunKey(claw.ID)
+	err := s.postLifecycleEvent(d, ev, runCtx, runKey, deliveryKey)
 	if err == nil {
 		s.clearPollWarning(lifecycleSendWarningKey)
 		return true
 	}
 	// Same send-failure policy as the task-run pass: config errors pause,
 	// permanent errors are burned as failed, transient errors stop the pass.
-	handled, _ := s.handleLifecycleSendError(err, "claw event "+deliveryKey, deliveryKey, threadKey)
+	handled, _ := s.handleLifecycleSendError(err, "claw event "+deliveryKey, deliveryKey, runKey)
 	return handled
 }
 
@@ -555,7 +552,7 @@ func (s *Server) lifecycleClawPRPass(d lifecycleDelivery) {
 			// cursor to move past it); the task-run pass dedupes under its
 			// own event ids, so the keys never collide.
 			s.recordNotificationDelivery(lifecycleClawPRKey(pr.Claw.ID, pr.PRURL),
-				lifecycleClawThreadKey(pr.Claw.ID), "", notificationDeliveryStatusSkipped)
+				lifecycleClawRunKey(pr.Claw.ID), "", notificationDeliveryStatusSkipped)
 			continue
 		}
 		if pr.ClawCreatedAt > cutoff {

--- a/pkg/hub/lifecycle_claw_notifier_test.go
+++ b/pkg/hub/lifecycle_claw_notifier_test.go
@@ -60,7 +60,7 @@ func insertSlackTestWorkflowRun(t *testing.T, db *sql.DB, id, clawID, status str
 	}
 }
 
-func TestLifecycleClawNotifierAdhocLifecycleThreadsUnderOneRoot(t *testing.T) {
+func TestLifecycleClawNotifierAdhocLifecyclePostsTopLevel(t *testing.T) {
 	fake := newFakeSlackServer(t)
 	s, db := newSlackNotifierTestServer(t, fake.server.URL, nil)
 	setSlackWatermark(t, s, 0)
@@ -75,7 +75,7 @@ func TestLifecycleClawNotifierAdhocLifecycleThreadsUnderOneRoot(t *testing.T) {
 	}
 	root := fake.request(0)
 	if root.ThreadTS != "" {
-		t.Fatalf("first claw message should be the thread root, got thread_ts %q", root.ThreadTS)
+		t.Fatalf("first claw message must be top-level, got thread_ts %q", root.ThreadTS)
 	}
 	if !strings.Contains(root.Fallback, "Agent started") || !strings.Contains(root.Fallback, "name-claw-adhoc") {
 		t.Fatalf("agent_started fallback = %q", root.Fallback)
@@ -125,13 +125,12 @@ func TestLifecycleClawNotifierAdhocLifecycleThreadsUnderOneRoot(t *testing.T) {
 		t.Fatal("failure message does not include bootstrap_diagnostic as the reason")
 	}
 
-	// All three thread under the same claw root.
-	var threadTS string
-	if err := db.QueryRow(`SELECT thread_ts FROM slack_run_threads WHERE run_id=?`, lifecycleClawThreadKey("claw-adhoc")).Scan(&threadTS); err != nil {
-		t.Fatalf("claw thread root row: %v", err)
+	if prMsg.ThreadTS != "" || failMsg.ThreadTS != "" {
+		t.Fatalf("claw lifecycle messages must be top-level: pr=%q fail=%q", prMsg.ThreadTS, failMsg.ThreadTS)
 	}
-	if prMsg.ThreadTS != threadTS || failMsg.ThreadTS != threadTS {
-		t.Fatalf("claw events not threaded under one root: pr=%q fail=%q root=%q", prMsg.ThreadTS, failMsg.ThreadTS, threadTS)
+	var threadRows int
+	if err := db.QueryRow(`SELECT COUNT(1) FROM slack_run_threads`).Scan(&threadRows); err != nil || threadRows != 0 {
+		t.Fatalf("claw lifecycle notifier wrote %d thread rows (err %v), want 0", threadRows, err)
 	}
 
 	// Deliveries recorded under the namespaced synthetic keys.
@@ -341,9 +340,9 @@ func TestLifecycleClawNotifierFailureToggleOff(t *testing.T) {
 	}
 }
 
-// A task-run thread and a claw thread must not interfere: each gets its own
-// root and its own replies.
-func TestLifecycleClawAndTaskRunThreadsAreIndependent(t *testing.T) {
+// Task-run and ad-hoc claw events must all remain independently visible at
+// the channel top level.
+func TestLifecycleClawAndTaskRunEventsAreTopLevel(t *testing.T) {
 	fake := newFakeSlackServer(t)
 	s, db := newSlackNotifierTestServer(t, fake.server.URL, nil)
 	setSlackWatermark(t, s, 0)
@@ -367,31 +366,15 @@ func TestLifecycleClawAndTaskRunThreadsAreIndependent(t *testing.T) {
 		t.Fatalf("sent %d messages, want 2 task-run + 2 claw", fake.count())
 	}
 
-	var runRoot, clawRoot string
-	if err := db.QueryRow(`SELECT thread_ts FROM slack_run_threads WHERE run_id='run-1'`).Scan(&runRoot); err != nil {
-		t.Fatalf("run thread root: %v", err)
-	}
-	if err := db.QueryRow(`SELECT thread_ts FROM slack_run_threads WHERE run_id=?`, lifecycleClawThreadKey("claw-adhoc")).Scan(&clawRoot); err != nil {
-		t.Fatalf("claw thread root: %v", err)
-	}
-	if runRoot == clawRoot {
-		t.Fatalf("task-run and claw threads share a root ts %q", runRoot)
-	}
 	for i := 0; i < fake.count(); i++ {
 		req := fake.request(i)
-		if req.ThreadTS == "" {
-			continue // a root
+		if req.ThreadTS != "" {
+			t.Fatalf("message %d posted in thread %q, want top-level", i, req.ThreadTS)
 		}
-		switch {
-		case strings.Contains(req.Fallback, "acme/app#7"):
-			if req.ThreadTS != runRoot {
-				t.Fatalf("task-run reply threaded under %q, want run root %q", req.ThreadTS, runRoot)
-			}
-		case strings.Contains(req.Fallback, "acme/tools#3"):
-			if req.ThreadTS != clawRoot {
-				t.Fatalf("claw reply threaded under %q, want claw root %q", req.ThreadTS, clawRoot)
-			}
-		}
+	}
+	var threadRows int
+	if err := db.QueryRow(`SELECT COUNT(1) FROM slack_run_threads`).Scan(&threadRows); err != nil || threadRows != 0 {
+		t.Fatalf("lifecycle notifier wrote %d thread rows (err %v), want 0", threadRows, err)
 	}
 }
 

--- a/pkg/hub/lifecycle_notifier.go
+++ b/pkg/hub/lifecycle_notifier.go
@@ -23,7 +23,7 @@ import (
 // opened, failures) into outbound notifications, delivered through the
 // hub-level notifier named by notifications.lifecycle.via. All provider
 // specifics (Block Kit, colours, pacing) live in pkg/hub/notify; this file
-// owns event scanning, dedupe, threading bookkeeping and the semantic
+// owns event scanning, dedupe and the semantic
 // message content.
 //
 // The dedupe/thread/state tables keep their historical slack_* names: they
@@ -168,21 +168,6 @@ func notifierCacheKey(name string, nc types.NotifierConfig, secrets notify.Secre
 	return key
 }
 
-// notifierDestination is the provider-reported destination of a constructed
-// notifier, used only as thread-root bookkeeping: a thread root recorded for
-// one destination must not be reused after the operator points the notifier
-// at another. Asking the instance (rather than reading a provider-specific
-// settings key) keeps the hub ignorant of provider config shapes and reflects
-// exactly what the notifier was built with, overrides included. A provider
-// that cannot name its destination yields "", which callers treat as unknown
-// — threading is skipped entirely — never as a match-everything wildcard.
-func notifierDestination(n notify.Notifier) string {
-	if d, ok := n.(notify.DestinationReporter); ok {
-		return d.Destination()
-	}
-	return ""
-}
-
 // enabledLifecycleEventTypes maps the config toggles onto concrete event
 // types. All categories default to enabled when the toggles block is absent.
 func enabledLifecycleEventTypes(lc *types.LifecycleNotificationsConfig) map[string]bool {
@@ -203,10 +188,6 @@ func enabledLifecycleEventTypes(lc *types.LifecycleNotificationsConfig) map[stri
 		}
 	}
 	return enabled
-}
-
-func lifecycleThreadByRun(lc *types.LifecycleNotificationsConfig) bool {
-	return lc == nil || lc.ThreadByRun == nil || *lc.ThreadByRun
 }
 
 func (s *Server) lifecyclePollInterval() time.Duration {
@@ -339,12 +320,10 @@ type lifecycleRunContext struct {
 }
 
 // lifecycleDelivery bundles what the two event passes need to deliver one
-// message: the notifier, the lifecycle config, and the thread-root
-// destination bookkeeping value.
+// message: the notifier and lifecycle config.
 type lifecycleDelivery struct {
-	notifier    notify.Notifier
-	lc          *types.LifecycleNotificationsConfig
-	destination string
+	notifier notify.Notifier
+	lc       *types.LifecycleNotificationsConfig
 }
 
 func (s *Server) lifecycleNotifierTick() {
@@ -381,9 +360,9 @@ func (s *Server) lifecycleNotifierTick() {
 	s.clearPollWarning("notify-config")
 	s.clearPollWarning("notify-notifier")
 
-	d := lifecycleDelivery{notifier: notifier, lc: lc, destination: notifierDestination(notifier)}
+	d := lifecycleDelivery{notifier: notifier, lc: lc}
 	// Two independent event sources share the notifier, dedupe table and
-	// thread table: task-run events for claws that belong to a task run, and
+	// legacy thread table: task-run events for claws that belong to a task run, and
 	// the claw pass for ad-hoc claws (task_run_id=''). See
 	// lifecycle_claw_notifier.go for the exclusivity rule that prevents
 	// double notifications.
@@ -579,26 +558,17 @@ func (s *Server) lifecycleMaxEventRowID() (int64, error) {
 	return maxRow, err
 }
 
-// sendLifecycleEvent renders one task-run event, posts it (threaded per run
-// when configured) and records the delivery.
+// sendLifecycleEvent renders one task-run event, posts it top-level and
+// records the delivery.
 func (s *Server) sendLifecycleEvent(d lifecycleDelivery, ev lifecycleEventRow) error {
 	runCtx := s.lifecycleRunContextFor(ev.RunID)
-	return s.postLifecycleEvent(d, ev, runCtx, ev.RunID, ev.ID, ev.TenantID)
+	return s.postLifecycleEvent(d, ev, runCtx, ev.RunID, ev.ID)
 }
 
-// postLifecycleEvent renders one event, posts it (threaded per threadKey
-// when configured) and records the delivery under deliveryKey. Task-run
-// events use (run_id, event id); claw-pass events use namespaced synthetic
-// keys ("claw:<id>", "claw:<id>:<kind>") so the two sources share the thread
-// and dedupe tables without ever colliding.
-//
-// Threading rides in Message.Thread — the opaque handle a provider returned
-// from an earlier Send — so the hub never names any provider's wire field
-// (Slack maps it onto thread_ts; providers without threading ignore it).
-// Roots are only recorded and reused when the notifier reports a destination:
-// an unknown destination ("") must not match anything, or a repointed
-// notifier would reply into threads that do not exist at the new destination.
-func (s *Server) postLifecycleEvent(d lifecycleDelivery, ev lifecycleEventRow, runCtx lifecycleRunContext, threadKey, deliveryKey, tenantID string) error {
+// postLifecycleEvent renders one event, posts it top-level and records the
+// delivery under deliveryKey. The slack_run_threads table remains for legacy
+// data, but lifecycle notifications no longer read or write it.
+func (s *Server) postLifecycleEvent(d lifecycleDelivery, ev lifecycleEventRow, runCtx lifecycleRunContext, runKey, deliveryKey string) error {
 	if s.lifecycleDeliveryPending(deliveryKey) {
 		// Already sent; only the delivery-row write is outstanding (see
 		// recordNotificationDelivery). Sending again would duplicate the
@@ -607,50 +577,13 @@ func (s *Server) postLifecycleEvent(d lifecycleDelivery, ev lifecycleEventRow, r
 	}
 	msg := buildLifecycleMessage(ev, runCtx)
 
-	threading := lifecycleThreadByRun(d.lc) && d.destination != ""
-	haveRoot := false
-	if threading {
-		var rootDest, rootTS string
-		err := s.db.QueryRow(`SELECT channel, thread_ts FROM slack_run_threads WHERE run_id=?`, threadKey).Scan(&rootDest, &rootTS)
-		switch {
-		case err == nil && rootDest == d.destination:
-			msg.Thread = rootTS
-			haveRoot = true
-		case err == nil:
-			// Root recorded for another destination: the notifier was
-			// repointed. Post top-level and let the upsert below move the
-			// root to the new destination.
-		case err == sql.ErrNoRows:
-			// First message for this thread key.
-		default:
-			// A transient read failure (a locked DB) must not be mistaken for
-			// "no root": posting top-level AND upserting would replace the
-			// run's existing root, permanently splitting the run across two
-			// threads. Post top-level but leave the root bookkeeping alone.
-			log.Printf("[notify] read thread root for %s: %v", threadKey, err)
-			threading = false
-		}
-	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	handle, err := d.notifier.Send(ctx, msg)
 	if err != nil {
 		return err
 	}
-	// The first message for a thread key becomes the thread root — whatever
-	// event it is (e.g. pr_opened when agent_started is disabled).
-	if threading && !haveRoot && handle != "" {
-		_, dbErr := s.db.Exec(`
-			INSERT INTO slack_run_threads(run_id, tenant_id, channel, thread_ts, created_at)
-			VALUES(?,?,?,?,?)
-			ON CONFLICT(run_id) DO UPDATE SET channel=excluded.channel, thread_ts=excluded.thread_ts`,
-			threadKey, tenantID, d.destination, handle, epochMillis(now()))
-		if dbErr != nil {
-			log.Printf("[notify] record thread root for %s: %v", threadKey, dbErr)
-		}
-	}
-	s.recordNotificationDelivery(deliveryKey, threadKey, handle, notificationDeliveryStatusSent)
+	s.recordNotificationDelivery(deliveryKey, runKey, handle, notificationDeliveryStatusSent)
 	// A success ends any transient-failure streak for this delivery.
 	s.clearNotifierState(lifecycleTransientFailureStateKey(deliveryKey))
 	return nil

--- a/pkg/hub/lifecycle_notifier.go
+++ b/pkg/hub/lifecycle_notifier.go
@@ -361,11 +361,10 @@ func (s *Server) lifecycleNotifierTick() {
 	s.clearPollWarning("notify-notifier")
 
 	d := lifecycleDelivery{notifier: notifier, lc: lc}
-	// Two independent event sources share the notifier, dedupe table and
-	// legacy thread table: task-run events for claws that belong to a task run, and
-	// the claw pass for ad-hoc claws (task_run_id=''). See
-	// lifecycle_claw_notifier.go for the exclusivity rule that prevents
-	// double notifications.
+	// Two independent event sources share the notifier and dedupe table:
+	// task-run events for claws that belong to a task run, and the claw pass
+	// for ad-hoc claws (task_run_id=''). See lifecycle_claw_notifier.go for
+	// the exclusivity rule that prevents double notifications.
 	s.lifecycleTaskRunPass(d)
 	s.lifecycleClawPass(d)
 }

--- a/pkg/hub/lifecycle_notifier_test.go
+++ b/pkg/hub/lifecycle_notifier_test.go
@@ -54,8 +54,8 @@ func newSlackNotifierTestServer(t *testing.T, slackURL string, mutate func(*type
 
 // testLifecycleDelivery builds the delivery bundle exactly as
 // lifecycleNotifierTick does, so tests that drive a single pass or a single
-// send exercise the real notifier instance (and therefore the real pacing and
-// destination bookkeeping) instead of a hand-rolled client.
+// send exercise the real notifier instance (and therefore the real pacing)
+// instead of a hand-rolled client.
 func testLifecycleDelivery(t *testing.T, s *Server) lifecycleDelivery {
 	t.Helper()
 	cfg := s.notificationsConfig()
@@ -70,7 +70,7 @@ func testLifecycleDelivery(t *testing.T, s *Server) lifecycleDelivery {
 	if err != nil {
 		t.Fatalf("build notifier: %v", err)
 	}
-	return lifecycleDelivery{notifier: notifier, lc: cfg.Lifecycle, destination: notifierDestination(notifier)}
+	return lifecycleDelivery{notifier: notifier, lc: cfg.Lifecycle}
 }
 
 func insertSlackTestEvent(t *testing.T, db *sql.DB, id, runID, eventType string, observedAt int64, targetURL, failureType, detail string) {
@@ -167,7 +167,7 @@ func TestSlackNotifierDedupesOnCursorRescan(t *testing.T) {
 	}
 }
 
-func TestSlackNotifierThreadsEventsByRun(t *testing.T) {
+func TestSlackNotifierPostsEventsTopLevel(t *testing.T) {
 	fake := newFakeSlackServer(t)
 	s, db := newSlackNotifierTestServer(t, fake.server.URL, nil)
 
@@ -187,18 +187,12 @@ func TestSlackNotifierThreadsEventsByRun(t *testing.T) {
 	}
 	root := fake.request(0)
 	reply := fake.request(1)
-	if root.ThreadTS != "" {
-		t.Fatalf("agent_started should be the thread root, got thread_ts %q", root.ThreadTS)
+	if root.ThreadTS != "" || reply.ThreadTS != "" {
+		t.Fatalf("lifecycle messages must be top-level: root=%q reply=%q", root.ThreadTS, reply.ThreadTS)
 	}
-	if reply.ThreadTS == "" {
-		t.Fatal("pr_opened was not threaded under the run root")
-	}
-	var threadTS string
-	if err := db.QueryRow(`SELECT thread_ts FROM slack_run_threads WHERE run_id='run-1'`).Scan(&threadTS); err != nil {
-		t.Fatalf("thread root row: %v", err)
-	}
-	if reply.ThreadTS != threadTS {
-		t.Fatalf("reply thread_ts %q != stored root %q", reply.ThreadTS, threadTS)
+	var threadRows int
+	if err := db.QueryRow(`SELECT COUNT(1) FROM slack_run_threads`).Scan(&threadRows); err != nil || threadRows != 0 {
+		t.Fatalf("lifecycle notifier wrote %d thread rows (err %v), want 0", threadRows, err)
 	}
 	if !strings.Contains(reply.Fallback, "PR opened") || !strings.Contains(reply.Fallback, "acme/app#7") {
 		t.Fatalf("pr_opened fallback = %q", reply.Fallback)
@@ -231,11 +225,6 @@ func TestSlackNotifierDisabledEventToggle(t *testing.T) {
 	}
 	if req.ThreadTS != "" {
 		t.Fatal("pr_opened without a prior root should post top-level")
-	}
-	// With no agent_started root, the pr_opened message becomes the run's root.
-	var threadTS string
-	if err := db.QueryRow(`SELECT thread_ts FROM slack_run_threads WHERE run_id='run-1'`).Scan(&threadTS); err != nil {
-		t.Fatalf("thread root row: %v", err)
 	}
 	// The muted event is parked as skipped so a later re-enable can never
 	// replay it (see TestSlackNotifierMutedCategoryNotReplayedOnReenable).
@@ -1259,9 +1248,7 @@ func TestSlackNotifierTransientFailureCapUnwedgesCursor(t *testing.T) {
 	}
 }
 
-// stubNotifier is a minimal provider without DestinationReporter: it returns
-// handles (so it LOOKS threadable to the old handle-based inference) but
-// cannot name its destination.
+// stubNotifier is a minimal provider that records top-level sends.
 type stubNotifier struct{ sends int }
 
 func (s *stubNotifier) Send(ctx context.Context, msg notify.Message) (string, error) {
@@ -1272,20 +1259,12 @@ func (s *stubNotifier) Send(ctx context.Context, msg notify.Message) (string, er
 	return fmt.Sprintf("handle-%d", s.sends), nil
 }
 
-// Regression: an unknown destination ("" — the provider does not implement
-// DestinationReporter) must disable thread bookkeeping entirely, not act as a
-// match-everything wildcard. Before the fix the root row was recorded with
-// channel=” and every later event matched it, replying into threads that may
-// not exist wherever the notifier now points.
-func TestLifecycleUnknownDestinationDisablesThreading(t *testing.T) {
+func TestLifecyclePostDoesNotWriteLegacyThreadRows(t *testing.T) {
 	fake := newFakeSlackServer(t)
 	s, db := newSlackNotifierTestServer(t, fake.server.URL, nil)
 
 	stub := &stubNotifier{}
-	if got := notifierDestination(stub); got != "" {
-		t.Fatalf("notifierDestination(stub) = %q, want empty", got)
-	}
-	d := lifecycleDelivery{notifier: stub, lc: s.notificationsConfig().Lifecycle, destination: notifierDestination(stub)}
+	d := lifecycleDelivery{notifier: stub, lc: s.notificationsConfig().Lifecycle}
 
 	base := int64(1760000000000)
 	insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{
@@ -1293,17 +1272,16 @@ func TestLifecycleUnknownDestinationDisablesThreading(t *testing.T) {
 		Factory: "bugfix", StartedAt: base - 1000,
 	})
 	ev := lifecycleEventRow{ID: "ev-1", RunID: "run-1", EventType: taskRunEventAgentStarted}
-	if err := s.postLifecycleEvent(d, ev, s.lifecycleRunContextFor("run-1"), "run-1", "ev-1", "test-tenant-id"); err != nil {
+	if err := s.postLifecycleEvent(d, ev, s.lifecycleRunContextFor("run-1"), "run-1", "ev-1"); err != nil {
 		t.Fatalf("first post: %v", err)
 	}
-	// The second event must post top-level (the stub errors on any Thread) and
-	// no root row may be recorded for the unknown destination.
+	// The second event must stay top-level and no legacy root row may be written.
 	ev2 := lifecycleEventRow{ID: "ev-2", RunID: "run-1", EventType: taskRunEventPROpened}
-	if err := s.postLifecycleEvent(d, ev2, s.lifecycleRunContextFor("run-1"), "run-1", "ev-2", "test-tenant-id"); err != nil {
+	if err := s.postLifecycleEvent(d, ev2, s.lifecycleRunContextFor("run-1"), "run-1", "ev-2"); err != nil {
 		t.Fatalf("second post: %v", err)
 	}
 	var n int
 	if err := db.QueryRow(`SELECT COUNT(1) FROM slack_run_threads`).Scan(&n); err != nil || n != 0 {
-		t.Fatalf("unknown destination recorded %d thread roots (err %v), want 0", n, err)
+		t.Fatalf("lifecycle post recorded %d thread roots (err %v), want 0", n, err)
 	}
 }

--- a/pkg/hub/notify/notify.go
+++ b/pkg/hub/notify/notify.go
@@ -124,11 +124,11 @@ type Notifier interface {
 }
 
 // DestinationReporter is implemented by providers that can name their
-// configured default destination (Slack: the channel ID). Callers use it only
-// as opaque bookkeeping — e.g. thread roots recorded for one destination must
-// stop matching after the operator repoints the notifier elsewhere. Callers
-// must treat a provider without this interface (or an empty string) as an
-// unknown destination, never as a match-everything wildcard.
+// configured default destination (Slack: the channel ID). The value is opaque
+// bookkeeping — it identifies where a notifier currently points so a caller
+// can tell two notifier configurations apart. Callers must treat a provider
+// without this interface (or an empty string) as an unknown destination,
+// never as a match-everything wildcard.
 type DestinationReporter interface {
 	Destination() string
 }

--- a/pkg/hub/notify_action.go
+++ b/pkg/hub/notify_action.go
@@ -40,9 +40,8 @@ const notifyActionTimeout = 10 * time.Minute
 // CloseIssue in the same on_enter make the same choice.
 //
 // A pipeline notification is a one-shot send: Message.Thread stays empty and
-// no thread bookkeeping (slack_run_threads) is written or reused — that state
-// belongs to the lifecycle notifier, whose thread roots track task runs, not
-// stages. A stage that wants threading passes provider options instead
+// no thread bookkeeping (slack_run_threads) is written or reused. A stage
+// that wants threading passes provider options instead
 // (e.g. options: {thread_ts: ...} for Slack).
 func (s *Server) executeNotifyAction(clawID string, stage pipeline.Stage, action pipeline.NotifyAction, pipelineCtx pipelineContext) {
 	via := strings.TrimSpace(action.Via)
@@ -78,11 +77,30 @@ func (s *Server) executeNotifyAction(clawID string, stage pipeline.Stage, action
 		return renderInjectWithData(clawID, text, data)
 	}
 	message := notify.Message{
-		Text:    render(action.Text),
-		Subject: render(action.Subject),
-		Target:  render(action.Target),
-		Options: action.Options,
+		Text:     render(action.Text),
+		Subject:  render(action.Subject),
+		Target:   render(action.Target),
+		Options:  action.Options,
+		Severity: notify.SeverityInfo,
 	}
+	switch action.Severity {
+	case "success":
+		message.Severity = notify.SeveritySuccess
+	case "warning":
+		message.Severity = notify.SeverityWarning
+	case "error":
+		message.Severity = notify.SeverityError
+	}
+	if pipelineCtx.IssueID != "" {
+		message.Fields = append(message.Fields, notify.Field{Label: "issue", Value: pipelineCtx.IssueID, Code: true})
+	}
+	if pipelineCtx.Workflow != nil && pipelineCtx.Workflow.Name != "" {
+		message.Fields = append(message.Fields, notify.Field{Value: "workflow " + pipelineCtx.Workflow.Name})
+	}
+	if clawID != "" {
+		message.Fields = append(message.Fields, notify.Field{Label: "claw", Value: shortID(clawID), Code: true})
+	}
+	message.Summary = pipelineNotifySummary(pipelineCtx.IssueID)
 	s.safeGo("pipeline notify", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), notifyActionTimeout)
 		defer cancel()
@@ -92,6 +110,17 @@ func (s *Server) executeNotifyAction(clawID string, stage pipeline.Stage, action
 		}
 		log.Printf("[pipeline] notify action sent for claw %s stage %q via %q", clawID, stage.ID, via)
 	})
+}
+
+// pipelineNotifySummary builds the push-notification summary slot.
+// slackFallbackText already leads with msg.Text (there is no Title on a
+// pipeline notification), so Summary must not repeat it — only the issue
+// identifier adds anything the fallback headline does not already say.
+func pipelineNotifySummary(issueID string) []string {
+	if issueID == "" {
+		return nil
+	}
+	return []string{issueID}
 }
 
 // notifierForPipeline resolves the named hub notifier for a pipeline notify

--- a/pkg/hub/notify_action.go
+++ b/pkg/hub/notify_action.go
@@ -76,20 +76,20 @@ func (s *Server) executeNotifyAction(clawID string, stage pipeline.Stage, action
 		}
 		return renderInjectWithData(clawID, text, data)
 	}
+	severity, known := notifySeverity(action.Severity)
+	if !known {
+		// Save-time validation rejects an unknown severity, so this can only
+		// be an artifact saved before that check existed. Warn instead of
+		// silently colouring it info, but still send: one notification typo
+		// must never suppress a stage's notification.
+		s.warnNotifyAction(clawID, stage.ID, fmt.Errorf("notify severity %q must be info, success, warning or error; sending as info", action.Severity))
+	}
 	message := notify.Message{
 		Text:     render(action.Text),
 		Subject:  render(action.Subject),
 		Target:   render(action.Target),
 		Options:  action.Options,
-		Severity: notify.SeverityInfo,
-	}
-	switch action.Severity {
-	case "success":
-		message.Severity = notify.SeveritySuccess
-	case "warning":
-		message.Severity = notify.SeverityWarning
-	case "error":
-		message.Severity = notify.SeverityError
+		Severity: severity,
 	}
 	if pipelineCtx.IssueID != "" {
 		message.Fields = append(message.Fields, notify.Field{Label: "issue", Value: pipelineCtx.IssueID, Code: true})
@@ -110,6 +110,26 @@ func (s *Server) executeNotifyAction(clawID string, stage pipeline.Stage, action
 		}
 		log.Printf("[pipeline] notify action sent for claw %s stage %q via %q", clawID, stage.ID, via)
 	})
+}
+
+// notifySeverity maps a notify action's severity: value onto the notify
+// tier's severity, reporting whether the value is known. It is the single
+// definition shared by the save-time check (validateNotifyVias) and this
+// send path, so an author can never be told a value is valid and then get a
+// different colour than the one they named. An unset severity is the
+// documented default, info.
+func notifySeverity(value string) (notify.Severity, bool) {
+	switch strings.TrimSpace(value) {
+	case "", "info":
+		return notify.SeverityInfo, true
+	case "success":
+		return notify.SeveritySuccess, true
+	case "warning":
+		return notify.SeverityWarning, true
+	case "error":
+		return notify.SeverityError, true
+	}
+	return notify.SeverityInfo, false
 }
 
 // pipelineNotifySummary builds the push-notification summary slot.

--- a/pkg/hub/notify_action_test.go
+++ b/pkg/hub/notify_action_test.go
@@ -154,6 +154,35 @@ func TestNotifyActionSendsRenderedSlackMessage(t *testing.T) {
 // {{.Issue.*}} from the pipeline context and {{.Inputs.*}} from a manual
 // trigger. A message with a subject opts into Slack's rich (attachment)
 // rendering, so the subject is asserted inside the blocks.
+// severity: picks the colour stripe; a value the save-time check never lets
+// through still sends, as info, with a warning.
+func TestNotifyActionMapsSeverity(t *testing.T) {
+	for severity, want := range map[string]string{
+		"warning": notify.SlackColorWarning,
+		"error":   notify.SlackColorError,
+		"success": notify.SlackColorSuccess,
+		"urgent":  notify.SlackColorInfo,
+	} {
+		t.Run(severity, func(t *testing.T) {
+			fake := newFakeSlackServer(t)
+			s, _, clawID := newNotifyActionTestServer(t, notifyTestNotifiers(fake.server.URL))
+			stage := pipeline.Stage{ID: "announce", OnEnter: pipeline.OnEnter{Notify: pipeline.NotifyAction{
+				Enabled:  true,
+				Via:      notifyTestVia,
+				Text:     "Build failed",
+				Severity: severity,
+			}}}
+			if _, err := s.runOnEnter(clawID, stage, pipelineContext{}); err != nil {
+				t.Fatalf("notify action blocked the stage transition: %v", err)
+			}
+			waitForSlackRequests(t, fake, 1)
+			if got := fake.request(0).Color; got != want {
+				t.Fatalf("severity %q colour = %q, want %q", severity, got, want)
+			}
+		})
+	}
+}
+
 func TestNotifyActionRendersIssueAndInputTemplates(t *testing.T) {
 	fake := newFakeSlackServer(t)
 	s, db, _ := newNotifyActionTestServer(t, notifyTestNotifiers(fake.server.URL))

--- a/pkg/hub/notify_action_test.go
+++ b/pkg/hub/notify_action_test.go
@@ -130,8 +130,17 @@ func TestNotifyActionSendsRenderedSlackMessage(t *testing.T) {
 	}
 	waitForSlackRequests(t, fake, 1)
 	req := fake.request(0)
-	if req.Text != "Build passed" {
-		t.Fatalf("Slack text = %q, want %q", req.Text, "Build passed")
+	if req.Text != "" {
+		t.Fatalf("semantic Slack message has top-level text %q, want empty", req.Text)
+	}
+	if req.Fallback != "Build passed" {
+		t.Fatalf("Slack fallback = %q, want %q", req.Fallback, "Build passed")
+	}
+	if req.Color != notify.SlackColorInfo || len(req.Blocks) == 0 {
+		t.Fatalf("plain notify action did not use semantic Slack rendering: color=%q blocks=%d", req.Color, len(req.Blocks))
+	}
+	if blocks := fmt.Sprintf("%v", req.Blocks); !strings.Contains(blocks, "Build passed") {
+		t.Fatalf("blocks %q do not preserve rendered operator text", blocks)
 	}
 	if req.Channel != "C0RELEASE1" {
 		t.Fatalf("Slack channel = %q, want templated target %q", req.Channel, "C0RELEASE1")
@@ -171,8 +180,11 @@ func TestNotifyActionRendersIssueAndInputTemplates(t *testing.T) {
 	}
 	waitForSlackRequests(t, fake, 1)
 	req := fake.request(0)
-	if want := "Merged https://github.com/octo/app/issues/7"; req.Fallback != want {
-		t.Fatalf("fallback = %q, want rendered text %q", req.Fallback, want)
+	// The fallback leads with the rendered text and appends the issue
+	// identifier as summary context, matching the lifecycle cards' slot
+	// discipline.
+	if want := "Merged https://github.com/octo/app/issues/7 — octo/app/7"; req.Fallback != want {
+		t.Fatalf("fallback = %q, want %q", req.Fallback, want)
 	}
 	blocks := fmt.Sprintf("%v", req.Blocks)
 	if !strings.Contains(blocks, "#7 requested by ana") {
@@ -204,9 +216,16 @@ func TestNotifyActionEscapesUntrustedTemplateData(t *testing.T) {
 		t.Fatalf("notify action blocked the stage transition: %v", err)
 	}
 	waitForSlackRequests(t, fake, 1)
+	// The notify action now renders through the semantic tier, so the
+	// escaped text lands in the fallback and blocks, not the top-level
+	// "text" field (which the semantic tier always omits).
 	want := "Build &lt;!channel&gt; &lt;https://evil.example|Approve&gt; &amp; done"
-	if got := fake.request(0).Text; got != want {
-		t.Fatalf("Slack text = %q, want escaped %q", got, want)
+	req := fake.request(0)
+	if req.Fallback != want {
+		t.Fatalf("Slack fallback = %q, want escaped %q", req.Fallback, want)
+	}
+	if blocks := fmt.Sprintf("%v", req.Blocks); !strings.Contains(blocks, want) {
+		t.Fatalf("blocks %q do not contain escaped text %q", blocks, want)
 	}
 }
 

--- a/pkg/hub/notify_validate.go
+++ b/pkg/hub/notify_validate.go
@@ -11,11 +11,12 @@ import (
 )
 
 // notifyActionRef locates one enabled notify action inside a pipeline: the
-// stage that declares it and its trimmed "via" notifier name (empty when the
-// action has no usable via).
+// stage that declares it, its trimmed "via" notifier name (empty when the
+// action has no usable via) and its raw "severity" value.
 type notifyActionRef struct {
-	StageID string
-	Via     string
+	StageID  string
+	Via      string
+	Severity string
 }
 
 // notifyActionRefs parses pipelineYAML and returns a ref for every enabled
@@ -36,8 +37,9 @@ func notifyActionRefs(pipelineYAML string) []notifyActionRef {
 			continue
 		}
 		refs = append(refs, notifyActionRef{
-			StageID: stage.ID,
-			Via:     strings.TrimSpace(stage.OnEnter.Notify.Via),
+			StageID:  stage.ID,
+			Via:      strings.TrimSpace(stage.OnEnter.Notify.Via),
+			Severity: stage.OnEnter.Notify.Severity,
 		})
 	}
 	return refs
@@ -62,7 +64,8 @@ func effectiveWorkflowPipelineYAML(workflow *types.WorkflowConfig) (string, erro
 
 // validateNotifyVias rejects a pipeline at save time when it contains a
 // notify action whose "via" is blank or names no notifier in notifiers (the
-// set under notifications.notifiers in hub.yaml). Every offending action is
+// set under notifications.notifiers in hub.yaml), or whose "severity" is not
+// one of the four known values. Every offending action is
 // reported in one error, prefixed with label — `workflow "release"`,
 // `factory "triage"` — naming its stage and listing the defined notifier
 // names so a typo is obvious. It is a free function taking the notifier set
@@ -92,6 +95,14 @@ func validateNotifyVias(notifiers map[string]types.NotifierConfig, label, pipeli
 	}
 	var problems []string
 	for _, ref := range notifyActionRefs(pipelineYAML) {
+		// Severity is checked here rather than in pipeline.Validate so a
+		// typo is rejected while the author is still saving: failing
+		// pipeline.Parse instead would let the save through and then kill
+		// every stage action of a running pipeline, notify or not.
+		if _, ok := notifySeverity(ref.Severity); !ok {
+			problems = append(problems, fmt.Sprintf(
+				"stage %q has notify severity %q, which must be info, success, warning or error", ref.StageID, ref.Severity))
+		}
 		if ref.Via == "" {
 			problems = append(problems, fmt.Sprintf(
 				"stage %q has a notify action without a \"via\" (the name of a notifier under notifications.notifiers)", ref.StageID))

--- a/pkg/hub/notify_validate_test.go
+++ b/pkg/hub/notify_validate_test.go
@@ -173,6 +173,43 @@ func TestWorkflowPushAcceptsValidNotifyVia(t *testing.T) {
 	}
 }
 
+// A severity typo is an author-time error too: pipeline.Parse stays lenient
+// on notify blocks (a bad severity must not kill every stage action of a
+// running pipeline), so this save path is the only place the author can be
+// told about it while nothing is running.
+func TestWorkflowPushRejectsInvalidNotifySeverity(t *testing.T) {
+	s := newNotifyValidateTestServer(t, notifyValidateTestNotifiers())
+	rr := pushWorkflowsForTest(t, s, []*types.WorkflowConfig{{
+		Name:                "release",
+		Integration:         "github",
+		EnableManualTrigger: true,
+		Stages: []types.WorkflowStage{
+			notifyWorkflowStage("announce", map[string]interface{}{"via": "eng-agents", "text": "hi", "severity": "urgent"}),
+		},
+	}})
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body = %s", rr.Code, rr.Body.String())
+	}
+	if body := rr.Body.String(); !strings.Contains(body, `stage "announce"`) || !strings.Contains(body, `"urgent"`) {
+		t.Fatalf("error does not name the stage and the bad severity: %s", body)
+	}
+}
+
+func TestWorkflowPushAcceptsKnownNotifySeverity(t *testing.T) {
+	s := newNotifyValidateTestServer(t, notifyValidateTestNotifiers())
+	rr := pushWorkflowsForTest(t, s, []*types.WorkflowConfig{{
+		Name:                "release",
+		Integration:         "github",
+		EnableManualTrigger: true,
+		Stages: []types.WorkflowStage{
+			notifyWorkflowStage("announce", map[string]interface{}{"via": "eng-agents", "text": "hi", "severity": "warning"}),
+		},
+	}})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+}
+
 // The check must cover both authoring shapes: a directly authored
 // pipeline_yaml: string is judged exactly like stages:.
 func TestWorkflowPushValidatesAuthoredPipelineYAML(t *testing.T) {

--- a/pkg/hub/pipeline/pipeline.go
+++ b/pkg/hub/pipeline/pipeline.go
@@ -306,6 +306,9 @@ type NotifyAction struct {
 	// plain text line to the Block Kit attachment layout, with the subject on
 	// its own line under the text. Omit it to keep the plain rendering.
 	Subject string `yaml:"subject,omitempty"`
+	// Severity controls provider-native emphasis. It must be info, success,
+	// warning or error when set.
+	Severity string `yaml:"severity,omitempty"`
 	// Target overrides the notifier's default destination (channel, address);
 	// templated.
 	Target string `yaml:"target,omitempty"`
@@ -427,6 +430,13 @@ func (p *Pipeline) Validate() error {
 	}
 	skipEdges := make(map[string][]string)
 	for _, stage := range p.Stages {
+		if action := stage.OnEnter.Notify; action.Enabled {
+			switch action.Severity {
+			case "", "info", "success", "warning", "error":
+			default:
+				return fmt.Errorf("stage %q notify severity %q must be info, success, warning or error", stage.ID, action.Severity)
+			}
+		}
 		for _, skip := range []struct {
 			name string
 			rule *StageSkip

--- a/pkg/hub/pipeline/pipeline.go
+++ b/pkg/hub/pipeline/pipeline.go
@@ -302,9 +302,8 @@ type NotifyAction struct {
 	// Subject names what the message is about; templated. It is a semantic
 	// field: providers with a native subject line (email) use it there, and
 	// every other provider renders it inside its rich layout rather than
-	// dropping it — on Slack, setting Subject upgrades the message from a
-	// plain text line to the Block Kit attachment layout, with the subject on
-	// its own line under the text. Omit it to keep the plain rendering.
+	// dropping it — on Slack, the subject gets its own line under the text
+	// inside the Block Kit attachment every notify action now renders as.
 	Subject string `yaml:"subject,omitempty"`
 	// Severity controls provider-native emphasis (the colour stripe). It
 	// must be info, success, warning or error when set; the value is

--- a/pkg/hub/pipeline/pipeline.go
+++ b/pkg/hub/pipeline/pipeline.go
@@ -306,8 +306,11 @@ type NotifyAction struct {
 	// plain text line to the Block Kit attachment layout, with the subject on
 	// its own line under the text. Omit it to keep the plain rendering.
 	Subject string `yaml:"subject,omitempty"`
-	// Severity controls provider-native emphasis. It must be info, success,
-	// warning or error when set.
+	// Severity controls provider-native emphasis (the colour stripe). It
+	// must be info, success, warning or error when set; the value is
+	// rejected at save time (validateNotifyVias), never here, because
+	// Parse must stay lenient on notify blocks — a notification typo must
+	// not take a whole running pipeline down.
 	Severity string `yaml:"severity,omitempty"`
 	// Target overrides the notifier's default destination (channel, address);
 	// templated.
@@ -430,13 +433,6 @@ func (p *Pipeline) Validate() error {
 	}
 	skipEdges := make(map[string][]string)
 	for _, stage := range p.Stages {
-		if action := stage.OnEnter.Notify; action.Enabled {
-			switch action.Severity {
-			case "", "info", "success", "warning", "error":
-			default:
-				return fmt.Errorf("stage %q notify severity %q must be info, success, warning or error", stage.ID, action.Severity)
-			}
-		}
 		for _, skip := range []struct {
 			name string
 			rule *StageSkip

--- a/pkg/hub/pipeline/pipeline_test.go
+++ b/pkg/hub/pipeline/pipeline_test.go
@@ -1102,8 +1102,12 @@ stages:
 	}
 }
 
-func TestParseNotifyActionRejectsInvalidSeverity(t *testing.T) {
-	_, err := pipeline.Parse([]byte(`
+func TestParseNotifyActionBadSeverityIsNotFatal(t *testing.T) {
+	// A severity typo is rejected when the workflow is SAVED
+	// (TestWorkflowPushRejectsInvalidNotifySeverity in pkg/hub). Parse must
+	// stay lenient: failing here would make one notify typo stop every stage
+	// action of an already-running pipeline, not just the notification.
+	p, err := pipeline.Parse([]byte(`
 stages:
   - id: announce
     on_enter:
@@ -1112,8 +1116,11 @@ stages:
         text: hello
         severity: urgent
 `))
-	if err == nil || !strings.Contains(err.Error(), "notify severity") {
-		t.Fatalf("Parse error = %v, want invalid notify severity", err)
+	if err != nil {
+		t.Fatalf("Parse error = %v, want the pipeline to survive a notify typo", err)
+	}
+	if got := p.Stages[0].OnEnter.Notify.Severity; got != "urgent" {
+		t.Fatalf("severity = %q, want the raw value preserved for the validator", got)
 	}
 }
 

--- a/pkg/hub/pipeline/pipeline_test.go
+++ b/pkg/hub/pipeline/pipeline_test.go
@@ -1070,6 +1070,7 @@ stages:
         via: eng-agents
         text: "PR merged: {{.Issue.URL}}"
         subject: "{{.Issue.Identifier}} merged"
+        severity: warning
         target: "{{.Outputs.build.channel}}"
         options:
           unfurl_links: false
@@ -1090,11 +1091,29 @@ stages:
 	if action.Subject != "{{.Issue.Identifier}} merged" {
 		t.Fatalf("subject = %q", action.Subject)
 	}
+	if action.Severity != "warning" {
+		t.Fatalf("severity = %q, want warning", action.Severity)
+	}
 	if action.Target != "{{.Outputs.build.channel}}" {
 		t.Fatalf("target = %q", action.Target)
 	}
 	if v, ok := action.Options["unfurl_links"].(bool); !ok || v {
 		t.Fatalf("options.unfurl_links = %#v, want false", action.Options["unfurl_links"])
+	}
+}
+
+func TestParseNotifyActionRejectsInvalidSeverity(t *testing.T) {
+	_, err := pipeline.Parse([]byte(`
+stages:
+  - id: announce
+    on_enter:
+      notify:
+        via: eng-agents
+        text: hello
+        severity: urgent
+`))
+	if err == nil || !strings.Contains(err.Error(), "notify severity") {
+		t.Fatalf("Parse error = %v, want invalid notify severity", err)
 	}
 }
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2387,6 +2387,12 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 			conn.Close(websocket.StatusPolicyViolation, "claw deleted")
 			return
 		}
+		// Bootstrap commonly completes before the bridge registers, so the
+		// upsert reaches connected directly and the promotion UPDATE never
+		// records agent_started. The event key makes reconnects harmless.
+		if currentStatus == "connected" {
+			go s.recordClawAgentStarted(clawID)
+		}
 	} else {
 		// For status channel, just read current status from DB
 		_ = s.db.QueryRow(`SELECT status FROM claws WHERE id = ? AND tenant_id = ?`, clawID, tenantID).Scan(&currentStatus)

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -1447,6 +1447,52 @@ func TestClawRegistrationPreservesTemplateWhenBridgeOmitsIt(t *testing.T) {
 	}
 }
 
+func TestClawRegistrationAlreadyConnectedRecordsAgentStartedOnce(t *testing.T) {
+	ready := true
+	const clawID = "claw-registration-agent-started"
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{
+		RunID: "run-registration-agent-started", AttemptID: "attempt-registration-agent-started", ClawID: clawID,
+		TenantID: "test-tenant-id", OwnerType: taskRunOwnerFactory, Factory: "factory", StartedAt: epochMillis(now()),
+	})
+	if _, err := db.Exec(`INSERT INTO claws(id, tenant_id, name, template, status, bootstrap_ok, task_run_id, created_at) VALUES(?,?,?,?,?,?,?,?)`,
+		clawID, "test-tenant-id", "started", "base", "starting", 1, "run-registration-agent-started", now()); err != nil {
+		t.Fatal(err)
+	}
+
+	ts := httptest.NewServer(s.Handler())
+	t.Cleanup(ts.Close)
+	register := func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		conn, _, err := websocket.Dial(ctx, "ws"+strings.TrimPrefix(ts.URL, "http")+"/claw/ws", nil)
+		if err != nil {
+			t.Fatalf("dial claw ws: %v", err)
+		}
+		defer conn.Close(websocket.StatusNormalClosure, "done")
+		if err := wsjson.Write(ctx, conn, types.WSMessage{Type: "register", Payload: types.RegisterPayload{ClawID: clawID, Name: "started", Template: "base", Token: "claw-token", GatewayReady: &ready}}); err != nil {
+			t.Fatalf("register claw: %v", err)
+		}
+		var ack types.WSMessage
+		if err := wsjson.Read(ctx, conn, &ack); err != nil || ack.Type != "registered" {
+			t.Fatalf("registration ack = %#v, err = %v", ack, err)
+		}
+	}
+
+	register()
+	waitForNotify(t, "agent_started event", func() bool {
+		var count int
+		_ = db.QueryRow(`SELECT COUNT(*) FROM task_run_events WHERE run_id=? AND event_type=?`, "run-registration-agent-started", taskRunEventAgentStarted).Scan(&count)
+		return count == 1
+	})
+	register()
+	time.Sleep(25 * time.Millisecond)
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM task_run_events WHERE run_id=? AND event_type=?`, "run-registration-agent-started", taskRunEventAgentStarted).Scan(&count); err != nil || count != 1 {
+		t.Fatalf("agent_started rows = %d (err %v), want one across reconnects", count, err)
+	}
+}
+
 func TestClawWorkspaceNameFallsBackToTags(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/pkg/hub/task_run_analytics.go
+++ b/pkg/hub/task_run_analytics.go
@@ -742,8 +742,9 @@ func taskRunPhaseEventForClawStatus(status string) string {
 // "connected"). ensureTaskRunForClaw only records phase events using the
 // claw's status at run-creation time, which is always "provisioning" or
 // "pending". Bridge registration also calls this because bootstrap commonly
-// finishes before the bridge connects and bypasses the promotion path. Safe to call repeatedly: the event key is deterministic
-// and recordTaskRunEventTx dedupes on (tenant_id, run_id, event_key).
+// finishes before the bridge connects and bypasses the promotion path. Safe
+// to call repeatedly: the event key is deterministic and
+// recordTaskRunEventTx dedupes on (tenant_id, run_id, event_key).
 func (s *Server) recordClawAgentStarted(clawID string) {
 	if s == nil || s.db == nil || clawID == "" {
 		return

--- a/pkg/hub/task_run_analytics.go
+++ b/pkg/hub/task_run_analytics.go
@@ -741,8 +741,8 @@ func taskRunPhaseEventForClawStatus(status string) string {
 // task run once its sandbox actually becomes ready (claws.status flips to
 // "connected"). ensureTaskRunForClaw only records phase events using the
 // claw's status at run-creation time, which is always "provisioning" or
-// "pending" — so without this, agent_started_at is never set for the normal
-// bootstrap flow. Safe to call repeatedly: the event key is deterministic
+// "pending". Bridge registration also calls this because bootstrap commonly
+// finishes before the bridge connects and bypasses the promotion path. Safe to call repeatedly: the event key is deterministic
 // and recordTaskRunEventTx dedupes on (tenant_id, run_id, event_key).
 func (s *Server) recordClawAgentStarted(clawID string) {
 	if s == nil || s.db == nil || clawID == "" {

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -573,9 +573,6 @@ type LifecycleNotificationsConfig struct {
 	Enabled *bool `yaml:"enabled,omitempty" json:"enabled,omitempty"`
 	// Via names the notifier (under notifications.notifiers) to send through.
 	Via string `yaml:"via" json:"via"`
-	// ThreadByRun groups all messages for a run into one thread on providers
-	// that support threading. Default true.
-	ThreadByRun *bool `yaml:"thread_by_run,omitempty" json:"threadByRun,omitempty"`
 	// PollInterval is how often the notifier scans for new events. Default "5s".
 	PollInterval string `yaml:"poll_interval,omitempty" json:"pollInterval,omitempty"`
 	// IdleAfter is how long an agent must sit idle (connected, no turn


### PR DESCRIPTION
Fixes three independent defects in the hub's Slack notifications, each diagnosed against production (`factory.fasterway.com`: `hub.db` snapshot + journal).

## 1. \"Agent started\" was never notified

`agent_started` is never recorded in production — zero non-backfilled rows in `task_run_events`, ever. `recordClawAgentStarted` only ran from the promotion `UPDATE claws SET status='connected' WHERE status='starting' AND bootstrap_ok=1`, but bridge registration already upserts `status='connected'` directly whenever `allowWakeBeforeBootstrap` passes. In the normal Daytona ordering the bootstrap finishes *before* the bridge connects, so the promotion UPDATE affects 0 rows. Logs show `[bridge] ✓ connected` and never `[bridge] ✓ ready`.

The registration path now records it too. Idempotent across reconnects and hub restarts: the event key is the deterministic `agent_started:<runID>` and `recordTaskRunEventTx` dedupes on it. The two existing call sites stay — they still cover the reverse ordering.

## 2. Notifications must never be posted in a thread

`thread_by_run` defaulted to true, so only the first lifecycle message of a run was top-level and every later one was a reply. Combined with defect 1, the thread root in production was usually an "Agent stalled" warning, with "PR opened" and "Agent died" buried under it:

```
agent_idle   17:46  ← root
agent_idle   18:10  ← reply
agent_idle   18:16  ← reply
pr_opened    18:26  ← reply
```

Per-run threading is removed: the `thread_by_run` config field, the `lifecycleThreadByRun` helper, the thread-root read/write on `slack_run_threads` and the now-dead destination plumbing all go. The `slack_run_threads` table stays for legacy data but is no longer read or written. Hub config YAML decoding is not strict, so an existing `hub.yaml` still setting `thread_by_run` keeps loading, ignored.

`notify.Message.Thread` and the provider-level `thread_ts` support remain — a stage can still opt in explicitly via `options: {thread_ts: ...}`.

## 3. Pipeline notifications looked nothing like the lifecycle ones

`executeNotifyAction` built a `notify.Message` with only `Text`, so `Semantic()` was false and Slack took the plain tier: bare `payload.text`, no Block Kit, no colour stripe, no metadata. Next to the lifecycle cards it read as a stray message — e.g. the `pr_opened` stage of `faster/faster_apps`.

Pipeline notifications now render through the semantic tier with the same visual system: the operator's text is preserved verbatim as the leading line, plus a colour stripe and the same dim metadata trail (issue, workflow, claw). New optional `severity:` on the notify action (`info` | `success` | `warning` | `error`, default `info`), validated at **save time** in `validateNotifyVias` rather than in `pipeline.Parse` — failing Parse would let the save through and then kill every stage action of a running pipeline, not just the notification.

## Testing

`go build ./...` clean. `go test ./pkg/hub/... ./pkg/types/...` passes except `TestDoneSignalRejectedWhenPRPersistenceFails`, `TestHandleClawDoneSignal_IssueLessWorkflowWatchesPR` and `TestCompleteIssueLessDoneClawKeepsRunningOnStoreFailure`, which fail identically on the base commit `aede66bc` (they reach the real GitHub API locally).

New coverage: agent_started recorded exactly once for a claw registering already-connected, including across a reconnect; successive lifecycle events for one run all top-level with `slack_run_threads` untouched; text-only notify action rendering as Block Kit with the operator's text preserved; severity parsing, mapping to colours, and save-time rejection of an invalid value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)