### PR TITLE
feat(hub): roles and permissions schema, authz engine, and access backfill

### DIFF
--- a/cmd/hub_backfill_access.go
+++ b/cmd/hub_backfill_access.go
@@ -41,10 +41,10 @@ func runHubBackfillAccess(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	fmt.Fprintln(cmd.OutOrStdout(), "login\tcargo\tação")
+	fmt.Fprintln(cmd.OutOrStdout(), "tenant\tlogin\tcargo\tação")
 	created, updated := 0, 0
 	for _, r := range rows {
-		fmt.Fprintf(cmd.OutOrStdout(), "%s\t%s\t%s\n", r.Login, r.Role, r.Action)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s\t%s\t%s\t%s\n", r.Tenant, r.Login, r.Role, r.Action)
 		if r.Action == "created" {
 			created++
 		}

--- a/cmd/hub_backfill_access.go
+++ b/cmd/hub_backfill_access.go
@@ -1,0 +1,57 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/elasticclaw/elasticclaw/pkg/hub"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+var backfillAccessDB, backfillAccessConfig string
+var backfillAccessDryRun bool
+
+var hubBackfillAccessCmd = &cobra.Command{Use: "backfill-access", Short: "Backfill hub access users and roles", RunE: runHubBackfillAccess}
+
+func init() {
+	hubCmd.AddCommand(hubBackfillAccessCmd)
+	home, _ := os.UserHomeDir()
+	base := filepath.Join(home, ".elasticclaw")
+	hubBackfillAccessCmd.Flags().StringVar(&backfillAccessDB, "db", filepath.Join(base, "hub.db"), "path to SQLite database")
+	hubBackfillAccessCmd.Flags().StringVar(&backfillAccessConfig, "config", filepath.Join(base, "hub.yaml"), "path to hub config")
+	hubBackfillAccessCmd.Flags().BoolVar(&backfillAccessDryRun, "dry-run", false, "report changes without writing")
+}
+func runHubBackfillAccess(cmd *cobra.Command, args []string) error {
+	data, err := os.ReadFile(backfillAccessConfig)
+	if err != nil {
+		return fmt.Errorf("read config: %w", err)
+	}
+	var cfg types.HubConfig
+	if err = yaml.Unmarshal(data, &cfg); err != nil {
+		return fmt.Errorf("parse config: %w", err)
+	}
+	var admins []string
+	if cfg.Auth != nil && cfg.Auth.Access != nil {
+		admins = cfg.Auth.Access.Admins
+	}
+	rows, err := hub.BackfillAccess(backfillAccessDB, admins, backfillAccessDryRun)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), "login\tcargo\tação")
+	created, updated := 0, 0
+	for _, r := range rows {
+		fmt.Fprintf(cmd.OutOrStdout(), "%s\t%s\t%s\n", r.Login, r.Role, r.Action)
+		if r.Action == "created" {
+			created++
+		}
+		if r.Action == "updated" {
+			updated++
+		}
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "%d users: %d created, %d updated, %d unchanged\n", len(rows), created, updated, len(rows)-created-updated)
+	return nil
+}

--- a/cmd/hub_backfill_access_test.go
+++ b/cmd/hub_backfill_access_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/elasticclaw/elasticclaw/pkg/hub"
 	_ "modernc.org/sqlite"
 )
 
@@ -98,14 +99,84 @@ func TestHubBackfillAccessCommand(t *testing.T) {
 		}
 	})
 
