### PR TITLE
fix(hub): order ticket list by first run start

### DIFF
--- a/pkg/hub/task_run_analytics_tickets_api.go
+++ b/pkg/hub/task_run_analytics_tickets_api.go
@@ -268,7 +268,7 @@ func (s *Server) readTaskRunAnalyticsTicketGroupsPage(filters taskRunAnalyticsFi
 	if err != nil {
 		return nil, 0, false, taskRunAnalyticsTicketGroup{}, err
 	}
-	orderAt := `MAX(COALESCE(NULLIF(MIN(NULLIF(issue_created_at,0)),0), MIN(started_at), 1), 1)`
+	orderAt := `MAX(MIN(started_at), 1)`
 	groupWhere := where + ` AND issue_id != ''`
 	groupArgs := append([]any{}, args...)
 	if cursorAt > 0 && cursorIssueID != "" {
@@ -292,7 +292,7 @@ func (s *Server) readTaskRunAnalyticsTicketGroupsPage(filters taskRunAnalyticsFi
 			return nil, 0, false, taskRunAnalyticsTicketGroup{}, err
 		}
 		ids = append(ids, id)
-		cursorGroups = append(cursorGroups, taskRunAnalyticsTicketGroup{key: id, reportedAt: ignored})
+		cursorGroups = append(cursorGroups, taskRunAnalyticsTicketGroup{key: id, firstStartedAt: ignored})
 	}
 	if err := rows.Err(); err != nil {
 		return nil, 0, false, taskRunAnalyticsTicketGroup{}, err
@@ -538,13 +538,11 @@ func taskRunAnalyticsTicketGroupsFromHydration(ids []string, runs []taskRunAnaly
 	for _, id := range ids {
 		rs := byID[id]
 		sort.Slice(rs, func(i, j int) bool { return rs[i].StartedAt < rs[j].StartedAt })
-		var reported int64
-		for _, run := range rs {
-			if run.IssueCreatedAt > 0 && (reported == 0 || run.IssueCreatedAt < reported) {
-				reported = run.IssueCreatedAt
-			}
+		var firstStartedAt int64
+		if len(rs) > 0 {
+			firstStartedAt = rs[0].StartedAt
 		}
-		if group, ok := taskRunAnalyticsTicketGroupWithRuns(id, rs, reported); ok {
+		if group, ok := taskRunAnalyticsTicketGroupWithRuns(id, rs, firstStartedAt); ok {
 			groups = append(groups, group)
 		}
 	}
@@ -552,10 +550,12 @@ func taskRunAnalyticsTicketGroupsFromHydration(ids []string, runs []taskRunAnaly
 }
 
 type taskRunAnalyticsTicketGroup struct {
-	key        string
-	issueID    string
-	runs       []taskRunAnalyticsRunView
-	reportedAt int64
+	key     string
+	issueID string
+	runs    []taskRunAnalyticsRunView
+	// firstStartedAt is the start of the ticket's first run, which is also the
+	// value the list is ordered and paginated by.
+	firstStartedAt int64
 }
 
 const taskRunAnalyticsTicketKeySeparator = "\x1f"
@@ -576,19 +576,16 @@ func nonEmptyTaskRunAnalyticsTicketGroups(groups []taskRunAnalyticsTicketGroup) 
 	return filtered
 }
 
-func taskRunAnalyticsTicketGroupWithRuns(issueID string, runs []taskRunAnalyticsRunView, reportedAt int64) (taskRunAnalyticsTicketGroup, bool) {
+func taskRunAnalyticsTicketGroupWithRuns(issueID string, runs []taskRunAnalyticsRunView, firstStartedAt int64) (taskRunAnalyticsTicketGroup, bool) {
 	if len(runs) == 0 {
 		return taskRunAnalyticsTicketGroup{}, false
 	}
-	return taskRunAnalyticsTicketGroup{key: issueID, issueID: runs[0].IssueID, runs: runs, reportedAt: reportedAt}, true
+	return taskRunAnalyticsTicketGroup{key: issueID, issueID: runs[0].IssueID, runs: runs, firstStartedAt: firstStartedAt}, true
 }
 
 func (group taskRunAnalyticsTicketGroup) cursorAt() int64 {
-	if group.reportedAt > 0 {
-		return group.reportedAt
-	}
-	if len(group.runs) > 0 && group.runs[0].StartedAt > 0 {
-		return group.runs[0].StartedAt
+	if group.firstStartedAt > 0 {
+		return group.firstStartedAt
 	}
 	return 1
 }

--- a/pkg/hub/task_run_analytics_tickets_api_test.go
+++ b/pkg/hub/task_run_analytics_tickets_api_test.go
@@ -352,6 +352,36 @@ func TestTaskRunAnalyticsTicketsHandlerAggregatesAndPaginates(t *testing.T) {
 	}
 }
 
+func TestTaskRunAnalyticsTicketsHandlerOrdersByFirstRunStart(t *testing.T) {
+	s, db := newTaskRunAnalyticsAPITestServer(t)
+	// issue_created_at is deliberately inverted against started_at so the two
+	// orderings cannot agree by accident.
+	for _, fixture := range []struct {
+		runID, issueID          string
+		startedAt, issueCreated int64
+	}{
+		{"order-early-run", "ORDER-EARLY", 1_000, 9_000},
+		{"order-late-run", "ORDER-LATE", 8_000, 2_000},
+	} {
+		insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{
+			RunID: fixture.runID, AttemptID: "attempt-" + fixture.runID, ClawID: "claw-" + fixture.runID,
+			TenantID: "test-tenant-id", Status: taskRunStatusClean, Phase: taskRunPhaseTerminal,
+			OwnerType: taskRunOwnerWorkflow, StartedAt: fixture.startedAt, IssueCreatedAt: fixture.issueCreated,
+			IssueTitle: fixture.issueID,
+		})
+		if _, err := db.Exec(`UPDATE task_run_summaries SET issue_id=? WHERE run_id=?`, fixture.issueID, fixture.runID); err != nil {
+			t.Fatalf("set fixture issue ID: %v", err)
+		}
+	}
+
+	rr := requestTaskRunAnalyticsAPI(t, s, http.MethodGet, "/api/analytics/tickets", "test-token")
+	var response taskRunAnalyticsTicketsResponse
+	decodeTaskRunAnalyticsAPI(t, rr, &response)
+	if len(response.Tickets) != 2 || response.Tickets[0].IssueID != "ORDER-LATE" || response.Tickets[1].IssueID != "ORDER-EARLY" {
+		t.Fatalf("tickets not ordered by first run start: %#v", response.Tickets)
+	}
+}
+
 func TestTaskRunAnalyticsTicketsHandlerHonorsMultiValueDimensionFilters(t *testing.T) {
 	s, db := newTaskRunAnalyticsAPITestServer(t)
 	for _, fixture := range []apiRunFixture{


### PR DESCRIPTION
## What changed

The analytics ticket list now orders groups by the start of the ticket's **first run** (`MIN(started_at)`) instead of the ticket's issue creation time.

Before: `MAX(COALESCE(NULLIF(MIN(NULLIF(issue_created_at,0)),0), MIN(started_at), 1), 1)`
After: `MAX(MIN(started_at), 1)`

## Why

The list should reflect when work actually began on each ticket, not when the issue was reported upstream. The old expression only fell back to run start when `issue_created_at` was missing, so tickets reported long ago but picked up recently sorted to the bottom.

## Notes for reviewers

- The pagination cursor key is the ordering value itself, so cursors stay consistent with the new order. The group field `reportedAt` was renamed to `firstStartedAt` (the old name was misleading) and `cursorAt()` simplified.
- The API payload field `ReportedAt` is **unchanged** — it still comes from `ticket_metadata`; it just no longer drives ordering.
- New test `TestTaskRunAnalyticsTicketsHandlerOrdersByFirstRunStart` uses fixtures where `issue_created_at` is inverted against `started_at`, so the two orderings cannot agree by accident. Verified it fails against the old expression and passes with the new one.
- `go test ./pkg/hub/` has 3 unrelated local failures (`TestDoneSignalRejectedWhenPRPersistenceFails`, `TestHandleClawDoneSignal_IssueLessWorkflowWatchesPR`, `TestCompleteIssueLessDoneClawKeepsRunningOnStoreFailure`) — the pr-watcher hits the real GitHub API from a local dev machine. All ticket tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)