### PR TITLE
fix(hub): deflake Grok OAuth sync test (SIGPIPE on stdin-ignoring fake openclaw)

### DIFF
--- a/pkg/hub/bootstrap_test.go
+++ b/pkg/hub/bootstrap_test.go
@@ -576,6 +576,9 @@ db.close();
 	fakeOpenClaw := filepath.Join(fakeBin, "openclaw")
 	invocationsPath := filepath.Join(home, "openclaw-invocations")
 	fakeOpenClawScript := `#!/bin/sh
+# Consume stdin like the real openclaw does; exiting with the pipe unread
+# lets the writer die with SIGPIPE under pipefail.
+cat >/dev/null
 printf '%s\n' "$*" >> "$OPENCLAW_INVOCATIONS"
 if [ "$*" = "models auth list --provider xai --json" ]; then
   printf '%s\n' '{"profiles":[{"id":"xai:default","type":"oauth"}]}'


### PR DESCRIPTION
## Problem

`TestBuildOpenClawOAuthAuthSyncShellMigratesGrokIntoSQLite` flakes intermittently in one of the two unit-test CI jobs (seen twice on PR #659, 2026-08-25/26), with two apparent symptoms:

- `run OAuth auth sync: exit status 141` (SIGPIPE)
- `missing a valid expires_at timestamp` assertion failure

## Root cause

Both symptoms are the same race. The generated sync shell runs, under `set -euo pipefail`:

```sh
printf '%s\n' 'elasticclaw-auth-store-initializer' | openclaw models auth paste-token ...
```

The test's fake `openclaw` script logged `"$*"` and exited **without ever reading stdin**. When the fake exited before `printf` wrote (a scheduling race, essentially only visible on loaded CI runners), `printf` died with SIGPIPE (141) and `pipefail` aborted the whole script:

- in the first (valid) run → `exit status 141`
- in the second (invalid-expiry) run → the script died before reaching the node validation, so the expected `missing a valid expires_at timestamp` message never appeared and the assertion failed while quoting it.

The real `openclaw` always consumes stdin (`paste-token` reads the token from it), so this is purely a test-fixture bug — no production change needed.

## Fix

The fake `openclaw` now does `cat >/dev/null` before exiting, matching the real binary's stdin behavior. Non-piped invocations inherit `/dev/null` stdin from the test harness, so `cat` returns immediately.

## Verification

- Reproduced the race in isolation: with a stdin-ignoring fake under 8 CPU-load loops, `printf | fake` returned 141 in 2/2000 iterations.
- After the fix: the full test passed 60/60 `-count` runs under the same background CPU load (previously the CI failure rate matched the ~0.1–0.2%/pipeline race window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)