### PR TITLE
fix(hub): re-brief agents after a claw-retry sandbox replacement

### DIFF
--- a/pkg/hub/claw_retry.go
+++ b/pkg/hub/claw_retry.go
@@ -395,11 +395,11 @@ func (s *Server) retryCheckpointID(tenantID, clawID string, attempt int) (string
 		  FROM task_run_attempts
 		 WHERE run_id=(SELECT task_run_id FROM claws WHERE id=?) AND attempt_number=?`, clawID, attempt-1).Scan(&previousCheckpointID)
 
-	var checkpointID string
+	var checkpointID, checkpointReason string
 	err := s.db.QueryRow(`
-		SELECT id FROM claw_checkpoints
+		SELECT id, COALESCE(reason,'') FROM claw_checkpoints
 		 WHERE tenant_id=? AND claw_id=? AND status='ready' AND manifest_path != ''
-		 ORDER BY created_at DESC LIMIT 1`, tenantID, clawID).Scan(&checkpointID)
+		 ORDER BY created_at DESC LIMIT 1`, tenantID, clawID).Scan(&checkpointID, &checkpointReason)
 	if err == sql.ErrNoRows {
 		return "", nil
 	}
@@ -409,14 +409,83 @@ func (s *Server) retryCheckpointID(tenantID, clawID string, attempt int) (string
 	if checkpointID == previousCheckpointID {
 		return "", nil
 	}
+	// A 'bootstrap' checkpoint captures state zero — it is taken seconds after
+	// provisioning, before the agent has done anything. Restoring it over a
+	// claw that has already made progress rolls the workspace back and
+	// discards real work (observed on NEXT-801/NEXT-790). Fall back to the
+	// newest non-bootstrap checkpoint instead — an earlier attempt's periodic
+	// checkpoint can hold hours of recoverable work even when a later
+	// attempt's bootstrap checkpoint sorted newest — and only when none exists
+	// provision the successor cleanly and let the reconnect re-brief point the
+	// fresh agent at the live PR/workspace state.
+	if checkpointReason == "bootstrap" && s.clawProgressedPastBootstrap(tenantID, clawID) {
+		err := s.db.QueryRow(`
+			SELECT id FROM claw_checkpoints
+			 WHERE tenant_id=? AND claw_id=? AND status='ready' AND manifest_path != ''
+			   AND COALESCE(reason,'') != 'bootstrap'
+			 ORDER BY created_at DESC LIMIT 1`, tenantID, clawID).Scan(&checkpointID)
+		if err == sql.ErrNoRows {
+			return "", nil
+		}
+		if err != nil {
+			return "", err
+		}
+		// Same guard as above: never restore the checkpoint the previous
+		// attempt already failed on.
+		if checkpointID == previousCheckpointID {
+			return "", nil
+		}
+	}
 	return checkpointID, nil
 }
 
