### PR TITLE
fix(hub): ensure gh wrapper is found first and clarify auth instructions

### DIFF
--- a/.elasticclaw/workspaces/elasticclaw/AGENTS.md
+++ b/.elasticclaw/workspaces/elasticclaw/AGENTS.md
@@ -40,9 +40,22 @@ go version && node --version && npm --version && oras version
 docker version   # Docker is on the VM; use for container tests
 ```
 
-## Git
+## Git & GitHub Auth
 
-You have a git credential helper installed. Use that to interaction with git and gh.
+You are already authenticated to GitHub via the ElasticClaw credential helper. Do not run `gh auth login`, `gh auth setup-git`, or set `GITHUB_TOKEN`/`GH_TOKEN` yourself. Just use `git` and `gh` directly — the helper mints a fresh, scoped GitHub App token for every operation.
+
+How it works: `/usr/local/bin/gh` is a wrapper that calls the credential helper (`/usr/local/bin/elasticclaw-git-credentials`) to fetch a token from the hub before delegating to the real `gh` binary. The credential helper hits `$ELASTICCLAW_HUB_URL/api/github/token/$ELASTICCLAW_CLAW_ID` and returns a short-lived GitHub App installation token. Because the token is refreshed per invocation, nothing is persisted in `~/.config/gh/hosts.yml`.
+
+Do not use `gh auth status` to check authentication — it looks at the persisted `hosts.yml` file and can report "not authenticated" even when the wrapper is working. To verify gh is ready, run a real command such as `gh api rate_limit` or `gh repo view <owner>/<repo>`.
+
+If you see an auth prompt or error, verify the credential helper is being invoked by running:
+
+```bash
+printf 'protocol=https\nhost=github.com\n' | git credential fill
+```
+
+This should return `username=x-access-token` and a password. Do not try logging in again. The helper is the source of truth.
+
 NEVER force push and rebase unless you are resolving conflicts. When addressing standard feedback, it's preferable to push a new commit.
 
 ## Memory

--- a/.elasticclaw/workspaces/elasticclaw/AGENTS.md
+++ b/.elasticclaw/workspaces/elasticclaw/AGENTS.md
@@ -40,22 +40,9 @@ go version && node --version && npm --version && oras version
 docker version   # Docker is on the VM; use for container tests
 ```
 
-## Git & GitHub Auth
+## Git
 
-You are already authenticated to GitHub via the ElasticClaw credential helper. Do not run `gh auth login`, `gh auth setup-git`, or set `GITHUB_TOKEN`/`GH_TOKEN` yourself. Just use `git` and `gh` directly — the helper mints a fresh, scoped GitHub App token for every operation.
-
-How it works: `/usr/local/bin/gh` is a wrapper that calls the credential helper (`/usr/local/bin/elasticclaw-git-credentials`) to fetch a token from the hub before delegating to the real `gh` binary. The credential helper hits `$ELASTICCLAW_HUB_URL/api/github/token/$ELASTICCLAW_CLAW_ID` and returns a short-lived GitHub App installation token. Because the token is refreshed per invocation, nothing is persisted in `~/.config/gh/hosts.yml`.
-
-Do not use `gh auth status` to check authentication — it looks at the persisted `hosts.yml` file and can report "not authenticated" even when the wrapper is working. To verify gh is ready, run a real command such as `gh api rate_limit` or `gh repo view <owner>/<repo>`.
-
-If you see an auth prompt or error, verify the credential helper is being invoked by running:
-
-```bash
-printf 'protocol=https\nhost=github.com\n' | git credential fill
-```
-
-This should return `username=x-access-token` and a password. Do not try logging in again. The helper is the source of truth.
-
+You have a git credential helper installed. Use that to interaction with git and gh.
 NEVER force push and rebase unless you are resolving conflicts. When addressing standard feedback, it's preferable to push a new commit.
 
 ## Memory

--- a/pkg/hub/github_token_refresh_test.go
+++ b/pkg/hub/github_token_refresh_test.go
@@ -47,6 +47,13 @@ func TestGitHubCLIWrapperHandlesRealGhInUsrLocalBin(t *testing.T) {
 	assertContains(t, script, "GitHub gh wrapper already configured", "wrapper logs when already installed")
 }
 
