### PR TITLE
feat(hub): scheduled Slack notifications with pending-PRs report

### DIFF
--- a/pkg/hub/doctor.go
+++ b/pkg/hub/doctor.go
@@ -1342,15 +1342,38 @@ func (s *Server) checkNotifications(cfg *types.HubConfig) []DoctorCheck {
 		}
 	}
 
-	// Scheduled reports. Only enabled schedules are checked: a disabled one
-	// delivers nothing, and an operator who pauses a schedule before deleting
-	// the notifier (or before upgrading to a build that carries the report)
-	// must not be nagged about a slot that never fires.
+	// Scheduled reports. A disabled schedule delivers nothing, so its report
+	// and destination checks are skipped: an operator who pauses a schedule
+	// before deleting the notifier (or before upgrading to a build that
+	// carries the report) must not be nagged about a slot that never fires.
+	// But the tick's whole-block gate (ValidateScheduledNotificationsConfig)
+	// judges EVERY entry regardless of Enabled, plus the cross-entry
+	// duplicate-id rule ValidateScheduledNotification excludes — so entry
+	// validity and id uniqueness are checked on disabled entries too (the very
+	// entry pausing every schedule must get its own critical row), and no
+	// entry may show a green row while the block is rejected and the tick
+	// delivers nothing.
+	scheduledBlockErr := types.ValidateScheduledNotificationsConfig(nCfg)
+	seenScheduledIDs := make(map[string]int, len(nCfg.Scheduled))
 	for i, scheduled := range nCfg.Scheduled {
+		label := fmt.Sprintf("Scheduled report %d (%q)", i+1, scheduled.ID)
+		duplicateOf, duplicate := seenScheduledIDs[scheduled.ID]
+		if !duplicate {
+			seenScheduledIDs[scheduled.ID] = i + 1
+		}
 		if scheduled.Enabled != nil && !*scheduled.Enabled {
+			if err := types.ValidateScheduledNotification(nCfg, i); err != nil {
+				checks = append(checks, DoctorCheck{
+					Category: "notifications", Severity: "critical", OK: false,
+					Title:       label + " is invalid",
+					Description: "The scheduled notifier pauses every schedule while any entry fails validation, even a disabled one; fix or remove this entry.",
+					Error:       err.Error(),
+				})
+			} else if duplicate {
+				checks = append(checks, scheduledDuplicateIDCheck(label, duplicateOf))
+			}
 			continue
 		}
-		label := fmt.Sprintf("Scheduled report %d (%q)", i+1, scheduled.ID)
 		if !ScheduledReportSupported(scheduled.Report) {
 			checks = append(checks, DoctorCheck{
 				Category: "notifications", Severity: "critical", OK: false,
@@ -1413,6 +1436,21 @@ func (s *Server) checkNotifications(cfg *types.HubConfig) []DoctorCheck {
 			})
 			continue
 		}
+		if duplicate {
+			checks = append(checks, scheduledDuplicateIDCheck(label, duplicateOf))
+			continue
+		}
+		if scheduledBlockErr != nil {
+			// This entry is healthy, but the tick's gate rejects the whole
+			// block: a green "is configured" row would contradict the
+			// section-level critical row while nothing is delivered.
+			checks = append(checks, DoctorCheck{
+				Category: "notifications", Severity: "warning", OK: false,
+				Title:       label + " is paused while the scheduled block is invalid",
+				Description: "This entry is configured correctly, but the scheduled notifier pauses every schedule until the invalid entry flagged above is fixed.",
+			})
+			continue
+		}
 		checks = append(checks, DoctorCheck{
 			Category: "notifications", Severity: "info", OK: true,
 			Title: label + " is configured",
@@ -1421,6 +1459,18 @@ func (s *Server) checkNotifications(cfg *types.HubConfig) []DoctorCheck {
 		})
 	}
 	return checks
+}
+
+// scheduledDuplicateIDCheck is the per-entry row for a schedule reusing an
+// earlier entry's id — the one rule ValidateScheduledNotification excludes
+// (it needs the whole list), yet one the tick's whole-block gate enforces.
+func scheduledDuplicateIDCheck(label string, duplicateOf int) DoctorCheck {
+	return DoctorCheck{
+		Category: "notifications", Severity: "critical", OK: false,
+		Title: label + " duplicates another schedule's id",
+		Description: fmt.Sprintf("Schedule ids key delivery state, and the scheduled notifier pauses every schedule while two entries share one (here with scheduled report %d). Give this entry a unique id.",
+			duplicateOf),
+	}
 }
 
 // scheduledSlotDescription renders a schedule's slot for doctor output.

--- a/pkg/hub/doctor.go
+++ b/pkg/hub/doctor.go
@@ -1324,7 +1324,60 @@ func (s *Server) checkNotifications(cfg *types.HubConfig) []DoctorCheck {
 			})
 		}
 	}
+
+	// Scheduled reports. Only enabled schedules are checked: a disabled one
+	// delivers nothing, and an operator who pauses a schedule before deleting
+	// the notifier (or before upgrading to a build that carries the report)
+	// must not be nagged about a slot that never fires.
+	for i, scheduled := range nCfg.Scheduled {
+		if scheduled.Enabled != nil && !*scheduled.Enabled {
+			continue
+		}
+		label := fmt.Sprintf("Scheduled report %d (%q)", i+1, scheduled.ID)
+		if !ScheduledReportSupported(scheduled.Report) {
+			checks = append(checks, DoctorCheck{
+				Category: "notifications", Severity: "critical", OK: false,
+				Title: label + " names an unknown report",
+				Description: fmt.Sprintf("This hub has no report named %q, so nothing is ever sent for this schedule. Supported reports: %s.",
+					scheduled.Report, scheduledReportNamesText()),
+			})
+			continue
+		}
+		unknownVia := false
+		for _, via := range scheduled.Via {
+			if _, ok := nCfg.Notifiers[strings.TrimSpace(via)]; !ok {
+				checks = append(checks, DoctorCheck{
+					Category: "notifications", Severity: "critical", OK: false,
+					Title:       label + " sends to an unknown notifier",
+					Description: fmt.Sprintf("Destination %q is not a configured notifier, so this schedule delivers nothing there.", via),
+				})
+				unknownVia = true
+			}
+		}
+		if unknownVia {
+			continue
+		}
+		checks = append(checks, DoctorCheck{
+			Category: "notifications", Severity: "info", OK: true,
+			Title: label + " is configured",
+			Description: fmt.Sprintf("Report %s is sent to %s at %s.",
+				scheduled.Report, strings.Join(scheduled.Via, ", "), scheduledSlotDescription(scheduled)),
+		})
+	}
 	return checks
+}
+
+// scheduledSlotDescription renders a schedule's slot for doctor output.
+func scheduledSlotDescription(scheduled types.ScheduledNotificationConfig) string {
+	timezone := scheduled.Timezone
+	if timezone == "" {
+		timezone = "UTC"
+	}
+	days := "every day"
+	if len(scheduled.Weekdays) > 0 {
+		days = strings.Join(scheduled.Weekdays, ", ")
+	}
+	return fmt.Sprintf("%s %s, %s", scheduled.At, timezone, days)
 }
 
 // checkNotifyActions validates every pipeline notify action the way the

--- a/pkg/hub/doctor.go
+++ b/pkg/hub/doctor.go
@@ -1223,12 +1223,29 @@ func (s *Server) checkNotifications(cfg *types.HubConfig) []DoctorCheck {
 		return nil
 	}
 	var checks []DoctorCheck
-	if err := types.ValidateNotificationsConfig(nCfg); err != nil {
+	// The two per-feature validators, not the composed one: each minute tick
+	// gates on the validity of its own feature's config only, so a defect
+	// confined to the lifecycle block pauses lifecycle alerts while scheduled
+	// reports keep delivering, and vice versa. One composed "no notifications
+	// will be delivered" row would be wrong in both directions; these two rows
+	// each describe exactly what its tick's gate actually pauses, mirroring
+	// the two tick log lines.
+	if err := types.ValidateLifecycleNotificationsConfig(nCfg); err != nil {
 		checks = append(checks, DoctorCheck{
 			Category:    "notifications",
 			Severity:    "critical",
-			Title:       "Notifications config invalid",
-			Description: "No notifications will be delivered until this is fixed in hub.yaml.",
+			Title:       "Lifecycle notifications config invalid",
+			Description: "No lifecycle notifications will be delivered until this is fixed in hub.yaml.",
+			OK:          false,
+			Error:       err.Error(),
+		})
+	}
+	if err := types.ValidateScheduledNotificationsConfig(nCfg); err != nil {
+		checks = append(checks, DoctorCheck{
+			Category:    "notifications",
+			Severity:    "critical",
+			Title:       "Scheduled reports config invalid",
+			Description: "No scheduled reports will be delivered until this is fixed in hub.yaml.",
 			OK:          false,
 			Error:       err.Error(),
 		})
@@ -1380,6 +1397,20 @@ func (s *Server) checkNotifications(cfg *types.HubConfig) []DoctorCheck {
 			}
 		}
 		if badVia {
+			continue
+		}
+		// The slot fields (at/timezone/weekdays) the destination checks above
+		// never touch: an invalid one fails the scheduled tick's validity gate
+		// — pausing EVERY schedule, not just this one — so the very entry
+		// causing the pause must not get the green row below. Runs after the
+		// via checks so their more specific rows keep precedence.
+		if err := types.ValidateScheduledNotification(nCfg, i); err != nil {
+			checks = append(checks, DoctorCheck{
+				Category: "notifications", Severity: "critical", OK: false,
+				Title:       label + " is invalid",
+				Description: "The scheduled notifier pauses every schedule while any entry fails validation; fix or remove this one.",
+				Error:       err.Error(),
+			})
 			continue
 		}
 		checks = append(checks, DoctorCheck{

--- a/pkg/hub/doctor.go
+++ b/pkg/hub/doctor.go
@@ -1343,18 +1343,43 @@ func (s *Server) checkNotifications(cfg *types.HubConfig) []DoctorCheck {
 			})
 			continue
 		}
-		unknownVia := false
+		// Each destination gets the same per-destination checks a lifecycle
+		// route gets (channel presence, notifier constructibility): a runtime
+		// send through a channel-less notifier fails permanently and silently
+		// burns the slot, so doctor must not report the schedule green.
+		badVia := false
 		for _, via := range scheduled.Via {
-			if _, ok := nCfg.Notifiers[strings.TrimSpace(via)]; !ok {
+			nc, ok := nCfg.Notifiers[strings.TrimSpace(via)]
+			if !ok {
 				checks = append(checks, DoctorCheck{
 					Category: "notifications", Severity: "critical", OK: false,
 					Title:       label + " sends to an unknown notifier",
 					Description: fmt.Sprintf("Destination %q is not a configured notifier, so this schedule delivers nothing there.", via),
 				})
-				unknownVia = true
+				badVia = true
+				continue
+			}
+			channel, _ := s.notifierSettings(nc)["channel"].(string)
+			if strings.TrimSpace(channel) == "" {
+				checks = append(checks, DoctorCheck{
+					Category: "notifications", Severity: "critical", OK: false,
+					Title:       fmt.Sprintf("%s destination %q has no channel", label, via),
+					Description: fmt.Sprintf("Notifier %q needs a channel for this schedule's reports to be delivered.", via),
+				})
+				badVia = true
+				continue
+			}
+			if _, err := notify.New(nc.Type, s.notifierSettings(nc), secrets); err != nil {
+				checks = append(checks, DoctorCheck{
+					Category: "notifications", Severity: "critical", OK: false,
+					Title:       fmt.Sprintf("%s destination %q is not constructible", label, via),
+					Description: fmt.Sprintf("Reports for this schedule through notifier %q will not be delivered.", via),
+					Error:       err.Error(),
+				})
+				badVia = true
 			}
 		}
-		if unknownVia {
+		if badVia {
 			continue
 		}
 		checks = append(checks, DoctorCheck{

--- a/pkg/hub/doctor_test.go
+++ b/pkg/hub/doctor_test.go
@@ -212,6 +212,71 @@ func TestCheckNotificationsFlagsInvalidScheduledSlotFields(t *testing.T) {
 	}
 }
 
+// The tick's whole-block gate validates every entry regardless of Enabled, so
+// a defective DISABLED schedule pauses every other schedule: the disabled
+// offender must get its own critical row (not be skipped as paused), and the
+// healthy victim must not get a green "is configured" row while nothing is
+// delivered.
+func TestCheckNotificationsFlagsDisabledOffenderAndDowngradesVictims(t *testing.T) {
+	s := &Server{}
+	disabled := false
+	cfg := &types.HubConfig{Secrets: map[string]string{"token": "xoxb-test"}, Notifications: &types.NotificationsConfig{
+		Notifiers: map[string]types.NotifierConfig{
+			"healthy": {Type: "slack", Settings: map[string]any{"token_secret": "token", "channel": "C0123ABCD"}},
+		},
+		Scheduled: []types.ScheduledNotificationConfig{
+			{ID: "victim", Report: "pending_prs", Via: []string{"healthy"}, At: "09:00"},
+			{ID: "offender", Report: "pending_prs", Via: []string{"healthy"}, At: "09:00", Weekdays: []string{"monday"}, Enabled: &disabled},
+		},
+	}}
+	var offenderRow, victimPausedRow bool
+	for _, check := range s.checkNotifications(cfg) {
+		if strings.Contains(check.Title, "Scheduled report") && check.OK {
+			t.Fatalf("green per-schedule row while the whole block is paused: %#v", check)
+		}
+		if strings.Contains(check.Title, `Scheduled report 2 ("offender") is invalid`) && strings.Contains(check.Error, `weekday "monday" is invalid`) {
+			offenderRow = true
+		}
+		if strings.Contains(check.Title, `Scheduled report 1 ("victim") is paused while the scheduled block is invalid`) {
+			victimPausedRow = true
+		}
+	}
+	if !offenderRow {
+		t.Fatal("the disabled entry causing the pause got no critical row of its own")
+	}
+	if !victimPausedRow {
+		t.Fatal("the healthy entry got no row explaining it is paused by the invalid block")
+	}
+}
+
+// Two schedules sharing an id fail only the cross-entry rule the per-entry
+// validator excludes: the duplicate must get its own critical row instead of
+// both entries showing green while the tick delivers nothing.
+func TestCheckNotificationsFlagsDuplicateScheduleIDs(t *testing.T) {
+	s := &Server{}
+	cfg := &types.HubConfig{Secrets: map[string]string{"token": "xoxb-test"}, Notifications: &types.NotificationsConfig{
+		Notifiers: map[string]types.NotifierConfig{
+			"healthy": {Type: "slack", Settings: map[string]any{"token_secret": "token", "channel": "C0123ABCD"}},
+		},
+		Scheduled: []types.ScheduledNotificationConfig{
+			{ID: "digest", Report: "pending_prs", Via: []string{"healthy"}, At: "09:00"},
+			{ID: "digest", Report: "pending_prs", Via: []string{"healthy"}, At: "17:00"},
+		},
+	}}
+	var duplicateRow bool
+	for _, check := range s.checkNotifications(cfg) {
+		if strings.Contains(check.Title, "Scheduled report") && check.OK {
+			t.Fatalf("green per-schedule row despite the duplicated id: %#v", check)
+		}
+		if strings.Contains(check.Title, `Scheduled report 2 ("digest") duplicates another schedule's id`) {
+			duplicateRow = true
+		}
+	}
+	if !duplicateRow {
+		t.Fatal("the duplicated id got no per-schedule row")
+	}
+}
+
 // The section-level validity rows mirror the per-feature tick gates: a defect
 // confined to one feature's block pauses only that feature, so the doctor must
 // not announce total notification failure — or stay silent about the feature

--- a/pkg/hub/doctor_test.go
+++ b/pkg/hub/doctor_test.go
@@ -136,6 +136,46 @@ func TestCheckNotificationsChecksEveryLifecycleRoute(t *testing.T) {
 	}
 }
 
+// Scheduled destinations get the same per-destination checks lifecycle routes
+// get: a schedule pointed at a channel-less (or non-constructible) notifier
+// fails every runtime send permanently and silently burns its slot, so doctor
+// must not report it green.
+func TestCheckNotificationsChecksEveryScheduledDestination(t *testing.T) {
+	s := &Server{}
+	cfg := &types.HubConfig{Secrets: map[string]string{"token": "xoxb-test"}, Notifications: &types.NotificationsConfig{
+		Notifiers: map[string]types.NotifierConfig{
+			"healthy": {Type: "slack", Settings: map[string]any{"token_secret": "token", "channel": "C0123ABCD"}},
+			"empty":   {Type: "slack", Settings: map[string]any{"token_secret": "token"}},
+			"broken":  {Type: "carrier-pigeon", Settings: map[string]any{"channel": "C0123ABCD"}},
+		},
+		Scheduled: []types.ScheduledNotificationConfig{
+			{ID: "digest", Report: "pending_prs", Via: []string{"healthy", "empty", "broken", "missing"}, At: "09:00"},
+		},
+	}}
+	checks := s.checkNotifications(cfg)
+	seen := map[string]bool{}
+	for _, check := range checks {
+		if strings.Contains(check.Title, "Scheduled report") {
+			if check.OK {
+				t.Fatalf("schedule with broken destinations reported green: %#v", check)
+			}
+			seen[check.Title] = true
+		}
+	}
+	for _, want := range []string{`destination "empty" has no channel`, `destination "broken" is not constructible`, "sends to an unknown notifier"} {
+		found := false
+		for title := range seen {
+			if strings.Contains(title, want) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("missing scheduled destination check %q in %#v", want, checks)
+		}
+	}
+}
+
 // Regression: the per-route checks ran even while lifecycle alerts were off, so
 // a deliberately muted config with a dangling via — a state
 // ValidateNotificationsConfig explicitly accepts, "an operator who mutes alerts

--- a/pkg/hub/doctor_test.go
+++ b/pkg/hub/doctor_test.go
@@ -176,6 +176,96 @@ func TestCheckNotificationsChecksEveryScheduledDestination(t *testing.T) {
 	}
 }
 
+// The per-schedule rows must also judge the slot fields (at/timezone/weekdays)
+// the destination checks never touch: an invalid one fails the scheduled
+// tick's validity gate — pausing EVERY schedule — so the very entry causing
+// the pause must not get a green "is configured" row.
+func TestCheckNotificationsFlagsInvalidScheduledSlotFields(t *testing.T) {
+	s := &Server{}
+	cfg := &types.HubConfig{Secrets: map[string]string{"token": "xoxb-test"}, Notifications: &types.NotificationsConfig{
+		Notifiers: map[string]types.NotifierConfig{
+			"healthy": {Type: "slack", Settings: map[string]any{"token_secret": "token", "channel": "C0123ABCD"}},
+		},
+		Scheduled: []types.ScheduledNotificationConfig{
+			{ID: "digest", Report: "pending_prs", Via: []string{"healthy"}, At: "09:00", Weekdays: []string{"monday"}},
+		},
+	}}
+	var invalidRow, sectionRow bool
+	for _, check := range s.checkNotifications(cfg) {
+		if strings.Contains(check.Title, `Scheduled report 1 ("digest")`) {
+			if check.OK {
+				t.Fatalf("schedule with an invalid weekday reported green: %#v", check)
+			}
+			if strings.Contains(check.Title, "is invalid") && strings.Contains(check.Error, `weekday "monday" is invalid`) {
+				invalidRow = true
+			}
+		}
+		if check.Title == "Scheduled reports config invalid" && !check.OK {
+			sectionRow = true
+		}
+	}
+	if !invalidRow {
+		t.Fatal("invalid weekday did not produce a critical per-schedule row")
+	}
+	if !sectionRow {
+		t.Fatal("invalid scheduled block did not produce the scheduled-reports section row")
+	}
+}
+
+// The section-level validity rows mirror the per-feature tick gates: a defect
+// confined to one feature's block pauses only that feature, so the doctor must
+// not announce total notification failure — or stay silent about the feature
+// that IS paused.
+func TestCheckNotificationsSplitsSectionValidityPerFeature(t *testing.T) {
+	s := &Server{}
+	notifiers := map[string]types.NotifierConfig{
+		"healthy": {Type: "slack", Settings: map[string]any{"token_secret": "token", "channel": "C0123ABCD"}},
+	}
+
+	titles := func(cfg *types.HubConfig) map[string]bool {
+		out := map[string]bool{}
+		for _, check := range s.checkNotifications(cfg) {
+			if !check.OK {
+				out[check.Title] = true
+			}
+		}
+		return out
+	}
+
+	// Defect confined to the (even disabled) lifecycle block: scheduled
+	// reports keep delivering, and the doctor must say so.
+	disabled := false
+	lifecycleBroken := titles(&types.HubConfig{Secrets: map[string]string{"token": "xoxb-test"}, Notifications: &types.NotificationsConfig{
+		Notifiers: notifiers,
+		Lifecycle: &types.LifecycleNotificationsConfig{Enabled: &disabled, PollInterval: "soon"},
+		Scheduled: []types.ScheduledNotificationConfig{
+			{ID: "digest", Report: "pending_prs", Via: []string{"healthy"}, At: "09:00"},
+		},
+	}})
+	if !lifecycleBroken["Lifecycle notifications config invalid"] {
+		t.Fatalf("lifecycle defect not surfaced: %#v", lifecycleBroken)
+	}
+	if lifecycleBroken["Scheduled reports config invalid"] {
+		t.Fatalf("lifecycle defect blamed on scheduled reports: %#v", lifecycleBroken)
+	}
+
+	// Defect confined to the scheduled block (a duplicated id): lifecycle
+	// alerts keep delivering.
+	scheduledBroken := titles(&types.HubConfig{Secrets: map[string]string{"token": "xoxb-test"}, Notifications: &types.NotificationsConfig{
+		Notifiers: notifiers,
+		Scheduled: []types.ScheduledNotificationConfig{
+			{ID: "digest", Report: "pending_prs", Via: []string{"healthy"}, At: "09:00"},
+			{ID: "digest", Report: "pending_prs", Via: []string{"healthy"}, At: "17:00"},
+		},
+	}})
+	if !scheduledBroken["Scheduled reports config invalid"] {
+		t.Fatalf("scheduled defect not surfaced: %#v", scheduledBroken)
+	}
+	if scheduledBroken["Lifecycle notifications config invalid"] {
+		t.Fatalf("scheduled defect blamed on lifecycle notifications: %#v", scheduledBroken)
+	}
+}
+
 // Regression: the per-route checks ran even while lifecycle alerts were off, so
 // a deliberately muted config with a dangling via — a state
 // ValidateNotificationsConfig explicitly accepts, "an operator who mutes alerts

--- a/pkg/hub/lifecycle_notifier.go
+++ b/pkg/hub/lifecycle_notifier.go
@@ -308,7 +308,7 @@ func (s *Server) initLifecycleNotifierBaseline() {
 	// baselined by the first poll tick, one poll interval after the producers
 	// started, and silently miss whatever they produced in that window. Both
 	// helpers are idempotent, so the tick keeps covering runtime saves.
-	if err := types.ValidateNotificationsConfig(cfg); err == nil {
+	if err := types.ValidateLifecycleNotificationsConfig(cfg); err == nil {
 		s.pruneLifecycleRouteState(cfg.Lifecycle)
 		s.ensureLifecycleRouteWatermarks(cfg.Lifecycle)
 		s.ensureLifecycleClawRouteBaselines(cfg.Lifecycle)
@@ -475,8 +475,11 @@ func (s *Server) lifecycleNotifierTick() {
 		s.parkLifecycleClawState()
 		return
 	}
-	if err := types.ValidateNotificationsConfig(cfg); err != nil {
-		s.logPollWarningOnce("notify-config", "[notify] invalid notifications config — notifications paused: %v", err)
+	// Only the config this tick consumes is judged (notifiers plus the
+	// lifecycle block): a defect in the scheduled block pauses scheduled
+	// reports, never lifecycle alerts.
+	if err := types.ValidateLifecycleNotificationsConfig(cfg); err != nil {
+		s.logPollWarningOnce("notify-config", "[notify] invalid notifications config — lifecycle notifications paused: %v", err)
 		return
 	}
 	lc := cfg.Lifecycle
@@ -1833,7 +1836,7 @@ func (s *Server) handleNotificationTest(w http.ResponseWriter, r *http.Request) 
 		jsonError(w, http.StatusBadRequest, "lifecycle notifications are not configured or not enabled (set notifications.lifecycle in hub.yaml)")
 		return
 	}
-	if err := types.ValidateNotificationsConfig(cfg); err != nil {
+	if err := types.ValidateLifecycleNotificationsConfig(cfg); err != nil {
 		jsonError(w, http.StatusBadRequest, "notifications config invalid: "+err.Error())
 		return
 	}

--- a/pkg/hub/lifecycle_notifier.go
+++ b/pkg/hub/lifecycle_notifier.go
@@ -1796,6 +1796,11 @@ func (s *Server) handleNotificationTest(w http.ResponseWriter, r *http.Request) 
 		EventType string `json:"event_type"`
 		RunID     string `json:"run_id"`
 		ClawID    string `json:"claw_id"`
+		// Report probes a scheduled report instead of a lifecycle event. It is
+		// mutually exclusive with event_type and takes the scheduled-report
+		// branch below, which shares only the notifier resolution and the
+		// dry-run rendering with the lifecycle path.
+		Report string `json:"report"`
 		// Via names which configured notifier to probe. Empty means the first
 		// effective route — lifecycle.via for a legacy single-channel config.
 		Via    string `json:"via"`
@@ -1803,6 +1808,14 @@ func (s *Server) handleNotificationTest(w http.ResponseWriter, r *http.Request) 
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		jsonError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+		return
+	}
+	if report := strings.TrimSpace(body.Report); report != "" {
+		if strings.TrimSpace(body.EventType) != "" {
+			jsonError(w, http.StatusBadRequest, "report and event_type are mutually exclusive")
+			return
+		}
+		s.handleScheduledReportTest(w, r, report, strings.TrimSpace(body.Via), body.DryRun)
 		return
 	}
 	supported := lifecycleSupportedEventTypes()
@@ -1962,6 +1975,92 @@ func (s *Server) handleNotificationTest(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	jsonOK(w, map[string]any{"ok": true, "message_id": handle, "via": via, "payload": payload})
+}
+
+// handleScheduledReportTest probes one scheduled report on demand: it builds
+// the report through the same registry the scheduler uses, so what the
+// operator previews or receives is byte-identical to what the next due slot
+// would post. It never touches the scheduler's dedupe state — a test send must
+// not suppress the real delivery it is testing.
+//
+// A report with nothing to say answers 200 with empty:true rather than an
+// error: "no pull requests are waiting" is a legitimate, and common, result.
+func (s *Server) handleScheduledReportTest(w http.ResponseWriter, r *http.Request, report, via string, dryRun bool) {
+	builder, ok := scheduledReport(report)
+	if !ok {
+		jsonError(w, http.StatusBadRequest, "unknown report "+strconv.Quote(report)+"; supported reports: "+scheduledReportNamesText())
+		return
+	}
+	cfg := s.notificationsConfig()
+	if cfg == nil {
+		jsonError(w, http.StatusBadRequest, "no notifiers are configured (set notifications.notifiers in hub.yaml)")
+		return
+	}
+	// Unlike the lifecycle probe there is no default destination to fall back
+	// to: a schedule names its own notifiers and nothing else in the config
+	// implies one.
+	if via == "" {
+		jsonError(w, http.StatusBadRequest, "via is required: name the notifier to send the report through (defined: "+configuredNotifierNames(cfg.Notifiers)+")")
+		return
+	}
+	nc, ok := cfg.Notifiers[via]
+	if !ok {
+		jsonError(w, http.StatusBadRequest, "via "+strconv.Quote(via)+" does not name a configured notifier (defined: "+configuredNotifierNames(cfg.Notifiers)+")")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	defer cancel()
+	msg, hasReport, err := builder(ctx, s)
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "build report "+strconv.Quote(report)+": "+err.Error())
+		return
+	}
+	if !hasReport {
+		jsonOK(w, map[string]any{"ok": true, "empty": true, "report": report, "via": via, "dry_run": dryRun})
+		return
+	}
+
+	secrets := s.hubSecretResolver()
+	if dryRun {
+		// Same fallback the lifecycle dry run uses: a preview must work while
+		// the token secret is still missing, and the payload never carries it.
+		dryResolver := func(name string) (string, bool) {
+			if v, ok := secrets(name); ok && v != "" {
+				return v, true
+			}
+			return "dry-run-placeholder", true
+		}
+		n, err := notify.New(nc.Type, s.notifierSettings(nc), dryResolver)
+		if err != nil {
+			jsonError(w, http.StatusBadRequest, "notifier "+strconv.Quote(via)+" invalid: "+err.Error())
+			return
+		}
+		payload, err := renderNotifierPayload(n, *msg)
+		if err != nil {
+			jsonError(w, http.StatusBadRequest, "render payload: "+err.Error())
+			return
+		}
+		jsonOK(w, map[string]any{"dry_run": true, "report": report, "via": via, "payload": payload})
+		return
+	}
+
+	n, err := s.notifierFor(via, nc, secrets)
+	if err != nil {
+		jsonError(w, http.StatusBadRequest, "notifier "+strconv.Quote(via)+" unavailable: "+err.Error())
+		return
+	}
+	payload, err := renderNotifierPayload(n, *msg)
+	if err != nil {
+		jsonError(w, http.StatusBadRequest, "render payload: "+err.Error())
+		return
+	}
+	handle, err := n.Send(ctx, *msg)
+	if err != nil {
+		jsonError(w, http.StatusBadGateway, "notification send failed: "+err.Error())
+		return
+	}
+	jsonOK(w, map[string]any{"ok": true, "message_id": handle, "report": report, "via": via, "payload": payload})
 }
 
 // configuredNotifierNames lists the configured notifier names for error text.

--- a/pkg/hub/lifecycle_notifier.go
+++ b/pkg/hub/lifecycle_notifier.go
@@ -106,6 +106,13 @@ func (s *Server) notificationsConfig() *types.NotificationsConfig {
 		lc := *src.Lifecycle
 		cfg.Lifecycle = &lc
 	}
+	if src.Scheduled != nil {
+		cfg.Scheduled = append([]types.ScheduledNotificationConfig(nil), src.Scheduled...)
+		for i := range cfg.Scheduled {
+			cfg.Scheduled[i].Via = append([]string(nil), src.Scheduled[i].Via...)
+			cfg.Scheduled[i].Weekdays = append([]string(nil), src.Scheduled[i].Weekdays...)
+		}
+	}
 	return cfg
 }
 

--- a/pkg/hub/lifecycle_notifier_test.go
+++ b/pkg/hub/lifecycle_notifier_test.go
@@ -161,6 +161,26 @@ func insertLifecycleRouteEvent(t *testing.T, db *sql.DB, id, eventType string) {
 	insertSlackTestEvent(t, db, id, "route-run", eventType, base+10, "", "", "")
 }
 
+// A defective scheduled block in a hand-written hub.yaml pauses scheduled
+// reports, never lifecycle alerts: the lifecycle tick gates only on the
+// config it consumes (notifiers plus the lifecycle block).
+func TestLifecycleTickRunsDespiteDefectiveScheduledBlock(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	s, db := newSlackNotifierTestServer(t, fake.server.URL, nil)
+	s.hubCfg.Notifications.Scheduled = []types.ScheduledNotificationConfig{
+		{ID: "broken", Report: "x", Via: []string{testNotifierName}, At: "09:00", Weekdays: []string{"monday"}},
+	}
+	if types.ValidateNotificationsConfig(s.hubCfg.Notifications) == nil {
+		t.Fatal("fixture is supposed to fail the composed validator")
+	}
+	insertLifecycleRouteEvent(t, db, "lifecycle-despite-scheduled", taskRunEventAgentStarted)
+	setSlackWatermark(t, s, 0)
+	s.lifecycleNotifierTick()
+	if fake.count() != 1 {
+		t.Fatalf("lifecycle alert was paused by the defective scheduled block: %d sends, want 1", fake.count())
+	}
+}
+
 func TestLifecycleRoutesFanoutAndFiltering(t *testing.T) {
 	fake := newFakeSlackServer(t)
 	routes := []types.LifecycleRoute{{Via: "all"}, {Via: "started", Events: []string{taskRunEventAgentStarted}}}

--- a/pkg/hub/notify_validate.go
+++ b/pkg/hub/notify_validate.go
@@ -191,6 +191,17 @@ func notifierPipelineReferences(factories []*types.FactoryConfig) map[string][]s
 // writes the notifier out of hub.yaml, and executeNotifyAction then drops
 // every stage notification with nothing but a warning in the claw
 // conversation.
+//
+// Enabled scheduled reports are guarded the same way: persisting a patch that
+// removes a notifier an ENABLED schedule's via still names (the schedule
+// carried forward, or re-sent verbatim, so scheduledEntryUnchanged exempts it
+// from validation) yields exactly the config the scheduler tick's validity
+// gate rejects — pausing EVERY scheduled report hub-wide with one log line as
+// the only signal. Only patch-introduced dangling is charged: the via must
+// have resolved in `current`, so a hand-written hub.yaml that already carries
+// a dangling via never bricks unrelated saves, and the screen's removeChannel
+// — which rewrites or pauses affected schedules in the same patch — keeps
+// working.
 func validateNotifierRemovals(current, patch *types.NotificationsConfig, factories []*types.FactoryConfig) error {
 	if current == nil || patch == nil {
 		return nil
@@ -206,6 +217,17 @@ func validateNotifierRemovals(current, patch *types.NotificationsConfig, factori
 	}
 	sort.Strings(removed)
 	references := notifierPipelineReferences(factories)
+	for _, scheduled := range patch.Scheduled {
+		if scheduled.Enabled != nil && !*scheduled.Enabled {
+			continue
+		}
+		for _, via := range scheduled.Via {
+			// TrimSpace matches how the scheduler and its validity gate
+			// resolve the via.
+			trimmed := strings.TrimSpace(via)
+			references[trimmed] = append(references[trimmed], fmt.Sprintf("scheduled report %q", scheduled.ID))
+		}
+	}
 	var problems []string
 	for _, name := range removed {
 		used := references[name]
@@ -218,7 +240,7 @@ func validateNotifierRemovals(current, patch *types.NotificationsConfig, factori
 	if len(problems) == 0 {
 		return nil
 	}
-	return fmt.Errorf("notifications.notifiers: cannot remove a notifier a pipeline still notifies through: %s", strings.Join(problems, "; "))
+	return fmt.Errorf("notifications.notifiers: cannot remove a notifier still in use: %s", strings.Join(problems, "; "))
 }
 
 // configuredNotifiers returns the notifier set defined under

--- a/pkg/hub/scheduled_notifier.go
+++ b/pkg/hub/scheduled_notifier.go
@@ -57,6 +57,23 @@ func scheduledReport(name string) (scheduledReportBuilder, bool) {
 	return builder, ok
 }
 
+// scheduledSendTimeout bounds each report build and each destination send,
+// mirroring the lifecycle notifier's 30s send cap: one slow destination must
+// not delay every schedule behind it in the tick, and a hanging send would
+// otherwise sit in stopScheduledNotifier's bounded wait, widening the
+// shutdown duplicate-send window.
+const scheduledSendTimeout = 30 * time.Second
+
+// scheduledMaxTransientFailures bounds consecutive transient send failures
+// for one (schedule, destination) slot, analogous to
+// lifecycleMaxTransientFailures. Unclassified errors default to transient, so
+// a permanently-undeliverable report a provider failed to classify would
+// otherwise re-post the identical message every minute until the next slot.
+// Unlike the lifecycle streak this one lives in memory (ticks are serial):
+// losing it to a restart costs at most one fresh retry budget for the same
+// slot, never a wedged cursor.
+const scheduledMaxTransientFailures = 60
+
 // startScheduledNotifier launches the background loop that fires scheduled
 // reports. It stops when stopScheduledNotifier is called (graceful shutdown,
 // before the DB closes).
@@ -64,8 +81,14 @@ func (s *Server) startScheduledNotifier() {
 	stop := make(chan struct{})
 	done := make(chan struct{})
 	s.scheduledNotifierStop, s.scheduledNotifierDone = stop, done
+	// tickCtx mirrors the stop channel as a context so the builds and sends
+	// of a tick in flight at shutdown are cancelled instead of running out
+	// stopScheduledNotifier's bounded wait.
+	tickCtx, cancelTicks := context.WithCancel(context.Background())
 	s.safeGo("scheduled notifier", func() {
 		defer close(done)
+		defer cancelTicks()
+		go func() { <-stop; cancelTicks() }()
 		for {
 			timer := time.NewTimer(time.Minute)
 			select {
@@ -83,7 +106,7 @@ func (s *Server) startScheduledNotifier() {
 						log.Printf("[notify] scheduled notifier tick panic: %v\n%s", r, debug.Stack())
 					}
 				}()
-				s.scheduledNotifierTick(s.nowFunc())
+				s.scheduledNotifierTick(tickCtx, s.nowFunc())
 			}()
 		}
 	})
@@ -108,20 +131,22 @@ func (s *Server) stopScheduledNotifier(timeout time.Duration) {
 	}
 }
 
-func (s *Server) scheduledNotifierTick(nowAt time.Time) {
+func (s *Server) scheduledNotifierTick(ctx context.Context, nowAt time.Time) {
 	cfg := s.notificationsConfig()
 	if cfg == nil {
 		return
 	}
+	s.pruneScheduledState(cfg.Scheduled)
 	for _, schedule := range cfg.Scheduled {
 		slot, ok := scheduledNotificationSlot(nowAt, schedule)
 		if !ok {
 			continue
 		}
 		paused := schedule.Enabled != nil && !*schedule.Enabled
+		digest := scheduledSlotDigest(schedule)
 		pending := make([]string, 0, len(schedule.Via))
 		for _, via := range schedule.Via {
-			fired, found, err := s.scheduledLastFired(schedule.ID, via)
+			fired, firedDigest, found, err := s.scheduledLastFired(schedule.ID, via)
 			if err != nil {
 				log.Printf("[notify] read scheduled state for %s via %s: %v", schedule.ID, via, err)
 				continue
@@ -131,11 +156,17 @@ func (s *Server) scheduledNotifierTick(nowAt time.Time) {
 			// The slot search reaches up to 8 days back, so firing here would
 			// replay a slot from before the schedule existed; seed the row to
 			// the current slot instead and deliver from the next one on. A
-			// paused schedule advances the same way: slots that pass while it
-			// is paused are skipped, not queued up for the re-enable.
-			if !found || paused {
-				if !found || fired.Before(slot) {
-					s.setScheduledLastFired(schedule.ID, via, slot)
+			// row whose slot digest no longer matches was written under a
+			// pre-edit at/timezone/weekdays definition: firing against it
+			// would post an off-schedule send the moment the edit is saved,
+			// so it is reseeded like a first sight and the edited schedule
+			// delivers from its next slot on. A paused schedule advances the
+			// same way: slots that pass while it is paused are skipped, not
+			// queued up for the re-enable.
+			edited := firedDigest != digest
+			if !found || edited || paused {
+				if !found || edited || fired.Before(slot) {
+					s.setScheduledLastFired(schedule.ID, via, slot, digest)
 				}
 				continue
 			}
@@ -151,14 +182,16 @@ func (s *Server) scheduledNotifierTick(nowAt time.Time) {
 			log.Printf("[notify] scheduled report %q is not registered", schedule.Report)
 			continue
 		}
-		message, hasReport, err := builder(context.Background(), s)
+		buildCtx, cancelBuild := context.WithTimeout(ctx, scheduledSendTimeout)
+		message, hasReport, err := builder(buildCtx, s)
+		cancelBuild()
 		if err != nil {
 			log.Printf("[notify] build scheduled report %q: %v", schedule.Report, err)
 			continue
 		}
 		if !hasReport {
 			for _, via := range pending {
-				s.setScheduledLastFired(schedule.ID, via, slot)
+				s.setScheduledLastFired(schedule.ID, via, slot, digest)
 			}
 			continue
 		}
@@ -166,18 +199,92 @@ func (s *Server) scheduledNotifierTick(nowAt time.Time) {
 			notifier, err := s.notifierFor(via, cfg.Notifiers[via], s.hubSecretResolver())
 			constructionFailed := err != nil
 			if err == nil {
-				_, err = notifier.Send(context.Background(), *message)
+				sendCtx, cancelSend := context.WithTimeout(ctx, scheduledSendTimeout)
+				_, err = notifier.Send(sendCtx, *message)
+				cancelSend()
 			}
 			if err == nil {
-				s.setScheduledLastFired(schedule.ID, via, slot)
+				s.clearScheduledTransientFailures(schedule.ID, via)
+				s.setScheduledLastFired(schedule.ID, via, slot, digest)
 				continue
 			}
 			if !constructionFailed && notify.Classify(err) == notify.ErrorTransient {
-				log.Printf("[notify] send scheduled report %q via %s: %v", schedule.Report, via, err)
-				continue
+				if count := s.noteScheduledTransientFailure(schedule.ID, via, slot); count < scheduledMaxTransientFailures {
+					log.Printf("[notify] send scheduled report %q via %s (failure %d/%d, will retry): %v", schedule.Report, via, count, scheduledMaxTransientFailures, err)
+					continue
+				}
+				log.Printf("[notify] giving up on scheduled report %q via %s after %d consecutive transient failures: %v", schedule.Report, via, scheduledMaxTransientFailures, err)
+			} else {
+				log.Printf("[notify] permanently failed scheduled report %q via %s: %v", schedule.Report, via, err)
 			}
-			log.Printf("[notify] permanently failed scheduled report %q via %s: %v", schedule.Report, via, err)
-			s.setScheduledLastFired(schedule.ID, via, slot)
+			s.clearScheduledTransientFailures(schedule.ID, via)
+			s.setScheduledLastFired(schedule.ID, via, slot, digest)
+		}
+	}
+}
+
+type scheduledFailureStreak struct {
+	slot  time.Time
+	count int
+}
+
+// noteScheduledTransientFailure records one more consecutive transient send
+// failure for the destination's current slot and returns the streak length.
+// Ticks run serially in one goroutine, so the map needs no lock; a slot
+// change resets the streak, so stale entries can never charge a later slot.
+func (s *Server) noteScheduledTransientFailure(id, via string, slot time.Time) int {
+	if s.scheduledTransientFailures == nil {
+		s.scheduledTransientFailures = map[string]scheduledFailureStreak{}
+	}
+	key := scheduledStateKey(id, via)
+	streak := s.scheduledTransientFailures[key]
+	if !streak.slot.Equal(slot) {
+		streak = scheduledFailureStreak{slot: slot}
+	}
+	streak.count++
+	s.scheduledTransientFailures[key] = streak
+	return streak.count
+}
+
+func (s *Server) clearScheduledTransientFailures(id, via string) {
+	delete(s.scheduledTransientFailures, scheduledStateKey(id, via))
+}
+
+// pruneScheduledState drops the dedupe rows of (schedule, destination) pairs
+// that are no longer configured, for the same reason pruneLifecycleRouteState
+// drops route cursors: nothing else clears them, so a schedule id deleted and
+// later re-created would resume from its stale row and replay a slot that
+// belongs to the removal window, and orphaned rows would otherwise accumulate
+// forever. Rows in a superseded key format fall out here too, as keys no
+// configured pair produces.
+func (s *Server) pruneScheduledState(scheduled []types.ScheduledNotificationConfig) {
+	configured := map[string]bool{}
+	for _, schedule := range scheduled {
+		for _, via := range schedule.Via {
+			configured[scheduledStateKey(schedule.ID, via)] = true
+		}
+	}
+	rows, err := s.db.Query(`SELECT key FROM slack_notifier_state WHERE key LIKE ?`, scheduledStateKeyPrefix+"%")
+	if err != nil {
+		log.Printf("[notify] list scheduled state: %v", err)
+		return
+	}
+	var stale []string
+	for rows.Next() {
+		var key string
+		if err := rows.Scan(&key); err != nil {
+			log.Printf("[notify] list scheduled state: %v", err)
+			rows.Close()
+			return
+		}
+		if !configured[key] {
+			stale = append(stale, key)
+		}
+	}
+	rows.Close()
+	for _, key := range stale {
+		if _, err := s.db.Exec(`DELETE FROM slack_notifier_state WHERE key=?`, key); err != nil {
+			log.Printf("[notify] prune scheduled state %q: %v", key, err)
 		}
 	}
 }
@@ -206,9 +313,24 @@ func scheduledNotificationSlot(nowAt time.Time, schedule types.ScheduledNotifica
 		if len(allowed) != 0 && !allowed[weekday] {
 			continue
 		}
+		// A spring-forward DST gap can swallow the configured wall time;
+		// time.Date then normalizes it to a real instant on one side of the
+		// gap (which side is not guaranteed). Keep a normalized instant —
+		// the post-gap one, e.g. 02:30 -> 03:30 — rather than skipping the
+		// day: a weekday-restricted schedule whose only allowed day lands in
+		// the gap would otherwise silently drop a full weekly cycle.
 		candidate := time.Date(day.Year(), day.Month(), day.Day(), at.Hour(), at.Minute(), 0, 0, location)
-		if candidate.Hour() != at.Hour() || candidate.Minute() != at.Minute() {
-			continue
+		if got := candidate.Hour()*60 + candidate.Minute(); got != at.Hour()*60+at.Minute() {
+			diff := at.Hour()*60 + at.Minute() - got
+			if diff < -12*60 {
+				diff += 24 * 60
+			} else if diff > 12*60 {
+				diff -= 24 * 60
+			}
+			// Both instants sit next to the gap; the later one is past it.
+			if shifted := candidate.Add(time.Duration(diff) * time.Minute); shifted.After(candidate) {
+				candidate = shifted
+			}
 		}
 		if !candidate.After(localNow) {
 			return candidate, true
@@ -217,31 +339,50 @@ func scheduledNotificationSlot(nowAt time.Time, schedule types.ScheduledNotifica
 	return time.Time{}, false
 }
 
+const scheduledStateKeyPrefix = "scheduled:last_fired:"
+
+// scheduledStateKey joins the schedule id and destination with a NUL: both
+// halves are free text that may contain any printable separator (a ':' most
+// plausibly), so distinct (id, via) pairs could otherwise collide on one
+// dedupe row. Control characters are banned in schedule ids and notifier
+// names (types.ValidateNotificationsConfig), so NUL cannot occur in either.
 func scheduledStateKey(id, via string) string {
-	return "scheduled:last_fired:" + id + ":" + via
+	return scheduledStateKeyPrefix + id + "\x00" + via
 }
 
-func (s *Server) scheduledLastFired(id, via string) (time.Time, bool, error) {
+// scheduledSlotDigest identifies the slot definition a dedupe row was written
+// under. It is stored alongside the last-fired instant so an edit to at,
+// timezone, or weekdays reads back as a digest mismatch and the row is
+// reseeded like a first sight, instead of the pre-edit history counting as
+// the new definition's own and firing an off-schedule send.
+func scheduledSlotDigest(schedule types.ScheduledNotificationConfig) string {
+	return schedule.At + "\x1f" + schedule.Timezone + "\x1f" + strings.Join(schedule.Weekdays, ",")
+}
+
+func (s *Server) scheduledLastFired(id, via string) (time.Time, string, bool, error) {
 	var raw string
 	err := s.db.QueryRow(`SELECT value FROM slack_notifier_state WHERE key=?`, scheduledStateKey(id, via)).Scan(&raw)
 	if err == sql.ErrNoRows {
-		return time.Time{}, false, nil
+		return time.Time{}, "", false, nil
 	}
 	if err != nil {
-		return time.Time{}, false, err
+		return time.Time{}, "", false, err
 	}
-	value, err := time.Parse(time.RFC3339, raw)
+	// The value is "<RFC3339 slot>\n<slot digest>". A row written before the
+	// digest existed parses as an empty digest and is reseeded on next sight.
+	stamp, digest, _ := strings.Cut(raw, "\n")
+	value, err := time.Parse(time.RFC3339, stamp)
 	if err != nil {
-		return time.Time{}, false, fmt.Errorf("parse scheduled state %q: %w", raw, err)
+		return time.Time{}, "", false, fmt.Errorf("parse scheduled state %q: %w", raw, err)
 	}
-	return value, true, nil
+	return value, digest, true, nil
 }
 
-func (s *Server) setScheduledLastFired(id, via string, slot time.Time) {
+func (s *Server) setScheduledLastFired(id, via string, slot time.Time, digest string) {
 	if _, err := s.db.Exec(`
 		INSERT INTO slack_notifier_state(key, value) VALUES(?,?)
 		ON CONFLICT(key) DO UPDATE SET value=excluded.value`,
-		scheduledStateKey(id, via), slot.Format(time.RFC3339)); err != nil {
+		scheduledStateKey(id, via), slot.Format(time.RFC3339)+"\n"+digest); err != nil {
 		log.Printf("[notify] persist scheduled state for %s via %s: %v", id, via, err)
 	}
 }

--- a/pkg/hub/scheduled_notifier.go
+++ b/pkg/hub/scheduled_notifier.go
@@ -1,0 +1,196 @@
+package hub
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+	"runtime/debug"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/hub/notify"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+type scheduledReportBuilder func(ctx context.Context, s *Server) (*notify.Message, bool, error)
+
+var scheduledReportRegistry = struct {
+	sync.RWMutex
+	builders map[string]scheduledReportBuilder
+}{builders: make(map[string]scheduledReportBuilder)}
+
+func registerScheduledReport(name string, builder scheduledReportBuilder) {
+	scheduledReportRegistry.Lock()
+	defer scheduledReportRegistry.Unlock()
+	scheduledReportRegistry.builders[name] = builder
+}
+
+// ScheduledReportSupported reports whether name is a registered scheduled report.
+func ScheduledReportSupported(name string) bool {
+	scheduledReportRegistry.RLock()
+	defer scheduledReportRegistry.RUnlock()
+	_, ok := scheduledReportRegistry.builders[name]
+	return ok
+}
+
+func scheduledReport(name string) (scheduledReportBuilder, bool) {
+	scheduledReportRegistry.RLock()
+	defer scheduledReportRegistry.RUnlock()
+	builder, ok := scheduledReportRegistry.builders[name]
+	return builder, ok
+}
+
+func (s *Server) startScheduledNotifier() {
+	s.safeGo("scheduled notifier", func() {
+		for {
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						log.Printf("[notify] scheduled notifier loop panic, restarting: %v\n%s", r, debug.Stack())
+					}
+				}()
+				ticker := time.NewTicker(time.Minute)
+				defer ticker.Stop()
+				for range ticker.C {
+					func() {
+						defer func() {
+							if r := recover(); r != nil {
+								log.Printf("[notify] scheduled notifier tick panic: %v\n%s", r, debug.Stack())
+							}
+						}()
+						s.scheduledNotifierTick(s.nowFunc())
+					}()
+				}
+			}()
+		}
+	})
+}
+
+func (s *Server) scheduledNotifierTick(nowAt time.Time) {
+	cfg := s.notificationsConfig()
+	if cfg == nil {
+		return
+	}
+	for _, schedule := range cfg.Scheduled {
+		if schedule.Enabled != nil && !*schedule.Enabled {
+			continue
+		}
+		slot, ok := scheduledNotificationSlot(nowAt, schedule)
+		if !ok {
+			continue
+		}
+		pending := make([]string, 0, len(schedule.Via))
+		for _, via := range schedule.Via {
+			fired, found, err := s.scheduledLastFired(schedule.ID, via)
+			if err != nil {
+				log.Printf("[notify] read scheduled state for %s via %s: %v", schedule.ID, via, err)
+				continue
+			}
+			if !found || fired.Before(slot) {
+				pending = append(pending, via)
+			}
+		}
+		if len(pending) == 0 {
+			continue
+		}
+		builder, found := scheduledReport(schedule.Report)
+		if !found {
+			log.Printf("[notify] scheduled report %q is not registered", schedule.Report)
+			continue
+		}
+		message, hasReport, err := builder(context.Background(), s)
+		if err != nil {
+			log.Printf("[notify] build scheduled report %q: %v", schedule.Report, err)
+			continue
+		}
+		if !hasReport {
+			for _, via := range pending {
+				s.setScheduledLastFired(schedule.ID, via, slot)
+			}
+			continue
+		}
+		for _, via := range pending {
+			notifier, err := s.notifierFor(via, cfg.Notifiers[via], s.hubSecretResolver())
+			constructionFailed := err != nil
+			if err == nil {
+				_, err = notifier.Send(context.Background(), *message)
+			}
+			if err == nil {
+				s.setScheduledLastFired(schedule.ID, via, slot)
+				continue
+			}
+			if !constructionFailed && notify.Classify(err) == notify.ErrorTransient {
+				log.Printf("[notify] send scheduled report %q via %s: %v", schedule.Report, via, err)
+				continue
+			}
+			log.Printf("[notify] permanently failed scheduled report %q via %s: %v", schedule.Report, via, err)
+			s.setScheduledLastFired(schedule.ID, via, slot)
+		}
+	}
+}
+
+func scheduledNotificationSlot(nowAt time.Time, schedule types.ScheduledNotificationConfig) (time.Time, bool) {
+	location := time.UTC
+	if schedule.Timezone != "" {
+		var err error
+		location, err = time.LoadLocation(schedule.Timezone)
+		if err != nil {
+			return time.Time{}, false
+		}
+	}
+	at, err := time.Parse("15:04", schedule.At)
+	if err != nil {
+		return time.Time{}, false
+	}
+	localNow := nowAt.In(location)
+	allowed := make(map[string]bool, len(schedule.Weekdays))
+	for _, weekday := range schedule.Weekdays {
+		allowed[weekday] = true
+	}
+	for daysAgo := 0; daysAgo < 8; daysAgo++ {
+		day := localNow.AddDate(0, 0, -daysAgo)
+		weekday := strings.ToLower(day.Weekday().String()[:3])
+		if len(allowed) != 0 && !allowed[weekday] {
+			continue
+		}
+		candidate := time.Date(day.Year(), day.Month(), day.Day(), at.Hour(), at.Minute(), 0, 0, location)
+		if candidate.Hour() != at.Hour() || candidate.Minute() != at.Minute() {
+			continue
+		}
+		if !candidate.After(localNow) {
+			return candidate, true
+		}
+	}
+	return time.Time{}, false
+}
+
+func scheduledStateKey(id, via string) string {
+	return "scheduled:last_fired:" + id + ":" + via
+}
+
+func (s *Server) scheduledLastFired(id, via string) (time.Time, bool, error) {
+	var raw string
+	err := s.db.QueryRow(`SELECT value FROM slack_notifier_state WHERE key=?`, scheduledStateKey(id, via)).Scan(&raw)
+	if err == sql.ErrNoRows {
+		return time.Time{}, false, nil
+	}
+	if err != nil {
+		return time.Time{}, false, err
+	}
+	value, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return time.Time{}, false, fmt.Errorf("parse scheduled state %q: %w", raw, err)
+	}
+	return value, true, nil
+}
+
+func (s *Server) setScheduledLastFired(id, via string, slot time.Time) {
+	if _, err := s.db.Exec(`
+		INSERT INTO slack_notifier_state(key, value) VALUES(?,?)
+		ON CONFLICT(key) DO UPDATE SET value=excluded.value`,
+		scheduledStateKey(id, via), slot.Format(time.RFC3339)); err != nil {
+		log.Printf("[notify] persist scheduled state for %s via %s: %v", id, via, err)
+	}
+}

--- a/pkg/hub/scheduled_notifier.go
+++ b/pkg/hub/scheduled_notifier.go
@@ -57,30 +57,55 @@ func scheduledReport(name string) (scheduledReportBuilder, bool) {
 	return builder, ok
 }
 
+// startScheduledNotifier launches the background loop that fires scheduled
+// reports. It stops when stopScheduledNotifier is called (graceful shutdown,
+// before the DB closes).
 func (s *Server) startScheduledNotifier() {
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	s.scheduledNotifierStop, s.scheduledNotifierDone = stop, done
 	s.safeGo("scheduled notifier", func() {
+		defer close(done)
 		for {
+			timer := time.NewTimer(time.Minute)
+			select {
+			case <-stop:
+				timer.Stop()
+				return
+			case <-timer.C:
+			}
+			// Run the tick inline (not via safeGo) so ticks never overlap and
+			// shutdown can wait for the one in flight. A panic is contained to
+			// this iteration.
 			func() {
 				defer func() {
 					if r := recover(); r != nil {
-						log.Printf("[notify] scheduled notifier loop panic, restarting: %v\n%s", r, debug.Stack())
+						log.Printf("[notify] scheduled notifier tick panic: %v\n%s", r, debug.Stack())
 					}
 				}()
-				ticker := time.NewTicker(time.Minute)
-				defer ticker.Stop()
-				for range ticker.C {
-					func() {
-						defer func() {
-							if r := recover(); r != nil {
-								log.Printf("[notify] scheduled notifier tick panic: %v\n%s", r, debug.Stack())
-							}
-						}()
-						s.scheduledNotifierTick(s.nowFunc())
-					}()
-				}
+				s.scheduledNotifierTick(s.nowFunc())
 			}()
 		}
 	})
+}
+
+// stopScheduledNotifier stops the tick loop and waits (bounded) for an
+// in-flight tick to finish, for the same reason stopLifecycleNotifier does:
+// a tick in flight at shutdown can complete an external Slack send and then
+// fail the dedupe-state upsert against a closed DB, re-sending the same slot
+// after restart. The timeout keeps a pathologically slow tick from wedging
+// shutdown, accepting the duplicate-send window in that case.
+func (s *Server) stopScheduledNotifier(timeout time.Duration) {
+	if s.scheduledNotifierStop == nil {
+		return
+	}
+	close(s.scheduledNotifierStop)
+	s.scheduledNotifierStop = nil
+	select {
+	case <-s.scheduledNotifierDone:
+	case <-time.After(timeout):
+		log.Printf("[notify] scheduled notifier tick still running after %v; shutting down anyway", timeout)
+	}
 }
 
 func (s *Server) scheduledNotifierTick(nowAt time.Time) {
@@ -89,13 +114,11 @@ func (s *Server) scheduledNotifierTick(nowAt time.Time) {
 		return
 	}
 	for _, schedule := range cfg.Scheduled {
-		if schedule.Enabled != nil && !*schedule.Enabled {
-			continue
-		}
 		slot, ok := scheduledNotificationSlot(nowAt, schedule)
 		if !ok {
 			continue
 		}
+		paused := schedule.Enabled != nil && !*schedule.Enabled
 		pending := make([]string, 0, len(schedule.Via))
 		for _, via := range schedule.Via {
 			fired, found, err := s.scheduledLastFired(schedule.ID, via)
@@ -103,7 +126,20 @@ func (s *Server) scheduledNotifierTick(nowAt time.Time) {
 				log.Printf("[notify] read scheduled state for %s via %s: %v", schedule.ID, via, err)
 				continue
 			}
-			if !found || fired.Before(slot) {
+			// A destination with no state row is one this hub has never
+			// delivered to — a schedule (or via) just created or first seen.
+			// The slot search reaches up to 8 days back, so firing here would
+			// replay a slot from before the schedule existed; seed the row to
+			// the current slot instead and deliver from the next one on. A
+			// paused schedule advances the same way: slots that pass while it
+			// is paused are skipped, not queued up for the re-enable.
+			if !found || paused {
+				if !found || fired.Before(slot) {
+					s.setScheduledLastFired(schedule.ID, via, slot)
+				}
+				continue
+			}
+			if fired.Before(slot) {
 				pending = append(pending, via)
 			}
 		}

--- a/pkg/hub/scheduled_notifier.go
+++ b/pkg/hub/scheduled_notifier.go
@@ -229,9 +229,18 @@ func (s *Server) runScheduledDelivery(ctx context.Context, nowAt time.Time, cfg 
 	}
 	builder, found := scheduledReport(schedule.Report)
 	if !found {
-		log.Printf("[notify] scheduled report %q is not registered", schedule.Report)
+		// A report this build does not carry is a state validation deliberately
+		// keeps saveable (scheduledReportUnchanged): fired never advances, so
+		// this branch re-runs every minute for the life of the process. Warn
+		// once per (schedule, report) — the NUL joiner is the same state-key
+		// hygiene as scheduledStateKey — instead of the unbounded per-minute
+		// repetition the build-failure branch below is explicitly capped to
+		// avoid; the key clears the moment the report becomes registered.
+		s.logPollWarningOnce(scheduledReportWarningKey(schedule),
+			"[notify] scheduled report %q is not registered", schedule.Report)
 		return
 	}
+	s.clearPollWarning(scheduledReportWarningKey(schedule))
 	buildCtx, cancelBuild := context.WithTimeout(ctx, scheduledSendTimeout)
 	message, hasReport, err := builder(buildCtx, s)
 	cancelBuild()
@@ -445,6 +454,13 @@ func scheduledNotificationSlot(nowAt time.Time, schedule types.ScheduledNotifica
 		}
 	}
 	return time.Time{}, false
+}
+
+// scheduledReportWarningKey keys the once-per-process "not registered" warning
+// for a schedule's report. The report name is part of the key so editing a
+// schedule from one unregistered report to another still logs the new name.
+func scheduledReportWarningKey(schedule types.ScheduledNotificationConfig) string {
+	return "scheduled-report:" + schedule.ID + "\x00" + schedule.Report
 }
 
 const scheduledStateKeyPrefix = "scheduled:last_fired:"

--- a/pkg/hub/scheduled_notifier.go
+++ b/pkg/hub/scheduled_notifier.go
@@ -3,7 +3,6 @@ package hub
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"log"
 	"runtime/debug"
 	"sort"
@@ -198,9 +197,14 @@ func (s *Server) runScheduledDelivery(ctx context.Context, nowAt time.Time, cfg 
 		via := strings.TrimSpace(via)
 		fired, firedDigest, found, err := s.scheduledLastFired(schedule.ID, via)
 		if err != nil {
-			log.Printf("[notify] read scheduled state for %s via %s: %v", schedule.ID, via, err)
+			// A persistently erroring read (a wedged DB) re-runs this branch
+			// every minute; warn once per (schedule, via) — cleared on the
+			// next successful read — like the unregistered-report branch below.
+			s.logPollWarningOnce(scheduledStateWarningKey(schedule.ID, via),
+				"[notify] read scheduled state for %s via %s: %v", schedule.ID, via, err)
 			continue
 		}
+		s.clearPollWarning(scheduledStateWarningKey(schedule.ID, via))
 		// A destination with no state row is one this hub has never
 		// delivered to — a schedule (or via) just created or first seen.
 		// The slot search reaches up to 8 days back, so firing here would
@@ -397,6 +401,25 @@ func (s *Server) pruneScheduledState(scheduled []types.ScheduledNotificationConf
 		}
 	}
 	s.scheduledFailureMu.Unlock()
+	// The once-per-process warning keys get the same hygiene: clearPollWarning
+	// for them only runs inside runScheduledDelivery's branches, which never
+	// execute again once the schedule (or the whole block) is removed — the
+	// entries would leak for the process lifetime, and a schedule later
+	// re-added with the same (id, report) would log nothing at all.
+	configuredWarnings := map[string]bool{}
+	for _, schedule := range scheduled {
+		configuredWarnings[scheduledReportWarningKey(schedule)] = true
+		for _, via := range schedule.Via {
+			configuredWarnings[scheduledStateWarningKey(schedule.ID, strings.TrimSpace(via))] = true
+		}
+	}
+	s.pollWarningMu.Lock()
+	for key := range s.pollWarnings {
+		if (strings.HasPrefix(key, scheduledReportWarningKeyPrefix) || strings.HasPrefix(key, scheduledStateWarningKeyPrefix)) && !configuredWarnings[key] {
+			delete(s.pollWarnings, key)
+		}
+	}
+	s.pollWarningMu.Unlock()
 }
 
 func scheduledNotificationSlot(nowAt time.Time, schedule types.ScheduledNotificationConfig) (time.Time, bool) {
@@ -456,11 +479,21 @@ func scheduledNotificationSlot(nowAt time.Time, schedule types.ScheduledNotifica
 	return time.Time{}, false
 }
 
+const scheduledReportWarningKeyPrefix = "scheduled-report:"
+const scheduledStateWarningKeyPrefix = "scheduled-state:"
+
 // scheduledReportWarningKey keys the once-per-process "not registered" warning
 // for a schedule's report. The report name is part of the key so editing a
 // schedule from one unregistered report to another still logs the new name.
 func scheduledReportWarningKey(schedule types.ScheduledNotificationConfig) string {
-	return "scheduled-report:" + schedule.ID + "\x00" + schedule.Report
+	return scheduledReportWarningKeyPrefix + schedule.ID + "\x00" + schedule.Report
+}
+
+// scheduledStateWarningKey keys the once-per-process warning for a
+// (schedule, destination) whose dedupe-state read keeps failing. The NUL
+// joiner is the same state-key hygiene as scheduledStateKey.
+func scheduledStateWarningKey(id, via string) string {
+	return scheduledStateWarningKeyPrefix + id + "\x00" + via
 }
 
 const scheduledStateKeyPrefix = "scheduled:last_fired:"
@@ -518,7 +551,15 @@ func (s *Server) scheduledLastFired(id, via string) (time.Time, string, bool, er
 	stamp, digest, _ := strings.Cut(raw, "\n")
 	value, err := time.Parse(time.RFC3339, stamp)
 	if err != nil {
-		return time.Time{}, "", false, fmt.Errorf("parse scheduled state %q: %w", raw, err)
+		// A value that does not parse (a partial write, external tampering) is
+		// permanently unreadable: surfacing it as an error would log an
+		// identical line every minute for the life of the process while the
+		// destination never fires. Report the row as absent instead — the
+		// caller reseeds it like a first sight, matching the digest-mismatch
+		// path, so this logs once per corruption (the reseeded row parses) and
+		// the destination delivers from its next slot on.
+		log.Printf("[notify] scheduled state for %s via %s is corrupt (%q) — reseeding from the current slot", id, via, raw)
+		return time.Time{}, "", false, nil
 	}
 	return value, digest, true, nil
 }

--- a/pkg/hub/scheduled_notifier.go
+++ b/pkg/hub/scheduled_notifier.go
@@ -136,90 +136,151 @@ func (s *Server) scheduledNotifierTick(ctx context.Context, nowAt time.Time) {
 	if cfg == nil {
 		return
 	}
+	// Gate on validity like the lifecycle tick does: nothing in the load path
+	// validates a hand-written hub.yaml, and an invalid scheduled block can
+	// misbehave without any error surfacing — two schedules sharing an id map
+	// to one dedupe row and mutually reseed each other every tick, delivering
+	// nothing. The shared "notify-config" key keeps the warning to one line
+	// across both ticks.
+	if err := types.ValidateNotificationsConfig(cfg); err != nil {
+		s.logPollWarningOnce("notify-config", "[notify] invalid notifications config — notifications paused: %v", err)
+		return
+	}
+	s.clearPollWarning("notify-config")
 	s.pruneScheduledState(cfg.Scheduled)
 	for _, schedule := range cfg.Scheduled {
-		slot, ok := scheduledNotificationSlot(nowAt, schedule)
-		if !ok {
-			continue
-		}
-		paused := schedule.Enabled != nil && !*schedule.Enabled
-		digest := scheduledSlotDigest(schedule)
-		pending := make([]string, 0, len(schedule.Via))
-		for _, via := range schedule.Via {
-			fired, firedDigest, found, err := s.scheduledLastFired(schedule.ID, via)
-			if err != nil {
-				log.Printf("[notify] read scheduled state for %s via %s: %v", schedule.ID, via, err)
-				continue
-			}
-			// A destination with no state row is one this hub has never
-			// delivered to — a schedule (or via) just created or first seen.
-			// The slot search reaches up to 8 days back, so firing here would
-			// replay a slot from before the schedule existed; seed the row to
-			// the current slot instead and deliver from the next one on. A
-			// row whose slot digest no longer matches was written under a
-			// pre-edit at/timezone/weekdays definition: firing against it
-			// would post an off-schedule send the moment the edit is saved,
-			// so it is reseeded like a first sight and the edited schedule
-			// delivers from its next slot on. A paused schedule advances the
-			// same way: slots that pass while it is paused are skipped, not
-			// queued up for the re-enable.
-			edited := firedDigest != digest
-			if !found || edited || paused {
-				if !found || edited || fired.Before(slot) {
-					s.setScheduledLastFired(schedule.ID, via, slot, digest)
-				}
-				continue
-			}
-			if fired.Before(slot) {
-				pending = append(pending, via)
-			}
-		}
-		if len(pending) == 0 {
-			continue
-		}
-		builder, found := scheduledReport(schedule.Report)
-		if !found {
-			log.Printf("[notify] scheduled report %q is not registered", schedule.Report)
-			continue
-		}
-		buildCtx, cancelBuild := context.WithTimeout(ctx, scheduledSendTimeout)
-		message, hasReport, err := builder(buildCtx, s)
-		cancelBuild()
-		if err != nil {
-			log.Printf("[notify] build scheduled report %q: %v", schedule.Report, err)
-			continue
-		}
-		if !hasReport {
+		s.runScheduledDelivery(ctx, nowAt, cfg, schedule)
+	}
+}
+
+// runScheduledDelivery seeds, builds, and sends one schedule's due slot. Its
+// recover contains a deterministic panic (a report-builder bug) to THIS
+// schedule: the tick-level recover alone would unwind the whole cfg.Scheduled
+// loop, permanently starving every schedule after the panicking one in config
+// order. The panicking schedule's still-pending destinations get their slot
+// burned — analogous to the transient-failure cap — so the panic does not also
+// log a stack trace every minute for the rest of the slot.
+func (s *Server) runScheduledDelivery(ctx context.Context, nowAt time.Time, cfg *types.NotificationsConfig, schedule types.ScheduledNotificationConfig) {
+	var (
+		slot    time.Time
+		digest  string
+		pending []string
+	)
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("[notify] scheduled report %q panicked — burning its %s slot: %v\n%s", schedule.Report, slot.Format(time.RFC3339), r, debug.Stack())
+			// Re-marking a destination already delivered this slot is an
+			// idempotent upsert of the same value, so the whole pending set
+			// can be burned without tracking how far the send loop got.
 			for _, via := range pending {
 				s.setScheduledLastFired(schedule.ID, via, slot, digest)
 			}
+		}
+	}()
+	slot, ok := scheduledNotificationSlot(nowAt, schedule)
+	if !ok {
+		return
+	}
+	paused := schedule.Enabled != nil && !*schedule.Enabled
+	digest = scheduledSlotDigest(schedule)
+	for _, via := range schedule.Via {
+		// TrimSpace matches the lifecycle runtime and doctor, both of which
+		// resolve the trimmed name: an untrimmed via from a hand-written
+		// hub.yaml would otherwise miss the notifier map here and burn one
+		// slot per day as "permanently failed" while doctor reports it green.
+		via := strings.TrimSpace(via)
+		fired, firedDigest, found, err := s.scheduledLastFired(schedule.ID, via)
+		if err != nil {
+			log.Printf("[notify] read scheduled state for %s via %s: %v", schedule.ID, via, err)
 			continue
 		}
-		for _, via := range pending {
-			notifier, err := s.notifierFor(via, cfg.Notifiers[via], s.hubSecretResolver())
-			constructionFailed := err != nil
-			if err == nil {
-				sendCtx, cancelSend := context.WithTimeout(ctx, scheduledSendTimeout)
-				_, err = notifier.Send(sendCtx, *message)
-				cancelSend()
-			}
-			if err == nil {
-				s.clearScheduledTransientFailures(schedule.ID, via)
+		// A destination with no state row is one this hub has never
+		// delivered to — a schedule (or via) just created or first seen.
+		// The slot search reaches up to 8 days back, so firing here would
+		// replay a slot from before the schedule existed; seed the row to
+		// the current slot instead and deliver from the next one on. A
+		// row whose slot digest no longer matches was written under a
+		// pre-edit at/timezone/weekdays definition: firing against it
+		// would post an off-schedule send the moment the edit is saved,
+		// so it is reseeded like a first sight and the edited schedule
+		// delivers from its next slot on. A paused schedule advances the
+		// same way: slots that pass while it is paused are skipped, not
+		// queued up for the re-enable.
+		edited := firedDigest != digest
+		if !found || edited || paused {
+			if !found || edited || fired.Before(slot) {
 				s.setScheduledLastFired(schedule.ID, via, slot, digest)
-				continue
 			}
-			if !constructionFailed && notify.Classify(err) == notify.ErrorTransient {
-				if count := s.noteScheduledTransientFailure(schedule.ID, via, slot); count < scheduledMaxTransientFailures {
-					log.Printf("[notify] send scheduled report %q via %s (failure %d/%d, will retry): %v", schedule.Report, via, count, scheduledMaxTransientFailures, err)
-					continue
-				}
-				log.Printf("[notify] giving up on scheduled report %q via %s after %d consecutive transient failures: %v", schedule.Report, via, scheduledMaxTransientFailures, err)
-			} else {
-				log.Printf("[notify] permanently failed scheduled report %q via %s: %v", schedule.Report, via, err)
-			}
-			s.clearScheduledTransientFailures(schedule.ID, via)
+			continue
+		}
+		if fired.Before(slot) {
+			pending = append(pending, via)
+		}
+	}
+	if len(pending) == 0 {
+		return
+	}
+	builder, found := scheduledReport(schedule.Report)
+	if !found {
+		log.Printf("[notify] scheduled report %q is not registered", schedule.Report)
+		return
+	}
+	buildCtx, cancelBuild := context.WithTimeout(ctx, scheduledSendTimeout)
+	message, hasReport, err := builder(buildCtx, s)
+	cancelBuild()
+	if err != nil {
+		// A failing build gets the same bounded retry budget as a failing
+		// send: fired never advances on a build error, so a persistently
+		// erroring builder (a wedged DB, an empty tenants table) would
+		// otherwise rebuild and log the identical line every minute for the
+		// life of the process.
+		if count := s.noteScheduledTransientFailure(schedule.ID, scheduledBuildFailureVia, slot); count < scheduledMaxTransientFailures {
+			log.Printf("[notify] build scheduled report %q (failure %d/%d, will retry): %v", schedule.Report, count, scheduledMaxTransientFailures, err)
+			return
+		}
+		log.Printf("[notify] giving up on scheduled report %q after %d consecutive build failures: %v", schedule.Report, scheduledMaxTransientFailures, err)
+		s.clearScheduledTransientFailures(schedule.ID, scheduledBuildFailureVia)
+		for _, via := range pending {
 			s.setScheduledLastFired(schedule.ID, via, slot, digest)
 		}
+		return
+	}
+	s.clearScheduledTransientFailures(schedule.ID, scheduledBuildFailureVia)
+	if !hasReport {
+		for _, via := range pending {
+			s.setScheduledLastFired(schedule.ID, via, slot, digest)
+		}
+		return
+	}
+	for _, via := range pending {
+		notifier, err := s.notifierFor(via, cfg.Notifiers[via], s.hubSecretResolver())
+		constructionFailed := err != nil
+		if err == nil {
+			sendCtx, cancelSend := context.WithTimeout(ctx, scheduledSendTimeout)
+			_, err = notifier.Send(sendCtx, *message)
+			cancelSend()
+		}
+		if err == nil {
+			s.clearScheduledTransientFailures(schedule.ID, via)
+			s.setScheduledLastFired(schedule.ID, via, slot, digest)
+			continue
+		}
+		// A notifier that cannot be constructed right now (a secret
+		// mid-rotation, a config half-applied) is retried on the transient
+		// budget, mirroring the lifecycle notifier's hold-until-buildable —
+		// but bounded by the cap, so a genuinely dead notifier still burns
+		// the slot instead of holding it forever.
+		if constructionFailed || notify.Classify(err) == notify.ErrorTransient {
+			if count := s.noteScheduledTransientFailure(schedule.ID, via, slot); count < scheduledMaxTransientFailures {
+				log.Printf("[notify] send scheduled report %q via %s (failure %d/%d, will retry): %v", schedule.Report, via, count, scheduledMaxTransientFailures, err)
+				continue
+			}
+			log.Printf("[notify] giving up on scheduled report %q via %s after %d consecutive transient failures: %v", schedule.Report, via, scheduledMaxTransientFailures, err)
+		} else {
+			log.Printf("[notify] permanently failed scheduled report %q via %s: %v", schedule.Report, via, err)
+		}
+		s.clearScheduledTransientFailures(schedule.ID, via)
+		s.setScheduledLastFired(schedule.ID, via, slot, digest)
 	}
 }
 
@@ -228,11 +289,21 @@ type scheduledFailureStreak struct {
 	count int
 }
 
-// noteScheduledTransientFailure records one more consecutive transient send
+// scheduledBuildFailureVia keys a schedule's report-build failure streak in
+// scheduledTransientFailures. The report is built once per tick per schedule,
+// not per destination, so the build streak is keyed by the schedule alone; the
+// NUL prefix cannot collide with a real via, which validation bans control
+// characters from.
+const scheduledBuildFailureVia = "\x00build"
+
+// noteScheduledTransientFailure records one more consecutive transient
 // failure for the destination's current slot and returns the streak length.
-// Ticks run serially in one goroutine, so the map needs no lock; a slot
-// change resets the streak, so stale entries can never charge a later slot.
+// A slot change resets the streak, so stale entries can never charge a later
+// slot. The map is shared between the serial tick goroutine and the settings
+// PATCH handler (pruneScheduledState), hence the lock.
 func (s *Server) noteScheduledTransientFailure(id, via string, slot time.Time) int {
+	s.scheduledFailureMu.Lock()
+	defer s.scheduledFailureMu.Unlock()
 	if s.scheduledTransientFailures == nil {
 		s.scheduledTransientFailures = map[string]scheduledFailureStreak{}
 	}
@@ -247,6 +318,8 @@ func (s *Server) noteScheduledTransientFailure(id, via string, slot time.Time) i
 }
 
 func (s *Server) clearScheduledTransientFailures(id, via string) {
+	s.scheduledFailureMu.Lock()
+	defer s.scheduledFailureMu.Unlock()
 	delete(s.scheduledTransientFailures, scheduledStateKey(id, via))
 }
 
@@ -257,12 +330,21 @@ func (s *Server) clearScheduledTransientFailures(id, via string) {
 // belongs to the removal window, and orphaned rows would otherwise accumulate
 // forever. Rows in a superseded key format fall out here too, as keys no
 // configured pair produces.
+//
+// Beyond the minute tick, the settings PATCH handler calls this after a
+// persisted notifications update: a schedule deleted and re-added under the
+// same id within one tick interval would otherwise inherit the stale row and
+// replay a slot from before the new schedule existed.
 func (s *Server) pruneScheduledState(scheduled []types.ScheduledNotificationConfig) {
 	configured := map[string]bool{}
 	for _, schedule := range scheduled {
 		for _, via := range schedule.Via {
-			configured[scheduledStateKey(schedule.ID, via)] = true
+			configured[scheduledStateKey(schedule.ID, strings.TrimSpace(via))] = true
 		}
+		// The build-failure streak key never reaches the DB, but it must
+		// count as configured so the in-memory prune below keeps a live
+		// build streak.
+		configured[scheduledStateKey(schedule.ID, scheduledBuildFailureVia)] = true
 	}
 	rows, err := s.db.Query(`SELECT key FROM slack_notifier_state WHERE key LIKE ?`, scheduledStateKeyPrefix+"%")
 	if err != nil {
@@ -287,6 +369,18 @@ func (s *Server) pruneScheduledState(scheduled []types.ScheduledNotificationConf
 			log.Printf("[notify] prune scheduled state %q: %v", key, err)
 		}
 	}
+	// Drop the in-memory failure streaks of removed pairs too, mirroring
+	// clearLifecycleTransientFailures: a streak entry is otherwise cleared
+	// only from the send path of still-configured pairs, so a pair removed
+	// mid-streak would leak its entry for the process lifetime and hand a
+	// same-slot re-add a retry budget already spent.
+	s.scheduledFailureMu.Lock()
+	for key := range s.scheduledTransientFailures {
+		if !configured[key] {
+			delete(s.scheduledTransientFailures, key)
+		}
+	}
+	s.scheduledFailureMu.Unlock()
 }
 
 func scheduledNotificationSlot(nowAt time.Time, schedule types.ScheduledNotificationConfig) (time.Time, bool) {
@@ -355,8 +449,23 @@ func scheduledStateKey(id, via string) string {
 // timezone, or weekdays reads back as a digest mismatch and the row is
 // reseeded like a first sight, instead of the pre-edit history counting as
 // the new definition's own and firing an off-schedule send.
+//
+// At and Timezone are normalized so semantically identical definitions cannot
+// read back as an edit: a hand-written "9:00" is zero-padded by any settings
+// save (normalizeScheduledTimes), and the edit dialog seeds an absent
+// timezone as the "UTC" the scheduler already defaults to. Without this, a
+// representation-only rewrite reseeds every (id, via) row like a real edit
+// and silently skips a pending or mid-retry slot.
 func scheduledSlotDigest(schedule types.ScheduledNotificationConfig) string {
-	return schedule.At + "\x1f" + schedule.Timezone + "\x1f" + strings.Join(schedule.Weekdays, ",")
+	at := schedule.At
+	if parsed, err := time.Parse("15:04", strings.TrimSpace(at)); err == nil {
+		at = parsed.Format("15:04")
+	}
+	timezone := schedule.Timezone
+	if timezone == "" {
+		timezone = "UTC"
+	}
+	return at + "\x1f" + timezone + "\x1f" + strings.Join(schedule.Weekdays, ",")
 }
 
 func (s *Server) scheduledLastFired(id, via string) (time.Time, string, bool, error) {

--- a/pkg/hub/scheduled_notifier.go
+++ b/pkg/hub/scheduled_notifier.go
@@ -134,19 +134,26 @@ func (s *Server) stopScheduledNotifier(timeout time.Duration) {
 func (s *Server) scheduledNotifierTick(ctx context.Context, nowAt time.Time) {
 	cfg := s.notificationsConfig()
 	if cfg == nil {
+		// A removed notifications block must still clear the scheduled dedupe
+		// rows, exactly as removing every schedule does: nothing else prunes
+		// them, and a block re-added days later with an identical schedule
+		// would otherwise inherit the stale row and replay a slot from the
+		// removal window instead of seeding on first sight.
+		s.pruneScheduledState(nil)
 		return
 	}
 	// Gate on validity like the lifecycle tick does: nothing in the load path
 	// validates a hand-written hub.yaml, and an invalid scheduled block can
 	// misbehave without any error surfacing — two schedules sharing an id map
 	// to one dedupe row and mutually reseed each other every tick, delivering
-	// nothing. The shared "notify-config" key keeps the warning to one line
-	// across both ticks.
-	if err := types.ValidateNotificationsConfig(cfg); err != nil {
-		s.logPollWarningOnce("notify-config", "[notify] invalid notifications config — notifications paused: %v", err)
+	// nothing. Only the config this tick consumes is judged (notifiers plus
+	// the scheduled block, under this tick's own warning key): a defect in the
+	// lifecycle block pauses lifecycle alerts, never scheduled reports.
+	if err := types.ValidateScheduledNotificationsConfig(cfg); err != nil {
+		s.logPollWarningOnce("scheduled-config", "[notify] invalid notifications config — scheduled reports paused: %v", err)
 		return
 	}
-	s.clearPollWarning("notify-config")
+	s.clearPollWarning("scheduled-config")
 	s.pruneScheduledState(cfg.Scheduled)
 	for _, schedule := range cfg.Scheduled {
 		s.runScheduledDelivery(ctx, nowAt, cfg, schedule)
@@ -401,8 +408,15 @@ func scheduledNotificationSlot(nowAt time.Time, schedule types.ScheduledNotifica
 	for _, weekday := range schedule.Weekdays {
 		allowed[weekday] = true
 	}
+	year, month, dayOfMonth := localNow.Date()
 	for daysAgo := 0; daysAgo < 8; daysAgo++ {
-		day := localNow.AddDate(0, 0, -daysAgo)
+		// Civil-date arithmetic (in UTC, where no gaps exist): AddDate on
+		// localNow would carry its wall time along, and when that lands in a
+		// midnight DST spring-forward gap Go normalizes it onto the previous
+		// date — the walk then visits that date twice and never the
+		// transition day, so restart catch-up could return an older slot
+		// than the latest (a double delivery) or transiently none at all.
+		day := time.Date(year, month, dayOfMonth-daysAgo, 12, 0, 0, 0, time.UTC)
 		weekday := strings.ToLower(day.Weekday().String()[:3])
 		if len(allowed) != 0 && !allowed[weekday] {
 			continue
@@ -465,7 +479,13 @@ func scheduledSlotDigest(schedule types.ScheduledNotificationConfig) string {
 	if timezone == "" {
 		timezone = "UTC"
 	}
-	return at + "\x1f" + timezone + "\x1f" + strings.Join(schedule.Weekdays, ",")
+	// Weekdays are an unordered set everywhere else (scheduledNotificationSlot,
+	// validation), and the settings screen's chips append in click order: a
+	// semantically identical reorder must not read back as an edit — it would
+	// reseed every (id, via) row and silently skip the pending slot.
+	weekdays := append([]string(nil), schedule.Weekdays...)
+	sort.Strings(weekdays)
+	return at + "\x1f" + timezone + "\x1f" + strings.Join(weekdays, ",")
 }
 
 func (s *Server) scheduledLastFired(id, via string) (time.Time, string, bool, error) {

--- a/pkg/hub/scheduled_notifier.go
+++ b/pkg/hub/scheduled_notifier.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"runtime/debug"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -33,6 +34,20 @@ func ScheduledReportSupported(name string) bool {
 	defer scheduledReportRegistry.RUnlock()
 	_, ok := scheduledReportRegistry.builders[name]
 	return ok
+}
+
+// scheduledReportNames lists every registered report, sorted. It backs the
+// error text a rejected report name gets and the doctor check for a schedule
+// naming a report this build does not carry.
+func scheduledReportNames() []string {
+	scheduledReportRegistry.RLock()
+	defer scheduledReportRegistry.RUnlock()
+	names := make([]string, 0, len(scheduledReportRegistry.builders))
+	for name := range scheduledReportRegistry.builders {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
 }
 
 func scheduledReport(name string) (scheduledReportBuilder, bool) {

--- a/pkg/hub/scheduled_notifier_test.go
+++ b/pkg/hub/scheduled_notifier_test.go
@@ -200,6 +200,10 @@ func TestScheduledNotifierEmptyReportMarksFiredWithoutSending(t *testing.T) {
 	schedule := types.ScheduledNotificationConfig{ID: "empty", Report: "empty-test-report", Via: []string{testNotifierName}, At: "09:00"}
 	s, _ := newScheduledNotifierTestServer(t, fake.server.URL, []types.ScheduledNotificationConfig{schedule})
 
+	// Arm the schedule with a pre-slot tick, as the minutely production loop
+	// would: the first tick a schedule is ever seen on only seeds its state.
+	s.scheduledNotifierTick(time.Date(2025, 1, 6, 8, 30, 0, 0, time.UTC))
+
 	nowAt := time.Date(2025, 1, 6, 9, 30, 0, 0, time.UTC)
 	s.scheduledNotifierTick(nowAt)
 	if fake.count() != 0 {
@@ -227,6 +231,10 @@ func TestScheduledNotifierDedupeAcrossSimulatedRestart(t *testing.T) {
 	fake := newFakeSlackServer(t)
 	schedule := types.ScheduledNotificationConfig{ID: "dedupe", Report: "dedupe-test-report", Via: []string{testNotifierName}, At: "09:00"}
 	s, db := newScheduledNotifierTestServer(t, fake.server.URL, []types.ScheduledNotificationConfig{schedule})
+
+	// Arm the schedule with a pre-slot tick (production ticks every minute,
+	// so a schedule created before its slot is always seen before it).
+	s.scheduledNotifierTick(time.Date(2025, 1, 6, 8, 30, 0, 0, time.UTC))
 
 	slotTime := time.Date(2025, 1, 6, 9, 30, 0, 0, time.UTC)
 	s.scheduledNotifierTick(slotTime)
@@ -272,16 +280,21 @@ func TestScheduledNotifierPerNotifierPartialFailureRetries(t *testing.T) {
 	}
 	s, _ := newScheduledNotifierTestServer(t, fake.server.URL, []types.ScheduledNotificationConfig{schedule})
 
+	// Arm both destinations before the slot: the first tick a schedule is
+	// ever seen on only seeds its state, posting nothing to Slack.
+	s.scheduledNotifierTick(time.Date(2025, 1, 6, 8, 30, 0, 0, time.UTC))
+
 	slotTime := time.Date(2025, 1, 6, 9, 30, 0, 0, time.UTC)
+	slot := time.Date(2025, 1, 6, 9, 0, 0, 0, time.UTC)
 	s.scheduledNotifierTick(slotTime)
 	if fake.count() != 2 {
 		t.Fatalf("tick sent %d messages, want 2 (one failed, one ok)", fake.count())
 	}
-	if _, found, _ := s.scheduledLastFired("partial", testNotifierName); found {
+	if fired, _, _ := s.scheduledLastFired("partial", testNotifierName); fired.Equal(slot) {
 		t.Fatal("failed notifier state was advanced despite a transient error")
 	}
-	if _, found, _ := s.scheduledLastFired("partial", "second-notifier"); !found {
-		t.Fatal("succeeding notifier state was not recorded")
+	if fired, _, _ := s.scheduledLastFired("partial", "second-notifier"); !fired.Equal(slot) {
+		t.Fatalf("succeeding notifier state = %v, want the slot recorded", fired)
 	}
 
 	// Next tick, same slot: only the previously-failed destination retries.
@@ -290,7 +303,79 @@ func TestScheduledNotifierPerNotifierPartialFailureRetries(t *testing.T) {
 	if fake.count() != 3 {
 		t.Fatalf("retry tick sent %d messages, want 3 (1 retry)", fake.count())
 	}
-	if _, found, _ := s.scheduledLastFired("partial", testNotifierName); !found {
-		t.Fatal("retried notifier state was not recorded after success")
+	if fired, _, _ := s.scheduledLastFired("partial", testNotifierName); !fired.Equal(slot) {
+		t.Fatalf("retried notifier state = %v, want the slot recorded after success", fired)
+	}
+}
+
+// A schedule seen for the first time AFTER its slot passed must wait for the
+// next occurrence: the slot search reaches up to 8 days back, so a newly
+// created (or newly re-routed) schedule would otherwise replay a stale slot
+// the moment it is saved.
+func TestScheduledNotifierNewScheduleDoesNotReplayPastSlot(t *testing.T) {
+	registerScheduledReport("no-replay-report", func(context.Context, *Server) (*notify.Message, bool, error) {
+		return &notify.Message{Title: "report", Body: "body"}, true, nil
+	})
+	fake := newFakeSlackServer(t)
+	schedule := types.ScheduledNotificationConfig{ID: "fresh", Report: "no-replay-report", Via: []string{testNotifierName}, At: "09:00"}
+	s, _ := newScheduledNotifierTestServer(t, fake.server.URL, []types.ScheduledNotificationConfig{schedule})
+
+	// First tick, hours after today's slot: seed, don't send.
+	nowAt := time.Date(2025, 1, 6, 15, 0, 0, 0, time.UTC)
+	s.scheduledNotifierTick(nowAt)
+	if fake.count() != 0 {
+		t.Fatalf("first sight of the schedule replayed a past slot: %d sends, want 0", fake.count())
+	}
+	fired, found, err := s.scheduledLastFired("fresh", testNotifierName)
+	if err != nil || !found {
+		t.Fatalf("scheduledLastFired: %v, found=%v — first sight must seed the state row", err, found)
+	}
+	if !fired.Equal(time.Date(2025, 1, 6, 9, 0, 0, 0, time.UTC)) {
+		t.Fatalf("seeded slot = %v, want today's 09:00", fired)
+	}
+
+	// The next occurrence fires normally.
+	s.scheduledNotifierTick(time.Date(2025, 1, 7, 9, 0, 30, 0, time.UTC))
+	if fake.count() != 1 {
+		t.Fatalf("next day's slot sent %d messages, want 1", fake.count())
+	}
+}
+
+// Slots that pass while a schedule is paused are skipped, not queued: the
+// re-enable must wait for its next occurrence instead of replaying whatever
+// slot last passed during the pause.
+func TestScheduledNotifierPausedScheduleSkipsSlotsUntilReEnabled(t *testing.T) {
+	registerScheduledReport("pause-skip-report", func(context.Context, *Server) (*notify.Message, bool, error) {
+		return &notify.Message{Title: "report", Body: "body"}, true, nil
+	})
+	fake := newFakeSlackServer(t)
+	schedule := types.ScheduledNotificationConfig{ID: "paused", Report: "pause-skip-report", Via: []string{testNotifierName}, At: "09:00"}
+	s, _ := newScheduledNotifierTestServer(t, fake.server.URL, []types.ScheduledNotificationConfig{schedule})
+
+	// Arm and fire once while enabled.
+	s.scheduledNotifierTick(time.Date(2025, 1, 6, 8, 30, 0, 0, time.UTC))
+	s.scheduledNotifierTick(time.Date(2025, 1, 6, 9, 30, 0, 0, time.UTC))
+	if fake.count() != 1 {
+		t.Fatalf("enabled slot sent %d messages, want 1", fake.count())
+	}
+
+	// Pause; the next day's slot passes silently but advances the state.
+	disabled := false
+	s.hubCfg.Notifications.Scheduled[0].Enabled = &disabled
+	s.scheduledNotifierTick(time.Date(2025, 1, 7, 9, 30, 0, 0, time.UTC))
+	if fake.count() != 1 {
+		t.Fatalf("paused slot sent %d messages, want still 1", fake.count())
+	}
+
+	// Re-enable after the slot: nothing to replay, next occurrence fires.
+	enabled := true
+	s.hubCfg.Notifications.Scheduled[0].Enabled = &enabled
+	s.scheduledNotifierTick(time.Date(2025, 1, 7, 15, 0, 0, 0, time.UTC))
+	if fake.count() != 1 {
+		t.Fatalf("re-enable replayed the slot that passed while paused: %d sends, want 1", fake.count())
+	}
+	s.scheduledNotifierTick(time.Date(2025, 1, 8, 9, 0, 30, 0, time.UTC))
+	if fake.count() != 2 {
+		t.Fatalf("next slot after re-enable sent %d messages, want 2", fake.count())
 	}
 }

--- a/pkg/hub/scheduled_notifier_test.go
+++ b/pkg/hub/scheduled_notifier_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 	"testing"
@@ -501,5 +502,217 @@ func TestScheduledNotifierPrunesRemovedScheduleState(t *testing.T) {
 	s.scheduledNotifierTick(context.Background(), time.Date(2025, 1, 6, 15, 2, 0, 0, time.UTC))
 	if fake.count() != 0 {
 		t.Fatalf("re-created schedule replayed a stale slot: %d sends, want 0", fake.count())
+	}
+}
+
+// A deterministic panic in one schedule's report builder must be contained to
+// that schedule: the tick-level recover alone unwinds the whole loop and
+// permanently starves every schedule after the panicking one in config order.
+// The panicking schedule's slot is burned so it does not also log a stack
+// trace every minute.
+func TestScheduledNotifierPanickingBuilderDoesNotStarveLaterSchedules(t *testing.T) {
+	panics := 0
+	registerScheduledReport("panicking-report", func(context.Context, *Server) (*notify.Message, bool, error) {
+		panics++
+		panic("builder bug")
+	})
+	registerScheduledReport("healthy-report", func(context.Context, *Server) (*notify.Message, bool, error) {
+		return &notify.Message{Title: "report", Body: "body"}, true, nil
+	})
+	fake := newFakeSlackServer(t)
+	schedules := []types.ScheduledNotificationConfig{
+		{ID: "bad", Report: "panicking-report", Via: []string{testNotifierName}, At: "09:00"},
+		{ID: "good", Report: "healthy-report", Via: []string{testNotifierName}, At: "09:00"},
+	}
+	s, _ := newScheduledNotifierTestServer(t, fake.server.URL, schedules)
+
+	s.scheduledNotifierTick(context.Background(), time.Date(2025, 1, 6, 8, 30, 0, 0, time.UTC))
+	s.scheduledNotifierTick(context.Background(), time.Date(2025, 1, 6, 9, 30, 0, 0, time.UTC))
+	if fake.count() != 1 {
+		t.Fatalf("schedule after the panicking one sent %d messages, want 1", fake.count())
+	}
+	slot := time.Date(2025, 1, 6, 9, 0, 0, 0, time.UTC)
+	if fired, _, _, _ := s.scheduledLastFired("bad", testNotifierName); !fired.Equal(slot) {
+		t.Fatalf("panicking schedule's slot = %v, want it burned to %v", fired, slot)
+	}
+
+	// The burned slot stops the minutely re-panic for the rest of the day.
+	s.scheduledNotifierTick(context.Background(), time.Date(2025, 1, 6, 9, 31, 0, 0, time.UTC))
+	if panics != 1 {
+		t.Fatalf("builder panicked %d times, want 1 (slot burned after the first)", panics)
+	}
+}
+
+// An invalid scheduled block (here: two schedules sharing an id, which would
+// map to one dedupe row and mutually reseed each other forever) pauses the
+// tick with a warning instead of running live, mirroring the lifecycle tick's
+// ValidateNotificationsConfig gate.
+func TestScheduledNotifierInvalidConfigPausesDeliveries(t *testing.T) {
+	registerScheduledReport("invalid-config-report", func(context.Context, *Server) (*notify.Message, bool, error) {
+		return &notify.Message{Title: "report", Body: "body"}, true, nil
+	})
+	fake := newFakeSlackServer(t)
+	schedules := []types.ScheduledNotificationConfig{
+		{ID: "daily", Report: "invalid-config-report", Via: []string{testNotifierName}, At: "09:00"},
+		{ID: "daily", Report: "invalid-config-report", Via: []string{testNotifierName}, At: "17:00"},
+	}
+	s, _ := newScheduledNotifierTestServer(t, fake.server.URL, schedules)
+
+	s.scheduledNotifierTick(context.Background(), time.Date(2025, 1, 6, 8, 30, 0, 0, time.UTC))
+	if _, _, found, _ := s.scheduledLastFired("daily", testNotifierName); found {
+		t.Fatal("invalid config still seeded dedupe state")
+	}
+	s.scheduledNotifierTick(context.Background(), time.Date(2025, 1, 6, 9, 30, 0, 0, time.UTC))
+	if fake.count() != 0 {
+		t.Fatalf("invalid config still delivered %d messages, want 0", fake.count())
+	}
+
+	// Repairing the config resumes the tick (the first sight seeds, as ever).
+	s.hubCfg.Notifications.Scheduled[1].ID = "evening"
+	s.scheduledNotifierTick(context.Background(), time.Date(2025, 1, 6, 9, 31, 0, 0, time.UTC))
+	if _, _, found, _ := s.scheduledLastFired("daily", testNotifierName); !found {
+		t.Fatal("repaired config did not resume seeding")
+	}
+}
+
+// A via with surrounding whitespace resolves and keys state by its trimmed
+// name, matching the lifecycle runtime and doctor: the raw name would miss the
+// notifier map and burn one slot per day as "permanently failed" while doctor
+// reports the schedule green.
+func TestScheduledNotifierTrimsViaWhitespace(t *testing.T) {
+	registerScheduledReport("trim-via-report", func(context.Context, *Server) (*notify.Message, bool, error) {
+		return &notify.Message{Title: "report", Body: "body"}, true, nil
+	})
+	fake := newFakeSlackServer(t)
+	schedule := types.ScheduledNotificationConfig{ID: "trimmed", Report: "trim-via-report", Via: []string{"  " + testNotifierName + " "}, At: "09:00"}
+	s, _ := newScheduledNotifierTestServer(t, fake.server.URL, []types.ScheduledNotificationConfig{schedule})
+
+	s.scheduledNotifierTick(context.Background(), time.Date(2025, 1, 6, 8, 30, 0, 0, time.UTC))
+	if _, _, found, _ := s.scheduledLastFired("trimmed", testNotifierName); !found {
+		t.Fatal("state row is not keyed by the trimmed via")
+	}
+	s.scheduledNotifierTick(context.Background(), time.Date(2025, 1, 6, 9, 30, 0, 0, time.UTC))
+	if fake.count() != 1 {
+		t.Fatalf("untrimmed via sent %d messages, want 1", fake.count())
+	}
+}
+
+// A notifier that cannot be constructed at the slot minute (a secret briefly
+// absent during rotation) retries on the transient budget instead of burning
+// the slot on the first miss, mirroring the lifecycle notifier's
+// hold-until-buildable — but still bounded by the cap.
+func TestScheduledNotifierConstructionFailureRetriesInsteadOfBurningSlot(t *testing.T) {
+	registerScheduledReport("construction-fail-report", func(context.Context, *Server) (*notify.Message, bool, error) {
+		return &notify.Message{Title: "report", Body: "body"}, true, nil
+	})
+	fake := newFakeSlackServer(t)
+	schedule := types.ScheduledNotificationConfig{ID: "rotating", Report: "construction-fail-report", Via: []string{testNotifierName}, At: "09:00"}
+	s, _ := newScheduledNotifierTestServer(t, fake.server.URL, []types.ScheduledNotificationConfig{schedule})
+
+	s.scheduledNotifierTick(context.Background(), time.Date(2025, 1, 6, 8, 30, 0, 0, time.UTC))
+
+	// The bot-token secret vanishes mid-rotation: construction fails.
+	secrets := s.hubCfg.Secrets
+	s.hubCfg.Secrets = map[string]string{}
+	slot := time.Date(2025, 1, 6, 9, 0, 0, 0, time.UTC)
+	s.scheduledNotifierTick(context.Background(), slot.Add(30*time.Minute))
+	if fake.count() != 0 {
+		t.Fatalf("unbuildable notifier sent %d messages, want 0", fake.count())
+	}
+	if fired, _, _, _ := s.scheduledLastFired("rotating", testNotifierName); fired.Equal(slot) {
+		t.Fatal("construction failure burned the slot instead of retrying")
+	}
+
+	// The secret is restored one minute later — well inside the retry budget.
+	s.hubCfg.Secrets = secrets
+	s.scheduledNotifierTick(context.Background(), slot.Add(31*time.Minute))
+	if fake.count() != 1 {
+		t.Fatalf("restored notifier sent %d messages, want 1", fake.count())
+	}
+	if fired, _, _, _ := s.scheduledLastFired("rotating", testNotifierName); !fired.Equal(slot) {
+		t.Fatalf("state = %v, want the slot recorded after the retried send", fired)
+	}
+}
+
+// A persistently erroring report builder gets the same bounded retry budget as
+// a failing send: without it, fired never advances and the builder re-runs and
+// logs the identical line every minute for the life of the process.
+func TestScheduledNotifierBuildFailureRetriesThenBurnsSlot(t *testing.T) {
+	builds := 0
+	registerScheduledReport("build-fail-report", func(context.Context, *Server) (*notify.Message, bool, error) {
+		builds++
+		return nil, false, errors.New("tenants table is empty")
+	})
+	fake := newFakeSlackServer(t)
+	schedule := types.ScheduledNotificationConfig{ID: "broken-build", Report: "build-fail-report", Via: []string{testNotifierName}, At: "09:00"}
+	s, _ := newScheduledNotifierTestServer(t, fake.server.URL, []types.ScheduledNotificationConfig{schedule})
+
+	s.scheduledNotifierTick(context.Background(), time.Date(2025, 1, 6, 8, 30, 0, 0, time.UTC))
+	slot := time.Date(2025, 1, 6, 9, 0, 0, 0, time.UTC)
+	for i := 0; i < scheduledMaxTransientFailures; i++ {
+		s.scheduledNotifierTick(context.Background(), slot.Add(time.Duration(30+i)*time.Minute))
+		fired, _, _, _ := s.scheduledLastFired("broken-build", testNotifierName)
+		if advanced := fired.Equal(slot); advanced != (i == scheduledMaxTransientFailures-1) {
+			t.Fatalf("after build failure %d state advanced=%v, want advance only on the %dth", i+1, advanced, scheduledMaxTransientFailures)
+		}
+	}
+	if builds != scheduledMaxTransientFailures {
+		t.Fatalf("builder ran %d times, want %d", builds, scheduledMaxTransientFailures)
+	}
+
+	// The slot is burned: later ticks in the same slot rebuild nothing.
+	s.scheduledNotifierTick(context.Background(), slot.Add(3*time.Hour))
+	if builds != scheduledMaxTransientFailures {
+		t.Fatalf("burned slot still rebuilt: %d builds", builds)
+	}
+	if fake.count() != 0 {
+		t.Fatalf("failing builds still sent %d messages", fake.count())
+	}
+}
+
+// Semantically identical slot definitions must produce identical digests:
+// normalizeScheduledTimes zero-pads a hand-written "9:00" on any settings
+// save, and the edit dialog seeds an absent timezone as "UTC" — neither
+// rewrite is an edit, and reading one back as a digest mismatch would reseed
+// the row and silently skip a pending or mid-retry slot.
+func TestScheduledSlotDigestNormalizesEquivalentRepresentations(t *testing.T) {
+	base := scheduledSlotDigest(types.ScheduledNotificationConfig{At: "09:00", Timezone: "UTC"})
+	if got := scheduledSlotDigest(types.ScheduledNotificationConfig{At: "9:00"}); got != base {
+		t.Fatalf("unpadded at / empty timezone digest = %q, want %q", got, base)
+	}
+	if scheduledSlotDigest(types.ScheduledNotificationConfig{At: "10:00", Timezone: "UTC"}) == base {
+		t.Fatal("a real at edit must change the digest")
+	}
+	if scheduledSlotDigest(types.ScheduledNotificationConfig{At: "09:00", Timezone: "America/Sao_Paulo"}) == base {
+		t.Fatal("a real timezone edit must change the digest")
+	}
+	if scheduledSlotDigest(types.ScheduledNotificationConfig{At: "09:00", Timezone: "UTC", Weekdays: []string{"mon"}}) == base {
+		t.Fatal("a weekday edit must change the digest")
+	}
+}
+
+// pruneScheduledState clears the in-memory failure streaks of removed pairs
+// too, mirroring clearLifecycleTransientFailures: a pair removed mid-streak
+// would otherwise leak its entry for the process lifetime and hand a same-slot
+// re-add a retry budget already spent.
+func TestPruneScheduledStateClearsRemovedStreaks(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	kept := types.ScheduledNotificationConfig{ID: "kept", Report: "prune-streak-report", Via: []string{testNotifierName}, At: "09:00"}
+	s, _ := newScheduledNotifierTestServer(t, fake.server.URL, []types.ScheduledNotificationConfig{kept})
+
+	slot := time.Date(2025, 1, 6, 9, 0, 0, 0, time.UTC)
+	s.noteScheduledTransientFailure("kept", testNotifierName, slot)
+	s.noteScheduledTransientFailure("kept", scheduledBuildFailureVia, slot)
+	s.noteScheduledTransientFailure("gone", testNotifierName, slot)
+
+	s.pruneScheduledState([]types.ScheduledNotificationConfig{kept})
+	if _, ok := s.scheduledTransientFailures[scheduledStateKey("gone", testNotifierName)]; ok {
+		t.Fatal("removed pair's streak survived the prune")
+	}
+	if _, ok := s.scheduledTransientFailures[scheduledStateKey("kept", testNotifierName)]; !ok {
+		t.Fatal("configured pair's send streak was pruned")
+	}
+	if _, ok := s.scheduledTransientFailures[scheduledStateKey("kept", scheduledBuildFailureVia)]; !ok {
+		t.Fatal("configured schedule's build streak was pruned")
 	}
 }

--- a/pkg/hub/scheduled_notifier_test.go
+++ b/pkg/hub/scheduled_notifier_test.go
@@ -31,6 +31,16 @@ func TestScheduledNotificationSlot(t *testing.T) {
 		// a sun-only 02:30 schedule silently drop a full weekly cycle.
 		{"dst spring forward uses the normalized post-gap instant", "2025-03-09T12:00:00Z", types.ScheduledNotificationConfig{At: "02:30", Timezone: "America/New_York"}, "2025-03-09T07:30:00Z"},
 		{"dst spring forward on the only allowed weekday still yields that day", "2025-03-09T12:00:00Z", types.ScheduledNotificationConfig{At: "02:30", Timezone: "America/New_York", Weekdays: []string{"sun"}}, "2025-03-09T07:30:00Z"},
+		// America/Santiago springs forward at MIDNIGHT (Sun 2026-09-06 00:00
+		// -04 -> 01:00 -03), so the lookback walk itself crosses a gap:
+		// AddDate from localNow would normalize day-2 onto Saturday twice and
+		// never visit the transition Sunday. The civil-date walk must still
+		// find Sunday's (gap-shifted) slot...
+		{"dst midnight gap does not skip the transition day in the walk", "2026-09-08T03:10:00Z", types.ScheduledNotificationConfig{At: "00:30", Timezone: "America/Santiago", Weekdays: []string{"sun"}}, "2026-09-06T04:30:00Z"},
+		// ...and restart catch-up must return the LATEST slot (Sunday's), not
+		// Saturday's — firing an older slot as catch-up would double-deliver
+		// once the current day's slot arrives.
+		{"dst midnight gap catch-up returns the latest slot not an older day's", "2026-09-07T03:10:00Z", types.ScheduledNotificationConfig{At: "00:30", Timezone: "America/Santiago"}, "2026-09-06T04:30:00Z"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -689,6 +699,17 @@ func TestScheduledSlotDigestNormalizesEquivalentRepresentations(t *testing.T) {
 	if scheduledSlotDigest(types.ScheduledNotificationConfig{At: "09:00", Timezone: "UTC", Weekdays: []string{"mon"}}) == base {
 		t.Fatal("a weekday edit must change the digest")
 	}
+	// Weekdays are an unordered set (the settings screen's chips append in
+	// click order): un-ticking and re-ticking a day is not an edit, and a
+	// digest mismatch here would reseed every (id, via) row and silently skip
+	// the pending slot.
+	ordered := scheduledSlotDigest(types.ScheduledNotificationConfig{At: "09:00", Weekdays: []string{"mon", "tue", "wed", "thu", "fri"}})
+	if got := scheduledSlotDigest(types.ScheduledNotificationConfig{At: "09:00", Weekdays: []string{"mon", "tue", "thu", "fri", "wed"}}); got != ordered {
+		t.Fatalf("a weekday reorder changed the digest: %q vs %q", got, ordered)
+	}
+	if scheduledSlotDigest(types.ScheduledNotificationConfig{At: "09:00", Weekdays: []string{"mon", "tue", "wed", "thu"}}) == ordered {
+		t.Fatal("a real weekday-set edit must change the digest")
+	}
 }
 
 // pruneScheduledState clears the in-memory failure streaks of removed pairs
@@ -714,5 +735,74 @@ func TestPruneScheduledStateClearsRemovedStreaks(t *testing.T) {
 	}
 	if _, ok := s.scheduledTransientFailures[scheduledStateKey("kept", scheduledBuildFailureVia)]; !ok {
 		t.Fatal("configured schedule's build streak was pruned")
+	}
+}
+
+// Removing the ENTIRE notifications block prunes the dedupe rows the same way
+// removing every schedule does: the rows would otherwise survive indefinitely,
+// and a block re-added days later with an identical schedule would inherit the
+// stale row and replay a slot from the removal window instead of seeding on
+// first sight.
+func TestScheduledNotifierPrunesStateWhenNotificationsBlockRemoved(t *testing.T) {
+	registerScheduledReport("block-removed-report", func(context.Context, *Server) (*notify.Message, bool, error) {
+		return &notify.Message{Title: "report", Body: "body"}, true, nil
+	})
+	fake := newFakeSlackServer(t)
+	schedule := types.ScheduledNotificationConfig{ID: "survivor", Report: "block-removed-report", Via: []string{testNotifierName}, At: "09:00"}
+	s, db := newScheduledNotifierTestServer(t, fake.server.URL, []types.ScheduledNotificationConfig{schedule})
+
+	// Arm and fire once.
+	s.scheduledNotifierTick(context.Background(), time.Date(2025, 1, 6, 8, 30, 0, 0, time.UTC))
+	s.scheduledNotifierTick(context.Background(), time.Date(2025, 1, 6, 9, 30, 0, 0, time.UTC))
+	if fake.count() != 1 {
+		t.Fatalf("armed slot sent %d messages, want 1", fake.count())
+	}
+
+	// The operator deletes the whole notifications block and restarts.
+	saved := s.hubCfg.Notifications
+	s.hubCfg.Notifications = nil
+	s.scheduledNotifierTick(context.Background(), time.Date(2025, 1, 6, 9, 31, 0, 0, time.UTC))
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM slack_notifier_state WHERE key LIKE 'scheduled:last_fired:%'`).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Fatalf("%d scheduled state rows survive the block's removal, want 0", n)
+	}
+
+	// Re-added days later with the same schedule: first sight seeds — the
+	// slots that passed while the block did not exist are not replayed.
+	s.hubCfg.Notifications = saved
+	s.scheduledNotifierTick(context.Background(), time.Date(2025, 1, 8, 9, 30, 0, 0, time.UTC))
+	if fake.count() != 1 {
+		t.Fatalf("re-added block replayed a removal-window slot: %d sends, want 1", fake.count())
+	}
+	s.scheduledNotifierTick(context.Background(), time.Date(2025, 1, 9, 9, 0, 30, 0, time.UTC))
+	if fake.count() != 2 {
+		t.Fatalf("next slot after the re-add sent %d messages, want 2", fake.count())
+	}
+}
+
+// A DISABLED lifecycle block carrying a duration the composed validator
+// rejects — a state the lifecycle tick itself tolerates by returning before
+// it validates — must not pause scheduled reports: the scheduled tick gates
+// only on the config it consumes (notifiers plus the scheduled block).
+func TestScheduledNotifierRunsDespiteDefectiveDisabledLifecycleBlock(t *testing.T) {
+	registerScheduledReport("lifecycle-defect-report", func(context.Context, *Server) (*notify.Message, bool, error) {
+		return &notify.Message{Title: "report", Body: "body"}, true, nil
+	})
+	fake := newFakeSlackServer(t)
+	schedule := types.ScheduledNotificationConfig{ID: "unaffected", Report: "lifecycle-defect-report", Via: []string{testNotifierName}, At: "09:00"}
+	s, _ := newScheduledNotifierTestServer(t, fake.server.URL, []types.ScheduledNotificationConfig{schedule})
+	disabled := false
+	s.hubCfg.Notifications.Lifecycle = &types.LifecycleNotificationsConfig{Enabled: &disabled, IdleAfter: "30s"}
+	if types.ValidateNotificationsConfig(s.hubCfg.Notifications) == nil {
+		t.Fatal("fixture is supposed to fail the composed validator")
+	}
+
+	s.scheduledNotifierTick(context.Background(), time.Date(2025, 1, 6, 8, 30, 0, 0, time.UTC))
+	s.scheduledNotifierTick(context.Background(), time.Date(2025, 1, 6, 9, 30, 0, 0, time.UTC))
+	if fake.count() != 1 {
+		t.Fatalf("scheduled report was paused by the defective disabled lifecycle block: %d sends, want 1", fake.count())
 	}
 }

--- a/pkg/hub/scheduled_notifier_test.go
+++ b/pkg/hub/scheduled_notifier_test.go
@@ -721,6 +721,78 @@ func TestScheduledNotifierUnregisteredReportWarnsOnceAndRecovers(t *testing.T) {
 	}
 }
 
+// A state row whose value does not parse as RFC3339 (a partial write, external
+// tampering) is permanently unreadable: instead of logging an identical error
+// every minute forever while the destination silently never fires, the row is
+// reseeded like a first sight and the destination delivers from its next slot.
+func TestScheduledNotifierCorruptStateRowReseedsInsteadOfWedging(t *testing.T) {
+	registerScheduledReport("corrupt-state-report", func(context.Context, *Server) (*notify.Message, bool, error) {
+		return &notify.Message{Title: "report", Body: "body"}, true, nil
+	})
+	fake := newFakeSlackServer(t)
+	schedule := types.ScheduledNotificationConfig{ID: "corrupt", Report: "corrupt-state-report", Via: []string{testNotifierName}, At: "09:00"}
+	s, db := newScheduledNotifierTestServer(t, fake.server.URL, []types.ScheduledNotificationConfig{schedule})
+	if _, err := db.Exec(`INSERT INTO slack_notifier_state(key, value) VALUES(?,?)`,
+		scheduledStateKey("corrupt", testNotifierName), "not-a-timestamp"); err != nil {
+		t.Fatal(err)
+	}
+
+	// The corrupt row reads as absent: the tick reseeds to the current slot
+	// without firing (seed-on-first-sight, not a replay).
+	s.scheduledNotifierTick(context.Background(), time.Date(2025, 1, 6, 9, 30, 0, 0, time.UTC))
+	if fake.count() != 0 {
+		t.Fatalf("corrupt row fired %d sends, want 0", fake.count())
+	}
+	fired, _, found, err := s.scheduledLastFired("corrupt", testNotifierName)
+	if err != nil || !found {
+		t.Fatalf("scheduledLastFired after reseed: %v, found=%v — the corrupt row must self-heal", err, found)
+	}
+	if !fired.Equal(time.Date(2025, 1, 6, 9, 0, 0, 0, time.UTC)) {
+		t.Fatalf("reseeded slot = %v, want today's 09:00", fired)
+	}
+
+	// The next slot delivers normally: the destination is not dead forever.
+	s.scheduledNotifierTick(context.Background(), time.Date(2025, 1, 7, 9, 0, 30, 0, time.UTC))
+	if fake.count() != 1 {
+		t.Fatalf("slot after the reseed sent %d messages, want 1", fake.count())
+	}
+}
+
+// The warn-once keys of removed schedules are pruned with the rest of their
+// state: clearPollWarning for them only runs inside runScheduledDelivery's
+// branches, which never execute after the removal, so the entries would leak —
+// and a schedule later re-added with the same (id, report) would log nothing.
+func TestPruneScheduledStateClearsRemovedWarningKeys(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	schedule := types.ScheduledNotificationConfig{ID: "future", Report: "never-a-registered-report", Via: []string{testNotifierName}, At: "09:00"}
+	s, _ := newScheduledNotifierTestServer(t, fake.server.URL, []types.ScheduledNotificationConfig{schedule})
+
+	// Seed, then hit the unregistered-report branch to record the warn key.
+	s.scheduledNotifierTick(context.Background(), time.Date(2025, 1, 6, 8, 30, 0, 0, time.UTC))
+	s.scheduledNotifierTick(context.Background(), time.Date(2025, 1, 6, 9, 30, 0, 0, time.UTC))
+	s.pollWarningMu.Lock()
+	_, warned := s.pollWarnings[scheduledReportWarningKey(schedule)]
+	s.pollWarningMu.Unlock()
+	if !warned {
+		t.Fatal("fixture did not record the unregistered-report warn key")
+	}
+	// A state-read warn key of the same schedule is pruned by the same rule.
+	s.logPollWarningOnce(scheduledStateWarningKey("gone", testNotifierName), "fixture state-read warning")
+
+	s.hubCfg.Notifications.Scheduled = nil
+	s.scheduledNotifierTick(context.Background(), time.Date(2025, 1, 6, 9, 31, 0, 0, time.UTC))
+	s.pollWarningMu.Lock()
+	_, warned = s.pollWarnings[scheduledReportWarningKey(schedule)]
+	_, stateWarned := s.pollWarnings[scheduledStateWarningKey("gone", testNotifierName)]
+	s.pollWarningMu.Unlock()
+	if warned {
+		t.Fatal("removed schedule's report warn key survived the prune; a re-added schedule would log nothing")
+	}
+	if stateWarned {
+		t.Fatal("removed schedule's state-read warn key survived the prune")
+	}
+}
+
 // Semantically identical slot definitions must produce identical digests:
 // normalizeScheduledTimes zero-pads a hand-written "9:00" on any settings
 // save, and the edit dialog seeds an absent timezone as "UTC" — neither

--- a/pkg/hub/scheduled_notifier_test.go
+++ b/pkg/hub/scheduled_notifier_test.go
@@ -680,6 +680,47 @@ func TestScheduledNotifierBuildFailureRetriesThenBurnsSlot(t *testing.T) {
 	}
 }
 
+// A schedule naming a report this build does not carry (a hub.yaml written
+// against a newer or older binary — a state validation deliberately keeps
+// saveable) never advances its dedupe state, so the branch re-runs every
+// minute: the "not registered" line must be logged once, not per tick, and
+// must clear the moment the report becomes registered.
+func TestScheduledNotifierUnregisteredReportWarnsOnceAndRecovers(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	schedule := types.ScheduledNotificationConfig{ID: "future", Report: "report-from-a-newer-build", Via: []string{testNotifierName}, At: "09:00"}
+	s, _ := newScheduledNotifierTestServer(t, fake.server.URL, []types.ScheduledNotificationConfig{schedule})
+
+	s.scheduledNotifierTick(context.Background(), time.Date(2025, 1, 6, 8, 30, 0, 0, time.UTC))
+	for i := 0; i < 3; i++ {
+		s.scheduledNotifierTick(context.Background(), time.Date(2025, 1, 6, 9, 30+i, 0, 0, time.UTC))
+	}
+	if fake.count() != 0 {
+		t.Fatalf("unregistered report sent %d messages, want 0", fake.count())
+	}
+	s.pollWarningMu.Lock()
+	_, warned := s.pollWarnings[scheduledReportWarningKey(schedule)]
+	s.pollWarningMu.Unlock()
+	if !warned {
+		t.Fatal("unregistered report did not record its warn-once key; the line would repeat every minute")
+	}
+
+	// The upgrade lands: the report registers, the pending slot delivers, and
+	// the warning key clears so a later disappearance logs again.
+	registerScheduledReport("report-from-a-newer-build", func(context.Context, *Server) (*notify.Message, bool, error) {
+		return &notify.Message{Title: "report", Body: "body"}, true, nil
+	})
+	s.scheduledNotifierTick(context.Background(), time.Date(2025, 1, 6, 9, 34, 0, 0, time.UTC))
+	if fake.count() != 1 {
+		t.Fatalf("registered report sent %d messages, want the pending slot delivered", fake.count())
+	}
+	s.pollWarningMu.Lock()
+	_, warned = s.pollWarnings[scheduledReportWarningKey(schedule)]
+	s.pollWarningMu.Unlock()
+	if warned {
+		t.Fatal("warning key survived the report becoming registered")
+	}
+}
+
 // Semantically identical slot definitions must produce identical digests:
 // normalizeScheduledTimes zero-pads a hand-written "9:00" on any settings
 // save, and the edit dialog seeds an absent timezone as "UTC" — neither

--- a/pkg/hub/scheduled_notifier_test.go
+++ b/pkg/hub/scheduled_notifier_test.go
@@ -1,0 +1,174 @@
+package hub
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/hub/notify"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func TestScheduledNotificationSlot(t *testing.T) {
+	tests := []struct {
+		name     string
+		now      string
+		schedule types.ScheduledNotificationConfig
+		want     string
+	}{
+		{"utc today", "2025-01-06T10:30:00Z", types.ScheduledNotificationConfig{At: "09:00"}, "2025-01-06T09:00:00Z"},
+		{"not yet due", "2025-01-06T08:30:00Z", types.ScheduledNotificationConfig{At: "09:00"}, "2025-01-05T09:00:00Z"},
+		{"weekday filter", "2025-01-06T10:30:00Z", types.ScheduledNotificationConfig{At: "09:00", Weekdays: []string{"fri"}}, "2025-01-03T09:00:00Z"},
+		{"timezone", "2025-01-06T14:30:00Z", types.ScheduledNotificationConfig{At: "09:00", Timezone: "America/New_York"}, "2025-01-06T14:00:00Z"},
+		// 2025-03-09 is the US spring-forward DST transition: 02:30 America/New_York
+		// does not exist that day, so the slot must skip it and fall back to the
+		// previous day's 02:30 EST rather than silently normalizing to 03:30.
+		{"dst spring forward skips nonexistent local time", "2025-03-09T12:00:00Z", types.ScheduledNotificationConfig{At: "02:30", Timezone: "America/New_York"}, "2025-03-08T07:30:00Z"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nowAt, err := time.Parse(time.RFC3339, tt.now)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, ok := scheduledNotificationSlot(nowAt, tt.schedule)
+			if !ok || got.UTC().Format(time.RFC3339) != tt.want {
+				t.Fatalf("slot = %v, %v; want %s", got, ok, tt.want)
+			}
+		})
+	}
+}
+
+// newScheduledNotifierTestServer wires a hub whose scheduled notifier posts to
+// the given httptest Slack server, mirroring newSlackNotifierTestServer.
+func newScheduledNotifierTestServer(t *testing.T, slackURL string, schedules []types.ScheduledNotificationConfig) (*Server, *sql.DB) {
+	t.Helper()
+	cfg := &types.HubConfig{
+		Token:   "test-token",
+		Secrets: map[string]string{testNotifierToken: "xoxb-test-token"},
+		Notifications: &types.NotificationsConfig{
+			Notifiers: map[string]types.NotifierConfig{
+				testNotifierName: {Type: "slack", Settings: map[string]any{
+					"token_secret": testNotifierToken,
+					"channel":      slackTestChannel,
+				}},
+				"second-notifier": {Type: "slack", Settings: map[string]any{
+					"token_secret": testNotifierToken,
+					"channel":      "C0SECOND12",
+				}},
+			},
+			Scheduled: schedules,
+		},
+	}
+	s, db := NewTestServerWithConfig(t, cfg, "", "", "")
+	s.notifierSettingOverrides = map[string]any{
+		"api_base":          slackURL,
+		"min_send_interval": time.Nanosecond.String(),
+	}
+	return s, db
+}
+
+func TestScheduledNotifierEmptyReportMarksFiredWithoutSending(t *testing.T) {
+	registerScheduledReport("empty-test-report", func(context.Context, *Server) (*notify.Message, bool, error) {
+		return nil, false, nil
+	})
+	fake := newFakeSlackServer(t)
+	schedule := types.ScheduledNotificationConfig{ID: "empty", Report: "empty-test-report", Via: []string{testNotifierName}, At: "09:00"}
+	s, _ := newScheduledNotifierTestServer(t, fake.server.URL, []types.ScheduledNotificationConfig{schedule})
+
+	nowAt := time.Date(2025, 1, 6, 9, 30, 0, 0, time.UTC)
+	s.scheduledNotifierTick(nowAt)
+	if fake.count() != 0 {
+		t.Fatalf("empty report sent %d messages, want 0", fake.count())
+	}
+	fired, found, err := s.scheduledLastFired("empty", testNotifierName)
+	if err != nil || !found {
+		t.Fatalf("scheduledLastFired: %v, found=%v", err, found)
+	}
+	if !fired.Equal(time.Date(2025, 1, 6, 9, 0, 0, 0, time.UTC)) {
+		t.Fatalf("fired slot = %v", fired)
+	}
+
+	// A second tick within the same slot must not send anything either.
+	s.scheduledNotifierTick(nowAt.Add(time.Minute))
+	if fake.count() != 0 {
+		t.Fatalf("re-tick within same slot sent %d messages, want 0", fake.count())
+	}
+}
+
+func TestScheduledNotifierDedupeAcrossSimulatedRestart(t *testing.T) {
+	registerScheduledReport("dedupe-test-report", func(context.Context, *Server) (*notify.Message, bool, error) {
+		return &notify.Message{Title: "report", Body: "body"}, true, nil
+	})
+	fake := newFakeSlackServer(t)
+	schedule := types.ScheduledNotificationConfig{ID: "dedupe", Report: "dedupe-test-report", Via: []string{testNotifierName}, At: "09:00"}
+	s, db := newScheduledNotifierTestServer(t, fake.server.URL, []types.ScheduledNotificationConfig{schedule})
+
+	slotTime := time.Date(2025, 1, 6, 9, 30, 0, 0, time.UTC)
+	s.scheduledNotifierTick(slotTime)
+	if fake.count() != 1 {
+		t.Fatalf("first tick sent %d messages, want 1", fake.count())
+	}
+
+	// Simulate a hub restart: build a fresh Server sharing the same DB so the
+	// persisted state table is the only thing carried across (the notifier
+	// cache and in-memory mutexes are legitimately empty after a restart).
+	restarted := &Server{db: s.db, hubCfg: s.hubCfg, notifierSettingOverrides: s.notifierSettingOverrides}
+	_ = db
+	restarted.scheduledNotifierTick(slotTime.Add(20 * time.Minute))
+	if fake.count() != 1 {
+		t.Fatalf("restart re-fired the same slot: got %d sends, want 1", fake.count())
+	}
+
+	// A later slot must fire again.
+	nextDay := slotTime.AddDate(0, 0, 1)
+	restarted.scheduledNotifierTick(nextDay)
+	if fake.count() != 2 {
+		t.Fatalf("next day's slot sent %d messages, want 2", fake.count())
+	}
+}
+
+func TestScheduledNotifierPerNotifierPartialFailureRetries(t *testing.T) {
+	registerScheduledReport("partial-fail-report", func(context.Context, *Server) (*notify.Message, bool, error) {
+		return &notify.Message{Title: "report", Body: "body"}, true, nil
+	})
+	fake := newFakeSlackServer(t)
+	fake.setRespond(func(n int, w http.ResponseWriter) {
+		if n == 1 {
+			http.Error(w, "temporary", http.StatusInternalServerError)
+			return
+		}
+		w.Write([]byte(`{"ok":true,"ts":"1.000001"}`))
+	})
+	schedule := types.ScheduledNotificationConfig{
+		ID:     "partial",
+		Report: "partial-fail-report",
+		Via:    []string{testNotifierName, "second-notifier"},
+		At:     "09:00",
+	}
+	s, _ := newScheduledNotifierTestServer(t, fake.server.URL, []types.ScheduledNotificationConfig{schedule})
+
+	slotTime := time.Date(2025, 1, 6, 9, 30, 0, 0, time.UTC)
+	s.scheduledNotifierTick(slotTime)
+	if fake.count() != 2 {
+		t.Fatalf("tick sent %d messages, want 2 (one failed, one ok)", fake.count())
+	}
+	if _, found, _ := s.scheduledLastFired("partial", testNotifierName); found {
+		t.Fatal("failed notifier state was advanced despite a transient error")
+	}
+	if _, found, _ := s.scheduledLastFired("partial", "second-notifier"); !found {
+		t.Fatal("succeeding notifier state was not recorded")
+	}
+
+	// Next tick, same slot: only the previously-failed destination retries.
+	fake.setRespond(nil)
+	s.scheduledNotifierTick(slotTime.Add(time.Minute))
+	if fake.count() != 3 {
+		t.Fatalf("retry tick sent %d messages, want 3 (1 retry)", fake.count())
+	}
+	if _, found, _ := s.scheduledLastFired("partial", testNotifierName); !found {
+		t.Fatal("retried notifier state was not recorded after success")
+	}
+}

--- a/pkg/hub/scheduled_notifier_test.go
+++ b/pkg/hub/scheduled_notifier_test.go
@@ -3,7 +3,9 @@ package hub
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -68,6 +70,126 @@ func newScheduledNotifierTestServer(t *testing.T, slackURL string, schedules []t
 		"min_send_interval": time.Nanosecond.String(),
 	}
 	return s, db
+}
+
+// ── Manual trigger endpoint ───────────────────────────────────────────────────
+
+// The test endpoint builds the report through the same registry the scheduler
+// uses, so what an operator previews is what the next due slot posts. A dry
+// run must render the real wire payload without touching Slack, and must not
+// advance the scheduler's dedupe state — suppressing the delivery it tests.
+func TestScheduledReportTestEndpointDryRunRendersWithoutSending(t *testing.T) {
+	registerScheduledReport("endpoint-test-report", func(context.Context, *Server) (*notify.Message, bool, error) {
+		return &notify.Message{Title: "Pull requests waiting", Body: "3 open"}, true, nil
+	})
+	fake := newFakeSlackServer(t)
+	schedule := types.ScheduledNotificationConfig{ID: "probe", Report: "endpoint-test-report", Via: []string{testNotifierName}, At: "09:00"}
+	s, _ := newScheduledNotifierTestServer(t, fake.server.URL, []types.ScheduledNotificationConfig{schedule})
+
+	rr := postSlackTest(t, s, `{"report":"endpoint-test-report","via":"`+testNotifierName+`","dry_run":true}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		DryRun  bool   `json:"dry_run"`
+		Report  string `json:"report"`
+		Via     string `json:"via"`
+		Payload struct {
+			Channel     string `json:"channel"`
+			Attachments []struct {
+				Fallback string           `json:"fallback"`
+				Blocks   []map[string]any `json:"blocks"`
+			} `json:"attachments"`
+		} `json:"payload"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.DryRun || resp.Report != "endpoint-test-report" || resp.Via != testNotifierName {
+		t.Fatalf("unexpected dry-run response: %s", rr.Body.String())
+	}
+	if resp.Payload.Channel != slackTestChannel || len(resp.Payload.Attachments) != 1 || len(resp.Payload.Attachments[0].Blocks) == 0 {
+		t.Fatalf("dry run did not render the real wire payload: %s", rr.Body.String())
+	}
+	if !strings.Contains(resp.Payload.Attachments[0].Fallback, "Pull requests waiting") {
+		t.Fatalf("payload does not carry the report title: %s", rr.Body.String())
+	}
+	if fake.count() != 0 {
+		t.Fatalf("dry run posted %d messages to Slack, want 0", fake.count())
+	}
+	if _, found, _ := s.scheduledLastFired("probe", testNotifierName); found {
+		t.Fatal("dry run advanced the scheduler's dedupe state")
+	}
+
+	// A real send posts, and still leaves the schedule's own slot untouched.
+	rr = postSlackTest(t, s, `{"report":"endpoint-test-report","via":"`+testNotifierName+`"}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("real send status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	if fake.count() != 1 {
+		t.Fatalf("real send posted %d messages, want 1", fake.count())
+	}
+	if _, found, _ := s.scheduledLastFired("probe", testNotifierName); found {
+		t.Fatal("test send advanced the scheduler's dedupe state")
+	}
+}
+
+// A report with nothing to say is a normal outcome, not a failure: the
+// endpoint answers 200 with empty:true so the screen can say "nothing to
+// report" instead of painting a red error.
+func TestScheduledReportTestEndpointEmptyReportReportsItWithoutSending(t *testing.T) {
+	registerScheduledReport("endpoint-empty-report", func(context.Context, *Server) (*notify.Message, bool, error) {
+		return nil, false, nil
+	})
+	fake := newFakeSlackServer(t)
+	s, _ := newScheduledNotifierTestServer(t, fake.server.URL, nil)
+
+	rr := postSlackTest(t, s, `{"report":"endpoint-empty-report","via":"`+testNotifierName+`"}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		OK    bool `json:"ok"`
+		Empty bool `json:"empty"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.OK || !resp.Empty {
+		t.Fatalf("empty report response = %s", rr.Body.String())
+	}
+	if fake.count() != 0 {
+		t.Fatalf("empty report posted %d messages, want 0", fake.count())
+	}
+}
+
+func TestScheduledReportTestEndpointRejectsUnknownReportAndVia(t *testing.T) {
+	fake := newFakeSlackServer(t)
+	s, _ := newScheduledNotifierTestServer(t, fake.server.URL, nil)
+
+	rr := postSlackTest(t, s, `{"report":"no-such-report","via":"`+testNotifierName+`"}`)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("unknown report = %d, want 400; body = %s", rr.Code, rr.Body.String())
+	}
+	// The 400 has to list what IS available, or the operator has nowhere to go.
+	if !strings.Contains(rr.Body.String(), "supported reports") {
+		t.Fatalf("unknown-report error does not list the supported names: %s", rr.Body.String())
+	}
+
+	registerScheduledReport("endpoint-via-report", func(context.Context, *Server) (*notify.Message, bool, error) {
+		return &notify.Message{Title: "report"}, true, nil
+	})
+	rr = postSlackTest(t, s, `{"report":"endpoint-via-report","via":"nope"}`)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("unknown via = %d, want 400; body = %s", rr.Code, rr.Body.String())
+	}
+	rr = postSlackTest(t, s, `{"report":"endpoint-via-report"}`)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("missing via = %d, want 400; body = %s", rr.Code, rr.Body.String())
+	}
+	if fake.count() != 0 {
+		t.Fatalf("a rejected probe still posted %d messages", fake.count())
+	}
 }
 
 func TestScheduledNotifierEmptyReportMarksFiredWithoutSending(t *testing.T) {

--- a/pkg/hub/scheduled_notifier_test.go
+++ b/pkg/hub/scheduled_notifier_test.go
@@ -25,9 +25,11 @@ func TestScheduledNotificationSlot(t *testing.T) {
 		{"weekday filter", "2025-01-06T10:30:00Z", types.ScheduledNotificationConfig{At: "09:00", Weekdays: []string{"fri"}}, "2025-01-03T09:00:00Z"},
 		{"timezone", "2025-01-06T14:30:00Z", types.ScheduledNotificationConfig{At: "09:00", Timezone: "America/New_York"}, "2025-01-06T14:00:00Z"},
 		// 2025-03-09 is the US spring-forward DST transition: 02:30 America/New_York
-		// does not exist that day, so the slot must skip it and fall back to the
-		// previous day's 02:30 EST rather than silently normalizing to 03:30.
-		{"dst spring forward skips nonexistent local time", "2025-03-09T12:00:00Z", types.ScheduledNotificationConfig{At: "02:30", Timezone: "America/New_York"}, "2025-03-08T07:30:00Z"},
+		// does not exist that day, so the slot uses the normalized post-gap
+		// instant (03:30 EDT) instead of skipping the day — skipping would make
+		// a sun-only 02:30 schedule silently drop a full weekly cycle.
+		{"dst spring forward uses the normalized post-gap instant", "2025-03-09T12:00:00Z", types.ScheduledNotificationConfig{At: "02:30", Timezone: "America/New_York"}, "2025-03-09T07:30:00Z"},
+		{"dst spring forward on the only allowed weekday still yields that day", "2025-03-09T12:00:00Z", types.ScheduledNotificationConfig{At: "02:30", Timezone: "America/New_York", Weekdays: []string{"sun"}}, "2025-03-09T07:30:00Z"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -117,7 +119,7 @@ func TestScheduledReportTestEndpointDryRunRendersWithoutSending(t *testing.T) {
 	if fake.count() != 0 {
 		t.Fatalf("dry run posted %d messages to Slack, want 0", fake.count())
 	}
-	if _, found, _ := s.scheduledLastFired("probe", testNotifierName); found {
+	if _, _, found, _ := s.scheduledLastFired("probe", testNotifierName); found {
 		t.Fatal("dry run advanced the scheduler's dedupe state")
 	}
 
@@ -129,7 +131,7 @@ func TestScheduledReportTestEndpointDryRunRendersWithoutSending(t *testing.T) {
 	if fake.count() != 1 {
 		t.Fatalf("real send posted %d messages, want 1", fake.count())
 	}
-	if _, found, _ := s.scheduledLastFired("probe", testNotifierName); found {
+	if _, _, found, _ := s.scheduledLastFired("probe", testNotifierName); found {
 		t.Fatal("test send advanced the scheduler's dedupe state")
 	}
 }
@@ -202,14 +204,14 @@ func TestScheduledNotifierEmptyReportMarksFiredWithoutSending(t *testing.T) {
 
 	// Arm the schedule with a pre-slot tick, as the minutely production loop
 	// would: the first tick a schedule is ever seen on only seeds its state.
-	s.scheduledNotifierTick(time.Date(2025, 1, 6, 8, 30, 0, 0, time.UTC))
+	s.scheduledNotifierTick(context.Background(), time.Date(2025, 1, 6, 8, 30, 0, 0, time.UTC))
 
 	nowAt := time.Date(2025, 1, 6, 9, 30, 0, 0, time.UTC)
-	s.scheduledNotifierTick(nowAt)
+	s.scheduledNotifierTick(context.Background(), nowAt)
 	if fake.count() != 0 {
 		t.Fatalf("empty report sent %d messages, want 0", fake.count())
 	}
-	fired, found, err := s.scheduledLastFired("empty", testNotifierName)
+	fired, _, found, err := s.scheduledLastFired("empty", testNotifierName)
 	if err != nil || !found {
 		t.Fatalf("scheduledLastFired: %v, found=%v", err, found)
 	}
@@ -218,7 +220,7 @@ func TestScheduledNotifierEmptyReportMarksFiredWithoutSending(t *testing.T) {
 	}
 
 	// A second tick within the same slot must not send anything either.
-	s.scheduledNotifierTick(nowAt.Add(time.Minute))
+	s.scheduledNotifierTick(context.Background(), nowAt.Add(time.Minute))
 	if fake.count() != 0 {
 		t.Fatalf("re-tick within same slot sent %d messages, want 0", fake.count())
 	}
@@ -234,10 +236,10 @@ func TestScheduledNotifierDedupeAcrossSimulatedRestart(t *testing.T) {
 
 	// Arm the schedule with a pre-slot tick (production ticks every minute,
 	// so a schedule created before its slot is always seen before it).
-	s.scheduledNotifierTick(time.Date(2025, 1, 6, 8, 30, 0, 0, time.UTC))
+	s.scheduledNotifierTick(context.Background(), time.Date(2025, 1, 6, 8, 30, 0, 0, time.UTC))
 
 	slotTime := time.Date(2025, 1, 6, 9, 30, 0, 0, time.UTC)
-	s.scheduledNotifierTick(slotTime)
+	s.scheduledNotifierTick(context.Background(), slotTime)
 	if fake.count() != 1 {
 		t.Fatalf("first tick sent %d messages, want 1", fake.count())
 	}
@@ -247,14 +249,14 @@ func TestScheduledNotifierDedupeAcrossSimulatedRestart(t *testing.T) {
 	// cache and in-memory mutexes are legitimately empty after a restart).
 	restarted := &Server{db: s.db, hubCfg: s.hubCfg, notifierSettingOverrides: s.notifierSettingOverrides}
 	_ = db
-	restarted.scheduledNotifierTick(slotTime.Add(20 * time.Minute))
+	restarted.scheduledNotifierTick(context.Background(), slotTime.Add(20*time.Minute))
 	if fake.count() != 1 {
 		t.Fatalf("restart re-fired the same slot: got %d sends, want 1", fake.count())
 	}
 
 	// A later slot must fire again.
 	nextDay := slotTime.AddDate(0, 0, 1)
-	restarted.scheduledNotifierTick(nextDay)
+	restarted.scheduledNotifierTick(context.Background(), nextDay)
 	if fake.count() != 2 {
 		t.Fatalf("next day's slot sent %d messages, want 2", fake.count())
 	}
@@ -282,28 +284,28 @@ func TestScheduledNotifierPerNotifierPartialFailureRetries(t *testing.T) {
 
 	// Arm both destinations before the slot: the first tick a schedule is
 	// ever seen on only seeds its state, posting nothing to Slack.
-	s.scheduledNotifierTick(time.Date(2025, 1, 6, 8, 30, 0, 0, time.UTC))
+	s.scheduledNotifierTick(context.Background(), time.Date(2025, 1, 6, 8, 30, 0, 0, time.UTC))
 
 	slotTime := time.Date(2025, 1, 6, 9, 30, 0, 0, time.UTC)
 	slot := time.Date(2025, 1, 6, 9, 0, 0, 0, time.UTC)
-	s.scheduledNotifierTick(slotTime)
+	s.scheduledNotifierTick(context.Background(), slotTime)
 	if fake.count() != 2 {
 		t.Fatalf("tick sent %d messages, want 2 (one failed, one ok)", fake.count())
 	}
-	if fired, _, _ := s.scheduledLastFired("partial", testNotifierName); fired.Equal(slot) {
+	if fired, _, _, _ := s.scheduledLastFired("partial", testNotifierName); fired.Equal(slot) {
 		t.Fatal("failed notifier state was advanced despite a transient error")
 	}
-	if fired, _, _ := s.scheduledLastFired("partial", "second-notifier"); !fired.Equal(slot) {
+	if fired, _, _, _ := s.scheduledLastFired("partial", "second-notifier"); !fired.Equal(slot) {
 		t.Fatalf("succeeding notifier state = %v, want the slot recorded", fired)
 	}
 
 	// Next tick, same slot: only the previously-failed destination retries.
 	fake.setRespond(nil)
-	s.scheduledNotifierTick(slotTime.Add(time.Minute))
+	s.scheduledNotifierTick(context.Background(), slotTime.Add(time.Minute))
 	if fake.count() != 3 {
 		t.Fatalf("retry tick sent %d messages, want 3 (1 retry)", fake.count())
 	}
-	if fired, _, _ := s.scheduledLastFired("partial", testNotifierName); !fired.Equal(slot) {
+	if fired, _, _, _ := s.scheduledLastFired("partial", testNotifierName); !fired.Equal(slot) {
 		t.Fatalf("retried notifier state = %v, want the slot recorded after success", fired)
 	}
 }
@@ -322,11 +324,11 @@ func TestScheduledNotifierNewScheduleDoesNotReplayPastSlot(t *testing.T) {
 
 	// First tick, hours after today's slot: seed, don't send.
 	nowAt := time.Date(2025, 1, 6, 15, 0, 0, 0, time.UTC)
-	s.scheduledNotifierTick(nowAt)
+	s.scheduledNotifierTick(context.Background(), nowAt)
 	if fake.count() != 0 {
 		t.Fatalf("first sight of the schedule replayed a past slot: %d sends, want 0", fake.count())
 	}
-	fired, found, err := s.scheduledLastFired("fresh", testNotifierName)
+	fired, _, found, err := s.scheduledLastFired("fresh", testNotifierName)
 	if err != nil || !found {
 		t.Fatalf("scheduledLastFired: %v, found=%v — first sight must seed the state row", err, found)
 	}
@@ -335,7 +337,7 @@ func TestScheduledNotifierNewScheduleDoesNotReplayPastSlot(t *testing.T) {
 	}
 
 	// The next occurrence fires normally.
-	s.scheduledNotifierTick(time.Date(2025, 1, 7, 9, 0, 30, 0, time.UTC))
+	s.scheduledNotifierTick(context.Background(), time.Date(2025, 1, 7, 9, 0, 30, 0, time.UTC))
 	if fake.count() != 1 {
 		t.Fatalf("next day's slot sent %d messages, want 1", fake.count())
 	}
@@ -353,8 +355,8 @@ func TestScheduledNotifierPausedScheduleSkipsSlotsUntilReEnabled(t *testing.T) {
 	s, _ := newScheduledNotifierTestServer(t, fake.server.URL, []types.ScheduledNotificationConfig{schedule})
 
 	// Arm and fire once while enabled.
-	s.scheduledNotifierTick(time.Date(2025, 1, 6, 8, 30, 0, 0, time.UTC))
-	s.scheduledNotifierTick(time.Date(2025, 1, 6, 9, 30, 0, 0, time.UTC))
+	s.scheduledNotifierTick(context.Background(), time.Date(2025, 1, 6, 8, 30, 0, 0, time.UTC))
+	s.scheduledNotifierTick(context.Background(), time.Date(2025, 1, 6, 9, 30, 0, 0, time.UTC))
 	if fake.count() != 1 {
 		t.Fatalf("enabled slot sent %d messages, want 1", fake.count())
 	}
@@ -362,7 +364,7 @@ func TestScheduledNotifierPausedScheduleSkipsSlotsUntilReEnabled(t *testing.T) {
 	// Pause; the next day's slot passes silently but advances the state.
 	disabled := false
 	s.hubCfg.Notifications.Scheduled[0].Enabled = &disabled
-	s.scheduledNotifierTick(time.Date(2025, 1, 7, 9, 30, 0, 0, time.UTC))
+	s.scheduledNotifierTick(context.Background(), time.Date(2025, 1, 7, 9, 30, 0, 0, time.UTC))
 	if fake.count() != 1 {
 		t.Fatalf("paused slot sent %d messages, want still 1", fake.count())
 	}
@@ -370,12 +372,134 @@ func TestScheduledNotifierPausedScheduleSkipsSlotsUntilReEnabled(t *testing.T) {
 	// Re-enable after the slot: nothing to replay, next occurrence fires.
 	enabled := true
 	s.hubCfg.Notifications.Scheduled[0].Enabled = &enabled
-	s.scheduledNotifierTick(time.Date(2025, 1, 7, 15, 0, 0, 0, time.UTC))
+	s.scheduledNotifierTick(context.Background(), time.Date(2025, 1, 7, 15, 0, 0, 0, time.UTC))
 	if fake.count() != 1 {
 		t.Fatalf("re-enable replayed the slot that passed while paused: %d sends, want 1", fake.count())
 	}
-	s.scheduledNotifierTick(time.Date(2025, 1, 8, 9, 0, 30, 0, time.UTC))
+	s.scheduledNotifierTick(context.Background(), time.Date(2025, 1, 8, 9, 0, 30, 0, time.UTC))
 	if fake.count() != 2 {
 		t.Fatalf("next slot after re-enable sent %d messages, want 2", fake.count())
+	}
+}
+
+// Editing a schedule's slot definition (at/timezone/weekdays) must not fire
+// an off-schedule send against the pre-edit state: the state row is reseeded
+// like a first sight and the edited schedule delivers from its next slot on.
+func TestScheduledNotifierEditReseedsSlotState(t *testing.T) {
+	registerScheduledReport("edit-reseed-report", func(context.Context, *Server) (*notify.Message, bool, error) {
+		return &notify.Message{Title: "report", Body: "body"}, true, nil
+	})
+	fake := newFakeSlackServer(t)
+	schedule := types.ScheduledNotificationConfig{ID: "edited", Report: "edit-reseed-report", Via: []string{testNotifierName}, At: "09:00"}
+	s, _ := newScheduledNotifierTestServer(t, fake.server.URL, []types.ScheduledNotificationConfig{schedule})
+
+	// Arm and fire once under the original definition.
+	s.scheduledNotifierTick(context.Background(), time.Date(2025, 1, 6, 8, 30, 0, 0, time.UTC))
+	s.scheduledNotifierTick(context.Background(), time.Date(2025, 1, 6, 9, 30, 0, 0, time.UTC))
+	if fake.count() != 1 {
+		t.Fatalf("original slot sent %d messages, want 1", fake.count())
+	}
+
+	// Edit the slot: the next tick sees a digest mismatch and reseeds instead
+	// of treating today's new 10:00 slot as pending against the old history.
+	s.hubCfg.Notifications.Scheduled[0].At = "10:00"
+	s.scheduledNotifierTick(context.Background(), time.Date(2025, 1, 6, 10, 30, 0, 0, time.UTC))
+	if fake.count() != 1 {
+		t.Fatalf("edit fired an off-schedule send: %d sends, want still 1", fake.count())
+	}
+	fired, _, found, err := s.scheduledLastFired("edited", testNotifierName)
+	if err != nil || !found {
+		t.Fatalf("scheduledLastFired: %v, found=%v — the edit must reseed the state row", err, found)
+	}
+	if !fired.Equal(time.Date(2025, 1, 6, 10, 0, 0, 0, time.UTC)) {
+		t.Fatalf("reseeded slot = %v, want today's 10:00", fired)
+	}
+
+	// The edited schedule's next occurrence fires normally.
+	s.scheduledNotifierTick(context.Background(), time.Date(2025, 1, 7, 10, 0, 30, 0, time.UTC))
+	if fake.count() != 2 {
+		t.Fatalf("next slot after the edit sent %d messages, want 2", fake.count())
+	}
+}
+
+// A destination whose sends keep failing transiently retries once per tick,
+// but only up to scheduledMaxTransientFailures: then the slot is advanced
+// with a permanent-failure log so the identical report is not re-posted every
+// minute for the rest of the day.
+func TestScheduledNotifierTransientFailureCapAdvancesSlot(t *testing.T) {
+	registerScheduledReport("retry-cap-report", func(context.Context, *Server) (*notify.Message, bool, error) {
+		return &notify.Message{Title: "report", Body: "body"}, true, nil
+	})
+	fake := newFakeSlackServer(t)
+	fake.setRespond(func(n int, w http.ResponseWriter) {
+		http.Error(w, "temporary", http.StatusInternalServerError)
+	})
+	schedule := types.ScheduledNotificationConfig{ID: "capped", Report: "retry-cap-report", Via: []string{testNotifierName}, At: "09:00"}
+	s, _ := newScheduledNotifierTestServer(t, fake.server.URL, []types.ScheduledNotificationConfig{schedule})
+
+	s.scheduledNotifierTick(context.Background(), time.Date(2025, 1, 6, 8, 30, 0, 0, time.UTC))
+	slot := time.Date(2025, 1, 6, 9, 0, 0, 0, time.UTC)
+	for i := 0; i < scheduledMaxTransientFailures; i++ {
+		s.scheduledNotifierTick(context.Background(), slot.Add(time.Duration(30+i)*time.Minute))
+		fired, _, _, _ := s.scheduledLastFired("capped", testNotifierName)
+		if advanced := fired.Equal(slot); advanced != (i == scheduledMaxTransientFailures-1) {
+			t.Fatalf("after failure %d state advanced=%v, want advance only on the %dth", i+1, advanced, scheduledMaxTransientFailures)
+		}
+	}
+	if fake.count() != scheduledMaxTransientFailures {
+		t.Fatalf("capped destination attempted %d sends, want %d", fake.count(), scheduledMaxTransientFailures)
+	}
+
+	// The slot is burned: later ticks in the same slot retry nothing more.
+	s.scheduledNotifierTick(context.Background(), slot.Add(3*time.Hour))
+	if fake.count() != scheduledMaxTransientFailures {
+		t.Fatalf("burned slot still retried: %d sends", fake.count())
+	}
+
+	// The next slot starts with a fresh retry budget and can succeed.
+	fake.setRespond(nil)
+	s.scheduledNotifierTick(context.Background(), slot.AddDate(0, 0, 1).Add(30*time.Minute))
+	if fake.count() != scheduledMaxTransientFailures+1 {
+		t.Fatalf("next slot sent %d messages total, want %d", fake.count(), scheduledMaxTransientFailures+1)
+	}
+}
+
+// Dedupe rows of schedules (or destinations) that leave the config are
+// pruned, mirroring pruneLifecycleRouteState: a schedule id deleted and later
+// re-created must behave like a brand-new schedule, and orphaned rows must
+// not accumulate in slack_notifier_state.
+func TestScheduledNotifierPrunesRemovedScheduleState(t *testing.T) {
+	registerScheduledReport("prune-report", func(context.Context, *Server) (*notify.Message, bool, error) {
+		return &notify.Message{Title: "report", Body: "body"}, true, nil
+	})
+	fake := newFakeSlackServer(t)
+	schedule := types.ScheduledNotificationConfig{ID: "pruned", Report: "prune-report", Via: []string{testNotifierName}, At: "09:00"}
+	s, db := newScheduledNotifierTestServer(t, fake.server.URL, []types.ScheduledNotificationConfig{schedule})
+
+	s.scheduledNotifierTick(context.Background(), time.Date(2025, 1, 6, 15, 0, 0, 0, time.UTC))
+	if _, _, found, _ := s.scheduledLastFired("pruned", testNotifierName); !found {
+		t.Fatal("first sight did not seed the state row")
+	}
+	// A row in a superseded key format is orphaned by definition and pruned too.
+	if _, err := db.Exec(`INSERT INTO slack_notifier_state(key, value) VALUES(?,?)`,
+		"scheduled:last_fired:pruned:"+testNotifierName, "2025-01-06T09:00:00Z"); err != nil {
+		t.Fatal(err)
+	}
+
+	s.hubCfg.Notifications.Scheduled = nil
+	s.scheduledNotifierTick(context.Background(), time.Date(2025, 1, 6, 15, 1, 0, 0, time.UTC))
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM slack_notifier_state WHERE key LIKE 'scheduled:last_fired:%'`).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Fatalf("%d scheduled state rows survive the schedule's removal, want 0", n)
+	}
+
+	// Re-created under the same id: first sight seeds, nothing replays.
+	s.hubCfg.Notifications.Scheduled = []types.ScheduledNotificationConfig{schedule}
+	s.scheduledNotifierTick(context.Background(), time.Date(2025, 1, 6, 15, 2, 0, 0, time.UTC))
+	if fake.count() != 0 {
+		t.Fatalf("re-created schedule replayed a stale slot: %d sends, want 0", fake.count())
 	}
 }

--- a/pkg/hub/scheduled_report_pending_prs.go
+++ b/pkg/hub/scheduled_report_pending_prs.go
@@ -1,0 +1,147 @@
+package hub
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/hub/notify"
+)
+
+const scheduledPendingPRsTicketLimit = 20
+const scheduledPendingPRsBodyLimit = 2800
+
+func init() {
+	registerScheduledReport("pending_prs", buildPendingPRsScheduledReport)
+}
+
+type scheduledPendingPRTicket struct {
+	key        string
+	issueID    string
+	issueTitle string
+	runIDs     []string
+	prs        []taskRunAnalyticsPRView
+}
+
+func buildPendingPRsScheduledReport(ctx context.Context, s *Server) (*notify.Message, bool, error) {
+	tenantID, err := s.githubTenantID()
+	if err != nil {
+		return nil, false, err
+	}
+	rows, err := s.db.QueryContext(ctx, `
+		WITH pending_tickets AS (
+			SELECT integration, integration_workspace, issue_id
+			  FROM task_run_summaries
+			 WHERE tenant_id=? AND issue_id != ''
+			 GROUP BY integration, integration_workspace, issue_id
+			HAVING SUM(open_pr_count) > 0
+		)
+		SELECT s.integration, s.integration_workspace, s.issue_id, s.issue_title, s.run_id, s.started_at
+		  FROM task_run_summaries s
+		  JOIN pending_tickets p
+		    ON p.integration=s.integration
+		   AND p.integration_workspace=s.integration_workspace
+		   AND p.issue_id=s.issue_id
+		 WHERE s.tenant_id=?
+		 ORDER BY s.started_at DESC`, tenantID, tenantID)
+	if err != nil {
+		return nil, false, err
+	}
+	defer rows.Close()
+
+	ticketsByKey := map[string]*scheduledPendingPRTicket{}
+	var runIDs []string
+	for rows.Next() {
+		var integration, workspace, issueID, issueTitle, runID string
+		var startedAt int64
+		if err := rows.Scan(&integration, &workspace, &issueID, &issueTitle, &runID, &startedAt); err != nil {
+			return nil, false, err
+		}
+		key := taskRunAnalyticsTicketKey(integration, workspace, issueID)
+		ticket := ticketsByKey[key]
+		if ticket == nil {
+			ticket = &scheduledPendingPRTicket{key: key, issueID: issueID}
+			ticketsByKey[key] = ticket
+		}
+		if len(ticket.runIDs) == 0 {
+			ticket.issueTitle = issueTitle
+		}
+		ticket.runIDs = append(ticket.runIDs, runID)
+		runIDs = append(runIDs, runID)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, false, err
+	}
+
+	prsByRun, err := s.readTaskRunAnalyticsPRsForRuns(tenantID, runIDs)
+	if err != nil {
+		return nil, false, err
+	}
+	var tickets []*scheduledPendingPRTicket
+	for _, ticket := range ticketsByKey {
+		for _, runID := range ticket.runIDs {
+			for _, pr := range prsByRun[runID] {
+				if pr.State == "open" && !pr.Merged {
+					ticket.prs = append(ticket.prs, pr)
+				}
+			}
+		}
+		if len(ticket.prs) > 0 {
+			tickets = append(tickets, ticket)
+		}
+	}
+	if len(tickets) == 0 {
+		return nil, false, nil
+	}
+
+	sort.Slice(tickets, func(i, j int) bool {
+		return scheduledPendingPROldestAt(tickets[i]) < scheduledPendingPROldestAt(tickets[j])
+	})
+	nowAt := time.Now()
+	lines := make([]string, 0, min(len(tickets), scheduledPendingPRsTicketLimit)+1)
+	for _, ticket := range tickets[:min(len(tickets), scheduledPendingPRsTicketLimit)] {
+		links := make([]string, 0, len(ticket.prs))
+		for _, pr := range ticket.prs {
+			links = append(links, fmt.Sprintf("#%d %s", pr.PRNumber, pr.URL))
+		}
+		ageDays := int(nowAt.Sub(time.UnixMilli(scheduledPendingPROldestAt(ticket))).Hours() / 24)
+		if ageDays < 0 {
+			ageDays = 0
+		}
+		title := ticket.issueTitle
+		if title == "" {
+			title = ticket.issueID
+		}
+		lines = append(lines, fmt.Sprintf("%s — %s: %s (%d days)", ticket.issueID, title, strings.Join(links, ", "), ageDays))
+	}
+	if len(tickets) > scheduledPendingPRsTicketLimit {
+		lines = append(lines, fmt.Sprintf("…and %d more", len(tickets)-scheduledPendingPRsTicketLimit))
+	}
+	body := strings.Join(lines, "\n")
+	if runeLen(body) > scheduledPendingPRsBodyLimit {
+		body = truncateRunes(body, scheduledPendingPRsBodyLimit-1) + "…"
+	}
+	message := &notify.Message{
+		Title:    "Pending PRs",
+		Emoji:    ":information_source:",
+		Severity: notify.SeverityInfo,
+		Body:     body,
+		Summary:  []string{fmt.Sprintf("%d tickets with open PRs", len(tickets))},
+	}
+	if hubURL := strings.TrimRight(s.clawHubURL(), "/"); hubURL != "" {
+		message.Link = notify.Link{URL: hubURL + "/analytics", Label: "View tickets"}
+	}
+	return message, true, nil
+}
+
+func scheduledPendingPROldestAt(ticket *scheduledPendingPRTicket) int64 {
+	oldestAt := ticket.prs[0].OpenedAt
+	for _, pr := range ticket.prs[1:] {
+		if pr.OpenedAt < oldestAt {
+			oldestAt = pr.OpenedAt
+		}
+	}
+	return oldestAt
+}

--- a/pkg/hub/scheduled_report_pending_prs.go
+++ b/pkg/hub/scheduled_report_pending_prs.go
@@ -44,7 +44,11 @@ type scheduledPendingPRTicket struct {
 // hold a stranded (open, merged=0) row for a PR another run's row already
 // records as merged or closed — and with no time window (correctly, per the
 // report's contract) such a zombie row would otherwise surface the ticket
-// forever, oldest-first, permanently occupying the cap.
+// forever, oldest-first, permanently occupying the cap. merged=1 is terminal
+// and vetoes unconditionally; state='closed' is reversible on GitHub (a retry
+// run can reopen the PR and record a fresh open row), so a closed row vetoes
+// only when it is not older than the open row — otherwise the pre-reopen
+// close latched by a dead run would hide the reopened PR forever.
 const scheduledPendingPRsTicketsSQL = `
 	SELECT s.integration, s.integration_workspace, s.issue_id,
 	       MIN(CASE WHEN p.opened_at > 0 THEN p.opened_at END) AS oldest_open_at
@@ -55,7 +59,7 @@ const scheduledPendingPRsTicketsSQL = `
 	   AND NOT EXISTS (
 	       SELECT 1 FROM task_run_prs done
 	        WHERE done.tenant_id=p.tenant_id AND done.repo=p.repo AND done.pr_number=p.pr_number
-	          AND (done.merged=1 OR done.state='closed'))
+	          AND (done.merged=1 OR (done.state='closed' AND done.updated_at >= p.updated_at)))
 	 GROUP BY s.integration, s.integration_workspace, s.issue_id`
 
 func buildPendingPRsScheduledReport(ctx context.Context, s *Server) (*notify.Message, bool, error) {
@@ -136,7 +140,7 @@ func buildPendingPRsScheduledReport(ctx context.Context, s *Server) (*notify.Mes
 				key := fmt.Sprintf("%s#%d", pr.Repo, pr.PRNumber)
 				// Same cross-row resolution as the ticket query: a stranded
 				// open row must not render a PR any other row for the tenant
-				// records as merged or closed.
+				// records as merged, or closed no earlier than the open row.
 				if resolved[key] {
 					continue
 				}
@@ -202,33 +206,52 @@ func buildPendingPRsScheduledReport(ctx context.Context, s *Server) (*notify.Mes
 
 // scheduledPendingPRsResolvedElsewhere returns, keyed "repo#number", the PRs
 // among prsByRun's open rows that ANY task_run_prs row for the tenant marks
-// merged or closed. The rows of the capped tickets alone cannot answer this: a
-// zombie open row's resolving row may belong to a run of a ticket outside the
-// cap, so resolution is read tenant-wide — mirroring the ticket query's
-// NOT EXISTS, which alone cannot cover a ticket that qualifies via another,
-// genuinely open PR.
+// merged — or closed no earlier than the newest open row, the same recency
+// rule as the ticket query's NOT EXISTS (a reopened PR's fresh open row must
+// win over the pre-reopen close). The rows of the capped tickets alone cannot
+// answer this: a zombie open row's resolving row may belong to a run of a
+// ticket outside the cap, so resolution is read tenant-wide — mirroring the
+// ticket query's NOT EXISTS, which alone cannot cover a ticket that qualifies
+// via another, genuinely open PR.
 func (s *Server) scheduledPendingPRsResolvedElsewhere(ctx context.Context, tenantID string, prsByRun map[string][]taskRunAnalyticsPRView) (map[string]bool, error) {
-	conds := make([]string, 0, 8)
-	args := []any{tenantID}
-	seen := map[string]bool{}
+	type openPR struct {
+		repo      string
+		number    int
+		updatedAt int64
+	}
+	// Keep the NEWEST open row per PR: if any open row postdates the close,
+	// the PR is open again and must not be resolved away.
+	newest := map[string]openPR{}
+	var keys []string
 	for _, prs := range prsByRun {
 		for _, pr := range prs {
-			key := fmt.Sprintf("%s#%d", pr.Repo, pr.PRNumber)
-			if pr.State != "open" || pr.Merged || seen[key] {
+			if pr.State != "open" || pr.Merged {
 				continue
 			}
-			seen[key] = true
-			conds = append(conds, "(repo=? AND pr_number=?)")
-			args = append(args, pr.Repo, pr.PRNumber)
+			key := fmt.Sprintf("%s#%d", pr.Repo, pr.PRNumber)
+			cur, ok := newest[key]
+			if !ok {
+				keys = append(keys, key)
+			}
+			if !ok || pr.UpdatedAt > cur.updatedAt {
+				newest[key] = openPR{pr.Repo, pr.PRNumber, pr.UpdatedAt}
+			}
 		}
 	}
 	resolved := map[string]bool{}
-	if len(conds) == 0 {
+	if len(keys) == 0 {
 		return resolved, nil
+	}
+	conds := make([]string, 0, len(keys))
+	args := []any{tenantID}
+	for _, key := range keys {
+		pr := newest[key]
+		conds = append(conds, "(repo=? AND pr_number=? AND (merged=1 OR (state='closed' AND updated_at >= ?)))")
+		args = append(args, pr.repo, pr.number, pr.updatedAt)
 	}
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT DISTINCT repo, pr_number FROM task_run_prs
-		 WHERE tenant_id=? AND (merged=1 OR state='closed') AND (`+strings.Join(conds, " OR ")+`)`, args...)
+		 WHERE tenant_id=? AND (`+strings.Join(conds, " OR ")+`)`, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/hub/scheduled_report_pending_prs.go
+++ b/pkg/hub/scheduled_report_pending_prs.go
@@ -39,6 +39,12 @@ type scheduledPendingPRTicket struct {
 // unknown, not 1970 — such rows are excluded from MIN so a ticket carrying
 // only unknowns gets a NULL oldest_open_at and sorts last, never displacing a
 // genuinely old ticket from the cap.
+// PR state is resolved ACROSS rows per (repo, pr_number), mirroring the
+// claw_prs backfill in db.go: pr_watcher only visits live claws, so a run can
+// hold a stranded (open, merged=0) row for a PR another run's row already
+// records as merged or closed — and with no time window (correctly, per the
+// report's contract) such a zombie row would otherwise surface the ticket
+// forever, oldest-first, permanently occupying the cap.
 const scheduledPendingPRsTicketsSQL = `
 	SELECT s.integration, s.integration_workspace, s.issue_id,
 	       MIN(CASE WHEN p.opened_at > 0 THEN p.opened_at END) AS oldest_open_at
@@ -46,6 +52,10 @@ const scheduledPendingPRsTicketsSQL = `
 	  JOIN task_run_prs p ON p.tenant_id=s.tenant_id AND p.run_id=s.run_id
 	 WHERE s.tenant_id=? AND s.issue_id != '' AND s.requires_pr=1 AND s.analytics_enabled=1
 	   AND p.state='open' AND p.merged=0
+	   AND NOT EXISTS (
+	       SELECT 1 FROM task_run_prs done
+	        WHERE done.tenant_id=p.tenant_id AND done.repo=p.repo AND done.pr_number=p.pr_number
+	          AND (done.merged=1 OR done.state='closed'))
 	 GROUP BY s.integration, s.integration_workspace, s.issue_id`
 
 func buildPendingPRsScheduledReport(ctx context.Context, s *Server) (*notify.Message, bool, error) {
@@ -107,6 +117,10 @@ func buildPendingPRsScheduledReport(ctx context.Context, s *Server) (*notify.Mes
 	if err != nil {
 		return nil, false, err
 	}
+	resolved, err := s.scheduledPendingPRsResolvedElsewhere(ctx, tenantID, prsByRun)
+	if err != nil {
+		return nil, false, err
+	}
 	var tickets []*scheduledPendingPRTicket
 	for _, ticket := range ticketsByKey {
 		// task_run_prs is unique per (run, repo, pr_number), so a PR carried
@@ -120,6 +134,12 @@ func buildPendingPRsScheduledReport(ctx context.Context, s *Server) (*notify.Mes
 					continue
 				}
 				key := fmt.Sprintf("%s#%d", pr.Repo, pr.PRNumber)
+				// Same cross-row resolution as the ticket query: a stranded
+				// open row must not render a PR any other row for the tenant
+				// records as merged or closed.
+				if resolved[key] {
+					continue
+				}
 				if at, ok := seen[key]; ok {
 					if pr.OpenedAt > 0 && (ticket.prs[at].OpenedAt == 0 || pr.OpenedAt < ticket.prs[at].OpenedAt) {
 						ticket.prs[at] = pr
@@ -178,6 +198,50 @@ func buildPendingPRsScheduledReport(ctx context.Context, s *Server) (*notify.Mes
 		message.Link = notify.Link{URL: hubURL + "/analytics", Label: "View tickets"}
 	}
 	return message, true, nil
+}
+
+// scheduledPendingPRsResolvedElsewhere returns, keyed "repo#number", the PRs
+// among prsByRun's open rows that ANY task_run_prs row for the tenant marks
+// merged or closed. The rows of the capped tickets alone cannot answer this: a
+// zombie open row's resolving row may belong to a run of a ticket outside the
+// cap, so resolution is read tenant-wide — mirroring the ticket query's
+// NOT EXISTS, which alone cannot cover a ticket that qualifies via another,
+// genuinely open PR.
+func (s *Server) scheduledPendingPRsResolvedElsewhere(ctx context.Context, tenantID string, prsByRun map[string][]taskRunAnalyticsPRView) (map[string]bool, error) {
+	conds := make([]string, 0, 8)
+	args := []any{tenantID}
+	seen := map[string]bool{}
+	for _, prs := range prsByRun {
+		for _, pr := range prs {
+			key := fmt.Sprintf("%s#%d", pr.Repo, pr.PRNumber)
+			if pr.State != "open" || pr.Merged || seen[key] {
+				continue
+			}
+			seen[key] = true
+			conds = append(conds, "(repo=? AND pr_number=?)")
+			args = append(args, pr.Repo, pr.PRNumber)
+		}
+	}
+	resolved := map[string]bool{}
+	if len(conds) == 0 {
+		return resolved, nil
+	}
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT DISTINCT repo, pr_number FROM task_run_prs
+		 WHERE tenant_id=? AND (merged=1 OR state='closed') AND (`+strings.Join(conds, " OR ")+`)`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var repo string
+		var number int
+		if err := rows.Scan(&repo, &number); err != nil {
+			return nil, err
+		}
+		resolved[fmt.Sprintf("%s#%d", repo, number)] = true
+	}
+	return resolved, rows.Err()
 }
 
 // scheduledPendingPRsBody fits the ticket lines into the body limit by

--- a/pkg/hub/scheduled_report_pending_prs.go
+++ b/pkg/hub/scheduled_report_pending_prs.go
@@ -34,8 +34,14 @@ type scheduledPendingPRTicket struct {
 // linked /analytics page hides. Deliberately no time window on the runs: a
 // ticket of ANY age with a still-open PR is exactly what this report exists
 // to surface.
+// opened_at=0 on an open PR is a row shape the codebase expects (the schema
+// default; pr_watcher matches it explicitly) and means the opening time is
+// unknown, not 1970 — such rows are excluded from MIN so a ticket carrying
+// only unknowns gets a NULL oldest_open_at and sorts last, never displacing a
+// genuinely old ticket from the cap.
 const scheduledPendingPRsTicketsSQL = `
-	SELECT s.integration, s.integration_workspace, s.issue_id, MIN(p.opened_at) AS oldest_open_at
+	SELECT s.integration, s.integration_workspace, s.issue_id,
+	       MIN(CASE WHEN p.opened_at > 0 THEN p.opened_at END) AS oldest_open_at
 	  FROM task_run_summaries s
 	  JOIN task_run_prs p ON p.tenant_id=s.tenant_id AND p.run_id=s.run_id
 	 WHERE s.tenant_id=? AND s.issue_id != '' AND s.requires_pr=1 AND s.analytics_enabled=1
@@ -43,7 +49,7 @@ const scheduledPendingPRsTicketsSQL = `
 	 GROUP BY s.integration, s.integration_workspace, s.issue_id`
 
 func buildPendingPRsScheduledReport(ctx context.Context, s *Server) (*notify.Message, bool, error) {
-	tenantID, err := s.githubTenantID()
+	tenantID, err := s.githubTenantIDContext(ctx)
 	if err != nil {
 		return nil, false, err
 	}
@@ -59,7 +65,7 @@ func buildPendingPRsScheduledReport(ctx context.Context, s *Server) (*notify.Mes
 	// run and PR of every pending ticket.
 	rows, err := s.db.QueryContext(ctx, `
 		WITH pending_tickets AS (`+scheduledPendingPRsTicketsSQL+`
-		 ORDER BY oldest_open_at, issue_id
+		 ORDER BY oldest_open_at IS NULL, oldest_open_at, issue_id
 		 LIMIT ?)
 		SELECT s.integration, s.integration_workspace, s.issue_id, s.issue_title, s.run_id
 		  FROM task_run_summaries s
@@ -97,17 +103,31 @@ func buildPendingPRsScheduledReport(ctx context.Context, s *Server) (*notify.Mes
 		return nil, false, err
 	}
 
-	prsByRun, err := s.readTaskRunAnalyticsPRsForRuns(tenantID, runIDs)
+	prsByRun, err := s.readTaskRunAnalyticsPRsForRunsContext(ctx, tenantID, runIDs)
 	if err != nil {
 		return nil, false, err
 	}
 	var tickets []*scheduledPendingPRTicket
 	for _, ticket := range ticketsByKey {
+		// task_run_prs is unique per (run, repo, pr_number), so a PR carried
+		// by several runs of the same ticket (a retry continuing the same
+		// branch) appears once per run; render each PR once, keeping the
+		// earliest known opened_at for the age.
+		seen := map[string]int{}
 		for _, runID := range ticket.runIDs {
 			for _, pr := range prsByRun[runID] {
-				if pr.State == "open" && !pr.Merged {
-					ticket.prs = append(ticket.prs, pr)
+				if pr.State != "open" || pr.Merged {
+					continue
 				}
+				key := fmt.Sprintf("%s#%d", pr.Repo, pr.PRNumber)
+				if at, ok := seen[key]; ok {
+					if pr.OpenedAt > 0 && (ticket.prs[at].OpenedAt == 0 || pr.OpenedAt < ticket.prs[at].OpenedAt) {
+						ticket.prs[at] = pr
+					}
+					continue
+				}
+				seen[key] = len(ticket.prs)
+				ticket.prs = append(ticket.prs, pr)
 			}
 		}
 		if len(ticket.prs) > 0 {
@@ -119,7 +139,12 @@ func buildPendingPRsScheduledReport(ctx context.Context, s *Server) (*notify.Mes
 	}
 
 	sort.Slice(tickets, func(i, j int) bool {
-		return scheduledPendingPROldestAt(tickets[i]) < scheduledPendingPROldestAt(tickets[j])
+		oi, oj := scheduledPendingPROldestAt(tickets[i]), scheduledPendingPROldestAt(tickets[j])
+		if (oi > 0) != (oj > 0) {
+			// Unknown ages sort last, matching the SQL cap's ordering.
+			return oi > 0
+		}
+		return oi < oj
 	})
 	nowAt := time.Now()
 	lines := make([]string, 0, len(tickets))
@@ -128,15 +153,19 @@ func buildPendingPRsScheduledReport(ctx context.Context, s *Server) (*notify.Mes
 		for _, pr := range ticket.prs {
 			links = append(links, fmt.Sprintf("#%d %s", pr.PRNumber, pr.URL))
 		}
-		ageDays := int(nowAt.Sub(time.UnixMilli(scheduledPendingPROldestAt(ticket))).Hours() / 24)
-		if ageDays < 0 {
-			ageDays = 0
-		}
 		title := ticket.issueTitle
 		if title == "" {
 			title = ticket.issueID
 		}
-		lines = append(lines, fmt.Sprintf("%s — %s: %s (%d days)", ticket.issueID, title, strings.Join(links, ", "), ageDays))
+		line := fmt.Sprintf("%s — %s: %s", ticket.issueID, title, strings.Join(links, ", "))
+		if oldestAt := scheduledPendingPROldestAt(ticket); oldestAt > 0 {
+			ageDays := int(nowAt.Sub(time.UnixMilli(oldestAt)).Hours() / 24)
+			if ageDays < 0 {
+				ageDays = 0
+			}
+			line += fmt.Sprintf(" (%d days)", ageDays)
+		}
+		lines = append(lines, line)
 	}
 	message := &notify.Message{
 		Title:    "Pending PRs",
@@ -181,10 +210,14 @@ func scheduledPendingPRsBody(lines []string, totalTickets int) string {
 	return truncateRunes(lines[0], scheduledPendingPRsBodyLimit-runeLen(overflow)-1) + "…" + overflow
 }
 
+// scheduledPendingPROldestAt returns the oldest KNOWN opened_at among the
+// ticket's open PRs, or 0 when none carries one: opened_at=0 means unknown,
+// and treating it as the epoch would render a ~20000-day age and sort the
+// ticket ahead of genuinely old ones.
 func scheduledPendingPROldestAt(ticket *scheduledPendingPRTicket) int64 {
-	oldestAt := ticket.prs[0].OpenedAt
-	for _, pr := range ticket.prs[1:] {
-		if pr.OpenedAt < oldestAt {
+	var oldestAt int64
+	for _, pr := range ticket.prs {
+		if pr.OpenedAt > 0 && (oldestAt == 0 || pr.OpenedAt < oldestAt) {
 			oldestAt = pr.OpenedAt
 		}
 	}

--- a/pkg/hub/scheduled_report_pending_prs.go
+++ b/pkg/hub/scheduled_report_pending_prs.go
@@ -25,27 +25,50 @@ type scheduledPendingPRTicket struct {
 	prs        []taskRunAnalyticsPRView
 }
 
+// scheduledPendingPRsTicketsSQL selects one row per ticket that currently has
+// at least one open PR, keyed by (integration, workspace, issue_id). It joins
+// task_run_prs directly — the same truth the rendered PR list reads — instead
+// of the summaries' open_pr_count, and applies the requires_pr=1 AND
+// analytics_enabled=1 defaults every analytics view applies
+// (taskRunAnalyticsSummaryWhere), so the digest never names a ticket the
+// linked /analytics page hides. Deliberately no time window on the runs: a
+// ticket of ANY age with a still-open PR is exactly what this report exists
+// to surface.
+const scheduledPendingPRsTicketsSQL = `
+	SELECT s.integration, s.integration_workspace, s.issue_id, MIN(p.opened_at) AS oldest_open_at
+	  FROM task_run_summaries s
+	  JOIN task_run_prs p ON p.tenant_id=s.tenant_id AND p.run_id=s.run_id
+	 WHERE s.tenant_id=? AND s.issue_id != '' AND s.requires_pr=1 AND s.analytics_enabled=1
+	   AND p.state='open' AND p.merged=0
+	 GROUP BY s.integration, s.integration_workspace, s.issue_id`
+
 func buildPendingPRsScheduledReport(ctx context.Context, s *Server) (*notify.Message, bool, error) {
 	tenantID, err := s.githubTenantID()
 	if err != nil {
 		return nil, false, err
 	}
+	var total int
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM (`+scheduledPendingPRsTicketsSQL+`)`, tenantID).Scan(&total); err != nil {
+		return nil, false, err
+	}
+	if total == 0 {
+		return nil, false, nil
+	}
+	// Cap the ticket set in SQL — keeping the oldest open PRs, the ones the
+	// report most wants eyes on — so rendering ~20 lines never loads every
+	// run and PR of every pending ticket.
 	rows, err := s.db.QueryContext(ctx, `
-		WITH pending_tickets AS (
-			SELECT integration, integration_workspace, issue_id
-			  FROM task_run_summaries
-			 WHERE tenant_id=? AND issue_id != ''
-			 GROUP BY integration, integration_workspace, issue_id
-			HAVING SUM(open_pr_count) > 0
-		)
-		SELECT s.integration, s.integration_workspace, s.issue_id, s.issue_title, s.run_id, s.started_at
+		WITH pending_tickets AS (`+scheduledPendingPRsTicketsSQL+`
+		 ORDER BY oldest_open_at, issue_id
+		 LIMIT ?)
+		SELECT s.integration, s.integration_workspace, s.issue_id, s.issue_title, s.run_id
 		  FROM task_run_summaries s
 		  JOIN pending_tickets p
 		    ON p.integration=s.integration
 		   AND p.integration_workspace=s.integration_workspace
 		   AND p.issue_id=s.issue_id
-		 WHERE s.tenant_id=?
-		 ORDER BY s.started_at DESC`, tenantID, tenantID)
+		 WHERE s.tenant_id=? AND s.requires_pr=1 AND s.analytics_enabled=1
+		 ORDER BY s.started_at DESC`, tenantID, scheduledPendingPRsTicketLimit, tenantID)
 	if err != nil {
 		return nil, false, err
 	}
@@ -55,8 +78,7 @@ func buildPendingPRsScheduledReport(ctx context.Context, s *Server) (*notify.Mes
 	var runIDs []string
 	for rows.Next() {
 		var integration, workspace, issueID, issueTitle, runID string
-		var startedAt int64
-		if err := rows.Scan(&integration, &workspace, &issueID, &issueTitle, &runID, &startedAt); err != nil {
+		if err := rows.Scan(&integration, &workspace, &issueID, &issueTitle, &runID); err != nil {
 			return nil, false, err
 		}
 		key := taskRunAnalyticsTicketKey(integration, workspace, issueID)
@@ -100,8 +122,8 @@ func buildPendingPRsScheduledReport(ctx context.Context, s *Server) (*notify.Mes
 		return scheduledPendingPROldestAt(tickets[i]) < scheduledPendingPROldestAt(tickets[j])
 	})
 	nowAt := time.Now()
-	lines := make([]string, 0, min(len(tickets), scheduledPendingPRsTicketLimit)+1)
-	for _, ticket := range tickets[:min(len(tickets), scheduledPendingPRsTicketLimit)] {
+	lines := make([]string, 0, len(tickets))
+	for _, ticket := range tickets {
 		links := make([]string, 0, len(ticket.prs))
 		for _, pr := range ticket.prs {
 			links = append(links, fmt.Sprintf("#%d %s", pr.PRNumber, pr.URL))
@@ -116,24 +138,47 @@ func buildPendingPRsScheduledReport(ctx context.Context, s *Server) (*notify.Mes
 		}
 		lines = append(lines, fmt.Sprintf("%s — %s: %s (%d days)", ticket.issueID, title, strings.Join(links, ", "), ageDays))
 	}
-	if len(tickets) > scheduledPendingPRsTicketLimit {
-		lines = append(lines, fmt.Sprintf("…and %d more", len(tickets)-scheduledPendingPRsTicketLimit))
-	}
-	body := strings.Join(lines, "\n")
-	if runeLen(body) > scheduledPendingPRsBodyLimit {
-		body = truncateRunes(body, scheduledPendingPRsBodyLimit-1) + "…"
-	}
 	message := &notify.Message{
 		Title:    "Pending PRs",
 		Emoji:    ":information_source:",
 		Severity: notify.SeverityInfo,
-		Body:     body,
-		Summary:  []string{fmt.Sprintf("%d tickets with open PRs", len(tickets))},
+		Body:     scheduledPendingPRsBody(lines, total),
+		Summary:  []string{fmt.Sprintf("%d tickets with open PRs", total)},
 	}
 	if hubURL := strings.TrimRight(s.clawHubURL(), "/"); hubURL != "" {
 		message.Link = notify.Link{URL: hubURL + "/analytics", Label: "View tickets"}
 	}
 	return message, true, nil
+}
+
+// scheduledPendingPRsBody fits the ticket lines into the body limit by
+// dropping whole trailing lines FIRST and appending the overflow line last,
+// so "…and N more" survives the cut instead of being the first thing
+// truncated. N counts every ticket not rendered as its own line — the ones
+// past the SQL cap and the ones dropped here.
+func scheduledPendingPRsBody(lines []string, totalTickets int) string {
+	compose := func(lines []string) string {
+		body := strings.Join(lines, "\n")
+		if more := totalTickets - len(lines); more > 0 {
+			body += fmt.Sprintf("\n…and %d more", more)
+		}
+		return body
+	}
+	body := compose(lines)
+	for runeLen(body) > scheduledPendingPRsBodyLimit && len(lines) > 1 {
+		lines = lines[:len(lines)-1]
+		body = compose(lines)
+	}
+	if runeLen(body) <= scheduledPendingPRsBodyLimit {
+		return body
+	}
+	// A single ticket line alone exceeds the limit: truncate the line itself,
+	// still keeping the overflow count intact after it.
+	overflow := ""
+	if more := totalTickets - 1; more > 0 {
+		overflow = fmt.Sprintf("\n…and %d more", more)
+	}
+	return truncateRunes(lines[0], scheduledPendingPRsBodyLimit-runeLen(overflow)-1) + "…" + overflow
 }
 
 func scheduledPendingPROldestAt(ticket *scheduledPendingPRTicket) int64 {

--- a/pkg/hub/scheduled_report_pending_prs_test.go
+++ b/pkg/hub/scheduled_report_pending_prs_test.go
@@ -1,0 +1,93 @@
+package hub
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPendingPRsScheduledReport(t *testing.T) {
+	s, db := newTaskRunAnalyticsAPITestServer(t)
+	nowAt := time.Now()
+	insertPendingPRReportRun(t, db, "first", "ENG-1", "eng", "Older title", nowAt.Add(-72*time.Hour), 1)
+	insertPendingPRReportRun(t, db, "second", "ENG-1", "eng", "Latest title", nowAt.Add(-24*time.Hour), 1)
+	insertPendingPRReportRun(t, db, "other-workspace", "ENG-1", "product", "Other workspace", nowAt.Add(-48*time.Hour), 1)
+	insertPendingPRReportRun(t, db, "empty", "", "eng", "Ignored", nowAt.Add(-96*time.Hour), 1)
+	insertPendingPRReportPR(t, db, "first", 1, "open", false, nowAt.Add(-72*time.Hour))
+	insertPendingPRReportPR(t, db, "first", 2, "closed", false, nowAt.Add(-72*time.Hour))
+	insertPendingPRReportPR(t, db, "second", 3, "open", true, nowAt.Add(-24*time.Hour))
+	insertPendingPRReportPR(t, db, "second", 4, "open", false, nowAt.Add(-48*time.Hour))
+	insertPendingPRReportPR(t, db, "other-workspace", 5, "open", false, nowAt.Add(-48*time.Hour))
+
+	message, ok, err := buildPendingPRsScheduledReport(context.Background(), s)
+	if err != nil || !ok {
+		t.Fatalf("build report = %v, %v, want report", ok, err)
+	}
+	if message.Title != "Pending PRs" || message.Summary[0] != "2 tickets with open PRs" {
+		t.Fatalf("message = %#v", message)
+	}
+	if !strings.Contains(message.Body, "ENG-1 — Latest title") || !strings.Contains(message.Body, "#1 https://example.test/first/1") || !strings.Contains(message.Body, "#4 https://example.test/second/4") {
+		t.Fatalf("body = %q", message.Body)
+	}
+	if strings.Contains(message.Body, "#2") || strings.Contains(message.Body, "#3") || strings.Contains(message.Body, "Ignored") {
+		t.Fatalf("body includes closed, merged, or empty-ticket PR: %q", message.Body)
+	}
+}
+
+func TestPendingPRsScheduledReportCapsTickets(t *testing.T) {
+	s, db := newTaskRunAnalyticsAPITestServer(t)
+	nowAt := time.Now()
+	for i := 0; i < 21; i++ {
+		runID := fmt.Sprintf("cap-%d", i)
+		insertPendingPRReportRun(t, db, runID, fmt.Sprintf("ENG-%d", i), "eng", fmt.Sprintf("Ticket %d", i), nowAt.Add(-time.Duration(i+1)*time.Hour), 1)
+		insertPendingPRReportPR(t, db, runID, i+1, "open", false, nowAt.Add(-time.Duration(i+1)*time.Hour))
+	}
+
+	message, ok, err := buildPendingPRsScheduledReport(context.Background(), s)
+	if err != nil || !ok {
+		t.Fatalf("build report = %v, %v, want report", ok, err)
+	}
+	if got := strings.Count(message.Body, " days)"); got != scheduledPendingPRsTicketLimit {
+		t.Fatalf("ticket lines = %d, want %d: %q", got, scheduledPendingPRsTicketLimit, message.Body)
+	}
+	if !strings.HasSuffix(message.Body, "…and 1 more") {
+		t.Fatalf("body = %q", message.Body)
+	}
+}
+
+func TestPendingPRsScheduledReportReturnsFalseWithoutOpenTickets(t *testing.T) {
+	s, db := newTaskRunAnalyticsAPITestServer(t)
+	insertPendingPRReportRun(t, db, "closed", "ENG-1", "eng", "Closed", time.Now(), 0)
+
+	message, ok, err := buildPendingPRsScheduledReport(context.Background(), s)
+	if err != nil || ok || message != nil {
+		t.Fatalf("build report = %#v, %v, %v, want nil, false, nil", message, ok, err)
+	}
+}
+
+func insertPendingPRReportRun(t *testing.T, db *sql.DB, runID, issueID, workspace, title string, startedAt time.Time, openPRCount int) {
+	t.Helper()
+	startedAtMillis := startedAt.UnixMilli()
+	insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{
+		RunID: runID, AttemptID: "attempt-" + runID, ClawID: "claw-" + runID, TenantID: "test-tenant-id",
+		Status: taskRunStatusClean, Phase: taskRunPhaseTerminal, OwnerType: taskRunOwnerWorkflow,
+		Integration: "linear", StartedAt: startedAtMillis, IssueTitle: title, OpenPRCount: openPRCount,
+	})
+	if _, err := db.Exec(`UPDATE task_run_summaries SET issue_id=?, integration_workspace=? WHERE run_id=?`, issueID, workspace, runID); err != nil {
+		t.Fatalf("set pending PR report ticket: %v", err)
+	}
+}
+
+func insertPendingPRReportPR(t *testing.T, db *sql.DB, runID string, number int, state string, merged bool, openedAt time.Time) {
+	t.Helper()
+	if _, err := db.Exec(`
+		INSERT INTO task_run_prs(id,tenant_id,run_id,repo,pr_number,pr_url,state,merged,opened_at,created_at,updated_at)
+		VALUES(?,?,?,?,?,?,?,?,?,?,?)`,
+		fmt.Sprintf("pr-%s-%d", runID, number), "test-tenant-id", runID, "acme/app", number,
+		fmt.Sprintf("https://example.test/%s/%d", runID, number), state, boolInt(merged), openedAt.UnixMilli(), openedAt.UnixMilli(), openedAt.UnixMilli()); err != nil {
+		t.Fatalf("insert PR: %v", err)
+	}
+}

--- a/pkg/hub/scheduled_report_pending_prs_test.go
+++ b/pkg/hub/scheduled_report_pending_prs_test.go
@@ -122,6 +122,57 @@ func TestPendingPRsScheduledReportTruncatesTicketLinesBeforeOverflowLine(t *test
 	}
 }
 
+// opened_at=0 on an open PR means the opening time is unknown, not 1970: such
+// a ticket must not render a ~20000-day age, and must sort behind tickets
+// whose age is known instead of displacing them from the cap.
+func TestPendingPRsScheduledReportTreatsZeroOpenedAtAsUnknown(t *testing.T) {
+	s, db := newTaskRunAnalyticsAPITestServer(t)
+	nowAt := time.Now()
+	insertPendingPRReportRun(t, db, "known", "ENG-1", "eng", "Known age", nowAt.Add(-20*24*time.Hour), 1)
+	insertPendingPRReportPR(t, db, "known", 1, "open", false, nowAt.Add(-20*24*time.Hour))
+	insertPendingPRReportRun(t, db, "unknown", "ENG-2", "eng", "Unknown age", nowAt.Add(-time.Hour), 1)
+	insertPendingPRReportPR(t, db, "unknown", 2, "open", false, time.UnixMilli(0))
+
+	message, ok, err := buildPendingPRsScheduledReport(context.Background(), s)
+	if err != nil || !ok {
+		t.Fatalf("build report = %v, %v, want report", ok, err)
+	}
+	if !strings.Contains(message.Body, "(20 days)") {
+		t.Fatalf("known-age ticket lost its age: %q", message.Body)
+	}
+	if strings.Index(message.Body, "ENG-1") > strings.Index(message.Body, "ENG-2") {
+		t.Fatalf("unknown-age ticket sorted ahead of a genuinely old one: %q", message.Body)
+	}
+	for _, line := range strings.Split(message.Body, "\n") {
+		if strings.Contains(line, "ENG-2") && strings.Contains(line, " days)") {
+			t.Fatalf("unknown opened_at rendered as an age: %q", line)
+		}
+	}
+}
+
+// A PR linked to multiple runs of the same ticket (a retry continuing the same
+// branch) renders once per ticket line, with the earliest known opened_at
+// backing the age.
+func TestPendingPRsScheduledReportDeduplicatesPRSharedAcrossRuns(t *testing.T) {
+	s, db := newTaskRunAnalyticsAPITestServer(t)
+	nowAt := time.Now()
+	insertPendingPRReportRun(t, db, "run-a", "ENG-1", "eng", "Retried ticket", nowAt.Add(-48*time.Hour), 1)
+	insertPendingPRReportRun(t, db, "run-b", "ENG-1", "eng", "Retried ticket", nowAt.Add(-24*time.Hour), 1)
+	insertPendingPRReportPR(t, db, "run-a", 7, "open", false, nowAt.Add(-48*time.Hour))
+	insertPendingPRReportPR(t, db, "run-b", 7, "open", false, nowAt.Add(-24*time.Hour))
+
+	message, ok, err := buildPendingPRsScheduledReport(context.Background(), s)
+	if err != nil || !ok {
+		t.Fatalf("build report = %v, %v, want report", ok, err)
+	}
+	if got := strings.Count(message.Body, "#7 "); got != 1 {
+		t.Fatalf("shared PR rendered %d times, want 1: %q", got, message.Body)
+	}
+	if !strings.Contains(message.Body, "(2 days)") {
+		t.Fatalf("age is not backed by the earliest opened_at: %q", message.Body)
+	}
+}
+
 func insertPendingPRReportExcludedRun(t *testing.T, db *sql.DB, runID, issueID string, requiresPR, analyticsEnabled *bool, startedAt time.Time) {
 	t.Helper()
 	insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{

--- a/pkg/hub/scheduled_report_pending_prs_test.go
+++ b/pkg/hub/scheduled_report_pending_prs_test.go
@@ -218,6 +218,66 @@ func TestPendingPRsScheduledReportRenderSkipsPRResolvedOnAnotherTicket(t *testin
 	}
 }
 
+// merged=1 is terminal, but state='closed' is reversible on GitHub: a PR
+// closed unmerged under run A and reopened under a retry run B (whose open row
+// is newer) must reappear in the digest — A's latched close must not veto the
+// ticket forever.
+func TestPendingPRsScheduledReportReopenedPRReappears(t *testing.T) {
+	s, db := newTaskRunAnalyticsAPITestServer(t)
+	nowAt := time.Now()
+	insertPendingPRReportRun(t, db, "run-a", "ENG-1", "eng", "Reopened ticket", nowAt.Add(-72*time.Hour), 0)
+	insertPendingPRReportRun(t, db, "run-b", "ENG-1", "eng", "Reopened ticket", nowAt.Add(-24*time.Hour), 1)
+	insertPendingPRReportPR(t, db, "run-a", 7, "closed", false, nowAt.Add(-72*time.Hour))
+	insertPendingPRReportPR(t, db, "run-b", 7, "open", false, nowAt.Add(-24*time.Hour))
+
+	message, ok, err := buildPendingPRsScheduledReport(context.Background(), s)
+	if err != nil || !ok {
+		t.Fatalf("build report = %v, %v, want the reopened ticket reported", ok, err)
+	}
+	if !strings.Contains(message.Body, "#7 ") {
+		t.Fatalf("body = %q, want the reopened #7 rendered", message.Body)
+	}
+}
+
+// The inverse preserves the zombie-row resolution: an open row OLDER than the
+// row recording the close is a stranded snapshot, not a reopen, and stays
+// suppressed even when the close is unmerged.
+func TestPendingPRsScheduledReportOlderOpenRowStaysSuppressed(t *testing.T) {
+	s, db := newTaskRunAnalyticsAPITestServer(t)
+	nowAt := time.Now()
+	insertPendingPRReportRun(t, db, "run-a", "ENG-1", "eng", "Closed ticket", nowAt.Add(-72*time.Hour), 1)
+	insertPendingPRReportRun(t, db, "run-b", "ENG-1", "eng", "Closed ticket", nowAt.Add(-24*time.Hour), 0)
+	insertPendingPRReportPR(t, db, "run-a", 7, "open", false, nowAt.Add(-72*time.Hour))
+	insertPendingPRReportPR(t, db, "run-b", 7, "closed", false, nowAt.Add(-24*time.Hour))
+
+	message, ok, err := buildPendingPRsScheduledReport(context.Background(), s)
+	if err != nil || ok || message != nil {
+		t.Fatalf("build report = %#v, %v, %v, want nil, false, nil — the stranded open row predates the close", message, ok, err)
+	}
+}
+
+// The render filter applies the same recency rule tenant-wide: a reopened PR
+// whose pre-reopen close was recorded by ANOTHER ticket's run must still
+// render alongside the ticket's other open PRs.
+func TestPendingPRsScheduledReportRenderKeepsPRReopenedAfterCloseElsewhere(t *testing.T) {
+	s, db := newTaskRunAnalyticsAPITestServer(t)
+	nowAt := time.Now()
+	insertPendingPRReportRun(t, db, "run-a", "ENG-1", "eng", "Reopened ticket", nowAt.Add(-24*time.Hour), 2)
+	insertPendingPRReportPR(t, db, "run-a", 7, "open", false, nowAt.Add(-24*time.Hour))
+	insertPendingPRReportPR(t, db, "run-a", 8, "open", false, nowAt.Add(-24*time.Hour))
+	// A run of a DIFFERENT ticket recorded #7 closed unmerged BEFORE the reopen.
+	insertPendingPRReportRun(t, db, "run-other", "ENG-2", "eng", "Other ticket", nowAt.Add(-72*time.Hour), 0)
+	insertPendingPRReportPR(t, db, "run-other", 7, "closed", false, nowAt.Add(-72*time.Hour))
+
+	message, ok, err := buildPendingPRsScheduledReport(context.Background(), s)
+	if err != nil || !ok {
+		t.Fatalf("build report = %v, %v, want report", ok, err)
+	}
+	if !strings.Contains(message.Body, "#7 ") || !strings.Contains(message.Body, "#8 ") {
+		t.Fatalf("body = %q, want both the reopened #7 and #8 rendered", message.Body)
+	}
+}
+
 func insertPendingPRReportExcludedRun(t *testing.T, db *sql.DB, runID, issueID string, requiresPR, analyticsEnabled *bool, startedAt time.Time) {
 	t.Helper()
 	insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{

--- a/pkg/hub/scheduled_report_pending_prs_test.go
+++ b/pkg/hub/scheduled_report_pending_prs_test.go
@@ -68,6 +68,74 @@ func TestPendingPRsScheduledReportReturnsFalseWithoutOpenTickets(t *testing.T) {
 	}
 }
 
+// The report applies the requires_pr=1 AND analytics_enabled=1 defaults every
+// analytics view applies, so the digest never names a ticket the linked
+// /analytics page hides (and its count matches the dashboard's).
+func TestPendingPRsScheduledReportAppliesAnalyticsDefaults(t *testing.T) {
+	s, db := newTaskRunAnalyticsAPITestServer(t)
+	nowAt := time.Now()
+	insertPendingPRReportRun(t, db, "visible", "ENG-1", "eng", "Visible", nowAt.Add(-24*time.Hour), 1)
+	insertPendingPRReportPR(t, db, "visible", 1, "open", false, nowAt.Add(-24*time.Hour))
+	insertPendingPRReportExcludedRun(t, db, "not-pr-task", "ENG-2", boolPtr(false), nil, nowAt.Add(-24*time.Hour))
+	insertPendingPRReportPR(t, db, "not-pr-task", 2, "open", false, nowAt.Add(-24*time.Hour))
+	insertPendingPRReportExcludedRun(t, db, "analytics-off", "ENG-3", nil, boolPtr(false), nowAt.Add(-24*time.Hour))
+	insertPendingPRReportPR(t, db, "analytics-off", 3, "open", false, nowAt.Add(-24*time.Hour))
+
+	message, ok, err := buildPendingPRsScheduledReport(context.Background(), s)
+	if err != nil || !ok {
+		t.Fatalf("build report = %v, %v, want report", ok, err)
+	}
+	if message.Summary[0] != "1 tickets with open PRs" {
+		t.Fatalf("summary = %q — excluded runs leaked into the count", message.Summary[0])
+	}
+	if strings.Contains(message.Body, "ENG-2") || strings.Contains(message.Body, "ENG-3") {
+		t.Fatalf("body names tickets the analytics views hide: %q", message.Body)
+	}
+}
+
+// The overflow line is appended AFTER the body is fitted into the rune limit,
+// so "…and N more" survives instead of being the first thing truncated, and N
+// counts the dropped lines too.
+func TestPendingPRsScheduledReportTruncatesTicketLinesBeforeOverflowLine(t *testing.T) {
+	s, db := newTaskRunAnalyticsAPITestServer(t)
+	nowAt := time.Now()
+	longTitle := strings.Repeat("very long ticket title ", 20)
+	for i := 0; i < 21; i++ {
+		runID := fmt.Sprintf("trunc-%d", i)
+		insertPendingPRReportRun(t, db, runID, fmt.Sprintf("ENG-%d", i), "eng", longTitle, nowAt.Add(-time.Duration(i+1)*time.Hour), 1)
+		insertPendingPRReportPR(t, db, runID, i+1, "open", false, nowAt.Add(-time.Duration(i+1)*time.Hour))
+	}
+
+	message, ok, err := buildPendingPRsScheduledReport(context.Background(), s)
+	if err != nil || !ok {
+		t.Fatalf("build report = %v, %v, want report", ok, err)
+	}
+	if runeLen(message.Body) > scheduledPendingPRsBodyLimit {
+		t.Fatalf("body is %d runes, over the %d limit", runeLen(message.Body), scheduledPendingPRsBodyLimit)
+	}
+	shown := strings.Count(message.Body, " days)")
+	if shown == 0 || shown >= 21 {
+		t.Fatalf("expected some but not all ticket lines to survive, got %d", shown)
+	}
+	if !strings.HasSuffix(message.Body, fmt.Sprintf("…and %d more", 21-shown)) {
+		t.Fatalf("overflow line missing or miscounted (shown=%d): %q", shown, message.Body)
+	}
+}
+
+func insertPendingPRReportExcludedRun(t *testing.T, db *sql.DB, runID, issueID string, requiresPR, analyticsEnabled *bool, startedAt time.Time) {
+	t.Helper()
+	insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{
+		RunID: runID, AttemptID: "attempt-" + runID, ClawID: "claw-" + runID, TenantID: "test-tenant-id",
+		Status: taskRunStatusClean, Phase: taskRunPhaseTerminal, OwnerType: taskRunOwnerWorkflow,
+		Integration: "linear", StartedAt: startedAt.UnixMilli(), IssueTitle: "Excluded",
+		RequiresPR: requiresPR, AnalyticsEnabled: analyticsEnabled, ExcludedReason: "excluded",
+		OpenPRCount: 1,
+	})
+	if _, err := db.Exec(`UPDATE task_run_summaries SET issue_id=?, integration_workspace='eng' WHERE run_id=?`, issueID, runID); err != nil {
+		t.Fatalf("set excluded pending PR report ticket: %v", err)
+	}
+}
+
 func insertPendingPRReportRun(t *testing.T, db *sql.DB, runID, issueID, workspace, title string, startedAt time.Time, openPRCount int) {
 	t.Helper()
 	startedAtMillis := startedAt.UnixMilli()

--- a/pkg/hub/scheduled_report_pending_prs_test.go
+++ b/pkg/hub/scheduled_report_pending_prs_test.go
@@ -173,6 +173,51 @@ func TestPendingPRsScheduledReportDeduplicatesPRSharedAcrossRuns(t *testing.T) {
 	}
 }
 
+// PR state is resolved across rows per (repo, pr_number): pr_watcher only
+// visits live claws, so a run can strand an (open, merged=0) row for a PR
+// another run's row already records as merged or closed. Such a zombie row
+// must not surface the ticket — with no time window it would occupy the
+// oldest-first cap forever.
+func TestPendingPRsScheduledReportResolvesPRStateAcrossRuns(t *testing.T) {
+	s, db := newTaskRunAnalyticsAPITestServer(t)
+	nowAt := time.Now()
+	insertPendingPRReportRun(t, db, "run-a", "ENG-1", "eng", "Merged ticket", nowAt.Add(-48*time.Hour), 1)
+	insertPendingPRReportRun(t, db, "run-b", "ENG-1", "eng", "Merged ticket", nowAt.Add(-24*time.Hour), 0)
+	// run-a's row is stranded open; run-b knows the same PR merged.
+	insertPendingPRReportPR(t, db, "run-a", 7, "open", false, nowAt.Add(-48*time.Hour))
+	insertPendingPRReportPR(t, db, "run-b", 7, "closed", true, nowAt.Add(-48*time.Hour))
+
+	message, ok, err := buildPendingPRsScheduledReport(context.Background(), s)
+	if err != nil || ok || message != nil {
+		t.Fatalf("build report = %#v, %v, %v, want nil, false, nil — the only 'open' PR is recorded merged elsewhere", message, ok, err)
+	}
+}
+
+// The render filter applies the same cross-row resolution tenant-wide: a
+// ticket that qualifies via a genuinely open PR must not also render a zombie
+// row whose resolving row belongs to another ticket's run.
+func TestPendingPRsScheduledReportRenderSkipsPRResolvedOnAnotherTicket(t *testing.T) {
+	s, db := newTaskRunAnalyticsAPITestServer(t)
+	nowAt := time.Now()
+	insertPendingPRReportRun(t, db, "run-a", "ENG-1", "eng", "Half zombie", nowAt.Add(-48*time.Hour), 2)
+	insertPendingPRReportPR(t, db, "run-a", 7, "open", false, nowAt.Add(-48*time.Hour))
+	insertPendingPRReportPR(t, db, "run-a", 8, "open", false, nowAt.Add(-24*time.Hour))
+	// A run of a DIFFERENT ticket records #7 merged.
+	insertPendingPRReportRun(t, db, "run-other", "ENG-2", "eng", "Other ticket", nowAt.Add(-12*time.Hour), 0)
+	insertPendingPRReportPR(t, db, "run-other", 7, "closed", true, nowAt.Add(-12*time.Hour))
+
+	message, ok, err := buildPendingPRsScheduledReport(context.Background(), s)
+	if err != nil || !ok {
+		t.Fatalf("build report = %v, %v, want report", ok, err)
+	}
+	if message.Summary[0] != "1 tickets with open PRs" {
+		t.Fatalf("summary = %q, want only the genuinely pending ticket counted", message.Summary[0])
+	}
+	if !strings.Contains(message.Body, "#8 ") || strings.Contains(message.Body, "#7 ") {
+		t.Fatalf("body = %q, want #8 rendered and the resolved #7 skipped", message.Body)
+	}
+}
+
 func insertPendingPRReportExcludedRun(t *testing.T, db *sql.DB, runID, issueID string, requiresPR, analyticsEnabled *bool, startedAt time.Time) {
 	t.Helper()
 	insertTaskRunAnalyticsAPIRun(t, db, apiRunFixture{

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -207,6 +207,12 @@ type Server struct {
 	// its delivery row (see stopLifecycleNotifier).
 	lifecycleNotifierStop chan struct{}
 	lifecycleNotifierDone chan struct{}
+
+	// scheduledNotifierStop/Done plumb the same graceful shutdown for the
+	// scheduled-report loop: its dedupe-state upsert after a completed Slack
+	// send must land before the DB closes, or the slot re-sends after restart.
+	scheduledNotifierStop chan struct{}
+	scheduledNotifierDone chan struct{}
 }
 
 // cachedNotifier is one constructed notifier plus the config/secret digest it
@@ -598,11 +604,13 @@ func (s *Server) run(ctx context.Context, opts ...RunOptions) error {
 		// ListenAndServe returns as soon as Shutdown starts. Wait for it to
 		// finish draining active requests before closing their database.
 		<-shutdownDone
-		// Stop the lifecycle notifier before the DB closes: a tick in flight
+		// Stop both notifier loops before the DB closes: a tick in flight
 		// could otherwise complete an external Slack send and then fail the
-		// delivery-row insert against the closed DB, re-sending the event
-		// after restart (the in-memory retry stash dies with the process).
+		// delivery-row insert (or scheduled dedupe-state upsert) against the
+		// closed DB, re-sending the event after restart (the in-memory retry
+		// stash dies with the process).
 		s.stopLifecycleNotifier(10 * time.Second)
+		s.stopScheduledNotifier(10 * time.Second)
 		if closeErr := s.db.Close(); closeErr != nil {
 			return fmt.Errorf("close database: %w", closeErr)
 		}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -213,6 +213,12 @@ type Server struct {
 	// send must land before the DB closes, or the slot re-sends after restart.
 	scheduledNotifierStop chan struct{}
 	scheduledNotifierDone chan struct{}
+
+	// scheduledTransientFailures tracks consecutive transient send failures
+	// per scheduled (id, via) state key, bounding minutely retries of one
+	// slot (see scheduledMaxTransientFailures). Only the serially-run
+	// scheduled notifier tick touches it, so it needs no lock.
+	scheduledTransientFailures map[string]scheduledFailureStreak
 }
 
 // cachedNotifier is one constructed notifier plus the config/secret digest it

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -526,6 +526,7 @@ func NewServer(addr, dbPath, identityDir string, hubCfg *types.HubConfig) (*Serv
 	}
 	srv.startIntegrationPoller()
 	srv.startLifecycleNotifier()
+	srv.startScheduledNotifier()
 
 	return srv, nil
 }

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -216,8 +216,10 @@ type Server struct {
 
 	// scheduledTransientFailures tracks consecutive transient send failures
 	// per scheduled (id, via) state key, bounding minutely retries of one
-	// slot (see scheduledMaxTransientFailures). Only the serially-run
-	// scheduled notifier tick touches it, so it needs no lock.
+	// slot (see scheduledMaxTransientFailures). Shared between the
+	// serially-run scheduled notifier tick and the settings PATCH handler
+	// (which prunes it via pruneScheduledState), hence the lock.
+	scheduledFailureMu         sync.Mutex
 	scheduledTransientFailures map[string]scheduledFailureStreak
 }
 
@@ -993,22 +995,34 @@ func (s *Server) resolveAuthToken(token string) (tenantID, githubLogin string, o
 
 // githubTenantID resolves the tenant backing GitHub OAuth sessions.
 func (s *Server) githubTenantID() (string, error) {
+	return s.githubTenantIDContext(context.Background())
+}
+
+// githubTenantIDContext is the ctx-bounded variant for callers whose queries
+// must honour a deadline or shutdown cancellation (the scheduled pending_prs
+// report builds under a 30s context and is cancelled at shutdown; a ctx-less
+// query would escape both).
+func (s *Server) githubTenantIDContext(ctx context.Context) (string, error) {
 	s.mu.RLock()
 	hubToken := s.hubCfg.Token
 	s.mu.RUnlock()
 	if hubToken != "" {
-		if tenantID, err := s.tenantByToken(hubToken); err == nil {
+		if tenantID, err := s.tenantByTokenContext(ctx, hubToken); err == nil {
 			return tenantID, nil
 		}
 	}
 	var tenantID string
-	err := s.db.QueryRow(`SELECT id FROM tenants ORDER BY created_at ASC LIMIT 1`).Scan(&tenantID)
+	err := s.db.QueryRowContext(ctx, `SELECT id FROM tenants ORDER BY created_at ASC LIMIT 1`).Scan(&tenantID)
 	return tenantID, err
 }
 
 func (s *Server) tenantByToken(token string) (string, error) {
+	return s.tenantByTokenContext(context.Background(), token)
+}
+
+func (s *Server) tenantByTokenContext(ctx context.Context, token string) (string, error) {
 	var id string
-	err := s.db.QueryRow(`SELECT id FROM tenants WHERE token = ?`, token).Scan(&id)
+	err := s.db.QueryRowContext(ctx, `SELECT id FROM tenants WHERE token = ?`, token).Scan(&id)
 	return id, err
 }
 

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -858,15 +858,18 @@ func validateSettingsNotifications(current, cfg *types.NotificationsConfig) erro
 			return fmt.Errorf("notifications.notifiers.%s: %w", name, err)
 		}
 	}
-	// Report names are checked only on schedules the patch adds or changes,
-	// for the same reason notifier construction is: the report registry is a
-	// property of THIS build, so a hub.yaml naming a report an older or newer
-	// binary carries is legitimate on disk (the scheduler logs "not
-	// registered" per tick and delivers nothing). The screen submits the whole
-	// scheduled list on every save, so failing on a stored entry would 400
-	// every save — including the one that deletes the offender.
+	// Report names are checked only on schedules the patch adds or whose
+	// report it changes, for the same reason notifier construction is: the
+	// report registry is a property of THIS build, so a hub.yaml naming a
+	// report an older or newer binary carries is legitimate on disk (the
+	// scheduler logs "not registered" per tick and delivers nothing). The
+	// screen submits the whole scheduled list on every save, so failing on a
+	// stored entry would 400 every save — including the one that deletes the
+	// offender, and every other edit to the entry itself: pausing it (which
+	// the doctor's "pause before upgrading" guidance depends on), re-routing
+	// it, or moving its slot.
 	for i, scheduled := range cfg.Scheduled {
-		if scheduledNotificationUnchanged(current, scheduled) {
+		if scheduledReportUnchanged(current, scheduled) {
 			continue
 		}
 		if !ScheduledReportSupported(scheduled.Report) {
@@ -877,24 +880,22 @@ func validateSettingsNotifications(current, cfg *types.NotificationsConfig) erro
 	return nil
 }
 
-// scheduledNotificationUnchanged reports whether the patched schedule matches
-// the one already stored under the same id.
+// scheduledReportUnchanged reports whether a stored schedule under the same id
+// already names the patched schedule's report.
 //
-// Compared through the settings view rather than field by field: the view is
-// what the screen round-trips, and it normalises exactly the shapes that make
-// a byte comparison lie — an absent `enabled` (which means true) coming back
-// as an explicit `true`, and an absent `weekdays` (every day) coming back as
-// []. Without that normalisation an untouched schedule reads as changed on
-// every save, which is precisely the case this function exists to exempt.
-func scheduledNotificationUnchanged(current *types.NotificationsConfig, patched types.ScheduledNotificationConfig) bool {
+// Only the report field is compared: the check this gates is against the
+// report registry of THIS build, so every other edit to a stored schedule —
+// pausing it, re-routing it, moving its slot — must stay possible even when
+// the stored report is one this binary does not carry. Comparing the whole
+// schedule here once made exactly those edits 400 with "unknown report".
+func scheduledReportUnchanged(current *types.NotificationsConfig, patched types.ScheduledNotificationConfig) bool {
 	if current == nil {
 		return false
 	}
 	for _, stored := range current.Scheduled {
-		if stored.ID != patched.ID {
-			continue
+		if stored.ID == patched.ID {
+			return stored.Report == patched.Report
 		}
-		return reflect.DeepEqual(scheduledNotificationViewOf(stored), scheduledNotificationViewOf(patched))
 	}
 	return false
 }
@@ -1131,6 +1132,15 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 		// the only channel binding the hub has.
 		if patch.Notifications.Lifecycle != nil && len(patch.Notifications.Lifecycle.Routes) > 0 {
 			patch.Notifications.Lifecycle.Via = ""
+		}
+		// An ABSENT scheduled list carries the stored schedules forward. The
+		// settings view always emits `scheduled` (as [] when there are none),
+		// so a patch without the key comes from a client that never saw the
+		// field — an older screen, or a hand-written PATCH that only meant to
+		// touch notifiers — not from one asking to delete every schedule.
+		// Deleting is expressed as a present, shorter (possibly empty) list.
+		if patch.Notifications.Scheduled == nil && s.hubCfg.Notifications != nil {
+			patch.Notifications.Scheduled = append([]types.ScheduledNotificationConfig(nil), s.hubCfg.Notifications.Scheduled...)
 		}
 		mergeNotifierSettings(s.hubCfg.Notifications, patch.Notifications)
 		dropRejectedLifecycleDurations(s.hubCfg.Notifications, patch.Notifications)

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -1139,6 +1139,17 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 		// field — an older screen, or a hand-written PATCH that only meant to
 		// touch notifiers — not from one asking to delete every schedule.
 		// Deleting is expressed as a present, shorter (possibly empty) list.
+		//
+		// This carry-forward is deliberately asymmetric: `notifiers` and
+		// `lifecycle` keep the block's pre-existing whole-replacement
+		// semantics (a patch with only `scheduled` still replaces them with
+		// whatever it carries, i.e. nothing). Every shipped client sends the
+		// whole notifications block, so nothing observable depends on
+		// carry-forward there yet — `scheduled` gets it only because it was
+		// added AFTER such clients existed, making an absent key genuinely
+		// mean "never saw the field". Extending carry-forward to the older
+		// keys would silently change what existing PATCHes do and belongs in
+		// its own change.
 		if patch.Notifications.Scheduled == nil && s.hubCfg.Notifications != nil {
 			patch.Notifications.Scheduled = append([]types.ScheduledNotificationConfig(nil), s.hubCfg.Notifications.Scheduled...)
 		}

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -1824,6 +1824,14 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 	// Only update in-memory config after successful disk write
 	s.hubCfg = &updatedCfg
 
+	// A deleted schedule's dedupe row must go NOW, not on the next minute
+	// tick: deleting and re-adding an id within one tick interval would
+	// otherwise inherit the stale row and replay a slot from before the new
+	// schedule existed (see pruneScheduledState).
+	if patch.Notifications != nil {
+		s.pruneScheduledState(updatedCfg.Notifications.Scheduled)
+	}
+
 	// If the concurrency limit was raised or removed, try to promote pending claws.
 	// This must run AFTER s.hubCfg is updated so promotePendingClaws reads the new limit.
 	if patch.MaxConcurrentClaws != nil {

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -835,7 +835,16 @@ func mergeNotifierSettings(current, patch *types.NotificationsConfig) {
 // no way to repair the offender from the UI. Whatever the operator does touch
 // is still checked, so this handler never persists a NEW broken notifier.
 func validateSettingsNotifications(current, cfg *types.NotificationsConfig) error {
-	if err := types.ValidateNotificationsConfig(cfg); err != nil {
+	// Notifier and lifecycle structure is validated on the whole patched
+	// block; the scheduled entries get the same structural checks per entry
+	// below, exempting stored ones the patch merely re-sends. A hand-written
+	// hub.yaml can hold a schedule the structural validator rejects (a
+	// "monday" weekday, a duplicated id) that the hub boots with and the
+	// screen re-sends verbatim on every save — and cannot repair: the edit
+	// dialog renders no chip for an invalid weekday and disables the id
+	// field, so validating stored entries here would 400 every save from the
+	// screen, including ones touching an unrelated channel.
+	if err := types.ValidateLifecycleNotificationsConfig(cfg); err != nil {
 		return err
 	}
 	for name, notifier := range cfg.Notifiers {
@@ -869,7 +878,23 @@ func validateSettingsNotifications(current, cfg *types.NotificationsConfig) erro
 	// offender, and every other edit to the entry itself: pausing it (which
 	// the doctor's "pause before upgrading" guidance depends on), re-routing
 	// it, or moving its slot.
+	ids := make(map[string]int, len(cfg.Scheduled))
+	for _, scheduled := range cfg.Scheduled {
+		ids[scheduled.ID]++
+	}
 	for i, scheduled := range cfg.Scheduled {
+		if !scheduledEntryUnchanged(current, scheduled) {
+			if err := types.ValidateScheduledNotification(cfg, i); err != nil {
+				return err
+			}
+			// The duplicate-id check runs against the whole patched list, but
+			// only an entry the patch adds or edits can be charged with it: a
+			// stored duplicate is unrepairable from the screen (the id field
+			// is disabled in edit mode) and must not block unrelated saves.
+			if ids[scheduled.ID] > 1 {
+				return fmt.Errorf("notifications.scheduled[%d]: id %q is duplicated", i, scheduled.ID)
+			}
+		}
 		if scheduledReportUnchanged(current, scheduled) {
 			continue
 		}
@@ -879,6 +904,24 @@ func validateSettingsNotifications(current, cfg *types.NotificationsConfig) erro
 		}
 	}
 	return nil
+}
+
+// scheduledEntryUnchanged reports whether the patch re-sends a schedule
+// identical to one already stored under its id — the patch carries it, not
+// edits it — mirroring notifierUnchanged above. Both sides are compared
+// through their settings view so the two defaults the screen cannot express
+// (an omitted `enabled`, a nil weekday list) do not read back as edits.
+func scheduledEntryUnchanged(current *types.NotificationsConfig, patched types.ScheduledNotificationConfig) bool {
+	if current == nil {
+		return false
+	}
+	view := scheduledNotificationViewOf(patched)
+	for _, stored := range current.Scheduled {
+		if stored.ID == patched.ID && reflect.DeepEqual(scheduledNotificationViewOf(stored), view) {
+			return true
+		}
+	}
+	return false
 }
 
 // normalizeScheduledTimes rewrites each schedule's `at` in zero-padded HH:MM.

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -92,6 +92,29 @@ type SettingsView struct {
 type NotificationsView struct {
 	Notifiers map[string]NotifierView     `json:"notifiers"`
 	Lifecycle *LifecycleNotificationsView `json:"lifecycle,omitempty"`
+	// Scheduled mirrors notifications.scheduled. It holds no secret — a
+	// schedule only names notifiers, a report and a wall-clock slot.
+	Scheduled []ScheduledNotificationView `json:"scheduled"`
+}
+
+// ScheduledNotificationView is the settings view of one scheduled report. Like
+// LifecycleNotificationsView it uses the SAME field names the PATCH body is
+// decoded under (types.ScheduledNotificationConfig), so a client that GETs the
+// view, edits it and PATCHes it back cannot silently drop a field.
+type ScheduledNotificationView struct {
+	ID     string   `json:"id"`
+	Report string   `json:"report"`
+	Via    []string `json:"via"`
+	At     string   `json:"at"`
+	// Timezone is an IANA name; empty means UTC, exactly as the scheduler
+	// reads it.
+	Timezone string `json:"timezone,omitempty"`
+	// Weekdays is always emitted, as [] for "every day", so the settings
+	// screen never has to distinguish absent from empty.
+	Weekdays []string `json:"weekdays"`
+	// Enabled is resolved (the config defaults it to true when omitted) so
+	// the screen renders a real toggle rather than a tri-state.
+	Enabled bool `json:"enabled"`
 }
 
 type NotifierView struct {
@@ -711,9 +734,12 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 
 func buildNotificationsView(cfg *types.NotificationsConfig) *NotificationsView {
 	if cfg == nil {
-		return &NotificationsView{Notifiers: map[string]NotifierView{}}
+		return &NotificationsView{Notifiers: map[string]NotifierView{}, Scheduled: []ScheduledNotificationView{}}
 	}
-	view := &NotificationsView{Notifiers: make(map[string]NotifierView, len(cfg.Notifiers))}
+	view := &NotificationsView{
+		Notifiers: make(map[string]NotifierView, len(cfg.Notifiers)),
+		Scheduled: make([]ScheduledNotificationView, 0, len(cfg.Scheduled)),
+	}
 	for name, notifier := range cfg.Notifiers {
 		view.Notifiers[name] = NotifierView{
 			Type:            notifier.Type,
@@ -741,7 +767,28 @@ func buildNotificationsView(cfg *types.NotificationsConfig) *NotificationsView {
 		}
 		view.Lifecycle = lifecycle
 	}
+	for _, scheduled := range cfg.Scheduled {
+		view.Scheduled = append(view.Scheduled, scheduledNotificationViewOf(scheduled))
+	}
 	return view
+}
+
+// scheduledNotificationViewOf projects one schedule into its settings view,
+// resolving the two defaults the screen cannot represent: an omitted `enabled`
+// is true, and an omitted `weekdays` is "every day", rendered as [].
+func scheduledNotificationViewOf(scheduled types.ScheduledNotificationConfig) ScheduledNotificationView {
+	return ScheduledNotificationView{
+		ID:     scheduled.ID,
+		Report: scheduled.Report,
+		// Never the config's own slice header: the settings screen PATCHes
+		// this view straight back, and aliasing would let a rejected save
+		// mutate the live config.
+		Via:      append([]string{}, scheduled.Via...),
+		At:       scheduled.At,
+		Timezone: scheduled.Timezone,
+		Weekdays: append([]string{}, scheduled.Weekdays...),
+		Enabled:  scheduled.Enabled == nil || *scheduled.Enabled,
+	}
 }
 
 func notifierSettingString(notifier types.NotifierConfig, key string) string {
@@ -811,7 +858,54 @@ func validateSettingsNotifications(current, cfg *types.NotificationsConfig) erro
 			return fmt.Errorf("notifications.notifiers.%s: %w", name, err)
 		}
 	}
+	// Report names are checked only on schedules the patch adds or changes,
+	// for the same reason notifier construction is: the report registry is a
+	// property of THIS build, so a hub.yaml naming a report an older or newer
+	// binary carries is legitimate on disk (the scheduler logs "not
+	// registered" per tick and delivers nothing). The screen submits the whole
+	// scheduled list on every save, so failing on a stored entry would 400
+	// every save — including the one that deletes the offender.
+	for i, scheduled := range cfg.Scheduled {
+		if scheduledNotificationUnchanged(current, scheduled) {
+			continue
+		}
+		if !ScheduledReportSupported(scheduled.Report) {
+			return fmt.Errorf("notifications.scheduled[%d]: unknown report %q (supported: %s)",
+				i, scheduled.Report, scheduledReportNamesText())
+		}
+	}
 	return nil
+}
+
+// scheduledNotificationUnchanged reports whether the patched schedule matches
+// the one already stored under the same id.
+//
+// Compared through the settings view rather than field by field: the view is
+// what the screen round-trips, and it normalises exactly the shapes that make
+// a byte comparison lie — an absent `enabled` (which means true) coming back
+// as an explicit `true`, and an absent `weekdays` (every day) coming back as
+// []. Without that normalisation an untouched schedule reads as changed on
+// every save, which is precisely the case this function exists to exempt.
+func scheduledNotificationUnchanged(current *types.NotificationsConfig, patched types.ScheduledNotificationConfig) bool {
+	if current == nil {
+		return false
+	}
+	for _, stored := range current.Scheduled {
+		if stored.ID != patched.ID {
+			continue
+		}
+		return reflect.DeepEqual(scheduledNotificationViewOf(stored), scheduledNotificationViewOf(patched))
+	}
+	return false
+}
+
+// scheduledReportNamesText lists the registered reports for error text.
+func scheduledReportNamesText() string {
+	names := scheduledReportNames()
+	if len(names) == 0 {
+		return "none"
+	}
+	return strings.Join(names, ", ")
 }
 
 // validateNotifierAPIBase refuses an api_base the patch introduces or changes

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/elasticclaw/elasticclaw/pkg/cliversion"
 	"github.com/elasticclaw/elasticclaw/pkg/config"
@@ -880,6 +881,28 @@ func validateSettingsNotifications(current, cfg *types.NotificationsConfig) erro
 	return nil
 }
 
+// normalizeScheduledTimes rewrites each schedule's `at` in zero-padded HH:MM.
+//
+// time.Parse("15:04") accepts an unpadded "9:00", so a hand-written hub.yaml
+// can carry one and the scheduler runs it correctly — but the settings screen
+// binds `at` to an <input type="time">, which renders anything that is not
+// HH:MM as blank. Normalizing whatever a patch carries (including the stored
+// list carried forward above) repairs such an entry on the first save from any
+// client, rather than leaving it permanently uneditable from the screen. An
+// unparseable value is left alone for validation to reject by its real text.
+func normalizeScheduledTimes(cfg *types.NotificationsConfig) {
+	if cfg == nil {
+		return
+	}
+	for i, scheduled := range cfg.Scheduled {
+		parsed, err := time.Parse("15:04", strings.TrimSpace(scheduled.At))
+		if err != nil {
+			continue
+		}
+		cfg.Scheduled[i].At = parsed.Format("15:04")
+	}
+}
+
 // scheduledReportUnchanged reports whether a stored schedule under the same id
 // already names the patched schedule's report.
 //
@@ -1153,6 +1176,7 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 		if patch.Notifications.Scheduled == nil && s.hubCfg.Notifications != nil {
 			patch.Notifications.Scheduled = append([]types.ScheduledNotificationConfig(nil), s.hubCfg.Notifications.Scheduled...)
 		}
+		normalizeScheduledTimes(patch.Notifications)
 		mergeNotifierSettings(s.hubCfg.Notifications, patch.Notifications)
 		dropRejectedLifecycleDurations(s.hubCfg.Notifications, patch.Notifications)
 		if err := validateSettingsNotifications(s.hubCfg.Notifications, patch.Notifications); err != nil {

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -882,17 +882,28 @@ func validateSettingsNotifications(current, cfg *types.NotificationsConfig) erro
 	for _, scheduled := range cfg.Scheduled {
 		ids[scheduled.ID]++
 	}
+	storedIDs := map[string]int{}
+	if current != nil {
+		for _, scheduled := range current.Scheduled {
+			storedIDs[scheduled.ID]++
+		}
+	}
 	for i, scheduled := range cfg.Scheduled {
+		// A duplicate id the PATCH introduces is charged even when every copy
+		// individually reads as unchanged — two byte-identical re-sends of one
+		// stored entry (a client retry, a double-submit) satisfy
+		// scheduledEntryUnchanged and would otherwise persist the exact
+		// dedupe-row collision the scheduler tick's validity gate pauses every
+		// schedule over. Only patch-introduced duplication is charged (more
+		// copies of an id than the stored list holds): a stored hand-written
+		// duplicate is unrepairable from the screen (the id field is disabled
+		// in edit mode) and must not block unrelated saves.
+		if ids[scheduled.ID] > 1 && ids[scheduled.ID] > storedIDs[scheduled.ID] {
+			return fmt.Errorf("notifications.scheduled[%d]: id %q is duplicated", i, scheduled.ID)
+		}
 		if !scheduledEntryUnchanged(current, scheduled) {
 			if err := types.ValidateScheduledNotification(cfg, i); err != nil {
 				return err
-			}
-			// The duplicate-id check runs against the whole patched list, but
-			// only an entry the patch adds or edits can be charged with it: a
-			// stored duplicate is unrepairable from the screen (the id field
-			// is disabled in edit mode) and must not block unrelated saves.
-			if ids[scheduled.ID] > 1 {
-				return fmt.Errorf("notifications.scheduled[%d]: id %q is duplicated", i, scheduled.ID)
 			}
 		}
 		if scheduledReportUnchanged(current, scheduled) {
@@ -933,6 +944,12 @@ func scheduledEntryUnchanged(current *types.NotificationsConfig, patched types.S
 // list carried forward above) repairs such an entry on the first save from any
 // client, rather than leaving it permanently uneditable from the screen. An
 // unparseable value is left alone for validation to reject by its real text.
+//
+// Runs AFTER validateSettingsNotifications: scheduledEntryUnchanged compares
+// the patch's text against the stored text, so normalizing first would turn a
+// carried-forward "9:00" into an apparent edit and subject an entry the
+// operator never touched to full validation. The dedupe digest is unaffected
+// either way — scheduledSlotDigest normalizes `at` itself.
 func normalizeScheduledTimes(cfg *types.NotificationsConfig) {
 	if cfg == nil {
 		return
@@ -1219,7 +1236,6 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 		if patch.Notifications.Scheduled == nil && s.hubCfg.Notifications != nil {
 			patch.Notifications.Scheduled = append([]types.ScheduledNotificationConfig(nil), s.hubCfg.Notifications.Scheduled...)
 		}
-		normalizeScheduledTimes(patch.Notifications)
 		mergeNotifierSettings(s.hubCfg.Notifications, patch.Notifications)
 		dropRejectedLifecycleDurations(s.hubCfg.Notifications, patch.Notifications)
 		if err := validateSettingsNotifications(s.hubCfg.Notifications, patch.Notifications); err != nil {
@@ -1232,6 +1248,12 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
+		// AFTER validation on purpose: normalizing first rewrites the patch's
+		// `at` before scheduledEntryUnchanged compares it against the stored
+		// text, so a stored unpadded "9:00" plus any other structural defect
+		// would read as an edit and 400 every notifications save — the exact
+		// brick the unchanged-entry exemption exists to prevent.
+		normalizeScheduledTimes(patch.Notifications)
 		updatedCfg.Notifications = patch.Notifications
 	}
 

--- a/pkg/hub/settings_notifications_test.go
+++ b/pkg/hub/settings_notifications_test.go
@@ -813,6 +813,66 @@ func TestSettingsPatchAllowsUnchangedUnknownScheduledReport(t *testing.T) {
 	}
 }
 
+// A stored schedule the structural validator rejects (a hand-written hub.yaml
+// with an invalid weekday) must not 400 every notifications save: the hub
+// boots with it, the screen re-sends it verbatim on every save and cannot
+// repair it (the weekday chips cannot render "monday" and the id field is
+// disabled in edit mode). Entries the patch merely re-sends are exempt, while
+// anything it adds or edits is still fully validated.
+func TestSettingsPatchAllowsUnchangedStructurallyInvalidSchedule(t *testing.T) {
+	registerScheduledReport("stored-invalid-report", func(context.Context, *Server) (*notify.Message, bool, error) {
+		return nil, false, nil
+	})
+	path := filepath.Join(t.TempDir(), "hub.yaml")
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", path)
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Notifications: &types.NotificationsConfig{
+		Notifiers: map[string]types.NotifierConfig{
+			"eng": {Type: "slack", Settings: map[string]any{"channel": "C0123ABCD", "token_secret": "slack_token"}},
+		},
+		Scheduled: []types.ScheduledNotificationConfig{
+			{ID: "legacy", Report: "stored-invalid-report", Via: []string{"eng"}, At: "09:00", Weekdays: []string{"monday"}},
+		},
+	}}, "", "", "")
+	if err := config.SaveHubConfig(s.hubCfg); err != nil {
+		t.Fatal(err)
+	}
+
+	// A save touching only an unrelated channel carries the entry verbatim.
+	legacy := `{"id":"legacy","report":"stored-invalid-report","via":["eng"],"at":"09:00","weekdays":["monday"],"enabled":true}`
+	body := []byte(`{"notifications":{"notifiers":{"eng":{"type":"slack","channel":"C0999NEW","token_secret":"slack_token"}},"scheduled":[` + legacy + `]}}`)
+	rr := httptest.NewRecorder()
+	s.patchSettings(rr, httptest.NewRequest(http.MethodPatch, "/api/settings", bytes.NewReader(body)))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("re-saving the stored schedule = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+
+	// An entry the patch ADDS is still fully validated.
+	added := `{"id":"fresh","report":"stored-invalid-report","via":["eng"],"at":"10:00","weekdays":["monday"],"enabled":true}`
+	body = []byte(`{"notifications":{"notifiers":{"eng":{"type":"slack","channel":"C0999NEW","token_secret":"slack_token"}},"scheduled":[` + legacy + `,` + added + `]}}`)
+	rr = httptest.NewRecorder()
+	s.patchSettings(rr, httptest.NewRequest(http.MethodPatch, "/api/settings", bytes.NewReader(body)))
+	if rr.Code != http.StatusBadRequest || !strings.Contains(rr.Body.String(), `weekday "monday" is invalid`) {
+		t.Fatalf("adding an invalid entry = %d (%s), want 400 on the weekday", rr.Code, rr.Body.String())
+	}
+
+	// So is one that duplicates a stored id.
+	duplicate := `{"id":"legacy","report":"stored-invalid-report","via":["eng"],"at":"10:00","weekdays":[],"enabled":true}`
+	body = []byte(`{"notifications":{"notifiers":{"eng":{"type":"slack","channel":"C0999NEW","token_secret":"slack_token"}},"scheduled":[` + legacy + `,` + duplicate + `]}}`)
+	rr = httptest.NewRecorder()
+	s.patchSettings(rr, httptest.NewRequest(http.MethodPatch, "/api/settings", bytes.NewReader(body)))
+	if rr.Code != http.StatusBadRequest || !strings.Contains(rr.Body.String(), "is duplicated") {
+		t.Fatalf("adding a duplicate id = %d (%s), want 400 on the duplicate", rr.Code, rr.Body.String())
+	}
+
+	// And the repair — deleting the stored offender — goes through.
+	body = []byte(`{"notifications":{"notifiers":{"eng":{"type":"slack","channel":"C0999NEW","token_secret":"slack_token"}},"scheduled":[]}}`)
+	rr = httptest.NewRecorder()
+	s.patchSettings(rr, httptest.NewRequest(http.MethodPatch, "/api/settings", bytes.NewReader(body)))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("deleting the stored schedule = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+}
+
 // A PATCH that omits the `scheduled` key entirely comes from a client that
 // never saw the field (an older screen, a hand-written notifiers-only PATCH),
 // not from one asking to delete every schedule: the stored schedules must be

--- a/pkg/hub/settings_notifications_test.go
+++ b/pkg/hub/settings_notifications_test.go
@@ -953,3 +953,206 @@ func TestSettingsPatchZeroPadsScheduledAt(t *testing.T) {
 		t.Fatalf("at = %q, want %q", got, "09:00")
 	}
 }
+
+// Removing a notifier an ENABLED schedule still routes through must 400: the
+// persisted config would be exactly what the scheduler tick's validity gate
+// rejects, silently pausing EVERY scheduled report hub-wide. Only the
+// carry-forward/verbatim paths need the guard — a patch that also edits the
+// schedule is fully validated — and a patch that pauses or re-routes the
+// schedule in the same save (the screen's removeChannel) must keep working.
+func TestSettingsPatchRejectsRemovingNotifierUsedByEnabledSchedule(t *testing.T) {
+	registerScheduledReport("removal-guard-report", func(context.Context, *Server) (*notify.Message, bool, error) {
+		return nil, false, nil
+	})
+	path := filepath.Join(t.TempDir(), "hub.yaml")
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", path)
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Notifications: &types.NotificationsConfig{
+		Notifiers: map[string]types.NotifierConfig{
+			"eng": {Type: "slack", Settings: map[string]any{"channel": "C0123ABCD", "token_secret": "slack_token"}},
+			"ops": {Type: "slack", Settings: map[string]any{"channel": "C0456EFGH", "token_secret": "slack_token"}},
+		},
+		Scheduled: []types.ScheduledNotificationConfig{
+			{ID: "daily", Report: "removal-guard-report", Via: []string{"eng"}, At: "09:00"},
+		},
+	}}, "", "", "")
+	if err := config.SaveHubConfig(s.hubCfg); err != nil {
+		t.Fatal(err)
+	}
+
+	ops := `"ops":{"type":"slack","channel":"C0456EFGH","token_secret":"slack_token"}`
+	// The carry-forward client: no `scheduled` key at all.
+	body := []byte(`{"notifications":{"notifiers":{` + ops + `}}}`)
+	rr := httptest.NewRecorder()
+	s.patchSettings(rr, httptest.NewRequest(http.MethodPatch, "/api/settings", bytes.NewReader(body)))
+	if rr.Code != http.StatusBadRequest || !strings.Contains(rr.Body.String(), "still in use") {
+		t.Fatalf("carry-forward removal = %d (%s), want 400 naming the schedule", rr.Code, rr.Body.String())
+	}
+	if _, kept := s.hubCfg.Notifications.Notifiers["eng"]; !kept {
+		t.Fatal("rejected removal still persisted")
+	}
+
+	// The schedule re-sent verbatim (an older screen) is the same dangle.
+	verbatim := `{"id":"daily","report":"removal-guard-report","via":["eng"],"at":"09:00","weekdays":[],"enabled":true}`
+	body = []byte(`{"notifications":{"notifiers":{` + ops + `},"scheduled":[` + verbatim + `]}}`)
+	rr = httptest.NewRecorder()
+	s.patchSettings(rr, httptest.NewRequest(http.MethodPatch, "/api/settings", bytes.NewReader(body)))
+	if rr.Code != http.StatusBadRequest || !strings.Contains(rr.Body.String(), "still in use") {
+		t.Fatalf("verbatim removal = %d (%s), want 400", rr.Code, rr.Body.String())
+	}
+
+	// Pausing the schedule in the same patch — the screen's removeChannel —
+	// releases the notifier.
+	paused := `{"id":"daily","report":"removal-guard-report","via":["eng"],"at":"09:00","weekdays":[],"enabled":false}`
+	body = []byte(`{"notifications":{"notifiers":{` + ops + `},"scheduled":[` + paused + `]}}`)
+	rr = httptest.NewRecorder()
+	s.patchSettings(rr, httptest.NewRequest(http.MethodPatch, "/api/settings", bytes.NewReader(body)))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("removal alongside a pause = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+	if _, kept := s.hubCfg.Notifications.Notifiers["eng"]; kept {
+		t.Fatal("allowed removal did not persist")
+	}
+}
+
+// A via that was ALREADY dangling in the stored config (a hand-written
+// hub.yaml) must not brick unrelated saves: only patch-introduced dangling —
+// a removed notifier the schedule's via resolved against — is charged.
+func TestSettingsPatchAllowsSaveWithStoredDanglingScheduleVia(t *testing.T) {
+	registerScheduledReport("stored-dangling-report", func(context.Context, *Server) (*notify.Message, bool, error) {
+		return nil, false, nil
+	})
+	path := filepath.Join(t.TempDir(), "hub.yaml")
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", path)
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Notifications: &types.NotificationsConfig{
+		Notifiers: map[string]types.NotifierConfig{
+			"eng": {Type: "slack", Settings: map[string]any{"channel": "C0123ABCD", "token_secret": "slack_token"}},
+		},
+		Scheduled: []types.ScheduledNotificationConfig{
+			{ID: "daily", Report: "stored-dangling-report", Via: []string{"ghost"}, At: "09:00"},
+		},
+	}}, "", "", "")
+	if err := config.SaveHubConfig(s.hubCfg); err != nil {
+		t.Fatal(err)
+	}
+
+	body := []byte(`{"notifications":{"notifiers":{"eng":{"type":"slack","channel":"C0999NEW","token_secret":"slack_token"}}}}`)
+	rr := httptest.NewRecorder()
+	s.patchSettings(rr, httptest.NewRequest(http.MethodPatch, "/api/settings", bytes.NewReader(body)))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("save with stored-dangling via = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+}
+
+// Two byte-identical copies of a stored schedule both satisfy the
+// unchanged-entry exemption, so the duplicate-id check must charge
+// patch-introduced duplication by COUNT (more copies than stored), not by
+// which copy reads as changed: persisting the duplicate is the dedupe-row
+// collision the scheduler tick's validity gate pauses every schedule over.
+func TestSettingsPatchRejectsPatchIntroducedDuplicateScheduleID(t *testing.T) {
+	registerScheduledReport("dup-count-report", func(context.Context, *Server) (*notify.Message, bool, error) {
+		return nil, false, nil
+	})
+	path := filepath.Join(t.TempDir(), "hub.yaml")
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", path)
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Notifications: &types.NotificationsConfig{
+		Notifiers: map[string]types.NotifierConfig{
+			"eng": {Type: "slack", Settings: map[string]any{"channel": "C0123ABCD", "token_secret": "slack_token"}},
+		},
+		Scheduled: []types.ScheduledNotificationConfig{
+			{ID: "daily", Report: "dup-count-report", Via: []string{"eng"}, At: "09:00"},
+		},
+	}}, "", "", "")
+	if err := config.SaveHubConfig(s.hubCfg); err != nil {
+		t.Fatal(err)
+	}
+
+	entry := `{"id":"daily","report":"dup-count-report","via":["eng"],"at":"09:00","weekdays":[],"enabled":true}`
+	body := []byte(`{"notifications":{"notifiers":{"eng":{"type":"slack","channel":"C0123ABCD","token_secret":"slack_token"}},"scheduled":[` + entry + `,` + entry + `]}}`)
+	rr := httptest.NewRecorder()
+	s.patchSettings(rr, httptest.NewRequest(http.MethodPatch, "/api/settings", bytes.NewReader(body)))
+	if rr.Code != http.StatusBadRequest || !strings.Contains(rr.Body.String(), "is duplicated") {
+		t.Fatalf("byte-identical duplicate = %d (%s), want 400 on the duplicate", rr.Code, rr.Body.String())
+	}
+	if len(s.hubCfg.Notifications.Scheduled) != 1 {
+		t.Fatalf("rejected duplicate still persisted: %#v", s.hubCfg.Notifications.Scheduled)
+	}
+}
+
+// A duplicate that already exists in the STORED list (hand-written hub.yaml)
+// stays exempt — it is unrepairable from the screen and must not block
+// unrelated saves that merely re-send it.
+func TestSettingsPatchAllowsStoredDuplicateScheduleID(t *testing.T) {
+	registerScheduledReport("stored-dup-report", func(context.Context, *Server) (*notify.Message, bool, error) {
+		return nil, false, nil
+	})
+	path := filepath.Join(t.TempDir(), "hub.yaml")
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", path)
+	entry := types.ScheduledNotificationConfig{ID: "daily", Report: "stored-dup-report", Via: []string{"eng"}, At: "09:00"}
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Notifications: &types.NotificationsConfig{
+		Notifiers: map[string]types.NotifierConfig{
+			"eng": {Type: "slack", Settings: map[string]any{"channel": "C0123ABCD", "token_secret": "slack_token"}},
+		},
+		Scheduled: []types.ScheduledNotificationConfig{entry, entry},
+	}}, "", "", "")
+	if err := config.SaveHubConfig(s.hubCfg); err != nil {
+		t.Fatal(err)
+	}
+
+	resent := `{"id":"daily","report":"stored-dup-report","via":["eng"],"at":"09:00","weekdays":[],"enabled":true}`
+	body := []byte(`{"notifications":{"notifiers":{"eng":{"type":"slack","channel":"C0999NEW","token_secret":"slack_token"}},"scheduled":[` + resent + `,` + resent + `]}}`)
+	rr := httptest.NewRecorder()
+	s.patchSettings(rr, httptest.NewRequest(http.MethodPatch, "/api/settings", bytes.NewReader(body)))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("re-sending a stored duplicate = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+}
+
+// A stored entry that combines an unpadded at ("9:00") with another structural
+// defect must keep its unchanged-entry exemption: normalization used to run
+// BEFORE the unchanged comparison, so the padded copy read as an edit and the
+// untouched entry 400'd every notifications save — carry-forward and verbatim
+// alike. Normalization now runs after validation, and still repairs the at.
+func TestSettingsPatchNormalizationDoesNotDefeatUnchangedExemption(t *testing.T) {
+	registerScheduledReport("unpadded-invalid-report", func(context.Context, *Server) (*notify.Message, bool, error) {
+		return nil, false, nil
+	})
+	path := filepath.Join(t.TempDir(), "hub.yaml")
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", path)
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Notifications: &types.NotificationsConfig{
+		Notifiers: map[string]types.NotifierConfig{
+			"eng": {Type: "slack", Settings: map[string]any{"channel": "C0123ABCD", "token_secret": "slack_token"}},
+		},
+		Scheduled: []types.ScheduledNotificationConfig{
+			{ID: "legacy", Report: "unpadded-invalid-report", Via: []string{"eng"}, At: "9:00", Weekdays: []string{"monday"}},
+		},
+	}}, "", "", "")
+	if err := config.SaveHubConfig(s.hubCfg); err != nil {
+		t.Fatal(err)
+	}
+
+	// Re-sent verbatim, unpadded at and all, alongside a notifier edit.
+	verbatim := `{"id":"legacy","report":"unpadded-invalid-report","via":["eng"],"at":"9:00","weekdays":["monday"],"enabled":true}`
+	body := []byte(`{"notifications":{"notifiers":{"eng":{"type":"slack","channel":"C0999NEW","token_secret":"slack_token"}},"scheduled":[` + verbatim + `]}}`)
+	rr := httptest.NewRecorder()
+	s.patchSettings(rr, httptest.NewRequest(http.MethodPatch, "/api/settings", bytes.NewReader(body)))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("verbatim re-send of the stored entry = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+
+	// The carry-forward client, against the (now zero-padded) stored entry.
+	body = []byte(`{"notifications":{"notifiers":{"eng":{"type":"slack","channel":"C0AAABBBB","token_secret":"slack_token"}}}}`)
+	rr = httptest.NewRecorder()
+	s.patchSettings(rr, httptest.NewRequest(http.MethodPatch, "/api/settings", bytes.NewReader(body)))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("carry-forward save = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+
+	// The repair the normalization exists for still happened.
+	diskCfg, err := config.LoadHubConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := diskCfg.Notifications.Scheduled[0].At; got != "09:00" {
+		t.Fatalf("at = %q, want the normalized %q", got, "09:00")
+	}
+}

--- a/pkg/hub/settings_notifications_test.go
+++ b/pkg/hub/settings_notifications_test.go
@@ -11,6 +11,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/elasticclaw/elasticclaw/pkg/config"
 	"github.com/elasticclaw/elasticclaw/pkg/hub/notify"
@@ -717,6 +718,39 @@ func TestSettingsPatchRejectsUnknownScheduledReport(t *testing.T) {
 	}
 	if len(s.hubCfg.Notifications.Scheduled) != 0 {
 		t.Fatalf("rejected patch still wrote %#v", s.hubCfg.Notifications.Scheduled)
+	}
+}
+
+// Deleting a schedule via the settings PATCH prunes its dedupe row on the save
+// itself, not on the next minute tick: deleting and re-adding the same id
+// within one tick interval would otherwise inherit the stale row and replay a
+// slot from before the new schedule existed.
+func TestSettingsPatchPrunesDeletedScheduleStateImmediately(t *testing.T) {
+	registerScheduledReport("patch-prune-report", func(context.Context, *Server) (*notify.Message, bool, error) {
+		return nil, false, nil
+	})
+	path := filepath.Join(t.TempDir(), "hub.yaml")
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", path)
+	schedule := types.ScheduledNotificationConfig{ID: "daily", Report: "patch-prune-report", Via: []string{"eng"}, At: "09:00"}
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Notifications: &types.NotificationsConfig{
+		Notifiers: map[string]types.NotifierConfig{
+			"eng": {Type: "slack", Settings: map[string]any{"channel": "C0123ABCD", "token_secret": "slack_token"}},
+		},
+		Scheduled: []types.ScheduledNotificationConfig{schedule},
+	}}, "", "", "")
+	if err := config.SaveHubConfig(s.hubCfg); err != nil {
+		t.Fatal(err)
+	}
+	s.setScheduledLastFired("daily", "eng", time.Date(2025, 1, 6, 9, 0, 0, 0, time.UTC), scheduledSlotDigest(schedule))
+
+	body := []byte(`{"notifications":{"notifiers":{"eng":{"type":"slack","channel":"C0123ABCD","token_secret":"slack_token"}},"scheduled":[]}}`)
+	rr := httptest.NewRecorder()
+	s.patchSettings(rr, httptest.NewRequest(http.MethodPatch, "/api/settings", bytes.NewReader(body)))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", rr.Code, rr.Body.String())
+	}
+	if _, _, found, _ := s.scheduledLastFired("daily", "eng"); found {
+		t.Fatal("deleted schedule's dedupe row survived the save; a same-id re-add before the next tick would replay a stale slot")
 	}
 }
 

--- a/pkg/hub/settings_notifications_test.go
+++ b/pkg/hub/settings_notifications_test.go
@@ -819,3 +819,43 @@ func TestSettingsPatchWithoutScheduledKeyKeepsStoredSchedules(t *testing.T) {
 		t.Fatalf("the notifier edit itself did not land: channel = %q", got)
 	}
 }
+
+// A stored `at` that time.Parse accepts but <input type="time"> cannot render
+// ("9:00") leaves the schedule uneditable from the settings screen, so any
+// patch that touches this hub repairs it — including one that never mentions
+// the schedule and only carries it forward.
+func TestSettingsPatchZeroPadsScheduledAt(t *testing.T) {
+	registerScheduledReport("unpadded-at-report", func(context.Context, *Server) (*notify.Message, bool, error) {
+		return nil, false, nil
+	})
+	path := filepath.Join(t.TempDir(), "hub.yaml")
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", path)
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Notifications: &types.NotificationsConfig{
+		Notifiers: map[string]types.NotifierConfig{
+			"eng": {Type: "slack", Settings: map[string]any{"channel": "C0123ABCD", "token_secret": "slack_token"}},
+		},
+		Scheduled: []types.ScheduledNotificationConfig{
+			{ID: "morning", Report: "unpadded-at-report", Via: []string{"eng"}, At: "9:00"},
+		},
+	}}, "", "", "")
+	if err := config.SaveHubConfig(s.hubCfg); err != nil {
+		t.Fatal(err)
+	}
+
+	body := []byte(`{"notifications":{"notifiers":{"eng":{"type":"slack","channel":"C0123ABCD","token_secret":"slack_token"}}}}`)
+	rr := httptest.NewRecorder()
+	s.patchSettings(rr, httptest.NewRequest(http.MethodPatch, "/api/settings", bytes.NewReader(body)))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+	diskCfg, err := config.LoadHubConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(diskCfg.Notifications.Scheduled) != 1 {
+		t.Fatalf("schedules = %#v, want 1", diskCfg.Notifications.Scheduled)
+	}
+	if got := diskCfg.Notifications.Scheduled[0].At; got != "09:00" {
+		t.Fatalf("at = %q, want %q", got, "09:00")
+	}
+}

--- a/pkg/hub/settings_notifications_test.go
+++ b/pkg/hub/settings_notifications_test.go
@@ -2,6 +2,7 @@ package hub
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -12,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/elasticclaw/elasticclaw/pkg/config"
+	"github.com/elasticclaw/elasticclaw/pkg/hub/notify"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
 
@@ -605,5 +607,159 @@ func TestSettingsPatchEditsChannelWithUnbuildableStoredAPIBase(t *testing.T) {
 	// A value the patch itself introduces is still judged, exemption or not.
 	if rr = patch(t, "slack.other.example/api"); rr.Code != http.StatusBadRequest {
 		t.Fatalf("changed api_base: status = %d, want 400; body = %s", rr.Code, rr.Body.String())
+	}
+}
+
+// ── Scheduled reports ─────────────────────────────────────────────────────────
+
+// The settings screen rebuilds the whole notifications block from the view it
+// GETs, so every scheduled-report field has to survive a GET → PATCH → disk
+// round trip. A field the view drops is a field the first save from the screen
+// silently deletes from hub.yaml.
+func TestSettingsScheduledNotificationsRoundTripThroughPatch(t *testing.T) {
+	registerScheduledReport("settings-round-trip-report", func(context.Context, *Server) (*notify.Message, bool, error) {
+		return nil, false, nil
+	})
+	path := filepath.Join(t.TempDir(), "hub.yaml")
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", path)
+	disabled := false
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Notifications: &types.NotificationsConfig{
+		Notifiers: map[string]types.NotifierConfig{
+			"eng": {Type: "slack", Settings: map[string]any{"channel": "C0123ABCD", "token_secret": "slack_token"}},
+			"ops": {Type: "slack", Settings: map[string]any{"channel": "C0456EFGH", "token_secret": "slack_token"}},
+		},
+		Scheduled: []types.ScheduledNotificationConfig{
+			{
+				ID: "morning-prs", Report: "settings-round-trip-report",
+				Via: []string{"eng", "ops"}, At: "09:30",
+				Timezone: "America/Sao_Paulo", Weekdays: []string{"mon", "fri"},
+			},
+			// Every-day, UTC, paused: the shapes whose zero values are easiest
+			// to lose on the way through the view.
+			{ID: "nightly", Report: "settings-round-trip-report", Via: []string{"ops"}, At: "23:00", Enabled: &disabled},
+		},
+	}}, "", "", "")
+	if err := config.SaveHubConfig(s.hubCfg); err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	s.getSettings(rr, httptest.NewRequest(http.MethodGet, "/api/settings", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GET status = %d: %s", rr.Code, rr.Body.String())
+	}
+	var view SettingsView
+	if err := json.Unmarshal(rr.Body.Bytes(), &view); err != nil {
+		t.Fatal(err)
+	}
+	want := []ScheduledNotificationView{
+		{
+			ID: "morning-prs", Report: "settings-round-trip-report", Via: []string{"eng", "ops"},
+			At: "09:30", Timezone: "America/Sao_Paulo", Weekdays: []string{"mon", "fri"}, Enabled: true,
+		},
+		{ID: "nightly", Report: "settings-round-trip-report", Via: []string{"ops"}, At: "23:00", Weekdays: []string{}, Enabled: false},
+	}
+	if !reflect.DeepEqual(view.Notifications.Scheduled, want) {
+		t.Fatalf("scheduled view = %#v, want %#v", view.Notifications.Scheduled, want)
+	}
+
+	// Byte-for-byte what the view returned, PATCHed straight back.
+	body, err := json.Marshal(map[string]any{"notifications": view.Notifications})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr = httptest.NewRecorder()
+	s.patchSettings(rr, httptest.NewRequest(http.MethodPatch, "/api/settings", bytes.NewReader(body)))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("round-tripping the view rejected the save: %d: %s", rr.Code, rr.Body.String())
+	}
+	diskCfg, err := config.LoadHubConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(diskCfg.Notifications.Scheduled) != 2 {
+		t.Fatalf("disk scheduled = %#v, want both schedules", diskCfg.Notifications.Scheduled)
+	}
+	first := diskCfg.Notifications.Scheduled[0]
+	if first.ID != "morning-prs" || first.At != "09:30" || first.Timezone != "America/Sao_Paulo" ||
+		!reflect.DeepEqual(first.Via, []string{"eng", "ops"}) || !reflect.DeepEqual(first.Weekdays, []string{"mon", "fri"}) {
+		t.Fatalf("disk schedule = %#v, want every field preserved", first)
+	}
+	if second := diskCfg.Notifications.Scheduled[1]; second.Enabled == nil || *second.Enabled {
+		t.Fatalf("disk schedule %#v lost its paused state", second)
+	}
+}
+
+// A schedule the patch ADDS must name a report this build carries: persisting
+// one it does not would leave a schedule that logs "not registered" every
+// minute and delivers nothing, with the settings screen reporting success.
+func TestSettingsPatchRejectsUnknownScheduledReport(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "hub.yaml")
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", path)
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Notifications: &types.NotificationsConfig{
+		Notifiers: map[string]types.NotifierConfig{
+			"eng": {Type: "slack", Settings: map[string]any{"channel": "C0123ABCD", "token_secret": "slack_token"}},
+		},
+	}}, "", "", "")
+	if err := config.SaveHubConfig(s.hubCfg); err != nil {
+		t.Fatal(err)
+	}
+
+	body := []byte(`{"notifications":{"notifiers":{"eng":{"type":"slack","channel":"C0123ABCD","token_secret":"slack_token"}},` +
+		`"scheduled":[{"id":"x","report":"no-such-report","via":["eng"],"at":"09:00","weekdays":[],"enabled":true}]}}`)
+	rr := httptest.NewRecorder()
+	s.patchSettings(rr, httptest.NewRequest(http.MethodPatch, "/api/settings", bytes.NewReader(body)))
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body = %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "unknown report") {
+		t.Fatalf("error does not name the problem: %s", rr.Body.String())
+	}
+	if len(s.hubCfg.Notifications.Scheduled) != 0 {
+		t.Fatalf("rejected patch still wrote %#v", s.hubCfg.Notifications.Scheduled)
+	}
+}
+
+// A stored schedule naming a report THIS build does not carry (an older or
+// newer binary's, a hand-written hub.yaml) must not 400 every save from the
+// screen — including the save that deletes it. Only entries the patch adds or
+// changes are judged, exactly as unbuildable notifiers are.
+func TestSettingsPatchAllowsUnchangedUnknownScheduledReport(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "hub.yaml")
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", path)
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Notifications: &types.NotificationsConfig{
+		Notifiers: map[string]types.NotifierConfig{
+			"eng": {Type: "slack", Settings: map[string]any{"channel": "C0123ABCD", "token_secret": "slack_token"}},
+		},
+		Scheduled: []types.ScheduledNotificationConfig{
+			{ID: "legacy", Report: "report-from-another-build", Via: []string{"eng"}, At: "09:00"},
+		},
+	}}, "", "", "")
+	if err := config.SaveHubConfig(s.hubCfg); err != nil {
+		t.Fatal(err)
+	}
+
+	notifiers := `{"eng":{"type":"slack","channel":"C0123ABCD","token_secret":"slack_token"}}`
+	unchanged := []byte(`{"notifications":{"notifiers":` + notifiers +
+		`,"scheduled":[{"id":"legacy","report":"report-from-another-build","via":["eng"],"at":"09:00","weekdays":[],"enabled":true}]}}`)
+	rr := httptest.NewRecorder()
+	s.patchSettings(rr, httptest.NewRequest(http.MethodPatch, "/api/settings", bytes.NewReader(unchanged)))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("re-saving the stored schedule = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+
+	// And the repair — deleting it — goes through too.
+	removed := []byte(`{"notifications":{"notifiers":` + notifiers + `,"scheduled":[]}}`)
+	rr = httptest.NewRecorder()
+	s.patchSettings(rr, httptest.NewRequest(http.MethodPatch, "/api/settings", bytes.NewReader(removed)))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("deleting the stored schedule = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+	diskCfg, err := config.LoadHubConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(diskCfg.Notifications.Scheduled) != 0 {
+		t.Fatalf("disk scheduled = %#v, want it deleted", diskCfg.Notifications.Scheduled)
 	}
 }

--- a/pkg/hub/settings_notifications_test.go
+++ b/pkg/hub/settings_notifications_test.go
@@ -748,6 +748,21 @@ func TestSettingsPatchAllowsUnchangedUnknownScheduledReport(t *testing.T) {
 		t.Fatalf("re-saving the stored schedule = %d, want 200; body = %s", rr.Code, rr.Body.String())
 	}
 
+	// Pausing it goes through: only the report name is pinned to the stored
+	// value, every other edit to the entry — the pause the doctor's "pause
+	// before upgrading" guidance depends on, a re-route, a new slot — is the
+	// operator's to make.
+	paused := []byte(`{"notifications":{"notifiers":` + notifiers +
+		`,"scheduled":[{"id":"legacy","report":"report-from-another-build","via":["eng"],"at":"09:00","weekdays":[],"enabled":false}]}}`)
+	rr = httptest.NewRecorder()
+	s.patchSettings(rr, httptest.NewRequest(http.MethodPatch, "/api/settings", bytes.NewReader(paused)))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("pausing the stored schedule = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+	if sched := s.hubCfg.Notifications.Scheduled; len(sched) != 1 || sched[0].Enabled == nil || *sched[0].Enabled {
+		t.Fatalf("pause did not persist: %#v", sched)
+	}
+
 	// And the repair — deleting it — goes through too.
 	removed := []byte(`{"notifications":{"notifiers":` + notifiers + `,"scheduled":[]}}`)
 	rr = httptest.NewRecorder()
@@ -761,5 +776,46 @@ func TestSettingsPatchAllowsUnchangedUnknownScheduledReport(t *testing.T) {
 	}
 	if len(diskCfg.Notifications.Scheduled) != 0 {
 		t.Fatalf("disk scheduled = %#v, want it deleted", diskCfg.Notifications.Scheduled)
+	}
+}
+
+// A PATCH that omits the `scheduled` key entirely comes from a client that
+// never saw the field (an older screen, a hand-written notifiers-only PATCH),
+// not from one asking to delete every schedule: the stored schedules must be
+// carried forward, exactly as the empty-routes guard preserves the lifecycle
+// channel binding. Deleting is expressed as a present, empty list.
+func TestSettingsPatchWithoutScheduledKeyKeepsStoredSchedules(t *testing.T) {
+	registerScheduledReport("carry-forward-report", func(context.Context, *Server) (*notify.Message, bool, error) {
+		return nil, false, nil
+	})
+	path := filepath.Join(t.TempDir(), "hub.yaml")
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", path)
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Notifications: &types.NotificationsConfig{
+		Notifiers: map[string]types.NotifierConfig{
+			"eng": {Type: "slack", Settings: map[string]any{"channel": "C0123ABCD", "token_secret": "slack_token"}},
+		},
+		Scheduled: []types.ScheduledNotificationConfig{
+			{ID: "morning", Report: "carry-forward-report", Via: []string{"eng"}, At: "09:00"},
+		},
+	}}, "", "", "")
+	if err := config.SaveHubConfig(s.hubCfg); err != nil {
+		t.Fatal(err)
+	}
+
+	body := []byte(`{"notifications":{"notifiers":{"eng":{"type":"slack","channel":"C0999NEW","token_secret":"slack_token"}}}}`)
+	rr := httptest.NewRecorder()
+	s.patchSettings(rr, httptest.NewRequest(http.MethodPatch, "/api/settings", bytes.NewReader(body)))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+	diskCfg, err := config.LoadHubConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(diskCfg.Notifications.Scheduled) != 1 || diskCfg.Notifications.Scheduled[0].ID != "morning" {
+		t.Fatalf("a scheduled-less patch wiped the stored schedules: %#v", diskCfg.Notifications.Scheduled)
+	}
+	if got, _ := diskCfg.Notifications.Notifiers["eng"].Settings["channel"].(string); got != "C0999NEW" {
+		t.Fatalf("the notifier edit itself did not land: channel = %q", got)
 	}
 }

--- a/pkg/hub/task_run_analytics_api.go
+++ b/pkg/hub/task_run_analytics_api.go
@@ -1,6 +1,7 @@
 package hub
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -1001,6 +1002,13 @@ func (s *Server) readTaskRunAnalyticsPRs(tenantID, runID string) ([]taskRunAnaly
 }
 
 func (s *Server) readTaskRunAnalyticsPRsForRuns(tenantID string, runIDs []string) (map[string][]taskRunAnalyticsPRView, error) {
+	return s.readTaskRunAnalyticsPRsForRunsContext(context.Background(), tenantID, runIDs)
+}
+
+// readTaskRunAnalyticsPRsForRunsContext is the ctx-bounded variant for callers
+// whose queries must honour a deadline or shutdown cancellation (the scheduled
+// pending_prs report builds under a 30s context and is cancelled at shutdown).
+func (s *Server) readTaskRunAnalyticsPRsForRunsContext(ctx context.Context, tenantID string, runIDs []string) (map[string][]taskRunAnalyticsPRView, error) {
 	prsByRun := map[string][]taskRunAnalyticsPRView{}
 	if len(runIDs) == 0 {
 		return prsByRun, nil
@@ -1011,7 +1019,7 @@ func (s *Server) readTaskRunAnalyticsPRsForRuns(tenantID string, runIDs []string
 			if end > len(runIDs) {
 				end = len(runIDs)
 			}
-			chunk, err := s.readTaskRunAnalyticsPRsForRuns(tenantID, runIDs[start:end])
+			chunk, err := s.readTaskRunAnalyticsPRsForRunsContext(ctx, tenantID, runIDs[start:end])
 			if err != nil {
 				return nil, err
 			}
@@ -1027,7 +1035,7 @@ func (s *Server) readTaskRunAnalyticsPRsForRuns(tenantID string, runIDs []string
 	for _, runID := range runIDs {
 		args = append(args, runID)
 	}
-	rows, err := s.db.Query(`
+	rows, err := s.db.QueryContext(ctx, `
 		SELECT run_id, id, repo, pr_number, pr_url, head_sha, head_branch, last_agent_head_sha, base_branch,
 		       state, merged, opened_at, closed_at, merged_at, merged_by_login, created_at, updated_at
 		  FROM task_run_prs

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -563,6 +563,26 @@ type NotificationsConfig struct {
 	// Lifecycle configures agent lifecycle notifications (agent started,
 	// PR opened, failures).
 	Lifecycle *LifecycleNotificationsConfig `yaml:"lifecycle,omitempty" json:"lifecycle,omitempty"`
+	// Scheduled configures time-driven reports sent through named notifiers.
+	Scheduled []ScheduledNotificationConfig `yaml:"scheduled,omitempty" json:"scheduled,omitempty"`
+}
+
+// ScheduledNotificationConfig configures a report sent at a wall-clock time.
+type ScheduledNotificationConfig struct {
+	// ID uniquely identifies this schedule.
+	ID string `yaml:"id" json:"id"`
+	// Report is the report type name, for example "pending_prs".
+	Report string `yaml:"report" json:"report"`
+	// Via names one or more notifiers from notifications.notifiers.
+	Via []string `yaml:"via" json:"via"`
+	// At is a 24-hour wall-clock time in "HH:MM" format.
+	At string `yaml:"at" json:"at"`
+	// Timezone is an IANA name; UTC is used when it is empty.
+	Timezone string `yaml:"timezone,omitempty" json:"timezone,omitempty"`
+	// Weekdays limits delivery to mon through sun; an empty list means every day.
+	Weekdays []string `yaml:"weekdays,omitempty" json:"weekdays,omitempty"`
+	// Enabled defaults to true when omitted.
+	Enabled *bool `yaml:"enabled,omitempty" json:"enabled,omitempty"`
 }
 
 // LifecycleEventTypes is the canonical set of lifecycle event wire types: the

--- a/pkg/types/validation.go
+++ b/pkg/types/validation.go
@@ -807,7 +807,25 @@ func ValidateNotificationsConfig(cfg *NotificationsConfig) error {
 		if len(scheduled.Via) == 0 {
 			return fmt.Errorf("%s: via is required", prefix)
 		}
+		scheduledEnabled := scheduled.Enabled == nil || *scheduled.Enabled
+		seenVia := make(map[string]struct{}, len(scheduled.Via))
 		for _, via := range scheduled.Via {
+			// The scheduler sends once per pending via entry, so a repeated
+			// name would post the same report twice in the same tick — exactly
+			// as a repeated lifecycle route would, and rejected the same way.
+			if _, duplicate := seenVia[via]; duplicate {
+				return fmt.Errorf("%s: via %q is duplicated", prefix, via)
+			}
+			seenVia[via] = struct{}{}
+			// The notifier reference is checked only while the schedule is
+			// enabled, symmetrically with the disabled lifecycle block below:
+			// an operator who pauses a schedule and then deletes its notifier
+			// must not be left with a hub that refuses to load, or a settings
+			// screen whose every save 400s on an entry it renders with a
+			// "no longer configured" warning instead.
+			if !scheduledEnabled {
+				continue
+			}
 			if _, ok := cfg.Notifiers[via]; !ok {
 				return fmt.Errorf("%s: via %q does not name a configured notifier (defined: %s)", prefix, via, notifierNames(cfg.Notifiers))
 			}

--- a/pkg/types/validation.go
+++ b/pkg/types/validation.go
@@ -797,6 +797,14 @@ func ValidateNotificationsConfig(cfg *NotificationsConfig) error {
 		if strings.TrimSpace(scheduled.ID) == "" {
 			return fmt.Errorf("%s: id is required", prefix)
 		}
+		// Same ban as notifier names above: the hub keys each destination's
+		// dedupe row by the schedule id and via joined with a NUL sentinel,
+		// so an id (or a not-yet-checked via on a disabled schedule) carrying
+		// control characters could collide with another pair's row or forge
+		// hub log lines.
+		if strings.ContainsFunc(scheduled.ID, unicode.IsControl) {
+			return fmt.Errorf("%s: id %q cannot contain control characters", prefix, scheduled.ID)
+		}
 		if _, duplicate := seenScheduled[scheduled.ID]; duplicate {
 			return fmt.Errorf("%s: id %q is duplicated", prefix, scheduled.ID)
 		}
@@ -817,6 +825,13 @@ func ValidateNotificationsConfig(cfg *NotificationsConfig) error {
 				return fmt.Errorf("%s: via %q is duplicated", prefix, via)
 			}
 			seenVia[via] = struct{}{}
+			// An enabled schedule's via must name a notifier (whose name is
+			// already control-character-free); a disabled one skips that
+			// check, so ban control characters here too — a paused schedule
+			// still writes state rows keyed by its via.
+			if strings.ContainsFunc(via, unicode.IsControl) {
+				return fmt.Errorf("%s: via %q cannot contain control characters", prefix, via)
+			}
 			// The notifier reference is checked only while the schedule is
 			// enabled, symmetrically with the disabled lifecycle block below:
 			// an operator who pauses a schedule and then deletes its notifier

--- a/pkg/types/validation.go
+++ b/pkg/types/validation.go
@@ -818,13 +818,17 @@ func ValidateNotificationsConfig(cfg *NotificationsConfig) error {
 		scheduledEnabled := scheduled.Enabled == nil || *scheduled.Enabled
 		seenVia := make(map[string]struct{}, len(scheduled.Via))
 		for _, via := range scheduled.Via {
+			// The scheduler resolves and keys state by the TrimSpace'd via —
+			// matching the lifecycle routes above — so dedupe and the
+			// notifier lookup run on the trimmed name too.
+			trimmedVia := strings.TrimSpace(via)
 			// The scheduler sends once per pending via entry, so a repeated
 			// name would post the same report twice in the same tick — exactly
 			// as a repeated lifecycle route would, and rejected the same way.
-			if _, duplicate := seenVia[via]; duplicate {
+			if _, duplicate := seenVia[trimmedVia]; duplicate {
 				return fmt.Errorf("%s: via %q is duplicated", prefix, via)
 			}
-			seenVia[via] = struct{}{}
+			seenVia[trimmedVia] = struct{}{}
 			// An enabled schedule's via must name a notifier (whose name is
 			// already control-character-free); a disabled one skips that
 			// check, so ban control characters here too — a paused schedule
@@ -841,7 +845,7 @@ func ValidateNotificationsConfig(cfg *NotificationsConfig) error {
 			if !scheduledEnabled {
 				continue
 			}
-			if _, ok := cfg.Notifiers[via]; !ok {
+			if _, ok := cfg.Notifiers[trimmedVia]; !ok {
 				return fmt.Errorf("%s: via %q does not name a configured notifier (defined: %s)", prefix, via, notifierNames(cfg.Notifiers))
 			}
 		}

--- a/pkg/types/validation.go
+++ b/pkg/types/validation.go
@@ -764,15 +764,57 @@ func ValidateProviderConfig(name string, cfg *ProviderConfig) error {
 }
 
 // ValidateNotificationsConfig validates the structural invariants of a
-// NotificationsConfig: notifier entries are named and typed, and the
-// lifecycle block references a defined notifier. Provider-level checks
-// (supported type, secret resolution, provider settings) happen in the hub,
-// which owns the provider registry and the secrets.
+// NotificationsConfig: notifier entries are named and typed, the scheduled
+// block is well-formed, and the lifecycle block references a defined notifier.
+// Provider-level checks (supported type, secret resolution, provider settings)
+// happen in the hub, which owns the provider registry and the secrets.
 // A nil config is valid (feature absent).
 func ValidateNotificationsConfig(cfg *NotificationsConfig) error {
 	if cfg == nil {
 		return nil
 	}
+	if err := validateNotifiersBlock(cfg); err != nil {
+		return err
+	}
+	if err := validateScheduledBlock(cfg); err != nil {
+		return err
+	}
+	return validateLifecycleBlock(cfg)
+}
+
+// ValidateScheduledNotificationsConfig validates only what the scheduled
+// notifier tick consumes: the notifier map and the scheduled block. Each
+// minute tick gates on the validity of its own feature's config, so a defect
+// in the lifecycle block — say, an idle_after typo in a DISABLED block, which
+// the lifecycle tick itself tolerates by returning before it validates — must
+// not pause every scheduled report, and vice versa.
+// ValidateNotificationsConfig composes both for the paths that judge the
+// whole block (the settings PATCH, hub.yaml validation, the doctor).
+func ValidateScheduledNotificationsConfig(cfg *NotificationsConfig) error {
+	if cfg == nil {
+		return nil
+	}
+	if err := validateNotifiersBlock(cfg); err != nil {
+		return err
+	}
+	return validateScheduledBlock(cfg)
+}
+
+// ValidateLifecycleNotificationsConfig validates only what the lifecycle
+// notifier tick consumes: the notifier map and the lifecycle block. See
+// ValidateScheduledNotificationsConfig for why the two features gate
+// separately.
+func ValidateLifecycleNotificationsConfig(cfg *NotificationsConfig) error {
+	if cfg == nil {
+		return nil
+	}
+	if err := validateNotifiersBlock(cfg); err != nil {
+		return err
+	}
+	return validateLifecycleBlock(cfg)
+}
+
+func validateNotifiersBlock(cfg *NotificationsConfig) error {
 	for name, notifier := range cfg.Notifiers {
 		if strings.TrimSpace(name) == "" {
 			return fmt.Errorf("notifications.notifiers: notifier name is required")
@@ -790,84 +832,113 @@ func ValidateNotificationsConfig(cfg *NotificationsConfig) error {
 			return fmt.Errorf("notifications.notifiers.%s: type is required", name)
 		}
 	}
+	return nil
+}
+
+func validateScheduledBlock(cfg *NotificationsConfig) error {
 	seenScheduled := make(map[string]struct{}, len(cfg.Scheduled))
-	validWeekdays := map[string]struct{}{"mon": {}, "tue": {}, "wed": {}, "thu": {}, "fri": {}, "sat": {}, "sun": {}}
 	for i, scheduled := range cfg.Scheduled {
-		prefix := fmt.Sprintf("notifications.scheduled[%d]", i)
-		if strings.TrimSpace(scheduled.ID) == "" {
-			return fmt.Errorf("%s: id is required", prefix)
-		}
-		// Same ban as notifier names above: the hub keys each destination's
-		// dedupe row by the schedule id and via joined with a NUL sentinel,
-		// so an id (or a not-yet-checked via on a disabled schedule) carrying
-		// control characters could collide with another pair's row or forge
-		// hub log lines.
-		if strings.ContainsFunc(scheduled.ID, unicode.IsControl) {
-			return fmt.Errorf("%s: id %q cannot contain control characters", prefix, scheduled.ID)
+		if err := ValidateScheduledNotification(cfg, i); err != nil {
+			return err
 		}
 		if _, duplicate := seenScheduled[scheduled.ID]; duplicate {
-			return fmt.Errorf("%s: id %q is duplicated", prefix, scheduled.ID)
+			return fmt.Errorf("notifications.scheduled[%d]: id %q is duplicated", i, scheduled.ID)
 		}
 		seenScheduled[scheduled.ID] = struct{}{}
-		if strings.TrimSpace(scheduled.Report) == "" {
-			return fmt.Errorf("%s: report is required", prefix)
+	}
+	return nil
+}
+
+// ValidateScheduledNotification validates one scheduled entry's own fields
+// against cfg's notifier map — everything except the cross-entry duplicate-id
+// check, which needs the whole list. Exported so the settings PATCH handler
+// can validate only the entries a patch adds or edits, exempting stored ones
+// it merely re-sends.
+func ValidateScheduledNotification(cfg *NotificationsConfig, i int) error {
+	scheduled := cfg.Scheduled[i]
+	prefix := fmt.Sprintf("notifications.scheduled[%d]", i)
+	if strings.TrimSpace(scheduled.ID) == "" {
+		return fmt.Errorf("%s: id is required", prefix)
+	}
+	// Same ban as notifier names: the hub keys each destination's
+	// dedupe row by the schedule id and via joined with a NUL sentinel,
+	// so an id (or a not-yet-checked via on a disabled schedule) carrying
+	// control characters could collide with another pair's row or forge
+	// hub log lines.
+	if strings.ContainsFunc(scheduled.ID, unicode.IsControl) {
+		return fmt.Errorf("%s: id %q cannot contain control characters", prefix, scheduled.ID)
+	}
+	if strings.TrimSpace(scheduled.Report) == "" {
+		return fmt.Errorf("%s: report is required", prefix)
+	}
+	if len(scheduled.Via) == 0 {
+		return fmt.Errorf("%s: via is required", prefix)
+	}
+	scheduledEnabled := scheduled.Enabled == nil || *scheduled.Enabled
+	seenVia := make(map[string]struct{}, len(scheduled.Via))
+	for _, via := range scheduled.Via {
+		// The scheduler resolves and keys state by the TrimSpace'd via —
+		// matching the lifecycle routes — so dedupe and the
+		// notifier lookup run on the trimmed name too.
+		trimmedVia := strings.TrimSpace(via)
+		// A via that trims to nothing can never name a notifier and would key
+		// the schedule's state rows by an empty via segment; rejected even on
+		// a disabled schedule — like the control-character ban below — so a
+		// pause-then-re-enable cannot round-trip one into a confusing
+		// "does not name a configured notifier" error later.
+		if trimmedVia == "" {
+			return fmt.Errorf("%s: via entries cannot be blank", prefix)
 		}
-		if len(scheduled.Via) == 0 {
-			return fmt.Errorf("%s: via is required", prefix)
+		// The scheduler sends once per pending via entry, so a repeated
+		// name would post the same report twice in the same tick — exactly
+		// as a repeated lifecycle route would, and rejected the same way.
+		if _, duplicate := seenVia[trimmedVia]; duplicate {
+			return fmt.Errorf("%s: via %q is duplicated", prefix, via)
 		}
-		scheduledEnabled := scheduled.Enabled == nil || *scheduled.Enabled
-		seenVia := make(map[string]struct{}, len(scheduled.Via))
-		for _, via := range scheduled.Via {
-			// The scheduler resolves and keys state by the TrimSpace'd via —
-			// matching the lifecycle routes above — so dedupe and the
-			// notifier lookup run on the trimmed name too.
-			trimmedVia := strings.TrimSpace(via)
-			// The scheduler sends once per pending via entry, so a repeated
-			// name would post the same report twice in the same tick — exactly
-			// as a repeated lifecycle route would, and rejected the same way.
-			if _, duplicate := seenVia[trimmedVia]; duplicate {
-				return fmt.Errorf("%s: via %q is duplicated", prefix, via)
-			}
-			seenVia[trimmedVia] = struct{}{}
-			// An enabled schedule's via must name a notifier (whose name is
-			// already control-character-free); a disabled one skips that
-			// check, so ban control characters here too — a paused schedule
-			// still writes state rows keyed by its via.
-			if strings.ContainsFunc(via, unicode.IsControl) {
-				return fmt.Errorf("%s: via %q cannot contain control characters", prefix, via)
-			}
-			// The notifier reference is checked only while the schedule is
-			// enabled, symmetrically with the disabled lifecycle block below:
-			// an operator who pauses a schedule and then deletes its notifier
-			// must not be left with a hub that refuses to load, or a settings
-			// screen whose every save 400s on an entry it renders with a
-			// "no longer configured" warning instead.
-			if !scheduledEnabled {
-				continue
-			}
-			if _, ok := cfg.Notifiers[trimmedVia]; !ok {
-				return fmt.Errorf("%s: via %q does not name a configured notifier (defined: %s)", prefix, via, notifierNames(cfg.Notifiers))
-			}
+		seenVia[trimmedVia] = struct{}{}
+		// An enabled schedule's via must name a notifier (whose name is
+		// already control-character-free); a disabled one skips that
+		// check, so ban control characters here too — a paused schedule
+		// still writes state rows keyed by its via.
+		if strings.ContainsFunc(via, unicode.IsControl) {
+			return fmt.Errorf("%s: via %q cannot contain control characters", prefix, via)
 		}
-		if _, err := time.Parse("15:04", scheduled.At); err != nil {
-			return fmt.Errorf("%s: invalid at %q: %w", prefix, scheduled.At, err)
+		// The notifier reference is checked only while the schedule is
+		// enabled, symmetrically with the disabled lifecycle block:
+		// an operator who pauses a schedule and then deletes its notifier
+		// must not be left with a hub that refuses to load, or a settings
+		// screen whose every save 400s on an entry it renders with a
+		// "no longer configured" warning instead.
+		if !scheduledEnabled {
+			continue
 		}
-		if scheduled.Timezone != "" {
-			if _, err := time.LoadLocation(scheduled.Timezone); err != nil {
-				return fmt.Errorf("%s: invalid timezone %q: %w", prefix, scheduled.Timezone, err)
-			}
-		}
-		seenWeekdays := make(map[string]struct{}, len(scheduled.Weekdays))
-		for _, weekday := range scheduled.Weekdays {
-			if _, ok := validWeekdays[weekday]; !ok {
-				return fmt.Errorf("%s: weekday %q is invalid", prefix, weekday)
-			}
-			if _, duplicate := seenWeekdays[weekday]; duplicate {
-				return fmt.Errorf("%s: weekday %q is duplicated", prefix, weekday)
-			}
-			seenWeekdays[weekday] = struct{}{}
+		if _, ok := cfg.Notifiers[trimmedVia]; !ok {
+			return fmt.Errorf("%s: via %q does not name a configured notifier (defined: %s)", prefix, via, notifierNames(cfg.Notifiers))
 		}
 	}
+	if _, err := time.Parse("15:04", scheduled.At); err != nil {
+		return fmt.Errorf("%s: invalid at %q: %w", prefix, scheduled.At, err)
+	}
+	if scheduled.Timezone != "" {
+		if _, err := time.LoadLocation(scheduled.Timezone); err != nil {
+			return fmt.Errorf("%s: invalid timezone %q: %w", prefix, scheduled.Timezone, err)
+		}
+	}
+	validWeekdays := map[string]struct{}{"mon": {}, "tue": {}, "wed": {}, "thu": {}, "fri": {}, "sat": {}, "sun": {}}
+	seenWeekdays := make(map[string]struct{}, len(scheduled.Weekdays))
+	for _, weekday := range scheduled.Weekdays {
+		if _, ok := validWeekdays[weekday]; !ok {
+			return fmt.Errorf("%s: weekday %q is invalid", prefix, weekday)
+		}
+		if _, duplicate := seenWeekdays[weekday]; duplicate {
+			return fmt.Errorf("%s: weekday %q is duplicated", prefix, weekday)
+		}
+		seenWeekdays[weekday] = struct{}{}
+	}
+	return nil
+}
+
+func validateLifecycleBlock(cfg *NotificationsConfig) error {
 	lc := cfg.Lifecycle
 	if lc == nil {
 		return nil

--- a/pkg/types/validation.go
+++ b/pkg/types/validation.go
@@ -790,6 +790,47 @@ func ValidateNotificationsConfig(cfg *NotificationsConfig) error {
 			return fmt.Errorf("notifications.notifiers.%s: type is required", name)
 		}
 	}
+	seenScheduled := make(map[string]struct{}, len(cfg.Scheduled))
+	validWeekdays := map[string]struct{}{"mon": {}, "tue": {}, "wed": {}, "thu": {}, "fri": {}, "sat": {}, "sun": {}}
+	for i, scheduled := range cfg.Scheduled {
+		prefix := fmt.Sprintf("notifications.scheduled[%d]", i)
+		if strings.TrimSpace(scheduled.ID) == "" {
+			return fmt.Errorf("%s: id is required", prefix)
+		}
+		if _, duplicate := seenScheduled[scheduled.ID]; duplicate {
+			return fmt.Errorf("%s: id %q is duplicated", prefix, scheduled.ID)
+		}
+		seenScheduled[scheduled.ID] = struct{}{}
+		if strings.TrimSpace(scheduled.Report) == "" {
+			return fmt.Errorf("%s: report is required", prefix)
+		}
+		if len(scheduled.Via) == 0 {
+			return fmt.Errorf("%s: via is required", prefix)
+		}
+		for _, via := range scheduled.Via {
+			if _, ok := cfg.Notifiers[via]; !ok {
+				return fmt.Errorf("%s: via %q does not name a configured notifier (defined: %s)", prefix, via, notifierNames(cfg.Notifiers))
+			}
+		}
+		if _, err := time.Parse("15:04", scheduled.At); err != nil {
+			return fmt.Errorf("%s: invalid at %q: %w", prefix, scheduled.At, err)
+		}
+		if scheduled.Timezone != "" {
+			if _, err := time.LoadLocation(scheduled.Timezone); err != nil {
+				return fmt.Errorf("%s: invalid timezone %q: %w", prefix, scheduled.Timezone, err)
+			}
+		}
+		seenWeekdays := make(map[string]struct{}, len(scheduled.Weekdays))
+		for _, weekday := range scheduled.Weekdays {
+			if _, ok := validWeekdays[weekday]; !ok {
+				return fmt.Errorf("%s: weekday %q is invalid", prefix, weekday)
+			}
+			if _, duplicate := seenWeekdays[weekday]; duplicate {
+				return fmt.Errorf("%s: weekday %q is duplicated", prefix, weekday)
+			}
+			seenWeekdays[weekday] = struct{}{}
+		}
+	}
 	lc := cfg.Lifecycle
 	if lc == nil {
 		return nil

--- a/pkg/types/validation_notifications_test.go
+++ b/pkg/types/validation_notifications_test.go
@@ -39,6 +39,36 @@ func TestValidateNotificationsConfig(t *testing.T) {
 			cfg:  &NotificationsConfig{Notifiers: slack()},
 		},
 		{
+			name: "valid scheduled notification",
+			cfg: &NotificationsConfig{Notifiers: slack(), Scheduled: []ScheduledNotificationConfig{{
+				ID: "morning-prs", Report: "pending_prs", Via: []string{"eng-agents"}, At: "09:30", Timezone: "America/Sao_Paulo", Weekdays: []string{"mon", "tue"},
+			}}},
+		},
+		{
+			name:    "scheduled notification requires unique id",
+			cfg:     &NotificationsConfig{Notifiers: slack(), Scheduled: []ScheduledNotificationConfig{{ID: "daily", Report: "x", Via: []string{"eng-agents"}, At: "09:00"}, {ID: "daily", Report: "x", Via: []string{"eng-agents"}, At: "10:00"}}},
+			wantErr: true,
+			errMsg:  "id \"daily\" is duplicated",
+		},
+		{
+			name:    "scheduled notification validates fields",
+			cfg:     &NotificationsConfig{Notifiers: slack(), Scheduled: []ScheduledNotificationConfig{{ID: "daily", Via: []string{"eng-agents"}, At: "09:00"}}},
+			wantErr: true,
+			errMsg:  "report is required",
+		},
+		{
+			name:    "scheduled notification validates notifier and clock",
+			cfg:     &NotificationsConfig{Notifiers: slack(), Scheduled: []ScheduledNotificationConfig{{ID: "daily", Report: "x", Via: []string{"missing"}, At: "9:00"}}},
+			wantErr: true,
+			errMsg:  "does not name a configured notifier",
+		},
+		{
+			name:    "scheduled notification validates timezone and weekdays",
+			cfg:     &NotificationsConfig{Notifiers: slack(), Scheduled: []ScheduledNotificationConfig{{ID: "daily", Report: "x", Via: []string{"eng-agents"}, At: "09:00", Timezone: "not/a-zone"}}},
+			wantErr: true,
+			errMsg:  "invalid timezone",
+		},
+		{
 			name: "valid lifecycle wiring",
 			cfg: &NotificationsConfig{
 				Notifiers: slack(),

--- a/pkg/types/validation_notifications_test.go
+++ b/pkg/types/validation_notifications_test.go
@@ -84,6 +84,16 @@ func TestValidateNotificationsConfig(t *testing.T) {
 			errMsg:  `via "gone" is duplicated`,
 		},
 		{
+			// A whitespace-only via can never name a notifier and would key the
+			// schedule's state rows by an empty via segment, surfacing only as a
+			// confusing error on a later re-enable — so it is rejected even
+			// while the schedule is disabled, like the control-character ban.
+			name:    "paused scheduled notification rejects a blank via",
+			cfg:     &NotificationsConfig{Notifiers: slack(), Scheduled: []ScheduledNotificationConfig{{ID: "daily", Report: "x", Via: []string{" "}, At: "09:00", Enabled: boolPtr(false)}}},
+			wantErr: true,
+			errMsg:  "via entries cannot be blank",
+		},
+		{
 			name:    "scheduled notification validates timezone and weekdays",
 			cfg:     &NotificationsConfig{Notifiers: slack(), Scheduled: []ScheduledNotificationConfig{{ID: "daily", Report: "x", Via: []string{"eng-agents"}, At: "09:00", Timezone: "not/a-zone"}}},
 			wantErr: true,
@@ -305,6 +315,55 @@ func TestValidateNotificationsConfig(t *testing.T) {
 				t.Fatalf("ValidateNotificationsConfig() error = %v", err)
 			}
 		})
+	}
+}
+
+// Each minute tick gates on the validity of its own feature's config: a
+// defect in a hand-written scheduled block must pause scheduled reports
+// without pausing lifecycle alerts, and a DISABLED lifecycle block carrying an
+// invalid duration — which the lifecycle tick itself tolerates by returning
+// before it validates — must not kill every scheduled report. The composed
+// ValidateNotificationsConfig still rejects both, so the settings PATCH and
+// hub.yaml validation never accept a new defect.
+func TestPerFeatureNotificationValidatorsAreScoped(t *testing.T) {
+	notifiers := map[string]NotifierConfig{"eng": {Type: "slack"}}
+	badScheduled := &NotificationsConfig{
+		Notifiers: notifiers,
+		Scheduled: []ScheduledNotificationConfig{{ID: "daily", Report: "x", Via: []string{"eng"}, At: "09:00", Weekdays: []string{"monday"}}},
+		Lifecycle: &LifecycleNotificationsConfig{Via: "eng"},
+	}
+	if err := ValidateLifecycleNotificationsConfig(badScheduled); err != nil {
+		t.Fatalf("lifecycle validator judged the scheduled block: %v", err)
+	}
+	if err := ValidateScheduledNotificationsConfig(badScheduled); err == nil {
+		t.Fatal("scheduled validator missed the invalid weekday")
+	}
+	if err := ValidateNotificationsConfig(badScheduled); err == nil {
+		t.Fatal("composed validator missed the invalid weekday")
+	}
+
+	badLifecycle := &NotificationsConfig{
+		Notifiers: notifiers,
+		Scheduled: []ScheduledNotificationConfig{{ID: "daily", Report: "x", Via: []string{"eng"}, At: "09:00"}},
+		Lifecycle: &LifecycleNotificationsConfig{Enabled: boolPtr(false), IdleAfter: "30s"},
+	}
+	if err := ValidateScheduledNotificationsConfig(badLifecycle); err != nil {
+		t.Fatalf("scheduled validator judged the disabled lifecycle block's durations: %v", err)
+	}
+	if err := ValidateLifecycleNotificationsConfig(badLifecycle); err == nil {
+		t.Fatal("lifecycle validator missed the sub-floor idle_after")
+	}
+	if err := ValidateNotificationsConfig(badLifecycle); err == nil {
+		t.Fatal("composed validator missed the sub-floor idle_after")
+	}
+
+	// A bad notifier name pauses both ticks: each consumes the notifier map.
+	badNotifiers := &NotificationsConfig{Notifiers: map[string]NotifierConfig{"eng\n": {Type: "slack"}}}
+	if err := ValidateScheduledNotificationsConfig(badNotifiers); err == nil {
+		t.Fatal("scheduled validator missed the control-character notifier name")
+	}
+	if err := ValidateLifecycleNotificationsConfig(badNotifiers); err == nil {
+		t.Fatal("lifecycle validator missed the control-character notifier name")
 	}
 }
 

--- a/pkg/types/validation_notifications_test.go
+++ b/pkg/types/validation_notifications_test.go
@@ -63,6 +63,27 @@ func TestValidateNotificationsConfig(t *testing.T) {
 			errMsg:  "does not name a configured notifier",
 		},
 		{
+			// The scheduler sends once per pending via entry, so a repeated
+			// name would post the same report twice in the same tick.
+			name:    "scheduled notification rejects duplicate via",
+			cfg:     &NotificationsConfig{Notifiers: slack(), Scheduled: []ScheduledNotificationConfig{{ID: "daily", Report: "x", Via: []string{"eng-agents", "eng-agents"}, At: "09:00"}}},
+			wantErr: true,
+			errMsg:  `via "eng-agents" is duplicated`,
+		},
+		{
+			// Symmetric with the disabled lifecycle block: an operator who
+			// pauses a schedule and then deletes its notifier must not be left
+			// with a hub that refuses to load.
+			name: "paused scheduled notification accepts a dangling via",
+			cfg:  &NotificationsConfig{Notifiers: slack(), Scheduled: []ScheduledNotificationConfig{{ID: "daily", Report: "x", Via: []string{"gone"}, At: "09:00", Enabled: boolPtr(false)}}},
+		},
+		{
+			name:    "paused scheduled notification still rejects duplicate via",
+			cfg:     &NotificationsConfig{Notifiers: slack(), Scheduled: []ScheduledNotificationConfig{{ID: "daily", Report: "x", Via: []string{"gone", "gone"}, At: "09:00", Enabled: boolPtr(false)}}},
+			wantErr: true,
+			errMsg:  `via "gone" is duplicated`,
+		},
+		{
 			name:    "scheduled notification validates timezone and weekdays",
 			cfg:     &NotificationsConfig{Notifiers: slack(), Scheduled: []ScheduledNotificationConfig{{ID: "daily", Report: "x", Via: []string{"eng-agents"}, At: "09:00", Timezone: "not/a-zone"}}},
 			wantErr: true,

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -4697,8 +4697,12 @@ function browserTimezone(): string {
 
 // The result of probing one scheduled report. `payload` is set only by a dry
 // run — the rendered message the hub would post, shown instead of sending it.
+// `mode` records WHICH probe this state belongs to: Preview and Send now share
+// one slot per schedule, so the busy label has to land on the button that was
+// actually clicked rather than on whichever one renders it.
 type ReportTestState = {
   status: "sending" | "ok" | "error"
+  mode: "preview" | "send"
   message: string
   payload?: unknown
 }
@@ -5112,7 +5116,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
       // The pause notice is deliberately NOT cleared by re-adding the channel:
       // the schedule it names is still disabled, and only the operator turning
       // it back on makes it fire again. The notice rewords itself once the via
-      // resolves — see schedulePauseText.
+      // resolves — see schedulePauseNotices.
     }
     setSaveErrors((current) => { const { [name]: _cleared, ...rest } = current; return rest })
     setDetachedSaveError("")
@@ -5159,7 +5163,6 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
       }
       return { ...schedule, via }
     })
-    setSchedulePause(null)
     const generation = saveGeneration.current
     const { persisted, message: failure } = await savePatch({
       notifiers: nextNotifiers,
@@ -5175,7 +5178,16 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
       // "Posts to eng". saveSchedule/removeSchedule invalidate for the same
       // reason; this is the third way a schedule's destinations change.
       touchedIds.forEach(invalidateReportTest)
-      if (pausedIds.length > 0) setSchedulePause({ ids: pausedIds, channel: name })
+      // Merged into whatever is already on screen rather than replacing it: a
+      // notice about the reports the LAST removal paused is still the only
+      // record of why they are off, and this delete did not answer it. Only a
+      // second removal of the same channel name supersedes its own notice.
+      if (pausedIds.length > 0) {
+        setSchedulePauses((current) => [
+          ...current.filter((pause) => pause.channel !== name),
+          { ids: pausedIds, channel: name },
+        ])
+      }
     }
     setSaveErrors((current) => { const { [name]: _cleared, ...rest } = current; return rest })
     if (generation !== saveGeneration.current) {
@@ -5240,6 +5252,13 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
   const [showSchedule, setShowSchedule] = useState(false)
   const [scheduleMode, setScheduleMode] = useState<"add" | "edit">("add")
   const [editScheduleId, setEditScheduleId] = useState<string | null>(null)
+  // Which ROW the editor is on. The hub tolerates a hand-written config that
+  // stores the same id twice, so an id is not an address: matching on it would
+  // edit, toggle or delete both rows at once — and a toggle that flips both is
+  // then rejected by the hub's own duplicate-id check, leaving the screen with
+  // no way to reach either row. Every card action carries its index instead;
+  // `editScheduleId` stays for the heading, which only has to name the report.
+  const [editScheduleIndex, setEditScheduleIndex] = useState<number | null>(null)
   const [formScheduleId, setFormScheduleId] = useState("")
   const [formReport, setFormReport] = useState(SCHEDULED_REPORTS[0].id)
   const [formVia, setFormVia] = useState<string[]>([])
@@ -5267,7 +5286,11 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
   // must not erase a notice about reports that are still paused, and re-adding
   // a channel by the same name answers only half the instruction — the report
   // still has to be turned back on by hand.
-  const [schedulePause, setSchedulePause] = useState<{ ids: string[]; channel: string } | null>(null)
+  // One entry PER REMOVED CHANNEL, because each notice names the channel that
+  // caused it: deleting `ops` while the notice about `eng` is still on screen
+  // has to add a second notice, not replace the only record of why the first
+  // batch of reports is off.
+  const [schedulePauses, setSchedulePauses] = useState<{ ids: string[]; channel: string }[]>([])
   const [reportTests, setReportTests] = useState<Record<string, ReportTestState>>({})
   // Invalidates an in-flight probe whose schedule has meanwhile been edited or
   // deleted: its result describes a report that went somewhere else.
@@ -5298,6 +5321,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     const report = SCHEDULED_REPORTS[0].id
     setScheduleMode("add")
     setEditScheduleId(null)
+    setEditScheduleIndex(null)
     setFormReport(report)
     setFormScheduleId(suggestScheduleId(report))
     // One channel is an unambiguous default; more than one is a choice.
@@ -5311,11 +5335,12 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     setShowSchedule(true)
   }
 
-  const openEditSchedule = (schedule: ScheduledNotificationView) => {
+  const openEditSchedule = (schedule: ScheduledNotificationView, index: number) => {
     loadZones()
     saveGeneration.current++
     setScheduleMode("edit")
     setEditScheduleId(schedule.id)
+    setEditScheduleIndex(index)
     setFormScheduleId(schedule.id)
     setFormReport(schedule.report)
     // Seeded on the resolved names, the same ones the checkboxes are keyed by:
@@ -5359,8 +5384,8 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
       weekdays: formWeekdays,
       enabled: formScheduleEnabled,
     }
-    const next = editScheduleId
-      ? schedules.map((schedule) => (schedule.id === editScheduleId ? entry : schedule))
+    const next = editScheduleIndex !== null
+      ? schedules.map((schedule, i) => (i === editScheduleIndex ? entry : schedule))
       : [...schedules, entry]
     const generation = saveGeneration.current
     const { persisted, message } = await savePatch({ scheduled: next })
@@ -5378,6 +5403,12 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
       // land elsewhere. A rejected EDIT left the schedule in place and its card
       // carries the reason; a rejected ADD created no schedule, so there is no
       // card to key it by and it goes to the banner above the list.
+      // Keyed on `persisted`, not `message`, for the reason toggleSchedule
+      // spells out: a PATCH the hub accepted whose follow-up re-read failed
+      // saved the report, and calling that `Adding report "x" failed` invites a
+      // re-add that collides on the id. The reload failure goes to the banner
+      // verbatim instead of blaming the save.
+      if (persisted) { setDetachedScheduleError(message ?? ""); return }
       if (message) {
         if (schedules.some((schedule) => schedule.id === id)) {
           setScheduleSaveErrors((current) => ({ ...current, [id]: message }))
@@ -5395,25 +5426,25 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     setScheduleSaveErrors((current) => { const { [id]: _cleared, ...rest } = current; return rest })
   }
 
-  // Drops ONE schedule from the pause notice: re-enabling, editing or deleting
+  // Drops ONE schedule from the pause notices: re-enabling, editing or deleting
   // it answers the pause for that report. Every other id stays — a save on an
   // unrelated schedule is not an answer to theirs, and the notice is the only
-  // record that this screen turned them off.
+  // record that this screen turned them off. A notice left with no ids is gone.
   function forgetSchedulePause(id: string) {
-    setSchedulePause((current) => {
-      if (!current) return null
-      const ids = current.ids.filter((other) => other !== id)
-      return ids.length > 0 ? { ...current, ids } : null
-    })
+    setSchedulePauses((current) =>
+      current
+        .map((pause) => ({ ...pause, ids: pause.ids.filter((other) => other !== id) }))
+        .filter((pause) => pause.ids.length > 0),
+    )
   }
 
-  async function removeSchedule(id: string) {
+  async function removeSchedule(id: string, index: number) {
     // Snapshotted for the same reason saveSchedule and removeChannel do it: a
     // rejected delete whose dialog has meanwhile been replaced has to report
     // onto the surviving schedule's card, since scheduleError renders only
     // inside the dialog that is no longer there.
     const generation = saveGeneration.current
-    const { persisted, message } = await savePatch({ scheduled: schedules.filter((schedule) => schedule.id !== id) })
+    const { persisted, message } = await savePatch({ scheduled: schedules.filter((_, i) => i !== index) })
     if (persisted) {
       invalidateReportTest(id)
       clearScheduleSaveError(id)
@@ -5422,7 +5453,10 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     setDetachedScheduleError("")
     if (generation !== saveGeneration.current) {
       // A rejected delete left the schedule in place, so its card carries the
-      // reason; a successful one has no card and needs none.
+      // reason; a successful one has no card and needs none — so a reload
+      // failure after a delete the hub accepted goes to the banner verbatim
+      // rather than writing "Last save failed" onto a card that is gone.
+      if (persisted) { setDetachedScheduleError(message ?? ""); return }
       if (message) setScheduleSaveErrors((current) => ({ ...current, [id]: message }))
       return
     }
@@ -5430,9 +5464,9 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     setShowSchedule(false)
   }
 
-  async function toggleSchedule(schedule: ScheduledNotificationView, value: boolean) {
+  async function toggleSchedule(schedule: ScheduledNotificationView, index: number, value: boolean) {
     const { persisted, message } = await savePatch({
-      scheduled: schedules.map((other) => (other.id === schedule.id ? { ...other, enabled: value } : other)),
+      scheduled: schedules.map((other, i) => (i === index ? { ...other, enabled: value } : other)),
     })
     // The cleanup follows `persisted`, not `message`, exactly as saveSchedule
     // and removeSchedule do: a PATCH the hub accepted whose follow-up re-read
@@ -5462,14 +5496,15 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     const targets = schedule.via.map(viaName).filter((via) => notifiers[via])
     if (targets.length === 0) return
     const generation = reportTestGeneration.current[schedule.id] ?? 0
-    const settle = (state: ReportTestState) =>
+    const mode = dryRun ? "preview" : "send"
+    const settle = (state: Omit<ReportTestState, "mode">) =>
       setReportTests((current) => {
         // A superseded result is dropped rather than written: whatever sits
         // under this id now belongs to the probe that replaced this one.
         if (generation !== (reportTestGeneration.current[schedule.id] ?? 0)) return current
-        return { ...current, [schedule.id]: state }
+        return { ...current, [schedule.id]: { ...state, mode } }
       })
-    setReportTests((current) => ({ ...current, [schedule.id]: { status: "sending", message: "" } }))
+    setReportTests((current) => ({ ...current, [schedule.id]: { status: "sending", mode, message: "" } }))
     if (dryRun) {
       try {
         const { empty, payload } = await sendScheduledReportTest(schedule.report, targets[0], true)
@@ -5526,20 +5561,25 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
   // last one left; buildPatch clears `enabled` rather than failing the save.
   const otherRoutedCount = routes.filter((route) => route.via !== editName && notifiers[route.via]).length
 
-  // The pause notice, derived from the config as it stands now. A report the
+  // The pause notices, derived from the config as it stands now. A report a
   // notice named that is enabled again — or gone — has answered it, and a
   // channel re-added under the same name resolves the via without un-pausing
-  // anything, so only the second half of the instruction still holds.
-  const pausedByRemoval = schedulePause
-    ? schedules.filter((schedule) => !schedule.enabled && schedulePause.ids.includes(schedule.id))
-    : []
-  const schedulePauseText = schedulePause && pausedByRemoval.length > 0
-    ? `Paused ${pausedByRemoval.map((schedule) => schedule.id).join(", ")} — "${schedulePause.channel}" was the only channel ${pausedByRemoval.length === 1 ? "it posts" : "they post"} to. ${
-      notifiers[schedulePause.channel]
-        ? "A channel by that name exists again: open Edit and turn the report back on."
-        : "Open Edit, pick another channel and turn the report back on."
-    }`
-    : ""
+  // anything, so only the second half of the instruction still holds. A notice
+  // whose reports have all answered it renders nothing.
+  const schedulePauseNotices = schedulePauses
+    .map((pause) => ({
+      channel: pause.channel,
+      paused: schedules.filter((schedule) => !schedule.enabled && pause.ids.includes(schedule.id)),
+    }))
+    .filter((notice) => notice.paused.length > 0)
+    .map((notice) => ({
+      channel: notice.channel,
+      text: `Paused ${notice.paused.map((schedule) => schedule.id).join(", ")} — "${notice.channel}" was the only channel ${notice.paused.length === 1 ? "it posts" : "they post"} to. ${
+        notifiers[notice.channel]
+          ? "A channel by that name exists again: open Edit and turn the report back on."
+          : "Open Edit, pick another channel and turn the report back on."
+      }`,
+    }))
 
   return (
     <div className="space-y-6">
@@ -5844,12 +5884,15 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
           </div>
         </div>
 
-        {schedulePauseText && (
-          <div className="flex items-start gap-2 rounded-md border border-amber-500/20 bg-amber-500/10 px-3 py-2 text-xs text-amber-400">
+        {schedulePauseNotices.map((notice) => (
+          <div
+            key={notice.channel}
+            className="flex items-start gap-2 rounded-md border border-amber-500/20 bg-amber-500/10 px-3 py-2 text-xs text-amber-400"
+          >
             <AlertTriangle className="size-3.5 mt-px shrink-0" />
-            <span className="break-words">{schedulePauseText}</span>
+            <span className="break-words">{notice.text}</span>
           </div>
-        )}
+        ))}
         {detachedScheduleError && (
           <div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
             <AlertTriangle className="size-3.5 mt-px shrink-0" />
@@ -5865,7 +5908,9 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
           </p>
         ) : (
           <div className="space-y-2">
-            {schedules.map((schedule) => {
+            {/* Keyed by position, not id: the hub tolerates a stored duplicate
+                id, and two cards sharing a React key collapse into one. */}
+            {schedules.map((schedule, index) => {
               const test = reportTests[schedule.id]
               // Resolved names, matching the hub: " eng " is delivered to the
               // channel `eng`, so the card must not flag it as missing — and
@@ -5873,8 +5918,11 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
               const missingVia = schedule.via.map(viaName).filter((via) => !notifiers[via])
               const targets = schedule.via.map(viaName).filter((via) => notifiers[via])
               const canTest = targets.length > 0 && !saving && test?.status !== "sending"
+              // Which probe is in flight, so "Working…" replaces the label of
+              // the button that was clicked and not the other one's.
+              const running = test?.status === "sending" ? test.mode : null
               return (
-                <div key={schedule.id} className="border border-border rounded-lg p-4">
+                <div key={`${index}-${schedule.id}`} className="border border-border rounded-lg p-4">
                   <div className="flex items-start justify-between gap-3">
                     <div className="min-w-0">
                       <div className="flex items-center gap-2 flex-wrap">
@@ -5914,7 +5962,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                       <Switch
                         checked={schedule.enabled}
                         disabled={saving}
-                        onCheckedChange={(checked) => toggleSchedule(schedule, checked)}
+                        onCheckedChange={(checked) => toggleSchedule(schedule, index, checked)}
                         aria-label={`Enable the ${schedule.id} report`}
                       />
                       {/* Disabled while a save is in flight for the same reason
@@ -5922,7 +5970,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                           the pre-save snapshot, so opening it mid-save would
                           hand the next save a stale copy of the change that is
                           still landing. */}
-                      <Button size="sm" variant="ghost" disabled={saving} onClick={() => openEditSchedule(schedule)}>Edit</Button>
+                      <Button size="sm" variant="ghost" disabled={saving} onClick={() => openEditSchedule(schedule, index)}>Edit</Button>
                     </div>
                   </div>
                   <div className="flex items-center gap-2 mt-3">
@@ -5935,7 +5983,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                       onClick={() => runReportTest(schedule, true)}
                     >
                       <Eye className="size-3.5" />
-                      Preview
+                      {running === "preview" ? "Working…" : "Preview"}
                     </Button>
                     <Button
                       size="sm"
@@ -5946,7 +5994,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                       onClick={() => runReportTest(schedule, false)}
                     >
                       <Send className="size-3.5" />
-                      {test?.status === "sending" ? "Working…" : "Send now"}
+                      {running === "send" ? "Working…" : "Send now"}
                     </Button>
                     {targets.length === 0 && (
                       <span className="text-xs text-muted-foreground">
@@ -6466,13 +6514,13 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
               </div>
             )}
             <div className="flex items-center justify-between px-5 py-4">
-              {scheduleMode === "edit" && editScheduleId && (
+              {scheduleMode === "edit" && editScheduleId && editScheduleIndex !== null && (
                 <Button
                   size="sm"
                   variant="ghost"
                   className="text-destructive hover:text-destructive"
                   disabled={saving}
-                  onClick={() => removeSchedule(editScheduleId)}
+                  onClick={() => removeSchedule(editScheduleId, editScheduleIndex)}
                 >
                   <Trash2 className="size-3.5 mr-1" /> Remove
                 </Button>

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -4655,10 +4655,39 @@ function viaName(via: string): string {
   return via.trim()
 }
 
+// How a schedule's per-row UI state — probe result, probe generation, save
+// failure — is addressed. The hub tolerates a stored duplicate schedule id, so
+// the actions (toggle, edit, remove) already address rows by position; keying
+// the state by id alone left the two cards of a duplicate sharing a probe
+// result, a "Last save failed" and a "Working…".
+function scheduleKey(index: number, id: string): string {
+  return `${index}-${id}`
+}
+
+// The position half of a scheduleKey. Only removeSchedule needs it: deleting a
+// row renumbers every row after it, so their state no longer addresses the
+// schedule it was recorded for.
+function scheduleKeyIndex(key: string): number {
+  return Number(key.slice(0, key.indexOf("-")))
+}
+
 // An empty weekday list is the hub's "every day", never "never".
 function weekdaysLabel(weekdays: string[]): string {
   if (weekdays.length === 0) return "Every day"
-  return WEEKDAYS.filter((day) => weekdays.includes(day.id)).map((day) => day.label).join(", ")
+  const known = WEEKDAYS.filter((day) => weekdays.includes(day.id)).map((day) => day.label)
+  // A day this build does not know can only come from a hand-written hub.yaml.
+  // Filtering it out left the card showing an empty day field — or a shorter
+  // week than the schedule actually carries — for a value the operator then
+  // has to find in the editor to clear.
+  const flagged = unknownWeekdays(weekdays).map((weekday) => `${weekday} (invalid)`)
+  return [...known, ...flagged].join(", ")
+}
+
+// The days the hub does not accept. The editor flags them so they can be
+// cleared from here; leaving them invisible made every edit to the schedule
+// 400 on a control that was not on the screen.
+function unknownWeekdays(weekdays: string[]): string[] {
+  return weekdays.filter((weekday) => !WEEKDAYS.some((day) => day.id === weekday))
 }
 
 // Wire values are the three-letter names the hub validates against; the labels
@@ -5144,22 +5173,30 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     // filtered the lifecycle routes would 400 on the schedule and leave the
     // channel undeletable from this screen. Dropping the channel from every
     // schedule's `via` keeps the rest of its destinations running; a schedule
-    // left with nothing else is PAUSED rather than emptied, because the hub
-    // also rejects an empty `via`. Pausing keeps the dangling name visible so
-    // the card's "no longer configured" warning still points at the repair.
+    // left with no channel this hub actually has is PAUSED rather than emptied,
+    // because the hub also rejects an empty `via`. Pausing keeps the dangling
+    // name visible so the card's "no longer configured" warning still points
+    // at the repair.
     const pausedIds: string[] = []
-    const touchedIds: string[] = []
+    const touchedKeys: string[] = []
     // Entries are matched on their resolved name: the hub trims before looking
     // the notifier up, so a hand-written " eng " points at the channel being
     // deleted just as `eng` does — and leaving it behind makes the delete
     // unsaveable.
-    const nextScheduled = schedules.map((schedule) => {
+    const nextScheduled = schedules.map((schedule, index) => {
       if (!schedule.via.some((entry) => viaName(entry) === name)) return schedule
-      touchedIds.push(schedule.id)
+      touchedKeys.push(scheduleKey(index, schedule.id))
       const via = schedule.via.filter((entry) => viaName(entry) !== name)
-      if (via.length === 0) {
+      // Paused when nothing LEFT resolves to a configured channel, not only
+      // when the list is emptied: the hub rejects an enabled schedule whose
+      // via names no notifier it has, so a schedule already carrying a
+      // dangling second name would 400 this delete on a channel the operator
+      // is not touching, with nothing on screen pointing at the repair.
+      if (!via.some((entry) => notifiers[viaName(entry)])) {
         if (schedule.enabled) pausedIds.push(schedule.id)
-        return { ...schedule, enabled: false }
+        // An empty `via` is rejected outright, so a schedule left with nothing
+        // keeps its list — paused, with the dangling name still on the card.
+        return { ...schedule, enabled: false, via: via.length > 0 ? via : schedule.via }
       }
       return { ...schedule, via }
     })
@@ -5177,7 +5214,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
       // longer happen: a green "Posted to eng, ops." above a card that reads
       // "Posts to eng". saveSchedule/removeSchedule invalidate for the same
       // reason; this is the third way a schedule's destinations change.
-      touchedIds.forEach(invalidateReportTest)
+      touchedKeys.forEach(invalidateReportTest)
       // Merged into whatever is already on screen rather than replacing it: a
       // notice about the reports the LAST removal paused is still the only
       // record of why they are off, and this delete did not answer it. Only a
@@ -5270,11 +5307,16 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
   const [formAt, setFormAt] = useState("09:00")
   const [formTimezone, setFormTimezone] = useState("UTC")
   const [formWeekdays, setFormWeekdays] = useState<string[]>([])
+  // The stored days this build does not know, snapshotted when the dialog
+  // opens — the same reason formDanglingVia is snapshotted: deriving the chips
+  // from formWeekdays would delete the flagged chip the moment it is unticked,
+  // and the only way back would be Cancel.
+  const [formUnknownWeekdays, setFormUnknownWeekdays] = useState<string[]>([])
   const [formScheduleEnabled, setFormScheduleEnabled] = useState(true)
   const [scheduleError, setScheduleError] = useState("")
   // A save made from a schedule's CARD (the enable switch) has no dialog to
   // report into — scheduleError renders inside the closed dialog — so its
-  // failure lands on the card itself, keyed by schedule id.
+  // failure lands on the card itself, keyed by row — see scheduleKey.
   const [scheduleSaveErrors, setScheduleSaveErrors] = useState<Record<string, string>>({})
   // A rejected ADD created no schedule, so keying its failure by id would render
   // it nowhere — the same reason detachedSaveError exists for channels.
@@ -5330,6 +5372,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     setFormAt("09:00")
     setFormTimezone(browserTimezone())
     setFormWeekdays([])
+    setFormUnknownWeekdays([])
     setFormScheduleEnabled(true)
     setScheduleError("")
     setShowSchedule(true)
@@ -5351,14 +5394,31 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     setFormAt(normalizeAt(schedule.at))
     setFormTimezone(schedule.timezone || "UTC")
     setFormWeekdays([...schedule.weekdays])
+    setFormUnknownWeekdays(unknownWeekdays(schedule.weekdays))
     setFormScheduleEnabled(schedule.enabled)
     setScheduleError("")
     setShowSchedule(true)
   }
 
-  const invalidateReportTest = (id: string) => {
-    reportTestGeneration.current[id] = (reportTestGeneration.current[id] ?? 0) + 1
-    setReportTests((current) => { const { [id]: _stale, ...rest } = current; return rest })
+  const invalidateReportTest = (key: string) => {
+    reportTestGeneration.current[key] = (reportTestGeneration.current[key] ?? 0) + 1
+    setReportTests((current) => { const { [key]: _stale, ...rest } = current; return rest })
+  }
+
+  // Deleting a row renumbers every row after it, so their probe results and
+  // save failures now name a schedule they were never recorded for. Dropping
+  // them is the only honest option: a green "Posted to eng, ops." rendered
+  // against the wrong card describes a delivery that card never made.
+  const dropScheduleRowState = (from: number) => {
+    for (const key of Object.keys(reportTestGeneration.current)) {
+      if (scheduleKeyIndex(key) >= from) {
+        reportTestGeneration.current[key] = (reportTestGeneration.current[key] ?? 0) + 1
+      }
+    }
+    const keepBefore = (current: Record<string, unknown>) =>
+      Object.fromEntries(Object.entries(current).filter(([key]) => scheduleKeyIndex(key) < from))
+    setReportTests((current) => keepBefore(current) as Record<string, ReportTestState>)
+    setScheduleSaveErrors((current) => keepBefore(current) as Record<string, string>)
   }
 
   async function saveSchedule() {
@@ -5387,15 +5447,19 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     const next = editScheduleIndex !== null
       ? schedules.map((schedule, i) => (i === editScheduleIndex ? entry : schedule))
       : [...schedules, entry]
+    // An add lands at the end of the list, so that is the row its state is
+    // addressed by once the save is through.
+    const index = editScheduleIndex ?? schedules.length
+    const key = scheduleKey(index, id)
     const generation = saveGeneration.current
     const { persisted, message } = await savePatch({ scheduled: next })
     // The schedule now posts something else, somewhere else, so any probe
     // result on its card is about a message that no longer describes it. A
     // rejected save changed nothing and keeps its result.
     if (persisted) {
-      invalidateReportTest(id)
-      clearScheduleSaveError(id)
-      forgetSchedulePause(id)
+      invalidateReportTest(key)
+      clearScheduleSaveError(key)
+      forgetSchedulePause(id, index)
     }
     setDetachedScheduleError("")
     if (generation !== saveGeneration.current) {
@@ -5410,8 +5474,8 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
       // verbatim instead of blaming the save.
       if (persisted) { setDetachedScheduleError(message ?? ""); return }
       if (message) {
-        if (schedules.some((schedule) => schedule.id === id)) {
-          setScheduleSaveErrors((current) => ({ ...current, [id]: message }))
+        if (editScheduleIndex !== null) {
+          setScheduleSaveErrors((current) => ({ ...current, [key]: message }))
         } else {
           setDetachedScheduleError(`Adding report "${id}" failed: ${message}`)
         }
@@ -5422,15 +5486,22 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     setShowSchedule(false)
   }
 
-  function clearScheduleSaveError(id: string) {
-    setScheduleSaveErrors((current) => { const { [id]: _cleared, ...rest } = current; return rest })
+  function clearScheduleSaveError(key: string) {
+    setScheduleSaveErrors((current) => { const { [key]: _cleared, ...rest } = current; return rest })
   }
 
   // Drops ONE schedule from the pause notices: re-enabling, editing or deleting
   // it answers the pause for that report. Every other id stays — a save on an
   // unrelated schedule is not an answer to theirs, and the notice is the only
   // record that this screen turned them off. A notice left with no ids is gone.
-  function forgetSchedulePause(id: string) {
+  //
+  // The notices name reports, not rows, so a stored duplicate id has to keep
+  // its name in the list while the OTHER row is still paused: answering row 1
+  // is not an answer for row 2, and dropping the id would erase the only
+  // record of why row 2 is off. schedulePauseNotices re-derives from the live
+  // config, so a name left behind cannot outlive the pause itself.
+  function forgetSchedulePause(id: string, index: number) {
+    if (schedules.some((schedule, i) => i !== index && schedule.id === id)) return
     setSchedulePauses((current) =>
       current
         .map((pause) => ({ ...pause, ids: pause.ids.filter((other) => other !== id) }))
@@ -5446,9 +5517,8 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     const generation = saveGeneration.current
     const { persisted, message } = await savePatch({ scheduled: schedules.filter((_, i) => i !== index) })
     if (persisted) {
-      invalidateReportTest(id)
-      clearScheduleSaveError(id)
-      forgetSchedulePause(id)
+      dropScheduleRowState(index)
+      forgetSchedulePause(id, index)
     }
     setDetachedScheduleError("")
     if (generation !== saveGeneration.current) {
@@ -5457,7 +5527,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
       // failure after a delete the hub accepted goes to the banner verbatim
       // rather than writing "Last save failed" onto a card that is gone.
       if (persisted) { setDetachedScheduleError(message ?? ""); return }
-      if (message) setScheduleSaveErrors((current) => ({ ...current, [id]: message }))
+      if (message) setScheduleSaveErrors((current) => ({ ...current, [scheduleKey(index, id)]: message }))
       return
     }
     if (message) { setScheduleError(message); return }
@@ -5475,36 +5545,37 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     // opposite of what the hub holds. The reload failure is real, so it goes
     // to the banner, which states it verbatim instead of blaming the save.
     if (persisted) {
-      clearScheduleSaveError(schedule.id)
+      clearScheduleSaveError(scheduleKey(index, schedule.id))
       // The operator has answered the pause note for THIS report by hand;
       // leaving it named there would report a state that no longer exists.
-      forgetSchedulePause(schedule.id)
+      forgetSchedulePause(schedule.id, index)
       setDetachedScheduleError(message ?? "")
       return
     }
     // A rejected toggle snaps the switch back with nothing else on screen —
     // the dialog that carries scheduleError is closed — so the failure has to
     // land on the schedule's own card.
-    if (message) setScheduleSaveErrors((current) => ({ ...current, [schedule.id]: message }))
+    if (message) setScheduleSaveErrors((current) => ({ ...current, [scheduleKey(index, schedule.id)]: message }))
   }
 
   // Probes one schedule. A dry run renders the message the next due slot would
   // post without sending it; a real run posts to every channel the schedule
   // names, which is the only way to prove the whole path works. Neither
   // touches the scheduler's own state, so the real delivery still happens.
-  async function runReportTest(schedule: ScheduledNotificationView, dryRun: boolean) {
+  async function runReportTest(schedule: ScheduledNotificationView, index: number, dryRun: boolean) {
     const targets = schedule.via.map(viaName).filter((via) => notifiers[via])
     if (targets.length === 0) return
-    const generation = reportTestGeneration.current[schedule.id] ?? 0
+    const key = scheduleKey(index, schedule.id)
+    const generation = reportTestGeneration.current[key] ?? 0
     const mode = dryRun ? "preview" : "send"
     const settle = (state: Omit<ReportTestState, "mode">) =>
       setReportTests((current) => {
         // A superseded result is dropped rather than written: whatever sits
-        // under this id now belongs to the probe that replaced this one.
-        if (generation !== (reportTestGeneration.current[schedule.id] ?? 0)) return current
-        return { ...current, [schedule.id]: { ...state, mode } }
+        // under this row now belongs to the probe that replaced this one.
+        if (generation !== (reportTestGeneration.current[key] ?? 0)) return current
+        return { ...current, [key]: { ...state, mode } }
       })
-    setReportTests((current) => ({ ...current, [schedule.id]: { status: "sending", mode, message: "" } }))
+    setReportTests((current) => ({ ...current, [key]: { status: "sending", mode, message: "" } }))
     if (dryRun) {
       try {
         const { empty, payload } = await sendScheduledReportTest(schedule.report, targets[0], true)
@@ -5560,6 +5631,16 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
   // Routing this channel off (or removing it) pauses the hub when it is the
   // last one left; buildPatch clears `enabled` rather than failing the save.
   const otherRoutedCount = routes.filter((route) => route.via !== editName && notifiers[route.via]).length
+  // Deleting a channel rewrites the `via` of every schedule that posts to it
+  // and invalidates their probe results — including one that is still posting,
+  // whose loop would then be left mid-send with nothing recording what it had
+  // already delivered. Held until it settles, exactly as the schedule card's
+  // own Edit and switch are.
+  const probingRemoveTarget = schedules.some(
+    (schedule, index) =>
+      schedule.via.some((entry) => viaName(entry) === editName) &&
+      reportTests[scheduleKey(index, schedule.id)]?.status === "sending",
+  )
 
   // The pause notices, derived from the config as it stands now. A report a
   // notice named that is enabled again — or gone — has answered it, and a
@@ -5790,7 +5871,12 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                         <Send className="size-3.5" />
                         {test?.status === "sending" ? "Sending…" : "Send test"}
                       </Button>
-                      <Button size="sm" variant="ghost" onClick={() => openEdit(name)}>Edit</Button>
+                      {/* Held while a save is in flight for the reason the
+                          schedule cards' Edit is: the dialog seeds from the
+                          pre-save snapshot, so opening it mid-save would hand
+                          the next save a stale copy of the change still
+                          landing — and Remove inside it reaches the schedules. */}
+                      <Button size="sm" variant="ghost" disabled={saving} onClick={() => openEdit(name)}>Edit</Button>
                     </div>
                   </div>
                   {test && test.status !== "sending" && (
@@ -5911,18 +5997,26 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
             {/* Keyed by position, not id: the hub tolerates a stored duplicate
                 id, and two cards sharing a React key collapse into one. */}
             {schedules.map((schedule, index) => {
-              const test = reportTests[schedule.id]
+              const key = scheduleKey(index, schedule.id)
+              const test = reportTests[key]
               // Resolved names, matching the hub: " eng " is delivered to the
               // channel `eng`, so the card must not flag it as missing — and
               // the trimmed name is what a probe has to be sent to.
               const missingVia = schedule.via.map(viaName).filter((via) => !notifiers[via])
               const targets = schedule.via.map(viaName).filter((via) => notifiers[via])
-              const canTest = targets.length > 0 && !saving && test?.status !== "sending"
+              // A probe holds this row the way a save does. "Send now" POSTs to
+              // each channel in turn and settles only once the loop is done, so
+              // a save landing mid-loop would invalidate the probe and drop the
+              // aggregate result — leaving real Slack messages sent with
+              // nothing on screen recording them, and both probe buttons
+              // re-enabled to send them a second time.
+              const probing = test?.status === "sending"
+              const canTest = targets.length > 0 && !saving && !probing
               // Which probe is in flight, so "Working…" replaces the label of
               // the button that was clicked and not the other one's.
-              const running = test?.status === "sending" ? test.mode : null
+              const running = probing ? test.mode : null
               return (
-                <div key={`${index}-${schedule.id}`} className="border border-border rounded-lg p-4">
+                <div key={key} className="border border-border rounded-lg p-4">
                   <div className="flex items-start justify-between gap-3">
                     <div className="min-w-0">
                       <div className="flex items-center gap-2 flex-wrap">
@@ -5961,16 +6055,19 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                     <div className="flex items-center gap-2 shrink-0">
                       <Switch
                         checked={schedule.enabled}
-                        disabled={saving}
+                        disabled={saving || probing}
                         onCheckedChange={(checked) => toggleSchedule(schedule, index, checked)}
-                        aria-label={`Enable the ${schedule.id} report`}
+                        // The id alone is not a name when the hub carries a
+                        // stored duplicate of it: both switches would announce
+                        // themselves identically.
+                        aria-label={`Enable the ${schedule.id} report (${scheduledReportLabel(schedule.report)}, row ${index + 1})`}
                       />
                       {/* Disabled while a save is in flight for the same reason
                           the dialog's own controls are: the editor seeds from
                           the pre-save snapshot, so opening it mid-save would
                           hand the next save a stale copy of the change that is
-                          still landing. */}
-                      <Button size="sm" variant="ghost" disabled={saving} onClick={() => openEditSchedule(schedule, index)}>Edit</Button>
+                          still landing. A probe holds it too — see `probing`. */}
+                      <Button size="sm" variant="ghost" disabled={saving || probing} onClick={() => openEditSchedule(schedule, index)}>Edit</Button>
                     </div>
                   </div>
                   <div className="flex items-center gap-2 mt-3">
@@ -5980,7 +6077,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                       className="gap-1.5"
                       disabled={!canTest}
                       title="Renders the report without posting it"
-                      onClick={() => runReportTest(schedule, true)}
+                      onClick={() => runReportTest(schedule, index, true)}
                     >
                       <Eye className="size-3.5" />
                       {running === "preview" ? "Working…" : "Preview"}
@@ -5991,7 +6088,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                       className="gap-1.5"
                       disabled={!canTest}
                       title={targets.length > 0 ? `Posts the report now to ${targets.join(", ")}` : undefined}
-                      onClick={() => runReportTest(schedule, false)}
+                      onClick={() => runReportTest(schedule, index, false)}
                     >
                       <Send className="size-3.5" />
                       {running === "send" ? "Working…" : "Send now"}
@@ -6024,10 +6121,10 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                       )}
                     </div>
                   )}
-                  {scheduleSaveErrors[schedule.id] && (
+                  {scheduleSaveErrors[key] && (
                     <div className="mt-3 flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
                       <AlertTriangle className="size-3.5 mt-px shrink-0" />
-                      <span className="break-words">Last save failed: {scheduleSaveErrors[schedule.id]}</span>
+                      <span className="break-words">Last save failed: {scheduleSaveErrors[key]}</span>
                     </div>
                   )}
                 </div>
@@ -6276,7 +6373,8 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                   size="sm"
                   variant="ghost"
                   className="text-destructive hover:text-destructive"
-                  disabled={saving}
+                  disabled={saving || probingRemoveTarget}
+                  title={probingRemoveTarget ? "A scheduled report is posting to this channel right now." : undefined}
                   onClick={() => removeChannel(editName)}
                 >
                   <Trash2 className="size-3.5 mr-1" /> Remove
@@ -6471,7 +6569,48 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                     </button>
                   )
                 })}
+                {/* A stored day this hub does not accept gets a chip of its
+                    own, flagged: the hub rejects the schedule the moment any
+                    other field is edited, so unticking it has to be possible
+                    from here — otherwise the only repair is Remove and re-add.
+                    Like the dangling channels, the list is the open-time
+                    snapshot, so unticking one leaves its chip to be re-ticked. */}
+                {formUnknownWeekdays.map((weekday) => {
+                  const selected = formWeekdays.includes(weekday)
+                  return (
+                    <button
+                      key={weekday}
+                      type="button"
+                      aria-pressed={selected}
+                      aria-label={`${weekday} (not a day this hub accepts)`}
+                      disabled={saving}
+                      onClick={() =>
+                        setFormWeekdays(
+                          selected
+                            ? formWeekdays.filter((day) => day !== weekday)
+                            : [...formWeekdays, weekday],
+                        )
+                      }
+                      className={cn(
+                        "px-2.5 py-1 text-xs rounded-md border transition-colors disabled:opacity-50",
+                        selected
+                          ? "border-amber-500/30 bg-amber-500/10 text-amber-400"
+                          : "border-border bg-muted/20 text-muted-foreground hover:bg-muted/50",
+                      )}
+                    >
+                      {weekday}
+                    </button>
+                  )
+                })}
               </div>
+              {unknownWeekdays(formWeekdays).length > 0 && (
+                <p className="text-xs text-amber-400 mt-1">
+                  The hub does not accept{" "}
+                  <span className="font-mono">{unknownWeekdays(formWeekdays).join(", ")}</span>{" "}
+                  as {unknownWeekdays(formWeekdays).length === 1 ? "a day" : "days"} — this report cannot be saved until the flagged{" "}
+                  {unknownWeekdays(formWeekdays).length === 1 ? "chip is" : "chips are"} unticked.
+                </p>
+              )}
               <p className="text-xs text-muted-foreground mt-1">
                 {formWeekdays.length === 0
                   ? "No days selected — runs every day."

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -4631,6 +4631,20 @@ function scheduledReportLabel(report: string): string {
   return SCHEDULED_REPORTS.find((r) => r.id === report)?.label || report
 }
 
+// The hub parses `at` with time.Parse("15:04"), which accepts an unpadded
+// "9:00", so a hand-written hub.yaml can carry one and the scheduler runs it
+// fine. <input type="time"> renders anything that is not HH:MM as blank, and
+// the save check below then rejects a time the operator never touched — so the
+// editor pads on the way in. Anything this cannot read is left alone: the
+// dialog's own error is a better answer than a silently rewritten value.
+function normalizeAt(at: string): string {
+  const match = /^\s*(\d{1,2}):([0-5]\d)\s*$/.exec(at)
+  if (!match) return at
+  const hour = Number(match[1])
+  if (hour > 23) return at
+  return `${String(hour).padStart(2, "0")}:${match[2]}`
+}
+
 // An empty weekday list is the hub's "every day", never "never".
 function weekdaysLabel(weekdays: string[]): string {
   if (weekdays.length === 0) return "Every day"
@@ -5107,14 +5121,39 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
   async function removeChannel(name: string) {
     const nextNotifiers = { ...notifiers }
     delete nextNotifiers[name]
+    // Scheduled reports name channels too, and the hub rejects an ENABLED
+    // schedule pointing at a notifier it does not have — so a delete that only
+    // filtered the lifecycle routes would 400 on the schedule and leave the
+    // channel undeletable from this screen. Dropping the channel from every
+    // schedule's `via` keeps the rest of its destinations running; a schedule
+    // left with nothing else is PAUSED rather than emptied, because the hub
+    // also rejects an empty `via`. Pausing keeps the dangling name visible so
+    // the card's "no longer configured" warning still points at the repair.
+    const pausedIds: string[] = []
+    const nextScheduled = schedules.map((schedule) => {
+      if (!schedule.via.includes(name)) return schedule
+      const via = schedule.via.filter((entry) => entry !== name)
+      if (via.length === 0) {
+        if (schedule.enabled) pausedIds.push(schedule.id)
+        return { ...schedule, enabled: false }
+      }
+      return { ...schedule, via }
+    })
+    setSchedulePauseNotice("")
     const generation = saveGeneration.current
     const { persisted, message: failure } = await savePatch({
       notifiers: nextNotifiers,
       routes: routes.filter((route) => route.via !== name),
+      scheduled: nextScheduled,
     })
     if (persisted) {
       invalidateTest(name)
       setTests((current) => { const { [name]: _removed, ...rest } = current; return rest })
+      if (pausedIds.length > 0) {
+        setSchedulePauseNotice(
+          `Paused ${pausedIds.join(", ")} — "${name}" was the only channel ${pausedIds.length === 1 ? "it posts" : "they post"} to. Open Edit, pick another channel and turn the report back on.`,
+        )
+      }
     }
     setSaveErrors((current) => { const { [name]: _cleared, ...rest } = current; return rest })
     if (generation !== saveGeneration.current) {
@@ -5191,6 +5230,12 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
   // report into — scheduleError renders inside the closed dialog — so its
   // failure lands on the card itself, keyed by schedule id.
   const [scheduleSaveErrors, setScheduleSaveErrors] = useState<Record<string, string>>({})
+  // A rejected ADD created no schedule, so keying its failure by id would render
+  // it nowhere — the same reason detachedSaveError exists for channels.
+  const [detachedScheduleError, setDetachedScheduleError] = useState("")
+  // Removing a channel can pause the schedules that had nowhere else to post.
+  // That pause is ours, not the operator's, so it has to say so somewhere.
+  const [schedulePauseNotice, setSchedulePauseNotice] = useState("")
   const [reportTests, setReportTests] = useState<Record<string, ReportTestState>>({})
   // Invalidates an in-flight probe whose schedule has meanwhile been edited or
   // deleted: its result describes a report that went somewhere else.
@@ -5212,8 +5257,12 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     }
   }
 
+  // Both openers bump saveGeneration for the same reason openAdd/openEdit do:
+  // an in-flight PATCH must not close, or drop its error into, a dialog the
+  // operator has meanwhile reopened on another entry.
   const openAddSchedule = () => {
     loadZones()
+    saveGeneration.current++
     const report = SCHEDULED_REPORTS[0].id
     setScheduleMode("add")
     setEditScheduleId(null)
@@ -5231,12 +5280,13 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
 
   const openEditSchedule = (schedule: ScheduledNotificationView) => {
     loadZones()
+    saveGeneration.current++
     setScheduleMode("edit")
     setEditScheduleId(schedule.id)
     setFormScheduleId(schedule.id)
     setFormReport(schedule.report)
     setFormVia([...schedule.via])
-    setFormAt(schedule.at)
+    setFormAt(normalizeAt(schedule.at))
     setFormTimezone(schedule.timezone || "UTC")
     setFormWeekdays([...schedule.weekdays])
     setFormScheduleEnabled(schedule.enabled)
@@ -5275,6 +5325,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     const next = editScheduleId
       ? schedules.map((schedule) => (schedule.id === editScheduleId ? entry : schedule))
       : [...schedules, entry]
+    const generation = saveGeneration.current
     const { persisted, message } = await savePatch({ scheduled: next })
     // The schedule now posts something else, somewhere else, so any probe
     // result on its card is about a message that no longer describes it. A
@@ -5282,6 +5333,22 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     if (persisted) {
       invalidateReportTest(id)
       clearScheduleSaveError(id)
+      setSchedulePauseNotice("")
+    }
+    setDetachedScheduleError("")
+    if (generation !== saveGeneration.current) {
+      // The dialog this save was started from is gone, so its failure has to
+      // land elsewhere. A rejected EDIT left the schedule in place and its card
+      // carries the reason; a rejected ADD created no schedule, so there is no
+      // card to key it by and it goes to the banner above the list.
+      if (message) {
+        if (schedules.some((schedule) => schedule.id === id)) {
+          setScheduleSaveErrors((current) => ({ ...current, [id]: message }))
+        } else {
+          setDetachedScheduleError(`Adding report "${id}" failed: ${message}`)
+        }
+      }
+      return
     }
     if (message) { setScheduleError(message); return }
     setShowSchedule(false)
@@ -5296,6 +5363,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     if (persisted) {
       invalidateReportTest(id)
       clearScheduleSaveError(id)
+      setSchedulePauseNotice("")
     }
     if (message) { setScheduleError(message); return }
     setShowSchedule(false)
@@ -5309,7 +5377,12 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     // the dialog that carries scheduleError is closed — so the failure has to
     // land on the schedule's own card.
     if (message) setScheduleSaveErrors((current) => ({ ...current, [schedule.id]: message }))
-    else clearScheduleSaveError(schedule.id)
+    else {
+      clearScheduleSaveError(schedule.id)
+      // The operator has answered the pause note by hand; leaving it up would
+      // report a state that no longer exists.
+      setSchedulePauseNotice("")
+    }
   }
 
   // Probes one schedule. A dry run renders the message the next due slot would
@@ -5328,27 +5401,42 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
         return { ...current, [schedule.id]: state }
       })
     setReportTests((current) => ({ ...current, [schedule.id]: { status: "sending", message: "" } }))
-    try {
-      if (dryRun) {
+    if (dryRun) {
+      try {
         const { empty, payload } = await sendScheduledReportTest(schedule.report, targets[0], true)
         settle(empty
           ? { status: "ok", message: "Nothing to report right now — a real run would post nothing." }
           : { status: "ok", message: `This is what would be posted to ${targets[0]}.`, payload })
-        return
+      } catch (e) {
+        settle({ status: "error", message: e instanceof Error ? e.message : "Test send failed" })
       }
-      let empty = false
-      for (const via of targets) {
-        empty = (await sendScheduledReportTest(schedule.report, via, false)).empty
-      }
-      settle({
-        status: "ok",
-        message: empty
-          ? "Nothing to report right now — no message was posted."
-          : `Posted to ${targets.join(", ")}.`,
-      })
-    } catch (e) {
-      settle({ status: "error", message: e instanceof Error ? e.message : "Test send failed" })
+      return
     }
+    // One POST per channel, each of which can fail on its own. Reporting only
+    // the first failure would hide that the channels before it already got the
+    // report — an operator reading "channel_not_found" must not re-run a send
+    // that has already posted somewhere.
+    const posted: string[] = []
+    const nothingToPost: string[] = []
+    const failures: string[] = []
+    for (const via of targets) {
+      try {
+        const { empty } = await sendScheduledReportTest(schedule.report, via, false)
+        if (empty) nothingToPost.push(via)
+        else posted.push(via)
+      } catch (e) {
+        failures.push(`${via} (${e instanceof Error ? e.message : "test send failed"})`)
+      }
+    }
+    if (posted.length === 0 && failures.length === 0) {
+      settle({ status: "ok", message: "Nothing to report right now — no message was posted." })
+      return
+    }
+    const parts: string[] = []
+    if (posted.length > 0) parts.push(`Posted to ${posted.join(", ")}.`)
+    if (nothingToPost.length > 0) parts.push(`Nothing to post to ${nothingToPost.join(", ")}.`)
+    if (failures.length > 0) parts.push(`Failed for ${failures.join(", ")}.`)
+    settle({ status: failures.length > 0 ? "error" : "ok", message: parts.join(" ") })
   }
 
   const routedCount = routes.filter((route) => notifiers[route.via]).length
@@ -5662,6 +5750,19 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
           </Button>
         </div>
 
+        {schedulePauseNotice && (
+          <div className="flex items-start gap-2 rounded-md border border-amber-500/20 bg-amber-500/10 px-3 py-2 text-xs text-amber-400">
+            <AlertTriangle className="size-3.5 mt-px shrink-0" />
+            <span className="break-words">{schedulePauseNotice}</span>
+          </div>
+        )}
+        {detachedScheduleError && (
+          <div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+            <AlertTriangle className="size-3.5 mt-px shrink-0" />
+            <span className="break-words">{detachedScheduleError}</span>
+          </div>
+        )}
+
         {schedules.length === 0 ? (
           <p className="text-sm text-muted-foreground px-4 py-6 text-center border border-border rounded-lg">
             {names.length === 0
@@ -5719,7 +5820,12 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                         onCheckedChange={(checked) => toggleSchedule(schedule, checked)}
                         aria-label={`Enable the ${schedule.id} report`}
                       />
-                      <Button size="sm" variant="ghost" onClick={() => openEditSchedule(schedule)}>Edit</Button>
+                      {/* Disabled while a save is in flight for the same reason
+                          the dialog's own controls are: the editor seeds from
+                          the pre-save snapshot, so opening it mid-save would
+                          hand the next save a stale copy of the change that is
+                          still landing. */}
+                      <Button size="sm" variant="ghost" disabled={saving} onClick={() => openEditSchedule(schedule)}>Edit</Button>
                     </div>
                   </div>
                   <div className="flex items-center gap-2 mt-3">
@@ -6044,8 +6150,9 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
 
           <div className="p-5 space-y-4">
             <div>
-              <label className="text-xs text-muted-foreground mb-1 block">Report</label>
+              <label htmlFor="schedule-report" className="text-xs text-muted-foreground mb-1 block">Report</label>
               <select
+                id="schedule-report"
                 value={formReport}
                 onChange={(e) => setFormReport(e.target.value)}
                 className="w-full h-8 text-sm rounded-md border border-input bg-background px-3"
@@ -6069,8 +6176,9 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
             </div>
 
             <div>
-              <label className="text-xs text-muted-foreground mb-1 block">Name</label>
+              <label htmlFor="schedule-name" className="text-xs text-muted-foreground mb-1 block">Name</label>
               <Input
+                id="schedule-name"
                 placeholder="e.g. pending-prs"
                 value={formScheduleId}
                 onChange={(e) => setFormScheduleId(e.target.value)}
@@ -6083,11 +6191,14 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
             </div>
 
             <div>
-              <label className="text-xs text-muted-foreground mb-1 block">Channels</label>
+              {/* A group heading, not a control label: each checkbox below
+                  carries its own aria-label, so the container is what the
+                  screen reader announces the set by. */}
+              <div className="text-xs text-muted-foreground mb-1">Channels</div>
               {names.length === 0 && formVia.length === 0 ? (
                 <p className="text-xs text-amber-400">No channels are configured yet.</p>
               ) : (
-                <div className="space-y-1">
+                <div className="space-y-1" role="group" aria-label="Channels">
                   {/* Deleted channels the schedule still names get a checkbox
                       of their own, flagged: the hub refuses to save a schedule
                       pointing at one, so unticking it has to be possible from
@@ -6121,17 +6232,23 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                   })}
                 </div>
               )}
+              {/* The hub only checks a schedule's channels while it is
+                  enabled, so the refusal is real for one and a warning about
+                  the future for the other. */}
               {formVia.some((via) => !notifiers[via]) && (
                 <p className="text-xs text-amber-400 mt-1">
-                  The hub refuses to save a report that posts to a channel it does not have. Untick the flagged one, or add the channel back first.
+                  {formScheduleEnabled
+                    ? "The hub refuses to save a report that posts to a channel it does not have. Untick the flagged one, or add the channel back first."
+                    : "A paused report may name a missing channel, but delivery there fails the moment it is enabled again — and the hub will refuse that save. Untick the flagged one, or add the channel back first."}
                 </p>
               )}
             </div>
 
             <div className="grid grid-cols-2 gap-3">
               <div>
-                <label className="text-xs text-muted-foreground mb-1 block">Time</label>
+                <label htmlFor="schedule-at" className="text-xs text-muted-foreground mb-1 block">Time</label>
                 <Input
+                  id="schedule-at"
                   type="time"
                   value={formAt}
                   onChange={(e) => setFormAt(e.target.value)}
@@ -6140,8 +6257,9 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                 />
               </div>
               <div>
-                <label className="text-xs text-muted-foreground mb-1 block">Timezone</label>
+                <label htmlFor="schedule-timezone" className="text-xs text-muted-foreground mb-1 block">Timezone</label>
                 <select
+                  id="schedule-timezone"
                   value={formTimezone}
                   onChange={(e) => setFormTimezone(e.target.value)}
                   className="w-full h-8 text-sm rounded-md border border-input bg-background px-3"
@@ -6161,8 +6279,8 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
             </div>
 
             <div>
-              <label className="text-xs text-muted-foreground mb-1 block">Days</label>
-              <div className="flex flex-wrap gap-1.5">
+              <div className="text-xs text-muted-foreground mb-1">Days</div>
+              <div className="flex flex-wrap gap-1.5" role="group" aria-label="Days">
                 {WEEKDAYS.map((day) => {
                   const selected = formWeekdays.includes(day.id)
                   return (

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -4,7 +4,7 @@ import { useParams, usePathname, useRouter } from "next/navigation"
 import React, { useEffect, useState, useCallback, useRef } from "react"
 import { getHubUrl } from "@/lib/hub-url"
 import { getAuthToken } from "@/lib/auth-storage"
-import { Cpu, Key, Github, ChevronLeft, Shield, Zap, Copy, Check, LayoutTemplate, Trash2, Lock, Sparkles, Send, RotateCcw, Eye, EyeOff, ExternalLink, AlertTriangle, X, CheckCircle2, Webhook, Stethoscope, ArrowRight, Wrench, GitBranch, ChevronDown, Bell } from "lucide-react"
+import { Cpu, Key, Github, ChevronLeft, Shield, Zap, Copy, Check, LayoutTemplate, Trash2, Lock, Sparkles, Send, RotateCcw, Eye, EyeOff, ExternalLink, AlertTriangle, X, CheckCircle2, Webhook, Stethoscope, ArrowRight, Wrench, GitBranch, ChevronDown, Bell, Clock } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Switch } from "@/components/ui/switch"
@@ -198,8 +198,24 @@ interface LifecycleEventToggles {
   stageStalled?: boolean
 }
 
+// One recurring report, as returned by GET /api/settings and read back by
+// PATCH. Every field round-trips under the name the hub decodes it under
+// (types.ScheduledNotificationConfig), and the hub resolves both defaults it
+// carries before sending it here: `enabled` is always a real boolean, and
+// `weekdays` is always an array — empty meaning every day.
+interface ScheduledNotificationView {
+  id: string
+  report: string
+  via: string[]
+  at: string
+  timezone?: string
+  weekdays: string[]
+  enabled: boolean
+}
+
 interface NotificationsView {
   notifiers?: Record<string, NotifierView>
+  scheduled?: ScheduledNotificationView[]
   lifecycle?: {
     enabled: boolean
     // Legacy single-channel field, superseded by routes. The hub clears it as
@@ -4599,6 +4615,109 @@ async function sendTestNotification(eventType: string, via: string): Promise<voi
   throw new Error(message || `Test send failed (${res.status})`)
 }
 
+// The reports this hub can schedule. Kept as a const list rather than read
+// from the config: a schedule naming a report the hub does not carry is
+// rejected on save, so offering only what exists is what keeps the editor from
+// producing one.
+const SCHEDULED_REPORTS: { id: string; label: string; description: string }[] = [
+  {
+    id: "pending_prs",
+    label: "Pull requests waiting for review",
+    description: "Every open pull request an agent has left waiting, grouped by ticket.",
+  },
+]
+
+function scheduledReportLabel(report: string): string {
+  return SCHEDULED_REPORTS.find((r) => r.id === report)?.label || report
+}
+
+// An empty weekday list is the hub's "every day", never "never".
+function weekdaysLabel(weekdays: string[]): string {
+  if (weekdays.length === 0) return "Every day"
+  return WEEKDAYS.filter((day) => weekdays.includes(day.id)).map((day) => day.label).join(", ")
+}
+
+// Wire values are the three-letter names the hub validates against; the labels
+// are what the chips show.
+const WEEKDAYS: { id: string; label: string }[] = [
+  { id: "mon", label: "Mon" },
+  { id: "tue", label: "Tue" },
+  { id: "wed", label: "Wed" },
+  { id: "thu", label: "Thu" },
+  { id: "fri", label: "Fri" },
+  { id: "sat", label: "Sat" },
+  { id: "sun", label: "Sun" },
+]
+
+// Every IANA zone the browser knows. Intl.supportedValuesOf is recent enough
+// that a hub opened in an older browser must still get a usable list, so the
+// fallback carries the viewer's own zone and UTC — the two a schedule is
+// realistically written in.
+function timezoneOptions(): string[] {
+  try {
+    const supported = (Intl as { supportedValuesOf?: (key: string) => string[] }).supportedValuesOf
+    if (supported) return supported.call(Intl, "timeZone")
+  } catch {
+    // Fall through to the minimal list.
+  }
+  return [...new Set([browserTimezone(), "UTC"])]
+}
+
+function browserTimezone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC"
+  } catch {
+    return "UTC"
+  }
+}
+
+// The result of probing one scheduled report. `payload` is set only by a dry
+// run — the rendered message the hub would post, shown instead of sending it.
+type ReportTestState = {
+  status: "sending" | "ok" | "error"
+  message: string
+  payload?: unknown
+}
+
+async function sendScheduledReportTest(
+  report: string,
+  via: string,
+  dryRun: boolean,
+): Promise<{ empty: boolean; payload?: unknown }> {
+  const hubUrl = getHubUrl()
+  const token = getAuthToken() || ""
+  const res = await fetch(`${hubUrl}/api/notifications/test`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+    body: JSON.stringify({ report, via, dry_run: dryRun }),
+  })
+  const raw = await res.text()
+  let parsed: { error?: string; empty?: boolean; payload?: unknown } = {}
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    // Not JSON — the raw body is the only thing to report.
+  }
+  if (!res.ok) throw new Error(parsed.error || raw || `Test send failed (${res.status})`)
+  return { empty: Boolean(parsed.empty), payload: parsed.payload }
+}
+
+// Turns a Slack payload into the lines an operator reads, so a preview shows
+// the message rather than its wire encoding. Anything this cannot walk falls
+// back to the raw JSON, which is still the honest answer.
+function previewLines(payload: unknown): string[] {
+  const attachments = (payload as { attachments?: { blocks?: { text?: { text?: string } }[] }[] })?.attachments
+  const lines: string[] = []
+  for (const attachment of attachments || []) {
+    for (const block of attachment.blocks || []) {
+      const text = block.text?.text
+      if (text) lines.push(text)
+    }
+  }
+  if (lines.length > 0) return lines
+  return [JSON.stringify(payload, null, 2)]
+}
+
 type TestState = { status: "sending" | "ok" | "error"; message: string }
 
 // Records that the Notifier screen itself cleared `enabled` because the route
@@ -4635,6 +4754,7 @@ function writeClampedPause(clamped: boolean): void {
 function NotifierSection({ settings, onSave, saving }: { settings: SettingsData; onSave: (p: object) => Promise<SaveOutcome>; saving: boolean }) {
   const lifecycle = settings.notifications?.lifecycle
   const notifiers = settings.notifications?.notifiers || {}
+  const schedules = settings.notifications?.scheduled || []
   const names = Object.keys(notifiers).sort((a, b) => a.localeCompare(b))
   const eventTypes = settings.lifecycleEventTypes?.length ? settings.lifecycleEventTypes : FALLBACK_LIFECYCLE_EVENT_TYPES
 
@@ -4821,6 +4941,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     enabled?: boolean
     routes?: LifecycleRouteView[]
     events?: Record<LifecycleCategory, boolean>
+    scheduled?: ScheduledNotificationView[]
   }): { patch: object; clamp: boolean } {
     const outNotifiers: Record<string, Record<string, string>> = {}
     for (const [name, notifier] of Object.entries(next.notifiers ?? notifiers)) {
@@ -4866,8 +4987,20 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     if (lifecycle?.pollInterval) outLifecycle.pollInterval = lifecycle.pollInterval
     if (lifecycle?.idleAfter) outLifecycle.idleAfter = lifecycle.idleAfter
     if (lifecycle?.stageProgressAfter) outLifecycle.stageProgressAfter = lifecycle.stageProgressAfter
+    // Always sent, even by a save that only touches a channel: PATCH replaces
+    // the whole notifications block, so omitting it would delete every
+    // scheduled report the first time anyone edits a Slack channel.
+    const outScheduled = (next.scheduled ?? schedules).map((schedule) => ({
+      id: schedule.id,
+      report: schedule.report,
+      via: schedule.via,
+      at: schedule.at,
+      timezone: schedule.timezone || "",
+      weekdays: schedule.weekdays,
+      enabled: schedule.enabled,
+    }))
     return {
-      patch: { notifications: { notifiers: outNotifiers, lifecycle: outLifecycle } },
+      patch: { notifications: { notifiers: outNotifiers, lifecycle: outLifecycle, scheduled: outScheduled } },
       // The never-configured hub is clamped too, and for the same reason: the
       // block this save creates carries `enabled:false` only because it has no
       // route to send to, which is this screen's own doing — the operator was
@@ -5036,6 +5169,164 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     try {
       await sendTestNotification(eventType, name)
       settle({ status: "ok", message: `Sent a "${lifecycleEventLabel(eventType)}" test alert.` })
+    } catch (e) {
+      settle({ status: "error", message: e instanceof Error ? e.message : "Test send failed" })
+    }
+  }
+
+  // ── Scheduled reports ──────────────────────────────────────────────────────
+
+  const [showSchedule, setShowSchedule] = useState(false)
+  const [scheduleMode, setScheduleMode] = useState<"add" | "edit">("add")
+  const [editScheduleId, setEditScheduleId] = useState<string | null>(null)
+  const [formScheduleId, setFormScheduleId] = useState("")
+  const [formReport, setFormReport] = useState(SCHEDULED_REPORTS[0].id)
+  const [formVia, setFormVia] = useState<string[]>([])
+  const [formAt, setFormAt] = useState("09:00")
+  const [formTimezone, setFormTimezone] = useState("UTC")
+  const [formWeekdays, setFormWeekdays] = useState<string[]>([])
+  const [formScheduleEnabled, setFormScheduleEnabled] = useState(true)
+  const [scheduleError, setScheduleError] = useState("")
+  const [reportTests, setReportTests] = useState<Record<string, ReportTestState>>({})
+  // Invalidates an in-flight probe whose schedule has meanwhile been edited or
+  // deleted: its result describes a report that went somewhere else.
+  const reportTestGeneration = useRef<Record<string, number>>({})
+  // Filled when the editor first opens, never during the initial render: the
+  // zone list is derived from the browser, and reading it while Next is
+  // prerendering would make the server and client markup disagree.
+  const [zoneOptions, setZoneOptions] = useState<string[]>([])
+  const loadZones = () => setZoneOptions((current) => (current.length ? current : timezoneOptions()))
+
+  // A name the operator can leave as-is: derived from the report, and suffixed
+  // only when it would collide with a schedule that already exists.
+  function suggestScheduleId(report: string): string {
+    const base = report.replace(/_/g, "-")
+    if (!schedules.some((schedule) => schedule.id === base)) return base
+    for (let i = 2; ; i++) {
+      const candidate = `${base}-${i}`
+      if (!schedules.some((schedule) => schedule.id === candidate)) return candidate
+    }
+  }
+
+  const openAddSchedule = () => {
+    loadZones()
+    const report = SCHEDULED_REPORTS[0].id
+    setScheduleMode("add")
+    setEditScheduleId(null)
+    setFormReport(report)
+    setFormScheduleId(suggestScheduleId(report))
+    // One channel is an unambiguous default; more than one is a choice.
+    setFormVia(names.length === 1 ? [names[0]] : [])
+    setFormAt("09:00")
+    setFormTimezone(browserTimezone())
+    setFormWeekdays([])
+    setFormScheduleEnabled(true)
+    setScheduleError("")
+    setShowSchedule(true)
+  }
+
+  const openEditSchedule = (schedule: ScheduledNotificationView) => {
+    loadZones()
+    setScheduleMode("edit")
+    setEditScheduleId(schedule.id)
+    setFormScheduleId(schedule.id)
+    setFormReport(schedule.report)
+    setFormVia([...schedule.via])
+    setFormAt(schedule.at)
+    setFormTimezone(schedule.timezone || "UTC")
+    setFormWeekdays([...schedule.weekdays])
+    setFormScheduleEnabled(schedule.enabled)
+    setScheduleError("")
+    setShowSchedule(true)
+  }
+
+  const invalidateReportTest = (id: string) => {
+    reportTestGeneration.current[id] = (reportTestGeneration.current[id] ?? 0) + 1
+    setReportTests((current) => { const { [id]: _stale, ...rest } = current; return rest })
+  }
+
+  async function saveSchedule() {
+    const id = formScheduleId.trim()
+    if (!id) { setScheduleError("Name is required."); return }
+    if (scheduleMode === "add" && schedules.some((schedule) => schedule.id === id)) {
+      setScheduleError(`A report named "${id}" already exists.`)
+      return
+    }
+    if (formVia.length === 0) { setScheduleError("Pick at least one channel to post the report to."); return }
+    if (!/^([01]\d|2[0-3]):[0-5]\d$/.test(formAt)) {
+      setScheduleError("Time must be a 24-hour HH:MM value, e.g. 09:30.")
+      return
+    }
+    setScheduleError("")
+
+    const entry: ScheduledNotificationView = {
+      id,
+      report: formReport,
+      via: formVia,
+      at: formAt,
+      timezone: formTimezone,
+      weekdays: formWeekdays,
+      enabled: formScheduleEnabled,
+    }
+    const next = editScheduleId
+      ? schedules.map((schedule) => (schedule.id === editScheduleId ? entry : schedule))
+      : [...schedules, entry]
+    const { persisted, message } = await savePatch({ scheduled: next })
+    // The schedule now posts something else, somewhere else, so any probe
+    // result on its card is about a message that no longer describes it. A
+    // rejected save changed nothing and keeps its result.
+    if (persisted) invalidateReportTest(id)
+    if (message) { setScheduleError(message); return }
+    setShowSchedule(false)
+  }
+
+  async function removeSchedule(id: string) {
+    const { persisted, message } = await savePatch({ scheduled: schedules.filter((schedule) => schedule.id !== id) })
+    if (persisted) invalidateReportTest(id)
+    if (message) { setScheduleError(message); return }
+    setShowSchedule(false)
+  }
+
+  async function toggleSchedule(schedule: ScheduledNotificationView, value: boolean) {
+    await savePatch({
+      scheduled: schedules.map((other) => (other.id === schedule.id ? { ...other, enabled: value } : other)),
+    })
+  }
+
+  // Probes one schedule. A dry run renders the message the next due slot would
+  // post without sending it; a real run posts to every channel the schedule
+  // names, which is the only way to prove the whole path works. Neither
+  // touches the scheduler's own state, so the real delivery still happens.
+  async function runReportTest(schedule: ScheduledNotificationView, dryRun: boolean) {
+    const targets = schedule.via.filter((via) => notifiers[via])
+    if (targets.length === 0) return
+    const generation = reportTestGeneration.current[schedule.id] ?? 0
+    const settle = (state: ReportTestState) =>
+      setReportTests((current) => {
+        // A superseded result is dropped rather than written: whatever sits
+        // under this id now belongs to the probe that replaced this one.
+        if (generation !== (reportTestGeneration.current[schedule.id] ?? 0)) return current
+        return { ...current, [schedule.id]: state }
+      })
+    setReportTests((current) => ({ ...current, [schedule.id]: { status: "sending", message: "" } }))
+    try {
+      if (dryRun) {
+        const { empty, payload } = await sendScheduledReportTest(schedule.report, targets[0], true)
+        settle(empty
+          ? { status: "ok", message: "Nothing to report right now — a real run would post nothing." }
+          : { status: "ok", message: `This is what would be posted to ${targets[0]}.`, payload })
+        return
+      }
+      let empty = false
+      for (const via of targets) {
+        empty = (await sendScheduledReportTest(schedule.report, via, false)).empty
+      }
+      settle({
+        status: "ok",
+        message: empty
+          ? "Nothing to report right now — no message was posted."
+          : `Posted to ${targets.join(", ")}.`,
+      })
     } catch (e) {
       settle({ status: "error", message: e instanceof Error ? e.message : "Test send failed" })
     }
@@ -5329,6 +5620,147 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
         <span className="text-sm">+</span> Add Channel
       </Button>
 
+      {/* Scheduled reports — time-driven digests, independent of the lifecycle
+          alerts above: they are not routed by event type and the master switch
+          does not mute them. */}
+      <div className="space-y-2 border-t border-border pt-6">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h3 className="text-sm font-medium">Scheduled reports</h3>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              Recurring digests posted at a fixed time. They run on their own schedule — the lifecycle switches above do not mute them.
+            </p>
+          </div>
+          <Button
+            size="sm"
+            variant="outline"
+            className="shrink-0"
+            disabled={saving || names.length === 0}
+            title={names.length === 0 ? "Add a channel first — a report needs somewhere to post" : undefined}
+            onClick={openAddSchedule}
+          >
+            <span className="mr-1 text-sm">+</span> Add report
+          </Button>
+        </div>
+
+        {schedules.length === 0 ? (
+          <p className="text-sm text-muted-foreground px-4 py-6 text-center border border-border rounded-lg">
+            {names.length === 0
+              ? "No scheduled reports. Add a channel first, then schedule a report to post into it."
+              : "No scheduled reports. Add one to get a recurring digest in Slack."}
+          </p>
+        ) : (
+          <div className="space-y-2">
+            {schedules.map((schedule) => {
+              const test = reportTests[schedule.id]
+              const missingVia = schedule.via.filter((via) => !notifiers[via])
+              const targets = schedule.via.filter((via) => notifiers[via])
+              const canTest = targets.length > 0 && !saving && test?.status !== "sending"
+              return (
+                <div key={schedule.id} className="border border-border rounded-lg p-4">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span className="text-sm font-medium">{scheduledReportLabel(schedule.report)}</span>
+                        <code className="text-xs text-muted-foreground font-mono">{schedule.id}</code>
+                        {!schedule.enabled && (
+                          <span className="text-xs bg-amber-500/10 text-amber-400 border border-amber-500/20 px-2 py-0.5 rounded font-medium">
+                            Paused
+                          </span>
+                        )}
+                      </div>
+                      <p className="text-xs text-muted-foreground mt-1 flex items-center gap-1.5">
+                        <Clock className="size-3 shrink-0" />
+                        <span className="font-mono">{schedule.at}</span>
+                        <span>{schedule.timezone || "UTC"}</span>
+                        <span>·</span>
+                        <span>{weekdaysLabel(schedule.weekdays)}</span>
+                      </p>
+                      <p className="text-xs text-muted-foreground mt-1">
+                        Posts to{" "}
+                        {schedule.via.map((via, i) => (
+                          <React.Fragment key={via}>
+                            {i > 0 && ", "}
+                            <span className={cn("font-mono", !notifiers[via] && "text-amber-400")}>{via}</span>
+                          </React.Fragment>
+                        ))}
+                      </p>
+                      {missingVia.length > 0 && (
+                        <p className="text-xs text-amber-400 mt-2">
+                          {missingVia.length === 1 ? "Channel" : "Channels"}{" "}
+                          <span className="font-mono">{missingVia.join(", ")}</span>{" "}
+                          {missingVia.length === 1 ? "is" : "are"} no longer configured, so nothing is delivered there — open Edit and pick another.
+                        </p>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-2 shrink-0">
+                      <Switch
+                        checked={schedule.enabled}
+                        disabled={saving}
+                        onCheckedChange={(checked) => toggleSchedule(schedule, checked)}
+                        aria-label={`Enable the ${schedule.id} report`}
+                      />
+                      <Button size="sm" variant="ghost" onClick={() => openEditSchedule(schedule)}>Edit</Button>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2 mt-3">
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="gap-1.5"
+                      disabled={!canTest}
+                      title="Renders the report without posting it"
+                      onClick={() => runReportTest(schedule, true)}
+                    >
+                      <Eye className="size-3.5" />
+                      Preview
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="gap-1.5"
+                      disabled={!canTest}
+                      title={targets.length > 0 ? `Posts the report now to ${targets.join(", ")}` : undefined}
+                      onClick={() => runReportTest(schedule, false)}
+                    >
+                      <Send className="size-3.5" />
+                      {test?.status === "sending" ? "Working…" : "Send now"}
+                    </Button>
+                    {targets.length === 0 && (
+                      <span className="text-xs text-muted-foreground">
+                        No configured channel to post to.
+                      </span>
+                    )}
+                  </div>
+                  {test && test.status !== "sending" && (
+                    <div
+                      className={cn(
+                        "mt-3 rounded-md border px-3 py-2 text-xs",
+                        test.status === "ok"
+                          ? "border-green-500/20 bg-green-500/10 text-green-400"
+                          : "border-destructive/30 bg-destructive/10 text-destructive",
+                      )}
+                    >
+                      <div className="flex items-start gap-2">
+                        {test.status === "ok"
+                          ? <CheckCircle2 className="size-3.5 mt-px shrink-0" />
+                          : <AlertTriangle className="size-3.5 mt-px shrink-0" />}
+                        <span className="break-words">{test.message}</span>
+                      </div>
+                      {test.payload !== undefined && (
+                        <pre className="mt-2 max-h-64 overflow-auto rounded bg-background/60 p-2 text-xs text-foreground whitespace-pre-wrap break-words">
+                          {previewLines(test.payload).join("\n\n")}
+                        </pre>
+                      )}
+                    </div>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </div>
+
       {/* Add / edit modal */}
       {/* Closing only closes: DialogContent stays mounted for its 200ms exit
           animation, so clearing the form here would let the operator watch the
@@ -5567,6 +5999,223 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                 <Button size="sm" variant="outline" disabled={saving} onClick={() => setShowModal(false)}>Cancel</Button>
                 <Button size="sm" disabled={saving || !formName.trim() || !formChannel.trim() || !formTokenSecret} onClick={saveChannel}>
                   {modalMode === "add" ? "Add Channel" : "Save changes"}
+                </Button>
+              </div>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* Add / edit scheduled report. Like the channel dialog, closing only
+          closes: openAddSchedule/openEditSchedule re-seed every field. */}
+      <Dialog open={showSchedule} onOpenChange={setShowSchedule}>
+        <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto p-0 gap-0">
+          <DialogTitle className="sr-only">
+            {scheduleMode === "add" ? "Add scheduled report" : `Edit ${editScheduleId}`}
+          </DialogTitle>
+          <div className="flex items-center justify-between px-5 py-4 border-b border-border">
+            <h3 className="font-medium">{scheduleMode === "add" ? "Add scheduled report" : `Edit ${editScheduleId}`}</h3>
+          </div>
+
+          <div className="p-5 space-y-4">
+            <div>
+              <label className="text-xs text-muted-foreground mb-1 block">Report</label>
+              <select
+                value={formReport}
+                onChange={(e) => setFormReport(e.target.value)}
+                className="w-full h-8 text-sm rounded-md border border-input bg-background px-3"
+                disabled={saving}
+              >
+                {/* A report this build does not know can only come from a
+                    hand-written hub.yaml. It gets an option of its own, flagged,
+                    so the controlled select cannot render blank while Save
+                    writes the unknown name straight back. */}
+                {!SCHEDULED_REPORTS.some((report) => report.id === formReport) && (
+                  <option value={formReport}>{formReport} (not supported by this hub)</option>
+                )}
+                {SCHEDULED_REPORTS.map((report) => (
+                  <option key={report.id} value={report.id}>{report.label}</option>
+                ))}
+              </select>
+              <p className="text-xs text-muted-foreground mt-1">
+                {SCHEDULED_REPORTS.find((report) => report.id === formReport)?.description
+                  || "This hub does not carry this report, so the schedule delivers nothing."}
+              </p>
+            </div>
+
+            <div>
+              <label className="text-xs text-muted-foreground mb-1 block">Name</label>
+              <Input
+                placeholder="e.g. pending-prs"
+                value={formScheduleId}
+                onChange={(e) => setFormScheduleId(e.target.value)}
+                className="font-mono text-sm h-8"
+                disabled={saving || scheduleMode === "edit"}
+              />
+              <p className="text-xs text-muted-foreground mt-1">
+                How this schedule is identified in <span className="font-mono">hub.yaml</span> and in the hub log. It cannot be changed later.
+              </p>
+            </div>
+
+            <div>
+              <label className="text-xs text-muted-foreground mb-1 block">Channels</label>
+              {names.length === 0 && formVia.length === 0 ? (
+                <p className="text-xs text-amber-400">No channels are configured yet.</p>
+              ) : (
+                <div className="space-y-1">
+                  {/* Deleted channels the schedule still names get a checkbox
+                      of their own, flagged: the hub refuses to save a schedule
+                      pointing at one, so unticking it has to be possible from
+                      here — otherwise the only repair is a hub.yaml edit. */}
+                  {[...names, ...formVia.filter((via) => !notifiers[via])].map((name) => {
+                    const missing = !notifiers[name]
+                    return (
+                      <label
+                        key={name}
+                        className="flex items-center gap-2 text-sm cursor-pointer rounded px-2 py-1 hover:bg-muted/50"
+                      >
+                        <input
+                          type="checkbox"
+                          aria-label={`Post the report to ${name}`}
+                          checked={formVia.includes(name)}
+                          disabled={saving}
+                          onChange={(e) =>
+                            setFormVia(
+                              e.target.checked
+                                ? [...formVia, name]
+                                : formVia.filter((via) => via !== name),
+                            )
+                          }
+                        />
+                        <code className={cn("font-mono", missing && "text-amber-400")}>{name}</code>
+                        <span className={cn("text-xs", missing ? "text-amber-400" : "text-muted-foreground")}>
+                          {missing ? "channel no longer configured" : notifiers[name]?.channel}
+                        </span>
+                      </label>
+                    )
+                  })}
+                </div>
+              )}
+              {formVia.some((via) => !notifiers[via]) && (
+                <p className="text-xs text-amber-400 mt-1">
+                  The hub refuses to save a report that posts to a channel it does not have. Untick the flagged one, or add the channel back first.
+                </p>
+              )}
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="text-xs text-muted-foreground mb-1 block">Time</label>
+                <Input
+                  type="time"
+                  value={formAt}
+                  onChange={(e) => setFormAt(e.target.value)}
+                  className="font-mono text-sm h-8"
+                  disabled={saving}
+                />
+              </div>
+              <div>
+                <label className="text-xs text-muted-foreground mb-1 block">Timezone</label>
+                <select
+                  value={formTimezone}
+                  onChange={(e) => setFormTimezone(e.target.value)}
+                  className="w-full h-8 text-sm rounded-md border border-input bg-background px-3"
+                  disabled={saving}
+                >
+                  {/* A zone this browser does not list — an older browser, or a
+                      name written by hand — still needs an option, or the
+                      select renders blank and Save rewrites it. */}
+                  {formTimezone && !zoneOptions.includes(formTimezone) && (
+                    <option value={formTimezone}>{formTimezone}</option>
+                  )}
+                  {zoneOptions.map((zone) => (
+                    <option key={zone} value={zone}>{zone}</option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
+            <div>
+              <label className="text-xs text-muted-foreground mb-1 block">Days</label>
+              <div className="flex flex-wrap gap-1.5">
+                {WEEKDAYS.map((day) => {
+                  const selected = formWeekdays.includes(day.id)
+                  return (
+                    <button
+                      key={day.id}
+                      type="button"
+                      aria-pressed={selected}
+                      disabled={saving}
+                      onClick={() =>
+                        setFormWeekdays(
+                          selected
+                            ? formWeekdays.filter((weekday) => weekday !== day.id)
+                            : [...formWeekdays, day.id],
+                        )
+                      }
+                      className={cn(
+                        "px-2.5 py-1 text-xs rounded-md border transition-colors disabled:opacity-50",
+                        selected
+                          ? "border-blue-500/30 bg-blue-500/10 text-blue-400"
+                          : "border-border bg-muted/20 text-muted-foreground hover:bg-muted/50",
+                      )}
+                    >
+                      {day.label}
+                    </button>
+                  )
+                })}
+              </div>
+              <p className="text-xs text-muted-foreground mt-1">
+                {formWeekdays.length === 0
+                  ? "No days selected — runs every day."
+                  : `Runs on ${weekdaysLabel(formWeekdays)}.`}
+              </p>
+            </div>
+
+            <div className="flex items-start justify-between gap-3 border-t border-border pt-4">
+              <div>
+                <div className="text-sm font-medium">Enabled</div>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  Turn it off to keep the schedule without posting anything.
+                </p>
+              </div>
+              <Switch
+                className="mt-1"
+                checked={formScheduleEnabled}
+                onCheckedChange={setFormScheduleEnabled}
+                disabled={saving}
+                aria-label="Enable this scheduled report"
+              />
+            </div>
+          </div>
+
+          <div className="border-t border-border">
+            {scheduleError && (
+              <div className="mx-5 mt-4 flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+                <AlertTriangle className="size-3.5 mt-px shrink-0" />
+                <span className="break-words">{scheduleError}</span>
+              </div>
+            )}
+            <div className="flex items-center justify-between px-5 py-4">
+              {scheduleMode === "edit" && editScheduleId && (
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="text-destructive hover:text-destructive"
+                  disabled={saving}
+                  onClick={() => removeSchedule(editScheduleId)}
+                >
+                  <Trash2 className="size-3.5 mr-1" /> Remove
+                </Button>
+              )}
+              <div className="flex items-center gap-2 ml-auto">
+                <Button size="sm" variant="outline" disabled={saving} onClick={() => setShowSchedule(false)}>Cancel</Button>
+                <Button
+                  size="sm"
+                  disabled={saving || !formScheduleId.trim() || formVia.length === 0 || !formAt}
+                  onClick={saveSchedule}
+                >
+                  {scheduleMode === "add" ? "Add report" : "Save changes"}
                 </Button>
               </div>
             </div>

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -4645,6 +4645,16 @@ function normalizeAt(at: string): string {
   return `${String(hour).padStart(2, "0")}:${match[2]}`
 }
 
+// The name a schedule's `via` entry actually resolves to. Both the scheduler
+// (scheduled_notifier.go) and validation (types/validation.go) TrimSpace it
+// before looking the notifier up, so a hand-written via of " eng " names the
+// channel `eng`. Matching it untrimmed here would leave the entry dangling
+// when `eng` is deleted, and the save the screen then sends is rejected for
+// the very reference it believed it had dropped.
+function viaName(via: string): string {
+  return via.trim()
+}
+
 // An empty weekday list is the hub's "every day", never "never".
 function weekdaysLabel(weekdays: string[]): string {
   if (weekdays.length === 0) return "Every day"
@@ -5099,13 +5109,10 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     if (persisted) {
       invalidateTest(name)
       setTests((current) => { const { [name]: _stale, ...rest } = current; return rest })
-      // Re-adding the channel a schedule was paused for answers the pause note:
-      // the paused schedule still names it — removeChannel keeps the dangling
-      // name so the repair stays visible — so the via resolves again and the
-      // note's "pick another channel" no longer describes anything.
-      if (schedules.some((schedule) => !schedule.enabled && schedule.via.includes(name))) {
-        setSchedulePauseNotice("")
-      }
+      // The pause notice is deliberately NOT cleared by re-adding the channel:
+      // the schedule it names is still disabled, and only the operator turning
+      // it back on makes it fire again. The notice rewords itself once the via
+      // resolves — see schedulePauseText.
     }
     setSaveErrors((current) => { const { [name]: _cleared, ...rest } = current; return rest })
     setDetachedSaveError("")
@@ -5138,17 +5145,21 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     // the card's "no longer configured" warning still points at the repair.
     const pausedIds: string[] = []
     const touchedIds: string[] = []
+    // Entries are matched on their resolved name: the hub trims before looking
+    // the notifier up, so a hand-written " eng " points at the channel being
+    // deleted just as `eng` does — and leaving it behind makes the delete
+    // unsaveable.
     const nextScheduled = schedules.map((schedule) => {
-      if (!schedule.via.includes(name)) return schedule
+      if (!schedule.via.some((entry) => viaName(entry) === name)) return schedule
       touchedIds.push(schedule.id)
-      const via = schedule.via.filter((entry) => entry !== name)
+      const via = schedule.via.filter((entry) => viaName(entry) !== name)
       if (via.length === 0) {
         if (schedule.enabled) pausedIds.push(schedule.id)
         return { ...schedule, enabled: false }
       }
       return { ...schedule, via }
     })
-    setSchedulePauseNotice("")
+    setSchedulePause(null)
     const generation = saveGeneration.current
     const { persisted, message: failure } = await savePatch({
       notifiers: nextNotifiers,
@@ -5164,11 +5175,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
       // "Posts to eng". saveSchedule/removeSchedule invalidate for the same
       // reason; this is the third way a schedule's destinations change.
       touchedIds.forEach(invalidateReportTest)
-      if (pausedIds.length > 0) {
-        setSchedulePauseNotice(
-          `Paused ${pausedIds.join(", ")} — "${name}" was the only channel ${pausedIds.length === 1 ? "it posts" : "they post"} to. Open Edit, pick another channel and turn the report back on.`,
-        )
-      }
+      if (pausedIds.length > 0) setSchedulePause({ ids: pausedIds, channel: name })
     }
     setSaveErrors((current) => { const { [name]: _cleared, ...rest } = current; return rest })
     if (generation !== saveGeneration.current) {
@@ -5255,7 +5262,12 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
   const [detachedScheduleError, setDetachedScheduleError] = useState("")
   // Removing a channel can pause the schedules that had nowhere else to post.
   // That pause is ours, not the operator's, so it has to say so somewhere.
-  const [schedulePauseNotice, setSchedulePauseNotice] = useState("")
+  // The schedules it covers are recorded with it, and the wording is derived
+  // from the live config rather than frozen at removal time: an unrelated save
+  // must not erase a notice about reports that are still paused, and re-adding
+  // a channel by the same name answers only half the instruction — the report
+  // still has to be turned back on by hand.
+  const [schedulePause, setSchedulePause] = useState<{ ids: string[]; channel: string } | null>(null)
   const [reportTests, setReportTests] = useState<Record<string, ReportTestState>>({})
   // Invalidates an in-flight probe whose schedule has meanwhile been edited or
   // deleted: its result describes a report that went somewhere else.
@@ -5306,8 +5318,11 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     setEditScheduleId(schedule.id)
     setFormScheduleId(schedule.id)
     setFormReport(schedule.report)
-    setFormVia([...schedule.via])
-    setFormDanglingVia(schedule.via.filter((via) => !notifiers[via]))
+    // Seeded on the resolved names, the same ones the checkboxes are keyed by:
+    // a hand-written " eng " has to tick `eng`, not sit beside it as a second,
+    // flagged row for a channel that is configured.
+    setFormVia(schedule.via.map(viaName))
+    setFormDanglingVia(schedule.via.map(viaName).filter((via) => !notifiers[via]))
     setFormAt(normalizeAt(schedule.at))
     setFormTimezone(schedule.timezone || "UTC")
     setFormWeekdays([...schedule.weekdays])
@@ -5355,7 +5370,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     if (persisted) {
       invalidateReportTest(id)
       clearScheduleSaveError(id)
-      setSchedulePauseNotice("")
+      forgetSchedulePause(id)
     }
     setDetachedScheduleError("")
     if (generation !== saveGeneration.current) {
@@ -5380,12 +5395,36 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     setScheduleSaveErrors((current) => { const { [id]: _cleared, ...rest } = current; return rest })
   }
 
+  // Drops ONE schedule from the pause notice: re-enabling, editing or deleting
+  // it answers the pause for that report. Every other id stays — a save on an
+  // unrelated schedule is not an answer to theirs, and the notice is the only
+  // record that this screen turned them off.
+  function forgetSchedulePause(id: string) {
+    setSchedulePause((current) => {
+      if (!current) return null
+      const ids = current.ids.filter((other) => other !== id)
+      return ids.length > 0 ? { ...current, ids } : null
+    })
+  }
+
   async function removeSchedule(id: string) {
+    // Snapshotted for the same reason saveSchedule and removeChannel do it: a
+    // rejected delete whose dialog has meanwhile been replaced has to report
+    // onto the surviving schedule's card, since scheduleError renders only
+    // inside the dialog that is no longer there.
+    const generation = saveGeneration.current
     const { persisted, message } = await savePatch({ scheduled: schedules.filter((schedule) => schedule.id !== id) })
     if (persisted) {
       invalidateReportTest(id)
       clearScheduleSaveError(id)
-      setSchedulePauseNotice("")
+      forgetSchedulePause(id)
+    }
+    setDetachedScheduleError("")
+    if (generation !== saveGeneration.current) {
+      // A rejected delete left the schedule in place, so its card carries the
+      // reason; a successful one has no card and needs none.
+      if (message) setScheduleSaveErrors((current) => ({ ...current, [id]: message }))
+      return
     }
     if (message) { setScheduleError(message); return }
     setShowSchedule(false)
@@ -5403,9 +5442,9 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     // to the banner, which states it verbatim instead of blaming the save.
     if (persisted) {
       clearScheduleSaveError(schedule.id)
-      // The operator has answered the pause note by hand; leaving it up would
-      // report a state that no longer exists.
-      setSchedulePauseNotice("")
+      // The operator has answered the pause note for THIS report by hand;
+      // leaving it named there would report a state that no longer exists.
+      forgetSchedulePause(schedule.id)
       setDetachedScheduleError(message ?? "")
       return
     }
@@ -5420,7 +5459,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
   // names, which is the only way to prove the whole path works. Neither
   // touches the scheduler's own state, so the real delivery still happens.
   async function runReportTest(schedule: ScheduledNotificationView, dryRun: boolean) {
-    const targets = schedule.via.filter((via) => notifiers[via])
+    const targets = schedule.via.map(viaName).filter((via) => notifiers[via])
     if (targets.length === 0) return
     const generation = reportTestGeneration.current[schedule.id] ?? 0
     const settle = (state: ReportTestState) =>
@@ -5486,6 +5525,21 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
   // Routing this channel off (or removing it) pauses the hub when it is the
   // last one left; buildPatch clears `enabled` rather than failing the save.
   const otherRoutedCount = routes.filter((route) => route.via !== editName && notifiers[route.via]).length
+
+  // The pause notice, derived from the config as it stands now. A report the
+  // notice named that is enabled again — or gone — has answered it, and a
+  // channel re-added under the same name resolves the via without un-pausing
+  // anything, so only the second half of the instruction still holds.
+  const pausedByRemoval = schedulePause
+    ? schedules.filter((schedule) => !schedule.enabled && schedulePause.ids.includes(schedule.id))
+    : []
+  const schedulePauseText = schedulePause && pausedByRemoval.length > 0
+    ? `Paused ${pausedByRemoval.map((schedule) => schedule.id).join(", ")} — "${schedulePause.channel}" was the only channel ${pausedByRemoval.length === 1 ? "it posts" : "they post"} to. ${
+      notifiers[schedulePause.channel]
+        ? "A channel by that name exists again: open Edit and turn the report back on."
+        : "Open Edit, pick another channel and turn the report back on."
+    }`
+    : ""
 
   return (
     <div className="space-y-6">
@@ -5768,22 +5822,32 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
               Recurring digests posted at a fixed time. They run on their own schedule — the lifecycle switches above do not mute them.
             </p>
           </div>
-          <Button
-            size="sm"
-            variant="outline"
-            className="shrink-0"
-            disabled={saving || names.length === 0}
-            title={names.length === 0 ? "Add a channel first — a report needs somewhere to post" : undefined}
-            onClick={openAddSchedule}
-          >
-            <span className="mr-1 text-sm">+</span> Add report
-          </Button>
+          <div className="flex flex-col items-end gap-1 shrink-0">
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={saving || names.length === 0}
+              onClick={openAddSchedule}
+            >
+              <span className="mr-1 text-sm">+</span> Add report
+            </Button>
+            {/* Rendered as text, not as the disabled button's `title`: the
+                Button base class sets `disabled:pointer-events-none`, so a
+                native tooltip on it can never fire — and once a report exists
+                the list replaces the empty state that carries the same hint,
+                leaving a greyed-out button with nothing explaining it. */}
+            {names.length === 0 && (
+              <p className="text-xs text-muted-foreground text-right">
+                Add a channel first — a report needs somewhere to post.
+              </p>
+            )}
+          </div>
         </div>
 
-        {schedulePauseNotice && (
+        {schedulePauseText && (
           <div className="flex items-start gap-2 rounded-md border border-amber-500/20 bg-amber-500/10 px-3 py-2 text-xs text-amber-400">
             <AlertTriangle className="size-3.5 mt-px shrink-0" />
-            <span className="break-words">{schedulePauseNotice}</span>
+            <span className="break-words">{schedulePauseText}</span>
           </div>
         )}
         {detachedScheduleError && (
@@ -5803,8 +5867,11 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
           <div className="space-y-2">
             {schedules.map((schedule) => {
               const test = reportTests[schedule.id]
-              const missingVia = schedule.via.filter((via) => !notifiers[via])
-              const targets = schedule.via.filter((via) => notifiers[via])
+              // Resolved names, matching the hub: " eng " is delivered to the
+              // channel `eng`, so the card must not flag it as missing — and
+              // the trimmed name is what a probe has to be sent to.
+              const missingVia = schedule.via.map(viaName).filter((via) => !notifiers[via])
+              const targets = schedule.via.map(viaName).filter((via) => notifiers[via])
               const canTest = targets.length > 0 && !saving && test?.status !== "sending"
               return (
                 <div key={schedule.id} className="border border-border rounded-lg p-4">
@@ -5828,7 +5895,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                       </p>
                       <p className="text-xs text-muted-foreground mt-1">
                         Posts to{" "}
-                        {schedule.via.map((via, i) => (
+                        {schedule.via.map(viaName).map((via, i) => (
                           <React.Fragment key={via}>
                             {i > 0 && ", "}
                             <span className={cn("font-mono", !notifiers[via] && "text-amber-400")}>{via}</span>
@@ -6138,6 +6205,17 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                 <span className="break-words">{detachedSaveError}</span>
               </div>
             )}
+            {/* A failed report ADD can be detached by opening THIS dialog —
+                the Edit buttons are not gated while a save is in flight — so
+                its banner ends up behind this overlay with nothing else naming
+                it. Its message names the report, so it cannot be read as a
+                rejection of the channel form on screen. */}
+            {detachedScheduleError && (
+              <div className="mx-5 mt-4 flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+                <AlertTriangle className="size-3.5 mt-px shrink-0" />
+                <span className="break-words">{detachedScheduleError}</span>
+              </div>
+            )}
             {formError && (
               <div className="mx-5 mt-4 flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
                 <AlertTriangle className="size-3.5 mt-px shrink-0" />
@@ -6371,6 +6449,16 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
           </div>
 
           <div className="border-t border-border">
+            {/* The failure from the save THIS dialog replaced. The list behind
+                the overlay carries it too, but the operator is looking here —
+                and a detached add is otherwise indistinguishable from one that
+                went through. */}
+            {detachedScheduleError && (
+              <div className="mx-5 mt-4 flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+                <AlertTriangle className="size-3.5 mt-px shrink-0" />
+                <span className="break-words">{detachedScheduleError}</span>
+              </div>
+            )}
             {scheduleError && (
               <div className="mx-5 mt-4 flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
                 <AlertTriangle className="size-3.5 mt-px shrink-0" />

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -5187,6 +5187,10 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
   const [formWeekdays, setFormWeekdays] = useState<string[]>([])
   const [formScheduleEnabled, setFormScheduleEnabled] = useState(true)
   const [scheduleError, setScheduleError] = useState("")
+  // A save made from a schedule's CARD (the enable switch) has no dialog to
+  // report into — scheduleError renders inside the closed dialog — so its
+  // failure lands on the card itself, keyed by schedule id.
+  const [scheduleSaveErrors, setScheduleSaveErrors] = useState<Record<string, string>>({})
   const [reportTests, setReportTests] = useState<Record<string, ReportTestState>>({})
   // Invalidates an in-flight probe whose schedule has meanwhile been edited or
   // deleted: its result describes a report that went somewhere else.
@@ -5275,22 +5279,37 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     // The schedule now posts something else, somewhere else, so any probe
     // result on its card is about a message that no longer describes it. A
     // rejected save changed nothing and keeps its result.
-    if (persisted) invalidateReportTest(id)
+    if (persisted) {
+      invalidateReportTest(id)
+      clearScheduleSaveError(id)
+    }
     if (message) { setScheduleError(message); return }
     setShowSchedule(false)
   }
 
+  function clearScheduleSaveError(id: string) {
+    setScheduleSaveErrors((current) => { const { [id]: _cleared, ...rest } = current; return rest })
+  }
+
   async function removeSchedule(id: string) {
     const { persisted, message } = await savePatch({ scheduled: schedules.filter((schedule) => schedule.id !== id) })
-    if (persisted) invalidateReportTest(id)
+    if (persisted) {
+      invalidateReportTest(id)
+      clearScheduleSaveError(id)
+    }
     if (message) { setScheduleError(message); return }
     setShowSchedule(false)
   }
 
   async function toggleSchedule(schedule: ScheduledNotificationView, value: boolean) {
-    await savePatch({
+    const { message } = await savePatch({
       scheduled: schedules.map((other) => (other.id === schedule.id ? { ...other, enabled: value } : other)),
     })
+    // A rejected toggle snaps the switch back with nothing else on screen —
+    // the dialog that carries scheduleError is closed — so the failure has to
+    // land on the schedule's own card.
+    if (message) setScheduleSaveErrors((current) => ({ ...current, [schedule.id]: message }))
+    else clearScheduleSaveError(schedule.id)
   }
 
   // Probes one schedule. A dry run renders the message the next due slot would
@@ -5752,6 +5771,12 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                           {previewLines(test.payload).join("\n\n")}
                         </pre>
                       )}
+                    </div>
+                  )}
+                  {scheduleSaveErrors[schedule.id] && (
+                    <div className="mt-3 flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+                      <AlertTriangle className="size-3.5 mt-px shrink-0" />
+                      <span className="break-words">Last save failed: {scheduleSaveErrors[schedule.id]}</span>
                     </div>
                   )}
                 </div>

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -5099,6 +5099,13 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     if (persisted) {
       invalidateTest(name)
       setTests((current) => { const { [name]: _stale, ...rest } = current; return rest })
+      // Re-adding the channel a schedule was paused for answers the pause note:
+      // the paused schedule still names it — removeChannel keeps the dangling
+      // name so the repair stays visible — so the via resolves again and the
+      // note's "pick another channel" no longer describes anything.
+      if (schedules.some((schedule) => !schedule.enabled && schedule.via.includes(name))) {
+        setSchedulePauseNotice("")
+      }
     }
     setSaveErrors((current) => { const { [name]: _cleared, ...rest } = current; return rest })
     setDetachedSaveError("")
@@ -5130,8 +5137,10 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     // also rejects an empty `via`. Pausing keeps the dangling name visible so
     // the card's "no longer configured" warning still points at the repair.
     const pausedIds: string[] = []
+    const touchedIds: string[] = []
     const nextScheduled = schedules.map((schedule) => {
       if (!schedule.via.includes(name)) return schedule
+      touchedIds.push(schedule.id)
       const via = schedule.via.filter((entry) => entry !== name)
       if (via.length === 0) {
         if (schedule.enabled) pausedIds.push(schedule.id)
@@ -5149,6 +5158,12 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     if (persisted) {
       invalidateTest(name)
       setTests((current) => { const { [name]: _removed, ...rest } = current; return rest })
+      // Every schedule that posted here now posts somewhere else — or nowhere,
+      // paused — so a probe result on its card describes a delivery that can no
+      // longer happen: a green "Posted to eng, ops." above a card that reads
+      // "Posts to eng". saveSchedule/removeSchedule invalidate for the same
+      // reason; this is the third way a schedule's destinations change.
+      touchedIds.forEach(invalidateReportTest)
       if (pausedIds.length > 0) {
         setSchedulePauseNotice(
           `Paused ${pausedIds.join(", ")} — "${name}" was the only channel ${pausedIds.length === 1 ? "it posts" : "they post"} to. Open Edit, pick another channel and turn the report back on.`,
@@ -5221,6 +5236,11 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
   const [formScheduleId, setFormScheduleId] = useState("")
   const [formReport, setFormReport] = useState(SCHEDULED_REPORTS[0].id)
   const [formVia, setFormVia] = useState<string[]>([])
+  // The channels the schedule named that no longer exist, snapshotted when the
+  // dialog opens. Deriving the rows from formVia instead would delete the
+  // flagged checkbox the moment it is unticked, and the only way back would be
+  // Cancel — discarding every other edit made in the same session.
+  const [formDanglingVia, setFormDanglingVia] = useState<string[]>([])
   const [formAt, setFormAt] = useState("09:00")
   const [formTimezone, setFormTimezone] = useState("UTC")
   const [formWeekdays, setFormWeekdays] = useState<string[]>([])
@@ -5270,6 +5290,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     setFormScheduleId(suggestScheduleId(report))
     // One channel is an unambiguous default; more than one is a choice.
     setFormVia(names.length === 1 ? [names[0]] : [])
+    setFormDanglingVia([])
     setFormAt("09:00")
     setFormTimezone(browserTimezone())
     setFormWeekdays([])
@@ -5286,6 +5307,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     setFormScheduleId(schedule.id)
     setFormReport(schedule.report)
     setFormVia([...schedule.via])
+    setFormDanglingVia(schedule.via.filter((via) => !notifiers[via]))
     setFormAt(normalizeAt(schedule.at))
     setFormTimezone(schedule.timezone || "UTC")
     setFormWeekdays([...schedule.weekdays])
@@ -5370,19 +5392,27 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
   }
 
   async function toggleSchedule(schedule: ScheduledNotificationView, value: boolean) {
-    const { message } = await savePatch({
+    const { persisted, message } = await savePatch({
       scheduled: schedules.map((other) => (other.id === schedule.id ? { ...other, enabled: value } : other)),
     })
-    // A rejected toggle snaps the switch back with nothing else on screen —
-    // the dialog that carries scheduleError is closed — so the failure has to
-    // land on the schedule's own card.
-    if (message) setScheduleSaveErrors((current) => ({ ...current, [schedule.id]: message }))
-    else {
+    // The cleanup follows `persisted`, not `message`, exactly as saveSchedule
+    // and removeSchedule do: a PATCH the hub accepted whose follow-up re-read
+    // failed still toggled the report, and calling that "Last save failed"
+    // under a switch snapped back to its old position tells the operator the
+    // opposite of what the hub holds. The reload failure is real, so it goes
+    // to the banner, which states it verbatim instead of blaming the save.
+    if (persisted) {
       clearScheduleSaveError(schedule.id)
       // The operator has answered the pause note by hand; leaving it up would
       // report a state that no longer exists.
       setSchedulePauseNotice("")
+      setDetachedScheduleError(message ?? "")
+      return
     }
+    // A rejected toggle snaps the switch back with nothing else on screen —
+    // the dialog that carries scheduleError is closed — so the failure has to
+    // land on the schedule's own card.
+    if (message) setScheduleSaveErrors((current) => ({ ...current, [schedule.id]: message }))
   }
 
   // Probes one schedule. A dry run renders the message the next due slot would
@@ -6195,15 +6225,17 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                   carries its own aria-label, so the container is what the
                   screen reader announces the set by. */}
               <div className="text-xs text-muted-foreground mb-1">Channels</div>
-              {names.length === 0 && formVia.length === 0 ? (
+              {names.length === 0 && formDanglingVia.length === 0 ? (
                 <p className="text-xs text-amber-400">No channels are configured yet.</p>
               ) : (
                 <div className="space-y-1" role="group" aria-label="Channels">
                   {/* Deleted channels the schedule still names get a checkbox
                       of their own, flagged: the hub refuses to save a schedule
                       pointing at one, so unticking it has to be possible from
-                      here — otherwise the only repair is a hub.yaml edit. */}
-                  {[...names, ...formVia.filter((via) => !notifiers[via])].map((name) => {
+                      here — otherwise the only repair is a hub.yaml edit. The
+                      list comes from the open-time snapshot, so unticking one
+                      leaves its row in place to be re-ticked. */}
+                  {[...names, ...formDanglingVia.filter((via) => !notifiers[via])].map((name) => {
                     const missing = !notifiers[name]
                     return (
                       <label
@@ -6212,7 +6244,13 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
                       >
                         <input
                           type="checkbox"
-                          aria-label={`Post the report to ${name}`}
+                          // The flag is the only thing telling the operator
+                          // WHICH box the warning above means, and colour alone
+                          // does not reach a screen reader — so the accessible
+                          // name has to carry it too.
+                          aria-label={missing
+                            ? `Post the report to ${name} (channel no longer configured)`
+                            : `Post the report to ${name}`}
                           checked={formVia.includes(name)}
                           disabled={saving}
                           onChange={(e) =>


### PR DESCRIPTION
## Summary

Adds a time-driven notification subsystem to the hub: **scheduled reports** that fire at a configured wall-clock time (daily or on selected weekdays) and post to one or more configured Slack notifiers — independent of agent lifecycle events. The first report type, `pending_prs`, posts a digest of unique tickets that currently have open PRs.

## Config

```yaml
notifications:
  scheduled:
    - id: pending-prs
      report: pending_prs
      via: [eng-agents, leadership]   # one or more notifiers from notifications.notifiers
      at: "09:00"
      timezone: America/Sao_Paulo
      weekdays: []                    # empty/omitted = every day; e.g. [mon, thu] = only those days
      enabled: true
```

## Design

- **Report registry** (`pkg/hub/scheduled_notifier.go`): report types are pluggable, mirroring the `notify` provider registry — a new scheduled report is one file plus one registry entry.
- **Scheduler loop**: 1-minute ticker started from `NewServer`, reaper-style double recover, inline ticks (no overlap), graceful shutdown mirroring `stopLifecycleNotifier`. Slot computation is a pure, tested function (timezone/DST aware; empty `weekdays` = daily).
- **Per-destination dedupe** in `slack_notifier_state` (`scheduled:last_fired:<id>:<notifier>`): a failed channel retries next tick without re-sending to channels that succeeded; restarts catch up at most the latest missed slot; state is seeded on first sight so new schedules don't replay stale slots.
- **`pending_prs` report**: unique tickets grouped by `(integration, integration_workspace, issue_id)` with `SUM(open_pr_count) > 0` (already indexed), open PR links + age from `task_run_prs`, oldest first, capped at 20 with overflow line. Zero pending tickets → nothing is sent.
- **Settings API + UI**: full round-trip in `/api/settings`; new "Scheduled reports" subsection in the Notifier settings section (report picker, channel multi-select, time, IANA timezone, 7 weekday chips where none selected = every day, enable toggle, dry-run/test send via the extended `/api/notifications/test`). Doctor validates `via` references and report names.

## Review

Reviewed by two independent passes; all 7 confirmed critical/major findings fixed in the final commit (duplicate-`via` validation, paused-schedule settings round-trip, UI error surfacing on toggle, stale-slot replay, graceful shutdown, omitted-key wipe of stored schedules). Remaining minor notes are consistent-with-existing-behavior items (e.g. PR dedupe across runs matches the tickets API) — happy to address in a follow-up if desired.

## Testing

- `go build ./...` and `ELASTICCLAW_HUB_CONFIG= go test ./pkg/types/... ./pkg/hub/...` — green except 3 pre-existing host-environment failures (DONE-signal/pr-watcher tests hitting the real GitHub API locally; verified identical at the base commit).
- `npm run build` in `web/` — green.
- New unit tests: slot/timezone/DST math, weekday semantics, restart dedupe, partial-failure retry, report fixtures (uniqueness, cap, zero case), settings round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