+// clawProgressedPastBootstrap reports whether the claw shows any signal of
+// real work beyond the freshly-provisioned state a 'bootstrap' checkpoint
+// captures. Kept deliberately simple and readable: any one signal is enough.
+func (s *Server) clawProgressedPastBootstrap(tenantID, clawID string) bool {
+	// A registered PR is unambiguous progress.
+	var count int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM claw_prs WHERE claw_id=?`, clawID).Scan(&count); err == nil && count > 0 {
+		return true
+	}
+	// A non-bootstrap ready checkpoint means the agent worked long enough for
+	// a later checkpoint to exist, even if the bootstrap one sorted newest.
+	if err := s.db.QueryRow(`
+		SELECT COUNT(*) FROM claw_checkpoints
+		 WHERE tenant_id=? AND claw_id=? AND status='ready' AND reason != 'bootstrap'`,
+		tenantID, clawID).Scan(&count); err == nil && count > 0 {
+		return true
+	}
+	// The pipeline moved past its entry stage. The entry stage itself is set
+	// right after initialization, before any work happens, so it does not
+	// count as progress.
+	stageID := s.getPipelineStage(clawID)
+	if stageID == "" {
+		return false
+	}
+	ctx, ok := s.findPipelineContextForClaw(clawID)
+	if !ok {
+		return false
+	}
+	pl := parsePipelineForContext(ctx)
+	if pl == nil {
+		return false
+	}
+	entry := pl.EntryStage()
+	return entry != nil && entry.ID != stageID
+}
+
 func (s *Server) resetClawForRetry(tenantID, clawID, checkpointID, bootstrapStatus string) (bool, error) {
+	// rebrief_pending=1 marks that the successor sandbox starts with a brand-new
+	// OpenClaw session: the checkpoint restore brings back workspace files but
+	// not the conversation, so the reconnect path must re-brief the agent with
+	// its task context. This UPDATE is the only place that arms the flag — a
+	// normal reconnect/bridge flap must never set it.
 	res, err := s.db.Exec(`
 		UPDATE claws
 		   SET status='provisioning', bootstrap_ok=0, bootstrap_status=?, bootstrap_diagnostic='',
-		       provider_id='', ssh_host='', ssh_port=0, ssh_user='', restore_checkpoint_id=?
+		       provider_id='', ssh_host='', ssh_port=0, ssh_user='', restore_checkpoint_id=?,
+		       rebrief_pending=1
 		 WHERE id=? AND tenant_id=? AND status IN ('error','offline')`,
 		bootstrapStatus, checkpointID, clawID, tenantID)
 	if err != nil {

--- a/pkg/hub/claw_retry_test.go
+++ b/pkg/hub/claw_retry_test.go
@@ -259,6 +259,112 @@ func TestRetryCheckpointSkipsCheckpointUsedByPreviousAttempt(t *testing.T) {
 	}
 }
 
+func TestRetryCheckpointSkipsBootstrapCheckpointAfterProgress(t *testing.T) {
+	insertBootstrapCheckpoint := func(t *testing.T, db *sql.DB) {
+		t.Helper()
+		if _, err := db.Exec(`
+			INSERT INTO claw_checkpoints(id,tenant_id,claw_id,status,reason,manifest_path,created_at)
+			VALUES('checkpoint-bootstrap','tenant','retry-claw','ready','bootstrap','manifest.json',?)`, now()); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Run("registered PR forces clean provision", func(t *testing.T) {
+		s, db, _ := newClawRetryTestServer(t, "connected")
+		insertBootstrapCheckpoint(t, db)
+		if _, err := db.Exec(`
+			INSERT INTO claw_prs(id,claw_id,repo,pr_number,pr_url,created_at)
+			VALUES('pr-1','retry-claw','acme/widgets',42,'https://github.com/acme/widgets/pull/42',?)`, now()); err != nil {
+			t.Fatal(err)
+		}
+		checkpointID, err := s.retryCheckpointID("tenant", "retry-claw", 2)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if checkpointID != "" {
+			t.Fatalf("checkpoint=%q, want clean provision instead of bootstrap rollback", checkpointID)
+		}
+	})
+
+	t.Run("pipeline past entry stage forces clean provision", func(t *testing.T) {
+		s, db, _ := newClawRetryTestServer(t, "connected")
+		insertBootstrapCheckpoint(t, db)
+		s.hubCfg.Factories = []*types.FactoryConfig{{
+			Name:         "retry-factory",
+			PipelineYAML: "stages:\n  - id: plan\n    entry: true\n  - id: implement\n",
+		}}
+		if _, err := db.Exec(`UPDATE claws SET tags='["factory:retry-factory"]', pipeline_stage='implement' WHERE id='retry-claw'`); err != nil {
+			t.Fatal(err)
+		}
+		checkpointID, err := s.retryCheckpointID("tenant", "retry-claw", 2)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if checkpointID != "" {
+			t.Fatalf("checkpoint=%q, want clean provision instead of bootstrap rollback", checkpointID)
+		}
+	})
+
+	t.Run("older non-bootstrap checkpoint is restored instead of bootstrap", func(t *testing.T) {
+		s, db, _ := newClawRetryTestServer(t, "connected")
+		insertBootstrapCheckpoint(t, db)
+		// A periodic checkpoint from an earlier attempt sorts below the
+		// successor's bootstrap checkpoint but holds real work — it must win.
+		if _, err := db.Exec(`
+			INSERT INTO claw_checkpoints(id,tenant_id,claw_id,status,reason,manifest_path,created_at)
+			VALUES('checkpoint-periodic','tenant','retry-claw','ready','periodic','manifest.json',?)`, now().Add(-time.Hour)); err != nil {
+			t.Fatal(err)
+		}
+		checkpointID, err := s.retryCheckpointID("tenant", "retry-claw", 2)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if checkpointID != "checkpoint-periodic" {
+			t.Fatalf("checkpoint=%q, want checkpoint-periodic", checkpointID)
+		}
+	})
+
+	t.Run("fallback never re-restores the previous attempt's checkpoint", func(t *testing.T) {
+		s, db, runID := newClawRetryTestServer(t, "connected")
+		insertBootstrapCheckpoint(t, db)
+		if _, err := db.Exec(`
+			INSERT INTO claw_checkpoints(id,tenant_id,claw_id,status,reason,manifest_path,created_at)
+			VALUES('checkpoint-periodic','tenant','retry-claw','ready','periodic','manifest.json',?)`, now().Add(-time.Hour)); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := db.Exec(`UPDATE task_run_attempts SET restored_checkpoint_id='checkpoint-periodic' WHERE run_id=? AND attempt_number=1`, runID); err != nil {
+			t.Fatal(err)
+		}
+		checkpointID, err := s.retryCheckpointID("tenant", "retry-claw", 2)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if checkpointID != "" {
+			t.Fatalf("checkpoint=%q, want clean provision", checkpointID)
+		}
+	})
+
+	t.Run("no progress keeps bootstrap restore", func(t *testing.T) {
+		s, db, _ := newClawRetryTestServer(t, "connected")
+		insertBootstrapCheckpoint(t, db)
+		s.hubCfg.Factories = []*types.FactoryConfig{{
+			Name:         "retry-factory",
+			PipelineYAML: "stages:\n  - id: plan\n    entry: true\n  - id: implement\n",
+		}}
+		// Entry stage set right after initialization is not progress.
+		if _, err := db.Exec(`UPDATE claws SET tags='["factory:retry-factory"]', pipeline_stage='plan' WHERE id='retry-claw'`); err != nil {
+			t.Fatal(err)
+		}
+		checkpointID, err := s.retryCheckpointID("tenant", "retry-claw", 2)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if checkpointID != "checkpoint-bootstrap" {
+			t.Fatalf("checkpoint=%q, want checkpoint-bootstrap", checkpointID)
+		}
+	})
+}
+
 func TestRetryCheckpointChoicePrecedesTerminationCheckpoint(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	s, db, runID := newClawRetryTestServer(t, "error")

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -109,6 +109,14 @@ func migrate(db *sql.DB) error {
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN trigger_actor_json TEXT NOT NULL DEFAULT '{}'`)
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN stop_comment_pending INTEGER NOT NULL DEFAULT 0`)
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN no_progress_paused INTEGER NOT NULL DEFAULT 0`)
+	// rebrief_pending is armed by [claw-retry] when a sandbox is replaced and
+	// consumed on reconnect to re-brief the fresh session. resetClawForRetry's
+	// UPDATE references it on the retry hot path, so a silently missing column
+	// would leave every retried claw without a successor — abort startup
+	// loudly instead.
+	if err := addColumn(db, "claws", "rebrief_pending", `INTEGER NOT NULL DEFAULT 0`); err != nil {
+		return err
+	}
 	// idle_since (epoch millis, 0 = not latched) is the durable once-per-idle-
 	// stretch latch for agent_idle notifications: the status watchdog sets it
 	// when it fires the notification for a stretch, and the claw-pass notifier
