### PR TITLE
Hub wall-clock mitigations: watermark hardening, checkpoint fallback, escalation guard, GitHub backpressure, stage-stall alert

### DIFF
--- a/pkg/hub/agent_failure_feedback.go
+++ b/pkg/hub/agent_failure_feedback.go
@@ -300,14 +300,9 @@ func commentGitHubIssueWithBase(base, token, repo string, issueNumber int, body 
 	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := issueTrackerHTTPClient.Do(req)
+	_, err = defaultGitHubClient.do(req)
 	if err != nil {
 		return err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode >= 400 {
-		respBody, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("github API error %d: %s", resp.StatusCode, string(respBody))
 	}
 	return nil
 }

--- a/pkg/hub/claw_retry.go
+++ b/pkg/hub/claw_retry.go
@@ -303,13 +303,13 @@ func (s *Server) scheduleClawRetry(clawID, reason string) clawRetryDisposition {
 }
 
 // replaceClawInstance tears down the corrupted provider instance and starts a
-// fresh one. It restores the newest ready checkpoint unless the previous failed
-// attempt used that exact checkpoint, in which case it provisions cleanly.
+// fresh one. It restores the newest eligible ready checkpoint, walking older
+// checkpoints when newer ones are unsafe to reuse or restore no files.
 func (s *Server) replaceClawInstance(ctx context.Context, tenantID, clawID, reason string, attempt int) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	checkpointID, err := s.retryCheckpointBeforeTermination(tenantID, clawID, attempt)
+	checkpointID, readyCheckpointCount, err := s.retryCheckpointBeforeTermination(tenantID, clawID, attempt)
 	if err != nil {
 		return err
 	}
@@ -337,7 +337,11 @@ func (s *Server) replaceClawInstance(ctx context.Context, tenantID, clawID, reas
 	}
 
 	bootstrapStatus := fmt.Sprintf("retrying (attempt %d/%d)", attempt, maxClawAttempts)
-	reset, err := s.resetClawForRetry(tenantID, clawID, checkpointID, bootstrapStatus)
+	bootstrapDiagnostic := ""
+	if checkpointID == "" {
+		bootstrapDiagnostic = bootstrapStatus + "; retry checkpoint=none"
+	}
+	reset, err := s.resetClawForRetry(tenantID, clawID, checkpointID, bootstrapStatus, bootstrapDiagnostic)
 	if err != nil {
 		return err
 	}
@@ -371,7 +375,11 @@ func (s *Server) replaceClawInstance(ctx context.Context, tenantID, clawID, reas
 			"claw_id": clawID, "status": "provisioning", "bootstrap_status": bootstrapStatus,
 		},
 	})
-	log.Printf("[claw-retry] replacing %s after %s (attempt %d/%d, checkpoint=%q)", shortID(clawID), sanitizeFailureDetails(reason), attempt, maxClawAttempts, checkpointID)
+	if checkpointID == "" {
+		log.Printf("[claw-retry] replacing %s after %s (attempt %d/%d, checkpoint=%q (0 eligible of %d ready))", shortID(clawID), sanitizeFailureDetails(reason), attempt, maxClawAttempts, checkpointID, readyCheckpointCount)
+	} else {
+		log.Printf("[claw-retry] replacing %s after %s (attempt %d/%d, checkpoint=%q)", shortID(clawID), sanitizeFailureDetails(reason), attempt, maxClawAttempts, checkpointID)
+	}
 	go s.provisionStoredClaw(clawID)
 	return nil
 }
