### PR TITLE
fix(hub): raise gateway-unhealthy escalation default to 40 checks

### DIFF
--- a/pkg/hub/claw_retry_test.go
+++ b/pkg/hub/claw_retry_test.go
@@ -394,13 +394,13 @@ func TestRetryCheckpointChoicePrecedesTerminationCheckpoint(t *testing.T) {
 }
 
 func TestHealthEscalationThresholds(t *testing.T) {
-	if heartbeatShouldEscalate(11, defaultGatewayUnhealthyMax, "connected", true) {
+	if heartbeatShouldEscalate(defaultGatewayUnhealthyMax-1, defaultGatewayUnhealthyMax, "connected", true) {
 		t.Fatal("heartbeat escalated before threshold")
 	}
-	if !heartbeatShouldEscalate(12, defaultGatewayUnhealthyMax, "connected", true) {
+	if !heartbeatShouldEscalate(defaultGatewayUnhealthyMax, defaultGatewayUnhealthyMax, "connected", true) {
 		t.Fatal("heartbeat did not escalate at threshold")
 	}
-	if heartbeatShouldEscalate(12, defaultGatewayUnhealthyMax, "provisioning", true) || heartbeatShouldEscalate(12, defaultGatewayUnhealthyMax, "connected", false) {
+	if heartbeatShouldEscalate(defaultGatewayUnhealthyMax, defaultGatewayUnhealthyMax, "provisioning", true) || heartbeatShouldEscalate(defaultGatewayUnhealthyMax, defaultGatewayUnhealthyMax, "connected", false) {
 		t.Fatal("heartbeat escalated an ineligible claw")
 	}
 

--- a/pkg/hub/reaper_settings_test.go
+++ b/pkg/hub/reaper_settings_test.go
@@ -15,6 +15,25 @@ func TestLivenessSettingsWatchdogDefaults(t *testing.T) {
 	}
 }
 
+// TestLivenessSettingsGatewayUnhealthyDefault pins the escalation threshold to a
+// literal: at the bridge's 15s heartbeat cadence it must stay well clear of the
+// ~2.8 minute event-loop stalls a busy gateway produces, so a lower value would
+// silently reintroduce the mid-work replacements it was raised to stop.
+func TestLivenessSettingsGatewayUnhealthyDefault(t *testing.T) {
+	s := &Server{}
+	if got := s.livenessSettings().gatewayUnhealthyMax; got != 40 {
+		t.Fatalf("default gatewayUnhealthyMax = %d, want 40", got)
+	}
+
+	checks := 25
+	s = &Server{hubCfg: &types.HubConfig{Liveness: &types.LivenessConfig{
+		GatewayUnhealthyChecks: &checks,
+	}}}
+	if got := s.livenessSettings().gatewayUnhealthyMax; got != 25 {
+		t.Fatalf("configured gatewayUnhealthyMax = %d, want 25", got)
+	}
+}
+
 func TestLivenessSettingsWatchdogConfig(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -275,7 +275,24 @@ type clawConn struct {
 }
 
 const (
-	defaultGatewayUnhealthyMax = 12
+	// defaultGatewayUnhealthyMax counts consecutive bridge heartbeats reporting
+	// gateway_healthy=false before the hub escalates and replaces the claw. The
+	// bridge heartbeats every 15s (startHubKeepalives in cmd/claw-bridge), so
+	// 40 checks is roughly 10 minutes of wall time.
+	//
+	// It is deliberately generous because the health probe cannot distinguish
+	// "dead" from "busy": checkGateway does GET /healthz against the gateway,
+	// and that endpoint is served by the same Node event loop the agent work
+	// blocks. In production (2026-08-21) heavy agent turns blocked the loop for
+	// 148-169s with cpuCoreRatio ~0.91 and the gateway still completing
+	// Anthropic API calls — genuinely busy, not wedged. The old default of 12
+	// (~3 minutes) sat barely above that stall, so healthy claws were destroyed
+	// mid-work, some without a usable checkpoint.
+	//
+	// A truly dead gateway is still caught: by this threshold at ~10 minutes,
+	// and sooner or independently by the offline reaper (the bridge stops
+	// heartbeating entirely) and the busy-turn watchdog.
+	defaultGatewayUnhealthyMax = 40
 	// minBusyTurnMax is the floor for the busy-turn watchdog. The watchdog is a
 	// backstop for a lost terminal message, not a turn cap: the bridge owns the
 	// cap (agentTurnTimeout, 1h) and always ends a turn with a message. So this


### PR DESCRIPTION
## Problem

The hub was destroying healthy agents in the middle of their work.

`claw-retry` replaces a claw after `agent process unhealthy for N consecutive heartbeats`. On 2026-08-21 that fired repeatedly across four separate tickets in one afternoon. The gateways were not dead — they were busy.

Diagnostics captured from a live sandbox:

```
[diagnostic] liveness warning: reasons=event_loop_delay,event_loop_utilization,cpu
  eventLoopDelayP99Ms=148579 eventLoopUtilization=1 cpuCoreRatio=0.91
  work=[active=agent:main:dashboard:...(processing/model_call,q=1,age=858s)]
```

`cpuCoreRatio=0.91` is genuinely busy, not wedged, and throughout the stall the gateway kept completing Anthropic API calls with `status=200`.

The health probe cannot tell the difference. `checkGateway` does `GET /healthz` against the gateway, and that endpoint is served by the **same Node event loop** the agent work blocks. So the probe times out and the heartbeat reports unhealthy while the very same payload says the process is fine:

```
[heartbeat] sending: gateway_healthy=false gateway_ready=true context_usage=5% restart_count=0
```

The bridge heartbeats every 15s, so the old default of 12 checks was **3 minutes** — barely above the measured 148–169s (2.5–2.8 min) stall. That tiny margin is why the outcome looked random: some claws logged `recovered after 9`, `after 10`, `after 11` unhealthy checks and survived; others crossed 12 and were replaced. Some replacements carried `checkpoint=""`, so the work was lost outright rather than resumed.

## Change

Raise `defaultGatewayUnhealthyMax` from 12 to 40 — roughly 10 minutes at the bridge's cadence — and document the cadence, the measured stall range, and the reasoning on the constant itself.

Nothing else changes: `checkGateway`, the bridge, and `escalateGatewayHealthFailure`'s logic are untouched, and the threshold remains configurable via `liveness.gateway_unhealthy_checks`.

A truly dead gateway is still caught — by this threshold at ~10 minutes, and independently by the offline reaper (a dead sandbox stops heartbeating entirely, which is the faster path) and the busy-turn watchdog.

## Tests

`TestHealthEscalationThresholds` hardcoded `11`/`12` as the unhealthy count while passing `defaultGatewayUnhealthyMax` as the max. Left alone it would have kept passing while asserting nothing useful — the first case becomes vacuous against a max of 40. Both are now derived from the constant.

Added `TestLivenessSettingsGatewayUnhealthyDefault`, covering the new default and that an explicit config value still overrides it. Verified it fails against the old value:

```
reaper_settings_test.go:25: default gatewayUnhealthyMax = 12, want 40
```

## Scope

This raises the margin; it does not fix the signal. A probe that rides the same event loop it is measuring can never distinguish "blocked" from "dead", and the information that would settle it — `gateway_ready`, `restart_count`, and the gateway's own `cpuCoreRatio` — is already present but unused. A liveness signal served off the blocked loop is an OpenClaw-side change, not one this repo can make.

The Faster hub already has `liveness.gateway_unhealthy_checks: 40` set explicitly as an operational mitigation, so it is unaffected either way; this makes every other deployment inherit the same headroom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
