### PR TITLE
feat: route Slack lifecycle alerts to multiple channels with per-channel allow-lists

### DIFF
--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -948,6 +948,18 @@ func migrate(db *sql.DB) error {
 	CREATE INDEX IF NOT EXISTS idx_slack_deliveries_time
 		ON slack_notification_deliveries(delivered_at);
 
+	-- Route-aware lifecycle delivery dedupe.  The legacy table remains read as
+	-- a fallback by the notifier, so pre-upgrade events are never re-sent.
+	CREATE TABLE IF NOT EXISTS slack_notification_deliveries_v2 (
+		event_id     TEXT NOT NULL,
+		notifier     TEXT NOT NULL,
+		run_id       TEXT NOT NULL,
+		delivered_at INTEGER NOT NULL,
+		message_ts   TEXT NOT NULL DEFAULT '',
+		status       TEXT NOT NULL DEFAULT 'sent',
+		PRIMARY KEY (event_id, notifier)
+	);
+
 	-- Key/value state for the Slack notifier (the rowid watermark).
 	CREATE TABLE IF NOT EXISTS slack_notifier_state (
 		key   TEXT PRIMARY KEY,

--- a/pkg/hub/doctor.go
+++ b/pkg/hub/doctor.go
@@ -1232,7 +1232,6 @@ func (s *Server) checkNotifications(cfg *types.HubConfig) []DoctorCheck {
 			OK:          false,
 			Error:       err.Error(),
 		})
-		return checks
 	}
 
 	secrets := func(name string) (string, bool) {
@@ -1276,6 +1275,49 @@ func (s *Server) checkNotifications(cfg *types.HubConfig) []DoctorCheck {
 			Description: fmt.Sprintf("Type %s constructed successfully with its hub secrets resolved.", nc.Type),
 			OK:          true,
 		})
+	}
+
+	// Lifecycle delivery only uses EffectiveRoutes. Check every one separately
+	// so a bad secondary route is visible even when another route is healthy.
+	// This intentionally complements (rather than replaces) the full config
+	// validation above: malformed configs still get their structural error.
+	if nCfg.Lifecycle != nil {
+		for i, route := range nCfg.Lifecycle.EffectiveRoutes() {
+			via := strings.TrimSpace(route.Via)
+			label := fmt.Sprintf("Lifecycle route %d (%q)", i+1, via)
+			nc, ok := nCfg.Notifiers[via]
+			if via == "" || !ok {
+				checks = append(checks, DoctorCheck{
+					Category: "notifications", Severity: "critical", OK: false,
+					Title:       label + " names an unknown notifier",
+					Description: "This lifecycle route will not deliver messages until its via names a configured notifier.",
+				})
+				continue
+			}
+			channel, _ := s.notifierSettings(nc)["channel"].(string)
+			if strings.TrimSpace(channel) == "" {
+				checks = append(checks, DoctorCheck{
+					Category: "notifications", Severity: "critical", OK: false,
+					Title:       label + " has no channel",
+					Description: fmt.Sprintf("Notifier %q needs a channel for this lifecycle route.", via),
+				})
+				continue
+			}
+			if _, err := notify.New(nc.Type, s.notifierSettings(nc), secrets); err != nil {
+				checks = append(checks, DoctorCheck{
+					Category: "notifications", Severity: "critical", OK: false,
+					Title:       label + " is not constructible",
+					Description: fmt.Sprintf("Messages for this lifecycle route through notifier %q will not be delivered.", via),
+					Error:       err.Error(),
+				})
+				continue
+			}
+			checks = append(checks, DoctorCheck{
+				Category: "notifications", Severity: "info", OK: true,
+				Title:       label + " is configured",
+				Description: fmt.Sprintf("Notifier %q constructed successfully and has a channel.", via),
+			})
+		}
 	}
 	return checks
 }

--- a/pkg/hub/doctor.go
+++ b/pkg/hub/doctor.go
@@ -1281,7 +1281,12 @@ func (s *Server) checkNotifications(cfg *types.HubConfig) []DoctorCheck {
 	// so a bad secondary route is visible even when another route is healthy.
 	// This intentionally complements (rather than replaces) the full config
 	// validation above: malformed configs still get their structural error.
-	if nCfg.Lifecycle != nil {
+	// Gated on IsEnabled for the same reason ValidateNotificationsConfig is: a
+	// muted lifecycle block may legitimately point at a notifier the operator
+	// has since deleted ("an operator who mutes alerts and then deletes the
+	// notifier must not be left with a hub that refuses to load"), and nothing
+	// is delivered through those routes anyway.
+	if nCfg.Lifecycle.IsEnabled() {
 		for i, route := range nCfg.Lifecycle.EffectiveRoutes() {
 			via := strings.TrimSpace(route.Via)
 			label := fmt.Sprintf("Lifecycle route %d (%q)", i+1, via)

--- a/pkg/hub/doctor_test.go
+++ b/pkg/hub/doctor_test.go
@@ -66,11 +66,14 @@ func TestCheckNotificationsSurfacesMisconfiguration(t *testing.T) {
 		},
 	}
 	checks := s.checkNotifications(badVia)
-	if len(checks) != 1 || checks[0].OK || checks[0].Severity != "critical" {
-		t.Fatalf("bad lifecycle.via: got %#v, want one critical failing check", checks)
+	var routeFailure bool
+	for _, check := range checks {
+		if !check.OK && strings.Contains(check.Title, "Lifecycle route") && strings.Contains(check.Title, "eng-agent") {
+			routeFailure = true
+		}
 	}
-	if !strings.Contains(checks[0].Error, "eng-agent") {
-		t.Fatalf("check error %q does not name the bad via", checks[0].Error)
+	if !routeFailure {
+		t.Fatalf("bad lifecycle.via did not produce a route-specific failure: %#v", checks)
 	}
 
 	// Provider-level failures: unknown type, then a secret that does not resolve.
@@ -99,6 +102,37 @@ func TestCheckNotificationsSurfacesMisconfiguration(t *testing.T) {
 	}
 	if c, ok := byTitle[`Notifier "healthy" is configured`]; !ok || !c.OK {
 		t.Fatalf("healthy notifier not reported OK: %#v", byTitle)
+	}
+}
+
+func TestCheckNotificationsChecksEveryLifecycleRoute(t *testing.T) {
+	s := &Server{}
+	cfg := &types.HubConfig{Secrets: map[string]string{"token": "xoxb-test"}, Notifications: &types.NotificationsConfig{
+		Notifiers: map[string]types.NotifierConfig{
+			"healthy": {Type: "slack", Settings: map[string]any{"token_secret": "token", "channel": "C0123ABCD"}},
+			"empty":   {Type: "slack", Settings: map[string]any{"token_secret": "token"}},
+			"broken":  {Type: "carrier-pigeon", Settings: map[string]any{"channel": "C0123ABCD"}},
+		},
+		Lifecycle: &types.LifecycleNotificationsConfig{Routes: []types.LifecycleRoute{{Via: "healthy"}, {Via: "empty"}, {Via: "broken"}, {Via: "missing"}}},
+	}}
+	checks := s.checkNotifications(cfg)
+	seen := map[string]bool{}
+	for _, check := range checks {
+		if strings.Contains(check.Title, "Lifecycle route") && !check.OK {
+			seen[check.Title] = true
+		}
+	}
+	for _, want := range []string{"(\"empty\") has no channel", "(\"broken\") is not constructible", "(\"missing\") names an unknown notifier"} {
+		found := false
+		for title := range seen {
+			if strings.Contains(title, want) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("missing route check %q in %#v", want, checks)
+		}
 	}
 }
 

--- a/pkg/hub/doctor_test.go
+++ b/pkg/hub/doctor_test.go
@@ -136,6 +136,24 @@ func TestCheckNotificationsChecksEveryLifecycleRoute(t *testing.T) {
 	}
 }
 
+// Regression: the per-route checks ran even while lifecycle alerts were off, so
+// a deliberately muted config with a dangling via — a state
+// ValidateNotificationsConfig explicitly accepts, "an operator who mutes alerts
+// and then deletes the notifier must not be left with a hub that refuses to
+// load" — reported a permanent critical.
+func TestCheckNotificationsSkipsRoutesWhileAlertsDisabled(t *testing.T) {
+	s := &Server{}
+	disabled := false
+	cfg := &types.HubConfig{Notifications: &types.NotificationsConfig{
+		Lifecycle: &types.LifecycleNotificationsConfig{Enabled: &disabled, Via: "old-channel"},
+	}}
+	for _, check := range s.checkNotifications(cfg) {
+		if strings.Contains(check.Title, "Lifecycle route") {
+			t.Fatalf("muted lifecycle config produced a route check: %#v", check)
+		}
+	}
+}
+
 // Pipeline notify actions must be validated against the hub-level notifiers
 // the runner resolves them from, under the runtime's secret scope: a blank or
 // unknown "via" and a notifier that fails to construct (unsupported type,

--- a/pkg/hub/external_storage.go
+++ b/pkg/hub/external_storage.go
@@ -123,16 +123,27 @@ var reservedWorkspaceNames = map[string]bool{
 	"troubleshoot":        true,
 }
 
-// validateWorkspaceName rejects names that are unsafe for filesystem use or
-// reserved by the settings UI routes.
-func validateWorkspaceName(name string) error {
+// validateWorkspaceNameForSave rejects names that are unsafe for filesystem use
+// or reserved by the settings UI routes.
+//
+// The reservation applies to NEW workspaces only. The reserved list grows every
+// time a settings section is added, so a workspace can predate its own name
+// becoming reserved — and nothing on the load path checks the list, so the hub
+// keeps serving it. Refusing every push for it would strand it as permanently
+// read-only with no in-product way to rename it (a rename is a push under the
+// new name), which is strictly worse than the URL collision the reservation
+// exists to prevent.
+func validateWorkspaceNameForSave(name string) error {
 	if err := validateName(name); err != nil {
 		return err
 	}
-	if reservedWorkspaceNames[name] {
-		return fmt.Errorf("workspace name %q is reserved", name)
+	if !reservedWorkspaceNames[name] {
+		return nil
 	}
-	return nil
+	if info, err := os.Stat(filepath.Join(workspacesDir(), name)); err == nil && info.IsDir() {
+		return nil
+	}
+	return fmt.Errorf("workspace name %q is reserved", name)
 }
 
 // saveExternalTemplate writes a template to the external templates directory.
@@ -647,7 +658,7 @@ func saveExternalWorkspace(workspace *types.WorkspaceConfig) error {
 	if workspace == nil || workspace.Name == "" {
 		return fmt.Errorf("workspace name required")
 	}
-	if err := validateWorkspaceName(workspace.Name); err != nil {
+	if err := validateWorkspaceNameForSave(workspace.Name); err != nil {
 		return err
 	}
 	if err := workspace.Validate(); err != nil {

--- a/pkg/hub/external_storage.go
+++ b/pkg/hub/external_storage.go
@@ -117,6 +117,7 @@ var reservedWorkspaceNames = map[string]bool{
 	"secrets":             true,
 	"ai-config":           true,
 	"mcp-servers":         true,
+	"notifier":            true,
 	"analytics":           true,
 	"doctor":              true,
 	"troubleshoot":        true,

--- a/pkg/hub/external_storage_validation_test.go
+++ b/pkg/hub/external_storage_validation_test.go
@@ -71,6 +71,35 @@ func TestSaveExternalWorkspaceRejectsReservedNames(t *testing.T) {
 	}
 }
 
+// TestSaveExternalWorkspaceKeepsPreexistingReservedName covers the workspace
+// that was created before its name became reserved: the load path never checks
+// the reserved list, so the hub keeps serving it, and refusing its pushes would
+// leave it permanently read-only with no way to rename it out of the collision.
+func TestSaveExternalWorkspaceKeepsPreexistingReservedName(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", t.TempDir()+"/hub.yaml")
+
+	// Persisted while "notifier" was still a legal workspace name.
+	if err := os.MkdirAll(filepath.Join(workspacesDir(), "notifier"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := saveExternalWorkspace(&types.WorkspaceConfig{
+		Name:  "notifier",
+		Files: map[string]string{"README.md": "test"},
+	}); err != nil {
+		t.Fatalf("saveExternalWorkspace(pre-existing reserved name) failed: %v", err)
+	}
+
+	// A reserved name with nothing on disk is still refused.
+	err := saveExternalWorkspace(&types.WorkspaceConfig{
+		Name:  "analytics",
+		Files: map[string]string{"README.md": "test"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "reserved") {
+		t.Fatalf("saveExternalWorkspace(new reserved name) error = %v, want reserved name error", err)
+	}
+}
+
 // TestReservedWorkspaceNamesCoverFrontendSections reads the frontend's
 // VALID_SECTIONS list and asserts every slug in it is reserved here and served
 // as a static section. The reserved list ranges over itself in the test above,

--- a/pkg/hub/external_storage_validation_test.go
+++ b/pkg/hub/external_storage_validation_test.go
@@ -70,3 +70,53 @@ func TestSaveExternalWorkspaceRejectsReservedNames(t *testing.T) {
 		t.Fatalf("saveExternalWorkspace(%q) failed: %v", "engineering", err)
 	}
 }
+
+// TestReservedWorkspaceNamesCoverFrontendSections reads the frontend's
+// VALID_SECTIONS list and asserts every slug in it is reserved here and served
+// as a static section. The reserved list ranges over itself in the test above,
+// so a section added to sections.ts but forgotten here would otherwise go
+// unnoticed until a workspace of that name lost its whole settings UI.
+func TestReservedWorkspaceNamesCoverFrontendSections(t *testing.T) {
+	path := filepath.Join("..", "..", "web", "app", "settings", "[[...parts]]", "sections.ts")
+	source, err := os.ReadFile(path) //nolint:gosec // fixed path inside the repo
+	if os.IsNotExist(err) {
+		t.Skipf("%s not present in this checkout", path)
+	}
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	sections := frontendValidSections(t, string(source))
+	if len(sections) == 0 {
+		t.Fatalf("no sections parsed out of %s", path)
+	}
+	for _, section := range sections {
+		if !reservedWorkspaceNames[section] {
+			t.Errorf("section %q is missing from reservedWorkspaceNames", section)
+		}
+		if !settingsStaticSection(section) {
+			t.Errorf("section %q is missing from settingsStaticSection", section)
+		}
+	}
+}
+
+// frontendValidSections pulls the quoted slugs out of the VALID_SECTIONS array
+// literal in sections.ts.
+func frontendValidSections(t *testing.T, source string) []string {
+	t.Helper()
+	_, rest, ok := strings.Cut(source, "VALID_SECTIONS = [")
+	if !ok {
+		t.Fatal("VALID_SECTIONS array not found in sections.ts")
+	}
+	body, _, ok := strings.Cut(rest, "]")
+	if !ok {
+		t.Fatal("VALID_SECTIONS array is not terminated in sections.ts")
+	}
+	var sections []string
+	for _, field := range strings.Split(body, ",") {
+		if slug := strings.Trim(strings.TrimSpace(field), `"`); slug != "" {
+			sections = append(sections, slug)
+		}
+	}
+	return sections
+}

--- a/pkg/hub/lifecycle_claw_notifier.go
+++ b/pkg/hub/lifecycle_claw_notifier.go
@@ -48,6 +48,14 @@ const (
 	// or claw_prs rows — the same rule the task-run watermark follows.
 	lifecycleStateClawBaselineKey = "claw_baseline_done"
 
+	// lifecycleClawRouteBaselinePrefix namespaces one route's own baseline.
+	// The claw pass has no cursor, so a route added to an existing config
+	// would otherwise find every currently connected claw (and every open
+	// claw_prs row) missing its delivery rows and replay the lot into the new
+	// channel. Seeding the route's history on first sight is the per-route
+	// analog of the task-run pass's first-run watermark.
+	lifecycleClawRouteBaselinePrefix = lifecycleStateClawBaselineKey + ":"
+
 	// lifecycleClawAdhocGrace is how old a claw must be before the claw pass will
 	// classify it as ad-hoc. See the race note above. Every ensureTaskRunForClaw
 	// caller attaches the run in the same request that inserts the claw row, so
@@ -154,6 +162,16 @@ func lifecycleClawKindsEnabled(cfg *types.LifecycleNotificationsConfig) (agentSt
 	return
 }
 
+func lifecycleClawRouteBaselineKey(notifier string) string {
+	return lifecycleClawRouteBaselinePrefix + notifier
+}
+
+// lifecycleRouteAccepts reports whether a route's allow-list covers an event
+// type. An empty allow-list means "every type".
+func lifecycleRouteAccepts(route lifecycleRouteDelivery, eventType string) bool {
+	return len(route.events) == 0 || route.events[eventType]
+}
+
 // lifecycleClawPass is the claw-level counterpart of slackTaskRunPass, covering
 // only claws with an empty task_run_id.
 func (s *Server) lifecycleClawPass(d lifecycleDelivery) {
@@ -169,6 +187,11 @@ func (s *Server) lifecycleClawPass(d lifecycleDelivery) {
 			return
 		}
 		s.setNotifierStateInt64(lifecycleStateClawBaselineKey, 1)
+		for _, route := range d.effectiveRoutes() {
+			// The shared baseline just recorded the current state for every
+			// route, so none of them needs its own seeding pass.
+			s.setNotifierStateInt64(lifecycleClawRouteBaselineKey(route.notifier), 1)
+		}
 		return
 	}
 
@@ -188,18 +211,105 @@ func (s *Server) lifecycleClawPass(d lifecycleDelivery) {
 		s.skipCurrentLifecycleClawPRs()
 	}
 
-	if startedOn && !s.sendLifecycleClawStateEvents(d, lifecycleClawKindStarted) {
+	// Every route selects and delivers on its own. The claw pass has no cursor,
+	// so a claw stays a candidate until it has a delivery row — and a shared
+	// candidate set means a route that cannot deliver (archived channel,
+	// unresolvable token secret) keeps its claws in that set forever and, at
+	// `ORDER BY created_at LIMIT 200`, eventually locks every newer claw out of
+	// the batch for the HEALTHY routes too. Per-route selection confines that
+	// debt to the route that owes it.
+	for _, route := range d.effectiveRoutes() {
+		if d.routePaused(route.notifier) {
+			continue
+		}
+		if !s.ensureLifecycleClawRouteBaseline(d, route) {
+			continue
+		}
+		s.lifecycleClawRoutePass(d, route, startedOn, prOn, failuresOn, idleOn)
+	}
+}
+
+// lifecycleClawRoutePass runs the four claw-sourced kinds for one route. A kind
+// the route's allow-list rejects is never scanned, so those claws cannot
+// consume the route's batch either.
+func (s *Server) lifecycleClawRoutePass(d lifecycleDelivery, route lifecycleRouteDelivery, startedOn, prOn, failuresOn, idleOn bool) {
+	if startedOn && lifecycleRouteAccepts(route, taskRunEventAgentStarted) &&
+		!s.sendLifecycleClawStateEvents(d, route, lifecycleClawKindStarted) {
 		return
 	}
-	if failuresOn && !s.sendLifecycleClawStateEvents(d, lifecycleClawKindFailure) {
+	if failuresOn && lifecycleRouteAccepts(route, taskRunEventAgentStopped) &&
+		!s.sendLifecycleClawStateEvents(d, route, lifecycleClawKindFailure) {
 		return
 	}
-	if idleOn && !s.sendLifecycleClawIdleEvents(d) {
+	if idleOn && lifecycleRouteAccepts(route, taskRunEventAgentIdle) &&
+		!s.sendLifecycleClawIdleEvents(d, route) {
 		return
 	}
-	if prOn {
-		s.lifecycleClawPRPass(d)
+	if prOn && lifecycleRouteAccepts(route, taskRunEventPROpened) {
+		s.lifecycleClawPRPass(d, route)
 	}
+}
+
+// ensureLifecycleClawRouteBaseline records a newly configured route's history
+// and reports whether the route may deliver this tick. The legacy single-`via`
+// shape needs none: it keeps writing the shared legacy rows, which already
+// fence every claw it has handled.
+func (s *Server) ensureLifecycleClawRouteBaseline(d lifecycleDelivery, route lifecycleRouteDelivery) bool {
+	if d.singleRoute() {
+		return true
+	}
+	key := lifecycleClawRouteBaselineKey(route.notifier)
+	_, found, err := s.notifierStateInt64(key)
+	if err != nil {
+		// Unreadable state must not be mistaken for "already baselined": that
+		// would replay the current claw list into the channel.
+		log.Printf("[notify] read claw baseline state for %q: %v", route.notifier, err)
+		return false
+	}
+	if found {
+		return true
+	}
+	if err := s.seedLifecycleClawRouteBaseline(route.notifier); err != nil {
+		log.Printf("[notify] seed claw baseline for %q: %v", route.notifier, err)
+		return false
+	}
+	s.setNotifierStateInt64(key, 1)
+	return false
+}
+
+// seedLifecycleClawRouteBaseline records the current claw/PR state as already
+// handled for one route, mirroring seedLifecycleClawBaseline into the per-route
+// table.
+func (s *Server) seedLifecycleClawRouteBaseline(notifier string) error {
+	startedCond, startedSuffix := lifecycleClawStateCondition(lifecycleClawKindStarted)
+	failureCond, failureSuffix := lifecycleClawStateCondition(lifecycleClawKindFailure)
+	at := epochMillis(now())
+	const insert = `INSERT INTO slack_notification_deliveries_v2(event_id, notifier, run_id, delivered_at, message_ts, status) `
+	stmts := []struct {
+		query string
+		args  []any
+	}{
+		{insert + `SELECT 'claw:' || c.id || ?, ?, 'claw:' || c.id, ?, '', ?
+			  FROM claws c WHERE c.task_run_id = '' AND ` + startedCond + `
+			ON CONFLICT(event_id, notifier) DO NOTHING`, []any{startedSuffix, notifier, at, notificationDeliveryStatusSkipped}},
+		{insert + `SELECT 'claw:' || c.id || ?, ?, 'claw:' || c.id, ?, '', ?
+			  FROM claws c WHERE c.task_run_id = '' AND ` + failureCond + `
+			ON CONFLICT(event_id, notifier) DO NOTHING`, []any{failureSuffix, notifier, at, notificationDeliveryStatusSkipped}},
+		{insert + `SELECT 'claw:' || c.id || ':idle:' || c.idle_since, ?, 'claw:' || c.id, ?, '', ?
+			  FROM claws c WHERE c.task_run_id = '' AND c.idle_since > 0
+			ON CONFLICT(event_id, notifier) DO NOTHING`, []any{notifier, at, notificationDeliveryStatusSkipped}},
+		// The WHERE clause is load-bearing: without it SQLite parses ON CONFLICT
+		// as the start of a join clause and rejects the statement.
+		{insert + `SELECT 'claw:' || p.claw_id || ':pr:' || p.pr_url, ?, 'claw:' || p.claw_id, ?, '', ?
+			  FROM claw_prs p WHERE true
+			ON CONFLICT(event_id, notifier) DO NOTHING`, []any{notifier, at, notificationDeliveryStatusSkipped}},
+	}
+	for _, stmt := range stmts {
+		if _, err := s.db.Exec(stmt.query, stmt.args...); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // seedLifecycleClawBaseline records the current claw/PR state as already handled.
@@ -294,7 +404,9 @@ func (s *Server) skipCurrentLifecycleClawIdle() error {
 }
 
 // selectLifecycleClawIdleCandidates returns ad-hoc claws whose idle latch has
-// no delivery row yet. The exclusion conditions mirror agentIdleEligible for
+// no delivery row yet for this route — the shared legacy row (baseline,
+// parking, or a legacy single-`via` send) fences every route, the v2 row only
+// its own. The exclusion conditions mirror agentIdleEligible for
 // the ad-hoc kind — status 'connected', no unresolved DELIVERED tracked PR,
 // still driven by a pipeline stage or a live workflow run — so a claw that
 // opened a PR, died, or lost its automatic driver between latch and delivery
@@ -302,7 +414,7 @@ func (s *Server) skipCurrentLifecycleClawIdle() error {
 // clawOpenPRCount and agentIdleHasClawPRs: a PR the agent merely linked is
 // not "PR out, awaiting humans", and suppressing the idle notification on it
 // would hide a hung claw the watcher will also never finalize.
-func (s *Server) selectLifecycleClawIdleCandidates() ([]lifecycleClawRow, []int64, error) {
+func (s *Server) selectLifecycleClawIdleCandidates(notifier string) ([]lifecycleClawRow, []int64, error) {
 	cutoff := now().Add(-lifecycleClawAdhocGrace).Unix()
 	rows, err := s.db.Query(`
 		SELECT `+lifecycleClawSelectColumns+`, c.idle_since
@@ -317,8 +429,12 @@ func (s *Server) selectLifecycleClawIdleCandidates() ([]lifecycleClawRow, []int6
 			SELECT 1 FROM slack_notification_deliveries d
 			 WHERE d.event_id = 'claw:' || c.id || ':idle:' || c.idle_since
 		   )
+		   AND NOT EXISTS (
+			SELECT 1 FROM slack_notification_deliveries_v2 v
+			 WHERE v.event_id = 'claw:' || c.id || ':idle:' || c.idle_since AND v.notifier = ?
+		   )
 		 ORDER BY c.created_at
-		 LIMIT `+strconv.Itoa(lifecycleBatchSize), cutoff)
+		 LIMIT `+strconv.Itoa(lifecycleBatchSize), cutoff, notifier)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -341,8 +457,8 @@ func (s *Server) selectLifecycleClawIdleCandidates() ([]lifecycleClawRow, []int6
 
 // sendLifecycleClawIdleEvents delivers the idle kind for ad-hoc claws. Returns
 // false when the claw pass must stop for this tick.
-func (s *Server) sendLifecycleClawIdleEvents(d lifecycleDelivery) bool {
-	claws, idleSinces, err := s.selectLifecycleClawIdleCandidates()
+func (s *Server) sendLifecycleClawIdleEvents(d lifecycleDelivery, route lifecycleRouteDelivery) bool {
+	claws, idleSinces, err := s.selectLifecycleClawIdleCandidates(route.notifier)
 	if err != nil {
 		log.Printf("[notify] select claw idle candidates: %v", err)
 		return false
@@ -354,7 +470,7 @@ func (s *Server) sendLifecycleClawIdleEvents(d lifecycleDelivery) bool {
 			detail["idleMinutes"] = minutes
 		}
 		ev := lifecycleEventRow{EventType: taskRunEventAgentIdle, Detail: detail}
-		if !s.deliverLifecycleClawEvent(d, claw, ev, lifecycleClawRunContext(claw), lifecycleClawIdleKey(claw.ID, idleSince)) {
+		if !s.deliverLifecycleClawEvent(d, route, claw, ev, lifecycleClawRunContext(claw), lifecycleClawIdleKey(claw.ID, idleSince)) {
 			return false
 		}
 	}
@@ -401,9 +517,11 @@ func lifecycleClawStateCondition(kind string) (cond, keySuffix string) {
 }
 
 // selectLifecycleClawStateCandidates returns ad-hoc claws currently in the kind's
-// state that have no delivery row yet. The dedupe happens in SQL (like the
-// task-run pass) so already-handled claws never consume the LIMIT.
-func (s *Server) selectLifecycleClawStateCandidates(kind string) ([]lifecycleClawRow, error) {
+// state that this route has no delivery row for. The dedupe happens in SQL (like
+// the task-run pass) so already-handled claws never consume the LIMIT — and it
+// is per route, so a route that cannot deliver keeps its debt to itself instead
+// of holding every other route's claws in a shared, oldest-first batch.
+func (s *Server) selectLifecycleClawStateCandidates(kind, notifier string) ([]lifecycleClawRow, error) {
 	cond, suffix := lifecycleClawStateCondition(kind)
 	cutoff := now().Add(-lifecycleClawAdhocGrace).Unix()
 	rows, err := s.db.Query(`
@@ -414,8 +532,12 @@ func (s *Server) selectLifecycleClawStateCandidates(kind string) ([]lifecycleCla
 		   AND NOT EXISTS (
 			SELECT 1 FROM slack_notification_deliveries d WHERE d.event_id = 'claw:' || c.id || ?
 		   )
+		   AND NOT EXISTS (
+			SELECT 1 FROM slack_notification_deliveries_v2 v
+			 WHERE v.event_id = 'claw:' || c.id || ? AND v.notifier = ?
+		   )
 		 ORDER BY c.created_at
-		 LIMIT `+strconv.Itoa(lifecycleBatchSize), cutoff, suffix)
+		 LIMIT `+strconv.Itoa(lifecycleBatchSize), cutoff, suffix, suffix, notifier)
 	if err != nil {
 		return nil, err
 	}
@@ -449,27 +571,27 @@ func lifecycleClawStateEvent(kind string, claw lifecycleClawRow) (lifecycleEvent
 
 // sendLifecycleClawStateEvents delivers one state kind. Returns false when the
 // claw pass must stop for this tick (config-level or transient Slack failure).
-func (s *Server) sendLifecycleClawStateEvents(d lifecycleDelivery, kind string) bool {
-	claws, err := s.selectLifecycleClawStateCandidates(kind)
+func (s *Server) sendLifecycleClawStateEvents(d lifecycleDelivery, route lifecycleRouteDelivery, kind string) bool {
+	claws, err := s.selectLifecycleClawStateCandidates(kind, route.notifier)
 	if err != nil {
 		log.Printf("[notify] select claw %s candidates: %v", kind, err)
 		return false
 	}
 	for _, claw := range claws {
 		ev, deliveryKey := lifecycleClawStateEvent(kind, claw)
-		if !s.deliverLifecycleClawEvent(d, claw, ev, lifecycleClawRunContext(claw), deliveryKey) {
+		if !s.deliverLifecycleClawEvent(d, route, claw, ev, lifecycleClawRunContext(claw), deliveryKey) {
 			return false
 		}
 	}
 	return true
 }
 
-// deliverLifecycleClawEvent posts one claw-sourced event with the shared error
-// policy: config errors pause everything, permanent errors are recorded as
-// failed (and count as handled), transient errors stop the pass for this
-// tick. Returns true when the event is handled (sent, permanently failed, or
-// ceded to the task-run path) and the caller may move past it.
-func (s *Server) deliverLifecycleClawEvent(d lifecycleDelivery, claw lifecycleClawRow, ev lifecycleEventRow, runCtx lifecycleRunContext, deliveryKey string) bool {
+// deliverLifecycleClawEvent posts one claw-sourced event through one route with
+// the shared error policy: config errors park the route, permanent errors are
+// recorded as failed (and count as handled), transient errors stop this route's
+// pass for the tick. Returns true when the event is handled (sent, permanently
+// failed, or ceded to the task-run path) and the caller may move past it.
+func (s *Server) deliverLifecycleClawEvent(d lifecycleDelivery, route lifecycleRouteDelivery, claw lifecycleClawRow, ev lifecycleEventRow, runCtx lifecycleRunContext, deliveryKey string) bool {
 	// Re-check ownership immediately before sending: task_run_id may have been
 	// populated after this claw was selected, and a claw that belongs to a
 	// task run must be notified exclusively by the task-run pass. Nothing is
@@ -484,27 +606,21 @@ func (s *Server) deliverLifecycleClawEvent(d lifecycleDelivery, claw lifecycleCl
 	}
 
 	runKey := lifecycleClawRunKey(claw.ID)
-	err := s.postLifecycleEvent(d, ev, runCtx, runKey, deliveryKey)
+	err := s.postLifecycleEventRoute(d, route, buildLifecycleMessage(ev, runCtx), runKey, deliveryKey)
 	if err == nil {
 		return true
 	}
-	// Same send-failure policy as the task-run pass, applied to EVERY failing
-	// route: config errors park the route, permanent errors are burned as
-	// failed, transient errors park the route until the next tick. Parking one
-	// destination instead of the whole pass is what keeps a single broken
-	// channel from muting the healthy ones; the claw keeps no delivery row for
-	// the parked route, so it is re-selected and retried later.
-	errs, ok := err.(lifecycleRouteSendErrors)
-	if !ok {
-		return false
+	// Same send-failure policy as the task-run pass: config errors park the
+	// route, permanent errors are burned as failed, transient errors park the
+	// route until the next tick. Parking one destination instead of the whole
+	// pass is what keeps a single broken channel from muting the healthy ones;
+	// the claw keeps no delivery row for the parked route, so it is re-selected
+	// and retried later — by that route's own pass only.
+	if handled, _ := s.handleLifecycleSendError(err, "claw event "+deliveryKey, deliveryKey, runKey, route.notifier, d.singleRoute()); handled {
+		return true
 	}
-	for _, routeErr := range errs {
-		if handled, _ := s.handleLifecycleSendError(routeErr.err, "claw event "+deliveryKey, deliveryKey, runKey, routeErr.notifier, d.singleRoute()); !handled {
-			d.pauseRoute(routeErr.notifier)
-		}
-	}
-	// Only stop the pass once nothing is left to deliver through.
-	return d.hasLiveRoutes()
+	d.pauseRoute(route.notifier)
+	return false
 }
 
 type lifecycleClawPRRow struct {
@@ -522,18 +638,22 @@ type lifecycleClawPRRow struct {
 // after deletes — see skipCurrentLifecycleClawPRs); the delivery-row anti-join
 // alone decides what is new, so every handled row must end up with a delivery
 // record or it would be re-selected forever and consume the LIMIT.
-func (s *Server) lifecycleClawPRPass(d lifecycleDelivery) {
+func (s *Server) lifecycleClawPRPass(d lifecycleDelivery, route lifecycleRouteDelivery) {
 	rows, err := s.db.Query(`
 		SELECT p.rowid, p.repo, p.pr_number, p.pr_url, c.task_run_id,
 		       CAST(strftime('%s', c.created_at) AS INTEGER),
-		       ` + lifecycleClawSelectColumns + `
+		       `+lifecycleClawSelectColumns+`
 		  FROM claw_prs p JOIN claws c ON c.id = p.claw_id
 		 WHERE NOT EXISTS (
 			SELECT 1 FROM slack_notification_deliveries d
 			 WHERE d.event_id = 'claw:' || p.claw_id || ':pr:' || p.pr_url
 		   )
+		   AND NOT EXISTS (
+			SELECT 1 FROM slack_notification_deliveries_v2 v
+			 WHERE v.event_id = 'claw:' || p.claw_id || ':pr:' || p.pr_url AND v.notifier = ?
+		   )
 		 ORDER BY p.rowid
-		 LIMIT ` + strconv.Itoa(lifecycleBatchSize))
+		 LIMIT `+strconv.Itoa(lifecycleBatchSize), route.notifier)
 	if err != nil {
 		log.Printf("[notify] select claw PR candidates: %v", err)
 		return
@@ -583,7 +703,7 @@ func (s *Server) lifecycleClawPRPass(d lifecycleDelivery) {
 		}
 		runCtx := lifecycleClawRunContext(pr.Claw)
 		runCtx.Repo = pr.Repo
-		if !s.deliverLifecycleClawEvent(d, pr.Claw, ev, runCtx, lifecycleClawPRKey(pr.Claw.ID, pr.PRURL)) {
+		if !s.deliverLifecycleClawEvent(d, route, pr.Claw, ev, runCtx, lifecycleClawPRKey(pr.Claw.ID, pr.PRURL)) {
 			break
 		}
 	}

--- a/pkg/hub/lifecycle_claw_notifier.go
+++ b/pkg/hub/lifecycle_claw_notifier.go
@@ -285,10 +285,12 @@ func (s *Server) stampLifecycleClawRouteBaselines(lc *types.LifecycleNotificatio
 // materialises the task-run cursor of a route whose notifier is unbuildable
 // (typo'd token secret), so seeding its claw baseline only on recovery would
 // bury exactly the claw events the tick promises are "held until it can be
-// built", while the task-run events of the same window are delivered.
+// built", while the task-run events of the same window are delivered. A config
+// collapsed onto ONE brand-new route is covered too (lifecycleRoutesNeedOwnState):
+// being the hub's only route does not make its outage any less of an outage.
 func (s *Server) ensureLifecycleClawRouteBaselines(lc *types.LifecycleNotificationsConfig) {
 	routes := lc.EffectiveRoutes()
-	if len(routes) < 2 {
+	if !s.lifecycleRoutesNeedOwnState(routes) {
 		// The legacy single-route shape is fenced by the legacy delivery table;
 		// ensureLifecycleClawRouteBaseline handles its one key.
 		return
@@ -302,6 +304,19 @@ func (s *Server) ensureLifecycleClawRouteBaselines(lc *types.LifecycleNotificati
 		via := strings.TrimSpace(route.Via)
 		if via == "" {
 			continue
+		}
+		if len(routes) == 1 {
+			// The stamp written below is what lifecycleSingleViaIncumbent
+			// reads, so for a lone route it must never land ahead of the
+			// cursor ensureLifecycleRouteWatermarks materialises earlier in
+			// this same tick: a route carrying a claw stamp and no cursor of
+			// its own IS the legacy incumbent, and would be handed the shared
+			// floor and replay the whole multi-route-era backlog. If that
+			// write did not land (a transient state-read failure), wait for
+			// the next tick, which retries both in order.
+			if _, found, err := s.notifierStateInt64(lifecycleRouteWatermarkKey(via)); err != nil || !found {
+				continue
+			}
 		}
 		key := lifecycleClawRouteBaselineKey(via)
 		if _, found, err := s.notifierStateInt64(key); err != nil || found {

--- a/pkg/hub/lifecycle_claw_notifier.go
+++ b/pkg/hub/lifecycle_claw_notifier.go
@@ -305,18 +305,17 @@ func (s *Server) ensureLifecycleClawRouteBaselines(lc *types.LifecycleNotificati
 		if via == "" {
 			continue
 		}
-		if len(routes) == 1 {
-			// The stamp written below is what lifecycleSingleViaIncumbent
-			// reads, so for a lone route it must never land ahead of the
-			// cursor ensureLifecycleRouteWatermarks materialises earlier in
-			// this same tick: a route carrying a claw stamp and no cursor of
-			// its own IS the legacy incumbent, and would be handed the shared
-			// floor and replay the whole multi-route-era backlog. If that
-			// write did not land (a transient state-read failure), wait for
-			// the next tick, which retries both in order.
-			if _, found, err := s.notifierStateInt64(lifecycleRouteWatermarkKey(via)); err != nil || !found {
-				continue
-			}
+		// The stamp written below is what lifecycleSingleViaIncumbent reads, so
+		// it must never land ahead of the cursor ensureLifecycleRouteWatermarks
+		// materialises earlier in this same tick: a route carrying a claw stamp
+		// and no cursor of its own reads as the legacy incumbent, and would then
+		// be handed the shared floor and replay the whole backlog piled up
+		// behind it. If that write did not land (a transient state-read failure
+		// made ensure bail), wait for the next tick, which retries both in
+		// order. Every configured route gets a cursor there, so in the healthy
+		// case this never skips anything.
+		if _, found, err := s.notifierStateInt64(lifecycleRouteWatermarkKey(via)); err != nil || !found {
+			continue
 		}
 		key := lifecycleClawRouteBaselineKey(via)
 		if _, found, err := s.notifierStateInt64(key); err != nil || found {
@@ -380,6 +379,16 @@ func (s *Server) ensureLifecycleClawRouteBaseline(d lifecycleDelivery, route lif
 	}
 	if found {
 		return true
+	}
+	if _, ok, err := s.notifierStateInt64(lifecycleRouteWatermarkKey(route.notifier)); err != nil || !ok {
+		// Same ordering rule as ensureLifecycleClawRouteBaselines: the stamp
+		// written below is what lifecycleSingleViaIncumbent reads, so it must
+		// never land ahead of the route's own cursor. ensureLifecycleRouteWatermarks
+		// gives every multi-route config's routes one; if it bailed on a
+		// transient state-read failure this tick, wait for the next one rather
+		// than leaving a stamp that reads as "legacy incumbent" and earns this
+		// route the incumbent's shared position.
+		return false
 	}
 	if err := s.seedLifecycleClawRouteBaseline(route.notifier); err != nil {
 		log.Printf("[notify] seed claw baseline for %q: %v", route.notifier, err)

--- a/pkg/hub/lifecycle_claw_notifier.go
+++ b/pkg/hub/lifecycle_claw_notifier.go
@@ -188,17 +188,7 @@ func (s *Server) lifecycleClawPass(d lifecycleDelivery) {
 			return
 		}
 		s.setNotifierStateInt64(lifecycleStateClawBaselineKey, 1)
-		for _, route := range d.lc.EffectiveRoutes() {
-			// The shared baseline just recorded the current state for every
-			// route, so none of them needs its own seeding pass. Stamp every
-			// CONFIGURED route, not only the ones that built this tick: a route
-			// whose notifier was unavailable here would otherwise arrive with no
-			// baseline key and be seeded on recovery, burying exactly the claw
-			// events the tick promises are "still pending for it".
-			if via := strings.TrimSpace(route.Via); via != "" {
-				s.setNotifierStateInt64(lifecycleClawRouteBaselineKey(via), 1)
-			}
-		}
+		s.stampLifecycleClawRouteBaselines(d.lc)
 		return
 	}
 
@@ -270,6 +260,21 @@ func (s *Server) lifecycleClawRoutePass(d lifecycleDelivery, route lifecycleRout
 			_ = s.skipCurrentLifecycleClawRoutePRs(route.notifier)
 		} else {
 			s.lifecycleClawPRPass(d, route)
+		}
+	}
+}
+
+// stampLifecycleClawRouteBaselines marks every CONFIGURED route as baselined
+// without seeding any rows. Callers use it where the shared baseline (or the
+// legacy delivery table it writes into) already fences the routes' history:
+// stamping every configured route — not only the ones that built this tick —
+// is what keeps a route whose notifier is unavailable from arriving with no
+// baseline key and being seeded on recovery, which would bury exactly the claw
+// events it is still owed.
+func (s *Server) stampLifecycleClawRouteBaselines(lc *types.LifecycleNotificationsConfig) {
+	for _, route := range lc.EffectiveRoutes() {
+		if via := strings.TrimSpace(route.Via); via != "" {
+			s.setNotifierStateInt64(lifecycleClawRouteBaselineKey(via), 1)
 		}
 	}
 }

--- a/pkg/hub/lifecycle_claw_notifier.go
+++ b/pkg/hub/lifecycle_claw_notifier.go
@@ -486,17 +486,25 @@ func (s *Server) deliverLifecycleClawEvent(d lifecycleDelivery, claw lifecycleCl
 	runKey := lifecycleClawRunKey(claw.ID)
 	err := s.postLifecycleEvent(d, ev, runCtx, runKey, deliveryKey)
 	if err == nil {
-		s.clearPollWarning(lifecycleSendWarningKey)
 		return true
 	}
-	// Same send-failure policy as the task-run pass: config errors pause,
-	// permanent errors are burned as failed, transient errors stop the pass.
-	routeErr, ok := err.(lifecycleRouteSendError)
+	// Same send-failure policy as the task-run pass, applied to EVERY failing
+	// route: config errors park the route, permanent errors are burned as
+	// failed, transient errors park the route until the next tick. Parking one
+	// destination instead of the whole pass is what keeps a single broken
+	// channel from muting the healthy ones; the claw keeps no delivery row for
+	// the parked route, so it is re-selected and retried later.
+	errs, ok := err.(lifecycleRouteSendErrors)
 	if !ok {
 		return false
 	}
-	handled, _ := s.handleLifecycleSendError(routeErr.err, "claw event "+deliveryKey, deliveryKey, runKey, routeErr.notifier, len(d.routes) == 1)
-	return handled
+	for _, routeErr := range errs {
+		if handled, _ := s.handleLifecycleSendError(routeErr.err, "claw event "+deliveryKey, deliveryKey, runKey, routeErr.notifier, d.singleRoute()); !handled {
+			d.pauseRoute(routeErr.notifier)
+		}
+	}
+	// Only stop the pass once nothing is left to deliver through.
+	return d.hasLiveRoutes()
 }
 
 type lifecycleClawPRRow struct {

--- a/pkg/hub/lifecycle_claw_notifier.go
+++ b/pkg/hub/lifecycle_claw_notifier.go
@@ -295,9 +295,30 @@ func (s *Server) ensureLifecycleClawRouteBaselines(lc *types.LifecycleNotificati
 		// ensureLifecycleClawRouteBaseline handles its one key.
 		return
 	}
-	if _, found, err := s.notifierStateInt64(lifecycleStateClawBaselineKey); err != nil || !found {
-		// Never baselined: the claw pass's own first-run seeding covers every
-		// route in one statement.
+	if _, found, err := s.notifierStateInt64(lifecycleStateClawBaselineKey); err != nil {
+		return
+	} else if !found {
+		// Never baselined. Leaving this to the claw pass's own first-run
+		// seeding is what buries the very window the tick promises is "held
+		// until it can be built": on a first-ever enable where NO route can be
+		// built, the tick returns before the claw pass runs, so the fence is
+		// written on the first BUILDABLE tick instead — marking every ad-hoc
+		// claw that connected during the outage as handled, while the task-run
+		// cursors stamped just above deliver that same window. Seed it here,
+		// at config time, exactly as initLifecycleNotifierBaseline does at boot.
+		if !s.lifecycleRouteWatermarksMaterialised(routes) {
+			// ensureLifecycleRouteWatermarks bailed on a state-read failure, so
+			// a route has no cursor yet; stamping its claw baseline now would
+			// make it read as the legacy incumbent (lifecycleSingleViaIncumbent)
+			// and hand it the shared floor. The next tick retries both in order.
+			return
+		}
+		if err := s.seedLifecycleClawBaseline(); err != nil {
+			log.Printf("[notify] seed claw baseline: %v", err)
+			return
+		}
+		s.setNotifierStateInt64(lifecycleStateClawBaselineKey, 1)
+		s.stampLifecycleClawRouteBaselines(lc)
 		return
 	}
 	for _, route := range routes {

--- a/pkg/hub/lifecycle_claw_notifier.go
+++ b/pkg/hub/lifecycle_claw_notifier.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/elasticclaw/elasticclaw/pkg/types"
@@ -187,10 +188,16 @@ func (s *Server) lifecycleClawPass(d lifecycleDelivery) {
 			return
 		}
 		s.setNotifierStateInt64(lifecycleStateClawBaselineKey, 1)
-		for _, route := range d.effectiveRoutes() {
+		for _, route := range d.lc.EffectiveRoutes() {
 			// The shared baseline just recorded the current state for every
-			// route, so none of them needs its own seeding pass.
-			s.setNotifierStateInt64(lifecycleClawRouteBaselineKey(route.notifier), 1)
+			// route, so none of them needs its own seeding pass. Stamp every
+			// CONFIGURED route, not only the ones that built this tick: a route
+			// whose notifier was unavailable here would otherwise arrive with no
+			// baseline key and be seeded on recovery, burying exactly the claw
+			// events the tick promises are "still pending for it".
+			if via := strings.TrimSpace(route.Via); via != "" {
+				s.setNotifierStateInt64(lifecycleClawRouteBaselineKey(via), 1)
+			}
 		}
 		return
 	}
@@ -231,34 +238,64 @@ func (s *Server) lifecycleClawPass(d lifecycleDelivery) {
 
 // lifecycleClawRoutePass runs the four claw-sourced kinds for one route. A kind
 // the route's allow-list rejects is never scanned, so those claws cannot
-// consume the route's batch either.
+// consume the route's batch either — but it IS parked, exactly as the global
+// toggles park a kind they mute. The claw pass has no cursor, so without a
+// delivery row every claw still connected (and every claw_prs row still open)
+// since the route's baseline would be replayed into the channel the moment the
+// operator adds that event type to the route's allow-list.
 func (s *Server) lifecycleClawRoutePass(d lifecycleDelivery, route lifecycleRouteDelivery, startedOn, prOn, failuresOn, idleOn bool) {
-	if startedOn && lifecycleRouteAccepts(route, taskRunEventAgentStarted) &&
-		!s.sendLifecycleClawStateEvents(d, route, lifecycleClawKindStarted) {
-		return
+	if startedOn {
+		if !lifecycleRouteAccepts(route, taskRunEventAgentStarted) {
+			_ = s.skipCurrentLifecycleClawRouteState(route.notifier, lifecycleClawKindStarted)
+		} else if !s.sendLifecycleClawStateEvents(d, route, lifecycleClawKindStarted) {
+			return
+		}
 	}
-	if failuresOn && lifecycleRouteAccepts(route, taskRunEventAgentStopped) &&
-		!s.sendLifecycleClawStateEvents(d, route, lifecycleClawKindFailure) {
-		return
+	if failuresOn {
+		if !lifecycleRouteAccepts(route, taskRunEventAgentStopped) {
+			_ = s.skipCurrentLifecycleClawRouteState(route.notifier, lifecycleClawKindFailure)
+		} else if !s.sendLifecycleClawStateEvents(d, route, lifecycleClawKindFailure) {
+			return
+		}
 	}
-	if idleOn && lifecycleRouteAccepts(route, taskRunEventAgentIdle) &&
-		!s.sendLifecycleClawIdleEvents(d, route) {
-		return
+	if idleOn {
+		if !lifecycleRouteAccepts(route, taskRunEventAgentIdle) {
+			_ = s.skipCurrentLifecycleClawRouteIdle(route.notifier)
+		} else if !s.sendLifecycleClawIdleEvents(d, route) {
+			return
+		}
 	}
-	if prOn && lifecycleRouteAccepts(route, taskRunEventPROpened) {
-		s.lifecycleClawPRPass(d, route)
+	if prOn {
+		if !lifecycleRouteAccepts(route, taskRunEventPROpened) {
+			_ = s.skipCurrentLifecycleClawRoutePRs(route.notifier)
+		} else {
+			s.lifecycleClawPRPass(d, route)
+		}
 	}
 }
 
 // ensureLifecycleClawRouteBaseline records a newly configured route's history
 // and reports whether the route may deliver this tick. The legacy single-`via`
-// shape needs none: it keeps writing the shared legacy rows, which already
-// fence every claw it has handled.
+// shape needs no seeding: it keeps writing the shared legacy rows, which
+// already fence every claw it has handled.
 func (s *Server) ensureLifecycleClawRouteBaseline(d lifecycleDelivery, route lifecycleRouteDelivery) bool {
+	key := lifecycleClawRouteBaselineKey(route.notifier)
 	if d.singleRoute() {
+		// Stamp the incumbent's baseline key anyway (best effort — an
+		// unreadable state must never hold up the legacy shape's delivery).
+		// Migrating this config to multi-route would otherwise present the
+		// incumbent as a newly added route and seed its current claw state as
+		// "skipped", destroying the backlog it never delivered — for example
+		// the claws that reached 'connected' while its token secret was
+		// missing. Its history lives in the legacy delivery table, so the key
+		// is stamped WITHOUT seeding any rows.
+		if route.notifier != "" {
+			if _, found, err := s.notifierStateInt64(key); err == nil && !found {
+				s.setNotifierStateInt64(key, 1)
+			}
+		}
 		return true
 	}
-	key := lifecycleClawRouteBaselineKey(route.notifier)
 	_, found, err := s.notifierStateInt64(key)
 	if err != nil {
 		// Unreadable state must not be mistaken for "already baselined": that
@@ -281,35 +318,64 @@ func (s *Server) ensureLifecycleClawRouteBaseline(d lifecycleDelivery, route lif
 // handled for one route, mirroring seedLifecycleClawBaseline into the per-route
 // table.
 func (s *Server) seedLifecycleClawRouteBaseline(notifier string) error {
-	startedCond, startedSuffix := lifecycleClawStateCondition(lifecycleClawKindStarted)
-	failureCond, failureSuffix := lifecycleClawStateCondition(lifecycleClawKindFailure)
-	at := epochMillis(now())
-	const insert = `INSERT INTO slack_notification_deliveries_v2(event_id, notifier, run_id, delivered_at, message_ts, status) `
-	stmts := []struct {
-		query string
-		args  []any
-	}{
-		{insert + `SELECT 'claw:' || c.id || ?, ?, 'claw:' || c.id, ?, '', ?
-			  FROM claws c WHERE c.task_run_id = '' AND ` + startedCond + `
-			ON CONFLICT(event_id, notifier) DO NOTHING`, []any{startedSuffix, notifier, at, notificationDeliveryStatusSkipped}},
-		{insert + `SELECT 'claw:' || c.id || ?, ?, 'claw:' || c.id, ?, '', ?
-			  FROM claws c WHERE c.task_run_id = '' AND ` + failureCond + `
-			ON CONFLICT(event_id, notifier) DO NOTHING`, []any{failureSuffix, notifier, at, notificationDeliveryStatusSkipped}},
-		{insert + `SELECT 'claw:' || c.id || ':idle:' || c.idle_since, ?, 'claw:' || c.id, ?, '', ?
-			  FROM claws c WHERE c.task_run_id = '' AND c.idle_since > 0
-			ON CONFLICT(event_id, notifier) DO NOTHING`, []any{notifier, at, notificationDeliveryStatusSkipped}},
-		// The WHERE clause is load-bearing: without it SQLite parses ON CONFLICT
-		// as the start of a join clause and rejects the statement.
-		{insert + `SELECT 'claw:' || p.claw_id || ':pr:' || p.pr_url, ?, 'claw:' || p.claw_id, ?, '', ?
-			  FROM claw_prs p WHERE true
-			ON CONFLICT(event_id, notifier) DO NOTHING`, []any{notifier, at, notificationDeliveryStatusSkipped}},
+	if err := s.skipCurrentLifecycleClawRouteState(notifier, lifecycleClawKindStarted); err != nil {
+		return err
 	}
-	for _, stmt := range stmts {
-		if _, err := s.db.Exec(stmt.query, stmt.args...); err != nil {
-			return err
-		}
+	if err := s.skipCurrentLifecycleClawRouteState(notifier, lifecycleClawKindFailure); err != nil {
+		return err
 	}
-	return nil
+	if err := s.skipCurrentLifecycleClawRouteIdle(notifier); err != nil {
+		return err
+	}
+	return s.skipCurrentLifecycleClawRoutePRs(notifier)
+}
+
+// lifecycleClawAdhocCutoff is the created_at bound (unix seconds) every
+// claw-pass statement shares: a claw younger than the ad-hoc grace is not yet
+// classified as ad-hoc, so it must be neither selected nor fenced.
+func lifecycleClawAdhocCutoff() int64 { return now().Add(-lifecycleClawAdhocGrace).Unix() }
+
+// lifecycleClawRouteSkip records claw-pass events as already handled for ONE
+// route — the per-route analog of the skipCurrent* helpers, which write the
+// shared legacy rows that fence every route at once. Two callers share it: the
+// baseline of a newly added route, and the per-tick parking of a kind the
+// route's allow-list rejects.
+func (s *Server) lifecycleClawRouteSkip(notifier, what, selectSQL string, args ...any) error {
+	_, err := s.db.Exec(`
+		INSERT INTO slack_notification_deliveries_v2(event_id, notifier, run_id, delivered_at, message_ts, status)`+
+		selectSQL+`
+		ON CONFLICT(event_id, notifier) DO NOTHING`, args...)
+	if err != nil {
+		log.Printf("[notify] seed skipped claw %s deliveries for %q: %v", what, notifier, err)
+	}
+	return err
+}
+
+func (s *Server) skipCurrentLifecycleClawRouteState(notifier, kind string) error {
+	cond, suffix := lifecycleClawStateCondition(kind)
+	return s.lifecycleClawRouteSkip(notifier, kind, `
+		SELECT 'claw:' || c.id || ?, ?, 'claw:' || c.id, ?, '', ?
+		  FROM claws c
+		 WHERE c.task_run_id = '' AND `+cond+`
+		   AND CAST(strftime('%s', c.created_at) AS INTEGER) <= ?`,
+		suffix, notifier, epochMillis(now()), notificationDeliveryStatusSkipped, lifecycleClawAdhocCutoff())
+}
+
+func (s *Server) skipCurrentLifecycleClawRouteIdle(notifier string) error {
+	return s.lifecycleClawRouteSkip(notifier, "idle", `
+		SELECT 'claw:' || c.id || ':idle:' || c.idle_since, ?, 'claw:' || c.id, ?, '', ?
+		  FROM claws c
+		 WHERE c.task_run_id = '' AND c.idle_since > 0
+		   AND CAST(strftime('%s', c.created_at) AS INTEGER) <= ?`,
+		notifier, epochMillis(now()), notificationDeliveryStatusSkipped, lifecycleClawAdhocCutoff())
+}
+
+func (s *Server) skipCurrentLifecycleClawRoutePRs(notifier string) error {
+	return s.lifecycleClawRouteSkip(notifier, "PR", `
+		SELECT 'claw:' || p.claw_id || ':pr:' || p.pr_url, ?, 'claw:' || p.claw_id, ?, '', ?
+		  FROM claw_prs p JOIN claws c ON c.id = p.claw_id
+		 WHERE CAST(strftime('%s', c.created_at) AS INTEGER) <= ?`,
+		notifier, epochMillis(now()), notificationDeliveryStatusSkipped, lifecycleClawAdhocCutoff())
 }
 
 // seedLifecycleClawBaseline records the current claw/PR state as already handled.
@@ -415,7 +481,7 @@ func (s *Server) skipCurrentLifecycleClawIdle() error {
 // not "PR out, awaiting humans", and suppressing the idle notification on it
 // would hide a hung claw the watcher will also never finalize.
 func (s *Server) selectLifecycleClawIdleCandidates(notifier string) ([]lifecycleClawRow, []int64, error) {
-	cutoff := now().Add(-lifecycleClawAdhocGrace).Unix()
+	cutoff := lifecycleClawAdhocCutoff()
 	rows, err := s.db.Query(`
 		SELECT `+lifecycleClawSelectColumns+`, c.idle_since
 		  FROM claws c
@@ -523,7 +589,7 @@ func lifecycleClawStateCondition(kind string) (cond, keySuffix string) {
 // of holding every other route's claws in a shared, oldest-first batch.
 func (s *Server) selectLifecycleClawStateCandidates(kind, notifier string) ([]lifecycleClawRow, error) {
 	cond, suffix := lifecycleClawStateCondition(kind)
-	cutoff := now().Add(-lifecycleClawAdhocGrace).Unix()
+	cutoff := lifecycleClawAdhocCutoff()
 	rows, err := s.db.Query(`
 		SELECT `+lifecycleClawSelectColumns+`
 		  FROM claws c
@@ -679,7 +745,7 @@ func (s *Server) lifecycleClawPRPass(d lifecycleDelivery, route lifecycleRouteDe
 		return
 	}
 
-	cutoff := now().Add(-lifecycleClawAdhocGrace).Unix()
+	cutoff := lifecycleClawAdhocCutoff()
 	for _, pr := range prs {
 		if pr.TaskRunID != "" {
 			// Owned by the task-run pass. Record a skipped row under this

--- a/pkg/hub/lifecycle_claw_notifier.go
+++ b/pkg/hub/lifecycle_claw_notifier.go
@@ -491,7 +491,11 @@ func (s *Server) deliverLifecycleClawEvent(d lifecycleDelivery, claw lifecycleCl
 	}
 	// Same send-failure policy as the task-run pass: config errors pause,
 	// permanent errors are burned as failed, transient errors stop the pass.
-	handled, _ := s.handleLifecycleSendError(err, "claw event "+deliveryKey, deliveryKey, runKey)
+	routeErr, ok := err.(lifecycleRouteSendError)
+	if !ok {
+		return false
+	}
+	handled, _ := s.handleLifecycleSendError(routeErr.err, "claw event "+deliveryKey, deliveryKey, runKey, routeErr.notifier, len(d.routes) == 1)
 	return handled
 }
 

--- a/pkg/hub/lifecycle_claw_notifier.go
+++ b/pkg/hub/lifecycle_claw_notifier.go
@@ -279,6 +279,37 @@ func (s *Server) stampLifecycleClawRouteBaselines(lc *types.LifecycleNotificatio
 	}
 }
 
+// stampLifecycleLegacyIncumbent records the single-`via` incumbent's claw
+// baseline at CONFIG time, without seeding, for the shape that keeps reading
+// the shared state. The first tick on which the notifier BUILDS stamps the same
+// key (ensureLifecycleClawRouteBaseline), but a lone route whose notifier can
+// never be built delivers nothing and stamps nothing, so the hub keeps no
+// record that it was the incumbent at all: replacing it with a working channel
+// then finds no per-route state to prune, leaves the routes_live latch clear,
+// and hands the newcomer the incumbent's frozen shared cursor — replaying
+// everything that piled up during the outage into a brand-new channel. Only
+// meaningful once the shared claw baseline exists; before that the claw pass's
+// own first-run seeding is the fence, and it stamps every configured route.
+func (s *Server) stampLifecycleLegacyIncumbent(lc *types.LifecycleNotificationsConfig) {
+	via := lifecycleLegacyIncumbentVia(lc)
+	if via == "" {
+		return
+	}
+	if _, found, err := s.notifierStateInt64(lifecycleStateClawBaselineKey); err != nil || !found {
+		return
+	}
+	// Once the per-route scheme is live nothing reads a lone route as the
+	// incumbent, so the stamp would only mislabel a newcomer.
+	if live, err := s.lifecycleRoutingSchemeLive(); err != nil || live {
+		return
+	}
+	key := lifecycleClawRouteBaselineKey(via)
+	if _, found, err := s.notifierStateInt64(key); err != nil || found {
+		return
+	}
+	s.setNotifierStateInt64(key, 1)
+}
+
 // ensureLifecycleClawRouteBaselines fences the claw-pass history of every
 // CONFIGURED route at the moment the route appears in config — not at the first
 // tick its notifier happens to build. ensureLifecycleRouteWatermarks already
@@ -292,7 +323,9 @@ func (s *Server) ensureLifecycleClawRouteBaselines(lc *types.LifecycleNotificati
 	routes := lc.EffectiveRoutes()
 	if !s.lifecycleRoutesNeedOwnState(routes) {
 		// The legacy single-route shape is fenced by the legacy delivery table;
-		// ensureLifecycleClawRouteBaseline handles its one key.
+		// ensureLifecycleClawRouteBaseline handles its one key — but only on a
+		// tick where the notifier builds, so record the incumbent here too.
+		s.stampLifecycleLegacyIncumbent(lc)
 		return
 	}
 	if _, found, err := s.notifierStateInt64(lifecycleStateClawBaselineKey); err != nil {

--- a/pkg/hub/lifecycle_claw_notifier.go
+++ b/pkg/hub/lifecycle_claw_notifier.go
@@ -279,6 +279,42 @@ func (s *Server) stampLifecycleClawRouteBaselines(lc *types.LifecycleNotificatio
 	}
 }
 
+// ensureLifecycleClawRouteBaselines fences the claw-pass history of every
+// CONFIGURED route at the moment the route appears in config — not at the first
+// tick its notifier happens to build. ensureLifecycleRouteWatermarks already
+// materialises the task-run cursor of a route whose notifier is unbuildable
+// (typo'd token secret), so seeding its claw baseline only on recovery would
+// bury exactly the claw events the tick promises are "held until it can be
+// built", while the task-run events of the same window are delivered.
+func (s *Server) ensureLifecycleClawRouteBaselines(lc *types.LifecycleNotificationsConfig) {
+	routes := lc.EffectiveRoutes()
+	if len(routes) < 2 {
+		// The legacy single-route shape is fenced by the legacy delivery table;
+		// ensureLifecycleClawRouteBaseline handles its one key.
+		return
+	}
+	if _, found, err := s.notifierStateInt64(lifecycleStateClawBaselineKey); err != nil || !found {
+		// Never baselined: the claw pass's own first-run seeding covers every
+		// route in one statement.
+		return
+	}
+	for _, route := range routes {
+		via := strings.TrimSpace(route.Via)
+		if via == "" {
+			continue
+		}
+		key := lifecycleClawRouteBaselineKey(via)
+		if _, found, err := s.notifierStateInt64(key); err != nil || found {
+			continue
+		}
+		if err := s.seedLifecycleClawRouteBaseline(via); err != nil {
+			log.Printf("[notify] seed claw baseline for %q: %v", via, err)
+			continue
+		}
+		s.setNotifierStateInt64(key, 1)
+	}
+}
+
 // ensureLifecycleClawRouteBaseline records a newly configured route's history
 // and reports whether the route may deliver this tick. The legacy single-`via`
 // shape needs no seeding: it keeps writing the shared legacy rows, which
@@ -296,6 +332,25 @@ func (s *Server) ensureLifecycleClawRouteBaseline(d lifecycleDelivery, route lif
 		// is stamped WITHOUT seeding any rows.
 		if route.notifier != "" {
 			if _, found, err := s.notifierStateInt64(key); err == nil && !found {
+				// ...but only the GENUINE legacy incumbent has history in that
+				// table. Collapsing a multi-route config to a single NEW route
+				// lands here too, and the multi-route era wrote v2 rows keyed by
+				// the OTHER notifiers only — so stamping would flood the new
+				// channel with every still-connected claw and open PR. Once the
+				// per-route scheme has been live, seed like any newcomer.
+				live, err := s.lifecycleRoutingSchemeLive()
+				if err != nil {
+					log.Printf("[notify] read routing scheme state for %q: %v", route.notifier, err)
+					return false
+				}
+				if live {
+					if err := s.seedLifecycleClawRouteBaseline(route.notifier); err != nil {
+						log.Printf("[notify] seed claw baseline for %q: %v", route.notifier, err)
+						return false
+					}
+					s.setNotifierStateInt64(key, 1)
+					return false
+				}
 				s.setNotifierStateInt64(key, 1)
 			}
 		}

--- a/pkg/hub/lifecycle_claw_notifier.go
+++ b/pkg/hub/lifecycle_claw_notifier.go
@@ -407,8 +407,20 @@ func (s *Server) lifecycleClawRouteSkip(notifier, what, selectSQL string, args .
 		ON CONFLICT(event_id, notifier) DO NOTHING`, args...)
 	if err != nil {
 		log.Printf("[notify] seed skipped claw %s deliveries for %q: %v", what, notifier, err)
+		return err
 	}
-	return err
+	// A route-level fence means this route's history no longer lives entirely in
+	// the legacy delivery table — the single-route shape reaches here too, via
+	// the per-tick parking of a kind its allow-list rejects. Latch the scheme so
+	// that swapping that route's name later cannot take the "stamp without
+	// seeding" path reserved for the genuine legacy incumbent and replay every
+	// still-connected, failed or idle claw into the new channel.
+	if notifier != "" {
+		if _, found, err := s.notifierStateInt64(lifecycleStateRoutedKey); err == nil && !found {
+			s.setNotifierStateInt64(lifecycleStateRoutedKey, 1)
+		}
+	}
+	return nil
 }
 
 func (s *Server) skipCurrentLifecycleClawRouteState(notifier, kind string) error {

--- a/pkg/hub/lifecycle_claw_notifier_test.go
+++ b/pkg/hub/lifecycle_claw_notifier_test.go
@@ -42,6 +42,15 @@ func insertSlackTestClawPR(t *testing.T, db *sql.DB, id, clawID, repo string, pr
 func setLifecycleClawBaseline(t *testing.T, s *Server) {
 	t.Helper()
 	s.setNotifierStateInt64(lifecycleStateClawBaselineKey, 1)
+	// Multi-route configs also carry a per-route baseline (a route added later
+	// must not replay the current claw list into its channel); mark the
+	// configured routes as already baselined so the helper keeps meaning
+	// "enabled with empty history".
+	if cfg := s.notificationsConfig(); cfg != nil && cfg.Lifecycle != nil {
+		for _, route := range cfg.Lifecycle.EffectiveRoutes() {
+			s.setNotifierStateInt64(lifecycleClawRouteBaselineKey(strings.TrimSpace(route.Via)), 1)
+		}
+	}
 }
 
 // oldEnough is safely past the ad-hoc grace period.
@@ -218,7 +227,9 @@ func TestLifecycleClawNotifierPreSendRecheckCedesToTaskRunPath(t *testing.T) {
 	setLifecycleClawBaseline(t, s)
 
 	insertSlackTestClaw(t, db, "claw-x", "connected", 1, "", oldEnough)
-	claws, err := s.selectLifecycleClawStateCandidates(lifecycleClawKindStarted)
+	d := testLifecycleDelivery(t, s)
+	route := d.effectiveRoutes()[0]
+	claws, err := s.selectLifecycleClawStateCandidates(lifecycleClawKindStarted, route.notifier)
 	if err != nil || len(claws) != 1 {
 		t.Fatalf("candidates = %d, err %v; want 1 candidate", len(claws), err)
 	}
@@ -228,9 +239,8 @@ func TestLifecycleClawNotifierPreSendRecheckCedesToTaskRunPath(t *testing.T) {
 		t.Fatalf("attach task run: %v", err)
 	}
 
-	d := testLifecycleDelivery(t, s)
 	ev, deliveryKey := lifecycleClawStateEvent(lifecycleClawKindStarted, claws[0])
-	if !s.deliverLifecycleClawEvent(d, claws[0], ev, lifecycleClawRunContext(claws[0]), deliveryKey) {
+	if !s.deliverLifecycleClawEvent(d, route, claws[0], ev, lifecycleClawRunContext(claws[0]), deliveryKey) {
 		t.Fatal("ceding to the task-run path must count as handled")
 	}
 	if fake.count() != 0 {
@@ -613,7 +623,7 @@ func TestLifecycleClawIdleCandidatesIgnoreMentionOnlyPRs(t *testing.T) {
 	if _, err := db.Exec(`UPDATE claw_prs SET mention_only=1 WHERE id='pr-idle-mention'`); err != nil {
 		t.Fatal(err)
 	}
-	claws, _, err := s.selectLifecycleClawIdleCandidates()
+	claws, _, err := s.selectLifecycleClawIdleCandidates("")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -625,7 +635,7 @@ func TestLifecycleClawIdleCandidatesIgnoreMentionOnlyPRs(t *testing.T) {
 	if _, err := db.Exec(`UPDATE claw_prs SET mention_only=0 WHERE id='pr-idle-mention'`); err != nil {
 		t.Fatal(err)
 	}
-	claws, _, err = s.selectLifecycleClawIdleCandidates()
+	claws, _, err = s.selectLifecycleClawIdleCandidates("")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/hub/lifecycle_notifier.go
+++ b/pkg/hub/lifecycle_notifier.go
@@ -484,14 +484,45 @@ func (s *Server) lifecycleWatermarkKeyFor(d lifecycleDelivery, notifier string) 
 	// legacy delivery row (multi-route writes v2 rows only, keyed by the OTHER
 	// notifiers), so the survivor would re-send every one of them. A route only
 	// has a cursor of its own because it was configured alongside a sibling, so
-	// keeping it whenever it exists is exactly the "no silent re-point" rule; a
-	// genuine legacy single-`via` never has one and still reads the shared key.
+	// keeping it whenever it exists is exactly the "no silent re-point" rule.
 	// A read error deliberately keeps the per-route key too: the pass's own read
 	// then fails and the route waits, rather than replaying from the floor.
 	if _, found, err := s.notifierStateInt64(key); err != nil || found {
 		return key
 	}
+	// The genuine legacy incumbent — the route that has already been running as
+	// the single `via` — reads the shared key: that IS its position, and its
+	// history lives in the legacy delivery table.
+	if s.lifecycleSingleViaIncumbent(notifier) {
+		return lifecycleStateWatermarkKey
+	}
+	// Anything else arriving here is a NEWCOMER that happens to be alone:
+	// collapsing a multi-route config to ONE brand-new route deletes the old
+	// cursors (pruneLifecycleRouteState) and leaves none of its own, so without
+	// this it would adopt the floor frozen at the stalled route's position and
+	// replay the whole multi-route-era backlog — none of which carries a legacy
+	// row, because that era wrote v2 rows keyed by the OLD notifiers only. Once
+	// the per-route scheme has been live, start it at the head like any other
+	// newcomer; the pass's first-run backstop materialises the cursor there.
+	if live, err := s.lifecycleRoutingSchemeLive(); err != nil || live {
+		return key
+	}
 	return lifecycleStateWatermarkKey
+}
+
+// lifecycleSingleViaIncumbent reports whether a route has already been
+// delivering as the legacy single-`via` incumbent. The single-route shape
+// stamps `claw_baseline_done:<via>` without seeding for exactly this purpose
+// (ensureLifecycleClawRouteBaseline), so the stamp — with no per-route cursor
+// beside it — is what tells the incumbent apart from a route that only just
+// appeared in config. An unreadable state is not an incumbent: the callers'
+// fallbacks (per-route key, stream head) are the safe side of that answer.
+func (s *Server) lifecycleSingleViaIncumbent(via string) bool {
+	if via == "" {
+		return false
+	}
+	_, found, err := s.notifierStateInt64(lifecycleClawRouteBaselineKey(via))
+	return err == nil && found
 }
 
 // ensureLifecycleRouteWatermarks gives every CONFIGURED route a cursor of its
@@ -541,6 +572,20 @@ func (s *Server) ensureLifecycleRouteWatermarks(lc *types.LifecycleNotifications
 		// the floor exists from the start.
 		s.setNotifierStateInt64(lifecycleStateWatermarkKey, head)
 	}
+	// At the migration tick only the incumbent may inherit the shared cursor.
+	// The shared key is the incumbent's real position, but for the channel being
+	// ADDED — the whole reason the migration runs through the settings screen —
+	// it is a cursor frozen wherever the incumbent stalled, and the events above
+	// it carry no delivery row of any kind that could fence them, so the
+	// newcomer would replay the incumbent's entire backlog. A config that was
+	// multi-route from its very first enable has no incumbent to tell apart, and
+	// there its routes do all share one starting position.
+	incumbents := map[string]bool{}
+	for _, route := range routes {
+		if via := strings.TrimSpace(route.Via); via != "" && s.lifecycleSingleViaIncumbent(via) {
+			incumbents[via] = true
+		}
+	}
 	for _, route := range routes {
 		via := strings.TrimSpace(route.Via)
 		if via == "" {
@@ -550,7 +595,7 @@ func (s *Server) ensureLifecycleRouteWatermarks(lc *types.LifecycleNotifications
 		if _, found, err := s.notifierStateInt64(key); err != nil || found {
 			continue
 		}
-		if !routed && sharedFound {
+		if !routed && sharedFound && (len(incumbents) == 0 || incumbents[via]) {
 			s.setNotifierStateInt64(key, shared)
 			continue
 		}

--- a/pkg/hub/lifecycle_notifier.go
+++ b/pkg/hub/lifecycle_notifier.go
@@ -784,6 +784,7 @@ func (s *Server) pruneLifecycleRouteState(lc *types.LifecycleNotificationsConfig
 		return
 	}
 	var stale []string
+	gone := map[string]bool{}
 	schemeLive := false
 	for rows.Next() {
 		var key string
@@ -798,6 +799,7 @@ func (s *Server) pruneLifecycleRouteState(lc *types.LifecycleNotificationsConfig
 		notifier := key[strings.Index(key, ":")+1:]
 		if !configured[notifier] {
 			stale = append(stale, key)
+			gone[notifier] = true
 			// Deleting ANY per-route stamp counts as evidence too: a hub that
 			// never went past the legacy single-`via` shape records its
 			// incumbent only as a claw baseline stamp, so replacing that route
@@ -818,6 +820,48 @@ func (s *Server) pruneLifecycleRouteState(lc *types.LifecycleNotificationsConfig
 			s.setNotifierStateInt64(lifecycleStateRoutedKey, 1)
 		}
 	}
+	for _, key := range stale {
+		s.clearNotifierState(key)
+	}
+	s.clearLifecycleTransientFailures(gone)
+}
+
+// clearLifecycleTransientFailures drops the transient-failure streaks of
+// notifiers that are no longer routed. A streak row exists only while a streak
+// is live — a successful send clears its own key, the cap clears the key it
+// burns — so a route removed mid-streak leaves its counters behind with nothing
+// left to clear them. Re-adding the route under the same name would then hand
+// it a retry budget already spent for every delivery key that recurs (a
+// reopened PR re-uses claw:<id>:pr:<url>), burning the notification on the
+// first transient blip instead of after lifecycleMaxTransientFailures.
+func (s *Server) clearLifecycleTransientFailures(notifiers map[string]bool) {
+	if len(notifiers) == 0 {
+		return
+	}
+	prefix := lifecycleTransientFailureStateKey("")
+	rows, err := s.db.Query(`SELECT key FROM slack_notifier_state WHERE key LIKE ?`, prefix+"%")
+	if err != nil {
+		log.Printf("[notify] list transient-failure state: %v", err)
+		return
+	}
+	var stale []string
+	for rows.Next() {
+		var key string
+		if err := rows.Scan(&key); err != nil {
+			log.Printf("[notify] list transient-failure state: %v", err)
+			rows.Close()
+			return
+		}
+		// Only the per-notifier shape is namespaced; the legacy key is
+		// "transient_failures:<deliveryKey>" and belongs to no notifier.
+		rest := key[len(prefix):]
+		sep := strings.Index(rest, ":")
+		if sep < 0 || !notifiers[rest[:sep]] {
+			continue
+		}
+		stale = append(stale, key)
+	}
+	rows.Close()
 	for _, key := range stale {
 		s.clearNotifierState(key)
 	}

--- a/pkg/hub/lifecycle_notifier.go
+++ b/pkg/hub/lifecycle_notifier.go
@@ -39,6 +39,15 @@ const (
 	// past), so a timestamp watermark would silently skip backdated rows.
 	lifecycleStateWatermarkKey = "watermark_rowid"
 
+	// lifecycleStateRoutedKey records that the per-route state scheme has been
+	// live at least once. The per-route keys alone cannot answer that question:
+	// pruneLifecycleRouteState deletes the cursors of routes that are no longer
+	// configured, so replacing every route in one save erases the evidence in
+	// the same tick the newcomers are seeded — and they would then inherit the
+	// (long frozen) shared floor instead of the stream head. Nothing deletes
+	// this key: once routing is live it stays live for the hub's lifetime.
+	lifecycleStateRoutedKey = "routes_live"
+
 	// lifecycleSendWarningKey keys the log-once warning for
 	// configuration-level send failures (bad token, missing channel).
 	lifecycleSendWarningKey = "notify-send"
@@ -416,6 +425,7 @@ func (s *Server) lifecycleNotifierTick() {
 	// route that cannot be built this tick is still treated as configured.
 	s.pruneLifecycleRouteState(lc)
 	s.ensureLifecycleRouteWatermarks(lc)
+	s.ensureLifecycleClawRouteBaselines(lc)
 	var routes []lifecycleRouteDelivery
 	incomplete := false
 	for _, route := range lc.EffectiveRoutes() {
@@ -461,10 +471,27 @@ func lifecycleRouteWatermarkKey(notifier string) string {
 }
 
 func (s *Server) lifecycleWatermarkKeyFor(d lifecycleDelivery, notifier string) string {
-	if notifier == "" || d.singleRoute() {
+	if notifier == "" {
 		return lifecycleStateWatermarkKey
 	}
-	return lifecycleRouteWatermarkKey(notifier)
+	key := lifecycleRouteWatermarkKey(notifier)
+	if !d.singleRoute() {
+		return key
+	}
+	// Collapsing a multi-route config back to one route must not silently
+	// re-point the survivor at the shared key: that floor is pinned to the
+	// SLOWEST route of the multi-route era, and the events above it carry no
+	// legacy delivery row (multi-route writes v2 rows only, keyed by the OTHER
+	// notifiers), so the survivor would re-send every one of them. A route only
+	// has a cursor of its own because it was configured alongside a sibling, so
+	// keeping it whenever it exists is exactly the "no silent re-point" rule; a
+	// genuine legacy single-`via` never has one and still reads the shared key.
+	// A read error deliberately keeps the per-route key too: the pass's own read
+	// then fails and the route waits, rather than replaying from the floor.
+	if _, found, err := s.notifierStateInt64(key); err != nil || found {
+		return key
+	}
+	return lifecycleStateWatermarkKey
 }
 
 // ensureLifecycleRouteWatermarks gives every CONFIGURED route a cursor of its
@@ -490,7 +517,7 @@ func (s *Server) ensureLifecycleRouteWatermarks(lc *types.LifecycleNotifications
 		// (lifecycleWatermarkKeyFor), so it needs no cursor of its own.
 		return
 	}
-	routed, err := s.lifecycleRouteStateExists(lifecycleStateWatermarkKey + ":")
+	routed, err := s.lifecycleRoutingSchemeLive()
 	if err != nil {
 		// Unreadable state must not be mistaken for "nothing routed yet": that
 		// would hand a route added later the (possibly long-frozen) shared floor.
@@ -529,6 +556,27 @@ func (s *Server) ensureLifecycleRouteWatermarks(lc *types.LifecycleNotifications
 		}
 		s.setNotifierStateInt64(key, head)
 	}
+	if !routed {
+		// Latch the scheme so a later save that replaces every route at once
+		// cannot make the newcomers look like a fresh migration.
+		s.setNotifierStateInt64(lifecycleStateRoutedKey, 1)
+	}
+}
+
+// lifecycleRoutingSchemeLive reports whether the per-route state scheme has
+// already gone live for this hub. It is how both passes tell a legacy
+// single-`via` migration (nothing per-route recorded yet, so the shared state is
+// the routes' shared history) from routes genuinely added later (the scheme is
+// already live, so a newcomer must start clean). The persisted latch is the
+// authority; the per-route cursors are the fallback for hubs that went
+// multi-route before the latch existed.
+func (s *Server) lifecycleRoutingSchemeLive() (bool, error) {
+	if _, found, err := s.notifierStateInt64(lifecycleStateRoutedKey); err != nil {
+		return false, err
+	} else if found {
+		return true, nil
+	}
+	return s.lifecycleRouteStateExists(lifecycleStateWatermarkKey + ":")
 }
 
 // lifecycleRouteStateExists reports whether any per-route state key with the
@@ -567,6 +615,7 @@ func (s *Server) pruneLifecycleRouteState(lc *types.LifecycleNotificationsConfig
 		return
 	}
 	var stale []string
+	schemeLive := false
 	for rows.Next() {
 		var key string
 		if err := rows.Scan(&key); err != nil {
@@ -574,12 +623,25 @@ func (s *Server) pruneLifecycleRouteState(lc *types.LifecycleNotificationsConfig
 			rows.Close()
 			return
 		}
+		if strings.HasPrefix(key, lifecycleStateWatermarkKey+":") {
+			schemeLive = true
+		}
 		notifier := key[strings.Index(key, ":")+1:]
 		if !configured[notifier] {
 			stale = append(stale, key)
 		}
 	}
 	rows.Close()
+	if schemeLive {
+		// Latch before deleting: a save that replaces EVERY route removes the
+		// only per-route cursors, and ensureLifecycleRouteWatermarks (which runs
+		// straight after) would then read "nothing routed yet" and hand the
+		// brand-new channels the stale shared floor. This covers hubs that went
+		// multi-route before the latch existed.
+		if _, found, err := s.notifierStateInt64(lifecycleStateRoutedKey); err == nil && !found {
+			s.setNotifierStateInt64(lifecycleStateRoutedKey, 1)
+		}
+	}
 	for _, key := range stale {
 		s.clearNotifierState(key)
 	}

--- a/pkg/hub/lifecycle_notifier.go
+++ b/pkg/hub/lifecycle_notifier.go
@@ -216,11 +216,33 @@ func (s *Server) initLifecycleNotifierBaseline() {
 			log.Printf("[notify] init watermark baseline: %v", err)
 		}
 	}
-	if _, found, err := s.notifierStateInt64(lifecycleStateClawBaselineKey); err == nil && !found {
-		if err := s.seedLifecycleClawBaseline(); err == nil {
-			s.setNotifierStateInt64(lifecycleStateClawBaselineKey, 1)
-		} else {
-			log.Printf("[notify] init claw baseline: %v", err)
+	if _, found, err := s.notifierStateInt64(lifecycleStateClawBaselineKey); err == nil {
+		if !found {
+			if err := s.seedLifecycleClawBaseline(); err == nil {
+				s.setNotifierStateInt64(lifecycleStateClawBaselineKey, 1)
+				// The shared seeding just recorded the current claw state for
+				// every route, so none of them needs its own seeding pass. The
+				// in-tick first-enable branch stamps the same keys, but it can
+				// never run once this path created the shared flag — leaving
+				// every configured route to be treated as "newly added" on its
+				// first tick and have its pending claw events buried as
+				// "skipped" (a route whose notifier cannot even be built at
+				// boot is exactly the case the tick promises is "still pending
+				// for it").
+				s.stampLifecycleClawRouteBaselines(cfg.Lifecycle)
+			} else {
+				log.Printf("[notify] init claw baseline: %v", err)
+			}
+		} else if routed, err := s.lifecycleRouteStateExists(lifecycleClawRouteBaselinePrefix); err == nil && !routed {
+			// The shared flag predates the per-route scheme: this is the first
+			// boot after a single-`via` config was migrated to routes. Every
+			// claw the incumbent already handled is fenced by the legacy
+			// delivery table (lifecycleRouteDelivered reads it for every
+			// route), so stamping without seeding is enough — and it is what
+			// keeps the incumbent's undelivered backlog (claws that connected
+			// while its token secret was broken) from being buried the moment
+			// a second route makes it look newly added.
+			s.stampLifecycleClawRouteBaselines(cfg.Lifecycle)
 		}
 	}
 	// Stamp the agent_idle baseline at boot on the first enabled run so idle
@@ -390,6 +412,10 @@ func (s *Server) lifecycleNotifierTick() {
 		return
 	}
 	lc := cfg.Lifecycle
+	// Both run off the CONFIGURED routes, before any notifier is built, so a
+	// route that cannot be built this tick is still treated as configured.
+	s.pruneLifecycleRouteState(lc)
+	s.ensureLifecycleRouteWatermarks(lc)
 	var routes []lifecycleRouteDelivery
 	incomplete := false
 	for _, route := range lc.EffectiveRoutes() {
@@ -441,18 +467,122 @@ func (s *Server) lifecycleWatermarkKeyFor(d lifecycleDelivery, notifier string) 
 	return lifecycleRouteWatermarkKey(notifier)
 }
 
-// lifecycleRouteWatermark reads one route's cursor, falling back to the shared
-// cursor the first time a route runs. Without the fallback, migrating a
-// single-`via` config to routes would look like a first run and park the
-// pending backlog; the shared cursor is kept as a floor (see
-// advanceLifecycleWatermarkFloor) so the fallback stays close to "now" and a
-// route added years later does not replay the archive.
-func (s *Server) lifecycleRouteWatermark(key string) (int64, bool, error) {
-	value, found, err := s.notifierStateInt64(key)
-	if err != nil || found || key == lifecycleStateWatermarkKey {
-		return value, found, err
+// ensureLifecycleRouteWatermarks gives every CONFIGURED route a cursor of its
+// own before any delivery runs — including a route whose notifier cannot be
+// built this tick, which would otherwise still have none when it recovers.
+// Materialising the cursor here, rather than falling back lazily inside the
+// pass, is what lets a route added later be told apart from one that has simply
+// never delivered anything yet: the newcomer has no cursor because it was not
+// configured, and must start at the stream head.
+//
+// The routes present when a single-`via` config is migrated to routes inherit
+// the shared cursor — the incumbent's real position — so the migration does not
+// look like a first run and park the pending backlog. Once ANY route keeps a
+// cursor the per-route scheme is live, and a newcomer starts at the head
+// instead: from then on the shared key is a floor pinned to the SLOWEST route
+// (advanceLifecycleWatermarkFloor bails entirely while a configured route
+// cannot be built), so inheriting it would flood the new channel with
+// everything that piled up behind a paused or unbuildable sibling.
+func (s *Server) ensureLifecycleRouteWatermarks(lc *types.LifecycleNotificationsConfig) {
+	routes := lc.EffectiveRoutes()
+	if len(routes) < 2 {
+		// The legacy single-route shape keeps using the shared key
+		// (lifecycleWatermarkKeyFor), so it needs no cursor of its own.
+		return
 	}
-	return s.notifierStateInt64(lifecycleStateWatermarkKey)
+	routed, err := s.lifecycleRouteStateExists(lifecycleStateWatermarkKey + ":")
+	if err != nil {
+		// Unreadable state must not be mistaken for "nothing routed yet": that
+		// would hand a route added later the (possibly long-frozen) shared floor.
+		log.Printf("[notify] read route watermark state: %v", err)
+		return
+	}
+	shared, sharedFound, err := s.notifierStateInt64(lifecycleStateWatermarkKey)
+	if err != nil {
+		log.Printf("[notify] read watermark floor: %v", err)
+		return
+	}
+	head, err := s.lifecycleMaxEventRowID()
+	if err != nil {
+		log.Printf("[notify] read max event rowid: %v", err)
+		return
+	}
+	if !sharedFound {
+		// A config that is multi-route from its very first enable never gets
+		// the floor written by advanceLifecycleWatermarkFloor while a sibling
+		// route cannot be built (it bails on d.incomplete). Freeze it here so
+		// the floor exists from the start.
+		s.setNotifierStateInt64(lifecycleStateWatermarkKey, head)
+	}
+	for _, route := range routes {
+		via := strings.TrimSpace(route.Via)
+		if via == "" {
+			continue
+		}
+		key := lifecycleRouteWatermarkKey(via)
+		if _, found, err := s.notifierStateInt64(key); err != nil || found {
+			continue
+		}
+		if !routed && sharedFound {
+			s.setNotifierStateInt64(key, shared)
+			continue
+		}
+		s.setNotifierStateInt64(key, head)
+	}
+}
+
+// lifecycleRouteStateExists reports whether any per-route state key with the
+// given prefix is persisted. It is how both passes tell a legacy migration
+// (nothing per-route recorded yet, so the shared state is the routes' shared
+// history) from a route genuinely added later (the per-route scheme is already
+// live, so the newcomer must start clean).
+func (s *Server) lifecycleRouteStateExists(prefix string) (bool, error) {
+	var n int
+	if err := s.db.QueryRow(`SELECT EXISTS(SELECT 1 FROM slack_notifier_state WHERE key LIKE ?)`, prefix+"%").Scan(&n); err != nil {
+		return false, err
+	}
+	return n != 0, nil
+}
+
+// pruneLifecycleRouteState drops the cursor and claw baseline of notifiers that
+// are no longer routed. Nothing else clears them while lifecycle alerts stay
+// enabled (parkLifecycleWatermark only runs while they are off, and
+// advanceLifecycleWatermarkFloor only touches the shared key), so a route that
+// is removed and later re-added under the same name would resume from its stale
+// cursor and flush the entire removal window into its channel — the events of
+// that window carry no v2 delivery row for it, and no legacy row either
+// whenever two or more routes remained. Dropping the state makes a re-added
+// route behave exactly like a newly added one.
+func (s *Server) pruneLifecycleRouteState(lc *types.LifecycleNotificationsConfig) {
+	configured := map[string]bool{}
+	for _, route := range lc.EffectiveRoutes() {
+		if via := strings.TrimSpace(route.Via); via != "" {
+			configured[via] = true
+		}
+	}
+	rows, err := s.db.Query(`SELECT key FROM slack_notifier_state WHERE key LIKE ? OR key LIKE ?`,
+		lifecycleRouteWatermarkKey("%"), lifecycleClawRouteBaselinePrefix+"%")
+	if err != nil {
+		log.Printf("[notify] list route state: %v", err)
+		return
+	}
+	var stale []string
+	for rows.Next() {
+		var key string
+		if err := rows.Scan(&key); err != nil {
+			log.Printf("[notify] list route state: %v", err)
+			rows.Close()
+			return
+		}
+		notifier := key[strings.Index(key, ":")+1:]
+		if !configured[notifier] {
+			stale = append(stale, key)
+		}
+	}
+	rows.Close()
+	for _, key := range stale {
+		s.clearNotifierState(key)
+	}
 }
 
 // lifecycleRouteCursor pairs a route with its own position in the event stream.
@@ -469,7 +599,7 @@ func (s *Server) lifecycleTaskRunPass(d lifecycleDelivery) {
 	lowest := int64(-1)
 	for _, route := range d.effectiveRoutes() {
 		key := s.lifecycleWatermarkKeyFor(d, route.notifier)
-		watermark, found, err := s.lifecycleRouteWatermark(key)
+		watermark, found, err := s.notifierStateInt64(key)
 		if err != nil {
 			// A read failure must not be mistaken for a first run: resetting
 			// the cursor here would silently skip the pending backlog.
@@ -477,27 +607,17 @@ func (s *Server) lifecycleTaskRunPass(d lifecycleDelivery) {
 			continue
 		}
 		if !found {
-			// First run for this route: start at the current end of the event
-			// stream so enabling it does not replay history.
+			// First run for this cursor: start at the current end of the event
+			// stream so enabling it does not replay history. Route cursors are
+			// normally materialised by ensureLifecycleRouteWatermarks before the
+			// pass runs; this stays as the backstop for the legacy shared key
+			// (and for a state write that failed there).
 			maxRow, err := s.lifecycleMaxEventRowID()
 			if err != nil {
 				log.Printf("[notify] read max event rowid: %v", err)
 				continue
 			}
 			s.setNotifierStateInt64(key, maxRow)
-			if key != lifecycleStateWatermarkKey {
-				// Freeze the shared floor at the same point. A config that is
-				// multi-route from its very first enable never gets the floor
-				// written by advanceLifecycleWatermarkFloor while a sibling
-				// route cannot be built (it bails on d.incomplete), so without
-				// this the shared key would still be missing when that route
-				// recovers — and it would then first-run at the CURRENT stream
-				// head, losing every event produced during the outage. Only
-				// reached when the shared key is absent too (lifecycleRouteWatermark
-				// falls back to it), so this can never fast-forward a floor
-				// that already exists.
-				s.setNotifierStateInt64(lifecycleStateWatermarkKey, maxRow)
-			}
 			continue
 		}
 		cursors = append(cursors, lifecycleRouteCursor{route: route, stateKey: key, watermark: watermark})

--- a/pkg/hub/lifecycle_notifier.go
+++ b/pkg/hub/lifecycle_notifier.go
@@ -69,10 +69,17 @@ var lifecycleFailureEventTypes = map[string]bool{
 	taskRunEventDoneWithoutPR:      true,
 }
 
-// lifecycleSupportedEventTypes is everything the notifier can render.
+// lifecycleSupportedEventTypes is everything the notifier can render: the
+// wire types a route's allow-list may name (types.LifecycleEventTypes) plus
+// the concrete failure kinds, which never appear as task_run_events.event_type
+// but do carry their own rendering (see lifecycleEventStyles). Callers that
+// mean the narrower route vocabulary use types.IsLifecycleEventType instead.
 func lifecycleSupportedEventTypes() map[string]bool {
-	supported := make(map[string]bool, len(types.LifecycleEventTypes))
+	supported := make(map[string]bool, len(types.LifecycleEventTypes)+len(lifecycleFailureEventTypes))
 	for _, t := range types.LifecycleEventTypes {
+		supported[t] = true
+	}
+	for t := range lifecycleFailureEventTypes {
 		supported[t] = true
 	}
 	return supported
@@ -988,18 +995,30 @@ func (s *Server) handleLifecycleSendError(err error, what, deliveryKey, runKey, 
 		// every boot, so the poisoned event would never be burned and the
 		// cursor would stay wedged for as long as the restarts continued.
 		stateKey := lifecycleTransientFailureStateKey(deliveryKey, notifier)
+		priorKey := lifecycleTransientFailureStateKey(deliveryKey)
 		if singleRoute {
 			// Legacy single-`via` key shape: no per-notifier component, so
 			// pre-routing streak state (and its corruption-recovery
 			// semantics) keeps working unchanged.
-			stateKey = lifecycleTransientFailureStateKey(deliveryKey)
+			stateKey, priorKey = priorKey, stateKey
 		}
-		count, _, stateErr := s.notifierStateInt64(stateKey)
+		count, found, stateErr := s.notifierStateInt64(stateKey)
 		if stateErr != nil {
 			// Unreadable streak state: retry without counting rather than
 			// risk resetting (or double-counting) the streak.
 			log.Printf("[notify] read transient-failure streak for %s: %v", what, stateErr)
 			return false, true
+		}
+		if !found {
+			// Adding or removing a sibling route flips this notifier between
+			// the legacy and per-notifier key shapes. Carry a live streak
+			// across the move: re-keying it would hand a route that has
+			// nearly exhausted its retry budget a fresh one, and the cap
+			// exists to stop a poisoned event wedging the cursor forever.
+			if prior, priorFound, priorErr := s.notifierStateInt64(priorKey); priorErr == nil && priorFound {
+				count = prior
+				s.clearNotifierState(priorKey)
+			}
 		}
 		count++
 		if count >= lifecycleMaxTransientFailures {

--- a/pkg/hub/lifecycle_notifier.go
+++ b/pkg/hub/lifecycle_notifier.go
@@ -324,9 +324,10 @@ type lifecycleDelivery struct {
 	lc       *types.LifecycleNotificationsConfig
 	// incomplete records that at least one CONFIGURED route could not be
 	// built this tick (unresolvable secret mid-rotation, bad settings). Its
-	// events are still owed to it, so nothing may write the shared legacy
-	// fence row — that row marks an event handled for every route and would
-	// turn a temporary outage into permanent per-route event loss.
+	// events are still owed to it, so the shared task-run watermark floor must
+	// not advance past them. It deliberately does NOT hold back the routes that
+	// did build: both passes dedupe per route, so an indefinitely broken
+	// channel cannot wedge a healthy one's delivery.
 	incomplete bool
 	// paused collects routes whose send failed in a way that must not be
 	// retried for the rest of this tick (a config error, or a transient error
@@ -370,16 +371,6 @@ func (d lifecycleDelivery) pauseRoute(notifier string) {
 }
 
 func (d lifecycleDelivery) routePaused(notifier string) bool { return d.paused[notifier] }
-
-// hasLiveRoutes reports whether any route is still deliverable this tick.
-func (d lifecycleDelivery) hasLiveRoutes() bool {
-	for _, route := range d.effectiveRoutes() {
-		if !d.routePaused(route.notifier) {
-			return true
-		}
-	}
-	return false
-}
 
 func (s *Server) lifecycleNotifierTick() {
 	// Drain delivery rows whose post-send write failed before anything can
@@ -564,7 +555,7 @@ func (s *Server) lifecycleTaskRunRoutePass(d lifecycleDelivery, cursor lifecycle
 		if d.routePaused(cursor.route.notifier) {
 			break
 		}
-		if len(cursor.route.events) != 0 && !cursor.route.events[ev.EventType] {
+		if !lifecycleRouteAccepts(cursor.route, ev.EventType) {
 			// Not this route's event type: handled by definition.
 			maxHandled = ev.RowID
 			continue
@@ -748,56 +739,6 @@ func (s *Server) lifecycleMaxEventRowID() (int64, error) {
 	return maxRow, err
 }
 
-// postLifecycleEvent renders one event, posts it top-level through every
-// configured route and records the deliveries under deliveryKey. It returns a
-// lifecycleRouteSendErrors carrying one entry per route that failed (nil when
-// every route is done), so no route's failure can be swallowed by another's.
-// The slack_run_threads table remains for legacy data, but lifecycle
-// notifications no longer read or write it.
-func (s *Server) postLifecycleEvent(d lifecycleDelivery, ev lifecycleEventRow, runCtx lifecycleRunContext, runKey, deliveryKey string) error {
-	msg := buildLifecycleMessage(ev, runCtx)
-	var errs lifecycleRouteSendErrors
-	// complete tracks whether every route this event is owed to has reached a
-	// terminal outcome. Only then may the legacy fence row be written.
-	complete := !d.incomplete
-	applicable, sentAny := 0, false
-	for _, route := range d.effectiveRoutes() {
-		if len(route.events) != 0 && !route.events[ev.EventType] {
-			continue
-		}
-		applicable++
-		if d.routePaused(route.notifier) {
-			complete = false
-			continue
-		}
-		sent, err := s.postLifecycleRoute(d, route, msg, runKey, deliveryKey)
-		if err != nil {
-			errs = append(errs, lifecycleRouteSendError{notifier: route.notifier, err: err})
-			complete = false
-			continue
-		}
-		sentAny = sentAny || sent
-	}
-	// The claw pass has no cursor: a handled event that ends up with no row in
-	// the legacy table is re-selected on every tick forever and eventually
-	// consumes the whole LIMIT, silently starving newer claws. The v2 rows are
-	// per-route and the pass cannot know the route set in SQL, so once every
-	// route is done a single legacy row fences the event for all of them.
-	// Skipped when one route already wrote it (the legacy single-`via` shape),
-	// so the real handle/status is never overwritten by a fence.
-	if complete && !(d.singleRoute() && applicable > 0) {
-		status := notificationDeliveryStatusSkipped
-		if sentAny {
-			status = notificationDeliveryStatusSent
-		}
-		s.recordNotificationDelivery(deliveryKey, runKey, "", status)
-	}
-	if len(errs) == 0 {
-		return nil
-	}
-	return errs
-}
-
 // postLifecycleRoute delivers one already-rendered message through one route
 // and records its delivery row. sent reports whether an external Send actually
 // happened (false when the route was already deduped).
@@ -840,32 +781,13 @@ func (s *Server) postLifecycleRoute(d lifecycleDelivery, route lifecycleRouteDel
 	return true, nil
 }
 
-// postLifecycleEventRoute is the single-route entry point used by the
-// per-route task-run pass.
+// postLifecycleEventRoute is the single-route entry point both passes use.
+// Every event is delivered per route — the task-run pass behind that route's
+// cursor, the claw pass behind that route's delivery rows — so no route's
+// failure can be swallowed by, or hold back, another's.
 func (s *Server) postLifecycleEventRoute(d lifecycleDelivery, route lifecycleRouteDelivery, msg notify.Message, runKey, deliveryKey string) error {
 	_, err := s.postLifecycleRoute(d, route, msg, runKey, deliveryKey)
 	return err
-}
-
-type lifecycleRouteSendError struct {
-	notifier string
-	err      error
-}
-
-func (e lifecycleRouteSendError) Error() string { return e.err.Error() }
-
-// lifecycleRouteSendErrors carries every failing route of one fan-out. Callers
-// must apply the send-failure policy to each entry: classifying only the first
-// one lets a later route's transient/config failure be mistaken for handled,
-// which advances the cursor past an event that route never received.
-type lifecycleRouteSendErrors []lifecycleRouteSendError
-
-func (e lifecycleRouteSendErrors) Error() string {
-	parts := make([]string, 0, len(e))
-	for _, routeErr := range e {
-		parts = append(parts, routeErr.notifier+": "+routeErr.err.Error())
-	}
-	return strings.Join(parts, "; ")
 }
 
 // lifecycleRouteDelivered reports whether this (event, route) pair already has

--- a/pkg/hub/lifecycle_notifier.go
+++ b/pkg/hub/lifecycle_notifier.go
@@ -285,6 +285,17 @@ func (s *Server) initLifecycleNotifierBaseline() {
 			}
 		}
 	}
+	// Give the CONFIGURED routes their own state here too, for the same reason
+	// the shared baseline is written synchronously: a route added while the hub
+	// was down (a `via` migrated to routes in hub.yaml) would otherwise be
+	// baselined by the first poll tick, one poll interval after the producers
+	// started, and silently miss whatever they produced in that window. Both
+	// helpers are idempotent, so the tick keeps covering runtime saves.
+	if err := types.ValidateNotificationsConfig(cfg); err == nil {
+		s.pruneLifecycleRouteState(cfg.Lifecycle)
+		s.ensureLifecycleRouteWatermarks(cfg.Lifecycle)
+		s.ensureLifecycleClawRouteBaselines(cfg.Lifecycle)
+	}
 	// Stamp the agent_idle baseline at boot on the first enabled run so idle
 	// stretches that predate the feature (or this deploy) are parked, not
 	// announced. Runtime enables are covered by the lazy stamp in
@@ -809,11 +820,22 @@ func (s *Server) lifecycleTaskRunPass(d lifecycleDelivery) {
 			continue
 		}
 		if !found {
+			if key != lifecycleStateWatermarkKey {
+				// A per-route cursor belongs to ensureLifecycleRouteWatermarks:
+				// it is the only place that knows whether this route inherits
+				// the incumbent's shared position or starts at the head. Its
+				// absence here means that write did not land (a transient
+				// state-read failure earlier in this same tick), so stamping the
+				// head would materialise the cursor from the WRONG source and
+				// bury the route's pending backlog for good — ensure sees the
+				// cursor as found on every later tick and never revisits it.
+				// Wait for the next tick, which retries both in order (the same
+				// guard ensureLifecycleClawRouteBaselines uses).
+				continue
+			}
 			// First run for this cursor: start at the current end of the event
-			// stream so enabling it does not replay history. Route cursors are
-			// normally materialised by ensureLifecycleRouteWatermarks before the
-			// pass runs; this stays as the backstop for the legacy shared key
-			// (and for a state write that failed there).
+			// stream so enabling it does not replay history. This is the
+			// backstop for the legacy shared key, which no ensure pass writes.
 			maxRow, err := s.lifecycleMaxEventRowID()
 			if err != nil {
 				log.Printf("[notify] read max event rowid: %v", err)

--- a/pkg/hub/lifecycle_notifier.go
+++ b/pkg/hub/lifecycle_notifier.go
@@ -251,7 +251,23 @@ func (s *Server) initLifecycleNotifierBaseline() {
 			// keeps the incumbent's undelivered backlog (claws that connected
 			// while its token secret was broken) from being buried the moment
 			// a second route makes it look newly added.
-			s.stampLifecycleClawRouteBaselines(cfg.Lifecycle)
+			//
+			// Only the INCUMBENT may be stamped. The stamp is also what
+			// lifecycleSingleViaIncumbent reads, so stamping every configured
+			// route would present a channel added in the same maintenance
+			// window as the legacy incumbent, hand it the incumbent's frozen
+			// shared cursor and replay the whole stalled backlog into it.
+			if via := lifecycleLegacyIncumbentVia(cfg.Lifecycle); via != "" {
+				s.setNotifierStateInt64(lifecycleClawRouteBaselineKey(via), 1)
+			} else {
+				// The config already carries several routes and no longer says
+				// which one was the single `via`, so no route can be verified
+				// as the incumbent. Latch the scheme instead: every route
+				// starts at the stream head and ensureLifecycleClawRouteBaselines
+				// seeds its claw fence, which loses the incumbent's undelivered
+				// backlog but never floods a brand-new channel with it.
+				s.setNotifierStateInt64(lifecycleStateRoutedKey, 1)
+			}
 		}
 	}
 	// Stamp the agent_idle baseline at boot on the first enabled run so idle
@@ -517,6 +533,27 @@ func (s *Server) lifecycleWatermarkKeyFor(d lifecycleDelivery, notifier string) 
 // beside it — is what tells the incumbent apart from a route that only just
 // appeared in config. An unreadable state is not an incumbent: the callers'
 // fallbacks (per-route key, stream head) are the safe side of that answer.
+// lifecycleLegacyIncumbentVia names the route that has been delivering as the
+// legacy single `via`, or "" when the config no longer says which one it was.
+// It is only meaningful against state written before the per-route scheme
+// existed, where the incumbent is not recorded anywhere else.
+func lifecycleLegacyIncumbentVia(lc *types.LifecycleNotificationsConfig) string {
+	routes := lc.EffectiveRoutes()
+	if len(routes) == 1 {
+		return strings.TrimSpace(routes[0].Via)
+	}
+	// A hand-written config can still carry the legacy `via` alongside routes
+	// (the settings screen clears it, hub.yaml does not have to); it names the
+	// incumbent as long as it is one of the routes.
+	via := strings.TrimSpace(lc.Via)
+	for _, route := range routes {
+		if via != "" && strings.TrimSpace(route.Via) == via {
+			return via
+		}
+	}
+	return ""
+}
+
 func (s *Server) lifecycleSingleViaIncumbent(via string) bool {
 	if via == "" {
 		return false
@@ -674,6 +711,13 @@ func (s *Server) pruneLifecycleRouteState(lc *types.LifecycleNotificationsConfig
 		notifier := key[strings.Index(key, ":")+1:]
 		if !configured[notifier] {
 			stale = append(stale, key)
+			// Deleting ANY per-route stamp counts as evidence too: a hub that
+			// never went past the legacy single-`via` shape records its
+			// incumbent only as a claw baseline stamp, so replacing that route
+			// with an all-new set would leave nothing per-route behind and let
+			// ensureLifecycleRouteWatermarks read "nothing routed yet" and hand
+			// each newcomer the incumbent's stalled shared cursor.
+			schemeLive = true
 		}
 	}
 	rows.Close()

--- a/pkg/hub/lifecycle_notifier.go
+++ b/pkg/hub/lifecycle_notifier.go
@@ -62,12 +62,8 @@ var lifecycleFailureEventTypes = map[string]bool{
 
 // lifecycleSupportedEventTypes is everything the notifier can render.
 func lifecycleSupportedEventTypes() map[string]bool {
-	supported := map[string]bool{
-		taskRunEventAgentStarted: true,
-		taskRunEventPROpened:     true,
-		taskRunEventAgentIdle:    true,
-	}
-	for t := range lifecycleFailureEventTypes {
+	supported := make(map[string]bool, len(types.LifecycleEventTypes))
+	for _, t := range types.LifecycleEventTypes {
 		supported[t] = true
 	}
 	return supported
@@ -322,8 +318,16 @@ type lifecycleRunContext struct {
 // lifecycleDelivery bundles what the two event passes need to deliver one
 // message: the notifier and lifecycle config.
 type lifecycleDelivery struct {
+	// notifier is kept for package-local test helpers; runtime uses routes.
 	notifier notify.Notifier
+	routes   []lifecycleRouteDelivery
 	lc       *types.LifecycleNotificationsConfig
+}
+
+type lifecycleRouteDelivery struct {
+	notifier string
+	send     notify.Notifier
+	events   map[string]bool
 }
 
 func (s *Server) lifecycleNotifierTick() {
@@ -344,23 +348,27 @@ func (s *Server) lifecycleNotifierTick() {
 		return
 	}
 	lc := cfg.Lifecycle
-	// Trimmed to match ValidateNotificationsConfig, which resolves the via
-	// after strings.TrimSpace: a hub.yaml with via: "eng-agents " passes
-	// validation, so looking it up raw here would yield a zero NotifierConfig
-	// and silently stop notifications while everything reports green.
-	via := strings.TrimSpace(lc.Via)
-	nc := cfg.Notifiers[via] // exists: validated above
-	notifier, err := s.notifierFor(via, nc, s.hubSecretResolver())
-	if err != nil {
-		// Unknown provider type, unresolvable secret, bad provider settings:
-		// pause (leaving all cursors) until the operator fixes the config.
-		s.logPollWarningOnce("notify-notifier", "[notify] notifier %q unavailable — notifications paused: %v", via, err)
+	var routes []lifecycleRouteDelivery
+	for _, route := range lc.EffectiveRoutes() {
+		via := strings.TrimSpace(route.Via)
+		n, err := s.notifierFor(via, cfg.Notifiers[via], s.hubSecretResolver())
+		if err != nil {
+			s.logPollWarningOnce("notify-notifier:"+via, "[notify] notifier %q unavailable: %v", via, err)
+			continue
+		}
+		events := map[string]bool{}
+		for _, event := range route.Events {
+			events[event] = true
+		}
+		routes = append(routes, lifecycleRouteDelivery{notifier: via, send: n, events: events})
+	}
+	if len(routes) == 0 {
 		return
 	}
 	s.clearPollWarning("notify-config")
 	s.clearPollWarning("notify-notifier")
 
-	d := lifecycleDelivery{notifier: notifier, lc: lc}
+	d := lifecycleDelivery{routes: routes, lc: lc}
 	// Two independent event sources share the notifier and dedupe table:
 	// task-run events for claws that belong to a task run, and the claw pass
 	// for ad-hoc claws (task_run_id=''). See lifecycle_claw_notifier.go for
@@ -418,7 +426,8 @@ func (s *Server) lifecycleTaskRunPass(d lifecycleDelivery) {
 	maxHandled := watermark
 	for _, ev := range events {
 		if err := s.sendLifecycleEvent(d, ev); err != nil {
-			if handled, stop := s.handleLifecycleSendError(err, "event "+ev.ID+" ("+ev.EventType+")", ev.ID, ev.RunID); handled {
+			routeErr := err.(lifecycleRouteSendError)
+			if handled, stop := s.handleLifecycleSendError(routeErr.err, "event "+ev.ID+" ("+ev.EventType+")", ev.ID, ev.RunID, routeErr.notifier, len(d.routes) == 1); handled {
 				maxHandled = ev.RowID
 				continue
 			} else if stop {
@@ -451,7 +460,7 @@ const lifecycleMaxTransientFailures = 60
 // lifecycleMaxTransientFailures times in a row, at which point it is recorded
 // failed so it cannot wedge the cursor forever. Returns handled=true when the
 // caller may move past the event; stop is informational for symmetry.
-func (s *Server) handleLifecycleSendError(err error, what, deliveryKey, runKey string) (handled, stop bool) {
+func (s *Server) handleLifecycleSendError(err error, what, deliveryKey, runKey, notifier string, singleRoute bool) (handled, stop bool) {
 	switch notify.Classify(err) {
 	case notify.ErrorConfig:
 		// Bad token / missing channel fails every message, not this one.
@@ -462,7 +471,10 @@ func (s *Server) handleLifecycleSendError(err error, what, deliveryKey, runKey s
 	case notify.ErrorPermanent:
 		// Never succeeds on retry — record it so we stop trying.
 		log.Printf("[notify] permanent failure for %s: %v", what, err)
-		s.recordNotificationDelivery(deliveryKey, runKey, "", notificationDeliveryStatusFailed)
+		s.recordNotificationDeliveryV2(deliveryKey, notifier, runKey, "", notificationDeliveryStatusFailed)
+		if singleRoute {
+			s.recordNotificationDelivery(deliveryKey, runKey, "", notificationDeliveryStatusFailed)
+		}
 		return true, false
 	default:
 		// The streak is persisted (not an in-memory counter) because the cap
@@ -470,7 +482,13 @@ func (s *Server) handleLifecycleSendError(err error, what, deliveryKey, runKey s
 		// more often than the cap window would reset an in-memory counter on
 		// every boot, so the poisoned event would never be burned and the
 		// cursor would stay wedged for as long as the restarts continued.
-		stateKey := lifecycleTransientFailureStateKey(deliveryKey)
+		stateKey := lifecycleTransientFailureStateKey(deliveryKey, notifier)
+		if singleRoute {
+			// Legacy single-`via` key shape: no per-notifier component, so
+			// pre-routing streak state (and its corruption-recovery
+			// semantics) keeps working unchanged.
+			stateKey = lifecycleTransientFailureStateKey(deliveryKey)
+		}
 		count, _, stateErr := s.notifierStateInt64(stateKey)
 		if stateErr != nil {
 			// Unreadable streak state: retry without counting rather than
@@ -482,7 +500,10 @@ func (s *Server) handleLifecycleSendError(err error, what, deliveryKey, runKey s
 		if count >= lifecycleMaxTransientFailures {
 			s.clearNotifierState(stateKey)
 			log.Printf("[notify] giving up on %s after %d consecutive transient failures: %v", what, count, err)
-			s.recordNotificationDelivery(deliveryKey, runKey, "", notificationDeliveryStatusFailed)
+			s.recordNotificationDeliveryV2(deliveryKey, notifier, runKey, "", notificationDeliveryStatusFailed)
+			if singleRoute {
+				s.recordNotificationDelivery(deliveryKey, runKey, "", notificationDeliveryStatusFailed)
+			}
 			return true, false
 		}
 		s.setNotifierStateInt64(stateKey, count)
@@ -495,8 +516,11 @@ func (s *Server) handleLifecycleSendError(err error, what, deliveryKey, runKey s
 // lifecycleTransientFailureStateKey keys one delivery key's consecutive
 // transient-failure streak in slack_notifier_state. Rows exist only while a
 // streak is live: they are cleared on success or when the cap burns the event.
-func lifecycleTransientFailureStateKey(deliveryKey string) string {
-	return "transient_failures:" + deliveryKey
+func lifecycleTransientFailureStateKey(deliveryKey string, notifier ...string) string {
+	if len(notifier) == 0 {
+		return "transient_failures:" + deliveryKey
+	} // legacy test/state compatibility
+	return "transient_failures:" + notifier[0] + ":" + deliveryKey
 }
 
 // skipLifecycleMutedEvents seeds "skipped" delivery rows for events of the
@@ -568,24 +592,71 @@ func (s *Server) sendLifecycleEvent(d lifecycleDelivery, ev lifecycleEventRow) e
 // delivery under deliveryKey. The slack_run_threads table remains for legacy
 // data, but lifecycle notifications no longer read or write it.
 func (s *Server) postLifecycleEvent(d lifecycleDelivery, ev lifecycleEventRow, runCtx lifecycleRunContext, runKey, deliveryKey string) error {
-	if s.lifecycleDeliveryPending(deliveryKey) {
-		// Already sent; only the delivery-row write is outstanding (see
-		// recordNotificationDelivery). Sending again would duplicate the
-		// external message.
-		return nil
-	}
 	msg := buildLifecycleMessage(ev, runCtx)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	handle, err := d.notifier.Send(ctx, msg)
-	if err != nil {
-		return err
+	routes := d.routes
+	if len(routes) == 0 && d.notifier != nil {
+		routes = []lifecycleRouteDelivery{{notifier: "", send: d.notifier}}
 	}
-	s.recordNotificationDelivery(deliveryKey, runKey, handle, notificationDeliveryStatusSent)
-	// A success ends any transient-failure streak for this delivery.
-	s.clearNotifierState(lifecycleTransientFailureStateKey(deliveryKey))
-	return nil
+	var firstErr error
+	for _, route := range routes {
+		if len(route.events) != 0 && !route.events[ev.EventType] {
+			continue
+		}
+		// Legacy rows are an upgrade fence: their single-key dedupe predates
+		// routing and therefore means this event was already handled.
+		if s.lifecycleRouteDelivered(deliveryKey, route.notifier) {
+			continue
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		handle, err := route.send.Send(ctx, msg)
+		cancel()
+		if err != nil {
+			// Permanent failures are terminal for this route. Record them here
+			// so a second broken route cannot be lost when the caller advances
+			// the shared watermark after handling the first error.
+			if notify.Classify(err) == notify.ErrorPermanent {
+				s.recordNotificationDeliveryV2(deliveryKey, route.notifier, runKey, "", notificationDeliveryStatusFailed)
+				if len(routes) == 1 {
+					s.recordNotificationDelivery(deliveryKey, runKey, "", notificationDeliveryStatusFailed)
+				}
+			}
+			if firstErr == nil {
+				firstErr = lifecycleRouteSendError{notifier: route.notifier, err: err}
+			}
+			continue
+		}
+		s.recordNotificationDeliveryV2(deliveryKey, route.notifier, runKey, handle, notificationDeliveryStatusSent)
+		if len(routes) == 1 {
+			// Exactly one configured route is the legacy single-`via` shape:
+			// keep writing the legacy table too so its dedupe/read behavior
+			// (and any external readers) stay identical to pre-routing.
+			s.recordNotificationDelivery(deliveryKey, runKey, handle, notificationDeliveryStatusSent)
+			s.clearNotifierState(lifecycleTransientFailureStateKey(deliveryKey))
+		}
+		s.clearNotifierState(lifecycleTransientFailureStateKey(deliveryKey, route.notifier))
+	}
+	return firstErr
+}
+
+type lifecycleRouteSendError struct {
+	notifier string
+	err      error
+}
+
+func (e lifecycleRouteSendError) Error() string { return e.err.Error() }
+
+func (s *Server) lifecycleRouteDelivered(eventID, notifier string) bool {
+	var n int
+	// The legacy read fallback is deliberately retained instead of a migration:
+	// it applies to every configured route, including routes added after upgrade.
+	err := s.db.QueryRow(`SELECT EXISTS(SELECT 1 FROM slack_notification_deliveries WHERE event_id=?) OR EXISTS(SELECT 1 FROM slack_notification_deliveries_v2 WHERE event_id=? AND notifier=?)`, eventID, eventID, notifier).Scan(&n)
+	return err == nil && n != 0
+}
+
+func (s *Server) recordNotificationDeliveryV2(eventID, notifier, runID, messageHandle, status string) {
+	if _, err := s.db.Exec(`INSERT INTO slack_notification_deliveries_v2(event_id, notifier, run_id, delivered_at, message_ts, status) VALUES(?,?,?,?,?,?) ON CONFLICT(event_id, notifier) DO NOTHING`, eventID, notifier, runID, epochMillis(now()), messageHandle, status); err != nil {
+		log.Printf("[notify] record route delivery for event %s via %s: %v", eventID, notifier, err)
+	}
 }
 
 // pendingNotificationDelivery is a delivery whose post-send bookkeeping write

--- a/pkg/hub/lifecycle_notifier.go
+++ b/pkg/hub/lifecycle_notifier.go
@@ -485,6 +485,19 @@ func (s *Server) lifecycleTaskRunPass(d lifecycleDelivery) {
 				continue
 			}
 			s.setNotifierStateInt64(key, maxRow)
+			if key != lifecycleStateWatermarkKey {
+				// Freeze the shared floor at the same point. A config that is
+				// multi-route from its very first enable never gets the floor
+				// written by advanceLifecycleWatermarkFloor while a sibling
+				// route cannot be built (it bails on d.incomplete), so without
+				// this the shared key would still be missing when that route
+				// recovers — and it would then first-run at the CURRENT stream
+				// head, losing every event produced during the outage. Only
+				// reached when the shared key is absent too (lifecycleRouteWatermark
+				// falls back to it), so this can never fast-forward a floor
+				// that already exists.
+				s.setNotifierStateInt64(lifecycleStateWatermarkKey, maxRow)
+			}
 			continue
 		}
 		cursors = append(cursors, lifecycleRouteCursor{route: route, stateKey: key, watermark: watermark})

--- a/pkg/hub/lifecycle_notifier.go
+++ b/pkg/hub/lifecycle_notifier.go
@@ -316,18 +316,69 @@ type lifecycleRunContext struct {
 }
 
 // lifecycleDelivery bundles what the two event passes need to deliver one
-// message: the notifier and lifecycle config.
+// message: the notifiers and lifecycle config.
 type lifecycleDelivery struct {
 	// notifier is kept for package-local test helpers; runtime uses routes.
 	notifier notify.Notifier
 	routes   []lifecycleRouteDelivery
 	lc       *types.LifecycleNotificationsConfig
+	// incomplete records that at least one CONFIGURED route could not be
+	// built this tick (unresolvable secret mid-rotation, bad settings). Its
+	// events are still owed to it, so nothing may write the shared legacy
+	// fence row — that row marks an event handled for every route and would
+	// turn a temporary outage into permanent per-route event loss.
+	incomplete bool
+	// paused collects routes whose send failed in a way that must not be
+	// retried for the rest of this tick (a config error, or a transient error
+	// under the retry policy). Parking the route instead of the whole pass is
+	// what keeps one archived channel from blocking every healthy one; the
+	// events it missed keep their missing delivery rows and are retried on a
+	// later tick.
+	paused map[string]bool
 }
 
 type lifecycleRouteDelivery struct {
 	notifier string
 	send     notify.Notifier
 	events   map[string]bool
+}
+
+// effectiveRoutes is the route set to deliver through, translating the
+// test-only single-notifier shape into one unnamed route.
+func (d lifecycleDelivery) effectiveRoutes() []lifecycleRouteDelivery {
+	if len(d.routes) != 0 {
+		return d.routes
+	}
+	if d.notifier != nil {
+		return []lifecycleRouteDelivery{{notifier: "", send: d.notifier}}
+	}
+	return nil
+}
+
+// singleRoute reports the legacy single-`via` shape: exactly one deliverable
+// route and no configured route missing. It gates the legacy-table writes and
+// the legacy (un-namespaced) state keys so pre-routing behaviour — and any
+// external reader of slack_notification_deliveries — is bit-for-bit unchanged.
+func (d lifecycleDelivery) singleRoute() bool {
+	return !d.incomplete && len(d.effectiveRoutes()) == 1
+}
+
+func (d lifecycleDelivery) pauseRoute(notifier string) {
+	if d.paused != nil {
+		d.paused[notifier] = true
+	}
+}
+
+func (d lifecycleDelivery) routePaused(notifier string) bool { return d.paused[notifier] }
+
+// hasLiveRoutes reports whether any route is still deliverable this tick.
+func (d lifecycleDelivery) hasLiveRoutes() bool {
+	for _, route := range d.effectiveRoutes() {
+		if !d.routePaused(route.notifier) {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *Server) lifecycleNotifierTick() {
@@ -349,13 +400,19 @@ func (s *Server) lifecycleNotifierTick() {
 	}
 	lc := cfg.Lifecycle
 	var routes []lifecycleRouteDelivery
+	incomplete := false
 	for _, route := range lc.EffectiveRoutes() {
 		via := strings.TrimSpace(route.Via)
 		n, err := s.notifierFor(via, cfg.Notifiers[via], s.hubSecretResolver())
 		if err != nil {
-			s.logPollWarningOnce("notify-notifier:"+via, "[notify] notifier %q unavailable: %v", via, err)
+			// The route keeps its own cursor and gets no delivery rows written
+			// on its behalf, so everything produced during the outage is still
+			// pending for it and is delivered once the notifier builds again.
+			incomplete = true
+			s.logPollWarningOnce("notify-notifier:"+via, "[notify] notifier %q unavailable — its lifecycle notifications are held until it can be built: %v", via, err)
 			continue
 		}
+		s.clearPollWarning("notify-notifier:" + via)
 		events := map[string]bool{}
 		for _, event := range route.Events {
 			events[event] = true
@@ -366,9 +423,8 @@ func (s *Server) lifecycleNotifierTick() {
 		return
 	}
 	s.clearPollWarning("notify-config")
-	s.clearPollWarning("notify-notifier")
 
-	d := lifecycleDelivery{routes: routes, lc: lc}
+	d := lifecycleDelivery{routes: routes, lc: lc, incomplete: incomplete, paused: map[string]bool{}}
 	// Two independent event sources share the notifier and dedupe table:
 	// task-run events for claws that belong to a task run, and the claw pass
 	// for ad-hoc claws (task_run_id=''). See lifecycle_claw_notifier.go for
@@ -377,70 +433,160 @@ func (s *Server) lifecycleNotifierTick() {
 	s.lifecycleClawPass(d)
 }
 
-// lifecycleTaskRunPass scans task_run_events behind the rowid watermark and
-// delivers the enabled event types.
-func (s *Server) lifecycleTaskRunPass(d lifecycleDelivery) {
-	watermark, found, err := s.notifierStateInt64(lifecycleStateWatermarkKey)
-	if err != nil {
-		// A read failure must not be mistaken for a first run: resetting the
-		// cursor here would silently skip the pending backlog.
-		log.Printf("[notify] read watermark: %v", err)
-		return
+// lifecycleRouteWatermarkKey names one route's cursor over task_run_events.
+// Routes advance independently on purpose: a shared cursor lets a healthy
+// route drag it past events a broken route never received, and those events
+// are then unreachable forever (the pass only ever selects rowid > cursor).
+// The legacy single-route shape keeps the original un-suffixed key so
+// pre-routing state — and anything reading it — is unchanged.
+func lifecycleRouteWatermarkKey(notifier string) string {
+	return lifecycleStateWatermarkKey + ":" + notifier
+}
+
+func (s *Server) lifecycleWatermarkKeyFor(d lifecycleDelivery, notifier string) string {
+	if notifier == "" || d.singleRoute() {
+		return lifecycleStateWatermarkKey
 	}
-	if !found {
-		// First run: start at the current end of the event stream so enabling
-		// the feature does not replay history.
-		maxRow, err := s.lifecycleMaxEventRowID()
+	return lifecycleRouteWatermarkKey(notifier)
+}
+
+// lifecycleRouteWatermark reads one route's cursor, falling back to the shared
+// cursor the first time a route runs. Without the fallback, migrating a
+// single-`via` config to routes would look like a first run and park the
+// pending backlog; the shared cursor is kept as a floor (see
+// advanceLifecycleWatermarkFloor) so the fallback stays close to "now" and a
+// route added years later does not replay the archive.
+func (s *Server) lifecycleRouteWatermark(key string) (int64, bool, error) {
+	value, found, err := s.notifierStateInt64(key)
+	if err != nil || found || key == lifecycleStateWatermarkKey {
+		return value, found, err
+	}
+	return s.notifierStateInt64(lifecycleStateWatermarkKey)
+}
+
+// lifecycleRouteCursor pairs a route with its own position in the event stream.
+type lifecycleRouteCursor struct {
+	route     lifecycleRouteDelivery
+	stateKey  string
+	watermark int64
+}
+
+// lifecycleTaskRunPass scans task_run_events behind each route's rowid
+// watermark and delivers the enabled event types.
+func (s *Server) lifecycleTaskRunPass(d lifecycleDelivery) {
+	var cursors []lifecycleRouteCursor
+	lowest := int64(-1)
+	for _, route := range d.effectiveRoutes() {
+		key := s.lifecycleWatermarkKeyFor(d, route.notifier)
+		watermark, found, err := s.lifecycleRouteWatermark(key)
 		if err != nil {
-			log.Printf("[notify] read max event rowid: %v", err)
-			return
+			// A read failure must not be mistaken for a first run: resetting
+			// the cursor here would silently skip the pending backlog.
+			log.Printf("[notify] read watermark %s: %v", key, err)
+			continue
 		}
-		s.setNotifierStateInt64(lifecycleStateWatermarkKey, maxRow)
+		if !found {
+			// First run for this route: start at the current end of the event
+			// stream so enabling it does not replay history.
+			maxRow, err := s.lifecycleMaxEventRowID()
+			if err != nil {
+				log.Printf("[notify] read max event rowid: %v", err)
+				continue
+			}
+			s.setNotifierStateInt64(key, maxRow)
+			continue
+		}
+		cursors = append(cursors, lifecycleRouteCursor{route: route, stateKey: key, watermark: watermark})
+		if lowest < 0 || watermark < lowest {
+			lowest = watermark
+		}
+	}
+	if len(cursors) == 0 {
 		return
 	}
 
 	enabled := enabledLifecycleEventTypes(d.lc)
 	if len(enabled) == 0 {
-		// Every event category is toggled off: keep the cursor moving so
+		// Every event category is toggled off: keep the cursors moving so
 		// re-enabling a category does not flush the skipped backlog.
 		s.parkLifecycleWatermark()
 		return
 	}
-	// Park the muted categories too: the shared watermark only advances when
-	// an enabled event is handled, so without this, muted-type events above
-	// the cursor would be replayed the moment their toggle is re-enabled — or
-	// silently dropped if a later enabled event happened to advance the
-	// watermark past them first. Seeding "skipped" delivery rows (the claw
-	// pass's parking mechanism) makes the outcome deterministic: whatever
-	// happened while a category was muted stays muted.
-	s.skipLifecycleMutedEvents(watermark, enabled)
-	events, err := s.selectLifecycleCandidateEvents(watermark, enabled)
+	// Park the muted categories too: a watermark only advances when an enabled
+	// event is handled, so without this, muted-type events above the cursor
+	// would be replayed the moment their toggle is re-enabled — or silently
+	// dropped if a later enabled event happened to advance the watermark past
+	// them first. Seeding "skipped" delivery rows (the claw pass's parking
+	// mechanism) makes the outcome deterministic: whatever happened while a
+	// category was muted stays muted. Seeding from the lowest cursor covers
+	// every route in one statement.
+	s.skipLifecycleMutedEvents(lowest, enabled)
+	floor := int64(-1)
+	for _, cursor := range cursors {
+		handled := s.lifecycleTaskRunRoutePass(d, cursor, enabled)
+		if floor < 0 || handled < floor {
+			floor = handled
+		}
+	}
+	if !d.singleRoute() && len(cursors) == len(d.effectiveRoutes()) {
+		s.advanceLifecycleWatermarkFloor(d, floor)
+	}
+}
+
+// advanceLifecycleWatermarkFloor keeps the shared cursor at the slowest route's
+// position. It is what a route added later inherits, so leaving it frozen where
+// the config first became multi-route would flood the new channel with the
+// whole backlog since then. It is deliberately NOT advanced while a configured
+// route could not be built this tick: that route has no cursor of its own yet,
+// so the floor is the only thing standing between it and permanent event loss.
+func (s *Server) advanceLifecycleWatermarkFloor(d lifecycleDelivery, floor int64) {
+	if d.incomplete || floor <= 0 {
+		return
+	}
+	shared, found, err := s.notifierStateInt64(lifecycleStateWatermarkKey)
+	if err != nil || (found && shared >= floor) {
+		return
+	}
+	s.setNotifierStateInt64(lifecycleStateWatermarkKey, floor)
+}
+
+// lifecycleTaskRunRoutePass delivers the pending task-run events for one route
+// and advances that route's cursor only over what it actually handled. It
+// returns the route's resulting cursor position.
+func (s *Server) lifecycleTaskRunRoutePass(d lifecycleDelivery, cursor lifecycleRouteCursor, enabled map[string]bool) int64 {
+	events, err := s.selectLifecycleCandidateEvents(cursor.watermark, enabled)
 	if err != nil {
 		log.Printf("[notify] select candidate events: %v", err)
-		return
+		return cursor.watermark
 	}
-	if len(events) == 0 {
-		return
-	}
-
-	maxHandled := watermark
+	maxHandled := cursor.watermark
 	for _, ev := range events {
-		if err := s.sendLifecycleEvent(d, ev); err != nil {
-			routeErr := err.(lifecycleRouteSendError)
-			if handled, stop := s.handleLifecycleSendError(routeErr.err, "event "+ev.ID+" ("+ev.EventType+")", ev.ID, ev.RunID, routeErr.notifier, len(d.routes) == 1); handled {
-				maxHandled = ev.RowID
-				continue
-			} else if stop {
-				break
-			}
+		if d.routePaused(cursor.route.notifier) {
 			break
 		}
-		s.clearPollWarning(lifecycleSendWarningKey)
+		if len(cursor.route.events) != 0 && !cursor.route.events[ev.EventType] {
+			// Not this route's event type: handled by definition.
+			maxHandled = ev.RowID
+			continue
+		}
+		msg := buildLifecycleMessage(ev, s.lifecycleRunContextFor(ev.RunID))
+		if err := s.postLifecycleEventRoute(d, cursor.route, msg, ev.RunID, ev.ID); err != nil {
+			handled, _ := s.handleLifecycleSendError(err, "event "+ev.ID+" ("+ev.EventType+")", ev.ID, ev.RunID, cursor.route.notifier, d.singleRoute())
+			if handled {
+				maxHandled = ev.RowID
+				continue
+			}
+			// Park the destination, not the cursor: the event stays pending
+			// for this route only.
+			d.pauseRoute(cursor.route.notifier)
+			break
+		}
 		maxHandled = ev.RowID
 	}
-	if maxHandled > watermark {
-		s.setNotifierStateInt64(lifecycleStateWatermarkKey, maxHandled)
+	if maxHandled > cursor.watermark {
+		s.setNotifierStateInt64(cursor.stateKey, maxHandled)
 	}
+	return maxHandled
 }
 
 // lifecycleMaxTransientFailures bounds consecutive transient failures for
@@ -453,20 +599,31 @@ func (s *Server) lifecycleTaskRunPass(d lifecycleDelivery) {
 // event per cap window, never the backlog).
 const lifecycleMaxTransientFailures = 60
 
+// lifecycleSendWarningKeyFor namespaces the log-once send warning per route so
+// one broken destination cannot swallow another's first failure.
+func lifecycleSendWarningKeyFor(notifier string) string {
+	if notifier == "" {
+		return lifecycleSendWarningKey
+	}
+	return lifecycleSendWarningKey + ":" + notifier
+}
+
 // handleLifecycleSendError applies the shared send-failure policy: config
-// errors pause everything (log-once), permanent errors are recorded as
+// errors pause THIS ROUTE (log-once), permanent errors are recorded as
 // failed under deliveryKey (and count as handled), transient errors stop the
-// pass for this tick — until the same delivery key has failed
+// route for this tick — until the same delivery key has failed
 // lifecycleMaxTransientFailures times in a row, at which point it is recorded
 // failed so it cannot wedge the cursor forever. Returns handled=true when the
 // caller may move past the event; stop is informational for symmetry.
 func (s *Server) handleLifecycleSendError(err error, what, deliveryKey, runKey, notifier string, singleRoute bool) (handled, stop bool) {
 	switch notify.Classify(err) {
 	case notify.ErrorConfig:
-		// Bad token / missing channel fails every message, not this one.
-		// Pause (leave the cursors) instead of burning events as failed, so
-		// delivery resumes once the config is fixed.
-		s.logPollWarningOnce(lifecycleSendWarningKey, "[notify] delivery paused until the notifier config is fixed: %v", err)
+		// Bad token / archived channel fails every message on this route, not
+		// this one message. Pause the route (leaving its cursor) instead of
+		// burning events as failed, so delivery resumes once the config is
+		// fixed — and pause only the route, so a single archived secondary
+		// channel cannot mute every healthy destination.
+		s.logPollWarningOnce(lifecycleSendWarningKeyFor(notifier), "[notify] delivery through %q paused until the notifier config is fixed: %v", notifier, err)
 		return false, true
 	case notify.ErrorPermanent:
 		// Never succeeds on retry — record it so we stop trying.
@@ -555,14 +712,14 @@ func (s *Server) skipLifecycleMutedEvents(afterRowID int64, enabled map[string]b
 	}
 }
 
-// parkLifecycleWatermark advances the cursor to the end of the event stream
-// without sending anything. Used while notifications (or every event
+// parkLifecycleWatermark advances every route cursor to the end of the event
+// stream without sending anything. Used while notifications (or every event
 // category) are disabled so a later re-enable does not replay the disabled
-// window.
+// window. Parking is driven off the state table rather than the config so it
+// covers routes that have since been removed or renamed.
 func (s *Server) parkLifecycleWatermark() {
-	watermark, found, err := s.notifierStateInt64(lifecycleStateWatermarkKey)
-	if err != nil || !found {
-		// Never enabled (or state unreadable): nothing to park.
+	_, found, err := s.notifierStateInt64(lifecycleStateWatermarkKey)
+	if err != nil {
 		return
 	}
 	maxRow, err := s.lifecycleMaxEventRowID()
@@ -570,8 +727,18 @@ func (s *Server) parkLifecycleWatermark() {
 		log.Printf("[notify] park watermark: %v", err)
 		return
 	}
-	if maxRow > watermark {
-		s.setNotifierStateInt64(lifecycleStateWatermarkKey, maxRow)
+	if !found {
+		// Never enabled: park only the per-route cursors, if any exist.
+		var routeCursors int
+		if err := s.db.QueryRow(`SELECT COUNT(1) FROM slack_notifier_state WHERE key LIKE ?`, lifecycleRouteWatermarkKey("%")).Scan(&routeCursors); err != nil || routeCursors == 0 {
+			return
+		}
+	}
+	if _, err := s.db.Exec(`
+		UPDATE slack_notifier_state SET value = ?
+		 WHERE (key = ? OR key LIKE ?) AND CAST(value AS INTEGER) < ?`,
+		strconv.FormatInt(maxRow, 10), lifecycleStateWatermarkKey, lifecycleRouteWatermarkKey("%"), maxRow); err != nil {
+		log.Printf("[notify] park watermark: %v", err)
 	}
 }
 
@@ -581,61 +748,103 @@ func (s *Server) lifecycleMaxEventRowID() (int64, error) {
 	return maxRow, err
 }
 
-// sendLifecycleEvent renders one task-run event, posts it top-level and
-// records the delivery.
-func (s *Server) sendLifecycleEvent(d lifecycleDelivery, ev lifecycleEventRow) error {
-	runCtx := s.lifecycleRunContextFor(ev.RunID)
-	return s.postLifecycleEvent(d, ev, runCtx, ev.RunID, ev.ID)
-}
-
-// postLifecycleEvent renders one event, posts it top-level and records the
-// delivery under deliveryKey. The slack_run_threads table remains for legacy
-// data, but lifecycle notifications no longer read or write it.
+// postLifecycleEvent renders one event, posts it top-level through every
+// configured route and records the deliveries under deliveryKey. It returns a
+// lifecycleRouteSendErrors carrying one entry per route that failed (nil when
+// every route is done), so no route's failure can be swallowed by another's.
+// The slack_run_threads table remains for legacy data, but lifecycle
+// notifications no longer read or write it.
 func (s *Server) postLifecycleEvent(d lifecycleDelivery, ev lifecycleEventRow, runCtx lifecycleRunContext, runKey, deliveryKey string) error {
 	msg := buildLifecycleMessage(ev, runCtx)
-	routes := d.routes
-	if len(routes) == 0 && d.notifier != nil {
-		routes = []lifecycleRouteDelivery{{notifier: "", send: d.notifier}}
-	}
-	var firstErr error
-	for _, route := range routes {
+	var errs lifecycleRouteSendErrors
+	// complete tracks whether every route this event is owed to has reached a
+	// terminal outcome. Only then may the legacy fence row be written.
+	complete := !d.incomplete
+	applicable, sentAny := 0, false
+	for _, route := range d.effectiveRoutes() {
 		if len(route.events) != 0 && !route.events[ev.EventType] {
 			continue
 		}
-		// Legacy rows are an upgrade fence: their single-key dedupe predates
-		// routing and therefore means this event was already handled.
-		if s.lifecycleRouteDelivered(deliveryKey, route.notifier) {
+		applicable++
+		if d.routePaused(route.notifier) {
+			complete = false
 			continue
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		handle, err := route.send.Send(ctx, msg)
-		cancel()
+		sent, err := s.postLifecycleRoute(d, route, msg, runKey, deliveryKey)
 		if err != nil {
-			// Permanent failures are terminal for this route. Record them here
-			// so a second broken route cannot be lost when the caller advances
-			// the shared watermark after handling the first error.
-			if notify.Classify(err) == notify.ErrorPermanent {
-				s.recordNotificationDeliveryV2(deliveryKey, route.notifier, runKey, "", notificationDeliveryStatusFailed)
-				if len(routes) == 1 {
-					s.recordNotificationDelivery(deliveryKey, runKey, "", notificationDeliveryStatusFailed)
-				}
-			}
-			if firstErr == nil {
-				firstErr = lifecycleRouteSendError{notifier: route.notifier, err: err}
-			}
+			errs = append(errs, lifecycleRouteSendError{notifier: route.notifier, err: err})
+			complete = false
 			continue
 		}
-		s.recordNotificationDeliveryV2(deliveryKey, route.notifier, runKey, handle, notificationDeliveryStatusSent)
-		if len(routes) == 1 {
-			// Exactly one configured route is the legacy single-`via` shape:
-			// keep writing the legacy table too so its dedupe/read behavior
-			// (and any external readers) stay identical to pre-routing.
-			s.recordNotificationDelivery(deliveryKey, runKey, handle, notificationDeliveryStatusSent)
-			s.clearNotifierState(lifecycleTransientFailureStateKey(deliveryKey))
-		}
-		s.clearNotifierState(lifecycleTransientFailureStateKey(deliveryKey, route.notifier))
+		sentAny = sentAny || sent
 	}
-	return firstErr
+	// The claw pass has no cursor: a handled event that ends up with no row in
+	// the legacy table is re-selected on every tick forever and eventually
+	// consumes the whole LIMIT, silently starving newer claws. The v2 rows are
+	// per-route and the pass cannot know the route set in SQL, so once every
+	// route is done a single legacy row fences the event for all of them.
+	// Skipped when one route already wrote it (the legacy single-`via` shape),
+	// so the real handle/status is never overwritten by a fence.
+	if complete && !(d.singleRoute() && applicable > 0) {
+		status := notificationDeliveryStatusSkipped
+		if sentAny {
+			status = notificationDeliveryStatusSent
+		}
+		s.recordNotificationDelivery(deliveryKey, runKey, "", status)
+	}
+	if len(errs) == 0 {
+		return nil
+	}
+	return errs
+}
+
+// postLifecycleRoute delivers one already-rendered message through one route
+// and records its delivery row. sent reports whether an external Send actually
+// happened (false when the route was already deduped).
+func (s *Server) postLifecycleRoute(d lifecycleDelivery, route lifecycleRouteDelivery, msg notify.Message, runKey, deliveryKey string) (sent bool, err error) {
+	delivered, err := s.lifecycleRouteDelivered(deliveryKey, route.notifier)
+	if err != nil {
+		// Unclassified, therefore transient: the route retries and its cursor
+		// stays put. Guessing "not delivered" here would re-send externally on
+		// every tick for as long as the database stayed unhappy.
+		return false, fmt.Errorf("check delivery record for %s via %s: %w", deliveryKey, route.notifier, err)
+	}
+	if delivered {
+		return false, nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	handle, err := route.send.Send(ctx, msg)
+	cancel()
+	if err != nil {
+		// Permanent failures are terminal for this route. Record them here so
+		// a second broken route cannot be lost when the caller moves on after
+		// handling the first error.
+		if notify.Classify(err) == notify.ErrorPermanent {
+			s.recordNotificationDeliveryV2(deliveryKey, route.notifier, runKey, "", notificationDeliveryStatusFailed)
+			if d.singleRoute() {
+				s.recordNotificationDelivery(deliveryKey, runKey, "", notificationDeliveryStatusFailed)
+			}
+		}
+		return false, err
+	}
+	s.recordNotificationDeliveryV2(deliveryKey, route.notifier, runKey, handle, notificationDeliveryStatusSent)
+	if d.singleRoute() {
+		// Exactly one configured route is the legacy single-`via` shape:
+		// keep writing the legacy table too so its dedupe/read behavior
+		// (and any external readers) stay identical to pre-routing.
+		s.recordNotificationDelivery(deliveryKey, runKey, handle, notificationDeliveryStatusSent)
+		s.clearNotifierState(lifecycleTransientFailureStateKey(deliveryKey))
+	}
+	s.clearNotifierState(lifecycleTransientFailureStateKey(deliveryKey, route.notifier))
+	s.clearPollWarning(lifecycleSendWarningKeyFor(route.notifier))
+	return true, nil
+}
+
+// postLifecycleEventRoute is the single-route entry point used by the
+// per-route task-run pass.
+func (s *Server) postLifecycleEventRoute(d lifecycleDelivery, route lifecycleRouteDelivery, msg notify.Message, runKey, deliveryKey string) error {
+	_, err := s.postLifecycleRoute(d, route, msg, runKey, deliveryKey)
+	return err
 }
 
 type lifecycleRouteSendError struct {
@@ -645,18 +854,53 @@ type lifecycleRouteSendError struct {
 
 func (e lifecycleRouteSendError) Error() string { return e.err.Error() }
 
-func (s *Server) lifecycleRouteDelivered(eventID, notifier string) bool {
+// lifecycleRouteSendErrors carries every failing route of one fan-out. Callers
+// must apply the send-failure policy to each entry: classifying only the first
+// one lets a later route's transient/config failure be mistaken for handled,
+// which advances the cursor past an event that route never received.
+type lifecycleRouteSendErrors []lifecycleRouteSendError
+
+func (e lifecycleRouteSendErrors) Error() string {
+	parts := make([]string, 0, len(e))
+	for _, routeErr := range e {
+		parts = append(parts, routeErr.notifier+": "+routeErr.err.Error())
+	}
+	return strings.Join(parts, "; ")
+}
+
+// lifecycleRouteDelivered reports whether this (event, route) pair already has
+// a delivery record, counting rows still stashed in memory after a failed
+// write. A query error is returned, never swallowed: reporting "not delivered"
+// on a sick database turns into a duplicate external send every tick.
+func (s *Server) lifecycleRouteDelivered(eventID, notifier string) (bool, error) {
+	if s.lifecycleDeliveryPending(eventID, notifier) {
+		return true, nil
+	}
 	var n int
 	// The legacy read fallback is deliberately retained instead of a migration:
 	// it applies to every configured route, including routes added after upgrade.
-	err := s.db.QueryRow(`SELECT EXISTS(SELECT 1 FROM slack_notification_deliveries WHERE event_id=?) OR EXISTS(SELECT 1 FROM slack_notification_deliveries_v2 WHERE event_id=? AND notifier=?)`, eventID, eventID, notifier).Scan(&n)
-	return err == nil && n != 0
+	if err := s.db.QueryRow(`SELECT EXISTS(SELECT 1 FROM slack_notification_deliveries WHERE event_id=?) OR EXISTS(SELECT 1 FROM slack_notification_deliveries_v2 WHERE event_id=? AND notifier=?)`, eventID, eventID, notifier).Scan(&n); err != nil {
+		return false, err
+	}
+	return n != 0, nil
 }
 
+// recordNotificationDeliveryV2 persists one per-route delivery row, stashing a
+// failed write for retry exactly like the legacy table (see
+// recordNotificationDelivery): the row is this route's only dedupe for
+// claw-pass events, so logging and forgetting means a duplicate send per tick
+// until the database recovers.
 func (s *Server) recordNotificationDeliveryV2(eventID, notifier, runID, messageHandle, status string) {
-	if _, err := s.db.Exec(`INSERT INTO slack_notification_deliveries_v2(event_id, notifier, run_id, delivered_at, message_ts, status) VALUES(?,?,?,?,?,?) ON CONFLICT(event_id, notifier) DO NOTHING`, eventID, notifier, runID, epochMillis(now()), messageHandle, status); err != nil {
-		log.Printf("[notify] record route delivery for event %s via %s: %v", eventID, notifier, err)
+	if err := s.execNotificationDeliveryV2(eventID, notifier, runID, messageHandle, status); err != nil {
+		log.Printf("[notify] record route delivery for event %s via %s (will retry): %v", eventID, notifier, err)
+		s.stashPendingDelivery(pendingDeliveryKey{eventID: eventID, notifier: notifier},
+			pendingNotificationDelivery{runID: runID, messageHandle: messageHandle, status: status})
 	}
+}
+
+func (s *Server) execNotificationDeliveryV2(eventID, notifier, runID, messageHandle, status string) error {
+	_, err := s.db.Exec(`INSERT INTO slack_notification_deliveries_v2(event_id, notifier, run_id, delivered_at, message_ts, status) VALUES(?,?,?,?,?,?) ON CONFLICT(event_id, notifier) DO NOTHING`, eventID, notifier, runID, epochMillis(now()), messageHandle, status)
+	return err
 }
 
 // pendingNotificationDelivery is a delivery whose post-send bookkeeping write
@@ -665,6 +909,24 @@ type pendingNotificationDelivery struct {
 	runID         string
 	messageHandle string
 	status        string
+}
+
+// lifecycleLegacyDeliveryNotifier keys the legacy (un-routed) delivery table in
+// the pending stash. The sentinel cannot collide with a notifier name: config
+// validation rejects the empty name and no name may contain a NUL.
+const lifecycleLegacyDeliveryNotifier = "\x00legacy"
+
+// pendingDeliveryKey identifies one stashed delivery row.
+type pendingDeliveryKey struct {
+	eventID  string
+	notifier string
+}
+
+func (s *Server) stashPendingDelivery(key pendingDeliveryKey, p pendingNotificationDelivery) {
+	if s.lifecyclePendingDeliveries == nil {
+		s.lifecyclePendingDeliveries = make(map[pendingDeliveryKey]pendingNotificationDelivery)
+	}
+	s.lifecyclePendingDeliveries[key] = p
 }
 
 // recordNotificationDelivery persists one delivery row. A failed write is
@@ -677,10 +939,8 @@ type pendingNotificationDelivery struct {
 func (s *Server) recordNotificationDelivery(eventID, runID, messageHandle, status string) {
 	if err := s.execNotificationDelivery(eventID, runID, messageHandle, status); err != nil {
 		log.Printf("[notify] record delivery for event %s (will retry): %v", eventID, err)
-		if s.lifecyclePendingDeliveries == nil {
-			s.lifecyclePendingDeliveries = make(map[string]pendingNotificationDelivery)
-		}
-		s.lifecyclePendingDeliveries[eventID] = pendingNotificationDelivery{runID: runID, messageHandle: messageHandle, status: status}
+		s.stashPendingDelivery(pendingDeliveryKey{eventID: eventID, notifier: lifecycleLegacyDeliveryNotifier},
+			pendingNotificationDelivery{runID: runID, messageHandle: messageHandle, status: status})
 	}
 }
 
@@ -693,9 +953,13 @@ func (s *Server) execNotificationDelivery(eventID, runID, messageHandle, status 
 }
 
 // lifecycleDeliveryPending reports whether the event was sent but its
-// delivery row is still awaiting persistence.
-func (s *Server) lifecycleDeliveryPending(eventID string) bool {
-	_, ok := s.lifecyclePendingDeliveries[eventID]
+// delivery row is still awaiting persistence — either the legacy row (a fence
+// for every route) or this route's own v2 row.
+func (s *Server) lifecycleDeliveryPending(eventID, notifier string) bool {
+	if _, ok := s.lifecyclePendingDeliveries[pendingDeliveryKey{eventID: eventID, notifier: lifecycleLegacyDeliveryNotifier}]; ok {
+		return true
+	}
+	_, ok := s.lifecyclePendingDeliveries[pendingDeliveryKey{eventID: eventID, notifier: notifier}]
 	return ok
 }
 
@@ -715,12 +979,18 @@ func (s *Server) lifecycleDeliveryPending(eventID string) bool {
 // (stopLifecycleNotifier), leaving only a hard crash in the microseconds
 // between Send and insert exposed.
 func (s *Server) flushPendingNotificationDeliveries() {
-	for eventID, p := range s.lifecyclePendingDeliveries {
-		if err := s.execNotificationDelivery(eventID, p.runID, p.messageHandle, p.status); err != nil {
-			log.Printf("[notify] retry delivery record for event %s: %v", eventID, err)
+	for key, p := range s.lifecyclePendingDeliveries {
+		var err error
+		if key.notifier == lifecycleLegacyDeliveryNotifier {
+			err = s.execNotificationDelivery(key.eventID, p.runID, p.messageHandle, p.status)
+		} else {
+			err = s.execNotificationDeliveryV2(key.eventID, key.notifier, p.runID, p.messageHandle, p.status)
+		}
+		if err != nil {
+			log.Printf("[notify] retry delivery record for event %s: %v", key.eventID, err)
 			return // DB still unhappy; keep the stash for the next tick
 		}
-		delete(s.lifecyclePendingDeliveries, eventID)
+		delete(s.lifecyclePendingDeliveries, key)
 	}
 }
 
@@ -1131,7 +1401,10 @@ func (s *Server) handleNotificationTest(w http.ResponseWriter, r *http.Request) 
 		EventType string `json:"event_type"`
 		RunID     string `json:"run_id"`
 		ClawID    string `json:"claw_id"`
-		DryRun    bool   `json:"dry_run"`
+		// Via names which configured notifier to probe. Empty means the first
+		// effective route — lifecycle.via for a legacy single-channel config.
+		Via    string `json:"via"`
+		DryRun bool   `json:"dry_run"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		jsonError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
@@ -1156,9 +1429,24 @@ func (s *Server) handleNotificationTest(w http.ResponseWriter, r *http.Request) 
 		jsonError(w, http.StatusBadRequest, "notifications config invalid: "+err.Error())
 		return
 	}
-	// Trimmed to match ValidateNotificationsConfig (see lifecycleNotifierTick).
-	via := strings.TrimSpace(cfg.Lifecycle.Via)
-	nc := cfg.Notifiers[via] // exists: validated above
+	// Resolve which destination to probe. A routes-only config has no
+	// lifecycle.via at all, so defaulting to it would 400 every test send the
+	// Notifier UI makes. Trimmed to match ValidateNotificationsConfig (see
+	// lifecycleNotifierTick).
+	via := strings.TrimSpace(body.Via)
+	if via == "" {
+		routes := cfg.Lifecycle.EffectiveRoutes()
+		if len(routes) == 0 { // unreachable: validated above while enabled
+			jsonError(w, http.StatusBadRequest, "notifications.lifecycle has no configured route to test")
+			return
+		}
+		via = strings.TrimSpace(routes[0].Via)
+	}
+	nc, ok := cfg.Notifiers[via]
+	if !ok {
+		jsonError(w, http.StatusBadRequest, "via "+strconv.Quote(via)+" does not name a configured notifier (defined: "+configuredNotifierNames(cfg.Notifiers)+")")
+		return
+	}
 
 	if body.RunID != "" && body.ClawID != "" {
 		jsonError(w, http.StatusBadRequest, "run_id and claw_id are mutually exclusive")
@@ -1279,6 +1567,19 @@ func (s *Server) handleNotificationTest(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	jsonOK(w, map[string]any{"ok": true, "message_id": handle, "via": via, "payload": payload})
+}
+
+// configuredNotifierNames lists the configured notifier names for error text.
+func configuredNotifierNames(notifiers map[string]types.NotifierConfig) string {
+	if len(notifiers) == 0 {
+		return "none"
+	}
+	names := make([]string, 0, len(notifiers))
+	for name := range notifiers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return strings.Join(names, ", ")
 }
 
 // renderNotifierPayload returns the provider-rendered wire payload when the

--- a/pkg/hub/lifecycle_notifier.go
+++ b/pkg/hub/lifecycle_notifier.go
@@ -714,6 +714,24 @@ func (s *Server) ensureLifecycleRouteWatermarks(lc *types.LifecycleNotifications
 	}
 }
 
+// lifecycleRouteWatermarksMaterialised reports whether every configured route
+// already carries a cursor of its own. It is the guard for writing per-route
+// claw baselines: a route stamped as baselined while it has no cursor reads as
+// the legacy incumbent (lifecycleSingleViaIncumbent) and would then be handed
+// the shared floor and replay everything piled up behind it.
+func (s *Server) lifecycleRouteWatermarksMaterialised(routes []types.LifecycleRoute) bool {
+	for _, route := range routes {
+		via := strings.TrimSpace(route.Via)
+		if via == "" {
+			continue
+		}
+		if _, found, err := s.notifierStateInt64(lifecycleRouteWatermarkKey(via)); err != nil || !found {
+			return false
+		}
+	}
+	return true
+}
+
 // lifecycleRoutingSchemeLive reports whether the per-route state scheme has
 // already gone live for this hub. It is how both passes tell a legacy
 // single-`via` migration (nothing per-route recorded yet, so the shared state is

--- a/pkg/hub/lifecycle_notifier.go
+++ b/pkg/hub/lifecycle_notifier.go
@@ -257,12 +257,27 @@ func (s *Server) initLifecycleNotifierBaseline() {
 			// route would present a channel added in the same maintenance
 			// window as the legacy incumbent, hand it the incumbent's frozen
 			// shared cursor and replay the whole stalled backlog into it.
-			if via := lifecycleLegacyIncumbentVia(cfg.Lifecycle); via != "" {
+			//
+			// An absent stamp is NOT proof the scheme never went live:
+			// pruneLifecycleRouteState deletes the stamps of routes that left
+			// the config and deliberately keeps the routes_live latch for
+			// exactly this reason. Consult the latch first, or a restart taken
+			// while a config was collapsed onto one brand-new route would
+			// present that route as the legacy incumbent.
+			var via string
+			live, liveErr := s.lifecycleRoutingSchemeLive()
+			if liveErr != nil {
+				log.Printf("[notify] read routing scheme state: %v", liveErr)
+			} else if !live {
+				via = lifecycleLegacyIncumbentVia(cfg.Lifecycle)
+			}
+			if via != "" {
 				s.setNotifierStateInt64(lifecycleClawRouteBaselineKey(via), 1)
-			} else {
-				// The config already carries several routes and no longer says
-				// which one was the single `via`, so no route can be verified
-				// as the incumbent. Latch the scheme instead: every route
+			} else if liveErr == nil {
+				// Either the scheme has already been live, or the config
+				// carries several routes and no longer says which one was the
+				// single `via`: no route can be verified as the incumbent.
+				// Latch the scheme instead: every route
 				// starts at the stream head and ensureLifecycleClawRouteBaselines
 				// seeds its claw fence, which loses the incumbent's undelivered
 				// backlog but never floods a brand-new channel with it.
@@ -554,6 +569,31 @@ func lifecycleLegacyIncumbentVia(lc *types.LifecycleNotificationsConfig) string 
 	return ""
 }
 
+// lifecycleRoutesNeedOwnState reports whether the configured routes must be
+// given per-route state (cursor and claw fence) at CONFIG time rather than at
+// the first tick their notifier happens to build. Multi-route configs always
+// do. A LONE route does too once the per-route scheme has gone live and that
+// route is not the legacy incumbent: collapsing a config onto one brand-new
+// channel leaves it as the hub's only route, and materialising its state only
+// on recovery would bury everything produced while its notifier could not be
+// built — the very window each tick logs as "held until it can be built".
+// The genuine legacy single-`via` shape keeps using the shared state and gets
+// no per-route keys, so pre-routing behaviour is byte-for-byte unchanged.
+func (s *Server) lifecycleRoutesNeedOwnState(routes []types.LifecycleRoute) bool {
+	if len(routes) >= 2 {
+		return true
+	}
+	if len(routes) == 0 {
+		return false
+	}
+	via := strings.TrimSpace(routes[0].Via)
+	if via == "" || s.lifecycleSingleViaIncumbent(via) {
+		return false
+	}
+	live, err := s.lifecycleRoutingSchemeLive()
+	return err == nil && live
+}
+
 func (s *Server) lifecycleSingleViaIncumbent(via string) bool {
 	if via == "" {
 		return false
@@ -580,7 +620,7 @@ func (s *Server) lifecycleSingleViaIncumbent(via string) bool {
 // everything that piled up behind a paused or unbuildable sibling.
 func (s *Server) ensureLifecycleRouteWatermarks(lc *types.LifecycleNotificationsConfig) {
 	routes := lc.EffectiveRoutes()
-	if len(routes) < 2 {
+	if !s.lifecycleRoutesNeedOwnState(routes) {
 		// The legacy single-route shape keeps using the shared key
 		// (lifecycleWatermarkKeyFor), so it needs no cursor of its own.
 		return
@@ -632,7 +672,18 @@ func (s *Server) ensureLifecycleRouteWatermarks(lc *types.LifecycleNotifications
 		if _, found, err := s.notifierStateInt64(key); err != nil || found {
 			continue
 		}
-		if !routed && sharedFound && (len(incumbents) == 0 || incumbents[via]) {
+		if sharedFound && incumbents[via] {
+			// The incumbent is read off the SHARED key precisely because it
+			// never got one of its own (lifecycleWatermarkKeyFor), so that is
+			// its real position no matter how the routes_live latch came to be
+			// set — a restricted single route latches it on its very first tick
+			// (lifecycleClawRouteSkip) without ever leaving the shared key.
+			// Stamping the head here instead would drop everything the
+			// incumbent had not yet delivered, silently and for good.
+			s.setNotifierStateInt64(key, shared)
+			continue
+		}
+		if !routed && sharedFound && len(incumbents) == 0 {
 			s.setNotifierStateInt64(key, shared)
 			continue
 		}

--- a/pkg/hub/lifecycle_notifier_test.go
+++ b/pkg/hub/lifecycle_notifier_test.go
@@ -2332,3 +2332,94 @@ func TestLifecycleLegacyViaMigrationStartsTheNewRouteAtHead(t *testing.T) {
 		}
 	}
 }
+
+// Regression: replacing the legacy single-`via` incumbent with an all-new route
+// set in one save deleted the incumbent's claw baseline stamp — the ONLY
+// per-route state a hub that never went multi-route has — so
+// ensureLifecycleRouteWatermarks read "nothing routed yet" and seeded every
+// brand-new channel with the incumbent's stalled shared cursor, replaying its
+// whole undelivered backlog into each of them.
+func TestLifecycleReplacingTheLegacyIncumbentStartsNewcomersAtHead(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	s, db := newSlackNotifierTestServer(t, fake.server.URL, nil)
+	setLifecycleClawBaseline(t, s)
+	setSlackWatermark(t, s, 0)
+	s.lifecycleNotifierTick() // records the incumbent; nothing pending yet
+
+	// The incumbent's channel is archived, so its cursor stays frozen while the
+	// event stream grows.
+	var down atomic.Bool
+	down.Store(true)
+	fake.setRespond(func(_ int, w http.ResponseWriter) {
+		if down.Load() {
+			http.Error(w, "temporary", http.StatusInternalServerError)
+			return
+		}
+		slackOK(w)
+	})
+	insertLifecycleRouteEvent(t, db, "stalled-0", taskRunEventAgentStarted)
+	for i, id := range []string{"stalled-1", "stalled-2"} {
+		insertSlackTestEvent(t, db, id, "route-run", taskRunEventAgentStarted, 1760000000030+int64(i), "", "", "")
+	}
+	s.lifecycleNotifierTick()
+	if wm, _ := slackWatermark(t, s); wm != 0 {
+		t.Fatalf("the incumbent's cursor advanced past the failed sends: %d, want 0", wm)
+	}
+
+	// The operator replaces the channel outright: one save drops the incumbent
+	// and routes two brand-new channels.
+	down.Store(false)
+	addSlackTestNotifier(s, "alerts-b", testNotifierToken, "C0ALERTSB")
+	addSlackTestNotifier(s, "alerts-c", testNotifierToken, "C0ALERTSC")
+	s.mu.Lock()
+	s.hubCfg.Notifications.Lifecycle.Via = ""
+	s.mu.Unlock()
+	setLifecycleRoutes(s, types.LifecycleRoute{Via: "alerts-b"}, types.LifecycleRoute{Via: "alerts-c"})
+	s.lifecycleNotifierTick()
+	s.lifecycleNotifierTick()
+
+	for _, via := range []string{"alerts-b", "alerts-c"} {
+		for _, id := range []string{"stalled-0", "stalled-1", "stalled-2"} {
+			if status, ok := routeDeliveryStatus(t, db, id, via); ok && status == notificationDeliveryStatusSent {
+				t.Fatalf("replacing the incumbent replayed its stalled backlog into %q (%s)", via, id)
+			}
+		}
+	}
+}
+
+// Regression: the first boot of the upgraded binary on a DB left by a legacy
+// single-`via` era stamped a claw baseline for EVERY configured route. The
+// stamp is what lifecycleSingleViaIncumbent reads, so a channel added in the
+// same maintenance window was reported as the legacy incumbent, inherited its
+// frozen shared cursor and replayed the stalled backlog into a channel that
+// should have started clean.
+func TestLifecycleLegacyBootWithRoutesStartsEveryRouteAtHead(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	s, db := newSlackNotifierRoutesTestServer(t, fake.server.URL,
+		[]types.LifecycleRoute{{Via: "incumbent"}, {Via: "oncall"}})
+	// Exactly the state the OLD binary leaves: a shared cursor frozen where the
+	// single `via` stalled plus the shared claw baseline, nothing per-route.
+	s.setNotifierStateInt64(lifecycleStateClawBaselineKey, 1)
+	setSlackWatermark(t, s, 0)
+	insertLifecycleRouteEvent(t, db, "stalled-0", taskRunEventAgentStarted)
+	for i, id := range []string{"stalled-1", "stalled-2"} {
+		insertSlackTestEvent(t, db, id, "route-run", taskRunEventAgentStarted, 1760000000030+int64(i), "", "", "")
+	}
+	insertSlackTestClaw(t, db, "claw-during-outage", "connected", 1, "", oldEnough)
+
+	// The operator upgrades the binary and saves the routes in one window.
+	s.initLifecycleNotifierBaseline()
+	s.lifecycleNotifierTick()
+	s.lifecycleNotifierTick()
+
+	if fake.count() != 0 {
+		t.Fatalf("the upgrade replayed the legacy backlog: %d messages, want 0", fake.count())
+	}
+	for _, via := range []string{"incumbent", "oncall"} {
+		for _, id := range []string{"stalled-0", "stalled-1", "stalled-2", lifecycleClawStartedKey("claw-during-outage")} {
+			if status, ok := routeDeliveryStatus(t, db, id, via); ok && status == notificationDeliveryStatusSent {
+				t.Fatalf("%s was sent to %q on the first boot after the upgrade", id, via)
+			}
+		}
+	}
+}

--- a/pkg/hub/lifecycle_notifier_test.go
+++ b/pkg/hub/lifecycle_notifier_test.go
@@ -261,10 +261,9 @@ func respondByChannel(fake *fakeSlackServer, fn func(channel string, w http.Resp
 func slackOK(w http.ResponseWriter) { fmt.Fprint(w, `{"ok":true,"ts":"1000.000001"}`) }
 
 // Regression: the claw pass has NO cursor — the delivery-row anti-join alone
-// decides what is new. With more than one route the legacy row stopped being
-// written, so every handled ad-hoc claw event was re-selected on every tick
-// forever and eventually ate the whole batch LIMIT, silently starving newer
-// claws of notifications.
+// decides what is new. With more than one route no row was written for the
+// handled claw, so it was re-selected on every tick forever and eventually ate
+// the whole batch LIMIT, silently starving newer claws of notifications.
 func TestLifecycleRoutesFanoutFencesClawEvents(t *testing.T) {
 	fake := newFakeSlackServer(t)
 	s, db := newSlackNotifierRoutesTestServer(t, fake.server.URL, []types.LifecycleRoute{{Via: "primary"}, {Via: "secondary"}})
@@ -276,12 +275,11 @@ func TestLifecycleRoutesFanoutFencesClawEvents(t *testing.T) {
 	if fake.count() != 2 {
 		t.Fatalf("fan-out sent %d messages, want 2", fake.count())
 	}
-	if _, ok := slackDeliveryStatus(t, db, lifecycleClawStartedKey("claw-adhoc")); !ok {
-		t.Fatal("handled claw event has no fence row; it would be re-selected on every tick forever")
-	}
-	claws, err := s.selectLifecycleClawStateCandidates(lifecycleClawKindStarted)
-	if err != nil || len(claws) != 0 {
-		t.Fatalf("handled claw still selected as a candidate: %d (err %v)", len(claws), err)
+	for _, notifier := range []string{"primary", "secondary"} {
+		claws, err := s.selectLifecycleClawStateCandidates(lifecycleClawKindStarted, notifier)
+		if err != nil || len(claws) != 0 {
+			t.Fatalf("handled claw still selected as a candidate for %s: %d (err %v)", notifier, len(claws), err)
+		}
 	}
 	s.lifecycleNotifierTick()
 	if fake.count() != 2 {
@@ -289,8 +287,8 @@ func TestLifecycleRoutesFanoutFencesClawEvents(t *testing.T) {
 	}
 }
 
-// Regression: an event type no route accepts is still "handled" and must be
-// fenced, or the claw pass re-selects it forever.
+// Regression: an event type a route does not accept must never be scanned for
+// that route, or those claws sit in its oldest-first batch forever.
 func TestLifecycleRoutesFenceClawEventNoRouteAccepts(t *testing.T) {
 	fake := newFakeSlackServer(t)
 	s, db := newSlackNotifierRoutesTestServer(t, fake.server.URL,
@@ -300,11 +298,137 @@ func TestLifecycleRoutesFenceClawEventNoRouteAccepts(t *testing.T) {
 	insertSlackTestClaw(t, db, "claw-adhoc", "connected", 1, "", oldEnough)
 
 	s.lifecycleNotifierTick()
+	s.lifecycleNotifierTick()
 	if fake.count() != 0 {
 		t.Fatalf("agent_started reached a pr_opened-only route: %d messages", fake.count())
 	}
-	if _, ok := slackDeliveryStatus(t, db, lifecycleClawStartedKey("claw-adhoc")); !ok {
-		t.Fatal("claw event no route accepts was not fenced; it would be re-selected forever")
+	route := lifecycleRouteDelivery{notifier: "prs-only", events: map[string]bool{taskRunEventPROpened: true}}
+	if lifecycleRouteAccepts(route, taskRunEventAgentStarted) {
+		t.Fatal("a pr_opened-only route must not scan agent_started claws; they would consume its batch forever")
+	}
+}
+
+// Regression: in the legacy single-`via` shape, a claw event whose route row
+// exists without the legacy row — the state a crash between the two writes
+// leaves, or a multi-route era where only this route ever delivered — was
+// re-selected on every tick forever: the dedupe read saw the route row and sent
+// nothing, so no legacy row was ever written and the event kept one slot of the
+// oldest-first batch for good.
+func TestLifecycleClawEventWithOnlyRouteDeliveryIsNotReselected(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	s, db := newSlackNotifierTestServer(t, fake.server.URL, nil)
+	setLifecycleClawBaseline(t, s)
+	setSlackWatermark(t, s, 0)
+	insertSlackTestClaw(t, db, "claw-adhoc", "connected", 1, "", oldEnough)
+	if _, err := db.Exec(`INSERT INTO slack_notification_deliveries_v2(event_id, notifier, run_id, delivered_at, message_ts, status) VALUES(?,?,?,?,?,?)`,
+		lifecycleClawStartedKey("claw-adhoc"), testNotifierName, lifecycleClawRunKey("claw-adhoc"), 1, "", notificationDeliveryStatusSent); err != nil {
+		t.Fatalf("seed route delivery: %v", err)
+	}
+
+	for i := 0; i < 3; i++ {
+		s.lifecycleNotifierTick()
+	}
+	if fake.count() != 0 {
+		t.Fatalf("an already-delivered claw event was re-sent %d times", fake.count())
+	}
+	claws, err := s.selectLifecycleClawStateCandidates(lifecycleClawKindStarted, testNotifierName)
+	if err != nil || len(claws) != 0 {
+		t.Fatalf("delivered claw is still a candidate: %d (err %v)", len(claws), err)
+	}
+}
+
+// Regression: claws delivered to a healthy route kept no delivery row while
+// another route was broken, so they stayed in the shared, oldest-first
+// `LIMIT 200` candidate set forever and eventually locked newer claws out of
+// every route — the cross-route muting the per-route parking exists to prevent.
+// ErrorConfig (is_archived) is never burned by the transient cap, so the state
+// persisted for as long as the channel stayed archived.
+func TestLifecycleClawBrokenRouteDoesNotStarveHealthyRoute(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	s, db := newSlackNotifierRoutesTestServer(t, fake.server.URL, []types.LifecycleRoute{{Via: "archived"}, {Via: "healthy"}})
+	respondByChannel(fake, func(channel string, w http.ResponseWriter) {
+		if channel == "C0ROUTE0001" { // the "archived" route
+			fmt.Fprint(w, `{"ok":false,"error":"is_archived"}`)
+			return
+		}
+		slackOK(w)
+	})
+	setLifecycleClawBaseline(t, s)
+	setSlackWatermark(t, s, 0)
+	for i := 0; i < 3; i++ {
+		insertSlackTestClaw(t, db, fmt.Sprintf("claw-%d", i), "connected", 1, "", oldEnough)
+	}
+
+	s.lifecycleNotifierTick()
+	s.lifecycleNotifierTick()
+
+	healthy, err := s.selectLifecycleClawStateCandidates(lifecycleClawKindStarted, "healthy")
+	if err != nil || len(healthy) != 0 {
+		t.Fatalf("claws already delivered to the healthy route still occupy its batch: %d (err %v)", len(healthy), err)
+	}
+	archived, err := s.selectLifecycleClawStateCandidates(lifecycleClawKindStarted, "archived")
+	if err != nil || len(archived) != 3 {
+		t.Fatalf("the broken route lost its backlog: %d candidates (err %v)", len(archived), err)
+	}
+}
+
+// Regression: a configured route that cannot be built at all (its token secret
+// no longer exists) marked every claw event incomplete — even event types its
+// own allow-list does not cover — so the routes that DID build never got a
+// fence row and replayed their candidate set on every tick until it filled the
+// batch. Pre-routing this was a loud total outage; here it was silent.
+func TestLifecycleClawUnbuildableRouteDoesNotStarveBuiltRoutes(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	s, db := newSlackNotifierRoutesTestServer(t, fake.server.URL, []types.LifecycleRoute{
+		{Via: "primary", Events: []string{taskRunEventAgentStarted}},
+		{Via: "secondary", Events: []string{taskRunEventPROpened}},
+	})
+	s.mu.Lock()
+	s.hubCfg.Notifications.Notifiers["secondary"] = types.NotifierConfig{Type: "slack", Settings: map[string]any{
+		"token_secret": "secret-that-no-longer-exists", "channel": "C0SECOND",
+	}}
+	s.mu.Unlock()
+	setLifecycleClawBaseline(t, s)
+	setSlackWatermark(t, s, 0)
+	insertSlackTestClaw(t, db, "claw-adhoc", "connected", 1, "", oldEnough)
+
+	for i := 0; i < 3; i++ {
+		s.lifecycleNotifierTick()
+	}
+	if fake.count() != 1 {
+		t.Fatalf("agent_started sent %d times; an unbuildable route must not make a built one replay", fake.count())
+	}
+	claws, err := s.selectLifecycleClawStateCandidates(lifecycleClawKindStarted, "primary")
+	if err != nil || len(claws) != 0 {
+		t.Fatalf("an unbuildable route kept a delivered claw in the built route's batch: %d (err %v)", len(claws), err)
+	}
+}
+
+// A route added to an existing config must not replay every currently
+// connected claw into its new channel: the claw pass has no cursor, so the
+// route needs its own baseline the way a new task-run route inherits a cursor.
+func TestLifecycleClawRouteAddedLaterDoesNotReplayCurrentClaws(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	s, db := newSlackNotifierRoutesTestServer(t, fake.server.URL, []types.LifecycleRoute{{Via: "primary"}, {Via: "secondary"}})
+	setLifecycleClawBaseline(t, s)
+	setSlackWatermark(t, s, 0)
+	insertSlackTestClaw(t, db, "claw-adhoc", "connected", 1, "", oldEnough)
+	s.lifecycleNotifierTick()
+	if fake.count() != 2 {
+		t.Fatalf("fan-out sent %d messages, want 2", fake.count())
+	}
+
+	s.mu.Lock()
+	s.hubCfg.Notifications.Notifiers["late"] = types.NotifierConfig{Type: "slack", Settings: map[string]any{
+		"token_secret": testNotifierToken, "channel": "C0LATEROUTE",
+	}}
+	s.hubCfg.Notifications.Lifecycle.Routes = append(s.hubCfg.Notifications.Lifecycle.Routes, types.LifecycleRoute{Via: "late"})
+	s.mu.Unlock()
+
+	s.lifecycleNotifierTick()
+	s.lifecycleNotifierTick()
+	if fake.count() != 2 {
+		t.Fatalf("a route added later replayed the current claw list: %d messages, want 2", fake.count())
 	}
 }
 
@@ -1667,13 +1791,16 @@ func TestLifecyclePostDoesNotWriteLegacyThreadRows(t *testing.T) {
 		RunID: "run-1", AttemptID: "attempt-run-1", ClawID: "claw-1", TenantID: "test-tenant-id", OwnerType: taskRunOwnerFactory,
 		Factory: "bugfix", StartedAt: base - 1000,
 	})
+	route := d.effectiveRoutes()[0]
 	ev := lifecycleEventRow{ID: "ev-1", RunID: "run-1", EventType: taskRunEventAgentStarted}
-	if err := s.postLifecycleEvent(d, ev, s.lifecycleRunContextFor("run-1"), "run-1", "ev-1"); err != nil {
+	msg := buildLifecycleMessage(ev, s.lifecycleRunContextFor("run-1"))
+	if err := s.postLifecycleEventRoute(d, route, msg, "run-1", "ev-1"); err != nil {
 		t.Fatalf("first post: %v", err)
 	}
 	// The second event must stay top-level and no legacy root row may be written.
 	ev2 := lifecycleEventRow{ID: "ev-2", RunID: "run-1", EventType: taskRunEventPROpened}
-	if err := s.postLifecycleEvent(d, ev2, s.lifecycleRunContextFor("run-1"), "run-1", "ev-2"); err != nil {
+	msg2 := buildLifecycleMessage(ev2, s.lifecycleRunContextFor("run-1"))
+	if err := s.postLifecycleEventRoute(d, route, msg2, "run-1", "ev-2"); err != nil {
 		t.Fatalf("second post: %v", err)
 	}
 	var n int

--- a/pkg/hub/lifecycle_notifier_test.go
+++ b/pkg/hub/lifecycle_notifier_test.go
@@ -1930,3 +1930,130 @@ func TestLifecycleClawRouteAllowListAdditionDoesNotReplay(t *testing.T) {
 		t.Fatalf("widening a route's allow-list replayed history: %d messages, want %d", fake.count(), delivered)
 	}
 }
+
+// Regression: per-route state survived the route's removal from an enabled
+// config (nothing parks it while alerts stay on), so re-adding the channel
+// resumed from its stale cursor and flushed the whole removal window — and its
+// stale claw baseline kept the claw pass from re-seeding, replaying every
+// still-connected ad-hoc claw on top.
+func TestLifecycleRemovedRouteStateIsDroppedSoReAddDoesNotReplay(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	routes := []types.LifecycleRoute{{Via: "primary"}, {Via: "secondary"}, {Via: "third"}}
+	s, db := newSlackNotifierRoutesTestServer(t, fake.server.URL, routes)
+	setLifecycleClawBaseline(t, s)
+	setSlackWatermark(t, s, 0)
+	insertLifecycleRouteEvent(t, db, "before-removal", taskRunEventAgentStarted)
+	s.lifecycleNotifierTick()
+	if fake.count() != 3 {
+		t.Fatalf("three routes sent %d messages, want 3", fake.count())
+	}
+
+	// The operator un-routes "third". Two routes remain, so nothing is written
+	// to the legacy table that could fence the removal window later.
+	setRoutes := func(routes ...types.LifecycleRoute) {
+		s.mu.Lock()
+		s.hubCfg.Notifications.Lifecycle.Routes = routes
+		s.mu.Unlock()
+	}
+	setRoutes(types.LifecycleRoute{Via: "primary"}, types.LifecycleRoute{Via: "secondary"})
+	s.lifecycleNotifierTick()
+	for _, key := range []string{lifecycleRouteWatermarkKey("third"), lifecycleClawRouteBaselineKey("third")} {
+		if _, found, err := s.notifierStateInt64(key); err != nil || found {
+			t.Fatalf("state %q survived the route's removal (found=%v, err=%v)", key, found, err)
+		}
+	}
+
+	insertSlackTestEvent(t, db, "during-removal", "route-run", taskRunEventAgentStarted, 1760000000030, "", "", "")
+	insertSlackTestClaw(t, db, "claw-during-removal", "connected", 1, "", oldEnough)
+	s.lifecycleNotifierTick()
+	sent := fake.count()
+
+	// Re-adding it must behave exactly like a newly added route.
+	setRoutes(types.LifecycleRoute{Via: "primary"}, types.LifecycleRoute{Via: "secondary"}, types.LifecycleRoute{Via: "third"})
+	s.lifecycleNotifierTick()
+	s.lifecycleNotifierTick()
+	if fake.count() != sent {
+		t.Fatalf("a re-added route replayed the removal window: %d messages, want %d", fake.count(), sent)
+	}
+}
+
+// Regression: a new route inherited the shared floor, which
+// advanceLifecycleWatermarkFloor freezes while any configured route cannot be
+// built. Adding a channel while a sibling was broken therefore flooded it with
+// the broken route's entire backlog.
+func TestLifecycleRouteAddedWhileSiblingBrokenStartsAtHead(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	s, db := newSlackNotifierRoutesTestServer(t, fake.server.URL, []types.LifecycleRoute{{Via: "healthy"}, {Via: "broken"}})
+	setSlackWatermark(t, s, 0)
+	s.mu.Lock()
+	s.hubCfg.Notifications.Notifiers["broken"] = types.NotifierConfig{Type: "slack", Settings: map[string]any{
+		"token_secret": "secret-that-does-not-exist", "channel": "C0BROKEN",
+	}}
+	s.mu.Unlock()
+
+	// The shared floor cannot advance past the broken route, so it stays at 0
+	// while the healthy route works through the backlog.
+	insertLifecycleRouteEvent(t, db, "backlog-0", taskRunEventAgentStarted)
+	for i, id := range []string{"backlog-1", "backlog-2", "backlog-3"} {
+		insertSlackTestEvent(t, db, id, "route-run", taskRunEventAgentStarted, 1760000000030+int64(i), "", "", "")
+	}
+	s.lifecycleNotifierTick()
+	sent := fake.count()
+	if sent == 0 {
+		t.Fatal("healthy route delivered nothing")
+	}
+	if floor, _ := slackWatermark(t, s); floor != 0 {
+		t.Fatalf("shared floor advanced past the broken route: %d, want 0", floor)
+	}
+
+	s.mu.Lock()
+	s.hubCfg.Notifications.Notifiers["late"] = types.NotifierConfig{Type: "slack", Settings: map[string]any{
+		"token_secret": testNotifierToken, "channel": "C0LATEROUTE",
+	}}
+	s.hubCfg.Notifications.Lifecycle.Routes = append(s.hubCfg.Notifications.Lifecycle.Routes, types.LifecycleRoute{Via: "late"})
+	s.mu.Unlock()
+
+	s.lifecycleNotifierTick()
+	if fake.count() != sent {
+		t.Fatalf("a route added behind a broken sibling replayed its backlog: %d messages, want %d", fake.count(), sent)
+	}
+}
+
+// Regression: initLifecycleNotifierBaseline created the shared claw baseline
+// itself, which makes the in-tick first-enable branch unreachable — so no route
+// was ever stamped at boot. A route that could not be built at boot was then
+// treated as newly added when it recovered, and the claw events it was owed in
+// the meantime were seeded as "skipped".
+func TestLifecycleBootBaselineStampsEveryConfiguredRoute(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	s, db := newSlackNotifierRoutesTestServer(t, fake.server.URL, []types.LifecycleRoute{{Via: "healthy"}, {Via: "rotating"}})
+	s.mu.Lock()
+	s.hubCfg.Notifications.Notifiers["rotating"] = types.NotifierConfig{Type: "slack", Settings: map[string]any{
+		"token_secret": "secret-being-rotated", "channel": "C0ROTATING",
+	}}
+	s.mu.Unlock()
+
+	s.initLifecycleNotifierBaseline()
+	for _, via := range []string{"healthy", "rotating"} {
+		if _, found, err := s.notifierStateInt64(lifecycleClawRouteBaselineKey(via)); err != nil || !found {
+			t.Fatalf("boot baseline did not stamp route %q (found=%v, err=%v)", via, found, err)
+		}
+	}
+
+	// An ad-hoc claw connects while the rotating route is unavailable.
+	insertSlackTestClaw(t, db, "claw-during-outage", "connected", 1, "", oldEnough)
+	s.lifecycleNotifierTick()
+	if fake.count() != 1 {
+		t.Fatalf("healthy route sent %d messages during the outage, want 1", fake.count())
+	}
+
+	s.mu.Lock()
+	s.hubCfg.Notifications.Notifiers["rotating"] = types.NotifierConfig{Type: "slack", Settings: map[string]any{
+		"token_secret": testNotifierToken, "channel": "C0ROTATING",
+	}}
+	s.mu.Unlock()
+	s.lifecycleNotifierTick()
+	if status, ok := routeDeliveryStatus(t, db, lifecycleClawStartedKey("claw-during-outage"), "rotating"); !ok || status != notificationDeliveryStatusSent {
+		t.Fatalf("claw event owed to the recovered route was buried: %q, %v", status, ok)
+	}
+}

--- a/pkg/hub/lifecycle_notifier_test.go
+++ b/pkg/hub/lifecycle_notifier_test.go
@@ -2057,3 +2057,154 @@ func TestLifecycleBootBaselineStampsEveryConfiguredRoute(t *testing.T) {
 		t.Fatalf("claw event owed to the recovered route was buried: %q, %v", status, ok)
 	}
 }
+
+// setLifecycleRoutes rewrites the configured routes the way a settings PATCH
+// does, so a test can replace, collapse or extend the route set mid-run.
+func setLifecycleRoutes(s *Server, routes ...types.LifecycleRoute) {
+	s.mu.Lock()
+	s.hubCfg.Notifications.Lifecycle.Routes = routes
+	s.mu.Unlock()
+}
+
+// addSlackTestNotifier registers a Slack destination; an empty tokenSecret name
+// that resolves to nothing is how a test makes a route unbuildable.
+func addSlackTestNotifier(s *Server, name, tokenSecret, channel string) {
+	s.mu.Lock()
+	s.hubCfg.Notifications.Notifiers[name] = types.NotifierConfig{Type: "slack", Settings: map[string]any{
+		"token_secret": tokenSecret, "channel": channel,
+	}}
+	s.mu.Unlock()
+}
+
+// Regression: pruneLifecycleRouteState runs before ensureLifecycleRouteWatermarks,
+// so replacing EVERY route in one save deleted the only per-route cursors and
+// made the newcomers look like a legacy migration — they inherited the shared
+// floor, frozen behind the paused sibling, and replayed the whole backlog.
+func TestLifecycleReplacingEveryRouteStartsNewcomersAtHead(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	s, db := newSlackNotifierRoutesTestServer(t, fake.server.URL, []types.LifecycleRoute{{Via: "alerts-a"}, {Via: "alerts-b"}})
+	setLifecycleClawBaseline(t, s)
+	setSlackWatermark(t, s, 0)
+	addSlackTestNotifier(s, "alerts-b", "secret-that-does-not-exist", "C0BROKEN")
+
+	// alerts-b never builds, so the shared floor stays pinned at 0 while
+	// alerts-a works through the backlog.
+	insertLifecycleRouteEvent(t, db, "backlog-0", taskRunEventAgentStarted)
+	for i, id := range []string{"backlog-1", "backlog-2", "backlog-3"} {
+		insertSlackTestEvent(t, db, id, "route-run", taskRunEventAgentStarted, 1760000000030+int64(i), "", "", "")
+	}
+	s.lifecycleNotifierTick()
+	sent := fake.count()
+	if sent == 0 {
+		t.Fatal("healthy route delivered nothing")
+	}
+	if floor, _ := slackWatermark(t, s); floor != 0 {
+		t.Fatalf("shared floor advanced past the unbuildable route: %d, want 0", floor)
+	}
+
+	// The operator gives up and swaps in two brand-new channels in one save.
+	addSlackTestNotifier(s, "alerts-c", testNotifierToken, "C0NEWC")
+	addSlackTestNotifier(s, "alerts-d", testNotifierToken, "C0NEWD")
+	setLifecycleRoutes(s, types.LifecycleRoute{Via: "alerts-c"}, types.LifecycleRoute{Via: "alerts-d"})
+	s.lifecycleNotifierTick()
+	s.lifecycleNotifierTick()
+	if fake.count() != sent {
+		t.Fatalf("replacing every route flooded the new channels: %d messages, want %d", fake.count(), sent)
+	}
+}
+
+// Regression: collapsing a multi-route config back to one route made
+// lifecycleWatermarkKeyFor return the shared key, silently re-pointing the
+// survivor from its own cursor to the floor its slowest sibling froze.
+func TestLifecycleCollapseToOneRouteKeepsItsOwnCursor(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	s, db := newSlackNotifierRoutesTestServer(t, fake.server.URL, []types.LifecycleRoute{{Via: "alerts-a"}, {Via: "alerts-b"}})
+	setLifecycleClawBaseline(t, s)
+	setSlackWatermark(t, s, 0)
+	addSlackTestNotifier(s, "alerts-b", "secret-that-does-not-exist", "C0BROKEN")
+
+	insertLifecycleRouteEvent(t, db, "backlog-0", taskRunEventAgentStarted)
+	for i, id := range []string{"backlog-1", "backlog-2"} {
+		insertSlackTestEvent(t, db, id, "route-run", taskRunEventAgentStarted, 1760000000030+int64(i), "", "", "")
+	}
+	s.lifecycleNotifierTick()
+	if fake.count() == 0 {
+		t.Fatal("healthy route delivered nothing")
+	}
+
+	// A fresh channel is routed while the sibling is still broken, so it
+	// correctly starts at the stream head rather than at the frozen floor.
+	addSlackTestNotifier(s, "alerts-c", testNotifierToken, "C0NEWC")
+	setLifecycleRoutes(s, types.LifecycleRoute{Via: "alerts-a"}, types.LifecycleRoute{Via: "alerts-b"}, types.LifecycleRoute{Via: "alerts-c"})
+	s.lifecycleNotifierTick()
+	sent := fake.count()
+
+	// The decommissioned channels are dropped; alerts-c is now the only route,
+	// and it must keep reading its own cursor.
+	setLifecycleRoutes(s, types.LifecycleRoute{Via: "alerts-c"})
+	s.lifecycleNotifierTick()
+	s.lifecycleNotifierTick()
+	if fake.count() != sent {
+		t.Fatalf("the surviving route replayed from the shared floor: %d messages, want %d", fake.count(), sent)
+	}
+}
+
+// Regression: collapsing to a single route with a NEW notifier name took the
+// singleRoute branch, which stamps the claw baseline without seeding on the
+// assumption that the legacy delivery table already fences the route. The
+// multi-route era wrote v2 rows for the OLD names only, so the new channel got
+// a one-time flood of every still-connected claw.
+func TestLifecycleCollapseToNewSingleRouteSeedsClawBaseline(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	s, db := newSlackNotifierRoutesTestServer(t, fake.server.URL, []types.LifecycleRoute{{Via: "alerts-a"}, {Via: "alerts-b"}})
+	setLifecycleClawBaseline(t, s)
+	setSlackWatermark(t, s, 0)
+
+	insertSlackTestClaw(t, db, "claw-multi-route-era", "connected", 1, "", oldEnough)
+	s.lifecycleNotifierTick()
+	if fake.count() != 2 {
+		t.Fatalf("multi-route era sent %d messages, want one per route", fake.count())
+	}
+
+	addSlackTestNotifier(s, "alerts-c", testNotifierToken, "C0NEWC")
+	setLifecycleRoutes(s, types.LifecycleRoute{Via: "alerts-c"})
+	s.lifecycleNotifierTick()
+	s.lifecycleNotifierTick()
+	if fake.count() != 2 {
+		t.Fatalf("the collapsed-to route replayed the claw backlog: %d messages, want 2", fake.count())
+	}
+	if status, ok := routeDeliveryStatus(t, db, lifecycleClawStartedKey("claw-multi-route-era"), "alerts-c"); !ok || status != notificationDeliveryStatusSkipped {
+		t.Fatalf("claw baseline for the collapsed-to route = %q (%v), want a skipped fence", status, ok)
+	}
+}
+
+// Regression: a route added while its notifier could not be built had its claw
+// baseline seeded at the first SUCCESSFUL build, burying the claw events it
+// accrued during the outage — even though ensureLifecycleRouteWatermarks had
+// already materialised its task-run cursor at add time and those events are
+// delivered on recovery.
+func TestLifecycleClawBaselineFencesAtConfigTimeNotAtRecovery(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	s, db := newSlackNotifierRoutesTestServer(t, fake.server.URL, []types.LifecycleRoute{{Via: "eng"}})
+	setLifecycleClawBaseline(t, s)
+	setSlackWatermark(t, s, 0)
+	s.lifecycleNotifierTick()
+
+	// A second route is added with a typo'd secret name: configured, unbuildable.
+	addSlackTestNotifier(s, "oncall", "secret-that-does-not-exist", "C0ONCALL")
+	setLifecycleRoutes(s, types.LifecycleRoute{Via: "eng"}, types.LifecycleRoute{Via: "oncall"})
+	s.lifecycleNotifierTick()
+
+	// The claw connects AFTER oncall was configured, so it is owed to oncall.
+	insertSlackTestClaw(t, db, "claw-during-outage", "connected", 1, "", oldEnough)
+	s.lifecycleNotifierTick()
+	if fake.count() != 1 {
+		t.Fatalf("eng sent %d messages during the outage, want 1", fake.count())
+	}
+
+	addSlackTestNotifier(s, "oncall", testNotifierToken, "C0ONCALL")
+	s.lifecycleNotifierTick()
+	if status, ok := routeDeliveryStatus(t, db, lifecycleClawStartedKey("claw-during-outage"), "oncall"); !ok || status != notificationDeliveryStatusSent {
+		t.Fatalf("claw event owed to the recovered route was buried: %q, %v", status, ok)
+	}
+}

--- a/pkg/hub/lifecycle_notifier_test.go
+++ b/pkg/hub/lifecycle_notifier_test.go
@@ -2208,3 +2208,127 @@ func TestLifecycleClawBaselineFencesAtConfigTimeNotAtRecovery(t *testing.T) {
 		t.Fatalf("claw event owed to the recovered route was buried: %q, %v", status, ok)
 	}
 }
+
+// Regression: replacing a multi-route config with exactly ONE brand-new route
+// left that route without a cursor (ensureLifecycleRouteWatermarks returns at
+// len(routes) < 2), so lifecycleWatermarkKeyFor's single-route fallback handed
+// it the shared floor — pinned to the stalled route of the multi-route era —
+// and it re-sent the whole backlog. The two-newcomers case was already guarded.
+func TestLifecycleCollapseToOneNewRouteStartsAtHead(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	s, db := newSlackNotifierRoutesTestServer(t, fake.server.URL, []types.LifecycleRoute{{Via: "alerts-a"}, {Via: "alerts-b"}})
+	setLifecycleClawBaseline(t, s)
+	setSlackWatermark(t, s, 0)
+	addSlackTestNotifier(s, "alerts-b", "secret-that-does-not-exist", "C0BROKEN")
+
+	insertLifecycleRouteEvent(t, db, "backlog-0", taskRunEventAgentStarted)
+	for i, id := range []string{"backlog-1", "backlog-2", "backlog-3"} {
+		insertSlackTestEvent(t, db, id, "route-run", taskRunEventAgentStarted, 1760000000030+int64(i), "", "", "")
+	}
+	s.lifecycleNotifierTick()
+	sent := fake.count()
+	if sent == 0 {
+		t.Fatal("healthy route delivered nothing")
+	}
+	if floor, _ := slackWatermark(t, s); floor != 0 {
+		t.Fatalf("shared floor advanced past the unbuildable route: %d, want 0", floor)
+	}
+
+	// One brand-new channel replaces BOTH in a single save.
+	addSlackTestNotifier(s, "alerts-c", testNotifierToken, "C0NEWC")
+	setLifecycleRoutes(s, types.LifecycleRoute{Via: "alerts-c"})
+	s.lifecycleNotifierTick()
+	s.lifecycleNotifierTick()
+	if fake.count() != sent {
+		t.Fatalf("collapsing to one new route replayed the multi-route backlog: %d messages, want %d", fake.count(), sent)
+	}
+}
+
+// Regression: on a hub that never had more than one route, swapping a
+// RESTRICTED route's notifier for a new name stamped the newcomer's claw
+// baseline without seeding — the "genuine legacy incumbent" shortcut — even
+// though the allow-list parking of the previous era wrote v2 rows keyed by the
+// OLD name only. Every still-connected ad-hoc claw was replayed into the new
+// channel.
+func TestLifecycleRestrictedSingleRouteSwapSeedsClawBaseline(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	s, db := newSlackNotifierRoutesTestServer(t, fake.server.URL, []types.LifecycleRoute{
+		{Via: "slack", Events: []string{taskRunEventPROpened}},
+	})
+	setLifecycleClawBaseline(t, s)
+	setSlackWatermark(t, s, 0)
+
+	// The claw connects while "slack" is the only route. Its agent_started is
+	// rejected by the route's allow-list, so it is parked as a v2 row keyed by
+	// "slack" — nothing lands in the legacy delivery table for it.
+	insertSlackTestClaw(t, db, "claw-adhoc", "connected", 1, "", oldEnough)
+	s.lifecycleNotifierTick()
+	sent := fake.count()
+	if _, ok := routeDeliveryStatus(t, db, lifecycleClawStartedKey("claw-adhoc"), "slack"); !ok {
+		t.Fatal("a kind the route's allow-list rejects must be parked for that route")
+	}
+
+	// The operator swaps the channel: still exactly one route, new name.
+	addSlackTestNotifier(s, "ops", testNotifierToken, "C0OPS")
+	setLifecycleRoutes(s, types.LifecycleRoute{Via: "ops"})
+	s.lifecycleNotifierTick()
+	s.lifecycleNotifierTick()
+	if fake.count() != sent {
+		t.Fatalf("swapping a restricted single route replayed the claw backlog: %d messages, want %d", fake.count(), sent)
+	}
+	if status, ok := routeDeliveryStatus(t, db, lifecycleClawStartedKey("claw-adhoc"), "ops"); !ok || status != notificationDeliveryStatusSkipped {
+		t.Fatalf("claw baseline for the swapped-in route = %q (%v), want a skipped fence", status, ok)
+	}
+}
+
+// Regression: at the legacy `via` → routes migration EVERY route inherited the
+// incumbent's shared cursor, so the channel the operator was adding — the whole
+// reason the migration runs — replayed the incumbent's stalled backlog. Only
+// the incumbent may inherit it; the newcomer starts at the stream head.
+func TestLifecycleLegacyViaMigrationStartsTheNewRouteAtHead(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	s, db := newSlackNotifierTestServer(t, fake.server.URL, nil)
+	setLifecycleClawBaseline(t, s)
+	setSlackWatermark(t, s, 0)
+	s.lifecycleNotifierTick() // records the incumbent; nothing pending yet
+
+	// The incumbent's channel goes down, so its cursor stays frozen while the
+	// event stream grows.
+	var down atomic.Bool
+	down.Store(true)
+	fake.setRespond(func(_ int, w http.ResponseWriter) {
+		if down.Load() {
+			http.Error(w, "temporary", http.StatusInternalServerError)
+			return
+		}
+		slackOK(w)
+	})
+	insertLifecycleRouteEvent(t, db, "stalled-0", taskRunEventAgentStarted)
+	for i, id := range []string{"stalled-1", "stalled-2"} {
+		insertSlackTestEvent(t, db, id, "route-run", taskRunEventAgentStarted, 1760000000030+int64(i), "", "", "")
+	}
+	s.lifecycleNotifierTick()
+	if wm, _ := slackWatermark(t, s); wm != 0 {
+		t.Fatalf("the incumbent's cursor advanced past the failed sends: %d, want 0", wm)
+	}
+
+	// The operator adds a second channel through the settings screen: the PATCH
+	// writes routes and clears the legacy via.
+	down.Store(false)
+	addSlackTestNotifier(s, "oncall", testNotifierToken, "C0ONCALL")
+	s.mu.Lock()
+	s.hubCfg.Notifications.Lifecycle.Via = ""
+	s.mu.Unlock()
+	setLifecycleRoutes(s, types.LifecycleRoute{Via: testNotifierName}, types.LifecycleRoute{Via: "oncall"})
+	s.lifecycleNotifierTick()
+	s.lifecycleNotifierTick()
+
+	for _, id := range []string{"stalled-0", "stalled-1", "stalled-2"} {
+		if status, ok := routeDeliveryStatus(t, db, id, "oncall"); ok && status == notificationDeliveryStatusSent {
+			t.Fatalf("the newly added channel replayed the incumbent's stalled backlog (%s)", id)
+		}
+		if status, ok := routeDeliveryStatus(t, db, id, testNotifierName); !ok || status != notificationDeliveryStatusSent {
+			t.Fatalf("the incumbent lost its pending backlog at the migration: %s = %q (%v)", id, status, ok)
+		}
+	}
+}

--- a/pkg/hub/lifecycle_notifier_test.go
+++ b/pkg/hub/lifecycle_notifier_test.go
@@ -52,6 +52,24 @@ func newSlackNotifierTestServer(t *testing.T, slackURL string, mutate func(*type
 	return s, db
 }
 
+// newSlackNotifierRoutesTestServer configures named Slack destinations against
+// one capture server; distinct channels make route assertions unambiguous.
+func newSlackNotifierRoutesTestServer(t *testing.T, slackURL string, routes []types.LifecycleRoute) (*Server, *sql.DB) {
+	t.Helper()
+	cfg := &types.HubConfig{
+		Token: "test-token", Secrets: map[string]string{testNotifierToken: "xoxb-test-token"},
+		Notifications: &types.NotificationsConfig{Notifiers: map[string]types.NotifierConfig{}, Lifecycle: &types.LifecycleNotificationsConfig{Routes: routes}},
+	}
+	for i, route := range routes {
+		cfg.Notifications.Notifiers[route.Via] = types.NotifierConfig{Type: "slack", Settings: map[string]any{
+			"token_secret": testNotifierToken, "channel": fmt.Sprintf("C0ROUTE%04d", i+1),
+		}}
+	}
+	s, db := NewTestServerWithConfig(t, cfg, "", "", "")
+	s.notifierSettingOverrides = map[string]any{"api_base": slackURL, "min_send_interval": time.Nanosecond.String()}
+	return s, db
+}
+
 // testLifecycleDelivery builds the delivery bundle exactly as
 // lifecycleNotifierTick does, so tests that drive a single pass or a single
 // send exercise the real notifier instance (and therefore the real pacing)
@@ -120,6 +138,116 @@ func slackDeliveryStatus(t *testing.T, db *sql.DB, eventID string) (string, bool
 		t.Fatalf("query delivery %s: %v", eventID, err)
 	}
 	return status, true
+}
+
+func routeDeliveryStatus(t *testing.T, db *sql.DB, eventID, notifier string) (string, bool) {
+	t.Helper()
+	var status string
+	err := db.QueryRow(`SELECT status FROM slack_notification_deliveries_v2 WHERE event_id=? AND notifier=?`, eventID, notifier).Scan(&status)
+	if err == sql.ErrNoRows {
+		return "", false
+	}
+	if err != nil {
+		t.Fatalf("query route delivery %s via %s: %v", eventID, notifier, err)
+	}
+	return status, true
+}
+
+func insertLifecycleRouteEvent(t *testing.T, db *sql.DB, id, eventType string) {
+	t.Helper()
+	base := int64(1760000000000)
+	insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{RunID: "route-run", AttemptID: "attempt-route-run", ClawID: "route-claw", TenantID: "test-tenant-id", OwnerType: taskRunOwnerFactory, Factory: "bugfix", StartedAt: base - 1000})
+	insertSlackTestEvent(t, db, id, "route-run", eventType, base+10, "", "", "")
+}
+
+func TestLifecycleRoutesFanoutAndFiltering(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	routes := []types.LifecycleRoute{{Via: "all"}, {Via: "started", Events: []string{taskRunEventAgentStarted}}}
+	s, db := newSlackNotifierRoutesTestServer(t, fake.server.URL, routes)
+	insertLifecycleRouteEvent(t, db, "route-started", taskRunEventAgentStarted)
+	setSlackWatermark(t, s, 0)
+	s.lifecycleNotifierTick()
+	if fake.count() != 2 {
+		t.Fatalf("fan-out sent %d messages, want 2", fake.count())
+	}
+	if fake.request(0).Channel == fake.request(1).Channel {
+		t.Fatalf("fan-out used one channel %q twice", fake.request(0).Channel)
+	}
+	if _, ok := routeDeliveryStatus(t, db, "route-started", "all"); !ok {
+		t.Fatal("empty allow-list route did not receive event")
+	}
+	if _, ok := routeDeliveryStatus(t, db, "route-started", "started"); !ok {
+		t.Fatal("matching allow-list route did not receive event")
+	}
+
+	insertSlackTestEvent(t, db, "route-pr", "route-run", taskRunEventPROpened, 1760000000020, "", "", "")
+	s.lifecycleNotifierTick()
+	if fake.count() != 3 {
+		t.Fatalf("filtered event sent %d messages, want 3", fake.count())
+	}
+	if _, ok := routeDeliveryStatus(t, db, "route-pr", "all"); !ok {
+		t.Fatal("empty allow-list route did not receive all event types")
+	}
+	if _, ok := routeDeliveryStatus(t, db, "route-pr", "started"); ok {
+		t.Fatal("non-matching allow-list route received pr_opened")
+	}
+}
+
+func TestLifecycleRoutesLegacyDeliveryAndUpgradeFence(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	s, db := newSlackNotifierTestServer(t, fake.server.URL, nil)
+	insertLifecycleRouteEvent(t, db, "legacy-event", taskRunEventAgentStarted)
+	setSlackWatermark(t, s, 0)
+	s.lifecycleNotifierTick()
+	if fake.count() != 1 {
+		t.Fatalf("legacy via sent %d messages, want 1", fake.count())
+	}
+
+	// A pre-v2 delivery is a global fence, including for routes added later.
+	if _, err := db.Exec(`INSERT INTO slack_notification_deliveries(event_id, run_id, delivered_at, message_ts, status) VALUES(?,?,?,?,?)`, "upgraded-event", "route-run", 1, "", notificationDeliveryStatusSent); err != nil {
+		t.Fatalf("seed legacy delivery: %v", err)
+	}
+	insertSlackTestEvent(t, db, "upgraded-event", "route-run", taskRunEventPROpened, 1760000000030, "", "", "")
+	s.mu.Lock()
+	s.hubCfg.Notifications.Lifecycle.Via = ""
+	s.hubCfg.Notifications.Lifecycle.Routes = []types.LifecycleRoute{{Via: testNotifierName}, {Via: "new-route"}}
+	s.hubCfg.Notifications.Notifiers["new-route"] = types.NotifierConfig{Type: "slack", Settings: map[string]any{"token_secret": testNotifierToken, "channel": "C0NEWROUTE"}}
+	s.mu.Unlock()
+	s.lifecycleNotifierTick()
+	if fake.count() != 1 {
+		t.Fatalf("legacy delivery was resent after upgrade: %d sends", fake.count())
+	}
+}
+
+func TestLifecycleRoutesErrorDoesNotBlockOtherRouteAndRetriesPerRoute(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	fake.setRespond(func(n int, w http.ResponseWriter) {
+		if n == 1 {
+			http.Error(w, "temporary", http.StatusInternalServerError)
+			return
+		}
+		fmt.Fprint(w, `{"ok":true,"ts":"1.000001"}`)
+	})
+	s, db := newSlackNotifierRoutesTestServer(t, fake.server.URL, []types.LifecycleRoute{{Via: "broken"}, {Via: "healthy"}})
+	insertLifecycleRouteEvent(t, db, "route-error", taskRunEventAgentStarted)
+	setSlackWatermark(t, s, 0)
+	s.lifecycleNotifierTick()
+	if fake.count() != 2 {
+		t.Fatalf("erroring route blocked fan-out: got %d sends, want 2", fake.count())
+	}
+	if status, ok := routeDeliveryStatus(t, db, "route-error", "healthy"); !ok || status != notificationDeliveryStatusSent {
+		t.Fatalf("healthy route = %q, %v; want sent", status, ok)
+	}
+	s.handleLifecycleSendError(fmt.Errorf("temporary"), "event", "retry-event", "run", "broken", false)
+	s.handleLifecycleSendError(fmt.Errorf("temporary"), "event", "retry-event", "run", "broken", false)
+	s.handleLifecycleSendError(fmt.Errorf("temporary"), "event", "retry-event", "run", "healthy", false)
+	var count int64
+	if err := db.QueryRow(`SELECT CAST(value AS INTEGER) FROM slack_notifier_state WHERE key=?`, lifecycleTransientFailureStateKey("retry-event", "broken")).Scan(&count); err != nil || count != 2 {
+		t.Fatalf("broken retry count = %d, err %v; want 2", count, err)
+	}
+	if err := db.QueryRow(`SELECT CAST(value AS INTEGER) FROM slack_notifier_state WHERE key=?`, lifecycleTransientFailureStateKey("retry-event", "healthy")).Scan(&count); err != nil || count != 1 {
+		t.Fatalf("healthy retry count = %d, err %v; want independent 1", count, err)
+	}
 }
 
 func TestSlackNotifierDedupesOnCursorRescan(t *testing.T) {

--- a/pkg/hub/lifecycle_notifier_test.go
+++ b/pkg/hub/lifecycle_notifier_test.go
@@ -2735,3 +2735,75 @@ func TestLifecycleBootBaselineMaterialisesAddedRouteCursors(t *testing.T) {
 		}
 	}
 }
+
+// Regression: pruneLifecycleRouteState dropped a removed route's cursor and
+// claw baseline but not its transient-failure streaks, so a route re-added
+// under the same name inherited a retry budget already spent for every delivery
+// key that recurs — burning the notification on the first transient blip.
+func TestLifecycleRemovedRouteTransientStreakIsDropped(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	s, db := newSlackNotifierRoutesTestServer(t, fake.server.URL, []types.LifecycleRoute{{Via: "primary"}, {Via: "secondary"}})
+	setLifecycleClawBaseline(t, s)
+	setSlackWatermark(t, s, 0)
+	insertLifecycleRouteEvent(t, db, "before-removal", taskRunEventAgentStarted)
+	s.lifecycleNotifierTick()
+
+	// "secondary" is mid-streak on a claw PR key when the operator un-routes it.
+	// That key recurs — a reopened PR re-uses claw:<id>:pr:<url> — so a surviving
+	// counter is a retry budget the re-added channel never spent.
+	prKey := lifecycleClawPRKey("claw-x", "https://github.com/acme/api/pull/7")
+	stale := lifecycleTransientFailureStateKey(prKey, "secondary")
+	s.setNotifierStateInt64(stale, lifecycleMaxTransientFailures-1)
+	kept := lifecycleTransientFailureStateKey(prKey, "primary")
+	s.setNotifierStateInt64(kept, 3)
+
+	s.mu.Lock()
+	s.hubCfg.Notifications.Lifecycle.Routes = []types.LifecycleRoute{{Via: "primary"}}
+	s.mu.Unlock()
+	s.lifecycleNotifierTick()
+
+	if _, found, err := s.notifierStateInt64(stale); err != nil || found {
+		t.Fatalf("the removed route's transient-failure streak survived (found=%v, err=%v)", found, err)
+	}
+	if _, found, err := s.notifierStateInt64(kept); err != nil || !found {
+		t.Fatalf("a configured route's streak was dropped (found=%v, err=%v)", found, err)
+	}
+}
+
+// Regression: a lone route whose notifier could never be built left no per-route
+// state at all, so nothing recorded that it had been the incumbent. Replacing it
+// with a working channel found nothing to prune, left the routes_live latch
+// clear, and handed the newcomer the incumbent's frozen shared cursor — plus a
+// claw baseline stamped without seeding — replaying the whole outage into a
+// brand-new channel.
+func TestLifecycleUnbuildableLoneRouteReplacementStartsAtHead(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	s, db := newSlackNotifierRoutesTestServer(t, fake.server.URL, []types.LifecycleRoute{{Via: "broken"}})
+	// An upgraded hub: shared cursor and shared claw baseline, nothing per-route.
+	s.setNotifierStateInt64(lifecycleStateClawBaselineKey, 1)
+	setSlackWatermark(t, s, 0)
+	s.mu.Lock()
+	s.hubCfg.Notifications.Notifiers["broken"] = types.NotifierConfig{Type: "slack", Settings: map[string]any{
+		"token_secret": "secret-that-does-not-exist", "channel": "C0BROKEN",
+	}}
+	s.hubCfg.Notifications.Notifiers["healthy"] = types.NotifierConfig{Type: "slack", Settings: map[string]any{
+		"token_secret": testNotifierToken, "channel": "C0HEALTHY",
+	}}
+	s.mu.Unlock()
+
+	insertLifecycleRouteEvent(t, db, "during-outage", taskRunEventAgentStarted)
+	insertSlackTestClaw(t, db, "claw-during-outage", "connected", 1, "", oldEnough)
+	s.lifecycleNotifierTick()
+	if fake.count() != 0 {
+		t.Fatalf("an unbuildable route delivered %d messages, want 0", fake.count())
+	}
+
+	s.mu.Lock()
+	s.hubCfg.Notifications.Lifecycle.Routes = []types.LifecycleRoute{{Via: "healthy"}}
+	s.mu.Unlock()
+	s.lifecycleNotifierTick()
+	s.lifecycleNotifierTick()
+	if fake.count() != 0 {
+		t.Fatalf("the replacement route replayed the outage: %d messages, want 0", fake.count())
+	}
+}

--- a/pkg/hub/lifecycle_notifier_test.go
+++ b/pkg/hub/lifecycle_notifier_test.go
@@ -2443,8 +2443,12 @@ func TestLifecycleBootBaselineHonoursTheRoutesLiveLatch(t *testing.T) {
 	insertSlackTestClaw(t, db, "claw-multi-route-era", "connected", 1, "", oldEnough)
 
 	s.initLifecycleNotifierBaseline()
-	if s.lifecycleSingleViaIncumbent("alerts-c") {
-		t.Fatal("a brand-new route was stamped as the legacy single-via incumbent at boot")
+	// Boot now materialises the route's own cursor as well, so the incumbent
+	// stamp alone no longer tells the two apart: what matters is that the route
+	// was not handed the legacy shared position (0) but the stream head.
+	wm, found, err := s.notifierStateInt64(lifecycleRouteWatermarkKey("alerts-c"))
+	if err != nil || !found || wm == 0 {
+		t.Fatalf("a brand-new route inherited the legacy incumbent's shared cursor at boot: %d, %v, %v", wm, found, err)
 	}
 
 	s.lifecycleNotifierTick()
@@ -2546,6 +2550,89 @@ func TestLifecycleRestrictedIncumbentKeepsItsBacklogWhenARouteIsAdded(t *testing
 		}
 		if status, ok := routeDeliveryStatus(t, db, id, "ops"); ok && status == notificationDeliveryStatusSent {
 			t.Fatalf("the newly added channel replayed the incumbent's backlog (%s)", id)
+		}
+	}
+}
+
+// Regression: at the via→routes migration tick a transient state-read failure
+// makes ensureLifecycleRouteWatermarks bail before it writes any per-route
+// cursor. lifecycleTaskRunPass then read the incumbent's absent per-route key,
+// mistook it for a first run and stamped it at the stream head, so everything
+// the incumbent had not yet delivered was skipped for good: ensure sees the
+// cursor as found on every later tick and never runs the inherit-the-shared-
+// cursor branch.
+func TestLifecycleMigrationStateFaultKeepsIncumbentBacklog(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	s, db := newSlackNotifierRoutesTestServer(t, fake.server.URL, []types.LifecycleRoute{{Via: "slack"}})
+	setLifecycleClawBaseline(t, s)
+	setSlackWatermark(t, s, 0)
+	// The legacy single-`via` era: the tick stamps the incumbent's claw baseline
+	// and the route keeps reading the shared cursor.
+	s.lifecycleNotifierTick()
+	if !s.lifecycleSingleViaIncumbent("slack") {
+		t.Fatal("the legacy single-via route was never recorded as the incumbent")
+	}
+
+	// Its token secret breaks, so events pile up with no delivery row of any
+	// kind and the shared cursor freezes.
+	addSlackTestNotifier(s, "slack", "secret-that-does-not-exist", slackTestChannel)
+	insertLifecycleRouteEvent(t, db, "pending-0", taskRunEventAgentStarted)
+	s.lifecycleNotifierTick()
+	if wm, _ := slackWatermark(t, s); wm != 0 {
+		t.Fatalf("the incumbent's cursor advanced past an undelivered event: %d, want 0", wm)
+	}
+
+	// The operator repairs the secret and adds a second channel in the same
+	// save, but the migration tick hits an unreadable shared floor.
+	addSlackTestNotifier(s, "slack", testNotifierToken, slackTestChannel)
+	addSlackTestNotifier(s, "ops", testNotifierToken, "C0OPS")
+	setLifecycleRoutes(s, types.LifecycleRoute{Via: "slack"}, types.LifecycleRoute{Via: "ops"})
+	if _, err := db.Exec(`UPDATE slack_notifier_state SET value='boom' WHERE key=?`, lifecycleStateWatermarkKey); err != nil {
+		t.Fatalf("inject state read fault: %v", err)
+	}
+	s.lifecycleNotifierTick()
+	for _, via := range []string{"slack", "ops"} {
+		if _, found, err := s.notifierStateInt64(lifecycleRouteWatermarkKey(via)); err != nil || found {
+			t.Fatalf("route %q was given a cursor while the shared floor was unreadable: %v, %v", via, found, err)
+		}
+	}
+
+	// The contention clears; the next tick migrates properly.
+	setSlackWatermark(t, s, 0)
+	s.lifecycleNotifierTick()
+	s.lifecycleNotifierTick()
+	if status, ok := routeDeliveryStatus(t, db, "pending-0", "slack"); !ok || status != notificationDeliveryStatusSent {
+		t.Fatalf("the incumbent lost its pending backlog across the faulted migration tick: %q (%v)", status, ok)
+	}
+	if status, ok := routeDeliveryStatus(t, db, "pending-0", "ops"); ok && status == notificationDeliveryStatusSent {
+		t.Fatal("the newly added channel replayed the incumbent's backlog")
+	}
+}
+
+// Regression: a route added while the hub was down (a `via` migrated to routes
+// in hub.yaml) was baselined by the first poll tick instead of synchronously at
+// boot, so an event produced in the startup-to-first-tick window landed BELOW
+// the cursor the tick then stamped at the head — exactly the window
+// initLifecycleNotifierBaseline exists to close for the shared cursor.
+func TestLifecycleBootBaselineMaterialisesAddedRouteCursors(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	s, db := newSlackNotifierRoutesTestServer(t, fake.server.URL,
+		[]types.LifecycleRoute{{Via: "slack"}, {Via: "ops"}})
+	// State from the single-`via` era: the incumbent's shared cursor and its
+	// claw stamp, with "ops" added to the config while the hub was down.
+	s.setNotifierStateInt64(lifecycleStateClawBaselineKey, 1)
+	s.setNotifierStateInt64(lifecycleClawRouteBaselineKey("slack"), 1)
+	setSlackWatermark(t, s, 0)
+
+	s.initLifecycleNotifierBaseline()
+
+	// An event produced by a producer that started right after the baseline,
+	// before the first poll tick.
+	insertLifecycleRouteEvent(t, db, "startup-window", taskRunEventAgentStarted)
+	s.lifecycleNotifierTick()
+	for _, via := range []string{"slack", "ops"} {
+		if status, ok := routeDeliveryStatus(t, db, "startup-window", via); !ok || status != notificationDeliveryStatusSent {
+			t.Fatalf("route %q missed the event produced in the startup window: %q (%v)", via, status, ok)
 		}
 	}
 }

--- a/pkg/hub/lifecycle_notifier_test.go
+++ b/pkg/hub/lifecycle_notifier_test.go
@@ -251,6 +251,47 @@ func TestLifecycleRoutesErrorDoesNotBlockOtherRouteAndRetriesPerRoute(t *testing
 	}
 }
 
+// Regression: the streak lives under a per-notifier key while more than one
+// route is configured and under the legacy key while exactly one is, so adding
+// or removing a sibling route re-keyed it and handed a nearly-exhausted route
+// a fresh retry budget — the cap exists so a poisoned event cannot wedge the
+// cursor forever.
+func TestLifecycleTransientStreakSurvivesRouteShapeChange(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	s, db := newSlackNotifierRoutesTestServer(t, fake.server.URL, []types.LifecycleRoute{{Via: "broken"}, {Via: "healthy"}})
+	streak := func(key string) int64 {
+		t.Helper()
+		var count int64
+		if err := db.QueryRow(`SELECT CAST(value AS INTEGER) FROM slack_notifier_state WHERE key=?`, key).Scan(&count); err != nil {
+			return 0
+		}
+		return count
+	}
+
+	// Two failures under the multi-route (per-notifier) key.
+	s.handleLifecycleSendError(fmt.Errorf("temporary"), "event", "ev", "run", "broken", false)
+	s.handleLifecycleSendError(fmt.Errorf("temporary"), "event", "ev", "run", "broken", false)
+
+	// The sibling route is removed: the same route now counts under the legacy
+	// key, and must continue the streak rather than restart it.
+	s.handleLifecycleSendError(fmt.Errorf("temporary"), "event", "ev", "run", "broken", true)
+	if got := streak(lifecycleTransientFailureStateKey("ev")); got != 3 {
+		t.Fatalf("streak after single-route transition = %d, want 3", got)
+	}
+	if got := streak(lifecycleTransientFailureStateKey("ev", "broken")); got != 0 {
+		t.Fatalf("per-notifier key still holds %d, want it moved", got)
+	}
+
+	// And back again.
+	s.handleLifecycleSendError(fmt.Errorf("temporary"), "event", "ev", "run", "broken", false)
+	if got := streak(lifecycleTransientFailureStateKey("ev", "broken")); got != 4 {
+		t.Fatalf("streak after multi-route transition = %d, want 4", got)
+	}
+	if got := streak(lifecycleTransientFailureStateKey("ev")); got != 0 {
+		t.Fatalf("legacy key still holds %d, want it moved", got)
+	}
+}
+
 // respondByChannel scripts the fake Slack server per destination channel,
 // which is how route-level failures are simulated (each route posts to its own
 // channel; see newSlackNotifierRoutesTestServer).
@@ -1504,6 +1545,27 @@ func TestSlackTestEndpointDryRunReturnsPayloadWithoutCallingSlack(t *testing.T) 
 	}
 	if !strings.Contains(resp.Payload.Attachments[0].Fallback, "SAMPLE-123") {
 		t.Fatalf("synthetic sample should be clearly marked, got %q", resp.Payload.Attachments[0].Fallback)
+	}
+	if fake.count() != 0 {
+		t.Fatalf("dry_run hit Slack %d times", fake.count())
+	}
+}
+
+// Regression: the endpoint's allow-list was narrowed to the route vocabulary
+// (types.LifecycleEventTypes), which does not name the concrete failure kinds.
+// The renderer still gives each of them its own card, so an admin lost the
+// only way to preview what a provision_failed or timeout alert looks like.
+func TestSlackTestEndpointRendersConcreteFailureKinds(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	s, _ := newSlackNotifierTestServer(t, fake.server.URL, nil)
+
+	for eventType := range lifecycleFailureEventTypes {
+		t.Run(eventType, func(t *testing.T) {
+			rr := postSlackTest(t, s, `{"event_type":"`+eventType+`","dry_run":true}`)
+			if rr.Code != http.StatusOK {
+				t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+			}
+		})
 	}
 	if fake.count() != 0 {
 		t.Fatalf("dry_run hit Slack %d times", fake.count())

--- a/pkg/hub/lifecycle_notifier_test.go
+++ b/pkg/hub/lifecycle_notifier_test.go
@@ -2557,6 +2557,43 @@ func TestLifecycleCollapseToOneUnbuildableRouteFencesAtConfigTime(t *testing.T) 
 	}
 }
 
+// Regression: on the FIRST-EVER enable of a multi-route config whose routes are
+// all unbuildable, the tick returns at `len(routes) == 0` before the claw pass
+// runs, so the shared claw baseline was written on the first BUILDABLE tick
+// instead — burying every ad-hoc claw event produced during the outage as
+// "skipped", while the task-run cursors stamped at enable time delivered that
+// same window.
+func TestLifecycleFirstEnableWithNoBuildableRouteFencesClawsAtConfigTime(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	s, db := newSlackNotifierRoutesTestServer(t, fake.server.URL, []types.LifecycleRoute{{Via: "alerts-a"}, {Via: "alerts-b"}})
+	// Enabled for the first time with the token secret not created yet: no
+	// cursor, no claw baseline, and not one route that can be built.
+	addSlackTestNotifier(s, "alerts-a", "secret-that-does-not-exist", "C0AAA")
+	addSlackTestNotifier(s, "alerts-b", "secret-that-does-not-exist", "C0BBB")
+	s.lifecycleNotifierTick()
+
+	// Produced during the outage, so owed to both routes.
+	insertLifecycleRouteEvent(t, db, "during-outage", taskRunEventAgentStarted)
+	insertSlackTestClaw(t, db, "claw-during-outage", "connected", 1, "", oldEnough)
+	s.lifecycleNotifierTick()
+	if fake.count() != 0 {
+		t.Fatalf("an unbuildable route sent %d messages", fake.count())
+	}
+
+	addSlackTestNotifier(s, "alerts-a", testNotifierToken, "C0AAA")
+	addSlackTestNotifier(s, "alerts-b", testNotifierToken, "C0BBB")
+	s.lifecycleNotifierTick()
+	s.lifecycleNotifierTick()
+	for _, via := range []string{"alerts-a", "alerts-b"} {
+		if status, ok := routeDeliveryStatus(t, db, "during-outage", via); !ok || status != notificationDeliveryStatusSent {
+			t.Fatalf("the task-run event produced during the outage was never delivered to %s: %q (%v)", via, status, ok)
+		}
+		if status, ok := routeDeliveryStatus(t, db, lifecycleClawStartedKey("claw-during-outage"), via); !ok || status != notificationDeliveryStatusSent {
+			t.Fatalf("the claw that connected during the outage was buried for %s: %q (%v)", via, status, ok)
+		}
+	}
+}
+
 // Regression: a lone route with a restricted allow-list latches routes_live
 // (parking a rejected kind writes per-route rows) while still reading the
 // SHARED cursor. ensureLifecycleRouteWatermarks gated the "inherit the shared

--- a/pkg/hub/lifecycle_notifier_test.go
+++ b/pkg/hub/lifecycle_notifier_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -88,7 +89,7 @@ func testLifecycleDelivery(t *testing.T, s *Server) lifecycleDelivery {
 	if err != nil {
 		t.Fatalf("build notifier: %v", err)
 	}
-	return lifecycleDelivery{notifier: notifier, lc: cfg.Lifecycle}
+	return lifecycleDelivery{notifier: notifier, lc: cfg.Lifecycle, paused: map[string]bool{}}
 }
 
 func insertSlackTestEvent(t *testing.T, db *sql.DB, id, runID, eventType string, observedAt int64, targetURL, failureType, detail string) {
@@ -247,6 +248,240 @@ func TestLifecycleRoutesErrorDoesNotBlockOtherRouteAndRetriesPerRoute(t *testing
 	}
 	if err := db.QueryRow(`SELECT CAST(value AS INTEGER) FROM slack_notifier_state WHERE key=?`, lifecycleTransientFailureStateKey("retry-event", "healthy")).Scan(&count); err != nil || count != 1 {
 		t.Fatalf("healthy retry count = %d, err %v; want independent 1", count, err)
+	}
+}
+
+// respondByChannel scripts the fake Slack server per destination channel,
+// which is how route-level failures are simulated (each route posts to its own
+// channel; see newSlackNotifierRoutesTestServer).
+func respondByChannel(fake *fakeSlackServer, fn func(channel string, w http.ResponseWriter)) {
+	fake.setRespond(func(n int, w http.ResponseWriter) { fn(fake.request(n-1).Channel, w) })
+}
+
+func slackOK(w http.ResponseWriter) { fmt.Fprint(w, `{"ok":true,"ts":"1000.000001"}`) }
+
+// Regression: the claw pass has NO cursor — the delivery-row anti-join alone
+// decides what is new. With more than one route the legacy row stopped being
+// written, so every handled ad-hoc claw event was re-selected on every tick
+// forever and eventually ate the whole batch LIMIT, silently starving newer
+// claws of notifications.
+func TestLifecycleRoutesFanoutFencesClawEvents(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	s, db := newSlackNotifierRoutesTestServer(t, fake.server.URL, []types.LifecycleRoute{{Via: "primary"}, {Via: "secondary"}})
+	setLifecycleClawBaseline(t, s)
+	setSlackWatermark(t, s, 0)
+	insertSlackTestClaw(t, db, "claw-adhoc", "connected", 1, "", oldEnough)
+
+	s.lifecycleNotifierTick()
+	if fake.count() != 2 {
+		t.Fatalf("fan-out sent %d messages, want 2", fake.count())
+	}
+	if _, ok := slackDeliveryStatus(t, db, lifecycleClawStartedKey("claw-adhoc")); !ok {
+		t.Fatal("handled claw event has no fence row; it would be re-selected on every tick forever")
+	}
+	claws, err := s.selectLifecycleClawStateCandidates(lifecycleClawKindStarted)
+	if err != nil || len(claws) != 0 {
+		t.Fatalf("handled claw still selected as a candidate: %d (err %v)", len(claws), err)
+	}
+	s.lifecycleNotifierTick()
+	if fake.count() != 2 {
+		t.Fatalf("handled claw was re-sent: %d messages", fake.count())
+	}
+}
+
+// Regression: an event type no route accepts is still "handled" and must be
+// fenced, or the claw pass re-selects it forever.
+func TestLifecycleRoutesFenceClawEventNoRouteAccepts(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	s, db := newSlackNotifierRoutesTestServer(t, fake.server.URL,
+		[]types.LifecycleRoute{{Via: "prs-only", Events: []string{taskRunEventPROpened}}})
+	setLifecycleClawBaseline(t, s)
+	setSlackWatermark(t, s, 0)
+	insertSlackTestClaw(t, db, "claw-adhoc", "connected", 1, "", oldEnough)
+
+	s.lifecycleNotifierTick()
+	if fake.count() != 0 {
+		t.Fatalf("agent_started reached a pr_opened-only route: %d messages", fake.count())
+	}
+	if _, ok := slackDeliveryStatus(t, db, lifecycleClawStartedKey("claw-adhoc")); !ok {
+		t.Fatal("claw event no route accepts was not fenced; it would be re-selected forever")
+	}
+}
+
+// Regression: Slack classifies is_archived/channel_not_found/not_in_channel as
+// ErrorConfig, and the config branch used to pause the shared cursor for every
+// route. One archived secondary channel therefore muted every healthy channel
+// indefinitely — no transient cap applies to ErrorConfig.
+func TestLifecycleRoutesConfigErrorParksOnlyTheBrokenRoute(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	s, db := newSlackNotifierRoutesTestServer(t, fake.server.URL, []types.LifecycleRoute{{Via: "archived"}, {Via: "healthy"}})
+	respondByChannel(fake, func(channel string, w http.ResponseWriter) {
+		if channel == "C0ROUTE0001" { // the "archived" route
+			fmt.Fprint(w, `{"ok":false,"error":"is_archived"}`)
+			return
+		}
+		slackOK(w)
+	})
+	insertLifecycleRouteEvent(t, db, "cfg-first", taskRunEventAgentStarted)
+	setSlackWatermark(t, s, 0)
+	s.lifecycleNotifierTick()
+
+	insertSlackTestEvent(t, db, "cfg-second", "route-run", taskRunEventAgentStarted, 1760000000030, "", "", "")
+	s.lifecycleNotifierTick()
+
+	if status, ok := routeDeliveryStatus(t, db, "cfg-second", "healthy"); !ok || status != notificationDeliveryStatusSent {
+		t.Fatalf("a broken route blocked the healthy one: cfg-second via healthy = %q, %v", status, ok)
+	}
+	if _, ok := routeDeliveryStatus(t, db, "cfg-first", "archived"); ok {
+		t.Fatal("a config-failed route must not record a delivery — its events stay pending until the config is fixed")
+	}
+}
+
+// Regression: postLifecycleEvent propagated only the FIRST route error, so a
+// permanent failure on an earlier route made the caller treat the event as
+// handled and advance past it — the later route's transient failure was
+// discarded and its copy of the event was lost forever.
+func TestLifecycleRoutesLaterRouteFailureIsNotSwallowed(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	s, db := newSlackNotifierRoutesTestServer(t, fake.server.URL, []types.LifecycleRoute{{Via: "permanent"}, {Via: "flaky"}})
+	var flakyDown atomic.Bool
+	flakyDown.Store(true)
+	respondByChannel(fake, func(channel string, w http.ResponseWriter) {
+		if channel == "C0ROUTE0001" { // the "permanent" route
+			fmt.Fprint(w, `{"ok":false,"error":"msg_too_long"}`)
+			return
+		}
+		if flakyDown.Load() {
+			http.Error(w, "temporary", http.StatusInternalServerError)
+			return
+		}
+		slackOK(w)
+	})
+	insertLifecycleRouteEvent(t, db, "mixed-event", taskRunEventAgentStarted)
+	setSlackWatermark(t, s, 0)
+	s.lifecycleNotifierTick()
+
+	if status, ok := routeDeliveryStatus(t, db, "mixed-event", "permanent"); !ok || status != notificationDeliveryStatusFailed {
+		t.Fatalf("permanent route delivery = %q, %v; want failed", status, ok)
+	}
+	if _, ok := routeDeliveryStatus(t, db, "mixed-event", "flaky"); ok {
+		t.Fatal("a transient failure must not record a delivery row")
+	}
+
+	flakyDown.Store(false)
+	s.lifecycleNotifierTick()
+	if status, ok := routeDeliveryStatus(t, db, "mixed-event", "flaky"); !ok || status != notificationDeliveryStatusSent {
+		t.Fatalf("event lost for the route that failed after a permanent one: %q, %v", status, ok)
+	}
+}
+
+// Regression: a route whose notifier cannot be built (unresolvable secret
+// mid-rotation) used to be skipped while the healthy routes advanced the
+// SHARED watermark, so everything produced during the outage was permanently
+// lost for that route. Pre-routing behaviour paused instead and never lost an
+// event; per-route cursors restore that.
+func TestLifecycleRoutesUnbuildableRouteKeepsItsBacklog(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	s, db := newSlackNotifierRoutesTestServer(t, fake.server.URL, []types.LifecycleRoute{{Via: "healthy"}, {Via: "rotating"}})
+	setNotifierSecret := func(secret string) {
+		s.mu.Lock()
+		s.hubCfg.Notifications.Notifiers["rotating"] = types.NotifierConfig{Type: "slack", Settings: map[string]any{
+			"token_secret": secret, "channel": "C0ROTATING",
+		}}
+		s.mu.Unlock()
+	}
+	setNotifierSecret("secret-being-rotated") // not in hubCfg.Secrets
+
+	insertLifecycleRouteEvent(t, db, "outage-event", taskRunEventAgentStarted)
+	setSlackWatermark(t, s, 0)
+	s.lifecycleNotifierTick()
+	if fake.count() != 1 {
+		t.Fatalf("healthy route sent %d messages during the outage, want 1", fake.count())
+	}
+	if _, ok := routeDeliveryStatus(t, db, "outage-event", "rotating"); ok {
+		t.Fatal("an unbuildable route must not be recorded as delivered")
+	}
+
+	setNotifierSecret(testNotifierToken)
+	s.lifecycleNotifierTick()
+	if status, ok := routeDeliveryStatus(t, db, "outage-event", "rotating"); !ok || status != notificationDeliveryStatusSent {
+		t.Fatalf("event produced during the outage was lost for the recovered route: %q, %v", status, ok)
+	}
+	if fake.count() != 2 {
+		t.Fatalf("sent %d messages, want 2 (one per route)", fake.count())
+	}
+}
+
+// Per-route cursors must not turn into a history replay: a route added to an
+// already-routed config inherits the shared cursor, so that cursor has to keep
+// tracking the slowest route instead of freezing where routing began.
+func TestLifecycleRouteAddedLaterDoesNotReplayHistory(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	s, db := newSlackNotifierRoutesTestServer(t, fake.server.URL, []types.LifecycleRoute{{Via: "primary"}, {Via: "secondary"}})
+	insertLifecycleRouteEvent(t, db, "history-1", taskRunEventAgentStarted)
+	setSlackWatermark(t, s, 0)
+	s.lifecycleNotifierTick()
+	insertSlackTestEvent(t, db, "history-2", "route-run", taskRunEventAgentStarted, 1760000000030, "", "", "")
+	s.lifecycleNotifierTick()
+	if fake.count() != 4 {
+		t.Fatalf("two events over two routes sent %d messages, want 4", fake.count())
+	}
+
+	s.mu.Lock()
+	s.hubCfg.Notifications.Notifiers["late"] = types.NotifierConfig{Type: "slack", Settings: map[string]any{
+		"token_secret": testNotifierToken, "channel": "C0LATEROUTE",
+	}}
+	s.hubCfg.Notifications.Lifecycle.Routes = append(s.hubCfg.Notifications.Lifecycle.Routes, types.LifecycleRoute{Via: "late"})
+	s.mu.Unlock()
+
+	s.lifecycleNotifierTick()
+	if fake.count() != 4 {
+		t.Fatalf("a route added later replayed the backlog: %d messages, want 4", fake.count())
+	}
+}
+
+// Regression: the pending stash only covered the legacy table, so a v2 write
+// that failed after a successful Send was logged and forgotten. The next tick
+// re-selected the event (the claw pass has no cursor) and re-sent it
+// externally — every tick, until the database recovered.
+func TestLifecycleStashCoversRouteDeliveryWrites(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	s, db := newSlackNotifierTestServer(t, fake.server.URL, nil)
+	setLifecycleClawBaseline(t, s)
+	setSlackWatermark(t, s, 0)
+	insertSlackTestClaw(t, db, "claw-adhoc", "connected", 1, "", oldEnough)
+
+	// A locked database rejects writes to BOTH delivery tables.
+	for _, table := range []string{"slack_notification_deliveries", "slack_notification_deliveries_v2"} {
+		if _, err := db.Exec(`CREATE TRIGGER fail_` + table + ` BEFORE INSERT ON ` + table +
+			` BEGIN SELECT RAISE(ABORT, 'simulated write failure'); END`); err != nil {
+			t.Fatalf("create failing trigger on %s: %v", table, err)
+		}
+	}
+
+	s.lifecycleNotifierTick()
+	if fake.count() != 1 {
+		t.Fatalf("first tick sent %d messages, want 1", fake.count())
+	}
+	s.lifecycleNotifierTick()
+	if fake.count() != 1 {
+		t.Fatalf("failed delivery writes caused a duplicate external send: %d messages", fake.count())
+	}
+
+	for _, table := range []string{"slack_notification_deliveries", "slack_notification_deliveries_v2"} {
+		if _, err := db.Exec(`DROP TRIGGER fail_` + table); err != nil {
+			t.Fatalf("drop trigger on %s: %v", table, err)
+		}
+	}
+	s.lifecycleNotifierTick()
+	if fake.count() != 1 {
+		t.Fatalf("stash drain re-sent the message: %d messages", fake.count())
+	}
+	if status, ok := routeDeliveryStatus(t, db, lifecycleClawStartedKey("claw-adhoc"), testNotifierName); !ok || status != notificationDeliveryStatusSent {
+		t.Fatalf("drained route delivery = %q, %v; want sent", status, ok)
+	}
+	if len(s.lifecyclePendingDeliveries) != 0 {
+		t.Fatalf("stash not drained: %d entries left", len(s.lifecyclePendingDeliveries))
 	}
 }
 
@@ -1066,6 +1301,39 @@ func postSlackTest(t *testing.T, s *Server, body string) *httptest.ResponseRecor
 	rr := httptest.NewRecorder()
 	s.Handler().ServeHTTP(rr, req)
 	return rr
+}
+
+// Regression: the endpoint resolved the notifier exclusively from
+// lifecycle.via. A routes-only config (everything the Notifier UI saves) has
+// an empty via, so the UI's own "Send test" button 400'd on every config it
+// produced — while already sending the notifier name in the request body.
+func TestSlackTestEndpointHonoursRequestedRoute(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	s, _ := newSlackNotifierRoutesTestServer(t, fake.server.URL, []types.LifecycleRoute{{Via: "primary"}, {Via: "secondary"}})
+
+	rr := postSlackTest(t, s, `{"event_type":"agent_started"}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("routes-only default send = %d, body %s", rr.Code, rr.Body.String())
+	}
+	if got := fake.request(0).Channel; got != "C0ROUTE0001" {
+		t.Fatalf("default test send went to %q, want the first route's channel", got)
+	}
+
+	rr = postSlackTest(t, s, `{"event_type":"agent_started","via":"secondary"}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("explicit via send = %d, body %s", rr.Code, rr.Body.String())
+	}
+	if got := fake.request(1).Channel; got != "C0ROUTE0002" {
+		t.Fatalf("explicit via send went to %q, want the secondary route's channel", got)
+	}
+
+	rr = postSlackTest(t, s, `{"event_type":"agent_started","via":"nope"}`)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("unknown via = %d, want 400; body %s", rr.Code, rr.Body.String())
+	}
+	if fake.count() != 2 {
+		t.Fatalf("unknown via still sent a message: %d requests", fake.count())
+	}
 }
 
 func TestSlackTestEndpointDryRunReturnsPayloadWithoutCallingSlack(t *testing.T) {

--- a/pkg/hub/lifecycle_notifier_test.go
+++ b/pkg/hub/lifecycle_notifier_test.go
@@ -1808,3 +1808,125 @@ func TestLifecyclePostDoesNotWriteLegacyThreadRows(t *testing.T) {
 		t.Fatalf("lifecycle post recorded %d thread roots (err %v), want 0", n, err)
 	}
 }
+
+// Regression: a config that is multi-route from its very first runtime enable
+// never got a shared watermark floor — advanceLifecycleWatermarkFloor bails
+// while any configured route is unbuildable, and nothing else wrote the key.
+// The broken route therefore first-ran at the CURRENT stream head once its
+// secret was fixed, losing every event produced during the outage: exactly the
+// loss the floor exists to prevent. The older backlog test hid this by
+// pre-seeding the shared key.
+func TestLifecycleRoutesFirstEnableCreatesWatermarkFloor(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	s, db := newSlackNotifierRoutesTestServer(t, fake.server.URL, []types.LifecycleRoute{{Via: "healthy"}, {Via: "rotating"}})
+	setNotifierSecret := func(secret string) {
+		s.mu.Lock()
+		s.hubCfg.Notifications.Notifiers["rotating"] = types.NotifierConfig{Type: "slack", Settings: map[string]any{
+			"token_secret": secret, "channel": "C0ROTATING",
+		}}
+		s.mu.Unlock()
+	}
+	setNotifierSecret("secret-being-rotated") // not in hubCfg.Secrets
+
+	// No cursor of any kind persisted yet: what a runtime enable through the
+	// settings screen looks like on a hub that booted with notifications off.
+	s.lifecycleNotifierTick()
+	if _, found := slackWatermark(t, s); !found {
+		t.Fatal("no shared watermark floor was created, so the unbuildable route will first-run at the stream head")
+	}
+
+	insertLifecycleRouteEvent(t, db, "outage-event", taskRunEventAgentStarted)
+	s.lifecycleNotifierTick()
+	if fake.count() != 1 {
+		t.Fatalf("healthy route sent %d messages during the outage, want 1", fake.count())
+	}
+
+	setNotifierSecret(testNotifierToken)
+	s.lifecycleNotifierTick()
+	if status, ok := routeDeliveryStatus(t, db, "outage-event", "rotating"); !ok || status != notificationDeliveryStatusSent {
+		t.Fatalf("event produced during the outage was lost for the recovered route: %q, %v", status, ok)
+	}
+}
+
+// Regression: migrating a legacy single-`via` config to routes presented the
+// incumbent as a newly added route, so its per-route baseline seeded the
+// current claw state as "skipped" — burying the claw alerts that were still
+// pending because the channel had been unreachable. Nothing ever delivered
+// them, on any route.
+func TestLifecycleClawLegacyViaMigrationKeepsIncumbentBacklog(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	s, db := newSlackNotifierTestServer(t, fake.server.URL, nil)
+	// The legacy shape needs no per-route key, so stamp only the shared
+	// baseline: "enabled, with no history".
+	s.setNotifierStateInt64(lifecycleStateClawBaselineKey, 1)
+	setSlackWatermark(t, s, 0)
+
+	// The channel is down while the claw comes up: its agent_started is owed
+	// but nothing is recorded for it.
+	var down atomic.Bool
+	down.Store(true)
+	fake.setRespond(func(_ int, w http.ResponseWriter) {
+		if down.Load() {
+			http.Error(w, "temporary", http.StatusInternalServerError)
+			return
+		}
+		slackOK(w)
+	})
+	insertSlackTestClaw(t, db, "claw-pending", "connected", 1, "", oldEnough)
+	s.lifecycleNotifierTick()
+	if _, ok := slackDeliveryStatus(t, db, lifecycleClawStartedKey("claw-pending")); ok {
+		t.Fatal("a transient failure must not record a delivery row")
+	}
+
+	// The operator adds a second channel through the settings screen: the
+	// PATCH writes routes and clears the legacy via.
+	down.Store(false)
+	s.mu.Lock()
+	s.hubCfg.Notifications.Notifiers["secondary"] = types.NotifierConfig{Type: "slack", Settings: map[string]any{
+		"token_secret": testNotifierToken, "channel": "C0SECONDARY",
+	}}
+	s.hubCfg.Notifications.Lifecycle.Via = ""
+	s.hubCfg.Notifications.Lifecycle.Routes = []types.LifecycleRoute{{Via: testNotifierName}, {Via: "secondary"}}
+	s.mu.Unlock()
+
+	s.lifecycleNotifierTick() // baselines the genuinely new route
+	s.lifecycleNotifierTick()
+	if status, ok := routeDeliveryStatus(t, db, lifecycleClawStartedKey("claw-pending"), testNotifierName); !ok || status != notificationDeliveryStatusSent {
+		t.Fatalf("the incumbent route's pending claw alert was buried by the migration: %q, %v", status, ok)
+	}
+}
+
+// Regression: a claw-pass kind a route's allow-list rejected was neither
+// scanned nor parked, and the claw pass has no cursor — so adding that event
+// type to the route later replayed every claw still connected and every PR
+// still open since the route's baseline.
+func TestLifecycleClawRouteAllowListAdditionDoesNotReplay(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	s, db := newSlackNotifierRoutesTestServer(t, fake.server.URL, []types.LifecycleRoute{
+		{Via: "primary", Events: []string{taskRunEventAgentStarted}},
+		{Via: "secondary"},
+	})
+	setLifecycleClawBaseline(t, s)
+	setSlackWatermark(t, s, 0)
+	insertSlackTestClaw(t, db, "claw-adhoc", "connected", 1, "", oldEnough)
+	insertSlackTestClawPR(t, db, "pr-1", "claw-adhoc", "acme/api", 7, "https://github.com/acme/api/pull/7")
+
+	s.lifecycleNotifierTick()
+	delivered := fake.count()
+	if delivered == 0 {
+		t.Fatal("first tick delivered nothing")
+	}
+	if _, ok := routeDeliveryStatus(t, db, lifecycleClawPRKey("claw-adhoc", "https://github.com/acme/api/pull/7"), "primary"); !ok {
+		t.Fatal("a kind the route's allow-list rejects must still be parked for that route")
+	}
+
+	// A month later the operator checks "PR opened" for primary.
+	s.mu.Lock()
+	s.hubCfg.Notifications.Lifecycle.Routes[0].Events = []string{taskRunEventAgentStarted, taskRunEventPROpened}
+	s.mu.Unlock()
+
+	s.lifecycleNotifierTick()
+	if fake.count() != delivered {
+		t.Fatalf("widening a route's allow-list replayed history: %d messages, want %d", fake.count(), delivered)
+	}
+}

--- a/pkg/hub/lifecycle_notifier_test.go
+++ b/pkg/hub/lifecycle_notifier_test.go
@@ -2423,3 +2423,129 @@ func TestLifecycleLegacyBootWithRoutesStartsEveryRouteAtHead(t *testing.T) {
 		}
 	}
 }
+
+// Regression: the boot-time migration branch stamped the single configured
+// route as the legacy incumbent whenever no claw_baseline_done key was left,
+// ignoring the routes_live latch pruneLifecycleRouteState deliberately keeps
+// when it drops the stamps of the routes a save replaced. A hub restarted in
+// that window presented a brand-new channel as the incumbent, handed it the
+// frozen shared cursor and replayed the whole multi-route-era backlog into it.
+func TestLifecycleBootBaselineHonoursTheRoutesLiveLatch(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	s, db := newSlackNotifierRoutesTestServer(t, fake.server.URL, []types.LifecycleRoute{{Via: "alerts-c"}})
+	// The hub has been running (shared claw flag) and the per-route scheme has
+	// been live, but the save that collapsed onto "alerts-c" left no per-route
+	// claw stamp behind.
+	s.setNotifierStateInt64(lifecycleStateClawBaselineKey, 1)
+	s.setNotifierStateInt64(lifecycleStateRoutedKey, 1)
+	setSlackWatermark(t, s, 0)
+	insertLifecycleRouteEvent(t, db, "backlog-0", taskRunEventAgentStarted)
+	insertSlackTestClaw(t, db, "claw-multi-route-era", "connected", 1, "", oldEnough)
+
+	s.initLifecycleNotifierBaseline()
+	if s.lifecycleSingleViaIncumbent("alerts-c") {
+		t.Fatal("a brand-new route was stamped as the legacy single-via incumbent at boot")
+	}
+
+	s.lifecycleNotifierTick()
+	s.lifecycleNotifierTick()
+	if fake.count() != 0 {
+		t.Fatalf("the collapsed-to route replayed the backlog after a restart: %d messages, want 0", fake.count())
+	}
+}
+
+// Regression: collapsing onto ONE brand-new route whose notifier could not be
+// built dropped everything produced during the outage — both ensure passes
+// bailed at len(routes) < 2, so the route's cursor and claw fence were
+// materialised at the first SUCCESSFUL build instead of at add time, past the
+// window every tick logs as "held until it can be built".
+func TestLifecycleCollapseToOneUnbuildableRouteFencesAtConfigTime(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	s, db := newSlackNotifierRoutesTestServer(t, fake.server.URL, []types.LifecycleRoute{{Via: "alerts-a"}, {Via: "alerts-b"}})
+	setLifecycleClawBaseline(t, s)
+	setSlackWatermark(t, s, 0)
+	s.lifecycleNotifierTick()
+
+	// One brand-new channel replaces both, with a typo'd secret name: it is
+	// configured, unbuildable, and the hub's ONLY route.
+	addSlackTestNotifier(s, "alerts-c", "secret-that-does-not-exist", "C0NEWC")
+	setLifecycleRoutes(s, types.LifecycleRoute{Via: "alerts-c"})
+	s.lifecycleNotifierTick()
+
+	// Produced during the outage, so owed to alerts-c.
+	insertLifecycleRouteEvent(t, db, "during-outage", taskRunEventAgentStarted)
+	insertSlackTestClaw(t, db, "claw-during-outage", "connected", 1, "", oldEnough)
+	s.lifecycleNotifierTick()
+	if fake.count() != 0 {
+		t.Fatalf("an unbuildable route sent %d messages", fake.count())
+	}
+
+	addSlackTestNotifier(s, "alerts-c", testNotifierToken, "C0NEWC")
+	s.lifecycleNotifierTick()
+	s.lifecycleNotifierTick()
+	if status, ok := routeDeliveryStatus(t, db, "during-outage", "alerts-c"); !ok || status != notificationDeliveryStatusSent {
+		t.Fatalf("the task-run event produced during the outage was never delivered: %q (%v)", status, ok)
+	}
+	if status, ok := routeDeliveryStatus(t, db, lifecycleClawStartedKey("claw-during-outage"), "alerts-c"); !ok || status != notificationDeliveryStatusSent {
+		t.Fatalf("the claw that connected during the outage was buried: %q (%v)", status, ok)
+	}
+}
+
+// Regression: a lone route with a restricted allow-list latches routes_live
+// (parking a rejected kind writes per-route rows) while still reading the
+// SHARED cursor. ensureLifecycleRouteWatermarks gated the "inherit the shared
+// position" branch on that latch, so adding a second channel later stamped the
+// incumbent's brand-new per-route cursor at the stream head and permanently
+// dropped everything it had not yet delivered.
+func TestLifecycleRestrictedIncumbentKeepsItsBacklogWhenARouteIsAdded(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	s, db := newSlackNotifierRoutesTestServer(t, fake.server.URL, []types.LifecycleRoute{
+		{Via: "slack", Events: []string{taskRunEventPROpened}},
+	})
+	setLifecycleClawBaseline(t, s)
+	setSlackWatermark(t, s, 0)
+	// Parking the kinds the allow-list rejects latches routes_live on the very
+	// first tick, without the route ever leaving the shared key.
+	s.lifecycleNotifierTick()
+	if live, err := s.lifecycleRoutingSchemeLive(); err != nil || !live {
+		t.Fatalf("a restricted route must latch the routing scheme: %v, %v", live, err)
+	}
+
+	// The channel goes down, so the shared cursor freezes while pr_opened
+	// events pile up.
+	var down atomic.Bool
+	down.Store(true)
+	fake.setRespond(func(_ int, w http.ResponseWriter) {
+		if down.Load() {
+			http.Error(w, "temporary", http.StatusInternalServerError)
+			return
+		}
+		slackOK(w)
+	})
+	insertLifecycleRouteEvent(t, db, "pending-0", taskRunEventPROpened)
+	for i, id := range []string{"pending-1", "pending-2"} {
+		insertSlackTestEvent(t, db, id, "route-run", taskRunEventPROpened, 1760000000030+int64(i), "", "", "")
+	}
+	s.lifecycleNotifierTick()
+	if wm, _ := slackWatermark(t, s); wm != 0 {
+		t.Fatalf("the incumbent's cursor advanced past the failed sends: %d, want 0", wm)
+	}
+
+	// The operator adds a second channel through the settings screen.
+	down.Store(false)
+	addSlackTestNotifier(s, "ops", testNotifierToken, "C0OPS")
+	setLifecycleRoutes(s,
+		types.LifecycleRoute{Via: "slack", Events: []string{taskRunEventPROpened}},
+		types.LifecycleRoute{Via: "ops"})
+	s.lifecycleNotifierTick()
+	s.lifecycleNotifierTick()
+
+	for _, id := range []string{"pending-0", "pending-1", "pending-2"} {
+		if status, ok := routeDeliveryStatus(t, db, id, "slack"); !ok || status != notificationDeliveryStatusSent {
+			t.Fatalf("the incumbent lost its pending backlog when a route was added: %s = %q (%v)", id, status, ok)
+		}
+		if status, ok := routeDeliveryStatus(t, db, id, "ops"); ok && status == notificationDeliveryStatusSent {
+			t.Fatalf("the newly added channel replayed the incumbent's backlog (%s)", id)
+		}
+	}
+}

--- a/pkg/hub/notify/notify.go
+++ b/pkg/hub/notify/notify.go
@@ -239,6 +239,22 @@ func New(typ string, cfg map[string]any, secrets SecretResolver) (Notifier, erro
 	return p.construct(cfg, secrets)
 }
 
+// ValidateConfig checks a notifier configuration the way New does, but without
+// resolving its secrets, so a writer (the settings PATCH) can reject a config
+// its own type would refuse to build — a missing token_secret, a #name where a
+// channel ID belongs, an unparseable min_send_interval — at write time instead
+// of silently delivering nothing on every later tick. Secret VALUES are
+// deliberately not checked: naming a secret that is created right afterwards is
+// a legitimate order of operations.
+func ValidateConfig(typ string, cfg map[string]any) error {
+	p, ok := registry[typ]
+	if !ok {
+		return fmt.Errorf("unknown notifier type %q (supported: %s)", typ, supportedTypes())
+	}
+	_, err := p.construct(cfg, func(string) (string, bool) { return "unchecked-secret-value", true })
+	return err
+}
+
 // SecretSettings returns the config keys of the given notifier type whose
 // values must reference an existing secret. Returns nil for unknown types.
 func SecretSettings(typ string) []string {

--- a/pkg/hub/notify/slack.go
+++ b/pkg/hub/notify/slack.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
@@ -163,6 +164,35 @@ type slackNotifier struct {
 	minSendInterval time.Duration
 }
 
+// validateSlackAPIBase checks the shape of an api_base override. Every send
+// puts the bot token in an Authorization header addressed to this host, so a
+// value that is not an absolute http(s) URL must never reach the wire: a
+// relative or scheme-less value would make http.NewRequest fail on every send
+// (silent, log-only), and embedded credentials, a query or a fragment can only
+// be an attempt to smuggle something into the request line. WHICH host is
+// allowed is decided by the writer, not here — the settings API restricts what
+// a remote caller may point a token at (see validateNotifierAPIBase), while
+// hub.yaml and tests stay free to name an internal proxy or a fake server.
+func validateSlackAPIBase(apiBase string) error {
+	u, err := url.Parse(apiBase)
+	if err != nil {
+		return fmt.Errorf("slack notifier api_base %q is not a valid URL: %w", apiBase, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("slack notifier api_base %q must be an absolute http(s) URL (e.g. %s)", apiBase, defaultSlackAPIBase)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("slack notifier api_base %q has no host", apiBase)
+	}
+	if u.User != nil {
+		return fmt.Errorf("slack notifier api_base %q must not embed credentials", apiBase)
+	}
+	if u.RawQuery != "" || u.Fragment != "" {
+		return fmt.Errorf("slack notifier api_base %q must not carry a query or fragment", apiBase)
+	}
+	return nil
+}
+
 func newSlack(cfg map[string]any, secrets SecretResolver) (Notifier, error) {
 	secretName := stringOption(cfg, "token_secret")
 	if secretName == "" {
@@ -179,9 +209,12 @@ func newSlack(cfg map[string]any, secrets SecretResolver) (Notifier, error) {
 	if channel != "" && !slackChannelIDRegex.MatchString(channel) {
 		return nil, fmt.Errorf("slack notifier channel %q does not look like a Slack channel ID (expected C/G/D followed by alphanumerics, e.g. C0123ABCD)", channel)
 	}
-	apiBase := stringOption(cfg, "api_base")
+	apiBase := strings.TrimRight(strings.TrimSpace(stringOption(cfg, "api_base")), "/")
 	if apiBase == "" {
 		apiBase = defaultSlackAPIBase
+	}
+	if err := validateSlackAPIBase(apiBase); err != nil {
+		return nil, err
 	}
 	interval := slackMinSendInterval
 	if raw := stringOption(cfg, "min_send_interval"); raw != "" {

--- a/pkg/hub/notify/slack_test.go
+++ b/pkg/hub/notify/slack_test.go
@@ -916,3 +916,28 @@ func TestSlackRenderPayloadMatchesSend(t *testing.T) {
 		t.Fatalf("dry-run payload differs from what Send posted:\n dry run: %s\n sent:    %s", rendered, sent)
 	}
 }
+
+// Every send addresses api_base with the bot token in an Authorization header,
+// so a value that is not a plain absolute http(s) URL is refused at
+// construction — where the settings PATCH reports it — instead of failing
+// silently on every send.
+func TestSlackRejectsMalformedAPIBase(t *testing.T) {
+	for _, apiBase := range []string{
+		"slack.example.com/api",
+		"ftp://slack.com/api",
+		"https://user:pass@slack.com/api",
+		"https://slack.com/api?token=leak",
+		"https:///api",
+	} {
+		cfg := map[string]any{"token_secret": "slack_bot_token", "channel": "C123", "api_base": apiBase}
+		if _, err := New("slack", cfg, testSecrets); err == nil {
+			t.Fatalf("New(slack) with api_base %q = nil error, want a rejection", apiBase)
+		}
+	}
+	// A trailing slash is a formatting difference, not a bad value.
+	if _, err := New("slack", map[string]any{
+		"token_secret": "slack_bot_token", "channel": "C123", "api_base": "https://slack.com/api/",
+	}, testSecrets); err != nil {
+		t.Fatalf("New(slack) with a trailing slash = %v, want it accepted", err)
+	}
+}

--- a/pkg/hub/notify_validate.go
+++ b/pkg/hub/notify_validate.go
@@ -141,6 +141,86 @@ func validateNotifyVias(notifiers map[string]types.NotifierConfig, label, pipeli
 	return fmt.Errorf("%s notify actions: %s (%s)", label, strings.Join(problems, "; "), definedDesc)
 }
 
+// notifierPipelineReferences maps a notifier name to the pipeline stages whose
+// notify actions route through it. It walks the same surface the doctor's
+// checkNotifyActions judges — every workspace workflow's effective pipeline
+// plus every factory's pipeline_yaml — so the two can never disagree about
+// which notifiers a pipeline depends on. Factories are passed in rather than
+// resolved here because callers already hold the server lock.
+func notifierPipelineReferences(factories []*types.FactoryConfig) map[string][]string {
+	out := map[string][]string{}
+	collect := func(kind, name, pipelineYAML string) {
+		for _, ref := range notifyActionRefs(pipelineYAML) {
+			if ref.Via == "" {
+				continue
+			}
+			out[ref.Via] = append(out[ref.Via], fmt.Sprintf("%s %q stage %q", kind, name, ref.StageID))
+		}
+	}
+	if workspaces, err := loadExternalWorkspaces(); err == nil {
+		for _, workspace := range workspaces {
+			if workspace == nil {
+				continue
+			}
+			for _, workflow := range workspace.Workflows {
+				if workflow == nil {
+					continue
+				}
+				pipelineYAML, err := effectiveWorkflowPipelineYAML(workflow)
+				if err != nil {
+					continue
+				}
+				collect("workflow", workflow.Name, pipelineYAML)
+			}
+		}
+	}
+	for _, factory := range factories {
+		if factory == nil {
+			continue
+		}
+		collect("factory", factory.Name, factory.PipelineYAML)
+	}
+	return out
+}
+
+// validateNotifierRemovals rejects a settings patch that drops a notifier a
+// pipeline notify action still routes through. The Notifier screen lists every
+// hub notifier — including ones no lifecycle route uses and only a pipeline
+// stage references — and its Remove button sends the whole notifiers map
+// without the deleted key. Without this the save returns 200, SaveHubConfig
+// writes the notifier out of hub.yaml, and executeNotifyAction then drops
+// every stage notification with nothing but a warning in the claw
+// conversation.
+func validateNotifierRemovals(current, patch *types.NotificationsConfig, factories []*types.FactoryConfig) error {
+	if current == nil || patch == nil {
+		return nil
+	}
+	var removed []string
+	for name := range current.Notifiers {
+		if _, kept := patch.Notifiers[name]; !kept {
+			removed = append(removed, name)
+		}
+	}
+	if len(removed) == 0 {
+		return nil
+	}
+	sort.Strings(removed)
+	references := notifierPipelineReferences(factories)
+	var problems []string
+	for _, name := range removed {
+		used := references[name]
+		if len(used) == 0 {
+			continue
+		}
+		sort.Strings(used)
+		problems = append(problems, fmt.Sprintf("%q is still used by %s", name, strings.Join(used, ", ")))
+	}
+	if len(problems) == 0 {
+		return nil
+	}
+	return fmt.Errorf("notifications.notifiers: cannot remove a notifier a pipeline still notifies through: %s", strings.Join(problems, "; "))
+}
+
 // configuredNotifiers returns the notifier set defined under
 // notifications.notifiers in hub.yaml. It takes the server lock; callers
 // already holding it must read s.hubCfg.Notifications directly instead.

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -192,7 +192,7 @@ type Server struct {
 	// while stashed, count as delivered so the message is never re-sent
 	// externally (see recordNotificationDelivery). Only touched from the
 	// lifecycle tick goroutine — ticks never overlap.
-	lifecyclePendingDeliveries map[string]pendingNotificationDelivery
+	lifecyclePendingDeliveries map[pendingDeliveryKey]pendingNotificationDelivery
 
 	// lifecycleNotifierStop/Done plumb graceful shutdown for the lifecycle
 	// notifier loop: run() stops the loop and waits for the in-flight tick

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1313,6 +1313,7 @@ func settingsStaticSection(section string) bool {
 		"ai-config",
 		"mcp-servers",
 		"analytics",
+		"notifier",
 		"doctor",
 		"troubleshoot":
 		return true

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/elasticclaw/elasticclaw/pkg/cliversion"
 	"github.com/elasticclaw/elasticclaw/pkg/config"
+	"github.com/elasticclaw/elasticclaw/pkg/hub/notify"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
 
@@ -74,11 +75,37 @@ type SettingsView struct {
 	Secrets              []string                    `json:"secrets"`
 	MCPServers           []MCPView                   `json:"mcpServers,omitempty"`
 	Auth                 *AuthView                   `json:"auth,omitempty"`
+	Notifications        *NotificationsView          `json:"notifications"`
+	LifecycleEventTypes  []string                    `json:"lifecycleEventTypes"`
 	// ConcurrencyGroups limits simultaneously running claws per group. 0 = unlimited.
 	ConcurrencyGroups []ConcurrencyGroupView `json:"concurrencyGroups"`
 	// MaxConcurrentClaws limits simultaneously running claws. 0 = unlimited.
 	// DEPRECATED: Use ConcurrencyGroups instead.
 	MaxConcurrentClaws int `json:"maxConcurrentClaws"`
+}
+
+// NotificationsView is the settings-safe view of outbound notifications.
+// It intentionally exposes secret references, never secret values.
+type NotificationsView struct {
+	Notifiers map[string]NotifierView     `json:"notifiers"`
+	Lifecycle *LifecycleNotificationsView `json:"lifecycle,omitempty"`
+}
+
+type NotifierView struct {
+	Type            string `json:"type"`
+	Channel         string `json:"channel,omitempty"`
+	TokenSecret     string `json:"token_secret,omitempty"`
+	APIBase         string `json:"api_base,omitempty"`
+	MinSendInterval string `json:"min_send_interval,omitempty"`
+}
+
+type LifecycleNotificationsView struct {
+	Enabled      bool                         `json:"enabled"`
+	Via          string                       `json:"via,omitempty"`
+	Routes       []types.LifecycleRoute       `json:"routes"`
+	PollInterval string                       `json:"poll_interval,omitempty"`
+	IdleAfter    string                       `json:"idle_after,omitempty"`
+	Events       *types.LifecycleEventToggles `json:"events,omitempty"`
 }
 
 type AuthView struct {
@@ -252,6 +279,8 @@ type SettingsPatch struct {
 	// MaxConcurrentClaws limits simultaneously running claws. 0 or omitted = unlimited.
 	// DEPRECATED: Use ConcurrencyGroups instead.
 	MaxConcurrentClaws *int `json:"maxConcurrentClaws,omitempty"`
+	// Notifications replaces the complete notifications configuration.
+	Notifications *types.NotificationsConfig `json:"notifications,omitempty"`
 }
 
 // MCPPatch is a request to add/update an MCP server config.
@@ -466,6 +495,8 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 	view.ModelAuthProfiles = []ModelAuthProfileView{}
+	view.LifecycleEventTypes = append([]string(nil), types.LifecycleEventTypes...)
+	view.Notifications = buildNotificationsView(s.hubCfg.Notifications)
 	for _, profile := range s.hubCfg.ModelAuthProfiles {
 		if profile == nil {
 			continue
@@ -668,6 +699,57 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 	jsonOK(w, view)
 }
 
+func buildNotificationsView(cfg *types.NotificationsConfig) *NotificationsView {
+	if cfg == nil {
+		return &NotificationsView{Notifiers: map[string]NotifierView{}}
+	}
+	view := &NotificationsView{Notifiers: make(map[string]NotifierView, len(cfg.Notifiers))}
+	for name, notifier := range cfg.Notifiers {
+		view.Notifiers[name] = NotifierView{
+			Type:            notifier.Type,
+			Channel:         notifierSettingString(notifier, "channel"),
+			TokenSecret:     notifierSettingString(notifier, "token_secret"),
+			APIBase:         notifierSettingString(notifier, "api_base"),
+			MinSendInterval: notifierSettingString(notifier, "min_send_interval"),
+		}
+	}
+	if lc := cfg.Lifecycle; lc != nil {
+		lifecycle := &LifecycleNotificationsView{
+			Enabled:      lc.IsEnabled(),
+			Via:          lc.Via,
+			Routes:       make([]types.LifecycleRoute, len(lc.Routes)),
+			PollInterval: lc.PollInterval,
+			IdleAfter:    lc.IdleAfter,
+		}
+		for i, route := range lc.Routes {
+			lifecycle.Routes[i] = types.LifecycleRoute{Via: route.Via, Events: append([]string(nil), route.Events...)}
+		}
+		if lc.Events != nil {
+			events := *lc.Events
+			lifecycle.Events = &events
+		}
+		view.Lifecycle = lifecycle
+	}
+	return view
+}
+
+func notifierSettingString(notifier types.NotifierConfig, key string) string {
+	value, _ := notifier.Settings[key].(string)
+	return value
+}
+
+func validateSettingsNotifications(cfg *types.NotificationsConfig) error {
+	if err := types.ValidateNotificationsConfig(cfg); err != nil {
+		return err
+	}
+	for name, notifier := range cfg.Notifiers {
+		if !notify.Supported(notifier.Type) {
+			return fmt.Errorf("notifications.notifiers.%s: unsupported notifier type %q", name, notifier.Type)
+		}
+	}
+	return nil
+}
+
 // buildGitHubAppView builds a GitHubAppView for the settings page, including
 // a live permission check if the private key is set.
 func (s *Server) buildGitHubAppView(ctx context.Context, app *types.GitHubAppConfig) GitHubAppView {
@@ -764,6 +846,19 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 
 	// Shallow copy of config struct; maps and slices are deep-copied only when modified below
 	updatedCfg := *s.hubCfg
+
+	if patch.Notifications != nil {
+		// A settings patch is the migration point from legacy lifecycle.via
+		// to routes: a supplied route set always wins and is written alone.
+		if patch.Notifications.Lifecycle != nil && patch.Notifications.Lifecycle.Routes != nil {
+			patch.Notifications.Lifecycle.Via = ""
+		}
+		if err := validateSettingsNotifications(patch.Notifications); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		updatedCfg.Notifications = patch.Notifications
+	}
 
 	// LLM keys — upsert/delete by name
 	if len(patch.LLMKeys) > 0 {

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -805,7 +805,7 @@ func validateSettingsNotifications(current, cfg *types.NotificationsConfig) erro
 		// send: a notifier that cannot be built delivers nothing and says so
 		// only in the hub log, so a PATCH that persists one silently mutes
 		// every route pointing at it.
-		if err := notify.ValidateConfig(notifier.Type, notifier.Settings); err != nil {
+		if err := notify.ValidateConfig(notifier.Type, notifierSettingsForValidation(current, name, notifier)); err != nil {
 			return fmt.Errorf("notifications.notifiers.%s: %w", name, err)
 		}
 	}
@@ -841,6 +841,35 @@ func validateNotifierAPIBase(current *types.NotificationsConfig, name string, pa
 		return fmt.Errorf("notifications.notifiers.%s: api_base %q must be an https URL on slack.com — the notifier's bot token is sent to this host, so it cannot be repointed through the settings API", name, apiBase)
 	}
 	return nil
+}
+
+// notifierSettingsForValidation drops an api_base the patch merely carries over
+// from the stored config before the provider's own check runs on the merged
+// settings. validateNotifierAPIBase exempts the stored value deliberately — the
+// settings screen round-trips api_base without rendering it — but the provider
+// check judges it too, and a stored value this build refuses to construct (a
+// scheme-less host written by hand, or accepted by an older build) would then
+// reject every save that touches that channel, on a field the screen can
+// neither show nor clear: the same dead end the min_send_interval field exists
+// to prevent, with no way out but a hub.yaml edit. Dropping the key falls back
+// to the provider default, so only an api_base the patch itself introduces or
+// changes is judged — by validateNotifierAPIBase, which is the stricter check.
+func notifierSettingsForValidation(current *types.NotificationsConfig, name string, patched types.NotifierConfig) map[string]any {
+	apiBase := strings.TrimSpace(notifierSettingString(patched, "api_base"))
+	if apiBase == "" || current == nil {
+		return patched.Settings
+	}
+	existing, ok := current.Notifiers[name]
+	if !ok || strings.TrimSpace(notifierSettingString(existing, "api_base")) != apiBase {
+		return patched.Settings
+	}
+	settings := make(map[string]any, len(patched.Settings))
+	for key, value := range patched.Settings {
+		if key != "api_base" {
+			settings[key] = value
+		}
+	}
+	return settings
 }
 
 // dropRejectedLifecycleDurations clears a lifecycle poll_interval or

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -99,12 +99,18 @@ type NotifierView struct {
 	MinSendInterval string `json:"min_send_interval,omitempty"`
 }
 
+// LifecycleNotificationsView deliberately uses the SAME field names the PATCH
+// body is decoded under (types.LifecycleNotificationsConfig): a client that
+// GETs this view, edits it and PATCHes it back must not silently drop the two
+// durations. They were emitted as poll_interval/idle_after, which
+// encoding/json discards as unknown keys on the way back in — resetting a
+// deliberately raised idle_after to the 5m default and persisting the loss.
 type LifecycleNotificationsView struct {
 	Enabled      bool                         `json:"enabled"`
 	Via          string                       `json:"via,omitempty"`
 	Routes       []types.LifecycleRoute       `json:"routes"`
-	PollInterval string                       `json:"poll_interval,omitempty"`
-	IdleAfter    string                       `json:"idle_after,omitempty"`
+	PollInterval string                       `json:"pollInterval,omitempty"`
+	IdleAfter    string                       `json:"idleAfter,omitempty"`
 	Events       *types.LifecycleEventToggles `json:"events,omitempty"`
 }
 
@@ -882,6 +888,12 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 		}
 		mergeNotifierSettings(s.hubCfg.Notifications, patch.Notifications)
 		if err := validateSettingsNotifications(patch.Notifications); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		// s.hubCfg.Factories is read directly: resolveFactories takes the lock
+		// this handler already holds.
+		if err := validateNotifierRemovals(s.hubCfg.Notifications, patch.Notifications, s.hubCfg.Factories); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -6,9 +6,11 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 
 	"github.com/elasticclaw/elasticclaw/pkg/cliversion"
 	"github.com/elasticclaw/elasticclaw/pkg/config"
@@ -787,6 +789,12 @@ func validateSettingsNotifications(current, cfg *types.NotificationsConfig) erro
 		return err
 	}
 	for name, notifier := range cfg.Notifiers {
+		// Checked before the unchanged short-circuit and against the stored
+		// value key by key, so editing a notifier that already carries an
+		// api_base stays possible while introducing or changing one does not.
+		if err := validateNotifierAPIBase(current, name, notifier); err != nil {
+			return err
+		}
 		if notifierUnchanged(current, name, notifier) {
 			continue
 		}
@@ -802,6 +810,69 @@ func validateSettingsNotifications(current, cfg *types.NotificationsConfig) erro
 		}
 	}
 	return nil
+}
+
+// validateNotifierAPIBase refuses an api_base the patch introduces or changes
+// unless it addresses Slack over https. api_base decides where the notifier's
+// bot token is sent: a patch that keeps token_secret and repoints api_base at
+// an attacker-controlled host turns the next test send into token
+// exfiltration (and every send into an SSRF probe from the hub). The stored
+// value is exempt — an operator who wrote an internal Slack proxy into
+// hub.yaml keeps it, and the settings screen, which round-trips api_base
+// without rendering it, keeps saving — because hub.yaml is the operator's own
+// file while this handler is remote input. Repointing a live notifier is
+// therefore a hub.yaml edit, not an API call.
+func validateNotifierAPIBase(current *types.NotificationsConfig, name string, patched types.NotifierConfig) error {
+	apiBase := strings.TrimSpace(notifierSettingString(patched, "api_base"))
+	if apiBase == "" {
+		return nil
+	}
+	if current != nil {
+		if existing, ok := current.Notifiers[name]; ok && strings.TrimSpace(notifierSettingString(existing, "api_base")) == apiBase {
+			return nil
+		}
+	}
+	u, err := url.Parse(apiBase)
+	if err != nil {
+		return fmt.Errorf("notifications.notifiers.%s: api_base %q is not a valid URL", name, apiBase)
+	}
+	host := strings.ToLower(u.Hostname())
+	if u.Scheme != "https" || (host != "slack.com" && !strings.HasSuffix(host, ".slack.com")) {
+		return fmt.Errorf("notifications.notifiers.%s: api_base %q must be an https URL on slack.com — the notifier's bot token is sent to this host, so it cannot be repointed through the settings API", name, apiBase)
+	}
+	return nil
+}
+
+// dropRejectedLifecycleDurations clears a lifecycle poll_interval or
+// idle_after that the patch re-sends unchanged from the stored config and that
+// validation would reject anyway. Both are validated on every patch, floors
+// included and regardless of `enabled`, while the settings screen rebuilds the
+// whole notifications block from a view that renders neither field: a hub.yaml
+// holding "idle_after: 30s" would otherwise 400 every save made from that
+// screen — the master switch, a category toggle, adding a channel — on a value
+// the screen can neither show nor clear, leaving a hand edit of hub.yaml as the
+// only way out. The offender is dropped rather than preserved because it is
+// already inert: lifecycleNotifierTick refuses to run while the config fails
+// validation, so keeping it would trade an unusable screen for a healthy-
+// looking screen that still delivers nothing. A value the patch itself
+// introduces or edits is left alone and still fails the save.
+func dropRejectedLifecycleDurations(current, patch *types.NotificationsConfig) {
+	if patch == nil || patch.Lifecycle == nil || current == nil || current.Lifecycle == nil {
+		return
+	}
+	stored, lc := current.Lifecycle, patch.Lifecycle
+	if lc.PollInterval == stored.PollInterval && lifecycleDurationRejected(&types.LifecycleNotificationsConfig{PollInterval: lc.PollInterval}) {
+		lc.PollInterval = ""
+	}
+	if lc.IdleAfter == stored.IdleAfter && lifecycleDurationRejected(&types.LifecycleNotificationsConfig{IdleAfter: lc.IdleAfter}) {
+		lc.IdleAfter = ""
+	}
+}
+
+// lifecycleDurationRejected asks the real validator whether a lone duration
+// passes, so the floors live in exactly one place.
+func lifecycleDurationRejected(probe *types.LifecycleNotificationsConfig) bool {
+	return types.ValidateNotificationsConfig(&types.NotificationsConfig{Lifecycle: probe}) != nil
 }
 
 // notifierUnchanged reports whether the patched notifier is byte-identical to
@@ -929,6 +1000,7 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 			patch.Notifications.Lifecycle.Via = ""
 		}
 		mergeNotifierSettings(s.hubCfg.Notifications, patch.Notifications)
+		dropRejectedLifecycleDurations(s.hubCfg.Notifications, patch.Notifications)
 		if err := validateSettingsNotifications(s.hubCfg.Notifications, patch.Notifications); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -738,6 +738,33 @@ func notifierSettingString(notifier types.NotifierConfig, key string) string {
 	return value
 }
 
+// mergeNotifierSettings folds a patched notifier's settings over the ones
+// already in the config. GET /api/settings projects only a handful of settings
+// keys (see buildNotificationsView) and the settings screen rebuilds the whole
+// notifications block from that projection, so replacing the block outright
+// would silently drop every other key under notifications.notifiers.<name> the
+// first time an operator touches the screen.
+func mergeNotifierSettings(current, patch *types.NotificationsConfig) {
+	if current == nil || patch == nil {
+		return
+	}
+	for name, patched := range patch.Notifiers {
+		existing, ok := current.Notifiers[name]
+		if !ok || len(existing.Settings) == 0 {
+			continue
+		}
+		merged := make(map[string]any, len(existing.Settings)+len(patched.Settings))
+		for key, value := range existing.Settings {
+			merged[key] = value
+		}
+		for key, value := range patched.Settings {
+			merged[key] = value
+		}
+		patched.Settings = merged
+		patch.Notifiers[name] = patched
+	}
+}
+
 func validateSettingsNotifications(cfg *types.NotificationsConfig) error {
 	if err := types.ValidateNotificationsConfig(cfg); err != nil {
 		return err
@@ -853,6 +880,7 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 		if patch.Notifications.Lifecycle != nil && patch.Notifications.Lifecycle.Routes != nil {
 			patch.Notifications.Lifecycle.Via = ""
 		}
+		mergeNotifierSettings(s.hubCfg.Notifications, patch.Notifications)
 		if err := validateSettingsNotifications(patch.Notifications); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -870,8 +870,13 @@ func dropRejectedLifecycleDurations(current, patch *types.NotificationsConfig) {
 }
 
 // lifecycleDurationRejected asks the real validator whether a lone duration
-// passes, so the floors live in exactly one place.
+// passes, so the floors live in exactly one place. The probe is disabled
+// explicitly: both durations are validated above the `if !lc.IsEnabled()`
+// short-circuit, while an ENABLED probe carries neither `via` nor routes and
+// would be rejected for that instead — reporting every value, valid ones
+// included, as rejected and silently erasing the stored durations on every save.
 func lifecycleDurationRejected(probe *types.LifecycleNotificationsConfig) bool {
+	probe.Enabled = new(bool)
 	return types.ValidateNotificationsConfig(&types.NotificationsConfig{Lifecycle: probe}) != nil
 }
 

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -883,7 +883,13 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 	if patch.Notifications != nil {
 		// A settings patch is the migration point from legacy lifecycle.via
 		// to routes: a supplied route set always wins and is written alone.
-		if patch.Notifications.Lifecycle != nil && patch.Notifications.Lifecycle.Routes != nil {
+		// Gated on a NON-EMPTY route set, never on a non-nil slice:
+		// LifecycleNotificationsView always emits `routes` (as `[]` for a
+		// via-only config), so a client that GETs the view and PATCHes it back
+		// verbatim — the round trip the view's doc comment invites — would
+		// otherwise decode to an empty-but-present slice and silently destroy
+		// the only channel binding the hub has.
+		if patch.Notifications.Lifecycle != nil && len(patch.Notifications.Lifecycle.Routes) > 0 {
 			patch.Notifications.Lifecycle.Via = ""
 		}
 		mergeNotifierSettings(s.hubCfg.Notifications, patch.Notifications)

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -779,6 +779,13 @@ func validateSettingsNotifications(cfg *types.NotificationsConfig) error {
 		if !notify.Supported(notifier.Type) {
 			return fmt.Errorf("notifications.notifiers.%s: unsupported notifier type %q", name, notifier.Type)
 		}
+		// The type's own required fields, checked here rather than at the first
+		// send: a notifier that cannot be built delivers nothing and says so
+		// only in the hub log, so a PATCH that persists one silently mutes
+		// every route pointing at it.
+		if err := notify.ValidateConfig(notifier.Type, notifier.Settings); err != nil {
+			return fmt.Errorf("notifications.notifiers.%s: %w", name, err)
+		}
 	}
 	return nil
 }

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"reflect"
 
 	"github.com/elasticclaw/elasticclaw/pkg/cliversion"
 	"github.com/elasticclaw/elasticclaw/pkg/config"
@@ -771,11 +772,24 @@ func mergeNotifierSettings(current, patch *types.NotificationsConfig) {
 	}
 }
 
-func validateSettingsNotifications(cfg *types.NotificationsConfig) error {
+// validateSettingsNotifications checks the patched notifications block. The
+// provider-level "can this be built" check runs only on notifiers the patch
+// actually adds or changes: load-time validation (types.ValidateNotificationsConfig)
+// accepts a notifier this build refuses to construct, so a hub.yaml written by
+// hand — or by an older build — can hold one and run fine, logging "notifier
+// unavailable" per tick. The settings screen submits the whole notifier map on
+// every save, so failing the patch on such an entry would 400 every save from
+// the screen, including saves that touch an entirely different channel, with
+// no way to repair the offender from the UI. Whatever the operator does touch
+// is still checked, so this handler never persists a NEW broken notifier.
+func validateSettingsNotifications(current, cfg *types.NotificationsConfig) error {
 	if err := types.ValidateNotificationsConfig(cfg); err != nil {
 		return err
 	}
 	for name, notifier := range cfg.Notifiers {
+		if notifierUnchanged(current, name, notifier) {
+			continue
+		}
 		if !notify.Supported(notifier.Type) {
 			return fmt.Errorf("notifications.notifiers.%s: unsupported notifier type %q", name, notifier.Type)
 		}
@@ -788,6 +802,21 @@ func validateSettingsNotifications(cfg *types.NotificationsConfig) error {
 		}
 	}
 	return nil
+}
+
+// notifierUnchanged reports whether the patched notifier is byte-identical to
+// the one already stored under that name — the patch is re-sending it, not
+// editing it. Compared after mergeNotifierSettings, so a patch that only omits
+// keys the settings view does not project still counts as unchanged.
+func notifierUnchanged(current *types.NotificationsConfig, name string, patched types.NotifierConfig) bool {
+	if current == nil {
+		return false
+	}
+	existing, ok := current.Notifiers[name]
+	if !ok {
+		return false
+	}
+	return existing.Type == patched.Type && reflect.DeepEqual(existing.Settings, patched.Settings)
 }
 
 // buildGitHubAppView builds a GitHubAppView for the settings page, including
@@ -900,7 +929,7 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 			patch.Notifications.Lifecycle.Via = ""
 		}
 		mergeNotifierSettings(s.hubCfg.Notifications, patch.Notifications)
-		if err := validateSettingsNotifications(patch.Notifications); err != nil {
+		if err := validateSettingsNotifications(s.hubCfg.Notifications, patch.Notifications); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}

--- a/pkg/hub/settings_notifications_test.go
+++ b/pkg/hub/settings_notifications_test.go
@@ -314,3 +314,61 @@ func TestSettingsPatchRejectsNotifierMissingRequiredSettings(t *testing.T) {
 		})
 	}
 }
+
+// Regression: the provider-level "can this be built" check ran over every
+// notifier in the PATCH body, and the Notifier screen always submits the whole
+// map. A hub.yaml holding a notifier this build refuses to construct — load
+// validation accepts one, the hub just logs "notifier unavailable" each tick —
+// therefore 400'd every save from the screen, including saves that touch an
+// entirely different channel, and the screen has no control for the keys the
+// check rejects.
+func TestSettingsPatchAllowsUnchangedBrokenNotifier(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "hub.yaml")
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", path)
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Notifications: &types.NotificationsConfig{
+		Notifiers: map[string]types.NotifierConfig{"ops": {Type: "slack", Settings: map[string]any{
+			"channel": "C0123ABCD", "token_secret": "slack_token", "min_send_interval": "5 minutes",
+		}}},
+		Lifecycle: &types.LifecycleNotificationsConfig{Via: "ops"},
+	}}, "", "", "")
+	if err := config.SaveHubConfig(s.hubCfg); err != nil {
+		t.Fatal(err)
+	}
+
+	// Adding an unrelated channel, exactly as the screen sends it: the whole
+	// notifiers map, with `ops` re-sent from the GET projection.
+	body := []byte(`{"notifications":{"notifiers":` +
+		`{"ops":{"type":"slack","channel":"C0123ABCD","token_secret":"slack_token"},` +
+		`"alerts":{"type":"slack","channel":"C0ALERTS","token_secret":"slack_token"}},` +
+		`"lifecycle":{"enabled":true,"routes":[{"via":"ops"},{"via":"alerts"}]}}}`)
+	rr := httptest.NewRecorder()
+	s.patchSettings(rr, httptest.NewRequest(http.MethodPatch, "/api/settings", bytes.NewReader(body)))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("PATCH status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+	diskCfg, err := config.LoadHubConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := diskCfg.Notifications.Notifiers["alerts"]; !ok {
+		t.Fatal("the new channel was not persisted")
+	}
+	if got := diskCfg.Notifications.Notifiers["ops"].Settings["min_send_interval"]; got != "5 minutes" {
+		t.Fatalf("untouched notifier setting = %v, want it left alone", got)
+	}
+
+	// Touching the offender is still checked: the operator is editing it, so
+	// the patch may not persist a notifier the hub cannot build.
+	body = []byte(`{"notifications":{"notifiers":` +
+		`{"ops":{"type":"slack","channel":"C0999NEW","token_secret":"slack_token"},` +
+		`"alerts":{"type":"slack","channel":"C0ALERTS","token_secret":"slack_token"}},` +
+		`"lifecycle":{"enabled":true,"routes":[{"via":"ops"},{"via":"alerts"}]}}}`)
+	rr = httptest.NewRecorder()
+	s.patchSettings(rr, httptest.NewRequest(http.MethodPatch, "/api/settings", bytes.NewReader(body)))
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("editing the broken notifier: status = %d, want 400; body = %s", rr.Code, rr.Body.String())
+	}
+	if got := rr.Body.String(); !strings.Contains(got, "notifications.notifiers.ops") {
+		t.Fatalf("error does not name the edited notifier: %s", got)
+	}
+}

--- a/pkg/hub/settings_notifications_test.go
+++ b/pkg/hub/settings_notifications_test.go
@@ -372,3 +372,53 @@ func TestSettingsPatchAllowsUnchangedBrokenNotifier(t *testing.T) {
 		t.Fatalf("error does not name the edited notifier: %s", got)
 	}
 }
+
+// Regression: the only key the provider check rejects that the screen does not
+// model was min_send_interval, so a notifier holding an unparseable one could
+// be neither edited (every save 400'd on it) nor removed (a pipeline notifies
+// through it). The Notifier dialog now edits the key, so both repairs — fixing
+// the value and clearing it back to the default — must land.
+func TestSettingsPatchRepairsBrokenMinSendInterval(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "hub.yaml")
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", path)
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Notifications: &types.NotificationsConfig{
+		Notifiers: map[string]types.NotifierConfig{"ops": {Type: "slack", Settings: map[string]any{
+			"channel": "C0123ABCD", "token_secret": "slack_token", "min_send_interval": "5 minutes",
+		}}},
+		Lifecycle: &types.LifecycleNotificationsConfig{Via: "ops"},
+	}}, "", "", "")
+	if err := config.SaveHubConfig(s.hubCfg); err != nil {
+		t.Fatal(err)
+	}
+
+	patch := func(t *testing.T, interval string) {
+		t.Helper()
+		body := []byte(`{"notifications":{"notifiers":` +
+			`{"ops":{"type":"slack","channel":"C0123ABCD","token_secret":"slack_token","min_send_interval":"` + interval + `"}},` +
+			`"lifecycle":{"enabled":true,"routes":[{"via":"ops"}]}}}`)
+		rr := httptest.NewRecorder()
+		s.patchSettings(rr, httptest.NewRequest(http.MethodPatch, "/api/settings", bytes.NewReader(body)))
+		if rr.Code != http.StatusOK {
+			t.Fatalf("PATCH min_send_interval %q: status = %d, want 200; body = %s", interval, rr.Code, rr.Body.String())
+		}
+	}
+	stored := func(t *testing.T) any {
+		t.Helper()
+		diskCfg, err := config.LoadHubConfig()
+		if err != nil {
+			t.Fatal(err)
+		}
+		return diskCfg.Notifications.Notifiers["ops"].Settings["min_send_interval"]
+	}
+
+	patch(t, "5m")
+	if got := stored(t); got != "5m" {
+		t.Fatalf("min_send_interval = %v, want the repaired value", got)
+	}
+	// Emptied, not omitted: the patch is folded over the settings on disk, so
+	// only an explicit empty value clears the key.
+	patch(t, "")
+	if got := stored(t); got != "" {
+		t.Fatalf("min_send_interval = %v, want it cleared", got)
+	}
+}

--- a/pkg/hub/settings_notifications_test.go
+++ b/pkg/hub/settings_notifications_test.go
@@ -83,6 +83,42 @@ func TestSettingsPatchNotificationsPersistsRoutesAndClearsLegacyVia(t *testing.T
 	}
 }
 
+// Regression: the settings view models only five notifier settings keys, so a
+// patch rebuilt from it used to erase everything else configured under
+// notifications.notifiers.<name> the first time the screen was saved.
+func TestSettingsPatchNotificationsKeepsUnmodelledNotifierSettings(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "hub.yaml")
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", path)
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Notifications: &types.NotificationsConfig{
+		Notifiers: map[string]types.NotifierConfig{"ops": {Type: "slack", Settings: map[string]any{
+			"channel": "C123", "token_secret": "slack_token", "unexpected_secret": "keep-me",
+		}}},
+		Lifecycle: &types.LifecycleNotificationsConfig{Via: "ops"},
+	}}, "", "", "")
+	if err := config.SaveHubConfig(s.hubCfg); err != nil {
+		t.Fatal(err)
+	}
+
+	// Exactly what the Notifier screen sends: the projected keys only.
+	body := []byte(`{"notifications":{"notifiers":{"ops":{"type":"slack","channel":"C999","token_secret":"slack_token"}},"lifecycle":{"enabled":true,"routes":[{"via":"ops","events":[]}]}}}`)
+	rr := httptest.NewRecorder()
+	s.patchSettings(rr, httptest.NewRequest(http.MethodPatch, "/api/settings", bytes.NewReader(body)))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("PATCH status = %d: %s", rr.Code, rr.Body.String())
+	}
+	diskCfg, err := config.LoadHubConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	settings := diskCfg.Notifications.Notifiers["ops"].Settings
+	if got := settings["unexpected_secret"]; got != "keep-me" {
+		t.Fatalf("unmodelled setting = %v, want it preserved", got)
+	}
+	if got := settings["channel"]; got != "C999" {
+		t.Fatalf("patched setting = %v, want C999", got)
+	}
+}
+
 func TestSettingsPatchNotificationsRejectsInvalidConfigWithoutWriting(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "hub.yaml")
 	t.Setenv("ELASTICCLAW_HUB_CONFIG", path)

--- a/pkg/hub/settings_notifications_test.go
+++ b/pkg/hub/settings_notifications_test.go
@@ -152,3 +152,62 @@ func TestSettingsPatchNotificationsRejectsInvalidConfigWithoutWriting(t *testing
 		}
 	}
 }
+
+// Regression: the Notifier screen lists every hub notifier, including ones no
+// lifecycle route uses and only a pipeline notify action references, and its
+// Remove button PATCHes the whole notifiers map without the deleted key.
+// Nothing server-side looked at pipelines, so the save returned 200, the
+// notifier left hub.yaml, and every stage notification through it was then
+// dropped at runtime with only a warning in the claw conversation.
+func TestSettingsPatchRejectsRemovingNotifierUsedByPipeline(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", filepath.Join(t.TempDir(), "hub.yaml"))
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{
+		Factories: []*types.FactoryConfig{{
+			Name:         "triage",
+			PipelineYAML: "stages:\n  - id: announce\n    on_enter:\n      notify:\n        via: releases\n        text: hi\n",
+		}},
+		Notifications: &types.NotificationsConfig{
+			Notifiers: map[string]types.NotifierConfig{
+				"releases": {Type: "slack", Settings: map[string]any{"channel": "C0123ABCD", "token_secret": "slack_tok"}},
+				"ops":      {Type: "slack", Settings: map[string]any{"channel": "C0456EFGH", "token_secret": "slack_tok"}},
+			},
+			Lifecycle: &types.LifecycleNotificationsConfig{Via: "ops"},
+		},
+	}, "", "", "")
+
+	body := []byte(`{"notifications":{"notifiers":{"ops":{"type":"slack","channel":"C0456EFGH","token_secret":"slack_tok"}},"lifecycle":{"enabled":true,"routes":[{"via":"ops"}]}}}`)
+	rr := httptest.NewRecorder()
+	s.patchSettings(rr, httptest.NewRequest(http.MethodPatch, "/api/settings", bytes.NewReader(body)))
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("PATCH status = %d, want 400; body = %s", rr.Code, rr.Body.String())
+	}
+	if got := rr.Body.String(); !strings.Contains(got, `"releases"`) || !strings.Contains(got, `stage "announce"`) {
+		t.Fatalf("error does not name the notifier and the stage that depends on it: %s", got)
+	}
+	if _, ok := s.hubCfg.Notifications.Notifiers["releases"]; !ok {
+		t.Fatal("a rejected patch must not have removed the notifier from the running config")
+	}
+}
+
+// Regression: the GET view emitted the two lifecycle durations as
+// poll_interval/idle_after while the PATCH body is decoded into
+// types.LifecycleNotificationsConfig, which reads pollInterval/idleAfter. A
+// client that GETs the settings, edits the routes and PATCHes the object back
+// therefore reset a deliberately raised idle_after to the 5m default, and
+// SaveHubConfig persisted the loss.
+func TestSettingsLifecycleViewRoundTripsThroughPatch(t *testing.T) {
+	encoded, err := json.Marshal(LifecycleNotificationsView{
+		Enabled: true, Routes: []types.LifecycleRoute{{Via: "ops"}},
+		PollInterval: "30s", IdleAfter: "30m",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var patched types.LifecycleNotificationsConfig
+	if err := json.Unmarshal(encoded, &patched); err != nil {
+		t.Fatal(err)
+	}
+	if patched.PollInterval != "30s" || patched.IdleAfter != "30m" {
+		t.Fatalf("GET→PATCH round trip dropped the durations: %#v (from %s)", patched, encoded)
+	}
+}

--- a/pkg/hub/settings_notifications_test.go
+++ b/pkg/hub/settings_notifications_test.go
@@ -62,7 +62,7 @@ func TestSettingsPatchNotificationsPersistsRoutesAndClearsLegacyVia(t *testing.T
 		t.Fatal(err)
 	}
 
-	body := []byte(`{"notifications":{"notifiers":{"ops":{"type":"slack","channel":"C123","token_secret":"slack_token","api_base":"https://slack.example","min_send_interval":"2s"}},"lifecycle":{"enabled":true,"via":"old","routes":[{"via":"ops","events":["agent_started"]}],"idleAfter":"5m","events":{"agentStarted":true}}}}`)
+	body := []byte(`{"notifications":{"notifiers":{"ops":{"type":"slack","channel":"C123","token_secret":"slack_token","api_base":"https://slack.com/api","min_send_interval":"2s"}},"lifecycle":{"enabled":true,"via":"old","routes":[{"via":"ops","events":["agent_started"]}],"idleAfter":"5m","events":{"agentStarted":true}}}}`)
 	rr := httptest.NewRecorder()
 	s.patchSettings(rr, httptest.NewRequest(http.MethodPatch, "/api/settings", bytes.NewReader(body)))
 	if rr.Code != http.StatusOK {
@@ -420,5 +420,100 @@ func TestSettingsPatchRepairsBrokenMinSendInterval(t *testing.T) {
 	patch(t, "")
 	if got := stored(t); got != "" {
 		t.Fatalf("min_send_interval = %v, want it cleared", got)
+	}
+}
+
+// Regression: lifecycle poll_interval and idle_after are validated on every
+// patch, floors included, and the Notifier screen renders neither — so a
+// hub.yaml holding a sub-floor value made EVERY save from that screen 400 on a
+// field the operator could not see, let alone repair.
+func TestSettingsPatchClearsUnusableLifecycleDurations(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "hub.yaml")
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", path)
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Notifications: &types.NotificationsConfig{
+		Notifiers: map[string]types.NotifierConfig{"eng": {Type: "slack", Settings: map[string]any{
+			"channel": "C0123ABCD", "token_secret": "slack_token",
+		}}},
+		Lifecycle: &types.LifecycleNotificationsConfig{Via: "eng", PollInterval: "500ms", IdleAfter: "30s"},
+	}}, "", "", "")
+	if err := config.SaveHubConfig(s.hubCfg); err != nil {
+		t.Fatal(err)
+	}
+
+	// The master switch, as the screen sends it: the whole block rebuilt from
+	// the GET projection, both durations re-sent verbatim.
+	body := []byte(`{"notifications":{"notifiers":` +
+		`{"eng":{"type":"slack","channel":"C0123ABCD","token_secret":"slack_token"}},` +
+		`"lifecycle":{"enabled":false,"routes":[{"via":"eng"}],"pollInterval":"500ms","idleAfter":"30s"}}}`)
+	rr := httptest.NewRecorder()
+	s.patchSettings(rr, httptest.NewRequest(http.MethodPatch, "/api/settings", bytes.NewReader(body)))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("PATCH status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+	diskCfg, err := config.LoadHubConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	lc := diskCfg.Notifications.Lifecycle
+	if lc.PollInterval != "" || lc.IdleAfter != "" {
+		t.Fatalf("lifecycle durations = %q/%q, want both cleared", lc.PollInterval, lc.IdleAfter)
+	}
+
+	// A value the patch itself introduces is still a typo worth reporting.
+	body = []byte(`{"notifications":{"notifiers":` +
+		`{"eng":{"type":"slack","channel":"C0123ABCD","token_secret":"slack_token"}},` +
+		`"lifecycle":{"enabled":false,"routes":[{"via":"eng"}],"idleAfter":"10s"}}}`)
+	rr = httptest.NewRecorder()
+	s.patchSettings(rr, httptest.NewRequest(http.MethodPatch, "/api/settings", bytes.NewReader(body)))
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("introducing a sub-floor idle_after: status = %d, want 400; body = %s", rr.Code, rr.Body.String())
+	}
+}
+
+// Regression: api_base decides where the notifier's bot token is sent, and the
+// patch preserves token_secret, so repointing it through the settings API was
+// token exfiltration (and SSRF) in one PATCH.
+func TestSettingsPatchRejectsRepointedNotifierAPIBase(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "hub.yaml")
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", path)
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Notifications: &types.NotificationsConfig{
+		Notifiers: map[string]types.NotifierConfig{"eng": {Type: "slack", Settings: map[string]any{
+			"channel": "C0123ABCD", "token_secret": "slack_token", "api_base": "https://slack-proxy.internal",
+		}}},
+		Lifecycle: &types.LifecycleNotificationsConfig{Via: "eng"},
+	}}, "", "", "")
+	if err := config.SaveHubConfig(s.hubCfg); err != nil {
+		t.Fatal(err)
+	}
+
+	patch := func(t *testing.T, apiBase string) *httptest.ResponseRecorder {
+		t.Helper()
+		body := []byte(`{"notifications":{"notifiers":` +
+			`{"eng":{"type":"slack","channel":"C0999NEW","token_secret":"slack_token","api_base":"` + apiBase + `"}},` +
+			`"lifecycle":{"enabled":true,"routes":[{"via":"eng"}]}}}`)
+		rr := httptest.NewRecorder()
+		s.patchSettings(rr, httptest.NewRequest(http.MethodPatch, "/api/settings", bytes.NewReader(body)))
+		return rr
+	}
+
+	rr := patch(t, "https://attacker.example")
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("repointed api_base: status = %d, want 400; body = %s", rr.Code, rr.Body.String())
+	}
+	if got := rr.Body.String(); !strings.Contains(got, "api_base") {
+		t.Fatalf("error does not name the offending setting: %s", got)
+	}
+	diskCfg, err := config.LoadHubConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := diskCfg.Notifications.Notifiers["eng"].Settings["api_base"]; got != "https://slack-proxy.internal" {
+		t.Fatalf("stored api_base = %v, want the rejected patch to have written nothing", got)
+	}
+
+	// The operator's own hub.yaml value is exempt: re-sending it unchanged —
+	// what the settings screen does on every save — still edits the channel.
+	if rr = patch(t, "https://slack-proxy.internal"); rr.Code != http.StatusOK {
+		t.Fatalf("unchanged api_base: status = %d, want 200; body = %s", rr.Code, rr.Body.String())
 	}
 }

--- a/pkg/hub/settings_notifications_test.go
+++ b/pkg/hub/settings_notifications_test.go
@@ -83,6 +83,55 @@ func TestSettingsPatchNotificationsPersistsRoutesAndClearsLegacyVia(t *testing.T
 	}
 }
 
+// Regression: LifecycleNotificationsView always emits `routes` (as `[]` for a
+// legacy via-only config), and the via→routes migration was gated on the
+// decoded slice being non-nil. A client that GETs the view and PATCHes it back
+// verbatim therefore destroyed `via` and left the hub with no channel binding
+// at all — or, with alerts enabled, could not save ANY notifications change.
+func TestSettingsPatchLegacyViaOnlyViewRoundTripKeepsVia(t *testing.T) {
+	for _, enabled := range []bool{false, true} {
+		name := "enabled"
+		if !enabled {
+			name = "paused"
+		}
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "hub.yaml")
+			t.Setenv("ELASTICCLAW_HUB_CONFIG", path)
+			s, _ := NewTestServerWithConfig(t, &types.HubConfig{Notifications: &types.NotificationsConfig{
+				Notifiers: map[string]types.NotifierConfig{"eng": {Type: "slack", Settings: map[string]any{"channel": "C123", "token_secret": "slack_token"}}},
+				Lifecycle: &types.LifecycleNotificationsConfig{Enabled: &enabled, Via: "eng"},
+			}}, "", "", "")
+			if err := config.SaveHubConfig(s.hubCfg); err != nil {
+				t.Fatal(err)
+			}
+
+			rr := httptest.NewRecorder()
+			s.getSettings(rr, httptest.NewRequest(http.MethodGet, "/api/settings", nil))
+			var view SettingsView
+			if err := json.Unmarshal(rr.Body.Bytes(), &view); err != nil {
+				t.Fatal(err)
+			}
+			// Byte-for-byte what the view returned, PATCHed straight back.
+			body, err := json.Marshal(map[string]any{"notifications": view.Notifications})
+			if err != nil {
+				t.Fatal(err)
+			}
+			rr = httptest.NewRecorder()
+			s.patchSettings(rr, httptest.NewRequest(http.MethodPatch, "/api/settings", bytes.NewReader(body)))
+			if rr.Code != http.StatusOK {
+				t.Fatalf("round-tripping the view rejected the save: %d: %s", rr.Code, rr.Body.String())
+			}
+			diskCfg, err := config.LoadHubConfig()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := diskCfg.Notifications.Lifecycle.Via; got != "eng" {
+				t.Fatalf("disk via = %q, want it preserved (routes = %#v)", got, diskCfg.Notifications.Lifecycle.Routes)
+			}
+		})
+	}
+}
+
 // Regression: the settings view models only five notifier settings keys, so a
 // patch rebuilt from it used to erase everything else configured under
 // notifications.notifiers.<name> the first time the screen was saved.

--- a/pkg/hub/settings_notifications_test.go
+++ b/pkg/hub/settings_notifications_test.go
@@ -1,0 +1,118 @@
+package hub
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/elasticclaw/elasticclaw/pkg/config"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func TestSettingsGetNotificationsIsRedacted(t *testing.T) {
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", filepath.Join(t.TempDir(), "hub.yaml"))
+	trueValue := true
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{
+		Secrets: map[string]string{"slack_token": "the-secret-value"},
+		Notifications: &types.NotificationsConfig{
+			Notifiers: map[string]types.NotifierConfig{
+				"ops": {Type: "slack", Settings: map[string]any{"channel": "C123", "token_secret": "slack_token", "unexpected_secret": "must-not-leak"}},
+			},
+			Lifecycle: &types.LifecycleNotificationsConfig{Via: "ops", Events: &types.LifecycleEventToggles{AgentStarted: &trueValue}},
+		},
+	}, "", "", "")
+
+	rr := httptest.NewRecorder()
+	s.getSettings(rr, httptest.NewRequest(http.MethodGet, "/api/settings", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GET status = %d: %s", rr.Code, rr.Body.String())
+	}
+	if strings.Contains(rr.Body.String(), "the-secret-value") || strings.Contains(rr.Body.String(), "must-not-leak") {
+		t.Fatalf("GET leaked a secret value: %s", rr.Body.String())
+	}
+	var view SettingsView
+	if err := json.Unmarshal(rr.Body.Bytes(), &view); err != nil {
+		t.Fatal(err)
+	}
+	if got := view.Notifications.Notifiers["ops"]; got.TokenSecret != "slack_token" || got.Channel != "C123" {
+		t.Fatalf("notifier view = %#v", got)
+	}
+	if view.Notifications.Lifecycle.Via != "ops" || !view.Notifications.Lifecycle.Enabled {
+		t.Fatalf("lifecycle view = %#v", view.Notifications.Lifecycle)
+	}
+	if !reflect.DeepEqual(view.LifecycleEventTypes, types.LifecycleEventTypes) {
+		t.Fatalf("lifecycle event types = %v, want %v", view.LifecycleEventTypes, types.LifecycleEventTypes)
+	}
+}
+
+func TestSettingsPatchNotificationsPersistsRoutesAndClearsLegacyVia(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "hub.yaml")
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", path)
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Notifications: &types.NotificationsConfig{
+		Notifiers: map[string]types.NotifierConfig{"old": {Type: "slack"}},
+		Lifecycle: &types.LifecycleNotificationsConfig{Via: "old"},
+	}}, "", "", "")
+	if err := config.SaveHubConfig(s.hubCfg); err != nil {
+		t.Fatal(err)
+	}
+
+	body := []byte(`{"notifications":{"notifiers":{"ops":{"type":"slack","channel":"C123","token_secret":"slack_token","api_base":"https://slack.example","min_send_interval":"2s"}},"lifecycle":{"enabled":true,"via":"old","routes":[{"via":"ops","events":["agent_started"]}],"idleAfter":"5m","events":{"agentStarted":true}}}}`)
+	rr := httptest.NewRecorder()
+	s.patchSettings(rr, httptest.NewRequest(http.MethodPatch, "/api/settings", bytes.NewReader(body)))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("PATCH status = %d: %s", rr.Code, rr.Body.String())
+	}
+	if got := s.hubCfg.Notifications.Lifecycle.Via; got != "" {
+		t.Fatalf("legacy via = %q, want cleared", got)
+	}
+	diskCfg, err := config.LoadHubConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := diskCfg.Notifications.Lifecycle.Routes; !reflect.DeepEqual(got, []types.LifecycleRoute{{Via: "ops", Events: []string{"agent_started"}}}) {
+		t.Fatalf("disk routes = %#v", got)
+	}
+	if diskCfg.Notifications.Lifecycle.Via != "" {
+		t.Fatalf("disk legacy via = %q, want cleared", diskCfg.Notifications.Lifecycle.Via)
+	}
+}
+
+func TestSettingsPatchNotificationsRejectsInvalidConfigWithoutWriting(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "hub.yaml")
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", path)
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Notifications: &types.NotificationsConfig{
+		Notifiers: map[string]types.NotifierConfig{"ops": {Type: "slack"}},
+		Lifecycle: &types.LifecycleNotificationsConfig{Via: "ops"},
+	}}, "", "", "")
+	if err := config.SaveHubConfig(s.hubCfg); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, body := range [][]byte{
+		[]byte(`{"notifications":{"notifiers":{"ops":{"type":"slack"}},"lifecycle":{"routes":[{"via":"ops","events":["not_an_event"]}]}}}`),
+		[]byte(`{"notifications":{"notifiers":{"ops":{"type":"slack"}},"lifecycle":{"routes":[{"via":"missing"}]}}}`),
+	} {
+		rr := httptest.NewRecorder()
+		s.patchSettings(rr, httptest.NewRequest(http.MethodPatch, "/api/settings", bytes.NewReader(body)))
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("PATCH status = %d: %s", rr.Code, rr.Body.String())
+		}
+		after, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(after, before) {
+			t.Fatalf("invalid patch changed disk config:\n%s", after)
+		}
+	}
+}

--- a/pkg/hub/settings_notifications_test.go
+++ b/pkg/hub/settings_notifications_test.go
@@ -553,3 +553,57 @@ func TestSettingsPatchRejectsRepointedNotifierAPIBase(t *testing.T) {
 		t.Fatalf("unchanged api_base: status = %d, want 200; body = %s", rr.Code, rr.Body.String())
 	}
 }
+
+// Regression: a stored api_base this build refuses to construct (written by
+// hand, or accepted by an older build) is exempt from validateNotifierAPIBase,
+// but the provider check that follows judged the merged settings — stored
+// api_base included — so every save that touched the channel 400d on a field
+// the settings screen neither renders nor can clear, leaving a hub.yaml edit as
+// the only repair.
+func TestSettingsPatchEditsChannelWithUnbuildableStoredAPIBase(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "hub.yaml")
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", path)
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Notifications: &types.NotificationsConfig{
+		Notifiers: map[string]types.NotifierConfig{"eng": {Type: "slack", Settings: map[string]any{
+			// Scheme-less: accepted at load, refused by newSlack.
+			"channel": "C0123ABCD", "token_secret": "slack_token", "api_base": "slack.example.com/api",
+		}}},
+		Lifecycle: &types.LifecycleNotificationsConfig{Via: "eng"},
+	}}, "", "", "")
+	if err := config.SaveHubConfig(s.hubCfg); err != nil {
+		t.Fatal(err)
+	}
+
+	patch := func(t *testing.T, apiBase string) *httptest.ResponseRecorder {
+		t.Helper()
+		body := []byte(`{"notifications":{"notifiers":` +
+			`{"eng":{"type":"slack","channel":"C0999NEW","token_secret":"slack_token","api_base":"` + apiBase + `"}},` +
+			`"lifecycle":{"enabled":true,"routes":[{"via":"eng"}]}}}`)
+		rr := httptest.NewRecorder()
+		s.patchSettings(rr, httptest.NewRequest(http.MethodPatch, "/api/settings", bytes.NewReader(body)))
+		return rr
+	}
+
+	// The repair the screen offers — a corrected channel ID, api_base
+	// round-tripped unchanged — must go through.
+	rr := patch(t, "slack.example.com/api")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("editing a channel with an unbuildable stored api_base: status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+	diskCfg, err := config.LoadHubConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stored := diskCfg.Notifications.Notifiers["eng"].Settings
+	if stored["channel"] != "C0999NEW" {
+		t.Fatalf("stored channel = %v, want the edit to have landed", stored["channel"])
+	}
+	if stored["api_base"] != "slack.example.com/api" {
+		t.Fatalf("stored api_base = %v, want it preserved", stored["api_base"])
+	}
+
+	// A value the patch itself introduces is still judged, exemption or not.
+	if rr = patch(t, "slack.other.example/api"); rr.Code != http.StatusBadRequest {
+		t.Fatalf("changed api_base: status = %d, want 400; body = %s", rr.Code, rr.Body.String())
+	}
+}

--- a/pkg/hub/settings_notifications_test.go
+++ b/pkg/hub/settings_notifications_test.go
@@ -470,6 +470,42 @@ func TestSettingsPatchClearsUnusableLifecycleDurations(t *testing.T) {
 	}
 }
 
+// Regression: the drop above must fire only on a duration validation actually
+// rejects. The probe it validates carries no `via` and no routes, so an ENABLED
+// probe is rejected for THAT — reporting every value as unusable and erasing a
+// perfectly valid poll_interval/idle_after from hub.yaml on every save made
+// from the Notifier screen, which re-sends both verbatim.
+func TestSettingsPatchKeepsValidLifecycleDurations(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "hub.yaml")
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", path)
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Notifications: &types.NotificationsConfig{
+		Notifiers: map[string]types.NotifierConfig{"eng": {Type: "slack", Settings: map[string]any{
+			"channel": "C0123ABCD", "token_secret": "slack_token",
+		}}},
+		Lifecycle: &types.LifecycleNotificationsConfig{Via: "eng", PollInterval: "60s", IdleAfter: "30m"},
+	}}, "", "", "")
+	if err := config.SaveHubConfig(s.hubCfg); err != nil {
+		t.Fatal(err)
+	}
+
+	body := []byte(`{"notifications":{"notifiers":` +
+		`{"eng":{"type":"slack","channel":"C0123ABCD","token_secret":"slack_token"}},` +
+		`"lifecycle":{"enabled":true,"routes":[{"via":"eng"}],"pollInterval":"60s","idleAfter":"30m"}}}`)
+	rr := httptest.NewRecorder()
+	s.patchSettings(rr, httptest.NewRequest(http.MethodPatch, "/api/settings", bytes.NewReader(body)))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("PATCH status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+	diskCfg, err := config.LoadHubConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	lc := diskCfg.Notifications.Lifecycle
+	if lc.PollInterval != "60s" || lc.IdleAfter != "30m" {
+		t.Fatalf("lifecycle durations = %q/%q, want them preserved", lc.PollInterval, lc.IdleAfter)
+	}
+}
+
 // Regression: api_base decides where the notifier's bot token is sent, and the
 // patch preserves token_secret, so repointing it through the settings API was
 // token exfiltration (and SSRF) in one PATCH.

--- a/pkg/hub/settings_notifications_test.go
+++ b/pkg/hub/settings_notifications_test.go
@@ -260,3 +260,57 @@ func TestSettingsLifecycleViewRoundTripsThroughPatch(t *testing.T) {
 		t.Fatalf("GET→PATCH round trip dropped the durations: %#v (from %s)", patched, encoded)
 	}
 }
+
+// Regression: PATCH validated only that the notifier TYPE was supported, so a
+// Slack channel saved without token_secret — or with a #name where a channel ID
+// belongs — persisted with a 200. Every later lifecycle tick then failed to
+// build that notifier and delivered nothing, saying so in the hub log alone.
+func TestSettingsPatchRejectsNotifierMissingRequiredSettings(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "hub.yaml")
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", path)
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Notifications: &types.NotificationsConfig{
+		Notifiers: map[string]types.NotifierConfig{"ops": {Type: "slack", Settings: map[string]any{
+			"channel": "C0123ABCD", "token_secret": "slack_token",
+		}}},
+		Lifecycle: &types.LifecycleNotificationsConfig{Via: "ops"},
+	}}, "", "", "")
+	if err := config.SaveHubConfig(s.hubCfg); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A brand-new channel, exactly as the Notifier screen adds one — the
+	// settings merge cannot backfill anything for a name the config has never
+	// seen.
+	for name, notifier := range map[string]string{
+		"no token secret": `{"type":"slack","channel":"C0NEWCHAN"}`,
+		"channel name":    `{"type":"slack","channel":"#alerts","token_secret":"slack_token"}`,
+		"bad interval":    `{"type":"slack","channel":"C0NEWCHAN","token_secret":"slack_token","min_send_interval":"soon"}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			body := []byte(`{"notifications":{"notifiers":{"ops":{"type":"slack","channel":"C0123ABCD","token_secret":"slack_token"},"added":` +
+				notifier + `},"lifecycle":{"enabled":true,"routes":[{"via":"ops"},{"via":"added"}]}}}`)
+			rr := httptest.NewRecorder()
+			s.patchSettings(rr, httptest.NewRequest(http.MethodPatch, "/api/settings", bytes.NewReader(body)))
+			if rr.Code != http.StatusBadRequest {
+				t.Fatalf("PATCH status = %d, want 400; body = %s", rr.Code, rr.Body.String())
+			}
+			if got := rr.Body.String(); !strings.Contains(got, "notifications.notifiers.added") {
+				t.Fatalf("error does not name the offending notifier: %s", got)
+			}
+			if _, ok := s.hubCfg.Notifications.Notifiers["added"]; ok {
+				t.Fatal("a rejected patch must not have added the notifier to the running config")
+			}
+			after, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(after, before) {
+				t.Fatalf("rejected patch changed disk config:\n%s", after)
+			}
+		})
+	}
+}

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -565,20 +565,25 @@ type NotificationsConfig struct {
 	Lifecycle *LifecycleNotificationsConfig `yaml:"lifecycle,omitempty" json:"lifecycle,omitempty"`
 }
 
-// LifecycleEventTypes is the canonical set of lifecycle event wire types.
+// LifecycleEventTypes is the canonical set of lifecycle event wire types: the
+// vocabulary a route's allow-list may name, and the one the settings screen
+// renders one checkbox per entry from.
+//
+// It holds ONLY values that are written as task_run_events.event_type, because
+// that is the column route matching compares against. The concrete failure
+// kinds (provision_failed, bootstrap_failed, provider_lost,
+// permission_or_auth_failed, timeout, creation_failed, unknown_failure) are
+// run-level classifications living in failure_type; no event ever carries them
+// as its type, so a route built from them would match nothing and receive no
+// message ever while the test-send endpoint happily reported success. Failures
+// route as agent_stopped — the event a dying agent produces, rendered with the
+// headline its failure_type earns — and done_without_pr.
 var LifecycleEventTypes = []string{
 	"agent_started",
 	"pr_opened",
 	"agent_stopped",
-	"creation_failed",
-	"provision_failed",
-	"bootstrap_failed",
-	"permission_or_auth_failed",
-	"provider_lost",
-	"timeout",
 	"agent_idle",
 	"done_without_pr",
-	"unknown_failure",
 }
 
 // IsLifecycleEventType reports whether event is a supported lifecycle event

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -565,14 +565,53 @@ type NotificationsConfig struct {
 	Lifecycle *LifecycleNotificationsConfig `yaml:"lifecycle,omitempty" json:"lifecycle,omitempty"`
 }
 
+// LifecycleEventTypes is the canonical set of lifecycle event wire types.
+var LifecycleEventTypes = []string{
+	"agent_started",
+	"pr_opened",
+	"agent_stopped",
+	"creation_failed",
+	"provision_failed",
+	"bootstrap_failed",
+	"permission_or_auth_failed",
+	"provider_lost",
+	"timeout",
+	"agent_idle",
+	"done_without_pr",
+	"unknown_failure",
+}
+
+// IsLifecycleEventType reports whether event is a supported lifecycle event
+// wire type.
+func IsLifecycleEventType(event string) bool {
+	for _, eventType := range LifecycleEventTypes {
+		if event == eventType {
+			return true
+		}
+	}
+	return false
+}
+
+// LifecycleRoute sends lifecycle events through a named notifier. An empty
+// Events list receives all lifecycle event types.
+type LifecycleRoute struct {
+	Via    string   `yaml:"via" json:"via"`
+	Events []string `yaml:"events,omitempty" json:"events,omitempty"`
+}
+
 // LifecycleNotificationsConfig configures outbound notifications for agent
-// lifecycle events, sent through a named hub-level notifier.
+// lifecycle events, sent through one or more named hub-level notifiers.
 type LifecycleNotificationsConfig struct {
 	// Enabled defaults to true when the lifecycle block is present; set it
 	// to false to mute lifecycle notifications without deleting the config.
 	Enabled *bool `yaml:"enabled,omitempty" json:"enabled,omitempty"`
 	// Via names the notifier (under notifications.notifiers) to send through.
+	// Deprecated: use Routes for per-channel routing. It remains for backward
+	// compatibility and cannot be set with Routes.
 	Via string `yaml:"via" json:"via"`
+	// Routes maps lifecycle events to named notifiers. A route with no Events
+	// receives all lifecycle event types.
+	Routes []LifecycleRoute `yaml:"routes,omitempty" json:"routes,omitempty"`
 	// PollInterval is how often the notifier scans for new events. Default "5s".
 	PollInterval string `yaml:"poll_interval,omitempty" json:"pollInterval,omitempty"`
 	// IdleAfter is how long an agent must sit idle (connected, no turn
@@ -588,6 +627,21 @@ type LifecycleNotificationsConfig struct {
 // be present and Enabled must be absent (the default) or true.
 func (c *LifecycleNotificationsConfig) IsEnabled() bool {
 	return c != nil && (c.Enabled == nil || *c.Enabled)
+}
+
+// EffectiveRoutes returns configured routes, translating the legacy Via field
+// to a single route that receives all events.
+func (c *LifecycleNotificationsConfig) EffectiveRoutes() []LifecycleRoute {
+	if c == nil {
+		return nil
+	}
+	if len(c.Routes) != 0 {
+		return c.Routes
+	}
+	if c.Via != "" {
+		return []LifecycleRoute{{Via: c.Via}}
+	}
+	return nil
 }
 
 // LifecycleEventToggles enables/disables individual lifecycle notification

--- a/pkg/types/validation.go
+++ b/pkg/types/validation.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/robfig/cron/v3"
 )
@@ -775,6 +776,15 @@ func ValidateNotificationsConfig(cfg *NotificationsConfig) error {
 	for name, notifier := range cfg.Notifiers {
 		if strings.TrimSpace(name) == "" {
 			return fmt.Errorf("notifications.notifiers: notifier name is required")
+		}
+		// TrimSpace does not strip NUL or other control characters, and both
+		// the settings PATCH and hub.yaml round-trip them. The hub keys its
+		// per-route delivery state by notifier name and reserves a NUL-prefixed
+		// sentinel for the legacy (un-routed) rows, so a name carrying one
+		// collides with it and fences an event for every other route; a name
+		// carrying a newline forges hub log lines.
+		if strings.ContainsFunc(name, unicode.IsControl) {
+			return fmt.Errorf("notifications.notifiers: notifier name %q cannot contain control characters", name)
 		}
 		if strings.TrimSpace(notifier.Type) == "" {
 			return fmt.Errorf("notifications.notifiers.%s: type is required", name)

--- a/pkg/types/validation.go
+++ b/pkg/types/validation.go
@@ -811,6 +811,16 @@ func ValidateNotificationsConfig(cfg *NotificationsConfig) error {
 			return fmt.Errorf("notifications.lifecycle: idle_after must be at least 1m, got %q", lc.IdleAfter)
 		}
 	}
+	if !lc.IsEnabled() {
+		return nil
+	}
+	// Routes are validated only from here on, symmetrically with the legacy
+	// `via` below: a DISABLED lifecycle block with a dangling reference is
+	// accepted (an operator who mutes alerts and then deletes the notifier
+	// must not be left with a hub that refuses to load), and the settings
+	// screen derives its route list from that same `via`. Validating routes
+	// above the short-circuit made every save from that screen 400 on a route
+	// entry it never renders, with no way to drop it from the UI.
 	seenRoutes := make(map[string]struct{}, len(lc.Routes))
 	for i, route := range lc.Routes {
 		via := strings.TrimSpace(route.Via)
@@ -835,9 +845,6 @@ func ValidateNotificationsConfig(cfg *NotificationsConfig) error {
 			}
 			seenEvents[event] = struct{}{}
 		}
-	}
-	if !lc.IsEnabled() {
-		return nil
 	}
 	if len(lc.EffectiveRoutes()) == 0 {
 		return fmt.Errorf("notifications.lifecycle: via is required when enabled (the name of a notifier under notifications.notifiers)")

--- a/pkg/types/validation.go
+++ b/pkg/types/validation.go
@@ -784,6 +784,9 @@ func ValidateNotificationsConfig(cfg *NotificationsConfig) error {
 	if lc == nil {
 		return nil
 	}
+	if lc.Via != "" && len(lc.Routes) != 0 {
+		return fmt.Errorf("notifications.lifecycle: via and routes cannot both be set")
+	}
 	// The poll interval is validated even when lifecycle is disabled, so a
 	// typo is caught before the operator flips the feature on.
 	if lc.PollInterval != "" {
@@ -808,13 +811,41 @@ func ValidateNotificationsConfig(cfg *NotificationsConfig) error {
 			return fmt.Errorf("notifications.lifecycle: idle_after must be at least 1m, got %q", lc.IdleAfter)
 		}
 	}
+	seenRoutes := make(map[string]struct{}, len(lc.Routes))
+	for i, route := range lc.Routes {
+		via := strings.TrimSpace(route.Via)
+		if via == "" {
+			return fmt.Errorf("notifications.lifecycle.routes[%d]: via is required (the name of a notifier under notifications.notifiers)", i)
+		}
+		if _, ok := cfg.Notifiers[via]; !ok {
+			return fmt.Errorf("notifications.lifecycle.routes[%d]: via %q does not name a configured notifier (defined: %s)", i, via, notifierNames(cfg.Notifiers))
+		}
+		if _, duplicate := seenRoutes[via]; duplicate {
+			return fmt.Errorf("notifications.lifecycle.routes[%d]: via %q is duplicated", i, via)
+		}
+		seenRoutes[via] = struct{}{}
+
+		seenEvents := make(map[string]struct{}, len(route.Events))
+		for _, event := range route.Events {
+			if !IsLifecycleEventType(event) {
+				return fmt.Errorf("notifications.lifecycle.routes[%d]: event %q is not a supported lifecycle event type", i, event)
+			}
+			if _, duplicate := seenEvents[event]; duplicate {
+				return fmt.Errorf("notifications.lifecycle.routes[%d]: event %q is duplicated", i, event)
+			}
+			seenEvents[event] = struct{}{}
+		}
+	}
 	if !lc.IsEnabled() {
 		return nil
 	}
-	via := strings.TrimSpace(lc.Via)
-	if via == "" {
+	if len(lc.EffectiveRoutes()) == 0 {
 		return fmt.Errorf("notifications.lifecycle: via is required when enabled (the name of a notifier under notifications.notifiers)")
 	}
+	if lc.Via == "" {
+		return nil
+	}
+	via := strings.TrimSpace(lc.Via)
 	if _, ok := cfg.Notifiers[via]; !ok {
 		return fmt.Errorf("notifications.lifecycle: via %q does not name a configured notifier (defined: %s)", via, notifierNames(cfg.Notifiers))
 	}

--- a/pkg/types/validation_notifications_test.go
+++ b/pkg/types/validation_notifications_test.go
@@ -192,6 +192,31 @@ func TestValidateNotificationsConfig(t *testing.T) {
 			wantErr: true,
 			errMsg:  "invalid idle_after",
 		},
+		{
+			// Routes are validated symmetrically with the legacy `via`: both
+			// only while lifecycle is enabled. A disabled block whose `via`
+			// names a deleted notifier loads fine, and the settings screen
+			// derives its route list from that same `via` — so validating
+			// routes above the short-circuit made every save from that screen
+			// 400 on an entry the screen never renders and cannot drop.
+			name: "dangling route is accepted while lifecycle is disabled",
+			cfg: &NotificationsConfig{
+				Notifiers: slack(),
+				Lifecycle: &LifecycleNotificationsConfig{
+					Enabled: boolPtr(false),
+					Routes:  []LifecycleRoute{{Via: "gone"}},
+				},
+			},
+		},
+		{
+			name: "dangling route is rejected while lifecycle is enabled",
+			cfg: &NotificationsConfig{
+				Notifiers: slack(),
+				Lifecycle: &LifecycleNotificationsConfig{Routes: []LifecycleRoute{{Via: "gone"}}},
+			},
+			wantErr: true,
+			errMsg:  `via "gone" does not name a configured notifier`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/types/validation_notifications_test.go
+++ b/pkg/types/validation_notifications_test.go
@@ -284,16 +284,23 @@ func TestLifecycleNotificationsConfigEffectiveRoutes(t *testing.T) {
 }
 
 func TestLifecycleEventTypes(t *testing.T) {
-	if len(LifecycleEventTypes) != 12 {
-		t.Fatalf("len(LifecycleEventTypes) = %d, want 12", len(LifecycleEventTypes))
+	// Regression: the vocabulary also listed the concrete failure kinds, which
+	// exist only as task_run_events.failure_type. Route matching compares
+	// against event_type, so a checkbox for one of them built a route that
+	// could never fire while the test-send endpoint reported success.
+	want := []string{"agent_started", "pr_opened", "agent_stopped", "agent_idle", "done_without_pr"}
+	if !reflect.DeepEqual(LifecycleEventTypes, want) {
+		t.Fatalf("LifecycleEventTypes = %v, want %v", LifecycleEventTypes, want)
 	}
 	for _, event := range LifecycleEventTypes {
 		if !IsLifecycleEventType(event) {
 			t.Errorf("IsLifecycleEventType(%q) = false, want true", event)
 		}
 	}
-	if IsLifecycleEventType("not_an_event") {
-		t.Fatal("IsLifecycleEventType(not_an_event) = true, want false")
+	for _, event := range []string{"not_an_event", "provision_failed", "timeout", "unknown_failure"} {
+		if IsLifecycleEventType(event) {
+			t.Errorf("IsLifecycleEventType(%q) = true, want false", event)
+		}
 	}
 }
 

--- a/pkg/types/validation_notifications_test.go
+++ b/pkg/types/validation_notifications_test.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
@@ -43,6 +44,58 @@ func TestValidateNotificationsConfig(t *testing.T) {
 				Notifiers: slack(),
 				Lifecycle: &LifecycleNotificationsConfig{Via: "eng-agents"},
 			},
+		},
+		{
+			name: "valid lifecycle routes",
+			cfg: &NotificationsConfig{
+				Notifiers: map[string]NotifierConfig{
+					"eng-agents": {Type: "slack"},
+					"failures":   {Type: "slack"},
+				},
+				Lifecycle: &LifecycleNotificationsConfig{Routes: []LifecycleRoute{
+					{Via: "eng-agents", Events: []string{"agent_started", "pr_opened"}},
+					{Via: "failures"},
+				}},
+			},
+		},
+		{
+			name: "via and routes cannot both be set",
+			cfg: &NotificationsConfig{
+				Notifiers: slack(),
+				Lifecycle: &LifecycleNotificationsConfig{Via: "eng-agents", Routes: []LifecycleRoute{{Via: "eng-agents"}}},
+			},
+			wantErr: true,
+			errMsg:  "via and routes cannot both be set",
+		},
+		{
+			name:    "route without via",
+			cfg:     &NotificationsConfig{Notifiers: slack(), Lifecycle: &LifecycleNotificationsConfig{Routes: []LifecycleRoute{{}}}},
+			wantErr: true,
+			errMsg:  "routes[0]: via is required",
+		},
+		{
+			name:    "route via naming an undefined notifier",
+			cfg:     &NotificationsConfig{Notifiers: slack(), Lifecycle: &LifecycleNotificationsConfig{Routes: []LifecycleRoute{{Via: "typo"}}}},
+			wantErr: true,
+			errMsg:  "does not name a configured notifier",
+		},
+		{
+			name:    "route with unsupported event",
+			cfg:     &NotificationsConfig{Notifiers: slack(), Lifecycle: &LifecycleNotificationsConfig{Routes: []LifecycleRoute{{Via: "eng-agents", Events: []string{"not_an_event"}}}}},
+			wantErr: true,
+			errMsg:  "not a supported lifecycle event type",
+		},
+		{
+			name:    "route with duplicate event",
+			cfg:     &NotificationsConfig{Notifiers: slack(), Lifecycle: &LifecycleNotificationsConfig{Routes: []LifecycleRoute{{Via: "eng-agents", Events: []string{"agent_started", "agent_started"}}}}},
+			wantErr: true,
+			errMsg:  "event \"agent_started\" is duplicated",
+		},
+		{
+			name:    "duplicate route via",
+			cfg:     &NotificationsConfig{Notifiers: slack(), Lifecycle: &LifecycleNotificationsConfig{Routes: []LifecycleRoute{{Via: "eng-agents"}, {Via: "eng-agents"}}}},
+			wantErr: true,
+			errMsg:  "via \"eng-agents\" is duplicated",
 		},
 		{
 			name: "notifier without a type",
@@ -156,6 +209,66 @@ func TestValidateNotificationsConfig(t *testing.T) {
 				t.Fatalf("ValidateNotificationsConfig() error = %v", err)
 			}
 		})
+	}
+}
+
+func TestLifecycleNotificationsRoutesYAMLRoundTrip(t *testing.T) {
+	const source = "routes:\n  - via: eng-agents\n    events:\n      - agent_started\n      - pr_opened\n  - via: failures\n"
+	var lifecycle LifecycleNotificationsConfig
+	if err := yaml.Unmarshal([]byte(source), &lifecycle); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	want := []LifecycleRoute{
+		{Via: "eng-agents", Events: []string{"agent_started", "pr_opened"}},
+		{Via: "failures"},
+	}
+	if !reflect.DeepEqual(lifecycle.Routes, want) {
+		t.Fatalf("Routes = %#v, want %#v", lifecycle.Routes, want)
+	}
+	data, err := yaml.Marshal(&lifecycle)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var roundTripped LifecycleNotificationsConfig
+	if err := yaml.Unmarshal(data, &roundTripped); err != nil {
+		t.Fatalf("round-trip unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(roundTripped.Routes, want) {
+		t.Fatalf("round-trip Routes = %#v, want %#v", roundTripped.Routes, want)
+	}
+}
+
+func TestLifecycleNotificationsConfigEffectiveRoutes(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *LifecycleNotificationsConfig
+		want []LifecycleRoute
+	}{
+		{name: "nil", cfg: nil},
+		{name: "empty", cfg: &LifecycleNotificationsConfig{}},
+		{name: "legacy via", cfg: &LifecycleNotificationsConfig{Via: "eng-agents"}, want: []LifecycleRoute{{Via: "eng-agents"}}},
+		{name: "routes", cfg: &LifecycleNotificationsConfig{Routes: []LifecycleRoute{{Via: "eng-agents", Events: []string{"agent_started"}}}}, want: []LifecycleRoute{{Via: "eng-agents", Events: []string{"agent_started"}}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cfg.EffectiveRoutes(); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("EffectiveRoutes() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLifecycleEventTypes(t *testing.T) {
+	if len(LifecycleEventTypes) != 12 {
+		t.Fatalf("len(LifecycleEventTypes) = %d, want 12", len(LifecycleEventTypes))
+	}
+	for _, event := range LifecycleEventTypes {
+		if !IsLifecycleEventType(event) {
+			t.Errorf("IsLifecycleEventType(%q) = false, want true", event)
+		}
+	}
+	if IsLifecycleEventType("not_an_event") {
+		t.Fatal("IsLifecycleEventType(not_an_event) = true, want false")
 	}
 }
 

--- a/pkg/types/validation_notifications_test.go
+++ b/pkg/types/validation_notifications_test.go
@@ -106,6 +106,26 @@ func TestValidateNotificationsConfig(t *testing.T) {
 			errMsg:  "type is required",
 		},
 		{
+			// The hub keys per-route delivery state by notifier name and
+			// reserves "\x00legacy" for the legacy un-routed rows: a name
+			// carrying a NUL forges that sentinel and fences an event for every
+			// other route. A name carrying a newline forges hub log lines.
+			name: "notifier name with a NUL",
+			cfg: &NotificationsConfig{
+				Notifiers: map[string]NotifierConfig{"\x00legacy": {Type: "slack"}},
+			},
+			wantErr: true,
+			errMsg:  "cannot contain control characters",
+		},
+		{
+			name: "notifier name with a newline",
+			cfg: &NotificationsConfig{
+				Notifiers: map[string]NotifierConfig{"eng\nagents": {Type: "slack"}},
+			},
+			wantErr: true,
+			errMsg:  "cannot contain control characters",
+		},
+		{
 			name: "lifecycle enabled without via",
 			cfg: &NotificationsConfig{
 				Notifiers: slack(),

--- a/web/app/settings/[[...parts]]/sections.ts
+++ b/web/app/settings/[[...parts]]/sections.ts
@@ -9,6 +9,7 @@ export const VALID_SECTIONS = [
   "secrets",
   "ai-config",
   "mcp-servers",
+  "notifier",
   "analytics",
   "doctor",
   "troubleshoot",

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -4676,13 +4676,27 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
   // the same block the moment alerts are enabled — so the screen has to render
   // the route and offer a way to drop it. Silently dropping it in buildPatch
   // would delete config the operator never saw.
-  const orphanRoutes = routes.filter((route) => !notifiers[route.via])
+  // One entry per via: "Remove route" drops every route naming it, and a
+  // hand-written block can name the same missing notifier twice.
+  const orphanRoutes = routes.filter(
+    (route, i) => !notifiers[route.via] && routes.findIndex((other) => other.via === route.via) === i,
+  )
   // A route whose allow-list names alert types this hub does not support. The
   // hub accepts it on disk while alerts are paused — routes are only validated
   // once enabled — and rejects the whole block the moment they are turned on,
   // exactly like an orphan route, so the master switch has to be gated on it
   // too rather than offering a save that is certain to fail.
   const unsupportedRoutes = routes.filter((route) => unknownEvents(route.events).length > 0)
+  // A `via` routed twice, or an allow-list naming the same alert type twice.
+  // Both are rejected only once alerts are enabled, so a hand-written block can
+  // hold them while paused — and the screen renders one card per notifier
+  // showing only the FIRST matching route, so the hub's error names a routes[]
+  // index that is nowhere on the page. Gated like the orphan and unsupported
+  // cases; saveChannel collapses both so "open Edit and save" actually clears it.
+  const duplicatedVias = new Set(routes.map((route) => route.via).filter((via, i, all) => all.indexOf(via) !== i))
+  const hasDuplicateEvents = (events?: string[]) => new Set(events || []).size !== (events || []).length
+  const isDuplicated = (name: string) => duplicatedVias.has(name) || hasDuplicateEvents(routeFor(name)?.events)
+  const duplicateRoutes = routes.filter((route) => duplicatedVias.has(route.via) || hasDuplicateEvents(route.events))
   // A hub that has never had a lifecycle block: routing its first channel turns
   // alerts on. This is deliberately NOT inferred from (enabled=false, routes=[]),
   // which an operator reaches by muting the master switch and then removing the
@@ -4782,7 +4796,10 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     setFormRouted(Boolean(route))
     // Only supported types can be checked, so only those are seeded; the rest
     // are surfaced separately rather than carried invisibly back out on save.
-    setFormEvents(knownEvents(route?.events))
+    // De-duplicated because a checkbox can only be on or off: a type listed
+    // twice on disk would otherwise be counted twice in the dialog summary and
+    // re-sent verbatim by a save that changed nothing.
+    setFormEvents([...new Set(knownEvents(route?.events))])
     setFormDroppedEvents(unknownEvents(route?.events))
     setFormError("")
     setEditName(name)
@@ -4901,13 +4918,21 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     // later-added alert type keeps reaching the channel. formEvents holds only
     // supported types, so any unsupported entry the route arrived with is
     // dropped here — the dialog says so before the operator saves.
-    const events = isAllAlerts(formEvents) ? [] : formEvents
+    // De-duplicated for the same reason the dialog seeds a Set: the hub rejects
+    // a repeated event once alerts are enabled, and the checkboxes have no way
+    // to express — or clear — a type listed twice.
+    const events = isAllAlerts(formEvents) ? [] : [...new Set(formEvents)]
     // Route ORDER is meaningful — a test send without an explicit `via` uses the
     // first effective route — so editing an already-routed channel updates it in
-    // place instead of removing and re-appending it.
+    // place instead of removing and re-appending it. Every OTHER entry naming
+    // the same via collapses into that one: a hand-written block can route a
+    // via twice, and rewriting only the first match would leave behind the
+    // duplicate the hub rejects, with no way to reach it from this screen.
     const routedIndex = routes.findIndex((route) => route.via === name)
     const nextRoutes = formRouted && routedIndex >= 0
-      ? routes.map((route, i) => (i === routedIndex ? { via: name, events } : route))
+      ? routes
+        .filter((route, i) => route.via !== name || i === routedIndex)
+        .map((route) => (route.via === name ? { via: name, events } : route))
       : routes.filter((route) => route.via !== name)
     if (formRouted && routedIndex < 0) nextRoutes.push({ via: name, events })
 
@@ -5062,17 +5087,20 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                   ? "Remove the routes pointing at deleted channels below — the hub refuses to enable alerts while one is left."
                   : unsupportedRoutes.length > 0
                     ? "Open Edit on the channels flagged below and save — the hub refuses to enable alerts while a route lists an unsupported alert type."
-                    : "The master switch. Turn it off to mute every channel without losing your routing."}
+                    : duplicateRoutes.length > 0
+                      ? "Open Edit on the channels flagged below and save — the hub refuses to enable alerts while a channel or an alert type is routed twice."
+                      : "The master switch. Turn it off to mute every channel without losing your routing."}
             </p>
           </div>
           <Switch
             checked={enabled}
             // Gated on every shape the hub rejects when a block is enabled: no
-            // routes, a route naming a notifier that no longer exists, and a
-            // route whose allow-list carries an alert type this hub does not
-            // support — all three in the vocabulary of hub.yaml (`via`,
-            // `events`) rather than of this screen.
-            disabled={saving || routedCount === 0 || orphanRoutes.length > 0 || unsupportedRoutes.length > 0}
+            // routes, a route naming a notifier that no longer exists, a route
+            // whose allow-list carries an alert type this hub does not support,
+            // and the same `via` or the same event listed twice — all in the
+            // vocabulary of hub.yaml (`via`, `events`) rather than of this
+            // screen.
+            disabled={saving || routedCount === 0 || orphanRoutes.length > 0 || unsupportedRoutes.length > 0 || duplicateRoutes.length > 0}
             title={
               routedCount === 0
                 ? "Add a channel and route it to alerts first"
@@ -5080,7 +5108,9 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                   ? "Remove the routes pointing at deleted channels first"
                   : unsupportedRoutes.length > 0
                     ? "Drop the unsupported alert types from the flagged channels first — open Edit and save"
-                    : undefined
+                    : duplicateRoutes.length > 0
+                      ? "Collapse the duplicated routing on the flagged channels first — open Edit and save"
+                      : undefined
             }
             // Invalidated only once the hub has taken the change, exactly as
             // saveChannel/removeChannel do it: a rejected save leaves every
@@ -5150,6 +5180,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
               const route = routeFor(name)
               const test = tests[name]
               const routeUnknownEvents = unknownEvents(route?.events)
+              const routeDuplicated = isDuplicated(name)
               const testEvent = testEventFor(name)
               const canTest = enabled && Boolean(testEvent) && !saving
               // Rendered as text, not as the disabled button's `title`: the
@@ -5195,7 +5226,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                           </span>
                         ) : (
                           <span className="text-xs bg-muted text-muted-foreground px-2 py-1 rounded font-medium">
-                            {knownEvents(route.events).length} of {eventTypes.length} alert types
+                            {new Set(knownEvents(route.events)).size} of {eventTypes.length} alert types
                           </span>
                         )}
                       </div>
@@ -5204,6 +5235,14 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                           This route also lists {routeUnknownEvents.length === 1 ? "an alert type" : "alert types"} this hub does not support (
                           <span className="font-mono">{routeUnknownEvents.join(", ")}</span>
                           ). Lifecycle alerts cannot be turned on until {routeUnknownEvents.length === 1 ? "it is" : "they are"} gone — open Edit and save to drop {routeUnknownEvents.length === 1 ? "it" : "them"}.
+                        </p>
+                      )}
+                      {routeDuplicated && (
+                        <p className="text-xs text-amber-400 mt-2">
+                          {duplicatedVias.has(name)
+                            ? "This channel is routed more than once on disk — the card shows only the first entry."
+                            : "This route lists the same alert type more than once on disk."}{" "}
+                          Lifecycle alerts cannot be turned on until the duplicate is gone — open Edit and save to collapse it.
                         </p>
                       )}
                       {testBlockedReason && (

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -4626,10 +4626,22 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
         : []
   ).map((route) => ({ ...route, via: (route.via || "").trim() }))
   const routeFor = (name: string) => routes.find((r) => r.via === name)
+  // The types a route names that this hub actually supports, and the rest.
+  // ValidateNotificationsConfig checks routes[].events against
+  // IsLifecycleEventType only AFTER the disabled-lifecycle short-circuit, so a
+  // hand-written hub.yaml with alerts paused can legitimately hold names the
+  // hub no longer knows. The dialog can only ever render supported types, so
+  // counting the others would make the card badge disagree with the checkboxes
+  // and let a test send pick an event the hub rejects.
+  const knownEvents = (events?: string[]) => (events || []).filter((eventType) => eventTypes.includes(eventType))
+  const unknownEvents = (events?: string[]) => (events || []).filter((eventType) => !eventTypes.includes(eventType))
   // The predicate saveChannel stores by: an allow-list naming every type is no
   // filter at all. Shared by the card badge and the dialog so the same route
-  // cannot read as filtered on one and unfiltered on the other.
-  const isAllAlerts = (events?: string[]) => !events?.length || events.length === eventTypes.length
+  // cannot read as filtered on one and unfiltered on the other. Membership, not
+  // length: a hand-written list of five names the hub no longer knows is not
+  // "all alerts", and reading it as one would rewrite the route to receive-all
+  // on the next save instead of dropping just the stale entries.
+  const isAllAlerts = (events?: string[]) => !events?.length || eventTypes.every((eventType) => events.includes(eventType))
   // A route whose notifier is gone. The hub deliberately accepts this on disk
   // while alerts are paused ("an operator who mutes alerts and then deletes the
   // notifier must not be left with a hub that refuses to load"), but it rejects
@@ -4668,6 +4680,12 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
   const [formMinSendInterval, setFormMinSendInterval] = useState("")
   const [formRouted, setFormRouted] = useState(true)
   const [formEvents, setFormEvents] = useState<string[]>([])
+  // Allow-list entries the edited route holds that this hub does not support.
+  // They are kept out of formEvents — no checkbox can ever represent them — so
+  // the dialog has to name them itself, or saving drops config the operator
+  // never saw and the master switch later 400s on a value the screen never
+  // showed.
+  const [formDroppedEvents, setFormDroppedEvents] = useState<string[]>([])
   const [formError, setFormError] = useState("")
   const [tests, setTests] = useState<Record<string, TestState>>({})
   // Save failures the dialog can no longer show, keyed by the channel the save
@@ -4676,6 +4694,11 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
   // so dropping the message leaves the operator believing a save that failed
   // went through.
   const [saveErrors, setSaveErrors] = useState<Record<string, string>>({})
+  // The same failure for a channel that has no card to land on: a rejected Add
+  // created no notifier, so keying it into saveErrors above would render it
+  // nowhere at all. Painted both inside the dialog and above the channel list,
+  // since the operator may close the dialog that replaced the failed one.
+  const [detachedSaveError, setDetachedSaveError] = useState("")
 
   // Reconcile the stored clamp against the config actually loaded: it records a
   // pause this screen imposed for an empty route set, so a config that HAS
@@ -4687,7 +4710,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
 
   const resetForm = () => {
     setFormName(""); setFormChannel(""); setFormTokenSecret(""); setFormMinSendInterval("")
-    setFormRouted(true); setFormEvents([]); setFormError(""); setEditName(null)
+    setFormRouted(true); setFormEvents([]); setFormDroppedEvents([]); setFormError(""); setEditName(null)
   }
 
   // Identifies the dialog a save was started from. An in-flight PATCH must not
@@ -4723,7 +4746,10 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     setFormTokenSecret(notifier.token_secret || "")
     setFormMinSendInterval(notifier.min_send_interval || "")
     setFormRouted(Boolean(route))
-    setFormEvents(route?.events ? [...route.events] : [])
+    // Only supported types can be checked, so only those are seeded; the rest
+    // are surfaced separately rather than carried invisibly back out on save.
+    setFormEvents(knownEvents(route?.events))
+    setFormDroppedEvents(unknownEvents(route?.events))
     setFormError("")
     setEditName(name)
     setModalMode("edit")
@@ -4834,8 +4860,10 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
       },
     }
     // Every type checked is the same thing as no filter; store it as one so a
-    // later-added alert type keeps reaching the channel.
-    const events = formEvents.length === eventTypes.length ? [] : formEvents
+    // later-added alert type keeps reaching the channel. formEvents holds only
+    // supported types, so any unsupported entry the route arrived with is
+    // dropped here — the dialog says so before the operator saves.
+    const events = isAllAlerts(formEvents) ? [] : formEvents
     // Route ORDER is meaningful — a test send without an explicit `via` uses the
     // first effective route — so editing an already-routed channel updates it in
     // place instead of removing and re-appending it.
@@ -4856,8 +4884,17 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
       setTests((current) => { const { [name]: _stale, ...rest } = current; return rest })
     }
     setSaveErrors((current) => { const { [name]: _cleared, ...rest } = current; return rest })
+    setDetachedSaveError("")
     if (generation !== saveGeneration.current) {
-      if (failure) setSaveErrors((current) => ({ ...current, [name]: failure }))
+      // The dialog this save was started from is gone, so the failure has to
+      // land somewhere else. A rejected edit leaves the channel in place and
+      // its card carries the reason; a rejected ADD created no notifier, so
+      // there is no card and keying it by name would render the message
+      // nowhere — the operator would read a silently failed add as a success.
+      if (failure) {
+        if (notifiers[name]) setSaveErrors((current) => ({ ...current, [name]: failure }))
+        else setDetachedSaveError(`Adding channel "${name}" failed: ${failure}`)
+      }
       return
     }
     if (failure) { setFormError(failure); return }
@@ -4902,7 +4939,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
   function testEventFor(name: string): string | null {
     const route = routeFor(name)
     if (!route) return null
-    const allowed = route.events?.length ? route.events : eventTypes
+    const allowed = route.events?.length ? knownEvents(route.events) : eventTypes
     const candidates = allowed.filter((eventType) => !isEventMuted(eventType))
     if (candidates.length === 0) return null
     return candidates.includes("agent_started") ? "agent_started" : candidates[0]
@@ -4942,7 +4979,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
   const receivingCount = routes.filter(
     (route) =>
       notifiers[route.via] &&
-      (route.events?.length ? route.events : eventTypes).some((eventType) => !isEventMuted(eventType)),
+      (route.events?.length ? knownEvents(route.events) : eventTypes).some((eventType) => !isEventMuted(eventType)),
   ).length
   // Same predicate saveChannel stores by: every type checked is persisted as
   // the empty allow-list, so the summary must call it "all alerts" too — or it
@@ -5053,6 +5090,12 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
       {/* Channels */}
       <div className="space-y-2">
         <h3 className="text-sm font-medium">Channels</h3>
+        {detachedSaveError && (
+          <div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+            <AlertTriangle className="size-3.5 mt-px shrink-0" />
+            <span className="break-words">{detachedSaveError}</span>
+          </div>
+        )}
         {names.length === 0 ? (
           <p className="text-sm text-muted-foreground px-4 py-6 text-center border border-border rounded-lg">
             No channels configured. Add one to start receiving alerts in Slack.
@@ -5063,6 +5106,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
               const notifier = notifiers[name]
               const route = routeFor(name)
               const test = tests[name]
+              const routeUnknownEvents = unknownEvents(route?.events)
               const testEvent = testEventFor(name)
               const canTest = enabled && Boolean(testEvent) && !saving
               // Rendered as text, not as the disabled button's `title`: the
@@ -5108,10 +5152,17 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                           </span>
                         ) : (
                           <span className="text-xs bg-muted text-muted-foreground px-2 py-1 rounded font-medium">
-                            {route.events?.length} of {eventTypes.length} alert types
+                            {knownEvents(route.events).length} of {eventTypes.length} alert types
                           </span>
                         )}
                       </div>
+                      {routeUnknownEvents.length > 0 && (
+                        <p className="text-xs text-amber-400 mt-2">
+                          This route also lists {routeUnknownEvents.length === 1 ? "an alert type" : "alert types"} this hub does not support (
+                          <span className="font-mono">{routeUnknownEvents.join(", ")}</span>
+                          ). Lifecycle alerts cannot be turned on until {routeUnknownEvents.length === 1 ? "it is" : "they are"} gone — open Edit and save to drop {routeUnknownEvents.length === 1 ? "it" : "them"}.
+                        </p>
+                      )}
                       {testBlockedReason && (
                         <p className="text-xs text-muted-foreground mt-2">{testBlockedReason}</p>
                       )}
@@ -5335,6 +5386,14 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                     </div>
                   </div>
 
+                  {formDroppedEvents.length > 0 && (
+                    <p className="text-xs text-amber-400 rounded-md border border-amber-500/20 bg-amber-500/10 px-3 py-2">
+                      This route also lists {formDroppedEvents.length === 1 ? "an alert type" : "alert types"} this hub does not support (
+                      <span className="font-mono">{formDroppedEvents.join(", ")}</span>
+                      ), so {formDroppedEvents.length === 1 ? "it has" : "they have"} no checkbox below and nothing is ever delivered for {formDroppedEvents.length === 1 ? "it" : "them"}. Saving drops {formDroppedEvents.length === 1 ? "it" : "them"} — the hub refuses to enable lifecycle alerts until then.
+                    </p>
+                  )}
+
                   <div className="space-y-1">
                     {eventTypes.map((eventType) => {
                       const checked = formEvents.includes(eventType)
@@ -5376,6 +5435,16 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
           <div className="border-t border-border">
             {/* The error sits with the buttons, never below the fold of a long
                 scrolling form. */}
+            {/* A failure from the save that THIS dialog replaced. The channel
+                list behind the overlay carries it too, but the operator is
+                looking at the dialog — and its message names the channel, so
+                it cannot be mistaken for a rejection of the form on screen. */}
+            {detachedSaveError && (
+              <div className="mx-5 mt-4 flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+                <AlertTriangle className="size-3.5 mt-px shrink-0" />
+                <span className="break-words">{detachedSaveError}</span>
+              </div>
+            )}
             {formError && (
               <div className="mx-5 mt-4 flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
                 <AlertTriangle className="size-3.5 mt-px shrink-0" />

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -370,6 +370,29 @@ export default function SettingsSectionPage() {
     }
   }
 
+  // save(), but handing the failure message back to the caller. The page-level
+  // banner lives inside <main>, which sits behind a modal overlay — a section
+  // that saves from its own dialog has to render the error there instead, or
+  // the button looks dead.
+  async function saveReportingError(patch: object): Promise<string | null> {
+    setSaving(true)
+    setError("")
+    setSuccess("")
+    try {
+      await patchSettings(patch)
+      setSuccess("Saved")
+      await load()
+      setTimeout(() => setSuccess(""), 2000)
+      return null
+    } catch (e) {
+      const message = e instanceof Error ? e.message : "Save failed"
+      setError(message)
+      return message
+    } finally {
+      setSaving(false)
+    }
+  }
+
   // Silent save: patches without the global 'Saved' banner (used for toggle-style updates)
   async function saveSilent(patch: object) {
     try {
@@ -526,7 +549,7 @@ export default function SettingsSectionPage() {
             <MCPServersSection settings={settings} onSave={save} saving={saving} />
           )}
           {settings && section === "notifier" && (
-            <NotifierSection settings={settings} onSave={save} saving={saving} />
+            <NotifierSection settings={settings} onSave={saveReportingError} saving={saving} />
           )}
           {section === "ai-config" && (
             <AIConfigSection />
@@ -4496,7 +4519,7 @@ async function sendTestNotification(eventType: string, via: string): Promise<voi
 
 type TestState = { status: "sending" | "ok" | "error"; message: string }
 
-function NotifierSection({ settings, onSave, saving }: { settings: SettingsData; onSave: (p: object) => Promise<boolean>; saving: boolean }) {
+function NotifierSection({ settings, onSave, saving }: { settings: SettingsData; onSave: (p: object) => Promise<string | null>; saving: boolean }) {
   const lifecycle = settings.notifications?.lifecycle
   const notifiers = settings.notifications?.notifiers || {}
   const names = Object.keys(notifiers).sort((a, b) => a.localeCompare(b))
@@ -4571,13 +4594,18 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
       if (notifier.min_send_interval) out.min_send_interval = notifier.min_send_interval
       outNotifiers[name] = out
     }
+    // Always an array: sending routes is what clears the legacy `via`.
+    const outRoutes = (next.routes ?? routes).map((route) => ({
+      via: route.via,
+      events: route.events?.length ? route.events : [],
+    }))
     const outLifecycle: Record<string, unknown> = {
-      enabled: next.enabled ?? enabled,
-      // Always an array: sending routes is what clears the legacy `via`.
-      routes: (next.routes ?? routes).map((route) => ({
-        via: route.via,
-        events: route.events?.length ? route.events : [],
-      })),
+      // The hub rejects an enabled lifecycle block with no routes ("via is
+      // required when enabled") and this screen never exposes `via`, so losing
+      // the last route pauses alerts instead of failing the save with a message
+      // about a field that is not on the page.
+      enabled: outRoutes.length > 0 && (next.enabled ?? enabled),
+      routes: outRoutes,
       events: next.events ?? categoryEnabled,
     }
     if (lifecycle?.poll_interval) outLifecycle.pollInterval = lifecycle.poll_interval
@@ -4616,22 +4644,23 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     const nextRoutes = routes.filter((route) => route.via !== name)
     if (formRouted) nextRoutes.push({ via: name, events })
 
-    const ok = await onSave(buildPatch({ notifiers: nextNotifiers, routes: nextRoutes }))
-    if (ok) { setShowModal(false); resetForm() }
+    const failure = await onSave(buildPatch({ notifiers: nextNotifiers, routes: nextRoutes }))
+    if (failure) { setFormError(failure); return }
+    setShowModal(false)
+    resetForm()
   }
 
   async function removeChannel(name: string) {
     const nextNotifiers = { ...notifiers }
     delete nextNotifiers[name]
-    const ok = await onSave(buildPatch({
+    const failure = await onSave(buildPatch({
       notifiers: nextNotifiers,
       routes: routes.filter((route) => route.via !== name),
     }))
-    if (ok) {
-      setTests((current) => { const { [name]: _removed, ...rest } = current; return rest })
-      setShowModal(false)
-      resetForm()
-    }
+    if (failure) { setFormError(failure); return }
+    setTests((current) => { const { [name]: _removed, ...rest } = current; return rest })
+    setShowModal(false)
+    resetForm()
   }
 
   // The event a test send uses: something this channel is routed for and that
@@ -4664,7 +4693,13 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
   }
 
   const routedCount = routes.filter((route) => notifiers[route.via]).length
-  const formAllAlerts = formEvents.length === 0
+  // Same predicate saveChannel stores by: every type checked is persisted as
+  // the empty allow-list, so the summary must call it "all alerts" too — or it
+  // promises a filter the save is about to discard.
+  const formAllAlerts = formEvents.length === 0 || formEvents.length === eventTypes.length
+  // Routing this channel off (or removing it) pauses the hub when it is the
+  // last one left; buildPatch clears `enabled` rather than failing the save.
+  const otherRoutedCount = routes.filter((route) => route.via !== editName && notifiers[route.via]).length
 
   return (
     <div className="space-y-6">
@@ -4695,12 +4730,17 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
           <div>
             <div className="text-sm font-medium">Lifecycle alerts</div>
             <p className="text-xs text-muted-foreground mt-0.5">
-              The master switch. Turn it off to mute every channel without losing your routing.
+              {routedCount === 0
+                ? "Add a channel and route it before turning alerts on — there is nowhere to send them yet."
+                : "The master switch. Turn it off to mute every channel without losing your routing."}
             </p>
           </div>
           <Switch
             checked={enabled}
-            disabled={saving}
+            // Enabling with no routes is rejected by the hub, in the vocabulary
+            // of hub.yaml (`via`) rather than of this screen.
+            disabled={saving || routes.length === 0}
+            title={routes.length === 0 ? "Add a channel and route it to alerts first" : undefined}
             onCheckedChange={(checked) => onSave(buildPatch({ enabled: checked }))}
             aria-label="Enable lifecycle alerts"
           />
@@ -4890,6 +4930,12 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                 />
               </div>
 
+              {modalMode === "edit" && enabled && otherRoutedCount === 0 && (
+                <p className="text-xs text-amber-400 rounded-md border border-amber-500/20 bg-amber-500/10 px-3 py-2">
+                  This is the only channel receiving alerts. Removing it — or turning routing off — pauses lifecycle alerts for the whole hub until another channel is routed.
+                </p>
+              )}
+
               {!formRouted ? (
                 <p className="text-xs text-muted-foreground rounded-md border border-border bg-muted/20 px-3 py-2">
                   This channel stays configured but receives no lifecycle alerts.
@@ -4912,7 +4958,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                         </div>
                         <p className="text-xs text-muted-foreground">
                           {formAllAlerts
-                            ? "Nothing is checked, so this channel receives every alert type — including any new type added later."
+                            ? "This channel receives every alert type — including any new type added later."
                             : "Only the checked types reach this channel."}
                         </p>
                         {!formAllAlerts && (

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -4677,6 +4677,14 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
   // went through.
   const [saveErrors, setSaveErrors] = useState<Record<string, string>>({})
 
+  // Reconcile the stored clamp against the config actually loaded: it records a
+  // pause this screen imposed for an empty route set, so a config that HAS
+  // routes has already been repaired — by this browser or any other — and the
+  // flag must go before it can lift an `enabled:false` the operator chose.
+  useEffect(() => {
+    if (routes.length > 0) writeClampedPause(false)
+  }, [routes.length])
+
   const resetForm = () => {
     setFormName(""); setFormChannel(""); setFormTokenSecret(""); setFormMinSendInterval("")
     setFormRouted(true); setFormEvents([]); setFormError(""); setEditName(null)
@@ -4760,7 +4768,13 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     // the hub forever, contradicting the dialog's "until another channel is
     // routed". The flag is recorded here rather than inferred from the reloaded
     // config so a deliberate master-switch OFF survives a channel swap.
-    const wantEnabled = next.enabled ?? (enabled || readClampedPause() || neverConfigured)
+    // The clamp only carries meaning while the LOADED config still has no
+    // routes: once routing is restored anywhere else (hub.yaml, the CLI, a
+    // second operator, another device) the hub holds a pause the operator owns,
+    // and a stale flag here would flip alerts back on from the next unrelated
+    // save with nothing on screen announcing it.
+    const clampActive = routes.length === 0 && readClampedPause()
+    const wantEnabled = next.enabled ?? (enabled || clampActive || neverConfigured)
     const outLifecycle: Record<string, unknown> = {
       enabled: outRoutes.length > 0 && wantEnabled,
       routes: outRoutes,
@@ -4770,7 +4784,10 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     if (lifecycle?.idleAfter) outLifecycle.idleAfter = lifecycle.idleAfter
     return {
       patch: { notifications: { notifiers: outNotifiers, lifecycle: outLifecycle } },
-      clamp: outRoutes.length === 0 && wantEnabled,
+      // A hub that never had a lifecycle block and is saved with routing off is
+      // pausing nothing — that is the operator's own choice, not a pause this
+      // screen imposed — so it must not leave a clamp behind to lift later.
+      clamp: outRoutes.length === 0 && wantEnabled && !neverConfigured,
     }
   }
 
@@ -4819,8 +4836,14 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     // Every type checked is the same thing as no filter; store it as one so a
     // later-added alert type keeps reaching the channel.
     const events = formEvents.length === eventTypes.length ? [] : formEvents
-    const nextRoutes = routes.filter((route) => route.via !== name)
-    if (formRouted) nextRoutes.push({ via: name, events })
+    // Route ORDER is meaningful — a test send without an explicit `via` uses the
+    // first effective route — so editing an already-routed channel updates it in
+    // place instead of removing and re-appending it.
+    const routedIndex = routes.findIndex((route) => route.via === name)
+    const nextRoutes = formRouted && routedIndex >= 0
+      ? routes.map((route, i) => (i === routedIndex ? { via: name, events } : route))
+      : routes.filter((route) => route.via !== name)
+    if (formRouted && routedIndex < 0) nextRoutes.push({ via: name, events })
 
     const generation = saveGeneration.current
     const { persisted, message: failure } = await savePatch({ notifiers: nextNotifiers, routes: nextRoutes })
@@ -4912,6 +4935,15 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
   }
 
   const routedCount = routes.filter((route) => notifiers[route.via]).length
+  // What the header badge counts: a channel is only receiving alerts if some
+  // event type can actually reach it. The global category switches mute before
+  // routing, so a channel routed for nothing but muted types receives nothing —
+  // exactly what its own card already says, type by type.
+  const receivingCount = routes.filter(
+    (route) =>
+      notifiers[route.via] &&
+      (route.events?.length ? route.events : eventTypes).some((eventType) => !isEventMuted(eventType)),
+  ).length
   // Same predicate saveChannel stores by: every type checked is persisted as
   // the empty allow-list, so the summary must call it "all alerts" too — or it
   // promises a filter the save is about to discard.
@@ -4933,7 +4965,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
           </span>
           {enabled ? (
             <span className="text-xs bg-green-500/10 text-green-400 border border-green-500/20 px-2 py-1 rounded font-medium">
-              {routedCount} receiving alerts
+              {receivingCount} receiving alerts
             </span>
           ) : (
             <span className="text-xs bg-amber-500/10 text-amber-400 border border-amber-500/20 px-2 py-1 rounded font-medium">

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -3329,11 +3329,20 @@ function SecretsSection({ settings, workspace }: { settings: SettingsData | null
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
 
+  // Two stores live behind this screen and only one of them was reachable: the
+  // workspace file, and hub.yaml's top-level `secrets`. Hub secrets are what
+  // notifier token_secret references resolve against, so without this scope a
+  // hub with any workspace has no way at all to create the secret the Notifier
+  // screen requires.
+  const [hubScope, setHubScope] = useState(!workspace)
+  const scoped = Boolean(workspace) && !hubScope
+
   const hubUrl = getHubUrl()
   const token = () => getAuthToken() || ""
-  const secretsPath = workspace ? `/api/workspaces/${encodeURIComponent(workspace)}/secrets` : "/api/secrets"
+  const secretsPath = scoped ? `/api/workspaces/${encodeURIComponent(workspace)}/secrets` : "/api/secrets"
 
   const refresh = useCallback(async () => {
+    setLoading(true)
     try {
       const res = await fetch(`${hubUrl}${secretsPath}`, { headers: { Authorization: `Bearer ${token()}` } })
       if (res.ok) {
@@ -3382,9 +3391,17 @@ function SecretsSection({ settings, workspace }: { settings: SettingsData | null
     <div className="space-y-6">
       <div>
         <h2 className="text-base font-semibold mb-1">Secrets</h2>
-        <p className="text-sm text-muted-foreground mb-6">
-          Named secrets for workspace <code className="bg-muted px-1 rounded text-xs">{workspace || "default"}</code>. Values are stored on the hub and referenced from workspace env or workflow secret refs.
+        <p className="text-sm text-muted-foreground mb-4">
+          {scoped
+            ? <>Named secrets for workspace <code className="bg-muted px-1 rounded text-xs">{workspace}</code>. Values are stored on the hub and referenced from workspace env or workflow secret refs.</>
+            : <>Hub-wide secrets, stored in the hub config. These are what hub-level references resolve against — notifier bot tokens (Settings → Notifier) among them.</>}
         </p>
+        {Boolean(workspace) && (
+          <div className="flex items-center gap-1 mb-6">
+            <Button size="sm" variant={scoped ? "secondary" : "ghost"} onClick={() => setHubScope(false)}>Workspace</Button>
+            <Button size="sm" variant={scoped ? "ghost" : "secondary"} onClick={() => setHubScope(true)}>Hub</Button>
+          </div>
+        )}
       </div>
 
       <div className="border border-border rounded-lg divide-y divide-border">
@@ -4519,6 +4536,34 @@ async function sendTestNotification(eventType: string, via: string): Promise<voi
 
 type TestState = { status: "sending" | "ok" | "error"; message: string }
 
+// Records that the Notifier screen itself cleared `enabled` because the route
+// set went empty — the pause is ours, not the operator's, and the next save
+// that routes a channel must lift it. It lives in sessionStorage rather than in
+// component state because NotifierSection unmounts on every navigation inside
+// Settings (and on reload): a clamp forgotten there latches the `enabled:false`
+// this screen wrote on its own initiative, so re-routing a channel would no
+// longer restore alerts — exactly what the edit dialog promises it does. The
+// stored value is the hub URL, so the clamp never leaks across hubs.
+const CLAMPED_PAUSE_STORAGE_KEY = "elasticclaw:notifier-clamped-pause"
+
+function readClampedPause(): boolean {
+  try {
+    return sessionStorage.getItem(CLAMPED_PAUSE_STORAGE_KEY) === getHubUrl()
+  } catch {
+    return false
+  }
+}
+
+function writeClampedPause(clamped: boolean): void {
+  try {
+    if (clamped) sessionStorage.setItem(CLAMPED_PAUSE_STORAGE_KEY, getHubUrl())
+    else sessionStorage.removeItem(CLAMPED_PAUSE_STORAGE_KEY)
+  } catch {
+    // Storage unavailable (private mode): the clamp degrades to not existing,
+    // which is what the screen did before it was persisted at all.
+  }
+}
+
 function NotifierSection({ settings, onSave, saving }: { settings: SettingsData; onSave: (p: object) => Promise<string | null>; saving: boolean }) {
   const lifecycle = settings.notifications?.lifecycle
   const notifiers = settings.notifications?.notifiers || {}
@@ -4533,12 +4578,18 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     agentIdle: lifecycle?.events?.agentIdle ?? true,
   }
   // A legacy single-channel `via` reads as one route over every event; saving
-  // any change migrates it to routes.
-  const routes: LifecycleRouteView[] = lifecycle?.routes?.length
-    ? lifecycle.routes
-    : lifecycle?.via
-      ? [{ via: lifecycle.via, events: [] }]
-      : []
+  // any change migrates it to routes. `via` is trimmed exactly where the hub
+  // trims it (ValidateNotificationsConfig, lifecycleNotifierTick): a `via` with
+  // surrounding whitespace is valid on disk and delivers normally, so matching
+  // it raw here would render a working channel as an unroutable orphan whose
+  // only offered remedy — "Remove route" — silently pauses alerts hub-wide.
+  const routes: LifecycleRouteView[] = (
+    lifecycle?.routes?.length
+      ? lifecycle.routes
+      : lifecycle?.via
+        ? [{ via: lifecycle.via, events: [] }]
+        : []
+  ).map((route) => ({ ...route, via: (route.via || "").trim() }))
   const routeFor = (name: string) => routes.find((r) => r.via === name)
   // A route whose notifier is gone. The hub deliberately accepts this on disk
   // while alerts are paused ("an operator who mutes alerts and then deletes the
@@ -4574,6 +4625,12 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
   const [formEvents, setFormEvents] = useState<string[]>([])
   const [formError, setFormError] = useState("")
   const [tests, setTests] = useState<Record<string, TestState>>({})
+  // Save failures the dialog can no longer show, keyed by the channel the save
+  // was for. A rejected PATCH whose dialog has meanwhile been replaced has
+  // nowhere else to land: the page-level banner lives under the Radix overlay,
+  // so dropping the message leaves the operator believing a save that failed
+  // went through.
+  const [saveErrors, setSaveErrors] = useState<Record<string, string>>({})
 
   const resetForm = () => {
     setFormName(""); setFormChannel(""); setFormTokenSecret("")
@@ -4585,13 +4642,6 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
   // reopened on another channel — that discards unsaved form state and blames
   // the wrong channel.
   const saveGeneration = useRef(0)
-
-  // Set only when buildPatch itself had to clear `enabled` because the route set
-  // went empty. Deriving that from the reloaded config instead (enabled=false
-  // with no routes) cannot tell our clamp from an operator who muted the master
-  // switch and then removed the last channel — and re-routing a channel would
-  // then silently un-mute a hub the operator deliberately paused.
-  const clampedPause = useRef(false)
 
   // Invalidates in-flight test sends. A result that lands after the channel's
   // destination or routing changed describes a message that went somewhere else
@@ -4640,14 +4690,14 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     // required when enabled") and this screen never exposes `via`, so losing the
     // last route pauses alerts instead of failing the save with a message about
     // a field that is not on the page. That pause is ours, not the operator's,
-    // and `clampedPause` lifts it on the next save that routes a channel again.
+    // and the clamp lifts it on the next save that routes a channel again.
     // Without it the `false` we wrote latches — every later save re-sends the
     // stale value read back from GET — and a plain channel swap silently mutes
     // the hub forever, contradicting the dialog's "until another channel is
     // routed". The flag is recorded here rather than inferred from the reloaded
     // config so a deliberate master-switch OFF survives a channel swap.
-    const wantEnabled = next.enabled ?? (enabled || clampedPause.current || neverConfigured)
-    clampedPause.current = outRoutes.length === 0 && wantEnabled
+    const wantEnabled = next.enabled ?? (enabled || readClampedPause() || neverConfigured)
+    writeClampedPause(outRoutes.length === 0 && wantEnabled)
     const outLifecycle: Record<string, unknown> = {
       enabled: outRoutes.length > 0 && wantEnabled,
       routes: outRoutes,
@@ -4695,7 +4745,11 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     // sitting on its card is about a message that went somewhere else.
     testGeneration.current++
     setTests((current) => { const { [name]: _stale, ...rest } = current; return rest })
-    if (generation !== saveGeneration.current) return
+    setSaveErrors((current) => { const { [name]: _cleared, ...rest } = current; return rest })
+    if (generation !== saveGeneration.current) {
+      if (failure) setSaveErrors((current) => ({ ...current, [name]: failure }))
+      return
+    }
     if (failure) { setFormError(failure); return }
     setShowModal(false)
   }
@@ -4710,7 +4764,13 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     }))
     testGeneration.current++
     setTests((current) => { const { [name]: _removed, ...rest } = current; return rest })
-    if (generation !== saveGeneration.current) return
+    setSaveErrors((current) => { const { [name]: _cleared, ...rest } = current; return rest })
+    if (generation !== saveGeneration.current) {
+      // The channel is still there — the remove was rejected — so its card can
+      // carry the reason.
+      if (failure) setSaveErrors((current) => ({ ...current, [name]: failure }))
+      return
+    }
     if (failure) { setFormError(failure); return }
     setShowModal(false)
   }
@@ -4951,6 +5011,12 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                       <span className="break-words">{test.message}</span>
                     </div>
                   )}
+                  {saveErrors[name] && (
+                    <div className="mt-3 flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+                      <AlertTriangle className="size-3.5 mt-px shrink-0" />
+                      <span className="break-words">Last save failed: {saveErrors[name]}</span>
+                    </div>
+                  )}
                 </div>
               )
             })}
@@ -5047,11 +5113,14 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
               </select>
               {secretMissing(formTokenSecret) ? (
                 <p className="text-xs text-amber-400 mt-1">
-                  No hub secret named <span className="font-mono">{formTokenSecret}</span> exists, so sends through this channel fail. Add it under Secrets, or pick another.
+                  No hub secret named <span className="font-mono">{formTokenSecret}</span> exists, so sends through this channel fail. Add it under Settings → Secrets → Hub, or pick another.
                 </p>
               ) : (
                 <p className="text-xs text-muted-foreground mt-1">
-                  The hub secret holding the Slack bot token (<span className="font-mono">xoxb-…</span>). Add it under Secrets first.
+                  {/* Channels are hub-wide, so the token must be a HUB secret —
+                      a workspace secret of the same name is a different store
+                      and never resolves here. */}
+                  The <strong>hub</strong> secret holding the Slack bot token (<span className="font-mono">xoxb-…</span>). Add it under Settings → Secrets → Hub first — workspace secrets are a separate store and are never read here.
                 </p>
               )}
             </div>

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -216,6 +216,11 @@ interface NotificationsView {
 // for an accepted one whose follow-up re-read failed.
 type SaveOutcome = { persisted: boolean; message: string | null }
 
+// What every screen says once the loaded settings can no longer be trusted. A
+// reload is the only repair: the snapshot the patches are built from is stale,
+// and this page has no other way to re-read it than the one that just failed.
+const STALE_SETTINGS_MESSAGE = "Reload the page before editing again — until then every save is refused, because it would re-send the settings this screen last read and revert what the hub now holds."
+
 async function fetchSettings(): Promise<SettingsData> {
   const hubUrl = getHubUrl()
   const token = getAuthToken() || ""
@@ -299,6 +304,13 @@ export default function SettingsSectionPage() {
 
   const [settings, setSettings] = useState<SettingsData | null>(null)
   const [saving, setSaving] = useState(false)
+  // Latched when a save landed but its follow-up re-read did not: `settings`
+  // then describes a hub that has already moved on, and every section builds
+  // its next patch from that snapshot — the next save would re-send the values
+  // this one replaced, recreating a channel the operator just deleted under a
+  // green "Saved". A ref, not state: the gate has to hold for a save started
+  // from the same render as the one that failed.
+  const staleSettings = useRef(false)
   const [error, setError] = useState("")
   const [success, setSuccess] = useState("")
   const [version, setVersion] = useState("")
@@ -370,6 +382,12 @@ export default function SettingsSectionPage() {
   // a re-read that failed after an accepted PATCH loses the record of a value
   // this screen wrote on its own initiative.
   async function runSave(patch: object): Promise<SaveOutcome> {
+    if (staleSettings.current) {
+      // Reporting it again is all this can do: the snapshot every patch is
+      // built from is stale, so sending one would revert whatever the save
+      // whose re-read failed had persisted.
+      return { persisted: false, message: STALE_SETTINGS_MESSAGE }
+    }
     setSaving(true)
     setError("")
     setSuccess("")
@@ -383,9 +401,10 @@ export default function SettingsSectionPage() {
         await load()
       } catch (e) {
         const reason = e instanceof Error ? e.message : "the settings could not be re-read"
+        staleSettings.current = true
         return {
           persisted: true,
-          message: `Saved, but reloading the settings failed (${reason}). Reload the page before editing again.`,
+          message: `Saved, but reloading the settings failed (${reason}). ${STALE_SETTINGS_MESSAGE}`,
         }
       }
       setSuccess("Saved")
@@ -3346,7 +3365,8 @@ function SecretsSection({ settings, workspace }: { settings: SettingsData | null
   const [newValue, setNewValue] = useState("")
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [loading, setLoading] = useState(true)
+  const [reloading, setReloading] = useState(true)
+  const [loadedPath, setLoadedPath] = useState("")
 
   // Two stores live behind this screen and only one of them was reachable: the
   // workspace file, and hub.yaml's top-level `secrets`. Hub secrets are what
@@ -3364,6 +3384,12 @@ function SecretsSection({ settings, workspace }: { settings: SettingsData | null
   const hubUrl = getHubUrl()
   const token = () => getAuthToken() || ""
   const secretsPath = scoped ? `/api/workspaces/${encodeURIComponent(workspace)}/secrets` : "/api/secrets"
+  // Switching scope must not leave the other store's names on screen while the
+  // new one loads. Derived from the path the list was last loaded for rather
+  // than set at the head of `refresh`, which the mount effect calls straight
+  // from its body — a synchronous setState there is what
+  // react-hooks/set-state-in-effect rejects.
+  const loading = reloading || loadedPath !== secretsPath
 
   // The scope switch changes `secretsPath` within one mount, so two refreshes
   // can be in flight at once and resolve out of order. The loser would render
@@ -3373,7 +3399,6 @@ function SecretsSection({ settings, workspace }: { settings: SettingsData | null
 
   const refresh = useCallback(async () => {
     const generation = ++refreshGeneration.current
-    setLoading(true)
     try {
       const res = await fetch(`${hubUrl}${secretsPath}`, { headers: { Authorization: `Bearer ${token()}` } })
       if (res.ok) {
@@ -3391,7 +3416,10 @@ function SecretsSection({ settings, workspace }: { settings: SettingsData | null
         setSecrets([])
       }
     } finally {
-      if (generation === refreshGeneration.current) setLoading(false)
+      if (generation === refreshGeneration.current) {
+        setLoadedPath(secretsPath)
+        setReloading(false)
+      }
     }
   }, [hubUrl, secretsPath])
 
@@ -4649,6 +4677,12 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
   // the route and offer a way to drop it. Silently dropping it in buildPatch
   // would delete config the operator never saw.
   const orphanRoutes = routes.filter((route) => !notifiers[route.via])
+  // A route whose allow-list names alert types this hub does not support. The
+  // hub accepts it on disk while alerts are paused — routes are only validated
+  // once enabled — and rejects the whole block the moment they are turned on,
+  // exactly like an orphan route, so the master switch has to be gated on it
+  // too rather than offering a save that is certain to fail.
+  const unsupportedRoutes = routes.filter((route) => unknownEvents(route.events).length > 0)
   // A hub that has never had a lifecycle block: routing its first channel turns
   // alerts on. This is deliberately NOT inferred from (enabled=false, routes=[]),
   // which an operator reaches by muting the master switch and then removing the
@@ -4810,10 +4844,14 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     if (lifecycle?.idleAfter) outLifecycle.idleAfter = lifecycle.idleAfter
     return {
       patch: { notifications: { notifiers: outNotifiers, lifecycle: outLifecycle } },
-      // A hub that never had a lifecycle block and is saved with routing off is
-      // pausing nothing — that is the operator's own choice, not a pause this
-      // screen imposed — so it must not leave a clamp behind to lift later.
-      clamp: outRoutes.length === 0 && wantEnabled && !neverConfigured,
+      // The never-configured hub is clamped too, and for the same reason: the
+      // block this save creates carries `enabled:false` only because it has no
+      // route to send to, which is this screen's own doing — the operator was
+      // adding a channel, not muting a hub that had nothing to mute. Without
+      // the flag, routing that channel later finds `enabled:false` in the
+      // loaded config, keeps it, and leaves the freshly routed channel paused
+      // until the master switch is found by hand.
+      clamp: outRoutes.length === 0 && wantEnabled,
     }
   }
 
@@ -5022,22 +5060,27 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                 ? "Add a channel and route it before turning alerts on — there is nowhere to send them yet."
                 : orphanRoutes.length > 0
                   ? "Remove the routes pointing at deleted channels below — the hub refuses to enable alerts while one is left."
-                  : "The master switch. Turn it off to mute every channel without losing your routing."}
+                  : unsupportedRoutes.length > 0
+                    ? "Open Edit on the channels flagged below and save — the hub refuses to enable alerts while a route lists an unsupported alert type."
+                    : "The master switch. Turn it off to mute every channel without losing your routing."}
             </p>
           </div>
           <Switch
             checked={enabled}
-            // Gated on routes that actually name a configured channel: the hub
-            // rejects both an enabled block with no routes and one routed at a
-            // notifier that no longer exists, in the vocabulary of hub.yaml
-            // (`via`) rather than of this screen.
-            disabled={saving || routedCount === 0 || orphanRoutes.length > 0}
+            // Gated on every shape the hub rejects when a block is enabled: no
+            // routes, a route naming a notifier that no longer exists, and a
+            // route whose allow-list carries an alert type this hub does not
+            // support — all three in the vocabulary of hub.yaml (`via`,
+            // `events`) rather than of this screen.
+            disabled={saving || routedCount === 0 || orphanRoutes.length > 0 || unsupportedRoutes.length > 0}
             title={
               routedCount === 0
                 ? "Add a channel and route it to alerts first"
                 : orphanRoutes.length > 0
                   ? "Remove the routes pointing at deleted channels first"
-                  : undefined
+                  : unsupportedRoutes.length > 0
+                    ? "Drop the unsupported alert types from the flagged channels first — open Edit and save"
+                    : undefined
             }
             // Invalidated only once the hub has taken the change, exactly as
             // saveChannel/removeChannel do it: a rejected save leaves every
@@ -5262,16 +5305,22 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                   value={formName}
                   onChange={(e) => setFormName(e.target.value)}
                   className="font-mono text-sm h-8"
-                  disabled={modalMode === "edit"}
+                  disabled={saving || modalMode === "edit"}
                 />
               </div>
               <div>
                 <label className="text-xs text-muted-foreground mb-1 block">Slack channel ID</label>
+                {/* Every control below is disabled while this dialog's own save
+                    is in flight: saveChannel snapshots the form at click time
+                    and closes the dialog on success, so an edit made during the
+                    round trip — seconds long, the re-read hits GitHub — would be
+                    discarded with nothing on screen saying so. */}
                 <Input
                   placeholder="C0123ABCD"
                   value={formChannel}
                   onChange={(e) => setFormChannel(e.target.value)}
                   className="font-mono text-sm h-8"
+                  disabled={saving}
                 />
               </div>
             </div>
@@ -5285,6 +5334,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                 value={formTokenSecret}
                 onChange={(e) => setFormTokenSecret(e.target.value)}
                 className="w-full h-8 text-sm rounded-md border border-input bg-background px-3"
+                disabled={saving}
               >
                 <option value="">Select secret…</option>
                 {/* A dangling reference has no option of its own, so the
@@ -5321,6 +5371,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                 value={formMinSendInterval}
                 onChange={(e) => setFormMinSendInterval(e.target.value)}
                 className="font-mono text-sm h-8"
+                disabled={saving}
               />
               <p className="text-xs text-muted-foreground mt-1">
                 Optional. How long this channel waits between messages, as a duration (<span className="font-mono">30s</span>, <span className="font-mono">5m</span>). Leave empty for the default.
@@ -5338,6 +5389,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                   className="mt-1"
                   checked={formRouted}
                   onCheckedChange={setFormRouted}
+                  disabled={saving}
                   aria-label="Send lifecycle alerts to this channel"
                 />
               </div>
@@ -5376,7 +5428,8 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                         {!formAllAlerts && (
                           <button
                             type="button"
-                            className="text-xs text-blue-400 hover:underline mt-1"
+                            className="text-xs text-blue-400 hover:underline mt-1 disabled:opacity-50"
+                            disabled={saving}
                             onClick={() => setFormEvents([])}
                           >
                             Clear selection to receive all alerts
@@ -5407,6 +5460,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                             type="checkbox"
                             aria-label={`${lifecycleEventLabel(eventType)} (${eventType})`}
                             checked={checked}
+                            disabled={saving}
                             onChange={(e) =>
                               setFormEvents(
                                 e.target.checked
@@ -5464,7 +5518,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                 </Button>
               )}
               <div className="flex items-center gap-2 ml-auto">
-                <Button size="sm" variant="outline" onClick={() => setShowModal(false)}>Cancel</Button>
+                <Button size="sm" variant="outline" disabled={saving} onClick={() => setShowModal(false)}>Cancel</Button>
                 <Button size="sm" disabled={saving || !formName.trim() || !formChannel.trim() || !formTokenSecret} onClick={saveChannel}>
                   {modalMode === "add" ? "Add Channel" : "Save changes"}
                 </Button>

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -211,6 +211,11 @@ interface NotificationsView {
   }
 }
 
+// The outcome of one save. `persisted` says whether the hub accepted the PATCH;
+// `message` is what to show, which is non-null both for a rejected PATCH and
+// for an accepted one whose follow-up re-read failed.
+type SaveOutcome = { persisted: boolean; message: string | null }
+
 async function fetchSettings(): Promise<SettingsData> {
   const hubUrl = getHubUrl()
   const token = getAuthToken() || ""
@@ -358,7 +363,13 @@ export default function SettingsSectionPage() {
   // past, and the next save re-sends those stale values — reverting whatever
   // this one just persisted. Report it as a failed save so the dialog that
   // triggered it stays open instead of closing on data it can no longer trust.
-  async function runSave(patch: object): Promise<string | null> {
+  //
+  // `persisted` separates the two failures: the hub is unchanged only when the
+  // PATCH itself was rejected. A caller that records what the hub now holds —
+  // the notifier section's clamped-pause flag — has to write it either way, or
+  // a re-read that failed after an accepted PATCH loses the record of a value
+  // this screen wrote on its own initiative.
+  async function runSave(patch: object): Promise<SaveOutcome> {
     setSaving(true)
     setError("")
     setSuccess("")
@@ -366,24 +377,27 @@ export default function SettingsSectionPage() {
       try {
         await patchSettings(patch)
       } catch (e) {
-        return e instanceof Error ? e.message : "Save failed"
+        return { persisted: false, message: e instanceof Error ? e.message : "Save failed" }
       }
       try {
         await load()
       } catch (e) {
         const reason = e instanceof Error ? e.message : "the settings could not be re-read"
-        return `Saved, but reloading the settings failed (${reason}). Reload the page before editing again.`
+        return {
+          persisted: true,
+          message: `Saved, but reloading the settings failed (${reason}). Reload the page before editing again.`,
+        }
       }
       setSuccess("Saved")
       setTimeout(() => setSuccess(""), 2000)
-      return null
+      return { persisted: true, message: null }
     } finally {
       setSaving(false)
     }
   }
 
   async function save(patch: object): Promise<boolean> {
-    const message = await runSave(patch)
+    const { message } = await runSave(patch)
     if (message) setError(message)
     return message === null
   }
@@ -392,10 +406,10 @@ export default function SettingsSectionPage() {
   // banner lives inside <main>, which sits behind a modal overlay — a section
   // that saves from its own dialog has to render the error there instead, or
   // the button looks dead.
-  async function saveReportingError(patch: object): Promise<string | null> {
-    const message = await runSave(patch)
-    if (message) setError(message)
-    return message
+  async function saveReportingError(patch: object): Promise<SaveOutcome> {
+    const outcome = await runSave(patch)
+    if (outcome.message) setError(outcome.message)
+    return outcome
   }
 
   // Silent save: patches without the global 'Saved' banner (used for toggle-style updates)
@@ -3351,16 +3365,33 @@ function SecretsSection({ settings, workspace }: { settings: SettingsData | null
   const token = () => getAuthToken() || ""
   const secretsPath = scoped ? `/api/workspaces/${encodeURIComponent(workspace)}/secrets` : "/api/secrets"
 
+  // The scope switch changes `secretsPath` within one mount, so two refreshes
+  // can be in flight at once and resolve out of order. The loser would render
+  // one store's names under the other store's heading — and Delete, which uses
+  // the render-time path, would then aim at the wrong endpoint.
+  const refreshGeneration = useRef(0)
+
   const refresh = useCallback(async () => {
+    const generation = ++refreshGeneration.current
     setLoading(true)
     try {
       const res = await fetch(`${hubUrl}${secretsPath}`, { headers: { Authorization: `Bearer ${token()}` } })
       if (res.ok) {
         const data = await res.json()
+        if (generation !== refreshGeneration.current) return
         setSecrets(data.secrets || [])
+        setError(null)
+      } else {
+        const message = await res.text()
+        if (generation !== refreshGeneration.current) return
+        // Keeping the other store's names on screen is worse than an empty
+        // list: they read as this scope's secrets, and a workspace name picked
+        // as a notifier token_secret is one the hub can never resolve.
+        setError(message)
+        setSecrets([])
       }
     } finally {
-      setLoading(false)
+      if (generation === refreshGeneration.current) setLoading(false)
     }
   }, [hubUrl, secretsPath])
 
@@ -4565,7 +4596,7 @@ function writeClampedPause(clamped: boolean): void {
   }
 }
 
-function NotifierSection({ settings, onSave, saving }: { settings: SettingsData; onSave: (p: object) => Promise<string | null>; saving: boolean }) {
+function NotifierSection({ settings, onSave, saving }: { settings: SettingsData; onSave: (p: object) => Promise<SaveOutcome>; saving: boolean }) {
   const lifecycle = settings.notifications?.lifecycle
   const notifiers = settings.notifications?.notifiers || {}
   const names = Object.keys(notifiers).sort((a, b) => a.localeCompare(b))
@@ -4647,7 +4678,19 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
   // Invalidates in-flight test sends. A result that lands after the channel's
   // destination or routing changed describes a message that went somewhere else
   // — exactly the stale state every setTests() below clears.
-  const testGeneration = useRef(0)
+  //
+  // Saving ONE channel leaves every other channel's notifier and route
+  // byte-identical, so their in-flight results are still accurate: invalidating
+  // them would throw away a real failure ("channel_not_found") with nothing on
+  // the card to replace it. Per-channel bumps cover a single channel's save or
+  // removal; the hub-wide counter covers the master switch and the category
+  // toggles, which change what every channel receives.
+  const testGeneration = useRef<Record<string, number>>({})
+  const testGenerationAll = useRef(0)
+  const testStamp = (name: string) => `${testGenerationAll.current}:${testGeneration.current[name] ?? 0}`
+  const invalidateTest = (name: string) => {
+    testGeneration.current[name] = (testGeneration.current[name] ?? 0) + 1
+  }
 
   const openAdd = () => { saveGeneration.current++; resetForm(); setModalMode("add"); setShowModal(true) }
   const openEdit = (name: string) => {
@@ -4717,11 +4760,15 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
   // flag on a save that fails — the hub keeps the `enabled:false` this screen
   // wrote earlier, the retry no longer reads a clamp to lift it, and every
   // later save re-sends that stale `false`, muting the hub for good.
-  async function savePatch(next: Parameters<typeof buildPatch>[0]): Promise<string | null> {
+  // The flag describes what the HUB holds, so it follows the PATCH, not the
+  // re-read that comes after it: a save whose follow-up GET failed still left
+  // the hub with the `enabled:false` this screen wrote on its own initiative,
+  // and losing the clamp there latches that `false` for good.
+  async function savePatch(next: Parameters<typeof buildPatch>[0]): Promise<SaveOutcome> {
     const { patch, clamp } = buildPatch(next)
-    const failure = await onSave(patch)
-    if (!failure) writeClampedPause(clamp)
-    return failure
+    const outcome = await onSave(patch)
+    if (outcome.persisted) writeClampedPause(clamp)
+    return outcome
   }
 
   async function saveChannel() {
@@ -4756,11 +4803,15 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     if (formRouted) nextRoutes.push({ via: name, events })
 
     const generation = saveGeneration.current
-    const failure = await savePatch({ notifiers: nextNotifiers, routes: nextRoutes })
-    // The channel's destination or routing just changed, so any test result
-    // sitting on its card is about a message that went somewhere else.
-    testGeneration.current++
-    setTests((current) => { const { [name]: _stale, ...rest } = current; return rest })
+    const { persisted, message: failure } = await savePatch({ notifiers: nextNotifiers, routes: nextRoutes })
+    // THIS channel's destination or routing just changed, so any test result
+    // sitting on its card is about a message that went somewhere else. A
+    // rejected PATCH changed nothing, and every OTHER channel's notifier and
+    // route went out byte-identical, so neither is invalidated.
+    if (persisted) {
+      invalidateTest(name)
+      setTests((current) => { const { [name]: _stale, ...rest } = current; return rest })
+    }
     setSaveErrors((current) => { const { [name]: _cleared, ...rest } = current; return rest })
     if (generation !== saveGeneration.current) {
       if (failure) setSaveErrors((current) => ({ ...current, [name]: failure }))
@@ -4774,12 +4825,14 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     const nextNotifiers = { ...notifiers }
     delete nextNotifiers[name]
     const generation = saveGeneration.current
-    const failure = await savePatch({
+    const { persisted, message: failure } = await savePatch({
       notifiers: nextNotifiers,
       routes: routes.filter((route) => route.via !== name),
     })
-    testGeneration.current++
-    setTests((current) => { const { [name]: _removed, ...rest } = current; return rest })
+    if (persisted) {
+      invalidateTest(name)
+      setTests((current) => { const { [name]: _removed, ...rest } = current; return rest })
+    }
     setSaveErrors((current) => { const { [name]: _cleared, ...rest } = current; return rest })
     if (generation !== saveGeneration.current) {
       // The channel is still there — the remove was rejected — so its card can
@@ -4794,7 +4847,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
   // Dropping a route whose notifier is gone. It has no card of its own, so this
   // is the only way back to a hub that can turn lifecycle alerts on again.
   async function removeOrphanRoute(via: string) {
-    testGeneration.current++
+    invalidateTest(via)
     setTests((current) => { const { [via]: _removed, ...rest } = current; return rest })
     // The page-level banner reports a failure here: this save is not made from
     // the dialog, so nothing covers the banner.
@@ -4818,11 +4871,11 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     // The hub bounds a test send at 30s, plenty of time for the operator to edit
     // the channel meanwhile. Landing the result afterwards would show a green
     // "sent" under a destination the message never reached.
-    const generation = testGeneration.current
+    const generation = testStamp(name)
     setTests((current) => ({ ...current, [name]: { status: "sending", message: "" } }))
     const settle = (state: TestState) => {
       setTests((current) => {
-        if (generation !== testGeneration.current) {
+        if (generation !== testStamp(name)) {
           const { [name]: _stale, ...rest } = current
           return rest
         }
@@ -4896,7 +4949,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                   ? "Remove the routes pointing at deleted channels first"
                   : undefined
             }
-            onCheckedChange={(checked) => { testGeneration.current++; setTests({}); savePatch({ enabled: checked }) }}
+            onCheckedChange={(checked) => { testGenerationAll.current++; setTests({}); savePatch({ enabled: checked }) }}
             aria-label="Enable lifecycle alerts"
           />
         </div>
@@ -4919,7 +4972,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                     // A muted category can change what (or whether) a channel
                     // receives anything, so every test result on the page is
                     // now about a configuration that no longer exists.
-                    testGeneration.current++
+                    testGenerationAll.current++
                     setTests({})
                     savePatch({ events: { ...categoryEnabled, [category.id]: checked } })
                   }}

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -4,7 +4,7 @@ import { useParams, usePathname, useRouter } from "next/navigation"
 import React, { useEffect, useState, useCallback, useRef } from "react"
 import { getHubUrl } from "@/lib/hub-url"
 import { getAuthToken } from "@/lib/auth-storage"
-import { Cpu, Key, Github, ChevronLeft, Shield, Zap, Copy, Check, LayoutTemplate, Trash2, Lock, Sparkles, Send, RotateCcw, Eye, EyeOff, ExternalLink, AlertTriangle, X, CheckCircle2, Webhook, Stethoscope, ArrowRight, Wrench, GitBranch, ChevronDown } from "lucide-react"
+import { Cpu, Key, Github, ChevronLeft, Shield, Zap, Copy, Check, LayoutTemplate, Trash2, Lock, Sparkles, Send, RotateCcw, Eye, EyeOff, ExternalLink, AlertTriangle, X, CheckCircle2, Webhook, Stethoscope, ArrowRight, Wrench, GitBranch, ChevronDown, Bell } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Switch } from "@/components/ui/switch"
@@ -159,6 +159,8 @@ interface SettingsData {
     }
     disablePasswordAuth?: boolean
   }
+  notifications?: NotificationsView | null
+  lifecycleEventTypes?: string[]
   concurrencyGroups?: ConcurrencyGroup[]
   maxConcurrentClaws?: number
 }
@@ -166,6 +168,47 @@ interface SettingsData {
 interface ConcurrencyGroup {
   name: string
   limit: number
+}
+
+// Outbound notification config, as returned by GET /api/settings. Notifier
+// settings are provider-specific and inline next to the type, so they keep the
+// snake_case wire names the hub reads them under. The lifecycle block is the
+// redacted view: it uses poll_interval/idle_after, while the PATCH payload
+// (types.LifecycleNotificationsConfig) expects pollInterval/idleAfter.
+interface NotifierView {
+  type: string
+  channel?: string
+  token_secret?: string
+  api_base?: string
+  min_send_interval?: string
+}
+
+interface LifecycleRouteView {
+  via: string
+  // An empty (or absent) event list is an allow-all: the channel receives
+  // every lifecycle alert type.
+  events?: string[]
+}
+
+interface LifecycleEventToggles {
+  agentStarted?: boolean
+  prOpened?: boolean
+  failures?: boolean
+  agentIdle?: boolean
+}
+
+interface NotificationsView {
+  notifiers?: Record<string, NotifierView>
+  lifecycle?: {
+    enabled: boolean
+    // Legacy single-channel field, superseded by routes. The hub clears it as
+    // soon as a patch carries routes.
+    via?: string
+    routes?: LifecycleRouteView[]
+    poll_interval?: string
+    idle_after?: string
+    events?: LifecycleEventToggles
+  }
 }
 
 async function fetchSettings(): Promise<SettingsData> {
@@ -355,6 +398,7 @@ export default function SettingsSectionPage() {
         { id: "runtimes", label: "Sandboxes", icon: Cpu },
         { id: "models", label: "Models", icon: Key },
         { id: "authentication", label: "Authentication", icon: Shield },
+        { id: "notifier", label: "Notifier", icon: Bell },
         { id: "ai-config", label: "Configure with AI", icon: Sparkles },
       ],
     },
@@ -480,6 +524,9 @@ export default function SettingsSectionPage() {
           )}
           {settings && section === "mcp-servers" && (
             <MCPServersSection settings={settings} onSave={save} saving={saving} />
+          )}
+          {settings && section === "notifier" && (
+            <NotifierSection settings={settings} onSave={save} saving={saving} />
           )}
           {section === "ai-config" && (
             <AIConfigSection />
@@ -4364,6 +4411,590 @@ function MCPServersSection({ settings, onSave, saving }: { settings: SettingsDat
                 </Button>
               </div>
             </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}
+
+// ── Notifier ─────────────────────────────────────────────────────────────────
+
+// Labels mirror the headlines the hub actually posts, so what an operator
+// checks here is what they will read in the channel.
+const LIFECYCLE_EVENT_LABELS: Record<string, string> = {
+  agent_started: "Agent started",
+  pr_opened: "PR opened",
+  agent_idle: "Agent stalled",
+  agent_stopped: "Agent died",
+  creation_failed: "Couldn't create the agent",
+  provision_failed: "Couldn't get a machine",
+  bootstrap_failed: "Agent crashed during startup",
+  permission_or_auth_failed: "Agent was denied access",
+  provider_lost: "Lost contact with the provider",
+  timeout: "Agent ran out of time",
+  done_without_pr: "Agent finished without a PR",
+  unknown_failure: "Agent failed",
+}
+
+type LifecycleCategory = keyof LifecycleEventToggles
+
+// Which global toggle mutes each event type. Anything the hub adds later that
+// is not listed here is treated as always-on rather than silently muted.
+const LIFECYCLE_EVENT_CATEGORY: Record<string, LifecycleCategory> = {
+  agent_started: "agentStarted",
+  pr_opened: "prOpened",
+  agent_idle: "agentIdle",
+  agent_stopped: "failures",
+  creation_failed: "failures",
+  provision_failed: "failures",
+  bootstrap_failed: "failures",
+  permission_or_auth_failed: "failures",
+  provider_lost: "failures",
+  timeout: "failures",
+  done_without_pr: "failures",
+  unknown_failure: "failures",
+}
+
+const LIFECYCLE_CATEGORIES: { id: LifecycleCategory; label: string; description: string }[] = [
+  { id: "agentStarted", label: "Agent started", description: "An agent picked up a ticket and started working" },
+  { id: "prOpened", label: "PR opened", description: "An agent opened a pull request" },
+  { id: "failures", label: "Failures", description: "Crashes, timeouts, lost machines, finished without a PR" },
+  { id: "agentIdle", label: "Agent stalled", description: "An agent stopped making progress" },
+]
+
+// Fallback only — the canonical list comes from settings.lifecycleEventTypes.
+const FALLBACK_LIFECYCLE_EVENT_TYPES = Object.keys(LIFECYCLE_EVENT_CATEGORY)
+
+// Slack conversation IDs: public channels (C…), private groups (G…), DMs (D…).
+const SLACK_CHANNEL_ID_RE = /^[CGD][A-Za-z0-9]+$/
+
+function lifecycleEventLabel(eventType: string): string {
+  return LIFECYCLE_EVENT_LABELS[eventType] || eventType.replace(/_/g, " ").replace(/^./, (c) => c.toUpperCase())
+}
+
+async function sendTestNotification(eventType: string, via: string): Promise<void> {
+  const hubUrl = getHubUrl()
+  const token = getAuthToken() || ""
+  const res = await fetch(`${hubUrl}/api/notifications/test`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+    // via is forward-looking: the hub currently sends the test through the
+    // configured lifecycle notifier and ignores unknown fields.
+    body: JSON.stringify({ event_type: eventType, dry_run: false, via }),
+  })
+  const raw = await res.text()
+  if (res.ok) return
+  let message = raw
+  try {
+    const parsed = JSON.parse(raw) as { error?: string }
+    if (parsed.error) message = parsed.error
+  } catch {
+    // Not JSON — surface the raw body.
+  }
+  throw new Error(message || `Test send failed (${res.status})`)
+}
+
+type TestState = { status: "sending" | "ok" | "error"; message: string }
+
+function NotifierSection({ settings, onSave, saving }: { settings: SettingsData; onSave: (p: object) => Promise<boolean>; saving: boolean }) {
+  const lifecycle = settings.notifications?.lifecycle
+  const notifiers = settings.notifications?.notifiers || {}
+  const names = Object.keys(notifiers).sort((a, b) => a.localeCompare(b))
+  const eventTypes = settings.lifecycleEventTypes?.length ? settings.lifecycleEventTypes : FALLBACK_LIFECYCLE_EVENT_TYPES
+
+  const enabled = lifecycle?.enabled ?? false
+  const categoryEnabled: Record<LifecycleCategory, boolean> = {
+    agentStarted: lifecycle?.events?.agentStarted ?? true,
+    prOpened: lifecycle?.events?.prOpened ?? true,
+    failures: lifecycle?.events?.failures ?? true,
+    agentIdle: lifecycle?.events?.agentIdle ?? true,
+  }
+  // A legacy single-channel `via` reads as one route over every event; saving
+  // any change migrates it to routes.
+  const routes: LifecycleRouteView[] = lifecycle?.routes?.length
+    ? lifecycle.routes
+    : lifecycle?.via
+      ? [{ via: lifecycle.via, events: [] }]
+      : []
+  const routeFor = (name: string) => routes.find((r) => r.via === name)
+
+  const isEventMuted = (eventType: string) => {
+    const category = LIFECYCLE_EVENT_CATEGORY[eventType]
+    return category ? !categoryEnabled[category] : false
+  }
+
+  const [showModal, setShowModal] = useState(false)
+  const [modalMode, setModalMode] = useState<"add" | "edit">("add")
+  const [editName, setEditName] = useState<string | null>(null)
+  const [formName, setFormName] = useState("")
+  const [formChannel, setFormChannel] = useState("")
+  const [formTokenSecret, setFormTokenSecret] = useState("")
+  const [formRouted, setFormRouted] = useState(true)
+  const [formEvents, setFormEvents] = useState<string[]>([])
+  const [formError, setFormError] = useState("")
+  const [tests, setTests] = useState<Record<string, TestState>>({})
+
+  const resetForm = () => {
+    setFormName(""); setFormChannel(""); setFormTokenSecret("")
+    setFormRouted(true); setFormEvents([]); setFormError(""); setEditName(null)
+  }
+
+  const openAdd = () => { resetForm(); setModalMode("add"); setShowModal(true) }
+  const openEdit = (name: string) => {
+    const notifier = notifiers[name]
+    const route = routeFor(name)
+    setFormName(name)
+    setFormChannel(notifier.channel || "")
+    setFormTokenSecret(notifier.token_secret || "")
+    setFormRouted(Boolean(route))
+    setFormEvents(route?.events ? [...route.events] : [])
+    setFormError("")
+    setEditName(name)
+    setModalMode("edit")
+    setShowModal(true)
+  }
+
+  // PATCH /api/settings replaces the whole notifications block, so every save
+  // rebuilds it from the current view plus the change being made.
+  function buildPatch(next: {
+    notifiers?: Record<string, NotifierView>
+    enabled?: boolean
+    routes?: LifecycleRouteView[]
+    events?: Record<LifecycleCategory, boolean>
+  }): object {
+    const outNotifiers: Record<string, Record<string, string>> = {}
+    for (const [name, notifier] of Object.entries(next.notifiers ?? notifiers)) {
+      const out: Record<string, string> = { type: notifier.type || "slack" }
+      if (notifier.channel) out.channel = notifier.channel
+      if (notifier.token_secret) out.token_secret = notifier.token_secret
+      if (notifier.api_base) out.api_base = notifier.api_base
+      if (notifier.min_send_interval) out.min_send_interval = notifier.min_send_interval
+      outNotifiers[name] = out
+    }
+    const outLifecycle: Record<string, unknown> = {
+      enabled: next.enabled ?? enabled,
+      // Always an array: sending routes is what clears the legacy `via`.
+      routes: (next.routes ?? routes).map((route) => ({
+        via: route.via,
+        events: route.events?.length ? route.events : [],
+      })),
+      events: next.events ?? categoryEnabled,
+    }
+    if (lifecycle?.poll_interval) outLifecycle.pollInterval = lifecycle.poll_interval
+    if (lifecycle?.idle_after) outLifecycle.idleAfter = lifecycle.idle_after
+    return { notifications: { notifiers: outNotifiers, lifecycle: outLifecycle } }
+  }
+
+  async function saveChannel() {
+    const name = formName.trim()
+    const channel = formChannel.trim()
+    if (!name) { setFormError("Name is required."); return }
+    if (modalMode === "add" && notifiers[name]) { setFormError(`A channel named "${name}" already exists.`); return }
+    if (!channel) { setFormError("Channel ID is required."); return }
+    if (channel.startsWith("#") || !SLACK_CHANNEL_ID_RE.test(channel)) {
+      setFormError(
+        `"${channel}" is not a Slack channel ID. Use the ID (e.g. C0123ABCD), not the #name — you'll find it at the bottom of the channel's details dialog in Slack.`,
+      )
+      return
+    }
+    if (!formTokenSecret) { setFormError("Pick the hub secret holding the Slack bot token."); return }
+    setFormError("")
+
+    const existing = editName ? notifiers[editName] : undefined
+    const nextNotifiers: Record<string, NotifierView> = {
+      ...notifiers,
+      [name]: {
+        ...existing,
+        type: existing?.type || "slack",
+        channel,
+        token_secret: formTokenSecret,
+      },
+    }
+    // Every type checked is the same thing as no filter; store it as one so a
+    // later-added alert type keeps reaching the channel.
+    const events = formEvents.length === eventTypes.length ? [] : formEvents
+    const nextRoutes = routes.filter((route) => route.via !== name)
+    if (formRouted) nextRoutes.push({ via: name, events })
+
+    const ok = await onSave(buildPatch({ notifiers: nextNotifiers, routes: nextRoutes }))
+    if (ok) { setShowModal(false); resetForm() }
+  }
+
+  async function removeChannel(name: string) {
+    const nextNotifiers = { ...notifiers }
+    delete nextNotifiers[name]
+    const ok = await onSave(buildPatch({
+      notifiers: nextNotifiers,
+      routes: routes.filter((route) => route.via !== name),
+    }))
+    if (ok) {
+      setTests((current) => { const { [name]: _removed, ...rest } = current; return rest })
+      setShowModal(false)
+      resetForm()
+    }
+  }
+
+  // The event a test send uses: something this channel is routed for and that
+  // is not muted globally, preferring the friendliest one.
+  function testEventFor(name: string): string | null {
+    const route = routeFor(name)
+    if (!route) return null
+    const allowed = route.events?.length ? route.events : eventTypes
+    const candidates = allowed.filter((eventType) => !isEventMuted(eventType))
+    if (candidates.length === 0) return null
+    return candidates.includes("agent_started") ? "agent_started" : candidates[0]
+  }
+
+  async function sendTest(name: string) {
+    const eventType = testEventFor(name)
+    if (!eventType) return
+    setTests((current) => ({ ...current, [name]: { status: "sending", message: "" } }))
+    try {
+      await sendTestNotification(eventType, name)
+      setTests((current) => ({
+        ...current,
+        [name]: { status: "ok", message: `Sent a "${lifecycleEventLabel(eventType)}" test alert.` },
+      }))
+    } catch (e) {
+      setTests((current) => ({
+        ...current,
+        [name]: { status: "error", message: e instanceof Error ? e.message : "Test send failed" },
+      }))
+    }
+  }
+
+  const routedCount = routes.filter((route) => notifiers[route.via]).length
+  const formAllAlerts = formEvents.length === 0
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-base font-semibold mb-1">Notifier</h2>
+        <p className="text-sm text-muted-foreground mb-4">
+          Send agent lifecycle alerts — starts, pull requests, stalls and failures — to Slack. Channels are hub-wide and shared by every workspace.
+        </p>
+        <div className="flex items-center gap-2 mb-6">
+          <span className="text-xs bg-muted text-muted-foreground px-2 py-1 rounded font-medium">
+            {names.length} channel{names.length !== 1 ? "s" : ""} configured
+          </span>
+          {enabled ? (
+            <span className="text-xs bg-green-500/10 text-green-400 border border-green-500/20 px-2 py-1 rounded font-medium">
+              {routedCount} receiving alerts
+            </span>
+          ) : (
+            <span className="text-xs bg-amber-500/10 text-amber-400 border border-amber-500/20 px-2 py-1 rounded font-medium">
+              Alerts paused
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Global switches: these mute an alert everywhere, before routing. */}
+      <div className="border border-border rounded-lg">
+        <div className="flex items-center justify-between gap-4 p-4">
+          <div>
+            <div className="text-sm font-medium">Lifecycle alerts</div>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              The master switch. Turn it off to mute every channel without losing your routing.
+            </p>
+          </div>
+          <Switch
+            checked={enabled}
+            disabled={saving}
+            onCheckedChange={(checked) => onSave(buildPatch({ enabled: checked }))}
+            aria-label="Enable lifecycle alerts"
+          />
+        </div>
+        <div className={cn("border-t border-border p-4 space-y-3 transition-opacity", !enabled && "opacity-50")}>
+          <p className="text-xs text-muted-foreground">
+            Alert types muted here never reach any channel, whatever the per-channel routing says.
+          </p>
+          <div className="grid gap-2 sm:grid-cols-2">
+            {LIFECYCLE_CATEGORIES.map((category) => (
+              <div key={category.id} className="flex items-start justify-between gap-3 rounded-md border border-border/60 bg-muted/20 px-3 py-2">
+                <div className="min-w-0">
+                  <div className="text-sm">{category.label}</div>
+                  <p className="text-xs text-muted-foreground">{category.description}</p>
+                </div>
+                <Switch
+                  className="mt-0.5"
+                  checked={categoryEnabled[category.id]}
+                  disabled={saving || !enabled}
+                  onCheckedChange={(checked) =>
+                    onSave(buildPatch({ events: { ...categoryEnabled, [category.id]: checked } }))
+                  }
+                  aria-label={`Toggle ${category.label} alerts`}
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Channels */}
+      <div className="space-y-2">
+        <h3 className="text-sm font-medium">Channels</h3>
+        {names.length === 0 ? (
+          <p className="text-sm text-muted-foreground px-4 py-6 text-center border border-border rounded-lg">
+            No channels configured. Add one to start receiving alerts in Slack.
+          </p>
+        ) : (
+          <div className="space-y-2">
+            {names.map((name) => {
+              const notifier = notifiers[name]
+              const route = routeFor(name)
+              const test = tests[name]
+              const testEvent = testEventFor(name)
+              const canTest = enabled && Boolean(testEvent) && !saving
+              return (
+                <div key={name} className="border border-border rounded-lg p-4">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2">
+                        <code className="text-sm font-mono font-medium">{name}</code>
+                        <span className="text-xs text-muted-foreground capitalize">{notifier.type}</span>
+                      </div>
+                      <p className="text-xs text-muted-foreground mt-1">
+                        <span className="font-mono">{notifier.channel || "no channel"}</span>
+                        {" · "}
+                        {notifier.token_secret
+                          ? <>token: <span className="font-mono">{notifier.token_secret}</span></>
+                          : <span className="text-amber-400">no token secret</span>}
+                      </p>
+                      <div className="mt-2">
+                        {!route ? (
+                          <span className="text-xs bg-muted text-muted-foreground px-2 py-1 rounded font-medium">
+                            Not receiving alerts
+                          </span>
+                        ) : route.events?.length ? (
+                          <span className="text-xs bg-muted text-muted-foreground px-2 py-1 rounded font-medium">
+                            {route.events.length} of {eventTypes.length} alert types
+                          </span>
+                        ) : (
+                          <span className="text-xs bg-blue-500/10 text-blue-400 border border-blue-500/20 px-2 py-1 rounded font-medium">
+                            All alerts
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-2 shrink-0">
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        disabled={!canTest || test?.status === "sending"}
+                        title={
+                          !enabled
+                            ? "Lifecycle alerts are turned off"
+                            : !testEvent
+                              ? "This channel is not routed to any alert type that is on"
+                              : `Posts a sample "${lifecycleEventLabel(testEvent)}" alert`
+                        }
+                        onClick={() => sendTest(name)}
+                        className="gap-1.5"
+                      >
+                        <Send className="size-3.5" />
+                        {test?.status === "sending" ? "Sending…" : "Send test"}
+                      </Button>
+                      <Button size="sm" variant="ghost" onClick={() => openEdit(name)}>Edit</Button>
+                    </div>
+                  </div>
+                  {test && test.status !== "sending" && (
+                    <div
+                      className={cn(
+                        "mt-3 flex items-start gap-2 rounded-md border px-3 py-2 text-xs",
+                        test.status === "ok"
+                          ? "border-green-500/20 bg-green-500/10 text-green-400"
+                          : "border-destructive/30 bg-destructive/10 text-destructive",
+                      )}
+                    >
+                      {test.status === "ok"
+                        ? <CheckCircle2 className="size-3.5 mt-px shrink-0" />
+                        : <AlertTriangle className="size-3.5 mt-px shrink-0" />}
+                      <span className="break-words">{test.message}</span>
+                    </div>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </div>
+
+      <Button onClick={openAdd} className="gap-2">
+        <span className="text-sm">+</span> Add Channel
+      </Button>
+
+      {/* Add / edit modal */}
+      <Dialog open={showModal} onOpenChange={(open) => { setShowModal(open); if (!open) resetForm() }}>
+        <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto p-0 gap-0">
+          <DialogTitle className="sr-only">{modalMode === "add" ? "Add Channel" : `Edit ${editName}`}</DialogTitle>
+          <div className="flex items-center justify-between px-5 py-4 border-b border-border">
+            <h3 className="font-medium">{modalMode === "add" ? "Add Channel" : `Edit ${editName}`}</h3>
+          </div>
+
+          <div className="p-5 space-y-4">
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="text-xs text-muted-foreground mb-1 block">Name</label>
+                <Input
+                  placeholder="e.g. eng-agents"
+                  value={formName}
+                  onChange={(e) => setFormName(e.target.value)}
+                  className="font-mono text-sm h-8"
+                  disabled={modalMode === "edit"}
+                />
+              </div>
+              <div>
+                <label className="text-xs text-muted-foreground mb-1 block">Slack channel ID</label>
+                <Input
+                  placeholder="C0123ABCD"
+                  value={formChannel}
+                  onChange={(e) => setFormChannel(e.target.value)}
+                  className="font-mono text-sm h-8"
+                />
+              </div>
+            </div>
+            <p className="text-xs text-muted-foreground -mt-2">
+              Use the channel ID, not the #name — names break when a channel is renamed. In Slack, open the channel details and copy the ID at the bottom.
+            </p>
+
+            <div>
+              <label className="text-xs text-muted-foreground mb-1 block">Bot token secret</label>
+              <select
+                value={formTokenSecret}
+                onChange={(e) => setFormTokenSecret(e.target.value)}
+                className="w-full h-8 text-sm rounded-md border border-input bg-background px-3"
+              >
+                <option value="">Select secret…</option>
+                {[...(settings.secrets || [])].sort((a, b) => a.localeCompare(b)).map((secret) => (
+                  <option key={secret} value={secret}>{secret}</option>
+                ))}
+              </select>
+              <p className="text-xs text-muted-foreground mt-1">
+                The hub secret holding the Slack bot token (<span className="font-mono">xoxb-…</span>). Add it under Secrets first.
+              </p>
+            </div>
+
+            {/* Routing */}
+            <div className="space-y-3 border-t border-border pt-4">
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <div className="text-sm font-medium">Alert routing</div>
+                  <p className="text-xs text-muted-foreground mt-0.5">Which lifecycle alerts land in this channel.</p>
+                </div>
+                <Switch
+                  className="mt-1"
+                  checked={formRouted}
+                  onCheckedChange={setFormRouted}
+                  aria-label="Send lifecycle alerts to this channel"
+                />
+              </div>
+
+              {!formRouted ? (
+                <p className="text-xs text-muted-foreground rounded-md border border-border bg-muted/20 px-3 py-2">
+                  This channel stays configured but receives no lifecycle alerts.
+                </p>
+              ) : (
+                <>
+                  <div
+                    className={cn(
+                      "rounded-md border px-3 py-2",
+                      formAllAlerts
+                        ? "border-blue-500/30 bg-blue-500/10"
+                        : "border-border bg-muted/20",
+                    )}
+                  >
+                    <div className="flex items-start gap-2">
+                      <Bell className={cn("size-4 mt-px shrink-0", formAllAlerts ? "text-blue-400" : "text-muted-foreground")} />
+                      <div className="min-w-0">
+                        <div className={cn("text-sm font-medium", formAllAlerts ? "text-blue-400" : "")}>
+                          {formAllAlerts ? "All alerts" : `${formEvents.length} of ${eventTypes.length} alert types`}
+                        </div>
+                        <p className="text-xs text-muted-foreground">
+                          {formAllAlerts
+                            ? "Nothing is checked, so this channel receives every alert type — including any new type added later."
+                            : "Only the checked types reach this channel."}
+                        </p>
+                        {!formAllAlerts && (
+                          <button
+                            type="button"
+                            className="text-xs text-blue-400 hover:underline mt-1"
+                            onClick={() => setFormEvents([])}
+                          >
+                            Clear selection to receive all alerts
+                          </button>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="space-y-1">
+                    {eventTypes.map((eventType) => {
+                      const checked = formEvents.includes(eventType)
+                      const muted = isEventMuted(eventType)
+                      return (
+                        <label
+                          key={eventType}
+                          className="flex items-center gap-2 text-sm cursor-pointer rounded px-2 py-1 hover:bg-muted/50"
+                        >
+                          <input
+                            type="checkbox"
+                            aria-label={`${lifecycleEventLabel(eventType)} (${eventType})`}
+                            checked={checked}
+                            onChange={(e) =>
+                              setFormEvents(
+                                e.target.checked
+                                  ? [...formEvents, eventType]
+                                  : formEvents.filter((t) => t !== eventType),
+                              )
+                            }
+                          />
+                          <span className={cn(!checked && !formAllAlerts && "text-muted-foreground")}>
+                            {lifecycleEventLabel(eventType)}
+                          </span>
+                          <code className="text-xs text-muted-foreground font-mono">{eventType}</code>
+                          {muted && (
+                            <span className="text-xs text-amber-400 ml-auto shrink-0">muted globally</span>
+                          )}
+                        </label>
+                      )
+                    })}
+                  </div>
+                </>
+              )}
+            </div>
+
+          </div>
+
+          <div className="border-t border-border">
+            {/* The error sits with the buttons, never below the fold of a long
+                scrolling form. */}
+            {formError && (
+              <div className="mx-5 mt-4 flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+                <AlertTriangle className="size-3.5 mt-px shrink-0" />
+                <span className="break-words">{formError}</span>
+              </div>
+            )}
+            <div className="flex items-center justify-between px-5 py-4">
+              {modalMode === "edit" && editName && (
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="text-destructive hover:text-destructive"
+                  disabled={saving}
+                  onClick={() => removeChannel(editName)}
+                >
+                  <Trash2 className="size-3.5 mr-1" /> Remove
+                </Button>
+              )}
+              <div className="flex items-center gap-2 ml-auto">
+                <Button size="sm" variant="outline" onClick={() => { setShowModal(false); resetForm() }}>Cancel</Button>
+                <Button size="sm" disabled={saving || !formName.trim() || !formChannel.trim() || !formTokenSecret} onClick={saveChannel}>
+                  {modalMode === "add" ? "Add Channel" : "Save changes"}
+                </Button>
+              </div>
+            </div>
+          </div>
         </DialogContent>
       </Dialog>
     </div>

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -3334,8 +3334,13 @@ function SecretsSection({ settings, workspace }: { settings: SettingsData | null
   // notifier token_secret references resolve against, so without this scope a
   // hub with any workspace has no way at all to create the secret the Notifier
   // screen requires.
-  const [hubScope, setHubScope] = useState(!workspace)
-  const scoped = Boolean(workspace) && !hubScope
+  //
+  // The default tracks the operator's CHOICE, not the `workspace` prop: the
+  // workspace list is fetched after the first render, so seeding state from the
+  // prop would latch "Hub" on every direct load of /settings/secrets and write
+  // hub.yaml secrets while the screen still said Workspace was available.
+  const [scopeChoice, setScopeChoice] = useState<"workspace" | "hub" | null>(null)
+  const scoped = Boolean(workspace) && scopeChoice !== "hub"
 
   const hubUrl = getHubUrl()
   const token = () => getAuthToken() || ""
@@ -3398,8 +3403,8 @@ function SecretsSection({ settings, workspace }: { settings: SettingsData | null
         </p>
         {Boolean(workspace) && (
           <div className="flex items-center gap-1 mb-6">
-            <Button size="sm" variant={scoped ? "secondary" : "ghost"} onClick={() => setHubScope(false)}>Workspace</Button>
-            <Button size="sm" variant={scoped ? "ghost" : "secondary"} onClick={() => setHubScope(true)}>Hub</Button>
+            <Button size="sm" variant={scoped ? "secondary" : "ghost"} onClick={() => setScopeChoice("workspace")}>Workspace</Button>
+            <Button size="sm" variant={scoped ? "ghost" : "secondary"} onClick={() => setScopeChoice("hub")}>Hub</Button>
           </div>
         )}
       </div>
@@ -4665,13 +4670,14 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
   }
 
   // PATCH /api/settings replaces the whole notifications block, so every save
-  // rebuilds it from the current view plus the change being made.
+  // rebuilds it from the current view plus the change being made. The clamp the
+  // patch implies is returned, never written here: see savePatch.
   function buildPatch(next: {
     notifiers?: Record<string, NotifierView>
     enabled?: boolean
     routes?: LifecycleRouteView[]
     events?: Record<LifecycleCategory, boolean>
-  }): object {
+  }): { patch: object; clamp: boolean } {
     const outNotifiers: Record<string, Record<string, string>> = {}
     for (const [name, notifier] of Object.entries(next.notifiers ?? notifiers)) {
       const out: Record<string, string> = { type: notifier.type || "slack" }
@@ -4697,7 +4703,6 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     // routed". The flag is recorded here rather than inferred from the reloaded
     // config so a deliberate master-switch OFF survives a channel swap.
     const wantEnabled = next.enabled ?? (enabled || readClampedPause() || neverConfigured)
-    writeClampedPause(outRoutes.length === 0 && wantEnabled)
     const outLifecycle: Record<string, unknown> = {
       enabled: outRoutes.length > 0 && wantEnabled,
       routes: outRoutes,
@@ -4705,7 +4710,22 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     }
     if (lifecycle?.pollInterval) outLifecycle.pollInterval = lifecycle.pollInterval
     if (lifecycle?.idleAfter) outLifecycle.idleAfter = lifecycle.idleAfter
-    return { notifications: { notifiers: outNotifiers, lifecycle: outLifecycle } }
+    return {
+      patch: { notifications: { notifiers: outNotifiers, lifecycle: outLifecycle } },
+      clamp: outRoutes.length === 0 && wantEnabled,
+    }
+  }
+
+  // The clamp describes what the hub holds, so it is written only once the
+  // PATCH has actually landed. Recording it while building the body loses the
+  // flag on a save that fails — the hub keeps the `enabled:false` this screen
+  // wrote earlier, the retry no longer reads a clamp to lift it, and every
+  // later save re-sends that stale `false`, muting the hub for good.
+  async function savePatch(next: Parameters<typeof buildPatch>[0]): Promise<string | null> {
+    const { patch, clamp } = buildPatch(next)
+    const failure = await onSave(patch)
+    if (!failure) writeClampedPause(clamp)
+    return failure
   }
 
   async function saveChannel() {
@@ -4740,7 +4760,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     if (formRouted) nextRoutes.push({ via: name, events })
 
     const generation = saveGeneration.current
-    const failure = await onSave(buildPatch({ notifiers: nextNotifiers, routes: nextRoutes }))
+    const failure = await savePatch({ notifiers: nextNotifiers, routes: nextRoutes })
     // The channel's destination or routing just changed, so any test result
     // sitting on its card is about a message that went somewhere else.
     testGeneration.current++
@@ -4758,10 +4778,10 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     const nextNotifiers = { ...notifiers }
     delete nextNotifiers[name]
     const generation = saveGeneration.current
-    const failure = await onSave(buildPatch({
+    const failure = await savePatch({
       notifiers: nextNotifiers,
       routes: routes.filter((route) => route.via !== name),
-    }))
+    })
     testGeneration.current++
     setTests((current) => { const { [name]: _removed, ...rest } = current; return rest })
     setSaveErrors((current) => { const { [name]: _cleared, ...rest } = current; return rest })
@@ -4782,7 +4802,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     setTests((current) => { const { [via]: _removed, ...rest } = current; return rest })
     // The page-level banner reports a failure here: this save is not made from
     // the dialog, so nothing covers the banner.
-    await onSave(buildPatch({ routes: routes.filter((route) => route.via !== via) }))
+    await savePatch({ routes: routes.filter((route) => route.via !== via) })
   }
 
   // The event a test send uses: something this channel is routed for and that
@@ -4880,7 +4900,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                   ? "Remove the routes pointing at deleted channels first"
                   : undefined
             }
-            onCheckedChange={(checked) => { testGeneration.current++; setTests({}); onSave(buildPatch({ enabled: checked })) }}
+            onCheckedChange={(checked) => { testGeneration.current++; setTests({}); savePatch({ enabled: checked }) }}
             aria-label="Enable lifecycle alerts"
           />
         </div>
@@ -4905,7 +4925,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                     // now about a configuration that no longer exists.
                     testGeneration.current++
                     setTests({})
-                    onSave(buildPatch({ events: { ...categoryEnabled, [category.id]: checked } }))
+                    savePatch({ events: { ...categoryEnabled, [category.id]: checked } })
                   }}
                   aria-label={`Toggle ${category.label} alerts`}
                 />

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -4540,6 +4540,13 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
       ? [{ via: lifecycle.via, events: [] }]
       : []
   const routeFor = (name: string) => routes.find((r) => r.via === name)
+  // A route whose notifier is gone. The hub deliberately accepts this on disk
+  // while alerts are paused ("an operator who mutes alerts and then deletes the
+  // notifier must not be left with a hub that refuses to load"), but it rejects
+  // the same block the moment alerts are enabled — so the screen has to render
+  // the route and offer a way to drop it. Silently dropping it in buildPatch
+  // would delete config the operator never saw.
+  const orphanRoutes = routes.filter((route) => !notifiers[route.via])
   // Alerts off with nothing routed is never a deliberate choice: the master
   // switch is disabled in that state, so the only way to reach it is buildPatch
   // clamping `enabled` when the last route went away (or a hub that has never
@@ -4568,8 +4575,15 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     setFormRouted(true); setFormEvents([]); setFormError(""); setEditName(null)
   }
 
-  const openAdd = () => { resetForm(); setModalMode("add"); setShowModal(true) }
+  // Identifies the dialog a save was started from. An in-flight PATCH must not
+  // close, reset, or drop its error into a dialog the operator has meanwhile
+  // reopened on another channel — that discards unsaved form state and blames
+  // the wrong channel.
+  const saveGeneration = useRef(0)
+
+  const openAdd = () => { saveGeneration.current++; resetForm(); setModalMode("add"); setShowModal(true) }
   const openEdit = (name: string) => {
+    saveGeneration.current++
     const notifier = notifiers[name]
     const route = routeFor(name)
     setFormName(name)
@@ -4655,23 +4669,37 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     const nextRoutes = routes.filter((route) => route.via !== name)
     if (formRouted) nextRoutes.push({ via: name, events })
 
+    const generation = saveGeneration.current
     const failure = await onSave(buildPatch({ notifiers: nextNotifiers, routes: nextRoutes }))
+    // The channel's destination or routing just changed, so any test result
+    // sitting on its card is about a message that went somewhere else.
+    setTests((current) => { const { [name]: _stale, ...rest } = current; return rest })
+    if (generation !== saveGeneration.current) return
     if (failure) { setFormError(failure); return }
     setShowModal(false)
-    resetForm()
   }
 
   async function removeChannel(name: string) {
     const nextNotifiers = { ...notifiers }
     delete nextNotifiers[name]
+    const generation = saveGeneration.current
     const failure = await onSave(buildPatch({
       notifiers: nextNotifiers,
       routes: routes.filter((route) => route.via !== name),
     }))
-    if (failure) { setFormError(failure); return }
     setTests((current) => { const { [name]: _removed, ...rest } = current; return rest })
+    if (generation !== saveGeneration.current) return
+    if (failure) { setFormError(failure); return }
     setShowModal(false)
-    resetForm()
+  }
+
+  // Dropping a route whose notifier is gone. It has no card of its own, so this
+  // is the only way back to a hub that can turn lifecycle alerts on again.
+  async function removeOrphanRoute(via: string) {
+    setTests((current) => { const { [via]: _removed, ...rest } = current; return rest })
+    // The page-level banner reports a failure here: this save is not made from
+    // the dialog, so nothing covers the banner.
+    await onSave(buildPatch({ routes: routes.filter((route) => route.via !== via) }))
   }
 
   // The event a test send uses: something this channel is routed for and that
@@ -4743,16 +4771,26 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
             <p className="text-xs text-muted-foreground mt-0.5">
               {routedCount === 0
                 ? "Add a channel and route it before turning alerts on — there is nowhere to send them yet."
-                : "The master switch. Turn it off to mute every channel without losing your routing."}
+                : orphanRoutes.length > 0
+                  ? "Remove the routes pointing at deleted channels below — the hub refuses to enable alerts while one is left."
+                  : "The master switch. Turn it off to mute every channel without losing your routing."}
             </p>
           </div>
           <Switch
             checked={enabled}
-            // Enabling with no routes is rejected by the hub, in the vocabulary
-            // of hub.yaml (`via`) rather than of this screen.
-            disabled={saving || routes.length === 0}
-            title={routes.length === 0 ? "Add a channel and route it to alerts first" : undefined}
-            onCheckedChange={(checked) => onSave(buildPatch({ enabled: checked }))}
+            // Gated on routes that actually name a configured channel: the hub
+            // rejects both an enabled block with no routes and one routed at a
+            // notifier that no longer exists, in the vocabulary of hub.yaml
+            // (`via`) rather than of this screen.
+            disabled={saving || routedCount === 0 || orphanRoutes.length > 0}
+            title={
+              routedCount === 0
+                ? "Add a channel and route it to alerts first"
+                : orphanRoutes.length > 0
+                  ? "Remove the routes pointing at deleted channels first"
+                  : undefined
+            }
+            onCheckedChange={(checked) => { setTests({}); onSave(buildPatch({ enabled: checked })) }}
             aria-label="Enable lifecycle alerts"
           />
         </div>
@@ -4771,9 +4809,13 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                   className="mt-0.5"
                   checked={categoryEnabled[category.id]}
                   disabled={saving || !enabled}
-                  onCheckedChange={(checked) =>
+                  onCheckedChange={(checked) => {
+                    // A muted category can change what (or whether) a channel
+                    // receives anything, so every test result on the page is
+                    // now about a configuration that no longer exists.
+                    setTests({})
                     onSave(buildPatch({ events: { ...categoryEnabled, [category.id]: checked } }))
-                  }
+                  }}
                   aria-label={`Toggle ${category.label} alerts`}
                 />
               </div>
@@ -4880,12 +4922,43 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
         )}
       </div>
 
+      {orphanRoutes.length > 0 && (
+        <div className="space-y-2">
+          <h3 className="text-sm font-medium">Routes without a channel</h3>
+          <p className="text-xs text-muted-foreground">
+            These alerts are routed to channels that no longer exist. The hub refuses to enable lifecycle alerts until they are removed.
+          </p>
+          {orphanRoutes.map((route) => (
+            <div key={route.via} className="border border-amber-500/20 bg-amber-500/5 rounded-lg p-4 flex items-center justify-between gap-3">
+              <div className="min-w-0">
+                <code className="text-sm font-mono font-medium">{route.via}</code>
+                <p className="text-xs text-amber-400 mt-1">No channel named {route.via} is configured.</p>
+              </div>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="text-destructive hover:text-destructive shrink-0"
+                disabled={saving}
+                onClick={() => removeOrphanRoute(route.via)}
+              >
+                <Trash2 className="size-3.5 mr-1" /> Remove route
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
+
       <Button onClick={openAdd} className="gap-2">
         <span className="text-sm">+</span> Add Channel
       </Button>
 
       {/* Add / edit modal */}
-      <Dialog open={showModal} onOpenChange={(open) => { setShowModal(open); if (!open) resetForm() }}>
+      {/* Closing only closes: DialogContent stays mounted for its 200ms exit
+          animation, so clearing the form here would let the operator watch the
+          heading turn into "Edit null" and every field blank out on the way
+          out. openAdd/openEdit re-seed the whole form, so nothing needs
+          clearing on close. */}
+      <Dialog open={showModal} onOpenChange={setShowModal}>
         <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto p-0 gap-0">
           <DialogTitle className="sr-only">{modalMode === "add" ? "Add Channel" : `Edit ${editName}`}</DialogTitle>
           <div className="flex items-center justify-between px-5 py-4 border-b border-border">
@@ -5054,7 +5127,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                 </Button>
               )}
               <div className="flex items-center gap-2 ml-auto">
-                <Button size="sm" variant="outline" onClick={() => { setShowModal(false); resetForm() }}>Cancel</Button>
+                <Button size="sm" variant="outline" onClick={() => setShowModal(false)}>Cancel</Button>
                 <Button size="sm" disabled={saving || !formName.trim() || !formChannel.trim() || !formTokenSecret} onClick={saveChannel}>
                   {modalMode === "add" ? "Add Channel" : "Save changes"}
                 </Button>

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -173,8 +173,8 @@ interface ConcurrencyGroup {
 // Outbound notification config, as returned by GET /api/settings. Notifier
 // settings are provider-specific and inline next to the type, so they keep the
 // snake_case wire names the hub reads them under. The lifecycle block is the
-// redacted view: it uses poll_interval/idle_after, while the PATCH payload
-// (types.LifecycleNotificationsConfig) expects pollInterval/idleAfter.
+// redacted view, and every one of its fields round-trips under the same name
+// the PATCH payload (types.LifecycleNotificationsConfig) reads it under.
 interface NotifierView {
   type: string
   channel?: string
@@ -205,8 +205,8 @@ interface NotificationsView {
     // soon as a patch carries routes.
     via?: string
     routes?: LifecycleRouteView[]
-    poll_interval?: string
-    idle_after?: string
+    pollInterval?: string
+    idleAfter?: string
     events?: LifecycleEventToggles
   }
 }
@@ -4540,6 +4540,12 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
       ? [{ via: lifecycle.via, events: [] }]
       : []
   const routeFor = (name: string) => routes.find((r) => r.via === name)
+  // Alerts off with nothing routed is never a deliberate choice: the master
+  // switch is disabled in that state, so the only way to reach it is buildPatch
+  // clamping `enabled` when the last route went away (or a hub that has never
+  // been configured). Either way the next save that routes a channel may turn
+  // alerts back on.
+  const autoPaused = !enabled && routes.length === 0
 
   const isEventMuted = (eventType: string) => {
     const category = LIFECYCLE_EVENT_CATEGORY[eventType]
@@ -4603,13 +4609,18 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
       // The hub rejects an enabled lifecycle block with no routes ("via is
       // required when enabled") and this screen never exposes `via`, so losing
       // the last route pauses alerts instead of failing the save with a message
-      // about a field that is not on the page.
-      enabled: outRoutes.length > 0 && (next.enabled ?? enabled),
+      // about a field that is not on the page. That pause is ours, not the
+      // operator's: `autoPaused` lifts it on the next save that routes a
+      // channel again. Without it the `false` we wrote latches — every later
+      // save re-sends the stale value read back from GET — and a plain channel
+      // swap silently mutes the hub forever, contradicting the dialog's
+      // "until another channel is routed".
+      enabled: outRoutes.length > 0 && (next.enabled ?? (enabled || autoPaused)),
       routes: outRoutes,
       events: next.events ?? categoryEnabled,
     }
-    if (lifecycle?.poll_interval) outLifecycle.pollInterval = lifecycle.poll_interval
-    if (lifecycle?.idle_after) outLifecycle.idleAfter = lifecycle.idle_after
+    if (lifecycle?.pollInterval) outLifecycle.pollInterval = lifecycle.pollInterval
+    if (lifecycle?.idleAfter) outLifecycle.idleAfter = lifecycle.idleAfter
     return { notifications: { notifiers: outNotifiers, lifecycle: outLifecycle } }
   }
 
@@ -4786,6 +4797,18 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
               const test = tests[name]
               const testEvent = testEventFor(name)
               const canTest = enabled && Boolean(testEvent) && !saving
+              // Rendered as text, not as the disabled button's `title`: the
+              // Button base class sets `disabled:pointer-events-none`, so a
+              // native tooltip on it can never fire. The globally-muted case
+              // has no badge of its own, so this is the only place the screen
+              // says why nothing can reach this channel.
+              const testBlockedReason = !enabled
+                ? "Lifecycle alerts are turned off — this channel receives nothing."
+                : !route
+                  ? null // the "Not receiving alerts" badge above already says it
+                  : !testEvent
+                    ? "Every alert type routed here is muted by a switch above, so this channel receives nothing."
+                    : null
               return (
                 <div key={name} className="border border-border rounded-lg p-4">
                   <div className="flex items-start justify-between gap-3">
@@ -4816,19 +4839,16 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                           </span>
                         )}
                       </div>
+                      {testBlockedReason && (
+                        <p className="text-xs text-muted-foreground mt-2">{testBlockedReason}</p>
+                      )}
                     </div>
                     <div className="flex items-center gap-2 shrink-0">
                       <Button
                         size="sm"
                         variant="outline"
                         disabled={!canTest || test?.status === "sending"}
-                        title={
-                          !enabled
-                            ? "Lifecycle alerts are turned off"
-                            : !testEvent
-                              ? "This channel is not routed to any alert type that is on"
-                              : `Posts a sample "${lifecycleEventLabel(testEvent)}" alert`
-                        }
+                        title={testEvent ? `Posts a sample "${lifecycleEventLabel(testEvent)}" alert` : undefined}
                         onClick={() => sendTest(name)}
                         className="gap-1.5"
                       >

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -303,14 +303,13 @@ export default function SettingsSectionPage() {
   const selectedWorkspaceLabel = selectedWorkspace || "No workspaces"
   const selectedWorkspaceInitial = selectedWorkspace ? selectedWorkspace.trim()[0].toUpperCase() : "-"
 
-  const load = useCallback(
-    () => fetchSettings()
-      .then((data) => setSettings(data))
-      .catch((e) => setError(e instanceof Error ? e.message : "Failed to load")),
-    [],
-  )
+  // Rejects on failure: the re-fetch that follows a save is part of the save,
+  // not bookkeeping after it (see runSave), so its caller has to see the error.
+  const load = useCallback(() => fetchSettings().then((data) => setSettings(data)), [])
 
-  useEffect(() => { load() }, [load])
+  useEffect(() => {
+    load().catch((e) => setError(e instanceof Error ? e.message : "Failed to load"))
+  }, [load])
 
   useEffect(() => {
     const hubUrl = getHubUrl()
@@ -352,22 +351,41 @@ export default function SettingsSectionPage() {
     }
   }, [firstPartIsPlaceholder, routeHasOverviewSlug, routeWorkspace, router, section, selectedWorkspace, workspaces])
 
-  async function save(patch: object): Promise<boolean> {
+  // runSave patches the settings and re-fetches them, returning null on success
+  // or the message to show. The re-fetch is not optional bookkeeping: every
+  // section builds its next patch from `settings`, so a swallowed reload
+  // failure leaves the screen editing a snapshot the hub has already moved
+  // past, and the next save re-sends those stale values — reverting whatever
+  // this one just persisted. Report it as a failed save so the dialog that
+  // triggered it stays open instead of closing on data it can no longer trust.
+  async function runSave(patch: object): Promise<string | null> {
     setSaving(true)
     setError("")
     setSuccess("")
     try {
-      await patchSettings(patch)
+      try {
+        await patchSettings(patch)
+      } catch (e) {
+        return e instanceof Error ? e.message : "Save failed"
+      }
+      try {
+        await load()
+      } catch (e) {
+        const reason = e instanceof Error ? e.message : "the settings could not be re-read"
+        return `Saved, but reloading the settings failed (${reason}). Reload the page before editing again.`
+      }
       setSuccess("Saved")
-      await load()
       setTimeout(() => setSuccess(""), 2000)
-      return true
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Save failed")
-      return false
+      return null
     } finally {
       setSaving(false)
     }
+  }
+
+  async function save(patch: object): Promise<boolean> {
+    const message = await runSave(patch)
+    if (message) setError(message)
+    return message === null
   }
 
   // save(), but handing the failure message back to the caller. The page-level
@@ -375,22 +393,9 @@ export default function SettingsSectionPage() {
   // that saves from its own dialog has to render the error there instead, or
   // the button looks dead.
   async function saveReportingError(patch: object): Promise<string | null> {
-    setSaving(true)
-    setError("")
-    setSuccess("")
-    try {
-      await patchSettings(patch)
-      setSuccess("Saved")
-      await load()
-      setTimeout(() => setSuccess(""), 2000)
-      return null
-    } catch (e) {
-      const message = e instanceof Error ? e.message : "Save failed"
-      setError(message)
-      return message
-    } finally {
-      setSaving(false)
-    }
+    const message = await runSave(patch)
+    if (message) setError(message)
+    return message
   }
 
   // Silent save: patches without the global 'Saved' banner (used for toggle-style updates)
@@ -4465,20 +4470,18 @@ function MCPServersSection({ settings, onSave, saving }: { settings: SettingsDat
 // ── Notifier ─────────────────────────────────────────────────────────────────
 
 // Labels mirror the headlines the hub actually posts, so what an operator
-// checks here is what they will read in the channel.
+// checks here is what they will read in the channel. The list is deliberately
+// the hub's routable vocabulary (types.LifecycleEventTypes) and nothing more:
+// the concrete failure kinds ("Couldn't get a machine", "Agent ran out of
+// time", ...) are how ONE agent_stopped event is titled, never event types of
+// their own, so offering them as separate checkboxes built routes that could
+// never fire.
 const LIFECYCLE_EVENT_LABELS: Record<string, string> = {
   agent_started: "Agent started",
   pr_opened: "PR opened",
   agent_idle: "Agent stalled",
-  agent_stopped: "Agent died",
-  creation_failed: "Couldn't create the agent",
-  provision_failed: "Couldn't get a machine",
-  bootstrap_failed: "Agent crashed during startup",
-  permission_or_auth_failed: "Agent was denied access",
-  provider_lost: "Lost contact with the provider",
-  timeout: "Agent ran out of time",
+  agent_stopped: "Agent died or failed",
   done_without_pr: "Agent finished without a PR",
-  unknown_failure: "Agent failed",
 }
 
 type LifecycleCategory = keyof LifecycleEventToggles
@@ -4490,14 +4493,7 @@ const LIFECYCLE_EVENT_CATEGORY: Record<string, LifecycleCategory> = {
   pr_opened: "prOpened",
   agent_idle: "agentIdle",
   agent_stopped: "failures",
-  creation_failed: "failures",
-  provision_failed: "failures",
-  bootstrap_failed: "failures",
-  permission_or_auth_failed: "failures",
-  provider_lost: "failures",
-  timeout: "failures",
   done_without_pr: "failures",
-  unknown_failure: "failures",
 }
 
 const LIFECYCLE_CATEGORIES: { id: LifecycleCategory; label: string; description: string }[] = [

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -4970,7 +4970,15 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                   ? "Remove the routes pointing at deleted channels first"
                   : undefined
             }
-            onCheckedChange={(checked) => { testGenerationAll.current++; setTests({}); savePatch({ enabled: checked }) }}
+            // Invalidated only once the hub has taken the change, exactly as
+            // saveChannel/removeChannel do it: a rejected save leaves every
+            // card's result describing the configuration it was sent under, and
+            // wiping it here would destroy a real diagnosis (a
+            // channel_not_found banner) with nothing to replace it.
+            onCheckedChange={async (checked) => {
+              const { persisted } = await savePatch({ enabled: checked })
+              if (persisted) { testGenerationAll.current++; setTests({}) }
+            }}
             aria-label="Enable lifecycle alerts"
           />
         </div>
@@ -4989,13 +4997,18 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                   className="mt-0.5"
                   checked={categoryEnabled[category.id]}
                   disabled={saving || !enabled}
-                  onCheckedChange={(checked) => {
+                  onCheckedChange={async (checked) => {
                     // A muted category can change what (or whether) a channel
                     // receives anything, so every test result on the page is
-                    // now about a configuration that no longer exists.
-                    testGenerationAll.current++
-                    setTests({})
-                    savePatch({ events: { ...categoryEnabled, [category.id]: checked } })
+                    // now about a configuration that no longer exists — but
+                    // only once the hub has actually taken the change. A
+                    // rejected save changed nothing, and clearing the results
+                    // anyway would erase a live failure diagnosis.
+                    const { persisted } = await savePatch({ events: { ...categoryEnabled, [category.id]: checked } })
+                    if (persisted) {
+                      testGenerationAll.current++
+                      setTests({})
+                    }
                   }}
                   aria-label={`Toggle ${category.label} alerts`}
                 />

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -4478,8 +4478,8 @@ async function sendTestNotification(eventType: string, via: string): Promise<voi
   const res = await fetch(`${hubUrl}/api/notifications/test`, {
     method: "POST",
     headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
-    // via is forward-looking: the hub currently sends the test through the
-    // configured lifecycle notifier and ignores unknown fields.
+    // via picks which configured notifier to probe; the hub falls back to the
+    // first effective route when it is omitted.
     body: JSON.stringify({ event_type: eventType, dry_run: false, via }),
   })
   const raw = await res.text()

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -4547,12 +4547,17 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
   // the route and offer a way to drop it. Silently dropping it in buildPatch
   // would delete config the operator never saw.
   const orphanRoutes = routes.filter((route) => !notifiers[route.via])
-  // Alerts off with nothing routed is never a deliberate choice: the master
-  // switch is disabled in that state, so the only way to reach it is buildPatch
-  // clamping `enabled` when the last route went away (or a hub that has never
-  // been configured). Either way the next save that routes a channel may turn
-  // alerts back on.
-  const autoPaused = !enabled && routes.length === 0
+  // A hub that has never had a lifecycle block: routing its first channel turns
+  // alerts on. This is deliberately NOT inferred from (enabled=false, routes=[]),
+  // which an operator reaches by muting the master switch and then removing the
+  // last channel — see clampedPause.
+  const neverConfigured = !lifecycle
+  const secretNames = [...(settings.secrets || [])].sort((a, b) => a.localeCompare(b))
+  // A token_secret naming a hub secret that no longer exists. The <select> below
+  // would otherwise render blank while still holding the dangling name, so Save
+  // writes the broken reference back with nothing on screen saying why the
+  // channel never delivers.
+  const secretMissing = (name?: string) => Boolean(name) && !secretNames.includes(name as string)
 
   const isEventMuted = (eventType: string) => {
     const category = LIFECYCLE_EVENT_CATEGORY[eventType]
@@ -4580,6 +4585,18 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
   // reopened on another channel — that discards unsaved form state and blames
   // the wrong channel.
   const saveGeneration = useRef(0)
+
+  // Set only when buildPatch itself had to clear `enabled` because the route set
+  // went empty. Deriving that from the reloaded config instead (enabled=false
+  // with no routes) cannot tell our clamp from an operator who muted the master
+  // switch and then removed the last channel — and re-routing a channel would
+  // then silently un-mute a hub the operator deliberately paused.
+  const clampedPause = useRef(false)
+
+  // Invalidates in-flight test sends. A result that lands after the channel's
+  // destination or routing changed describes a message that went somewhere else
+  // — exactly the stale state every setTests() below clears.
+  const testGeneration = useRef(0)
 
   const openAdd = () => { saveGeneration.current++; resetForm(); setModalMode("add"); setShowModal(true) }
   const openEdit = (name: string) => {
@@ -4619,17 +4636,20 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
       via: route.via,
       events: route.events?.length ? route.events : [],
     }))
+    // The hub rejects an enabled lifecycle block with no routes ("via is
+    // required when enabled") and this screen never exposes `via`, so losing the
+    // last route pauses alerts instead of failing the save with a message about
+    // a field that is not on the page. That pause is ours, not the operator's,
+    // and `clampedPause` lifts it on the next save that routes a channel again.
+    // Without it the `false` we wrote latches — every later save re-sends the
+    // stale value read back from GET — and a plain channel swap silently mutes
+    // the hub forever, contradicting the dialog's "until another channel is
+    // routed". The flag is recorded here rather than inferred from the reloaded
+    // config so a deliberate master-switch OFF survives a channel swap.
+    const wantEnabled = next.enabled ?? (enabled || clampedPause.current || neverConfigured)
+    clampedPause.current = outRoutes.length === 0 && wantEnabled
     const outLifecycle: Record<string, unknown> = {
-      // The hub rejects an enabled lifecycle block with no routes ("via is
-      // required when enabled") and this screen never exposes `via`, so losing
-      // the last route pauses alerts instead of failing the save with a message
-      // about a field that is not on the page. That pause is ours, not the
-      // operator's: `autoPaused` lifts it on the next save that routes a
-      // channel again. Without it the `false` we wrote latches — every later
-      // save re-sends the stale value read back from GET — and a plain channel
-      // swap silently mutes the hub forever, contradicting the dialog's
-      // "until another channel is routed".
-      enabled: outRoutes.length > 0 && (next.enabled ?? (enabled || autoPaused)),
+      enabled: outRoutes.length > 0 && wantEnabled,
       routes: outRoutes,
       events: next.events ?? categoryEnabled,
     }
@@ -4673,6 +4693,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     const failure = await onSave(buildPatch({ notifiers: nextNotifiers, routes: nextRoutes }))
     // The channel's destination or routing just changed, so any test result
     // sitting on its card is about a message that went somewhere else.
+    testGeneration.current++
     setTests((current) => { const { [name]: _stale, ...rest } = current; return rest })
     if (generation !== saveGeneration.current) return
     if (failure) { setFormError(failure); return }
@@ -4687,6 +4708,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
       notifiers: nextNotifiers,
       routes: routes.filter((route) => route.via !== name),
     }))
+    testGeneration.current++
     setTests((current) => { const { [name]: _removed, ...rest } = current; return rest })
     if (generation !== saveGeneration.current) return
     if (failure) { setFormError(failure); return }
@@ -4696,6 +4718,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
   // Dropping a route whose notifier is gone. It has no card of its own, so this
   // is the only way back to a hub that can turn lifecycle alerts on again.
   async function removeOrphanRoute(via: string) {
+    testGeneration.current++
     setTests((current) => { const { [via]: _removed, ...rest } = current; return rest })
     // The page-level banner reports a failure here: this save is not made from
     // the dialog, so nothing covers the banner.
@@ -4716,18 +4739,25 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
   async function sendTest(name: string) {
     const eventType = testEventFor(name)
     if (!eventType) return
+    // The hub bounds a test send at 30s, plenty of time for the operator to edit
+    // the channel meanwhile. Landing the result afterwards would show a green
+    // "sent" under a destination the message never reached.
+    const generation = testGeneration.current
     setTests((current) => ({ ...current, [name]: { status: "sending", message: "" } }))
+    const settle = (state: TestState) => {
+      setTests((current) => {
+        if (generation !== testGeneration.current) {
+          const { [name]: _stale, ...rest } = current
+          return rest
+        }
+        return { ...current, [name]: state }
+      })
+    }
     try {
       await sendTestNotification(eventType, name)
-      setTests((current) => ({
-        ...current,
-        [name]: { status: "ok", message: `Sent a "${lifecycleEventLabel(eventType)}" test alert.` },
-      }))
+      settle({ status: "ok", message: `Sent a "${lifecycleEventLabel(eventType)}" test alert.` })
     } catch (e) {
-      setTests((current) => ({
-        ...current,
-        [name]: { status: "error", message: e instanceof Error ? e.message : "Test send failed" },
-      }))
+      settle({ status: "error", message: e instanceof Error ? e.message : "Test send failed" })
     }
   }
 
@@ -4790,7 +4820,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                   ? "Remove the routes pointing at deleted channels first"
                   : undefined
             }
-            onCheckedChange={(checked) => { setTests({}); onSave(buildPatch({ enabled: checked })) }}
+            onCheckedChange={(checked) => { testGeneration.current++; setTests({}); onSave(buildPatch({ enabled: checked })) }}
             aria-label="Enable lifecycle alerts"
           />
         </div>
@@ -4813,6 +4843,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                     // A muted category can change what (or whether) a channel
                     // receives anything, so every test result on the page is
                     // now about a configuration that no longer exists.
+                    testGeneration.current++
                     setTests({})
                     onSave(buildPatch({ events: { ...categoryEnabled, [category.id]: checked } }))
                   }}
@@ -4863,7 +4894,12 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                         <span className="font-mono">{notifier.channel || "no channel"}</span>
                         {" · "}
                         {notifier.token_secret
-                          ? <>token: <span className="font-mono">{notifier.token_secret}</span></>
+                          ? (
+                            <>
+                              token: <span className={cn("font-mono", secretMissing(notifier.token_secret) && "text-amber-400")}>{notifier.token_secret}</span>
+                              {secretMissing(notifier.token_secret) && <span className="text-amber-400"> — secret not found</span>}
+                            </>
+                          )
                           : <span className="text-amber-400">no token secret</span>}
                       </p>
                       <div className="mt-2">
@@ -4999,13 +5035,25 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                 className="w-full h-8 text-sm rounded-md border border-input bg-background px-3"
               >
                 <option value="">Select secret…</option>
-                {[...(settings.secrets || [])].sort((a, b) => a.localeCompare(b)).map((secret) => (
+                {/* A dangling reference has no option of its own, so the
+                    controlled select would render blank while Save happily
+                    writes the broken name back. Give it one, flagged. */}
+                {secretMissing(formTokenSecret) && (
+                  <option value={formTokenSecret}>{formTokenSecret} (secret not found)</option>
+                )}
+                {secretNames.map((secret) => (
                   <option key={secret} value={secret}>{secret}</option>
                 ))}
               </select>
-              <p className="text-xs text-muted-foreground mt-1">
-                The hub secret holding the Slack bot token (<span className="font-mono">xoxb-…</span>). Add it under Secrets first.
-              </p>
+              {secretMissing(formTokenSecret) ? (
+                <p className="text-xs text-amber-400 mt-1">
+                  No hub secret named <span className="font-mono">{formTokenSecret}</span> exists, so sends through this channel fail. Add it under Secrets, or pick another.
+                </p>
+              ) : (
+                <p className="text-xs text-muted-foreground mt-1">
+                  The hub secret holding the Slack bot token (<span className="font-mono">xoxb-…</span>). Add it under Secrets first.
+                </p>
+              )}
             </div>
 
             {/* Routing */}

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -4570,17 +4570,20 @@ type TestState = { status: "sending" | "ok" | "error"; message: string }
 
 // Records that the Notifier screen itself cleared `enabled` because the route
 // set went empty — the pause is ours, not the operator's, and the next save
-// that routes a channel must lift it. It lives in sessionStorage rather than in
+// that routes a channel must lift it. It lives in localStorage rather than in
 // component state because NotifierSection unmounts on every navigation inside
 // Settings (and on reload): a clamp forgotten there latches the `enabled:false`
 // this screen wrote on its own initiative, so re-routing a channel would no
-// longer restore alerts — exactly what the edit dialog promises it does. The
-// stored value is the hub URL, so the clamp never leaks across hubs.
+// longer restore alerts — exactly what the edit dialog promises it does.
+// localStorage rather than sessionStorage because the clamp outlives the
+// browsing context that wrote it: the repair is routinely finished in another
+// tab, or after a browser restart, and a per-tab clamp would be gone by then.
+// The stored value is the hub URL, so the clamp never leaks across hubs.
 const CLAMPED_PAUSE_STORAGE_KEY = "elasticclaw:notifier-clamped-pause"
 
 function readClampedPause(): boolean {
   try {
-    return sessionStorage.getItem(CLAMPED_PAUSE_STORAGE_KEY) === getHubUrl()
+    return localStorage.getItem(CLAMPED_PAUSE_STORAGE_KEY) === getHubUrl()
   } catch {
     return false
   }
@@ -4588,8 +4591,8 @@ function readClampedPause(): boolean {
 
 function writeClampedPause(clamped: boolean): void {
   try {
-    if (clamped) sessionStorage.setItem(CLAMPED_PAUSE_STORAGE_KEY, getHubUrl())
-    else sessionStorage.removeItem(CLAMPED_PAUSE_STORAGE_KEY)
+    if (clamped) localStorage.setItem(CLAMPED_PAUSE_STORAGE_KEY, getHubUrl())
+    else localStorage.removeItem(CLAMPED_PAUSE_STORAGE_KEY)
   } catch {
     // Storage unavailable (private mode): the clamp degrades to not existing,
     // which is what the screen did before it was persisted at all.
@@ -4657,6 +4660,12 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
   const [formName, setFormName] = useState("")
   const [formChannel, setFormChannel] = useState("")
   const [formTokenSecret, setFormTokenSecret] = useState("")
+  // The hub refuses to build a slack notifier whose min_send_interval it cannot
+  // parse, and re-checks it on every save that touches the channel. A hub.yaml
+  // written by hand can hold such a value, so the screen must offer a way to
+  // repair it: without this field the save can never be made to pass, and a
+  // notifier a pipeline notifies through cannot be removed either.
+  const [formMinSendInterval, setFormMinSendInterval] = useState("")
   const [formRouted, setFormRouted] = useState(true)
   const [formEvents, setFormEvents] = useState<string[]>([])
   const [formError, setFormError] = useState("")
@@ -4669,7 +4678,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
   const [saveErrors, setSaveErrors] = useState<Record<string, string>>({})
 
   const resetForm = () => {
-    setFormName(""); setFormChannel(""); setFormTokenSecret("")
+    setFormName(""); setFormChannel(""); setFormTokenSecret(""); setFormMinSendInterval("")
     setFormRouted(true); setFormEvents([]); setFormError(""); setEditName(null)
   }
 
@@ -4704,6 +4713,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     setFormName(name)
     setFormChannel(notifier.channel || "")
     setFormTokenSecret(notifier.token_secret || "")
+    setFormMinSendInterval(notifier.min_send_interval || "")
     setFormRouted(Boolean(route))
     setFormEvents(route?.events ? [...route.events] : [])
     setFormError("")
@@ -4727,7 +4737,12 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
       if (notifier.channel) out.channel = notifier.channel
       if (notifier.token_secret) out.token_secret = notifier.token_secret
       if (notifier.api_base) out.api_base = notifier.api_base
-      if (notifier.min_send_interval) out.min_send_interval = notifier.min_send_interval
+      // An emptied interval is sent as "" rather than omitted when the stored
+      // notifier has one: the hub folds a patch over the settings already on
+      // disk, so omitting the key would keep the value the operator just
+      // cleared — and keep rejecting the save if that value is unparseable.
+      const interval = notifier.min_send_interval ?? ""
+      if (interval || notifiers[name]?.min_send_interval) out.min_send_interval = interval
       outNotifiers[name] = out
     }
     // Always an array: sending routes is what clears the legacy `via`.
@@ -4798,6 +4813,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
         type: existing?.type || "slack",
         channel,
         token_secret: formTokenSecret,
+        min_send_interval: formMinSendInterval.trim(),
       },
     }
     // Every type checked is the same thing as no filter; store it as one so a
@@ -5197,6 +5213,22 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                   The <strong>hub</strong> secret holding the Slack bot token (<span className="font-mono">xoxb-…</span>). Add it under Settings → Secrets → Hub first — workspace secrets are a separate store and are never read here.
                 </p>
               )}
+            </div>
+
+            {/* The hub rejects a channel whose interval it cannot parse, on
+                every save that touches it. Editable here so a value written by
+                hand can be repaired from the screen instead of hub.yaml. */}
+            <div>
+              <label className="text-xs text-muted-foreground mb-1 block">Minimum send interval</label>
+              <Input
+                placeholder="30s"
+                value={formMinSendInterval}
+                onChange={(e) => setFormMinSendInterval(e.target.value)}
+                className="font-mono text-sm h-8"
+              />
+              <p className="text-xs text-muted-foreground mt-1">
+                Optional. How long this channel waits between messages, as a duration (<span className="font-mono">30s</span>, <span className="font-mono">5m</span>). Leave empty for the default.
+              </p>
             </div>
 
             {/* Routing */}

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -4623,6 +4623,10 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
         : []
   ).map((route) => ({ ...route, via: (route.via || "").trim() }))
   const routeFor = (name: string) => routes.find((r) => r.via === name)
+  // The predicate saveChannel stores by: an allow-list naming every type is no
+  // filter at all. Shared by the card badge and the dialog so the same route
+  // cannot read as filtered on one and unfiltered on the other.
+  const isAllAlerts = (events?: string[]) => !events?.length || events.length === eventTypes.length
   // A route whose notifier is gone. The hub deliberately accepts this on disk
   // while alerts are paused ("an operator who mutes alerts and then deletes the
   // notifier must not be left with a hub that refuses to load"), but it rejects
@@ -4875,10 +4879,11 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     setTests((current) => ({ ...current, [name]: { status: "sending", message: "" } }))
     const settle = (state: TestState) => {
       setTests((current) => {
-        if (generation !== testStamp(name)) {
-          const { [name]: _stale, ...rest } = current
-          return rest
-        }
+        // A superseded result is dropped, not written — and it must leave the
+        // map alone: whatever sits under this name now belongs to the newer
+        // send that replaced this one (its "sending" indicator, or its real
+        // error), so deleting it would erase a live result.
+        if (generation !== testStamp(name)) return current
         return { ...current, [name]: state }
       })
     }
@@ -4894,7 +4899,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
   // Same predicate saveChannel stores by: every type checked is persisted as
   // the empty allow-list, so the summary must call it "all alerts" too — or it
   // promises a filter the save is about to discard.
-  const formAllAlerts = formEvents.length === 0 || formEvents.length === eventTypes.length
+  const formAllAlerts = isAllAlerts(formEvents)
   // Routing this channel off (or removing it) pauses the hub when it is the
   // last one left; buildPatch clears `enabled` rather than failing the save.
   const otherRoutedCount = routes.filter((route) => route.via !== editName && notifiers[route.via]).length
@@ -5036,13 +5041,13 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                           <span className="text-xs bg-muted text-muted-foreground px-2 py-1 rounded font-medium">
                             Not receiving alerts
                           </span>
-                        ) : route.events?.length ? (
-                          <span className="text-xs bg-muted text-muted-foreground px-2 py-1 rounded font-medium">
-                            {route.events.length} of {eventTypes.length} alert types
-                          </span>
-                        ) : (
+                        ) : isAllAlerts(route.events) ? (
                           <span className="text-xs bg-blue-500/10 text-blue-400 border border-blue-500/20 px-2 py-1 rounded font-medium">
                             All alerts
+                          </span>
+                        ) : (
+                          <span className="text-xs bg-muted text-muted-foreground px-2 py-1 rounded font-medium">
+                            {route.events?.length} of {eventTypes.length} alert types
                           </span>
                         )}
                       </div>
@@ -5237,7 +5242,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                         </div>
                         <p className="text-xs text-muted-foreground">
                           {formAllAlerts
-                            ? "This channel receives every alert type — including any new type added later."
+                            ? "Saved as receive-all: this channel gets every alert type, including any added later."
                             : "Only the checked types reach this channel."}
                         </p>
                         {!formAllAlerts && (

--- a/web/scripts/check-static-export.sh
+++ b/web/scripts/check-static-export.sh
@@ -10,39 +10,32 @@ set -euo pipefail
 OUT_DIR="${1:-out}"
 ERRORS=0
 
+# The section list is READ from sections.ts rather than restated here: it is
+# the same list page.tsx's generateStaticParams derives the routes from, so a
+# hand-maintained copy drifts silently — a section added there but missed here
+# is exactly the missing-route failure this script exists to catch.
+SECTIONS_FILE="$(cd "$(dirname "$0")/.." && pwd)/app/settings/[[...parts]]/sections.ts"
+if [ ! -f "$SECTIONS_FILE" ]; then
+  echo "ERROR: cannot read the section list at $SECTIONS_FILE"
+  exit 1
+fi
+SECTIONS=$(sed -n '/VALID_SECTIONS = \[/,/^\]/p' "$SECTIONS_FILE" | sed -n 's/^[[:space:]]*"\([a-z0-9-]*\)".*$/\1/p')
+if [ -z "$SECTIONS" ]; then
+  echo "ERROR: no sections parsed from $SECTIONS_FILE"
+  exit 1
+fi
+
 # Expected paths that must exist for the settings route, plus the
 # standalone analytics route the agents shell toggles into.
 EXPECTED_PATHS=(
   "analytics/index.html"
   "settings/index.html"
-  "settings/runtimes/index.html"
-  "settings/models/index.html"
-  "settings/github/index.html"
-  "settings/authentication/index.html"
-  "settings/issue-trackers/index.html"
-  "settings/workspaces/index.html"
-  "settings/workflows/index.html"
-  "settings/secrets/index.html"
-  "settings/mcp-servers/index.html"
-  "settings/ai-config/index.html"
-  "settings/analytics/index.html"
-  "settings/doctor/index.html"
-  "settings/troubleshoot/index.html"
   "settings/_workspace/index.html"
-  "settings/_workspace/runtimes/index.html"
-  "settings/_workspace/models/index.html"
-  "settings/_workspace/github/index.html"
-  "settings/_workspace/authentication/index.html"
-  "settings/_workspace/issue-trackers/index.html"
-  "settings/_workspace/workspaces/index.html"
-  "settings/_workspace/workflows/index.html"
-  "settings/_workspace/secrets/index.html"
-  "settings/_workspace/mcp-servers/index.html"
-  "settings/_workspace/ai-config/index.html"
-  "settings/_workspace/analytics/index.html"
-  "settings/_workspace/doctor/index.html"
-  "settings/_workspace/troubleshoot/index.html"
 )
+for section in $SECTIONS; do
+  EXPECTED_PATHS+=("settings/$section/index.html")
+  EXPECTED_PATHS+=("settings/_workspace/$section/index.html")
+done
 
 echo "Checking static export in: $OUT_DIR"
 echo ""


### PR DESCRIPTION
## Summary

Replaces the single-destination Slack lifecycle notifier (`notifications.lifecycle.via`) with N-channel routing configured per alert type, plus a new **Notifier** settings screen.

### Config

```yaml
notifications:
  notifiers:
    eng-alerts: {type: slack, channel: C01…, token_secret: slack_bot_token}
    eng-prs:    {type: slack, channel: C02…, token_secret: slack_bot_token}
  lifecycle:
    enabled: true
    routes:
      - via: eng-alerts
        events: [agent_stopped, agent_idle]   # allow-list
      - via: eng-prs
        events: []                            # empty = receives everything
```

- `events` is an allow-list over the **5 lifecycle event types** (`agent_started`, `pr_opened`, `agent_stopped`, `agent_idle`, `done_without_pr`); empty/absent means the channel receives all alerts, including types added later. The 7 failure subtypes (`timeout`, `provision_failed`, …) are `failure_type` values inside `agent_stopped`, never standalone events, so they are not routable — routing by failure subtype would be a follow-up feature.
- Legacy `via` keeps working (treated as one route with an empty allow-list) with byte-identical delivery behavior; the global event toggles still mute before routing.

### Backend

- `pkg/types`: `LifecycleRoute`, `Routes`, `EffectiveRoutes()`, canonical `LifecycleEventTypes`, validation.
- `pkg/hub`: fan-out in the lifecycle, claw, and idle passes; `slack_notification_deliveries_v2` dedupe keyed `(event_id, notifier)` with an upgrade fence (historical events never resend); per-route cursors, baselines, and backpressure — a broken/archived/unbuildable channel parks only its own route and keeps its backlog; routes added later start at the stream head; migration paths (via→routes, route add/remove/swap/collapse) covered by dedicated regression tests; doctor validates every route.
- Settings API: GET/PATCH for the notifications block (secret names only, never values; validation — including provider-level via `notify.ValidateConfig` — before any disk write; `api_base` changes restricted to `https` on `slack.com`/`*.slack.com` to prevent SSRF/token exfiltration; dependency check blocks deleting a notifier referenced by pipeline `notify:` actions).
- `POST /api/notifications/test` accepts `via` to target a specific channel.

### Web UI

New **Notifier** item in the settings sidebar (System group): lifecycle master switch + global toggles, per-channel cards with routing summary and per-channel *Send test*, add/edit modal with channel-ID validation, secret picker, `min_send_interval`, and the event-type allow-list with an explicit receive-all state. Handles orphan routes, duplicate routes, unknown event names in paused configs, stale secrets, and PATCH-failure surfacing inside the dialog.

### Review process

3 multi-agent review loops (4 specialties × paired gpt-5.6 + Claude reviewers, adversarial verification, fix + regression tests per round): **95 confirmed findings fixed** across 15 rounds, including 1 SSRF (api_base), claw-pass starvation, and a large family of per-route cursor/baseline migration bugs. Rounds were still producing findings at cutoff — the per-route cursor/baseline state machine has grown complex, and a simplifying redesign is recommended before extending it further.

### Testing

- `go build`/`go vet` clean; `go test ./pkg/hub/... ./pkg/types/...` green except 3 pre-existing failures unrelated to this diff (DONE-signal tests hitting the live GitHub API), verified to fail identically at the base commit.
- `tsc --noEmit`, lint, `npm run build` clean; `/settings/notifier` in the static export and its smoke check.
- UI exercised against a seeded local hub.
- Known CI noise: `TestBuildOpenClawOAuthAuthSyncShellMigratesGrokIntoSQLite` is a pre-existing flake (deflake in progress separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)