@@ -468,6 +476,7 @@ func migrate(db *sql.DB) error {
 		workflow_volumes TEXT NOT NULL DEFAULT '[]',
 		trigger_actor_json TEXT NOT NULL DEFAULT '{}',
 		stop_comment_pending INTEGER NOT NULL DEFAULT 0,
+		rebrief_pending INTEGER NOT NULL DEFAULT 0,
 		no_progress_paused INTEGER NOT NULL DEFAULT 0,
 		idle_since INTEGER NOT NULL DEFAULT 0,
 		idle_resume_at INTEGER NOT NULL DEFAULT 0,

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -1127,6 +1127,93 @@ func (e *routedRequiredGateError) Error() string {
 	return fmt.Sprintf("required gate %q %s", e.stageID, e.verdict)
 }
 
+// renderStageInject renders a stage's on_enter inject template with the
+// claw's issue context, manual trigger inputs, and persisted outputs.
+// Delivery of the rendered inject, the initial-plan marker, and every other
+// on_enter side effect (run/gate/judge/move_issue/labels/notify) stay with
+// the caller, so the re-brief path can reuse the exact task context without
+// re-running side effects. Note it is not fully side-effect free: tracker
+// fetch failures still surface as warnPipelineRender hub messages and the
+// GitHub fetch retries with backoff, identical to the runOnEnter path.
+func (s *Server) renderStageInject(clawID string, stage pipeline.Stage, ctx pipelineContext) string {
+	issueID := ctx.IssueID
+	injectMsg := stage.OnEnter.Inject
+	manualInputs := s.loadManualTriggerInputs(clawID)
+
+	// Build base template data from issue context, manual inputs, and persisted outputs.
+	baseData := map[string]interface{}{}
+
+	// Render {{.Issue.Identifier}}, {{.Issue.Title}}, {{.Issue.URL}} when this
+	// claw is backed by a Linear or GitHub issue. Shortcut IDs (sc-...) are
+	// intentionally excluded from the Issue namespace.
+	if issueID != "" && !strings.HasPrefix(issueID, "sc-") {
+		if !strings.Contains(issueID, "/") {
+			// Linear issue
+			log.Printf("[pipeline] attempting to render template for claw %s issue %s", clawID[:8], issueID)
+			linearToken := s.resolveLinearTokenForPipeline(ctx)
+			details := &linearIssueDetails{Identifier: issueID}
+			if linearToken == "" {
+				s.warnPipelineRender(clawID, "%s: no Linear issue tracker token configured; rendering inject with fallback issue context", ctx.Name())
+			} else {
+				var err error
+				details, err = s.fetchLinearIssueDetails(linearToken, issueID)
+				if err != nil {
+					s.warnPipelineRender(clawID, "%s: failed to fetch Linear issue details for %s: %v", ctx.Name(), issueID, err)
+					details = &linearIssueDetails{Identifier: issueID}
+				}
+				if details == nil {
+					s.warnPipelineRender(clawID, "%s: Linear issue %s returned no details", ctx.Name(), issueID)
+					details = &linearIssueDetails{Identifier: issueID}
+				}
+			}
+			baseData["Issue"] = details
+		} else {
+			// GitHub issue — fetch details and render with same {{.Issue.*}} variables
+			ghToken := s.resolveGitHubIssuesTokenForPipeline(ctx)
+			details := fallbackGitHubIssueDetails(issueID)
+			if ghToken != "" {
+				parts := strings.Split(issueID, "/")
+				if len(parts) == 3 {
+					repo := parts[0] + "/" + parts[1]
+					var issueNum int
+					if _, err := fmt.Sscanf(parts[2], "%d", &issueNum); err == nil {
+						base := s.githubBaseURL
+						if base == "" {
+							base = "https://api.github.com"
+						}
+						fetchedDetails, err := s.fetchGitHubIssueDetailsWithRetry(clawID, ghToken, repo, issueNum, base)
+						if err != nil || fetchedDetails == nil {
+							s.warnPipelineRender(clawID, "%s: failed to fetch GitHub issue details for %s: %v", ctx.Name(), issueID, err)
+						} else {
+							details = fetchedDetails
+						}
+					} else {
+						s.warnPipelineRender(clawID, "%s: invalid GitHub issue number in %q: %v", ctx.Name(), issueID, err)
+					}
+				} else {
+					s.warnPipelineRender(clawID, "%s: invalid GitHub issue ID format %q", ctx.Name(), issueID)
+				}
+				log.Printf("[pipeline] fetched GitHub issue %s: #%s title=%s", issueID, details.Identifier, details.Title)
+			} else {
+				s.warnPipelineRender(clawID, "%s: no GitHub Issues token configured; rendering inject with fallback issue context", ctx.Name())
+			}
+			baseData["Issue"] = details
+		}
+	}
+
+	if manualInputs != nil {
+		baseData["Inputs"] = manualInputs
+	}
+
+	// Always render with persisted outputs so cron and manual workflows can use {{.Outputs.*}}.
+	injectMsg = renderInjectWithData(clawID, injectMsg, s.injectTemplateData(clawID, baseData))
+
+	if inputContext := formatManualTriggerInputs(manualInputs); inputContext != "" {
+		injectMsg = inputContext + "\n\n" + injectMsg
+	}
+	return injectMsg
+}
+
 // runOnEnter executes the on_enter actions for a given stage.
 //
 // - stage.OnEnter.Run: executes a command in the agent workspace
@@ -1418,80 +1505,7 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 	}
 
 	if stage.OnEnter.Inject != "" {
-		injectMsg := stage.OnEnter.Inject
-		manualInputs := s.loadManualTriggerInputs(clawID)
-
-		// Build base template data from issue context, manual inputs, and persisted outputs.
-		baseData := map[string]interface{}{}
-
-		// Render {{.Issue.Identifier}}, {{.Issue.Title}}, {{.Issue.URL}} when this
-		// claw is backed by a Linear or GitHub issue. Shortcut IDs (sc-...) are
-		// intentionally excluded from the Issue namespace.
-		if issueID != "" && !strings.HasPrefix(issueID, "sc-") {
-			if !strings.Contains(issueID, "/") {
-				// Linear issue
-				log.Printf("[pipeline] attempting to render template for claw %s issue %s", clawID[:8], issueID)
-				linearToken := s.resolveLinearTokenForPipeline(ctx)
-				details := &linearIssueDetails{Identifier: issueID}
-				if linearToken == "" {
-					s.warnPipelineRender(clawID, "%s: no Linear issue tracker token configured; rendering inject with fallback issue context", ctx.Name())
-				} else {
-					var err error
-					details, err = s.fetchLinearIssueDetails(linearToken, issueID)
-					if err != nil {
-						s.warnPipelineRender(clawID, "%s: failed to fetch Linear issue details for %s: %v", ctx.Name(), issueID, err)
-						details = &linearIssueDetails{Identifier: issueID}
-					}
-					if details == nil {
-						s.warnPipelineRender(clawID, "%s: Linear issue %s returned no details", ctx.Name(), issueID)
-						details = &linearIssueDetails{Identifier: issueID}
-					}
-				}
-				baseData["Issue"] = details
-			} else {
-				// GitHub issue — fetch details and render with same {{.Issue.*}} variables
-				ghToken := s.resolveGitHubIssuesTokenForPipeline(ctx)
-				details := fallbackGitHubIssueDetails(issueID)
-				if ghToken != "" {
-					parts := strings.Split(issueID, "/")
-					if len(parts) == 3 {
-						repo := parts[0] + "/" + parts[1]
-						var issueNum int
-						if _, err := fmt.Sscanf(parts[2], "%d", &issueNum); err == nil {
-							base := s.githubBaseURL
-							if base == "" {
-								base = "https://api.github.com"
-							}
-							fetchedDetails, err := s.fetchGitHubIssueDetailsWithRetry(clawID, ghToken, repo, issueNum, base)
-							if err != nil || fetchedDetails == nil {
-								s.warnPipelineRender(clawID, "%s: failed to fetch GitHub issue details for %s: %v", ctx.Name(), issueID, err)
-							} else {
-								details = fetchedDetails
-							}
-						} else {
-							s.warnPipelineRender(clawID, "%s: invalid GitHub issue number in %q: %v", ctx.Name(), issueID, err)
-						}
-					} else {
-						s.warnPipelineRender(clawID, "%s: invalid GitHub issue ID format %q", ctx.Name(), issueID)
-					}
-					log.Printf("[pipeline] fetched GitHub issue %s: #%s title=%s", issueID, details.Identifier, details.Title)
-				} else {
-					s.warnPipelineRender(clawID, "%s: no GitHub Issues token configured; rendering inject with fallback issue context", ctx.Name())
-				}
-				baseData["Issue"] = details
-			}
-		}
-
-		if manualInputs != nil {
-			baseData["Inputs"] = manualInputs
-		}
-
-		// Always render with persisted outputs so cron and manual workflows can use {{.Outputs.*}}.
-		injectMsg = renderInjectWithData(clawID, injectMsg, s.injectTemplateData(clawID, baseData))
-
-		if inputContext := formatManualTriggerInputs(manualInputs); inputContext != "" {
-			injectMsg = inputContext + "\n\n" + injectMsg
-		}
+		injectMsg := s.renderStageInject(clawID, stage, ctx)
 		if s.clawNeedsInitialPlan(clawID) && s.insertSystemMarker(clawID, s.tenantIDForClaw(clawID), initialPlanRequiredMarker) {
 			injectMsg = initialPlanWakeContent + "\n\nTask context:\n" + injectMsg
 		}

--- a/pkg/hub/rebrief.go
+++ b/pkg/hub/rebrief.go
@@ -1,0 +1,78 @@
+package hub
+
+import (
+	"fmt"
+	"log"
+	"strings"
+)
+
+// clearRebriefPending discards an armed re-brief without delivering it. Used
+// when pipeline entry initialization has just briefed the fresh session with
+// full task context (a claw that died before its first stage): leaving the
+// flag armed would make a later benign bridge flap replay a "sandbox was
+// replaced" brief into a live, intact session.
+func (s *Server) clearRebriefPending(clawID string) {
+	_, _ = s.db.Exec(`UPDATE claws SET rebrief_pending=0 WHERE id=?`, clawID)
+}
+
+// rebriefAfterRestoreIfNeeded re-briefs a claw whose sandbox was replaced by
+// [claw-retry]. The replacement runs a brand-new OpenClaw session: the
+// checkpoint restore brings back workspace files but not the conversation, so
+// without a re-brief the fresh agent's first input is an unrelated
+// watchdog/pr-watcher nag and it has no idea which ticket it owns.
+// rebrief_pending is armed only by resetClawForRetry — a normal
+// reconnect/bridge flap never sets it, so this is a no-op outside retries.
+//
+// The re-brief deliberately re-renders ONLY the current stage's inject text.
+// Re-running on_enter side effects (run/gate/judge/move_issue/labels/notify/
+// merge_pr) on a restore would double-post comments and re-trigger builds.
+func (s *Server) rebriefAfterRestoreIfNeeded(cc *clawConn, clawID string) bool {
+	// Consume the flag before doing any work so two racing reconnects cannot
+	// deliver the brief twice: at-most-once beats at-least-once here.
+	res, err := s.db.Exec(`UPDATE claws SET rebrief_pending=0 WHERE id=? AND rebrief_pending=1`, clawID)
+	if err != nil {
+		return false
+	}
+	if rows, _ := res.RowsAffected(); rows == 0 {
+		return false
+	}
+
+	// If the pipeline context or stage cannot be resolved anymore the flag
+	// stays consumed — there is no task context to re-brief with, and the
+	// normal wake path can take over on the next branch.
+	ctx, ok := s.findPipelineContextForClaw(clawID)
+	if !ok {
+		return false
+	}
+	pl := parsePipelineForContext(ctx)
+	if pl == nil {
+		return false
+	}
+	stage := pl.StageByID(s.getPipelineStage(clawID))
+	if stage == nil {
+		// The recorded stage no longer exists in the pipeline definition
+		// (e.g. the workflow was edited); the entry stage's context is still
+		// better than briefing with nothing.
+		stage = pl.EntryStage()
+	}
+	if stage == nil {
+		return false
+	}
+
+	var b strings.Builder
+	b.WriteString("[hub] Your sandbox was replaced after an infrastructure failure and this is a fresh session — your previous conversation is gone. Re-read the task context below and continue from the current state of the workspace and PR; do not start over and do not ask which ticket this is.")
+	b.WriteString(fmt.Sprintf("\n\nCurrent workflow stage: %s", stage.ID))
+	if stage.Label != "" {
+		b.WriteString(fmt.Sprintf(" (%s)", stage.Label))
+	}
+	if stage.OnEnter.Inject != "" {
+		b.WriteString("\n\n" + s.renderStageInject(clawID, *stage, ctx))
+	}
+	for _, pr := range s.checkpointPRs(clawID) {
+		b.WriteString(fmt.Sprintf("\nOpen PR: %s (%s, #%d)", pr.URL, pr.Repo, pr.Number))
+	}
+
+	s.injectHubMessageByID(clawID, b.String())
+	log.Printf("[pipeline] re-briefed claw %s after restore (stage %q)", shortID(clawID), stage.ID)
+	return true
+}

--- a/pkg/hub/rebrief_test.go
+++ b/pkg/hub/rebrief_test.go
@@ -1,0 +1,224 @@
+package hub
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func rebriefTestFactory() *types.FactoryConfig {
+	return &types.FactoryConfig{
+		Name: "rebrief-factory",
+		PipelineYAML: `
+stages:
+  - id: plan
+    entry: true
+    on_enter:
+      inject: Plan the work
+  - id: implement
+    triggers:
+      - message_contains: "[GO]"
+    on_enter:
+      inject: Implement {{.Issue.Identifier}}
+`,
+	}
+}
+
+func newRebriefTestServer(t *testing.T, clawID, status, stage string) (*Server, *sql.DB) {
+	t.Helper()
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{
+		Token:     "test-token",
+		Factories: []*types.FactoryConfig{rebriefTestFactory()},
+	}, "", "", "")
+	if _, err := db.Exec(
+		`INSERT INTO claws(id, tenant_id, name, template, status, tags, linear_issue_id, pipeline_stage, created_at) VALUES(?,?,?,?,?,?,?,?,datetime('now'))`,
+		clawID, "test-tenant-id", "rebrief claw", "elasticclaw", status, `["factory:rebrief-factory"]`, "AMA-200", stage,
+	); err != nil {
+		t.Fatalf("insert claw: %v", err)
+	}
+	return s, db
+}
+
+func clawRebriefPending(t *testing.T, db *sql.DB, clawID string) int {
+	t.Helper()
+	var pending int
+	if err := db.QueryRow(`SELECT rebrief_pending FROM claws WHERE id=?`, clawID).Scan(&pending); err != nil {
+		t.Fatalf("read rebrief_pending: %v", err)
+	}
+	return pending
+}
+
+func TestRebriefPendingArmedByRetryAndConsumedOnce(t *testing.T) {
+	const clawID = "claw-rebrief-consume"
+	s, db := newRebriefTestServer(t, clawID, "error", "implement")
+	if _, err := db.Exec(
+		`INSERT INTO claw_prs(id, claw_id, repo, pr_number, pr_url, created_at) VALUES('pr-1',?,?,?,?,datetime('now'))`,
+		clawID, "acme/widgets", 42, "https://github.com/acme/widgets/pull/42",
+	); err != nil {
+		t.Fatalf("insert claw_prs: %v", err)
+	}
+
+	reset, err := s.resetClawForRetry("test-tenant-id", clawID, "", "retrying (attempt 2/3)")
+	if err != nil {
+		t.Fatalf("resetClawForRetry: %v", err)
+	}
+	if !reset {
+		t.Fatal("resetClawForRetry did not update the claw")
+	}
+	if pending := clawRebriefPending(t, db, clawID); pending != 1 {
+		t.Fatalf("rebrief_pending=%d after retry reset, want 1", pending)
+	}
+
+	if !s.rebriefAfterRestoreIfNeeded(nil, clawID) {
+		t.Fatal("first rebriefAfterRestoreIfNeeded returned false, want true")
+	}
+	// The flag is consumed atomically before delivery, so a racing second
+	// reconnect must not re-brief again.
+	if s.rebriefAfterRestoreIfNeeded(nil, clawID) {
+		t.Fatal("second rebriefAfterRestoreIfNeeded returned true, want false")
+	}
+	if pending := clawRebriefPending(t, db, clawID); pending != 0 {
+		t.Fatalf("rebrief_pending=%d after consume, want 0", pending)
+	}
+
+	rows, err := db.Query(`SELECT content FROM messages WHERE claw_id=? AND role='hub'`, clawID)
+	if err != nil {
+		t.Fatalf("select hub messages: %v", err)
+	}
+	defer rows.Close()
+	var briefs []string
+	for rows.Next() {
+		var content string
+		if err := rows.Scan(&content); err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(content, "Your sandbox was replaced") {
+			briefs = append(briefs, content)
+		}
+	}
+	if len(briefs) != 1 {
+		t.Fatalf("re-brief messages=%d, want exactly 1", len(briefs))
+	}
+	brief := briefs[0]
+	for _, want := range []string{
+		"Current workflow stage: implement",
+		"Implement AMA-200",
+		"Open PR: https://github.com/acme/widgets/pull/42 (acme/widgets, #42)",
+	} {
+		if !strings.Contains(brief, want) {
+			t.Fatalf("re-brief missing %q:\n%s", want, brief)
+		}
+	}
+}
+
+func TestRebriefNotArmedOnNormalReconnect(t *testing.T) {
+	const clawID = "claw-rebrief-normal"
+	s, db := newRebriefTestServer(t, clawID, "connected", "implement")
+
+	if s.rebriefAfterRestoreIfNeeded(nil, clawID) {
+		t.Fatal("rebriefAfterRestoreIfNeeded returned true without a retry reset")
+	}
+	if pending := clawRebriefPending(t, db, clawID); pending != 0 {
+		t.Fatalf("rebrief_pending=%d on normal reconnect, want 0", pending)
+	}
+	var messages int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=?`, clawID).Scan(&messages); err != nil {
+		t.Fatal(err)
+	}
+	if messages != 0 {
+		t.Fatalf("messages=%d after no-op rebrief, want 0", messages)
+	}
+}
+
+func TestRenderStageInjectRendersIssueIdentifier(t *testing.T) {
+	const clawID = "claw-rebrief-render"
+	s, _ := newRebriefTestServer(t, clawID, "connected", "implement")
+
+	factory := rebriefTestFactory()
+	ctx := pipelineContext{Factory: factory, IssueID: "AMA-200"}
+	pl := parsePipelineForContext(ctx)
+	if pl == nil {
+		t.Fatal("parse pipeline")
+	}
+	stage := pl.StageByID("implement")
+	if stage == nil {
+		t.Fatal("implement stage not found")
+	}
+	// No Linear token is configured, so rendering falls back to the identifier
+	// from the claw's issue context — exactly what the re-brief needs.
+	got := s.renderStageInject(clawID, *stage, ctx)
+	if got != "Implement AMA-200" {
+		t.Fatalf("renderStageInject=%q, want %q", got, "Implement AMA-200")
+	}
+}
+
+// A claw that dies before its first pipeline initialization takes the
+// entry-init branch on reconnect: the entry inject briefs the fresh session,
+// so the armed flag must be discarded there or a later benign bridge flap
+// would replay the "sandbox was replaced" brief into a live session.
+func TestClearRebriefPendingDiscardsArmedFlag(t *testing.T) {
+	const clawID = "claw-rebrief-clear"
+	s, db := newRebriefTestServer(t, clawID, "error", "")
+
+	if _, err := s.resetClawForRetry("test-tenant-id", clawID, "", "retrying (attempt 2/3)"); err != nil {
+		t.Fatalf("resetClawForRetry: %v", err)
+	}
+	if pending := clawRebriefPending(t, db, clawID); pending != 1 {
+		t.Fatalf("rebrief_pending=%d after retry reset, want 1", pending)
+	}
+
+	s.clearRebriefPending(clawID)
+	if pending := clawRebriefPending(t, db, clawID); pending != 0 {
+		t.Fatalf("rebrief_pending=%d after clear, want 0", pending)
+	}
+	if s.rebriefAfterRestoreIfNeeded(nil, clawID) {
+		t.Fatal("rebriefAfterRestoreIfNeeded returned true after clear, want false")
+	}
+}
+
+// An existing hub database predates rebrief_pending. resetClawForRetry's
+// UPDATE references the column on the retry hot path, so the additive
+// migration must add it (backfilled to 0 so no mid-flight claw gets a
+// spurious re-brief) and absorb the re-run on every later hub restart.
+func TestMigrateAddsRebriefPendingToExistingClaws(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	// Minimal pre-migration shape of claws; migrate()'s ALTERs add the rest.
+	if _, err := db.Exec(`CREATE TABLE claws (
+		id         TEXT PRIMARY KEY,
+		tenant_id  TEXT NOT NULL,
+		name       TEXT NOT NULL,
+		template   TEXT NOT NULL DEFAULT '',
+		status     TEXT NOT NULL DEFAULT 'offline',
+		created_at DATETIME NOT NULL
+	)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO claws(id,tenant_id,name,created_at) VALUES('c','t','claw',datetime('now'))`); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := migrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	var pending int
+	if err := db.QueryRow(`SELECT rebrief_pending FROM claws WHERE id='c'`).Scan(&pending); err != nil {
+		t.Fatalf("select after migration: %v", err)
+	}
+	if pending != 0 {
+		t.Fatalf("rebrief_pending=%d on pre-existing row, want 0", pending)
+	}
+
+	// Every hub restart re-runs migrate() against a database that already has
+	// the column. addColumn must absorb that, not abort startup.
+	if err := migrate(db); err != nil {
+		t.Fatalf("second migrate: %v", err)
+	}
+}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -4985,7 +4985,16 @@ func (s *Server) startWorkflowAfterVolumes(ctx context.Context, cc *clawConn, cl
 		cc.mu.Unlock()
 
 		if s.initializePipelineEntryIfNeeded(clawID) {
+			// The entry inject just briefed this session with full task
+			// context (a retried claw can land here when it died before its
+			// first stage), so discard any armed re-brief: left in place it
+			// would fire on a later benign bridge flap and tell a live
+			// session its conversation is gone.
+			s.clearRebriefPending(clawID)
 			s.sendInitialPlanInstruction(cc, clawID)
+		} else if s.rebriefAfterRestoreIfNeeded(cc, clawID) {
+			// Retry replacement: the fresh session was re-briefed with its
+			// task context; nothing else to send.
 		} else if s.getPipelineStage(clawID) == "" && !s.clawHasMessages(clawID) {
 			s.sendWakeMessage(cc, clawID)
 		}


### PR DESCRIPTION
## Problem

When `[claw-retry]` replaces a claw, the same `claw_id` gets a new sandbox running a **brand-new OpenClaw session**. Three defects then made the agent lose the ticket entirely:

1. The checkpoint restore only restores workspace **files** — the checkpoint's message blob (`message_tree_sha256`) is written but never read back, so the new session starts empty.
2. `startWorkflowAfterVolumes` only briefs a claw whose `pipeline_stage` is empty. After a retry the stage is set and message history exists, so **both branches were skipped** and the fresh agent got nothing; its first input was an unrelated watchdog/pr-watcher nag.
3. `retryCheckpointID` picked the newest ready checkpoint, which in both production incidents was the `bootstrap` checkpoint taken seconds after provisioning — restoring state zero and rolling the workspace back.

Observed in the Faster factory on 2026-08-21:

- claw `24584ee6` (NEXT-801) after restore: *"This is the whole session — no active ticket or long-running task in progress."*
- claw `d125a840` (NEXT-790) after restore: *"I don't have a ticket loaded in this session — no Linear issue ID, description, or repo scope has been provided."*
- Both repos reported clean on `develop` with "nothing to open" — the bootstrap-checkpoint rollback.

10 distinct claws hit `Restoring from checkpoint` in the last 7 days, so this is not a one-off.

## Changes

- **`renderStageInject`** extracted from `runOnEnter` (pure refactor) so a stage's task context can be re-rendered without re-running any `on_enter` side effect (run/gate/judge/move_issue/labels/notify/merge_pr).
- **`rebrief_pending`** column on `claws`, armed only by `resetClawForRetry` and consumed at-most-once on reconnect by `rebriefAfterRestoreIfNeeded`, which injects: a header explaining the session is fresh, the current stage, the re-rendered stage inject, and any registered PR. Cleared on the entry-init branch so a claw that died before its first stage cannot fire a spurious brief on a later bridge flap.
- **Checkpoint selection**: a `bootstrap` checkpoint is no longer restored over a claw that has progressed (registered PR / non-bootstrap checkpoint / past the entry stage). It falls back to the newest non-bootstrap checkpoint, or provisions cleanly, keeping the existing "never restore the checkpoint the previous attempt failed on" guard.

## Tests

`TestRebriefPendingArmedByRetryAndConsumedOnce`, `TestRebriefNotArmedOnNormalReconnect`, `TestClearRebriefPendingDiscardsArmedFlag`, `TestRenderStageInjectRendersIssueIdentifier`, `TestMigrateAddsRebriefPendingToExistingClaws`, `TestRetryCheckpointSkipsBootstrapCheckpointAfterProgress` (5 subtests).

`go build ./...`, `go vet ./pkg/hub/` clean. `go test ./pkg/hub/` passes except 3 failures that reproduce identically on `origin/main` (the known local hub-config leak in the DONE-signal tests).

## Follow-up (not in this PR)

Replaying the previous conversation into the new OpenClaw session. The checkpoint already stores the messages, but injecting them into a fresh session is an OpenClaw-side design and out of scope here. The re-brief makes the agent resume knowing its ticket, stage and PR; it does not restore the transcript.

Also worth a separate look: the trigger itself — these replacements were caused by the Daytona gateway going unhealthy for 12 consecutive heartbeats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