@@ -379,64 +387,67 @@ func (s *Server) replaceClawInstance(ctx context.Context, tenantID, clawID, reas
 // retryCheckpointBeforeTermination fixes the restore choice at the failure
 // boundary. A best-effort termination checkpoint is retained for diagnostics,
 // but is never selected as the state used to recover that same failure.
-func (s *Server) retryCheckpointBeforeTermination(tenantID, clawID string, attempt int) (string, error) {
-	checkpointID, err := s.retryCheckpointID(tenantID, clawID, attempt)
+func (s *Server) retryCheckpointBeforeTermination(tenantID, clawID string, attempt int) (string, int, error) {
+	checkpointID, readyCheckpointCount, err := s.retryCheckpointIDWithCount(tenantID, clawID, attempt)
 	if err != nil {
-		return "", err
+		return "", 0, err
 	}
 	s.checkpointBeforeTermination(clawID, "automatic-retry")
-	return checkpointID, nil
+	return checkpointID, readyCheckpointCount, nil
 }
 
 func (s *Server) retryCheckpointID(tenantID, clawID string, attempt int) (string, error) {
+	checkpointID, _, err := s.retryCheckpointIDWithCount(tenantID, clawID, attempt)
+	return checkpointID, err
+}
+
+type retryCheckpointCandidate struct {
+	id       string
+	reason   string
+	rootTree string
+}
+
+func (s *Server) retryCheckpointIDWithCount(tenantID, clawID string, attempt int) (string, int, error) {
 	var previousCheckpointID string
 	_ = s.db.QueryRow(`
 		SELECT COALESCE(restored_checkpoint_id,'')
 		  FROM task_run_attempts
 		 WHERE run_id=(SELECT task_run_id FROM claws WHERE id=?) AND attempt_number=?`, clawID, attempt-1).Scan(&previousCheckpointID)
 
-	var checkpointID, checkpointReason string
-	err := s.db.QueryRow(`
-		SELECT id, COALESCE(reason,'') FROM claw_checkpoints
+	rows, err := s.db.Query(`
+		SELECT id, COALESCE(reason,''), COALESCE(root_tree_sha256,'') FROM claw_checkpoints
 		 WHERE tenant_id=? AND claw_id=? AND status='ready' AND manifest_path != ''
-		 ORDER BY created_at DESC LIMIT 1`, tenantID, clawID).Scan(&checkpointID, &checkpointReason)
-	if err == sql.ErrNoRows {
-		return "", nil
-	}
+		 ORDER BY created_at DESC`, tenantID, clawID)
 	if err != nil {
-		return "", err
+		return "", 0, err
 	}
-	if checkpointID == previousCheckpointID {
-		return "", nil
+	defer rows.Close()
+
+	var candidates []retryCheckpointCandidate
+	for rows.Next() {
+		var candidate retryCheckpointCandidate
+		if err := rows.Scan(&candidate.id, &candidate.reason, &candidate.rootTree); err != nil {
+			return "", 0, err
+		}
+		candidates = append(candidates, candidate)
 	}
-	// A 'bootstrap' checkpoint captures state zero — it is taken seconds after
-	// provisioning, before the agent has done anything. Restoring it over a
-	// claw that has already made progress rolls the workspace back and
-	// discards real work (observed on NEXT-801/NEXT-790). Fall back to the
-	// newest non-bootstrap checkpoint instead — an earlier attempt's periodic
-	// checkpoint can hold hours of recoverable work even when a later
-	// attempt's bootstrap checkpoint sorted newest — and only when none exists
-	// provision the successor cleanly and let the reconnect re-brief point the
-	// fresh agent at the live PR/workspace state.
-	if checkpointReason == "bootstrap" && s.clawProgressedPastBootstrap(tenantID, clawID) {
-		err := s.db.QueryRow(`
-			SELECT id FROM claw_checkpoints
-			 WHERE tenant_id=? AND claw_id=? AND status='ready' AND manifest_path != ''
-			   AND COALESCE(reason,'') != 'bootstrap'
-			 ORDER BY created_at DESC LIMIT 1`, tenantID, clawID).Scan(&checkpointID)
-		if err == sql.ErrNoRows {
-			return "", nil
-		}
-		if err != nil {
-			return "", err
-		}
-		// Same guard as above: never restore the checkpoint the previous
-		// attempt already failed on.
-		if checkpointID == previousCheckpointID {
-			return "", nil
-		}
+	if err := rows.Err(); err != nil {
+		return "", 0, err
 	}
-	return checkpointID, nil
+
+	// A 'bootstrap' checkpoint captures state zero. Once work has progressed,
+	// walk past it to older usable checkpoints instead of rolling real work
+	// back or giving up when the newest candidate is blocked.
+	progressedPastBootstrap := s.clawProgressedPastBootstrap(tenantID, clawID)
+	for _, candidate := range candidates {
+		if candidate.id == previousCheckpointID ||
+			(candidate.reason == "bootstrap" && progressedPastBootstrap) ||
+			candidate.rootTree == "" {
+			continue
+		}
+		return candidate.id, len(candidates), nil
+	}
+	return "", len(candidates), nil
 }
 
 // clawProgressedPastBootstrap reports whether the claw shows any signal of
@@ -475,7 +486,7 @@ func (s *Server) clawProgressedPastBootstrap(tenantID, clawID string) bool {
 	return entry != nil && entry.ID != stageID
 }
 
-func (s *Server) resetClawForRetry(tenantID, clawID, checkpointID, bootstrapStatus string) (bool, error) {
+func (s *Server) resetClawForRetry(tenantID, clawID, checkpointID, bootstrapStatus, bootstrapDiagnostic string) (bool, error) {
 	// rebrief_pending=1 marks that the successor sandbox starts with a brand-new
 	// OpenClaw session: the checkpoint restore brings back workspace files but
 	// not the conversation, so the reconnect path must re-brief the agent with
@@ -483,11 +494,11 @@ func (s *Server) resetClawForRetry(tenantID, clawID, checkpointID, bootstrapStat
 	// normal reconnect/bridge flap must never set it.
 	res, err := s.db.Exec(`
 		UPDATE claws
-		   SET status='provisioning', bootstrap_ok=0, bootstrap_status=?, bootstrap_diagnostic='',
+		   SET status='provisioning', bootstrap_ok=0, bootstrap_status=?, bootstrap_diagnostic=?,
 		       provider_id='', ssh_host='', ssh_port=0, ssh_user='', restore_checkpoint_id=?,
 		       rebrief_pending=1
 		 WHERE id=? AND tenant_id=? AND status IN ('error','offline')`,
-		bootstrapStatus, checkpointID, clawID, tenantID)
+		bootstrapStatus, bootstrapDiagnostic, checkpointID, clawID, tenantID)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/hub/claw_retry_test.go
+++ b/pkg/hub/claw_retry_test.go
@@ -202,11 +202,11 @@ func TestConcurrentPrepareClawRetryHasSingleWinner(t *testing.T) {
 
 func TestResetClawForRetryRaceGuard(t *testing.T) {
 	s, _, _ := newClawRetryTestServer(t, "error")
-	reset, err := s.resetClawForRetry("tenant", "retry-claw", "", "retrying")
+	reset, err := s.resetClawForRetry("tenant", "retry-claw", "", "retrying", "")
 	if err != nil || !reset {
 		t.Fatalf("first reset: reset=%v err=%v", reset, err)
 	}
-	reset, err = s.resetClawForRetry("tenant", "retry-claw", "", "retrying")
+	reset, err = s.resetClawForRetry("tenant", "retry-claw", "", "retrying", "")
 	if err != nil || reset {
 		t.Fatalf("second reset: reset=%v err=%v, want no-op", reset, err)
 	}
@@ -243,8 +243,8 @@ func TestReplaceClawInstanceFailsDanglingAttemptWhenClawChangedState(t *testing.
 func TestRetryCheckpointSkipsCheckpointUsedByPreviousAttempt(t *testing.T) {
 	s, db, runID := newClawRetryTestServer(t, "connected")
 	if _, err := db.Exec(`
-		INSERT INTO claw_checkpoints(id,tenant_id,claw_id,status,manifest_path,created_at)
-		VALUES('checkpoint-x','tenant','retry-claw','ready','manifest.json',?)`, now()); err != nil {
+		INSERT INTO claw_checkpoints(id,tenant_id,claw_id,status,manifest_path,root_tree_sha256,created_at)
+		VALUES('checkpoint-x','tenant','retry-claw','ready','manifest.json','root-x',?)`, now()); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := db.Exec(`UPDATE task_run_attempts SET restored_checkpoint_id='checkpoint-x' WHERE run_id=? AND attempt_number=1`, runID); err != nil {
@@ -263,8 +263,8 @@ func TestRetryCheckpointSkipsBootstrapCheckpointAfterProgress(t *testing.T) {
 	insertBootstrapCheckpoint := func(t *testing.T, db *sql.DB) {
 		t.Helper()
 		if _, err := db.Exec(`
-			INSERT INTO claw_checkpoints(id,tenant_id,claw_id,status,reason,manifest_path,created_at)
-			VALUES('checkpoint-bootstrap','tenant','retry-claw','ready','bootstrap','manifest.json',?)`, now()); err != nil {
+			INSERT INTO claw_checkpoints(id,tenant_id,claw_id,status,reason,manifest_path,root_tree_sha256,created_at)
+			VALUES('checkpoint-bootstrap','tenant','retry-claw','ready','bootstrap','manifest.json','root-bootstrap',?)`, now()); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -311,8 +311,8 @@ func TestRetryCheckpointSkipsBootstrapCheckpointAfterProgress(t *testing.T) {
 		// A periodic checkpoint from an earlier attempt sorts below the
 		// successor's bootstrap checkpoint but holds real work — it must win.
 		if _, err := db.Exec(`
-			INSERT INTO claw_checkpoints(id,tenant_id,claw_id,status,reason,manifest_path,created_at)
-			VALUES('checkpoint-periodic','tenant','retry-claw','ready','periodic','manifest.json',?)`, now().Add(-time.Hour)); err != nil {
+			INSERT INTO claw_checkpoints(id,tenant_id,claw_id,status,reason,manifest_path,root_tree_sha256,created_at)
+			VALUES('checkpoint-periodic','tenant','retry-claw','ready','periodic','manifest.json','root-periodic',?)`, now().Add(-time.Hour)); err != nil {
 			t.Fatal(err)
 		}
 		checkpointID, err := s.retryCheckpointID("tenant", "retry-claw", 2)
@@ -328,8 +328,8 @@ func TestRetryCheckpointSkipsBootstrapCheckpointAfterProgress(t *testing.T) {
 		s, db, runID := newClawRetryTestServer(t, "connected")
 		insertBootstrapCheckpoint(t, db)
 		if _, err := db.Exec(`
-			INSERT INTO claw_checkpoints(id,tenant_id,claw_id,status,reason,manifest_path,created_at)
-			VALUES('checkpoint-periodic','tenant','retry-claw','ready','periodic','manifest.json',?)`, now().Add(-time.Hour)); err != nil {
+			INSERT INTO claw_checkpoints(id,tenant_id,claw_id,status,reason,manifest_path,root_tree_sha256,created_at)
+			VALUES('checkpoint-periodic','tenant','retry-claw','ready','periodic','manifest.json','root-periodic',?)`, now().Add(-time.Hour)); err != nil {
 			t.Fatal(err)
 		}
 		if _, err := db.Exec(`UPDATE task_run_attempts SET restored_checkpoint_id='checkpoint-periodic' WHERE run_id=? AND attempt_number=1`, runID); err != nil {
@@ -365,19 +365,96 @@ func TestRetryCheckpointSkipsBootstrapCheckpointAfterProgress(t *testing.T) {
 	})
 }
 
+func TestRetryCheckpointFallsBackPastBlockedNewest(t *testing.T) {
+	s, db, runID := newClawRetryTestServer(t, "connected")
+	createdAt := now()
+	for _, checkpoint := range []struct {
+		id        string
+		createdAt time.Time
+	}{
+		{"checkpoint-newest", createdAt},
+		{"checkpoint-mid", createdAt.Add(-time.Hour)},
+		{"checkpoint-old", createdAt.Add(-2 * time.Hour)},
+	} {
+		if _, err := db.Exec(`
+			INSERT INTO claw_checkpoints(id,tenant_id,claw_id,status,manifest_path,root_tree_sha256,created_at)
+			VALUES(?,?,?,'ready','manifest.json',?,?)`, checkpoint.id, "tenant", "retry-claw", "root-"+checkpoint.id, checkpoint.createdAt); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := db.Exec(`UPDATE task_run_attempts SET restored_checkpoint_id='checkpoint-newest' WHERE run_id=? AND attempt_number=1`, runID); err != nil {
+		t.Fatal(err)
+	}
+
+	checkpointID, err := s.retryCheckpointID("tenant", "retry-claw", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if checkpointID != "checkpoint-mid" {
+		t.Fatalf("checkpoint=%q, want checkpoint-mid", checkpointID)
+	}
+}
+
+func TestRetryCheckpointOnlyMetadataOnlyCheckpointsYieldsScratch(t *testing.T) {
+	s, db, _ := newClawRetryTestServer(t, "connected")
+	for _, checkpoint := range []struct {
+		id        string
+		createdAt time.Time
+	}{
+		{"checkpoint-newest", now()},
+		{"checkpoint-old", now().Add(-time.Hour)},
+	} {
+		if _, err := db.Exec(`
+			INSERT INTO claw_checkpoints(id,tenant_id,claw_id,status,manifest_path,root_tree_sha256,created_at)
+			VALUES(?,?,?,'ready','manifest.json','',?)`, checkpoint.id, "tenant", "retry-claw", checkpoint.createdAt); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	checkpointID, err := s.retryCheckpointID("tenant", "retry-claw", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if checkpointID != "" {
+		t.Fatalf("checkpoint=%q, want clean provision", checkpointID)
+	}
+}
+
+func TestRetryCheckpointSkipsMetadataOnlyCheckpointForOlderRealCheckpoint(t *testing.T) {
+	s, db, _ := newClawRetryTestServer(t, "connected")
+	if _, err := db.Exec(`
+		INSERT INTO claw_checkpoints(id,tenant_id,claw_id,status,manifest_path,root_tree_sha256,created_at)
+		VALUES('checkpoint-metadata','tenant','retry-claw','ready','manifest.json','',?)`, now()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`
+		INSERT INTO claw_checkpoints(id,tenant_id,claw_id,status,manifest_path,root_tree_sha256,created_at)
+		VALUES('checkpoint-real','tenant','retry-claw','ready','manifest.json','root-real',?)`, now().Add(-time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+
+	checkpointID, err := s.retryCheckpointID("tenant", "retry-claw", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if checkpointID != "checkpoint-real" {
+		t.Fatalf("checkpoint=%q, want checkpoint-real", checkpointID)
+	}
+}
+
 func TestRetryCheckpointChoicePrecedesTerminationCheckpoint(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	s, db, runID := newClawRetryTestServer(t, "error")
 	if _, err := db.Exec(`
-		INSERT INTO claw_checkpoints(id,tenant_id,claw_id,status,manifest_path,created_at)
-		VALUES('checkpoint-x','tenant','retry-claw','ready','manifest.json',?)`, now().Add(-time.Minute)); err != nil {
+		INSERT INTO claw_checkpoints(id,tenant_id,claw_id,status,manifest_path,root_tree_sha256,created_at)
+		VALUES('checkpoint-x','tenant','retry-claw','ready','manifest.json','root-x',?)`, now().Add(-time.Minute)); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := db.Exec(`UPDATE task_run_attempts SET attempt_number=2, restored_checkpoint_id='checkpoint-x' WHERE run_id=?`, runID); err != nil {
 		t.Fatal(err)
 	}
 
-	checkpointID, err := s.retryCheckpointBeforeTermination("tenant", "retry-claw", 3)
+	checkpointID, _, err := s.retryCheckpointBeforeTermination("tenant", "retry-claw", 3)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -557,6 +557,7 @@ func migrate(db *sql.DB) error {
 	CREATE INDEX IF NOT EXISTS idx_messages_claw ON messages(claw_id, created_at);
 	CREATE INDEX IF NOT EXISTS idx_messages_pending ON messages(claw_id, created_at) WHERE delivered_at IS NULL;
 	CREATE INDEX IF NOT EXISTS idx_claws_tenant  ON claws(tenant_id);
+	CREATE INDEX IF NOT EXISTS idx_claws_stage_stalled ON claws(stage_stalled_since) WHERE stage_stalled_since > 0;
 
 	CREATE TABLE IF NOT EXISTS task_runs (
 		id                    TEXT PRIMARY KEY,

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -126,6 +126,12 @@ func migrate(db *sql.DB) error {
 	if err := addColumn(db, "claws", "idle_since", `INTEGER NOT NULL DEFAULT 0`); err != nil {
 		return err
 	}
+	if err := addColumn(db, "claws", "stage_entered_at", `INTEGER`); err != nil {
+		return err
+	}
+	if err := addColumn(db, "claws", "stage_stalled_since", `INTEGER NOT NULL DEFAULT 0`); err != nil {
+		return err
+	}
 	// idle_resume_at (epoch millis, 0 = not resumed) is the durable
 	// once-per-idle-stretch latch for the idle AUTO-RESUME recovery, kept
 	// separate from idle_since because the two fire at different thresholds
@@ -495,6 +501,8 @@ func migrate(db *sql.DB) error {
 		rebrief_pending INTEGER NOT NULL DEFAULT 0,
 		no_progress_paused INTEGER NOT NULL DEFAULT 0,
 		idle_since INTEGER NOT NULL DEFAULT 0,
+		stage_entered_at INTEGER,
+		stage_stalled_since INTEGER NOT NULL DEFAULT 0,
 		idle_resume_at INTEGER NOT NULL DEFAULT 0,
 		idle_resume_count INTEGER NOT NULL DEFAULT 0
 	);
@@ -636,7 +644,7 @@ func migrate(db *sql.DB) error {
 			'task_start','task_completed','run_claimed','run_queued','provision_started','claw_created','agent_started',
 			'creation_failed','provision_failed','bootstrap_failed','model_selected','agent_stopped',
 			'manual_stop_before_delivery','provider_lost','done_without_pr','permission_or_auth_failed',
-			'timeout','unknown_failure','agent_idle','pr_associated','pr_opened','pr_closed_unmerged','pr_merged',
+			'timeout','unknown_failure','agent_idle','stage_stalled','pr_associated','pr_opened','pr_closed_unmerged','pr_merged',
 			'approval_only_pr_review','human_requested_changes','human_review_comment','human_pr_comment',
 			'human_manual_code_push','human_tracker_update','human_dashboard_message',
 			'human_manual_stop_or_resume','human_settings_or_status_change',
@@ -1124,7 +1132,7 @@ func rebuildTaskRunEventsAgentIdleV1(db *sql.DB) error {
 		}
 		return fmt.Errorf("read task run events schema: %w", err)
 	}
-	if strings.Contains(schema, "'ci_succeeded'") && strings.Contains(schema, "'ci_failed'") {
+	if strings.Contains(schema, "'stage_stalled'") {
 		return nil
 	}
 	tx, err := db.Begin()
@@ -1145,7 +1153,7 @@ func rebuildTaskRunEventsAgentIdleV1(db *sql.DB) error {
 			'task_start','task_completed','run_claimed','run_queued','provision_started','claw_created','agent_started',
 			'creation_failed','provision_failed','bootstrap_failed','model_selected','agent_stopped',
 			'manual_stop_before_delivery','provider_lost','done_without_pr','permission_or_auth_failed',
-			'timeout','unknown_failure','agent_idle','pr_associated','pr_opened','pr_closed_unmerged','pr_merged',
+			'timeout','unknown_failure','agent_idle','stage_stalled','pr_associated','pr_opened','pr_closed_unmerged','pr_merged',
 			'approval_only_pr_review','human_requested_changes','human_review_comment','human_pr_comment',
 			'human_manual_code_push','human_tracker_update','human_dashboard_message',
 			'human_manual_stop_or_resume','human_settings_or_status_change',

--- a/pkg/hub/db_task_run_events_agent_idle_migration_test.go
+++ b/pkg/hub/db_task_run_events_agent_idle_migration_test.go
@@ -156,6 +156,9 @@ func TestRebuildTaskRunEventsAgentIdleV1MigratesPopulatedDatabase(t *testing.T) 
 	if !strings.Contains(schema, "'agent_idle'") {
 		t.Fatalf("rebuilt schema lacks agent_idle: %s", schema)
 	}
+	if !strings.Contains(schema, "'stage_stalled'") {
+		t.Fatalf("rebuilt schema lacks stage_stalled: %s", schema)
+	}
 
 	rows, err := db.Query(`SELECT rowid, id, event_type FROM task_run_events ORDER BY rowid`)
 	if err != nil {
@@ -259,7 +262,7 @@ func TestRebuildTaskRunEventsAgentIdleV1AddsCIEventsAfterAgentIdle(t *testing.T)
 	if err := db.QueryRow(`SELECT event_type FROM task_run_events WHERE id='ev-idle'`).Scan(&eventType); err != nil || eventType != "agent_idle" {
 		t.Fatalf("pre-existing agent_idle row = %q, %v; want agent_idle", eventType, err)
 	}
-	for _, eventType := range []string{"ci_succeeded", "ci_failed"} {
+	for _, eventType := range []string{"ci_succeeded", "ci_failed", "stage_stalled"} {
 		if _, err := db.Exec(`INSERT INTO task_run_events(id, tenant_id, run_id, event_key, event_type, event_time, observed_at, created_at) VALUES(?,?,?,?,?,?,?,?)`, "ev-"+eventType, "tenant", "run-1", "key-"+eventType, eventType, 200, 200, 200); err != nil {
 			t.Fatalf("rebuilt schema rejects %s: %v", eventType, err)
 		}
@@ -281,11 +284,11 @@ func TestRebuildTaskRunEventsAgentIdleV1AddsCIEventsAfterAgentIdle(t *testing.T)
 		t.Fatal("second rebuild did not skip the current schema")
 	}
 	var count int
-	if err := db.QueryRow(`SELECT COUNT(*) FROM task_run_events WHERE event_type IN ('agent_idle','ci_succeeded','ci_failed')`).Scan(&count); err != nil {
+	if err := db.QueryRow(`SELECT COUNT(*) FROM task_run_events WHERE event_type IN ('agent_idle','ci_succeeded','ci_failed','stage_stalled')`).Scan(&count); err != nil {
 		t.Fatal(err)
 	}
-	if count != 3 {
-		t.Fatalf("rows after skipped second rebuild = %d, want 3", count)
+	if count != 4 {
+		t.Fatalf("rows after skipped second rebuild = %d, want 4", count)
 	}
 }
 

--- a/pkg/hub/github.go
+++ b/pkg/hub/github.go
@@ -68,7 +68,7 @@ func NewGitHubTokenProvider(cfg *types.GitHubAppConfig) (*GitHubTokenProvider, e
 		cfg:        cfg,
 		privateKey: key,
 		apiBaseURL: "https://api.github.com",
-		httpClient: http.DefaultClient,
+		httpClient: &http.Client{Timeout: 30 * time.Second},
 	}, nil
 }
 

--- a/pkg/hub/github.go
+++ b/pkg/hub/github.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -158,6 +159,7 @@ func (p *GitHubTokenProvider) ListInstallations(ctx context.Context) ([]githubIn
 		return nil, fmt.Errorf("github list installations: %w", err)
 	}
 	defer resp.Body.Close()
+	defaultGitHubClient.observe(resp.StatusCode, resp.Header, nil)
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("github list installations: status %d", resp.StatusCode)
@@ -195,6 +197,7 @@ func (p *GitHubTokenProvider) ListInstallationRepositories(ctx context.Context, 
 		if err != nil {
 			return nil, fmt.Errorf("github list installation repositories: %w", err)
 		}
+		defaultGitHubClient.observe(resp.StatusCode, resp.Header, nil)
 		if resp.StatusCode != http.StatusOK {
 			var errBody map[string]interface{}
 			_ = json.NewDecoder(resp.Body).Decode(&errBody)
@@ -328,11 +331,12 @@ func (p *GitHubTokenProvider) InstallationToken(ctx context.Context, installatio
 		return "", time.Time{}, fmt.Errorf("github api: %w", err)
 	}
 	defer resp.Body.Close()
+	defaultGitHubClient.observe(resp.StatusCode, resp.Header, nil)
 
 	if resp.StatusCode != http.StatusCreated {
-		var errBody map[string]interface{}
-		json.NewDecoder(resp.Body).Decode(&errBody)
-		return "", time.Time{}, fmt.Errorf("github api %d: %v", resp.StatusCode, errBody["message"])
+		body, _ := io.ReadAll(resp.Body)
+		defaultGitHubClient.observe(resp.StatusCode, resp.Header, body)
+		return "", time.Time{}, &githubAPIError{StatusCode: resp.StatusCode, Body: string(body), RateLimited: githubIsRateLimited(resp.StatusCode, resp.Header, body)}
 	}
 
 	var result githubTokenResponse
@@ -364,6 +368,7 @@ func (p *GitHubTokenProvider) CheckAppPermissions(ctx context.Context) (map[stri
 		return nil, fmt.Errorf("github get app: %w", err)
 	}
 	defer resp.Body.Close()
+	defaultGitHubClient.observe(resp.StatusCode, resp.Header, nil)
 
 	if resp.StatusCode != http.StatusOK {
 		var errBody map[string]interface{}
@@ -416,6 +421,7 @@ func (p *GitHubTokenProvider) installationPermissions(ctx context.Context, insta
 		return nil, fmt.Errorf("github get installation: %w", err)
 	}
 	defer resp.Body.Close()
+	defaultGitHubClient.observe(resp.StatusCode, resp.Header, nil)
 
 	if resp.StatusCode != http.StatusOK {
 		var errBody map[string]interface{}

--- a/pkg/hub/github_client.go
+++ b/pkg/hub/github_client.go
@@ -66,7 +66,7 @@ type githubClient struct {
 }
 
 func newGitHubClient() *githubClient {
-	return &githubClient{httpClient: http.DefaultClient, etags: map[string]*githubETagEntry{}}
+	return &githubClient{httpClient: &http.Client{Timeout: 30 * time.Second}, etags: map[string]*githubETagEntry{}}
 }
 
 // defaultGitHubClient backs the githubAPI* helpers, so every GitHub consumer in

--- a/pkg/hub/github_client.go
+++ b/pkg/hub/github_client.go
@@ -96,6 +96,29 @@ func (c *githubClient) getContext(ctx context.Context, url, token string) (*gith
 	return c.doGetContext(ctx, url, token, true)
 }
 
+// do sends a GitHub request through the shared rate-limit gate. Callers build
+// the request when they need a non-GET method or custom body.
+func (c *githubClient) do(req *http.Request) (*githubResponse, error) {
+	if until, blocked := c.blockedUntilTime(); blocked {
+		return nil, &githubAPIError{StatusCode: http.StatusForbidden, RateLimited: true,
+			Body: fmt.Sprintf("github rate limit exhausted; not retrying until %s", until.UTC().Format(time.RFC3339))}
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("github API response read error: %w", err)
+	}
+	c.observe(resp.StatusCode, resp.Header, body)
+	if resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, &githubAPIError{StatusCode: resp.StatusCode, Body: string(body), RateLimited: githubIsRateLimited(resp.StatusCode, resp.Header, body)}
+	}
+	return &githubResponse{StatusCode: resp.StatusCode, Body: body, Header: resp.Header}, nil
+}
+
 func (c *githubClient) doGet(url, token string, conditional bool) (*githubResponse, error) {
 	return c.doGetContext(context.Background(), url, token, conditional)
 }

--- a/pkg/hub/github_client_test.go
+++ b/pkg/hub/github_client_test.go
@@ -131,6 +131,28 @@ func TestGitHubRetryAfterBlocksSubsequentCalls(t *testing.T) {
 	}
 }
 
+func TestGitHubWriteRateLimitBlocksTierTwoHelpers(t *testing.T) {
+	resetGitHubClientForTest(t)
+	var calls int64
+	gh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&calls, 1)
+		w.Header().Set("Retry-After", "60")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"message":"rate limit"}`))
+	}))
+	defer gh.Close()
+
+	if _, err := githubAPIPostWithBase(gh.URL, "repos/o/r/issues/1", "tok", http.MethodPatch, map[string]string{"title": "x"}); err == nil {
+		t.Fatal("expected write rate-limit error")
+	}
+	if err := commentGitHubIssueWithBase(gh.URL, "tok", "o/r", 1, "later"); err == nil {
+		t.Fatal("expected blocked tier-two helper error")
+	}
+	if got := atomic.LoadInt64(&calls); got != 1 {
+		t.Fatalf("requests=%d, want 1 after shared block", got)
+	}
+}
+
 func TestGitHubRateLimitBlockIsClamped(t *testing.T) {
 	resetGitHubClientForTest(t)
 
@@ -268,7 +290,6 @@ func TestPollAllPRsStopsCallingGitHubWhileRateLimited(t *testing.T) {
 	}
 }
 
-
 func TestInstallationTokensAreCachedAcrossCalls(t *testing.T) {
 	var mints int64
 	oldTransport := http.DefaultTransport
@@ -289,6 +310,47 @@ func TestInstallationTokensAreCachedAcrossCalls(t *testing.T) {
 	if got := atomic.LoadInt64(&mints); got != 2 {
 		t.Fatalf("installation tokens minted=%d, want 2 (one per distinct scope)", got)
 	}
+}
+
+func TestInstallationTokenFailuresAreNegativelyCached(t *testing.T) {
+	resetGitHubClientForTest(t)
+	var mints int64
+	oldTransport := http.DefaultTransport
+	http.DefaultTransport = githubAppAnyTokenTransport{base: oldTransport, mints: &mints}
+	t.Cleanup(func() { http.DefaultTransport = oldTransport })
+
+	// Return a rate limit for the mint endpoint while retaining the normal app
+	// installation discovery response supplied by the test transport.
+	http.DefaultTransport = githubAppRateLimitedTokenTransport{base: http.DefaultTransport, mints: &mints}
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{GitHubApps: []*types.GitHubAppConfig{{AppID: 1, PrivateKeyPEM: testGitHubAppPEM(t)}}}, "", "", "")
+	if got := s.resolveGitHubTokenForRepo("owner/repo"); got != "" {
+		t.Fatalf("token = %q, want empty after mint failure", got)
+	}
+	firstAttempts := atomic.LoadInt64(&mints)
+	if firstAttempts == 0 {
+		t.Fatal("expected at least one mint attempt")
+	}
+	if got := s.resolveGitHubTokenForRepo("owner/repo"); got != "" {
+		t.Fatalf("token = %q, want cached empty failure", got)
+	}
+	if got := atomic.LoadInt64(&mints); got != firstAttempts {
+		t.Fatalf("mint attempts=%d, want %d while negative cache is live", got, firstAttempts)
+	}
+}
+
+type githubAppRateLimitedTokenTransport struct {
+	base  http.RoundTripper
+	mints *int64
+}
+
+func (t githubAppRateLimitedTokenTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	if r.URL.Host == "api.github.com" && r.Method == http.MethodPost && r.URL.Path == "/app/installations/1/access_tokens" {
+		atomic.AddInt64(t.mints, 1)
+		resp := githubAppTokenResponse(http.StatusTooManyRequests, `{"message":"rate limit"}`)
+		resp.Header.Set("Retry-After", "60")
+		return resp, nil
+	}
+	return t.base.RoundTrip(r)
 }
 
 // Factories often configure GitHub Apps only on the workspace (no hub-global

--- a/pkg/hub/github_issues.go
+++ b/pkg/hub/github_issues.go
@@ -1143,18 +1143,11 @@ func fetchGitHubIssueCommentsPage(ctx context.Context, baseURL, path, token stri
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
-	resp, err := issueTrackerHTTPClient.Do(req)
+	resp, err := defaultGitHubClient.do(req)
 	if err != nil {
 		return nil, "", err
 	}
-	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, "", fmt.Errorf("github comments response read error: %w", err)
-	}
-	if resp.StatusCode >= 400 {
-		return nil, "", fmt.Errorf("github comments API returned status %d: %s", resp.StatusCode, string(body))
-	}
+	body := resp.Body
 	var comments []githubIssueComment
 	if err := json.Unmarshal(body, &comments); err != nil {
 		return nil, "", fmt.Errorf("github comments parse error: %w", err)
@@ -1215,15 +1208,11 @@ func githubAPIPostWithBase(baseURL, path, token, method string, body interface{}
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	resp, err := issueTrackerHTTPClient.Do(req)
+	resp, err := defaultGitHubClient.do(req)
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
-	respBody, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("github API %s %s: %d %s", method, path, resp.StatusCode, string(respBody))
-	}
+	respBody := resp.Body
 	var result map[string]interface{}
 	if err := json.Unmarshal(respBody, &result); err != nil {
 		return nil, fmt.Errorf("github API parse error: %w", err)

--- a/pkg/hub/github_webhook.go
+++ b/pkg/hub/github_webhook.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -1469,21 +1470,24 @@ func (s *Server) mergeSinglePRForClaw(clawID, repo string, prNumber int) (failur
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := defaultGitHubClient.do(req)
 	if err != nil {
 		log.Printf("[pipeline] merge_pr: request failed for %s#%d: %v", repo, prNumber, err)
+		var apiErr *githubAPIError
+		if errors.As(err, &apiErr) && apiErr.RateLimited {
+			s.injectExternalHubMessageByID(clawID, fmt.Sprintf("[hub] merge_pr: GitHub rate limit; retry later (PR #%d).", prNumber))
+			return fmt.Sprintf("PR #%d failed (GitHub rate limit)", prNumber)
+		}
 		s.injectExternalHubMessageByID(clawID, fmt.Sprintf("[hub] merge_pr: failed to merge PR #%d: %v", prNumber, err))
 		return fmt.Sprintf("PR #%d failed (%v)", prNumber, err)
 	}
-	defer resp.Body.Close()
-	respBody, _ := io.ReadAll(resp.Body)
 
 	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusCreated {
 		log.Printf("[pipeline] merge_pr: merged %s#%d successfully", repo, prNumber)
 		s.injectHubMessageByID(clawID, fmt.Sprintf("[hub] PR #%d merged successfully.", prNumber))
 		return ""
 	}
-	log.Printf("[pipeline] merge_pr: failed to merge %s#%d: HTTP %d: %s", repo, prNumber, resp.StatusCode, string(respBody))
+	log.Printf("[pipeline] merge_pr: failed to merge %s#%d: HTTP %d: %s", repo, prNumber, resp.StatusCode, string(resp.Body))
 	s.injectExternalHubMessageByID(clawID, fmt.Sprintf("[hub] merge_pr: failed to merge PR #%d (HTTP %d). Check CI status and review requirements.", prNumber, resp.StatusCode))
 	return fmt.Sprintf("PR #%d failed (HTTP %d)", prNumber, resp.StatusCode)
 }

--- a/pkg/hub/github_webhook.go
+++ b/pkg/hub/github_webhook.go
@@ -1491,5 +1491,10 @@ func (s *Server) mergeSinglePRForClaw(clawID, repo string, prNumber int) (failur
 		s.injectHubMessageByID(clawID, fmt.Sprintf("[hub] PR #%d merged successfully.", prNumber))
 		return ""
 	}
-	return ""
+	// do() only errors for >= 300, so this is an unexpected 2xx (202/204/...):
+	// GitHub did not confirm the merge, and counting it as merged would silently
+	// drop the PR from tracking.
+	log.Printf("[pipeline] merge_pr: unexpected status %d for %s#%d", resp.StatusCode, repo, prNumber)
+	s.injectExternalHubMessageByID(clawID, fmt.Sprintf("[hub] merge_pr: failed to merge PR #%d (HTTP %d). Check CI status and review requirements.", prNumber, resp.StatusCode))
+	return fmt.Sprintf("PR #%d failed (HTTP %d)", prNumber, resp.StatusCode)
 }

--- a/pkg/hub/github_webhook.go
+++ b/pkg/hub/github_webhook.go
@@ -1474,9 +1474,13 @@ func (s *Server) mergeSinglePRForClaw(clawID, repo string, prNumber int) (failur
 	if err != nil {
 		log.Printf("[pipeline] merge_pr: request failed for %s#%d: %v", repo, prNumber, err)
 		var apiErr *githubAPIError
-		if errors.As(err, &apiErr) && apiErr.RateLimited {
-			s.injectExternalHubMessageByID(clawID, fmt.Sprintf("[hub] merge_pr: GitHub rate limit; retry later (PR #%d).", prNumber))
-			return fmt.Sprintf("PR #%d failed (GitHub rate limit)", prNumber)
+		if errors.As(err, &apiErr) {
+			if apiErr.RateLimited {
+				s.injectExternalHubMessageByID(clawID, fmt.Sprintf("[hub] merge_pr: GitHub rate limit; retry later (PR #%d).", prNumber))
+				return fmt.Sprintf("PR #%d failed (GitHub rate limit)", prNumber)
+			}
+			s.injectExternalHubMessageByID(clawID, fmt.Sprintf("[hub] merge_pr: failed to merge PR #%d (HTTP %d). Check CI status and review requirements.", prNumber, apiErr.StatusCode))
+			return fmt.Sprintf("PR #%d failed (HTTP %d)", prNumber, apiErr.StatusCode)
 		}
 		s.injectExternalHubMessageByID(clawID, fmt.Sprintf("[hub] merge_pr: failed to merge PR #%d: %v", prNumber, err))
 		return fmt.Sprintf("PR #%d failed (%v)", prNumber, err)
@@ -1487,7 +1491,5 @@ func (s *Server) mergeSinglePRForClaw(clawID, repo string, prNumber int) (failur
 		s.injectHubMessageByID(clawID, fmt.Sprintf("[hub] PR #%d merged successfully.", prNumber))
 		return ""
 	}
-	log.Printf("[pipeline] merge_pr: failed to merge %s#%d: HTTP %d: %s", repo, prNumber, resp.StatusCode, string(resp.Body))
-	s.injectExternalHubMessageByID(clawID, fmt.Sprintf("[hub] merge_pr: failed to merge PR #%d (HTTP %d). Check CI status and review requirements.", prNumber, resp.StatusCode))
-	return fmt.Sprintf("PR #%d failed (HTTP %d)", prNumber, resp.StatusCode)
+	return ""
 }

--- a/pkg/hub/github_webhook_merge_test.go
+++ b/pkg/hub/github_webhook_merge_test.go
@@ -1,0 +1,50 @@
+package hub
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+type mergeFailureTransport struct{}
+
+func (mergeFailureTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	if r.URL.Host == "api.github.com" {
+		if r.Method == http.MethodGet && r.URL.Path == "/app/installations" {
+			return githubAppTokenResponse(http.StatusOK, `[{"id":1,"account":{"login":"owner"}}]`), nil
+		}
+		if r.Method == http.MethodPost && r.URL.Path == "/app/installations/1/access_tokens" {
+			return githubAppTokenResponse(http.StatusCreated, `{"token":"repo-token","expires_at":"2030-01-01T00:00:00Z"}`), nil
+		}
+	}
+	return &http.Response{
+		StatusCode: http.StatusMethodNotAllowed,
+		Body:       io.NopCloser(strings.NewReader(`{"message":"Pull Request is not mergeable"}`)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func TestMergeSinglePRForClawHTTPFailureMessage(t *testing.T) {
+	oldTransport := http.DefaultTransport
+	oldClient := defaultGitHubClient
+	transport := mergeFailureTransport{}
+	http.DefaultTransport = transport
+	defaultGitHubClient = newGitHubClient()
+	defaultGitHubClient.httpClient = &http.Client{Timeout: 30 * time.Second, Transport: transport}
+	t.Cleanup(func() {
+		http.DefaultTransport = oldTransport
+		defaultGitHubClient = oldClient
+	})
+
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{GitHubApps: []*types.GitHubAppConfig{{AppID: 1, PrivateKeyPEM: testGitHubAppPEM(t)}}}, "https://github.test", "", "")
+	insertWatcherTestPR(t, db, "claw-merge-failure", "pr-merge-failure")
+
+	if got := s.mergeSinglePRForClaw("claw-merge-failure", "owner/repo", 1); got != "PR #1 failed (HTTP 405)" {
+		t.Fatalf("failure = %q, want HTTP failure", got)
+	}
+	assertMessageContains(t, db, "claw-merge-failure", "hub", []string{"[hub] merge_pr: failed to merge PR #1 (HTTP 405). Check CI status and review requirements."})
+}

--- a/pkg/hub/integration_poller.go
+++ b/pkg/hub/integration_poller.go
@@ -87,16 +87,20 @@ func (s *Server) pollTick() {
 	}
 
 	// === GITHUB ISSUES ===
-	ghIssuesSince := s.pollSince("github-issues", now).Format(time.RFC3339)
-	ghIssuesOK := true
-	if integrations != nil && len(integrations.GitHubIssues) > 0 {
-		ghIssuesOK = s.pollGitHubIssues(factories, integrations.GitHubIssues, ghIssuesSince)
-	}
-	if len(githubIssueWorkflowWorkspaces) > 0 {
-		ghIssuesOK = s.pollGitHubIssueWorkflows(githubIssueWorkflowWorkspaces, ghIssuesSince) && ghIssuesOK
-	}
-	if ((integrations != nil && len(integrations.GitHubIssues) > 0) || len(githubIssueWorkflowWorkspaces) > 0) && ghIssuesOK {
-		s.setPollHighWaterMark("github-issues", now)
+	if !defaultGitHubClient.allowLowPriority() {
+		log.Printf("[poll] tick: GitHub polling skipped; rate-limit reserve active")
+	} else {
+		ghIssuesSince := s.pollSince("github-issues", now).Format(time.RFC3339)
+		ghIssuesOK := true
+		if integrations != nil && len(integrations.GitHubIssues) > 0 {
+			ghIssuesOK = s.pollGitHubIssues(factories, integrations.GitHubIssues, ghIssuesSince)
+		}
+		if len(githubIssueWorkflowWorkspaces) > 0 {
+			ghIssuesOK = s.pollGitHubIssueWorkflows(githubIssueWorkflowWorkspaces, ghIssuesSince) && ghIssuesOK
+		}
+		if ((integrations != nil && len(integrations.GitHubIssues) > 0) || len(githubIssueWorkflowWorkspaces) > 0) && ghIssuesOK {
+			s.setPollHighWaterMark("github-issues", now)
+		}
 	}
 
 	// === JIRA ===
@@ -114,7 +118,7 @@ func (s *Server) pollTick() {
 
 	// === GITHUB PRs ===
 	// Use factories with integration=="github" to discover repos
-	if len(factories) > 0 {
+	if len(factories) > 0 && defaultGitHubClient.allowLowPriority() {
 		if s.pollGitHubPRs(factories, s.pollSince("github", now).Format(time.RFC3339)) {
 			s.setPollHighWaterMark("github", now)
 		}

--- a/pkg/hub/lifecycle_claw_notifier.go
+++ b/pkg/hub/lifecycle_claw_notifier.go
@@ -659,12 +659,14 @@ func (s *Server) skipCurrentLifecycleClawRouteStageStalled(notifier string) erro
 // same single-writer sqlite connection — iterating an open *Rows cursor while
 // writing through it deadlocks.
 func (s *Server) selectLifecycleClawStageStalledCandidates(notifier string) ([]lifecycleClawRow, []int64, []string, []sql.NullInt64, error) {
+	cutoff := lifecycleClawAdhocCutoff()
 	rows, err := s.db.Query(`SELECT `+lifecycleClawSelectColumns+`, c.stage_stalled_since, c.pipeline_stage, c.stage_entered_at FROM claws c
 		WHERE c.task_run_id='' AND c.status='connected' AND c.pipeline_stage<>'' AND c.stage_stalled_since>0
+		AND CAST(strftime('%s', c.created_at) AS INTEGER) <= ?
 		AND NOT EXISTS (SELECT 1 FROM claw_prs p WHERE p.claw_id=c.id AND p.state NOT IN ('merged','closed') AND p.mention_only=0)
 		AND NOT EXISTS (SELECT 1 FROM slack_notification_deliveries d WHERE d.event_id='claw:' || c.id || ':stage_stalled:' || c.stage_stalled_since)
 		AND NOT EXISTS (SELECT 1 FROM slack_notification_deliveries_v2 v WHERE v.event_id='claw:' || c.id || ':stage_stalled:' || c.stage_stalled_since AND v.notifier=?)
-		ORDER BY c.created_at LIMIT `+strconv.Itoa(lifecycleBatchSize), notifier)
+		ORDER BY c.created_at LIMIT `+strconv.Itoa(lifecycleBatchSize), cutoff, notifier)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}

--- a/pkg/hub/lifecycle_claw_notifier.go
+++ b/pkg/hub/lifecycle_claw_notifier.go
@@ -144,8 +144,8 @@ func lifecycleClawRunContext(claw lifecycleClawRow) lifecycleRunContext {
 // lifecycleClawKindsEnabled maps the existing config toggles onto the claw-pass
 // kinds. The claw pass intentionally shares the task-run toggles: an operator
 // muting pr_opened mutes it for both sources.
-func lifecycleClawKindsEnabled(cfg *types.LifecycleNotificationsConfig) (agentStarted, prOpened, failures, agentIdle bool) {
-	agentStarted, prOpened, failures, agentIdle = true, true, true, true
+func lifecycleClawKindsEnabled(cfg *types.LifecycleNotificationsConfig) (agentStarted, prOpened, failures, agentIdle, stageStalled bool) {
+	agentStarted, prOpened, failures, agentIdle, stageStalled = true, true, true, true, true
 	if cfg != nil && cfg.Events != nil {
 		if cfg.Events.AgentStarted != nil {
 			agentStarted = *cfg.Events.AgentStarted
@@ -158,6 +158,9 @@ func lifecycleClawKindsEnabled(cfg *types.LifecycleNotificationsConfig) (agentSt
 		}
 		if cfg.Events.AgentIdle != nil {
 			agentIdle = *cfg.Events.AgentIdle
+		}
+		if cfg.Events.StageStalled != nil {
+			stageStalled = *cfg.Events.StageStalled
 		}
 	}
 	return
@@ -192,7 +195,7 @@ func (s *Server) lifecycleClawPass(d lifecycleDelivery) {
 		return
 	}
 
-	startedOn, prOn, failuresOn, idleOn := lifecycleClawKindsEnabled(d.lc)
+	startedOn, prOn, failuresOn, idleOn, stalledOn := lifecycleClawKindsEnabled(d.lc)
 	// Park disabled kinds so re-enabling a toggle behaves like a fresh enable
 	// instead of flushing every transition from the muted window.
 	if !startedOn {
@@ -203,6 +206,9 @@ func (s *Server) lifecycleClawPass(d lifecycleDelivery) {
 	}
 	if !idleOn {
 		s.skipCurrentLifecycleClawIdle()
+	}
+	if !stalledOn {
+		s.skipCurrentLifecycleClawStageStalled()
 	}
 	if !prOn {
 		s.skipCurrentLifecycleClawPRs()
@@ -222,7 +228,7 @@ func (s *Server) lifecycleClawPass(d lifecycleDelivery) {
 		if !s.ensureLifecycleClawRouteBaseline(d, route) {
 			continue
 		}
-		s.lifecycleClawRoutePass(d, route, startedOn, prOn, failuresOn, idleOn)
+		s.lifecycleClawRoutePass(d, route, startedOn, prOn, failuresOn, idleOn, stalledOn)
 	}
 }
 
@@ -233,7 +239,7 @@ func (s *Server) lifecycleClawPass(d lifecycleDelivery) {
 // delivery row every claw still connected (and every claw_prs row still open)
 // since the route's baseline would be replayed into the channel the moment the
 // operator adds that event type to the route's allow-list.
-func (s *Server) lifecycleClawRoutePass(d lifecycleDelivery, route lifecycleRouteDelivery, startedOn, prOn, failuresOn, idleOn bool) {
+func (s *Server) lifecycleClawRoutePass(d lifecycleDelivery, route lifecycleRouteDelivery, startedOn, prOn, failuresOn, idleOn, stalledOn bool) {
 	if startedOn {
 		if !lifecycleRouteAccepts(route, taskRunEventAgentStarted) {
 			_ = s.skipCurrentLifecycleClawRouteState(route.notifier, lifecycleClawKindStarted)
@@ -252,6 +258,13 @@ func (s *Server) lifecycleClawRoutePass(d lifecycleDelivery, route lifecycleRout
 		if !lifecycleRouteAccepts(route, taskRunEventAgentIdle) {
 			_ = s.skipCurrentLifecycleClawRouteIdle(route.notifier)
 		} else if !s.sendLifecycleClawIdleEvents(d, route) {
+			return
+		}
+	}
+	if stalledOn {
+		if !lifecycleRouteAccepts(route, taskRunEventStageStalled) {
+			_ = s.skipCurrentLifecycleClawRouteStageStalled(route.notifier)
+		} else if !s.sendLifecycleClawStageStalledEvents(d, route) {
 			return
 		}
 	}
@@ -539,6 +552,9 @@ func (s *Server) seedLifecycleClawBaseline() error {
 	if err := s.skipCurrentLifecycleClawIdle(); err != nil {
 		return err
 	}
+	if err := s.skipCurrentLifecycleClawStageStalled(); err != nil {
+		return err
+	}
 	return s.skipCurrentLifecycleClawPRs()
 }
 
@@ -554,6 +570,7 @@ func (s *Server) parkLifecycleClawState() {
 	_ = s.skipCurrentLifecycleClawState(lifecycleClawKindStarted)
 	_ = s.skipCurrentLifecycleClawState(lifecycleClawKindFailure)
 	_ = s.skipCurrentLifecycleClawIdle()
+	_ = s.skipCurrentLifecycleClawStageStalled()
 	_ = s.skipCurrentLifecycleClawPRs()
 }
 
@@ -617,6 +634,75 @@ func (s *Server) skipCurrentLifecycleClawIdle() error {
 		log.Printf("[notify] seed skipped claw idle deliveries: %v", err)
 	}
 	return err
+}
+
+func lifecycleClawStageStalledKey(id string, since int64) string {
+	return "claw:" + id + ":stage_stalled:" + strconv.FormatInt(since, 10)
+}
+
+func (s *Server) skipCurrentLifecycleClawStageStalled() error {
+	_, err := s.db.Exec(`INSERT INTO slack_notification_deliveries(event_id,run_id,delivered_at,message_ts,status)
+		SELECT 'claw:' || c.id || ':stage_stalled:' || c.stage_stalled_since, 'claw:' || c.id, ?, '', ? FROM claws c
+		WHERE c.task_run_id='' AND c.stage_stalled_since>0 ON CONFLICT(event_id) DO NOTHING`, epochMillis(now()), notificationDeliveryStatusSkipped)
+	return err
+}
+func (s *Server) skipCurrentLifecycleClawRouteStageStalled(notifier string) error {
+	return s.lifecycleClawRouteSkip(notifier, "stage_stalled", `SELECT 'claw:' || c.id || ':stage_stalled:' || c.stage_stalled_since, ?, 'claw:' || c.id, ?, '', ? FROM claws c WHERE c.task_run_id='' AND c.stage_stalled_since>0 AND CAST(strftime('%s',c.created_at) AS INTEGER)<=?`, notifier, epochMillis(now()), notificationDeliveryStatusSkipped, lifecycleClawAdhocCutoff())
+}
+
+// selectLifecycleClawStageStalledCandidates mirrors
+// selectLifecycleClawIdleCandidates: the full result set is materialized
+// before any row is delivered, because delivery issues further writes on the
+// same single-writer sqlite connection — iterating an open *Rows cursor while
+// writing through it deadlocks.
+func (s *Server) selectLifecycleClawStageStalledCandidates(notifier string) ([]lifecycleClawRow, []int64, []string, []sql.NullInt64, error) {
+	rows, err := s.db.Query(`SELECT `+lifecycleClawSelectColumns+`, c.stage_stalled_since, c.pipeline_stage, c.stage_entered_at FROM claws c
+		WHERE c.task_run_id='' AND c.status='connected' AND c.pipeline_stage<>'' AND c.stage_stalled_since>0
+		AND NOT EXISTS (SELECT 1 FROM claw_prs p WHERE p.claw_id=c.id AND p.state NOT IN ('merged','closed') AND p.mention_only=0)
+		AND NOT EXISTS (SELECT 1 FROM slack_notification_deliveries d WHERE d.event_id='claw:' || c.id || ':stage_stalled:' || c.stage_stalled_since)
+		AND NOT EXISTS (SELECT 1 FROM slack_notification_deliveries_v2 v WHERE v.event_id='claw:' || c.id || ':stage_stalled:' || c.stage_stalled_since AND v.notifier=?)
+		ORDER BY c.created_at LIMIT `+strconv.Itoa(lifecycleBatchSize), notifier)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	defer rows.Close()
+	var claws []lifecycleClawRow
+	var stalledSinces []int64
+	var stages []string
+	var entereds []sql.NullInt64
+	for rows.Next() {
+		var claw lifecycleClawRow
+		var stalled int64
+		var entered sql.NullInt64
+		var stage string
+		if err := scanLifecycleClawRow(func(dest ...any) error { return rows.Scan(append(dest, &stalled, &stage, &entered)...) }, &claw); err != nil {
+			return nil, nil, nil, nil, err
+		}
+		claws = append(claws, claw)
+		stalledSinces = append(stalledSinces, stalled)
+		stages = append(stages, stage)
+		entereds = append(entereds, entered)
+	}
+	return claws, stalledSinces, stages, entereds, rows.Err()
+}
+
+func (s *Server) sendLifecycleClawStageStalledEvents(d lifecycleDelivery, route lifecycleRouteDelivery) bool {
+	claws, stalledSinces, stages, entereds, err := s.selectLifecycleClawStageStalledCandidates(route.notifier)
+	if err != nil {
+		log.Printf("[notify] select stalled stages: %v", err)
+		return false
+	}
+	for i, claw := range claws {
+		stalled, stage, entered := stalledSinces[i], stages[i], entereds[i]
+		detail := map[string]any{"stage": stage, "lastProgressMinutes": int(now().Sub(time.UnixMilli(stalled)).Minutes())}
+		if entered.Valid && entered.Int64 > 0 {
+			detail["stageAgeMinutes"] = int(now().Sub(time.UnixMilli(entered.Int64)).Minutes())
+		}
+		if !s.deliverLifecycleClawEvent(d, route, claw, lifecycleEventRow{EventType: taskRunEventStageStalled, Detail: detail}, lifecycleClawRunContext(claw), lifecycleClawStageStalledKey(claw.ID, stalled)) {
+			return false
+		}
+	}
+	return true
 }
 
 // selectLifecycleClawIdleCandidates returns ad-hoc claws whose idle latch has

--- a/pkg/hub/lifecycle_claw_notifier.go
+++ b/pkg/hub/lifecycle_claw_notifier.go
@@ -478,6 +478,9 @@ func (s *Server) seedLifecycleClawRouteBaseline(notifier string) error {
 	if err := s.skipCurrentLifecycleClawRouteIdle(notifier); err != nil {
 		return err
 	}
+	if err := s.skipCurrentLifecycleClawRouteStageStalled(notifier); err != nil {
+		return err
+	}
 	return s.skipCurrentLifecycleClawRoutePRs(notifier)
 }
 

--- a/pkg/hub/lifecycle_claw_notifier_test.go
+++ b/pkg/hub/lifecycle_claw_notifier_test.go
@@ -643,3 +643,23 @@ func TestLifecycleClawIdleCandidatesIgnoreMentionOnlyPRs(t *testing.T) {
 		t.Fatalf("idle candidates with an unresolved DELIVERED PR = %v, want none (an owned open PR suppresses the idle alert)", claws)
 	}
 }
+
+func TestLifecycleClawStageStalledCandidatesExcludeYoungClaws(t *testing.T) {
+	s, db := newSlackNotifierTestServer(t, "", nil)
+	setLifecycleClawBaseline(t, s)
+
+	insertSlackTestClaw(t, db, "claw-stage-stalled-old", "connected", 1, "", oldEnough)
+	insertSlackTestClaw(t, db, "claw-stage-stalled-young", "connected", 1, "", lifecycleClawAdhocGrace-time.Minute)
+	if _, err := db.Exec(`UPDATE claws SET pipeline_stage='work', stage_stalled_since=? WHERE id IN (?, ?)`,
+		time.Now().Add(-time.Minute).UnixMilli(), "claw-stage-stalled-old", "claw-stage-stalled-young"); err != nil {
+		t.Fatal(err)
+	}
+
+	claws, _, _, _, err := s.selectLifecycleClawStageStalledCandidates("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(claws) != 1 || claws[0].ID != "claw-stage-stalled-old" {
+		t.Fatalf("stage-stalled candidates = %v, want exactly claw-stage-stalled-old", claws)
+	}
+}

--- a/pkg/hub/lifecycle_notifier.go
+++ b/pkg/hub/lifecycle_notifier.go
@@ -183,7 +183,7 @@ func notifierCacheKey(name string, nc types.NotifierConfig, secrets notify.Secre
 // enabledLifecycleEventTypes maps the config toggles onto concrete event
 // types. All categories default to enabled when the toggles block is absent.
 func enabledLifecycleEventTypes(lc *types.LifecycleNotificationsConfig) map[string]bool {
-	agentStarted, prOpened, failures, agentIdle := lifecycleClawKindsEnabled(lc)
+	agentStarted, prOpened, failures, agentIdle, stageStalled := lifecycleClawKindsEnabled(lc)
 	enabled := map[string]bool{}
 	if agentStarted {
 		enabled[taskRunEventAgentStarted] = true
@@ -193,6 +193,9 @@ func enabledLifecycleEventTypes(lc *types.LifecycleNotificationsConfig) map[stri
 	}
 	if agentIdle {
 		enabled[taskRunEventAgentIdle] = true
+	}
+	if stageStalled {
+		enabled[taskRunEventStageStalled] = true
 	}
 	if failures {
 		for t := range lifecycleFailureEventTypes {
@@ -1536,6 +1539,7 @@ var lifecycleEventStyles = map[string]lifecycleEventStyle{
 	taskRunFailureProviderLost:     {":satellite_antenna:", "Lost contact with the provider", notify.SeverityError},
 	taskRunFailureTimeout:          {":hourglass_flowing_sand:", "Agent ran out of time", notify.SeverityWarning},
 	taskRunEventAgentIdle:          {":zzz:", "Agent stalled", notify.SeverityWarning},
+	taskRunEventStageStalled:       {":warning:", "Pipeline stage stalled", notify.SeverityWarning},
 	taskRunEventDoneWithoutPR:      {":mailbox_with_no_mail:", "Agent finished without a PR", notify.SeverityWarning},
 	"unknown_failure":              {":question:", "Agent failed", notify.SeverityError},
 }
@@ -1545,7 +1549,7 @@ var lifecycleEventStyles = map[string]lifecycleEventStyle{
 // still gets a readable humanized headline, never a raw snake_case string.
 func lifecycleEventStyleFor(ev lifecycleEventRow) lifecycleEventStyle {
 	key := ev.EventType
-	if key != taskRunEventAgentStarted && key != taskRunEventPROpened && key != taskRunEventAgentIdle {
+	if key != taskRunEventAgentStarted && key != taskRunEventPROpened && key != taskRunEventAgentIdle && key != taskRunEventStageStalled {
 		key = firstNonEmpty(ev.FailureType, ev.EventType)
 	}
 	if key == taskRunFailureUnknown {
@@ -1594,6 +1598,8 @@ func buildLifecycleMessage(ev lifecycleEventRow, runCtx lifecycleRunContext) not
 		return buildPROpenedMessage(ev, runCtx)
 	case taskRunEventAgentIdle:
 		return buildAgentIdleMessage(ev, runCtx)
+	case taskRunEventStageStalled:
+		return buildStageStalledMessage(ev, runCtx)
 	default:
 		return buildFailureMessage(ev, runCtx)
 	}
@@ -1717,6 +1723,28 @@ func buildAgentIdleMessage(ev lifecycleEventRow, runCtx lifecycleRunContext) not
 		Fields:   lifecycleMetaFields(runCtx, true, false),
 		Summary:  []string{runCtx.Repo, subject, summaryIdle},
 	}
+}
+
+func buildStageStalledMessage(ev lifecycleEventRow, runCtx lifecycleRunContext) notify.Message {
+	style := lifecycleEventStyleFor(ev)
+	subject := lifecycleIssueRef(runCtx)
+	if subject == "" {
+		subject = "task"
+	}
+	stage := detailString(ev.Detail, "stage")
+	if stage == "" {
+		stage = "current stage"
+	}
+	stageAge, progressAge := stageProgressDurationLabel(ev.Detail, "stageAgeMinutes"), stageProgressDurationLabel(ev.Detail, "lastProgressMinutes")
+	body := fmt.Sprintf("Stage %q has not made meaningful progress", stage)
+	if progressAge != "" {
+		body += " for " + progressAge
+	}
+	if stageAge != "" {
+		body += " (stage age: " + stageAge + ")"
+	}
+	body += "."
+	return notify.Message{Title: style.title, Emoji: style.emoji, Severity: style.severity, Subject: subject, Body: body, Fields: lifecycleMetaFields(runCtx, true, false), Summary: []string{runCtx.Repo, subject, "stage stalled: " + stage}}
 }
 
 func buildFailureMessage(ev lifecycleEventRow, runCtx lifecycleRunContext) notify.Message {

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -2266,6 +2266,7 @@ func (s *Server) stopAgentTerminalWithReason(clawID, reason string, skipVMTermin
 		delete(s.claws, clawID)
 	}
 	delete(s.gatewayUnhealthyCounts, clawID)
+	delete(s.gatewayEscalatedAt, clawID)
 	s.mu.Unlock()
 
 	// 4. Write issue-tracker comment without delaying agent shutdown.

--- a/pkg/hub/pipeline_runner.go
+++ b/pkg/hub/pipeline_runner.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -152,21 +151,11 @@ func (s *Server) fetchGitHubIssueDetails(token, repo string, issueNumber int, ba
 		baseURL = "https://api.github.com"
 	}
 	url := fmt.Sprintf("%s/repos/%s/issues/%d", baseURL, repo, issueNumber)
-	req, err := http.NewRequest("GET", url, nil)
+	resp, err := defaultGitHubClient.get(url, token)
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("Accept", "application/vnd.github+json")
-	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
-
-	resp, err := issueTrackerHTTPClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	body, _ := io.ReadAll(resp.Body)
+	body := resp.Body
 	if resp.StatusCode != 200 {
 		return nil, fmt.Errorf("github API GET %s: %d %s", url, resp.StatusCode, string(body))
 	}
@@ -258,14 +247,9 @@ func githubAPIAddLabel(baseURL, repo string, issueNumber int, label, token strin
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
 	req.Header.Set("Content-Type", "application/json")
-	resp, err := issueTrackerHTTPClient.Do(req)
+	_, err = defaultGitHubClient.do(req)
 	if err != nil {
 		return err
-	}
-	defer resp.Body.Close()
-	respBody, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode >= 300 {
-		return fmt.Errorf("github API POST %s: %d %s", path, resp.StatusCode, string(respBody))
 	}
 	return nil
 }
@@ -285,17 +269,13 @@ func githubAPIDeleteLabel(baseURL, repo string, issueNumber int, label, token st
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
-	resp, err := issueTrackerHTTPClient.Do(req)
+	_, err = defaultGitHubClient.do(req)
 	if err != nil {
+		var apiErr *githubAPIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound && strings.Contains(apiErr.Body, "Label does not exist") {
+			return nil
+		}
 		return err
-	}
-	defer resp.Body.Close()
-	respBody, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode == http.StatusNotFound && strings.Contains(string(respBody), "Label does not exist") {
-		return nil
-	}
-	if resp.StatusCode >= 300 {
-		return fmt.Errorf("github API DELETE %s: %d %s", path, resp.StatusCode, string(respBody))
 	}
 	return nil
 }

--- a/pkg/hub/pipeline_state.go
+++ b/pkg/hub/pipeline_state.go
@@ -1,6 +1,9 @@
 package hub
 
-import "log"
+import (
+	"log"
+	"time"
+)
 
 // getPipelineStage returns the current pipeline stage ID for a claw.
 // Returns "" if the claw has no pipeline stage set.
@@ -14,7 +17,7 @@ func (s *Server) getPipelineStage(clawID string) string {
 // claw is not already in that stage. It returns true when the caller won the
 // transition and should run on_enter actions.
 func (s *Server) claimPipelineStageTransition(clawID, stageID string) bool {
-	res, err := s.db.Exec(`UPDATE claws SET pipeline_stage=? WHERE id=? AND pipeline_stage<>?`, stageID, clawID, stageID)
+	res, err := s.db.Exec(`UPDATE claws SET pipeline_stage=?, stage_entered_at=? WHERE id=? AND pipeline_stage<>?`, stageID, time.Now().UnixMilli(), clawID, stageID)
 	if err != nil {
 		log.Printf("[pipeline] failed to set stage %q for claw %s: %v", stageID, clawID[:8], err)
 		return false

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -1049,6 +1049,21 @@ func (s *Server) resolveGitHubTokenWithRepos(repoAccess []RepoAccess) string {
 	if lastErr != nil {
 		log.Printf("[pr-watcher] CRITICAL: GitHub token resolution failed after trying %d app(s): %v", len(appCfgs), lastErr)
 	}
+	// Only negatively cache rate-limit failures: those are the ones that
+	// recur on every poll of every PR until the window passes, and the
+	// shared client's blockedUntil already tells us when that is. Other
+	// mint failures (outages, bad config) must be retried on the very next
+	// poll — token_miss_count and the re-arm sweep depend on that.
+	if apiErr, ok := lastErr.(*githubAPIError); ok && apiErr.RateLimited {
+		if s.ghTokenCache == nil {
+			s.ghTokenCache = map[string]cachedGitHubToken{}
+		}
+		until := time.Now().Add(time.Minute)
+		if blockedUntil, blocked := defaultGitHubClient.blockedUntilTime(); blocked && blockedUntil.After(until) {
+			until = blockedUntil
+		}
+		s.ghTokenCache[cacheKey] = cachedGitHubToken{expiresAt: until}
+	}
 	return ""
 }
 

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -1023,6 +1023,16 @@ func (s *Server) resolveGitHubTokenWithRepos(repoAccess []RepoAccess) string {
 	if cached, ok := s.ghTokenCache[cacheKey]; ok && time.Now().Before(cached.expiresAt) {
 		return cached.token
 	}
+	// If the shared client is already rate-limit blocked, don't mint: a
+	// mid-pass 429 on one repo must stop token mints for the rest of the
+	// pass, not just the repo that hit it.
+	if blockedUntil, blocked := defaultGitHubClient.blockedUntilTime(); blocked {
+		if s.ghTokenCache == nil {
+			s.ghTokenCache = map[string]cachedGitHubToken{}
+		}
+		s.ghTokenCache[cacheKey] = cachedGitHubToken{expiresAt: blockedUntil}
+		return ""
+	}
 	var lastErr error
 	for _, appCfg := range appCfgs {
 		provider, err := NewGitHubTokenProvider(appCfg)

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -1512,6 +1512,7 @@ func (s *Server) updateWatermarkGuarded(query string, args []interface{}, clawID
 		if err == nil || !isSQLiteBusy(err) {
 			break
 		}
+		time.Sleep(time.Duration(attempt+1) * 10 * time.Millisecond)
 	}
 	if err != nil {
 		log.Printf("[pr-watcher] watermark update failed for claw %s pr #%d: %v", clawID[:8], prNumber, err)

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -1811,7 +1811,8 @@ func (s *Server) claimPRFeedbackDelivery(clawID, feedbackType string, id int64) 
 func (s *Server) updatePRReviewWatermark(pr clawPR, reviewsData []interface{}) {
 	maxID := maxPRReviewID(reviewsData, pr.lastReviewID)
 	if maxID > pr.lastReviewID {
-		_, _ = s.db.Exec(`UPDATE claw_prs SET last_review_id=? WHERE id=?`, maxID, pr.id)
+		s.updateWatermarkGuarded(`UPDATE claw_prs SET last_review_id=? WHERE id=? AND last_review_id < ?`,
+			[]interface{}{maxID, pr.id, maxID}, pr.clawID, pr.prNumber)
 	}
 }
 

--- a/pkg/hub/pr_watcher.go
+++ b/pkg/hub/pr_watcher.go
@@ -869,6 +869,9 @@ func (s *Server) pollAllPRs() {
 		s.checkBugbotComments(r.pr, commentsData)
 		s.checkGreptileComments(r.pr, commentsData)
 		log.Printf("[pr-watcher] checking %d comment(s) for claw %s (watermark=%d, forward=%v)", len(commentsData), r.pr.clawID[:8], r.pr.lastCommentID, isPipelineDriven)
+		if !isPipelineDriven && hasNewComments(commentsData, r.pr.lastCommentID) {
+			log.Printf("[pr-watcher] claw=%s pr #%d has new comment(s) above watermark but forward=false (no pipeline context) — not delivering", r.pr.clawID[:8], r.pr.prNumber)
+		}
 		s.checkPRComments(r.pr, commentsData, prCommentOptions{
 			skipBugbot:   true,
 			skipGreptile: true,
@@ -1463,12 +1466,42 @@ func (s *Server) updatePRCommentWatermark(pr clawPR, commentsData []interface{})
 	}
 	if maxID > pr.lastCommentID {
 		if latestCommentAt != "" {
-			_, _ = s.db.Exec(`UPDATE claw_prs SET last_comment_id=?, last_comment_at=? WHERE id=?`,
-				maxID, latestCommentAt, pr.id)
+			s.updateWatermarkGuarded(`UPDATE claw_prs SET last_comment_id=?, last_comment_at=? WHERE id=? AND last_comment_id < ?`,
+				[]interface{}{maxID, latestCommentAt, pr.id, maxID}, pr.clawID, pr.prNumber)
 		} else {
-			_, _ = s.db.Exec(`UPDATE claw_prs SET last_comment_id=? WHERE id=?`, maxID, pr.id)
+			s.updateWatermarkGuarded(`UPDATE claw_prs SET last_comment_id=? WHERE id=? AND last_comment_id < ?`,
+				[]interface{}{maxID, pr.id, maxID}, pr.clawID, pr.prNumber)
 		}
 	}
+}
+
+// hasNewComments reports whether commentsData has an ID above watermark.
+func hasNewComments(commentsData []interface{}, watermark int64) bool {
+	for _, c := range commentsData {
+		comment, _ := c.(map[string]interface{})
+		idF, _ := comment["id"].(float64)
+		if int64(idF) > watermark {
+			return true
+		}
+	}
+	return false
+}
+
+// updateWatermarkGuarded advances a monotonic watermark, retrying once on a
+// SQLite busy error. Zero rows affected means another writer already advanced
+// the watermark at or past the requested value, which is not an error.
+func (s *Server) updateWatermarkGuarded(query string, args []interface{}, clawID string, prNumber int) error {
+	var err error
+	for attempt := 0; attempt < 2; attempt++ {
+		_, err = s.db.Exec(query, args...)
+		if err == nil || !isSQLiteBusy(err) {
+			break
+		}
+	}
+	if err != nil {
+		log.Printf("[pr-watcher] watermark update failed for claw %s pr #%d: %v", clawID[:8], prNumber, err)
+	}
+	return err
 }
 
 // checkGreptileReviewComments polls PR review comments (pulls/{n}/comments) for
@@ -1792,7 +1825,8 @@ func (s *Server) updateReviewCommentWatermark(pr clawPR, reviewCommentsData []in
 		}
 	}
 	if maxID > pr.lastReviewCommentID {
-		_, _ = s.db.Exec(`UPDATE claw_prs SET last_review_comment_id=? WHERE id=?`, maxID, pr.id)
+		s.updateWatermarkGuarded(`UPDATE claw_prs SET last_review_comment_id=? WHERE id=? AND last_review_comment_id < ?`,
+			[]interface{}{maxID, pr.id, maxID}, pr.clawID, pr.prNumber)
 	}
 }
 

--- a/pkg/hub/pr_watcher_test.go
+++ b/pkg/hub/pr_watcher_test.go
@@ -211,6 +211,62 @@ func insertWatcherTestPR(t *testing.T, db *sql.DB, clawID, prID string) {
 	}
 }
 
+func TestPRCommentWatermarkOnlyAdvances(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{}, "", "", "")
+	insertWatcherTestPR(t, db, "claw-watermark", "pr-watermark")
+
+	pr := clawPR{id: "pr-watermark", clawID: "claw-watermark", prNumber: 1, lastCommentID: 10}
+	s.updatePRCommentWatermark(pr, []interface{}{map[string]interface{}{
+		"id":         float64(20),
+		"created_at": "2026-01-01T00:00:00Z",
+	}})
+	var got int64
+	if err := db.QueryRow(`SELECT last_comment_id FROM claw_prs WHERE id=?`, pr.id).Scan(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got != 20 {
+		t.Fatalf("last_comment_id = %d, want 20", got)
+	}
+
+	if _, err := db.Exec(`UPDATE claw_prs SET last_comment_id=30 WHERE id=?`, pr.id); err != nil {
+		t.Fatal(err)
+	}
+	// pr retains a stale in-memory watermark, as can happen with concurrent polls.
+	s.updatePRCommentWatermark(pr, []interface{}{map[string]interface{}{"id": float64(25)}})
+	if err := db.QueryRow(`SELECT last_comment_id FROM claw_prs WHERE id=?`, pr.id).Scan(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got != 30 {
+		t.Fatalf("last_comment_id regressed to %d, want 30", got)
+	}
+}
+
+func TestReviewCommentWatermarkOnlyAdvances(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{}, "", "", "")
+	insertWatcherTestPR(t, db, "claw-review-watermark", "pr-review-watermark")
+
+	pr := clawPR{id: "pr-review-watermark", clawID: "claw-review-watermark", prNumber: 1, lastReviewCommentID: 10}
+	s.updateReviewCommentWatermark(pr, []interface{}{map[string]interface{}{"id": float64(20)}})
+	var got int64
+	if err := db.QueryRow(`SELECT last_review_comment_id FROM claw_prs WHERE id=?`, pr.id).Scan(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got != 20 {
+		t.Fatalf("last_review_comment_id = %d, want 20", got)
+	}
+
+	if _, err := db.Exec(`UPDATE claw_prs SET last_review_comment_id=30 WHERE id=?`, pr.id); err != nil {
+		t.Fatal(err)
+	}
+	s.updateReviewCommentWatermark(pr, []interface{}{map[string]interface{}{"id": float64(25)}})
+	if err := db.QueryRow(`SELECT last_review_comment_id FROM claw_prs WHERE id=?`, pr.id).Scan(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got != 30 {
+		t.Fatalf("last_review_comment_id regressed to %d, want 30", got)
+	}
+}
+
 func TestCheckPRMergedStopsAfterPermanentFailures(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"message":"Not Found"}`, http.StatusNotFound)

--- a/pkg/hub/pr_watcher_test.go
+++ b/pkg/hub/pr_watcher_test.go
@@ -267,6 +267,32 @@ func TestReviewCommentWatermarkOnlyAdvances(t *testing.T) {
 	}
 }
 
+func TestPRReviewWatermarkOnlyAdvances(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{}, "", "", "")
+	insertWatcherTestPR(t, db, "claw-review-watermark", "pr-review-watermark")
+
+	pr := clawPR{id: "pr-review-watermark", clawID: "claw-review-watermark", prNumber: 1, lastReviewID: 10}
+	s.updatePRReviewWatermark(pr, []interface{}{map[string]interface{}{"id": float64(20)}})
+	var got int64
+	if err := db.QueryRow(`SELECT last_review_id FROM claw_prs WHERE id=?`, pr.id).Scan(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got != 20 {
+		t.Fatalf("last_review_id = %d, want 20", got)
+	}
+
+	if _, err := db.Exec(`UPDATE claw_prs SET last_review_id=30 WHERE id=?`, pr.id); err != nil {
+		t.Fatal(err)
+	}
+	s.updatePRReviewWatermark(pr, []interface{}{map[string]interface{}{"id": float64(25)}})
+	if err := db.QueryRow(`SELECT last_review_id FROM claw_prs WHERE id=?`, pr.id).Scan(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got != 30 {
+		t.Fatalf("last_review_id regressed to %d, want 30", got)
+	}
+}
+
 func TestCheckPRMergedStopsAfterPermanentFailures(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"message":"Not Found"}`, http.StatusNotFound)

--- a/pkg/hub/pr_watcher_test.go
+++ b/pkg/hub/pr_watcher_test.go
@@ -822,3 +822,121 @@ func TestInjectMessageSkipsIdenticalPendingRow(t *testing.T) {
 		t.Fatalf("same text rows=%d err=%v, want 2", pending, err)
 	}
 }
+
+// countingGitHubAppTransport is like githubAppTokenTransport but counts every
+// request reaching api.github.com so tests can assert a blocked gate mints
+// zero tokens.
+type countingGitHubAppTransport struct {
+	base     http.RoundTripper
+	requests *atomic.Int64
+}
+
+func (t countingGitHubAppTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	if r.URL.Host != "api.github.com" {
+		return t.base.RoundTrip(r)
+	}
+	t.requests.Add(1)
+	if r.Method == http.MethodGet && r.URL.Path == "/app/installations" {
+		return githubAppTokenResponse(http.StatusOK, `[{"id":1,"account":{"login":"owner"}}]`), nil
+	}
+	if r.Method == http.MethodPost && r.URL.Path == "/app/installations/1/access_tokens" {
+		return githubAppTokenResponse(http.StatusCreated, `{"token":"repo-token","expires_at":"2030-01-01T00:00:00Z"}`), nil
+	}
+	return githubAppTokenResponse(http.StatusNotFound, `{"message":"not found"}`), nil
+}
+
+// TestResolveGitHubTokenWithReposGatedDuringBlockMintsNothing verifies that
+// resolveGitHubTokenWithRepos refuses to mint (and reaches GitHub zero
+// times) while defaultGitHubClient is already rate-limit blocked.
+func TestResolveGitHubTokenWithReposGatedDuringBlockMintsNothing(t *testing.T) {
+	oldTransport := http.DefaultTransport
+	oldClient := defaultGitHubClient
+	var requests atomic.Int64
+	http.DefaultTransport = countingGitHubAppTransport{base: oldTransport, requests: &requests}
+	defaultGitHubClient = newGitHubClient()
+	t.Cleanup(func() {
+		http.DefaultTransport = oldTransport
+		defaultGitHubClient = oldClient
+	})
+
+	// Arm the shared client's rate-limit gate.
+	defaultGitHubClient.observe(http.StatusForbidden, http.Header{"Retry-After": []string{"60"}}, nil)
+	if _, blocked := defaultGitHubClient.blockedUntilTime(); !blocked {
+		t.Fatal("expected defaultGitHubClient to be blocked after observe(403, Retry-After)")
+	}
+
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{GitHubApps: []*types.GitHubAppConfig{{AppID: 1, PrivateKeyPEM: testGitHubAppPEM(t)}}}, "", "", "")
+
+	got := s.resolveGitHubTokenForRepo("org/uncached-repo")
+	if got != "" {
+		t.Fatalf("resolveGitHubTokenForRepo = %q, want empty while gate is blocked", got)
+	}
+	if n := requests.Load(); n != 0 {
+		t.Fatalf("GitHub requests during blocked gate = %d, want 0", n)
+	}
+}
+
+// TestPollAllPRsStopsMintingAfterMidPassRateLimit verifies that once one
+// repo's poll trips the shared rate-limit gate, later repos in the same
+// pollAllPRs pass make no further token-mint attempts.
+func TestPollAllPRsStopsMintingAfterMidPassRateLimit(t *testing.T) {
+	oldTransport := http.DefaultTransport
+	oldClient := defaultGitHubClient
+	var mintRequests atomic.Int64
+	rateLimitedOnce := &atomic.Bool{}
+
+	transport := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.Host != "api.github.com" {
+			return oldTransport.RoundTrip(r)
+		}
+		if r.URL.Path == "/app/installations" {
+			return githubAppTokenResponse(http.StatusOK, `[{"id":1,"account":{"login":"owner"}}]`), nil
+		}
+		if r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/app/installations/") {
+			mintRequests.Add(1)
+			return githubAppTokenResponse(http.StatusCreated, `{"token":"repo-token","expires_at":"2030-01-01T00:00:00Z"}`), nil
+		}
+		if strings.HasSuffix(r.URL.Path, "/pulls/1") {
+			if r.URL.Path == "/repos/owner/repo-a/pulls/1" && rateLimitedOnce.CompareAndSwap(false, true) {
+				h := http.Header{}
+				h.Set("Retry-After", "60")
+				return &http.Response{StatusCode: http.StatusForbidden, Body: io.NopCloser(strings.NewReader(`{"message":"rate limit exceeded"}`)), Header: h}, nil
+			}
+			return githubAppTokenResponse(http.StatusOK, `{"state":"open"}`), nil
+		}
+		return githubAppTokenResponse(http.StatusOK, `{"state":"open"}`), nil
+	})
+	http.DefaultTransport = transport
+	defaultGitHubClient = newGitHubClient()
+	t.Cleanup(func() {
+		http.DefaultTransport = oldTransport
+		defaultGitHubClient = oldClient
+	})
+
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{GitHubApps: []*types.GitHubAppConfig{{AppID: 1, PrivateKeyPEM: testGitHubAppPEM(t)}}}, "https://api.github.com", "", "")
+
+	if _, err := db.Exec(`INSERT INTO claws(id,tenant_id,name,template,status,created_at) VALUES(?,?,?,?,?,?)`, "claw-aaaa", "test-tenant-id", "claw-aaaa", "elasticclaw", "connected", now()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO claws(id,tenant_id,name,template,status,created_at) VALUES(?,?,?,?,?,?)`, "claw-bbbb", "test-tenant-id", "claw-bbbb", "elasticclaw", "connected", now()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO claw_prs(id,claw_id,repo,pr_number,pr_url,created_at) VALUES(?,?,?,?,?,?)`, "pr-a", "claw-aaaa", "owner/repo-a", 1, "https://github.com/owner/repo-a/pull/1", now()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO claw_prs(id,claw_id,repo,pr_number,pr_url,created_at) VALUES(?,?,?,?,?,?)`, "pr-b", "claw-bbbb", "owner/repo-b", 1, "https://github.com/owner/repo-b/pull/1", now()); err != nil {
+		t.Fatal(err)
+	}
+
+	s.pollAllPRs()
+
+	// repo-a mints once, trips the gate on its pulls/1 call; repo-b must not
+	// mint at all in this same pass.
+	if n := mintRequests.Load(); n != 1 {
+		t.Fatalf("token mint requests in pass = %d, want 1 (repo-b must be gated)", n)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }

--- a/pkg/hub/rebrief_test.go
+++ b/pkg/hub/rebrief_test.go
@@ -60,7 +60,7 @@ func TestRebriefPendingArmedByRetryAndConsumedOnce(t *testing.T) {
 		t.Fatalf("insert claw_prs: %v", err)
 	}
 
-	reset, err := s.resetClawForRetry("test-tenant-id", clawID, "", "retrying (attempt 2/3)")
+	reset, err := s.resetClawForRetry("test-tenant-id", clawID, "", "retrying (attempt 2/3)", "")
 	if err != nil {
 		t.Fatalf("resetClawForRetry: %v", err)
 	}
@@ -162,7 +162,7 @@ func TestClearRebriefPendingDiscardsArmedFlag(t *testing.T) {
 	const clawID = "claw-rebrief-clear"
 	s, db := newRebriefTestServer(t, clawID, "error", "")
 
-	if _, err := s.resetClawForRetry("test-tenant-id", clawID, "", "retrying (attempt 2/3)"); err != nil {
+	if _, err := s.resetClawForRetry("test-tenant-id", clawID, "", "retrying (attempt 2/3)", ""); err != nil {
 		t.Fatalf("resetClawForRetry: %v", err)
 	}
 	if pending := clawRebriefPending(t, db, clawID); pending != 1 {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -67,6 +67,9 @@ type Server struct {
 	gatewayRestartCounts map[string]int
 	// gatewayUnhealthyCounts survives WebSocket reconnects so flapping gateways still escalate.
 	gatewayUnhealthyCounts map[string]int
+	// gatewayEscalatedAt records the last gateway-health escalation dispatch per claw,
+	// preventing retries from piling up while a replacement is pending or in flight. Guarded by s.mu.
+	gatewayEscalatedAt map[string]time.Time
 	// autoResumeRestartCounts records restart counts already handled per claw. Guarded by s.mu.
 	autoResumeRestartCounts map[string]int
 	lastTokenFailureLog     time.Time
@@ -473,6 +476,7 @@ func NewServer(addr, dbPath, identityDir string, hubCfg *types.HubConfig) (*Serv
 		users:                    make(map[string]*userConn),
 		gatewayRestartCounts:     make(map[string]int),
 		gatewayUnhealthyCounts:   make(map[string]int),
+		gatewayEscalatedAt:       make(map[string]time.Time),
 		autoResumeRestartCounts:  make(map[string]int),
 		dependencyStatus:         newDependencyStatusService(hubCfg),
 		fileAckWaiters:           make(map[string]chan types.FileAck),
@@ -1913,6 +1917,7 @@ func (s *Server) handleClawDetail(w http.ResponseWriter, r *http.Request) {
 			delete(s.claws, clawID)
 		}
 		delete(s.gatewayUnhealthyCounts, clawID)
+		delete(s.gatewayEscalatedAt, clawID)
 		s.mu.Unlock()
 		go func() {
 			s.checkpointBeforeTermination(clawID, "manual-kill")
@@ -2911,7 +2916,19 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 						// that reconnects no longer reset the counter, a single declined
 						// attempt would otherwise be the last one this claw ever gets.
 						if unhealthyCount >= gatewayUnhealthyMax && unhealthyCount%gatewayUnhealthyMax == 0 {
-							shouldEscalateGateway = true
+							cooldown := 2 * time.Duration(gatewayUnhealthyMax) * bridgeHeartbeatInterval
+							if cooldown < 10*time.Minute {
+								cooldown = 10 * time.Minute
+							}
+							nowAt := now()
+							escalatedAt := s.gatewayEscalatedAt[clawID]
+							if unhealthyCount == gatewayUnhealthyMax || nowAt.Sub(escalatedAt) >= cooldown {
+								shouldEscalateGateway = true
+								if s.gatewayEscalatedAt == nil {
+									s.gatewayEscalatedAt = make(map[string]time.Time)
+								}
+								s.gatewayEscalatedAt[clawID] = nowAt
+							}
 						}
 					}
 					// Log context usage on every heartbeat when it crosses the 80% threshold,
@@ -2922,6 +2939,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 					if hb.GatewayHealthy && s.gatewayUnhealthyCounts[clawID] > 0 {
 						log.Printf("[heartbeat] %s (%s): gateway recovered after %d unhealthy checks", rp.Name, clawID[:8], s.gatewayUnhealthyCounts[clawID])
 						s.gatewayUnhealthyCounts[clawID] = 0
+						delete(s.gatewayEscalatedAt, clawID)
 					}
 					// Inject context warning once per streaming turn when usage is >=95%
 					if !activeCC.streamingStartedAt.IsZero() &&

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -120,6 +120,10 @@ type Server struct {
 	agentIdleBaselineAt      time.Time
 	agentIdleBaselineCleared bool
 
+	stageProgressBaselineMu      sync.Mutex
+	stageProgressBaselineAt      time.Time
+	stageProgressBaselineCleared bool
+
 	// agentIdleResumeBaselineAt caches the persisted idle AUTO-RESUME baseline
 	// (see agentIdleResumeBaseline in agent_idle.go). Deliberately separate
 	// state from the alert baseline above: the resume never reads the
@@ -6157,6 +6161,7 @@ func (s *Server) checkClawStatus() {
 		// of whether anyone is being notified (NEXT-713: an agent parked in a
 		// tool call that never returns is only unstuck by a prompt).
 		s.checkAgentIdleResume(now, id, cc)
+		s.checkStageProgress(now, id, cc)
 
 		// If user sent a message in the last 2 minutes, skip status broadcast
 		if now.Sub(lastUserMessageAt) < 2*time.Minute {

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -109,12 +109,13 @@ type NotifierView struct {
 // encoding/json discards as unknown keys on the way back in — resetting a
 // deliberately raised idle_after to the 5m default and persisting the loss.
 type LifecycleNotificationsView struct {
-	Enabled      bool                         `json:"enabled"`
-	Via          string                       `json:"via,omitempty"`
-	Routes       []types.LifecycleRoute       `json:"routes"`
-	PollInterval string                       `json:"pollInterval,omitempty"`
-	IdleAfter    string                       `json:"idleAfter,omitempty"`
-	Events       *types.LifecycleEventToggles `json:"events,omitempty"`
+	Enabled            bool                         `json:"enabled"`
+	Via                string                       `json:"via,omitempty"`
+	Routes             []types.LifecycleRoute       `json:"routes"`
+	PollInterval       string                       `json:"pollInterval,omitempty"`
+	IdleAfter          string                       `json:"idleAfter,omitempty"`
+	StageProgressAfter string                       `json:"stageProgressAfter,omitempty"`
+	Events             *types.LifecycleEventToggles `json:"events,omitempty"`
 }
 
 type AuthView struct {
@@ -724,11 +725,12 @@ func buildNotificationsView(cfg *types.NotificationsConfig) *NotificationsView {
 	}
 	if lc := cfg.Lifecycle; lc != nil {
 		lifecycle := &LifecycleNotificationsView{
-			Enabled:      lc.IsEnabled(),
-			Via:          lc.Via,
-			Routes:       make([]types.LifecycleRoute, len(lc.Routes)),
-			PollInterval: lc.PollInterval,
-			IdleAfter:    lc.IdleAfter,
+			Enabled:            lc.IsEnabled(),
+			Via:                lc.Via,
+			Routes:             make([]types.LifecycleRoute, len(lc.Routes)),
+			PollInterval:       lc.PollInterval,
+			IdleAfter:          lc.IdleAfter,
+			StageProgressAfter: lc.StageProgressAfter,
 		}
 		for i, route := range lc.Routes {
 			lifecycle.Routes[i] = types.LifecycleRoute{Via: route.Via, Events: append([]string(nil), route.Events...)}
@@ -895,6 +897,9 @@ func dropRejectedLifecycleDurations(current, patch *types.NotificationsConfig) {
 	}
 	if lc.IdleAfter == stored.IdleAfter && lifecycleDurationRejected(&types.LifecycleNotificationsConfig{IdleAfter: lc.IdleAfter}) {
 		lc.IdleAfter = ""
+	}
+	if lc.StageProgressAfter == stored.StageProgressAfter && lifecycleDurationRejected(&types.LifecycleNotificationsConfig{StageProgressAfter: lc.StageProgressAfter}) {
+		lc.StageProgressAfter = ""
 	}
 }
 

--- a/pkg/hub/stage_progress.go
+++ b/pkg/hub/stage_progress.go
@@ -1,0 +1,158 @@
+package hub
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"strconv"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+const stageProgressBaselineKey = "stage_progress_baseline"
+
+// lifecycleStageProgressAfter is deliberately opt-in: unlike agent_idle, an
+// empty value means no detector runs at all.
+func lifecycleStageProgressAfter(lc *types.LifecycleNotificationsConfig) (time.Duration, bool) {
+	if lc == nil || lc.StageProgressAfter == "" {
+		return 0, false
+	}
+	d, err := time.ParseDuration(lc.StageProgressAfter)
+	return d, err == nil && d >= time.Minute
+}
+
+func (s *Server) stageProgressBaseline(nowAt time.Time, enabled bool) (time.Time, bool) {
+	s.stageProgressBaselineMu.Lock()
+	defer s.stageProgressBaselineMu.Unlock()
+	if !enabled {
+		if !s.stageProgressBaselineCleared {
+			s.clearNotifierState(stageProgressBaselineKey)
+			s.stageProgressBaselineCleared = true
+			s.stageProgressBaselineAt = time.Time{}
+		}
+		return time.Time{}, true
+	}
+	s.stageProgressBaselineCleared = false
+	if !s.stageProgressBaselineAt.IsZero() {
+		return s.stageProgressBaselineAt, true
+	}
+	v, found, err := s.notifierStateInt64(stageProgressBaselineKey)
+	if err != nil {
+		log.Printf("[stage-progress] read baseline: %v", err)
+		return time.Time{}, false
+	}
+	if found && v > 0 {
+		s.stageProgressBaselineAt = time.UnixMilli(v)
+	} else {
+		s.stageProgressBaselineAt = nowAt
+		s.setNotifierStateInt64(stageProgressBaselineKey, nowAt.UnixMilli())
+	}
+	return s.stageProgressBaselineAt, true
+}
+
+type stageProgressSnapshot struct {
+	lastTurn, lastUser, subagents, streamingStarted time.Time
+	subagentsActive                                 bool
+}
+
+func stageProgressSnapshotOf(nowAt time.Time, cc *clawConn) stageProgressSnapshot {
+	cc.mu.RLock()
+	defer cc.mu.RUnlock()
+	return stageProgressSnapshot{cc.lastTurnFinishedAt, cc.lastUserMessageAt, cc.subagentsActiveAt, cc.streamingStartedAt, !cc.subagentsActiveAt.IsZero() && nowAt.Sub(cc.subagentsActiveAt) < subagentsActiveFreshFor}
+}
+
+func latestStageProgress(stageEntered int64, snap stageProgressSnapshot) time.Time {
+	latest := time.UnixMilli(stageEntered)
+	if stageEntered == 0 {
+		latest = time.Time{}
+	}
+	for _, t := range []time.Time{snap.lastTurn, snap.lastUser, snap.subagents} {
+		if t.After(latest) {
+			latest = t
+		}
+	}
+	return latest
+}
+
+// checkStageProgress detects a pipeline stage which is still current but has
+// had no turn completion, user message, subagent activity, or stage entry.
+// Heartbeat/activity rows intentionally never participate in this calculation.
+func (s *Server) checkStageProgress(nowAt time.Time, clawID string, cc *clawConn) {
+	cfg := s.notificationsConfig()
+	threshold, configured := lifecycleStageProgressAfter(func() *types.LifecycleNotificationsConfig {
+		if cfg == nil {
+			return nil
+		}
+		return cfg.Lifecycle
+	}())
+	baseline, ok := s.stageProgressBaseline(nowAt, configured && cfg.Lifecycle.IsEnabled())
+	if !configured || cfg == nil || !cfg.Lifecycle.IsEnabled() || !ok {
+		return
+	}
+	snap := stageProgressSnapshotOf(nowAt, cc)
+	if snap.subagentsActive || (!snap.streamingStarted.IsZero() && nowAt.Sub(snap.streamingStarted) < threshold) {
+		return
+	}
+	var status, runID, stage string
+	var entered sql.NullInt64
+	var latched int64
+	err := s.db.QueryRow(`SELECT status, COALESCE(task_run_id,''), COALESCE(pipeline_stage,''), stage_entered_at, stage_stalled_since FROM claws WHERE id=?`, clawID).Scan(&status, &runID, &stage, &entered, &latched)
+	if err != nil {
+		if err != sql.ErrNoRows {
+			log.Printf("[stage-progress] read claw %s: %v", shortID(clawID), err)
+		}
+		return
+	}
+	if stage == "" || !agentIdleEligible(status, runID, s.agentIdleRunPhase(runID), s.agentIdleHasClawPRs(clawID), true) {
+		return
+	}
+	progress := latestStageProgress(entered.Int64, snap)
+	if progress.IsZero() {
+		return
+	}
+	// Any meaningful progress after the latched episode re-arms it.
+	if latched != 0 && progress.UnixMilli() > latched {
+		if _, err := s.db.Exec(`UPDATE claws SET stage_stalled_since=0 WHERE id=?`, clawID); err != nil {
+			log.Printf("[stage-progress] clear latch for %s: %v", shortID(clawID), err)
+		}
+		latched = 0
+	}
+	if nowAt.Sub(progress) < threshold || latched != 0 {
+		return
+	}
+	if progress.Before(baseline) {
+		s.parkStageProgress(nowAt, clawID, runID, progress.UnixMilli())
+		return
+	}
+	detail := map[string]any{"stage": stage, "lastProgressMinutes": int(nowAt.Sub(progress).Minutes())}
+	if entered.Valid && entered.Int64 > 0 {
+		detail["stageAgeMinutes"] = int(nowAt.Sub(time.UnixMilli(entered.Int64)).Minutes())
+	}
+	if runID != "" {
+		if err := s.recordTaskRunEventForClaw(clawID, TaskRunEvent{EventKey: taskRunEventStageStalled + ":" + strconv.FormatInt(progress.UnixMilli(), 10), Source: taskRunSourceHub, EventType: taskRunEventStageStalled, ActorType: taskRunActorSystem, InteractionRole: taskRunInteractionNeutral, Detail: detail, OccurredAt: nowAt}); err != nil {
+			log.Printf("[stage-progress] record %s: %v", shortID(clawID), err)
+			return
+		}
+	}
+	if _, err := s.db.Exec(`UPDATE claws SET stage_stalled_since=? WHERE id=?`, progress.UnixMilli(), clawID); err != nil {
+		log.Printf("[stage-progress] latch %s: %v", shortID(clawID), err)
+	}
+}
+
+func (s *Server) parkStageProgress(nowAt time.Time, clawID, runID string, key int64) {
+	if runID == "" {
+		if _, err := s.db.Exec(`INSERT INTO slack_notification_deliveries(event_id,run_id,delivered_at,message_ts,status) VALUES(?,?,?,?,?) ON CONFLICT(event_id) DO NOTHING`, lifecycleClawStageStalledKey(clawID, key), lifecycleClawRunKey(clawID), epochMillis(nowAt), "", notificationDeliveryStatusSkipped); err != nil {
+			return
+		}
+	}
+	_, _ = s.db.Exec(`UPDATE claws SET stage_stalled_since=? WHERE id=?`, key, clawID)
+}
+
+func stageProgressDurationLabel(v map[string]any, key string) string {
+	n := intFromDetail(v, key)
+	if n <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("%d minute%s", n, pluralS(n))
+}

--- a/pkg/hub/stage_progress_test.go
+++ b/pkg/hub/stage_progress_test.go
@@ -1,0 +1,160 @@
+package hub
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func clawStageStalledSince(t *testing.T, db *sql.DB, clawID string) int64 {
+	t.Helper()
+	var v int64
+	if err := db.QueryRow(`SELECT stage_stalled_since FROM claws WHERE id=?`, clawID).Scan(&v); err != nil {
+		t.Fatalf("read stage_stalled_since for %s: %v", clawID, err)
+	}
+	return v
+}
+
+func backdateStageProgressBaseline(t *testing.T, s *Server) {
+	t.Helper()
+	s.setNotifierStateInt64(stageProgressBaselineKey, time.Now().Add(-24*time.Hour).UnixMilli())
+	s.stageProgressBaselineMu.Lock()
+	s.stageProgressBaselineAt = time.Time{}
+	s.stageProgressBaselineMu.Unlock()
+}
+
+// Disabled by default: with no stage_progress_after configured, a
+// long-stalled ad-hoc claw must not latch or notify.
+func TestStageProgressDisabledByDefaultDoesNothing(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	s, db := newSlackNotifierTestServer(t, fake.server.URL, nil)
+	const clawID = "stage-disabled"
+	insertSlackTestClaw(t, db, clawID, "connected", 0, "", oldEnough)
+	setClawPipelineStage(t, db, clawID, "implement")
+
+	cc := idleTestConn(clawID, 2*time.Hour)
+	s.checkStageProgress(time.Now(), clawID, cc)
+	if got := clawStageStalledSince(t, db, clawID); got != 0 {
+		t.Fatalf("disabled stage-progress alert latched: %d", got)
+	}
+}
+
+// Enabling the alert for the first time must park every already-stale stage
+// instead of flooding on the first check.
+func TestStageProgressFirstEnableParksPreexistingStretches(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	s, db := newSlackNotifierTestServer(t, fake.server.URL, func(lc *types.LifecycleNotificationsConfig) {
+		lc.StageProgressAfter = "5m"
+	})
+	const clawID = "stage-preexisting"
+	insertSlackTestClaw(t, db, clawID, "connected", 0, "", oldEnough)
+	setClawPipelineStage(t, db, clawID, "implement")
+	seedIdleTestBaseline(t, s)
+	setSlackWatermark(t, s, 0)
+	d := testLifecycleDelivery(t, s)
+
+	// Stage was already stalled for an hour before the feature was ever
+	// enabled: the baseline parks it (latching it silently), so it must not
+	// notify.
+	cc := idleTestConn(clawID, time.Hour)
+	s.checkStageProgress(time.Now(), clawID, cc)
+	if got := clawStageStalledSince(t, db, clawID); got == 0 {
+		t.Fatal("pre-existing stale stage was not parked")
+	}
+	s.lifecycleClawPass(d)
+	if fake.count() != 0 {
+		t.Fatalf("pre-existing stale stage notified on first enable: %d messages", fake.count())
+	}
+}
+
+// A stall that begins after the baseline notifies exactly once per episode,
+// and heartbeat-only activity (no clock update) does not re-arm it.
+func TestStageProgressNotifiesOncePerStallEpisode(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	s, db := newSlackNotifierTestServer(t, fake.server.URL, func(lc *types.LifecycleNotificationsConfig) {
+		lc.StageProgressAfter = "5m"
+	})
+	const clawID = "stage-stalls"
+	insertSlackTestClaw(t, db, clawID, "connected", 0, "", oldEnough)
+	setClawPipelineStage(t, db, clawID, "implement")
+	seedIdleTestBaseline(t, s)
+	backdateStageProgressBaseline(t, s)
+	setSlackWatermark(t, s, 0)
+	d := testLifecycleDelivery(t, s)
+
+	cc := idleTestConn(clawID, 10*time.Minute)
+	now := time.Now()
+	s.checkStageProgress(now, clawID, cc)
+	first := clawStageStalledSince(t, db, clawID)
+	if first == 0 {
+		t.Fatal("stalled stage past threshold did not latch")
+	}
+	s.lifecycleClawPass(d)
+	if fake.count() != 1 {
+		t.Fatalf("sent %d messages, want 1", fake.count())
+	}
+	if !strings.Contains(fake.request(0).Fallback, "stalled") {
+		t.Fatalf("unexpected message: %q", fake.request(0).Fallback)
+	}
+
+	// Re-checking the same stretch (no new progress) must not re-latch or
+	// re-notify.
+	s.checkStageProgress(now.Add(time.Minute), clawID, cc)
+	if got := clawStageStalledSince(t, db, clawID); got != first {
+		t.Fatalf("re-check re-latched: %d -> %d", first, got)
+	}
+	s.lifecycleClawPass(d)
+	if fake.count() != 1 {
+		t.Fatalf("same stall episode re-notified: %d messages", fake.count())
+	}
+
+	// Meaningful progress (a finished turn) re-arms the latch, and once the
+	// new stretch itself passes the threshold it notifies again.
+	cc.mu.Lock()
+	cc.lastTurnFinishedAt = now.Add(-6 * time.Minute)
+	cc.mu.Unlock()
+	s.checkStageProgress(now, clawID, cc)
+	if got := clawStageStalledSince(t, db, clawID); got == 0 || got == first {
+		t.Fatalf("second stretch latch = %d (first %d), want a fresh latch", got, first)
+	}
+	s.lifecycleClawPass(d)
+	if fake.count() != 2 {
+		t.Fatalf("second stall episode sent %d total messages, want 2", fake.count())
+	}
+}
+
+// Active subagent work suppresses the alert even past the threshold.
+func TestStageProgressSuppressedWhileSubagentsActive(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	s, db := newSlackNotifierTestServer(t, fake.server.URL, func(lc *types.LifecycleNotificationsConfig) {
+		lc.StageProgressAfter = "5m"
+	})
+	const clawID = "stage-subagents"
+	insertSlackTestClaw(t, db, clawID, "connected", 0, "", oldEnough)
+	setClawPipelineStage(t, db, clawID, "implement")
+	seedIdleTestBaseline(t, s)
+	backdateStageProgressBaseline(t, s)
+
+	cc := idleTestConn(clawID, 10*time.Minute)
+	cc.mu.Lock()
+	cc.subagentsActiveAt = time.Now()
+	cc.mu.Unlock()
+	s.checkStageProgress(time.Now(), clawID, cc)
+	if got := clawStageStalledSince(t, db, clawID); got != 0 {
+		t.Fatalf("subagent-active stage latched: %d", got)
+	}
+}
+
+// The stage_progress_after floor rejects sub-minute durations, matching
+// idle_after.
+func TestLifecycleStageProgressAfterFloor(t *testing.T) {
+	cfg := &types.NotificationsConfig{Lifecycle: &types.LifecycleNotificationsConfig{
+		Via: testNotifierName, StageProgressAfter: "30s",
+	}}
+	if err := types.ValidateNotificationsConfig(cfg); err == nil {
+		t.Fatal("expected sub-minute stage_progress_after to be rejected")
+	}
+}

--- a/pkg/hub/task_run_analytics.go
+++ b/pkg/hub/task_run_analytics.go
@@ -79,6 +79,7 @@ const (
 	taskRunEventManualStopBeforeDelivery = "manual_stop_before_delivery"
 	taskRunEventAgentStopped             = "agent_stopped"
 	taskRunEventAgentIdle                = "agent_idle"
+	taskRunEventStageStalled             = "stage_stalled"
 	taskRunEventCISucceeded              = "ci_succeeded"
 	taskRunEventCIFailed                 = "ci_failed"
 	taskRunEventManualResume             = "human_manual_stop_or_resume"

--- a/pkg/hub/testhelpers.go
+++ b/pkg/hub/testhelpers.go
@@ -56,6 +56,8 @@ func NewTestServerWithConfig(t interface {
 		artifacts:                artifacts,
 		claws:                    make(map[string]*clawConn),
 		users:                    make(map[string]*userConn),
+		gatewayUnhealthyCounts:   make(map[string]int),
+		gatewayEscalatedAt:       make(map[string]time.Time),
 		dependencyStatus:         newDependencyStatusService(cfg),
 		webhookDedup:             make(map[string]time.Time),
 		githubBaseURL:            githubBaseURL,

--- a/pkg/hub/watchdog_enforcement_test.go
+++ b/pkg/hub/watchdog_enforcement_test.go
@@ -112,6 +112,64 @@ func TestWatchdogUnhealthyHeartbeatsScheduleClawRetry(t *testing.T) {
 	}, "replacement attempt scheduled for unhealthy claw")
 }
 
+func TestWatchdogUnhealthyHeartbeatsCooldownPreventsOverlappingRetries(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	const clawID = "watchdog-unhealthy-cooldown"
+	conn := watchdogClaw(t, s, clawID)
+	if _, err := db.Exec(`UPDATE claws SET status='error', bootstrap_ok=1 WHERE id=?`, clawID); err != nil {
+		t.Fatal(err)
+	}
+
+	writeUnhealthy := func() {
+		t.Helper()
+		if err := wsjson.Write(context.Background(), conn, types.WSMessage{Type: "heartbeat", Payload: map[string]any{"gateway_healthy": false}}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	escalatedAt := func() time.Time {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+		return s.gatewayEscalatedAt[clawID]
+	}
+
+	// The first crossing must dispatch regardless of an empty cooldown record.
+	for i := 0; i < defaultGatewayUnhealthyMax; i++ {
+		writeUnhealthy()
+	}
+	eventuallyWatchdog(t, func() bool {
+		return s.gatewayUnhealthyCount(clawID) == defaultGatewayUnhealthyMax && !escalatedAt().IsZero()
+	}, "first unhealthy escalation dispatch")
+	firstEscalatedAt := escalatedAt()
+
+	// Match the interval after retry preparation: its successor is pending while
+	// the original claw remains unhealthy, but is no longer eligible to stop.
+	for i := 0; i < defaultGatewayUnhealthyMax; i++ {
+		writeUnhealthy()
+	}
+	eventuallyWatchdog(t, func() bool {
+		return s.gatewayUnhealthyCount(clawID) == 2*defaultGatewayUnhealthyMax
+	}, "second unhealthy threshold")
+	if got := escalatedAt(); !got.Equal(firstEscalatedAt) {
+		t.Fatalf("second threshold dispatched during cooldown: first=%v got=%v", firstEscalatedAt, got)
+	}
+
+	// Once the replacement has had time to settle, a continued unhealthy episode
+	// may be dispatched again.
+	cooldown := 2 * time.Duration(defaultGatewayUnhealthyMax) * bridgeHeartbeatInterval
+	if cooldown < 10*time.Minute {
+		cooldown = 10 * time.Minute
+	}
+	s.mu.Lock()
+	s.gatewayEscalatedAt[clawID] = now().Add(-cooldown)
+	s.mu.Unlock()
+	for i := 0; i < defaultGatewayUnhealthyMax; i++ {
+		writeUnhealthy()
+	}
+	eventuallyWatchdog(t, func() bool {
+		return s.gatewayUnhealthyCount(clawID) == 3*defaultGatewayUnhealthyMax && escalatedAt().After(firstEscalatedAt)
+	}, "post-cooldown unhealthy escalation dispatch")
+}
+
 func TestWatchdogHealthyHeartbeatResetsUnhealthyCounter(t *testing.T) {
 	s, _ := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
 	const clawID = "watchdog-heartbeat-reset"
@@ -128,8 +186,15 @@ func TestWatchdogHealthyHeartbeatResetsUnhealthyCounter(t *testing.T) {
 	eventuallyWatchdog(t, func() bool {
 		return s.gatewayUnhealthyCount(clawID) == defaultGatewayUnhealthyMax-1
 	}, "unhealthy heartbeat count")
+	s.mu.Lock()
+	s.gatewayEscalatedAt[clawID] = now()
+	s.mu.Unlock()
 	writeHeartbeat(true)
-	eventuallyWatchdog(t, func() bool { return s.gatewayUnhealthyCount(clawID) == 0 }, "healthy reset")
+	eventuallyWatchdog(t, func() bool {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+		return s.gatewayUnhealthyCounts[clawID] == 0 && s.gatewayEscalatedAt[clawID].IsZero()
+	}, "healthy reset")
 	for i := 0; i < defaultGatewayUnhealthyMax-1; i++ {
 		writeHeartbeat(false)
 	}

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -583,6 +583,7 @@ var LifecycleEventTypes = []string{
 	"pr_opened",
 	"agent_stopped",
 	"agent_idle",
+	"stage_stalled",
 	"done_without_pr",
 }
 
@@ -624,6 +625,9 @@ type LifecycleNotificationsConfig struct {
 	// fires. Default "5m", minimum "1m". Detection rides the 2-minute status
 	// watchdog tick, so the alert lands between IdleAfter and IdleAfter+2m.
 	IdleAfter string `yaml:"idle_after,omitempty" json:"idleAfter,omitempty"`
+	// StageProgressAfter alerts when a pipeline stage receives no meaningful
+	// progress for this duration. Empty disables this opt-in alert.
+	StageProgressAfter string `yaml:"stage_progress_after,omitempty" json:"stageProgressAfter,omitempty"`
 	// Events toggles individual event categories. All default true when absent.
 	Events *LifecycleEventToggles `yaml:"events,omitempty" json:"events,omitempty"`
 }
@@ -656,6 +660,7 @@ type LifecycleEventToggles struct {
 	PROpened     *bool `yaml:"pr_opened,omitempty" json:"prOpened,omitempty"`
 	Failures     *bool `yaml:"failures,omitempty" json:"failures,omitempty"`
 	AgentIdle    *bool `yaml:"agent_idle,omitempty" json:"agentIdle,omitempty"`
+	StageStalled *bool `yaml:"stage_stalled,omitempty" json:"stageStalled,omitempty"`
 }
 
 // LivenessConfig controls boot reconciliation and the periodic safety-net reaper.

--- a/pkg/types/validation.go
+++ b/pkg/types/validation.go
@@ -821,6 +821,15 @@ func ValidateNotificationsConfig(cfg *NotificationsConfig) error {
 			return fmt.Errorf("notifications.lifecycle: idle_after must be at least 1m, got %q", lc.IdleAfter)
 		}
 	}
+	if lc.StageProgressAfter != "" {
+		d, err := time.ParseDuration(lc.StageProgressAfter)
+		if err != nil {
+			return fmt.Errorf("notifications.lifecycle: invalid stage_progress_after %q: %w", lc.StageProgressAfter, err)
+		}
+		if d < time.Minute {
+			return fmt.Errorf("notifications.lifecycle: stage_progress_after must be at least 1m, got %q", lc.StageProgressAfter)
+		}
+	}
 	if !lc.IsEnabled() {
 		return nil
 	}

--- a/pkg/types/validation_notifications_test.go
+++ b/pkg/types/validation_notifications_test.go
@@ -308,7 +308,7 @@ func TestLifecycleEventTypes(t *testing.T) {
 	// exist only as task_run_events.failure_type. Route matching compares
 	// against event_type, so a checkbox for one of them built a route that
 	// could never fire while the test-send endpoint reported success.
-	want := []string{"agent_started", "pr_opened", "agent_stopped", "agent_idle", "done_without_pr"}
+	want := []string{"agent_started", "pr_opened", "agent_stopped", "agent_idle", "stage_stalled", "done_without_pr"}
 	if !reflect.DeepEqual(LifecycleEventTypes, want) {
 		t.Fatalf("LifecycleEventTypes = %v, want %v", LifecycleEventTypes, want)
 	}

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -195,6 +195,7 @@ interface LifecycleEventToggles {
   prOpened?: boolean
   failures?: boolean
   agentIdle?: boolean
+  stageStalled?: boolean
 }
 
 interface NotificationsView {
@@ -207,6 +208,7 @@ interface NotificationsView {
     routes?: LifecycleRouteView[]
     pollInterval?: string
     idleAfter?: string
+    stageProgressAfter?: string
     events?: LifecycleEventToggles
   }
 }
@@ -4539,6 +4541,7 @@ const LIFECYCLE_EVENT_LABELS: Record<string, string> = {
   agent_started: "Agent started",
   pr_opened: "PR opened",
   agent_idle: "Agent stalled",
+  stage_stalled: "Pipeline stage stalled",
   agent_stopped: "Agent died or failed",
   done_without_pr: "Agent finished without a PR",
 }
@@ -4551,6 +4554,7 @@ const LIFECYCLE_EVENT_CATEGORY: Record<string, LifecycleCategory> = {
   agent_started: "agentStarted",
   pr_opened: "prOpened",
   agent_idle: "agentIdle",
+  stage_stalled: "stageStalled",
   agent_stopped: "failures",
   done_without_pr: "failures",
 }
@@ -4560,6 +4564,7 @@ const LIFECYCLE_CATEGORIES: { id: LifecycleCategory; label: string; description:
   { id: "prOpened", label: "PR opened", description: "An agent opened a pull request" },
   { id: "failures", label: "Failures", description: "Crashes, timeouts, lost machines, finished without a PR" },
   { id: "agentIdle", label: "Agent stalled", description: "An agent stopped making progress" },
+  { id: "stageStalled", label: "Pipeline stage stalled", description: "A pipeline stage stopped making meaningful progress" },
 ]
 
 // Fallback only — the canonical list comes from settings.lifecycleEventTypes.
@@ -4639,6 +4644,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     prOpened: lifecycle?.events?.prOpened ?? true,
     failures: lifecycle?.events?.failures ?? true,
     agentIdle: lifecycle?.events?.agentIdle ?? true,
+    stageStalled: lifecycle?.events?.stageStalled ?? true,
   }
   // A legacy single-channel `via` reads as one route over every event; saving
   // any change migrates it to routes. `via` is trimmed exactly where the hub
@@ -4859,6 +4865,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     }
     if (lifecycle?.pollInterval) outLifecycle.pollInterval = lifecycle.pollInterval
     if (lifecycle?.idleAfter) outLifecycle.idleAfter = lifecycle.idleAfter
+    if (lifecycle?.stageProgressAfter) outLifecycle.stageProgressAfter = lifecycle.stageProgressAfter
     return {
       patch: { notifications: { notifiers: outNotifiers, lifecycle: outLifecycle } },
       // The never-configured hub is clamped too, and for the same reason: the


### PR DESCRIPTION
## Motivation

2026-08 wall-clock audit: the top 10 stage instances held 83% of 458h of open stage time, dominated by silent stalls that heartbeat-like telemetry hides from any activity-keyed watchdog. Contributing patterns found in the audit:

- pr-watcher watermark loops holding stages open 35-63h
- replacement-claw storms retrying against an empty checkpoint (`checkpoint=""`)
- an escalation race that fired a second replacement while one was already in flight
- a 1,376-line GitHub 429 night with no shared backpressure across tier-2 calls
- stages with no enforcement mechanism at all when the agent goes quiet but keeps emitting "Waiting on model response" heartbeats

This PR is five independent, atomic mitigations.

## Commits

1. **`fix(hub): harden PR-comment watermark writes`** — hardens the pr-watcher watermark persistence path so a partial/failed write can't loop the same PR comments for 35-63h.
2. **`fix(hub): claw-retry falls back to older checkpoints, skips metadata-only ones`** — claw-retry/restore now walks back to an older checkpoint instead of retrying against an empty or metadata-only one.
3. **`fix(hub): do not re-escalate a claw with a replacement already in flight`** — closes a race where the escalation path could fire a second replacement for a claw that already had one being created.
4. **`fix(hub): route tier-2 GitHub calls through shared rate-limit backoff`** — tier-2 GitHub API calls now share the same backoff/rate-limit state as tier-1, preventing an uncoordinated 429 storm.
5. **`feat(hub): opt-in stage-progress stall alert (alert-only)`** — new opt-in, alert-only `stage_stalled` lifecycle notification: fires when a pipeline stage has seen no meaningful progress (turn completion, user message, subagent activity, or stage entry) for a configurable duration. Modeled end-to-end on the existing `agent_idle` feature (latch/rearm, baseline parking, Slack routing for both run-backed and ad-hoc claws). Heartbeat-only activity never counts as progress. No enforcement — alert only.

## Validation

- `go build ./...`
- Targeted `go test` on each touched package per commit, plus `ELASTICCLAW_HUB_CONFIG= go test ./pkg/hub/...` and `./pkg/types/...` for the stage-stall commit
- New/modified stage-progress tests re-run with `-race`
- `stage_stalled` confirmed disabled by default (empty config = no behavior change beyond the additive `claws.stage_entered_at` / `stage_stalled_since` columns), confirmed to fire exactly once per stall episode, confirmed baseline parking suppresses a first-enable flood, confirmed heartbeat-only activity does not count as progress
- Note: `TestDoneSignalRejectedWhenPRPersistenceFails`, `TestHandleClawDoneSignal_IssueLessWorkflowWatchesPR`, and `TestCompleteIssueLessDoneClawKeepsRunningOnStoreFailure` fail locally against real GitHub API calls even with `ELASTICCLAW_HUB_CONFIG=` and are pre-existing on `origin/main`/this branch's prior HEAD — unrelated to this PR

## Rollback

Revert this PR. The `stage_stalled` schema additions (`claws.stage_entered_at`, `claws.stage_stalled_since`, and the `task_run_events` CHECK-enum rebuild) are additive-only and safe to leave in place even on rollback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
