### PR TITLE
fix(hub): finalize a claw only when every delivered PR is resolved

### DIFF
--- a/pkg/hub/agent_idle.go
+++ b/pkg/hub/agent_idle.go
@@ -665,13 +665,18 @@ func (s *Server) agentIdleRunPhase(taskRunID string) string {
 }
 
 // agentIdleHasClawPRs reports whether the claw currently tracks any
-// unresolved PR. Resolved rows (state merged/closed) survive until the claw
-// is finalized so the all-PRs-resolved gate can count them — a resolved row
-// must never read as "awaiting humans" here, or a retried claw carrying one
-// would have its stuck alert suppressed for life.
+// unresolved DELIVERED PR. Resolved rows (state merged/closed) survive until
+// the claw is finalized so the all-PRs-resolved gate can count them — a
+// resolved row must never read as "awaiting humans" here, or a retried claw
+// carrying one would have its stuck alert suppressed for life. Mention-only
+// rows are excluded for the same reason, matching clawOpenPRCount: a PR the
+// agent merely linked is not "PR out, awaiting humans", and since the watcher
+// never finalizes a claw with zero delivered rows, counting a mention here
+// would make a hung mention-only claw simultaneously immortal (never torn
+// down) and invisible (stuck alert suppressed).
 func (s *Server) agentIdleHasClawPRs(clawID string) bool {
 	var n int
-	if err := s.db.QueryRow(`SELECT COUNT(*) FROM claw_prs WHERE claw_id=? AND state NOT IN ('merged','closed')`, clawID).Scan(&n); err != nil {
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM claw_prs WHERE claw_id=? AND state NOT IN ('merged','closed') AND mention_only=0`, clawID).Scan(&n); err != nil {
 		log.Printf("[agent-idle] count claw prs for %s: %v", shortID(clawID), err)
 		return false
 	}

--- a/pkg/hub/agent_idle.go
+++ b/pkg/hub/agent_idle.go
@@ -579,9 +579,11 @@ func agentIdleResumeMessage(idleFor time.Duration) string {
 //     (idle/completed/deleted — see isProtectedClawStatus) plus
 //     error/offline/provisioning are all either finished or covered by the
 //     failure notifications.
-//   - any claw_prs row excludes, run-backed or not. claw_prs rows exist only
-//     while a delivered PR is being tracked (they are deleted on close/merge/
-//     teardown), so a row means "PR out, awaiting CI/review/merge". For
+//   - any UNRESOLVED claw_prs row (state not merged/closed) excludes,
+//     run-backed or not. Rows are deleted only when the claw is finalized;
+//     until then resolved rows survive so the all-PRs-resolved teardown gate
+//     can count them, and only an unresolved row still means "PR out,
+//     awaiting CI/review/merge". For
 //     run-backed claws this is deliberately checked in ADDITION to the run
 //     phase: associateTaskRunPR can fail (and is never retried), leaving the
 //     phase at agent_running forever even though the PR was delivered.
@@ -662,10 +664,14 @@ func (s *Server) agentIdleRunPhase(taskRunID string) string {
 	return phase
 }
 
-// agentIdleHasClawPRs reports whether the claw currently tracks any delivered PR.
+// agentIdleHasClawPRs reports whether the claw currently tracks any
+// unresolved PR. Resolved rows (state merged/closed) survive until the claw
+// is finalized so the all-PRs-resolved gate can count them — a resolved row
+// must never read as "awaiting humans" here, or a retried claw carrying one
+// would have its stuck alert suppressed for life.
 func (s *Server) agentIdleHasClawPRs(clawID string) bool {
 	var n int
-	if err := s.db.QueryRow(`SELECT COUNT(*) FROM claw_prs WHERE claw_id=?`, clawID).Scan(&n); err != nil {
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM claw_prs WHERE claw_id=? AND state NOT IN ('merged','closed')`, clawID).Scan(&n); err != nil {
 		log.Printf("[agent-idle] count claw prs for %s: %v", shortID(clawID), err)
 		return false
 	}

--- a/pkg/hub/checkpoints.go
+++ b/pkg/hub/checkpoints.go
@@ -953,7 +953,10 @@ func (s *Server) buildCheckpointManifest(checkpointID, clawID, rootSHA, msgSHA s
 }
 
 func (s *Server) checkpointPRs(clawID string) []checkpointPR {
-	rows, err := s.db.Query(`SELECT repo, pr_number, pr_url, last_ci_sha FROM claw_prs WHERE claw_id=? ORDER BY created_at ASC`, clawID)
+	// Resolved rows (merged/closed) survive in claw_prs until the claw is
+	// finalized, but a checkpoint lists tracked WORK — restoring one taken
+	// after a partial merge must not present already-merged PRs as open.
+	rows, err := s.db.Query(`SELECT repo, pr_number, pr_url, last_ci_sha FROM claw_prs WHERE claw_id=? AND state NOT IN ('merged','closed') ORDER BY created_at ASC`, clawID)
 	if err != nil {
 		return nil
 	}

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -156,6 +156,13 @@ func migrate(db *sql.DB) error {
 	if err := addColumn(db, "claw_prs", "merged_at", `TEXT`); err != nil {
 		return err
 	}
+	// mention_only=1 marks rows created by the message scanner for PR URLs the
+	// agent merely mentioned, as opposed to PRs it delivered via [DONE]. Only
+	// delivered rows (mention_only=0) gate claw finalization. Default 0 keeps
+	// every pre-existing row blocking — fail safe, no backfill needed.
+	if err := addColumn(db, "claw_prs", "mention_only", `INTEGER NOT NULL DEFAULT 0`); err != nil {
+		return err
+	}
 	// The PR watcher never polls claws in terminal/offline states. Legacy rows
 	// therefore cannot safely retain the historical default of "open". Preserve
 	// a known terminal task-run PR state when available; otherwise mark it unknown.
@@ -763,6 +770,7 @@ func migrate(db *sql.DB) error {
 		last_review_id INTEGER NOT NULL DEFAULT 0, -- last top-level PR review ID seen
 		pr_conditions_fired INTEGER NOT NULL DEFAULT 0,
 		permanent_failure_count INTEGER NOT NULL DEFAULT 0,
+		mention_only INTEGER NOT NULL DEFAULT 0, -- 1 = URL scanned from a message, not delivered via [DONE]; never gates finalization
 		created_at  DATETIME NOT NULL,
 		UNIQUE(claw_id, pr_url)
 	);

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -163,6 +163,15 @@ func migrate(db *sql.DB) error {
 	if err := addColumn(db, "claw_prs", "mention_only", `INTEGER NOT NULL DEFAULT 0`); err != nil {
 		return err
 	}
+	// token_miss_count bounds how long a row whose repo has NO resolvable
+	// GitHub App token keeps blocking finalization. It is deliberately separate
+	// from permanent_failure_count: that counter belongs to checkPRMerged's
+	// permanent-API-error handling and is reset there on every successful
+	// fetch — sharing one column would let each pollAllPRs token resolve reset
+	// the API-error count (or vice versa) and neither bound would ever fire.
+	if err := addColumn(db, "claw_prs", "token_miss_count", `INTEGER NOT NULL DEFAULT 0`); err != nil {
+		return err
+	}
 	// The PR watcher never polls claws in terminal/offline states. Legacy rows
 	// therefore cannot safely retain the historical default of "open". Preserve
 	// a known terminal task-run PR state when available; otherwise mark it unknown.
@@ -771,6 +780,7 @@ func migrate(db *sql.DB) error {
 		pr_conditions_fired INTEGER NOT NULL DEFAULT 0,
 		permanent_failure_count INTEGER NOT NULL DEFAULT 0,
 		mention_only INTEGER NOT NULL DEFAULT 0, -- 1 = URL scanned from a message, not delivered via [DONE]; never gates finalization
+		token_miss_count INTEGER NOT NULL DEFAULT 0, -- consecutive polls with no resolvable GitHub token for the repo; separate from permanent_failure_count (see migrate)
 		created_at  DATETIME NOT NULL,
 		UNIQUE(claw_id, pr_url)
 	);

--- a/pkg/hub/github_webhook.go
+++ b/pkg/hub/github_webhook.go
@@ -286,6 +286,14 @@ func (s *Server) processGitHubPREvent(payload githubPRPayload) {
 					log.Printf("[factory:%s] github PR #%d synchronize from own app bot %q — skipping", factory.Name, payload.Number, payload.Sender.Login)
 					continue
 				}
+				if payload.Action == "reopened" {
+					// A closed row is sticky: the poller excludes resolved
+					// states and nothing else resets them, so without this the
+					// reopened PR would never be polled again and the claw
+					// could be finalized while it sits open. Reset before the
+					// inject, regardless of claw readiness.
+					s.resetReopenedClawPR(existingClawID, payload.PullRequest.HTMLURL)
+				}
 				// Only inject if the claw is connected and ready — otherwise the
 				// claw hasn't started yet and the update is redundant (claw gets
 				// full context from BOOTSTRAP on startup).
@@ -887,6 +895,21 @@ func (s *Server) isOwnAppBot(login string) bool {
 	return false
 }
 
+// resetReopenedClawPR puts a resolved claw_prs row back into the open state
+// when its PR is reopened on GitHub, so the watcher polls it again and it
+// gates claw finalization again. Idempotent: a row that is already open (or
+// unknown) is left untouched.
+func (s *Server) resetReopenedClawPR(clawID, prURL string) {
+	res, err := s.db.Exec(`UPDATE claw_prs SET state='open', merged=0, merged_at=NULL WHERE claw_id=? AND pr_url=?`, clawID, prURL)
+	if err != nil {
+		log.Printf("[github-webhook] failed to reset reopened PR %s for claw %s: %v", prURL, clawID[:8], err)
+		return
+	}
+	if affected, err := res.RowsAffected(); err == nil && affected > 0 {
+		log.Printf("[github-webhook] PR %s reopened — reset tracked row to open for claw %s", prURL, clawID[:8])
+	}
+}
+
 // findClawForGitHubPR returns the claw ID that is already tracking this PR URL, or "".
 func (s *Server) findClawForGitHubPR(prURL string) string {
 	var clawID string
@@ -1160,7 +1183,9 @@ func (s *Server) createClawForGitHubPR(factory *types.FactoryConfig, pr githubPR
 	// the trigger claim active — permanently blocking re-creation for this PR. If
 	// the association fails, tear the claw down and release the claim so poll/webhook
 	// can retry.
-	if _, err := s.storePRMention(clawID, repoFullName, prNumber, prURL); err != nil {
+	// mentionOnly=false: this PR is the claw's reason to exist, so it must
+	// gate finalization like a delivered PR.
+	if _, err := s.storePRMention(clawID, repoFullName, prNumber, prURL, false); err != nil {
 		_, _ = s.db.Exec(`UPDATE claws SET status='deleted' WHERE id=?`, clawID)
 		if s.cronScheduler != nil {
 			s.cronScheduler.finishRunByClawID(clawID, "failed", err.Error())
@@ -1314,31 +1339,54 @@ func (s *Server) mergePRForClaw(clawID string) {
 	for rows.Next() {
 		var pr trackedPR
 		if err := rows.Scan(&pr.prURL, &pr.repo, &pr.prNumber); err != nil {
-			log.Printf("[pipeline] merge_pr: failed to scan tracked PR for claw %s: %v", clawID[:8], err)
-			continue
+			// Fatal to the batch: merging a silently partial PR set would leave
+			// the finalization gate waiting on PRs this call never attempted.
+			log.Printf("[pipeline] merge_pr: failed to scan tracked PR for claw %s — aborting merge batch: %v", clawID[:8], err)
+			return
 		}
 		if pr.prURL != "" {
 			prs = append(prs, pr)
 		}
+	}
+	if err := rows.Err(); err != nil {
+		log.Printf("[pipeline] merge_pr: failed to iterate tracked PRs for claw %s — aborting merge batch: %v", clawID[:8], err)
+		return
 	}
 	if len(prs) == 0 {
 		log.Printf("[pipeline] merge_pr: no tracked PR for claw %s", clawID[:8])
 		return
 	}
 
+	merged := 0
+	var failures []string
 	for _, pr := range prs {
-		s.mergeSinglePRForClaw(clawID, pr.repo, pr.prNumber)
+		if failure := s.mergeSinglePRForClaw(clawID, pr.repo, pr.prNumber); failure == "" {
+			merged++
+		} else {
+			failures = append(failures, failure)
+		}
+	}
+	// Aggregate outcome so the agent can act on a partial merge (e.g. rebase a
+	// PR whose merge 405ed because an earlier merge made its base out of date)
+	// instead of waiting indefinitely for a finalization that cannot happen.
+	if len(prs) > 1 {
+		if len(failures) == 0 {
+			s.injectHubMessageByID(clawID, fmt.Sprintf("[hub] merge_pr: merged %d/%d tracked PRs.", merged, len(prs)))
+		} else {
+			s.injectHubMessageByID(clawID, fmt.Sprintf("[hub] merge_pr: merged %d/%d tracked PRs — %s. Fix and merge the remaining PR(s) or the claw cannot finish.", merged, len(prs), strings.Join(failures, "; ")))
+		}
 	}
 }
 
 // mergeSinglePRForClaw merges one tracked PR via the GitHub API, reporting the
-// outcome to the claw as a hub message.
-func (s *Server) mergeSinglePRForClaw(clawID, repo string, prNumber int) {
+// outcome to the claw as a hub message. Returns "" on success, or a short
+// failure description (e.g. "PR #7 failed (HTTP 405)") for the aggregate.
+func (s *Server) mergeSinglePRForClaw(clawID, repo string, prNumber int) (failure string) {
 	token := s.resolveGitHubTokenForRepo(repo)
 	if token == "" {
 		log.Printf("[pipeline] merge_pr: no GitHub token for repo %s", repo)
 		s.injectHubMessageByID(clawID, fmt.Sprintf("[hub] merge_pr: no GitHub token available for %s — cannot auto-merge.", repo))
-		return
+		return fmt.Sprintf("PR #%d failed (no GitHub token for %s)", prNumber, repo)
 	}
 
 	body, _ := json.Marshal(map[string]string{
@@ -1352,7 +1400,7 @@ func (s *Server) mergeSinglePRForClaw(clawID, repo string, prNumber int) {
 	if err != nil {
 		log.Printf("[pipeline] merge_pr: failed to build request for %s#%d: %v", repo, prNumber, err)
 		s.injectHubMessageByID(clawID, fmt.Sprintf("[hub] merge_pr: failed to prepare merge request for PR #%d: %v", prNumber, err))
-		return
+		return fmt.Sprintf("PR #%d failed (%v)", prNumber, err)
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Accept", "application/vnd.github+json")
@@ -1363,7 +1411,7 @@ func (s *Server) mergeSinglePRForClaw(clawID, repo string, prNumber int) {
 	if err != nil {
 		log.Printf("[pipeline] merge_pr: request failed for %s#%d: %v", repo, prNumber, err)
 		s.injectHubMessageByID(clawID, fmt.Sprintf("[hub] merge_pr: failed to merge PR #%d: %v", prNumber, err))
-		return
+		return fmt.Sprintf("PR #%d failed (%v)", prNumber, err)
 	}
 	defer resp.Body.Close()
 	respBody, _ := io.ReadAll(resp.Body)
@@ -1371,8 +1419,9 @@ func (s *Server) mergeSinglePRForClaw(clawID, repo string, prNumber int) {
 	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusCreated {
 		log.Printf("[pipeline] merge_pr: merged %s#%d successfully", repo, prNumber)
 		s.injectHubMessageByID(clawID, fmt.Sprintf("[hub] PR #%d merged successfully.", prNumber))
-	} else {
-		log.Printf("[pipeline] merge_pr: failed to merge %s#%d: HTTP %d: %s", repo, prNumber, resp.StatusCode, string(respBody))
-		s.injectHubMessageByID(clawID, fmt.Sprintf("[hub] merge_pr: failed to merge PR #%d (HTTP %d). Check CI status and review requirements.", prNumber, resp.StatusCode))
+		return ""
 	}
+	log.Printf("[pipeline] merge_pr: failed to merge %s#%d: HTTP %d: %s", repo, prNumber, resp.StatusCode, string(respBody))
+	s.injectHubMessageByID(clawID, fmt.Sprintf("[hub] merge_pr: failed to merge PR #%d (HTTP %d). Check CI status and review requirements.", prNumber, resp.StatusCode))
+	return fmt.Sprintf("PR #%d failed (HTTP %d)", prNumber, resp.StatusCode)
 }

--- a/pkg/hub/github_webhook.go
+++ b/pkg/hub/github_webhook.go
@@ -1292,19 +1292,48 @@ To check out this PR:
 	return b.String()
 }
 
-// mergePRForClaw finds the tracked PR for a claw and merges it via the GitHub API.
+// mergePRForClaw merges every unresolved PR tracked for a claw via the GitHub
+// API. Claw finalization is gated on all tracked PRs being resolved, so merging
+// only one of several open PRs would leave the claw alive forever.
 func (s *Server) mergePRForClaw(clawID string) {
-	var prURL, repo string
-	var prNumber int
-	err := s.db.QueryRow(
-		`SELECT pr_url, repo, pr_number FROM claw_prs WHERE claw_id=? ORDER BY created_at DESC LIMIT 1`,
+	rows, err := s.db.Query(
+		`SELECT pr_url, repo, pr_number FROM claw_prs WHERE claw_id=? AND state NOT IN ('merged','closed') ORDER BY created_at ASC`,
 		clawID,
-	).Scan(&prURL, &repo, &prNumber)
-	if err != nil || prURL == "" {
+	)
+	if err != nil {
+		log.Printf("[pipeline] merge_pr: failed to load tracked PRs for claw %s: %v", clawID[:8], err)
+		return
+	}
+	defer rows.Close()
+
+	type trackedPR struct {
+		prURL, repo string
+		prNumber    int
+	}
+	var prs []trackedPR
+	for rows.Next() {
+		var pr trackedPR
+		if err := rows.Scan(&pr.prURL, &pr.repo, &pr.prNumber); err != nil {
+			log.Printf("[pipeline] merge_pr: failed to scan tracked PR for claw %s: %v", clawID[:8], err)
+			continue
+		}
+		if pr.prURL != "" {
+			prs = append(prs, pr)
+		}
+	}
+	if len(prs) == 0 {
 		log.Printf("[pipeline] merge_pr: no tracked PR for claw %s", clawID[:8])
 		return
 	}
 
+	for _, pr := range prs {
+		s.mergeSinglePRForClaw(clawID, pr.repo, pr.prNumber)
+	}
+}
+
+// mergeSinglePRForClaw merges one tracked PR via the GitHub API, reporting the
+// outcome to the claw as a hub message.
+func (s *Server) mergeSinglePRForClaw(clawID, repo string, prNumber int) {
 	token := s.resolveGitHubTokenForRepo(repo)
 	if token == "" {
 		log.Printf("[pipeline] merge_pr: no GitHub token for repo %s", repo)

--- a/pkg/hub/github_webhook.go
+++ b/pkg/hub/github_webhook.go
@@ -212,6 +212,19 @@ func (s *Server) processGitHubPREvent(payload githubPRPayload) {
 		s.recordGitHubPRReadyForReview(payload)
 	}
 
+	// A reopened PR must reset its sticky resolved row no matter which factory
+	// kind created the claw: the loop below only reaches github/pull_request
+	// factories, but most claws tracking PRs come from Linear- or
+	// issue-triggered factories and their reopened PRs would otherwise stay
+	// state='closed' forever — never polled again, never gating finalization,
+	// so the claw could finish with a delivered PR sitting open. Reset here,
+	// before any factory filtering, regardless of claw readiness.
+	if payload.Action == "reopened" {
+		if reopenedClawID := s.findClawForGitHubPR(payload.PullRequest.HTMLURL); reopenedClawID != "" {
+			s.resetReopenedClawPR(reopenedClawID, payload.PullRequest.HTMLURL)
+		}
+	}
+
 	for _, factory := range factories {
 		if factory.Integration != "github" {
 			continue
@@ -286,14 +299,9 @@ func (s *Server) processGitHubPREvent(payload githubPRPayload) {
 					log.Printf("[factory:%s] github PR #%d synchronize from own app bot %q — skipping", factory.Name, payload.Number, payload.Sender.Login)
 					continue
 				}
-				if payload.Action == "reopened" {
-					// A closed row is sticky: the poller excludes resolved
-					// states and nothing else resets them, so without this the
-					// reopened PR would never be polled again and the claw
-					// could be finalized while it sits open. Reset before the
-					// inject, regardless of claw readiness.
-					s.resetReopenedClawPR(existingClawID, payload.PullRequest.HTMLURL)
-				}
+				// The reopened row reset already ran before the factory loop
+				// (it must not depend on factory kind or filters) — only the
+				// message inject is factory-scoped here.
 				// Only inject if the claw is connected and ready — otherwise the
 				// claw hasn't started yet and the update is redundant (claw gets
 				// full context from BOOTSTRAP on startup).
@@ -1322,7 +1330,12 @@ To check out this PR:
 // only one of several open PRs would leave the claw alive forever.
 func (s *Server) mergePRForClaw(clawID string) {
 	rows, err := s.db.Query(
-		`SELECT pr_url, repo, pr_number FROM claw_prs WHERE claw_id=? AND state NOT IN ('merged','closed') ORDER BY created_at ASC`,
+		// mention_only=0: a mention-only row is a polling target, never an
+		// action target. Merging every unresolved row would let a pipeline
+		// merge_pr action PUT .../merge on a third-party PR the agent merely
+		// linked — and silently merge someone else's PR wherever the App has
+		// write access.
+		`SELECT pr_url, repo, pr_number FROM claw_prs WHERE claw_id=? AND state NOT IN ('merged','closed') AND mention_only=0 ORDER BY created_at ASC`,
 		clawID,
 	)
 	if err != nil {
@@ -1369,23 +1382,30 @@ func (s *Server) mergePRForClaw(clawID string) {
 	// Aggregate outcome so the agent can act on a partial merge (e.g. rebase a
 	// PR whose merge 405ed because an earlier merge made its base out of date)
 	// instead of waiting indefinitely for a finalization that cannot happen.
-	if len(prs) > 1 {
+	// External inject: the whole point is acting instead of waiting, which is
+	// defeated when the claw sits in a no-progress pause — see the rationale
+	// at injectExternalHubMessageByID. Fires for a single PR too: a lone
+	// failure deserves its summary as much as a partial batch.
+	if len(prs) >= 1 {
 		if len(failures) == 0 {
-			s.injectHubMessageByID(clawID, fmt.Sprintf("[hub] merge_pr: merged %d/%d tracked PRs.", merged, len(prs)))
+			s.injectExternalHubMessageByID(clawID, fmt.Sprintf("[hub] merge_pr: merged %d/%d tracked PRs.", merged, len(prs)))
 		} else {
-			s.injectHubMessageByID(clawID, fmt.Sprintf("[hub] merge_pr: merged %d/%d tracked PRs — %s. Fix and merge the remaining PR(s) or the claw cannot finish.", merged, len(prs), strings.Join(failures, "; ")))
+			s.injectExternalHubMessageByID(clawID, fmt.Sprintf("[hub] merge_pr: merged %d/%d tracked PRs — %s. Fix and merge the remaining PR(s) or the claw cannot finish.", merged, len(prs), strings.Join(failures, "; ")))
 		}
 	}
 }
 
 // mergeSinglePRForClaw merges one tracked PR via the GitHub API, reporting the
-// outcome to the claw as a hub message. Returns "" on success, or a short
-// failure description (e.g. "PR #7 failed (HTTP 405)") for the aggregate.
+// outcome to the claw as a hub message. Failure reports use the external
+// inject so a paused (no-progress) claw is woken to act on them — a merge
+// failure the agent must fix (e.g. 405 base-out-of-date) is useless while the
+// claw sleeps. Returns "" on success, or a short failure description
+// (e.g. "PR #7 failed (HTTP 405)") for the aggregate.
 func (s *Server) mergeSinglePRForClaw(clawID, repo string, prNumber int) (failure string) {
 	token := s.resolveGitHubTokenForRepo(repo)
 	if token == "" {
 		log.Printf("[pipeline] merge_pr: no GitHub token for repo %s", repo)
-		s.injectHubMessageByID(clawID, fmt.Sprintf("[hub] merge_pr: no GitHub token available for %s — cannot auto-merge.", repo))
+		s.injectExternalHubMessageByID(clawID, fmt.Sprintf("[hub] merge_pr: no GitHub token available for %s — cannot auto-merge.", repo))
 		return fmt.Sprintf("PR #%d failed (no GitHub token for %s)", prNumber, repo)
 	}
 
@@ -1399,7 +1419,7 @@ func (s *Server) mergeSinglePRForClaw(clawID, repo string, prNumber int) (failur
 	)
 	if err != nil {
 		log.Printf("[pipeline] merge_pr: failed to build request for %s#%d: %v", repo, prNumber, err)
-		s.injectHubMessageByID(clawID, fmt.Sprintf("[hub] merge_pr: failed to prepare merge request for PR #%d: %v", prNumber, err))
+		s.injectExternalHubMessageByID(clawID, fmt.Sprintf("[hub] merge_pr: failed to prepare merge request for PR #%d: %v", prNumber, err))
 		return fmt.Sprintf("PR #%d failed (%v)", prNumber, err)
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
@@ -1410,7 +1430,7 @@ func (s *Server) mergeSinglePRForClaw(clawID, repo string, prNumber int) (failur
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		log.Printf("[pipeline] merge_pr: request failed for %s#%d: %v", repo, prNumber, err)
-		s.injectHubMessageByID(clawID, fmt.Sprintf("[hub] merge_pr: failed to merge PR #%d: %v", prNumber, err))
+		s.injectExternalHubMessageByID(clawID, fmt.Sprintf("[hub] merge_pr: failed to merge PR #%d: %v", prNumber, err))
 		return fmt.Sprintf("PR #%d failed (%v)", prNumber, err)
 	}
 	defer resp.Body.Close()
@@ -1422,6 +1442,6 @@ func (s *Server) mergeSinglePRForClaw(clawID, repo string, prNumber int) (failur
 		return ""
 	}
 	log.Printf("[pipeline] merge_pr: failed to merge %s#%d: HTTP %d: %s", repo, prNumber, resp.StatusCode, string(respBody))
-	s.injectHubMessageByID(clawID, fmt.Sprintf("[hub] merge_pr: failed to merge PR #%d (HTTP %d). Check CI status and review requirements.", prNumber, resp.StatusCode))
+	s.injectExternalHubMessageByID(clawID, fmt.Sprintf("[hub] merge_pr: failed to merge PR #%d (HTTP %d). Check CI status and review requirements.", prNumber, resp.StatusCode))
 	return fmt.Sprintf("PR #%d failed (HTTP %d)", prNumber, resp.StatusCode)
 }

--- a/pkg/hub/github_webhook.go
+++ b/pkg/hub/github_webhook.go
@@ -907,8 +907,13 @@ func (s *Server) isOwnAppBot(login string) bool {
 // when its PR is reopened on GitHub, so the watcher polls it again and it
 // gates claw finalization again. Idempotent: a row that is already open (or
 // unknown) is left untouched.
+//
+// Both failure counters are zeroed too: a reopen is the natural "this row is
+// live again" signal, and a row administratively closed at either bound
+// (token misses or permanent API errors) would otherwise come back with a
+// tripped counter and get no grace before being closed again.
 func (s *Server) resetReopenedClawPR(clawID, prURL string) {
-	res, err := s.db.Exec(`UPDATE claw_prs SET state='open', merged=0, merged_at=NULL WHERE claw_id=? AND pr_url=?`, clawID, prURL)
+	res, err := s.db.Exec(`UPDATE claw_prs SET state='open', merged=0, merged_at=NULL, token_miss_count=0, permanent_failure_count=0 WHERE claw_id=? AND pr_url=?`, clawID, prURL)
 	if err != nil {
 		log.Printf("[github-webhook] failed to reset reopened PR %s for claw %s: %v", prURL, clawID[:8], err)
 		return
@@ -1382,13 +1387,16 @@ func (s *Server) mergePRForClaw(clawID string) {
 	// Aggregate outcome so the agent can act on a partial merge (e.g. rebase a
 	// PR whose merge 405ed because an earlier merge made its base out of date)
 	// instead of waiting indefinitely for a finalization that cannot happen.
-	// External inject: the whole point is acting instead of waiting, which is
-	// defeated when the claw sits in a no-progress pause — see the rationale
-	// at injectExternalHubMessageByID. Fires for a single PR too: a lone
-	// failure deserves its summary as much as a partial batch.
+	// Only the FAILURE aggregate uses the external inject (which resumes a
+	// no-progress pause): a failure needs action even from a paused claw. The
+	// all-success aggregate needs no action — waking a deliberately paused
+	// claw for it would burn a turn moments before the watcher finalizes the
+	// claw anyway — so it uses the plain inject, consistent with
+	// mergeSinglePRForClaw's own success message. Fires for a single PR too: a
+	// lone failure deserves its summary as much as a partial batch.
 	if len(prs) >= 1 {
 		if len(failures) == 0 {
-			s.injectExternalHubMessageByID(clawID, fmt.Sprintf("[hub] merge_pr: merged %d/%d tracked PRs.", merged, len(prs)))
+			s.injectHubMessageByID(clawID, fmt.Sprintf("[hub] merge_pr: merged %d/%d tracked PRs.", merged, len(prs)))
 		} else {
 			s.injectExternalHubMessageByID(clawID, fmt.Sprintf("[hub] merge_pr: merged %d/%d tracked PRs — %s. Fix and merge the remaining PR(s) or the claw cannot finish.", merged, len(prs), strings.Join(failures, "; ")))
 		}

--- a/pkg/hub/lifecycle_claw_notifier.go
+++ b/pkg/hub/lifecycle_claw_notifier.go
@@ -295,7 +295,7 @@ func (s *Server) skipCurrentLifecycleClawIdle() error {
 
 // selectLifecycleClawIdleCandidates returns ad-hoc claws whose idle latch has
 // no delivery row yet. The exclusion conditions mirror agentIdleEligible for
-// the ad-hoc kind — status 'connected', no tracked PR, still driven by a
+// the ad-hoc kind — status 'connected', no unresolved tracked PR, still driven by a
 // pipeline stage or a live workflow run — so a claw that opened a PR, died,
 // or lost its automatic driver between latch and delivery is not alerted on
 // stale grounds.
@@ -305,7 +305,7 @@ func (s *Server) selectLifecycleClawIdleCandidates() ([]lifecycleClawRow, []int6
 		SELECT `+lifecycleClawSelectColumns+`, c.idle_since
 		  FROM claws c
 		 WHERE c.task_run_id = '' AND c.idle_since > 0 AND c.status = 'connected'
-		   AND NOT EXISTS (SELECT 1 FROM claw_prs p WHERE p.claw_id = c.id)
+		   AND NOT EXISTS (SELECT 1 FROM claw_prs p WHERE p.claw_id = c.id AND p.state NOT IN ('merged','closed'))
 		   AND (c.pipeline_stage != '' OR EXISTS (
 			SELECT 1 FROM workflow_runs w WHERE w.claw_id = c.id AND w.status IN ('pending','running')
 		   ))

--- a/pkg/hub/lifecycle_claw_notifier.go
+++ b/pkg/hub/lifecycle_claw_notifier.go
@@ -295,17 +295,20 @@ func (s *Server) skipCurrentLifecycleClawIdle() error {
 
 // selectLifecycleClawIdleCandidates returns ad-hoc claws whose idle latch has
 // no delivery row yet. The exclusion conditions mirror agentIdleEligible for
-// the ad-hoc kind — status 'connected', no unresolved tracked PR, still driven by a
-// pipeline stage or a live workflow run — so a claw that opened a PR, died,
-// or lost its automatic driver between latch and delivery is not alerted on
-// stale grounds.
+// the ad-hoc kind — status 'connected', no unresolved DELIVERED tracked PR,
+// still driven by a pipeline stage or a live workflow run — so a claw that
+// opened a PR, died, or lost its automatic driver between latch and delivery
+// is not alerted on stale grounds. Mention-only rows are excluded, matching
+// clawOpenPRCount and agentIdleHasClawPRs: a PR the agent merely linked is
+// not "PR out, awaiting humans", and suppressing the idle notification on it
+// would hide a hung claw the watcher will also never finalize.
 func (s *Server) selectLifecycleClawIdleCandidates() ([]lifecycleClawRow, []int64, error) {
 	cutoff := now().Add(-lifecycleClawAdhocGrace).Unix()
 	rows, err := s.db.Query(`
 		SELECT `+lifecycleClawSelectColumns+`, c.idle_since
 		  FROM claws c
 		 WHERE c.task_run_id = '' AND c.idle_since > 0 AND c.status = 'connected'
-		   AND NOT EXISTS (SELECT 1 FROM claw_prs p WHERE p.claw_id = c.id AND p.state NOT IN ('merged','closed'))
+		   AND NOT EXISTS (SELECT 1 FROM claw_prs p WHERE p.claw_id = c.id AND p.state NOT IN ('merged','closed') AND p.mention_only = 0)
 		   AND (c.pipeline_stage != '' OR EXISTS (
 			SELECT 1 FROM workflow_runs w WHERE w.claw_id = c.id AND w.status IN ('pending','running')
 		   ))

--- a/pkg/hub/lifecycle_claw_notifier_test.go
+++ b/pkg/hub/lifecycle_claw_notifier_test.go
@@ -590,3 +590,46 @@ func TestSlackTestEndpointRejectsRunIDAndClawIDTogether(t *testing.T) {
 		t.Fatalf("unexpected body: %s", rr.Body.String())
 	}
 }
+
+// The idle candidate query's ownership filter: only a DELIVERED unresolved PR
+// (mention_only=0) counts as "PR out, awaiting humans" and suppresses the
+// agent_idle notification. A mention-only row is a polling target the agent
+// merely linked — suppressing on it would hide a hung claw the watcher will
+// also never finalize. Removing `AND p.mention_only = 0` from the NOT EXISTS
+// clause in selectLifecycleClawIdleCandidates fails the first assertion here.
+func TestLifecycleClawIdleCandidatesIgnoreMentionOnlyPRs(t *testing.T) {
+	s, db := newSlackNotifierTestServer(t, "", nil)
+	setLifecycleClawBaseline(t, s)
+
+	insertSlackTestClaw(t, db, "claw-idle-mention", "connected", 1, "", oldEnough)
+	if _, err := db.Exec(`UPDATE claws SET pipeline_stage='work', idle_since=? WHERE id='claw-idle-mention'`,
+		time.Now().Add(-lifecycleClawAdhocGrace-time.Minute).UnixMilli()); err != nil {
+		t.Fatal(err)
+	}
+	insertSlackTestClawPR(t, db, "pr-idle-mention", "claw-idle-mention", "acme/app", 7, "https://github.com/acme/app/pull/7")
+
+	// Unresolved mention-only row: NOT an ownership signal — the claw must
+	// still be an idle candidate.
+	if _, err := db.Exec(`UPDATE claw_prs SET mention_only=1 WHERE id='pr-idle-mention'`); err != nil {
+		t.Fatal(err)
+	}
+	claws, _, err := s.selectLifecycleClawIdleCandidates()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(claws) != 1 || claws[0].ID != "claw-idle-mention" {
+		t.Fatalf("idle candidates with an unresolved MENTION-ONLY PR = %v, want exactly claw-idle-mention (a linked PR must not suppress the idle alert)", claws)
+	}
+
+	// Same row flipped to delivered: "PR out, awaiting humans" — suppressed.
+	if _, err := db.Exec(`UPDATE claw_prs SET mention_only=0 WHERE id='pr-idle-mention'`); err != nil {
+		t.Fatal(err)
+	}
+	claws, _, err = s.selectLifecycleClawIdleCandidates()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(claws) != 0 {
+		t.Fatalf("idle candidates with an unresolved DELIVERED PR = %v, want none (an owned open PR suppresses the idle alert)", claws)
+	}
+}

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -1830,7 +1830,7 @@ func (s *Server) registerDonePRURLs(clawID string, prURLs []string) string {
 
 	// Single URL: reuse the normal path (no multi-row partial-write risk).
 	if len(prs) == 1 {
-		if _, err := s.storePRMention(clawID, prs[0].repo, prs[0].number, prs[0].url); err != nil {
+		if _, err := s.storePRMention(clawID, prs[0].repo, prs[0].number, prs[0].url, false); err != nil {
 			log.Printf("[factory] failed to register PR %s for claw %s: %v", prs[0].url, shortID(clawID), err)
 			return prs[0].url
 		}
@@ -1839,7 +1839,7 @@ func (s *Server) registerDonePRURLs(clawID string, prURLs []string) string {
 
 	var toInsert []prMentionCandidate
 	for _, pr := range prs {
-		already, row, err := s.preparePRMention(clawID, pr.repo, pr.number, pr.url)
+		already, row, err := s.preparePRMention(clawID, pr.repo, pr.number, pr.url, false)
 		if err != nil {
 			log.Printf("[factory] failed to prepare PR %s for claw %s: %v", pr.url, shortID(clawID), err)
 			return pr.url
@@ -1849,7 +1849,7 @@ func (s *Server) registerDonePRURLs(clawID string, prURLs []string) string {
 		}
 		toInsert = append(toInsert, row)
 	}
-	if failURL := s.insertClawPRsAtomic(clawID, toInsert); failURL != "" {
+	if failURL := s.insertClawPRsAtomic(clawID, toInsert, false); failURL != "" {
 		log.Printf("[factory] failed to register PR set for claw %s (first failure %s)", shortID(clawID), failURL)
 		return failURL
 	}

--- a/pkg/hub/no_progress.go
+++ b/pkg/hub/no_progress.go
@@ -210,18 +210,21 @@ func (s *Server) turnProgressFingerprint(clawID, response string) (string, error
 	}
 	parts = append(parts, "stage="+stage)
 
-	rows, err := s.db.Query(`SELECT repo, pr_number, last_ci_sha, last_ci_conclusion, last_comment_id, last_comment_at, last_review_comment_id, last_review_id, pr_conditions_fired FROM claw_prs WHERE claw_id=? ORDER BY repo, pr_number`, clawID)
+	// state/merged are part of the fingerprint: resolved rows survive in
+	// claw_prs until the claw is finalized, so a merge or close no longer
+	// changes the row set — only these columns make it visible as progress.
+	rows, err := s.db.Query(`SELECT repo, pr_number, state, merged, last_ci_sha, last_ci_conclusion, last_comment_id, last_comment_at, last_review_comment_id, last_review_id, pr_conditions_fired FROM claw_prs WHERE claw_id=? ORDER BY repo, pr_number`, clawID)
 	if err != nil {
 		return "", fmt.Errorf("query tracked pull requests: %w", err)
 	}
 	for rows.Next() {
-		var repo, ciSHA, ciConclusion, commentAt string
-		var number, commentID, reviewCommentID, reviewID, conditions int
-		if err := rows.Scan(&repo, &number, &ciSHA, &ciConclusion, &commentID, &commentAt, &reviewCommentID, &reviewID, &conditions); err != nil {
+		var repo, prState, ciSHA, ciConclusion, commentAt string
+		var number, prMerged, commentID, reviewCommentID, reviewID, conditions int
+		if err := rows.Scan(&repo, &number, &prState, &prMerged, &ciSHA, &ciConclusion, &commentID, &commentAt, &reviewCommentID, &reviewID, &conditions); err != nil {
 			rows.Close()
 			return "", fmt.Errorf("scan tracked pull request: %w", err)
 		}
-		parts = append(parts, fmt.Sprintf("pr=%s#%d:%s:%s:%d:%s:%d:%d:%d", repo, number, ciSHA, ciConclusion, commentID, commentAt, reviewCommentID, reviewID, conditions))
+		parts = append(parts, fmt.Sprintf("pr=%s#%d:%s:%d:%s:%s:%d:%s:%d:%d:%d", repo, number, prState, prMerged, ciSHA, ciConclusion, commentID, commentAt, reviewCommentID, reviewID, conditions))
 	}
 	if err := rows.Err(); err != nil {
 		rows.Close()

--- a/pkg/hub/phase0a_test.go
+++ b/pkg/hub/phase0a_test.go
@@ -255,7 +255,7 @@ func TestCheckPRMergedPersistsStateBeforeTerminating(t *testing.T) {
 	}
 
 	pr := clawPR{id: prID, clawID: clawID, repo: "acme/widgets", prNumber: 42, prURL: "https://github.com/acme/widgets/pull/42"}
-	terminated := s.checkPRMerged(pr, "gh-token")
+	_, terminated := s.checkPRMerged(pr, "gh-token")
 	if !terminated {
 		t.Fatal("checkPRMerged returned false, want true for a merged PR")
 	}

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -1414,7 +1414,12 @@ func (s *Server) runOnEnter(clawID string, stage pipeline.Stage, ctx pipelineCon
 	// only after a required gate (if any) has allowed the stage to continue, so
 	// a failed gate cannot leave the PR watcher armed on a blocked claw.
 	if strings.TrimSpace(runStdoutForPRScan) != "" {
-		s.scanMessageForPRs(clawID, runStdoutForPRScan)
+		// mentionOnly=false: this is a delivery channel, not a mention. Gate
+		// scripts like verify-github-pr-links emit the claw's OWN delivered PR
+		// URLs, and for pipeline-driven claws this is often the only
+		// registration path — mention-only rows here would leave the
+		// finalization gate permanently empty.
+		s.scanMessageForPRs(clawID, runStdoutForPRScan, false)
 	}
 
 	if stage.OnEnter.Inject != "" {

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -74,10 +74,20 @@ func extractPRs(content string) []struct {
 // storePRMention persists a detected PR reference for a claw (idempotent by URL).
 // Also tracks analytics for the first detection of a PR open.
 // inserted is true only when this call created the claw_prs row.
-func (s *Server) storePRMention(clawID, repo string, prNumber int, prURL string) (inserted bool, err error) {
+//
+// mentionOnly marks rows created from PR URLs the agent merely mentioned in a
+// message; only delivered rows (mentionOnly=false) gate claw finalization. A
+// delivered call for an already-tracked URL upgrades a mention-only row to
+// delivered, so a PR mentioned mid-work and then listed in [DONE] blocks.
+func (s *Server) storePRMention(clawID, repo string, prNumber int, prURL string, mentionOnly bool) (inserted bool, err error) {
 	var existing string
 	_ = s.db.QueryRow(`SELECT id FROM claw_prs WHERE claw_id=? AND pr_url=?`, clawID, prURL).Scan(&existing)
 	if existing != "" {
+		if !mentionOnly {
+			if err := s.upgradeMentionOnlyPR(clawID, prURL); err != nil {
+				return false, err
+			}
+		}
 		return false, nil
 	}
 
@@ -140,15 +150,22 @@ func (s *Server) storePRMention(clawID, repo string, prNumber int, prURL string)
 	// hitting the (claw_id, pr_url) unique index means the PR is already
 	// tracked — idempotent success, not a persistence failure.
 	res, err := s.db.Exec(
-		`INSERT OR IGNORE INTO claw_prs(id,claw_id,repo,pr_number,pr_url,title,last_comment_id,last_comment_at,last_review_id,last_ci_sha,created_at) VALUES(?,?,?,?,?,?,?,?,?,?,?)`,
-		prID, clawID, repo, prNumber, prURL, title, maxCommentID, lastCommentAt, maxReviewID, headSHA, now(),
+		`INSERT OR IGNORE INTO claw_prs(id,claw_id,repo,pr_number,pr_url,title,last_comment_id,last_comment_at,last_review_id,last_ci_sha,mention_only,created_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?)`,
+		prID, clawID, repo, prNumber, prURL, title, maxCommentID, lastCommentAt, maxReviewID, headSHA, boolInt(mentionOnly), now(),
 	)
 	if err != nil {
 		log.Printf("[pr-watcher] failed to persist PR %s#%d for claw %s: %v", repo, prNumber, clawID[:8], err)
 		return false, err
 	}
 	if affected, err := res.RowsAffected(); err == nil && affected == 0 {
-		return false, nil // concurrent writer already registered this PR
+		// A concurrent writer already registered this PR. If it was the message
+		// scanner, its row may be mention-only while this call is a delivery.
+		if !mentionOnly {
+			if err := s.upgradeMentionOnlyPR(clawID, prURL); err != nil {
+				return false, err
+			}
+		}
+		return false, nil
 	}
 	if _, runID, _, ok, err := s.taskRunContextForClaw(clawID); err != nil {
 		log.Printf("[task-run-analytics] failed to resolve task run for PR mention claw %s: %v", clawID, err)
@@ -173,12 +190,30 @@ func (s *Server) storePRMention(clawID, repo string, prNumber int, prURL string)
 }
 
 // scanMessageForPRs extracts and stores any PR URLs found in a message.
+// The agent can mention any PR in passing ("depends on .../pull/12"), so these
+// rows are registered mention-only: they keep being polled (CI, comments and
+// reviews are still forwarded) but never gate claw finalization.
 func (s *Server) scanMessageForPRs(clawID, content string) {
 	for _, pr := range extractPRs(content) {
-		if _, err := s.storePRMention(clawID, pr.repo, pr.number, pr.url); err != nil {
+		if _, err := s.storePRMention(clawID, pr.repo, pr.number, pr.url, true); err != nil {
 			log.Printf("[pr-watcher] failed to store PR mention: %v", err)
 		}
 	}
+}
+
+// upgradeMentionOnlyPR promotes a mention-only claw_prs row to delivered, so a
+// PR the agent mentioned mid-work and then delivered via [DONE] starts gating
+// finalization. No-op when the row is already delivered or does not exist.
+func (s *Server) upgradeMentionOnlyPR(clawID, prURL string) error {
+	res, err := s.db.Exec(`UPDATE claw_prs SET mention_only=0 WHERE claw_id=? AND pr_url=? AND mention_only=1`, clawID, prURL)
+	if err != nil {
+		log.Printf("[pr-watcher] failed to upgrade mention-only PR %s for claw %s: %v", prURL, shortID(clawID), err)
+		return err
+	}
+	if affected, err := res.RowsAffected(); err == nil && affected > 0 {
+		log.Printf("[pr-watcher] PR %s upgraded from mention-only to delivered for claw %s", prURL, shortID(clawID))
+	}
+	return nil
 }
 
 // prMentionCandidate is a PR URL pending claw_prs registration.
@@ -194,11 +229,18 @@ type prMentionCandidate struct {
 }
 
 // preparePRMention loads GitHub watermarks for a PR insert. alreadyTracked is
-// true when claw_prs already has this URL (no write needed).
-func (s *Server) preparePRMention(clawID, repo string, prNumber int, prURL string) (alreadyTracked bool, row prMentionCandidate, err error) {
+// true when claw_prs already has this URL (no insert needed) — though a
+// delivered (mentionOnly=false) call still upgrades a mention-only row so the
+// PR starts gating finalization.
+func (s *Server) preparePRMention(clawID, repo string, prNumber int, prURL string, mentionOnly bool) (alreadyTracked bool, row prMentionCandidate, err error) {
 	var existing string
 	_ = s.db.QueryRow(`SELECT id FROM claw_prs WHERE claw_id=? AND pr_url=?`, clawID, prURL).Scan(&existing)
 	if existing != "" {
+		if !mentionOnly {
+			if err := s.upgradeMentionOnlyPR(clawID, prURL); err != nil {
+				return true, prMentionCandidate{}, err
+			}
+		}
 		return true, prMentionCandidate{}, nil
 	}
 
@@ -249,7 +291,8 @@ func (s *Server) preparePRMention(clawID, repo string, prNumber int, prURL strin
 // transaction. Either every new row is committed, or none are — so callers
 // never leave the PR watcher partially armed when one URL fails.
 // Returns the URL that failed, or "" on full success.
-func (s *Server) insertClawPRsAtomic(clawID string, rows []prMentionCandidate) string {
+// mentionOnly is stamped onto every inserted row; see storePRMention.
+func (s *Server) insertClawPRsAtomic(clawID string, rows []prMentionCandidate, mentionOnly bool) string {
 	if len(rows) == 0 {
 		return ""
 	}
@@ -272,18 +315,32 @@ func (s *Server) insertClawPRsAtomic(clawID string, rows []prMentionCandidate) s
 		var existing string
 		_ = tx.QueryRow(`SELECT id FROM claw_prs WHERE claw_id=? AND pr_url=?`, clawID, row.url).Scan(&existing)
 		if existing != "" {
+			// A concurrent writer (possibly the message scanner) got here first.
+			// A delivered call must still upgrade a mention-only row.
+			if !mentionOnly {
+				if _, err := tx.Exec(`UPDATE claw_prs SET mention_only=0 WHERE claw_id=? AND pr_url=? AND mention_only=1`, clawID, row.url); err != nil {
+					log.Printf("[pr-watcher] failed to upgrade mention-only PR %s for claw %s: %v", row.url, shortID(clawID), err)
+					return row.url
+				}
+			}
 			continue
 		}
 		prID := uuid.New().String()
 		res, err := tx.Exec(
-			`INSERT OR IGNORE INTO claw_prs(id,claw_id,repo,pr_number,pr_url,title,last_comment_id,last_comment_at,last_review_id,last_ci_sha,created_at) VALUES(?,?,?,?,?,?,?,?,?,?,?)`,
-			prID, clawID, row.repo, row.number, row.url, row.title, row.comment, row.commentAt, row.review, row.headSHA, now(),
+			`INSERT OR IGNORE INTO claw_prs(id,claw_id,repo,pr_number,pr_url,title,last_comment_id,last_comment_at,last_review_id,last_ci_sha,mention_only,created_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?)`,
+			prID, clawID, row.repo, row.number, row.url, row.title, row.comment, row.commentAt, row.review, row.headSHA, boolInt(mentionOnly), now(),
 		)
 		if err != nil {
 			log.Printf("[pr-watcher] failed to persist PR %s#%d for claw %s: %v", row.repo, row.number, shortID(clawID), err)
 			return row.url
 		}
 		if affected, err := res.RowsAffected(); err == nil && affected == 0 {
+			if !mentionOnly {
+				if _, err := tx.Exec(`UPDATE claw_prs SET mention_only=0 WHERE claw_id=? AND pr_url=? AND mention_only=1`, clawID, row.url); err != nil {
+					log.Printf("[pr-watcher] failed to upgrade mention-only PR %s for claw %s: %v", row.url, shortID(clawID), err)
+					return row.url
+				}
+			}
 			continue // concurrent insert won the race
 		}
 		inserted = append(inserted, row)
@@ -638,6 +695,27 @@ func (s *Server) pollAllPRs() {
 		if token == "" {
 			tokenMisses++
 			log.Printf("[pr-watcher] no token for %s (claw %s); skipping this PR", r.pr.repo, shortID(r.pr.clawID))
+			// A row skipped here never reaches checkPRMerged, so nothing else
+			// can ever move it to a resolved state — bound the failures so an
+			// unreachable repo cannot pin the claw forever. The counter is
+			// shared with checkPRMerged's permanent-API-error handling, which
+			// resets it whenever the token resolves and the fetch is not a
+			// permanent failure — keeping the "consecutive failures" semantics.
+			if _, err := s.db.Exec(`UPDATE claw_prs SET permanent_failure_count=permanent_failure_count+1 WHERE id=?`, r.pr.id); err != nil {
+				log.Printf("[pr-watcher] failed to count token failure for PR %s: %v", r.pr.prURL, err)
+				continue
+			}
+			var failures int
+			if err := s.db.QueryRow(`SELECT permanent_failure_count FROM claw_prs WHERE id=?`, r.pr.id).Scan(&failures); err != nil {
+				log.Printf("[pr-watcher] failed to read token failure count for PR %s: %v", r.pr.prURL, err)
+				continue
+			}
+			if failures >= prMergedPermanentFailureLimit {
+				if _, terminated := s.closeUnreachablePR(r.pr,
+					fmt.Sprintf("unpollable for %d consecutive polls (no GitHub token resolvable for %s)", prMergedPermanentFailureLimit, r.pr.repo)); terminated {
+					terminatedClaws[r.pr.clawID] = true
+				}
+			}
 			continue
 		}
 
@@ -648,16 +726,23 @@ func (s *Server) pollAllPRs() {
 		// Check if PR is merged/closed for any non-terminal claw status.
 		// checkPRMerged also runs human code push detection off the same PR
 		// fetch, before any termination handling.
-		merged := s.checkPRMerged(r.pr, token)
-		if lowPriorityOK || merged {
+		resolved, terminated := s.checkPRMerged(r.pr, token)
+		if lowPriorityOK || resolved {
 			// Record a terminal CI result even when merge handling removed the PR row
-			// earlier in this poll. Outside the merge case this stays gated by the
+			// earlier in this poll. Outside the resolved case this stays gated by the
 			// budget reserve like the rest of the low-priority checks below.
 			s.checkCIStatus(r.pr, token)
 		}
-		if merged {
+		if terminated {
 			terminatedClaws[r.pr.clawID] = true
 			continue // claw is being terminated, skip other checks
+		}
+		if resolved {
+			// The row reached a terminal state (merged/closed) but the claw
+			// stays alive for its other PRs. Skip the low-priority pipeline —
+			// comments, reviews and pr_conditions must not fire off a PR that
+			// is already resolved.
+			continue
 		}
 		if !lowPriorityOK {
 			// Merge detection above is the only call worth the remaining budget.
@@ -1874,23 +1959,58 @@ func clawPRStoredState(githubState string, merged bool) string {
 	return githubState
 }
 
-// clawOpenPRCount returns how many PRs tracked for the claw are still
-// unresolved — neither merged nor closed. Teardown is gated on this being
-// zero so an agent that delivered several PRs keeps watching the rest.
+// clawOpenPRCount returns how many DELIVERED PRs tracked for the claw are
+// still unresolved — neither merged nor closed. Teardown is gated on this
+// being zero so an agent that delivered several PRs keeps watching the rest.
+// Mention-only rows (PR URLs the agent merely mentioned in a message) are
+// excluded: they keep being polled — CI, comments and reviews are still
+// forwarded — but they never block finalization.
 func (s *Server) clawOpenPRCount(clawID string) (int, error) {
 	var n int
-	err := s.db.QueryRow(`SELECT COUNT(*) FROM claw_prs WHERE claw_id=? AND state NOT IN ('merged','closed')`, clawID).Scan(&n)
+	err := s.db.QueryRow(`SELECT COUNT(*) FROM claw_prs WHERE claw_id=? AND state NOT IN ('merged','closed') AND mention_only=0`, clawID).Scan(&n)
 	return n, err
 }
 
+// closeUnreachablePR marks a tracked PR row closed after it has been
+// unreachable (permanent API errors, or unresolvable tokens) for
+// prMergedPermanentFailureLimit consecutive polls, so an unreachable repo
+// stops blocking claw finalization instead of pinning the claw forever.
+//
+// The claw is stopped only when no unresolved delivered PR remains; otherwise
+// it keeps watching the rest. Returns (resolved, terminated) with checkPRMerged
+// semantics: resolved reports whether this row reached a terminal state.
+func (s *Server) closeUnreachablePR(pr clawPR, cause string) (resolved, terminated bool) {
+	log.Printf("[pr-watcher] WARN: PR %s (%s#%d) %s — marking it closed so it stops blocking finalization of claw %s", pr.prURL, pr.repo, pr.prNumber, cause, shortID(pr.clawID))
+	if _, err := s.db.Exec(`UPDATE claw_prs SET state='closed' WHERE id=?`, pr.id); err != nil {
+		log.Printf("[pr-watcher] failed to mark unreachable PR %s closed for claw %s: %v", pr.prURL, shortID(pr.clawID), err)
+		return false, false
+	}
+	remaining, err := s.clawOpenPRCount(pr.clawID)
+	if err != nil {
+		// Never tear a claw down on an unknown PR count — the next poll retries.
+		log.Printf("[pr-watcher] failed to count open PRs for claw %s: %v", shortID(pr.clawID), err)
+		return true, false
+	}
+	if remaining > 0 {
+		log.Printf("[pr-watcher] claw %s still has %d unresolved delivered PR(s) — keeping it alive", shortID(pr.clawID), remaining)
+		return true, false
+	}
+	go s.stopAgentWithReason(pr.clawID, fmt.Sprintf("PR %s has been %s", pr.prURL, cause), false)
+	return true, true
+}
+
 // checkPRMerged checks if a tracked PR is merged or closed.
-// It returns true when it terminates the claw, which happens in two cases:
-// every tracked PR is now resolved and the last one merged, or the PR has
-// been inaccessible (permanent API error: 404/410/401/non-rate-limit 403)
-// for prMergedPermanentFailureLimit consecutive polls — repo/PR deleted or
-// GitHub App uninstalled. While at least one tracked PR is still open the
-// claw stays alive and keeps watching.
-func (s *Server) checkPRMerged(pr clawPR, token string) bool {
+//
+// resolved is true when THIS row reached a terminal state (merged, closed, or
+// closed administratively after prMergedPermanentFailureLimit consecutive
+// permanent API errors: 404/410/401/non-rate-limit 403 — repo/PR deleted or
+// GitHub App uninstalled). Callers must skip further polling work for a
+// resolved row.
+//
+// terminated is true when the claw itself is being torn down, which happens
+// only once every delivered tracked PR is resolved. While at least one
+// delivered PR is still open the claw stays alive and keeps watching.
+func (s *Server) checkPRMerged(pr clawPR, token string) (resolved, terminated bool) {
 	tokenForPR := s.resolveGitHubTokenForRepo(pr.repo)
 	if tokenForPR == "" {
 		tokenForPR = token
@@ -1908,15 +2028,18 @@ func (s *Server) checkPRMerged(pr clawPR, token string) bool {
 			if failures >= prMergedPermanentFailureLimit {
 				var apiErr *githubAPIError
 				_ = errors.As(err, &apiErr)
-				go s.stopAgentWithReason(pr.clawID, fmt.Sprintf("PR %s has been inaccessible (HTTP %d) for %d consecutive polls — repo or PR deleted, or GitHub App uninstalled", pr.prURL, apiErr.StatusCode, prMergedPermanentFailureLimit), false)
-				return true
+				// One inaccessible PR must not kill a claw whose other PRs are
+				// fine: close this row so it stops blocking finalization, and
+				// stop the claw only when no delivered PR remains unresolved.
+				return s.closeUnreachablePR(pr,
+					fmt.Sprintf("inaccessible (HTTP %d) for %d consecutive polls — repo or PR deleted, or GitHub App uninstalled", apiErr.StatusCode, prMergedPermanentFailureLimit))
 			}
-			return false
+			return false, false
 		}
 		// Transient error (5xx, network): reset the counter so only genuinely
 		// consecutive permanent failures accumulate toward the limit.
 		_, _ = s.db.Exec(`UPDATE claw_prs SET permanent_failure_count=0 WHERE id=? AND permanent_failure_count != 0`, pr.id)
-		return false
+		return false, false
 	}
 	_, _ = s.db.Exec(`UPDATE claw_prs SET permanent_failure_count=0 WHERE id=? AND permanent_failure_count != 0`, pr.id)
 	// Detect human pushes off this same PR fetch, before any merge handling,
@@ -1961,13 +2084,13 @@ func (s *Server) checkPRMerged(pr clawPR, token string) bool {
 	log.Printf("[pr-watcher] checkPRMerged: claw=%s pr=%s state=%s merged=%v", pr.clawID[:8], pr.prURL, state, merged)
 
 	if state != "closed" && !merged {
-		return false // still open
+		return false, false // still open
 	}
 
 	clawID := pr.clawID
 	var tenantID string
 	if err := s.db.QueryRow(`SELECT tenant_id FROM claws WHERE id=?`, clawID).Scan(&tenantID); err != nil {
-		return false
+		return false, false
 	}
 
 	// If the PR was closed without merging, mark the row resolved and decide
@@ -1978,7 +2101,7 @@ func (s *Server) checkPRMerged(pr clawPR, token string) bool {
 		// bookkeeping stays correct; the poll queries exclude resolved states.
 		if _, err := s.db.Exec(`UPDATE claw_prs SET state='closed' WHERE id=?`, pr.id); err != nil {
 			log.Printf("[pr-watcher] failed to mark PR %s closed for claw %s: %v", pr.prURL, shortID(clawID), err)
-			return false
+			return false, false
 		}
 
 		pipelineCtx, hasPipelineCtx := s.findPipelineContextForClaw(clawID)
@@ -1990,12 +2113,14 @@ func (s *Server) checkPRMerged(pr clawPR, token string) bool {
 		if err != nil {
 			// Never tear a claw down on an unknown PR count — the next poll retries.
 			log.Printf("[pr-watcher] failed to count open PRs for claw %s: %v", shortID(clawID), err)
-			return false
+			return true, false
 		}
 		if remaining > 0 {
 			log.Printf("[pr-watcher] PR %s#%d closed without merge — claw %s still has %d open PR(s), not stopping", pr.repo, pr.prNumber, clawID[:8], remaining)
-			s.injectHubMessageByID(clawID, fmt.Sprintf("[hub] PR %s was closed without being merged. Still watching %d other open PR(s).", pr.prURL, remaining))
-			return false
+			// External inject: a paused (no-progress) claw must be woken so it
+			// can react to the close instead of sitting on the remaining PRs.
+			s.injectExternalHubMessageByID(clawID, fmt.Sprintf("[hub] PR %s was closed without being merged. Still watching %d other open PR(s).", pr.prURL, remaining))
+			return true, false
 		}
 
 		log.Printf("[pr-watcher] PR %s#%d closed without merge — stopping claw %s", pr.repo, pr.prNumber, clawID[:8])
@@ -2014,9 +2139,14 @@ func (s *Server) checkPRMerged(pr clawPR, token string) bool {
 			}
 		}
 		if !pipelineHandled {
+			// Mirror the merged teardown: stopAgentWithReason can end in a claw
+			// retry that reuses this claw id, and surviving resolved rows would
+			// permanently suppress the agent-idle stuck alert for the retried
+			// claw (its consumers read "row exists" as "awaiting humans").
+			_, _ = s.db.Exec(`DELETE FROM claw_prs WHERE claw_id=?`, clawID)
 			go s.stopAgentWithReason(clawID, fmt.Sprintf("PR %s was closed without being merged", pr.prURL), false)
 		}
-		return false
+		return true, true
 	}
 
 	// PR was merged — make the resolved state durable before gating on it. The
@@ -2024,7 +2154,7 @@ func (s *Server) checkPRMerged(pr clawPR, token string) bool {
 	// skipped; the all-PRs-resolved gate must not depend on it.
 	if _, err := s.db.Exec(`UPDATE claw_prs SET state='merged', merged=1 WHERE id=?`, pr.id); err != nil {
 		log.Printf("[pr-watcher] failed to mark PR %s merged for claw %s: %v", pr.prURL, shortID(clawID), err)
-		return false
+		return false, false
 	}
 
 	// Track analytics for PR merge. These are per-PR facts and fire on every
@@ -2046,17 +2176,19 @@ func (s *Server) checkPRMerged(pr clawPR, token string) bool {
 		}
 	}
 
-	// Finalize only when every tracked PR is resolved (merged or closed).
+	// Finalize only when every delivered tracked PR is resolved (merged or closed).
 	remaining, err := s.clawOpenPRCount(clawID)
 	if err != nil {
 		// Never tear a claw down on an unknown PR count — the next poll retries.
 		log.Printf("[pr-watcher] failed to count open PRs for claw %s: %v", shortID(clawID), err)
-		return false
+		return true, false
 	}
 	if remaining > 0 {
 		log.Printf("[pr-watcher] PR %s#%d merged — claw %s still has %d open PR(s), not terminating", pr.repo, pr.prNumber, clawID[:8], remaining)
-		s.injectHubMessageByID(clawID, fmt.Sprintf("[hub] PR %s merged. Still watching %d other open PR(s) — will finish when they are all merged or closed.", pr.prURL, remaining))
-		return false
+		// External inject: a paused (no-progress) claw must be woken so it can
+		// act on the partial merge instead of staying paused with PRs open.
+		s.injectExternalHubMessageByID(clawID, fmt.Sprintf("[hub] PR %s merged. Still watching %d other open PR(s) — will finish when they are all merged or closed.", pr.prURL, remaining))
+		return true, false
 	}
 
 	log.Printf("[pr-watcher] PR %s#%d merged — terminating claw %s", pr.repo, pr.prNumber, clawID[:8])
@@ -2125,7 +2257,7 @@ func (s *Server) checkPRMerged(pr clawPR, token string) bool {
 	// If the pipeline handled termination (terminal stage), we're done.
 	if pipelineHandled {
 		_, _ = s.db.Exec(`DELETE FROM claw_prs WHERE claw_id=?`, clawID)
-		return true
+		return true, true
 	}
 
 	var providerID, provider string
@@ -2136,7 +2268,7 @@ func (s *Server) checkPRMerged(pr clawPR, token string) bool {
 	_, _ = s.db.Exec(`DELETE FROM claw_prs WHERE claw_id=?`, clawID)
 	applied, err := s.finishClawTerminalTx(clawID, "deleted", "", "completed", "PR merged", terminalTxOpts{})
 	if err != nil || !applied {
-		return false
+		return true, false
 	}
 	if s.cronScheduler != nil {
 		s.cronScheduler.releaseClawWorkflowSlot(clawID)
@@ -2161,7 +2293,7 @@ func (s *Server) checkPRMerged(pr clawPR, token string) bool {
 	// Promote any pending claws now that a slot is free
 	go s.promotePendingClaws()
 
-	return true
+	return true, true
 }
 
 // prConditionsStatus explains why checkPRConditions did or didn't fire, so the

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -633,6 +633,17 @@ func (s *Server) loadClawPRsByNumber(repo string, prNumber int) []clawPR {
 // attempted at all. Token resolution per distinct repo is the only external
 // work — no PR fetches happen here.
 func (s *Server) rearmTokenMissClosedPRs() {
+	// Mirror pollAllPRs's own gates. While GitHub reports the quota exhausted,
+	// or no GitHub App can mint installation tokens, the per-repo token
+	// resolution below is exactly the spend those gates exist to prevent —
+	// and any row re-armed now would not be polled in this pass anyway, so
+	// deferring the sweep to the first healthy pass loses nothing.
+	if _, blocked := defaultGitHubClient.blockedUntilTime(); blocked {
+		return
+	}
+	if len(s.githubAppConfigsForTokens()) == 0 {
+		return
+	}
 	rows, err := s.db.Query(`
 		SELECT DISTINCT cp.repo
 		FROM claw_prs cp

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -516,6 +516,7 @@ func (s *Server) loadClawPRsByNumber(repo string, prNumber int) []clawPR {
 		FROM claw_prs cp
 		JOIN claws cl ON cl.id = cp.claw_id
 		WHERE cp.repo = ? AND cp.pr_number = ? AND cl.status NOT IN ('deleted','error','offline')
+		  AND cp.state NOT IN ('merged','closed')
 		ORDER BY cp.created_at DESC
 	`, repo, prNumber)
 	if err != nil {
@@ -551,6 +552,7 @@ func (s *Server) pollAllPRs() {
 		FROM claw_prs cp
 		JOIN claws cl ON cl.id = cp.claw_id
 		WHERE cl.status NOT IN ('deleted','error','offline')
+		  AND cp.state NOT IN ('merged','closed')
 	`)
 	if err != nil {
 		if strings.Contains(err.Error(), "database is closed") {
@@ -1872,11 +1874,22 @@ func clawPRStoredState(githubState string, merged bool) string {
 	return githubState
 }
 
+// clawOpenPRCount returns how many PRs tracked for the claw are still
+// unresolved — neither merged nor closed. Teardown is gated on this being
+// zero so an agent that delivered several PRs keeps watching the rest.
+func (s *Server) clawOpenPRCount(clawID string) (int, error) {
+	var n int
+	err := s.db.QueryRow(`SELECT COUNT(*) FROM claw_prs WHERE claw_id=? AND state NOT IN ('merged','closed')`, clawID).Scan(&n)
+	return n, err
+}
+
 // checkPRMerged checks if a tracked PR is merged or closed.
 // It returns true when it terminates the claw, which happens in two cases:
-// the PR was merged, or the PR has been inaccessible (permanent API error:
-// 404/410/401/non-rate-limit 403) for prMergedPermanentFailureLimit
-// consecutive polls — repo/PR deleted or GitHub App uninstalled.
+// every tracked PR is now resolved and the last one merged, or the PR has
+// been inaccessible (permanent API error: 404/410/401/non-rate-limit 403)
+// for prMergedPermanentFailureLimit consecutive polls — repo/PR deleted or
+// GitHub App uninstalled. While at least one tracked PR is still open the
+// claw stays alive and keeps watching.
 func (s *Server) checkPRMerged(pr clawPR, token string) bool {
 	tokenForPR := s.resolveGitHubTokenForRepo(pr.repo)
 	if tokenForPR == "" {
@@ -1957,15 +1970,35 @@ func (s *Server) checkPRMerged(pr clawPR, token string) bool {
 		return false
 	}
 
-	// If the PR was closed without merging, notify the claw and let it decide — don't terminate.
+	// If the PR was closed without merging, mark the row resolved and decide
+	// whether the claw is finished: while other tracked PRs are still open the
+	// claw stays alive and keeps watching them.
 	if state == "closed" && !merged {
-		log.Printf("[pr-watcher] PR %s#%d closed without merge — stopping claw %s", pr.repo, pr.prNumber, clawID[:8])
-		_, _ = s.db.Exec(`DELETE FROM claw_prs WHERE id=?`, pr.id)
+		// The row must survive (not be deleted) so the all-PRs-resolved
+		// bookkeeping stays correct; the poll queries exclude resolved states.
+		if _, err := s.db.Exec(`UPDATE claw_prs SET state='closed' WHERE id=?`, pr.id); err != nil {
+			log.Printf("[pr-watcher] failed to mark PR %s closed for claw %s: %v", pr.prURL, shortID(clawID), err)
+			return false
+		}
 
 		pipelineCtx, hasPipelineCtx := s.findPipelineContextForClaw(clawID)
 		if hasPipelineCtx {
 			s.trackPRClosed(pipelineCtx.Name(), pipelineCtx.IssueID, clawID, pr.repo, pr.prNumber)
 		}
+
+		remaining, err := s.clawOpenPRCount(clawID)
+		if err != nil {
+			// Never tear a claw down on an unknown PR count — the next poll retries.
+			log.Printf("[pr-watcher] failed to count open PRs for claw %s: %v", shortID(clawID), err)
+			return false
+		}
+		if remaining > 0 {
+			log.Printf("[pr-watcher] PR %s#%d closed without merge — claw %s still has %d open PR(s), not stopping", pr.repo, pr.prNumber, clawID[:8], remaining)
+			s.injectHubMessageByID(clawID, fmt.Sprintf("[hub] PR %s was closed without being merged. Still watching %d other open PR(s).", pr.prURL, remaining))
+			return false
+		}
+
+		log.Printf("[pr-watcher] PR %s#%d closed without merge — stopping claw %s", pr.repo, pr.prNumber, clawID[:8])
 
 		// Check if the pipeline handles pr_closed (run on_enter before stopping)
 		pipelineHandled := false
@@ -1986,10 +2019,16 @@ func (s *Server) checkPRMerged(pr clawPR, token string) bool {
 		return false
 	}
 
-	// PR was merged — run pipeline on_enter if applicable, then terminate the claw.
-	log.Printf("[pr-watcher] PR %s#%d merged — terminating claw %s", pr.repo, pr.prNumber, clawID[:8])
+	// PR was merged — make the resolved state durable before gating on it. The
+	// general UPDATE earlier in this function is conditional and could be
+	// skipped; the all-PRs-resolved gate must not depend on it.
+	if _, err := s.db.Exec(`UPDATE claw_prs SET state='merged', merged=1 WHERE id=?`, pr.id); err != nil {
+		log.Printf("[pr-watcher] failed to mark PR %s merged for claw %s: %v", pr.prURL, shortID(clawID), err)
+		return false
+	}
 
-	// Track analytics for PR merge
+	// Track analytics for PR merge. These are per-PR facts and fire on every
+	// merge, regardless of whether the claw is finished yet.
 	mergeCtx, hasMergeCtx := s.findPipelineContextForClaw(clawID)
 	if hasMergeCtx {
 		s.trackPRMergedAt(mergeCtx.Name(), mergeCtx.IssueID, clawID, pr.repo, pr.prNumber, firstNonZeroTime(mergedAt, now()))
@@ -2006,6 +2045,21 @@ func (s *Server) checkPRMerged(pr clawPR, token string) bool {
 			log.Printf("[pr-watcher] failed to record merge for run %s: %v", runID, err)
 		}
 	}
+
+	// Finalize only when every tracked PR is resolved (merged or closed).
+	remaining, err := s.clawOpenPRCount(clawID)
+	if err != nil {
+		// Never tear a claw down on an unknown PR count — the next poll retries.
+		log.Printf("[pr-watcher] failed to count open PRs for claw %s: %v", shortID(clawID), err)
+		return false
+	}
+	if remaining > 0 {
+		log.Printf("[pr-watcher] PR %s#%d merged — claw %s still has %d open PR(s), not terminating", pr.repo, pr.prNumber, clawID[:8], remaining)
+		s.injectHubMessageByID(clawID, fmt.Sprintf("[hub] PR %s merged. Still watching %d other open PR(s) — will finish when they are all merged or closed.", pr.prURL, remaining))
+		return false
+	}
+
+	log.Printf("[pr-watcher] PR %s#%d merged — terminating claw %s", pr.repo, pr.prNumber, clawID[:8])
 
 	// Check if the pipeline handles pr_merged (run on_enter before terminating)
 	pipelineHandled := false

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -190,12 +190,19 @@ func (s *Server) storePRMention(clawID, repo string, prNumber int, prURL string,
 }
 
 // scanMessageForPRs extracts and stores any PR URLs found in a message.
-// The agent can mention any PR in passing ("depends on .../pull/12"), so these
-// rows are registered mention-only: they keep being polled (CI, comments and
-// reviews are still forwarded) but never gate claw finalization.
-func (s *Server) scanMessageForPRs(clawID, content string) {
+//
+// mentionOnly must reflect what the content IS, not where the URLs end up:
+//   - true for arbitrary agent turn text: the agent can mention any PR in
+//     passing ("depends on .../pull/12"), so those rows keep being polled
+//     (CI, comments and reviews are still forwarded) but never gate claw
+//     finalization and are never action targets.
+//   - false for content that is a delivery channel — e.g. the stdout of a
+//     pipeline gate script such as verify-github-pr-links, whose whole job is
+//     to emit the claw's OWN delivered PR URLs. Those rows must block
+//     finalization exactly like PRs registered via [DONE].
+func (s *Server) scanMessageForPRs(clawID, content string, mentionOnly bool) {
 	for _, pr := range extractPRs(content) {
-		if _, err := s.storePRMention(clawID, pr.repo, pr.number, pr.url, true); err != nil {
+		if _, err := s.storePRMention(clawID, pr.repo, pr.number, pr.url, mentionOnly); err != nil {
 			log.Printf("[pr-watcher] failed to store PR mention: %v", err)
 		}
 	}
@@ -696,27 +703,39 @@ func (s *Server) pollAllPRs() {
 			tokenMisses++
 			log.Printf("[pr-watcher] no token for %s (claw %s); skipping this PR", r.pr.repo, shortID(r.pr.clawID))
 			// A row skipped here never reaches checkPRMerged, so nothing else
-			// can ever move it to a resolved state — bound the failures so an
-			// unreachable repo cannot pin the claw forever. The counter is
-			// shared with checkPRMerged's permanent-API-error handling, which
-			// resets it whenever the token resolves and the fetch is not a
-			// permanent failure — keeping the "consecutive failures" semantics.
-			if _, err := s.db.Exec(`UPDATE claw_prs SET permanent_failure_count=permanent_failure_count+1 WHERE id=?`, r.pr.id); err != nil {
-				log.Printf("[pr-watcher] failed to count token failure for PR %s: %v", r.pr.prURL, err)
+			// can ever move it to a resolved state — bound the misses so an
+			// unreachable repo cannot pin the claw forever. Tracked in
+			// token_miss_count, NOT permanent_failure_count: that counter
+			// belongs to checkPRMerged's permanent-API-error handling and
+			// resetting one from the other's path would break both bounds.
+			if _, err := s.db.Exec(`UPDATE claw_prs SET token_miss_count=token_miss_count+1 WHERE id=?`, r.pr.id); err != nil {
+				log.Printf("[pr-watcher] failed to count token miss for PR %s: %v", r.pr.prURL, err)
 				continue
 			}
-			var failures int
-			if err := s.db.QueryRow(`SELECT permanent_failure_count FROM claw_prs WHERE id=?`, r.pr.id).Scan(&failures); err != nil {
-				log.Printf("[pr-watcher] failed to read token failure count for PR %s: %v", r.pr.prURL, err)
+			var misses int
+			if err := s.db.QueryRow(`SELECT token_miss_count FROM claw_prs WHERE id=?`, r.pr.id).Scan(&misses); err != nil {
+				log.Printf("[pr-watcher] failed to read token miss count for PR %s: %v", r.pr.prURL, err)
 				continue
 			}
-			if failures >= prMergedPermanentFailureLimit {
-				if _, terminated := s.closeUnreachablePR(r.pr,
-					fmt.Sprintf("unpollable for %d consecutive polls (no GitHub token resolvable for %s)", prMergedPermanentFailureLimit, r.pr.repo)); terminated {
-					terminatedClaws[r.pr.clawID] = true
+			if misses >= prMergedPermanentFailureLimit {
+				// Close ONLY the row — never the claw. A token miss has
+				// transient causes (installation-token mint 5xx, network
+				// errors, JWT clock skew), and a mid-work agent may have
+				// delivered nothing yet, so escalating here would kill a
+				// healthy claw during a token outage. The teardown decision
+				// stays with checkPRMerged observing a real delivered row.
+				log.Printf("[pr-watcher] WARN: PR %s (%s#%d) unpollable for %d consecutive polls (no GitHub token resolvable for %s) — marking the row closed so it stops blocking finalization; claw %s left untouched",
+					r.pr.prURL, r.pr.repo, r.pr.prNumber, prMergedPermanentFailureLimit, r.pr.repo, shortID(r.pr.clawID))
+				if _, err := s.db.Exec(`UPDATE claw_prs SET state='closed' WHERE id=?`, r.pr.id); err != nil {
+					log.Printf("[pr-watcher] failed to mark unpollable PR %s closed for claw %s: %v", r.pr.prURL, shortID(r.pr.clawID), err)
 				}
 			}
 			continue
+		}
+		// The token resolved: only genuinely consecutive misses may accumulate
+		// toward the bound above.
+		if _, err := s.db.Exec(`UPDATE claw_prs SET token_miss_count=0 WHERE id=? AND token_miss_count != 0`, r.pr.id); err != nil {
+			log.Printf("[pr-watcher] failed to reset token miss count for PR %s: %v", r.pr.prURL, err)
 		}
 
 		pipelineCtx, hasPipelineCtx := s.findPipelineContextForClaw(r.pr.clawID)
@@ -727,10 +746,15 @@ func (s *Server) pollAllPRs() {
 		// checkPRMerged also runs human code push detection off the same PR
 		// fetch, before any termination handling.
 		resolved, terminated := s.checkPRMerged(r.pr, token)
-		if lowPriorityOK || resolved {
+		if lowPriorityOK || terminated {
 			// Record a terminal CI result even when merge handling removed the PR row
-			// earlier in this poll. Outside the resolved case this stays gated by the
-			// budget reserve like the rest of the low-priority checks below.
+			// earlier in this poll. The bypass is gated on terminated ("the claw
+			// is being torn down — one last CI record on the way out"), NOT on
+			// resolved: a row can resolve while the claw survives (a PR closed
+			// with others open, or administratively closed as unreachable), and
+			// firing below the budget reserve there would burn the headroom the
+			// reserve protects and inject a misleading CI verdict for a PR that
+			// was just closed.
 			s.checkCIStatus(r.pr, token)
 		}
 		if terminated {
@@ -1913,8 +1937,12 @@ func (s *Server) handleClawPRs(w http.ResponseWriter, r *http.Request, clawID st
 		return
 	}
 
+	// Every row is returned — resolved and mention-only included — with the
+	// state and the mention_only flag exposed, so the UI can distinguish
+	// delivered work from merely-mentioned PRs the same way the finalization
+	// gate (clawOpenPRCount) does.
 	rows, err := s.db.Query(
-		`SELECT id, repo, pr_number, pr_url, title, state, merged, merged_at, created_at FROM claw_prs WHERE claw_id=? ORDER BY created_at ASC`,
+		`SELECT id, repo, pr_number, pr_url, title, state, merged, merged_at, mention_only, created_at FROM claw_prs WHERE claw_id=? ORDER BY created_at ASC`,
 		clawID,
 	)
 	if err != nil {
@@ -1923,20 +1951,21 @@ func (s *Server) handleClawPRs(w http.ResponseWriter, r *http.Request, clawID st
 	}
 	defer rows.Close()
 	type PR struct {
-		ID        string  `json:"id"`
-		Repo      string  `json:"repo"`
-		PRNumber  int     `json:"prNumber"`
-		URL       string  `json:"url"`
-		Title     string  `json:"title"`
-		State     string  `json:"state"`
-		Merged    bool    `json:"merged"`
-		MergedAt  *string `json:"mergedAt,omitempty"`
-		CreatedAt string  `json:"createdAt"`
+		ID          string  `json:"id"`
+		Repo        string  `json:"repo"`
+		PRNumber    int     `json:"prNumber"`
+		URL         string  `json:"url"`
+		Title       string  `json:"title"`
+		State       string  `json:"state"`
+		Merged      bool    `json:"merged"`
+		MergedAt    *string `json:"mergedAt,omitempty"`
+		MentionOnly bool    `json:"mentionOnly"`
+		CreatedAt   string  `json:"createdAt"`
 	}
 	var prs []PR
 	for rows.Next() {
 		var p PR
-		if err := rows.Scan(&p.ID, &p.Repo, &p.PRNumber, &p.URL, &p.Title, &p.State, &p.Merged, &p.MergedAt, &p.CreatedAt); err != nil {
+		if err := rows.Scan(&p.ID, &p.Repo, &p.PRNumber, &p.URL, &p.Title, &p.State, &p.Merged, &p.MergedAt, &p.MentionOnly, &p.CreatedAt); err != nil {
 			continue
 		}
 		prs = append(prs, p)
@@ -1971,12 +2000,43 @@ func (s *Server) clawOpenPRCount(clawID string) (int, error) {
 	return n, err
 }
 
-// closeUnreachablePR marks a tracked PR row closed after it has been
-// unreachable (permanent API errors, or unresolvable tokens) for
-// prMergedPermanentFailureLimit consecutive polls, so an unreachable repo
-// stops blocking claw finalization instead of pinning the claw forever.
+// clawPRIsMentionOnly reports whether a claw_prs row is mention-only. The read
+// happens at decision time (not from a possibly stale clawPR loaded at the top
+// of a poll) because a mention row can be upgraded to delivered mid-poll by a
+// concurrent [DONE] registration. ok is false when the row cannot be read —
+// callers must then never run terminal handling off the row.
+func (s *Server) clawPRIsMentionOnly(prID string) (mentionOnly, ok bool) {
+	var v int
+	if err := s.db.QueryRow(`SELECT mention_only FROM claw_prs WHERE id=?`, prID).Scan(&v); err != nil {
+		log.Printf("[pr-watcher] failed to read mention_only for PR row %s: %v", prID, err)
+		return false, false
+	}
+	return v == 1, true
+}
+
+// clawHasDeliveredPR reports whether the claw tracks at least one DELIVERED
+// (mention_only=0) row, in any state. The PR watcher may finalize a claw only
+// when this is true: a claw whose rows are all mention-only has delivered
+// nothing, so nothing it is watching can mean "the claw's work is done" — a
+// stranger merging or closing a merely-mentioned PR must never destroy the
+// sandbox or move the tracker issue. This is an explicit guard, not an
+// emergent property of the mention-only early returns, so a future refactor
+// of those returns cannot silently reintroduce the teardown.
+func (s *Server) clawHasDeliveredPR(clawID string) (bool, error) {
+	var n int
+	err := s.db.QueryRow(`SELECT COUNT(*) FROM claw_prs WHERE claw_id=? AND mention_only=0`, clawID).Scan(&n)
+	return n > 0, err
+}
+
+// closeUnreachablePR marks a tracked PR row closed after checkPRMerged saw
+// permanent API errors for prMergedPermanentFailureLimit consecutive polls,
+// so an unreachable repo stops blocking claw finalization instead of pinning
+// the claw forever. (Token-resolution misses are bounded separately in
+// pollAllPRs and only ever close the row — they must never reach this
+// escalating path.)
 //
-// The claw is stopped only when no unresolved delivered PR remains; otherwise
+// The claw is stopped only for a delivered row, and only when no unresolved
+// delivered PR remains and the claw has delivered at least one PR; otherwise
 // it keeps watching the rest. Returns (resolved, terminated) with checkPRMerged
 // semantics: resolved reports whether this row reached a terminal state.
 func (s *Server) closeUnreachablePR(pr clawPR, cause string) (resolved, terminated bool) {
@@ -1984,6 +2044,12 @@ func (s *Server) closeUnreachablePR(pr clawPR, cause string) (resolved, terminat
 	if _, err := s.db.Exec(`UPDATE claw_prs SET state='closed' WHERE id=?`, pr.id); err != nil {
 		log.Printf("[pr-watcher] failed to mark unreachable PR %s closed for claw %s: %v", pr.prURL, shortID(pr.clawID), err)
 		return false, false
+	}
+	// A mention-only row must never TRIGGER finalization: it is a polling
+	// target only, and its unreachability says nothing about the claw's own
+	// delivered work. (An unreadable flag also never triggers — fail alive.)
+	if mentionOnly, ok := s.clawPRIsMentionOnly(pr.id); !ok || mentionOnly {
+		return true, false
 	}
 	remaining, err := s.clawOpenPRCount(pr.clawID)
 	if err != nil {
@@ -1993,6 +2059,14 @@ func (s *Server) closeUnreachablePR(pr clawPR, cause string) (resolved, terminat
 	}
 	if remaining > 0 {
 		log.Printf("[pr-watcher] claw %s still has %d unresolved delivered PR(s) — keeping it alive", shortID(pr.clawID), remaining)
+		return true, false
+	}
+	if delivered, err := s.clawHasDeliveredPR(pr.clawID); err != nil || !delivered {
+		// See clawHasDeliveredPR: zero delivered rows means the watcher has no
+		// authority to stop this claw, whatever happened to mentioned PRs.
+		if err != nil {
+			log.Printf("[pr-watcher] failed to count delivered PRs for claw %s: %v", shortID(pr.clawID), err)
+		}
 		return true, false
 	}
 	go s.stopAgentWithReason(pr.clawID, fmt.Sprintf("PR %s has been %s", pr.prURL, cause), false)
@@ -2010,6 +2084,11 @@ func (s *Server) closeUnreachablePR(pr clawPR, cause string) (resolved, terminat
 // terminated is true when the claw itself is being torn down, which happens
 // only once every delivered tracked PR is resolved. While at least one
 // delivered PR is still open the claw stays alive and keeps watching.
+//
+// A mention-only row resolves silently: its state is persisted and nothing
+// else runs — no per-PR analytics, no pipeline transition, no tracker move,
+// no teardown. A claw with zero delivered rows is never finalized here at all
+// (see clawHasDeliveredPR).
 func (s *Server) checkPRMerged(pr clawPR, token string) (resolved, terminated bool) {
 	tokenForPR := s.resolveGitHubTokenForRepo(pr.repo)
 	if tokenForPR == "" {
@@ -2104,6 +2183,14 @@ func (s *Server) checkPRMerged(pr clawPR, token string) (resolved, terminated bo
 			return false, false
 		}
 
+		// A mention-only row resolves silently: persist the state (done above)
+		// and stop. A stranger closing a PR the agent merely linked must not
+		// fire per-PR analytics, pipeline transitions, or any stop path.
+		// (Unreadable flag: fail alive, run no terminal handling.)
+		if mentionOnly, ok := s.clawPRIsMentionOnly(pr.id); !ok || mentionOnly {
+			return true, false
+		}
+
 		pipelineCtx, hasPipelineCtx := s.findPipelineContextForClaw(clawID)
 		if hasPipelineCtx {
 			s.trackPRClosed(pipelineCtx.Name(), pipelineCtx.IssueID, clawID, pr.repo, pr.prNumber)
@@ -2120,6 +2207,15 @@ func (s *Server) checkPRMerged(pr clawPR, token string) (resolved, terminated bo
 			// External inject: a paused (no-progress) claw must be woken so it
 			// can react to the close instead of sitting on the remaining PRs.
 			s.injectExternalHubMessageByID(clawID, fmt.Sprintf("[hub] PR %s was closed without being merged. Still watching %d other open PR(s).", pr.prURL, remaining))
+			return true, false
+		}
+
+		if delivered, err := s.clawHasDeliveredPR(clawID); err != nil || !delivered {
+			// See clawHasDeliveredPR: never finalize a claw with zero
+			// delivered rows, whatever happened to mentioned PRs.
+			if err != nil {
+				log.Printf("[pr-watcher] failed to count delivered PRs for claw %s: %v", shortID(clawID), err)
+			}
 			return true, false
 		}
 
@@ -2157,6 +2253,15 @@ func (s *Server) checkPRMerged(pr clawPR, token string) (resolved, terminated bo
 		return false, false
 	}
 
+	// A mention-only row resolves silently: persist the state (done above) and
+	// stop. A stranger merging a PR the agent merely linked must not fire
+	// per-PR analytics, the pipeline stage transition, the DoneStatus tracker
+	// move, or any teardown. (Unreadable flag: fail alive, run no terminal
+	// handling.)
+	if mentionOnly, ok := s.clawPRIsMentionOnly(pr.id); !ok || mentionOnly {
+		return true, false
+	}
+
 	// Track analytics for PR merge. These are per-PR facts and fire on every
 	// merge, regardless of whether the claw is finished yet.
 	mergeCtx, hasMergeCtx := s.findPipelineContextForClaw(clawID)
@@ -2188,6 +2293,15 @@ func (s *Server) checkPRMerged(pr clawPR, token string) (resolved, terminated bo
 		// External inject: a paused (no-progress) claw must be woken so it can
 		// act on the partial merge instead of staying paused with PRs open.
 		s.injectExternalHubMessageByID(clawID, fmt.Sprintf("[hub] PR %s merged. Still watching %d other open PR(s) — will finish when they are all merged or closed.", pr.prURL, remaining))
+		return true, false
+	}
+
+	if delivered, err := s.clawHasDeliveredPR(clawID); err != nil || !delivered {
+		// See clawHasDeliveredPR: never finalize a claw with zero delivered
+		// rows, whatever happened to mentioned PRs.
+		if err != nil {
+			log.Printf("[pr-watcher] failed to count delivered PRs for claw %s: %v", shortID(clawID), err)
+		}
 		return true, false
 	}
 

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -562,6 +562,13 @@ type clawPR struct {
 	state               string
 	merged              bool
 	mergedAt            *string
+	// mentionOnly mirrors claw_prs.mention_only at load time. A mention-only
+	// row is a POLLING target (CI, comments and reviews are still forwarded)
+	// but never an ACTION target and never a TRIGGER: it must not block
+	// finalization, drive a pipeline transition, move a tracker issue, be
+	// merged by the hub, or terminate a claw. Decision-time reads should still
+	// prefer clawPRIsMentionOnly (the flag can be upgraded mid-poll).
+	mentionOnly bool
 }
 
 // loadClawPRsByNumber hydrates every tracked-PR row for a (repo, number) pair
@@ -608,11 +615,76 @@ func (s *Server) loadClawPRsByNumber(repo string, prNumber int) []clawPR {
 	return prs
 }
 
+// rearmTokenMissClosedPRs reopens rows the token-miss bound closed once their
+// repo's installation token resolves again. The bound closes a row after
+// prMergedPermanentFailureLimit consecutive polls without a token so an
+// unpollable repo cannot pin the claw, but the cause is usually transient
+// (mint 5xx, network, JWT clock skew) — and a closed row is excluded from
+// polling, so without this sweep the row would stay closed forever after the
+// outage ends: the PR still open on GitHub, the tracker issue never moved, the
+// workflow slot never released, the VM still running.
+//
+// A closed unmerged row with token_miss_count at the bound is exactly "closed
+// by the token-miss bound": the closing path deliberately does NOT zero the
+// counter, and every other closing path (checkPRMerged, closeUnreachablePR) is
+// only reachable after a successful token resolve already reset it to 0.
+//
+// Kept cheap: one DB query; when nothing matches, no token resolution is
+// attempted at all. Token resolution per distinct repo is the only external
+// work — no PR fetches happen here.
+func (s *Server) rearmTokenMissClosedPRs() {
+	rows, err := s.db.Query(`
+		SELECT DISTINCT cp.repo
+		FROM claw_prs cp
+		JOIN claws cl ON cl.id = cp.claw_id
+		WHERE cl.status NOT IN ('deleted','error','offline')
+		  AND cp.state='closed' AND cp.merged=0
+		  AND cp.token_miss_count >= ?
+	`, prMergedPermanentFailureLimit)
+	if err != nil {
+		if !strings.Contains(err.Error(), "database is closed") {
+			log.Printf("[pr-watcher] token-miss re-arm query error: %v", err)
+		}
+		return
+	}
+	defer rows.Close()
+	var repos []string
+	for rows.Next() {
+		var repo string
+		if err := rows.Scan(&repo); err != nil {
+			continue
+		}
+		repos = append(repos, repo)
+	}
+	rows.Close()
+	for _, repo := range repos {
+		if s.tokenForRepo(repo) == "" {
+			continue // outage still ongoing for this repo
+		}
+		res, err := s.db.Exec(`
+			UPDATE claw_prs SET state='open', token_miss_count=0
+			WHERE repo=? AND state='closed' AND merged=0 AND token_miss_count >= ?
+			  AND claw_id IN (SELECT id FROM claws WHERE status NOT IN ('deleted','error','offline'))
+		`, repo, prMergedPermanentFailureLimit)
+		if err != nil {
+			log.Printf("[pr-watcher] failed to re-arm token-miss-closed PR rows for %s: %v", repo, err)
+			continue
+		}
+		if n, err := res.RowsAffected(); err == nil && n > 0 {
+			log.Printf("[pr-watcher] token for %s resolvable again — re-armed %d PR row(s) closed by the token-miss bound", repo, n)
+		}
+	}
+}
+
 func (s *Server) pollAllPRs() {
+	// Re-arm rows the token-miss bound closed, before the main query, so a
+	// recovered row is polled again in this same pass.
+	s.rearmTokenMissClosedPRs()
+
 	rows, err := s.db.Query(`
 		SELECT cp.id, cp.claw_id, cp.repo, cp.pr_number, cp.pr_url, cp.last_ci_sha, cp.last_ci_conclusion, cp.last_comment_id,
 		       cp.last_comment_at, cp.last_review_comment_id, cp.last_review_id, cp.pr_conditions_fired, cp.created_at,
-		       cl.status
+		       cp.mention_only, cl.status
 		FROM claw_prs cp
 		JOIN claws cl ON cl.id = cp.claw_id
 		WHERE cl.status NOT IN ('deleted','error','offline')
@@ -634,13 +706,14 @@ func (s *Server) pollAllPRs() {
 	var prs []row
 	for rows.Next() {
 		var r row
-		var prConditionsFiredInt int
+		var prConditionsFiredInt, mentionOnlyInt int
 		if err := rows.Scan(&r.pr.id, &r.pr.clawID, &r.pr.repo, &r.pr.prNumber, &r.pr.prURL,
 			&r.pr.lastCISHA, &r.pr.lastCIConclusion, &r.pr.lastCommentID, &r.pr.lastCommentAt, &r.pr.lastReviewCommentID, &r.pr.lastReviewID, &prConditionsFiredInt, &r.pr.createdAt,
-			&r.clawStatus); err != nil {
+			&mentionOnlyInt, &r.clawStatus); err != nil {
 			continue
 		}
 		r.pr.prConditionsFired = prConditionsFiredInt == 1
+		r.pr.mentionOnly = mentionOnlyInt == 1
 		prs = append(prs, r)
 	}
 	rows.Close()
@@ -724,6 +797,10 @@ func (s *Server) pollAllPRs() {
 				// delivered nothing yet, so escalating here would kill a
 				// healthy claw during a token outage. The teardown decision
 				// stays with checkPRMerged observing a real delivered row.
+				// token_miss_count is deliberately NOT zeroed here: a closed
+				// unmerged row with the counter at the bound is how
+				// rearmTokenMissClosedPRs recognises (and reopens) these rows
+				// once the token resolves again.
 				log.Printf("[pr-watcher] WARN: PR %s (%s#%d) unpollable for %d consecutive polls (no GitHub token resolvable for %s) — marking the row closed so it stops blocking finalization; claw %s left untouched",
 					r.pr.prURL, r.pr.repo, r.pr.prNumber, prMergedPermanentFailureLimit, r.pr.repo, shortID(r.pr.clawID))
 				if _, err := s.db.Exec(`UPDATE claw_prs SET state='closed' WHERE id=?`, r.pr.id); err != nil {
@@ -806,8 +883,13 @@ func (s *Server) pollAllPRs() {
 			s.updatePRReviewWatermark(r.pr, reviewsData)
 		}
 
-		// For pipeline-driven claws, evaluate pr_conditions trigger.
-		if isPipelineDriven && !r.pr.prConditionsFired {
+		// For pipeline-driven claws, evaluate pr_conditions trigger — but only
+		// off a DELIVERED row. A mention-only row is a polling target, never a
+		// TRIGGER: a stranger's green CI must not advance the claw's pipeline
+		// (and finalize it on a terminal stage), and a stale mentioned PR with
+		// no check runs must not trip the max-wait stop and destroy a sandbox
+		// mid-work.
+		if isPipelineDriven && !r.pr.prConditionsFired && !r.pr.mentionOnly {
 			stage, status := s.checkPRConditions(r.pr, token, pipelineCtx)
 			if stage != nil {
 				s.firePRConditions(r.pr, *stage, pipelineCtx)

--- a/pkg/hub/pr_watcher_multi_pr_test.go
+++ b/pkg/hub/pr_watcher_multi_pr_test.go
@@ -5,12 +5,15 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/elasticclaw/elasticclaw/pkg/hub/pipeline"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
 
@@ -100,6 +103,50 @@ func clawStatusAndPRState(t *testing.T, db *sql.DB, clawID, prID string) (clawSt
 	return clawStatus, prState
 }
 
+// assertClawStatusStays asserts claws.status remains `want` for a short
+// window. The stop paths under test run via `go s.stopAgentWithReason(...)`,
+// so a single synchronous read right after the call under test proves nothing
+// — it can win the race against a stop that WAS fired. Polling the window
+// makes an erroneously fired stop actually flip the assertion.
+func assertClawStatusStays(t *testing.T, db *sql.DB, clawID, want string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		var status string
+		if err := db.QueryRow(`SELECT status FROM claws WHERE id=?`, clawID).Scan(&status); err != nil {
+			t.Fatal(err)
+		}
+		if status != want {
+			t.Fatalf("claw %s status = %q, want it to stay %q", clawID, status, want)
+		}
+		if time.Now().After(deadline) {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// waitForClawStatusLeaving polls claws.status until it differs from `from`,
+// failing if it never does. Counterpart of assertClawStatusStays for tests
+// that expect the asynchronous stop path to actually run. The generous
+// deadline covers stopAgentWithReason sleeping while the retry disposition is
+// indeterminate under DB contention.
+func waitForClawStatusLeaving(t *testing.T, db *sql.DB, clawID, from string) {
+	t.Helper()
+	deadline := time.Now().Add(15 * time.Second)
+	for {
+		var status string
+		_ = db.QueryRow(`SELECT status FROM claws WHERE id=?`, clawID).Scan(&status)
+		if status != from {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("claw %s status = %q, want it to leave %q", clawID, status, from)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
 func TestCheckPRMergedKeepsClawAliveUntilAllPRsResolved(t *testing.T) {
 	s, db, stub, prs := multiPRFixture(t, "claw-multi-merge", 1, 2)
 	stub.set(1, "merged")
@@ -109,10 +156,8 @@ func TestCheckPRMergedKeepsClawAliveUntilAllPRsResolved(t *testing.T) {
 	if _, terminated := s.checkPRMerged(prs[0], "token"); terminated {
 		t.Fatal("checkPRMerged terminated the claw with another PR still open")
 	}
-	clawStatus, stateA := clawStatusAndPRState(t, db, "claw-multi-merge", prs[0].id)
-	if clawStatus != "connected" {
-		t.Fatalf("claw status = %q, want connected", clawStatus)
-	}
+	_, stateA := clawStatusAndPRState(t, db, "claw-multi-merge", prs[0].id)
+	assertClawStatusStays(t, db, "claw-multi-merge", "connected")
 	if stateA != "merged" {
 		t.Fatalf("PR 1 state = %q, want merged", stateA)
 	}
@@ -161,10 +206,8 @@ func TestCheckPRMergedClosedWithoutMergeKeepsClawWatching(t *testing.T) {
 	if _, terminated := s.checkPRMerged(prs[0], "token"); terminated {
 		t.Fatal("checkPRMerged terminated the claw on a closed PR with another still open")
 	}
-	clawStatus, stateA := clawStatusAndPRState(t, db, "claw-multi-close", prs[0].id)
-	if clawStatus != "connected" {
-		t.Fatalf("claw status = %q, want connected", clawStatus)
-	}
+	_, stateA := clawStatusAndPRState(t, db, "claw-multi-close", prs[0].id)
+	assertClawStatusStays(t, db, "claw-multi-close", "connected")
 	if stateA != "closed" {
 		t.Fatalf("PR 1 state = %q, want closed", stateA)
 	}
@@ -310,7 +353,9 @@ func TestDeliveryUpgradesMentionOnlyRow(t *testing.T) {
 // and it gates finalization again.
 func TestReopenedPRResetMakesRowPolledAgain(t *testing.T) {
 	s, db, _, prs := multiPRFixture(t, "claw-reopen", 1, 2)
-	if _, err := db.Exec(`UPDATE claw_prs SET state='closed', merged=1, merged_at='2026-01-02T03:04:05Z' WHERE id=?`, prs[0].id); err != nil {
+	// Tripped failure counters simulate a row that was administratively closed
+	// at one of the bounds: a reopen must grant fresh grace on both.
+	if _, err := db.Exec(`UPDATE claw_prs SET state='closed', merged=1, merged_at='2026-01-02T03:04:05Z', token_miss_count=5, permanent_failure_count=5 WHERE id=?`, prs[0].id); err != nil {
 		t.Fatal(err)
 	}
 
@@ -325,13 +370,16 @@ func TestReopenedPRResetMakesRowPolledAgain(t *testing.T) {
 	s.resetReopenedClawPR("claw-reopen", prs[0].prURL)
 
 	var state string
-	var merged int
+	var merged, tokenMisses, permFailures int
 	var mergedAt sql.NullString
-	if err := db.QueryRow(`SELECT state, merged, merged_at FROM claw_prs WHERE id=?`, prs[0].id).Scan(&state, &merged, &mergedAt); err != nil {
+	if err := db.QueryRow(`SELECT state, merged, merged_at, token_miss_count, permanent_failure_count FROM claw_prs WHERE id=?`, prs[0].id).Scan(&state, &merged, &mergedAt, &tokenMisses, &permFailures); err != nil {
 		t.Fatal(err)
 	}
 	if state != "open" || merged != 0 || mergedAt.Valid {
 		t.Fatalf("row after reopen = state=%q merged=%d merged_at=%v, want open/0/NULL", state, merged, mergedAt)
+	}
+	if tokenMisses != 0 || permFailures != 0 {
+		t.Fatalf("failure counters after reopen = token_miss=%d permanent=%d, want 0/0 (a reopened row gets fresh grace)", tokenMisses, permFailures)
 	}
 	if n, err := s.clawOpenPRCount("claw-reopen"); err != nil || n != 2 {
 		t.Fatalf("clawOpenPRCount = %d, %v; want 2 (reopened PR gates finalization again)", n, err)
@@ -371,13 +419,7 @@ func TestCheckPRMergedCountErrorDoesNotTerminate(t *testing.T) {
 	if _, terminated := s.checkPRMerged(prs[0], "token"); terminated {
 		t.Fatal("checkPRMerged terminated the claw on a failed open-PR count")
 	}
-	var clawStatus string
-	if err := db.QueryRow(`SELECT status FROM claws WHERE id=?`, "claw-count-err").Scan(&clawStatus); err != nil {
-		t.Fatal(err)
-	}
-	if clawStatus != "connected" {
-		t.Fatalf("claw status = %q, want connected (unchanged on count error)", clawStatus)
-	}
+	assertClawStatusStays(t, db, "claw-count-err", "connected")
 }
 
 // FIX 3: a single-PR claw whose PR is closed without merge is stopped AND its
@@ -397,20 +439,7 @@ func TestSinglePRClosedWithoutMergeDeletesRowsAndStopsClaw(t *testing.T) {
 	if rows != 0 {
 		t.Fatalf("claw_prs rows after closed-without-merge stop = %d, want 0", rows)
 	}
-	// stopAgentWithReason runs in a goroutine and may sleep several seconds
-	// when the retry disposition is indeterminate under DB contention.
-	deadline := time.Now().Add(15 * time.Second)
-	for {
-		var status string
-		_ = db.QueryRow(`SELECT status FROM claws WHERE id=?`, "claw-close-single").Scan(&status)
-		if status != "connected" {
-			break
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("claw status = %q, want a stopped status", status)
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	waitForClawStatusLeaving(t, db, "claw-close-single", "connected")
 }
 
 // Per-PR analytics must fire on a NON-final merge: after PR A merges with B
@@ -600,23 +629,82 @@ func TestTokenMissBoundClosesRowWithoutTouchingClaw(t *testing.T) {
 		t.Fatalf("row state after recovered poll = %q, want open", state)
 	}
 
-	// A full run of consecutive misses closes the row — and only the row.
+	// A full run of consecutive misses closes the row — and only the row. The
+	// pre-fix escalation ran via `go stopAgentWithReason`, so the claw check
+	// must poll a window: a synchronous read right after pollAllPRs() wins the
+	// race against the goroutine and passes even with the escalation restored.
 	fail.Store(true)
 	for i := 0; i < prMergedPermanentFailureLimit; i++ {
 		s.pollAllPRs()
 	}
-	var clawStatus string
 	if err := db.QueryRow(`SELECT state FROM claw_prs WHERE id='pr-token-miss'`).Scan(&state); err != nil {
-		t.Fatal(err)
-	}
-	if err := db.QueryRow(`SELECT status FROM claws WHERE id='claw-token-miss'`).Scan(&clawStatus); err != nil {
 		t.Fatal(err)
 	}
 	if state != "closed" {
 		t.Fatalf("row state after token-miss bound = %q, want closed", state)
 	}
-	if clawStatus != "connected" {
-		t.Fatalf("claw status after token-miss bound = %q, want connected (the bound must never touch the claw)", clawStatus)
+	// The bound must never touch the claw.
+	assertClawStatusStays(t, db, "claw-token-miss", "connected")
+}
+
+// FIX 2 (round 3): the token-miss bound closes a row so it stops blocking
+// finalization, but a closed row is excluded from polling — so once the token
+// outage ends, something must put the row back or it stays closed forever
+// while the PR is genuinely open on GitHub (tracker never moves, workflow slot
+// never released, VM keeps running). rearmTokenMissClosedPRs reopens such rows
+// when their repo's token resolves again, and the next poll visits them.
+func TestTokenMissClosedRowReArmedWhenTokenReturns(t *testing.T) {
+	resetGitHubClientForTest(t)
+	fail := &atomic.Bool{}
+	fail.Store(true)
+	oldTransport := http.DefaultTransport
+	http.DefaultTransport = tokenMintOutageTransport{base: oldTransport, fail: fail}
+	t.Cleanup(func() { http.DefaultTransport = oldTransport })
+
+	stub := &multiPRGitHubStub{states: map[int]string{}}
+	gh := httptest.NewServer(stub.handler())
+	t.Cleanup(gh.Close)
+
+	cfg := &types.HubConfig{GitHubApps: []*types.GitHubAppConfig{{AppID: 1, PrivateKeyPEM: testGitHubAppPEM(t)}}}
+	s, db := NewTestServerWithConfig(t, cfg, gh.URL, "", "")
+	if _, err := db.Exec(`INSERT INTO claws(id,tenant_id,name,template,status,created_at) VALUES(?,?,?,?,?,?)`, "claw-rearm", "test-tenant-id", "claw-rearm", "elasticclaw", "connected", now()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO claw_prs(id,claw_id,repo,pr_number,pr_url,created_at) VALUES(?,?,?,?,?,?)`,
+		"pr-rearm", "claw-rearm", "owner/repo", 1, "https://github.com/owner/repo/pull/1", now()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Token outage runs the row into the bound: closed, no longer polled.
+	for i := 0; i < prMergedPermanentFailureLimit; i++ {
+		s.pollAllPRs()
+	}
+	var state string
+	if err := db.QueryRow(`SELECT state FROM claw_prs WHERE id='pr-rearm'`).Scan(&state); err != nil {
+		t.Fatal(err)
+	}
+	if state != "closed" {
+		t.Fatalf("row state after token outage = %q, want closed", state)
+	}
+
+	// Token minting recovers: the next poll re-arms the row and visits it again.
+	fail.Store(false)
+	s.pollAllPRs()
+	var misses int
+	if err := db.QueryRow(`SELECT state, token_miss_count FROM claw_prs WHERE id='pr-rearm'`).Scan(&state, &misses); err != nil {
+		t.Fatal(err)
+	}
+	if state != "open" {
+		t.Fatalf("row state after token recovery = %q, want open (re-armed for polling)", state)
+	}
+	if misses != 0 {
+		t.Fatalf("token_miss_count after re-arm = %d, want 0", misses)
+	}
+	s.mu.Lock()
+	tracked := s.trackedPRCount
+	s.mu.Unlock()
+	if tracked != 1 {
+		t.Fatalf("pollAllPRs visited %d row(s) after re-arm, want 1 (the row must be polled again)", tracked)
 	}
 }
 
@@ -635,10 +723,9 @@ func TestMentionOnlyPRMergeDoesNotTerminateClaw(t *testing.T) {
 	if !resolved || terminated {
 		t.Fatalf("checkPRMerged = (resolved=%v, terminated=%v), want (true, false) for a mention-only merge", resolved, terminated)
 	}
-	clawStatus, state := clawStatusAndPRState(t, db, "claw-mention-merge", prs[0].id)
-	if clawStatus != "connected" {
-		t.Fatalf("claw status = %q, want connected (a stranger merging a mentioned PR must not destroy the sandbox)", clawStatus)
-	}
+	_, state := clawStatusAndPRState(t, db, "claw-mention-merge", prs[0].id)
+	// A stranger merging a mentioned PR must not destroy the sandbox.
+	assertClawStatusStays(t, db, "claw-mention-merge", "connected")
 	if state != "merged" {
 		t.Fatalf("PR state = %q, want merged (the resolution must persist)", state)
 	}
@@ -647,22 +734,34 @@ func TestMentionOnlyPRMergeDoesNotTerminateClaw(t *testing.T) {
 }
 
 // FIX C: the closed-without-merge variant of the same asymmetry — a stray
-// mentioned PR being closed must not stop the claw or delete its rows.
+// mentioned PR being closed must resolve SILENTLY: no stop, no row deletion,
+// no partial-resolution inject, no trackPRClosed analytics. The claw also has
+// a delivered open PR so this test does not lean on the clawHasDeliveredPR
+// backstop: without the mention-only early return the close would take the
+// remaining>0 branch and fire the "Still watching" inject and trackPRClosed.
 func TestMentionOnlyPRCloseDoesNotStopClaw(t *testing.T) {
-	s, db, stub, prs := multiPRFixture(t, "claw-mention-close", 1)
+	s, db, stub, prs := multiPRFixture(t, "claw-mention-close", 1, 2)
 	if _, err := db.Exec(`UPDATE claw_prs SET mention_only=1 WHERE id=?`, prs[0].id); err != nil {
 		t.Fatal(err)
 	}
+	// Give the claw a pipeline context and a task run so trackPRClosed would
+	// leave observable traces (a pr_closed_unmerged task-run event) if it fired.
+	if _, err := db.Exec(`UPDATE claws SET tags='["factory:mention-close-factory"]' WHERE id='claw-mention-close'`); err != nil {
+		t.Fatal(err)
+	}
+	s.mu.Lock()
+	s.hubCfg.Factories = []*types.FactoryConfig{{Name: "mention-close-factory", Integration: "github", Template: "elasticclaw"}}
+	s.mu.Unlock()
+	startTaskRunForTest(t, s, "claw-mention-close", "mention-close")
 	stub.set(1, "closed")
+	stub.set(2, "open")
 
 	resolved, terminated := s.checkPRMerged(prs[0], "token")
 	if !resolved || terminated {
 		t.Fatalf("checkPRMerged = (resolved=%v, terminated=%v), want (true, false) for a mention-only close", resolved, terminated)
 	}
-	clawStatus, state := clawStatusAndPRState(t, db, "claw-mention-close", prs[0].id)
-	if clawStatus != "connected" {
-		t.Fatalf("claw status = %q, want connected", clawStatus)
-	}
+	_, state := clawStatusAndPRState(t, db, "claw-mention-close", prs[0].id)
+	assertClawStatusStays(t, db, "claw-mention-close", "connected")
 	if state != "closed" {
 		t.Fatalf("PR state = %q, want closed", state)
 	}
@@ -670,8 +769,25 @@ func TestMentionOnlyPRCloseDoesNotStopClaw(t *testing.T) {
 	if err := db.QueryRow(`SELECT COUNT(*) FROM claw_prs WHERE claw_id='claw-mention-close'`).Scan(&rows); err != nil {
 		t.Fatal(err)
 	}
-	if rows != 1 {
-		t.Fatalf("claw_prs rows = %d, want 1 (mention-only close must not run the stop path that deletes rows)", rows)
+	if rows != 2 {
+		t.Fatalf("claw_prs rows = %d, want 2 (mention-only close must not run the stop path that deletes rows)", rows)
+	}
+	// No partial-resolution inject: the "Still watching" message is for a
+	// DELIVERED PR closing, not for a stranger closing a PR the agent linked.
+	var partialMsgs int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id='claw-mention-close' AND content LIKE '%closed without being merged%'`).Scan(&partialMsgs); err != nil {
+		t.Fatal(err)
+	}
+	if partialMsgs != 0 {
+		t.Fatalf("partial-resolution messages = %d, want 0 for a mention-only close", partialMsgs)
+	}
+	// trackPRClosed must not fire for the mentioned PR.
+	var closedEvents int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM task_run_events WHERE event_key='pr_closed_unmerged:owner/repo#1'`).Scan(&closedEvents); err != nil {
+		t.Fatal(err)
+	}
+	if closedEvents != 0 {
+		t.Fatalf("pr_closed_unmerged events = %d, want 0 (trackPRClosed fired for a mention-only PR)", closedEvents)
 	}
 }
 
@@ -689,10 +805,8 @@ func TestUnreachableMentionOnlyPRNeverStopsClaw(t *testing.T) {
 			t.Fatal("checkPRMerged terminated a claw off an unreachable mention-only PR")
 		}
 	}
-	clawStatus, state := clawStatusAndPRState(t, db, "claw-mention-unreachable", prs[0].id)
-	if clawStatus != "connected" {
-		t.Fatalf("claw status = %q, want connected", clawStatus)
-	}
+	_, state := clawStatusAndPRState(t, db, "claw-mention-unreachable", prs[0].id)
+	assertClawStatusStays(t, db, "claw-mention-unreachable", "connected")
 	if state != "closed" {
 		t.Fatalf("PR state = %q, want closed (unreachable row must stop blocking finalization)", state)
 	}
@@ -710,10 +824,8 @@ func TestPermanentFailureClosesRowButClawSurvivesWithOtherOpenPR(t *testing.T) {
 			t.Fatal("checkPRMerged terminated the claw while another delivered PR is open")
 		}
 	}
-	clawStatus, state := clawStatusAndPRState(t, db, "claw-perm-partial", prs[0].id)
-	if clawStatus != "connected" {
-		t.Fatalf("claw status = %q, want connected", clawStatus)
-	}
+	_, state := clawStatusAndPRState(t, db, "claw-perm-partial", prs[0].id)
+	assertClawStatusStays(t, db, "claw-perm-partial", "connected")
 	if state != "closed" {
 		t.Fatalf("unreachable PR state = %q, want closed", state)
 	}
@@ -809,5 +921,187 @@ func TestAgentIdleHasClawPRsIgnoresResolvedRows(t *testing.T) {
 	}
 	if s.agentIdleHasClawPRs("claw-idle-prs") {
 		t.Fatal("agentIdleHasClawPRs = true for a state='merged' row, want false")
+	}
+}
+
+// FIX 5 (round 3): a mention-only row must not read as "PR out, awaiting
+// humans" either. The watcher never finalizes a claw with zero delivered rows,
+// so counting a mention here would make a hung mention-only claw both
+// immortal (never torn down) and invisible (stuck alert suppressed).
+func TestAgentIdleHasClawPRsIgnoresMentionOnlyRows(t *testing.T) {
+	s, db, _, prs := multiPRFixture(t, "claw-idle-mention", 1)
+	if _, err := db.Exec(`UPDATE claw_prs SET mention_only=1 WHERE id=?`, prs[0].id); err != nil {
+		t.Fatal(err)
+	}
+	if s.agentIdleHasClawPRs("claw-idle-mention") {
+		t.Fatal("agentIdleHasClawPRs = true for a mention-only row, want false")
+	}
+}
+
+// prConditionsTransport serves the GitHub App token endpoints like
+// githubAppAnyTokenTransport plus empty comment/review lists: pollAllPRs
+// fetches those via githubAPIList against api.github.com (not the test
+// server's githubBaseURL), and an error there `continue`s past the
+// pr_conditions evaluation, making the tests below vacuous.
+type prConditionsTransport struct {
+	base http.RoundTripper
+}
+
+func (t prConditionsTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	if r.URL.Host != "api.github.com" {
+		return t.base.RoundTrip(r)
+	}
+	if r.Method == http.MethodGet && r.URL.Path == "/app/installations" {
+		return githubAppTokenResponse(http.StatusOK, `[{"id":1,"account":{"login":"owner"}}]`), nil
+	}
+	if r.Method == http.MethodPost && r.URL.Path == "/app/installations/1/access_tokens" {
+		return githubAppTokenResponse(http.StatusCreated, `{"token":"tok","expires_at":"2030-01-01T00:00:00Z"}`), nil
+	}
+	if strings.Contains(r.URL.Path, "/comments") || strings.Contains(r.URL.Path, "/reviews") {
+		return githubAppTokenResponse(http.StatusOK, `[]`), nil
+	}
+	return githubAppTokenResponse(http.StatusNotFound, `{"message":"not found"}`), nil
+}
+
+// prConditionsPollFixture wires a pipeline-driven claw (factory tag plus a
+// pipeline with a pr_conditions: ci: passing stage) tracking one MENTION-ONLY
+// PR row older than prConditionsMaxWait, against a GitHub stub with a fixed
+// check-runs response. Comment/review endpoints serve empty lists so
+// pollAllPRs reaches the pr_conditions evaluation at the end of its loop.
+func prConditionsPollFixture(t *testing.T, clawID, checkRunsJSON string) (*Server, *sql.DB, clawPR) {
+	t.Helper()
+	resetGitHubClientForTest(t)
+	oldTransport := http.DefaultTransport
+	http.DefaultTransport = prConditionsTransport{base: oldTransport}
+	t.Cleanup(func() { http.DefaultTransport = oldTransport })
+
+	gh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(r.URL.Path, "/check-runs"):
+			fmt.Fprintf(w, `{"check_runs":%s}`, checkRunsJSON)
+		case strings.Contains(r.URL.Path, "/comments"), strings.Contains(r.URL.Path, "/reviews"):
+			fmt.Fprint(w, `[]`)
+		default:
+			fmt.Fprint(w, `{"state":"open","merged":false,"created_at":"2026-01-01T00:00:00Z","draft":false,"head":{"sha":"deadbeef"}}`)
+		}
+	}))
+	t.Cleanup(gh.Close)
+
+	cfg := &types.HubConfig{
+		GitHubApps: []*types.GitHubAppConfig{{AppID: 1, PrivateKeyPEM: testGitHubAppPEM(t)}},
+		Factories: []*types.FactoryConfig{{
+			Name:        "cond-factory",
+			Integration: "github",
+			Template:    "elasticclaw",
+			PipelineYAML: "stages:\n" +
+				"  - id: work\n" +
+				"    entry: true\n" +
+				"  - id: done\n" +
+				"    triggers:\n" +
+				"      - pr_conditions:\n" +
+				"          ci: passing\n",
+		}},
+	}
+	s, db := NewTestServerWithConfig(t, cfg, gh.URL, "", "")
+	if _, err := db.Exec(`INSERT INTO claws(id,tenant_id,name,template,status,pipeline_stage,tags,created_at) VALUES(?,?,?,?,?,?,?,?)`,
+		clawID, "test-tenant-id", clawID, "elasticclaw", "connected", "work", `["factory:cond-factory"]`, now()); err != nil {
+		t.Fatal(err)
+	}
+	// Older than the 2h default prConditionsMaxWait, so the stuck path would
+	// be eligible for the max-wait stop if the ownership guard were missing.
+	created := time.Now().Add(-3 * time.Hour).UTC().Format(time.RFC3339)
+	pr := clawPR{id: clawID + "-pr-12", clawID: clawID, repo: "owner/repo", prNumber: 12, prURL: "https://github.com/owner/repo/pull/12"}
+	if _, err := db.Exec(`INSERT INTO claw_prs(id,claw_id,repo,pr_number,pr_url,mention_only,created_at) VALUES(?,?,?,?,?,1,?)`,
+		pr.id, pr.clawID, pr.repo, pr.prNumber, pr.prURL, created); err != nil {
+		t.Fatal(err)
+	}
+	return s, db, pr
+}
+
+// FIX 1 (round 3): the pr_conditions trigger must never fire off a
+// mention-only row. Stuck half: a stale mentioned PR with no check runs, older
+// than prConditionsMaxWait, must not trip the max-wait stop — that would
+// destroy the sandbox mid-work with the agent's own PRs still open — and must
+// not move the pipeline.
+func TestMentionOnlyPRConditionsStuckDoesNotStopClaw(t *testing.T) {
+	s, db, _ := prConditionsPollFixture(t, "claw-cond-stuck", `[]`)
+
+	s.pollAllPRs()
+
+	assertClawStatusStays(t, db, "claw-cond-stuck", "connected")
+	var stage string
+	if err := db.QueryRow(`SELECT pipeline_stage FROM claws WHERE id='claw-cond-stuck'`).Scan(&stage); err != nil {
+		t.Fatal(err)
+	}
+	if stage != "work" {
+		t.Fatalf("pipeline_stage = %q, want work (a mention-only row must not move the pipeline)", stage)
+	}
+}
+
+// FIX 1 (round 3): green half — a stranger's green CI on a merely-mentioned PR
+// must not advance the claw's pipeline (and finalize it on a terminal stage)
+// or consume the one-shot pr_conditions trigger.
+func TestMentionOnlyGreenCIDoesNotAdvancePipeline(t *testing.T) {
+	s, db, pr := prConditionsPollFixture(t, "claw-cond-green", `[{"name":"ci","status":"completed","conclusion":"success"}]`)
+
+	s.pollAllPRs()
+
+	var stage string
+	if err := db.QueryRow(`SELECT pipeline_stage FROM claws WHERE id='claw-cond-green'`).Scan(&stage); err != nil {
+		t.Fatal(err)
+	}
+	if stage != "work" {
+		t.Fatalf("pipeline_stage = %q, want work (a stranger's green CI must not advance the pipeline)", stage)
+	}
+	var fired int
+	if err := db.QueryRow(`SELECT pr_conditions_fired FROM claw_prs WHERE id=?`, pr.id).Scan(&fired); err != nil {
+		t.Fatal(err)
+	}
+	if fired != 0 {
+		t.Fatalf("pr_conditions_fired = %d, want 0 for a mention-only row", fired)
+	}
+}
+
+// FIX 4 (round 3): the runOnEnter call site must register gate/run stdout PR
+// URLs as DELIVERED. For a pipeline-driven claw whose PRs arrive only via a
+// verify-github-pr-links style gate, this call site is the only registration
+// path — with mentionOnly=true there the finalization gate would be a
+// permanent no-op. TestPipelineGateRegisteredPRBlocksFinalization only covers
+// scanMessageForPRs itself; this test drives the real call site.
+func TestRunOnEnterRunStdoutRegistersDeliveredPR(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("ELASTICCLAW_TESTEXEC_PROVIDER", "1")
+	if err := os.MkdirAll(filepath.Join(tmpHome, ".openclaw", "workspace"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{
+		Providers: map[string]types.ProviderConfig{"testexec": {Type: "testexec"}},
+	}, "", "", "")
+	const clawID = "claw-onenter-pr"
+	if _, err := db.Exec(`INSERT INTO claws(id,tenant_id,name,template,status,provider,provider_id,created_at) VALUES(?,?,?,?,?,?,?,?)`,
+		clawID, "test-tenant-id", clawID, "elasticclaw", "connected", "testexec", "local", now()); err != nil {
+		t.Fatal(err)
+	}
+
+	const url = "https://github.com/owner/repo/pull/31"
+	stage := pipeline.Stage{ID: "verify", OnEnter: pipeline.OnEnter{
+		Run: pipeline.RunAction{Command: `echo '{"prs":["` + url + `"]}'`},
+	}}
+	if _, err := s.runOnEnter(clawID, stage, pipelineContext{}); err != nil {
+		t.Fatalf("runOnEnter: %v", err)
+	}
+
+	var mentionOnly int
+	if err := db.QueryRow(`SELECT mention_only FROM claw_prs WHERE claw_id=? AND pr_url=?`, clawID, url).Scan(&mentionOnly); err != nil {
+		t.Fatalf("gate-run PR was not registered: %v", err)
+	}
+	if mentionOnly != 0 {
+		t.Fatalf("mention_only for a run-stdout-registered PR = %d, want 0 (run stdout is a delivery channel)", mentionOnly)
+	}
+	if n, err := s.clawOpenPRCount(clawID); err != nil || n != 1 {
+		t.Fatalf("clawOpenPRCount = %d, %v; want 1 (run-registered PR must block finalization)", n, err)
 	}
 }

--- a/pkg/hub/pr_watcher_multi_pr_test.go
+++ b/pkg/hub/pr_watcher_multi_pr_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -16,9 +17,10 @@ import (
 // multiPRGitHubStub serves repos/{repo}/pulls/{n} responses whose per-PR state
 // the test can flip mid-test, so one server can drive a claw through
 // "first PR resolved, second still open, second resolves later" sequences.
+// The extra "missing" state answers 404 for permanent-failure scenarios.
 type multiPRGitHubStub struct {
 	mu     sync.Mutex
-	states map[int]string // pr number -> "open" | "merged" | "closed"
+	states map[int]string // pr number -> "open" | "merged" | "closed" | "missing"
 }
 
 func (m *multiPRGitHubStub) set(prNumber int, state string) {
@@ -37,6 +39,10 @@ func (m *multiPRGitHubStub) handler() http.HandlerFunc {
 		m.mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
 		switch state {
+		case "missing":
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, `{"message":"Not Found"}`)
+			return
 		case "merged":
 			fmt.Fprintf(w, `{"state":"closed","merged":true,"merged_at":"2026-01-02T03:04:05Z","created_at":"2026-01-01T00:00:00Z","draft":false,"head":{"sha":"deadbeef"}}`)
 		case "closed":
@@ -49,13 +55,25 @@ func (m *multiPRGitHubStub) handler() http.HandlerFunc {
 
 // multiPRFixture wires a test server against the mutable GitHub stub and
 // inserts one claw tracking prNumbers, returning one clawPR per number.
+//
+// The server carries a GitHubApps config and the process-wide transport mints
+// installation tokens: pollAllPRs returns early when githubAppConfigsForTokens
+// is empty and skips rows whose token cannot resolve, so without both every
+// poll-loop assertion in this file would be vacuous.
 func multiPRFixture(t *testing.T, clawID string, prNumbers ...int) (*Server, *sql.DB, *multiPRGitHubStub, []clawPR) {
 	t.Helper()
+	resetGitHubClientForTest(t)
+	oldTransport := http.DefaultTransport
+	var mints int64
+	http.DefaultTransport = githubAppAnyTokenTransport{base: oldTransport, mints: &mints}
+	t.Cleanup(func() { http.DefaultTransport = oldTransport })
+
 	stub := &multiPRGitHubStub{states: map[int]string{}}
 	gh := httptest.NewServer(stub.handler())
 	t.Cleanup(gh.Close)
 
-	s, db := NewTestServerWithConfig(t, &types.HubConfig{}, gh.URL, "", "")
+	cfg := &types.HubConfig{GitHubApps: []*types.GitHubAppConfig{{AppID: 1, PrivateKeyPEM: testGitHubAppPEM(t)}}}
+	s, db := NewTestServerWithConfig(t, cfg, gh.URL, "", "")
 	if _, err := db.Exec(`INSERT INTO claws(id,tenant_id,name,template,status,created_at) VALUES(?,?,?,?,?,?)`, clawID, "test-tenant-id", clawID, "elasticclaw", "connected", now()); err != nil {
 		t.Fatal(err)
 	}
@@ -262,7 +280,7 @@ func TestDeliveryUpgradesMentionOnlyRow(t *testing.T) {
 	s, db, _, _ := multiPRFixture(t, "claw-upgrade")
 	const url = "https://github.com/owner/repo/pull/9"
 
-	s.scanMessageForPRs("claw-upgrade", "this depends on "+url)
+	s.scanMessageForPRs("claw-upgrade", "this depends on "+url, true)
 	var mentionOnly int
 	if err := db.QueryRow(`SELECT mention_only FROM claw_prs WHERE claw_id=? AND pr_url=?`, "claw-upgrade", url).Scan(&mentionOnly); err != nil {
 		t.Fatal(err)
@@ -446,13 +464,18 @@ func TestMergePRForClawMergesOpenSkipsResolved(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	for n := 1; n <= 3; n++ {
+	for n := 1; n <= 4; n++ {
 		if _, err := db.Exec(`INSERT INTO claw_prs(id,claw_id,repo,pr_number,pr_url,created_at) VALUES(?,?,?,?,?,?)`,
 			fmt.Sprintf("merge-pr-%d", n), "claw-merge-batch", "owner/repo", n, fmt.Sprintf("https://github.com/owner/repo/pull/%d", n), now()); err != nil {
 			t.Fatal(err)
 		}
 	}
 	if _, err := db.Exec(`UPDATE claw_prs SET state='merged', merged=1 WHERE id='merge-pr-3'`); err != nil {
+		t.Fatal(err)
+	}
+	// FIX E: a mention-only row is a polling target, never an action target —
+	// no merge PUT may be issued for a third-party PR the agent merely linked.
+	if _, err := db.Exec(`UPDATE claw_prs SET mention_only=1 WHERE id='merge-pr-4'`); err != nil {
 		t.Fatal(err)
 	}
 
@@ -468,6 +491,9 @@ func TestMergePRForClawMergesOpenSkipsResolved(t *testing.T) {
 	}
 	if got[3] != 0 {
 		t.Fatalf("merge PUTs = %v, PR 3 is already merged and must be skipped", got)
+	}
+	if got[4] != 0 {
+		t.Fatalf("merge PUTs = %v, PR 4 is mention-only and must never be merged", got)
 	}
 
 	// "No tracked PR" early return: nothing merged, nothing injected.
@@ -487,5 +513,301 @@ func TestMergePRForClawMergesOpenSkipsResolved(t *testing.T) {
 	}
 	if msgs != 0 {
 		t.Fatalf("messages injected for claw with no tracked PRs = %d, want 0", msgs)
+	}
+}
+
+// tokenMintOutageTransport serves the GitHub App endpoints like
+// githubAppAnyTokenTransport, but fails installation-token minting while fail
+// is set — simulating a token outage. Successful mints carry a near-immediate
+// expiry so the token is never cached and every poll exercises minting again.
+type tokenMintOutageTransport struct {
+	base http.RoundTripper
+	fail *atomic.Bool
+}
+
+func (t tokenMintOutageTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	if r.URL.Host != "api.github.com" {
+		return t.base.RoundTrip(r)
+	}
+	if r.Method == http.MethodGet && r.URL.Path == "/app/installations" {
+		return githubAppTokenResponse(http.StatusOK, `[{"id":1,"account":{"login":"owner"}}]`), nil
+	}
+	if r.Method == http.MethodPost && r.URL.Path == "/app/installations/1/access_tokens" {
+		if t.fail.Load() {
+			return githubAppTokenResponse(http.StatusInternalServerError, `{"message":"mint outage"}`), nil
+		}
+		expiry := time.Now().Add(time.Minute).UTC().Format(time.RFC3339)
+		return githubAppTokenResponse(http.StatusCreated, fmt.Sprintf(`{"token":"tok","expires_at":%q}`, expiry)), nil
+	}
+	return githubAppTokenResponse(http.StatusNotFound, `{"message":"not found"}`), nil
+}
+
+// FIX A: hitting the token-miss bound closes the row (so it stops blocking
+// finalization) but must NEVER touch the claw — token resolution fails for
+// transient causes too, and a mid-work agent with nothing delivered would be
+// killed. The counter must also reset once the token resolves again, so only
+// genuinely consecutive misses accumulate.
+func TestTokenMissBoundClosesRowWithoutTouchingClaw(t *testing.T) {
+	resetGitHubClientForTest(t)
+	fail := &atomic.Bool{}
+	fail.Store(true)
+	oldTransport := http.DefaultTransport
+	http.DefaultTransport = tokenMintOutageTransport{base: oldTransport, fail: fail}
+	t.Cleanup(func() { http.DefaultTransport = oldTransport })
+
+	stub := &multiPRGitHubStub{states: map[int]string{}}
+	gh := httptest.NewServer(stub.handler())
+	t.Cleanup(gh.Close)
+
+	cfg := &types.HubConfig{GitHubApps: []*types.GitHubAppConfig{{AppID: 1, PrivateKeyPEM: testGitHubAppPEM(t)}}}
+	s, db := NewTestServerWithConfig(t, cfg, gh.URL, "", "")
+	if _, err := db.Exec(`INSERT INTO claws(id,tenant_id,name,template,status,created_at) VALUES(?,?,?,?,?,?)`, "claw-token-miss", "test-tenant-id", "claw-token-miss", "elasticclaw", "connected", now()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO claw_prs(id,claw_id,repo,pr_number,pr_url,created_at) VALUES(?,?,?,?,?,?)`,
+		"pr-token-miss", "claw-token-miss", "owner/repo", 1, "https://github.com/owner/repo/pull/1", now()); err != nil {
+		t.Fatal(err)
+	}
+
+	readMisses := func() int {
+		t.Helper()
+		var n int
+		if err := db.QueryRow(`SELECT token_miss_count FROM claw_prs WHERE id='pr-token-miss'`).Scan(&n); err != nil {
+			t.Fatal(err)
+		}
+		return n
+	}
+
+	// One miss short of the bound...
+	for i := 0; i < prMergedPermanentFailureLimit-1; i++ {
+		s.pollAllPRs()
+	}
+	if got := readMisses(); got != prMergedPermanentFailureLimit-1 {
+		t.Fatalf("token_miss_count = %d, want %d", got, prMergedPermanentFailureLimit-1)
+	}
+
+	// ...then the token resolves: the counter resets and the row stays open.
+	fail.Store(false)
+	s.pollAllPRs()
+	if got := readMisses(); got != 0 {
+		t.Fatalf("token_miss_count after a successful token resolve = %d, want 0", got)
+	}
+	var state string
+	if err := db.QueryRow(`SELECT state FROM claw_prs WHERE id='pr-token-miss'`).Scan(&state); err != nil {
+		t.Fatal(err)
+	}
+	if state != "open" {
+		t.Fatalf("row state after recovered poll = %q, want open", state)
+	}
+
+	// A full run of consecutive misses closes the row — and only the row.
+	fail.Store(true)
+	for i := 0; i < prMergedPermanentFailureLimit; i++ {
+		s.pollAllPRs()
+	}
+	var clawStatus string
+	if err := db.QueryRow(`SELECT state FROM claw_prs WHERE id='pr-token-miss'`).Scan(&state); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT status FROM claws WHERE id='claw-token-miss'`).Scan(&clawStatus); err != nil {
+		t.Fatal(err)
+	}
+	if state != "closed" {
+		t.Fatalf("row state after token-miss bound = %q, want closed", state)
+	}
+	if clawStatus != "connected" {
+		t.Fatalf("claw status after token-miss bound = %q, want connected (the bound must never touch the claw)", clawStatus)
+	}
+}
+
+// FIX C: a mention-only PR that a human merges resolves its row silently — no
+// teardown, no per-PR analytics, no tracker move.
+func TestMentionOnlyPRMergeDoesNotTerminateClaw(t *testing.T) {
+	s, db, stub, prs := multiPRFixture(t, "claw-mention-merge", 1)
+	if _, err := db.Exec(`UPDATE claw_prs SET mention_only=1 WHERE id=?`, prs[0].id); err != nil {
+		t.Fatal(err)
+	}
+	runID, _ := startTaskRunForTest(t, s, "claw-mention-merge", "mention-merge")
+	associatePRForTest(t, s, runID, "owner/repo", 1, taskRunPRStateOpen)
+	stub.set(1, "merged")
+
+	resolved, terminated := s.checkPRMerged(prs[0], "token")
+	if !resolved || terminated {
+		t.Fatalf("checkPRMerged = (resolved=%v, terminated=%v), want (true, false) for a mention-only merge", resolved, terminated)
+	}
+	clawStatus, state := clawStatusAndPRState(t, db, "claw-mention-merge", prs[0].id)
+	if clawStatus != "connected" {
+		t.Fatalf("claw status = %q, want connected (a stranger merging a mentioned PR must not destroy the sandbox)", clawStatus)
+	}
+	if state != "merged" {
+		t.Fatalf("PR state = %q, want merged (the resolution must persist)", state)
+	}
+	// Per-PR merge analytics must not fire for a merely-mentioned PR.
+	assertTaskRunPR(t, db, runID, "owner/repo", 1, taskRunPRStateOpen, false)
+}
+
+// FIX C: the closed-without-merge variant of the same asymmetry — a stray
+// mentioned PR being closed must not stop the claw or delete its rows.
+func TestMentionOnlyPRCloseDoesNotStopClaw(t *testing.T) {
+	s, db, stub, prs := multiPRFixture(t, "claw-mention-close", 1)
+	if _, err := db.Exec(`UPDATE claw_prs SET mention_only=1 WHERE id=?`, prs[0].id); err != nil {
+		t.Fatal(err)
+	}
+	stub.set(1, "closed")
+
+	resolved, terminated := s.checkPRMerged(prs[0], "token")
+	if !resolved || terminated {
+		t.Fatalf("checkPRMerged = (resolved=%v, terminated=%v), want (true, false) for a mention-only close", resolved, terminated)
+	}
+	clawStatus, state := clawStatusAndPRState(t, db, "claw-mention-close", prs[0].id)
+	if clawStatus != "connected" {
+		t.Fatalf("claw status = %q, want connected", clawStatus)
+	}
+	if state != "closed" {
+		t.Fatalf("PR state = %q, want closed", state)
+	}
+	var rows int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM claw_prs WHERE claw_id='claw-mention-close'`).Scan(&rows); err != nil {
+		t.Fatal(err)
+	}
+	if rows != 1 {
+		t.Fatalf("claw_prs rows = %d, want 1 (mention-only close must not run the stop path that deletes rows)", rows)
+	}
+}
+
+// FIX C: an unreachable (404) mention-only PR closes its row at the failure
+// bound but never escalates to stopping the claw.
+func TestUnreachableMentionOnlyPRNeverStopsClaw(t *testing.T) {
+	s, db, stub, prs := multiPRFixture(t, "claw-mention-unreachable", 1)
+	if _, err := db.Exec(`UPDATE claw_prs SET mention_only=1 WHERE id=?`, prs[0].id); err != nil {
+		t.Fatal(err)
+	}
+	stub.set(1, "missing")
+
+	for i := 0; i < prMergedPermanentFailureLimit; i++ {
+		if _, terminated := s.checkPRMerged(prs[0], "token"); terminated {
+			t.Fatal("checkPRMerged terminated a claw off an unreachable mention-only PR")
+		}
+	}
+	clawStatus, state := clawStatusAndPRState(t, db, "claw-mention-unreachable", prs[0].id)
+	if clawStatus != "connected" {
+		t.Fatalf("claw status = %q, want connected", clawStatus)
+	}
+	if state != "closed" {
+		t.Fatalf("PR state = %q, want closed (unreachable row must stop blocking finalization)", state)
+	}
+}
+
+// A permanently failing (404) PR is closed at the bound, but the claw survives
+// because another delivered PR is still open.
+func TestPermanentFailureClosesRowButClawSurvivesWithOtherOpenPR(t *testing.T) {
+	s, db, stub, prs := multiPRFixture(t, "claw-perm-partial", 1, 2)
+	stub.set(1, "missing")
+	stub.set(2, "open")
+
+	for i := 0; i < prMergedPermanentFailureLimit; i++ {
+		if _, terminated := s.checkPRMerged(prs[0], "token"); terminated {
+			t.Fatal("checkPRMerged terminated the claw while another delivered PR is open")
+		}
+	}
+	clawStatus, state := clawStatusAndPRState(t, db, "claw-perm-partial", prs[0].id)
+	if clawStatus != "connected" {
+		t.Fatalf("claw status = %q, want connected", clawStatus)
+	}
+	if state != "closed" {
+		t.Fatalf("unreachable PR state = %q, want closed", state)
+	}
+	if n, err := s.clawOpenPRCount("claw-perm-partial"); err != nil || n != 1 {
+		t.Fatalf("clawOpenPRCount = %d, %v; want 1 (the healthy PR keeps blocking finalization)", n, err)
+	}
+}
+
+// FIX B: the reopened-PR reset must not depend on the factory trigger kind.
+// A claw created by an issue-triggered factory never enters the pull_request
+// factory loop, so the reset has to run before it.
+func TestProcessGitHubPREventReopenedResetsRowForNonPRFactory(t *testing.T) {
+	s, db, _, prs := multiPRFixture(t, "claw-reopen-issue-factory", 1)
+	if _, err := db.Exec(`UPDATE claw_prs SET state='closed' WHERE id=?`, prs[0].id); err != nil {
+		t.Fatal(err)
+	}
+	s.mu.Lock()
+	s.hubCfg.Factories = []*types.FactoryConfig{{
+		Name:        "issues-factory",
+		Integration: "github",
+		Template:    "elasticclaw",
+		Trigger:     &types.GitHubTrigger{On: "issue"},
+	}}
+	s.mu.Unlock()
+
+	var payload githubPRPayload
+	payload.Action = "reopened"
+	payload.Number = 1
+	payload.Repository.FullName = "owner/repo"
+	payload.PullRequest.HTMLURL = prs[0].prURL
+	s.processGitHubPREvent(payload)
+
+	var state string
+	if err := db.QueryRow(`SELECT state FROM claw_prs WHERE id=?`, prs[0].id).Scan(&state); err != nil {
+		t.Fatal(err)
+	}
+	if state != "open" {
+		t.Fatalf("row state after reopened webhook = %q, want open (reset must run outside the pull_request factory loop)", state)
+	}
+	if n, err := s.clawOpenPRCount("claw-reopen-issue-factory"); err != nil || n != 1 {
+		t.Fatalf("clawOpenPRCount = %d, %v; want 1 (reopened PR gates finalization again)", n, err)
+	}
+}
+
+// FIX D: a PR registered from pipeline gate stdout (a delivery channel) blocks
+// finalization, unlike a PR mentioned in agent turn text.
+func TestPipelineGateRegisteredPRBlocksFinalization(t *testing.T) {
+	s, db, _, _ := multiPRFixture(t, "claw-gate-registered")
+	const url = "https://github.com/owner/repo/pull/31"
+
+	s.scanMessageForPRs("claw-gate-registered", `{"prs":["`+url+`"]}`, false)
+	var mentionOnly int
+	if err := db.QueryRow(`SELECT mention_only FROM claw_prs WHERE claw_id=? AND pr_url=?`, "claw-gate-registered", url).Scan(&mentionOnly); err != nil {
+		t.Fatal(err)
+	}
+	if mentionOnly != 0 {
+		t.Fatalf("mention_only for a gate-registered PR = %d, want 0 (gate stdout is a delivery channel)", mentionOnly)
+	}
+	if n, err := s.clawOpenPRCount("claw-gate-registered"); err != nil || n != 1 {
+		t.Fatalf("clawOpenPRCount = %d, %v; want 1 (gate-registered PR must block finalization)", n, err)
+	}
+}
+
+// A merge or close must be visible as turn progress: resolved rows survive in
+// claw_prs, so only the state/merged columns can register the change.
+func TestTurnProgressFingerprintChangesWhenPRMerges(t *testing.T) {
+	s, db, _, prs := multiPRFixture(t, "claw-fingerprint", 1)
+	before, err := s.turnProgressFingerprint("claw-fingerprint", "same response")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`UPDATE claw_prs SET state='merged', merged=1 WHERE id=?`, prs[0].id); err != nil {
+		t.Fatal(err)
+	}
+	after, err := s.turnProgressFingerprint("claw-fingerprint", "same response")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before == after {
+		t.Fatal("turnProgressFingerprint unchanged after a tracked PR merged — the merge is invisible as progress")
+	}
+}
+
+// A resolved row must not read as "PR out, awaiting humans" to the agent-idle
+// alert, or a claw carrying one would have its stuck alert suppressed for life.
+func TestAgentIdleHasClawPRsIgnoresResolvedRows(t *testing.T) {
+	s, db, _, prs := multiPRFixture(t, "claw-idle-prs", 1)
+	if !s.agentIdleHasClawPRs("claw-idle-prs") {
+		t.Fatal("agentIdleHasClawPRs = false with an open tracked PR, want true")
+	}
+	if _, err := db.Exec(`UPDATE claw_prs SET state='merged', merged=1 WHERE id=?`, prs[0].id); err != nil {
+		t.Fatal(err)
+	}
+	if s.agentIdleHasClawPRs("claw-idle-prs") {
+		t.Fatal("agentIdleHasClawPRs = true for a state='merged' row, want false")
 	}
 }

--- a/pkg/hub/pr_watcher_multi_pr_test.go
+++ b/pkg/hub/pr_watcher_multi_pr_test.go
@@ -545,6 +545,72 @@ func TestMergePRForClawMergesOpenSkipsResolved(t *testing.T) {
 	}
 }
 
+// The merge aggregate's inject kind is deliberate: the ALL-SUCCESS summary
+// uses the plain inject (a deliberately no-progress-paused claw must NOT be
+// woken moments before the watcher finalizes it), while the FAILURE summary
+// uses the external inject (a 405 base-out-of-date needs the agent to act, so
+// the pause must lift). Reverting the success aggregate to the external
+// variant flips the first assertion here.
+func TestMergePRForClawAggregateInjectKindRespectsNoProgressPause(t *testing.T) {
+	oldTransport := http.DefaultTransport
+	var mints int64
+	http.DefaultTransport = githubAppAnyTokenTransport{base: oldTransport, mints: &mints}
+	t.Cleanup(func() { http.DefaultTransport = oldTransport })
+
+	// PR 1 merges cleanly; PR 2's merge is rejected (405 base out of date).
+	gh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut && strings.HasSuffix(r.URL.Path, "/merge") {
+			parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+			var n int
+			fmt.Sscanf(parts[len(parts)-2], "%d", &n)
+			w.Header().Set("Content-Type", "application/json")
+			if n == 1 {
+				fmt.Fprint(w, `{"merged":true}`)
+			} else {
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				fmt.Fprint(w, `{"message":"Base branch was modified"}`)
+			}
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(gh.Close)
+
+	cfg := &types.HubConfig{GitHubApps: []*types.GitHubAppConfig{{AppID: 1, PrivateKeyPEM: testGitHubAppPEM(t)}}}
+	s, db := NewTestServerWithConfig(t, cfg, gh.URL, "", "")
+	for i, clawID := range []string{"claw-merge-paused-ok", "claw-merge-paused-fail"} {
+		if _, err := db.Exec(`INSERT INTO claws(id,tenant_id,name,template,status,no_progress_paused,created_at) VALUES(?,?,?,?,?,1,?)`, clawID, "test-tenant-id", clawID, "elasticclaw", "connected", now()); err != nil {
+			t.Fatal(err)
+		}
+		n := i + 1
+		if _, err := db.Exec(`INSERT INTO claw_prs(id,claw_id,repo,pr_number,pr_url,created_at) VALUES(?,?,?,?,?,?)`,
+			fmt.Sprintf("paused-pr-%d", n), clawID, "owner/repo", n, fmt.Sprintf("https://github.com/owner/repo/pull/%d", n), now()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	readPaused := func(clawID string) int {
+		t.Helper()
+		var paused int
+		if err := db.QueryRow(`SELECT no_progress_paused FROM claws WHERE id=?`, clawID).Scan(&paused); err != nil {
+			t.Fatal(err)
+		}
+		return paused
+	}
+
+	// All merges succeed: the success aggregate must leave the pause latched.
+	s.mergePRForClaw("claw-merge-paused-ok")
+	if got := readPaused("claw-merge-paused-ok"); got != 1 {
+		t.Fatalf("no_progress_paused after all-success merge aggregate = %d, want 1 (success summary must not wake a paused claw)", got)
+	}
+
+	// A merge fails: the failure aggregate must resume the pause so the agent
+	// can act on the 405.
+	s.mergePRForClaw("claw-merge-paused-fail")
+	if got := readPaused("claw-merge-paused-fail"); got != 0 {
+		t.Fatalf("no_progress_paused after failed merge aggregate = %d, want 0 (failure summary must wake the claw to act)", got)
+	}
+}
+
 // tokenMintOutageTransport serves the GitHub App endpoints like
 // githubAppAnyTokenTransport, but fails installation-token minting while fail
 // is set — simulating a token outage. Successful mints carry a near-immediate
@@ -705,6 +771,70 @@ func TestTokenMissClosedRowReArmedWhenTokenReturns(t *testing.T) {
 	s.mu.Unlock()
 	if tracked != 1 {
 		t.Fatalf("pollAllPRs visited %d row(s) after re-arm, want 1 (the row must be polled again)", tracked)
+	}
+}
+
+// The re-arm sweep runs before pollAllPRs's rate-limit gate, so it must carry
+// the gate itself: while defaultGitHubClient reports the quota exhausted, the
+// sweep's per-repo token mint is exactly the spend the gate exists to prevent,
+// and a row re-armed under the block would not be polled that pass anyway.
+// Reverting the early return re-arms the row while blocked and fails here.
+func TestTokenMissRearmSweepSkippedWhileRateLimitBlocked(t *testing.T) {
+	resetGitHubClientForTest(t)
+	fail := &atomic.Bool{}
+	fail.Store(true)
+	oldTransport := http.DefaultTransport
+	http.DefaultTransport = tokenMintOutageTransport{base: oldTransport, fail: fail}
+	t.Cleanup(func() { http.DefaultTransport = oldTransport })
+
+	stub := &multiPRGitHubStub{states: map[int]string{}}
+	gh := httptest.NewServer(stub.handler())
+	t.Cleanup(gh.Close)
+
+	cfg := &types.HubConfig{GitHubApps: []*types.GitHubAppConfig{{AppID: 1, PrivateKeyPEM: testGitHubAppPEM(t)}}}
+	s, db := NewTestServerWithConfig(t, cfg, gh.URL, "", "")
+	if _, err := db.Exec(`INSERT INTO claws(id,tenant_id,name,template,status,created_at) VALUES(?,?,?,?,?,?)`, "claw-rearm-blocked", "test-tenant-id", "claw-rearm-blocked", "elasticclaw", "connected", now()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO claw_prs(id,claw_id,repo,pr_number,pr_url,created_at) VALUES(?,?,?,?,?,?)`,
+		"pr-rearm-blocked", "claw-rearm-blocked", "owner/repo", 1, "https://github.com/owner/repo/pull/1", now()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Token outage runs the row into the bound: closed, re-arm candidate.
+	for i := 0; i < prMergedPermanentFailureLimit; i++ {
+		s.pollAllPRs()
+	}
+	readState := func() string {
+		t.Helper()
+		var state string
+		if err := db.QueryRow(`SELECT state FROM claw_prs WHERE id='pr-rearm-blocked'`).Scan(&state); err != nil {
+			t.Fatal(err)
+		}
+		return state
+	}
+	if got := readState(); got != "closed" {
+		t.Fatalf("row state after token outage = %q, want closed", got)
+	}
+
+	// Token minting recovers, but GitHub reports the quota exhausted: the
+	// sweep must not mint per-repo tokens or re-arm the row under the block.
+	fail.Store(false)
+	defaultGitHubClient.mu.Lock()
+	defaultGitHubClient.blockedUntil = time.Now().Add(time.Hour)
+	defaultGitHubClient.mu.Unlock()
+	s.pollAllPRs()
+	if got := readState(); got != "closed" {
+		t.Fatalf("row state after blocked pass = %q, want closed (sweep must not re-arm while rate-limit blocked)", got)
+	}
+
+	// Block lifts: the next pass re-arms the row again.
+	defaultGitHubClient.mu.Lock()
+	defaultGitHubClient.blockedUntil = time.Time{}
+	defaultGitHubClient.mu.Unlock()
+	s.pollAllPRs()
+	if got := readState(); got != "open" {
+		t.Fatalf("row state after the block lifted = %q, want open (re-armed for polling)", got)
 	}
 }
 

--- a/pkg/hub/pr_watcher_multi_pr_test.go
+++ b/pkg/hub/pr_watcher_multi_pr_test.go
@@ -1,0 +1,233 @@
+package hub
+
+import (
+	"database/sql"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+// multiPRGitHubStub serves repos/{repo}/pulls/{n} responses whose per-PR state
+// the test can flip mid-test, so one server can drive a claw through
+// "first PR resolved, second still open, second resolves later" sequences.
+type multiPRGitHubStub struct {
+	mu     sync.Mutex
+	states map[int]string // pr number -> "open" | "merged" | "closed"
+}
+
+func (m *multiPRGitHubStub) set(prNumber int, state string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.states[prNumber] = state
+}
+
+func (m *multiPRGitHubStub) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var prNumber int
+		parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+		fmt.Sscanf(parts[len(parts)-1], "%d", &prNumber)
+		m.mu.Lock()
+		state := m.states[prNumber]
+		m.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		switch state {
+		case "merged":
+			fmt.Fprintf(w, `{"state":"closed","merged":true,"merged_at":"2026-01-02T03:04:05Z","created_at":"2026-01-01T00:00:00Z","draft":false,"head":{"sha":"deadbeef"}}`)
+		case "closed":
+			fmt.Fprintf(w, `{"state":"closed","merged":false,"created_at":"2026-01-01T00:00:00Z","draft":false,"head":{"sha":"deadbeef"}}`)
+		default:
+			fmt.Fprintf(w, `{"state":"open","merged":false,"created_at":"2026-01-01T00:00:00Z","draft":false,"head":{"sha":"deadbeef"}}`)
+		}
+	}
+}
+
+// multiPRFixture wires a test server against the mutable GitHub stub and
+// inserts one claw tracking prNumbers, returning one clawPR per number.
+func multiPRFixture(t *testing.T, clawID string, prNumbers ...int) (*Server, *sql.DB, *multiPRGitHubStub, []clawPR) {
+	t.Helper()
+	stub := &multiPRGitHubStub{states: map[int]string{}}
+	gh := httptest.NewServer(stub.handler())
+	t.Cleanup(gh.Close)
+
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{}, gh.URL, "", "")
+	if _, err := db.Exec(`INSERT INTO claws(id,tenant_id,name,template,status,created_at) VALUES(?,?,?,?,?,?)`, clawID, "test-tenant-id", clawID, "elasticclaw", "connected", now()); err != nil {
+		t.Fatal(err)
+	}
+	var prs []clawPR
+	for _, n := range prNumbers {
+		prID := fmt.Sprintf("%s-pr-%d", clawID, n)
+		prURL := fmt.Sprintf("https://github.com/owner/repo/pull/%d", n)
+		if _, err := db.Exec(`INSERT INTO claw_prs(id,claw_id,repo,pr_number,pr_url,created_at) VALUES(?,?,?,?,?,?)`, prID, clawID, "owner/repo", n, prURL, now()); err != nil {
+			t.Fatal(err)
+		}
+		prs = append(prs, clawPR{id: prID, clawID: clawID, repo: "owner/repo", prNumber: n, prURL: prURL})
+	}
+	return s, db, stub, prs
+}
+
+func clawStatusAndPRState(t *testing.T, db *sql.DB, clawID, prID string) (clawStatus, prState string) {
+	t.Helper()
+	if err := db.QueryRow(`SELECT status FROM claws WHERE id=?`, clawID).Scan(&clawStatus); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT state FROM claw_prs WHERE id=?`, prID).Scan(&prState); err != nil {
+		t.Fatal(err)
+	}
+	return clawStatus, prState
+}
+
+func TestCheckPRMergedKeepsClawAliveUntilAllPRsResolved(t *testing.T) {
+	s, db, stub, prs := multiPRFixture(t, "claw-multi-merge", 1, 2)
+	stub.set(1, "merged")
+	stub.set(2, "open")
+
+	// PR 1 merges while PR 2 is still open: the claw must keep watching.
+	if terminated := s.checkPRMerged(prs[0], "token"); terminated {
+		t.Fatal("checkPRMerged terminated the claw with another PR still open")
+	}
+	clawStatus, stateA := clawStatusAndPRState(t, db, "claw-multi-merge", prs[0].id)
+	if clawStatus != "connected" {
+		t.Fatalf("claw status = %q, want connected", clawStatus)
+	}
+	if stateA != "merged" {
+		t.Fatalf("PR 1 state = %q, want merged", stateA)
+	}
+	var stateB string
+	if err := db.QueryRow(`SELECT state FROM claw_prs WHERE id=?`, prs[1].id).Scan(&stateB); err != nil {
+		t.Fatal(err)
+	}
+	if stateB != "open" {
+		t.Fatalf("PR 2 state = %q, want open", stateB)
+	}
+	var msg string
+	if err := db.QueryRow(`SELECT content FROM messages WHERE claw_id=? AND role='hub' ORDER BY created_at DESC LIMIT 1`, "claw-multi-merge").Scan(&msg); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(msg, "Still watching 1 other open PR(s)") {
+		t.Fatalf("unexpected hub message after partial merge: %q", msg)
+	}
+
+	// PR 2 merges: every tracked PR is resolved, so the claw terminates.
+	stub.set(2, "merged")
+	if terminated := s.checkPRMerged(prs[1], "token"); !terminated {
+		t.Fatal("checkPRMerged returned false, want true once all PRs are merged")
+	}
+	var clawStatusAfter string
+	if err := db.QueryRow(`SELECT status FROM claws WHERE id=?`, "claw-multi-merge").Scan(&clawStatusAfter); err != nil {
+		t.Fatal(err)
+	}
+	if clawStatusAfter != "deleted" {
+		t.Fatalf("claw status = %q, want deleted", clawStatusAfter)
+	}
+	var rows int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM claw_prs WHERE claw_id=?`, "claw-multi-merge").Scan(&rows); err != nil {
+		t.Fatal(err)
+	}
+	if rows != 0 {
+		t.Fatalf("claw_prs rows after termination = %d, want 0", rows)
+	}
+}
+
+func TestCheckPRMergedClosedWithoutMergeKeepsClawWatching(t *testing.T) {
+	s, db, stub, prs := multiPRFixture(t, "claw-multi-close", 1, 2)
+	stub.set(1, "closed")
+	stub.set(2, "open")
+
+	// PR 1 closed without merge while PR 2 is open: no stop, row marked closed.
+	if terminated := s.checkPRMerged(prs[0], "token"); terminated {
+		t.Fatal("checkPRMerged terminated the claw on a closed PR with another still open")
+	}
+	clawStatus, stateA := clawStatusAndPRState(t, db, "claw-multi-close", prs[0].id)
+	if clawStatus != "connected" {
+		t.Fatalf("claw status = %q, want connected", clawStatus)
+	}
+	if stateA != "closed" {
+		t.Fatalf("PR 1 state = %q, want closed", stateA)
+	}
+	var msg string
+	if err := db.QueryRow(`SELECT content FROM messages WHERE claw_id=? AND role='hub' ORDER BY created_at DESC LIMIT 1`, "claw-multi-close").Scan(&msg); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(msg, "closed without being merged") || !strings.Contains(msg, "Still watching 1 other open PR(s)") {
+		t.Fatalf("unexpected hub message after unmerged close: %q", msg)
+	}
+
+	// PR 2 merges: the closed row counts as resolved, so the claw terminates.
+	stub.set(2, "merged")
+	if terminated := s.checkPRMerged(prs[1], "token"); !terminated {
+		t.Fatal("checkPRMerged returned false, want true once the last open PR merged")
+	}
+	var clawStatusAfter string
+	if err := db.QueryRow(`SELECT status FROM claws WHERE id=?`, "claw-multi-close").Scan(&clawStatusAfter); err != nil {
+		t.Fatal(err)
+	}
+	if clawStatusAfter != "deleted" {
+		t.Fatalf("claw status = %q, want deleted", clawStatusAfter)
+	}
+}
+
+// Regression: a claw with a single tracked PR keeps the original contract —
+// its one merge terminates the claw in the same call.
+func TestCheckPRMergedSinglePRStillTerminates(t *testing.T) {
+	s, db, stub, prs := multiPRFixture(t, "claw-single", 1)
+	stub.set(1, "merged")
+
+	if terminated := s.checkPRMerged(prs[0], "token"); !terminated {
+		t.Fatal("checkPRMerged returned false, want true for the only tracked PR merging")
+	}
+	var clawStatus string
+	if err := db.QueryRow(`SELECT status FROM claws WHERE id=?`, "claw-single").Scan(&clawStatus); err != nil {
+		t.Fatal(err)
+	}
+	if clawStatus != "deleted" {
+		t.Fatalf("claw status = %q, want deleted", clawStatus)
+	}
+	var rows int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM claw_prs WHERE claw_id=?`, "claw-single").Scan(&rows); err != nil {
+		t.Fatal(err)
+	}
+	if rows != 0 {
+		t.Fatalf("claw_prs rows after termination = %d, want 0", rows)
+	}
+}
+
+// Resolved rows persist in claw_prs but must be excluded from polling.
+func TestPollAllPRsSkipsResolvedRows(t *testing.T) {
+	s, db, _, prs := multiPRFixture(t, "claw-poll-skip", 1, 2)
+	if _, err := db.Exec(`UPDATE claw_prs SET state='merged', merged=1 WHERE id=?`, prs[0].id); err != nil {
+		t.Fatal(err)
+	}
+
+	// pollAllPRs records how many rows its query selected before any GitHub
+	// call; only the still-open row may be visited.
+	s.pollAllPRs()
+	s.mu.Lock()
+	tracked := s.trackedPRCount
+	s.mu.Unlock()
+	if tracked != 1 {
+		t.Fatalf("pollAllPRs visited %d row(s), want 1 (resolved row must be skipped)", tracked)
+	}
+}
+
+// loadClawPRsByNumber feeds the webhook CI path and must not act on a PR that
+// is already resolved.
+func TestLoadClawPRsByNumberSkipsResolvedRows(t *testing.T) {
+	s, db, _, prs := multiPRFixture(t, "claw-load-skip", 1, 2)
+	if _, err := db.Exec(`UPDATE claw_prs SET state='closed' WHERE id=?`, prs[0].id); err != nil {
+		t.Fatal(err)
+	}
+
+	got := s.loadClawPRsByNumber("owner/repo", 1)
+	if len(got) != 0 {
+		t.Fatalf("loadClawPRsByNumber returned %d row(s) for a closed PR, want 0", len(got))
+	}
+	got = s.loadClawPRsByNumber("owner/repo", 2)
+	if len(got) != 1 {
+		t.Fatalf("loadClawPRsByNumber returned %d row(s) for an open PR, want 1", len(got))
+	}
+}

--- a/pkg/hub/pr_watcher_multi_pr_test.go
+++ b/pkg/hub/pr_watcher_multi_pr_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
@@ -87,7 +88,7 @@ func TestCheckPRMergedKeepsClawAliveUntilAllPRsResolved(t *testing.T) {
 	stub.set(2, "open")
 
 	// PR 1 merges while PR 2 is still open: the claw must keep watching.
-	if terminated := s.checkPRMerged(prs[0], "token"); terminated {
+	if _, terminated := s.checkPRMerged(prs[0], "token"); terminated {
 		t.Fatal("checkPRMerged terminated the claw with another PR still open")
 	}
 	clawStatus, stateA := clawStatusAndPRState(t, db, "claw-multi-merge", prs[0].id)
@@ -114,7 +115,7 @@ func TestCheckPRMergedKeepsClawAliveUntilAllPRsResolved(t *testing.T) {
 
 	// PR 2 merges: every tracked PR is resolved, so the claw terminates.
 	stub.set(2, "merged")
-	if terminated := s.checkPRMerged(prs[1], "token"); !terminated {
+	if _, terminated := s.checkPRMerged(prs[1], "token"); !terminated {
 		t.Fatal("checkPRMerged returned false, want true once all PRs are merged")
 	}
 	var clawStatusAfter string
@@ -139,7 +140,7 @@ func TestCheckPRMergedClosedWithoutMergeKeepsClawWatching(t *testing.T) {
 	stub.set(2, "open")
 
 	// PR 1 closed without merge while PR 2 is open: no stop, row marked closed.
-	if terminated := s.checkPRMerged(prs[0], "token"); terminated {
+	if _, terminated := s.checkPRMerged(prs[0], "token"); terminated {
 		t.Fatal("checkPRMerged terminated the claw on a closed PR with another still open")
 	}
 	clawStatus, stateA := clawStatusAndPRState(t, db, "claw-multi-close", prs[0].id)
@@ -159,7 +160,7 @@ func TestCheckPRMergedClosedWithoutMergeKeepsClawWatching(t *testing.T) {
 
 	// PR 2 merges: the closed row counts as resolved, so the claw terminates.
 	stub.set(2, "merged")
-	if terminated := s.checkPRMerged(prs[1], "token"); !terminated {
+	if _, terminated := s.checkPRMerged(prs[1], "token"); !terminated {
 		t.Fatal("checkPRMerged returned false, want true once the last open PR merged")
 	}
 	var clawStatusAfter string
@@ -177,7 +178,7 @@ func TestCheckPRMergedSinglePRStillTerminates(t *testing.T) {
 	s, db, stub, prs := multiPRFixture(t, "claw-single", 1)
 	stub.set(1, "merged")
 
-	if terminated := s.checkPRMerged(prs[0], "token"); !terminated {
+	if _, terminated := s.checkPRMerged(prs[0], "token"); !terminated {
 		t.Fatal("checkPRMerged returned false, want true for the only tracked PR merging")
 	}
 	var clawStatus string
@@ -229,5 +230,262 @@ func TestLoadClawPRsByNumberSkipsResolvedRows(t *testing.T) {
 	got = s.loadClawPRsByNumber("owner/repo", 2)
 	if len(got) != 1 {
 		t.Fatalf("loadClawPRsByNumber returned %d row(s) for an open PR, want 1", len(got))
+	}
+}
+
+// FIX 1: a mention-only row (a PR URL the agent merely mentioned in a message)
+// must never block finalization — when every delivered PR is resolved the claw
+// terminates even though the mentioned PR is still open.
+func TestMentionOnlyPRDoesNotBlockFinalization(t *testing.T) {
+	s, db, stub, prs := multiPRFixture(t, "claw-mention-only", 1, 2)
+	if _, err := db.Exec(`UPDATE claw_prs SET mention_only=1 WHERE id=?`, prs[1].id); err != nil {
+		t.Fatal(err)
+	}
+	stub.set(1, "merged")
+	stub.set(2, "open")
+
+	if _, terminated := s.checkPRMerged(prs[0], "token"); !terminated {
+		t.Fatal("checkPRMerged returned terminated=false, want true when the only delivered PR merged")
+	}
+	var clawStatus string
+	if err := db.QueryRow(`SELECT status FROM claws WHERE id=?`, "claw-mention-only").Scan(&clawStatus); err != nil {
+		t.Fatal(err)
+	}
+	if clawStatus != "deleted" {
+		t.Fatalf("claw status = %q, want deleted (mention-only PR must not pin the claw)", clawStatus)
+	}
+}
+
+// FIX 1: a PR the agent mentioned mid-work and then delivered via [DONE] must
+// be upgraded to delivered (mention_only=0) so it gates finalization.
+func TestDeliveryUpgradesMentionOnlyRow(t *testing.T) {
+	s, db, _, _ := multiPRFixture(t, "claw-upgrade")
+	const url = "https://github.com/owner/repo/pull/9"
+
+	s.scanMessageForPRs("claw-upgrade", "this depends on "+url)
+	var mentionOnly int
+	if err := db.QueryRow(`SELECT mention_only FROM claw_prs WHERE claw_id=? AND pr_url=?`, "claw-upgrade", url).Scan(&mentionOnly); err != nil {
+		t.Fatal(err)
+	}
+	if mentionOnly != 1 {
+		t.Fatalf("mention_only after scan = %d, want 1", mentionOnly)
+	}
+	if n, err := s.clawOpenPRCount("claw-upgrade"); err != nil || n != 0 {
+		t.Fatalf("clawOpenPRCount = %d, %v; want 0 (mention-only must not block)", n, err)
+	}
+
+	if failURL := s.registerDonePRURLs("claw-upgrade", []string{url}); failURL != "" {
+		t.Fatalf("registerDonePRURLs failed on %q", failURL)
+	}
+	if err := db.QueryRow(`SELECT mention_only FROM claw_prs WHERE claw_id=? AND pr_url=?`, "claw-upgrade", url).Scan(&mentionOnly); err != nil {
+		t.Fatal(err)
+	}
+	if mentionOnly != 0 {
+		t.Fatalf("mention_only after [DONE] delivery = %d, want 0", mentionOnly)
+	}
+	if n, err := s.clawOpenPRCount("claw-upgrade"); err != nil || n != 1 {
+		t.Fatalf("clawOpenPRCount = %d, %v; want 1 (delivered PR must block)", n, err)
+	}
+}
+
+// FIX 2: a reopened PR resets its resolved row so the watcher polls it again
+// and it gates finalization again.
+func TestReopenedPRResetMakesRowPolledAgain(t *testing.T) {
+	s, db, _, prs := multiPRFixture(t, "claw-reopen", 1, 2)
+	if _, err := db.Exec(`UPDATE claw_prs SET state='closed', merged=1, merged_at='2026-01-02T03:04:05Z' WHERE id=?`, prs[0].id); err != nil {
+		t.Fatal(err)
+	}
+
+	s.pollAllPRs()
+	s.mu.Lock()
+	tracked := s.trackedPRCount
+	s.mu.Unlock()
+	if tracked != 1 {
+		t.Fatalf("pollAllPRs visited %d row(s) before reopen, want 1", tracked)
+	}
+
+	s.resetReopenedClawPR("claw-reopen", prs[0].prURL)
+
+	var state string
+	var merged int
+	var mergedAt sql.NullString
+	if err := db.QueryRow(`SELECT state, merged, merged_at FROM claw_prs WHERE id=?`, prs[0].id).Scan(&state, &merged, &mergedAt); err != nil {
+		t.Fatal(err)
+	}
+	if state != "open" || merged != 0 || mergedAt.Valid {
+		t.Fatalf("row after reopen = state=%q merged=%d merged_at=%v, want open/0/NULL", state, merged, mergedAt)
+	}
+	if n, err := s.clawOpenPRCount("claw-reopen"); err != nil || n != 2 {
+		t.Fatalf("clawOpenPRCount = %d, %v; want 2 (reopened PR gates finalization again)", n, err)
+	}
+
+	s.pollAllPRs()
+	s.mu.Lock()
+	tracked = s.trackedPRCount
+	s.mu.Unlock()
+	if tracked != 2 {
+		t.Fatalf("pollAllPRs visited %d row(s) after reopen, want 2 (reopened row must be polled again)", tracked)
+	}
+}
+
+// FIX 5 safety rule: when the open-PR count query itself fails, checkPRMerged
+// must never terminate the claw — the next poll retries.
+func TestCheckPRMergedCountErrorDoesNotTerminate(t *testing.T) {
+	s, db, stub, prs := multiPRFixture(t, "claw-count-err", 1)
+	stub.set(1, "merged")
+
+	// Recreate claw_prs without the mention_only column: every UPDATE the
+	// merge path runs still works, but clawOpenPRCount (which filters on
+	// mention_only) fails.
+	if _, err := db.Exec(`CREATE TABLE claw_prs_slim AS SELECT id, claw_id, repo, pr_number, pr_url, title, state, merged, merged_at, permanent_failure_count, created_at FROM claw_prs`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`DROP TABLE claw_prs`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`ALTER TABLE claw_prs_slim RENAME TO claw_prs`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.clawOpenPRCount("claw-count-err"); err == nil {
+		t.Fatal("test setup broken: clawOpenPRCount did not fail")
+	}
+
+	if _, terminated := s.checkPRMerged(prs[0], "token"); terminated {
+		t.Fatal("checkPRMerged terminated the claw on a failed open-PR count")
+	}
+	var clawStatus string
+	if err := db.QueryRow(`SELECT status FROM claws WHERE id=?`, "claw-count-err").Scan(&clawStatus); err != nil {
+		t.Fatal(err)
+	}
+	if clawStatus != "connected" {
+		t.Fatalf("claw status = %q, want connected (unchanged on count error)", clawStatus)
+	}
+}
+
+// FIX 3: a single-PR claw whose PR is closed without merge is stopped AND its
+// claw_prs rows are deleted, so a retried claw under the same id does not come
+// back carrying a resolved row that suppresses the agent-idle alert.
+func TestSinglePRClosedWithoutMergeDeletesRowsAndStopsClaw(t *testing.T) {
+	s, db, stub, prs := multiPRFixture(t, "claw-close-single", 1)
+	stub.set(1, "closed")
+
+	if _, terminated := s.checkPRMerged(prs[0], "token"); !terminated {
+		t.Fatal("checkPRMerged returned terminated=false, want true for the only delivered PR closing")
+	}
+	var rows int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM claw_prs WHERE claw_id=?`, "claw-close-single").Scan(&rows); err != nil {
+		t.Fatal(err)
+	}
+	if rows != 0 {
+		t.Fatalf("claw_prs rows after closed-without-merge stop = %d, want 0", rows)
+	}
+	// stopAgentWithReason runs in a goroutine and may sleep several seconds
+	// when the retry disposition is indeterminate under DB contention.
+	deadline := time.Now().Add(15 * time.Second)
+	for {
+		var status string
+		_ = db.QueryRow(`SELECT status FROM claws WHERE id=?`, "claw-close-single").Scan(&status)
+		if status != "connected" {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("claw status = %q, want a stopped status", status)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// Per-PR analytics must fire on a NON-final merge: after PR A merges with B
+// still open, A's task_run_prs row already records merged=1. A refactor that
+// moves the analytics below the all-PRs-resolved gate fails here.
+func TestPartialMergeRecordsPerPRAnalytics(t *testing.T) {
+	s, db, stub, prs := multiPRFixture(t, "claw-partial-analytics", 1, 2)
+	runID, _ := startTaskRunForTest(t, s, "claw-partial-analytics", "partial-analytics")
+	associatePRForTest(t, s, runID, "owner/repo", 1, taskRunPRStateOpen)
+	associatePRForTest(t, s, runID, "owner/repo", 2, taskRunPRStateOpen)
+	stub.set(1, "merged")
+	stub.set(2, "open")
+
+	if _, terminated := s.checkPRMerged(prs[0], "token"); terminated {
+		t.Fatal("checkPRMerged terminated the claw with PR 2 still open")
+	}
+	assertTaskRunPR(t, db, runID, "owner/repo", 1, taskRunPRStateClosed, true)
+	assertTaskRunPR(t, db, runID, "owner/repo", 2, taskRunPRStateOpen, false)
+}
+
+// FIX 7: mergePRForClaw merges every open tracked PR exactly once, skips rows
+// already resolved, and keeps the "no tracked PR" early return.
+func TestMergePRForClawMergesOpenSkipsResolved(t *testing.T) {
+	oldTransport := http.DefaultTransport
+	var mints int64
+	http.DefaultTransport = githubAppAnyTokenTransport{base: oldTransport, mints: &mints}
+	t.Cleanup(func() { http.DefaultTransport = oldTransport })
+
+	var mu sync.Mutex
+	mergeCalls := map[int]int{}
+	gh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut && strings.HasSuffix(r.URL.Path, "/merge") {
+			parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+			var n int
+			fmt.Sscanf(parts[len(parts)-2], "%d", &n)
+			mu.Lock()
+			mergeCalls[n]++
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"merged":true}`)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(gh.Close)
+
+	cfg := &types.HubConfig{GitHubApps: []*types.GitHubAppConfig{{AppID: 1, PrivateKeyPEM: testGitHubAppPEM(t)}}}
+	s, db := NewTestServerWithConfig(t, cfg, gh.URL, "", "")
+	for _, clawID := range []string{"claw-merge-batch", "claw-merge-none"} {
+		if _, err := db.Exec(`INSERT INTO claws(id,tenant_id,name,template,status,created_at) VALUES(?,?,?,?,?,?)`, clawID, "test-tenant-id", clawID, "elasticclaw", "connected", now()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for n := 1; n <= 3; n++ {
+		if _, err := db.Exec(`INSERT INTO claw_prs(id,claw_id,repo,pr_number,pr_url,created_at) VALUES(?,?,?,?,?,?)`,
+			fmt.Sprintf("merge-pr-%d", n), "claw-merge-batch", "owner/repo", n, fmt.Sprintf("https://github.com/owner/repo/pull/%d", n), now()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := db.Exec(`UPDATE claw_prs SET state='merged', merged=1 WHERE id='merge-pr-3'`); err != nil {
+		t.Fatal(err)
+	}
+
+	s.mergePRForClaw("claw-merge-batch")
+	mu.Lock()
+	got := map[int]int{}
+	for k, v := range mergeCalls {
+		got[k] = v
+	}
+	mu.Unlock()
+	if got[1] != 1 || got[2] != 1 {
+		t.Fatalf("merge PUTs = %v, want exactly one for PR 1 and PR 2", got)
+	}
+	if got[3] != 0 {
+		t.Fatalf("merge PUTs = %v, PR 3 is already merged and must be skipped", got)
+	}
+
+	// "No tracked PR" early return: nothing merged, nothing injected.
+	s.mergePRForClaw("claw-merge-none")
+	mu.Lock()
+	total := 0
+	for _, v := range mergeCalls {
+		total += v
+	}
+	mu.Unlock()
+	if total != 2 {
+		t.Fatalf("merge PUTs after empty-claw call = %d, want 2 (early return must not merge)", total)
+	}
+	var msgs int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id='claw-merge-none'`).Scan(&msgs); err != nil {
+		t.Fatal(err)
+	}
+	if msgs != 0 {
+		t.Fatalf("messages injected for claw with no tracked PRs = %d, want 0", msgs)
 	}
 }

--- a/pkg/hub/pr_watcher_test.go
+++ b/pkg/hub/pr_watcher_test.go
@@ -275,7 +275,7 @@ func TestCheckPRMergedResetsCounterBetweenPermanentFailures(t *testing.T) {
 	insertWatcherTestPR(t, db, "claw-mix", "pr-mix")
 	pr := clawPR{id: "pr-mix", clawID: "claw-mix", repo: "owner/repo", prNumber: 1, prURL: "https://github.com/owner/repo/pull/1"}
 	for i := 0; i < (prMergedPermanentFailureLimit+1)*2; i++ {
-		if s.checkPRMerged(pr, "token") {
+		if _, terminated := s.checkPRMerged(pr, "token"); terminated {
 			t.Fatalf("checkPRMerged terminated on non-consecutive failures")
 		}
 	}
@@ -429,7 +429,7 @@ func TestStorePRMentionConcurrentDuplicate(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			_, errs[i] = s.storePRMention("claw-dup", "owner/repo", 7, "https://github.com/owner/repo/pull/7")
+			_, errs[i] = s.storePRMention("claw-dup", "owner/repo", 7, "https://github.com/owner/repo/pull/7", true)
 		}(i)
 	}
 	wg.Wait()

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1358,7 +1358,10 @@ func (s *Server) handleClaws(w http.ResponseWriter, r *http.Request) {
 				placeholders[i] = "?"
 				args[i] = claw.ID
 			}
-			prRows, err := s.db.Query(`SELECT cp.claw_id, COUNT(*) FROM claw_prs cp JOIN claws c ON c.id = cp.claw_id WHERE cp.claw_id IN (`+strings.Join(placeholders, ",")+`) AND cp.state = 'open' AND c.status NOT IN ('deleted','error','offline') GROUP BY cp.claw_id`, args...)
+			// Same predicate as clawOpenPRCount (unresolved AND delivered): the
+			// dashboard count must agree with the finalization gate, or a claw
+			// can show "1 open PR" while nothing blocks it from finalizing.
+			prRows, err := s.db.Query(`SELECT cp.claw_id, COUNT(*) FROM claw_prs cp JOIN claws c ON c.id = cp.claw_id WHERE cp.claw_id IN (`+strings.Join(placeholders, ",")+`) AND cp.state NOT IN ('merged','closed') AND cp.mention_only=0 AND c.status NOT IN ('deleted','error','offline') GROUP BY cp.claw_id`, args...)
 			if err != nil {
 				log.Printf("handleClaws open PR count query error: %v", err)
 				http.Error(w, fmt.Sprintf("db error: %v", err), http.StatusInternalServerError)
@@ -3129,7 +3132,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				// A transport error can quote a repository URL (git and CI
 				// failures routinely do). Arming the PR watcher on text the
 				// agent never wrote would watch a PR nobody opened.
-				go s.scanMessageForPRs(clawID, turnContent)
+				go s.scanMessageForPRs(clawID, turnContent, true)
 			}
 			// Detect tool error loops and inject a corrective message
 			if !automaticContinuationPaused && detectToolLoop(hm.Content) {

--- a/pkg/hub/task_run_analytics_test.go
+++ b/pkg/hub/task_run_analytics_test.go
@@ -1229,7 +1229,7 @@ func TestTaskRunPRMentionInstrumentationAssociatesPROpenedEvent(t *testing.T) {
 	s, db := newTaskRunAnalyticsTestServer(t, "claw-pr-mention")
 	runID, _ := startTaskRunForTest(t, s, "claw-pr-mention", "mention")
 
-	s.storePRMention("claw-pr-mention", "elastic/claw", 71, "https://github.com/elastic/claw/pull/71")
+	s.storePRMention("claw-pr-mention", "elastic/claw", 71, "https://github.com/elastic/claw/pull/71", true)
 
 	assertTaskRunPR(t, db, runID, "elastic/claw", 71, taskRunPRStateOpen, false)
 	assertTaskRunEventExists(t, db, runID, taskRunEventPRAssociated, taskRunInteractionNeutral)
@@ -1243,7 +1243,7 @@ func TestTaskRunPRMentionAnalyticsFailureDoesNotRollbackPRTracking(t *testing.T)
 		t.Fatalf("drop task_run_prs: %v", err)
 	}
 
-	s.storePRMention("claw-pr-mention-failure", "elastic/claw", 76, "https://github.com/elastic/claw/pull/76")
+	s.storePRMention("claw-pr-mention-failure", "elastic/claw", 76, "https://github.com/elastic/claw/pull/76", true)
 
 	var count int
 	if err := db.QueryRow(`

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -273,6 +273,8 @@ export interface ClawPR {
   state: "open" | "merged" | "closed"
   merged: boolean
   mergedAt?: string
+  /** True for PR URLs the agent merely mentioned in a message; only delivered PRs (false) gate claw finalization. */
+  mentionOnly: boolean
 }
 
 export async function fetchClawPRs(clawId: string): Promise<ClawPR[]> {


### PR DESCRIPTION
## Problem

The hub terminated a claw as soon as **any** single tracked PR was merged. `checkPRMerged` ran `DELETE FROM claw_prs WHERE claw_id=?` and tore the claw down on the first merge, so an agent that delivered several PRs lost merge detection, CI monitoring and review-comment forwarding for every remaining one, and the tracker issue moved to `DoneStatus` while half the delivery was still open.

Multi-PR was already supported at *registration* — `handleClawDoneSignal` parses and validates every URL in a `[DONE]` message. Only finalization was single-PR.

## Rule

> A claw is finalized only when every **delivered** PR it tracks is merged or closed.

## What that required

The gate itself is small. Most of this branch is the consequences.

**`claw_prs` is not a curated set of delivered PRs.** `scanMessageForPRs` registers any PR URL the agent happens to mention in a turn. Under the old contract a stray row was harmless — the first merge tore the claw down. Under a gate it pins the claw forever. So the table gained `mention_only`, set only by the mention scanner and cleared when the same URL is later delivered via `[DONE]`. Default is 0 (delivered), so pre-existing rows keep blocking and no backfill is needed.

**Ownership has to cut both ways.** A mentioned PR must not *block* finalization, but it must also never *trigger* one. Before that was closed, a PR the agent merely linked would destroy the sandbox and move the tracker issue to Done when a stranger merged it; `pr_conditions` would stop the claw on a stale linked PR or advance its pipeline off a stranger's green CI; and `mergePRForClaw` could `PUT /merge` against a third party's PR. A mention-only row is now a polling target — CI, comments and reviews still reach the agent — and nothing else.

**Rows that survive instead of being deleted change what other queries mean.** The agent-idle alert and the idle Slack notification read "a `claw_prs` row exists" as "PR out, awaiting humans"; the stop path lost the DELETE it relied on; `turnProgressFingerprint` stopped seeing merges as progress; the dashboard's open-PR count and the checkpoint PR list drifted from the gate. All realigned.

**Pipeline gate stdout is a delivery channel, not a mention.** `verify-github-pr-links` emits the claw's own PR URLs. Registering those as mentions would have made the gate a no-op for every pipeline-driven claw — the original bug, reintroduced.

## Bounds

A gate creates a new way to fail: a delivered PR that never resolves pins the claw. Each route is bounded, and none of the bounds may kill a healthy claw:

- **No token for the repo** → `token_miss_count` closes the row after 5 consecutive misses, without terminating (a transient installation-token failure must not be fatal), and a sweep re-arms the row once the token resolves again.
- **Permanent API error** (404/410/401) → `permanent_failure_count` closes that row and re-runs the gate, instead of killing a claw whose other PRs are fine.
- **PR reopened after being closed** → the reset moved out of the factory loop, where a `pull_request`-trigger guard made it unreachable for issue-triggered claws — exactly the multi-PR case.

The two counters are separate columns so neither bound can disarm the other.

## Known limits, not addressed here

- A pipeline stage declared `terminal` still deletes the claw without consulting the gate. That is the pipeline's own contract, unchanged by this branch.
- A repo answering 5xx forever increments no counter (every transient error resets it), so such a claw is pinned until an unrelated bound fires. Pre-existing.
- `createClawForGitHubPR` and `processGitHubPRPollItem` decide factory 1:1 dedupe without filtering `mention_only`, so a third-party PR linked by an agent blocks claw creation for that PR while the agent lives. Pre-existing; worth a follow-up.

## Review

Four adversarial review rounds, each driven by throwaway Go probes against a fixture DB rather than reading. Each round found a real blocker the previous round's report claimed was handled — including one introduced by a fix (a bound that escalated to `stopAgentWithReason`, which a 2-minute GitHub App token blip would have turned into a fleet-wide claw killer). The final round enumerated every path to a terminal state and confirmed each requires `mention_only=0`.

Every new test was verified to go **red** when its fix is reverted. Three that passed both ways — a status read racing a goroutine, a test calling a helper instead of the call site, and an inject-kind choice — were rewritten.

## Verification

`go build ./...`, `go vet ./pkg/hub/...` and `gofmt` clean. `go test ./pkg/hub/...` passes except three pre-existing failures that read the host hub config and hit the real GitHub API (`TestDoneSignalRejectedWhenPRPersistenceFails`, `TestHandleClawDoneSignal_IssueLessWorkflowWatchesPR`, `TestCompleteIssueLessDoneClawKeepsRunningOnStoreFailure`) — identical on the merge-base.

No UI change beyond `ClawPR.mentionOnly` in the API payload; `web` typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