+	t.Run("missing database is an error and creates no file", func(t *testing.T) {
+		dir := t.TempDir()
+		dbPath := filepath.Join(dir, "typo.db")
+		configPath := writeBackfillAccessConfig(t, dir, []string{"admin@example.com"})
+		_, err := runBackfillAccessCommand(t, dbPath, configPath, false)
+		if err == nil || !strings.Contains(err.Error(), dbPath) {
+			t.Fatalf("error = %v, want a failure naming %s", err, dbPath)
+		}
+		if _, statErr := os.Stat(dbPath); !os.IsNotExist(statErr) {
+			t.Fatalf("stat %s = %v, want the file to be absent", dbPath, statErr)
+		}
+	})
+
+	t.Run("database without access tables is an error", func(t *testing.T) {
+		dir := t.TempDir()
+		dbPath := filepath.Join(dir, "hub.db")
+		db, err := sql.Open("sqlite", dbPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := db.Exec(`CREATE TABLE tenants (id TEXT PRIMARY KEY)`); err != nil {
+			t.Fatal(err)
+		}
+		if err := db.Close(); err != nil {
+			t.Fatal(err)
+		}
+		configPath := writeBackfillAccessConfig(t, dir, []string{"admin@example.com"})
+		_, err = runBackfillAccessCommand(t, dbPath, configPath, false)
+		if err == nil || !strings.Contains(err.Error(), "start the hub once") {
+			t.Fatalf("error = %v, want a hint to start the hub first", err)
+		}
+	})
+
+	t.Run("dry run reports the same rows as the real run", func(t *testing.T) {
+		admins, logins := []string{"admin@example.com"}, []string{"reader@example.com"}
+		// Two identical databases: one previewed, one written. Comparing their
+		// output pins the dry run to the write path's decisions.
+		previewDB, previewConfig := newBackfillAccessFixture(t, admins, logins)
+		writeDB, writeConfig := newBackfillAccessFixture(t, admins, logins)
+		preview, err := runBackfillAccessCommand(t, previewDB, previewConfig, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		written, err := runBackfillAccessCommand(t, writeDB, writeConfig, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if preview != written {
+			t.Fatalf("dry run output %q != real run output %q", preview, written)
+		}
+		// Repeat over a mixed state so "updated" and "unchanged" are compared too.
+		for _, dbPath := range []string{previewDB, writeDB} {
+			if _, err := runBackfillAccessCommand(t, dbPath, writeConfig, false); err != nil {
+				t.Fatal(err)
+			}
+			execBackfillSQL(t, dbPath, `UPDATE users SET role_id='reader', active=0 WHERE login='admin@example.com'`)
+		}
+		preview, err = runBackfillAccessCommand(t, previewDB, previewConfig, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		written, err = runBackfillAccessCommand(t, writeDB, writeConfig, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if preview != written {
+			t.Fatalf("dry run output %q != real run output %q on mixed state", preview, written)
+		}
+	})
+
 	t.Run("missing admins warns and writes nothing", func(t *testing.T) {
 		dbPath, configPath := newBackfillAccessFixture(t, nil, []string{"reader@example.com"})
 		_, err := runBackfillAccessCommand(t, dbPath, configPath, false)
 		if err == nil || !strings.Contains(err.Error(), "auth.access.admins is empty") {
 			t.Fatalf("error = %v, want missing administrators warning", err)
 		}
-		if backfillTableExists(t, dbPath, "users") {
-			t.Fatal("missing-admin invocation created the users table")
+		if got := backfillUserCount(t, dbPath); got != 0 {
+			t.Fatalf("missing-admin invocation wrote %d users", got)
 		}
 	})
 }
@@ -114,13 +185,16 @@ func newBackfillAccessFixture(t *testing.T, admins, messageLogins []string) (str
 	t.Helper()
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "hub.db")
+	// The command no longer migrates, so the fixture builds the schema the same
+	// way a hub start would.
+	if err := hub.InitDBForTest(dbPath); err != nil {
+		t.Fatal(err)
+	}
 	db, err := sql.Open("sqlite", dbPath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = db.Exec(`CREATE TABLE tenants (id TEXT PRIMARY KEY, name TEXT NOT NULL, token TEXT NOT NULL UNIQUE, claw_token TEXT NOT NULL UNIQUE, created_at DATETIME NOT NULL);
-		CREATE TABLE messages (id TEXT PRIMARY KEY, claw_id TEXT NOT NULL, tenant_id TEXT NOT NULL, role TEXT NOT NULL, content TEXT NOT NULL, format TEXT NOT NULL DEFAULT '', user_login TEXT, created_at DATETIME NOT NULL, delivered_at DATETIME);
-		INSERT INTO tenants(id,name,token,claw_token,created_at) VALUES('tenant','test','token','claw-token',datetime('now'))`)
+	_, err = db.Exec(`INSERT INTO tenants(id,name,token,claw_token,created_at) VALUES('tenant','test','token','claw-token',datetime('now'))`)
 	if err != nil {
 		db.Close()
 		t.Fatal(err)
@@ -134,6 +208,11 @@ func newBackfillAccessFixture(t *testing.T, admins, messageLogins []string) (str
 	if err := db.Close(); err != nil {
 		t.Fatal(err)
 	}
+	return dbPath, writeBackfillAccessConfig(t, dir, admins)
+}
+
+func writeBackfillAccessConfig(t *testing.T, dir string, admins []string) string {
+	t.Helper()
 	configPath := filepath.Join(dir, "hub.yaml")
 	config := "auth:\n  access:\n"
 	if admins != nil {
@@ -145,7 +224,7 @@ func newBackfillAccessFixture(t *testing.T, admins, messageLogins []string) (str
 	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	return dbPath, configPath
+	return configPath
 }
 
 func runBackfillAccessCommand(t *testing.T, dbPath, configPath string, dryRun bool) (string, error) {
@@ -202,20 +281,6 @@ func backfillTableCount(t *testing.T, dbPath, table string) int {
 		t.Fatal(err)
 	}
 	return count
-}
-
-func backfillTableExists(t *testing.T, dbPath, table string) bool {
-	t.Helper()
-	db, err := sql.Open("sqlite", dbPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer db.Close()
-	var count int
-	if err := db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=?`, table).Scan(&count); err != nil {
-		t.Fatal(err)
-	}
-	return count != 0
 }
 
 func execBackfillSQL(t *testing.T, dbPath, query string) {

--- a/cmd/hub_backfill_access_test.go
+++ b/cmd/hub_backfill_access_test.go
@@ -1,0 +1,175 @@
+package cmd
+
+import (
+	"bytes"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+func TestHubBackfillAccessCommand(t *testing.T) {
+	t.Run("backfills configured admins and message users", func(t *testing.T) {
+		dbPath, configPath := newBackfillAccessFixture(t, []string{" Admin@Example.com "}, []string{"reader@example.com", "ADMIN@example.com"})
+		output, err := runBackfillAccessCommand(t, dbPath, configPath, false)
+		if err != nil {
+			t.Fatalf("run backfill: %v", err)
+		}
+		if !strings.Contains(output, "2 users: 2 created") {
+			t.Fatalf("unexpected output: %q", output)
+		}
+		assertBackfillRoles(t, dbPath, map[string]string{"admin@example.com": "admin", "reader@example.com": "reader"})
+	})
+
+	t.Run("is idempotent and does not demote admins", func(t *testing.T) {
+		dbPath, configPath := newBackfillAccessFixture(t, []string{"admin@example.com"}, []string{"reader@example.com"})
+		if _, err := runBackfillAccessCommand(t, dbPath, configPath, false); err != nil {
+			t.Fatal(err)
+		}
+		output, err := runBackfillAccessCommand(t, dbPath, configPath, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(output, "2 users: 0 created, 0 updated, 2 unchanged") {
+			t.Fatalf("second output: %q", output)
+		}
+		assertBackfillRoles(t, dbPath, map[string]string{"admin@example.com": "admin", "reader@example.com": "reader"})
+		assertBackfillUserCount(t, dbPath, 2)
+	})
+
+	t.Run("dry run writes no users", func(t *testing.T) {
+		dbPath, configPath := newBackfillAccessFixture(t, []string{"admin@example.com"}, []string{"reader@example.com"})
+		if _, err := runBackfillAccessCommand(t, dbPath, configPath, false); err != nil {
+			t.Fatal(err)
+		}
+		before := backfillUserCount(t, dbPath)
+		if _, err := runBackfillAccessCommand(t, dbPath, configPath, true); err != nil {
+			t.Fatal(err)
+		}
+		if after := backfillUserCount(t, dbPath); after != before {
+			t.Fatalf("user count after dry run = %d, want %d", after, before)
+		}
+	})
+
+	t.Run("missing admins warns and writes nothing", func(t *testing.T) {
+		dbPath, configPath := newBackfillAccessFixture(t, nil, []string{"reader@example.com"})
+		_, err := runBackfillAccessCommand(t, dbPath, configPath, false)
+		if err == nil || !strings.Contains(err.Error(), "auth.access.admins is empty") {
+			t.Fatalf("error = %v, want missing administrators warning", err)
+		}
+		if backfillTableExists(t, dbPath, "users") {
+			t.Fatal("missing-admin invocation created the users table")
+		}
+	})
+}
+
+func newBackfillAccessFixture(t *testing.T, admins, messageLogins []string) (string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "hub.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = db.Exec(`CREATE TABLE tenants (id TEXT PRIMARY KEY, name TEXT NOT NULL, token TEXT NOT NULL UNIQUE, claw_token TEXT NOT NULL UNIQUE, created_at DATETIME NOT NULL);
+		CREATE TABLE messages (id TEXT PRIMARY KEY, claw_id TEXT NOT NULL, tenant_id TEXT NOT NULL, role TEXT NOT NULL, content TEXT NOT NULL, format TEXT NOT NULL DEFAULT '', user_login TEXT, created_at DATETIME NOT NULL, delivered_at DATETIME);
+		INSERT INTO tenants(id,name,token,claw_token,created_at) VALUES('tenant','test','token','claw-token',datetime('now'))`)
+	if err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	for i, login := range messageLogins {
+		if _, err := db.Exec(`INSERT INTO messages(id,claw_id,tenant_id,role,content,user_login,created_at) VALUES(?,?,?,'user','message',?,datetime('now'))`, string(rune('a'+i)), "claw", "tenant", login); err != nil {
+			db.Close()
+			t.Fatal(err)
+		}
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	configPath := filepath.Join(dir, "hub.yaml")
+	config := "auth:\n  access:\n"
+	if admins != nil {
+		config += "    admins:\n"
+		for _, admin := range admins {
+			config += "      - " + admin + "\n"
+		}
+	}
+	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return dbPath, configPath
+}
+
+func runBackfillAccessCommand(t *testing.T, dbPath, configPath string, dryRun bool) (string, error) {
+	t.Helper()
+	oldDB, oldConfig, oldDryRun := backfillAccessDB, backfillAccessConfig, backfillAccessDryRun
+	t.Cleanup(func() { backfillAccessDB, backfillAccessConfig, backfillAccessDryRun = oldDB, oldConfig, oldDryRun })
+	backfillAccessDB, backfillAccessConfig, backfillAccessDryRun = dbPath, configPath, dryRun
+	var output bytes.Buffer
+	command := hubBackfillAccessCmd
+	command.SetOut(&output)
+	t.Cleanup(func() { command.SetOut(nil) })
+	err := runHubBackfillAccess(command, nil)
+	return output.String(), err
+}
+
+func assertBackfillRoles(t *testing.T, dbPath string, want map[string]string) {
+	t.Helper()
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	for login, role := range want {
+		var got string
+		if err := db.QueryRow(`SELECT r.name FROM users u JOIN roles r ON r.id=u.role_id WHERE u.login=?`, login).Scan(&got); err != nil {
+			t.Fatalf("role for %s: %v", login, err)
+		}
+		if got != role {
+			t.Errorf("role for %s = %q, want %q", login, got, role)
+		}
+	}
+}
+
+func assertBackfillUserCount(t *testing.T, dbPath string, want int) {
+	t.Helper()
+	if got := backfillUserCount(t, dbPath); got != want {
+		t.Fatalf("user count = %d, want %d", got, want)
+	}
+}
+
+func backfillUserCount(t *testing.T, dbPath string) int {
+	return backfillTableCount(t, dbPath, "users")
+}
+
+func backfillTableCount(t *testing.T, dbPath, table string) int {
+	t.Helper()
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM ` + table).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	return count
+}
+
+func backfillTableExists(t *testing.T, dbPath, table string) bool {
+	t.Helper()
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=?`, table).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	return count != 0
+}

--- a/cmd/hub_backfill_access_test.go
+++ b/cmd/hub_backfill_access_test.go
@@ -54,6 +54,50 @@ func TestHubBackfillAccessCommand(t *testing.T) {
 		}
 	})
 
+	t.Run("reactivates an existing user promoted to admin", func(t *testing.T) {
+		dbPath, configPath := newBackfillAccessFixture(t, []string{"admin@example.com"}, []string{"reader@example.com"})
+		if _, err := runBackfillAccessCommand(t, dbPath, configPath, false); err != nil {
+			t.Fatal(err)
+		}
+		execBackfillSQL(t, dbPath, `UPDATE users SET role_id='reader', active=0 WHERE login='admin@example.com'`)
+		output, err := runBackfillAccessCommand(t, dbPath, configPath, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(output, "1 updated") {
+			t.Fatalf("unexpected output: %q", output)
+		}
+		assertBackfillRoles(t, dbPath, map[string]string{"admin@example.com": "admin"})
+		if got := backfillScalar(t, dbPath, `SELECT active FROM users WHERE login='admin@example.com'`); got != 1 {
+			t.Fatalf("promoted admin active = %d, want 1", got)
+		}
+	})
+
+	t.Run("backfills every tenant and scopes message users to their tenant", func(t *testing.T) {
+		dbPath, configPath := newBackfillAccessFixture(t, []string{"admin@example.com"}, []string{"reader@example.com"})
+		execBackfillSQL(t, dbPath, `INSERT INTO tenants(id,name,token,claw_token,created_at) VALUES('tenant-2','second','token-2','claw-token-2',datetime('now'));
+			INSERT INTO messages(id,claw_id,tenant_id,role,content,user_login,created_at) VALUES('z','claw','tenant-2','user','message','other@example.com',datetime('now'))`)
+		if _, err := runBackfillAccessCommand(t, dbPath, configPath, false); err != nil {
+			t.Fatal(err)
+		}
+		// Every tenant gets its own active admin, and a message author only
+		// gets an account in the tenant it actually wrote in.
+		for _, tenant := range []string{"tenant", "tenant-2"} {
+			if got := backfillScalar(t, dbPath, `SELECT COUNT(*) FROM users u JOIN roles r ON r.id=u.role_id WHERE u.tenant_id='`+tenant+`' AND r.name='admin' AND u.active=1`); got != 1 {
+				t.Fatalf("active admins in %s = %d, want 1", tenant, got)
+			}
+		}
+		if got := backfillScalar(t, dbPath, `SELECT COUNT(*) FROM users WHERE login='other@example.com'`); got != 1 {
+			t.Fatalf("other@example.com rows = %d, want 1", got)
+		}
+		if got := backfillScalar(t, dbPath, `SELECT COUNT(*) FROM users WHERE login='other@example.com' AND tenant_id='tenant-2'`); got != 1 {
+			t.Fatalf("other@example.com was not created in tenant-2")
+		}
+		if got := backfillScalar(t, dbPath, `SELECT COUNT(*) FROM users WHERE login='reader@example.com' AND tenant_id='tenant-2'`); got != 0 {
+			t.Fatalf("reader@example.com leaked into tenant-2")
+		}
+	})
+
 	t.Run("missing admins warns and writes nothing", func(t *testing.T) {
 		dbPath, configPath := newBackfillAccessFixture(t, nil, []string{"reader@example.com"})
 		_, err := runBackfillAccessCommand(t, dbPath, configPath, false)
@@ -172,4 +216,30 @@ func backfillTableExists(t *testing.T, dbPath, table string) bool {
 		t.Fatal(err)
 	}
 	return count != 0
+}
+
+func execBackfillSQL(t *testing.T, dbPath, query string) {
+	t.Helper()
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if _, err := db.Exec(query); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func backfillScalar(t *testing.T, dbPath, query string) int {
+	t.Helper()
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	var value int
+	if err := db.QueryRow(query).Scan(&value); err != nil {
+		t.Fatal(err)
+	}
+	return value
 }

--- a/pkg/hub/authz.go
+++ b/pkg/hub/authz.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -484,30 +485,56 @@ func (s *Server) changeUser(tenant, login, field string, value any) error {
 
 type AccessBackfillRow struct{ Tenant, Login, Role, Action string }
 
+// backfillQuerier is the read surface shared by *sql.DB and *sql.Tx, so the
+// dry run can reuse the real run's queries without holding a transaction.
+type backfillQuerier interface {
+	Query(query string, args ...any) (*sql.Rows, error)
+	QueryRow(query string, args ...any) *sql.Row
+}
+
+// openBackfillDB opens an existing hub database without migrating it.
+//
+// This command runs against the live hub's database, so it must not be a second
+// migrator: migrate() applies write-heavy rebuilds that abort halfway (or, for
+// the legacy steps that discard their error, half-apply in silence) when the hub
+// holds a write transaction. It also must not let SQLite create the file, or a
+// typo in --db would leave an empty database behind for a later hub start to
+// migrate into a blank hub. The DSN mirrors openDB's, _txlock=immediate
+// included: without it Begin() opens DEFERRED, and the read-then-write order of
+// the backfill turns a concurrent hub commit into SQLITE_BUSY_SNAPSHOT, which
+// the busy handler does not retry.
+func openBackfillDB(dbPath string) (*sql.DB, error) {
+	if _, err := os.Stat(dbPath); err != nil {
+		return nil, fmt.Errorf("hub database %s: %w", dbPath, err)
+	}
+	db, err := sql.Open("sqlite", dbPath+"?_time_format=sqlite&_txlock=immediate&_pragma=journal_mode(WAL)&_pragma=foreign_keys(on)&_pragma=busy_timeout(5000)")
+	if err != nil {
+		return nil, fmt.Errorf("open db: %w", err)
+	}
+	if err = requireAccessTables(db); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	return db, nil
+}
+
+func requireAccessTables(db *sql.DB) error {
+	var found int
+	err := db.QueryRow(`SELECT count(*) FROM sqlite_master WHERE type='table' AND name IN ('users','roles','permissions','role_permissions')`).Scan(&found)
+	if err != nil {
+		return fmt.Errorf("inspect access control tables: %w", err)
+	}
+	if found != 4 {
+		return errors.New("access control tables are missing; start the hub once on this version to create and seed them before running the backfill")
+	}
+	return nil
+}
+
 // BackfillAccess seeds the users table from the configured administrators and
 // from historical message authors. It runs once per tenant: the admin list is
 // hub-wide, and every tenant needs at least one active admin of its own, so a
 // tenant that only shows up in the messages table must not be left without one.
 func BackfillAccess(dbPath string, admins []string, dryRun bool) ([]AccessBackfillRow, error) {
-	if len(admins) == 0 {
-		return nil, errors.New("auth.access.admins is empty; refusing backfill without an administrator")
-	}
-	var db *sql.DB
-	var err error
-	if dryRun {
-		db, err = sql.Open("sqlite", dbPath+"?_time_format=sqlite&_pragma=foreign_keys(on)&_pragma=busy_timeout(5000)")
-	} else {
-		db, err = openDB(dbPath)
-	}
-	if err != nil {
-		return nil, err
-	}
-	defer db.Close()
-	tx, err := db.Begin()
-	if err != nil {
-		return nil, err
-	}
-	defer tx.Rollback()
 	adminSet := map[string]bool{}
 	for _, login := range admins {
 		if login = normalizeLogin(login); login != "" {
@@ -522,13 +549,42 @@ func BackfillAccess(dbPath string, admins []string, dryRun bool) ([]AccessBackfi
 		adminLogins = append(adminLogins, login)
 	}
 	sort.Strings(adminLogins)
-	tenants, err := backfillTenants(tx)
+	db, err := openBackfillDB(dbPath)
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+	if dryRun {
+		// Purely read-only: simulating with a transaction that is rolled back
+		// would still take a write lock on the production database.
+		return backfillRows(db, nil, adminSet, adminLogins)
+	}
+	tx, err := db.Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+	out, err := backfillRows(tx, tx, adminSet, adminLogins)
+	if err != nil {
+		return nil, err
+	}
+	if err = tx.Commit(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// backfillRows walks every tenant and reports the action for each login. It
+// applies those actions when apply is non-nil and only reads when it is nil, so
+// the dry run and the real run cannot decide differently.
+func backfillRows(q backfillQuerier, apply *sql.Tx, adminSet map[string]bool, adminLogins []string) ([]AccessBackfillRow, error) {
+	tenants, err := backfillTenants(q)
 	if err != nil {
 		return nil, err
 	}
 	var out []AccessBackfillRow
 	for _, tenant := range tenants {
-		logins, e := backfillTenantLogins(tx, tenant, adminSet, adminLogins)
+		logins, e := backfillTenantLogins(q, tenant, adminSet, adminLogins)
 		if e != nil {
 			return nil, e
 		}
@@ -537,24 +593,23 @@ func BackfillAccess(dbPath string, admins []string, dryRun bool) ([]AccessBackfi
 			if adminSet[login] {
 				role = "admin"
 			}
-			action, e := backfillUser(tx, tenant, login, role)
+			var action string
+			if apply != nil {
+				action, e = backfillUser(apply, tenant, login, role)
+			} else {
+				action, e = backfillAction(q, tenant, login, role)
+			}
 			if e != nil {
 				return nil, e
 			}
 			out = append(out, AccessBackfillRow{tenant, login, role, action})
 		}
 	}
-	if dryRun {
-		return out, nil
-	}
-	if err = tx.Commit(); err != nil {
-		return nil, err
-	}
 	return out, nil
 }
 
-func backfillTenants(tx *sql.Tx) ([]string, error) {
-	rows, err := tx.Query(`SELECT id FROM tenants ORDER BY created_at`)
+func backfillTenants(q backfillQuerier) ([]string, error) {
+	rows, err := q.Query(`SELECT id FROM tenants ORDER BY created_at`)
 	if err != nil {
 		return nil, fmt.Errorf("find tenant: %w", err)
 	}
@@ -579,9 +634,9 @@ func backfillTenants(tx *sql.Tx) ([]string, error) {
 // backfillTenantLogins returns the administrators plus the message authors that
 // belong to this tenant. Message authors are filtered by tenant_id so that a
 // login only seen in another tenant does not get an account here.
-func backfillTenantLogins(tx *sql.Tx, tenant string, adminSet map[string]bool, adminLogins []string) ([]string, error) {
+func backfillTenantLogins(q backfillQuerier, tenant string, adminSet map[string]bool, adminLogins []string) ([]string, error) {
 	logins := append([]string{}, adminLogins...)
-	rows, err := tx.Query(`SELECT DISTINCT lower(trim(user_login)) FROM messages WHERE tenant_id=? AND user_login <> '' ORDER BY 1`, tenant)
+	rows, err := q.Query(`SELECT DISTINCT lower(trim(user_login)) FROM messages WHERE tenant_id=? AND user_login <> '' ORDER BY 1`, tenant)
 	if err != nil {
 		return nil, err
 	}
@@ -598,21 +653,35 @@ func backfillTenantLogins(tx *sql.Tx, tenant string, adminSet map[string]bool, a
 	return logins, rows.Err()
 }
 
-func backfillUser(tx *sql.Tx, tenant, login, role string) (string, error) {
+// backfillAction is the single decision rule behind both the dry run and the
+// real run.
+func backfillAction(q backfillQuerier, tenant, login, role string) (string, error) {
 	var existingRole string
 	var existingActive int
-	e := tx.QueryRow(`SELECT r.name,u.active FROM users u JOIN roles r ON r.id=u.role_id WHERE u.tenant_id=? AND u.login=?`, tenant, login).Scan(&existingRole, &existingActive)
+	e := q.QueryRow(`SELECT r.name,u.active FROM users u JOIN roles r ON r.id=u.role_id WHERE u.tenant_id=? AND u.login=?`, tenant, login).Scan(&existingRole, &existingActive)
 	switch {
 	case e == sql.ErrNoRows:
-		_, e = tx.Exec(`INSERT INTO users(id,tenant_id,login,role_id,created_at,last_login_at) VALUES(?,?,?,?,?,0)`, uuid.NewString(), tenant, login, role, now().UnixMilli())
-		return "created", e
+		return "created", nil
 	case e != nil:
 		return "", e
 	case role == "admin" && (existingRole != "admin" || existingActive == 0):
+		return "updated", nil
+	}
+	return "unchanged", nil
+}
+
+func backfillUser(tx *sql.Tx, tenant, login, role string) (string, error) {
+	action, e := backfillAction(tx, tenant, login, role)
+	if e != nil {
+		return "", e
+	}
+	switch action {
+	case "created":
+		_, e = tx.Exec(`INSERT INTO users(id,tenant_id,login,role_id,created_at,last_login_at) VALUES(?,?,?,?,?,0)`, uuid.NewString(), tenant, login, role, now().UnixMilli())
+	case "updated":
 		// Promoting without reactivating would satisfy "the tenant has an
 		// admin" with an admin that cannot log in, so do both at once.
 		_, e = tx.Exec(`UPDATE users SET role_id='admin',active=1 WHERE tenant_id=? AND login=?`, tenant, login)
-		return "updated", e
 	}
-	return "unchanged", nil
+	return action, e
 }

--- a/pkg/hub/authz.go
+++ b/pkg/hub/authz.go
@@ -1,0 +1,500 @@
+package hub
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type Permission string
+
+const (
+	PermAuthLogin        Permission = "auth:login"
+	PermClawViewAll      Permission = "claw:view:all"
+	PermClawViewOwn      Permission = "claw:view:own"
+	PermClawMessagesRead Permission = "claw:messages:read"
+	PermClawCreate       Permission = "claw:create"
+	PermClawInteractAll  Permission = "claw:interact:all"
+	PermClawInteractOwn  Permission = "claw:interact:own"
+	PermClawModifyAll    Permission = "claw:modify:all"
+	PermClawModifyOwn    Permission = "claw:modify:own"
+	PermClawDeleteAll    Permission = "claw:delete:all"
+	PermClawDeleteOwn    Permission = "claw:delete:own"
+	PermClawCheckpoint   Permission = "claw:checkpoint"
+	PermClawTerminal     Permission = "claw:terminal"
+	PermClawFiles        Permission = "claw:files"
+	PermWorkflowView     Permission = "workflow:view"
+	PermWorkflowTrigger  Permission = "workflow:trigger"
+	PermWorkflowEdit     Permission = "workflow:edit"
+	PermWorkspaceView    Permission = "workspace:view"
+	PermWorkspaceEdit    Permission = "workspace:edit"
+	PermWorkspaceSecrets Permission = "workspace:secrets"
+	PermFactoryView      Permission = "factory:view"
+	PermFactoryTrigger   Permission = "factory:trigger"
+	PermFactoryEdit      Permission = "factory:edit"
+	PermAnalyticsView    Permission = "analytics:view"
+	PermAnalyticsCosts   Permission = "analytics:costs"
+	PermSettingsView     Permission = "settings:view"
+	PermSettingsEdit     Permission = "settings:edit"
+	PermSecretsManage    Permission = "secrets:manage"
+	PermAccessManage     Permission = "access:manage"
+	PermDoctorRun        Permission = "doctor:run"
+)
+
+type PermissionMeta struct {
+	Key                          Permission
+	Resource, Label, Description string
+}
+
+var AllPermissions = []PermissionMeta{
+	{PermAuthLogin, "auth", "Enter the UI", ""}, {PermClawViewAll, "claw", "View all agents", ""}, {PermClawViewOwn, "claw", "View own agents", ""}, {PermClawMessagesRead, "claw", "Read agent conversations and transcripts", ""}, {PermClawCreate, "claw", "Create agent", "Provisions a VM and consumes LLM usage"}, {PermClawInteractAll, "claw", "Message any agent", ""}, {PermClawInteractOwn, "claw", "Message own agents", ""}, {PermClawModifyAll, "claw", "Modify any agent", ""}, {PermClawModifyOwn, "claw", "Modify own agents", ""}, {PermClawDeleteAll, "claw", "Delete any agent", ""}, {PermClawDeleteOwn, "claw", "Delete own agents", ""}, {PermClawCheckpoint, "claw", "Create and restore checkpoints", ""}, {PermClawTerminal, "claw", "Open sandbox terminal", ""}, {PermClawFiles, "claw", "Transfer agent files", ""},
+	{PermWorkflowView, "workflow", "View workflows, runs, and cron history", ""}, {PermWorkflowTrigger, "workflow", "Trigger workflows", ""}, {PermWorkflowEdit, "workflow", "Edit workflows", ""}, {PermWorkspaceView, "workspace", "View workspaces", ""}, {PermWorkspaceEdit, "workspace", "Edit workspaces", ""}, {PermWorkspaceSecrets, "workspace", "Manage workspace secrets and integrations", ""}, {PermFactoryView, "factory", "View factories and events", ""}, {PermFactoryTrigger, "factory", "Trigger factories", ""}, {PermFactoryEdit, "factory", "Edit factories", ""}, {PermAnalyticsView, "analytics", "View cost-free dashboard", ""}, {PermAnalyticsCosts, "analytics", "View costs and factory analytics", ""}, {PermSettingsView, "admin", "View settings", ""}, {PermSettingsEdit, "admin", "Edit hub configuration", ""}, {PermSecretsManage, "admin", "Manage global secrets and model credentials", ""}, {PermAccessManage, "admin", "Manage users, roles, and permissions", ""}, {PermDoctorRun, "admin", "Run doctor and troubleshoot", ""},
+}
+
+var (
+	ErrRoleImmutable     = errors.New("role is immutable")
+	ErrRoleSystem        = errors.New("role is a system role")
+	ErrRoleInUse         = errors.New("role is in use")
+	ErrLastAdmin         = errors.New("last active admin")
+	ErrUnknownPermission = errors.New("unknown permission")
+)
+
+type Principal struct {
+	TenantID, Login, RoleName string
+	perms                     map[Permission]struct{}
+}
+
+func (p *Principal) Allows(perm Permission, tags []string) bool {
+	if p == nil || p.Login == "" {
+		return true
+	}
+	if _, ok := p.perms[perm]; ok {
+		return true
+	}
+	key := string(perm)
+	if !strings.HasSuffix(key, ":all") {
+		return false
+	}
+	own := Permission(strings.TrimSuffix(key, ":all") + ":own")
+	if _, ok := p.perms[own]; !ok {
+		return false
+	}
+	if tags == nil {
+		return true
+	}
+	want := "owner=" + strings.ToLower(p.Login)
+	for _, tag := range tags {
+		if strings.EqualFold(strings.TrimSpace(tag), want) {
+			return true
+		}
+	}
+	return false
+}
+
+type Role struct {
+	ID, Name          string
+	System, Immutable bool
+}
+type AccessUser struct {
+	ID, TenantID, Login, Name, AvatarURL, RoleID, RoleName string
+	Active                                                 bool
+}
+type accessCache struct {
+	principal *Principal
+	until     time.Time
+	version   uint64
+}
+type accessState struct {
+	mu      sync.Mutex
+	version uint64
+	cache   map[string]accessCache
+}
+
+func (s *Server) access() *accessState { // lazily attach avoids changing existing Server construction paths.
+	accessStates.Lock()
+	defer accessStates.Unlock()
+	if v := accessStates.m[s]; v != nil {
+		return v
+	}
+	v := &accessState{cache: map[string]accessCache{}}
+	accessStates.m[s] = v
+	return v
+}
+
+var accessStates = struct {
+	sync.Mutex
+	m map[*Server]*accessState
+}{m: map[*Server]*accessState{}}
+
+func (s *Server) invalidateAccess() {
+	a := s.access()
+	a.mu.Lock()
+	a.version++
+	a.cache = map[string]accessCache{}
+	a.mu.Unlock()
+}
+
+func migrateAccessControl(db *sql.DB) error {
+	_, err := db.Exec(`CREATE TABLE IF NOT EXISTS permissions (key TEXT PRIMARY KEY, resource TEXT NOT NULL, label TEXT NOT NULL, description TEXT NOT NULL DEFAULT ''); CREATE TABLE IF NOT EXISTS roles (id TEXT PRIMARY KEY, name TEXT NOT NULL UNIQUE, system INTEGER NOT NULL DEFAULT 0, immutable INTEGER NOT NULL DEFAULT 0, created_at INTEGER NOT NULL); CREATE TABLE IF NOT EXISTS role_permissions (role_id TEXT NOT NULL REFERENCES roles(id) ON DELETE CASCADE, permission_key TEXT NOT NULL REFERENCES permissions(key), PRIMARY KEY(role_id, permission_key)); CREATE TABLE IF NOT EXISTS users (id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL REFERENCES tenants(id), login TEXT NOT NULL, name TEXT NOT NULL DEFAULT '', avatar_url TEXT NOT NULL DEFAULT '', role_id TEXT NOT NULL REFERENCES roles(id), active INTEGER NOT NULL DEFAULT 1, created_at INTEGER NOT NULL, last_login_at INTEGER NOT NULL DEFAULT 0, UNIQUE(tenant_id, login)); CREATE INDEX IF NOT EXISTS idx_users_tenant_login ON users(tenant_id, login)`)
+	if err != nil {
+		return err
+	}
+	return reconcileAccessControl(db)
+}
+func reconcileAccessControl(db *sql.DB) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	for _, p := range AllPermissions {
+		if _, err = tx.Exec(`INSERT INTO permissions(key,resource,label,description) VALUES(?,?,?,?) ON CONFLICT(key) DO UPDATE SET resource=excluded.resource,label=excluded.label,description=excluded.description`, p.Key, p.Resource, p.Label, p.Description); err != nil {
+			return err
+		}
+	}
+	for _, r := range []struct {
+		name      string
+		immutable int
+	}{{"admin", 1}, {"reader", 0}} {
+		result, e := tx.Exec(`INSERT OR IGNORE INTO roles(id,name,system,immutable,created_at) VALUES(?,?,?,?,?)`, r.name, r.name, 1, r.immutable, now().UnixMilli())
+		if e != nil {
+			return e
+		}
+		if r.name == "reader" {
+			n, _ := result.RowsAffected()
+			if n == 1 {
+				for _, p := range []Permission{PermAuthLogin, PermClawViewAll, PermClawMessagesRead} {
+					if _, e = tx.Exec(`INSERT OR IGNORE INTO role_permissions(role_id,permission_key) VALUES('reader',?)`, p); e != nil {
+						return e
+					}
+				}
+			}
+		}
+	}
+	if _, err = tx.Exec(`DELETE FROM role_permissions WHERE role_id='admin'`); err != nil {
+		return err
+	}
+	permissions, err := tx.Query(`SELECT key FROM permissions ORDER BY key`)
+	if err != nil {
+		return err
+	}
+	defer permissions.Close()
+	for permissions.Next() {
+		var key string
+		if err = permissions.Scan(&key); err != nil {
+			return err
+		}
+		if _, err = tx.Exec(`INSERT INTO role_permissions(role_id,permission_key) VALUES('admin',?)`, key); err != nil {
+			return err
+		}
+	}
+	if err = permissions.Err(); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+func normalizeLogin(login string) string { return strings.ToLower(strings.TrimSpace(login)) }
+func (s *Server) principalFor(tenantID, login string) (*Principal, error) {
+	login = normalizeLogin(login)
+	if login == "" {
+		return &Principal{TenantID: tenantID}, nil
+	}
+	a := s.access()
+	k := tenantID + "\x00" + login
+	a.mu.Lock()
+	c, ok := a.cache[k]
+	if ok && c.until.After(now()) && c.version == a.version {
+		a.mu.Unlock()
+		return c.principal, nil
+	}
+	a.mu.Unlock()
+	p := &Principal{TenantID: tenantID, Login: login, perms: map[Permission]struct{}{}}
+	rows, e := s.db.Query(`SELECT r.name,rp.permission_key FROM users u JOIN roles r ON r.id=u.role_id LEFT JOIN role_permissions rp ON rp.role_id=r.id WHERE u.tenant_id=? AND u.login=? AND u.active=1`, tenantID, login)
+	if e != nil {
+		return nil, e
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var key sql.NullString
+		if e = rows.Scan(&p.RoleName, &key); e != nil {
+			return nil, e
+		}
+		if key.Valid {
+			p.perms[Permission(key.String)] = struct{}{}
+		}
+	}
+	if e = rows.Err(); e != nil {
+		return nil, e
+	}
+	a.mu.Lock()
+	a.cache[k] = accessCache{p, now().Add(5 * time.Second), a.version}
+	a.mu.Unlock()
+	return p, nil
+}
+func (s *Server) upsertUserOnLogin(tenantID, login, name, avatar string) (*Principal, error) {
+	login = normalizeLogin(login)
+	_, e := s.db.Exec(`INSERT INTO users(id,tenant_id,login,name,avatar_url,role_id,active,created_at,last_login_at) VALUES(?,?,?,?,?,'reader',1,?,?) ON CONFLICT(tenant_id,login) DO UPDATE SET name=excluded.name,avatar_url=excluded.avatar_url,last_login_at=excluded.last_login_at`, uuid.NewString(), tenantID, login, name, avatar, now().UnixMilli(), now().UnixMilli())
+	if e != nil {
+		return nil, e
+	}
+	s.invalidateAccess()
+	return s.principalFor(tenantID, login)
+}
+func (s *Server) listRoles() ([]Role, error) {
+	rows, e := s.db.Query(`SELECT id,name,system,immutable FROM roles ORDER BY name`)
+	if e != nil {
+		return nil, e
+	}
+	defer rows.Close()
+	var out []Role
+	for rows.Next() {
+		var r Role
+		var x, y int
+		if e = rows.Scan(&r.ID, &r.Name, &x, &y); e != nil {
+			return nil, e
+		}
+		r.System = x != 0
+		r.Immutable = y != 0
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+func (s *Server) listUsers(tenant string) ([]AccessUser, error) {
+	rows, e := s.db.Query(`SELECT u.id,u.tenant_id,u.login,u.name,u.avatar_url,u.role_id,r.name,u.active FROM users u JOIN roles r ON r.id=u.role_id WHERE u.tenant_id=? ORDER BY u.login`, tenant)
+	if e != nil {
+		return nil, e
+	}
+	defer rows.Close()
+	var out []AccessUser
+	for rows.Next() {
+		var u AccessUser
+		var a int
+		if e = rows.Scan(&u.ID, &u.TenantID, &u.Login, &u.Name, &u.AvatarURL, &u.RoleID, &u.RoleName, &a); e != nil {
+			return nil, e
+		}
+		u.Active = a != 0
+		out = append(out, u)
+	}
+	return out, rows.Err()
+}
+func (s *Server) createRole(name string) (Role, error) {
+	r := Role{ID: uuid.NewString(), Name: strings.TrimSpace(name)}
+	_, e := s.db.Exec(`INSERT INTO roles(id,name,created_at) VALUES(?,?,?)`, r.ID, r.Name, now().UnixMilli())
+	if e == nil {
+		s.invalidateAccess()
+	}
+	return r, e
+}
+
+func (s *Server) renameRole(id, name string) error {
+	var immutable int
+	if err := s.db.QueryRow(`SELECT immutable FROM roles WHERE id=?`, id).Scan(&immutable); err != nil {
+		return err
+	}
+	if immutable != 0 {
+		return ErrRoleImmutable
+	}
+	_, err := s.db.Exec(`UPDATE roles SET name=? WHERE id=?`, strings.TrimSpace(name), id)
+	if err == nil {
+		s.invalidateAccess()
+	}
+	return err
+}
+func knownPermission(p Permission) bool {
+	for _, x := range AllPermissions {
+		if x.Key == p {
+			return true
+		}
+	}
+	return false
+}
+func (s *Server) updateRolePermissions(id string, perms []Permission) error {
+	var imm int
+	if e := s.db.QueryRow(`SELECT immutable FROM roles WHERE id=?`, id).Scan(&imm); e != nil {
+		return e
+	}
+	if imm != 0 {
+		return ErrRoleImmutable
+	}
+	for _, p := range perms {
+		if !knownPermission(p) {
+			return fmt.Errorf("%w: %s", ErrUnknownPermission, p)
+		}
+	}
+	tx, e := s.db.Begin()
+	if e != nil {
+		return e
+	}
+	defer tx.Rollback()
+	if _, e = tx.Exec(`DELETE FROM role_permissions WHERE role_id=?`, id); e != nil {
+		return e
+	}
+	for _, p := range perms {
+		if _, e = tx.Exec(`INSERT INTO role_permissions(role_id,permission_key) VALUES(?,?)`, id, p); e != nil {
+			return e
+		}
+	}
+	if e = tx.Commit(); e == nil {
+		s.invalidateAccess()
+	}
+	return e
+}
+func (s *Server) deleteRole(id string) error {
+	var sys int
+	if e := s.db.QueryRow(`SELECT system FROM roles WHERE id=?`, id).Scan(&sys); e != nil {
+		return e
+	}
+	if sys != 0 {
+		return ErrRoleSystem
+	}
+	var n int
+	if e := s.db.QueryRow(`SELECT COUNT(*) FROM users WHERE role_id=?`, id).Scan(&n); e != nil {
+		return e
+	}
+	if n > 0 {
+		return fmt.Errorf("%w: %d users", ErrRoleInUse, n)
+	}
+	_, e := s.db.Exec(`DELETE FROM roles WHERE id=?`, id)
+	if e == nil {
+		s.invalidateAccess()
+	}
+	return e
+}
+func (s *Server) setUserRole(tenant, login, role string) error {
+	return s.changeUser(tenant, login, `role_id=?`, role)
+}
+func (s *Server) setUserActive(tenant, login string, active bool) error {
+	v := 0
+	if active {
+		v = 1
+	}
+	return s.changeUser(tenant, login, `active=?`, v)
+}
+func (s *Server) changeUser(tenant, login, field string, value any) error {
+	login = normalizeLogin(login)
+	var oldRole string
+	var active int
+	e := s.db.QueryRow(`SELECT r.name,u.active FROM users u JOIN roles r ON r.id=u.role_id WHERE u.tenant_id=? AND u.login=?`, tenant, login).Scan(&oldRole, &active)
+	if e != nil {
+		return e
+	}
+	nextAdmin := oldRole == "admin"
+	if field == "role_id=?" {
+		var name string
+		if e = s.db.QueryRow(`SELECT name FROM roles WHERE id=?`, value).Scan(&name); e != nil {
+			return e
+		}
+		nextAdmin = name == "admin"
+	}
+	nextActive := active != 0
+	if field == "active=?" {
+		nextActive = value.(int) != 0
+	}
+	if oldRole == "admin" && active != 0 && (!nextAdmin || !nextActive) {
+		var n int
+		if e = s.db.QueryRow(`SELECT COUNT(*) FROM users u JOIN roles r ON r.id=u.role_id WHERE u.tenant_id=? AND r.name='admin' AND u.active=1`, tenant).Scan(&n); e != nil {
+			return e
+		}
+		if n <= 1 {
+			return ErrLastAdmin
+		}
+	}
+	_, e = s.db.Exec(`UPDATE users SET `+field+` WHERE tenant_id=? AND login=?`, value, tenant, login)
+	if e == nil {
+		s.invalidateAccess()
+	}
+	return e
+}
+
+type AccessBackfillRow struct{ Login, Role, Action string }
+
+func BackfillAccess(dbPath string, admins []string, dryRun bool) ([]AccessBackfillRow, error) {
+	if len(admins) == 0 {
+		return nil, errors.New("auth.access.admins is empty; refusing backfill without an administrator")
+	}
+	var db *sql.DB
+	var err error
+	if dryRun {
+		db, err = sql.Open("sqlite", dbPath+"?_time_format=sqlite&_pragma=foreign_keys(on)&_pragma=busy_timeout(5000)")
+	} else {
+		db, err = openDB(dbPath)
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+	tx, err := db.Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+	adminSet := map[string]bool{}
+	for _, login := range admins {
+		if login = normalizeLogin(login); login != "" {
+			adminSet[login] = true
+		}
+	}
+	if len(adminSet) == 0 {
+		return nil, errors.New("auth.access.admins is empty; refusing backfill without an administrator")
+	}
+	var tenant string
+	if err = tx.QueryRow(`SELECT id FROM tenants ORDER BY created_at LIMIT 1`).Scan(&tenant); err != nil {
+		return nil, fmt.Errorf("find tenant: %w", err)
+	}
+	logins := make([]string, 0, len(adminSet))
+	for login := range adminSet {
+		logins = append(logins, login)
+	}
+	rows, err := tx.Query(`SELECT DISTINCT lower(trim(user_login)) FROM messages WHERE user_login <> '' ORDER BY 1`)
+	if err != nil {
+		return nil, err
+	}
+	for rows.Next() {
+		var l string
+		if err = rows.Scan(&l); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		if !adminSet[l] {
+			logins = append(logins, l)
+		}
+	}
+	if err = rows.Err(); err != nil {
+		rows.Close()
+		return nil, err
+	}
+	rows.Close()
+	var out []AccessBackfillRow
+	for _, login := range logins {
+		role := "reader"
+		if adminSet[login] {
+			role = "admin"
+		}
+		var existingRole string
+		e := tx.QueryRow(`SELECT r.name FROM users u JOIN roles r ON r.id=u.role_id WHERE u.tenant_id=? AND u.login=?`, tenant, login).Scan(&existingRole)
+		action := "unchanged"
+		if e == sql.ErrNoRows {
+			action = "created"
+			_, e = tx.Exec(`INSERT INTO users(id,tenant_id,login,role_id,created_at,last_login_at) VALUES(?,?,?,?,?,0)`, uuid.NewString(), tenant, login, role, now().UnixMilli())
+		} else if e == nil && role == "admin" && existingRole != "admin" {
+			action = "updated"
+			_, e = tx.Exec(`UPDATE users SET role_id='admin' WHERE tenant_id=? AND login=?`, tenant, login)
+		}
+		if e != nil {
+			return nil, e
+		}
+		out = append(out, AccessBackfillRow{login, role, action})
+	}
+	if dryRun {
+		return out, nil
+	}
+	if err = tx.Commit(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/pkg/hub/authz.go
+++ b/pkg/hub/authz.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -44,6 +45,9 @@ const (
 	PermSecretsManage    Permission = "secrets:manage"
 	PermAccessManage     Permission = "access:manage"
 	PermDoctorRun        Permission = "doctor:run"
+	PermTemplateView     Permission = "template:view"
+	PermTemplateEdit     Permission = "template:edit"
+	PermMCPManage        Permission = "mcp:manage"
 )
 
 type PermissionMeta struct {
@@ -54,6 +58,7 @@ type PermissionMeta struct {
 var AllPermissions = []PermissionMeta{
 	{PermAuthLogin, "auth", "Enter the UI", ""}, {PermClawViewAll, "claw", "View all agents", ""}, {PermClawViewOwn, "claw", "View own agents", ""}, {PermClawMessagesRead, "claw", "Read agent conversations and transcripts", ""}, {PermClawCreate, "claw", "Create agent", "Provisions a VM and consumes LLM usage"}, {PermClawInteractAll, "claw", "Message any agent", ""}, {PermClawInteractOwn, "claw", "Message own agents", ""}, {PermClawModifyAll, "claw", "Modify any agent", ""}, {PermClawModifyOwn, "claw", "Modify own agents", ""}, {PermClawDeleteAll, "claw", "Delete any agent", ""}, {PermClawDeleteOwn, "claw", "Delete own agents", ""}, {PermClawCheckpoint, "claw", "Create and restore checkpoints", ""}, {PermClawTerminal, "claw", "Open sandbox terminal", ""}, {PermClawFiles, "claw", "Transfer agent files", ""},
 	{PermWorkflowView, "workflow", "View workflows, runs, and cron history", ""}, {PermWorkflowTrigger, "workflow", "Trigger workflows", ""}, {PermWorkflowEdit, "workflow", "Edit workflows", ""}, {PermWorkspaceView, "workspace", "View workspaces", ""}, {PermWorkspaceEdit, "workspace", "Edit workspaces", ""}, {PermWorkspaceSecrets, "workspace", "Manage workspace secrets and integrations", ""}, {PermFactoryView, "factory", "View factories and events", ""}, {PermFactoryTrigger, "factory", "Trigger factories", ""}, {PermFactoryEdit, "factory", "Edit factories", ""}, {PermAnalyticsView, "analytics", "View cost-free dashboard", ""}, {PermAnalyticsCosts, "analytics", "View costs and factory analytics", ""}, {PermSettingsView, "admin", "View settings", ""}, {PermSettingsEdit, "admin", "Edit hub configuration", ""}, {PermSecretsManage, "admin", "Manage global secrets and model credentials", ""}, {PermAccessManage, "admin", "Manage users, roles, and permissions", ""}, {PermDoctorRun, "admin", "Run doctor and troubleshoot", ""},
+	{PermTemplateView, "template", "View agent templates", ""}, {PermTemplateEdit, "template", "Push and remove agent templates", "Templates decide the repo, tags, and env of new agents"}, {PermMCPManage, "admin", "Manage MCP servers", ""},
 }
 
 var (
@@ -67,33 +72,88 @@ var (
 type Principal struct {
 	TenantID, Login, RoleName string
 	perms                     map[Permission]struct{}
+	// ownTags are the tag patterns that prove a claw belongs to this
+	// principal. They come from the hub AccessConfig (the same
+	// view_requires_tags / interact_requires_tags patterns canViewClaw
+	// already honours) so that the :own scopes match whatever ownership
+	// convention the deployment actually writes onto its claws. Only
+	// patterns containing {user} qualify: a static pattern such as
+	// "team=core" grants access to a group, it does not prove ownership.
+	// When the list is empty ownership cannot be proven and every :own
+	// scope denies.
+	ownTags []string
 }
 
+// clawTagScopedPerms are claw permissions that have no :own/:all axis of their
+// own. Each is evaluated together with the view scope of the same claw, so a
+// principal holding only claw:view:own cannot read the transcript, open the
+// terminal, pull files, or checkpoint somebody else's claw.
+var clawTagScopedPerms = map[Permission]struct{}{
+	PermClawMessagesRead: {}, PermClawTerminal: {}, PermClawFiles: {}, PermClawCheckpoint: {},
+}
+
+// Allows reports whether the principal may act on a claw carrying tags.
+//
+// tags must be the claw's complete tag list. An empty or nil slice means "this
+// claw carries no tag that proves ownership", so it denies every :own scope —
+// callers that do not know the tags must not pretend they do.
 func (p *Principal) Allows(perm Permission, tags []string) bool {
 	if p == nil || p.Login == "" {
 		return true
 	}
-	if _, ok := p.perms[perm]; ok {
-		return true
+	if _, ok := clawTagScopedPerms[perm]; ok {
+		return p.holds(perm) && p.scopedAllows(PermClawViewAll, tags)
 	}
+	return p.scopedAllows(perm, tags)
+}
+
+func (p *Principal) holds(perm Permission) bool {
+	_, ok := p.perms[perm]
+	return ok
+}
+
+func (p *Principal) scopedAllows(perm Permission, tags []string) bool {
 	key := string(perm)
-	if !strings.HasSuffix(key, ":all") {
-		return false
+	// A :own key handed in directly is evaluated as the scoped check the
+	// caller naturally expects: holding the permission is not enough, the
+	// claw has to be owned.
+	if base := strings.TrimSuffix(key, ":own"); base != key {
+		return p.holds(perm) && p.ownsTags(tags)
 	}
-	own := Permission(strings.TrimSuffix(key, ":all") + ":own")
-	if _, ok := p.perms[own]; !ok {
-		return false
-	}
-	if tags == nil {
+	if p.holds(perm) {
 		return true
 	}
-	want := "owner=" + strings.ToLower(p.Login)
-	for _, tag := range tags {
-		if strings.EqualFold(strings.TrimSpace(tag), want) {
-			return true
-		}
+	if base := strings.TrimSuffix(key, ":all"); base != key {
+		return p.holds(Permission(base+":own")) && p.ownsTags(tags)
 	}
 	return false
+}
+
+func (p *Principal) ownsTags(tags []string) bool {
+	if len(p.ownTags) == 0 || len(tags) == 0 {
+		return false
+	}
+	return matchesTags(p.ownTags, p.Login, tags)
+}
+
+// ownershipTagPatterns keeps the RBAC :own scopes in sync with the tag rules
+// the hub is already configured with, instead of inventing a convention no
+// producer emits.
+func (s *Server) ownershipTagPatterns() []string {
+	if s.hubCfg == nil || s.hubCfg.Auth == nil || s.hubCfg.Auth.Access == nil {
+		return nil
+	}
+	cfg := s.hubCfg.Auth.Access
+	var out []string
+	seen := map[string]bool{}
+	for _, pattern := range append(append([]string{}, cfg.ViewRequiresTags...), cfg.InteractRequiresTags...) {
+		if !strings.Contains(pattern, "{user}") || seen[pattern] {
+			continue
+		}
+		seen[pattern] = true
+		out = append(out, pattern)
+	}
+	return out
 }
 
 type Role struct {
@@ -213,7 +273,7 @@ func (s *Server) principalFor(tenantID, login string) (*Principal, error) {
 		return c.principal, nil
 	}
 	a.mu.Unlock()
-	p := &Principal{TenantID: tenantID, Login: login, perms: map[Permission]struct{}{}}
+	p := &Principal{TenantID: tenantID, Login: login, perms: map[Permission]struct{}{}, ownTags: s.ownershipTagPatterns()}
 	rows, e := s.db.Query(`SELECT r.name,rp.permission_key FROM users u JOIN roles r ON r.id=u.role_id LEFT JOIN role_permissions rp ON rp.role_id=r.id WHERE u.tenant_id=? AND u.login=? AND u.active=1`, tenantID, login)
 	if e != nil {
 		return nil, e
@@ -375,18 +435,27 @@ func (s *Server) setUserActive(tenant, login string, active bool) error {
 	}
 	return s.changeUser(tenant, login, `active=?`, v)
 }
+
+// changeUser reads, checks the last-active-admin invariant, and writes inside a
+// single transaction. openDB uses _txlock=immediate, so concurrent demotions
+// serialize on the write lock instead of both observing the same admin count
+// and leaving the tenant with nobody holding access:manage.
 func (s *Server) changeUser(tenant, login, field string, value any) error {
 	login = normalizeLogin(login)
+	tx, e := s.db.Begin()
+	if e != nil {
+		return e
+	}
+	defer tx.Rollback()
 	var oldRole string
 	var active int
-	e := s.db.QueryRow(`SELECT r.name,u.active FROM users u JOIN roles r ON r.id=u.role_id WHERE u.tenant_id=? AND u.login=?`, tenant, login).Scan(&oldRole, &active)
-	if e != nil {
+	if e = tx.QueryRow(`SELECT r.name,u.active FROM users u JOIN roles r ON r.id=u.role_id WHERE u.tenant_id=? AND u.login=?`, tenant, login).Scan(&oldRole, &active); e != nil {
 		return e
 	}
 	nextAdmin := oldRole == "admin"
 	if field == "role_id=?" {
 		var name string
-		if e = s.db.QueryRow(`SELECT name FROM roles WHERE id=?`, value).Scan(&name); e != nil {
+		if e = tx.QueryRow(`SELECT name FROM roles WHERE id=?`, value).Scan(&name); e != nil {
 			return e
 		}
 		nextAdmin = name == "admin"
@@ -397,22 +466,28 @@ func (s *Server) changeUser(tenant, login, field string, value any) error {
 	}
 	if oldRole == "admin" && active != 0 && (!nextAdmin || !nextActive) {
 		var n int
-		if e = s.db.QueryRow(`SELECT COUNT(*) FROM users u JOIN roles r ON r.id=u.role_id WHERE u.tenant_id=? AND r.name='admin' AND u.active=1`, tenant).Scan(&n); e != nil {
+		if e = tx.QueryRow(`SELECT COUNT(*) FROM users u JOIN roles r ON r.id=u.role_id WHERE u.tenant_id=? AND r.name='admin' AND u.active=1`, tenant).Scan(&n); e != nil {
 			return e
 		}
 		if n <= 1 {
 			return ErrLastAdmin
 		}
 	}
-	_, e = s.db.Exec(`UPDATE users SET `+field+` WHERE tenant_id=? AND login=?`, value, tenant, login)
-	if e == nil {
+	if _, e = tx.Exec(`UPDATE users SET `+field+` WHERE tenant_id=? AND login=?`, value, tenant, login); e != nil {
+		return e
+	}
+	if e = tx.Commit(); e == nil {
 		s.invalidateAccess()
 	}
 	return e
 }
 
-type AccessBackfillRow struct{ Login, Role, Action string }
+type AccessBackfillRow struct{ Tenant, Login, Role, Action string }
 
+// BackfillAccess seeds the users table from the configured administrators and
+// from historical message authors. It runs once per tenant: the admin list is
+// hub-wide, and every tenant needs at least one active admin of its own, so a
+// tenant that only shows up in the messages table must not be left without one.
 func BackfillAccess(dbPath string, admins []string, dryRun bool) ([]AccessBackfillRow, error) {
 	if len(admins) == 0 {
 		return nil, errors.New("auth.access.admins is empty; refusing backfill without an administrator")
@@ -442,53 +517,32 @@ func BackfillAccess(dbPath string, admins []string, dryRun bool) ([]AccessBackfi
 	if len(adminSet) == 0 {
 		return nil, errors.New("auth.access.admins is empty; refusing backfill without an administrator")
 	}
-	var tenant string
-	if err = tx.QueryRow(`SELECT id FROM tenants ORDER BY created_at LIMIT 1`).Scan(&tenant); err != nil {
-		return nil, fmt.Errorf("find tenant: %w", err)
-	}
-	logins := make([]string, 0, len(adminSet))
+	adminLogins := make([]string, 0, len(adminSet))
 	for login := range adminSet {
-		logins = append(logins, login)
+		adminLogins = append(adminLogins, login)
 	}
-	rows, err := tx.Query(`SELECT DISTINCT lower(trim(user_login)) FROM messages WHERE user_login <> '' ORDER BY 1`)
+	sort.Strings(adminLogins)
+	tenants, err := backfillTenants(tx)
 	if err != nil {
 		return nil, err
 	}
-	for rows.Next() {
-		var l string
-		if err = rows.Scan(&l); err != nil {
-			rows.Close()
-			return nil, err
-		}
-		if !adminSet[l] {
-			logins = append(logins, l)
-		}
-	}
-	if err = rows.Err(); err != nil {
-		rows.Close()
-		return nil, err
-	}
-	rows.Close()
 	var out []AccessBackfillRow
-	for _, login := range logins {
-		role := "reader"
-		if adminSet[login] {
-			role = "admin"
-		}
-		var existingRole string
-		e := tx.QueryRow(`SELECT r.name FROM users u JOIN roles r ON r.id=u.role_id WHERE u.tenant_id=? AND u.login=?`, tenant, login).Scan(&existingRole)
-		action := "unchanged"
-		if e == sql.ErrNoRows {
-			action = "created"
-			_, e = tx.Exec(`INSERT INTO users(id,tenant_id,login,role_id,created_at,last_login_at) VALUES(?,?,?,?,?,0)`, uuid.NewString(), tenant, login, role, now().UnixMilli())
-		} else if e == nil && role == "admin" && existingRole != "admin" {
-			action = "updated"
-			_, e = tx.Exec(`UPDATE users SET role_id='admin' WHERE tenant_id=? AND login=?`, tenant, login)
-		}
+	for _, tenant := range tenants {
+		logins, e := backfillTenantLogins(tx, tenant, adminSet, adminLogins)
 		if e != nil {
 			return nil, e
 		}
-		out = append(out, AccessBackfillRow{login, role, action})
+		for _, login := range logins {
+			role := "reader"
+			if adminSet[login] {
+				role = "admin"
+			}
+			action, e := backfillUser(tx, tenant, login, role)
+			if e != nil {
+				return nil, e
+			}
+			out = append(out, AccessBackfillRow{tenant, login, role, action})
+		}
 	}
 	if dryRun {
 		return out, nil
@@ -497,4 +551,68 @@ func BackfillAccess(dbPath string, admins []string, dryRun bool) ([]AccessBackfi
 		return nil, err
 	}
 	return out, nil
+}
+
+func backfillTenants(tx *sql.Tx) ([]string, error) {
+	rows, err := tx.Query(`SELECT id FROM tenants ORDER BY created_at`)
+	if err != nil {
+		return nil, fmt.Errorf("find tenant: %w", err)
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var id string
+		if err = rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("find tenant: %w", err)
+		}
+		out = append(out, id)
+	}
+	if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("find tenant: %w", err)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("find tenant: %w", sql.ErrNoRows)
+	}
+	return out, nil
+}
+
+// backfillTenantLogins returns the administrators plus the message authors that
+// belong to this tenant. Message authors are filtered by tenant_id so that a
+// login only seen in another tenant does not get an account here.
+func backfillTenantLogins(tx *sql.Tx, tenant string, adminSet map[string]bool, adminLogins []string) ([]string, error) {
+	logins := append([]string{}, adminLogins...)
+	rows, err := tx.Query(`SELECT DISTINCT lower(trim(user_login)) FROM messages WHERE tenant_id=? AND user_login <> '' ORDER BY 1`, tenant)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var l string
+		if err = rows.Scan(&l); err != nil {
+			return nil, err
+		}
+		if l != "" && !adminSet[l] {
+			logins = append(logins, l)
+		}
+	}
+	return logins, rows.Err()
+}
+
+func backfillUser(tx *sql.Tx, tenant, login, role string) (string, error) {
+	var existingRole string
+	var existingActive int
+	e := tx.QueryRow(`SELECT r.name,u.active FROM users u JOIN roles r ON r.id=u.role_id WHERE u.tenant_id=? AND u.login=?`, tenant, login).Scan(&existingRole, &existingActive)
+	switch {
+	case e == sql.ErrNoRows:
+		_, e = tx.Exec(`INSERT INTO users(id,tenant_id,login,role_id,created_at,last_login_at) VALUES(?,?,?,?,?,0)`, uuid.NewString(), tenant, login, role, now().UnixMilli())
+		return "created", e
+	case e != nil:
+		return "", e
+	case role == "admin" && (existingRole != "admin" || existingActive == 0):
+		// Promoting without reactivating would satisfy "the tenant has an
+		// admin" with an admin that cannot log in, so do both at once.
+		_, e = tx.Exec(`UPDATE users SET role_id='admin',active=1 WHERE tenant_id=? AND login=?`, tenant, login)
+		return "updated", e
+	}
+	return "unchanged", nil
 }

--- a/pkg/hub/authz_test.go
+++ b/pkg/hub/authz_test.go
@@ -1,0 +1,214 @@
+package hub
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestAccessSeed(t *testing.T) {
+	_, db := NewTestServerWithConfig(t, nil, "", "", "")
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM permissions`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != len(AllPermissions) {
+		t.Fatalf("permission count = %d, want %d", count, len(AllPermissions))
+	}
+	for _, role := range []string{"admin", "reader"} {
+		if err := db.QueryRow(`SELECT COUNT(*) FROM roles WHERE id=?`, role).Scan(&count); err != nil || count != 1 {
+			t.Fatalf("role %q count = %d, err = %v", role, count, err)
+		}
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM role_permissions WHERE role_id='admin'`).Scan(&count); err != nil || count != len(AllPermissions) {
+		t.Fatalf("admin permission count = %d, err = %v; want %d", count, err, len(AllPermissions))
+	}
+	rows, err := db.Query(`SELECT permission_key FROM role_permissions WHERE role_id='reader' ORDER BY permission_key`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	var got []Permission
+	for rows.Next() {
+		var permission Permission
+		if err := rows.Scan(&permission); err != nil {
+			t.Fatal(err)
+		}
+		got = append(got, permission)
+	}
+	want := []Permission{PermAuthLogin, PermClawMessagesRead, PermClawViewAll}
+	if len(got) != len(want) {
+		t.Fatalf("reader permissions = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("reader permissions = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestAccessPermissionEnumMatchesTable(t *testing.T) {
+	_, db := NewTestServerWithConfig(t, nil, "", "", "")
+	enum := make(map[Permission]bool, len(AllPermissions))
+	for _, permission := range AllPermissions {
+		enum[permission.Key] = true
+	}
+	rows, err := db.Query(`SELECT key FROM permissions`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	table := map[Permission]bool{}
+	for rows.Next() {
+		var permission Permission
+		if err := rows.Scan(&permission); err != nil {
+			t.Fatal(err)
+		}
+		table[permission] = true
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	for permission := range enum {
+		if !table[permission] {
+			t.Errorf("enum permission %q is missing from the table", permission)
+		}
+	}
+	for permission := range table {
+		if !enum[permission] {
+			t.Errorf("table permission %q is missing from the enum", permission)
+		}
+	}
+}
+
+func TestAccessReconcileGrantsFuturePermissionToAdmin(t *testing.T) {
+	_, db := NewTestServerWithConfig(t, nil, "", "", "")
+	const future Permission = "future:operate"
+	if _, err := db.Exec(`INSERT INTO permissions(key,resource,label,description) VALUES(?,?,?,?)`, future, "future", "Operate", ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := reconcileAccessControl(db); err != nil {
+		t.Fatalf("reconcile access control: %v", err)
+	}
+	for _, role := range []struct {
+		name string
+		want int
+	}{{"admin", 1}, {"reader", 0}} {
+		var count int
+		if err := db.QueryRow(`SELECT COUNT(*) FROM role_permissions WHERE role_id=? AND permission_key=?`, role.name, future).Scan(&count); err != nil {
+			t.Fatal(err)
+		}
+		if count != role.want {
+			t.Errorf("%s future permission = %d, want %d", role.name, count, role.want)
+		}
+	}
+}
+
+func TestAccessReaderPermissionsSurviveMigration(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, nil, "", "", "")
+	want := []Permission{PermAuthLogin, PermWorkflowView}
+	if err := s.updateRolePermissions("reader", want); err != nil {
+		t.Fatal(err)
+	}
+	if err := migrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	rows, err := db.Query(`SELECT permission_key FROM role_permissions WHERE role_id='reader' ORDER BY permission_key`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	got := map[Permission]bool{}
+	for rows.Next() {
+		var permission Permission
+		if err := rows.Scan(&permission); err != nil {
+			t.Fatal(err)
+		}
+		got[permission] = true
+	}
+	if len(got) != len(want) || !got[PermAuthLogin] || !got[PermWorkflowView] {
+		t.Fatalf("reader permissions after migration = %v, want %v", got, want)
+	}
+}
+
+func TestRenameImmutableRoleReturnsErrRoleImmutable(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, nil, "", "", "")
+	if !errors.Is(s.renameRole("admin", "administrators"), ErrRoleImmutable) {
+		t.Fatal("rename admin did not return ErrRoleImmutable")
+	}
+}
+
+func TestDeleteSystemRoleReturnsErrRoleSystem(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, nil, "", "", "")
+	if !errors.Is(s.deleteRole("reader"), ErrRoleSystem) {
+		t.Fatal("delete reader did not return ErrRoleSystem")
+	}
+}
+
+func TestDeleteRoleInUseReturnsErrRoleInUse(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, nil, "", "", "")
+	role, err := s.createRole("operator")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.upsertUserOnLogin("test-tenant-id", "alice", "", ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.setUserRole("test-tenant-id", "alice", role.ID); err != nil {
+		t.Fatal(err)
+	}
+	if !errors.Is(s.deleteRole(role.ID), ErrRoleInUse) {
+		t.Fatal("delete used role did not return ErrRoleInUse")
+	}
+}
+
+func TestRemoveLastAdminReturnsErrLastAdmin(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, nil, "", "", "")
+	if _, err := s.upsertUserOnLogin("test-tenant-id", "alice", "", ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.setUserRole("test-tenant-id", "alice", "admin"); err != nil {
+		t.Fatal(err)
+	}
+	if !errors.Is(s.setUserActive("test-tenant-id", "alice", false), ErrLastAdmin) {
+		t.Fatal("deactivating last admin did not return ErrLastAdmin")
+	}
+}
+
+func TestUpdateRoleWithUnknownPermissionReturnsErrUnknownPermission(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, nil, "", "", "")
+	if !errors.Is(s.updateRolePermissions("reader", []Permission{"not:known"}), ErrUnknownPermission) {
+		t.Fatal("unknown permission did not return ErrUnknownPermission")
+	}
+}
+
+func TestPrincipalAllows(t *testing.T) {
+	t.Run("all grants", func(t *testing.T) {
+		p := &Principal{Login: "alice", perms: map[Permission]struct{}{PermClawInteractAll: {}}}
+		if !p.Allows(PermClawInteractAll, []string{"owner=bob"}) {
+			t.Fatal("all permission was denied")
+		}
+	})
+	t.Run("own grants matching owner case insensitively", func(t *testing.T) {
+		p := &Principal{Login: "Alice", perms: map[Permission]struct{}{PermClawInteractOwn: {}}}
+		if !p.Allows(PermClawInteractAll, []string{" OWNER=alice "}) {
+			t.Fatal("own permission was denied for matching owner")
+		}
+	})
+	t.Run("own denies another owner", func(t *testing.T) {
+		p := &Principal{Login: "alice", perms: map[Permission]struct{}{PermClawInteractOwn: {}}}
+		if p.Allows(PermClawInteractAll, []string{"owner=bob"}) {
+			t.Fatal("own permission was granted for another owner")
+		}
+	})
+	t.Run("empty login grants all", func(t *testing.T) {
+		if !(&Principal{}).Allows(PermSecretsManage, nil) {
+			t.Fatal("empty login was denied")
+		}
+	})
+	t.Run("nil tags retain direct permission", func(t *testing.T) {
+		p := &Principal{Login: "alice", perms: map[Permission]struct{}{PermClawMessagesRead: {}}}
+		if !p.Allows(PermClawMessagesRead, nil) {
+			t.Fatal("direct permission was denied with nil tags")
+		}
+	})
+}

--- a/pkg/hub/authz_test.go
+++ b/pkg/hub/authz_test.go
@@ -3,6 +3,8 @@ package hub
 import (
 	"errors"
 	"testing"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
 
 func TestAccessSeed(t *testing.T) {
@@ -182,22 +184,46 @@ func TestUpdateRoleWithUnknownPermissionReturnsErrUnknownPermission(t *testing.T
 }
 
 func TestPrincipalAllows(t *testing.T) {
+	ownTags := []string{"owner={user}"}
 	t.Run("all grants", func(t *testing.T) {
-		p := &Principal{Login: "alice", perms: map[Permission]struct{}{PermClawInteractAll: {}}}
+		p := &Principal{Login: "alice", perms: map[Permission]struct{}{PermClawInteractAll: {}}, ownTags: ownTags}
 		if !p.Allows(PermClawInteractAll, []string{"owner=bob"}) {
 			t.Fatal("all permission was denied")
 		}
 	})
-	t.Run("own grants matching owner case insensitively", func(t *testing.T) {
-		p := &Principal{Login: "Alice", perms: map[Permission]struct{}{PermClawInteractOwn: {}}}
-		if !p.Allows(PermClawInteractAll, []string{" OWNER=alice "}) {
+	t.Run("own grants matching owner", func(t *testing.T) {
+		p := &Principal{Login: "alice", perms: map[Permission]struct{}{PermClawInteractOwn: {}}, ownTags: ownTags}
+		if !p.Allows(PermClawInteractAll, []string{"owner=alice"}) {
 			t.Fatal("own permission was denied for matching owner")
 		}
 	})
 	t.Run("own denies another owner", func(t *testing.T) {
-		p := &Principal{Login: "alice", perms: map[Permission]struct{}{PermClawInteractOwn: {}}}
+		p := &Principal{Login: "alice", perms: map[Permission]struct{}{PermClawInteractOwn: {}}, ownTags: ownTags}
 		if p.Allows(PermClawInteractAll, []string{"owner=bob"}) {
 			t.Fatal("own permission was granted for another owner")
+		}
+	})
+	t.Run("own denies untagged claw", func(t *testing.T) {
+		p := &Principal{Login: "alice", perms: map[Permission]struct{}{PermClawViewOwn: {}}, ownTags: ownTags}
+		for _, tags := range [][]string{nil, {}} {
+			if p.Allows(PermClawViewAll, tags) {
+				t.Fatalf("own permission was granted for a claw with tags %v", tags)
+			}
+		}
+	})
+	t.Run("own key passed directly still checks ownership", func(t *testing.T) {
+		p := &Principal{Login: "alice", perms: map[Permission]struct{}{PermClawModifyOwn: {}}, ownTags: ownTags}
+		if p.Allows(PermClawModifyOwn, []string{"owner=bob"}) {
+			t.Fatal("own permission was granted for another owner when queried directly")
+		}
+		if !p.Allows(PermClawModifyOwn, []string{"owner=alice"}) {
+			t.Fatal("own permission was denied for own claw when queried directly")
+		}
+	})
+	t.Run("own denies when no ownership pattern is configured", func(t *testing.T) {
+		p := &Principal{Login: "alice", perms: map[Permission]struct{}{PermClawViewOwn: {}}}
+		if p.Allows(PermClawViewAll, []string{"owner=alice"}) {
+			t.Fatal("ownership was inferred without a configured pattern")
 		}
 	})
 	t.Run("empty login grants all", func(t *testing.T) {
@@ -205,10 +231,39 @@ func TestPrincipalAllows(t *testing.T) {
 			t.Fatal("empty login was denied")
 		}
 	})
-	t.Run("nil tags retain direct permission", func(t *testing.T) {
-		p := &Principal{Login: "alice", perms: map[Permission]struct{}{PermClawMessagesRead: {}}}
-		if !p.Allows(PermClawMessagesRead, nil) {
-			t.Fatal("direct permission was denied with nil tags")
+	t.Run("tag scoped claw permissions follow the view scope", func(t *testing.T) {
+		p := &Principal{Login: "alice", perms: map[Permission]struct{}{PermClawViewOwn: {}, PermClawMessagesRead: {}, PermClawTerminal: {}, PermClawFiles: {}, PermClawCheckpoint: {}}, ownTags: ownTags}
+		for _, perm := range []Permission{PermClawMessagesRead, PermClawTerminal, PermClawFiles, PermClawCheckpoint} {
+			if p.Allows(perm, []string{"owner=bob"}) {
+				t.Fatalf("%s was granted on another user's claw", perm)
+			}
+			if !p.Allows(perm, []string{"owner=alice"}) {
+				t.Fatalf("%s was denied on own claw", perm)
+			}
 		}
 	})
+	t.Run("tag scoped claw permissions still need the permission itself", func(t *testing.T) {
+		p := &Principal{Login: "alice", perms: map[Permission]struct{}{PermClawViewAll: {}}, ownTags: ownTags}
+		if p.Allows(PermClawTerminal, []string{"owner=alice"}) {
+			t.Fatal("terminal was granted without claw:terminal")
+		}
+	})
+}
+
+func TestOwnershipTagPatternsKeepsOnlyUserPatterns(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, nil, "", "", "")
+	s.hubCfg = &types.HubConfig{Auth: &types.AuthConfig{Access: &types.AccessConfig{
+		ViewRequiresTags:     []string{"assignee={user}", "team=core"},
+		InteractRequiresTags: []string{"assignee={user}", "owner={user}"},
+	}}}
+	got := s.ownershipTagPatterns()
+	want := []string{"assignee={user}", "owner={user}"}
+	if len(got) != len(want) {
+		t.Fatalf("patterns = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("patterns = %v, want %v", got, want)
+		}
+	}
 }

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -985,6 +985,9 @@ func migrate(db *sql.DB) error {
 	if err != nil {
 		return err
 	}
+	if err := migrateAccessControl(db); err != nil {
+		return fmt.Errorf("migrate access control: %w", err)
+	}
 	if err := workflowv2.Migrate(db); err != nil {
 		return err
 	}

--- a/pkg/hub/testhelpers.go
+++ b/pkg/hub/testhelpers.go
@@ -163,3 +163,15 @@ func (s *Server) ClearWebhookDedupForTest() {
 		delete(s.webhookDedup, k)
 	}
 }
+
+// InitDBForTest creates and migrates a hub database at path, then closes it.
+// Commands such as backfill-access no longer migrate on their own, so tests
+// outside this package need a way to produce a database the hub would have
+// created. Only call from tests.
+func InitDBForTest(path string) error {
+	db, err := openDB(path)
+	if err != nil {
+		return err
+	}
+	return db.Close()
+}


### PR DESCRIPTION
Phase 1 of the hub RBAC: users, roles and permissions live in the database, replacing the `is_admin` boolean derived from `auth.access.admins` in `hub.yaml`.

**This PR is deliberately inert.** No route, middleware or handler changes behaviour — `Allows()` has zero production call sites. Enforcement lands in Phase 3.

## What's here

- **Schema** (`pkg/hub/db.go`) — `permissions`, `roles`, `role_permissions`, `users`, with an idempotent seed inside `migrate()`.
- **Engine** (`pkg/hub/authz.go`) — 33-permission catalogue, `Principal.Allows(perm, tags)` with `:all`/`:own` scoping, a 5s cache, and the invariants as sentinel errors (`ErrRoleImmutable`, `ErrRoleSystem`, `ErrRoleInUse`, `ErrLastAdmin`, `ErrUnknownPermission`).
- **Backfill** (`cmd/hub_backfill_access.go`) — `elasticclaw hub backfill-access [--dry-run]`, transactional and idempotent.

The `admin` role is immutable and reconciled to the full permission set on every boot, so a permission added in a future release lands on `admin` automatically and on no user-created role. The `reader` role is seeded only at creation, so admin edits to it survive every subsequent boot. Those two seeds look alike and must behave differently; each has its own test.

## Review findings that changed the design

Three independent reviewers ran against this branch. Two blockers were real:

- `Allows()` **failed open when tags arrived `nil`** — and two broadcast paths pass `nil` for a claw with no tags, so a `:own` holder would have seen a neighbour's claw. Now `nil` and empty are identical and deny.
- The ownership convention `owner=<login>` that `:own` checked **is written by nothing in this repo.** Ownership now routes through the `AccessConfig` patterns `access.go` already uses (`{user}` substitution via `matchesTags`), so RBAC and `canViewClaw` agree, and `:own` denies when ownership cannot be proven.

Catalogue holes: `/api/templates` and `/api/mcp` had no permission. Templates define claw tags, i.e. they were the vector to sidestep `:own`. Added `template:view`, `template:edit`, `mcp:manage`.

A migration-safety review then caught two majors in the backfill command, both reproduced:

- `--dry-run` opened without `_txlock=immediate`, so the transaction was DEFERRED and read before writing. A concurrent hub commit yields `SQLITE_BUSY_SNAPSHOT` (517), which **does not go through the busy handler** — it returns in ~147µs, ignoring `busy_timeout(5000)`. The pre-flight broke against exactly the database it exists for.
- The real path called `openDB`, which **runs all 60+ migrations** — including write-heavy rebuilds — as a second process against the live production database. Reproduced: aborts after ~10s with `database is locked`, having already applied part of the migrations. Many legacy migrations use `_, _ = db.Exec(...)` and swallow the error, so a partial rewrite under contention would pass silently.

Fixed by `openBackfillDB`: `os.Stat` first (so a typo in `--db` cannot create an empty database), `openDB`'s exact DSN, no `migrate()`, and a check that the four RBAC tables exist. `--dry-run` is now genuinely read-only rather than write-then-rollback.

## Backfill, validated against production data

Measured on a read-only snapshot of the Faster Factory hub (discarded after analysis):

- 7 logins in `auth.access.admins` → `admin`.
- The OAuth allowlist is the whole `FasterWayToFatLoss` org — 38 people, with no record of who has logged in.
- `messages.user_login` is a recent column and nearly empty: 28 messages from 3 logins, 2 of them already admins. It cannot reconstruct who operates, which is why everyone else starts as `reader`.
- Tag scoping has never been used: no `view_requires_tags` in production and 0 of 153 claws carry an ownership tag. `:own` ships as capability, not migration.
- 101 of 105 task runs originate from a ticket webhook, a path with no user identity — so closing `claw:create` barely touches the production pipeline.

In production this materialises 8 rows: the 7 admins plus one reader. Everyone else arrives via JIT on first login.

**The dry-run has not been executed against production.** After the two findings above, the first run against the live hub should be a deliberate call, not a side effect of this PR.

## Tests

`ELASTICCLAW_HUB_CONFIG= go test ./pkg/... ./cmd/...` passes except three DONE-signal tests (`TestDoneSignalRejectedWhenPRPersistenceFails`, `TestHandleClawDoneSignal_IssueLessWorkflowWatchesPR`, `TestCompleteIssueLessDoneClawKeepsRunningOnStoreFailure`). I verified these fail identically at the base commit `1190d14f` in a separate worktree — pre-existing host-config leakage, not this diff.

No UI in this PR, so no screenshots. The access management screen is Phase 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
