### PR TITLE
feat(hub): report analytics ticket requester from the trigger actor

### DIFF
--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -2220,7 +2220,8 @@ type linearIssueDetails struct {
 	Description string `json:"description"`
 	CreatedAt   string `json:"createdAt"`
 	Creator     struct {
-		Name string `json:"name"`
+		Name  string `json:"name"`
+		Email string `json:"email"`
 	} `json:"creator"`
 	Team struct {
 		Name string `json:"name"`
@@ -2250,7 +2251,7 @@ func (s *Server) fetchLinearIssueDetails(token, issueIdentifier string) (*linear
 	// Linear's issue(id:) actually accepts the display identifier like "CAN-61"
 	// directly (not just UUID). This is documented in Linear's GraphQL examples.
 	queryBody := map[string]interface{}{
-		"query": "query($id: String!) { issue(id: $id) { identifier title url description createdAt creator { name } team { name } priorityLabel } }",
+		"query": "query($id: String!) { issue(id: $id) { identifier title url description createdAt creator { name email } team { name } priorityLabel } }",
 		"variables": map[string]string{
 			"id": issueIdentifier,
 		},

--- a/pkg/hub/linear.go
+++ b/pkg/hub/linear.go
@@ -2294,7 +2294,12 @@ func (s *Server) fetchLinearIssueDetails(token, issueIdentifier string) (*linear
 		combined := strings.Join(errMsgs, "; ")
 		log.Printf("[linear] fetchLinearIssueDetails GraphQL errors for %s: %s", issueIdentifier, combined)
 		log.Printf("[linear] fetchLinearIssueDetails response body for %s: %s", issueIdentifier, string(bodyBytes))
-		return nil, fmt.Errorf("GraphQL error: %s", combined)
+		// GraphQL reports per-field failures (an unreadable creator email, say) alongside a
+		// usable issue. Dropping the whole response there would cost the caller the title,
+		// team and priority too, so keep the partial issue and only fail when it is missing.
+		if result.Data.Issue.Identifier == "" {
+			return nil, fmt.Errorf("GraphQL error: %s", combined)
+		}
 	}
 	if result.Data.Issue.Identifier == "" {
 		log.Printf("[linear] fetchLinearIssueDetails: empty issue returned for %s", issueIdentifier)

--- a/pkg/hub/linear_issue_details_test.go
+++ b/pkg/hub/linear_issue_details_test.go
@@ -1,0 +1,67 @@
+package hub
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newLinearIssueDetailsServer(t *testing.T, response string, capturedQuery *string) *Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Query string `json:"query"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		if capturedQuery != nil {
+			*capturedQuery = body.Query
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(response))
+	}))
+	t.Cleanup(srv.Close)
+	return &Server{linearBaseURL: srv.URL}
+}
+
+func TestFetchLinearIssueDetailsRequestsCreatorEmail(t *testing.T) {
+	var query string
+	s := newLinearIssueDetailsServer(t, `{"data":{"issue":{"identifier":"CAN-61","title":"Ship it","creator":{"name":"Adrian Costa","email":"adrian@example.com"}}}}`, &query)
+
+	details, err := s.fetchLinearIssueDetails("token", "CAN-61")
+	if err != nil {
+		t.Fatalf("fetchLinearIssueDetails: %v", err)
+	}
+	if !strings.Contains(query, "creator { name email }") {
+		t.Errorf("query = %q, want it to request creator name and email", query)
+	}
+	if details.Creator.Name != "Adrian Costa" || details.Creator.Email != "adrian@example.com" {
+		t.Errorf("creator = %+v, want name and email populated", details.Creator)
+	}
+}
+
+func TestFetchLinearIssueDetailsKeepsIssueWhenOnlyFieldsFail(t *testing.T) {
+	s := newLinearIssueDetailsServer(t, `{"data":{"issue":{"identifier":"CAN-61","title":"Ship it","priorityLabel":"Urgent","creator":{"name":"Adrian Costa"}}},"errors":[{"message":"You are not authorized to read User.email"}]}`, nil)
+
+	details, err := s.fetchLinearIssueDetails("token", "CAN-61")
+	if err != nil {
+		t.Fatalf("fetchLinearIssueDetails: %v", err)
+	}
+	if details.Identifier != "CAN-61" || details.PriorityLabel != "Urgent" || details.Creator.Name != "Adrian Costa" {
+		t.Errorf("details = %+v, want the partial issue preserved", details)
+	}
+	if details.Creator.Email != "" {
+		t.Errorf("creator email = %q, want empty", details.Creator.Email)
+	}
+}
+
+func TestFetchLinearIssueDetailsFailsWhenErrorsLeaveNoIssue(t *testing.T) {
+	s := newLinearIssueDetailsServer(t, `{"data":{"issue":null},"errors":[{"message":"Entity not found"}]}`, nil)
+
+	if _, err := s.fetchLinearIssueDetails("token", "CAN-61"); err == nil {
+		t.Fatal("fetchLinearIssueDetails succeeded, want an error")
+	}
+}

--- a/pkg/hub/task_run_analytics_tickets_api.go
+++ b/pkg/hub/task_run_analytics_tickets_api.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"database/sql"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -164,10 +165,13 @@ func (s *Server) handleTaskRunAnalyticsTickets(w http.ResponseWriter, r *http.Re
 	groups = nonEmptyTaskRunAnalyticsTicketGroups(groups)
 
 	// Keep these reads page-batched: query count must not grow with ticket count.
-	runIDs, issueIDs := []string{}, []string{}
+	runIDs, issueIDs, clawIDs := []string{}, []string{}, []string{}
 	for _, group := range groups {
 		for _, run := range group.runs {
 			runIDs = append(runIDs, run.RunID)
+			if run.ClawID != "" {
+				clawIDs = append(clawIDs, run.ClawID)
+			}
 		}
 		issueIDs = append(issueIDs, group.key)
 	}
@@ -191,9 +195,14 @@ func (s *Server) handleTaskRunAnalyticsTickets(w http.ResponseWriter, r *http.Re
 		jsonError(w, http.StatusInternalServerError, "db error")
 		return
 	}
+	actorsByClaw, err := s.readTaskRunAnalyticsTriggerActorsForClaws(filters.TenantID, clawIDs)
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "db error")
+		return
+	}
 	tickets := make([]taskRunAnalyticsTicketView, 0, len(groups))
 	for _, group := range groups {
-		ticket, err := s.buildTaskRunAnalyticsTicket(filters.TenantID, group.issueID, group.runs, attemptsByRun, prsByRun, eventsByRun, metadataByIssue[group.key], false)
+		ticket, err := s.buildTaskRunAnalyticsTicket(filters.TenantID, group.issueID, group.runs, attemptsByRun, prsByRun, eventsByRun, actorsByClaw, metadataByIssue[group.key], false)
 		if err != nil {
 			jsonError(w, http.StatusInternalServerError, "db error")
 			return
@@ -372,8 +381,12 @@ func (s *Server) readTaskRunAnalyticsTicketByKey(ctx context.Context, filters ta
 		return nil, err
 	}
 	runIDs := make([]string, 0, len(runs))
+	clawIDs := make([]string, 0, len(runs))
 	for _, run := range runs {
 		runIDs = append(runIDs, run.RunID)
+		if run.ClawID != "" {
+			clawIDs = append(clawIDs, run.ClawID)
+		}
 	}
 	attempts, err := s.readTaskRunAnalyticsAttemptsForRuns(filters.TenantID, runIDs)
 	if err != nil {
@@ -391,7 +404,11 @@ func (s *Server) readTaskRunAnalyticsTicketByKey(ctx context.Context, filters ta
 	if err != nil {
 		return nil, err
 	}
-	ticket, err := s.buildTaskRunAnalyticsTicket(filters.TenantID, parts[2], runs, attempts, prs, events, metadata[key], true)
+	actorsByClaw, err := s.readTaskRunAnalyticsTriggerActorsForClaws(filters.TenantID, clawIDs)
+	if err != nil {
+		return nil, err
+	}
+	ticket, err := s.buildTaskRunAnalyticsTicket(filters.TenantID, parts[2], runs, attempts, prs, events, actorsByClaw, metadata[key], true)
 	if err != nil {
 		return nil, err
 	}
@@ -593,7 +610,7 @@ func (group taskRunAnalyticsTicketGroup) cursorAt() int64 {
 	return 1
 }
 
-func (s *Server) buildTaskRunAnalyticsTicket(tenantID, issueID string, runs []taskRunAnalyticsRunView, attemptsByRun map[string][]taskRunAnalyticsAttemptView, prsByRun map[string][]taskRunAnalyticsPRView, eventsByRun map[string][]taskRunAnalyticsEventView, metadata taskRunAnalyticsTicketMetadata, includeStory bool) (taskRunAnalyticsTicketView, error) {
+func (s *Server) buildTaskRunAnalyticsTicket(tenantID, issueID string, runs []taskRunAnalyticsRunView, attemptsByRun map[string][]taskRunAnalyticsAttemptView, prsByRun map[string][]taskRunAnalyticsPRView, eventsByRun map[string][]taskRunAnalyticsEventView, actorsByClaw map[string]triggerActor, metadata taskRunAnalyticsTicketMetadata, includeStory bool) (taskRunAnalyticsTicketView, error) {
 	sort.Slice(runs, func(i, j int) bool { return runs[i].StartedAt < runs[j].StartedAt })
 	ticket := taskRunAnalyticsTicketView{TicketKey: taskRunAnalyticsTicketKey(runs[0].Integration, runs[0].IntegrationWorkspace, issueID), IssueID: issueID, IssueTitle: runs[0].IssueTitle, Source: runs[0].Integration, Repo: runs[0].Repo, WorkflowName: runs[0].WorkflowName, WorkspaceName: runs[0].WorkspaceName, RunIDs: []string{}, Runs: []taskRunAnalyticsTicketRunSummary{}, PRs: []taskRunAnalyticsTicketPRView{}, Story: []taskRunAnalyticsTicketStoryEntry{}}
 	events := []taskRunAnalyticsTicketStoryEntry{}
@@ -635,6 +652,11 @@ func (s *Server) buildTaskRunAnalyticsTicket(tenantID, issueID string, runs []ta
 	ticket.Status = deriveTaskRunAnalyticsTicketStatus(ticket.Runs, ticket.PRs)
 	// Resolve fallback reported time before deriving ticket timing metrics.
 	s.applyOrScheduleTaskRunAnalyticsTicketMetadata(tenantID, &ticket, runs[0], metadata)
+	// The requester is whoever triggered the ticket, not whoever authored it in the tracker;
+	// the tracker creator stays the fallback for legacy runs with no recorded trigger actor.
+	if requester := triggerActorRequester(actorsByClaw[runs[0].ClawID]); requester != "" {
+		ticket.Requester = requester
+	}
 	sort.Slice(events, func(i, j int) bool {
 		if events[i].Time != events[j].Time {
 			return events[i].Time < events[j].Time
@@ -666,6 +688,67 @@ func (s *Server) buildTaskRunAnalyticsTicket(tenantID, issueID string, runs []ta
 		}
 	}
 	return ticket, nil
+}
+
+// readTaskRunAnalyticsTriggerActorsForClaws resolves the trigger actors for a whole
+// ticket page in one query, so the requester lookup does not add a query per ticket.
+func (s *Server) readTaskRunAnalyticsTriggerActorsForClaws(tenantID string, clawIDs []string) (map[string]triggerActor, error) {
+	actorsByClaw := map[string]triggerActor{}
+	if len(clawIDs) == 0 {
+		return actorsByClaw, nil
+	}
+	if len(clawIDs) > 500 {
+		for start := 0; start < len(clawIDs); start += 500 {
+			end := start + 500
+			if end > len(clawIDs) {
+				end = len(clawIDs)
+			}
+			chunk, err := s.readTaskRunAnalyticsTriggerActorsForClaws(tenantID, clawIDs[start:end])
+			if err != nil {
+				return nil, err
+			}
+			for id, actor := range chunk {
+				actorsByClaw[id] = actor
+			}
+		}
+		return actorsByClaw, nil
+	}
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(clawIDs)), ",")
+	args := make([]any, 0, len(clawIDs)+1)
+	args = append(args, tenantID)
+	for _, clawID := range clawIDs {
+		args = append(args, clawID)
+	}
+	rows, err := s.db.Query(`SELECT id, COALESCE(trigger_actor_json,'') FROM claws WHERE tenant_id=? AND id IN (`+placeholders+`)`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var clawID, actorJSON string
+		if err := rows.Scan(&clawID, &actorJSON); err != nil {
+			return nil, err
+		}
+		if strings.TrimSpace(actorJSON) == "" {
+			continue
+		}
+		var actor triggerActor
+		if err := json.Unmarshal([]byte(actorJSON), &actor); err != nil {
+			log.Printf("[task-run-analytics] failed to parse trigger actor for claw %s: %v", shortID(clawID), err)
+			continue
+		}
+		actorsByClaw[clawID] = actor
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return actorsByClaw, nil
+}
+
+// triggerActorRequester renders the person who triggered a ticket, preferring a
+// human-readable name over the email or handle the tracker webhook carried.
+func triggerActorRequester(actor triggerActor) string {
+	return strings.TrimSpace(firstNonEmpty(strings.TrimSpace(actor.Name), strings.TrimSpace(actor.Email), strings.TrimSpace(actor.Login)))
 }
 
 func taskRunTicketCostAndTokens(run taskRunAnalyticsRunView) (float64, int64) {
@@ -740,7 +823,7 @@ func (s *Server) enrichTaskRunAnalyticsTicket(ticket *taskRunAnalyticsTicketView
 		if _, workflow, ok, err := s.resolveWorkflowConfig(run.WorkspaceName, run.WorkflowName); err == nil && ok {
 			if token := s.resolveLinearTokenForWorkflow(run.WorkspaceName, workflow); token != "" {
 				if details, err := s.fetchLinearIssueDetails(token, ticket.IssueID); err == nil {
-					ticket.Requester, ticket.Priority, ticket.Ask, ticket.Team = details.Creator.Name, details.PriorityLabel, details.Description, details.Team.Name
+					ticket.Requester, ticket.Priority, ticket.Ask, ticket.Team = firstNonEmpty(details.Creator.Name, details.Creator.Email), details.PriorityLabel, details.Description, details.Team.Name
 					// Neither Linear nor GitHub exposes a reliable requester-role field for an issue.
 					if ticket.ReportedAt == 0 {
 						if parsed, err := parseTicketTimestamp(details.CreatedAt); err == nil {

--- a/pkg/hub/task_run_analytics_tickets_api_test.go
+++ b/pkg/hub/task_run_analytics_tickets_api_test.go
@@ -247,6 +247,85 @@ func TestCollapseTaskRunAnalyticsTicketStory(t *testing.T) {
 	}
 }
 
+func TestTriggerActorRequester(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		actor triggerActor
+		want  string
+	}{
+		{name: "name preferred", actor: triggerActor{Name: "Ada Lovelace", Email: "ada@example.com", Login: "ada"}, want: "Ada Lovelace"},
+		{name: "email falls back", actor: triggerActor{Email: "ada@example.com", Login: "ada"}, want: "ada@example.com"},
+		{name: "login falls back", actor: triggerActor{Login: "ada"}, want: "ada"},
+		{name: "whitespace fields ignored", actor: triggerActor{Name: "  ", Email: " \t ", Login: " ada "}, want: "ada"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := triggerActorRequester(test.actor); got != test.want {
+				t.Fatalf("triggerActorRequester(%#v) = %q, want %q", test.actor, got, test.want)
+			}
+		})
+	}
+}
+
+func TestBuildTaskRunAnalyticsTicketUsesFirstTriggerActor(t *testing.T) {
+	build := func(t *testing.T, actors map[string]string, runs []taskRunAnalyticsRunView, metadata taskRunAnalyticsTicketMetadata) taskRunAnalyticsTicketView {
+		t.Helper()
+		s, db := newTaskRunAnalyticsAPITestServer(t)
+		for clawID, actorJSON := range actors {
+			if _, err := db.Exec(`INSERT INTO claws(id,tenant_id,name,template,status,trigger_actor_json,created_at) VALUES(?,?,?,?,?,?,datetime('now'))`, clawID, "test-tenant-id", clawID, "base", "connected", actorJSON); err != nil {
+				t.Fatalf("insert claw %s: %v", clawID, err)
+			}
+		}
+		if metadata.updatedAt > 0 {
+			if _, err := db.Exec(`INSERT INTO ticket_metadata(tenant_id,integration,integration_workspace,issue_id,requester,updated_at) VALUES(?,?,?,?,?,?)`, "test-tenant-id", "external", "", "ENG-1", metadata.requester, metadata.updatedAt); err != nil {
+				t.Fatalf("insert cached metadata: %v", err)
+			}
+			cached, err := s.readTaskRunAnalyticsTicketMetadataPage(context.Background(), "test-tenant-id", []string{taskRunAnalyticsTicketKey("external", "", "ENG-1")})
+			if err != nil {
+				t.Fatalf("read cached metadata: %v", err)
+			}
+			metadata = cached[taskRunAnalyticsTicketKey("external", "", "ENG-1")]
+		}
+		clawIDs := make([]string, 0, len(runs))
+		for _, run := range runs {
+			clawIDs = append(clawIDs, run.ClawID)
+		}
+		actorsByClaw, err := s.readTaskRunAnalyticsTriggerActorsForClaws("test-tenant-id", clawIDs)
+		if err != nil {
+			t.Fatalf("read trigger actors: %v", err)
+		}
+		ticket, err := s.buildTaskRunAnalyticsTicket("test-tenant-id", "ENG-1", runs, nil, nil, nil, actorsByClaw, metadata, false)
+		if err != nil {
+			t.Fatalf("build ticket: %v", err)
+		}
+		return ticket
+	}
+	run := func(id, clawID string, startedAt int64) taskRunAnalyticsRunView {
+		return taskRunAnalyticsRunView{RunID: id, ClawID: clawID, Integration: "external", IssueID: "ENG-1", StartedAt: startedAt, Status: taskRunStatusClean}
+	}
+	freshMetadata := func(requester string) taskRunAnalyticsTicketMetadata {
+		return taskRunAnalyticsTicketMetadata{requester: requester, updatedAt: time.Now().UnixMilli()}
+	}
+	for _, test := range []struct {
+		name     string
+		actors   map[string]string
+		runs     []taskRunAnalyticsRunView
+		metadata taskRunAnalyticsTicketMetadata
+		want     string
+	}{
+		{name: "name", actors: map[string]string{"claw-name": `{"name":"Ada Lovelace","email":"ada@example.com","login":"ada"}`}, runs: []taskRunAnalyticsRunView{run("run-name", "claw-name", 1)}, metadata: freshMetadata("tracker creator"), want: "Ada Lovelace"},
+		{name: "email", actors: map[string]string{"claw-email": `{"email":"ada@example.com","login":"ada"}`}, runs: []taskRunAnalyticsRunView{run("run-email", "claw-email", 1)}, metadata: freshMetadata("tracker creator"), want: "ada@example.com"},
+		{name: "login", actors: map[string]string{"claw-login": `{"login":"octocat","type":"User"}`}, runs: []taskRunAnalyticsRunView{run("run-login", "claw-login", 1)}, metadata: freshMetadata("tracker creator"), want: "octocat"},
+		{name: "empty actor preserves cached requester", actors: map[string]string{"claw-empty": `{}`}, runs: []taskRunAnalyticsRunView{run("run-empty", "claw-empty", 1)}, metadata: freshMetadata("tracker creator"), want: "tracker creator"},
+		{name: "older run actor wins", actors: map[string]string{"claw-older": `{"name":"Older Trigger"}`, "claw-newer": `{"name":"Newer Trigger"}`}, runs: []taskRunAnalyticsRunView{run("run-newer", "claw-newer", 2), run("run-older", "claw-older", 1)}, metadata: freshMetadata("tracker creator"), want: "Older Trigger"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := build(t, test.actors, test.runs, test.metadata).Requester; got != test.want {
+				t.Fatalf("Requester = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
 func TestTaskRunAnalyticsTicketStoryUsesHubNativeEventTypes(t *testing.T) {
 	tests := []struct {
 		eventType string


### PR DESCRIPTION
## Problem

The analytics **Unique tickets** table showed the tracker *author* of an issue in the `Requester` column, not the person who actually triggered the agent — so on tickets where one person files the issue and someone else moves it to the trigger status, the column names the wrong person.

There was also no name → email fallback: the Linear GraphQL query only asked for `creator { name }`, so when Linear had no display name the cell went blank. GitHub tickets showed a bare `issue.User.Login`.

Sample from the Faster hub before this change (57 tickets, `GET /api/analytics/tickets`): 44 names, 12 raw emails, 1 blank. The emails were not a fallback — those Linear accounts simply have the email as their display name.

## Change

The requester now resolves from `claws.trigger_actor_json` of the ticket's **first** run (`runs[0]`, already sorted ascending by `StartedAt`), preferring **name → email → login**. That data was already recorded by the Linear, Jira and GitHub webhook paths and was only being consumed by agent-failure feedback.

- Resolved outside the `ticket_metadata` cache, so a stale cached creator name can't shadow it and it stays correct even when tracker enrichment has never run or has failed.
- The tracker creator remains the fallback for legacy factory-created runs, which never recorded a trigger actor.
- Trigger actors are prefetched per page in one `IN (...)` query, keeping `TestTaskRunAnalyticsTicketsHandlerUsesConstantQueriesPerPage` green — the query count still doesn't grow with ticket count.
- The Linear query now also asks for `creator { name email }` so the fallback itself can degrade from name to email instead of going blank.
- Because that new field could in principle be rejected by a token that can't read `User.email`, `fetchLinearIssueDetails` now treats a GraphQL `errors` array as fatal only when it leaves no issue behind — previously a per-field error also cost the caller the title, team and priority.

No frontend change: `analytics-command-center.tsx` and `ticket-detail-panel.tsx` already render `ticket.requester` with a `—` / "Unknown requester" fallback.

## Tests

- `TestTriggerActorRequester` — name/email/login precedence and whitespace-only fields.
- `TestBuildTaskRunAnalyticsTicketUsesFirstTriggerActor` — name, email-only, login-only, empty actor preserves the cached tracker value, and a two-run ticket fed newer-run-first to prove the **older** run's actor wins.
- `TestFetchLinearIssueDetails{RequestsCreatorEmail,KeepsIssueWhenOnlyFieldsFail,FailsWhenErrorsLeaveNoIssue}`.

`go build ./...`, `go vet ./pkg/hub` and `gofmt` clean. Three `pkg/hub` failures (`TestDoneSignalRejectedWhenPRPersistenceFails`, `TestHandleClawDoneSignal_IssueLessWorkflowWatchesPR`, `TestCompleteIssueLessDoneClawKeepsRunningOnStoreFailure`) are pre-existing — confirmed by running them identically at the merge-base `11649fea`; they reach the real GitHub API from a dev machine and touch DONE-signal code this PR does not modify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)