### PR TITLE
fix(hub): do not alert agent stalled while spawned subagents run

### DIFF
--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -1971,6 +1971,96 @@ func (gs *gatewaySession) refreshContextUsage(ctx context.Context) {
 	gs.ctxMu.Unlock()
 }
 
+// countActiveSubagents extracts, from a sessions.list response, how many
+// spawned subagent sessions currently have a run in flight. Subagent sessions
+// are recognised by the ":subagent:" marker in their key — the agent-id half
+// of the key varies across OpenClaw versions (there is an upstream issue about
+// exactly that), the marker does not. Only an explicit hasActiveRun=true
+// counts: a missing field is "no information", and activeRunIds is
+// deliberately not consulted at all — it may be absent or empty even while
+// hasActiveRun is true, so its absence must never be read as "idle".
+//
+// A payload without a sessions index at all is an error, not zero: zero is a
+// positive "nothing running" claim the hub acts on, and it must never be
+// fabricated from a response shape we did not understand.
+func countActiveSubagents(payload []byte) (int, error) {
+	var parsed struct {
+		Sessions *[]struct {
+			Key          string `json:"key"`
+			HasActiveRun *bool  `json:"hasActiveRun"`
+		} `json:"sessions"`
+	}
+	if err := json.Unmarshal(payload, &parsed); err != nil {
+		return 0, fmt.Errorf("unmarshal sessions.list response: %w", err)
+	}
+	if parsed.Sessions == nil {
+		return 0, fmt.Errorf("sessions.list response carries no sessions index")
+	}
+	count := 0
+	sawAnyKey := false
+	for _, row := range *parsed.Sessions {
+		if row.Key != "" {
+			sawAnyKey = true
+		}
+		if strings.Contains(row.Key, ":subagent:") && row.HasActiveRun != nil && *row.HasActiveRun {
+			count++
+		}
+	}
+	// A non-empty index in which no row carried a key is the row-level version
+	// of the shape problem above: the gateway is telling us about sessions in
+	// a vocabulary we do not speak (the upstream key-shape drift again), so
+	// zero here would be fabricated, not observed.
+	if len(*parsed.Sessions) > 0 && !sawAnyKey {
+		return 0, fmt.Errorf("sessions.list rows carry no recognisable key")
+	}
+	return count, nil
+}
+
+// subagentHeartbeatFields turns one subagent-activity poll into the optional
+// heartbeat fields and a log-line suffix. The contract the hub depends on:
+// both fields are present iff the poll actually succeeded — a not-ready
+// gateway or any poll error yields nil, so the hub sees "no information"
+// rather than a fabricated "nothing running" (which it would treat as
+// positive evidence and clear its suppression state). failLogged quiets the
+// error log after the first miss, since an older gateway without
+// sessions.list would otherwise fail every heartbeat forever; a success
+// re-arms it.
+func subagentHeartbeatFields(gatewayReady bool, poll func() (int, error), failLogged *bool) (map[string]interface{}, string) {
+	if !gatewayReady {
+		return nil, ""
+	}
+	count, err := poll()
+	if err != nil {
+		if !*failLogged {
+			log.Printf("[heartbeat] subagent activity poll failed (quieting until it recovers): %v", err)
+			*failLogged = true
+		}
+		return nil, ""
+	}
+	*failLogged = false
+	fields := map[string]interface{}{
+		"subagents_active":      count > 0,
+		"subagent_active_count": count,
+	}
+	return fields, fmt.Sprintf(" subagents_active=%v subagent_active_count=%d", count > 0, count)
+}
+
+// pollSubagentActivity polls sessions.list and reports how many spawned
+// subagent sessions have a run in flight. Best-effort, same shape as
+// refreshContextUsage: bounded per-call context, and the caller logs and moves
+// on. The hub uses the result to tell "parked on sessions_yield while spawned
+// work runs" apart from a genuine stall, which per-session turn state cannot
+// see (subagent activity does not make the parent session busy).
+func (gs *gatewaySession) pollSubagentActivity(ctx context.Context) (int, error) {
+	pollCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	resp, err := gs.sendReq(pollCtx, "sessions.list", map[string]interface{}{})
+	if err != nil {
+		return 0, err
+	}
+	return countActiveSubagents(resp.Payload)
+}
+
 // ContextUsage returns the last-known context window usage percentage (0-100).
 func (gs *gatewaySession) ContextUsage() int {
 	gs.ctxMu.RLock()
@@ -4589,6 +4679,11 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 	}
 	proxy.mu.Unlock()
 
