### PR TITLE
fix(hub): keep petting Daytona sandboxes for offline claws

### DIFF
--- a/pkg/hub/daytona_keepalive_test.go
+++ b/pkg/hub/daytona_keepalive_test.go
@@ -2,7 +2,9 @@ package hub
 
 import (
 	"context"
+	"database/sql"
 	"errors"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -52,5 +54,56 @@ func TestPetDaytonaSandboxDoesNotRetryPermanentFailure(t *testing.T) {
 	}
 	if executor.calls != 1 {
 		t.Fatalf("keepalive attempts = %d, want 1", executor.calls)
+	}
+}
+
+func TestSelectDaytonaKeepaliveClawsIncludesOffline(t *testing.T) {
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "hub.db")+"?_pragma=foreign_keys(on)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if err := migrate(db); err != nil {
+		t.Fatal(err)
+	}
+
+	// This fixture only needs claws rows; skip the tenant/task_run parents.
+	if _, err := db.Exec(`PRAGMA foreign_keys=OFF`); err != nil {
+		t.Fatal(err)
+	}
+
+	statuses := []string{"connected", "offline", "error", "deleted", "idle"}
+	for _, status := range statuses {
+		if _, err := db.Exec(
+			`INSERT INTO claws(id,tenant_id,name,template,status,provider,provider_id,created_at) VALUES(?,?,?,?,?,?,?,?)`,
+			"claw-"+status, "tenant", "claw-"+status, "base", status, "daytona", "sandbox-"+status, now(),
+		); err != nil {
+			t.Fatalf("seed %s: %v", status, err)
+		}
+	}
+	// A daytona claw without a sandbox id must never be petted.
+	if _, err := db.Exec(
+		`INSERT INTO claws(id,tenant_id,name,template,status,provider,provider_id,created_at) VALUES(?,?,?,?,?,?,?,?)`,
+		"claw-nosandbox", "tenant", "claw-nosandbox", "base", "connected", "daytona", "", now(),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	claws, err := selectDaytonaKeepaliveClaws(db)
+	if err != nil {
+		t.Fatalf("selectDaytonaKeepaliveClaws: %v", err)
+	}
+	got := map[string]bool{}
+	for _, c := range claws {
+		got[c.providerID] = true
+	}
+	want := map[string]bool{"sandbox-connected": true, "sandbox-offline": true}
+	if len(got) != len(want) {
+		t.Fatalf("selected sandboxes = %v, want %v", got, want)
+	}
+	for id := range want {
+		if !got[id] {
+			t.Fatalf("selected sandboxes = %v, want %v", got, want)
+		}
 	}
 }

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -5841,27 +5841,41 @@ func (s *Server) pruneAnalytics() {
 	}
 }
 
-func (s *Server) petDaytonaSandboxes() {
-	rows, err := s.db.Query(`
+type daytonaKeepaliveClaw struct{ id, name, providerID string }
+
+// selectDaytonaKeepaliveClaws lists the Daytona sandboxes that must stay awake.
+// 'offline' is included on purpose: the gateway may have crashed while the
+// sandbox is still fine, and the bridge can only reconnect if we keep petting
+// it. The reaper bounds that window by flipping the claw to 'error' after the
+// offline grace, which this query excludes.
+func selectDaytonaKeepaliveClaws(db *sql.DB) ([]daytonaKeepaliveClaw, error) {
+	rows, err := db.Query(`
 		SELECT id, name, provider_id
 		FROM claws
 		WHERE provider = 'daytona'
 		  AND provider_id != ''
-		  AND status NOT IN ('idle','deleted','error','offline')
+		  AND status NOT IN ('idle','deleted','error')
 	`)
 	if err != nil {
-		log.Printf("keepAliveDaytonaSandboxes: query error: %v", err)
-		return
+		return nil, err
 	}
 	defer rows.Close()
 
-	type clawRow struct{ id, name, providerID string }
-	var claws []clawRow
+	var claws []daytonaKeepaliveClaw
 	for rows.Next() {
-		var c clawRow
+		var c daytonaKeepaliveClaw
 		if err := rows.Scan(&c.id, &c.name, &c.providerID); err == nil {
 			claws = append(claws, c)
 		}
+	}
+	return claws, rows.Err()
+}
+
+func (s *Server) petDaytonaSandboxes() {
+	claws, err := selectDaytonaKeepaliveClaws(s.db)
+	if err != nil {
+		log.Printf("keepAliveDaytonaSandboxes: query error: %v", err)
+		return
 	}
 	if len(claws) == 0 {
 		return


### PR DESCRIPTION
## Problem

When an OpenClaw gateway crashes or stalls inside a Daytona sandbox, the claw-bridge WebSocket to the hub drops and the claw's status becomes `offline`. The sandbox itself is usually still healthy, and the bridge retries on its own — a real claw (`20d64af3` / NEXT-790) went offline at 14:03:52 and reconnected unaided at 14:11:49.

But `petDaytonaSandboxes` excluded `offline` from its keepalive query:

```sql
AND status NOT IN ('idle','deleted','error','offline')
```

So the hub stopped issuing keepalives exactly during the window where the sandbox most needs to stay awake for the bridge to reconnect. Daytona can auto-stop it for inactivity, turning a recoverable gateway crash into a permanently dead claw.

## Change

Drop `'offline'` from the excluded statuses.

The exposure is bounded by the reaper, which terminates a claw after `offline_grace` (default 10 minutes) and moves it to `error` — a status this query already excludes. With a 5-minute keepalive ticker, an offline claw receives roughly one to two extra pets.

When the sandbox really is gone, the pet fails and logs `[daytona] keepalive failed for ...`. That is left as-is on purpose: it is a useful signal that distinguishes "sandbox dead" from "gateway dead".

The query is extracted into `selectDaytonaKeepaliveClaws` so it can be tested without constructing a real Daytona provider from config. No other behaviour changes.

## Tests

`TestSelectDaytonaKeepaliveClawsIncludesOffline` seeds claws across `connected`, `offline`, `error`, `deleted` and `idle` (plus a Daytona claw with no `provider_id`) and asserts only `connected` and `offline` are selected. Verified it fails against the previous query:

```
--- FAIL: TestSelectDaytonaKeepaliveClawsIncludesOffline
    selected sandboxes = map[sandbox-connected:true], want map[sandbox-connected:true sandbox-offline:true]
```

## Scope

This is one of three separate gaps found while investigating NEXT-790. The other two are **not** addressed here:

1. The reaper stops an offline claw with the reason `agent offline for 10m0s, sandbox presumed dead`, which matches no rule in `classifyAgentFailure` and so resolves to `agentFailureUnknown` — not retryable. Every offline reap is terminal with zero retry attempts.
2. The Linear `Agent Error` state does not exist, so `agent-failure-feedback` fails with `issue or state not found` and these deaths are silent in the tracker.

The same signature was terminal for four claws in seven days, including NEXT-724 and NEXT-725.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
