### PR TITLE
feat(hub): add exclude_repositories to github_issues workflow trigger

### DIFF
--- a/pkg/hub/github_issues.go
+++ b/pkg/hub/github_issues.go
@@ -284,6 +284,13 @@ func githubIssuesWorkflowTriggerRepos(workflow *types.WorkflowConfig) []string {
 	return workflow.Repos
 }
 
+func githubIssuesWorkflowTriggerExcludeRepos(workflow *types.WorkflowConfig) []string {
+	if workflow.Trigger != nil && workflow.Trigger.GitHubIssues != nil {
+		return workflow.Trigger.GitHubIssues.ExcludeRepositories
+	}
+	return nil
+}
+
 func (s *Server) processGitHubIssuesFactoryEvent(payload githubIssuesWebhookPayload, issueID, currentStatus string, issueLabels map[string]bool, assignee string) bool {
 	matched := false
 	for _, factory := range s.resolveFactories() {
@@ -345,7 +352,7 @@ func (s *Server) processGitHubIssuesWorkflowEvent(workspaces []*types.WorkspaceC
 			if workflow.Enabled != nil && !*workflow.Enabled {
 				continue
 			}
-			if !githubRepoMatches(payload.Repository.FullName, githubIssuesWorkflowTriggerRepos(workflow)) {
+			if !githubRepoMatchesWithExclusions(payload.Repository.FullName, githubIssuesWorkflowTriggerRepos(workflow), githubIssuesWorkflowTriggerExcludeRepos(workflow)) {
 				continue
 			}
 			if workflow.AssignedTo != "" && !assignedToMatches(workflow.AssignedTo, assignee) {

--- a/pkg/hub/github_issues_trigger_repos_internal_test.go
+++ b/pkg/hub/github_issues_trigger_repos_internal_test.go
@@ -42,6 +42,29 @@ func TestResolveGitHubIssuesTokenForRepoUsesTriggerRepos(t *testing.T) {
 	}
 }
 
+func TestGitHubRepoMatchesWithExclusions(t *testing.T) {
+	cases := []struct {
+		fullName string
+		include  []string
+		exclude  []string
+		want     bool
+	}{
+		{"org/a", []string{"org/*"}, []string{"org/b"}, true},
+		{"org/b", []string{"org/*"}, []string{"org/b"}, false},
+		{"org/c", []string{"org/*"}, []string{"org/b"}, true},
+		{"org/a", []string{"org/a", "org/b"}, []string{"org/a"}, false},
+		{"org/a", nil, []string{"org/a"}, false},
+		{"org/a", []string{"org/*"}, []string{"other/*"}, true},
+		{"org/sub/a", []string{"org/*"}, []string{"org/b"}, true}, // nested path still matches org/* include
+	}
+	for _, c := range cases {
+		got := githubRepoMatchesWithExclusions(c.fullName, c.include, c.exclude)
+		if got != c.want {
+			t.Errorf("githubRepoMatchesWithExclusions(%q, %v, %v) = %v, want %v", c.fullName, c.include, c.exclude, got, c.want)
+		}
+	}
+}
+
 func TestResolveGitHubIssuesTokenForRepoFallsBackToLegacyRepos(t *testing.T) {
 	cfg := &types.HubConfig{
 		ClawToken: "test-claw-token",

--- a/pkg/hub/github_webhook.go
+++ b/pkg/hub/github_webhook.go
@@ -863,6 +863,40 @@ func githubRepoMatches(fullName string, repos []string) bool {
 	return false
 }
 
+// githubRepoExcluded reports whether a repo matches an exclude pattern.
+// Supports exact owner/repo and owner/* globs.
+func githubRepoExcluded(fullName string, excludeRepos []string) bool {
+	if len(excludeRepos) == 0 {
+		return false
+	}
+	parts := strings.SplitN(fullName, "/", 2)
+	if len(parts) != 2 {
+		return false
+	}
+	owner := parts[0]
+	for _, pattern := range excludeRepos {
+		if strings.EqualFold(pattern, fullName) {
+			return true
+		}
+		if strings.HasSuffix(pattern, "/*") {
+			patternOwner := strings.TrimSuffix(pattern, "/*")
+			if strings.EqualFold(patternOwner, owner) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// githubRepoMatchesWithExclusions is like githubRepoMatches but also excludes
+// repos that match any pattern in excludeRepos.
+func githubRepoMatchesWithExclusions(fullName string, includeRepos, excludeRepos []string) bool {
+	if !githubRepoMatches(fullName, includeRepos) {
+		return false
+	}
+	return !githubRepoExcluded(fullName, excludeRepos)
+}
+
 // createClawForGitHubPR provisions a new claw for a GitHub PR event.
 // isOwnAppBot returns true if the given GitHub login is the bot account for one of
 // the configured GitHub Apps (hub-global or workspace-scoped). App bots have the

--- a/pkg/types/validation.go
+++ b/pkg/types/validation.go
@@ -403,6 +403,14 @@ func validateGitHubIssuesWorkflowTrigger(workflowName string, trigger *GitHubIss
 			return fmt.Errorf("workflow %q: trigger.github_issues.repositories[%d] invalid format %q (expected owner/repo or owner/*)", workflowName, i, repo)
 		}
 	}
+	for i, repo := range trigger.ExcludeRepositories {
+		if repo == "" {
+			return fmt.Errorf("workflow %q: trigger.github_issues.exclude_repositories[%d] cannot be empty", workflowName, i)
+		}
+		if !validRepoSelector(repo) {
+			return fmt.Errorf("workflow %q: trigger.github_issues.exclude_repositories[%d] invalid format %q (expected owner/repo or owner/*)", workflowName, i, repo)
+		}
+	}
 	if trigger.AgentStatusError != "" && strings.TrimSpace(trigger.AgentStatusError) == "" {
 		return fmt.Errorf("workflow %q: trigger.github_issues.agent_status_error cannot be blank", workflowName)
 	}

--- a/pkg/types/workflow_normalize_test.go
+++ b/pkg/types/workflow_normalize_test.go
@@ -46,6 +46,46 @@ stages:
 	}
 }
 
+func TestWorkflowV1GitHubIssuesTriggerExcludesRepositories(t *testing.T) {
+	data := []byte(`
+schema_version: v1
+name: github-issue
+trigger:
+  github_issues:
+    event: issue_labeled
+    repositories:
+      - someorg/*
+    exclude_repositories:
+      - someorg/skip-me
+    states:
+      - open
+    labels:
+      - agent-ready
+stages:
+  - id: working
+    entry: true
+    on_enter:
+      inject: start
+`)
+	var workflow WorkflowConfig
+	if err := yaml.Unmarshal(data, &workflow); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if err := NormalizeWorkflowConfig(&workflow); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if err := workflow.Validate(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if workflow.Trigger == nil || workflow.Trigger.GitHubIssues == nil {
+		t.Fatalf("trigger.github_issues missing")
+	}
+	got := workflow.Trigger.GitHubIssues.ExcludeRepositories
+	if len(got) != 1 || got[0] != "someorg/skip-me" {
+		t.Fatalf("exclude_repositories = %#v, want [someorg/skip-me]", got)
+	}
+}
+
 func TestWorkflowV1JiraProjectsValidateAsProjectKeys(t *testing.T) {
 	data := []byte(`
 schema_version: v1
@@ -79,6 +119,41 @@ stages:
 	}
 	if err := workflow.Validate(); err != nil {
 		t.Fatalf("validate: %v", err)
+	}
+}
+
+func TestWorkflowV1GitHubIssuesTriggerRejectsInvalidExcludeRepositories(t *testing.T) {
+	data := []byte(`
+schema_version: v1
+name: github-issue
+trigger:
+  github_issues:
+    event: issue_labeled
+    repositories:
+      - someorg/*
+    exclude_repositories:
+      - not-a-valid-repo
+    states:
+      - open
+    labels:
+      - agent-ready
+stages:
+  - id: working
+    entry: true
+    on_enter:
+      inject: start
+`)
+	var workflow WorkflowConfig
+	if err := yaml.Unmarshal(data, &workflow); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if err := NormalizeWorkflowConfig(&workflow); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if err := workflow.Validate(); err == nil {
+		t.Fatalf("expected validation error for invalid exclude_repositories, got nil")
+	} else if !strings.Contains(err.Error(), "exclude_repositories[0]") {
+		t.Fatalf("expected error to mention exclude_repositories[0], got %v", err)
 	}
 }
 

--- a/pkg/types/workspace.go
+++ b/pkg/types/workspace.go
@@ -118,14 +118,15 @@ type WorkflowRun struct {
 }
 
 type GitHubIssuesWorkflowTrigger struct {
-	Event            string   `yaml:"event,omitempty" json:"event,omitempty"`
-	Repositories     []string `yaml:"repositories,omitempty" json:"repositories,omitempty"`
-	States           []string `yaml:"states,omitempty" json:"states,omitempty"`
-	Labels           []string `yaml:"labels,omitempty" json:"labels,omitempty"`
-	ExcludeLabels    []string `yaml:"exclude_labels,omitempty" json:"exclude_labels,omitempty"`
-	Labelers         []string `yaml:"labelers,omitempty" json:"labelers,omitempty"`
-	AssignedTo       string   `yaml:"assigned_to,omitempty" json:"assigned_to,omitempty"`
-	AgentStatusError string   `yaml:"agent_status_error,omitempty" json:"agent_status_error,omitempty"`
+	Event                string   `yaml:"event,omitempty" json:"event,omitempty"`
+	Repositories         []string `yaml:"repositories,omitempty" json:"repositories,omitempty"`
+	ExcludeRepositories  []string `yaml:"exclude_repositories,omitempty" json:"exclude_repositories,omitempty"`
+	States               []string `yaml:"states,omitempty" json:"states,omitempty"`
+	Labels               []string `yaml:"labels,omitempty" json:"labels,omitempty"`
+	ExcludeLabels        []string `yaml:"exclude_labels,omitempty" json:"exclude_labels,omitempty"`
+	Labelers             []string `yaml:"labelers,omitempty" json:"labelers,omitempty"`
+	AssignedTo           string   `yaml:"assigned_to,omitempty" json:"assigned_to,omitempty"`
+	AgentStatusError     string   `yaml:"agent_status_error,omitempty" json:"agent_status_error,omitempty"`
 }
 
 type LinearWorkflowTrigger struct {


### PR DESCRIPTION
Adds `exclude_repositories` to the `github_issues` workflow trigger so workspace authors can opt out specific repos from an org-wide glob like `someorg/*`.

- `pkg/types/workspace.go`: add `ExcludeRepositories` field.
- `pkg/types/validation.go`: validate the same `owner/repo` / `owner/*` format.
- `pkg/hub/github_webhook.go`: add `githubRepoExcluded` and `githubRepoMatchesWithExclusions`.
- `pkg/hub/github_issues.go`: use the new exclusion check when matching workflow triggers.
- `pkg/types/workflow_normalize_test.go` and `pkg/hub/github_issues_trigger_repos_internal_test.go`: add tests.

Example:

```yaml
trigger:
  github_issues:
    event: issue_labeled
    repositories:
      - someorg/*
    exclude_repositories:
      - someorg/noisy-repo
```

This is v1-only; v2 workflows do not have a `github_issues` trigger yet.