+	// Heartbeats run on a single goroutine (the ticker in startHubKeepalives),
+	// so this needs no lock. It quiets the sessions.list failure log after the
+	// first miss: an older gateway without the method would otherwise fail
+	// every 15s forever.
+	subagentPollFailLogged := false
 	startHubKeepalives(connCtx, func(pingCtx context.Context) error {
 		pingCtx, cancel := context.WithTimeout(pingCtx, 10*time.Second)
 		defer cancel()
@@ -4612,8 +4707,19 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 		cu := gwSession.ContextUsage()
 		usage := gwSession.Usage()
 		restarts := gatewayRestartBase + gatewayRestartCount()
-		log.Printf("[heartbeat] sending: gateway_healthy=%v gateway_ready=%v context_usage=%d%% restart_count=%d", health, gwSession.IsReady(), cu, restarts)
+		// Best-effort subagent activity: subagentHeartbeatFields returns both
+		// fields only for a successful poll, so on any failure (RPC error,
+		// method not found on an older gateway, unparseable payload) the hub
+		// falls back to judging idleness without them, rather than being fed
+		// a fabricated "nothing running".
+		subagentFields, subagentLog := subagentHeartbeatFields(gwSession.IsReady(), func() (int, error) {
+			return gwSession.pollSubagentActivity(connCtx)
+		}, &subagentPollFailLogged)
+		log.Printf("[heartbeat] sending: gateway_healthy=%v gateway_ready=%v context_usage=%d%% restart_count=%d%s", health, gwSession.IsReady(), cu, restarts, subagentLog)
 		heartbeatPayload := map[string]interface{}{"gateway_healthy": health, "gateway_ready": gwSession.IsReady(), "context_usage": cu, "restart_count": restarts}
+		for k, v := range subagentFields {
+			heartbeatPayload[k] = v
+		}
 		if usage.sessionKey != "" {
 			heartbeatPayload["session_key"] = usage.sessionKey
 		}

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/base64"
@@ -8,6 +9,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"log"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -2862,5 +2864,114 @@ func TestReplayQueuedRunsTurnForInputs(t *testing.T) {
 	}
 	if len(ran) != 1 || ran[0] != "do the work" {
 		t.Fatalf("expected runTurn invoked with the input, got %v", ran)
+	}
+}
+
+// countActiveSubagents feeds the heartbeat's subagents_active fields, which
+// suppress the hub's "Agent stalled" notification — so it must count only
+// spawned subagent sessions with a run actually in flight, and any payload it
+// cannot understand must be an error (fields omitted from the heartbeat),
+// never a fabricated zero.
+func TestCountActiveSubagents(t *testing.T) {
+	payload := []byte(`{"sessions":[
+		{"key":"agent:main:subagent:abc","hasActiveRun":true},
+		{"key":"agent:main:subagent:def","hasActiveRun":false},
+		{"key":"agent:main:subagent:ghi"},
+		{"key":"agent:main","hasActiveRun":true},
+		{"key":"other:subagent:jkl","hasActiveRun":true,"activeRunIds":[]}
+	]}`)
+	count, err := countActiveSubagents(payload)
+	if err != nil {
+		t.Fatalf("countActiveSubagents: %v", err)
+	}
+	// abc and jkl only: the main session's own run is not subagent work, a
+	// missing hasActiveRun is "no information" rather than active, and an
+	// empty activeRunIds must not override an explicit hasActiveRun=true.
+	if count != 2 {
+		t.Fatalf("count = %d, want 2", count)
+	}
+
+	// An empty index is a successful "nothing running".
+	count, err = countActiveSubagents([]byte(`{"sessions":[]}`))
+	if err != nil || count != 0 {
+		t.Fatalf("empty index: count=%d err=%v, want 0, nil", count, err)
+	}
+
+	// No sessions index at all: this shape carries no information, so it must
+	// surface as an error, not as zero.
+	if _, err := countActiveSubagents([]byte(`{}`)); err == nil {
+		t.Fatal("missing sessions index did not error")
+	}
+	if _, err := countActiveSubagents([]byte(`{"sessions":null}`)); err == nil {
+		t.Fatal("null sessions index did not error")
+	}
+	if _, err := countActiveSubagents([]byte(`not json`)); err == nil {
+		t.Fatal("malformed payload did not error")
+	}
+
+	// A non-empty index whose rows do not carry the key field under the name
+	// we expect (cross-version shape drift) must be an error: matching zero
+	// rows out of an index we could not read would be a fabricated "nothing
+	// running", and the hub treats that as positive evidence.
+	if _, err := countActiveSubagents([]byte(`{"sessions":[
+		{"sessionKey":"agent:main:subagent:abc","hasActiveRun":true},
+		{"sessionKey":"agent:main","hasActiveRun":true}
+	]}`)); err == nil {
+		t.Fatal("keyless rows did not error")
+	}
+}
+
+// subagentHeartbeatFields decides whether the heartbeat carries the
+// subagents_active fields at all. The hub reads an explicit false as positive
+// "nothing running" evidence and clears its suppression state, so the fields
+// must appear only when the sessions.list poll actually succeeded — never on
+// a poll error or a not-ready gateway.
+func TestSubagentHeartbeatFields(t *testing.T) {
+	var logBuf bytes.Buffer
+	prevOut := log.Writer()
+	log.SetOutput(&logBuf)
+	defer log.SetOutput(prevOut)
+
+	// Not-ready gateway: no fields, and the poll must not even run.
+	failLogged := false
+	fields, suffix := subagentHeartbeatFields(false, func() (int, error) {
+		t.Fatal("poll ran while the gateway session was not ready")
+		return 0, nil
+	}, &failLogged)
+	if fields != nil || suffix != "" || failLogged {
+		t.Fatalf("not-ready gateway: fields=%v suffix=%q failLogged=%v, want none", fields, suffix, failLogged)
+	}
+
+	// Successful poll: both fields, matching values.
+	fields, suffix = subagentHeartbeatFields(true, func() (int, error) { return 2, nil }, &failLogged)
+	if fields["subagents_active"] != true || fields["subagent_active_count"] != 2 || len(fields) != 2 {
+		t.Fatalf("successful poll fields = %v, want subagents_active=true subagent_active_count=2", fields)
+	}
+	if !strings.Contains(suffix, "subagents_active=true") {
+		t.Fatalf("log suffix %q does not surface the activity", suffix)
+	}
+	fields, _ = subagentHeartbeatFields(true, func() (int, error) { return 0, nil }, &failLogged)
+	if fields["subagents_active"] != false || fields["subagent_active_count"] != 0 {
+		t.Fatalf("zero-count poll fields = %v, want explicit false/0", fields)
+	}
+
+	// Failing poll (e.g. older gateway without sessions.list): both fields
+	// omitted, and the failure is logged exactly once across repeats.
+	pollErr := func() (int, error) { return 0, errors.New("method not found") }
+	for i := 0; i < 3; i++ {
+		if fields, suffix = subagentHeartbeatFields(true, pollErr, &failLogged); fields != nil || suffix != "" {
+			t.Fatalf("failing poll %d produced fields=%v suffix=%q, want none", i, fields, suffix)
+		}
+	}
+	if !failLogged {
+		t.Fatal("failing poll did not arm the logged-once flag")
+	}
+	if got := strings.Count(logBuf.String(), "subagent activity poll failed"); got != 1 {
+		t.Fatalf("failure logged %d times across 3 failing polls, want 1", got)
+	}
+
+	// A recovery re-arms the log for the next outage.
+	if _, _ = subagentHeartbeatFields(true, func() (int, error) { return 1, nil }, &failLogged); failLogged {
+		t.Fatal("successful poll did not re-arm the failure log")
 	}
 }

--- a/pkg/hub/agent_idle.go
+++ b/pkg/hub/agent_idle.go
@@ -69,6 +69,24 @@ const agentIdleResumeBlindGrace = minBusyTurnMax
 const (
 	lifecycleDefaultIdleAfter = 5 * time.Minute
 
+	// bridgeHeartbeatInterval is the bridge's heartbeat period — the 15s
+	// ticker in startHubKeepalives (cmd/claw-bridge). Named here because the
+	// freshness window below must be expressed in heartbeats, not in an
+	// unrelated wall-clock guess; if the bridge's ticker changes, this must
+	// change with it (defaultGatewayUnhealthyMax's comment carries the same
+	// dependency).
+	bridgeHeartbeatInterval = 15 * time.Second
+
+	// subagentsActiveFreshFor bounds how long one "subagents active" report
+	// keeps suppressing the agent_idle alert without being renewed. A live
+	// bridge re-reports every bridgeHeartbeatInterval, so the state is
+	// normally refreshed long before this expires; three intervals tolerate a
+	// couple of dropped or delayed heartbeats without flapping, while a bridge
+	// that dies (or stops being able to poll the gateway) can silence the
+	// alert for at most ~45s past its last word — stale state must never
+	// suppress it indefinitely.
+	subagentsActiveFreshFor = 3 * bridgeHeartbeatInterval
+
 	// agentIdleStretchSlack absorbs clock drift in the stretch-start value
 	// across hub restarts: a reconnect seeds lastTurnFinishedAt from the last
 	// claw message's created_at, which can differ from the pre-restart
@@ -145,9 +163,15 @@ func (s *Server) agentIdleBaseline(nowAt time.Time, enabled bool) (baseline time
 type agentIdleSnapshot struct {
 	busy             bool
 	noProgressPaused bool
-	lastTurn         time.Time
-	notifiedAt       time.Time
-	connectedAt      time.Time
+	// subagentsActive is true while the bridge RECENTLY reported spawned
+	// subagent sessions with a run in flight (sessions.list, ridden on the
+	// heartbeat). Freshness matters: the report suppresses the alert, so a
+	// stale one — a bridge that died mid-spawn — must expire (see
+	// subagentsActiveFreshFor) rather than silence the alert forever.
+	subagentsActive bool
+	lastTurn        time.Time
+	notifiedAt      time.Time
+	connectedAt     time.Time
 	// turnBoundarySeen is false while the hub has never watched a turn end on
 	// this connection, which is exactly when it cannot tell an idle agent from
 	// one whose turn it simply cannot see.
@@ -177,6 +201,7 @@ func agentIdleSnapshotOf(cc *clawConn) agentIdleSnapshot {
 	snap := agentIdleSnapshot{
 		busy:             cc.isBusyLocked(),
 		noProgressPaused: cc.noProgressPaused,
+		subagentsActive:  !cc.subagentsActiveAt.IsZero() && time.Since(cc.subagentsActiveAt) < subagentsActiveFreshFor,
 		lastTurn:         cc.lastTurnFinishedAt,
 		notifiedAt:       cc.idleNotifiedAt,
 		connectedAt:      cc.connectedAt,
@@ -239,6 +264,21 @@ func (s *Server) checkAgentIdle(nowAt time.Time, clawID string, cc *clawConn) {
 	if snap.busy {
 		// A running turn ends the idle stretch.
 		s.clearAgentIdleLatch(clawID, cc)
+		return
+	}
+	if snap.subagentsActive {
+		// Spawned subagent sessions are still running on the gateway. An agent
+		// that calls sessions_yield after sessions_spawn ENDS ITS TURN on
+		// purpose — the spawned work's completion arrives as the next message —
+		// so by turn state alone it is indistinguishable from a stall, and
+		// notifying here pages a human about an agent that is working exactly
+		// as designed. This is NOT the busy case above: busy means a turn is in
+		// flight and legitimately clears the latch, whereas here the claw is
+		// neither confirmed idle nor confirmed to have run a turn. So leave
+		// every latch exactly as it is — idle_since untouched, idleNotifiedAt
+		// unstamped — and re-decide on the next tick, once the completion turn
+		// runs (clearing the latch through the busy path) or the activity
+		// report goes stale.
 		return
 	}
 	stretchStartAt := snap.stretchStartAt
@@ -449,6 +489,9 @@ func (s *Server) checkAgentIdleResume(nowAt time.Time, clawID string, cc *clawCo
 		return
 	}
 	snap := agentIdleSnapshotOf(cc)
+	// snap.subagentsActive is deliberately NOT consulted here: the auto-resume
+	// still fires for a claw parked on sessions_yield with spawned work
+	// running. Only the notification is suppressed by that signal.
 	if snap.busy {
 		// A turn is running: nothing to resume.
 		//

--- a/pkg/hub/agent_idle_subagents_test.go
+++ b/pkg/hub/agent_idle_subagents_test.go
@@ -1,0 +1,176 @@
+package hub
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+	"nhooyr.io/websocket/wsjson"
+)
+
+// A claw parked on sessions_yield looks exactly like a stalled one to turn
+// state (no turn in flight, lastTurnFinishedAt old) while its spawned work is
+// still running. While the bridge's subagent-activity report is fresh the
+// alert must stay quiet and leave every latch untouched; once the report goes
+// stale (bridge died or stopped reporting) the suppression lifts and the
+// alert fires normally.
+func TestAgentIdleSuppressedWhileSubagentsActive(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	s, db := newSlackNotifierTestServer(t, fake.server.URL, nil)
+	const clawID = "idle-subagents"
+	insertSlackTestClaw(t, db, clawID, "connected", 0, "", oldEnough)
+	setClawPipelineStage(t, db, clawID, "implement")
+	seedIdleTestBaseline(t, s)
+	backdateAgentIdleBaseline(t, s)
+	setSlackWatermark(t, s, 0)
+	d := testLifecycleDelivery(t, s)
+
+	cc := idleTestConn(clawID, 10*time.Minute)
+	cc.subagentsActiveAt = time.Now()
+	cc.subagentActiveCount = 2
+
+	s.checkAgentIdle(time.Now(), clawID, cc)
+	if got := clawIdleSince(t, db, clawID); got != 0 {
+		t.Fatalf("fresh subagent activity latched idle_since=%d, want untouched (0)", got)
+	}
+	if !cc.idleNotifiedAt.IsZero() {
+		t.Fatal("fresh subagent activity stamped idleNotifiedAt")
+	}
+	s.lifecycleClawPass(d)
+	if fake.count() != 0 {
+		t.Fatalf("sent %d messages while subagents active, want 0", fake.count())
+	}
+
+	// The report goes stale without a zero-subagents heartbeat ever arriving:
+	// the claw may be genuinely stuck and the alert must not stay silenced.
+	cc.mu.Lock()
+	cc.subagentsActiveAt = time.Now().Add(-subagentsActiveFreshFor - time.Second)
+	cc.mu.Unlock()
+	s.checkAgentIdle(time.Now(), clawID, cc)
+	if clawIdleSince(t, db, clawID) == 0 {
+		t.Fatal("stale subagent state kept suppressing the alert")
+	}
+	s.lifecycleClawPass(d)
+	if fake.count() != 1 {
+		t.Fatalf("sent %d messages after the state went stale, want 1", fake.count())
+	}
+}
+
+// A heartbeat reporting zero active subagents is positive evidence that the
+// spawned work is gone: it clears the suppression and the alert fires on the
+// next tick like it always did.
+func TestAgentIdleZeroSubagentHeartbeatClearsSuppression(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	s, db := newSlackNotifierTestServer(t, fake.server.URL, nil)
+	const clawID = "idle-subagents-zero"
+	insertSlackTestClaw(t, db, clawID, "connected", 0, "", oldEnough)
+	setClawPipelineStage(t, db, clawID, "implement")
+	seedIdleTestBaseline(t, s)
+	backdateAgentIdleBaseline(t, s)
+	setSlackWatermark(t, s, 0)
+	d := testLifecycleDelivery(t, s)
+
+	cc := idleTestConn(clawID, 10*time.Minute)
+	cc.subagentsActiveAt = time.Now()
+	cc.subagentActiveCount = 1
+	s.checkAgentIdle(time.Now(), clawID, cc)
+	if got := clawIdleSince(t, db, clawID); got != 0 {
+		t.Fatalf("suppressed tick latched idle_since=%d", got)
+	}
+
+	inactive, zero := false, 0
+	cc.mu.Lock()
+	cc.applySubagentHeartbeatLocked(&inactive, &zero)
+	cc.mu.Unlock()
+	if !cc.subagentsActiveAt.IsZero() || cc.subagentActiveCount != 0 {
+		t.Fatalf("zero-subagents heartbeat did not clear state: at=%v count=%d", cc.subagentsActiveAt, cc.subagentActiveCount)
+	}
+
+	s.checkAgentIdle(time.Now(), clawID, cc)
+	if clawIdleSince(t, db, clawID) == 0 {
+		t.Fatal("alert did not fire after subagent state was cleared")
+	}
+	s.lifecycleClawPass(d)
+	if fake.count() != 1 {
+		t.Fatalf("sent %d messages, want 1", fake.count())
+	}
+}
+
+// The heartbeat fields are optional precisely so an old bridge stays
+// distinguishable from one reporting "no subagents": absent fields carry no
+// information and must leave the state untouched in either direction.
+func TestApplySubagentHeartbeatAbsentFieldsLeaveStateAlone(t *testing.T) {
+	cc := &clawConn{}
+
+	// Old bridge from the start: state stays zero, so agentIdleSnapshotOf
+	// reports subagentsActive=false and behaviour is exactly pre-change.
+	cc.applySubagentHeartbeatLocked(nil, nil)
+	if !cc.subagentsActiveAt.IsZero() || cc.subagentActiveCount != 0 {
+		t.Fatal("absent fields on a fresh connection touched the state")
+	}
+	if agentIdleSnapshotOf(cc).subagentsActive {
+		t.Fatal("zero state reported subagentsActive")
+	}
+
+	active, three := true, 3
+	cc.applySubagentHeartbeatLocked(&active, &three)
+	if cc.subagentsActiveAt.IsZero() || cc.subagentActiveCount != 3 {
+		t.Fatalf("active report not recorded: at=%v count=%d", cc.subagentsActiveAt, cc.subagentActiveCount)
+	}
+	if !agentIdleSnapshotOf(cc).subagentsActive {
+		t.Fatal("fresh active state not reported by the snapshot")
+	}
+
+	// A later heartbeat without the fields (bridge poll failed mid-flight)
+	// must not clear the recorded activity — only positive evidence may.
+	recordedAt := cc.subagentsActiveAt
+	cc.applySubagentHeartbeatLocked(nil, nil)
+	if !cc.subagentsActiveAt.Equal(recordedAt) || cc.subagentActiveCount != 3 {
+		t.Fatal("absent fields cleared previously recorded activity")
+	}
+}
+
+// The suppression only works if the bridge's JSON keys and the hub's struct
+// tags actually agree, and every other test here sets clawConn state directly.
+// This one sends real heartbeat frames over the claw websocket — a typo on
+// either side of the wire contract fails here and nowhere else.
+func TestHeartbeatWireCarriesSubagentActivity(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	const clawID = "subagent-wire"
+	conn := watchdogClaw(t, s, clawID)
+	cc := watchdogClawConn(t, s, clawID)
+
+	if err := wsjson.Write(context.Background(), conn, types.WSMessage{Type: "heartbeat", Payload: map[string]any{
+		"gateway_healthy": true, "subagents_active": true, "subagent_active_count": 2,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	eventuallyWatchdog(t, func() bool {
+		cc.mu.RLock()
+		defer cc.mu.RUnlock()
+		return !cc.subagentsActiveAt.IsZero() && cc.subagentActiveCount == 2
+	}, "subagent activity ingested from a wire heartbeat")
+
+	// An old-bridge heartbeat without the keys must leave the state alone.
+	// context_usage doubles as the processed marker: it is written in the same
+	// critical section, so once it changes the heartbeat has been fully applied.
+	cc.mu.RLock()
+	recordedAt := cc.subagentsActiveAt
+	cc.mu.RUnlock()
+	if err := wsjson.Write(context.Background(), conn, types.WSMessage{Type: "heartbeat", Payload: map[string]any{
+		"gateway_healthy": true, "context_usage": 55,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	eventuallyWatchdog(t, func() bool {
+		cc.mu.RLock()
+		defer cc.mu.RUnlock()
+		return cc.contextUsage == 55
+	}, "field-less heartbeat processed")
+	cc.mu.RLock()
+	defer cc.mu.RUnlock()
+	if !cc.subagentsActiveAt.Equal(recordedAt) || cc.subagentActiveCount != 2 {
+		t.Fatalf("field-less heartbeat touched subagent state: at=%v count=%d", cc.subagentsActiveAt, cc.subagentActiveCount)
+	}
+}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -258,6 +258,8 @@ type clawConn struct {
 	connectedAt          time.Time       // when this connection registered; immutable after registration
 	idleNotifiedAt       time.Time       // when the agent_idle notification fired for the current idle stretch (zero = armed)
 	turnBoundarySeen     bool            // a turn actually ended on THIS connection, so turn tracking is known live (see agentIdleResumeBlindGrace)
+	subagentsActiveAt    time.Time       // when the last heartbeat that REPORTED active spawned subagent sessions arrived (zero = none known; see applySubagentHeartbeatLocked)
+	subagentActiveCount  int             // subagent sessions with a run in flight per that heartbeat
 
 	deliveryInFlight bool // serializes DB-backed delivery writes
 
@@ -329,6 +331,30 @@ func gatewayReadyBool(v *bool) bool {
 
 func (cc *clawConn) isBusyLocked() bool {
 	return cc.awaitingResponse || !cc.streamingStartedAt.IsZero() || cc.streamingMsgID != ""
+}
+
+// applySubagentHeartbeatLocked folds one heartbeat's subagent-activity report
+// into the connection state. The fields arrive as pointers because absence
+// carries meaning: an old bridge (or one whose sessions.list poll failed)
+// omits them, which is "no information" and must leave the state untouched —
+// only an explicit report of zero active subagents is positive evidence that
+// nothing is running, and clears it.
+func (cc *clawConn) applySubagentHeartbeatLocked(active *bool, count *int) {
+	if active == nil {
+		return
+	}
+	if !*active {
+		cc.subagentsActiveAt = time.Time{}
+		cc.subagentActiveCount = 0
+		return
+	}
+	cc.subagentsActiveAt = time.Now()
+	// The bridge always sends the count alongside the flag; the fallback of 1
+	// just keeps "active" internally consistent should they ever split.
+	cc.subagentActiveCount = 1
+	if count != nil {
+		cc.subagentActiveCount = *count
+	}
 }
 
 // finishTurnLocked ends a turn that actually ran (or was force-finished):
@@ -2751,6 +2777,11 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				EstimatedCostUSD *float64 `json:"estimated_cost_usd"`
 				Model            string   `json:"model"`
 				ModelProvider    string   `json:"model_provider"`
+				// Pointers on purpose: an old bridge omits both, which must
+				// stay distinguishable from a bridge reporting "no subagents"
+				// (see applySubagentHeartbeatLocked).
+				SubagentsActive     *bool `json:"subagents_active"`
+				SubagentActiveCount *int  `json:"subagent_active_count"`
 			}
 			if err := json.Unmarshal(payload, &hb); err == nil {
 				gatewayUnhealthyMax := s.livenessSettings().gatewayUnhealthyMax
@@ -2774,6 +2805,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 					// Log only on status changes, not every heartbeat
 					prevUsage = activeCC.contextUsage
 					activeCC.contextUsage = hb.ContextUsage
+					activeCC.applySubagentHeartbeatLocked(hb.SubagentsActive, hb.SubagentActiveCount)
 					if s.gatewayRestartCounts == nil {
 						s.gatewayRestartCounts = make(map[string]int)
 					}


### PR DESCRIPTION
## Problem

The `agent_idle` Slack alert ("Agent stalled") fires for agents that are not stalled. An agent that calls OpenClaw's `sessions_yield` after `sessions_spawn` **ends its turn on purpose** — the spawned work's completion arrives as the next message. To the hub that is indistinguishable from a stall: no turn in flight, `lastTurnFinishedAt` old. Activity in descendant subagent sessions never makes the parent session busy, so no existing signal covered it.

## Change

- **bridge**: rides the existing 15s heartbeat to poll the gateway's `sessions.list` and count sessions whose key carries the `:subagent:` marker with `hasActiveRun=true`. Reports `subagents_active` / `subagent_active_count`.
- Both fields are sent **only when the poll succeeded**. On RPC failure, an older gateway without the method, or an unrecognised response/row shape, both are omitted — the hub falls back to today's behaviour instead of being fed a fabricated "nothing running". The failure log is quieted after the first miss and re-arms on recovery.
- **hub**: the fields arrive as pointers, so an old bridge (absent = no information) stays distinguishable from a bridge reporting zero (positive evidence, clears the state).
- `checkAgentIdle` suppresses the notification while the report is fresh and **touches no latch** — the claw is neither confirmed idle nor confirmed to have run a turn, so it re-decides next tick. Freshness is bounded at three heartbeats (~45s), so a bridge that dies mid-spawn cannot silence the alert indefinitely.

## Deliberately unchanged

The **auto-resume** (`checkAgentIdleResume`) still fires for a yield-parked claw — product decision, recorded in a comment at the call site. Only the notification is suppressed. Worth flagging: pinned OpenClaw treats a mid-turn injection as a session takeover, so if a lost turn shows up on a yielded claw, the same signal is already available to gate the resume on.

## Tests

New coverage for: suppression with fresh state (latches untouched), alerting once the state goes stale, a zero report clearing suppression, an old bridge omitting the fields behaving exactly as before, the heartbeat wire contract through the real websocket decoder, `sessions.list` parsing (only `:subagent:` + `hasActiveRun=true` counts; unknown shapes error out), and the both-or-neither heartbeat field contract including the log-once behaviour.

`go build ./...`, `go vet`, `go test ./cmd/claw-bridge/...` clean. `./pkg/hub/...` passes except the three known host-config `DoneSignal` failures that hit the real GitHub API locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)