### PR TITLE
feat(hub): notify agent when a tracked PR enters a merge conflict

### DIFF
--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -181,6 +181,12 @@ func migrate(db *sql.DB) error {
 	if err := addColumn(db, "claw_prs", "token_miss_count", `INTEGER NOT NULL DEFAULT 0`); err != nil {
 		return err
 	}
+	// last_mergeable_state stores the last GitHub mergeable_state observed for
+	// the PR (e.g. "clean", "dirty", "blocked", "unknown"). It is used to
+	// surface a merge conflict to the agent only once per conflict episode.
+	if err := addColumn(db, "claw_prs", "last_mergeable_state", `TEXT NOT NULL DEFAULT ''`); err != nil {
+		return err
+	}
 	// The PR watcher never polls claws in terminal/offline states. Legacy rows
 	// therefore cannot safely retain the historical default of "open". Preserve
 	// a known terminal task-run PR state when available; otherwise mark it unknown.
@@ -804,6 +810,7 @@ func migrate(db *sql.DB) error {
 		permanent_failure_count INTEGER NOT NULL DEFAULT 0,
 		mention_only INTEGER NOT NULL DEFAULT 0, -- 1 = URL scanned from a message, not delivered via [DONE]; never gates finalization
 		token_miss_count INTEGER NOT NULL DEFAULT 0, -- consecutive polls with no resolvable GitHub token for the repo; separate from permanent_failure_count (see migrate)
+		last_mergeable_state TEXT NOT NULL DEFAULT '', -- last GitHub mergeable_state observed (e.g. "dirty"); used for one-shot conflict notifications
 		created_at  DATETIME NOT NULL,
 		UNIQUE(claw_id, pr_url)
 	);

--- a/pkg/hub/no_progress.go
+++ b/pkg/hub/no_progress.go
@@ -213,18 +213,18 @@ func (s *Server) turnProgressFingerprint(clawID, response string) (string, error
 	// state/merged are part of the fingerprint: resolved rows survive in
 	// claw_prs until the claw is finalized, so a merge or close no longer
 	// changes the row set — only these columns make it visible as progress.
-	rows, err := s.db.Query(`SELECT repo, pr_number, state, merged, last_ci_sha, last_ci_conclusion, last_comment_id, last_comment_at, last_review_comment_id, last_review_id, pr_conditions_fired FROM claw_prs WHERE claw_id=? ORDER BY repo, pr_number`, clawID)
+	rows, err := s.db.Query(`SELECT repo, pr_number, state, merged, last_ci_sha, last_ci_conclusion, last_comment_id, last_comment_at, last_review_comment_id, last_review_id, pr_conditions_fired, last_mergeable_state FROM claw_prs WHERE claw_id=? ORDER BY repo, pr_number`, clawID)
 	if err != nil {
 		return "", fmt.Errorf("query tracked pull requests: %w", err)
 	}
 	for rows.Next() {
-		var repo, prState, ciSHA, ciConclusion, commentAt string
+		var repo, prState, ciSHA, ciConclusion, commentAt, mergeableState string
 		var number, prMerged, commentID, reviewCommentID, reviewID, conditions int
-		if err := rows.Scan(&repo, &number, &prState, &prMerged, &ciSHA, &ciConclusion, &commentID, &commentAt, &reviewCommentID, &reviewID, &conditions); err != nil {
+		if err := rows.Scan(&repo, &number, &prState, &prMerged, &ciSHA, &ciConclusion, &commentID, &commentAt, &reviewCommentID, &reviewID, &conditions, &mergeableState); err != nil {
 			rows.Close()
 			return "", fmt.Errorf("scan tracked pull request: %w", err)
 		}
-		parts = append(parts, fmt.Sprintf("pr=%s#%d:%s:%d:%s:%s:%d:%s:%d:%d:%d", repo, number, prState, prMerged, ciSHA, ciConclusion, commentID, commentAt, reviewCommentID, reviewID, conditions))
+		parts = append(parts, fmt.Sprintf("pr=%s#%d:%s:%d:%s:%s:%d:%s:%d:%d:%d:%s", repo, number, prState, prMerged, ciSHA, ciConclusion, commentID, commentAt, reviewCommentID, reviewID, conditions, mergeableState))
 	}
 	if err := rows.Err(); err != nil {
 		rows.Close()

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -2,6 +2,7 @@ package hub
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -106,6 +107,7 @@ func (s *Server) storePRMention(clawID, repo string, prNumber int, prURL string,
 	var lastCommentTime time.Time
 	var headSHA string
 	var title string
+	var mergeableState string
 	if token != "" {
 		commentsData, err := githubAPIList(fmt.Sprintf("repos/%s/issues/%d/comments", repo, prNumber), token)
 		if err == nil {
@@ -137,6 +139,7 @@ func (s *Server) storePRMention(clawID, repo string, prNumber int, prURL string,
 				headSHA, _ = headObj["sha"].(string)
 			}
 			title, _ = prData["title"].(string)
+			mergeableState, _ = prData["mergeable_state"].(string)
 		}
 		reviewsData, err := githubAPIList(fmt.Sprintf("repos/%s/pulls/%d/reviews", repo, prNumber), token)
 		if err == nil {
@@ -150,8 +153,8 @@ func (s *Server) storePRMention(clawID, repo string, prNumber int, prURL string,
 	// hitting the (claw_id, pr_url) unique index means the PR is already
 	// tracked — idempotent success, not a persistence failure.
 	res, err := s.db.Exec(
-		`INSERT OR IGNORE INTO claw_prs(id,claw_id,repo,pr_number,pr_url,title,last_comment_id,last_comment_at,last_review_id,last_ci_sha,mention_only,created_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?)`,
-		prID, clawID, repo, prNumber, prURL, title, maxCommentID, lastCommentAt, maxReviewID, headSHA, boolInt(mentionOnly), now(),
+		`INSERT OR IGNORE INTO claw_prs(id,claw_id,repo,pr_number,pr_url,title,last_comment_id,last_comment_at,last_review_id,last_ci_sha,mention_only,last_mergeable_state,created_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		prID, clawID, repo, prNumber, prURL, title, maxCommentID, lastCommentAt, maxReviewID, headSHA, boolInt(mentionOnly), mergeableState, now(),
 	)
 	if err != nil {
 		log.Printf("[pr-watcher] failed to persist PR %s#%d for claw %s: %v", repo, prNumber, clawID[:8], err)
@@ -225,14 +228,15 @@ func (s *Server) upgradeMentionOnlyPR(clawID, prURL string) error {
 
 // prMentionCandidate is a PR URL pending claw_prs registration.
 type prMentionCandidate struct {
-	repo      string
-	number    int
-	url       string
-	comment   int64
-	review    int64
-	commentAt string
-	headSHA   string
-	title     string
+	repo             string
+	number           int
+	url              string
+	comment          int64
+	review           int64
+	commentAt        string
+	headSHA          string
+	title            string
+	mergeableState   string
 }
 
 // preparePRMention loads GitHub watermarks for a PR insert. alreadyTracked is
@@ -286,6 +290,7 @@ func (s *Server) preparePRMention(clawID, repo string, prNumber int, prURL strin
 			row.headSHA, _ = headObj["sha"].(string)
 		}
 		row.title, _ = prData["title"].(string)
+		row.mergeableState, _ = prData["mergeable_state"].(string)
 	}
 	reviewsData, err := githubAPIList(fmt.Sprintf("repos/%s/pulls/%d/reviews", repo, prNumber), token)
 	if err == nil {
@@ -334,8 +339,8 @@ func (s *Server) insertClawPRsAtomic(clawID string, rows []prMentionCandidate, m
 		}
 		prID := uuid.New().String()
 		res, err := tx.Exec(
-			`INSERT OR IGNORE INTO claw_prs(id,claw_id,repo,pr_number,pr_url,title,last_comment_id,last_comment_at,last_review_id,last_ci_sha,mention_only,created_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?)`,
-			prID, clawID, row.repo, row.number, row.url, row.title, row.comment, row.commentAt, row.review, row.headSHA, boolInt(mentionOnly), now(),
+			`INSERT OR IGNORE INTO claw_prs(id,claw_id,repo,pr_number,pr_url,title,last_comment_id,last_comment_at,last_review_id,last_ci_sha,mention_only,last_mergeable_state,created_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+			prID, clawID, row.repo, row.number, row.url, row.title, row.comment, row.commentAt, row.review, row.headSHA, boolInt(mentionOnly), row.mergeableState, now(),
 		)
 		if err != nil {
 			log.Printf("[pr-watcher] failed to persist PR %s#%d for claw %s: %v", row.repo, row.number, shortID(clawID), err)
@@ -562,6 +567,7 @@ type clawPR struct {
 	state               string
 	merged              bool
 	mergedAt            *string
+	lastMergeableState  string
 	// mentionOnly mirrors claw_prs.mention_only at load time. A mention-only
 	// row is a POLLING target (CI, comments and reviews are still forwarded)
 	// but never an ACTION target and never a TRIGGER: it must not block
@@ -583,7 +589,8 @@ type clawPR struct {
 func (s *Server) loadClawPRsByNumber(repo string, prNumber int) []clawPR {
 	rows, err := s.db.Query(`
 		SELECT cp.id, cp.claw_id, cp.repo, cp.pr_number, cp.pr_url, cp.last_ci_sha, cp.last_ci_conclusion, cp.last_comment_id,
-		       cp.last_comment_at, cp.last_review_comment_id, cp.last_review_id, cp.pr_conditions_fired, cp.created_at
+		       cp.last_comment_at, cp.last_review_comment_id, cp.last_review_id, cp.pr_conditions_fired, cp.created_at,
+		       cp.last_mergeable_state
 		FROM claw_prs cp
 		JOIN claws cl ON cl.id = cp.claw_id
 		WHERE cp.repo = ? AND cp.pr_number = ? AND cl.status NOT IN ('deleted','error','offline')
@@ -602,7 +609,8 @@ func (s *Server) loadClawPRsByNumber(repo string, prNumber int) []clawPR {
 		var prConditionsFiredInt int
 		if err := rows.Scan(&pr.id, &pr.clawID, &pr.repo, &pr.prNumber, &pr.prURL,
 			&pr.lastCISHA, &pr.lastCIConclusion, &pr.lastCommentID, &pr.lastCommentAt,
-			&pr.lastReviewCommentID, &pr.lastReviewID, &prConditionsFiredInt, &pr.createdAt); err != nil {
+			&pr.lastReviewCommentID, &pr.lastReviewID, &prConditionsFiredInt, &pr.createdAt,
+			&pr.lastMergeableState); err != nil {
 			log.Printf("[pr-watcher] failed to scan tracked PR %s#%d: %v", repo, prNumber, err)
 			return prs
 		}
@@ -695,7 +703,7 @@ func (s *Server) pollAllPRs() {
 	rows, err := s.db.Query(`
 		SELECT cp.id, cp.claw_id, cp.repo, cp.pr_number, cp.pr_url, cp.last_ci_sha, cp.last_ci_conclusion, cp.last_comment_id,
 		       cp.last_comment_at, cp.last_review_comment_id, cp.last_review_id, cp.pr_conditions_fired, cp.created_at,
-		       cp.mention_only, cl.status
+		       cp.mention_only, cp.last_mergeable_state, cl.status
 		FROM claw_prs cp
 		JOIN claws cl ON cl.id = cp.claw_id
 		WHERE cl.status NOT IN ('deleted','error','offline')
@@ -720,7 +728,7 @@ func (s *Server) pollAllPRs() {
 		var prConditionsFiredInt, mentionOnlyInt int
 		if err := rows.Scan(&r.pr.id, &r.pr.clawID, &r.pr.repo, &r.pr.prNumber, &r.pr.prURL,
 			&r.pr.lastCISHA, &r.pr.lastCIConclusion, &r.pr.lastCommentID, &r.pr.lastCommentAt, &r.pr.lastReviewCommentID, &r.pr.lastReviewID, &prConditionsFiredInt, &r.pr.createdAt,
-			&mentionOnlyInt, &r.clawStatus); err != nil {
+			&mentionOnlyInt, &r.pr.lastMergeableState, &r.clawStatus); err != nil {
 			continue
 		}
 		r.pr.prConditionsFired = prConditionsFiredInt == 1
@@ -2256,6 +2264,8 @@ func (s *Server) checkPRMerged(pr clawPR, token string) (resolved, terminated bo
 	log.Printf("[pr-watcher] checkPRMerged: claw=%s pr=%s state=%s merged=%v", pr.clawID[:8], pr.prURL, state, merged)
 
 	if state != "closed" && !merged {
+		// While the PR is still open, surface merge conflicts once per episode.
+		s.checkPRMergeConflict(pr, data)
 		return false, false // still open
 	}
 
@@ -2501,6 +2511,53 @@ func (s *Server) checkPRMerged(pr clawPR, token string) (resolved, terminated bo
 	go s.promotePendingClaws()
 
 	return true, true
+}
+
+// checkPRMergeConflict watches the mergeable_state field on an open PR and
+// notifies the agent once when the PR becomes "dirty" (merge conflict). It is
+// called from checkPRMerged while the PR is still open, so it never runs for
+// closed or merged PRs. Mention-only rows are ignored: a conflict on a PR the
+// agent merely mentioned must not interrupt the agent's own work.
+func (s *Server) checkPRMergeConflict(pr clawPR, data map[string]interface{}) {
+	if pr.mentionOnly {
+		return
+	}
+	mergeableState, _ := data["mergeable_state"].(string)
+	if mergeableState == "" {
+		return
+	}
+
+	// Read the persisted watermark so a stale in-memory clawPR or a concurrent
+	// poll cannot cause duplicate notifications.
+	var oldState string
+	if err := s.db.QueryRow(`SELECT last_mergeable_state FROM claw_prs WHERE id=?`, pr.id).Scan(&oldState); err != nil {
+		if !errors.Is(err, sql.ErrNoRows) {
+			log.Printf("[pr-watcher] failed to read mergeable state for %s: %v", pr.prURL, err)
+		}
+		return
+	}
+	if mergeableState == oldState {
+		return
+	}
+
+	// Notify only on a genuine transition to dirty from a known non-dirty state.
+	shouldNotify := mergeableState == "dirty" && oldState != "dirty" && oldState != ""
+
+	// Use a conditional update so only the poll that actually changes the
+	// watermark delivers the notification.
+	res, err := s.db.Exec(`UPDATE claw_prs SET last_mergeable_state=? WHERE id=? AND last_mergeable_state != ?`, mergeableState, pr.id, mergeableState)
+	if err != nil {
+		log.Printf("[pr-watcher] failed to update mergeable state for %s: %v", pr.prURL, err)
+		return
+	}
+	if affected, _ := res.RowsAffected(); affected == 0 {
+		return
+	}
+	if shouldNotify {
+		msg := fmt.Sprintf("PR #%d ([%s](%s)) is now in a merge conflict. Please resolve the conflicts on the same branch.",
+			pr.prNumber, pr.repo, pr.prURL)
+		s.injectUserMessage(pr.clawID, msg)
+	}
 }
 
 // prConditionsStatus explains why checkPRConditions did or didn't fire, so the

--- a/pkg/hub/pr_watcher_test.go
+++ b/pkg/hub/pr_watcher_test.go
@@ -715,6 +715,119 @@ func TestCheckCIStatusNeutralAndSkippedAreGreen(t *testing.T) {
 	}
 }
 
+// mergeConflictFixture creates a server with a stub GitHub that reports a
+// configurable mergeable_state for PR #1. The returned atomic value can be
+// flipped mid-test.
+func mergeConflictFixture(t *testing.T, clawID, initialState string) (*Server, *sql.DB, clawPR, *atomic.Value) {
+	t.Helper()
+	state := &atomic.Value{}
+	state.Store(initialState)
+	gh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/pulls/1") {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"state":           "open",
+				"merged":          false,
+				"mergeable_state": state.Load(),
+				"head":            map[string]interface{}{"sha": "abc123"},
+				"created_at":      "2026-01-01T00:00:00Z",
+				"draft":           false,
+			})
+			return
+		}
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	t.Cleanup(gh.Close)
+
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{}, gh.URL, "", "")
+	insertWatcherTestPR(t, db, clawID, "pr-"+clawID)
+	if _, err := db.Exec(`UPDATE claw_prs SET last_mergeable_state=? WHERE id=?`, initialState, "pr-"+clawID); err != nil {
+		t.Fatal(err)
+	}
+	pr := clawPR{id: "pr-" + clawID, clawID: clawID, repo: "owner/repo", prNumber: 1, prURL: "https://github.com/owner/repo/pull/1", lastMergeableState: initialState}
+	return s, db, pr, state
+}
+
+func TestCheckPRMergeConflictNotifiesOnTransition(t *testing.T) {
+	const clawID = "claw-conflict-transition"
+	s, db, pr, state := mergeConflictFixture(t, clawID, "clean")
+
+	state.Store("dirty")
+	s.checkPRMerged(pr, "token")
+
+	msgs := ciMessages(t, db, clawID)
+	if len(msgs) != 1 || !strings.Contains(msgs[0], "merge conflict") {
+		t.Fatalf("messages = %v, want one merge conflict message", msgs)
+	}
+	if !strings.Contains(msgs[0], "PR #1") {
+		t.Fatalf("message missing PR number: %q", msgs[0])
+	}
+
+	var got string
+	if err := db.QueryRow(`SELECT last_mergeable_state FROM claw_prs WHERE id=?`, pr.id).Scan(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got != "dirty" {
+		t.Fatalf("last_mergeable_state = %q, want dirty", got)
+	}
+}
+
+func TestCheckPRMergeConflictDoesNotDuplicate(t *testing.T) {
+	const clawID = "claw-conflict-dedupe"
+	s, db, pr, _ := mergeConflictFixture(t, clawID, "dirty")
+
+	// Poll twice with the same stale pr value; the DB watermark blocks the duplicate.
+	s.checkPRMerged(pr, "token")
+	s.checkPRMerged(pr, "token")
+
+	if msgs := ciMessages(t, db, clawID); len(msgs) != 0 {
+		t.Fatalf("messages = %v, want none when already dirty", msgs)
+	}
+}
+
+func TestCheckPRMergeConflictResetsWhenClean(t *testing.T) {
+	const clawID = "claw-conflict-reset"
+	s, db, pr, state := mergeConflictFixture(t, clawID, "dirty")
+
+	state.Store("clean")
+	s.checkPRMerged(pr, "token")
+
+	if msgs := ciMessages(t, db, clawID); len(msgs) != 0 {
+		t.Fatalf("messages = %v, want none when becoming clean", msgs)
+	}
+	var got string
+	if err := db.QueryRow(`SELECT last_mergeable_state FROM claw_prs WHERE id=?`, pr.id).Scan(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got != "clean" {
+		t.Fatalf("last_mergeable_state = %q, want clean", got)
+	}
+
+	state.Store("dirty")
+	// The in-memory pr is stale, but the DB was updated to clean above.
+	s.checkPRMerged(pr, "token")
+
+	msgs := ciMessages(t, db, clawID)
+	if len(msgs) != 1 || !strings.Contains(msgs[0], "merge conflict") {
+		t.Fatalf("messages = %v, want one merge conflict message after re-dirtying", msgs)
+	}
+}
+
+func TestCheckPRMergeConflictSkippedForMentionOnly(t *testing.T) {
+	const clawID = "claw-conflict-mention"
+	s, db, pr, state := mergeConflictFixture(t, clawID, "clean")
+	if _, err := db.Exec(`UPDATE claw_prs SET mention_only=1 WHERE id=?`, pr.id); err != nil {
+		t.Fatal(err)
+	}
+	pr.mentionOnly = true
+
+	state.Store("dirty")
+	s.checkPRMerged(pr, "token")
+
+	if msgs := ciMessages(t, db, clawID); len(msgs) != 0 {
+		t.Fatalf("messages = %v, want none for mention-only PR", msgs)
+	}
+}
+
 func TestInjectMessageSkipsIdenticalPendingRow(t *testing.T) {
 	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
 	const clawID = "inject-message-dedupe"


### PR DESCRIPTION
## What

The PR watcher already polls GitHub pull request objects to detect merges and closes, but it ignored the `mergeable_state` field. As a result, a PR could silently flip into a merge-conflict state (`mergeable_state: dirty`) and the agent would only discover it when it tried to merge locally.

## How

- Reads the `mergeable_state` field from the existing PR fetch in `checkPRMerged`.
- Stores the last observed state in a new `claw_prs.last_mergeable_state` column.
- Injects a user message once per conflict episode when the state transitions to `dirty`:
  > PR #N is now in a merge conflict. Please resolve the conflicts on the same branch.
- Re-arms the watermark when the PR becomes clean again, so a future re-conflict notifies again.
- Skips mention-only PRs (URLs the agent merely mentioned, not delivered work) and closed/merged PRs.
- Includes the state in the no-progress fingerprint so a conflict flip counts as activity.

## Why polling

GitHub does not emit a webhook specifically for merge-conflict state changes, so polling is the only reliable source. The watcher is already fetching the PR object on every poll, so the incremental cost is minimal.

## Tests

Added tests covering transition to dirty, deduplication while dirty, re-notification after clean→dirty, and mention-only skip.

## Checklist

- [x] Code builds
- [x] Tests pass (`go test ./pkg/hub/...`)