+func TestGitHubCLIWrapperInstallEnsuresLocalBinIsFirstInPath(t *testing.T) {
+	script := buildGitHubCLIWrapperInstallScript()
+
+	assertContains(t, script, "sudo tee /etc/profile.d/elasticclaw-path.sh", "wrapper installs PATH profile to ensure /usr/local/bin is first")
+	assertContains(t, script, `export PATH="/usr/local/bin:$PATH"`, "wrapper prepends /usr/local/bin to PATH")
+}
+
 func TestGitHubCLIWrapperEscapesRealGhPathForSed(t *testing.T) {
 	script := buildGitHubCLIWrapperInstallScript()
 

--- a/pkg/hub/github_webhook.go
+++ b/pkg/hub/github_webhook.go
@@ -1281,8 +1281,10 @@ func buildGitHubPRContext(pr githubPRPayload) string {
 	b.WriteString(`
 ## Git & GitHub Auth
 
-A git credential helper is pre-configured. You do NOT need to run gh auth login or set GH_TOKEN.
+A git credential helper is pre-configured. /usr/local/bin/gh is a wrapper that calls the credential helper to fetch a fresh GitHub App token before each invocation. You do NOT need to run gh auth login or set GH_TOKEN.
 Just use git and gh commands directly — authentication is handled automatically.
+
+Do not use gh auth status to verify authentication; it checks the persisted hosts.yml file and may report "not authenticated" even when the wrapper is working. Use a real command such as gh api rate_limit or gh repo view <owner>/<repo>.
 
 To check out this PR:
 `)

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -6590,7 +6590,9 @@ func (s *Server) bootstrapReplicated(clawID, clawName, vmID string, cfg types.Pr
 		githubSection := fmt.Sprintf(`
 ## GitHub Access
 
-This agent has authenticated access to the following repositories via a GitHub App installation token. The token is fetched automatically — you don't need to configure anything.
+This agent has already authenticated to GitHub via an ElasticClaw GitHub App. The credential helper is installed and will mint a fresh, scoped installation token for every git/gh operation. **Do not run gh auth login, gh auth setup-git, or set GITHUB_TOKEN/GH_TOKEN yourself.** Just use git and gh commands directly.
+
+How it works: /usr/local/bin/gh is a wrapper that calls /usr/local/bin/elasticclaw-git-credentials to fetch a token from the hub before delegating to the real gh binary. The credential helper hits the hub's /api/github/token endpoint and returns a short-lived GitHub App installation token. Nothing is persisted in ~/.config/gh/hosts.yml, so gh auth status may look empty even though gh is authenticated.
 
 %s
 **git** and **gh CLI** are pre-configured and will work without any additional auth setup:
@@ -6600,7 +6602,14 @@ git clone https://github.com/owner/repo
 gh pr create
 gh issue list
 `+"```\n"+`
-Tokens are short-lived and refreshed automatically on each git/gh operation.
+Do not use gh auth status to verify authentication. Instead, run a real command such as gh api rate_limit or gh repo view <owner>/<repo>.
+
+If you see an authentication prompt or error, do not try to fix it by logging in. Verify the credential helper is being invoked by running:
+
+`+"```bash\n"+`printf 'protocol=https\nhost=github.com\n' | git credential fill
+`+"```\n"+`
+
+This should return "username=x-access-token" and a password. The helper is the source of truth.
 `, repoLines)
 		if existing, ok := files["TOOLS.md"]; ok {
 			files["TOOLS.md"] = existing + "\n" + githubSection
@@ -7011,6 +7020,13 @@ GHEOF
     REAL_GH_ESCAPED="$(printf '%s' "$REAL_GH" | sed 's/[&\\|]/\\&/g')"
     sudo sed -i "s|__ELASTICCLAW_REAL_GH__|$REAL_GH_ESCAPED|g" /usr/local/bin/gh
     sudo chmod +x /usr/local/bin/gh
+    # Ensure the wrapper is found before any system gh in /usr/bin.
+    if [ -d /etc/profile.d ]; then
+      sudo tee /etc/profile.d/elasticclaw-path.sh >/dev/null << 'PATHEOF'
+export PATH="/usr/local/bin:$PATH"
+PATHEOF
+    fi
+    export PATH="/usr/local/bin:$PATH"
     echo "GitHub gh wrapper configured"
   fi
 fi`


### PR DESCRIPTION
This PR addresses two agent-reported issues with the GitHub credential helper:

1. **Wrapper PATH ordering**: `buildGitHubCLIWrapperInstallScript` installed the wrapper at `/usr/local/bin/gh`, but if `/usr/bin` appears earlier in `PATH` (which some agents report), the system `gh` is used instead and the wrapper is silently bypassed. The install script now writes `/etc/profile.d/elasticclaw-path.sh` to prepend `/usr/local/bin` to `PATH` and exports the same ordering in the current shell.

2. **Clarify auth helper behavior**: Ports the important documentation updates from the closed #614 into the hub-injected agent instructions (injected `TOOLS.md` and PR-assignment `BOOTSTRAP.md` context):
   - Explain that `/usr/local/bin/gh` is a wrapper that calls the credential helper.
   - Tell agents not to use `gh auth status` to verify auth (it checks `~/.config/gh/hosts.yml`, which stays empty because tokens are short-lived).
   - Direct agents to real commands like `gh api rate_limit` or `gh repo view`.
   - Include the `printf 'protocol=https\nhost=github.com\n' | git credential fill` diagnostic.
   - Reiterate: do not run `gh auth login` or set `GH_TOKEN`/`GITHUB_TOKEN`.

Note: the static workspace `AGENTS.md` was intentionally left unchanged because the hub injects these instructions at runtime via `TOOLS.md`.

Verification:

- `nix develop -c make build`
- `nix develop -c go test ./...`
